### PR TITLE
Remove `version` from `Particle.onHandle*` handlers

### DIFF
--- a/runtime/handle.js
+++ b/runtime/handle.js
@@ -143,14 +143,14 @@ class Collection extends Handle {
   _notify(forSync, particle, version, details) {
     assert(this.canRead, '_notify should not be called for non-readable handles');
     if (forSync) {
-      particle.onHandleSync(this, this._restore(details), version);
+      particle.onHandleSync(this, this._restore(details));
     } else {
       let update = {};
       if ('add' in details)
         update.added = this._restore(details.add);
       if ('remove' in details)
         update.removed = this._restore(details.remove);
-      particle.onHandleUpdate(this, update, version);
+      particle.onHandleUpdate(this, update);
     }
   }
 
@@ -209,9 +209,9 @@ class Variable extends Handle {
   _notify(forSync, particle, version, details) {
     assert(this.canRead, '_notify should not be called for non-readable handles');
     if (forSync) {
-      particle.onHandleSync(this, this._restore(details), version);
+      particle.onHandleSync(this, this._restore(details));
     } else {
-      particle.onHandleUpdate(this, {data: this._restore(details.data)}, version);
+      particle.onHandleUpdate(this, {data: this._restore(details.data)});
     }
   }
 

--- a/runtime/test/particle-api-test.js
+++ b/runtime/test/particle-api-test.js
@@ -52,16 +52,16 @@ describe('particle-api', function() {
               this.resHandle = handles.get('res');
             }
 
-            onHandleSync(handle, model, version) {
-              this.addResult('sync:' + version + ':' + JSON.stringify(model));
+            onHandleSync(handle, model) {
+              this.addResult('sync:' + JSON.stringify(model));
             }
 
-            onHandleUpdate(handle, update, version) {
-              this.addResult('update:' + version + ':' + JSON.stringify(update));
+            onHandleUpdate(handle, update) {
+              this.addResult('update:' + JSON.stringify(update));
             }
 
-            onHandleDesync(handle, version) {
-              this.addResult('desync:' + version);
+            onHandleDesync(handle) {
+              this.addResult('desync');
             }
 
             async addResult(value) {
@@ -82,7 +82,7 @@ describe('particle-api', function() {
     recipe.normalize();
 
     await arc.instantiate(recipe);
-    await inspector.verify('sync:0:null');
+    await inspector.verify('sync:null');
 
     // Drop event 2; desync is triggered by v3.
     await fooStore.set(new Data({value: 'v1'}));
@@ -91,12 +91,12 @@ describe('particle-api', function() {
     await fooStore.set(new Data({value: 'v2'}));
     fooStore._fire = fireFn;
     await fooStore.set(new Data({value: 'v3'}));
-    await inspector.verify('update:1:{"data":{"rawData":{"value":"v1"}}}',
-                           'desync:3',
-                           'sync:3:{"rawData":{"value":"v3"}}');
+    await inspector.verify('update:{"data":{"rawData":{"value":"v1"}}}',
+                           'desync',
+                           'sync:{"rawData":{"value":"v3"}}');
 
     await fooStore.clear();
-    await inspector.verify('update:4:{"data":null}');
+    await inspector.verify('update:{"data":null}');
   });
 
   it('contains handle synchronize calls', async () => {


### PR DESCRIPTION
We should avoid passing this to particles this until we have a need
for it. Once we start accepting local mutations at the storage-proxy
or storage object the notion of version gets hairy (remote vs client vs pec).

An alternative would be that we drop this PR and maintain some notion
of version. e.g. short-term the storage-proxy starts at 0 and increments
each time it sees a mutation (both internal and external).