### PR TITLE
Prepare to tag v0.4.1 stable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Tagged release URLs have the form
 (the list of releases is
 [here](https://github.com/PolymerLabs/arcs-live/releases)). A recent version
 (latest as of this writing) is
-[v0.3.5](https://cdn.rawgit.com/PolymerLabs/arcs-live/v0.3.5/shell/apps/web/index.html).
+[v0.4.1](https://cdn.rawgit.com/PolymerLabs/arcs-live/v0.4.1/shell/apps/web/index.html).
 
 Bleeding edge often works and is available via github pages:
 https://polymerlabs.github.io/arcs-live/shell/apps/web/.

--- a/shell/apps/common/firebase-config.js
+++ b/shell/apps/common/firebase-config.js
@@ -16,7 +16,7 @@ const config = (() => {
   if (!testFirebaseKey) {
     return {
       // arc data is under this child node on database root
-      version: '0_4-alpha',
+      version: '0_4_1',
       server: 'arcs-storage.firebaseio.com',
       apiKey: 'AIzaSyBme42moeI-2k8WgXh-6YK_wYyjEXo4Oz8',
       authDomain: 'arcs-storage.firebaseapp.com',


### PR DESCRIPTION
Following https://github.com/PolymerLabs/arcs#releasing

```
current: 0_4-alpha
last release: 0.3.5

old mainline: 0_4-alpha
new mainline: 0_4_1-alpha
new stable: 0_4_1
```