### PR TITLE
Muxer stores templates keyed by subid.

### DIFF
--- a/runtime/dom-particle.js
+++ b/runtime/dom-particle.js
@@ -134,9 +134,14 @@ class DomParticle extends XenStateMixin(Particle) {
     // TODO(sjmiles): redundant, same answer for every slot
     if (this.shouldRender(...stateArgs)) {
       let content = {};
-      if (slot._requestedContentTypes.has('template')) {
+      // TODO(wkorman): Consider (1) removing this optimization, or (2) evolve
+      // it to support sub id specific templates, or (3) rework it to
+      // differently handle caching (a) Xen templates and (b) not shipping the
+      // output template string over the api port repeatedly unnecessarily.
+      // See https://github.com/PolymerLabs/arcs/issues/1233.
+      // if (slot._requestedContentTypes.has('template')) {
         content.template = this.getTemplate(slot.slotName);
-      }
+      // }
       if (slot._requestedContentTypes.has('model')) {
         content.model = this.render(...stateArgs);
       }

--- a/runtime/dom-slot.js
+++ b/runtime/dom-slot.js
@@ -134,9 +134,15 @@ class DomSlot extends Slot {
   }
   constructRenderRequest() {
     let request = ['model'];
-    if (!this.getTemplate()) {
+    // TODO(wkorman): Consider (1) removing this optimization, or (2) evolve
+    // it to support sub id specific templates, or (3) rework it to
+    // differently handle caching (a) Xen templates and (b) not shipping the
+    // output template string over the api port repeatedly unnecessarily.
+    // See https://github.com/PolymerLabs/arcs/issues/1233 and related logic
+    // in `DomParticle.renderSlot`.
+    // if (!this.getTemplate()) {
       request.push('template');
-    }
+    // }
     return request;
   }
   static findRootSlots(context) {

--- a/runtime/multiplexer-dom-particle.js
+++ b/runtime/multiplexer-dom-particle.js
@@ -165,7 +165,12 @@ export default class MultiplexerDomParticle extends TransformationDomParticle {
   }
 
   combineHostedTemplate(slotName, hostedSlotId, content) {
-    if (!this._state.template && !!content.template) {
+    let subId = this._itemSubIdByHostedSlotId.get(hostedSlotId);
+    if (!subId) {
+      return;
+    }
+
+    if ((!this._state.template || !this._state.template[subId]) && !!content.template) {
       let template = content.template;
       // Replace hosted particle connection in template with the corresponding particle connection names.
       // TODO: make this generic!
@@ -174,7 +179,8 @@ export default class MultiplexerDomParticle extends TransformationDomParticle {
             new RegExp(`{{${hostedConn}.description}}`, 'g'),
             `{{${conn}.description}}`);
       });
-      this._setState({template});
+      const mergedTemplates = Object.assign(this._state.template || {}, {[subId]: template});
+      this._setState({template: mergedTemplates});
     }
   }
 

--- a/runtime/test/artifacts/transformations/frob-muxer.js
+++ b/runtime/test/artifacts/transformations/frob-muxer.js
@@ -1,0 +1,24 @@
+// @license
+// Copyright (c) 2018 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+'use strict';
+
+// A trivial muxer particle for testing purposes that passes through the
+// `renderRecipe` in the input item with muxer knowledge specific substitutions.
+defineParticle(({MultiplexerDomParticle}) => {
+  return class FrobMuxer extends MultiplexerDomParticle {
+    constructInnerRecipe(hostedParticle, item, itemView, slot, other) {
+      let value = item.renderRecipe.replace('{{slot_id}}', slot.id);
+      value = value.replace('{{item_id}}', itemView._id);
+      value = value.replace('{{other_views}}', other.views.join('\n'));
+      value =
+          value.replace('{{other_connections}}', other.connections.join('\n'));
+      return value;
+    }
+  };
+});

--- a/runtime/test/artifacts/transformations/test-mux-a.js
+++ b/runtime/test/artifacts/transformations/test-mux-a.js
@@ -1,0 +1,18 @@
+// @license
+// Copyright (c) 2018 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+defineParticle(({DomParticle}) => {
+  return class A extends DomParticle {
+    get template() {
+      return `<div mux-a><{{value}}</div>`;
+    }
+    render(props, state) {
+      return {value: 'A'};
+    }
+  };
+});

