### PR TITLE
only clamp width if device > 600px

### DIFF
--- a/shell/apps/common/index.css
+++ b/shell/apps/common/index.css
@@ -1,6 +1,13 @@
 body {
-  --max-width: 460px;
+  --max-width: auto;
   --min-width: 320px;
+}
+
+@media (min-width: 600px) {
+  body {
+    --max-width: 460px;
+    --min-width: 320px;
+  }
 }
 
 body {


### PR DESCRIPTION
@dstockwell noticed Arcs not fitting to his phone screen, I thought this patch might improve that situation, while still being mobile-first on desktop displays.