### PR TITLE
Allow arc serialize/deserialize to deal with handles/storage and particles.

### DIFF
--- a/runtime/handle.js
+++ b/runtime/handle.js
@@ -39,6 +39,7 @@ function restore(entry, entityClass) {
  */
 class Handle {
   constructor(view, particleId, canRead, canWrite) {
+    assert(!(view instanceof Handle));
     this._view = view;
     this.canRead = canRead;
     this.canWrite = canWrite;

--- a/runtime/loader.js
+++ b/runtime/loader.js
@@ -30,6 +30,9 @@ class Loader {
   join(prefix, path) {
     if (/^https?:\/\//.test(path))
       return path;
+    // TODO: replace this with something that isn't hacky
+    if (path[0] == '/' || path[1] == ':')
+      return path;
     prefix = this.path(prefix);
     return prefix + path;
   }

--- a/runtime/manifest-parser.peg
+++ b/runtime/manifest-parser.peg
@@ -215,9 +215,15 @@ Meta
 
 MetaItem = MetaStorageKey / MetaName
 
-MetaName = 'name' whiteSpace? ':' whiteSpace? name:id { return { key: 'name', value: name, location: location(), kind: 'name' } }
+MetaName = 'name' whiteSpace? ':' whiteSpace? name:id eolWhiteSpace
+{
+  return { key: 'name', value: name, location: location(), kind: 'name' }
+}
 
-MetaStorageKey = 'storageKey' whiteSpace? ':' whiteSpace? key:id { return {key: 'storageKey', value: key}};
+MetaStorageKey = 'storageKey' whiteSpace? ':' whiteSpace? key:id eolWhiteSpace
+{
+  return {key: 'storageKey', value: key, location: location(), kind: 'storageKey' }
+};
 
 Particle
   = 'particle' whiteSpace name:TopLevelIdent implFile:(whiteSpace 'in' whiteSpace id)? eolWhiteSpace items:(Indent (SameIndent ParticleItem)*)? eolWhiteSpace?

--- a/runtime/manifest.js
+++ b/runtime/manifest.js
@@ -410,6 +410,9 @@ ${e.message}
       let ref = item.ref || {tags: []};
       if (ref.id) {
         view.id = ref.id;
+        let targetView = manifest.findHandleById(view.id);
+        if (targetView)
+          view.mapToView(targetView);
       } else if (ref.name) {
         let targetView = manifest.findViewByName(ref.name);
         // TODO: Error handling.
@@ -655,21 +658,28 @@ ${e.message}
       json = await loader.loadResource(source);
     } else if (item.origin == 'resource') {
       json = manifest.resources[item.source];
+      if (json == undefined)
+        throw new Error(`Resource ${item.source} referenced by view ${id} is not defined in this manifest`);
     }
     let entities = JSON.parse(json);
     for (let entity of entities) {
-      let id = entity.$id || manifest.generateID();
-      delete entity.$id;
-      if (type.isSetView) {
+      if (entity == null && !type.isSetView) {
+        view.clear();
+      } else {
+        let id = entity.$id || manifest.generateID();
+        delete entity.$id;
+      
+        if (type.isSetView) {
         view.store({
           id,
           rawData: entity,
         });
-      } else {
-        view.set({
-          id,
-          rawData: entity,
-        });
+        } else {
+          view.set({
+            id,
+            rawData: entity,
+          });
+        }
       }
     }
   }

--- a/runtime/manifest.js
+++ b/runtime/manifest.js
@@ -670,10 +670,10 @@ ${e.message}
         delete entity.$id;
       
         if (type.isSetView) {
-        view.store({
-          id,
-          rawData: entity,
-        });
+          view.store({
+            id,
+            rawData: entity,
+          });
         } else {
           view.set({
             id,

--- a/runtime/storage/in-memory-storage.js
+++ b/runtime/storage/in-memory-storage.js
@@ -149,30 +149,8 @@ class InMemoryCollection extends InMemoryStorageProvider {
   // TODO: Something about iterators??
   // TODO: Something about changing order?
 
-  extractEntities(set) {
-    this._items.forEach(a => set.add(a));
-  }
-
-  serialize(list) {
-    list.push({
-      id: this.id,
-      sort: 'view',
-      type: this.type.toLiteral(),
-      name: this.name,
-      values: this.toList().map(a => a.id),
-      version: this._version
-    });
-  }
-
-  serializeMappingRecord(list) {
-    list.push({
-      id: this.id,
-      sort: 'view',
-      type: this.type.toLiteral(),
-      name: this.name,
-      version: this._version,
-      arc: this._arcId
-    });
+  serializedData() {
+    return this.toList();
   }
 }
 
@@ -216,34 +194,7 @@ class InMemoryVariable extends InMemoryStorageProvider {
     this.set(undefined);
   }
 
-  extractEntities(set) {
-    if (!this._stored) {
-      return;
-    }
-    set.add(this._stored);
-  }
-
-  serialize(list) {
-    if (this._stored == undefined)
-      return;
-    list.push({
-      id: this.id,
-      sort: 'variable',
-      type: this.type.toLiteral(),
-      name: this.name,
-      value: this._stored.id,
-      version: this._version
-    });
-  }
-
-  serializeMappingRecord(list) {
-    list.push({
-      id: this.id,
-      sort: 'variable',
-      type: this.type.toLiteral(),
-      name: this.name,
-      version: this._version,
-      arc: this._arcId
-    });
+  serializedData() {
+    return [this._stored];
   }
 }


### PR DESCRIPTION
Note that the storageProviderFactory needs to be an argument to arc so that the already-constructed factory from the manifest can be used.