### PR TITLE
Replace handle.synchronize with new API

### DIFF
--- a/runtime/dom-particle.js
+++ b/runtime/dom-particle.js
@@ -110,21 +110,10 @@ export class DomParticle extends XenStateMixin(Particle) {
     this.handles = handles;
     let config = this.config;
 
-    console.log('\n' + this.id, 'setViews', [...handles.keys()]);
-    this.newApproach = true;
-    if (!this.newApproach) {
-      // calls _handlesToProps once all handles have been sent (via the afterAllModels/modelCallback logic)
-      // and then whenever the backing stores are changed (via the .on listener attached in onSynchronize)
-      this.when([new HandleChanges(handles, config.handles, 'change', this.id)], async () => {
-        await this._handlesToProps(handles, config);
-      });
-    }
-
     // this.config isn't a static property; not sure how important it is to avoid re-generating
     // it in the onHandle* functions
     this._configSnapshot = config;
     this._modelCount = this._configSnapshot.handles.length;
-    console.log(this.id, 'handle names:', this._configSnapshot.handles);
 
     // make sure we invalidate once, even if there are no incoming handles
     this._invalidate();
@@ -133,17 +122,12 @@ export class DomParticle extends XenStateMixin(Particle) {
   // onHandleSync should replace the afterAllModels logic
   // onHandleUpdate should replace the .on listener updates
   async onHandleSync(handle, model, version) {
-    let warn = this._modelCount < 1 ? '*************************' : '';
-    console.log(this.id, 'onHandleSync', handle.name, this._modelCount, version, warn);
-    if (--this._modelCount == 0 && this.newApproach) {
+    if (--this._modelCount == 0) {
       await this._handlesToProps(this.handles, this._configSnapshot);
     }
   }
   async onHandleUpdate(handle, update, version) {
-    console.log(this.id, 'onHandleUpdate', handle.name), this.id;
-    if (this.newApproach) {
-      await this._handlesToProps(this.handles, this._configSnapshot);
-    }
+    await this._handlesToProps(this.handles, this._configSnapshot);
   }
 
   async _handlesToProps(handles, config) {

--- a/runtime/outer-PEC.js
+++ b/runtime/outer-PEC.js
@@ -36,7 +36,7 @@ export class OuterPEC extends ParticleExecutionContext {
     };
 
     this._apiPort.onInitializeProxy = async ({handle, callback}) => {
-      let target = {_scheduler: this._arc.scheduler};
+      let target = {_handle: handle, _scheduler: this._arc.scheduler};
       handle.on('change', data => this._apiPort.SimpleCallback({callback, data}), target);
     };
 

--- a/runtime/particle.js
+++ b/runtime/particle.js
@@ -203,16 +203,23 @@ export class Particle {
 }
 
 export class HandleChanges {
-  constructor(handles, names, type) {
+  constructor(handles, names, type, particleId) {
     if (typeof names == 'string')
       names = [names];
     this.names = names;
     this.handles = handles;
     this.type = type;
+    this.particleId = particleId;
   }
   register(particle, f) {
     let modelCount = 0;
-    let afterAllModels = () => { if (++modelCount == this.names.length) { f(); } };
+    let afterAllModels = () => { 
+      console.log(this.particleId, 'afterAllModels', modelCount + 1);
+      if (++modelCount == this.names.length) { 
+        console.log(this.particleId, '-> calling _handlesToProps');
+        f();
+      }
+    };
 
     for (let name of this.names) {
       let handle = this.handles.get(name);

--- a/runtime/scheduler.js
+++ b/runtime/scheduler.js
@@ -92,8 +92,8 @@ export class Scheduler {
     let totalRecords = 0;
     for (let [handle, kinds] of frame.handles.entries()) {
       for (let [kind, records] of kinds.entries()) {
-        let record = records[records.length - 1];
-        record.callback(record.details);
+        for (let record of records)
+          record.callback(record.details);
       }
     }
 

--- a/runtime/test/demo-flow-test.js
+++ b/runtime/test/demo-flow-test.js
@@ -8,7 +8,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
- 'use strict';
+'use strict';
 
 import {Manifest} from '../manifest.js';
 import {Loader} from '../loader.js';
@@ -21,15 +21,10 @@ describe('demo flow', function() {
     await Manifest.load('./shell/artifacts/Products/Products.recipes', new Loader());
   });
 
-  it('BORKED flows like a demo', async function() {
-
-    let timeout = setTimeout(function() {
-      helper.slotComposer.assertExpectationsCompleted();
-    }, 5000);
+  it('flows like a demo', async function() {
 
     let helper = await TestHelper.loadManifestAndPlan('./shell/artifacts/Products/Products.recipes', {
       expectedNumPlans: 2,
-      logging: true,
       verify: async (plans) => {
         let descriptions = await Promise.all(plans.map(plan => plan.description.getRecipeSuggestion()));
         assert.include(descriptions, 'Show products from your browsing context (Minecraft Book plus 2 other items) ' +
@@ -40,6 +35,8 @@ describe('demo flow', function() {
       // slotComposerStrict: false,
       // logging: true
     });
+
+    helper.setTimeout(5000);
 
     // 1. Accept "Show ... and choose ... products" suggestion.
     helper.slotComposer
@@ -55,7 +52,6 @@ describe('demo flow', function() {
         .expectRenderSlot('Multiplexer2', 'annotation', {verify: helper.slotComposer.expectContentItemsNumber.bind(null, 3)})
         .expectRenderSlot('AlsoOn', 'annotation', {contentTypes: ['model'], times: 3, isOptional: true});
     await helper.acceptSuggestion({particles: ['ShowCollection', 'Multiplexer', 'Chooser', 'Recommend', 'Multiplexer2']});
-    clearTimeout(timeout);
 
     assert.equal(2, helper.arc.findStoresByType(helper.arc.context.findSchemaByName('Product').entityClass().type.collectionOf()).length);
     await helper.verifySetSize('ShowCollection', 'collection', 3);
@@ -179,6 +175,8 @@ describe('demo flow', function() {
     await helper.acceptSuggestion({particles: ['Interests']});
     await helper.makePlans({expectedNumPlans: 2});
     helper.log('----------------------------------------');
+
+    helper.clearTimeout();
 
     // TODO(mmandlis): Provide methods in helper to verify slot contents (helper.slotComposer._slots[i]._content).
   }).timeout(10000);

--- a/runtime/test/demo-flow-test.js
+++ b/runtime/test/demo-flow-test.js
@@ -21,9 +21,15 @@ describe('demo flow', function() {
     await Manifest.load('./shell/artifacts/Products/Products.recipes', new Loader());
   });
 
-  it('flows like a demo', async function() {
+  it('BORKED flows like a demo', async function() {
+
+    let timeout = setTimeout(function() {
+      helper.slotComposer.assertExpectationsCompleted();
+    }, 5000);
+
     let helper = await TestHelper.loadManifestAndPlan('./shell/artifacts/Products/Products.recipes', {
       expectedNumPlans: 2,
+      logging: true,
       verify: async (plans) => {
         let descriptions = await Promise.all(plans.map(plan => plan.description.getRecipeSuggestion()));
         assert.include(descriptions, 'Show products from your browsing context (Minecraft Book plus 2 other items) ' +
@@ -49,6 +55,7 @@ describe('demo flow', function() {
         .expectRenderSlot('Multiplexer2', 'annotation', {verify: helper.slotComposer.expectContentItemsNumber.bind(null, 3)})
         .expectRenderSlot('AlsoOn', 'annotation', {contentTypes: ['model'], times: 3, isOptional: true});
     await helper.acceptSuggestion({particles: ['ShowCollection', 'Multiplexer', 'Chooser', 'Recommend', 'Multiplexer2']});
+    clearTimeout(timeout);
 
     assert.equal(2, helper.arc.findStoresByType(helper.arc.context.findSchemaByName('Product').entityClass().type.collectionOf()).length);
     await helper.verifySetSize('ShowCollection', 'collection', 3);
@@ -174,5 +181,5 @@ describe('demo flow', function() {
     helper.log('----------------------------------------');
 
     // TODO(mmandlis): Provide methods in helper to verify slot contents (helper.slotComposer._slots[i]._content).
-  }).timeout(5000);
+  }).timeout(10000);
 });

--- a/runtime/testing/mock-slot-composer.js
+++ b/runtime/testing/mock-slot-composer.js
@@ -62,7 +62,7 @@ export class MockSlotComposer extends SlotComposer {
    * Allows ignoring unexpected render slot requests.
    */
   ignoreUnexpectedRender() {
-    this.expectQueue.push({type: 'render', ignoreUnexpected: true, isOptional: true});
+    this.expectQueue.push({type: 'render', ignoreUnexpected: true, isOptional: true, toString: () => `render: ignoreUnexpected optional`});
     return this;
   }
 
@@ -109,6 +109,13 @@ export class MockSlotComposer extends SlotComposer {
     return new Promise((resolve, reject) => this.onExpectationsComplete = resolve);
   }
 
+  assertExpectationsCompleted() {
+    if (this.expectQueue.length == 0 || this.expectQueue.every(e => e.isOptional)) {
+      return true;
+    }
+    assert.isTrue(false, 'remaining expectations:\n' + this.expectQueue.map(expect => `  ${expect.toString()}`).join('\n'));
+  }
+
   /** @method sendEvent(particleName, slotName, event, data)
    * Sends an event to the given particle and slot.
    */
@@ -126,7 +133,8 @@ export class MockSlotComposer extends SlotComposer {
           && e.isOptional == expectation.isOptional;
     });
     if (!current) {
-      current = {type: 'render', particleName: expectation.particleName, slotName: expectation.slotName, hostedParticle: expectation.hostedParticle, isOptional: expectation.isOptional};
+      current = {type: 'render', particleName: expectation.particleName, slotName: expectation.slotName, hostedParticle: expectation.hostedParticle, isOptional: expectation.isOptional, 
+                 toString: () => `render:${expectation.isOptional ? '  optional' : ' '} ${expectation.particleName} ${expectation.slotName} ${expectation.hostedParticle} ${current.contentTypes}`};
       this.expectQueue.push(current);
     }
     if (expectation.verifyComplete) {

--- a/runtime/testing/test-helper.js
+++ b/runtime/testing/test-helper.js
@@ -56,9 +56,7 @@ export class TestHelper {
   }
 
   setTimeout(timeout) {
-    this.timeout = setTimeout(function() {
-      this.slotComposer.assertExpectationsCompleted();
-    }, timeout);
+    this.timeout = setTimeout(() => this.slotComposer.assertExpectationsCompleted(), timeout);
   }
 
   clearTimeout() {

--- a/runtime/testing/test-helper.js
+++ b/runtime/testing/test-helper.js
@@ -55,6 +55,16 @@ export class TestHelper {
     this.logging = options.logging;
   }
 
+  setTimeout(timeout) {
+    this.timeout = setTimeout(function() {
+      this.slotComposer.assertExpectationsCompleted();
+    }, timeout);
+  }
+
+  clearTimeout() {
+    clearTimeout(this.timeout);
+  }
+
   /** @static @method loadManifestAndPlan(manifestFilename, options)
    * Creates and returns a TestHelper instance, loads a manifest file and makes planning.
    */


### PR DESCRIPTION
This seems to pass consistently now. The relevant change is in scheduler.js.

If I get a chance later tonight, I'll also flesh out the testing approach I added here to demo-flow-test.js - it is suffering from the problem of async multistage expectations not reporting what wasn't satisfied. If I don't get to it, feel free to pull that stuff back out.