### PR TITLE
Display arc and context stores in DevTools

### DIFF
--- a/devtools/src/arcs-overview.js
+++ b/devtools/src/arcs-overview.js
@@ -1,6 +1,8 @@
 import {PolymerElement} from '../deps/@polymer/polymer/polymer-element.js';
 import '../deps/@vaadin/vaadin-split-layout/vaadin-split-layout.js';
 import {MessengerMixin} from './arcs-shared.js';
+import '../deps/@vaadin/vaadin-split-layout/vaadin-split-layout.js';
+import './arcs-stores.js';
 import {html} from '../deps/@polymer/polymer/lib/utils/html-tag.js';
 
 class ArcsOverview extends MessengerMixin(PolymerElement) {
@@ -10,6 +12,8 @@ class ArcsOverview extends MessengerMixin(PolymerElement) {
       :host {
         display: block;
         padding: 0;
+      }
+      #graphContainer {
         position: relative;
       }
       .legend {
@@ -49,21 +53,28 @@ class ArcsOverview extends MessengerMixin(PolymerElement) {
         background-color: var(--light-gray);
       }
     </style>
-    <div class="legend">
-      <div><span node="" style="background: var(--highlight-blue)"></span> Particle</div>
-      <div><span node="" style="background: var(--light-gray)"></span> Handle</div>
-      <div><span edge="" style="background: var(--dark-green)"></span> Read</div>
-      <div><span edge="" style="background: var(--dark-red)"></span> Write</div>
-      <div><span edge="" style="background: var(--highlight-blue)"></span> Read-Write</div>
-      <div><span edge="" style="background: var(--dark-gray)"></span> Hosted</div>
-    </div>
-    <div id="popup">
-      <pre id="popupText"></pre>
-      <div class="nav-list">
-        <a id="dataflowLink" href=""><iron-icon icon="swap-horiz"></iron-icon>Show in Dataflow</a>
+    <vaadin-split-layout>
+      <div id="graphContainer" style="flex: .5">
+        <div class="legend">
+          <div><span node="" style="background: var(--highlight-blue)"></span> Particle</div>
+          <div><span node="" style="background: var(--light-gray)"></span> Handle</div>
+          <div><span edge="" style="background: var(--dark-green)"></span> Read</div>
+          <div><span edge="" style="background: var(--dark-red)"></span> Write</div>
+          <div><span edge="" style="background: var(--highlight-blue)"></span> Read-Write</div>
+          <div><span edge="" style="background: var(--dark-gray)"></span> Hosted</div>
+        </div>
+        <div id="popup">
+          <pre id="popupText"></pre>
+          <div class="nav-list">
+            <a id="dataflowLink" href=""><iron-icon icon="swap-horiz"></iron-icon>Show in Dataflow</a>
+          </div>
+        </div>
+        <div id="graph"></div>
       </div>
-    </div>
-    <div id="graph"></div>
+      <aside style="flex: .5">
+        <arcs-stores></arcs-stores>
+      </aside>
+    </vaadin-split-layout>
 `;
   }
 
@@ -82,7 +93,7 @@ class ArcsOverview extends MessengerMixin(PolymerElement) {
       let {height, width} = rects[0].contentRect;
       this.$.graph.style.width = `${width}px`;
       this.$.graph.style.height = `${height}px`;
-    }).observe(this);
+    }).observe(this.$.graphContainer);
     this.$.popup.addEventListener('mouseleave', e => {
       this.$.popup.style.display = 'none';
     });

--- a/devtools/src/arcs-shared.js
+++ b/devtools/src/arcs-shared.js
@@ -14,6 +14,10 @@ $_documentContainer.innerHTML = `<dom-module id="shared-styles">
         --highlight-blue: #3879d9;
         --dark-red: #b71c1c;
         --dark-green: #09ba12;
+
+        --devtools-purple: rgb(136, 19, 145);
+        --devtools-blue: rgb(13, 34, 170);
+        --devtools-red: rgb(196, 26, 22);
       }
       .devtools-icon {
         display: inline-block;
@@ -24,6 +28,16 @@ $_documentContainer.innerHTML = `<dom-module id="shared-styles">
             url(../img/devtools_icons_2x.png) 2x);
         background-color: rgb(110, 110, 110);
       }
+      .devtools-small-icon {
+        display: inline-block;
+        width: 10px;
+        height: 10px;
+        min-width: 10px;
+        -webkit-mask-image: -webkit-image-set(
+            url(../img/devtools_icons_color_1x.png) 1x,
+            url(../img/devtools_icons_color_2x.png) 2x);
+        background-color: rgb(110, 110, 110);
+      }
       .devtools-icon-color {
         display: inline-block;
         background-image: -webkit-image-set(
@@ -31,6 +45,14 @@ $_documentContainer.innerHTML = `<dom-module id="shared-styles">
             url(../img/devtools_icons_color_2x.png) 2x);
         width: 10px;
         height: 10px;
+      }
+      .triangle {
+        -webkit-mask-position: 0px 10px;
+        margin: 0 5px;
+        zoom: .8;
+      }
+      [expanded].triangle {
+        -webkit-mask-position: -80px 30px;
       }
       .nav-list {
         margin: 10px 0;
@@ -64,7 +86,7 @@ $_documentContainer.innerHTML = `<dom-module id="shared-styles">
         background-color: var(--light-gray);
         overflow: scroll;
       }
-      vaadin-split-layout > aside > * {
+      vaadin-split-layout > aside.paddedBlocks > * {
         margin: 5px 5px 5px 2px;
       }
     </style>

--- a/devtools/src/arcs-stores.js
+++ b/devtools/src/arcs-stores.js
@@ -1,0 +1,188 @@
+import {PolymerElement} from '../deps/@polymer/polymer/polymer-element.js';
+import {MessengerMixin} from './arcs-shared.js';
+import './object-explorer.js';
+import {html} from '../deps/@polymer/polymer/lib/utils/html-tag.js';
+
+class ArcsStores extends MessengerMixin(PolymerElement) {
+  static get template() {
+    return html`
+    <style include="shared-styles">
+      :host {
+        display: block;
+        border-left: 1px solid var(--mid-gray);
+        line-height: 22px;
+      }
+      .group-title {
+        display: flex;
+        align-items: center;
+        background-color: var(--light-gray);
+        border-bottom: 1px solid var(--mid-gray);
+        white-space: nowrap;
+        overflow: hidden;
+        position: relative;
+        cursor: pointer;
+      }
+      .refresh {
+        -webkit-mask-position: -84px 48px;
+        position: absolute;
+        right: 0;
+        top: -1px;
+        cursor: pointer;
+        transition: transform .5s;
+      }
+      :host([loading]) .refresh {
+        transform: rotate(1turn);
+      }
+      .group-content {
+        background-color: white;
+        border-bottom: 1px solid var(--mid-gray);
+        display: flex;
+        flex-direction: column;
+      }
+      .item-title {
+        font-family: Menlo, monospace;
+        font-size: 11px;
+        display: inline-flex;
+        align-items: center;
+        white-space: nowrap;
+        overflow: hidden;
+        cursor: pointer;
+        width: fit-content;
+        max-width: 100%;
+      }
+      .empty {
+        text-align: center;
+        font-style: italic;
+        color: var(--mid-gray);
+        white-space: nowrap;
+      }
+      [name]:not(:empty) {
+        color: var(--devtools-purple);
+        margin-right: 1ch;
+      }
+      [tags]:not(:empty) {
+        color: var(--devtools-blue);
+        margin-right: 1ch;
+      }
+      [type]:not(:empty) {
+        margin-right: 1ch;
+      }
+      [id] {
+        color: var(--devtools-red);
+      }
+    </style>
+    <template is="dom-repeat" items="{{storeGroups}}">
+      <div class="group-title" on-click="_handleExpand">
+        <span class="triangle devtools-small-icon" expanded$="{{item.expanded}}"></span>
+        {{item.label}}
+        <span class="devtools-icon refresh" on-click="_fetchStores"></span>
+      </div>
+      <template is="dom-if" if="{{item.expanded}}">
+        <div class="group-content">
+          <template is="dom-repeat" items="{{item.items}}">
+            <div class="item-title" expanded$="{{item.expanded}}" on-click="_handleExpand">
+              <span class="triangle devtools-small-icon"></span>
+              <span name>[[item.store.name]]</span>
+              <span tags>[[_tagsString(item.store.tags)]]</span>
+              <span type>[[_typeString(item.store.type)]]</span>
+              <span id>[[item.store.id]]</span>
+            </div>
+            <template is="dom-if" if="{{item.expanded}}">
+              <object-explorer data="[[item.store]]" expanded skip-header></object-explorer>
+            </template>
+          </template>
+          <template is="dom-if" if="{{!item.items.length}}">
+            <div class="empty">No stores</div>
+          </template>
+        </div>
+      </template>
+    </template>`;
+  }
+
+  static get is() { return 'arcs-stores'; }
+
+  static get properties() {
+    return {
+      loading: {
+        type: Boolean,
+        reflectToAttribute: true,
+        value: false
+      }
+    };
+  }
+
+  constructor() {
+    super();
+    this.storeGroups = [{
+      label: 'Arc Stores',
+      expanded: true,
+      items: []
+    }, {
+      label: 'Context Stores',
+      expanded: true,
+      items: []
+    }];
+  }
+
+  onMessageBundle(messages) {
+    for (let msg of messages) {
+      switch (msg.messageType) {
+        case 'arc-available':
+          if (!this.arcId && !msg.messageBody.isSpeculative) {
+            this.arcId = msg.messageBody.id;
+            this._fetchStores();
+          }
+          break;
+        case 'fetch-stores-result':
+          this.loading = false;
+          // Need to do below to force re-render without any stale data.
+          this.set('storeGroups.0.items', []);
+          this.set('storeGroups.1.items', []);
+          Promise.resolve().then(() => {
+            this.set('storeGroups.0.items', msg.messageBody.arcStores.map(h => this._toDisplayItem(h)));
+            this.set('storeGroups.1.items', msg.messageBody.contextStores.map(h => this._toDisplayItem(h)));
+          });
+          break;
+        case 'page-refresh':
+          this.loading = false;
+          this.set('storeGroups.0.items', []);
+          this.set('storeGroups.1.items', []);
+          break;
+      }
+    }
+  }
+
+  _toDisplayItem(store) {
+    // For nicer printing in object-explorer, but without being enumerable.
+    Object.defineProperty(store.type, 'toString', {value: () => this._typeString(store.type)});
+    return {store, expanded: false};
+  }
+
+  _fetchStores(e) {
+    this.loading = true;
+    this.send({
+      messageType: 'fetch-stores',
+      messageBody: {},
+      arcId: this.arcId
+    });
+    if (e) e.cancelBubble = true;
+  }
+
+  _tagsString(tags) {
+    return tags.map(t => `#${t}`).join(' ');
+  }
+
+  _typeString(type) {
+    switch (type.tag) {
+      case 'Collection': return `[${this._typeString(type.data)}]`;
+      case 'Entity': return type.data._model.names.join(' ');
+    }
+    return type.tag;
+  }
+
+  _handleExpand(e) {
+    e.model.set('item.expanded', !e.model.item.expanded);
+  }
+}
+
+window.customElements.define(ArcsStores.is, ArcsStores);

