### PR TITLE
tweak checks order in handle.isResolved

### DIFF
--- a/runtime/recipe/handle.js
+++ b/runtime/recipe/handle.js
@@ -146,42 +146,51 @@ export class Handle {
 
   isResolved(options) {
     assert(Object.isFrozen(this));
-    if (!this._type) {
+    let resolved;
+    if (this.type) {
+      if ((!this.type.isResolved() && this.fate !== 'create') || 
+          (!this.type.canEnsureResolved() && this.fate == 'create')) {
+        if (options) {
+          options.details = 'unresolved type';
+        }
+        resolved = false;
+      }
+    } else {
       if (options) {
         options.details = 'missing type';
       }
-      return false;
+      resolved = false;
     }
+
     switch (this.fate) {
       case '?': {
         if (options) {
-          options.details = 'missing fate';
+          options.details += 'missing fate';
         }
-        return false;
+        resolved = false;
+        break;
       }
       case 'copy':
       case 'map':
       case 'use': {
         if (options && this.id === null) {
-          options.details = 'missing id';
+          options.details += 'missing id';
         }
-        return this.id !== null;
+        resolved = this.id !== null;
+        break;
       }
       case 'create':
-        return true;
+        resolved = true;
+        break;
       default: {
         if (options) {
-          options.details = `invalid fate ${this.fate}`;
+          options.details += `invalid fate ${this.fate}`;
         }
         assert(false, `Unexpected fate: ${this.fate}`);
+        resolved = false;
       }
     }
-    if ((!this.type.isResolved() && this.fate !== 'create') || (!this.type.canEnsureResolved() && this.fate == 'create')) {
-      if (options) {
-        options.details = 'unresolved type';
-      }
-      return false;
-    }
+    return resolved;
   }
 
   toString(nameMap, options) {

--- a/runtime/recipe/handle.js
+++ b/runtime/recipe/handle.js
@@ -152,12 +152,6 @@ export class Handle {
       }
       return false;
     }
-    if ((!this.type.isResolved() && this.fate !== 'create') || (!this.type.canEnsureResolved() && this.fate == 'create')) {
-      if (options) {
-        options.details = 'unresolved type';
-      }
-      return false;
-    }
     switch (this.fate) {
       case '?': {
         if (options) {
@@ -181,6 +175,12 @@ export class Handle {
         }
         assert(false, `Unexpected fate: ${this.fate}`);
       }
+    }
+    if ((!this.type.isResolved() && this.fate !== 'create') || (!this.type.canEnsureResolved() && this.fate == 'create')) {
+      if (options) {
+        options.details = 'unresolved type';
+      }
+      return false;
     }
   }
 

--- a/runtime/test/strategies/rulesets-tests.js
+++ b/runtime/test/strategies/rulesets-tests.js
@@ -60,9 +60,9 @@ class FateAssigner extends Strategy {
   }
 }
 
-class AssignFateA extends FateAssigner {constructor() {super('A');}}
-class AssignFateB extends FateAssigner {constructor() {super('B');}}
-class AssignFateC extends FateAssigner {constructor() {super('C');}}
+class AssignFateA extends FateAssigner {constructor() {super('copy');}}
+class AssignFateB extends FateAssigner {constructor() {super('map');}}
+class AssignFateC extends FateAssigner {constructor() {super('use');}}
 
 class Resolve extends Strategy {
   async generate(inputParams) {


### PR DESCRIPTION
"missing id" is a more helpful error message than "unresolved type" IMO
alternatively, i can update the code to accumulate both errors. lmk