### PR TITLE
Allow GroupHandleConnection to run outside of search to create handles.

### DIFF
--- a/runtime/planner.js
+++ b/runtime/planner.js
@@ -28,7 +28,6 @@ import InitSearch from './strategies/init-search.js';
 import SearchTokensToParticles from './strategies/search-tokens-to-particles.js';
 import FallbackFate from './strategies/fallback-fate.js';
 import GroupHandleConnections from './strategies/group-handle-connections.js';
-import CombinedStrategy from './strategies/combined-strategy.js';
 import MatchFreeHandlesToConnections from './strategies/match-free-handles-to-connections.js';
 import CreateViews from './strategies/create-views.js';
 import ResolveRecipe from './strategies/resolve-recipe.js';
@@ -46,10 +45,8 @@ class Planner {
     strategies = strategies || [
       new InitPopulation(arc),
       new InitSearch(arc),
-      new CombinedStrategy([
-        new SearchTokensToParticles(arc),
-        new GroupHandleConnections(),
-      ]),
+      new SearchTokensToParticles(arc),
+      new GroupHandleConnections(),
       new FallbackFate(),
       new CreateViews(),
       new AssignViewsByTagAndType(arc),

--- a/runtime/strategies/rulesets.js
+++ b/runtime/strategies/rulesets.js
@@ -32,11 +32,14 @@ export const ExperimentalPhased = new Ruleset.Builder().order(
   [
     InitPopulation,
     InitSearch
-  ], [
+  ],
+  SearchTokensToParticles,
+  [
     MatchRecipeByVerb,
     MatchParticleByVerb
   ],
   ConvertConstraintsToConnections,
+  GroupHandleConnections,
   [
     CreateViews,
     AddUseViews,
@@ -54,9 +57,11 @@ export const ExperimentalPhased = new Ruleset.Builder().order(
 export const ExperimentalLinear = new Ruleset.Builder().order(
   InitPopulation,
   InitSearch,
+  SearchTokensToParticles,
   MatchRecipeByVerb,
   MatchParticleByVerb,
   ConvertConstraintsToConnections,
+  GroupHandleConnections,
   MatchFreeHandlesToConnections,
   CreateViews,
   AddUseViews,


### PR DESCRIPTION
I want to make some progress towards automatic resolution of handles in the recipes. In this first step I'm allowing GroupHandleConnection to run so that it can be used to join connections between particles. I've checked and it doesn't cause recipe explosion with the current set of demos, but I will continue to monitor state of affairs there. I will be gradually adding various cases of automatic resolution to planner-tests to maintain we keep on supporting them.