### PR TITLE
Adds recipes for making generic lists of items

### DIFF
--- a/artifacts/Common/Detail.manifest
+++ b/artifacts/Common/Detail.manifest
@@ -10,4 +10,10 @@ particle DetailSlider in 'source/DetailSlider.js'
   inout ~a selected
   consume modal
     must provide content
+      handle selected
   description `show details about ${selected}`
+
+recipe DetailSlider
+  use #selected as selected
+  DetailSlider
+    selected = selected

--- a/artifacts/Common/List.manifest
+++ b/artifacts/Common/List.manifest
@@ -28,7 +28,7 @@ particle List in 'source/List.js'
     provide action
       handle items
     provide postamble
-  description `list that can contain ${items}`
+  description `list of ${items}`
 
 particle SelectableList in 'source/List.js'
   inout [~a] items
@@ -42,7 +42,7 @@ particle SelectableList in 'source/List.js'
     provide action
       handle items
     provide postamble
-  description `list that can contain ${items} with selection`
+  description `list of ${items} with selection`
 
 particle ContentList in 'source/List.js'
   in [~a] items
@@ -55,7 +55,16 @@ particle ContentList in 'source/List.js'
     provide action
       handle items
     provide postamble
-  description `list that can contain ${items}`
+  description `list of ${items}`
+
+recipe
+  use as items
+  create #selected as selected
+  SelectableList
+    items = items
+    selected = selected
+  ItemMultiplexer
+    list = items
 
 // tile lists
 
@@ -73,7 +82,7 @@ particle TileList in 'source/TileList.js'
   consume root
     must provide set of tile
     provide set of action
-  description `tiling that can contain ${items}`
+  description `tiling of ${items}`
 
 particle SelectableTileList in 'source/TileList.js'
   inout [~a] items
@@ -81,4 +90,13 @@ particle SelectableTileList in 'source/TileList.js'
   consume root
     must provide set of tile
     provide set of action
-  description `tiling that can contain ${items} with selection`
+  description `tiling of ${items} with selection`
+
+recipe
+  use as items
+  create #selected as selected
+  SelectableTileList
+    items = items
+    selected = selected
+  TileMultiplexer
+    list = items

--- a/runtime/test/demo-flow-test.js
+++ b/runtime/test/demo-flow-test.js
@@ -80,7 +80,8 @@ describe('demo flow', function() {
       `Add items from Claire's wishlist (Book: How to Draw plus 2 other items).`,
       'Check manufacturer information for products from your browsing context ' +
         '(Minecraft Book plus 2 other items).',
-      `Find out about Claire's interests.`
+      `Find out about Claire's interests.`,
+      `List of products from your browsing context (Minecraft Book plus 2 other items) with selection.`
       /*
       'Buy gifts for Claire\'s Birthday on 2017-08-04, estimate arrival date for ' +
         'products from your browsing context (Minecraft Book plus 2 other items), and estimate ' +
@@ -96,7 +97,7 @@ describe('demo flow', function() {
       // 'Show products from your browsing context (Minecraft Book plus 2 other items).',
       // 'Show products recommended based on products from your browsing context and Claire\'s wishlist (Book: How to Draw plus 2 other items).'
     ];
-    await helper.makePlans({expectedNumPlans: 4, expectedSuggestions});
+    await helper.makePlans({expectedNumPlans: 5, expectedSuggestions});
     helper.log('----------------------------------------');
 /*
     // 1.5 Select 'Add items from...'


### PR DESCRIPTION
This patch adds generic recipes for list and tiling, made of our generic particles.

Now we can leverages `FindHostedParticle` strategy and coalescing to produce list/tiles anytime we have a collection of items (in a handle or as an output of a recipe) and a particle that can render a single item.

Added tests to ensure such composition is possible.

Once we have better ranking in place, we should ensure that more specific recipes are taking priority, this however is (probably) a useful thing to have in our toolkit.