### PR TITLE
Initial framing for Blob support.

### DIFF
--- a/platform/blob-node.js
+++ b/platform/blob-node.js
@@ -1,0 +1,16 @@
+// Copyright (c) 2018 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+'use strict';
+
+// TODO(wkorman): Implement further perhaps via
+// https://nodejs.org/api/buffer.html
+export default class Blob {
+  constructor(values, options) {
+    this._values = values;
+    this._options = options;
+  }
+};

--- a/platform/blob-web.js
+++ b/platform/blob-web.js
@@ -1,0 +1,9 @@
+// Copyright (c) 2018 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+'use strict';
+
+export default window.Blob;

--- a/runtime/bytes.js
+++ b/runtime/bytes.js
@@ -1,0 +1,35 @@
+// Copyright (c) 2018 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+'use strict';
+
+// Represents a Blob of binary data. Intended for use in storing things such as
+// media data.
+export default class Bytes {
+  constructor(blob) {
+    this._blob = blob;
+  }
+  // Returns a Promise with the Blob.
+  async content() {
+    return new Promise((resolve, reject) => resolve(this._blob));
+  }
+  // Returns a Promise with the Blob for the specified range of data.
+  async range(offset, length) {
+    // TODO(wkorman): Slice out the right portion.
+    throw 'NotImplemented';
+  }
+  // Returns a Promise with the String for a URL that can fetch the contents
+  // of the stored Blob.
+  async url() {
+    // TODO(wkorman): Consider returning as a data url ex.
+    // 'data:image/png;base64,...' for now.'
+    throw 'NotImplemented';
+  }
+  toString() {
+    return `Bytes{blob=${this._blob}}`;
+  }
+  // TODO(wkorman): Perhaps rangeUrl, type (mimetype), size.
+};

--- a/runtime/manifest-parser.peg
+++ b/runtime/manifest-parser.peg
@@ -792,7 +792,7 @@ SchemaType
   = SchemaPrimitiveType / SchemaUnionType / SchemaTupleType
 
 SchemaPrimitiveType
-  = 'Text' / 'URL' / 'Number' / 'Boolean' / 'Object'
+  = 'Text' / 'URL' / 'Number' / 'Boolean' / 'Bytes' / 'Object'
 
 SchemaUnionType
   = '(' whiteSpace? first:SchemaPrimitiveType rest:(whiteSpace 'or' whiteSpace SchemaPrimitiveType)+ whiteSpace? ')'

--- a/runtime/test/manifest-parser-test.js
+++ b/runtime/test/manifest-parser-test.js
@@ -146,4 +146,12 @@ describe('manifest parser', function() {
         Foo(in * {value} optionalType)
     `);
   });
+  it('parses a schema with a bytes field', () => {
+    parse(`
+      schema Avatar
+        normative
+          Text name
+          Bytes profileImage
+      `);
+  });
 });


### PR DESCRIPTION
Add parsing support for 'Bytes' in Schema definitions. Rough
framing for Bytes per design, and Blob in platform.

No real logic yet other than parsing.

Part of https://github.com/PolymerLabs/arcs/issues/806.