### PR TITLE
Impedance match SlotComposer to AppShell for suggestion rendering

### DIFF
--- a/runtime/slot-composer.js
+++ b/runtime/slot-composer.js
@@ -31,7 +31,7 @@ class SlotComposer {
       this._contextById["root"] = options.rootContext;
     }
 
-    this._suggestionsContext = options.suggestionsContext;
+    this._suggestionsContext = options.suggestionsContext || this._contextById["suggestions"];
 
     this._slots = [];
   }
@@ -75,7 +75,8 @@ class SlotComposer {
       return;
     }
 
-    this._suggestionsContext.clear();
+    this._suggestionsContext.textContent = '';
+
     suggestions.forEach(async suggestion => {
       let suggestionContent =
         await suggestion.description.getRecipeSuggestion(this._getDescriptionFormatter());
@@ -85,9 +86,17 @@ class SlotComposer {
       }
 
       this._getSuggestionContext().createContext(
-          this._suggestionsContext.createSuggestionElement({hash: suggestion.hash, plan: suggestion.plan}),
-          suggestionContent);
+          this.createSuggestionElement(this._suggestionsContext, suggestion),
+          suggestionContent
+      );
     });
+  }
+
+  createSuggestionElement(container, plan) {
+    let suggest = Object.assign(document.createElement("suggestion-element"), {plan});
+    // TODO(sjmiles): LIFO is weird, iterate top-down elsewhere?
+    container.insertBefore(suggest, container.firstElementChild);
+    return suggest;
   }
 
   getSlot(particle, slotName) {


### PR DESCRIPTION
- Allow `_suggestionsContext` to be a simple context (DomNode) with no special API (almost: `textContent`). 
- Expect `suggestion-element` custom element to supply suggestion implementation.