### PR TITLE
Coalesce restaurants

### DIFF
--- a/artifacts/Restaurants/FindRestaurants.manifest
+++ b/artifacts/Restaurants/FindRestaurants.manifest
@@ -14,6 +14,6 @@ particle FindRestaurants in 'source/FindRestaurants.js'
   inout [Restaurant] restaurants
   affordance dom
   consume root
-    provide masterdetail
+    must provide masterdetail
       handle restaurants
   description `find restaurants near ${location}`

--- a/artifacts/Restaurants/Restaurants.recipes
+++ b/artifacts/Restaurants/Restaurants.recipes
@@ -12,33 +12,22 @@ import 'RestaurantDetail.manifest'
 import '../Places/ExtractLocation.manifest'
 
 recipe &displayRestaurants
+  ? as list
   RestaurantMasterDetail.selected -> RestaurantList.selected
   RestaurantDetail.selected -> RestaurantList.selected
   RestaurantMasterDetail.list -> RestaurantList.list
   RestaurantList
+    list <- list
 
-recipe &findLocation
+recipe
   create as location
   ExtractLocation
     location -> location
-
-recipe &showRestaurants
-  create #restaurants #nosync as restaurants
-  FindRestaurants
-    restaurants = restaurants
-  &displayRestaurants
-    list <- restaurants
 
 recipe &nearbyRestaurants
   create #restaurants #nosync as restaurants
-  create as location
-  ExtractLocation
-    location -> location
   FindRestaurants
-    location <- location
     restaurants = restaurants
-  &displayRestaurants
-    list <- restaurants
 
 import '../Events/Event.schema'
 import '../Events/PartySize.manifest'

--- a/artifacts/Restaurants/Restaurants.recipes
+++ b/artifacts/Restaurants/Restaurants.recipes
@@ -17,7 +17,19 @@ recipe &displayRestaurants
   RestaurantMasterDetail.list -> RestaurantList.list
   RestaurantList
 
-recipe
+recipe &findLocation
+  create as location
+  ExtractLocation
+    location -> location
+
+recipe &showRestaurants
+  create #restaurants #nosync as restaurants
+  FindRestaurants
+    restaurants = restaurants
+  &displayRestaurants
+    list <- restaurants
+
+recipe &nearbyRestaurants
   create #restaurants #nosync as restaurants
   create as location
   ExtractLocation

--- a/runtime/planner.js
+++ b/runtime/planner.js
@@ -83,12 +83,6 @@ export class Planner {
     return allResolved;
   }
 
