### PR TITLE
Suggestions must be piped to AndroidWebView as JSON string

### DIFF
--- a/shell/app-shell/elements/pipes/mi-toast-pipe.js
+++ b/shell/app-shell/elements/pipes/mi-toast-pipe.js
@@ -145,7 +145,7 @@ class MiToastPipe extends Xen.Debug(Xen.Base, log) {
         // reduce plans to descriptionText
         const suggestions = piped.map(metaplan => metaplan.descriptionText);
         log('piped suggestions', suggestions);
-        MiToast.foundSuggestions(suggestions);
+        MiToast.foundSuggestions(JSON.stringify(suggestions));
       }
     }
   }


### PR DESCRIPTION
Small fix to code that sends suggestions to Android, you can't send JS arrays to Java.
