### PR TITLE
Dependent connections

### DIFF
--- a/runtime/manifest-parser.peg
+++ b/runtime/manifest-parser.peg
@@ -303,8 +303,10 @@ ParticleInterface
   }
 
 ParticleHandle
-  = arg:ParticleArgument eolWhiteSpace
+  = arg:ParticleArgument eolWhiteSpace dependentConnections:(Indent (SameIndent ParticleHandle)*)?
   {
+    dependentConnections = optional(dependentConnections, extractIndented, []);
+    arg.dependentConnections = dependentConnections;
     return arg;
   }
 

--- a/runtime/manifest.js
+++ b/runtime/manifest.js
@@ -549,9 +549,11 @@ ${e.message}
       particleItem.implFile = loader.join(manifest.fileName, particleItem.implFile);
     }
 
-    for (let arg of particleItem.args) {
+    let processArgTypes = args => args.forEach(arg => {
       arg.type = arg.type.model;
-    }
+      processArgTypes(arg.dependentConnections);
+    });
+    processArgTypes(particleItem.args);
 
     let particleSpec = new ParticleSpec(particleItem);
     manifest._particles[particleItem.name] = particleSpec;

--- a/runtime/particle-spec.js
+++ b/runtime/particle-spec.js
@@ -25,7 +25,6 @@ class ConnectionSpec {
 
   instantiateDependentConnections(particle, typeVarMap) {
     for (let dependentArg of this.rawData.dependentConnections) {
-      dependentArg.type = dependentArg.type.model;
       let dependentConnection = particle.createConnection(dependentArg, typeVarMap);
       dependentConnection.parentConnection = this;
       this.dependentConnections.push(dependentConnection);

--- a/runtime/test/manifest-test.js
+++ b/runtime/test/manifest-test.js
@@ -118,6 +118,17 @@ ${particleStr1}
     assert.equal(manifest.particles.length, 1);
     assert.equal(manifest.particles[0].connections.length, 2);
   });
+  it('can parse a manifest with dependent handles', async () => {
+    let manifest = await Manifest.parse(`
+    particle TestParticle in 'a.js'
+      in [Product {}] input
+        out [Product {}] output
+      consume thing
+        provide otherThing
+    `);
+    assert.equal(manifest.particles.length, 1);
+    assert.equal(manifest.particles[0].connections.length, 2);
+  });
   it('can parse a manifest containing a schema', async () => {
     let manifest = await Manifest.parse(`
       schema Bar

--- a/runtime/test/particle-shape-loading-test.js
+++ b/runtime/test/particle-shape-loading-test.js
@@ -92,9 +92,9 @@ describe('particle-shape-loading', function() {
       name: 'outerParticle',
       implFile: 'outer-particle.js',
       args: [
-        {direction: 'host', type: shapeType, name: 'particle'},
-        {direction: 'in', type: fooType, name: 'input'},
-        {direction: 'out', type: barType, name: 'output'}
+        {direction: 'host', type: shapeType, name: 'particle', dependentConnections: []},
+        {direction: 'in', type: fooType, name: 'input', dependentConnections: []},
+        {direction: 'out', type: barType, name: 'output', dependentConnections: []}
       ],
     });
 

--- a/runtime/test/recipe-test.js
+++ b/runtime/test/recipe-test.js
@@ -142,11 +142,11 @@ describe('recipe', function() {
       schema Foo
 
       particle A in 'A.js'
-        A(host HostedParticleShape hostedParticle)
+        host HostedParticleShape hostedParticle
         consume set of annotation
 
       particle B in 'B.js'
-        B(in Foo foo)
+        in Foo foo
         consume annotation
 
       recipe
@@ -166,7 +166,7 @@ describe('recipe', function() {
          [{"nobId": "12345"}]
 
       particle A in 'A.js'
-        A(in NobIdStore {Text nobId} foo)
+        in NobIdStore {Text nobId} foo
 
       recipe
         use NobId as foo
@@ -186,7 +186,7 @@ describe('recipe', function() {
          [{"nobId": "12345"}, {"nobId": "67890"}]
 
       particle A in 'A.js'
-        A(in [NobIdStore {Text nobId}] foo)
+        in [NobIdStore {Text nobId}] foo
 
       recipe
         use NobId as foo


### PR DESCRIPTION
- allow dependent connections to be parsed
- inflate dependent connections & track parents
- ensure dependent connections can be literalized correctly
- make recipes with satisfied connections that have unsatisfied parents unresolved.
- fix some new recipes to match new recipe syntax