### PR TITLE
small launcher recipe fix

### DIFF
--- a/shell/app-shell/app-shell.js
+++ b/shell/app-shell/app-shell.js
@@ -242,7 +242,7 @@ class AppShell extends Xen.Debug(Xen.Base, log) {
       return;
     }
     if (key === Const.SHELLKEYS.launcher) {
-      if (launcherPlan && !state.launched) {
+      if (arc && arc.findStoreById('SYSTEM_arcs') && launcherPlan && !state.launched) {
         log('instantiating launcher');
         state.launched = true;
         arc.instantiate(launcherPlan);


### PR DESCRIPTION
this helps avoid an exception when opening an existing arc and then going back to launcher.

`arc.findStoreById('SYSTEM_arcs')` feels hacky, but it's a timing issue, this store is just created later, is there a better way maybe?