### PR TITLE
First cut at particle API rewrite.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21719,7 +21719,7 @@
     "websocket-extensions": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
-      "integrity": "sha1-XS/yKXcAPsaHpLhwc9+7rBRszyk="
+      "integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg=="
     },
     "wgxpath": {
       "version": "1.0.0",

--- a/runtime/api-channel.js
+++ b/runtime/api-channel.js
@@ -263,6 +263,8 @@ class PECOuterPort extends APIPort {
     this.registerCall('StopRender', {particle: this.Mapped, slotName: this.Direct});
 
     this.registerHandler('Render', {particle: this.Mapped, slotName: this.Direct, content: this.Direct});
+    this.registerHandler('InitializeProxy', {handle: this.Mapped, callback: this.Direct});
+    this.registerHandler('ResyncHandle', {handle: this.Mapped, callback: this.Direct});
     this.registerHandler('Synchronize', {handle: this.Mapped, target: this.Mapped,
                                     type: this.Direct, callback: this.Direct,
                                     modelCallback: this.Direct, particleId: this.Direct});
@@ -311,6 +313,8 @@ class PECInnerPort extends APIPort {
     this.registerHandler('StopRender', {particle: this.Mapped, slotName: this.Direct});
 
     this.registerCall('Render', {particle: this.Mapped, slotName: this.Direct, content: this.Direct});
+    this.registerCall('InitializeProxy', {handle: this.Mapped, callback: this.LocalMapped});
+    this.registerCall('ResyncHandle', {handle: this.Mapped, callback: this.LocalMapped});
     this.registerCall('Synchronize', {handle: this.Mapped, target: this.Mapped,
                                  type: this.Direct, callback: this.LocalMapped,
                                  modelCallback: this.LocalMapped, particleId: this.Direct});

--- a/runtime/arc.js
+++ b/runtime/arc.js
@@ -47,13 +47,9 @@ class Arc {
     // All the handles, mapped by handle ID
     this._handlesById = new Map();
 
-    // information about last-seen-versions of handles
-    this._lastSeenVersion = new Map();
-
     // storage keys for referenced handles
     this._storageKeys = {};
     this._storageKey = storageKey;
-
 
     this.particleHandleMaps = new Map();
     let pecId = this.generateID();
@@ -264,7 +260,7 @@ ${this.activeRecipe.toString()}`;
     // At least all non-optional connections must be resolved
     assert(handleMap.handles.size >= handleMap.spec.connections.filter(c => !c.isOptional).length,
            `Not all mandatory connections are resolved for {$particle}`);
-    this.pec.instantiate(recipeParticle, id, handleMap.spec, handleMap.handles, this._lastSeenVersion);
+    this.pec.instantiate(recipeParticle, id, handleMap.spec, handleMap.handles);
     recipeParticle._scheduler = this.scheduler;
     return id;
   }

--- a/runtime/outer-PEC.js
+++ b/runtime/outer-PEC.js
@@ -33,9 +33,32 @@ class OuterPEC extends PEC {
       }
     };
 
+    this._apiPort.onInitializeProxy = async ({handle, callback}) => {
+      let target = {_scheduler: this._arc.scheduler};
+      let model;
+      if (handle.toList === undefined) {
+        model = await handle.getWithVersion();
+      } else {
+        model = await handle.toListWithVersion();
+      }
+      this._apiPort.SimpleCallback({callback, data: model}, target);
+      handle.on('change', data => this._apiPort.SimpleCallback({callback, data}), target);
+    };
+
+    this._apiPort.onResyncHandle = async ({handle, callback}) => {
+      let target = {_scheduler: this._arc.scheduler};
+      let model;
+      if (handle.toList === undefined) {
+        model = await handle.getWithVersion();
+      } else {
+        model = await handle.toListWithVersion();
+      }
+      this._apiPort.SimpleCallback({callback, data: model}, target);
+    };
+
     this._apiPort.onSynchronize = async ({handle, target, callback, modelCallback, type}) => {
       let model;
-      if (handle.toList == undefined) {
+      if (handle.toList === undefined) {
         model = await handle.get();
       } else {
         model = await handle.toList();
@@ -159,11 +182,9 @@ class OuterPEC extends PEC {
     this._apiPort.UIEvent({particle, slotName, event});
   }
 
-  instantiate(particleSpec, id, spec, handles, lastSeenVersion) {
+  instantiate(particleSpec, id, spec, handles) {
     handles.forEach(handle => {
-      let version = lastSeenVersion.get(handle.id) || 0;
-      this._apiPort.DefineHandle(handle, {type: handle.type.resolvedType(), name: handle.name,
-                                       version});
+      this._apiPort.DefineHandle(handle, {type: handle.type.resolvedType(), name: handle.name});
     });
 
     // TODO: Can we just always define the particle and map a handle for use in later

--- a/runtime/particle.js
+++ b/runtime/particle.js
@@ -47,6 +47,37 @@ export class Particle {
 
   }
 
+  /** @method onHandleUpdate(handle, data, add, remove)
+   * Called once after setViews() for each readable handle to establish the current handle values.
+   * Thereafter called whenever the data for a given handle has been updated to the next version.
+   *
+   * handle is the Handle instance that was updated.
+   * version is the received version number.
+   * update is an object with the following fields:
+   *   variable:   The Entity data, or null if the handle was not set prior to setViews or has been
+   *               explicitly cleared. Only defined for Variable-backed handles.
+   *   collection: An Array of Entities; empty if the handle does not contain any entities. Only
+   *               defined for Collection-backed handles.
+   *   added:      An Array of ids indicating which entities were added. Only defined for updates
+   *               to Collection-backed handles.
+   *   removed:    An Array of ids indicating which entities were removed. Only defined for updates
+   *               to Collection-backed handles.
+   */
+  onHandleUpdate(handle, version, update) {
+
+  }
+
+  /** @method onHandleDesync(handle)
+   * Called when an update event for a Collection-backed handle has been missed.
+   * The default implementation automatically resyncronizes the handle.
+   *
+   * handle is the Handle instance that has desynchronized.
+   * version is the received version number.
+   */
+  onHandleDesync(handle, version) {
+    handle.resync();
+  }
+
   constructInnerArc() {
     if (!this.capabilities.constructInnerArc)
       throw new Error('This particle is not allowed to construct inner arcs');

--- a/runtime/storage-proxy.js
+++ b/runtime/storage-proxy.js
@@ -1,0 +1,185 @@
+/**
+ * @license
+ * Copyright (c) 2017 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+'use strict';
+
+import assert from '../platform/assert-web.js';
+
+class StorageProxy {
+  constructor(id, type, port, pec, name, version) {
+    this._id = id;
+    this._type = type;
+    this._port = port;
+    this._pec = pec;
+    this.name = name;
+    this._version = version;
+    this._variable = undefined;
+    this._collection = undefined;
+    this._observers = [];
+  }
+
+  get id() {
+    return this._id;
+  }
+
+  get type() {
+    return this._type;
+  }
+
+  // Sets up a change listener on the outer storage provider.
+  // Must be invoked after the newly constructed proxy has been mapped into the API channel.
+  _initialize() {
+    let callback = received => {
+      if (received.version < this._version) {
+        console.warn(`StorageProxy '${this._id}' received old version ${received.version}; current is ${this._version}`);
+        return;
+      }
+      if (received.version == this._version) {
+        return;
+      }
+
+      let added, removed;
+      if ('data' in received) {
+        // Backing storage is a Variable containing a single Entity.
+        this._variable = received.data;
+      } else if ('list' in received) {
+        // Backing storage is a Collection and we've been given the full set.
+        this._collection = received.list;
+      } else if (this._version !== null && received.version === this._version + 1) {
+        // We've been given the next version of a Collection and have previously received the initial set.
+        [added, removed] = this._processCollectionUpdate(received);
+      } else {
+        // We've missed an update or didn't receive the initial set.
+        // TODO: move to a "desync" state that discards new updates until resynced?
+        this._observers.forEach(({particle, handle}) => particle.onHandleDesync(handle, received.version));
+        return;
+      }
+      this._version = received.version;
+      this._observers.forEach(({particle, handle}) => {
+        handle.notify(particle, this._version, this._buildUpdate(added, removed));
+      });
+    };
+    // TODO: consider deferring this until we have a registered observer; if all particles in the
+    // current arc only ever write to this proxy, there's no need to catch update events.
+    this._port.InitializeProxy({handle: this, callback});
+  }
+
+  // Folds the add/remove change into the stored _collection model, and returns the ids of the
+  // entities added or removed.
+  _processCollectionUpdate(received) {
+    if ('add' in received) {
+      this._collection.push(...received.add);
+      return [received.add.map(e => e.id), undefined];
+    }
+    if ('remove' in received) {
+      let keep = [];
+      let removed = [];
+      for (let held of this._collection) {
+        keep.push(held);
+        // TODO: avoid revisiting removed items? (e.g. use a set of ids, prune as they are matched)
+        for (let item of received.remove) {
+          if (held.id === item.id) {
+            keep.pop();
+            removed.push(item.id);
+            break;
+          }
+        }
+      }
+      this._collection = keep;
+      return [undefined, removed];
+    }
+    assert(false, `StorageProxy received invalid change event: ${JSON.stringify(received)}`);
+  }
+
+  // Called by InnerPEC to associate (potentially multiple) particle/handle pairs with this proxy.
+  register(particle, handle) {
+    this._observers.push({particle, handle});
+    if (this._version != null) {
+      handle.notify(particle, this._version, this._buildUpdate());
+    }
+  }
+
+  // Builds the update object passed to particles. Only relevant fields are defined. Note that we
+  // don't want to say 'update.x = undefined', because then ('x' in update) still returns true.
+  _buildUpdate(added, removed) {
+    let update = {};
+    if (this._variable !== undefined) {
+      update.variable = this._variable;
+    }
+    if (this._collection !== undefined) {
+      update.collection = this._collection;
+    }
+    if (added !== undefined) {
+      update.added = added;
+    }
+    if (removed !== undefined) {
+      update.removed = removed;
+    }
+    return update;
+  }
+
+  // Retrieve the full data from the backing storage.
+  resync() {
+    let callback = received => {
+      if ('data' in received) {
+        this._variable = received.data;
+      } else if ('list' in received) {
+        this._collection = received.list;
+      } else {
+        assert(false, `StorageProxy received invalid resync event: ${JSON.stringify(received)}`);
+      }
+      this._version = received.version;
+      this._observers.forEach(({particle, handle}) => {
+        handle.notify(particle, this._version, this._buildUpdate());
+      });
+    };
+    this._port.ResyncHandle({handle: this, callback});
+  }
+
+  generateIDComponents() {
+    return this._pec.generateIDComponents();
+  }
+
+  on(type, callback, target, particleId) {
+    let dataFreeCallback = (d) => callback();
+    this.synchronize(type, dataFreeCallback, dataFreeCallback, target, particleId);
+  }
+
+  synchronize(type, modelCallback, callback, target, particleId) {
+    this._port.Synchronize({handle: this, modelCallback, callback, target, type, particleId});
+  }
+
+  get(particleId) {
+    return new Promise((resolve, reject) =>
+      this._port.HandleGet({callback: r => resolve(r), handle: this, particleId}));
+  }
+
+  toList(particleId) {
+    return new Promise((resolve, reject) =>
+      this._port.HandleToList({callback: r => resolve(r), handle: this, particleId}));
+  }
+
+  set(entity, particleId) {
+    this._port.HandleSet({data: entity, handle: this, particleId});
+  }
+
+  store(entity, particleId) {
+    this._port.HandleStore({data: entity, handle: this, particleId});
+  }
+
+  remove(entityId, particleId) {
+    this._port.HandleRemove({data: entityId, handle: this, particleId});
+  }
+
+  clear(particleId) {
+    this._port.HandleClear({handle: this, particleId});
+  }
+}
+
+export {StorageProxy};

--- a/runtime/storage/firebase-storage.js
+++ b/runtime/storage/firebase-storage.js
@@ -162,7 +162,7 @@ class FirebaseVariable extends FirebaseStorageProvider {
   }
 
   async cloneFrom(store) {
-    let {data, version} = await store._getWithVersion();
+    let {data, version} = await store.getWithVersion();
     await this._setWithVersion(data, version);
   }
 
@@ -170,7 +170,7 @@ class FirebaseVariable extends FirebaseStorageProvider {
     return this.dataSnapshot.val().data;
   }
 
-  async _getWithVersion() {
+  async getWithVersion() {
     if (this.dataSnapshot == undefined) {
       return new Promise((resolve, reject) => {
         this._pendingGets.push(resolve);
@@ -206,7 +206,7 @@ class FirebaseCollection extends FirebaseStorageProvider {
       let data = dataSnapshot.val();
       this._pendingGets.forEach(_get => _get(data));
       this._pendingGets = [];
-      this._fire('change', {data: this._setToList(data.data), version: data.version});
+      this._fire('change', {list: this._setToList(data.data), version: data.version});
     });
   }
 
@@ -243,7 +243,7 @@ class FirebaseCollection extends FirebaseStorageProvider {
   }
 
   async cloneFrom(store) {
-    let {list, version} = await store._toListWithVersion();
+    let {list, version} = await store.toListWithVersion();
     await this._fromListWithVersion(list, version);
   }
 
@@ -269,7 +269,7 @@ class FirebaseCollection extends FirebaseStorageProvider {
     return this._setToList(this.dataSnapshot.val().data);
   }
 
-  async _toListWithVersion() {
+  async toListWithVersion() {
     if (this.dataSnapshot == undefined) {
       return new Promise((resolve, reject) => {
         this._pendingGets.push(resolve);

--- a/runtime/storage/in-memory-storage.js
+++ b/runtime/storage/in-memory-storage.js
@@ -88,6 +88,10 @@ class InMemoryStorageProvider extends StorageProviderBase {
       return new InMemoryCollection(type, arcId, name, id, key);
     return new InMemoryVariable(type, arcId, name, id, key);
   }
+
+  assignVersionForTesting(v) {
+    this._version = v;
+  }
 }
 
 class InMemoryCollection extends InMemoryStorageProvider {
@@ -104,7 +108,7 @@ class InMemoryCollection extends InMemoryStorageProvider {
   }
 
   async cloneFrom(handle) {
-    let {list, version} = await handle._toListWithVersion();
+    let {list, version} = await handle.toListWithVersion();
     assert(version !== null);
     await this._fromListWithVersion(list, version);
   }
@@ -125,7 +129,7 @@ class InMemoryCollection extends InMemoryStorageProvider {
     return [...this._items.values()];
   }
 
-  async _toListWithVersion() {
+  async toListWithVersion() {
     return {list: [...this._items.values()], version: this._version};
   }
 
@@ -155,6 +159,10 @@ class InMemoryCollection extends InMemoryStorageProvider {
     trace.end({args: {entity}});
   }
 
+  clearItemsForTesting() {
+    this._items.clear();
+  }
+
   // TODO: Something about iterators??
   // TODO: Something about changing order?
 
@@ -176,7 +184,7 @@ class InMemoryVariable extends InMemoryStorageProvider {
   }
 
   async cloneFrom(handle) {
-    let {data, version} = await handle._getWithVersion();
+    let {data, version} = await handle.getWithVersion();
     await this._setWithVersion(data, version);
   }
 
@@ -193,7 +201,7 @@ class InMemoryVariable extends InMemoryStorageProvider {
     return this._stored;
   }
 
-  async _getWithVersion() {
+  async getWithVersion() {
     return {data: this._stored, version: this._version};
   }
 
@@ -206,7 +214,7 @@ class InMemoryVariable extends InMemoryStorageProvider {
   }
 
   async clear() {
-    this.set(undefined);
+    this.set(null);
   }
 
   serializedData() {

--- a/runtime/test/particle-api-test.js
+++ b/runtime/test/particle-api-test.js
@@ -16,66 +16,277 @@ import MessageChannel from '../message-channel.js';
 import InnerPec from '../inner-PEC.js';
 import Loader from '../loader.js';
 
+async function setup(fileMap) {
+  let registry = {};
+  let loader = new class extends Loader {
+    loadResource(path) {
+      return fileMap[path];
+    }
+    path(fileName) {
+      return fileName;
+    }
+    join(_, file) {
+      return file;
+    }
+  };
+  let manifest = await Manifest.load('manifest', loader, {registry});
+  let pecFactory = function(id) {
+    let channel = new MessageChannel();
+    new InnerPec(channel.port1, `${id}:inner`, loader);
+    return channel.port2;
+  };
+  let arc = new Arc({id: 'test', pecFactory, loader});
+  return {manifest, arc};
+}
+
+class ResultInspector {
+  constructor(arc, setView, field) {
+    this._arc = arc;
+    this._handle = setView;
+    this._field = field;
+  }
+
+  async verify(...expectations) {
+    await this._arc.idle;
+    let received = await this._handle.toList();
+    let misses = [];
+    for (let item of received.map(r => r.rawData[this._field])) {
+      let i = expectations.indexOf(item);
+      if (i >= 0) {
+        expectations.splice(i, 1);
+      } else {
+        misses.push(item);
+      }
+    }
+    this._handle.clearItemsForTesting();
+
+    let errors = [];
+    if (expectations.length) {
+      errors.push(`Expected, not received: ${expectations.join(' ')}`);
+    }
+    if (misses.length) {
+      errors.push(`Received, not expected: ${misses.join(' ')}`);
+    }
+
+    return new Promise((resolve, reject) => {
+      if (errors.length == 0) {
+        resolve();
+      } else {
+        reject(new Error(errors.join(' | ')));
+      }
+    });
+  }
+}
+
+async function setupProxySyncTests() {
+  let {manifest, arc} = await setup({
+    manifest: `
+      schema Data
+        Text value
+      schema Result
+        Text value
+
+      particle P in 'a.js'
+        P(in Data foo, inout [Data] bar, out [Result] res)
+
+      recipe
+        use 'test:0' as view0
+        use 'test:1' as view1
+        use 'test:2' as view2
+        P
+          foo <- view0
+          bar = view1
+          res -> view2
+    `,
+    'a.js': `
+      'use strict';
+
+      defineParticle(({Particle}) => {
+        return class P extends Particle {
+          setViews(views) {
+            this._resHandle = views.get('res');
+          }
+
+          onHandleUpdate(handle, version, update) {
+            let res = \`\${handle.name}:\${version}:\`;
+            if ('variable' in update) {
+              res += (update.variable !== null) ? update.variable.value : '(null)';
+            }
+            if ('collection' in update) {
+              res += '[' + update.collection.map(v => v.rawData.value).join('|') + ']';
+            }
+            if ('added' in update) {
+              res += update.added.map(id => '+' + id);
+            }
+            if ('removed' in update) {
+              res += update.removed.map(id => '-' + id);
+            }
+            this.addResult(res);
+          }
+
+          onHandleDesync(handle, version) {
+            this.addResult(\`\${handle.name}:\${version}:<desync>\`);
+            handle.resync();
+          }
+
+          async addResult(msg) {
+            await this._resHandle.store(new this._resHandle.entityClass({value: msg}));
+          }
+        }
+      });
+    `
+  });
+
+  let Data = manifest.findSchemaByName('Data').entityClass();
+  let Result = manifest.findSchemaByName('Result').entityClass();
+  let fooHandle = await arc.createHandle(Data.type, 'foo', 'test:0');
+  let barHandle = await arc.createHandle(Data.type.setViewOf(), 'bar', 'test:1');
+  let resHandle = await arc.createHandle(Result.type.setViewOf(), 'res', 'test:2');
+  let inspector = new ResultInspector(arc, resHandle, 'value');
+
+  let recipe = manifest.recipes[0];
+  recipe.handles[0].mapToStorage(fooHandle);
+  recipe.handles[1].mapToStorage(barHandle);
+  recipe.handles[2].mapToStorage(resHandle);
+  recipe.normalize();
+  return {arc, recipe, Data, fooHandle, barHandle, inspector};
+}
+
 describe('particle-api', function() {
+  it('notifies on updates for initially empty handles', async function() {
+    let {arc, recipe, Data, fooHandle, barHandle, inspector} = await setupProxySyncTests();
+
+    await arc.instantiate(recipe);
+    await inspector.verify('foo:0:(null)', 'bar:0:[]');
+
+    await fooHandle.set(new Data({value: 'oh'}));
+    await barHandle.store({id: 'i1', rawData: {value: 'hai'}});
+    await inspector.verify('foo:1:oh', 'bar:1:[hai]+i1');
+  });
+
+  it('notifies on updates for initially populated handles', async () => {
+    let {arc, recipe, Data, fooHandle, barHandle, inspector} = await setupProxySyncTests();
+
+    await fooHandle.set(new Data({value: 'well'}));
+    await barHandle.store({id: 'i1', rawData: {value: 'hi'}});
+    await barHandle.store({id: 'i2', rawData: {value: 'there'}});
+    await arc.instantiate(recipe);
+    await inspector.verify('foo:1:well', 'bar:2:[hi|there]');
+
+    await fooHandle.set(new Data({value: 'heeey'}));
+    await barHandle.store({id: 'i3', rawData: {value: 'buddy'}});
+    await inspector.verify('foo:2:heeey', 'bar:3:[hi|there|buddy]+i3');
+  });
+
+  it('notifies for Variables being cleared', async () => {
+    let {arc, recipe, Data, fooHandle, inspector} = await setupProxySyncTests();
+
+    await fooHandle.set(new Data({value: 'well'}));
+    await arc.instantiate(recipe);
+    await inspector.verify('foo:1:well', 'bar:0:[]');
+
+    await fooHandle.clear();
+    await inspector.verify('foo:2:(null)');
+  });
+
+  it('notifies for items being removed from Collections', async () => {
+    let {arc, recipe, barHandle, inspector} = await setupProxySyncTests();
+
+    await barHandle.store({id: 'i1', rawData: {value: 'its'}});
+    await barHandle.store({id: 'i2', rawData: {value: 'ame'}});
+    await barHandle.store({id: 'i3', rawData: {value: 'mario'}});
+    await arc.instantiate(recipe);
+    await inspector.verify('foo:0:(null)', 'bar:3:[its|ame|mario]');
+
+    await barHandle.remove('i1');
+    await barHandle.remove('i2');
+    await barHandle.remove('i3');
+    await inspector.verify('bar:4:[ame|mario]-i1', 'bar:5:[mario]-i2', 'bar:6:[]-i3');
+  });
+
+  it('notifies on Collection desyncronized', async function() {
+    let {arc, recipe, Data, fooHandle, barHandle, inspector} = await setupProxySyncTests();
+
+    await barHandle.store({id: 'i1', rawData: {value: 'thelma'}});
+    await arc.instantiate(recipe);
+    await inspector.verify('foo:0:(null)', 'bar:1:[thelma]');
+
+    // Fake a message being missed.
+    barHandle.assignVersionForTesting(2);
+    await barHandle.store({id: 'i3', rawData: {value: 'louise'}});
+    // Test particle auto-resyncs, so we should see a second update with the full set.
+    await inspector.verify('bar:3:<desync>', 'bar:3:[thelma|louise]');
+  });
+
+  it('ignores updates for current and previous versions', async () => {
+    let {arc, recipe, Data, fooHandle, barHandle, inspector} = await setupProxySyncTests();
+
+    fooHandle.assignVersionForTesting(3);
+    barHandle.assignVersionForTesting(3);
+    await fooHandle.set(new Data({value: 'batman'}));
+    await barHandle.store({id: 'i4', rawData: {value: 'robin'}});
+    await arc.instantiate(recipe);
+    await inspector.verify('foo:4:batman', 'bar:4:[robin]');
+
+    // Updates with previous version should be ignored.
+    fooHandle.assignVersionForTesting(2);
+    barHandle.assignVersionForTesting(2);
+    await fooHandle.set(new Data({value: 'gnatman'}));
+    await barHandle.store({id: 'i3', rawData: {value: 'bobbin'}});
+    await inspector.verify();
+
+    // Updates with same version should be ignored.
+    await fooHandle.set(new Data({value: 'ratman'}));
+    await barHandle.store({id: 'i4', rawData: {value: 'sobbin'}});
+    await inspector.verify();
+
+    // Updates with a new version should not be ignored.
+    await fooHandle.set(new Data({value: 'statman'}));
+    await barHandle.store({id: 'i5', rawData: {value: 'globbin'}});
+    await inspector.verify('foo:5:statman', 'bar:5:[robin|globbin]+i5');
+  });
+
   it('contains view synchronize calls', async () => {
-    let registry = {};
-    let loader = new class extends Loader {
-      loadResource(path) {
-        return {
-          manifest: `
-          schema Input
-            Text value
+    let {manifest, arc} = await setup({
+      manifest: `
+        schema Input
+          Text value
 
-          schema Result
-            Text value
+        schema Result
+          Text value
 
-          particle P in 'a.js'
-            in [Input] inputs
-            out Result result
+        particle P in 'a.js'
+          in [Input] inputs
+          out Result result
 
-          recipe
-            use 'test:1' as view0
-            use 'test:2' as view1
-            P
-              inputs <- view0
-              result -> view1
-          `,
-          'a.js': `
-            "use strict";
+        recipe
+          use 'test:1' as view0
+          use 'test:2' as view1
+          P
+            inputs <- view0
+            result -> view1
+      `,
+      'a.js': `
+        "use strict";
 
-            defineParticle(({Particle}) => {
-              return class P extends Particle {
-                async setViews(views) {
-                  var input = views.get("inputs");
-                  var output = views.get("result");
-                  input.synchronize('change', model => {
-                    output.set(new output.entityClass({value: '' + model.length}));
-                  }, _update => undefined, this);
-                }
-              }
-            });
-          `
-        }[path];
-      }
-      path(fileName) {
-        return fileName;
-      }
-      join(_, file) {
-        return file;
-      }
-    };
-    let manifest = await Manifest.load('manifest', loader, {registry});
-    let pecFactory = function(id) {
-      let channel = new MessageChannel();
-      new InnerPec(channel.port1, `${id}:inner`, loader);
-      return channel.port2;
-    };
-    let arc = new Arc({id: 'test', pecFactory});
+        defineParticle(({Particle}) => {
+          return class P extends Particle {
+            async setViews(views) {
+              var input = views.get("inputs");
+              var output = views.get("result");
+              input.synchronize('change', model => {
+                output.set(new output.entityClass({value: '' + model.length}));
+              }, _update => undefined, this);
+            }
+          }
+        });
+      `
+    });
 
     let Input = manifest.findSchemaByName('Input').entityClass();
     let inputView = await arc.createHandle(Input.type.setViewOf(), undefined, 'test:1');
-    inputView.store({id: 1, text: 'Hi'});
-    inputView.store({id: 2, text: 'There'});
+    inputView.store({id: '1', rawData: {value: 'Hi'}});
+    inputView.store({id: '2', rawData: {value: 'There'}});
 
     let Result = manifest.findSchemaByName('Result').entityClass();
     let resultHandle = await arc.createHandle(Result.type, undefined, 'test:2');
@@ -86,56 +297,39 @@ describe('particle-api', function() {
     await arc.instantiate(recipe);
 
     await util.assertSingletonWillChangeTo(resultHandle, Result, '2');
-  }),
+  });
+
   it('contains a constructInnerArc call', async () => {
-    let registry = {};
-    let loader = new class extends Loader {
-      loadResource(path) {
-        return {
-          manifest: `
-            schema Result
-              Text value
+    let {manifest, arc} = await setup({
+      manifest: `
+        schema Result
+          Text value
 
-            particle P in 'a.js'
-              out Result result
+        particle P in 'a.js'
+          out Result result
 
-            recipe
-              use as view0
-              P
-                result -> view0
+        recipe
+          use as view0
+          P
+            result -> view0
+      `,
+      'a.js': `
+        "use strict";
 
-          `,
-          'a.js': `
-            "use strict";
+        defineParticle(({Particle}) => {
+          return class P extends Particle {
+            async setViews(views) {
+              let arc = await this.constructInnerArc();
+              var resultHandle = views.get('result');
+              let view = await arc.createHandle(resultHandle.type, "a view");
+              view.set(new resultHandle.entityClass({value: 'success'}));
+              resultHandle.set(new resultHandle.entityClass({value: 'done'}));
+            }
+          }
+        });
+      `
+    });
 
-            defineParticle(({Particle}) => {
-              return class P extends Particle {
-                async setViews(views) {
-                  let arc = await this.constructInnerArc();
-                  var resultHandle = views.get('result');
-                  let view = await arc.createHandle(resultHandle.type, "a view");
-                  view.set(new resultHandle.entityClass({value: 'success'}));
-                  resultHandle.set(new resultHandle.entityClass({value: 'done'}));
-                }
-              }
-            });
-          `
-        }[path];
-      }
-      path(fileName) {
-        return fileName;
-      }
-      join(_, file) {
-        return file;
-      }
-    };
-    let manifest = await Manifest.load('manifest', loader, {registry});
-    let pecFactory = function(id) {
-      let channel = new MessageChannel();
-      new InnerPec(channel.port1, `${id}:inner`, loader);
-      return channel.port2;
-    };
-    let arc = new Arc({id: 'test', pecFactory});
     let Result = manifest.findSchemaByName('Result').entityClass();
     let resultHandle = await arc.createHandle(Result.type, undefined, 'test:1');
     let recipe = manifest.recipes[0];
@@ -150,88 +344,70 @@ describe('particle-api', function() {
   });
 
   it('can load a recipe', async () => {
-    let registry = {};
-    let loader = new class extends Loader {
-      loadResource(path) {
-        return {
-          manifest: `
-            schema Result
-              Text value
+    let {manifest, arc} = await setup({
+      manifest: `
+        schema Result
+          Text value
 
-            particle P in 'a.js'
-              out Result result
+        particle P in 'a.js'
+          out Result result
 
-            recipe
-              use 'test:1' as view0
-              P
-                result -> view0
+        recipe
+          use 'test:1' as view0
+          P
+            result -> view0
+      `,
+      'a.js': `
+        "use strict";
 
-          `,
-          'a.js': `
-            "use strict";
+        defineParticle(({Particle}) => {
+          return class P extends Particle {
+            async setViews(views) {
+              let arc = await this.constructInnerArc();
+              var resultHandle = views.get('result');
+              let inView = await arc.createHandle(resultHandle.type, "in view");
+              let outView = await arc.createHandle(resultHandle.type, "out view");
+              try {
+                await arc.loadRecipe(\`
+                  schema Result
+                    Text value
 
-            defineParticle(({Particle}) => {
-              return class P extends Particle {
-                async setViews(views) {
-                  let arc = await this.constructInnerArc();
-                  var resultHandle = views.get('result');
-                  let inView = await arc.createHandle(resultHandle.type, "in view");
-                  let outView = await arc.createHandle(resultHandle.type, "out view");
-                  try {
-                    await arc.loadRecipe(\`
-                      schema Result
-                        Text value
+                  particle PassThrough in 'pass-through.js'
+                    in Result a
+                    out Result b
 
-                      particle PassThrough in 'pass-through.js'
-                        in Result a
-                        out Result b
+                  recipe
+                    use '\${inView._id}' as v1
+                    use '\${outView._id}' as v2
+                    PassThrough
+                      a <- v1
+                      b -> v2
 
-                      recipe
-                        use '\${inView._id}' as v1
-                        use '\${outView._id}' as v2
-                        PassThrough
-                          a <- v1
-                          b -> v2
-
-                    \`);
-                    inView.set(new resultHandle.entityClass({value: 'success'}));
-                    resultHandle.set(new resultHandle.entityClass({value: 'done'}));
-                  } catch (e) {
-                    resultHandle.set(new resultHandle.entityClass({value: e}));
-                  }
-                }
+                \`);
+                inView.set(new resultHandle.entityClass({value: 'success'}));
+                resultHandle.set(new resultHandle.entityClass({value: 'done'}));
+              } catch (e) {
+                resultHandle.set(new resultHandle.entityClass({value: e}));
               }
-            });
-          `,
-          'pass-through.js': `
-            "use strict";
+            }
+          }
+        });
+      `,
+      'pass-through.js': `
+        "use strict";
 
-            defineParticle(({Particle}) => {
-              return class PassThrough extends Particle {
-                setViews(views) {
-                  views.get('a').get().then(result => {
-                    views.get('b').set(result);
-                  });
-                }
-              }
-          });
-          `
-        }[path];
-      }
-      path(fileName) {
-        return fileName;
-      }
-      join(_, file) {
-        return file;
-      }
-    };
-    let manifest = await Manifest.load('manifest', loader, {registry});
-    let pecFactory = function(id) {
-      let channel = new MessageChannel();
-      new InnerPec(channel.port1, `${id}:inner`, loader);
-      return channel.port2;
-    };
-    let arc = new Arc({id: 'test', pecFactory, loader});
+        defineParticle(({Particle}) => {
+          return class PassThrough extends Particle {
+            setViews(views) {
+              views.get('a').get().then(result => {
+                views.get('b').set(result);
+              });
+            }
+          }
+        });
+      `
+    });
+
     let Result = manifest.findSchemaByName('Result').entityClass();
     let resultHandle = await arc.createHandle(Result.type, undefined, 'test:1');
     let recipe = manifest.recipes[0];
@@ -246,100 +422,82 @@ describe('particle-api', function() {
   });
 
   it('can load a recipe referencing a manifest store', async () => {
-    let registry = {};
-    let loader = new class extends Loader {
-      loadResource(path) {
-        return {
-          manifest: `
-            schema Result
-              Text value
+    let {manifest, arc} = await setup({
+      manifest: `
+        schema Result
+          Text value
 
-            particle P in 'a.js'
-              out Result result
+        particle P in 'a.js'
+          out Result result
 
-            recipe
-              use 'test:1' as view0
-              P
-                result -> view0
+        recipe
+          use 'test:1' as view0
+          P
+            result -> view0
+      `,
+      'a.js': `
+        "use strict";
 
-          `,
-          'a.js': `
-            "use strict";
+        defineParticle(({Particle}) => {
+          return class P extends Particle {
+            async setViews(views) {
+              let arc = await this.constructInnerArc();
+              var resultHandle = views.get('result');
+              let inView = await arc.createHandle(resultHandle.type, "in view");
+              let outView = await arc.createHandle(resultHandle.type, "out view");
+              try {
+                await arc.loadRecipe(\`
+                  schema Result
+                    Text value
 
-            defineParticle(({Particle}) => {
-              return class P extends Particle {
-                async setViews(views) {
-                  let arc = await this.constructInnerArc();
-                  var resultHandle = views.get('result');
-                  let inView = await arc.createHandle(resultHandle.type, "in view");
-                  let outView = await arc.createHandle(resultHandle.type, "out view");
-                  try {
-                    await arc.loadRecipe(\`
-                      schema Result
-                        Text value
+                  store NobId of NobIdStore {Text nobId} in NobIdJson
+                   resource NobIdJson
+                     start
+                     [{"nobId": "12345"}]
 
-                      store NobId of NobIdStore {Text nobId} in NobIdJson
-                       resource NobIdJson
-                         start
-                         [{"nobId": "12345"}]
+                   particle PassThrough in 'pass-through.js'
+                     in NobIdStore {Text nobId} nobId
+                     in Result a
+                     out Result b
 
-                       particle PassThrough in 'pass-through.js'
-                         in NobIdStore {Text nobId} nobId
-                         in Result a
-                         out Result b
+                   recipe
+                     map NobId as nobId
+                     use '\${inView._id}' as v1
+                     use '\${outView._id}' as v2
+                     PassThrough
+                       nobId <- nobId
+                       a <- v1
+                       b -> v2
 
-                       recipe
-                         map NobId as nobId
-                         use '\${inView._id}' as v1
-                         use '\${outView._id}' as v2
-                         PassThrough
-                           nobId <- nobId
-                           a <- v1
-                           b -> v2
+                \`);
+                inView.set(new resultHandle.entityClass({value: 'success'}));
+                resultHandle.set(new resultHandle.entityClass({value: 'done'}));
+              } catch (e) {
+                resultHandle.set(new resultHandle.entityClass({value: e}));
+              }
+            }
+          }
+        });
+      `,
+      'pass-through.js': `
+        "use strict";
 
-                    \`);
-                    inView.set(new resultHandle.entityClass({value: 'success'}));
-                    resultHandle.set(new resultHandle.entityClass({value: 'done'}));
-                  } catch (e) {
-                    resultHandle.set(new resultHandle.entityClass({value: e}));
+        defineParticle(({Particle}) => {
+          return class PassThrough extends Particle {
+            setViews(views) {
+              views.get('a').get().then(resultA => {
+                views.get('nobId').get().then(resultNob => {
+                  if (resultNob.nobId === '12345') {
+                    views.get('b').set(resultA);
                   }
-                }
-              }
-            });
-          `,
-          'pass-through.js': `
-            "use strict";
+                })
+              });
+            }
+          }
+        });
+      `
+    });
 
-            defineParticle(({Particle}) => {
-              return class PassThrough extends Particle {
-                setViews(views) {
-                  views.get('a').get().then(resultA => {
-                    views.get('nobId').get().then(resultNob => {
-                      if (resultNob.nobId === '12345') {
-                        views.get('b').set(resultA);
-                      }
-                    })
-                  });
-                }
-              }
-            });
-          `
-        }[path];
-      }
-      path(fileName) {
-        return fileName;
-      }
-      join(_, file) {
-        return file;
-      }
-    };
-    let manifest = await Manifest.load('manifest', loader, {registry});
-    let pecFactory = function(id) {
-      let channel = new MessageChannel();
-      new InnerPec(channel.port1, `${id}:inner`, loader);
-      return channel.port2;
-    };
-    let arc = new Arc({id: 'test', pecFactory, loader});
     let Result = manifest.findSchemaByName('Result').entityClass();
     let resultHandle = await arc.createHandle(Result.type, undefined, 'test:1');
     let recipe = manifest.recipes[0];
@@ -354,102 +512,84 @@ describe('particle-api', function() {
   });
 
   it('can load a recipe referencing a tagged handle in containing arc', async () => {
-    let registry = {};
-    let loader = new class extends Loader {
-      loadResource(path) {
-        return {
-          manifest: `
-            schema Result
-              Text value
+    let {manifest, arc} = await setup({
+      manifest: `
+        schema Result
+          Text value
 
-            schema Foo
-              Text bar
+        schema Foo
+          Text bar
 
-            particle P in 'a.js'
-              out Result result
-              in Foo target
+        particle P in 'a.js'
+          out Result result
+          in Foo target
 
-            recipe
-              use 'test:1' as view0
-              create #target as target
-              P
-                result -> view0
-                target <- target
+        recipe
+          use 'test:1' as view0
+          create #target as target
+          P
+            result -> view0
+            target <- target
+      `,
+      'a.js': `
+        "use strict";
 
-          `,
-          'a.js': `
-            "use strict";
+        defineParticle(({Particle}) => {
+          return class P extends Particle {
+            async setViews(views) {
+              let arc = await this.constructInnerArc();
+              var resultHandle = views.get('result');
+              let inView = await arc.createHandle(resultHandle.type, "in view");
+              let outView = await arc.createHandle(resultHandle.type, "out view");
+              try {
+                await arc.loadRecipe(\`
+                   schema Foo
+                     Text bar
 
-            defineParticle(({Particle}) => {
-              return class P extends Particle {
-                async setViews(views) {
-                  let arc = await this.constructInnerArc();
-                  var resultHandle = views.get('result');
-                  let inView = await arc.createHandle(resultHandle.type, "in view");
-                  let outView = await arc.createHandle(resultHandle.type, "out view");
-                  try {
-                    await arc.loadRecipe(\`
-                       schema Foo
-                         Text bar
+                   schema Result
+                     Text value
 
-                       schema Result
-                         Text value
+                   particle PassThrough in 'pass-through.js'
+                     in Foo target
+                     in Result a
+                     out Result b
 
-                       particle PassThrough in 'pass-through.js'
-                         in Foo target
-                         in Result a
-                         out Result b
+                   recipe
+                     use #target as target
+                     use '\${inView._id}' as v1
+                     use '\${outView._id}' as v2
+                     PassThrough
+                       target <- target
+                       a <- v1
+                       b -> v2
 
-                       recipe
-                         use #target as target
-                         use '\${inView._id}' as v1
-                         use '\${outView._id}' as v2
-                         PassThrough
-                           target <- target
-                           a <- v1
-                           b -> v2
-
-                    \`);
-                    inView.set(new resultHandle.entityClass({value: 'success'}));
-                    resultHandle.set(new resultHandle.entityClass({value: 'done'}));
-                  } catch (e) {
-                    resultHandle.set(new resultHandle.entityClass({value: e}));
-                  }
-                }
+                \`);
+                inView.set(new resultHandle.entityClass({value: 'success'}));
+                resultHandle.set(new resultHandle.entityClass({value: 'done'}));
+              } catch (e) {
+                resultHandle.set(new resultHandle.entityClass({value: e}));
               }
-            });
-          `,
-          'pass-through.js': `
-            "use strict";
+            }
+          }
+        });
+      `,
+      'pass-through.js': `
+        "use strict";
 
-            defineParticle(({Particle}) => {
-              return class PassThrough extends Particle {
-                setViews(views) {
-                  views.get('a').get().then(resultA => {
-                    views.get('target').get().then(resultTarget => {
-                      views.get('b').set(resultA);
-                    })
-                  });
-                }
-              }
-            });
-          `
-        }[path];
-      }
-      path(fileName) {
-        return fileName;
-      }
-      join(_, file) {
-        return file;
-      }
-    };
-    let manifest = await Manifest.load('manifest', loader, {registry});
-    let pecFactory = function(id) {
-      let channel = new MessageChannel();
-      new InnerPec(channel.port1, `${id}:inner`, loader);
-      return channel.port2;
-    };
-    let arc = new Arc({id: 'test', pecFactory, loader});
+        defineParticle(({Particle}) => {
+          return class PassThrough extends Particle {
+            setViews(views) {
+              views.get('a').get().then(resultA => {
+                views.get('target').get().then(resultTarget => {
+                  views.get('b').set(resultA);
+                })
+              });
+            }
+          }
+        });
+      `
+    });
+
     let Result = manifest.findSchemaByName('Result').entityClass();
     let resultHandle = await arc.createHandle(Result.type, undefined, 'test:1');
     let recipe = manifest.recipes[0];
@@ -470,100 +610,82 @@ describe('particle-api', function() {
   // potentially address either by including more strategies in the outer-PEC's
   // strategizer or adding such fallback to `arc.findHandlesByType`.
   it.skip('can load a recipe referencing a tagged handle in manifest', async () => {
-    let registry = {};
-    let loader = new class extends Loader {
-      loadResource(path) {
-        return {
-          manifest: `
-            schema Result
-              Text value
+    let {manifest, arc} = await setup({
+      manifest: `
+        schema Result
+          Text value
 
-            store NobId of NobIdStore {Text nobId} #target in NobIdJson
-             resource NobIdJson
-               start
-               [{"nobId": "12345"}]
+        store NobId of NobIdStore {Text nobId} #target in NobIdJson
+         resource NobIdJson
+           start
+           [{"nobId": "12345"}]
 
-            particle P in 'a.js'
-              out Result result
+        particle P in 'a.js'
+          out Result result
 
-            recipe
-              use 'test:1' as view0
-              P
-                result -> view0
+        recipe
+          use 'test:1' as view0
+          P
+            result -> view0
+      `,
+      'a.js': `
+        "use strict";
 
-          `,
-          'a.js': `
-            "use strict";
+        defineParticle(({Particle}) => {
+          return class P extends Particle {
+            async setViews(views) {
+              let arc = await this.constructInnerArc();
+              var resultHandle = views.get('result');
+              let inView = await arc.createHandle(resultHandle.type, "in view");
+              let outView = await arc.createHandle(resultHandle.type, "out view");
+              try {
+                await arc.loadRecipe(\`
+                   schema Result
+                     Text value
 
-            defineParticle(({Particle}) => {
-              return class P extends Particle {
-                async setViews(views) {
-                  let arc = await this.constructInnerArc();
-                  var resultHandle = views.get('result');
-                  let inView = await arc.createHandle(resultHandle.type, "in view");
-                  let outView = await arc.createHandle(resultHandle.type, "out view");
-                  try {
-                    await arc.loadRecipe(\`
-                       schema Result
-                         Text value
+                   particle PassThrough in 'pass-through.js'
+                     in NobIdStore {Text nobId} target
+                     in Result a
+                     out Result b
 
-                       particle PassThrough in 'pass-through.js'
-                         in NobIdStore {Text nobId} target
-                         in Result a
-                         out Result b
+                   recipe
+                     use #target as target
+                     use '\${inView._id}' as v1
+                     use '\${outView._id}' as v2
+                     PassThrough
+                       target <- target
+                       a <- v1
+                       b -> v2
 
-                       recipe
-                         use #target as target
-                         use '\${inView._id}' as v1
-                         use '\${outView._id}' as v2
-                         PassThrough
-                           target <- target
-                           a <- v1
-                           b -> v2
+                \`);
+                inView.set(new resultHandle.entityClass({value: 'success'}));
+                resultHandle.set(new resultHandle.entityClass({value: 'done'}));
+              } catch (e) {
+                resultHandle.set(new resultHandle.entityClass({value: e}));
+              }
+            }
+          }
+        });
+      `,
+      'pass-through.js': `
+        "use strict";
 
-                    \`);
-                    inView.set(new resultHandle.entityClass({value: 'success'}));
-                    resultHandle.set(new resultHandle.entityClass({value: 'done'}));
-                  } catch (e) {
-                    resultHandle.set(new resultHandle.entityClass({value: e}));
+        defineParticle(({Particle}) => {
+          return class PassThrough extends Particle {
+            setViews(views) {
+              views.get('a').get().then(resultA => {
+                views.get('target').get().then(resultNob => {
+                  if (resultNob.nobId === '12345') {
+                    views.get('b').set(resultA);
                   }
-                }
-              }
-            });
-          `,
-          'pass-through.js': `
-            "use strict";
+                })
+              });
+            }
+          }
+        });
+      `
+    });
 
-            defineParticle(({Particle}) => {
-              return class PassThrough extends Particle {
-                setViews(views) {
-                  views.get('a').get().then(resultA => {
-                    views.get('target').get().then(resultNob => {
-                      if (resultNob.nobId === '12345') {
-                        views.get('b').set(resultA);
-                      }
-                    })
-                  });
-                }
-              }
-            });
-          `
-        }[path];
-      }
-      path(fileName) {
-        return fileName;
-      }
-      join(_, file) {
-        return file;
-      }
-    };
-    let manifest = await Manifest.load('manifest', loader, {registry});
-    let pecFactory = function(id) {
-      let channel = new MessageChannel();
-      new InnerPec(channel.port1, `${id}:inner`, loader);
-      return channel.port2;
-    };
-    let arc = new Arc({id: 'test', pecFactory, loader});
     let Result = manifest.findSchemaByName('Result').entityClass();
     let resultHandle = await arc.createHandle(Result.type, undefined, 'test:1');
     let recipe = manifest.recipes[0];
@@ -578,104 +700,86 @@ describe('particle-api', function() {
   });
 
   it('multiplexing', async () => {
-    let registry = {};
-    let loader = new class extends Loader {
-      loadResource(path) {
-        return {
-          manifest: `
-            schema Result
-              Text value
+    let {manifest, arc} = await setup({
+      manifest: `
+        schema Result
+          Text value
 
-            particle P in 'a.js'
-              in [Result] inputs
-              inout [Result] results
+        particle P in 'a.js'
+          in [Result] inputs
+          inout [Result] results
 
-            recipe
-              use 'test:1' as view0
-              use 'test:2' as view1
-              P
-                inputs <- view0
-                results = view1
+        recipe
+          use 'test:1' as view0
+          use 'test:2' as view1
+          P
+            inputs <- view0
+            results = view1
+      `,
+      'a.js': `
+        "use strict";
 
-          `,
-          'a.js': `
-            "use strict";
+        defineParticle(({Particle}) => {
+          return class P extends Particle {
+            async setViews(views) {
+              let arc = await this.constructInnerArc();
+              var inputsView = views.get('inputs');
+              var inputsList = await inputsView.toList();
+              var resultsView = views.get('results');
+              for (let input of inputsList) {
+                let inView = await arc.createHandle(resultsView.type.primitiveType(), "in view");
+                let outView = await arc.createHandle(resultsView.type.primitiveType(), "out view");
+                try {
+                  let done = await arc.loadRecipe(\`
+                    schema Result
+                      Text value
 
-            defineParticle(({Particle}) => {
-              return class P extends Particle {
-                async setViews(views) {
-                  let arc = await this.constructInnerArc();
-                  var inputsView = views.get('inputs');
-                  var inputsList = await inputsView.toList();
-                  var resultsView = views.get('results');
-                  for (let input of inputsList) {
-                    let inView = await arc.createHandle(resultsView.type.primitiveType(), "in view");
-                    let outView = await arc.createHandle(resultsView.type.primitiveType(), "out view");
-                    try {
-                      let done = await arc.loadRecipe(\`
-                        schema Result
-                          Text value
+                    particle PassThrough in 'pass-through.js'
+                      in Result a
+                      out Result b
 
-                        particle PassThrough in 'pass-through.js'
-                          in Result a
-                          out Result b
+                    recipe
+                      use '\${inView._id}' as v1
+                      use '\${outView._id}' as v2
+                      PassThrough
+                        a <- v1
+                        b -> v2
 
-                        recipe
-                          use '\${inView._id}' as v1
-                          use '\${outView._id}' as v2
-                          PassThrough
-                            a <- v1
-                            b -> v2
+                  \`);
+                  inView.set(input);
+                  let res = resultsView.store(new resultsView.entityClass({value: 'done'}));
 
-                      \`);
-                      inView.set(input);
-                      let res = resultsView.store(new resultsView.entityClass({value: 'done'}));
-
-                      outView.on('change', () => {
-                        outView.get().then(result => {
-                          if (result) {
-                            resultsView.store(result);
-                          }
-                        })
-                      }, this);
-                    } catch (e) {
-                      resultsView.store(new resultsView.entityClass({value: e}));
-                    }
-                  }
+                  outView.on('change', () => {
+                    outView.get().then(result => {
+                      if (result) {
+                        resultsView.store(result);
+                      }
+                    })
+                  }, this);
+                } catch (e) {
+                  resultsView.store(new resultsView.entityClass({value: e}));
                 }
               }
-            });
-          `,
-          'pass-through.js': `
-            "use strict";
+            }
+          }
+        });
+      `,
+      'pass-through.js': `
+        "use strict";
 
-            defineParticle(({Particle}) => {
-              return class PassThrough extends Particle {
-                setViews(views) {
-                  views.get('a').get().then(result => {
-                    var bView = views.get('b');
-                    bView.set(new bView.entityClass({value:result.value.toUpperCase()}));
-                  });
-                }
-              }
-          });
-          `
-        }[path];
-      }
-      path(fileName) {
-        return fileName;
-      }
-      join(_, file) {
-        return file;
-      }
-    };
-    let manifest = await Manifest.load('manifest', loader, {registry});
-    let pecFactory = function(id) {
-      let channel = new MessageChannel();
-      new InnerPec(channel.port1, `${id}:inner`, loader);
-      return channel.port2;
-    };
-    let arc = new Arc({id: 'test', pecFactory, loader});
+        defineParticle(({Particle}) => {
+          return class PassThrough extends Particle {
+            setViews(views) {
+              views.get('a').get().then(result => {
+                var bView = views.get('b');
+                bView.set(new bView.entityClass({value:result.value.toUpperCase()}));
+              });
+            }
+          }
+        });
+      `
+    });
+
     let Result = manifest.findSchemaByName('Result').entityClass();
     let inputsView = await arc.createHandle(Result.type.setViewOf(), undefined, 'test:1');
     inputsView.store({id: '1', rawData: {value: 'hello'}});

--- a/runtime/test/particle-api-test.js
+++ b/runtime/test/particle-api-test.js
@@ -16,7 +16,7 @@ import MessageChannel from '../message-channel.js';
 import InnerPec from '../inner-PEC.js';
 import Loader from '../loader.js';
 
-async function setup(fileMap) {
+async function loadFilesIntoNewArc(fileMap) {
   let registry = {};
   let loader = new class extends Loader {
     loadResource(path) {
@@ -79,7 +79,7 @@ class ResultInspector {
 }
 
 async function setupProxySyncTests() {
-  let {manifest, arc} = await setup({
+  let {manifest, arc} = await loadFilesIntoNewArc({
     manifest: `
       schema Data
         Text value
@@ -247,7 +247,7 @@ describe('particle-api', function() {
   });
 
   it('contains view synchronize calls', async () => {
-    let {manifest, arc} = await setup({
+    let {manifest, arc} = await loadFilesIntoNewArc({
       manifest: `
         schema Input
           Text value
@@ -300,7 +300,7 @@ describe('particle-api', function() {
   });
 
   it('contains a constructInnerArc call', async () => {
-    let {manifest, arc} = await setup({
+    let {manifest, arc} = await loadFilesIntoNewArc({
       manifest: `
         schema Result
           Text value
@@ -344,7 +344,7 @@ describe('particle-api', function() {
   });
 
   it('can load a recipe', async () => {
-    let {manifest, arc} = await setup({
+    let {manifest, arc} = await loadFilesIntoNewArc({
       manifest: `
         schema Result
           Text value
@@ -422,7 +422,7 @@ describe('particle-api', function() {
   });
 
   it('can load a recipe referencing a manifest store', async () => {
-    let {manifest, arc} = await setup({
+    let {manifest, arc} = await loadFilesIntoNewArc({
       manifest: `
         schema Result
           Text value
@@ -512,7 +512,7 @@ describe('particle-api', function() {
   });
 
   it('can load a recipe referencing a tagged handle in containing arc', async () => {
-    let {manifest, arc} = await setup({
+    let {manifest, arc} = await loadFilesIntoNewArc({
       manifest: `
         schema Result
           Text value
@@ -610,7 +610,7 @@ describe('particle-api', function() {
   // potentially address either by including more strategies in the outer-PEC's
   // strategizer or adding such fallback to `arc.findHandlesByType`.
   it.skip('can load a recipe referencing a tagged handle in manifest', async () => {
-    let {manifest, arc} = await setup({
+    let {manifest, arc} = await loadFilesIntoNewArc({
       manifest: `
         schema Result
           Text value
@@ -700,7 +700,7 @@ describe('particle-api', function() {
   });
 
   it('multiplexing', async () => {
-    let {manifest, arc} = await setup({
+    let {manifest, arc} = await loadFilesIntoNewArc({
       manifest: `
         schema Result
           Text value


### PR DESCRIPTION
This automatically sets up event listeners between the storage layer and the inner-PEC StorageProxy objects. The proxies now hold a full copy of the stored data and propagate change events to observing particles (via the Handles for correct type instantiation).

For now, this is in parallel to the existing "synchronise" and direct access APIs.