### PR TITLE
Show overview traces in our devtools extension.

### DIFF
--- a/devtools/src/arcs-dataflow.html
+++ b/devtools/src/arcs-dataflow.html
@@ -328,7 +328,7 @@
       }
 
       _formatTimestamp(timestamp) {
-        return formatTime(timestamp, true /* with millis */);
+        return formatTime(timestamp, 3 /* with millis */);
       }
 
       _truncate(data) {
@@ -338,8 +338,7 @@
       }
 
       _indentPrint(thing) {
-        if (typeof thing === "string") thing = JSON.parse(thing)
-        return JSON.stringify(thing, null, 2);
+        return indentPrint(thing); // from arcs-shared
       }
 
       _operationCssClass(operation) {

--- a/devtools/src/arcs-devtools-app.html
+++ b/devtools/src/arcs-devtools-app.html
@@ -2,6 +2,7 @@
 <link rel="import" href="../bower_components/app-route/app-route.html">
 <link rel="import" href="../bower_components/iron-icons/iron-icons.html">
 <link rel="import" href="../bower_components/iron-icons/social-icons.html">
+<link rel="import" href="../bower_components/iron-icons/communication-icons.html">
 <link rel="import" href="../bower_components/iron-pages/iron-pages.html">
 <link rel="import" href="../bower_components/iron-selector/iron-selector.html">
 <link rel="import" href="../bower_components/neon-animation/web-animations.html">
@@ -15,6 +16,7 @@
 <link rel="import" href="arcs-communication-channel.html">
 <link rel="import" href="arcs-shared.html">
 <link rel="import" href="arcs-notifications.html">
+<link rel="import" href="arcs-tracing.html">
 <link rel="import" href="strategy-explorer/strategy-explorer.html">
 
 <dom-module id="arcs-devtools-app">
@@ -105,12 +107,14 @@
       <nav>
         <iron-selector selected="[[routeData.page]]" attr-for-selected="name" class="nav-list" role="navigation">
           <a name="overview" href="#overview"><iron-icon icon="timeline"></iron-icon>Overview</a>
+          <a name="traces" href="#traces"><iron-icon icon="communication:clear-all"></iron-icon>Traces</a>          
           <a name="dataflow" href="#dataflow"><iron-icon icon="swap-horiz"></iron-icon>Dataflow</a>
           <a name="strategyExplorer" href="#strategyExplorer"><iron-icon icon="settings-applications"></iron-icon>Strategy Explorer</a>
         </iron-selector>
       </nav>
-      <iron-pages selected="[[routeData.page]]" attr-for-selected="name" role="main" id="pages">
+      <iron-pages selected="[[routeData.page]]" attr-for-selected="name" selected-attribute="active" role="main" id="pages">
         <arcs-overview name="overview"></arcs-overview>
+        <arcs-tracing name="traces"></arcs-tracing>
         <arcs-dataflow id="dataflow" name="dataflow" query-params="{{queryParams}}"></arcs-dataflow>
         <strategy-explorer name="strategyExplorer"></strategy-explorer>
       </iron-pages>

--- a/devtools/src/arcs-overview.html
+++ b/devtools/src/arcs-overview.html
@@ -1,8 +1,6 @@
 <link rel="import" href="../bower_components/polymer/polymer-element.html">
 <link rel="import" href="arcs-shared.html">
 
-<script src="../bower_components/vis/dist/vis-network.min.js"></script>
-
 <dom-module id="arcs-overview">
   <template>
     <style include="shared-styles">

--- a/devtools/src/arcs-shared.html
+++ b/devtools/src/arcs-shared.html
@@ -1,3 +1,5 @@
+<script src="../bower_components/vis/dist/vis.min.js"></script>
+
 <dom-module id="shared-styles">
   <template>
     <style>
@@ -48,6 +50,21 @@
       .nav-list a iron-icon {
         margin-right: 3px;
       }
+      resizable-panels {
+        height: 100%;
+        --resizable-panels-knob: {
+          background-color: var(--light-gray);
+          border-left: 1px solid var(--mid-gray);
+        };
+      }
+      resizable-panels > aside {
+        background-color: var(--light-gray);
+        overflow: scroll;
+        width: 200px; /* Initial width before resizing */
+      }
+      resizable-panels > aside > * {
+        margin: 5px 5px 5px 2px;
+      }
     </style>
   </template>
 </dom-module>
@@ -55,12 +72,15 @@
 <script>
   const writeOps = ['set', 'store', 'clear', 'remove'];
 
-  const formatTime = function(timestamp, withMillis) {
+  function formatTime(timestamp, digits = 0) {
     let d = new Date(timestamp);
     let time = [ d.getHours(), d.getMinutes(), d.getSeconds() ].map(x => String(x).padStart(2, '0')).join(':');
-    if (withMillis) {
-      time += '.' + String(d.getMilliseconds()).padStart(3, '0');
-    }
+    if (digits > 0) time += (timestamp / 1000 % 1).toFixed(digits).substr(1);
     return time;
+  }
+
+  function indentPrint(thing) {
+    if (typeof thing === "string") thing = JSON.parse(thing)
+    return JSON.stringify(thing, null, 2);
   }
 </script>

--- a/devtools/src/arcs-tracing.html
+++ b/devtools/src/arcs-tracing.html
@@ -1,0 +1,278 @@
+<link rel="import" href="../bower_components/polymer/polymer-element.html">
+<link rel="import" href="../bower_components/resizable-panels/resizable-panels.html">
+<link rel="import" href="../bower_components/iron-icons/iron-icons.html">
+<link rel="import" href="../bower_components/iron-icons/editor-icons.html">
+<link rel="import" href="../bower_components/iron-icons/maps-icons.html">
+<link rel="import" href="../bower_components/iron-icons/image-icons.html">
+<link rel="import" href="arcs-shared.html">
+
+<dom-module id="arcs-tracing">
+  <link rel="import" type="css" href="../bower_components/vis/dist/vis-timeline-graph2d.min.css">
+  <template>
+    <style include="shared-styles">
+      :host {
+        display: block;
+      }
+      #timelineContainer {
+        width: 100%;
+        height: 100vh;
+      }
+      aside > div {
+        padding: 5px;
+        border: 1px solid var(--mid-gray);
+        background-color: white;
+      }
+      .controls {
+        text-align: center;
+      }
+      .buttons-panel {
+        display: flex;
+        justify-content: space-evenly;
+        margin-bottom: 5px;
+      }
+      .vis-timeline {
+        border: 0;
+      }
+      .vis-item.vis-background {
+        border: 4px solid transparent;
+        border-right: 4px solid rgba(150, 0, 0, .5);
+        border-left: 4px solid rgba(0, 150, 0, .5);
+      }
+      .vis-custom-time.startup {
+        /* Makes page startup time vertical line not draggable. */
+        pointer-events: none;
+      }
+    </style>
+    <resizable-panels>
+      <div id='timelineContainer'></div>
+      <aside>
+        <div class='controls'>
+          <div class='buttons-panel'>
+            <iron-icon on-click='_fit' title='Fit to events' icon="maps:zoom-out-map"></iron-icon>
+            <iron-icon on-click='_redraw' title='Redraw timeline if looks weird' icon="image:brush"></iron-icon>
+            <iron-icon id='download' on-click='_download' title='Download for inspection in chrome://tracing' icon="file-download"></iron-icon>
+          </div>
+          zoom-key: ctrl
+        </div>
+        <template is='dom-if' if='{{_selectedItem}}'>
+          <div id='details'>
+            [[_selectedItem.group]]: [[_selectedItem.content]]
+            <hr>
+            <div>Duration: [[_durationDetail(_selectedItem)]]</end>
+            <div>Start: [[_startTimeDetail(_selectedItem)]]</end>
+            <div>End: [[_endTimeDetail(_selectedItem)]]</end>
+            <hr>
+            Args:
+            <pre>[[_indentPrint(_selectedItem.args)]]</pre>
+          </div>
+        </template>
+      </aside>
+    </resizable-panels>
+  </template>
+  <script>
+    class ArcsTracing extends Polymer.Element {
+      static get is() { return 'arcs-tracing'; }
+
+      static get properties() {
+        return {
+          active: {
+            type: Boolean,
+            observer: '_activeChanged',
+            reflectToAttribute: true
+          }
+        }
+      }
+
+      constructor() {
+        super();
+        this._timeline = null;
+        this._items = new vis.DataSet({queue: true});
+        this._groups = new vis.DataSet({queue: true});
+        this._selectedItem = null;
+        this._timeBase = 0;
+      }
+
+      ready() {
+        super.ready();
+        if (!chrome.devtools || !chrome.devtools.inspectedWindow || !chrome.devtools.inspectedWindow.tabId) {
+          // Download only works right now when running Arcs in the browser.
+          this.$.download.style.display = 'none';
+        }
+      }
+
+      onMessages(messages) {
+        let needsRedraw = false;
+        let startEmpty = this._items.length === 0;
+        let flowEventsCache = new Map();
+
+        for (let msg of messages) {
+          switch (msg.messageType) {
+            case 'startup-time':
+              if (this._timeline) {
+                this._timeline.addCustomTime(msg.messageBody, 'startup');
+              } else {
+                this._startupTime = msg.messageBody;
+              }
+              break;
+            case 'trace-time-sync':
+              this._timeBase = msg.messageBody.localTime - msg.messageBody.traceTime / 1000;
+              break;
+            case 'trace':
+              needsRedraw = true;
+
+              let trace = msg.messageBody;
+              let group = trace.cat;
+
+              this._groups.update({
+                id: group,
+                content: group,
+                visible: this.active
+              });
+
+              let subgroup = trace.name;
+              if (subgroup.endsWith(' (async)')) subgroup = subgroup.slice(0, -8);
+
+              if (trace.ph === 'X') { // Duration event.
+                this._items.update({
+                  id: `${trace.cat}_${trace.name}_${trace.ts}`,
+                  content: trace.name,
+                  title: trace.name,
+                  group,
+                  subgroup,
+                  start: Math.floor(trace.ts / 1000 + this._timeBase),
+                  end: Math.ceil((trace.ts + trace.dur) / 1000 + this._timeBase),
+                  ts: trace.ts,
+                  dur: trace.dur,
+                  args: trace.args
+                });
+              } else { // Flow event.
+                // We store updated item in the flowEventsCache, to accumulate
+                // changes from messages in the same bundle, as changes on the
+                // _items dataset are only visible on flush().
+
+                let start, end;
+                start = end = [trace.ts / 1000 + this._timeBase];
+                for (let item of [
+                    this._items.get(trace.id),
+                    flowEventsCache.get(trace.id)]) {
+                  if (item) {
+                    start = Math.min(item.start, start);
+                    end = Math.max(item.end, end);
+                  }
+                }
+
+                let item = {
+                  id: trace.id,
+                  group,
+                  subgroup,
+                  type: 'background',
+                  start: Math.floor(start),
+                  end: Math.ceil(end)
+                };
+
+                flowEventsCache.set(trace.id, item);
+                this._items.update(item);
+              }
+              break;
+            case 'page-refresh':
+              needsRedraw = true;
+              this._groups.clear();
+              this._items.clear();
+              this._startupTime = null;
+              if (this._timeline) this._timeline.removeCustomTime('startup');
+              return;
+          }
+        }
+
+        if (!needsRedraw) return;
+
+        this._groups.flush();
+        this._items.flush();
+
+        if (!this._timeline && this._items.length > 0) {
+          this._timeline = new vis.Timeline(this.$.timelineContainer, this._items, this._groups, {
+            verticalScroll: true,
+            horizontalScroll: true,
+            zoomKey: 'ctrlKey',
+            width: '100%',
+            height: '100%',
+            stack: false,
+            stackSubgroups: true,
+            showCurrentTime: true,
+            orientation: 'top',
+            zoomMax: 1000 * 60 * 60, // Max zoom-out is 1 hour.
+            end: this._aBitInTheFuture(),
+          });
+          this._timeline.on('itemover', props => {
+            this._selectedItem = this._items.get(props.item);
+          });
+          if (this._startupTime) {
+            this._timeline.addCustomTime(this._startupTime, 'startup');
+          }
+        } else if (this._timeline && startEmpty) {
+          // Refocus on new events after a page refresh.
+          this._timeline.setWindow({
+            start: this._items.min('start').start,
+            end: this._aBitInTheFuture()
+          });
+        }
+      }
+
+      _aBitInTheFuture() {
+        return Date.now() + 2000;
+      }
+
+      _startTimeDetail(item) {
+        return formatTime(item.ts / 1000 + this._timeBase, 6 /* with Micros */);
+      }
+
+      _endTimeDetail(item) {
+        return formatTime((item.ts + item.dur) / 1000 + this._timeBase, 6 /* with Micros */);
+      }
+
+      _durationDetail(item) {
+        if (item.dur < 1000) {
+          return `${item.dur.toFixed(0)}µs`;
+        } else if (item.dur < 1000 * 1000) {
+          return `${(item.dur / 1000).toFixed(3)}ms`;
+        } else if (item.dir < 1000 * 1000 * 60) {
+          return `${(item.dur / (1000 * 1000)).toFixed(6)}s`;
+        }
+      }
+
+      _indentPrint(thing) {
+        return indentPrint(thing); // from arcs-shared
+      }
+
+      _activeChanged(active) {
+        // Avoiding jank by rendering only if it is an active page.
+        this._groups.forEach(g => {
+          this._groups.update({id: g.id, visible: active});
+        });
+        this._groups.flush();
+      }
+
+      _download() {
+        chrome.devtools.inspectedWindow.eval('Arcs.Tracing.download()');
+      }
+
+      _redraw() {
+        if (this._timeline) this._timeline.redraw();
+      }
+
+      _fit() {
+        if (this._timeline && this._items.length > 0) {
+          // There's timeline.fit(), but it doesn't leave margins and looks weird.
+          let start = this._items.min('start').start;
+          let end = this._items.max('end').end;
+          const fraction = (end - start) * .05;
+          start = start - fraction;
+          end = end + fraction;
+          this._timeline.setWindow({start, end});
+        }
+      }
+    }
+
+    window.customElements.define(ArcsTracing.is, ArcsTracing);
+  </script>
+</dom-module>

--- a/devtools/src/contentScript.js
+++ b/devtools/src/contentScript.js
@@ -1,3 +1,5 @@
+const startupTime = Date.now();
+
 let log = console.log.bind(console,
   '%cArcsExplorer',
   'background: #000; color: white; padding: 1px 6px 2px 7px; border-radius: 6px;');
@@ -31,6 +33,10 @@ chrome.runtime.onMessage.addListener(function(message, sender, sendResponse) {
           }
         };
       }
