### PR TITLE
Slots polish: strategies, inner slots etc

### DIFF
--- a/particles/Chooser/Chooser.js
+++ b/particles/Chooser/Chooser.js
@@ -109,8 +109,8 @@ defineParticle(({DomParticle}) => {
         <img src="{{image}}">
       </div>
     </div>
-  <!-- annotation slot will be provided, as soon as SlotComposer and MapRemoteSlots strategy support it. ->
-  <!-- div slotid="annotation" subid$="{{subId}}" -->
+  <!-- TODO: Declare this slot in the Chooser.manifest, when strategizer supports it well. -->
+  <div slotid="annotation" subid$="{{subId}}">
   </div>
 </template>
   `;

--- a/particles/Chooser/Chooser.manifest
+++ b/particles/Chooser/Chooser.manifest
@@ -12,6 +12,6 @@ particle Chooser in 'Chooser.js'
   Chooser(in [Product] choices, inout [Product] resultList)
   affordance dom
   consume action
-  # annotation slot will be provided, as soon as SlotComposer and MapRemoteSlots strategy support it.
+  # annotation slot will be provided, when strategizer supports it well.
   #  provide set of annotation
   description `Choose from ${choices}`

--- a/runtime/dom-context.js
+++ b/runtime/dom-context.js
@@ -69,9 +69,27 @@ class DomContext {
   getInnerContext(innerSlotName) {
     return this._innerContextBySlotName[innerSlotName];
   }
+  isDirectInnerSlot(slot) {
+    let parentNode = slot.parentNode;
+    while (parentNode) {
+      if (parentNode == this._context) {
+        return true;
+      }
+      if (parentNode.getAttribute("slotid")) {
+        // this is an inner slot of an inner slot.
+        return false;
+      }
+      parentNode = parentNode.parentNode;
+    }
+    assert(false);
+  }
   initInnerContexts(slotSpec) {
     this._innerContextBySlotName = {};
     Array.from(this._context.querySelectorAll("[slotid]")).forEach(s => {
+      if (!this.isDirectInnerSlot(s)) {
+        // Skip inner slots of an inner slot of the given slot.
+        return;
+      }
       let slotId = s.getAttribute('slotid');
       let providedSlotSpec = slotSpec.providedSlots.find(ps => ps.name == slotId);
       if (providedSlotSpec) {  // Skip non-declared slots

--- a/runtime/slot-composer.js
+++ b/runtime/slot-composer.js
@@ -104,23 +104,23 @@ class SlotComposer {
       assert(slot.consumeConn.targetSlot);
       Object.values(slot.consumeConn.providedSlots).forEach(ps => {
         if (!availableSlots[ps.name]) {
-          availableSlots[ps.name] = {};
+          availableSlots[ps.name] = [];
         }
         let psId = ps.id || `slotid-${this._nextSlotId++}`;
         ps.id = psId;
-        // TODO(mmandlis): availableSlots[ps.name] should be an array of slots,
-        // in case slot with the same name if provided by more than one particle.
-        availableSlots[ps.name] = {
+        let providedSlotSpec = slot.consumeConn.slotSpec.providedSlots.find(psSpec => psSpec.name == ps.name);
+        availableSlots[ps.name].push({
           id: psId,
           count: ps.consumeConnections.length,
+          providedSlotSpec,
           views: ps.viewConnections.map(vc => vc.view)
-        };
+        });
       });
     });
 
     // Populate default "root" slot, if not available yet.
     assert(!availableSlots["root"], `Root slot cannot be provided`);
-    availableSlots["root"] = {id:"r0", count:0, views: []};
+    availableSlots["root"] = [{id:"r0", count:0, views: [], providedSlotSpec: {isSet: false}}];
 
     return availableSlots;
   }

--- a/runtime/strategies/map-consumed-slots.js
+++ b/runtime/strategies/map-consumed-slots.js
@@ -20,8 +20,12 @@ class MapConsumedSlots extends Strategy {
           if (slotConnection.name != slot.name)
             return false;
 
-          // TODO: verify isSet matches the map-remote-slots and map-consumed strategies.
+          let providedSlotSpec =
+              slot.sourceConnection.slotSpec.providedSlots.find(ps => ps.name == slotConnection.name);
+          if (slotConnection.slotSpec.isSet != providedSlotSpec.isSet)
+            return;
 
+          // Verify view connections match.
           var views = slot.viewConnections.map(connection => connection.view);
           if (views.length == 0) {
             return true;

--- a/runtime/test/planner-tests.js
+++ b/runtime/test/planner-tests.js
@@ -28,7 +28,10 @@ describe('Planner', function() {
     var arc = new Arc({
       id: "test-plan-arc",
       context: manifest,
-      slotComposer: { affordance: 'dom', getAvailableSlots: (() => { return {root: {id: 'r0', count: 0, views: []}}; }) }
+      slotComposer: {
+        affordance: 'dom',
+        getAvailableSlots: (() => { return {root: [{id: 'r0', count: 0, views: [], providedSlotSpec: {isSet: false}}]}; })
+      }
     });
     let Person = manifest.findSchemaByName('Person').entityClass();
     let Product = manifest.findSchemaByName('Person').entityClass();
@@ -45,7 +48,10 @@ describe('Planner', function() {
     var arc = new Arc({
       id: "test-plan-arc",
       context: manifest,
-      slotComposer: { affordance: 'dom', getAvailableSlots: (() => { return {root: {id: 'r0', count: 0, views: []}}; }) }
+      slotComposer: {
+        affordance: 'dom',
+        getAvailableSlots: (() => { return {root: [{id: 'r0', count: 0, views: [], providedSlotSpec: {isSet: false}}]}; })
+      }
     });
     let Person = manifest.findSchemaByName('Person').entityClass();
     let Product = manifest.findSchemaByName('Product').entityClass();


### PR DESCRIPTION
- Enforce matching isSet in map-remote-slots and map-consumed-slots strategies
- Support slot with the same name provided by different particles in slot-componser and map-remote-slot strategy
- Avoid inner-inner slots recognized as inner slots in dom-context