### PR TITLE
Temporarily add description text to planner results

### DIFF
--- a/runtime/planner.js
+++ b/runtime/planner.js
@@ -181,6 +181,7 @@ class Planner {
         plan,
         rank,
         description: relevance.newArc.description,
+        descriptionText: description,  // TODO(mmandlis): exclude the text description from returned results.
         hash
       });
     }


### PR DESCRIPTION
this is needed for suggestions filtering in arcs-cdn, until the changes to suggestions element are properly integrated.