### PR TITLE
cloud-handles fixes

### DIFF
--- a/artifacts/Demo/Browse.manifest
+++ b/artifacts/Demo/Browse.manifest
@@ -1,0 +1,5 @@
+import '../Products/Product.schema'
+
+store PageProducts of [Product] #shoplist in 'products.json'
+  description `products from your browsing context`
+

--- a/artifacts/Demo/ClairesWishlist.manifest
+++ b/artifacts/Demo/ClairesWishlist.manifest
@@ -1,9 +1,6 @@
 import '../Products/Product.schema'
 import '../People/Person.schema'
 
-store PageProducts of [Product] #shoplist in 'products.json'
-  description `products from your browsing context`
-
 store ClairesWishlist of [Product] #wishlist in 'wishlist.json'
   description `wishlist`
 

--- a/artifacts/Products/Products.recipes
+++ b/artifacts/Products/Products.recipes
@@ -12,5 +12,6 @@ import 'Manufacturer.recipes'
 import 'Gifts.recipes'
 import 'Interests.recipes'
 
+import '../Demo/Browse.manifest'
 import '../Demo/ClairesWishlist.manifest'
 

--- a/artifacts/Products/Recommend.recipes
+++ b/artifacts/Products/Recommend.recipes
@@ -6,17 +6,6 @@
 // subject to an additional IP rights grant found at
 // http://polymer.github.io/PATENTS.txt
 
-// TODO(sjmiles):
-// Generally we want to drive the association of Claire in the product recipes
-// against a Person of interest.
-// In particular `wishlist` implies a person (it's "Claire's Wishlist").
-// In some way the 'wishlist' should be produced relative to a person, but today it's
-// just static data.
-// I need a spot to bind a Person record to make the Suggestions appear correct,
-// even if the particles aren't using that record. This is why there is
-// `in Person person` in the `Chooser` particle (it's just convenient for now).
-// Note that the `addFromWishlist` recipe requires an active user with `use as person`
-// (i.e. it will not pull from context).
 
 import 'Product.schema'
 import '../People/Person.schema'
@@ -45,11 +34,8 @@ particle AlsoOn in 'source/AlsoOn.js'
   consume annotation
 
 recipe &addFromWishlist
-  // TODO(sjmiles): chooser won't render if `person.name !== 'Claire'`, but that's
-  // not enough to prevent non-Claire suggestions from appearing (ask, file ticket).
-  // I cannot tag the person (ask), nor copy tags via `copy` fate (ask, file ticket).
-  use as person
   use as shoplist
+  use #claire as person
   map #wishlist as wishlist
   create as choices
   Recommend

--- a/artifacts/Products/source/Chooser.js
+++ b/artifacts/Products/source/Chooser.js
@@ -125,11 +125,7 @@ ${productStyles}
       return template;
     }
     shouldRender({choices, resultList, person}) {
-      if (choices && resultList && person) {
-        // TODO(sjmiles): simulate data fetch that only resolves for someone with wishlist data
-        return (person.name === 'Claire');
-      }
-      return false;
+      return Boolean(choices && resultList && person);
     }
     render({choices, resultList}, state) {
       let result = [...difference(choices, resultList)];

--- a/runtime/arc-exceptions.js
+++ b/runtime/arc-exceptions.js
@@ -25,3 +25,8 @@ export function removeSystemExceptionHandler(handler) {
   if (idx > -1)
     systemHandlers.splice(idx, 1);
 }
+
+registerSystemExceptionHandler((exception, methodName, particle) => {
+  console.log(methodName, particle);
+  throw exception;
+});

--- a/runtime/storage-proxy.js
+++ b/runtime/storage-proxy.js
@@ -199,7 +199,7 @@ class StorageProxyBase {
 }
 
 
-// Collections are synchronized in a CRDT Observed/Removed scheme. 
+// Collections are synchronized in a CRDT Observed/Removed scheme.
 // Each value is identified by an ID and a set of membership keys.
 // Concurrent adds of the same value will specify the same ID but different
 // keys. A value is removed by removing all of the observed keys. A value
@@ -327,7 +327,7 @@ class CollectionProxy extends StorageProxyBase {
 }
 
 // Variables are synchronized in a 'last-writer-wins' scheme. When the
-// VariableProxy mutates the model, it sets a barrier and expects to 
+// VariableProxy mutates the model, it sets a barrier and expects to
 // receive the barrier value echoed back in a subsequent update event.
 // Between those two points in time updates are not applied or
 // notified about as these reflect concurrent writes that did not 'win'.
@@ -436,7 +436,7 @@ export class StorageProxyScheduler {
       this._idleResolver = null;
     }
   }
