### PR TITLE
Social: Wrap subtemplate with div to fit new Xen requirement.

### DIFF
--- a/shell/artifacts/Social/source/PostList.js
+++ b/shell/artifacts/Social/source/PostList.js
@@ -18,8 +18,10 @@ defineParticle(({DomParticle, resolver, html}) => {
 </style>
 <div ${host} style="padding: 8px;">
   <template items>
-    <div slotid="item" subid="{{id}}" key="{{id}}"></div>
-    <div slotid="action" subid="{{id}}"></div>
+    <div>
+      <div slotid="item" subid="{{id}}" key="{{id}}"></div>
+      <div slotid="action" subid="{{id}}"></div>
+    </div>
   </template>
   <div items>{{items}}</div>
 </div>


### PR DESCRIPTION
Fixes https://github.com/PolymerLabs/arcs/issues/1518

https://github.com/PolymerLabs/arcs/commit/277ca7e688be5c8d930d888c8e98f24762f5f0d8 introduced requirement that subtemplates be rooted at a single node. Filed https://github.com/PolymerLabs/arcs/issues/1521 for potential followup on fixing silent failure.