### PR TITLE
Don't assign/use real slots during speculative execution

### DIFF
--- a/runtime/arc.js
+++ b/runtime/arc.js
@@ -53,7 +53,7 @@ class Arc {
   }
 
   clone() {
-    var arc = new Arc({loader: this._loader, id: this.generateID(), pecFactory: this._pecFactory, slotManager: this.pec.slotManager});
+    var arc = new Arc({loader: this._loader, id: this.generateID(), pecFactory: this._pecFactory});
     var viewMap = new Map();
     this.views.forEach(v => viewMap.set(v, v.clone()));
     arc.particles = this.particles.map(p => p.clone(viewMap));

--- a/runtime/arc.js
+++ b/runtime/arc.js
@@ -21,7 +21,6 @@ const OuterPec = require('./outer-PEC.js');
 class Arc {
   constructor({id, loader, pecFactory, slotManager}) {
     assert(loader);
-    assert(slotManager);
     this._loader = loader;
     // TODO: pecFactory should not be optional. update all callers and fix here.
     this._pecFactory = pecFactory ||  require('./fake-pec-factory').bind(null);
@@ -31,7 +30,6 @@ class Arc {
     this.views = new Set();
     this._viewsByType = new Map();
     this.particleViewMaps = new Map();
-    this._slotManager = slotManager;
     let pecId = this.generateID();
     let innerPecPort = this._pecFactory(pecId);
     this.pec = new OuterPec(innerPecPort, slotManager, `${pecId}:outer`);
@@ -55,7 +53,7 @@ class Arc {
   }
 
   clone() {
-    var arc = new Arc({loader: this._loader, id: this.generateID(), pecFactory: this._pecFactory, slotManager: this._slotManager});
+    var arc = new Arc({loader: this._loader, id: this.generateID(), pecFactory: this._pecFactory, slotManager: this.pec.slotManager});
     var viewMap = new Map();
     this.views.forEach(v => viewMap.set(v, v.clone()));
     arc.particles = this.particles.map(p => p.clone(viewMap));

--- a/runtime/browser-demo/browser-demo.js
+++ b/runtime/browser-demo/browser-demo.js
@@ -14,7 +14,7 @@ let Arc = require("../arc.js");
 let BrowserLoader = require("../browser-loader.js");
 let Resolver = require('../resolver.js');
 let SlotManager = require('../slot-manager.js');
-//let Suggestinator = require("../suggestinator.js");
+let Suggestinator = require("../suggestinator.js");
 
 let recipe = require('../recipe.js');
 let systemParticles = require('../system-particles.js');
@@ -56,33 +56,25 @@ let buildRecipe = info => {
 
 let arc = prepareExtensionArc();
 
-let suggest = index => {
-  let r = buildRecipe(recipes[index]);
-  if (Resolver.resolve(r, arc)) {
-    r.instantiate(arc);
-  } 
-};
-
-let suggestions = recipes.map(r => r.name);
-
 let container = document.querySelector('suggestions');
-suggestions.forEach((s, i) => {
-  container.appendChild(
-    Object.assign(document.createElement("suggest"), {
-      index: i,
-      textContent: s,
-      onclick: e => suggest(e.currentTarget.index)
-    })
-  );
+let rs = recipes.map(r => {
+  let recipe = buildRecipe(r);
+  recipe.name = r.name;
+  return recipe;
 });
 
-/*
 let suggestinator = new Suggestinator();
-suggestinator._getSuggestions = a => [r];
+suggestinator._getSuggestions = a => rs;
 
 let results = suggestinator.suggestinate(arc);
 results.then(r => {
   console.log(r);
-  //window.trace = tracing.save();
+  r.forEach(recipe => {
+    container.appendChild(
+      Object.assign(document.createElement("suggest"), {
+        textContent: recipe.name,
+        onclick: e => recipe.instantiate(arc)
+      })
+    );
+  });
 });
-*/

--- a/runtime/browser-test/browser-test.js
+++ b/runtime/browser-test/browser-test.js
@@ -69,7 +69,5 @@ var results = suggestinator.suggestinate(arc);
 results.then(r => {
   console.log(r);
   window.trace = tracing.save();
-  // TODO(mmandlis): This causes all particle to re-render their slots.
-  // Should support speculative execution in SlotManager instead.
   r[0].instantiate(arc);
 })

--- a/runtime/outer-PEC.js
+++ b/runtime/outer-PEC.js
@@ -24,7 +24,8 @@ class OuterPEC extends PEC {
     this.slotManager = slotManager;
 
     this._apiPort.onRenderSlot = ({particle, content}) => {
-      this.slotManager.renderSlot(particle, content, this._makeEventletHandler(particle));
+      if (this.slotManager)
+        this.slotManager.renderSlot(particle, content, this._makeEventletHandler(particle));
     };
 
     this._apiPort.onViewOn = ({view, target, callback, type}) => {
@@ -51,14 +52,17 @@ class OuterPEC extends PEC {
 
     this._apiPort.onGetSlot = ({particle, name, callback}) => {
       assert(particle.renderMap.has(name));
-      this.slotManager.registerSlot(particle, name).then(() =>
-        this._apiPort.ViewCallback({callback}));
+      if (this.slotManager)
+        this.slotManager.registerSlot(particle, name).then(() =>
+          this._apiPort.ViewCallback({callback}));
     }
 
     this._apiPort.onReleaseSlot = ({particle}) => {
-      let affectedParticles = this.slotManager.releaseSlot(particle);
-      if (affectedParticles) {
-        this._apiPort.LostSlots({particles: affectedParticles});
+      if (this.slotManager) {
+        let affectedParticles = this.slotManager.releaseSlot(particle);
+        if (affectedParticles) {
+          this._apiPort.LostSlots({particles: affectedParticles});
+        }
       }
     }
   }

--- a/runtime/slot-manager.js
+++ b/runtime/slot-manager.js
@@ -83,7 +83,7 @@ class SlotManager {
       if (originalContent) {
         // TODO(sjmiles): recurses
         this.renderSlot(this._getParticle(info.id), originalContent);
-      } else {
+      } else if (!inner.isAssociated()) {
         // TODO(sjmiles): falsey test for originalContent is an implicit signal, really don't we want `isAvailable()`?
         inner.providePendingSlot();
       }

--- a/runtime/speculator.js
+++ b/runtime/speculator.js
@@ -19,7 +19,6 @@ class Speculator {
   speculate(arc, plan) {
     var callTrace = tracing.start({cat: "speculator", name: "Speculator::speculate"});
     var newArc = arc.clone();
-
     plan.instantiate(newArc);
     callTrace.end();
     let relevance = new Relevance();

--- a/runtime/speculator.js
+++ b/runtime/speculator.js
@@ -19,7 +19,6 @@ class Speculator {
   speculate(arc, plan) {
     var callTrace = tracing.start({cat: "speculator", name: "Speculator::speculate"});
     var newArc = arc.clone();
-    newArc.pec.slotManager = undefined;
 
     plan.instantiate(newArc);
     callTrace.end();

--- a/runtime/speculator.js
+++ b/runtime/speculator.js
@@ -19,6 +19,8 @@ class Speculator {
   speculate(arc, plan) {
     var callTrace = tracing.start({cat: "speculator", name: "Speculator::speculate"});
     var newArc = arc.clone();
+    newArc.pec.slotManager = undefined;
+
     plan.instantiate(newArc);
     callTrace.end();
     let relevance = new Relevance();

--- a/runtime/test/speculator-tests.js
+++ b/runtime/test/speculator-tests.js
@@ -16,19 +16,17 @@ let assert = require('chai').assert;
 let particles = require('./test-particles.js');
 let util = require('./test-util.js');
 let Loader = require('../loader');
-let SlotManager = require('../slot-manager.js');
 
 require("./trace-setup.js");
 
 let loader = new Loader();
 particles.register(loader);
-const slotManager = new SlotManager({});
 const Foo = loader.loadEntity("Foo");
 const Bar = loader.loadEntity("Bar");
 
 describe('speculator', function() {
   it('can speculatively produce a relevance', async () => {
-    var arc = new Arc({loader, slotManager});
+    var arc = new Arc({loader});
     let fooView = arc.createView(Foo.type);
     let barView = arc.createView(Bar.type);
     var r = new recipe.RecipeBuilder()


### PR DESCRIPTION
- updated Speculator to unset the SlotManager in the cloned arc
- added support outerPec to run without SlotManager
- updated the browser-demo to run Suggestinator, display produced suggestion and instantiate plans on user acceptance of a suggestion.

https://github.com/PolymerLabs/arcs/issues/139