### PR TITLE
Fix manifest parsing for provided slots with no local name

### DIFF
--- a/runtime/manifest.js
+++ b/runtime/manifest.js
@@ -707,7 +707,9 @@ ${e.message}
         slotConnectionItem.providedSlots.forEach(ps => {
           let providedSlot = slotConn.providedSlots[ps.param];
           if (providedSlot) {
-            items.byName.set(ps.name, providedSlot);
+            if (ps.name) {
+              items.byName.set(ps.name, providedSlot);
+            }
             items.bySlot.set(providedSlot, ps);
           } else
             providedSlot = items.byName.get(ps.name);
@@ -715,8 +717,10 @@ ${e.message}
             providedSlot = recipe.newSlot(ps.param);
             providedSlot.localName = ps.name;
             providedSlot.sourceConnection = slotConn;
-            assert(!items.byName.has(ps.name));
-            items.byName.set(ps.name, providedSlot);
+            if (ps.name) {
+              assert(!items.byName.has(ps.name));
+              items.byName.set(ps.name, providedSlot);
+            }
             items.bySlot.set(providedSlot, ps);
           }
           if (!slotConn.providedSlots[ps.param]) {

--- a/runtime/test/manifest-test.js
+++ b/runtime/test/manifest-test.js
@@ -636,6 +636,25 @@ ${particleStr1}
     recipe.normalize();
     assert.isTrue(recipe.isResolved());
   });
+  it('recipe provided slot with no local name', async () => {
+    let manifest = await Manifest.parse(`
+      particle ParticleA in 'some-particle.js'
+        consume slotA1
+          provide slotA2
+      recipe
+        ParticleA
+          consume slotA1
+            provide slotA2
+    `);
+    assert.equal(manifest.particles.length, 1);
+    assert.equal(manifest.recipes.length, 1);
+    let recipe = manifest.recipes[0];
+    assert.equal(recipe.slots.length, 1);
+    assert.equal('slotA2', recipe.slots[0].name);
+    assert.isUndefined(recipe.particles[0].consumedSlotConnections['slotA1'].targetSlot);
+    recipe.normalize();
+    assert.isFalse(recipe.isResolved());
+  });
   it('incomplete aliasing', async () => {
     let recipe = (await Manifest.parse(`
       particle P1 in 'some-particle.js'


### PR DESCRIPTION
@sjmiles this fixes the TV shows demo (well, just partially)
