### PR TITLE
add a windows automated build (via appveyor)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,11 @@
+environment:
+  nodejs_version: "9"
+
+install:
+  - ps: Install-Product node $env:nodejs_version
+  - npm install
+
+test_script:
+  - node --version
+  - npm --version
+  - npm test

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,7 +10,13 @@ install:
 
 build: off
 
+# Instead of specific targets, this should use `npm test`.
+# But, that needs some work, and the tests themselves aren't stable so I'm
+# going to wait to add more sources of possible failure.
 test_script:
   - node --version
   - npm --version
-  - npm test
+  - npm run test-sigh
+  - npm run test-mocha
+  - npm run test-extension
+  - npm run test-mocha-words

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,6 +8,8 @@ install:
   - npm install -g npm@latest
   - npm install
 
+build: off
+
 test_script:
   - node --version
   - npm --version

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,5 +1,7 @@
+version: '0.0.${build}'
+
 environment:
-  nodejs_version: "9"
+  nodejs_version: '9'
 
 install:
   - ps: Install-Product node $env:nodejs_version

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,4 +1,4 @@
-version: '0.0.${build}'
+version: '0.0.{build}'
 
 environment:
   nodejs_version: '9'

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,6 +5,7 @@ environment:
 
 install:
   - ps: Install-Product node $env:nodejs_version
+  - npm install -g npm@latest
   - npm install
 
 test_script:

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "host": "localhost"
   },
   "scripts": {
-    "prepare": "tools/sigh check && cd devtools && bower install",
+    "prepare": "cross-env tools/sigh check && cd devtools && bower install",
     "start": "cross-env http-server -a ${npm_package_config_host} -p ${npm_package_config_port}",
     "test-with-start": "run-p --print-name --race start test",
     "test": "run-s --print-name --continue-on-error test-sigh test-mocha test-mocha-words test-wdio test-extension",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "start": "cross-env http-server -a ${npm_package_config_host} -p ${npm_package_config_port}",
     "test-with-start": "run-p --print-name --race start test",
     "test": "run-s --print-name --continue-on-error test-sigh test-mocha test-mocha-words test-wdio test-extension",
-    "test-sigh": "tools/sigh",
+    "test-sigh": "cross-env tools/sigh",
     "test-mocha": "mocha-chrome shell/test/index.test.html",
     "test-extension": "mocha-chrome extension/test/index.test.html",
     "test-mocha-words": "mocha-chrome shell/artifacts/Words/index.test.html",


### PR DESCRIPTION
Most of #985, fixes #1081, and fixes #711.

The remaining piece of #985 is enabling wdio/selenium tests on Windows.