### PR TITLE
Makes dataflow relaxed about missing particleId

### DIFF
--- a/devtools/src/arcs-dataflow.js
+++ b/devtools/src/arcs-dataflow.js
@@ -297,7 +297,10 @@ class ArcsDataflow extends PolymerElement {
 
   _listUnique(extract) {
     let bag = {};
-    this.selectedArcLog.map(event => bag[extract(event).id] = extract(event));
+    this.selectedArcLog.forEach(event => {
+      let extracted = extract(event);
+      if (extracted) bag[extracted.id] = extracted;
+    });
     return Object.values(bag).sort((x, y) => this._compareIds(x.id, y.id));
   }
 

--- a/runtime/debug/outer-port-attachment.js
+++ b/runtime/debug/outer-port-attachment.js
@@ -37,13 +37,14 @@ export class OuterPortAttachment {
     }
   }
 
-  // TODO: particle IDs for proxy calls?
   onInitializeProxy({handle, callback}) {
-    this._callbackRegistry[callback] = this._describeHandleCall({operation: 'on-change', handle});
+    this._callbackRegistry[callback] = this._describeHandleCall(
+      {operation: 'on-change', handle});
   }
 
   onSynchronizeProxy({handle, callback}) {
-    this._callbackRegistry[callback] = this._describeHandleCall({operation: 'sync-model', handle});
+    this._callbackRegistry[callback] = this._describeHandleCall(
+      {operation: 'sync-model', handle});
   }
 
   onHandleGet({handle, callback, particleId}) {
@@ -83,11 +84,12 @@ export class OuterPortAttachment {
   }
 
   _describeHandleCall({operation, handle, particleId}) {
-    return Object.assign(this._arcMetadata(), {
+    let metadata = Object.assign(this._arcMetadata(), {
       operation,
-      particle: this._describeParticle(particleId),
       handle: this._describeHandle(handle)
     });
+    if (particleId) metadata.particle = this._describeParticle(particleId);
+    return metadata;
   }
 
   _arcMetadata() {


### PR DESCRIPTION
Which is missing for proxy related calls after the Particle API rewrite.