### PR TITLE
track dom-slot created MutationObservers to afford teardown of an Arc

### DIFF
--- a/runtime/arc.js
+++ b/runtime/arc.js
@@ -200,7 +200,7 @@ ${this._serializeParticles()}
 ${this.activeRecipe.toString()}`;
   }
 
-  static async deserialize({serialization, pecFactory, slotComposer, loader, fileName}) {
+  static async deserialize({serialization, pecFactory, slotComposer, loader, fileName, context}) {
     let manifest = await Manifest.parse(serialization, {loader, fileName});
     let arc = new Arc({
       id: manifest.meta.name,
@@ -209,7 +209,7 @@ ${this.activeRecipe.toString()}`;
       pecFactory,
       loader,
       storageProviderFactory: manifest._storageProviderFactory,
-      context: manifest
+      context
     });
     // TODO: pass tags through too
     manifest.handles.forEach(handle => arc._registerHandle(handle, []));

--- a/shell/app-shell-prototype/elements/arc-host.js
+++ b/shell/app-shell-prototype/elements/arc-host.js
@@ -172,6 +172,7 @@ class ArcHost extends Xen.Debug(Xen.Base, log) {
     log(serialization);
     console.groupEnd();
     // remove rendered particle DOM
+    Arcs.DomSlot.disconnectObservers();
     Array.from(document.querySelectorAll('[slotid]')).forEach(n => n.textContent = '');
     // generate new slotComposer
     const slotComposer = this._createSlotComposer(config);

--- a/shell/source/ArcsLib.js
+++ b/shell/source/ArcsLib.js
@@ -13,6 +13,7 @@ import Description from '../../runtime/description.js';
 import Manifest from '../../runtime/manifest.js';
 import Planner from '../../runtime/planner.js';
 import SlotComposer from '../../runtime/slot-composer.js';
+import DomSlot from '../../runtime/dom-slot.js';
 import Type from '../../runtime/type.js';
 import BrowserLoader from './browser-loader.js';
 import Tracing from '../../tracelib/trace.js';
@@ -27,15 +28,16 @@ const Arcs = {
   Manifest,
   Planner,
   SlotComposer,
+  DomSlot,
   Type,
   BrowserLoader,
   Tracing,
   scheduler
 };
 
-// TODO(sjmiles): can't export because WebPack can't/doesn't make a built version with a module export
+// TODO(sjmiles): can't export because WebPack won't make a built version with a module export
 // Instead we fall back to populating a global (possibly already created in app-shell/lib/arcs.js).
-//export default Arcs;
+// export default Arcs;
 
 window.Arcs = window.Arcs ? Object.assign(window.Arcs, Arcs) : Arcs;
 


### PR DESCRIPTION
We'll probably want something more sophisticated when Maria gets back, but I wanted to get this in so we could keep testing serialization loop-back.

If y'all would rather wait for a more comprehensive change, that's ok too.