### PR TITLE
Resolved type

### DIFF
--- a/shell/app-shell/elements/arc-handle.js
+++ b/shell/app-shell/elements/arc-handle.js
@@ -32,7 +32,7 @@ class ArcHandle extends Xen.Base {
       //this._fire('handle', state.handle);
     }
   }
-  async _createHandle(arc, manifest, {name, tags, type, id, asContext}) {
+  async _createHandle(arc, manifest, {name, tags, type, id, asContext, description}) {
     let handleOf = false;
     if (type[0] == '[') {
       handleOf = true;
@@ -50,6 +50,7 @@ class ArcHandle extends Xen.Base {
       // arc-handle, suitable for `use`, `?`
       handle = await arc.createHandle(typeOf, name, id, tags);
     }
+    handle.description = description;
     // observe handle
     handle.on('change', () => this._handleChanged(handle), arc);
     ArcHandle.log('created handle', name, tags);

--- a/shell/app-shell/elements/persistent-handles.js
+++ b/shell/app-shell/elements/persistent-handles.js
@@ -46,7 +46,7 @@ class PersistentHandles extends Xen.Base {
     let remoteHandleMeta = state.db.child(`views/${handleId}`);
     // TODO(sjmiles): maybe not do this unless we have to (reducing FB thrash)
     remoteHandleMeta.child('metadata').update({
-      type: ArcsUtils.metaTypeFromType(localHandle.type),
+      type: ArcsUtils.metaTypeFromType(localHandle.type.resolvedType()),
       name: localHandle.name || null,
       tags: [...tags]
     });

--- a/shell/apps/chrome-extension/extension-app-shell.js
+++ b/shell/apps/chrome-extension/extension-app-shell.js
@@ -167,6 +167,7 @@ ${super.template}
                 tags:
                     [shortTypeName == 'Product' ? '#shortlist' :
                                                   `#${shortTypeName}`],
+                description: `${shortTypeName} from your browsing context`,
                 asContext: true
               },
               data: data


### PR DESCRIPTION
This fixes an error I've been seeing:

```
ReferenceError: assert is not defined
    at TypeVariable.toLiteral (type-variable.js:21)
    at Type.toLiteral (type.js:192)
    at Type.toLiteral (type.js:192)
    at Object.metaTypeFromType (arcs-utils.js:139)
    at HTMLElement._watchHandle (persistent-handles.js:49)
    at state.watchers.map.tagEntry (persistent-handles.js:34)
    at Array.map (<anonymous>)
    at HTMLElement._watchHandles (persistent-handles.js:34)
    at HTMLElement._update (persistent-handles.js:26)
    at HTMLElement._validate (xen-state.js:77)
```

@shans suggested this fix (thanks!).

It appears that the type isn't fully resolved, and toLiteral() chokes from that. Resolving the type first fixes the issue.

Ignore the changes to `arc-handle.js`, that's from a reviewed (but not yet merged, due to demos) pr #888.