### PR TITLE
Host conn fixes

### DIFF
--- a/runtime/recipe-index.js
+++ b/runtime/recipe-index.js
@@ -169,8 +169,9 @@ export class RecipeIndex {
             // Find potential handle connections to coalesce
             slot.handleConnections.forEach(slotHandleConn => {
               let matchingConns = Object.values(slotConn.particle.connections).filter(particleConn => {
-                return (!particleConn.handle || !particleConn.handle.id || particleConn.handle.id == slotHandleConn.handle.id) &&
-                       Handle.effectiveType(slotHandleConn.handle._mappedType, [particleConn]);
+                return particleConn.direction !== 'host'
+                    && (!particleConn.handle || !particleConn.handle.id || particleConn.handle.id == slotHandleConn.handle.id)
+                    && Handle.effectiveType(slotHandleConn.handle._mappedType, [particleConn]);
               });
               matchingConns.forEach(matchingConn => {
                 if (this._fatesAndDirectionsMatch(slotHandleConn, matchingConn)) {

--- a/runtime/strategies/add-use-handles.js
+++ b/runtime/strategies/add-use-handles.js
@@ -24,7 +24,8 @@ export class AddUseHandles extends Strategy {
 
         // TODO: "description" handles are always created, and in the future they need to be "optional" (blocked by optional handles
         // not being properly supported in arc instantiation). For now just hardcode skiping them.
-        let disconnectedConnections = recipe.handleConnections.filter(hc => hc.handle == null && !hc.isOptional && hc.name != 'descriptions');
+        let disconnectedConnections = recipe.handleConnections.filter(
+            hc => hc.handle == null && !hc.isOptional && hc.name != 'descriptions' && hc.direction !== 'host');
         if (disconnectedConnections.length == 0) {
           return;
         }

--- a/runtime/test/strategies/add-use-handles-test.js
+++ b/runtime/test/strategies/add-use-handles-test.js
@@ -1,0 +1,88 @@
+/**
+ * @license
+ * Copyright (c) 2018 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+'use strict';
+
+import {Manifest} from '../../manifest.js';
+import {StrategyTestHelper} from './strategy-test-helper.js';
+import {AddUseHandles} from '../../strategies/add-use-handles.js';
+import {assert} from '../chai-web.js';
+
+async function runStrategy(manifestStr) {
+  let manifest = await Manifest.parse(manifestStr);
+  let recipes = manifest.recipes;
+  recipes.forEach(recipe => recipe.normalize());
+  let arc = StrategyTestHelper.createTestArc('test-plan-arc', manifest, 'dom');
+  let inputParams = {generated: recipes.map(recipe => ({result: recipe, score: 1}))};
+  let strategy = new AddUseHandles(arc);
+  return (await strategy.generate(inputParams)).map(r => r.result);
+}
+
+describe('AddUseHandles', function() {
+  it(`doesn't add handles if there are constraints`, async () => {
+    assert.isEmpty(await runStrategy(`
+      schema Thing
+      particle P1
+        out Thing thing
+
+      particle P2
+        in Thing thing
+
+      recipe
+        P1.thing -> P2.thing
+        P1
+        P2
+    `));
+  });
+  it(`doesn't add handles if there are free handles`, async () => {
+    assert.isEmpty(await runStrategy(`
+      schema Thing
+      particle P1
+        in Thing thing
+
+      recipe
+        create as free
+        P1
+    `));
+  });
+  it(`adds handles to free connections`, async () => {
+    let results = await runStrategy(`
+      schema Thing
+      particle P1
+        in Thing thing
+        out Thing otherThing
+      particle P2
+        inout Thing yetAnother
+
+      recipe
+        P1
+        P2
+    `);
+    assert.lengthOf(results, 1);
+    let recipe = results[0];
+    assert.lengthOf(recipe.handles, 3);
+    assert.isTrue(recipe.handles.every(h => h.fate === 'use'));
+  });
+  it(`doesn't add handles to host connections`, async () => {
+    let results = await runStrategy(`
+      schema Thing
+      shape HostedShape
+        in ~a *
+      particle P1
+        in Thing thing
+        host HostedShape hosted
+      recipe
+        P1
+    `);
+    assert.lengthOf(results, 1);
+    let recipe = results[0];
+    assert.lengthOf(recipe.handles, 1);
+    assert.isUndefined(recipe.particles[0].connections['hosted'].handle);
+  });
+});

--- a/runtime/test/strategies/coalesce-recipes-test.js
+++ b/runtime/test/strategies/coalesce-recipes-test.js
@@ -92,7 +92,7 @@ describe('CoalesceRecipes', function() {
           other = otherHandle
         P3
           thing = thingHandle
-      
+
       resource MyThing
           start
           []
@@ -102,6 +102,44 @@ describe('CoalesceRecipes', function() {
     assert.isTrue(recipe.isResolved());
     assert.lengthOf(recipe.particles, 3);
     assert.lengthOf(recipe.slots, 2);
+  });
+
+  it.only('host connections are ignored for handle requirements', async () => {
+    let recipe = await doCoalesceRecipes(`
+      schema Thing
+      particle P1
+        inout Thing thing
+        consume root
+          must provide foo
+            handle thing
+
+      shape HostedShape
+        in ~a *
+      particle P2
+        host HostedShape hostedParticle
+        in Thing thing
+        consume foo
+
+      recipe
+        slot 'id0' as slot0
+        copy as thingHandle
+        P1
+          thing = thingHandle
+          consume root as slot0
+
+      recipe
+        use as thingHandle
+        P2
+          thing = thingHandle
+    `);
+
+    assert.isTrue(Object.isFrozen(recipe), 'recipe should be valid');
+    assert.lengthOf(recipe.particles, 2);
+    assert.lengthOf(recipe.slots, 2);
+
+    // hostedParticle connection should not be affected.
+    const p2 = recipe.particles.find(p => p.name === 'P2');
+    assert.isUndefined(p2.connections['hostedParticle'].handle);
   });
 
   it('does not coalesce required slots if handle constraint is not met', async () => {

--- a/runtime/test/strategies/coalesce-recipes-test.js
+++ b/runtime/test/strategies/coalesce-recipes-test.js
@@ -104,7 +104,7 @@ describe('CoalesceRecipes', function() {
     assert.lengthOf(recipe.slots, 2);
   });
 
-  it.only('host connections are ignored for handle requirements', async () => {
+  it('host connections are ignored for handle requirements', async () => {
     let recipe = await doCoalesceRecipes(`
       schema Thing
       particle P1


### PR DESCRIPTION
Two fixes around `host` connections:
* Stops `AddUseHandles` to add `use` handles to `host` connections. Added basic tests for this strategy while there.
* Ignores `host` connections as candidates for fulfilling slot handle requirements for coalescing based on slots.