### PR TITLE
WIP: Demo social mux with merged lists.

### DIFF
--- a/runtime/handle.js
+++ b/runtime/handle.js
@@ -84,6 +84,8 @@ class Handle {
 
   _restore(entry) {
     assert(this.entityClass, 'Handles need entity classes for deserialization');
+    console.log(`handle._restore: ${this.entityClass.name}`, this.entityClass.type);
+    // debugger;
     return restore(entry, this.entityClass);
   }
 

--- a/runtime/outer-PEC.js
+++ b/runtime/outer-PEC.js
@@ -162,6 +162,7 @@ class OuterPEC extends PEC {
     }
 
     // TODO: rename this concept to something like instantiatedParticle, handle or registration.
+    // console.log(`InstantiateParticle [spec=${particleSpec}].`);
     this._apiPort.InstantiateParticle(particleSpec, {id, spec, handles});
     return particleSpec;
   }

--- a/runtime/test/particles/artifacts/copy-collection-multiple-types-test.recipes
+++ b/runtime/test/particles/artifacts/copy-collection-multiple-types-test.recipes
@@ -1,0 +1,42 @@
+// Copyright (c) 2018 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+import '../../../../shell/artifacts/Common/CopyCollection.manifest'
+
+schema Prosimian
+  Text name
+  Number fingerCount
+
+schema Lemur extends Prosimian
+  Number tailLength
+
+resource ProsimianData
+  start
+  [
+    {"name": "loris", "fingerCount": 5},
+    {"name": "tenrec", "fingerCount": 5}
+  ]
+view View0 of [Prosimian] 'prosimians' in ProsimianData
+
+resource LemurData
+  start
+  [
+    {"name": "aye-aye", "fingerCount": 5, "tailLength": 42}
+  ]
+view View1 of [Lemur] 'lemurs' in LemurData
+
+recipe
+  map 'prosimians' as prosimians
+  map 'lemurs' as lemurs
+  create as all_prosimians
+  CopyCollection
+    input <- prosimians
+    output -> all_prosimians
+  CopyCollection
+    input <- lemurs
+    output -> all_prosimians
+  description `copy all of the prosimians!`

