### PR TITLE
Issue in shape vs entity checking in processTypeList

### DIFF
--- a/runtime/test/type-checker-tests.js
+++ b/runtime/test/type-checker-tests.js
@@ -13,6 +13,7 @@
 import {assert} from './chai-web.js';
 
 import {Schema} from '../schema.js';
+import {Shape} from '../shape.js';
 import {Type} from '../type.js';
 import {TypeChecker} from '../recipe/type-checker.js';
 import {TypeVariable} from '../type-variable.js';
@@ -171,6 +172,19 @@ describe('TypeChecker', () => {
     let a = Type.newEntity(new Schema({names: ['Thing'], fields: {}}));
     let b = Type.newVariable(new TypeVariable('a')).collectionOf();
     assert.isNull(TypeChecker.processTypeList(a, [{type: b, direction: 'inout'}]));
+  });
+
+  it.only('does not resolve type variable constraint to an Entity and an Interface', async () => {
+    let a = Type.newVariable(new TypeVariable('a'));
+    let b = Type.newEntity(new Schema({names: ['Product'], fields: {}}));
+    let c = Type.newInterface(new Shape('Test', [], [{name: Type.newVariable({name: 'y'})}]));
+
+    // Constraints 'a' canWriteSuperset to 'b'.
+    assert.exists(TypeChecker.processTypeList(a, [{type: b, direction: 'in'}]));
+    assert.equal(a.variable.canWriteSuperset.entitySchema.name, 'Product');
+
+    // 'a' cannot be an entity and an interface at the same time.
+    assert.notExists(Handle.effectiveType(a, [{type: c, direction: 'host'}]));
   });
 
   it('does not modify an input baseType if invoked through Handle.effectiveType', async () => {


### PR DESCRIPTION
@shans maybe you could look into this? Seems to me that we are not checking for `isInterface` vs. `isEntity` correctly everywhere in `TypeChecker`.

I would have taken a stab at this myself, but I need to leave in couple of hours for good, so I'm leaving this to you.

I wanted to have a stab at fixing `(arc/manifest).findStoresByType` and found that when comparing interface and entity stores using `Handle.effectiveType` doesn't yield correct result.