### PR TITLE
Make SE comfortable with parents in later generations

### DIFF
--- a/runtime/debug/strategy-explorer-adapter.js
+++ b/runtime/debug/strategy-explorer-adapter.js
@@ -15,78 +15,75 @@ export class StrategyExplorerAdapter {
       messageType: 'generations',
       // TODO: Implement simple serialization and move the logic in adapt()
       //       into the Strategy Explorer proper.
-      messageBody: new StrategyExplorerAdapter().adapt(generations)
+      messageBody: StrategyExplorerAdapter.adapt(generations)
     });
   }
-  constructor() {
-    this.parentMap = new Map();
-    this.lastID = 0;
-  }
-  adapt(generations) {
-    return generations.map(pop => this._preparePopulation(pop.generated, pop.record));
-  }
-  _preparePopulation(population, record) {
-    // Adding those here to reuse recipe resolution computation.
-    record.resolvedDerivations = 0;
-    record.resolvedDerivationsByStrategy = {};
+  static adapt(generations) {
+    const idMap = new Map(); // Recipe -> ID
+    let lastID = 0;
 
-    // Hidden predecessors are listed in recipe derivation, but not in the
-    // population itself. They currently come from the CombinedStrategy. We want
-    // to surface them in the StrategyExplorer for transparency.
-    let hiddenPredecessorsCandidates = [];
-    const addHiddenPredecessorsCandidates = ({parent}) => {
-      if (!parent || this.parentMap.has(parent)) return;
-      hiddenPredecessorsCandidates.push(parent);
-      parent.derivation.forEach(addHiddenPredecessorsCandidates);
-    };
-    const assignIdAndCopy = recipe => {
-      this.parentMap.set(recipe, this.lastID);
-      let {result, score, derivation, description, hash, valid, active, irrelevant} = recipe;
-      return {result, score, derivation, description, hash, valid, active, irrelevant, id: this.lastID++};
-    };
-    population = population.map(recipe => {
-      recipe.derivation.forEach(addHiddenPredecessorsCandidates);
-      return assignIdAndCopy(recipe);
-    });
-    // As a recipe might have regular predecessors in the current generation,
-    // the check for presence in the parentMap needs to re-evaluated after
-    // processing entire population to avoid false positives.
-    for (let predecessor of hiddenPredecessorsCandidates) {
-      if (!this.parentMap.has(predecessor)) {
-        population.push(Object.assign(assignIdAndCopy(predecessor), {combined: true}));
+    // Make a copy of everything and assign IDs to recipes.
+    for (let pop of generations) {
+      pop.generated = pop.generated.map(function assignIdAndCopy(recipe) {
+        idMap.set(recipe, lastID);
+        let {result, score, derivation, description, hash, valid, active, irrelevant} = recipe;
+        return {result, score, derivation, description, hash, valid, active, irrelevant, id: lastID++};
+      });
+    }
+
+    // CombinedStrategy creates recipes with derivations that are missing
+    // from the population. Re-adding them as 'combined'.
+    for (let pop of generations) {
+      let lengthWithoutCombined = pop.generated.length;
+      for (let i = 0; i < lengthWithoutCombined; i++) {
+        pop.generated[i].derivation.forEach(function addMissing({parent}) {
+          if (parent && !idMap.has(parent)) {
+            pop.generated.push(Object.assign(assignIdAndCopy(parent), {combined: true}));
+            parent.derivation.forEach(addMissing);
+          }
+        });
       }
     }
 
-    population.forEach(item => {
-      item.derivation = item.derivation.map(derivItem => {
-        let parent, strategy;
-        if (derivItem.parent)
-          parent = this.parentMap.get(derivItem.parent);
-        if (derivItem.strategy)
-          strategy = derivItem.strategy.constructor.name;
-        return {parent, strategy};
+    return generations.map(pop => {
+      let population = pop.generated;
+      let record = pop.record;
+      // Adding those here to reuse recipe resolution computation.
+      record.resolvedDerivations = 0;
+      record.resolvedDerivationsByStrategy = {};
+
+      population.forEach(item => {
+        // Change recipes in derivation to IDs.
+        item.derivation = item.derivation.map(derivItem => {
+          let parent, strategy;
+          if (derivItem.parent)
+            parent = idMap.get(derivItem.parent);
+          if (derivItem.strategy)
+            strategy = derivItem.strategy.constructor.name;
+          return {parent, strategy};
+        });
+        item.resolved = item.result.isResolved();
+        if (item.resolved) {
+          record.resolvedDerivations++;
+          let strategy = item.derivation[0].strategy;
+          if (record.resolvedDerivationsByStrategy[strategy] === undefined)
+            record.resolvedDerivationsByStrategy[strategy] = 0;
+          record.resolvedDerivationsByStrategy[strategy]++;
+        }
+        let options = {showUnresolved: true, showInvalid: false, details: ''};
+        item.result = item.result.toString(options);
       });
-      item.resolved = item.result.isResolved();
-      if (item.resolved) {
-        record.resolvedDerivations++;
-        let strategy = item.derivation[0].strategy;
-        if (record.resolvedDerivationsByStrategy[strategy] === undefined)
-          record.resolvedDerivationsByStrategy[strategy] = 0;
-        record.resolvedDerivationsByStrategy[strategy]++;
-      }
-      let options = {showUnresolved: true, showInvalid: false, details: ''};
-      item.result = item.result.toString(options);
+      let populationMap = {};
+      population.forEach(item => {
+        if (populationMap[item.derivation[0].strategy] == undefined)
+          populationMap[item.derivation[0].strategy] = [];
+        populationMap[item.derivation[0].strategy].push(item);
+      });
+      let result = {population: [], record};
+      Object.keys(populationMap).forEach(strategy => {
+        result.population.push({strategy: strategy, recipes: populationMap[strategy]});
+      });
+      return result;
     });
-    let populationMap = {};
-    population.forEach(item => {
-      if (populationMap[item.derivation[0].strategy] == undefined)
-        populationMap[item.derivation[0].strategy] = [];
-      populationMap[item.derivation[0].strategy].push(item);
-    });
-    let result = {population: [], record};
-    Object.keys(populationMap).forEach(strategy => {
-      result.population.push({strategy: strategy, recipes: populationMap[strategy]});
-    });
-    return result;
   }
 }


### PR DESCRIPTION
Refactors the SE adapter from doing work per generation to doing it in stages on all generations. This is motivated by cases where one of the ancestors of a given recipe appears in later generations, which can weirdly sometimes happen. Previously this would be wrongly considered an intermediate result of the CombinedStrategy, now we look for those intermediate results globally after processing all generations.