### PR TITLE
Generic interface for Chooser - use type variable

### DIFF
--- a/shell/artifacts/Products/Chooser.manifest
+++ b/shell/artifacts/Products/Chooser.manifest
@@ -9,7 +9,7 @@
 import 'Product.schema'
 
 particle Chooser in 'source/Chooser.js'
-  Chooser(in [Product] choices, inout [Product] resultList)
+  Chooser(in [~a] choices, inout [~a] resultList)
   consume action
     provide set of annotation
       view choices


### PR DESCRIPTION
Reproducible in both - demo-flow-test and runtime/browser/demo:

assert-web.js:11 Uncaught (in promise) Error: Handles need entity classes for deserialization
    at assert (assert-web.js:11)
    at Collection._restore (handle.js:86)
    at map.a (handle.js:130)
    at Array.map (<anonymous>)
    at Collection.toList (handle.js:130)
    at <anonymous>
assert @ assert-web.js:11
_restore @ handle.js:86
map.a @ handle.js:130
toList @ handle.js:130
async function (async)
when @ dom-particle.js:75
InnerPEC._apiPort.onSimpleCallback @ inner-PEC.js:136
_handle @ api-channel.js:182
APIPort._port.onmessage @ api-channel.js:89
