### PR TITLE
Use non-UI particles for descriptions, if there are no others

### DIFF
--- a/runtime/description.js
+++ b/runtime/description.js
@@ -63,11 +63,15 @@ export class DescriptionFormatter {
   async getDescription(particles) {
     await this._updateDescriptionHandles(this._description);
 
-    // Choose particles that render UI, sort them by rank and generate suggestions.
+    // Choose particles, sort them by rank and generate suggestions.
     let particlesSet = new Set(particles);
     let selectedDescriptions = this._particleDescriptions
-      .filter(desc => { return particlesSet.has(desc._particle) && desc._particle.spec.slots.size > 0 && this._isSelectedDescription(desc); })
-      .sort(DescriptionFormatter.sort);
+      .filter(desc => (particlesSet.has(desc._particle) && this._isSelectedDescription(desc)));
+    // Prefer particles that render UI, if any.
+    if (selectedDescriptions.find(desc => (desc._particle.spec.slots.size > 0))) {
+      selectedDescriptions = selectedDescriptions.filter(desc => (desc._particle.spec.slots.size > 0));
+    }
+    selectedDescriptions = selectedDescriptions.sort(DescriptionFormatter.sort);
 
     if (selectedDescriptions.length > 0) {
       return this._combineSelectedDescriptions(selectedDescriptions);

--- a/runtime/test/description-test.js
+++ b/runtime/test/description-test.js
@@ -583,6 +583,27 @@ recipe
       await test.verifySuggestion('Hello first b and second b, see you at only c.', description);
     });
   });
+
+  tests.forEach((test) => {
+    it('particle without UI description ' + test.name, async () => {
+      let {arc, recipe, fooView} = (await prepareRecipeAndArc(`
+${schemaManifest}
+${bParticleManifest}
+  description \`Populate \${ofoo}\`
+recipe
+  create as fooView   # Foo
+  B
+    ofoo -> fooView
+      `));
+
+      let description = new Description(arc);
+      await test.verifySuggestion('Populate foo.', description);
+
+      // Add value to singleton view.
+      fooView.set({id: 1, rawData: {name: 'foo-name', fooValue: 'the-FOO'}});
+      await test.verifySuggestion('Populate foo-name.', description);
+    });
+  });
 });
 
 describe('Dynamic description', function() {


### PR DESCRIPTION
If there are no UI rendering particles in the recipe, use non-UI particles for the description.
Currently we show 'undefined' in the suggestions box for such recipes.