### PR TITLE
Fix link urls, plus minor tweaks

### DIFF
--- a/shell/apps/multishell/index.html
+++ b/shell/apps/multishell/index.html
@@ -27,29 +27,40 @@
     z-index: 100;
     box-shadow: 0 1px 5px rgba(0, 0, 0, 0.15);
   }
-  dynamic-frame > [toolbar] > div {
-    padding-top: 28px;
-    position: absolute;
-  }
   dynamic-frame > [toolbar] div {
     width: 32px;
     text-align: center;
-    visibility: hidden;
-    top: 0px;
+    padding-top: 4px;
+    position: relative;
+    opacity: 0;
     z-index: -1;
     transition: all 200ms cubic-bezier(0.215, 0.61, 0.355, 1);
   }
   dynamic-frame > [toolbar]:hover div {
-    visibility: visible;
-    transform: translateY(10px);
+    opacity: 1;
   }
-  dynamic-frame > [toolbar] icon {
-    margin-top: 5px;
-    position: relative;
+  dynamic-frame > [toolbar] > div > * {
+    display: inline-block;
+    transition: all 200ms cubic-bezier(0.215, 0.61, 0.355, 1);
+    padding: 4px 6px;
     color: #969696;
+  }
+  dynamic-frame > [toolbar] div > *:nth-child(1) {
+    transform: translate3d(0, -60px, 0);
+  }
+  dynamic-frame > [toolbar] div > *:nth-child(2) {
+    transform: translate3d(0, -70px, 0);
+  }
+  dynamic-frame > [toolbar] div > *:nth-child(3) {
+    transform: translate3d(0, -80px, 0);
+  }
+  dynamic-frame > [toolbar] div > *:nth-child(4) {
+    transform: translate3d(0, -90px, 0);
+  }
+  dynamic-frame > [toolbar]:hover div > * {
+    transform: translate3d(0, 0, 0);
   }
   dynamic-frame > [toolbar] a {
-    color: #969696;
     text-decoration: none;
   }
   iframe {
@@ -78,20 +89,12 @@
 <template frame>
   <iframe src="../web/"></iframe>
   <div toolbar>
-    <avatar style="{{avatarStyle}}" on-click="onClose"></avatar>
+    <avatar style="{{avatarStyle}}"></avatar>
     <div>
-      <div>
-        <icon on-click="onClose">close</icon>
-        <div>
-          <a href="{{url}}" on-click="onNew"><icon>add_circle_outline</icon></a>
-          <div>
-            <a href="{{url}}"><icon>link</icon></a>
-            <div>
-              <a href="{{vr}}" on-click="onVR"><icon>3d_rotation</icon></a>
-            </div>
-          </div>
-        </div>
-      </div>
+      <icon on-click="onClose" title="Close Panel">close</icon>
+      <a href="{{url}}" on-click="onNew" title="Open in New Panel"><icon>add_circle_outline</icon></a>
+      <a href="{{url}}" target="_blank" title="Open in New Tab"><icon>link</icon></a>
+      <a href="{{vr}}" on-click="onVR" title="Toggle 2D/VR"><icon>3d_rotation</icon></a>
     </div>
   </div>
 </template>
@@ -123,9 +126,7 @@
     jackIframe(iframe, linkHandler);
     iframe.contentWindow.location = href;
     const resolved = href;
-    const vr = href.search(/\/apps\/vr/) === -1
-      ? href.replace('/apps/web', '/apps/vr')
-      : href.replace('/apps/vr', '/apps/web');
+    const vr = href.includes('/vr') ? href.replace('/vr', '/web') : href.replace('/web', '/vr');
     //const resolved = new URL(href, document.location.href).href;
     iframe.dom.set({url: resolved, vr: vr, title: resolved});
   }
@@ -148,7 +149,6 @@
         e.stopPropagation();
         e.preventDefault();
         routeIframe(iframe, e.currentTarget.href, linkHandler);
-        //frame.firstElementChild.src = e.currentTarget.href;
       }
     };
     const dom = Xen.Template.stamp(template).appendTo(frame).events(handlers);
@@ -158,8 +158,7 @@
   }
 
   // TODO(sjmiles): had all kinds of trouble listening to events from the page itself, I assume
-  // these were timing related. Forcing the shell to fire an event on `window` (`window.top` from
-  // shell's perspective) provided stability.
+  // these were timing related. Forcing the shell to fire an event on `window.top` provided stability.
 
   window.addEventListener('profile', e => {
     const {source, profile} = e.detail;


### PR DESCRIPTION
- on my system, the urls looked like `../web`, so the regex for `apps/web` was failling; I simplified the search string to just `/web`
- `visibility` style cannot be animated, creating some slight jank ... swapped for `opacity`
- moved structural animation into CSS (not obviously better, tbh)
- added tooltips to the buttons
