### PR TITLE
Filter pipe suggestion against most recent entity type

### DIFF
--- a/artifacts/Pipes/AddCollectionItem.manifest
+++ b/artifacts/Pipes/AddCollectionItem.manifest
@@ -1,0 +1,3 @@
+particle AddCollectionItem in './source/AddCollectionItem.js'
+  in ~a item
+  inout [~a] collection

--- a/artifacts/Pipes/Pipes.recipes
+++ b/artifacts/Pipes/Pipes.recipes
@@ -1,17 +1,22 @@
 import 'TVMazePipe.recipes'
 import 'ShowcaseArtistPipe.recipes'
 import 'ShowcasePlayRecordPipe.recipes'
+import 'AddCollectionItem.manifest'
 
 particle BackgroundProcess in 'source/BackgroundProcess.js'
   consume root
   in ShowcasePlayRecord playRecord
 
 recipe BackgroundPipe
-  create #piped #showcase_play_record as playRecord
   slot 'rootslotid-root' as root
+  create #piped #showcase_play_record as playRecord
+  create #all_piped #all_showcase_play_record as playRecords
   BackgroundProcess
-    playRecord = playRecord
     consume root as root
+    playRecord = playRecord
+  AddCollectionItem
+    item = playRecord
+    collection = playRecords
   //
   create as findShow
   create #piped #tv_show as show
@@ -19,15 +24,18 @@ recipe BackgroundPipe
   TVMazeFindShow
     find = findShow
     show = show
-  TvMazeAddToCollection
+  AddCollectionItem
     item = show
     collection = shows
   //
   create as findArtist
   create #piped #showcase_artist as artist
-  //create #all_piped #all_showcase_artists as artists
+  create #all_piped #all_showcase_artists as artists
   ShowcaseFindArtist
     find = findArtist
     artist = artist
+  AddCollectionItem
+    item = artist
+    collection = artists
 
 

--- a/artifacts/Pipes/PopCollectionItem.manifest
+++ b/artifacts/Pipes/PopCollectionItem.manifest
@@ -1,3 +1,3 @@
-particle PopCollectionItem in '../Pipes/source/PopCollectionItem.js'
+particle PopCollectionItem in './source/PopCollectionItem.js'
   in [~a] collection
   out ~a item

--- a/artifacts/Pipes/ShowcaseArtistPipe.recipes
+++ b/artifacts/Pipes/ShowcaseArtistPipe.recipes
@@ -16,6 +16,3 @@ particle ShowcaseFindArtist in '../Showcase/source/ShowcaseFindArtist.js'
   out ShowcaseArtist artist
   //out [Description] descriptions
 
-particle AddToShowcaseCollection in './source/AddToCollection.js'
-  in ShowcaseArtist item
-  inout [ShowcaseArtist] collection

--- a/artifacts/Pipes/TVMazePipe.recipes
+++ b/artifacts/Pipes/TVMazePipe.recipes
@@ -1,24 +1,10 @@
 import '../Profile/User.schema'
+import '../TVMaze/TVMazeShow.schema'
+import '../Common/Description.schema'
 
 schema TVMazeFind
   Text name
   Text type
-
-schema TVMazeShow
-  Text showid
-  Text name
-  Text description
-  Text image
-  Text network
-  Text day
-  Text time
-  Text suggestion
-  Text extra
-  Boolean favorite
-  Boolean delete
-  //description `${name} is on ${network} at ${time} on {$day}`
-
-import '../Common/Description.schema'
 
 particle TVMazeFindShow in '../TVMaze/source/TVMazeFindShow.js'
   in TVMazeFind find

--- a/artifacts/Pipes/source/AddCollectionItem.js
+++ b/artifacts/Pipes/source/AddCollectionItem.js
@@ -12,13 +12,13 @@
 defineParticle(({DomParticle, log}) => {
 
   return class extends DomParticle {
-    update({item, collection}, state) {
+    update({item}, state) {
       if (item && item.id !== state.item_id) {
         state.item_id = item.id;
         // TODO(sjmiles): was supposed to be type agnostic ... oh well
-        if (!collection.find(show => show.showid === item.showid)) {
+        //if (!collection.find(show => show.showid === item.showid)) {
           this.updateSet('collection', item);
-        }
+        //}
       }
     }
   };

--- a/artifacts/Showcase/ShowcaseArtist.recipes
+++ b/artifacts/Showcase/ShowcaseArtist.recipes
@@ -20,8 +20,8 @@ particle ShowcaseArtistPanel in './source/ShowcaseArtistPanel.js'
     provide nearbyShows
     provide nowPlayingList
 
-recipe ShowcaseArtistPanel
-  map as artist
-  ShowcaseArtistPanel
-    artist = artist
-  description `see info about ${ShowcaseArtistPanel.artist}`
+//recipe ShowcaseArtistPanel
+//  map as artist
+//  ShowcaseArtistPanel
+//    artist = artist
+//  description `see info about ${ShowcaseArtistPanel.artist}`

--- a/artifacts/TVMaze/TVMazeShow.recipes
+++ b/artifacts/TVMaze/TVMazeShow.recipes
@@ -6,19 +6,7 @@
 // subject to an additional IP rights grant found at
 // http://polymer.github.io/PATENTS.txt
 
-schema TVMazeShow
-  Text showid
-  Text name
-  Text description
-  Text image
-  Text network
-  Text day
-  Text time
-  Text suggestion
-  Text extra
-  Boolean favorite
-  Boolean delete
-  //description `${name} is on ${network} at ${time} on {$day}`
+import 'TVMazeShow.schema'
 
 particle TVMazeShowTile in './source/TVMazeShowTile.js'
   in TVMazeShow show

--- a/artifacts/TVMaze/TVMazeShow.schema
+++ b/artifacts/TVMaze/TVMazeShow.schema
@@ -1,0 +1,21 @@
+// @license
+// Copyright (c) 2017 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+schema TVMazeShow
+  Text showid
+  Text name
+  Text description
+  Text image
+  Text network
+  Text day
+  Text time
+  Text suggestion
+  Text extra
+  Boolean favorite
+  Boolean delete
+  //description `${name} is on ${network} at ${time} on {$day}`


### PR DESCRIPTION
... also, store history for `artist` and `play_record` (`all_piped-all_showcase_artists
` and `all_piped-all_showcase_play_record` respectively).

Changes piped-arc structure (users will need to Plunge Pipes to get latest features).