### PR TITLE
Introduces contextual init-population if arc is not empty.

### DIFF
--- a/runtime/strategies.md
+++ b/runtime/strategies.md
@@ -3,7 +3,8 @@
 The planner applies these strategies to produce resolved recipes to be instantiated in the Arc.
 
 ## InitPopulation
-Loads recipes from arc’s context recipes.<br/>
+Loads recipes from arc's recipe index. If contextual planning is requested,
+only recipes that match handles or slots of the active recipe are returned.<br/>
 [init-population.js](https://github.com/PolymerLabs/arcs/blob/master/runtime/strategies/init-population.js)
 
 ## ConvertConstraintsToConnections

--- a/runtime/strategies/coalesce-recipes.js
+++ b/runtime/strategies/coalesce-recipes.js
@@ -121,12 +121,4 @@ export class CoalesceRecipes extends Strategy {
       }
     }(Walker.Independent), this);
   }
-
-  _compatibleConnections(handle, otherHandle) {
-    const allConnections = [...handle.connections, ...otherHandle.connections];
-    return !!Handle.effectiveType(undefined,
-        // Make copies of types to not modify actual recipes.
-        // TODO: Remove this once effectiveType doesn't mutate inputs.
-        allConnections.map(({type, direction}) => ({type: Type.fromLiteral(type.toLiteral()), direction})));
-  }
 }

--- a/runtime/strategies/coalesce-recipes.js
+++ b/runtime/strategies/coalesce-recipes.js
@@ -121,4 +121,12 @@ export class CoalesceRecipes extends Strategy {
       }
     }(Walker.Independent), this);
   }
+
+  _compatibleConnections(handle, otherHandle) {
+    const allConnections = [...handle.connections, ...otherHandle.connections];
+    return !!Handle.effectiveType(undefined,
+        // Make copies of types to not modify actual recipes.
+        // TODO: Remove this once effectiveType doesn't mutate inputs.
+        allConnections.map(({type, direction}) => ({type: Type.fromLiteral(type.toLiteral()), direction})));
+  }
 }

--- a/runtime/strategies/init-population.js
+++ b/runtime/strategies/init-population.js
@@ -6,25 +6,53 @@
 // http://polymer.github.io/PATENTS.txt
 
 import {Strategy} from '../../strategizer/strategizer.js';
