### PR TITLE
Make Strategy Explorer displaying synchronous

### DIFF
--- a/devtools/src/strategy-explorer/se-compare-populations.js
+++ b/devtools/src/strategy-explorer/se-compare-populations.js
@@ -68,10 +68,15 @@ class SeComparePopulations extends PolymerElement {
     return {
       results: {
         type: Array,
-        notify: true,
-        observer: '_onResultsUpdated'
+        notify: true
       }
     };
+  }
+
+  static get observers() {
+    return [
+      '_onResultsUpdated(results.*)'
+    ];
   }
 
   constructor() {
@@ -86,9 +91,9 @@ class SeComparePopulations extends PolymerElement {
     }
   }
 
-  _onResultsUpdated(results) {
-    if (results.length === 0 || results.overlapBase
-        || [...this.library, this.current].some(p => p.results === results)) {
+  _onResultsUpdated() {
+    if (this.results.length === 0 || this.results.overlapBase
+        || [...this.library, this.current].some(p => p.results === this.results)) {
       this._updateSelection();
       return;
     }
@@ -99,7 +104,7 @@ class SeComparePopulations extends PolymerElement {
       surviving: stats.survivingDerivations,
       resolved: stats.resolvedDerivations,
       selected: true,
-      results
+      results: this.results
     };
 
     this._updateSelection();
@@ -126,7 +131,7 @@ class SeComparePopulations extends PolymerElement {
       let overlapOther = this.library.find(p => p.id === e.path[1].id).results;
       if (this.results.overlapOther === overlapOther) {
         // Clicking on diff again deselects it.
-        this._displayResults(this.results.overlapBase, true);
+        this._displayResults(this.results.overlapBase);
         return;
       }
       this._overlap(this.results.overlapBase || this.results, overlapOther);
@@ -134,7 +139,7 @@ class SeComparePopulations extends PolymerElement {
     }
 
     let selected = [this.current, ...this.library].find(p => p.id === e.srcElement.id);
-    this._displayResults(selected.results, selected.results === this.results.overlapBase);
+    this._displayResults(selected.results);
     this._updateSelection();
   }
 
@@ -154,14 +159,8 @@ class SeComparePopulations extends PolymerElement {
     }
   }
 
-  _displayResults(results, maintainSelection) {
-    // When diffing between results we keep user selection
-    // through swapping without reseting.
-    if (maintainSelection) {
-      this.results = results;
-    } else {
-      document.strategyExplorer.displayResults({results});
-    }
+  _displayResults(results) {
+    document.strategyExplorer.displayResults({results}, true);
   }
 
   _overlap(base, other) {
@@ -179,7 +178,7 @@ class SeComparePopulations extends PolymerElement {
         this._overlapGeneration(base[i].population, other[i].population);
       }
     }
-    this._displayResults(base, true);
+    this._displayResults(base);
   }
 
   _overlapGeneration(base, other) {

--- a/devtools/src/strategy-explorer/se-recipe.js
+++ b/devtools/src/strategy-explorer/se-recipe.js
@@ -49,20 +49,23 @@ Polymer({
     findHighlight: {
       type: Boolean,
       reflectToAttribute: true
-    }
+    },
+    recipe: Object
   },
 
-  attached: function() {
-    let recipeView = document.strategyExplorer.shadowRoot.querySelector('se-recipe-view');
-    this.$['recipe-box'].addEventListener('mouseenter', e => {
-      recipeView.over = this;
-      recipeView.recipe = this.recipe;
-    });
-    this.$['recipe-box'].addEventListener('mouseleave', e => {
-      recipeView.resetToPinned();
-    });
+  observers: [
+    '_recipeChanged(recipe)',
+  ],
+
+  _recipeChanged: function(recipe) {
     // Maintain find-highlight after results are reloaded.
     this.setFindPhrase(document.strategyExplorer.$.find.phrase);
+
+    this.selected = false;
+    this.selectedParent = false;
+    this.selectedAncestor = false;
+    this.selectedChild = false;
+    this.selectedDescendant = false;
 
     this.ancestors = new Set();
     this.childrens = new Set();
@@ -119,11 +122,22 @@ Polymer({
     });
     this.shortHash = this.recipe.hash.substring(this.recipe.hash.length - 4);
 
-
     if (document.strategyExplorer.pendingActions.has(this.recipe.id)) {
       document.strategyExplorer.pendingActions.get(this.recipe.id).forEach(action => action(this));
     }
+  },
+
+  attached: function() {
+    let recipeView = document.strategyExplorer.shadowRoot.querySelector('se-recipe-view');
+    this.$['recipe-box'].addEventListener('mouseenter', e => {
+      recipeView.over = this;
+      recipeView.recipe = this.recipe;
+    });
+    this.$['recipe-box'].addEventListener('mouseleave', e => {
+      recipeView.resetToPinned();
+    });
     this.$['recipe-box'].addEventListener('click', e => {
+      if (this.recipe._diff === 'remove') return;
       if (document._selectedBox !== undefined) {
         document._selectedBox.selected = false;
         document._selectedBox.parents.forEach(parent => parent.selectedParent = false);

--- a/devtools/src/strategy-explorer/strategy-explorer.js
+++ b/devtools/src/strategy-explorer/strategy-explorer.js
@@ -53,7 +53,10 @@ class StrategyExplorer extends MessengerMixin(PolymerElement) {
 
   static get properties() {
     return {
-      results: Array,
+      results: {
+        type: Array,
+        value: []
+      },
       findBacklit: Boolean
     };
   }
@@ -68,23 +71,13 @@ class StrategyExplorer extends MessengerMixin(PolymerElement) {
     super.ready();
     document.strategyExplorer = this;
     this.reset();
-    this.timeoutId = null;
   }
 
-  displayResults({results, options}) {
-    if (JSON.stringify(this.results) === JSON.stringify(results)) return;
+  displayResults({results, options}, force = false) {
+    if (JSON.stringify(this.results) === JSON.stringify(results) && !force) return;
     this.reset();
-    if (this.timeoutId) {
-      // Clear previous timeout if it hasn't fired yet. Prevents
-      // race conditions between multiple reset() and setting results.
-      clearTimeout(this.timeoutId);
-    }
-
-    this.timeoutId = setTimeout(() => {
-      this.set('results', results);
-      // TODO(piotrs): Make generic once more components need options.
-      if (options) this.$.compare.processOptions(options);
-    }, 0);
+    this.set('results', results);
+    if (options) this.$.compare.processOptions(options);
   }
 
   onMessageBundle(messages) {


### PR DESCRIPTION
Refactors StrategyExplorer to no longer require destroying and recreating se-recipe elements, which allows to make message processing (and displaying) synchronous. This allows to process multiple SE messages in the bundle, and not just the last one. This in turn ensures that the 'index' message is not swallowed up and always shows up in the strategy explorer.