### PR TITLE
Improve planner grouping logic under high core count.

### DIFF
--- a/runtime/planner.js
+++ b/runtime/planner.js
@@ -157,9 +157,9 @@ class Planner {
   _splitToGroups(items, groupCount) {
     const groups = [];
     if (!items || items.length == 0) return groups;
-    const groupItemSize = Math.floor(items.length / groupCount);
+    const groupItemSize = Math.max(1, Math.floor(items.length / groupCount));
     let startIndex = 0;
-    for (let i = 0; i < groupCount; i++) {
+    for (let i = 0; i < groupCount && startIndex < items.length; i++) {
       groups.push(items.slice(startIndex, startIndex + groupItemSize));
       startIndex += groupItemSize;
     }


### PR DESCRIPTION
This change ensures we place at least one item in each group, and will no longer create empty groups. In development my machine was lower core/memory and so I never saw this behavior.

We should perhaps also mock out the `DeviceInfo` return values for more test solidarity but since we'll be reworking this soon to move to a thread pool type of thing rather than splitting into groups this seems sufficient for now.

Fixes https://github.com/PolymerLabs/arcs/issues/775