### PR TITLE
Type rationalization

### DIFF
--- a/runtime/arc.js
+++ b/runtime/arc.js
@@ -234,9 +234,9 @@ class Arc {
     tags = tags || [];
     assert(type instanceof Type, `can't createView with type ${type} that isn't a Type`);
     if (type.isRelation)
-      type = Type.newView(type);
+      type = Type.newSetView(type);
     let view;
-    if (type.isView) {
+    if (type.isSetView) {
       view = new View(type, this, name, id);
     } else {
       assert(type.isEntity || type.isInterface, `Expected entity or interface type, but... ${JSON.stringify(type.toLiteral())}`);
@@ -265,7 +265,7 @@ class Arc {
   // TODO: Don't use this, we should be testing the schemas for compatiblity
   //       instead of using just the name.
   static _viewKey(type) {
-    if (type.isView) {
+    if (type.isSetView) {
       return `list:${type.primitiveType().entitySchema.name}`;
     } else if (type.isEntity) {
       return type.entitySchema.name;
@@ -306,11 +306,11 @@ class Arc {
   commit(entities) {
     let entityMap = new Map();
     for (let entity of entities) {
-      entityMap.set(entity, this._viewFor(Type.newView(entity.constructor.type)));
+      entityMap.set(entity, this._viewFor(Type.newSetView(entity.constructor.type)));
     }
     for (let entity of entities) {
       if (entity instanceof Relation) {
-        entity.entities.forEach(entity => entityMap.set(entity, this._viewFor(Type.newView(entity.constructor.type))));
+        entity.entities.forEach(entity => entityMap.set(entity, this._viewFor(Type.newSetView(entity.constructor.type))));
       }
     }
     this.newCommit(entityMap);

--- a/runtime/arc.js
+++ b/runtime/arc.js
@@ -239,7 +239,7 @@ class Arc {
     if (type.isView) {
       view = new View(type, this, name, id);
     } else {
-      assert(type.isEntity || type.isShape, `Expected entity or shape type, but... ${JSON.stringify(type.toLiteral())}`);
+      assert(type.isEntity || type.isInterface, `Expected entity or interface type, but... ${JSON.stringify(type.toLiteral())}`);
       view = new Variable(type, this, name, id);
     }
     this._registerView(view, tags);

--- a/runtime/browser/particle-ui-tester/particle-ui-tester.js
+++ b/runtime/browser/particle-ui-tester/particle-ui-tester.js
@@ -32,8 +32,8 @@ function prepareExtensionArc() {
   let slotComposer = new SlotComposer({rootContext: particleRoot, affordance: 'mock'});
   let arc = new Arc({id: 'demo', pecFactory, slotComposer});
   //
-  arc.createView(Person.type.viewOf(), "peopleFromWebpage");
-  arc.createView(Product.type.viewOf(), "productsFromWebpage");
+  arc.createView(Person.type.setViewOf(), "peopleFromWebpage");
+  arc.createView(Product.type.setViewOf(), "productsFromWebpage");
   arc.createView(Person.type, "personSlot");
   arc.commit([
     new Person({name: "Claire"}),

--- a/runtime/browser/test/test.js
+++ b/runtime/browser/test/test.js
@@ -24,8 +24,8 @@ function prepareExtensionArc() {
   var domRoot = global.document ? document.querySelector('[particle-container]') || document.body : {};
   var slotComposer = new SlotComposer({rootContext: domRoot, affordance: 'mock'});
   var arc = new Arc({pecFactory, slotComposer});
-  var personView = arc.createView(Person.type.viewOf(), "peopleFromWebpage");
-  var productView = arc.createView(Product.type.viewOf(), "productsFromWebpage");
+  var personView = arc.createView(Person.type.setViewOf(), "peopleFromWebpage");
+  var productView = arc.createView(Product.type.setViewOf(), "productsFromWebpage");
   var personSlot = arc.createView(Person.type, "personSlot");
   arc.commit([new Person({name: "Claire"}), new Product({name: "Tea Pot"}), new Product({name: "Bee Hive"}),
               new Product({name: "Denim Jeans"})]);

--- a/runtime/description.js
+++ b/runtime/description.js
@@ -160,7 +160,7 @@ class ValueToken {
       // Use view values (eg "How to draw book, Hockey stick")
       result.push(this._formatViewValue(view));
     } else if (view && this._property && this._property.length > 0) {
-      assert(!view.type.isView, `Cannot return property ${this._property.join(",")} for set-view`);
+      assert(!view.type.isSetView, `Cannot return property ${this._property.join(",")} for set-view`);
       // Use singleton value's property (eg. "09/15" for person's birthday)
       let viewVar = view.get();
       if (viewVar) {
@@ -203,7 +203,7 @@ class ValueToken {
       if (options.includeViewValues !== false && !this._excludeValues && view) {
         let viewValues = this._formatViewValue(view);
         if (viewValues) {
-          if (!view.type.isView && !chosenConnectionSpec.description.hasPattern()) {
+          if (!view.type.isSetView && !chosenConnectionSpec.description.hasPattern()) {
             // For singleton view, if there is no real description (the type was used), use the plain value for description.
             result = [];
             result.push(`${viewValues}`);
@@ -226,7 +226,7 @@ class ValueToken {
     if (!view) {
       return;
     }
-    if (view.type.isView) {
+    if (view.type.isSetView) {
       let viewList = view.toList();
       if (viewList && viewList.length > 0) {
         if (viewList[0].rawData.name) {

--- a/runtime/inner-PEC.js
+++ b/runtime/inner-PEC.js
@@ -195,8 +195,8 @@ class InnerPEC {
       createView: function(viewType, name) {
         return new Promise((resolve, reject) =>
           pec._apiPort.ArcCreateView({arc: arcId, viewType, name, callback: view => {
-            var v = viewlet.viewletFor(view, view.type.isView, true, true);
-            v.entityClass = (view.type.isView ? view.type.primitiveType().entitySchema : view.type.entitySchema).entityClass();
+            var v = viewlet.viewletFor(view, view.type.isSetView, true, true);
+            v.entityClass = (view.type.isSetView ? view.type.primitiveType().entitySchema : view.type.entitySchema).entityClass();
             resolve(v);
           }}));
       },
@@ -234,13 +234,13 @@ class InnerPEC {
 
     var viewMap = new Map();
     views.forEach((value, key) => {
-      viewMap.set(key, viewlet.viewletFor(value, value.type.isView, spec.connectionMap.get(key).isInput, spec.connectionMap.get(key).isOutput));
+      viewMap.set(key, viewlet.viewletFor(value, value.type.isSetView, spec.connectionMap.get(key).isInput, spec.connectionMap.get(key).isOutput));
     });
 
     for (var view of viewMap.values()) {
       var type = view.underlyingView().type;
       let schemaModel;
-      if (type.isView && type.primitiveType().isEntity) {
+      if (type.isSetView && type.primitiveType().isEntity) {
         schemaModel = type.primitiveType().entitySchema;
       } else if (type.isEntity) {
         schemaModel = type.entitySchema;

--- a/runtime/manifest.js
+++ b/runtime/manifest.js
@@ -58,7 +58,7 @@ class Manifest {
   // TODO: simplify() / isValid().
   newView(type, name, id, tags) {
     let view;
-    if (type.isView) {
+    if (type.isSetView) {
       view = new View(type, this, name, id);
     } else {
       view = new Variable(type, this, name, id);
@@ -248,7 +248,7 @@ ${e.message}
       case 'reference-type':
         return Type.newManifestReference(typeItem.name);
       case 'list-type':
-        return Type.newView(Manifest._processType(typeItem.type));
+        return Type.newSetView(Manifest._processType(typeItem.type));
       default:
         throw `Unexpected type item of kind '${typeItem.kind}'`;
     }
@@ -517,7 +517,7 @@ ${e.message}
     for (let entity of entities) {
       let id = entity.$id || manifest.generateID();
       delete entity.$id;
-      if (type.isView) {
+      if (type.isSetView) {
         view.store({
           id,
           rawData: entity,

--- a/runtime/recipe/type-checker.js
+++ b/runtime/recipe/type-checker.js
@@ -32,7 +32,7 @@ class TypeChecker {
     var leftType = left.type;
     var rightType = right.type;
 
-    while (leftType.isView && rightType.isView) {
+    while (leftType.isSetView && rightType.isSetView) {
       leftType = leftType.primitiveType();
       rightType = rightType.primitiveType();
     }
@@ -45,10 +45,10 @@ class TypeChecker {
 
     // TODO: direction?
     if (leftType.isVariable) {
-      leftType.variableVariable.resolution = rightType;
+      leftType.variable.resolution = rightType;
       var type = right;
     } else if (rightType.isVariable) {
-      rightType.variableVariable.resolution = leftType;
+      rightType.variable.resolution = leftType;
       var type = left;
     } else {
       return null;
@@ -59,7 +59,7 @@ class TypeChecker {
   static isSubclass(subclass, superclass) {
     var subtype = subclass.type;
     var supertype = superclass.type;
-    while (subtype.isView && supertype.isView) {
+    while (subtype.isSetView && supertype.isSetView) {
       subtype = subtype.primitiveType();
       supertype = supertype.primitiveType();
     }
@@ -122,8 +122,8 @@ class TypeChecker {
   static substitute(type, variable, value) {
     if (type.equals(variable))
       return value;
-    if (type.isView)
-      return TypeChecker.substitute(type.primitiveType(), variable, value).viewOf();
+    if (type.isSetView)
+      return TypeChecker.substitute(type.primitiveType(), variable, value).setViewOf();
     return type;
   }
 }

--- a/runtime/test/data-layer-test.js
+++ b/runtime/test/data-layer-test.js
@@ -29,7 +29,7 @@ describe('entity', function() {
     assert.isDefined(entity);
     arc.commit([entity]);
 
-    let list = await arc.findViewsByType(entity.constructor.type.viewOf())[0].toList();
+    let list = await arc.findViewsByType(entity.constructor.type.setViewOf())[0].toList();
     let clone = list[0];
     assert.isDefined(clone);
     assert.deepEqual(clone.rawData, {value: 'hello world'});
@@ -43,7 +43,7 @@ describe.skip('relation', function() {
     let relation = new Relation(new BasicEntity('thing1'), new BasicEntity('thing2'));
     assert.isDefined(relation);
     arc.commit([relation]);
-    let clone = arc.findViewsByType(relation.constructor.type.viewOf())[0].toList()[0];
+    let clone = arc.findViewsByType(relation.constructor.type.setViewOf())[0].toList()[0];
     assert.isDefined(clone);
     assert.equal(clone.entities[0].data, 'thing1');
     assert.notEqual(relation, clone);

--- a/runtime/test/demo-flow-test.js
+++ b/runtime/test/demo-flow-test.js
@@ -89,10 +89,10 @@ describe('demo flow', function() {
 
     await slotComposer.expectationsCompleted();
 
-    let productViews = arc.findViewsByType(Product.type.viewOf());
+    let productViews = arc.findViewsByType(Product.type.setViewOf());
     assert.equal(productViews.length, 2);
 
-    //var giftView = arc.findViewsByType(Product.type.viewOf(), {tag: "giftlist"})[0];
+    //var giftView = arc.findViewsByType(Product.type.setViewOf(), {tag: "giftlist"})[0];
     //await testUtil.assertViewHas(giftView, Product, "name",
     //    ["Tea Pot", "Bee Hive", "Denim Jeans", "Arduino Starter Pack"]);
 
@@ -115,9 +115,9 @@ describe('demo flow', function() {
     //var newArc = Arc.deserialize({serialization, loader, slotComposer, arcMap});
     // await slotComposer.expectationsCompleted();
     //
-    // productViews = arc.findViewsByType(Product.type.viewOf());
+    // productViews = arc.findViewsByType(Product.type.setViewOf());
     //assert.equal(productViews.length, 5);
-    //var giftView = arc.findViewsByType(Product.type.viewOf(), {tag: "gift list"})[0];
+    //var giftView = arc.findViewsByType(Product.type.setViewOf(), {tag: "gift list"})[0];
     //await testUtil.assertViewHas(giftView, Product, "name",
     //    ["Tea Pot", "Bee Hive", "Denim Jeans", "Arduino Starter Pack"]);
   });

--- a/runtime/test/description-test.js
+++ b/runtime/test/description-test.js
@@ -60,14 +60,14 @@ recipe
     let Foo = manifest.findSchemaByName('Foo').entityClass();
     recipe.views[0].mapToView({id: 'test:1', type: Foo.type});
     if (recipe.views.length > 1) {
-      recipe.views[1].mapToView({id: 'test:2', type: Foo.type.viewOf()});
+      recipe.views[1].mapToView({id: 'test:2', type: Foo.type.setViewOf()});
     }
     if (recipe.views.length > 2) {
       recipe.views[2].mapToView({id: 'test:3', type: Foo.type});
     }
     let arc = createTestArc();
     let fooView = arc.createView(Foo.type);
-    let foosView = arc.createView(Foo.type.viewOf());
+    let foosView = arc.createView(Foo.type.setViewOf());
     recipe.normalize();
     assert.isTrue(recipe.isResolved());
     let ifooViewConn = recipe.viewConnections.find(vc => vc.particle.name == 'A' && vc.name == 'ifoo');
@@ -375,11 +375,11 @@ recipe
       let MyBESTType = manifest.findSchemaByName('MyBESTType').entityClass();
       recipe.views[0].mapToView({id: 'test:1', type: MyBESTType.type});
       if (recipe.views.length > 1) {
-        recipe.views[1].mapToView({id: 'test:2', type: MyBESTType.type.viewOf()});
+        recipe.views[1].mapToView({id: 'test:2', type: MyBESTType.type.setViewOf()});
       }
       let arc = createTestArc();
       let tView = arc.createView(MyBESTType.type);
-      let tsView = arc.createView(MyBESTType.type.viewOf());
+      let tsView = arc.createView(MyBESTType.type.setViewOf());
       recipe.normalize();
       assert.isTrue(recipe.isResolved());
 

--- a/runtime/test/particle-api-test.js
+++ b/runtime/test/particle-api-test.js
@@ -276,10 +276,10 @@ describe('particle-api', function() {
     };
     let arc = new Arc({id:'test', pecFactory, loader});
     let Result = manifest.findSchemaByName('Result').entityClass();
-    let inputsView = arc.createView(Result.type.viewOf());
+    let inputsView = arc.createView(Result.type.setViewOf());
     inputsView.store({id: 1, rawData: {value: 'hello'} });
     inputsView.store({id: 2, rawData: {value: 'world'} });
-    let resultsView = arc.createView(Result.type.viewOf());
+    let resultsView = arc.createView(Result.type.setViewOf());
     let recipe = manifest.recipes[0];
     recipe.normalize();
     arc.instantiate(recipe);

--- a/runtime/test/particle-shape-loading-test.js
+++ b/runtime/test/particle-shape-loading-test.js
@@ -89,7 +89,7 @@ describe('particle-shape-loading', function() {
 
     let shape = new Shape([{type: fooType}, {type: barType}], []);
 
-    let shapeType = Type.newShape(shape);
+    let shapeType = Type.newInterface(shape);
 
     let outerParticleSpec = new ParticleSpec({
       name: 'outerParticle',

--- a/runtime/test/planner-tests.js
+++ b/runtime/test/planner-tests.js
@@ -58,8 +58,8 @@ describe('Planner', function() {
     var arc = createTestArc("test-plan-arc", manifest, "dom");
     let Person = manifest.findSchemaByName('Person').entityClass();
     let Product = manifest.findSchemaByName('Product').entityClass();
-    var personView = arc.createView(Person.type.viewOf(), "aperson");
-    var productView = arc.createView(Product.type.viewOf(), "products");
+    var personView = arc.createView(Person.type.setViewOf(), "aperson");
+    var productView = arc.createView(Product.type.setViewOf(), "products");
     var planner = new Planner();
     planner.init(arc);
     await planner.generate(),
@@ -383,9 +383,9 @@ describe('AssignOrCopyRemoteViews', function() {
       `));
 
       let schema = manifest.findSchemaByName('Foo');
-      manifest.newView(schema.type.viewOf(), 'Test1', 'test-1', ['#tag1']);
-      manifest.newView(schema.type.viewOf(), 'Test2', 'test-2', ['#tag2']);
-      manifest.newView(schema.type.viewOf(), 'Test2', 'test-3', []);
+      manifest.newView(schema.type.setViewOf(), 'Test1', 'test-1', ['#tag1']);
+      manifest.newView(schema.type.setViewOf(), 'Test2', 'test-2', ['#tag2']);
+      manifest.newView(schema.type.setViewOf(), 'Test2', 'test-3', []);
 
       var arc = createTestArc("test-plan-arc", manifest, "dom");
 

--- a/runtime/test/shape-test.js
+++ b/runtime/test/shape-test.js
@@ -40,12 +40,12 @@ describe('shape', function() {
         {name: Type.newVariableReference('a')},
       ]);
     assert.equal(shape._typeVars.length, 4);
-    var type = Type.newShape(shape);
+    var type = Type.newInterface(shape);
     var map = new Map();
     type = type.assignVariableIds(map);
     assert(map.has('a'));
     assert(map.has('b'));
-    shape = type.shapeShape;
+    shape = type.interfaceShape;
     assert(shape.views[0].name.variableId == shape.slots[0].name.variableId);
     assert(shape.views[1].type.variableId == shape.views[2].type.viewType.variableId);
   });

--- a/runtime/test/shape-test.js
+++ b/runtime/test/shape-test.js
@@ -19,14 +19,14 @@ describe('shape', function() {
     var shape = new Shape([{type: Type.newVariableReference('a')}], []);
     assert.equal(shape._typeVars.length, 1);
     assert(shape._typeVars[0].field == 'type');
-    assert(shape._typeVars[0].object[shape._typeVars[0].field].variableReferenceName == 'a');
+    assert(shape._typeVars[0].object[shape._typeVars[0].field].variableReference == 'a');
   });
 
   it('finds type variable references in slots', function() {
     var shape = new Shape([], [{name: Type.newVariableReference('a')}]);
     assert.equal(shape._typeVars.length, 1);
     assert(shape._typeVars[0].field == 'name');
-    assert(shape._typeVars[0].object[shape._typeVars[0].field].variableReferenceName == 'a');
+    assert(shape._typeVars[0].object[shape._typeVars[0].field].variableReference == 'a');
   });
 
   it('upgrades type variable references', function() {
@@ -34,7 +34,7 @@ describe('shape', function() {
       [
         {name: Type.newVariableReference('a')},
         {type: Type.newVariableReference('b'), name: 'singleton'},
-        {type: Type.newVariableReference('b').viewOf(), name: 'set'}
+        {type: Type.newVariableReference('b').setViewOf(), name: 'set'}
       ],
       [
         {name: Type.newVariableReference('a')},
@@ -47,7 +47,7 @@ describe('shape', function() {
     assert(map.has('b'));
     shape = type.interfaceShape;
     assert(shape.views[0].name.variableId == shape.slots[0].name.variableId);
-    assert(shape.views[1].type.variableId == shape.views[2].type.viewType.variableId);
+    assert(shape.views[1].type.variableId == shape.views[2].type.setViewType.variableId);
   });
 
   it('matches particleSpecs', async () => {

--- a/runtime/test/type-integration-test.js
+++ b/runtime/test/type-integration-test.js
@@ -41,7 +41,7 @@ describe('type integration', () => {
     let manifest = await setup();
 
     let recipe = manifest.recipes[1];
-    recipe.views[0].mapToView({id: 'test1', type: manifest.findSchemaByName('Product').entityClass().type.viewOf()});
+    recipe.views[0].mapToView({id: 'test1', type: manifest.findSchemaByName('Product').entityClass().type.setViewOf()});
     assert(recipe.normalize());
     assert(recipe.isResolved());
     assert(recipe.views.length == 1);
@@ -52,7 +52,7 @@ describe('type integration', () => {
     let manifest = await setup();
 
     let recipe = manifest.recipes[1];
-    recipe.views[0].mapToView({id: 'test1', type: manifest.findSchemaByName('Lego').entityClass().type.viewOf()});
+    recipe.views[0].mapToView({id: 'test1', type: manifest.findSchemaByName('Lego').entityClass().type.setViewOf()});
     assert(recipe.normalize());
     assert(recipe.isResolved());
     assert(recipe.views.length == 1);

--- a/runtime/test/view-test.js
+++ b/runtime/test/view-test.js
@@ -54,7 +54,7 @@ describe('View', function() {
                            {type: Type.newEntity(manifest.schemas.Bar)}], []);
     assert(shape._particleMatches(manifest.particles[0]));
 
-    let shapeView = arc.createView(Type.newShape(shape));
+    let shapeView = arc.createView(Type.newInterface(shape));
     shapeView.set(manifest.particles[0]);
     assert(shapeView.get() == manifest.particles[0]);
   });

--- a/runtime/test/view-test.js
+++ b/runtime/test/view-test.js
@@ -39,7 +39,7 @@ describe('View', function() {
 
   it('remove entry from view', async () => {
     let arc = new Arc({slotComposer});
-    let barView = arc.createView(Bar.type.viewOf());
+    let barView = arc.createView(Bar.type.setViewOf());
     let bar = new Bar({id: 0, value: 'a Bar'});
     barView.store(bar);
     barView.remove(bar.id);

--- a/runtime/type.js
+++ b/runtime/type.js
@@ -11,36 +11,18 @@ const assert = require('assert');
 
 let nextVariableId = 0;
 
-function addType(name, tag, args) {
+function addType(name, tag, arg) {
   var lowerName = name[0].toLowerCase() + name.substring(1);
-  if (args.length == 1) {
-    Object.defineProperty(Type, `new${name}`, {
-      value: function() {
-        return new Type(tag, arguments[0]);
-      }});
-    var upperArg = args[0][0].toUpperCase() + args[0].substring(1);
-    Object.defineProperty(Type.prototype, `${lowerName}${upperArg}`, {
-      get: function() {
-        assert(this[`is${name}`]);
-        return this.data;
-      }});
-  } else {
-    Object.defineProperty(Type, `new${name}`, {
-      value: function() {
-        var data = {};
-        for (var i = 0; i < args.length; i++)
-          data[args[i]] = arguments[i];
-        return new Type(tag, data);
-      }});
-    for (let arg of args) {
-      var upperArg = arg[0].toUpperCase() + arg.substring(1);
-      Object.defineProperty(Type.prototype, `${lowerName}${upperArg}`, {
-        get: function() {
-          assert(this[`is${name}`]);
-          return this.data[arg];
-        }});
-    }
-  }
+  Object.defineProperty(Type, `new${name}`, {
+    value: function() {
+      return new Type(tag, arguments[0]);
+    }});
+  var upperArg = arg[0].toUpperCase() + arg.substring(1);
+  Object.defineProperty(Type.prototype, `${lowerName}${upperArg}`, {
+    get: function() {
+      assert(this[`is${name}`]);
+      return this.data;
+    }});
   Object.defineProperty(Type.prototype, `is${name}`, {
     get: function() {
       return this.tag == tag;
@@ -140,13 +122,8 @@ class Type {
   }
 
   toLiteral() {
-    if (this.tag == 'entity' || this.tag == 'list')
+    if (this.tag == 'entity' || this.tag == 'list' || this.tag == 'shape')
       return {tag: this.tag, data: this.data.toLiteral()};
-
-    // TODO: make sure we can deal with multiple-arg type literalization
-    // generically.
-    if (this.tag == 'shape')
-      return {tag: this.tag, data: {shape: this.data.shape.toLiteral()}};
 
     return this;
   }
@@ -154,7 +131,7 @@ class Type {
   static fromLiteral(literal) {
     let data = literal.data;
     if (literal.tag == 'shape')
-      data = {shape: Shape.fromLiteral(data.shape)};
+      data = Shape.fromLiteral(data);
     else if (literal.tag == 'entity')
       data = Schema.fromLiteral(data);
     else if (literal.tag == 'list')
@@ -204,13 +181,13 @@ class Type {
   }
 }
 
-addType('ManifestReference', 'manifestReference', ['name']);
-addType('Entity', 'entity', ['schema']);
-addType('VariableReference', 'variableReference', ['name']);
-addType('Variable', 'variable', ['variable']);
-addType('View', 'list', ['type']);
-addType('Relation', 'relation', ['entities']);
-addType('Shape', 'shape', ['shape', 'disambiguation'])
+addType('ManifestReference', 'manifestReference', 'name');
+addType('Entity', 'entity', 'schema');
+addType('VariableReference', 'variableReference', 'name');
+addType('Variable', 'variable', 'variable');
+addType('View', 'list', 'type');
+addType('Relation', 'relation', 'entities');
+addType('Shape', 'shape', 'shape');
 
 module.exports = Type;
 

--- a/runtime/type.js
+++ b/runtime/type.js
@@ -157,21 +157,26 @@ class Type {
   }
 
   toLiteral() {
-    if (this.tag == 'Entity' || this.tag == 'SetView' || this.tag == 'Interface')
+    if (this.data.toLiteral)
       return {tag: this.tag, data: this.data.toLiteral()};
-
     return this;
   }
 
+  static _deliteralizer(tag) {
+    switch (tag) {
+      case 'Interface':
+        return Shape.fromLiteral;
+      case 'Entity':
+        return Schema.fromLiteral;
+      case 'SetView':
+        return Type.fromLiteral;
+      default:
+        return a => a;
+    }
+  }
+
   static fromLiteral(literal) {
-    let data = literal.data;
-    if (literal.tag == 'Interface')
-      data = Shape.fromLiteral(data);
-    else if (literal.tag == 'Entity')
-      data = Schema.fromLiteral(data);
-    else if (literal.tag == 'SetView')
-      data = Type.fromLiteral(data);
-    return new Type(literal.tag, data);
+    return new Type(literal.tag, Type._deliteralizer(literal.tag)(literal.data));
   }
 
   setViewOf() {

--- a/runtime/type.js
+++ b/runtime/type.js
@@ -77,10 +77,10 @@ class Type {
       return this.primitiveType().assignVariableIds(variableMap).viewOf();
     }
 
-    if (this.isShape) {
-      var shape = this.shapeShape.clone();
+    if (this.isInterface) {
+      var shape = this.interfaceShape.clone();
       shape._typeVars.map(({object, field}) => object[field] = object[field].assignVariableIds(variableMap));
-      return Type.newShape(shape, this.shapeDisambiguation);
+      return Type.newInterface(shape);
     }
 
     return this;
@@ -93,7 +93,7 @@ class Type {
       if (resolved.schema) {
         return Type.newEntity(resolved.schema);
       } else if (resolved.shape) {
-        return Type.newShape(resolved.shape);
+        return Type.newInterface(resolved.shape);
       } else {
         throw new Error('Expected {shape} or {schema}')
       }
@@ -137,7 +137,7 @@ class Type {
   }
 
   toLiteral() {
-    if (this.tag == 'Entity' || this.tag == 'SetView' || this.tag == 'Shape')
+    if (this.tag == 'Entity' || this.tag == 'SetView' || this.tag == 'Interface')
       return {tag: this.tag, data: this.data.toLiteral()};
 
     return this;
@@ -145,7 +145,7 @@ class Type {
 
   static fromLiteral(literal) {
     let data = literal.data;
-    if (literal.tag == 'Shape')
+    if (literal.tag == 'Interface')
       data = Shape.fromLiteral(data);
     else if (literal.tag == 'Entity')
       data = Schema.fromLiteral(data);
@@ -171,8 +171,8 @@ class Type {
       return `[${this.primitiveType().toString()}]`;
     if (this.isEntity)
       return this.entitySchema.name;
-    if (this.isShape)
-      return 'Shape'
+    if (this.isInterface)
+      return 'Interface'
     assert('Add support to serializing type:', this);
   }
 
@@ -191,8 +191,8 @@ class Type {
       return this.entitySchema.name.replace(/([^A-Z])([A-Z])/g, "$1 $2").replace(/([A-Z][^A-Z])/g, " $1").trim();
     if (this.isManifestReference)
       return this.manifestReferenceName;
-    if (this.isShape)
-      return this.shapeShape.toPrettyString();
+    if (this.isInterface)
+      return this.interfaceShape.toPrettyString();
   }
 }
 
@@ -202,7 +202,7 @@ addType('VariableReference', 'name');
 addType('Variable', 'variable');
 addType('SetView', 'type');
 addType('Relation', 'entities');
-addType('Shape', 'shape');
+addType('Interface', 'shape');
 
 module.exports = Type;
 

--- a/runtime/type.js
+++ b/runtime/type.js
@@ -17,7 +17,7 @@ function addType(name, arg) {
     value: function() {
       return new Type(name, arguments[0]);
     }});
-  var upperArg = arg[0].toUpperCase() + arg.substring(1);
+  var upperArg = arg ? arg[0].toUpperCase() + arg.substring(1) : '';
   Object.defineProperty(Type.prototype, `${lowerName}${upperArg}`, {
     get: function() {
       assert(this[`is${name}`]);
@@ -58,6 +58,21 @@ class Type {
   /** DEPRECATED */
   get viewType() {
     return this.setViewType;
+  }
+
+  /** DEPRECATED */
+  get manifestReferenceName() {
+    return this.manifestReference;
+  }
+
+  /** DEPRECATED */
+  get variableReferenceName() {
+    return this.variableReference;
+  }
+
+  /** DEPRECATED */
+  get variableVariable() {
+    return this.variable;
   }
 
   // Replaces variableReference types with variable types .
@@ -196,10 +211,10 @@ class Type {
   }
 }
 
-addType('ManifestReference', 'name');
+addType('ManifestReference');
 addType('Entity', 'schema');
-addType('VariableReference', 'name');
-addType('Variable', 'variable');
+addType('VariableReference');
+addType('Variable');
 addType('SetView', 'type');
 addType('Relation', 'entities');
 addType('Interface', 'shape');

--- a/runtime/type.js
+++ b/runtime/type.js
@@ -45,33 +45,38 @@ class Type {
     this.data = data;
   }
 
-  /** DEPRECATED */
   static newView(type) {
+    console.warn('Type.newView is deprecated. Please use Type.newSetView instead');
     return Type.newSetView(type);
   }
 
-  /** DEPRECATED */
   get isView() {
+    console.warn('Type.isView is deprecated. Please use Type.isSetView instead');
     return this.isSetView;
   }
 
-  /** DEPRECATED */
   get viewType() {
+    console.warn('Type.viewType is deprecated. Please use Type.setViewType isntead');
     return this.setViewType;
   }
 
-  /** DEPRECATED */
+  viewOf() {
+    console.warn('Type.viewOf is deprecated. Please use Type.setViewOf instead');
+    return this.setViewOf();
+  }
+
   get manifestReferenceName() {
+    console.warn('Type.manifestReferenceName is deprecated. Please use Type.manifestReference instead');
     return this.manifestReference;
   }
 
-  /** DEPRECATED */
   get variableReferenceName() {
+    console.warn('Type.variableReferenceName is deprecated. Please use Type.variableReference instead');
     return this.variableReference;
   }
 
-  /** DEPRECATED */
   get variableVariable() {
+    console.warn('Type.variableVariable is deprecated. Please use Type.variable instead');
     return this.variable;
   }
 
@@ -88,8 +93,8 @@ class Type {
       return Type.newVariable(sharedVariable);
     }
 
-    if (this.isView) {
-      return this.primitiveType().assignVariableIds(variableMap).viewOf();
+    if (this.isSetView) {
+      return this.primitiveType().assignVariableIds(variableMap).setViewOf();
     }
 
     if (this.isInterface) {
@@ -114,8 +119,8 @@ class Type {
       }
     }
 
-    if (this.isView) {
-      return this.primitiveType().resolveReferences(resolve).viewOf();
+    if (this.isSetView) {
+      return this.primitiveType().resolveReferences(resolve).setViewOf();
     }
 
     return this;
@@ -129,7 +134,7 @@ class Type {
       //       types by schema name.
       return this.data.name == type.data.name;
     }
-    if (this.isView) {
+    if (this.isSetView) {
       return this.data.equals(type.data);
     }
     return JSON.stringify(this.data) == JSON.stringify(type.data);
@@ -140,7 +145,7 @@ class Type {
   }
 
   primitiveType() {
-    var type = this.viewType;
+    var type = this.setViewType;
     return new Type(type.tag, type.data);
   }
 
@@ -169,20 +174,20 @@ class Type {
     return new Type(literal.tag, data);
   }
 
-  viewOf() {
-    return Type.newView(this);
+  setViewOf() {
+    return Type.newSetView(this);
   }
 
   hasProperty(property) {
     if (property(this))
       return true;
-    if (this.isView)
-      return this.viewType.hasProperty(property);
+    if (this.isSetView)
+      return this.setViewType.hasProperty(property);
     return false;
   }
 
   toString() {
-    if (this.isView)
+    if (this.isSetView)
       return `[${this.primitiveType().toString()}]`;
     if (this.isEntity)
       return this.entitySchema.name;
@@ -194,7 +199,7 @@ class Type {
   toPrettyString() {
     if (this.isRelation)
       return JSON.stringify(this.data);
-    if (this.isView) {
+    if (this.isSetView) {
       return `${this.primitiveType().toPrettyString()} List`;
     }
     if (this.isVariable)

--- a/runtime/viewlet.js
+++ b/runtime/viewlet.js
@@ -177,7 +177,7 @@ class Variable extends Viewlet {
       return undefined;
     if (this.type.isEntity)
       return this._restore(result);
-    if (this.type.isShape)
+    if (this.type.isInterface)
       return ParticleSpec.fromLiteral(result);
     return result;
   }


### PR DESCRIPTION
* remove multiple argument input types & rely on using objects as the data member of types instead
* remove type tags, just use the type name as the tag
* rename the shape type to 'interface' type
* make having a name to reference data optional - when it's missing, the type name is used instead (e.g. type.variableVariable -> type.variable)
* add deprecated versions of a bunch of methods I've removed