### PR TITLE
Fix direction compatibility test with host

### DIFF
--- a/runtime/manifest.js
+++ b/runtime/manifest.js
@@ -412,7 +412,7 @@ ${e.message}
         connection.tags = connectionItem.target ? connectionItem.target.tags : [];
         let direction = {'->': 'out', '<-': 'in', '=': 'inout'}[connectionItem.dir];
         if (connection.direction) {
-          if (connection.direction != direction && direction != 'inout') {
+          if (connection.direction != direction && direction != 'inout' && !(connection.direction == 'host' && direction == 'in')) {
             let error = new Error(`'${connectionItem.dir}' not compatible with '${connection.direction}' param of '${particle.name}'`);
             error.location = connectionItem.location;
             throw error;

--- a/runtime/test/particle-shape-loading-test.js
+++ b/runtime/test/particle-shape-loading-test.js
@@ -152,7 +152,7 @@ describe('particle-shape-loading', function() {
         create as v0
         create as v1
         OuterParticle
-          particle = TestParticle
+          particle <- TestParticle
           output -> v0
           input <- v1
       `, {loader, fileName: './test.manifest'});


### PR DESCRIPTION
Previously `hosted = Particle` would parse, but not `hosted <- Particle`