--- a/runtime/test/particles/common-test.js
+++ b/runtime/test/particles/common-test.js
@@ -14,7 +14,7 @@ import {assert} from '../chai-web.js';
 import TestHelper from '../test-helper.js';
 
 describe('common particles test', function() {
-  it('copy handle test', async () => {
+  it('can copy two sets into one', async () => {
     let helper = await TestHelper.loadManifestAndPlan(
         './runtime/test/particles/artifacts/copy-collection-test.recipes',
         {expectedNumPlans: 1, expectedSuggestions: ['Copy all things!']});
@@ -24,5 +24,17 @@ describe('common particles test', function() {
 
     // Copied 2 and 3 entities from two collections.
     assert.equal(5, helper.arc._handles[0]._items.size);
+  });
+
+  it('can copy two sets of differing types with the same base class into one set', async () => {
+    let helper = await TestHelper.loadManifestAndPlan(
+        './runtime/test/particles/artifacts/copy-collection-multiple-types-test.recipes',
+        {expectedNumPlans: 1, expectedSuggestions: ['Copy all of the prosimians!']});
+    assert.equal(0, helper.arc._handles.length);
+
+    await helper.acceptSuggestion({particles: ['CopyCollection', 'CopyCollection']});
+
+    // Copied 2 and 3 entities from two collections.
+    assert.equal(3, helper.arc._handles[0]._items.size);
   });
 });

--- a/shell/artifacts/Common/source/CopyCollection.js
+++ b/shell/artifacts/Common/source/CopyCollection.js
@@ -14,7 +14,10 @@ defineParticle(({Particle}) => {
       this.on(views, 'input', 'change', e => {
         let inputHandle = views.get('input');
         inputHandle.toList().then(input => {
-          input.forEach(elem => views.get('output').store(elem));
+          input.forEach(elem => {
+            console.log(`Copying item [elem=${elem}].`);
+            views.get('output').store(elem);
+          });
           this.relevance = input.length; // TODO: set appropriate relevance.
         });
       });

--- a/shell/artifacts/Social/Social.recipes
+++ b/shell/artifacts/Social/Social.recipes
@@ -7,6 +7,7 @@
 // http://polymer.github.io/PATENTS.txt
 
 import 'Particles.manifest'
+import 'https://$cdn/artifacts/Common/CopyCollection.manifest'
 import 'https://$cdn/artifacts/Common/Detail.manifest'
 import 'https://$cdn/artifacts/Common/List.manifest'
 
@@ -38,28 +39,37 @@ recipe
     selected = post
 
 // A feed that aggregates everything a user and friends say.
-recipe
-  map #BOXED_posts as posts
-  // TODO(wkorman): Genericize stats integration via polymorphic recipe antics.
-  map #BOXED_stats as stats
-  map #BOXED_avatar as avatars
-  use #user as user
-  use #identities as people
+// recipe
+//   map #BOXED_posts as posts
+//   // TODO(wkorman): Genericize stats integration via polymorphic recipe antics.
+//   map #BOXED_stats as stats
+//   map #BOXED_avatar as avatars
+//   use #user as user
+//   use #identities as people
+//
+//   OnlyShowPosts
+//     posts <- posts
+//     stats <- stats
+//     user <- user
+//     avatars <- avatars
+//     people <- people
 
-  OnlyShowPosts
-    posts <- posts
-    stats <- stats
-    user <- user
-    avatars <- avatars
-    people <- people
-
 recipe
-  map #BOXED_stats as posts
-  // TODO(wkorman): Merge together posts and stats with CopyCollection if needed.
-  // map #BOXED_posts as posts
   map #BOXED_avatar as avatars
+  // map #BOXED_stats as posts
+  map #BOXED_stats as game_posts
+  map #BOXED_posts as social_posts
+  create as all_posts
+  CopyCollection
+    input <- game_posts
+    output -> all_posts
+  CopyCollection
+    input <- social_posts
+    output -> all_posts
   List
-    items = posts
+    items = all_posts
+    // items = posts
   PostMuxer
-    list = posts
+    list = all_posts
+    // list = posts
     avatars = avatars

--- a/shell/artifacts/Social/source/PostMuxer.js
+++ b/shell/artifacts/Social/source/PostMuxer.js
@@ -12,13 +12,13 @@
 defineParticle(({MultiplexerDomParticle, log}) => {
   return class PostMultiplexer extends MultiplexerDomParticle {
     constructInnerRecipe(hostedParticle, item, itemView, slot, other) {
-      // log(`PostMuxer input recipe: `, item.renderRecipe);
+      log(`PostMuxer input recipe: `, item.renderRecipe);
       let value = item.renderRecipe.replace('{{slot_id}}', slot.id);
       value = value.replace('{{item_id}}', itemView._id);
       value = value.replace('{{other_views}}', other.views.join('\n'));
       value =
           value.replace('{{other_connections}}', other.connections.join('\n'));
-      // log(`PostMuxer interpolated recipe: `, value);
+      log(`PostMuxer interpolated recipe: `, value);
       return value;
     }
   };

--- a/shell/artifacts/canonical.manifest
+++ b/shell/artifacts/canonical.manifest
@@ -10,12 +10,12 @@
 // grows the current alphabetized list will stop scaling, and we should
 // consider moving these into separate files or grouping by demo/test.
 
-import 'Events/Events.recipes'
-import 'Messages/Messages.recipes'
-import 'Products/Products.recipes'
-import 'Profile/Profile.recipes'
-import 'Restaurants/Restaurants.recipes'
+// import 'Events/Events.recipes'
+// import 'Messages/Messages.recipes'
+// import 'Products/Products.recipes'
+// import 'Profile/Profile.recipes'
+// import 'Restaurants/Restaurants.recipes'
 import 'Social/Social.recipes'
-import 'VideoPlayer/VideoPlayer.recipes'
-import 'Words/Words.recipes'
-import 'hex/hex.manifest'
+// import 'VideoPlayer/VideoPlayer.recipes'
+// import 'Words/Words.recipes'
+// import 'hex/hex.manifest'


### PR DESCRIPTION
*Note*: Does not need code review.

For @mmandlis exploration per discussion on doc. To use, run `./tools/sigh` to build, visit Arcs launcher locally, switch to 'Walt' user, and click 'New Arc'. Note errors in console already due to speculative execution.

This PR is messy currently as it incorporates debug logging, exploratory unit test addition (which seemed to confirm CopyCollection is fine with varying types where one extends another), but I left these in since you may end up poking in the same code while looking.

If you comment out the `CopyCollection` bits in `Social.recipes`, you'll find that you can in fact get and select the 'show morphed posts' suggestion and view the posts in a muxed feed as long as it incorporates only one or the other of `Post` or `Stats` entities.

Part of https://github.com/PolymerLabs/arcs/issues/842