### PR TITLE
Add 'plannertimeout' query param to allow specifying plan timeout.

### DIFF
--- a/runtime/planner.js
+++ b/runtime/planner.js
@@ -99,9 +99,10 @@ class Planner {
     return this.strategizer.generated;
   }
 
+  // Specify a timeout value less than zero to disable timeouts.
   async plan(timeout, generations) {
     let trace = Tracing.async({cat: 'planning', name: 'Planner::plan', args: {timeout}});
-    timeout = timeout || NaN;
+    timeout = timeout || -1;
     let allResolved = [];
     let now = () => (typeof performance == 'object') ? performance.now() : process.hrtime();
     let start = now();
@@ -118,8 +119,9 @@ class Planner {
           .map(individual => individual.result)
           .filter(recipe => recipe.isResolved());
       allResolved.push(...resolved);
-      if (now() - start > timeout) {
-        console.warn('Planner.plan timed out.');
+      const elapsed = now() - start;
+      if (timeout >= 0 && elapsed > timeout) {
+        console.warn(`Planner.plan timed out [elapsed=${Math.floor(elapsed)}ms, timeout=${timeout}ms].`);
         break;
       }
     } while (this.strategizer.generated.length > 0);

--- a/shell/app-shell/elements/arc-config.js
+++ b/shell/app-shell/elements/arc-config.js
@@ -17,6 +17,11 @@ class ArcConfig extends Xen.Base {
       this._fire('config', this._configure(props.rootpath));
     }
   }
+  _getPlannerTimeout(params) {
+    const DEFAULT_PLANNER_TIMEOUT = 5000;
+    const timeout = params.get('plannertimeout');
+    return timeout ? parseInt(timeout) : DEFAULT_PLANNER_TIMEOUT;
+  }
   _configure(rootPath) {
     let params = (new URL(document.location)).searchParams;
     return {
@@ -32,6 +37,7 @@ class ArcConfig extends Xen.Base {
       //shared: params.getAll('shared'),
       search: params.get('search'),
       arcsToolsVisible: localStorage.getItem('0-3-arcs-dev-tools') === 'open',
+      plannerTimeout: this._getPlannerTimeout(params),
       urls: {}
     };
   }

--- a/shell/app-shell/elements/arc-host.js
+++ b/shell/app-shell/elements/arc-host.js
@@ -157,14 +157,14 @@ class ArcHost extends Xen.Base {
     let plans;
     while (state.invalid) {
       state.invalid = false;
-      plans = await this._plan(state.arc);
+      plans = await this._plan(state.arc, state.config.plannerTimeout);
     }
     time = ((Date.now() - time) / 1000).toFixed(2);
     ArcHost.log(`plans`, plans, `${time}s`);
     this._fire('plans', plans);
   }
-  async _plan(arc) {
-    return await ArcsUtils.makePlans(arc, 5000) || [];
+  async _plan(arc, timeout) {
+    return await ArcsUtils.makePlans(arc, timeout) || [];
   }
   async _applySuggestion(arc, plan) {
     // aggressively remove old suggestions when a suggestion is applied


### PR DESCRIPTION
- Change `Planner.plan` to treat `timeout < 0` as no-timeout.
- Add `plannertimeout` to `ArcConfig` and reference in `ArcHost` when we kick off planning antics.

Fixes https://github.com/PolymerLabs/arcs/issues/864