### PR TITLE
Restore support for illumination of particles.

### DIFF
--- a/shell/app-shell/app-shell.js
+++ b/shell/app-shell/app-shell.js
@@ -141,6 +141,7 @@ const template = html`
     user="{{user}}"
     key="{{key}}"
     arc="{{arc}}"
+    plan="{{plan}}"
     metadata="{{metadata}}"
     friends="{{friends}}"
     avatars="{{avatars}}"

--- a/shell/app-shell/elements/shell-ui.js
+++ b/shell/app-shell/elements/shell-ui.js
@@ -75,7 +75,7 @@ const Main = Xen.html`
 </app-main>
 
 <app-tools>
-  <shell-particles arc="{{arc}}"></shell-particles>
+  <shell-particles arc="{{arc}}" plan="{{plan}}"></shell-particles>
   <simple-tabs>
     <div tab="Handle Explorer">
       <handle-explorer arc="{{arc}}"></handle-explorer>
@@ -96,7 +96,7 @@ const log = Xen.Base.logFactory('ShellUi', '#294740');
 
 class ShellUi extends Xen.Debug(Xen.Base, log) {
   static get observedAttributes() {
-    return ['config', 'manifests', 'exclusions', 'users', 'user', 'friends', 'avatars', 'key', 'arc', 'metadata', 'share', 'theme'];
+    return ['config', 'manifests', 'exclusions', 'users', 'user', 'friends', 'avatars', 'key', 'arc', 'plan', 'metadata', 'share', 'theme'];
   }
   get css() {
     return Css;
@@ -145,13 +145,14 @@ class ShellUi extends Xen.Debug(Xen.Base, log) {
       toolsVisible: config.arcsToolsVisible
     });
   }
-  _render({config, manifests, exclusions, users, user, friends, avatars, key, arc, share, theme}, state) {
+  _render({config, manifests, exclusions, users, user, friends, avatars, key, arc, plan, share, theme}, state) {
     const avatarUrl = user && user.avatar ? user.avatar : `${shellPath}/assets/avatars/user (0).png`;
     const render = {
       manifests,
       exclusions,
       users,
       arc,
+      plan,
       friends,
       avatars,
       share,

--- a/shell/components/arc-tools/shell-particles.js
+++ b/shell/components/arc-tools/shell-particles.js
@@ -10,7 +10,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 import Xen from '../xen/xen.js';
 
 class ShellParticles extends Xen.Base {
-  static get observedAttributes() { return ['arc']; }
+  static get observedAttributes() { return ['arc', 'plan']; }
   _update(props, state, lastProps) {
     if (props.arc) {
       let slots = props.arc.pec.slotComposer._slots;


### PR DESCRIPTION
Revise `ShellParticles` to update when plan is updated, as that
corresponds to when `SlotComposer` has finished computing slots.

I'm not sure how this worked previously -- presumably it was sufficient to watch the arc. That appears to no longer be the case (it is not a matter of adding `_wouldChangeProp` to `ShellParticles`).

`SlotComposer` computes slots as part of `Arc.instantiate`, and `ArcHost` fires a `plan` event with the updated plan immediately following that. I believe this causes `AppShell` to propagate the plan update into its components, which will eventually wend its way into `ShellParticles` with this change.

Open to alternate approaches or insights I may have missed.

Part of https://github.com/PolymerLabs/arcs/issues/1025. Leaving that issue open so that we can pursue its second bullet separately.