### PR TITLE
Coalesce handles in search-tokens-to-particles/recipes.

### DIFF
--- a/artifacts/Restaurants/Restaurants.recipes
+++ b/artifacts/Restaurants/Restaurants.recipes
@@ -36,10 +36,12 @@ import 'ReservationAnnotation.manifest'
 
 recipe &makeReservation
   create #event as event
+  use #restaurants as list
   ReservationForm
     event = event
   ReservationAnnotation
     event = event
+    list = list
   PartySize
     event = event
 

--- a/runtime/recipe-index.js
+++ b/runtime/recipe-index.js
@@ -289,4 +289,28 @@ export class RecipeIndex {
         assert(false, `Unexpected fate ${slotHandleConn.handle.fate}`);
     }
   }
+
+  get coalescableFates() { return ['create', 'use', '?']; }
+
+  findCoalescableHandles(recipe, otherRecipe, usedHandles) {
+    assert(recipe != otherRecipe, 'Cannot coalesce handles in the same recipe');
+    let otherToHandle = new Map();
+    usedHandles = usedHandles || new Set();
+    for (let handle of recipe.handles) {
+      if (usedHandles.has(handle) || !this.coalescableFates.includes(handle.fate)) {
+        continue;
+      }
+      for (let otherHandle of otherRecipe.handles) {
+        if (usedHandles.has(otherHandle) || !this.coalescableFates.includes(otherHandle.fate)) {
+          continue;
+        }
+        if (this.doesHandleMatch(handle, otherHandle)) {
+          otherToHandle.set(handle, otherHandle);
+          usedHandles.add(handle);
+          usedHandles.add(otherHandle);
+        }
+      }
+    }
+    return otherToHandle;
+  }
 }

