### PR TITLE
Fix our usage of the Firebase API.

### DIFF
--- a/runtime/handle.js
+++ b/runtime/handle.js
@@ -303,7 +303,7 @@ class Cursor {
    * Terminates the streamed read. This must be called if a cursor is no longer needed but has not
    * yet completed streaming (i.e. next() hasn't returned {done: true}).
    */
-  async close() {
+  close() {
     this._parent._proxy.cursorClose(this._cursorId);
   }
 }

--- a/runtime/manual_tests/firebase-tests.js
+++ b/runtime/manual_tests/firebase-tests.js
@@ -419,7 +419,7 @@ describe('firebase', function() {
       // close() should terminate a stream.
       let cursorId3 = await collection.stream(3);
       await checkNext(cursorId3, ['i02', 'q04', 'h05']);
-      await collection.cursorClose(cursorId3);
+      collection.cursorClose(cursorId3);
       await checkDone(cursorId3);
     }).timeout(20000);
   });

--- a/runtime/storage-proxy.js
+++ b/runtime/storage-proxy.js
@@ -567,7 +567,7 @@ class BigCollectionProxy extends StorageProxyBase {
       this._port.StreamCursorNext({handle: this, callback: resolve, cursorId}));
   }
 
-  async cursorClose(cursorId) {
+  cursorClose(cursorId) {
     this._port.StreamCursorClose({handle: this, cursorId});
   }
 }

--- a/runtime/test/in-memory-test.js
+++ b/runtime/test/in-memory-test.js
@@ -332,7 +332,7 @@ describe('in-memory', function() {
       // Verify close().
       let cursorId3 = await collection.stream(3);
       await checkNext(cursorId3, ['r01', 'i02', 'h05']);
-      await collection.cursorClose(cursorId3);
+      collection.cursorClose(cursorId3);
       await checkDone(cursorId3);
     });
   });

--- a/runtime/ts/storage/firebase-storage.ts
+++ b/runtime/ts/storage/firebase-storage.ts
@@ -200,7 +200,7 @@ export class FirebaseStorage extends StorageBase {
     assert(!type.isCollection || !type.primitiveType().isVariable);
 
     const {fbKey, reference} = this.attach(keyString);
-    let currentSnapshot = await getSnapshot(reference);
+    const currentSnapshot = await getSnapshot(reference);
     if (shouldExist !== 'unknown' && shouldExist !== currentSnapshot.exists()) {
       return null;
     }

--- a/runtime/ts/storage/firebase-storage.ts
+++ b/runtime/ts/storage/firebase-storage.ts
@@ -89,6 +89,14 @@ class FirebaseKey extends KeyBase {
   }
 }
 
