### PR TITLE
Remove references to view from manifest.

### DIFF
--- a/runtime/arc.js
+++ b/runtime/arc.js
@@ -495,7 +495,7 @@ ${this.activeRecipe.toString()}`;
   findHandleById(id) {
     let handle = this._handlesById.get(id);
     if (handle == null) {
-      handle = this._context.findHandleById(id);
+      handle = this._context.findStorageById(id);
     }
     return handle;
   }

--- a/runtime/outer-PEC.js
+++ b/runtime/outer-PEC.js
@@ -99,7 +99,7 @@ class OuterPEC extends PEC {
             missingHandles.push(handle);
             continue;
           }
-          handle.mapToView(fromHandle);
+          handle.mapToStorage(fromHandle);
         }
         if (missingHandles.length > 0) {
           error = `Recipe couldn't load due to missing handles [recipe=${recipe0}, missingHandles=${missingHandles.join('\n')}].`;

--- a/runtime/recipe/handle.js
+++ b/runtime/recipe/handle.js
@@ -97,12 +97,12 @@ class Handle {
     }
     this._id = id;
   }
-  mapToView(view) {
-    this._id = view.id;
+  mapToStorage(storage) {
+    this._id = storage.id;
     this._type = undefined;
-    assert(view.type == undefined || !(view.type.hasVariableReference), `variable references shouldn't be part of handle types`);
-    this._mappedType = view.type;
-    this._storageKey = view.storageKey;
+    assert(storage.type == undefined || !(storage.type.hasVariableReference), `variable references shouldn't be part of handle types`);
+    this._mappedType = storage.type;
+    this._storageKey = storage.storageKey;
   }
   get localName() { return this._localName; }
   set localName(name) { this._localName = name; }

--- a/runtime/strategies/assign-remote-views.js
+++ b/runtime/strategies/assign-remote-views.js
@@ -22,6 +22,6 @@ export default class AssignRemoteViews extends ViewMapperBase {
   }
 
   getMappableViews(type, tags=[]) {
-    return this._arc.context.findHandlesByType(type, {tags, subtype: true});
+    return this._arc.context.findStorageByType(type, {tags, subtype: true});
   }
 }

--- a/runtime/strategies/copy-remote-views.js
+++ b/runtime/strategies/copy-remote-views.js
@@ -22,6 +22,6 @@ export default class CopyRemoteViews extends ViewMapperBase {
   }
 
   getMappableViews(type, tags=[]) {
-    return this._arc.context.findHandlesByType(type, {tags, subtype: true});
+    return this._arc.context.findStorageByType(type, {tags, subtype: true});
   }
 }

