### PR TITLE
Reimplement ManufacturerInfo with multiplexer transformation

### DIFF
--- a/particles/ManufacturerInfoX/ManufacturerInfoX.js
+++ b/particles/ManufacturerInfoX/ManufacturerInfoX.js
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright (c) 2017 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+"use strict";
+
+defineParticle(({DomParticle}) => {
+
+  let template = `
+    <div style="/*font-size: 0.85em;*/ /*font-weight: bold;*/ font-style: italic">{{msg}}</div>
+    `.trim();
+
+  return class extends DomParticle {
+    get template() {
+      return template;
+    }
+    _shouldRender(props) {
+      return !!props && !!props.product;
+    }
+    _render(props) {
+      let {product} = props;
+      let msg = '';
+      switch (product.name) {
+        case 'Power Tool Set':
+          msg = `Newer version available: ${product.name} v2.`;
+          break;
+        case 'Guardian of the Galaxy Figure':
+          msg = `Manufacturer recommends a more appropriate gift for a 13yo.`;
+          break;
+        case 'Book: How to Draw':
+          msg = `Award-winning book!`;
+          break;
+      }
+      return {msg};
+    }
+  };
+});

--- a/particles/ManufacturerInfoX/ManufacturerInfoX.manifest
+++ b/particles/ManufacturerInfoX/ManufacturerInfoX.manifest
@@ -8,12 +8,7 @@
 
 import '../../entities/Product.manifest'
 
-shape HostedParticleShape
-  HostedParticleShape(in Product foo)
+particle ManufacturerInfoX in 'ManufacturerInfoX.js'
+  ManufacturerInfoX(in Product product)
   consume annotation
-
-# TODO: This particle should use generic handle type and slot name.
-particle ProductMultiplexer in 'ProductMultiplexer.js'
-  ProductMultiplexer(host HostedParticleShape hostedParticle, in [Product] products)
-  consume set of annotation
-  description `${hostedParticle} for each product in ${products}`
+  description `check manufacturer information`

