### PR TITLE
Removes the race condition in arcs<->devtools messaging

### DIFF
--- a/devtools/src/arcs-communication-channel.js
+++ b/devtools/src/arcs-communication-channel.js
@@ -3,32 +3,34 @@ import {PolymerElement} from '../deps/@polymer/polymer/polymer-element.js';
 class ArcsCommunicationChannel extends PolymerElement {
   static get is() { return 'arcs-communication-channel'; }
 
-  constructor() {
-    super();
-    this._preInitMsgQueue = [];
-  }
-
   ready() {
-    document.addEventListener('arcs-communication-channel-ready', e => {
+    document.addEventListener('send-message', ({detail}) => {
       if (this._preInitMsgQueue) {
-        for (let msg of this._preInitMsgQueue) {
-          this._fire(msg);
-        }
-        this._preInitMsgQueue = undefined;
+        this._preInitMsgQueue.push(detail);
+      } else {
+        this._fire(detail);
       }
     });
-    document.addEventListener('messages', e => {
-      this.dispatchEvent(new CustomEvent('messages', {detail: e.detail}));
-    });
-  }
-
-  send(messageType, messageBody, targetArcId = null) {
-    let msg = {messageType, messageBody, targetArcId};
-    if (this._preInitMsgQueue) {
-      this._preInitMsgQueue.push(msg);
-    } else {
-      this._fire(msg);
-    }
+    // We perform below after the event loop tick to let other polymer elements
+    // to go through ready() handlers before we let the events in.
+    setTimeout(() => {
+      if (window._msgRaceConditionGuard) {
+        // devtools.js loaded first (most likely in standalone mode),
+        // we'll let it know we're ready to receive.
+        document.dispatchEvent(new Event('arcs-communication-channel-ready'));
+      } else {
+        // We loaded first (most likely in extension mode),
+        // let's wait for devtools.js.
+        window._msgRaceConditionGuard = 'devtools-webapp-loaded';
+        this._preInitMsgQueue = [];
+        document.addEventListener('arcs-communication-channel-ready', e => {
+          for (let msg of this._preInitMsgQueue) {
+            this._fire(msg);
+          }
+          this._preInitMsgQueue = undefined;
+        });
+      }
+    }, 0);
   }
 
   _fire(msg) {

--- a/devtools/src/arcs-dataflow.js
+++ b/devtools/src/arcs-dataflow.js
@@ -3,10 +3,10 @@ import '../deps/@polymer/paper-item/paper-item.js';
 import '../deps/@vaadin/vaadin-grid/vaadin-grid.js';
 import '../deps/@vaadin/vaadin-grid/vaadin-grid-sorter.js';
 import {PolymerElement} from '../deps/@polymer/polymer/polymer-element.js';
-import {formatTime, writeOps, indentPrint} from './arcs-shared.js';
+import {formatTime, writeOps, indentPrint, MessengerMixin} from './arcs-shared.js';
 import {html} from '../deps/@polymer/polymer/lib/utils/html-tag.js';
 
-class ArcsDataflow extends PolymerElement {
+class ArcsDataflow extends MessengerMixin(PolymerElement) {
   static get template() {
     return html`
     <style include="shared-styles">

--- a/devtools/src/arcs-notifications.js
+++ b/devtools/src/arcs-notifications.js
@@ -1,8 +1,8 @@
 import {PolymerElement} from '../deps/@polymer/polymer/polymer-element.js';
-import './arcs-shared.js';
+import {MessengerMixin} from './arcs-shared.js';
 import {html} from '../deps/@polymer/polymer/lib/utils/html-tag.js';
 
-class ArcsNotifications extends PolymerElement {
+class ArcsNotifications extends MessengerMixin(PolymerElement) {
   static get template() {
     return html`
     <style include="shared-styles">

--- a/devtools/src/arcs-overview.js
+++ b/devtools/src/arcs-overview.js
@@ -1,8 +1,9 @@
 import {PolymerElement} from '../deps/@polymer/polymer/polymer-element.js';
-import './arcs-shared.js';
+import '../deps/@vaadin/vaadin-split-layout/vaadin-split-layout.js';
+import {MessengerMixin} from './arcs-shared.js';
 import {html} from '../deps/@polymer/polymer/lib/utils/html-tag.js';
 
-class ArcsOverview extends PolymerElement {
+class ArcsOverview extends MessengerMixin(PolymerElement) {
   static get template() {
     return html`
     <style include="shared-styles">

--- a/devtools/src/arcs-shared.js
+++ b/devtools/src/arcs-shared.js
@@ -87,10 +87,26 @@ export function indentPrint(thing) {
 }
 
 /* @polymerMixin */
-const MessageSenderMixin = subclass => class extends subclass {
+const MessengerMixin = subclass => class extends subclass {
+
+  constructor() {
+    super();
+    if (this.onMessageBundle || this.onMessage) {
+      document.addEventListener('messages', ({detail}) => {
+        if (this.onMessageBundle) {
+          this.onMessageBundle(detail);
+        } else {
+          for (let msg of detail) {
+            this.onMessage(msg);
+          }
+        }
+      });
+    }
+  }
+
   send(message) {
-    this.dispatchEvent(new CustomEvent('message', {detail: message}));
+    document.dispatchEvent(new CustomEvent('send-message', {detail: message}));
   }
 };
 
-export {MessageSenderMixin, writeOps};
+export {MessengerMixin, writeOps};

--- a/devtools/src/arcs-strategy-runner.js
+++ b/devtools/src/arcs-strategy-runner.js
@@ -3,10 +3,10 @@ import '../deps/@polymer/paper-dropdown-menu/paper-dropdown-menu.js';
 import '../deps/@polymer/paper-item/paper-item.js';
 import '../deps/@polymer/paper-fab/paper-fab.js';
 import '../deps/@polymer/paper-input/paper-textarea.js';
-import {MessageSenderMixin} from './arcs-shared.js';
+import {MessengerMixin} from './arcs-shared.js';
 import {html} from '../deps/@polymer/polymer/lib/utils/html-tag.js';
 
-class ArcsStrategyRunner extends MessageSenderMixin(PolymerElement) {
+class ArcsStrategyRunner extends MessengerMixin(PolymerElement) {
   static get template() {
     return html`
     <style include="shared-styles">
@@ -104,7 +104,7 @@ class ArcsStrategyRunner extends MessageSenderMixin(PolymerElement) {
           });
         }
         break;
-      case 'planner-strategies':
+      case 'fetch-strategies-result':
         this.set('strategies', msg.messageBody);
         break;
       case 'invoke-planner-result':

--- a/devtools/src/arcs-tracing.js
+++ b/devtools/src/arcs-tracing.js
@@ -5,7 +5,7 @@ import '../deps/@polymer/iron-icons/maps-icons.js';
 import '../deps/@polymer/iron-icons/image-icons.js';
 import '../deps/@vaadin/vaadin-split-layout/vaadin-split-layout.js';
 import '../deps/vis/dist/vis-timeline-graph2d.min.js';
-import {formatTime, indentPrint} from './arcs-shared.js';
+import {formatTime, indentPrint, MessengerMixin} from './arcs-shared.js';
 
 
 const $_documentContainer = document.createElement('template');
@@ -86,7 +86,7 @@ $_documentContainer.innerHTML = `<dom-module id="arcs-tracing">
 </dom-module>`;
 
 document.head.appendChild($_documentContainer.content);
-class ArcsTracing extends PolymerElement {
+class ArcsTracing extends MessengerMixin(PolymerElement) {
   static get is() { return 'arcs-tracing'; }
 
   static get properties() {

--- a/devtools/src/strategy-explorer/strategy-explorer.js
+++ b/devtools/src/strategy-explorer/strategy-explorer.js
@@ -14,13 +14,14 @@ import './se-recipe-view.js';
 import './se-stats.js';
 import './se-compare-populations.js';
 import './se-find.js';
-import '../arcs-shared.js';
+import {MessengerMixin} from '../arcs-shared.js';
 import '../../deps/@vaadin/vaadin-split-layout/vaadin-split-layout.js';
-import {Polymer} from '../../deps/@polymer/polymer/lib/legacy/polymer-fn.js';
+import {PolymerElement} from '../../deps/@polymer/polymer/polymer-element.js';
 import {html} from '../../deps/@polymer/polymer/lib/utils/html-tag.js';
 
-Polymer({
-  _template: html`
+class StrategyExplorer extends MessengerMixin(PolymerElement) {
+  static get template() {
+    return html`
     <style include="shared-styles">
       .se-explorer-container {
         overflow: scroll;
@@ -45,29 +46,32 @@ Polymer({
         <se-stats results="{{results}}"></se-stats>
         <se-legend></se-legend>
       </aside>
-    </vaadin-split-layout>
-`,
+    </vaadin-split-layout>`;
+  }
 
-  is: 'strategy-explorer',
+  static get is() { return 'strategy-explorer'; }
 
-  properties: {
-    results: Array,
-    findBacklit: Boolean
-  },
+  static get properties() {
+    return {
+      results: Array,
+      findBacklit: Boolean
+    };
+  }
 
-  reset: function() {
+  reset() {
     this.set('results', []);
     this.idMap = new Map();
     this.pendingActions = new Map();
-  },
+  }
 
-  attached: function() {
+  ready() {
+    super.ready();
     document.strategyExplorer = this;
     this.reset();
     this.timeoutId = null;
-  },
+  }
 
-  displayResults: function({results, options}) {
+  displayResults({results, options}) {
     if (JSON.stringify(this.results) === JSON.stringify(results)) return;
     this.reset();
     if (this.timeoutId) {
@@ -81,9 +85,9 @@ Polymer({
       // TODO(piotrs): Make generic once more components need options.
       if (options) this.$.compare.processOptions(options);
     }, 0);
-  },
+  }
 
-  onMessageBundle: function(messages) {
+  onMessageBundle(messages) {
     for (let msg of messages) {
       switch (msg.messageType) {
         case 'generations':
@@ -94,7 +98,7 @@ Polymer({
           break;
       }
     }
-  },
+  }
 
   onFindPhrase(e) {
     const phrase = e.detail;
@@ -103,4 +107,6 @@ Polymer({
       seRecipe.setFindPhrase(phrase);
     }
   }
-});
+}
+
+window.customElements.define(StrategyExplorer.is, StrategyExplorer);

--- a/runtime/debug/abstract-devtools-channel.js
+++ b/runtime/debug/abstract-devtools-channel.js
@@ -41,7 +41,7 @@ export class AbstractDevtoolsChannel {
   }
 
   _handleMessage(msg) {
-    let listeners = this.messageListeners.get(`${msg.targetArcId}/${msg.messageType}`);
+    let listeners = this.messageListeners.get(`${msg.arcId}/${msg.messageType}`);
     if (!listeners) {
       console.warn(`No one is listening to ${msg.messageType} message`);
     } else {

--- a/runtime/debug/arc-debug-handler.js
+++ b/runtime/debug/arc-debug-handler.js
@@ -23,6 +23,8 @@ export class ArcDebugHandler {
     // Message handles go here.
     new ArcPlannerInvoker(arc, devtoolsChannel);
 
+    // TODO: Disconnect when arc is disposed?
+
     devtoolsChannel.send({
       messageType: 'arc-available',
       messageBody: {

--- a/runtime/debug/arc-planner-invoker.js
+++ b/runtime/debug/arc-planner-invoker.js
@@ -18,7 +18,7 @@ export class ArcPlannerInvoker {
     this.planner.init(arc);
 
     devtoolsChannel.listen(arc, 'fetch-strategies', () => devtoolsChannel.send({
-      messageType: 'planner-strategies',
+      messageType: 'fetch-strategies-result',
       messageBody: this.planner.strategizer._strategies.map(a => a.constructor.name)
     }));
 

--- a/runtime/recipe-index.js
+++ b/runtime/recipe-index.js
@@ -76,6 +76,8 @@ export class RecipeIndex {
       context: new Manifest({id: 'empty-context'}),
       slotComposer: affordance ? new SlotComposer({affordance, noRoot: true}) : null,
       recipeIndex: {},
+      // TODO: Not speculative really, figure out how to mark it so DevTools doesn't pick it up.
+      speculative: true
     });
     let strategizer = new Strategizer(
       [


### PR DESCRIPTION
Two changes to message passing:
* Fixes existing race condition which was causing losing the first few bundles of messages if not run in the extension mode. Caused by different order in which devtools.js and arcs-devtools-app.js are loaded depending on the mode (i.e. extension vs. standalone).
* No longer uses arcs-devtools-app.js as a proxy for message passing - this unlocks having message passing components which are not direct children of arcs-devtools-app.