### PR TITLE
TypeScript module improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -165,14 +165,6 @@
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-0.0.30.tgz",
       "integrity": "sha512-orGL5LXERPYsLov6CWs3Fh6203+dXzJkR7OnddIr2514Hsecwc8xRpzCapshBbKFImCsvS/mk6+FWiN5LyZJAQ=="
     },
-    "@types/firebase": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@types/firebase/-/firebase-3.2.1.tgz",
-      "integrity": "sha512-G8XgHMu2jHlElfc2xVNaYP50F0qrqeTCjgeG1v5b4SRwWG4XKC4fCuEdVZuZaMRmVygcnbRZBAo9O7RsDvmkGQ==",
-      "requires": {
-        "firebase": "*"
-      }
-    },
     "@types/mkdirp": {
       "version": "0.3.29",
       "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-0.3.29.tgz",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "webpack": "^4.16.5"
   },
   "dependencies": {
-    "@types/firebase": "^3.2.1",
     "@types/pouchdb": "^6.3.2",
     "atob": "^2.1.0",
     "btoa": "^1.2.1",

--- a/runtime/ts/storage/firebase-storage.ts
+++ b/runtime/ts/storage/firebase-storage.ts
@@ -7,7 +7,8 @@
 // http://polymer.github.io/PATENTS.txt
 
 import {StorageProviderBase} from './storage-provider-base';
-import {firebase} from '../../../platform/firebase-web.js';
+import * as firebase from 'firebase';
+
 import {assert} from '../../../platform/assert-web.js';
 import {KeyBase} from './key-base.js';
 import {atob} from '../../../platform/atob-web.js';
@@ -15,8 +16,6 @@ import {btoa} from '../../../platform/btoa-web.js';
 import {CrdtCollectionModel} from './crdt-collection-model.js';
 import {Id} from '../id.js';
 import {Type} from '../type.js';
-
-import {app, database} from '../../../node_modules/firebase/index';
 
 export async function resetStorageForTesting(key) {
   key = new FirebaseKey(key);
@@ -89,7 +88,7 @@ let _nextAppNameSuffix = 0;
 
 export class FirebaseStorage {
   private readonly arcId: Id;
-  private readonly apps: {[index: string]: {app: app.App, owned: boolean}};
+  private readonly apps: {[index: string]: {app: firebase.app.App, owned: boolean}};
   private readonly sharedStores: {[index: string]: FirebaseStorageProvider|null};
   private baseStores: Map<Type, FirebaseCollection>;
 
@@ -151,7 +150,7 @@ export class FirebaseStorage {
 
     if (this.apps[key.projectId] == undefined) {
       for (const app of firebase.apps) {
-        if (app.options.databaseURL === key.databaseUrl) {
+        if (app.options['databaseURL'] === key.databaseUrl) {
           this.apps[key.projectId] = {app, owned: false};
           break;
         }
@@ -205,7 +204,7 @@ export class FirebaseStorage {
 abstract class FirebaseStorageProvider extends StorageProviderBase {
   private firebaseKey: string;
   protected persisting: Promise<void>|null;
-  protected reference: database.Reference;
+  protected reference: firebase.database.Reference;
   protected backingStore: FirebaseCollection|null;
   protected storageEngine: FirebaseStorage;
 
@@ -918,11 +917,11 @@ enum CursorState {'new', 'init', 'stream', 'removed', 'done'}
 // NOTE: entity mutation removes elements from a streamed read; the entity will be updated with an
 // index past the cursor's end but Firebase doesn't issue a child_removed event for it.
 class Cursor {
-  private orderByIndex: database.Query;
+  private orderByIndex: firebase.database.Query;
   private readonly pageSize: number;
   private state: CursorState;
   private removed: {}[];
-  private baseQuery: database.Query|null;
+  private baseQuery: firebase.database.Query|null;
   private nextStart: string|null;
   private end: string|null;
   private removedFn: ((removed: firebase.database.DataSnapshot) => void) | null;
@@ -979,7 +978,7 @@ class Cursor {
       return {done: true};
     }
 
-    let query;
+    let query: firebase.database.Query;
     if (this.state === CursorState.init) {
       query = this.baseQuery;
       this.state = CursorState.stream;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,10 +8,12 @@
 
     "noFallthroughCasesInSwitch": true,
     "noImplicitReturns": true,
+    "module": "es2015",
+    "moduleResolution": "Node",
 
     "allowJs": false,
     "sourceMap": true,
-    "target": "es6",
+    "target": "ES2017",
     "lib": ["es2017", "dom"] 
   },
   "include": [


### PR DESCRIPTION
- Use es2017 as the target output to avoid polyfill await code
- Use Node module type to allow for using node_modules as a search path
- Import firebase from typescript definitions in firebase-storage.ts
- Remove @types/typescript, it is deprecated as firebase proper contains the typing