--- a/devtools/src/arcs-tracing.js
+++ b/devtools/src/arcs-tracing.js
@@ -55,7 +55,7 @@ $_documentContainer.innerHTML = `<dom-module id="arcs-tracing">
     </style>
     <vaadin-split-layout>
       <div id="timelineContainer" style="flex: .8"></div>
-      <aside style="flex: .2">
+      <aside style="flex: .2" class="paddedBlocks">
         <div class="controls">
           <div class="buttons-panel">
             <iron-icon on-click="_fit" title="Fit to events" icon="maps:zoom-out-map"></iron-icon>

--- a/devtools/src/object-explorer.js
+++ b/devtools/src/object-explorer.js
@@ -1,0 +1,204 @@
+import {PolymerElement} from '../deps/@polymer/polymer/polymer-element.js';
+import {html} from '../deps/@polymer/polymer/lib/utils/html-tag.js';
+
+class ObjectExplorer extends PolymerElement {
+  static get template() {
+    return html`
+    <style include="shared-styles">
+      :host {
+        font-family: Menlo, monospace;
+        font-size: 11px;
+        overflow: hidden;
+        display: flex;
+        align-items: flex-start;
+      }
+      :host([folded]) {
+        white-space: nowrap;
+        display: inline-flex;
+      }
+      :host([expanded]:not([folded])) {
+        flex-direction: column;
+      }
+      :host([inner]:not([folded])) {
+        padding-left: 10px;
+      }
+      .header {
+        display: inline-flex;
+        align-items: center;
+        white-space: nowrap;
+      }
+      .triangle {
+        visibility: hidden;
+      }
+      [expandable] > .triangle {
+        visibility: visible;
+      }
+      [expandable] {
+        cursor: pointer;
+      }
+      [key] {
+        color: var(--devtools-purple);
+      }
+      [keySeparator] {
+        width: 2ch;
+      }
+      [meta]:not(:empty) {
+        color: var(--dark-gray);
+        margin-right: 1ch;
+      }
+      [asString]:not(:empty) {
+        font-style: italic;
+        margin-right: 1ch;
+      }
+      [prop] {
+        max-width: 100%;
+      }
+      [prop][folded] {
+        display: inline-flex;
+      }
+      [prop][folded]:not(:last-of-type)::after {
+        content: ',';
+        width: 2ch;
+      }
+      [string] {
+        color: var(--devtools-red);
+        word-break: break-all;
+        width: initial;
+      }
+      [numberOrBool] {
+        color: var(--devtools-blue);
+      }
+      [function] {
+        font-style: italic;
+      }
+      [hidden] {
+        display: none;
+      }
+    </style>
+    <span class="header" expandable$=[[_expandable(folded)]] on-click="_handleExpand" inner$=[[inner]] hidden$=[[skipHeader]]>
+      <span class="triangle devtools-small-icon" expanded$="[[expanded]]" hidden$=[[folded]]></span>
+      <template is="dom-if" if="[[!skipKey]]"><span key>[[key]]</span><span keySeparator>[[_separator(key)]]</span></template is="dom-if">
+      <span meta>[[_describe(folded)]]</span>
+      <span asString>[[_asString(data)]]</span>
+    </span>
+    <template is="dom-if" if="[[_isObject()]]">
+      [[_begin(data, expanded, folded)]]<!--
+   --><template is="dom-if" if="[[!folded]]"><!--
+     --><template is="dom-repeat" items="[[_props(data)]]">
+          <div prop folded$="[[!expanded]]">
+            <object-explorer inner folded$="[[!expanded]]" key="[[item.key]]" data="[[item.value]]" skip-key="[[_skipKey(expanded)]]"></object-explorer>
+          </div>
+        </template><!--
+   --></template is="dom-if"><!--
+   --><template is="dom-if" if="[[folded]]">...</template><!--
+ -->[[_end(data, expanded, folded)]]
+    </template>
+    <template is="dom-if" if="[[_isString()]]">
+      <span string>"[[data]]"</span>
+    </template>
+    <template is="dom-if" if="[[_isNumberOrBoolean()]]">
+      <span numberOrBool>[[data]]</span>
+    </template>
+    <template is="dom-if" if="[[_isFunction()]]">
+      <span function>ƒ [[data.name]]()</span>
+    </template>
+    <template is="dom-if" if="[[_isNullOrUndefined()]]">
+      <span>[[_toString()]]</span>
+    </template>
+`;
+  }
+
+  static get is() { return 'object-explorer'; }
+
+  static get properties() {
+    return {
+      data: Object,
+      key: String,
+      expanded: {
+        type: Boolean,
+        reflectToAttribute: true,
+        value: false
+      },
+      inner: {
+        type: Boolean,
+        reflectToAttribute: true,
+        value: false,
+      },
+      folded: {
+        type: Boolean,
+        reflectToAttribute: true,
+        value: false
+      },
+      skipKey: Boolean,
+      skipHeader: Boolean
+    };
+  }
+
+  _isObject() {
+    return this.data && typeof this.data === 'object';
+  }
+
+  _isString() {
+    return typeof this.data === 'string';
+  }
+
+  _isNumberOrBoolean() {
+    return typeof this.data === 'number' || typeof this.data === 'boolean';
+  }
+
+  _isNullOrUndefined() {
+    return this.data == null;
+  }
+
+  _isFunction() {
+    return typeof this.data === 'function';
+  }
+
+  _expandable(folded) {
+    return this._isObject() && !folded;
+  }
+
+  _skipKey(expanded) {
+    return !expanded && this.data && Array.isArray(this.data);
+  }
+
+  _toString() {
+    return String(this.data);
+  }
+
+  _asString(object) {
+    if (object && object.hasOwnProperty('toString') && typeof object.toString === 'function') {
+      return `'${object.toString()}'`;
+    } else return '';
+  }
+
+  _props(data) {
+    return Object.entries(data).map(([key, value]) => ({key, value}));
+  }
+
+  _describe(folded) {
+    if (folded || !this._isObject()) return '';
+    return Array.isArray(this.data)
+        ? `Array(${this.data.length})`
+        : this.data.constructor.name;
+  }
+
+  _begin(data, expanded, folded) {
+    return expanded && !folded ? '' : (Array.isArray(data) ? '[' : '{');
+  }
+
+  _end(data, expanded, folded) {
+    return expanded && !folded ? '' : (Array.isArray(data) ? ']' : '}');
+  }
+
+  _separator(key) {
+    return key ? ': ' : '';
+  }
+
+  _handleExpand(e) {
+    if (!this.data || !this._isObject() || this.folded) return;
+    this.expanded = !this.expanded;
+  }
+}
+
+window.customElements.define(ObjectExplorer.is, ObjectExplorer);

--- a/devtools/src/strategy-explorer/strategy-explorer.js
+++ b/devtools/src/strategy-explorer/strategy-explorer.js
@@ -38,7 +38,7 @@ class StrategyExplorer extends MessengerMixin(PolymerElement) {
       <div style="flex: .7" class="se-explorer-container" find-backlit\$="[[findBacklit]]">
         <se-explorer results="{{results}}"></se-explorer>
       </div>
-      <aside style="flex: .3">
+      <aside style="flex: .3" class="paddedBlocks">
         <se-find id="find" on-find-phrase="onFindPhrase"></se-find>
         <se-compare-populations results="{{results}}" id='compare'></se-compare-populations>
         <se-recipe-view></se-recipe-view>

--- a/runtime/debug/arc-debug-handler.js
+++ b/runtime/debug/arc-debug-handler.js
@@ -10,6 +10,7 @@
 
 import {enableTracingAdapter} from './tracing-adapter.js';
 import {ArcPlannerInvoker} from './arc-planner-invoker.js';
+import {ArcStoresFetcher} from './arc-stores-fetcher.js';
 import {DevtoolsConnection} from './devtools-connection.js';
 
 // Arc-independent handlers for devtools logic.
@@ -21,7 +22,10 @@ export class ArcDebugHandler {
   constructor(arc, devtoolsChannel) {
 
     // Message handles go here.
-    new ArcPlannerInvoker(arc, devtoolsChannel);
+    if (!arc.isSpeculative) {
+      new ArcPlannerInvoker(arc, devtoolsChannel);
+      new ArcStoresFetcher(arc, devtoolsChannel);
+    }
 
     // TODO: Disconnect when arc is disposed?
 

--- a/runtime/debug/arc-stores-fetcher.js
+++ b/runtime/debug/arc-stores-fetcher.js
@@ -1,0 +1,56 @@
+/**
+ * @license
+ * Copyright (c) 2018 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+export class ArcStoresFetcher {
+  constructor(arc, devtoolsChannel) {
+    this._arc = arc;
+
+    devtoolsChannel.listen(arc, 'fetch-stores', async () => devtoolsChannel.send({
+      messageType: 'fetch-stores-result',
+      messageBody: await this._listStores()
+    }));
+  }
+
+  async _listStores() {
+    const find = manifest => {
+      let tags = [...manifest._storeTags];
+      if (manifest.imports) {
+        manifest.imports.forEach(imp => tags = tags.concat(find(imp)));
+      }
+      return tags;
+    };
+    return {
+      arcStores: await this._digestStores(this._arc._storeTags),
+      contextStores: await this._digestStores(find(this._arc.context))
+    };
+  }
+
+  async _digestStores(stores) {
+    const result = [];
+    for (let [store, tags] of stores) {
+      let value = `(don't know how to dereference)`;
+      if (store.toList) {
+        value = await store.toList();
+      } else if (store.get) {
+        value = await store.get();
+      }
+      result.push({
+        name: store.name,
+        tags: tags ? [...tags] : [],
+        id: store.id,
+        storage: store.storageKey,
+        type: store.type,
+        description: store.description,
+        value
+      });
+    }
+    return result;
+  }
+}


### PR DESCRIPTION
Adds a panel in the overview section displaying stores. Currently fetching is done initially and on a button click, but could be improved to keep in sync later. I've added a generic viewer of JSON objects, as I figured it will come in handy often. Store fetching code is inspired by `shell/components/arc-tools/store-explorer.js`.

@sjmiles would you like me to remove `store-explorer.js`, or would you like to keep it in light of occasional devtools flakiness?

Looks like this:
<img width="703" alt="arcs-stores" src="https://user-images.githubusercontent.com/26159485/42197772-b9683fa0-7ec7-11e8-9b57-9c29b14ec9dd.png">
