### PR TITLE
Default particle source filename to empty string in loader.

### DIFF
--- a/runtime/loader.js
+++ b/runtime/loader.js
@@ -73,6 +73,7 @@ export class Loader {
   }
 
   async requireParticle(fileName) {
+    if (fileName === null) fileName = '';
     let src = await this.loadResource(fileName);
     // Note. This is not real isolation.
     let script = new vm.Script(src, {filename: fileName, displayErrors: true});


### PR DESCRIPTION
Fixes two failing recipe description unit tests under Node v10.

In Node v10 `vm.Script` throws an error if `options.filename` is null.
For cases such as trivial particle definitions used in tests we may
not bother specifying an implementation file.

Fixes https://github.com/PolymerLabs/arcs/issues/1466