### PR TITLE
Incorporate the frontend search in planner

### DIFF
--- a/runtime/arc.js
+++ b/runtime/arc.js
@@ -55,7 +55,14 @@ class Arc {
     // Map from each view to a list of tags.
     this._viewTags = new Map();
 
-    this.availableSlotIds = new Set();
+    this._search = null;
+  }
+  set search(search) {
+    this._search = search ? search.toLowerCase().trim() : null;
+  }
+
+  get search() {
+    return this._search;
   }
 
   static deserialize({serialization, pecFactory, slotComposer, arcMap}) {

--- a/runtime/planner.js
+++ b/runtime/planner.js
@@ -154,6 +154,22 @@ class Planner {
       // TODO: Move this logic inside speculate, so that it can stop the arc
       // before returning.
       relevance.newArc.stop();
+
+      // Filter plans based on arc._search string.
+      if (this._arc.search) {
+        if (!plan.search) {
+          // This plan wasn't constructed based on the provided search terms.
+          if (description.toLowerCase().indexOf(arc.search) < 0) {
+            // Description must contain the full search string.
+            // TODO: this could be a strategy, if description was already available during strategies execution.
+            continue;
+          }
+        } else {
+          // This mean the plan was constructed based on provided search terms,
+          // and at least one of them were resolved (in order for the plan to be resolved).
+        }
+      }
+
       results.push({
         plan,
         rank,

--- a/runtime/strategies/init-search.js
+++ b/runtime/strategies/init-search.js
@@ -13,7 +13,7 @@ module.exports = class InitSearch extends Strategy {
   constructor(arc) {
     super();
     // TODO: Figure out where this should really come from.
-    this._search = arc._search;
+    this._search = arc.search;
   }
   async generate(strategizer) {
     if (this._search == null || strategizer.generation != 0) {


### PR DESCRIPTION
Scott and I discussed this offline.
We agreed that the search input change will trigger a throttled request to planner to generate new suggestions.
The planner will be responsible for both - the "backend" (search token - to particles etc) and "frontend" (description text matching) searches.

PS: ideally this could be a strategy too, but that is blocked by speculative execution being a strategy first.