### PR TITLE
Track originating particle for mutations from pec

### DIFF
--- a/runtime/handle.js
+++ b/runtime/handle.js
@@ -139,7 +139,7 @@ class Collection extends Handle {
           update.added = this._restore(details.add);
         if ('remove' in details)
           update.removed = this._restore(details.remove);
-        update.originator = details.originator == this._particleId;
+        update.originator = details.originatorId == this._particleId;
         particle.onHandleUpdate(this, update);
         return;
       }

--- a/runtime/handle.js
+++ b/runtime/handle.js
@@ -139,6 +139,7 @@ class Collection extends Handle {
           update.added = this._restore(details.add);
         if ('remove' in details)
           update.removed = this._restore(details.remove);
+        update.originator = details.originator == this._particleId;
         particle.onHandleUpdate(this, update);
         return;
       }

--- a/runtime/particle-execution-host.js
+++ b/runtime/particle-execution-host.js
@@ -56,10 +56,10 @@ export class ParticleExecutionHost {
       this._apiPort.SimpleCallback({callback, data: await handle.toList()});
     };
 
-    this._apiPort.onHandleSet = ({handle, data}) => {handle.set(data);};
-    this._apiPort.onHandleStore = ({handle, data}) => handle.store(data);
-    this._apiPort.onHandleClear = ({handle}) => handle.clear();
-    this._apiPort.onHandleRemove = ({handle, data}) => handle.remove(data);
+    this._apiPort.onHandleSet = ({handle, data, particleId}) => handle.set(data, particleId);
+    this._apiPort.onHandleStore = ({handle, data, particleId}) => handle.store(data, particleId);
+    this._apiPort.onHandleClear = ({handle, particleId}) => handle.clear(particleId);
+    this._apiPort.onHandleRemove = ({handle, data, particleId}) => handle.remove(data, particleId);
 
     this._apiPort.onIdle = ({version, relevance}) => {
       if (version == this._idleVersion) {

--- a/runtime/storage/in-memory-storage.js
+++ b/runtime/storage/in-memory-storage.js
@@ -128,7 +128,7 @@ class InMemoryCollection extends InMemoryStorageProvider {
     return {list: [...this._items.values()], version: this._version};
   }
 
-  async store(entity) {
+  async store(entity, originator) {
     let trace = Tracing.start({cat: 'handle', name: 'InMemoryCollection::store', args: {name: this.name}});
     let entityWasPresent = this._items.has(entity.id);
     if (entityWasPresent && (JSON.stringify(this._items.get(entity.id)) == JSON.stringify(entity))) {
@@ -138,11 +138,11 @@ class InMemoryCollection extends InMemoryStorageProvider {
     this._items.set(entity.id, entity);
     this._version++;
     if (!entityWasPresent)
-      this._fire('change', {add: [entity], version: this._version});
+      this._fire('change', {add: [entity], version: this._version, originator});
     trace.end({args: {entity}});
   }
 
-  async remove(id) {
+  async remove(id, originator) {
     let trace = Tracing.start({cat: 'handle', name: 'InMemoryCollection::remove', args: {name: this.name}});
     if (!this._items.has(id)) {
       return;
@@ -150,7 +150,7 @@ class InMemoryCollection extends InMemoryStorageProvider {
     let entity = this._items.get(id);
     assert(this._items.delete(id));
     this._version++;
-    this._fire('change', {remove: [entity], version: this._version});
+    this._fire('change', {remove: [entity], version: this._version, originator});
     trace.end({args: {entity}});
   }
 
@@ -200,16 +200,16 @@ class InMemoryVariable extends InMemoryStorageProvider {
     return {data: this._stored, version: this._version};
   }
 
-  async set(entity) {
+  async set(entity, originator) {
     if (JSON.stringify(this._stored) == JSON.stringify(entity))
       return;
     this._stored = entity;
     this._version++;
-    this._fire('change', {data: this._stored, version: this._version});
+    this._fire('change', {data: this._stored, version: this._version, originator});
   }
 
-  async clear() {
-    this.set(null);
+  async clear(originator) {
+    this.set(null, originator);
   }
 
   serializedData() {

--- a/runtime/storage/in-memory-storage.js
+++ b/runtime/storage/in-memory-storage.js
@@ -128,7 +128,7 @@ class InMemoryCollection extends InMemoryStorageProvider {
     return {list: [...this._items.values()], version: this._version};
   }
 
-  async store(entity, originator) {
+  async store(entity, originatorId) {
     let trace = Tracing.start({cat: 'handle', name: 'InMemoryCollection::store', args: {name: this.name}});
     let entityWasPresent = this._items.has(entity.id);
     if (entityWasPresent && (JSON.stringify(this._items.get(entity.id)) == JSON.stringify(entity))) {
@@ -138,11 +138,11 @@ class InMemoryCollection extends InMemoryStorageProvider {
     this._items.set(entity.id, entity);
     this._version++;
     if (!entityWasPresent)
-      this._fire('change', {add: [entity], version: this._version, originator});
+      this._fire('change', {add: [entity], version: this._version, originatorId});
     trace.end({args: {entity}});
   }
 
-  async remove(id, originator) {
+  async remove(id, originatorId) {
     let trace = Tracing.start({cat: 'handle', name: 'InMemoryCollection::remove', args: {name: this.name}});
     if (!this._items.has(id)) {
       return;
@@ -150,7 +150,7 @@ class InMemoryCollection extends InMemoryStorageProvider {
     let entity = this._items.get(id);
     assert(this._items.delete(id));
     this._version++;
-    this._fire('change', {remove: [entity], version: this._version, originator});
+    this._fire('change', {remove: [entity], version: this._version, originatorId});
     trace.end({args: {entity}});
   }
 
@@ -200,16 +200,16 @@ class InMemoryVariable extends InMemoryStorageProvider {
     return {data: this._stored, version: this._version};
   }
 
-  async set(entity, originator) {
+  async set(entity, originatorId) {
     if (JSON.stringify(this._stored) == JSON.stringify(entity))
       return;
     this._stored = entity;
     this._version++;
-    this._fire('change', {data: this._stored, version: this._version, originator});
+    this._fire('change', {data: this._stored, version: this._version, originatorId});
   }
 
-  async clear(originator) {
-    this.set(null, originator);
+  async clear(originatorId) {
+    this.set(null, originatorId);
   }
 
   serializedData() {

--- a/runtime/test/storage-proxy-test.js
+++ b/runtime/test/storage-proxy-test.js
@@ -44,17 +44,17 @@ class TestVariable {
   //  sendEvent: if true, send an update event to attached listeners.
   //  version: optionally override the current version being incremented.
 
-  set(entity, {sendEvent = true, version, originator} = {}) {
+  set(entity, {sendEvent = true, version, originatorId} = {}) {
     this._stored = entity;
     this._version = (version !== undefined) ? version : this._version + 1;
     if (sendEvent) {
-      let event = {data: this._stored, version: this._version, originator};
+      let event = {data: this._stored, version: this._version, originatorId};
       this._listeners.forEach(cb => cb(event));
     }
   }
 
-  clear({sendEvent = true, version, originator} = {}) {
-    this.set(null, {sendEvent, version, originator});
+  clear({sendEvent = true, version, originatorId} = {}) {
+    this.set(null, {sendEvent, version, originatorId});
   }
 }
 
@@ -84,24 +84,24 @@ class TestCollection {
   //  sendEvent: if true, send an update event to attached listeners.
   //  version: optionally override the current version being incremented.
 
-  store(id, entity, {sendEvent = true, version, originator} = {}) {
+  store(id, entity, {sendEvent = true, version, originatorId} = {}) {
     let entry = {id, rawData: entity.rawData};
     this._items.set(id, entry);
     this._version = (version !== undefined) ? version : this._version + 1;
     if (sendEvent) {
-      let event = {add: [entry], version: this._version, originator};
+      let event = {add: [entry], version: this._version, originatorId};
       this._listeners.forEach(cb => cb(event));
     }
   }
 
-  remove(id, {sendEvent = true, version, originator} = {}) {
+  remove(id, {sendEvent = true, version, originatorId} = {}) {
     let entry = this._items.get(id);
     assert.notStrictEqual(entry, undefined,
            `Test bug: attempt to remove non-existent id '${id}' from '${this.name}'`);
     this._items.delete(id);
     this._version = (version !== undefined) ? version : this._version + 1;
     if (sendEvent) {
-      let event = {remove: [entry], version: this._version, originator};
+      let event = {remove: [entry], version: this._version, originatorId};
       this._listeners.forEach(cb => cb(event));
     }
   }
@@ -786,13 +786,13 @@ describe('storage-proxy', function() {
     await engine.verify('InitializeProxy:bar', 'SynchronizeProxy:bar',
                         'onHandleSync:P1:bar:[]', 'onHandleSync:P2:bar:[]');
 
-    barStore.store('i1', engine.newEntity('v1'), {originator: particle1.id});
+    barStore.store('i1', engine.newEntity('v1'), {originatorId: particle1.id});
 
     await engine.verifySubsequence('onHandleUpdate:P1:bar:+[v1](originator)');
     await engine.verifySubsequence('onHandleUpdate:P2:bar:+[v1]');
     await engine.verify();
 
-    barStore.store('i2', engine.newEntity('v2'), {originator: particle2.id});
+    barStore.store('i2', engine.newEntity('v2'), {originatorId: particle2.id});
 
     await engine.verifySubsequence('onHandleUpdate:P1:bar:+[v2]');
     await engine.verifySubsequence('onHandleUpdate:P2:bar:+[v2](originator)');

--- a/runtime/test/storage-proxy-test.js
+++ b/runtime/test/storage-proxy-test.js
@@ -44,17 +44,17 @@ class TestVariable {
   //  sendEvent: if true, send an update event to attached listeners.
   //  version: optionally override the current version being incremented.
 
-  set(entity, {sendEvent = true, version} = {}) {
+  set(entity, {sendEvent = true, version, originator} = {}) {
     this._stored = entity;
     this._version = (version !== undefined) ? version : this._version + 1;
     if (sendEvent) {
-      let event = {data: this._stored, version: this._version};
+      let event = {data: this._stored, version: this._version, originator};
       this._listeners.forEach(cb => cb(event));
     }
   }
 
-  clear({sendEvent = true, version} = {}) {
-    this.set(null, {sendEvent, version});
+  clear({sendEvent = true, version, originator} = {}) {
+    this.set(null, {sendEvent, version, originator});
   }
 }
 
@@ -84,24 +84,24 @@ class TestCollection {
   //  sendEvent: if true, send an update event to attached listeners.
   //  version: optionally override the current version being incremented.
 
-  store(id, entity, {sendEvent = true, version} = {}) {
+  store(id, entity, {sendEvent = true, version, originator} = {}) {
     let entry = {id, rawData: entity.rawData};
     this._items.set(id, entry);
     this._version = (version !== undefined) ? version : this._version + 1;
     if (sendEvent) {
-      let event = {add: [entry], version: this._version};
+      let event = {add: [entry], version: this._version, originator};
       this._listeners.forEach(cb => cb(event));
     }
   }
 
-  remove(id, {sendEvent = true, version} = {}) {
+  remove(id, {sendEvent = true, version, originator} = {}) {
     let entry = this._items.get(id);
     assert.notStrictEqual(entry, undefined,
            `Test bug: attempt to remove non-existent id '${id}' from '${this.name}'`);
     this._items.delete(id);
     this._version = (version !== undefined) ? version : this._version + 1;
     if (sendEvent) {
-      let event = {remove: [entry], version: this._version};
+      let event = {remove: [entry], version: this._version, originator};
       this._listeners.forEach(cb => cb(event));
     }
   }
@@ -128,6 +128,9 @@ class TestParticle {
     }
     if ('removed' in update) {
       details += '-' + this._toString(update.removed);
+    }
+    if (update.originator) {
+      details += '(originator)';
     }
     this._report(['onHandleUpdate', this.id, handle.name, details].join(':'));
   }
@@ -764,5 +767,35 @@ describe('storage-proxy', function() {
     engine.sendSync(fooStore);
     fooStore.set(engine.newEntity('z'));
     await engine.verify('SynchronizeProxy:foo', 'onHandleSync:P3:foo:y', 'onHandleUpdate:P2:foo:z');
+  });
+
+  it('delivers the originator status to the originating particle', async () => {
+    let engine = new TestEngine();
+    let barStore = engine.newCollection('bar');
+    let barProxy = engine.newProxy(barStore);
+
+    let particle1 = engine.newParticle();
+    let particle2 = engine.newParticle();
+    let barHandle1 = engine.newHandle(barStore, barProxy, particle1, CAN_READ, CAN_WRITE);
+    let barHandle2 = engine.newHandle(barStore, barProxy, particle2, CAN_READ, CAN_WRITE);
+
+    barProxy.register(particle1, barHandle1);
+    barProxy.register(particle2, barHandle2);
+    engine.sendSync(barStore);
+
+    await engine.verify('InitializeProxy:bar', 'SynchronizeProxy:bar',
+                        'onHandleSync:P1:bar:[]', 'onHandleSync:P2:bar:[]');
+
+    barStore.store('i1', engine.newEntity('v1'), {originator: particle1.id});
+
+    await engine.verifySubsequence('onHandleUpdate:P1:bar:+[v1](originator)');
+    await engine.verifySubsequence('onHandleUpdate:P2:bar:+[v1]');
+    await engine.verify();
+
+    barStore.store('i2', engine.newEntity('v2'), {originator: particle2.id});
+
+    await engine.verifySubsequence('onHandleUpdate:P1:bar:+[v2]');
+    await engine.verifySubsequence('onHandleUpdate:P2:bar:+[v2](originator)');
+    await engine.verify();
   });
 });


### PR DESCRIPTION
All mutation messages from PEC thread the originating particle ID. This
is echoed back in any events generated by storage.

Before delivery to the particle, the originator is converted to a boolean
flag.