### PR TITLE
Initial simple particle to display a single game Stats record.

### DIFF
--- a/shell/artifacts/Words/ShowSingleStats.manifest
+++ b/shell/artifacts/Words/ShowSingleStats.manifest
@@ -1,0 +1,14 @@
+// @license
+// Copyright (c) 2018 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+import 'Stats.schema'
+
+particle ShowSingleStats in 'source/ShowSingleStats.js'
+  ShowSingleStats(in Stats stats)
+  consume root
+  description `show ${stats}`

--- a/shell/artifacts/Words/source/ShowSingleStats.js
+++ b/shell/artifacts/Words/source/ShowSingleStats.js
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright (c) 2018 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+'use strict';
+
+defineParticle(({DomParticle, html}) => {
+  importScripts(resolver(`GamePane/Scoring.js`));
+
+  const host = `show-single-stats`;
+
+  const template = html`
+<div ${host}>{{message}}</div>
+   `.trim();
+
+  return class extends DomParticle {
+    get template() {
+      return template;
+    }
+    render({stats}) {
+      const message = stats ? Scoring.scoreToMessage(stats) : '';
+      return {message};
+    }
+  };
+});


### PR DESCRIPTION
This is likely just a temporary placeholder to simplify our lives
while we wire up the muxing and polymorphic bits. We plan to shift to
a particle that renders the full board, potentially with full
interactivity, perhaps via `GamePane` itself, or a tweaked variant
thereof.

Part of https://github.com/PolymerLabs/arcs/issues/842