### PR TITLE
Resolve handles

### DIFF
--- a/devtools/src/strategy-explorer/se-stats.html
+++ b/devtools/src/strategy-explorer/se-stats.html
@@ -1,0 +1,40 @@
+<!--
+Copyright (c) 2018 Google Inc. All rights reserved.
+This code may only be used under the BSD style license found at
+http://polymer.github.io/LICENSE.txt
+Code distributed by Google as part of this project is also
+subject to an additional IP rights grant found at
+http://polymer.github.io/PATENTS.txt
+-->
+<link rel="import" href="../../bower_components/polymer/polymer.html">
+<link rel="import" href="../arcs-shared.html">
+<link rel="import" href="se-shared.html">
+
+<dom-module id='se-stats'>
+  <template>
+    <style include='shared-styles se-shared-styles'>
+      :host {
+        display: block;
+      }
+    </style>
+    <template is='dom-repeat' items='{{results}}'>
+      <template is='dom-repeat' items='{{item.population}}'>
+        <div>{{populationSize(item)}}</div>
+      </template>
+      <div>{{generationSize(item.population)}}</div>
+    </template>
+  </template>
+  <script>
+    Polymer({is: 'se-stats',
+  
+      populationSize: function(strategy) {
+        return `${strategy.strategy}: ${strategy.recipes.length}`;
+      }, 
+
+      generationSize: function(population) {
+        return `total: ${population.reduce((a, b) => a + b.recipes.length, 0)}`;
+      }
+  
+    });
+  </script>
+</dom-module>

--- a/devtools/src/strategy-explorer/strategy-explorer.html
+++ b/devtools/src/strategy-explorer/strategy-explorer.html
@@ -14,7 +14,8 @@ http://polymer.github.io/PATENTS.txt
 <link rel="import" href="se-explorer.html"></link>
 <link rel="import" href="se-legend.html"></link>
 <link rel="import" href="se-recipe-view.html"></link>
-<link rel="import" href="../arcs-shared.html">
+<link rel="import" href="se-stats.html"></link>
+<link rel="import" href="../arcs-shared.html"></link>
 
 <dom-module id='strategy-explorer'>
   <template>
@@ -49,6 +50,7 @@ http://polymer.github.io/PATENTS.txt
         <se-recipe-view></se-recipe-view>
         <se-arc-view></se-arc-view>
         <se-legend></se-legend>
+        <se-stats results='{{results}}'></se-stats>
       </aside>
     </resizable-panels>
   </template>