--- a/runtime/test/planner-tests.js
+++ b/runtime/test/planner-tests.js
@@ -736,7 +736,7 @@ describe('Automatic resolution', function() {
       provide preamble as slot5`);
   });
 
-  it('searches and coalesces nearby restaurants by recipe name', async () => {
+  let verifyRestaurantsPlanSearch = async (searchStr) => {
     let recipes = await verifyResolvedPlans(`
       import 'artifacts/Restaurants/Restaurants.recipes'
       import 'artifacts/People/Person.schema'
@@ -744,26 +744,21 @@ describe('Automatic resolution', function() {
       store User of Person 'User' in './artifacts/Things/empty.json'
 
       recipe
-        search \`nearby restaurants\`
+        search \`${searchStr}\`
     `, () => {});
     assert.lengthOf(recipes, 1);
-    assert.deepEqual(recipes[0].particles.map(p => p.name).sort(),
+    return recipes[0];
+  };
+
+  it('searches and coalesces nearby restaurants by recipe name', async () => {
+    let recipe = await verifyRestaurantsPlanSearch('nearby restaurants');
+    assert.deepEqual(recipe.particles.map(p => p.name).sort(),
       ['FindRestaurants', 'ExtractLocation', 'RestaurantList', 'RestaurantMasterDetail', 'RestaurantDetail'].sort());
-    assert.lengthOf(recipes[0].handles, 4);
+    assert.lengthOf(recipe.handles, 4);
   });
 
   it('searches and coalesces make reservation by recipe name', async () => {
-    let recipes = await verifyResolvedPlans(`
-      import 'artifacts/Restaurants/Restaurants.recipes'
-      import 'artifacts/People/Person.schema'
-
-      store User of Person 'User' in './artifacts/Things/empty.json'
-
-      recipe
-        search \`make reservation\`
-    `, () => {});
-    assert.lengthOf(recipes, 1);
-    let recipe = recipes[0];
+    let recipe = await verifyRestaurantsPlanSearch('make reservation');
     assert.deepEqual(recipe.particles.map(p => p.name).sort(),
       ['FindRestaurants', 'ExtractLocation', 'PartySize', 'ReservationAnnotation', 'ReservationForm', 'RestaurantList', 'RestaurantMasterDetail', 'RestaurantDetail'].sort());
 
@@ -776,6 +771,41 @@ describe('Automatic resolution', function() {
     // Naive verification that a specific connection name only binds to the same handle.
     recipe.handles.forEach(handle => handle.connections.every(conn => {
       assert.isTrue(recipe.handles.every(otherHandle => handle == otherHandle || !otherHandle.connections.some(otherConn => otherConn.name == conn.name)),
+                    `Connection name ${conn.name} is bound to multiple handles.`);
+    }));
+  });
+
+  it('searches and coalesces "nearby restaurants make reservation"', async () => {
+    let recipe = await verifyRestaurantsPlanSearch('nearby restaurants make reservation');
+    assert.deepEqual(recipe.particles.map(p => p.name).sort(),
+      ['FindRestaurants', 'ExtractLocation', 'PartySize', 'ReservationAnnotation', 'ReservationForm', 'RestaurantList', 'RestaurantMasterDetail', 'RestaurantDetail'].sort());
+    // Verify handles.
+    assert.lengthOf(recipe.handles, 6);
+    // Only descriptions and person handle have one handle connection.
+    assert.isTrue(recipe.handles.every(h => h.connections.length > 1 || ['descriptions', 'person'].includes(h.connections[0].name)));
+    // Only person handle has fate other than `create`
+    assert.isTrue(recipe.handles.every(h => h.fate == 'create' || 'person' == h.connections[0].name));
+    // Naive verification that a specific connection name only binds to the same handle.
+    recipe.handles.forEach(handle => handle.connections.every(conn => {
+      assert.isTrue(recipe.handles.every(otherHandle => handle == otherHandle || !otherHandle.connections.some(otherConn => otherConn.name == conn.name)),
+                    `Connection name ${conn.name} is bound to multiple handles.`);
+    }));
+  });
+
+  it('searches and coalesces "nearby restaurants calendar"', async () => {
+    let recipe = await verifyRestaurantsPlanSearch('nearby restaurants calendar');
+    assert.deepEqual(recipe.particles.map(p => p.name).sort(),
+      ['Calendar', 'FindRestaurants', 'ExtractLocation', 'PartySize', 'ReservationAnnotation', 'ReservationForm', 'RestaurantList', 'RestaurantMasterDetail', 'RestaurantDetail'].sort());
+    // Verify handles.
+    assert.lengthOf(recipe.handles, 7);
+    // Only descriptions and person handle have one handle connection.
+    assert.isTrue(recipe.handles.every(h => h.connections.length > 1 || ['descriptions', 'person'].includes(h.connections[0].name)));
+    // Only person handle has fate other than `create`
+    assert.isTrue(recipe.handles.every(h => h.fate == 'create' || 'person' == h.connections[0].name));
+    // Naive verification that a specific connection name only binds to the same handle.
+    recipe.handles.forEach(handle => handle.connections.every(conn => {
+      assert.isTrue(conn.name == 'descriptions' ||
+                    recipe.handles.every(otherHandle => handle == otherHandle || !otherHandle.connections.some(otherConn => otherConn.name == conn.name)),
                     `Connection name ${conn.name} is bound to multiple handles.`);
     }));
   });

--- a/shell/test/specs/demo-tests.js
+++ b/shell/test/specs/demo-tests.js
@@ -432,7 +432,7 @@ describe('Arcs demos', function() {
   it('can book a restaurant', /** @this Context */ function() {
     initTestWithNewArc(this.test.fullTitle(), true);
     allSuggestions();
-    acceptSuggestion('Find restaurants[^\0]{0,30}$');
+    acceptSuggestion('Find restaurants near [^\0]{0,30} location.$');
     // Our location is relative to where you are now, so this list is dynamic.
     // Rather than trying to mock this out let's just grab the first
     // restaurant.


### PR DESCRIPTION
* Move handle-coalescing method from coalesce-recipe to recipe-index and reuse it in search-token-to-particle strategy
* Exclude from coalescing candidates these recipes that are already in the arc's active recipe (added to Strategy exploration doc)

With this PR the following searches work:
- "nearby restaurants"
- "nearby restaurants make reservation"
- "nearby restaurants calendar"

This doesn't work (I'm investigating):
- "nearby restaurants make reservation calendar"