### PR TITLE
RecipeIndex handle matching tags fix

### DIFF
--- a/runtime/recipe-index.js
+++ b/runtime/recipe-index.js
@@ -154,10 +154,9 @@ export class RecipeIndex {
               || otherCounts.out + counts.out === 0) continue;
         }
 
-        // If one or the handles have tags, we need to have overlap.
-        if (handle.tags.length > 0 || otherHandle.tags.length > 0) {
-          if (!handle.tags.some(t => otherHandle.tags.includes(t))) continue;
-        }
+        // If requesting handle has tags, we should have overlap.
+        if (handle.tags.length > 0 && !handle.tags.some(t => otherHandle.tags.includes(t))) continue;
+
 
         // If types don't match.
         if (!Handle.effectiveType(handle._mappedType,

--- a/runtime/test/recipe-index-test.js
+++ b/runtime/test/recipe-index-test.js
@@ -259,6 +259,36 @@ describe('RecipeIndex', function() {
         index.findHandleMatch(handle).map(h => h.recipe.name));
   });
 
+  it('finds tagged handles if selecting handle is not tagged', async () => {
+    let index = await createIndex(`
+      schema Thing
+
+      particle Consumer
+        in Thing thing
+      particle Producer
+        out Thing thing
+
+      recipe TakeMe1
+        create #loved as thing
+        Producer
+
+      recipe TakeMe2
+        create #hated as thing
+        Producer
+
+      recipe Selector
+        use as thing
+        Consumer
+    `);
+
+    let recipe = index.recipes.find(r => r.name === 'Selector');
+    let handle = recipe.handles[0];
+
+    assert.deepEqual(
+        ['TakeMe1', 'TakeMe2'],
+        index.findHandleMatch(handle).map(h => h.recipe.name));
+  });
+
   it('matching use/create handle pairs require communication', async () => {
     let index = await createIndex(`
       schema Thing


### PR DESCRIPTION
Makes tag checking more lenient, if a `use` handle doesn't have any tags, the matching `create` handle with tags is accepted.

This allows feeding the tagged data to generic non-tagged recipes.