### PR TITLE
Preserve post editing state on props update.

### DIFF
--- a/shell/artifacts/Social/source/EditPost.js
+++ b/shell/artifacts/Social/source/EditPost.js
@@ -63,23 +63,18 @@ defineParticle(({DomParticle, html, log}) => {
   </div>
   <img src="{{image}}">
   <textarea value="{{message}}" on-input="onTextInput"></textarea>
-</div>
-  `.trim();
+</div>`;
 
   return class extends DomParticle {
     get template() {
       return template;
-    }
-    willReceiveProps({post}, state) {
-      state.message = post && post.message;
-      state.image = post && post.image;
     }
     render({user, post}, {message, image, savePost}) {
       if (savePost) {
         this.savePost(user, message, image);
       }
       const saveButtonActive = Boolean(message && (message.trim().length > 0));
-      const model = {saveButtonActive, message, image: image || ''};
+      const model = {saveButtonActive, message: message || '', image: image || ''};
       return model;
     }
     setHandle(name, data) {
@@ -90,7 +85,7 @@ defineParticle(({DomParticle, html, log}) => {
       this.setHandle(
           'post',
           {message, image, createdTimestamp: Date.now(), author: user.id});
-      this.setState({savePost: false});
+      this.setState({savePost: false, message: '', image: ''});
     }
     onTextInput(e) {
       this.setIfDirty({message: e.data.value});


### PR DESCRIPTION
This is a sufficient fix for now, would like to discuss further in person this week.

The previous logic may be a better structure for when we eventually allow editing an existing post, but it suffers from overwriting the post-under-edit's content (incl. image) when we see a property update, which can be triggered by reloading the arc in a second tab. Adding logic to fix that by scrutinizing `props`/`lastProps` to determine what we're transitioning to/from in `WritePost` didn't pan out because I see an empty post in `lastProps` when I'd expect not.

Fixes https://github.com/PolymerLabs/arcs/issues/1048.