### PR TITLE
Improve sigh linting speed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 **/*~
 \#*\#
 .\#*
+.eslint_sigh_cache
 **/trace.json
 runtime/browser-test/browser-test-ified.js
 manifest-railroad.html


### PR DESCRIPTION
- Uses native eslint api, avoids spawning eslint processes
- Also enable caching to speed up subsequent lint runs

Rough Performance Improvement (macOS)

BASELINE
real    0m10.329s
user    0m13.845s
sys     0m0.918s

COLD LINT
real    0m6.330s
user    0m8.710s
sys     0m0.468s

CACHED LINT
real    0m0.911s
user    0m0.710s
sys     0m0.185s

Fixes #1506