### PR TITLE
Allow inline schemas to specify multiple names

### DIFF
--- a/runtime/manifest-parser.peg
+++ b/runtime/manifest-parser.peg
@@ -735,12 +735,12 @@ ExtendsList
 }
 
 SchemaInline
-  = name:(upperIdent / '*') whiteSpace '{' fields:(SchemaInlineField (',' whiteSpace SchemaInlineField)*)? '}'
+  = names:((upperIdent / '*') whiteSpace)+ '{' fields:(SchemaInlineField (',' whiteSpace SchemaInlineField)*)? '}'
   {
     return {
       kind: 'schema-inline',
       location: location(),
-      name: name == '*' ? null : name,
+      names: optional(names, names => names.map(name => name[0]).filter(name => name != '*'), []),
       fields: optional(fields, fields => [fields[0], ...fields[1].map(tail => tail[2])], []),
     }
   }

--- a/runtime/test/manifest-test.js
+++ b/runtime/test/manifest-test.js
@@ -1132,9 +1132,36 @@ resource SomeName
           foo = view
     `);
     let [validRecipe] = manifest.recipes;
+    debugger;
     assert(validRecipe.normalize());
     assert(validRecipe.isResolved());
   });
+
+  it('supports inline schemas with multiple names', async () => {
+    let manifest = await Manifest.parse(`
+      schema Thing1
+        Text value1
+      schema Thing2
+        Number value2
+      particle P
+        P(in Thing1 Thing2 {value1, value2} foo)
+      particle P2
+        P2(in * {Text value1, Number value2} foo)
+
+      recipe
+        create as view
+        P
+          foo = view
+        P2
+          foo = view
+    `);
+    let [validRecipe] = manifest.recipes;
+    debugger;
+    assert(validRecipe.normalize());
+    assert(validRecipe.isResolved());
+
+  });
+
 
   it('can parse a manifest with storage key handle definitions', async () => {
     let manifest = await Manifest.parse(`


### PR DESCRIPTION
This is intended to support serialization in the short term. We'll
probably add additional syntax to support proper hierarchies soon.