### PR TITLE
Trigger imported manifest loads in parallel

### DIFF
--- a/runtime/manifest.js
+++ b/runtime/manifest.js
@@ -238,23 +238,25 @@ class Manifest {
   static async load(fileName, loader, options) {
     options = options || {};
     let {registry, id} = options;
+    registry = registry || {};
     if (registry && registry[fileName]) {
-      return registry[fileName];
+      return await registry[fileName];
     }
-    let content = await loader.loadResource(fileName);
-    assert(content !== undefined, `${fileName} unable to be loaded by Manifest parser`);
-    let manifest = await Manifest.parse(content, {
-      id,
-      fileName,
-      loader,
-      registry,
-      position: {line: 1, column: 0}
-    });
-    if (manifest && registry) {
-      registry[fileName] = manifest;
-    }
-    return manifest;
+    registry[fileName] = (async () => {
+      let content = await loader.loadResource(fileName);
+      // TODO: When does this happen? The loader should probably throw an exception here.
+      assert(content !== undefined, `${fileName} unable to be loaded by Manifest parser`);
+      return await Manifest.parse(content, {
+        id,
+        fileName,
+        loader,
+        registry,
+        position: {line: 1, column: 0}
+      });
+    })();
+    return await registry[fileName];
   }
+
   static async parse(content, options) {
     options = options || {};
     let {id, fileName, position, loader, registry} = options;
@@ -316,16 +318,9 @@ ${e.message}
     manifest._fileName = fileName;
 
     try {
-      let processItems = async (kind, f) => {
-        for (let item of items) {
-          if (item.kind == kind) {
-            Manifest._augmentAstWithTypes(manifest, item);
-            await f(item);
-          }
-        }
-      };
-
-      await processItems('import', async item => {
+      // Loading of imported manifests is triggered in parallel to avoid a serial loading
+      // of resources over the network. 
+      await Promise.all(items.filter(item => item.kind == 'import').map(async item => {
         let path = loader.path(manifest.fileName);
         let target = loader.join(path, item.path);
         try {
@@ -334,7 +329,16 @@ ${e.message}
           manifest._warnings.push(e);
           manifest._warnings.push(new ManifestError(item.location, `Error importing '${target}'`));
         }
-      });
+      }));
+
+      let processItems = async (kind, f) => {
+        for (let item of items) {
+          if (item.kind == kind) {
+            Manifest._augmentAstWithTypes(manifest, item);
+            await f(item);
+          }
+        }
+      };
 
       // processing meta sections should come first as this contains identifying
       // information that might need to be used in other sections. For example,

--- a/runtime/test/manifest-test.js
+++ b/runtime/test/manifest-test.js
@@ -325,7 +325,7 @@ ${particleStr1}
     };
     let manifest = await Manifest.load('some-path', loader, {registry});
     assert(manifest.recipes[0]);
-    assert.equal(manifest, registry['some-path']);
+    assert.equal(manifest, await registry['some-path']);
   });
   it('can load a manifest with imports', async () => {
     let registry = {};
@@ -344,8 +344,8 @@ ${particleStr1}
       },
     };
     let manifest = await Manifest.load('a', loader, {registry});
-    assert.equal(registry.a, manifest);
-    assert.equal(manifest.imports[0], registry.b);
+    assert.equal(await registry.a, manifest);
+    assert.equal(manifest.imports[0], await registry.b);
   });
   it('can resolve recipe particles imported from another manifest', async () => {
     let registry = {};
@@ -371,7 +371,7 @@ ${particleStr1}
       },
     };
     let manifest = await Manifest.load('a', loader, {registry});
-    assert.isTrue(manifest.recipes[0].particles[0].spec.equals(registry.b.findParticleByName('ParticleB')));
+    assert.isTrue(manifest.recipes[0].particles[0].spec.equals((await registry.b).findParticleByName('ParticleB')));
   });
   it('can parse a schema extending a schema in another manifest', async () => {
     let registry = {};


### PR DESCRIPTION
Allowing network requests to overlap.