### PR TITLE
Small bugfix in restricting type for shapes

### DIFF
--- a/runtime/shape.js
+++ b/runtime/shape.js
@@ -349,10 +349,10 @@ ${this._slotsToManifestString()}
       } else if (constraint.var.variable.resolution.isVariable) {
         // TODO(shans): revisit how this should be done,
         // consider reusing tryMergeTypeVariablesWith(other).
-        assert(TypeChecker._tryMergeConstraints(constraint.var, {
-          type: constraint.value, direction: constraint.direction}));
+        if (!TypeChecker.processTypeList(constraint.var, [{
+            type: constraint.value, direction: constraint.direction}])) return false;
       } else {
-        assert(constraint.var.variable.resolution.equals(constraint.value));
+        if (!constraint.var.variable.resolution.equals(constraint.value)) return false;
       }
     }
 


### PR DESCRIPTION
Two changes to `shape.restrictType()`:
* Moves from using `_tryMergeConstraints` to `processTypeList` as the former doesn't check whether `canWriteSuperset` is a subset of `canReadSubset`, which is needed.
* `returns false` instead of asserting, as this method is also used by `particleMatches()`, which should be lenient.

This is a followup to changes made in #1606.