### PR TITLE
Reland: Make manifest ids unique via a session id.

### DIFF
--- a/runtime/arc.js
+++ b/runtime/arc.js
@@ -34,8 +34,8 @@ class Arc {
     this._pecFactory = pecFactory || FakePecFactory.bind(null);
 
     // for now, every Arc gets its own session
-    this.sessionId = Id.newSessionId();
-    this.id = this.sessionId.fromString(id);
+    const sessionId = Id.newSessionId();
+    this.id = sessionId.fromString(id);
     this._speculative = !!speculative; // undefined => false
     this._nextLocalID = 0;
     this._activeRecipe = new Recipe();

--- a/runtime/manifest.js
+++ b/runtime/manifest.js
@@ -21,6 +21,7 @@ import StorageProviderFactory from './storage/storage-provider-factory.js';
 import scheduler from './scheduler.js';
 import ManifestMeta from './manifest-meta.js';
 import TypeChecker from './recipe/type-checker.js';
+import Id from './id.js';
 
 class ManifestError extends Error {
   constructor(location, message) {
@@ -78,7 +79,8 @@ class Manifest {
     this._handleTags = new Map();
     this._fileName = null;
     this._nextLocalID = 0;
-    this._id = id;
+    const sessionId = Id.newSessionId();
+    this._id = sessionId.fromString(id);
     this._storageProviderFactory = undefined;
     this._scheduler = scheduler;
     this._meta = new ManifestMeta();
@@ -319,7 +321,7 @@ ${e.message}
 
     try {
       // Loading of imported manifests is triggered in parallel to avoid a serial loading
-      // of resources over the network. 
+      // of resources over the network.
       await Promise.all(items.filter(item => item.kind == 'import').map(async item => {
         let path = loader.path(manifest.fileName);
         let target = loader.join(path, item.path);
@@ -502,7 +504,7 @@ ${e.message}
       }
       Object.assign(fields, result.fields);
       names.push(...result.names);
-    } 
+    }
     names = [names[0], ...names.filter(name => name != names[0])];
     let name = schemaItem.alias || names[0];
     if (!name) {
@@ -797,7 +799,7 @@ ${e.message}
       }
 
       for (let slotConnectionItem of item.slotConnections) {
-        // particles that reference verbs should store slot connection information as constraints to be used 
+        // particles that reference verbs should store slot connection information as constraints to be used
         // during verb matching. However, if there's a spec then the slots need to be validated against it
         // instead.
         if (particle.spec !== undefined) {

--- a/runtime/recipe/handle.js
+++ b/runtime/recipe/handle.js
@@ -183,12 +183,30 @@ class Handle {
     }
   }
 
+  // Options:
+  // - showUnresolved: if true, includes unresolved handle details if
+  //   handle is in fact unresolved and they're available.
+  // - stripManifestSessionFromId: if true, strips any manifest session
+  //   id prefix from the handle id.
   toString(nameMap, options) {
     // TODO: type? maybe output in a comment
     let result = [];
     result.push(this.fate);
     if (this.id) {
-      result.push(`'${this.id}'`);
+      let outputId = this.id.toString();
+      if (options && options.stripManifestSessionFromId) {
+        const isEntity = this.type.isEntity || (this.type.isCollection && this.type.primitiveType().isEntity);
+        // TODO(wkorman): `Manifest._processRecipe` has a TODO currently to mark
+        // a handle as immediate. Until we've a cleaner way to identify, we just
+        // scrutinize the handle id for a clear marker. A sample immediate
+        // handle id looks like:
+        // '!130690574120708:manifest:./manifest.manifest::0:immediateB'
+        const isImmediate = /:immediate[^:]+$/.test(this.id);
+        if (isEntity || isImmediate) {
+          outputId = outputId.replace(/^![^:]+:/, '');
+        }
+      }
+      result.push(`'${outputId}'`);
     }
     result.push(...this.tags);
     result.push(`as ${(nameMap && nameMap.get(this)) || this.localName}`);

--- a/runtime/recipe/recipe.js
+++ b/runtime/recipe/recipe.js
@@ -202,7 +202,7 @@ class Recipe {
   }
 
   async digest() {
-    return digest(this.toString());
+    return digest(this.toString({stripManifestSessionFromId: true}));
   }
 
   normalize(options) {
@@ -436,7 +436,10 @@ class Recipe {
   // TODO: Add a normalize() which strips local names and puts and nested
   //       lists into a normal ordering.
   //
-  // use { showUnresolved: true } in options to see why a recipe can't resolve.
+  // Options:
+  // - showUnresolved: if true, includes detail on why a recipe can't resolve.
+  // - stripManifestSessionFromId: if true, strips any manifest session
+  //   id prefix from handle ids.
   toString(options) {
     let nameMap = this._makeLocalNameMap();
     let result = [];

--- a/runtime/test/recipe-test.js
+++ b/runtime/test/recipe-test.js
@@ -9,6 +9,7 @@
  */
 
 import {assert} from './chai-web.js';
+import Loader from '../../runtime/loader.js';
 import Manifest from '../manifest.js';
 import Recipe from '../recipe/recipe.js';
 
@@ -122,5 +123,88 @@ describe('recipe', function() {
     assert.lengthOf(recipe.slots, 1);
     assert.lengthOf(recipe.particles, 1);
     assert.lengthOf(recipe.handles, 1);
+  });
+
+  const getFirstRecipeHash = async manifestContent => {
+    let loader = new Loader();
+    let manifest = await Manifest.parse(manifestContent,
+        {loader, fileName: './manifest.manifest'});
+    let [recipe] = manifest.recipes;
+    assert.isTrue(recipe.normalize());
+    return recipe.digest();
+  };
+
+  it('generates the same hash regardless of session for immediates', async () => {
+    // The `shape` definition below will have an id that includes the manifest
+    // id. We want to make sure that doesn't propagate into causing variance for
+    // the recipe digest.
+    const manifestContent = `
+      shape HostedParticleShape
+        HostedParticleShape(in ~a)
+        consume
+
+      schema Foo
+
+      particle A in 'A.js'
+        A(host HostedParticleShape hostedParticle)
+        consume set of annotation
+
+      particle B in 'B.js'
+        B(in Foo foo)
+        consume annotation
+
+      recipe
+        A
+          hostedParticle <- B
+    `;
+    const digestA = await getFirstRecipeHash(manifestContent);
+    const digestB = await getFirstRecipeHash(manifestContent);
+    assert.equal(digestA, digestB);
+  });
+
+  it('generates the same hash regardless of session for stores', async () => {
+    // The `store` definition below will have an id that includes the manifest
+    // id. We want to make sure that doesn't propagate into causing variance for
+    // the recipe digest.
+    const manifestContent = `
+      store NobId of NobIdStore {Text nobId} in NobIdJson
+       resource NobIdJson
+         start
+         [{"nobId": "12345"}]
+
+      particle A in 'A.js'
+        A(in NobIdStore {Text nobId} foo)
+
+      recipe
+        use NobId as foo
+        A
+          foo <- foo
+    `;
+    const digestA = await getFirstRecipeHash(manifestContent);
+    const digestB = await getFirstRecipeHash(manifestContent);
+    assert.equal(digestA, digestB);
+  });
+
+  it('generates the same hash regardless of session for stores of collections', async () => {
+    // The `store` definition below will have an id that includes the manifest
+    // id. We want to make sure that doesn't propagate into causing variance for
+    // the recipe digest.
+    const manifestContent = `
+      store NobId of [NobIdStore {Text nobId}] in NobIdJson
+       resource NobIdJson
+         start
+         [{"nobId": "12345"}, {"nobId": "67890"}]
+
+      particle A in 'A.js'
+        A(in [NobIdStore {Text nobId}] foo)
+
+      recipe
+        use NobId as foo
+        A
+          foo <- foo
+    `;
+    const digestA = await getFirstRecipeHash(manifestContent);
+    const digestB = await getFirstRecipeHash(manifestContent);
+    assert.equal(digestA, digestB);
   });
 });


### PR DESCRIPTION
Ensures that, for example, store ids for stores with the same name
loaded from a manifest file with the same name receive differing ids,
as they should, since their values could differ.

Updated for reland: Added logic and unit test to ensure that recipe
digest stays the same across multiple parses regardless of immediate
or entity handle manifest session id (as this is important, for example,
for replay purposes).

Reland of https://github.com/PolymerLabs/arcs/pull/1231. Fixes https://github.com/PolymerLabs/arcs/pull/1230.