### PR TITLE
Initial social feed recipe using muxer and embedded item recipes.

### DIFF
--- a/shell/artifacts/Social/Particles.manifest
+++ b/shell/artifacts/Social/Particles.manifest
@@ -23,8 +23,8 @@ particle OnlyShowPosts in 'source/ShowPosts.js'
   description `show ${posts}`
 
 particle ShowSinglePost in 'source/ShowSinglePost.js'
-  ShowSinglePost(in Post post)
-  consume root
+  ShowSinglePost(in Post post, in [Avatar] avatars)
+  consume item
   description `show ${post}`
 
 particle WritePosts in 'source/WritePosts.js'
@@ -32,7 +32,18 @@ particle WritePosts in 'source/WritePosts.js'
   consume root
   description `write posts`
 
+// TODO(wkorman): Should we just use HostedParticleShape as
+// defined in Multiplexer.manifest directly?
+shape RenderParticleShape
+  RenderParticleShape(in Post)
+  consume
+
 particle EditPost in 'source/EditPost.js'
-  EditPost(inout Post post, inout [Post] posts, in Person user)
+  EditPost(host RenderParticleShape renderParticle, inout Post post, inout [Post] posts, in Person user)
   consume content
   description `edit a post`
+
+particle PostMuxer in 'source/PostMuxer.js'
+  PostMuxer(in [Post] list, in [Avatar] avatars)
+  consume set of item
+  description `show morphed ${list}`

--- a/shell/artifacts/Social/Post.schema
+++ b/shell/artifacts/Social/Post.schema
@@ -20,7 +20,10 @@ schema Post
   // polymorphic display of and interaction with the post, as the
   // particles creating or updating the Post entity can set whatever
   // recipe they deem appropriate for the Post (or Post subclass).
-  Text recipe
+  Text renderRecipe
+  // A JSON representation of the primary particle referenced in
+  // |renderRecipe| intended for use in displaying this post.
+  Text renderParticleSpec
   // The opaque user id of the post author as populated by sharing logic.
   // Note this is only populated for friends of the viewing user, and so
   // is not always present, and one may as well just use the |author| field.

--- a/shell/artifacts/Social/Social.recipes
+++ b/shell/artifacts/Social/Social.recipes
@@ -8,6 +8,7 @@
 
 import 'Particles.manifest'
 import 'https://$cdn/artifacts/Common/Detail.manifest'
+import 'https://$cdn/artifacts/Common/List.manifest'
 
 // Allows creating multiple posts by the author and viewing all posts created
 // in this Arc.
@@ -26,6 +27,7 @@ recipe
     posts = posts
     post = post
     user <- user
+    renderParticle = ShowSinglePost
   ShowPosts
     posts = posts
     metadata = metadata
@@ -50,3 +52,13 @@ recipe
     user <- user
     avatars <- avatars
     people <- people
+
+recipe
+  map #BOXED_posts as posts
+  map #BOXED_avatar as avatars
+  // TODO(wkorman): Merge together posts and stats with CopyCollection if needed.
+  List
+    items = posts
+  PostMuxer
+    list = posts
+    avatars = avatars

--- a/shell/artifacts/Social/source/PostMuxer.js
+++ b/shell/artifacts/Social/source/PostMuxer.js
@@ -1,0 +1,25 @@
+/**
+ * @license
+ * Copyright (c) 2018 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+'use strict';
+
+defineParticle(({MultiplexerDomParticle, log}) => {
+  return class PostMultiplexer extends MultiplexerDomParticle {
+    constructInnerRecipe(hostedParticle, item, itemView, slot, other) {
+      // log(`PostMuxer input recipe: `, item.renderRecipe);
+      let value = item.renderRecipe.replace('{{slot_id}}', slot.id);
+      value = value.replace('{{item_id}}', itemView._id);
+      value = value.replace('{{other_views}}', other.views.join('\n'));
+      value =
+          value.replace('{{other_connections}}', other.connections.join('\n'));
+      // log(`PostMuxer interpolated recipe: `, value);
+      return value;
+    }
+  };
+});


### PR DESCRIPTION
Single post styling still a hack, focus here was on the post and avatar data making it into `ShowSinglePost` particle and cleanup to follow.

Depends on https://github.com/PolymerLabs/arcs/pull/1107.

Part of https://github.com/PolymerLabs/arcs/issues/842.