### PR TITLE
Fix template in handle-explorer.js

### DIFF
--- a/shell/components/arc-tools/handle-explorer.js
+++ b/shell/components/arc-tools/handle-explorer.js
@@ -41,10 +41,6 @@ const template = html`
 
 const handleTemplate = html`
   <div>
-    <!--<div style="margin-bottom: 8px;">
-      <span>{{name}}</span>
-      <a href="{{href}}" target="_blank"><i class="material-icons" style="font-size: 0.8em; vertical-align: middle;">open_in_new</i></a>
-    </div>-->
     <data-explorer style="font-size: 0.8em;" object="{{data}}"></data-explorer>
   </div>
 `;

--- a/shell/components/arc-tools/handle-explorer.js
+++ b/shell/components/arc-tools/handle-explorer.js
@@ -40,7 +40,7 @@ const template = html`
 `;
 
 const handleTemplate = html`
-  <div>
+  <div style="border-bottom: 1px dashed silver; padding-bottom: 8px; margin-bottom: 8px;">
     <data-explorer style="font-size: 0.8em;" object="{{data}}"></data-explorer>
   </div>
 `;

--- a/shell/components/arc-tools/handle-explorer.js
+++ b/shell/components/arc-tools/handle-explorer.js
@@ -40,12 +40,13 @@ const template = html`
 `;
 
 const handleTemplate = html`
-  <!--<div style="margin-bottom: 8px;">
-    <span>{{name}}</span>
-    <a href="{{href}}" target="_blank"><i class="material-icons" style="font-size: 0.8em; vertical-align: middle;">open_in_new</i></a>
-  </div>-->
-  <data-explorer style="font-size: 0.8em;" object="{{data}}"></data-explorer>
-  <br>
+  <div>
+    <!--<div style="margin-bottom: 8px;">
+      <span>{{name}}</span>
+      <a href="{{href}}" target="_blank"><i class="material-icons" style="font-size: 0.8em; vertical-align: middle;">open_in_new</i></a>
+    </div>-->
+    <data-explorer style="font-size: 0.8em;" object="{{data}}"></data-explorer>
+  </div>
 `;
 
 class HandleExplorer extends Xen.Base {


### PR DESCRIPTION
templates used for sub-template expansions must have a single root-node