### PR TITLE
Only show delete button on hover of associated message.

### DIFF
--- a/shell/artifacts/Social/source/ShowPosts.js
+++ b/shell/artifacts/Social/source/ShowPosts.js
@@ -16,6 +16,10 @@ defineParticle(({DomParticle, resolver, log, html}) => {
   [${host}] icon {
     float: right;
     margin-right: 1em;
+    visibility: hidden;
+  }
+  [${host}] [msg]:hover icon {
+    visibility: visible;
   }
   [${host}] {
     font-family: 'Google Sans', sans-serif;


### PR DESCRIPTION
Part of https://github.com/PolymerLabs/arcs/issues/1319

This is perhaps imperfect since the icon even when hidden takes up flow space pushing more-than-one-line-long message text content down to the next line prematurely, but, maybe it'd be differently a poor experience to have the text re-flow when we show the button.

Step one is self-awareness.