### PR TITLE
Support recipe resolution in particle API for loadRecipe.

### DIFF
--- a/runtime/recipe/recipe-resolver.js
+++ b/runtime/recipe/recipe-resolver.js
@@ -1,0 +1,36 @@
+// Copyright (c) 2018 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+import ResolveRecipe from '../strategies/resolve-recipe.js';
+
+import Recipe from './recipe.js';
+
+// Provides basic recipe resolution for recipes against a particular arc.
+export class RecipeResolver {
+  constructor(arc) {
+    this._resolver = new ResolveRecipe(arc);
+  }
+
+  // Attempts to run basic resolution on the given recipe. Returns a new
+  // instance of the recipe normalized and resolved if possible. Returns null if
+  // normalization or attempting to resolve slot connection fails.
+  async resolve(recipe) {
+    recipe = recipe.clone();
+    let options = {errors: new Map()};
+    if (!recipe.normalize(options)) {
+      console.warn(`could not normalize a recipe: ${
+              [...options.errors.values()].join('\n')}.\n${recipe.toString()}`);
+      return null;
+    }
+
+    const result = await this._resolver.generate(
+        {generated: [{result: recipe, score: 1}], terminal: []});
+    return (result.length == 0) ? null : result[0].result;
+  }
+}
+
+export default {RecipeResolver};

--- a/runtime/test/particle-api-test.js
+++ b/runtime/test/particle-api-test.js
@@ -349,6 +349,225 @@ describe('particle-api', function() {
     await util.assertSingletonWillChangeTo(newView, Result, 'success');
   });
 
