### PR TITLE
Mark old-style shape body as deprecated and fix in tests.

### DIFF
--- a/runtime/manifest-parser.peg
+++ b/runtime/manifest-parser.peg
@@ -217,7 +217,7 @@ ShapeArgument
   }
   
 ShapeArgument2
-  = direction:(ParticleArgumentDirection)? whiteSpace? type:(ParticleArgumentType)? whiteSpace? name:(lowerIdent)
+  = direction:(ParticleArgumentDirection)? whiteSpace? type:(ParticleArgumentType)? whiteSpace? name:(lowerIdent / '*') ! {return name == 'consume' || name == 'provide'}
   {
     if (direction == 'host') {
       error(`Shape cannot have arguments with a 'host' direction.`);

--- a/runtime/manifest.js
+++ b/runtime/manifest.js
@@ -557,13 +557,20 @@ ${e.message}
   }
   // TODO: Move this to a generic pass over the AST and merge with resolveReference.
   static _processShape(manifest, shapeItem) {
-    let handles = shapeItem.interface ? shapeItem.interface.args : shapeItem.args;
+    if (shapeItem.interface) {
+      let warning = new ManifestError(shapeItem.location, `Shape uses deprecated argument body`);
+      warning.key = 'hasShapeArgument';
+      manifest._warnings.push(warning);
+    }
+    let inHandles = shapeItem.interface ? shapeItem.interface.args : shapeItem.args;
+    let handles = [];
 
-    for (let arg of handles) {
-      if (arg.type) {
-        // TODO: we should copy rather than mutate the AST like this
-        arg.type = arg.type.model;
-      }
+    for (let arg of inHandles) {
+      let handle = {};
+      handle.name = arg.name == '*' ? undefined : arg.name;
+      handle.type = arg.type ? arg.type.model : undefined;
+      handle.direction = arg.direction;
+      handles.push(handle);
     }
     let slots = [];
     for (let slotItem of shapeItem.slots) {

--- a/runtime/shape.js
+++ b/runtime/shape.js
@@ -86,8 +86,8 @@ class Shape {
     return this.handles
       .map(handle => {
         let type = handle.type.resolvedType();
-        return `${handle.direction ? handle.direction + ' ': ''}${type.toString()}${handle.name ? ' ' + handle.name : ''}`;
-      }).join(', ');
+        return `  ${handle.direction ? handle.direction + ' ': ''}${type.toString()} ${handle.name ? handle.name : '*'}`;
+      }).join('\n');
   }
 
   _slotsToManifestString() {
@@ -100,7 +100,7 @@ class Shape {
   // toString().
   toString() {
     return `shape ${this.name}
-  ${this.name}(${this._handlesToManifestString()})
+${this._handlesToManifestString()}
 ${this._slotsToManifestString()}
 `;
   }

--- a/runtime/test/artifacts/test-particles.manifest
+++ b/runtime/test/artifacts/test-particles.manifest
@@ -22,7 +22,8 @@ particle TwoInputTestParticle in 'two-input-test-particle.js'
   out Far far
 
 shape TestShape
-  AnyThing(in Foo foo, out Bar bar)
+  in Foo foo
+  out Bar bar
 
 particle OuterParticle in 'outer-particle.js'
   host TestShape particle

--- a/runtime/test/artifacts/transformations/test-slots-particles.manifest
+++ b/runtime/test/artifacts/transformations/test-slots-particles.manifest
@@ -15,7 +15,7 @@ particle SingleSlotParticle in 'test-single-slot-particle.js'
   description `test slot particle`
 
 shape HostedParticleShape
-  HostedParticleShape(in Foo foo)
+  in Foo foo
   consume annotation
 
 particle MultiplexSlotsParticle in 'test-multiplex-slots-particle.js'

--- a/runtime/test/manifest-test.js
+++ b/runtime/test/manifest-test.js
@@ -1031,27 +1031,25 @@ resource SomeName
     let manifest = await Manifest.parse(`
       schema Foo
       shape FullShape
-        AnyThing(in Foo foo)
+        in Foo foo
         consume root
         provide action
       shape ShapeNoHandleName
-        AnyThing(in Foo)
+        in Foo *
       shape ShapeNoHandleType
-        AnyThing(inout foo)
+        inout foo
       shape ShapeNoHandleDirection
-        AnyThing(Foo foo)
+        Foo foo
       shape ShapeOnlyHandleDirection
-        AnyThing(out)
+        out *
       shape ShapeManyHandles
-        AnyThing(in Foo, out [~a])
+        in Foo *
+        out [~a] *
       shape ShapeConsumeNoName
-        Anything()
         consume
       shape ShapeConsumeRequiredSetSlot
-        Anything()
         must consume set of
       shape ShapeOnlyProvideSlots
-        AnyThing()
         provide action
     `);
     assert.equal(9, manifest.shapes.length);
@@ -1061,7 +1059,7 @@ resource SomeName
     let manifest = await Manifest.parse(`
       schema Foo
       shape Shape
-        AnyThing(in Foo foo)
+        in Foo foo
       particle ShapeParticle
         host Shape shape
       recipe
@@ -1111,7 +1109,7 @@ resource SomeName
     let manifest = await Manifest.parse(`
       schema S
       shape HostedShape
-        HostedShape(in S foo)
+        in S foo
 
       particle Hosted
         in S foo

--- a/runtime/test/particle-api-test.js
+++ b/runtime/test/particle-api-test.js
@@ -87,7 +87,9 @@ async function setupProxySyncTests() {
         Text value
 
       particle P in 'a.js'
-        P(in Data foo, inout [Data] bar, out [Result] res)
+        in Data foo
+        inout [Data] bar
+        out [Result] res
 
       recipe
         use 'test:0' as view0

--- a/runtime/test/particles/artifacts/provide-hosted-particle-slots.manifest
+++ b/runtime/test/particles/artifacts/provide-hosted-particle-slots.manifest
@@ -19,12 +19,12 @@ particle ShowFooAnnotation in 'source/ShowFooAnnotation.js'
   consume annotation
 
 shape FooShape
-  FooShape(in Foo)
+  in Foo *
   consume
   provide
 
 shape FooAnnotationShape
-  FooShape(in Foo)
+  in Foo *
   consume
 
 particle Fooxer in '../../../../shell/artifacts/Common/source/Multiplexer.js'

--- a/runtime/test/planner-tests.js
+++ b/runtime/test/planner-tests.js
@@ -466,7 +466,7 @@ describe('Type variable resolution', function() {
   it('transformation particles type variable resolution', async () => {
     let particleSpecs = `
 shape HostedShape
-  HostedShape(in ~a)
+  in ~a *
 particle P1
   in Thing1 input
 particle Muxer in 'Muxer.js'

--- a/runtime/test/recipe-test.js
+++ b/runtime/test/recipe-test.js
@@ -179,7 +179,7 @@ describe('recipe', function() {
   it('generates the same hash on manifest re-parse for immediates', async () => {
     const manifestContent = `
       shape HostedParticleShape
-        HostedParticleShape(in ~a)
+        in ~a *
         consume
 
       schema Foo

--- a/runtime/test/strategies/search-tokens-to-particles-tests.js
+++ b/runtime/test/strategies/search-tokens-to-particles-tests.js
@@ -41,12 +41,9 @@ describe('SearchTokensToParticles', function() {
 
   it('recipes by verb strategy', async () => {
     let manifest = (await Manifest.parse(`
-      particle SimpleJumper in 'A.js'
-        jump()
+      particle SimpleJumper #jump in 'A.js'
       particle FlightPreparation in 'AA.js'
-        FlightPreparation()
       particle GalaxyFlyer in 'AA.js'
-        GalaxyFlyer()
       recipe fly
         FlightPreparation
         GalaxyFlyer

--- a/runtime/test/strategy-sequence-test.js
+++ b/runtime/test/strategy-sequence-test.js
@@ -155,7 +155,7 @@ describe('A Strategy Sequence', function() {
         consume annotation
   
       shape HostedParticleShape
-        HostedParticleShape(in ~a)
+        in ~a *
         consume
   
       particle Multiplexer in 'source/Multiplexer.js'
@@ -176,7 +176,8 @@ describe('A Strategy Sequence', function() {
         out [Product] recommendations
   
       shape HostedParticleShape2
-        HostedParticleShape2(in ~a, in [~a])
+        in ~a *
+        in [~a] *
         consume
         
       particle Multiplexer2 in 'source/Multiplexer.js'

--- a/runtime/test/type-checker-tests.js
+++ b/runtime/test/type-checker-tests.js
@@ -122,7 +122,7 @@ describe('TypeChecker', () => {
   it('correctly applies then resolves a one-sided Entity constraint', async () => {
     let manifest = await Manifest.parse(`
       shape Shape
-        Shape(in ~a item)
+        in ~a item
 
       particle Concrete
         in Product {} item

--- a/shell/artifacts/Common/Multiplexer.manifest
+++ b/shell/artifacts/Common/Multiplexer.manifest
@@ -7,7 +7,7 @@
 // http://polymer.github.io/PATENTS.txt
 
 shape HostedParticleShape
-  HostedParticleShape(in ~a)
+  in ~a *
   consume
 
 // TODO: This particle should use generic slot name.
@@ -19,7 +19,8 @@ particle Multiplexer in 'source/Multiplexer.js'
 
 // Same as Multiplexer above, but with an additional connection.
 shape HostedParticleShape2
-  HostedParticleShape2(in ~a, in [~a])
+  in ~a *
+  in [~a] *
   consume
 
 particle Multiplexer2 in 'source/Multiplexer.js'

--- a/shell/artifacts/Products/ProductFilter.manifest
+++ b/shell/artifacts/Products/ProductFilter.manifest
@@ -9,7 +9,8 @@
 import 'Product.schema'
 
 shape HostedParticleShape
-  HostedParticleShape(in Product, out Product)
+  in Product *
+  out Product *
 
 // TODO: This particle should use generic handle type and slot name.
 particle ProductFilter in 'source/ProductFilter.js'


### PR DESCRIPTION
Doing this exercise uncovered an issue with the way I'd set up parsing (specifically, slots were parsed as handles) and also required implementing the use of '*' to mean no name.