### PR TITLE
Allow manifests to be built from a string substitution tag function

### DIFF
--- a/runtime/api-channel.js
+++ b/runtime/api-channel.js
@@ -254,7 +254,7 @@ class PECOuterPort extends APIPort {
     this.registerCall("ConstructArcCallback", {callback: this.Direct, arc: this.LocalMapped});
 
     this.registerHandler("ArcCreateView", {callback: this.Direct, arc: this.LocalMapped, viewType: this.ByLiteral(Type), name: this.Direct});
-    this.registerInitializer("CreateViewCallback", {callback: this.Direct, viewType: this.Direct, name: this.Direct, id: this.Direct});
+    this.registerInitializer("CreateViewCallback", {callback: this.Direct, viewType: this.ByLiteral(Type), name: this.Direct, id: this.Direct});
 
     this.registerHandler("ArcLoadRecipe", {arc: this.LocalMapped, recipe: this.Direct, callback: this.Direct});
   }
@@ -294,7 +294,7 @@ class PECInnerPort extends APIPort {
     this.registerHandler("ConstructArcCallback", {callback: this.LocalMapped, arc: this.Direct});
 
     this.registerCall("ArcCreateView", {callback: this.LocalMapped, arc: this.Direct, viewType: this.ByLiteral(Type), name: this.Direct});
-    this.registerInitializerHandler("CreateViewCallback", {callback: this.LocalMapped, viewType: this.Direct, name: this.Direct, id: this.Direct});
+    this.registerInitializerHandler("CreateViewCallback", {callback: this.LocalMapped, viewType: this.ByLiteral(Type), name: this.Direct, id: this.Direct});
 
     this.registerCall("ArcLoadRecipe", {arc: this.Direct, recipe: this.Direct, callback: this.LocalMapped});
   }