+  it('can load a recipe referencing a tagged handle in containing arc', async () => {
+    let registry = {};
+    let loader = new class extends Loader {
+      loadResource(path) {
+        return {
+          manifest: `
+            schema Result
+              Text value
+
+            schema Foo
+              Text bar
+
+            particle P in 'a.js'
+              P(out Result result, in Foo target)
+
+            recipe
+              use 'test:1' as view0
+              create #target as target
+              P
+                result -> view0
+                target <- target
+
+          `,
+          'a.js': `
+            "use strict";
+
+            defineParticle(({Particle}) => {
+              return class P extends Particle {
+                async setViews(views) {
+                  let arc = await this.constructInnerArc();
+                  var resultHandle = views.get('result');
+                  let inView = await arc.createHandle(resultHandle.type, "in view");
+                  let outView = await arc.createHandle(resultHandle.type, "out view");
+                  try {
+                    await arc.loadRecipe(\`
+                       schema Foo
+                         Text bar
+
+                       schema Result
+                         Text value
+
+                       particle PassThrough in 'pass-through.js'
+                         PassThrough(in Foo target, in Result a, out Result b)
+
+                       recipe
+                         use #target as target
+                         use '\${inView._id}' as v1
+                         use '\${outView._id}' as v2
+                         PassThrough
+                           target <- target
+                           a <- v1
+                           b -> v2
+
+                    \`);
+                    inView.set(new resultHandle.entityClass({value: 'success'}));
+                    resultHandle.set(new resultHandle.entityClass({value: 'done'}));
+                  } catch (e) {
+                    resultHandle.set(new resultHandle.entityClass({value: e}));
+                  }
+                }
+              }
+            });
+          `,
+          'pass-through.js': `
+            "use strict";
+
+            defineParticle(({Particle}) => {
+              return class PassThrough extends Particle {
+                setViews(views) {
+                  views.get('a').get().then(resultA => {
+                    views.get('target').get().then(resultTarget => {
+                      views.get('b').set(resultA);
+                    })
+                  });
+                }
+              }
+            });
+          `
+        }[path];
+      }
+      path(fileName) {
+        return fileName;
+      }
+      join(_, file) {
+        return file;
+      }
+    };
+    let manifest = await Manifest.load('manifest', loader, {registry});
+    let pecFactory = function(id) {
+      let channel = new MessageChannel();
+      new InnerPec(channel.port1, `${id}:inner`, loader);
+      return channel.port2;
+    };
+    let arc = new Arc({id: 'test', pecFactory, loader});
+    let Result = manifest.findSchemaByName('Result').entityClass();
+    let resultHandle = await arc.createHandle(Result.type, undefined, 'test:1');
+    let recipe = manifest.recipes[0];
+    recipe.handles[0].mapToStorage(resultHandle);
+    recipe.normalize();
+    await arc.instantiate(recipe);
+
+    await util.assertSingletonWillChangeTo(resultHandle, Result, 'done');
+    let newView = arc.findHandlesByType(Result.type)[2];
+    assert(newView.name == 'out view');
+    await util.assertSingletonWillChangeTo(newView, Result, 'success');
+  });
+
+  // TODO(wkorman): The below test fails and is currently skipped as we're only
+  // running basic recipe resolution, and `use` ends up in
+  // `arc.findHandlesByType` which doesn't fall back to considering handles in
+  // the arc's context as does, for example, `arc.findHandleById`. We could
+  // potentially address either by including more strategies in the outer-PEC's
+  // strategizer or adding such fallback to `arc.findHandlesByType`.
+  it.skip('can load a recipe referencing a tagged handle in manifest', async () => {
+    let registry = {};
+    let loader = new class extends Loader {
+      loadResource(path) {
+        return {
+          manifest: `
+            schema Result
+              Text value
+
+            store NobId of NobIdStore {Text nobId} #target in NobIdJson
+             resource NobIdJson
+               start
+               [{"nobId": "12345"}]
+
+            particle P in 'a.js'
+              P(out Result result)
+
+            recipe
+              use 'test:1' as view0
+              P
+                result -> view0
+
+          `,
+          'a.js': `
+            "use strict";
+
+            defineParticle(({Particle}) => {
+              return class P extends Particle {
+                async setViews(views) {
+                  let arc = await this.constructInnerArc();
+                  var resultHandle = views.get('result');
+                  let inView = await arc.createHandle(resultHandle.type, "in view");
+                  let outView = await arc.createHandle(resultHandle.type, "out view");
+                  try {
+                    await arc.loadRecipe(\`
+                       schema Result
+                         Text value
+
+                       particle PassThrough in 'pass-through.js'
+                         PassThrough(in NobIdStore {Text nobId} target, in Result a, out Result b)
+
+                       recipe
+                         use #target as target
+                         use '\${inView._id}' as v1
+                         use '\${outView._id}' as v2
+                         PassThrough
+                           target <- target
+                           a <- v1
+                           b -> v2
+
+                    \`);
+                    inView.set(new resultHandle.entityClass({value: 'success'}));
+                    resultHandle.set(new resultHandle.entityClass({value: 'done'}));
+                  } catch (e) {
+                    resultHandle.set(new resultHandle.entityClass({value: e}));
+                  }
+                }
+              }
+            });
+          `,
+          'pass-through.js': `
+            "use strict";
+
+            defineParticle(({Particle}) => {
+              return class PassThrough extends Particle {
+                setViews(views) {
+                  views.get('a').get().then(resultA => {
+                    views.get('target').get().then(resultNob => {
+                      if (resultNob.nobId === '12345') {
+                        views.get('b').set(resultA);
+                      }
+                    })
+                  });
+                }
+              }
+            });
+          `
+        }[path];
+      }
+      path(fileName) {
+        return fileName;
+      }
+      join(_, file) {
+        return file;
+      }
+    };
+    let manifest = await Manifest.load('manifest', loader, {registry});
+    let pecFactory = function(id) {
+      let channel = new MessageChannel();
+      new InnerPec(channel.port1, `${id}:inner`, loader);
+      return channel.port2;
+    };
+    let arc = new Arc({id: 'test', pecFactory, loader});
+    let Result = manifest.findSchemaByName('Result').entityClass();
+    let resultHandle = await arc.createHandle(Result.type, undefined, 'test:1');
+    let recipe = manifest.recipes[0];
+    recipe.handles[0].mapToStorage(resultHandle);
+    recipe.normalize();
+    await arc.instantiate(recipe);
+
+    await util.assertSingletonWillChangeTo(resultHandle, Result, 'done');
+    let newView = arc.findHandlesByType(Result.type)[2];
+    assert(newView.name == 'out view');
+    await util.assertSingletonWillChangeTo(newView, Result, 'success');
+  });
+
   it('multiplexing', async () => {
     let registry = {};
     let loader = new class extends Loader {

--- a/runtime/test/recipe-resolver-test.js
+++ b/runtime/test/recipe-resolver-test.js
@@ -1,0 +1,116 @@
+/**
+ * @license
+ * Copyright (c) 2018 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import Arc from '../arc.js';
+import Loader from '../loader.js';
+import Manifest from '../manifest.js';
+import {RecipeResolver} from '../recipe/recipe-resolver.js';
+
+import {assert} from './chai-web.js';
+
+describe('RecipeResolver', function() {
+  const buildRecipe = async (content) => {
+    let registry = {};
+    let loader = new class extends Loader {
+      loadResource(path) {
+        return content[path];
+      }
+      path(fileName) {
+        return fileName;
+      }
+      join(_, file) {
+        return file;
+      }
+    };
+    let manifest = await Manifest.load('manifest', loader, {registry});
+    return manifest.recipes[0];
+  };
+
+  const createArc = () => {
+    return new Arc({
+      id: 'test',
+      slotComposer: {
+        affordance: 'dom',
+        getAvailableSlots: (() => {
+          return [{
+            name: 'root',
+            id: 'r0',
+            tags: ['#root'],
+            handles: [],
+            handleConnections: [],
+            getProvidedSlotSpec: () => {
+              return {isSet: false};
+            }
+          }];
+        })
+      }
+    });
+  };
+
+  it('resolves a recipe', async () => {
+    const arc = createArc();
+    const resolver = new RecipeResolver(arc);
+    const recipe = await buildRecipe({
+      manifest: `
+      particle P in 'A.js'
+        P()
+        consume root
+        affordance dom
+
+      recipe
+        P
+        `
+    });
+    // Initially the recipe should not be normalized (after which it's srozen).
+    assert.isFalse(Object.isFrozen(recipe));
+    const result = await resolver.resolve(recipe);
+    // The original recipe should remain untouched and the new instance
+    // should have been normalized.
+    assert.isFalse(Object.isFrozen(recipe));
+    assert.isTrue(Object.isFrozen(result));
+    assert.isTrue(result.isResolved());
+  });
+
+  it('returns an unresolvable recipe as unresolved', async () => {
+    const arc = createArc();
+    const resolver = new RecipeResolver(arc);
+    // The recipe below is unresolvable as it's missing an
+    // output handle connection.
+    const recipe = await buildRecipe({
+      manifest: `
+      particle P in 'A.js'
+        P(out * {Text value} text)
+        consume root
+        affordance dom
+
+      recipe
+        P
+        `
+    });
+    const result = await resolver.resolve(recipe);
+    assert.isFalse(result.isResolved());
+  });
+
+  it('returns null for an invalid recipe', async () => {
+    const arc = createArc();
+    const resolver = new RecipeResolver(arc);
+    // The recipe below is invalid as it's  missing consume and affordance.
+    const recipe = await buildRecipe({
+      manifest: `
+      particle P in 'A.js'
+        P()
+
+      recipe
+        P
+        `
+    });
+    assert.isNull(await resolver.resolve(recipe));
+  });
+});


### PR DESCRIPTION
Allow specifying an optional list of recipes for incorporation into
strategizing via InitPopulation rather than just reading from the arc
context recipes.

Allows inner recipes to do things like referencing tagged handles
without an id.

This PR is broken out from https://github.com/PolymerLabs/arcs/compare/master...shaper:embed_end_to_end_exploration and is part of an evolution of the discussion in https://github.com/PolymerLabs/arcs/issues/1192.