### PR TITLE
run peg generation before trying to run tests

### DIFF
--- a/runtime/gulpfile.js
+++ b/runtime/gulpfile.js
@@ -73,7 +73,7 @@ gulp.task('webpack', async function() {
 
 gulp.task('build', ['peg', 'webpack']);
 
-gulp.task('test', function() {
+gulp.task('test', ['peg'], function() {
   const mocha = require('gulp-mocha');
   // OMG gulp, why are you so hideously, hideously bad?
   //


### PR DESCRIPTION
A small change, but improved my build-test cycle when making peg changes.