### PR TITLE
Use polymorphic muxing for Words stats items.

### DIFF
--- a/shell/artifacts/Social/Social.recipes
+++ b/shell/artifacts/Social/Social.recipes
@@ -54,9 +54,10 @@ recipe
     people <- people
 
 recipe
-  map #BOXED_posts as posts
-  map #BOXED_avatar as avatars
+  map #BOXED_stats as posts
   // TODO(wkorman): Merge together posts and stats with CopyCollection if needed.
+  // map #BOXED_posts as posts
+  map #BOXED_avatar as avatars
   List
     items = posts
   PostMuxer

--- a/shell/artifacts/Words/GamePane.manifest
+++ b/shell/artifacts/Words/GamePane.manifest
@@ -12,8 +12,14 @@ import 'Stats.schema'
 
 import 'https://$cdn/artifacts/People/Person.schema'
 
+// TODO(wkorman): Should we just use HostedParticleShape as
+// defined in Multiplexer.manifest directly?
+shape RenderParticleShape
+  RenderParticleShape(in Stats)
+  consume
+
 particle GamePane in 'source/GamePane.js'
-  GamePane(in Person person, inout Board board, inout Move move, inout Stats stats)
+  GamePane(host RenderParticleShape renderParticle, in Person person, inout Board board, inout Move move, inout Stats stats)
   affordance dom
   consume root
 //    provide leaderboard

--- a/shell/artifacts/Words/ShowSingleStats.manifest
+++ b/shell/artifacts/Words/ShowSingleStats.manifest
@@ -10,5 +10,5 @@ import 'Stats.schema'
 
 particle ShowSingleStats in 'source/ShowSingleStats.js'
   ShowSingleStats(in Stats stats)
-  consume root
+  consume item
   description `show ${stats}`

--- a/shell/artifacts/Words/Words.recipes
+++ b/shell/artifacts/Words/Words.recipes
@@ -6,6 +6,7 @@
 // http://polymer.github.io/PATENTS.txt
 
 import 'GamePane.manifest'
+import 'ShowSingleStats.manifest'
 
 recipe
   use #user as person
@@ -18,6 +19,7 @@ recipe
     board = board
     stats = stats
     person <- person
+    renderParticle = ShowSingleStats
 
 //  LeaderboardPane
 //    avatars <- avatars

--- a/shell/artifacts/Words/source/Scoring.js
+++ b/shell/artifacts/Words/source/Scoring.js
@@ -83,7 +83,13 @@ class Scoring {
         stats.longestWordScore}). Score: ${stats.score}. Moves: ${
         stats.moveCount}.`;
   }
-  static applyMoveStats(user, stats, word, score) {
+  static applyMoveStats(
+      renderParticleSpec,
+      renderRecipe,
+      user,
+      stats,
+      word,
+      score) {
     let updatedValues = {
       highestScoringWord: stats.highestScoringWord,
       highestScoringWordScore: stats.highestScoringWordScore,
@@ -112,6 +118,9 @@ class Scoring {
     updatedValues.createdTimestamp = stats.startstamp;
     updatedValues.message = Scoring.scoreToMessage(updatedValues);
     updatedValues.author = user.id;
+
+    updatedValues.renderParticleSpec = renderParticleSpec;
+    updatedValues.renderRecipe = renderRecipe;
 
     return updatedValues;
   }

--- a/shell/artifacts/Words/source/ShowSingleStats.js
+++ b/shell/artifacts/Words/source/ShowSingleStats.js
@@ -10,8 +10,6 @@
 'use strict';
 
 defineParticle(({DomParticle, html}) => {
-  importScripts(resolver(`GamePane/Scoring.js`));
-
   const host = `show-single-stats`;
 
   const template = html`
