### PR TITLE
Restaurants: require location:person to match use fate

### DIFF
--- a/artifacts/Restaurants/Restaurants.recipes
+++ b/artifacts/Restaurants/Restaurants.recipes
@@ -20,8 +20,10 @@ recipe &displayRestaurants
     list <- list
 
 recipe
+  use as person
   create as location
   ExtractLocation
+    person = person
     location -> location
 
 recipe &nearbyRestaurants


### PR DESCRIPTION
... so we don't map in random people from Context, preventing "Find X near Claire", where the Claire entity is demo context (that has no location data).