### PR TITLE
prevent null data in firebase

### DIFF
--- a/runtime/manifest.js
+++ b/runtime/manifest.js
@@ -454,7 +454,7 @@ ${e.message}
     visitor.traverse(items);
   }
   static _processSchema(manifest, schemaItem) {
-    let description;
+    let description = '';
     let fields = {};
     let names = [...schemaItem.names];
     for (let item of schemaItem.items) {

--- a/runtime/particle-spec.js
+++ b/runtime/particle-spec.js
@@ -75,7 +75,6 @@ class ParticleSpec {
     this.connections.forEach(a => this.connectionMap.set(a.name, a));
     this.inputs = this.connections.filter(a => a.isInput);
     this.outputs = this.connections.filter(a => a.isOutput);
-    this.transient = model.transient;
 
     // initialize descriptions patterns.
     model.description = model.description || {};
@@ -121,19 +120,19 @@ class ParticleSpec {
   }
 
   toLiteral() {
-    let {args, name, verbs, transient, description, implFile, affordance, slots} = this._model;
+    let {args, name, verbs, description, implFile, affordance, slots} = this._model;
     args = args.map(a => {
       let {type, direction, name, isOptional} = a;
       type = type.toLiteral();
       return {type, direction, name, isOptional};
     });
-    return {args, name, verbs, transient, description, implFile, affordance, slots};
+    return {args, name, verbs, description, implFile, affordance, slots};
   }
 
   static fromLiteral(literal) {
-    let {args, name, verbs, transient, description, implFile, affordance, slots} = literal;
+    let {args, name, verbs, description, implFile, affordance, slots} = literal;
     args = args.map(({type, direction, name, isOptional}) => ({type: Type.fromLiteral(type), direction, name, isOptional}));
-    return new ParticleSpec({args, name, verbs, transient, description, implFile, affordance, slots});
+    return new ParticleSpec({args, name, verbs, description, implFile, affordance, slots});
   }
 
   clone() {

--- a/runtime/storage/firebase-storage.js
+++ b/runtime/storage/firebase-storage.js
@@ -54,7 +54,9 @@ async function realTransaction(reference, transactionFunction) {
   return reference.transaction(data => {
     if (data == null)
       data = realData;
-    return transactionFunction(data);
+    let result = transactionFunction(data);
+    assert(result);
+    return result;
   }, undefined, false);
 }
 
@@ -108,6 +110,7 @@ export default class FirebaseStorage {
       if (!shouldExist) {
         return {version: 0};
       }
+     assert(data);     
       return data;
     });
 


### PR DESCRIPTION
* `transient` is an old thing that we'd (almost completely) removed
* descriptions in schemas end up in the serialized version so they need to be initialized to the empty string
* asserts never hurt

@mmandlis FYI - changing the default value of descriptions.