### PR TITLE
Matching variable view in resolver and implement SaveList and ChooseMany particles in system-particles, plus minor changes.

### DIFF
--- a/particles/WishlistFor/WishlistFor.js
+++ b/particles/WishlistFor/WishlistFor.js
@@ -28,12 +28,10 @@ class WishlistFor extends Particle {
 
   setViews(views) {
     var trace = tracing.start({cat: "Product", name: "Product::setViews"});
+    this.logDebug("person", views.get("person"));
     var wishlist = views.get('wishlist');
     ["a new bike!", "Fresh Puppies", "A packet of Tim Loh that never runs out"].map(p => wishlist.store(new Product(p)));
     this.logDebug("wishlist", wishlist);
-    // TODO(mmandlis): Fix resolver, so that Choose could run before Wishlist,
-    // and so Person would not be undefined.
-    // this.logDebug("person", views.get("person"));
     trace.end();
   }
 }

--- a/runtime/arc.js
+++ b/runtime/arc.js
@@ -217,7 +217,7 @@ class Arc {
     var channel = new MessageChannel();
     this.pec = new OuterPEC(scope, channel.port2);
     this._innerPEC = new InnerPEC(channel.port1);
-    var nextParticleHandle = 0;
+    this.nextParticleHandle = 0;
   }
 
   clone() {

--- a/runtime/particle.js
+++ b/runtime/particle.js
@@ -175,7 +175,7 @@ class Particle {
   on(views, names, action, f) {
     if (typeof names == "string")
       names = [names];
-    var trace = tracing.start({cat: 'particle', name: this.constructor.name + "::on", args: {view: name, event: action}});
+    var trace = tracing.start({cat: 'particle', names: this.constructor.name + "::on", args: {view: names, event: action}});
     names.forEach(name => views.get(name).on(action, tracing.wrap({cat: 'particle', name: this.constructor.name, args: {view: name, event: action}}, f), this));
     trace.end();
   }

--- a/runtime/recipe.js
+++ b/runtime/recipe.js
@@ -9,6 +9,7 @@
  */
 "use strict";
 
+var assert = require("assert");
 var runtime = require("./runtime.js");
 
 class RecipeViewConnection {
@@ -46,8 +47,10 @@ class RecipeComponent {
 
   instantiate(arc) {
     var particle = arc.scope.instantiateParticle(this.particleName, arc);
-    for (var connection of this.connections)
+    for (var connection of this.connections) {
+      assert(connection.view, 'cannot connect particle ' + this.particleName + ' to NULL view ' + connection.name);
       arc.connectParticleToView(particle, connection.name, connection.view);
+    }
   }
 }
 

--- a/runtime/test/demo-flow-test.js
+++ b/runtime/test/demo-flow-test.js
@@ -34,7 +34,7 @@ describe('demo flow', function() {
   it('flows like a demo', function(done) {
     let arc = prepareExtensionArc();
     // TODO: add a loader to the scope so this fallback can happen automatically.
-    ['Create', 'Recommend', 'Save', 'WishlistFor', 'ListView', 'Chooser'].forEach(name => {
+    ['Create', 'Recommend', 'WishlistFor', 'ListView', 'Chooser'].forEach(name => {
       let particleClass = loader.loadParticle(name);
       arc.scope.registerParticle(particleClass);
     });
@@ -48,7 +48,7 @@ describe('demo flow', function() {
         .connectConstraint("known", "list")
         .connectConstraint("population", "wishlist")
         .connectConstraint("recommendations", "recommended")
-      .addParticle("Save")
+      .addParticle("SaveList")
         .connectConstraint("list", "list")
       .addParticle("Choose")
         .connectConstraint("singleton", "person")

--- a/runtime/viewlet.js
+++ b/runtime/viewlet.js
@@ -86,8 +86,8 @@ class View extends Viewlet {
     return this._view.store(serialization);
   }
   async debugString() {
-   var list = await this.toList();
-    return list.map(p => p.debugString).join(", ");
+    var list = await this.toList();
+    return list ? list.map(p => p.debugString).join(", ") : 'undefined';
   }
 }
 
@@ -109,7 +109,7 @@ class Variable extends Viewlet {
   }
   async debugString() {
     var value = await this.get();
-    return value.debugString;
+    return value ? value.debugString : 'undefined';
   }
 }
 


### PR DESCRIPTION
I didn't exclude the previous changes from this commit, let me know if I should have.
Basically, I wanted to add system-particles that worked with views of variable types, and made updates to resolver to support that.
