### PR TITLE
Arguments for Strategies

### DIFF
--- a/runtime/arc.js
+++ b/runtime/arc.js
@@ -63,7 +63,6 @@ export class Arc {
     // Map from each store to its description (originating in the manifest).
     this._storeDescriptions = new Map();
 
-    this._search = null;
     this._description = new Description(this);
 
     this._instantiatePlanCallbacks = [];
@@ -74,14 +73,6 @@ export class Arc {
   }
   get loader() {
     return this._loader;
-  }
-
-  set search(search) {
-    this._search = search ? search.toLowerCase().trim() : null;
-  }
-
-  get search() {
-    return this._search;
   }
 
   get description() {

--- a/runtime/planificator.js
+++ b/runtime/planificator.js
@@ -92,6 +92,7 @@ export class Planificator {
   constructor(arc, options) {
     this._arc = arc;
     this._speculator = new Speculator();
+    this._search = null;
 
     // The currently running Planner object.
     this._planner = null;
@@ -182,11 +183,11 @@ export class Planificator {
       return;
     }
 
-    if (this._arc.search !== search) {
-      this._arc.search = search;
+    if (this._search !== search) {
+      this._search = search;
       this._requestPlanning({
         cancelOngoingPlanning: true,
-        strategies: [InitSearch].concat(Planner.ResolutionStrategies).map(strategy => new strategy(this._arc)),
+        strategies: [InitSearch].concat(Planner.ResolutionStrategies),
         append: true
       });
     }
@@ -312,7 +313,10 @@ export class Planificator {
   async _doNextPlans(options) {
     this._next = {generations: []};
     this._planner = new Planner();
-    this._planner.init(this._arc, {strategies: (options.strategies || null)});
+    this._planner.init(this._arc, {
+      strategies: (options.strategies || null),
+      strategyArgs: {search: this._search}
+    });
     this._next.plans = await this._planner.suggest(options.timeout || defaultTimeoutMs, this._next.generations, this._speculator);
     this._planner = null;
   }

--- a/runtime/planner.js
+++ b/runtime/planner.js
@@ -42,9 +42,10 @@ export class Planner {
   }
 
   // TODO: Use context.arc instead of arc
-  init(arc, {strategies, ruleset} = {}) {
+  init(arc, {strategies, ruleset, strategyArgs = {}} = {}) {
+    strategyArgs = Object.freeze(Object.assign({}, strategyArgs));
     this._arc = arc;
-    strategies = strategies || Planner.AllStrategies.map(strategy => new strategy(arc));
+    strategies = (strategies || Planner.AllStrategies).map(strategy => new strategy(arc, strategyArgs));
     this.strategizer = new Strategizer(strategies, [], ruleset || Rulesets.Empty);
   }
 

--- a/runtime/strategies/init-search.js
+++ b/runtime/strategies/init-search.js
@@ -10,10 +10,9 @@ import {Recipe} from '../recipe/recipe.js';
 import {assert} from '../../platform/assert-web.js';
 
 export class InitSearch extends Strategy {
-  constructor(arc) {
+  constructor(arc, {search}) {
     super();
-    // TODO: Figure out where this should really come from.
-    this._search = arc.search;
+    this._search = search;
   }
   async generate({generation}) {
     if (this._search == null || generation != 0) {

--- a/runtime/test/strategies/init-search-tests.js
+++ b/runtime/test/strategies/init-search-tests.js
@@ -9,16 +9,12 @@
  */
 'use strict';
 
-import {Arc} from '../../arc.js';
 import {InitSearch} from '../../strategies/init-search.js';
-import {Manifest} from '../../manifest.js';
 import {assert} from '../chai-web.js';
 
 describe('InitSearch', async () => {
   it('initializes the search recipe', async () => {
-    let arc = new Arc({id: 'test-plan-arc', context: new Manifest({id: 'test'})});
-    arc._search = 'search';
-    let initSearch = new InitSearch(arc);
+    let initSearch = new InitSearch(null, {search: 'search'});
     let inputParams = {generated: [], generation: 0};
     let results = await initSearch.generate(inputParams);
     assert.lengthOf(results, 1);


### PR DESCRIPTION
Introduces a new object containing arguments for strategies. This allows us to move 'search' off from the Arc and pass it directly from the Planificator to strategies.

I'm proposing this in preparation for the InitStrategy switching between contextual vs. all recipes (as discussed in #1551). I think this switch should be governed by the Planificator, so that it knows whether the returned plans contain only arc-relevant or all suggestions and so that it can order a planning with all context recipes (e.g. for a '*' query). This switch for a broad vs. narrow init population would then be passed via this newly introduced argument object, as today it could only live on an Arc.

Let me know what you think.