### PR TITLE
A fix for type checking entity and collection of type var

### DIFF
--- a/runtime/recipe/type-checker.js
+++ b/runtime/recipe/type-checker.js
@@ -26,7 +26,7 @@ export class TypeChecker {
     if (baseType)
       newBaseType.data.resolution = baseType;
     baseType = newBaseType;
-    
+
     let concreteTypes = [];
 
     // baseType might be a variable (and is definitely a variable if no baseType was available).
@@ -104,6 +104,12 @@ export class TypeChecker {
         return null;
       return Type.newInterface(result);
     } else {
+      if ((primitiveBase.isCollection && primitiveBase.hasVariable)
+          || (primitiveOnto.isCollection && primitiveOnto.hasVariable)) {
+        // Cannot merge [~a] with a type that is not a variable and not a collection.
+        return null;
+      }
+
       assert(false, 'tryMergeTypeVariable shouldn\'t be called on two types without any type variables');
     }
 

--- a/runtime/test/type-checker-tests.js
+++ b/runtime/test/type-checker-tests.js
@@ -167,6 +167,12 @@ describe('TypeChecker', () => {
     assert.isNull(TypeChecker.processTypeList(undefined, [collection, entity]));
   });
 
+  it(`doesn't resolve entity and collection of type variable`, () => {
+    let a = Type.newEntity(new Schema({names: ['Thing'], fields: {}}));
+    let b = Type.newVariable(new TypeVariable('a')).collectionOf();
+    assert.isNull(TypeChecker.processTypeList(a, [{type: b, direction: 'inout'}]));
+  });
+
   it('does not modify an input baseType if invoked through Handle.effectiveType', async () => {
     let baseType = Type.newVariable(new TypeVariable('a'));
     let connection = {
@@ -192,15 +198,10 @@ describe('TypeChecker', () => {
     assert.isFalse(TypeChecker.compareTypes({type: leftType}, {type: rightType}));
     assert.isFalse(TypeChecker.compareTypes({type: rightType}, {type: leftType}));
   });
-  function depth(v, level = 0) {
-    if (v.isVariable && v.data._resolution) return depth(v.data._resolution, level + 1);
-    return level;
-  }
   it(`doesn't mutate types provided to effectiveType calls`, () => {
     let a = Type.newVariable(new TypeVariable('a'));
-    for (let i = 0; i < 100; i++) {
-      assert.equal(0, depth(a));
-      Handle.effectiveType(undefined, [{type: a, direction: 'inout'}]);
-    }
+    assert.isNull(a.data._resolution);
+    Handle.effectiveType(undefined, [{type: a, direction: 'inout'}]);
+    assert.isNull(a.data._resolution);
   });
 });


### PR DESCRIPTION
Fixes an overly strict assert where attempting to merge [~a] with an Entity.

Also simplifies the 'doesn't mutate types provided to effectiveType calls' test.