### PR TITLE
add more debug logs to demo-flow-test and refactor particle-shape-loading-with-slots test

### DIFF
--- a/runtime/test/demo-flow-test.js
+++ b/runtime/test/demo-flow-test.js
@@ -43,7 +43,7 @@ describe('demo flow', function() {
     helper.slotComposer
       .newExpectations('Show products from your browsing context (...)')
         .expectRenderSlot('List', 'root', {contentTypes: ['template']})
-        .expectRenderSlot('List', 'root', {contentTypes: ['model'], times: 1})
+        .expectRenderSlot('List', 'root', {contentTypes: ['model']})
         .expectRenderSlot('ShowProduct', 'item', {contentTypes: ['template', 'model']})
         .expectRenderSlot('ShowProduct', 'item', {contentTypes: ['model'], times: 2})
         .expectRenderSlot('ItemMultiplexer', 'item', {contentTypes: ['template', 'model'], hostedParticle: 'ShowProduct'})

--- a/runtime/testing/mock-slot-composer.js
+++ b/runtime/testing/mock-slot-composer.js
@@ -46,6 +46,17 @@ export class MockSlotComposer extends SlotComposer {
     SlotDomConsumer.dispose();
   }
 
+   // Overriding this method to investigate AppVeyor failures.
+   // TODO: get rid of it once the problem is fixed.
+  _addSlotConsumer(slot) {
+    super._addSlotConsumer(slot);
+    let startCallback = slot.startRenderCallback;
+    slot.startRenderCallback = ({particle, slotName, contentTypes}) => {
+      this._addDebugMessages(`  StartRender: ${slot.consumeConn.getQualifiedName()}`);
+      startCallback({particle, slotName, contentTypes});
+    };
+  }
+
   /** @method newExpectations()
    * Reinitializes expectations queue.
    */


### PR DESCRIPTION
AppVeyor failure:
```
1) demo flow
       flows like a demo:
     Uncaught AssertionError: --------------------------------------------
Show products from your browsing context (...) : 
    renderSlot List : root - template, model, templateName
3 expectations : {ShowProduct: (template=1; model=3), ItemMultiplexer: (template=1; model=1; opt_model=2)}
    renderSlot ShowProduct : item - template, model, templateName
    renderSlot ShowProduct : item - template, model, templateName
    renderSlot ShowProduct : item - template, model, templateName
    renderSlot ItemMultiplexer (ShowProduct) : item - template, model, templateName
3 expectations : {ShowProduct: (model=2), ItemMultiplexer: (template=1; model=1; opt_model=2)}
3 expectations : {ShowProduct: (model=1), ItemMultiplexer: (template=1; model=1; opt_model=2)}
2 expectations : {ItemMultiplexer: (template=1; model=1; opt_model=2)}
1 expectations : {ItemMultiplexer: (opt_model=2)}
----------------------
Check shipping for Claire (Claire)'s Birthday on... : 
    renderSlot GiftList : preamble - template, model, templateName
4 expectations : {Arrivinator: (template=3; model=3), AlternateShipping: (template=3; model=3), Multiplexer: (template=2; undefined=2)}
    renderSlot Arrivinator : annotation - template, model, templateName
    renderSlot Arrivinator : annotation - template, model, templateName
    renderSlot Arrivinator : annotation - template, model, templateName
    renderSlot Multiplexer (Arrivinator) : annotation - template, model, templateName
4 expectations : {Arrivinator: (template=2; model=2), AlternateShipping: (template=3; model=3), Multiplexer: (template=2; undefined=2)}
4 expectations : {Arrivinator: (template=1; model=1), AlternateShipping: (template=3; model=3), Multiplexer: (template=2; undefined=2)}
3 expectations : {AlternateShipping: (template=3; model=3), Multiplexer: (template=2; undefined=2)}
2 expectations : {AlternateShipping: (template=3; model=3), Multiplexer: (template=1; undefined=1)}
    renderSlot AlternateShipping : annotation - template, model, templateName
    renderSlot AlternateShipping : annotation - template, model, templateName
    renderSlot AlternateShipping : annotation - template, model, templateName
    renderSlot Multiplexer (AlternateShipping) : annotation - template, model, templateName
2 expectations : {AlternateShipping: (template=2; model=2), Multiplexer: (template=1; undefined=1)}
2 expectations : {AlternateShipping: (template=1; model=1), Multiplexer: (template=1; undefined=1)}
1 expectations : {Multiplexer: (template=1; undefined=1)}
0 expectations : {}
----------------------
Add items from Claire's wishlist (...) : 
    renderSlot Chooser : action - template, model, templateName
2 expectations : {AlsoOn: (template=1; model=3), Multiplexer2: (template=1; undefined=1)}
----------------------
remaining expectations:
   render:  AlsoOn annotation undefined template,model,model,model
  render:  Multiplexer2 annotation undefined template,
      at MockSlotComposer.assertExpectationsCompleted (file:///C:/projects/ARCS-3~1/runtime/testing/mock-slot-composer.js:120:5)
      at Timeout.timeout.setTimeout [as _onTimeout] (file:///C:/projects/ARCS-3~1/runtime/testing/test-helper.js:84:55)
  2) multi-slot test
       can render question slot:
      AssertionError: expected false to be true
      + expected - actual
      -false
      +true
      
      at verifyFooItems (file:///C:/projects/ARCS-3~1/runtime/test/particle-shape-loading-with-slots-test.js:66:14)
      at Context.it (file:///C:/projects/ARCS-3~1/runtime/test/particle-shape-loading-with-slots-test.js:151:5)
      at <anonymous>
  3) "after each" hook:
     Uncaught TypeError: Cannot set property 'state' of undefined
      at <anonymous>
```
This change should fix (2) and help understand (1).