### PR TITLE
fix Xen.Template.html

### DIFF
--- a/shell/app-shell/elements/user-picker.js
+++ b/shell/app-shell/elements/user-picker.js
@@ -1,11 +1,8 @@
 // code
 import Xen from '../../components/xen/xen.js';
-// elements
-// strings
+
 // globals
 const shellPath = window.shellPath;
-
-Xen.Template.html = (...args) => Xen.Template.createTemplate(Xen.html.apply(null, args));
 
 const Main = Xen.html`
 <style>

--- a/shell/components/xen/xen.js
+++ b/shell/components/xen/xen.js
@@ -8,6 +8,8 @@ const html = (strings, ...values) => {
   return (strings[0] + values.map((v, i) => v + strings[i + 1]).join('')).trim();
 };
 
+Template.html = (...args) => Template.createTemplate(html.apply(null, args)); // eslint-disable-line prefer-spread
+
 const walker = (node, tree) => {
   let subtree = tree;
   if (!subtree) {


### PR DESCRIPTION
Xen.Template.Html is a JS template literal tag that converts a JS template literal into a Template instance.

I've been using it in various modules not realizing it was declared in a weird place. This puts the declaration into Xen proper.