### PR TITLE
Auto range resize in devtools tracing UI

### DIFF
--- a/devtools/src/arcs-tracing.js
+++ b/devtools/src/arcs-tracing.js
@@ -229,6 +229,7 @@ class ArcsTracing extends MessengerMixin(PolymerElement) {
           this._items.clear();
           this._startupTime = null;
           if (this._timeline) this._timeline.removeCustomTime('startup');
+          this._autoWindowResize = true;
           return;
       }
     }
@@ -255,15 +256,14 @@ class ArcsTracing extends MessengerMixin(PolymerElement) {
       this._timeline.on('itemover', props => {
         this._selectedItem = this._items.get(props.item);
       });
+      this._timeline.on('rangechange', ({byUser}) => {
+        if (byUser) this._autoWindowResize = false;
+      });
       if (this._startupTime) {
         this._timeline.addCustomTime(this._startupTime, 'startup');
       }
-    } else if (this._timeline && startEmpty) {
-      // Refocus on new events after a page refresh.
-      this._timeline.setWindow({
-        start: this._items.min('start').start,
-        end: this._aBitInTheFuture()
-      });
+    } else if (this._timeline && this._autoWindowResize) {
+      this._fit();
     }
   }
 
@@ -328,13 +328,12 @@ class ArcsTracing extends MessengerMixin(PolymerElement) {
   }
 
   _fit() {
+    this._autoWindowResize = true;
     if (this._timeline && this._items.length > 0) {
       // There's timeline.fit(), but it doesn't leave margins and looks weird.
       let start = this._items.min('start').start;
       let end = this._items.max('end').end;
-      const fraction = (end - start) * .05;
-      start = start - fraction;
-      end = end + fraction;
+      end = end + (end - start) * .1;
       this._timeline.setWindow({start, end});
     }
   }


### PR DESCRIPTION
Keeps all events in the view until the user manually moves or zooms the timeline.