### PR TITLE
Manifest to not map slots with no name

### DIFF
--- a/runtime/manifest.js
+++ b/runtime/manifest.js
@@ -548,7 +548,8 @@ ${e.message}
         } else {
           targetSlot = recipe.newSlot(slotConnectionItem.param);
           targetSlot.localName = slotConnectionItem.name;
-          items.byName.set(slotConnectionItem.name, targetSlot);
+          if (slotConnectionItem.name)
+            items.byName.set(slotConnectionItem.name, targetSlot);
           items.bySlot.set(targetSlot, slotConnectionItem);
         }
         particle.consumedSlotConnections[slotConnectionItem.param].connectToSlot(targetSlot);

--- a/runtime/test/manifest-test.js
+++ b/runtime/test/manifest-test.js
@@ -22,26 +22,6 @@ async function assertRecipeParses(input, result) {
 }
 
 describe('manifest', function() {
-  it('duplicate consume slot', async () => {
-    let manifest = await Manifest.parse(`
-      particle SomeParticle in 'some-particle.js'
-        work()
-        consume slotA
-        consume slotB
-      particle SomeParticle1 in 'some-particle.js'
-        rest()
-        consume slotC
-
-      recipe
-        SomeParticle
-          consume slotA
-        SomeParticle1
-          consume slotC
-    `);
-    let recipe = manifest.recipes[0];
-    assert(recipe);
-  });
-
   it('can parse a manifest containing a recipe', async () => {
     let manifest = await Manifest.parse(`
       schema S
@@ -453,6 +433,24 @@ describe('manifest', function() {
     };
     verify(manifest);
     verify(await Manifest.parse(manifest.toString()));
+  });
+  it.only('unnamed consume slots', async () => {
+    let manifest = await Manifest.parse(`
+      particle SomeParticle in 'some-particle.js'
+        work()
+        consume slotA
+      particle SomeParticle1 in 'some-particle.js'
+        rest()
+        consume slotC
+
+      recipe
+        SomeParticle
+          consume slotA
+        SomeParticle1
+          consume slotC
+    `);
+    let recipe = manifest.recipes[0];
+    assert.equal(2, recipe.slots.length);
   });
   it('relies on the loader to combine paths', async () => {
     let registry = {};

--- a/runtime/test/manifest-test.js
+++ b/runtime/test/manifest-test.js
@@ -22,6 +22,26 @@ async function assertRecipeParses(input, result) {
 }
 
 describe('manifest', function() {
+  it('duplicate consume slot', async () => {
+    let manifest = await Manifest.parse(`
+      particle SomeParticle in 'some-particle.js'
+        work()
+        consume slotA
+        consume slotB
+      particle SomeParticle1 in 'some-particle.js'
+        rest()
+        consume slotC
+
+      recipe
+        SomeParticle
+          consume slotA
+        SomeParticle1
+          consume slotC
+    `);
+    let recipe = manifest.recipes[0];
+    assert(recipe);
+  });
+
   it('can parse a manifest containing a recipe', async () => {
     let manifest = await Manifest.parse(`
       schema S

--- a/runtime/test/planner-tests.js
+++ b/runtime/test/planner-tests.js
@@ -367,7 +367,7 @@ describe('MapRemoteSlots', function() {
       B()
       consume root
     `;
-    let testManifest = async (recipeManifest) => {
+    let testManifest = async (recipeManifest, expectedSlots) => {
       let manifest = (await Manifest.parse(`
         ${particlesSpec}
 
@@ -380,32 +380,39 @@ describe('MapRemoteSlots', function() {
       let {results} = await mrs.generate(strategizer);
       assert.equal(results.length, 1);
       assert.isTrue(results[0].result.isResolved());
-      assert.equal(results[0].result.slots.length, 1);
+      assert.equal(results[0].result.slots.length, expectedSlots);
     };
     await testManifest(`
       recipe
         A as particle0
         B as particle1
-    `);
+    `, /* expectedSlots= */ 1);
     await testManifest(`
       recipe
         A as particle0
           consume root
         B as particle1
-    `);
+    `, /* expectedSlots= */ 1);
     await testManifest(`
       recipe
         A as particle0
         B as particle1
           consume root
-    `);
+    `, /* expectedSlots= */ 1);
+    await testManifest(`
+      recipe
+        A as particle0
+          consume root as slot0
+        B as particle1
+          consume root as slot0
+    `, /* expectedSlots= */ 1);
     await testManifest(`
       recipe
         A as particle0
           consume root
         B as particle1
           consume root
-    `);
+    `, /* expectedSlots= */ 2);
   });
 });
 


### PR DESCRIPTION
to avoid incorrect assert:  "Target slot name X doesn't match slot connection name Y"