### PR TITLE
Implements Schema.intersect for non subtypes and adds tests.

### DIFF
--- a/runtime/manifest.js
+++ b/runtime/manifest.js
@@ -454,7 +454,7 @@ ${e.message}
     visitor.traverse(items);
   }
   static _processSchema(manifest, schemaItem) {
-    let description = '';
+    let description;
     let fields = {};
     let names = [...schemaItem.names];
     for (let item of schemaItem.items) {
@@ -510,11 +510,9 @@ ${e.message}
           schemaItem.location,
           `Schema defined without name or alias`);
     }
-    let schema = new Schema({
-      names,
-      description: description,
-      fields,
-    });
+    let model = {names, fields};
+    if (description) model.description = description;
+    let schema = new Schema(model);
     if (schemaItem.alias) {
       schema.isAlias = true;
     }

--- a/runtime/schema.js
+++ b/runtime/schema.js
@@ -112,14 +112,20 @@ export default class Schema {
   }
 
   static intersect(schema1, schema2) {
-    if (schema1.isMoreSpecificThan(schema2))
-      return schema2;
-    else if (schema2.isMoreSpecificThan(schema1))
-      return schema1;
-    
-    // TODO: Don't be lazy
-    assert(false, 'non-trivial intersection of schemas not implemented.');
-    return null;
+    let names = [...schema1.names].filter(name => schema2.names.includes(name));
+    let fields = {};
+
+    for (let [field, type] of Object.entries(schema1.fields)) {
+      let otherType = schema2.fields[field];
+      if (otherType && Schema.typesEqual(type, otherType)) {
+        fields[field] = type;
+      }
+    }
+
+    return new Schema({
+      names,
+      fields,
+    });
   }
 
   equals(otherSchema) {
@@ -294,7 +300,7 @@ export default class Schema {
     let fields = Object.entries(this.fields).map(([name, type]) => `${Schema._typeString(type)} ${name}`).join(', ');
     return `${names} {${fields}}`;
   }
-  
+
   toManifestString() {
     let results = [];
     results.push(`schema ${this.names.join(' ')}`);


### PR DESCRIPTION
I've hit limitations of Schema.intersect in the other patch I'm working on (#1229), so here's a fix.

Returning null for empty intersection and disregarding fields of conflicting types can be controversial, opinions welcome.