### PR TITLE
Update sigh.js to detect when peg & railroad steps can be skipped.

### DIFF
--- a/tools/sigh.js
+++ b/tools/sigh.js
@@ -138,9 +138,9 @@ function railroad() {
   });
 
   let data = {
-      title: `Railroad diagram for ${sources.peg.grammar}`,
-      style: readProjectFile(diagramStyle) + '\n' + readProjectFile(appStyle),
-      grammars: grammars
+    title: `Railroad diagram for ${sources.peg.grammar}`,
+    style: readProjectFile(diagramStyle) + '\n' + readProjectFile(appStyle),
+    grammars: grammars
   };
   let template = handlebars.compile(readProjectFile(baseTemplate));
   fs.writeFileSync(path.resolve(projectRoot, sources.peg.railroad), template(data));


### PR DESCRIPTION
This allows the watch command to monitor files in runtime with infinite
looping.