### PR TITLE
Set particle-host attribute on dom context div elements.

### DIFF
--- a/runtime/dom-context.js
+++ b/runtime/dom-context.js
@@ -30,6 +30,7 @@ class DomContext {
     assert(context);
     if (!this._context) {
       this._context = document.createElement(this._containerKind || 'div');
+      this._context.setAttribute('particle-host', '');
       context.appendChild(this._context);
     } else {
       assert(this._context.parentNode == context,


### PR DESCRIPTION
Fixes https://github.com/PolymerLabs/arcs/issues/1023

I'll open a separate issue to track the busted particle illumination.