### PR TITLE
Make shell bootstrap from `https://$artifacts/`

### DIFF
--- a/shell/apps/common/config.js
+++ b/shell/apps/common/config.js
@@ -39,8 +39,8 @@ if ('serviceWorker' in navigator) {
 // default manifest!
 window.defaultManifest = `
 
-import '${window.arcsPath}/artifacts/Arcs/Arcs.recipes'
-import '${window.arcsPath}/artifacts/canonical.manifest'
+import 'https://$artifacts/Arcs/Arcs.recipes'
+import 'https://$artifacts/canonical.manifest'
 import 'https://sjmiles.github.io/arcs-stories/0.4/canonical.manifest'
 
 `;

--- a/shell/lib/arcs-utils.js
+++ b/shell/lib/arcs-utils.js
@@ -54,6 +54,7 @@ const ArcsUtils = {
       './': './',
       'assets': `${arcsRoot}/shell/assets`,
       'https://$shell': `${arcsRoot}`,
+      'https://$artifacts': `${arcsRoot}/artifacts`,
       // TODO(sjmiles): map must always contain (explicitly, no prefixing) a mapping for `worker-entry-cdn.js`
       'worker-entry.js': `${arcsRoot}/shell/${lib}/worker-entry.js`,
       // BC

--- a/shell/source/browser-loader.js
+++ b/shell/source/browser-loader.js
@@ -25,10 +25,20 @@ export class BrowserLoader extends Loader {
     this._urlMap = urlMap;
   }
   _loadURL(url) {
+    const resolved = this._resolve(url);
     // use URL to normalize the path for deduping
-    const cacheKey = new URL(url, document.URL).href;
+    const cacheKey = new URL(resolved, document.URL).href;
+    // console.log(`browser-loader::_loadURL`);
+    // console.log(`    ${url}`);
+    // console.log(`    ${resolved}`);
+    // console.log(`    ${cacheKey}`);
     const resource = dumbCache[cacheKey];
-    return resource || (dumbCache[cacheKey] = super._loadURL(url));
+    return resource || (dumbCache[cacheKey] = super._loadURL(resolved));
+  }
+  loadResource(name) {
+    // subclass impl differentiates paths and URLs,
+    // for browser env we can feed both kinds into _loadURL
+    return this._loadURL(name);
   }
   _resolve(path) {
     //return new URL(path, this._base).href;
@@ -43,9 +53,6 @@ export class BrowserLoader extends Loader {
     url = url || path;
     //console.log(`browser-loader: resolve(${path}) = ${url}`);
     return url;
-  }
-  loadResource(name) {
-    return this._loadURL(this._resolve(name));
   }
   requireParticle(fileName) {
     const path = this._resolve(fileName);


### PR DESCRIPTION
The virtual path `https://$artifacts/` will then be consistent across environments for accessing canonical artifacts.

This works by leveraging the BrowserLoader path-prefix mapper.