### PR TITLE
Standardize on `createStore` for manifest and arc API

### DIFF
--- a/runtime/manifest.js
+++ b/runtime/manifest.js
@@ -151,9 +151,9 @@ export class Manifest {
   }
   // TODO: newParticle, Schema, etc.
   // TODO: simplify() / isValid().
-  async createStore(type, name, id, tags) {
+  async createStore(type, name, id, tags, storageKey) {
     assert(!type.hasVariableReference, `stores can't have variable references`);
-    let store = await this.storageProviderFactory.construct(id, type, `in-memory://${this.id}`);
+    let store = await this.storageProviderFactory.construct(id, type, storageKey || `in-memory://${this.id}`);
     assert(store._version !== null);
     store.name = name;
     this._storeManifestUrls.set(store.id, this.fileName);

--- a/runtime/manifest.js
+++ b/runtime/manifest.js
@@ -151,7 +151,7 @@ export class Manifest {
   }
   // TODO: newParticle, Schema, etc.
   // TODO: simplify() / isValid().
-  async newStore(type, name, id, tags) {
+  async createStore(type, name, id, tags) {
     assert(!type.hasVariableReference, `stores can't have variable references`);
     let store = await this.storageProviderFactory.construct(id, type, `in-memory://${this.id}`);
     assert(store._version !== null);
@@ -819,7 +819,7 @@ ${e.message}
           let id = `${manifest.generateID()}:${particleSpecHash}:${hostedParticle.name}`;
           targetHandle = recipe.newHandle();
           targetHandle.fate = 'copy';
-          let store = await manifest.newStore(connection.type, null, id, []);
+          let store = await manifest.createStore(connection.type, null, id, []);
           store.set(hostedParticleLiteral);
           targetHandle.mapToStorage(store);
         }
@@ -985,7 +985,7 @@ ${e.message}
     }
   }
   static async _createStore(manifest, type, name, id, tags, item) {
-    let store = await manifest.newStore(type, name, id, tags);
+    let store = await manifest.createStore(type, name, id, tags);
     store.source = item.source;
     store.description = item.description;
     return store;

--- a/runtime/test/planner-tests.js
+++ b/runtime/test/planner-tests.js
@@ -175,9 +175,9 @@ describe('AssignOrCopyRemoteHandles', function() {
       `));
 
       let schema = manifest.findSchemaByName('Foo');
-      manifest.newStore(schema.type.collectionOf(), 'Test1', 'test-1', ['tag1']);
-      manifest.newStore(schema.type.collectionOf(), 'Test2', 'test-2', ['tag2']);
-      manifest.newStore(schema.type.collectionOf(), 'Test2', 'test-3', []);
+      manifest.createStore(schema.type.collectionOf(), 'Test1', 'test-1', ['tag1']);
+      manifest.createStore(schema.type.collectionOf(), 'Test2', 'test-2', ['tag2']);
+      manifest.createStore(schema.type.collectionOf(), 'Test2', 'test-3', []);
 
       let arc = StrategyTestHelper.createTestArc('test-plan-arc', manifest, 'dom');
 

--- a/shell/app-shell/elements/arc-handle.js
+++ b/shell/app-shell/elements/arc-handle.js
@@ -63,8 +63,8 @@ class ArcHandle extends Xen.Debug(Xen.Base, log) {
     id = id || arc.generateID();
     // context-handles are for `map`, `copy`, `?`
     // arc-handles are for `use`, `?`
-    const factory = asContext ? arc.context.newStore.bind(arc.context) : arc.createStore.bind(arc);
-    const handle = await factory(typeOf, name, id, tags, storageKey);
+    const owner = asContext ? arc.context : arc;
+    const handle = await owner.createStore(typeOf, name, id, tags, storageKey);
     if (description) {
       handle.description = description;
     }

--- a/shell/app-shell/elements/cloud-data/cloud-shared-handles.js
+++ b/shell/app-shell/elements/cloud-data/cloud-shared-handles.js
@@ -190,7 +190,7 @@ class CloudSharedHandles extends Xen.Debug(Xen.Base, log) {
   }
   // low-level
   async _requireHandle(arc, id, type, name, tags) {
-    return arc.context.findStoreById(id) || await arc.context.newStore(type, name, id, tags);
+    return arc.context.findStoreById(id) || await arc.context.createStore(type, name, id, tags);
   }
   _addWatch(path, kind, handler) {
     const {watches} = this._state;

--- a/shell/app-shell/lib/arcs-utils.js
+++ b/shell/app-shell/lib/arcs-utils.js
@@ -121,7 +121,7 @@ const ArcsUtils = {
   async _requireHandle(arc, type, name, id, tags) {
     let store = arc.context.findStoreById(id);
     if (!store) {
-      store = await arc.context.newStore(type, name, id, tags);
+      store = await arc.context.createStore(type, name, id, tags);
       log('synthesized handle', id, tags);
     }
     return store;


### PR DESCRIPTION
`manifest.newStore` and `arc.createStore` having different names was a minor inconvenience for the front-end. 

Also, plumbing `storageKey` argument into the manifest store creator was needed.

Now we can simply `createStore` on either context.