### PR TITLE
First tiny runtime PR to shake out process

### DIFF
--- a/runtime/ts/runtime.ts
+++ b/runtime/ts/runtime.ts
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright (c) 2018 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {Description} from '../description.js';
+
+// To start with, this class will simply hide the runtime classes that are
+// currently imported by ArcsLib.js. Once that refactoring is done, we can
+// think about what the api should actually look like. 
+export class Runtime {
+  // list of all the arcs this runtime knows about
+  private arcs;
+  constructor() {
+    this.arcs = [];
+
+    // user information. One persona per runtime for now.
+  };
+
+
+  // Stuff the shell needs
+  static getArcDescription(arc) : string {
+    // Verify that it's one of my arcs, and make this non-static, once I have
+    // Runtime objects in the calling code.
+    return new Description(arc).getArcDescription();
+  };
+
+  // stuff the strategizer needs
+
+}

--- a/runtime/ts/runtime.ts
+++ b/runtime/ts/runtime.ts
@@ -20,7 +20,7 @@ export class Runtime {
     this.arcs = [];
 
     // user information. One persona per runtime for now.
-  };
+  }
 
 
   // Stuff the shell needs
@@ -28,7 +28,7 @@ export class Runtime {
     // Verify that it's one of my arcs, and make this non-static, once I have
     // Runtime objects in the calling code.
     return new Description(arc).getArcDescription();
-  };
+  }
 
   // stuff the strategizer needs
 

--- a/shell/app-shell/app-shell.js
+++ b/shell/app-shell/app-shell.js
@@ -262,7 +262,7 @@ class AppShell extends Xen.Debug(Xen.Base, log) {
     this._setState({arc: null, key});
   }
   async _describeArc(arc, fallback) {
-    const description = (await new Arcs.Description(arc).getArcDescription()) || fallback;
+    const description = (await Arcs.Runtime.getArcDescription(arc)) || fallback;
     this._setState({description});
   }
   _onStateData(e, data) {

--- a/shell/source/ArcsLib.js
+++ b/shell/source/ArcsLib.js
@@ -8,15 +8,20 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
+import {Runtime} from '../../runtime/ts-build/runtime.js';
+
+// The following will be pulled into Runtime.
 import {Arc} from '../../runtime/arc.js';
-import {Description} from '../../runtime/description.js';
 import {Manifest} from '../../runtime/manifest.js';
 import {Planificator} from '../../runtime/planificator.js';
 import {Planner} from '../../runtime/planner.js';
 import {SlotComposer} from '../../runtime/slot-composer.js';
 import {Type} from '../../runtime/ts-build/type.js';
+
+
 import {BrowserLoader} from './browser-loader.js';
 import {Tracing} from '../../tracelib/trace.js';
+
 // Keep in sync with runtime/ts/storage/firebase-storage.ts
 import firebase from 'firebase/app';
 import 'firebase/database';
@@ -28,7 +33,7 @@ import 'firebase/storage';
 const Arcs = {
   version: '0.3',
   Arc,
-  Description,
+  Runtime,
   Manifest,
   Planificator,
   Planner,


### PR DESCRIPTION
This adds a runtime.ts file and hides Description from the shell.

This is a first step toward a) refactoring most of the classes imported by ArcsLib.js to be behind the Runtime class, and b) actually refining the resulting Runtime class into a decent api.

The principal purpose of this PR is to run through the full edit, test, build, commit, push, pull-request, merge process, without a lot at stake.