### PR TITLE
Eliminate excess renders by fixing data model to be more conservative:

### DIFF
--- a/particles/Chooser/Chooser.js
+++ b/particles/Chooser/Chooser.js
@@ -25,7 +25,7 @@ defineParticle(({particle: {Particle, ViewChanges, StateChanges, SlotChanges}}) 
         var result = [...difference(inputList, outputList)];
         this.emit('values', result);
       });
-      this.when([new StateChanges('values'), new SlotChanges()], async e => {
+      this.when([new StateChanges('values')], async e => {
         let slotName = 'action';
         let model = this._buildViewModel(views);
         if (!model) {

--- a/runtime/particle.js
+++ b/runtime/particle.js
@@ -212,7 +212,13 @@ class ViewChanges {
     this.type = type;
   }
   register(particle, f) {
-    particle.on(this.views, this.names, this.type, f);
+    var modelCount = 0;
+    var afterAllModels = () => { if (++modelCount == this.names.length) { f(); } };
+
+    for (var name of this.names) {
+      var view = this.views.get(name);
+      view.synchronize(this.type, afterAllModels, f, particle)
+    }
   }
 }
 

--- a/runtime/test/demo-flow-test.js
+++ b/runtime/test/demo-flow-test.js
@@ -86,7 +86,6 @@ describe('demo flow', function() {
                  .expectRender("ListView")
                  .expectRender("Chooser")
                  .expectRender("Chooser")
-                 .expectRender("Chooser")
                  .thenSend("action", "chooseValue", {key: "1"})
                  .expectRender("ListView")
                  .expectRender("Chooser");
@@ -105,9 +104,6 @@ describe('demo flow', function() {
       slotManager.expectGetSlot("ListView", "root")
                  .expectGetSlot("Chooser", "action")
                  .expectRender("ListView")
-                 .expectRender("Chooser")
-                 .expectRender("Chooser")
-                 .expectRender("Chooser")
                  .expectRender("Chooser")
 
       var arcMap = new Map();

--- a/runtime/view.js
+++ b/runtime/view.js
@@ -87,10 +87,13 @@ class View extends ViewBase {
 
   store(entity) {
     var trace = tracing.start({cat: "view", name: "View::store", args: {name: this.name}});
+    var entityWasPresent = this._items.has(entity.id);
+
     this._items.set(entity.id, entity);
     this._version++;
     trace.update({ entity });
-    this._fire('change', {add: [entity], version: this._version});
+    if (!entityWasPresent)
+      this._fire('change', {add: [entity], version: this._version});
     trace.end();
   }
 

--- a/runtime/viewlet.js
+++ b/runtime/viewlet.js
@@ -41,6 +41,10 @@ class Viewlet {
     return this._view.on(kind, callback, target);
   }
 
+  synchronize(kind, modelCallback, callback, target) {
+    return this._view.synchronize(kind, modelCallback, callback, target);
+  }
+
   generateID() {
     return this._view.generateID();
   }
@@ -66,6 +70,10 @@ class Viewlet {
   }
   get name() {
     return this._view.name;
+  }
+
+  get _id() {
+    return this._view._id;
   }
 }
 


### PR DESCRIPTION
 - don't fire events when duplicate entities are stored in views
 - fix when so that it uses synchronize and only reports once when syncing views
(also remove the useless listening to slot changes in Chooser).