### PR TITLE
Improves geolocation with Restaurants demo

### DIFF
--- a/shell/app-shell/elements/shell-handles.js
+++ b/shell/app-shell/elements/shell-handles.js
@@ -69,15 +69,22 @@ class ShellHandles extends Xen.Base {
     };
   }
   _watchGeolocation() {
+    const fallback = () => this._maybeUpdateGeoCoords(
+        {latitude: 37.7610927, longitude: -122.4208173}); // San Francisco
+
     if ('geolocation' in navigator) {
-      navigator.geolocation.watchPosition(({coords}) => {
-        const {geoCoords} = this._state;
-        const {latitude, longitude} = coords;
-        // Skip setting the position if it's the same as what we've already got.
-        if (!geoCoords || geoCoords.latitude != latitude || geoCoords.longitude != longitude) {
-          this._setState({geoCoords: {latitude, longitude}});
-        }
-      });
+      navigator.geolocation.watchPosition(
+        ({coords}) => this._maybeUpdateGeoCoords(coords),
+        fallback, {timeout: 3000, maximumAge: Infinity});
+    } else {
+      fallback();
+    }
+  }
+  _maybeUpdateGeoCoords({latitude, longitude}) {
+    const {geoCoords} = this._state;
+    // Skip setting the position if it's the same as what we've already got.
+    if (!geoCoords || geoCoords.latitude != latitude || geoCoords.longitude != longitude) {
+      this._setState({geoCoords: {latitude, longitude}});
     }
   }
   _update(props, state, lastProps, lastState) {

--- a/shell/artifacts/Restaurants/source/FindRestaurants.js
+++ b/shell/artifacts/Restaurants/source/FindRestaurants.js
@@ -27,14 +27,13 @@ defineParticle(({DomParticle, resolver}) => {
       return template;
     }
     willReceiveProps(props, state) {
-      if (props.restaurants && !state.count) {
+      if (props.restaurants && props.location && !state.count) {
         this._fetchPlaces(props.location);
       }
     }
     _fetchPlaces(location) {
       this._setState({count: -1});
-      const loc = location ? `${location.latitude},${location.longitude}`
-          : `37.7610927,-122.4208173`; // Using San Francisco as a fallback.
+      const loc = `${location.latitude},${location.longitude}`;
       const radius = `1000`;
       const type = `restaurant`;
       fetch(`${placesService}?location=${loc}&radius=${radius}&type=${type}`)


### PR DESCRIPTION
Moves San Francisco callback up to the shell and requires geolocation to be set to fetch restaurants. 

This means that San Francisco will only be used if geolocation request timed out, while today we always use the fallback, as FindRestaurants is called before geolocation is set in the handle.