### PR TITLE
Derive view descriptions from view names.

### DIFF
--- a/runtime/browser/demo/recipes.manifest
+++ b/runtime/browser/demo/recipes.manifest
@@ -60,7 +60,7 @@ recipe
   Interests
 
 # TODO: move these to separate manifests for claire's wishlist / page
-view PageProducts of [Product] in 'products.json'
-view ClairesWishlist of [Product] #wishlist in 'wishlist.json'
-view APerson of Person in 'people.json'
+view ProductsFromYourBrowsingContext of [Product] in 'products.json'
+view Claire_sWishlist of [Product] #wishlist in 'wishlist.json'
+view Claire of Person in 'people.json'
 #view ThePeople of Person in 'people.json'

--- a/runtime/description-generator.js
+++ b/runtime/description-generator.js
@@ -52,12 +52,18 @@ class DescriptionGenerator {
         }
         assert(this._descriptionsByView.get(view).type.equals(connection.type),
                `Unexpected type for view ${view}`);
+        let description = particle.spec.description ? particle.spec.description[connection.name] : undefined;
+        if (!description) {
+          if (view.id) {
+            description = this.relevance.newArc.findViewById(view.id).description
+          }
+        }
         // should verify same particle doesn't push twice?
         this._descriptionsByView.get(view)["descriptions"].push({
           connectionName: connection.name,
           recipeParticle: particle,
           direction: particle.spec.connectionMap.get(connection.name).isOutput ? "out" : "in",
-          description: particle.spec.description ? particle.spec.description[connection.name] : undefined
+          description
         });
       });
     });

--- a/runtime/manifest.js
+++ b/runtime/manifest.js
@@ -384,6 +384,7 @@ class Manifest {
     type = type.resolveSchemas(resolveSchema);
 
     let view = manifest.newView(type, name, id, tags);
+    view.description = view.name.replace(/([A-Z])/g, ' $1').replace('_', "'").trim();
     // TODO: How to set the version?
     // view.version = item.version;
     let source = loader.join(manifest.fileName, item.source);


### PR DESCRIPTION
This is a very humble first step towards better descriptions.

Next steps:
1) Use real singleton view value (not just the "name" property) in description - this will allow to populate occasion "birthday" and date (currently showing {occasion} and {timeframe} placeholders)
2) Update view values on dynamically, if the view has changed (currently showing wrong "..and 2 more products", when there is actually more products)
3) Allow particles update descriptions of "create" views


