### PR TITLE
Make handle-test.js more hermetic

### DIFF
--- a/runtime/test/handle-test.js
+++ b/runtime/test/handle-test.js
@@ -23,9 +23,13 @@ import {StorageProviderFactory} from '../ts-build/storage/storage-provider-facto
 let loader = new Loader();
 
 const createSlotComposer = () => new SlotComposer({rootContainer: 'test', affordance: 'mock'});
-const Bar = new Schema({names: ['Bar'], fields: {id: 'Number', value: 'Text'}}).entityClass();
 
 describe('Handle', function() {
+
+  let Bar;
+  before(() => {
+    Bar = new Schema({names: ['Bar'], fields: {id: 'Number', value: 'Text'}}).entityClass();
+  });
 
   it('clear singleton store', async () => {
     let slotComposer = createSlotComposer();


### PR DESCRIPTION
It shouldn't create the Schema instance (thus executing code) if the tests aren't being run.