--- a/runtime/test/artifacts/transformations/test-mux-b.js
+++ b/runtime/test/artifacts/transformations/test-mux-b.js
@@ -1,0 +1,18 @@
+// @license
+// Copyright (c) 2018 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+defineParticle(({DomParticle}) => {
+  return class A extends DomParticle {
+    get template() {
+      return `<div mux-b><{{value}}</div>`;
+    }
+    render(props, state) {
+      return {value: 'B'};
+    }
+  };
+});

--- a/runtime/test/dom-slot-tests.js
+++ b/runtime/test/dom-slot-tests.js
@@ -146,8 +146,11 @@ describe('dom-slot', function() {
     assert.deepEqual(['model', 'template'], slot.constructRenderRequest());
 
     // only request model, if template already found.
+    // TODO(wkorman): Review and potentially restore this optimization.
+    // See https://github.com/PolymerLabs/arcs/issues/1233.
     slot._context = new MockDomContext();
     slot.setContent({template: 'dummy-template'}, {});
-    assert.deepEqual(['model'], slot.constructRenderRequest());
+    // assert.deepEqual(['model'], slot.constructRenderRequest());
+    assert.deepEqual(['model', 'template'], slot.constructRenderRequest());
   });
 });

--- a/runtime/test/mock-slot-composer.js
+++ b/runtime/test/mock-slot-composer.js
@@ -31,7 +31,14 @@ class MockSlot extends Slot {
 
   }
   getInnerContext(slotName) {
-    if (this._content.template && this._content.template.indexOf(`slotid="${slotName}"`) > 0) {
+    let templateValue = null;
+    if (this._content.template) {
+      // Slot templates can either be the template directly, or an object whose
+      // keys are subids and values are the associated templates.
+      templateValue = (typeof this._content.template === 'object') ?
+          Object.values(this._content.template)[0] : this._content.template;
+    }
+    if (templateValue && templateValue.indexOf(`slotid="${slotName}"`) > 0) {
       return new MockContext('dummy-context');
     }
   }

--- a/runtime/test/multiplexer-test.js
+++ b/runtime/test/multiplexer-test.js
@@ -11,9 +11,12 @@
 import {assert} from '../../runtime/test/chai-web.js';
 
 import Arc from '../../runtime/arc.js';
+import DomParticle from '../../runtime/dom-particle.js';
 import Loader from '../../runtime/loader.js';
 import Manifest from '../../runtime/manifest.js';
+import {RecipeResolver} from '../recipe/recipe-resolver.js';
 import SlotComposer from '../../runtime/slot-composer.js';
+import MockSlotComposer from './mock-slot-composer.js';
 
 
 let loader = new Loader();
@@ -23,7 +26,7 @@ describe('Multiplexer', function() {
     let manifest = await Manifest.parse(`
       import 'shell/artifacts/Common/Multiplexer.manifest'
       import 'runtime/test/artifacts/test-particles.manifest'
-      
+
       recipe
         slot 'slotid' as s0
         use 'test:1' as v0
@@ -66,5 +69,114 @@ describe('Multiplexer', function() {
     await arc.idle;
 
     assert.equal(slotsCreated, 3);
+  });
+
+  const processManifest = async content => {
+    let registry = {};
+    let loader = new class extends Loader {
+      loadResource(path) {
+        return content[path];
+      }
+      path(fileName) {
+        return fileName;
+      }
+      join(_, file) {
+        return file;
+      }
+    };
+    return Manifest.load('manifest', loader, {registry});
+  };
+
+  const buildEmbeddedItemValues = async name => {
+    const sourceFilename = `${name}.js`;
+    const manifest = await processManifest({manifest: `
+        schema Frob
+          Text renderParticleSpec
+          Text renderRecipe
+
+        schema ${name}Item
+          Text dummy${name}
+
+        particle ${name} in 'runtime/test/artifacts/transformations/test-mux-${name.toLowerCase()}.js'
+          ${name}(in Frob frob)
+          consume item
+      `
+    });
+    const renderParticle = manifest.particles[0];
+    const renderParticleSpec = JSON.stringify(renderParticle.toLiteral());
+    const renderRecipe = DomParticle
+                             .buildManifest`
+${renderParticle}
+recipe
+  use '{{item_id}}' as v1
+  slot '{{slot_id}}' as s1
+  ${renderParticle.name}
+    ${renderParticle.connections[0].name} <- v1
+    consume item as s1
+  `.trim();
+    return {renderParticleSpec, renderRecipe: renderRecipe.replace(/[\n]/g, '\\n')};
+  };
+
+  it('varies render particle across heterogeneous items with embedded recipes', async () => {
+    let resultA = await buildEmbeddedItemValues('A');
+    let resultB = await buildEmbeddedItemValues('B');
+
+    const manifest = await Manifest.parse(`
+import 'shell/artifacts/Common/List.manifest'
+
+schema Frob
+  Text renderParticleSpec
+  Text renderRecipe
+
+store Frobs of [Frob] in FrobsJson
+ resource FrobsJson
+   start
+   [
+     {"renderParticleSpec": ${JSON.stringify(resultA.renderParticleSpec)},
+      "renderRecipe": "${resultA.renderRecipe}"},
+     {"renderParticleSpec": ${JSON.stringify(resultB.renderParticleSpec)},
+      "renderRecipe": "${resultB.renderRecipe}"}
+    ]
+
+particle FrobMuxer in 'runtime/test/artifacts/transformations/frob-muxer.js'
+  FrobMuxer(in [Frob] list)
+  consume set of item
+
+recipe
+  use Frobs as frobs
+  List
+    items = frobs
+  FrobMuxer
+    list = frobs
+    `, {loader, fileName: './manifest.manifest'});
+
+    let recipe = manifest.recipes[0];
+    let slotComposer = new MockSlotComposer({strict: false});
+    slotComposer
+      .newExpectations()
+      .expectRenderSlot('A', 'item', {contentTypes: ['template', 'model'], verify: (content) => {
+        if (content.template == '<div mux-a><{{value}}</div>') {
+          return true;
+        }
+      }})
+      .expectRenderSlot('B', 'item', {contentTypes: ['template', 'model'], verify: (content) => {
+        if (content.template == '<div mux-b><{{value}}</div>') {
+          return true;
+        }
+      }})
+      .expectRenderSlot('FrobMuxer', 'item', {contentTypes: ['template', 'model'], verify: content => {
+        if (Object.keys(content.template).length == 2 &&
+            Object.values(content.template)[0] == '<div mux-a><{{value}}</div>' &&
+            Object.values(content.template)[1] == '<div mux-b><{{value}}</div>') {
+          return true;
+        }
+      }})
+      ;
+
+    let arc = new Arc({id: 'test', context: manifest, slotComposer});
+    const resolvedRecipe = await new RecipeResolver(arc).resolve(recipe);
+    await arc.instantiate(resolvedRecipe);
+    await slotComposer.arc.pec.idle;
+    await slotComposer.expectationsCompleted();
   });
 });


### PR DESCRIPTION
Breakout from https://github.com/PolymerLabs/arcs/pull/1219

Incorporates at least partial test for https://github.com/PolymerLabs/arcs/pull/1222

Disables (perhaps only temporarily) the optimization to only ship templates over the api port once per slot. See https://github.com/PolymerLabs/arcs/issues/1233