### PR TITLE
Ensure new social posts show up in realtime again

### DIFF
--- a/runtime/recipe/type-checker.js
+++ b/runtime/recipe/type-checker.js
@@ -105,7 +105,7 @@ export class TypeChecker {
   static _tryMergeConstraints(handleType, {type, direction}) {
     let [primitiveHandleType, primitiveConnectionType] = Type.unwrapPair(handleType.resolvedType(), type.resolvedType());
     if (primitiveHandleType.isVariable) {
-      if (primitiveConnectionType.isCollection) {
+      while (primitiveConnectionType.isCollection) {
         if (primitiveHandleType.variable.resolution != null
             || primitiveHandleType.variable.canReadSubset != null
             || primitiveHandleType.variable.canWriteSuperset != null) {

--- a/shell/artifacts/Social/source/PostTimeRanker.js
+++ b/shell/artifacts/Social/source/PostTimeRanker.js
@@ -11,19 +11,25 @@
 defineParticle(({Particle}) => {
   return class PostTimeRanker extends Particle {
     setHandles(handles) {
-      this.on(handles, 'input', 'change', e => {
-        let inputHandle = handles.get('input');
-        inputHandle.toList().then(input => {
-          // Rank the posts by creation time.
-          input.sort((a, b) => {
-            return b.createdTimestamp - a.createdTimestamp;
-          });
-          // Set the final set of posts into the output handle.
-          input.forEach((post, index) => {
-            post.rank = index;
-            handles.get('output').store(post);
-          });
-        });
+      this.handles = handles;
+    }
+    onHandleSync(handle, input, version) {
+      this.updateOutput(input);
+    }
+
+    onHandleUpdate(handle, update, version) {
+      handle.toList().then(input => this.updateOutput(input));
+    }
+
+    updateOutput(input) {
+      // Rank the posts by creation time.
+      input.sort((a, b) => {
+        return b.createdTimestamp - a.createdTimestamp;
+      });
+      // Set the final set of posts into the output handle.
+      input.forEach((post, index) => {
+        post.rank = index;
+        this.handles.get('output').store(post);
       });
     }
   };


### PR DESCRIPTION
Fixes #1399 

There's a long-standing issue with reliable data delivery that the new PostTimeRanker was tickling (it's part of what we were seeing with the GitHub example). Fortunately, @mykmartin has fixed many of these issues with his awesome new API for events. Unfortunately (for me) you need to opt-in to that - it doesn't replace the old `this.on` stuff.

See the shiny new PostTimeRanker below on how to do that.
