### PR TITLE
More stats in Strategy Explorer

### DIFF
--- a/devtools/src/strategy-explorer/se-compare-populations.html
+++ b/devtools/src/strategy-explorer/se-compare-populations.html
@@ -44,14 +44,14 @@ http://polymer.github.io/PATENTS.txt
     </style>
     <div on-click="_onSelected">
       <header id="current" current class="entry" selected$="[[current.selected]]">
-        Most Recent: #[[current.total]], ✓[[current.resolved]]
+        Most Recent: ⊕[[current.surviving]], ✓[[current.resolved]]
         <template is="dom-if" if="[[!current.added]]">
           <iron-icon id="addCurrent" title="Add to Library" icon="av:playlist-add" on-click="_addCurrent"></iron-icon>
         </template>
       </header>
       <template is='dom-repeat' items='{{library}}'>
         <div id="[[item.id]]" class="entry" selected$="[[item.selected]]">
-          @[[item.time]] : #[[item.total]], ✓[[item.resolved]]
+          @[[item.time]] : ⊕[[item.surviving]], ✓[[item.resolved]]
           <iron-icon hidden$=[[item.selected]] id="compare" title="Compare" icon="image:exposure"></iron-icon></div>
       </template>
     </div>
@@ -83,10 +83,11 @@ http://polymer.github.io/PATENTS.txt
           return;
         }
 
+        let stats = summaryStats(this.results);
         this.current = {
           id: 'current',
-          total: totalResults(this.results),
-          resolved: resolvedResults(this.results),
+          surviving: stats.survivingDerivations,
+          resolved: stats.resolvedDerivations,
           selected: true,
           results
         };

--- a/devtools/src/strategy-explorer/se-shared.html
+++ b/devtools/src/strategy-explorer/se-shared.html
@@ -61,16 +61,107 @@
     </style>
   </template>
   <script>