--- a/runtime/api-channel.js
+++ b/runtime/api-channel.js
@@ -153,7 +153,13 @@ class APIPort {
     this.messageCount++;
 
     let handler = this._messageMap.get(e.data.messageType);
-    let args = this._unprocessArguments(handler.args, e.data.messageBody);
+    let args;
+    try {
+      args = this._unprocessArguments(handler.args, e.data.messageBody);
+    } catch (exc) {
+      console.error(`Exception during unmarshaling for ${e.data.messageType}`);
+      throw exc;
+    }
     // If any of the converted arguments are still pending promises
     // wait for them to complete before processing the message.
     for (let arg of Object.values(args)) {
@@ -228,7 +234,7 @@ class PECOuterPort extends APIPort {
     this.registerCall("Stop", {});
     this.registerCall("DefineParticle",
       {particleDefinition: this.Direct, particleFunction: this.Stringify});
-    this.registerRedundantInitializer("DefineView", {viewType: this.Direct, name: this.Direct})
+    this.registerRedundantInitializer("DefineView", {viewType: this.ByLiteral(Type), name: this.Direct})
     this.registerInitializer("InstantiateParticle",
       {spec: this.ByLiteral(ParticleSpec), views: this.Map(this.Direct, this.Mapped)});
 
@@ -268,7 +274,7 @@ class PECInnerPort extends APIPort {
     // particleFunction needs to be eval'd in context or it won't work.
     this.registerHandler("DefineParticle",
       {particleDefinition: this.Direct, particleFunction: this.Direct});
-    this.registerInitializerHandler("DefineView", {viewType: this.Direct, name: this.Direct});
+    this.registerInitializerHandler("DefineView", {viewType: this.ByLiteral(Type), name: this.Direct});
     this.registerInitializerHandler("InstantiateParticle",
       {spec: this.ByLiteral(ParticleSpec), views: this.Map(this.Direct, this.Mapped)});
 

--- a/runtime/entity.js
+++ b/runtime/entity.js
@@ -9,7 +9,6 @@
 
 const assert = require('assert');
 const Symbols = require('./symbols.js');
-const Type = require('./type.js');
 
 class Entity {
   constructor() {
@@ -42,3 +41,5 @@ class Entity {
 }
 
 module.exports = Entity;
+
+const Type = require('./type.js');

--- a/runtime/inner-PEC.js
+++ b/runtime/inner-PEC.js
@@ -101,7 +101,7 @@ class InnerPEC {
     };
 
     this._apiPort.onCreateViewCallback = ({viewType, identifier, id, name, callback}) => {
-      var view = new RemoteView(id, Type.fromLiteral(viewType), this._apiPort, this, name, 0);
+      var view = new RemoteView(id, viewType, this._apiPort, this, name, 0);
       Promise.resolve().then(() => callback(view));
       return view;
     }
@@ -196,7 +196,7 @@ class InnerPEC {
         return new Promise((resolve, reject) =>
           pec._apiPort.ArcCreateView({arc: arcId, viewType, name, callback: view => {
             var v = viewlet.viewletFor(view, view.type.isView, true, true);
-            v.entityClass = new Schema(view.type.isView ? view.type.primitiveType().entitySchema : view.type.entitySchema).entityClass();
+            v.entityClass = (view.type.isView ? view.type.primitiveType().entitySchema : view.type.entitySchema).entityClass();
             resolve(v);
           }}));
       },
@@ -246,7 +246,7 @@ class InnerPEC {
         schemaModel = type.entitySchema;
       }
       if (schemaModel)
-        view.entityClass = new Schema(schemaModel).entityClass();
+        view.entityClass = schemaModel.entityClass();
     }
 
     return [particle, () => {

--- a/runtime/inner-PEC.js
+++ b/runtime/inner-PEC.js
@@ -97,7 +97,7 @@ class InnerPEC {
      * only keeping type information on the arc side.
      */
     this._apiPort.onDefineView = ({viewType, identifier, name, version}) => {
-      return new RemoteView(identifier, Type.fromLiteral(viewType), this._apiPort, this, name, version);
+      return new RemoteView(identifier, viewType, this._apiPort, this, name, version);
     };
 
     this._apiPort.onCreateViewCallback = ({viewType, identifier, id, name, callback}) => {
@@ -245,6 +245,7 @@ class InnerPEC {
       } else if (type.isEntity) {
         schemaModel = type.entitySchema;
       }
+
       if (schemaModel)
         view.entityClass = schemaModel.entityClass();
     }

--- a/runtime/outer-PEC.js
+++ b/runtime/outer-PEC.js
@@ -122,7 +122,7 @@ class OuterPEC extends PEC {
   instantiate(particleSpec, spec, views, lastSeenVersion) {
     views.forEach(view => {
       var version = lastSeenVersion.get(view.id) || 0;
-      this._apiPort.DefineView(view, { viewType: view.type.toLiteral(), name: view.name,
+      this._apiPort.DefineView(view, { viewType: view.type, name: view.name,
                                        version });
     });
 

--- a/runtime/particle-spec.js
+++ b/runtime/particle-spec.js
@@ -162,6 +162,10 @@ class ParticleSpec {
     }
     return results.join('\n');
   }
+
+  toManifestString() {
+    return this.toString();
+  }
 }
 
 module.exports = ParticleSpec;

--- a/runtime/particle.js
+++ b/runtime/particle.js
@@ -156,6 +156,24 @@ class Particle {
     assert(slot, `Particle::fireEvent: slot ${slotName} is falsey`);
     slot.fireEvent(event);
   }
+
+  static buildManifest(strings, ...bits) {
+    let output = [];
+    for (let i = 0; i < bits.length; i++) {
+        let str = strings[i];
+        let indent = / *$/.exec(str)[0];
+        if (typeof bits[i] == 'string')
+          var bitStr = bits[i];
+        else
+          var bitStr = bits[i].toManifestString();
+        bitStr = bitStr.replace(/(\n)/g, '$1' + indent);
+        output.push(str);
+        output.push(bitStr);
+    }
+    if (strings.length > bits.length)
+      output.push(strings[strings.length - 1]);
+    return output.join('');
+  }
 }
 
 class ViewChanges {

--- a/runtime/recipe/type-checker.js
+++ b/runtime/recipe/type-checker.js
@@ -67,7 +67,7 @@ class TypeChecker {
     function checkSuper(schema) {
       if (!schema)
         return false;
-      if (schema == supertype.entitySchema)
+      if (schema.equals(supertype.entitySchema))
         return true;
       for (let parent of schema.parents)
         if (checkSuper(parent))

--- a/runtime/schema.js
+++ b/runtime/schema.js
@@ -18,7 +18,7 @@ class Schema {
     this._normative = {};
     this._optional = {};
 
-    assert(model.sections);
+    assert(model.sections, `${JSON.stringify(model)} should have sections`);
     for (var section of model.sections) {
       var into = section.sectionType == 'normative' ? this._normative : this._optional;
       for (var field in section.fields) {
@@ -36,8 +36,12 @@ class Schema {
     return new Schema(data);
   }
 
+  equals(otherSchema) {
+    return this.toLiteral() == otherSchema.toLiteral();
+  }
+
   get type() {
-    return Type.newEntity(this.toLiteral());
+    return Type.newEntity(this);
   }
 
   get normative() {

--- a/runtime/schema.js
+++ b/runtime/schema.js
@@ -8,9 +8,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-const Entity = require("./entity.js");
 const assert = require('assert');
-const Type = require('./type.js');
 
 class Schema {
   constructor(model) {
@@ -19,6 +17,7 @@ class Schema {
     this.parents = (model.parents || []).map(parent => new Schema(parent));
     this._normative = {};
     this._optional = {};
+
     assert(model.sections);
     for (var section of model.sections) {
       var into = section.sectionType == 'normative' ? this._normative : this._optional;
@@ -31,6 +30,10 @@ class Schema {
 
   toLiteral() {
     return this._model;
+  }
+
+  static fromLiteral(data) {
+    return new Schema(data);
   }
 
   get type() {
@@ -143,6 +146,13 @@ class Schema {
     propertiesToString(this.optional, 'optional');
     return results.join('\n');
   }
+
+  toManifestString() {
+    return this.toString();
+  }
 }
 
 module.exports = Schema;
+
+const Type = require('./type.js');
+const Entity = require("./entity.js");

--- a/runtime/shape.js
+++ b/runtime/shape.js
@@ -19,6 +19,12 @@ function _fromLiteral(member) {
   return member;
 }
 
+function _toLiteral(member) {
+  if (member && member.toLiteral)
+    return member.toLiteral();
+  return member;
+}
+
 class Shape {
   constructor(views, slots) {
     this.views = views;
@@ -46,7 +52,9 @@ class Shape {
   }
 
   toLiteral() {
-    return {views: this.views, slots: this.slots};
+    let views = this.views.map(view => ({type: _toLiteral(view.type), name: _toLiteral(view.name), direction: _toLiteral(view.direction)}));
+    let slots = this.slots.map(slot => ({name: _toLiteral(slot.name), direction: _toLiteral(slot.direction)}));
+    return {views, slots};
   }
 
   clone() {

--- a/runtime/test/manifest-integration-test.js
+++ b/runtime/test/manifest-integration-test.js
@@ -39,7 +39,7 @@ describe('manifest integration', () => {
     assert(view);
     let viewlet = Viewlet.viewletFor(view);
     // TODO: This should not be necessary.
-    viewlet.entityClass = new Schema(type.entitySchema).entityClass();
+    viewlet.entityClass = type.entitySchema.entityClass();
     let result = await viewlet.get();
     assert.equal(result.value, 'Hello, world!');
   });

--- a/runtime/test/particle-shape-loading-test.js
+++ b/runtime/test/particle-shape-loading-test.js
@@ -40,24 +40,20 @@ describe('particle-shape-loading', function() {
                 let outView = await arc.createView(outputView.type, "output");
                 let particle = await views.get('particle').get();
 
-                var recipe = \`
-                  schema Foo
-                    optional
-                      Text value
-                  schema Bar
-                    optional
-                      Text value
+                var recipe = Particle.buildManifest\`
+                  \${inputView.type.entitySchema}
+                  \${outputView.type.entitySchema}
 
-                  particle \${particle.name} in '\${particle.implFile}'
-                    \${particle.name}(in Foo foo, out Bar bar)
+                  \${particle}
 
                   recipe
-                    use '\${inView._id}' as v1
-                    use '\${outView._id}' as v2
+                    use \${inView} as v1
+                    use \${outView} as v2
                     \${particle.name}
                       foo <- v1
                       bar -> v2
                 \`;
+
                 try {
                   await arc.loadRecipe(recipe);
                   var input = await inputView.get();

--- a/runtime/test/particle-shape-loading-test.js
+++ b/runtime/test/particle-shape-loading-test.js
@@ -84,8 +84,8 @@ describe('particle-shape-loading', function() {
 
     let manifest = await Manifest.load('../particles/test/test-particles.manifest', loader);
 
-    let fooType = Type.newEntity(manifest.schemas.Foo.toLiteral());
-    let barType = Type.newEntity(manifest.schemas.Bar.toLiteral());
+    let fooType = Type.newEntity(manifest.schemas.Foo);
+    let barType = Type.newEntity(manifest.schemas.Bar);
 
     let shape = new Shape([{type: fooType}, {type: barType}], []);
 

--- a/runtime/test/shape-test.js
+++ b/runtime/test/shape-test.js
@@ -67,7 +67,7 @@ describe('shape', function() {
         particle S
           S(in NotTest bar, out Test far, out NotTest foo)
       `);
-      let type = Type.newEntity(manifest.schemas.Test.toLiteral());
+      let type = Type.newEntity(manifest.schemas.Test);
       var shape = new Shape([{name: 'foo'}, {direction: 'in'}, {type}], []);
       assert(!shape._particleMatches(manifest.particles[0]));
       assert(shape._particleMatches(manifest.particles[1]));

--- a/runtime/test/view-test.js
+++ b/runtime/test/view-test.js
@@ -50,8 +50,8 @@ describe('View', function() {
     let arc = new Arc({slotComposer});
     let manifest = await Manifest.load('../particles/test/test-particles.manifest', loader);
 
-    let shape = new Shape([{type: Type.newEntity(manifest.schemas.Foo.toLiteral())},
-                           {type: Type.newEntity(manifest.schemas.Bar.toLiteral())}], []);
+    let shape = new Shape([{type: Type.newEntity(manifest.schemas.Foo)},
+                           {type: Type.newEntity(manifest.schemas.Bar)}], []);
     assert(shape._particleMatches(manifest.particles[0]));
 
     let shapeView = arc.createView(Type.newShape(shape));

--- a/runtime/type.js
+++ b/runtime/type.js
@@ -135,6 +135,8 @@ class Type {
     let data = literal.data;
     if (literal.tag == 'shape')
       data = {shape: Shape.fromLiteral(data.shape)};
+    else if (literal.tag == 'entity')
+      data = Schema.fromLiteral(data);
     return new Type(literal.tag, data);
   }
 
@@ -194,3 +196,4 @@ addType('Shape', 'shape', ['shape', 'disambiguation'])
 module.exports = Type;
 
 const Shape = require('./shape.js');
+const Schema = require('./schema.js');

--- a/runtime/viewlet.js
+++ b/runtime/viewlet.js
@@ -15,6 +15,7 @@ const Symbols = require('./symbols.js');
 const underlyingView = require('./view.js');
 let identifier = Symbols.identifier;
 const assert = require("assert");
+const ParticleSpec = require("./particle-spec.js");
 
 // TODO: This won't be needed once runtime is transferred between contexts.
 function cloneData(data) {
@@ -88,6 +89,10 @@ class Viewlet {
 
   get _id() {
     return this._view._id;
+  }
+
+  toManifestString() {
+    return `'${this._id}'`;
   }
 }
 
@@ -172,6 +177,8 @@ class Variable extends Viewlet {
       return undefined;
     if (this.type.isEntity)
       return this._restore(result);
+    if (this.type.isShape)
+      return ParticleSpec.fromLiteral(result);
     return result;
   }
 


### PR DESCRIPTION
Note that there's a likely **breaking change** in this patch: Entity Type objects now require Schemas (rather than serialized schemas) to be constructed.

Generally this just means changing ```Type.newEntity(thing.toLiteral())``` to ```Type.newEntity(thing)```