### PR TITLE
Assert that a particle body exists if an implfile is specified.

### DIFF
--- a/runtime/manifest.js
+++ b/runtime/manifest.js
@@ -193,10 +193,12 @@ ${e.message}
     manifest._schemas[schemaItem.name] = new Schema(schemaItem);
   }
   static _processParticle(manifest, particleItem, loader) {
+    assert(particleItem.implFile == null || particleItem.args !== null, "no valid body defined for this particle");
     // TODO: loader should not be optional.
     if (particleItem.implFile && loader) {
       particleItem.implFile = loader.join(manifest.fileName, particleItem.implFile);
     }
+
     let resolveSchema = name => {
       let schema = manifest.findSchemaByName(name);
       if (!schema) {

--- a/runtime/test/manifest-test.js
+++ b/runtime/test/manifest-test.js
@@ -217,6 +217,17 @@ describe('manifest', function() {
         Thing`);
     assert(manifest.recipes[0].particles[0].spec);
   });
+  it('throws an error when a particle has no appropriate body definition', async () => {
+    try {
+      let manifest = await Manifest.parse(`
+        schema Thixthpenthe
+        particle Thing in 'thing.js'
+          Thong(in Thixthpenthe thixthpenthe)`);
+      assert(false);
+    } catch (e) {
+      assert.equal(e.message, "no valid body defined for this particle");
+    }
+  })
   it('can load a manifest via a loader', async () => {
     let registry = {};
     let loader = {


### PR DESCRIPTION
An alternative approach would be to always assert that particleItem.args is not null, however this means that the common testing practice of forward-declaring particles doesn't work any more. This seems like a reasonable compromise.