-    const resolvedResults = function(results) {
-      return totalResults(results, r => r.resolved);
+    // Basic stats for the entire run.
+    function summaryStats(results) {
+      return results.map(r => r.record).reduce((acc, recorc) => {
+        let result = {};
+        for (let name of [
+            'generatedDerivations',
+            'duplicateDerivations',
+            'duplicateSameParentDerivations',
+            'invalidDerivations',
+            'nullDerivations',
+            'survivingDerivations',
+            'resolvedDerivations',
+        ]) {
+          result[name] = recorc[name] + (acc[name] || 0);
+        }
+        return result;
+      }, {});
     }
 
-    const totalResults = function(results, recipeFilter = (x => true)) {
-      return results.reduce((a, b) => a + generationSize(b, recipeFilter), 0);
+    // Returning a one element array to get around inability to use
+    // function call followed by property access in the polymer template :(
+    function summaryStatsForTemplate(results) {
+      return [summaryStats(results)];
     }
 
-    const generationSize = function(generation, recipeFilter = (x => true)) {
-      return generation.population.reduce((a, b) => a + b.recipes.filter(recipeFilter).length, 0);
+    // Computes [{Header, [PerStrategyStats]}], where first element pertains
+    // to all generations summed up, following by one element per generation.
+    function strategySummary(results) {
+      let summaries = results.map(x => ({
+        header: `Generation ${x.record.generation}`,
+        strategies: perStrategyRecord(x)
+      }));
+
+      summaries = [{
+        header: 'Strategy Summary',
+        strategies: collapseStrategyMaps(summaries.map(summary => summary.strategies))
+      }, ...summaries];
+
+      for (let summary of summaries) {
+        // Array for iterating over with a template.
+        summary.strategies = Array.from(summary.strategies.values());
+      }
+
+      // Filter out empty generations, i.e. sometimes the last one.
+      return summaries.filter(summary => summary.strategies.length > 0);
+    }
+
+    // Returns a Map(Strategy -> Stats)
+    function perStrategyRecord(generation) {
+      let result = new Map();
+      for (let [field, perStrategyField] of [
+        ['generatedDerivations', 'generatedDerivationsByStrategy'],
+        ['duplicateDerivations', 'duplicateDerivationsByStrategy'],
+        ['duplicateSameParentDerivations', 'duplicateSameParentDerivationsByStrategy'],
+        ['invalidDerivations', 'invalidDerivationsByStrategy'],
+        ['nullDerivations', 'nullDerivationsByStrategy'],
+        ['resolvedDerivations', 'resolvedDerivationsByStrategy'],
+      ]) {
+        for (let strategy of Object.getOwnPropertyNames(generation.record[perStrategyField])) {
+          let value = generation.record[perStrategyField][strategy];
+          if (value > 0) {
+            let obj = {strategy};
+            obj[field] = value;
+            result.set(strategy, Object.assign(result.get(strategy) || {}, obj));
+          };
+        }
+      }
+
+      result.forEach(r => {
+        r.survivingDerivations = r.generatedDerivations
+            - (r.duplicateDerivations || 0)
+            - (r.invalidDerivations || 0)
+            - (r.nullDerivations || 0)
+            - (r.duplicateSameParentDerivations || 0);
+      });
+
+      return result;
+    }
+
+    // Collapses a [Map(Strategy -> Stats)] into a single Map(Strategy -> Stats).
+    function collapseStrategyMaps(strategyMaps) {
+      let result = new Map();
+      for (let map of strategyMaps) {
+        map.forEach((props, strategy) => {
+          let prevProps = result.get(strategy) || {};
+          let newProps = {strategy};
+          for (let name of [
+              'generatedDerivations',
+              'duplicateDerivations',
+              'duplicateSameParentDerivations',
+              'invalidDerivations',
+              'nullDerivations',
+              'survivingDerivations',
+              'resolvedDerivations',
+          ]) {
+            newProps[name] = props[name] + (prevProps[name] || 0);
+          }
+          result.set(strategy, newProps);
+        });
+      }
+      return result;
     }
   </script>
 </dom-module>

--- a/devtools/src/strategy-explorer/se-stats.html
+++ b/devtools/src/strategy-explorer/se-stats.html
@@ -28,19 +28,76 @@ http://polymer.github.io/PATENTS.txt
         font-size: 75%;
         padding-bottom: 5px;
       }
+      .generated {
+        color: gray;
+      }
+      .duplicate {
+        color: blue;
+      }
+      .sameParentDuplicate {
+        color: purple;
+      }
+      .invalid {
+        color: red;
+      }
+      .null {
+        color: olive;
+      }
+      .surviving {
+        font-weight: bold;
+      }
+      .resolved {
+        font-weight: bold;
+        color: green;
+      }
     </style>
     <div class='section'>
-      <div>Summary</div>
-      <div>total: {{totalResults(results)}}</div>
-      <div>resolved: {{resolvedResults(results)}}</div>
-    </div>
-    <template is='dom-repeat' items='{{results}}'>
-      <div class='section'>
-        <div>Generation [[index]]</div>
-        <template is='dom-repeat' items='{{item.population}}'>
-          <div>[[item.strategy]]: [[item.recipes.length]]</div>
+      <div>Totals Summary</div>
+      <template is='dom-repeat' items='{{summaryStatsForTemplate(results)}}'>
+        <div class="generated">Generated: Σ{{item.generatedDerivations}}</div>
+        <template is='dom-if' if='{{item.duplicateDerivations}}'>
+          <div class="duplicate">Duplicate: ={{item.duplicateDerivations}}</div>
         </template>
-        <div>total: {{generationSize(item)}}</div>
+        <template is='dom-if' if='{{item.duplicateSameParentDerivations}}'>
+          <div class="sameParentDuplicate">Same Parent Duplicate: ≡{{item.duplicateSameParentDerivations}}</div>
+        </template>
+        <template is='dom-if' if='{{item.nullDerivations}}'>
+          <div class="null">Null: ∅{{item.nullDerivations}}</div>
+        </template>
+        <template is='dom-if' if='{{item.invalidDerivations}}'>
+          <div class="invalid">Invalid: ✘{{item.invalidDerivations}}</div>
+        </template>
+        <div class="surviving">Surviving: ⊕{{item.survivingDerivations}}</div>
+        <div class="resolved">Resolved: ✓{{item.resolvedDerivations}}</div>
+      </template>
+    </div>
+    <template is='dom-repeat' items='{{strategySummary(results)}}'>
+      <div class='section'>
+        <div>[[item.header]]</div>
+        <template is='dom-repeat' items='{{item.strategies}}'>
+          <div>
+            [[item.strategy]]:
+            <span class="generated">Σ[[item.generatedDerivations]]</span>
+            <template is='dom-if' if='{{item.duplicateDerivations}}'>
+              <span class="duplicate">={{item.duplicateDerivations}}</span>
+            </template>
+            <template is='dom-if' if='{{item.duplicateSameParentDerivations}}'>
+              <span class="sameParentDuplicate">≡{{item.duplicateSameParentDerivations}}</span>
+            </template>
+            <template is='dom-if' if='{{item.nullDerivations}}'>
+              <span class="null">∅{{item.nullDerivations}}</span>
+            </template>
+            <template is='dom-if' if='{{item.invalidDerivations}}'>
+              <span class="invalid">✘[[item.invalidDerivations]]</span>
+            </template>
+            <template is='dom-if' if='{{item.survivingDerivations}}'>
+              <span class="surviving">⊕{{item.survivingDerivations}}</span>
+            </template>
+            <template is='dom-if' if='{{item.resolvedDerivations}}'>
+              <span class="resolved">✓{{item.resolvedDerivations}}</span>
+            </template>
+          </div>
+        </template>
       </div>
     </template>
   </template>
@@ -48,9 +105,8 @@ http://polymer.github.io/PATENTS.txt
 
     Polymer({is: 'se-stats',
       // Methods from se-shared for using in DOM
-      resolvedResults,
-      totalResults,
-      generationSize,
+      summaryStatsForTemplate,
+      strategySummary
     });
   </script>
 </dom-module>

--- a/runtime/test/planner-tests.js
+++ b/runtime/test/planner-tests.js
@@ -89,9 +89,9 @@ describe('Planner', function() {
   it('can generate things', async () => {
     let manifest = await Manifest.load('./runtime/test/artifacts/giftlist.manifest', loader);
     let testSteps = async planner => {
-      await planner.generate();
-      await planner.generate();
-      await planner.generate();
+      await planner.strategizer.generate();
+      await planner.strategizer.generate();
+      await planner.strategizer.generate();
       return planner.strategizer.population.length;
     };
     let results = await planFromManifest(manifest, {testSteps});
@@ -110,9 +110,9 @@ describe('Planner', function() {
       return arc;
     };
     let testSteps = async planner => {
-      await planner.generate();
-      await planner.generate();
-      await planner.generate();
+      await planner.strategizer.generate();
+      await planner.strategizer.generate();
+      await planner.strategizer.generate();
       return planner.strategizer.population.length;
     };
     let results = await planFromManifest(manifest, {arcFactory, testSteps});

--- a/runtime/test/slot-composer-tests.js
+++ b/runtime/test/slot-composer-tests.js
@@ -62,7 +62,7 @@ async function initSlotComposer(recipeStr) {
   arc.pec.startRender = ({particle, slotName, contentTypes}) => { startRenderParticles.push(particle.name); };
   let planner = new Planner();
   planner.init(arc);
-  await planner.generate();
+  await planner.strategizer.generate();
   assert.equal(planner.strategizer.population.length, 1);
   let plan = planner.strategizer.population[0].result;
   return {arc, slotComposer, plan, startRenderParticles};

--- a/runtime/test/strategies/rulesets-tests.js
+++ b/runtime/test/strategies/rulesets-tests.js
@@ -103,7 +103,7 @@ describe('Rulesets', () => {
     planner.init(arc, options);
     let generations = [];
     await planner.plan(Infinity, generations);
-    let recipes = [].concat(...generations);
+    let recipes = [].concat(...generations.map(instance => instance.generated));
     return {
       total: recipes.length,
       fateAssigned: recipes.reduce((acc, r) => acc + (r.result.handles.every(h => h.fate !== '?')), 0),


### PR DESCRIPTION
Surfaces extended record of the run in the Strategy Explorer. Some renames discussed with @dstockwell.

Should help in understanding how many invalid and duplicate recipes we create when we fiddle with rules and strategies.