### PR TITLE
use 'build' instead of 'lib' to store built files in the shell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,5 @@
 runtime/browser-test/browser-test-ified.js
 manifest-railroad.html
 **/*.code-workspace
-shell/lib
-shell/test/errorShots/**
+shell/build
+shell/test/errorShots

--- a/shell/app-shell/lib/arcs-utils.js
+++ b/shell/app-shell/lib/arcs-utils.js
@@ -40,8 +40,8 @@ const ArcsUtils = {
   },
   createUrlMap(cdnRoot) {
     // Module import not available in workers yet, we have to use the build for now
-    //const lib = document.URL.includes('debug') ? 'source' : 'lib';
-    const lib = 'lib';
+    //const lib = document.URL.includes('debug') ? 'source' : 'build';
+    const lib = 'build';
     return {
       // TODO(sjmiles): mapping root and dot-root allows browser-cdn-loader to replace right-hand
       // side with fully-qualified URL when loading from worker context

--- a/shell/apps/vr/index.debug.html
+++ b/shell/apps/vr/index.debug.html
@@ -35,8 +35,8 @@
   <!-- firebase config is required before loading runtime -->
   <script type="module" src="../../app-shell/firebase-config.js"></script>
 
-  <!-- load runtime (from build [lib] or source [source])
-  <!--<script type="module" src="../../lib/ArcsLib.js"></script>-->
+  <!-- load runtime (from build [build] or source [source])
+  <!--<script type="module" src="../../build/ArcsLib.js"></script>-->
   <script type="module" src="../../source/ArcsLib.js"></script>
 
   <script src="https://rawgit.com/aframevr/aframe/f8cb168/dist/aframe-master.js"></script>

--- a/shell/apps/vr/index.html
+++ b/shell/apps/vr/index.html
@@ -35,8 +35,8 @@
   <!-- firebase config is required before loading runtime -->
   <script type="module" src="../../app-shell/firebase-config.js"></script>
 
-  <!-- load runtime (from build [lib] or source [source])-->
-  <script type="module" src="../../lib/ArcsLib.js"></script>
+  <!-- load runtime (from build [build] or source [source])-->
+  <script type="module" src="../../build/ArcsLib.js"></script>
   <!--<script type="module" src="../../source/ArcsLib.js"></script>-->
 
   <script src="https://rawgit.com/aframevr/aframe/f8cb168/dist/aframe-master.js"></script>

--- a/shell/apps/web/index.debug.html
+++ b/shell/apps/web/index.debug.html
@@ -35,8 +35,8 @@
   <!-- firebase config is required before loading runtime -->
   <script type="module" src="../../app-shell/firebase-config.js"></script>
 
-  <!-- load runtime (from build [lib] or source [source])
-  <!--<script type="module" src="../../lib/ArcsLib.js"></script>-->
+  <!-- load runtime (from build [build] or source [source])
+  <!--<script type="module" src="../../build/ArcsLib.js"></script>-->
   <script type="module" src="../../source/ArcsLib.js"></script>
 
   <script type="module" src="../../app-shell/app-shell.js"></script>

--- a/shell/apps/web/index.html
+++ b/shell/apps/web/index.html
@@ -35,8 +35,8 @@
   <!-- firebase config is required before loading runtime -->
   <script type="module" src="../../app-shell/firebase-config.js"></script>
 
-  <!-- load runtime (from build [lib] or source [source])-->
-  <script type="module" src="../../lib/ArcsLib.js"></script>
+  <!-- load runtime (from build [build] or source [source])-->
+  <script type="module" src="../../build/ArcsLib.js"></script>
   <!--<script type="module" src="../../source/ArcsLib.js"></script>-->
 
   <script type="module" src="../../app-shell/app-shell.js"></script>

--- a/shell/gulpfile.js
+++ b/shell/gulpfile.js
@@ -13,7 +13,7 @@ const resolve = path.resolve;
 const normalize = path.normalize;
 const argv = require('yargs').argv;
 
-const target = `./lib`;
+const target = `./build`;
 
 const paths = {
   build: `${target}`


### PR DESCRIPTION
This is more consistent with paths used elsewhere, so we can
consistently skip things (like lint) on 'build' paths.

Previously, after running `shell> gulp`, `> npm test` would fail because it'd try to lint ArcsLib.js.