### PR TITLE
Proposal for using object IDs for api channel mapping

### DIFF
--- a/runtime/storage/storage-provider-base.js
+++ b/runtime/storage/storage-provider-base.js
@@ -103,4 +103,8 @@ export default class StorageProviderBase {
       results.push(`  description \`${this.description}\``);
     return results.join('\n');
   }
+
+  get apiChannelMappingId() {
+    return this.id;
+  }
 }


### PR DESCRIPTION
Proposes using handle IDs and particle IDs as keys in the mapping for api-channel communication.

We introduce 2 mechanisms:
- Defining '__api_channel_mapping_id' getter on the object to be used for api channel mapping in the initializer (better name suggestions welcome).
- Indicating one of the initializer arguments as ID to be used (as on the outer PEC side there is no real particle object, earlier strategy cannot be used).