### PR TITLE
Remove unneeded out parameter from ListView particle

### DIFF
--- a/particles/ListView/ListView.ptcl
+++ b/particles/ListView/ListView.ptcl
@@ -8,7 +8,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-ListView(in [Product] list, out [Product] sameList)
+ListView(in [Product] list)
 
 renders: root none-need
 exposes: action(list)


### PR DESCRIPTION
Best bugs are the ones that fix themselves:
https://github.com/PolymerLabs/arcs/issues/81