### PR TITLE
Enhance Planificator log formatting.

### DIFF
--- a/runtime/planificator.js
+++ b/runtime/planificator.js
@@ -14,6 +14,13 @@ import {SuggestionComposer} from './suggestion-composer.js';
 
 let defaultTimeoutMs = 5000;
 
+const bindLog = (log) => {
+  return console[log].bind(console, `%cPlanificator`,
+      `background: #ff0090; color: white; padding: 1px 6px 2px 7px; border-radius: 6px;`);
+};
+const log = bindLog('log');
+const error = bindLog('error');
+
 class ReplanQueue {
   constructor(planificator, options) {
     this._planificator = planificator;
@@ -264,7 +271,7 @@ export class Planificator {
       try {
         await this._runPlanning(options);
       } catch (x) {
-        console.error(x);
+        error(`Planning failed [error=${x}].`);
       }
       this.isPlanning = false;
       this._setCurrent({plans: this._next.plans, generations: this._next.generations},
@@ -279,7 +286,7 @@ export class Planificator {
       await this._doNextPlans(options);
     }
     time = ((now() - time) / 1000).toFixed(2);
-    console.log(`Produced ${this._next.plans.length} in ${time}s.`);
+    log(`Produced plans [count=${this._next.plans.length}, elapsed=${time}s].`);
   }
 
   _plansDiffer(newPlans, oldPlans) {


### PR DESCRIPTION
Trivial Friday antics.

This logging is always present in console currently, so I figured we may as well make it fit better with the other shell logging for eye pleasantries.

This replicates some `logFactory` logic in `shell/components/xen/xen.js`. We could factor that out into a common place, or leave that as is and create a separate common place for these for code that lives in runtime. But referencing Xen's log factory from Planificator wasn't clearly a good idea, so, I didn't, but we can do that if that seems sufficiently kosher.