### PR TITLE
Enable recipe coalescing again

### DIFF
--- a/runtime/planner.js
+++ b/runtime/planner.js
@@ -31,6 +31,7 @@ import {CreateHandles} from './strategies/create-handles.js';
 import {CreateHandleGroup} from './strategies/create-handle-group.js';
 import {CombinedStrategy} from './strategies/combined-strategy.js';
 import {FindHostedParticle} from './strategies/find-hosted-particle.js';
+import {CoalesceRecipes} from './strategies/coalesce-recipes.js';
 import {ResolveRecipe} from './strategies/resolve-recipe.js';
 import {Speculator} from './speculator.js';
 import {Tracing} from '../tracelib/trace.js';
@@ -240,7 +241,8 @@ Planner.ResolutionStrategies = [
   CreateDescriptionHandle,
   MatchFreeHandlesToConnections,
   ResolveRecipe,
-  FindHostedParticle
+  FindHostedParticle,
+  CoalesceRecipes
 ];
 
 Planner.AllStrategies = Planner.InitializationStrategies.concat(Planner.ResolutionStrategies);

--- a/runtime/test/planner-tests.js
+++ b/runtime/test/planner-tests.js
@@ -578,8 +578,7 @@ describe('Automatic handle resolution', function() {
         B`);
   });
 
-  // CoalesceRecipes is disabled for now.
-  it.skip('coalesces recipes to resolve connections', async () => {
+  it('coalesces recipes to resolve connections', async () => {
     let result = await verifyResolvedPlan(`
       schema Thing
         Text id


### PR DESCRIPTION
Coalescer was temporarily disabled, as it was producing additional suggestions in demos (e.g. Calendar + Reservation Form coalesced), which was breaking the demo tests. It was correct-ish, but was changing the assumptions a bit.

It can be enabled now after #1551 without changing the tests, as that PR ensures that the set of suggestions grows from the context and those extra suggestions are not appearing without searching for `*`.