### PR TITLE
invoke `bower install` from `npm install`

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ Particle developers should visit our [particle developer website](https://polyme
 Note that you need a **recent** version of Node because we use new ES6 features. v9 is definitely OK.
 
 ```
-$ ./tools/install
+$ npm install
 $ ./tools/sigh
 ```
 
 ## Starting Arcs
 
-After the full build (`tools/install && tools/sigh`) run: (note that `npm
+After the full build (`npm install && tools/sigh`) run: (note that `npm
 start` will block, so you'll have to run the second command in a new shell):
 
 ```
@@ -48,8 +48,8 @@ commands will install all packages, run a build, start a background server,
 run all the tests, and kill the background server:
 
 ```
-$ ./tools/install
-$ npm run test-with-start
+$ npm install
+$ npm test-with-start
 ```
 
 There are additional targets provided to run subsets of those commands.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1216,6 +1216,12 @@
       "integrity": "sha1-WjiTlFSfIzMIdaOxUGVldPip63E=",
       "dev": true
     },
+    "bower": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/bower/-/bower-1.8.2.tgz",
+      "integrity": "sha1-rfU1KcjUrwLvJPuNU0HBQZ0z4vc=",
+      "dev": true
+    },
     "brace-expansion": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
@@ -2056,7 +2062,7 @@
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
-        "es5-ext": "0.10.39"
+        "es5-ext": "0.10.40"
       }
     },
     "dashdash": {
@@ -2389,9 +2395,9 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.39",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.39.tgz",
-      "integrity": "sha512-AlaXZhPHl0po/uxMx1tyrlt1O86M6D5iVaDH8UgLfgek4kXTX6vzsRfJQWC2Ku+aG8pkw1XWzh9eTkwfVrsD5g==",
+      "version": "0.10.40",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.40.tgz",
+      "integrity": "sha512-S9Fh3oya5OOvYSNGvPZJ+vyrs6VYpe1IXPowVe3N1OhaiwVaGlwfn3Zf5P5klYcWOA0toIwYQW8XEv/QqhdHvQ==",
       "dev": true,
       "requires": {
         "es6-iterator": "2.0.3",
@@ -2405,7 +2411,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.39",
+        "es5-ext": "0.10.40",
         "es6-symbol": "3.1.1"
       }
     },
@@ -2416,7 +2422,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.39"
+        "es5-ext": "0.10.40"
       }
     },
     "escape-string-regexp": {
@@ -2544,6 +2550,12 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
       "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+      "dev": true
+    },
+    "esprima-fb": {
+      "version": "15001.1.0-dev-harmony-fb",
+      "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1.0-dev-harmony-fb.tgz",
+      "integrity": "sha1-MKlHMDxrjV6VW+4rmbHSMyBqaQE=",
       "dev": true
     },
     "esquery": {
@@ -5385,12 +5397,6 @@
         "source-map": "0.4.4"
       },
       "dependencies": {
-        "esprima-fb": {
-          "version": "15001.1.0-dev-harmony-fb",
-          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1.0-dev-harmony-fb.tgz",
-          "integrity": "sha1-MKlHMDxrjV6VW+4rmbHSMyBqaQE=",
-          "dev": true
-        },
         "object-assign": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "host": "localhost"
   },
   "scripts": {
+    "prepare": "cd devtools && bower install",
     "start": "cross-env http-server -a ${npm_package_config_host} -p ${npm_package_config_port}",
     "test-with-start": "run-p --print-name --race start test",
     "test": "run-s --print-name --continue-on-error test-sigh test-mocha test-mocha-words test-wdio test-extension",
@@ -17,6 +18,7 @@
     "test-wdio": "cross-env wdio -b http://${npm_package_config_host}:${npm_package_config_port}/ shell/test/wdio.conf.js"
   },
   "devDependencies": {
+    "bower": "^1.8.2",
     "chai": "^4.1.2",
     "chokidar": "^1.7.0",
     "chromedriver": "^2.35.0",

--- a/tools/install
+++ b/tools/install
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-ROOT=$(dirname $0)/..
-(cd $ROOT && npm install)
-npm install -g bower
-(cd $ROOT/devtools && bower install)


### PR DESCRIPTION
Also removes the reliance on a globally-installed bower, since the script can use a locally installed version.

Part of #826 - continues consolidating the build into a single command.