### PR TITLE
Refactoring of strategy interface

### DIFF
--- a/runtime/planner.js
+++ b/runtime/planner.js
@@ -39,8 +39,8 @@ import StrategyExplorerAdapter from './debug/strategy-explorer-adapter.js';
 
 class CreateViews extends Strategy {
   // TODO: move generation to use an async generator.
-  async generate(strategizer) {
-    let results = Recipe.over(this.getResults(strategizer), new class extends RecipeWalker {
+  async generate(inputParams) {
+    return Recipe.over(this.getResults(inputParams), new class extends RecipeWalker {
       onView(recipe, view) {
         let counts = RecipeUtil.directionCounts(view);
 
@@ -59,8 +59,6 @@ class CreateViews extends Strategy {
         }
       }
     }(RecipeWalker.Permuted), this);
-
-    return {results, generate: null};
   }
 }
 

--- a/runtime/strategies/add-use-views.js
+++ b/runtime/strategies/add-use-views.js
@@ -11,8 +11,8 @@ import RecipeWalker from '../recipe/walker.js';
 
 export default class AddUseViews extends Strategy {
   // TODO: move generation to use an async generator.
-  async generate(strategizer) {
-    let results = Recipe.over(this.getResults(strategizer), new class extends RecipeWalker {
+  async generate(inputParams) {
+    return Recipe.over(this.getResults(inputParams), new class extends RecipeWalker {
       onRecipe(recipe) {
         // Don't add use handles while there are outstanding constraints
         if (recipe.connectionConstraints.length > 0)
@@ -40,7 +40,5 @@ export default class AddUseViews extends Strategy {
         };
       }
     }(RecipeWalker.Permuted), this);
-
-    return {results, generate: null};
   }
 }

--- a/runtime/strategies/combined-strategy.js
+++ b/runtime/strategies/combined-strategy.js
@@ -31,8 +31,8 @@ export default class CombinedStrategy extends Strategy {
     });
     return resultsList.filter(r => !recipeByParent.has(r));
   }
-  async generate(strategizer) {
-    let results = this._strategies[0].getResults(strategizer);
+  async generate(inputParams) {
+    let results = this._strategies[0].getResults(inputParams);
     let totalResults = new Map();
     for (let strategy of this._strategies) {
       results = Recipe.over(results, strategy.walker, strategy);
@@ -50,6 +50,6 @@ export default class CombinedStrategy extends Strategy {
       results = this._getLeaves(totalResults);
     }
 
-    return {results, generate: null};
+    return results;
   }
 }

--- a/runtime/strategies/convert-constraints-to-connections.js
+++ b/runtime/strategies/convert-constraints-to-connections.js
@@ -15,9 +15,9 @@ export default class ConvertConstraintsToConnections extends Strategy {
     super();
     this.affordance = arc.pec.slotComposer ? arc.pec.slotComposer.affordance : null;
   }
-  async generate(strategizer) {
+  async generate(inputParams) {
     let affordance = this.affordance;
-    let results = Recipe.over(this.getResults(strategizer), new class extends RecipeWalker {
+    return Recipe.over(this.getResults(inputParams), new class extends RecipeWalker {
       onRecipe(recipe) {
         let particles = new Set();
         let views = new Set();
@@ -104,7 +104,5 @@ export default class ConvertConstraintsToConnections extends Strategy {
         });
       }
     }(RecipeWalker.Independent), this);
-
-    return {results, generate: null};
   }
 }

--- a/runtime/strategies/create-description-handle.js
+++ b/runtime/strategies/create-description-handle.js
@@ -11,8 +11,8 @@ import Recipe from '../recipe/recipe.js';
 import RecipeWalker from '../recipe/walker.js';
 
 export default class CreateDescriptionHandle extends Strategy {
-  async generate(strategizer) {
-    let results = Recipe.over(this.getResults(strategizer), new class extends RecipeWalker {
+  async generate(inputParams) {
+    return Recipe.over(this.getResults(inputParams), new class extends RecipeWalker {
       onHandleConnection(recipe, handleConnection) {
         if (handleConnection.handle)
           return;
@@ -27,7 +27,5 @@ export default class CreateDescriptionHandle extends Strategy {
         };
       }
     }(RecipeWalker.Permuted), this);
-
-    return {results, generate: null};
   }
 }

--- a/runtime/strategies/fallback-fate.js
+++ b/runtime/strategies/fallback-fate.js
@@ -12,11 +12,15 @@ import Recipe from '../recipe/recipe.js';
 import RecipeWalker from '../recipe/walker.js';
 
 export default class FallbackFate extends Strategy {
-  async generate(strategizer) {
-    assert(strategizer);
-    let generated = strategizer.generated.filter(result => !result.result.isResolved());
-    let terminal = strategizer.terminal;
-    let results = Recipe.over([...generated, ...terminal], new class extends RecipeWalker {
+  getResults(inputParams) {
+    assert(inputParams);
+    let generated = inputParams.generated.filter(result => !result.result.isResolved());
+    let terminal = inputParams.terminal;
+    return [...generated, ...terminal];
+  }
+
+  async generate(inputParams) {
+    return Recipe.over(this.getResults(inputParams), new class extends RecipeWalker {
       onView(recipe, view) {
         // Only apply this strategy only to user query based recipes with resolved tokens.
         if (!recipe.search || (recipe.search.resolvedTokens.length == 0)) {
@@ -40,7 +44,5 @@ export default class FallbackFate extends Strategy {
         };
       }
     }(RecipeWalker.Permuted), this);
-
-    return {results, generate: null};
   }
 }

--- a/runtime/strategies/group-handle-connections.js
+++ b/runtime/strategies/group-handle-connections.js
@@ -105,10 +105,7 @@ export default class GroupHandleConnections extends Strategy {
   get walker() {
     return this._walker;
   }
-  async generate(strategizer) {
-    return {
-      results: Recipe.over(this.getResults(strategizer), this.walker, this),
-      generate: null,
-    };
+  async generate(inputParams) {
+    return Recipe.over(this.getResults(inputParams), this.walker, this);
   }
 }

--- a/runtime/strategies/init-population.js
+++ b/runtime/strategies/init-population.js
@@ -28,21 +28,16 @@ export default class InitPopulation extends Strategy {
     }
     this._loadedParticles = new Set(arc.loadedParticles().map(spec => spec.implFile));
   }
-  async generate(strategizer) {
-    if (strategizer.generation != 0) {
-      return {results: [], generate: null};
+  async generate({generation}) {
+    if (generation != 0) {
+      return [];
     }
-    let results = this._recipes.map(recipe => ({
+    return this._recipes.map(recipe => ({
       result: recipe,
       score: 1 - recipe.particles.filter(particle => particle.spec && this._loadedParticles.has(particle.spec.implFile)).length,
       derivation: [{strategy: this, parent: undefined}],
       hash: recipe.digest(),
       valid: Object.isFrozen(recipe),
     }));
-
-    return {
-      results: results,
-      generate: null,
-    };
   }
 }

--- a/runtime/strategies/init-search.js
+++ b/runtime/strategies/init-search.js
@@ -15,12 +15,9 @@ export default class InitSearch extends Strategy {
     // TODO: Figure out where this should really come from.
     this._search = arc.search;
   }
-  async generate(strategizer) {
-    if (this._search == null || strategizer.generation != 0) {
-      return {
-        results: [],
-        generate: null,
-      };
+  async generate({generation}) {
+    if (this._search == null || generation != 0) {
+      return [];
     }
 
     let recipe = new Recipe();
@@ -28,14 +25,11 @@ export default class InitSearch extends Strategy {
     assert(recipe.normalize());
     assert(!recipe.isResolved());
 
-    return {
-      results: [{
-        result: recipe,
-        score: 0,
-        derivation: [{strategy: this, parent: undefined}],
-        hash: recipe.digest(),
-      }],
-      generate: null,
-    };
+    return [{
+      result: recipe,
+      score: 0,
+      derivation: [{strategy: this, parent: undefined}],
+      hash: recipe.digest(),
+    }];
   }
 }

--- a/runtime/strategies/map-slots.js
+++ b/runtime/strategies/map-slots.js
@@ -16,10 +16,10 @@ export default class MapSlots extends Strategy {
     super();
     this._arc = arc;
   }
-  async generate(strategizer) {
+  async generate(inputParams) {
     let arc = this._arc;
 
-    let results = Recipe.over(this.getResults(strategizer), new class extends RecipeWalker {
+    return Recipe.over(this.getResults(inputParams), new class extends RecipeWalker {
       onSlotConnection(recipe, slotConnection) {
         if (slotConnection.isConnected()) {
           return;
@@ -38,8 +38,6 @@ export default class MapSlots extends Strategy {
         };
       }
     }(RecipeWalker.Permuted), this);
-
-    return {results, generate: null};
   }
 
   // Helper methods.
@@ -112,7 +110,7 @@ export default class MapSlots extends Strategy {
   }
 
   // Returns true, if the slot connection's tags intersection with slot's tags is nonempty.
-  // TODO: replace with generic tag matcher      
+  // TODO: replace with generic tag matcher
   static _tagsMatch(slotConnection, slot) {
     let consumeConnTags = slotConnection.slotSpec.tags || [];
     let slotTags = new Set([].concat(slot.tags, slot.getProvidedSlotSpec().tags || []));
@@ -121,7 +119,7 @@ export default class MapSlots extends Strategy {
   }
 
   // Returns true, if the providing slot handle restrictions are satisfied by the consuming slot connection.
-      // TODO: should we move some of this logic to the recipe? Or type matching?  
+      // TODO: should we move some of this logic to the recipe? Or type matching?
   static _handlesMatch(consumingParticle, providingSlotHandles) {
     if (providingSlotHandles.length == 0) {
       return true; // slot is not limited to specific handles

--- a/runtime/strategies/match-free-handles-to-connections.js
+++ b/runtime/strategies/match-free-handles-to-connections.js
@@ -16,16 +16,16 @@ import assert from '../../platform/assert-web.js';
  * to connections.
  */
 export default class MatchFreeHandlesToConnections extends Strategy {
-  async generate(strategizer) {
+  async generate(inputParams) {
     let self = this;
 
-    let results = Recipe.over(this.getResults(strategizer), new class extends RecipeWalker {
+    return Recipe.over(this.getResults(inputParams), new class extends RecipeWalker {
       onView(recipe, handle) {
         if (handle.connections.length > 0)
           return;
 
         let matchingConnections = recipe.handleConnections.filter(connection => connection.handle == undefined && connection.name !== 'descriptions');
-           
+
         return matchingConnections.map(connection => {
           return (recipe, handle) => {
             let newConnection = recipe.updateToClone({connection}).connection;
@@ -35,7 +35,5 @@ export default class MatchFreeHandlesToConnections extends Strategy {
         });
       }
     }(RecipeWalker.Permuted), this);
-
-    return {results, generate: null};
   }
 }

--- a/runtime/strategies/match-particle-by-verb.js
+++ b/runtime/strategies/match-particle-by-verb.js
@@ -15,9 +15,9 @@ export default class MatchParticleByVerb extends Strategy {
     this._arc = arc;
   }
 
-  async generate(strategizer) {
+  async generate(inputParams) {
     let arc = this._arc;
-    let results = Recipe.over(this.getResults(strategizer), new class extends RecipeWalker {
+    return Recipe.over(this.getResults(inputParams), new class extends RecipeWalker {
       onParticle(recipe, particle) {
         if (particle.name) {
           // Particle already has explicit name.
@@ -39,7 +39,5 @@ export default class MatchParticleByVerb extends Strategy {
         });
       }
     }(RecipeWalker.Permuted), this);
-
-    return {results, generate: null};
   }
 }

--- a/runtime/strategies/match-recipe-by-verb.js
+++ b/runtime/strategies/match-recipe-by-verb.js
@@ -15,9 +15,9 @@ export default class MatchRecipeByVerb extends Strategy {
     this._arc = arc;
   }
 
-  async generate(strategizer) {
+  async generate(inputParams) {
     let arc = this._arc;
-    let results = Recipe.over(this.getResults(strategizer), new class extends RecipeWalker {
+    return Recipe.over(this.getResults(inputParams), new class extends RecipeWalker {
       onParticle(recipe, particle) {
         if (particle.name) {
           // Particle already has explicit name.
@@ -42,7 +42,5 @@ export default class MatchRecipeByVerb extends Strategy {
         });
       }
     }(RecipeWalker.Permuted), this);
-
-    return {results, generate: null};
   }
 }

--- a/runtime/strategies/name-unnamed-connections.js
+++ b/runtime/strategies/name-unnamed-connections.js
@@ -10,8 +10,8 @@ import Recipe from '../recipe/recipe.js';
 import RecipeWalker from '../recipe/walker.js';
 
 export default class NameUnnamedConnections extends Strategy {
-  async generate(strategizer) {
-    let results = Recipe.over(this.getResults(strategizer), new class extends RecipeWalker {
+  async generate(inputParams) {
+    return Recipe.over(this.getResults(inputParams), new class extends RecipeWalker {
       onHandleConnection(recipe, handleConnection) {
         if (handleConnection.name)
           return; // it is already named.
@@ -34,7 +34,5 @@ export default class NameUnnamedConnections extends Strategy {
         });
       }
     }(RecipeWalker.Permuted), this);
-
-    return {results, generate: null};
   }
 }

--- a/runtime/strategies/resolve-recipe.js
+++ b/runtime/strategies/resolve-recipe.js
@@ -18,9 +18,9 @@ export default class ResolveRecipe extends Strategy {
     this._arc = arc;
   }
 
-  async generate(strategizer) {
+  async generate(inputParams) {
     let arc = this._arc;
-    let results = Recipe.over(this.getResults(strategizer), new class extends RecipeWalker {
+    return Recipe.over(this.getResults(inputParams), new class extends RecipeWalker {
       onView(recipe, handle) {
         if (handle.connections.length == 0 || handle.id || (!handle.type) || (!handle.fate))
           return;
@@ -55,7 +55,7 @@ export default class ResolveRecipe extends Strategy {
         if (mappable.length == 1) {
           return (recipe, handle) => {
             handle.mapToView(mappable[0]);
-          };            
+          };
         }
       }
 
@@ -63,12 +63,12 @@ export default class ResolveRecipe extends Strategy {
         if (slotConnection.isConnected()) {
           return;
         }
-        
+
         let selectedSlots = MapSlots.findAllSlotCandidates(slotConnection, arc);
         if (selectedSlots.length !== 1) {
           return;
         }
-        
+
         let selectedSlot = selectedSlots[0];
 
         return (recipe, slotConnection) => {
@@ -77,7 +77,5 @@ export default class ResolveRecipe extends Strategy {
         };
       }
     }(RecipeWalker.Permuted), this);
-
-    return {results, generate: null};
   }
 }

--- a/runtime/strategies/search-tokens-to-particles.js
+++ b/runtime/strategies/search-tokens-to-particles.js
@@ -71,10 +71,10 @@ export default class SearchTokensToParticles extends Strategy {
     return this._walker;
   }
 
-  getResults(strategizer) {
-    assert(strategizer);
-    let generated = super.getResults(strategizer).filter(result => !result.result.isResolved());
-    let terminal = strategizer.terminal;
+  getResults(inputParams) {
+    assert(inputParams);
+    let generated = super.getResults(inputParams).filter(result => !result.result.isResolved());
+    let terminal = inputParams.terminal;
     return [...generated, ...terminal];
   }
 
@@ -82,10 +82,7 @@ export default class SearchTokensToParticles extends Strategy {
     this._byToken[token] = this._byToken[token] || [];
     this._byToken[token].push(particle);
   }
-  async generate(strategizer) {
-    return {
-      results: Recipe.over(this.getResults(strategizer), this.walker, this),
-      generate: null,
-    };
+  async generate(inputParams) {
+    return Recipe.over(this.getResults(inputParams), this.walker, this);
   }
 }

--- a/runtime/strategies/view-mapper-base.js
+++ b/runtime/strategies/view-mapper-base.js
@@ -12,10 +12,10 @@ import RecipeUtil from '../recipe/recipe-util.js';
 import assert from '../../platform/assert-web.js';
 
 export default class ViewMapperBase extends Strategy {
-  async generate(strategizer) {
+  async generate(inputParams) {
     let self = this;
 
-    let results = Recipe.over(this.getResults(strategizer), new class extends RecipeWalker {
+    return Recipe.over(this.getResults(inputParams), new class extends RecipeWalker {
       onView(recipe, view) {
         if (view.fate !== self.fate)
           return;
@@ -78,7 +78,5 @@ export default class ViewMapperBase extends Strategy {
         return responses;
       }
     }(RecipeWalker.Permuted), this);
-
-    return {results, generate: null};
   }
 }

--- a/runtime/test/planner-tests.js
+++ b/runtime/test/planner-tests.js
@@ -222,8 +222,8 @@ describe('InitSearch', async () => {
     let arc = new Arc({id: 'test-plan-arc', context: {}});
     arc._search = 'search';
     let initSearch = new InitSearch(arc);
-    let strategizer = {generated: [], generation: 0};
-    let {results} = await initSearch.generate(strategizer);
+    let inputParams = {generated: [], generation: 0};
+    let results = await initSearch.generate(inputParams);
     assert.equal(results.length, 1);
     assert.equal(results[0].score, 0);
   });
@@ -247,8 +247,8 @@ describe('InitPopulation', async () => {
     await arc.instantiate(recipe);
     let ip = new InitPopulation(arc);
 
-    let strategizer = {generated: [], generation: 0};
-    let {results} = await ip.generate(strategizer);
+    let inputParams = {generated: [], generation: 0};
+    let results = await ip.generate(inputParams);
     assert.equal(results.length, 1);
     assert.equal(results[0].score, 0);
   });
@@ -266,9 +266,9 @@ describe('ConvertConstraintsToConnections', async () => {
 
       recipe
         A.b -> C.d`)).recipes[0];
-    let strategizer = {generated: [{result: recipe, score: 1}]};
+    let inputParams = {generated: [{result: recipe, score: 1}]};
     let cctc = new ConvertConstraintsToConnections({pec: {}});
-    let {results} = await cctc.generate(strategizer);
+    let results = await cctc.generate(inputParams);
     assert.equal(1, results.length);
     let {result, score} = results[0];
     assert.deepEqual(result.toString(),
@@ -290,9 +290,9 @@ describe('ConvertConstraintsToConnections', async () => {
 
       recipe
         A.b -> C.d`)).recipes[0];
-    let strategizer = {generated: [{result: recipe, score: 1}]};
+    let inputParams = {generated: [{result: recipe, score: 1}]};
     let cctc = new ConvertConstraintsToConnections({pec: {}});
-    let {results} = await cctc.generate(strategizer);
+    let results = await cctc.generate(inputParams);
     assert.equal(0, results.length);
   });
 
@@ -307,9 +307,9 @@ describe('ConvertConstraintsToConnections', async () => {
       recipe
         map as v0
         A.b -> C.d`)).recipes[0];
-    let strategizer = {generated: [{result: recipe, score: 1}]};
+    let inputParams = {generated: [{result: recipe, score: 1}]};
     let cctc = new ConvertConstraintsToConnections({pec: {}});
-    let {results} = await cctc.generate(strategizer);
+    let results = await cctc.generate(inputParams);
     assert.equal(1, results.length);
   });
 
@@ -328,9 +328,9 @@ describe('ConvertConstraintsToConnections', async () => {
         ${constraint2}`)).recipes[0];
     let verify = async (constraint1, constraint2) => {
       let recipe = await createRecipe(constraint1, constraint2);
-      let strategizer = {generated: [{result: recipe, score: 1}]};
+      let inputParams = {generated: [{result: recipe, score: 1}]};
       let cctc = new ConvertConstraintsToConnections({pec: {}});
-      let {results} = await cctc.generate(strategizer);
+      let results = await cctc.generate(inputParams);
       assert.equal(1, results.length, `Failed to resolve ${constraint1} & ${constraint2}`);
     };
     // Test for all possible combination of connection constraints with 3 particles.
@@ -358,9 +358,9 @@ describe('ConvertConstraintsToConnections', async () => {
       recipe
         A.b -> C.d
         C`)).recipes[0];
-    let strategizer = {generated: [{result: recipe, score: 1}]};
+    let inputParams = {generated: [{result: recipe, score: 1}]};
     let cctc = new ConvertConstraintsToConnections({pec: {}});
-    let {results} = await cctc.generate(strategizer);
+    let results = await cctc.generate(inputParams);
     assert.equal(1, results.length);
     let {result, score} = results[0];
     assert.deepEqual(result.toString(),
@@ -383,9 +383,9 @@ describe('ConvertConstraintsToConnections', async () => {
       recipe
         A.b -> C.d
         A`)).recipes[0];
-    let strategizer = {generated: [{result: recipe, score: 1}]};
+    let inputParams = {generated: [{result: recipe, score: 1}]};
     let cctc = new ConvertConstraintsToConnections({pec: {}});
-    let {results} = await cctc.generate(strategizer);
+    let results = await cctc.generate(inputParams);
     assert.equal(1, results.length);
     let {result, score} = results[0];
     assert.deepEqual(result.toString(),
@@ -410,9 +410,9 @@ describe('ConvertConstraintsToConnections', async () => {
         A.b -> C.d
         C
         A`)).recipes[0];
-    let strategizer = {generated: [{result: recipe, score: 1}]};
+    let inputParams = {generated: [{result: recipe, score: 1}]};
     let cctc = new ConvertConstraintsToConnections({pec: {}});
-    let {results} = await cctc.generate(strategizer);
+    let results = await cctc.generate(inputParams);
     assert.equal(1, results.length);
     let {result, score} = results[0];
     assert.deepEqual(result.toString(),
@@ -438,9 +438,9 @@ describe('ConvertConstraintsToConnections', async () => {
         C
           d = v1
         A`)).recipes[0];
-    let strategizer = {generated: [{result: recipe, score: 1}]};
+    let inputParams = {generated: [{result: recipe, score: 1}]};
     let cctc = new ConvertConstraintsToConnections({pec: {}});
-    let {results} = await cctc.generate(strategizer);
+    let results = await cctc.generate(inputParams);
     assert.equal(1, results.length);
     let {result, score} = results[0];
     assert.deepEqual(result.toString(),
@@ -466,9 +466,9 @@ describe('ConvertConstraintsToConnections', async () => {
         C
         A
           b = v1`)).recipes[0];
-    let strategizer = {generated: [{result: recipe, score: 1}]};
+    let inputParams = {generated: [{result: recipe, score: 1}]};
     let cctc = new ConvertConstraintsToConnections({pec: {}});
-    let {results} = await cctc.generate(strategizer);
+    let results = await cctc.generate(inputParams);
     assert.equal(1, results.length);
     let {result, score} = results[0];
     assert.deepEqual(result.toString(),
@@ -495,9 +495,9 @@ describe('ConvertConstraintsToConnections', async () => {
           d = v1
         A
           b = v1`)).recipes[0];
-    let strategizer = {generated: [{result: recipe, score: 1}]};
+    let inputParams = {generated: [{result: recipe, score: 1}]};
     let cctc = new ConvertConstraintsToConnections({pec: {}});
-    let {results} = await cctc.generate(strategizer);
+    let results = await cctc.generate(inputParams);
     assert.equal(1, results.length);
     let {result, score} = results[0];
     assert.deepEqual(result.toString(), `recipe
@@ -528,9 +528,9 @@ describe('ConvertConstraintsToConnections', async () => {
       recipe
         A.b -> E.f
     `)).recipes;
-    let strategizer = {generated: [{result: recipes[0], score: 1}, {result: recipes[1], score: 1}]};
+    let inputParams = {generated: [{result: recipes[0], score: 1}, {result: recipes[1], score: 1}]};
     let cctc = new ConvertConstraintsToConnections({pec: {slotComposer: {affordance: 'voice'}}});
-    let {results} = await cctc.generate(strategizer);
+    let results = await cctc.generate(inputParams);
     assert.equal(results.length, 1);
     assert.deepEqual(results[0].result.particles.map(p => p.name), ['A', 'C']);
   });
@@ -552,17 +552,17 @@ describe('ResolveRecipe/MapSlots', function() {
 
       ${recipeManifest}
     `));
-    let strategizer = {generated: [{result: manifest.recipes[0], score: 1}]};
+    let inputParams = {generated: [{result: manifest.recipes[0], score: 1}]};
     let arc = createTestArc('test-plan-arc', manifest, 'dom');
-    
-    let {results} = await new MapSlots(arc).generate(strategizer);
+
+    let results = await new MapSlots(arc).generate(inputParams);
     if (results.length == 1) {
-      strategizer = {generated: [{result: results[0].result, score: 1}]};
+      inputParams = {generated: [{result: results[0].result, score: 1}]};
     }
 
-    let resultStruct = await new ResolveRecipe(arc).generate(strategizer);
-    assert.equal(resultStruct.results.length, 1);
-    let recipe = resultStruct.results[0].result;
+    results = await new ResolveRecipe(arc).generate(inputParams);
+    assert.equal(results.length, 1);
+    let recipe = results[0].result;
 
     if (expectedSlots >= 0) {
       assert.isTrue(recipe.isResolved());
@@ -633,20 +633,20 @@ describe('ResolveRecipe/MapSlots', function() {
         A
         B
     `));
-    let strategizer = {generated: [{result: manifest.recipes[0], score: 1}]};
+    let inputParams = {generated: [{result: manifest.recipes[0], score: 1}]};
     let arc = createTestArc('test-plan-arc', manifest, 'dom');
 
     let strategy = new MapSlots(arc);
-    let {results} = await strategy.generate(strategizer);
+    let results = await strategy.generate(inputParams);
     assert.equal(results.length, 1);
 
     let plan = results[0].result;
 
     strategy = new ResolveRecipe(arc);
-    let resultStruct = await strategy.generate({generated: [{result: plan, score: 1}]});
-    assert.equal(resultStruct.results.length, 1);
+    results = await strategy.generate({generated: [{result: plan, score: 1}]});
+    assert.equal(results.length, 1);
 
-    plan = resultStruct.results[0].result;
+    plan = results[0].result;
 
     assert.equal(plan.slots.length, 2);
     plan.normalize();
@@ -813,9 +813,9 @@ describe('SearchTokensToParticles', function() {
     let recipe = manifest.recipes[0];
     assert(recipe.normalize());
     assert(!recipe.isResolved());
-    let strategizer = {generated: [], terminal: [{result: recipe, score: 1}]};
+    let inputParams = {generated: [], terminal: [{result: recipe, score: 1}]};
     let stp = new SearchTokensToParticles(arc);
-    let {results} = await stp.generate(strategizer);
+    let results = await stp.generate(inputParams);
     assert.equal(results.length, 2);
     assert.deepEqual([['GalaxyFlyer', 'Rester', 'SimpleJumper'],
                       ['GalaxyFlyer', 'Rester', 'StarJumper']], results.map(r => r.result.particles.map(p => p.name).sort()));
@@ -829,7 +829,7 @@ describe('MatchRecipeByVerb', function() {
     let manifest = await Manifest.parse(`
       recipe
         particle can jump
-      
+
       schema Feet
       schema Energy
 
@@ -842,13 +842,13 @@ describe('MatchRecipeByVerb', function() {
 
       recipe jump
         JumpingBoots.f <- FootFactory.f
-        JumpingBoots.e <- NuclearReactor.e         
+        JumpingBoots.e <- NuclearReactor.e
     `);
 
     let arc = createTestArc('test-plan-arc', manifest, 'dom');
-    let strategizer = {generated: [{result: manifest.recipes[0], score: 1}]};
+    let inputParams = {generated: [{result: manifest.recipes[0], score: 1}]};
     let mrv = new MatchRecipeByVerb(arc);
-    let {results} = await mrv.generate(strategizer);
+    let results = await mrv.generate(inputParams);
     assert.equal(results.length, 1);
     assert.equal(results[0].result.particles.length, 0);
     assert.deepEqual(results[0].result.toString(), 'recipe\n  JumpingBoots.e -> NuclearReactor.e\n  JumpingBoots.f -> FootFactory.f');
@@ -859,25 +859,25 @@ describe('MatchRecipeByVerb', function() {
       particle P in 'A.js'
         P(out S p)
       particle Q in 'B.js'
-        Q(in S q)  
-    
+        Q(in S q)
+
       recipe
         P.p -> Q.q
         particle can a
-      
+
       recipe a
         P
     `);
 
     let arc = createTestArc('test-plan-arc', manifest, 'dom');
-    let strategizer = {generated: [{result: manifest.recipes[0], score: 1}]};
+    let inputParams = {generated: [{result: manifest.recipes[0], score: 1}]};
     let mrv = new MatchRecipeByVerb(arc);
-    let {results} = await mrv.generate(strategizer);
+    let results = await mrv.generate(inputParams);
     assert.equal(results.length, 1);
     let cctc = new ConvertConstraintsToConnections(arc);
-    let output = await cctc.generate({generated: results});
-    assert.equal(output.results.length, 1);
-    assert.deepEqual(output.results[0].result.toString(), 
+    results = await cctc.generate({generated: results});
+    assert.equal(results.length, 1);
+    assert.deepEqual(results[0].result.toString(),
 `recipe
   create as view0 // S
   P as particle0
@@ -922,9 +922,9 @@ describe('MatchParticleByVerb', function() {
     let manifest = (await Manifest.parse(manifestStr));
     let arc = createTestArc('test-plan-arc', manifest, 'dom');
     // Apply MatchParticleByVerb strategy.
-    let strategizer = {generated: [{result: manifest.recipes[0], score: 1}]};
+    let inputParams = {generated: [{result: manifest.recipes[0], score: 1}]};
     let mpv = new MatchParticleByVerb(arc);
-    let {results} = await mpv.generate(strategizer);
+    let results = await mpv.generate(inputParams);
     assert.equal(results.length, 3);
     // Note: view connections are not resolved yet.
     assert.deepEqual(['GalaxyJumper', 'SimpleJumper', 'StarJumper'], results.map(r => r.result.particles[0].name).sort());
@@ -971,12 +971,12 @@ recipe
   C
   D
       `));
-      let strategizer = {generated: [{result: manifest.recipes[0], score: 1}]};
+      let inputParams = {generated: [{result: manifest.recipes[0], score: 1}]};
       let arc = createTestArc('test-plan-arc', manifest, 'dom');
       arc._search = 'ShowCollection and chooser alsoon recommend';
       let ghc = new GroupHandleConnections(arc);
 
-      let {results} = await ghc.generate(strategizer);
+      let results = await ghc.generate(inputParams);
       assert.equal(results.length, 1);
       let recipe = results[0].result;
       assert.equal(4, recipe.handles.length);
@@ -1000,14 +1000,14 @@ recipe
           search \`prepare and jump\`
       `));
       manifest.recipes[0].normalize();
-      let strategizer = {generated: [{result: manifest.recipes[0], score: 1}], terminal: []};
+      let inputParams = {generated: [{result: manifest.recipes[0], score: 1}], terminal: []};
       let arc = createTestArc('test-plan-arc', manifest, 'dom');
       let strategy = new CombinedStrategy([
         new SearchTokensToParticles(arc),
         new GroupHandleConnections(arc),
       ]);
 
-      let {results} = await strategy.generate(strategizer);
+      let results = await strategy.generate(inputParams);
       assert.equal(results.length, 1);
       let recipe = results[0].result;
       assert.equal(2, recipe.particles.length);
@@ -1035,16 +1035,16 @@ describe('FallbackFate', function() {
     recipe.handles.forEach(v => v._originalFate = '?');
     assert(recipe.normalize());
     let arc = createTestArc('test-plan-arc', manifest, 'dom');
-    let strategizer = {generated: [{result: manifest.recipes[0], score: 1}], terminal: []};
+    let inputParams = {generated: [{result: manifest.recipes[0], score: 1}], terminal: []};
     let strategy = new FallbackFate(arc);
 
     // no resolved search tokens.
-    let {results} = await strategy.generate(strategizer);
+    let results = await strategy.generate(inputParams);
     assert.equal(results.length, 0);
 
     // Resolved a search token and rerun strategy.
     recipe.search.resolveToken('DoSomething');
-    results = (await strategy.generate(strategizer)).results;
+    results = (await strategy.generate(inputParams));
     assert.equal(results.length, 1);
     let plan = results[0].result;
     assert.equal(plan.handles.length, 2);
@@ -1070,10 +1070,10 @@ describe('FallbackFate', function() {
     recipe.handles.forEach(v => v._originalFate = '?');
     assert(recipe.normalize());
     let arc = createTestArc('test-plan-arc', manifest, 'dom');
-    let strategizer = {generated: [{result: manifest.recipes[0], score: 1}], terminal: []};
+    let inputParams = {generated: [{result: manifest.recipes[0], score: 1}], terminal: []};
 
     let strategy = new FallbackFate(arc);
-    let {results} = await strategy.generate(strategizer);
+    let results = await strategy.generate(inputParams);
     assert.equal(results.length, 0);
   });
 });
@@ -1287,9 +1287,9 @@ describe('CreateDescriptionHandle', function() {
         DoSomething as particle0
     `));
     let recipe = manifest.recipes[0];
-    let strategizer = {generated: [{result: manifest.recipes[0], score: 1}], terminal: []};
+    let inputParams = {generated: [{result: manifest.recipes[0], score: 1}], terminal: []};
     let strategy = new CreateDescriptionHandle();
-    let results = (await strategy.generate(strategizer)).results;
+    let results = (await strategy.generate(inputParams));
 
     assert.equal(results.length, 1);
     let plan = results[0].result;

--- a/strategizer/hello-strategizer.js
+++ b/strategizer/hello-strategizer.js
@@ -8,34 +8,32 @@
 let {Strategizer, Strategy} = require('./strategizer.js');
 
 class Seed extends Strategy {
-  async generate(strategizer, n) {
-    let results = strategizer.generation == 0 ? [{result: '', score: 1}] : [];
-    return {results, generate: null};
+  async generate({generation}) {
+    return generation == 0 ? [{result: '', score: 1}] : [];
   }
 }
 
 class Grow extends Strategy {
-  async generate(strategizer, n) {
-    if (strategizer.population.length == 0)
-      return {results: [], generate: null};
+  async generate({population, outputLimit}) {
+    if (population.length == 0)
+      return [];
     const alphabet = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ.,! ';
-    let population = strategizer.population;
     let results = [];
-    for (let i = 0; i < n; i++) {
+    for (let i = 0; outputLimit < n; i++) {
       let source = population[Math.random() * population.length|0].result;
       let split = Math.random() * (source.length + 1) |0;
       let str = source.substr(0, split) + alphabet[Math.random() * alphabet.length|0] + source.substr(split);
       results.push({result: str, score: 1});
     }
-    return {results, generate: null};
+    return results;
   }
 }
 
 class Cross extends Strategy {
-  async generate(strategizer, n) {
-    let population = strategizer.population.filter(str => str.length > 0);
+  async generate({population, outputLimit}) {
+    population = population.filter(str => str.length > 0);
     let results = [];
-    while (population.length > 0 && results.length < n) {
+    while (population.length > 0 && results.length < outputLimit) {
       let p1 = population[Math.random() * population.length|0].result;
       let p2 = population[Math.random() * population.length|0].result;
       let str = '';
@@ -44,15 +42,15 @@ class Cross extends Strategy {
       }
       results.push({result: str, score: 1});
     }
-    return {results, generate: null};
+    return results;
   }
 }
 
 class Mutate extends Strategy {
-  async generate(strategizer, n) {
-    let population = strategizer.population.filter(str => str.length > 2);
+  async generate({population, outputLimit}) {
+    population = population.filter(str => str.length > 2);
     let results = [];
-    while (population.length > 0 && results.length < n) {
+    while (population.length > 0 && results.length < outputLimit) {
       let source = population[Math.random() * population.length|0].result;
       let str = source.split('');
       let i = Math.random() * source.length |0;
@@ -62,7 +60,7 @@ class Mutate extends Strategy {
       str[j] = tmp;
       results.push({result: str.join(''), score: 1});
     }
-    return {results, generate: null};
+    return results;
   }
 }
 

--- a/strategizer/strategizer.js
+++ b/strategizer/strategizer.js
@@ -51,7 +51,13 @@ export class Strategizer {
     let generation = this.generation + 1;
     let individualsPerStrategy = Math.floor(this._options.generationSize / this._strategies.length);
     let generated = await Promise.all(this._strategies.map(strategy => {
-      return strategy.generate(this, individualsPerStrategy);
+      return strategy.generate({
+        generation: this.generation,
+        generated: this.generated,
+        terminal: this.terminal,
+        population: this.population,
+        outputLimit: individualsPerStrategy
+      });
     }));
 
     let record = {};
@@ -59,10 +65,9 @@ export class Strategizer {
     record.sizeOfLastGeneration = this.generated.length;
     record.outputSizesOfStrategies = {};
     for (let i = 0; i < this._strategies.length; i++) {
-      record.outputSizesOfStrategies[this._strategies[i].constructor.name] = generated[i].results.length;
+      record.outputSizesOfStrategies[this._strategies[i].constructor.name] = generated[i].length;
     }
 
-    generated = generated.map(({results}) => results);
     generated = [].concat(...generated);
 
     // TODO: get rid of this additional asynchrony
@@ -264,10 +269,10 @@ export class Strategy {
     // generated individuals and evaluations.
     return {generate: 0, evaluate: 0};
   }
-  getResults(strategizer) {
-    return strategizer.generated;
+  getResults(inputParams) {
+    return inputParams.generated;
   }
-  async generate(strategizer, n) {
+  async generate(inputParams) {
     return [];
   }
   discard(individuals) {


### PR DESCRIPTION
Introducing a inputParams object instead of passing a reference to the Strategizer will unlock adding rules by limiting what recipes a strategy is allowed to operate on.

As a bonus cleans up return value to the array of results, which is the only thing that has been used so far.

