### PR TITLE
small fixes for documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # arcs
 
-Particle developers should visit our [particle developer website](https://polymerlabs.github.io/arcs-cdn/dev/) instead of reading this document which is more geared towards Arcs core system developers.
+Particle developers should visit our [particle developer website](https://polymerlabs.github.io/arcs-live/shell/docs/) instead of reading this document which is more geared towards Arcs core system developers.
 
 ## Install
 

--- a/shell/docs/doc-urls.js
+++ b/shell/docs/doc-urls.js
@@ -1,4 +1,4 @@
-const runtime = `../../../arcs/runtime`;
+const runtime = `../../runtime`;
 window.docUrls = [
   `${runtime}/inner-PEC.js`,
   `${runtime}/particle.js`,

--- a/shell/docs/index.html
+++ b/shell/docs/index.html
@@ -110,7 +110,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     // Convert this-type-of_variables ToCamelNotation.
     let toCamel = fn => {
       return fn.replace(/.*\/([^/.]+)\.\w+/, "$1").replace(/^[a-z]|(-[a-z])|(_[a-z])/g, v => {
-        return v.length < 2 ? v.toUpperCase() : " " + v[1].toLowerCase();
+        return v.length < 2 ? v.toUpperCase() : v[1].toUpperCase();
       })
     };
 
@@ -122,8 +122,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       let values = await Promise.all(mds.map(async f => {
         let response = await fetch(f);
         let text = await response.text();
+        let name = toCamel(f);
         return {
-          name: toCamel(f),
+          name,
           chapter: f.startsWith('docs') ? 'Background' : 'Reference',
           description: buildMdRenderer(f).render(text)
         };
@@ -184,6 +185,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     let updateTopic = () => {
       let name = location.hash.slice(1) || `Manifest`;
+      debugger;
       let topic = corpus.classes.find(c => c.name === name);
       doc.innerHTML = topic ? renderTopic(topic) : 'n/a';
     };


### PR DESCRIPTION
- the runtime path was incorrect (it was still referencing a separate
  arcs repo)
- the toCamelCase method was transforming 'foo-bar' -> 'foo bar',
  instead of 'foo-bar' -> 'FooBar'. The spaces weren't supported
  elsewhere (sometimes we used an escaped `%20`, but not always), so the
  getting started page wasn't loaded.