### PR TITLE
maybeEnsureResolved clears canReadSubset and canWriteSuperset

### DIFF
--- a/runtime/test/type-variable-tests.js
+++ b/runtime/test/type-variable-tests.js
@@ -12,6 +12,7 @@
 import {assert} from './chai-web.js';
 
 import {Type} from '../type.js';
+import {Schema} from '../schema.js';
 import {TypeVariable} from '../type-variable.js';
 
 describe('TypeVariable', () => {
@@ -53,5 +54,21 @@ describe('TypeVariable', () => {
     b.variable.resolution = a.collectionOf();
     assert.throws(() => a.variable.resolution = b,
         'variable cannot resolve to collection of itself');
+  });
+  it(`maybeEnsureResolved clears canReadSubset and canWriteSuperset`, () => {
+    let a = new TypeVariable('x');
+    let b = Type.newEntity(new Schema({names: ['Thing'], fields: {}}));
+
+    a.maybeMergeCanWriteSuperset(b);
+
+    assert.equal(a.canWriteSuperset, b);
+    assert.notExists(a.canReadSubset);
+    assert.notExists(a.resolution);
+
+    a.maybeEnsureResolved();
+
+    assert.notExists(a.canWriteSuperset);
+    assert.notExists(a.canReadSubset);
+    assert.equal(a.resolution, b);
   });
 });

--- a/runtime/type-variable.js
+++ b/runtime/type-variable.js
@@ -38,7 +38,7 @@ export class TypeVariable {
   maybeMergeCanReadSubset(constraint) {
     if (constraint == null)
       return true;
-    
+
     if (this.canReadSubset == null) {
       this.canReadSubset = constraint;
       return true;
@@ -47,7 +47,7 @@ export class TypeVariable {
     let mergedSchema = Schema.intersect(this.canReadSubset.entitySchema, constraint.entitySchema);
     if (!mergedSchema)
       return false;
-    
+
     this.canReadSubset = Type.newEntity(mergedSchema);
     return true;
   }
@@ -156,11 +156,11 @@ export class TypeVariable {
     if (this._resolution)
       return this._resolution.maybeEnsureResolved();
     if (this._canWriteSuperset) {
-      this._resolution = this._canWriteSuperset;
+      this.resolution = this._canWriteSuperset;
       return true;
     }
     if (this._canReadSubset) {
-      this._resolution = this._canReadSubset;
+      this.resolution = this._canReadSubset;
       return true;
     }
     return false;


### PR DESCRIPTION
There is an invariant of if resolution exists then canReadSubset/canWriteSuperset should not exist. It is expressed in setters and getters for resolution/canWriteSuperset/canReadSubset.

This PR clears canReadSubset/canWriteSuperset if resolution is set in maybeEnsureResolved(), via using a setter for resolution.