### PR TITLE
add missing await to interface handle ID generation

### DIFF
--- a/runtime/manifest.js
+++ b/runtime/manifest.js
@@ -783,7 +783,7 @@ ${e.message}
             hostedParticle.implFile = loader.join(manifest.fileName, hostedParticle.implFile);
           }
           const hostedParticleLiteral = hostedParticle.clone().toLiteral();
-          let particleSpecHash = digest(JSON.stringify(hostedParticleLiteral));
+          let particleSpecHash = await digest(JSON.stringify(hostedParticleLiteral));
           let id = `${manifest.generateID()}:${particleSpecHash}:${hostedParticle.name}`;
           targetHandle = recipe.newHandle();
           targetHandle.fate = 'copy';


### PR DESCRIPTION
currently IDs are smth like: `manifest:https://$cdn/artifacts/Products/Products.recipes::8:[object Promise]:ShowProduct`