### PR TITLE
Rename and refactor methods in Slot and SlotManager classes

### DIFF
--- a/runtime/outer-PEC.js
+++ b/runtime/outer-PEC.js
@@ -25,7 +25,7 @@ class OuterPEC extends PEC {
 
     this._apiPort.onRenderSlot = ({particle, content}) => {
       if (this.slotManager)
-        this.slotManager.renderSlot(particle, content, this._makeEventletHandler(particle));
+        this.slotManager.renderContent(particle, content, this._makeEventletHandler(particle));
     };
 
     this._apiPort.onViewOn = ({view, target, callback, type}) => {
@@ -53,13 +53,13 @@ class OuterPEC extends PEC {
     this._apiPort.onGetSlot = ({particle, name, callback}) => {
       assert(particle.renderMap.has(name));
       if (this.slotManager)
-        this.slotManager.registerSlot(particle, name).then(() =>
+        this.slotManager.registerParticle(particle, name).then(() =>
           this._apiPort.ViewCallback({callback}));
     }
 
     this._apiPort.onReleaseSlot = ({particle}) => {
       if (this.slotManager) {
-        let affectedParticles = this.slotManager.releaseSlot(particle);
+        let affectedParticles = this.slotManager.releaseParticle(particle);
         if (affectedParticles) {
           this._apiPort.LostSlots({particles: affectedParticles});
         }

--- a/runtime/slot-dom.js
+++ b/runtime/slot-dom.js
@@ -24,9 +24,9 @@ class DomSlot extends Slot {
   isInitialized() {
     return Boolean(this._dom);
   }
-  // Returns true, if slot's DOM is initialized, and there is no Particle associated with it.
+  // Returns true, if slot's DOM is initialized, and there is no Particle assigned to it.
   isAvailable() {
-    return this.isInitialized() && !this.isAssociated();
+    return this.isInitialized() && !this.hasParticle();
   }
   uninitialize() {
     this._dom = null;

--- a/runtime/slot.js
+++ b/runtime/slot.js
@@ -27,20 +27,20 @@ class Slot {
   get particleSpec() { 
     return this._particleSpec; 
   }
-  associateWithParticle(particleSpec) {
-    assert(!this._particleSpec, "Particle spec already set, cannot associate slot");
+  assignParticle(particleSpec) {
+    assert(!this._particleSpec, "Particle spec already set, cannot assign slot");
     // Verify that particle that hosts this slot exposes the same view that is
-    // being rendered by the particle that is being associated with it.
+    // being rendered by the particle that is being assigned to it.
     assert(!this._exposedView ||
            this._particleSpec.renderMap.get(this._slotid) == this._exposedView,
-           "Cannot associate particle-spec with an unmatching view.");
+           "Cannot assign slot to particle-spec with an unmatching view.");
     this._particleSpec = particleSpec;
   }
-  disassociateParticle() {
-    assert(this._particleSpec, "Particle spec is not set, cannot disassociate slot");
+  unassignParticle() {
+    assert(this._particleSpec, "Particle spec is not set, cannot unassign slot");
     this._particleSpec = null;
   }
-  isAssociated() {
+  hasParticle() {
     return !!this._particleSpec;
   }
   addPendingRequest(particleSpec, resolve, reject) {
@@ -56,7 +56,7 @@ class Slot {
     this._pendingRequests.delete(particleName);
   }
   providePendingSlot() {
-    assert(!this.isAssociated(), "Cannot provide associated slot.");
+    assert(!this.hasParticle(), "Cannot provide assigned slot.");
     if (this._pendingRequests.size > 0) {
       let pendingRequest = this._pendingRequests.entries().next();
       if (pendingRequest && pendingRequest.value[1].resolve) {

--- a/runtime/test/mock-slot-manager.js
+++ b/runtime/test/mock-slot-manager.js
@@ -45,7 +45,7 @@ class MockSlotManager {
     this.pec.sendEvent(spec, {handler: event, data});
   }
 
-  renderSlot(particleSpec, content) {
+  renderContent(particleSpec, content) {
     var expectation = this.expectQueue.shift();
     assert(expectation, "Got a render but not expecting anything further.");
     assert.equal('render', expectation.type, `expecting a render, not ${expectation.type}`);
@@ -58,7 +58,7 @@ class MockSlotManager {
       this.onExpectationsComplete();
   }
 
-  registerSlot(particleSpec, slotId) {
+  registerParticle(particleSpec, slotId) {
     var expectation = this.expectQueue.shift();
     assert(expectation, `Got a getSlot '${slotId}' from '${particleSpec.particle.spec.name}' but not expecting anything further`);
     assert.equal('getSlot', expectation.type, `expecting a getSlot, not ${expectation.type}`);

--- a/runtime/test/slot-dom-tests.js
+++ b/runtime/test/slot-dom-tests.js
@@ -55,12 +55,12 @@ describe('slot-dom', function() {
     // Slot isn't initialized.
     assert.isFalse(slot.isAvailable());
 
-    // Slot is initialized and not associated with a Particle.
+    // Slot is initialized and unassigned to a Particle.
     slot.initialize(/* context= */{}, /* exposedView= */undefined);
     assert.isTrue(slot.isAvailable());
 
-    // Slot is associated with a Particle.
-    slot.associateWithParticle(util.initParticleSpec('particle'));
+    // Slot is assign to a Particle.
+    slot.assignParticle(util.initParticleSpec('particle'));
     assert.isFalse(slot.isAvailable());
 
 	// Slot isn't initialized.

--- a/runtime/test/slot-manager-tests.js
+++ b/runtime/test/slot-manager-tests.js
@@ -22,80 +22,80 @@ describe('slot manager', function() {
   it('register and release slots', async () => {
    let slotManager = new SlotManager(/* domRoot= */{}, /* pec= */ {});
 
-    // successfully register a slot.
-    await slotManager.registerSlot(particleSpec, rootSlotid, "view");
-    assert.equal(rootSlotid, slotManager._getSlotId(particleSpec));
-    assert.equal(particleSpec, slotManager._getParticle(rootSlotid));
+    // successfully register particle for a slot.
+    await slotManager.registerParticle(particleSpec, rootSlotid, "view");
+    assert.equal(rootSlotid, slotManager._getParticleSlot(particleSpec).slotid);
+    assert.equal(particleSpec, slotManager._getSlot(rootSlotid).particleSpec);
 
-    // successfully release slot.
-    slotManager.releaseSlot(particleSpec);
-    assert.equal(undefined, slotManager._getSlotId(particleSpec));
-    assert.equal(undefined, slotManager._getParticle(rootSlotid));
+    // particle successfully release slot.
+    slotManager.releaseParticle(particleSpec);
+    assert.equal(undefined, slotManager._getParticleSlot(particleSpec));
+    assert.equal(undefined, slotManager._getSlot(rootSlotid).particleSpec);
   });
 
   it('provide pending slot', async () => {
     let slotManager = new SlotManager(/* domRoot= */{}, /* pec= */ {});
 
-    // successfully register a slot.
-    await slotManager.registerSlot(particleSpec, rootSlotid, "view");
+    // successfully register particle for a slot.
+    await slotManager.registerParticle(particleSpec, rootSlotid, "view");
     // register other particle for the same slot - added pending handler.
     let otherParticleSpec1 = util.initParticleSpec("OtherParticleSpec1");
-    let pendingPromise1 = slotManager.registerSlot(otherParticleSpec1, rootSlotid, "view");
+    let pendingPromise1 = slotManager.registerParticle(otherParticleSpec1, rootSlotid, "view");
     pendingPromise1.done = false;
     var verifyPromise = (pendingParticleId) => {
       // verify released slot was provided to the pending particle.
-      assert.equal(pendingParticleId, slotManager._getParticle(rootSlotid));
-      assert.equal(undefined, slotManager._getSlotId(particleSpec));
-      assert.equal(rootSlotid, slotManager._getSlotId(pendingParticleId));
+      assert.equal(pendingParticleId, slotManager._getSlot(rootSlotid).particleSpec);
+      assert.equal(undefined, slotManager._getParticleSlot(particleSpec));
+      assert.equal(rootSlotid, slotManager._getParticleSlot(pendingParticleId).slotid);
     };
     pendingPromise1.then(() => { verifyPromise(otherParticleSpec1); pendingPromise1.done=true });
 
     let otherParticleSpec2 = util.initParticleSpec("OtherParticleSpec2");
-    let pendingPromise2 = slotManager.registerSlot(otherParticleSpec2, rootSlotid, "view");
+    let pendingPromise2 = slotManager.registerParticle(otherParticleSpec2, rootSlotid, "view");
     pendingPromise2.done = false;
     pendingPromise2.then(() => { verifyPromise(otherParticleSpec2); pendingPromise2.done=true });
 
     // verify registered and pending slots.
-    assert.equal(rootSlotid, slotManager._getSlotId(particleSpec));
-    assert.equal(particleSpec, slotManager._getParticle(rootSlotid));
+    assert.equal(rootSlotid, slotManager._getParticleSlot(particleSpec).slotid);
+    assert.equal(particleSpec, slotManager._getSlot(rootSlotid).particleSpec);
     // verify pending promises are still pending.
     assert.isFalse(pendingPromise1.done);
     assert.isFalse(pendingPromise2.done);
 
-    // successfully release slot.
-    slotManager.releaseSlot(particleSpec);
+    // particle successfully release slot.
+    slotManager.releaseParticle(particleSpec);
 
     // TODO(mmandlis): this test depends on the order the pending slots are provided, it shouldn't.
     await pendingPromise1;
-    slotManager.releaseSlot(otherParticleSpec1);
+    slotManager.releaseParticle(otherParticleSpec1);
     await pendingPromise2;
   });
 
-  it('re-render inner slot', async () => {
+  it('re-render inner slot content', async () => {
     let slotManager = new SlotManager(/* domRoot= */{}, /* pec= */ {});
-    // successfully register and render root slot.
-    await slotManager.registerSlot(particleSpec, rootSlotid, "view");
-    slotManager.renderSlot(particleSpec, `Foo<div slotid="${innerSlotid}"></div>`);
+    // successfully register particle for root slot and render it.
+    await slotManager.registerParticle(particleSpec, rootSlotid, "view");
+    slotManager.renderContent(particleSpec, `Foo<div slotid="${innerSlotid}"></div>`);
 
     // require inner and render inner slot.
-    await slotManager.registerSlot(otherParticleSpec, innerSlotid);
+    await slotManager.registerParticle(otherParticleSpec, innerSlotid);
     let innerSlotContent = "Bar";
-    slotManager.renderSlot(otherParticleSpec, innerSlotContent);
+    slotManager.renderContent(otherParticleSpec, innerSlotContent);
     assert.equal(innerSlotContent, slotManager._getSlot(innerSlotid)._dom.innerHTML);
 
     // re-render content of the root slot, and verify the inner slot content is preserved.
-    slotManager.renderSlot(particleSpec, `Not Foo<div slotid="${innerSlotid}"></div>`);
+    slotManager.renderContent(particleSpec, `Not Foo<div slotid="${innerSlotid}"></div>`);
     assert.equal(innerSlotContent, slotManager._getSlot(innerSlotid)._dom.innerHTML);
   });
 
   it('provide pending inner slot', async () => {
     let slotManager = new SlotManager(/* domRoot= */{}, /* pec= */ {});
     // require inner slot
-    let innerSlotPromise = slotManager.registerSlot(otherParticleSpec, innerSlotid);
+    let innerSlotPromise = slotManager.registerParticle(otherParticleSpec, innerSlotid);
 
-    // successfully register and render root slot.
-    await slotManager.registerSlot(particleSpec, rootSlotid, "view");
-    slotManager.renderSlot(particleSpec, `Foo<div slotid="${innerSlotid}"></div>`);
+    // successfully register particle and render root slot content.
+    await slotManager.registerParticle(particleSpec, rootSlotid, "view");
+    slotManager.renderContent(particleSpec, `Foo<div slotid="${innerSlotid}"></div>`);
 
     await innerSlotPromise;
   });
@@ -103,9 +103,9 @@ describe('slot manager', function() {
   it('release pending inner slot', async () => {
     let slotManager = new SlotManager(/* domRoot= */{}, /* pec= */ {});
     // require inner slot
-    let innerSlotPromise = slotManager.registerSlot(otherParticleSpec, innerSlotid);
+    let innerSlotPromise = slotManager.registerParticle(otherParticleSpec, innerSlotid);
     // release particle, while slot request is still pending.
-    slotManager.releaseSlot(otherParticleSpec);
+    slotManager.releaseParticle(otherParticleSpec);
     innerSlotPromise.then(function() {
       assert.fail('slot was released, promise should have been rejected.');
     }, function() {
@@ -114,34 +114,34 @@ describe('slot manager', function() {
 
   it('release inner slot', async () => {
     let slotManager = new SlotManager(/* domRoot= */{}, /* pec= */ {});
-    // Register and render slot
-    await slotManager.registerSlot(particleSpec, rootSlotid, "view");
-    slotManager.renderSlot(particleSpec, `Foo<div slotid="${innerSlotid}"></div>`);
+    // Register particle and render slot content
+    await slotManager.registerParticle(particleSpec, rootSlotid, "view");
+    slotManager.renderContent(particleSpec, `Foo<div slotid="${innerSlotid}"></div>`);
     // require inner slot
-    await slotManager.registerSlot(otherParticleSpec, innerSlotid);
-    assert.equal(innerSlotid, slotManager._getSlotId(otherParticleSpec));
-    assert.equal(otherParticleSpec, slotManager._getParticle(innerSlotid));
+    await slotManager.registerParticle(otherParticleSpec, innerSlotid);
+    assert.equal(innerSlotid, slotManager._getParticleSlot(otherParticleSpec).slotid);
+    assert.equal(otherParticleSpec, slotManager._getSlot(innerSlotid).particleSpec);
 
     // release root slot and verify inner slot was released too.
-    slotManager.releaseSlot(particleSpec);
-    assert.equal(undefined, slotManager._getSlotId(otherParticleSpec));
-    assert.equal(undefined, slotManager._getParticle(innerSlotid));
+    slotManager.releaseParticle(particleSpec);
+    assert.equal(undefined, slotManager._getParticleSlot(otherParticleSpec));
+    assert.isFalse(slotManager.hasSlot(innerSlotid));
   });
 
   it('three-level-nested-slots', async () => {
     let slotManager = new SlotManager(/* domRoot= */{}, /* pec= */ {});
-    // Register and render 3 inner slots
-    await slotManager.registerSlot(particleSpec, rootSlotid, "view");
+    // Register and render 3 inner slots' content
+    await slotManager.registerParticle(particleSpec, rootSlotid, "view");
     let rootContent = `Foo<div slotid="${innerSlotid}"></div>`;
-    slotManager.renderSlot(particleSpec, rootContent);
-    await slotManager.registerSlot(otherParticleSpec, innerSlotid, "view");
+    slotManager.renderContent(particleSpec, rootContent);
+    await slotManager.registerParticle(otherParticleSpec, innerSlotid, "view");
     let subInnerSlotid = "sub";
     let innerContent = `Bar<div slotid="${subInnerSlotid}"></div>`;
-    slotManager.renderSlot(otherParticleSpec, innerContent);
+    slotManager.renderContent(otherParticleSpec, innerContent);
     let subParticleSpec = util.initParticleSpec("SubParticle");
-    await slotManager.registerSlot(subParticleSpec, subInnerSlotid, "view");
+    await slotManager.registerParticle(subParticleSpec, subInnerSlotid, "view");
     let subInnerContent = "Bazzzz";
-    slotManager.renderSlot(subParticleSpec, subInnerContent);
+    slotManager.renderContent(subParticleSpec, subInnerContent);
 
     // Verify all 3 slots' content and mappings.
     let rootDom = slotManager._getSlot(rootSlotid)._dom;
@@ -151,12 +151,12 @@ describe('slot manager', function() {
     assert.equal(subInnerContent, slotManager._getSlot(subInnerSlotid)._dom.innerHTML);
 
     // release mid-layer slot.
-    slotManager.releaseSlot(otherParticleSpec);
+    slotManager.releaseParticle(otherParticleSpec);
 
     // Verify only root slot content remains
     assert.equal(rootContent, rootDom.innerHTML);
     assert.equal('', innerDom.innerHTML);
-    assert.equal(undefined, slotManager._getSlotId(subParticleSpec));
-    assert.equal(undefined, slotManager._getParticle(subInnerSlotid));
+    assert.equal(undefined, slotManager._getParticleSlot(subParticleSpec));
+    assert.isFalse(slotManager.hasSlot(subInnerSlotid));
   });
 });

--- a/runtime/test/slot-tests.js
+++ b/runtime/test/slot-tests.js
@@ -14,24 +14,24 @@ var Slot = require("../slot.js");
 let util = require('./test-util.js');
 
 describe('slot', function() {
-  it('associate and disassociate slot', function() {
+  it('assign and unassign slot', function() {
     let slot = new Slot('slotid');
-    assert.isFalse(slot.isAssociated());
+    assert.isFalse(slot.hasParticle());
 
-    // cannot disassociate not associated slot.
-    assert.throws(() => { slot.disassociateParticle() });
+    // cannot unassign slot that wasn't assigned.
+    assert.throws(() => { slot.unassignParticle() });
 
-    // associate slot.
+    // assign slot.
     let particleSpec = util.initParticleSpec('particle');
-    slot.associateWithParticle(particleSpec);
-    assert.isTrue(slot.isAssociated());
-    // cannot associate slot that is already associated.
-    assert.throws(() => { slot.associateWithParticle(particleSpec); });
+    slot.assignParticle(particleSpec);
+    assert.isTrue(slot.hasParticle());
+    // cannot assign slot that is already assigned.
+    assert.throws(() => { slot.assignParticle(particleSpec); });
   });
 
   it('add and provide pending requests', function() {
     let slot = new Slot('slotid');
-    assert.isFalse(slot.isAssociated());
+    assert.isFalse(slot.hasParticle());
 
     let count = 0;
     let handler = () => { count++; };
@@ -49,8 +49,8 @@ describe('slot', function() {
     slot.providePendingSlot();
     assert.equal(expectedCount, count);
 
-    // Cannot provide not associated slot.
-    slot.associateWithParticle(util.initParticleSpec('particle'));
+    // Cannot provide unassigned slot.
+    slot.assignParticle(util.initParticleSpec('particle'));
     assert.throws(() => { slot.providePendingSlot(); });
     assert.equal(expectedCount, count);
   });


### PR DESCRIPTION
https://github.com/PolymerLabs/arcs/issues/86

PS: it repeats some of the SlotManager changes in the other pull request. 
PPS: next step would be to rename SlotManager to SlotComposer (if that's ok with you)

