### PR TITLE
Simplify speculative execution logic: remove plan groups.

### DIFF
--- a/runtime/test/planner-tests.js
+++ b/runtime/test/planner-tests.js
@@ -179,11 +179,9 @@ describe('Planner', function() {
       }
     );
     assert.equal(plans.length, 2);
-    // Make sure the recipes were processed as separate plan groups.
-    // TODO(wkorman): When we move to a thread pool we'll revise this to check
-    // the thread index instead.
-    assert.equal(plans[0].groupIndex, 0);
-    assert.equal(plans[1].groupIndex, 1);
+    // Make sure the recipes were processed as separate async calls.
+    assert.equal(plans[0].planIndex, 0);
+    assert.equal(plans[1].planIndex, 1);
   });
 });
 


### PR DESCRIPTION
Experiment with removing plan grouping and instead (go back to?)
kicking off an async task for each plan. This may be similar to what
we did in the past which (I understand may have) caused OOM or other
performance issues particularly on mobile devices.

However, the plan grouping logic as written was confusing as the V8 VM
doesn't actually use multiple threads for these async tasks, and, the
grouping was inefficient since one group could finish ahead of another
and thus tasks weren't as evenly distributed as they could have been.

Before potentially doing that rework I figure we should see whether
it's actually needed.

Part of https://github.com/PolymerLabs/arcs/issues/705