### PR TITLE
Tear down the arc before consuming serialization.

### DIFF
--- a/shell/app-shell/elements/arc-host.js
+++ b/shell/app-shell/elements/arc-host.js
@@ -152,7 +152,8 @@ class ArcHost extends Xen.Debug(Xen.Base, log) {
     }
     // TODO(sjmiles): temporarily elide search info, it seems to choke the deserializer
     serialization = serialization.replace(/search `[^`]*`/, '').replace(/tokens \/\/ `[^`]*`/, '');
-
+    // Tearing down the existing arc, so that the DOM gets cleared before initializing
+    // slot composer.
     this._teardownArc(state.arc);
     //
     // generate new slotComposer

--- a/shell/app-shell/elements/arc-host.js
+++ b/shell/app-shell/elements/arc-host.js
@@ -154,6 +154,7 @@ class ArcHost extends Xen.Debug(Xen.Base, log) {
     serialization = serialization.replace(/search `[^`]*`/, '').replace(/tokens \/\/ `[^`]*`/, '');
     // Tearing down the existing arc, so that the DOM gets cleared before initializing
     // slot composer.
+    // TODO: investigate why it didn't already happen.
     this._teardownArc(state.arc);
     //
     // generate new slotComposer

--- a/shell/app-shell/elements/arc-host.js
+++ b/shell/app-shell/elements/arc-host.js
@@ -152,6 +152,8 @@ class ArcHost extends Xen.Debug(Xen.Base, log) {
     }
     // TODO(sjmiles): temporarily elide search info, it seems to choke the deserializer
     serialization = serialization.replace(/search `[^`]*`/, '').replace(/tokens \/\/ `[^`]*`/, '');
+
+    this._teardownArc(state.arc);
     //
     // generate new slotComposer
     const slotComposer = this._createSlotComposer(config);


### PR DESCRIPTION
Fixes "duplicate root slot" errors.
Addresses:
https://github.com/PolymerLabs/arcs/issues/1913
https://github.com/PolymerLabs/arcs/issues/2013