### PR TITLE
FindHostedParticle bugfix

### DIFF
--- a/runtime/strategies/find-hosted-particle.js
+++ b/runtime/strategies/find-hosted-particle.js
@@ -49,8 +49,19 @@ export class FindHostedParticle extends Strategy {
             //      then type system has to ensure ~a is at least Entity.
             // The type of a handle hosting the particle literal has to be
             // concrete, so we concretize connection type with maybeEnsureResolved().
-            let handleType = hc.type.clone(new Map());
+            const handleType = hc.type.clone(new Map());
             handleType.maybeEnsureResolved();
+
+            const id = `${arc.id}:particle-literal:${particle.name}`;
+
+            // Reuse a handle if we already hold this particle spec in the recipe.
+            for (let handle of recipe.handles) {
+              if (handle.id === id && handle.fate === 'copy'
+                  && handle._mappedType && handle._mappedType.equals(handleType)) {
+                hc.connectToHandle(handle);
+                return;
+              }
+            }
 
             // TODO: Add a digest of a particle literal to the ID, so that we
             //       can ensure we load the correct particle. It is currently
@@ -59,12 +70,12 @@ export class FindHostedParticle extends Strategy {
             let handle = recipe.newHandle();
             handle._mappedType = handleType;
             handle.fate = 'copy';
-            handle.id = `${arc.generateID()}:particle-literal:${particle.name}`;
+            handle.id = id;
             hc.connectToHandle(handle);
           });
         }
         return results;
       }
-    }(Walker.Independent), this);
+    }(Walker.Permuted), this);
   }
 }


### PR DESCRIPTION
Avoids `arc.generateID()` in the FindHostedParticle, as it was causing generating multiple copies of the same recipe in the strategizer with only this handle id different.

Fixes the issue of introducing 2 handles with the same ID by reusing the handle.