### PR TITLE
Remove mode arg from webpack

### DIFF
--- a/tools/sigh.js
+++ b/tools/sigh.js
@@ -263,7 +263,6 @@ async function webpack() {
       webpack(
           {
             entry: path.resolve(projectRoot, file),
-            mode: 'development',
             output: {
               path: process.cwd(),
               filename: `${sources.pack.buildDir}/${path.basename(file)}`,


### PR DESCRIPTION
The mode arg fails for me:

🙋 webpack 
WebpackOptionsValidationError: Invalid configuration object. Webpack has been initialised using a configuration object that does not match the API schema.
 - configuration has an unknown property 'mode'. These properties are valid:
   object { amd?, bail?, cache?, context?, dependencies?, devServer?, devtool?, entry, externals?, loader?, module?, name?, node?, output?, performance?, plugins?, profile?, recordsInputPath?, recordsOutputPath?, recordsPath?, resolve?, resolveLoader?, stats?, target?, watch?, watchOptions? }
   For typos: please correct them.
   For loader options: webpack 2 no longer allows custom properties in configuration.
     Loaders should be updated to allow passing options via loader options in module.rules.
     Until loaders are updated one can use the LoaderOptionsPlugin to pass these options to the loader:
     plugins: [
       new webpack.LoaderOptionsPlugin({
         // test: /\.xxx$/, // may apply this only for some modules
         options: {
           mode: ...
         }
       })
     ]
    at webpack (/usr/local/google/home/mykmartin/code/arcs/node_modules/webpack/lib/webpack.js:19:9)
    at Promise (/usr/local/google/home/mykmartin/code/arcs/tools/sigh.js:263:7)
