### PR TITLE
Rework social muxing toward Post-focused embedded recipes.

### DIFF
--- a/shell/artifacts/Social/Particles.manifest
+++ b/shell/artifacts/Social/Particles.manifest
@@ -6,6 +6,7 @@
 // subject to an additional IP rights grant found at
 // http://polymer.github.io/PATENTS.txt
 
+import 'https://$cdn/artifacts/Common/List.manifest'
 import 'https://$cdn/artifacts/People/Person.schema'
 import 'https://$cdn/artifacts/People/Avatar.schema'
 import 'https://$cdn/artifacts/Words/Stats.schema'
@@ -32,18 +33,12 @@ particle WritePosts in 'source/WritePosts.js'
   consume root
   description `write posts`
 
-// TODO(wkorman): Should we just use HostedParticleShape as
-// defined in Multiplexer.manifest directly?
-shape RenderParticleShape
-  RenderParticleShape(in Post)
-  consume
-
 particle EditPost in 'source/EditPost.js'
-  EditPost(host RenderParticleShape renderParticle, inout Post post, inout [Post] posts, in Person user)
+  EditPost(host HostedParticleShape renderParticle, inout Post post, inout [Post] posts, in Person user)
   consume content
   description `edit a post`
 
 particle PostMuxer in 'source/PostMuxer.js'
-  PostMuxer(in [Post] list, in [Avatar] avatars)
+  PostMuxer(in [Post] list)
   consume set of item
   description `show morphed ${list}`

--- a/shell/artifacts/Social/Particles.manifest
+++ b/shell/artifacts/Social/Particles.manifest
@@ -6,10 +6,10 @@
 // subject to an additional IP rights grant found at
 // http://polymer.github.io/PATENTS.txt
 
-import 'https://$cdn/artifacts/Common/List.manifest'
-import 'https://$cdn/artifacts/People/Person.schema'
-import 'https://$cdn/artifacts/People/Avatar.schema'
-import 'https://$cdn/artifacts/Words/Stats.schema'
+import '../Common/List.manifest'
+import '../People/Person.schema'
+import '../People/Avatar.schema'
+import '../Words/Stats.schema'
 import 'Post.schema'
 import 'BlogMetadata.schema'
 

--- a/shell/artifacts/Social/Social.recipes
+++ b/shell/artifacts/Social/Social.recipes
@@ -7,9 +7,9 @@
 // http://polymer.github.io/PATENTS.txt
 
 import 'Particles.manifest'
-import 'https://$cdn/artifacts/Common/CopyCollection.manifest'
-import 'https://$cdn/artifacts/Common/Detail.manifest'
-import 'https://$cdn/artifacts/Common/List.manifest'
+import '../Common/CopyCollection.manifest'
+import '../Common/Detail.manifest'
+import '../Common/List.manifest'
 
 // Allows creating multiple posts by the author and viewing all posts created
 // in this Arc.

--- a/shell/artifacts/Social/Social.recipes
+++ b/shell/artifacts/Social/Social.recipes
@@ -7,6 +7,7 @@
 // http://polymer.github.io/PATENTS.txt
 
 import 'Particles.manifest'
+import 'https://$cdn/artifacts/Common/CopyCollection.manifest'
 import 'https://$cdn/artifacts/Common/Detail.manifest'
 import 'https://$cdn/artifacts/Common/List.manifest'
 
@@ -54,12 +55,16 @@ recipe
     people <- people
 
 recipe
-  map #BOXED_stats as posts
-  // TODO(wkorman): Merge together posts and stats with CopyCollection if needed.
-  // map #BOXED_posts as posts
-  map #BOXED_avatar as avatars
+  map #BOXED_stats as game_posts
+  map #BOXED_posts as social_posts
+  create as posts
+  CopyCollection
+    input <- game_posts
+    output -> posts
+  CopyCollection
+    input <- social_posts
+    output -> posts
   List
     items = posts
   PostMuxer
     list = posts
-    avatars = avatars

