### PR TITLE
Add clearing the `templates` cache to DomSlot cleanup

### DIFF
--- a/runtime/dom-slot.js
+++ b/runtime/dom-slot.js
@@ -13,7 +13,7 @@ import assert from '../platform/assert-web.js';
 import Slot from './slot.js';
 import {DomContext, SetDomContext} from './dom-context.js';
 
-let templates = new Map();
+const templates = new Map();
 
 class DomSlot extends Slot {
   constructor(consumeConn, arc, containerKind) {
@@ -60,10 +60,13 @@ class DomSlot extends Slot {
     const observers = DomSlot._observers || (DomSlot._observers = []);
     observers.push(observer);
   }
-  static disconnectObservers() {
+  static dispose() {
+    // disconnect observers
     const observers = DomSlot._observers;
     observers && observers.forEach(o => o.disconnect());
     DomSlot._observers = [];
+    // empty template cache
+    templates.clear();
   }
   _initMutationObserver() {
     const observer = this.__initMutationObserver();

--- a/shell/app-shell-prototype/elements/arc-host.js
+++ b/shell/app-shell-prototype/elements/arc-host.js
@@ -159,6 +159,10 @@ class ArcHost extends Xen.Debug(Xen.Base, log) {
     this._fire('plan', plan);
   }
   async _consumeSerialization(serialization) {
+    // Clean up from last arc
+    Arcs.DomSlot.dispose();
+    Array.from(document.querySelectorAll('[slotid]')).forEach(n => n.textContent = '');
+    //
     const {config, manifest} = this._props;
     const {arc, loader} = this._state;
     //
@@ -170,12 +174,9 @@ class ArcHost extends Xen.Debug(Xen.Base, log) {
     //
     serialization = `${manifest}\n${serialization}`;
     // serialize old arc
-    groupCollapsed('serializing...');
+    groupCollapsed('serialized arc:');
     log(serialization);
     groupEnd();
-    // remove rendered particle DOM
-    Arcs.DomSlot.disconnectObservers();
-    Array.from(document.querySelectorAll('[slotid]')).forEach(n => n.textContent = '');
     // generate new slotComposer
     const slotComposer = this._createSlotComposer(config);
     // generate new arc via deserialization


### PR DESCRIPTION
Rename `disconnectObservers` to `dispose`, add clearing of the template cache to it's mandate.