### PR TITLE
dispatch events directly, bypassing slot event registration

### DIFF
--- a/runtime/dom-particle.js
+++ b/runtime/dom-particle.js
@@ -12,17 +12,10 @@
 import assert from '../platform/assert-web.js';
 import {
   Particle,
-  ViewChanges,
-  //StateChanges,
-  //SlotChanges
+  ViewChanges
 } from './particle.js';
 
 import XenStateMixin from './browser/lib/xen-state.js';
-
-//let log = !global.document || (global.logging === false) ? () => {} : console.log.bind(console, `---------- DomParticle::`);
-//console.log(!!global.document, global.logging, log);
-
-let log = false ? console.log.bind(console) : () => {};
 
 /** @class DomParticle
  * Particle that does stuff with DOM.
@@ -126,25 +119,13 @@ class DomParticle extends XenStateMixin(Particle) {
       slot.render({});
     }
   }
-  _initializeRender(slot) {
-    let template = this.getTemplate(slot.slotName);
-    this._findHandlerNames(template).forEach(name => {
-      slot.clearEventHandlers(name);
-      slot.registerEventHandler(name, eventlet => {
-        if (this[name]) {
-          this[name](eventlet, this._state, this._views);
-        }
-      });
-    });
-    return template;
-  }
-  _findHandlerNames(html) {
-    let handlers = new Map();
-    let re = /on-.*?=\"([^\"]*)"/gmi;
-    for (let m=re.exec(html); m; m=re.exec(html)) {
-      handlers.set(m[1], true);
+  fireEvent(slotName, {handler, data}) {
+    if (this[handler]) {
+      this[handler]({data});
     }
-    return Array.from(handlers.keys());
+  }
+  _initializeRender(slot) {
+    return this.getTemplate(slot.slotName);
   }
   setParticleDescription(pattern) {
     if (typeof pattern === 'string') {

--- a/runtime/dom-particle.js
+++ b/runtime/dom-particle.js
@@ -108,7 +108,7 @@ class DomParticle extends XenStateMixin(Particle) {
     if (this._shouldRender(this._props, this._state)) {
       let content = {};
       if (slot._requestedContentTypes.has('template')) {
-        content['template'] = this._initializeRender(slot);
+        content['template'] = this.getTemplate(slot.slotName);
       }
       if (slot._requestedContentTypes.has('model')) {
         content['model'] = this._render(this._props, this._state);
@@ -121,11 +121,8 @@ class DomParticle extends XenStateMixin(Particle) {
   }
   fireEvent(slotName, {handler, data}) {
     if (this[handler]) {
-      this[handler]({data});
+      this[handler]({data}, this._state);
     }
-  }
-  _initializeRender(slot) {
-    return this.getTemplate(slot.slotName);
   }
   setParticleDescription(pattern) {
     if (typeof pattern === 'string') {


### PR DESCRIPTION
I did this because it eliminates some the work around event registration that is bothersome in DomParticle, but it also incidentally fixed a problem I was having in the TVShow demo (where DOM events only worked on the first invocation of the detail panel).

The incidental repair removes a blocker for me, so that increased the priority on getting this in (if it's ok).

This change is isolated to DomParticle, so that limits the risk if we decide it's _too_ simple.

