### PR TITLE
Reference arc IDs instead of arcs inside storage objects.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "firebase": "^4.9.0",
-    "node-fetch": "^1.7.2"
+    "node-fetch": "^1.7.2",
+    "btoa": "^1.1.2"
   }
 }

--- a/platform/btoa-node.js
+++ b/platform/btoa-node.js
@@ -1,0 +1,9 @@
+// Copyright (c) 2017 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+import btoa from 'btoa';
+export default btoa;

--- a/platform/btoa-web.js
+++ b/platform/btoa-web.js
@@ -1,0 +1,10 @@
+// Copyright (c) 2017 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+// Assume firebase has been loaded. We can't `import` it here as it does not
+// support strict mode.
+export default window.btoa;

--- a/runtime/arc.js
+++ b/runtime/arc.js
@@ -57,7 +57,7 @@ class Arc {
     if (slotComposer) {
       slotComposer.arc = this;
     }
-    this._storageProviderFactory = new StorageProviderFactory(this);
+    this._storageProviderFactory = new StorageProviderFactory(this.id);
 
     // Dictionary from each tag string to a list of handles
     this._tags = {};
@@ -147,6 +147,7 @@ ${this.activeRecipe.toString()}`;
     assert(handleMap.views.size >= handleMap.spec.connections.filter(c => !c.isOptional).length,
            `Not all mandatory connections are resolved for {$particle}`);
     this.pec.instantiate(recipeParticle, id, handleMap.spec, handleMap.views, this._lastSeenVersion);
+    recipeParticle._scheduler = this.scheduler;
     return id;
   }
 

--- a/runtime/manual_tests/firebase-tests.js
+++ b/runtime/manual_tests/firebase-tests.js
@@ -22,7 +22,7 @@ describe('firebase', function() {
           Text value
     `);
     let arc = new Arc({id: 'test'});
