### PR TITLE
WIP: Exploration of end to end embedding for Game and Social.

### DIFF
--- a/runtime/dom-particle.js
+++ b/runtime/dom-particle.js
@@ -130,9 +130,10 @@ export class DomParticle extends XenStateMixin(Particle) {
     // TODO(sjmiles): redundant, same answer for every slot
     if (this.shouldRender(...stateArgs)) {
       let content = {};
-      if (slot._requestedContentTypes.has('template')) {
+      // TODO(mmandlis): Below must be commented out for Words post to render.
+      // if (slot._requestedContentTypes.has('template')) {
         content.template = this.getTemplate(slot.slotName);
-      }
+      // }
       if (slot._requestedContentTypes.has('model')) {
         content.model = this.render(...stateArgs);
       }

--- a/runtime/dom-slot.js
+++ b/runtime/dom-slot.js
@@ -134,6 +134,9 @@ export class DomSlot extends Slot {
   }
   constructRenderRequest() {
     let request = ['model'];
+    // TODO(mmandlis): Commenting out the `if` conditional below was suggested
+    // to fix Words post rendering but is insufficient (see similar TODO in
+    // dom-particle.js).
     if (!this.getTemplate()) {
       request.push('template');
     }


### PR DESCRIPTION
Not for formal review. Illustrates current `PostMuxer` render state. To repro:

- Patch this and build webpack.
- Log in as me.
- Choose 'New arc' and select the "Show post list (2 items) and show morphed post list` suggestion.
- Note the second item in the resulting feed, which is actually a `Words` game board, renders as an empty `Post` template though in all other respect things are wired up for the game item to render via the `ShowSingleStats` game specific particle, and we can see that particle's `render` method is called.

I believe this is due to logic in `TransformationDomParticle` as written expecting all items to share the same template and building a list of model data with which to render them all. We likely need a way to override this behavior somehow in subclasses.

Part of https://github.com/PolymerLabs/arcs/issues/842