-  
+
   get idle() {
     if (!this.busy) {
       return Promise.resolve();
@@ -472,8 +472,8 @@ export class StorageProxyScheduler {
           try {
             handle._notify(...args);
           } catch (e) {
-            // TODO: report it via channel?
             console.error('Error dispatching to particle', e);
+            handle._proxy.raiseSystemException(e, 'StorageProxyScheduler::_dispatch', particle.id);
           }
         }
       }

--- a/shell/app-shell/elements/cloud-data/cloud-handles.js
+++ b/shell/app-shell/elements/cloud-data/cloud-handles.js
@@ -56,7 +56,7 @@ class CloudHandles extends Xen.Debug(Xen.Base, log) {
   _computeContextHandleId(type, tags, prefix) {
     return ''
       + (prefix ? `${prefix}-` : '')
-      //+ (`${type.toPrettyString()}`.replace(/ /g, '_'))
+      + (`${type.toPrettyString()}-`.replace(/ /g, '_'))
       + ((tags && [...tags].length) ? `${[...tags].sort().join('-').replace(/#/g, '')}` : '')
       ;
   }

--- a/shell/app-shell/elements/cloud-data/cloud-handles.js
+++ b/shell/app-shell/elements/cloud-data/cloud-handles.js
@@ -89,9 +89,6 @@ class CloudHandles extends Xen.Debug(Xen.Base, log) {
     this._removeWatch(`${path}/data`, 'value');
   }
   _watchVariable(arc, path, handle) {
-    Firebase.db.child(`${path}/metadata`).set({
-      type: ArcsUtils.metaTypeFromType(handle.type)
-    });
     const handler = this._remoteVariableChange(arc, path, handle);
     this._addWatch(`${path}/data`, 'value', handler);
   }
@@ -99,14 +96,21 @@ class CloudHandles extends Xen.Debug(Xen.Base, log) {
     // Ensure we get at least one response from Firebase before
     // we start writing back.
     let initialized = false;
-    let remoteValue;
     // actual handler is here
-    return snap => {
+    return async snap => {
       log(`remote handle change [${path}]`);
-      remoteValue = snap.val();
+      const remoteValue = snap.val();
       if (!initialized) {
         initialized = true;
         handle.on('change', change => this._localVariableChange(handle, path, change, remoteValue), arc);
+        // if the first callback has no data...
+        if (remoteValue === null) {
+          // ... avoiding setting `null` locally if there is no metadata
+          const metaSnap = await snap.ref.parent.child('metadata').once('value');
+          if (!metaSnap.exists()) {
+            return;
+          }
+        }
       }
       handle.set(remoteValue, originatorId);
     };
@@ -116,6 +120,9 @@ class CloudHandles extends Xen.Debug(Xen.Base, log) {
       return;
     }
     log(`local handle change [${path}]`, change.data);
+    Firebase.db.child(`${path}/metadata`).set({
+      type: ArcsUtils.metaTypeFromType(handle.type)
+    });
     const node = Firebase.db.child(`${path}/data`);
     node.set(change.data ? this._removeUndefined(change.data) : null);
   }
@@ -137,7 +144,7 @@ class CloudHandles extends Xen.Debug(Xen.Base, log) {
   }
   async _remoteSetChildAdded(snap, arc, path, handle) {
     const entity = snap.val();
-    log('trigger: remote add', entity);
+    log('trigger: remote add', handle.id, entity);
     let keys = [arc.generateID('key')];
     // doesn't trigger an `add` event if `entity` is already in `handle`
     handle.store(entity, originatorId, keys);
@@ -145,7 +152,7 @@ class CloudHandles extends Xen.Debug(Xen.Base, log) {
   }
   async _remoteSetChildRemoved(snap, arc, path, handle) {
     const entity = snap.val();
-    log('trigger: remote remove', entity);
+    log('trigger: remote remove', handle.id, entity);
     // Use any existing keys.
     let keys = [];
     // doesn't trigger a `remove` event if `entity` is not part of `handle`


### PR DESCRIPTION
Fixes #1680:
- If FB reports a null Variable, only write it locally if there is also metadata (meaning it's been written to FB at least once).

Fixes #1657:
- add type-specificity to cloud-handles generated ids, to avoid remote-handle collisions

**Note that changes to ids will prevent existing Arcs from reading old values.**

Also added some exception plumbing to surface errors in the outer-pec.