### PR TITLE
Revamp entity loading and entityClass derivation for tests and browser tests.

### DIFF
--- a/entities/Bar.schema
+++ b/entities/Bar.schema
@@ -1,0 +1,4 @@
+schema Bar {
+  normative:
+    Text value;
+}

--- a/entities/Far.schema
+++ b/entities/Far.schema
@@ -1,0 +1,4 @@
+schema Far {
+  normative:
+    Text value;
+}

--- a/entities/Foo.schema
+++ b/entities/Foo.schema
@@ -1,0 +1,4 @@
+schema Foo {
+  normative:
+    Text value;
+}

--- a/particles/Chooser/Chooser.js
+++ b/particles/Chooser/Chooser.js
@@ -13,8 +13,8 @@ var { Particle, ViewChanges, StateChanges, SlotChanges } = require("../../runtim
 
 function difference(a, b) {
   var result = new Map();
-  a.forEach(value => result.set(JSON.stringify(value.data), value));
-  b.map(a => JSON.stringify(a.data)).forEach(value => result.delete(value));
+  a.forEach(value => result.set(JSON.stringify(value.name), value));
+  b.map(a => JSON.stringify(a.name)).forEach(value => result.delete(value));
   return result.values();
 }
 
@@ -35,7 +35,7 @@ class Chooser extends Particle {
         for (var i in this.states.get('values')) {
           let value = this.states.get('values')[i];
           let eventName = `clack${i}`;
-          content += `${value.data.name} <button events on-click=${eventName}>Choose me!</button><br>`;
+          content += `${value.name} <button events on-click=${eventName}>Choose me!</button><br>`;
           slot.clearEventHandlers(eventName);
           slot.registerEventHandler(eventName, a => views.get('resultList').store(value));
          }

--- a/particles/WishlistFor/WishlistFor.js
+++ b/particles/WishlistFor/WishlistFor.js
@@ -12,12 +12,11 @@
 var Particle = require("../../runtime/particle.js").Particle;
 var runtime = require("../../runtime/runtime.js");
 
-const loader = require("../../runtime/loader.js");
-const Product = loader.loadEntity("Product");
-
 class WishlistFor extends Particle {
 
   setViews(views) {
+    // TODO: Don't let this stay here.
+    const Product = runtime.loader.loadEntity("Product");
     this.logDebug("person", views.get("person"));
     var wishlist = views.get('wishlist');
     ["a new bike!", "Fresh Puppies", "A packet of Tim Loh that never runs out"].map(p => wishlist.store(

--- a/runtime/browser-loader.js
+++ b/runtime/browser-loader.js
@@ -10,11 +10,13 @@
 "use strict";
 
 var parser = require("./parser.js");
+var schemaParser = require("./schema-parser.js");
 //var fs = require("fs");
 //var recipe = require("../../runtime/recipe.js");
 //var runtime = require("../../runtime/runtime.js");
 //var assert = require("assert");
 var ParticleSpec = require("./particle-spec.js");
+var Schema = require("./schema.js");
 
 // dynamic loading not so bueno under browserify ...
 // preload these here so they:
@@ -28,8 +30,6 @@ var _lv = require("../particles/ListView/ListView.js");
 var _c = require("../particles/Chooser/Chooser.js");
 //var _slp = require("../particles/StackingLayout/StackingLayout.js");
 //
-var _pne = require("../entities/Person.js");
-var _pre = require("../entities/Product.js");
 
 let fs = {
   readFileSync: name => {
@@ -66,8 +66,19 @@ function loadRecipe(name) {
 }
 
 function loadEntity(name) {
-  let clazz = require(entityLocationFor(name, 'js'));
+  let clazz = loadSchema(name).entityClass();
   return clazz;
+}
+
+function loadSchema(name) {
+  let data = fs.readFileSync('../' + entityLocationFor(name, 'schema'), "utf-8");
+  var parsed = schemaParser.parse(data);
+  if (parsed.parent) {
+    var parent = loadSchema(parsed.parent);
+  } else {
+    var parent = undefined;
+  }
+  return new Schema(parsed, parent);
 }
 
 Object.assign(exports, { loadParticle, loadDefinition, loadRecipe, loadEntity })

--- a/runtime/entity.js
+++ b/runtime/entity.js
@@ -29,22 +29,9 @@ class Entity {
   toLiteral() {
     return this.rawData;
   }
-  static fromLiteral(id, literal) {
-    // TODO: restore as the appropriate type from type registry (scope)?
-    let entity = new (class BasicEntity extends Entity {
-        constructor(rawData) {
-        super();
-        this.rawData = rawData;
-      }
-      get data() {
-        return this.rawData;
-      }
-    })(literal);
-    entity[Symbols.identifier] = id;
-    return entity;
-  }
+
   get debugString() {
-    return JSON.stringify(this.data.name);
+    return JSON.stringify(this.rawData);
   }
 }
 

--- a/runtime/inner-PEC.js
+++ b/runtime/inner-PEC.js
@@ -35,7 +35,7 @@ class RemoteView {
 
   get() {
     return new Promise((resolve, reject) =>
-      this._port.ViewGet({ callback: r => resolve(r), view: this }));
+      this._port.ViewGet({ callback: r => {resolve(r)}, view: this }));
   }
 
   toList() {
@@ -164,7 +164,7 @@ class InnerPEC {
 
     // the problem with doing this here is that it's only after we return particle below
     // that the target mapping gets established.
-    Promise.resolve().then(() => particle.setViews(viewMap));
+    Promise.resolve().then(() => particle._setViews(viewMap));
 
     return particle;
   }

--- a/runtime/package.json
+++ b/runtime/package.json
@@ -18,6 +18,7 @@
     "pegjs": "^0.10.0"
   },
   "browser": {
-    "./loader.js": "./browser-loader.js"
+    "./loader.js": "./browser-loader.js",
+    "../../runtime/loader.js": "../../runtime/browser-loader.js"
   }
 }

--- a/runtime/particle.js
+++ b/runtime/particle.js
@@ -13,7 +13,8 @@ var parser = require("./parser.js");
 var runtime = require("./runtime.js");
 var ParticleSpec = require("./particle-spec.js");
 var tracing = require('tracelib');
-var assert = require('assert');   
+var assert = require('assert');
+const typeLiteral = require('./type-literal.js');
 
 function define(def, update) {
   let spec = new ParticleSpec(parser.parse(def));
@@ -63,6 +64,32 @@ class Particle {
     this.slotHandlers = [];
     this.stateHandlers = new Map();
     this.states = new Map();
+  }
+
+  /*
+  entityClassFor(name) {
+    console.log("get entity class!", name);
+    var typeName = this.spec.connectionMap.get(name).typeName;
+    if (typeLiteral.isView(typeName)) {
+      typeName = typeLiteral.primitiveType(typeName);
+    }
+    if (typeLiteral.isVariable(typeName)) {
+
+    }
+    console.log(typeName);
+    return runtime.loader.loadEntity(typeName);
+  }
+  */
+
+  _setViews(views) {
+    for (var view of views.values()) {
+      var type = view.underlyingView().type.toLiteral();
+      if (typeLiteral.isView(type)) {
+        type = typeLiteral.primitiveType(type);
+      }
+      view.entityClass = runtime.loader.loadEntity(type);
+    }
+    this.setViews(views);
   }
 
   // Override this to do stuff

--- a/runtime/particle.js
+++ b/runtime/particle.js
@@ -66,21 +66,6 @@ class Particle {
     this.states = new Map();
   }
 
-  /*
-  entityClassFor(name) {
-    console.log("get entity class!", name);
-    var typeName = this.spec.connectionMap.get(name).typeName;
-    if (typeLiteral.isView(typeName)) {
-      typeName = typeLiteral.primitiveType(typeName);
-    }
-    if (typeLiteral.isVariable(typeName)) {
-
-    }
-    console.log(typeName);
-    return runtime.loader.loadEntity(typeName);
-  }
-  */
-
   _setViews(views) {
     for (var view of views.values()) {
       var type = view.underlyingView().type.toLiteral();

--- a/runtime/runtime.js
+++ b/runtime/runtime.js
@@ -16,6 +16,7 @@ const Entity = require('./entity.js');
 const Type = require('./type.js');
 const Relation = require('./relation.js');
 const Scope = require('./scope.js');
+const loader = require("./loader.js");
 
 class BasicEntity extends Entity {
   constructor(rawData) {
@@ -39,6 +40,7 @@ Object.assign(exports, {
   Entity,
   BasicEntity,
   Relation,
+  loader,
   testing: {
     testEntityClass,
   },

--- a/runtime/test/arc-tests.js
+++ b/runtime/test/arc-tests.js
@@ -16,50 +16,52 @@ let assert = require('chai').assert;
 let particles = require('./test-particles.js');
 let view = require('../view.js');
 let util = require('./test-util.js');
-let testEntities = require('./test-entities.js');
 let viewlet = require('../viewlet.js');
 
 let scope = new runtime.Scope();
-testEntities.register(scope);
+
+const Foo = loader.loadEntity("Foo");
+const Bar = loader.loadEntity("Bar");
 
 describe('Arc', function() {
 
   it('applies existing runtime to a particle', async () => {
     let arc = new Arc(scope);
-    let fooView = arc.createView(scope.typeFor(testEntities.Foo));
-    viewlet.viewletFor(fooView).set(new testEntities.Foo('a Foo'));
-    let barView = arc.createView(scope.typeFor(testEntities.Bar));
+    let fooView = arc.createView(scope.typeFor(Foo));
+    viewlet.viewletFor(fooView).set(new Foo({value: 'a Foo'}));
+    let barView = arc.createView(scope.typeFor(Bar));
     var particle = arc.constructParticle(particles.TestParticle);
     arc.connectParticleToView(particle, 'foo', fooView);
     arc.connectParticleToView(particle, 'bar', barView);
-    await util.assertSingletonHas(barView, "a Foo1");
+    await util.assertSingletonHas(barView, Bar, "a Foo1");
   });
 
   it('applies new runtime to a particle', async () => {
     let arc = new Arc(scope);
-    let fooView = arc.createView(scope.typeFor(testEntities.Foo));
-    let barView = arc.createView(scope.typeFor(testEntities.Bar));
+    let fooView = arc.createView(scope.typeFor(Foo));
+    let barView = arc.createView(scope.typeFor(Bar));
     var particle = arc.constructParticle(particles.TestParticle);
     arc.connectParticleToView(particle, 'foo', fooView);
     arc.connectParticleToView(particle, 'bar', barView);
-    viewlet.viewletFor(fooView).set(new testEntities.Foo('a Foo'));
-    await util.assertSingletonHas(barView, "a Foo1");
+    viewlet.viewletFor(fooView).set(new Foo({value: 'a Foo'}));
+    await util.assertSingletonHas(barView, Bar, "a Foo1");
   });
 
   it('works with inline particle definitions', async () => {
     let arc = new Arc(scope);
     let particleClass = require('../particle').define('P(in Foo foo, out Bar bar)', (views) => {
-      views.get("bar").set(new testEntities.Bar(123));
+      var view = views.get("bar");
+      view.set(new view.entityClass({value: 123}));
       return 5;
     });
 
-    let fooView = arc.createView(scope.typeFor(testEntities.Foo));
-    viewlet.viewletFor(fooView).set(new testEntities.Foo(1));
-    let barView = arc.createView(scope.typeFor(testEntities.Bar));
+    let fooView = arc.createView(scope.typeFor(Foo));
+    viewlet.viewletFor(fooView).set(new Foo({value: 1}));
+    let barView = arc.createView(scope.typeFor(Bar));
     let instance = arc.constructParticle(particleClass);
     arc.connectParticleToView(instance, 'foo', fooView);
     arc.connectParticleToView(instance, 'bar', barView);
-    await util.assertSingletonHas(barView, 123);
+    await util.assertSingletonHas(barView, Bar, 123);
   });
 
 });

--- a/runtime/test/data-layer-test.js
+++ b/runtime/test/data-layer-test.js
@@ -23,7 +23,7 @@ describe('entity', function() {
     let list = await arc.findViews(scope.typeFor(entity).viewOf(scope))[0].toList();
     let clone = list[0];
     assert.isDefined(clone);
-    assert.equal(clone.data, 'hello world');
+    assert.equal(clone.rawData, 'hello world');
     assert.notEqual(entity, clone);
   });
 });

--- a/runtime/test/recipe-tests.js
+++ b/runtime/test/recipe-tests.js
@@ -18,14 +18,13 @@ let util = require('./test-util.js');
 let viewlet = require('../viewlet.js');
 
 
-var Foo = runtime.testing.testEntityClass('Foo');
-var Bar = runtime.testing.testEntityClass('Bar');
+const Foo = runtime.loader.loadEntity("Foo");
+const Bar = runtime.loader.loadEntity("Bar");
 
 describe('recipe', function() {
 
   it('recipes can load', async () => {
     let scope = new runtime.Scope();
-    [Foo, Bar].map(a => scope.registerEntityClass(a));
     particles.register(scope);
     var arc = new Arc(scope);
     let fooView = arc.createView(scope.typeFor(Foo));
@@ -38,7 +37,7 @@ describe('recipe', function() {
         .build();
 
     r.instantiate(arc);
-    viewlet.viewletFor(fooView).set(new Foo("not a Bar"));
-    await util.assertSingletonHas(barView, "not a Bar1");
+    viewlet.viewletFor(fooView).set(new Foo({value: "not a Bar"}));
+    await util.assertSingletonHas(barView, Bar, "not a Bar1");
   });
 });

--- a/runtime/test/resolver-tests.js
+++ b/runtime/test/resolver-tests.js
@@ -22,10 +22,8 @@ var viewlet = require('../viewlet.js');
 require("./trace-setup.js");
 
 let scope = new runtime.Scope();
-var Foo = runtime.testing.testEntityClass('Foo');
-var Bar = runtime.testing.testEntityClass('Bar');
-
-[Foo, Bar].map(a => scope.registerEntityClass(a));
+const Foo = loader.loadEntity("Foo");
+const Bar = loader.loadEntity("Bar");
 
 describe('resolver', () => {
   it('can resolve a partially constructed recipe', async () => {
@@ -37,11 +35,11 @@ describe('resolver', () => {
             .connectSpec("foo", {typeName: "Foo", mustCreate: false})
             .connectSpec("bar", {typeName: "Bar", mustCreate: true})
         .build();
-    viewlet.viewletFor(fooView).set(new Foo("not a Bar"));
+    viewlet.viewletFor(fooView).set(new Foo({value: "not a Bar"}));
     assert(Resolver.resolve(r, arc), "recipe resolves");
     r.instantiate(arc);
     var barView = arc.findViews(scope.typeFor(Bar))[0];
-    await util.assertSingletonHas(barView, "not a Bar1");
+    await util.assertSingletonHas(barView, Bar, "not a Bar1");
   });
 
   it("can resolve a recipe from a particle's spec", async () => {
@@ -51,10 +49,10 @@ describe('resolver', () => {
     var r = particles.TestParticle.spec.buildRecipe();
     let fooView = arc.createView(scope.typeFor(Foo));
     let barView = arc.createView(scope.typeFor(Bar));
-    viewlet.viewletFor(fooView).set(new Foo("not a Bar"));
+    viewlet.viewletFor(fooView).set(new Foo({value: "not a Bar"}));
     Resolver.resolve(r, arc);
     r.instantiate(arc);
-    await util.assertSingletonHas(barView, "not a Bar1");
+    await util.assertSingletonHas(barView, Bar, "not a Bar1");
   });
 
   it('can resolve a recipe that is just a particle name', async () => {
@@ -64,10 +62,10 @@ describe('resolver', () => {
     var r = new recipe.RecipeBuilder().addParticle("TestParticle").build();
     let fooView = arc.createView(scope.typeFor(Foo));
     let barView = arc.createView(scope.typeFor(Bar));
-    viewlet.viewletFor(fooView).set(new Foo("not a Bar"));
+    viewlet.viewletFor(fooView).set(new Foo({value: "not a Bar"}));
     Resolver.resolve(r, arc);
     r.instantiate(arc);
-    await util.assertSingletonHas(barView, "not a Bar1");
+    await util.assertSingletonHas(barView, Bar, "not a Bar1");
   });
 
   it("won't resolve a recipe that mentions connections that are not in a particle's connection list", function() {
@@ -90,7 +88,7 @@ describe('resolver', () => {
         .addParticle("TestParticle")
             .connectConstraint("foo", "shared")
         .build();
-    scope.commit([new Foo(1), new Foo(2), new Foo(3)]);
+    scope.commit([new Foo({value: 1}), new Foo({value: 2}), new Foo({value: 3})]);
     assert(Resolver.resolve(r, arc), "recipe should resolve");
     r.instantiate(arc);
     arc.tick(); arc.tick();

--- a/runtime/test/speculator-tests.js
+++ b/runtime/test/speculator-tests.js
@@ -18,8 +18,8 @@ let util = require('./test-util.js');
 
 require("./trace-setup.js");
 
-var Foo = runtime.testing.testEntityClass('Foo');
-var Bar = runtime.testing.testEntityClass('Bar');
+const Foo = runtime.loader.loadEntity("Foo");
+const Bar = runtime.loader.loadEntity("Bar");
 
 describe('speculator', function() {
   it('can speculatively produce a relevance', async () => {
@@ -34,7 +34,8 @@ describe('speculator', function() {
             .connectView("bar", barView)
         .build();
     var speculator = new Speculator();
-    fooView.set(new Foo("not a Bar"));
+    console.log(new Foo({value: "not a Bar"}));
+    fooView.set(new Foo({value: "not a Bar"}));
     var relevance = await speculator.speculate(arc, r);
     assert.equal(relevance, 1.8);
     await util.assertSingletonEmpty(barView);

--- a/runtime/test/test-particles.js
+++ b/runtime/test/test-particles.js
@@ -13,12 +13,16 @@ var runtime = require("../runtime.js");
 var testEntities = require("./test-entities.js");
 
 exports.TestParticle = particle.define('TestParticle(in Foo foo, out Bar bar)', (map) => {
-  map.get('foo').get().then(result => map.get('bar').set(new testEntities.Bar(result.data + 1)));
+  const Bar = loader.loadEntity("Bar");
+  map.get('foo').get().then(result => {
+    var bar = map.get('bar');
+    bar.set(new bar.entityClass({value: result.value + 1}))
+  });
   return 9;
 });
 
 exports.TwoInputTestParticle = particle.define('TwoInputTestParticle(in Foo foo, in Bar bar, out Far far)', map => {
-  map.get('far').set(new testEntities.Far(map.get('foo').get().data + ' ' + map.get('bar').get().data));
+  map.get('far').set(new testEntities.Far({value: map.get('foo').get().value + ' ' + map.get('bar').get().value}));
   return 3;
 });
 

--- a/runtime/test/test-util.js
+++ b/runtime/test/test-util.js
@@ -13,13 +13,14 @@
 let assert = require('chai').assert;
 let viewlet = require('../viewlet.js');
 
-function assertSingletonHas(view, expectation) {
+function assertSingletonHas(view, entityClass, expectation) {
   return new Promise((resolve, reject) => {
     var variable = viewlet.viewletFor(view);
+    variable.entityClass = entityClass;
     variable.on('change', () => variable.get().then(result => {
       if (result == undefined)
         return;
-      assert.equal(result.data, expectation);
+      assert.equal(result.value, expectation);
       resolve();
     }), {});
   });

--- a/runtime/type.js
+++ b/runtime/type.js
@@ -11,7 +11,7 @@ const assert = require('assert');
 const typeLiteral = require('./type-literal.js');
 
 class Type {
-  constructor(key, scope, entityClass) {
+  constructor(key, scope) {
     assert(scope);
     assert(!typeLiteral.isNamedVariable(key));
     let normalized = JSON.stringify(key);
@@ -20,10 +20,6 @@ class Type {
       return type;
     }
     this.key = key;
-    if (!(this.isVariable || this.isView)) {
-      assert(entityClass, `type ${this.toString()} requires an entity class`);
-      this.entityClass = entityClass;
-    }
     scope._types.set(normalized, this);
   }
   get isRelation() {

--- a/runtime/viewlet.js
+++ b/runtime/viewlet.js
@@ -24,9 +24,7 @@ function cloneData(data) {
 function restore(entry, scope, entityClass) {
   let {id, rawData} = entry;
   var entity = new entityClass(cloneData(rawData));
-  // var entity = Entity.fromLiteral(id, cloneData(data));
   var type = scope.typeFor(entity);
-  // entity.constructor = type.entityClass;
   // TODO: Relation magic should happen elsewhere, and be better.
   if (scope.typeFor(entity).isRelation) {
     let ids = data.map(literal => Identifier.fromLiteral(literal, scope));


### PR DESCRIPTION
Particles now provide the entityClass to use when loading data from viewlets,
but this defaults to the base loaded classes derived from type information
in the underlying views.

All entity loading is now done via schema files.