### PR TITLE
Allows binding a slot to any candidate

### DIFF
--- a/runtime/strategies/map-slots.js
+++ b/runtime/strategies/map-slots.js
@@ -32,16 +32,16 @@ export default class MapSlots extends Strategy {
         }
 
         let selectedSlots = MapSlots.findAllSlotCandidates(slotConnection, arc);
+
+        // ResolveRecipe handles one-slot case.
         if (selectedSlots.length < 2) {
           return;
         }
 
-        let selectedSlot = selectedSlots[0]; // TODO: return combinatorial results?
-
-        return (recipe, slotConnection) => {
-          MapSlots.connectSlotConnection(slotConnection, selectedSlot);
+        return selectedSlots.map(slot => ((recipe, slotConnection) => {
+          MapSlots.connectSlotConnection(slotConnection, slot);
           return 1;
-        };
+        }));
       }
     }(RecipeWalker.Permuted), this);
   }

--- a/runtime/strategies/resolve-recipe.js
+++ b/runtime/strategies/resolve-recipe.js
@@ -65,6 +65,8 @@ export default class ResolveRecipe extends Strategy {
         }
 
         let selectedSlots = MapSlots.findAllSlotCandidates(slotConnection, arc);
+
+        // MapSlots handles a multi-slot case.
         if (selectedSlots.length !== 1) {
           return;
         }

--- a/runtime/test/strategies/map-slots-tests.js
+++ b/runtime/test/strategies/map-slots-tests.js
@@ -98,34 +98,61 @@ describe('MapSlots', function() {
       particle A in 'A.js'
         A()
         consume master #root
-          provide detail #info #detail
-
-      particle B in 'B.js'
-        B()
-        consume info #detail #more
 
       recipe
         slot 'id0' #root as s0
         A
+    `));
+
+    let inputParams = {generated: [{result: manifest.recipes[0], score: 1}]};
+    let arc = StrategyTestHelper.createTestArc('test-plan-arc', manifest, 'dom');
+
+    let strategy = new MapSlots(arc);
+    let results = await strategy.generate(inputParams);
+    // consue #root can be bound to the local 'id0' slot or the root slot.
+    assert.equal(results.length, 2);
+  });
+
+  it('allows to bind by name to any available slot', async () => {
+    let manifest = (await Manifest.parse(`
+      particle A in 'A.js'
+        A()
+        consume root
+          provide detail
+
+      particle B in 'B.js'
+        B()
+        consume root
+          provide detail
+
+      particle C in 'C.js'
+        C()
+        consume detail
+
+      recipe
+        A
         B
+        C
     `));
     let inputParams = {generated: [{result: manifest.recipes[0], score: 1}]};
     let arc = StrategyTestHelper.createTestArc('test-plan-arc', manifest, 'dom');
 
     let strategy = new MapSlots(arc);
     let results = await strategy.generate(inputParams);
-    assert.equal(results.length, 1);
+    assert.equal(results.length, 2);
 
-    let plan = results[0].result;
+    results = await new ResolveRecipe(arc).generate({
+      generated: results.map(r => ({
+        result: r.result,
+        score: 1
+      }))
+    });
 
-    strategy = new ResolveRecipe(arc);
-    results = await strategy.generate({generated: [{result: plan, score: 1}]});
-    assert.equal(results.length, 1);
-
-    plan = results[0].result;
-
-    assert.equal(plan.slots.length, 2);
-    plan.normalize();
-    assert.isTrue(plan.isResolved());
+    assert.equal(results.length, 2);
+    for (let result of results) {
+      let plan = result.result;
+      plan.normalize();
+      assert.isTrue(plan.isResolved());
+    }
   });
 });

--- a/runtime/test/strategies/resolve-recipe-test.js
+++ b/runtime/test/strategies/resolve-recipe-test.js
@@ -131,6 +131,25 @@ describe('resolve recipe', function() {
     assert.isTrue(recipe.isResolved());
   });
 
+  it('maps slots by tags', async () => {
+    let manifest = (await Manifest.parse(`
+      particle A in 'A.js'
+        A()
+        consume master #parent
+
+      recipe
+        slot 'id0' #parent as s0
+        A
+    `));
+    let [recipe] = manifest.recipes;
+    let arc = createTestArc('test-plan-arc', manifest, 'dom');
+    assert.isTrue(recipe.normalize());
+
+
+    recipe = await onlyResult(arc, ResolveRecipe, recipe);
+    assert.isTrue(recipe.isResolved());
+  });
+
   it('map slots by slot connection tags', async () => {
     let manifest = (await Manifest.parse(`
       particle A in 'A.js'


### PR DESCRIPTION
Allows for mapping any non-context slot in MapSlots. This is motivated by seeing different results being produced depending on strategy ordering, which is the case I'm trying to remove.

Haven't allowed for full combinatorial results with both context and non-context slots yet, for no particular reason other that I haven't seen it cause issues and it would require reworking a number of tests etc.