### PR TITLE
Remove unused Planner import from ArcsLib.

### DIFF
--- a/shell/source/ArcsLib.js
+++ b/shell/source/ArcsLib.js
@@ -12,7 +12,6 @@ import {Runtime} from '../../runtime/ts-build/runtime.js';
 
 // The following will be pulled into Runtime.
 import {Arc} from '../../runtime/arc.js';
-//import {Manifest} from '../../runtime/manifest.js';
 import {Planificator} from '../../runtime/planificator.js';
 import {Planner} from '../../runtime/planner.js';
 import {SlotComposer} from '../../runtime/slot-composer.js';
@@ -34,9 +33,7 @@ const Arcs = {
   version: '0.3',
   Arc,
   Runtime,
-//  Manifest,
   Planificator,
-  Planner,
   SlotComposer,
   Type,
   BrowserLoader,


### PR DESCRIPTION
This isn't used anywhere via ArcsLib, so I'm removing it. All tests pass and demo works.