--- a/particles/ProductMultiplexer/ProductMultiplexer.js
+++ b/particles/ProductMultiplexer/ProductMultiplexer.js
@@ -21,6 +21,11 @@ defineParticle(({DomParticle}) => {
       this.on(views, 'products', 'change', async e => {
         var productsView = views.get('products');
         var productsList = await productsView.toList();
+
+        if (productsList.length > 0) {
+          this.relevance = 0.1;
+        }
+
         let hostedParticle = await views.get('hostedParticle').get();
         for (let [index, product] of productsList.entries()) {
           if (this._handleIds.has(product.id)) {

--- a/runtime/browser/demo/recipes.manifest
+++ b/runtime/browser/demo/recipes.manifest
@@ -11,11 +11,12 @@ import '../../../particles/Recommend/Recommend.manifest'
 import '../../../particles/Chooser/Chooser.manifest'
 import '../../../particles/AlsoOn/AlsoOn.manifest'
 import '../../../particles/GiftList/GiftList.manifest'
-import '../../../particles/Arrivinator/Arrivinator.manifest'
-import '../../../particles/ManufacturerInfo/ManufacturerInfo.manifest'
+#import '../../../particles/Arrivinator/Arrivinator.manifest'
+#import '../../../particles/ManufacturerInfo/ManufacturerInfo.manifest'
 import '../../../particles/Interests/Interests.manifest'
 import '../../../particles/ProductMultiplexer/ProductMultiplexer.manifest'
 import '../../../particles/ArrivinatorX/ArrivinatorX.manifest'
+import '../../../particles/ManufacturerInfoX/ManufacturerInfoX.manifest'
 
 # Create shortlist with [product, ...]
 recipe
@@ -56,18 +57,10 @@ recipe
   use as view3
   GiftList
     person <- view1
-  Arrivinator
-    list <- view2
-  Arrivinator
-    list <- view3
-
-# Buying for [person]'s [occasion] in [timeframe]? Product [X] arrives too late.
-recipe
-  map as view1
-  use as view2
-  use as view3
-  GiftList
-    person <- view1
+#  Arrivinator
+#    list <- view2
+#  Arrivinator
+#    list <- view3
   ProductMultiplexer
     products <- view2
     hostedParticle = ArrivinatorX
@@ -78,8 +71,11 @@ recipe
 # Check manufacturer information for products.
 recipe
   use #shortlist as shortlist
-  ManufacturerInfo
-    list <- shortlist
+#  ManufacturerInfo
+#   list <- shortlist
+  ProductMultiplexer
+    products <- shortlist
+    hostedParticle <- ManufacturerInfoX
 
 # TODO: Check for newer versions, e.g. there is a new version of [product].
 # TODO: [Manufacturer] recommends [product] instead of [product] for 13 year olds.

--- a/runtime/browser/demo/recipes.manifest
+++ b/runtime/browser/demo/recipes.manifest
@@ -11,8 +11,6 @@ import '../../../particles/Recommend/Recommend.manifest'
 import '../../../particles/Chooser/Chooser.manifest'
 import '../../../particles/AlsoOn/AlsoOn.manifest'
 import '../../../particles/GiftList/GiftList.manifest'
-#import '../../../particles/Arrivinator/Arrivinator.manifest'
-#import '../../../particles/ManufacturerInfo/ManufacturerInfo.manifest'
 import '../../../particles/Interests/Interests.manifest'
 import '../../../particles/ProductMultiplexer/ProductMultiplexer.manifest'
 import '../../../particles/ArrivinatorX/ArrivinatorX.manifest'
@@ -57,10 +55,6 @@ recipe
   use as view3
   GiftList
     person <- view1
-#  Arrivinator
-#    list <- view2
-#  Arrivinator
-#    list <- view3
   ProductMultiplexer
     products <- view2
     hostedParticle = ArrivinatorX
@@ -71,8 +65,6 @@ recipe
 # Check manufacturer information for products.
 recipe
   use #shortlist as shortlist
-#  ManufacturerInfo
-#   list <- shortlist
   ProductMultiplexer
     products <- shortlist
     hostedParticle <- ManufacturerInfoX

--- a/runtime/description-dom-formatter.js
+++ b/runtime/description-dom-formatter.js
@@ -93,6 +93,7 @@ export default class DescriptionDomFormatter extends DescriptionFormatter {
       } else {  // view or slot handle.
         let sanitizedFullName = token.fullName.replace(/[.{}_\$]/g, '');
         let attribute = '';
+        // TODO(mmandlis): capitalize the data in the model instead.
         if (i == 0) {
           // Capitalize the first letter in the token.
           template = template.concat(`<style>

--- a/runtime/dom-slot.js
+++ b/runtime/dom-slot.js
@@ -18,7 +18,8 @@ let templates = new Map();
 class DomSlot extends Slot {
   constructor(consumeConn, arc, containerKind) {
     super(consumeConn, arc);
-    this._templateName = `${this.consumeConn.particle.name}::${this.consumeConn.name}`;
+    this._templateName = [this.consumeConn.particle.name, this.consumeConn.name].concat(
+        Object.values(this.consumeConn.particle.connections).filter(conn => conn.type.isInterface).map(conn => conn.view.id)).join('::');
     this._model = null;
     this._observer = this._initMutationObserver();
     this._containerKind = containerKind;

--- a/runtime/test/dom-slot-tests.js
+++ b/runtime/test/dom-slot-tests.js
@@ -33,7 +33,7 @@ DomContext.createTemplateElement = (template) => template;
 
 function createDomSlot(slotName) {
   // slotName should differ in each test case to avoid collision in DomSlot::templates.
-  return new DomSlot(/* consumeConn= */ {particle: {name:'MyParticle'}, name: slotName}, 'dummy-arc');
+  return new DomSlot(/* consumeConn= */ {particle: {name: 'MyParticle', connections: []}, name: slotName}, 'dummy-arc');
 }
 
 describe('dom-slot', function() {

--- a/runtime/test/manifest-test.js
+++ b/runtime/test/manifest-test.js
@@ -471,7 +471,7 @@ describe('manifest', function() {
         ++count;
       }
     })
-    assert.equal(count, 17);
+    assert.equal(count, 18);
   });
   it('loads entities from json files', async () => {
     let manifestSource = `
@@ -723,7 +723,7 @@ Expected " ", "#", "\\n", "\\r", [ ], [A-Z], or [a-z] but "?" found.
     let manifest = await Manifest.parse(`
       schema S
       shape HostedShape
-        HostedShape(in S foo) 
+        HostedShape(in S foo)
 
       particle Hosted
         Hosted(in S foo, in S bar)


### PR DESCRIPTION
Misc fixes:
- Product multiplexer: set positive rank
- Description
  . Maintain the correct order (by rank) of particles combined into a suggestion 
  . Capitalize first letter of resolved pattern's token in dom formatter 
- Hosted slots: distinguish xen templates of the same transformation particle but different hosted particles.

PS: I still keep the original particles for now, because they are helpful in debugging.

https://github.com/PolymerLabs/arcs/issues/299