### PR TITLE
Allows async processing in the speculative execution

### DIFF
--- a/artifacts/Music/Music.recipes
+++ b/artifacts/Music/Music.recipes
@@ -66,6 +66,7 @@ particle FindShows in 'source/FindShows.js'
   in Artist artist
   in GeoCoordinates location
   inout [Show] shows
+  out [Description] descriptions
   consume nearbyShows
     provide listing
       handle shows

--- a/runtime/particle-execution-context.js
+++ b/runtime/particle-execution-context.js
@@ -264,6 +264,9 @@ export class ParticleExecutionContext {
     if (this._pendingLoads.length > 0 || this._scheduler.busy) {
       return true;
     }
+    if (this._particles.filter(particle => particle.busy).length > 0) {
+      return true;
+    }
     return false;
   }
 
@@ -271,6 +274,7 @@ export class ParticleExecutionContext {
     if (!this.busy) {
       return Promise.resolve();
     }
-    return Promise.all([this._scheduler.idle, ...this._pendingLoads]).then(() => this.idle);
+    let busyParticlePromises = this._particles.filter(particle => particle.busy).map(particle => particle.idle);
+    return Promise.all([this._scheduler.idle, ...this._pendingLoads, ...busyParticlePromises]).then(() => this.idle);
   }
 }

--- a/runtime/particle.js
+++ b/runtime/particle.js
@@ -104,6 +104,20 @@ export class Particle {
     this.relevances.push(r);
   }
 
+  startBusy() {
+    if (this._busy == 0) {
+      this._idle = new Promise(resolve => this._idleResolver = resolve);
+    }
+    this._busy++;
+  }
+  
+   doneBusy() {
+    this._busy--;
+    if (this._busy == 0) {
+      this._idleResolver();
+    }
+  }
+
   inputs() {
     return this.spec.inputs;
   }


### PR DESCRIPTION
I quick way to get async processing in the speculative execution. Primarily for meaningful suggestion text.

No tests to get this in for M1 - tests should follow, but first we need to get this done more properly. Current iteration is flaky unless you put this.startBusy() in the constructor.

Sorry for combining runtime changes with the demo changes, but at least in the absence of tests we get an example of how to use this.

This is for #1958.