### PR TITLE
Removes discarding mechanism from the Strategizer

### DIFF
--- a/runtime/planner.js
+++ b/runtime/planner.js
@@ -36,12 +36,7 @@ export class Planner {
   init(arc, {strategies, ruleset} = {}) {
     this._arc = arc;
     strategies = strategies || Planner.AllStrategies.map(strategy => new strategy(arc));
-    this.strategizer = new Strategizer(strategies, [], {
-      maxPopulation: 100,
-      generationSize: 100,
-      discardSize: 20,
-      ruleset: ruleset || Rulesets.Empty
-    });
+    this.strategizer = new Strategizer(strategies, [], ruleset || Rulesets.Empty);
   }
 
   // Specify a timeout value less than zero to disable timeouts.

--- a/strategizer/hello-strategizer.js
+++ b/strategizer/hello-strategizer.js
@@ -101,11 +101,7 @@ class Eval extends Strategy {
 }
 
 let target = 'Hello, world.';
-let strategizer = new Strategizer([new Seed(), new Grow(), new Mutate(), new Cross()], [new Eval(target)], {
-  maxPopulation: 100,
-  generationSize: 1000,
-  discardSize: 20,
-});
+let strategizer = new Strategizer([new Seed(), new Grow(), new Mutate(), new Cross()], [new Eval(target)]);
 
 (async () => {
   do {

--- a/strategizer/strategizer.js
+++ b/strategizer/strategizer.js
@@ -8,7 +8,7 @@
 import {assert} from '../platform/assert-web.js';
 
 export class Strategizer {
-  constructor(strategies, evaluators, {maxPopulation, generationSize, discardSize, ruleset}) {
+  constructor(strategies, evaluators, ruleset) {
     this._strategies = strategies;
     this._evaluators = evaluators;
     this._generation = 0;
@@ -17,11 +17,6 @@ export class Strategizer {
     this._generated = [];
     this._terminal = [];
     this._ruleset = ruleset;
-    this._options = {
-      maxPopulation,
-      generationSize,
-      discardSize,
-    };
     this.populationHash = new Map();
   }
   // Latest generation number.
@@ -36,11 +31,6 @@ export class Strategizer {
   get generated() {
     return this._generated;
   }
-  // Individuals that were discarded in the latest generation.
-  get discarded() {
-    return this._discarded;
-    // TODO: Do we need this?
-  }
   // Individuals from the previous generation that were not decended from in the
   // current generation.
   get terminal() {
@@ -50,15 +40,13 @@ export class Strategizer {
   async generate() {
     // Generate
     let generation = this.generation + 1;
-    let individualsPerStrategy = Math.floor(this._options.generationSize / this._strategies.length);
     let generated = await Promise.all(this._strategies.map(strategy => {
       let recipeFilter = recipe => this._ruleset.isAllowed(strategy, recipe);
       return strategy.generate({
         generation: this.generation,
         generated: this.generated.filter(recipeFilter),
         terminal: this.terminal.filter(recipeFilter),
-        population: this.population.filter(recipeFilter),
-        outputLimit: individualsPerStrategy
+        population: this.population.filter(recipeFilter)
       });
     }));
 
@@ -150,40 +138,17 @@ export class Strategizer {
       return strategy.evaluate(this, generated);
     }));
     let fitness = Strategizer._mergeEvaluations(evaluations, generated);
+
     assert(fitness.length == generated.length);
-
-
-    // Merge + Discard
-    let discarded = [];
-    let newGeneration = [];
-
     for (let i = 0; i < fitness.length; i++) {
-      newGeneration.push({
+      this._internalPopulation.push({
         fitness: fitness[i],
         individual: generated[i],
       });
     }
 
-    while (this._internalPopulation.length > (this._options.maxPopulation - this._options.discardSize)) {
-      discarded.push(this._internalPopulation.pop().individual);
-    }
-
-    newGeneration.sort((x, y) => y.fitness - x.fitness);
-
-    for (let i = 0; i < newGeneration.length && i < this._options.discardSize; i++) {
-      if (i < this._options.discardSize) {
-        this._internalPopulation.push(newGeneration[i]);
-      } else {
-        discarded.push(newGeneration[i].individual);
-      }
-    }
-
     // TODO: Instead of push+sort, merge `internalPopulation` with `generated`.
     this._internalPopulation.sort((x, y) => y.fitness - x.fitness);
-
-    for (let strategy of this._strategies) {
-      strategy.discard(discarded);
-    }
 
     // Publish
     this._terminal = terminal;
@@ -282,8 +247,6 @@ export class Strategy {
   }
   async generate(inputParams) {
     return [];
-  }
-  discard(individuals) {
   }
   async evaluate(strategizer, individuals) {
     return individuals.map(() => NaN);


### PR DESCRIPTION
Those limits might seems like a good idea, but they are effectively not enforced today.
- No strategy honors 'outputLimit',
- 'maxPopulation' only affects the published population size, not the 'generated', which is used by almost all strategies. It does not stop the Strategizer from working.

While it is the case that we will need to have some controls over Strategizer behavior at some point, we don't need them yet. The ones we had are not used, add complexity and actually have bugs in them.