### PR TITLE
Manifest to support recursive serialization

### DIFF
--- a/runtime/manifest.js
+++ b/runtime/manifest.js
@@ -482,10 +482,17 @@ ${e.message}
 
   toString(options) {
     // TODO: sort?
-    let results = []
+    options = options || {};
+    let results = [];
 
     this._imports.forEach(i => {
-      results.push(`import '${i.fileName}'`);
+      if (options.recursive) {
+        results.push(`# import '${i.fileName}'`);
+        let importStr = i.toString(options);
+        results.push(`${i.toString(options)}`);
+      } else {
+        results.push(`import '${i.fileName}'`);
+      }
     });
 
     Object.values(this._schemas).forEach(s => {


### PR DESCRIPTION
This is helpful to see all the manifests in the arc's context in the console. I talked to Scott earlier today about making a UI for it in the "manifests" tab, but until it's in place (or even there) - i think this is useful.