### PR TITLE
Fix boxing collections: only add set to type if not already a set.

### DIFF
--- a/shell/app-shell/elements/remote-friends-shared-handles.js
+++ b/shell/app-shell/elements/remote-friends-shared-handles.js
@@ -96,7 +96,10 @@ class RemoteFriendsSharedHandles extends Xen.Base {
       // formulate an id
       const id = `BOXED_${tagString}`;
       // acquire type record for a Set of the given type
-      const arcsType = ArcsUtils.typeFromMetaType(type).setViewOf();
+      let arcsType = ArcsUtils.typeFromMetaType(type);
+      if (!arcsType.isSetView) {
+        arcsType = arcsType.setViewOf();
+      }
       // combine the data into a box
       this._addToBox(arc, id, arcsType, name, [`#${id}`]/*tags*/, data);
     }


### PR DESCRIPTION
https://github.com/PolymerLabs/arcs/pull/841 reworked boxing but also introduced this bug.