### PR TITLE
schema.org returns junk for the structured representations of Thing.

### DIFF
--- a/converters/jsonldToManifest.js
+++ b/converters/jsonldToManifest.js
@@ -11,10 +11,11 @@
 var supportedTypes = ["Text", "URL"];
 
 class JsonldToManifest {
-  static convert(jsonld) {
+  static convert(jsonld, theClass) {
     var obj = JSON.parse(jsonld);
     var classes = {};
     var properties = {};
+
     for (var item of obj['@graph']) {
       if (item["@type"] == "rdf:Property")
         properties[item["@id"]] = item;
@@ -31,9 +32,8 @@ class JsonldToManifest {
         clazz.superclass = classes[superclass];
       }
     }
-    var theClass = null;
     for (var clazz of Object.values(classes)) {
-      if (clazz.subclasses.length == 0) {
+      if (clazz.subclasses.length == 0 && theClass == undefined) {
         theClass = clazz;
       }
     }
@@ -41,12 +41,16 @@ class JsonldToManifest {
     var relevantProperties = [];
     for (var property of Object.values(properties)) {
       var domains = property['schema:domainIncludes'];
+      if (!domains)
+        domains = {'@id': theClass['@id']};
       if (!domains.length)
         domains = [domains];
       domains = domains.map(a => a['@id']);
       if (domains.includes(theClass['@id'])) {
         var name = property['@id'].split(':')[1];
         var type = property['schema:rangeIncludes'];
+        if (!type)
+          console.log(property);
         if (!type.length)
           type = [type];
 

--- a/runtime/loader.js
+++ b/runtime/loader.js
@@ -54,8 +54,12 @@ class Loader {
   }
 
   _loadURL(url) {
-    if (/\/\/schema.org\//.test(url))
+    if (/\/\/schema.org\//.test(url)) {
+      if (url.endsWith('/Thing')) {
+        return fetch("https://schema.org/Product.jsonld").then(res => res.text()).then(data => JsonldToManifest.convert(data, {'@id': 'schema:Thing'}));
+      }
       return fetch(url + ".jsonld").then(res => res.text()).then(data => JsonldToManifest.convert(data));
+    }
     return fetch(url).then(res => res.text());
   }
 

--- a/runtime/manual_tests/loader-tests.js
+++ b/runtime/manual_tests/loader-tests.js
@@ -1,0 +1,23 @@
+/**
+ * @license
+ * Copyright (c) 2017 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+const Loader = require("../loader.js");
+const assert = require('chai').assert;
+const Manifest = require('../manifest.js');
+
+let loader = new Loader();
+
+describe('loader', function() {
+  it('can read a schema.org schema', async () => {
+    let schemaString = await loader.loadResource('http://schema.org/Product');
+    let manifest = await Manifest.parse(schemaString, {loader, fileName: 'http://schema.org/Product'});
+  assert(manifest.schemas.Product.optional.description == 'Text');
+  });
+});


### PR DESCRIPTION
This patch works around this issue by extracting Thing from Product instead.

Fixes #417 