### PR TITLE
Pull Manifest load and parse into Runtime class.

### DIFF
--- a/runtime/test/runtime-tests.js
+++ b/runtime/test/runtime-tests.js
@@ -11,6 +11,8 @@
 import {assert} from './chai-web.js';
 import {Arc} from '../arc.js';
 import {Description} from '../description.js';
+import {Loader} from '../loader.js';
+import {Manifest} from '../manifest.js';
 import {Runtime} from '../ts-build/runtime.js';
 import {SlotComposer} from '../slot-composer.js';
 
@@ -21,11 +23,34 @@ function createTestArc() {
 }
 
 describe('Runtime', function() {
-  it('getting arc description', async () => {
+  it('gets an arc description for an arc', async () => {
     let arc = createTestArc();
     let description = new Description(arc);
     let expected = await description.getArcDescription();
     let actual = await Runtime.getArcDescription(arc);
     assert.equal(expected, actual);
+  });
+  it('parses a Manifest', async () => {
+    let content = `
+    schema Text
+      Text value
+
+    particle Hello in 'hello.js'
+      out Text text
+
+    recipe
+      create as handleA
+      Hello
+        text -> handleA`;
+    let expected = await Manifest.parse(content);
+    let actual = await Runtime.parseManifest(content);
+    assert.deepEqual(expected, actual);
+  });
+  it('loads a Manifest', async () => {
+    let registry = {};
+    let loader = new Loader();
+    let expected = await Manifest.load('./runtime/test/artifacts/test.manifest', loader, registry);
+    let actual = await Runtime.loadManifest('./runtime/test/artifacts/test.manifest', loader, registry);
+    assert.deepEqual(expected, actual);
   });
 });

--- a/runtime/ts/runtime.ts
+++ b/runtime/ts/runtime.ts
@@ -25,17 +25,24 @@ export class Runtime {
 
 
   // Stuff the shell needs
+
+  // Given an arc, returns it's description as a string.
   static getArcDescription(arc) : Promise<string> {
     // Verify that it's one of my arcs, and make this non-static, once I have
     // Runtime objects in the calling code.
     return new Description(arc).getArcDescription();
   }
 
-  static parseManifest(content, options) : Manifest {
+  // Parse a textual manifest and return a Manifest object. See the Manifest
+  // class for the options accepted.
+  static parseManifest(content, options) : Promise<Manifest> {
     return Manifest.parse(content, options);
   }
 
-  static loadManifest(fileName, loader, options) : Manifest {
+  // Load and parse a manifest from a resource (not striclty a file) and return
+  // a Manifest object. The loader determines the semantics of the fileName. See
+  // the Manifest class for details.
+  static loadManifest(fileName, loader, options) : Promise<Manifest> {
     return Manifest.load(fileName, loader, options);
   }
 

--- a/runtime/ts/runtime.ts
+++ b/runtime/ts/runtime.ts
@@ -9,10 +9,11 @@
  */
 
 import {Description} from '../description.js';
+import {Manifest} from '../manifest.js';
 
 // To start with, this class will simply hide the runtime classes that are
 // currently imported by ArcsLib.js. Once that refactoring is done, we can
-// think about what the api should actually look like. 
+// think about what the api should actually look like.
 export class Runtime {
   // list of all the arcs this runtime knows about
   private arcs;
@@ -28,6 +29,14 @@ export class Runtime {
     // Verify that it's one of my arcs, and make this non-static, once I have
     // Runtime objects in the calling code.
     return new Description(arc).getArcDescription();
+  }
+
+  static parseManifest(content, options) : Manifest {
+    return Manifest.parse(content, options);
+  }
+
+  static loadManifest(fileName, loader, options) : Manifest {
+    return Manifest.load(fileName, loader, options);
   }
 
   // stuff the strategizer needs

--- a/shell/app-shell/elements/arc-host.js
+++ b/shell/app-shell/elements/arc-host.js
@@ -85,10 +85,10 @@ class ArcHost extends Xen.Debug(Xen.Base, log) {
     // TODO(sjmiles): do we need to be able to `config` this value?
     const fileName = './in-memory.manifest';
     try {
-      return await Arcs.Manifest.parse(content, {loader, fileName});
+      return await Arcs.Runtime.parseManifest(content, {loader, fileName});
     } catch (x) {
       warn(x);
-      return await Arcs.Manifest.parse('', {loader, fileName});
+      return await Arcs.Runtime.parseManifest('', {loader, fileName});
     }
   }
   _teardownArc(arc) {

--- a/shell/app-shell/elements/arc-store.js
+++ b/shell/app-shell/elements/arc-store.js
@@ -33,7 +33,7 @@ class ArcStore extends Xen.Debug(Xen.Base, log) {
         state.manifest = options.manifest;
       }
       if (!state.manifest && options && options.schemas) {
-        state.manifest = await Arcs.Manifest.load(options.schemas, arc.loader);
+        state.manifest = await Arcs.Runtime.loadManifest(options.schemas, arc.loader);
       }
       if (options && (state.manifest || options.schema)) {
         state.store = await this._attachStore(arc, state.manifest, options);

--- a/shell/source/ArcsLib.js
+++ b/shell/source/ArcsLib.js
@@ -12,7 +12,7 @@ import {Runtime} from '../../runtime/ts-build/runtime.js';
 
 // The following will be pulled into Runtime.
 import {Arc} from '../../runtime/arc.js';
-import {Manifest} from '../../runtime/manifest.js';
+//import {Manifest} from '../../runtime/manifest.js';
 import {Planificator} from '../../runtime/planificator.js';
 import {Planner} from '../../runtime/planner.js';
 import {SlotComposer} from '../../runtime/slot-composer.js';
@@ -34,7 +34,7 @@ const Arcs = {
   version: '0.3',
   Arc,
   Runtime,
-  Manifest,
+//  Manifest,
   Planificator,
   Planner,
   SlotComposer,

--- a/shell/workbench/onearc/index.html
+++ b/shell/workbench/onearc/index.html
@@ -67,7 +67,7 @@
         fileName: './in-memory.manifest',
         loader: host._state.loader
       };
-      const manifest = window.manifest = await Arcs.Manifest.parse(manifestContent, options);
+      const manifest = window.manifest = await Arcs.Runtime.parseManifest(manifestContent, options);
       //console.log(manifest);
       // TODO(sjmiles): clone is probably optional in this context
       //const recipe = window.recipe = manifest.recipes[0].clone();


### PR DESCRIPTION
This is still just removing explicit imports of Manifest, not yet refactoring to expose only what's needed.