### PR TITLE
Add workaround for npm installation when using an empty node_modules directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,11 @@ RUN npm install
 RUN ./tools/sigh && npm run build:rollup
 
 WORKDIR /usr/src/app/server
-RUN npm install
+
+# This odd npm syntax solves a problem installing with an empty
+# node_modules directory: See https://npm.community/t/518
+RUN npm install --no-package-lock && npm install --package-lock-only
+
 RUN npm test
 
 EXPOSE 8080


### PR DESCRIPTION
Related npm bug is discussed in https://npm.community/t/518