### PR TITLE
Revert "Replace handle.synchronize with new API"

### DIFF
--- a/runtime/dom-particle.js
+++ b/runtime/dom-particle.js
@@ -109,27 +109,12 @@ export class DomParticle extends XenStateMixin(Particle) {
   async setHandles(handles) {
     this.handles = handles;
     let config = this.config;
-
-    // this.config isn't a static property; not sure how important it is to avoid re-generating
-    // it in the onHandle* functions
-    this._configSnapshot = config;
-    this._modelCount = this._configSnapshot.handles.length;
-
+    this.when([new HandleChanges(handles, config.handles, 'change')], async () => {
+      await this._handlesToProps(handles, config);
+    });
     // make sure we invalidate once, even if there are no incoming handles
     this._invalidate();
   }
-
-  // onHandleSync should replace the afterAllModels logic
-  // onHandleUpdate should replace the .on listener updates
-  async onHandleSync(handle, model, version) {
-    if (--this._modelCount == 0) {
-      await this._handlesToProps(this.handles, this._configSnapshot);
-    }
-  }
-  async onHandleUpdate(handle, update, version) {
-    await this._handlesToProps(this.handles, this._configSnapshot);
-  }
-
   async _handlesToProps(handles, config) {
     // acquire (async) list data from handles
     let data = await Promise.all(

--- a/runtime/outer-PEC.js
+++ b/runtime/outer-PEC.js
@@ -36,7 +36,7 @@ export class OuterPEC extends ParticleExecutionContext {
     };
 
     this._apiPort.onInitializeProxy = async ({handle, callback}) => {
-      let target = {_handle: handle, _scheduler: this._arc.scheduler};
+      let target = {_scheduler: this._arc.scheduler};
       handle.on('change', data => this._apiPort.SimpleCallback({callback, data}), target);
     };
 

--- a/runtime/particle.js
+++ b/runtime/particle.js
@@ -203,23 +203,16 @@ export class Particle {
 }
 
 export class HandleChanges {
-  constructor(handles, names, type, particleId) {
+  constructor(handles, names, type) {
     if (typeof names == 'string')
       names = [names];
     this.names = names;
     this.handles = handles;
     this.type = type;
-    this.particleId = particleId;
   }
   register(particle, f) {
     let modelCount = 0;
-    let afterAllModels = () => { 
-      console.log(this.particleId, 'afterAllModels', modelCount + 1);
-      if (++modelCount == this.names.length) { 
-        console.log(this.particleId, '-> calling _handlesToProps');
-        f();
-      }
-    };
+    let afterAllModels = () => { if (++modelCount == this.names.length) { f(); } };
 
     for (let name of this.names) {
       let handle = this.handles.get(name);

--- a/runtime/scheduler.js
+++ b/runtime/scheduler.js
@@ -92,8 +92,8 @@ export class Scheduler {
     let totalRecords = 0;
     for (let [handle, kinds] of frame.handles.entries()) {
       for (let [kind, records] of kinds.entries()) {
-        for (let record of records)
-          record.callback(record.details);
+        let record = records[records.length - 1];
+        record.callback(record.details);
       }
     }
 

--- a/runtime/test/demo-flow-test.js
+++ b/runtime/test/demo-flow-test.js
@@ -8,7 +8,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-'use strict';
+ 'use strict';
 
 import {Manifest} from '../manifest.js';
 import {Loader} from '../loader.js';
@@ -22,7 +22,6 @@ describe('demo flow', function() {
   });
 
   it('flows like a demo', async function() {
-
     let helper = await TestHelper.loadManifestAndPlan('./shell/artifacts/Products/Products.recipes', {
       expectedNumPlans: 2,
       verify: async (plans) => {
@@ -35,8 +34,6 @@ describe('demo flow', function() {
       // slotComposerStrict: false,
       // logging: true
     });
-
-    helper.setTimeout(5000);
 
     // 1. Accept "Show ... and choose ... products" suggestion.
     helper.slotComposer
@@ -176,8 +173,6 @@ describe('demo flow', function() {
     await helper.makePlans({expectedNumPlans: 2});
     helper.log('----------------------------------------');
 
-    helper.clearTimeout();
-
     // TODO(mmandlis): Provide methods in helper to verify slot contents (helper.slotComposer._slots[i]._content).
-  }).timeout(10000);
+  }).timeout(5000);
 });

--- a/runtime/testing/mock-slot-composer.js
+++ b/runtime/testing/mock-slot-composer.js
@@ -62,7 +62,7 @@ export class MockSlotComposer extends SlotComposer {
    * Allows ignoring unexpected render slot requests.
    */
   ignoreUnexpectedRender() {
-    this.expectQueue.push({type: 'render', ignoreUnexpected: true, isOptional: true, toString: () => `render: ignoreUnexpected optional`});
+    this.expectQueue.push({type: 'render', ignoreUnexpected: true, isOptional: true});
     return this;
   }
 
@@ -109,13 +109,6 @@ export class MockSlotComposer extends SlotComposer {
     return new Promise((resolve, reject) => this.onExpectationsComplete = resolve);
   }
 
-  assertExpectationsCompleted() {
-    if (this.expectQueue.length == 0 || this.expectQueue.every(e => e.isOptional)) {
-      return true;
-    }
-    assert.isTrue(false, 'remaining expectations:\n' + this.expectQueue.map(expect => `  ${expect.toString()}`).join('\n'));
-  }
-
   /** @method sendEvent(particleName, slotName, event, data)
    * Sends an event to the given particle and slot.
    */
@@ -133,8 +126,7 @@ export class MockSlotComposer extends SlotComposer {
           && e.isOptional == expectation.isOptional;
     });
     if (!current) {
-      current = {type: 'render', particleName: expectation.particleName, slotName: expectation.slotName, hostedParticle: expectation.hostedParticle, isOptional: expectation.isOptional, 
-                 toString: () => `render:${expectation.isOptional ? '  optional' : ' '} ${expectation.particleName} ${expectation.slotName} ${expectation.hostedParticle} ${current.contentTypes}`};
+      current = {type: 'render', particleName: expectation.particleName, slotName: expectation.slotName, hostedParticle: expectation.hostedParticle, isOptional: expectation.isOptional};
       this.expectQueue.push(current);
     }
     if (expectation.verifyComplete) {

--- a/runtime/testing/test-helper.js
+++ b/runtime/testing/test-helper.js
@@ -55,14 +55,6 @@ export class TestHelper {
     this.logging = options.logging;
   }
 
-  setTimeout(timeout) {
-    this.timeout = setTimeout(() => this.slotComposer.assertExpectationsCompleted(), timeout);
-  }
-
-  clearTimeout() {
-    clearTimeout(this.timeout);
-  }
-
   /** @static @method loadManifestAndPlan(manifestFilename, options)
    * Creates and returns a TestHelper instance, loads a manifest file and makes planning.
    */


### PR DESCRIPTION
Reverts PolymerLabs/arcs#1446.

The demo flows test becomes flaky (~10% failure rate) with these changes in. I'm looking at this (sorry, should have removed my approval on the PR).