### PR TITLE
More tests for connecting to localNames in constraints

### DIFF
--- a/runtime/recipe/recipe-util.js
+++ b/runtime/recipe/recipe-util.js
@@ -16,8 +16,8 @@ class Shape {
     this.reverse = new Map();
     for (let p in particles)
       this.reverse.set(particles[p], p);
-    for (let h in handles)
-      this.reverse.set(handles[h], h);
+    for (let h of handles.keys())
+      this.reverse.set(handles.get(h), h);
     for (let hc in hcs)
       this.reverse.set(hcs[hc], hc);
   }
@@ -27,10 +27,10 @@ export class RecipeUtil {
   static makeShape(particles, handles, map, recipe) {
     recipe = recipe || new Recipe();
     let pMap = {};
-    let hMap = {};
+    let hMap = new Map();
     let hcMap = {};
     particles.forEach(particle => pMap[particle] = recipe.newParticle(particle));
-    handles.forEach(handle => hMap[handle] = recipe.newHandle());
+    handles.forEach(handle => hMap.set(handle, recipe.newHandle()));
     Object.keys(map).forEach(key => {
       Object.keys(map[key]).forEach(name => {
         let handle = map[key][name];
@@ -47,8 +47,8 @@ export class RecipeUtil {
         }
         let connection = pMap[key].addConnectionName(name);
         connection.direction = direction;
-        hMap[handle].tags = tags;
-        connection.connectToHandle(hMap[handle]);
+        hMap.get(handle).tags = tags;
+        connection.connectToHandle(hMap.get(handle));
         hcMap[key + ':' + name] = pMap[key].connections[name];
       });
     });
@@ -59,8 +59,8 @@ export class RecipeUtil {
     let particles = {};
     let id = 0;
     recipe.particles.forEach(particle => particles[particle.name] = particle);
-    let handles = {};
-    recipe.handles.forEach(handle => handles['h' + id++] = handle);
+    let handles = new Map();
+    recipe.handles.forEach(handle => handles.set('h' + id++, handle));
     let hcs = {};
     recipe.handleConnections.forEach(hc => hcs[hc.particle.name + ':' + hc.name] = hc);
     return new Shape(recipe, particles, handles, hcs);
@@ -257,7 +257,7 @@ export class RecipeUtil {
     if (emptyHandles.length > 0) {
       let newMatches = [];
       for (let match of matches) {
-        let nullHandles = Object.values(shape.handles).filter(handle => match.forward.get(handle) == null);
+        let nullHandles = [...shape.handles.values()].filter(handle => match.forward.get(handle) == null);
         if (nullHandles.length > 0)
           newMatches = newMatches.concat(_assignHandlesToEmptyPosition(match, emptyHandles, nullHandles));
         else

--- a/runtime/recipe/recipe-util.js
+++ b/runtime/recipe/recipe-util.js
@@ -45,6 +45,9 @@ export class RecipeUtil {
           tags = handle.tags || [];
           handle = handle.handle;
         }
+        if (handle.localName)
+          hMap.get(handle).localName = handle.localName;
+
         let connection = pMap[key].addConnectionName(name);
         connection.direction = direction;
         hMap.get(handle).tags = tags;
@@ -89,6 +92,9 @@ export class RecipeUtil {
           if (!acceptedDirections[shapeHC.direction].includes(recipeHC.direction))
             continue;
         }
+
+        if (shapeHC.handle && recipeHC.handle && shapeHC.handle.localName && shapeHC.handle.localName !== recipeHC.handle.localName)
+          continue;
 
         // recipeHC is a candidate for shapeHC. shapeHC references a
         // particle, so recipeHC must reference the matching particle,
@@ -173,6 +179,22 @@ export class RecipeUtil {
 
         if (recipeParticle.name != shapeParticle.name)
           continue;
+
+        let handleNamesMatch = true;
+        for (let connectionName in recipeParticle.connections) {
+          let recipeConnection = recipeParticle.connections[connectionName];
+          if (!recipeConnection.handle)
+            continue;
+          let shapeConnection = shapeParticle.connections[connectionName];
+          if (shapeConnection && shapeConnection.handle && shapeConnection.handle.localName && shapeConnection.handle.localName !== recipeConnection.handle.localName) {
+            handleNamesMatch = false;
+            break;
+          }
+        }
+
+        if (!handleNamesMatch)
+          continue;
+
         let newMatch = {forward: new Map(forward), reverse: new Map(reverse), score};
         newMatch.forward.set(shapeParticle, recipeParticle);
         newMatch.reverse.set(recipeParticle, shapeParticle);

--- a/runtime/test/strategies/convert-constraints-to-connections-tests.js
+++ b/runtime/test/strategies/convert-constraints-to-connections-tests.js
@@ -388,10 +388,13 @@ describe('ConvertConstraintsToConnections', async () => {
     assert.equal(results.length, 1);
     assert.deepEqual(results[0].result.toString(), `recipe
   ? as handle0 // S {}
+  ? as handle1 // S {}
   A as particle0
     o -> handle0
-  B as particle1
-    i <- handle0`);
+  A as particle1
+    o -> handle1
+  B as particle2
+    i <- handle1`);
   });
 
   it('connects to tags', async () => {


### PR DESCRIPTION
I also needed to convert the handles component of Shape to a map, because we're storing actual handles as the key sometimes, rather than strings.

The main thing that this does is ensure that connection matches and particle matches fail if there's a specified localName for the handle in the shape and it doesn't match what the recipe version's connected to.