### PR TITLE
Prepare arc for instantiating new-style recipes.

### DIFF
--- a/runtime/api-channel.js
+++ b/runtime/api-channel.js
@@ -193,7 +193,7 @@ class PECOuterPort extends APIPort {
       {particleDefinition: this.Direct, particleFunction: this.Stringify});
     this.registerRedundantInitializer("DefineView", {viewType: this.Direct, name: this.Direct})
     this.registerInitializer("InstantiateParticle",
-      {particleName: this.Direct, views: this.Map(this.Direct, this.Mapped)});
+      {spec: this.Direct, views: this.Map(this.Direct, this.Mapped)});
 
     this.registerCall("UIEvent", {particle: this.Mapped, event: this.Direct});
     this.registerCall("ViewCallback", {callback: this.Direct, data: this.Direct});
@@ -223,7 +223,7 @@ class PECInnerPort extends APIPort {
       {particleDefinition: this.Direct, particleFunction: this.Direct});
     this.registerInitializerHandler("DefineView", {viewType: this.Direct, name: this.Direct});
     this.registerInitializerHandler("InstantiateParticle",
-      {particleName: this.Direct, views: this.Map(this.Direct, this.Mapped)});
+      {spec: this.Direct, views: this.Map(this.Direct, this.Mapped)});
 
     this.registerHandler("UIEvent", {particle: this.Mapped, event: this.Direct});
     this.registerHandler("ViewCallback", {callback: this.LocalMapped, data: this.Direct});

