### PR TITLE
Don't synthesize views in view mappers.

### DIFF
--- a/runtime/browser/demo/recipes.manifest
+++ b/runtime/browser/demo/recipes.manifest
@@ -42,7 +42,9 @@ recipe
 
 # Buying for [person]'s [occasion] in [timeframe]? Product [X] arrives too late.
 recipe
+  map as view1
   GiftList
+    person <- view1
   Arrivinator
 
 # Check manufacturer information for products.

--- a/runtime/planner.js
+++ b/runtime/planner.js
@@ -16,6 +16,7 @@ let AssignViewsByTagAndType = require('./strategies/assign-views-by-tag-and-type
 let ResolveParticleByName = require('./strategies/resolve-particle-by-name.js');
 let InitPopulation = require('./strategies/init-population.js');
 let MapRemoteSlots = require('./strategies/map-remote-slots.js');
+let AddUseViews = require('./strategies/add-use-views.js');
 let Manifest = require('./manifest.js');
 
 const Speculator = require('./speculator.js');
@@ -96,7 +97,8 @@ class Planner {
       new ConvertConstraintsToConnections(),
       new MatchConsumedSlots(),
       new AssignRemoteViews(arc),
-      new MapRemoteSlots(arc)
+      new MapRemoteSlots(arc),
+      new AddUseViews(),
     ];
     this.strategizer = new Strategizer(strategies, [], {
       maxPopulation: 100,

--- a/runtime/planner.js
+++ b/runtime/planner.js
@@ -12,6 +12,7 @@ let RecipeUtil = require('./recipe/recipe-util.js');
 let RecipeWalker = require('./recipe/walker.js');
 let ConvertConstraintsToConnections = require('./strategies/convert-constraints-to-connections.js');
 let AssignRemoteViews = require('./strategies/assign-remote-views.js');
+let CopyRemoteViews = require('./strategies/copy-remote-views.js');
 let AssignViewsByTagAndType = require('./strategies/assign-views-by-tag-and-type.js');
 let ResolveParticleByName = require('./strategies/resolve-particle-by-name.js');
 let InitPopulation = require('./strategies/init-population.js');
@@ -97,6 +98,7 @@ class Planner {
       new ConvertConstraintsToConnections(),
       new MatchConsumedSlots(),
       new AssignRemoteViews(arc),
+      new CopyRemoteViews(arc),
       new MapRemoteSlots(arc),
       new AddUseViews(),
     ];

--- a/runtime/recipe/walker-base.js
+++ b/runtime/recipe/walker-base.js
@@ -90,6 +90,8 @@ class WalkerBase extends Strategizer.Walker {
     if (result.constructor == Array && result.length <= 0)
       return true;
 
+      assert(typeof result == 'function' || result.length);
+
     return false;
   }
 }

--- a/runtime/recipe/walker.js
+++ b/runtime/recipe/walker.js
@@ -19,7 +19,7 @@ class Walker extends WalkerBase {
 
     if (this.onRecipe) {
       var result = this.onRecipe(recipe, result);
-      if (!this.isEmptyResult(result));
+      if (!this.isEmptyResult(result))
         updateList.push({continuation: result});
     }
     for (var particle of recipe.particles) {

--- a/runtime/strategies/add-use-views.js
+++ b/runtime/strategies/add-use-views.js
@@ -1,0 +1,41 @@
+
+// Copyright (c) 2017 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+let {Strategy} = require('../../strategizer/strategizer.js');
+let Recipe = require('../recipe/recipe.js');
+let RecipeWalker = require('../recipe/walker.js');
+
+class AddUseViews extends Strategy {
+  // TODO: move generation to use an async generator.
+  async generate(strategizer) {
+    var results = Recipe.over(strategizer.generated, new class extends RecipeWalker {
+      onRecipe(recipe) {
+        // Don't add use views to a recipe with free views
+        var freeViews = recipe.views.filter(view => view.connections.length == 0);
+        if (freeViews.length > 0)
+          return;
+
+        var disconnectedConnections = recipe.viewConnections.filter(vc => vc.view == null);
+
+        return recipe => {
+          disconnectedConnections.forEach(vc => {
+            var clonedVC = recipe.updateToClone({vc}).vc;
+            var view = recipe.newView();
+            view.fate = 'use';
+            clonedVC.connectToView(view);
+          });
+          return 0;
+        };
+      }
+    }(RecipeWalker.Permuted), this);
+
+    return { results, generate: null };
+  }
+}
+
+module.exports = AddUseViews;

--- a/runtime/strategies/copy-remote-views.js
+++ b/runtime/strategies/copy-remote-views.js
@@ -1,0 +1,33 @@
+// Copyright (c) 2017 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+let {Strategy} = require('../../strategizer/strategizer.js');
+let RecipeWalker = require('../recipe/walker.js');
+let Recipe = require('../recipe/recipe.js');
+let RecipeUtil = require('../recipe/recipe-util.js');
+let ViewMapperBase = require('./view-mapper-base.js');
+let Schema = require('../schema.js');
+
+let assert = require('assert');
+
+class CopyRemoteViews extends ViewMapperBase {
+  constructor(arc) {
+    super();
+    this._arc = arc;
+    this.fate = 'copy';
+  }
+
+  getMappableViews(type, tags) {
+    if (tags.length > 0) {
+      return this._arc.context.findViewsByType(type, {tag: tags[0]});
+    } else {
+      return this._arc.context.findViewsByType(type);
+    }
+  }
+}
+
+module.exports = CopyRemoteViews;

--- a/runtime/strategies/view-mapper-base.js
+++ b/runtime/strategies/view-mapper-base.js
@@ -17,7 +17,7 @@ class ViewMapperBase extends Strategy {
 
     var results = Recipe.over(strategizer.generated, new class extends RecipeWalker {
       onView(recipe, view) {
-        if (view.fate == "create")
+        if (view.fate !== self.fate)
           return;
 
         if (view.connections.length == 0)

--- a/runtime/strategies/view-mapper-base.js
+++ b/runtime/strategies/view-mapper-base.js
@@ -16,22 +16,6 @@ class ViewMapperBase extends Strategy {
     var self = this;
 
     var results = Recipe.over(strategizer.generated, new class extends RecipeWalker {
-      onViewConnection(recipe, vc) {
-        if (vc.view)
-          return;
-        if (!vc.type)
-          return;
-        if (vc.direction == 'in')
-          var counts = {'in': 1, 'out': 0, 'unknown': 0};
-        else if (vc.direction == 'out')
-          var counts = {'in': 0, 'out': 1, 'unknown': 0};
-        else if (vc.direction == 'inout')
-          var counts = {'in': 1, 'out': 1, 'unknown': 0};
-        else
-          var counts = {'in': 0, 'out': 0, 'unknown': 1};
-        return this.mapView(null, vc.tags, vc.type, counts);
-      }
-
       onView(recipe, view) {
         if (view.fate == "create")
           return;
@@ -63,10 +47,6 @@ class ViewMapperBase extends Strategy {
             score = 0;
         }
 
-        var contextIsViewConnection = view == null;
-        if (contextIsViewConnection)
-          score -= 2;
-
         if (tags.length > 0)
           score += 4;
 
@@ -80,18 +60,13 @@ class ViewMapperBase extends Strategy {
           return;
 
         var responses = views.map(newView =>
-          ((recipe, clonedObject) => {
+          ((recipe, clonedView) => {
             for (var existingView of recipe.views)
               // TODO: Why don't we link the view connections to the existingView?
               if (existingView.id == newView.id)
                 return 0;
             var tscore = 0;
-            if (contextIsViewConnection) {
-              var clonedView = recipe.newView();
-              clonedObject.connectToView(clonedView);
-            } else {
-              var clonedView = clonedObject;
-            }
+
             assert(newView.id);
             clonedView.mapToView(newView);
             if (clonedView.fate != 'copy') {

--- a/runtime/test/planner-tests.js
+++ b/runtime/test/planner-tests.js
@@ -33,7 +33,7 @@ describe('Planner', function() {
     await planner.generate(),
     await planner.generate(),
     await planner.generate(),
-    assert.equal(planner.strategizer.population.length, 6);
+    assert.equal(planner.strategizer.population.length, 9);
   });
 
   it('make a plan with views', async () => {
@@ -48,7 +48,7 @@ describe('Planner', function() {
     await planner.generate(),
     await planner.generate(),
     await planner.generate(),
-    assert.equal(planner.strategizer.population.length, 10);
+    assert.equal(planner.strategizer.population.length, 11);
   });
 });
 

--- a/runtime/test/planner-tests.js
+++ b/runtime/test/planner-tests.js
@@ -48,7 +48,7 @@ describe('Planner', function() {
     await planner.generate(),
     await planner.generate(),
     await planner.generate(),
-    assert.equal(planner.strategizer.population.length, 15);
+    assert.equal(planner.strategizer.population.length, 10);
   });
 });
 


### PR DESCRIPTION
Instead, a new AddUseViews strategy does very limited view synthesis (use views only). Effectively, a recipe should call out any views it doesn't expect to be 'use' mapped into the existing arc.