### PR TITLE
Don't keep in-memory traces if streaming them to DevTools

### DIFF
--- a/devtools/src/arcs-tracing.js
+++ b/devtools/src/arcs-tracing.js
@@ -60,7 +60,6 @@ $_documentContainer.innerHTML = `<dom-module id="arcs-tracing">
           <div class="buttons-panel">
             <iron-icon on-click="_fit" title="Fit to events" icon="maps:zoom-out-map"></iron-icon>
             <iron-icon on-click="_redraw" title="Redraw timeline if looks weird" icon="image:brush"></iron-icon>
-            <iron-icon id="download" on-click="_download" title="Download for inspection in chrome://tracing" icon="file-download"></iron-icon>
           </div>
           zoom-key: ctrl
         </div>
@@ -317,10 +316,6 @@ class ArcsTracing extends MessengerMixin(PolymerElement) {
       this._groups.update({id: g.id, visible: active});
     });
     this._groups.flush();
-  }
-
-  _download() {
-    chrome.devtools.inspectedWindow.eval('Arcs.Tracing.download()');
   }
 
   _redraw() {

--- a/tracelib/test/trace-tests.js
+++ b/tracelib/test/trace-tests.js
@@ -306,6 +306,8 @@ describe('Tracing', function() {
     Tracing.start({cat: 'Stuff', name: 'Moar::things'}).end();
     await Promise.resolve();
     assert.deepEqual(events.map(e => e.name), ['Thingy::thing', 'Other::thing', 'Moar::things']);
+
+    assert.deepEqual(Tracing.save().traceEvents, []);
   });
 
   it('allows filtering while streaming', async () => {

--- a/tracelib/trace.js
+++ b/tracelib/trace.js
@@ -55,7 +55,8 @@ function pushEvent(event) {
     if (!event.cat) {
       event.cat = '';
     }
-    events.push(event);
+    // Only keep events in memory if we're not streaming them.
+    if (streamingCallbacks.length === 0) events.push(event);
     Promise.resolve().then(() => {
       for (let {callback, predicate} of streamingCallbacks) {
           if (!predicate || predicate(event)) callback(event);
@@ -265,6 +266,8 @@ function init() {
   };
   module.exports.now = now;
   module.exports.stream = function(callback, predicate) {
+    // Once we start streaming we no longer keep events in memory.
+    events.length = 0;
     streamingCallbacks.push({callback, predicate});
   };
   module.exports.__clearForTests = function() {


### PR DESCRIPTION
This should fix #2090.