--- a/runtime/description-generator.js
+++ b/runtime/description-generator.js
@@ -35,9 +35,10 @@ class DescriptionGenerator {
       return description.replace(/\([a-zA-Z:, ]*\)/ig, '');
   }
   setViewDescriptions(arc) {
+    // TODO: This should iterate arc.particles instead.
     arc.particleViewMaps.forEach((value, key) => {
       value.views.forEach((view, connectionName) => {
-        let description = this.getViewShortDescription(value.clazz.name, connectionName);
+        let description = this.getViewShortDescription(value.spec.name, connectionName);
         if (description)
           view.description = description;
       });

--- a/runtime/dom-slot.js
+++ b/runtime/dom-slot.js
@@ -66,7 +66,7 @@ class DomSlot extends Slot {
       this.dom.innerHTML = content;
     } else {
       // content is multiplexed
-      let templateName = `${this.particleSpec.particle.name}${content.name || 'main'}`;
+      let templateName = `${this.particleSpec.spec.name}${content.name || 'main'}`;
       if (content.template) {
         templates[templateName] = Object.assign(document.createElement('template'), {
           innerHTML: content.template

--- a/runtime/inner-PEC.js
+++ b/runtime/inner-PEC.js
@@ -15,6 +15,7 @@ const define = require('./particle.js').define;
 const assert = require('assert');
 const typeLiteral = require('./type-literal.js');
 const PECInnerPort = require('./api-channel.js').PECInnerPort;
+const ParticleSpec = require('./particle-spec.js');
 
 class RemoteView {
   constructor(id, type, port, pec, name, version) {
@@ -88,7 +89,7 @@ class InnerPEC {
     };
 
     this._apiPort.onInstantiateParticle =
-      ({particleName, views}) => this._instantiateParticle(particleName, views);
+      ({spec, views}) => this._instantiateParticle(spec, views);
 
     this._apiPort.onViewCallback = ({callback, data}) => callback(data);
 
@@ -104,8 +105,10 @@ class InnerPEC {
     return `${this._idBase}:${this._nextLocalID++}`;
   }
 
-  _instantiateParticle(name, views) {
-    let clazz = this._loader.loadParticle(name);
+  _instantiateParticle(spec, views) {
+    spec = new ParticleSpec(spec);
+    let name = spec.name;
+    let clazz = this._loader.loadParticleClass(spec);
     let particle = new clazz();
     this._particles.push(particle);
 

--- a/runtime/loader.js
+++ b/runtime/loader.js
@@ -67,17 +67,18 @@ class Loader {
     return new ParticleSpec(parser.parse(data));
   }
 
-  // TODO: onlyRegisteredScript is a hack for inline particles. remove it.
-  loadParticle(name, onlyRegisteredScript) {
-    let particleClass = this._particlesByName[name];
+  loadParticleClass(spec) {
+    let particleClass = this._particlesByName[spec.name];
     if (particleClass) {
       return particleClass;
     }
 
-    let clazz = onlyRegisteredScript ? {name} : this.requireParticle(name);
-    clazz.spec = this.loadParticleSpec(name);
-    this._particlesByName[name] = clazz;
+    let clazz = this.requireParticle(spec.name);
+    assert(spec.resolve, JSON.stringify(spec));
+    clazz.spec = spec;
+    this._particlesByName[spec.name] = clazz;
     return clazz;
+
   }
 
   requireParticle(name) {

--- a/runtime/outer-PEC.js
+++ b/runtime/outer-PEC.js
@@ -92,32 +92,33 @@ class OuterPEC extends PEC {
     this._apiPort.UIEvent({particle, event})
   }
 
-  instantiate(particle, views, lastSeenVersion) {
+  instantiate(spec, views, lastSeenVersion) {
     views.forEach(view => {
       var version = lastSeenVersion.get(view.id) || 0;
       this._apiPort.DefineView(view, { viewType: view.type.toLiteral(), name: view.name,
                                        version });
     });
 
-    if (particle._isInline) {
+    // TODO: Can we just always define the particle and map a handle for use in later
+    //       calls to InstantiateParticle?
+    if (spec._model._isInline) {
       this._apiPort.DefineParticle({
-        particleDefinition: particle._inlineDefinition,
-        particleFunction: particle._inlineUpdateFunction
+        particleDefinition: spec._model._inlineDefinition,
+        particleFunction: spec._model._inlineUpdateFunction
       });
     }
 
     var renderMap = new Map();
-    particle.spec.renders.forEach(
+    spec.renders.forEach(
       render => renderMap.set(render.name.name, views.get(render.name.view)));
 
     var exposeMap = new Map();
-    particle.spec.exposes.forEach(
+    spec.exposes.forEach(
       expose => exposeMap.set(expose.name, views.get(expose.view)));
-    
-    var particleSpec = {particle, views, renderMap, exposeMap };
 
-    this._apiPort.InstantiateParticle(particleSpec, { particleName: particle.name, views });
-
+    // TODO: rename this concept to something like instantiatedParticle, handle or registration.
+    var particleSpec = {spec, views, renderMap, exposeMap};
+    this._apiPort.InstantiateParticle(particleSpec, {spec: spec._model, views});
     return particleSpec;
   }
 

--- a/runtime/particle-spec.js
+++ b/runtime/particle-spec.js
@@ -37,23 +37,23 @@ class ConnectionSpec {
 }
 
 class ParticleSpec {
-  constructor(rawData) {
-    this.rawData = rawData;
-    this.name = rawData.name;
+  constructor(model) {
+    this._model = model;
+    this.name = model.name;
     var typeVarMap = new Map();
-    this.connections = this.rawData.args.map(a => new ConnectionSpec(a, typeVarMap));
+    this.connections = model.args.map(a => new ConnectionSpec(a, typeVarMap));
     this.connectionMap = new Map();
     this.connections.forEach(a => this.connectionMap.set(a.name, a));
     this.inputs = this.connections.filter(a => a.isInput);
     this.outputs = this.connections.filter(a => a.isOutput);
-    this.exposes = rawData.exposes;
-    this.renders = rawData.renders;
-    this.transient = rawData.transient;
-    this.description = rawData.description;
+    this.exposes = model.exposes;
+    this.renders = model.renders;
+    this.transient = model.transient;
+    this.description = model.description;
   }
 
   resolve() {
-    let result = new ParticleSpec(this.rawData);
+    let result = new ParticleSpec(this._model);
     // FIXME: do we need this now?
     return result;
   }

--- a/runtime/particle.js
+++ b/runtime/particle.js
@@ -51,9 +51,10 @@ function define(def, update) {
   Object.defineProperty(clazz, 'name', {
     value: spec.name,
   });
-  clazz._isInline = true;
-  clazz._inlineDefinition = def;
-  clazz._inlineUpdateFunction = update;
+  // TODO: Super hacks.
+  clazz.spec._model._isInline = true;
+  clazz.spec._model._inlineDefinition = def;
+  clazz.spec._model._inlineUpdateFunction = String(update);
   return clazz;
 }
 

--- a/runtime/planner.js
+++ b/runtime/planner.js
@@ -52,10 +52,10 @@ class ResolveParticleByName extends Strategy {
     var results = Recipe.over(strategizer.generated, new class extends RecipeWalker {
       onParticle(recipe, particle) {
         if (particle.spec == undefined) {
-          var impl = loader.loadParticle(particle.name, true);
-          if (impl == undefined)
+          var spec = loader.loadParticleSpec(particle.name, true);
+          if (spec == undefined)
             return;
-          return (recipe, particle) => {particle.spec = impl.spec; return 1};
+          return (recipe, particle) => {particle.spec = spec; return 1};
         }
       }
     }(RecipeWalker.Permuted), this);

--- a/runtime/relevance.js
+++ b/runtime/relevance.js
@@ -48,7 +48,7 @@ class Relevance {
 
   calcParticleRelevance(particleName) {
     for (let key of this.relevanceMap.keys()) {
-      if (key.particle.name == particleName)
+      if (key.spec.name == particleName)
         return Relevance.particleRelevance(this.relevanceMap.get(key));
     }
     return -1;

--- a/runtime/slot-composer.js
+++ b/runtime/slot-composer.js
@@ -38,7 +38,7 @@ class SlotComposer {
   }
   // TODO(sjmiles): this is a _request_ for a slot, it's mapped to `GetSlot` message
   registerSlot(particleSpec, slotid) {
-    log(`registerSlot("${particleSpec.particle.name}", "${slotid}")`);
+    log(`registerSlot("${particleSpec.spec.name}", "${slotid}")`);
     return new Promise((resolve, reject) => {
       try {
         let slot = this._getOrCreateSlot(slotid);

--- a/runtime/slot.js
+++ b/runtime/slot.js
@@ -21,11 +21,11 @@ class Slot {
     // A map of pending slot requests, mapping {resolve, reject} tuple by requesting particle name.
     this._pendingRequests = new Map();
   }
-  get slotid() { 
-    return this._slotid; 
+  get slotid() {
+    return this._slotid;
   }
-  get particleSpec() { 
-    return this._particleSpec; 
+  get particleSpec() {
+    return this._particleSpec;
   }
   associateWithParticle(particleSpec) {
     assert(!this._particleSpec, "Particle spec already set, cannot associate slot");
@@ -44,14 +44,14 @@ class Slot {
     return !!this._particleSpec;
   }
   addPendingRequest(particleSpec, resolve, reject) {
-    if (!this._pendingRequests.has(particleSpec.particle.name)) {
-      this._pendingRequests.set(particleSpec.particle.name, {resolve, reject});
+    if (!this._pendingRequests.has(particleSpec.spec.name)) {
+      this._pendingRequests.set(particleSpec.spec.name, {resolve, reject});
     }
   }
   removePendingRequest(particleSpec) {
-    let particleName = particleSpec.particle.name;
+    let particleName = particleSpec.spec.name;
     assert(this._pendingRequests.has(particleName),
-      `Cannot remove pending request from particle ${particleSpec.particle.name} for slot ${this.slotid}`);
+      `Cannot remove pending request from particle ${particleSpec.spec.name} for slot ${this.slotid}`);
     this._pendingRequests.get(particleName).reject();
     this._pendingRequests.delete(particleName);
   }

--- a/runtime/test/manifest-test.js
+++ b/runtime/test/manifest-test.js
@@ -258,25 +258,6 @@ describe('manifest', function() {
     let manifest = await Manifest.load('a', loader, registry);
     assert.equal(manifest.schemas.Bar.normative.value, 'Text');
   });
-  it('relies on the loader to combine paths', async () => {
-    let registry = {};
-    let loader = {
-      loadFile(path) {
-        return {
-          'somewhere/a': `import 'path/b'`,
-          'somewhere/a path/b': `recipe`,
-        }[path];
-      },
-      path(fileName) {
-        return fileName;
-      },
-      join(path, file) {
-        return `${path} ${file}`;
-      },
-    };
-    let manifest = await Manifest.load('somewhere/a', loader, registry);
-    assert(registry['somewhere/a path/b']);
-  });
   it('can parse a manifest containing a recipe with slots', async () => {
     let manifest = await Manifest.parse(`
       recipe SomeRecipe
@@ -315,4 +296,23 @@ describe('manifest', function() {
     assert.equal(recipe.particles[1].consumedSlots[1].viewConnections.length, 0);
     assert.equal(recipe.particles[1].providedSlots.length, 0);
   });
+  it('relies on the loader to combine paths', async () => {
+    let registry = {};
+    let loader = {
+      loadFile(path) {
+        return {
+          'somewhere/a': `import 'path/b'`,
+          'somewhere/a path/b': `recipe`,
+        }[path];
+      },
+      path(fileName) {
+        return fileName;
+      },
+      join(path, file) {
+        return `${path} ${file}`;
+      },
+    };
+    let manifest = await Manifest.load('somewhere/a', loader, registry);
+    assert(registry['somewhere/a path/b']);
+  })
 });

--- a/runtime/test/mock-slot-composer.js
+++ b/runtime/test/mock-slot-composer.js
@@ -55,22 +55,22 @@ class MockSlotComposer {
   }
 
   renderSlot(particleSpec, content) {
-    log(`renderSlot: ${particleSpec.particle.name}`, content && content.template ? 'TEMPLATE' : 'MODEL');
+    log(`renderSlot: ${particleSpec.spec.name}`, content && content.template ? 'TEMPLATE' : 'MODEL');
     var expectation = this.expectQueue.shift();
     assert(expectation, "Got a render but not expecting anything further.");
     assert.equal('render', expectation.type, `expecting a render, not ${expectation.type}`);
-    assert.equal(particleSpec.particle.spec.name, expectation.name,
-        `expecting a render from ${expectation.name}, not ${particleSpec.particle.spec.name}`);
+    assert.equal(particleSpec.spec.name, expectation.name,
+        `expecting a render from ${expectation.name}, not ${particleSpec.spec.name}`);
     this.expectationMet(expectation);
   }
 
   registerSlot(particleSpec, slotId) {
-    log(`registerSlot: ${particleSpec.particle.name}:${slotId}`);
+    log(`registerSlot: ${particleSpec.spec.name}:${slotId}`);
     var expectation = this.expectQueue.shift();
-    assert(expectation, `Got a getSlot '${slotId}' from '${particleSpec.particle.spec.name}' but not expecting anything further`);
+    assert(expectation, `Got a getSlot '${slotId}' from '${particleSpec.spec.name}' but not expecting anything further`);
     assert.equal('getSlot', expectation.type, `expecting a ${expectation.type}, not a getSlot`);
-    assert.equal(particleSpec.particle.spec.name, expectation.name,
-        `expecting a getSlot from ${expectation.name}, not ${particleSpec.particle.spec.name}`);
+    assert.equal(particleSpec.spec.name, expectation.name,
+        `expecting a getSlot from ${expectation.name}, not ${particleSpec.spec.name}`);
     assert.equal(slotId, expectation.slotId,
         `expecting slotId ${expectation.slotId}, not ${slotId}`);
     this.specs.set(slotId, particleSpec);
@@ -81,7 +81,7 @@ class MockSlotComposer {
 
   releaseSlot(particleSpec) {
     // TODO(sjmiles): do something?
-    log(`releaseSlot:`, particleSpec.particle.name);
+    log(`releaseSlot:`, particleSpec.spec.name);
     var expectation = this.expectQueue.shift();
     assert(expectation, `Got a releaseSlot from '${particleSpec.particle.spec.name}' but not expecting anything further`);
     assert.equal('releaseSlot', expectation.type, `expecting a ${expectation.type}, not a releaseSlot`);

--- a/runtime/test/test-util.js
+++ b/runtime/test/test-util.js
@@ -48,10 +48,13 @@ function assertSingletonEmpty(view) {
 }
 
 function initParticleSpec(name) {
-  var particleSpec = JSON.parse(`{"particle":{"name":"${name}"}}`);
-  particleSpec.exposeMap = new Map();
-  particleSpec.renderMap = new Map();
-  return particleSpec;
+  return {
+    spec: {
+      name,
+    },
+    exposeMap: new Map(),
+    renderMap: new Map(),
+  };
 }
 
 exports.assertSingletonHas = assertSingletonHas;


### PR DESCRIPTION
* Arc now deals with particle specifications and not particle classes.
* OuterPec sends the InnerPec a particle specification rather than
having the InnerPec obtain it via a loader.