### PR TITLE
Throw error when a handle tries to write to a non-handle

### DIFF
--- a/runtime/manifest.js
+++ b/runtime/manifest.js
@@ -865,6 +865,8 @@ ${e.message}
             entry = {item: handle.item, handle};
             items.byName.set(handle.localName, entry);
             items.byHandle.set(handle, handle.item);
+          } else if (!entry.item) {
+            throw new Error(`did not expect ${entry} expected handle or particle`);
           }
 
           if (entry.item.kind == 'handle') {


### PR DESCRIPTION
The entry created via
```
let entry = items.byName.get(connectionItem.target.name);
```
may not have a `.item` field.

This adds an exception for this case.