### PR TITLE
Resolver to examine rendered vs exposed slots (from particle specs)

### DIFF
--- a/particles/ListView/ListView.ptcl
+++ b/particles/ListView/ListView.ptcl
@@ -11,7 +11,7 @@
 ListView(in [Product] list)
 
 renders: root none-need
-exposes: action(list), preamble
+exposes: action(list), preamble, annotation
 
 Description {
   pattern: Show ${list}

--- a/particles/ShowProducts/ShowProducts.ptcl
+++ b/particles/ShowProducts/ShowProducts.ptcl
@@ -11,7 +11,7 @@
 ShowProducts(in [Product] list)
 
 renders: root none-need
-exposes: action(list), preamble
+exposes: action(list), preamble, annotation
 
 Description {
   pattern: Show ${list}

--- a/particles/VrPot/VrPot.ptcl
+++ b/particles/VrPot/VrPot.ptcl
@@ -11,4 +11,3 @@
 VrPot(in Person person)
 
 renders: root none-need
-exposes: action(person)

--- a/runtime/arc.js
+++ b/runtime/arc.js
@@ -46,6 +46,8 @@ class Arc {
     this._tags = {};
     // Map from each view to a list of tags.
     this._viewTags = new Map();
+
+    this.availableSlotIds = new Set();
   }
 
   static deserialize({serialization, pecFactory, loader, slotComposer, arcMap}) {
@@ -121,8 +123,8 @@ class Arc {
         renderMap: new Map(),
         views: new Map()
       };
-      p.exposeMap.forEach((view, slotid) => arc.exposeMap.set(slotid, view ? view.clone() : view));
-      p.renderMap.forEach((view, slotid) => arc.renderMap.set(slotid, view ? view.clone() : view));
+      p.exposeMap.forEach((view, slotid) => cloneParticleSpec.exposeMap.set(slotid, view ? view.clone() : view));
+      p.renderMap.forEach((view, slotid) => cloneParticleSpec.renderMap.set(slotid, view ? view.clone() : view));
       p.views.forEach(v => cloneParticleSpec.views.set(v.name, v.clone()));
       arc.particles.push(cloneParticleSpec);
     });

--- a/runtime/recipe.js
+++ b/runtime/recipe.js
@@ -75,7 +75,12 @@ class Recipe {
 
   instantiate(arc) {
     this.beforeInstantiation.forEach(f => f(arc));
-    this.components.forEach(component => component.instantiate(arc));
+    this.components.forEach(component => {
+      component.instantiate(arc);
+      let particleSpec = arc.particleSpec(component.particleName);
+      particleSpec.exposes.forEach(e => arc.availableSlotIds.add(e.name));
+      particleSpec.renders.forEach(e => arc.availableSlotIds.delete(e.name.name));
+    });
   }
 }
 


### PR DESCRIPTION
The change can be seen in vr-demo, where the "render box" recipe is not suggested until either "render sphere" or "render pot" are chosen, because only then there is a slot for the box.

This is a very naive implementation, just a sanity check that recipe has a potential ability to render.
Next step would be to make the logic more sophisticated and in parallel to migrate it to the new strategies API.