### PR TITLE
remove debugger statement

### DIFF
--- a/platform/assert-web.js
+++ b/platform/assert-web.js
@@ -7,7 +7,6 @@
 
 export default function assert(test, message) {
   if (!test) {
-    debugger;
     throw new Error(message);
   }
 };


### PR DESCRIPTION
Forcing the debugger to break on this assert is problematic for my front-end work. 

I'm hoping it's just vestigial and not important for some other reason. Can discuss further if this change is a problem.