### PR TITLE
Merge ShapeArgument and ShapeArgument2

### DIFF
--- a/runtime/manifest-parser.peg
+++ b/runtime/manifest-parser.peg
@@ -188,7 +188,7 @@ ShapeInterface
   }
 
 ShapeArgumentItem
-  = arg:ShapeArgument2 eolWhiteSpace
+  = arg:ShapeArgument eolWhiteSpace
   {
     return arg;
   }
@@ -201,28 +201,6 @@ ShapeArgumentList
 
 ShapeArgument
   = direction:(ParticleArgumentDirection whiteSpace)? type:(ParticleArgumentType whiteSpace)? name:(lowerIdent)?
-  {
-    if(direction) {
-      direction = direction[0]
-    }
-    if(type) {
-      type = type[0]
-    }
-    if (direction == 'host') {
-      error(`Shape cannot have arguments with a 'host' direction.`);
-    }
-
-    return {
-      kind: 'shape-argument',
-      location: location(),
-      direction,
-      type,
-      name,
-    };
-  }
-
-ShapeArgument2
-  = direction:(ParticleArgumentDirection whiteSpace)? type:(ParticleArgumentType whiteSpace)? name:(lowerIdent / '*') ! {return name == 'consume' || name == 'provide'}
   {
     if(direction) {
       direction = direction[0]


### PR DESCRIPTION
 The ensures that Particles cannot have handles named consume or provide and also allows the names to be '*'.

TODO: name = '*' may not be handled outside of the parser. Support may need to be added to the runtime.