### PR TITLE
Include hash of read-only manifest handle values in handle id.

### DIFF
--- a/runtime/test/manifest-test.js
+++ b/runtime/test/manifest-test.js
@@ -136,7 +136,7 @@ ${particleStr1}
   affordance dom
   consume thing
     provide otherThing`;
-    
+
     let manifest = await Manifest.parse(manifestString);
     assert.equal(manifest.particles.length, 1);
     assert.equal(manifestString, manifest.particles[0].toString());
@@ -157,6 +157,40 @@ ${particleStr1}
     let verify = (manifest) => assert.equal(manifest.schemas.Bar.fields.value, 'Text');
     verify(manifest);
     verify(await Manifest.parse(manifest.toString(), {}));
+  });
+  it('two manifests with stores with the same filename, store name and data have the same ids', async () => {
+    let manifestA = await Manifest.parse(`
+        store NobId of NobIdStore {Text nobId} in NobIdJson
+        resource NobIdJson
+          start
+          [{"nobId": "12345"}]
+        `, {fileName: 'the.manifest'});
+
+    let manifestB = await Manifest.parse(`
+        store NobId of NobIdStore {Text nobId} in NobIdJson
+        resource NobIdJson
+          start
+          [{"nobId": "12345"}]
+        `, {fileName: 'the.manifest'});
+
+    assert.equal(manifestA.handles[0].id.toString(), manifestB.handles[0].id.toString());
+  });
+  it('two manifests with stores with the same filename and store name but different data have different ids', async () => {
+    let manifestA = await Manifest.parse(`
+        store NobId of NobIdStore {Text nobId} in NobIdJson
+        resource NobIdJson
+          start
+          [{"nobId": "12345"}]
+        `, {fileName: 'the.manifest'});
+
+    let manifestB = await Manifest.parse(`
+        store NobId of NobIdStore {Text nobId} in NobIdJson
+         resource NobIdJson
+           start
+           [{"nobId": "67890"}]
+          `, {fileName: 'the.manifest'});
+
+    assert.notEqual(manifestA.handles[0].id.toString(), manifestB.handles[0].id.toString());
   });
   it('supports recipes specified with bidirectional connections', async () => {
     let manifest = await Manifest.parse(`
@@ -790,7 +824,7 @@ Error parsing JSON from 'EntityList' (Unexpected token h in JSON at position 1)'
     };
     let manifest = await Manifest.load('the.manifest', loader);
     let recipe = manifest.recipes[0];
-    assert.deepEqual(recipe.toString(), 'recipe\n  map \'manifest:the.manifest:store0\' as myStore');
+    assert.deepEqual(recipe.toString(), 'recipe\n  map \'manifest:the.manifest:store0:97d170e1550eee4afc0af065b78cda302a97674c\' as myStore');
   });
   it('has prettyish syntax errors', async () => {
     try {
@@ -1184,7 +1218,7 @@ resource SomeName
           foo = view
         P3
           foo = view
-        
+
       recipe
         create as view
         P2
@@ -1254,7 +1288,7 @@ resource SomeName
         in Bar foo
 
       view Foo of Bar 'test' @0 at 'firebase://testing'
-      
+
       recipe
         map Foo as myView
         P


### PR DESCRIPTION
Early-ish checkpoint to solicit feedback. In particular:
- seeking to make sure we shouldn't be doing something to else to check read-only status such as scrutinizing any associated connection/type, I'm just presuming the spot where I'm computing and inserting the hash in the `unitType.isEntity` block within `_processStore` is one where that entity is implicitly always read-only, but perhaps I am naive/mistaken.
- the `handle._store.id` we discussed in chat is computed [here](https://github.com/PolymerLabs/arcs/compare/master...shaper:hash_read_only?expand=1#diff-7cf67f07396d399da8d0403d5df1dc2bR922) and is not currently updated to include the hash value, should it be? It seems a separate id to me, and then should the hash included be the hash of just that entity's value or the full list of entities (the latter is what's inserted into the handle id)?
- removed `immediate` from the id of particle specs since we're including hash instead which seems sufficient, but if we still want it, let's discuss, because then shouldn't we have it in the read-only entity case as well?
- this PR doesn't address the work item around turning off duplicate-id errors for read-only data, but this work should be sufficient for the Social muxing embedded recipe case where the game id value does always vary, so we can file an issue for the duplicate-id work and pursue separately

Part of https://github.com/PolymerLabs/arcs/issues/842