### PR TITLE
Update gulp-babili to gulp-babel-minify to address deprecation.

### DIFF
--- a/shell/package.json
+++ b/shell/package.json
@@ -28,7 +28,7 @@
     "chromedriver": "^2.35.0",
     "cross-env": "^5.1.3",
     "gulp": "^3.9.1",
-    "gulp-babili": "^0.1.4",
+    "gulp-babel-minify": "^0.3.0",
     "http-server": "^0.10.0",
     "mocha-chrome": "^1.0.2",
     "npm-run-all": "^4.1.2",

--- a/shell/package.json
+++ b/shell/package.json
@@ -7,18 +7,10 @@
     "host": "localhost"
   },
   "scripts": {
-    "//": "We're abusing npm as a build system here using the npm-run-all package.",
-    "//": "Long-term the logic here might move into either sigh or gulp",
-
     "test": "run-p --print-name start test-after-build",
     "start": "cross-env http-server -a ${npm_package_config_host} -p ${npm_package_config_port}",
-
     "gulp": "gulp --ignore-arc-failure",
-
-    "//": "test-test is a useful target if you're need neither a server (perhaps because you've",
-    "//": "already invoked npm server manually) or to re-run the build.",
     "test-test": "run-s --print-name --continue-on-error test-mocha test-wdio",
-
     "test-after-build": "run-s --print-name gulp test-test",
     "test-mocha": "mocha-chrome test/index.test.html",
     "test-wdio": "cross-env wdio -b http://${npm_package_config_host}:${npm_package_config_port}/ test/wdio.conf.js"


### PR DESCRIPTION
Addresses deprecation warnings that can be seen here:

https://travis-ci.org/PolymerLabs/arcs/jobs/341588804

Also sadly removes useful comments since `npm install` blows them away anyway.
