### PR TITLE
Store both serialization and steps data so we can switch on the fly (ish)

### DIFF
--- a/shell/app-shell/elements/cloud-data/cloud-arc.js
+++ b/shell/app-shell/elements/cloud-data/cloud-arc.js
@@ -80,7 +80,7 @@ class CloudArc extends Xen.Debug(Xen.Base, log) {
   }
   _serializationReceived(snap, key) {
     log('watch triggered on arc serialization', `${key}/serialization`);
-    const serialization = snap.val() || '';
+    const serialization = this._props.config.useSerialization ? (snap.val() || '') : '';
     if (serialization !== this._state.serialization) {
       this._state.serialization = serialization;
       this._fire('serialization', serialization);

--- a/shell/app-shell/elements/cloud-data/cloud-arc.js
+++ b/shell/app-shell/elements/cloud-data/cloud-arc.js
@@ -45,7 +45,7 @@ class CloudArc extends Xen.Debug(Xen.Base, log) {
           {path: `arcs/${key}/serialization`, handler: snap => this._serializationReceived(snap, key)}
         ];
       }
-      if (plan && plan !== oldProps.plan && !Const.SHELLKEYS[key] && config.useSerialization) {
+      if (plan && plan !== oldProps.plan && !Const.SHELLKEYS[key]) {
         log('plan changed, good time to serialize?');
         this._serialize(state.db, key, arc);
       }

--- a/shell/app-shell/elements/cloud-data/cloud-steps.js
+++ b/shell/app-shell/elements/cloud-data/cloud-steps.js
@@ -29,10 +29,6 @@ class CloudSteps extends Xen.Debug(Xen.Base, log) {
     };
   }
   _update({config, key, plans, plan}, state, oldProps) {
-    // completely disable steps processing if we are using runtime serialization
-    if (!config || config.useSerialization) {
-      return;
-    }
     const {applied, steps} = state;
     if (key && !Const.SHELLKEYS[key]) {
       if (key !== oldProps.key) {
@@ -47,10 +43,12 @@ class CloudSteps extends Xen.Debug(Xen.Base, log) {
         // `plan` has been instantiated into host, record it into `steps`
         this._addStep(key, plan.plan, plan.generations, steps || [], applied);
       }
-      // TODO(sjmiles): using latest suggestions
-      if (plans && steps.length) {
-        // find a step from `steps` that correspondes to a plan in `suggestions` but hasn't been `applied`
-        this._providePlanStep(plans.plans, plans.generations, steps, applied);
+      // enable steps playback only if we are NOT using runtime serialization
+      if (config && !config.useSerialization) {
+        if (plans && steps.length) {
+          // find a step from `steps` that correspondes to a plan in `suggestions` but hasn't been `applied`
+          this._providePlanStep(plans.plans, plans.generations, steps, applied);
+        }
       }
     }
   }

--- a/shell/artifacts/Common/List.manifest
+++ b/shell/artifacts/Common/List.manifest
@@ -22,7 +22,14 @@ particle List in 'source/List.js'
   consume root
     provide set of item
     provide set of action
-  description `show ${items}`
+  description `list that can contain ${items}`
+
+particle ContentList in 'source/List.js'
+  in [~a] items
+  consume content
+    provide set of item
+    provide set of action
+  description `list that can contain ${items}`
 
 particle SelectableList in 'source/List.js'
   inout [~a] items
@@ -30,7 +37,7 @@ particle SelectableList in 'source/List.js'
   consume root
     provide set of item
     provide set of action
-  description `show ${items}`
+  description `list that can contain ${items} with selection`
 
 // tile lists
 
@@ -48,7 +55,7 @@ particle TileList in 'source/TileList.js'
   consume root
     provide set of tile
     provide set of action
-  description `show ${items}`
+  description `tiling that can contain ${items}`
 
 particle SelectableTileList in 'source/TileList.js'
   inout [~a] items
@@ -56,4 +63,4 @@ particle SelectableTileList in 'source/TileList.js'
   consume root
     provide set of tile
     provide set of action
-  description `show ${items}`
+  description `tiling that can contain ${items} with selection`

--- a/shell/artifacts/Common/source/DetailSlider.js
+++ b/shell/artifacts/Common/source/DetailSlider.js
@@ -11,6 +11,7 @@ defineParticle(({DomParticle, resolver, html, log}) => {
   let host = `detail-slider`;
 
   const template = html`
+
 <style>
   [${host}] {
     position: absolute;
@@ -37,6 +38,7 @@ defineParticle(({DomParticle, resolver, html, log}) => {
   }
   [${host}] > [modal] {
     display: flex;
+    flex-direction: column;
     position: absolute;
     top: 0;
     right: 0;
@@ -55,16 +57,12 @@ defineParticle(({DomParticle, resolver, html, log}) => {
   }
   [${host}] > [modal] > [buttons] {
     border-bottom: 1px solid lightgrey;
-    height: 56px;
+    padding: 12px 12px 8px;
   }
   [${host}] > [modal] > [buttons] > [back-button] {
     background-color: transparent;
     border: none;
     border-radius: 100%;
-    position: absolute;
-    left: 8px;
-    top: 8px;
-    padding: 8px;
   }
   [${host}] > [modal] > [buttons] > [back-button]:active {
     background-color: #b0e3ff;
@@ -88,11 +86,15 @@ defineParticle(({DomParticle, resolver, html, log}) => {
     <div slot-content slotid="content"></div>
   </div>
 </div>
-    `.trim();
+
+`;
 
   return class extends DomParticle {
     get template() {
       return template;
+    }
+    shouldRender({selected}, {open}) {
+      return Boolean(selected || open);
     }
     render({selected}, state) {
       let hide = true;


### PR DESCRIPTION
Constrain effect of `serial` param: always record both steps and serialization, but only reify the latter when `serial` param exists (aka is true).

There are also a couple of other changes because I don't want to try to extract them and they are useful anyway.