### PR TITLE
Allow node modules to be loaded using non-filesystem paths from non-n…

### DIFF
--- a/tools/custom-loader.mjs
+++ b/tools/custom-loader.mjs
@@ -2,10 +2,15 @@ import url from 'url';
 
 export function resolve(specifier, parent, resolve) {
   if (!/^[./]/.test(specifier)) {
-    if (!parent.includes('-node.js') && !parent.includes('node_modules')) {
-      throw new Error(`cannot load ${specifier} from ${parent}`);
+    let result;
+    try {
+      result = resolve(specifier, parent);
+    } catch(e) {}
+
+    if (!result && !parent.includes('-node.js') && !parent.includes('node_modules')) {
+      throw new Error(`cannot load ${specifier} from ${parent}. Only node_modules can be loaded using non-filesystem paths.`);
     }
-    let result = resolve(specifier, parent);
+
     return result;
   }
   if (!/\.(js|mjs)$/.test(specifier)) {


### PR DESCRIPTION
…ode-modules

Currently the module loader allows an import like

import {Foo} from 'Bar'

If 'Bar' lives in the node_modules directory and the file that is referencing
it is also located in the node_modules directory, otherwisew an error is thrown.

This change allows node_modules to be loaded without filesystem paths from
any module.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/polymerlabs/arcs/1781)
<!-- Reviewable:end -->
