### PR TITLE
fix "ReferenceError: strategy is not defined" error in strategizer

### DIFF
--- a/strategizer/strategizer.js
+++ b/strategizer/strategizer.js
@@ -80,9 +80,9 @@ export class Strategizer {
     record.invalidDerivationsByStrategy = {};
 
     generated = generated.filter(result => {
+      let strategy = result.derivation[0].strategy.constructor.name;
       if (result.hash) {
         let existingResult = this.populationHash.get(result.hash);
-        let strategy = result.derivation[0].strategy.constructor.name;
         if (existingResult) {
           if (result.derivation[0].parent == existingResult) {
             record.nullDerivations += 1;


### PR DESCRIPTION
ReferenceError: strategy is not defined
      at generated.filter.result (file://strategizer/strategizer.js:106:45)
      at Array.filter (<anonymous>)
      at Strategizer.generate (file://strategizer/strategizer.js:82:27)
      at <anonymous>

Introduced here:
https://github.com/PolymerLabs/arcs/commit/883e4a604c573d0b2b0dc24090188f112be5dc74#diff-4021dc4909f1a16b075906ee819de976