### PR TITLE
Move footer element to static rather than relative positioning.

### DIFF
--- a/shell/app-shell/elements/shell-ui.css.js
+++ b/shell/app-shell/elements/shell-ui.css.js
@@ -106,7 +106,6 @@ export default Xen.html`
   }
   footer {
     display: block;
-    position: relative;
     height: var(--footer-height);
   }
   arc-footer {


### PR DESCRIPTION
It's role is purely to reserve space for scrolling. Relative position
creates a new composited layer which appears to cause a hit-testing
issue and interferes with interaction with content in the modal slot.

Fixes https://github.com/PolymerLabs/arcs/issues/1049