### PR TITLE
Split test that identifiers are not keywords into a test per keyword

### DIFF
--- a/runtime/test/manifest-parser-test.js
+++ b/runtime/test/manifest-parser-test.js
@@ -86,13 +86,23 @@ describe('manifest parser', function() {
         description \`my store\`
       store Store1 of Person 'some-id' @7 in 'people.json'`);
   });
-  it('fails to parse an argument list that uses reserved words', () => {
+  it('fails to parse an argument list that use reserved word \'consume\' as an identifier', () => {
     try {
       parse(`
         particle MyParticle
           in MyThing consume
-          in MyThing? provide
-          out [MyThing] in
+          out BigCollection<MyThing>? out`);
+      assert.fail('this parse should have failed, identifiers should not be reserved words!');
+    } catch (e) {
+      assert.include(e.message, 'Expected',
+          `bad error: '${e}'`);
+    }
+  });
+  it('fails to parse an argument list that use reserved word \'provide\' as an identifier', () => {
+    try {
+      parse(`
+        particle MyParticle
+          in MyThing provide
           out BigCollection<MyThing>? out`);
       assert.fail('this parse should have failed, identifiers should not be reserved words!');
     } catch (e) {


### PR DESCRIPTION
This test was previously a single test which did not actually ensure that both 'consume' and 'provide' were being checked.

Splitting this test lets us check each individually.