### PR TITLE
Fix duplicate slots create as a result of resolved particle slot spec setting

### DIFF
--- a/runtime/recipe/slot-connection.js
+++ b/runtime/recipe/slot-connection.js
@@ -116,8 +116,12 @@ class SlotConnection {
       result.push(`consume ${this.name}`);
 
     Object.keys(this.providedSlots).forEach(psName => {
-      result.push(`  provide ${psName} as ${(nameMap && nameMap.get(this.providedSlots[psName])) || this.providedSlots[psName]}`);
-    })
+      let providedSlot = this.providedSlots[psName];
+      result.push(`  provide ${psName} as ${(nameMap && nameMap.get(providedSlot)) || providedSlot}`);
+      providedSlot.viewConnections.forEach(vc => {
+        result.push(`    view ${vc.name}`);
+      });
+    });
     return result.join("\n");
   }
 }

--- a/runtime/recipe/slot-connection.js
+++ b/runtime/recipe/slot-connection.js
@@ -33,12 +33,18 @@ class SlotConnection {
     assert(this.name == slotSpec.name);
     this._slotSpec = slotSpec;
     slotSpec.providedSlots.forEach(providedSlot => {
-      let slot = this.recipe.newSlot(providedSlot.name);
-      slot.localName = providedSlot.name;
-      slot.formFactor = providedSlot.formFactor;
-      slot._sourceConnection = this;
+      let slot = this.providedSlots[providedSlot.name];
+      if (slot == undefined) {
+        slot = this.recipe.newSlot(providedSlot.name);
+        slot._sourceConnection = this;
+        slot._name = providedSlot.name;
+        this.providedSlots[providedSlot.name] = slot;
+      }
+      assert(slot.viewConnections.length == 0, "View connections must be empty");
       providedSlot.views.forEach(view => slot.viewConnections.push(this.particle.connections[view]));
-      this.providedSlots[providedSlot.name] = slot;
+      assert(slot._name == providedSlot.name);
+      assert(!slot.formFactor);
+      slot.formFactor = providedSlot.formFactor;
     });
   }
 
@@ -83,7 +89,12 @@ class SlotConnection {
   }
 
   _isValid() {
-    // TODO: implement
+    if (this._targetSlot && this._targetSlot.sourceConnection &&
+        this._targetSlot != this._targetSlot.sourceConnection.providedSlots[this._targetSlot.name]) {
+      return false;
+    }
+
+    // TODO: add more checks.
     return true;
   }
 

--- a/runtime/strategies/resolve-particle-by-name.js
+++ b/runtime/strategies/resolve-particle-by-name.js
@@ -32,6 +32,8 @@ class ResolveParticleByName extends Strategy {
     var loadedParticles = this._loadedParticles;
     var results = Recipe.over(strategizer.generated, new class extends RecipeWalker {
       onParticle(recipe, particle) {
+        if (particle.spec)
+          return;
         let particles = find(particle.name);
         return particles.map(spec => {
           var score = 1 / particles.length;

--- a/runtime/test/manifest-test.js
+++ b/runtime/test/manifest-test.js
@@ -335,7 +335,7 @@ describe('manifest', function() {
         OtherParticle
           aParam -> myView
           consume aSlot as slot0
-          consume bSlot as slot1
+          consume oneMoreSlot as slot1
           `);
     let recipe = manifest.recipes[0];
     assert(recipe);
@@ -351,7 +351,7 @@ describe('manifest', function() {
     let mySlot = recipe.particles[1].consumedSlotConnections['mySlot'];
     assert.isDefined(mySlot.targetSlot);
     assert.equal(Object.keys(mySlot.providedSlots).length, 2);
-    assert.equal(mySlot.providedSlots["oneMoreSlot"], recipe.particles[0].consumedSlotConnections['bSlot'].targetSlot);
+    assert.equal(mySlot.providedSlots["oneMoreSlot"], recipe.particles[0].consumedSlotConnections['oneMoreSlot'].targetSlot);
   });
   it('relies on the loader to combine paths', async () => {
     let registry = {};


### PR DESCRIPTION
Also fix mistakenly set slot's localName
and avoid calling ResolveParticleByName repeatedly.