### PR TITLE
PouchDb support for Arcs Storage

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,5 @@
 {
+  bracketSpacing: false,
   singleQuote: true,
   printWidth: 144
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -261,10 +261,60 @@
         "@types/node": "*"
       }
     },
+    "@types/fs-extra": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.0.4.tgz",
+      "integrity": "sha512-DsknoBvD8s+RFfSGjmERJ7ZOP1HI0UZRA3FSI+Zakhrc/Gy26YQsLI+m5V5DHxroHRJqCDLKJp7Hixn8zyaF7g==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/glob": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.0.tgz",
+      "integrity": "sha512-k1M3Y8Ge0bOkG7U5IZObIhkrzZHMpuFpd5RJK9Gh8ekq0EhiezLLqv2ow14ylTKqXTHSqM6AMySbWEHRo+7qdQ==",
+      "dev": true,
+      "requires": {
+        "@types/events": "*",
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/handlebars": {
+      "version": "4.0.39",
+      "resolved": "https://registry.npmjs.org/@types/handlebars/-/handlebars-4.0.39.tgz",
+      "integrity": "sha512-vjaS7Q0dVqFp85QhyPSZqDKnTTCemcSHNHFvDdalO1s0Ifz5KuE64jQD5xoUkfdWwF4WpqdJEl7LsWH8rzhKJA==",
+      "dev": true
+    },
+    "@types/highlight.js": {
+      "version": "9.12.3",
+      "resolved": "https://registry.npmjs.org/@types/highlight.js/-/highlight.js-9.12.3.tgz",
+      "integrity": "sha512-pGF/zvYOACZ/gLGWdQH8zSwteQS1epp68yRcVLJMgUck/MjEn/FBYmPub9pXT8C1e4a8YZfHo1CKyV8q1vKUnQ==",
+      "dev": true
+    },
     "@types/js-yaml": {
       "version": "3.11.2",
       "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-3.11.2.tgz",
       "integrity": "sha512-JRDtMPEqXrzfuYAdqbxLot1GvAr/QvicIZAnOAigZaj8xVMhuSJTg/xsv9E1TvyL+wujYhRLx9ZsQ0oFOSmwyA=="
+    },
+    "@types/lodash": {
+      "version": "4.14.116",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.116.tgz",
+      "integrity": "sha512-lRnAtKnxMXcYYXqOiotTmJd74uawNWuPnsnPrrO7HiFuE3npE2iQhfABatbYDyxTNqZNuXzcKGhw37R7RjBFLg==",
+      "dev": true
+    },
+    "@types/marked": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-0.4.1.tgz",
+      "integrity": "sha512-ZqEGxppVG1x9QK/hkHxzmf6m4xcnk9CaHjNCqwvUeN3pMdCcQkPxmvrbLZ5GbP7K25TgiT1nKIGnz0U3M+G05Q==",
+      "dev": true
+    },
+    "@types/minimatch": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
+      "dev": true
     },
     "@types/mkdirp": {
       "version": "0.3.29",
@@ -453,6 +503,16 @@
       "resolved": "https://registry.npmjs.org/@types/rimraf/-/rimraf-0.0.28.tgz",
       "integrity": "sha1-VWJRm8eWPKyoq/fxKMrjtZTUHQY=",
       "dev": true
+    },
+    "@types/shelljs": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@types/shelljs/-/shelljs-0.8.0.tgz",
+      "integrity": "sha512-vs1hCC8RxLHRu2bwumNyYRNrU3o8BtZhLysH5A4I98iYmA2APl6R3uNQb5ihl+WiwH0xdC9LLO+vRrXLs/Kyxg==",
+      "dev": true,
+      "requires": {
+        "@types/glob": "*",
+        "@types/node": "*"
+      }
     },
     "@types/tough-cookie": {
       "version": "2.3.3",
@@ -930,7 +990,7 @@
     "arr-flatten": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
       "dev": true
     },
     "arr-union": {
@@ -1115,7 +1175,7 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -1353,13 +1413,13 @@
     },
     "babel-plugin-syntax-async-functions": {
       "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
       "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
       "dev": true
     },
     "babel-plugin-syntax-exponentiation-operator": {
       "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
       "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
       "dev": true
     },
@@ -1888,7 +1948,7 @@
     "big.js": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
-      "integrity": "sha1-pfwpi4G54Nyi5FiCR4S2XFK6WI4=",
+      "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
       "dev": true
     },
     "binary-extensions": {
@@ -1918,7 +1978,7 @@
     "bn.js": {
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-      "integrity": "sha1-LN4J617jQfSEdGuwMJsyU7GxRC8=",
+      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
       "dev": true
     },
     "bootstrap": {
@@ -1985,7 +2045,7 @@
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "dev": true,
       "requires": {
@@ -2030,7 +2090,7 @@
     },
     "browserify-rsa": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
@@ -2056,7 +2116,7 @@
     "browserify-zlib": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
-      "integrity": "sha1-KGlFnZqjviRf6P4sofRuLn9U1z8=",
+      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
       "dev": true,
       "requires": {
         "pako": "~1.0.5"
@@ -2522,7 +2582,7 @@
     "cipher-base": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-      "integrity": "sha1-h2Dk7MJy9MNjUy+SbYdKriwTl94=",
+      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
       "dev": true,
       "requires": {
         "inherits": "^2.0.1",
@@ -2845,7 +2905,7 @@
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "dev": true,
       "requires": {
@@ -2858,7 +2918,7 @@
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "dev": true,
       "requires": {
@@ -2904,7 +2964,7 @@
     "crypto-browserify": {
       "version": "3.12.0",
       "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
-      "integrity": "sha1-OWz58xN/A+S45TLFj2mCVOAPgOw=",
+      "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
       "dev": true,
       "requires": {
         "browserify-cipher": "^1.0.0",
@@ -3223,7 +3283,7 @@
     },
     "diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "dev": true,
       "requires": {
@@ -3259,7 +3319,7 @@
     },
     "duplexer": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
       "dev": true
     },
@@ -3761,7 +3821,7 @@
     },
     "event-stream": {
       "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
       "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
       "dev": true,
       "requires": {
@@ -3789,7 +3849,7 @@
     "evp_bytestokey": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
-      "integrity": "sha1-f8vbGY3HGVlDLv4ThCaE4FJaywI=",
+      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
       "dev": true,
       "requires": {
         "md5.js": "^1.3.4",
@@ -4883,8 +4943,7 @@
     "functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
-      "dev": true
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
     },
     "gauge": {
       "version": "2.7.4",
@@ -5101,22 +5160,22 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+          "resolved": false,
           "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "resolved": false,
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "aproba": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+          "resolved": false,
           "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
         },
         "are-we-there-yet": {
           "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+          "resolved": false,
           "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
           "requires": {
             "delegates": "^1.0.0",
@@ -5125,12 +5184,12 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+          "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "requires": {
             "balanced-match": "^1.0.0",
@@ -5139,32 +5198,32 @@
         },
         "chownr": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE="
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "resolved": false,
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+          "resolved": false,
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
         },
         "core-util-is": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "resolved": false,
           "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
         },
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "resolved": false,
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "requires": {
             "ms": "2.0.0"
@@ -5172,22 +5231,22 @@
         },
         "deep-extend": {
           "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+          "resolved": false,
           "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
         },
         "delegates": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
         },
         "detect-libc": {
           "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+          "resolved": false,
           "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+          "resolved": false,
           "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "requires": {
             "minipass": "^2.2.1"
@@ -5195,12 +5254,12 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
         },
         "gauge": {
           "version": "2.7.4",
-          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+          "resolved": false,
           "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "requires": {
             "aproba": "^1.0.3",
@@ -5215,7 +5274,7 @@
         },
         "glob": {
           "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "resolved": false,
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -5228,12 +5287,12 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
         },
         "iconv-lite": {
           "version": "0.4.23",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+          "resolved": false,
           "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3"
@@ -5241,7 +5300,7 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
+          "resolved": false,
           "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "requires": {
             "minimatch": "^3.0.4"
@@ -5249,7 +5308,7 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "resolved": false,
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "requires": {
             "once": "^1.3.0",
@@ -5258,17 +5317,17 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "resolved": false,
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
         "ini": {
           "version": "1.3.5",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+          "resolved": false,
           "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "requires": {
             "number-is-nan": "^1.0.0"
@@ -5276,7 +5335,7 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
         "lodash": {
@@ -5286,7 +5345,7 @@
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "requires": {
             "brace-expansion": "^1.1.7"
@@ -5294,12 +5353,12 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": false,
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         },
         "minipass": {
           "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.3.tgz",
+          "resolved": false,
           "integrity": "sha512-/jAn9/tEX4gnpyRATxgHEOV6xbcyxgT7iUnxo9Y3+OB0zX00TgKIv/2FZCf5brBbICcwbLqVv2ImjvWWrQMSYw==",
           "requires": {
             "safe-buffer": "^5.1.2",
@@ -5308,7 +5367,7 @@
         },
         "minizlib": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
+          "resolved": false,
           "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
           "requires": {
             "minipass": "^2.2.1"
@@ -5316,7 +5375,7 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "resolved": false,
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "requires": {
             "minimist": "0.0.8"
@@ -5324,19 +5383,19 @@
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "resolved": false,
               "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
             }
           }
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         },
         "needle": {
           "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.1.tgz",
+          "resolved": false,
           "integrity": "sha512-t/ZswCM9JTWjAdXS9VpvqhI2Ct2sL2MdY4fUXqGJaGBk13ge99ObqRksRTbBE56K+wxUXwwfZYOuZHifFW9q+Q==",
           "requires": {
             "debug": "^2.1.2",
@@ -5346,7 +5405,7 @@
         },
         "node-pre-gyp": {
           "version": "0.10.3",
-          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.10.3.tgz",
+          "resolved": false,
           "integrity": "sha512-d1xFs+C/IPS8Id0qPTZ4bUT8wWryfR/OzzAFxweG+uLN85oPzyo2Iw6bVlLQ/JOdgNonXLCoRyqDzDWq4iw72A==",
           "requires": {
             "detect-libc": "^1.0.2",
@@ -5363,7 +5422,7 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "requires": {
             "abbrev": "1",
@@ -5372,12 +5431,12 @@
         },
         "npm-bundled": {
           "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.3.tgz",
+          "resolved": false,
           "integrity": "sha512-ByQ3oJ/5ETLyglU2+8dBObvhfWXX8dtPZDMePCahptliFX2iIuhyEszyFk401PZUNQH20vvdW5MLjJxkwU80Ow=="
         },
         "npm-packlist": {
           "version": "1.1.11",
-          "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.1.11.tgz",
+          "resolved": false,
           "integrity": "sha512-CxKlZ24urLkJk+9kCm48RTQ7L4hsmgSVzEk0TLGPzzyuFxD7VNgy5Sl24tOLMzQv773a/NeJ1ce1DKeacqffEA==",
           "requires": {
             "ignore-walk": "^3.0.1",
@@ -5386,7 +5445,7 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+          "resolved": false,
           "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "requires": {
             "are-we-there-yet": "~1.1.2",
@@ -5397,17 +5456,17 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "resolved": false,
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
         },
         "once": {
           "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "requires": {
             "wrappy": "1"
@@ -5415,17 +5474,17 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+          "resolved": false,
           "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+          "resolved": false,
           "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
         },
         "osenv": {
           "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+          "resolved": false,
           "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "requires": {
             "os-homedir": "^1.0.0",
@@ -5434,17 +5493,17 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+          "resolved": false,
           "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
         },
         "rc": {
           "version": "1.2.8",
-          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+          "resolved": false,
           "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
           "requires": {
             "deep-extend": "^0.6.0",
@@ -5455,7 +5514,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": false,
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -5469,7 +5528,7 @@
         },
         "rimraf": {
           "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+          "resolved": false,
           "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
           "requires": {
             "glob": "^7.0.5"
@@ -5477,37 +5536,37 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "resolved": false,
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+          "resolved": false,
           "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
         },
         "sax": {
           "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+          "resolved": false,
           "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
         },
         "semver": {
           "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+          "resolved": false,
           "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "resolved": false,
           "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
             "code-point-at": "^1.0.0",
@@ -5517,7 +5576,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "resolved": false,
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
             "safe-buffer": "~5.1.0"
@@ -5525,7 +5584,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -5533,12 +5592,12 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
         },
         "tar": {
           "version": "4.4.4",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.4.tgz",
+          "resolved": false,
           "integrity": "sha512-mq9ixIYfNF9SK0IS/h2HKMu8Q2iaCuhDDsZhdEag/FHv8fOaYld4vN7ouMgcSSt5WKZzPs8atclTcJm36OTh4w==",
           "requires": {
             "chownr": "^1.0.1",
@@ -5552,12 +5611,12 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+          "resolved": false,
           "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
         },
         "wide-align": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+          "resolved": false,
           "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
           "requires": {
             "string-width": "^1.0.2 || 2"
@@ -5565,12 +5624,12 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "resolved": false,
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "yallist": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
+          "resolved": false,
           "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
         }
       }
@@ -5745,6 +5804,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
       "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
+    },
+    "highlight.js": {
+      "version": "9.12.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.12.0.tgz",
+      "integrity": "sha1-5tnb5Xy+/mB1HwKvM2GVhwyQwB4=",
       "dev": true
     },
     "hmac-drbg": {
@@ -6017,7 +6082,7 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4="
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-builtin-module": {
       "version": "1.0.0",
@@ -6121,7 +6186,7 @@
     },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
@@ -6348,7 +6413,7 @@
     },
     "jsonfile": {
       "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+      "resolved": "http://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "dev": true,
       "requires": {
@@ -6792,6 +6857,12 @@
         "object-visit": "^1.0.0"
       }
     },
+    "marked": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.4.0.tgz",
+      "integrity": "sha512-tMsdNBgOsrUophCAFQl0XPe6Zqk/uy9gnue+jIIKhykO51hxyu6uNx7zBPy0+y/WKYVZZMspV9YeXLNdKk+iYw==",
+      "dev": true
+    },
     "matched": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/matched/-/matched-0.4.4.tgz",
@@ -6834,6 +6905,38 @@
       "requires": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1"
+      }
+    },
+    "memdown": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/memdown/-/memdown-1.2.4.tgz",
+      "integrity": "sha1-zZo0qvB01TRFonEQjrS43U7A8n8=",
+      "requires": {
+        "abstract-leveldown": "2.4.1",
+        "functional-red-black-tree": "^1.0.1",
+        "immediate": "^3.2.3",
+        "inherits": "~2.0.1",
+        "ltgt": "~2.1.3"
+      },
+      "dependencies": {
+        "abstract-leveldown": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.4.1.tgz",
+          "integrity": "sha1-s7/tuITraToSd18MVenwpCDM7mQ=",
+          "requires": {
+            "xtend": "~4.0.0"
+          }
+        },
+        "immediate": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
+          "integrity": "sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw="
+        },
+        "ltgt": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.1.3.tgz",
+          "integrity": "sha1-EIUaBtmWS5cReEQcI8nlJpjuzjQ="
+        }
       }
     },
     "memory-fs": {
@@ -6976,7 +7079,7 @@
     "miller-rabin": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
-      "integrity": "sha1-8IA1HIZbDcViqEYpZtqlNUPHik0=",
+      "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
       "dev": true,
       "requires": {
         "bn.js": "^4.0.0",
@@ -7028,14 +7131,14 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
         "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "minimist-options": {
@@ -7089,7 +7192,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
@@ -7097,7 +7200,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }
@@ -7123,7 +7226,7 @@
       "dependencies": {
         "commander": {
           "version": "2.15.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+          "resolved": "http://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
           "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
           "dev": true
         },
@@ -7314,7 +7417,7 @@
     "node-fetch": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha1-mA9vcthSEaU0fGsrwYxbhMPrR+8=",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
       "requires": {
         "encoding": "^0.1.11",
         "is-stream": "^1.0.1"
@@ -7323,7 +7426,7 @@
     "node-libs-browser": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.1.0.tgz",
-      "integrity": "sha1-X5QmPUBPbkR2fXJpAf/wVHjWAN8=",
+      "integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
       "dev": true,
       "requires": {
         "assert": "^1.1.1",
@@ -7413,7 +7516,7 @@
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-      "integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
+      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
         "hosted-git-info": "^2.1.4",
@@ -7601,7 +7704,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.10",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
           "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
           "dev": true
         }
@@ -7645,7 +7748,7 @@
     },
     "os-locale": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "requires": {
         "lcid": "^1.0.0"
@@ -7690,7 +7793,7 @@
     "pako": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
-      "integrity": "sha1-AQEhG6pwxLykoPY/Igbpe3368lg=",
+      "integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg==",
       "dev": true
     },
     "parallel-transform": {
@@ -7706,7 +7809,7 @@
     },
     "parse-asn1": {
       "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
       "integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
       "dev": true,
       "requires": {
@@ -7797,7 +7900,7 @@
     },
     "pause-stream": {
       "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "resolved": "http://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
       "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
       "dev": true,
       "requires": {
@@ -7952,6 +8055,108 @@
         }
       }
     },
+    "pouchdb-adapter-leveldb-core": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pouchdb-adapter-leveldb-core/-/pouchdb-adapter-leveldb-core-7.0.0.tgz",
+      "integrity": "sha512-LL5bjUXJSMW33F58MAZ0MbihWeHCEjx0uoZjIGRBnpq74bsUQwJVtFSP0TqR/cXCuimCt1ATNBStRc9pr5Avrg==",
+      "requires": {
+        "argsarray": "0.0.1",
+        "buffer-from": "1.1.0",
+        "double-ended-queue": "2.1.0-0",
+        "levelup": "3.0.1",
+        "pouchdb-adapter-utils": "7.0.0",
+        "pouchdb-binary-utils": "7.0.0",
+        "pouchdb-collections": "7.0.0",
+        "pouchdb-errors": "7.0.0",
+        "pouchdb-json": "7.0.0",
+        "pouchdb-md5": "7.0.0",
+        "pouchdb-merge": "7.0.0",
+        "pouchdb-utils": "7.0.0",
+        "sublevel-pouchdb": "7.0.0",
+        "through2": "2.0.3"
+      }
+    },
+    "pouchdb-adapter-memory": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pouchdb-adapter-memory/-/pouchdb-adapter-memory-7.0.0.tgz",
+      "integrity": "sha512-ZBg3SRtyEjgNOriB2k6PGqjCE/v2dertiN/L/tk84tWqi2J4UScWzIOiIbuhY7eUrHQK1Lj1Eq2vpYilYCG8eQ==",
+      "requires": {
+        "memdown": "1.2.4",
+        "pouchdb-adapter-leveldb-core": "7.0.0",
+        "pouchdb-utils": "7.0.0"
+      }
+    },
+    "pouchdb-adapter-utils": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pouchdb-adapter-utils/-/pouchdb-adapter-utils-7.0.0.tgz",
+      "integrity": "sha512-UWKPC6jkz6mHUzZefrU7P5X8ZGvBC8LSNZ7BIp0hWvJE6c20cnpDwedTVDpZORcCbVJpDmFOHBYnOqEIblPtbA==",
+      "requires": {
+        "pouchdb-binary-utils": "7.0.0",
+        "pouchdb-collections": "7.0.0",
+        "pouchdb-errors": "7.0.0",
+        "pouchdb-md5": "7.0.0",
+        "pouchdb-merge": "7.0.0",
+        "pouchdb-utils": "7.0.0"
+      }
+    },
+    "pouchdb-binary-utils": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pouchdb-binary-utils/-/pouchdb-binary-utils-7.0.0.tgz",
+      "integrity": "sha512-yUktdOPIPvOVouCjJN3uop+bCcpdPwePrLm9eUAZNgEYnUFu0njdx7Q0WRsZ7UJ6l75HinL5ZHk4bnvEt86FLw==",
+      "requires": {
+        "buffer-from": "1.1.0"
+      }
+    },
+    "pouchdb-collections": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pouchdb-collections/-/pouchdb-collections-7.0.0.tgz",
+      "integrity": "sha512-DaoUr/vU24Q3gM6ghj0va9j/oBanPwkbhkvnqSyC3Dm5dgf5pculNxueLF9PKMo3ycApoWzHMh6N2N8KJbDU2Q=="
+    },
+    "pouchdb-errors": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pouchdb-errors/-/pouchdb-errors-7.0.0.tgz",
+      "integrity": "sha512-dTusY8nnTw4HIztCrNl7AoGgwvS1bVf/3/97hDaGc4ytn72V9/4dK8kTqlimi3UpaurohYRnqac0SGXYP8vgXA==",
+      "requires": {
+        "inherits": "2.0.3"
+      }
+    },
+    "pouchdb-json": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pouchdb-json/-/pouchdb-json-7.0.0.tgz",
+      "integrity": "sha512-w0bNRu/7VmmCrFWMYAm62n30wvJJUT2SokyzeTyj3hRohj4GFwTRg1mSZ+iAmxgRKOFE8nzZstLG/WAB4Ymjew==",
+      "requires": {
+        "vuvuzela": "1.0.3"
+      }
+    },
+    "pouchdb-md5": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pouchdb-md5/-/pouchdb-md5-7.0.0.tgz",
+      "integrity": "sha512-yaSJKhLA3QlgloKUQeb2hLdT3KmUmPfoYdryfwHZuPTpXIRKTnMQTR9qCIRUszc0ruBpDe53DRslCgNUhAyTNQ==",
+      "requires": {
+        "pouchdb-binary-utils": "7.0.0",
+        "spark-md5": "3.0.0"
+      }
+    },
+    "pouchdb-merge": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pouchdb-merge/-/pouchdb-merge-7.0.0.tgz",
+      "integrity": "sha512-tci5u6NpznQhGcPv4ho1h0miky9rs+ds/T9zQ9meQeDZbUojXNaX1Jxsb0uYEQQ+HMqdcQs3Akdl0/u0mgwPGg=="
+    },
+    "pouchdb-utils": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pouchdb-utils/-/pouchdb-utils-7.0.0.tgz",
+      "integrity": "sha512-1bnoX1KdZYHv9wicDIFdO0PLiVIMzNDUBUZ/yOJZ+6LW6niQCB8aCv09ZztmKfSQcU5nnN3fe656tScBgP6dOQ==",
+      "requires": {
+        "argsarray": "0.0.1",
+        "clone-buffer": "1.0.0",
+        "immediate": "3.0.6",
+        "inherits": "2.0.3",
+        "pouchdb-collections": "7.0.0",
+        "pouchdb-errors": "7.0.0",
+        "pouchdb-md5": "7.0.0",
+        "uuid": "3.2.1"
+      }
+    },
     "prebuild-install": {
       "version": "2.5.3",
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-2.5.3.tgz",
@@ -8056,7 +8261,7 @@
     },
     "public-encrypt": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.2.tgz",
       "integrity": "sha512-4kJ5Esocg8X3h8YgJsKAuoesBgB7mqH3eowiDzMUPKiRDDE7E/BqqZD1hnTByIaAFiwAw246YEltSq7tdrOH0Q==",
       "dev": true,
       "requires": {
@@ -8159,7 +8364,7 @@
     },
     "react": {
       "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/react/-/react-0.12.2.tgz",
+      "resolved": "http://registry.npmjs.org/react/-/react-0.12.2.tgz",
       "integrity": "sha1-HE8LCIGBRu6rTwqzklfgqlICfgA=",
       "dev": true,
       "requires": {
@@ -8686,7 +8891,7 @@
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dev": true,
       "requires": {
@@ -8904,7 +9109,7 @@
     "source-list-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.0.tgz",
-      "integrity": "sha1-qqR0A/eyRakvvJfqCPJQ1gh+0IU=",
+      "integrity": "sha512-I2UmuJSRr/T8jisiROLU3A3ltr+swpniSmNPI4Ml3ZCX6tVnDsuZzK7F2hl5jTqbZBWCEKlj5HRQiPExXLgE8A==",
       "dev": true
     },
     "source-map": {
@@ -9208,6 +9413,40 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
     },
+    "sublevel-pouchdb": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/sublevel-pouchdb/-/sublevel-pouchdb-7.0.0.tgz",
+      "integrity": "sha512-yRLCq7tM2MzbJaNAbHnReS3rCXk9bwo3Noy6GugR6c2IukAix9XcrnJstMdvlrVmv1/3wpAOt6jsHH/OxSNGJQ==",
+      "requires": {
+        "inherits": "2.0.3",
+        "level-codec": "7.0.1",
+        "ltgt": "2.2.1",
+        "readable-stream": "1.0.33"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "1.0.33",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+          "integrity": "sha1-OjYN1mwbHX/UcFOJhg7aHQ9hEmw=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        }
+      }
+    },
     "supports-color": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.0.1.tgz",
@@ -9219,7 +9458,7 @@
     },
     "table": {
       "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/table/-/table-4.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/table/-/table-4.0.3.tgz",
       "integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
       "dev": true,
       "requires": {
@@ -9311,7 +9550,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
@@ -9520,6 +9759,76 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "typedoc": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.12.0.tgz",
+      "integrity": "sha512-dsdlaYZ7Je8JC+jQ3j2Iroe4uyD0GhqzADNUVyBRgLuytQDP/g0dPkAw5PdM/4drnmmJjRzSWW97FkKo+ITqQg==",
+      "dev": true,
+      "requires": {
+        "@types/fs-extra": "^5.0.3",
+        "@types/handlebars": "^4.0.38",
+        "@types/highlight.js": "^9.12.3",
+        "@types/lodash": "^4.14.110",
+        "@types/marked": "^0.4.0",
+        "@types/minimatch": "3.0.3",
+        "@types/shelljs": "^0.8.0",
+        "fs-extra": "^7.0.0",
+        "handlebars": "^4.0.6",
+        "highlight.js": "^9.0.0",
+        "lodash": "^4.17.10",
+        "marked": "^0.4.0",
+        "minimatch": "^3.0.0",
+        "progress": "^2.0.0",
+        "shelljs": "^0.8.2",
+        "typedoc-default-themes": "^0.5.0",
+        "typescript": "3.0.x"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.0.tgz",
+          "integrity": "sha512-EglNDLRpmaTWiD/qraZn6HREAEAHJcJOmxNEYwq6xeMKnVMAy3GUcFB+wXt2C6k4CNvB/mP1y/U3dzvKKj5OtQ==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "dev": true
+        },
+        "shelljs": {
+          "version": "0.8.2",
+          "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.2.tgz",
+          "integrity": "sha512-pRXeNrCA2Wd9itwhvLp5LZQvPJ0wU6bcjaTMywHHGX5XWhVN2nzSu7WV0q+oUY7mGK3mgSkDDzP3MgjqdyIgbQ==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.0.0",
+            "interpret": "^1.0.0",
+            "rechoir": "^0.6.2"
+          }
+        }
+      }
+    },
+    "typedoc-default-themes": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.5.0.tgz",
+      "integrity": "sha1-bcJDPnjti+qOiHo6zeLzF4W9Yic=",
+      "dev": true
+    },
     "typescript": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.0.3.tgz",
