### PR TITLE
Remove improper '#', implement node reuse for subtemplate stamping

### DIFF
--- a/shell/app-shell/elements/arc-handle.js
+++ b/shell/app-shell/elements/arc-handle.js
@@ -58,7 +58,7 @@ class ArcHandle extends Xen.Debug(Xen.Base, log) {
     }
     const schema = manifest.findSchemaByName(type);
     const typeOf = setOf ? schema.type.collectionOf() : schema.type;
-    tags = tags.concat(['#nosync']);
+    tags = tags.concat(['nosync']);
     const storageKey = 'in-memory';
     id = id || arc.generateID();
     // context-handles are for `map`, `copy`, `?`

--- a/shell/app-shell/elements/cloud-data/cloud-handles.js
+++ b/shell/app-shell/elements/cloud-data/cloud-handles.js
@@ -40,7 +40,7 @@ class CloudHandles extends Xen.Debug(Xen.Base, log) {
     this._updateWatches(arc, roots, paths);
   }
   _handleToPath(paths, key, [localHandle, tags]) {
-    if (tags && tags.size > 0 && !tags.has('#nosync')) {
+    if (tags && tags.size > 0 && !tags.has('nosync')) {
       const contextId = ArcsUtils.getContextHandleId(localHandle.type, tags);
       const path = `arcs/${key}/${Const.DBLABELS.handles}/${contextId}`;
       paths[path] = localHandle;


### PR DESCRIPTION
Sub-template stamping optimization requires that sub-templates have a single root-node. 

It works fine with Launcher and Words, there may be a bad template somewhere.

Interested to see if the CI tests pass.