### PR TITLE
Replace any user error with system exceptions.

### DIFF
--- a/runtime/test/test-environment-test.js
+++ b/runtime/test/test-environment-test.js
@@ -9,7 +9,7 @@ afterEach(function() {
     for (let {exception, name, particle} of exceptions) {
       let error = new Error(`${exception.name} when invoking system function ${name} on behalf of ${particle}`); 
       error.stack = exception.stack;
-      this.test.error(error); // eslint-disable-line no-invalid-this
+      this.test.ctx.currentTest.err = error; // eslint-disable-line no-invalid-this
     }
     exceptions = [];
   }


### PR DESCRIPTION
We were raising the system exception as an error on the afterEach hook, however this made mocha double-print the system exception if there was a user exception too (the user exception .. was not printed).

Why? WHO KNOWS?! I guess it's too much to ask for a testing suite to be well tested.

So now we lose the user exception all together, but we weren't getting it anyway so that's no great loss.