+      chrome.runtime.sendMessage([{
+        messageType: 'startup-time',
+        messageBody: startupTime
+      }]);
       break;
     case 'illuminate': {
       let shell = document.getElementsByTagName('app-shell')[0];
@@ -48,8 +54,5 @@ chrome.runtime.onMessage.addListener(function(message, sender, sendResponse) {
 });
 
 function addInitDebugScript() {
-  let script = document.createElement('script');
-  script.setAttribute('type', 'module');
-  script.setAttribute('src', chrome.extension.getURL('/src/run-init-debug.js'));
-  document.getElementsByTagName('body')[0].appendChild(script);
+  document.body.appendChild(Object.assign(document.createElement('script'), {type: 'module', src: chrome.extension.getURL('/src/run-init-debug.js')}));
 }

--- a/devtools/src/strategy-explorer/strategy-explorer.html
+++ b/devtools/src/strategy-explorer/strategy-explorer.html
@@ -21,26 +21,12 @@ http://polymer.github.io/PATENTS.txt
 <dom-module id='strategy-explorer'>
   <template>
     <style include='shared-styles'>
-      resizable-panels {
-        height: 100%;
-        --resizable-panels-knob: {
-          background-color: var(--light-gray);
-          border-left: 1px solid var(--mid-gray);
-        };
-      }
       .se-explorer-container {
         overflow: scroll;
         flex-grow: 1;
       }
       aside {
-        background-color: var(--light-gray);
-        overflow: scroll;
-        width: 200px; /* Initial width before resizing */
         flex-shrink: 0;
-      }
-      aside > * {
-        /* Weird CSS, but padding-right causes issues with resizable-panels */
-        margin: 5px 5px 5px 2px;
       }
     </style>
     <resizable-panels>

--- a/runtime/arc.js
+++ b/runtime/arc.js
@@ -11,7 +11,6 @@
 
 import runtime from './runtime.js';
 import assert from '../platform/assert-web.js';
-import tracing from '../tracelib/trace.js';
 import Type from './type.js';
 import Relation from './relation.js';
 import handle from './handle.js';
@@ -25,6 +24,7 @@ import StorageProviderFactory from './storage/storage-provider-factory.js';
 import scheduler from './scheduler.js';
 import {registerArc} from '../devtools/shared/arc-registry.js';
 import Id from './id.js';
+import {enableTracingAdapter} from './debug/tracing-adapter.js';
 
 class Arc {
   constructor({id, context, pecFactory, slotComposer, loader, storageKey, storageProviderFactory, speculative}) {
@@ -128,7 +128,7 @@ class Arc {
     for (let handle of this._activeRecipe.handles) {
       if (handle.fate == 'map')
         importSet.add(this.context.findManifestUrlForHandleId(handle.id));
-      else 
+      else
         handleSet.add(handle.id);
     }
     for (let url of importSet.values())
@@ -540,6 +540,7 @@ ${this.activeRecipe.toString()}`;
   }
 
   initDebug() {
+    enableTracingAdapter();
     this._debugging = true;
     this.pec.initDebug();
   }

--- a/runtime/debug/tracing-adapter.js
+++ b/runtime/debug/tracing-adapter.js
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright (c) 2018 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+import devtoolsChannelProvider from './devtools-channel-provider.js';
+import Tracing from '../../tracelib/trace.js';
+
+let streamingToDevtools = false;
+
+function enableTracingAdapter() {
+  if (!streamingToDevtools) {
+    if (!Tracing.enabled) Tracing.enable();
+
+    const channel = devtoolsChannelProvider.get();
+
+    channel.send({
+      messageType: 'trace-time-sync',
+      messageBody: {
+        traceTime: Tracing.now(),
+        localTime: Date.now()
+      }
+    });
+
+    Tracing.stream(
+      trace => channel.send({
+        messageType: 'trace',
+        messageBody: trace
+      }),
+      trace => trace.ov // Overview events only.
+    );
+
+    streamingToDevtools = true;
+  }
+}
+
+export {enableTracingAdapter};

--- a/runtime/planner.js
+++ b/runtime/planner.js
@@ -72,7 +72,7 @@ class Planner {
 
   // Specify a timeout value less than zero to disable timeouts.
   async plan(timeout, generations) {
-    let trace = Tracing.async({cat: 'planning', name: 'Planner::plan', args: {timeout}});
+    let trace = Tracing.async({cat: 'planning', name: 'Planner::plan', overview: true, args: {timeout}});
     timeout = timeout || -1;
     let allResolved = [];
     let now = () => (typeof performance == 'object') ? performance.now() : process.hrtime();
@@ -144,7 +144,7 @@ class Planner {
     return groups;
   }
   async suggest(timeout, generations) {
-    let trace = Tracing.async({cat: 'planning', name: 'Planner::suggest', args: {timeout}});
+    let trace = Tracing.async({cat: 'planning', name: 'Planner::suggest', overview: true, args: {timeout}});
     if (!generations && this._arc._debugging) generations = [];
     let plans = await trace.wait(this.plan(timeout, generations));
     let suggestions = [];


### PR DESCRIPTION
Added a new tool to our devtools extension - visualization of traces. Added a new field to the tracing events - overview. It is used to distinguish traces to be shown in the devtools extension. Intention is to only show high level state of the application, and leave detailed debugging to chrome://tracing.