### PR TITLE
Temporary fix assigning the global scheduler in the manifest

### DIFF
--- a/runtime/manifest.js
+++ b/runtime/manifest.js
@@ -18,6 +18,7 @@ import Shape from './shape.js';
 import Type from './type.js';
 import util from './recipe/util.js';
 import StorageProviderFactory from './storage/storage-provider-factory.js';
+import scheduler from './scheduler.js';
 
 class Manifest {
   constructor({id}) {
@@ -33,6 +34,7 @@ class Manifest {
     this._nextLocalID = 0;
     this._id = id;
     this._storageProviderFactory = new StorageProviderFactory(this);
+    this._scheduler = scheduler;
   }
   get id() {
     return this._id;


### PR DESCRIPTION
Arcs-cdn is seeing the following error: 
Uncaught (in promise) TypeError: Cannot read property 'enqueue' of undefined
    at InMemoryCollection._fire (storage-provider-base.js:66)
    at InMemoryCollection.store (in-memory-storage.js:133)
    at Object.values.forEach.e (arcs-utils.js:146)
    at Array.forEach (<anonymous>)
    at Function.addHandleData (arcs-utils.js:146)
    at Function.setHandleData (arcs-utils.js:133)
    at <anonymous>

Callstack:
_fire (storage-provider-base.js:66)
remove (in-memory-storage.js:145)
entities.forEach.e (arcs-utils.js:138)
clearHandle (arcs-utils.js:138)
______________________
await in clearHandle (async)
setHandleData (arcs-utils.js:132)
createOrUpdateHandle (arcs-utils.js:94)
await in createOrUpdateHandle (async)
______________________
Object.keys.forEach (remote-profile-handles.js:52)
_remoteHandlesChanged (remote-profile-handles.js:49)
handler (remote-profile-handles.js:41)
(anonymous) (firebase-storage.js:3474)
z (firebase-storage.js:3474)
t.raise (firebase-storage.js:3474)
t.In (firebase-storage.js:3474)
t.raiseEventsAtPath (firebase-storage.js:3474)
t.addEventCallbackForQuery (firebase-storage.js:3474)
t.onValueEvent (firebase-storage.js:3474)
t.on (firebase-storage.js:3474)
...