### PR TITLE
Switch from browserify to webpack

### DIFF
--- a/runtime/gulpfile.js
+++ b/runtime/gulpfile.js
@@ -8,26 +8,36 @@
 
 const gulp = require('gulp');
 
-gulp.task('build', function() {
-  const browserify = require('browserify');
-  const source = require('vinyl-source-stream');
-  const buffer = require('vinyl-buffer');
-  const sourcemaps = require('gulp-sourcemaps');
+gulp.task('build', async function() {
+  const webpack = require('webpack');
+
+  let node = {
+    fs: 'empty',
+    mkdirp: 'empty',
+    minimist: 'empty',
+  };
 
   for (let file of [
-    'browser-test/browser-test.js',
-    'browser-demo/browser-demo.js',
-    'worker-entry.js',
+    './browser-test/browser-test.js',
+    './browser-demo/browser-demo.js',
+    './worker-entry.js',
   ]) {
-    browserify({
-      entries: file,
-      debug: true,
-    }).bundle()
-        .pipe(source(file))
-        .pipe(buffer())
-        .pipe(sourcemaps.init({loadMaps: true}))
-        .pipe(sourcemaps.write('./'))
-        .pipe(gulp.dest('./build/'));
+    await new Promise((resolve, reject) => {
+      webpack({
+        entry: file,
+        output: {
+          filename: 'build/' + file,
+        },
+        node,
+        devtool: 'sourcemap',
+      }, (err, stats) => {
+        if (err) {
+          reject(err);
+        }
+        console.log(stats.toString({colors: true, verbose: true}));
+        resolve();
+      });
+    });
   }
 });
 

--- a/runtime/package.json
+++ b/runtime/package.json
@@ -9,15 +9,12 @@
     "tracelib": "../tracelib"
   },
   "devDependencies": {
-    "browserify": "^14.3.0",
     "chai": "^3.5.0",
     "gulp": "^3.9.1",
     "gulp-mocha": "^4.3.1",
-    "gulp-sourcemaps": "^2.6.0",
     "mocha": "^3.2.0",
     "pegjs": "^0.10.0",
-    "vinyl-buffer": "^1.0.0",
-    "vinyl-source-stream": "^1.1.0",
-    "watchify": "^3.9.0"
+    "watchify": "^3.9.0",
+    "webpack": "^2.6.1"
   }
 }

--- a/tracelib/trace.js
+++ b/tracelib/trace.js
@@ -14,7 +14,6 @@
 var fs = require('fs');
 var mkdirp = require('mkdirp');
 var path = require('path');
-var zlib = require('zlib');
 var options = require('./options');
 
 var events = [];


### PR DESCRIPTION
This makes it easlier to stub out node modules, and will support moving to
JavaScript modules in the future.