### PR TITLE
Some improvements to arcs-tracing panel

### DIFF
--- a/tracelib/test/trace-tests.js
+++ b/tracelib/test/trace-tests.js
@@ -142,6 +142,10 @@ describe('Tracing', function() {
     assertFlowEnclosedInComplete(flowStartEvent, completeEvents[0]);
     assertFlowEnclosedInComplete(flowStepEvent, completeEvents[1]);
     assertFlowEnclosedInComplete(flowEndEvent, completeEvents[2]);
+
+    let flowId = flowStartEvent.id;
+    assert.isTrue([flowStepEvent, flowEndEvent].every(event => event.id === flowId));
+    assert.isTrue(completeEvents.every(event => event.flowId === flowId));
   });
 
   it('traces an asynchronous event with endWith', async () => {


### PR DESCRIPTION
Adds a 'flowId' attribute to duration events linked by the flow (not in chrome tracing spec), which makes various things easier:
- Adding the duration of an entire async in our tracing displayer.
- Expand visualization of the async 'background' to encompass start and end event.