### PR TITLE
Proper support for recursive literal types

### DIFF
--- a/runtime/type.js
+++ b/runtime/type.js
@@ -53,8 +53,14 @@ class Type {
     assert(data);
     if (tag == 'entity')
       assert(data.tag == undefined);
+    if (tag == 'list') {
+      if (!(data instanceof Type) && data.tag) {
+        this.data = new Type(data.tag, data.data);
+      } else {
+        this.data = data;
+      }
+    }
     this.tag = tag;
-    this.data = data;
   }
 
   // TODO: Replace these static functions with operations on Types directly.

--- a/runtime/type.js
+++ b/runtime/type.js
@@ -54,13 +54,12 @@ class Type {
     if (tag == 'entity')
       assert(data.tag == undefined);
     if (tag == 'list') {
-      if (!(data instanceof Type) && data.tag) {
-        this.data = new Type(data.tag, data.data);
-      } else {
-        this.data = data;
+      if (!(data instanceof Type) && data.tag && data.data) {
+        data = new Type(data.tag, data.data);
       }
     }
     this.tag = tag;
+    this.data = data;
   }
 
   // TODO: Replace these static functions with operations on Types directly.


### PR DESCRIPTION
equals() is recursive yet the fromLiteral builder method isn't. This causes issues when a type is serialized and synced via Firebase. Updated the constructor to be recursive as well.