### PR TITLE
Last-writer-wins scheme for in-memory variables

### DIFF
--- a/runtime/api-channel.js
+++ b/runtime/api-channel.js
@@ -310,10 +310,10 @@ export class PECInnerPort extends APIPort {
     this.registerCall('SynchronizeProxy', {handle: this.Mapped, callback: this.LocalMapped});
     this.registerCall('HandleGet', {handle: this.Mapped, callback: this.LocalMapped, particleId: this.Direct});
     this.registerCall('HandleToList', {handle: this.Mapped, callback: this.LocalMapped, particleId: this.Direct});
-    this.registerCall('HandleSet', {handle: this.Mapped, data: this.Direct, particleId: this.Direct});
+    this.registerCall('HandleSet', {handle: this.Mapped, data: this.Direct, particleId: this.Direct, barrier: this.Direct});
     this.registerCall('HandleStore', {handle: this.Mapped, data: this.Direct, particleId: this.Direct});
     this.registerCall('HandleRemove', {handle: this.Mapped, data: this.Direct});
-    this.registerCall('HandleClear', {handle: this.Mapped, particleId: this.Direct});
+    this.registerCall('HandleClear', {handle: this.Mapped, particleId: this.Direct, barrier: this.Direct});
     this.registerCall('Idle', {version: this.Direct, relevance: this.Map(this.Mapped, this.Direct)});
 
     this.registerCall('ConstructInnerArc', {callback: this.LocalMapped, particle: this.Mapped});

--- a/runtime/particle-execution-host.js
+++ b/runtime/particle-execution-host.js
@@ -56,9 +56,9 @@ export class ParticleExecutionHost {
       this._apiPort.SimpleCallback({callback, data: await handle.toList()});
     };
 
-    this._apiPort.onHandleSet = ({handle, data, particleId}) => handle.set(data, particleId);
+    this._apiPort.onHandleSet = ({handle, data, particleId, barrier}) => handle.set(data, particleId, barrier);
     this._apiPort.onHandleStore = ({handle, data, particleId}) => handle.store(data, particleId);
-    this._apiPort.onHandleClear = ({handle, particleId}) => handle.clear(particleId);
+    this._apiPort.onHandleClear = ({handle, particleId, barrier}) => handle.clear(particleId, barrier);
     this._apiPort.onHandleRemove = ({handle, data, particleId}) => handle.remove(data, particleId);
 
     this._apiPort.onIdle = ({version, relevance}) => {

--- a/runtime/storage-proxy.js
+++ b/runtime/storage-proxy.js
@@ -281,14 +281,13 @@ class VariableProxy extends StorageProxyBase {
     assert('data' in update);
     // If we have set a barrier, suppress updates until after
     // we have seen the barrier return via an update.
-    if (this._barrier != null && update.barrier != this._barrier) {
+    if (this._barrier != null) {
+      if (update.barrier == this._barrier) {
+        this._barrier = null;
+      }
       return false;
     }
     this._model = update.data;
-    if (this._barrier != null) {
-      this._barrier = null;
-      return false;
-    }
     return true;
   }
   // Read ops: if we're synchronized we can just return the local copy of the data.

--- a/runtime/storage-proxy.js
+++ b/runtime/storage-proxy.js
@@ -158,21 +158,27 @@ class StorageProxyBase {
     this._processUpdates();
   }
 
+  _notify(kind, update, predicate=() => true) {
+    for (let {handle, particle} of this._observers) {
+      if (predicate(handle.options)) {
+        this._scheduler.enqueue(particle, handle, [kind, particle, update]);
+      }
+    }
+  }
+
   _processUpdates() {
     // Consume all queued updates whose versions are monotonically increasing from our stored one.
     while (this._updates.length > 0 && this._updates[0].version === this._version + 1) {
       let update = this._updates.shift();
 
       // Fold the update into our stored model.
-      this._updateModel(update);
+      let notify = this._updateModel(update);
       this._version = update.version;
 
       // Notify handles configured with keepSynced and notifyUpdates (non-keepSynced handles are
       // notified as updates are received).
-      for (let {handle, particle} of this._observers) {
-        if (handle.options.keepSynced && handle.options.notifyUpdate) {
-          this._scheduler.enqueue(particle, handle, ['update', particle, update]);
-        }
+      if (notify) {
+        this._notify('update', update, options => options.keepSynced && options.notifyUpdate);
       }
     }
 
@@ -227,6 +233,7 @@ class CollectionProxy extends StorageProxyBase {
     } else {
       assert(false, `StorageProxy received invalid update event: ${JSON.stringify(update)}`);
     }
+    return true;
   }
   // Read ops: if we're synchronized we can just return the local copy of the data.
   // Otherwise, send a request to the backing store.
@@ -255,10 +262,16 @@ class CollectionProxy extends StorageProxyBase {
   }
 }
 
+// Variables are synchronized in a 'last-writer-wins' scheme. When the
+// VariableProxy mutates the model, it sets a barrier and expects to 
+// receive the barrier value echoed back in a subsequent update event.
+// Between those two points in time updates are not applied or
+// notified about as these reflect concurrent writes that did not 'win'.
 class VariableProxy extends StorageProxyBase {
   constructor(...args) {
     super(...args);
     this._model = null;
+    this._barrier = null;
   }
   _synchronizeModel(model) {
     assert('data' in model);
@@ -266,7 +279,17 @@ class VariableProxy extends StorageProxyBase {
   }
   _updateModel(update) {
     assert('data' in update);
+    // If we have set a barrier, suppress updates until after
+    // we have seen the barrier return via an update.
+    if (this._barrier && update.barrier != this._barrier) {
+      return false;
+    }
     this._model = update.data;
+    if (this._barrier) {
+      this._barrier = null;
+      return false;
+    }
+    return true;
   }
   // Read ops: if we're synchronized we can just return the local copy of the data.
   // Otherwise, send a request to the backing store.
@@ -274,24 +297,41 @@ class VariableProxy extends StorageProxyBase {
   //       sending a parallel request
   get(particleId) {
     if (this._synchronized == SyncState.full) {
-      return new Promise((resolve, reject) => resolve(this._model));
+      return Promise.resolve(this._model);
     } else {
       return new Promise((resolve, reject) =>
-        this._port.HandleGet({callback: r => resolve(r), handle: this, particleId}));
+        this._port.HandleGet({callback: resolve, handle: this, particleId}));
     }
   }
-  // Write ops: in synchronized mode, any write operation will desynchronize the proxy, so
-  // subsequent reads will call to the backing store until resync is established via the update
-  // event triggered by the write.
-  // TODO: handle concurrent writes from other parties to the backing store
   set(entity, particleId) {
-    this._port.HandleSet({data: entity, handle: this, particleId});
-    this._synchronized = SyncState.pending;
+    if (JSON.stringify(this._model) == JSON.stringify(entity)) {
+      return;
+    }
+    let barrier = this._pec.generateID();
+    // TODO: is this already a clone?
+    this._model = JSON.parse(JSON.stringify(entity));
+    this._barrier = barrier;
+    this._port.HandleSet({data: entity, handle: this, particleId, barrier});
+    let update = {
+      originatorId: particleId,
+      data: entity,
+    };
+    this._notify('update', update, options => options.notifyUpdate);
   }
 
   clear(particleId) {
-    this._port.HandleClear({handle: this, particleId});
-    this._synchronized = SyncState.pending;
+    if (this._model == null) {
+      return;
+    }
+    let barrier = this._pec.generateID();
+    this._model = null;
+    this._barrier = barrier;
+    this._port.HandleClear({handle: this, particleId, barrier});
+    let update = {
+      originatorId: particleId,
+      data: null,
+    };
+    this._notify('update', update, options => options.notifyUpdate);
   }
 }
 

--- a/runtime/storage-proxy.js
+++ b/runtime/storage-proxy.js
@@ -281,11 +281,11 @@ class VariableProxy extends StorageProxyBase {
     assert('data' in update);
     // If we have set a barrier, suppress updates until after
     // we have seen the barrier return via an update.
-    if (this._barrier && update.barrier != this._barrier) {
+    if (this._barrier != null && update.barrier != this._barrier) {
       return false;
     }
     this._model = update.data;
-    if (this._barrier) {
+    if (this._barrier != null) {
       this._barrier = null;
       return false;
     }

--- a/runtime/storage/in-memory-storage.js
+++ b/runtime/storage/in-memory-storage.js
@@ -200,16 +200,18 @@ class InMemoryVariable extends InMemoryStorageProvider {
     return {data: this._stored, version: this._version};
   }
 
-  async set(entity, originatorId) {
-    if (JSON.stringify(this._stored) == JSON.stringify(entity))
+  async set(entity, originatorId, barrier) {
+    // If there's a barrier set, then the originating storage-proxy is expecting
+    // a result so we cannot suppress the event here.
+    if (JSON.stringify(this._stored) == JSON.stringify(entity) && !barrier)
       return;
     this._stored = entity;
     this._version++;
-    this._fire('change', {data: this._stored, version: this._version, originatorId});
+    this._fire('change', {data: this._stored, version: this._version, originatorId, barrier});
   }
 
-  async clear(originatorId) {
-    this.set(null, originatorId);
+  async clear(originatorId, barrier) {
+    this.set(null, originatorId, barrier);
   }
 
   serializedData() {

--- a/runtime/storage/in-memory-storage.js
+++ b/runtime/storage/in-memory-storage.js
@@ -203,7 +203,7 @@ class InMemoryVariable extends InMemoryStorageProvider {
   async set(entity, originatorId, barrier) {
     // If there's a barrier set, then the originating storage-proxy is expecting
     // a result so we cannot suppress the event here.
-    if (JSON.stringify(this._stored) == JSON.stringify(entity) && barrier != null)
+    if (JSON.stringify(this._stored) == JSON.stringify(entity) && barrier == null)
       return;
     this._stored = entity;
     this._version++;

--- a/runtime/storage/in-memory-storage.js
+++ b/runtime/storage/in-memory-storage.js
@@ -203,7 +203,7 @@ class InMemoryVariable extends InMemoryStorageProvider {
   async set(entity, originatorId, barrier) {
     // If there's a barrier set, then the originating storage-proxy is expecting
     // a result so we cannot suppress the event here.
-    if (JSON.stringify(this._stored) == JSON.stringify(entity) && !barrier)
+    if (JSON.stringify(this._stored) == JSON.stringify(entity) && barrier != null)
       return;
     this._stored = entity;
     this._version++;

--- a/runtime/testing/test-helper.js
+++ b/runtime/testing/test-helper.js
@@ -186,7 +186,7 @@ export class TestHelper {
    * Awaits particle execution context idleness and mock slot composer expectations completeness.
    */
   async idle() {
-    await this.arc.pec.idle;
+    await this.arc.idle;
     await this.slotComposer.expectationsCompleted();
   }
 


### PR DESCRIPTION
* updates storage-proxy to allow writes to variables to take place
  synchronously without a roundtrip via storage
* uses a barrier scheme to suppress concurrent (but losing) writes

Part of https://github.com/PolymerLabs/arcs/issues/1471