### PR TITLE
Reverse pec

### DIFF
--- a/artifacts/Music/source/FilterPlaylists.js
+++ b/artifacts/Music/source/FilterPlaylists.js
@@ -39,7 +39,7 @@ ${styles}
       if (props.artist && props.allPlaylists && props.artistsPlaylists.length === 0) {
         const artistName = props.artist.name.toLowerCase();
         const artistsPlaylists = this.handles.get('artistsPlaylists');
-        const cursor = await props.allPlaylists.stream(40);
+        const cursor = await props.allPlaylists.stream({pageSize: 40});
         const promises = [];
         for (;;) {
           let {value, done} = await cursor.next();

--- a/runtime/api-channel.js
+++ b/runtime/api-channel.js
@@ -265,7 +265,7 @@ export class PECOuterPort extends APIPort {
     this.registerHandler('HandleStore', {handle: this.Mapped, callback: this.Direct, data: this.Direct, particleId: this.Direct});
     this.registerHandler('HandleRemove', {handle: this.Mapped, callback: this.Direct, data: this.Direct, particleId: this.Direct});
     this.registerHandler('HandleRemoveMultiple', {handle: this.Mapped, callback: this.Direct, data: this.Direct, particleId: this.Direct});
-    this.registerHandler('HandleStream', {handle: this.Mapped, callback: this.Direct, pageSize: this.Direct});
+    this.registerHandler('HandleStream', {handle: this.Mapped, callback: this.Direct, pageSize: this.Direct, forward: this.Direct});
     this.registerHandler('StreamCursorNext', {handle: this.Mapped, callback: this.Direct, cursorId: this.Direct});
     this.registerHandler('StreamCursorClose', {handle: this.Mapped, cursorId: this.Direct});
 
@@ -320,7 +320,7 @@ export class PECInnerPort extends APIPort {
     this.registerCall('HandleStore', {handle: this.Mapped, callback: this.LocalMapped, data: this.Direct, particleId: this.Direct});
     this.registerCall('HandleRemove', {handle: this.Mapped, callback: this.LocalMapped, data: this.Direct, particleId: this.Direct});
     this.registerCall('HandleRemoveMultiple', {handle: this.Mapped, callback: this.LocalMapped, data: this.Direct, particleId: this.Direct});
-    this.registerCall('HandleStream', {handle: this.Mapped, callback: this.LocalMapped, pageSize: this.Direct});
+    this.registerCall('HandleStream', {handle: this.Mapped, callback: this.LocalMapped, pageSize: this.Direct, forward: this.Direct});
     this.registerCall('StreamCursorNext', {handle: this.Mapped, callback: this.LocalMapped, cursorId: this.Direct});
     this.registerCall('StreamCursorClose', {handle: this.Mapped, cursorId: this.Direct});
 

--- a/runtime/particle-execution-host.js
+++ b/runtime/particle-execution-host.js
@@ -69,8 +69,8 @@ export class ParticleExecutionHost {
       this._apiPort.SimpleCallback({callback});
     };
 
-    this._apiPort.onHandleStream = async ({handle, callback, pageSize}) => {
-      this._apiPort.SimpleCallback({callback, data: await handle.stream(pageSize)});
+    this._apiPort.onHandleStream = async ({handle, callback, pageSize, forward}) => {
+      this._apiPort.SimpleCallback({callback, data: await handle.stream(pageSize, forward)});
     };
 
     this._apiPort.onStreamCursorNext = async ({handle, callback, cursorId}) => {

--- a/runtime/storage-proxy.js
+++ b/runtime/storage-proxy.js
@@ -500,9 +500,9 @@ class BigCollectionProxy extends StorageProxyBase {
       this._port.HandleRemove({handle: this, callback: resolve, data: {id, keys: []}, particleId}));
   }
 
-  async stream(pageSize) {
+  async stream(pageSize, forward) {
     return new Promise(resolve =>
-      this._port.HandleStream({handle: this, callback: resolve, pageSize}));
+      this._port.HandleStream({handle: this, callback: resolve, pageSize, forward}));
   }
 
   async cursorNext(cursorId) {

--- a/runtime/test/particle-api-test.js
+++ b/runtime/test/particle-api-test.js
@@ -721,14 +721,14 @@ describe('particle-api', function() {
           return class P extends Particle {
             async setHandles(handles) {
               this.resHandle = handles.get('res');
-              let cursor = await handles.get('big').stream(3);
+              let cursor = await handles.get('big').stream({pageSize: 3});
               for (let i = 0; i < 3; i++) {
-                let data = await cursor.next();
-                if (data.done) {
+                let {value, done} = await cursor.next();
+                if (done) {
                   this.addResult('done');
                   return;
                 }
-                this.addResult(data.value.map(item => item.rawData.value).join(','));
+                this.addResult(value.map(item => item.rawData.value).join(','));
               }
               this.addResult('error - cursor did not terminate correctly');
             }

--- a/runtime/test/volatile-storage-test.js
+++ b/runtime/test/volatile-storage-test.js
@@ -356,7 +356,7 @@ describe('volatile', function() {
       await col.store({id: 'p07', data: 'vp07'}, ['kXX']);
       await col.store({id: 'q04', data: 'vq04'}, ['kYY']);
 
-      let cid1 = await col.stream(6, {forward: false});
+      let cid1 = await col.stream(6, false);
       await checkNext(col, cid1, ['q04', 'p07', 'o10', 'x09', 'g08', 'y06']);
 
       await col.store({id: 'f11', data: 'vf11'}, ['kf11']);
@@ -364,7 +364,7 @@ describe('volatile', function() {
       await col.remove('o10');
 
       // Interleave another cursor at a different version.
-      let cid2 = await col.stream(20, {forward: false});
+      let cid2 = await col.stream(20, false);
       assert.equal(col.cursorVersion(cid2), col.cursorVersion(cid1) + 3);
       await checkNext(col, cid2, ['f11', 'q04', 'p07', 'x09', 'g08', 'h05', 'z03', 'i02', 'r01']);
       
@@ -373,7 +373,7 @@ describe('volatile', function() {
       await checkDone(col, cid2);
 
       // Verify close().
-      let cid3 = await col.stream(3, {forward: false});
+      let cid3 = await col.stream(3, false);
       await checkNext(col, cid3, ['f11', 'q04', 'p07']);
       col.cursorClose(cid3);
       await checkDone(col, cid3);

--- a/runtime/ts/handle.ts
+++ b/runtime/ts/handle.ts
@@ -394,18 +394,26 @@ class BigCollection extends Handle {
     return this._proxy.remove(serialization.id, [], this._particleId);
   }
 
-  /** @method stream(pageSize)
+  /** @method stream({pageSize, forward})
    * Returns a Cursor instance that iterates over the full set of entities, reading `pageSize`
    * entities at a time. The cursor views a snapshot of the collection, locked to the version
    * at which the cursor is created.
+   *
+   * By default items are returned in order of original insertion into the collection (with the
+   * caveat that items removed during a streamed read may be returned at the end). Set `forward`
+   * to false to return items in reverse insertion order.
+   *
    * throws: Error if this variable is not configured as a readable handle (i.e. 'in' or 'inout')
    * in the particle's manifest.
    */
-  async stream(pageSize: number) {
+  async stream({pageSize, forward = true}) {
     if (!this.canRead) {
       throw new Error('Handle not readable');
     }
-    const cursorId = await this._proxy.stream(pageSize);
+    if (isNaN(pageSize) || pageSize < 1) {
+      throw new Error('Streamed reads require a positive pageSize');
+    }
+    const cursorId = await this._proxy.stream(pageSize, forward);
     return new Cursor(this, cursorId);
   }
 }

--- a/runtime/ts/storage/firebase-storage.ts
+++ b/runtime/ts/storage/firebase-storage.ts
@@ -1371,7 +1371,7 @@ class FirebaseBigCollection extends FirebaseStorageProvider {
   // By default items are returned in order of original insertion into the collection (with the
   // caveat that items removed during a streamed read may be returned at the end). Set forward to
   // false to return items in reverse insertion order.
-  async stream(pageSize, {forward = true} = {}) {
+  async stream(pageSize, forward = true) {
     assert(!isNaN(pageSize) && pageSize > 0);
     this.cursorIndex++;
     const cursor = new FirebaseCursor(this.reference, pageSize, forward);

--- a/runtime/ts/storage/volatile-storage.ts
+++ b/runtime/ts/storage/volatile-storage.ts
@@ -543,7 +543,7 @@ class VolatileBigCollection extends VolatileStorageProvider {
     this.items.delete(id);
   }
 
-  async stream(pageSize, {forward = true} = {}) {
+  async stream(pageSize, forward = true) {
     assert(!isNaN(pageSize) && pageSize > 0);
     this.cursorIndex++;
     const cursor = new VolatileCursor(this.version, this.items.values(), pageSize, forward);


### PR DESCRIPTION
I've also changed the API to pass simple args within the runtime storage area (because that's basically wired in and won't be accessed from outside the system), but use named objects fields in particles (so particle authors have a clearer but more verbose API).