### PR TITLE
Clean up how we deal with recipe actions.

### DIFF
--- a/runtime/recipe/constraint-walker.js
+++ b/runtime/recipe/constraint-walker.js
@@ -5,16 +5,10 @@
 // subject to an additional IP rights grant found at
 // http://polymer.github.io/PATENTS.txt
 
-var Strategizer = require('../../strategizer/strategizer.js').Strategizer;
 var Recipe = require('./recipe.js');
-var Walker = require('./walker.js');
+var WalkerBase = require('./walker-base.js');
 
-class ConstraintWalker extends Strategizer.Walker {
-  constructor(tactic) {
-    super();
-    this.tactic = tactic;
-  }
-
+class ConstraintWalker extends WalkerBase {
   onResult(result) {
     super.onResult(result);
     var recipe = result.result;
@@ -28,46 +22,7 @@ class ConstraintWalker extends Strategizer.Walker {
       }
     });
 
-    var newRecipes = [];
-    if (updateList.length) {
-      switch (this.tactic) {
-        case Walker.ApplyAll:
-          var cloneMap = new Map();
-          var newRecipe = recipe.clone(cloneMap);
-          updateList.forEach(({continuation, context}) => {
-            if (typeof continuation == 'function')
-              continuation = [continuation];
-            continuation.forEach(f => {
-              f(newRecipe, cloneMap.get(context));
-            });
-          });
-          newRecipes.push(newRecipe);
-          break;
-        case Walker.ApplyEach:
-          updateList.forEach(({continuation, context}) => {
-            var cloneMap = new Map();
-            var newRecipe = recipe.clone(cloneMap);
-            if (typeof continuation == 'function')
-              continuation = [continuation];
-            continuation.forEach(f => {
-              f(newRecipe, cloneMap.get(context));
-            });
-            newRecipes.push(newRecipe);
-          });
-          break;
-        default:
-          throw `${this.tactic} not supported`;
-      }
-    }
-
-    for (var newRecipe of newRecipes) {
-      var result = this.createDescendant(newRecipe);
-    }
-  }
-
-  createDescendant(recipe) {
-    recipe.normalize();
-    super.createDescendant(recipe, recipe.digest());
+    this._runUpdateList(recipe, updateList);
   }
 }
 

--- a/runtime/recipe/walker-base.js
+++ b/runtime/recipe/walker-base.js
@@ -1,0 +1,90 @@
+// Copyright (c) 2017 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+var Strategizer = require('../../strategizer/strategizer.js').Strategizer;
+var Recipe = require('./recipe.js');
+var assert = require('assert');
+
+class WalkerBase extends Strategizer.Walker {
+  constructor(tactic) {
+    super();
+    assert(tactic);
+    this.tactic = tactic;
+  }
+
+  _runUpdateList(recipe, updateList) {
+    var newRecipes = [];
+    if (updateList.length) {
+      switch (this.tactic) {
+        case WalkerBase.Permuted:
+          var permutations = [[]];
+          updateList.forEach(({continuation, context}) => {
+            var newResults = [];
+            if (typeof continuation == 'function')
+              continuation = [continuation];
+            continuation.forEach(f => {
+              permutations.forEach(p => {
+                var newP = p.slice();
+                newP.push({f, context});
+                newResults.push(newP);
+              });
+            });
+            permutations = newResults;
+          });
+
+          for (var permutation of permutations) {
+            var cloneMap = new Map();
+            var newRecipe = recipe.clone(cloneMap);
+            var score = 0;
+            permutation.forEach(({f, context}) => score += f(newRecipe, cloneMap.get(context)));
+            newRecipes.push({recipe: newRecipe, score});
+          }
+          break;
+        case WalkerBase.Independent:
+          updateList.forEach(({continuation, context}) => {
+            if (typeof continuation == 'function')
+              continuation = [continuation];
+            continuation.forEach(f => {
+              var cloneMap = new Map();
+              var newRecipe = recipe.clone(cloneMap);
+              var score = f(newRecipe, cloneMap.get(context));
+              newRecipes.push({recipe: newRecipe, score});
+            });
+          });
+          break;
+        default:
+          throw `${this.tactic} not supported`;
+      }
+    }
+
+    // commit phase - output results.
+
+    for (var newRecipe of newRecipes) {
+      var result = this.createDescendant(newRecipe.recipe, newRecipe.score);
+    }
+  }
+
+  createDescendant(recipe, score) {
+    recipe.normalize();
+    super.createDescendant(recipe, score, recipe.digest());
+  }
+
+  isEmptyResult(result) {
+    if (!result)
+      return true;
+
+    if (result.constructor == Array && result.length <= 0)
+      return true;
+
+    return false;
+  }
+}
+
+WalkerBase.Permuted = "permuted";
+WalkerBase.Independent = "independent";
+
+module.exports = WalkerBase;

--- a/runtime/recipe/walker.js
+++ b/runtime/recipe/walker.js
@@ -5,15 +5,10 @@
 // subject to an additional IP rights grant found at
 // http://polymer.github.io/PATENTS.txt
 
-var Strategizer = require('../../strategizer/strategizer.js').Strategizer;
 var Recipe = require('./recipe.js');
+let WalkerBase = require('./walker-base.js');
 
