### PR TITLE
remove direct runtime/ import from Generalizer.js 

### DIFF
--- a/shell/app-shell/elements/shell-ui/generalizer.js
+++ b/shell/app-shell/elements/shell-ui/generalizer.js
@@ -1,4 +1,3 @@
-import {Manifest} from '../../../../runtime/manifest.js';
 import {BrowserLoader} from '../../../source/browser-loader.js';
 import ArcsUtils from '../../lib/arcs-utils.js';
 


### PR DESCRIPTION
don't import modules directly from runtime, that's what `arcs.js` is for