### PR TITLE
Improve error logging for invalid view with no id.

### DIFF
--- a/runtime/recipe/recipe.js
+++ b/runtime/recipe/recipe.js
@@ -171,7 +171,7 @@ class Recipe {
         if (invalids.length > 0)
           console.log(`Has Invalid ${name} ${invalids.map(f)}`)
       }
-      checkForInvalid('Views', this._views, view => view.id);
+      checkForInvalid('Views', this._views, view => `'${view.toString()}'`);
       checkForInvalid('Particles', this._particles, particle => particle.name);
       checkForInvalid('Slots', this._slots, slot => slot.name);
       checkForInvalid('ViewConnections', this.viewConnections, viewConnection => `${viewConnection.particle.name}::${viewConnection.name}`);


### PR DESCRIPTION
It seems it's possible to have a recipe fail with an invalid view where there is no id. In this case the console log message looks like `Has Invalid Views` and then nothing further.

In the case I'm looking at, this change produces instead, `Has Invalid Views 'create #stats as undefined'`.

I think relying on the object's `toString` to output whatever useful information it may have is a better path than trying to finagle which field is most relevant and/or likely to be populated. Arguably we should revise the other invalid error message functions as well, but I have less insight there currently.

I also looked briefly at adding a test but there is no `recipe-test.js` currently and all this changes is a `console.log` message, so it seems perhaps not worthy, but open to feedback.