@@ -22,8 +20,15 @@ defineParticle(({DomParticle, html}) => {
     get template() {
       return template;
     }
+    scoreToMessage(stats) {
+      return `Words Puzzle Game Stats -- Highest scoring word: ${
+          stats.highestScoringWord} (${
+          stats.highestScoringWordScore}). Longest word: ${stats.longestWord} (${
+          stats.longestWordScore}). Score: ${stats.score}. Moves: ${
+          stats.moveCount}.`;
+    }
     render({stats}) {
-      const message = stats ? Scoring.scoreToMessage(stats) : '';
+      const message = stats ? this.scoreToMessage(stats) : '';
       return {message};
     }
   };

--- a/shell/artifacts/Words/test/scoring-test.js
+++ b/shell/artifacts/Words/test/scoring-test.js
@@ -89,6 +89,8 @@ describe('Scoring', function() {
       delete actualCopy.author;
       delete actualCopy.createdTimestamp;
       delete actualCopy.message;
+      delete actualCopy.renderParticleSpec;
+      delete actualCopy.renderRecipe;
       assert.deepEqual(actualCopy, expected);
     };
 
@@ -103,7 +105,7 @@ describe('Scoring', function() {
         startstamp: 7331
       };
       const user = {id: '42'};
-      const actual = Scoring.applyMoveStats(user, stats, 'short', 38);
+      const actual = Scoring.applyMoveStats('renderParticleSpec', 'renderRecipe', user, stats, 'short', 38);
       validateStats(actual, {
         highestScoringWord: 'highest',
         highestScoringWordScore: 43,
@@ -126,7 +128,7 @@ describe('Scoring', function() {
         startstamp: 7331
       };
       const user = {id: '42'};
-      const actual = Scoring.applyMoveStats(user, stats, 'higher', 100);
+      const actual = Scoring.applyMoveStats('renderParticleSpec', 'renderRecipe', user, stats, 'higher', 100);
       validateStats(actual, {
         highestScoringWord: 'higher',
         highestScoringWordScore: 100,
@@ -149,7 +151,7 @@ describe('Scoring', function() {
         startstamp: 7331
       };
       const user = {id: '42'};
-      const actual = Scoring.applyMoveStats(user, stats, 'higher', 100);
+      const actual = Scoring.applyMoveStats('renderParticleSpec', 'renderRecipe', user, stats, 'higher', 100);
       validateStats(actual, {
         highestScoringWord: 'higher',
         highestScoringWordScore: 100,
@@ -172,7 +174,7 @@ describe('Scoring', function() {
         startstamp: 7331
       };
       const user = {id: '42'};
-      const actual = Scoring.applyMoveStats(user, stats, 'evenlonger', 23);
+      const actual = Scoring.applyMoveStats('renderParticleSpec', 'renderRecipe', user, stats, 'evenlonger', 23);
       validateStats(actual, {
         highestScoringWord: 'highest',
         highestScoringWordScore: 43,
@@ -195,7 +197,7 @@ describe('Scoring', function() {
         startstamp: 7331
       };
       const user = {id: '42'};
-      const actual = Scoring.applyMoveStats(user, stats, 'evenlonger', 23);
+      const actual = Scoring.applyMoveStats('renderParticleSpec', 'renderRecipe', user, stats, 'evenlonger', 23);
       validateStats(actual, {
         highestScoringWord: 'highest',
         highestScoringWordScore: 43,
@@ -218,7 +220,7 @@ describe('Scoring', function() {
         startstamp: 7331
       };
       const user = {id: '42'};
-      const actual = Scoring.applyMoveStats(user, stats, 'evenlonger', 2300);
+      const actual = Scoring.applyMoveStats('renderParticleSpec', 'renderRecipe', user, stats, 'evenlonger', 2300);
       validateStats(actual, {
         highestScoringWord: 'evenlonger',
         highestScoringWordScore: 2300,


### PR DESCRIPTION
More incrementalism -- subsequent items to look at:

- de-`async` the render-particle/recipe bits in `EditPost.js` following use of `willReceiveProps` for same here in `GamePane.js`
- fiddle the `Social` and `Words` references to `shape RenderParticleShape` to share the definition of `HostedParticleShape` already in `List.manifest`
- try merging the `Post` and `Stats` lists with `CopyCollection` (which may be better named `ConcatCollection`)
- try modifying `onArcLoadRecipe` to use `_arc.context` to allow removing explicit mapping of `#BOXED_avatars` and adding `avatar` param to `PostMuxer` particle just to make it available to the individual render item particle
- finish display and style of content for both the posts and stats single-item particle rendering
- update particle rendering (and stored data/recipes as needed) for Words to allow for a more animated display

Part of https://github.com/PolymerLabs/arcs/issues/842