### PR TITLE
Remove dead code from Particle

### DIFF
--- a/runtime/particle.js
+++ b/runtime/particle.js
@@ -23,11 +23,7 @@ export class Particle {
       this.extraData = true;
     this.relevances = [];
     this._idle = Promise.resolve();
-    this._idleResolver = null;
     this._busy = 0;
-    this.slotHandlers = [];
-    this.stateHandlers = new Map();
-    this.states = new Map();
     this._slotByName = new Map();
     this.capabilities = capabilities || {};
   }
@@ -119,31 +115,6 @@ export class Particle {
    */
   getSlot(name) {
     return this._slotByName.get(name);
-  }
-
-  addSlotHandler(f) {
-    this.slotHandlers.push(f);
-  }
-
-  addStateHandler(states, f) {
-    states.forEach(state => {
-      if (!this.stateHandlers.has(state)) {
-        this.stateHandlers.set(state, []);
-      }
-      this.stateHandlers.get(state).push(f);
-    });
-  }
-
-  emit(state, value) {
-    this.states.set(state, value);
-    this.stateHandlers.get(state).forEach(f => f(value));
-  }
-
-  fireEvent(slotName, event) {
-    // TODO(sjmiles): tests can get here without a `this.slot`, maybe this needs to be fixed in MockSlotManager?
-    let slot = this.getSlot(slotName);
-    assert(slot, `Particle::fireEvent: slot ${slotName} is falsey`);
-    slot.fireEvent(event);
   }
 
   static buildManifest(strings, ...bits) {


### PR DESCRIPTION
These methods (and their underlying fields) appear to be unused. fireEvent is called from the PEC but is provided by DomParticle[Base]. The others aren't referenced at all.

Let me know if they should be kept for future use.