### PR TITLE
don't treat steps as immutable, dirty checking is performed upstream

### DIFF
--- a/shell/app-shell/elements/arc-cloud.js
+++ b/shell/app-shell/elements/arc-cloud.js
@@ -103,8 +103,8 @@ class ArcCloud extends Xen.Debug(Xen.Base, log) {
   }
   _consumeSteps(steps, metadata) {
     // steps are part of metadata, metadata is dirty-checked via JSON serialization
-    if (steps && metadata && steps !== metadata.steps) {
-      log(`setting new steps to metadata`);
+    if (steps && metadata) {
+      log(`setting steps to metadata`);
       metadata.steps = steps;
       this._setState({metadata});
     }

--- a/shell/app-shell/elements/persistent-arc.js
+++ b/shell/app-shell/elements/persistent-arc.js
@@ -99,10 +99,10 @@ class PersistentArc extends Xen.Debug(Xen.Base, log) {
     return {
       node: arcMetadata,
       handler: snap => {
-        //log('READING', String(arcMetadata));
+        log('watch fired on current arc metadata', String(arcMetadata));
         let metadata = snap.val();
         if (this._hasMetadataChanged(metadata)) {
-          log('READING', metadata);
+          log('installing new remote metadata', metadata);
           this._fire('metadata', metadata);
         }
       }


### PR DESCRIPTION
Intent is to make sure user-selected Suggestions are stored in Steps metadata.

Refs #1002, specifically "attempting to reopen an Arc from the launcher produces an empty Arc content region". 

For an arc in the 'empty content' state, you will have to select suggestions anew to see if the fix was effective. The change affects the recording of steps (not the playback).


