### PR TITLE
Add SLANDLES version of 'recipe slots with different names' test

### DIFF
--- a/runtime/test/manifest-test.js
+++ b/runtime/test/manifest-test.js
@@ -805,9 +805,9 @@ ${particleStr1}
     assert.lengthOf(manifest.recipes, 1);
     let recipe = manifest.recipes[0];
     assert.lengthOf(recipe.handles, 2);
-    //TODO(jopra): Give recipes the dependentConnections syntax+handling
-    // assert.equal(recipe.particles.find(p => p.name == 'ParticleB').consumedSlotConnections['slotB1'].providedSlots['slotB2'],
-      //            recipe.particles.find(p => p.name == 'ParticleA').consumedSlotConnections['slotA'].targetSlot);
+    assert.equal(
+      recipe.particles.find(p => p.name == 'ParticleA')._connections['slotA']._handle._localName,
+      recipe.particles.find(p => p.name == 'ParticleB')._connections['slotB2']._handle._localName);
     recipe.normalize();
     assert.isTrue(recipe.isResolved());
   });

--- a/runtime/test/manifest-test.js
+++ b/runtime/test/manifest-test.js
@@ -806,8 +806,8 @@ ${particleStr1}
     let recipe = manifest.recipes[0];
     assert.lengthOf(recipe.handles, 2);
     assert.equal(
-      recipe.particles.find(p => p.name == 'ParticleA')._connections['slotA']._handle._localName,
-      recipe.particles.find(p => p.name == 'ParticleB')._connections['slotB2']._handle._localName);
+      recipe.particles.find(p => p.name == 'ParticleA')._connections['slotA'].handle,
+      recipe.particles.find(p => p.name == 'ParticleB')._connections['slotB2'].handle);
     recipe.normalize();
     assert.isTrue(recipe.isResolved());
   });

--- a/runtime/test/manifest-test.js
+++ b/runtime/test/manifest-test.js
@@ -786,6 +786,31 @@ ${particleStr1}
     recipe.normalize();
     assert.isTrue(recipe.isResolved());
   });
+  it('SLANDLES recipe slots with different names', async () => {
+    let manifest = await Manifest.parse(`
+      particle ParticleA in 'some-particle.js'
+        \`consume Slot slotA
+      particle ParticleB in 'some-particle.js'
+        \`consume Slot slotB1
+          \`provide Slot slotB2
+      recipe
+        \`slot 'slot-id0' as s0
+        ParticleA
+          slotA consume mySlot
+        ParticleB
+          slotB1 consume s0
+          slotB2 provide mySlot
+    `);
+    assert.lengthOf(manifest.particles, 2);
+    assert.lengthOf(manifest.recipes, 1);
+    let recipe = manifest.recipes[0];
+    assert.lengthOf(recipe.handles, 2);
+    //TODO(jopra): Give recipes the dependentConnections syntax+handling
+    // assert.equal(recipe.particles.find(p => p.name == 'ParticleB').consumedSlotConnections['slotB1'].providedSlots['slotB2'],
+      //            recipe.particles.find(p => p.name == 'ParticleA').consumedSlotConnections['slotA'].targetSlot);
+    recipe.normalize();
+    assert.isTrue(recipe.isResolved());
+  });
   it('recipe provided slot with no local name', async () => {
     let manifest = await Manifest.parse(`
       particle ParticleA in 'some-particle.js'


### PR DESCRIPTION
First pass at converting 'recipe slots with different names' test to SLANDLES.

At the moment the parser does not handle dependent connections (it may not make sense to do so), as such I've commented out an assertion that used to check the providedSlots associated with the consumed slots.