### PR TITLE
One-time format of extension code with prettier.

### DIFF
--- a/extension/arcs-content-script.js
+++ b/extension/arcs-content-script.js
@@ -7,11 +7,12 @@
 
 // TODO(smalls) there should be a better way to detect an arcs page we can
 // inject data into.
-const isArcsPage = document.body.getElementsByTagName('extension-app-shell').length>0;
+const isArcsPage =
+  document.body.getElementsByTagName("extension-app-shell").length > 0;
 
 function sendInjectArcsDataMessage() {
-  chrome.runtime.sendMessage({method: 'loadAllEntities'}, entities => {
-    window.postMessage({method: 'injectArcsData', entities: entities}, '*');
+  chrome.runtime.sendMessage({ method: "loadAllEntities" }, entities => {
+    window.postMessage({ method: "injectArcsData", entities: entities }, "*");
   });
 }
 
@@ -19,9 +20,9 @@ if (!isArcsPage) {
   // In the common case, if we're not running an arcs instance, extract entities
   // from the page.
   extractEntities().then(results => {
-    console.log('content-script result of extractEntities', results);
+    console.log("content-script result of extractEntities", results);
     chrome.runtime.sendMessage({
-      method: 'storePageEntities',
+      method: "storePageEntities",
       url: window.location.toString(),
       results: results
     });
@@ -34,9 +35,9 @@ if (!isArcsPage) {
 
 // In case we fired entities before anyone was listening, let's listen for
 // requests to send entities as well.
-window.addEventListener('message', event => {
-  console.log('content script received event '+event.data.method, event.data);
-  if (event.source != window || event.data.method != 'pleaseInjectArcsData') {
+window.addEventListener("message", event => {
+  console.log("content script received event " + event.data.method, event.data);
+  if (event.source != window || event.data.method != "pleaseInjectArcsData") {
     return;
   }
   sendInjectArcsDataMessage();

--- a/extension/arcs-content-script.js
+++ b/extension/arcs-content-script.js
@@ -8,11 +8,11 @@
 // TODO(smalls) there should be a better way to detect an arcs page we can
 // inject data into.
 const isArcsPage =
-  document.body.getElementsByTagName("extension-app-shell").length > 0;
+  document.body.getElementsByTagName('extension-app-shell').length > 0;
 
 function sendInjectArcsDataMessage() {
-  chrome.runtime.sendMessage({ method: "loadAllEntities" }, entities => {
-    window.postMessage({ method: "injectArcsData", entities: entities }, "*");
+  chrome.runtime.sendMessage({ method: 'loadAllEntities' }, entities => {
+    window.postMessage({ method: 'injectArcsData', entities: entities }, '*');
   });
 }
 
@@ -20,9 +20,9 @@ if (!isArcsPage) {
   // In the common case, if we're not running an arcs instance, extract entities
   // from the page.
   extractEntities().then(results => {
-    console.log("content-script result of extractEntities", results);
+    console.log('content-script result of extractEntities', results);
     chrome.runtime.sendMessage({
-      method: "storePageEntities",
+      method: 'storePageEntities',
       url: window.location.toString(),
       results: results
     });
@@ -35,9 +35,9 @@ if (!isArcsPage) {
 
 // In case we fired entities before anyone was listening, let's listen for
 // requests to send entities as well.
-window.addEventListener("message", event => {
-  console.log("content script received event " + event.data.method, event.data);
-  if (event.source != window || event.data.method != "pleaseInjectArcsData") {
+window.addEventListener('message', event => {
+  console.log('content script received event ' + event.data.method, event.data);
+  if (event.source != window || event.data.method != 'pleaseInjectArcsData') {
     return;
   }
   sendInjectArcsDataMessage();

--- a/extension/event-page.js
+++ b/extension/event-page.js
@@ -6,23 +6,23 @@
 // http://polymer.github.io/PATENTS.txt
 
 chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
-  console.log("event page received message " + request.method, request);
-  if (request.method == "storePageEntities") {
+  console.log('event page received message ' + request.method, request);
+  if (request.method == 'storePageEntities') {
     let key = request.url;
     chrome.storage.local.set({ [request.url]: request.results }, () => {
       if (chrome.runtime.lastError) {
-        console.log("ERROR failed to store: " + chrome.runtime.lastError);
+        console.log('ERROR failed to store: ' + chrome.runtime.lastError);
       }
     });
 
     // TODO(smalls) remove this, it's only for debugging
     chrome.storage.local.get(null, result => {
-      console.log("after store completed, storage contains", result);
+      console.log('after store completed, storage contains', result);
     });
-  } else if (request.method == "loadAllEntities") {
+  } else if (request.method == 'loadAllEntities') {
     chrome.storage.local.get(null, result => {
       if (chrome.runtime.lastError) {
-        console.log("ERROR retrieving storage: " + chrome.runtime.lastError);
+        console.log('ERROR retrieving storage: ' + chrome.runtime.lastError);
         return;
       }
 

--- a/extension/event-page.js
+++ b/extension/event-page.js
@@ -5,33 +5,31 @@
 // subject to an additional IP rights grant found at
 // http://polymer.github.io/PATENTS.txt
 
-chrome.runtime.onMessage.addListener(
-  function(request, sender, sendResponse) {
-    console.log('event page received message '+request.method, request);
-    if (request.method == 'storePageEntities') {
-      let key = request.url;
-      chrome.storage.local.set({[request.url]: request.results}, () => {
-        if (chrome.runtime.lastError) {
-          console.log('ERROR failed to store: '+chrome.runtime.lastError);
-        }
-      });
+chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
+  console.log("event page received message " + request.method, request);
+  if (request.method == "storePageEntities") {
+    let key = request.url;
+    chrome.storage.local.set({ [request.url]: request.results }, () => {
+      if (chrome.runtime.lastError) {
+        console.log("ERROR failed to store: " + chrome.runtime.lastError);
+      }
+    });
 
-      // TODO(smalls) remove this, it's only for debugging
-      chrome.storage.local.get(null, result => {
-        console.log('after store completed, storage contains', result);
-      });
-    } else if (request.method == 'loadAllEntities') {
-      chrome.storage.local.get(null, result => {
-        if (chrome.runtime.lastError) {
-          console.log('ERROR retrieving storage: '+chrome.runtime.lastError);
-          return;
-        }
+    // TODO(smalls) remove this, it's only for debugging
+    chrome.storage.local.get(null, result => {
+      console.log("after store completed, storage contains", result);
+    });
+  } else if (request.method == "loadAllEntities") {
+    chrome.storage.local.get(null, result => {
+      if (chrome.runtime.lastError) {
+        console.log("ERROR retrieving storage: " + chrome.runtime.lastError);
+        return;
+      }
 
-        sendResponse(result);
-      });
-      return true;
-    } else {
-      return;
-    }
+      sendResponse(result);
+    });
+    return true;
+  } else {
+    return;
   }
-);
+});

--- a/extension/new-tab.js
+++ b/extension/new-tab.js
@@ -9,8 +9,9 @@
  * Load schema.org entities from all available tabs.
  */
 async function loadEntitiesFromTabs() {
-
-  let devices = await new Promise((resolve) => chrome.sessions.getDevices(null, resolve));
+  let devices = await new Promise(resolve =>
+    chrome.sessions.getDevices(null, resolve)
+  );
   let tabs = [];
   for (let device of devices) {
     for (let session of device.sessions) {
@@ -24,23 +25,25 @@ async function loadEntitiesFromTabs() {
           id: tab.sessionId,
           url: tab.url,
           title: tab.title,
-          favIconUrl: tab.favIconUrl,
+          favIconUrl: tab.favIconUrl
         });
       }
     }
   }
-  let currentTabs = await new Promise((resolve) => chrome.tabs.query({}, resolve));
+  let currentTabs = await new Promise(resolve =>
+    chrome.tabs.query({}, resolve)
+  );
   for (let tab of currentTabs) {
     if (!/^https?/.test(tab.url)) {
       continue;
     }
     tabs.push({
-      device: 'local',
+      device: "local",
       group: `local:${tab.windowId}`,
       url: tab.url,
       title: tab.title,
       id: tab.id,
-      local: true,
+      local: true
     });
   }
   tabs.sort((a, b) => {
@@ -63,6 +66,7 @@ async function loadEntitiesFromTabs() {
     groupTabMap.get(tab.group).push(tab);
   }
 
-  return [].concat(...await Promise.all(tabs.map(tab => tabEntityMap.get(tab))));
+  return [].concat(
+    ...(await Promise.all(tabs.map(tab => tabEntityMap.get(tab))))
+  );
 }
-

--- a/extension/new-tab.js
+++ b/extension/new-tab.js
@@ -38,7 +38,7 @@ async function loadEntitiesFromTabs() {
       continue;
     }
     tabs.push({
-      device: "local",
+      device: 'local',
       group: `local:${tab.windowId}`,
       url: tab.url,
       title: tab.title,

--- a/extension/page-extractor.js
+++ b/extension/page-extractor.js
@@ -16,7 +16,7 @@ async function extractEntities() {
     'link[rel~="image_src"], link[rel~="icon"]'
   );
   let pageEntity = {
-    "@type": "http://schema.org/WebPage",
+    '@type': 'http://schema.org/WebPage',
     name: document.title,
     url: window.location.toString()
   };
@@ -31,11 +31,11 @@ async function extractEntities() {
 // This is out in a separate function, as extractMicrodata() may be replaced
 // with a library for https://github.com/PolymerLabs/arcs/issues/431
 function extractManifests() {
-  const manifestType = "text/x-arcs-manifest";
+  const manifestType = 'text/x-arcs-manifest';
   return Array.prototype.map.call(
     document.querySelectorAll('link[type="' + manifestType + '"]'),
     link => {
-      return { "@type": manifestType, url: link.href };
+      return { '@type': manifestType, url: link.href };
     }
   );
 }
@@ -46,8 +46,8 @@ function extractMicrodata(root) {
   function entityWalker(root) {
     return document.createTreeWalker(root, NodeFilter.SHOW_ELEMENT, {
       acceptNode(node) {
-        if (node.hasAttribute("itemscope") || node.hasAttribute("itemtype")) {
-          if (node.hasAttribute("itemprop")) {
+        if (node.hasAttribute('itemscope') || node.hasAttribute('itemtype')) {
+          if (node.hasAttribute('itemprop')) {
             // The entity is a property of another entity.
             return NodeFilter.FILTER_SKIP;
           }
@@ -68,12 +68,12 @@ function extractMicrodata(root) {
         if (
           parent &&
           parent != root &&
-          (parent.hasAttribute("itemscope") || parent.hasAttribute("itemtype"))
+          (parent.hasAttribute('itemscope') || parent.hasAttribute('itemtype'))
         ) {
           // No need to look for props inside nested entities.
           return NodeFilter.FILTER_REJECT;
         }
-        if (node.hasAttribute("itemprop")) {
+        if (node.hasAttribute('itemprop')) {
           return NodeFilter.FILTER_ACCEPT;
         }
         return NodeFilter.FILTER_SKIP;
@@ -82,31 +82,31 @@ function extractMicrodata(root) {
   }
 
   function extractProperty(node) {
-    let prop = node.getAttribute("itemprop");
+    let prop = node.getAttribute('itemprop');
     let value;
-    if (node.hasAttribute("content")) {
+    if (node.hasAttribute('content')) {
       // TODO: Is it valid to prefer 'content' over all?
       // tandy has <meta itemprop="itemCondition" itemtype="http://schema.org/OfferItemCondition" content="http://schema.org/NewCondition"
       // officeworks has <a itemprop="sameAs" content="http://www.facebook.com/officeworks">http://www.facebook.com/officeworks</a>, the twitter
       // ebay has <div itemprop=x content=y>
-      value = node.getAttribute("content");
-    } else if (node.getAttribute("itemtype")) {
+      value = node.getAttribute('content');
+    } else if (node.getAttribute('itemtype')) {
       value = extractEntity(node);
-    } else if (node.tagName == "LINK") {
+    } else if (node.tagName == 'LINK') {
       // TODO: untested
       value = node.href;
-    } else if (node.tagName == "META") {
+    } else if (node.tagName == 'META') {
       value = node.content;
-    } else if (node.tagName == "IMG") {
+    } else if (node.tagName == 'IMG') {
       value = node.src;
-    } else if (node.tagName == "A") {
+    } else if (node.tagName == 'A') {
       value = node.href;
-    } else if (node.tagName == "TIME") {
+    } else if (node.tagName == 'TIME') {
       // TODO: untested
       value = node.datetime;
     }
     if (value == undefined) {
-      value = node.textContent.replace(/(^\s*|\s*$)/g, "");
+      value = node.textContent.replace(/(^\s*|\s*$)/g, '');
     }
     return { prop, value };
   }
@@ -120,11 +120,11 @@ function extractMicrodata(root) {
 
   function extractEntity(node) {
     let result = {};
-    if (node.hasAttribute("itemtype")) {
-      result["@type"] = node.getAttribute("itemtype");
+    if (node.hasAttribute('itemtype')) {
+      result['@type'] = node.getAttribute('itemtype');
     }
     for (let { prop, value } of extractProperties(node)) {
-      if (typeof result[prop] != "undefined") {
+      if (typeof result[prop] != 'undefined') {
         if (!Array.isArray(result[prop])) {
           result[prop] = [result[prop]];
         }

--- a/extension/page-extractor.js
+++ b/extension/page-extractor.js
@@ -12,11 +12,13 @@ async function extractEntities() {
     results.push(...microdata);
   }
 
-  let linkImage = document.querySelector('link[rel~="image_src"], link[rel~="icon"]')
+  let linkImage = document.querySelector(
+    'link[rel~="image_src"], link[rel~="icon"]'
+  );
   let pageEntity = {
-    '@type': 'http://schema.org/WebPage',
+    "@type": "http://schema.org/WebPage",
     name: document.title,
-    url: window.location.toString(),
+    url: window.location.toString()
   };
   if (linkImage && linkImage.href) {
     pageEntity.image = linkImage.href;
@@ -29,11 +31,11 @@ async function extractEntities() {
 // This is out in a separate function, as extractMicrodata() may be replaced
 // with a library for https://github.com/PolymerLabs/arcs/issues/431
 function extractManifests() {
-  const manifestType = 'text/x-arcs-manifest';
+  const manifestType = "text/x-arcs-manifest";
   return Array.prototype.map.call(
-    document.querySelectorAll('link[type="'+manifestType+'"]'),
+    document.querySelectorAll('link[type="' + manifestType + '"]'),
     link => {
-      return {'@type': manifestType, url: link.href};
+      return { "@type": manifestType, url: link.href };
     }
   );
 }
@@ -44,8 +46,8 @@ function extractMicrodata(root) {
   function entityWalker(root) {
     return document.createTreeWalker(root, NodeFilter.SHOW_ELEMENT, {
       acceptNode(node) {
-        if (node.hasAttribute('itemscope') || node.hasAttribute('itemtype')) {
-          if (node.hasAttribute('itemprop')) {
+        if (node.hasAttribute("itemscope") || node.hasAttribute("itemtype")) {
+          if (node.hasAttribute("itemprop")) {
             // The entity is a property of another entity.
             return NodeFilter.FILTER_SKIP;
           }
@@ -63,11 +65,15 @@ function extractMicrodata(root) {
           return NodeFilter.FILTER_SKIP;
         }
         let parent = node.parentElement;
-        if (parent && parent != root && (parent.hasAttribute('itemscope') || parent.hasAttribute('itemtype'))) {
+        if (
+          parent &&
+          parent != root &&
+          (parent.hasAttribute("itemscope") || parent.hasAttribute("itemtype"))
+        ) {
           // No need to look for props inside nested entities.
           return NodeFilter.FILTER_REJECT;
         }
-        if (node.hasAttribute('itemprop')) {
+        if (node.hasAttribute("itemprop")) {
           return NodeFilter.FILTER_ACCEPT;
         }
         return NodeFilter.FILTER_SKIP;
@@ -76,33 +82,33 @@ function extractMicrodata(root) {
   }
 
   function extractProperty(node) {
-    let prop = node.getAttribute('itemprop');
+    let prop = node.getAttribute("itemprop");
     let value;
-    if (node.hasAttribute('content')) {
+    if (node.hasAttribute("content")) {
       // TODO: Is it valid to prefer 'content' over all?
       // tandy has <meta itemprop="itemCondition" itemtype="http://schema.org/OfferItemCondition" content="http://schema.org/NewCondition"
       // officeworks has <a itemprop="sameAs" content="http://www.facebook.com/officeworks">http://www.facebook.com/officeworks</a>, the twitter
       // ebay has <div itemprop=x content=y>
-      value = node.getAttribute('content');
-    } else if (node.getAttribute('itemtype')) {
+      value = node.getAttribute("content");
+    } else if (node.getAttribute("itemtype")) {
       value = extractEntity(node);
-    } else if (node.tagName == 'LINK') {
+    } else if (node.tagName == "LINK") {
       // TODO: untested
       value = node.href;
-    } else if (node.tagName == 'META') {
+    } else if (node.tagName == "META") {
       value = node.content;
-    } else if (node.tagName == 'IMG') {
+    } else if (node.tagName == "IMG") {
       value = node.src;
-    } else if (node.tagName == 'A') {
+    } else if (node.tagName == "A") {
       value = node.href;
-    } else if (node.tagName == 'TIME') {
+    } else if (node.tagName == "TIME") {
       // TODO: untested
       value = node.datetime;
     }
     if (value == undefined) {
-      value = node.textContent.replace(/(^\s*|\s*$)/g, '');
+      value = node.textContent.replace(/(^\s*|\s*$)/g, "");
     }
-    return {prop, value};
+    return { prop, value };
   }
 
   function* extractProperties(node) {
@@ -114,11 +120,11 @@ function extractMicrodata(root) {
 
   function extractEntity(node) {
     let result = {};
-    if (node.hasAttribute('itemtype')) {
-      result['@type'] = node.getAttribute('itemtype');
+    if (node.hasAttribute("itemtype")) {
+      result["@type"] = node.getAttribute("itemtype");
     }
-    for (let {prop, value} of extractProperties(node)) {
-      if (typeof result[prop] != 'undefined') {
+    for (let { prop, value } of extractProperties(node)) {
+      if (typeof result[prop] != "undefined") {
         if (!Array.isArray(result[prop])) {
           result[prop] = [result[prop]];
         }


### PR DESCRIPTION
Ran manually on command line with `prettier --write *.js`. Easy to revise config and re-run in the future if we want to format differently, eh. I wonder about the double-quotes vs. the single-quotes but otherwise it looks good to me. I like 80-cols, and the wrapping and adding spaces between binary ops like + and such.

Maybe we can live with just doing this manually for a bit and see how we like it.