### PR TITLE
Send resolved type across PEC rather than type variable.

### DIFF
--- a/runtime/outer-PEC.js
+++ b/runtime/outer-PEC.js
@@ -137,7 +137,7 @@ class OuterPEC extends PEC {
   instantiate(particleSpec, id, spec, handles, lastSeenVersion) {
     handles.forEach(handle => {
       let version = lastSeenVersion.get(handle.id) || 0;
-      this._apiPort.DefineHandle(handle, {type: handle.type, name: handle.name,
+      this._apiPort.DefineHandle(handle, {type: handle.type.resolvedType(), name: handle.name,
                                        version});
     });
 

--- a/runtime/shape.js
+++ b/runtime/shape.js
@@ -102,6 +102,13 @@ ${this._slotsToManifestString()}
     return new Shape(this.name, views, slots);
   }
 
+  resolvedType() {
+    let result = this.clone();
+    for (let typeVar of result._typeVars)
+      typeVar.object[typeVar.field] = typeVar.object[typeVar.field].resolvedType();
+    return result;
+  }
+
   equals(other) {
     if (this.views.length !== other.views.length)
       return false;

--- a/runtime/type-variable.js
+++ b/runtime/type-variable.js
@@ -14,7 +14,11 @@ class TypeVariable {
     this.resolution = null;
   }
 
+  // this shouldn't be called on a 
+  // resolved TypeVariable.. how do we
+  // pass a resolution across the PEC?
   toLiteral() {
+    assert(this.resolution == null);
     return this;
   }
 

--- a/runtime/type.js
+++ b/runtime/type.js
@@ -171,6 +171,9 @@ class Type {
     if (this.isTypeVariable && this.data.isResolved) {
       return this.data.resolution.resolvedType();
     }
+    if (this.isInterface) {
+      return Type.newInterface(this.data.resolvedType());
+    }
     return this;
   }
 
@@ -200,6 +203,8 @@ class Type {
         return Type.fromLiteral;
       case 'Tuple':
         return TupleFields.fromLiteral;
+      case 'Variable':
+        return TypeVariable.fromLiteral;
       default:
         return a => a;
     }


### PR DESCRIPTION
Ensure that interface types can report their resolved type.

Should at least partially resolve the issue in #761 