### PR TITLE
Fix some Id type usages

### DIFF
--- a/runtime/ts/id.ts
+++ b/runtime/ts/id.ts
@@ -8,7 +8,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {Random} from './random';
+import {Random} from './random.js';
 
 export class Id {
   private session: string;

--- a/runtime/ts/id.ts
+++ b/runtime/ts/id.ts
@@ -7,14 +7,13 @@
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
-'use strict';
 
-import {Random} from './random.js';
+import {Random} from './random';
 
 export class Id {
   private session: string;
   private currentSession: string;
-  private nextIdComponent: number = 0;
+  private nextIdComponent = 0;
   private components: string[] = [];
 
   constructor(currentSession: string) {
@@ -23,16 +22,15 @@ export class Id {
   }
 
   static newSessionId() {
-    let session = Math.floor(Random.next() * Math.pow(2, 50)) + '';
+    const session = Math.floor(Random.next() * Math.pow(2, 50)) + '';
     return new Id(session);
   }
 
-  fromString(str: string) {
-    let components = str.split(':');
+  fromString(str: string): Id {
+    const components = str.split(':');
+    const id = new Id(this.currentSession);
 
-    let id = new Id(this.currentSession);
-
-    if (components[0][0] == '!') {
+    if (components[0][0] === '!') {
       id.session = components[0].slice(1);
       id.components = components.slice(1);
     } else {
@@ -42,23 +40,23 @@ export class Id {
     return id;
   }
 
-  toString() {
+  toString(): string {
     return `!${this.session}:${this.components.join(':')}`;
   }
 
   // Only use this for testing!
-  toStringWithoutSessionForTesting() {
+  toStringWithoutSessionForTesting(): string {
     return this.components.join(':');
   }
 
-  createId(component = '') {
-    let id = new Id(this.currentSession);
+  createId(component = ''): Id {
+    const id = new Id(this.currentSession);
     id.components = this.components.slice();
     id.components.push(component + this.nextIdComponent++);
     return id;
   }
 
-  equal(id: Id) {
+  equal(id: Id): boolean {
     if (id.session !== this.session || id.components.length !== this.components.length) {
       return false;
     }

--- a/runtime/ts/storage/firebase-storage.ts
+++ b/runtime/ts/storage/firebase-storage.ts
@@ -13,6 +13,7 @@ import {KeyBase} from './key-base';
 import {atob} from '../../../platform/atob-web.js';
 import {btoa} from '../../../platform/btoa-web.js';
 import {CrdtCollectionModel} from './crdt-collection-model';
+import {Id} from '../id';
 import {Type} from '../type';
 
 import {app, database} from '../../../node_modules/firebase/index';
@@ -83,12 +84,11 @@ class FirebaseKey extends KeyBase {
 let _nextAppNameSuffix = 0;
 
 export class FirebaseStorage {
-  private arcId: string;
   private apps: {[index: string]: app.App};
   private sharedStores: {[index: string]: FirebaseStorageProvider};
   private baseStores: Map<Type, FirebaseCollection>;
-  constructor(arcId) {
-    this.arcId = arcId;
+
+  constructor(private readonly arcId: Id) {
     this.apps = {};
     this.sharedStores = {};
     this.baseStores = new Map();

--- a/runtime/ts/storage/firebase-storage.ts
+++ b/runtime/ts/storage/firebase-storage.ts
@@ -13,7 +13,7 @@ import {KeyBase} from './key-base';
 import {atob} from '../../../platform/atob-web.js';
 import {btoa} from '../../../platform/btoa-web.js';
 import {CrdtCollectionModel} from './crdt-collection-model';
-import {Id} from '../id';
+import {Id} from '../id.js';
 import {Type} from '../type';
 
 import {app, database} from '../../../node_modules/firebase/index';

--- a/runtime/ts/storage/firebase-storage.ts
+++ b/runtime/ts/storage/firebase-storage.ts
@@ -9,12 +9,12 @@
 import {StorageProviderBase} from './storage-provider-base';
 import {firebase} from '../../../platform/firebase-web.js';
 import {assert} from '../../../platform/assert-web.js';
-import {KeyBase} from './key-base';
+import {KeyBase} from './key-base.js';
 import {atob} from '../../../platform/atob-web.js';
 import {btoa} from '../../../platform/btoa-web.js';
-import {CrdtCollectionModel} from './crdt-collection-model';
+import {CrdtCollectionModel} from './crdt-collection-model.js';
 import {Id} from '../id.js';
-import {Type} from '../type';
+import {Type} from '../type.js';
 
 import {app, database} from '../../../node_modules/firebase/index';
 
@@ -84,11 +84,13 @@ class FirebaseKey extends KeyBase {
 let _nextAppNameSuffix = 0;
 
 export class FirebaseStorage {
+  private readonly arcId: Id
   private apps: {[index: string]: app.App};
   private sharedStores: {[index: string]: FirebaseStorageProvider};
   private baseStores: Map<Type, FirebaseCollection>;
 
-  constructor(private readonly arcId: Id) {
+  constructor(arcId: Id) {
+    this.arcId = arcId;
     this.apps = {};
     this.sharedStores = {};
     this.baseStores = new Map();

--- a/runtime/ts/storage/in-memory-storage.ts
+++ b/runtime/ts/storage/in-memory-storage.ts
@@ -8,11 +8,11 @@
 
 import {assert} from '../../../platform/assert-web.js';
 import {Tracing} from '../../../tracelib/trace.js';
-import {StorageProviderBase} from './storage-provider-base';
-import {KeyBase} from './key-base';
-import {CrdtCollectionModel} from './crdt-collection-model';
-import {Id} from '../id';
-import {Type} from '../type';
+import {StorageProviderBase} from './storage-provider-base.js';
+import {KeyBase} from './key-base.js';
+import {CrdtCollectionModel} from './crdt-collection-model.js';
+import {Id} from '../id.js';
+import {Type} from '../type.js';
 
 export function resetInMemoryStorageForTesting() {
   for (const key in __storageCache) {
@@ -54,12 +54,14 @@ class InMemoryKey extends KeyBase {
 const __storageCache = {};
 
 export class InMemoryStorage {
+  private readonly arcId: Id;
   _memoryMap: { [index: string]: InMemoryStorageProvider};
   _typeMap: Map<Type, InMemoryCollection>;
   localIDBase: number;
 
-  constructor(private readonly arcId: Id) {
+  constructor(arcId: Id) {
     assert(arcId !== undefined, 'Arcs with storage must have ids');
+    this.arcId = arcId;
     this._memoryMap = {};
     this._typeMap = new Map();
     this.localIDBase = 0;

--- a/runtime/ts/storage/in-memory-storage.ts
+++ b/runtime/ts/storage/in-memory-storage.ts
@@ -11,6 +11,7 @@ import {Tracing} from '../../../tracelib/trace.js';
 import {StorageProviderBase} from './storage-provider-base';
 import {KeyBase} from './key-base';
 import {CrdtCollectionModel} from './crdt-collection-model';
+import {Id} from '../id';
 import {Type} from '../type';
 
 export function resetInMemoryStorageForTesting() {
@@ -23,7 +24,8 @@ class InMemoryKey extends KeyBase {
   protocol: string;
   arcId: string;
   location: string;
-  constructor(key) {
+
+  constructor(key: string) {
     super();
     let parts = key.split('://');
     this.protocol = parts[0];
@@ -52,25 +54,24 @@ class InMemoryKey extends KeyBase {
 const __storageCache = {};
 
 export class InMemoryStorage {
-  _arcId: string;
   _memoryMap: { [index: string]: InMemoryStorageProvider};
   _typeMap: Map<Type, InMemoryCollection>;
   localIDBase: number;
-  constructor(arcId) {
-      assert(arcId !== undefined, 'Arcs with storage must have ids');
-      this._arcId = arcId;
-      this._memoryMap = {};
-      this._typeMap = new Map();
-      this.localIDBase = 0;
-      // TODO(shans): re-add this assert once we have a runtime object to put it on.
-      // assert(__storageCache[this._arc.id] == undefined, `${this._arc.id} already exists in local storage cache`);
-      __storageCache[this._arcId] = this;
+
+  constructor(private readonly arcId: Id) {
+    assert(arcId !== undefined, 'Arcs with storage must have ids');
+    this._memoryMap = {};
+    this._typeMap = new Map();
+    this.localIDBase = 0;
+    // TODO(shans): re-add this assert once we have a runtime object to put it on.
+    // assert(__storageCache[this._arc.id] == undefined, `${this._arc.id} already exists in local storage cache`);
+    __storageCache[this.arcId.toString()] = this;
   }
 
   async construct(id, type, keyFragment) {
     const key = new InMemoryKey(keyFragment);
     if (key.arcId == undefined) {
-      key.arcId = this._arcId;
+      key.arcId = this.arcId.toString();
     }
     if (key.location == undefined) {
       key.location = 'in-memory-' + this.localIDBase++;
@@ -86,7 +87,7 @@ export class InMemoryStorage {
 
   async connect(id, type, keyString) {
     const key = new InMemoryKey(keyString);
-    if (key.arcId !== this._arcId.toString()) {
+    if (key.arcId !== this.arcId.toString()) {
       if (__storageCache[key.arcId] == undefined) {
         return null;
       }
@@ -101,7 +102,7 @@ export class InMemoryStorage {
 
   async share(id, type, keyString) {
     const key = new InMemoryKey(keyString);
-    assert(key.arcId == this._arcId.toString());
+    assert(key.arcId == this.arcId.toString());
     if (this._memoryMap[keyString] == undefined) {
       return this.construct(id, type, keyString);
     }

--- a/runtime/ts/storage/storage-provider-factory.ts
+++ b/runtime/ts/storage/storage-provider-factory.ts
@@ -8,12 +8,12 @@
 
 import {InMemoryStorage} from './in-memory-storage';
 import {FirebaseStorage} from './firebase-storage';
+import {Id} from '../id';
 
 export class StorageProviderFactory {
   _storageInstances: {[index: string]: InMemoryStorage | FirebaseStorage};
-  _arcId: string;
-  constructor(arcId) {
-    this._arcId = arcId;
+
+  constructor(private readonly arcId:Id) {
     this._storageInstances = {'in-memory': new InMemoryStorage(arcId), 'firebase': new FirebaseStorage(arcId)};
   }
 


### PR DESCRIPTION
- Fixes type signature in storage-provider-factory and other classes where string
  was being used instead
- Explicit usage of toString when setting key.arcId in InMemoryStorage
- Uses id.toString as the cache key in InMemoryStorage
