### PR TITLE
Initial hooks for the Arcs DevTools Extension.

### DIFF
--- a/debug/outer-port-debug-channel.js
+++ b/debug/outer-port-debug-channel.js
@@ -1,0 +1,120 @@
+/**
+ * @license
+ * Copyright (c) 2018 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+ 'use strict';
+
+export default class OuterPortDebugChannel {
+  constructor(arcId) {
+    this._arcId = arcId;
+    this._callbackRegistry = {};
+    this._particleRegistry = {};
+  }
+
+  InstantiateParticle(particle, {id, spec, handles}) {
+    this._particleRegistry[id] = spec;
+  }
+
+  SimpleCallback({callback, data}) {
+    let callbackDetails = this._callbackRegistry[callback];
+    if (callbackDetails) {
+      // Copying callback data, as the callback can be used multiple times.
+      this._fireEvent(Object.assign({}, callbackDetails), data);
+    } else {
+      console.log('Missing SimpleCallback ', callback);
+    }
+  }
+
+  onSynchronize({handle, target, callback, modelCallback, type, particleId}) {
+    this._callbackRegistry[callback] = this._describeHandleCall(
+      {operation: `on-${type}`, handle, particleId});
+    this._callbackRegistry[modelCallback] = this._describeHandleCall(
+      {operation: 'sync-model', handle, particleId});
+  }
+
+  onHandleGet({handle, callback, particleId}) {
+    this._callbackRegistry[callback] = this._describeHandleCall(
+      {operation: 'get', handle, particleId});
+  }
+
+  onHandleToList({handle, callback, particleId}) {
+    this._callbackRegistry[callback] = this._describeHandleCall(
+      {operation: 'toList', handle, particleId});
+  }
+
+  onHandleSet({handle, data, particleId}) {
+    this._logHandleCall({operation: 'set', handle, data, particleId});
+  }
+
+  onHandleStore({handle, data, particleId}) {
+    this._logHandleCall({operation: 'store', handle, data, particleId});
+  }
+
+  onHandleClear({handle, particleId}) {
+    this._logHandleCall({operation: 'clear', handle, particleId});
+  }
+
+  onHandleRemove({handle, data, particleId}) {
+    this._logHandleCall({operation: 'remove', handle, data, particleId});
+  }
+
+  _logHandleCall(args) {
+    this._fireEvent(this._describeHandleCall(args), args.data);
+  }
+
+  _fireEvent(detail, data) {
+    // Debugging is currently only available in the browser env.
+    if (typeof window === 'object') {
+      detail.data = JSON.stringify(data);
+      detail.timestamp = Date.now();
+      document.dispatchEvent(new CustomEvent('arcs-debug', {detail}));
+    }
+  }
+
+  _describeHandleCall({operation, handle, particleId}) {
+    return {
+      arcId: this._arcId,
+      operation,
+      particle: this._describeParticle(particleId),
+      handle: this._describeHandle(handle)
+    };
+  }
+
+  _describeParticle(id) {
+    let particleSpec = this._particleRegistry[id];
+    return {
+      id,
+      name: particleSpec && particleSpec.name
+      // TODO: Send entire spec only once and refer to it by ID in the tool.
+    };
+  }
+
+  _describeHandle(handle) {
+    return {
+      id: handle.id,
+      storageKey: handle._storageKey,
+      name: handle.name,
+      description: handle.description,
+      type: this._describeHandleType(handle._type)
+    };
+  }
+
+  // TODO: This is fragile and incomplete. Change this into sending entire
+  //       handle object once and refer back to it via its ID in the tool.
+  _describeHandleType(handleType) {
+    switch (handleType.constructor.name) {
+      case 'Type':
+        return `${handleType.tag} ${this._describeHandleType(handleType.data)}`;
+      case 'Schema':
+        return handleType.name;
+      case 'Shape':
+        return 'Shape';
+    }
+    return '';
+  }
+}

--- a/runtime/api-channel.js
+++ b/runtime/api-channel.js
@@ -235,6 +235,9 @@ class APIPort {
       var call = {messageType: name, messageBody: this._processArguments(argumentTypes, args)};
       call.messageBody.identifier = this._mapper.createMappingForThing(thing);
       this._port.postMessage(call);
+      if (this._debugChannel && this._debugChannel[name]) {
+        this._debugChannel[name](thing, args);
+      }
     };
   }
 

--- a/runtime/arc.js
+++ b/runtime/arc.js
@@ -68,6 +68,12 @@ class Arc {
 
     this._search = null;
     this._description = new Description(this);
+
+    // Debugging is currently only available in the browser env.
+    if (typeof window === 'object') {
+      window._arcDebugHandles = window._arcDebugHandles || [];
+      window._arcDebugHandles.push(this);
+    }
   }
   get loader() {
     return this._loader;
@@ -392,6 +398,10 @@ ${this.activeRecipe.toString()}`;
     }
 
     return results.join('\n');
+  }
+
+  initDebug() {
+    this.pec.initDebug();
   }
 }
 

--- a/runtime/handle.js
+++ b/runtime/handle.js
@@ -38,7 +38,7 @@ function restore(entry, entityClass) {
  * Base class for Views and Variables.
  */
 class Handle {
-  constructor(view, canRead, canWrite, particleId) {
+  constructor(view, particleId, canRead, canWrite) {
     this._view = view;
     this.canRead = canRead;
     this.canWrite = canWrite;
@@ -110,9 +110,9 @@ class Handle {
  * connected.
  */
 class Collection extends Handle {
-  constructor(view, canRead, canWrite, particleId) {
+  constructor(view, particleId, canRead, canWrite) {
     // TODO: this should talk to an API inside the PEC.
-    super(view, canRead, canWrite, particleId);
+    super(view, particleId, canRead, canWrite);
   }
   query() {
     // TODO: things
@@ -206,10 +206,10 @@ class Variable extends Handle {
   }
 }
 
-function handleFor(view, isSet, canRead = true, canWrite = true, particleId) {
+function handleFor(view, isSet, particleId, canRead = true, canWrite = true) {
   return (isSet || (isSet == undefined && view.type.isSetView))
-      ? new Collection(view, canRead, canWrite, particleId)
-      : new Variable(view, canRead, canWrite, particleId);
+      ? new Collection(view, particleId, canRead, canWrite)
+      : new Variable(view, particleId, canRead, canWrite);
 }
 
 export default {handleFor};

--- a/runtime/inner-PEC.js
+++ b/runtime/inner-PEC.js
@@ -212,7 +212,7 @@ class InnerPEC {
       createHandle: function(type, name) {
         return new Promise((resolve, reject) =>
           pec._apiPort.ArcCreateHandle({arc: arcId, type, name, callback: proxy => {
-            var v = handle.handleFor(proxy, proxy.type.isSetView, true, true, particleId);
+            var v = handle.handleFor(proxy, proxy.type.isSetView, particleId);
             v.entityClass = (proxy.type.isSetView ? proxy.type.primitiveType().entitySchema : proxy.type.entitySchema).entityClass();
             resolve(v);
           }}));
@@ -265,7 +265,7 @@ class InnerPEC {
 
     var handleMap = new Map();
     proxies.forEach((value, key) => {
-      handleMap.set(key, handle.handleFor(value, value.type.isSetView, spec.connectionMap.get(key).isInput, spec.connectionMap.get(key).isOutput, id));
+      handleMap.set(key, handle.handleFor(value, value.type.isSetView, id, spec.connectionMap.get(key).isInput, spec.connectionMap.get(key).isOutput));
     });
 
     for (let localHandle of handleMap.values()) {

--- a/runtime/outer-PEC.js
+++ b/runtime/outer-PEC.js
@@ -161,6 +161,9 @@ class OuterPEC extends PEC {
   innerArcRender(transformationParticle, transformationSlotName, hostedSlotId, content) {
     this._apiPort.InnerArcRender({transformationParticle, transformationSlotName, hostedSlotId, content});
   }
+  initDebug() {
+    this._apiPort.initDebug(this._arc.id);
+  }
 }
 
 export default OuterPEC;


### PR DESCRIPTION
Adds particle IDs to handle related calls in the API channel and adds a debug channel firing events on the window object. These events will be consumed by the devtools extension that's coming in the following patch.