### PR TITLE
Fix ArcsUtils.clearStore to reference model items via new name.

### DIFF
--- a/shell/app-shell/lib/arcs-utils.js
+++ b/shell/app-shell/lib/arcs-utils.js
@@ -105,7 +105,7 @@ const ArcsUtils = {
       // TODO(sjmiles): if we go async here, we have nasty re-entry issues, so
       // hacking store API to fix for now. Probably we need low-level support
       // for 'setStoreData' above.
-      const ids = [...store._model._items.keys()];
+      const ids = [...store._model.items.keys()];
       //const entities = await store.toList();
       ids.forEach(id => store.remove(id));
     } else {


### PR DESCRIPTION
This was broken by #1749.