### PR TITLE
Fix slot manager bugs regarding pending slots

### DIFF
--- a/runtime/test/slot-manager-tests.js
+++ b/runtime/test/slot-manager-tests.js
@@ -100,6 +100,18 @@ describe('slot manager', function() {
     await innerSlotPromise;
   });
 
+  it('release pending inner slot', async () => {
+    let slotManager = new SlotManager(/* domRoot= */{}, /* pec= */ {});
+    // require inner slot
+    let innerSlotPromise = slotManager.registerSlot(otherParticleSpec, innerSlotid);
+    // release particle, while slot request is still pending.
+    slotManager.releaseSlot(otherParticleSpec);
+    innerSlotPromise.then(function() {
+      assert.fail('slot was released, promise should have been rejected.');
+    }, function() {
+    });
+  });
+
   it('release inner slot', async () => {
     let slotManager = new SlotManager(/* domRoot= */{}, /* pec= */ {});
     // Register and render slot

--- a/runtime/test/slot-tests.js
+++ b/runtime/test/slot-tests.js
@@ -29,15 +29,17 @@ describe('slot', function() {
     assert.throws(() => { slot.associateWithParticle(particleSpec); });
   });
 
-  it('pending handler', function() {
+  it('add and provide pending requests', function() {
     let slot = new Slot('slotid');
     assert.isFalse(slot.isAssociated());
 
     let count = 0;
     let handler = () => { count++; };
 
-    slot.addPendingRequest(handler);
-    slot.addPendingRequest(handler);
+    slot.addPendingRequest(util.initParticleSpec('particle1'), handler, {});
+    // Add request for the same particle, so it is ignored.
+    slot.addPendingRequest(util.initParticleSpec('particle1'), handler, {});
+    slot.addPendingRequest(util.initParticleSpec('particle2'), handler, {});
     slot.providePendingSlot();
     let expectedCount = 0;
     assert.equal(++expectedCount, count);
@@ -51,5 +53,13 @@ describe('slot', function() {
     slot.associateWithParticle(util.initParticleSpec('particle'));
     assert.throws(() => { slot.providePendingSlot(); });
     assert.equal(expectedCount, count);
+  });
+  it('remove pending request', function() {
+    let slot = new Slot('slotid');
+    let count = 0;
+    let reject = () => { count++; };
+    slot.addPendingRequest(util.initParticleSpec('particle1'), {}, reject);
+    slot.removePendingRequest(util.initParticleSpec('particle1'));
+    assert.equal(1, count);
   });
 });

--- a/runtime/test/test-util.js
+++ b/runtime/test/test-util.js
@@ -48,7 +48,7 @@ function assertSingletonEmpty(view) {
 }
 
 function initParticleSpec(name) {
-  var particleSpec = JSON.parse(`{"spec":{"name":"${name}"}}`);
+  var particleSpec = JSON.parse(`{"particle":{"name":"${name}"}}`);
   particleSpec.exposeMap = new Map();
   particleSpec.renderMap = new Map();
   return particleSpec;


### PR DESCRIPTION
SlotManager to disallow duplicate pending requests for {slotid, particle}   
https://github.com/PolymerLabs/arcs/issues/135

SlotManager to remove pending request, if particle released the slot
https://github.com/PolymerLabs/arcs/issues/125

PS: I admit that I currently made the code a bit messier than before, but I intend to fix it in the next iteration, promise.
