### PR TITLE
sketch of encapsulating views (and related logic - mostly tags)

### DIFF
--- a/runtime/manifest.js
+++ b/runtime/manifest.js
@@ -26,12 +26,11 @@ class Manifest {
     // TODO: These should be lists, possibly with a separate flattened map.
     this._particles = {};
     this._schemas = {};
-    this._views = [];
     this._shapes = [];
-    this._viewTags = new Map();
     this._fileName = null;
     this._nextLocalID = 0;
     this._id = null;
+    this._viewRegistry = ViewRegistry(_findAll);
   }
   get id() {
     return this._id;
@@ -52,25 +51,11 @@ class Manifest {
     return this._fileName;
   }
   get views() {
-    return this._views;
+    return this._viewRegistry.views();
   }
 
   get shapes() {
     return this._shapes;
-  }
-
-  // TODO: newParticle, Schema, etc.
-  // TODO: simplify() / isValid().
-  newView(type, name, id, tags) {
-    let view;
-    if (type.isSetView) {
-      view = new View(type, this, name, id);
-    } else {
-      view = new Variable(type, this, name, id);
-    }
-    this._views.push(view);
-    this._viewTags.set(view, tags ? tags : []);
-    return view;
   }
   _find(manifestFinder) {
     let result = manifestFinder(this);
@@ -98,16 +83,6 @@ class Manifest {
   }
   findParticlesByVerb(verb) {
     return [...this._findAll(manifest => Object.values(manifest._particles).filter(particle => particle.primaryVerb == verb))];
-  }
-  findViewByName(name) {
-    return this._find(manifest => manifest._views.find(view => view.name == name));
-  }
-  findViewById(id) {
-    return this._find(manifest => manifest._views.find(view => view.id == id));
-  }
-  findViewsByType(type, options) {
-    var tags = options && options.tags ? options.tags : [];
-    return [...this._findAll(manifest => manifest._views.filter(view => view.type.equals(type) && tags.filter(tag => !manifest._viewTags.get(view).includes(tag)).length == 0))];
   }
   findShapeByName(name) {
     return this._find(manifest => manifest._shapes.find(shape => shape.name == name));

--- a/runtime/view.js
+++ b/runtime/view.js
@@ -253,3 +253,28 @@ Object.assign(module.exports, {
   View,
   Variable,
 });
+
+class ViewRegistry {
+
+  /**
+   * @param finder A generator allowing contexts that contain a tree of
+   * view-containing elements to be walked for recursive view-finding.
+   */
+  constructor(finder) {
+  }
+
+  create(type, name, id, tags) {
+  }
+
+  _registerView(view, tags) {
+  }
+
+  findByType(type, options) {
+  }
+
+  findById() {
+  }
+
+  findByName() {
+  }
+}


### PR DESCRIPTION
Just a sketch for discussion - this isn't a complete solution.

Both arcs and manifests (among others) can contain views, and operate on tags (and other facets of views?) This is a proposal to consolidate that logic into a single registry. I missed a spot to add validation to prevent the problem I was seeing yesterday, and someone else had before me, too.

I'm not sure if this really jibes with the long-term goals, though. Let me know if I should keep going or chuck this out.