### PR TITLE
Two small CSS fixes and a README update

### DIFF
--- a/devtools/README.md
+++ b/devtools/README.md
@@ -48,3 +48,10 @@ To see the changes in the DevTools extension you'll need to rerun:
 If you made changes to the manifest, or if you're sure your changes are
 not showing up, you should click the "Reload" button on the `chrome://extensions/` page.
 
+### Errors
+
+`Invocation of form runtime.connect(null, ) doesn't match definition runtime.connect(optional string extensionId, optional object connectInfo)`
+happens when the newly build DevTools extension is opened on the AppShell which
+received the content script from the earlier version of the extension. This is
+harmless and requires a page refresh, so that the content script and the
+extension proper are in sync.

--- a/devtools/src/arcs-dataflow.html
+++ b/devtools/src/arcs-dataflow.html
@@ -37,7 +37,7 @@
         color: var(--mid-gray);
       }
       paper-listbox {
-        width: 220px;
+        width: 320px;
         padding: 0;
         --paper-item: {
           white-space: nowrap;

--- a/devtools/src/strategy-explorer/strategy-explorer.html
+++ b/devtools/src/strategy-explorer/strategy-explorer.html
@@ -27,6 +27,7 @@ http://polymer.github.io/PATENTS.txt
       }
       .se-explorer-container {
         overflow: scroll;
+        flex-grow: 1;
       }
       aside {
         background-color: var(--light-gray);


### PR DESCRIPTION
CSS fixes:
- Bigger dropdown accounting for longer ids including the session token.
- Strategy Explorer layout change which makes the left-panel stay on the left even if Strategy Explorer itself is empty.

+ Explanation of the error which can be encountered when developing the extension.