### PR TITLE
Update xen template

### DIFF
--- a/particles/Interests/Interests.js
+++ b/particles/Interests/Interests.js
@@ -15,7 +15,7 @@ defineParticle(({DomParticle}) => {
   let template = `
 <x-list items="{{items}}">
   <template>
-    <div>{{caption}}</div>
+    <div unsafe-html="{{caption}}"></div>
   </template>
 </x-list>
     `.trim();

--- a/runtime/browser/lib/x-list.js
+++ b/runtime/browser/lib/x-list.js
@@ -45,7 +45,7 @@ class XList extends XState(XElement) {
       if (!child) {
         try {
           // TODO(sjmiles): install event handlers explicitly now
-          var dom = XTemplate.stamp(template).mapEvents(props.eventMapper);
+          var dom = XTemplate.stamp(template).events(props.eventMapper);
         } catch(x) {
           console.warn('x-list: if `listen` is undefined, you need to provide a `handler` property for `on-*` events');
           throw x;

--- a/runtime/browser/lib/xen-template.js
+++ b/runtime/browser/lib/xen-template.js
@@ -185,10 +185,18 @@ let mapEvents = function(notes, map, controller) {
     let events = notes[key] && notes[key].events;
     if (node && events) {
       for (let name in events) {
-        controller(node, name, events[name]);
+        listen(node, name, controller, events[name]);
       }
     }
   }
+};
+
+let listen = function(node, eventName, controller, handlerName) {
+  node.addEventListener(eventName, function(e) {
+    if (controller[handlerName]) {
+      return controller[handlerName](e, e.detail);
+    }
+  });
 };
 
 let set = function(notes, map, scope) {
@@ -200,7 +208,10 @@ let set = function(notes, map, scope) {
       // now get your regularly scheduled bindings
       let mustaches = notes[key].mustaches;
       for (let name in mustaches) {
-        _set(node, name, scope[mustaches[name]]);
+        let property = mustaches[name];
+        if (property in scope) {
+          _set(node, name, scope[property]);
+        }
       }
     }
   }
@@ -209,8 +220,12 @@ let set = function(notes, map, scope) {
 let _set = function(node, property, value) {
   let modifier = property.slice(-1);
   //console.log('_set: %s, %s, '%s'', node.localName || '(text)', property, value);
-  if (property === 'style%') {
-    Object.assign(node.style, value);
+  if (property === 'style%' || property === 'style') {
+    if (typeof value === 'string') {
+      node.style.cssText = value;
+    } else {
+      Object.assign(node.style, value);
+    }
   } else if (modifier == '$') {
     let n = property.slice(0, -1);
     if (typeof value === 'boolean') {
@@ -219,9 +234,32 @@ let _set = function(node, property, value) {
       node.setAttribute(n, value);
     }
   } else if (property === 'textContent') {
-    node.innerHTML = (value || '');
+    if (value && (value.$template || value.template)) {
+      _setSubTemplate(node, value);
+    } else {
+      node.textContent = (value || '');
+    }
+  } else if (property === 'unsafe-html') {
+    node.innerHTML = value || '';
   } else {
-    node[property] = (property === 'textContent') ? (value || '') : value;
+    node[property] = value;
+  }
+};
+
+let _setSubTemplate = function(node, value) {
+  // TODO(sjmiles): sub-template iteration ability
+  // specially implemented to support arcs (serialization boundary)
+  // Aim to re-implement as a plugin.
+  let template = value.template;
+  if (!template) {
+    let container = node.getRootNode(); //node.parentElement
+    template = container.querySelector(`template[${value.$template}]`);
+  }
+  node.textContent = '';
+  if (template) {
+    for (let m of value.models) {
+      stamp(template).set(m).appendTo(node);
+    }
   }
 };
 
@@ -245,15 +283,18 @@ let stamp = function(template, opts) {
   // map DOM to keys
   let map = locateNodes(root, notes.locator);
   // return dom manager
-  return {
+  let dom = {
     root: root,
     notes: notes,
     map: map,
+    dispatch(handler, e) {
+      // abstract
+    },
     set: function(scope) {
       set(notes, map, scope);
       return this;
     },
-    mapEvents: function(controller) {
+    events: function(controller) {
       if (controller) {
         mapEvents(notes, map, controller);
       }
@@ -271,6 +312,10 @@ let stamp = function(template, opts) {
       return this;
     }
   };
+  mapEvents(notes, map, (node, event, handler) => {
+    node.addEventListener(event, e => dom.dispatch(handler, e));
+  });
+  return dom;
 };
 
 module.exports = {

--- a/runtime/dom-context.js
+++ b/runtime/dom-context.js
@@ -59,7 +59,7 @@ class DomContext {
       // TODO(sjmiles): hack to allow subtree elements (e.g. x-list) to marshal events
       this._context._eventMapper = this._eventMapper.bind(this, eventHandler);
       this._liveDom = Template.stamp(template, eventHandler)
-          .mapEvents(this._context._eventMapper)
+          .events(this._context._eventMapper)
           .appendTo(this._context);
     }
   }


### PR DESCRIPTION
Four modifications to xen-template (and downstream fixes):

1. On dom agent object, `mapEvents` is now `events`.
2. To bind an HTML string into the DOM, you must use `<elt unsafe-html="{{someHTML}}">` instead of `<elt>{{someHTML}}</elt>`.
3. Early support for subtemplate iteration (simpler built-in replacement for x-list [as used in Chat particle]).
4. More flexible style binding (can use `style%` or `style`, can supply CSSOM or CSSText).
