### PR TITLE
HELP NEEDED: reproduce the "Claire problem"

### DIFF
--- a/artifacts/Products/Products.recipes
+++ b/artifacts/Products/Products.recipes
@@ -8,9 +8,9 @@
 
 import 'ShowProducts.recipes'
 import 'Recommend.recipes'
-import 'Manufacturer.recipes'
+// import 'Manufacturer.recipes'
 import 'Gifts.recipes'
-import 'Interests.recipes'
+// import 'Interests.recipes'
 
 import '../Demo/ClairesWishlist.manifest'
 

--- a/runtime/storage/in-memory-storage.js
+++ b/runtime/storage/in-memory-storage.js
@@ -206,6 +206,10 @@ class InMemoryVariable extends InMemoryStorageProvider {
 
   async set(value, originatorId=null, barrier=null) {
     assert(value !== undefined);
+    if (this.type && this.type.toString().includes('Person')) {
+      console.error('>>>> setting person: ', value, ' current value: ', this._stored);
+      console.trace();
+    }
     // If there's a barrier set, then the originating storage-proxy is expecting
     // a result so we cannot suppress the event here.
     if (JSON.stringify(this._stored) == JSON.stringify(value) && barrier == null)

--- a/shell/app-shell/elements/shell-stores.js
+++ b/shell/app-shell/elements/shell-stores.js
@@ -64,13 +64,13 @@ class ShellStores extends Xen.Debug(Xen.Base, log) {
         name: 'ShellTheme',
         tags: ['shelltheme']
       },
-      userStoreOptions: {
-        schemas: `${typesPath}/identity-types.manifest`,
-        type: 'Person',
-        id: 'User',
-        name: 'User',
-        tags: ['user']
-      },
+      // userStoreOptions: {
+      //   schemas: `${typesPath}/identity-types.manifest`,
+      //   type: 'Person',
+      //   id: 'User',
+      //   name: 'User',
+      //   tags: ['user']
+      // },
       usersStoreOptions: {
         schemas: `${typesPath}/identity-types.manifest`,
         type: '[Person]',

--- a/shell/test/specs/demo-tests.js
+++ b/shell/test/specs/demo-tests.js
@@ -466,8 +466,8 @@ describe('Arcs demos', function() {
     // (2) verify 'action' slot is not visible after all products were moved.
     [
       `Check shipping for Claire \\(Claire\\)'s Birthday on 2019-08-04.`,
-      'Check manufacturer information for products from your browsing context',
-      // `Add items from Claire's wishlist \\(Book: How to Draw plus 2 other items\\)\\.`,
+      // 'Check manufacturer information for products from your browsing context',
+      `Add items from Claire's wishlist \\(Book: How to Draw plus 2 other items\\)\\.`,
       // TODO: fix and uncomment.
       // `Find out about Claire's interests\\.`
     ].forEach(suggestion => {


### PR DESCRIPTION
https://github.com/PolymerLabs/arcs/issues/1680
1) run app-shell with solo `Products.recipes`
2) accept `Show products...` suggestion
3) accept `Check shipping for Claire` 
this recipe (recipe name: `MakeIntoGiftList`) has: `copy as user` that copies the #claire store into the current arc.
4) `add items from Claire's wishlist... ` suggestion appears, but the store in the arc no longer has the value.

Observations:
during (3) the store is being copied (`cloneFrom`) and for a moment the newly created store in the arc has the correct value.
however there is a callback that arrives soon afterwards that sets the store to `null`:
https://paste.googleplex.com/5939803778449408

PS: the PR removes some stuff from the demo, and adds the debug log. I'm hoping that for someone more knowledgeable about the storage layer this might be enough to understand the problem. Otherwise, I'll try to minimize the repro. Please, let me know.



