### PR TITLE
Remove duplication in definition of ParticleRef

### DIFF
--- a/runtime/manifest-parser.peg
+++ b/runtime/manifest-parser.peg
@@ -889,14 +889,6 @@ ParticleRef
       verbs: [verb],
     };
   }
-  / verb:Verb
-  {
-    return {
-      kind: 'particle-ref',
-      location: location(),
-      verbs: [verb],
-    };
-  }
 
 HandleOrSlotRef
   = id:id tags:SpaceTagList?


### PR DESCRIPTION
ParticleRef / verb:Verb was duplicated in the manifest-parser.peg, this is just removing one of the duplicates.