### PR TITLE
First step in plumbing BigCollections through to the PEC.

### DIFF
--- a/runtime/api-channel.js
+++ b/runtime/api-channel.js
@@ -261,9 +261,13 @@ export class PECOuterPort extends APIPort {
     this.registerHandler('HandleGet', {handle: this.Mapped, callback: this.Direct, particleId: this.Direct});
     this.registerHandler('HandleToList', {handle: this.Mapped, callback: this.Direct, particleId: this.Direct});
     this.registerHandler('HandleSet', {handle: this.Mapped, data: this.Direct, particleId: this.Direct, barrier: this.Direct});
+    this.registerHandler('HandleClear', {handle: this.Mapped, particleId: this.Direct, barrier: this.Direct});
     this.registerHandler('HandleStore', {handle: this.Mapped, data: this.Direct, particleId: this.Direct});
     this.registerHandler('HandleRemove', {handle: this.Mapped, data: this.Direct, particleId: this.Direct});
-    this.registerHandler('HandleClear', {handle: this.Mapped, particleId: this.Direct, barrier: this.Direct});
+    this.registerHandler('HandleStream', {handle: this.Mapped, callback: this.Direct, pageSize: this.Direct});
+    this.registerHandler('StreamCursorNext', {handle: this.Mapped, callback: this.Direct, cursorId: this.Direct});
+    this.registerHandler('StreamCursorClose', {handle: this.Mapped, cursorId: this.Direct});
+
     this.registerHandler('Idle', {version: this.Direct, relevance: this.Map(this.Mapped, this.Direct)});
 
     this.registerHandler('GetBackingStore', {callback: this.Direct, storageKey: this.Direct, type: this.ByLiteral(Type)});
@@ -274,10 +278,8 @@ export class PECOuterPort extends APIPort {
 
     this.registerHandler('ArcCreateHandle', {callback: this.Direct, arc: this.LocalMapped, type: this.ByLiteral(Type), name: this.Direct});
     this.registerInitializer('CreateHandleCallback', {callback: this.Direct, type: this.ByLiteral(Type), name: this.Direct, id: this.Direct});
-
     this.registerHandler('ArcMapHandle', {callback: this.Direct, arc: this.LocalMapped, handle: this.Mapped});
     this.registerInitializer('MapHandleCallback', {callback: this.Direct, id: this.Direct});
-
     this.registerHandler('ArcCreateSlot',
       {callback: this.Direct, arc: this.LocalMapped, transformationParticle: this.Mapped, transformationSlotName: this.Direct, hostedParticleName: this.Direct, hostedSlotName: this.Direct, handleId: this.Direct});
     this.registerInitializer('CreateSlotCallback', {callback: this.Direct, hostedSlotId: this.Direct});
@@ -313,9 +315,13 @@ export class PECInnerPort extends APIPort {
     this.registerCall('HandleGet', {handle: this.Mapped, callback: this.LocalMapped, particleId: this.Direct});
     this.registerCall('HandleToList', {handle: this.Mapped, callback: this.LocalMapped, particleId: this.Direct});
     this.registerCall('HandleSet', {handle: this.Mapped, data: this.Direct, particleId: this.Direct, barrier: this.Direct});
+    this.registerCall('HandleClear', {handle: this.Mapped, particleId: this.Direct, barrier: this.Direct});
     this.registerCall('HandleStore', {handle: this.Mapped, data: this.Direct, particleId: this.Direct});
     this.registerCall('HandleRemove', {handle: this.Mapped, data: this.Direct, particleId: this.Direct});
-    this.registerCall('HandleClear', {handle: this.Mapped, particleId: this.Direct, barrier: this.Direct});
+    this.registerCall('HandleStream', {handle: this.Mapped, callback: this.LocalMapped, pageSize: this.Direct});
+    this.registerCall('StreamCursorNext', {handle: this.Mapped, callback: this.LocalMapped, cursorId: this.Direct});
+    this.registerCall('StreamCursorClose', {handle: this.Mapped, cursorId: this.Direct});
+
     this.registerCall('Idle', {version: this.Direct, relevance: this.Map(this.Mapped, this.Direct)});
 
     this.registerCall('GetBackingStore', {callback: this.LocalMapped, storageKey: this.Direct, type: this.ByLiteral(Type)});
@@ -336,6 +342,5 @@ export class PECInnerPort extends APIPort {
     this.registerCall('ArcLoadRecipe', {arc: this.Direct, recipe: this.Direct, callback: this.LocalMapped});
 
     this.registerCall('RaiseSystemException', {exception: this.Direct, methodName: this.Direct, particleId: this.Direct});
-
   }
 }

--- a/runtime/debug/outer-port-attachment.js
+++ b/runtime/debug/outer-port-attachment.js
@@ -73,6 +73,8 @@ export class OuterPortAttachment {
     this._logHandleCall({operation: 'remove', handle, data, particleId});
   }
 
+  // TODO: add BigCollection stream APIs?
+
   _logHandleCall(args) {
     this._sendDataflowMessage(this._describeHandleCall(args), args.data);
   }

--- a/runtime/particle-execution-host.js
+++ b/runtime/particle-execution-host.js
@@ -56,6 +56,16 @@ export class ParticleExecutionHost {
     this._apiPort.onHandleStore = ({handle, data: {value, keys}, particleId}) => handle.store(value, keys, particleId);
     this._apiPort.onHandleRemove = ({handle, data: {id, keys}, particleId}) => handle.remove(id, keys, particleId);
 
+    this._apiPort.onHandleStream = async ({handle, callback, pageSize}) => {
+      this._apiPort.SimpleCallback({callback, data: await handle.stream(pageSize)});
+    };
+
+    this._apiPort.onStreamCursorNext = async ({handle, callback, cursorId}) => {
+      this._apiPort.SimpleCallback({callback, data: await handle.cursorNext(cursorId)});
+    };
+
+    this._apiPort.onStreamCursorClose = ({handle, cursorId}) => handle.cursorClose(cursorId);
+
     this._apiPort.onIdle = ({version, relevance}) => {
       if (version == this._idleVersion) {
         this._idlePromise = undefined;

--- a/runtime/ts/storage/in-memory-storage.ts
+++ b/runtime/ts/storage/in-memory-storage.ts
@@ -460,14 +460,41 @@ class InMemoryVariable extends InMemoryStorageProvider {
 }
 
 // In-memory version of the BigCollection API; primarily for testing.
+class InMemoryCursor {
+  public readonly version: number;
+  private readonly pageSize: number;
+  private data;
+
+  constructor(version, data, pageSize) {
+    this.version = version;
+    this.pageSize = pageSize;
+    const copy = [...data];
+    copy.sort((a, b) => a.index - b.index);
+    this.data = copy.map(v => v.value);
+  }
+
+  async next() {
+    if (this.data.length === 0) {
+      return {done: true};
+    }
+    return {value: this.data.splice(0, this.pageSize), done: false};
+  }
+
+  async close() {
+    this.data = [];
+  }
+}
+
 class InMemoryBigCollection extends InMemoryStorageProvider {
-  protected version: number;
   private items: Map<string, {index: number, value: {}, keys: {[index: string]: number}}>;
+  private cursors: Map<number, InMemoryCursor>;
+  private cursorIndex: number;
 
   constructor(type, storageEngine, name, id, key) {
     super(type, name, id, key);
-    this.version = 0;
     this.items = new Map();
+    this.cursors = new Map();
+    this.cursorIndex = 0;
   }
 
   backingType() {
@@ -479,7 +506,7 @@ class InMemoryBigCollection extends InMemoryStorageProvider {
     return (data !== undefined) ? data.value : null;
   }
 
-  async store(value, keys) {
+  async store(value, keys, originatorId) {
     assert(keys != null && keys.length > 0, 'keys required');
     this.version++;
 
@@ -493,29 +520,42 @@ class InMemoryBigCollection extends InMemoryStorageProvider {
     return data;
   }
 
-  async remove(id) {
+  async remove(id, keys, originatorId) {
     this.version++;
     this.items.delete(id);
   }
 
-  async stream(pageSize: number) {
+  async stream(pageSize) {
     assert(!isNaN(pageSize) && pageSize > 0);
-    let copy = [...this.items.values()];
-    copy.sort((a, b) => a.index - b.index);
-    return {
-      version: this.version,
+    this.cursorIndex++;
+    const cursor = new InMemoryCursor(this.version, this.items.values(), pageSize);
+    this.cursors.set(this.cursorIndex, cursor);
+    return this.cursorIndex;
+  }
 
-      async next() {
-        if (copy.length === 0) {
-          return {done: true};
-        }
-        return {value: copy.splice(0, pageSize).map(v => v.value), done: false};
-      },
+  async cursorNext(cursorId) {
+    const cursor = this.cursors.get(cursorId);
+    if (!cursor) {
+      return {done: true};
+    }
+    const data = await cursor.next();
+    if (data.done) {
+      this.cursors.delete(cursorId);
+    }
+    return data;
+  }
 
-      async close() {
-        copy = [];
-      }
-    };
+  async cursorClose(cursorId) {
+    const cursor = this.cursors.get(cursorId);
+    if (cursor) {
+      this.cursors.delete(cursorId);
+      await cursor.close();
+    }
+  }
+
+  cursorVersion(cursorId) {
+    const cursor = this.cursors.get(cursorId);
+    return cursor ? cursor.version : null;
   }
 
   toLiteral() {


### PR DESCRIPTION
Initiating a streamed read creates a Cursor object on the host side that is mirrored inside the PEC, but the API calls for reading the stream are mediated via the BigCollection/Handle pair and the Cursor itself is
tracked by the BigCollection instance. This is to avoid using the API channel "Thing" tracking, which never releases objects once mapped.