+import {assert} from '../../platform/assert-web.js';
 
 export class InitPopulation extends Strategy {
-  constructor(arc) {
+  constructor(arc, {contextual = false}) {
     super();
     this._arc = arc;
+    this._contextual = contextual;
     this._loadedParticles = new Set(this._arc.loadedParticles().map(spec => spec.implFile));
   }
+
   async generate({generation}) {
     if (generation != 0) {
       return [];
     }
 
     await this._arc.recipeIndex.ready;
-    return this._arc.recipeIndex.recipes.map(recipe => ({
+    const results = this._contextual
+        ? this._contextualResults()
+        : this._allResults();
+
+    return results.map(({recipe, score = 1}) => ({
       result: recipe,
-      score: 1 - recipe.particles.filter(particle => particle.spec && this._loadedParticles.has(particle.spec.implFile)).length,
+      score,
       derivation: [{strategy: this, parent: undefined}],
       hash: recipe.digest(),
-      valid: Object.isFrozen(recipe),
+      valid: Object.isFrozen(recipe)
+    }));
+  }
+
+  _contextualResults() {
+    let results = [];
+    for (let slot of this._arc.activeRecipe.slots.filter(s => s.sourceConnection)) {
+      results.push(...this._arc.recipeIndex.findConsumeSlotConnectionMatch(slot).map(
+          ({slotConn}) => ({recipe: slotConn.recipe})));
+    }
+    for (let handle of this._arc.activeRecipe.handles) {
+      results.push(...this._arc.recipeIndex.findHandleMatch(handle, ['use', '?']).map(
+          otherHandle => ({recipe: otherHandle.recipe})));
+    }
+    return results;
+  }
+
+  _allResults() {
+    return this._arc.recipeIndex.recipes.map(recipe => ({
+      recipe,
+      score: 1 - recipe.particles.filter(
+          particle => particle.spec && this._loadedParticles.has(particle.spec.implFile)).length
     }));
   }
 }

--- a/runtime/test/recipe-index-test.js
+++ b/runtime/test/recipe-index-test.js
@@ -14,8 +14,8 @@ import {Arc} from '../arc.js';
 import {assert} from './chai-web.js';
 import {MockSlotComposer} from '../testing/mock-slot-composer.js';
 
-describe('Recipe index', function() {
-  async function extractIndexRecipeStrings(manifestContent) {
+describe('RecipeIndex', function() {
+  async function createIndex(manifestContent) {
     let manifest = (await Manifest.parse(manifestContent));
     for (let recipe of manifest.recipes) {
       assert(recipe.normalize());
@@ -26,7 +26,11 @@ describe('Recipe index', function() {
       slotComposer: new MockSlotComposer()
     });
     await arc.recipeIndex.ready;
-    return arc.recipeIndex._recipes.map(r => r.toString());
+    return arc.recipeIndex;
+  }
+
+  async function extractIndexRecipeStrings(manifestContent) {
+    return (await createIndex(manifestContent)).recipes.map(r => r.toString());
   }
 
   it('adds use handles', async () => {
@@ -47,6 +51,24 @@ describe('Recipe index', function() {
   Transform as particle0
     lumberjack -> handle0
     person <- handle1`
+    ]);
+  });
+
+  it('matches free handles to connections', async () => {
+    assert.sameMembers(await extractIndexRecipeStrings(`
+      schema Person
+
+      particle A
+        inout Person person
+
+      recipe
+        create as person
+        A
+    `), [
+`recipe
+  create as handle0 // Person {}
+  A as particle0
+    person = handle0`
     ]);
   });
 
@@ -131,5 +153,185 @@ describe('Recipe index', function() {
 `recipe
   &verb`
     ]);
+  });
+
+  it('finds matching handles by fate', async () => {
+    let index = await createIndex(`
+      schema Thing
+
+      particle A
+        in Thing thing
+      recipe A
+        map as thing
+        A
+          thing = thing
+
+      particle B
+        out Thing thing
+      recipe B
+        create as thing
+        B
+          thing = thing
+
+      particle C
+        in Thing thing
+      recipe C
+        use as thing
+        C
+          thing = thing
+    `);
+
+    let recipe = index.recipes.find(r => r.name === 'C');
+    let handle = recipe.handles[0];
+
+    assert.deepEqual(['A'], index.findHandleMatch(handle, ['map']).map(h => h.recipe.name));
+    assert.deepEqual(['B'], index.findHandleMatch(handle, ['create']).map(h => h.recipe.name));
+  });
+
+  it('finds matching handle by type', async () => {
+    let index = await createIndex(`
+      schema Thing
+      schema OtherThing
+
+      particle ConsumerThing
+        in Thing thing
+      particle ProducerThing
+        out Thing thing
+      particle ProducerOtherThing
+        out OtherThing thing
+
+      recipe Selector
+        use as thing
+        ConsumerThing
+
+      recipe
+        create as thing
+        ProducerThing
+
+      recipe
+        create as otherThing
+        ProducerOtherThing
+    `);
+
+    let recipe = index.recipes.find(r => r.name === 'Selector');
+    let handle = recipe.handles[0];
+
+    assert.deepEqual(
+        ['ProducerThing'],
+        index.findHandleMatch(handle).map(h => h.recipe.particles[0].name));
+  });
+
+  it('finds matching handles by tags', async () => {
+    let index = await createIndex(`
+      schema Thing
+
+      particle Consumer
+        in Thing thing
+      particle Producer
+        out Thing thing
+
+      recipe TakeMe1
+        create #loved as thing
+        Producer
+
+      recipe TakeMe2
+        create #loved #adored as thing
+        Producer
+
+      recipe TakeMe3
+        create #appreciated as thing
+        Producer
+
+      recipe IgnoreMe
+        create #hated as thing
+        Producer
+
+      recipe Selector
+        use #loved #appreciated as thing
+        Consumer
+    `);
+
+    let recipe = index.recipes.find(r => r.name === 'Selector');
+    let handle = recipe.handles[0];
+
+    assert.deepEqual(
+        ['TakeMe1', 'TakeMe2', 'TakeMe3'],
+        index.findHandleMatch(handle).map(h => h.recipe.name));
+  });
+
+  it('matching use/create handle pairs require communication', async () => {
+    let index = await createIndex(`
+      schema Thing
+
+      particle Consumer1
+        in Thing thing
+      particle Consumer2
+        in Thing thing
+      particle Producer
+        out Thing thing
+      particle ProducerConsumer
+        inout Thing thing
+
+      recipe Selector
+        use as thing
+        Consumer1
+
+      recipe
+        create as thing
+        Consumer2
+
+      recipe
+        create as thing
+        Producer
+
+      recipe
+        create as thing
+        ProducerConsumer
+    `);
+
+    let recipe = index.recipes.find(r => r.name === 'Selector');
+    let handle = recipe.handles[0];
+
+    assert.deepEqual(
+        ['Producer', 'ProducerConsumer'],
+        index.findHandleMatch(handle).map(h => h.recipe.particles[0].name));
+  });
+
+  it('matching use/copy handle pairs do not require communication', async () => {
+    let index = await createIndex(`
+      schema Thing
+
+      particle Consumer1
+        in Thing thing
+      particle Consumer2
+        in Thing thing
+      particle Producer
+        out Thing thing
+      particle ProducerConsumer
+        inout Thing thing
+
+      recipe Selector
+        use as thing
+        Consumer1
+
+      recipe
+        copy as thing
+        Consumer2
+
+      recipe
+        copy as thing
+        Producer
+
+      recipe
+        copy as thing
+        ProducerConsumer
+    `);
+
+    let recipe = index.recipes.find(r => r.name === 'Selector');
+    let handle = recipe.handles[0];
+
+    assert.deepEqual(
+        ['Consumer2', 'Producer', 'ProducerConsumer'],
+        index.findHandleMatch(handle).map(h => h.recipe.particles[0].name));
   });
 });

--- a/shell/test/specs/demo-tests.js
+++ b/shell/test/specs/demo-tests.js
@@ -464,6 +464,7 @@ describe('Arcs demos', function() {
     ].forEach(suggestion => {
       waitForStillness();
       openSystemUi();
+      clickElement('input[search]');
       acceptSuggestion(suggestion);
     });
 


### PR DESCRIPTION
Summary:
* Planificator controls whether planning is contextual (i.e. targeted to arc content) or broad (i.e. includes all context recipes).
* InitPopulation can fetches either all recipes from the RecipeIndex or only those matching active recipe slots or handles.