### PR TITLE
ArcsLib.js must be loaded as a module

### DIFF
--- a/shell/apps/web/index.debug.html
+++ b/shell/apps/web/index.debug.html
@@ -12,7 +12,7 @@
 
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Google+Sans">
 
-  <script src="../../source/ArcsLib.js"></script>
+  <script type="module" src="../../source/ArcsLib.js"></script>
 
   <link rel="stylesheet" href="../common/index.css">
   <script type="module" src="../common/index.js"></script>


### PR DESCRIPTION
Note that debug mode is also available by adding `debug` parameter to the regular `index.html` URL (e.g. `index.html?debug`).

I'd like to deprecate the `index.debug.html` file in favor of the parameter, unless it would be inconvenient.