### PR TITLE
Allow '*' as an identifier name

### DIFF
--- a/runtime/manifest-parser.peg
+++ b/runtime/manifest-parser.peg
@@ -200,7 +200,7 @@ ShapeArgumentList
   }
 
 ShapeArgument
-  = direction:(ParticleArgumentDirection whiteSpace)? type:(ParticleArgumentType whiteSpace)? name:(lowerIdent)?
+  = direction:(ParticleArgumentDirection whiteSpace)? type:(ParticleArgumentType whiteSpace)? name:(lowerIdent / '*')
   {
     if(direction) {
       direction = direction[0]


### PR DESCRIPTION
I missed allowing '*' and removed the '?' in my most recent PR on this branch.
This CL undoes this.