### PR TITLE
Prevent duplicate registration of x-list custom element.

### DIFF
--- a/shell/components/x-list.js
+++ b/shell/components/x-list.js
@@ -96,6 +96,6 @@ class XList extends Xen.State(Xen.Element(HTMLElement)) {
   }
 }
 
-if (typeof customElements != 'undefined') {
+if (typeof customElements != 'undefined' && !customElements.get('x-list')) {
   customElements.define('x-list', XList);
 }


### PR DESCRIPTION
Something is causing `x-list.js` to load twice at tip of tree. I stopped in debugger but there's no callstack or other obvious way to figure out where. I see exactly one import in `app-shell.js`.

It's causing a local non-debug build to fail with empty page, so here's a hack to fix, but maybe I'm holding something wrong. I figured since `x-list` is deprecated and slated for death soon anyway, looking further maybe isn't worth it, but open to other thoughts.

Are others seeing this issue as well?