### PR TITLE
Improves message handling of the Devtools Extension

### DIFF
--- a/devtools/src/arcs-dataflow.html
+++ b/devtools/src/arcs-dataflow.html
@@ -214,25 +214,33 @@
         };
       }
 
-      handleEvents(eventsLog) {
+      onMessages(messages) {
         let current = [];
         let filtered = [];
         let rest = new Map();
-        for (let e of eventsLog) {
-          // If user hasn't selected an arc, and this event is not from
-          // a speculative execution, select this arc.
-          if (!this.selectedArcId && e.arcId.indexOf(':') === -1) {
-            this.set('selectedArcId', e.arcId);
-          }
-          if (this.selectedArcId === e.arcId) {
-            current.push(e);
-            if (this._filter(e)) filtered.push(e);
-          } else {
-            if (rest.has(e.arcId)) {
-              rest.get(e.arcId).push(e);
-            } else {
-              rest.set(e.arcId, [e]);
-            }
+        for (let msg of messages) {
+          switch (msg.messageType) {
+            case 'dataflow':
+              let e = msg.messageBody;
+              // If user hasn't selected an arc, and this event is not from
+              // a speculative execution, select this arc.
+              if (!this.selectedArcId && e.arcId.indexOf(':') === -1) {
+                this.set('selectedArcId', e.arcId);
+              }
+              if (this.selectedArcId === e.arcId) {
+                current.push(e);
+                if (this._filter(e)) filtered.push(e);
+              } else {
+                if (rest.has(e.arcId)) {
+                  rest.get(e.arcId).push(e);
+                } else {
+                  rest.set(e.arcId, [e]);
+                }
+              }
+              break;
+            case 'page-refresh':
+              this._clear();
+              return; // page-refresh is not bundled with anything else.
           }
         }
         // Apply changes in bulk to avoid freezing page.
@@ -250,7 +258,7 @@
         }
       }
 
-      clear() {
+      _clear() {
         this.set('perArcLogs', {});
         this.set('selectedArcId', '');
       }

--- a/devtools/src/arcs-debug-channel.html
+++ b/devtools/src/arcs-debug-channel.html
@@ -52,7 +52,7 @@
             tabId: chrome.devtools.inspectedWindow.tabId
         });
         backgroundPageConnection.onMessage.addListener(
-          e => this._surfaceIncomingMessage(e));
+          e => this._surfaceIncomingMessages(e));
       }
 
       _connectViaWebSocket() {
@@ -63,10 +63,7 @@
         ws.onclose = e => this._updateUi('Disconnected', false);
         ws.onopen = e => {
           this._updateUi('Node JS', true);
-          ws.onmessage = message => this._surfaceIncomingMessage({
-            message: 'arcs-message',
-            data: JSON.parse(message.data)
-          });
+          ws.onmessage = msg => this._surfaceIncomingMessages(JSON.parse(msg.data));
           ws.send("init");
         };
       }
@@ -80,8 +77,8 @@
         }
       }
 
-      _surfaceIncomingMessage(e) {
-        this.dispatchEvent(new CustomEvent('message', {detail: e}));
+      _surfaceIncomingMessages(e) {
+        this.dispatchEvent(new CustomEvent('messages', {detail: e}));
       }
     }
 

--- a/devtools/src/arcs-devtools-app.html
+++ b/devtools/src/arcs-devtools-app.html
@@ -55,9 +55,9 @@
           <a name="dataflow" href="javascript:void(0)"><iron-icon icon="swap-horiz"></iron-icon>Dataflow</a>
           <a name="strategyExplorer" href="javascript:void();"><iron-icon icon="settings-applications"></iron-icon>Strategy Explorer</a>
         </iron-selector>
-        <arcs-debug-channel on-message="onMessage"></arcs-debug-channel>
+        <arcs-debug-channel on-messages="onMessages"></arcs-debug-channel>
       </app-drawer>
-      <iron-pages selected="[[page]]" attr-for-selected="name" role="main">
+      <iron-pages selected="[[page]]" attr-for-selected="name" role="main" id="pages">
         <arcs-inspector name="inspector"></arcs-inspector>
         <arcs-dataflow id="dataflow" name="dataflow"></arcs-dataflow>
         <arcs-strategy-explorer name="strategyExplorer"></arcs-strategy-explorer>
@@ -74,15 +74,9 @@
         this.page = 'dataflow';
       }
 
-      onMessage({detail}) {
-        switch (detail.message) {
-          case 'arcs-message':
-            this.$.dataflow.handleEvents(detail.data);
-            break;
-          case 'page-refresh':
-            this.$.dataflow.clear();
-            break;
-        }
+      onMessages({detail}) {
+        this.$.pages.childNodes.forEach(
+          page => {if (page.onMessages) page.onMessages(detail);});
       }
     }
 

--- a/devtools/src/background.js
+++ b/devtools/src/background.js
@@ -21,10 +21,10 @@ chrome.runtime.onConnect.addListener(function(port) {
 });
 
 // Message from the content script.
-chrome.runtime.onMessage.addListener(function(data, sender, sendResponse) {
+chrome.runtime.onMessage.addListener(function(message, sender, sendResponse) {
   let tabId = sender.tab.id;
   if (tabId in connections) {
-    connections[tabId].postMessage({message: 'arcs-message', data});
+    connections[tabId].postMessage(message);
   }
   return true;
 });
@@ -35,7 +35,7 @@ chrome.webNavigation.onCommitted.addListener(function(details) {
   }
   let tabId = details.tabId;
   if (tabId in connections) {
-    connections[tabId].postMessage({message: 'page-refresh'});
+    connections[tabId].postMessage([{messageType: 'page-refresh'}]);
     chrome.tabs.sendMessage(tabId, {initDebug: true});
   }
 });

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "minimist": "^1.2.0",
     "mocha": "^3.2.0",
     "pegjs": "^0.10.0",
-    "polymer-cli": "^1.5.7",
+    "polymer-cli": "^1.6.0",
     "webpack": "^2.6.1"
   },
   "dependencies": {

--- a/runtime/debug/outer-port-attachment.js
+++ b/runtime/debug/outer-port-attachment.js
@@ -67,10 +67,10 @@ export default class OuterPortAttachment {
     this._sendMessage(this._describeHandleCall(args), args.data);
   }
 
-  _sendMessage(message, data) {
-    message.data = JSON.stringify(data);
-    message.timestamp = Date.now();
-    devtoolsChannelProvider.get().send(message);
+  _sendMessage(messageBody, data) {
+    messageBody.data = JSON.stringify(data);
+    messageBody.timestamp = Date.now();
+    devtoolsChannelProvider.get().send({messageType: 'dataflow', messageBody});
   }
 
   _describeHandleCall({operation, handle, particleId}) {


### PR DESCRIPTION
In particular:
- Renames attributes of the message to messageType and messageBody, which is cleaner.
- Pages of the devtools extension get incoming messages as is, without the need for the master page to understand semantics.
- Metadata about message types are no longer scattered around random files, but defined by the sender. This will unlock adding new message types in a sane way.

Also updating the polymer CLI to new version, so that it doesn't complain.