### PR TITLE
Fix verbose error in particle-shape-loading test.

### DIFF
--- a/runtime/handle.js
+++ b/runtime/handle.js
@@ -79,6 +79,7 @@ class Handle {
   }
 
   _serialize(entity) {
+    assert(entity, 'can\'t serialize a null entity');
     if (!entity.isIdentified())
       entity.createIdentity(this.generateIDComponents());
     let id = entity[identifier];

--- a/runtime/test/artifacts/outer-particle.js
+++ b/runtime/test/artifacts/outer-particle.js
@@ -36,7 +36,7 @@ defineParticle(({Particle}) => {
         inView.set(input);
         outView.on('change', async () => {
           let output = await outView.get();
-          if (output !== undefined)
+          if (output)
             outputView.set(output);
         }, this);
       } catch (e) {


### PR DESCRIPTION
A few notes:
- `outer-particle.js` is getting `null` for `outView`, it seemed like we should be checking for that as well as `undefined`. It may also be that something else in the involved test is not written as desired, maybe out view should have been wired up, I didn't look deeper.
- adding an `assert` to `Handle._serialize` to report a more informative error on attempt to serialize a null entity seemed helpful.
- the test was still passing, maybe it shouldn't have been? Mocha has an [alternate way](https://mochajs.org/#asynchronous-code) via `done` param to handle async tests, I've seen other cases where we get errors and we get the deprecation warning about Promise rejections in the sample at https://github.com/PolymerLabs/arcs/issues/1267 and I wonder whether we should move to using the `done` bit instead in some manner. Note the Mocha docs don't seem to say anything about the deprecation.

Fixes https://github.com/PolymerLabs/arcs/issues/1267