### PR TITLE
Reimplement Firebase storage using CRDT

### DIFF
--- a/runtime/manual_tests/firebase-tests.js
+++ b/runtime/manual_tests/firebase-tests.js
@@ -13,8 +13,15 @@ import {Arc} from '../arc.js';
 import {Manifest} from '../manifest.js';
 import {Type} from '../type.js';
 import {assert} from '../test/chai-web.js';
+import {resetStorageForTesting} from '../storage/firebase-storage.js';
+
+const testUrl = 'firebase://arcs-storage-test.firebaseio.com/AIzaSyBLqThan3QCOICj0JZ-nEwk27H4gmnADP8/firebase-storage-test';
 
 describe('firebase', function() {
+  before(async () => {
+    // TODO: perhaps we should do this after the test, and use a unique path for each run instead?
+    await resetStorageForTesting(testUrl);
+  });
   it('can host a variable', async () => {
     let manifest = await Manifest.parse(`
       schema Bar
@@ -24,8 +31,7 @@ describe('firebase', function() {
     let storage = new StorageProviderFactory(arc.id);
     let BarType = Type.newEntity(manifest.schemas.Bar);
     let value = 'Hi there' + Math.random();
-    let variable = await storage.connect('test0', BarType, 
-      'firebase://test-firebase-45a3e.firebaseio.com/AIzaSyBLqThan3QCOICj0JZ-nEwk27H4gmnADP8/test');
+    let variable = await storage.construct('test0', BarType, `${testUrl}/test-variable`);
     await variable.set({id: 'test0:test', value});
     let result = await variable.get();
     assert.equal(value, result.value);
@@ -41,10 +47,9 @@ describe('firebase', function() {
     let BarType = Type.newEntity(manifest.schemas.Bar);
     let value1 = 'Hi there' + Math.random();
     let value2 = 'Goodbye' + Math.random();
-    let collection = await storage.connect('test1', BarType.collectionOf(), 
-      'firebase://test-firebase-45a3e.firebaseio.com/AIzaSyBLqThan3QCOICj0JZ-nEwk27H4gmnADP8/collection/test');
-    await collection.store({id: 'test0:test0', value: value1}, ['key7']);
-    await collection.store({id: 'test0:test1', value: value2}, ['key8']);
+    let collection = await storage.construct('test1', BarType.collectionOf(), `${testUrl}/test-collection`);
+    await collection.store({id: 'test0:test0', value: value1}, ['key0']);
+    await collection.store({id: 'test0:test1', value: value2}, ['key1']);
     let result = await collection.get('test0:test0');
     assert.equal(value1, result.value);
     result = await collection.toList();

--- a/runtime/manual_tests/firebase-tests.js
+++ b/runtime/manual_tests/firebase-tests.js
@@ -12,7 +12,7 @@ import {StorageProviderFactory} from '../storage/storage-provider-factory.js';
 import {Arc} from '../arc.js';
 import {Manifest} from '../manifest.js';
 import {Type} from '../type.js';
-import {assert} from '../../platform/assert-web.js';
+import {assert} from '../test/chai-web.js';
 
 describe('firebase', function() {
   it('can host a variable', async () => {
@@ -29,7 +29,7 @@ describe('firebase', function() {
     await variable.set({id: 'test0:test', value});
     let result = await variable.get();
     assert.equal(value, result.value);
-  });
+  }).timeout(10000);
 
   it('can host a collection', async () => {
     let manifest = await Manifest.parse(`
@@ -43,8 +43,8 @@ describe('firebase', function() {
     let value2 = 'Goodbye' + Math.random();
     let collection = await storage.connect('test1', BarType.collectionOf(), 
       'firebase://test-firebase-45a3e.firebaseio.com/AIzaSyBLqThan3QCOICj0JZ-nEwk27H4gmnADP8/collection/test');
-    await collection.store({id: 'test0:test0', value: value1});
-    await collection.store({id: 'test0:test1', value: value2});
+    await collection.store({id: 'test0:test0', value: value1}, ['key7']);
+    await collection.store({id: 'test0:test1', value: value2}, ['key8']);
     let result = await collection.get('test0:test0');
     assert.equal(value1, result.value);
     result = await collection.toList();

--- a/runtime/manual_tests/firebase-tests.js
+++ b/runtime/manual_tests/firebase-tests.js
@@ -17,46 +17,137 @@ import {resetStorageForTesting} from '../storage/firebase-storage.js';
 
 const testUrl = 'firebase://arcs-storage-test.firebaseio.com/AIzaSyBLqThan3QCOICj0JZ-nEwk27H4gmnADP8/firebase-storage-test';
 
+// Resolves when the two stores are synchronzied with each other:
+// * same version
+// * no pending changes
+async function synchronized(store1, store2, delay=1) {
+  while (store1._hasLocalChanges || store2._hasLocalChanges || store1.versionForTesting != store2.versionForTesting) {
+    await new Promise(resolve => {
+      setTimeout(resolve, delay);
+    });
+  }
+}
+
 describe('firebase', function() {
+  this.timeout(10000); // eslint-disable-line no-invalid-this
+
+  let lastStoreId = 0;
+  function newStoreKey(name) {
+    return `${testUrl}/${name}-${lastStoreId++}`;
+  }
+
   before(async () => {
     // TODO: perhaps we should do this after the test, and use a unique path for each run instead?
     await resetStorageForTesting(testUrl);
   });
-  it('can host a variable', async () => {
-    let manifest = await Manifest.parse(`
-      schema Bar
-        Text value
-    `);
-    let arc = new Arc({id: 'test'});
-    let storage = new StorageProviderFactory(arc.id);
-    let BarType = Type.newEntity(manifest.schemas.Bar);
-    let value = 'Hi there' + Math.random();
-    let variable = await storage.construct('test0', BarType, `${testUrl}/test-variable`);
-    await variable.set({id: 'test0:test', value});
-    let result = await variable.get();
-    assert.equal(value, result.value);
-  }).timeout(10000);
 
-  it('can host a collection', async () => {
-    let manifest = await Manifest.parse(`
-      schema Bar
-        Text value
-    `);
-    let arc = new Arc({id: 'test'});
-    let storage = new StorageProviderFactory(arc.id);
-    let BarType = Type.newEntity(manifest.schemas.Bar);
-    let value1 = 'Hi there' + Math.random();
-    let value2 = 'Goodbye' + Math.random();
-    let collection = await storage.construct('test1', BarType.collectionOf(), `${testUrl}/test-collection`);
-    await collection.store({id: 'test0:test0', value: value1}, ['key0']);
-    await collection.store({id: 'test0:test1', value: value2}, ['key1']);
-    let result = await collection.get('test0:test0');
-    assert.equal(value1, result.value);
-    result = await collection.toList();
-    assert.lengthOf(result, 2);
-    assert(result[0].value = value1);
-    assert(result[0].id = 'test0:test0');
-    assert(result[1].value = value2);
-    assert(result[1].id = 'test1:test1');
-  }).timeout(10000);
+  describe('variable', () => {
+    it('supports basic construct and mutate', async () => {
+      let manifest = await Manifest.parse(`
+        schema Bar
+          Text value
+      `);
+      let arc = new Arc({id: 'test'});
+      let storage = new StorageProviderFactory(arc.id);
+      let BarType = Type.newEntity(manifest.schemas.Bar);
+      let value = 'Hi there' + Math.random();
+      let variable = await storage.construct('test0', BarType, newStoreKey('variable'));
+      await variable.set({id: 'test0:test', value});
+      let result = await variable.get();
+      assert.equal(value, result.value);
+    });
+    it('resolves concurrent set', async () => {
+      let manifest = await Manifest.parse(`
+        schema Bar
+          Text value
+      `);
+      let arc = new Arc({id: 'test'});
+      let storage = new StorageProviderFactory(arc.id);
+      let BarType = Type.newEntity(manifest.schemas.Bar);
+      let key = newStoreKey('variable');
+      let var1 = await storage.construct('test0', BarType, key);
+      let var2 = await storage.connect('test0', BarType, key);
+      var1.set({id: 'id1', value: 'value1'});
+      var2.set({id: 'id2', value: 'value2'});
+      await synchronized(var1, var2);
+      assert.deepEqual(await var1.get(), await var2.get());
+    });
+  });
+
+  describe('collection', () => {
+    it('supports basic construct and mutate', async () => {
+      let manifest = await Manifest.parse(`
+        schema Bar
+          Text value
+      `);
+      let arc = new Arc({id: 'test'});
+      let storage = new StorageProviderFactory(arc.id);
+      let BarType = Type.newEntity(manifest.schemas.Bar);
+      let value1 = 'Hi there' + Math.random();
+      let value2 = 'Goodbye' + Math.random();
+      let collection = await storage.construct('test1', BarType.collectionOf(), newStoreKey('collection'));
+      await collection.store({id: 'test0:test0', value: value1}, ['key0']);
+      await collection.store({id: 'test0:test1', value: value2}, ['key1']);
+      let result = await collection.get('test0:test0');
+      assert.equal(value1, result.value);
+      result = await collection.toList();
+      assert.lengthOf(result, 2);
+      assert(result[0].value = value1);
+      assert(result[0].id = 'test0:test0');
+      assert(result[1].value = value2);
+      assert(result[1].id = 'test1:test1');
+    });
+    it('resolves concurrent add of same id', async () => {
+      let manifest = await Manifest.parse(`
+        schema Bar
+          Text value
+      `);
+      let arc = new Arc({id: 'test'});
+      let storage = new StorageProviderFactory(arc.id);
+      let BarType = Type.newEntity(manifest.schemas.Bar);
+      let key = newStoreKey('collection');
+      let collection1 = await storage.construct('test1', BarType.collectionOf(), key);
+      let collection2 = await storage.connect('test1', BarType.collectionOf(), key);
+      collection1.store({id: 'id1', value: 'value'}, ['key1']);
+      await collection2.store({id: 'id1', value: 'value'}, ['key2']);
+      await synchronized(collection1, collection2);
+      assert.deepEqual(await collection1.toList(), await collection2.toList());
+    });
+    it('resolves concurrent add/remove of same id', async () => {
+      let manifest = await Manifest.parse(`
+        schema Bar
+          Text value
+      `);
+      let arc = new Arc({id: 'test'});
+      let storage = new StorageProviderFactory(arc.id);
+      let BarType = Type.newEntity(manifest.schemas.Bar);
+      let key = newStoreKey('collection');
+      let collection1 = await storage.construct('test1', BarType.collectionOf(), key);
+      let collection2 = await storage.connect('test1', BarType.collectionOf(), key);
+      collection1.store({id: 'id1', value: 'value'}, ['key1']);
+      collection2.store({id: 'id1', value: 'value'}, ['key2']);
+      collection1.remove('id1', ['key1']);
+      collection2.remove('id1', ['key2']);
+      await synchronized(collection1, collection2);
+      assert.isEmpty(await collection1.toList());
+      assert.isEmpty(await collection2.toList());
+    });
+    it('resolves concurrent add of different id', async () => {
+      let manifest = await Manifest.parse(`
+        schema Bar
+          Text value
+      `);
+      let arc = new Arc({id: 'test'});
+      let storage = new StorageProviderFactory(arc.id);
+      let BarType = Type.newEntity(manifest.schemas.Bar);
+      let key = newStoreKey('collection');
+      let collection1 = await storage.construct('test1', BarType.collectionOf(), key);
+      let collection2 = await storage.connect('test1', BarType.collectionOf(), key);
+      await collection1.store({id: 'id1', value: 'value1'}, ['key1']);
+      await collection2.store({id: 'id2', value: 'value2'}, ['key2']);
+      await synchronized(collection1, collection2);
+      assert.lengthOf(await collection1.toList(), 2);
+      assert.sameDeepMembers(await collection1.toList(), await collection2.toList());
+    });
+  });
 });

--- a/runtime/storage/crdt-collection-model.js
+++ b/runtime/storage/crdt-collection-model.js
@@ -84,6 +84,9 @@ export class CrdtCollectionModel {
   toList() {
     return [...this._items.values()].map(item => item.value);
   }
+  has(id) {
+    return this._items.has(id);
+  }
   getKeys(id) {
     let item = this._items.get(id);
     return item ? [...item.keys] : [];

--- a/runtime/storage/firebase-storage.js
+++ b/runtime/storage/firebase-storage.js
@@ -225,7 +225,7 @@ class FirebaseVariable extends FirebaseStorageProvider {
     // written locally.
     this._value = null;
 
-    // Monotonic vesion, initialized via response from firebase,
+    // Monotonic version, initialized via response from firebase,
     // or a call to `set` (as 0). Updated on changes from firebase
     // or during local modifications.
     this._version = null;
@@ -396,7 +396,7 @@ function setDiff(from, to) {
 // added and removed remotely. These are filtered by a set of suppressions
 // for adds that we have previously issued and then applied to our local
 // model. Each time we receive an update from firebase, we update our local
-// version number. We align it whith the remote version when possible.
+// version number. We align it with the remote version when possible.
 //
 // Local modifications: Additions and removal of entries (and membership
 // keys) are tracked in a local structure, `_localChanges`, and a process

--- a/runtime/storage/firebase-storage.js
+++ b/runtime/storage/firebase-storage.js
@@ -699,4 +699,25 @@ class FirebaseCollection extends FirebaseStorageProvider {
     await this._initialized;
     return this._model.toList();
   }
+
+  async cloneFrom(handle) {
+    this.fromLiteral(await handle.toLiteral());
+  }
+
+  // Returns {version, model: [{id, value, keys: []}]}
+  async toLiteral() {
+    await this._initialized;
+    // TODO: think about what to do here, do we really need toLiteral for a firebase store?
+    // if yes, how should it represent local modifications?
+    await this._persisting;
+    return {
+      version: this._version,
+      model: this._model.toLiteral(),
+    };
+  }
+
+  fromLiteral({version, model}) {
+    this._version = version;
+    this._model = new CrdtCollectionModel(model);
+  }
 }

--- a/runtime/storage/firebase-storage.js
+++ b/runtime/storage/firebase-storage.js
@@ -293,6 +293,10 @@ class FirebaseVariable extends FirebaseStorageProvider {
     this._value = data.value;
   }
 
+  get versionForTesting() {
+    return this._version;
+  }
+
   async get() {
     await this._initialized;
     return this._value;
@@ -486,6 +490,10 @@ class FirebaseCollection extends FirebaseStorageProvider {
       add,
       remove,
     });
+  }
+
+  get versionForTesting() {
+    return this._version;
   }
 
   async get(id) {

--- a/runtime/storage/storage-provider-base.js
+++ b/runtime/storage/storage-provider-base.js
@@ -50,6 +50,7 @@ export class StorageProviderBase {
     this._listeners.set(kind, listeners);
   }
 
+  // TODO: rename to _fireAsync so it's clear that callers are not re-entrant.
   async _fire(kind, details) {
     let listenerMap = this._listeners.get(kind);
     if (!listenerMap || listenerMap.size == 0)


### PR DESCRIPTION
* variable uses LWW (client always wins)
* collection synchronizes the set of membership keys for each entry

Part of https://github.com/PolymerLabs/arcs/issues/1471