### PR TITLE
Adds a basic test for the OuterPortAttachment

### DIFF
--- a/runtime/debug/devtools-channel-provider.js
+++ b/runtime/debug/devtools-channel-provider.js
@@ -10,10 +10,13 @@
 'use strict';
 
 import {DevtoolsChannel} from '../../platform/devtools-channel-web.js';
+import {DevtoolsChannelStub} from './testing/devtools-channel-stub.js';
 
 let instance = null;
 
-export function getDevtoolsChannel() {
-  if (!instance) instance = new DevtoolsChannel();
+export function getDevtoolsChannel({useStub} = {}) {
+  if (!instance) {
+    instance = useStub ? new DevtoolsChannelStub() : new DevtoolsChannel();
+  }
   return instance;
 }

--- a/runtime/debug/testing/devtools-channel-stub.js
+++ b/runtime/debug/testing/devtools-channel-stub.js
@@ -1,0 +1,34 @@
+/**
+ * @license
+ * Copyright (c) 2018 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+export class DevtoolsChannelStub {
+  constructor() {
+    this._ready = Promise.resolve();
+    this._messages = [];
+  }
+
+  get ready() {
+    return this._ready;
+  }
+
+  get messages() {
+    return this._messages;
+  }
+
+  send(message) {
+    this._messages.push(JSON.parse(JSON.stringify(message)));
+  }
+
+  listen(arcOrId, messageType, callback) { /* No-op */ }
+
+  clear() {
+    this._messages.length = 0;
+  }
+}

--- a/runtime/random.js
+++ b/runtime/random.js
@@ -10,10 +10,9 @@
 
 let random = Math.random;
 
-const seededRandom = (() => {
-  let x = 0;
-  return () => (x = Math.pow(x + Math.E, Math.PI) % 1);
-})();
+const seededRandom = () => {
+  return seededRandom.x = Math.pow(seededRandom.x + Math.E, Math.PI) % 1;
+};
 
 export class Random {
   static next() {
@@ -21,6 +20,7 @@ export class Random {
   }
 
   static seedForTests() {
+    seededRandom.x = 0; // Re-seed on each call for test isolation.
     random = seededRandom;
   }
 }

--- a/runtime/test/debug/outer-port-attachments-tests.js
+++ b/runtime/test/debug/outer-port-attachments-tests.js
@@ -1,0 +1,100 @@
+/**
+ * @license
+ * Copyright (c) 2018 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {Manifest} from '../../manifest.js';
+import {assert} from '../chai-web.js';
+import * as util from '../../testing/test-util.js';
+import {Arc} from '../../arc.js';
+import {MessageChannel} from '../../message-channel.js';
+import {InnerPEC} from '../../inner-PEC.js';
+import {StubLoader} from '../../testing/stub-loader.js';
+import {getDevtoolsChannel} from '../../debug/devtools-channel-provider.js';
+import {Random} from '../../random.js';
+import {TestHelper} from '../../testing/test-helper.js';
+
+describe('OuterPortAttachment', function() {
+  it('produces dataflow messages on devtools channel', async () => {
+    Random.seedForTests();
+    let devtoolsChannelStub = getDevtoolsChannel({useStub: true});
+    const testHelper = new TestHelper({
+      loader: new StubLoader({
+        'manifest': `
+          schema Foo
+            Text value
+          particle P in 'p.js'
+            inout Foo foo
+          recipe
+            use as foo
+            P
+              foo = foo`,
+        'p.js': `defineParticle(({Particle}) => class P extends Particle {
+          async setViews(views) {
+            let foo = views.get('foo');
+            foo.set(new foo.entityClass({value: 'FooBar'}));
+          }
+        });`
+      })
+    });
+    await testHelper.loadManifest('manifest');
+    const arc = testHelper.arc;
+    arc.initDebug();
+
+    const Foo = arc._context.findSchemaByName('Foo').entityClass();
+    const fooHandle = await arc.createHandle(Foo.type, undefined, 'fooHandle');
+
+    const recipe = arc._context.recipes[0];
+    recipe.handles[0].mapToStorage(fooHandle);
+    recipe.normalize();
+    await arc.instantiate(recipe);
+
+    let instantiateParticleCall = devtoolsChannelStub.messages.find(m =>
+        m.messageType === 'InstantiateParticle').messageBody;
+    // IDs are stable thanks to Random.seedForTests().
+    assert.deepEqual(instantiateParticleCall, {
+      arcId: '!158405822139616:demo',
+      speculative: false,
+      id: '!158405822139616:demo:particle1',
+      name: 'P',
+      connections: {
+        foo: {
+          direction: 'inout',
+          id: 'fooHandle',
+          storageKey: 'in-memory://!158405822139616:demo^^in-memory-0',
+          type: 'Foo'
+        },
+      },
+      implFile: 'p.js'
+    });
+
+    await util.assertSingletonWillChangeTo(fooHandle, Foo, 'FooBar');
+    let dateflowSetCall = devtoolsChannelStub.messages.find(m =>
+        m.messageType === 'dataflow' &&
+        m.messageBody.operation === 'set').messageBody;
+
+    assert.approximately(dateflowSetCall.timestamp, Date.now(), 2000);
+    delete dateflowSetCall.timestamp; // This bit we don't want to assert on.
+
+    assert.deepEqual(dateflowSetCall, {
+      arcId: '!158405822139616:demo',
+      speculative: false,
+      operation: 'set',
+      particle: {
+        id: '!158405822139616:demo:particle1',
+        name: 'P'
+      },
+      handle: {
+        id: 'fooHandle',
+        storageKey: 'in-memory://!158405822139616:demo^^in-memory-0',
+        type: 'Foo'
+      },
+      data: '{"id":"!158405822139616:demo:0:inner:0","rawData":{"value":"FooBar"}}',
+    });
+  });
+});

--- a/runtime/testing/test-helper.js
+++ b/runtime/testing/test-helper.js
@@ -20,9 +20,6 @@ import {MockSlotComposer} from '../testing/mock-slot-composer.js';
 import {MessageChannel} from '../message-channel.js';
 import {InnerPEC} from '../inner-PEC.js';
 
-// Makes tests deterministic, which aids debugging.
-Random.seedForTests();
-
 /** @class TestHelper
  * Helper class to recipe instantiation and replanning.
  * Usage example:


### PR DESCRIPTION
Just a simple assertion on what is produced by OuterPortAttachment. Testing just two of many calls, but aims to catch only the simplest regressions. More tests can come later, not it will be easier.

This would have caught a change to the arc id (some months ago) and an attempted removal of particle IDs (last week) from the api-channel calls.