### PR TITLE
Allow Devtools to connect to remote planning node

### DIFF
--- a/devtools/src/devtools.js
+++ b/devtools/src/devtools.js
@@ -71,7 +71,7 @@
   function connectViaWebSocket() {
     let ws;
 
-    let retriesLeft = 5;
+    let retriesLeft = 10;
     (function createWebSocket() {
       ws = new WebSocket('ws://localhost:8787');
       ws.onopen = e => {
@@ -81,7 +81,7 @@
       };
       ws.onerror = e => {
         console.log(`No WebSocket connection found, ${retriesLeft} retries left.`);
-        if (retriesLeft--) setTimeout(createWebSocket, 300);
+        if (retriesLeft--) setTimeout(createWebSocket, 500);
       };
     })();
     return msg => ws.send(JSON.stringify(msg));

--- a/shell/apps/remote-planning/debug.cmd
+++ b/shell/apps/remote-planning/debug.cmd
@@ -1,1 +1,1 @@
-node --inspect-brk --experimental-modules --loader ../../../tools/custom-loader.mjs index.js
+node --inspect-brk --experimental-modules --loader ../../../tools/custom-loader.mjs index.js %*

--- a/shell/apps/remote-planning/debug.sh
+++ b/shell/apps/remote-planning/debug.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-node --inspect-brk --experimental-modules --loader ../../../tools/custom-loader.mjs index.js
+node --inspect-brk --experimental-modules --loader ../../../tools/custom-loader.mjs index.js "$@"

--- a/shell/apps/remote-planning/interface.js
+++ b/shell/apps/remote-planning/interface.js
@@ -14,6 +14,7 @@
 import {UserPlanner} from './user-planner.js';
 import {UserContext} from './shell/user-context.js';
 import {ArcFactory} from './arc-factory.js';
+import {DevtoolsConnection} from '../../../runtime/debug/devtools-connection.js';
 
 const manifest = `
   import 'https://$artifacts/canonical.manifest'
@@ -29,6 +30,12 @@ export class ShellPlanningInterface {
   static async start(assetsPath, userid) {
     if (!assetsPath || !userid) {
       throw new Error('assetsPath and userid required');
+    }
+
+    if (process.argv.includes('--explore')) {
+      console.log('Waiting for Arcs Explorer');
+      DevtoolsConnection.ensure();
+      await DevtoolsConnection.onceConnected;  
     }
     
     const factory = new ArcFactory(assetsPath);

--- a/shell/apps/remote-planning/serve.cmd
+++ b/shell/apps/remote-planning/serve.cmd
@@ -1,1 +1,1 @@
-node --experimental-modules --loader ../../../tools/custom-loader.mjs index.js
+node --experimental-modules --loader ../../../tools/custom-loader.mjs index.js %*

--- a/shell/apps/remote-planning/serve.sh
+++ b/shell/apps/remote-planning/serve.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-node --experimental-modules --loader ../../../tools/custom-loader.mjs index.js
+node --experimental-modules --loader ../../../tools/custom-loader.mjs index.js "$@"


### PR DESCRIPTION
Running `serve` or `debug` with `--explore` with wait for the devtools to connect.

The UI is not yet suitable for multi-user and multi-arc server, but it's a start.