### PR TITLE
Repair firebase imports

### DIFF
--- a/runtime/ts/storage/firebase-storage.ts
+++ b/runtime/ts/storage/firebase-storage.ts
@@ -12,9 +12,12 @@ import {StorageProviderBase} from './storage-provider-base';
 import * as firebase from 'firebase/app';
 import 'firebase/database';
 import 'firebase/storage';
-const firebase_initializeApp = (<any>firebase).default.initializeApp;
-const firebase_database = (<any>firebase).default.database;
-const firebase_apps = (<any>firebase).default.apps;
+
+/* tslint:disable:no-any */
+const firebaseInitializeApp = (firebase as any).default.initializeApp; 
+const firebaseDatabase = (firebase as any).default.database;
+const firebaseApps = (firebase as any).default.apps;
+/* tslint:enable:no-any */
 
 import {assert} from '../../../platform/assert-web.js';
 import {KeyBase} from './key-base.js';
@@ -26,17 +29,17 @@ import {Type} from '../type.js';
 
 export async function resetStorageForTesting(key) {
   key = new FirebaseKey(key);
-  const app = firebase_initializeApp({
+  const app = firebaseInitializeApp({
     apiKey: key.apiKey,
     databaseURL: key.databaseUrl
   });
 
-  let reference = firebase_database(app).ref(key.location);
+  let reference = firebaseDatabase(app).ref(key.location);
   await new Promise(resolve => {
     reference.remove(resolve);
   });
 
-  reference = firebase_database(app).ref('backingStores');
+  reference = firebaseDatabase(app).ref('backingStores');
   await new Promise(resolve => {
     reference.remove(resolve);
   });
@@ -156,7 +159,7 @@ export class FirebaseStorage {
     }
 
     if (this.apps[key.projectId] == undefined) {
-      for (const app of firebase_apps) {
+      for (const app of firebaseApps) {
         if (app.options['databaseURL'] === key.databaseUrl) {
           this.apps[key.projectId] = {app, owned: false};
           break;
@@ -165,7 +168,7 @@ export class FirebaseStorage {
     }
 
     if (this.apps[key.projectId] == undefined) {
-      const app = firebase_initializeApp({
+      const app = firebaseInitializeApp({
         apiKey: key.apiKey,
         databaseURL: key.databaseUrl
       }, `app${_nextAppNameSuffix++}`);
@@ -173,7 +176,7 @@ export class FirebaseStorage {
       this.apps[key.projectId] = {app, owned: true};
     }
 
-    const reference = firebase_database(this.apps[key.projectId].app).ref(key.location);
+    const reference = firebaseDatabase(this.apps[key.projectId].app).ref(key.location);
 
     let currentSnapshot: firebase.database.DataSnapshot;
     await reference.once('value', snapshot => currentSnapshot = snapshot);

--- a/runtime/ts/storage/firebase-storage.ts
+++ b/runtime/ts/storage/firebase-storage.ts
@@ -12,6 +12,9 @@ import {StorageProviderBase} from './storage-provider-base';
 import * as firebase from 'firebase/app';
 import 'firebase/database';
 import 'firebase/storage';
+const firebase_initializeApp = (<any>firebase).default.initializeApp;
+const firebase_database = (<any>firebase).default.database;
+const firebase_apps = (<any>firebase).default.apps;
 
 import {assert} from '../../../platform/assert-web.js';
 import {KeyBase} from './key-base.js';
@@ -23,17 +26,17 @@ import {Type} from '../type.js';
 
 export async function resetStorageForTesting(key) {
   key = new FirebaseKey(key);
-  const app = firebase.initializeApp({
+  const app = firebase_initializeApp({
     apiKey: key.apiKey,
     databaseURL: key.databaseUrl
   });
 
-  let reference = firebase.database(app).ref(key.location);
+  let reference = firebase_database(app).ref(key.location);
   await new Promise(resolve => {
     reference.remove(resolve);
   });
 
-  reference = firebase.database(app).ref('backingStores');
+  reference = firebase_database(app).ref('backingStores');
   await new Promise(resolve => {
     reference.remove(resolve);
   });
@@ -153,7 +156,7 @@ export class FirebaseStorage {
     }
 
     if (this.apps[key.projectId] == undefined) {
-      for (const app of firebase.apps) {
+      for (const app of firebase_apps) {
         if (app.options['databaseURL'] === key.databaseUrl) {
           this.apps[key.projectId] = {app, owned: false};
           break;
@@ -162,7 +165,7 @@ export class FirebaseStorage {
     }
 
     if (this.apps[key.projectId] == undefined) {
-      const app = firebase.initializeApp({
+      const app = firebase_initializeApp({
         apiKey: key.apiKey,
         databaseURL: key.databaseUrl
       }, `app${_nextAppNameSuffix++}`);
@@ -170,7 +173,7 @@ export class FirebaseStorage {
       this.apps[key.projectId] = {app, owned: true};
     }
 
-    const reference = firebase.database(this.apps[key.projectId].app).ref(key.location);
+    const reference = firebase_database(this.apps[key.projectId].app).ref(key.location);
 
     let currentSnapshot: firebase.database.DataSnapshot;
     await reference.once('value', snapshot => currentSnapshot = snapshot);


### PR DESCRIPTION
As an aside: tslint has control issues.

I mean, I get it, banning 'any' is a good idea. But here? I'm explicitly asking to use any because *it's better that way*. Sure, I could do something like
```
const firebaseInitializeApp = ((firebase as {})["default"] as {})["initializeApp"];
```

except that (1) this isn't fundamentally any safer and (2) it's *way* harder to see what the code is doing. 

The point of any, I thought, was that it was an escape hatch for when you needed to deal with things that were outside the ken of typescript. So why are my only options no-any (ever) or no-dynamic-any (which wouldn't let me do this either)? Where's no-implicit-any, to make sure that I only declare something any when I actually need to?

@mykmartin noticed a similar thing with variable declaration. You can:
* force everyone to always declare variables on one line, always
* force everyone to always declare each variable on its own line, always
* force everyone to always declare adjacent variables on one line, always

in other words, you get lots of *fundamentalist* options. But you can't force variables to be declared on their own line only when they have an initializing value, or any other nuanced combination. So we turned the option off altogether, because we don't like having tslint dictate stupid rules for no other reason than that it can.

I don't think we can turn off no-any without opening ourselves up to a world of hurt, but I'm also pretty convinced that tslint annotations on lines where we need to use any aren't going to go down well in the long run. Is this the point where we fork tslint?