### PR TITLE
Explicitly set DetailSlider slot content to fill available space below buttons.

### DIFF
--- a/shell/artifacts/Common/source/DetailSlider.js
+++ b/shell/artifacts/Common/source/DetailSlider.js
@@ -62,6 +62,13 @@ defineParticle(({DomParticle, resolver, html, log}) => {
   [${host}] > [dialog] > [buttons] > [back-button]:active {
     background-color: #b0e3ff;
   }
+  [${host}] > [dialog] > [slot-content] {
+    position: absolute;
+    top: 57px;
+    right: 0;
+    left: 0;
+    bottom: 0;
+  }
 </style>
 
 <div ${host} modal open$="{{open}}">


### PR DESCRIPTION
Temporary workaround intended to allow post editor to fill vertical space until we revamp slider to use flexbox or something else cleaner for extensibility.

I do intend to explore flexbox instead in the short term.

Part of https://github.com/PolymerLabs/arcs/issues/823