### PR TITLE
exclude the may-resolved type from recipe hash calculation

### DIFF
--- a/runtime/recipe/handle.js
+++ b/runtime/recipe/handle.js
@@ -216,12 +216,14 @@ export class Handle {
       result.push('//');
       if (this.type.isResolved()) {
         result.push(this.type.resolvedType().toString());
-      } else if (this.type.canEnsureResolved()) {
-        let type = Type.fromLiteral(this.type.toLiteral());
-        type.maybeEnsureResolved();
-        result.push(type.resolvedType().toString());
       } else {
         result.push(this.type.toString());
+        if (options && options.showUnresolved && this.type.canEnsureResolved()) {
+          let type = Type.fromLiteral(this.type.toLiteral());
+          type.maybeEnsureResolved();
+          result.push('//');
+          result.push(type.resolvedType().toString());
+        }
       }
     }
     if (options && options.showUnresolved) {

--- a/runtime/recipe/handle.js
+++ b/runtime/recipe/handle.js
@@ -217,6 +217,7 @@ export class Handle {
       if (this.type.isResolved()) {
         result.push(this.type.resolvedType().toString());
       } else {
+        // TODO: include the unresolved constraints in toString (ie in the hash).
         result.push(this.type.toString());
         if (options && options.showUnresolved && this.type.canEnsureResolved()) {
           let type = Type.fromLiteral(this.type.toLiteral());

--- a/runtime/test/planner-tests.js
+++ b/runtime/test/planner-tests.js
@@ -621,8 +621,8 @@ describe('Automatic resolution', function() {
 `);
 
     assert.equal(`recipe
-  create as handle0 // Thing {Text id}
-  create as handle1 //  {Number count}
+  create as handle0 // ~
+  create as handle1 // ~
   create as handle2 // Location {Number lat, Number lng}
   A as particle0
     product -> handle0

--- a/runtime/test/recipe-index-test.js
+++ b/runtime/test/recipe-index-test.js
@@ -46,8 +46,8 @@ describe('RecipeIndex', function() {
         Transform
     `), [
 `recipe
-  use as handle0 // Lumberjack {}
-  use as handle1 // Person {}
+  use as handle0 // ~
+  use as handle1 // ~
   Transform as particle0
     lumberjack -> handle0
     person <- handle1`
@@ -110,9 +110,9 @@ describe('RecipeIndex', function() {
         Transform.b -> TransformAgain.b
     `), [
 `recipe
-  use as handle0 // A {}
+  use as handle0 // ~
   create as handle1 // B {}
-  use as handle2 // C {}
+  use as handle2 // ~
   Transform as particle0
     a <- handle0
     b -> handle1

--- a/runtime/test/recipe-test.js
+++ b/runtime/test/recipe-test.js
@@ -342,6 +342,18 @@ describe('recipe', function() {
     recipe.handles[0].id = 'my-things';
     recipe.normalize();
     assert.isFalse(recipe.isResolved());
+    assert.equal(`recipe
+  map 'my-things' as handle0 // ~
+  Generic as particle0
+    any <- handle0
+  Specific as particle1
+    thing <- handle0`, recipe.toString());
+    assert.equal(`recipe
+  map 'my-things' as handle0 // ~ // Thing {}  // unresolved handle: unresolved type
+  Generic as particle0
+    any <- handle0
+  Specific as particle1
+    thing <- handle0`, recipe.toString({showUnresolved: true}));
     let hash = await recipe.digest();
 
     let recipeClone = recipe.clone();
@@ -353,6 +365,13 @@ describe('recipe', function() {
     recipeClone.normalize();
     assert.isTrue(recipeClone.isResolved());
     let hashResolvedClone = await recipeClone.digest();
+    assert.equal(`recipe
+  map 'my-things' as handle0 // Thing {}
+  Generic as particle0
+    any <- handle0
+  Specific as particle1
+    thing <- handle0`, recipeClone.toString());
+    assert.equal(recipeClone.toString(), recipeClone.toString({showUnresolved: true}));
     assert.notEqual(hash, hashResolvedClone);
   });
 });

--- a/runtime/test/strategies/convert-constraints-to-connections-tests.js
+++ b/runtime/test/strategies/convert-constraints-to-connections-tests.js
@@ -387,7 +387,7 @@ describe('ConvertConstraintsToConnections', async () => {
     let results = await cctc.generate(inputParams);
     assert.lengthOf(results, 1);
     assert.deepEqual(results[0].result.toString(), `recipe
-  ? as handle0 // S {}
+  ? as handle0 // ~
   ? as handle1 // S {}
   A as particle0
     o -> handle0
@@ -413,8 +413,8 @@ describe('ConvertConstraintsToConnections', async () => {
     let results = await cctc.generate(inputParams);
     assert.lengthOf(results, 1);
     assert.deepEqual(results[0].result.toString(), `recipe
-  ? #hashtag as handle0 // S {}
-  create #trashbag as handle1 // S {}
+  ? #hashtag as handle0 // ~
+  create #trashbag as handle1 // ~
   A as particle0
     o -> handle0
   B as particle1
@@ -439,8 +439,8 @@ describe('ConvertConstraintsToConnections', async () => {
     let results = await cctc.generate(inputParams);
     assert.lengthOf(results, 1);
     assert.deepEqual(results[0].result.toString(), `recipe
-  ? #hashtag as handle0 // S {}
-  create #trashbag as handle1 // S {}
+  ? #hashtag as handle0 // ~
+  create #trashbag as handle1 // ~
   A as particle0
     o -> handle0
   B as particle1
@@ -467,7 +467,7 @@ describe('ConvertConstraintsToConnections', async () => {
     let results = await cctc.generate(inputParams);
     assert.lengthOf(results, 1);
     assert.deepEqual(results[0].result.toString(), `recipe
-  ? #hashtag as handle0 // S {}
+  ? #hashtag as handle0 // ~
   A as particle0
     o -> handle0
   B as particle1


### PR DESCRIPTION
The problem it is trying to solve:
```
recipe SerialContext4
  map 'favorite|from|-L8ZV2_gCxnL4SSz-16-|-LH4k7Ai27t49lWgsQ_Y' as food
  slot #root as slot0
  SerialContext
    food <- food
    consume root as slot0

recipe SerialContext5
  map 'favorite|from|-L8ZV2_gCxnL4SSz-16-|-LH4k7Ai27t49lWgsQ_Y' as food
  slot 'rootslotid-root' #root as slot0
  SerialContext
    food <- food
    consume root as slot0
```
resolve-recipe works for SerialContext4, but fails for SerialContext5. the reason is that when only resolving the handle, ie calling mapToStorage, the strategy resolves the type, but resolving the type doesn't affect the recipe hash. Hence the resolved recipe is being filtered out as previously seen.

I think that recipe.toString() should use the resolved type, unless the toString is called to user visible / debugging purposes. If this change seems reasonable, I'll fix the tests to pass.














