### PR TITLE
Add missing particleId arg to HandleRemove in API channel.

### DIFF
--- a/runtime/api-channel.js
+++ b/runtime/api-channel.js
@@ -261,7 +261,7 @@ export class PECOuterPort extends APIPort {
     this.registerHandler('HandleToList', {handle: this.Mapped, callback: this.Direct, particleId: this.Direct});
     this.registerHandler('HandleSet', {handle: this.Mapped, data: this.Direct, particleId: this.Direct, barrier: this.Direct});
     this.registerHandler('HandleStore', {handle: this.Mapped, data: this.Direct, particleId: this.Direct});
-    this.registerHandler('HandleRemove', {handle: this.Mapped, data: this.Direct});
+    this.registerHandler('HandleRemove', {handle: this.Mapped, data: this.Direct, particleId: this.Direct});
     this.registerHandler('HandleClear', {handle: this.Mapped, particleId: this.Direct, barrier: this.Direct});
     this.registerHandler('Idle', {version: this.Direct, relevance: this.Map(this.Mapped, this.Direct)});
 
@@ -310,7 +310,7 @@ export class PECInnerPort extends APIPort {
     this.registerCall('HandleToList', {handle: this.Mapped, callback: this.LocalMapped, particleId: this.Direct});
     this.registerCall('HandleSet', {handle: this.Mapped, data: this.Direct, particleId: this.Direct, barrier: this.Direct});
     this.registerCall('HandleStore', {handle: this.Mapped, data: this.Direct, particleId: this.Direct});
-    this.registerCall('HandleRemove', {handle: this.Mapped, data: this.Direct});
+    this.registerCall('HandleRemove', {handle: this.Mapped, data: this.Direct, particleId: this.Direct});
     this.registerCall('HandleClear', {handle: this.Mapped, particleId: this.Direct, barrier: this.Direct});
     this.registerCall('Idle', {version: this.Direct, relevance: this.Map(this.Mapped, this.Direct)});
 

--- a/runtime/debug/outer-port-attachment.js
+++ b/runtime/debug/outer-port-attachment.js
@@ -57,7 +57,7 @@ export class OuterPortAttachment {
       {operation: 'toList', handle, particleId});
   }
 
-  onHandleSet({handle, data, particleId}) {
+  onHandleSet({handle, data, particleId, barrier}) {
     this._logHandleCall({operation: 'set', handle, data, particleId});
   }
 
@@ -65,7 +65,7 @@ export class OuterPortAttachment {
     this._logHandleCall({operation: 'store', handle, data, particleId});
   }
 
-  onHandleClear({handle, particleId}) {
+  onHandleClear({handle, particleId, barrier}) {
     this._logHandleCall({operation: 'clear', handle, particleId});
   }
 


### PR DESCRIPTION
Also put the barrier arg in Set/Clear in OuterPortAttachment; it isn't used but having it there documents that it wasn't just forgotten.