### PR TITLE
Ensure that the 'originalId' (generated when a handle is copied) is maintained through (de)serialization.

### DIFF
--- a/runtime/arc.js
+++ b/runtime/arc.js
@@ -139,9 +139,16 @@ export class Arc {
     let tags = this._storeTags.get(handle) || [];
     let handleTags = [...tags].map(a => `#${a}`).join(' ');
 
+    const actualHandle = this.activeRecipe.findHandle(handle.id);
+    const originalId = actualHandle ? actualHandle.originalId : null;
+    let combinedId = `'${handle.id}'`;
+    if (originalId) {
+      combinedId += `!!'${originalId}'`;
+    }
+
     switch (key.protocol) {
       case 'firebase':
-        context.handles += `store ${id} of ${handle.type.toString()} '${handle.id}' @${handle.version === null ? 0 : handle.version} ${handleTags} at '${handle.storageKey}'\n`;
+        context.handles += `store ${id} of ${handle.type.toString()} ${combinedId} @${handle.version === null ? 0 : handle.version} ${handleTags} at '${handle.storageKey}'\n`;
         break;
       case 'in-memory': {
         // TODO(sjmiles): emit empty data for stores marked `nosync`: shell will supply data
@@ -190,7 +197,7 @@ export class Arc {
         let data = JSON.stringify(serializedData);
         context.resources += data.split('\n').map(line => indent + line).join('\n');
         context.resources += '\n';
-        context.handles += `store ${id} of ${handle.type.toString()} '${handle.id}' @${handle.version || 0} ${handleTags} in ${id}Resource\n`;
+        context.handles += `store ${id} of ${handle.type.toString()} ${combinedId} @${handle.version || 0} ${handleTags} in ${id}Resource\n`;
         break;
       }
     }

--- a/runtime/manifest-parser.peg
+++ b/runtime/manifest-parser.peg
@@ -99,7 +99,7 @@ ResourceLine = [^\n]* eol { return text(); }
 
 // TODO: Entity syntax.
 ManifestStorage
-  = 'store' whiteSpace name:TopLevelIdent whiteSpace 'of' whiteSpace type:ManifestStorageType id:(whiteSpace id)?
+  = 'store' whiteSpace name:TopLevelIdent whiteSpace 'of' whiteSpace type:ManifestStorageType id:(whiteSpace id)? originalId:('!!' id)?
     version:(whiteSpace Version)? tags:(whiteSpace TagList)? whiteSpace source:ManifestStorageSource eolWhiteSpace
     items:(Indent (SameIndent ManifestStorageItem)+)?
   {
@@ -110,6 +110,7 @@ ManifestStorage
       name,
       type,
       id: optional(id, id => id[1], null),
+      originalId: optional(originalId, originalId => originalId[1], null),
       version: optional(version, version => version[1], null),
       tags: optional(tags, tags => tags[1], null),
       source: source.source,

--- a/runtime/manifest.js
+++ b/runtime/manifest.js
@@ -32,16 +32,19 @@ class ManifestError extends Error {
 }
 
 class StorageStub {
-  constructor(type, id, name, storageKey, storageProviderFactory) {
+  constructor(type, id, name, storageKey, storageProviderFactory, originalId) {
     this.type = type;
     this.id = id;
+    this.originalId = originalId;
     this.name = name;
     this.storageKey = storageKey;
     this.storageProviderFactory = storageProviderFactory;
   }
 
-  inflate() {
-    return this.storageProviderFactory.connect(this.id, this.type, this.storageKey);
+  async inflate() {
+    let store = await this.storageProviderFactory.connect(this.id, this.type, this.storageKey);
+    store.originalId = this.originalId;
+    return store;
   }
 }
 
@@ -172,8 +175,8 @@ export class Manifest {
     return store;
   }
 
-  newStorageStub(type, name, id, storageKey, tags) {
-    return this._addStore(new StorageStub(type, id, name, storageKey, this.storageProviderFactory), tags);
+  newStorageStub(type, name, id, storageKey, tags, originalId) {
+    return this._addStore(new StorageStub(type, id, name, storageKey, this.storageProviderFactory, originalId), tags);
   }
 
   _find(manifestFinder) {
@@ -988,6 +991,7 @@ ${e.message}
   static async _processStore(manifest, item, loader) {
     let name = item.name;
     let id = item.id;
+    const originalId = item.originalId;
     let type = item.type.model;
     if (id == null) {
       id = `${manifest._id}store${manifest._stores.length}`;
@@ -1001,7 +1005,7 @@ ${e.message}
     // Instead of creating links to remote firebase during manifest parsing,
     // we generate storage stubs that contain the relevant information.
     if (item.origin == 'storage') {
-      manifest.newStorageStub(type, name, id, item.source, tags);
+      manifest.newStorageStub(type, name, id, item.source, tags, originalId);
       return;
     }
 
@@ -1033,7 +1037,7 @@ ${e.message}
       unitType = type.bigCollectionType;
     } else {
       if (entities.length == 0) {
-        await Manifest._createStore(manifest, type, name, id, tags, item);
+        await Manifest._createStore(manifest, type, name, id, tags, item, originalId);
         return;
       }
       entities = entities.slice(entities.length - 1);
@@ -1063,7 +1067,7 @@ ${e.message}
     }
 
     let version = item.version || 0;
-    let store = await Manifest._createStore(manifest, type, name, id, tags, item);
+    let store = await Manifest._createStore(manifest, type, name, id, tags, item, originalId);
 
     // While the referenceMode hack exists, we need to look at the entities being stored to
     // determine whether this store should be in referenceMode or not.
@@ -1094,10 +1098,11 @@ ${e.message}
     }
     store.fromLiteral({version, model});
   }
-  static async _createStore(manifest, type, name, id, tags, item) {
+  static async _createStore(manifest, type, name, id, tags, item, originalId) {
     let store = await manifest.createStore(type, name, id, tags);
     store.source = item.source;
     store.description = item.description;
+    store.originalId = originalId;
     return store;
   }
   _newRecipe(name) {

--- a/runtime/recipe/handle.js
+++ b/runtime/recipe/handle.js
@@ -123,6 +123,7 @@ export class Handle {
   }
   mapToStorage(storage) {
     this._id = storage.id;
+    this._originalId = storage.originalId;
     this._type = undefined;
     assert(storage.type == undefined || !(storage.type.hasVariableReference), `variable references shouldn't be part of handle types`);
     this._mappedType = storage.type;


### PR DESCRIPTION
This fixes #1942 