### PR TITLE
Revert "skip the restaurant demo temporarily"

### DIFF
--- a/shell/test/specs/starter-test.js
+++ b/shell/test/specs/starter-test.js
@@ -376,7 +376,7 @@ function clickInParticles(slotName, selectors, textQuery) {
 }
 
 describe('test Arcs demo flows', function() {
-  it.skip('can use the restaurant demo flow', function() {
+  it('can use the restaurant demo flow', function() {
     initTestWithNewArc();
 
     allSuggestions();


### PR DESCRIPTION
This reverts commit 7671a0344d9c2148d587d96c7ecdf801a8ea74de.

> git revert 7671a0344d9c2148d587d96c7ecdf801a8ea74de

Closes #877 (although the actual fix happened elsewhere)