### PR TITLE
DEMO ONLY: Demonstrate duplicate recipes

### DIFF
--- a/particles/ShowProducts/ShowProducts.js
+++ b/particles/ShowProducts/ShowProducts.js
@@ -143,8 +143,8 @@ ${productStyles}
       });
 
       // This is for description capabilities demo purposes.
-      this._setDynamicDescription(items);
-      this._setDynamicDomDescription(items);
+      // this._setDynamicDescription(items);
+      // this._setDynamicDomDescription(items);
 
       this._setState({
         renderModel: {

--- a/particles/ShowProducts/ShowProducts.manifest
+++ b/particles/ShowProducts/ShowProducts.manifest
@@ -14,10 +14,10 @@ particle ShowProducts in 'ShowProducts.js'
   affordance dom
   affordance dom-touch
   consume root
-    provide action
-      view list
-    provide preamble
-    provide postamble
-    provide set of annotation
-      view list
+#    provide action
+#      view list
+#    provide preamble
+#    provide postamble
+#    provide set of annotation
+#      view list
   description `show ${list}`

--- a/runtime/browser/demo/demo.js
+++ b/runtime/browser/demo/demo.js
@@ -76,7 +76,7 @@ class DemoFlow extends DemoBase {
       slotComposer: new SlotComposer({
         rootContext: this.$('[particle-container]').parentNode,
         affordance: 'dom'}),
-      context: await Manifest.load('browser/demo/recipes.manifest', loader),
+      context: await Manifest.load('browser/demo/recipes-duplicate.manifest', loader),
       loader,
     });
     this.arc = arc;

--- a/runtime/browser/demo/recipes-duplicate.manifest
+++ b/runtime/browser/demo/recipes-duplicate.manifest
@@ -1,0 +1,67 @@
+# Copyright (c) 2017 Google Inc. All rights reserved.
+# This code may only be used under the BSD style license found at
+# http://polymer.github.io/LICENSE.txt
+# Code distributed by Google as part of this project is also
+# subject to an additional IP rights grant found at
+# http://polymer.github.io/PATENTS.txt
+
+import '../../../particles/ShowProducts/ShowProducts.manifest'
+import '../../../particles/ManageProducts/ManageProducts.manifest'
+import '../../../particles/Recommend/Recommend.manifest'
+import '../../../particles/Chooser/Chooser.manifest'
+import '../../../particles/GiftList/GiftList.manifest'
+import '../../../particles/Interests/Interests.manifest'
+import '../../../particles/ProductMultiplexer/ProductMultiplexer.manifest'
+import '../../../particles/ProductMultiplexer2/ProductMultiplexer2.manifest'
+import '../../../particles/AlsoOn/AlsoOn.manifest'
+import '../../../particles/Arrivinator/Arrivinator.manifest'
+import '../../../particles/ManufacturerInfo/ManufacturerInfo.manifest'
+
+############################
+# This recipe causes duplicate suggestion, because of the description handle.
+recipe
+  map as view0
+  map as view1
+  ShowProducts
+    list <- view0
+  ShowProducts
+    list <- view1
+############################
+#recipe
+#  create as view0 # Description List
+#  create as view1 # Description List
+#  map 'manifest:browser/demo/recipes-mini.manifest:view0' as view2 # Product List
+#  map 'manifest:browser/demo/recipes-mini.manifest:view1' as view3 # Product List
+#  slot 'rootslotid-root' as slot0
+#  ShowProducts as particle0
+#    descriptions -> view0
+#    list <- view3
+#    consume root as slot0
+#  ShowProducts as particle1
+#    descriptions -> view1
+#    list <- view2
+#    consume root as slot0
+#
+#
+#recipe
+#  create as view0 # Description List
+#  create as view1 # Description List
+#  map 'manifest:browser/demo/recipes-mini.manifest:view0' as view2 # Product List
+#  map 'manifest:browser/demo/recipes-mini.manifest:view1' as view3 # Product List
+#  slot 'rootslotid-root' as slot0
+#  ShowProducts as particle0
+#    descriptions -> view0
+#    list <- view2
+#    consume root as slot0
+#  ShowProducts as particle1
+#    descriptions -> view1
+#    list <- view3
+############################
+
+# TODO: move these to separate manifests for claire's wishlist / page
+view PageProducts of [Product] #shortlist in 'products.json'
+  description `products from your browsing context`
+view ClairesWishlist of [Product] #wishlist in 'wishlist.json'
+  description `Claire's wishlist`
+view APerson of Person in 'people.json'
+#view ThePeople of Person in 'people.json'


### PR DESCRIPTION
This is because of description views in this case, but in general I think we need to incorporate the logic that "create" views of the same type are interchangeable.

And also with PR https://github.com/PolymerLabs/arcs/pull/623, the question is
      recipe
        A as particle0
          consume root
        B as particle1
          consume root

The "root" slot - should it be same slot, or different slots?