### PR TITLE
Minor cleanup of model-input.

### DIFF
--- a/shell/components/model-input.js
+++ b/shell/components/model-input.js
@@ -17,11 +17,10 @@ class ModelInput extends Xen.Base {
   _wouldChangeProps() {
     return true;
   }
-  _render(props, state) {
+  _render({focus}) {
     const input = this.querySelector('input') || this.querySelector('textarea');
-    if (input && props.focus) {
-      // TODO(sjmiles): why needing timeout?
-      setTimeout(() => input.focus(), 500);
+    if (input && focus) {
+      input.focus();
     }
   }
 }


### PR DESCRIPTION
Try removing `setTimeout`. Destructure props for single parameter.

Testing with https://github.com/PolymerLabs/arcs/pull/1188 I'm not able to reproduce an issue requiring `setTimeout` but of course I believe that you were seeing something. Maybe it only happens in the prototype app shell? If you remember or are able to repro let me know.

Anyway, I made this a separate PR so it's easy to revert.