### PR TITLE
Display suggestion description in the strategy-explorer

### DIFF
--- a/runtime/planner.js
+++ b/runtime/planner.js
@@ -131,6 +131,15 @@ class Planner {
       let descriptionGenerator = new DescriptionGenerator(plan, relevance);
 
       let hash = ((hash) => { return hash.substring(hash.length - 4)}) (await plan.digest());
+      if (generations) {
+        generations.forEach(g => {
+          g.forEach(gg => {
+            if (gg.hash.endsWith(hash)) {
+              gg.description = descriptionGenerator.description;
+            }
+          });
+        });
+      }
       // TODO: Move this logic inside speculate, so that it can stop the arc
       // before returning.
       relevance.newArc.stop();

--- a/strategy-explorer/se-recipe-view.html
+++ b/strategy-explorer/se-recipe-view.html
@@ -35,7 +35,11 @@ http://polymer.github.io/PATENTS.txt
       }
     </style>
     <template is='dom-if' if='{{shownRecipe}}'>
-      <div class='recipe-box'>{{strategyString}}<span inner-h-t-m-l='{{shownRecipe.result}}'></span>
+      <div class='recipe-box'>{{strategyString}}<div hidden$="[[isDescriptionEmpty(shownRecipe.description)]]">
+          <span inner-h-t-m-l='{{shownRecipe.description}}'></span>
+          <hr>
+        </div>
+        <span inner-h-t-m-l='{{shownRecipe.result}}'></span>
       </div>
   </template>
 </template>
@@ -50,9 +54,12 @@ http://polymer.github.io/PATENTS.txt
           observer: "shownRecipeChanged"
         },
       },
+      isDescriptionEmpty(description) {
+        return !description;
+      },
       recipeChanged: function(recipe) {
         if (!this.pinned) {
-          this.shownRecipe = (({result, strategy, id, parent, score}) => ({result, strategy, id, parent, score}))(this.recipe);
+          this.shownRecipe = (({result, strategy, id, parent, score, description}) => ({result, strategy, id, parent, score, description}))(this.recipe);
         } else {
           if (recipe.id == this.shownRecipe.id) {
             this.set("shownRecipe.result", this.pinnedResult);
@@ -104,7 +111,7 @@ http://polymer.github.io/PATENTS.txt
       },
       unpin: function() {
         this.pinned = false;
-        this.shownRecipe = (({result, strategy, id, parent, score}) => ({result, strategy, id, parent, score}))(this.recipe);
+        this.shownRecipe = (({result, strategy, id, parent, score, description}) => ({result, strategy, id, parent, score, description}))(this.recipe);
         this.strategyString = '';
         this.to = undefined;
       }

--- a/strategy-explorer/strategy-explorer.html
+++ b/strategy-explorer/strategy-explorer.html
@@ -44,9 +44,9 @@ http://polymer.github.io/PATENTS.txt
     },
     preparePopulation: function(population) {
       population = population.map(recipe => {
-        let { result, score, derivation, hash } = recipe;
+        let { result, score, derivation, description, hash } = recipe;
         this.parentMap.set(recipe, this.lastID);
-        return { result, score, derivation, hash, id: this.lastID++ };
+        return { result, score, derivation, description, hash, id: this.lastID++ };
       });
 
       population.forEach(item => {


### PR DESCRIPTION
I'm not super happy with now it looks, but I don't seem to be able to figure out why there is so much whitespace preserved on the left:
https://screenshot.googleplex.com/s8k1Tq4rTWM.png

any ideas?