### PR TITLE
Clean up assert usages to use more specific methods

### DIFF
--- a/extension/test/page-extractor-webtest.js
+++ b/extension/test/page-extractor-webtest.js
@@ -17,7 +17,7 @@ describe('PageExtractor', function() {
             <span itemprop="name">Chile Verde Burrito</span>
           </div>`;
       return extractEntities(document, window.location).then(function(results) {
-        assert.equal(2, results.length);
+        assert.lengthOf(results, 2);
         assert.deepEqual(
             {'@type': 'http://schema.org/Product', name: 'Chile Verde Burrito'},
             results[0]);

--- a/runtime/manual_tests/firebase-tests.js
+++ b/runtime/manual_tests/firebase-tests.js
@@ -28,7 +28,7 @@ describe('firebase', function() {
       'firebase://test-firebase-45a3e.firebaseio.com/AIzaSyBLqThan3QCOICj0JZ-nEwk27H4gmnADP8/test');
     await variable.set({id: 'test0:test', value});
     let result = await variable.get();
-    assert(value == result.value);
+    assert.equal(value, result.value);
   });
 
   it('can host a collection', async () => {
@@ -46,9 +46,9 @@ describe('firebase', function() {
     await collection.store({id: 'test0:test0', value: value1});
     await collection.store({id: 'test0:test1', value: value2});
     let result = await collection.get('test0:test0');
-    assert(value1 == result.value);
+    assert.equal(value1, result.value);
     result = await collection.toList();
-    assert(result.length == 2);
+    assert.lengthOf(result, 2);
     assert(result[0].value = value1);
     assert(result[0].id = 'test0:test0');
     assert(result[1].value = value2);

--- a/runtime/manual_tests/loader-tests.js
+++ b/runtime/manual_tests/loader-tests.js
@@ -18,19 +18,19 @@ describe('loader', function() {
   it('correctly loads Thing as a dependency', async () => {
     let schemaString = await loader.loadResource('http://schema.org/Product');
     let manifest = await Manifest.parse(schemaString, {loader, fileName: 'http://schema.org/Product'});
-    assert(manifest.schemas.Product.fields.description == 'Text');
+    assert.equal(manifest.schemas.Product.fields.description, 'Text');
   }).timeout(10000);
 
   it('can read a schema.org schema that aliases another type', async () => {
     let schemaString = await loader.loadResource('http://schema.org/Restaurant');
     let manifest = await Manifest.parse(schemaString, {loader, fileName: 'http://schema.org/Restaurant'});
-    assert(manifest.schemas.Restaurant.fields.servesCuisine == 'Text');
+    assert.equal(manifest.schemas.Restaurant.fields.servesCuisine, 'Text');
   }).timeout(10000);
 
   it('can read a schema.org schema with multiple inheritance', async () => {
     let schemaString = await loader.loadResource('http://schema.org/LocalBusiness');
     let manifest = await Manifest.parse(schemaString, {loader, fileName: 'http://schema.org/LocalBusiness'});
-    assert(manifest.schemas.LocalBusiness.fields.duns == 'Text');
-    assert(manifest.schemas.LocalBusiness.fields.branchCode == 'Text');
+    assert.equal(manifest.schemas.LocalBusiness.fields.duns, 'Text');
+    assert.equal(manifest.schemas.LocalBusiness.fields.branchCode, 'Text');
   }).timeout(10000);
 });

--- a/runtime/test/demo-flow-test.js
+++ b/runtime/test/demo-flow-test.js
@@ -61,7 +61,7 @@ describe('demo flow', function() {
         .expectRenderSlot('Multiplexer2', 'annotation', {verify: helper.slotComposer.expectContentItemsNumber.bind(null, 3), isOptional: true});
     await helper.acceptSuggestion({particles: ['ShowCollection', 'Multiplexer', 'Chooser', 'Recommend', 'Multiplexer2']});
 
-    assert.equal(2, helper.arc.findStoresByType(helper.arc.context.findSchemaByName('Product').entityClass().type.collectionOf()).length);
+    assert.lengthOf(helper.arc.findStoresByType(helper.arc.context.findSchemaByName('Product').entityClass().type.collectionOf()), 2);
     await helper.verifySetSize('ShowCollection', 'collection', 3);
     await helper.verifySetSize('Multiplexer', 'list', 3);
     await helper.verifySetSize('Chooser', 'choices', 3);

--- a/runtime/test/description-test.js
+++ b/runtime/test/description-test.js
@@ -75,7 +75,7 @@ recipe
     consume root as slot0`;
   async function prepareRecipeAndArc(manifestStr) {
     let manifest = (await Manifest.parse(manifestStr));
-    assert.equal(1, manifest.recipes.length);
+    assert.lengthOf(manifest.recipes, 1);
     let recipe = manifest.recipes[0];
     let Foo = manifest.findSchemaByName('Foo').entityClass();
     recipe.handles[0].mapToStorage({id: 'test:1', type: Foo.type});
@@ -357,7 +357,7 @@ recipe
     consume root as slot0
     `;
       let manifest = (await Manifest.parse(manifestStr));
-      assert.equal(1, manifest.recipes.length);
+      assert.lengthOf(manifest.recipes, 1);
       let recipe = manifest.recipes[0];
       let Foo = manifest.findSchemaByName('Foo').entityClass();
       recipe.handles[0].mapToStorage({id: 'test:1', type: Foo.type.collectionOf()});
@@ -491,7 +491,7 @@ recipe
            ts = tsHandle
            consume root as slot0`;
         let manifest = (await Manifest.parse(manifestStr));
-        assert.equal(1, manifest.recipes.length);
+        assert.lengthOf(manifest.recipes, 1);
         let recipe = manifest.recipes[0];
         let MyBESTType = manifest.findSchemaByName('MyBESTType').entityClass();
         recipe.handles[0].mapToStorage({id: 'test:1', type: MyBESTType.type});
@@ -564,7 +564,7 @@ recipe
     consume otherslot as slot2
 `;
       let manifest = (await Manifest.parse(manifestStr));
-      assert.equal(1, manifest.recipes.length);
+      assert.lengthOf(manifest.recipes, 1);
       let recipe = manifest.recipes[0];
       recipe.normalize();
       assert.isTrue(recipe.isResolved());
@@ -654,7 +654,7 @@ recipe
     consume root as slot0
 `;
     let manifest = (await Manifest.parse(manifestStr));
-    assert.equal(1, manifest.recipes.length);
+    assert.lengthOf(manifest.recipes, 1);
     let recipe = manifest.recipes[0];
     let Foo = manifest.findSchemaByName('Foo').entityClass();
     let DescriptionType = manifest.findSchemaByName('Description').entityClass();

--- a/runtime/test/dom-slot-tests.js
+++ b/runtime/test/dom-slot-tests.js
@@ -30,7 +30,7 @@ describe('dom-slot', function() {
 
     // context was null; set none null - initializes DOM context
     slot.setContainer('dummy-container');
-    assert.isTrue(slot.getContext() instanceof MockDomContext);
+    assert.instanceOf(slot.getContext(), MockDomContext);
     let clearCount = 0;
     slot.getContext().clear = () => { clearCount++; };
     assert.equal('dummy-container', slot.getContext().container);

--- a/runtime/test/handle-test.js
+++ b/runtime/test/handle-test.js
@@ -32,7 +32,7 @@ describe('Handle', function() {
     let barStore = await arc.createStore(Bar.type);
     barStore.set(new Bar({value: 'a Bar'}));
     barStore.clear();
-    assert.equal(await barStore.get(), undefined);
+    assert.isNull(await barStore.get());
   });
 
   it('ignores duplicate stores of the same entity value (variable)', async () => {
@@ -74,7 +74,7 @@ describe('Handle', function() {
     await fooHandle.store(new Foo({value: 'a Foo'}, 'first'));
     await fooHandle.store(new Foo({value: 'another Foo'}, 'second'));
     await fooHandle.store(new Foo({value: 'a Foo, again'}, 'first'));
-    assert.equal((await fooHandle.toList()).length, 2);
+    assert.lengthOf((await fooHandle.toList()), 2);
   });
 
   it('remove entry from store', async () => {
@@ -83,7 +83,7 @@ describe('Handle', function() {
     let bar = new Bar({id: 0, value: 'a Bar'});
     barStore.store(bar);
     barStore.remove(bar.id);
-    assert.equal((await barStore.toList()).length, 0);
+    assert.isEmpty((await barStore.toList()));
   });
 
   it('can store a particle in a shape store', async () => {

--- a/runtime/test/manifest-parser-test.js
+++ b/runtime/test/manifest-parser-test.js
@@ -93,7 +93,7 @@ describe('manifest parser', function() {
           Nonsense()`);
       assert.fail('this parse should have failed, no nonsense!');
     } catch (e) {
-      assert(e.message.includes('Nonsense'),
+      assert.include(e.message, 'Nonsense',
           'bad error: '+e);
     }
   });

--- a/runtime/test/manifest-test.js
+++ b/runtime/test/manifest-test.js
@@ -49,18 +49,18 @@ describe('manifest', function() {
       assert.deepEqual(['someVerb1', 'someVerb2'], recipe.verbs);
       assert.sameMembers(manifest.findRecipesByVerb('someVerb1'), [recipe]);
       assert.sameMembers(manifest.findRecipesByVerb('someVerb2'), [recipe]);
-      assert.equal(recipe.particles.length, 1);
-      assert.equal(recipe.handles.length, 2);
+      assert.lengthOf(recipe.particles, 1);
+      assert.lengthOf(recipe.handles, 2);
       assert.equal(recipe.handles[0].fate, 'map');
       assert.equal(recipe.handles[1].fate, 'create');
-      assert.equal(recipe.handleConnections.length, 1);
+      assert.lengthOf(recipe.handleConnections, 1);
       assert.sameMembers(recipe.handleConnections[0].tags, ['tag']);
       assert.equal(recipe.pattern, 'hello world');
       assert.equal(recipe.handles[1].pattern, 'best handle');
       let type = recipe.handleConnections[0].rawType;
-      assert.equal(1, Object.keys(manifest.schemas).length);
+      assert.lengthOf(Object.keys(manifest.schemas), 1);
       let schema = Object.values(manifest.schemas)[0];
-      assert.equal(3, Object.keys(schema.description).length);
+      assert.lengthOf(Object.keys(schema.description), 3);
       assert.deepEqual(Object.keys(schema.description), ['pattern', 'plural', 'value']);
     };
     verify(manifest);
@@ -105,7 +105,7 @@ ${particleStr0}
 ${particleStr1}
     `);
     let verify = (manifest) => {
-      assert.equal(manifest.particles.length, 2);
+      assert.lengthOf(manifest.particles, 2);
       assert.equal(particleStr0, manifest.particles[0].toString());
       assert.equal(particleStr1, manifest.particles[1].toString());
     };
@@ -120,8 +120,8 @@ ${particleStr1}
       consume thing
         provide otherThing
     `);
-    assert.equal(manifest.particles.length, 1);
-    assert.equal(manifest.particles[0].connections.length, 2);
+    assert.lengthOf(manifest.particles, 1);
+    assert.lengthOf(manifest.particles[0].connections, 2);
   });
   it('can parse a manifest with dependent handles', async () => {
     let manifest = await Manifest.parse(`
@@ -131,8 +131,8 @@ ${particleStr1}
       consume thing
         provide otherThing
     `);
-    assert.equal(manifest.particles.length, 1);
-    assert.equal(manifest.particles[0].connections.length, 2);
+    assert.lengthOf(manifest.particles, 1);
+    assert.lengthOf(manifest.particles[0].connections, 2);
   });
   it('can round-trip particles with dependent handles', async () => {
     let manifestString = `particle TestParticle in 'a.js'
@@ -143,7 +143,7 @@ ${particleStr1}
     provide otherThing`;
 
     let manifest = await Manifest.parse(manifestString);
-    assert.equal(manifest.particles.length, 1);
+    assert.lengthOf(manifest.particles, 1);
     assert.equal(manifestString, manifest.particles[0].toString());
   });
   it('can parse a manifest containing a schema', async () => {
@@ -210,7 +210,7 @@ ${particleStr1}
     let verify = (manifest) => {
       let recipe = manifest.recipes[0];
       assert(recipe);
-      assert.equal(recipe._connectionConstraints.length, 1);
+      assert.lengthOf(recipe._connectionConstraints, 1);
       let constraint = recipe._connectionConstraints[0];
       assert.equal(constraint.from.particle.name, 'A');
       assert.equal(constraint.from.connection, 'a');
@@ -231,7 +231,7 @@ ${particleStr1}
     let verify = (manifest) => {
       let recipe = manifest.recipes[0];
       assert(recipe);
-      assert.equal(recipe._connectionConstraints.length, 1);
+      assert.lengthOf(recipe._connectionConstraints, 1);
       let constraint = recipe._connectionConstraints[0];
       assert.equal(constraint.from.particle.name, 'A');
       assert.equal(constraint.from.connection, 'a');
@@ -474,7 +474,7 @@ ${particleStr1}
       },
     };
     let manifest = await Manifest.load('a', loader);
-    assert.equal(manifest.recipes.length, 3);
+    assert.lengthOf(manifest.recipes, 3);
   });
   it('can parse a schema with union typing', async () => {
     let manifest = await Manifest.parse(`
@@ -527,16 +527,16 @@ ${particleStr1}
       assert(recipe);
       recipe.normalize();
 
-      assert.equal(recipe.particles.length, 2);
-      assert.equal(recipe.handles.length, 1);
-      assert.equal(recipe.handleConnections.length, 2);
-      assert.equal(recipe.slots.length, 3);
-      assert.equal(recipe.slotConnections.length, 3);
-      assert.equal(Object.keys(recipe.particles[0].consumedSlotConnections).length, 2);
-      assert.equal(Object.keys(recipe.particles[1].consumedSlotConnections).length, 1);
+      assert.lengthOf(recipe.particles, 2);
+      assert.lengthOf(recipe.handles, 1);
+      assert.lengthOf(recipe.handleConnections, 2);
+      assert.lengthOf(recipe.slots, 3);
+      assert.lengthOf(recipe.slotConnections, 3);
+      assert.lengthOf(Object.keys(recipe.particles[0].consumedSlotConnections), 2);
+      assert.lengthOf(Object.keys(recipe.particles[1].consumedSlotConnections), 1);
       let mySlot = recipe.particles[1].consumedSlotConnections['mySlot'];
       assert.isDefined(mySlot.targetSlot);
-      assert.equal(Object.keys(mySlot.providedSlots).length, 2);
+      assert.lengthOf(Object.keys(mySlot.providedSlots), 2);
       assert.equal(mySlot.providedSlots['oneMoreSlot'], recipe.particles[0].consumedSlotConnections['oneMoreSlot'].targetSlot);
     };
     verify(manifest);
@@ -556,8 +556,8 @@ ${particleStr1}
           consume slotC
     `);
     let recipe = manifest.recipes[0];
-    assert.equal(2, recipe.slotConnections.length);
-    assert.equal(0, recipe.slots.length);
+    assert.lengthOf(recipe.slotConnections, 2);
+    assert.isEmpty(recipe.slots);
   });
   it('multiple consumed slots', async () => {
     let parseRecipe = async (args) => {
@@ -591,19 +591,19 @@ ${particleStr1}
               provide slotB
     `);
     // verify particle spec
-    assert.equal(manifest.particles.length, 1);
+    assert.lengthOf(manifest.particles, 1);
     let spec = manifest.particles[0];
     assert.equal(spec.slots.size, 1);
     let slotSpec = [...spec.slots.values()][0];
     assert.deepEqual(slotSpec.tags, ['aaa']);
-    assert.equal(slotSpec.providedSlots.length, 1);
+    assert.lengthOf(slotSpec.providedSlots, 1);
     let providedSlotSpec = slotSpec.providedSlots[0];
     assert.deepEqual(providedSlotSpec.tags, ['bbb']);
 
     // verify recipe slots
-    assert.equal(manifest.recipes.length, 1);
+    assert.lengthOf(manifest.recipes, 1);
     let recipe = manifest.recipes[0];
-    assert.equal(recipe.slots.length, 2);
+    assert.lengthOf(recipe.slots, 2);
     let recipeSlot = recipe.slots.find(s => s.id == 'slot-id0');
     assert(recipeSlot);
     assert.deepEqual(recipeSlot.tags, ['aa', 'aaa']);
@@ -611,7 +611,7 @@ ${particleStr1}
     let slotConn = recipe.particles[0].consumedSlotConnections['slotA'];
     assert(slotConn);
     assert.deepEqual(['aa', 'hello'], slotConn.tags);
-    assert.equal(1, Object.keys(slotConn.providedSlots).length);
+    assert.lengthOf(Object.keys(slotConn.providedSlots), 1);
   });
   it('recipe slots with different names', async () => {
     let manifest = await Manifest.parse(`
@@ -628,10 +628,10 @@ ${particleStr1}
           consume slotB1 as s0
             provide slotB2 as mySlot
     `);
-    assert.equal(manifest.particles.length, 2);
-    assert.equal(manifest.recipes.length, 1);
+    assert.lengthOf(manifest.particles, 2);
+    assert.lengthOf(manifest.recipes, 1);
     let recipe = manifest.recipes[0];
-    assert.equal(recipe.slots.length, 2);
+    assert.lengthOf(recipe.slots, 2);
     assert.equal(recipe.particles.find(p => p.name == 'ParticleB').consumedSlotConnections['slotB1'].providedSlots['slotB2'],
                  recipe.particles.find(p => p.name == 'ParticleA').consumedSlotConnections['slotA'].targetSlot);
     recipe.normalize();
@@ -647,10 +647,10 @@ ${particleStr1}
           consume slotA1
             provide slotA2
     `);
-    assert.equal(manifest.particles.length, 1);
-    assert.equal(manifest.recipes.length, 1);
+    assert.lengthOf(manifest.particles, 1);
+    assert.lengthOf(manifest.recipes, 1);
     let recipe = manifest.recipes[0];
-    assert.equal(recipe.slots.length, 1);
+    assert.lengthOf(recipe.slots, 1);
     assert.equal('slotA2', recipe.slots[0].name);
     assert.isUndefined(recipe.particles[0].consumedSlotConnections['slotA1'].targetSlot);
     recipe.normalize();
@@ -672,14 +672,14 @@ ${particleStr1}
     `)).recipes[0];
     recipe.normalize();
 
-    assert.equal(2, recipe.slotConnections.length);
+    assert.lengthOf(recipe.slotConnections, 2);
     let slotConnA = recipe.slotConnections.find(s => s.name === 'slotA');
     assert.isUndefined(slotConnA.sourceConnection);
 
-    assert.equal(recipe.slots.length, 1);
+    assert.lengthOf(recipe.slots, 1);
     let slotB = recipe.slots[0];
     assert.equal('slotB', slotB.name);
-    assert.equal(slotB.consumeConnections.length, 1);
+    assert.lengthOf(slotB.consumeConnections, 1);
     assert.equal(slotB.sourceConnection, slotConnA);
   });
   it('relies on the loader to combine paths', async () => {
@@ -731,7 +731,7 @@ ${particleStr1}
                 .map(fileName => path.join(manifestFolderName, fileName)));
       }
     });
-    assert.isTrue(0 < verifyParticleManifests(shellParticleNames));
+    assert.isAbove(verifyParticleManifests(shellParticleNames), 0);
   });
   it('loads entities from json files', async () => {
     let manifestSource = `
@@ -1059,7 +1059,7 @@ Expected " ", "&", "//", "\\n", "\\r", [ ], or [A-Z] but "?" found.
   store ClairesWishlist of [Product] #wishlist in 'wishlist.json'
     description \`Claire's wishlist\``, {loader});
     let verify = (manifest) => {
-      assert.equal(manifest.stores.length, 1);
+      assert.lengthOf(manifest.stores, 1);
       assert.deepEqual(['wishlist'], manifest._storeTags.get(manifest.stores[0]));
     };
     verify(manifest);
@@ -1100,7 +1100,7 @@ resource SomeName
       shape ShapeOnlyProvideSlots
         provide action
     `);
-    assert.equal(9, manifest.shapes.length);
+    assert.lengthOf(manifest.shapes, 9);
     assert(manifest.findShapeByName('FullShape'));
   });
   it('can parse a manifest containing shapes', async () => {
@@ -1404,7 +1404,7 @@ resource SomeName
     assert(recipe.normalize());
 
     assert.equal(recipe.particles[0]._verbs[0], 'verb');
-    assert.equal(recipe.particles[0]._spec, undefined);
+    assert.isUndefined(recipe.particles[0]._spec);
     let slotConnection = recipe.particles[0]._consumedSlotConnections.consumeSlot;
     assert(slotConnection._providedSlots.provideSlot);
     assert.equal(slotConnection._providedSlots.provideSlot.sourceConnection, slotConnection);

--- a/runtime/test/particle-shape-loading-with-slots-test.js
+++ b/runtime/test/particle-shape-loading-with-slots-test.js
@@ -56,7 +56,7 @@ describe('particle-shape-loading-with-slots', function() {
   }
 
   function verifyFooItems(items, expectedValues) {
-    assert.equal(items.length, expectedValues.length);
+    assert.lengthOf(items, expectedValues.length);
     expectedValues.forEach(value => assert(items.find(item => item.value == value), `Cannot find item '${value}' in model`));
   }
 
@@ -73,9 +73,9 @@ describe('particle-shape-loading-with-slots', function() {
     await slotComposer.expectationsCompleted();
 
     // Verify slot template and models.
-    assert.equal(1, slotComposer._slots.length);
+    assert.lengthOf(slotComposer._slots, 1);
     let slot = slotComposer._slots[0];
-    assert.isTrue(slot._content.template.length > 0);
+    assert.isAbove(slot._content.template.length, 0);
     verifyFooItems(slot._content.model.items, ['foo1', 'foo2']);
 
     // Add one more element.
@@ -89,8 +89,8 @@ describe('particle-shape-loading-with-slots', function() {
     await slotComposer.expectationsCompleted();
 
     // Verify slot template and models.
-    assert.equal(1, slotComposer._slots.length);
-    assert.isTrue(slot._content.template.length > 0);
+    assert.lengthOf(slotComposer._slots, 1);
+    assert.isAbove(slot._content.template.length, 0);
     verifyFooItems(slot._content.model.items, ['foo1', 'foo2', 'foo3']);
   });
 
@@ -119,9 +119,9 @@ describe('particle-shape-loading-with-slots', function() {
     await slotComposer.expectationsCompleted();
 
     // Verify slot template and models.
-    assert.equal(1, slotComposer._slots.length);
+    assert.lengthOf(slotComposer._slots, 1);
     let slot = slotComposer._slots[0];
-    assert.isTrue(slot._content.template.length > 0);
+    assert.isAbove(slot._content.template.length, 0);
     verifyFooItems(slot._content.model.items, ['foo1', 'foo2']);
 
     // Add one more element.
@@ -136,8 +136,8 @@ describe('particle-shape-loading-with-slots', function() {
     await slotComposer.expectationsCompleted();
 
     // Verify slot template and models.
-    assert.equal(1, slotComposer._slots.length);
-    assert.isTrue(slot._content.template.length > 0);
+    assert.lengthOf(slotComposer._slots, 1);
+    assert.isAbove(slot._content.template.length, 0);
     verifyFooItems(slot._content.model.items, ['foo1', 'foo2', 'foo3']);
   });
 });

--- a/runtime/test/particles/common-test.js
+++ b/runtime/test/particles/common-test.js
@@ -70,7 +70,7 @@ describe('common particles test', function() {
     let helper = await TestHelper.loadManifestAndPlan(
         './runtime/test/particles/artifacts/copy-collection-test.recipes',
         {expectedNumPlans: 1, expectedSuggestions: ['Copy all things!']});
-    assert.equal(0, helper.arc._stores.length);
+    assert.isEmpty(helper.arc._stores);
 
     await helper.acceptSuggestion({particles: ['CopyCollection', 'CopyCollection']});
 

--- a/runtime/test/particles/products-test.js
+++ b/runtime/test/particles/products-test.js
@@ -18,7 +18,7 @@ describe('products test', function() {
 
   let verifyFilteredBook = async (handle) => {
     let list = await handle.toList();
-    assert.equal(1, list.length);
+    assert.lengthOf(list, 1);
     assert.equal('Harry Potter', list[0].rawData.name);
   };
 

--- a/runtime/test/planificator-test.js
+++ b/runtime/test/planificator-test.js
@@ -103,14 +103,14 @@ describe('Planificator', function() {
     assert.isFalse(planificator.isPlanning);
     assert.equal(0, Object.keys(planificator.getLastActivatedPlan()));
     let {plans} = planificator.getCurrentPlans();
-    assert.lengthOf(plans, 0);
+    assert.isEmpty(plans);
 
     planificator._arc.dispose();
     planificator.dispose();
-    assert.lengthOf(planificator._arc._instantiatePlanCallbacks, 0);
-    assert.lengthOf(planificator._stateChangedCallbacks, 0);
-    assert.lengthOf(planificator._plansChangedCallbacks, 0);
-    assert.lengthOf(planificator._suggestChangedCallbacks, 0);
+    assert.isEmpty(planificator._arc._instantiatePlanCallbacks);
+    assert.isEmpty(planificator._stateChangedCallbacks);
+    assert.isEmpty(planificator._plansChangedCallbacks);
+    assert.isEmpty(planificator._suggestChangedCallbacks);
   });
 
   it('makes replanning requests', async () => {
@@ -144,7 +144,7 @@ describe('Planificator', function() {
     await new Promise((resolve, reject) => setTimeout(async () => resolve(), 300));
 
     assert.isTrue(planificator.isPlanning);
-    assert.lengthOf(planificator.getCurrentPlans().plans, 0);
+    assert.isEmpty(planificator.getCurrentPlans().plans);
 
     planificator.plannerReturnFakeResults([1, 2, 3]);
     await planificator.allPlanningDone();
@@ -159,7 +159,7 @@ describe('Planificator', function() {
     assert.lengthOf(planificator.getCurrentPlans().plans, 3);
     planificator.suggestFilter = {showAll: true};
     assert.lengthOf(planificator.getCurrentSuggestions(), 3);
-    assert.lengthOf(Object.keys(planificator._past), 0);
+    assert.isEmpty(Object.keys(planificator._past));
   });
 
   it('groups data change triggered replanning', async () => {
@@ -214,7 +214,7 @@ describe('Planificator', function() {
     // Plan instantiated, data change events triggered replanning scheduling is canceled.
     await planificator._arc.instantiate(plan);
     assert.isTrue(planificator.isPlanning);
-    assert.lengthOf(planificator._dataChangesQueue._changes, 0);
+    assert.isEmpty(planificator._dataChangesQueue._changes);
     assert.isNull(planificator._dataChangesQueue._replanTimer);
   });
 
@@ -254,7 +254,7 @@ describe('Planificator', function() {
 
     // Planning is triggered and previous suggestions are no long available.
     assert.isTrue(planificator.isPlanning);
-    assert.lengthOf(planificator.getCurrentSuggestions(), 0);
+    assert.isEmpty(planificator.getCurrentSuggestions());
     assert.equal(plan, planificator.getLastActivatedPlan().plan);
     assert.lengthOf(planificator.getLastActivatedPlan().plans, 1);
   });
@@ -356,7 +356,7 @@ describe('Planificator', function() {
 
    // Search for plans that aren't available.
    planificator.setSearch('nosuchplan');
-   assert.lengthOf(planificator.getCurrentSuggestions(), 0);
+   assert.isEmpty(planificator.getCurrentSuggestions());
   });
   it('shows suggestions involving handle from active recipe', async () => {
     let plan0 = newPlan('0', {hasSlot: true, hasRootSlot: true, handlesIds: ['handle0']});
@@ -384,7 +384,7 @@ describe('Planificator', function() {
     planificator.registerPlansChangedCallback(() => { ++planChanged; });
 
     planificator._setCurrent({plans: [], generations: []});
-    assert.lengthOf(planificator._current.plans, 0);
+    assert.isEmpty(planificator._current.plans);
     assert.equal(0, planChanged);
 
     // Sets current plans
@@ -414,7 +414,7 @@ describe('Planificator', function() {
 
     // Override with empty plans.
     planificator._setCurrent({plans: [], generations: []});
-    assert.lengthOf(planificator._current.plans, 0);
+    assert.isEmpty(planificator._current.plans);
     assert.equal(4, planChanged);
   });
 });

--- a/runtime/test/planner-tests.js
+++ b/runtime/test/planner-tests.js
@@ -119,7 +119,7 @@ describe('Planner', function() {
         P1
           text <- handle
     `);
-    assert.equal(results.length, 1);
+    assert.lengthOf(results, 1);
   });
 
   it('can copy remote handles structurally', async () => {
@@ -132,7 +132,7 @@ describe('Planner', function() {
         P1
           text <- handle
     `);
-    assert.equal(results.length, 1);
+    assert.lengthOf(results, 1);
   });
 
   it('can resolve multiple consumed slots', async () => {
@@ -145,7 +145,7 @@ describe('Planner', function() {
         P1
           consume one as s0
     `);
-    assert.equal(results.length, 1);
+    assert.lengthOf(results, 1);
   });
 
   it('can speculate in parallel', async () => {
@@ -178,7 +178,7 @@ describe('Planner', function() {
         assertRecipeResolved(manifest.recipes[1]);
       }
     );
-    assert.equal(plans.length, 2);
+    assert.lengthOf(plans, 2);
     // Make sure the recipes were processed as separate async calls.
     assert.equal(plans[0].planIndex, 0);
     assert.equal(plans[1].planIndex, 1);
@@ -216,7 +216,7 @@ describe('AssignOrCopyRemoteHandles', function() {
       planner.init(arc);
       let plans = await planner.plan(1000);
 
-      assert.equal(plans.length, expectedResults, recipeManifest);
+      assert.lengthOf(plans, expectedResults, recipeManifest);
     };
 
     // map one
@@ -340,7 +340,7 @@ describe('Type variable resolution', function() {
   };
   let verifyResolvedPlan = async (manifestStr) => {
     let plans = await loadAndPlan(manifestStr);
-    assert.equal(1, plans.length);
+    assert.lengthOf(plans, 1);
 
     let recipe = plans[0];
     recipe.normalize();
@@ -349,7 +349,7 @@ describe('Type variable resolution', function() {
 
   let verifyUnresolvedPlan = async (manifestStr) => {
     let plans = await loadAndPlan(manifestStr);
-    assert.equal(0, plans.length);
+    assert.isEmpty(plans);
   };
   it('unresolved type variables', async () => {
     // [~a] doesn't resolve to Thing.
@@ -550,7 +550,7 @@ describe('Description', async () => {
         assertRecipeResolved(manifest.recipes[0]);
       }
     );
-    assert.equal(plans.length, 1);
+    assert.lengthOf(plans, 1);
     assert.equal('Make MYTHING.', await plans[0].description.getRecipeSuggestion());
     assert.equal(0, arc._storesById.size);
   });
@@ -578,7 +578,7 @@ describe('Automatic handle resolution', function() {
   };
   let verifyUnresolvedPlan = async (manifestStr, arcCreatedCallback) => {
     let plans = await loadAndPlan(manifestStr, arcCreatedCallback);
-    assert.lengthOf(plans, 0);
+    assert.isEmpty(plans);
   };
 
   it('introduces create handles for particle communication', async () => {

--- a/runtime/test/recipe-descriptions-test.js
+++ b/runtime/test/recipe-descriptions-test.js
@@ -69,7 +69,7 @@ store BoxesStore of [Box] 'allboxes' in AllBoxes` : ''}
 
   async function generateRecipeDescription(options) {
     let helper = await TestHelper.parseManifestAndPlan(createManifestString(options));
-    assert.equal(helper.plans.length, 1);
+    assert.lengthOf(helper.plans, 1);
 
     return helper.plans[0].description.getRecipeSuggestion(options.formatter);
   }
@@ -251,12 +251,12 @@ store BoxesStore of [Box] 'allboxes' in AllBoxes` : ''}
         Dummy
         description \`show \${ShowFoo.foo} with dummy\`
   `);
-    assert.equal(helper.plans.length, 2);
+    assert.lengthOf(helper.plans, 2);
     assert.equal('Show foo.', await helper.plans[0].description.getRecipeSuggestion());
 
     await helper.acceptSuggestion({particles: ['ShowFoo']});
     await helper.makePlans();
-    assert.equal(helper.plans.length, 1);
+    assert.lengthOf(helper.plans, 1);
 
     assert.equal('Show foo with dummy.', await helper.plans[0].description.getRecipeSuggestion());
   });

--- a/runtime/test/recipe-util-tests.js
+++ b/runtime/test/recipe-util-tests.js
@@ -31,11 +31,11 @@ describe('recipe-util', function() {
     let shape = RecipeUtil.makeShape(['A', 'B'], ['v'],
       {'A': {'a': 'v'}, 'B': {'b': 'v'}});
     let results = RecipeUtil.find(recipe, shape);
-    assert(results.length == 1);
-    assert(results[0].score == 0);
-    assert(results[0].match.A.name == 'A');
-    assert(results[0].match.B.name == 'B');
-    assert(results[0].match.v.localName == 'handle1');
+    assert.lengthOf(results, 1);
+    assert.equal(results[0].score, 0);
+    assert.equal(results[0].match.A.name, 'A');
+    assert.equal(results[0].match.B.name, 'B');
+    assert.equal(results[0].match.v.localName, 'handle1');
   });
 
   it('can produce multiple partial shape matches to a simple recipe', async () => {
@@ -63,17 +63,17 @@ describe('recipe-util', function() {
     let shape = RecipeUtil.makeShape(['A', 'B', 'C'], ['v'],
       {'A': {'a': 'v'}, 'B': {'b': 'v'}, 'C': {'c': 'v'}});
     let results = RecipeUtil.find(recipe, shape);
-    assert(results.length == 2);
-    assert(results[0].score == -1);
-    assert(results[0].match.A.name == 'A');
-    assert(results[0].match.B.name == 'B');
-    assert(results[0].match.C.name == 'C');
-    assert(results[0].match.v.localName == 'handle1');
-    assert(results[1].score == -1);
-    assert(results[1].match.A.name == 'A');
-    assert(results[1].match.B.name == 'B');
-    assert(results[1].match.C.name == 'C');
-    assert(results[1].match.v.localName == 'handle2');
+    assert.lengthOf(results, 2);
+    assert.equal(results[0].score, -1);
+    assert.equal(results[0].match.A.name, 'A');
+    assert.equal(results[0].match.B.name, 'B');
+    assert.equal(results[0].match.C.name, 'C');
+    assert.equal(results[0].match.v.localName, 'handle1');
+    assert.equal(results[1].score, -1);
+    assert.equal(results[1].match.A.name, 'A');
+    assert.equal(results[1].match.B.name, 'B');
+    assert.equal(results[1].match.C.name, 'C');
+    assert.equal(results[1].match.v.localName, 'handle2');
   });
 
   it('can match a free handle', async () => {
@@ -89,9 +89,9 @@ describe('recipe-util', function() {
     let shape = RecipeUtil.makeShape(['A', 'B'], ['v'],
       {'A': {'a': 'v'}, 'B': {'b': 'v'}});
     let results = RecipeUtil.find(recipe, shape);
-    assert(results.length == 1);
-    assert(results[0].score == -3);
-    assert(results[0].match.v.localName == 'h1');
+    assert.lengthOf(results, 1);
+    assert.equal(results[0].score, -3);
+    assert.equal(results[0].match.v.localName, 'h1');
   });
 
   it('can match dangling handle connections', async () => {
@@ -113,10 +113,10 @@ describe('recipe-util', function() {
     let shape = RecipeUtil.makeShape(['A', 'B'], ['h'],
       {'A': {'a': 'h'}, 'B': {'b': 'h'}});
     let results = RecipeUtil.find(recipe, shape);
-    assert(results.length == 1);
-    assert(results[0].score == -1);
-    assert(results[0].match.h.localName == 'h1');
-    assert(results[0].match['A:a'].name == 'a');
-    assert(results[0].match['B:b'].name == 'b');
+    assert.lengthOf(results, 1);
+    assert.equal(results[0].score, -1);
+    assert.equal(results[0].match.h.localName, 'h1');
+    assert.equal(results[0].match['A:a'].name, 'a');
+    assert.equal(results[0].match['B:b'].name, 'b');
   });
 });

--- a/runtime/test/schema-tests.js
+++ b/runtime/test/schema-tests.js
@@ -57,16 +57,16 @@ describe('schema', function() {
                                description: 'A sandwich with pickles and chicken',
                                image: 'http://www.example.com/pcs.jpg',
                                category: 'Delicious Food', shipDays: 5});
-    assert(product instanceof Product);
+    assert.instanceOf(product, Product);
     assert.equal(product.name, 'Pickled Chicken Sandwich');
     assert.equal(product.description, 'A sandwich with pickles and chicken');
     assert.equal(product.image, 'http://www.example.com/pcs.jpg');
     assert.equal(product.category, 'Delicious Food');
     assert.equal(product.shipDays, 5);
-    assert.equal(product.url, undefined);
-    assert.equal(product.identifier, undefined);
-    assert.equal(product.seller, undefined);
-    assert.equal(product.price, undefined);
+    assert.isUndefined(product.url);
+    assert.isUndefined(product.identifier);
+    assert.isUndefined(product.seller);
+    assert.isUndefined(product.price);
   });
 
   it('stores a copy of the constructor arguments', async function() {
@@ -78,7 +78,7 @@ describe('schema', function() {
     data.description = 'no seriously why';
     assert.equal(product.name, 'Seafood Ice Cream');
     assert.equal(product.category, 'Terrible Food');
-    assert.equal(product.description, undefined);
+    assert.isUndefined(product.description);
   });
 
   it('has accessors for all schema fields', async function() {
@@ -186,8 +186,8 @@ describe('schema', function() {
 
     unions.u1 = null;
     unions.u2 = undefined;
-    assert.equal(unions.u1, null);
-    assert.equal(unions.u2, undefined);
+    assert.isNull(unions.u1);
+    assert.isUndefined(unions.u2);
     assert.doesNotThrow(() => { new Unions({u1: null, u2: undefined}); });
 
     assert.throws(() => { new Unions({u1: false}); }, TypeError, 'Type mismatch setting field u1');
@@ -212,8 +212,8 @@ describe('schema', function() {
 
     tuples.t1 = null;
     tuples.t2 = undefined;
-    assert.equal(tuples.t1, null);
-    assert.equal(tuples.t2, undefined);
+    assert.isNull(tuples.t1);
+    assert.isUndefined(tuples.t2);
     assert.doesNotThrow(() => { new Tuples({t1: null, t2: undefined}); });
 
     assert.throws(() => { new Tuples({t1: 'foo'}); }, TypeError,

--- a/runtime/test/shape-test.js
+++ b/runtime/test/shape-test.js
@@ -19,14 +19,14 @@ import {Schema} from '../schema.js';
 describe('shape', function() {
   it('finds type variable references in handles', function() {
     let shape = new Shape('Test', [{type: Type.newVariable({name: 'a'})}], []);
-    assert.equal(shape._typeVars.length, 1);
+    assert.lengthOf(shape._typeVars, 1);
     assert.equal(shape._typeVars[0].field, 'type');
     assert.equal(shape._typeVars[0].object[shape._typeVars[0].field].variable.name, 'a');
   });
 
   it('finds type variable references in slots', function() {
     let shape = new Shape('Test', [], [{name: Type.newVariable({name: 'a'})}]);
-    assert.equal(shape._typeVars.length, 1);
+    assert.lengthOf(shape._typeVars, 1);
     assert.equal(shape._typeVars[0].field, 'name');
     assert.equal(shape._typeVars[0].object[shape._typeVars[0].field].variable.name, 'a');
   });
@@ -41,7 +41,7 @@ describe('shape', function() {
       [
         {name: Type.newVariable({name: 'a'})},
       ]);
-    assert.equal(shape._typeVars.length, 4);
+    assert.lengthOf(shape._typeVars, 4);
     let type = Type.newInterface(shape);
     let map = new Map();
     type = type.mergeTypeVariablesByName(map);

--- a/runtime/test/slot-composer-tests.js
+++ b/runtime/test/slot-composer-tests.js
@@ -54,7 +54,7 @@ async function initSlotComposer(recipeStr) {
   let planner = new Planner();
   planner.init(arc);
   await planner.strategizer.generate();
-  assert.equal(planner.strategizer.population.length, 1);
+  assert.lengthOf(planner.strategizer.population, 1);
   let plan = planner.strategizer.population[0].result;
   return {arc, slotComposer, plan, startRenderParticles};
 }

--- a/runtime/test/storage-proxy-test.js
+++ b/runtime/test/storage-proxy-test.js
@@ -76,7 +76,7 @@ class TestCollection {
 
   remove(id, version) {
     let entry = this._items.get(id);
-    assert(entry !== undefined,
+    assert.notStrictEqual(entry, undefined,
            `Test bug: attempt to remove non-existent id '${id}' from '${this.name}'`);
     this._items.delete(id);
     this._version = (version !== undefined) ? version : this._version + 1;

--- a/runtime/test/strategies/combined-strategy-tests.js
+++ b/runtime/test/strategies/combined-strategy-tests.js
@@ -39,10 +39,10 @@ describe('CombinedStrategy', function() {
     ]);
 
     let results = await strategy.generate(inputParams);
-    assert.equal(results.length, 1);
+    assert.lengthOf(results, 1);
     let recipe = results[0].result;
-    assert.equal(2, recipe.particles.length);
-    assert.equal(1, recipe.handles.length);
-    assert.equal(2, recipe.handles[0].connections.length);
+    assert.lengthOf(recipe.particles, 2);
+    assert.lengthOf(recipe.handles, 1);
+    assert.lengthOf(recipe.handles[0].connections, 2);
   });
 });

--- a/runtime/test/strategies/convert-constraints-to-connections-tests.js
+++ b/runtime/test/strategies/convert-constraints-to-connections-tests.js
@@ -27,7 +27,7 @@ describe('ConvertConstraintsToConnections', async () => {
     let inputParams = {generated: [{result: recipe, score: 1}]};
     let cctc = new ConvertConstraintsToConnections({pec: {}});
     let results = await cctc.generate(inputParams);
-    assert.equal(1, results.length);
+    assert.lengthOf(results, 1);
     let {result, score} = results[0];
     assert.deepEqual(result.toString(),
 `recipe
@@ -51,7 +51,7 @@ describe('ConvertConstraintsToConnections', async () => {
     let inputParams = {generated: [{result: recipe, score: 1}]};
     let cctc = new ConvertConstraintsToConnections({pec: {}});
     let results = await cctc.generate(inputParams);
-    assert.equal(0, results.length);
+    assert.isEmpty(results);
   });
 
   it('can resolve input only handle connection with a mapped handle', async () => {
@@ -68,7 +68,7 @@ describe('ConvertConstraintsToConnections', async () => {
     let inputParams = {generated: [{result: recipe, score: 1}]};
     let cctc = new ConvertConstraintsToConnections({pec: {}});
     let results = await cctc.generate(inputParams);
-    assert.equal(1, results.length);
+    assert.lengthOf(results, 1);
   });
 
   it('can create handle for input and output handle', async () => {
@@ -89,7 +89,7 @@ describe('ConvertConstraintsToConnections', async () => {
       let inputParams = {generated: [{result: recipe, score: 1}]};
       let cctc = new ConvertConstraintsToConnections({pec: {}});
       let results = await cctc.generate(inputParams);
-      assert.equal(1, results.length, `Failed to resolve ${constraint1} & ${constraint2}`);
+      assert.lengthOf(results, 1, `Failed to resolve ${constraint1} & ${constraint2}`);
     };
     // Test for all possible combination of connection constraints with 3 particles.
     let constraints = [['A.b = C.d', 'C.d = A.b'], ['A.b -> E.f', 'E.f <- A.b'], ['C.d -> E.f', 'E.f <- C.d']];
@@ -119,7 +119,7 @@ describe('ConvertConstraintsToConnections', async () => {
     let inputParams = {generated: [{result: recipe, score: 1}]};
     let cctc = new ConvertConstraintsToConnections({pec: {}});
     let results = await cctc.generate(inputParams);
-    assert.equal(1, results.length);
+    assert.lengthOf(results, 1);
     let {result, score} = results[0];
     assert.deepEqual(result.toString(),
 `recipe
@@ -144,7 +144,7 @@ describe('ConvertConstraintsToConnections', async () => {
     let inputParams = {generated: [{result: recipe, score: 1}]};
     let cctc = new ConvertConstraintsToConnections({pec: {}});
     let results = await cctc.generate(inputParams);
-    assert.equal(1, results.length);
+    assert.lengthOf(results, 1);
     let {result, score} = results[0];
     assert.deepEqual(result.toString(),
 `recipe
@@ -171,7 +171,7 @@ describe('ConvertConstraintsToConnections', async () => {
     let inputParams = {generated: [{result: recipe, score: 1}]};
     let cctc = new ConvertConstraintsToConnections({pec: {}});
     let results = await cctc.generate(inputParams);
-    assert.equal(1, results.length);
+    assert.lengthOf(results, 1);
     let {result, score} = results[0];
     assert.deepEqual(result.toString(),
 `recipe
@@ -199,7 +199,7 @@ describe('ConvertConstraintsToConnections', async () => {
     let inputParams = {generated: [{result: recipe, score: 1}]};
     let cctc = new ConvertConstraintsToConnections({pec: {}});
     let results = await cctc.generate(inputParams);
-    assert.equal(1, results.length);
+    assert.lengthOf(results, 1);
     let {result, score} = results[0];
     assert.deepEqual(result.toString(),
 `recipe
@@ -227,7 +227,7 @@ describe('ConvertConstraintsToConnections', async () => {
     let inputParams = {generated: [{result: recipe, score: 1}]};
     let cctc = new ConvertConstraintsToConnections({pec: {}});
     let results = await cctc.generate(inputParams);
-    assert.equal(1, results.length);
+    assert.lengthOf(results, 1);
     let {result, score} = results[0];
     assert.deepEqual(result.toString(),
 `recipe
@@ -256,7 +256,7 @@ describe('ConvertConstraintsToConnections', async () => {
     let inputParams = {generated: [{result: recipe, score: 1}]};
     let cctc = new ConvertConstraintsToConnections({pec: {}});
     let results = await cctc.generate(inputParams);
-    assert.equal(1, results.length);
+    assert.lengthOf(results, 1);
     let {result, score} = results[0];
     assert.deepEqual(result.toString(), `recipe
   use as handle0 // S {}
@@ -289,7 +289,7 @@ describe('ConvertConstraintsToConnections', async () => {
     let inputParams = {generated: [{result: recipes[0], score: 1}, {result: recipes[1], score: 1}]};
     let cctc = new ConvertConstraintsToConnections({pec: {slotComposer: {affordance: 'voice'}}});
     let results = await cctc.generate(inputParams);
-    assert.equal(results.length, 1);
+    assert.lengthOf(results, 1);
     assert.deepEqual(results[0].result.particles.map(p => p.name), ['A', 'C']);
   });
 
@@ -307,7 +307,7 @@ describe('ConvertConstraintsToConnections', async () => {
     let inputParams = {generated: [{result: recipes[0], score: 1}]};
     let cctc = new ConvertConstraintsToConnections({pec: {}});
     let results = await cctc.generate(inputParams);
-    assert.equal(results.length, 1);
+    assert.lengthOf(results, 1);
     assert.deepEqual(results[0].result.toString(), `recipe
   ? as handle0 // S {}
   A as particle0
@@ -332,7 +332,7 @@ describe('ConvertConstraintsToConnections', async () => {
     let inputParams = {generated: [{result: recipes[0], score: 1}]};
     let cctc = new ConvertConstraintsToConnections({pec: {}});
     let results = await cctc.generate(inputParams);
-    assert.equal(results.length, 1);
+    assert.lengthOf(results, 1);
     assert.deepEqual(results[0].result.toString(), `recipe
   ? as handle0 // S {}
   A as particle0
@@ -358,7 +358,7 @@ describe('ConvertConstraintsToConnections', async () => {
     let inputParams = {generated: [{result: recipes[0], score: 1}]};
     let cctc = new ConvertConstraintsToConnections({pec: {}});
     let results = await cctc.generate(inputParams);
-    assert.equal(results.length, 1);
+    assert.lengthOf(results, 1);
     assert.deepEqual(results[0].result.toString(), `recipe
   ? as handle0 // S {}
   A as particle0
@@ -385,7 +385,7 @@ describe('ConvertConstraintsToConnections', async () => {
     let inputParams = {generated: [{result: recipes[0], score: 1}]};
     let cctc = new ConvertConstraintsToConnections({pec: {}});
     let results = await cctc.generate(inputParams);
-    assert.equal(results.length, 1);
+    assert.lengthOf(results, 1);
     assert.deepEqual(results[0].result.toString(), `recipe
   ? as handle0 // S {}
   ? as handle1 // S {}
@@ -411,7 +411,7 @@ describe('ConvertConstraintsToConnections', async () => {
     let inputParams = {generated: [{result: recipes[0], score: 1}]};
     let cctc = new ConvertConstraintsToConnections({pec: {}});
     let results = await cctc.generate(inputParams);
-    assert.equal(results.length, 1);
+    assert.lengthOf(results, 1);
     assert.deepEqual(results[0].result.toString(), `recipe
   ? #hashtag as handle0 // S {}
   create #trashbag as handle1 // S {}
@@ -437,7 +437,7 @@ describe('ConvertConstraintsToConnections', async () => {
     let inputParams = {generated: [{result: recipes[0], score: 1}]};
     let cctc = new ConvertConstraintsToConnections({pec: {}});
     let results = await cctc.generate(inputParams);
-    assert.equal(results.length, 1);
+    assert.lengthOf(results, 1);
     assert.deepEqual(results[0].result.toString(), `recipe
   ? #hashtag as handle0 // S {}
   create #trashbag as handle1 // S {}
@@ -465,7 +465,7 @@ describe('ConvertConstraintsToConnections', async () => {
     let inputParams = {generated: [{result: recipes[0], score: 1}]};
     let cctc = new ConvertConstraintsToConnections({pec: {}});
     let results = await cctc.generate(inputParams);
-    assert.equal(results.length, 1);
+    assert.lengthOf(results, 1);
     assert.deepEqual(results[0].result.toString(), `recipe
   ? #hashtag as handle0 // S {}
   A as particle0
@@ -486,10 +486,10 @@ describe('ConvertConstraintsToConnections', async () => {
     let inputParams = {generated: [{result: recipes[0], score: 1}]};
     let cctc = new ConvertConstraintsToConnections({pec: {}});
     let results = await cctc.generate(inputParams);
-    assert.equal(results.length, 1);
+    assert.lengthOf(results, 1);
     let recipe = results[0].result;
     assert.deepEqual(recipe.particles.map(p => p.name), ['A', 'B']);
-    assert.equal(recipe.obligations.length, 1);
+    assert.lengthOf(recipe.obligations, 1);
     assert.equal(recipe.obligations[0].from.instance, recipe.particles[0]);
     assert.equal(recipe.obligations[0].to.instance, recipe.particles[1]);
   });
@@ -508,10 +508,10 @@ describe('ConvertConstraintsToConnections', async () => {
     let inputParams = {generated: [{result: recipes[0], score: 1}]};
     let cctc = new ConvertConstraintsToConnections({pec: {}});
     let results = await cctc.generate(inputParams);
-    assert.equal(results.length, 1);
+    assert.lengthOf(results, 1);
     let recipe = results[0].result;
     assert.deepEqual(recipe.particles.map(p => p.name), ['A', 'B']);
-    assert.equal(recipe.obligations.length, 1);
+    assert.lengthOf(recipe.obligations, 1);
     assert.equal(recipe.obligations[0].from.instance, recipe.particles[0]);
     assert.equal(recipe.obligations[0].to.instance, recipe.particles[1]);
   });
@@ -530,10 +530,10 @@ describe('ConvertConstraintsToConnections', async () => {
     let inputParams = {generated: [{result: recipes[0], score: 1}]};
     let cctc = new ConvertConstraintsToConnections({pec: {}});
     let results = await cctc.generate(inputParams);
-    assert.equal(results.length, 1);
+    assert.lengthOf(results, 1);
     let recipe = results[0].result;
     assert.deepEqual(recipe.particles.map(p => p.name), ['A', 'B']);
-    assert.equal(recipe.obligations.length, 1);
+    assert.lengthOf(recipe.obligations, 1);
     assert.equal(recipe.obligations[0].from.instance, recipe.particles[0]);
     assert.equal(recipe.obligations[0].to.instance, recipe.particles[1]);
   });

--- a/runtime/test/strategies/create-description-handle-tests.js
+++ b/runtime/test/strategies/create-description-handle-tests.js
@@ -28,9 +28,9 @@ describe('CreateDescriptionHandle', function() {
     let strategy = new CreateDescriptionHandle();
     let results = (await strategy.generate(inputParams));
 
-    assert.equal(results.length, 1);
+    assert.lengthOf(results, 1);
     let plan = results[0].result;
-    assert.equal(plan.handles.length, 1);
+    assert.lengthOf(plan.handles, 1);
     assert.equal('create', plan.handles[0].fate);
     assert.isTrue(plan.isResolved());
   });

--- a/runtime/test/strategies/create-handles-tests.js
+++ b/runtime/test/strategies/create-handles-tests.js
@@ -33,9 +33,9 @@ describe('CreateHandles', function() {
     let results = await new CreateHandles(arc).generate(inputParams);
 
     if (!expectedToAssignFate) {
-      assert.equal(results.length, 0);
+      assert.isEmpty(results);
     } else {
-      assert.equal(results.length, 1);
+      assert.lengthOf(results, 1);
       assert.isTrue(results[0].result.isResolved());
     }
   };

--- a/runtime/test/strategies/fallback-fate-tests.js
+++ b/runtime/test/strategies/fallback-fate-tests.js
@@ -39,14 +39,14 @@ describe('FallbackFate', function() {
 
     // no resolved search tokens.
     let results = await strategy.generate(inputParams);
-    assert.equal(results.length, 0);
+    assert.isEmpty(results);
 
     // Resolved a search token and rerun strategy.
     recipe.search.resolveToken('DoSomething');
     results = (await strategy.generate(inputParams));
-    assert.equal(results.length, 1);
+    assert.lengthOf(results, 1);
     let plan = results[0].result;
-    assert.equal(plan.handles.length, 2);
+    assert.lengthOf(plan.handles, 2);
     assert.equal('map', plan.handles[0].fate);
     assert.equal('copy', plan.handles[1].fate);
   });
@@ -74,6 +74,6 @@ describe('FallbackFate', function() {
 
     let strategy = new FallbackFate(arc);
     let results = await strategy.generate(inputParams);
-    assert.equal(results.length, 0);
+    assert.isEmpty(results);
   });
 });

--- a/runtime/test/strategies/group-handle-connections-tests.js
+++ b/runtime/test/strategies/group-handle-connections-tests.js
@@ -48,9 +48,9 @@ describe('GroupHandleConnections', function() {
     let ghc = new GroupHandleConnections();
 
     let results = await ghc.generate(inputParams);
-    assert.equal(results.length, 1);
+    assert.lengthOf(results, 1);
     let recipe = results[0].result;
-    assert.equal(4, recipe.handles.length);
+    assert.lengthOf(recipe.handles, 4);
     // Verify all connections are bound to handles.
     assert.isUndefined(recipe.handleConnections.find(hc => !hc.handle));
     // Verify all handles have non-empty connections list.
@@ -72,6 +72,6 @@ describe('GroupHandleConnections', function() {
     let ghc = new GroupHandleConnections();
 
     let results = await ghc.generate(inputParams);
-    assert.lengthOf(results, 0);
+    assert.isEmpty(results);
   });
 });

--- a/runtime/test/strategies/init-population-tests.js
+++ b/runtime/test/strategies/init-population-tests.js
@@ -34,7 +34,7 @@ describe('InitPopulation', async () => {
 
     let inputParams = {generated: [], generation: 0};
     let results = await ip.generate(inputParams);
-    assert.equal(results.length, 1);
+    assert.lengthOf(results, 1);
     assert.equal(results[0].score, 0);
   });
 });

--- a/runtime/test/strategies/init-search-tests.js
+++ b/runtime/test/strategies/init-search-tests.js
@@ -20,7 +20,7 @@ describe('InitSearch', async () => {
     let initSearch = new InitSearch(arc);
     let inputParams = {generated: [], generation: 0};
     let results = await initSearch.generate(inputParams);
-    assert.equal(results.length, 1);
+    assert.lengthOf(results, 1);
     assert.equal(results[0].score, 0);
   });
 });

--- a/runtime/test/strategies/map-slots-tests.js
+++ b/runtime/test/strategies/map-slots-tests.js
@@ -35,7 +35,7 @@ describe('MapSlots', function() {
 
     if (expectedSlots >= 0) {
       assert.isTrue(recipe.isResolved());
-      assert.equal(recipe.slots.length, expectedSlots);
+      assert.lengthOf(recipe.slots, expectedSlots);
     } else {
       assert.isFalse(recipe.normalize());
     }
@@ -48,7 +48,7 @@ describe('MapSlots', function() {
     }
 
     results = await StrategyTestHelper.theResults(arc, ResolveRecipe, recipe);
-    assert.equal(results.length, 1);
+    assert.lengthOf(results, 1);
     return results[0];
   };
 
@@ -131,7 +131,7 @@ describe('MapSlots', function() {
 
     let strategy = new MapSlots(arc);
     let results = await strategy.generate(inputParams);
-    assert.equal(results.length, 2);
+    assert.lengthOf(results, 2);
 
     results = await new ResolveRecipe(arc).generate({
       generated: results.map(r => ({
@@ -140,7 +140,7 @@ describe('MapSlots', function() {
       }))
     });
 
-    assert.equal(results.length, 2);
+    assert.lengthOf(results, 2);
     for (let result of results) {
       let plan = result.result;
       plan.normalize();

--- a/runtime/test/strategies/match-particle-by-verb-tests.js
+++ b/runtime/test/strategies/match-particle-by-verb-tests.js
@@ -55,7 +55,7 @@ describe('MatchParticleByVerb', function() {
     let inputParams = {generated: [{result: manifest.recipes[0], score: 1}]};
     let mpv = new MatchParticleByVerb(arc);
     let results = await mpv.generate(inputParams);
-    assert.equal(results.length, 3);
+    assert.lengthOf(results, 3);
     // Note: handle connections are not resolved yet.
     assert.deepEqual(['GalaxyJumper', 'SimpleJumper', 'StarJumper'], results.map(r => r.result.particles[0].name).sort());
   });
@@ -73,7 +73,7 @@ describe('MatchParticleByVerb', function() {
     planner.init(arc);
     let plans = await planner.plan(1000);
 
-    assert.equal(2, plans.length);
+    assert.lengthOf(plans, 2);
     assert.deepEqual([['SimpleJumper'], ['StarJumper']],
                      plans.map(plan => plan.particles.map(particle => particle.name)));
   });

--- a/runtime/test/strategies/match-recipe-by-verb-tests.js
+++ b/runtime/test/strategies/match-recipe-by-verb-tests.js
@@ -41,8 +41,8 @@ describe('MatchRecipeByVerb', function() {
     let inputParams = {generated: [{result: manifest.recipes[0], score: 1}]};
     let mrv = new MatchRecipeByVerb(arc);
     let results = await mrv.generate(inputParams);
-    assert.equal(results.length, 1);
-    assert.equal(results[0].result.particles.length, 0);
+    assert.lengthOf(results, 1);
+    assert.isEmpty(results[0].result.particles);
     assert.deepEqual(results[0].result.toString(), 'recipe\n  JumpingBoots.e <- NuclearReactor.e\n  JumpingBoots.f <- FootFactory.f');
   });
   it('plays nicely with constraints', async () => {
@@ -65,10 +65,10 @@ describe('MatchRecipeByVerb', function() {
     let inputParams = {generated: [{result: manifest.recipes[0], score: 1}]};
     let mrv = new MatchRecipeByVerb(arc);
     let results = await mrv.generate(inputParams);
-    assert.equal(results.length, 1);
+    assert.lengthOf(results, 1);
     let cctc = new ConvertConstraintsToConnections(arc);
     results = await cctc.generate({generated: results});
-    assert.equal(results.length, 1);
+    assert.lengthOf(results, 1);
     assert.deepEqual(results[0].result.toString(),
 `recipe
   create as handle0 // S {}
@@ -128,32 +128,32 @@ describe('MatchRecipeByVerb', function() {
     let inputParams = {generated: [{result: manifest.recipes[4], score: 1}]};
     let mrv = new MatchRecipeByVerb(arc);
     let results = await mrv.generate(inputParams);
-    assert.equal(results.length, 4);
+    assert.lengthOf(results, 4);
 
     inputParams = {generated: [{result: manifest.recipes[5], score: 1}]};
     results = await mrv.generate(inputParams);
-    assert.equal(results.length, 2);
-    assert.equal(results[0].result.particles.length, 1);
+    assert.lengthOf(results, 2);
+    assert.lengthOf(results[0].result.particles, 1);
     assert.equal(results[0].result.particles[0].name, 'P');
-    assert.equal(results[1].result.particles.length, 2);
+    assert.lengthOf(results[1].result.particles, 2);
     
     inputParams = {generated: [{result: manifest.recipes[6], score: 1}]};
     results = await mrv.generate(inputParams);
-    assert.equal(results.length, 2);
-    assert.equal(results[1].result.particles.length, 1);
+    assert.lengthOf(results, 2);
+    assert.lengthOf(results[1].result.particles, 1);
     assert.equal(results[1].result.particles[0].name, 'Q');
-    assert.equal(results[0].result.particles.length, 2);
+    assert.lengthOf(results[0].result.particles, 2);
     
     inputParams = {generated: [{result: manifest.recipes[7], score: 1}]};
     results = await mrv.generate(inputParams);
-    assert.equal(results.length, 2);
-    assert.equal(results[1].result.particles.length, 1);
+    assert.lengthOf(results, 2);
+    assert.lengthOf(results[1].result.particles, 1);
     assert.equal(results[1].result.particles[0].name, 'Q');
-    assert.equal(results[0].result.particles.length, 2);
+    assert.lengthOf(results[0].result.particles, 2);
 
     inputParams = {generated: [{result: manifest.recipes[8], score: 1}]};
     results = await mrv.generate(inputParams);
-    assert.equal(results.length, 3);
+    assert.lengthOf(results, 3);
   });
   it('listens to slot constraints', async () => {
     let manifest = await Manifest.parse(`
@@ -192,21 +192,21 @@ describe('MatchRecipeByVerb', function() {
     let inputParams = {generated: [{result: manifest.recipes[3], score: 1}]};
     let mrv = new MatchRecipeByVerb(arc);
     let results = await mrv.generate(inputParams);
-    assert.equal(results.length, 3);
+    assert.lengthOf(results, 3);
 
     inputParams = {generated: [{result: manifest.recipes[4], score: 1}]};
     results = await mrv.generate(inputParams);
-    assert.equal(results.length, 2);
-    assert.equal(results[0].result.particles.length, 1);
+    assert.lengthOf(results, 2);
+    assert.lengthOf(results[0].result.particles, 1);
     assert.equal(results[0].result.particles[0].name, 'Q');
-    assert.equal(results[1].result.particles.length, 2);
+    assert.lengthOf(results[1].result.particles, 2);
 
     inputParams = {generated: [{result: manifest.recipes[5], score: 1}]};
     results = await mrv.generate(inputParams);
-    assert.equal(results.length, 2);
-    assert.equal(results[0].result.particles.length, 1);
+    assert.lengthOf(results, 2);
+    assert.lengthOf(results[0].result.particles, 1);
     assert.equal(results[0].result.particles[0].name, 'P');
-    assert.equal(results[1].result.particles.length, 2);
+    assert.lengthOf(results[1].result.particles, 2);
   });
   it('carries handle assignments across verb substitution', async () => {
     let manifest = await Manifest.parse(`
@@ -232,7 +232,7 @@ describe('MatchRecipeByVerb', function() {
     let inputParams = {generated: [{result: manifest.recipes[1], score: 1}]};
     let mrv = new MatchRecipeByVerb(arc);
     let results = await mrv.generate(inputParams);
-    assert.equal(results.length, 1);
+    assert.lengthOf(results, 1);
     let recipe = results[0].result;
     assert.equal(recipe.particles[0].connections.a.handle, recipe.particles[1].connections.b.handle);
     assert.equal(recipe.particles[0].connections.a.handle.connections[0].particle, recipe.particles[0]);
@@ -262,7 +262,7 @@ describe('MatchRecipeByVerb', function() {
     let inputParams = {generated: [{result: manifest.recipes[1], score: 1}]};
     let mrv = new MatchRecipeByVerb(arc);
     let results = await mrv.generate(inputParams);
-    assert.equal(results.length, 1);
+    assert.lengthOf(results, 1);
     let recipe = results[0].result;
     assert.equal(recipe.particles[0].connections.a.handle, recipe.particles[1].connections.b.handle);
     assert.equal(recipe.particles[0].connections.a.handle.connections[0].particle, recipe.particles[0]);
@@ -299,7 +299,7 @@ describe('MatchRecipeByVerb', function() {
     let inputParams = {generated: [{result: manifest.recipes[1], score: 1}]};
     let mrv = new MatchRecipeByVerb(arc);
     let results = await mrv.generate(inputParams);
-    assert.equal(results.length, 1);
+    assert.lengthOf(results, 1);
     let recipe = results[0].result;
     assert.equal(recipe.particles[1].connections.a.handle, recipe.particles[2].connections.b.handle);
     assert.equal(recipe.particles[1].connections.a.handle.connections[0].particle, recipe.particles[1]);
@@ -337,7 +337,7 @@ describe('MatchRecipeByVerb', function() {
     let inputParams = {generated: [{result: manifest.recipes[1], score: 1}]};
     let mrv = new MatchRecipeByVerb(arc);
     let results = await mrv.generate(inputParams);
-    assert.equal(results.length, 1);
+    assert.lengthOf(results, 1);
     let recipe = results[0].result;
     assert.equal(recipe.particles[0].consumedSlotConnections.foo.providedSlots.bar, recipe.particles[1].consumedSlotConnections.bar.targetSlot);
     assert.equal(recipe.slots[0].consumeConnections[0], recipe.particles[1].consumedSlotConnections.bar);
@@ -392,7 +392,7 @@ describe('MatchRecipeByVerb', function() {
   let inputParams = {generated: [{result: manifest.recipes[1], score: 1}]};
   let mrv = new MatchRecipeByVerb(arc);
   let results = await mrv.generate(inputParams);
-  assert.equal(results.length, 1);
+  assert.lengthOf(results, 1);
   let recipe = results[0].result;
   assert.equal(recipe.particles[0].consumedSlotConnections.foo.providedSlots.bar, recipe.particles[1].consumedSlotConnections.bar.targetSlot);
   assert.equal(recipe.slots[0].consumeConnections[0], recipe.particles[1].consumedSlotConnections.bar);

--- a/runtime/test/strategies/resolve-recipe-test.js
+++ b/runtime/test/strategies/resolve-recipe-test.js
@@ -165,10 +165,10 @@ describe('resolve recipe', function() {
 
     let strategy = new ResolveRecipe(arc);
     let results = await strategy.generate({generated: [{result: manifest.recipes[0], score: 1}]});
-    assert.equal(results.length, 1);
+    assert.lengthOf(results, 1);
 
     let plan = results[0].result;
-    assert.equal(plan.slots.length, 2);
+    assert.lengthOf(plan.slots, 2);
     plan.normalize();
     assert.isTrue(plan.isResolved());
   });

--- a/runtime/test/strategies/search-tokens-to-handles-test.js
+++ b/runtime/test/strategies/search-tokens-to-handles-test.js
@@ -46,7 +46,7 @@ describe('SearchTokensToHandles', function() {
     let strategy = new SearchTokensToHandles(arc);
     let results = await strategy.generate({generated: [{result: recipe, score: 1}], terminal: []});
 
-    assert.equal(results.length, 1);
+    assert.lengthOf(results, 1);
     let result = results[0].result;
     assert.isTrue(result.isResolved());
     assert.equal('use', result.handles[0].fate);
@@ -84,10 +84,10 @@ recipe
     let strategy = new SearchTokensToHandles(arc);
     let results = await strategy.generate({generated: [{result: recipe, score: 1}], terminal: []});
 
-    assert.equal(results.length, 1);
+    assert.lengthOf(results, 1);
     let result = results[0].result;
     assert.isTrue(result.isResolved());
-    assert.equal(2, result.handles.length);
+    assert.lengthOf(result.handles, 2);
     assert.equal('map', result.handles[0].fate);
     assert.equal('copy', result.handles[1].fate);
   });

--- a/runtime/test/strategies/search-tokens-to-particles-tests.js
+++ b/runtime/test/strategies/search-tokens-to-particles-tests.js
@@ -32,7 +32,7 @@ describe('SearchTokensToParticles', function() {
     let inputParams = {generated: [], terminal: [{result: recipe, score: 1}]};
     let stp = new SearchTokensToParticles(arc);
     let results = await stp.generate(inputParams);
-    assert.equal(results.length, 2);
+    assert.lengthOf(results, 2);
     assert.deepEqual([['GalaxyFlyer', 'Rester', 'SimpleJumper'],
                       ['GalaxyFlyer', 'Rester', 'StarJumper']], results.map(r => r.result.particles.map(p => p.name).sort()));
     assert.deepEqual(['fly', 'jump', 'rester'], results[0].result.search.resolvedTokens);
@@ -62,7 +62,7 @@ describe('SearchTokensToParticles', function() {
     let inputParams = {generated: [], terminal: [{result: recipes[0], score: 1}, {result: recipes[1], score: 1}]};
     let stp = new SearchTokensToParticles(arc);
     let results = await stp.generate(inputParams);
-    assert.equal(results.length, 2);
+    assert.lengthOf(results, 2);
     let result = results[0].result;
     assert.deepEqual(['FlightPreparation', 'GalaxyFlyer', 'SimpleJumper'], result.particles.map(p => p.name).sort());
     assert.deepEqual(['fly', 'jump'], result.search.resolvedTokens);

--- a/runtime/test/strategies/strategy-sequence-test.js
+++ b/runtime/test/strategies/strategy-sequence-test.js
@@ -213,7 +213,7 @@ describe('A Strategy Sequence', function() {
 
     recipe = await onlyResult(arc, MatchRecipeByVerb, recipe);
     recipes = await theResults(arc, ConvertConstraintsToConnections, recipe);
-    assert.equal(recipes.length, 2);
+    assert.lengthOf(recipes, 2);
     recipe = await onlyResult(arc, ResolveRecipe, recipes[1]);
   });
 
@@ -256,7 +256,7 @@ describe('A Strategy Sequence', function() {
 
     recipe = await onlyResult(arc, CreateHandleGroup, recipe);
     recipe = await onlyResult(arc, ResolveRecipe, recipe);
-    assert.equal(recipe.obligations.length, 0);
+    assert.isEmpty(recipe.obligations);
   });
 
   it('connects particles together with multiple connections', async () => {

--- a/runtime/test/strategies/strategy-test-helper.js
+++ b/runtime/test/strategies/strategy-test-helper.js
@@ -27,13 +27,13 @@ export class StrategyTestHelper {
     return new clazz(arc).generate({generated: [{result: recipe, score: 1}], terminal: []});
   }
   static onlyResult(arc, clazz, recipe) {
-    return StrategyTestHelper.run(arc, clazz, recipe).then(result => { assert.equal(result.length, 1); return result[0].result;});
+    return StrategyTestHelper.run(arc, clazz, recipe).then(result => { assert.lengthOf(result, 1); return result[0].result;});
   }
   static theResults(arc, clazz, recipe) {
     return StrategyTestHelper.run(arc, clazz, recipe).then(results => results.map(result => result.result)); // chicken chicken
   }
 
   static noResult(arc, clazz, recipe) {
-    return StrategyTestHelper.run(arc, clazz, recipe).then(result => { assert.equal(result.length, 0); });
+    return StrategyTestHelper.run(arc, clazz, recipe).then(result => { assert.isEmpty(result); });
   }
 }

--- a/runtime/test/suggestion-composer-tests.js
+++ b/runtime/test/suggestion-composer-tests.js
@@ -33,12 +33,12 @@ class TestSuggestionComposer extends SuggestionComposer {
 describe('suggestion composer', function() {
   it('sets suggestions', async () => {
     let suggestionComposer = new TestSuggestionComposer();
-    assert.lengthOf(suggestionComposer.suggestions, 0);
+    assert.isEmpty(suggestionComposer.suggestions);
 
     // Sets suggestions
     await suggestionComposer.setSuggestions([1, 2, 3]);
     assert.equal(1, suggestionComposer.updatesCount);
-    assert.lengthOf(suggestionComposer.suggestions, 0);
+    assert.isEmpty(suggestionComposer.suggestions);
     await suggestionComposer.updateDone();
     assert.equal(1, suggestionComposer.updatesCount);
     assert.lengthOf(suggestionComposer.suggestions, 3);
@@ -57,6 +57,6 @@ describe('suggestion composer', function() {
     await suggestionComposer.updateDone();
     await suggestionComposer.updateDone();
     assert.equal(4, suggestionComposer.updatesCount);
-    assert.lengthOf(suggestionComposer.suggestions, 0);
+    assert.isEmpty(suggestionComposer.suggestions);
   });
 });

--- a/runtime/test/type-checker-tests.js
+++ b/runtime/test/type-checker-tests.js
@@ -78,7 +78,7 @@ describe('TypeChecker', () => {
     a.primitiveType().variable.resolution = resolution;
     let c = Type.newEntity(new Schema({names: ['Product', 'Thing'], fields: {}})).collectionOf();
     let result = TypeChecker.processTypeList(undefined, [{type: a, direction: 'out'}, {type: c, direction: 'in'}]);
-    assert.equal(result, null);
+    assert.isNull(result);
   });
 
   it('doesn\'t resolve a pair of out [~a (is Thing)], inout [Product]', async () => {
@@ -87,7 +87,7 @@ describe('TypeChecker', () => {
     a.primitiveType().variable.resolution = resolution;
     let c = Type.newEntity(new Schema({names: ['Product', 'Thing'], fields: {}})).collectionOf();
     let result = TypeChecker.processTypeList(undefined, [{type: a, direction: 'out'}, {type: c, direction: 'inout'}]);
-    assert.equal(result, null);
+    assert.isNull(result);
   });
 
   it('resolves inout [~a] (is Thing), in [~b] (is Thing), in [Product], in [~c], in [~d] (is Product)', async () => {
@@ -102,7 +102,7 @@ describe('TypeChecker', () => {
     resolution = Type.newEntity(new Schema({names: ['Product', 'Thing'], fields: {}}));
     e.primitiveType().variable.resolution = resolution;
     let result = TypeChecker.processTypeList(undefined, [{type: a, direction: 'inout'}, {type: b, direction: 'in'}, {type: c, direction: 'in'}, {type: d, direction: 'in'}, {type: e, direction: 'in'}]);
-    assert.equal(result, null);
+    assert.isNull(result);
   });
 
   it('doesn\'t depend on ordering in assigning a resolution to a type variable', async () => {

--- a/runtime/test/type-integration-test.js
+++ b/runtime/test/type-integration-test.js
@@ -30,9 +30,9 @@ describe('type integration', () => {
     let recipe = manifest.recipes[0];
     assert(recipe.normalize());
     assert(recipe.isResolved());
-    assert(recipe.handles.length == 1);
-    assert(recipe.handles[0].type.primitiveType().canReadSubset.entitySchema.name == 'Lego');
-    assert(recipe.handles[0].type.primitiveType().canWriteSuperset.entitySchema.name == 'Product');
+    assert.equal(recipe.handles.length, 1);
+    assert.equal(recipe.handles[0].type.primitiveType().canReadSubset.entitySchema.name, 'Lego');
+    assert.equal(recipe.handles[0].type.primitiveType().canWriteSuperset.entitySchema.name, 'Product');
   });
 
   it('a subtype matches to a supertype that wants to be read when a handle exists', async () => {
@@ -42,8 +42,8 @@ describe('type integration', () => {
     recipe.handles[0].mapToStorage({id: 'test1', type: manifest.findSchemaByName('Product').entityClass().type.collectionOf()});
     assert(recipe.normalize());
     assert(recipe.isResolved());
-    assert(recipe.handles.length == 1);
-    assert(recipe.handles[0].type.primitiveType().entitySchema.name == 'Product');
+    assert.lengthOf(recipe.handles, 1);
+    assert.equal(recipe.handles[0].type.primitiveType().entitySchema.name, 'Product');
   });
 
   it('a subtype matches to a supertype that wants to be read when a handle exists', async () => {
@@ -53,7 +53,7 @@ describe('type integration', () => {
     recipe.handles[0].mapToStorage({id: 'test1', type: manifest.findSchemaByName('Lego').entityClass().type.collectionOf()});
     assert(recipe.normalize());
     assert(recipe.isResolved());
-    assert(recipe.handles.length == 1);
-    assert(recipe.handles[0].type.primitiveType().entitySchema.name == 'Lego');
+    assert.lengthOf(recipe.handles, 1);
+    assert.equal(recipe.handles[0].type.primitiveType().entitySchema.name, 'Lego');
   });
 });

--- a/runtime/testing/mock-slot-composer.js
+++ b/runtime/testing/mock-slot-composer.js
@@ -196,7 +196,7 @@ export class MockSlotComposer extends SlotComposer {
 
   async renderSlot(particle, slotName, content) {
     // console.log(`    renderSlot ${particle.name} ${((names) => names.length > 0 ? `(${names.join(',')}) ` : '')(this._getHostedParticleNames(particle))}: ${slotName} - ${Object.keys(content).join(', ')}`);
-    assert(this.expectQueue.length > 0,
+    assert.isAbove(this.expectQueue.length, 0,
       `Got a renderSlot from ${particle.name}:${slotName} (content types: ${Object.keys(content).join(', ')}), but not expecting anything further.`);
 
     let found = this._verifyRenderContent(particle, slotName, content);

--- a/runtime/testing/test-helper.js
+++ b/runtime/testing/test-helper.js
@@ -116,7 +116,7 @@ export class TestHelper {
     this.plans = await planner.suggest();
     if (options) {
       if (options.expectedNumPlans) {
-        assert.equal(options.expectedNumPlans, this.plans.length);
+        assert.lengthOf(this.plans, options.expectedNumPlans);
       }
       if (options.expectedSuggestions) {
         let suggestions = await Promise.all(this.plans.map(async p => await p.description.getRecipeSuggestion()));
@@ -159,14 +159,14 @@ export class TestHelper {
             });
           });
         }
-        assert.equal(1, plans.length);
+        assert.lengthOf(plans, 1);
         plan = plans[0];
       } else if (options.descriptionText) {
         plan = this.plans.find(p => p.descriptionText == options.descriptionText);
       }
     }
     if (!plan) {
-      assert.equal(1, this.plans.length);
+      assert.lengthOf(this.plans, 1);
       plan = this.plans[0];
     }
     this.log(`Accepting suggestion: '${((str) => str.length > 50 ? str.substring(0, Math.min(str.length, 50)).concat('...') : str)(plan.descriptionText)}'`);
@@ -183,7 +183,7 @@ export class TestHelper {
    * Getter for a single available suggestion plan (fails, if there is more than one).
    */
   get plan() {
-    assert.equal(1, this.plans.length);
+    assert.lengthOf(this.plans, 1);
     return this.plans[0].plan;
   }
 
@@ -232,12 +232,12 @@ export class TestHelper {
   async verifySetSize(particleName, connectionName, expectedSetSize) {
     this.log(`Verifying ${particleName}:${connectionName} size is: ${expectedSetSize}`);
     return this.verifyData(particleName, connectionName, async (handle) => {
-      assert.equal(expectedSetSize, (await handle.toList()).length, `${particleName}:${connectionName} expected size ${expectedSetSize}`);
+      assert.lengthOf((await handle.toList()), expectedSetSize, `${particleName}:${connectionName} expected size ${expectedSetSize}`);
     });
   }
 
   verifySlots(numSlots, verifyHandler) {
-    assert.equal(numSlots, this.slotComposer._slots.length);
+    assert.lengthOf(this.slotComposer._slots, numSlots);
     this.slotComposer._slots.forEach(s => verifyHandler(s.consumeConn.particle.name, s.consumeConn.name, s._content));
   }
 

--- a/runtime/testing/test-util.js
+++ b/runtime/testing/test-util.js
@@ -147,7 +147,7 @@ export function assertSingletonEmpty(store) {
   return new Promise((resolve, reject) => {
     let variable = new handle.handleFor(store);
     variable.get().then(result => {
-      assert.equal(result, undefined);
+      assert.isUndefined(result);
       resolve();
     });
   });

--- a/shell/artifacts/Words/test/boardsolver-test.js
+++ b/shell/artifacts/Words/test/boardsolver-test.js
@@ -14,7 +14,7 @@ describe('BoardSolver', function() {
         letters += 'Z' + Tile.StyleToNumber[Tile.Style.NORMAL];
       const board = new TileBoard({letters, shuffleAvailableCount: 0});
       const solver = new BoardSolver(dictionary, board);
-      assert.equal(solver.getValidWords().length, 0);
+      assert.isEmpty(solver.getValidWords());
     });
 
     // TODO(wkorman): Move this to a board test utility class.
@@ -42,7 +42,7 @@ describe('BoardSolver', function() {
       });
       const solver = new BoardSolver(dictionary, board);
       const validWords = solver.getValidWords();
-      assert.equal(validWords.length, 1);
+      assert.lengthOf(validWords, 1);
       assert.equal(validWords[0].text, 'CAT');
     });
   });

--- a/shell/artifacts/Words/test/tileboard-test.js
+++ b/shell/artifacts/Words/test/tileboard-test.js
@@ -251,8 +251,8 @@ describe('TileBoard', function() {
   describe('#pickCharWithFrequencies()', function() {
     it('should return a single caps alpha character', function() {
       let result = TileBoard.pickCharWithFrequencies();
-      assert.equal(result.length, 1);
-      assert.isTrue(/[A-Z]/.test(result));
+      assert.lengthOf(result, 1);
+      assert.match(result, /[A-Z]/);
     });
   });
 

--- a/shell/test/selenium-utils-test.js
+++ b/shell/test/selenium-utils-test.js
@@ -19,7 +19,7 @@ describe('SeleniumUtils', function() {
         <div outer>
         </div>`;
       const outer = target.querySelectorAll('div[outer]');
-      assert.equal(outer.length, 1);
+      assert.lengthOf(outer, 1);
       const shadow = outer[0].attachShadow({mode: 'open'});
       shadow.innerHTML = `
         <div inner>
@@ -39,7 +39,7 @@ describe('SeleniumUtils', function() {
         <div outer>
         </div>`;
       const outer = target.querySelectorAll('div[outer]');
-      assert.equal(outer.length, 1);
+      assert.lengthOf(outer, 1);
       const firstShadow = outer[0].attachShadow({mode: 'open'});
       firstShadow.innerHTML = `
         <div firstInner>
@@ -76,7 +76,7 @@ describe('SeleniumUtils', function() {
           </div>
         </div>`;
       const outer = target.querySelectorAll('div[outer]');
-      assert.equal(outer.length, 1);
+      assert.lengthOf(outer, 1);
       const firstShadow = outer[0].attachShadow({mode: 'open'});
       firstShadow.innerHTML = `
         <div firstInner>
@@ -113,7 +113,7 @@ describe('SeleniumUtils', function() {
         <div outer>
         </div>`;
       const outer = target.querySelectorAll('div[outer]');
-      assert.equal(outer.length, 1);
+      assert.lengthOf(outer, 1);
       const shadow = outer[0].attachShadow({mode: 'open'});
       shadow.innerHTML = `
         <div inner>

--- a/tracelib/test/trace-tests.js
+++ b/tracelib/test/trace-tests.js
@@ -271,7 +271,7 @@ describe('Tracing', function() {
     const events = [];
     Tracing.stream(event => events.push(event));
 
-    assert.lengthOf(events, 0);
+    assert.isEmpty(events);
 
     Tracing.start({cat: 'Stuff', name: 'Thingy::thing'}).end();
     await Promise.resolve(); // Streaming callback is scheduled on job queue.
@@ -293,7 +293,7 @@ describe('Tracing', function() {
     const events = [];
     Tracing.stream(event => events.push(event), event => event.name === 'I\'m Special');
 
-    assert.lengthOf(events, 0);
+    assert.isEmpty(events);
 
     Tracing.start({cat: 'Stuff', name: 'Thingy::thing'}).end();
     await Promise.resolve(); // Streaming callback is scheduled on job queue.


### PR DESCRIPTION
- Length checks now use assert.lengthOf
- Length checks for 0 now use assert.isEmpty
- assert() with == now use assert.equal
- assert() with includes switched to assert.include
- checks for instanceof switched to assert.instanceOf
- checks for undefined switched to assert.isUndefined
- checks for > value switched to assert.isAbove