### PR TITLE
Coalesce-recipes strategy support for coalescing multiple handles, if applicable.

### DIFF
--- a/runtime/recipe-index.js
+++ b/runtime/recipe-index.js
@@ -131,7 +131,6 @@ export class RecipeIndex {
   findHandleMatch(handle, requestedFates) {
     this.ensureReady();
 
-    let counts = RecipeUtil.directionCounts(handle);
     let particleNames = handle.connections.map(conn => conn.particle.name);
 
     let results = [];
@@ -142,30 +141,13 @@ export class RecipeIndex {
         continue;
       }
       for (let otherHandle of recipe.handles) {
-        if (requestedFates && !(requestedFates.includes(otherHandle.fate))
-            || otherHandle.connections.length === 0
-            || otherHandle.name === 'descriptions') continue;
-
-        // If we're connecting only create/use/? handles, we require communication.
-        // We don't do that if at least one handle is map/copy, as in such case
-        // everyone can be a reader.
-        // We inspect both fate and originalFate as copy ends up as use in an
-        // active recipe, and ? could end up as anything.
-        let fates = [handle.originalFate, handle.fate, otherHandle.originalFate, otherHandle.fate];
-        if (!fates.includes('copy') && !fates.includes('map')) {
-          let otherCounts = RecipeUtil.directionCounts(otherHandle);
-          // Someone has to read and someone has to write.
-          if (otherCounts.in + counts.in === 0
-              || otherCounts.out + counts.out === 0) continue;
+        if (requestedFates && !(requestedFates.includes(otherHandle.fate))) {
+          continue;
         }
 
-        // If requesting handle has tags, we should have overlap.
-        if (handle.tags.length > 0 && !handle.tags.some(t => otherHandle.tags.includes(t))) continue;
-
-
-        // If types don't match.
-        if (!Handle.effectiveType(handle._mappedType,
-            [...handle.connections, ...otherHandle.connections])) continue;
+        if (!this.doesHandleMatch(handle, otherHandle)) {
+          continue;
+        }
 
         // If we're connecting the same sets of particles, that's probably not OK.
         // This is a poor workaround for connecting the exact same recipes together, to be improved.
@@ -178,6 +160,43 @@ export class RecipeIndex {
       }
     }
     return results;
+  }
+
+  doesHandleMatch(handle, otherHandle) {
+    if (Boolean(handle.id) && Boolean(otherHandle.id) && handle.id !== otherHandle.id) {
+      // Either at most one of the handles has an ID, or they are the same.
+      return false;
+    }
+    if (otherHandle.connections.length === 0 || otherHandle.name === 'descriptions') {
+      return false;
+    }
+
+    // If we're connecting only create/use/? handles, we require communication.
+    // We don't do that if at least one handle is map/copy, as in such case
+    // everyone can be a reader.
+    // We inspect both fate and originalFate as copy ends up as use in an
+    // active recipe, and ? could end up as anything.
+    let fates = [handle.originalFate, handle.fate, otherHandle.originalFate, otherHandle.fate];
+    if (!fates.includes('copy') && !fates.includes('map')) {
+      let counts = RecipeUtil.directionCounts(handle);
+      let otherCounts = RecipeUtil.directionCounts(otherHandle);
+      // Someone has to read and someone has to write.
+      if (otherCounts.in + counts.in === 0 || otherCounts.out + counts.out === 0) {
+        return false;
+      }
+    }
+
+    // If requesting handle has tags, we should have overlap.
+    if (handle.tags.length > 0 && !handle.tags.some(t => otherHandle.tags.includes(t))) {
+      return false;
+    }
+
+    // If types don't match.
+    if (!Handle.effectiveType(handle._mappedType, [...handle.connections, ...otherHandle.connections])) {
+      return false;
+    }
+
+    return true;
   }
 
   // Given a slot, find consume slot connections that could be connected to it.

--- a/runtime/strategies/fallback-fate.js
+++ b/runtime/strategies/fallback-fate.js
@@ -25,13 +25,14 @@ export class FallbackFate extends Strategy {
           return;
         }
 
-        // Only apply to handles whose fate is set, but wasn't explicitly defined in the recipe.
-        if (handle.isResolved() || handle.fate == '?' || handle.originalFate != '?') {
+        // Only apply to handles whose fate is set, but was explicitly defined as ? in the recipe.
+        if (handle.isResolved() || handle.fate == '?' || !handle.originalFate || handle.originalFate != '?') {
           return;
         }
 
         let hasOutConns = handle.connections.some(hc => hc.isOutput);
         let newFate = hasOutConns ? 'copy' : 'map';
+
         if (handle.fate == newFate) {
           return;
         }

--- a/shell/test/specs/demo-tests.js
+++ b/shell/test/specs/demo-tests.js
@@ -271,6 +271,11 @@ function openSystemUi() {
   wait(200);
 }
 
+function waitForStillnessAndOpenSystemUi() {
+  waitForStillness();
+  openSystemUi();
+}
+
 function allSuggestions() {
   waitForStillness();
   openSystemUi();
@@ -427,7 +432,7 @@ describe('Arcs demos', function() {
   it('can book a restaurant', /** @this Context */ function() {
     initTestWithNewArc(this.test.fullTitle(), true);
     allSuggestions();
-    acceptSuggestion('Find restaurants');
+    acceptSuggestion('Find restaurants[^\0]{0,30}$');
     // Our location is relative to where you are now, so this list is dynamic.
     // Rather than trying to mock this out let's just grab the first
     // restaurant.
@@ -437,7 +442,12 @@ describe('Arcs demos', function() {
     let restaurantNodes = pierceShadows(restaurantSelectors);
     console.log(`click: restaurantSelectors`);
     browser.elementIdClick(restaurantNodes.value[0].ELEMENT);
+    // TODO: figure out why waitForStillnessAndOpenSystemUi is needed here -
+    // the suggestion is visible, 'found suggestion' log appears,
+    // but it is not clickable and hence cannot be accepted.
+    waitForStillnessAndOpenSystemUi();
     acceptSuggestion('table for 2 available[^\0]{0,30}$');
+    waitForStillnessAndOpenSystemUi();
     acceptSuggestion('from your calendar');
     testAroundRefresh();
 


### PR DESCRIPTION
Typing "make reservation" in the search input coalesces the &makeReservation recipe with &nearbyRestaurants, ExtractLocation and &displayRestaurants and properly resolves.
("Strategy explorations" doc describes the required changes: https://docs.google.com/document/d/19QixNPDuDVRmDvKmKqoI2VnPHOOOnQ_jVU0NXz8mocE/edit#)

Next step is to properly coalesce "nearby restaurants and make reservation" search (creates duplicate handles, as described in "SearchTokensToParticles" section of the doc).