### PR TITLE
Muxer: map/build other views and connections per-item.

### DIFF
--- a/runtime/multiplexer-dom-particle.js
+++ b/runtime/multiplexer-dom-particle.js
@@ -19,38 +19,69 @@ export default class MultiplexerDomParticle extends TransformationDomParticle {
     this._connByHostedConn = new Map();
   }
 
+  async _mapParticleConnections(
+      listHandleName,
+      particleHandleName,
+      hostedParticle,
+      views,
+      arc) {
+    let otherMappedViews = [];
+    let otherConnections = [];
+    let index = 2;
+    const skipConnectionNames = [listHandleName, particleHandleName];
+    for (let [connectionName, otherView] of views) {
+      if (skipConnectionNames.includes(connectionName)) {
+        continue;
+      }
+      // TODO(wkorman): For items with embedded recipes we may need a map
+      // (perhaps id to index) to make sure we don't map a handle into the inner
+      // arc multiple times unnecessarily.
+      otherMappedViews.push(
+          `map '${await arc.mapHandle(otherView._proxy)}' as v${index}`);
+      let hostedOtherConnection = hostedParticle.connections.find(
+          conn => conn.isCompatibleType(otherView.type));
+      if (hostedOtherConnection) {
+        otherConnections.push(`${hostedOtherConnection.name} <- v${index++}`);
+        // TODO(wkorman): For items with embedded recipes where we may have a
+        // different particle rendering each item, we need to track
+        // |connByHostedConn| keyed on the particle type.
+        this._connByHostedConn.set(hostedOtherConnection.name, connectionName);
+      }
+    }
+    return [otherMappedViews, otherConnections];
+  }
+
   async setViews(views) {
     this.handleIds = {};
     let arc = await this.constructInnerArc();
-
-    let particleView = views.get('hostedParticle');
-    // Map all additional connections. Note that muxers with embedded recipes
-    // may have no direct hosted particle reference here.
+    const listHandleName = 'list';
+    const particleHandleName = 'hostedParticle';
+    let particleView = views.get(particleHandleName);
+    let hostedParticle = null;
     let otherMappedViews = [];
     let otherConnections = [];
-    let hostedParticle = null;
     if (particleView) {
       hostedParticle = await particleView.get();
-      let index = 2;
-      for (let [connectionName, otherView] of views) {
-        // TODO(wkorman): Do we need to filter 'renderParticle' or similar below?
-        if (['list', 'hostedParticle'].includes(connectionName)) {
-          continue;
-        }
-        otherMappedViews.push(`map '${await arc.mapHandle(otherView._proxy)}' as v${index}`);
-        let hostedOtherConnection = hostedParticle.connections.find(conn => conn.isCompatibleType(otherView.type));
-        if (hostedOtherConnection) {
-          otherConnections.push(`${hostedOtherConnection.name} <- v${index++}`);
-          this._connByHostedConn.set(hostedOtherConnection.name, connectionName);
-        }
+      if (hostedParticle) {
+        [otherMappedViews, otherConnections] =
+            await this._mapParticleConnections(
+                listHandleName, particleHandleName, hostedParticle, views, arc);
       }
     }
-    this.setState({arc, type: views.get('list').type, hostedParticle, otherMappedViews, otherConnections});
+    this.setState({
+      arc,
+      type: views.get(listHandleName).type,
+      hostedParticle,
+      otherMappedViews,
+      otherConnections
+    });
 
     super.setViews(views);
   }
 
-  async willReceiveProps({list}, {arc, type, hostedParticle, otherMappedViews, otherConnections}) {
+  async willReceiveProps(
+      {list},
+      {arc, type, hostedParticle, otherMappedViews, otherConnections}) {
     if (list.length > 0) {
       this.relevance = 0.1;
     }
@@ -62,7 +93,8 @@ export default class MultiplexerDomParticle extends TransformationDomParticle {
         continue;
       }
 
-      let itemViewPromise = arc.createHandle(type.primitiveType(), 'item' + index);
+      let itemViewPromise =
+          arc.createHandle(type.primitiveType(), 'item' + index);
       this.handleIds[item.id] = itemViewPromise;
 
       let itemView = await itemViewPromise;
@@ -74,11 +106,24 @@ export default class MultiplexerDomParticle extends TransformationDomParticle {
         if (!item.renderParticleSpec) {
           continue;
         }
-        hostedParticle = ParticleSpec.fromLiteral(JSON.parse(item.renderParticleSpec));
+        hostedParticle =
+            ParticleSpec.fromLiteral(JSON.parse(item.renderParticleSpec));
+        // Re-map compatible handles and compute the connections specific
+        // to this item's render particle.
+        const listHandleName = 'list';
+        const particleHandleName = 'renderParticle';
+        [otherMappedViews, otherConnections] =
+            await this._mapParticleConnections(
+                listHandleName,
+                particleHandleName,
+                hostedParticle,
+                this._views,
+                arc);
       }
       let hostedSlotName = [...hostedParticle.slots.keys()][0];
       let slotName = [...this.spec.slots.values()][0].name;
-      let slotId = await arc.createSlot(this, slotName, hostedParticle.name, hostedSlotName);
+      let slotId = await arc.createSlot(
+          this, slotName, hostedParticle.name, hostedSlotName);
 
       if (!slotId) {
         continue;
@@ -87,7 +132,14 @@ export default class MultiplexerDomParticle extends TransformationDomParticle {
       this._itemSubIdByHostedSlotId.set(slotId, item.id);
 
       try {
-        await arc.loadRecipe(this.constructInnerRecipe(hostedParticle, item, itemView, {name: hostedSlotName, id: slotId}, {connections: otherConnections, views: otherMappedViews}), this);
+        await arc.loadRecipe(
+            this.constructInnerRecipe(
+                hostedParticle,
+                item,
+                itemView,
+                {name: hostedSlotName, id: slotId},
+                {connections: otherConnections, views: otherMappedViews}),
+            this);
         itemView.set(item);
       } catch (e) {
         console.log(e);
@@ -114,10 +166,12 @@ export default class MultiplexerDomParticle extends TransformationDomParticle {
   combineHostedTemplate(slotName, hostedSlotId, content) {
     if (!this._state.template && !!content.template) {
       let template = content.template;
-      // Replace hosted particle connection in template with the corresponding this particle connection names.
+      // Replace hosted particle connection in template with the corresponding particle connection names.
       // TODO: make this generic!
       this._connByHostedConn.forEach((conn, hostedConn) => {
-        template = template.replace(new RegExp(`{{${hostedConn}.description}}`, 'g'), `{{${conn}.description}}`);
+        template = template.replace(
+            new RegExp(`{{${hostedConn}.description}}`, 'g'),
+            `{{${conn}.description}}`);
       });
       this._setState({template});
     }


### PR DESCRIPTION
When muxing on a per-item basis the other-views/connections can vary
with each item. This patch is just an incremental step toward dealing
with this gracefully, and leaves a couple of TODOs.

A social recipe that makes demonstrative use of these muxer changes to
follow shortly.

Also ran code through `clang-format`.

Part of https://github.com/PolymerLabs/arcs/issues/842