### PR TITLE
Enable shell serialization for testing, incorporating #1259

### DIFF
--- a/runtime/arc.js
+++ b/runtime/arc.js
@@ -223,7 +223,11 @@ ${this.activeRecipe.toString()}`;
       context
     });
     // TODO: pass tags through too
-    manifest.stores.forEach(store => arc._registerStore(store, []));
+    manifest.stores.forEach(store => {
+      if (store.constructor.name == 'StorageStub')
+        store = store.inflate();
+      arc._registerStore(store, []);
+    });
     let recipe = manifest.activeRecipe.clone();
     let options = {errors: new Map()};
     assert(recipe.normalize(options), `Couldn't normalize recipe ${recipe.toString()}:\n${[...options.errors.values()].join('\n')}`);

--- a/runtime/manifest.js
+++ b/runtime/manifest.js
@@ -30,6 +30,20 @@ class ManifestError extends Error {
   }
 }
 
+class StorageStub {
+  constructor(type, id, name, storageKey, storageProviderFactory) {
+    this.type = type;
+    this.id = id;
+    this.name = name;
+    this.storageKey = storageKey;
+    this.storageProviderFactory;
+  }
+
+  inflate() {
+    return this.storageProviderFactory.connect(this.id, this.type, this.storageKey);
+  }
+}
+
 // Calls `this.visit()` for each node in a manfest AST, parents before children.
 class ManifestVisitor {
   traverse(ast) {
@@ -153,7 +167,7 @@ export class Manifest {
   }
 
   newStorageStub(type, name, id, storageKey, tags) {
-    return this._addStore({type, id, name, storageKey}, tags);
+    return this._addStore(new StorageStub(type, id, name, storageKey, this.storageProviderFactory), tags);
   }
 
   _find(manifestFinder) {
@@ -903,6 +917,9 @@ ${e.message}
     if (tags == null)
       tags = [];
 
+
+    // Instead of creating links to remote firebase during manifest parsing,
+    // we generate storage stubs that contain the relevant information.
     if (item.origin == 'storage') {
       manifest.newStorageStub(type, name, id, item.source, tags);
       return;

--- a/shell/app-shell/elements/arc-config.js
+++ b/shell/app-shell/elements/arc-config.js
@@ -50,7 +50,8 @@ class ArcConfig extends Xen.Base {
       key: params.get('arc') || null,
       search: params.get('search') || '',
       urls: window.shellUrls || {},
-      useStorage: false
+      useStorage: false,
+      useSerialization: !params.has('noserial')
     };
   }
 }

--- a/shell/app-shell/elements/cloud-data.js
+++ b/shell/app-shell/elements/cloud-data.js
@@ -54,6 +54,7 @@ const template = html`
   ></cloud-arc>
 
   <cloud-steps
+    config="{{config}}"
     key="{{key}}"
     plans="{{plans}}"
     plan="{{plan}}"

--- a/shell/app-shell/elements/cloud-data/cloud-arc.js
+++ b/shell/app-shell/elements/cloud-data/cloud-arc.js
@@ -45,7 +45,7 @@ class CloudArc extends Xen.Debug(Xen.Base, log) {
           {path: `arcs/${key}/serialization`, handler: snap => this._serializationReceived(snap, key)}
         ];
       }
-      if (plan && plan !== oldProps.plan && !Const.SHELLKEYS[key] && config.useStorage) {
+      if (plan && plan !== oldProps.plan && !Const.SHELLKEYS[key] && config.useSerialization) {
         log('plan changed, good time to serialize?');
         this._serialize(state.db, key, arc);
       }
@@ -65,12 +65,13 @@ class CloudArc extends Xen.Debug(Xen.Base, log) {
   }
   async _serialize(db, key, arc) {
     const serialization = await arc.serialize();
-    if (this._props.arc && serialization !== this._state.serialization) {
+    // on return from asynchrony, validate arc
+    if (this._props.arc === arc && serialization !== this._state.serialization) {
       // must cache first, Firebase update can fire callback synchronously
       this._state.serialization = serialization;
       const node = db.child(`${key}/serialization`);
       groupCollapsed('writing arc serialization', String(node));
-      log(serialization);
+      log('serialization:', serialization);
       groupEnd();
       node.set(serialization);
     }

--- a/shell/app-shell/elements/cloud-data/cloud-steps.js
+++ b/shell/app-shell/elements/cloud-data/cloud-steps.js
@@ -18,7 +18,7 @@ const warn = Xen.logFactory('CloudSteps', '#7b5e57', 'warn');
 
 class CloudSteps extends Xen.Debug(Xen.Base, log) {
   static get observedAttributes() {
-    return ['key', 'plans', 'plan'];
+    return ['config', 'key', 'plans', 'plan'];
   }
   _getInitialState() {
     return {
@@ -28,7 +28,11 @@ class CloudSteps extends Xen.Debug(Xen.Base, log) {
       watch: new WatchGroup()
     };
   }
-  _update({key, plans, plan}, state, oldProps) {
+  _update({config, key, plans, plan}, state, oldProps) {
+    // completely disable steps processing if we are using runtime serialization
+    if (!config || config.useSerialization) {
+      return;
+    }
     const {applied, steps} = state;
     if (key && !Const.SHELLKEYS[key]) {
       if (key !== oldProps.key) {


### PR DESCRIPTION
Note this is a pull into a branch, mostly because #1259 is labelled so as not to be merged into Master.

Runtime serialization is turned on by default (can revert to lofi `steps` behavior via `noserial` url param).