### PR TITLE
Remove some dead/unused code

### DIFF
--- a/runtime/handle.js
+++ b/runtime/handle.js
@@ -55,10 +55,6 @@ class Handle {
     this._proxy.raiseSystemException(exception, method, this._particleId);
   }
 
-  underlyingProxy() {
-    return this._proxy;
-  }
-
   // `options` may contain any of:
   // - keepSynced (bool): load full data on startup, maintain data in proxy and resync as required
   // - notifySync (bool): if keepSynced is true, call onHandleSync when the full data is received

--- a/runtime/inner-PEC.js
+++ b/runtime/inner-PEC.js
@@ -236,11 +236,6 @@ export class InnerPEC {
   get busy() {
     if (this._pendingLoads.length > 0)
       return true;
-    for (let particle of this._particles) {
-      if (particle.busy) {
-        return true;
-      }
-    }
     return false;
   }
 

--- a/runtime/particle.js
+++ b/runtime/particle.js
@@ -106,28 +106,6 @@ export class Particle {
     return this._idle;
   }
 
-  /** @method setBusy()
-   * Prevents this particle from indicating that it's idle until a matching
-   * call to setIdle is made.
-   */
-  setBusy() {
-    if (this._busy == 0)
-    this._idle = new Promise((resolve, reject) => {
-      this._idleResolver = resolve;
-    });
-    this._busy++;
-  }
-
-  /** @method setIdle()
-   * Indicates that a busy period (initiated by a call to setBusy) has completed.
-   */
-  setIdle() {
-    assert(this._busy > 0);
-    this._busy--;
-    if (this._busy == 0)
-      this._idleResolver();
-  }
-
   set relevance(r) {
     this.relevances.push(r);
   }


### PR DESCRIPTION
None of our current particles use `setBusy` and it's probably better for
this tracking to be the responsibility of the inner-pec. If a particle
is able to defer execution the PEC should be aware that it is happening.