### PR TITLE
Move the protocol field to the base class.

### DIFF
--- a/runtime/ts/storage/firebase-storage.ts
+++ b/runtime/ts/storage/firebase-storage.ts
@@ -44,7 +44,6 @@ export async function resetStorageForTesting(key) {
 }
 
 class FirebaseKey extends KeyBase {
-  private protocol: string;
   databaseUrl?: string;
   projectId?: string;
   apiKey?: string;

--- a/runtime/ts/storage/in-memory-storage.ts
+++ b/runtime/ts/storage/in-memory-storage.ts
@@ -21,7 +21,6 @@ export function resetInMemoryStorageForTesting() {
 }
 
 class InMemoryKey extends KeyBase {
-  protocol: string;
   arcId: string;
   location: string;
   constructor(key: string) {

--- a/runtime/ts/storage/key-base.ts
+++ b/runtime/ts/storage/key-base.ts
@@ -7,6 +7,7 @@
 // http://polymer.github.io/PATENTS.txt
 
 export abstract class KeyBase {
+  protocol: string;
   abstract childKeyForHandle(id): KeyBase;
   abstract toString(): string;
 }


### PR DESCRIPTION
The value is directly accessed in arc.js in _serializeHandle.