--- a/runtime/arc.js
+++ b/runtime/arc.js
@@ -486,7 +486,7 @@ ${this.activeRecipe.toString()}`;
       return false;
     });
 
-    if (options && options.tags) {
+    if (options && options.tags && options.tags.length > 0) {
       handles = handles.filter(handle => options.tags.filter(tag => !this._handleTags.get(handle).has(tag)).length == 0);
     }
     return handles;

--- a/runtime/planner.js
+++ b/runtime/planner.js
@@ -29,6 +29,7 @@ import FallbackFate from './strategies/fallback-fate.js';
 import GroupHandleConnections from './strategies/group-handle-connections.js';
 import CombinedStrategy from './strategies/combined-strategy.js';
 import MatchFreeHandlesToConnections from './strategies/match-free-handles-to-connections.js';
+import ResolveHandles from './strategies/resolve-handles.js';
 
 import Speculator from './speculator.js';
 import Description from './description.js';
@@ -87,7 +88,8 @@ class Planner {
       new NameUnnamedConnections(arc),
       new AddUseViews(),
       new CreateDescriptionHandle(),
-      new MatchFreeHandlesToConnections()
+      new MatchFreeHandlesToConnections(),
+      new ResolveHandles(arc)
     ];
     this.strategizer = new Strategizer(strategies, [], {
       maxPopulation: 100,

--- a/runtime/recipe/walker-base.js
+++ b/runtime/recipe/walker-base.js
@@ -9,6 +9,31 @@ import {Strategizer} from '../../strategizer/strategizer.js';
 import Recipe from './recipe.js';
 import assert from '../../platform/assert-web.js';
 
+/**
+ * Walkers traverse an object, calling methods based on the
+ * features encountered on that object. For example, a RecipeWalker
+ * takes a list of recipes and calls methods when:
+ *  - a new recipe is encountered
+ *  - a handle is found inside a recipe
+ *  - a particle is found inside a recipe
+ *  - etc..
+ * 
+ * Each of these methods can return a list of updates:
+ *   [(recipe, encountered_thing) => new_recipe]
+ *
+ * The walker then does something with the updates depending on the
+ * tactic selected.
+ * 
+ * If the tactic is "Permuted", then an output will be generated
+ * for every combination of 1 element drawn from each update list.
+ * For example, if 3 methods return [a,b], [c,d,e], and [f] respectively
+ * then "Permuted" will cause 6 outputs to be generated: [acf, adf, aef, bcf, bdf, bef]
+ * 
+ * If the tactic is "Independent", an output will be generated for each
+ * update, regardless of the list the update is in. For example,
+ * if 3 methods return [a,b], [c,d,e], and [f] respectively,
+ * then "Independent" will cause 6 outputs to be generated: [a,b,c,d,e,f]
+ */
 class WalkerBase extends Strategizer.Walker {
   constructor(tactic) {
     super();

--- a/runtime/strategies/resolve-handles.js
+++ b/runtime/strategies/resolve-handles.js
@@ -1,0 +1,34 @@
+// Copyright (c) 2017 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+import {Strategy} from '../../strategizer/strategizer.js';
+import Recipe from '../recipe/recipe.js';
+import RecipeUtil from '../recipe/recipe-util.js';
+import assert from '../../platform/assert-web.js';
+
+export default class ResolveHandles extends Strategy {
+  async generate(strategizer) {
+    let inputs = this.getResults(strategizer);
+    inputs.forEach(input => {
+      let recipe = input.result;
+      let unresolvedHandles = recipe.handles.filter(handle => {
+        if (handle.connections.length == 0)
+          return false;
+        if (handle.id)
+          return false;
+        if (!handle.type)
+          return false;
+        return true;
+      });
+
+      console.log(recipe.toString());
+      console.log(unresolvedHandles);
+    });
+
+    return {results: [], generate: null};
+  }
+}

--- a/runtime/strategies/resolve-handles.js
+++ b/runtime/strategies/resolve-handles.js
@@ -6,29 +6,59 @@
 // http://polymer.github.io/PATENTS.txt
 
 import {Strategy} from '../../strategizer/strategizer.js';
+import RecipeWalker from '../recipe/walker.js';
 import Recipe from '../recipe/recipe.js';
 import RecipeUtil from '../recipe/recipe-util.js';
 import assert from '../../platform/assert-web.js';
 
 export default class ResolveHandles extends Strategy {
+  constructor(arc) {
+    super();
+    this._arc = arc;
+  }
+
   async generate(strategizer) {
-    let inputs = this.getResults(strategizer);
-    inputs.forEach(input => {
-      let recipe = input.result;
-      let unresolvedHandles = recipe.handles.filter(handle => {
-        if (handle.connections.length == 0)
-          return false;
-        if (handle.id)
-          return false;
-        if (!handle.type)
-          return false;
-        return true;
-      });
+    let arc = this._arc;
+    let results = Recipe.over(this.getResults(strategizer), new class extends RecipeWalker {
+      onView(recipe, handle) {
+        if (handle.connections.length == 0 || handle.id || (!handle.type) || (!handle.fate))
+          return;
 
-      console.log(recipe.toString());
-      console.log(unresolvedHandles);
-    });
+        const counts = RecipeUtil.directionCounts(handle);
 
-    return {results: [], generate: null};
+        let mappable;
+
+        switch (handle.fate) {
+          case 'use':
+            mappable = arc.findHandlesByType(handle.type, {tags: handle.tags, subtype: counts.out == 0});
+            break;
+          case 'map':
+          case 'copy':
+            mappable = arc.context.findHandlesByType(handle.type, {tags: handle.tags, subtype: true});
+            break;
+          case 'create':
+          case '?':
+            mappable = [];
+            break;
+          default:
+            assert(false, `unexpected fate ${handle.fate}`);
+        }
+
+        mappable = mappable.filter(incomingHandle => {
+          for (let existingHandle of recipe.handles)
+            if (incomingHandle.id == existingHandle.id)
+              return false;
+          return true;
+        });
+
+        if (mappable.length == 1) {
+          return (recipe, handle) => {
+            handle.mapToView(mappable[0]);
+          };            
+        }
+      }
+    }(RecipeWalker.Permuted), this);
+
+    return {results, generate: null};
   }
 }

--- a/runtime/strategies/view-mapper-base.js
+++ b/runtime/strategies/view-mapper-base.js
@@ -55,7 +55,7 @@ export default class ViewMapperBase extends Strategy {
           return;
         }
         let views = self.getMappableViews(type, tags, counts);
-        if (views.length == 0)
+        if (views.length < 2)
           return;
 
         let responses = views.map(newView =>


### PR DESCRIPTION
1) Add a strategy that resolves handles when there's only one choice.
2) Stop view mapper strategies from resolving when there's only one choice.
3) Add some very simple metrics to the strategy explorer.

Splitting just view resolution like this (deterministic vs. non-deterministic) reduces
the total number of generated recipes (on current front-end environment) from 190 to 108.
Most savings are early on in the generation.