### PR TITLE
ensure that a few checks are consistent through a page reload

### DIFF
--- a/shell/app-shell/elements/shell-ui.js
+++ b/shell/app-shell/elements/shell-ui.js
@@ -58,7 +58,7 @@ const Main = Xen.html`
     <!-- app-toolbar is position-fixed -->
     <app-toolbar style="{{shellStyle}}">
       <a trigger="launcher" href="{{launcherUrl}}" title="Go to Launcher">${AppIcon}</a>
-      <arc-title style="{{titleStatic}}" on-click="_onStartEditingTitle" unsafe-html="{{description}}"></arc-title>
+      <arc-title id="arc-title" style="{{titleStatic}}" on-click="_onStartEditingTitle" unsafe-html="{{description}}"></arc-title>
       <toolbar-buttons>
         <icon hidden$="{{micHidden}}">mic</icon>
         <icon on-click="_onMenuClick">more_vert</icon>

--- a/shell/test/selenium-utils-test.js
+++ b/shell/test/selenium-utils-test.js
@@ -13,7 +13,7 @@ afterEach(function() {
 });
 
 describe('SeleniumUtils', function() {
-  describe('#pierceShadowsSingle', function() {
+  describe('#pierceShadowsSingle()', function() {
     it('should cross a simple shadow boundary', function() {
       target.innerHTML = `
         <div outer>
@@ -107,7 +107,7 @@ describe('SeleniumUtils', function() {
       assert.equal(result.textContent, 'goal');
     });
   });
-  describe('#pierceShadows', function() {
+  describe('#pierceShadows()', function() {
     it('should return multiple valid matches', function() {
       target.innerHTML = `
         <div outer>

--- a/shell/test/specs/demo-tests.js
+++ b/shell/test/specs/demo-tests.js
@@ -424,7 +424,7 @@ function testAroundRefresh() {
         }
 
         return actualValues;
-      }
+      };
 
 
   const expectedValues = getOrCompare();

--- a/shell/test/specs/demo-tests.js
+++ b/shell/test/specs/demo-tests.js
@@ -243,7 +243,7 @@ function initTestWithNewArc(testTitle) {
   // use a solo URL pointing to our local recipes
   browser.url(`${browser.getUrl()}&${urlParams.join('&')}`);
 
-  // that reload (`browser.url()`) will drop our utils, so load again.
+  // that page load (`browser.url()`) will drop our utils, so load again.
   loadSeleniumUtils();
 
   // check out some basic structure relative to the app footer
@@ -399,6 +399,44 @@ function clickInParticles(slotName, selectors, textQuery) {
           realSelectors} textQuery ${textQuery}`);
 }
 
+/**
+ * Grab some data from the page, refresh the page, and validate that the data
+ * hasn't changed.
+ */
+function testAroundRefresh() {
+  const getOrCompare =
+      expectedValues => {
+        let actualValues = {};
+
+        const titleElem =
+            pierceShadowsSingle(['app-shell', 'shell-ui', '#arc-title']);
+        actualValues.title = browser.elementIdText(titleElem.value.ELEMENT);
+
+        const suggestionsElement = getAtLeastOneSuggestion();
+        actualValues.suggestions = suggestionsElement ?
+            suggestionsElement.value.map(suggestion => {
+              return browser.elementIdText(suggestion.ELEMENT).value;
+            }) :
+            [];
+
+        for (let key in expectedValues) {
+          assert.equal(actualValues[key].value, expectedValues[key].value);
+        }
+
+        return actualValues;
+      }
+
+
+  const expectedValues = getOrCompare();
+
+  browser.refresh();
+  loadSeleniumUtils();
+
+  waitForStillness();
+
+  getOrCompare(expectedValues);
+}
+
 describe('Arcs demos', function() {
   it('can book a restaurant', /** @this Context */ function() {
     initTestWithNewArc(this.test.fullTitle());
@@ -423,6 +461,8 @@ describe('Arcs demos', function() {
 
     acceptSuggestion('Table for 2');
     acceptSuggestion('from your calendar');
+
+    testAroundRefresh();
 
     // debug hint: to drop into debug mode with a REPL; also a handy way to
     // see the state at the end of the test:


### PR DESCRIPTION
Currently, the arc title & suggestions list are checked to make sure they're consistent through a reload.

@seefeldb suggested this a loong time ago. I'm pretty sure I did, but who knows.