### PR TITLE
Add simple install and test scripts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,17 +9,13 @@ Particle developers should visit our [particle developer website](https://polyme
 Note that you need a **recent** version of Node because we use new ES6 features. v9 is definitely OK.
 
 ```
-$ npm install
-$ npm install -g bower
-$ (cd strategy-explorer && bower install)
-$ (cd extension && npm install)
+% ./tools/install
 
 ```
 
 ## Test
 ```
-$ ./tools/sigh test
-$ (cd extension && npm test)
+$ ./tools/test
 ```
 
 ## Demo

--- a/tools/install
+++ b/tools/install
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+ROOT=$(dirname $0)/..
+(cd $ROOT && npm install)
+(cd $ROOT && npm install)
+npm install -g bower
+(cd $ROOT/strategy-explorer && bower install)
+(cd $ROOT/extension && npm install)

--- a/tools/install
+++ b/tools/install
@@ -2,7 +2,7 @@
 
 ROOT=$(dirname $0)/..
 (cd $ROOT && npm install)
-(cd $ROOT && npm install)
 npm install -g bower
+(cd $ROOT/devtools && npm install && bower install)
 (cd $ROOT/strategy-explorer && bower install)
 (cd $ROOT/extension && npm install)

--- a/tools/test
+++ b/tools/test
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+ROOT=$(dirname $0)/..
+$ROOT/tools/sigh test
+(cd $ROOT/extension && npm test)


### PR DESCRIPTION
For discussion, catalyzed by my never knowing whether there are `npm` packages I need to install for one or another subdirectory, feeling like the `README.md` directions were getting long, and having to check out and install stuff on a new Mac laptop recently.

In fact I did find I was missing some packages when I ran the install script. Potentially we could rename it `update` or `update-build` or something else since one might want to run it more than one time.

Obvious alternatives:

- Keep things as they are
- Move this into `sigh`, and have `sigh install` and `sigh test` do all of the right stuff
- Makefiles (LOL?) or similar