### PR TITLE
default views to [] instead of undefined

### DIFF
--- a/runtime/manifest.js
+++ b/runtime/manifest.js
@@ -61,7 +61,7 @@ class Manifest {
       view = new Variable(type, this, name, id);
     }
     this._views.push(view);
-    this._viewTags.set(view, tags);
+    this._viewTags.set(view, tags ? tags : []);
     return view;
   }
   _find(manifestFinder) {


### PR DESCRIPTION
I ran into an issue where we were setting tags on a view to undefined instead of []. This caused findViewsByType to blow up (manifest._viewTags.get(view).includes was undefined).

I'm not sure this is the right spot, though. Checking on use might be better, or checking before we write (although bad data has a tendency to sneak into any system, so I'm not sure that's foolproof). I chose the constructor as a fair place to filter out data that the rest of this class might find surprising.