### PR TITLE
Avoid repopulating SYSTEM_users

### DIFF
--- a/shell/app-shell/elements/sharing/single-user-context.js
+++ b/shell/app-shell/elements/sharing/single-user-context.js
@@ -48,11 +48,11 @@ const SingleUserContext = class {
     this.handles = {};
     this.field = new Field(null, `/users/${userid}`, userid, this._userSchema).activate();
   }
-  dispose() {
+  async dispose() {
     // chuck all observers
     Object.values(this.observers).forEach(({key}) => this._unobserve(key));
     // chuck all data
-    this._removeUserEntities(this.context, this.userid, this.isProfile);
+    await this._removeUserEntities(this.context, this.userid, this.isProfile);
   }
   get _userSchema() {
     return {
@@ -276,7 +276,10 @@ const SingleUserContext = class {
     log(`removing entities for [${userid}]`);
     const jobs = [];
     for (let i=0, store; (store=context.stores[i]); i++) {
-      jobs.push(this._removeUserStoreEntities(userid, store, isProfile));
+      // SYSTEM_users persists across users
+      if (store.id !== 'SYSTEM_users') {
+        jobs.push(this._removeUserStoreEntities(userid, store, isProfile));
+      }
     }
     await Promise.all(jobs);
   }

--- a/shell/app-shell/elements/sharing/user-context.js
+++ b/shell/app-shell/elements/sharing/user-context.js
@@ -43,21 +43,14 @@ customElements.define('user-context', class extends Xen.Debug(Xen.Base, log) {
       // once.
       this._updateSystemUsers(users, usersStore);
     }
-    if (context && user && userid !== state.userid) {
+    if (context && user && userStore && userid !== state.userid) {
       state.userid = userid;
-      if (userContext) {
-        userContext.dispose();
-        state.userContext = null;
-      }
-      if (userid) {
-        state.userContext = new SingleUserContext(context, userid, true);
-      }
-      this._updateSystemUser(user, userid, coords, userStore);
+      this._updateSystemUser(context, userid, coords, state);
     }
-    if (user && coords && coords !== user.rawData.location) {
-      log('updating user coords:', user);
+    if (user && userStore && coords && coords !== user.rawData.location) {
       user.rawData.location = coords;
-      //userStore.set({user});
+      log('updating user coords:', user);
+      userStore.set({user});
     }
   }
   async _requireStores(context) {
@@ -163,11 +156,24 @@ customElements.define('user-context', class extends Xen.Debug(Xen.Base, log) {
       }
     }, ['users-stores-keys']));
   }
-  _updateSystemUser(user, userid, coords, userStore) {
-    user.rawData.id = userid;
-    user.rawData.location = coords;
-    log(user);
-    userStore.set(user);
+  async _updateSystemUser(context, userid, coords, state) {
+    const {user, userStore, userContext} = state;
+    if (userContext) {
+      await userContext.dispose();
+      state.userContext = null;
+    }
+    // if the `userid` has changed before we finished cleaning up, re-validate
+    if (state.userid !== userid) {
+      this._invalidate();
+    } else {
+      if (userid) {
+        state.userContext = new SingleUserContext(context, userid, true);
+      }
+      user.rawData.id = userid;
+      user.rawData.location = coords;
+      log('updating user', user);
+      userStore.set(user);
+    }
   }
   _onFriendChange(context, info) {
     const {friends, friendEntityIds} = this._state;

--- a/shell/app-shell/elements/sharing/user-context.js
+++ b/shell/app-shell/elements/sharing/user-context.js
@@ -38,6 +38,9 @@ customElements.define('user-context', class extends Xen.Debug(Xen.Base, log) {
     }
     if (users && usersStore && state.users !== users) {
       state.users = users;
+      // TODO(sjmiles): clear usersStore first, or modify _updateSystemStores to avoid
+      // duplication ... as of now this never happens since `users` is only generated
+      // once.
       this._updateSystemUsers(users, usersStore);
     }
     if (context && user && userid !== state.userid) {

--- a/shell/app-shell/elements/sharing/user-context.js
+++ b/shell/app-shell/elements/sharing/user-context.js
@@ -36,7 +36,8 @@ customElements.define('user-context', class extends Xen.Debug(Xen.Base, log) {
       state.initStores = true;
       this._requireStores(context);
     }
-    if (users && usersStore) {
+    if (users && usersStore && state.users !== users) {
+      state.users = users;
       this._updateSystemUsers(users, usersStore);
     }
     if (context && user && userid !== state.userid) {
@@ -150,6 +151,7 @@ customElements.define('user-context', class extends Xen.Debug(Xen.Base, log) {
     return store;
   }
   _updateSystemUsers(users, usersStore) {
+    log('updateSystemUsers');
     Object.values(users).forEach(user => usersStore.store({
       id: usersStore.generateID(),
       rawData: {


### PR DESCRIPTION
Prevent `user-context` from calling _updateSystemUser is `users` is unchanged.