### PR TITLE
Add an optional userID to Entity constructors.

### DIFF
--- a/runtime/arc.js
+++ b/runtime/arc.js
@@ -130,6 +130,10 @@ class Arc {
     return `${this.id}:${this._nextLocalID++}`;
   }
 
+  generateIDComponents() {
+    return {base: this.id, component: () => this._nextLocalID++};
+  }
+
   get _views() {
     return [...this._viewsById.values()];
   }

--- a/runtime/entity.js
+++ b/runtime/entity.js
@@ -11,11 +11,17 @@ const assert = require('assert');
 const Symbols = require('./symbols.js');
 
 class Entity {
-  constructor() {
+  constructor(userIDComponent) {
+    assert(!userIDComponent || userIDComponent.indexOf(':') == -1, "user IDs must not contain the ':' character")
     this[Symbols.identifier] = undefined;
+    this._userIDComponent = userIDComponent;
   }
   get data() {
     return undefined;
+  }
+
+  getUserID() {
+    return this._userIDComponent;
   }
 
   isIdentified() {
@@ -24,6 +30,17 @@ class Entity {
   identify(identifier) {
     assert(!this.isIdentified());
     this[Symbols.identifier] = identifier;
+    let components = identifier.split(':');
+    if (components[components.length - 2] == 'uid')
+      this._userIDComponent = components[components.length - 1];
+  }
+  createIdentity(components) {
+    assert(!this.isIdentified());
+    if (this._userIDComponent)
+      var id = `${components.base}:uid:${this._userIDComponent}`;
+    else
+      var id = `${components.base}:${components.component()}`;
+    this[Symbols.identifier] = id;
   }
   toLiteral() {
     return this.rawData;

--- a/runtime/inner-PEC.js
+++ b/runtime/inner-PEC.js
@@ -36,8 +36,8 @@ class RemoteView {
     return this._type;
   }
 
-  generateID() {
-    return this._pec.generateID();
+  generateIDComponents() {
+    return this._pec.generateIDComponents();
   }
 
   on(type, callback, target) {
@@ -192,6 +192,10 @@ class InnerPEC {
         `Stop render called for particle ${particle.name} slot ${slotName} without start render being called.`);
       particle._slotByName.delete(slotName);
     }
+  }
+
+  generateIDComponents() {
+    return {base: this._idBase, component: () => this._nextLocalID++};
   }
 
   generateID() {

--- a/runtime/schema.js
+++ b/runtime/schema.js
@@ -67,7 +67,7 @@ class Schema {
     var classJunk = ['toJSON', 'prototype', 'toString', 'inspect'];
 
     var clazz = class extends Entity {
-      constructor(data) {
+      constructor(data, userIDComponent) {
         var p = new Proxy(data, {
           get: (target, name) => {
             if (classJunk.includes(name))
@@ -86,7 +86,7 @@ class Schema {
             return true;
           }
         });
-        super();
+        super(userIDComponent);
         this.rawData = p;
       }
 

--- a/runtime/test/particle-api-test.js
+++ b/runtime/test/particle-api-test.js
@@ -277,8 +277,8 @@ describe('particle-api', function() {
     let arc = new Arc({id:'test', pecFactory, loader});
     let Result = manifest.findSchemaByName('Result').entityClass();
     let inputsView = arc.createView(Result.type.setViewOf());
-    inputsView.store({id: 1, rawData: {value: 'hello'} });
-    inputsView.store({id: 2, rawData: {value: 'world'} });
+    inputsView.store({id: "1", rawData: {value: 'hello'} });
+    inputsView.store({id: "2", rawData: {value: 'world'} });
     let resultsView = arc.createView(Result.type.setViewOf());
     let recipe = manifest.recipes[0];
     recipe.normalize();

--- a/runtime/test/particle-shape-loading-with-slots-test.js
+++ b/runtime/test/particle-shape-loading-with-slots-test.js
@@ -59,8 +59,8 @@ describe('particle-shape-loading-with-slots', function() {
     let fooType = Type.newEntity(manifest.schemas.Foo);
     let inView = arc.createView(fooType.setViewOf());
     var Foo = manifest.schemas.Foo.entityClass();
-    inView.store({id: 1, rawData: {value: 'foo1'} });
-    inView.store({id: 2, rawData: {value: 'foo2'} });
+    inView.store({id: "1", rawData: {value: 'foo1'} });
+    inView.store({id: "2", rawData: {value: 'foo2'} });
     recipeInView.mapToView(inView);
 
     assert.equal(1, Object.keys(recipeParticle.consumedSlotConnections).length);
@@ -113,7 +113,7 @@ describe('particle-shape-loading-with-slots', function() {
     assert.deepEqual([{value: 'foo1'}, {value: 'foo2'}], slot._content.model);
   });
 
-  it('multiplex recipe with slots (init context later)', async () => {
+  it.skip('multiplex recipe with slots (init context later)', async () => {
     // This test is different from the one above because it initializes the transformation particle context
     // after the hosted particles are also instantiated.
     // This verifies a different start-render call in slot-composer.

--- a/runtime/test/particle-shape-loading-with-slots-test.js
+++ b/runtime/test/particle-shape-loading-with-slots-test.js
@@ -113,7 +113,7 @@ describe('particle-shape-loading-with-slots', function() {
     assert.deepEqual([{value: 'foo1'}, {value: 'foo2'}], slot._content.model);
   });
 
-  it.skip('multiplex recipe with slots (init context later)', async () => {
+  it('multiplex recipe with slots (init context later)', async () => {
     // This test is different from the one above because it initializes the transformation particle context
     // after the hosted particles are also instantiated.
     // This verifies a different start-render call in slot-composer.

--- a/runtime/test/view-test.js
+++ b/runtime/test/view-test.js
@@ -37,6 +37,20 @@ describe('View', function() {
     assert.equal(barView.get(), undefined);
   });
 
+  it('dedupes common user-provided ids', async() => {
+    let arc = new Arc({slotComposer});
+
+    let manifest = await Manifest.load('../particles/test/test-particles.manifest', loader);
+    let Foo = manifest.schemas.Foo.entityClass();
+    let fooView = viewlet.viewletFor(arc.createView(Foo.type.setViewOf()));
+    fooView.entityClass = Foo;
+
+    await fooView.store(new Foo({value: 'a Foo'}, 'first'));
+    await fooView.store(new Foo({value: 'another Foo'}, 'second'));
+    await fooView.store(new Foo({value: 'a Foo, again'}, 'first'));
+    assert.equal((await fooView.toList()).length, 2);
+  });
+
   it('remove entry from view', async () => {
     let arc = new Arc({slotComposer});
     let barView = arc.createView(Bar.type.setViewOf());

--- a/runtime/view.js
+++ b/runtime/view.js
@@ -29,6 +29,10 @@ class ViewBase {
     return this._arc.generateID();
   }
 
+  generateIDComponents() {
+    return this._arc.generateIDComponents();
+  }
+
   get type() {
     return this._type;
   }

--- a/runtime/viewlet.js
+++ b/runtime/viewlet.js
@@ -61,12 +61,18 @@ class Viewlet {
   }
 
   generateID() {
+    assert (this._view.generateID);
     return this._view.generateID();
+  }
+
+  generateIDComponents() {
+    assert (this._view.generateIDComponents);
+    return this._view.generateIDComponents();
   }
 
   _serialize(entity) {
     if (!entity.isIdentified())
-      entity.identify(this.generateID());
+      entity.createIdentity(this.generateIDComponents());
     let id = entity[identifier];
     let rawData = entity.dataClone();
     return {

--- a/runtime/viewlet.js
+++ b/runtime/viewlet.js
@@ -61,12 +61,12 @@ class Viewlet {
   }
 
   generateID() {
-    assert (this._view.generateID);
+    assert(this._view.generateID);
     return this._view.generateID();
   }
 
   generateIDComponents() {
-    assert (this._view.generateIDComponents);
+    assert(this._view.generateIDComponents);
     return this._view.generateIDComponents();
   }
 


### PR DESCRIPTION
This will be used as the last component of the ID if specified. Note that you are responsible for providing unique IDs if this facility is used.

UserIDs are namespaced separately from automatic IDs, both to prevent accidental collision and to provide for extraction of the ID when read from a handle.