### PR TITLE
References in the back-end:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ enclave/toolchains
 enclave/host/storage/db.img
 enclave/host/storage/key
 runtime/ts-build
+.vscode
+devtools/build

--- a/runtime/manual_tests/firebase-tests.js
+++ b/runtime/manual_tests/firebase-tests.js
@@ -86,7 +86,29 @@ describe('firebase', function() {
       await synchronized(var1, var2);
       assert.deepEqual(await var1.get(), await var2.get());
     });
-    it.skip('supports pointer dereferences', async () => {
+    it('enables referenceMode by default', async() => {
+      let manifest = await Manifest.parse(`
+        schema Bar
+          Text value
+      `);
+
+      let arc = new Arc({id: 'test'});
+      let storage = createStorage(arc.id);
+      let BarType = Type.newEntity(manifest.schemas.Bar);
+      let key1 = newStoreKey('varPtr');
+  
+      let var1 = await storage.construct('test0', BarType, key1);
+      await var1.set({id: 'id1', value: 'underlying'});
+      
+      let result = await var1.get();
+      assert.equal('underlying', result.value);
+
+      assert.isTrue(var1.referenceMode);
+      assert.isNotNull(var1.backingStore);
+
+      assert.deepEqual(await var1.backingStore.get('id1'), await var1.get());
+    });
+    it('supports references', async () => {
       let manifest = await Manifest.parse(`
         schema Bar
           Text value
@@ -98,17 +120,13 @@ describe('firebase', function() {
       let key1 = newStoreKey('varPtr');
 
       let var1 = await storage.construct('test0', Type.newReference(BarType), key1);
-      await var1.set({id: 'id1', value: 'underlying'});
+      await var1.set({id: 'id1', storageKey: 'underlying'});
 
       let result = await var1.get();
-      assert.equal('underlying', result.value);
+      assert.equal('underlying', result.storageKey);
 
-      let underlyingValue = await storage._storageInstances['firebase'].baseStores.get(BarType).get('id1');
-      assert.equal('underlying', underlyingValue.value);
-
-      // force variable to reconnect to underlying storage
-      var1._backingStore = null;
-      assert.equal('underlying', (await var1.get()).value);
+      assert.isFalse(var1.referenceMode);
+      assert.isNull(var1.backingStore);
     });
   });
 
@@ -187,7 +205,34 @@ describe('firebase', function() {
       assert.lengthOf(await collection1.toList(), 2);
       assert.sameDeepMembers(await collection1.toList(), await collection2.toList());
     });
-    it.skip('supports pointer dereferences', async () => {
+    it('enables referenceMode by default', async() => {
+      let manifest = await Manifest.parse(`
+        schema Bar
+          Text value
+      `);
+
+      let arc = new Arc({id: 'test'});
+      let storage = createStorage(arc.id);
+      let BarType = Type.newEntity(manifest.schemas.Bar);
+      let key1 = newStoreKey('colPtr');
+  
+      let collection1 = await storage.construct('test0', BarType.collectionOf(), key1);
+  
+      await collection1.store({id: 'id1', value: 'value1'}, ['key1']);
+      await collection1.store({id: 'id2', value: 'value2'}, ['key2']);
+      
+      let result = await collection1.get('id1');
+      assert.equal('value1', result.value);
+      result = await collection1.get('id2');
+      assert.equal('value2', result.value);
+
+      assert.isTrue(collection1.referenceMode);
+      assert.isNotNull(collection1.backingStore);
+
+      assert.deepEqual(await collection1.backingStore.get('id1'), await collection1.get('id1'));
+      assert.deepEqual(await collection1.backingStore.get('id2'), await collection1.get('id2'));
+    });
+    it('supports references', async () => {
       let manifest = await Manifest.parse(`
         schema Bar
           Text value
@@ -200,24 +245,16 @@ describe('firebase', function() {
   
       let collection1 = await storage.construct('test0', Type.newReference(BarType).collectionOf(), key1);
   
-      await collection1.store({id: 'id1', value: 'value1'}, ['key1']);
-      await collection1.store({id: 'id2', value: 'value2'}, ['key2']);
+      await collection1.store({id: 'id1', storageKey: 'value1'}, ['key1']);
+      await collection1.store({id: 'id2', storageKey: 'value2'}, ['key2']);
       
       let result = await collection1.get('id1');
-      assert.equal('value1', result.value);
+      assert.equal('value1', result.storageKey);
       result = await collection1.get('id2');
-      assert.equal('value2', result.value);
-      
-      result = await collection1.toList();
-      let underlyingValues = await storage._storageInstances['firebase'].baseStores.get(BarType);
+      assert.equal('value2', result.storageKey);
 
-      assert.sameDeepMembers(result, await underlyingValues.toList());
-
-      // force collection to reconnect to Entity storage
-      collection1._backingStore = null;
-
-      result = await collection1.toList();
-      assert.sameDeepMembers(result, await underlyingValues.toList());
+      assert.isFalse(collection1.referenceMode);
+      assert.isNull(collection1.backingStore);
     }); 
   });
 

--- a/runtime/test/in-memory-test.js
+++ b/runtime/test/in-memory-test.js
@@ -69,7 +69,30 @@ describe('in-memory', function() {
       assert.deepEqual(await var1.get(), await var2.get());
     });
 
-    it.skip('supports pointer dereferences', async () => {
+    it('enables referenceMode by default', async() => {
+      let manifest = await Manifest.parse(`
+        schema Bar
+          Text value
+      `);
+
+      let arc = new Arc({id: 'test'});
+      let storage = new StorageProviderFactory(arc.id);
+      let BarType = Type.newEntity(manifest.schemas.Bar);
+      let key1 = newStoreKey('variablePointer');
+  
+      let var1 = await storage.construct('test0', BarType, key1);
+      await var1.set({id: 'id1', value: 'underlying'});
+      
+      let result = await var1.get();
+      assert.equal('underlying', result.value);
+
+      assert.isTrue(var1.referenceMode);
+      assert.isNotNull(var1.backingStore);
+
+      assert.deepEqual(await var1.backingStore.get('id1'), await var1.get());
+    });
+
+    it('supports references', async () => {
       let manifest = await Manifest.parse(`
         schema Bar
           Text value
@@ -81,17 +104,13 @@ describe('in-memory', function() {
       let key1 = newStoreKey('variablePointer');
 
       let var1 = await storage.construct('test0', Type.newReference(BarType), key1);
-      await var1.set({id: 'id1', value: 'underlying'});
+      await var1.set({id: 'id1', storageKey: 'underlying'});
       
       let result = await var1.get();
-      assert.equal('underlying', result.value);
+      assert.equal('underlying', result.storageKey);
 
-      let underlyingValue = await storage._storageInstances['in-memory']._typeMap.get(BarType).get('id1');
-      assert.equal('underlying', underlyingValue.value);
-
-      // force variable to reconnect to underlying storage
-      var1._backingStore = null;
-      assert.equal('underlying', (await var1.get()).value);
+      assert.isFalse(var1.referenceMode);
+      assert.isNull(var1.backingStore);
     });
   });
 
@@ -170,7 +189,33 @@ describe('in-memory', function() {
       assert.lengthOf(await collection1.toList(), 2);
       assert.sameDeepMembers(await collection1.toList(), await collection2.toList());
     });
-    it.skip('supports pointer dereferences', async () => {
+    it('enables referenceMode by default', async() => {
+      let manifest = await Manifest.parse(`
+        schema Bar
+          Text value
+      `);
+
+      let arc = new Arc({id: 'test'});
+      let storage = new StorageProviderFactory(arc.id);
+      let BarType = Type.newEntity(manifest.schemas.Bar);
+      let key1 = newStoreKey('variablePointer');
+  
+      let collection1 = await storage.construct('test0', BarType.collectionOf(), key1);
+  
+      await collection1.store({id: 'id1', value: 'value1'}, ['key1']);
+      await collection1.store({id: 'id2', value: 'value2'}, ['key2']);
+      
+      let result = await collection1.get('id1');
+      assert.equal('value1', result.value);
+      result = await collection1.get('id2');
+      assert.equal('value2', result.value);
+
+      assert.isTrue(collection1.referenceMode);
+      assert.isNotNull(collection1.backingStore);
+
+      assert.deepEqual(await collection1.backingStore.toList(), await collection1.toList());
+    });
+    it('supports references', async () => {
       let manifest = await Manifest.parse(`
         schema Bar
           Text value
@@ -183,23 +228,16 @@ describe('in-memory', function() {
   
       let collection1 = await storage.construct('test0', Type.newReference(BarType).collectionOf(), key1);
   
-      await collection1.store({id: 'id1', value: 'value1'}, ['key1']);
-      await collection1.store({id: 'id2', value: 'value2'}, ['key2']);
+      await collection1.store({id: 'id1', storageKey: 'value1'}, ['key1']);
+      await collection1.store({id: 'id2', storageKey: 'value2'}, ['key2']);
       
       let result = await collection1.get('id1');
-      assert.equal('value1', result.value);
+      assert.equal('value1', result.storageKey);
       result = await collection1.get('id2');
-      assert.equal('value2', result.value);
+      assert.equal('value2', result.storageKey);
 
-      result = await collection1.toList();
-      let underlyingValues = await storage._storageInstances['in-memory']._typeMap.get(BarType);
-      assert.sameDeepMembers(result, await underlyingValues.toList());
-
-      // force collection to reconnect to Entity storage
-      collection1._backingStore = null;
-
-      result = await collection1.toList();
-      assert.sameDeepMembers(result, await underlyingValues.toList());
+      assert.isFalse(collection1.referenceMode);
+      assert.isNull(collection1.backingStore);
     }); 
   });
 

--- a/runtime/ts/storage/firebase-storage.ts
+++ b/runtime/ts/storage/firebase-storage.ts
@@ -105,7 +105,10 @@ export class FirebaseStorage extends StorageBase {
   }
 
   async construct(id: string, type: Type, keyFragment: string) : Promise<FirebaseStorageProvider> {
-    return this._join(id, type, keyFragment, false, true);
+    let referenceMode = !type.isReference;
+    if (type.isCollection && type.primitiveType().isReference)
+      referenceMode = false;
+    return this._join(id, type, keyFragment, false, referenceMode);
   }
 
   async connect(id: string, type: Type, key: string) : Promise<FirebaseStorageProvider> {

--- a/runtime/ts/storage/in-memory-storage.ts
+++ b/runtime/ts/storage/in-memory-storage.ts
@@ -72,6 +72,10 @@ export class InMemoryStorage extends StorageBase {
 
   async construct(id: string, type: Type, keyFragment: string) : Promise<InMemoryStorageProvider> {
     const provider = await this._construct(id, type, keyFragment);
+    if (type.isReference)
+      return provider;
+    if (type.isCollection && type.primitiveType().isReference)
+      return provider;
     provider.enableReferenceMode();
     return provider;
   }


### PR DESCRIPTION
* don't switch to referenceMode if the requested Type is a reference type
* re-enable reference tests
* add test to ensure stores are still in referenceMode by default