### PR TITLE
don't allow non-parseable particle sub-elements be treated as affordances

### DIFF
--- a/runtime/manifest-parser.peg
+++ b/runtime/manifest-parser.peg
@@ -93,7 +93,7 @@ Particle
       } else if (item.affordance) {
         affordance.push(item.affordance)
       } else {
-        error('Unknown particle element ', item);
+        error(`Particle ${name} contains an unknown element: ${item.name}`);
       }
     });
     if (affordance.length == 0) {

--- a/runtime/manifest-parser.peg
+++ b/runtime/manifest-parser.peg
@@ -90,8 +90,10 @@ Particle
       } else if (item.kind == 'description') {
         description = {};
         item.description.forEach(d => { description[d.name] = d.pattern; });
-      } else {
+      } else if (item.affordance) {
         affordance.push(item.affordance)
+      } else {
+        error('Unknown particle element ', item);
       }
     });
     if (affordance.length == 0) {

--- a/runtime/particle.js
+++ b/runtime/particle.js
@@ -120,7 +120,7 @@ class Particle {
    *
    * views is a map from names to view handles
    * names indicates the views which should have a callback installed on them
-   * kind is the kind of event that should ve registered for
+   * kind is the kind of event that should be registered for
    * f is the callback function
    */
   on(views, names, kind, f) {

--- a/runtime/test/manifest-parser-test.js
+++ b/runtime/test/manifest-parser-test.js
@@ -83,4 +83,15 @@ describe('manifest parser', function() {
         description \`my view\`
       view View1 of Person 'some-id' @7 in 'people.json'`);
   });
+  it('fails to parse a nonsense argument list', () => {
+    try {
+      parse(`
+        particle AParticle
+          Nonsense()`);
+      assert.fail('this parse should have failed, no nonsense!');
+    } catch(e) {
+      assert(e.message.includes('Unknown particle element'),
+          'bad error: '+e);
+    }
+  });
 });

--- a/runtime/test/manifest-parser-test.js
+++ b/runtime/test/manifest-parser-test.js
@@ -90,7 +90,7 @@ describe('manifest parser', function() {
           Nonsense()`);
       assert.fail('this parse should have failed, no nonsense!');
     } catch(e) {
-      assert(e.message.includes('Unknown particle element'),
+      assert(e.message.includes('Nonsense'),
           'bad error: '+e);
     }
   });

--- a/runtime/test/manifest-test.js
+++ b/runtime/test/manifest-test.js
@@ -221,8 +221,7 @@ describe('manifest', function() {
     try {
       let manifest = await Manifest.parse(`
         schema Thixthpenthe
-        particle Thing in 'thing.js'
-          Thong(in Thixthpenthe thixthpenthe)`);
+        particle Thing in 'thing.js'`);
       assert(false);
     } catch (e) {
       assert.equal(e.message, "no valid body defined for this particle");


### PR DESCRIPTION
Add an error when something isn't anything else (instead of assuming that it's an affordance).

This is one idea to give a better user error, although there's more discussion at #365.