### PR TITLE
Better testing for demo

### DIFF
--- a/runtime/arc.js
+++ b/runtime/arc.js
@@ -38,6 +38,13 @@ class Arc {
     this.nextParticleHandle = 0;
     this._particlesByName = {};
   }
+  
+  static deserialize(json) {
+    var arc = new Arc(json.id);
+    for (var view in json.views) {
+      console.log(view);
+    }
+  }
 
   instantiateParticle(name) {
     let particleClass = this._loader.loadParticle(name);

--- a/runtime/arc.js
+++ b/runtime/arc.js
@@ -38,7 +38,7 @@ class Arc {
     this.nextParticleHandle = 0;
     this._particlesByName = {};
   }
-  
+
   static deserialize(json) {
     var arc = new Arc(json.id);
     for (var view in json.views) {
@@ -62,8 +62,8 @@ class Arc {
     return `${this.id}:${this.nextLocalID++}`;
   }
 
-  clone(id) {
-    var arc = new Arc({loader: this._loader, id});
+  clone() {
+    var arc = new Arc({loader: this._loader, id: this.generateID()});
     var viewMap = new Map();
     this.views.forEach(v => viewMap.set(v, v.clone()));
     arc.particles = this.particles.map(p => p.clone(viewMap));
@@ -77,8 +77,9 @@ class Arc {
     // If speculatively executing then we need to translate the view
     // in the plan to its clone.
     if (this._viewMap) {
-      targetView = this._viewMap.get(targetView);
+      targetView = this._viewMap.get(targetView) || targetView;
     }
+    assert(targetView, "no target view provided");
     assert(this.views.has(targetView), "view of type " + targetView.type.key + " not visible to arc");
     var viewMap = this.particleViewMaps.get(particle);
     assert(viewMap.clazz.spec.connectionMap.get(name) !== undefined, "can't connect view to a view slot that doesn't exist");

--- a/runtime/arc.js
+++ b/runtime/arc.js
@@ -39,13 +39,6 @@ class Arc {
     this._particlesByName = {};
   }
 
-  static deserialize(json) {
-    var arc = new Arc(json.id);
-    for (var view in json.views) {
-      console.log(view);
-    }
-  }
-
   instantiateParticle(name) {
     let particleClass = this._loader.loadParticle(name);
     assert(particleClass, `can't find particle ${name}`);

--- a/runtime/recipe.js
+++ b/runtime/recipe.js
@@ -57,9 +57,11 @@ class RecipeComponent {
 class Recipe {
   constructor(...components) {
     this.components = components;
+    this.beforeInstantiation = [];
   }
 
   instantiate(arc) {
+    this.beforeInstantiation.forEach(f => f(arc));
     this.components.forEach(component => component.instantiate(arc));
   }
 }

--- a/runtime/suggestinator.js
+++ b/runtime/suggestinator.js
@@ -27,8 +27,12 @@ class Suggestinator {
     var trace = tracing.start({cat: "suggestinator", name: "Suggestinator::suggestinate"});
     var suggestions = this._getSuggestions(arc);
     trace.update({suggestions: suggestions.length});
+    var Product = arc._loader.loadEntity("Product");
+    console.log("BEFORE", arc.findViews(Product.type.viewOf()).length);
+
     suggestions = suggestions.filter(suggestion => Resolver.resolve(suggestion, arc));
-    
+    console.log("AFTER", arc.findViews(Product.type.viewOf()).length);
+
     for (var suggestion of suggestions)
       suggestion.rank = await this.speculator.speculate(arc, suggestion);
   

--- a/runtime/suggestinator.js
+++ b/runtime/suggestinator.js
@@ -27,10 +27,8 @@ class Suggestinator {
     var trace = tracing.start({cat: "suggestinator", name: "Suggestinator::suggestinate"});
     var suggestions = this._getSuggestions(arc);
     trace.update({suggestions: suggestions.length});
-    var Product = arc._loader.loadEntity("Product");
 
     suggestions = suggestions.filter(suggestion => Resolver.resolve(suggestion, arc));
-
     for (var suggestion of suggestions)
       suggestion.rank = await this.speculator.speculate(arc, suggestion);
   

--- a/runtime/suggestinator.js
+++ b/runtime/suggestinator.js
@@ -28,10 +28,8 @@ class Suggestinator {
     var suggestions = this._getSuggestions(arc);
     trace.update({suggestions: suggestions.length});
     var Product = arc._loader.loadEntity("Product");
-    console.log("BEFORE", arc.findViews(Product.type.viewOf()).length);
 
     suggestions = suggestions.filter(suggestion => Resolver.resolve(suggestion, arc));
-    console.log("AFTER", arc.findViews(Product.type.viewOf()).length);
 
     for (var suggestion of suggestions)
       suggestion.rank = await this.speculator.speculate(arc, suggestion);

--- a/runtime/test/demo-flow-test.js
+++ b/runtime/test/demo-flow-test.js
@@ -7,6 +7,7 @@
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
+ "use strict";
 
 var runtime = require("../runtime.js");
 var Arc = require("../arc.js");
@@ -16,6 +17,7 @@ var recipe = require('../recipe.js');
 var systemParticles = require('../system-particles.js');
 let assert = require('chai').assert;
 const testUtil = require('./test-util.js');
+const FakeSlotManager = require('./fake-slot-manager.js');
 
 require("./trace-setup.js");
 
@@ -31,73 +33,6 @@ function prepareExtensionArc() {
   arc.commit([new Person({name: "Claire"}), new Product({name: "Tea Pot"}), new Product({name: "Bee Hive"}), 
               new Product({name: "Denim Jeans"})]);
   return {arc, Person, Product};
-}
-
-class FakeSlotManager {
-  constructor(pec) {
-    this.pec = pec;
-    this.expectQueue = [];
-    this.specs = new Map();
-    this.onExpectationsComplete = () => undefined;
-  }
-
-  expectGetSlot(name, slotId) {
-    this.expectQueue.push({type: 'getSlot', name, slotId});
-    return this;
-  }
-
-  expectRender(name) {
-    this.expectQueue.push({type: 'render', name});
-    return this;
-  }
-
-  thenSend(slot, event, data) {
-    this.expectQueue[this.expectQueue.length - 1].then = {slot, event, data};
-    return this;
-  }
-
-  expectationsCompleted() {
-    if (this.expectQueue.length == 0)
-      return Promise.resolve();
-    return new Promise((resolve, reject) => this.onExpectationsComplete = resolve);
-  }
-
-  _sendEvent({slot, event, data}) {
-    var spec = this.specs.get(slot);
-    console.log(slot);
-    this.pec.sendEvent(spec, {handler: event, data});
-  }
-
-  renderSlot(particleSpec, content) {
-    var expectation = this.expectQueue.shift();
-    assert(expectation, "Got a render but not expecting anything further.");
-    assert.equal('render', expectation.type, `expecting a render, not ${expectation.type}`);
-    assert.equal(particleSpec.particle.spec.name, expectation.name, 
-        `expecting a render from ${expectation.name}, not ${particleSpec.particle.spec.name}`);
-    if (expectation.then) {
-      this._sendEvent(expectation.then);
-    }
-    if (this.expectQueue.length == 0)
-      this.onExpectationsComplete();
-  }
-
-  registerSlot(particleSpec, slotId) {
-    var expectation = this.expectQueue.shift();
-    assert(expectation, "Got a getSlot but not expecting anything further");
-    assert.equal('getSlot', expectation.type, `expecting a getSlot, not ${expectation.type}`);
-    assert.equal(particleSpec.particle.spec.name, expectation.name,
-        `expecting a getSlot from ${expectation.name}, not ${particleSpec.particle.spec.name}`);
-    assert.equal(slotId, expectation.slotId,
-        `expecting slotId ${expectation.slotId}, not ${slotId}`);
-    this.specs.set(slotId, particleSpec);
-    return Promise.resolve().then(() => {
-      if (expectation.then) {
-        this._sendEvent(expectation.then);
-      }
-      if (this.expectQueue.length == 0)
-        this.onExpectationsComplete();      
-    });
-  }
 }
 
 describe('demo flow', function() {

--- a/runtime/test/demo-flow-test.js
+++ b/runtime/test/demo-flow-test.js
@@ -17,7 +17,7 @@ var recipe = require('../recipe.js');
 var systemParticles = require('../system-particles.js');
 let assert = require('chai').assert;
 const testUtil = require('./test-util.js');
-const FakeSlotManager = require('./fake-slot-manager.js');
+const MockSlotManager = require('./mock-slot-manager.js');
 
 require("./trace-setup.js");
 
@@ -72,7 +72,7 @@ describe('demo flow', function() {
       var productViews = arc.findViews(Product.type.viewOf());
       assert.equal(productViews.length, 1);
       await testUtil.assertViewHas(productViews[0], Product, "name", ["Tea Pot", "Bee Hive", "Denim Jeans"]);
-      var slotManager = new FakeSlotManager(arc.pec);
+      var slotManager = new MockSlotManager(arc.pec);
       slotManager.expectGetSlot("ListView", "root")
                  .expectGetSlot("Chooser", "action")
                  .expectRender("ListView")

--- a/runtime/test/fake-slot-manager.js
+++ b/runtime/test/fake-slot-manager.js
@@ -1,0 +1,81 @@
+/**
+ * @license
+ * Copyright (c) 2017 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+"use strict";
+
+let assert = require('chai').assert;
+
+class FakeSlotManager {
+  constructor(pec) {
+    this.pec = pec;
+    this.expectQueue = [];
+    this.specs = new Map();
+    this.onExpectationsComplete = () => undefined;
+  }
+
+  expectGetSlot(name, slotId) {
+    this.expectQueue.push({type: 'getSlot', name, slotId});
+    return this;
+  }
+
+  expectRender(name) {
+    this.expectQueue.push({type: 'render', name});
+    return this;
+  }
+
+  thenSend(slot, event, data) {
+    this.expectQueue[this.expectQueue.length - 1].then = {slot, event, data};
+    return this;
+  }
+
+  expectationsCompleted() {
+    if (this.expectQueue.length == 0)
+      return Promise.resolve();
+    return new Promise((resolve, reject) => this.onExpectationsComplete = resolve);
+  }
+
+  _sendEvent({slot, event, data}) {
+    var spec = this.specs.get(slot);
+    console.log(slot);
+    this.pec.sendEvent(spec, {handler: event, data});
+  }
+
+  renderSlot(particleSpec, content) {
+    var expectation = this.expectQueue.shift();
+    assert(expectation, "Got a render but not expecting anything further.");
+    assert.equal('render', expectation.type, `expecting a render, not ${expectation.type}`);
+    assert.equal(particleSpec.particle.spec.name, expectation.name, 
+        `expecting a render from ${expectation.name}, not ${particleSpec.particle.spec.name}`);
+    if (expectation.then) {
+      this._sendEvent(expectation.then);
+    }
+    if (this.expectQueue.length == 0)
+      this.onExpectationsComplete();
+  }
+
+  registerSlot(particleSpec, slotId) {
+    var expectation = this.expectQueue.shift();
+    assert(expectation, "Got a getSlot but not expecting anything further");
+    assert.equal('getSlot', expectation.type, `expecting a getSlot, not ${expectation.type}`);
+    assert.equal(particleSpec.particle.spec.name, expectation.name,
+        `expecting a getSlot from ${expectation.name}, not ${particleSpec.particle.spec.name}`);
+    assert.equal(slotId, expectation.slotId,
+        `expecting slotId ${expectation.slotId}, not ${slotId}`);
+    this.specs.set(slotId, particleSpec);
+    return Promise.resolve().then(() => {
+      if (expectation.then) {
+        this._sendEvent(expectation.then);
+      }
+      if (this.expectQueue.length == 0)
+        this.onExpectationsComplete();      
+    });
+  }
+}
+
+module.exports = FakeSlotManager;

--- a/runtime/test/mock-slot-manager.js
+++ b/runtime/test/mock-slot-manager.js
@@ -11,7 +11,7 @@
 
 let assert = require('chai').assert;
 
-class FakeSlotManager {
+class MockSlotManager {
   constructor(pec) {
     this.pec = pec;
     this.expectQueue = [];
@@ -78,4 +78,4 @@ class FakeSlotManager {
   }
 }
 
-module.exports = FakeSlotManager;
+module.exports = MockSlotManager;

--- a/runtime/test/speculator-tests.js
+++ b/runtime/test/speculator-tests.js
@@ -35,7 +35,6 @@ describe('speculator', function() {
             .connectView("bar", barView)
         .build();
     var speculator = new Speculator();
-    console.log(new Foo({value: "not a Bar"}));
     fooView.set(new Foo({value: "not a Bar"}));
     var relevance = await speculator.speculate(arc, r);
     assert.equal(relevance, 1.8);

--- a/runtime/test/test-util.js
+++ b/runtime/test/test-util.js
@@ -26,6 +26,17 @@ function assertSingletonHas(view, entityClass, expectation) {
   });
 }
 
+function assertViewHas(view, entityClass, field, expectations) {
+  return new Promise((resolve, reject) => {
+    view = viewlet.viewletFor(view, true);
+    view.entityClass = entityClass;
+    view.toList().then(result => {
+      assert.deepEqual(result.map(a => a[field]), expectations);
+      resolve();
+    });
+  });
+}
+
 function assertSingletonEmpty(view) {
   return new Promise((resolve, reject) => {
     var variable = new viewlet.viewletFor(view);
@@ -38,3 +49,4 @@ function assertSingletonEmpty(view) {
 
 exports.assertSingletonHas = assertSingletonHas;
 exports.assertSingletonEmpty = assertSingletonEmpty;
+exports.assertViewHas = assertViewHas;


### PR DESCRIPTION
This patch extends what the demo script does slightly - a suggested recipe is selected and run "for realz" in an arc. A faked SlotManager then mediates display requests and generates a user interaction that selects one of the provided wishlist items.

I've also added a bunch of testing to make sure the arc isn't modified by resolution - this required shifting where post-recipe resolution things like view creation happen - but things are a bunch better now.

Also I added some comments to the resolver to help out when we do the redesign.