--- a/runtime/strategies/resolve-recipe.js
+++ b/runtime/strategies/resolve-recipe.js
@@ -35,7 +35,7 @@ export default class ResolveRecipe extends Strategy {
             break;
           case 'map':
           case 'copy':
-            mappable = arc.context.findHandlesByType(handle.type, {tags: handle.tags, subtype: true});
+            mappable = arc.context.findStorageByType(handle.type, {tags: handle.tags, subtype: true});
             break;
           case 'create':
           case '?':
@@ -54,7 +54,7 @@ export default class ResolveRecipe extends Strategy {
 
         if (mappable.length == 1) {
           return (recipe, handle) => {
-            handle.mapToView(mappable[0]);
+            handle.mapToStorage(mappable[0]);
           };
         }
       }

--- a/runtime/strategies/view-mapper-base.js
+++ b/runtime/strategies/view-mapper-base.js
@@ -67,7 +67,7 @@ export default class ViewMapperBase extends Strategy {
             let tscore = 0;
 
             assert(newView.id);
-            clonedView.mapToView(newView);
+            clonedView.mapToStorage(newView);
             if (clonedView.fate != 'copy') {
               clonedView.fate = fate;
             }

--- a/runtime/test/arc-tests.js
+++ b/runtime/test/arc-tests.js
@@ -44,8 +44,8 @@ describe('Arc', function() {
     let fooView = await arc.createHandle(Foo.type, undefined, 'test:1');
     let barView = await arc.createHandle(Bar.type, undefined, 'test:2');
     await handle.handleFor(fooView).set(new Foo({value: 'a Foo'}));
-    recipe.handles[0].mapToView(fooView);
-    recipe.handles[1].mapToView(barView); 
+    recipe.handles[0].mapToStorage(fooView);
+    recipe.handles[1].mapToStorage(barView); 
     assert(recipe.normalize());
     await arc.instantiate(recipe);
     await util.assertSingletonWillChangeTo(barView, Bar, 'a Foo1');
@@ -55,8 +55,8 @@ describe('Arc', function() {
     let {arc, recipe, Foo, Bar} = await setup();
     let fooView = await arc.createHandle(Foo.type, undefined, 'test:1');
     let barView = await arc.createHandle(Bar.type, undefined, 'test:2');
-    recipe.handles[0].mapToView(fooView);
-    recipe.handles[1].mapToView(barView); 
+    recipe.handles[0].mapToStorage(fooView);
+    recipe.handles[1].mapToStorage(barView); 
     recipe.normalize();
     await arc.instantiate(recipe);
 
@@ -78,8 +78,8 @@ describe('Arc', function() {
     let fooView = await arc.createHandle(Foo.type, undefined, 'test:1');
     handle.handleFor(fooView).set(new Foo({value: 'a Foo'}));
     let barView = await arc.createHandle(Bar.type, undefined, 'test:2');
-    recipe.handles[0].mapToView(fooView);
-    recipe.handles[1].mapToView(barView); 
+    recipe.handles[0].mapToStorage(fooView);
+    recipe.handles[1].mapToStorage(barView); 
     recipe.normalize();
     await arc.instantiate(recipe);
     await util.assertSingletonWillChangeTo(barView, Bar, 'a Foo1');
@@ -128,7 +128,7 @@ describe('Arc', function() {
 
     let barType = manifest.findTypeByName('Bar');
     let handle = await arc.createHandle(barType.setViewOf(), undefined, 'test:1');
-    recipe.handles[0].mapToView(handle);
+    recipe.handles[0].mapToStorage(handle);
     
     assert(recipe.normalize());
     assert(recipe.isResolved());

--- a/runtime/test/description-test.js
+++ b/runtime/test/description-test.js
@@ -79,12 +79,12 @@ recipe
     assert(1, manifest.recipes.length);
     let recipe = manifest.recipes[0];
     let Foo = manifest.findSchemaByName('Foo').entityClass();
-    recipe.handles[0].mapToView({id: 'test:1', type: Foo.type});
+    recipe.handles[0].mapToStorage({id: 'test:1', type: Foo.type});
     if (recipe.handles.length > 1) {
-      recipe.handles[1].mapToView({id: 'test:2', type: Foo.type.setViewOf()});
+      recipe.handles[1].mapToStorage({id: 'test:2', type: Foo.type.setViewOf()});
     }
     if (recipe.handles.length > 2) {
-      recipe.handles[2].mapToView({id: 'test:3', type: Foo.type});
+      recipe.handles[2].mapToStorage({id: 'test:3', type: Foo.type});
     }
     let arc = createTestArc();
     let fooView = await arc.createHandle(Foo.type, undefined, 'test:1');
@@ -362,8 +362,8 @@ recipe
       assert(1, manifest.recipes.length);
       let recipe = manifest.recipes[0];
       let Foo = manifest.findSchemaByName('Foo').entityClass();
-      recipe.handles[0].mapToView({id: 'test:1', type: Foo.type.setViewOf()});
-      recipe.handles[1].mapToView({id: 'test:2', type: Foo.type.setViewOf()});
+      recipe.handles[0].mapToStorage({id: 'test:1', type: Foo.type.setViewOf()});
+      recipe.handles[1].mapToStorage({id: 'test:2', type: Foo.type.setViewOf()});
       let arc = createTestArc();
       let fooView1 = await arc.createHandle(Foo.type.setViewOf(), undefined, 'test:1');
       let fooView2 = await arc.createHandle(Foo.type.setViewOf(), undefined, 'test:2');
@@ -495,8 +495,8 @@ recipe
         assert(1, manifest.recipes.length);
         let recipe = manifest.recipes[0];
         let MyBESTType = manifest.findSchemaByName('MyBESTType').entityClass();
-        recipe.handles[0].mapToView({id: 'test:1', type: MyBESTType.type});
-        recipe.handles[1].mapToView({id: 'test:2', type: MyBESTType.type.setViewOf()});
+        recipe.handles[0].mapToStorage({id: 'test:1', type: MyBESTType.type});
+        recipe.handles[1].mapToStorage({id: 'test:2', type: MyBESTType.type.setViewOf()});
         let arc = createTestArc();
         let tView = await arc.createHandle(MyBESTType.type, undefined, 'test:1');
         let tsView = await arc.createHandle(MyBESTType.type.setViewOf(), undefined, 'test:2');
@@ -627,8 +627,8 @@ recipe
     let recipe = manifest.recipes[0];
     let Foo = manifest.findSchemaByName('Foo').entityClass();
     let DescriptionType = manifest.findSchemaByName('Description').entityClass();
-    recipe.handles[0].mapToView({id: 'test:1', type: Foo.type});
-    recipe.handles[1].mapToView({id: 'test:2', type: DescriptionType.type.setViewOf()});
+    recipe.handles[0].mapToStorage({id: 'test:1', type: Foo.type});
+    recipe.handles[1].mapToStorage({id: 'test:2', type: DescriptionType.type.setViewOf()});
     let arc = createTestArc();
     let fooView = await arc.createHandle(Foo.type, undefined, 'test:1');
     let descriptionView = await arc.createHandle(DescriptionType.type.setViewOf(), undefined, 'test:2');

--- a/runtime/test/manifest-test.js
+++ b/runtime/test/manifest-test.js
@@ -693,7 +693,7 @@ ${particleStr1}
       },
     };
     let manifest = await Manifest.load('the.manifest', loader);
-    let view = manifest.findHandleByName('View0');
+    let view = manifest.findStorageByName('View0');
     assert(view);
     assert.deepEqual(await view.toList(), [
       {
@@ -735,7 +735,7 @@ Error parsing JSON from 'EntityList' (Unexpected token h in JSON at position 1)'
 
       view View0 of [Thing] in EntityList
     `, {fileName: 'the.manifest'});
-    let view = manifest.findHandleByName('View0');
+    let view = manifest.findStorageByName('View0');
     assert(view);
     assert.deepEqual(await view.toList(), [
       {
@@ -750,9 +750,9 @@ Error parsing JSON from 'EntityList' (Unexpected token h in JSON at position 1)'
   it('resolves view names to ids', async () => {
     let manifestSource = `
         schema Thing
-        view View0 of [Thing] in 'entities.json'
+        store Store0 of [Thing] in 'entities.json'
         recipe
-          map View0 as myView`;
+          map Store0 as myStore`;
     let entitySource = JSON.stringify([]);
     let loader = {
       loadResource(path) {
@@ -770,7 +770,7 @@ Error parsing JSON from 'EntityList' (Unexpected token h in JSON at position 1)'
     };
     let manifest = await Manifest.load('the.manifest', loader);
     let recipe = manifest.recipes[0];
-    assert.deepEqual(recipe.toString(), 'recipe\n  map \'manifest:the.manifest:view0\' as myView');
+    assert.deepEqual(recipe.toString(), 'recipe\n  map \'manifest:the.manifest:store0\' as myStore');
   });
   it('has prettyish syntax errors', async () => {
     try {

--- a/runtime/test/multiplexer-test.js
+++ b/runtime/test/multiplexer-test.js
@@ -51,7 +51,7 @@ describe('Multiplexer', function() {
 
     let arc = new Arc({id: 'test', context: manifest, slotComposer});
     let handle = await arc.createHandle(barType.setViewOf(), null, 'test:1');
-    recipe.handles[0].mapToView(handle);
+    recipe.handles[0].mapToStorage(handle);
     assert(recipe.normalize());
     assert(recipe.isResolved());
 

--- a/runtime/test/particle-api-test.js
+++ b/runtime/test/particle-api-test.js
@@ -79,8 +79,8 @@ describe('particle-api', function() {
     let Result = manifest.findSchemaByName('Result').entityClass();
     let resultHandle = await arc.createHandle(Result.type, undefined, 'test:2');
     let recipe = manifest.recipes[0];
-    recipe.handles[0].mapToView(inputView);
-    recipe.handles[1].mapToView(resultHandle);
+    recipe.handles[0].mapToStorage(inputView);
+    recipe.handles[1].mapToStorage(resultHandle);
     recipe.normalize();
     await arc.instantiate(recipe);
 
@@ -138,7 +138,7 @@ describe('particle-api', function() {
     let Result = manifest.findSchemaByName('Result').entityClass();
     let resultHandle = await arc.createHandle(Result.type, undefined, 'test:1');
     let recipe = manifest.recipes[0];
-    recipe.handles[0].mapToView(resultHandle);
+    recipe.handles[0].mapToStorage(resultHandle);
     recipe.normalize();
     await arc.instantiate(recipe);
 
@@ -233,7 +233,7 @@ describe('particle-api', function() {
     let Result = manifest.findSchemaByName('Result').entityClass();
     let resultHandle = await arc.createHandle(Result.type, undefined, 'test:1');
     let recipe = manifest.recipes[0];
-    recipe.handles[0].mapToView(resultHandle);
+    recipe.handles[0].mapToStorage(resultHandle);
     recipe.normalize();
     await arc.instantiate(recipe);
 
@@ -346,8 +346,8 @@ describe('particle-api', function() {
     inputsView.store({id: '2', rawData: {value: 'world'}});
     let resultsView = await arc.createHandle(Result.type.setViewOf(), undefined, 'test:2');
     let recipe = manifest.recipes[0];
-    recipe.handles[0].mapToView(inputsView);
-    recipe.handles[1].mapToView(resultsView);
+    recipe.handles[0].mapToStorage(inputsView);
+    recipe.handles[1].mapToStorage(resultsView);
     recipe.normalize();
     await arc.instantiate(recipe);
 

--- a/runtime/test/particle-shape-loading-test.js
+++ b/runtime/test/particle-shape-loading-test.js
@@ -112,17 +112,17 @@ describe('particle-shape-loading', function() {
     let recipeShapeView = recipe.newHandle();
     particle.connections['particle'].connectToHandle(recipeShapeView);
     recipeShapeView.fate = 'use';
-    recipeShapeView.mapToView(shapeView);
+    recipeShapeView.mapToStorage(shapeView);
 
     let recipeOutView = recipe.newHandle();
     particle.connections['output'].connectToHandle(recipeOutView);
     recipeOutView.fate = 'use';
-    recipeOutView.mapToView(outView);
+    recipeOutView.mapToStorage(outView);
 
     let recipeInView = recipe.newHandle();
     particle.connections['input'].connectToHandle(recipeInView);
     recipeInView.fate = 'use';
-    recipeInView.mapToView(inView);
+    recipeInView.mapToStorage(inView);
 
     assert(recipe.normalize(), 'can\'t normalize recipe');
     assert(recipe.isResolved(), 'recipe isn\'t resolved');

--- a/runtime/test/planner-tests.js
+++ b/runtime/test/planner-tests.js
@@ -219,9 +219,9 @@ describe('AssignOrCopyRemoteViews', function() {
       `));
 
       let schema = manifest.findSchemaByName('Foo');
-      manifest.newHandle(schema.type.setViewOf(), 'Test1', 'test-1', ['#tag1']);
-      manifest.newHandle(schema.type.setViewOf(), 'Test2', 'test-2', ['#tag2']);
-      manifest.newHandle(schema.type.setViewOf(), 'Test2', 'test-3', []);
+      manifest.newStore(schema.type.collectionOf(), 'Test1', 'test-1', ['#tag1']);
+      manifest.newStore(schema.type.collectionOf(), 'Test2', 'test-2', ['#tag2']);
+      manifest.newStore(schema.type.collectionOf(), 'Test2', 'test-3', []);
 
       let arc = StrategyTestHelper.createTestArc('test-plan-arc', manifest, 'dom');
 

--- a/runtime/test/strategies/match-particle-by-verb-tests.js
+++ b/runtime/test/strategies/match-particle-by-verb-tests.js
@@ -61,8 +61,8 @@ describe('MatchParticleByVerb', function() {
   it('particles by verb recipe fully resolved', async () => {
     let manifest = (await Manifest.parse(manifestStr));
     let recipe = manifest.recipes[0];
-    recipe.handles[0].mapToView({id: 'test1', type: manifest.findSchemaByName('Height').entityClass().type});
-    recipe.handles[1].mapToView({id: 'test2', type: manifest.findSchemaByName('Energy').entityClass().type});
+    recipe.handles[0].mapToStorage({id: 'test1', type: manifest.findSchemaByName('Height').entityClass().type});
+    recipe.handles[1].mapToStorage({id: 'test2', type: manifest.findSchemaByName('Energy').entityClass().type});
 
     let arc = StrategyTestHelper.createTestArc('test-plan-arc', manifest, 'dom');
 

--- a/runtime/test/type-integration-test.js
+++ b/runtime/test/type-integration-test.js
@@ -41,7 +41,7 @@ describe('type integration', () => {
     let manifest = await setup();
 
     let recipe = manifest.recipes[1];
-    recipe.handles[0].mapToView({id: 'test1', type: manifest.findSchemaByName('Product').entityClass().type.setViewOf()});
+    recipe.handles[0].mapToStorage({id: 'test1', type: manifest.findSchemaByName('Product').entityClass().type.setViewOf()});
     assert(recipe.normalize());
     assert(recipe.isResolved());
     assert(recipe.handles.length == 1);
@@ -52,7 +52,7 @@ describe('type integration', () => {
     let manifest = await setup();
 
     let recipe = manifest.recipes[1];
-    recipe.handles[0].mapToView({id: 'test1', type: manifest.findSchemaByName('Lego').entityClass().type.setViewOf()});
+    recipe.handles[0].mapToStorage({id: 'test1', type: manifest.findSchemaByName('Lego').entityClass().type.setViewOf()});
     assert(recipe.normalize());
     assert(recipe.isResolved());
     assert(recipe.handles.length == 1);

--- a/runtime/type.js
+++ b/runtime/type.js
@@ -88,7 +88,10 @@ class Type {
   static newCollection(type) {
     return Type.newSetView(type);
   }
-
+  collectionOf() {
+    return Type.newSetView(this);
+  }
+  
   mergeTypeVariablesByName(variableMap) {
     if (this.isVariable) {
       let name = this.variable.name;

--- a/shell/app-shell-prototype/elements/arc-handle.js
+++ b/shell/app-shell-prototype/elements/arc-handle.js
@@ -57,7 +57,7 @@ class ArcHandle extends Xen.Base {
     id = id || arc.generateID();
     // context-handles are for `map`, `copy`, `?`
     // arc-handles are for `use`, `?`
-    const factory = asContext ? arc.context.newHandle.bind(arc.context) : arc.createHandle.bind(arc);
+    const factory = asContext ? arc.context.newStore.bind(arc.context) : arc.createHandle.bind(arc);
     const handle = await factory(typeOf, name, id, tags);
     if (description) {
       handle.description = description;

--- a/shell/app-shell-prototype/lib/arcs-utils.js
+++ b/shell/app-shell-prototype/lib/arcs-utils.js
@@ -130,12 +130,12 @@ const ArcsUtils = {
       }
   },
   async _requireHandle(arc, type, name, id, tags) {
-    let handle = arc.context.findHandleById(id);
-    if (!handle) {
-      handle = await arc.context.newHandle(type, name, id, tags);
+    let store = arc.context.findStorageById(id);
+    if (!store) {
+      store = await arc.context.newStore(type, name, id, tags);
       log('synthesized handle', id, tags);
     }
-    return handle;
+    return store;
   },
   metaTypeFromType(type) {
     return JSON.stringify(type ? type.toLiteral() : null);

--- a/shell/app-shell/elements/arc-handle.js
+++ b/shell/app-shell/elements/arc-handle.js
@@ -57,7 +57,7 @@ class ArcHandle extends Xen.Base {
     id = id || arc.generateID();
     // context-handles are for `map`, `copy`, `?`
     // arc-handles are for `use`, `?`
-    const factory = asContext ? arc.context.newHandle.bind(arc.context) : arc.createHandle.bind(arc);
+    const factory = asContext ? arc.context.newStore.bind(arc.context) : arc.createHandle.bind(arc);
     const handle = await factory(typeOf, name, id, tags);
     if (description) {
       handle.description = description;

--- a/shell/app-shell/elements/remote-friends-shared-handles.js
+++ b/shell/app-shell/elements/remote-friends-shared-handles.js
@@ -164,7 +164,7 @@ class RemoteFriendsSharedHandles extends Xen.Base {
     }
   }
   async _requireHandle(arc, id, type, name, tags) {
-    return arc.context.findHandleById(id) || await arc.context.newHandle(type, name, id, tags);
+    return arc.context.findStorageById(id) || await arc.context.newStore(type, name, id, tags);
   }
   _addHandleData(handle, data, friend) {
     ArcsUtils.addHandleData(handle, data);

--- a/shell/app-shell/lib/arcs-utils.js
+++ b/shell/app-shell/lib/arcs-utils.js
@@ -130,12 +130,12 @@ const ArcsUtils = {
       }
   },
   async _requireHandle(arc, type, name, id, tags) {
-    let handle = arc.context.findHandleById(id);
-    if (!handle) {
-      handle = await arc.context.newHandle(type, name, id, tags);
+    let store = arc.context.findStorageById(id);
+    if (!store) {
+      store = await arc.context.newStore(type, name, id, tags);
       log('synthesized handle', id, tags);
     }
-    return handle;
+    return store;
   },
   metaTypeFromType(type) {
     return JSON.stringify(type ? type.resolvedType().toLiteral() : null);


### PR DESCRIPTION
@dstockwell what do you think about the changes of 'handle' to 'storage' in manifest.js? I think they'll need to be copies across to arcs eventually so I'm open to discussion, but this seems more correct.