### PR TITLE
Keeps orphaned slots in recipe.normalize()

### DIFF
--- a/runtime/recipe/recipe.js
+++ b/runtime/recipe/recipe.js
@@ -265,8 +265,10 @@ class Recipe {
 
     let seenHandles = new Set();
     let seenParticles = new Set();
+    let seenSlots = new Set();
     let particles = [];
     let handles = [];
+    let slots = [];
     // Reorder connections so that interfaces come last.
     // TODO: update handle-connection comparison method instead?
     for (let connection of connections.filter(c => !c.type || !c.type.isInterface).concat(connections.filter(c => !!c.type && !!c.type.isInterface))) {
@@ -280,17 +282,6 @@ class Recipe {
       }
     }
 
-    let orphanedHandles = this._handles.filter(handle => !seenHandles.has(handle));
-    orphanedHandles.sort(util.compareComparables);
-    handles.push(...orphanedHandles);
-
-    let orphanedParticles = this._particles.filter(particle => !seenParticles.has(particle));
-    orphanedParticles.sort(util.compareComparables);
-    particles.push(...orphanedParticles);
-
-    // TODO: redo slots as above.
-    let seenSlots = new Set();
-    let slots = [];
     for (let slotConnection of slotConnections) {
       if (slotConnection.targetSlot && !seenSlots.has(slotConnection.targetSlot)) {
         slots.push(slotConnection.targetSlot);
@@ -303,6 +294,18 @@ class Recipe {
         }
       });
     }
+
+    let orphanedHandles = this._handles.filter(handle => !seenHandles.has(handle));
+    orphanedHandles.sort(util.compareComparables);
+    handles.push(...orphanedHandles);
+
+    let orphanedParticles = this._particles.filter(particle => !seenParticles.has(particle));
+    orphanedParticles.sort(util.compareComparables);
+    particles.push(...orphanedParticles);
+
+    let orphanedSlots = this._slots.filter(slot => !seenSlots.has(slot));
+    orphanedSlots.sort(util.compareComparables);
+    slots.push(...orphanedSlots);
 
     // Put particles and handles in their final ordering.
     this._particles = particles;

--- a/runtime/test/recipe-test.js
+++ b/runtime/test/recipe-test.js
@@ -94,4 +94,22 @@ describe('recipe', function() {
     assert.isTrue(p5ConnSpec.isCompatibleType(MyType.setViewOf()));
     assert.isTrue(p5ConnSpec.isCompatibleType(MySubType.setViewOf()));
   });
+  it('keeps orphaned slots, handles and particles', async () => {
+    let manifest = await Manifest.parse(`
+      particle A in 'A.js'
+        A()
+
+      recipe
+        create #data as h0
+        slot #master as s0
+        A
+    `);
+
+    let [recipe] = manifest.recipes;
+    assert.isTrue(recipe.normalize());
+
+    assert.lengthOf(recipe.slots, 1);
+    assert.lengthOf(recipe.particles, 1);
+    assert.lengthOf(recipe.handles, 1);
+  });
 });


### PR DESCRIPTION
I found that it was throwing them away when I worked on the tests for MapSlots.