### PR TITLE
better AppVeyor badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Build Status](https://travis-ci.org/PolymerLabs/arcs.svg?branch=master)](https://travis-ci.org/PolymerLabs/arcs)
-[![Appveyor Build status](https://ci.appveyor.com/api/projects/status/rswlpkq2vtp9cns0?svg=true)](https://ci.appveyor.com/project/arcs/arcs-3i77k)
+[![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/rswlpkq2vtp9cns0/branch/master?svg=true)](https://ci.appveyor.com/project/arcs/arcs-3i77k/branch/master)
+
 
 
 # arcs


### PR DESCRIPTION
The AppVeyor build icon should only provide status for the last build on master.

The old link location was using the status from the build on master, but the link would go to the last build on any branch (including PRs) - so you might see a failing build via the icon, and follow the link to find a later passing one on a random PR.