### PR TITLE
Adds traces of speculative execution

### DIFF
--- a/devtools/src/arcs-tracing.js
+++ b/devtools/src/arcs-tracing.js
@@ -69,7 +69,7 @@ $_documentContainer.innerHTML = `<dom-module id="arcs-tracing">
             [[_selectedItem.group]]: [[_selectedItem.content]]
             <hr>
             <div>Sync duration: [[_syncDurationDetail(_selectedItem)]]</div>
-            <template is="dom-if" if="[[_selectedItem.flowId !== undefined]]">
+            <template is="dom-if" if="[[_isAsyncEvent(_selectedItem)]]">
               <div>Async duration: [[_asyncDurationDetail(_selectedItem)]]</div>
             </template>
             <div>Start: [[_startTimeDetail(_selectedItem)]]</div>
@@ -145,8 +145,13 @@ class ArcsTracing extends PolymerElement {
             visible: this.active
           });
 
-          let subgroup = trace.name;
-          if (subgroup.endsWith(' (async)')) subgroup = subgroup.slice(0, -8);
+          let subgroup;
+          if (trace.seq) {
+            subgroup = trace.seq;
+          } else {
+            subgroup = trace.name;
+            if (subgroup.endsWith(' (async)')) subgroup = subgroup.slice(0, -8);
+          }
 
           if (trace.ph === 'X') { // Duration event.
             let start = Math.floor(trace.ts / 1000 + this._timeBase);
@@ -275,6 +280,10 @@ class ArcsTracing extends PolymerElement {
 
   _syncDurationDetail(item) {
     return this._displayDuration(item.dur);
+  }
+
+  _isAsyncEvent(item) {
+    return item.flowId !== undefined;
   }
 
   _asyncDurationDetail(item) {

--- a/runtime/recipe-index.js
+++ b/runtime/recipe-index.js
@@ -33,7 +33,7 @@ const IndexStrategies = [
 
 export class RecipeIndex {
   constructor(context) {
-    let trace = Tracing.start({cat: 'index', name: 'RecipeIndex::constructor', overview: true});
+    let trace = Tracing.start({cat: 'indexing', name: 'RecipeIndex::constructor', overview: true});
     let arcStub = new Arc({
       id: 'index-stub',
       slotComposer: new SlotComposer({affordance: 'mock', noRoot: true}),

--- a/runtime/speculator.js
+++ b/runtime/speculator.js
@@ -27,7 +27,6 @@ export class Speculator {
       }
     }
 
-    let trace = Tracing.start({cat: 'speculator', name: 'Speculator::speculate'});
     let newArc = await arc.cloneForSpeculativeExecution();
     let relevance = new Relevance(arc.getStoresState());
     let relevanceByHash = this._relevanceByHash;
@@ -45,6 +44,6 @@ export class Speculator {
       }
     }
 
-    return trace.endWith(newArc.instantiate(plan).then(a => awaitCompletion()));
+    return newArc.instantiate(plan).then(a => awaitCompletion());
   }
 }

--- a/tracelib/trace.js
+++ b/tracelib/trace.js
@@ -125,21 +125,24 @@ function init() {
       addArgs: function(extraArgs) {
         args = Object.assign(args || {}, extraArgs);
       },
-      end: function(endInfo, flow) {
-        if (endInfo && endInfo.args) {
+      end: function(endInfo = {}, flow) {
+        endInfo = parseInfo(endInfo);
+        if (endInfo.args) {
           args = Object.assign(args || {}, endInfo.args);
         }
+        endInfo = Object.assign({}, info, endInfo);
         this.endTs = now();
         pushEvent({
           ph: 'X',
           ts: begin,
           dur: this.endTs - begin,
-          cat: info.cat,
-          name: info.name,
-          ov: info.overview,
+          cat: endInfo.cat,
+          name: endInfo.name,
+          ov: endInfo.overview,
           args: args,
           // Arcs Devtools Specific:
-          flowId: flow && flow.id()
+          flowId: flow && flow.id(),
+          seq: endInfo.sequence
         });
       },
       beginTs: begin
@@ -148,7 +151,7 @@ function init() {
   module.exports.start = function(info) {
     let trace = startSyncTrace(info);
     let flow;
-    let baseInfo = {cat: info.cat, name: info.name + ' (async)', overview: info.overview};
+    let baseInfo = {cat: info.cat, name: info.name + ' (async)', overview: info.overview, sequence: info.sequence};
     return {
       async wait(v, info) {
         let flowExisted = !!flow;
@@ -208,6 +211,7 @@ function init() {
           ov: info.overview,
           args: info.args,
           id: id,
+          seq: info.sequence
         });
         return this;
       },
@@ -224,6 +228,7 @@ function init() {
           ov: info.overview,
           args: endInfo && endInfo.args,
           id: id,
+          seq: info.sequence
         });
         return this;
       },
@@ -239,6 +244,7 @@ function init() {
           ov: info.overview,
           args: stepInfo && stepInfo.args,
           id: id,
+          seq: info.sequence
         });
         return this;
       },


### PR DESCRIPTION
Adds traces of speculative execution, sliced by suggestion and divided into groups.
<img width="929" alt="screen shot 2018-06-27 at 5 43 21 pm" src="https://user-images.githubusercontent.com/26159485/41960045-02b469e4-7a32-11e8-9be3-7b2ee036c2a1.png">

To do that I added an extra parameter `sequence` which can be added on a trace to ensure seemingly unrelated traces are rendered in the same line in DevTools.

I also allowed assigning trace parameters (e.g. name) in the end() call, which is useful here.
