### PR TITLE
plumb through an option to change the type of container node used by DomContext

### DIFF
--- a/runtime/dom-context.js
+++ b/runtime/dom-context.js
@@ -19,11 +19,10 @@ if (global.document) {
   require('./browser/lib/model-select.js');
 }
 
-let templates = new Map();
-
 class DomContext {
-  constructor(context) {
+  constructor(context, containerKind) {
     this._context = context;
+    this._containerKind = containerKind;
     // TODO(sjmiles): _liveDom needs new name
     this._liveDom = null;
     this._innerContextBySlotName = {};
@@ -31,7 +30,7 @@ class DomContext {
   initContext(context) {
     assert(context);
     if (!this._context) {
-      this._context = document.createElement('div');
+      this._context = document.createElement(this._containerKind || 'div');
       context.appendChild(this._context);
     } else {
       assert(this._context.parentNode == context,
@@ -111,7 +110,7 @@ class DomContext {
       }
     });
   }
-  findRootSlots(context) {
+  findRootSlots() {
     let innerSlotById = {};
     Array.from(this._context.querySelectorAll("[slotid]")).forEach(s => {
       assert(this.isDirectInnerSlot(s), 'Unexpected inner slot');
@@ -135,13 +134,14 @@ class DomContext {
 }
 
 class SetDomContext {
-  constructor() {
+  constructor(containerKind) {
     this._contextBySubId = {};
+    this._containerKind = containerKind;
   }
   initContext(context) {
     Object.keys(context).forEach(subId => {
       if (!this._contextBySubId[subId] || !this._contextBySubId[subId].isEqual(context[subId])) {
-        this._contextBySubId[subId] = new DomContext();
+        this._contextBySubId[subId] = new DomContext(this._containerKind);
       }
       this._contextBySubId[subId].initContext(context[subId]);
     });

--- a/runtime/dom-slot.js
+++ b/runtime/dom-slot.js
@@ -16,12 +16,12 @@ const {DomContext, SetDomContext} = require('./dom-context.js');
 let templates = new Map();
 
 class DomSlot extends Slot {
-  constructor(consumeConn, arc) {
+  constructor(consumeConn, arc, containerKind) {
     super(consumeConn, arc);
     this._templateName = `${this.consumeConn.particle.name}::${this.consumeConn.name}`;
     this._model = null;
-
     this._observer = this._initMutationObserver();
+    this._containerKind = containerKind;
   }
 
   get context() { return super.context;  }
@@ -45,7 +45,8 @@ class DomSlot extends Slot {
     }
   }
   _createDomContext() {
-    return this.consumeConn.slotSpec.isSet ? new SetDomContext() : new DomContext();
+    let type = this.consumeConn.slotSpec.isSet ? SetDomContext : DomContext;
+    return new (type)(null, this._containerKind);
   }
   _initMutationObserver() {
     return new MutationObserver(() => {
@@ -126,8 +127,7 @@ class DomSlot extends Slot {
     return request;
   }
   static findRootSlots(context) {
-    let domContext = new DomContext(context);
-    return domContext.findRootSlots(context);
+    return new DomContext(context, this._containerKind).findRootSlots(context);
   }
 }
 

--- a/runtime/slot-composer.js
+++ b/runtime/slot-composer.js
@@ -18,6 +18,7 @@ class SlotComposer {
     assert(options.affordance, "Affordance is mandatory");
     assert(options.rootContext, "Root context is mandatory");
 
+    this._containerKind = options.containerKind;
     this._affordance = options.affordance;
     this._slotClass = this.getSlotClass();
     assert(this._slotClass);
@@ -54,7 +55,7 @@ class SlotComposer {
     // Create slots for each of the recipe's particles slot connections.
     recipeParticles.forEach(p => {
       Object.values(p.consumedSlotConnections).forEach(cs => {
-        let slot = new this._slotClass(cs, this.arc);
+        let slot = new this._slotClass(cs, this.arc, this._containerKind);
         slot.startRenderCallback = this.arc.pec.startRender.bind(this.arc.pec);
         slot.stopRenderCallback = this.arc.pec.stopRender.bind(this.arc.pec);
         slot.innerSlotsUpdateCallback = this.updateInnerSlots.bind(this);
@@ -106,7 +107,6 @@ class SlotComposer {
   }
 
   getAvailableSlots() {
-    let targetSlots = new Set();
     let availableSlots = {};
     this._slots.forEach(slot => {
       assert(slot.consumeConn.targetSlot);


### PR DESCRIPTION
DomContext enforces that each particle live inside a container element, originally a `div`.

For the a-frame demo, the container element has to be `a-entity` or the contained vr-content is not scanned by a-frame.

This PR plumbs through an option from SlotComposer to allow specifying the tag-name (optional, defaults to `div`).

There are probably other ways to skin this cat if you don't like what you see here.