### PR TITLE
Tighten typescript usage, part 2

### DIFF
--- a/runtime/description.js
+++ b/runtime/description.js
@@ -299,7 +299,7 @@ export class DescriptionFormatter {
     } else if (token.consumeSlotName && token.provideSlotName) {
       return this._slotTokenToString(token);
     }
-    assert(false, 'no handle or slot name');
+    throw new Error('no handle or slot name');
   }
 
   async _handleTokenToString(token) {

--- a/runtime/manifest.js
+++ b/runtime/manifest.js
@@ -708,7 +708,7 @@ ${e.message}
           return new TagEndPoint(info.tags);
         }
         default:
-          assert(false, `endpoint ${info.targetType} not supported`);
+          throw new Error(`endpoint ${info.targetType} not supported`);
       }
     };
 
@@ -847,7 +847,7 @@ ${e.message}
           } else if (entry.item.kind == 'particle') {
             targetParticle = entry.particle;
           } else {
-            assert(false, `did not expect ${entry.item.kind}`);
+            throw new Error(`did not expect ${entry.item.kind}`);
           }
         }
 

--- a/runtime/recipe-index.js
+++ b/runtime/recipe-index.js
@@ -285,7 +285,7 @@ export class RecipeIndex {
       case '?':
         return false;
       default:
-        assert(false, `Unexpected fate ${slotHandleConn.handle.fate}`);
+        throw new Error(`Unexpected fate ${slotHandleConn.handle.fate}`);
     }
   }
 

--- a/runtime/recipe/handle.js
+++ b/runtime/recipe/handle.js
@@ -220,8 +220,7 @@ export class Handle {
         if (options) {
           options.details.push(`invalid fate ${this.fate}`);
         }
-        assert(false, `Unexpected fate: ${this.fate}`);
-        resolved = false;
+        throw new Error(`Unexpected fate: ${this.fate}`);
       }
     }
     return resolved;

--- a/runtime/recipe/type-checker.js
+++ b/runtime/recipe/type-checker.js
@@ -121,7 +121,7 @@ export class TypeChecker {
         return null;
       }
 
-      assert(false, 'tryMergeTypeVariable shouldn\'t be called on two types without any type variables');
+      throw new Error('tryMergeTypeVariable shouldn\'t be called on two types without any type variables');
     }
 
     return base;

--- a/runtime/slot-dom-consumer.js
+++ b/runtime/slot-dom-consumer.js
@@ -302,7 +302,7 @@ export class SlotDomConsumer extends SlotConsumer {
         content.templateName = `${hostedSlot.consumeConn.particle.name}::${hostedSlot.consumeConn.name}::${content.templateName}`;
       } else {
         // TODO(mmandlis): add support for hosted particle rendering set slot.
-        assert(false, 'TODO: Implement this!');
+        throw new Error('TODO: Implement this!');
       }
     }
     return content;

--- a/runtime/storage-proxy.js
+++ b/runtime/storage-proxy.js
@@ -252,7 +252,7 @@ class CollectionProxy extends StorageProxyBase {
         }
       }
     } else {
-      assert(false, `StorageProxy received invalid update event: ${JSON.stringify(update)}`);
+      throw new Error(`StorageProxy received invalid update event: ${JSON.stringify(update)}`);
     }
     if (added.length || removed.length) {
       let result = {};

--- a/runtime/strategies/resolve-recipe.js
+++ b/runtime/strategies/resolve-recipe.js
@@ -46,7 +46,7 @@ export class ResolveRecipe extends Strategy {
               mappable = [];
               break;
             default:
-              assert(false, `unexpected fate ${handle.fate}`);
+              throw new Error(`unexpected fate ${handle.fate}`);
           }
         } else if (!handle.storageKey) {
           // Handle specified by the ID, but not yet mapped to storage.
@@ -63,7 +63,7 @@ export class ResolveRecipe extends Strategy {
             case '?':
               break;
             default:
-              assert(false, `unexpected fate ${handle.fate}`);
+              throw new Error(`unexpected fate ${handle.fate}`);
           }
           mappable = storeById ? [storeById] : [];
         }

