### PR TITLE
fix "id must be provided when constructing StorageProviders" exception

### DIFF
--- a/runtime/storage/firebase-storage.js
+++ b/runtime/storage/firebase-storage.js
@@ -135,7 +135,7 @@ export class FirebaseStorage {
 
 class FirebaseStorageProvider extends StorageProviderBase {
   constructor(type, arcId, id, reference, key) {
-    super(type, arcId, undefined, id, key.toString());
+    super(type, undefined, id, key.toString());
     this._firebaseKey = key;
     this._reference = reference;
 


### PR DESCRIPTION
the base class ctor interface has changed here:
https://github.com/PolymerLabs/arcs/commit/8b23495e2a55547e0af8a516af3b2a1a7523499a#diff-88d1788b681d284f291ff9625b56ef12L14

causing:
```
(anonymous)	@	VM659:1
assert	@	assert-web.js:10
StorageProviderBase	@	storage-provider-base.js:15
FirebaseStorageProvider	@	firebase-storage.js:138
FirebaseCollection	@	firebase-storage.js:426
newProvider	@	firebase-storage.js:149
```
reproducible on arcs-live when accepting any suggestion with `?serial=&store=`


Actually, now the `arcId` argument in `FirebaseStorageProvider` ctor is unused - shall i remove it completely? 