### PR TITLE
`mapEvents()` has different api from `events()`, restore `mapEvents()`

### DIFF
--- a/runtime/browser/lib/x-list.js
+++ b/runtime/browser/lib/x-list.js
@@ -45,7 +45,7 @@ class XList extends XState(XElement) {
       if (!child) {
         try {
           // TODO(sjmiles): install event handlers explicitly now
-          var dom = XTemplate.stamp(template).events(props.eventMapper);
+          var dom = XTemplate.stamp(template).mapEvents(props.eventMapper);
         } catch(x) {
           console.warn('x-list: if `listen` is undefined, you need to provide a `handler` property for `on-*` events');
           throw x;

--- a/runtime/browser/lib/xen-template.js
+++ b/runtime/browser/lib/xen-template.js
@@ -178,23 +178,23 @@ let annotate = function(root, key, opts) {
 };
 
 /* Annotation Consumer */
-let mapEvents = function(notes, map, controller) {
+let mapEvents = function(notes, map, mapper) {
   // add event listeners
   for (let key in notes) {
     let node = map[key];
     let events = notes[key] && notes[key].events;
     if (node && events) {
       for (let name in events) {
-        listen(node, name, controller, events[name]);
+        mapper(node, name, events[name]);
       }
     }
   }
 };
 
-let listen = function(node, eventName, controller, handlerName) {
+let listen = function(handlers, node, eventName, handlerName) {
   node.addEventListener(eventName, function(e) {
-    if (controller[handlerName]) {
-      return controller[handlerName](e, e.detail);
+    if (handlers[handlerName]) {
+      return handlers[handlerName](e, e.detail);
     }
   });
 };
@@ -287,17 +287,17 @@ let stamp = function(template, opts) {
     root: root,
     notes: notes,
     map: map,
+    /*
     dispatch(handler, e) {
       // abstract
     },
+    */
     set: function(scope) {
       set(notes, map, scope);
       return this;
     },
     events: function(controller) {
-      if (controller) {
-        mapEvents(notes, map, controller);
-      }
+      mapEvents(notes, map, listen.bind(null, controller));
       return this;
     },
     appendTo: function(node) {
@@ -310,11 +310,17 @@ let stamp = function(template, opts) {
       // TODO(sjmiles): this.root is no longer a fragment
       this.root = node;
       return this;
+    },
+    mapEvents: function(mapper) {
+      mapEvents(notes, map, mapper);
+      return this;
     }
   };
+  /*
   mapEvents(notes, map, (node, event, handler) => {
     node.addEventListener(event, e => dom.dispatch(handler, e));
   });
+  */
   return dom;
 };
 

--- a/runtime/dom-context.js
+++ b/runtime/dom-context.js
@@ -59,7 +59,7 @@ class DomContext {
       // TODO(sjmiles): hack to allow subtree elements (e.g. x-list) to marshal events
       this._context._eventMapper = this._eventMapper.bind(this, eventHandler);
       this._liveDom = Template.stamp(template, eventHandler)
-          .events(this._context._eventMapper)
+          .mapEvents(this._context._eventMapper)
           .appendTo(this._context);
     }
   }


### PR DESCRIPTION
I was too aggressive with the last push, tried to oversimplify the event handling. This PR should fix the breakage.

This could have been caught by testing, evidence that it's the right time for Maria's push toward automated browser tests.