### PR TITLE
[exploration] inline suggestion in set-slots with gift demo

### DIFF
--- a/artifacts/Products/Gifts.recipes
+++ b/artifacts/Products/Gifts.recipes
@@ -19,6 +19,8 @@ particle GiftList in 'source/GiftList.js'
 particle Arrivinator in 'source/Arrivinator.js'
   in Product product
   consume annotation
+    provide tooLate
+      handle product
   description `estimate arrival date`
   // TODO: add support for patterns:
   //description `estimate ${product} arrival date`
@@ -27,7 +29,23 @@ particle Arrivinator in 'source/Arrivinator.js'
 particle AlternateShipping in 'source/AlternateShipping.js'
   in Product product
   consume annotation
-  description `find alternate shipping for products which won't make it on time`
+  consume tooLate
+  description `find alternate shipping for ${product}`
+
+recipe &alternative
+  AlternateShipping
+
+shape ArrivinatorShape
+  in ~a *
+  consume
+  provide
+
+// TODO: This particle should use generic slot name.
+particle ArrivinatorMultiplexer in '../Common/source/Multiplexer.js'
+  host ArrivinatorShape hostedParticle
+  in [~a] list
+  consume set of annotation
+    provide set of tooLate
 
 // Buying for [person]'s [occasion] in [timeframe]? Product [X] arrives too late.
 recipe MakeIntoGiftList
@@ -35,14 +53,12 @@ recipe MakeIntoGiftList
   copy as person
   GiftList
     person = person
-  Multiplexer
+  ArrivinatorMultiplexer
     list = shoplist
     hostedParticle = Arrivinator
-    consume annotation as annotationSlot
-  Multiplexer
-    list = shoplist
-    hostedParticle = AlternateShipping
-    consume annotation as annotationSlot
+  //  consume annotation as annotationSlot
+  // Multiplexer
+  //   list = shoplist
+  //   hostedParticle = AlternateShipping
+  //   consume annotation as annotationSlot
   description `check shipping for ${GiftList.person}'s ${GiftList.person.occasion} on ${GiftList.person.date}`
-
-

--- a/artifacts/Products/source/AlternateShipping.js
+++ b/artifacts/Products/source/AlternateShipping.js
@@ -21,24 +21,25 @@ defineParticle(({DomParticle, html}) => {
       return template;
     }
     shouldRender(props) {
-      return Boolean(props && props.product);
+      return Boolean(props && props.product && !this._isHidden(props.product));
     }
-    render(props) {
-      const {product} = props;
+    _isHidden(product) {
       const needed = new Date();
       needed.setDate(needed.getDate() + 12);
 
-      let hidden = true;
-      if (props.product.shipDays) {
+      if (product.shipDays) {
         // create a date-only Date (with a time of 00:00:00etc)
         const estimated = new Date(new Date().toDateString());
         estimated.setDate(estimated.getDate() + product.shipDays);
-        hidden = estimated <= needed;
+        return estimated <= needed;
       }
+      return true;
+    }
+    render({product}) {
       const alternatives = ['<not yet implemented>'].join(', ');
       return {
         alternatives,
-        hidden
+        hidden: this._isHidden(product)
       };
     }
   };

--- a/artifacts/Products/source/Arrivinator.js
+++ b/artifacts/Products/source/Arrivinator.js
@@ -13,7 +13,10 @@
 defineParticle(({DomParticle, html}) => {
 
   const template = html`
-    <div style="padding: 4px 0;" style%="{{style}}"><span>{{arrival}}</span></div>
+    <div style="padding: 4px 0;" style%="{{style}}">
+      <span>{{arrival}}</span>
+      <div slotid="tooLate"></div>
+    </div>
   `;
 
   const daysToMs = 24*60*60*1000;

--- a/runtime/planificator.js
+++ b/runtime/planificator.js
@@ -225,12 +225,15 @@ export class Planificator {
           return suggestion.descriptionText.toLowerCase().includes(this.suggestFilter.search);
         });
       } else {
+        let allHandlesIds = new Set(this._arc._activeRecipe.handles.map(h => h.id));
+        this._arc._recipes.forEach(recipe => [...recipe.innerArcs.values()].forEach(
+          innerArc => innerArc.activeRecipe.handles.forEach(innerHandle => allHandlesIds.add(innerHandle.id))));
         suggestions = suggestions.filter(suggestion => {
           let plan = suggestion.plan;
           let usesHandlesFromActiveRecipe = plan.handles.find(handle => {
             // TODO(mmandlis): find a generic way to exlude system handles (eg Theme), either by tagging or
             // by exploring connection directions etc.
-            return !!handle.id && this._arc._activeRecipe.handles.find(activeHandle => activeHandle.id == handle.id);
+            return !!handle.id && allHandlesIds.has(handle.id);
           });
           let usesRemoteNonRootSlots = plan.slots.find(slot => {
             return !slot.name.includes('root') && !slot.tags.includes('root') && slot.id && !slot.id.includes('root');

--- a/runtime/recipe-index.js
+++ b/runtime/recipe-index.js
@@ -181,7 +181,7 @@ export class RecipeIndex {
       let counts = RecipeUtil.directionCounts(handle);
       let otherCounts = RecipeUtil.directionCounts(otherHandle);
       // Someone has to read and someone has to write.
-      if (otherCounts.in + counts.in === 0 || otherCounts.out + counts.out === 0) {
+      if (otherCounts.in + counts.in === 0) { // || otherCounts.out + counts.out === 0) {
         return false;
       }
     }


### PR DESCRIPTION
- update recipes / manifests: `Arrivinator` provides `tooLate` slot, consumed by `AlternateShipping`, which is also in a separate recipe
- planificator & recipe-index update to surface suggestion without '*' search
- the generic slot fixes are part of #1725