### PR TITLE
Verb constraints

### DIFF
--- a/runtime/manifest.js
+++ b/runtime/manifest.js
@@ -764,19 +764,25 @@ ${e.message}
       }
 
       for (let slotConnectionItem of item.slotConnections) {
-        // Validate consumed and provided slots names are according to spec.
-        if (!particle.spec.slots.has(slotConnectionItem.param)) {
-          throw new ManifestError(
-              slotConnectionItem.location,
-              `Consumed slot '${slotConnectionItem.param}' is not defined by '${particle.name}'`);
-        }
-        slotConnectionItem.providedSlots.forEach(ps => {
-          if (!particle.spec.slots.get(slotConnectionItem.param).getProvidedSlotSpec(ps.param)) {
+        // particles that reference verbs should store slot connection information as constraints to be used 
+        // during verb matching. However, if there's a spec then the slots need to be validated against it
+        // instead.
+        if (particle.spec !== undefined) {
+          // Validate consumed and provided slots names are according to spec.
+          if (!particle.spec.slots.has(slotConnectionItem.param)) {
             throw new ManifestError(
-                ps.location,
-                `Provided slot '${ps.param}' is not defined by '${particle.name}'`);
+                slotConnectionItem.location,
+                `Consumed slot '${slotConnectionItem.param}' is not defined by '${particle.name}'`);
           }
-        });
+          slotConnectionItem.providedSlots.forEach(ps => {
+            if (!particle.spec.slots.get(slotConnectionItem.param).getProvidedSlotSpec(ps.param)) {
+              throw new ManifestError(
+                  ps.location,
+                  `Provided slot '${ps.param}' is not defined by '${particle.name}'`);
+            }
+          });
+        }
+
         let targetSlot = items.byName.get(slotConnectionItem.name);
         if (targetSlot) {
           assert(items.bySlot.has(targetSlot));

--- a/runtime/manifest.js
+++ b/runtime/manifest.js
@@ -650,6 +650,7 @@ ${e.message}
           if (!providedSlot) {
             providedSlot = recipe.newSlot(ps.param);
             providedSlot.localName = ps.name;
+            providedSlot.sourceConnection = slotConn;
             assert(!items.byName.has(ps.name));
             items.byName.set(ps.name, providedSlot);
             items.bySlot.set(providedSlot, ps);

--- a/runtime/recipe/particle.js
+++ b/runtime/recipe/particle.js
@@ -210,6 +210,11 @@ class Particle {
     return slotConn;
   }
 
+  removeSlotConnection(slotConnection) {
+    this._consumedSlotConnections[slotConnection._name] = null;
+    slotConnection.disconnectFromSlot();
+  }
+
   remove() {
     this.recipe.removeParticle(this);
   }

--- a/runtime/recipe/recipe.js
+++ b/runtime/recipe/recipe.js
@@ -58,6 +58,15 @@ class Recipe {
     let idx = this._particles.indexOf(particle);
     assert(idx > -1);
     this._particles.splice(idx, 1);
+    for (let slotConnection of Object.values(particle._consumedSlotConnections))
+      slotConnection.remove();
+  }
+
+  removeSlot(slot) {
+    assert(slot.consumeConnections.length == 0);
+    let idx = this._slots.indexOf(slot);
+    assert(idx > -1);
+    this._slots.splice(idx, 1);
   }
 
   newHandle() {

--- a/runtime/recipe/slot-connection.js
+++ b/runtime/recipe/slot-connection.js
@@ -22,6 +22,10 @@ class SlotConnection {
     this._providedSlots = {}; // Slot*
   }
 
+  remove() {
+    this._particle.removeSlotConnection(this);
+  }
+
   get recipe() { return this._recipe; }
   get particle() { return this._particle; }
   get name() { return this._name; }
@@ -57,6 +61,13 @@ class SlotConnection {
     targetSlot.consumeConnections.push(this);
   }
 
+  disconnectFromSlot() {
+    if (this._targetSlot) {
+      this._targetSlot.removeConsumeConnection(this);
+      this._targetSlot = undefined;
+    }
+  }
+  
   _clone(particle, cloneMap) {
     if (cloneMap.has(this)) {
       return cloneMap.get(this);
@@ -155,8 +166,13 @@ class SlotConnection {
       let providedSlot = this.providedSlots[psName];
       let provideRes = [];
       provideRes.push('  provide');
-      let providedSlotSpec = this.slotSpec.getProvidedSlotSpec(psName);
-      assert(providedSlotSpec, `Cannot find providedSlotSpec for ${psName}`);
+      
+      // Only assert that there's a spec for this provided slot if there's a spec for
+      // the consumed slot .. otherwise this is just a constraint.
+      if (this.slotSpec) {
+        let providedSlotSpec = this.slotSpec.getProvidedSlotSpec(psName);
+        assert(providedSlotSpec, `Cannot find providedSlotSpec for ${psName}`);
+      }
       provideRes.push(`${psName} as ${(nameMap && nameMap.get(providedSlot)) || providedSlot}`);
       result.push(provideRes.join(' '));
     });

--- a/runtime/recipe/slot.js
+++ b/runtime/recipe/slot.js
@@ -40,7 +40,9 @@ class Slot {
   set sourceConnection(sourceConnection) { this._sourceConnection = sourceConnection; }
   get consumeConnections() { return this._consumerConnections; }
   getProvidedSlotSpec() {
-    return this.sourceConnection ? this.sourceConnection.slotSpec.getProvidedSlotSpec(this.name) : {isSet: false, tags: []};
+    // TODO: should this return something that indicates this isn't available yet instead of 
+    // the constructed {isSet: false, tags: []}?
+    return (this.sourceConnection && this.sourceConnection.slotSpec) ? this.sourceConnection.slotSpec.getProvidedSlotSpec(this.name) : {isSet: false, tags: []};
   }
 
   _copyInto(recipe, cloneMap) {
@@ -82,6 +84,18 @@ class Slot {
     if ((cmp = util.compareStrings(this.formFactor, other.formFactor)) != 0) return cmp;
     if ((cmp = util.compareArrays(this._tags, other._tags, util.compareStrings)) != 0) return cmp;
     return 0;
+  }
+
+  removeConsumeConnection(slotConnection) {
+    let idx = this._consumerConnections.indexOf(slotConnection);
+    assert(idx > -1);
+    this._consumerConnections.splice(idx, 1);
+    if (this._consumerConnections.length == 0)
+      this.remove();
+  }
+
+  remove() {
+    this._recipe.removeSlot(this);
   }
 
   isResolved(options) {

--- a/runtime/strategies/map-slots.js
+++ b/runtime/strategies/map-slots.js
@@ -21,6 +21,12 @@ export default class MapSlots extends Strategy {
 
     return Recipe.over(this.getResults(inputParams), new class extends RecipeWalker {
       onSlotConnection(recipe, slotConnection) {
+        // don't try to connect verb constraints
+        // TODO: is this right? Should constraints be connectible, in order to precompute the
+        // recipe side once the verb is substituted?
+        if (slotConnection.slotSpec == undefined)
+          return;
+
         if (slotConnection.isConnected()) {
           return;
         }
@@ -89,6 +95,10 @@ export default class MapSlots extends Strategy {
 
   // Returns true, if the given slot is a viable candidate for the slotConnection.
   static _filterSlot(slotConnection, slot) {
+    // if there's no slotSpec, this is just a slot constraint on a verb
+    if (!slotConnection.slotSpec)
+      return false;
+
     if (slotConnection.slotSpec.isSet != slot.getProvidedSlotSpec().isSet) {
       return false;
     }

--- a/runtime/strategies/match-recipe-by-verb.js
+++ b/runtime/strategies/match-recipe-by-verb.js
@@ -40,7 +40,7 @@ export default class MatchRecipeByVerb extends Strategy {
 
         let recipes = arc.context.findRecipesByVerb(particle.primaryVerb);
 
-        let slotConstraints = {}
+        let slotConstraints = {};
         for (let consumeSlot of Object.values(particle.consumedSlotConnections)) {
           let targetSlot = consumeSlot.targetSlot.sourceConnection ? consumeSlot.targetSlot : null;
           slotConstraints[consumeSlot.name] = {targetSlot, providedSlots: {}};

--- a/runtime/test/manifest-test.js
+++ b/runtime/test/manifest-test.js
@@ -1242,4 +1242,22 @@ resource SomeName
     assert(validRecipe.normalize());
     assert(validRecipe.isResolved());
   });
+
+  it('can parse a recipe with slot constraints on verbs', async () => {
+    let manifest = await Manifest.parse(`
+      recipe
+        particle can verb
+          consume consumeSlot
+            provide provideSlot
+    `);
+
+    let recipe = manifest.recipes[0];
+    assert(recipe.normalize());
+
+    assert.equal(recipe.particles[0]._verbs[0], 'verb');
+    assert.equal(recipe.particles[0]._spec, undefined);
+    let slotConnection = recipe.particles[0]._consumedSlotConnections.consumeSlot;
+    assert(slotConnection._providedSlots.provideSlot);
+    assert.equal(slotConnection._providedSlots.provideSlot.sourceConnection, slotConnection);
+  });
 });

--- a/runtime/test/strategies/match-recipe-by-verb-tests.js
+++ b/runtime/test/strategies/match-recipe-by-verb-tests.js
@@ -131,7 +131,7 @@ describe('MatchRecipeByVerb', function() {
     assert.equal(results[0].result.particles[0].name, 'P');
     assert.equal(results[1].result.particles.length, 2);
   });
-  it('carries slot assignments across verb substitution', async() => {
+  it('carries slot assignments across verb substitution', async () => {
     let manifest = await Manifest.parse(`
       particle P in 'A.js'
         P()

--- a/runtime/test/strategies/match-recipe-by-verb-tests.js
+++ b/runtime/test/strategies/match-recipe-by-verb-tests.js
@@ -76,4 +76,106 @@ describe('MatchRecipeByVerb', function() {
   Q as particle1
     q <- view0`);
   });
+  it('listens to slot constraints', async () => {
+    let manifest = await Manifest.parse(`
+      particle P in 'A.js'
+        P()
+        consume foo
+          provide bar
+    
+      particle Q in 'B.js'
+        Q()
+        consume boo
+          provide far
+
+      recipe verb
+        P
+
+      recipe verb
+        Q
+
+      recipe verb
+        P
+        Q
+
+      recipe
+        particle can verb
+
+      recipe
+        particle can verb
+          consume boo
+
+      recipe
+        particle can verb
+          consume foo
+            provide bar
+    `);
+
+    let arc = StrategyTestHelper.createTestArc('test-plan-arc', manifest, 'dom');
+    let inputParams = {generated: [{result: manifest.recipes[3], score: 1}]};
+    let mrv = new MatchRecipeByVerb(arc);
+    let results = await mrv.generate(inputParams);
+    assert.equal(results.length, 3);
+
+    inputParams = {generated: [{result: manifest.recipes[4], score: 1}]};
+    results = await mrv.generate(inputParams);
+    assert.equal(results.length, 2);
+    assert.equal(results[0].result.particles.length, 1);
+    assert.equal(results[0].result.particles[0].name, 'Q');
+    assert.equal(results[1].result.particles.length, 2);
+
+    inputParams = {generated: [{result: manifest.recipes[5], score: 1}]};
+    results = await mrv.generate(inputParams);
+    assert.equal(results.length, 2);
+    assert.equal(results[0].result.particles.length, 1);
+    assert.equal(results[0].result.particles[0].name, 'P');
+    assert.equal(results[1].result.particles.length, 2);
+  });
+  it('carries slot assignments across verb substitution', async() => {
+    let manifest = await Manifest.parse(`
+      particle P in 'A.js'
+        P()
+        consume foo
+          provide bar  
+
+      particle S in 'B.js'
+        S()
+        consume bar
+          provide foo
+
+      recipe verb
+        P
+    
+      recipe
+        particle can verb
+          consume foo
+            provide bar as s0
+        S
+          consume bar as s0
+
+      recipe
+        particle can verb
+          consume foo as s0
+        S
+          consume bar
+            provide foo as s0
+    `);
+
+    let arc = StrategyTestHelper.createTestArc('test-plan-arc', manifest, 'dom');
+    let inputParams = {generated: [{result: manifest.recipes[1], score: 1}]};
+    let mrv = new MatchRecipeByVerb(arc);
+    let results = await mrv.generate(inputParams);
+    assert.equal(results.length, 1);
+    let recipe = results[0].result;
+    assert.equal(recipe.particles[0].consumedSlotConnections.foo.providedSlots.bar, recipe.particles[1].consumedSlotConnections.bar.targetSlot);
+    assert.equal(recipe.slots[0].consumeConnections[0], recipe.particles[1].consumedSlotConnections.bar);
+    assert.equal(recipe.slots[0].sourceConnection, recipe.particles[0].consumedSlotConnections.foo);
+    
+    inputParams = {generated: [{result: manifest.recipes[2], score: 1}]};
+    results = await mrv.generate(inputParams);
+    recipe = results[0].result;
+    assert.equal(recipe.particles[0].consumedSlotConnections.foo.targetSlot, recipe.particles[1].consumedSlotConnections.bar.providedSlots.foo);
+    assert.equal(recipe.slots[1].consumeConnections[0], recipe.particles[0].consumedSlotConnections.foo);
+    assert.equal(recipe.slots[1].sourceConnection, recipe.particles[1].consumedSlotConnections.bar);
+  });
 });


### PR DESCRIPTION
1) Allow particles specified by verbs to hold slot constraints. For example:

```recipe
  particle can doTheThing
    consume bar
      provide foo
```

This means that a particle or recipe can only substitute into doTheThing if it consumes a bar slot and provides a foo slot.

2) Make match-recipe-by-verb obey these constraints. Note that match-particle-by-verb doesn't, yet.

3) Ensure that in at least some cases slot connections made with these constraints persist after recipe substitution. For example:

```recipe
  particle can doTheThing
    consume foo as s1
      provide bar as s2
  P
    consume master
      provide foo as s1
  Q
    consume bar as s2
```

Will result in the matched `foo` in the recipe selected to replace doTheThing consuming `P`'s `foo`, and the matched `bar` providing a slot for `Q`'s `bar`.

This almost certainly doesn't yet work in all circumstances, for example I haven't tested what happens when the slot is shared across multiple consumers.

At some point we're going to want to do the same thing as this for handles, too.