### PR TITLE
Assert that storage key is defined.

### DIFF
--- a/runtime/arc.js
+++ b/runtime/arc.js
@@ -257,6 +257,7 @@ ${this.activeRecipe.toString()}`;
       let storageKey = recipeView.storageKey;
       if (!storageKey)
         storageKey = this.keyForId(recipeView.id);
+      assert(storageKey, `couldn't find storage key for view '${recipeView}'`);
       let view = await this._storageProviderFactory.connect(recipeView.id, recipeView.type, storageKey);
       assert(view, `view '${recipeView.id}' was not found`);
     }


### PR DESCRIPTION
This came up as an attempt to split on an undefined string while initially exploring Noe's prototype Social recipes. The recipe file has:

`map 'FRIENDS_PROFILE_posts' #friends_posts as posts`

and this ends up finding no storage key in `Arc.instantiate`. The recipe is rather kooky but at minimum having a more informative message seemed worth considering. Ref:

https://github.com/shaper/arcs-stories/blob/master/social/Social/Social.recipes#L25