### PR TITLE
hack hosted particle in manifest view and manifest.js

### DIFF
--- a/particles/ProductMultiplexer/ProductMultiplexer.js
+++ b/particles/ProductMultiplexer/ProductMultiplexer.js
@@ -16,16 +16,11 @@ defineParticle(({DomParticle}) => {
       let arc = await this.constructInnerArc();
       var productsView = views.get('products');
       var productsList = await productsView.toList();
+
       for (let [index, product] of productsList.entries()) {
         let productView = await arc.createHandle(productsView.type.primitiveType(), "product" + index);
 
-        // TODO: fetch the particle from "hostedParticle" handle.
-        // let hostedParticle = await views.get('hostedParticle').get();
-        let hostedParticle = {
-          name: "ArrivinatorX",
-          implFile: "../particles/ArrivinatorX/ArrivinatorX.js",
-          slots: new Map([["annotation", {} ]])
-        };
+        let hostedParticle = await views.get('hostedParticle').get();
 
         let hostedSlotName =  [...hostedParticle.slots.keys()][0];
         let slotName = [...this.spec.slots.values()][0].name;

--- a/particles/ProductMultiplexer/ProductMultiplexer.manifest
+++ b/particles/ProductMultiplexer/ProductMultiplexer.manifest
@@ -8,12 +8,12 @@
 
 import '../../entities/Product.manifest'
 
-shape HostedParticleShape
-  HostedParticleShape(in Product foo)
+shape HostedProductParticle
+  HostedProductParticle(in Product foo)
   consume annotation
 
 # TODO: This particle should use generic handle type and slot name.
 particle ProductMultiplexer in 'ProductMultiplexer.js'
-  ProductMultiplexer(host HostedParticleShape hostedParticle, in [Product] products)
+  ProductMultiplexer(host HostedProductParticle hostedParticle, in [Product] products)
   consume set of annotation
-  description `${hostedParticle} for each product`
+  description `${hostedParticle._description_} for each product`

--- a/runtime/arc.js
+++ b/runtime/arc.js
@@ -214,6 +214,15 @@ class Arc {
     for (let recipeView of views) {
       if (['copy', 'create'].includes(recipeView.fate)) {
         let view = this.createView(recipeView.type, /* name= */ null, /* id= */ null, recipeView.tags);
+
+        // THIS IS THE VERY FIRST HACK I USED, PUTTING THE HOSTED PARTICLE NAME IN VIEW-ID,
+        // AND THIS WORKED, BECAUSE BEFORE INSTANTIATING THE RECIPE FOR REAL, I SET THE VIEW TO .toLiteral()
+        // OVERRIDING THE PROBLEMATIC CHANGES THAT HAPPEN DURING INSTANTIATION OF INNER RECIPE IN SPECULATIVE EXECUTION.
+
+        // if (recipeView.id == "ArrivinatorX") {
+        //   view.set(this.context.findParticleByName(recipeView.id).toLiteral());
+        // }
+
         if (recipeView.fate === "copy") {
           var copiedView = this.findViewById(recipeView.id);
           view.cloneFrom(copiedView);

--- a/runtime/browser/demo/recipes.manifest
+++ b/runtime/browser/demo/recipes.manifest
@@ -17,20 +17,12 @@ import '../../../particles/Interests/Interests.manifest'
 import '../../../particles/ProductMultiplexer/ProductMultiplexer.manifest'
 import '../../../particles/ArrivinatorX/ArrivinatorX.manifest'
 
-# Create shortlist with [product, ...]
-recipe
-   ShowProducts
-
-# See [person]'s wishlist
-recipe
-  map #wishlist as wishlist
-  ShowProducts
-    list <- wishlist
+view ArrivinatorParticle of HostedProductParticle #arrivinator in '../../../particles/ArrivinatorX/ArrivinatorX.manifest'
 
 # See products shortlist with estimated arrival dates (transformation)
 recipe
   map #shortlist as shortlist
-  create as shape0
+  map #arrivinator as shape0
   ShowProducts
     list <- shortlist
     consume root as slot0
@@ -40,55 +32,6 @@ recipe
     # TODO: get rid of shape0 and replace it with Arrivinator particle shape.
     hostedParticle = shape0  # ArrivinatorX
     consume annotation as slot1
-
-
-# Create shortlist with [product, ...] and suggest similar products from [person]'s wish list
-recipe
-  Chooser.choices -> Recommend.recommendations
-  #Chooser.resultList -> ManageProducts.list
-  Chooser.resultList -> ShowProducts.list
-  Chooser.resultList -> Recommend.known
-  Chooser.resultList -> AlsoOn.list
-  Chooser.choices -> AlsoOn.choices
-  map #wishlist as wishlist
-  copy #shortlist as shortlist
-  slot as slot0
-  Recommend
-    population <- wishlist
-  ShowProducts
-    list <- shortlist
-  #ManageProducts
-    #list = shortlist
-    consume root as slot0
-      provide annotation as slot1
-  AlsoOn
-    consume annotation as slot1
-
-# Buying for [person]'s [occasion] in [timeframe]? Product [X] arrives too late.
-recipe
-  map as view1
-  use as view2
-  use as view3
-  GiftList
-    person <- view1
-  Arrivinator
-    list <- view2
-  Arrivinator
-    list <- view3
-
-# Check manufacturer information for products.
-recipe
-  use #shortlist as shortlist
-  ManufacturerInfo
-    list <- shortlist
-
-# TODO: Check for newer versions, e.g. there is a new version of [product].
-# TODO: [Manufacturer] recommends [product] instead of [product] for 13 year olds.
-# TODO: See awards, e.g. [product] winning the [award].
-
-# Recommendations based on Claire's interest in field hockey.
-recipe
-  Interests
 
 # TODO: move these to separate manifests for claire's wishlist / page
 view PageProducts of [Product] #shortlist in 'products.json'

--- a/runtime/description.js
+++ b/runtime/description.js
@@ -11,6 +11,7 @@
 
 import assert from '../platform/assert-web.js';
 import Type from './type.js';
+import ParticleSpec  from './particle-spec.js';
 
 export default class Description {
   constructor(arc) {
@@ -181,6 +182,12 @@ export default class Description {
         return this._formatViewValue(token._view);
       case "_name_": {
         return this._formatDescription(token._viewConn, token._view, options).toString();
+      }
+      case "_description_": {
+        // hosted particle
+        assert(token._view.type.isInterface, 'Expected interface');
+        // TODO: support hosted particle dynamic description pattern?
+        return ParticleSpec.fromLiteral(token._view.get()).pattern;
       }
       case undefined:
         // full view description

--- a/runtime/outer-PEC.js
+++ b/runtime/outer-PEC.js
@@ -13,6 +13,7 @@ import PEC from './particle-execution-context.js';
 import assert from '../platform/assert-web.js';
 import {PECOuterPort} from './api-channel.js';
 import Manifest from './manifest.js';
+import Schema  from './schema.js';
 
 // TODO: fix
 import Loader from './loader.js';
@@ -80,7 +81,17 @@ class OuterPEC extends PEC {
     }
 
     this._apiPort.onArcLoadRecipe = async ({arc, recipe, callback}) => {
+      debugger;
+      let typeOfArrivinatorConnection = this._arc.context.views[0]._stored.args[0].type.data;
+      console.log(typeOfArrivinatorConnection);
+
       let manifest = await Manifest.parse(recipe, {loader: this._arc._loader, fileName: ''});
+
+      let newTypeOfArrivinatorConnection = this._arc.context.views[0]._stored.args[0].type.data;
+      console.log(newTypeOfArrivinatorConnection);
+      // typeOfArrivinatorConnection and newTypeOfArrivinatorConnection should be equal! but they are not :(
+      console.log(Schema.fromLiteral(typeOfArrivinatorConnection).equals(newTypeOfArrivinatorConnection));
+
       let error = undefined;
       var recipe = manifest.recipes[0];
       if (recipe) {

--- a/runtime/schema.js
+++ b/runtime/schema.js
@@ -18,6 +18,11 @@ class Schema {
     this._normative = {};
     this._optional = {};
 
+    if (!model.sections) {
+      // HERE HAPPENS THE EVENTUAL FAILURE!
+      debugger;
+    }
+
     assert(model.sections, `${JSON.stringify(model)} should have sections`);
     for (var section of model.sections) {
       var into = section.sectionType == 'normative' ? this._normative : this._optional;

--- a/runtime/strategies/view-mapper-base.js
+++ b/runtime/strategies/view-mapper-base.js
@@ -39,7 +39,8 @@ export default class ViewMapperBase extends Strategy {
       mapView(view, tags, type, counts) {
         var score = -1;
         if (counts.in == 0 || counts.out == 0) {
-          if (counts.unknown > 0)
+          // DONOTSUBMIT this is hack, count "host" connections too.
+          if (counts.unknown > 1)
             return;
           if (counts.out == 0)
             score = 1;


### PR DESCRIPTION
fix hosted particle description
failure in real instantiation, because the hosted particle handle gets overriden when inner arc's recipe in instantiated during speculative execution.