### PR TITLE
Revert #1513 as it causes Linux sad-tab OOM.

### DIFF
--- a/runtime/manifest.js
+++ b/runtime/manifest.js
@@ -804,8 +804,8 @@ ${e.message}
                 `Could not find hosted particle '${connectionItem.target.particle}'`);
           }
           assert(!connection.type.hasVariableReference);
-          assert(connection.type.isInterface);
-          if (!connection.type.interfaceShape.restrictType(hostedParticle)) {
+          let type = TypeChecker.restrictType(connection.type, hostedParticle);
+          if (!type) {
             throw new ManifestError(
                 connectionItem.target.location,
                 `Hosted particle '${hostedParticle.name}' does not match shape '${connection.name}'`);
@@ -819,7 +819,7 @@ ${e.message}
           let id = `${manifest.generateID()}:${particleSpecHash}:${hostedParticle.name}`;
           targetHandle = recipe.newHandle();
           targetHandle.fate = 'copy';
-          let store = await manifest.newStore(connection.type, null, id, []);
+          let store = await manifest.newStore(type, null, id, []);
           store.set(hostedParticleLiteral);
           targetHandle.mapToStorage(store);
         }

--- a/runtime/recipe/handle.js
+++ b/runtime/recipe/handle.js
@@ -114,14 +114,6 @@ export class Handle {
   set pattern(pattern) { this._pattern = pattern; }
 
   static effectiveType(handleType, connections) {
-    let variableMap = new Map();
-    // It's OK to use _cloneWithResolutions here as for the purpose of this test, the handle set + handleType
-    // contain the full set of type variable information that needs to be maintained across the clone.
-    let typeSet = connections.filter(connection => connection.type != null).map(connection => ({type: connection.type._cloneWithResolutions(variableMap), direction: connection.direction}));
-    return TypeChecker.processTypeList(handleType ? handleType._cloneWithResolutions(variableMap) : null, typeSet);
-  }
-
-  static resolveEffectiveType(handleType, connections) {
     let typeSet = connections.filter(connection => connection.type != null).map(connection => ({type: connection.type, direction: connection.direction}));
     return TypeChecker.processTypeList(handleType, typeSet);
   }
@@ -138,7 +130,7 @@ export class Handle {
       }
       connection.tags.forEach(tag => tags.add(tag));
     }
-    let type = Handle.resolveEffectiveType(this._mappedType, this._connections);
+    let type = Handle.effectiveType(this._mappedType, this._connections);
     if (type) {
       this._type = type;
       this._tags.forEach(tag => tags.add(tag));
@@ -156,7 +148,7 @@ export class Handle {
     assert(Object.isFrozen(this));
     let resolved = true;
     if (this.type) {
-      if ((!this.type.isResolved() && this.fate !== 'create') ||
+      if ((!this.type.isResolved() && this.fate !== 'create') || 
           (!this.type.canEnsureResolved() && this.fate == 'create')) {
         if (options) {
           options.details = 'unresolved type';

--- a/runtime/recipe/type-checker.js
+++ b/runtime/recipe/type-checker.js
@@ -22,10 +22,9 @@ export class TypeChecker {
   // NOTE: you probably don't want to call this function, if you think you
   // do, talk to shans@.
   static processTypeList(baseType, list) {
-    let newBaseType = Type.newVariable(new TypeVariable(''));
-    if (baseType)
-      newBaseType.data.resolution = baseType;
-    baseType = newBaseType;
+    baseType = baseType == undefined
+        ? Type.newVariable(new TypeVariable('a'))
+        : Type.fromLiteral(baseType.toLiteral()); // Copy for mutating.
     
     let concreteTypes = [];
 
@@ -87,8 +86,6 @@ export class TypeChecker {
         let result = primitiveBase.variable.maybeMergeConstraints(primitiveOnto.variable);
         if (result == false)
           return null;
-        // Here onto grows, one level at a time,
-        // as we assign new resolution to primitiveOnto, which is a leaf.
         primitiveOnto.variable.resolution = primitiveBase;
       } else {
         // base variable, onto not.
@@ -98,11 +95,6 @@ export class TypeChecker {
       // onto variable, base not.
       primitiveOnto.variable.resolution = primitiveBase;
       return onto;
-    } else if (primitiveBase.isInterface && primitiveOnto.isInterface) {
-      let result = primitiveBase.interfaceShape.tryMergeTypeVariablesWith(primitiveOnto.interfaceShape);
-      if (result == null)
-        return null;
-      return Type.newInterface(result);
     } else {
       assert(false, 'tryMergeTypeVariable shouldn\'t be called on two types without any type variables');
     }
@@ -178,6 +170,16 @@ export class TypeChecker {
     if (handleType.canWriteSuperset.isMoreSpecificThan(readType))
       return true;
     return false;
+  }
+
+  // TODO: what is this? Does it still belong here?
+  static restrictType(type, instance) {
+    assert(type.isInterface, `restrictType not implemented for ${type}`);
+
+    let shape = type.interfaceShape.restrictType(instance);
+    if (shape == false)
+      return false;
+    return Type.newInterface(shape);
   }
 
   // Compare two types to see if they could be potentially resolved (in the absence of other

--- a/runtime/shape.js
+++ b/runtime/shape.js
@@ -117,18 +117,8 @@ ${this._slotsToManifestString()}
     return {name: this.name, handles, slots};
   }
 
-  clone(variableMap) {
-    let handles = this.handles.map(({name, direction, type}) => ({name, direction, type: type ? type.clone(variableMap) : undefined}));
-    let slots = this.slots.map(({name, direction, isRequired, isSet}) => ({name, direction, isRequired, isSet}));
-    return new Shape(this.name, handles, slots);
-  }
-
-  cloneWithResolutions(variableMap) {
-    return this._cloneWithResolutions(variableMap);
-  }
-
-  _cloneWithResolutions(variableMap) {
-    let handles = this.handles.map(({name, direction, type}) => ({name, direction, type: type ? type._cloneWithResolutions(variableMap) : undefined}));
+  clone() {
+    let handles = this.handles.map(({name, direction, type}) => ({name, direction, type}));
     let slots = this.slots.map(({name, direction, isRequired, isSet}) => ({name, direction, isRequired, isSet}));
     return new Shape(this.name, handles, slots);
   }
@@ -148,55 +138,6 @@ ${this._slotsToManifestString()}
     for (let typeVar of this._typeVars)
       typeVar.object[typeVar.field].maybeEnsureResolved();
     return true;
-  }
-
-  tryMergeTypeVariablesWith(other) {
-    // Type variable enabled slot matching will Just Work when we
-    // unify slots and handles.
-    if (!this._equalItems(other.slots, this.slots, this._equalSlot))
-      return null;
-    if (other.handles.length !== this.handles.length)
-      return null;
-
-    let handles = new Set(this.handles);
-    let otherHandles = new Set(other.handles);
-    let handleMap = new Map();
-    let sizeCheck = handles.size;
-    while (handles.size > 0) {
-      let handleMatches = [...handles.values()].map(
-        handle => ({handle, match: [...otherHandles.values()].filter(otherHandle =>this._equalHandle(handle, otherHandle))}));
-
-      for (let handleMatch of handleMatches) {
-        // no match!
-        if (handleMatch.match.length == 0)
-          return null;
-        if (handleMatch.match.length == 1) {
-          handleMap.set(handleMatch.handle, handleMatch.match[0]);
-          otherHandles.delete(handleMatch.match[0]);
-          handles.delete(handleMatch.handle);
-        }
-      }
-      // no progress!
-      if (handles.size == sizeCheck)
-        return null;
-      sizeCheck = handles.size;
-    }
-
-    handles = [];
-    for (let handle of this.handles) {
-      let otherHandle = handleMap.get(handle);
-      let resultType;
-      if (handle.type.hasVariable || otherHandle.type.hasVariable) {
-        resultType = TypeChecker._tryMergeTypeVariable(handle.type, otherHandle.type);
-        if (!resultType)
-          return null;
-      } else {
-        resultType = handle.type || otherHandle.type;
-      }
-      handles.push({name: handle.name || otherHandle.name, direction: handle.direction || otherHandle.direction, type: resultType});
-    }
-    let slots = this.slots.map(({name, direction, isRequired, isSet}) => ({name, direction, isRequired, isSet}));
-    return new Shape(this.name, handles, slots);
   }
 
   resolvedType() {
@@ -243,7 +184,7 @@ ${this._slotsToManifestString()}
   }
 
   _cloneAndUpdate(update) {
-    let copy = this.clone(new Map());
+    let copy = this.clone();
     copy._typeVars.forEach(typeVar => Shape._updateTypeVar(typeVar, update));
     return copy;
   }
@@ -292,12 +233,12 @@ ${this._slotsToManifestString()}
   }
 
   particleMatches(particleSpec) {
-    let shape = this.cloneWithResolutions(new Map());
-    return shape.restrictType(particleSpec) !== false;
+    return this.restrictType(particleSpec) !== false;
   }
 
   restrictType(particleSpec) {
-    return this._restrictThis(particleSpec);
+    let newShape = this.clone();
+    return newShape._restrictThis(particleSpec);
   }
 
   _restrictThis(particleSpec) {
@@ -352,4 +293,3 @@ ${this._slotsToManifestString()}
 }
 
 import {Type} from './type.js';
-import {TypeChecker} from './recipe/type-checker.js';

--- a/runtime/test/type-checker-tests.js
+++ b/runtime/test/type-checker-tests.js
@@ -167,14 +167,14 @@ describe('TypeChecker', () => {
     assert.isNull(TypeChecker.processTypeList(undefined, [collection, entity]));
   });
 
-  it('does not modify an input baseType if invoked through Handle.effectiveType', async () => {
+  it('does not modify an input baseType', async () => {
     let baseType = Type.newVariable(new TypeVariable('a'));
     let connection = {
       type: Type.newEntity(new Schema({names: ['Thing'], fields: {}})),
       direction: 'inout'
     };
 
-    let newType = Handle.effectiveType(baseType, [connection]);
+    let newType = TypeChecker.processTypeList(baseType, [connection]);
     assert.notStrictEqual(baseType, newType);
     assert.isNull(baseType.variable.resolution);
     assert.isNotNull(newType.variable.resolution);
@@ -191,16 +191,5 @@ describe('TypeChecker', () => {
     let rightType = Type.newVariable(new TypeVariable('b', canWrite));
     assert.isFalse(TypeChecker.compareTypes({type: leftType}, {type: rightType}));
     assert.isFalse(TypeChecker.compareTypes({type: rightType}, {type: leftType}));
-  });
-  function depth(v, level = 0) {
-    if (v.isVariable && v.data._resolution) return depth(v.data._resolution, level + 1);
-    return level;
-  }
-  it(`doesn't mutate types provided to effectiveType calls`, () => {
-    let a = Type.newVariable(new TypeVariable('a'));
-    for (let i = 0; i < 100; i++) {
-      assert.equal(0, depth(a));
-      Handle.effectiveType(undefined, [{type: a, direction: 'inout'}]);
-    }
   });
 });

--- a/runtime/type-variable.js
+++ b/runtime/type-variable.js
@@ -162,10 +162,6 @@ export class TypeVariable {
 
   toLiteral() {
     assert(this.resolution == null);
-    return this.toLiteralIgnoringResolutions();
-  }
-
-  toLiteralIgnoringResolutions() {
     return {
       name: this.name,
       canWriteSuperset: this._canWriteSuperset && this._canWriteSuperset.toLiteral(),

--- a/runtime/type.js
+++ b/runtime/type.js
@@ -78,7 +78,7 @@ export class Type {
     }
 
     if (this.isInterface) {
-      let shape = this.interfaceShape.clone(new Map());
+      let shape = this.interfaceShape.clone();
       shape._typeVars.map(({object, field}) => object[field] = object[field].mergeTypeVariablesByName(variableMap));
       // TODO: only build a new type when a variable is modified
       return Type.newInterface(shape);
@@ -232,10 +232,6 @@ export class Type {
     return Type._canMergeCanReadSubset(type1, type2) && Type._canMergeCanWriteSuperset(type1, type2);
   }
 
-  // Clone a type object.
-  // When cloning multiple types, variables that were associated with the same name
-  // before cloning should still be associated after cloning. To maintain this 
-  // property, create a Map() and pass it into all clone calls in the group.
   clone(variableMap) {
     let type = this.resolvedType();
     if (type.isVariable) {
@@ -251,32 +247,6 @@ export class Type {
       return new Type(type.tag, type.data.clone(variableMap));
     }
     return Type.fromLiteral(type.toLiteral());
-  }
-
-  // Clone a type object, maintaining resolution information.
-  // This function SHOULD NOT BE USED at the type level. In order for type variable
-  // information to be maintained correctly, an entire context root needs to be
-  // cloned.
-  _cloneWithResolutions(variableMap) {
-    if (this.isVariable) {
-      if (variableMap.has(this.variable)) {
-        return new Type('Variable', variableMap.get(this.variable));
-      } else {
-        let newTypeVariable = TypeVariable.fromLiteral(this.variable.toLiteralIgnoringResolutions());
-        if (this.variable.resolution)
-          newTypeVariable.resolution = this.variable.resolution._cloneWithResolutions(variableMap);
-        if (this.variable._canReadSubset)
-          newTypeVariable.canReadSubset = this.variable.canReadSubset._cloneWithResolutions(variableMap);
-        if (this.variable._canWriteSuperset)
-          newTypeVariable.canWriteSuperset = this.variable.canWriteSuperset._cloneWithResolutions(variableMap);
-        variableMap.set(this.variable, newTypeVariable);
-        return new Type('Variable', newTypeVariable);
-      }
-    }
-    if (this.data._cloneWithResolutions) {
-      return new Type(this.tag, this.data._cloneWithResolutions(variableMap));
-    }
-    return Type.fromLiteral(this.toLiteral());
   }
 
   toLiteral() {


### PR DESCRIPTION
Revert of https://github.com/PolymerLabs/arcs/pull/1513 as it causes Linux sad-tab OOM.

Part of https://github.com/PolymerLabs/arcs/issues/1527

Reverting:

commit 922efb952c4906da6594b6f91869a065b138355c
Author: shans <shane.stephens@gmail.com>
Date:   Thu Jun 21 15:12:52 2018 +1000

     Differentiate Handle.effectiveType (to see if a set of types will resolve) from Handle.resolveEffectiveType. (#1513)

    This allows effectiveType to be used for speculative resolution inside strategies.

    Note that this uncovered a more fundamental problem around type cloning:

    There's a clone() method on type which works on individual types. However, type variables work by linking all instances of the same variable to a single TypeVariable object, which means that cloning can't maintain type variable information. So clone() flattens out type variables to their resolved values.

    This means that clone() can't be used to try speculative type changes (like what strategies are trying to do with effectiveType), because all the linkages are lost and the effect of the change isn't correctly evaluated.

    To get around this, I've added a cloneWithResolutions() method; but there's an important caveat here: it can only be used with an understanding of the domain of the test that the clone is going to be used for. In this case, we only care about this specific handle and it's connections, so it's OK to cloneWithResolutions() across that set of types.

    This investigation also uncovered some bugs with the way we were cloning shapes, and a place where shapes were being cloned but shouldn't have been.