### PR TITLE
run webpack before test by default

### DIFF
--- a/tools/sigh.js
+++ b/tools/sigh.js
@@ -33,7 +33,7 @@ const steps = {
   webpack: [peg, webpack],
   watch: [watch],
   lint: [lint],
-  default: [peg, test, webpack, lint],
+  default: [peg, webpack, test, lint],
 };
 
 // Paths to `watch` for the `watch` step.


### PR DESCRIPTION
This allows downstream builds (specifically those in arcs-cdn) to continue even if the
arcs tests fail.