### PR TITLE
Add a runner for executing runtime tests in a browser

### DIFF
--- a/runtime/test/chai-web.js
+++ b/runtime/test/chai-web.js
@@ -1,0 +1,10 @@
+// Copyright (c) 2017 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+import '../../node_modules/chai/chai.js';
+export default window.chai;
+export const assert = window.chai.assert;

--- a/runtime/test/test-runner.html
+++ b/runtime/test/test-runner.html
@@ -1,0 +1,21 @@
+<!--
+Copyright (c) 2017 Google Inc. All rights reserved.
+This code may only be used under the BSD style license found at
+http://polymer.github.io/LICENSE.txt
+Code distributed by Google as part of this project is also
+subject to an additional IP rights grant found at
+http://polymer.github.io/PATENTS.txt
+-->
+<!DOCTYPE html>
+<link href="../../node_modules/mocha/mocha.css" rel="stylesheet" />
+<div id="mocha"></div>
+<script src="../../node_modules/mocha/mocha.js"></script>
+<script>mocha.setup('bdd')</script>
+<script>
+onload = () => {
+  mocha.checkLeaks();
+  mocha.run();
+};
+</script>
+
+<script type="module" src="recipe-util-tests.js"></script>


### PR DESCRIPTION
This is not intended to run all tests yet, but it can be useful for debugging errors. Replace `recipe-util-tests.js` with your problem test.