### PR TITLE
marshal `launcher` recipe directly (don't bother the planner)

### DIFF
--- a/artifacts/Arcs/Arcs.recipes
+++ b/artifacts/Arcs/Arcs.recipes
@@ -5,6 +5,5 @@
 // subject to an additional IP rights grant found at
 
 import 'Login.recipe'
-import 'Launcher.recipe'
 import 'Dashboard.recipe'
 

--- a/artifacts/Arcs/Launcher.recipe
+++ b/artifacts/Arcs/Launcher.recipe
@@ -12,7 +12,10 @@ particle Launcher in 'source/Launcher.js'
   description `arcs launcher`
 
 recipe Launcher
-  use #arcmetadata as arcs
+  // literal ids needed to avoid resolution
+  use 'SYSTEM_arcs' as arcs
+  slot 'rootslotid-root' as root
   Launcher
     arcs = arcs
+    consume root as root
 

--- a/shell/app-shell/app-shell.js
+++ b/shell/app-shell/app-shell.js
@@ -229,14 +229,26 @@ class AppShell extends Xen.Debug(Xen.Base, log) {
       this._describeArc(arc, description);
     }
   }
-  _updateLauncher(state, oldState) {
-    const {key, metaplan, metaplans, suggestion, pendingSuggestion} = state;
+  async _updateLauncher(state, oldState) {
+    const {key, arc, metaplans, suggestion, pendingSuggestion, launcherPlan} = state;
+    if (arc && !launcherPlan) {
+      log('loading launcher recipe');
+      const loader = arc._loader;
+      const fileName = './in-memory.manifest';
+      const manny = await Arcs.Runtime.parseManifest(`import 'https://$artifacts/Arcs/Launcher.recipe'`, {loader, fileName});
+      const recipe = manny.recipes[0];
+      recipe.normalize();
+      state.launcherPlan = recipe;
+    }
     if (key === Const.SHELLKEYS.launcher) {
-      if (!suggestion && (!metaplan || !metaplan.plan) && metaplans && metaplans.plans && metaplans.plans.length) {
-        // TODO(sjmiles): need a better way to find the launcher suggestion
-        state.suggestion = metaplans.plans.find(s => s.descriptionText === 'Arcs launcher.');
+      if (launcherPlan && !state.launched) {
+        log('instantiating launcher');
+        state.launched = true;
+        arc.instantiate(launcherPlan);
       }
-      else if (suggestion && suggestion !== oldState.suggestion) {
+    } else {
+      state.launched = false;
+      if (suggestion && suggestion !== oldState.suggestion) {
         log('suggestion registered from launcher, generate new arc (set key to *)');
         state.suggestion = null;
         state.pendingSuggestion = suggestion;

--- a/shell/app-shell/app-shell.js
+++ b/shell/app-shell/app-shell.js
@@ -236,9 +236,10 @@ class AppShell extends Xen.Debug(Xen.Base, log) {
       const loader = arc._loader;
       const fileName = './in-memory.manifest';
       const manny = await Arcs.Runtime.parseManifest(`import 'https://$artifacts/Arcs/Launcher.recipe'`, {loader, fileName});
-      const recipe = manny.recipes[0];
-      recipe.normalize();
-      state.launcherPlan = recipe;
+      const launcherPlan = manny.recipes[0];
+      launcherPlan.normalize();
+      this._setState({launcherPlan});
+      return;
     }
     if (key === Const.SHELLKEYS.launcher) {
       if (launcherPlan && !state.launched) {

--- a/shell/app-shell/elements/fb-data/fb-user.js
+++ b/shell/app-shell/elements/fb-data/fb-user.js
@@ -91,6 +91,7 @@ class FbUserElement extends Xen.Debug(Xen.Base, log) {
       schema: schemas.ArcMetadata,
       type: '[ArcMetadata]',
       name: 'ArcMetadata',
+      id: 'SYSTEM_arcs',
       tags: ['arcmetadata', 'nosync'],
       storageKey: 'in-memory'
     };

--- a/shell/app-shell/elements/fb-data/fb-user.js
+++ b/shell/app-shell/elements/fb-data/fb-user.js
@@ -89,9 +89,9 @@ class FbUserElement extends Xen.Debug(Xen.Base, log) {
   async _createArcStore(arc) {
     const options = {
       schema: schemas.ArcMetadata,
-      type: '[ArcMetadata]',
-      name: 'ArcMetadata',
+      name: 'SYSTEM_arcs',
       id: 'SYSTEM_arcs',
+      type: '[ArcMetadata]',
       tags: ['arcmetadata', 'nosync'],
       storageKey: 'in-memory'
     };

--- a/shell/apps/remote-planning/arc-factory.js
+++ b/shell/apps/remote-planning/arc-factory.js
@@ -26,7 +26,6 @@ const ArcFactory = class {
   constructor(overridePath) {
     // Allow caller to specify where to find assets
     const path = overridePath ? overridePath : '../../../';
-
     this.loader = new LoaderKind({
       'https://$cdn/': path,
       'https://$shell/': path,


### PR DESCRIPTION
Load `Launcher.recipe` directly so Planner and friends needn't worry about `ArcMetadata` store.