### PR TITLE
Implement consumer-mode planificator

### DIFF
--- a/runtime/suggestion-composer.js
+++ b/runtime/suggestion-composer.js
@@ -51,7 +51,9 @@ export class SuggestionComposer {
 
     let sortedSuggestions = suggestions.sort((s1, s2) => s2.rank - s1.rank);
     for (let suggestion of sortedSuggestions) {
-      let suggestionContent =
+      // TODO(mmandlis): This hack is needed for deserialized suggestions to work. Should
+      // instead serialize the description object and generation suggestion content here.
+      let suggestionContent = suggestion.suggestionContent ? suggestion.suggestionContent :
         await suggestion.description.getRecipeSuggestion(this._affordance.descriptionFormatter);
       assert(suggestionContent, 'No suggestion content available');
 

--- a/runtime/suggestion-storage.js
+++ b/runtime/suggestion-storage.js
@@ -1,0 +1,96 @@
+/**
+ * @license
+ * Copyright (c) 2018 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+import {assert} from '../platform/assert-web.js';
+import {Manifest} from './manifest.js';
+import {RecipeResolver} from './recipe/recipe-resolver.js';
+import {Schema} from './ts-build/schema.js';
+import {Type} from './ts-build/type.js';
+
+export class SuggestionStorage {
+  constructor(arc, userid) {
+    assert(arc, `Arc must not be null`);
+    assert(arc._storageKey, `Arc must has a storage key`);
+    assert(userid, `User id must not be null`);
+
+    this._arc = arc;
+    let storageKeyTokens = this._arc._storageKey.split('/');
+    this._arcKey = storageKeyTokens.slice(-1)[0];
+    this._storageKey = 
+      `${storageKeyTokens.slice(0, -2).join('/')}/users/${userid}/suggestions/${this._arcKey}`;
+
+    this._recipeResolver = new RecipeResolver(this._arc);
+    this._suggestionsUpdatedCallbacks = [];
+
+    let suggestionsSchema = new Schema({
+      names: ['Suggestions'],
+      fields: {current: 'Object'}
+    });
+    this._storePromise = this._arc._storageProviderFactory._storageForKey(this.storageKey)._join(
+        `${this.userid}-suggestions`,
+        Type.newEntity(suggestionsSchema),
+        this._storageKey,
+        /* shoudExist= */ 'unknown',
+        /* referenceMode= */ false);
+    this._storePromise.then((store) => {
+        this._store = store;
+        this._store.on('change', () => this._onStoreUpdated(), this);
+      },
+      (e) => console.error(`Failed to initialize suggestion store at '${this._storageKey}' with error: ${e}`));
+  }
+
+  get storageKey() { return this._storageKey; }
+  get store() { return this._store; }
+
+  async ensureInitialized() {
+    await this._storePromise;
+    assert(this._store, `Store couldn't be initialized`);
+  }
+
+  async _onStoreUpdated() {
+    let value = (await this._store.get()) || {};
+    if (!value.current) {
+      return;
+    }
+
+    let plans = [];
+    for (let {descriptionText, recipe, hash, rank, suggestionContent} of value.current.plans) {
+      plans.push({
+        plan: await this._planFromString(recipe),
+        descriptionText,
+        recipe,
+        hash,
+        rank,
+        suggestionContent
+      });
+    }
+    console.log(`Suggestions store was updated, ${plans.length} suggestions fetched.`);
+    this._suggestionsUpdatedCallbacks.forEach(callback => callback({plans}));
+  }
+
+  registerSuggestionsUpdatedCallback(callback) {
+    this._suggestionsUpdatedCallbacks.push(callback);
+  }
+
+  async _planFromString(planString) {
+    let manifest = await Manifest.parse(
+        planString, {loader: this._arc.loader, context: this._arc._context, fileName: ''});
+    assert(manifest._recipes.length == 1);
+    let plan = manifest._recipes[0];
+    assert(plan.normalize(), `can't normalize deserialized suggestion`);
+    if (!plan.isResolved()) {
+      let resolvedPlan = await this._recipeResolver.resolve(plan);
+      assert(resolvedPlan, `can't resolve plan: ${plan.toString({showUnresolved: true})}`);
+      if (resolvedPlan) {
+        plan = resolvedPlan;
+      }
+    }
+    return plan;
+  }
+}

--- a/runtime/test/planificator-test.js
+++ b/runtime/test/planificator-test.js
@@ -93,7 +93,9 @@ class TestPlanificator extends Planificator {
 
 function createPlanificator(options) {
   let arc = new Arc({id: 'demo-test'});
-  return new TestPlanificator(arc, options);
+  let planificator = new TestPlanificator(arc, options);
+  assert.isTrue(planificator.isFull);
+  return planificator;
 }
 
 function newPlan(name, options) {
@@ -508,3 +510,5 @@ describe('Planificator', function() {
     assert.isFalse(planificator.isPlanning);
   });
 });
+
+// TODO(mmandlis): add tests for Consumer and Provider planificator modes.

--- a/shell/app-shell/elements/arc-planner.js
+++ b/shell/app-shell/elements/arc-planner.js
@@ -10,6 +10,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 import Xen from '../../components/xen/xen.js';
 import Arcs from '../lib/arcs.js';
+import ArcsUtils from '../lib/arcs-utils.js';
 
 const log = Xen.logFactory('ArcPlanner', '#104a91');
 const error = Xen.logFactory('ArcPlanner', '#104a91', 'error');
@@ -60,7 +61,8 @@ class ArcPlanner extends Xen.Debug(Xen.Base, log) {
     }
   }
   _createPlanificator(arc, userid) {
-    const planificator = new Arcs.Planificator(arc, {userid});
+    let planificatorMode = ArcsUtils.getUrlParam('planificator');
+    const planificator = new Arcs.Planificator(arc, {userid, mode: planificatorMode});
     planificator.registerPlansChangedCallback(current => this._plansChanged(current, planificator.getLastActivatedPlan()));
     planificator.registerSuggestChangedCallback(suggestions => this._suggestionsChanged(suggestions));
     return planificator;


### PR DESCRIPTION
- introduce different modes of planificator
- implement suggestion storage class (only read atm)
- fetching serialized suggestions from storage

-----------------------------
ATM i have some locally pre-made suggestions for couple arcs for my user https://firebase.corp.google.com/u/0/project/arcs-storage/database/arcs-storage/data/0_4_1-alpha/users/-LBYGLHP0fy9YKrI4C34 and loading http://localhost:8001/shell/apps/web/index.html?**arc=-LMmpn82W3EmM2pU2XnG&planificator=consumer** shows suggestions that weren't made locally but instead read from the firebase.