--- a/runtime/ts/shape.ts
+++ b/runtime/ts/shape.ts
@@ -31,11 +31,11 @@ const handleFields = ['type', 'name', 'direction'];
 const slotFields = ['name', 'direction', 'isRequired', 'isSet'];
 
 export class Shape {
-  public name: string;
-  public handles: {type: Type, name: string, direction: string}[];
-  public slots: {name: string, direction: string, isRequired: boolean, isSet: boolean}[];
+  name: string;
+  handles: Array<{type: Type, name: string, direction: string}>;
+  slots: Array<{name: string, direction: string, isRequired: boolean, isSet: boolean}>;
 
-  private typeVars: {object: any, field: string}[];
+  private typeVars: Array<{object: any, field: string}>;
 
   constructor(name, handles, slots) {
     assert(name);
@@ -45,16 +45,16 @@ export class Shape {
     this.handles = handles;
     this.slots = slots;
     this.typeVars = [];
-    for (let handle of handles) {
-      for (let field of handleFields) {
+    for (const handle of handles) {
+      for (const field of handleFields) {
         if (Shape.isTypeVar(handle[field])) {
           this.typeVars.push({object: handle, field});
         }
       }
     }
 
-    for (let slot of slots) {
-      for (let field of slotFields) {
+    for (const slot of slots) {
+      for (const field of slotFields) {
         if (Shape.isTypeVar(slot[field])) {
           this.typeVars.push({object: slot, field});
         }
@@ -85,8 +85,8 @@ export class Shape {
     }
     // TODO: should probably confirm that handles and slots actually match.
     for (let i = 0; i < this.typeVars.length; i++) {
-      let thisTypeVar = this.typeVars[i];
-      let otherTypeVar = other.typeVars[i];
+      const thisTypeVar = this.typeVars[i];
+      const otherTypeVar = other.typeVars[i];
       if (!thisTypeVar.object[thisTypeVar.field].isMoreSpecificThan(
               otherTypeVar.object[otherTypeVar.field])) {
         return false;
@@ -96,7 +96,7 @@ export class Shape {
   }
 
   _applyExistenceTypeTest(test) {
-    for (let typeRef of this.typeVars) {
+    for (const typeRef of this.typeVars) {
       if (test(typeRef.object[typeRef.field])) {
         return true;
       }
@@ -108,7 +108,7 @@ export class Shape {
   _handlesToManifestString() {
     return this.handles
       .map(handle => {
-        let type = handle.type.resolvedType();
+        const type = handle.type.resolvedType();
         return `  ${handle.direction ? handle.direction + ' ': ''}${type.toString()} ${handle.name ? handle.name : '*'}`;
       }).join('\n');
   }
@@ -129,20 +129,20 @@ ${this._slotsToManifestString()}
   }
 
   static fromLiteral(data) {
-    let handles = data.handles.map(handle => ({type: _fromLiteral(handle.type), name: _fromLiteral(handle.name), direction: _fromLiteral(handle.direction)}));
-    let slots = data.slots.map(slot => ({name: _fromLiteral(slot.name), direction: _fromLiteral(slot.direction), isRequired: _fromLiteral(slot.isRequired), isSet: _fromLiteral(slot.isSet)}));
+    const handles = data.handles.map(handle => ({type: _fromLiteral(handle.type), name: _fromLiteral(handle.name), direction: _fromLiteral(handle.direction)}));
+    const slots = data.slots.map(slot => ({name: _fromLiteral(slot.name), direction: _fromLiteral(slot.direction), isRequired: _fromLiteral(slot.isRequired), isSet: _fromLiteral(slot.isSet)}));
     return new Shape(data.name, handles, slots);
   }
 
   toLiteral() {
-    let handles = this.handles.map(handle => ({type: _toLiteral(handle.type), name: _toLiteral(handle.name), direction: _toLiteral(handle.direction)}));
-    let slots = this.slots.map(slot => ({name: _toLiteral(slot.name), direction: _toLiteral(slot.direction), isRequired: _toLiteral(slot.isRequired), isSet: _toLiteral(slot.isSet)}));
+    const handles = this.handles.map(handle => ({type: _toLiteral(handle.type), name: _toLiteral(handle.name), direction: _toLiteral(handle.direction)}));
+    const slots = this.slots.map(slot => ({name: _toLiteral(slot.name), direction: _toLiteral(slot.direction), isRequired: _toLiteral(slot.isRequired), isSet: _toLiteral(slot.isSet)}));
     return {name: this.name, handles, slots};
   }
 
   clone(variableMap) : Shape {
-    let handles = this.handles.map(({name, direction, type}) => ({name, direction, type: type ? type.clone(variableMap) : undefined}));
-    let slots = this.slots.map(({name, direction, isRequired, isSet}) => ({name, direction, isRequired, isSet}));
+    const handles = this.handles.map(({name, direction, type}) => ({name, direction, type: type ? type.clone(variableMap) : undefined}));
+    const slots = this.slots.map(({name, direction, isRequired, isSet}) => ({name, direction, isRequired, isSet}));
     return new Shape(this.name, handles, slots);
   }
 
@@ -151,13 +151,13 @@ ${this._slotsToManifestString()}
   }
 
   _cloneWithResolutions(variableMap) {
-    let handles = this.handles.map(({name, direction, type}) => ({name, direction, type: type ? type._cloneWithResolutions(variableMap) : undefined}));
-    let slots = this.slots.map(({name, direction, isRequired, isSet}) => ({name, direction, isRequired, isSet}));
+    const handles = this.handles.map(({name, direction, type}) => ({name, direction, type: type ? type._cloneWithResolutions(variableMap) : undefined}));
+    const slots = this.slots.map(({name, direction, isRequired, isSet}) => ({name, direction, isRequired, isSet}));
     return new Shape(this.name, handles, slots);
   }
 
   canEnsureResolved() {
-    for (let typeVar of this.typeVars) {
+    for (const typeVar of this.typeVars) {
       if (!typeVar.object[typeVar.field].canEnsureResolved()) {
         return false;
       }
@@ -166,12 +166,12 @@ ${this._slotsToManifestString()}
   }
 
   maybeEnsureResolved() {
-    for (let typeVar of this.typeVars) {
+    for (const typeVar of this.typeVars) {
       let variable = typeVar.object[typeVar.field];
       variable = variable.clone(new Map());
       if (!variable.maybeEnsureResolved()) return false;
     }
-    for (let typeVar of this.typeVars) {
+    for (const typeVar of this.typeVars) {
       typeVar.object[typeVar.field].maybeEnsureResolved();
     }
     return true;
@@ -187,15 +187,15 @@ ${this._slotsToManifestString()}
       return null;
     }
 
-    let handles = new Set(this.handles);
-    let otherHandles = new Set(other.handles);
-    let handleMap = new Map();
+    const handles = new Set(this.handles);
+    const otherHandles = new Set(other.handles);
+    const handleMap = new Map();
     let sizeCheck = handles.size;
     while (handles.size > 0) {
-      let handleMatches = [...handles.values()].map(
+      const handleMatches = [...handles.values()].map(
         handle => ({handle, match: [...otherHandles.values()].filter(otherHandle =>this._equalHandle(handle, otherHandle))}));
 
-      for (let handleMatch of handleMatches) {
+      for (const handleMatch of handleMatches) {
         // no match!
         if (handleMatch.match.length == 0) {
           return null;
@@ -213,9 +213,9 @@ ${this._slotsToManifestString()}
       sizeCheck = handles.size;
     }
 
-    let handleList = [];
-    for (let handle of this.handles) {
-      let otherHandle = handleMap.get(handle);
+    const handleList = [];
+    for (const handle of this.handles) {
+      const otherHandle = handleMap.get(handle);
       let resultType;
       if (handle.type.hasVariable || otherHandle.type.hasVariable) {
         resultType = TypeChecker._tryMergeTypeVariable(handle.type, otherHandle.type);
@@ -227,7 +227,7 @@ ${this._slotsToManifestString()}
       }
       handleList.push({name: handle.name || otherHandle.name, direction: handle.direction || otherHandle.direction, type: resultType});
     }
-    let slots = this.slots.map(({name, direction, isRequired, isSet}) => ({name, direction, isRequired, isSet}));
+    const slots = this.slots.map(({name, direction, isRequired, isSet}) => ({name, direction, isRequired, isSet}));
     return new Shape(this.name, handleList, slots);
   }
 
@@ -260,9 +260,9 @@ ${this._slotsToManifestString()}
   }
 
   _equalItems(otherItems, items, compareItem) {
-    for (let otherItem of otherItems) {
+    for (const otherItem of otherItems) {
       let exists = false;
-      for (let item of items) {
+      for (const item of items) {
         if (compareItem(item, otherItem)) {
           exists = true;
           break;
@@ -277,7 +277,7 @@ ${this._slotsToManifestString()}
   }
 
   _cloneAndUpdate(update) {
-    let copy = this.clone(new Map());
+    const copy = this.clone(new Map());
     copy.typeVars.forEach(typeVar => Shape._updateTypeVar(typeVar, update));
     return copy;
   }
@@ -310,7 +310,7 @@ ${this._slotsToManifestString()}
     if (shapeHandle.type.isVariableReference) {
       return false;
     }
-    let [left, right] = Type.unwrapPair(shapeHandle.type, particleHandle.type);
+    const [left, right] = Type.unwrapPair(shapeHandle.type, particleHandle.type);
     if (left.isVariable) {
       return [{var: left, value: right, direction: shapeHandle.direction}];
     } else {
@@ -340,7 +340,7 @@ ${this._slotsToManifestString()}
   }
 
   particleMatches(particleSpec) {
-    let shape = this.cloneWithResolutions(new Map());
+    const shape = this.cloneWithResolutions(new Map());
     return shape.restrictType(particleSpec) !== false;
   }
 
@@ -350,11 +350,11 @@ ${this._slotsToManifestString()}
 
   _restrictThis(particleSpec) {
 
-    let handleMatches = this.handles.map(
+    const handleMatches = this.handles.map(
       handle => particleSpec.connections.map(connection => ({match: connection, result: Shape.handlesMatch(handle, connection)}))
                                       .filter(a => a.result !== false));
 
-    let particleSlots = [];
+    const particleSlots = [];
     particleSpec.slots.forEach(consumedSlot => {
       particleSlots.push({name: consumedSlot.name, direction: 'consume', isRequired: consumedSlot.isRequired, isSet: consumedSlot.isSet});
       consumedSlot.providedSlots.forEach(providedSlot => {
@@ -364,21 +364,21 @@ ${this._slotsToManifestString()}
     let slotMatches = this.slots.map(slot => particleSlots.filter(particleSlot => Shape.slotsMatch(slot, particleSlot)));
     slotMatches = slotMatches.map(matchList => matchList.map(slot => ({match: slot, result: true})));
 
-    let exclusions = [];
+    const exclusions = [];
 
     // TODO: this probably doesn't deal with multiple match options.
     function choose(list, exclusions) {
       if (list.length == 0) {
         return [];
       }
-      let thisLevel = list.pop();
-      for (let connection of thisLevel) {
+      const thisLevel = list.pop();
+      for (const connection of thisLevel) {
         if (exclusions.includes(connection.match)) {
           continue;
         }
-        let newExclusions = exclusions.slice();
+        const newExclusions = exclusions.slice();
         newExclusions.push(connection.match);
-        let constraints = choose(list, newExclusions);
+        const constraints = choose(list, newExclusions);
         if (constraints !== false) {
           return connection.result.length ? constraints.concat(connection.result) : constraints;
         }
@@ -387,14 +387,14 @@ ${this._slotsToManifestString()}
       return false;
     }
 
-    let handleOptions = choose(handleMatches, []);
-    let slotOptions = choose(slotMatches, []);
+    const handleOptions = choose(handleMatches, []);
+    const slotOptions = choose(slotMatches, []);
 
     if (handleOptions === false || slotOptions === false) {
       return false;
     }
 
-    for (let constraint of handleOptions) {
+    for (const constraint of handleOptions) {
       if (!constraint.var.variable.resolution) {
         constraint.var.variable.resolution = constraint.value;
       } else if (constraint.var.variable.resolution.isVariable) {

--- a/runtime/ts/storage/in-memory-storage.ts
+++ b/runtime/ts/storage/in-memory-storage.ts
@@ -5,8 +5,6 @@
 // Code distributed by Google as part of this project is also
 // subject to an additional IP rights grant found at
 // http://polymer.github.io/PATENTS.txt
-'use strict';
-
 
 import {assert} from '../../../platform/assert-web.js';
 import {Tracing} from '../../../tracelib/trace.js';

--- a/runtime/ts/storage/key-base.ts
+++ b/runtime/ts/storage/key-base.ts
@@ -5,7 +5,6 @@
 // Code distributed by Google as part of this project is also
 // subject to an additional IP rights grant found at
 // http://polymer.github.io/PATENTS.txt
-'use strict';
 
 export class KeyBase {
   childKeyForHandle(id) {

--- a/runtime/ts/storage/storage-provider-factory.ts
+++ b/runtime/ts/storage/storage-provider-factory.ts
@@ -5,7 +5,6 @@
 // Code distributed by Google as part of this project is also
 // subject to an additional IP rights grant found at
 // http://polymer.github.io/PATENTS.txt
-'use strict';
 
 import {InMemoryStorage} from './in-memory-storage';
 import {FirebaseStorage} from './firebase-storage';

--- a/runtime/ts/type.ts
+++ b/runtime/ts/type.ts
@@ -5,7 +5,6 @@
 // Code distributed by Google as part of this project is also
 // subject to an additional IP rights grant found at
 // http://polymer.github.io/PATENTS.txt
-'use strict';
 
 import {assert} from '../../platform/assert-web.js';
 

--- a/runtime/ts/type.ts
+++ b/runtime/ts/type.ts
@@ -237,8 +237,7 @@ export class Type {
     if (this.isInterface) {
       return Type.newInterface(this.interfaceShape.canWriteSuperset);
     }
-    assert(false, `canWriteSuperset not implemented for ${this}`);
-    return undefined;
+    throw new Error(`canWriteSuperset not implemented for ${this}`);
   }
 
   get canReadSubset() {
@@ -251,8 +250,7 @@ export class Type {
     if (this.isInterface) {
       return Type.newInterface(this.interfaceShape.canReadSubset);
     }
-    assert(false, `canReadSubset not implemented for ${this}`);
-    return undefined;
+    throw new Error(`canReadSubset not implemented for ${this}`);
   }
 
   isMoreSpecificThan(type) {
@@ -269,7 +267,7 @@ export class Type {
       // TODO: formFactor checking, etc.
       return true;
     }
-    assert(false, `contains not implemented for ${this}`);
+    throw new Error(`contains not implemented for ${this}`);
   }
 
   static _canMergeCanReadSubset(type1, type2) {
@@ -282,7 +280,7 @@ export class Type {
                    type1.canReadSubset.entitySchema,
                    type2.canReadSubset.entitySchema) !== null;
       }
-      assert(false, `_canMergeCanReadSubset not implemented for types tagged with ${type1.canReadSubset.tag}`);
+      throw new Error(`_canMergeCanReadSubset not implemented for types tagged with ${type1.canReadSubset.tag}`);
     }
     return true;
   }
@@ -423,7 +421,7 @@ export class Type {
     if (this.isSlot) {
       return 'Slot';
     }
-    assert(false, `Add support to serializing type: ${JSON.stringify(this)}`);
+    throw new Error(`Add support to serializing type: ${JSON.stringify(this)}`);
   }
 
   getEntitySchema() {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,16 @@
 {
   "compilerOptions": {
+    "allowUnreachableCode": false,
+    "allowUnusedLabels": false,
     "alwaysStrict": true,
+
     "outDir": "runtime/ts-build",
+
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitReturns": true,
+
     "allowJs": false,
+    "sourceMap": true,
     "target": "es6",
     "lib": ["es2017", "dom"] 
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "alwaysStrict": true,
     "outDir": "runtime/ts-build",
     "allowJs": false,
     "target": "es6",


### PR DESCRIPTION
- More automated lint cleanups, let/const fixes, etc.
- Introduce alwaysStrict compiler option, remove redundant 'use strict' from code
- Add more strict compiler options, fix issues for noImplicitReturns  
  - Use abstract class syntax for FirebaseStorageProvider
  - Replace assert(false ...) with throw Error
  - Use Promise<void> for a function to denote that the return is not evaluated
- Replace remaining assert(false...) usages with throw Error