--- a/shell/artifacts/Social/source/EditPost.js
+++ b/shell/artifacts/Social/source/EditPost.js
@@ -96,6 +96,7 @@ defineParticle(({DomParticle, html, log}) => {
                                  .buildManifest`
 ${renderParticle}
 recipe
+  map #BOXED_avatar as avatars
   use '{{item_id}}' as v1
   slot '{{slot_id}}' as s1
   {{other_views}}

--- a/shell/artifacts/Social/source/ShowPosts.js
+++ b/shell/artifacts/Social/source/ShowPosts.js
@@ -209,8 +209,8 @@ defineParticle(({DomParticle, resolver, log}) => {
       return this._avatarToStyle(avatarUrl);
     }
     _blogDescription(user, metadata) {
-      const blogDescription = (metadata && metadata.description) ?
-          metadata.description : '';
+      const blogDescription =
+          (metadata && metadata.description) ? metadata.description : '';
       return {
         $template: (metadata && metadata.blogOwner == user.id) ?
             'blog-description-editable' :

--- a/shell/artifacts/Words/Board.schema
+++ b/shell/artifacts/Words/Board.schema
@@ -7,6 +7,12 @@
 // http://polymer.github.io/PATENTS.txt
 
 schema Board
+  // A unique game identifier to allow shared data to stitch together all of the
+  // information regarding a single game from separate boxed instances.
+  // Eventually this usage could be revised to either use the Board entity id,
+  // or to have the social feed instantiate the source arc directly which would
+  // then implicitly pull in all of the relevant entity data.
+  Text gameId
   // A string list of (Character, Tile.Style) comprising the board laid out in
   // an NxN grid filled from left to right starting at top left. Tile.Style is
   // encoded as an integer used to map to the appropriate style enum. So an

--- a/shell/artifacts/Words/GamePane.manifest
+++ b/shell/artifacts/Words/GamePane.manifest
@@ -6,9 +6,9 @@
 // subject to an additional IP rights grant found at
 // http://polymer.github.io/PATENTS.txt
 
-import 'https://$cdn/artifacts/Common/List.manifest'
-import 'https://$cdn/artifacts/People/Person.schema'
-import 'https://$cdn/artifacts/Social/Post.schema'
+import '../Common/List.manifest'
+import '../People/Person.schema'
+import '../Social/Post.schema'
 import 'Board.schema'
 import 'Move.schema'
 import 'Stats.schema'

--- a/shell/artifacts/Words/GamePane.manifest
+++ b/shell/artifacts/Words/GamePane.manifest
@@ -6,20 +6,15 @@
 // subject to an additional IP rights grant found at
 // http://polymer.github.io/PATENTS.txt
 
+import 'https://$cdn/artifacts/Common/List.manifest'
+import 'https://$cdn/artifacts/People/Person.schema'
+import 'https://$cdn/artifacts/Social/Post.schema'
 import 'Board.schema'
 import 'Move.schema'
 import 'Stats.schema'
 
-import 'https://$cdn/artifacts/People/Person.schema'
-
-// TODO(wkorman): Should we just use HostedParticleShape as
-// defined in Multiplexer.manifest directly?
-shape RenderParticleShape
-  RenderParticleShape(in Stats)
-  consume
-
 particle GamePane in 'source/GamePane.js'
-  GamePane(host RenderParticleShape renderParticle, in Person person, inout Board board, inout Move move, inout Stats stats)
+  GamePane(host HostedParticleShape renderParticle, in Person person, inout Board board, inout Move move, inout Stats stats, inout Post post)
   affordance dom
   consume root
   description `play Words`

--- a/shell/artifacts/Words/Move.schema
+++ b/shell/artifacts/Words/Move.schema
@@ -7,6 +7,8 @@
 // http://polymer.github.io/PATENTS.txt
 
 schema Move
+  // The unique game id of the associated Words game.
+  Text gameId
   // A string list of tuples as [(x1, y1), (x2, y2)] representing the
   // contiguous characters selected by the user for the move.
   // TODO(wkorman): Change this to use Number.

--- a/shell/artifacts/Words/ShowSingleStats.manifest
+++ b/shell/artifacts/Words/ShowSingleStats.manifest
@@ -6,7 +6,7 @@
 // subject to an additional IP rights grant found at
 // http://polymer.github.io/PATENTS.txt
 
-import 'https://$cdn/artifacts/Social/Post.schema'
+import '../Social/Post.schema'
 
 particle ShowSingleStats in 'source/ShowSingleStats.js'
   ShowSingleStats(in Post post)

--- a/shell/artifacts/Words/ShowSingleStats.manifest
+++ b/shell/artifacts/Words/ShowSingleStats.manifest
@@ -6,9 +6,9 @@
 // subject to an additional IP rights grant found at
 // http://polymer.github.io/PATENTS.txt
 
-import 'Stats.schema'
+import 'https://$cdn/artifacts/Social/Post.schema'
 
 particle ShowSingleStats in 'source/ShowSingleStats.js'
-  ShowSingleStats(in Stats stats)
+  ShowSingleStats(in Post post)
   consume item
   description `show ${stats}`

--- a/shell/artifacts/Words/Stats.schema
+++ b/shell/artifacts/Words/Stats.schema
@@ -6,10 +6,9 @@
 // subject to an additional IP rights grant found at
 // http://polymer.github.io/PATENTS.txt
 
-import 'https://$cdn/artifacts/Social/Post.schema'
-
-schema Stats extends Post
-  // TODO(wkorman): Add a copy of game state (in progress or game over).
+schema Stats
+  // The unique game id of the associated Words game.
+  Text gameId
   // Current or ending (if over) game score.
   Number score
   // Total number of moves made in game thus far (or total, if over).
@@ -26,3 +25,11 @@ schema Stats extends Post
   Text highestScoringWord
   // Highest scoring word (score)
   Number highestScoringWordScore
+  // TODO(wkorman): Below are temporary fields copied from Post while we
+  // rework social feed to use muxing embedded recipes.
+  // Time this post was created in milliseconds since the epoch.
+  Number createdTimestamp
+  // The primary message content of the post.
+  Text message
+  // The opaque user id of the post author.
+  Text author

--- a/shell/artifacts/Words/Words.recipes
+++ b/shell/artifacts/Words/Words.recipes
@@ -13,9 +13,11 @@ recipe
   create #board as board
   create #move as move
   create #stats as stats
+  create #post as post
   GamePane
     move = move
     board = board
     stats = stats
+    post = post
     person <- person
     renderParticle = ShowSingleStats

--- a/shell/artifacts/Words/source/Scoring.js
+++ b/shell/artifacts/Words/source/Scoring.js
@@ -83,13 +83,7 @@ class Scoring {
         stats.longestWordScore}). Score: ${stats.score}. Moves: ${
         stats.moveCount}.`;
   }
-  static applyMoveStats(
-      renderParticleSpec,
-      renderRecipe,
-      user,
-      stats,
-      word,
-      score) {
+  static applyMoveStats(gameId, user, stats, word, score) {
     let updatedValues = {
       highestScoringWord: stats.highestScoringWord,
       highestScoringWordScore: stats.highestScoringWordScore,
@@ -110,6 +104,7 @@ class Scoring {
       updatedValues.longestWordScore = score;
     }
 
+    updatedValues.gameId = gameId;
     updatedValues.score = stats.score + score;
     updatedValues.moveCount = stats.moveCount + 1;
 
@@ -119,17 +114,17 @@ class Scoring {
     updatedValues.message = Scoring.scoreToMessage(updatedValues);
     updatedValues.author = user.id;
 
-    updatedValues.renderParticleSpec = renderParticleSpec;
-    updatedValues.renderRecipe = renderRecipe;
-
     return updatedValues;
   }
-  static create(user) {
+  static create(user, gameId) {
     const now = Date.now();
     return {
+      gameId,
       score: 0,
       moveCount: 0,
       startstamp: now,
+      // TODO(wkorman): Write the below into a Post entity that references
+      // the associated Stats instance and other affiliated game entities.
       author: user.id,
       createdTimestamp: now,
       message: 'Word Puzzle Game Stats - New game.'

--- a/shell/artifacts/Words/source/ShowSingleStats.js
+++ b/shell/artifacts/Words/source/ShowSingleStats.js
@@ -23,9 +23,9 @@ defineParticle(({DomParticle, html}) => {
     scoreToMessage(stats) {
       return `Words Puzzle Game Stats -- Highest scoring word: ${
           stats.highestScoringWord} (${
-          stats.highestScoringWordScore}). Longest word: ${stats.longestWord} (${
-          stats.longestWordScore}). Score: ${stats.score}. Moves: ${
-          stats.moveCount}.`;
+          stats.highestScoringWordScore}). Longest word: ${
+          stats.longestWord} (${stats.longestWordScore}). Score: ${
+          stats.score}. Moves: ${stats.moveCount}.`;
     }
     render({stats}) {
       const message = stats ? this.scoreToMessage(stats) : '';

--- a/shell/artifacts/Words/source/TileBoard.js
+++ b/shell/artifacts/Words/source/TileBoard.js
@@ -29,6 +29,7 @@ const CHANCE_OF_FIRE_ON_REFILL = 0.1;
 class TileBoard {
   constructor(board) {
     console.assert(board, 'Input board values must not be null.');
+    this._gameId = board.gameId;
     this._shuffleAvailableCount = board.shuffleAvailableCount;
     this._state = board.state !== undefined ?
         TileBoard.NumberToState[board.state] :
@@ -62,6 +63,9 @@ class TileBoard {
   }
   get size() {
     return TILE_COUNT;
+  }
+  get gameId() {
+    return this._gameId;
   }
   tileAt(x, y) {
     return this._rows[y][x];
@@ -221,7 +225,12 @@ class TileBoard {
     for (let i = 0; i < TILE_COUNT; i++) {
       tiles.push(new Tile(i, TileBoard.pickCharWithFrequencies()));
     }
+    // Unique id generation is a hack swiped from ArcsUtils. We could perhaps
+    // use the Board entity id, or a more legitimate id generator if needed.
+    const gameId = Date.now().toString(36).substr(2) +
+        Math.random().toString(36).substr(2);
     return {
+      gameId,
       letters: tiles.map(t => `${t.letter}${t.styleAsNumber}`).join(''),
       shuffleAvailableCount: DEFAULT_SHUFFLE_AVAILABLE_COUNT,
       state: TileBoard.StateToNumber[TileBoard.State.ACTIVE]

--- a/shell/artifacts/Words/test/scoring-test.js
+++ b/shell/artifacts/Words/test/scoring-test.js
@@ -89,8 +89,6 @@ describe('Scoring', function() {
       delete actualCopy.author;
       delete actualCopy.createdTimestamp;
       delete actualCopy.message;
-      delete actualCopy.renderParticleSpec;
-      delete actualCopy.renderRecipe;
       assert.deepEqual(actualCopy, expected);
     };
 
@@ -104,9 +102,11 @@ describe('Scoring', function() {
         moveCount: 0,
         startstamp: 7331
       };
+      const gameId = '8118';
       const user = {id: '42'};
-      const actual = Scoring.applyMoveStats('renderParticleSpec', 'renderRecipe', user, stats, 'short', 38);
+      const actual = Scoring.applyMoveStats(gameId, user, stats, 'short', 38);
       validateStats(actual, {
+        gameId,
         highestScoringWord: 'highest',
         highestScoringWordScore: 43,
         longestWord: 'longest',
@@ -127,9 +127,11 @@ describe('Scoring', function() {
         moveCount: 0,
         startstamp: 7331
       };
+      const gameId = '8118';
       const user = {id: '42'};
-      const actual = Scoring.applyMoveStats('renderParticleSpec', 'renderRecipe', user, stats, 'higher', 100);
+      const actual = Scoring.applyMoveStats(gameId, user, stats, 'higher', 100);
       validateStats(actual, {
+        gameId,
         highestScoringWord: 'higher',
         highestScoringWordScore: 100,
         longestWord: 'longest',
@@ -150,9 +152,11 @@ describe('Scoring', function() {
         moveCount: 0,
         startstamp: 7331
       };
+      const gameId = '8118';
       const user = {id: '42'};
-      const actual = Scoring.applyMoveStats('renderParticleSpec', 'renderRecipe', user, stats, 'higher', 100);
+      const actual = Scoring.applyMoveStats(gameId, user, stats, 'higher', 100);
       validateStats(actual, {
+        gameId,
         highestScoringWord: 'higher',
         highestScoringWordScore: 100,
         longestWord: 'longest',
@@ -173,9 +177,11 @@ describe('Scoring', function() {
         moveCount: 0,
         startstamp: 7331
       };
+      const gameId = '8118';
       const user = {id: '42'};
-      const actual = Scoring.applyMoveStats('renderParticleSpec', 'renderRecipe', user, stats, 'evenlonger', 23);
+      const actual = Scoring.applyMoveStats(gameId, user, stats, 'evenlonger', 23);
       validateStats(actual, {
+        gameId,
         highestScoringWord: 'highest',
         highestScoringWordScore: 43,
         longestWord: 'evenlonger',
@@ -196,9 +202,11 @@ describe('Scoring', function() {
         moveCount: 0,
         startstamp: 7331
       };
+      const gameId = '8118';
       const user = {id: '42'};
-      const actual = Scoring.applyMoveStats('renderParticleSpec', 'renderRecipe', user, stats, 'evenlonger', 23);
+      const actual = Scoring.applyMoveStats(gameId, user, stats, 'evenlonger', 23);
       validateStats(actual, {
+        gameId,
         highestScoringWord: 'highest',
         highestScoringWordScore: 43,
         longestWord: 'evenlonger',
@@ -219,9 +227,11 @@ describe('Scoring', function() {
         moveCount: 345,
         startstamp: 7331
       };
+      const gameId = '8118';
       const user = {id: '42'};
-      const actual = Scoring.applyMoveStats('renderParticleSpec', 'renderRecipe', user, stats, 'evenlonger', 2300);
+      const actual = Scoring.applyMoveStats(gameId, user, stats, 'evenlonger', 2300);
       validateStats(actual, {
+        gameId,
         highestScoringWord: 'evenlonger',
         highestScoringWordScore: 2300,
         longestWord: 'evenlonger',


### PR DESCRIPTION
- Moving away from Stats schema subclassing Post.
- Introducing unique game id for Words to allow (in subsequent work) a new social feed that uses embedded recipes to stitch together shared game data for a single game. Maybe we'll end up using entity ids but I figure we can try this for now.

The current Social demo feed recipe should continue to work after this change as we've copied the relevant Post fields into the game Stats schema directly.

Part of https://github.com/PolymerLabs/arcs/issues/842