### PR TITLE
Ensure inner handles don't get stored in firebase.

### DIFF
--- a/runtime/particle-execution-host.js
+++ b/runtime/particle-execution-host.js
@@ -69,7 +69,11 @@ export class ParticleExecutionHost {
     };
 
     this._apiPort.onArcCreateHandle = async ({callback, arc, type, name}) => {
-      let store = await this._arc.createStore(type, name);
+      // At the moment, inner arcs are not persisted like their containers, but are instead
+      // recreated when an arc is deserialized. As a consequence of this, dynamically 
+      // created handles for inner arcs must always be in-memory to prevent storage 
+      // in firebase.
+      let store = await this._arc.createStore(type, name, null, [], 'in-memory');
       this._apiPort.CreateHandleCallback(store, {type, name, callback, id: store.id});
     };
 


### PR DESCRIPTION
This fixes #1700.

It might also break deserialization. I can't tell, because there's an assert firing at planificator.js:259 which seems to prevent the arc from being stored.

(This assert isn't new, it's been around for the last couple of days).