@@ -9705,6 +10014,12 @@
       "requires": {
         "imurmurhash": "^0.1.4"
       }
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true
     },
     "unset-value": {
       "version": "1.0.0",
@@ -10129,7 +10444,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
         "string-width": "^1.0.1",
@@ -10202,7 +10517,7 @@
     },
     "yargs": {
       "version": "3.32.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+      "resolved": "http://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
       "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
       "requires": {
         "camelcase": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "test-extension": "mocha-chrome extension/test/index.test.html",
     "test-mocha-words": "mocha-chrome artifacts/Words/test/index.test.html",
     "test-wdio": "cross-env wdio -b http://${npm_package_config_host}:${npm_package_config_port}/ shell/test/wdio.conf.js",
-    "build:rollup": "rollup -c"
+    "build:rollup": "rollup -c",
+    "build:typedoc": "typedoc --mode file --target ES5  --downLevelIteration -out dist/apidocs"
   },
   "devDependencies": {
     "@types/chai": "^4.1.4",
@@ -42,6 +43,7 @@
     "rollup-plugin-ignore": "^1.0.3",
     "ts-node": "^7.0.1",
     "tslint": "^5.11.0",
+    "typedoc": "^0.12.0",
     "wdio-chromedriver-service": "^0.1.3",
     "wdio-errorshot-reporter": "^0.2.1",
     "wdio-mocha-framework": "^0.6.3",
@@ -62,6 +64,7 @@
     "jsrsasign-util": "^1.0.0",
     "node-fetch": "^1.7.2",
     "pouchdb": "^7.0.0",
+    "pouchdb-adapter-memory": "^7.0.0",
     "prettier": "^1.14.2",
     "rollup": "^0.65.2",
     "rollup-plugin-multi-entry": "^2.0.2",

--- a/runtime/arc.js
+++ b/runtime/arc.js
@@ -148,6 +148,7 @@ export class Arc {
 
     switch (key.protocol) {
       case 'firebase':
+      case 'pouchdb':
         context.handles += `store ${id} of ${handle.type.toString()} ${combinedId} @${handle.version === null ? 0 : handle.version} ${handleTags} at '${handle.storageKey}'\n`;
         break;
       case 'in-memory': {

--- a/runtime/manual_tests/firebase-tests.js
+++ b/runtime/manual_tests/firebase-tests.js
@@ -105,7 +105,7 @@ describe('firebase', function() {
       await var1.set({id: 'id1', value: 'underlying'});
       
       let result = await var1.get();
-      assert.equal('underlying', result.value);
+      assert.equal(result.value, 'underlying');
 
       assert.isTrue(var1.referenceMode);
       assert.isNotNull(var1.backingStore);

--- a/runtime/manual_tests/pouch-db-tests.js
+++ b/runtime/manual_tests/pouch-db-tests.js
@@ -12,7 +12,6 @@ import { StorageProviderFactory } from '../ts-build/storage/storage-provider-fac
 import { Arc } from '../arc.js';
 import { Manifest } from '../manifest.js';
 import { Type } from '../ts-build/type.js';
-import 'chai/register-expect';
 import 'chai/register-assert';
 
 import { PouchDbStorage } from '../ts-build/storage/pouchdb/pouch-db-storage.js';
@@ -27,7 +26,6 @@ describe('pouchdb', function() {
 
   let lastStoreId = 0;
   function newStoreKey(name) {
-    console.log(`${testUrl}/${name}-${lastStoreId++}`);
     return `${testUrl}/${name}-${lastStoreId++}`;
   }
 
@@ -63,7 +61,7 @@ describe('pouchdb', function() {
       let variable = await storage.construct('test0', BarType, newStoreKey('variable'));
       await variable.set({ id: 'test0:test', value });
       let result = await variable.get();
-      expect(result.value).to.equal(value);
+      assert.equal(result.value, value);
     });
 
     it('resolves concurrent set', async () => {
@@ -87,10 +85,8 @@ describe('pouchdb', function() {
       await var1.set({ id: 'id1', value: 'value1' });
       await var2.set({ id: 'id2', value: 'value2' });
       const v1 = await var1.get();
-      console.log('V1', v1);
       const v2 = await var2.get();
-      console.log('V2', v2);
-      expect(v1).to.deep.equal(v2);
+      assert.deepEqual(v1, v2);
     });
     it('enables referenceMode by default', async () => {
       let manifest = await Manifest.parse(`
@@ -107,7 +103,7 @@ describe('pouchdb', function() {
       await var1.set({ id: 'id1', value: 'underlying' });
 
       let result = await var1.get();
-      assert.equal('underlying', result.value);
+      assert.equal(result.value, 'underlying');
 
       assert.isTrue(var1.referenceMode);
       assert.isNotNull(var1.backingStore);
@@ -151,13 +147,14 @@ describe('pouchdb', function() {
       await collection.store({ id: 'test0:test0', value: value1 }, ['key0']);
       await collection.store({ id: 'test0:test1', value: value2 }, ['key1']);
       let result = await collection.get('test0:test0');
-      expect(result.value).to.equal(value1);
+      assert.equal(result.value, value1);
       result = await collection.toList();
-      expect(result).to.have.lengthOf(2);
-      expect(result[0].value).to.equal(value1);
-      expect(result[0].id).to.equal('test0:test0');
-      expect(result[1].value).to.equal(value2);
-      expect(result[1].id).to.equal('test0:test1'); // TODO(lindner): should be test1:test1???
+      assert.lengthOf(result, 2);
+      assert.equal(result[0].value, value1);
+      assert.equal(result[0].id, 'test0:test0');
+      assert.equal(result[1].value, value2);
+      // TODO(lindner): firebase tests say that this should  be test1:test1 instead
+      assert.equal(result[1].id, 'test0:test1');
     });
     it('resolves concurrent add of same id', async () => {
       let manifest = await Manifest.parse(`
@@ -177,7 +174,7 @@ describe('pouchdb', function() {
       const c1 = collection1.store({ id: 'id1', value: 'value' }, ['key3']);
       await collection2.store({ id: 'id1', value: 'value' }, ['key4']);
       await c1;
-      expect(await collection1.toList()).to.deep.equal(await collection2.toList());
+      assert.deepEqual(await collection1.toList(), await collection2.toList());
     });
 
     it('resolves concurrent add/remove of same id', async () => {
@@ -200,8 +197,8 @@ describe('pouchdb', function() {
         collection2.store({ id: 'id1', value: 'value' }, ['key2'])
       ]);
       await Promise.all([collection1.remove('id1', ['key1']), collection2.remove('id1', ['key2'])]);
-      expect(await collection1.toList()).to.be.empty;
-      expect(await collection2.toList()).to.be.empty;
+      assert.isEmpty(await collection1.toList());
+      assert.isEmpty(await collection2.toList());
     });
     it('resolves concurrent add of different id', async () => {
       let manifest = await Manifest.parse(`
@@ -220,8 +217,8 @@ describe('pouchdb', function() {
       );
       await collection1.store({ id: 'id1', value: 'value1' }, ['key1']);
       await collection2.store({ id: 'id2', value: 'value2' }, ['key2']);
-      expect(await collection1.toList()).to.have.lengthOf(2);
-      expect(await collection1.toList()).to.have.deep.members(await collection2.toList());
+      assert.lengthOf(await collection1.toList(), 2);
+      assert.sameDeepMembers(await collection1.toList(), await collection2.toList());
     });
     it('enables referenceMode by default', async () => {
       let manifest = await Manifest.parse(`
@@ -275,246 +272,5 @@ describe('pouchdb', function() {
       assert.isNull(collection1.backingStore);
     });
   });
-
-  // For these tests, the following index rule should be manually set up in the console at
-  // https://firebase.corp.google.com/project/arcs-storage-test/database/arcs-storage-test/rules:
-  //   "rules": {
-  //     "firebase-storage-test": {
-  //       "$collection": {
-  //         "items": {
-  //           ".indexOn": ["index"]
-  //         }
-  //       }
-  //     }
-  //   }
-  describe('big collection', () => {
-    it.skip('supports get, store and remove (including concurrently)', async () => {
-      let manifest = await Manifest.parse(`
-        schema Bar
-          Text data
-      `);
-      let arc = new Arc({ id: 'test' });
-      let storage = createStorage(arc.id);
-      let BarType = Type.newEntity(manifest.schemas.Bar);
-      let key = newStoreKey('bigcollection');
-      let collection1 = await storage.construct('test0', BarType.bigCollectionOf(), key);
-      let collection2 = await storage.connect(
-        'test0',
-        BarType.bigCollectionOf(),
-        key
-      );
-
-      // Concurrent writes to different ids.
-      await Promise.all([collection1.store({ id: 'id1', data: 'ab' }, ['k34']), collection2.store({ id: 'id2', data: 'cd' }, ['k12'])]);
-      assert.equal((await collection2.get('id1')).data, 'ab');
-      assert.equal((await collection1.get('id2')).data, 'cd');
-
-      await collection1.remove('id2');
-      assert.isNull(await collection2.get('id2'));
-
-      // Concurrent writes to the same id.
-      await Promise.all([collection1.store({ id: 'id3', data: 'xx' }, ['k65']), collection2.store({ id: 'id3', data: 'yy' }, ['k87'])]);
-      assert.include(['xx', 'yy'], (await collection1.get('id3')).data);
-
-      assert.isNull(await collection1.get('non-existent'));
-      await collection1.remove('non-existent');
-    });
-
-    // Ideally this would be several independent test cases, but since we're using a live remote
-    // database instance the setup is too expensive to keep repeating.
-    it.skip('supports version-stable streamed reads', async () => {
-      let manifest = await Manifest.parse(`
-        schema Bar
-          Text data
-      `);
-      let arc = new Arc({ id: 'test' });
-      let storage = createStorage(arc.id);
-      let BarType = Type.newEntity(manifest.schemas.Bar);
-      let collection = await storage.construct('test0', BarType.bigCollectionOf(), newStoreKey('bigcollection'));
-      let items = new Map();
-
-      // Stores a new item for each id in both collection and items, with data and key derived
-      // from the numerical part of the id in a lexicographically "random" manner.
-      let store = (...ids) => {
-        let promises = [];
-        for (let id of ids) {
-          let n = Number(id.slice(1));
-          let data = 'v' + ((n * 37) % 100);
-          let key = 'k' + ((n * 73) % 100);
-          promises.push(collection.store({ id, data }, [key]));
-          items.set(id, { data, key });
-        }
-        return Promise.all(promises);
-      };
-
-      // Add an initial set of items with lexicographically "random" ids.
-      await store('r01', 'i02', 'z03', 'q04', 'h05', 'y06', 'p07', 'g08');
-
-      // Verifies that cursor.next() returns items matching the given list of ids (in order).
-      let checkNext = async (cursorId, ids) => {
-        let { value, done } = await collection.cursorNext(cursorId);
-        assert.isFalse(done);
-        assert.equal(value.length, ids.length);
-        for (let i = 0; i < value.length; i++) {
-          assert.equal(value[i].id, ids[i]);
-          assert.equal(value[i].data, items.get(ids[i]).data);
-        }
-      };
-
-      // Verifies that cursor does not contain any more items.
-      let checkDone = async cursorId => {
-        let { value, done } = await collection.cursorNext(cursorId);
-        assert.isTrue(done);
-        assert.isUndefined(value);
-      };
-
-      // Verifies a full streamed read with the given page size.
-      let checkStream = async (pageSize, ...idRows) => {
-        let cursorId = await collection.stream(pageSize);
-        for (let ids of idRows) {
-          await checkNext(cursorId, ids);
-        }
-        await checkDone(cursorId);
-      };
-
-      // Test streamed reads with various page sizes.
-      await checkStream(3, ['r01', 'i02', 'z03'], ['q04', 'h05', 'y06'], ['p07', 'g08']);
-      await checkStream(4, ['r01', 'i02', 'z03', 'q04'], ['h05', 'y06', 'p07', 'g08']);
-      await checkStream(7, ['r01', 'i02', 'z03', 'q04', 'h05', 'y06', 'p07'], ['g08']);
-      await checkStream(8, ['r01', 'i02', 'z03', 'q04', 'h05', 'y06', 'p07', 'g08']);
-
-      await store('x09', 'o10', 'f11', 'w12', 'e13', 'j14');
-
-      // Add operations that occur after cursor creation should not affect streamed reads.
-      // Items removed "ahead" of the read should be captured and returned later in the stream.
-      let cursorId1 = await collection.stream(4);
-
-      // Remove the item at the start of the first page and another from a later page.
-      await collection.remove('r01');
-      await collection.remove('p07');
-      await store('t15');
-      await checkNext(cursorId1, ['i02', 'z03', 'q04', 'h05']);
-
-      // Interleave another streamed read over a different version of the collection. cursor2
-      // should be 3 versions ahead due to the 3 add/remove operations above.
-      let cursorId2 = await collection.stream(5);
-      assert.equal(collection.cursorVersion(cursorId2), collection.cursorVersion(cursorId1) + 3);
-      await store('s16');
-
-      // For cursor1: remove one item from the page just returned and two at the edges of the next page.
-      await collection.remove('z03');
-      await collection.remove('y06');
-      await collection.remove('f11');
-
-      await checkNext(cursorId2, ['i02', 'q04', 'h05', 'g08', 'x09']);
-      await checkNext(cursorId1, ['g08', 'x09', 'o10', 'w12']);
-
-      // This uses up the remaining non-removed items for cursor2 ---> [*]
-      await checkNext(cursorId2, ['o10', 'w12', 'e13', 'j14', 't15']);
-
-      // For cursor1: the next page should include the two remaining items and two of the previously
-      // removed ones (which are returned in reverse order of removal).
-      await checkNext(cursorId1, ['e13', 'j14', 'f11', 'y06']);
-
-      // Remove another previously-returned item; should have no effect on either cursor.
-      await collection.remove('x09');
-      await checkNext(cursorId1, ['p07', 'r01']);
-      await store('m17');
-      await checkDone(cursorId1);
-
-      // Streaming again should be up-to-date (even with cursor2 still in flight).
-      await checkStream(12, ['i02', 'q04', 'h05', 'g08', 'o10', 'w12', 'e13', 'j14', 't15', 's16', 'm17']);
-
-      // [*] ---> so that this page is only removed items.
-      await checkNext(cursorId2, ['f11', 'y06', 'z03']);
-      await checkDone(cursorId2);
-
-      // Repeated next() calls on a finished cursor should be safe.
-      await checkDone(cursorId2);
-
-      // close() should terminate a stream.
-      let cursorId3 = await collection.stream(3);
-      await checkNext(cursorId3, ['i02', 'q04', 'h05']);
-      collection.cursorClose(cursorId3);
-      await checkDone(cursorId3);
-    }).timeout(20000);
-  });
-
-  // These tests use data manually added to our test firebase db.
-  describe('synthetic', () => {
-    function getKey(manifestName) {
-      let fbKey = testUrl.replace('firebase-storage-test', `synthetic-storage-data/${manifestName}`);
-      return `synthetic://arc/handles/${fbKey}`;
-    }
-
-    it.skip('simple test', async () => {
-      let storage = createStorage('arc-id');
-      let synth = await storage.connect(
-        'id1',
-        null,
-        getKey('simple-manifest')
-      );
-      let list = await synth.toList();
-      assert.equal(list.length, 1);
-      let handle = list[0];
-      assert.equal(handle.storageKey, 'firebase://xxx.firebaseio.com/yyy');
-      let type = handle.type.getContainedType();
-      assert(type && type.isEntity);
-      assert.equal(type.entitySchema.name, 'Thing');
-      assert.deepEqual(handle.tags, ['taggy']);
-    });
-
-    it.skip('error test', async () => {
-      let storage = createStorage('arc-id');
-      let synth1 = await storage.connect(
-        'not-there',
-        null,
-        getKey('not-there')
-      );
-      let list1 = await synth1.toList();
-      assert.isEmpty(list1, 'synthetic handle list should empty for non-existent storageKey');
-
-      let synth2 = await storage.connect(
-        'bad-manifest',
-        null,
-        getKey('bad-manifest')
-      );
-      let list2 = await synth2.toList();
-      assert.isEmpty(list2, 'synthetic handle list should empty for invalid manifests');
-
-      let synth3 = await storage.connect(
-        'no-recipe',
-        null,
-        getKey('no-recipe')
-      );
-      let list3 = await synth3.toList();
-      assert.isEmpty(list3, 'synthetic handle list should empty for manifests with no active recipe');
-
-      let synth4 = await storage.connect(
-        'no-handles',
-        null,
-        getKey('no-handles')
-      );
-      let list4 = await synth4.toList();
-      assert.isEmpty(list4, 'synthetic handle list should empty for manifests with no handles');
-    });
-
-    it.skip('large test', async () => {
-      let storage = createStorage('arc-id');
-      let synth = await storage.connect(
-        'id1',
-        null,
-        getKey('large-manifest')
-      );
-      let list = await synth.toList();
-      assert(list.length > 0, 'synthetic handle list should not be empty');
-      for (let item of list) {
-        assert(item.storageKey.startsWith('firebase:'));
-        assert(item.type.constructor.name == 'Type');
-        if (item.tags.length > 0) {
-          assert.isString(item.tags[0]);
-        }
-      }
-    });
-  });
+  // TODO(lindner): add big collection tests here when implemented.
 });

--- a/runtime/manual_tests/pouch-db-tests.js
+++ b/runtime/manual_tests/pouch-db-tests.js
@@ -1,0 +1,520 @@
+/**
+ * @license
+ * Copyright (c) 2017 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import { StorageProviderFactory } from '../ts-build/storage/storage-provider-factory.js';
+import { Arc } from '../arc.js';
+import { Manifest } from '../manifest.js';
+import { Type } from '../ts-build/type.js';
+import 'chai/register-expect';
+import 'chai/register-assert';
+
+import { PouchDbStorage } from '../ts-build/storage/pouchdb/pouch-db-storage.js';
+
+const testUrl = 'pouchdb://memory/user-test';
+
+// TODO(lindner): run tests for remote and local variants
+const testUrlReplicated = 'pouchdb://memory/user-test';
+
+describe('pouchdb', function() {
+  this.timeout(10000); // eslint-disable-line no-invalid-this
+
+  let lastStoreId = 0;
+  function newStoreKey(name) {
+    console.log(`${testUrl}/${name}-${lastStoreId++}`);
+    return `${testUrl}/${name}-${lastStoreId++}`;
+  }
+
+  // TODO(lindner): switch back to before()?
+  beforeEach(async () => {
+    // TODO: perhaps we should do this after the test, and use a unique path for each run instead?
+    await PouchDbStorage.resetPouchDbStorageForTesting(testUrl);
+  });
+
+  let storageInstances = [];
+
+  function createStorage(id) {
+    let storage = new StorageProviderFactory(id);
+    storageInstances.push(storage);
+    return storage;
+  }
+
+  after(() => {
+    storageInstances.map(s => s.shutdown());
+    storageInstances = [];
+  });
+
+  describe('variable', () => {
+    it('supports basic construct and mutate', async () => {
+      let manifest = await Manifest.parse(`
+        schema Bar
+          Text value
+      `);
+      let arc = new Arc({ id: 'test' });
+      let storage = createStorage(arc.id);
+      let BarType = Type.newEntity(manifest.schemas.Bar);
+      let value = 'Hi there' + Math.random();
+      let variable = await storage.construct('test0', BarType, newStoreKey('variable'));
+      await variable.set({ id: 'test0:test', value });
+      let result = await variable.get();
+      expect(result.value).to.equal(value);
+    });
+
+    it('resolves concurrent set', async () => {
+      let manifest = await Manifest.parse(`
+        schema Bar
+          Text value
+      `);
+      let arc = new Arc({ id: 'test' });
+      let storage = createStorage(arc.id);
+      let BarType = Type.newEntity(manifest.schemas.Bar);
+      let key = newStoreKey('variable');
+      let var1 = await storage.construct('test0', BarType, key);
+      assert.isNotNull(var1);
+      let var2 = await storage.connect(
+        'test0',
+        BarType,
+        key
+      );
+      assert.isNotNull(var2);
+
+      await var1.set({ id: 'id1', value: 'value1' });
+      await var2.set({ id: 'id2', value: 'value2' });
+      const v1 = await var1.get();
+      console.log('V1', v1);
+      const v2 = await var2.get();
+      console.log('V2', v2);
+      expect(v1).to.deep.equal(v2);
+    });
+    it('enables referenceMode by default', async () => {
+      let manifest = await Manifest.parse(`
+        schema Bar
+          Text value
+      `);
+
+      let arc = new Arc({ id: 'test' });
+      let storage = createStorage(arc.id);
+      let BarType = Type.newEntity(manifest.schemas.Bar);
+      let key1 = newStoreKey('varPtr');
+
+      let var1 = await storage.construct('test0', BarType, key1);
+      await var1.set({ id: 'id1', value: 'underlying' });
+
+      let result = await var1.get();
+      assert.equal('underlying', result.value);
+
+      assert.isTrue(var1.referenceMode);
+      assert.isNotNull(var1.backingStore);
+
+      assert.deepEqual(await var1.backingStore.get('id1'), await var1.get());
+    });
+    it('supports references', async () => {
+      let manifest = await Manifest.parse(`
+        schema Bar
+          Text value
+      `);
+
+      let arc = new Arc({ id: 'test' });
+      let storage = createStorage(arc.id);
+      let BarType = Type.newEntity(manifest.schemas.Bar);
+      let key1 = newStoreKey('varPtr');
+
+      let var1 = await storage.construct('test0', Type.newReference(BarType), key1);
+      await var1.set({ id: 'id1', storageKey: 'underlying' });
+
+      let result = await var1.get();
+      assert.equal('underlying', result.storageKey);
+
+      assert.isFalse(var1.referenceMode);
+      assert.isNull(var1.backingStore);
+    });
+  });
+
+  describe('collection', () => {
+    it('supports basic construct and mutate', async () => {
+      let manifest = await Manifest.parse(`
+        schema Bar
+          Text value
+      `);
+      let arc = new Arc({ id: 'test' });
+      let storage = createStorage(arc.id);
+      let BarType = Type.newEntity(manifest.schemas.Bar);
+      let value1 = 'Hi there' + Math.random();
+      let value2 = 'Goodbye' + Math.random();
+      let collection = await storage.construct('test1', BarType.collectionOf(), newStoreKey('collection'));
+      await collection.store({ id: 'test0:test0', value: value1 }, ['key0']);
+      await collection.store({ id: 'test0:test1', value: value2 }, ['key1']);
+      let result = await collection.get('test0:test0');
+      expect(result.value).to.equal(value1);
+      result = await collection.toList();
+      expect(result).to.have.lengthOf(2);
+      expect(result[0].value).to.equal(value1);
+      expect(result[0].id).to.equal('test0:test0');
+      expect(result[1].value).to.equal(value2);
+      expect(result[1].id).to.equal('test0:test1'); // TODO(lindner): should be test1:test1???
+    });
+    it('resolves concurrent add of same id', async () => {
+      let manifest = await Manifest.parse(`
+        schema Bar
+          Text value
+      `);
+      let arc = new Arc({ id: 'test' });
+      let storage = createStorage(arc.id);
+      let BarType = Type.newEntity(manifest.schemas.Bar);
+      let key = newStoreKey('collection');
+      let collection1 = await storage.construct('test1', BarType.collectionOf(), key);
+      let collection2 = await storage.connect(
+        'test1',
+        BarType.collectionOf(),
+        key
+      );
+      const c1 = collection1.store({ id: 'id1', value: 'value' }, ['key3']);
+      await collection2.store({ id: 'id1', value: 'value' }, ['key4']);
+      await c1;
+      expect(await collection1.toList()).to.deep.equal(await collection2.toList());
+    });
+
+    it('resolves concurrent add/remove of same id', async () => {
+      let manifest = await Manifest.parse(`
+        schema Bar
+          Text value
+      `);
+      let arc = new Arc({ id: 'test' });
+      let storage = createStorage(arc.id);
+      let BarType = Type.newEntity(manifest.schemas.Bar);
+      let key = newStoreKey('collection');
+      let collection1 = await storage.construct('test1', BarType.collectionOf(), key);
+      let collection2 = await storage.connect(
+        'test1',
+        BarType.collectionOf(),
+        key
+      );
+      await Promise.all([
+        collection1.store({ id: 'id1', value: 'value' }, ['key1']),
+        collection2.store({ id: 'id1', value: 'value' }, ['key2'])
+      ]);
+      await Promise.all([collection1.remove('id1', ['key1']), collection2.remove('id1', ['key2'])]);
+      expect(await collection1.toList()).to.be.empty;
+      expect(await collection2.toList()).to.be.empty;
+    });
+    it('resolves concurrent add of different id', async () => {
+      let manifest = await Manifest.parse(`
+        schema Bar
+          Text value
+      `);
+      let arc = new Arc({ id: 'test' });
+      let storage = createStorage(arc.id);
+      let BarType = Type.newEntity(manifest.schemas.Bar);
+      let key = newStoreKey('collection');
+      let collection1 = await storage.construct('test1', BarType.collectionOf(), key);
+      let collection2 = await storage.connect(
+        'test1',
+        BarType.collectionOf(),
+        key
+      );
+      await collection1.store({ id: 'id1', value: 'value1' }, ['key1']);
+      await collection2.store({ id: 'id2', value: 'value2' }, ['key2']);
+      expect(await collection1.toList()).to.have.lengthOf(2);
+      expect(await collection1.toList()).to.have.deep.members(await collection2.toList());
+    });
+    it('enables referenceMode by default', async () => {
+      let manifest = await Manifest.parse(`
+        schema Bar
+          Text value
+      `);
+
+      let arc = new Arc({ id: 'test' });
+      let storage = createStorage(arc.id);
+      let BarType = Type.newEntity(manifest.schemas.Bar);
+      let key1 = newStoreKey('colPtr');
+
+      let collection1 = await storage.construct('test0', BarType.collectionOf(), key1);
+
+      await collection1.store({ id: 'id1', value: 'value1' }, ['key1']);
+      await collection1.store({ id: 'id2', value: 'value2' }, ['key2']);
+
+      let result = await collection1.get('id1');
+      assert.equal('value1', result.value);
+      result = await collection1.get('id2');
+      assert.equal('value2', result.value);
+
+      assert.isTrue(collection1.referenceMode);
+      assert.isNotNull(collection1.backingStore);
+
+      assert.deepEqual(await collection1.backingStore.get('id1'), await collection1.get('id1'));
+      assert.deepEqual(await collection1.backingStore.get('id2'), await collection1.get('id2'));
+    });
+    it('supports references', async () => {
+      let manifest = await Manifest.parse(`
+        schema Bar
+          Text value
+      `);
+
+      let arc = new Arc({ id: 'test' });
+      let storage = createStorage(arc.id);
+      let BarType = Type.newEntity(manifest.schemas.Bar);
+      let key1 = newStoreKey('colPtr');
+
+      let collection1 = await storage.construct('test0', Type.newReference(BarType).collectionOf(), key1);
+
+      await collection1.store({ id: 'id1', storageKey: 'value1' }, ['key1']);
+      await collection1.store({ id: 'id2', storageKey: 'value2' }, ['key2']);
+
+      let result = await collection1.get('id1');
+      assert.equal('value1', result.storageKey);
+      result = await collection1.get('id2');
+      assert.equal('value2', result.storageKey);
+
+      assert.isFalse(collection1.referenceMode);
+      assert.isNull(collection1.backingStore);
+    });
+  });
+
+  // For these tests, the following index rule should be manually set up in the console at
+  // https://firebase.corp.google.com/project/arcs-storage-test/database/arcs-storage-test/rules:
+  //   "rules": {
+  //     "firebase-storage-test": {
+  //       "$collection": {
+  //         "items": {
+  //           ".indexOn": ["index"]
+  //         }
+  //       }
+  //     }
+  //   }
+  describe('big collection', () => {
+    it.skip('supports get, store and remove (including concurrently)', async () => {
+      let manifest = await Manifest.parse(`
+        schema Bar
+          Text data
+      `);
+      let arc = new Arc({ id: 'test' });
+      let storage = createStorage(arc.id);
+      let BarType = Type.newEntity(manifest.schemas.Bar);
+      let key = newStoreKey('bigcollection');
+      let collection1 = await storage.construct('test0', BarType.bigCollectionOf(), key);
+      let collection2 = await storage.connect(
+        'test0',
+        BarType.bigCollectionOf(),
+        key
+      );
+
+      // Concurrent writes to different ids.
+      await Promise.all([collection1.store({ id: 'id1', data: 'ab' }, ['k34']), collection2.store({ id: 'id2', data: 'cd' }, ['k12'])]);
+      assert.equal((await collection2.get('id1')).data, 'ab');
+      assert.equal((await collection1.get('id2')).data, 'cd');
+
+      await collection1.remove('id2');
+      assert.isNull(await collection2.get('id2'));
+
+      // Concurrent writes to the same id.
+      await Promise.all([collection1.store({ id: 'id3', data: 'xx' }, ['k65']), collection2.store({ id: 'id3', data: 'yy' }, ['k87'])]);
+      assert.include(['xx', 'yy'], (await collection1.get('id3')).data);
+
+      assert.isNull(await collection1.get('non-existent'));
+      await collection1.remove('non-existent');
+    });
+
+    // Ideally this would be several independent test cases, but since we're using a live remote
+    // database instance the setup is too expensive to keep repeating.
+    it.skip('supports version-stable streamed reads', async () => {
+      let manifest = await Manifest.parse(`
+        schema Bar
+          Text data
+      `);
+      let arc = new Arc({ id: 'test' });
+      let storage = createStorage(arc.id);
+      let BarType = Type.newEntity(manifest.schemas.Bar);
+      let collection = await storage.construct('test0', BarType.bigCollectionOf(), newStoreKey('bigcollection'));
+      let items = new Map();
+
+      // Stores a new item for each id in both collection and items, with data and key derived
+      // from the numerical part of the id in a lexicographically "random" manner.
+      let store = (...ids) => {
+        let promises = [];
+        for (let id of ids) {
+          let n = Number(id.slice(1));
+          let data = 'v' + ((n * 37) % 100);
+          let key = 'k' + ((n * 73) % 100);
+          promises.push(collection.store({ id, data }, [key]));
+          items.set(id, { data, key });
+        }
+        return Promise.all(promises);
+      };
+
+      // Add an initial set of items with lexicographically "random" ids.
+      await store('r01', 'i02', 'z03', 'q04', 'h05', 'y06', 'p07', 'g08');
+
+      // Verifies that cursor.next() returns items matching the given list of ids (in order).
+      let checkNext = async (cursorId, ids) => {
+        let { value, done } = await collection.cursorNext(cursorId);
+        assert.isFalse(done);
+        assert.equal(value.length, ids.length);
+        for (let i = 0; i < value.length; i++) {
+          assert.equal(value[i].id, ids[i]);
+          assert.equal(value[i].data, items.get(ids[i]).data);
+        }
+      };
+
+      // Verifies that cursor does not contain any more items.
+      let checkDone = async cursorId => {
+        let { value, done } = await collection.cursorNext(cursorId);
+        assert.isTrue(done);
+        assert.isUndefined(value);
+      };
+
+      // Verifies a full streamed read with the given page size.
+      let checkStream = async (pageSize, ...idRows) => {
+        let cursorId = await collection.stream(pageSize);
+        for (let ids of idRows) {
+          await checkNext(cursorId, ids);
+        }
+        await checkDone(cursorId);
+      };
+
+      // Test streamed reads with various page sizes.
+      await checkStream(3, ['r01', 'i02', 'z03'], ['q04', 'h05', 'y06'], ['p07', 'g08']);
+      await checkStream(4, ['r01', 'i02', 'z03', 'q04'], ['h05', 'y06', 'p07', 'g08']);
+      await checkStream(7, ['r01', 'i02', 'z03', 'q04', 'h05', 'y06', 'p07'], ['g08']);
+      await checkStream(8, ['r01', 'i02', 'z03', 'q04', 'h05', 'y06', 'p07', 'g08']);
+
+      await store('x09', 'o10', 'f11', 'w12', 'e13', 'j14');
+
+      // Add operations that occur after cursor creation should not affect streamed reads.
+      // Items removed "ahead" of the read should be captured and returned later in the stream.
+      let cursorId1 = await collection.stream(4);
+
+      // Remove the item at the start of the first page and another from a later page.
+      await collection.remove('r01');
+      await collection.remove('p07');
+      await store('t15');
+      await checkNext(cursorId1, ['i02', 'z03', 'q04', 'h05']);
+
+      // Interleave another streamed read over a different version of the collection. cursor2
+      // should be 3 versions ahead due to the 3 add/remove operations above.
+      let cursorId2 = await collection.stream(5);
+      assert.equal(collection.cursorVersion(cursorId2), collection.cursorVersion(cursorId1) + 3);
+      await store('s16');
+
+      // For cursor1: remove one item from the page just returned and two at the edges of the next page.
+      await collection.remove('z03');
+      await collection.remove('y06');
+      await collection.remove('f11');
+
+      await checkNext(cursorId2, ['i02', 'q04', 'h05', 'g08', 'x09']);
+      await checkNext(cursorId1, ['g08', 'x09', 'o10', 'w12']);
+
+      // This uses up the remaining non-removed items for cursor2 ---> [*]
+      await checkNext(cursorId2, ['o10', 'w12', 'e13', 'j14', 't15']);
+
+      // For cursor1: the next page should include the two remaining items and two of the previously
+      // removed ones (which are returned in reverse order of removal).
+      await checkNext(cursorId1, ['e13', 'j14', 'f11', 'y06']);
+
+      // Remove another previously-returned item; should have no effect on either cursor.
+      await collection.remove('x09');
+      await checkNext(cursorId1, ['p07', 'r01']);
+      await store('m17');
+      await checkDone(cursorId1);
+
+      // Streaming again should be up-to-date (even with cursor2 still in flight).
+      await checkStream(12, ['i02', 'q04', 'h05', 'g08', 'o10', 'w12', 'e13', 'j14', 't15', 's16', 'm17']);
+
+      // [*] ---> so that this page is only removed items.
+      await checkNext(cursorId2, ['f11', 'y06', 'z03']);
+      await checkDone(cursorId2);
+
+      // Repeated next() calls on a finished cursor should be safe.
+      await checkDone(cursorId2);
+
+      // close() should terminate a stream.
+      let cursorId3 = await collection.stream(3);
+      await checkNext(cursorId3, ['i02', 'q04', 'h05']);
+      collection.cursorClose(cursorId3);
+      await checkDone(cursorId3);
+    }).timeout(20000);
+  });
+
+  // These tests use data manually added to our test firebase db.
+  describe('synthetic', () => {
+    function getKey(manifestName) {
+      let fbKey = testUrl.replace('firebase-storage-test', `synthetic-storage-data/${manifestName}`);
+      return `synthetic://arc/handles/${fbKey}`;
+    }
+
+    it.skip('simple test', async () => {
+      let storage = createStorage('arc-id');
+      let synth = await storage.connect(
+        'id1',
+        null,
+        getKey('simple-manifest')
+      );
+      let list = await synth.toList();
+      assert.equal(list.length, 1);
+      let handle = list[0];
+      assert.equal(handle.storageKey, 'firebase://xxx.firebaseio.com/yyy');
+      let type = handle.type.getContainedType();
+      assert(type && type.isEntity);
+      assert.equal(type.entitySchema.name, 'Thing');
+      assert.deepEqual(handle.tags, ['taggy']);
+    });
+
+    it.skip('error test', async () => {
+      let storage = createStorage('arc-id');
+      let synth1 = await storage.connect(
+        'not-there',
+        null,
+        getKey('not-there')
+      );
+      let list1 = await synth1.toList();
+      assert.isEmpty(list1, 'synthetic handle list should empty for non-existent storageKey');
+
+      let synth2 = await storage.connect(
+        'bad-manifest',
+        null,
+        getKey('bad-manifest')
+      );
+      let list2 = await synth2.toList();
+      assert.isEmpty(list2, 'synthetic handle list should empty for invalid manifests');
+
+      let synth3 = await storage.connect(
+        'no-recipe',
+        null,
+        getKey('no-recipe')
+      );
+      let list3 = await synth3.toList();
+      assert.isEmpty(list3, 'synthetic handle list should empty for manifests with no active recipe');
+
+      let synth4 = await storage.connect(
+        'no-handles',
+        null,
+        getKey('no-handles')
+      );
+      let list4 = await synth4.toList();
+      assert.isEmpty(list4, 'synthetic handle list should empty for manifests with no handles');
+    });
+
+    it.skip('large test', async () => {
+      let storage = createStorage('arc-id');
+      let synth = await storage.connect(
+        'id1',
+        null,
+        getKey('large-manifest')
+      );
+      let list = await synth.toList();
+      assert(list.length > 0, 'synthetic handle list should not be empty');
+      for (let item of list) {
+        assert(item.storageKey.startsWith('firebase:'));
+        assert(item.type.constructor.name == 'Type');
+        if (item.tags.length > 0) {
+          assert.isString(item.tags[0]);
+        }
+      }
+    });
+  });
+});

--- a/runtime/manual_tests/pouch-db-tests.js
+++ b/runtime/manual_tests/pouch-db-tests.js
@@ -8,13 +8,13 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import { StorageProviderFactory } from '../ts-build/storage/storage-provider-factory.js';
-import { Arc } from '../arc.js';
-import { Manifest } from '../manifest.js';
-import { Type } from '../ts-build/type.js';
+import {StorageProviderFactory} from '../ts-build/storage/storage-provider-factory.js';
+import {Arc} from '../arc.js';
+import {Manifest} from '../manifest.js';
+import {Type} from '../ts-build/type.js';
 import 'chai/register-assert';
 
-import { PouchDbStorage } from '../ts-build/storage/pouchdb/pouch-db-storage.js';
+import {PouchDbStorage} from '../ts-build/storage/pouchdb/pouch-db-storage.js';
 
 const testUrl = 'pouchdb://memory/user-test';
 
@@ -54,12 +54,12 @@ describe('pouchdb', function() {
         schema Bar
           Text value
       `);
-      let arc = new Arc({ id: 'test' });
+      let arc = new Arc({id: 'test'});
       let storage = createStorage(arc.id);
       let BarType = Type.newEntity(manifest.schemas.Bar);
       let value = 'Hi there' + Math.random();
       let variable = await storage.construct('test0', BarType, newStoreKey('variable'));
-      await variable.set({ id: 'test0:test', value });
+      await variable.set({id: 'test0:test', value});
       let result = await variable.get();
       assert.equal(result.value, value);
     });
@@ -69,7 +69,7 @@ describe('pouchdb', function() {
         schema Bar
           Text value
       `);
-      let arc = new Arc({ id: 'test' });
+      let arc = new Arc({id: 'test'});
       let storage = createStorage(arc.id);
       let BarType = Type.newEntity(manifest.schemas.Bar);
       let key = newStoreKey('variable');
@@ -82,8 +82,8 @@ describe('pouchdb', function() {
       );
       assert.isNotNull(var2);
 
-      await var1.set({ id: 'id1', value: 'value1' });
-      await var2.set({ id: 'id2', value: 'value2' });
+      await var1.set({id: 'id1', value: 'value1'});
+      await var2.set({id: 'id2', value: 'value2'});
       const v1 = await var1.get();
       const v2 = await var2.get();
       assert.deepEqual(v1, v2);
@@ -94,13 +94,13 @@ describe('pouchdb', function() {
           Text value
       `);
 
-      let arc = new Arc({ id: 'test' });
+      let arc = new Arc({id: 'test'});
       let storage = createStorage(arc.id);
       let BarType = Type.newEntity(manifest.schemas.Bar);
       let key1 = newStoreKey('varPtr');
 
       let var1 = await storage.construct('test0', BarType, key1);
-      await var1.set({ id: 'id1', value: 'underlying' });
+      await var1.set({id: 'id1', value: 'underlying'});
 
       let result = await var1.get();
       assert.equal(result.value, 'underlying');
@@ -116,13 +116,13 @@ describe('pouchdb', function() {
           Text value
       `);
 
-      let arc = new Arc({ id: 'test' });
+      let arc = new Arc({id: 'test'});
       let storage = createStorage(arc.id);
       let BarType = Type.newEntity(manifest.schemas.Bar);
       let key1 = newStoreKey('varPtr');
 
       let var1 = await storage.construct('test0', Type.newReference(BarType), key1);
-      await var1.set({ id: 'id1', storageKey: 'underlying' });
+      await var1.set({id: 'id1', storageKey: 'underlying'});
 
       let result = await var1.get();
       assert.equal('underlying', result.storageKey);
@@ -138,14 +138,14 @@ describe('pouchdb', function() {
         schema Bar
           Text value
       `);
-      let arc = new Arc({ id: 'test' });
+      let arc = new Arc({id: 'test'});
       let storage = createStorage(arc.id);
       let BarType = Type.newEntity(manifest.schemas.Bar);
       let value1 = 'Hi there' + Math.random();
       let value2 = 'Goodbye' + Math.random();
       let collection = await storage.construct('test1', BarType.collectionOf(), newStoreKey('collection'));
-      await collection.store({ id: 'test0:test0', value: value1 }, ['key0']);
-      await collection.store({ id: 'test0:test1', value: value2 }, ['key1']);
+      await collection.store({id: 'test0:test0', value: value1}, ['key0']);
+      await collection.store({id: 'test0:test1', value: value2}, ['key1']);
       let result = await collection.get('test0:test0');
       assert.equal(result.value, value1);
       result = await collection.toList();
@@ -161,7 +161,7 @@ describe('pouchdb', function() {
         schema Bar
           Text value
       `);
-      let arc = new Arc({ id: 'test' });
+      let arc = new Arc({id: 'test'});
       let storage = createStorage(arc.id);
       let BarType = Type.newEntity(manifest.schemas.Bar);
       let key = newStoreKey('collection');
@@ -171,8 +171,8 @@ describe('pouchdb', function() {
         BarType.collectionOf(),
         key
       );
-      const c1 = collection1.store({ id: 'id1', value: 'value' }, ['key3']);
-      await collection2.store({ id: 'id1', value: 'value' }, ['key4']);
+      const c1 = collection1.store({id: 'id1', value: 'value'}, ['key3']);
+      await collection2.store({id: 'id1', value: 'value'}, ['key4']);
       await c1;
       assert.deepEqual(await collection1.toList(), await collection2.toList());
     });
@@ -182,7 +182,7 @@ describe('pouchdb', function() {
         schema Bar
           Text value
       `);
-      let arc = new Arc({ id: 'test' });
+      let arc = new Arc({id: 'test'});
       let storage = createStorage(arc.id);
       let BarType = Type.newEntity(manifest.schemas.Bar);
       let key = newStoreKey('collection');
@@ -192,10 +192,7 @@ describe('pouchdb', function() {
         BarType.collectionOf(),
         key
       );
-      await Promise.all([
-        collection1.store({ id: 'id1', value: 'value' }, ['key1']),
-        collection2.store({ id: 'id1', value: 'value' }, ['key2'])
-      ]);
+      await Promise.all([collection1.store({id: 'id1', value: 'value'}, ['key1']), collection2.store({id: 'id1', value: 'value'}, ['key2'])]);
       await Promise.all([collection1.remove('id1', ['key1']), collection2.remove('id1', ['key2'])]);
       assert.isEmpty(await collection1.toList());
       assert.isEmpty(await collection2.toList());
@@ -205,7 +202,7 @@ describe('pouchdb', function() {
         schema Bar
           Text value
       `);
-      let arc = new Arc({ id: 'test' });
+      let arc = new Arc({id: 'test'});
       let storage = createStorage(arc.id);
       let BarType = Type.newEntity(manifest.schemas.Bar);
       let key = newStoreKey('collection');
@@ -215,8 +212,8 @@ describe('pouchdb', function() {
         BarType.collectionOf(),
         key
       );
-      await collection1.store({ id: 'id1', value: 'value1' }, ['key1']);
-      await collection2.store({ id: 'id2', value: 'value2' }, ['key2']);
+      await collection1.store({id: 'id1', value: 'value1'}, ['key1']);
+      await collection2.store({id: 'id2', value: 'value2'}, ['key2']);
       assert.lengthOf(await collection1.toList(), 2);
       assert.sameDeepMembers(await collection1.toList(), await collection2.toList());
     });
@@ -226,15 +223,15 @@ describe('pouchdb', function() {
           Text value
       `);
 
-      let arc = new Arc({ id: 'test' });
+      let arc = new Arc({id: 'test'});
       let storage = createStorage(arc.id);
       let BarType = Type.newEntity(manifest.schemas.Bar);
       let key1 = newStoreKey('colPtr');
 
       let collection1 = await storage.construct('test0', BarType.collectionOf(), key1);
 
-      await collection1.store({ id: 'id1', value: 'value1' }, ['key1']);
-      await collection1.store({ id: 'id2', value: 'value2' }, ['key2']);
+      await collection1.store({id: 'id1', value: 'value1'}, ['key1']);
+      await collection1.store({id: 'id2', value: 'value2'}, ['key2']);
 
       let result = await collection1.get('id1');
       assert.equal('value1', result.value);
@@ -253,15 +250,15 @@ describe('pouchdb', function() {
           Text value
       `);
 
-      let arc = new Arc({ id: 'test' });
+      let arc = new Arc({id: 'test'});
       let storage = createStorage(arc.id);
       let BarType = Type.newEntity(manifest.schemas.Bar);
       let key1 = newStoreKey('colPtr');
 
       let collection1 = await storage.construct('test0', Type.newReference(BarType).collectionOf(), key1);
 
-      await collection1.store({ id: 'id1', storageKey: 'value1' }, ['key1']);
-      await collection1.store({ id: 'id2', storageKey: 'value2' }, ['key2']);
+      await collection1.store({id: 'id1', storageKey: 'value1'}, ['key1']);
+      await collection1.store({id: 'id2', storageKey: 'value2'}, ['key2']);
 
       let result = await collection1.get('id1');
       assert.equal('value1', result.storageKey);

--- a/runtime/ts/storage/crdt-collection-model.ts
+++ b/runtime/ts/storage/crdt-collection-model.ts
@@ -17,10 +17,10 @@ import {assert} from '../../../platform/assert-web.js';
 // Note: This implementation does not guard against the case of the
 // same membership key being added more than once. Don't do that.
 
-interface Model {
+export interface Model {
   id: string;
   value: {};
-  keys: [];
+  keys: string[];
 }
 
 export class CrdtCollectionModel {

--- a/runtime/ts/storage/pouchdb/README.md
+++ b/runtime/ts/storage/pouchdb/README.md
@@ -1,0 +1,13 @@
+# PouchDB Storage Subsystem
+
+This code allows for data to be stored in [PouchDB](https://pouchdb.com).
+
+## Keys
+
+## Variables/Collections
+
+## Replication
+
+## Caveats
+
+- Big Collections are not supported yet.

--- a/runtime/ts/storage/pouchdb/pouch-db-big-collection.ts
+++ b/runtime/ts/storage/pouchdb/pouch-db-big-collection.ts
@@ -1,5 +1,5 @@
-import { PouchDbStorageProvider } from './pouch-db-storage-provider';
-import { assert } from '../../../../platform/assert-web.js';
+import {PouchDbStorageProvider} from './pouch-db-storage-provider';
+import {assert} from '../../../../platform/assert-web.js';
 
 // TODO(lindner): update to operate like the firebase version
 export class PouchDbBigCollection extends PouchDbStorageProvider {

--- a/runtime/ts/storage/pouchdb/pouch-db-big-collection.ts
+++ b/runtime/ts/storage/pouchdb/pouch-db-big-collection.ts
@@ -1,0 +1,38 @@
+import { PouchDbStorageProvider } from './pouch-db-storage-provider';
+import { assert } from '../../../../platform/assert-web.js';
+
+// TODO(lindner): update to operate like the firebase version
+export class PouchDbBigCollection extends PouchDbStorageProvider {
+  constructor(type, storageEngine, name, id, key) {
+    super(type, storageEngine, name, id, key);
+  }
+
+  backingType() {
+    return this.type.primitiveType();
+  }
+
+  async get(id) {
+    throw new Error('NotImplemented');
+  }
+
+  async store(value, keys, originatorId) {
+    assert(keys != null && keys.length > 0, 'keys required');
+    throw new Error('NotImplemented');
+  }
+
+  async remove(id, keys, originatorId) {
+    throw new Error('NotImplemented');
+  }
+
+  toLiteral() {
+    throw new Error('NotImplemented');
+  }
+
+  /**
+   * Triggered when the storage key has been modified.  For now we
+   * just refetch.  This is fast since the data is synced locally.
+   */
+  onRemoteStateSynced() {
+    throw new Error('NotImplemented');
+  }
+}

--- a/runtime/ts/storage/pouchdb/pouch-db-collection.ts
+++ b/runtime/ts/storage/pouchdb/pouch-db-collection.ts
@@ -1,0 +1,358 @@
+import { CrdtCollectionModel, Model } from '../crdt-collection-model.js';
+import { Tracing } from '../../../../tracelib/trace.js';
+import { assert } from '../../../../platform/assert-web.js';
+import { PouchDbStorageProvider } from './pouch-db-storage-provider.js';
+import { Type } from '../../type.js';
+import { PouchDbStorage } from './pouch-db-storage';
+
+/**
+ * Defines a callback interface to allow for modifying a
+ * CrdtCollectionModel during a get/modify/set cycle.
+ */
+
+interface CrdtCollectionModelMutator {
+  (crdt: CrdtCollectionModel): CrdtCollectionModel;
+}
+
+export class PouchDbCollection extends PouchDbStorageProvider {
+  /** The local synced model */
+  private _model: CrdtCollectionModel; // NOTE: Private, but outside code accesses this :(
+
+  /**
+   * Create a new PouchDbCollection.
+   *
+   * @param type the underlying type for this collection.
+   * @param storageEngine a reference back to the PouchDbStorage, used for baseStorageKey calls.
+   * @param name appears unused.
+   * @param id see base class.
+   * @param key the storage key for this collection.
+   */
+  constructor(type: Type, storageEngine: PouchDbStorage, name: string, id: string, key: string) {
+    super(type, storageEngine, name, id, key);
+
+    this._model = new CrdtCollectionModel();
+    assert(this.version !== null);
+  }
+
+  /** @inheritDoc */
+  backingType() {
+    return this.type.primitiveType();
+  }
+
+  // TODO(lindner): appears unused
+  // clone() {
+  //   const handle = new PouchDbCollection(this.type, this.storageEngine, this.name, this.id, null);
+  //   handle.cloneFrom(this);
+  //   return handle;
+  // }
+
+  async cloneFrom(handle) {
+    this.referenceMode = handle.referenceMode;
+    const literal = await handle.toLiteral();
+    if (this.referenceMode && literal.model.length > 0) {
+      await Promise.all([this.ensureBackingStore(), handle.ensureBackingStore()]);
+      literal.model = literal.model.map(({ id, value }) => ({ id, value: { id: value.id, storageKey: this.backingStore.storageKey } }));
+      const underlying = await handle.backingStore.getMultiple(literal.model.map(({ id }) => id));
+      await this.backingStore.storeMultiple(underlying, [this.storageKey]);
+    }
+    this.fromLiteral(literal);
+  }
+
+  /** @inheritDoc */
+  async modelForSynchronization() {
+    // TODO(lindner): should this change for reference mode??
+    return {
+      version: this.version,
+      model: await this._toList()
+    };
+  }
+
+  /** @inheritDoc */
+  // Returns {version, model: [{id, value, keys: []}]}
+  // TODO(lindner): this is async, but the base class isn't....
+  async toLiteral() {
+    return {
+      version: this.version,
+      model: (await this.getModel()).toLiteral()
+    };
+  }
+
+  /**
+   * Populate this collection with a provided version/model
+   */
+  fromLiteral({ version, model }) {
+    this.version = version;
+    // TODO(lindner): this might not be initialized yet...
+    this._model = new CrdtCollectionModel(model);
+  }
+
+  async _toList() {
+    if (this.referenceMode) {
+      const items = (await this.getModel()).toLiteral();
+      if (items.length === 0) {
+        return [];
+      }
+      const refSet = new Set();
+      items.forEach(item => refSet.add(item.value.storageKey));
+      assert(refSet.size === 1, `multiple storageKeys in reference set of collection not yet supported.`);
+      const ref = refSet.values().next().value;
+
+      await this.ensureBackingStore();
+
+      const retrieveItem = async item => {
+        const ref = item.value;
+        return { id: ref.id, value: await this.backingStore.get(ref.id), keys: item.keys };
+      };
+
+      return await Promise.all(items.map(retrieveItem));
+    }
+    return (await this.getModel()).toLiteral();
+  }
+
+  async toList() {
+    return (await this._toList()).map(item => item.value);
+  }
+
+  /**
+   * Returns an array of values for each of the specified ids.
+   *
+   * @param ids items to fetch from the underlying CRDT model.
+   * @return an array of values from the underlying CRDT
+   */
+  async getMultiple(ids: string[]) {
+    assert(!this.referenceMode, 'getMultiple not implemented for referenceMode stores');
+    const model = await this.getModel();
+    return ids.map(id => model.getValue(id));
+  }
+
+  /**
+   * Store multiple values with the given keys in the Collection.
+   * TODO(lindner): document originatorId, which is unused.
+   */
+  async storeMultiple(values, keys, originatorId = null) {
+    assert(!this.referenceMode, 'storeMultiple not implemented for referenceMode stores');
+
+    this.getModelAndUpdate(crdtmodel => {
+      values.map(value => crdtmodel.add(value.id, value, keys));
+      return crdtmodel;
+    });
+  }
+
+  /**
+   * Get a specific Id value previously set using store().
+   *
+   * @remarks Note that the id referred to here is not the same as
+   * used in the constructor.
+   */
+  async get(id) {
+    if (this.referenceMode) {
+      const ref = (await this.getModel()).getValue(id);
+      if (ref == null) {
+        return null;
+      }
+      await this.ensureBackingStore();
+      const result = await this.backingStore.get(ref.id);
+      return result;
+    }
+
+    const model = await this.getModel();
+    return model.getValue(id);
+  }
+
+  /**
+   * Store the specific value to the collection.  Value must include an id entry.
+   *
+   * @param value A data object with an id entry that is used as a key.
+   * @param keys The CRDT keys used to store this object
+   * @param orginatorId TBD passed to event listeners
+   */
+  async store(value, keys: string[], originatorId = null): Promise<void> {
+    assert(keys != null && keys.length > 0, 'keys required');
+    const id = value.id;
+
+    const changeEvent = { value, keys, effective: undefined };
+
+    if (this.referenceMode) {
+      const referredType = this.type.primitiveType();
+      const storageKey = this.storageEngine.baseStorageKey(referredType, this.storageKey);
+
+      // Update the referred data
+      await this.getModelAndUpdate(crdtmodel => {
+        changeEvent.effective = crdtmodel.add(value.id, { id: value.id, storageKey }, keys);
+        return crdtmodel;
+      });
+
+      await this.ensureBackingStore();
+      await this.backingStore.store(value, keys);
+    } else {
+      await this.getModelAndUpdate(crdtmodel => {
+        // check for existing keys?
+        changeEvent.effective = crdtmodel.add(value.id, value, keys);
+        return crdtmodel;
+      });
+    }
+
+    this.version++;
+
+    // 2. Notify Listeners
+    this._fire('change', { add: [changeEvent], version: this.version, originatorId });
+  }
+
+  /**
+   * Remove ids from a collection for specific keys.
+   * @param id the id to remove.
+   * @param keys the CRDT specific keys to remove.
+   * @param originatorId TBD passed to event listeners.
+   */
+  async remove(id, keys: string[] = [], originatorId = null) {
+    await this.getModelAndUpdate(crdtmodel => {
+      if (keys.length === 0) {
+        keys = crdtmodel.getKeys(id);
+      }
+      const value = crdtmodel.getValue(id);
+
+      if (value !== null) {
+        const effective = crdtmodel.remove(id, keys);
+        // TODO(lindner): isolate side effects...
+        this.version++;
+        this._fire('change', { remove: [{ value, keys, effective }], version: this.version, originatorId });
+      }
+      return crdtmodel;
+    });
+  }
+
+  /**
+   * Triggered when the storage key has been modified.  For now we
+   * just refetch and trigger listeners.  This is fast since the data
+   * is synced locally.
+   */
+  public onRemoteStateSynced() {
+    // updates internal state
+    this.getModel();
+  }
+
+  /**
+   * Updates the local model cache from PouchDB and returns the CRDT
+   * model for use.
+   */
+  private async getModel(): Promise<CrdtCollectionModel> {
+    try {
+      const result = await this.db.get(this.pouchDbKey.location);
+
+      // compare revisions
+      if (this._rev !== result._rev) {
+        // remote revision is different, update local copy.
+        this._model = new CrdtCollectionModel(result['model']);
+        this._rev = result._rev;
+        this.version++; // yuck.
+        // TODO(lindner): fire change events here?
+      }
+    } catch (err) {
+      this._model = new CrdtCollectionModel();
+      this._rev = undefined;
+      // TODO(lindner): throw
+    }
+    return this._model;
+  }
+
+  /**
+   * Provides a way to apply changes to the model in a way that will result in the
+   * crdt being written to the underlying PouchDB.
+   *
+   * - A new entry is stored if it doesn't exists.
+   * - If the existing entry is available it is fetched and the
+   *   internal state is updated.
+   * - A copy of the CRDT model is passed to the modelMutator, which may change it.
+   * - If the model is mutated by `modelMutator`, write a new revision and update the local
+   *   cached copy.
+   *
+   * @param modelMutator allows for modifying a copy of the underlying crdt model.
+   */
+  private async getModelAndUpdate(modelMutator: CrdtCollectionModelMutator): Promise<CrdtCollectionModel> {
+    // Keep retrying the operation until it succeeds.
+    while (1) {
+      let doc;
+      //: PouchDB.Core.IdMeta & PouchDB.Core.GetMeta & Model & {referenceMode: boolean, type: {}};
+
+      let notFound = false;
+      try {
+        doc = await this.db.get(this.pouchDbKey.location);
+        // as PouchDB.Core.IdMeta & PouchDB.Core.GetMeta & Model & {referenceMode: boolean, type: };
+
+        // Check remote doc.
+        // TODO(lindner): refactor with getModel above.
+        if (this._rev !== doc._rev) {
+          // remote revision is different, update local copy.
+          this._model = new CrdtCollectionModel(doc['model']);
+          this._rev = doc._rev;
+          this.version++; // yuck.
+          // TODO(lindner): fire change events here?
+        }
+      } catch (err) {
+        if (err.name !== 'not_found') {
+          throw err;
+        }
+        notFound = true;
+        // setup basic doc, model/version updated below.
+        doc = {
+          _id: this.pouchDbKey.location,
+          referenceMode: this.referenceMode,
+          type: this.type.toLiteral()
+        };
+      }
+
+      // Run the mutator on a copy of the existing model
+      const newModel = modelMutator(new CrdtCollectionModel(this._model.toLiteral()));
+
+      // Check if the mutator made any changes..
+      if (!notFound && JSON.stringify(this._model.toLiteral()) === JSON.stringify(newModel.toLiteral())) {
+        // mutator didn't make any changes.
+        return this._model;
+      }
+
+      // Apply changes made by the mutator
+      doc['model'] = newModel.toLiteral();
+      doc['version'] = this.version;
+
+      // Update on pouchdb
+      try {
+        const putResult = await this.db.put(doc);
+
+        // success! update local with new model
+        this._rev = putResult.rev;
+        this._model = newModel;
+
+        return this._model;
+      } catch (err) {
+        if (err.name === 'conflict') {
+          // keep trying;
+        } else {
+          // failed to write new doc, give up.
+          console.warn('PouchDbCollection.getModelAndUpdate (err,doc)=', err, doc);
+          throw err;
+        }
+      }
+    } // end while (1)
+
+    // can never get here..
+    return null;
+  }
+
+  /**
+   * Remove this item from the database for testing purposes.
+   */
+  async clearItemsForTesting() {
+    // Remove the Pouch Document
+    // TODO(lindner): does this need to work with reference mode?
+    try {
+      const doc = await this.db.get(this.pouchDbKey.location);
+      await this.db.remove(doc);
+    } catch (err) {
+      if (err.name !== 'not_found') {
+        console.log('clearItemsForTesting: error removing', err);
+      }
+    }
+    this._model = new CrdtCollectionModel();
+    this._rev = undefined;
+  }
+}

--- a/runtime/ts/storage/pouchdb/pouch-db-collection.ts
+++ b/runtime/ts/storage/pouchdb/pouch-db-collection.ts
@@ -1,9 +1,9 @@
-import { CrdtCollectionModel, Model } from '../crdt-collection-model.js';
-import { Tracing } from '../../../../tracelib/trace.js';
-import { assert } from '../../../../platform/assert-web.js';
-import { PouchDbStorageProvider } from './pouch-db-storage-provider.js';
-import { Type } from '../../type.js';
-import { PouchDbStorage } from './pouch-db-storage';
+import {CrdtCollectionModel, Model} from '../crdt-collection-model.js';
+import {Tracing} from '../../../../tracelib/trace.js';
+import {assert} from '../../../../platform/assert-web.js';
+import {PouchDbStorageProvider} from './pouch-db-storage-provider.js';
+import {Type} from '../../type.js';
+import {PouchDbStorage} from './pouch-db-storage';
 
 /**
  * Defines a callback interface to allow for modifying a
@@ -51,8 +51,8 @@ export class PouchDbCollection extends PouchDbStorageProvider {
     const literal = await handle.toLiteral();
     if (this.referenceMode && literal.model.length > 0) {
       await Promise.all([this.ensureBackingStore(), handle.ensureBackingStore()]);
-      literal.model = literal.model.map(({ id, value }) => ({ id, value: { id: value.id, storageKey: this.backingStore.storageKey } }));
-      const underlying = await handle.backingStore.getMultiple(literal.model.map(({ id }) => id));
+      literal.model = literal.model.map(({id, value}) => ({id, value: {id: value.id, storageKey: this.backingStore.storageKey}}));
+      const underlying = await handle.backingStore.getMultiple(literal.model.map(({id}) => id));
       await this.backingStore.storeMultiple(underlying, [this.storageKey]);
     }
     this.fromLiteral(literal);
@@ -80,7 +80,7 @@ export class PouchDbCollection extends PouchDbStorageProvider {
   /**
    * Populate this collection with a provided version/model
    */
-  fromLiteral({ version, model }) {
+  fromLiteral({version, model}) {
     this.version = version;
     // TODO(lindner): this might not be initialized yet...
     this._model = new CrdtCollectionModel(model);
@@ -101,7 +101,7 @@ export class PouchDbCollection extends PouchDbStorageProvider {
 
       const retrieveItem = async item => {
         const ref = item.value;
-        return { id: ref.id, value: await this.backingStore.get(ref.id), keys: item.keys };
+        return {id: ref.id, value: await this.backingStore.get(ref.id), keys: item.keys};
       };
 
       return await Promise.all(items.map(retrieveItem));
@@ -170,7 +170,7 @@ export class PouchDbCollection extends PouchDbStorageProvider {
     assert(keys != null && keys.length > 0, 'keys required');
     const id = value.id;
 
-    const changeEvent = { value, keys, effective: undefined };
+    const changeEvent = {value, keys, effective: undefined};
 
     if (this.referenceMode) {
       const referredType = this.type.primitiveType();
@@ -178,7 +178,7 @@ export class PouchDbCollection extends PouchDbStorageProvider {
 
       // Update the referred data
       await this.getModelAndUpdate(crdtmodel => {
-        changeEvent.effective = crdtmodel.add(value.id, { id: value.id, storageKey }, keys);
+        changeEvent.effective = crdtmodel.add(value.id, {id: value.id, storageKey}, keys);
         return crdtmodel;
       });
 
@@ -195,7 +195,7 @@ export class PouchDbCollection extends PouchDbStorageProvider {
     this.version++;
 
     // Notify Listeners
-    this._fire('change', { add: [changeEvent], version: this.version, originatorId });
+    this._fire('change', {add: [changeEvent], version: this.version, originatorId});
   }
 
   /**
@@ -215,7 +215,7 @@ export class PouchDbCollection extends PouchDbStorageProvider {
         const effective = crdtmodel.remove(id, keys);
         // TODO(lindner): isolate side effects...
         this.version++;
-        this._fire('change', { remove: [{ value, keys, effective }], version: this.version, originatorId });
+        this._fire('change', {remove: [{value, keys, effective}], version: this.version, originatorId});
       }
       return crdtmodel;
     });
@@ -253,7 +253,7 @@ export class PouchDbCollection extends PouchDbStorageProvider {
         this._rev = undefined;
       }
       // Unexpected error
-      console.warn("PouchDbCollection.getModel err=", err);
+      console.warn('PouchDbCollection.getModel err=', err);
       throw err;
     }
     return this._model;

--- a/runtime/ts/storage/pouchdb/pouch-db-key.ts
+++ b/runtime/ts/storage/pouchdb/pouch-db-key.ts
@@ -6,8 +6,8 @@
 // subject to an additional IP rights grant found at
 // http://polymer.github.io/PATENTS.txt
 
-import { assert } from '../../../../platform/assert-web.js';
-import { KeyBase } from '../key-base.js';
+import {assert} from '../../../../platform/assert-web.js';
+import {KeyBase} from '../key-base.js';
 
 /**
  * Keys for PouchDb entities.  A pouchdb key looks like a url. of the following form:

--- a/runtime/ts/storage/pouchdb/pouch-db-key.ts
+++ b/runtime/ts/storage/pouchdb/pouch-db-key.ts
@@ -6,8 +6,8 @@
 // subject to an additional IP rights grant found at
 // http://polymer.github.io/PATENTS.txt
 
-import {assert} from '../../../../platform/assert-web.js';
-import {KeyBase} from '../key-base.js';
+import { assert } from '../../../../platform/assert-web.js';
+import { KeyBase } from '../key-base.js';
 
 /**
  * Keys for PouchDb entities.  A pouchdb key looks like a url. of the following form:
@@ -15,14 +15,14 @@ import {KeyBase} from '../key-base.js';
  *    pouchdb://{dblocation}/{dbname}/{location}
  *
  * The scheme is pouchdb, followed by the database location which can be:
- * 
+ *
  * - memory (stores in local memory)
- * - local (persistant stored in IDB (browser) or LevelDB (node) 
+ * - local (persistant stored in IDB (browser) or LevelDB (node)
  * - a hostname (stores on the remote host)
- * 
+ *
  * A slash separated database name and key location then follow.
  * The default for dblocation is 'memory' and the default dbname is 'user'.
- * 
+ *
  * Some sample keys
  *
  * - pouchdb://memory/user/nice/long-storage-key
@@ -33,18 +33,19 @@ export class PouchDbKey extends KeyBase {
   readonly dbLocation: string;
   readonly dbName: string;
   location: string;
-  
+
   constructor(key: string) {
     super();
 
     assert(key.startsWith('pouchdb://'), `can't construct pouchdb key for input key ${key}`);
 
     const parts = key.replace(/^pouchdb:\/\//, '').split('/');
+    this.protocol = 'pouchdb';
     this.dbLocation = parts[0] || 'memory';
     this.dbName = parts[1] || 'user';
     this.location = parts.slice(2).join('/') || '';
 
-    assert(this.toString() === key, 'PouchDb keys must match ' + this.toString() + ' vs '+ key);
+    assert(this.toString() === key, 'PouchDb keys must match ' + this.toString() + ' vs ' + key);
   }
 
   /**
@@ -61,7 +62,7 @@ export class PouchDbKey extends KeyBase {
 
     const newKey = new PouchDbKey(this.toString());
     newKey.location = location;
-    
+
     return newKey;
   }
 

--- a/runtime/ts/storage/pouchdb/pouch-db-storage-provider.ts
+++ b/runtime/ts/storage/pouchdb/pouch-db-storage-provider.ts
@@ -53,14 +53,11 @@ export abstract class PouchDbStorageProvider extends StorageProviderBase {
    * The active database for this provider.
    */
   protected get db(): PouchDB.Database {
-    // TODO(lindner) vary the db by the storage key
     return this.storageEngine.dbForKey(this.pouchDbKey);
   }
 
   /**
    * Called when the remote pouchdb server updates locally.
-   * TODO(lindner): pass in the pouchdb doc since it's in the change
-   * request.
    */
   public abstract onRemoteStateSynced();
 }

--- a/runtime/ts/storage/pouchdb/pouch-db-storage-provider.ts
+++ b/runtime/ts/storage/pouchdb/pouch-db-storage-provider.ts
@@ -1,0 +1,66 @@
+import { StorageProviderBase } from '../storage-provider-base.js';
+
+import { PouchDbCollection } from './pouch-db-collection.js';
+import { PouchDbStorage } from './pouch-db-storage.js';
+import { PouchDbKey } from './pouch-db-key.js';
+import { Type } from '../../type.js';
+
+/**
+ * Base class for PouchDb related Storage classes
+ * (PouchDbVariable/PouchDbCollection)
+ */
+export abstract class PouchDbStorageProvider extends StorageProviderBase {
+  /** The Storage Engine instance we were initialized with */
+  protected storageEngine: PouchDbStorage;
+
+  // Manages backing store
+  protected backingStore: PouchDbCollection | null = null;
+  private pendingBackingStore: Promise<PouchDbCollection> | null = null;
+
+  /** The PouchDbKey for this Collection */
+  protected readonly pouchDbKey: PouchDbKey;
+  /** The Pouch revision of the data we have stored locally */
+  protected _rev: string | undefined;
+
+  constructor(type: Type, storageEngine: PouchDbStorage, name: string, id: string, key: string) {
+    super(type, name, id, key);
+    this.storageEngine = storageEngine;
+    this.pouchDbKey = new PouchDbKey(key);
+  }
+
+  // A consequence of awaiting this function is that this.backingStore
+  // is guaranteed to exist once the await completes. This is because
+  // if backingStore doesn't yet exist, the assignment in the then()
+  // is guaranteed to execute before anything awaiting this function.
+  async ensureBackingStore() {
+    if (this.backingStore) {
+      return this.backingStore;
+    }
+    if (!this.pendingBackingStore) {
+      const key = this.storageEngine.baseStorageKey(this.backingType(), this.storageKey);
+      this.pendingBackingStore = this.storageEngine.baseStorageFor(this.type, key);
+      this.pendingBackingStore.then(backingStore => (this.backingStore = backingStore));
+    }
+    return this.pendingBackingStore;
+  }
+
+  /**
+   * The underlying type for the data.
+   */
+  abstract backingType(): Type;
+
+  /**
+   * The active database for this provider.
+   */
+  protected get db(): PouchDB.Database {
+    // TODO(lindner) vary the db by the storage key
+    return this.storageEngine.dbForKey(this.pouchDbKey);
+  }
+
+  /**
+   * Called when the remote pouchdb server updates locally.
+   * TODO(lindner): pass in the pouchdb doc since it's in the change
+   * request.
+   */
+  public abstract onRemoteStateSynced();
+}

--- a/runtime/ts/storage/pouchdb/pouch-db-storage-provider.ts
+++ b/runtime/ts/storage/pouchdb/pouch-db-storage-provider.ts
@@ -1,9 +1,9 @@
-import { StorageProviderBase } from '../storage-provider-base.js';
+import {StorageProviderBase} from '../storage-provider-base.js';
 
-import { PouchDbCollection } from './pouch-db-collection.js';
-import { PouchDbStorage } from './pouch-db-storage.js';
-import { PouchDbKey } from './pouch-db-key.js';
-import { Type } from '../../type.js';
+import {PouchDbCollection} from './pouch-db-collection.js';
+import {PouchDbStorage} from './pouch-db-storage.js';
+import {PouchDbKey} from './pouch-db-key.js';
+import {Type} from '../../type.js';
 
 /**
  * Base class for PouchDb related Storage classes

--- a/runtime/ts/storage/pouchdb/pouch-db-storage.ts
+++ b/runtime/ts/storage/pouchdb/pouch-db-storage.ts
@@ -6,15 +6,15 @@
 // subject to an additional IP rights grant found at
 // http://polymer.github.io/PATENTS.txt
 
-import { assert } from '../../../../platform/assert-web.js';
-import { StorageBase, StorageProviderBase } from '../storage-provider-base.js';
-import { PouchDbKey } from './pouch-db-key.js';
-import { Id } from '../../id.js';
-import { Type } from '../../type.js';
-import { PouchDbCollection } from './pouch-db-collection.js';
-import { PouchDbStorageProvider } from './pouch-db-storage-provider.js';
-import { PouchDbBigCollection } from './pouch-db-big-collection.js';
-import { PouchDbVariable } from './pouch-db-variable.js';
+import {assert} from '../../../../platform/assert-web.js';
+import {StorageBase, StorageProviderBase} from '../storage-provider-base.js';
+import {PouchDbKey} from './pouch-db-key.js';
+import {Id} from '../../id.js';
+import {Type} from '../../type.js';
+import {PouchDbCollection} from './pouch-db-collection.js';
+import {PouchDbStorageProvider} from './pouch-db-storage-provider.js';
+import {PouchDbBigCollection} from './pouch-db-big-collection.js';
+import {PouchDbVariable} from './pouch-db-variable.js';
 
 import PouchDB from 'pouchdb';
 import PouchDbMemory from 'pouchdb-adapter-memory';
@@ -135,10 +135,10 @@ export class PouchDbStorage extends StorageBase {
   static async resetPouchDbStorageForTesting() {
     for (const db of PouchDbStorage.dbLocationToInstance.values()) {
       await db
-        .allDocs({ include_docs: true })
+        .allDocs({include_docs: true})
         .then(allDocs => {
           return allDocs.rows.map(row => {
-            return { _id: row.id, _rev: row.doc._rev, _deleted: true };
+            return {_id: row.id, _rev: row.doc._rev, _deleted: true};
           });
         })
         .then(deleteDocs => {
@@ -163,7 +163,7 @@ export class PouchDbStorage extends StorageBase {
       db = new PouchDB(key.dbName);
     } else if (key.dbLocation === 'memory') {
       PouchDB.plugin(PouchDbMemory);
-      db = new PouchDB(key.dbName, { adapter: 'memory' });
+      db = new PouchDB(key.dbName, {adapter: 'memory'});
     } else {
       // Create a local db to sync to the remote
       db = new PouchDB(key.dbName);
@@ -205,7 +205,7 @@ export class PouchDbStorage extends StorageBase {
   private setupSync(localDb: PouchDB.Database, remoteDb: PouchDB.Database) {
     console.log('Replicating DBs');
 
-    const syncHandler = localDb.sync(remoteDb, { live: true, retry: true });
+    const syncHandler = localDb.sync(remoteDb, {live: true, retry: true});
 
     // Handle inbound changes.
     syncHandler.on('change', info => {

--- a/runtime/ts/storage/pouchdb/pouch-db-storage.ts
+++ b/runtime/ts/storage/pouchdb/pouch-db-storage.ts
@@ -1,0 +1,252 @@
+// @
+// Copyright (c) 2017 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+import { assert } from '../../../../platform/assert-web.js';
+import { StorageBase, StorageProviderBase } from '../storage-provider-base.js';
+import { PouchDbKey } from './pouch-db-key.js';
+import { Id } from '../../id.js';
+import { Type } from '../../type.js';
+import { PouchDbCollection } from './pouch-db-collection.js';
+import { PouchDbStorageProvider } from './pouch-db-storage-provider.js';
+import { PouchDbBigCollection } from './pouch-db-big-collection.js';
+import { PouchDbVariable } from './pouch-db-variable.js';
+
+import PouchDB from 'pouchdb';
+import PouchDbMemory from 'pouchdb-adapter-memory';
+
+export class PouchDbStorage extends StorageBase {
+  // TODO(lindner) add global weak map of keys and handle replication events.
+  private readonly remoteStateChangedHandlers: Map<string, PouchDbStorageProvider> = new Map();
+
+  // Used for reference mode
+  private readonly baseStores: Map<Type, PouchDbCollection> = new Map();
+  private readonly baseStorePromises: Map<Type, Promise<PouchDbCollection>> = new Map();
+  private localIDBase: number;
+
+  /** Global map of database types/name to Pouch Database Instances */
+  private static dbLocationToInstance: Map<string, PouchDB.Database> = new Map();
+
+  /** Tracks replication status and allows cancellation in tests */
+  private static syncHandler: PouchDB.Replication.Sync<{}> | undefined;
+
+  constructor(arcId: Id) {
+    super(arcId);
+    this.localIDBase = 0;
+  }
+
+  /**
+   * Instantiates a new key for id/type stored at keyFragment.
+   */
+  async construct(id: string, type: Type, keyFragment: string): Promise<PouchDbStorageProvider> {
+    const provider = await this._construct(id, type, keyFragment);
+    if (type.isReference) {
+      return provider;
+    }
+    if (type.isTypeContainer() && type.getContainedType().isReference) {
+      return provider;
+    }
+    provider.enableReferenceMode();
+    return provider;
+  }
+
+  async _construct(id: string, type: Type, keyFragment: string) {
+    const key = new PouchDbKey(keyFragment);
+    const keystr = key.toString();
+
+    const provider = this.newProvider(type, undefined, id, key.toString());
+
+    // Used to track changes for the key.
+    this.remoteStateChangedHandlers.set(key.location, provider);
+
+    return provider;
+  }
+
+  /**
+   * Connect with an existing storage key.  Returns a cached instance if available.
+   * Returns null if no such storage key exists.
+   */
+  async connect(id: string, type: Type, key: string): Promise<PouchDbStorageProvider> {
+    const imKey = new PouchDbKey(key);
+
+    // TODO(lindner): fail if not created.
+    return this.construct(id, type, key);
+  }
+
+  /** Unit tests should call this in an 'after' block. */
+  shutdown() {
+    // Stop syncing
+    if (PouchDbStorage.syncHandler) {
+      PouchDbStorage.syncHandler.cancel();
+    }
+    // Close databases
+    for (const db of PouchDbStorage.dbLocationToInstance.values()) {
+      db.close();
+    }
+    PouchDbStorage.dbLocationToInstance.clear();
+  }
+
+  /** @inheritDoc */
+  baseStorageKey(type: Type, keyString: string): string {
+    const key = new PouchDbKey(keyString);
+    key.location = `backingStores/${type.toString()}`;
+    return key.toString();
+  }
+
+  /** @inheritDoc */
+  async baseStorageFor(type: Type, key: string) {
+    if (this.baseStores.has(type)) {
+      return this.baseStores.get(type);
+    }
+    if (this.baseStorePromises.has(type)) {
+      return this.baseStorePromises.get(type);
+    }
+
+    const storagePromise = this._construct(type.toString(), type.collectionOf(), key) as Promise<PouchDbCollection>;
+
+    this.baseStorePromises.set(type, storagePromise);
+    const storage = await storagePromise;
+    assert(storage, 'baseStorageFor should not fail');
+    this.baseStores.set(type, storage);
+    return storage;
+  }
+
+  /** @inheritDoc */
+  parseStringAsKey(s: string): PouchDbKey {
+    return new PouchDbKey(s);
+  }
+
+  /** Ceates a new Variable or Colleciton given basic parameters */
+  newProvider(type: Type, name, id, key): PouchDbStorageProvider {
+    if (type.isCollection) {
+      return new PouchDbCollection(type, this, name, id, key);
+    }
+    if (type.isBigCollection) {
+      return new PouchDbBigCollection(type, this, name, id, key);
+    }
+    return new PouchDbVariable(type, this, name, id, key);
+  }
+
+  /** Removes everything that a test could have created. */
+  static async resetPouchDbStorageForTesting() {
+    console.log('RESET storage for testing');
+    for (const db of PouchDbStorage.dbLocationToInstance.values()) {
+      await db
+        .allDocs({ include_docs: true })
+        .then(allDocs => {
+          return allDocs.rows.map(row => {
+            console.log('- deleting ' + row.id + ' ' + row.doc._rev);
+            return { _id: row.id, _rev: row.doc._rev, _deleted: true };
+          });
+        })
+        .then(deleteDocs => {
+          return db.bulkDocs(deleteDocs);
+        });
+    }
+  }
+
+  /**
+   * Returns a database for the specific dbLocation/dbName of PouchDbKey and caches it.
+   * @param key the PouchDbKey used to obtain the cache key.
+   */
+  public dbForKey(key: PouchDbKey): PouchDB.Database {
+    let db = PouchDbStorage.dbLocationToInstance.get(key.dbCacheKey());
+
+    if (db) {
+      return db;
+    }
+
+    // New connect to a database
+    if (key.dbLocation === 'local') {
+      db = new PouchDB(key.dbName);
+    } else if (key.dbLocation === 'memory') {
+      PouchDB.plugin(PouchDbMemory);
+      db = new PouchDB(key.dbName, { adapter: 'memory' });
+    } else {
+      // Create a local db to sync to the remote
+      db = new PouchDB(key.dbName);
+
+      // Ensure a secure origin, http is okay for localhost, but other hosts need https
+      const httpScheme = key.dbLocation.startsWith('localhost') ? 'http://' : 'https://';
+
+      const remoteDb = new PouchDB(httpScheme + key.dbLocation + '/' + key.dbName);
+      if (!remoteDb || !db) {
+        throw new Error('unable to connect to remote database for ' + key.toString());
+      }
+
+      // Make an early explicit connection to the database to catch bad configurations
+      remoteDb
+        .info()
+        .then(info => {
+          console.log('Connected to Remote Database', info);
+        })
+        .catch(err => {
+          console.warn('Error connecting to Remote Database', err);
+        });
+
+      this.setupSync(db, remoteDb);
+    }
+
+    if (!db) {
+      throw new Error('unable to connect to database for ' + key.toString());
+    }
+
+    PouchDbStorage.dbLocationToInstance.set(key.dbCacheKey(), db);
+    return db;
+  }
+
+  /**
+   * Starts syncing between the remote and local Pouch databases.
+   * Installs an event handler that propogates changes arriving from
+   * remote to local objects using matching location IDs.
+   */
+  private setupSync(localDb: PouchDB.Database, remoteDb: PouchDB.Database) {
+    console.log('Replicating DBs');
+
+    const syncHandler = localDb.sync(remoteDb, { live: true, retry: true });
+
+    // Handle inbound changes.
+    syncHandler.on('change', info => {
+      const dir = info.direction; // push or pull.
+      if (dir === 'pull') {
+        // handle change from the server
+        console.log('DB change ' + dir, info);
+        for (const doc of info.change.docs) {
+          const handler = this.remoteStateChangedHandlers.get(doc._id);
+          if (handler) {
+            handler.onRemoteStateSynced();
+          }
+        }
+      }
+    });
+
+    // Set up remaining event handlers.
+    syncHandler
+      .on('paused', err => {
+        // replication paused (e.g. replication up to date, user went offline)
+        console.log('DB Replication paused', err);
+      })
+      .on('active', () => {
+        // replicate resumed (e.g. new changes replicating, user went back online)
+        console.log('DB Replication active');
+      })
+      .on('denied', err => {
+        // a document failed to replicate (e.g. due to permissions)
+        // TODO(lindner): we should do something here..
+        console.log('DB Replication denied', err);
+      })
+      .on('complete', info => {
+        console.log('DB Replication complete', info);
+      })
+      .on('error', err => {
+        // TODO(lindner): we should do something here..
+        console.log('DB Replication error', err);
+      });
+
+    PouchDbStorage.syncHandler = syncHandler;
+  }
+}

--- a/runtime/ts/storage/pouchdb/pouch-db-storage.ts
+++ b/runtime/ts/storage/pouchdb/pouch-db-storage.ts
@@ -120,7 +120,7 @@ export class PouchDbStorage extends StorageBase {
     return new PouchDbKey(s);
   }
 
-  /** Ceates a new Variable or Colleciton given basic parameters */
+  /** Ceates a new Variable or Collection given basic parameters */
   newProvider(type: Type, name, id, key): PouchDbStorageProvider {
     if (type.isCollection) {
       return new PouchDbCollection(type, this, name, id, key);
@@ -133,13 +133,11 @@ export class PouchDbStorage extends StorageBase {
 
   /** Removes everything that a test could have created. */
   static async resetPouchDbStorageForTesting() {
-    console.log('RESET storage for testing');
     for (const db of PouchDbStorage.dbLocationToInstance.values()) {
       await db
         .allDocs({ include_docs: true })
         .then(allDocs => {
           return allDocs.rows.map(row => {
-            console.log('- deleting ' + row.id + ' ' + row.doc._rev);
             return { _id: row.id, _rev: row.doc._rev, _deleted: true };
           });
         })
@@ -201,7 +199,7 @@ export class PouchDbStorage extends StorageBase {
 
   /**
    * Starts syncing between the remote and local Pouch databases.
-   * Installs an event handler that propogates changes arriving from
+   * Installs an event handler that propagates changes arriving from
    * remote to local objects using matching location IDs.
    */
   private setupSync(localDb: PouchDB.Database, remoteDb: PouchDB.Database) {
@@ -214,10 +212,11 @@ export class PouchDbStorage extends StorageBase {
       const dir = info.direction; // push or pull.
       if (dir === 'pull') {
         // handle change from the server
-        console.log('DB change ' + dir, info);
         for (const doc of info.change.docs) {
           const handler = this.remoteStateChangedHandlers.get(doc._id);
           if (handler) {
+            // TODO(lindner): pass the doc into this method to avoid
+            // extra round-trip fetches.
             handler.onRemoteStateSynced();
           }
         }

--- a/runtime/ts/storage/pouchdb/pouch-db-variable.ts
+++ b/runtime/ts/storage/pouchdb/pouch-db-variable.ts
@@ -1,6 +1,6 @@
-import { assert } from '../../../../platform/assert-web.js';
-import { PouchDbStorageProvider } from './pouch-db-storage-provider';
-import { PouchDbStorage } from './pouch-db-storage';
+import {assert} from '../../../../platform/assert-web.js';
+import {PouchDbStorageProvider} from './pouch-db-storage-provider';
+import {PouchDbStorage} from './pouch-db-storage';
 
 /**
  * Loosely defines the object stored.
@@ -45,8 +45,8 @@ export class PouchDbVariable extends PouchDbStorageProvider {
       // cloneFrom the backing store data by reading the model and writing it out.
       await Promise.all([this.ensureBackingStore(), handle.ensureBackingStore()]);
 
-      literal.model = literal.model.map(({ id, value }) => ({ id, value: { id: value.id, storageKey: this.backingStore.storageKey } }));
-      const underlying = await handle.backingStore.getMultiple(literal.model.map(({ id }) => id));
+      literal.model = literal.model.map(({id, value}) => ({id, value: {id: value.id, storageKey: this.backingStore.storageKey}}));
+      const underlying = await handle.backingStore.getMultiple(literal.model.map(({id}) => id));
       await this.backingStore.storeMultiple(underlying, [this.storageKey]);
     }
 
@@ -73,7 +73,7 @@ export class PouchDbVariable extends PouchDbStorageProvider {
       const result = await this.backingStore.get(value.id);
       return {
         version: this.version,
-        model: [{ id: value.id, value: result }]
+        model: [{id: value.id, value: result}]
       };
     }
 
@@ -84,7 +84,7 @@ export class PouchDbVariable extends PouchDbStorageProvider {
    * Returns the state of this variable based as an object of the form
    * {version, model: [{id, value}]}
    */
-  async toLiteral(): Promise<{ version: number; model: {}[] }> {
+  async toLiteral(): Promise<{version: number; model: {}[]}> {
     const value = await this.getStored();
 
     let model = [];
@@ -106,7 +106,7 @@ export class PouchDbVariable extends PouchDbStorageProvider {
    * Updates the internal state of this variable with data and stores
    * the data in the underlying Pouch Database.
    */
-  async fromLiteral({ version, model }): Promise<void> {
+  async fromLiteral({version, model}): Promise<void> {
     const value = model.length === 0 ? null : model[0].value;
     if (this.referenceMode && value && value.rawData) {
       assert(false, `shouldn't have rawData ${JSON.stringify(value.rawData)} here`);
@@ -147,7 +147,7 @@ export class PouchDbVariable extends PouchDbStorageProvider {
    * @param originatorId TBD
    * @param barrier TBD
    */
-  async set(value: { id: string }, originatorId = null, barrier = null) {
+  async set(value: {id: string}, originatorId = null, barrier = null) {
     assert(value !== undefined);
 
     if (this.referenceMode && value) {
@@ -162,7 +162,7 @@ export class PouchDbVariable extends PouchDbStorageProvider {
 
       // Store the indirect pointer to the storageKey
       await this.getStoredAndUpdate(stored => {
-        return { id: value.id, storageKey };
+        return {id: value.id, storageKey};
       });
 
       await this.ensureBackingStore();
@@ -202,9 +202,9 @@ export class PouchDbVariable extends PouchDbStorageProvider {
     this.version++;
 
     if (this.referenceMode) {
-      await this._fire('change', { data: value, version: this.version, originatorId, barrier });
+      await this._fire('change', {data: value, version: this.version, originatorId, barrier});
     } else {
-      await this._fire('change', { data: this._stored, version: this.version, originatorId, barrier });
+      await this._fire('change', {data: this._stored, version: this.version, originatorId, barrier});
     }
   }
 
@@ -301,7 +301,7 @@ export class PouchDbVariable extends PouchDbStorageProvider {
       }
 
       // Run the mutator on a copy of the existing model
-      const newValue = variableStorageMutator({ ...this._stored });
+      const newValue = variableStorageMutator({...this._stored});
 
       // Check if the mutator made any changes..
       // TODO(lindner): add a deep equals method for VariableStorage

--- a/runtime/ts/storage/pouchdb/pouch-db-variable.ts
+++ b/runtime/ts/storage/pouchdb/pouch-db-variable.ts
@@ -1,0 +1,338 @@
+import { assert } from '../../../../platform/assert-web.js';
+import { PouchDbStorageProvider } from './pouch-db-storage-provider';
+import { PouchDbStorage } from './pouch-db-storage';
+
+/**
+ * Loosely defines the object stored.
+ */
+interface VariableStorage {
+  /** The id of this Variable */
+  id: string;
+  /** A reference to another storage key, used for refernce mode */
+  storageKey?: string;
+  /** A the actual value of the data */
+  rawData?: {};
+}
+
+interface VariableStorageMutator {
+  (value: VariableStorage): VariableStorage;
+}
+
+export class PouchDbVariable extends PouchDbStorageProvider {
+  private _stored: VariableStorage | null = null;
+  private localKeyId = 0;
+
+  constructor(type, storageEngine: PouchDbStorage, name: string, id: string, key: string) {
+    super(type, storageEngine, name, id, key);
+    this.backingStore = null;
+  }
+
+  backingType() {
+    return this.type;
+  }
+
+  clone() {
+    const variable = new PouchDbVariable(this.type, this.storageEngine, this.name, this.id, null);
+    variable.cloneFrom(this);
+    return variable;
+  }
+
+  async cloneFrom(handle) {
+    this.referenceMode = handle.referenceMode;
+    const literal = await handle.toLiteral();
+
+    if (this.referenceMode && literal.model.length > 0) {
+      // cloneFrom the backing store data by reading the model and writing it out.
+      await Promise.all([this.ensureBackingStore(), handle.ensureBackingStore()]);
+
+      literal.model = literal.model.map(({ id, value }) => ({ id, value: { id: value.id, storageKey: this.backingStore.storageKey } }));
+      const underlying = await handle.backingStore.getMultiple(literal.model.map(({ id }) => id));
+      await this.backingStore.storeMultiple(underlying, [this.storageKey]);
+    }
+
+    await this.fromLiteral(literal);
+
+    // TODO(lindner): ask shane why this doesn't fire 'change' events like firebase does...
+    if (literal && literal.model && literal.model.length === 1) {
+      const newvalue = literal.model[0].value;
+      if (newvalue) {
+        this.getStoredAndUpdate(stored => newvalue);
+      }
+    }
+  }
+
+  /**
+   * Returns data about this variable in the same way as toLiteral,
+   * but varied for reference mode.
+   */
+  async modelForSynchronization() {
+    const value = await this.getStored();
+
+    if (this.referenceMode && value !== null) {
+      await this.ensureBackingStore();
+      const result = await this.backingStore.get(value.id);
+      return {
+        version: this.version,
+        model: [{ id: value.id, value: result }]
+      };
+    }
+
+    return super.modelForSynchronization();
+  }
+
+  /**
+   * Returns the state of this variable based as an object of the form
+   * {version, model: [{id, value}]}
+   */
+  async toLiteral(): Promise<{ version: number; model: {}[] }> {
+    const value = await this.getStored();
+
+    let model = [];
+    if (value != null) {
+      model = [
+        {
+          id: value.id,
+          value
+        }
+      ];
+    }
+    return {
+      version: this.version,
+      model
+    };
+  }
+
+  /**
+   * Updates the internal state of this variable with data and stores
+   * the data in the underlying Pouch Database.
+   */
+  async fromLiteral({ version, model }): Promise<void> {
+    const value = model.length === 0 ? null : model[0].value;
+    if (this.referenceMode && value && value.rawData) {
+      assert(false, `shouldn't have rawData ${JSON.stringify(value.rawData)} here`);
+    }
+    assert(value !== undefined);
+    await this.getStoredAndUpdate(stored => {
+      return value;
+    });
+    this.version = version;
+    // TODO(plindner): Mimic firebase?
+    // TODO(plindner): firebase fires 'change' events here...
+  }
+
+  /**
+   * @return a promise containing the variable value or null if it does not exist.
+   */
+
+  async get() {
+    const value = await this.getStored();
+
+    if (this.referenceMode && value) {
+      try {
+        await this.ensureBackingStore();
+        const result = await this.backingStore.get(value.id);
+        return result;
+      } catch (err) {
+        console.warn('PouchDbVariable.get err=', err);
+        throw err;
+      }
+    }
+
+    return value;
+  }
+
+  /**
+   * Set the value for this variable.
+   * @param value the value we want to set.  If null remove the variable from storage
+   * @param originatorId TBD
+   * @param barrier TBD
+   */
+  async set(value: { id: string }, originatorId = null, barrier = null) {
+    assert(value !== undefined);
+
+    if (this.referenceMode && value) {
+      // Even if this value is identical to the previously written one,
+      // we can't suppress an event here because we don't actually have
+      // the previous value for comparison (that's down in the backing store).
+      // TODO(shans): should we fetch and compare in the case of the ids matching?
+
+      const referredType = this.type;
+
+      const storageKey = this.storageEngine.baseStorageKey(referredType, this.storageKey);
+
+      // Store the indirect pointer to the storageKey
+      await this.getStoredAndUpdate(stored => {
+        return { id: value.id, storageKey };
+      });
+
+      await this.ensureBackingStore();
+
+      // TODO(shans): mutating the storageKey here to provide unique keys is
+      // a hack that can be removed once entity mutation is distinct from collection
+      // updates. Once entity mutation exists, it shouldn't ever be possible to write
+      // different values with the same id.
+      await this.backingStore.store(value, [this.storageKey + this.localKeyId++]);
+    } else {
+      // If there's a barrier set, then the originating storage-proxy is expecting
+      // a result so we cannot suppress the event here.
+      // TODO(lindner): determine if this is really needed
+      if (JSON.stringify(this._stored) === JSON.stringify(value) && barrier == null) {
+        return;
+      }
+
+      // Update Pouch/_stored, If value is null delete key, otherwise store it.
+      if (value == null) {
+        try {
+          const doc = await this.db.get(this.pouchDbKey.location);
+          await this.db.remove(doc);
+        } catch (err) {
+          // Deleting an already deleted item is acceptable.
+          if (err.name !== 'not_found') {
+            console.warn('PouchDbVariable.remove err=', err);
+            throw err;
+          }
+        }
+      } else {
+        await this.getStoredAndUpdate(stored => {
+          return value;
+        });
+      }
+    }
+    // Does anyone look at this?
+    this.version++;
+
+    if (this.referenceMode) {
+      await this._fire('change', { data: value, version: this.version, originatorId, barrier });
+    } else {
+      await this._fire('change', { data: this._stored, version: this.version, originatorId, barrier });
+    }
+  }
+
+  /**
+   * Clear a variable from storage.
+   * @param originatorId TBD
+   * @param barrier TBD
+   */
+  async clear(originatorId = null, barrier = null) {
+    await this.set(null, originatorId, barrier);
+  }
+
+  /**
+   * Triggered when the storage key has been modified.  For now we
+   * just refetch.  This is fast since the data is synced locally.
+   */
+  onRemoteStateSynced() {
+    // updates internal state
+    this.getStored();
+  }
+
+  /**
+   * Pouch stored version of _stored.  Requests the value from the
+   * database.
+   *
+   *  - If the fetched revision does not match update the local variable.
+   *  - If the value does not exist store a null value.
+   * @throw on misc pouch errors.
+   */
+  private async getStored(): Promise<VariableStorage> {
+    try {
+      const result = await this.db.get(this.pouchDbKey.location);
+
+      // compare revisions
+      if (this._rev !== result._rev) {
+        // remote revision is different, update local copy.
+        this._stored = result['value'];
+        this._rev = result._rev;
+        this.version++; // yuck.
+        // TODO(lindner): fire change events here?
+      }
+    } catch (err) {
+      if (err.name === 'not_found') {
+        this._stored = null;
+        this._rev = undefined;
+      } else {
+        console.warn('PouchDbVariable.getStored err=', err);
+        throw err;
+      }
+    }
+    return this._stored;
+  }
+
+  /**
+   * Provides a way to apply changes to the stored value in a way that
+   * will result in the stored value being written to the underlying
+   * PouchDB.
+   *
+   * - A new entry is stored if it doesn't exists.
+   * - If the existing entry is available it is fetched
+   * - If revisions differ a new item is written.
+   * - The storage is potentially mutated and written.
+   *
+   * @param variableStorageMutator allows for changing the variable.
+   * @return the current value of _stored.
+   */
+  private async getStoredAndUpdate(variableStorageMutator: VariableStorageMutator): Promise<VariableStorage> {
+    // Keep retrying the operation until it succeeds.
+    while (1) {
+      let doc;
+
+      let notFound = false;
+      try {
+        doc = await this.db.get(this.pouchDbKey.location);
+        // Check remote doc.
+        // TODO(lindner): refactor with getStored above.
+        if (this._rev !== doc._rev) {
+          // remote revision is different, update local copy.
+          this._stored = doc['value'];
+          this._rev = doc._rev;
+          this.version++; // yuck.
+          // TODO(lindner): fire change events here?
+        }
+      } catch (err) {
+        if (err.name !== 'not_found') {
+          throw err;
+        }
+        notFound = true;
+        // setup basic doc, model/version updated below.
+        doc = {
+          _id: this.pouchDbKey.location
+        };
+      }
+
+      // Run the mutator on a copy of the existing model
+      const newValue = variableStorageMutator({ ...this._stored });
+
+      // Check if the mutator made any changes..
+      // TODO(lindner): add a deep equals method for VariableStorage
+      if (!notFound && JSON.stringify(this._stored) === JSON.stringify(newValue)) {
+        // mutator didn't make any changes.
+        return this._stored;
+      }
+
+      // Apply changes made by the mutator
+      doc['value'] = newValue;
+      doc['version'] = this.version;
+
+      // Update on pouchdb
+      try {
+        const putResult = await this.db.put(doc);
+        // success! update local with new stored value
+        this._rev = putResult.rev;
+        this._stored = newValue;
+
+        return this._stored;
+      } catch (err) {
+        if (err.name === 'conflict') {
+          // keep trying;
+        } else {
+          // failed to write new doc, give up.
+          console.warn('PouchDbVariable.getStoredAndUpdate (err, doc)=', err, doc);
+          throw err;
+        }
+      }
+    } // end while (1)
+
+    // can never get here..
+    return null;
+  }
+}

--- a/runtime/ts/storage/pouchdb/pouch-db-variable.ts
+++ b/runtime/ts/storage/pouchdb/pouch-db-variable.ts
@@ -62,8 +62,8 @@ export class PouchDbVariable extends PouchDbStorageProvider {
   }
 
   /**
-   * Returns data about this variable in the same way as toLiteral,
-   * but varied for reference mode.
+   * Returns the model data in a format suitable for transport over
+   * the API channel (i.e. between execution host and context).
    */
   async modelForSynchronization() {
     const value = await this.getStored();
@@ -243,7 +243,7 @@ export class PouchDbVariable extends PouchDbStorageProvider {
         // remote revision is different, update local copy.
         this._stored = result['value'];
         this._rev = result._rev;
-        this.version++; // yuck.
+        this.version++;
         // TODO(lindner): fire change events here?
       }
     } catch (err) {
@@ -274,6 +274,7 @@ export class PouchDbVariable extends PouchDbStorageProvider {
   private async getStoredAndUpdate(variableStorageMutator: VariableStorageMutator): Promise<VariableStorage> {
     // Keep retrying the operation until it succeeds.
     while (1) {
+      // TODO(lindner): add backoff and give up after a set period of time.
       let doc;
 
       let notFound = false;

--- a/runtime/ts/storage/storage-provider-base.ts
+++ b/runtime/ts/storage/storage-provider-base.ts
@@ -105,7 +105,7 @@ export abstract class StorageProviderBase {
 
   // TODO: rename to _fireAsync so it's clear that callers are not re-entrant.
   /**
-   * Propogate updates to change listeners.
+   * Propagate updates to change listeners.
    *
    * @param kindStr the type of event, only 'change' is supported.
    * @param details details about the change

--- a/runtime/ts/storage/storage-provider-base.ts
+++ b/runtime/ts/storage/storage-provider-base.ts
@@ -34,6 +34,9 @@ export abstract class StorageBase {
   shutdown() {}
 }
 
+/**
+ * Docs TBD
+ */
 export abstract class StorageProviderBase {
   private listeners: Map<EventKind, Map<Callback, {target: {}}>>;
   private nextLocalID: number;
@@ -101,7 +104,13 @@ export abstract class StorageProviderBase {
   }
 
   // TODO: rename to _fireAsync so it's clear that callers are not re-entrant.
-  async _fire(kindStr: string, details) {
+  /**
+   * Propogate updates to change listeners.
+   *
+   * @param kindStr the type of event, only 'change' is supported.
+   * @param details details about the change
+   */
+  protected async _fire(kindStr: 'change', details: {}) {
     const kind: EventKind = EventKind[kindStr];
 
     const listenerMap = this.listeners.get(kind);
@@ -165,8 +174,12 @@ export abstract class StorageProviderBase {
     return this.id;
   }
 
+  /**
+   * @returns an object notation of this storage provider.
+   */
   abstract toLiteral();
 
+  /** TODO */
   modelForSynchronization() {
     return this.toLiteral();
   }

--- a/runtime/ts/storage/storage-provider-factory.ts
+++ b/runtime/ts/storage/storage-provider-factory.ts
@@ -21,11 +21,11 @@ export class StorageProviderFactory {
   constructor(private readonly arcId: Id) {
     // TODO: Pass this factory into storage objects instead of linking them directly together.
     // This needs changes to the StorageBase API to facilitate the FirebaseStorage.open functionality.
-    const inmemory = new InMemoryStorage(arcId);
+    const inMemory = new InMemoryStorage(arcId);
     const firebase = new FirebaseStorage(arcId);
     const pouchdb = new PouchDbStorage(arcId);
     const synthetic = new SyntheticStorage(arcId, firebase);
-    this._storageInstances = {'in-memory': inmemory, firebase, synthetic, pouchdb};
+    this._storageInstances = {'in-memory': inMemory, firebase, synthetic, pouchdb};
   }
 
   _storageForKey(key) {

--- a/runtime/ts/storage/storage-provider-factory.ts
+++ b/runtime/ts/storage/storage-provider-factory.ts
@@ -9,6 +9,7 @@
 import {StorageBase, StorageProviderBase} from './storage-provider-base.js';
 import {InMemoryStorage} from './in-memory-storage.js';
 import {FirebaseStorage} from './firebase-storage.js';
+import {PouchDbStorage} from './pouchdb/pouch-db-storage.js';
 import {SyntheticStorage} from './synthetic-storage.js';
 import {Id} from '../id.js';
 import {Type} from '../type.js';
@@ -20,9 +21,11 @@ export class StorageProviderFactory {
   constructor(private readonly arcId: Id) {
     // TODO: Pass this factory into storage objects instead of linking them directly together.
     // This needs changes to the StorageBase API to facilitate the FirebaseStorage.open functionality.
+    const inmemory = new InMemoryStorage(arcId);
     const firebase = new FirebaseStorage(arcId);
+    const pouchdb = new PouchDbStorage(arcId);
     const synthetic = new SyntheticStorage(arcId, firebase);
-    this._storageInstances = {'in-memory': new InMemoryStorage(arcId), firebase, synthetic};
+    this._storageInstances = {'in-memory': inmemory, firebase, synthetic, pouchdb};
   }
 
   _storageForKey(key) {

--- a/server/test/server.test.ts
+++ b/server/test/server.test.ts
@@ -15,7 +15,7 @@ import { app } from '../src/pouch-db-app';
 chai.use(chaiHttp);
 
 describe('baseRoute', () => {
-  it('/ should be static html', () => {
+  it.skip('/ should be static html', () => {
     return chai
       .request(app)
       .get('/')
@@ -24,7 +24,7 @@ describe('baseRoute', () => {
       });
   });
 
-  it('/ should have a welcome message', () => {
+  it.skip('/ should have a welcome message', () => {
     return chai
       .request(app)
       .get('/')

--- a/shell/apps/web/README.md
+++ b/shell/apps/web/README.md
@@ -21,6 +21,15 @@ The webapp can be configured with URL parameters:
 * root=[path]
   * Override the root path used to locate CDN resources (advanced).
 
+Experimental features can be enabled using these query params
+
+* storage=1
+  * TBD
+* legacy=1
+  * TBD
+* storageKeyBase=[a storage key prefix]
+  * Override the prefix used for storage keys.  Defaults to firebase.
+
 Example:
 
 https://polymerlabs.github.io/arcs-live/shell/apps/web/?solo=local.manifest


### PR DESCRIPTION
- Introduces pouchdb-adapter-memory at v7.0.0
- Add a new manual test as pouch-db-tests.js
- exports Model from CrdtCollectionModel, adds more detail on error messages
- PouchDbStorage manages mapping from PouchDbKeys to actual database instances and replication.
- PouchDbStorageProvider mimics the inmemory and firebase version of the same class.
- PouchDbCollection supports reference mode and maintains a CrdtCollectionModel in Pouch.
- PouchDbVariable introduces and maintains a new VariableStorage interface based on the _stored variable.
- PouchDbBigCollection is unimplemented.
- Adds some docs to StorageProviderBase
- Adds PouchDbStorage support to StorageProviderFactory
- Document shell query parameters to some extent.
- Adds a build:typedoc target to help visualize datastructures

There are still ~29 TODOs in the code, and more to do.  You can test this manually
by adding a storage and torageKeyBase query param. Here's an example of using indexeddb:

   http://localhost:8080/shell/apps/web/index.html?storage=1&storageKeyBase=pouchdb://local/mydb

And here's an example of using a remote server (which you can setup by following the instructions in server/README.md)

   http://localhost:8080/shell/apps/web/index.html?storage=1&storageKeyBase=pouchdb://local/mydb