### PR TITLE
Fix various persistence issues with Restaurant demo

### DIFF
--- a/shell/app-shell/elements/persistent-handles.js
+++ b/shell/app-shell/elements/persistent-handles.js
@@ -76,7 +76,7 @@ class PersistentHandles extends Xen.Base {
         // local changes and applying those to the remote variable.
         initialLoad = false;
         localVariable.on('change', change => {
-          if (change.data && change.data.id.startsWith(arc.id)) {
+          if (change.data && JSON.stringify(change.data) !== JSON.stringify(remoteValue)) {
             remoteVariable.set(ArcsUtils.removeUndefined(change.data));
           } else if (change.data === undefined) {
             remoteVariable.remove();

--- a/shell/app-shell/elements/persistent-handles.js
+++ b/shell/app-shell/elements/persistent-handles.js
@@ -52,12 +52,11 @@ class PersistentHandles extends Xen.Base {
     });
     let remoteHandle = remoteHandleMeta.child('values');
     if (localHandle.type.isSetView) {
-      PersistentHandles.log(`Syncing set ${handleId}`);
+      PersistentHandles.log(`Syncing set [${handleId}]`);
       return this._syncSet(arc, localHandle, remoteHandle);
     }
     if (localHandle.type.isEntity) {
-      //PersistentHandles.log(`[disabled] Syncing variable ${handleId}`);
-      PersistentHandles.log(`Syncing variable ${handleId}`);
+      PersistentHandles.log(`Syncing variable [${handleId}]`);
       return this._syncVariable(arc, localHandle, remoteHandle);
     }
   }

--- a/shell/artifacts/Events/source/PartySize.js
+++ b/shell/artifacts/Events/source/PartySize.js
@@ -73,29 +73,28 @@ ${styles}
       return template;
     }
     _willReceiveProps({event}, state) {
-      const currentEvent = Object.assign({}, event && event.rawData || {});
-      currentEvent.participants = 2;
-      this._setState({currentEvent});
+      if (event && !event.participants) {
+        this._setParticipants(2);
+      }
     }
-    _shouldRender(props, {currentEvent}) {
-      return Boolean(currentEvent);
+    _setParticipants(size) {
+      const event = this._props.event;
+      event.participants = Number(size);
+      this._views.get('event').set(event);
     }
-    _render(props, {currentEvent}) {
-      const partySize = parseInt(currentEvent.participants);
+    _shouldRender({event}) {
+      return Boolean(event);
+    }
+    _render({event}) {
+      const partySize = event.participants;
       const selected = {};
       for (let i = 1; i <= 21; ++i) {
         selected[`selected${i}`] = Boolean(partySize == i);
       }
       return selected;
     }
-    _onPartySizeChanged(e, {currentEvent}) {
-      const newEvent = Object.assign({}, currentEvent);
-      newEvent.participants = e.data.value;
-      this._storeNewEvent(newEvent);
-    }
-    _storeNewEvent(newEvent) {
-      const event = this._views.get('event');
-      event.set(new event.entityClass(newEvent));
+    _onPartySizeChanged(e) {
+      this._setParticipants(e.data.value);
     }
   };
 

--- a/shell/artifacts/Events/source/PartySize.js
+++ b/shell/artifacts/Events/source/PartySize.js
@@ -72,24 +72,24 @@ ${styles}
     get template() {
       return template;
     }
-    _willReceiveProps(props, state) {
-      const event = Object.assign({}, props.event.rawData || {participants: 2});
-
-      this._setState({currentEvent: event});
+    _willReceiveProps({event}, state) {
+      const currentEvent = Object.assign({}, event && event.rawData || {});
+      currentEvent.participants = 2;
+      this._setState({currentEvent});
     }
-    _shouldRender(props, state) {
-      return Boolean(state.currentEvent);
+    _shouldRender(props, {currentEvent}) {
+      return Boolean(currentEvent);
     }
-    _render(props, state) {
-      const partySize = parseInt(state.currentEvent.participants);
+    _render(props, {currentEvent}) {
+      const partySize = parseInt(currentEvent.participants);
       const selected = {};
       for (let i = 1; i <= 21; ++i) {
         selected[`selected${i}`] = Boolean(partySize == i);
       }
       return selected;
     }
-    _onPartySizeChanged(e, state) {
-      let newEvent = Object.assign({}, state.currentEvent || {});
+    _onPartySizeChanged(e, {currentEvent}) {
+      const newEvent = Object.assign({}, currentEvent);
       newEvent.participants = e.data.value;
       this._storeNewEvent(newEvent);
     }

--- a/shell/artifacts/Restaurants/Restaurants.recipes
+++ b/shell/artifacts/Restaurants/Restaurants.recipes
@@ -36,11 +36,8 @@ import '../Events/PartySize.manifest'
 import 'ReservationForm.manifest'
 import 'ReservationAnnotation.manifest'
 
-view EmptyEvent of Event in 'data/event.json'
-
 recipe
-  copy EmptyEvent as event
-//  create as event
+  create #event as event
   ReservationForm
     event = event
   ReservationAnnotation

--- a/shell/artifacts/Restaurants/data/event.json
+++ b/shell/artifacts/Restaurants/data/event.json
@@ -1,4 +1,0 @@
-[{
-    "participants": 2,
-    "description": "Table for two available at 19:00"
-}]

--- a/shell/artifacts/Restaurants/source/ReservationForm.js
+++ b/shell/artifacts/Restaurants/source/ReservationForm.js
@@ -256,7 +256,7 @@ ${styles}
     }
     _onPartySizeChanged(e, state) {
       let newEvent = Object.assign({}, state.currentEvent || {});
-      newEvent.participants = e.data.value;
+      newEvent.participants = Number(e.data.value);
       this._storeNewEvent(newEvent);
     }
     _storeNewEvent(newEvent) {

--- a/shell/components/data-item.js
+++ b/shell/components/data-item.js
@@ -36,7 +36,9 @@ class DataItem extends Xen.Base {
   _render(props, state) {
     let type = typeof props.value;
     let isnull = props.value === null;
-    let isobject = (type === 'object' && !isnull), isstring = (type === 'string' || isnull), isbool = (type==='boolean');
+    let isobject = (type === 'object' && !isnull),
+        isstring = (type === 'string' || type === 'number' || isnull),
+        isbool = (type==='boolean');
     if (!isNaN(Number(props.name))) {
       state.expanded = true;
     }


### PR DESCRIPTION
- Only handles with tags are persisted, so add `#event` tag to persist it.
- Use real data-testing to prevent iloops in persistent-handle instead of using arc.id prefix check.
- Make sure we only assign Numbers to `event.participants`
- Modernize PartySize.js
- Make sure HandleExplorer display Number fields properly (fix in data-item)