### PR TITLE
Type validation

### DIFF
--- a/runtime/planner.js
+++ b/runtime/planner.js
@@ -79,12 +79,12 @@ class AssignViewsByTagAndType extends Strategy {
           let view = viewConnection.view;
           if (view.isResolved())
             return;
-          if (view.type == undefined && viewConnection.type == undefined) {
+          if (view.type == undefined) { //} && viewConnection.type == undefined) {
             return;
           }
           if (view.create)
             return;
-          return arc.findViews(view.type || viewConnection.type, view.tags).map(newView =>
+          return arc.findViews(view.type /* || viewConnection.type */, view.tags).map(newView =>
             ((recipe, viewConnection) => {
               // TODO: verify that same Arc's view is not assigned to different connections' views.
               if (newView.type == undefined || viewConnection.type == undefined)

--- a/runtime/planner.js
+++ b/runtime/planner.js
@@ -89,7 +89,7 @@ class AssignViewsByTagAndType extends Strategy {
               // TODO: verify that same Arc's view is not assigned to different connections' views.
               if (newView.type == undefined || viewConnection.type == undefined)
                 viewConnection.connectToView(newView);
-              viewConnection.view.id = newView.id;
+              viewConnection.view.mapToView(newView);
               return 0;
             }));
         }

--- a/runtime/recipe/particle.js
+++ b/runtime/recipe/particle.js
@@ -135,6 +135,10 @@ class Particle {
     return this._connections[name];
   }
 
+  allConnections() {
+    return Object.values(this._connections).concat(this._unnamedConnections);
+  }
+
   ensureConnectionName(name) {
     return this._connections[name] || this.addConnectionName(name);
   }

--- a/runtime/recipe/type-checker.js
+++ b/runtime/recipe/type-checker.js
@@ -5,25 +5,76 @@
 // subject to an additional IP rights grant found at
 // http://polymer.github.io/PATENTS.txt
 
+var Type = require('../type.js');
+
 class TypeChecker {
 
+  // list: [{type, direction, connection}]
   static processTypeList(list) {
+    if (list.length == 0) {
+      return {type: {type: undefined}, valid: true};
+    }
     var baseType = list[0];
     var variableResolutions = [];
     for (var i = 1; i < list.length; i++) {
-      var {baseType, valid} = TypeChecker.compareTypes(baseType, list[i], variableResolutions);
-      if (!valid)
-        return {valid};
+      let result = TypeChecker.compareTypes(baseType, list[i], variableResolutions);
+      baseType = result.type;
+      if (!result.valid)
+        return {valid: false};
     }
     TypeChecker.applyVariableResolutions(variableResolutions);
-    return {type: baseType, valid};
+    return {type: baseType, valid: true};
   }
 
+  static _applyResolutionsToType(type, resolutions) {
+    console.log('apply resolutions to type', type, resolutions);
+    return type;
+  }
+
+  static _coerceTypes(left, right) {
+    var leftType = left.type;
+    var rightType = right.type;
+    var resolutions = [];
+
+    while (leftType.isView && rightType.isView) {
+      leftType = leftType.primitiveType();
+      rightType = rightType.primitiveType();
+    }
+    // TODO: direction?
+    if (leftType.isVariable) {
+      resolutions.push({variable: leftType, becomes: rightType, context: left.connection});
+      var type = right;
+    } else if (rightType.isVariable) {
+      resolutions.push({variable: rightType, becomes: leftType, context: right.connection});
+      var type = left;
+    } else {
+      debugger;
+      return null;
+    }
+    return {type, resolutions};
+  }
+
+  // left, right: {type, direction, connection}
   static compareTypes(left, right, resolutions) {
+    left = TypeChecker._applyResolutionsToType(left, resolutions);
+    right = TypeChecker._applyResolutionsToType(right, resolutions);
 
+    if (left.type.equals(right.type))
+      return {type: left, valid: true};
+
+    // TODO: subset/superset relations between types.
+
+    let result  = TypeChecker._coerceTypes(left, right);
+    if (result == null)
+      return {valid: false};
+    // TODO: direction?
+    result.resolutions.forEach(resolution => resolutions.push(resolution));
+    return {type: result.type, valid: true}
   }
 
-  static applyVariableResolutions(resolutions);
+  static applyVariableResolutions(resolutions) {
+    console.log('apply variable resolutions', resolutions)
+  }
 }
 
 module.exports = TypeChecker;

--- a/runtime/recipe/type-checker.js
+++ b/runtime/recipe/type-checker.js
@@ -6,6 +6,7 @@
 // http://polymer.github.io/PATENTS.txt
 
 var Type = require('../type.js');
+var assert = require('assert');
 
 class TypeChecker {
 
@@ -27,7 +28,8 @@ class TypeChecker {
   }
 
   static _applyResolutionsToType(type, resolutions) {
-    console.log('apply resolutions to type', type, resolutions);
+    if (resolutions.length > 0)
+      console.log('apply resolutions to type', type, resolutions);
     return type;
   }
 
@@ -72,8 +74,24 @@ class TypeChecker {
     return {type: result.type, valid: true}
   }
 
+  static substitute(type, variable, value) {
+    if (type.equals(variable))
+      return value;
+    if (type.isView)
+      return TypeChecker.substitute(type.primitiveType(), variable, value).viewOf();
+    return type;
+  }
+
   static applyVariableResolutions(resolutions) {
-    console.log('apply variable resolutions', resolutions)
+    resolutions.forEach(resolution => {
+      var particle = resolution.context.particle;
+      particle.allConnections().forEach(connection => {
+        // TODO: is this actually always true?
+        assert(connection.type == connection.rawType);
+        connection._type = TypeChecker.substitute(connection.rawType, resolution.variable, resolution.becomes);
+        console.log(particle.name, connection.name, connection.rawType, '->', connection._type);
+      });
+    });
   }
 }
 

--- a/runtime/recipe/type-checker.js
+++ b/runtime/recipe/type-checker.js
@@ -1,0 +1,29 @@
+// Copyright (c) 2017 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+class TypeChecker {
+
+  static processTypeList(list) {
+    var baseType = list[0];
+    var variableResolutions = [];
+    for (var i = 1; i < list.length; i++) {
+      var {baseType, valid} = TypeChecker.compareTypes(baseType, list[i], variableResolutions);
+      if (!valid)
+        return {valid};
+    }
+    TypeChecker.applyVariableResolutions(variableResolutions);
+    return {type: baseType, valid};
+  }
+
+  static compareTypes(left, right, resolutions) {
+
+  }
+
+  static applyVariableResolutions(resolutions);
+}
+
+module.exports = TypeChecker;

--- a/runtime/recipe/view-connection.js
+++ b/runtime/recipe/view-connection.js
@@ -16,6 +16,7 @@ class ViewConnection {
     this._name = name;
     this._tags = [];
     this._type = undefined;
+    this._rawType = undefined;
     this._direction = undefined;
     this._particle = particle;
     this._view = undefined;
@@ -28,6 +29,7 @@ class ViewConnection {
     var viewConnection = new ViewConnection(this._name, particle);  // Note: This is the original, not the cloned particle, is it a right?
     viewConnection._tags = [...this._tags];
     viewConnection._type = this._type;
+    viewConnection._rawType = this._rawType;
     viewConnection._direction = this._direction;
     if (this._view != undefined) {
       viewConnection._view = cloneMap.get(this._view);
@@ -58,14 +60,22 @@ class ViewConnection {
   get recipe() { return this._recipe; }
   get name() { return this._name; } // Parameter name?
   get tags() { return this._tags; }
-  get type() { return this._type; }
+  get type() {
+    if (this._type)
+      return this._type;
+    return this._rawType;
+  }
+  get rawType() {
+    return this._rawType;
+  }
   get direction() { return this._direction; } // in/out
   get view() { return this._view; } // View?
   get particle() { return this._particle; } // never null
 
   set tags(tags) { this._tags = tags; }
   set type(type) {
-    this._type = type;
+    this._rawType = type;
+    this._type = undefined;
     this._resetViewType();
   }
 
@@ -83,7 +93,7 @@ class ViewConnection {
       let connectionSpec = this.particle.spec.connectionMap.get(this.name);
       if (connectionSpec) {
         // TODO: this shouldn't be a direct comparison
-        if (this.type != connectionSpec.type) {
+        if (this.rawType != connectionSpec.type) {
           return false;
         }
         if (this.direction != connectionSpec.direction) {

--- a/runtime/recipe/view-connection.js
+++ b/runtime/recipe/view-connection.js
@@ -64,8 +64,15 @@ class ViewConnection {
   get particle() { return this._particle; } // never null
 
   set tags(tags) { this._tags = tags; }
-  set type(type) { this._type = type;}
-  set direction(direction) { this._direction = direction; }
+  set type(type) {
+    this._type = type;
+    this._resetViewType();
+  }
+
+  set direction(direction) {
+    this._direction = direction;
+    this._resetViewType();
+  }
 
   _isValid() {
     // TODO: 'create' is not a valid direction
@@ -94,17 +101,15 @@ class ViewConnection {
         && this.view;
   }
 
+  _resetViewType() {
+    if (this._view)
+      this._view._type = undefined;
+  }
+
   connectToView(view) {
     assert(view.recipe == this.recipe);
-    if (this._type !== undefined) {
-      if (view._type == undefined)
-        view._type = this._type;
-      else
-        assert(this_type == view._type);
-    } else if (view._type !== undefined) {
-        this._type = view._type;
-    }
     this._view = view;
+    this._resetViewType();
     this._view.connections.push(this);
   }
 

--- a/runtime/recipe/view.js
+++ b/runtime/recipe/view.js
@@ -81,8 +81,10 @@ class View {
       if (connection.type)
         typeSet.push({type: connection.type, direction: connection.direction, connection});
     }
-    var {type, valid} TypeChecker.processTypeList(typeSet);
-    this._type = type;
+    var {type, valid} = TypeChecker.processTypeList(typeSet);
+    if (valid) {
+      this._type = type.type;
+    }
     return valid;
   }
 


### PR DESCRIPTION
Add a type checker than propagates type information back into recipe views.
View connections also have information propagated into them - this is to deal with type variables being resolved to concrete types. For this reason, there's now a 'rawType' and a 'type' on every view connection.