### PR TITLE
Fix muxer bug with sticky hosted particle.

### DIFF
--- a/runtime/multiplexer-dom-particle.js
+++ b/runtime/multiplexer-dom-particle.js
@@ -87,6 +87,7 @@ export default class MultiplexerDomParticle extends TransformationDomParticle {
     }
 
     for (let [index, item] of list.entries()) {
+      let resolvedHostedParticle = hostedParticle;
       if (this.handleIds[item.id]) {
         let itemView = await this.handleIds[item.id];
         itemView.set(item);
@@ -99,14 +100,14 @@ export default class MultiplexerDomParticle extends TransformationDomParticle {
 
       let itemView = await itemViewPromise;
 
-      if (!hostedParticle) {
+      if (!resolvedHostedParticle) {
         // If we're muxing on behalf of an item with an embedded recipe, the
         // hosted particle should be retrievable from the item itself. Else we
         // just skip this item.
         if (!item.renderParticleSpec) {
           continue;
         }
-        hostedParticle =
+        resolvedHostedParticle =
             ParticleSpec.fromLiteral(JSON.parse(item.renderParticleSpec));
         // Re-map compatible handles and compute the connections specific
         // to this item's render particle.
@@ -116,14 +117,14 @@ export default class MultiplexerDomParticle extends TransformationDomParticle {
             await this._mapParticleConnections(
                 listHandleName,
                 particleHandleName,
-                hostedParticle,
+                resolvedHostedParticle,
                 this._views,
                 arc);
       }
-      let hostedSlotName = [...hostedParticle.slots.keys()][0];
+      let hostedSlotName = [...resolvedHostedParticle.slots.keys()][0];
       let slotName = [...this.spec.slots.values()][0].name;
       let slotId = await arc.createSlot(
-          this, slotName, hostedParticle.name, hostedSlotName);
+          this, slotName, resolvedHostedParticle.name, hostedSlotName);
 
       if (!slotId) {
         continue;
@@ -134,7 +135,7 @@ export default class MultiplexerDomParticle extends TransformationDomParticle {
       try {
         await arc.loadRecipe(
             this.constructInnerRecipe(
-                hostedParticle,
+                resolvedHostedParticle,
                 item,
                 itemView,
                 {name: hostedSlotName, id: slotId},


### PR DESCRIPTION
The hosted particle can vary on a per-item basis and we were only
looking up the item-specific particle spec the first time as we were
setting it in `hostedParticle` and leaving it there for subsequent
iterations.

*Note:* I spent a chunk of time working on a unit test for this (I made it all the way through to needing to populate the DOM context for each slot in the test somehow) and decided I'd prefer to do it as a separate PR if that's ok. This will let me forge ahead and look at the `subid` template issue next, which may change what we do a bit, and then revisit with tests for both this and that.

Part of https://github.com/PolymerLabs/arcs/issues/842