### PR TITLE
Allow shape bodies to use new syntax

### DIFF
--- a/runtime/manifest-parser.peg
+++ b/runtime/manifest-parser.peg
@@ -150,17 +150,30 @@ Import
 Shape
   = 'shape' whiteSpace name:TopLevelIdent typeVars:(whiteSpace? '<' whiteSpace? VariableTypeList whiteSpace? '>')? eolWhiteSpace items:(Indent (SameIndent ShapeItem)*)? eolWhiteSpace?
   {
-    return {
-      kind: 'shape',
-      location: location(),
-      name,
-      interface: optional(items, extractIndented, []).find(item => item.kind == 'shape-interface'),
-      slots: optional(items, extractIndented, []).filter(item => item.kind == 'shape-slot'),
+    var iface = optional(items, extractIndented, []).find(item => item.kind == 'shape-interface');
+    if (iface) {
+      return {
+        kind: 'shape',
+        location: location(),
+        name,
+        interface: iface,
+        slots: optional(items, extractIndented, []).filter(item => item.kind == 'shape-slot'),
+      };
+    } else {
+      return {
+        kind: 'shape',
+        location: location(),
+        name,
+        args: optional(items, extractIndented, []).filter(item => item.kind == 'shape-argument'),
+        slots: optional(items, extractIndented, []).filter(item => item.kind == 'shape-slot'),
+      };
+
     }
   }
 
 ShapeItem
   = ShapeInterface
+  / ShapeArgumentItem
   / ShapeSlot
 
 
@@ -175,6 +188,12 @@ ShapeInterface
     };
   }
 
+ShapeArgumentItem
+  = arg:ShapeArgument2 eolWhiteSpace
+  {
+    return arg;
+  }
+
 ShapeArgumentList
   = head:ShapeArgument tail:(',' whiteSpace ShapeArgument)*
   {
@@ -183,6 +202,22 @@ ShapeArgumentList
 
 ShapeArgument
   = direction:(ParticleArgumentDirection)? whiteSpace? type:(ParticleArgumentType)? whiteSpace? name:(lowerIdent)?
+  {
+    if (direction == 'host') {
+      error(`Shape cannot have arguments with a 'host' direction.`);
+    }
+
+    return {
+      kind: 'shape-argument',
+      location: location(),
+      direction,
+      type,
+      name,
+    };
+  }
+  
+ShapeArgument2
+  = direction:(ParticleArgumentDirection)? whiteSpace? type:(ParticleArgumentType)? whiteSpace? name:(lowerIdent)
   {
     if (direction == 'host') {
       error(`Shape cannot have arguments with a 'host' direction.`);

--- a/runtime/manifest.js
+++ b/runtime/manifest.js
@@ -557,13 +557,14 @@ ${e.message}
   }
   // TODO: Move this to a generic pass over the AST and merge with resolveReference.
   static _processShape(manifest, shapeItem) {
-    for (let arg of shapeItem.interface.args) {
+    let handles = shapeItem.interface ? shapeItem.interface.args : shapeItem.args;
+
+    for (let arg of handles) {
       if (arg.type) {
         // TODO: we should copy rather than mutate the AST like this
         arg.type = arg.type.model;
       }
     }
-    let handles = shapeItem.interface.args;
     let slots = [];
     for (let slotItem of shapeItem.slots) {
       slots.push({

--- a/runtime/test/manifest-test.js
+++ b/runtime/test/manifest-test.js
@@ -1085,7 +1085,7 @@ resource SomeName
     `);
     assert(manifest.findShapeByName('Shape'));
     assert(manifest.recipes[0].normalize());
-  })
+  });
   it('can resolve optional handles', async () => {
     let manifest = await Manifest.parse(`
       schema Something

--- a/runtime/test/manifest-test.js
+++ b/runtime/test/manifest-test.js
@@ -1071,6 +1071,21 @@ resource SomeName
     assert(manifest.findShapeByName('Shape'));
     assert(manifest.recipes[0].normalize());
   });
+  it('can parse shapes using new-style body syntax', async () => {
+    let manifest = await Manifest.parse(`
+      schema Foo
+      shape Shape
+        in Foo foo
+      particle ShapeParticle
+        host Shape shape
+      recipe
+        create as view0
+        ShapeParticle
+          shape = view0
+    `);
+    assert(manifest.findShapeByName('Shape'));
+    assert(manifest.recipes[0].normalize());
+  })
   it('can resolve optional handles', async () => {
     let manifest = await Manifest.parse(`
       schema Something


### PR DESCRIPTION
Notice I need a new version of ShapeArgument because if the everything stays optional then there's an infinite recursion in parsing. Once we get rid of the legacy version of this then we can go back to a single version.

I'm planning to require '*' instead of a name if that's supposed to be optional - WDYT? We probably should think through the right grammar for this in general anyway.