### PR TITLE
[exploration] inline suggestion in restaurant detail page

### DIFF
--- a/artifacts/Restaurants/RestaurantDetail.manifest
+++ b/artifacts/Restaurants/RestaurantDetail.manifest
@@ -13,5 +13,6 @@ particle RestaurantDetail in 'source/RestaurantDetail.js'
   affordance dom
   consume detail
     provide action
+      handle selected
 // removing description for now to clean up suggestions
 //  description `show restaurant details`

--- a/artifacts/Restaurants/Restaurants.recipes
+++ b/artifacts/Restaurants/Restaurants.recipes
@@ -34,6 +34,11 @@ import '../Events/PartySize.manifest'
 import 'ReservationForm.manifest'
 import 'ReservationAnnotation.manifest'
 
+recipe &reserve
+  create #event as event
+  ReservationForm
+    event = event
+
 recipe &makeReservation
   create #event as event
   use #restaurants as list


### PR DESCRIPTION
This is inline suggestion is displayed:
https://screenshot.googleplex.com/PoKBdeWByck.png

Problems:
* on page load there is flickering, because it first shows "make reservation", then is replaced with "table for 2.." (after speculative execution has finished)

* too many coalesced recipes are produced. (1) with just `&reserve` recipe (2) with just `&makeReservation` recipe (3) with both `&reserve` and `&makeReservation` recipes - this is wrong, because create 2 events!

* Can't show inline suggestions in restaurants list, because it doesn't use transformations, so there are no singleton stores for each individual restaurants, and inline suggestions for the whole list (displayed in the list header?) aren't support yet.