### PR TITLE
Enable devtools tracing before creation of an Arc

### DIFF
--- a/runtime/debug/arc-debug-handler.js
+++ b/runtime/debug/arc-debug-handler.js
@@ -10,10 +10,15 @@
 
 import {enableTracingAdapter} from './tracing-adapter.js';
 import {ArcPlannerInvoker} from './arc-planner-invoker.js';
+import {DevtoolsConnection} from './devtools-connection.js';
+
+// Arc-independent handlers for devtools logic.
+DevtoolsConnection.onceConnected.then(devtoolsChannel => {
+  enableTracingAdapter(devtoolsChannel);
+});
 
 export class ArcDebugHandler {
   constructor(arc, devtoolsChannel) {
-    enableTracingAdapter(devtoolsChannel);
 
     // Message handles go here.
     new ArcPlannerInvoker(arc, devtoolsChannel);


### PR DESCRIPTION
Separates instantiation of arc-dependent and arc-independent handlers for DevTools.

Motivating example is making traces started in the arc constructor before ArcDebugHandler instantiation (E.g. for RecipeIndex) visible in DevTools.