### PR TITLE
Fallback fate strategy for search based unresolved and terminal recipes

### DIFF
--- a/runtime/arc.js
+++ b/runtime/arc.js
@@ -185,7 +185,7 @@ class Arc {
     for (let recipeView of views) {
       if (['copy', 'create'].includes(recipeView.fate)) {
         let view = this.createView(recipeView.type, /* name= */ null, /* id= */ null, recipeView.tags);
-        if (recipeView._fate === "copy") {
+        if (recipeView.fate === "copy") {
           var copiedView = this.findViewById(recipeView.id);
           view.cloneFrom(copiedView);
         }

--- a/runtime/planner.js
+++ b/runtime/planner.js
@@ -23,6 +23,7 @@ let AddUseViews = require('./strategies/add-use-views.js');
 let Manifest = require('./manifest.js');
 let InitSearch = require('./strategies/init-search.js');
 let SearchTokensToParticles = require('./strategies/search-tokens-to-particles.js');
+let FallbackFate = require('./strategies/fallback-fate.js');
 
 const Speculator = require('./speculator.js');
 const Description = require('./description.js');
@@ -45,8 +46,8 @@ class CreateViews extends Strategy {
             score = 0;
         }
 
-        if (!view.id && view._fate == "?") {
-          return (recipe, view) => {view._fate = "create"; return score}
+        if (!view.id && view.fate == "?") {
+          return (recipe, view) => {view.fate = "create"; return score}
         }
       }
     }(RecipeWalker.Permuted), this);
@@ -64,6 +65,7 @@ class Planner {
       new InitPopulation(arc),
       new InitSearch(arc),
       new SearchTokensToParticles(arc),
+      new FallbackFate(),
       new CreateViews(),
       new AssignViewsByTagAndType(arc),
       new ConvertConstraintsToConnections(arc),

--- a/runtime/recipe/search.js
+++ b/runtime/recipe/search.js
@@ -39,10 +39,10 @@ class Search {
   get unresolvedTokens() { return this._unresolvedTokens; }
   get resolvedTokens() { return this._resolvedTokens; }
   resolveToken(token) {
-    let index = this.unresolvedTokens.indexOf(token);
+    let index = this.unresolvedTokens.indexOf(token.toLowerCase());
     assert(index >= 0, `Cannot resolved nonexistent token ${token}`);
     this._unresolvedTokens.splice(index, 1);
-    this._resolvedTokens.push(token);
+    this._resolvedTokens.push(token.toLowerCase());
   }
 
   isValid() {

--- a/runtime/recipe/search.js
+++ b/runtime/recipe/search.js
@@ -80,7 +80,7 @@ class Search {
     result.push(`search \`${this.phrase}\``);
 
     let tokenStr = [];
-    tokenStr.push('tokens');
+    tokenStr.push('  tokens');
     if (this.unresolvedTokens.length > 0) {
       tokenStr.push(this.unresolvedTokens.map(t => `\`${t}\``).join(" "));
     }

--- a/runtime/recipe/view-connection.js
+++ b/runtime/recipe/view-connection.js
@@ -70,6 +70,12 @@ class ViewConnection {
     return this._rawType;
   }
   get direction() { return this._direction; } // in/out
+  get isInput() {
+    return this.direction == "in" || this.direction == "inout";
+  }
+  get isOutput() {
+    return this.direction == "out" || this.direction == "inout";
+  }
   get view() { return this._view; } // View?
   get particle() { return this._particle; } // never null
 

--- a/runtime/recipe/view.js
+++ b/runtime/recipe/view.js
@@ -18,6 +18,8 @@ class View {
     this._tags = [];
     this._type = undefined;
     this._fate = null;
+    // TODO: replace originalFate with more generic mechanism for tracking
+    // how and from what the recipe was generated.
     this._originalFate = null;
     this._connections = [];
     this._mappedType = undefined;

--- a/runtime/recipe/view.js
+++ b/runtime/recipe/view.js
@@ -17,14 +17,15 @@ class View {
     this._localName = undefined;
     this._tags = [];
     this._type = undefined;
-    this._fate = "?";
+    this._fate = null;
+    this._originalFate = null;
     this._connections = [];
     this._mappedType = undefined;
   }
 
   _copyInto(recipe) {
     var view = undefined;
-    if (this._id !== null && ['map', 'use', 'copy'].includes(this._fate))
+    if (this._id !== null && ['map', 'use', 'copy'].includes(this.fate))
       view = recipe.findView(this._id);
 
     if (view == undefined) {
@@ -33,6 +34,7 @@ class View {
       view._tags = [...this._tags];
       view._type = this._type;
       view._fate = this._fate;
+      view._originalFate = this._originalFate;
       view._mappedType = this._mappedType;
 
       // the connections are re-established when Particles clone their
@@ -62,13 +64,19 @@ class View {
     if ((cmp = util.compareStrings(this._localName, other._localName)) != 0) return cmp;
     if ((cmp = util.compareArrays(this._tags, other._tags, util.compareStrings)) != 0) return cmp;
     // TODO: type?
-    if ((cmp = util.compareStrings(this._fate, other._fate)) != 0) return cmp;
+    if ((cmp = util.compareStrings(this.fate, other.fate)) != 0) return cmp;
     return 0;
   }
 
   // a resolved View has either an id or create=true
-  get fate() { return this._fate; }
-  set fate(fate) { this._fate = fate; }
+  get fate() { return this._fate || "?"; }
+  set fate(fate) {
+    if (!this._originalFate) {
+      this._originalFate = this._fate;
+    }
+    this._fate = fate;
+  }
+  get originalFate() { return this._originalFate || "?"; }
   get recipe() { return this._recipe; }
   get tags() { return this._tags; } // only tags owned by the view
   set tags(tags) { this._tags = tags; }
@@ -115,7 +123,7 @@ class View {
       }
       return false;
     }
-    switch (this._fate) {
+    switch (this.fate) {
       case "?": {
         if (options) {
           options.details = "missing fate";
@@ -134,9 +142,9 @@ class View {
         return true;
       default: {
         if (options) {
-          options.details = `invalid fate ${this._fate}`;
+          options.details = `invalid fate ${this.fate}`;
         }
-        assert(false, `Unexpected fate: ${this._fate}`);
+        assert(false, `Unexpected fate: ${this.fate}`);
       }
     }
   }
@@ -144,7 +152,7 @@ class View {
   toString(nameMap, options) {
     // TODO: type? maybe output in a comment
     let result = [];
-    result.push(this._fate);
+    result.push(this.fate);
     if (this.id) {
       result.push(`'${this.id}'`);
     }

--- a/runtime/strategies/convert-constraints-to-connections.js
+++ b/runtime/strategies/convert-constraints-to-connections.js
@@ -68,6 +68,7 @@ class ConvertConstraintsToConnections extends Strategy {
                 var recipeView = recipeMap[view];
                 if (recipeView == null) {
                   recipeView = recipe.newView();
+                  recipeView.fate = 'create';
                   recipeMap[view] = recipeView;
                 }
                 if (recipeViewConnection.view == null)

--- a/runtime/strategies/fallback-fate.js
+++ b/runtime/strategies/fallback-fate.js
@@ -18,8 +18,8 @@ class FallbackFate extends Strategy {
     let terminal = strategizer.terminal;
     var results = Recipe.over([...generated, ...terminal], new class extends RecipeWalker {
       onView(recipe, view) {
-        // Only apply this strategy to user query based recipes.
-        if (!recipe.search) {
+        // Only apply this strategy only to user query based recipes with resolved tokens.
+        if (!recipe.search || (recipe.search.resolvedTokens.length == 0)) {
           return;
         }
 
@@ -28,9 +28,14 @@ class FallbackFate extends Strategy {
           return;
         }
 
+        let hasOutConns = view.connections.some(vc => vc.isOutput);
+        let newFate = hasOutConns ? "copy" : "map";
+        if (view.fate == newFate) {
+          return;
+        }
+
         return (recipe, clonedView) => {
-          let hasOutConns = clonedView.connections.some(vc => vc.isOutput);
-          clonedView.fate = hasOutConns ? "copy" : "map";
+          clonedView.fate = newFate;
           return 0;
         };
       }

--- a/runtime/strategies/fallback-fate.js
+++ b/runtime/strategies/fallback-fate.js
@@ -1,0 +1,43 @@
+
+// Copyright (c) 2017 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+let assert = require('assert');
+let {Strategy} = require('../../strategizer/strategizer.js');
+let Recipe = require('../recipe/recipe.js');
+let RecipeWalker = require('../recipe/walker.js');
+
+class FallbackFate extends Strategy {
+  async generate(strategizer) {
+    assert(strategizer);
+    let generated = strategizer.generated.filter(result => !result.result.isResolved());
+    let terminal = strategizer.terminal;
+    var results = Recipe.over([...generated, ...terminal], new class extends RecipeWalker {
+      onView(recipe, view) {
+        // Only apply this strategy to user query based recipes.
+        if (!recipe.search) {
+          return;
+        }
+
+        // Only apply to views whose fate is set, but wasn't explicitly defined in the recipe.
+        if (view.isResolved() || view.fate == "?" || view.originalFate != "?") {
+          return;
+        }
+
+        return (recipe, clonedView) => {
+          let hasOutConns = clonedView.connections.some(vc => vc.isOutput);
+          clonedView.fate = hasOutConns ? "copy" : "map";
+          return 0;
+        };
+      }
+    }(RecipeWalker.Permuted), this);
+
+    return { results, generate: null };
+  }
+}
+
+module.exports = FallbackFate;

--- a/runtime/test/manifest-test.js
+++ b/runtime/test/manifest-test.js
@@ -37,8 +37,8 @@ describe('manifest', function() {
       assert(recipe);
       assert.equal(recipe.particles.length, 1);
       assert.equal(recipe.views.length, 2);
-      assert.equal(recipe.views[0]._fate, "map");
-      assert.equal(recipe.views[1]._fate, "create");
+      assert.equal(recipe.views[0].fate, "map");
+      assert.equal(recipe.views[1].fate, "create");
       assert.equal(recipe.viewConnections.length, 1);
       assert.sameMembers(recipe.viewConnections[0].tags, ['#tag']);
     };
@@ -573,7 +573,7 @@ Expected " ", "#", "\\n", "\\r", [ ] or [A-Z] but "?" found.
     assert.isFalse(recipe.isResolved());
     assert.equal(recipe.toString(), `recipe
   search \`Hello dear world\`
-  tokens \`dear\` \`hello\` \`world\``);
+    tokens \`dear\` \`hello\` \`world\``);
 
     recipe = (await Manifest.parse(manifestSource)).recipes[0];
     // resolve some tokens.
@@ -584,7 +584,7 @@ Expected " ", "#", "\\n", "\\r", [ ] or [A-Z] but "?" found.
     assert.deepEqual(['hello', 'world'], recipe.search.resolvedTokens);
     assert.equal(recipe.toString(), `recipe
   search \`Hello dear world\`
-  tokens \`dear\` # \`hello\` \`world\``);
+    tokens \`dear\` # \`hello\` \`world\``);
 
     // resolve all tokens.
     recipe.search.resolveToken('dear');
@@ -596,7 +596,7 @@ Expected " ", "#", "\\n", "\\r", [ ] or [A-Z] but "?" found.
     assert.isTrue(recipe.isResolved());
     assert.equal(recipe.toString(), `recipe
   search \`Hello dear world\`
-  tokens # \`dear\` \`hello\` \`world\``);
+    tokens # \`dear\` \`hello\` \`world\``);
   });
   it('merge recipes with search strings', async () => {
     let recipe1 = (await Manifest.parse(`recipe

--- a/runtime/test/planner-tests.js
+++ b/runtime/test/planner-tests.js
@@ -46,7 +46,7 @@ describe('Planner', function() {
     await planner.generate(),
     await planner.generate(),
     await planner.generate(),
-    assert.equal(planner.strategizer.population.length, 6);
+    assert.equal(planner.strategizer.population.length, 5);
   });
 
   it('make a plan with views', async () => {
@@ -61,7 +61,7 @@ describe('Planner', function() {
     await planner.generate(),
     await planner.generate(),
     await planner.generate(),
-    assert.equal(planner.strategizer.population.length, 6);
+    assert.equal(planner.strategizer.population.length, 5);
   });
 });
 
@@ -119,7 +119,7 @@ describe('ConvertConstraintsToConnections', async() => {
     let { result, score } = results[0];
     assert.deepEqual(result.toString(),
 `recipe
-  ? as view0
+  create as view0
   A as particle0
     b = view0
   C as particle1
@@ -141,7 +141,7 @@ describe('ConvertConstraintsToConnections', async() => {
     let { result, score } = results[0];
     assert.deepEqual(result.toString(),
 `recipe
-  ? as view0
+  create as view0
   A as particle0
     b = view0
   C as particle1
@@ -163,7 +163,7 @@ describe('ConvertConstraintsToConnections', async() => {
     let { result, score } = results[0];
     assert.deepEqual(result.toString(),
 `recipe
-  ? as view0
+  create as view0
   A as particle0
     b = view0
   C as particle1
@@ -187,7 +187,7 @@ describe('ConvertConstraintsToConnections', async() => {
     let { result, score } = results[0];
     assert.deepEqual(result.toString(),
 `recipe
-  ? as view0
+  create as view0
   A as particle0
     b = view0
   C as particle1
@@ -588,7 +588,7 @@ describe('FallbackFate', function() {
         DoSomething(in Thing inthing, out Thing outthing)
 
       recipe
-        search \`DoSomething\`
+        search \`DoSomething DoSomethingElse\`
         use as view0
         use as view1
         DoSomething as particle0
@@ -600,10 +600,15 @@ describe('FallbackFate', function() {
     assert(recipe.normalize());
     var arc = createTestArc("test-plan-arc", manifest, "dom");
     var strategizer = {generated: [{result: manifest.recipes[0], score: 1}], terminal: []};
+    var strategy = new FallbackFate(arc);
 
-    var ff = new FallbackFate(arc);
-    let { results } = await ff.generate(strategizer);
+    // no resolved search tokens.
+    let { results } = await strategy.generate(strategizer);
+    assert.equal(results.length, 0);
 
+    // Resolved a search token and rerun strategy.
+    recipe.search.resolveToken('DoSomething');
+    results = (await strategy.generate(strategizer)).results;
     assert.equal(results.length, 1);
     let plan = results[0].result;
     assert.equal(plan.views.length, 2);
@@ -631,8 +636,8 @@ describe('FallbackFate', function() {
     var arc = createTestArc("test-plan-arc", manifest, "dom");
     var strategizer = {generated: [{result: manifest.recipes[0], score: 1}], terminal: []};
 
-    var ff = new FallbackFate(arc);
-    let { results } = await ff.generate(strategizer);
+    var strategy = new FallbackFate(arc);
+    let { results } = await strategy.generate(strategizer);
     assert.equal(results.length, 0);
   });
 });


### PR DESCRIPTION
Like we discussed yesterday, for recipes produced from user queries, the strategy fallbacks to either "map" or "copy" (depending on the direction), in case the "use" fate cannot be resolved.

I added the originalFate to the view, but I'm not sure this is needed - for now all particles added based on user query will always have views with undefined fates. but knowing the original fate should still be useful, i think. shall i keep this part or revert it?

I ran it with together with the strategy from the other PR, and it works well-ish. We still have the problem of views that are created, instead of being mapped, let's discuss it next week. 