### PR TITLE
Switch to synthetic default imports for firebase

### DIFF
--- a/runtime/ts/storage/firebase-storage.ts
+++ b/runtime/ts/storage/firebase-storage.ts
@@ -9,7 +9,7 @@
 import {StorageProviderBase} from './storage-provider-base';
 
 // keep in sync with shell/source/ArcsLib.js
-import * as firebase from 'firebase/app';
+import firebase from 'firebase/app';
 import 'firebase/database';
 import 'firebase/storage';
 

--- a/shell/source/ArcsLib.js
+++ b/shell/source/ArcsLib.js
@@ -18,7 +18,7 @@ import {Type} from '../../runtime/ts-build/type.js';
 import {BrowserLoader} from './browser-loader.js';
 import {Tracing} from '../../tracelib/trace.js';
 // Keep in sync with runtime/ts/storage/firebase-storage.ts
-import * as firebase from 'firebase/app';
+import firebase from 'firebase/app';
 import 'firebase/database';
 import 'firebase/storage';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,10 @@
 {
   "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
     "allowUnreachableCode": false,
     "allowUnusedLabels": false,
     "alwaysStrict": true,
+    "esModuleInterop": true,
 
     "outDir": "runtime/ts-build",
 


### PR DESCRIPTION
This switches typescript to use allowSyntheticDefaultImports and esModuleInterop.  These changes pass manual tests, and get rid of the tslint workarounds.  They are also required to support PouchDB, so might as well include them now.