### PR TITLE
Revert "Allows binding a slot to any candidate"

### DIFF
--- a/runtime/strategies/map-slots.js
+++ b/runtime/strategies/map-slots.js
@@ -32,16 +32,16 @@ export default class MapSlots extends Strategy {
         }
 
         let selectedSlots = MapSlots.findAllSlotCandidates(slotConnection, arc);
-
-        // ResolveRecipe handles one-slot case.
         if (selectedSlots.length < 2) {
           return;
         }
 
-        return selectedSlots.map(slot => ((recipe, slotConnection) => {
-          MapSlots.connectSlotConnection(slotConnection, slot);
+        let selectedSlot = selectedSlots[0]; // TODO: return combinatorial results?
+
+        return (recipe, slotConnection) => {
+          MapSlots.connectSlotConnection(slotConnection, selectedSlot);
           return 1;
-        }));
+        };
       }
     }(RecipeWalker.Permuted), this);
   }

--- a/runtime/strategies/resolve-recipe.js
+++ b/runtime/strategies/resolve-recipe.js
@@ -65,8 +65,6 @@ export default class ResolveRecipe extends Strategy {
         }
 
         let selectedSlots = MapSlots.findAllSlotCandidates(slotConnection, arc);
-
-        // MapSlots handles a multi-slot case.
         if (selectedSlots.length !== 1) {
           return;
         }

--- a/runtime/test/strategies/resolve-recipe-test.js
+++ b/runtime/test/strategies/resolve-recipe-test.js
@@ -131,25 +131,6 @@ describe('resolve recipe', function() {
     assert.isTrue(recipe.isResolved());
   });
 
-  it('maps slots by tags', async () => {
-    let manifest = (await Manifest.parse(`
-      particle A in 'A.js'
-        A()
-        consume master #parent
-
-      recipe
-        slot 'id0' #parent as s0
-        A
-    `));
-    let [recipe] = manifest.recipes;
-    let arc = createTestArc('test-plan-arc', manifest, 'dom');
-    assert.isTrue(recipe.normalize());
-
-
-    recipe = await onlyResult(arc, ResolveRecipe, recipe);
-    assert.isTrue(recipe.isResolved());
-  });
-
   it('map slots by slot connection tags', async () => {
     let manifest = (await Manifest.parse(`
       particle A in 'A.js'


### PR DESCRIPTION
Reverts PolymerLabs/arcs#1122

It was causing duplicate suggestions due to 'action' slot being available in the active arc from different recipes.