### PR TITLE
move service-worker handler into common code, make it opt-in

### DIFF
--- a/shell/apps/common/config.js
+++ b/shell/apps/common/config.js
@@ -1,8 +1,10 @@
 const defaultDebugLevel = 0;
 
+const params = (new URL(document.location)).searchParams;
+
 // must establish Debug level before using logFactory
 import Xen from '../../components/xen/xen.js';
-Xen.Debug.level = ((new URL(document.location)).searchParams.has('log')) ? 2 : defaultDebugLevel;
+Xen.Debug.level = params.has('log') ? 2 : defaultDebugLevel;
 
 // some globals configured here for the convenience of providing in this simple config file.
 // TODO(sjmiles): at least collate globals into a namespace, or provide as a module
@@ -17,6 +19,18 @@ window.shellUrls = {};
 // TOOD(sjmiles): allow persistent configurable redirects for developer environments, maybe via `localstorage`?
 if (document.location.pathname.includes('projects')) {
   window.shellUrls['https://sjmiles.github.io/'] = `${window.shellPath}/../../`;
+}
+
+// optional service worker
+const useSw = params.has('sw');
+if (useSw) {
+  navigator.serviceWorker.register('../../sw.js');
+} else {
+  navigator.serviceWorker.getRegistrations().then(function(registrations) {
+    for (let registration of registrations) {
+      registration.unregister();
+    }
+  });
 }
 
 // default manifest!

--- a/shell/apps/web/index.html
+++ b/shell/apps/web/index.html
@@ -12,18 +12,6 @@
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Google+Sans:400,700">
   <link rel="stylesheet" href="../common/index.css">
 
-  <script>
-    if ((new URL(document.location)).searchParams.has('nosw')) {
-      navigator.serviceWorker.getRegistrations().then(function(registrations) {
-        for (let registration of registrations) {
-          registration.unregister();
-        }
-      });
-    } else {
-      navigator.serviceWorker.register('../../sw.js');
-    }
-  </script>
-
   <script type="module">
     // global configuration
     import '../common/config.js';


### PR DESCRIPTION
The ServiceWorker has had some unintended consequences (e.g., takes two refreshes to load changes), also it generally is a bit difficult to reason about (at the moment).

This patch makes the service worker opt-in (`sw` param) **instead** of opt-out (`nosw` param).

I also moved the relevant code to `common/config.js`.