### PR TITLE
use runtime storage/serialization by default

### DIFF
--- a/shell/app-shell/elements/arc-config.js
+++ b/shell/app-shell/elements/arc-config.js
@@ -51,8 +51,8 @@ class ArcConfig extends Xen.Base {
       key: params.get('arc') || null,
       search: params.get('search') || '',
       urls: window.shellUrls || {},
-      useStorage: params.has('store'),
-      useSerialization: params.has('serial')
+      useStorage: !params.has('legacy'),
+      useSerialization: !params.has('legacy') && !params.has('legacy-steps')
     };
   }
 }

--- a/shell/app-shell/elements/arc-config.js
+++ b/shell/app-shell/elements/arc-config.js
@@ -51,8 +51,8 @@ class ArcConfig extends Xen.Base {
       key: params.get('arc') || null,
       search: params.get('search') || '',
       urls: window.shellUrls || {},
-      useStorage: !params.has('legacy'),
-      useSerialization: !params.has('legacy') && !params.has('legacy-steps')
+      useStorage: !params.has('legacy') && !params.has('legacy-store'),
+      useSerialization: !params.has('legacy')
     };
   }
 }


### PR DESCRIPTION
Use `legacy` flag to enable old shim-processing for both services, use `legacy-store` to enable shim-storage only.

Currently failing Gifts selenium tests, but fixing that demo is part of the reason this PR exists.