-  _matchesActiveRecipe(plan) {
-    let planShape = RecipeUtil.recipeToShape(plan);
-    let result = RecipeUtil.find(this._arc._activeRecipe, planShape);
-    return result.some(r => r.score == 0);
-  }
-
   _speculativeThreadCount() {
     // TODO(wkorman): We'll obviously have to rework the below when we do
     // speculation in the cloud.
@@ -143,7 +137,7 @@ export class Planner {
       for (let plan of group) {
         let hash = ((hash) => { return hash.substring(hash.length - 4);})(await plan.digest());
 
-        if (this._matchesActiveRecipe(plan)) {
+        if (RecipeUtil.matchesRecipe(this._arc._activeRecipe, plan)) {
           this._updateGeneration(generations, hash, (g) => g.active = true);
           continue;
         }

--- a/runtime/recipe/handle.js
+++ b/runtime/recipe/handle.js
@@ -161,13 +161,13 @@ export class Handle {
         mustBeResolved = false;
       if ((mustBeResolved && !this.type.isResolved()) || !this.type.canEnsureResolved()) {
         if (options) {
-          options.details = 'unresolved type';
+          options.details.push('unresolved type');
         }
         resolved = false;
       }
     } else {
       if (options) {
-        options.details = 'missing type';
+        options.details.push('missing type');
       }
       resolved = false;
     }
@@ -175,7 +175,7 @@ export class Handle {
     switch (this.fate) {
       case '?': {
         if (options) {
-          options.details += 'missing fate';
+          options.details.push('missing fate');
         }
         resolved = false;
         break;
@@ -184,7 +184,7 @@ export class Handle {
       case 'map':
       case 'use': {
         if (options && this.id === null) {
-          options.details += 'missing id';
+          options.details.push('missing id');
         }
         resolved = resolved && (this.id !== null);
         break;
@@ -194,7 +194,7 @@ export class Handle {
         break;
       default: {
         if (options) {
-          options.details += `invalid fate ${this.fate}`;
+          options.details.push(`invalid fate ${this.fate}`);
         }
         assert(false, `Unexpected fate: ${this.fate}`);
         resolved = false;
@@ -204,6 +204,7 @@ export class Handle {
   }
 
   toString(nameMap, options) {
+    options = options || {};
     // TODO: type? maybe output in a comment
     let result = [];
     result.push(this.fate);
@@ -215,22 +216,22 @@ export class Handle {
     if (this.type) {
       result.push('//');
       if (this.type.isResolved()) {
-        result.push(this.type.resolvedType().toString());
+        result.push(this.type.resolvedType().toString({hideFields: options.hideFields == undefined ? true: options.hideFields}));
       } else {
         // TODO: include the unresolved constraints in toString (ie in the hash).
         result.push(this.type.toString());
-        if (options && options.showUnresolved && this.type.canEnsureResolved()) {
+        if (options.showUnresolved && this.type.canEnsureResolved()) {
           let type = Type.fromLiteral(this.type.toLiteral());
           type.maybeEnsureResolved();
           result.push('//');
-          result.push(type.resolvedType().toString());
+          result.push(type.resolvedType().toString({hideFields: options.hideFields == undefined ? true: options.hideFields}));
         }
       }
     }
-    if (options && options.showUnresolved) {
-      let options = {};
-      if (!this.isResolved(options)) {
-        result.push(` // unresolved handle: ${options.details}`);
+    if (options.showUnresolved) {
+      let unresolvedOptions = {details: []};
+      if (!this.isResolved(unresolvedOptions)) {
+        result.push(` // unresolved handle: ${unresolvedOptions.details.join(', ')}`);
       }
     }
 

--- a/runtime/recipe/recipe-util.js
+++ b/runtime/recipe/recipe-util.js
@@ -307,4 +307,11 @@ export class RecipeUtil {
     counts.out += counts.inout;
     return counts;
   }
+
+  // Returns true if `otherRecipe` matches the shape of recipe.
+  static matchesRecipe(recipe, otherRecipe) {
+    let shape = RecipeUtil.recipeToShape(otherRecipe);
+    let result = RecipeUtil.find(recipe, shape);
+    return result.some(r => r.score == 0);
+  }
 }

--- a/runtime/recipe/recipe.js
+++ b/runtime/recipe/recipe.js
@@ -20,7 +20,7 @@ export class Recipe {
     this._particles = [];
     this._handles = [];
     this._slots = [];
-    this.name = name;
+    this._name = name;
 
     // TODO: Recipes should be collections of records that are tagged
     // with a type. Strategies should register the record types they
@@ -154,6 +154,8 @@ export class Recipe {
         && (!this.search || this.search.isValid(options));
   }
 
+  get name() { return this._name; }
+  set name(name) { this._name = name; }
   get localName() { return this._localName; }
   set localName(name) { this._localName = name; }
   get particles() { return this._particles; } // Particle*
@@ -388,6 +390,8 @@ export class Recipe {
       cloneMap.set(object, clonedObject);
     }
 
+    recipe._name = this.name;
+    recipe._verbs = this._verbs.slice();
     this._handles.forEach(cloneTheThing);
     this._particles.forEach(cloneTheThing);
     this._slots.forEach(cloneTheThing);

--- a/runtime/schema.js
+++ b/runtime/schema.js
@@ -295,10 +295,10 @@ export class Schema {
     return clazz;
   }
 
-  toInlineSchemaString() {
+  toInlineSchemaString(options) {
     let names = (this.names || ['*']).join(' ');
     let fields = Object.entries(this.fields).map(([name, type]) => `${Schema._typeString(type)} ${name}`).join(', ');
-    return `${names} {${fields}}`;
+    return `${names} {${fields.length > 0 && options && options.hideFields ? '...' : fields}}`;
   }
 
   toManifestString() {

--- a/runtime/strategies/fallback-fate.js
+++ b/runtime/strategies/fallback-fate.js
@@ -14,15 +14,13 @@ import {Walker} from '../recipe/walker.js';
 export class FallbackFate extends Strategy {
   getResults(inputParams) {
     assert(inputParams);
-    let generated = inputParams.generated.filter(result => !result.result.isResolved());
-    let terminal = inputParams.terminal;
-    return [...generated, ...terminal];
+    return inputParams.terminal.filter(result => !result.result.isResolved());
   }
 
   async generate(inputParams) {
     return Recipe.over(this.getResults(inputParams), new class extends Walker {
       onHandle(recipe, handle) {
-        // Only apply this strategy only to user query based recipes with resolved tokens.
+        // Only apply this strategy to user query based recipes with resolved tokens.
         if (!recipe.search || (recipe.search.resolvedTokens.length == 0)) {
           return;
         }

--- a/runtime/test/recipe/search-test.js
+++ b/runtime/test/recipe/search-test.js
@@ -1,0 +1,65 @@
+/**
+ * @license
+ * Copyright (c) 2018 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {Search} from '../../recipe/search.js';
+import {Recipe} from '../../recipe/recipe.js';
+import {assert} from '../chai-web.js';
+
+describe('Recipe Search', function() {
+  let createAndVerifyResolved = (search) => {
+    assert.isTrue(search.isValid());
+    search._normalize();
+    assert.isTrue(search.isResolved());
+    return search;
+  };
+  let createAndVerifyUnresolved = (search) => {
+    assert.isTrue(search.isValid());
+    search._normalize();
+    assert.isFalse(search.isResolved());
+    return search;
+  };
+
+  it('constructs new search', () => {
+    let search = createAndVerifyUnresolved(new Search('hello world'));
+    assert.equal('hello world', search.phrase);
+    assert.deepEqual(['hello', 'world'], search.unresolvedTokens);
+    assert.isEmpty(search.resolvedTokens);
+
+    search = createAndVerifyResolved(new Search('hello world', []));
+    assert.equal('hello world', search.phrase);
+    assert.isEmpty(search.unresolvedTokens);
+    assert.deepEqual(['hello', 'world'], search.resolvedTokens);
+
+    search = createAndVerifyResolved(new Search('hello world bye world', ['hello', 'world']));
+    assert.equal('hello world bye world', search.phrase);
+    assert.deepEqual(['hello', 'world'], search.unresolvedTokens);
+    assert.deepEqual(['bye', 'world'], search.resolvedTokens);
+  });
+
+  it('copies search to recipe', () => {
+    let recipe = new Recipe();
+    new Search('hello world bye world')._copyInto(recipe);
+
+    assert.equal('hello world bye world', recipe.search.phrase);
+    assert.deepEqual(['hello', 'world', 'bye', 'world'], recipe.search.unresolvedTokens);
+    assert.isEmpty(recipe.search.resolvedTokens);
+    let cloneRecipe = recipe.clone();
+    assert(cloneRecipe.normalize());
+    assert.isFalse(cloneRecipe.isResolved());
+
+    new Search('one two three', ['two'])._copyInto(recipe);    
+    assert.equal('hello world bye world one two three', recipe.search.phrase);
+    assert.deepEqual(['hello', 'world', 'bye', 'world', 'two'], recipe.search.unresolvedTokens);
+    assert.deepEqual(['one', 'three'], recipe.search.resolvedTokens);
+    cloneRecipe = recipe.clone();
+    assert(cloneRecipe.normalize());
+    assert.isTrue(cloneRecipe.isResolved());
+  });
+});

--- a/runtime/test/strategies/fallback-fate-tests.js
+++ b/runtime/test/strategies/fallback-fate-tests.js
@@ -34,7 +34,7 @@ describe('FallbackFate', function() {
     recipe.handles.forEach(v => v._originalFate = '?');
     assert(recipe.normalize());
     let arc = StrategyTestHelper.createTestArc('test-plan-arc', manifest, 'dom');
-    let inputParams = {generated: [{result: manifest.recipes[0], score: 1}], terminal: []};
+    let inputParams = {terminal: [{result: manifest.recipes[0], score: 1}], generated: []};
     let strategy = new FallbackFate(arc);
 
     // no resolved search tokens.

--- a/runtime/test/strategies/match-recipe-by-verb-tests.js
+++ b/runtime/test/strategies/match-recipe-by-verb-tests.js
@@ -43,7 +43,7 @@ describe('MatchRecipeByVerb', function() {
     let results = await mrv.generate(inputParams);
     assert.lengthOf(results, 1);
     assert.isEmpty(results[0].result.particles);
-    assert.deepEqual(results[0].result.toString(), 'recipe\n  JumpingBoots.e <- NuclearReactor.e\n  JumpingBoots.f <- FootFactory.f');
+    assert.deepEqual(results[0].result.toString(), 'recipe &jump\n  JumpingBoots.e <- NuclearReactor.e\n  JumpingBoots.f <- FootFactory.f');
   });
   it('plays nicely with constraints', async () => {
     let manifest = await Manifest.parse(`
@@ -70,7 +70,7 @@ describe('MatchRecipeByVerb', function() {
     results = await cctc.generate({generated: results});
     assert.lengthOf(results, 1);
     assert.deepEqual(results[0].result.toString(),
-`recipe
+`recipe &a
   create as handle0 // S {}
   P as particle0
     p -> handle0

--- a/runtime/type.js
+++ b/runtime/type.js
@@ -326,15 +326,15 @@ export class Type {
     return false;
   }
 
-  toString() {
+  toString(options) {
     if (this.isCollection)
-      return `[${this.primitiveType().toString()}]`;
+      return `[${this.primitiveType().toString(options)}]`;
     if (this.isEntity)
-      return this.entitySchema.toInlineSchemaString();
+      return this.entitySchema.toInlineSchemaString(options);
     if (this.isInterface)
       return this.interfaceShape.name;
     if (this.isTuple)
-      return this.tupleFields.toString();
+      return this.tupleFields.toString(options);
     if (this.isVariableReference)
       return `~${this.data}`;
     if (this.isManifestReference)


### PR DESCRIPTION
Type "nearby restaurants" in the search input box. The `&nearbyRestaurants` recipe only contains the `FindRestaurants` particle. 
The strategizer finds a recipe that can provide a missing `location` handle and a `displayRestaurants` recipe that consumes the `masterdetail` provided slot (that must be consumed).

https://github.com/PolymerLabs/arcs/issues/1650