### PR TITLE
CSP Provisioning (Alternate Take)

### DIFF
--- a/shell/apps/common/csp.js
+++ b/shell/apps/common/csp.js
@@ -29,39 +29,37 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         wss://*.firebase.io wss://*.firebaseio.com
         https://*.firebaseio.com
         https://*.firebase.io
-        https://xenonjs.com
         https://raw.githubusercontent.com/shaper/
+        https://sjmiles.github.io
+        https://xenonjs.com
         https://*.tvmaze.com
         https://media.w3.org
-        Xttps://bost.ocks.org
-        Xttps://noelutz.github.io
         ;
     font-src
-      'self'
+        'self'
         https://fonts.googleapis.com
         https://fonts.gstatic.com
+        https://raw.githubusercontent.com/shaper/
         https://sjmiles.github.io
         ;
     img-src
         'self'
-        https://xenonjs.com
         https://raw.githubusercontent.com/shaper/
+        https://sjmiles.github.io
+        https://xenonjs.com
         https://*.tvmaze.com
         https://media.w3.org
-        Xttps://bost.ocks.org
-        Xttps://noelutz.github.io
         data:
         ;
-    style-src 'self'
+    style-src
+        'self'
         'unsafe-inline'
         https://fonts.googleapis.com
         https://fonts.gstatic.com
+        https://raw.githubusercontent.com/shaper/
         https://sjmiles.github.io
         https://xenonjs.com
-        https://raw.githubusercontent.com/shaper/
         https://media.w3.org
-        Xttps://bost.ocks.org
-        Xttps://noelutz.github.io
         ;
   `
   // (optional) compress whitespace

--- a/shell/apps/common/csp.js
+++ b/shell/apps/common/csp.js
@@ -20,7 +20,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   // TODO: get rid of unsafe-inline for style?
   // TODO: construct whitelist dynamically from particle manifests
   //       OR use service worker to enforce
-  // TODO(sjmiles): explain failure of script-src 'dynamic-self'
+  // TODO(sjmiles): explain failure of `script-src 'strict-dynamic'`
   //
   const httpEquiv = 'Content-Security-Policy';
   const content = `

--- a/shell/apps/common/csp.js
+++ b/shell/apps/common/csp.js
@@ -1,0 +1,71 @@
+/*
+@license
+Copyright (c) 2018 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+*/
+(() => {
+  //
+  // 1. Deny everything
+  // 2. Scripts from self, the inner <script> tag, and transitively loaded are allowed
+  //   a. nonce currently is hardcoded, but should be random
+  // 3. Scripts from explicitly whitelisted 3P allowed
+  // 4. fonts only allowed from Google fonts and sjmiles repo
+  // 5. Images allowed from 3P, plus data: URLs
+  // 6. CSS allowed as inline <style>, as well as 3P whitelist
+  // TODO: make this dynamically generated at build time for static file serving
+  // TODO: get rid of unsafe-inline for style?
+  // TODO: construct whitelist dynamically from particle manifests
+  //       OR use service worker to enforce
+  // TODO(sjmiles): explain failure of script-src 'dynamic-self'
+  //
+  const httpEquiv = 'Content-Security-Policy';
+  const content = `
+    script-src
+        'self'
+        wss://*.firebase.io wss://*.firebaseio.com
+        https://*.firebaseio.com
+        https://*.firebase.io
+        https://xenonjs.com
+        https://raw.githubusercontent.com/shaper/
+        https://*.tvmaze.com
+        https://media.w3.org
+        Xttps://bost.ocks.org
+        Xttps://noelutz.github.io
+        ;
+    font-src
+      'self'
+        https://fonts.googleapis.com
+        https://fonts.gstatic.com
+        https://sjmiles.github.io
+        ;
+    img-src
+        'self'
+        https://xenonjs.com
+        https://raw.githubusercontent.com/shaper/
+        https://*.tvmaze.com
+        https://media.w3.org
+        Xttps://bost.ocks.org
+        Xttps://noelutz.github.io
+        data:
+        ;
+    style-src 'self'
+        'unsafe-inline'
+        https://fonts.googleapis.com
+        https://fonts.gstatic.com
+        https://sjmiles.github.io
+        https://xenonjs.com
+        https://raw.githubusercontent.com/shaper/
+        https://media.w3.org
+        Xttps://bost.ocks.org
+        Xttps://noelutz.github.io
+        ;
+  `
+  // (optional) compress whitespace
+  .replace(/\n| +/g, ' ')
+  ;
+  document.head.appendChild(Object.assign(document.createElement('meta'), {httpEquiv, content}));
+})();

--- a/shell/apps/web/index.html
+++ b/shell/apps/web/index.html
@@ -1,3 +1,12 @@
+<!--
+@license
+Copyright (c) 2018 Google Inc. All rights reserved.
+This code may only be used under the BSD style license found at
+http://polymer.github.io/LICENSE.txt
+Code distributed by Google as part of this project is also
+subject to an additional IP rights grant found at
+http://polymer.github.io/PATENTS.txt
+-->
 <!doctype html>
 <html lang="en">
 <head>
@@ -7,23 +16,14 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
 
+  <script src="../common/csp.js"></script>
+
   <link rel="manifest" href="../common/manifest.json"/>
-  <link rel="shortcut icon" href="../common/logo_64.png">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Google+Sans:400,700">
   <link rel="stylesheet" href="../common/index.css">
+  <link rel="shortcut icon" href="../common/logo_64.png">
 
-  <script type="module">
-    // global configuration
-    import '../common/config.js';
-    // arcs runtime
-    import '../../build/ArcsLib.js';
-    // firebase config requires arcs runtime
-    import '../common/firebase-config.js';
-    // elements
-    import '../../app-shell/app-shell.js';
-    // components for particle use
-    import '../common/whitelisted.js';
-  </script>
+  <script type="module" src="index.js"></script>
 
 </head>
 <body>

--- a/shell/apps/web/index.js
+++ b/shell/apps/web/index.js
@@ -1,0 +1,20 @@
+/*
+@license
+Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+*/
+
+// global configuration
+import '../common/config.js';
+// arcs runtime
+import '../../build/ArcsLib.js';
+// firebase config requires arcs runtime
+import '../common/firebase-config.js';
+// elements
+import '../../app-shell/app-shell.js';
+// components for particle use
+import '../common/whitelisted.js';


### PR DESCRIPTION
This is virtually the same CSP policy as in #1815, with a few tweaks.

I made a new PR because:
1. #1815 has some weird duplicate commits (happens!)
2. avoid build pressure 
    a. no pretend nonce
    b. support easy application of the policy to other entry-points

Other notes:
* I didn't root this, but `script-src 'strict-dynamic`' caused `apps/web` to fail on my machine, so I removed it with the `nonce`.
* I don't recognize `bost.ocks.org` so I temporarily disabled it.
* `noelutz.github.io` shouldn't be a dependency any more, so I disabled that too.

WDYT?