### PR TITLE
Small rename in SE Explorer

### DIFF
--- a/devtools/src/strategy-explorer/se-legend.html
+++ b/devtools/src/strategy-explorer/se-legend.html
@@ -19,9 +19,16 @@ http://polymer.github.io/PATENTS.txt
       .legend {
         background: white;
         border: 1px solid var(--mid-gray);
+        padding-top: 5px;
+        overflow: hidden;
       }
-      .legend > div {
-        margin: 5px;
+      .column {
+        display: inline-block;
+        min-width: max-content;
+        width: 45%;
+      }
+      .column > div {
+        margin: 0 5px 5px;
         line-height: 25px;
       }
       #recipe-box {
@@ -33,16 +40,20 @@ http://polymer.github.io/PATENTS.txt
       }
     </style>
     <div class="legend">
-      <div><div id='recipe-box' resolved></div> Not Valid</div>
-      <div><div id='recipe-box' valid></div> Not Resolved</div>
-      <div><div id='recipe-box' valid resolved active></div> Active</div>
-      <div><div id='recipe-box' valid resolved selected></div> Selected</div>
-      <div><div id='recipe-box' valid resolved activeAncestor></div> Active Ancestor</div>
-      <div><div id='recipe-box' valid resolved activeParent></div> Active Parent</div>
-      <div><div id='recipe-box' valid resolved activeDescendant></div> Active Descendant</div>
-      <div><div id='recipe-box' valid resolved activeChild></div> Active Child</div>
-      <div><div id='recipe-box' valid resolved terminal></div> Terminal</div>
-      <div><div id='recipe-box' valid resolved combined></div> Combined</div>
+      <div class="column">
+        <div><div id='recipe-box' resolved></div> Not Valid</div>
+        <div><div id='recipe-box' valid></div> Not Resolved</div>
+        <div><div id='recipe-box' valid resolved combined></div> Combined</div>
+        <div><div id='recipe-box' valid resolved active></div> Active</div>
+        <div><div id='recipe-box' valid resolved terminal></div> Terminal</div>
+      </div>
+      <div class="column">
+        <div><div id='recipe-box' valid resolved selected></div> Selected</div>
+        <div><div id='recipe-box' valid resolved selectedAncestor></div> Selected Ancestor</div>
+        <div><div id='recipe-box' valid resolved selectedParent></div> Selected Parent</div>
+        <div><div id='recipe-box' valid resolved selectedDescendant></div> Selected Descendant</div>
+        <div><div id='recipe-box' valid resolved selectedChild></div> Selected Child</div>
+      </div>
     </div>
   </template>
   <script>

--- a/devtools/src/strategy-explorer/se-recipe.html
+++ b/devtools/src/strategy-explorer/se-recipe.html
@@ -36,10 +36,10 @@ http://polymer.github.io/PATENTS.txt
       valid$='{{recipe.valid}}'
       active$='{{recipe.active}}'
       selected$='{{selected}}'
-      activeParent$='{{activeParent}}'
-      activeAncestor$='{{activeAncestor}}'
-      activeChild$='{{activeChild}}'
-      activeDescendant$='{{activeDescendant}}'
+      selectedParent$='{{selectedParent}}'
+      selectedAncestor$='{{selectedAncestor}}'
+      selectedChild$='{{selectedChild}}'
+      selectedDescendant$='{{selectedDescendant}}'
       terminal$='{{terminal}}'
       resolved$='{{recipe.resolved}}'
       combined$='{{recipe.combined}}'
@@ -123,17 +123,17 @@ http://polymer.github.io/PATENTS.txt
           if (document._selectedBox !== undefined) {
             document._selectedBox.selected = false;
 
-            document._selectedBox.parents.forEach(parent => parent.activeParent = false);
-            document._selectedBox.ancestors.forEach(ancestor => ancestor.activeAncestor = false);
-            document._selectedBox.childrens.forEach(child => child.activeChild = false);
-            document._selectedBox.descendants.forEach(descendant => descendant.activeDescendant = false);
+            document._selectedBox.parents.forEach(parent => parent.selectedParent = false);
+            document._selectedBox.ancestors.forEach(ancestor => ancestor.selectedAncestor = false);
+            document._selectedBox.childrens.forEach(child => child.selectedChild = false);
+            document._selectedBox.descendants.forEach(descendant => descendant.selectedDescendant = false);
             recipeView.unpin();
           }
           this.selected = true;
-          this.parents.forEach(parent => parent.activeParent = true);
-          this.ancestors.forEach(ancestor => ancestor.activeAncestor = true);
-          this.childrens.forEach(child => child.activeChild = true);
-          this.descendants.forEach(descendant => descendant.activeDescendant = true);
+          this.parents.forEach(parent => parent.selectedParent = true);
+          this.ancestors.forEach(ancestor => ancestor.selectedAncestor = true);
+          this.childrens.forEach(child => child.selectedChild = true);
+          this.descendants.forEach(descendant => descendant.selectedDescendant = true);
           document._selectedBox = this;
 
           recipeView.over = this;

--- a/devtools/src/strategy-explorer/se-shared.html
+++ b/devtools/src/strategy-explorer/se-shared.html
@@ -19,22 +19,22 @@
         background: #afa;
       }
 
-      #recipe-box[activeAncestor] {
+      #recipe-box[selectedAncestor] {
         border: 1px solid blue;
         background: #ccf;
       }
 
-      #recipe-box[activeParent] {
+      #recipe-box[selectedParent] {
         border: 2px solid blue;
         background: #aaf;
       }
 
-      #recipe-box[activeDescendant] {
+      #recipe-box[selectedDescendant] {
         border: 1px solid purple;
         background: #fcf;
       }
 
-      #recipe-box[activeChild] {
+      #recipe-box[selectedChild] {
         border: 2px solid purple;
         background: #faf;
       }


### PR DESCRIPTION
Renames attributes for ancestors and descendants of the selected node with s/active/selected/ and renames these items in the legend. Additionally improves the legend element to collapse into two columns if possible.