### PR TITLE
Fixes addition of hidden predecessors caused by the combined strategy

### DIFF
--- a/devtools/src/strategy-explorer/se-recipe.html
+++ b/devtools/src/strategy-explorer/se-recipe.html
@@ -89,9 +89,6 @@ http://polymer.github.io/PATENTS.txt
         this.recipe.derivation.forEach(derivation => {
           if (derivation.parent !== undefined) {
             let newParent = document.strategyExplorer.idMap.get(derivation.parent);
-            if (newParent == undefined) {
-              return;
-            }
 
             let setupContext = (newParent => {
               this.strategyMap.set(newParent, [[derivation.strategy]]);


### PR DESCRIPTION
It was relying on parentMap.has(), but with occasional parent-child relation this is not reliable before entire population is processed - which was causing additional 'combined' boxes in SE.