### PR TITLE
Store image size post-upload and use to improve layout performance.

### DIFF
--- a/shell/artifacts/Social/Post.schema
+++ b/shell/artifacts/Social/Post.schema
@@ -16,6 +16,10 @@ schema Post
   // An optional image associated with the message content for the post.
   // Populated only if the user chose to attach one when creating/editing.
   URL image
+  // The width of the full size image in pixels, if an image is present.
+  Number imageWidth
+  // The height of the full size image in pixels, if an image is present.
+  Number imageHeight
   // A recipe that can be used to display this post's content. Allows for
   // polymorphic display of and interaction with the post, as the
   // particles creating or updating the Post entity can set whatever

--- a/shell/artifacts/Social/source/EditPost.js
+++ b/shell/artifacts/Social/source/EditPost.js
@@ -92,11 +92,11 @@ defineParticle(({DomParticle, html, log}) => {
         this.savePost(renderParticleSpec, renderRecipe, user, message, image);
       }
       const saveButtonActive =
-          this.hasContent(message) || this.hasContent(image);
+          this.hasContent(message) || (image && this.hasContent(image.url));
       const model = {
         saveButtonActive,
         message: message || '',
-        image: image || '',
+        image: image ? image.url : '',
         hideUploadProgress: !uploading,
         uploadPercent
       };
@@ -132,11 +132,13 @@ recipe
         renderParticleSpec,
         renderRecipe,
         message,
-        image,
+        image: image.url,
+        imageWidth: image.width,
+        imageHeight: image.height,
         createdTimestamp: Date.now(),
         author: user.id
       });
-      this.setState({savePost: false, message: '', image: ''});
+      this.setState({savePost: false, message: '', image: null});
     }
     onTextInput(e) {
       this.setState({message: e.data.value});

--- a/shell/artifacts/Social/source/ShowPosts.js
+++ b/shell/artifacts/Social/source/ShowPosts.js
@@ -81,7 +81,6 @@ defineParticle(({DomParticle, resolver, log}) => {
   }
   [${host}] [msg] [content] img {
     display: block;
-    width: 256px;
   }
   [${host}] [owner] {
     font-size: 14pt;
@@ -114,7 +113,7 @@ defineParticle(({DomParticle, resolver, log}) => {
             <br>
           </div>
           <div content value="{{id}}">
-            <img src="{{image}}">
+            <img src="{{image}}" width="{{imageWidth}}" height="{{imageHeight}}">
             <span>{{message}}</span>
           </div>
         </div>
@@ -223,10 +222,32 @@ defineParticle(({DomParticle, resolver, log}) => {
         return b.createdTimestamp - a.createdTimestamp;
       });
     }
-    _postToModel(visible, {createdTimestamp, message, image, id, author}) {
+    clampSize(width, height) {
+      if (!width || !height) {
+        return {clampedWidth: width, clampedHeight: height};
+      }
+      const ratio = width / height;
+      const maxWidth = 256;
+      const clampedWidth = Math.min(maxWidth, width);
+      const clampedHeight = clampedWidth / ratio;
+      return {clampedWidth, clampedHeight};
+    }
+    _postToModel(visible, {
+      createdTimestamp,
+      message,
+      image,
+      imageWidth,
+      imageHeight,
+      id,
+      author
+    }) {
+      const {clampedWidth, clampedHeight} =
+          this.clampSize(imageWidth, imageHeight);
       return {
         message,
         image: image || '',
+        imageWidth: clampedWidth,
+        imageHeight: clampedHeight,
         id,
         time: new Date(createdTimestamp).toLocaleDateString('en-US', {
           'month': 'short',


### PR DESCRIPTION
This fixes a re-layout that happens in the social feed if we don't set both an explicit width and height for image elements, plus, I think it's always better to have image dimensions persistently stored along with image data (or a reference to the image data) since inevitably one ends up needing it for some reason.

Approach derived from https://stackoverflow.com/questions/7460272/getting-image-dimensions-using-javascript-file-api