### PR TITLE
Ensure lower case identifiers are not directions

### DIFF
--- a/runtime/manifest-parser.peg
+++ b/runtime/manifest-parser.peg
@@ -221,7 +221,7 @@ ShapeArgument
   }
 
 ShapeArgument2
-  = direction:(ParticleArgumentDirection whiteSpace)? type:(ParticleArgumentType whiteSpace)? name:(lowerIdent / '*') ! {return name == 'consume' || name == 'provide'}
+  = direction:(ParticleArgumentDirection whiteSpace)? type:(ParticleArgumentType whiteSpace)? name:(lowerIdent / '*')
   {
     if(direction) {
       direction = direction[0]

--- a/runtime/manifest-parser.peg
+++ b/runtime/manifest-parser.peg
@@ -211,7 +211,6 @@ ShapeArgument
     if (direction == 'host') {
       error(`Shape cannot have arguments with a 'host' direction.`);
     }
-
     return {
       kind: 'shape-argument',
       location: location(),
@@ -1112,10 +1111,14 @@ SameOrMoreIndent = &(i:" "* &{
 TopLevelIdent
   = upperIdent
 
+//TODO Add ParticleArgumentDirection (rewrite recipies to not use directions as identifiers.
+ReservedWord
+  = Direction
+
 backquotedString = '`' pattern:([^`]+) '`' { return pattern.join(''); }
 id = "'" id:[^']+ "'" {return id.join('')}
 upperIdent = ident:([A-Z][a-z0-9_]i*) {return text()}
-lowerIdent = ident:([a-z][a-z0-9_]i*) {return text()}
+lowerIdent = ident:(!(ReservedWord (whiteSpace / eolWhiteSpace))[a-z][a-z0-9_]i*) {return text()}
 whiteSpace
   = " "+
 eolWhiteSpace

--- a/runtime/manifest-parser.peg
+++ b/runtime/manifest-parser.peg
@@ -211,6 +211,7 @@ ShapeArgument
     if (direction == 'host') {
       error(`Shape cannot have arguments with a 'host' direction.`);
     }
+
     return {
       kind: 'shape-argument',
       location: location(),

--- a/runtime/test/manifest-parser-test.js
+++ b/runtime/test/manifest-parser-test.js
@@ -86,6 +86,20 @@ describe('manifest parser', function() {
         description \`my store\`
       store Store1 of Person 'some-id' @7 in 'people.json'`);
   });
+  it('fails to parse an argument list that uses reserved words', () => {
+    try {
+      parse(`
+        particle MyParticle
+          in MyThing consume
+          in MyThing? provide
+          out [MyThing] in
+          out BigCollection<MyThing>? out`);
+      assert.fail('this parse should have failed, identifiers should not be reserved words!');
+    } catch (e) {
+      assert.include(e.message, 'Expected',
+          `bad error: '${e}'`);
+    }
+  });
   it('fails to parse a nonsense argument list', () => {
     try {
       parse(`


### PR DESCRIPTION
Parse lower case identifiers only if they do not match reserved words (this makes parsing slot and handle descriptions simpler).

Also adds a test to ensure that identifiers such as 'consume' are rejected.

It would be good to clear up the error message for this as, currently, it is just a parser error, rather than a more informative reserved word error.