### PR TITLE
Adds 5 retries to the WebSocket connection

### DIFF
--- a/devtools/src/devtools.js
+++ b/devtools/src/devtools.js
@@ -52,12 +52,21 @@
   }
 
   function connectViaWebSocket() {
-    let ws = new WebSocket('ws://localhost:8787');
-    ws.onerror = e => console.log('No NodeJS connection found.');
-    ws.onopen = e => {
-      ws.onmessage = msg => queueOrFire(JSON.parse(msg.data));
-      ws.send('init');
-    };
+    let ws;
+
+    let retriesLeft = 5;
+    (function createWebSocket() {
+      ws = new WebSocket('ws://localhost:8787');
+      ws.onopen = e => {
+        console.log(`WebSocket connection established.`);
+        ws.onmessage = msg => queueOrFire(JSON.parse(msg.data));
+        ws.send('init');
+      };
+      ws.onerror = e => {
+        console.log(`No WebSocket connection found, ${retriesLeft} retries left.`);
+        if (retriesLeft--) setTimeout(createWebSocket, 300);
+      };
+    })();
     return message => {
       // TODO: Add the message itself and figure out how this will work
       // when we implement first DevTools -> NodeJS command.


### PR DESCRIPTION
This allows for using --inspect and --explore together with the Arcs Explorer as Chrome DevTools extension. The problem was that the test was waiting for the debugger first, and only then opening the websocket server for Arcs Explorer. At the latter point Chrome DevTools was opened and Arcs Explorer failed to find a websocket server.