### PR TITLE
Add a new entity tagged type to contain the associated schema

### DIFF
--- a/runtime/arc.js
+++ b/runtime/arc.js
@@ -195,6 +195,7 @@ class Arc {
     if (type.isView) {
       var v = new view.View(type, this, name, id);
     } else {
+      assert(type.isEntity, `Expected entity type, but... ${JSON.stringify(type.toLiteral())}`);
       var v = new view.Variable(type, this, name, id);
     }
     this.registerView(v);
@@ -217,13 +218,23 @@ class Arc {
     this._viewTags.get(view).add(tag);
   }
 
+  // TODO: Don't use this, we should be testing the schemas for compatiblity
+  //       instead of using just the name.
+  static _viewKey(type) {
+    if (type.isView) {
+      return `list:${type.primitiveType().schema.name}`;
+    } else {
+      assert(type.isEntity);
+      return type.schema.name;
+    }
+  }
+
   registerView(view) {
     let views = this.findViews(view.type);
     if (!views.length) {
-      this._viewsByType.set(JSON.stringify(view.type.toLiteral()), views);
+      this._viewsByType.set(Arc._viewKey(view.type), views);
     }
     views.push(view);
-
     this.addView(view);
   }
 
@@ -233,7 +244,7 @@ class Arc {
 
   findViews(type, options) {
     // TODO: use options (location, labels, etc.) somehow.
-    var views = this._viewsByType.get(JSON.stringify(type.toLiteral())) || [];
+    var views = this._viewsByType.get(Arc._viewKey(type)) || [];
     if (options && options.tag) {
       views = views.filter(view => this.tagsForView(view).has(options.tag));
     }

--- a/runtime/inner-PEC.js
+++ b/runtime/inner-PEC.js
@@ -13,9 +13,9 @@ const Type = require('./type.js');
 const viewlet = require('./viewlet.js');
 const define = require('./particle.js').define;
 const assert = require('assert');
-const typeLiteral = require('./type-literal.js');
 const PECInnerPort = require('./api-channel.js').PECInnerPort;
 const ParticleSpec = require('./particle-spec.js');
+const Schema = require('./schema.js');
 
 class RemoteView {
   constructor(id, type, port, pec, name, version) {
@@ -159,11 +159,14 @@ class InnerPEC {
 
 
     for (var view of viewMap.values()) {
-      var type = view.underlyingView().type.toLiteral();
-      if (typeLiteral.isView(type)) {
-        type = typeLiteral.primitiveType(type);
+      var type = view.underlyingView().type;
+      let schemaModel;
+      if (type.isView) {
+        schemaModel = type.primitiveType().schema;
+      } else {
+        schemaModel = type.schema;
       }
-      view.entityClass = this._loader.loadEntity(type);
+      view.entityClass = new Schema(schemaModel).entityClass();
     }
 
     // the problem with doing this here is that it's only after we return particle below

--- a/runtime/loader.js
+++ b/runtime/loader.js
@@ -38,6 +38,7 @@ class Loader {
     return fs.readFileSync(file, "utf-8");
   }
 
+  // TODO: Remove this once schemas are only loaded from manifests.
   loadSchema(name) {
     let data = this.loadFile(schemaLocationFor(name));
     var parsed = schemaParser.parse(data);
@@ -58,6 +59,7 @@ class Loader {
     this._particlesByName[particleClass.name] = particleClass;
   }
 
+  // TODO: Remove this once particles are only loaded from manifests.
   loadParticleSpec(name) {
     if (this._particlesByName[name])
       return this._particlesByName[name].spec;

--- a/runtime/loader.js
+++ b/runtime/loader.js
@@ -42,7 +42,7 @@ class Loader {
     let data = this.loadFile(schemaLocationFor(name));
     var parsed = schemaParser.parse(data);
     if (parsed.parent) {
-      parsed.parent = this.loadSchema(parsed.parent);
+      parsed.parent = this.loadSchema(parsed.parent).toLiteral();
     }
     return new Schema(parsed);
   }
@@ -62,7 +62,11 @@ class Loader {
     if (this._particlesByName[name])
       return this._particlesByName[name].spec;
     let data = this.loadFile(this.particleLocationFor(name, 'ptcl'));
-    return new ParticleSpec(parser.parse(data));
+    let model = parser.parse(data);
+    let resolveSchema = name => {
+      return this.loadSchema(name);
+    };
+    return new ParticleSpec(model, resolveSchema);
   }
 
   loadParticleClass(spec) {

--- a/runtime/manifest.js
+++ b/runtime/manifest.js
@@ -97,12 +97,18 @@ class Manifest {
       let parent = manifest.findSchemaByName(schemaItem.parent);
       // TODO: error handling
       assert(parent);
-      schemaItem.parent = parent;
+      schemaItem.parent = parent.toLiteral();
     }
     manifest._schemas[schemaItem.name] = new Schema(schemaItem);
   }
   static _processParticle(manifest, particleItem) {
-    let particleSpec = new ParticleSpec(ParticleParser.parse(particleItem.body));
+    let model = ParticleParser.parse(particleItem.body);
+    // TODO: Remove the fallback hack.
+    let resolveSchema = name => manifest.findSchemaByName(name) || new Schema({
+        name,
+        sections: [],
+      });
+    let particleSpec = new ParticleSpec(model, resolveSchema);
     manifest._particles[particleItem.name] = particleSpec;
   }
   static _processRecipe(manifest, recipeItem) {

--- a/runtime/manifest.js
+++ b/runtime/manifest.js
@@ -103,11 +103,13 @@ class Manifest {
   }
   static _processParticle(manifest, particleItem) {
     let model = ParticleParser.parse(particleItem.body);
-    // TODO: Remove the fallback hack.
-    let resolveSchema = name => manifest.findSchemaByName(name) || new Schema({
-        name,
-        sections: [],
-      });
+    let resolveSchema = name => {
+      let schema = manifest.findSchemaByName(name);
+      if (!schema) {
+        throw new Error(`Schema '${name}' was not declared or imported`);
+      }
+      return schema;
+    };
     let particleSpec = new ParticleSpec(model, resolveSchema);
     manifest._particles[particleItem.name] = particleSpec;
   }

--- a/runtime/particle-spec.js
+++ b/runtime/particle-spec.js
@@ -9,17 +9,16 @@
  */
 "use strict";
 
-var runtime = require("./runtime.js");
-var recipe = require("./recipe.js");
-var typeLiteral = require("./type-literal.js");
+const runtime = require("./runtime.js");
+const recipe = require("./recipe.js");
+const Type = require('./type.js');
 
 class ConnectionSpec {
   constructor(rawData, typeVarMap) {
     this.rawData = rawData;
     this.direction = rawData.direction;
     this.name = rawData.name;
-    let type = rawData.type;
-    type = typeLiteral.convertNamedVariablesToVariables(type, typeVarMap);
+    let type = Type.assignVariableIds(rawData.type, typeVarMap);
     this.type = new runtime.internals.Type(type);
   }
 
@@ -37,7 +36,9 @@ class ConnectionSpec {
 }
 
 class ParticleSpec {
-  constructor(model) {
+  constructor(model, resolveSchema) {
+    // TODO: This should really happen after parsing, not here.
+    model.args.forEach(arg => arg.type = Type.resolveSchemas(arg.type, resolveSchema));
     this._model = model;
     this.name = model.name;
     var typeVarMap = new Map();

--- a/runtime/particle.js
+++ b/runtime/particle.js
@@ -11,16 +11,22 @@
 
 var parser = require("./build/particle-parser.js");
 var runtime = require("./runtime.js");
-//var loader = require("./loader.js");
 var ParticleSpec = require("./particle-spec.js");
 var tracing = require('tracelib');
 var assert = require('assert');
-const typeLiteral = require('./type-literal.js');
+const Schema = require('./schema.js');
 
 const DEBUGGING = false;
 
 function define(def, update) {
-  let spec = new ParticleSpec(parser.parse(def));
+  let model = parser.parse(def);
+  // TODO: Remove this, inline definition should happen at the manifest level
+  //       and include schemas.
+  let resolveSchema = name => new Schema({
+    name,
+    sections: [],
+  });
+  let spec = new ParticleSpec(model, resolveSchema);
   let clazz = class extends Particle {
     static get spec() {
       return spec;

--- a/runtime/recipe/view.js
+++ b/runtime/recipe/view.js
@@ -108,7 +108,7 @@ class View {
     result.push(`as ${(nameMap && nameMap.get(this)) || this.localName}`);
     if (this.type) {
       result.push('#');
-      result.push(JSON.stringify(this.type.key));
+      result.push(this.type.toString());
     }
     return result.join(' ');
   }

--- a/runtime/runtime.js
+++ b/runtime/runtime.js
@@ -13,26 +13,18 @@ const assert = require('assert');
 const view = require('./view.js');
 const Symbols = require('./symbols.js');
 const Entity = require('./entity.js');
+const Schema = require('./schema.js');
 const Type = require('./type.js');
 const Relation = require('./relation.js');
 
-class BasicEntity extends Entity {
-  constructor(rawData) {
-    super();
-    this.rawData = rawData;
-  }
-  get data() {
-    return this.rawData;
-  }
+function testEntityClass(type) {
+  return new Schema({
+    name: type,
+    sections: [],
+  }).entityClass();
 }
 
-function testEntityClass(type) {
-  return class TestEntity extends BasicEntity {
-    static get key() {
-      return type;
-    }
-  };
-}
+let BasicEntity = testEntityClass('BasicEntity');
 
 Object.assign(exports, {
   Entity,

--- a/runtime/schema.js
+++ b/runtime/schema.js
@@ -9,14 +9,16 @@
  */
 
 const Entity = require("./entity.js");
+const assert = require('assert');
 
 class Schema {
   constructor(model) {
     this._model = model;
     this.name = model.name;
-    this.parent = model.parent;
+    this.parent = model.parent ? new Schema(model.parent) : null;
     this._normative = {};
     this._optional = {};
+    assert(model.sections);
     for (var section of model.sections) {
       var into = section.sectionType == 'normative' ? this._normative : this._optional;
       for (var field in section.fields) {
@@ -26,7 +28,7 @@ class Schema {
     }
   }
 
-  get toLiteral() {
+  toLiteral() {
     return this._model;
   }
 
@@ -43,6 +45,7 @@ class Schema {
   }
 
   entityClass() {
+    let schema = this;
     const name = this.name;
     var clazz = class extends Entity {
       constructor(data) {
@@ -51,7 +54,10 @@ class Schema {
       }
 
       static get key() {
-        return name;
+        return {
+          tag: 'entity',
+          schema: schema.toLiteral(),
+        };
       }
     }
     Object.defineProperty(clazz, 'name', {value: this.name});

--- a/runtime/test/manifest-test.js
+++ b/runtime/test/manifest-test.js
@@ -37,6 +37,7 @@ describe('manifest', function() {
   });
   it('can parse a manifest containing a particle specification', async () => {
     let manifest = await Manifest.parse(`
+      schema Product
       particle Chooser in 'chooser.js'
         Chooser(in [Product] choices, out [Product] resultList)
 
@@ -169,6 +170,8 @@ describe('manifest', function() {
   });
   it('can resolve recipe particles defined in the same manifest', async () => {
     let manifest = await Manifest.parse(`
+      schema Something
+      schema Someother
       particle Thing in 'thing.js'
         Thing(in [Something] someThings, out [Someother] someOthers)
       recipe
@@ -223,6 +226,7 @@ describe('manifest', function() {
                 ParticleB
                 `,
           b: `
+              schema Thing
               particle ParticleB in 'b.js'
                 ParticleB(in Thing)`
         }[path];

--- a/runtime/test/resolver-tests.js
+++ b/runtime/test/resolver-tests.js
@@ -19,7 +19,6 @@ let util = require('./test-util.js');
 var viewlet = require('../viewlet.js');
 let SlotComposer = require('../slot-composer.js');
 var Loader = require('../loader');
-let Type = require('../type.js');
 
 require("./trace-setup.js");
 
@@ -36,8 +35,8 @@ describe('resolver', () => {
     let fooView = arc.createView(Foo.type);
     var r = new recipe.RecipeBuilder()
         .addParticle("TestParticle")
-            .connectSpec("foo", {type: new Type("Foo"), mustCreate: false})
-            .connectSpec("bar", {type: new Type("Bar"), mustCreate: true})
+            .connectSpec("foo", {type: Foo.type, mustCreate: false})
+            .connectSpec("bar", {type: Bar.type, mustCreate: true})
         .build();
     viewlet.viewletFor(fooView).set(new Foo({value: "not a Bar"}));
     assert(Resolver.resolve(r, arc), "recipe resolves");
@@ -72,7 +71,7 @@ describe('resolver', () => {
     var arc = new Arc({loader, slotComposer});
     var r = new recipe.RecipeBuilder()
         .addParticle("TestParticle")
-            .connectSpec("herp", {type: new Type("Foo"), mustCreate: false})
+            .connectSpec("herp", {type: Foo.type, mustCreate: false})
         .build();
     assert(!Resolver.resolve(r, arc), "recipe should not resolve");
   });

--- a/runtime/test/suggestinator-tests.js
+++ b/runtime/test/suggestinator-tests.js
@@ -37,15 +37,15 @@ describe('suggestinator', function() {
 
     var recipe1 = new recipe.RecipeBuilder()
         .addParticle("TestParticle")
-            .connectSpec("foo", {type: new Type("Foo"), mustCreate: false})
-            .connectSpec("bar", {type: new Type("Bar"), mustCreate: false})
+            .connectSpec("foo", {type: Foo.type, mustCreate: false})
+            .connectSpec("bar", {type: Bar.type, mustCreate: false})
         .build();
 
     var recipe2 = new recipe.RecipeBuilder()
         .addParticle("TwoInputTestParticle")
-            .connectSpec("foo", {type: new Type("Foo"), mustCreate: false})
-            .connectSpec("bar", {type: new Type("Bar"), mustCreate: false})
-            .connectSpec("far", {type: new Type("Far"), mustCreate: true})
+            .connectSpec("foo", {type: Foo.type, mustCreate: false})
+            .connectSpec("bar", {type: Bar.type, mustCreate: false})
+            .connectSpec("far", {type: Far.type, mustCreate: true})
         .build();
 
     var suggestinator = new Suggestinator();

--- a/runtime/type-literal.js
+++ b/runtime/type-literal.js
@@ -27,7 +27,11 @@ function isVariable(t) {
   return (typeof t == "object" && t.tag == "variable");
 }
 
-// TODO: clauses for relations too 
+function isEntity(t) {
+  return (typeof t == "object" && t.tag == "entity");
+}
+
+// TODO: clauses for relations too
 function hasVariable(t) {
   return isVariable(t) || (isView(t) && hasVariable(primitiveType(t)));
 }
@@ -55,27 +59,7 @@ function variableID(t) {
   return t.id;
 }
 
-function convertNamedVariablesToVariables(variable, typeMap) {
-  if (isView(variable)) {
-    return viewOf(convertNamedVariablesToVariables(primitiveType(variable), typeMap));
-  }
-  if (isRelation(variable)) {
-    return variable.map(a => convertNamedVariablesToVariables(a, typeMap));
-  }
-
-  if (isNamedVariable(variable)) {
-    var id = typeMap.get(variable.name);
-    if (id == undefined) {
-      id = typeVariable(variable.name);
-      typeMap.set(variable.name, id);
-    }
-    return id.clone();
-  }
-
-  return variable;
-}
-
-// TODO: we can do better than this. 
+// TODO: we can do better than this.
 function equal(t1, t2) {
   return stringFor(t1) == stringFor(t2);
 }
@@ -87,12 +71,14 @@ function stringFor(t) {
     return `${stringFor(primitiveType(t))} List`;
   else if (isVariable(t) || isNamedVariable(t))
     return `[${t.name}]`;
+  else if (isEntity(t))
+    return t.schema.name;
   if (typeof t == "object")
     return JSON.stringify(t);
   return String(t);
 }
 
 
-Object.assign(module.exports, { isRelation, isView, isNamedVariable, isVariable, primitiveType, viewOf,
-                                namedTypeVariable, typeVariable, variableID, hasVariable,
-                                convertNamedVariablesToVariables, stringFor, equal });
+Object.assign(module.exports, { isRelation, isView, isEntity, isNamedVariable, isVariable, primitiveType, viewOf,
+  namedTypeVariable, typeVariable, variableID, hasVariable,
+  stringFor, equal });

--- a/runtime/type.js
+++ b/runtime/type.js
@@ -18,6 +18,7 @@ class Type {
     this.key = key;
   }
 
+  // TODO: Replace these static functions with operations on Types directly.
   // Replaces 'prevariable' types with 'variable'+id types .
   static assignVariableIds(literal, variableMap) {
     if (typeof literal == 'string') {


### PR DESCRIPTION
* Schemas are sent from outer to inner pec (inner pec never calls
  loader.loadSchema).
* type-literal.js is only used by Type.js and the old particle parser.