### PR TITLE
lock npm version to 5.8.0

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,7 +5,7 @@ environment:
 
 install:
   - ps: Install-Product node $env:nodejs_version
-  - npm install -g npm@latest
+  - npm install -g npm@5.8.0
   - npm install
 
 build: off

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,9 @@ addons:
 script: "cd ${TRAVIS_BUILD_DIR} && npm install && npm run test-with-start"
 
 before_install:
-  - npm install -g npm@latest
+  - npm install -g npm@5.8.0
+  - node --version
+  - npm --version
 
 before_deploy:
   # Travis pages deploys skips artifacts from .gitignore. We need some of those, so


### PR DESCRIPTION
This may help with some stream closed appveyor failures (see #1242).
For consistency I've made the same change to both travis & appveyor
configuration.