### PR TITLE
Avoid '*' when doubleclicking to select a word

### DIFF
--- a/shell/app-shell/elements/shell-ui.js
+++ b/shell/app-shell/elements/shell-ui.js
@@ -275,7 +275,10 @@ class ShellUi extends Xen.Debug(Xen.Base, log) {
     this._commitSearch('');
   }
   _onResetSearch(e) {
-    this._commitSearch('*');
+    // Doubleclick on empty search box searches for '*'
+    if (e.target.value === '') {
+      this._commitSearch('*');
+    }
   }
   _commitSearch(search) {
     search = search || '';


### PR DESCRIPTION
When trying searches and hence doubleclicking to select words to replace I kept losing my search terms. I think as shortcut restricting double click leading to '*' only when the search box was still empty is still in the original spirit.. WDYT?