### PR TITLE
Decentralized planificator fixes

### DIFF
--- a/runtime/arc.js
+++ b/runtime/arc.js
@@ -401,6 +401,9 @@ ${this.activeRecipe.toString()}`;
     }
     let {handles, particles, slots} = recipe.mergeInto(currentArc.activeRecipe);
     currentArc.recipes.push({particles, handles, slots, innerArcs: new Map(), patterns: recipe.patterns});
+
+    // TODO(mmandlis): Get rid of populating the missing local slot IDs here,
+    // it should be done at planning stage.
     slots.forEach(slot => slot.id = slot.id || `slotid-${this.generateID()}`);
 
     for (let recipeHandle of handles) {
@@ -425,7 +428,8 @@ ${this.activeRecipe.toString()}`;
           await newStore.set(particleClone);
         } else if (recipeHandle.fate === 'copy') {
           let copiedStore = this.findStoreById(recipeHandle.id);
-          assert(copiedStore.version !== null);
+          assert(copiedStore, `Cannot find store ${recipeHandle.id}`);
+          assert(copiedStore.version !== null, `Copied store ${recipeHandle.id} doesn't have version.`);
           await newStore.cloneFrom(copiedStore);
           this._tagStore(newStore, this.findStoreTags(copiedStore));
           let copiedStoreDesc = this.getStoreDescription(copiedStore);

--- a/runtime/description.js
+++ b/runtime/description.js
@@ -163,7 +163,7 @@ export class DescriptionFormatter {
   }
 
   _populateParticleDescription(particle, descriptionByName) {
-    let pattern = descriptionByName['_pattern_'] || particle.spec.pattern;
+    let pattern = descriptionByName['pattern'] || particle.spec.pattern;
     return pattern ? {pattern} : {};
   }
 

--- a/runtime/manifest-parser.peg
+++ b/runtime/manifest-parser.peg
@@ -577,8 +577,8 @@ Description
     let patterns = [];
     if (pattern) {
       patterns.push(pattern);
-      handleDescriptions.filter(desc => desc.name == '_pattern_').forEach(pattern => patterns.push(pattern));
-      handleDescriptions = handleDescriptions.filter(desc => desc.name != '_pattern_');
+      handleDescriptions.filter(desc => desc.name == 'pattern').forEach(pattern => patterns.push(pattern));
+      handleDescriptions = handleDescriptions.filter(desc => desc.name != 'pattern');
     }
     return {
       kind: 'description',

--- a/runtime/manifest.js
+++ b/runtime/manifest.js
@@ -770,7 +770,23 @@ ${e.message}
           let providedSlot = slotConn.providedSlots[ps.param];
           if (providedSlot) {
             if (ps.name) {
-              items.byName.set(ps.name, providedSlot);
+              if (items.byName.has(ps.name)) {
+                // The slot was added to the recipe twice - once as part of the
+                // slots in the manifest, then as part of particle spec.
+                // Unifying both slots, updating name and source slot connection.
+                let theSlot = items.byName.get(ps.name);
+                assert(theSlot !== providedSlot);
+                assert(!theSlot.name && providedSlot);
+                assert(!theSlot.sourceConnection && providedSlot.sourceConnection);
+                assert(theSlot.handleConnections.length == 0);
+                theSlot.name = providedSlot.name;
+                theSlot.sourceConnection = providedSlot.sourceConnection;
+                theSlot.sourceConnection.providedSlots[theSlot.name] = theSlot;
+                theSlot._handleConnections = providedSlot.handleConnections.slice();
+                theSlot.recipe.removeSlot(providedSlot);
+              } else {
+                items.byName.set(ps.name, providedSlot);
+              }
             }
             items.bySlot.set(providedSlot, ps);
           } else {

--- a/runtime/particle.js
+++ b/runtime/particle.js
@@ -141,7 +141,7 @@ export class Particle {
   }
 
   setParticleDescription(pattern) {
-    return this.setDescriptionPattern('_pattern_', pattern);
+    return this.setDescriptionPattern('pattern', pattern);
   }
   setDescriptionPattern(connectionName, pattern) {
     let descriptions = this.handles.get('descriptions');

--- a/runtime/recipe/recipe.js
+++ b/runtime/recipe/recipe.js
@@ -507,7 +507,7 @@ export class Recipe {
     if (this.patterns.length > 0 || this.handles.find(h => h.pattern)) {
       result.push(`  description \`${this.patterns[0]}\``);
       for (let i = 1; i < this.patterns.length; ++i) {
-        result.push(`    _pattern_ \`${this.patterns[i]}\``);
+        result.push(`    pattern \`${this.patterns[i]}\``);
       }
       this.handles.forEach(h => {
         if (h.pattern) {

--- a/runtime/test/description-test.js
+++ b/runtime/test/description-test.js
@@ -305,7 +305,6 @@ particle A
 recipe
   create as fooHandle   // Foo
   slot 'r0' as slot0
-  slot 'action::slot' as slot1
   X1
     ofoo -> fooHandle
     consume action as slot1
@@ -410,7 +409,6 @@ recipe
   create as foosHandle    // [Foo]
   create as fooHandle2    // Foo
   slot 'r0' as slot0
-  slot 'action::slot' as slot1
   B
     ofoo -> fooHandle1
     consume action as slot1
@@ -773,12 +771,12 @@ recipe
       await test.verifySuggestion('Hello world.', description);
 
       // Particle (dynamic) description handle (override static description).
-      await descriptionHandle.store(new Description({key: '_pattern_', value: 'Return my foo'}));
+      await descriptionHandle.store(new Description({key: 'pattern', value: 'Return my foo'}));
       await test.verifySuggestion('Return my foo.', description);
 
       // Particle description handle with handle connections.
-      await descriptionHandle.store(new Description({key: '_pattern_', value: 'Return my temporary foo'}));
-      await descriptionHandle.store(new Description({key: '_pattern_', value: 'Return my ${ofoo}'}));
+      await descriptionHandle.store(new Description({key: 'pattern', value: 'Return my temporary foo'}));
+      await descriptionHandle.store(new Description({key: 'pattern', value: 'Return my ${ofoo}'}));
       let ofooDesc = new Description({key: 'ofoo', value: 'best-foo'});
       await descriptionHandle.store(ofooDesc);
       await test.verifySuggestion('Return my best-foo.', description);
@@ -810,7 +808,7 @@ recipe
       await test.verifySuggestion('Here it is: hello world.', description);
 
       // Particle (dynamic) description handle (override static description).
-      await descriptionHandle.store(new Description({key: '_pattern_', value: 'dynamic B description'}));
+      await descriptionHandle.store(new Description({key: 'pattern', value: 'dynamic B description'}));
       await test.verifySuggestion('Here it is: dynamic B description.', description);
     });
   });
@@ -818,7 +816,7 @@ recipe
   tests.forEach((test) => {
     it('particle dynamic dom description ' + test.name, async () => {
       let {recipe, description, fooStore, Description, descriptionHandle} = await prepareRecipeAndArc();
-      await descriptionHandle.store(new Description({key: '_pattern_', value: 'return my ${ofoo} (text)'}));
+      await descriptionHandle.store(new Description({key: 'pattern', value: 'return my ${ofoo} (text)'}));
       await descriptionHandle.store(new Description({key: '_template_', value: 'Return my <span>{{ofoo}}</span> (dom)'}));
       await descriptionHandle.store(new Description({key: '_model_', value: JSON.stringify({'ofoo': '${ofoo}'})}));
       await test.verifySuggestion(`Return my foo (${test.name}).`, description);

--- a/runtime/test/manifest-test.js
+++ b/runtime/test/manifest-test.js
@@ -796,6 +796,25 @@ ${particleStr1}
     assert.lengthOf(slotB.consumeConnections, 1);
     assert.equal(slotB.sourceConnection, slotConnA);
   });
+  it('parses local slots with IDs', async () => {
+    let recipe = (await Manifest.parse(`
+      particle P1 in 'some-particle.js'
+        consume slotA
+          provide slotB
+      particle P2 in 'some-particle.js'
+        consume slotB
+      recipe
+        slot 'rootslot-0' as slot0
+        slot 'local-slot-0' as slot1
+        P1
+          consume slotA as slot0
+            provide slotB as slot1
+        P2
+          consume slotB as slot1
+    `)).recipes[0];
+    recipe.normalize();
+    assert.lengthOf(recipe.slots, 2);
+  });
   it('relies on the loader to combine paths', async () => {
     let registry = {};
     let loader = {


### PR DESCRIPTION
- Hosted particle specs correctly de/serialized
- IDs for local slots generated during planning and correctly parsed in manifest
- Fix serialization of multiple description patterns (introduced in #1857)