### PR TITLE
Implement simplified tag naming syntax for connections

### DIFF
--- a/runtime/manifest-parser.peg
+++ b/runtime/manifest-parser.peg
@@ -351,7 +351,7 @@ ParticleArgumentList
   }
 
 ParticleArgument
-  = direction:ParticleArgumentDirection whiteSpace type:ParticleArgumentType isOptional:'?'? whiteSpace name:lowerIdent
+  = direction:ParticleArgumentDirection whiteSpace type:ParticleArgumentType isOptional:'?'? nametag:NameAndTagList
   {
     return {
       kind: 'particle-argument',
@@ -360,7 +360,8 @@ ParticleArgument
       type: type,
       isOptional: !!isOptional,
       dependentConnections: [],
-      name,
+      name: nametag.name,
+      tags: nametag.tags,
     };
   }
 
@@ -787,6 +788,32 @@ VerbList
 SpaceTagList
   = whiteSpace tags:TagList
   { return tags; }
+
+// Allow for an optional name followed by a TagList
+// - If name is not specified the first tag is used for the name
+// - Syntax error if no name or taglist are provided.
+NameAndTagList
+   = whiteSpace name:lowerIdent whiteSpace tags:TagList
+   {
+     return {
+       name: name,
+       tags: tags
+     }
+   }
+   / whiteSpace name:lowerIdent
+   {
+     return {
+       name: name,
+       tags: []
+     };
+   }
+   / whiteSpace tags:TagList
+   {
+      return {
+        name: tags[0],
+        tags: tags
+      }
+   }
 
 ParticleRef
   = name:upperIdent

--- a/runtime/particle-spec.js
+++ b/runtime/particle-spec.js
@@ -20,6 +20,7 @@ class ConnectionSpec {
     this.name = rawData.name;
     this.type = rawData.type.mergeTypeVariablesByName(typeVarMap);
     this.isOptional = rawData.isOptional;
+    this.tags = rawData.tags || [];
     this.dependentConnections = [];
   }
 

--- a/runtime/test/manifest-test.js
+++ b/runtime/test/manifest-test.js
@@ -1409,4 +1409,33 @@ resource SomeName
     assert(slotConnection._providedSlots.provideSlot);
     assert.equal(slotConnection._providedSlots.provideSlot.sourceConnection, slotConnection);
   });
+
+  it('can parse particle arguments with tags and optional names', async () => {
+    let manifest = await Manifest.parse(`
+      schema Dog
+      schema Sled
+      schema DogSled
+      particle DogSledMaker in 'thing.js'
+        in Dog #leader
+        in [Dog] team
+        in Sled sled #dogsled
+        out DogSled dogsled #multidog #winter #sled
+    `);
+
+    assert.equal(manifest.particles.length, 1);
+    assert.equal(manifest.particles[0].connections.length, 4);
+
+    let connections = manifest.particles[0].connections;
+    assert.equal(connections[0].name, 'leader');
+    assert.deepEqual(connections[0].tags, ['leader']);
+
+    assert.equal(connections[1].name, 'team');
+    assert.equal(connections[1].tags.length, 0);
+
+    assert.equal(connections[2].name, 'sled');
+    assert.deepEqual(connections[2].tags, ['dogsled']);
+
+    assert.equal(connections[3].name, 'dogsled');
+    assert.deepEqual(connections[3].tags, ['multidog', 'winter', 'sled']);
+  });
 });


### PR DESCRIPTION
- Adds tag support for particle arguments.
- Allows for 'name' to be optional if tags are specified

Addresses #1149