-    let storage = new StorageProviderFactory(arc);
+    let storage = new StorageProviderFactory(arc.id);
     let BarType = Type.newEntity(manifest.schemas.Bar);
     let value = 'Hi there' + Math.random();
     let variable = await storage.connect('test0', BarType, 
@@ -39,7 +39,7 @@ describe('firebase', function() {
           Text value
     `);
     let arc = new Arc({id: 'test'});
-    let storage = new StorageProviderFactory(arc);
+    let storage = new StorageProviderFactory(arc.id);
     let BarType = Type.newEntity(manifest.schemas.Bar);
     let value1 = 'Hi there' + Math.random();
     let value2 = 'Goodbye' + Math.random();
@@ -55,5 +55,5 @@ describe('firebase', function() {
     assert(result[0].id = 'test0:test0');
     assert(result[1].value = value2);
     assert(result[1].id = 'test1:test1');
-  });
+  }).timeout(10000);
 });

--- a/runtime/storage/firebase-storage.js
+++ b/runtime/storage/firebase-storage.js
@@ -10,6 +10,7 @@ import StorageProviderBase from './storage-provider-base.js';
 import firebase from '../../platform/firebase-web.js';
 import assert from '../../platform/assert-web.js';
 import KeyBase from './key-base.js';
+import btoa from '../../platform/btoa-web.js';
 
 class FirebaseKey extends KeyBase {
   constructor(key) {
@@ -60,8 +61,8 @@ async function realTransaction(reference, transactionFunction) {
 let _nextAppNameSuffix = 0;
 
 export default class FirebaseStorage {
-  constructor(arc) {
-    this._arc = arc;
+  constructor(arcId) {
+    this._arcId = arcId;
     this._apps = {};
   }
 
@@ -114,21 +115,21 @@ export default class FirebaseStorage {
     if (!result.committed)
       return null;
 
-    return FirebaseStorageProvider.newProvider(type, this._arc, id, reference, key);
+    return FirebaseStorageProvider.newProvider(type, this._arcId, id, reference, key);
   }
 }
 
 class FirebaseStorageProvider extends StorageProviderBase {
-  constructor(type, arc, id, reference, key) {
-    super(type, arc, undefined, id, key.toString());
+  constructor(type, arcId, id, reference, key) {
+    super(type, arcId, undefined, id, key.toString());
     this.firebaseKey = key;
     this.reference = reference;
   }
 
-  static newProvider(type, arc, id, reference, key) {
+  static newProvider(type, arcId, id, reference, key) {
     if (type.isSetView)
-      return new FirebaseCollection(type, arc, id, reference, key);
-    return new FirebaseVariable(type, arc, id, reference, key);
+      return new FirebaseCollection(type, arcId, id, reference, key);
+    return new FirebaseVariable(type, arcId, id, reference, key);
   }
 
   static encodeKey(key) {
@@ -142,8 +143,8 @@ class FirebaseStorageProvider extends StorageProviderBase {
 }
 
 class FirebaseVariable extends FirebaseStorageProvider {
-  constructor(type, arc, id, reference, firebaseKey) {
-    super(type, arc, id, reference, firebaseKey);
+  constructor(type, arcId, id, reference, firebaseKey) {
+    super(type, arcId, id, reference, firebaseKey);
     this.dataSnapshot = undefined;
     this._pendingGets = [];
     this.reference.on('value', dataSnapshot => {
@@ -183,8 +184,8 @@ class FirebaseVariable extends FirebaseStorageProvider {
 }
 
 class FirebaseCollection extends FirebaseStorageProvider {
-  constructor(type, arc, id, reference, firebaseKey) {
-    super(type, arc, id, reference, firebaseKey);
+  constructor(type, arcId, id, reference, firebaseKey) {
+    super(type, arcId, id, reference, firebaseKey);
     this.dataSnapshot = undefined;
     this._pendingGets = [];
     this.reference.on('value', dataSnapshot => {

--- a/runtime/storage/storage-provider-factory.js
+++ b/runtime/storage/storage-provider-factory.js
@@ -11,9 +11,9 @@ import InMemoryStorage from './in-memory-storage.js';
 import FirebaseStorage from './firebase-storage.js';
 
 export default class StorageProviderFactory {
-  constructor(arc) {
-    this._arc = arc;
-    this._storageInstances = {'in-memory': new InMemoryStorage(arc), 'firebase': new FirebaseStorage(arc)};
+  constructor(arcId) {
+    this._arcId = arcId;
+    this._storageInstances = {'in-memory': new InMemoryStorage(arcId), 'firebase': new FirebaseStorage(arcId)};
   }
 
   _storageForKey(key) {

--- a/runtime/test/test-util.js
+++ b/runtime/test/test-util.js
@@ -12,6 +12,7 @@
 
 import {assert} from './chai-web.js';
 import handle from '../handle.js';
+import scheduler from '../scheduler.js';
 
 function assertSingletonWillChangeTo(view, entityClass, expectation) {
   return new Promise((resolve, reject) => {
@@ -22,7 +23,7 @@ function assertSingletonWillChangeTo(view, entityClass, expectation) {
         return;
       assert.equal(result.value, expectation);
       resolve();
-    }), {});
+    }), {_scheduler: scheduler});
   });
 }
 
@@ -48,7 +49,7 @@ function assertViewWillChangeTo(setView, entityClass, field, expectations) {
           else
             reject(new Error(`expected ${expectations} but got ${result.map(a => a[field])}`));
       }
-    }), {});
+    }), {_scheduler: scheduler});
   });
 }
 

--- a/runtime/test/view-test.js
+++ b/runtime/test/view-test.js
@@ -115,7 +115,7 @@ describe('View', function() {
         resolver(keyFragment);
         return {type};
       }
-    }(arc);
+    }(arc.id);
     arc.createHandle(manifest.schemas.Bar.type, 'foo', 'test1');
     let result = await promise;
     assert(result == 'firebase://test-firebase-45a3e.firebaseio.com/AIzaSyBLqThan3QCOICj0JZ-nEwk27H4gmnADP8/handles/test1');


### PR DESCRIPTION
This enables us to boot up storage objects for manifests representing
arcs without having to make a live arc first.