### PR TITLE
Adds a hash of a recipe to the recipe view

### DIFF
--- a/devtools/src/strategy-explorer/se-recipe-view.html
+++ b/devtools/src/strategy-explorer/se-recipe-view.html
@@ -44,14 +44,16 @@ http://polymer.github.io/PATENTS.txt
       }
     </style>
     <template is='dom-if' if='{{shownRecipe}}'>
-      <div class='recipe-box'>{{strategyString}}<div hidden$="[[isDescriptionEmpty(shownRecipe.description)]]" class="description">
+      <div class='recipe-box'>{{strategyString}}<!--
+     --><div hidden$="[[isDescriptionEmpty(shownRecipe.description)]]" class="description">
           <span inner-h-t-m-l='{{shownRecipe.description}}'></span>
           <hr>
         </div>
         <span inner-h-t-m-l='{{shownRecipe.result}}'></span>
-      </div>
+        <span class="hash" inner-h-t-m-l='{{shownRecipe.hash}}'></span><!--
+   --></div>
+    </template>
   </template>
-</template>
   <script>
     Polymer({
       is: 'se-recipe-view',
@@ -68,10 +70,11 @@ http://polymer.github.io/PATENTS.txt
       },
       recipeChanged: function(recipe) {
         if (!this.pinned) {
-          this.shownRecipe = (({result, strategy, id, parent, score, description}) => ({result, strategy, id, parent, score, description}))(this.recipe);
+          this.shownRecipe = (({result, strategy, id, parent, score, description, hash}) => ({result, strategy, id, parent, score, description, hash}))(this.recipe);
         } else {
           if (recipe.id == this.shownRecipe.id) {
             this.set("shownRecipe.result", this.pinnedResult);
+            this.set("shownRecipe.hash", this.pinnedHash);
             this.strategyString = '';
             return;
           }
@@ -93,6 +96,7 @@ http://polymer.github.io/PATENTS.txt
             this.strategyString = "Strategies: [" + strategies.join(']\n[') + "]\n";
           else
             this.strategyString = '';
+          this.set("shownRecipe.hash", `<span class='added'>${this.pinnedHash}</span> <span class='removed'>${this.recipe.hash}</span>`);
         }
       },
       shownRecipeChanged: function(shownRecipe) {
@@ -108,6 +112,7 @@ http://polymer.github.io/PATENTS.txt
       pin: function() {
         this.pinned = true;
         this.pinnedResult = this.recipe.result;
+        this.pinnedHash = this.recipe.hash;
         this.to = this.over;
       },
       resetToPinned: function() {
@@ -119,7 +124,7 @@ http://polymer.github.io/PATENTS.txt
       },
       unpin: function() {
         this.pinned = false;
-        this.shownRecipe = (({result, strategy, id, parent, score, description}) => ({result, strategy, id, parent, score, description}))(this.recipe);
+        this.shownRecipe = (({result, strategy, id, parent, score, description, hash}) => ({result, strategy, id, parent, score, description, hash}))(this.recipe);
         this.strategyString = '';
         this.to = undefined;
       }

--- a/devtools/src/strategy-explorer/strategy-explorer.html
+++ b/devtools/src/strategy-explorer/strategy-explorer.html
@@ -41,9 +41,9 @@ http://polymer.github.io/PATENTS.txt
         <se-find id="find" on-find-phrase="onFindPhrase"></se-find>
         <se-compare-populations results='{{results}}'></se-compare-populations>
         <se-recipe-view></se-recipe-view>
-        <se-arc-view></se-arc-view>
-        <se-legend></se-legend>
+        <!--<se-arc-view></se-arc-view> this is disconnected today, PRs welcome-->
         <se-stats results='{{results}}'></se-stats>
+        <se-legend></se-legend>
       </aside>
     </resizable-panels>
   </template>


### PR DESCRIPTION
And reorders items in the sidebar, hiding arc-view, which has not been connected since dawn of DevTools.

I found this useful when debugging, might be helpful again soon.