### PR TITLE
Strategy to make a create handle greedily grouping free connections

### DIFF
--- a/runtime/planner.js
+++ b/runtime/planner.js
@@ -28,6 +28,8 @@ import {FallbackFate} from './strategies/fallback-fate.js';
 import {GroupHandleConnections} from './strategies/group-handle-connections.js';
 import {MatchFreeHandlesToConnections} from './strategies/match-free-handles-to-connections.js';
 import {CreateHandles} from './strategies/create-handles.js';
+import {CreateHandleGroup} from './strategies/create-handle-group.js';
+import {CombinedStrategy} from './strategies/combined-strategy.js';
 import {ResolveRecipe} from './strategies/resolve-recipe.js';
 import {Speculator} from './speculator.js';
 import {Tracing} from '../tracelib/trace.js';
@@ -197,6 +199,7 @@ Planner.ResolutionStrategies = [
   GroupHandleConnections,
   FallbackFate,
   CreateHandles,
+  CreateHandleGroup,
   AssignHandlesByTagAndType,
   ConvertConstraintsToConnections,
   MapSlots,

--- a/runtime/strategies.md
+++ b/runtime/strategies.md
@@ -31,7 +31,12 @@ The strategy is not executed on recipes with outstanding constraints or with fre
 ## CreateHandles
 Sets handle’s fate to “create”, if its fate was unknown and ID was undefined.
 Requires that there are at least 2 particles connected, at least one reading and one writing.<br/>
-[planner.js](https://github.com/PolymerLabs/arcs/blob/master/runtime/planner.js#L34)
+[create-handles.js](https://github.com/PolymerLabs/arcs/blob/master/runtime/strategies/create-handles.js)
+
+## CreateHandleGroup
+Creates a new 'create' handle connecting a broadest possible set of unresolved connections.
+Will never connect 2 connections from the same particle and requires at least one writing and one reading particle.<br/>
+[create-handle-group.js](https://github.com/PolymerLabs/arcs/blob/master/runtime/strategies/create-handle-group.js)
 
 ## MapSlots
 Maps consumed slots with provided slots within the same recipe and pre existing slots (provided by slot-composer).<br/>

--- a/runtime/strategies/create-handle-group.js
+++ b/runtime/strategies/create-handle-group.js
@@ -1,0 +1,68 @@
+// Copyright (c) 2017 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+import {Strategy} from '../../strategizer/strategizer.js';
+import {Recipe} from '../recipe/recipe.js';
+import {Walker} from '../recipe/walker.js';
+import {Handle} from '../recipe/handle.js';
+
+export class CreateHandleGroup extends Strategy {
+
+  async generate(inputParams) {
+    return Recipe.over(this.getResults(inputParams), new class extends Walker {
+      onRecipe(recipe) {
+        // Resolve constraints before assuming connections are free.
+        if (recipe.connectionConstraints.length > 0) return;
+
+        const freeConnections = recipe.handleConnections.filter(hc => !hc.handle && !hc.isOptional);
+        let maximalGroup = null;
+        for (let writer of freeConnections.filter(hc => hc.isOutput)) {
+          let compatibleConnections = [writer];
+          let effectiveType = Handle.effectiveType(null, compatibleConnections);
+          let typeCandidate = null;
+          let involvedParticles = new Set([writer.particle]);
+
+          let foundSomeReader = false;
+          for (let reader of freeConnections.filter(hc => hc.isInput)) {
+            if (!involvedParticles.has(reader.particle) &&
+                (typeCandidate = Handle.effectiveType(effectiveType, [reader])) !== null) {
+              compatibleConnections.push(reader);
+              involvedParticles.add(reader.particle);
+              effectiveType = typeCandidate;
+              foundSomeReader = true;
+            }
+          }
+
+          // Only make a 'create' group for a writer->reader case.
+          if (!foundSomeReader) continue;
+
+          for (let otherWriter of freeConnections.filter(hc => hc.isOutput)) {
+            if (!involvedParticles.has(otherWriter.particle) &&
+                (typeCandidate = Handle.effectiveType(effectiveType, [otherWriter])) !== null) {
+              compatibleConnections.push(otherWriter);
+              involvedParticles.add(otherWriter.particle);
+              effectiveType = typeCandidate;
+            }
+          }
+
+          if (!maximalGroup || compatibleConnections.length > maximalGroup.length) {
+            maximalGroup = compatibleConnections;
+          }
+        }
+
+        if (maximalGroup) return recipe => {
+          let newHandle = recipe.newHandle();
+          newHandle.fate = 'create';
+          for (let conn of maximalGroup) {
+            let cloneConn = recipe.updateToClone({conn}).conn;
+            cloneConn.connectToHandle(newHandle);
+          }
+        };
+      }
+    }(Walker.Independent), this);
+  }
+}

--- a/runtime/test/strategies/create-handle-group-tests.js
+++ b/runtime/test/strategies/create-handle-group-tests.js
@@ -1,0 +1,139 @@
+/**
+ * @license
+ * Copyright (c) 2018 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+'use strict';
+
+import {Manifest} from '../../manifest.js';
+import {StrategyTestHelper} from './strategy-test-helper.js';
+import {CreateHandleGroup} from '../../strategies/create-handle-group.js';
+import {assert} from '../chai-web.js';
+
+describe('CreateHandleGroup', function() {
+  it('connects variables and inline schemas', async () => {
+    let manifest = await Manifest.parse(`
+      schema Human
+        Text name
+      schema Child extends Human
+        Object toy
+
+      particle Bear
+        out ~a with Child infant
+      particle Describe
+        in * {Text name} thing
+      particle Entertain
+        inout Child child
+      particle Notify
+        in ~a something
+      particle Employ
+        in Human human
+
+      recipe
+        Bear
+        Describe
+        Entertain
+        Notify
+        Employ
+    `);
+
+    let result = await StrategyTestHelper.onlyResult(null, CreateHandleGroup, manifest.recipes[0]);
+    assert.lengthOf(result.handles, 1);
+    assert.equal(result.handles[0].fate, 'create');
+    assert.isTrue(result.isResolved());
+  });
+
+  it('requires read-write connection between particles', async () => {
+    let manifest = await Manifest.parse(`
+      schema Human
+        Text name
+      schema Child extends Human
+        Object toy
+
+      particle Entertain
+        in Child child
+      particle Employ
+        in Human human
+
+      recipe
+        Entertain
+        Employ
+    `);
+
+    assert.isEmpty(await StrategyTestHelper.theResults(null, CreateHandleGroup, manifest.recipes[0]));
+  });
+
+  it('does not connect a single particle', async () => {
+    let manifest = await Manifest.parse(`
+      schema Human
+        Text name
+
+      particle Clone
+        in Human before
+        out Human after
+        inout Human researcher
+
+      recipe
+        Clone
+    `);
+
+    assert.isEmpty(await StrategyTestHelper.theResults(null, CreateHandleGroup, manifest.recipes[0]));
+  });
+
+  it('connects the biggest groups available', async () => {
+    // CreateHandleGroup looks for a maximal group of connections. It's not
+    // always the right thing to do, but an experimental step for now. This test
+    // should be updated if we do something smarter.
+    let manifest = await Manifest.parse(`
+      particle ReaderA
+        in * {Text a} a
+      particle ReaderB
+        in * {Text b} b
+      particle ReaderC
+        in * {Text c} c
+      particle ReaderD
+        in * {Text d} d
+      particle ReaderE
+        in * {Text e} e
+
+      particle WriterAB
+        out * {Text a, Text b} ab
+      particle WriterBCD
+        out * {Text b, Text c, Text d} bcd
+      particle WriterDE
+        out * {Text d, Text e} de
+
+      recipe
+        WriterAB
+        WriterBCD
+        WriterDE
+        ReaderA
+        ReaderB
+        ReaderC
+        ReaderD
+        ReaderE
+    `);
+
+    let result = await StrategyTestHelper.onlyResult(null, CreateHandleGroup, manifest.recipes[0]);
+
+    assert.lengthOf(result.handles, 1);
+    let handle = result.handles[0];
+    assert.equal(handle.fate, 'create');
+
+    for (let particle of result.particles) {
+      let connections = Object.values(particle.connections);
+      assert.lengthOf(connections, 1);
+      let connection = connections[0];
+
+      if (['ReaderB', 'ReaderC', 'ReaderD', 'WriterBCD'].includes(particle.name)) {
+        assert.equal(connection.handle, handle);
+      } else {
+        assert.isUndefined(connection.handle);
+      }
+    }
+  });
+});


### PR DESCRIPTION
Adds a strategy that will find a maximal group of free connections that can be fulfilled meaningfully with a 'create' handle.

GroupHandleConnections is moved back into the CombinedStrategy, as it doesn't deal with types very well and is more generic, assigning '?' fate, therefore we cannot put constraints on the read-write relationship between particles there. I decided to have a dedicated strategy for this use case.

Tests fail now, but will be fixed with #1228.