### PR TITLE
Fix hosted particle paths

### DIFF
--- a/particles/ProductFilter/ProductFilter.js
+++ b/particles/ProductFilter/ProductFilter.js
@@ -36,14 +36,15 @@ defineParticle(({Particle}) => {
           this._handleIds.add(product.id);
 
           var recipe = `
-            import '${hostedParticle.implFile.replace(/\.[^\.]+$/, '.manifest')}'
-            recipe
-              use '${productView._id}' as v1
-              use '${resultView._id}' as v2
-              ${hostedParticle.name}
-                ${hostedParticle.connections[0].name} <- v1
-                ${hostedParticle.connections[1].name} -> v2
-          `;
+${this.serializeSchema(hostedParticle)}
+import '${hostedParticle.implFile.replace(/\.[^\.]+$/, '.manifest')}'
+recipe
+  use '${productView._id}' as v1
+  use '${resultView._id}' as v2
+  ${hostedParticle.name}
+    ${hostedParticle.connections[0].name} <- v1
+    ${hostedParticle.connections[1].name} -> v2
+`;
 
           try {
             await arc.loadRecipe(recipe, this);

--- a/particles/ProductMultiplexer/ProductMultiplexer.js
+++ b/particles/ProductMultiplexer/ProductMultiplexer.js
@@ -44,15 +44,14 @@ defineParticle(({DomParticle}) => {
           this.hostedSlotBySlotId.set(slotId, {subId: item.id});
 
           var recipe = `
-            import '${hostedParticle.implFile.replace(/\.[^\.]+$/, '.manifest')}'
-            recipe
-              use '${itemView._id}' as v1
-              slot '${slotId}' as s1
-              ${hostedParticle.name}
-                ${hostedParticle.connections[0].name} <- v1
-                consume ${hostedSlotName} as s1
-          `;
-
+${this.serializeSchema(hostedParticle)}
+recipe
+  use '${itemView._id}' as v1
+  slot '${slotId}' as s1
+  ${hostedParticle.name}
+    ${hostedParticle.connections[0].name} <- v1
+    consume ${hostedSlotName} as s1
+`;
           try {
             await arc.loadRecipe(recipe, this);
             itemView.set(item);

--- a/particles/ProductMultiplexer2/ProductMultiplexer2.js
+++ b/particles/ProductMultiplexer2/ProductMultiplexer2.js
@@ -46,20 +46,19 @@ defineParticle(({DomParticle}) => {
           if (!slotId) {
             continue;
           }
-
           this.hostedSlotBySlotId.set(slotId, {subId: item.id});
 
-          var recipe = `
-            import '${hostedParticle.implFile.replace(/\.[^\.]+$/, '.manifest')}'
-            recipe
-              use '${itemView._id}' as v1
-              map '${othersMappedId}' as v2
-              slot '${slotId}' as s1
-              ${hostedParticle.name}
-                ${productConnName} <- v1
-                ${otherConnName} <- v2
-                consume ${hostedSlotName} as s1
-          `;
+          var recipe =
+`${this.serializeSchema(hostedParticle)}
+recipe
+  use '${itemView._id}' as v1
+  map '${othersMappedId}' as v2
+  slot '${slotId}' as s1
+  ${hostedParticle.name}
+    ${productConnName} <- v1
+    ${otherConnName} <- v2
+    consume ${hostedSlotName} as s1
+`;
 
           try {
             await arc.loadRecipe(recipe, this);

--- a/runtime/manifest.js
+++ b/runtime/manifest.js
@@ -235,7 +235,7 @@ ${e.message}
         await this._processView(manifest, item, loader);
       }
       for (let item of items.filter(item => item.kind == 'recipe')) {
-        await this._processRecipe(manifest, item);
+        await this._processRecipe(manifest, item, loader);
       }
       for (let meta of items.filter(item => item.kind == 'meta')) {
         manifest._meta.apply(meta.items);
@@ -332,7 +332,7 @@ ${e.message}
     shape.name = shapeItem.name;
     manifest._shapes.push(shape);
   }
-  static async _processRecipe(manifest, recipeItem) {
+  static async _processRecipe(manifest, recipeItem, loader) {
     // TODO: annotate other things too
     let recipe = manifest._newRecipe(recipeItem.name);
     recipe.annotation = recipeItem.annotation;
@@ -506,6 +506,10 @@ ${e.message}
           targetView = recipe.newView();
           targetView.fate = 'map';
           var view = await manifest.newView(connection.type, null, id, []);
+          // TODO: loader should not be optional.
+          if (hostedParticle.implFile && loader) {
+            hostedParticle.implFile = loader.join(manifest.fileName, hostedParticle.implFile);
+          }
           view.set(hostedParticle.toLiteral());
           targetView.mapToView(view);
         }

--- a/runtime/particle.js
+++ b/runtime/particle.js
@@ -178,6 +178,18 @@ export class Particle {
     }
     return false;
   }
+  // TODO: Move to transformation-particle class.
+  // TODO: Don't serialize schemas, once partial schemas are in use.
+  serializeSchema(hostedParticle) {
+    let hostedConnSchemas = new Set();
+    hostedParticle.connections.forEach(conn => {
+      hostedConnSchemas.add((conn.type.isSetView ? conn.type.primitiveType() : conn.type).entitySchema.toString());
+    });
+    var schemaString =
+`${[...hostedConnSchemas].map(schema => schema.toString()).join('\n\r')}
+${hostedParticle.toString()}`;
+    return schemaString;
+  }
 }
 
 export class ViewChanges {

--- a/runtime/test/demo-flow-test.js
+++ b/runtime/test/demo-flow-test.js
@@ -97,10 +97,10 @@ describe('demo flow', function() {
         .expectRenderSlot('Chooser', 'action', ['template', 'model'])
         .expectRenderSlot('AlsoOn', 'annotation', ['template', 'model'])
         .expectRenderSlot('ProductMultiplexer2', 'annotation', ['template', 'model'])
-        .expectRenderSlot('AlsoOn', 'annotation', ['model'])
-        .expectRenderSlot('ProductMultiplexer2', 'annotation', ['model'])
-        .expectRenderSlot('AlsoOn', 'annotation', ['model'])
-        .expectRenderSlot('ProductMultiplexer2', 'annotation', ['model']);
+        .expectRenderSlot('AlsoOn', 'annotation', ['template', 'model'])
+        .expectRenderSlot('ProductMultiplexer2', 'annotation', ['template', 'model'])
+        .expectRenderSlot('AlsoOn', 'annotation', ['template', 'model'])
+        .expectRenderSlot('ProductMultiplexer2', 'annotation', ['template', 'model']);
     await arc.instantiate(plan);
     await arc.pec.idle;
     await slotComposer.expectationsCompleted();


### PR DESCRIPTION
- use absolute paths for hosted particle impl files in manifest
- serialize particle spec and connection type schemas in inner recipe (instead of import)