### PR TITLE
Small appveyor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 [![Build Status](https://travis-ci.org/PolymerLabs/arcs.svg?branch=master)](https://travis-ci.org/PolymerLabs/arcs)
+[![Appveyor Build status](https://ci.appveyor.com/api/projects/status/rswlpkq2vtp9cns0?svg=true)](https://ci.appveyor.com/project/smalls/arcs-3i77k)
+
 
 # arcs
 

--- a/shell/source/Tracelib.js
+++ b/shell/source/Tracelib.js
@@ -8,6 +8,6 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import Tracing from '../../../arcs/tracelib/trace.js';
+import Tracing from '../../tracelib/trace.js';
 
 window.Tracing = Tracing;


### PR DESCRIPTION
* Add an appveyor build icon
* Keep references within this repo (don't assume that the top source directory is `arcs`)