+// Firebase's 'once' API does not return a Promise; wrap it so we can await the invocation of the
+// callback that returns the snapshot.
+function getSnapshot(reference) : Promise<firebase.database.DataSnapshot> {
+  return new Promise(resolve => {
+    reference.once('value', snapshot => resolve(snapshot));
+  });
+}
+
 let _nextAppNameSuffix = 0;
 
 export class FirebaseStorage extends StorageBase {
@@ -192,16 +200,12 @@ export class FirebaseStorage extends StorageBase {
     assert(!type.isCollection || !type.primitiveType().isVariable);
 
     const {fbKey, reference} = this.attach(keyString);
-    let enableReferenceMode = false;
-    let currentSnapshot: firebase.database.DataSnapshot;
-    await reference.once('value', snapshot => currentSnapshot = snapshot);
+    let currentSnapshot = await getSnapshot(reference);
     if (shouldExist !== 'unknown' && shouldExist !== currentSnapshot.exists()) {
       return null;
     }
 
-    if (currentSnapshot.exists() && currentSnapshot.val().referenceMode) {
-      enableReferenceMode = true;
-    }
+    let enableReferenceMode = currentSnapshot.exists() && currentSnapshot.val().referenceMode;
 
     if (shouldExist === false || (shouldExist === 'unknown' && currentSnapshot.exists() === false)) {
       const result = await reference.transaction(data => {
@@ -384,9 +388,7 @@ class FirebaseVariable extends FirebaseStorageProvider {
     // Resolved when data is first available. The earlier of
     // * the initial value is supplied via firebase `reference.on`
     // * a value is written to the variable by a call to `set`.
-    this.initialized = new Promise(resolve => {
-      this.resolveInitialized = resolve;
-    });
+    this.initialized = new Promise(resolve => this.resolveInitialized = resolve);
 
     this.reference.on('value', dataSnapshot => this.remoteStateChanged(dataSnapshot));
   }
@@ -1110,7 +1112,7 @@ class FirebaseCursor {
   private removed: {}[];
   private baseQuery: firebase.database.Query|null;
   private nextStart: string|null;
-  private end: string|null;
+  private end: number|null;
   private removedFn: ((removed: firebase.database.DataSnapshot) => void) | null;
 
   constructor(reference, pageSize) {
@@ -1129,29 +1131,25 @@ class FirebaseCursor {
     assert(this.state === CursorState.new);
 
     // Retrieve the current last item to establish our streaming version.
-    await this.orderByIndex.limitToLast(1).once('value', snapshot => snapshot.forEach(entry => {
-      this.end = entry.val().index;
-      // don't cancel
-      return false;
-    }));
+    const lastEntry = await getSnapshot(this.orderByIndex.limitToLast(1));
+    lastEntry.forEach(entry => this.end = entry.val().index);
 
     // Read one past the page size each time to establish the starting index for the next page.
     this.baseQuery = this.orderByIndex.endAt(this.end).limitToFirst(this.pageSize + 1);
 
     // Attach a listener for removed items and capture any that occur ahead of our streaming
     // frame. These will be returned after the cursor reaches the item at this.end.
-    this.removedFn = snapshot => {
+    this.removedFn = this.orderByIndex.on('child_removed', snapshot => {
       if (snapshot.val().index <= this.end &&
           (this.nextStart === null || snapshot.val().index >= this.nextStart)) {
         this.removed.push(snapshot.val().value);
       }
-    };
-    await this.orderByIndex.on('child_removed', this.removedFn);
+    });
     this.state = CursorState.init;
   }
 
   // Returns the BigCollection version at which this cursor is reading.
-  get version(): string {
+  get version(): number {
     return this.end;
   }
 
@@ -1176,15 +1174,16 @@ class FirebaseCursor {
     const value = [];
     if (this.state === CursorState.stream) {
       this.nextStart = null;
-      await query.once('value', snapshot => snapshot.forEach(entry => {
+      const queryResults = await getSnapshot(query);
+      queryResults.forEach(entry => {
         if (value.length < this.pageSize) {
           value.push(entry.val().value);
         } else {
           this.nextStart = entry.val().index;
         }
-      }));
+      });
       if (this.nextStart === null) {
-        await this._detach();
+        this._detach();
         this.state = CursorState.removed;
       }
     }
@@ -1203,14 +1202,14 @@ class FirebaseCursor {
 
   // Terminates the streamed read. This must be called if a cursor is no longer needed but has not
   // yet completed streaming (i.e. next() hasn't returned {done: true}).
-  async close() {
-    await this._detach();
+  close() {
+    this._detach();
     this.state = CursorState.done;
   }
 
-  async _detach() {
+  _detach() {
     if (this.removedFn) {
-      await this.orderByIndex.off('child_removed', this.removedFn);
+      this.orderByIndex.off('child_removed', this.removedFn);
       this.removedFn = null;
     }
   }
@@ -1251,12 +1250,9 @@ class FirebaseBigCollection extends FirebaseStorageProvider {
 
   // TODO: rename this to avoid clashing with Variable and allow particles some way to specify the id
   async get(id) {
-    let value;
     const encId = FirebaseStorage.encodeKey(id);
-    await this.reference.child('items/' + encId).once('value', snapshot => {
-      value = (snapshot.val() !== null) ? snapshot.val().value : null;
-    });
-    return value;
+    const snapshot = await getSnapshot(this.reference.child('items/' + encId));
+    return (snapshot.val() !== null) ? snapshot.val().value : null;
   }
 
   // originatorId is included to maintain parity with Collection.store but is not used.
@@ -1281,7 +1277,7 @@ class FirebaseBigCollection extends FirebaseStorageProvider {
     }, undefined, false);
 
     const encId = FirebaseStorage.encodeKey(value.id);
-    return this.reference.child('items/' + encId).transaction(data => {
+    await this.reference.child('items/' + encId).transaction(data => {
       if (data === null) {
         data = {value, keys: {}};
       } else {
@@ -1310,7 +1306,7 @@ class FirebaseBigCollection extends FirebaseStorageProvider {
     }, undefined, false);
 
     const encId = FirebaseStorage.encodeKey(id);
-    return this.reference.child('items/' + encId).remove();
+    await this.reference.child('items/' + encId).remove();
   }
 
   // Returns a FirebaseCursor id for paginated reads of the current version of this BigCollection.
@@ -1340,11 +1336,11 @@ class FirebaseBigCollection extends FirebaseStorageProvider {
   }
 
   // Calls close() on and discards the cursor identified by cursorId.
-  async cursorClose(cursorId) {
+  cursorClose(cursorId) {
     const cursor = this.cursors.get(cursorId);
     if (cursor) {
       this.cursors.delete(cursorId);
-      await cursor.close();
+      cursor.close();
     }
   }
 

--- a/runtime/ts/storage/in-memory-storage.ts
+++ b/runtime/ts/storage/in-memory-storage.ts
@@ -480,7 +480,7 @@ class InMemoryCursor {
     return {value: this.data.splice(0, this.pageSize), done: false};
   }
 
-  async close() {
+  close() {
     this.data = [];
   }
 }
@@ -517,7 +517,6 @@ class InMemoryBigCollection extends InMemoryStorageProvider {
     data.index = this.version;
     data.value = value;
     keys.forEach(k => data.keys[k] = this.version);
-    return data;
   }
 
   async remove(id, keys, originatorId) {
@@ -545,11 +544,11 @@ class InMemoryBigCollection extends InMemoryStorageProvider {
     return data;
   }
 
-  async cursorClose(cursorId) {
+  cursorClose(cursorId) {
     const cursor = this.cursors.get(cursorId);
     if (cursor) {
       this.cursors.delete(cursorId);
-      await cursor.close();
+      cursor.close();
     }
   }
 


### PR DESCRIPTION
Turns out we were using await incorrectly on some of the Firebase methods. 'on' and 'off' don't need to be awaited at all, and 'once' needs to be Promise-wrapped to correctly capture the callback result.

I've also removed async from the cursor close method inside the PEC (even though it is still sending a message over the API channel), since there's nothing meaningful about awaiting that.