### PR TITLE
Revert "Skip restaurant demo test."

### DIFF
--- a/shell/test/specs/starter-test.js
+++ b/shell/test/specs/starter-test.js
@@ -382,7 +382,7 @@ function clickInParticles(slotName, selectors, textQuery) {
 }
 
 describe('test Arcs demo flows', function() {
-  it.skip('can use the restaurant demo flow', function() {
+  it('can use the restaurant demo flow', function() {
     initTestWithNewArc();
 
     allSuggestions();


### PR DESCRIPTION
Reverts PolymerLabs/arcs#1039

Load on our services provider is back down so we can re-enable this. However, #1043 probably remains at a relatively high priority.