### PR TITLE
Runtime store option

### DIFF
--- a/runtime/arc.js
+++ b/runtime/arc.js
@@ -231,11 +231,11 @@ ${this.activeRecipe.toString()}`;
       storageProviderFactory: manifest._storageProviderFactory,
       context
     });
-    manifest.stores.forEach(store => {
+    await Promise.all(manifest.stores.map(async store => {
       if (store.constructor.name == 'StorageStub')
-        store = store.inflate();
+        store = await store.inflate();
       arc._registerStore(store, manifest._storeTags.get(store));
-    });
+    }));
     let recipe = manifest.activeRecipe.clone();
     let options = {errors: new Map()};
     assert(recipe.normalize(options), `Couldn't normalize recipe ${recipe.toString()}:\n${[...options.errors.values()].join('\n')}`);

--- a/runtime/manifest.js
+++ b/runtime/manifest.js
@@ -37,7 +37,7 @@ class StorageStub {
     this.id = id;
     this.name = name;
     this.storageKey = storageKey;
-    this.storageProviderFactory;
+    this.storageProviderFactory = storageProviderFactory;
   }
 
   inflate() {

--- a/runtime/particle-spec.js
+++ b/runtime/particle-spec.js
@@ -150,9 +150,10 @@ export class ParticleSpec {
 
   static fromLiteral(literal) {
     let {args, name, verbs, description, implFile, affordance, slots} = literal;
-    let connectionFromLiteral = ({type, direction, name, isOptional, dependentConnections}) => ({type: Type.fromLiteral(type), direction, name, isOptional, dependentConnections: dependentConnections.map(connectionFromLiteral)}); 
+    let connectionFromLiteral = ({type, direction, name, isOptional, dependentConnections}) =>
+      ({type: Type.fromLiteral(type), direction, name, isOptional, dependentConnections: dependentConnections ? dependentConnections.map(connectionFromLiteral) : []});
     args = args.map(connectionFromLiteral);
-    return new ParticleSpec({args, name, verbs, description, implFile, affordance, slots});
+    return new ParticleSpec({args, name, verbs: verbs || [], description, implFile, affordance, slots});
   }
 
   clone() {

--- a/runtime/storage/firebase-storage.js
+++ b/runtime/storage/firebase-storage.js
@@ -169,7 +169,9 @@ class FirebaseStorageProvider extends StorageProviderBase {
         // we never actually commit it.
         return 0;
       }
-      return transactionFunction(data);
+      const newData = transactionFunction(data);
+      // TODO(sjmiles): remove `undefined` values from the object tree
+      return JSON.parse(JSON.stringify(newData));
     }, undefined, false);
     if (result.committed) {
       assert(result.snapshot.val() !== 0);
@@ -181,7 +183,7 @@ class FirebaseStorageProvider extends StorageProviderBase {
   get _hasLocalChanges() {
     assert(false, 'subclass should implement _hasLocalChanges');
   }
-  
+
   async _persistChangesImpl() {
     assert(false, 'subclass should implement _persistChangesImpl');
   }
@@ -245,7 +247,7 @@ class FirebaseVariable extends FirebaseStorageProvider {
     // the value to the remote store and will suppress any
     // incoming changes from firebase.
     this._localModified = false;
-    
+
     // Resolved when data is first available. The earlier of
     // * the initial value is supplied via firebase `reference.on`
     // * a value is written to the variable by a call to `set`.
@@ -273,7 +275,7 @@ class FirebaseVariable extends FirebaseStorageProvider {
   get _hasLocalChanges() {
     return this._localModified;
   }
-  
+
   async _persistChangesImpl() {
     assert(this._localModified);
     // Guard the specific version that we're writing. If we receive another
@@ -435,7 +437,7 @@ class FirebaseCollection extends FirebaseStorageProvider {
     // They can be removed once the state received from firebase
     // reaches `barrierVersion`.
     // id => {keys: Set[key], barrierVersion}
-    this._addSuppressions = new Map(); 
+    this._addSuppressions = new Map();
 
     // Local model of entries stored in this collection. Updated
     // by local modifications and when we receive remote updates

--- a/shell/app-shell/elements/arc-config.js
+++ b/shell/app-shell/elements/arc-config.js
@@ -50,7 +50,7 @@ class ArcConfig extends Xen.Base {
       key: params.get('arc') || null,
       search: params.get('search') || '',
       urls: window.shellUrls || {},
-      useStorage: false,
+      useStorage: params.has('store'),
       useSerialization: params.has('serial')
     };
   }

--- a/shell/app-shell/elements/cloud-data.js
+++ b/shell/app-shell/elements/cloud-data.js
@@ -67,6 +67,7 @@ const template = html`
   ></cloud-steps>
 
   <cloud-handles
+    config="{{config}}"
     key="{{key}}"
     arc="{{arc}}"
     plans="{{plans}}"

--- a/shell/app-shell/elements/cloud-data/cloud-handles.js
+++ b/shell/app-shell/elements/cloud-data/cloud-handles.js
@@ -18,7 +18,7 @@ const originatorId = 'cloud-handles';
 
 class CloudHandles extends Xen.Debug(Xen.Base, log) {
   static get observedAttributes() {
-    return ['key', 'arc', 'plans'];
+    return ['config', 'key', 'arc', 'plans'];
   }
   _getInitialState() {
     return {
@@ -26,7 +26,11 @@ class CloudHandles extends Xen.Debug(Xen.Base, log) {
       watches: {}
     };
   }
-  _willReceiveProps({key, arc}, {roots, watches}, oldProps, oldState) {
+  _willReceiveProps({config, key, arc}, {roots, watches}, oldProps) {
+    if (config.useStorage) {
+      // use runtime storage instead of this code
+      return;
+    }
     if (oldProps.key && key !== oldProps.key) {
       this._disposeWatches(watches);
     }

--- a/shell/app-shell/elements/fb-data/FbStore.js
+++ b/shell/app-shell/elements/fb-data/FbStore.js
@@ -20,11 +20,11 @@ export class FbStore {
     }
     const schemaType = Arcs.Type.fromLiteral(options.schema);
     const typeOf = setOf ? schemaType.collectionOf() : schemaType;
-    const store = await this._requireStore(context, typeOf, options.name, options.id, options.tags);
+    const store = await this._requireStore(context, typeOf, options);
     return store;
   }
-  static async _requireStore(context, type, name, id, tags) {
+  static async _requireStore(context, type, {name, id, tags, storageKey}) {
     const store = context.findStoreById(id);
-    return store || await context.createStore(type, name, id, tags);
+    return store || await context.createStore(type, name, id, tags, storageKey);
   }
 }

--- a/shell/app-shell/elements/fb-data/fb-user.js
+++ b/shell/app-shell/elements/fb-data/fb-user.js
@@ -109,7 +109,8 @@ class FbUserElement extends Xen.Debug(Xen.Base, log) {
       },
       type: '[ArcMetadata]',
       name: 'ArcMetadata',
-      tags: ['arcmetadata', 'nosync']
+      tags: ['arcmetadata', 'nosync'],
+      storageKey: 'in-memory'
     };
     return FbStore.createContextStore(arc, options);
   }


### PR DESCRIPTION
Add support for `store` option (for Arcs web front-ends) that enables the runtime-storage layer (and disables the cloud-handles) for persisting Arc data.