### PR TITLE
Force resolve optional expectations when awaiting mock-slot-composer expectation completeness

### DIFF
--- a/runtime/test/demo-flow-test.js
+++ b/runtime/test/demo-flow-test.js
@@ -107,9 +107,11 @@ describe('demo flow', function() {
         .maybeRenderSlot('AlsoOn', 'annotation', ['model'])
         .maybeRenderSlot('AlsoOn', 'annotation', ['model'])
         .maybeRenderSlot('AlsoOn', 'annotation', ['model']);
+    let slotComposerCompletePromise = slotComposer.expectationsCompleted();
     await arc.instantiate(plan);
     await arc.pec.idle;
-    await slotComposer.expectationsCompleted();
+    slotComposer.skipOptional();
+    await slotComposerCompletePromise;
     let productViews = arc.findHandlesByType(Product.type.setViewOf());
     assert.equal(productViews.length, 2);
 

--- a/runtime/test/demo-flow-test.js
+++ b/runtime/test/demo-flow-test.js
@@ -110,7 +110,9 @@ describe('demo flow', function() {
     let slotComposerCompletePromise = slotComposer.expectationsCompleted();
     await arc.instantiate(plan);
     await arc.pec.idle;
-    slotComposer.skipOptional();
+    // TODO: get rid of set timeout. Instead update MockSlotComposer to return two promises:
+    // one for required expectations, another for all promises.
+    setTimeout(slotComposer.skipOptional.bind(slotComposer), 500);
     await slotComposerCompletePromise;
     let productViews = arc.findHandlesByType(Product.type.setViewOf());
     assert.equal(productViews.length, 2);

--- a/runtime/test/mock-slot-composer.js
+++ b/runtime/test/mock-slot-composer.js
@@ -159,6 +159,7 @@ class MockSlotComposer extends SlotComposer {
     } else {
       // Slots of particles hosted in transformation particles.
     }
+    // this.detailedLogDebug();
   }
 
   // Helper method to resolve the current expectation group, if all remaining expectations are optional.
@@ -181,6 +182,25 @@ class MockSlotComposer extends SlotComposer {
     if (this.expectQueue.length == 0) {
       this.onExpectationsComplete();
     }
+  }
+
+  detailedLogDebug() {
+    console.log(`    Has ${this.expectQueue.length} expectation groups:  [ ${this.expectQueue.map(expectations => {
+      let expectationsByParticle = {};
+      expectations.forEach(e => {
+        if (!expectationsByParticle[e.particleName]) {
+          expectationsByParticle[e.particleName] = {};
+        }
+        let key = `${e.isOptional ? 'opt_' : ''}${e.contentType}`;
+        if (!expectationsByParticle[e.particleName][key]) {
+          expectationsByParticle[e.particleName][key] = 0;
+        }
+        expectationsByParticle[e.particleName][key]++;
+      });
+      return `${expectations.length} expectations : {${Object.keys(expectationsByParticle).map(p => {
+        return `${p}: (${Object.keys(expectationsByParticle[p]).map(key => `${key}=${expectationsByParticle[p][key]}`).join('; ')})`;
+      }).join(', ')}}`;
+    }).join('\n\t\t\t\t')}]`);
   }
 }
 

--- a/runtime/test/mock-slot-composer.js
+++ b/runtime/test/mock-slot-composer.js
@@ -132,7 +132,7 @@ class MockSlotComposer extends SlotComposer {
   }
 
   async renderSlot(particle, slotName, content) {
-//    console.log(`renderSlot ${particle.name}:${slotName}`, Object.keys(content).join(', '));
+    // console.log(`renderSlot ${particle.name}:${slotName}`, Object.keys(content).join(', '));
     assert(this.expectQueue.length > 0 && this.expectQueue[0],
       `Got a renderSlot from ${particle.name}:${slotName} (content types: ${Object.keys(content).join(', ')}), but not expecting anything further.`);
 
@@ -161,12 +161,22 @@ class MockSlotComposer extends SlotComposer {
     }
   }
 
+  // Helper method to resolve the current expectation group, if all remaining expectations are optional.
+  skipOptional() {
+    let expectations = this.expectQueue[0];
+    if (expectations.every(e => e.isOptional)) {
+      this.expectQueue.shift();
+      this.expectationsMet();
+    }
+  }
+
   expectationMet(expectation) {
     if (expectation.then) {
       log(`expectationMet: sending event`, expectation.then);
       this._sendEvent(expectation.then);
     }
   }
+
   expectationsMet() {
     if (this.expectQueue.length == 0) {
       this.onExpectationsComplete();


### PR DESCRIPTION
Temporarily addresses https://github.com/PolymerLabs/arcs/issues/780