### PR TITLE
Require Whitespace after ParticleArgumentDirection and Type

### DIFF
--- a/runtime/manifest-parser.peg
+++ b/runtime/manifest-parser.peg
@@ -200,8 +200,14 @@ ShapeArgumentList
   }
 
 ShapeArgument
-  = direction:(ParticleArgumentDirection)? whiteSpace? type:(ParticleArgumentType)? whiteSpace? name:(lowerIdent)?
+  = direction:(ParticleArgumentDirection whiteSpace)? type:(ParticleArgumentType whiteSpace)? name:(lowerIdent)?
   {
+    if(direction) {
+      direction = direction[0]
+    }
+    if(type) {
+      type = type[0]
+    }
     if (direction == 'host') {
       error(`Shape cannot have arguments with a 'host' direction.`);
     }
@@ -216,8 +222,14 @@ ShapeArgument
   }
 
 ShapeArgument2
-  = direction:(ParticleArgumentDirection)? whiteSpace? type:(ParticleArgumentType)? whiteSpace? name:(lowerIdent / '*') ! {return name == 'consume' || name == 'provide'}
+  = direction:(ParticleArgumentDirection whiteSpace)? type:(ParticleArgumentType whiteSpace)? name:(lowerIdent / '*') ! {return name == 'consume' || name == 'provide'}
   {
+    if(direction) {
+      direction = direction[0]
+    }
+    if(type) {
+      type = type[0]
+    }
     if (direction == 'host') {
       error(`Shape cannot have arguments with a 'host' direction.`);
     }

--- a/runtime/manifest-parser.peg
+++ b/runtime/manifest-parser.peg
@@ -448,7 +448,7 @@ SlotType
   };
 }
 
-SlotField 
+SlotField
   = name:lowerIdent whiteSpace? ':' whiteSpace? value:lowerIdent
 {
   return {
@@ -1039,7 +1039,7 @@ SchemaField
   }
 
 SchemaType
-  = SchemaReferenceType / SchemaCollectionType / SchemaPrimitiveType / SchemaUnionType / SchemaTupleType 
+  = SchemaReferenceType / SchemaCollectionType / SchemaPrimitiveType / SchemaUnionType / SchemaTupleType
 
 SchemaCollectionType = '[' whiteSpace* schema:SchemaType whiteSpace* ']'
   {


### PR DESCRIPTION
The white-space after ParticleArgumentDirection and ParticleArugmentType was previously not associated with the preceding token.

The token or the white-space could appear or not appear independently.

We now, correctly require spacing between the ParticleArgumentDirection and ParticleArgumentType.