### PR TITLE
Return new variable instance from SimpleParticle.updateVariable.

### DIFF
--- a/runtime/dom-particle.js
+++ b/runtime/dom-particle.js
@@ -164,7 +164,9 @@ class DomParticle extends XenStateMixin(Particle) {
   }
   updateVariable(handleName, record) {
     const handle = this.handles.get(handleName);
-    handle.set(new (handle.entityClass)(record));
+    const newRecord = new (handle.entityClass)(record);
+    handle.set(newRecord);
+    return newRecord;
   }
   updateSet(handleName, record) {
     // Set the record into the right place in the set. If we find it


### PR DESCRIPTION
Callers might want to use it further subsequently, and it seems only
polite to allow for such antics.

I have such a case currently in Word puzzle rework to write `Post` entities.