### PR TITLE
Support multiple description patterns in recipe to improve recipe descriptions coalescing.

### DIFF
--- a/runtime/arc.js
+++ b/runtime/arc.js
@@ -344,7 +344,7 @@ ${this.activeRecipe.toString()}`;
    let slotIndex = 0;
 
    this._recipes.forEach(recipe => {
-     let arcRecipe = {particles: [], handles: [], slots: [], innerArcs: new Map(), pattern: recipe.pattern};
+     let arcRecipe = {particles: [], handles: [], slots: [], innerArcs: new Map(), patterns: recipe.patterns};
      recipe.particles.forEach(p => {
        arcRecipe.particles.push(particles[particleIndex++]);
        if (recipe.innerArcs.has(p)) {
@@ -400,7 +400,7 @@ ${this.activeRecipe.toString()}`;
       currentArc = innerArcs.get(innerArc.particle);
     }
     let {handles, particles, slots} = recipe.mergeInto(currentArc.activeRecipe);
-    currentArc.recipes.push({particles, handles, slots, innerArcs: new Map(), pattern: recipe.pattern});
+    currentArc.recipes.push({particles, handles, slots, innerArcs: new Map(), patterns: recipe.patterns});
     slots.forEach(slot => slot.id = slot.id || `slotid-${this.generateID()}`);
 
     for (let recipeHandle of handles) {

--- a/runtime/description-dom-formatter.js
+++ b/runtime/description-dom-formatter.js
@@ -145,8 +145,8 @@ export class DescriptionDomFormatter extends DescriptionFormatter {
     let result = {template: '', model: {}};
     let count = descs.length;
     descs.forEach((desc, i) => {
-      if (!desc.template || !desc.model) {
-        return;
+      if (typeof desc === 'string') {
+        desc = Object.assign({}, {template: desc, model: {}});
       }
 
       result.template += desc.template;

--- a/runtime/description.js
+++ b/runtime/description.js
@@ -64,10 +64,15 @@ export class DescriptionFormatter {
   async getDescription(recipe) {
     await this._updateDescriptionHandles(this._description);
 
-    if (recipe.pattern) {
-      let recipeDesc = await this.patternToSuggestion(recipe.pattern, {_recipe: recipe});
-      if (recipeDesc) {
-        return this._capitalizeAndPunctuate(recipeDesc);
+    if (recipe.patterns.length > 0) {
+      let recipePatterns = [];
+      for (let pattern of recipe.patterns) {
+        recipePatterns.push(await this.patternToSuggestion(pattern, {_recipe: recipe}));
+      }
+      recipePatterns = recipePatterns.filter(pattern => Boolean(pattern));
+      if (recipePatterns.length > 0) {
+        // TODO(mmandlis): Sort the descriptions.
+        return this._capitalizeAndPunctuate(this._joinDescriptions(recipePatterns));
       }
     }
 

--- a/runtime/manifest-parser.peg
+++ b/runtime/manifest-parser.peg
@@ -291,7 +291,7 @@ ParticleDefinition
           kind: 'description?',
           location: 'FIXME',
         };
-        item.description.forEach(d => { description[d.name] = d.pattern; });
+        item.description.forEach(d => description[d.name] = d.pattern || d.patterns[0]);
       } else if (item.affordance) {
         affordance.push(item.affordance)
       } else {
@@ -550,6 +550,13 @@ ParticleProvidedSlotHandle
 Description
   = 'description' whiteSpace pattern:backquotedString eolWhiteSpace handleDescriptions:(Indent (SameIndent ParticleHandleDescription)+)?
   {
+    handleDescriptions = optional(handleDescriptions, extractIndented, []);
+    let patterns = [];
+    if (pattern) {
+      patterns.push(pattern);
+      handleDescriptions.filter(desc => desc.name == '_pattern_').forEach(pattern => patterns.push(pattern));
+      handleDescriptions = handleDescriptions.filter(desc => desc.name != '_pattern_');
+    }
     return {
       kind: 'description',
       location: location(),
@@ -559,9 +566,9 @@ Description
           kind: 'default-description?',
           location: location(),
           name: 'pattern',
-          pattern: pattern,
+          patterns: patterns,
         },
-        ...optional(handleDescriptions, extractIndented, []),
+        ...handleDescriptions,
       ],
     };
   }

--- a/runtime/test/description-test.js
+++ b/runtime/test/description-test.js
@@ -643,7 +643,7 @@ recipe
       recipe.normalize();
       assert.isTrue(recipe.isResolved());
       arc._activeRecipe = recipe;
-      arc.recipes.push({particles: recipe.particles, handles: recipe.handles, slots: recipe.slots, innerArcs: new Map(), pattern: recipe.pattern});
+      arc.recipes.push({particles: recipe.particles, handles: recipe.handles, slots: recipe.slots, innerArcs: new Map(), patterns: recipe.patterns});
       let description = new Description(arc);
 
       assert.equal(expectedDescription, await description.getRecipeSuggestion());

--- a/runtime/test/manifest-test.js
+++ b/runtime/test/manifest-test.js
@@ -55,7 +55,8 @@ describe('manifest', function() {
       assert.equal(recipe.handles[1].fate, 'create');
       assert.lengthOf(recipe.handleConnections, 1);
       assert.sameMembers(recipe.handleConnections[0].tags, ['tag']);
-      assert.equal(recipe.pattern, 'hello world');
+      assert.lengthOf(recipe.patterns, 1);
+      assert.equal(recipe.patterns[0], 'hello world');
       assert.equal(recipe.handles[1].pattern, 'best handle');
       let type = recipe.handleConnections[0].rawType;
       assert.lengthOf(Object.keys(manifest.schemas), 1);

--- a/runtime/test/strategies/coalesce-recipes-test.js
+++ b/runtime/test/strategies/coalesce-recipes-test.js
@@ -306,7 +306,7 @@ describe('CoalesceRecipes', function() {
         description \`output thing\`
     `);
     assert.isTrue(recipe.isResolved());
-    assert.equal('input thing and output thing', recipe.pattern);
+    assert.deepEqual(['input thing', 'output thing'], recipe.patterns);
   });
 
   it('coalesces for unresolved consume slots', async () => {

--- a/runtime/ts/schema.ts
+++ b/runtime/ts/schema.ts
@@ -50,7 +50,7 @@ export class Schema {
     this._model = model;
     this.description = {};
     if (model.description) {
-      model.description.description.forEach(desc => this.description[desc.name] = desc.pattern);
+      model.description.description.forEach(desc => this.description[desc.name] = desc.pattern || desc.patterns[0]);
     }
   }
 


### PR DESCRIPTION
part of https://github.com/PolymerLabs/arcs/issues/1570

This change solves the case when coalescing recipes as recipe1 + recipe2 vs recipe2 + recipe1, results in getting different descriptions and causing the resulting recipes to be considered different. 
Next step is to also include descriptions for recipes that don't have a recipe pattern (by using particles descriptions).