### PR TITLE
Add a description to CopyCollection particle.

### DIFF
--- a/shell/artifacts/Common/CopyCollection.manifest
+++ b/shell/artifacts/Common/CopyCollection.manifest
@@ -8,3 +8,4 @@
 
 particle CopyCollection in 'source/CopyCollection.js'
   CopyCollection(in [~a] input, out [~a] output)
+  description `copy ${input} to ${output}`


### PR DESCRIPTION
While looking at https://github.com/PolymerLabs/arcs/issues/1170 and hacking on recipe, at one point I had the recipe resolving and showing a suggestion as `undefined`. This seems an improvement.