### PR TITLE
Stops test-helper from setting arc._context

### DIFF
--- a/runtime/test/debug/outer-port-attachments-tests.js
+++ b/runtime/test/debug/outer-port-attachments-tests.js
@@ -24,17 +24,17 @@ describe('OuterPortAttachment', function() {
   after(() => DevtoolsForTests.reset());
   it('produces dataflow messages on devtools channel', async () => {
     Random.seedForTests();
-    const testHelper = new TestHelper({
+    const testHelper = await TestHelper.create({
+      manifestString: `
+        schema Foo
+          Text value
+        particle P in 'p.js'
+          inout Foo foo
+        recipe
+          use as foo
+          P
+            foo = foo`,
       loader: new StubLoader({
-        'manifest': `
-          schema Foo
-            Text value
-          particle P in 'p.js'
-            inout Foo foo
-          recipe
-            use as foo
-            P
-              foo = foo`,
         'p.js': `defineParticle(({Particle}) => class P extends Particle {
           async setHandles(handles) {
             let foo = handles.get('foo');
@@ -43,7 +43,6 @@ describe('OuterPortAttachment', function() {
         });`
       })
     });
-    await testHelper.loadManifest('manifest');
     const arc = testHelper.arc;
 
     const Foo = arc._context.findSchemaByName('Foo').entityClass();

--- a/runtime/test/demo-flow-test.js
+++ b/runtime/test/demo-flow-test.js
@@ -22,7 +22,8 @@ describe('demo flow', function() {
   });
 
   it('flows like a demo', async function() {
-    let helper = await TestHelper.loadManifestAndPlan('./shell/artifacts/Products/Products.recipes', {
+    let helper = await TestHelper.createAndPlan({
+      manifestFilename: './shell/artifacts/Products/Products.recipes',
       expectedNumPlans: 2,
       verify: async (plans) => {
         let descriptions = await Promise.all(plans.map(plan => plan.description.getRecipeSuggestion()));

--- a/runtime/test/multiplexer-test.js
+++ b/runtime/test/multiplexer-test.js
@@ -71,8 +71,9 @@ describe('Multiplexer', function() {
   });
 
   it('renders polymorphic multiplexed slots', async function() {
-    let helper = new TestHelper();
-    await helper.loadManifest('./runtime/test/particles/artifacts/polymorphic-muxing.recipes');
+    let helper = await TestHelper.create({
+      manifestFilename: './runtime/test/particles/artifacts/polymorphic-muxing.recipes'
+    });
     let context = helper.arc._context;
 
     let showOneParticle = context.particles.find(p => p.name == 'ShowOne');

--- a/runtime/test/particle-api-test.js
+++ b/runtime/test/particle-api-test.js
@@ -16,8 +16,10 @@ import {StubLoader} from '../testing/stub-loader.js';
 import {TestHelper} from '../testing/test-helper.js';
 
 async function loadFilesIntoNewArc(fileMap) {
-  const testHelper = new TestHelper({loader: new StubLoader(fileMap)});
-  await testHelper.loadManifest('manifest');
+  const testHelper = await TestHelper.create({
+    manifestString: fileMap.manifest,
+    loader: new StubLoader(fileMap)
+  });
   return {
     arc: testHelper.arc,
     manifest: testHelper.arc._context

--- a/runtime/test/particles/common-test.js
+++ b/runtime/test/particles/common-test.js
@@ -38,7 +38,7 @@ describe('common particles test', function() {
     CopyCollection
       input <- smallthings
       output -> things
-  
+
   resource BigThings
     start
     [
@@ -46,7 +46,7 @@ describe('common particles test', function() {
       {"name": "car"}
     ]
   store Store0 of [Thing] 'bigthings' in BigThings
-  
+
   resource SmallThings
     start
     [
@@ -56,7 +56,7 @@ describe('common particles test', function() {
     ]
   store Store1 of [Thing] 'smallthings' in SmallThings
     `);
-  
+
     let recipe = manifest.recipes[0];
     let newRecipe = recipe.clone();
     recipe.normalize();
@@ -67,9 +67,11 @@ describe('common particles test', function() {
 
 
   it('copy handle test', async () => {
-    let helper = await TestHelper.loadManifestAndPlan(
-        './runtime/test/particles/artifacts/copy-collection-test.recipes',
-        {expectedNumPlans: 1, expectedSuggestions: ['Copy all things!']});
+    let helper = await TestHelper.createAndPlan({
+      manifestFilename: './runtime/test/particles/artifacts/copy-collection-test.recipes',
+      expectedNumPlans: 1,
+      expectedSuggestions: ['Copy all things!']
+    });
     assert.isEmpty(helper.arc._stores);
 
     await helper.acceptSuggestion({particles: ['CopyCollection', 'CopyCollection']});

--- a/runtime/test/particles/multi-slot-test.js
+++ b/runtime/test/particles/multi-slot-test.js
@@ -15,16 +15,16 @@ import {TestHelper} from '../../testing/test-helper.js';
 
 describe('multi-slot test', function() {
   async function init() {
-    return await TestHelper.loadManifestAndPlan(
-      './runtime/test/particles/artifacts/multi-slot-test.manifest', {
-        expectedNumPlans: 4,
-        expectedSuggestions: ['Show question.', 'Show answer.', 'Show question and answer.', 'Show question and hints.']
+    return await TestHelper.createAndPlan({
+      manifestFilename: './runtime/test/particles/artifacts/multi-slot-test.manifest',
+      expectedNumPlans: 4,
+      expectedSuggestions: ['Show question.', 'Show answer.', 'Show question and answer.', 'Show question and hints.']
     });
   }
 
   let verifyHandler = (expectedSlotNames, particleName, slotName, content) => {
     assert.isTrue(expectedSlotNames.includes(slotName), `Unexpected slot ${slotName}`);
- 
+
     assert.isTrue(content.template.includes(`{{${slotName}}}`));
     let exclude = slotName == 'question' ? 'answer' : 'question';
     assert.isFalse(content.template.includes(`{{${exclude}}}`));

--- a/runtime/test/particles/products-test.js
+++ b/runtime/test/particles/products-test.js
@@ -14,7 +14,7 @@ import {assert} from '../chai-web.js';
 import {TestHelper} from '../../testing/test-helper.js';
 
 describe('products test', function() {
-  let testProductsManifestFile = './runtime/test/particles/artifacts/products-test.recipes';
+  let manifestFilename = './runtime/test/particles/artifacts/products-test.recipes';
 
   let verifyFilteredBook = async (handle) => {
     let list = await handle.toList();
@@ -23,7 +23,7 @@ describe('products test', function() {
   };
 
   it('filters', async function() {
-    let helper = await TestHelper.loadManifestAndPlan(testProductsManifestFile);
+    let helper = await TestHelper.createAndPlan({manifestFilename});
 
     await helper.acceptSuggestion({particles: ['ProductFilter']});
 
@@ -31,7 +31,7 @@ describe('products test', function() {
   });
 
   it('filters and displays', async function() {
-    let helper = await TestHelper.loadManifestAndPlan(testProductsManifestFile);
+    let helper = await TestHelper.createAndPlan({manifestFilename});
 
     helper.slotComposer
         .newExpectations()

--- a/runtime/test/particles/transformation-slots-test.js
+++ b/runtime/test/particles/transformation-slots-test.js
@@ -14,8 +14,10 @@ import {TestHelper} from '../../testing/test-helper.js';
 
 describe('transformation slots', function() {
   it('combines hosted particles provided singleton slots into transformation provided set slot', async () => {
-    let helper = await TestHelper.loadManifestAndPlan(
-      './runtime/test/particles/artifacts/provide-hosted-particle-slots.manifest', {expectedNumPlans: 1});
+    let helper = await TestHelper.createAndPlan({
+      manifestFilename: './runtime/test/particles/artifacts/provide-hosted-particle-slots.manifest',
+      expectedNumPlans: 1
+    });
 
     helper.slotComposer
       .newExpectations()


### PR DESCRIPTION
We should not swap arc._context after arc instantiation, as some subcomponents might read arc.context at instantiation time. This is what recipe-index is doing and this refactoring unlocks taking init-population from the recipe-index.

I propose TestHelper.create(options) factory method which can take manifest filename or manifest string and creates the context before arc instantiation. With this we can remove (load|parse)Manifest methods and replace (load|parse)ManifestAndPlan with createAndPlan.