-class Walker extends Strategizer.Walker {
-  constructor(tactic) {
-    super();
-    this.tactic = tactic;
-  }
-
+class Walker extends WalkerBase {
   onResult(result) {
     super.onResult(result);
     var recipe = result.result;
@@ -59,64 +54,11 @@ class Walker extends Strategizer.Walker {
       }
     }
 
-    // application phase - apply updates and track results
-
-    var newRecipes = [];
-    if (updateList.length) {
-      switch (this.tactic) {
-        case Walker.ApplyAll:
-          var cloneMap = new Map();
-          var newRecipe = recipe.clone(cloneMap);
-          updateList.forEach(({continuation, context}) => {
-            if (typeof continuation == 'function')
-              continuation = [continuation];
-            continuation.forEach(f => {
-              f(newRecipe, cloneMap.get(context));
-            });
-          });
-          newRecipes.push(newRecipe);
-          break;
-        case Walker.ApplyEach:
-          updateList.forEach(({continuation, context}) => {
-            var cloneMap = new Map();
-            var newRecipe = recipe.clone(cloneMap);
-            if (typeof continuation == 'function')
-              continuation = [continuation];
-            continuation.forEach(f => {
-              f(newRecipe, cloneMap.get(context));
-            });
-            newRecipes.push(newRecipe);
-          });
-          break;
-        default:
-          throw `${this.tactic} not supported`;
-      }
-    }
-
-    // commit phase - output results.
-
-    for (var newRecipe of newRecipes) {
-      var result = this.createDescendant(newRecipe);
-    }
-  }
-
-  createDescendant(recipe) {
-    recipe.normalize();
-    super.createDescendant(recipe, recipe.digest());
-  }
-
-  isEmptyResult(result) {
-    if (!result)
-      return true;
-
-    if (result.constructor == Array && result.length <= 0)
-      return true;
-
-    return false;
+    this._runUpdateList(recipe, updateList);
   }
 }
 
-Walker.ApplyAll = "apply all";
-Walker.ApplyEach = "apply each";
+Walker.Permuted = WalkerBase.Permuted;
+Walker.Independent = WalkerBase.Independent;
 
 module.exports = Walker;

--- a/runtime/strategies/convert-constraints-to-connections.js
+++ b/runtime/strategies/convert-constraints-to-connections.js
@@ -28,7 +28,7 @@ class ConvertConstraintsToConnections extends Strategy {
 
         var resolved = RecipeUtil.find(recipe, connectedShape);
         if (resolved.length > 0) {
-          return (recipe, constraint) => recipe.removeConstraint(constraint);
+          return (recipe, constraint) => {recipe.removeConstraint(constraint); return 4};
         }
 
         // existing particles, joined on the left side
@@ -51,6 +51,7 @@ class ConvertConstraintsToConnections extends Strategy {
             resolveMap = recipe.updateToClone(resolveMap);
             resolveMap[constraint.toParticle].ensureConnectionName(constraint.toConnection).connectToView(resolveMap['a']);
             recipe.removeConstraint(constraint);
+            return 3;
           }
         });
         var rightResolved = RecipeUtil.find(recipe, rightShape);
@@ -59,6 +60,7 @@ class ConvertConstraintsToConnections extends Strategy {
             resolveMap = recipe.updateToClone(resolveMap);
             resolveMap[constraint.fromParticle].ensureConnectionName(constraint.fromConnection).connectToView(resolveMap['a']);
             recipe.removeConstraint(constraint);
+            return 3;
           };
         });
         var actions = leftActions.concat(rightActions);
@@ -75,6 +77,7 @@ class ConvertConstraintsToConnections extends Strategy {
             resolveMap[constraint.fromParticle].ensureConnectionName(constraint.fromConnection).connectToView(view);
             resolveMap[constraint.toParticle].ensureConnectionName(constraint.toConnection).connectToView(view);
             recipe.removeConstraint(constraint);
+            return 2;
           };
         });
         if (actions.length > 0)
@@ -92,6 +95,7 @@ class ConvertConstraintsToConnections extends Strategy {
             resolveMap[constraint.fromParticle].ensureConnectionName(constraint.fromConnection).connectToView(view);
             recipe.newParticle(constraint.toParticle).addConnectionName(constraint.toConnection).connectToView(view);
             recipe.removeConstraint(constraint);
+            return 1;
           }
         });
         var rightActions = rightResolved.map(resolveMap => {
@@ -101,6 +105,7 @@ class ConvertConstraintsToConnections extends Strategy {
             recipe.newParticle(constraint.fromParticle).addConnectionName(constraint.fromConnection).connectToView(view);
             resolveMap[constraint.toParticle].ensureConnectionName(constraint.toConnection).connectToView(view);
             recipe.removeConstraint(constraint);
+            return 1;
           }
         });
 
@@ -118,9 +123,10 @@ class ConvertConstraintsToConnections extends Strategy {
               },
             recipe);
           recipe.removeConstraint(constraint);
+          return 0;
         }
       }
-    }(RecipeWalker.ApplyEach), this);
+    }(RecipeWalker.Independent), this);
 
     return { results, generate: null };
   }

--- a/strategizer/strategizer.js
+++ b/strategizer/strategizer.js
@@ -198,11 +198,11 @@ class Walker {
     this.currentResult = result;
   }
 
-  createDescendant(result, hash) {
+  createDescendant(result, score, hash) {
     assert(this.currentResult, "no current result");
     assert(this.currentStrategy, "no current strategy");
-    var score = (this.score || 0) + (this.currentResult.score || 0);
-
+    if (this.currentResult.score)
+      score += this.currentResult.score;
     this.descendants.push({result, score, derivation: [{parent: this.currentResult, strategy: this.currentStrategy}], hash });
   }
 


### PR DESCRIPTION
This should be more consistent in output. Each Walker function returns one or more functions, which are always assumed to be alternative actions that can be taken on the current context.

If the tactic is "Permute" then the lists returned from each function will be permuted together - this generates a large number of outputs that covers the output space.

If the tactic is "Individual" then each alternative is run independently on a clone of the recipe. This produces a much smaller set of outputs that have only been modified by a single step.