### PR TITLE
Shell expects descriptions to be always present on schemas

### DIFF
--- a/runtime/ts/schema.ts
+++ b/runtime/ts/schema.ts
@@ -82,7 +82,7 @@ export class Schema {
       }
     }
     const result = new Schema({names: data.names, fields});
-    result.description = data.description;
+    result.description = data.description || {};
     return result;
   }
 


### PR DESCRIPTION
Firebase strips empty descriptions. We actually started cloning properly.
Whackiness ensues!