### PR TITLE
Update descriptions and recipe coalescing for BigCollections.

### DIFF
--- a/runtime/description-dom-formatter.js
+++ b/runtime/description-dom-formatter.js
@@ -229,6 +229,13 @@ export class DescriptionDomFormatter extends DescriptionFormatter {
     };
   }
 
+  _formatBigCollection(handleName, firstValue) {
+    return {
+      template: `collection of items like {{${handleName}FirstName}}`,
+      model: {[`${handleName}FirstName`]: firstValue.rawData.name}
+    };
+  }
+
   _formatSingleton(handleName, value, handleDescription) {
     let formattedValue = super._formatSingleton(handleName, value, handleDescription);
     if (formattedValue) {

--- a/runtime/description.js
+++ b/runtime/description.js
@@ -351,7 +351,8 @@ export class DescriptionFormatter {
         let storeValue = await this._formatStoreValue(token.handleName, token._store);
         if (!description) {
           // For singleton handle, if there is no real description (the type was used), use the plain value for description.
-          if (storeValue && !token._store.type.isCollection && !this.excludeValues) {
+          // TODO: should this look at type.getContainedType() (which includes references), or maybe just type.isEntity?
+          if (storeValue && !this.excludeValues && !token._store.type.isCollection) { // && !token._store.type.isBigCollection) {
             return storeValue;
           }
         }
@@ -393,7 +394,8 @@ export class DescriptionFormatter {
   }
 
   async _propertyTokenToString(handleName, store, properties) {
-    assert(!store.type.isCollection, `Cannot return property ${properties.join(',')} for collection`);
+    assert(!store.type.isCollection && !store.type.isBigCollection,
+           `Cannot return property ${properties.join(',')} for Collection or BigCollection`);
     // Use singleton value's property (eg. "09/15" for person's birthday)
     let valueVar = await store.get();
     if (valueVar) {
@@ -422,6 +424,13 @@ export class DescriptionFormatter {
       if (values && values.length > 0) {
         return this._formatCollection(handleName, values);
       }
+    } else if (store.type.isBigCollection) {
+      let cursorId = await store.stream(1);
+      let {value, done} = await store.cursorNext(cursorId);
+      store.cursorClose(cursorId);
+      if (!done && value[0].rawData.name) {
+        return await this._formatBigCollection(handleName, value[0]);
+      }
     } else {
       let value = await store.get();
       if (value) {
@@ -439,6 +448,10 @@ export class DescriptionFormatter {
     } else {
       return `${values.length} items`;
     }
+  }
+
+  _formatBigCollection(handleName, firstValue) {
+    return `collection of items like ${firstValue.rawData.name}`;
   }
 
   _formatSingleton(handleName, value, handleDescription) {

--- a/runtime/strategies/coalesce-recipes.js
+++ b/runtime/strategies/coalesce-recipes.js
@@ -170,7 +170,8 @@ export class CoalesceRecipes extends Strategy {
           // generic recipes would apply - which we currently don't want here.
           if (otherHandle.type.hasVariable) {
             let resolved = otherHandle.type.resolvedType();
-            if (resolved.isCollection) resolved = resolved.collectionType;
+            // TODO: getContainedType returns non-null for references ... is that correct here?
+            resolved = resolved.getContainedType() || resolved;
             if (resolved.isVariable && !resolved.canReadSubset) continue;
           }
 

--- a/runtime/test/strategies/coalesce-recipes-test.js
+++ b/runtime/test/strategies/coalesce-recipes-test.js
@@ -232,26 +232,33 @@ describe('CoalesceRecipes', function() {
     let recipe = await doCoalesceRecipes(`
       schema Thing1
       schema Thing2
+      schema Thing3
       particle P1
         in Thing1 thing1
-        in Thing2 thing2
+        in [Thing2] thing2
+        in BigCollection<Thing3> thing3
       particle P2
         out Thing1 thing1
-        out Thing2 thing2
+        out [Thing2] thing2
+        out BigCollection<Thing3> thing3
       recipe
         use as handle1
         use as handle2
+        use as handle3
         P1
           thing1 <- handle1
           thing2 <- handle2
+          thing3 <- handle3
       recipe
         create as handle1
         create as handle2
+        create as handle3
         P2
           thing1 -> handle1
           thing2 -> handle2
+          thing3 -> handle3
       `);
-    assert.lengthOf(recipe.handles, 2);
+    assert.lengthOf(recipe.handles, 3);
     recipe.handles.forEach(handle => assert.lengthOf(handle.connections, 2));
   });
 

--- a/runtime/ts/type.ts
+++ b/runtime/ts/type.ts
@@ -541,7 +541,7 @@ export class Type {
       return `${this.collectionType.toPrettyString()} List`;
     }
     if (this.isBigCollection) {
-      return `${this.bigCollectionType.toPrettyString()} BigCollection`;
+      return `Collection of ${this.bigCollectionType.toPrettyString()}`;
     }
     if (this.isVariable) {
       return this.variable.isResolved() ? this.resolvedType().toPrettyString() : `[~${this.variable.name}]`;


### PR DESCRIPTION
Also flipped the ordering of assert.equal(..) args in description-test.js, since Chai expects the actual value to be given first.