### PR TITLE
Correctly de/serialize version number for arcs.

### DIFF
--- a/runtime/manifest.js
+++ b/runtime/manifest.js
@@ -676,24 +676,21 @@ ${e.message}
       error.location = item.location;
       throw error;
     }
-    for (let entity of entities) {
-      if (entity == null && !type.isSetView) {
-        view.clear();
-      } else {
+    if (type.isSetView) {
+      entities = entities.map(entity => {
         let id = entity.$id || manifest.generateID();
         delete entity.$id;
-      
-        if (type.isSetView) {
-          view.store({
-            id,
-            rawData: entity,
-          });
-        } else {
-          view.set({
-            id,
-            rawData: entity,
-          });
-        }
+        return {id, rawData: entity};
+      });
+      view._fromListWithVersion(entities, item.version);
+    } else if (entities.length > 0) {
+      let entity = entities[entities.length - 1];
+      if (entity == null)
+        view._setWithVersion(null, item.version);
+      else {
+        let id = entity.$id || manifest.generateID();
+        delete entity.$id;
+        view._setWithVersion({id, rawData: entity}, item.version);
       }
     }
   }

--- a/runtime/test/arc-tests.js
+++ b/runtime/test/arc-tests.js
@@ -62,7 +62,7 @@ describe('Arc', function() {
 
   it('deserializing a serialized empty arc produces an empty arc', async () => {
     let arc = new Arc({slotComposer, loader, id: 'test'});
-    let serialization = arc.serialize();
+    let serialization = await arc.serialize();
     let newArc = await Arc.deserialize({serialization, loader, slotComposer});
     assert(newArc._handlesById.size == 0);
     assert(newArc.activeRecipe.toString() == arc.activeRecipe.toString());
@@ -77,10 +77,17 @@ describe('Arc', function() {
     let barView = await arc.createHandle(Bar.type);
     recipe.normalize();
     await arc.instantiate(recipe);
-
-    let serialization = arc.serialize();
-    let newArc = await Arc.deserialize({serialization, loader, slotComposer});
     await util.assertSingletonWillChangeTo(barView, Bar, 'a Foo1');
-    
+    assert.equal(fooView._version, 1);
+    assert.equal(barView._version, 1);
+
+    let serialization = await arc.serialize();
+    arc.stop();
+
+    let newArc = await Arc.deserialize({serialization, loader, slotComposer});
+    fooView = newArc.findHandleById(fooView.id);
+    barView = newArc.findHandleById(barView.id);
+    assert.equal(fooView._version, 1);
+    assert.equal(barView._version, 1);
   });
 });

--- a/runtime/test/view-test.js
+++ b/runtime/test/view-test.js
@@ -39,6 +39,34 @@ describe('View', function() {
     assert.equal(await barView.get(), undefined);
   });
 
+  it('ignores duplicate stores of the same entity value (variable)', async () => {
+    let arc = new Arc({slotComposer, id: 'test'});
+    let handle = await arc.createHandle(Bar.type);
+    assert.equal(handle._version, 0);
+    let bar1 = {id: 'an id', value: 'a Bar'};
+    await handle.set(bar1);
+    assert.equal(handle._version, 1);
+    await handle.set(bar1);
+    assert.equal(handle._version, 1);
+    await handle.set({value: 'a Bar'});
+    assert.equal(handle._version, 2);
+  });
+
+  it('ignores duplicate stores of the same entity value (collection)', async () => {
+    let arc = new Arc({slotComposer, id: 'test'});
+    let handle = await arc.createHandle(Bar.type.setViewOf());
+    assert.equal(handle._version, 0);
+    let bar1 = {id: 'an id', value: 'a Bar'};
+    await handle.store(bar1);
+    assert.equal(handle._version, 1);
+    await handle.store(bar1);
+    assert.equal(handle._version, 1);
+    await handle.store({value: 'a Bar'});
+    assert.equal(handle._version, 2);
+    await handle.store(bar1);
+    assert.equal(handle._version, 2);
+  });
+
   it('dedupes common user-provided ids', async () => {
     let arc = new Arc({slotComposer, id: 'test'});
 


### PR DESCRIPTION
Also ignore duplicate writes to storage objects when data is identical.