### PR TITLE
Revert "ensure that a few checks are consistent through a page reload"

### DIFF
--- a/shell/app-shell/elements/shell-ui.js
+++ b/shell/app-shell/elements/shell-ui.js
@@ -58,7 +58,7 @@ const Main = Xen.html`
     <!-- app-toolbar is position-fixed -->
     <app-toolbar style="{{shellStyle}}">
       <a trigger="launcher" href="{{launcherUrl}}" title="Go to Launcher">${AppIcon}</a>
-      <arc-title id="arc-title" style="{{titleStatic}}" on-click="_onStartEditingTitle" unsafe-html="{{description}}"></arc-title>
+      <arc-title style="{{titleStatic}}" on-click="_onStartEditingTitle" unsafe-html="{{description}}"></arc-title>
       <toolbar-buttons>
         <icon hidden$="{{micHidden}}">mic</icon>
         <icon on-click="_onMenuClick">more_vert</icon>

--- a/shell/test/selenium-utils-test.js
+++ b/shell/test/selenium-utils-test.js
@@ -13,7 +13,7 @@ afterEach(function() {
 });
 
 describe('SeleniumUtils', function() {
-  describe('#pierceShadowsSingle()', function() {
+  describe('#pierceShadowsSingle', function() {
     it('should cross a simple shadow boundary', function() {
       target.innerHTML = `
         <div outer>
@@ -107,7 +107,7 @@ describe('SeleniumUtils', function() {
       assert.equal(result.textContent, 'goal');
     });
   });
-  describe('#pierceShadows()', function() {
+  describe('#pierceShadows', function() {
     it('should return multiple valid matches', function() {
       target.innerHTML = `
         <div outer>

--- a/shell/test/specs/demo-tests.js
+++ b/shell/test/specs/demo-tests.js
@@ -256,7 +256,7 @@ function initTestWithNewArc(testTitle) {
   // use a solo URL pointing to our local recipes
   browser.url(`${browser.getUrl()}&${urlParams.join('&')}`);
 
-  // that page load (`browser.url()`) will drop our utils, so load again.
+  // that reload (`browser.url()`) will drop our utils, so load again.
   loadSeleniumUtils();
 
   // check out some basic structure relative to the app footer
@@ -412,44 +412,6 @@ function clickInParticles(slotName, selectors, textQuery) {
           realSelectors} textQuery ${textQuery}`);
 }
 
-/**
- * Grab some data from the page, refresh the page, and validate that the data
- * hasn't changed.
- */
-function testAroundRefresh() {
-  const getOrCompare =
-      expectedValues => {
-        let actualValues = {};
-
-        const titleElem =
-            pierceShadowsSingle(['app-shell', 'shell-ui', '#arc-title']);
-        actualValues.title = browser.elementIdText(titleElem.value.ELEMENT);
-
-        const suggestionsElement = getAtLeastOneSuggestion();
-        actualValues.suggestions = suggestionsElement ?
-            suggestionsElement.value.map(suggestion => {
-              return browser.elementIdText(suggestion.ELEMENT).value;
-            }) :
-            [];
-
-        for (let key in expectedValues) {
-          assert.equal(actualValues[key].value, expectedValues[key].value);
-        }
-
-        return actualValues;
-      };
-
-
-  const expectedValues = getOrCompare();
-
-  browser.refresh();
-  loadSeleniumUtils();
-
-  waitForStillness();
-
-  getOrCompare(expectedValues);
-}
-
 describe('Arcs demos', function() {
   it('can book a restaurant', /** @this Context */ function() {
     initTestWithNewArc(this.test.fullTitle());
@@ -474,8 +436,6 @@ describe('Arcs demos', function() {
 
     acceptSuggestion('Table for 2');
     acceptSuggestion('from your calendar');
-
-    testAroundRefresh();
 
     // debug hint: to drop into debug mode with a REPL; also a handy way to
     // see the state at the end of the test:


### PR DESCRIPTION
Reverts PolymerLabs/arcs#1132.

It's causing a regression that I'll need to investigate.

```
[chrome #0-0] Running: chrome
[chrome #0-0]
[chrome #0-0] Arcs demos
[chrome #0-0]   1) can book a restaurant
[chrome #0-0]   ✓ can buy gifts
[chrome #0-0]
[chrome #0-0] Arcs system
[chrome #0-0]   ✓ can load with global manifests
[chrome #0-0]
[chrome #0-0]
[chrome #0-0] 2 passing (31s)
[chrome #0-0] 1 failing
[chrome #0-0]
[chrome #0-0] 1) Arcs demos can book a restaurant:
[chrome #0-0] 'Find restaurants near Selenium\'s location.' == 'Select a time from your calendar, Table for 2 available at 19:00, and find restaurants near Selenium\'s location.'
[chrome #0-0] AssertionError [ERR_ASSERTION]: 'Find restaurants near Selenium\'s location.' == 'Select a time from your calendar, Table for 2 available at 19:00, and find restaurants near Selenium\'s location.'
[chrome #0-0]     at getOrCompare (/home/travis/build/PolymerLabs/arcs/shell/test/specs/demo-tests.js:436:18)
[chrome #0-0]     at testAroundRefresh (/home/travis/build/PolymerLabs/arcs/shell/test/specs/demo-tests.js:450:3)
[chrome #0-0]     at Context.<anonymous> (/home/travis/build/PolymerLabs/arcs/shell/test/specs/demo-tests.js:478:5)
[chrome #0-0]     at new Promise (<anonymous>)
[chrome #0-0]     at new F (/home/travis/build/PolymerLabs/arcs/node_modules/core-js/library/modules/_export.js:35:28)
[chrome #0-0]

```