### PR TITLE
Planificator refactoring

### DIFF
--- a/runtime/planificator.js
+++ b/runtime/planificator.js
@@ -5,6 +5,9 @@
 // subject to an additional IP rights grant found at
 // http://polymer.github.io/PATENTS.txt
 
+// Deprecated.
+// TODO: Replace by ts/planificator.ts
+
 import {assert} from '../platform/assert-web.js';
 import {now} from '../platform/date-web.js';
 import {InitSearch} from './strategies/init-search.js';

--- a/runtime/suggestion-storage.js
+++ b/runtime/suggestion-storage.js
@@ -116,8 +116,8 @@ export class SuggestionStorage {
   async _planFromString(planString) {
     const manifest = await Manifest.parse(
         planString, {loader: this._arc.loader, context: this._arc._context, fileName: ''});
-    assert(manifest._recipes.length == 1);
-    let plan = manifest._recipes[0];
+    assert(manifest.recipes.length == 1);
+    let plan = manifest.recipes[0];
     assert(plan.normalize(), `can't normalize deserialized suggestion: ${plan.toString()}`);
     if (!plan.isResolved()) {
       const resolvedPlan = await this._recipeResolver.resolve(plan);

--- a/runtime/suggestion-storage.js
+++ b/runtime/suggestion-storage.js
@@ -7,6 +7,10 @@
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
+
+// Deprecated.
+// TODO: Delete, once shell fully migrated to ts/planificator.ts
+
 import {assert} from '../platform/assert-web.js';
 import {Manifest} from './ts-build/manifest.js';
 import {RecipeResolver} from './ts-build/recipe/recipe-resolver.js';

--- a/runtime/test/plan/plan-consumer-test.js
+++ b/runtime/test/plan/plan-consumer-test.js
@@ -1,0 +1,68 @@
+/**
+ * @license
+ * Copyright (c) 2017 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+import {assert} from '../chai-web.js';
+import {TestHelper} from '../../testing/test-helper.js';
+import {PlanConsumer} from '../../ts-build/plan/plan-consumer.js';
+import {Planificator} from '../../ts-build/plan/planificator.js';
+import {PlanningResult} from '../../ts-build/plan/planning-result.js';
+
+describe('plan consumer', function() {
+  it('consumes', async function() {
+    let helper = await TestHelper.createAndPlan({
+      manifestFilename: './runtime/test/artifacts/Products/Products.recipes'
+    });
+    const userid = 'TestUser';
+    helper.arc.storageKey = 'firebase://xxx.firebaseio.com/yyy/serialization/zzz';
+    const store = await Planificator._initStore(helper.arc, {userid, protocol: 'volatile'});
+    assert.isNotNull(store);
+    let consumer = new PlanConsumer(helper.arc, store);
+
+    let planChangeCount = 0;
+    const planCallback = (plans) => { ++planChangeCount; };
+    let suggestChangeCount = 0;
+    const suggestCallback = (plans) => { ++suggestChangeCount; };
+    consumer.registerPlansChangedCallback(planCallback);
+    consumer.registerSuggestChangedCallback(suggestCallback);
+    assert.isEmpty(consumer.getCurrentSuggestions());
+
+    const storeResults = async (plans) => {
+      let result = new PlanningResult(helper.arc);
+      result.set({plans});
+      await store.set(result.serialize());
+      await new Promise(resolve => setTimeout(resolve, 100));
+    };
+    // Updates plans.
+    await storeResults([helper.plans[0]]);
+    assert.lengthOf(consumer.result.plans, 1);
+    assert.lengthOf(consumer.getCurrentSuggestions(), 0);
+    assert.equal(planChangeCount, 1);
+    assert.equal(suggestChangeCount, 0);
+
+    // Shows all suggestions.
+    consumer.setSuggestFilter(true);
+    assert.lengthOf(consumer.result.plans, 1);
+    assert.lengthOf(consumer.getCurrentSuggestions(), 1);
+    assert.equal(planChangeCount, 1);
+    assert.equal(suggestChangeCount, 1);
+
+    // Filters suggestions by string.
+    consumer.setSuggestFilter(false, 'show');
+    assert.lengthOf(consumer.result.plans, 1);
+    assert.lengthOf(consumer.getCurrentSuggestions(), 1);
+    assert.equal(planChangeCount, 1);
+    assert.equal(suggestChangeCount, 1);
+
+    consumer.setSuggestFilter(false);
+    assert.lengthOf(consumer.result.plans, 1);
+    assert.lengthOf(consumer.getCurrentSuggestions(), 0);
+    assert.equal(planChangeCount, 1);
+    assert.equal(suggestChangeCount, 2);
+  });
+});

--- a/runtime/test/plan/plan-consumer-test.js
+++ b/runtime/test/plan/plan-consumer-test.js
@@ -15,14 +15,14 @@ import {PlanningResult} from '../../ts-build/plan/planning-result.js';
 
 describe('plan consumer', function() {
   it('consumes', async function() {
-    let helper = await TestHelper.createAndPlan({
+    const helper = await TestHelper.createAndPlan({
       manifestFilename: './runtime/test/artifacts/Products/Products.recipes'
     });
     const userid = 'TestUser';
     helper.arc.storageKey = 'firebase://xxx.firebaseio.com/yyy/serialization/zzz';
     const store = await Planificator._initStore(helper.arc, {userid, protocol: 'volatile'});
     assert.isNotNull(store);
-    let consumer = new PlanConsumer(helper.arc, store);
+    const consumer = new PlanConsumer(helper.arc, store);
 
     let planChangeCount = 0;
     const planCallback = (plans) => { ++planChangeCount; };
@@ -33,7 +33,7 @@ describe('plan consumer', function() {
     assert.isEmpty(consumer.getCurrentSuggestions());
 
     const storeResults = async (plans) => {
-      let result = new PlanningResult(helper.arc);
+      const result = new PlanningResult(helper.arc);
       result.set({plans});
       await store.set(result.serialize());
       await new Promise(resolve => setTimeout(resolve, 100));

--- a/runtime/test/plan/plan-producer-test.js
+++ b/runtime/test/plan/plan-producer-test.js
@@ -122,7 +122,7 @@ describe('plan producer', function() {
     assert.equal(producer.cancelCount, 0);
   });
 
-  it.only('cancels planning', async function() {
+  it('cancels planning', async function() {
     let {helper, producer} = await createProducer('./runtime/test/artifacts/Products/Products.recipes');
     assert.lengthOf(producer.result.plans, 0);
 

--- a/runtime/test/plan/plan-producer-test.js
+++ b/runtime/test/plan/plan-producer-test.js
@@ -43,7 +43,7 @@ class TestPlanProducer extends PlanProducer {
   async runPlanner(options) {
     ++this.plannerRunCount;
     return new Promise((resolve, reject) => {
-      let plans = this.plannerNextResults.shift();
+      const plans = this.plannerNextResults.shift();
       if (plans) {
         resolve(plans);
       } else {
@@ -54,12 +54,12 @@ class TestPlanProducer extends PlanProducer {
   }
 
   plannerReturnFakeResults(planInfos) {
-    let plans = [];
+    const plans = [];
     planInfos.forEach(info => {
       if (!info.hash) {
         info = {hash: info};
       }
-      let plan = new Recipe(`recipe${info.hash}`);
+      const plan = new Recipe(`recipe${info.hash}`);
       if (!info.options || !info.options.invisible) {
         plan.newSlot('slot0').id = 'id0';
       }
@@ -82,17 +82,17 @@ class TestPlanProducer extends PlanProducer {
 
 describe('plan producer', function() {
   async function createProducer(manifestFilename) {
-    let helper = await TestHelper.createAndPlan({
+    const helper = await TestHelper.createAndPlan({
       manifestFilename: './runtime/test/artifacts/Products/Products.recipes'
     });
     helper.arc.storageKey = 'firebase://xxx.firebaseio.com/yyy/serialization/zzz';
     const store = await Planificator._initStore(helper.arc, {userid: 'TestUser', protocol: 'volatile'});
     assert.isNotNull(store);
-    let producer = new TestPlanProducer(helper.arc, store);
+    const producer = new TestPlanProducer(helper.arc, store);
     return {helper, producer};
   }
   it('produces plans', async function() {
-    let {helper, producer} = await createProducer('./runtime/test/artifacts/Products/Products.recipes');
+    const {helper, producer} = await createProducer('./runtime/test/artifacts/Products/Products.recipes');
     assert.lengthOf(producer.result.plans, 0);
 
     await producer.producePlans();
@@ -107,7 +107,7 @@ describe('plan producer', function() {
   });
   
   it('throttles requests to produce plans', async function() {
-    let {helper, producer} = await createProducer('./runtime/test/artifacts/Products/Products.recipes');
+    const {helper, producer} = await createProducer('./runtime/test/artifacts/Products/Products.recipes');
     assert.lengthOf(producer.result.plans, 0);
 
     for (let i = 0; i < 10; ++i) {
@@ -123,7 +123,7 @@ describe('plan producer', function() {
   });
 
   it('cancels planning', async function() {
-    let {helper, producer} = await createProducer('./runtime/test/artifacts/Products/Products.recipes');
+    const {helper, producer} = await createProducer('./runtime/test/artifacts/Products/Products.recipes');
     assert.lengthOf(producer.result.plans, 0);
 
     producer.producePlans();

--- a/runtime/test/plan/plan-producer-test.js
+++ b/runtime/test/plan/plan-producer-test.js
@@ -8,7 +8,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 import {assert} from '../chai-web.js';
-import {Recipe} from '../../recipe/recipe.js';
+import {Recipe} from '../../ts-build/recipe/recipe.js';
 import {TestHelper} from '../../testing/test-helper.js';
 import {PlanProducer} from '../../ts-build/plan/plan-producer.js';
 import {Planificator} from '../../ts-build/plan/planificator.js';

--- a/runtime/test/plan/plan-producer-test.js
+++ b/runtime/test/plan/plan-producer-test.js
@@ -1,0 +1,138 @@
+/**
+ * @license
+ * Copyright (c) 2017 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+import {assert} from '../chai-web.js';
+import {Recipe} from '../../recipe/recipe.js';
+import {TestHelper} from '../../testing/test-helper.js';
+import {PlanProducer} from '../../ts-build/plan/plan-producer.js';
+import {Planificator} from '../../ts-build/plan/planificator.js';
+
+class TestPlanProducer extends PlanProducer {
+  constructor(arc, store) {
+    super(arc, store);
+    this.produceCalledCount = 0;
+    this.plannerRunCount = 0;
+    this.cancelCount = 0;
+    this.producePromises = [];
+    this.plannerNextResults = [];
+    this.plannerPromise = null;
+  }
+
+  async producePlans(options) {
+    ++this.produceCalledCount;
+    this.producePromises.push(super.producePlans(options));
+  }
+
+  _cancelPlanning() {
+    ++this.cancelCount;
+    this.plannerPromise(null);
+    this.plannerPromise = null;
+    super._cancelPlanning();
+  }
+
+  async allPlanningDone() {
+    return Promise.all(this.producePromises).then(() => this.producePromises = []);
+  }
+
+  async runPlanner(options) {
+    ++this.plannerRunCount;
+    return new Promise((resolve, reject) => {
+      let plans = this.plannerNextResults.shift();
+      if (plans) {
+        resolve(plans);
+      } else {
+        assert(!this.plannerPromise);
+        this.plannerPromise = resolve;
+      }
+    }).then(plans => plans);
+  }
+
+  plannerReturnFakeResults(planInfos) {
+    let plans = [];
+    planInfos.forEach(info => {
+      if (!info.hash) {
+        info = {hash: info};
+      }
+      let plan = new Recipe(`recipe${info.hash}`);
+      if (!info.options || !info.options.invisible) {
+        plan.newSlot('slot0').id = 'id0';
+      }
+      plan.normalize();
+      plans.push({plan, hash: info.hash});
+    });
+    this.plannerReturnResults(plans);
+    return plans;
+  }
+
+  plannerReturnResults(plans) {
+    if (this.plannerPromise) {
+      this.plannerPromise(plans);
+      this.plannerPromise = null;
+    } else {
+      this.plannerNextResults.push(plans);
+    }
+  }
+}
+
+describe('plan producer', function() {
+  async function createProducer(manifestFilename) {
+    let helper = await TestHelper.createAndPlan({
+      manifestFilename: './runtime/test/artifacts/Products/Products.recipes'
+    });
+    helper.arc.storageKey = 'firebase://xxx.firebaseio.com/yyy/serialization/zzz';
+    const store = await Planificator._initStore(helper.arc, {userid: 'TestUser', protocol: 'volatile'});
+    assert.isNotNull(store);
+    let producer = new TestPlanProducer(helper.arc, store);
+    return {helper, producer};
+  }
+  it('produces plans', async function() {
+    let {helper, producer} = await createProducer('./runtime/test/artifacts/Products/Products.recipes');
+    assert.lengthOf(producer.result.plans, 0);
+
+    await producer.producePlans();
+    assert.lengthOf(producer.result.plans, 0);
+
+    producer.plannerReturnFakeResults(helper.plans);
+    await producer.allPlanningDone();
+    assert.lengthOf(producer.result.plans, 1);
+    assert.equal(producer.produceCalledCount, 1);
+    assert.equal(producer.plannerRunCount, 1);
+    assert.equal(producer.cancelCount, 0);
+  });
+  
+  it('throttles requests to produce plans', async function() {
+    let {helper, producer} = await createProducer('./runtime/test/artifacts/Products/Products.recipes');
+    assert.lengthOf(producer.result.plans, 0);
+
+    for (let i = 0; i < 10; ++i) {
+      producer.producePlans();
+    }
+
+    producer.plannerReturnFakeResults(helper.plans);
+    producer.plannerReturnFakeResults(helper.plans);
+    await producer.allPlanningDone();
+    assert.equal(producer.produceCalledCount, 10);
+    assert.equal(producer.plannerRunCount, 2);
+    assert.equal(producer.cancelCount, 0);
+  });
+
+  it.only('cancels planning', async function() {
+    let {helper, producer} = await createProducer('./runtime/test/artifacts/Products/Products.recipes');
+    assert.lengthOf(producer.result.plans, 0);
+
+    producer.producePlans();
+    producer.producePlans({cancelOngoingPlanning: true});
+
+    producer.plannerReturnFakeResults(helper.plans);
+    await producer.allPlanningDone();
+    assert.equal(producer.produceCalledCount, 2);
+    assert.equal(producer.plannerRunCount, 2);
+    assert.equal(producer.cancelCount, 1);
+  });
+});

--- a/runtime/test/plan/planning-result-test.js
+++ b/runtime/test/plan/planning-result-test.js
@@ -13,13 +13,13 @@ import {PlanningResult} from '../../ts-build/plan/planning-result.js';
 
 describe('planning result', function() {
   async function testResultSerialization(manifestFilename) {
-    let helper = await TestHelper.createAndPlan({manifestFilename});
+    const helper = await TestHelper.createAndPlan({manifestFilename});
     assert.isNotEmpty(helper.plans);
-    let result = new PlanningResult(helper.arc, {plans: helper.plans});
+    const result = new PlanningResult(helper.arc, {plans: helper.plans});
 
-    let serialization = result.serialize();
+    const serialization = result.serialize();
     assert(serialization.plans);
-    let resultNew = new PlanningResult(helper.arc);
+    const resultNew = new PlanningResult(helper.arc);
     assert.isEmpty(resultNew.plans);
     await resultNew.deserialize({plans: serialization.plans});
     assert.isTrue(resultNew.isEquivalent(helper.plans));

--- a/runtime/test/plan/planning-result-test.js
+++ b/runtime/test/plan/planning-result-test.js
@@ -24,7 +24,7 @@ describe('planning result', function() {
     await resultNew.deserialize({plans: serialization.plans});
     assert.isTrue(resultNew.isEquivalent(helper.plans));
   }
-  it('serializes and deserializes Products recipes', async function() {
+  it.only('serializes and deserializes Products recipes', async function() {
     await testResultSerialization('./runtime/test/artifacts/Products/Products.recipes');
   });
 

--- a/runtime/test/plan/planning-result-test.js
+++ b/runtime/test/plan/planning-result-test.js
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright (c) 2017 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+'use strict';
+
+import {assert} from '../chai-web.js';
+import {TestHelper} from '../../testing/test-helper.js';
+import {PlanningResult} from '../../ts-build/plan/planning-result.js';
+
+describe('planning result', function() {
+  async function testResultSerialization(manifestFilename) {
+    let helper = await TestHelper.createAndPlan({manifestFilename});
+    assert.isNotEmpty(helper.plans);
+    let result = new PlanningResult(helper.arc, {plans: helper.plans});
+
+    let serialization = result.serialize();
+    assert(serialization.plans);
+    let resultNew = new PlanningResult(helper.arc);
+    assert.isEmpty(resultNew.plans);
+    await resultNew.deserialize({plans: serialization.plans});
+    assert.isTrue(resultNew.isEquivalent(helper.plans));
+  }
+  it('serializes and deserializes Products recipes', async function() {
+    await testResultSerialization('./runtime/test/artifacts/Products/Products.recipes');
+  });
+
+  // TODO: add more recipes tests.
+});

--- a/runtime/test/plan/planning-result-test.js
+++ b/runtime/test/plan/planning-result-test.js
@@ -24,7 +24,7 @@ describe('planning result', function() {
     await resultNew.deserialize({plans: serialization.plans});
     assert.isTrue(resultNew.isEquivalent(helper.plans));
   }
-  it.only('serializes and deserializes Products recipes', async function() {
+  it('serializes and deserializes Products recipes', async function() {
     await testResultSerialization('./runtime/test/artifacts/Products/Products.recipes');
   });
 

--- a/runtime/test/plan/planning-result-test.js
+++ b/runtime/test/plan/planning-result-test.js
@@ -7,9 +7,6 @@
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
-
-'use strict';
-
 import {assert} from '../chai-web.js';
 import {TestHelper} from '../../testing/test-helper.js';
 import {PlanningResult} from '../../ts-build/plan/planning-result.js';

--- a/runtime/ts/manifest.ts
+++ b/runtime/ts/manifest.ts
@@ -105,8 +105,7 @@ type ManifestFinderGenerator<a> = ((manifest: Manifest) => IterableIterator<a>) 
 
 
 export class Manifest {
-  // TODO: rename existing getter to `allRecipes` and add getter for this._recipes.
-  _recipes = <Recipe[]>[];
+  private _recipes = <Recipe[]>[];
   private _imports = <Manifest[]>[];
     // TODO: These should be lists, possibly with a separate flattened map.
   private _particles: {[index: string]: ParticleSpec} = {};

--- a/runtime/ts/manifest.ts
+++ b/runtime/ts/manifest.ts
@@ -105,7 +105,8 @@ type ManifestFinderGenerator<a> = ((manifest: Manifest) => IterableIterator<a>) 
 
 
 export class Manifest {
-  private _recipes = <Recipe[]>[];
+  // TODO: rename existing getter to `allRecipes` and add getter for this._recipes.
+  _recipes = <Recipe[]>[];
   private _imports = <Manifest[]>[];
     // TODO: These should be lists, possibly with a separate flattened map.
   private _particles: {[index: string]: ParticleSpec} = {};

--- a/runtime/ts/plan/plan-consumer.ts
+++ b/runtime/ts/plan/plan-consumer.ts
@@ -1,0 +1,107 @@
+/**
+ * @license
+ * Copyright (c) 2017 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {assert} from '../../../platform/assert-web.js';
+import {Arc} from '../arc';
+import {PlanningResult} from './planning-result.js';
+import {StorageProviderBase} from '../storage/storage-provider-base';
+
+type Callback = ({}) => void;
+
+export class PlanConsumer {
+  arc: Arc;
+  result: PlanningResult;
+  store: StorageProviderBase;
+  suggestFilter: {};
+  plansChangeCallbacks: Callback[] = [];
+  suggestionsChangeCallbacks: Callback[] = [];
+  storeCallback: Callback;
+
+  constructor(arc, store) {
+    assert(arc, 'arc cannot be null');
+    assert(store, 'store cannot be null');
+    this.arc = arc;
+    this.result = new PlanningResult(arc);
+    this.store = store;
+    this.suggestFilter = {showAll: false};
+    this.plansChangeCallbacks = [];
+    this.suggestionsChangeCallbacks = [];
+
+    this.storeCallback = () => this.onStoreChanged();
+    this.store.on('change', this.storeCallback, this);
+  }
+
+  setSuggestFilter(showAll, search) {
+    assert(!showAll || !search);
+    if (this.suggestFilter['showAll'] === showAll && this.suggestFilter['search'] === search) {
+      return;
+    }
+    const previousSuggestions = this.getCurrentSuggestions();
+    this.suggestFilter = {showAll, search};
+    const suggestions = this.getCurrentSuggestions();
+    if (!PlanningResult.isEquivalent(previousSuggestions, suggestions)) {
+      this.suggestionsChangeCallbacks.forEach(callback => callback(suggestions));
+    }
+  }
+
+  async onStoreChanged() {
+    // Update current plans
+    assert(this.store['get'], 'Unsupported getter in suggestion storage');
+    const value = await this.store['get']() || {};
+    if (!value.plans) {
+      return;
+    }
+    const previousSuggestions = this.getCurrentSuggestions();
+    // if (this.result.set(value.current)) {
+    if (await this.result.deserialize(value)) {
+      // Notify callbacks
+      this.plansChangeCallbacks.forEach(callback => callback({plans: this.result.plans}));
+      const suggestions = this.getCurrentSuggestions();
+      if (!PlanningResult.isEquivalent(previousSuggestions, suggestions)) {
+        this.suggestionsChangeCallbacks.forEach(callback => callback(suggestions));
+      }
+    }
+  }
+
+  getCurrentSuggestions() {
+    const suggestions = this.result.plans.filter(suggestion => suggestion['plan'].slots.length > 0);
+
+    // `showAll`: returns all plans that render into slots.
+    if (this.suggestFilter['showAll']) {
+      return suggestions;
+    }
+
+    // search filter non empty: match plan search phrase or description text.
+    if (this.suggestFilter['search']) {
+      return suggestions.filter(suggestion =>
+        suggestion['descriptionText'].toLowerCase().includes(this.suggestFilter['search']) ||
+        (suggestion['plan'].search && suggestion['plan'].search.phrase.includes(this.suggestFilter['search'])));
+    }
+
+    return suggestions.filter(suggestion => {
+      const usesHandlesFromActiveRecipe = suggestion['plan'].handles.find(handle => {
+        // TODO(mmandlis): find a generic way to exlude system handles (eg Theme), either by tagging or
+        // by exploring connection directions etc.
+        return !!handle.id && this.arc.activeRecipe.handles.find(activeHandle => activeHandle.id === handle.id);
+      });
+      const usesRemoteNonRootSlots = suggestion['plan'].slots.find(slot => {
+        return !slot.name.includes('root') && !slot.tags.includes('root') && slot.id && !slot.id.includes('root');
+      });
+      const onlyUsesNonRootSlots = !suggestion['plan'].slots.find(s => s.name.includes('root') || s.tags.includes('root'));
+      return (usesHandlesFromActiveRecipe && usesRemoteNonRootSlots) || onlyUsesNonRootSlots;
+    });
+  }
+
+  dispose() {
+    this.store.off('change', this.storeCallback);
+    this.plansChangeCallbacks = [];
+    this.suggestionsChangeCallbacks = [];
+  }
+}

--- a/runtime/ts/plan/plan-consumer.ts
+++ b/runtime/ts/plan/plan-consumer.ts
@@ -27,7 +27,7 @@ export class PlanConsumer {
   storeCallback: Callback;
   suggestionComposer: SuggestionComposer|null = null;
 
-  constructor(arc, store) {
+  constructor(arc: Arc, store: StorageProviderBase) {
     assert(arc, 'arc cannot be null');
     assert(store, 'store cannot be null');
     this.arc = arc;

--- a/runtime/ts/plan/plan-producer.ts
+++ b/runtime/ts/plan/plan-producer.ts
@@ -27,7 +27,7 @@ export class PlanProducer {
   needReplan: boolean;
   isPlanning: boolean;
 
-  constructor(arc, store) {
+  constructor(arc: Arc, store: StorageProviderBase) {
     assert(arc, 'arc cannot be null');
     assert(store, 'store cannot be null');
     this.arc = arc;
@@ -84,7 +84,7 @@ export class PlanProducer {
     return null;
   }
 
-  _cancelPlanning() {
+  private _cancelPlanning() {
     if (this.planner) {
       this.planner.dispose();
       this.planner = null;
@@ -94,7 +94,7 @@ export class PlanProducer {
     console.log(`Cancel planning`);
   }
 
-  async _updateResult({plans, generations}, options) {
+  private async _updateResult({plans, generations}, options) {
     if (options.append) {
       if (!this.result.append({plans, generations})) {
         return;

--- a/runtime/ts/plan/plan-producer.ts
+++ b/runtime/ts/plan/plan-producer.ts
@@ -1,0 +1,104 @@
+// Copyright (c) 2018 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+import {assert} from '../../../platform/assert-web.js';
+import {Arc} from '../arc';
+import {now} from '../../../platform/date-web.js';
+import {Planner} from '../../planner.js';
+import {PlanningResult} from './planning-result.js';
+import {Speculator} from '../speculator';
+import {StorageProviderBase} from '../storage/storage-provider-base';
+
+const defaultTimeoutMs = 5000;
+
+export class PlanProducer {
+  arc: Arc;
+  result: PlanningResult;
+  store: StorageProviderBase;
+  planner: Planner|null = null;
+  speculator: Speculator;
+  needReplan: boolean;
+  isPlanning: boolean;
+
+  constructor(arc, store) {
+    assert(arc, 'arc cannot be null');
+    assert(store, 'store cannot be null');
+    this.arc = arc;
+    this.result = new PlanningResult(arc);
+    this.store = store;
+    this.speculator = new Speculator();
+  }
+
+  async runPlanner(options = {}) {
+    if (options['cancelOngoingPlanning'] && this.isPlanning) {
+      this._cancelPlanning();
+    }
+
+    this.needReplan = true;
+    if (this.isPlanning) {
+      return;
+    }
+    this.isPlanning = true;
+
+
+    let time = now();
+
+    let plans = [];
+    const generations = [];
+    while (this.needReplan) {
+      this.needReplan = false;
+
+      assert(!this.planner, 'Planner must be null');
+      this.planner = new Planner();
+      this.planner.init(this.arc, {
+        strategies: options['strategies']
+        // TODO: add `search` and `contextual` params.
+      });
+
+      plans = await this.planner.suggest(options['timeout'] || defaultTimeoutMs, generations, this.speculator);
+      this.planner = null;
+    }
+    time = ((now() - time) / 1000).toFixed(2);
+
+    console.log(`Produced ${plans.length}${options['append'] ? ' additional' : ''} plans [elapsed=${time}s].`);
+
+    if (this.isPlanning) {
+      this.isPlanning = false;
+      await this._updateResult({plans, generations}, options);
+    }
+  }
+
+  _cancelPlanning() {
+    if (this.planner) {
+      this.planner.dispose();
+      this.planner = null;
+    }
+    this.needReplan = false;
+    this.isPlanning = false; // using the setter method to trigger callbacks.
+    log(`Cancel planning`);
+  }
+
+  async _updateResult({plans, generations}, options) {
+    if (options.append) {
+      if (!this.result.append({plans, generations})) {
+        return;
+      }
+    } else {
+      if (!this.result.set({plans, generations})) {
+        return;
+      }
+    }
+    // Store plans to store.
+    try {
+      assert(this.store['set'], 'Unsupported setter in suggestion storage');
+      await this.store['set'](this.result.serialize());
+    } catch(e) {
+      console.error('Failed storing suggestions: ', e);
+      throw e;
+    }
+  }
+}

--- a/runtime/ts/plan/planificator.ts
+++ b/runtime/ts/plan/planificator.ts
@@ -1,49 +1,60 @@
-// Copyright (c) 2018 Google Inc. All rights reserved.
-// This code may only be used under the BSD style license found at
-// http://polymer.github.io/LICENSE.txt
-// Code distributed by Google as part of this project is also
-// subject to an additional IP rights grant found at
-// http://polymer.github.io/PATENTS.txt
+/**
+ * @license
+ * Copyright (c) 2018 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
 
 import {assert} from '../../../platform/assert-web.js';
 import {Arc} from '../arc';
 import {now} from '../../../platform/date-web.js';
 import {PlanConsumer} from './plan-consumer';
 import {PlanProducer} from './plan-producer';
+import {Recipe} from '../recipe/recipe';
 import {Schema} from '../schema';
-import {SuggestionComposer} from '../../suggestion-composer.js';
 import {Type} from '../type';
 
 export class Planificator {
   static async create(arc, {userid, protocol}) {
-    const store = await Planificator._initStore(arc, {userid, protocol});
-    const planificator = new Planificator(arc, store);
+    const store = await Planificator._initStore(arc, {userid, protocol, arcKey: null});
+    const planificator = new Planificator(arc, userid, store);
+    planificator.requestPlanning();
     return planificator;
   }
 
   arc: Arc;
+  userid: string;
   consumer: PlanConsumer;
   producer: PlanProducer;
   search: string|null = null;
-  suggestionComposer: SuggestionComposer|null = null;
 
-  constructor(arc, store) {
+  // In <0.6 shell, this is needed to backward compatibility, in order to (1)
+  // (1) trigger replanning with a local producer and (2) notify shell of the
+  // last activated plan, to allow serialization.
+  // TODO(mmandlis): Is this really needed in the >0.6 shell?
+  arcCallback: ({}) => void;
+  lastActivatedPlan: Recipe|null;
+
+  constructor(arc, userid, store) {
     this.arc = arc;
+    this.userid = userid;
     this.producer = new PlanProducer(arc, store);
     this.consumer = new PlanConsumer(arc, store);
 
-    // create suggestion composer and register for a callback.
-    const composer = arc.pec.slotComposer;
-    if (composer) {
-      if (composer.findContextById('rootslotid-suggestions')) {
-        this.suggestionComposer = new SuggestionComposer(composer);
-        this.registerSuggestChangedCallback((suggestions) => this.suggestionComposer.setSuggestions(suggestions));
-      }
-    }
+    this.lastActivatedPlan = null;
+    this.arcCallback = this._onPlanInstantiated.bind(this);
+    this.arc.registerInstantiatePlanCallback(this.arcCallback);
   }
 
-  async requestPlanning(options) {
-    await this.producer.runPlanner(options);
+  async requestPlanning(options = {}) {
+    await this.producer.producePlans(options);
+  }
+
+  async loadPlans() {
+    return this.consumer.loadPlans();
   }
 
   setSearch(search) {
@@ -57,21 +68,37 @@ export class Planificator {
     }
   }
 
-  registerPlansChangedCallback(callback) { this.consumer.plansChangeCallbacks.push(callback); }
-  registerSuggestChangedCallback(callback) { this.consumer.suggestionsChangeCallbacks.push(callback); }
+  registerPlansChangedCallback(callback) {
+    this.consumer.registerPlansChangedCallback(callback);
+  }
+
+  registerSuggestChangedCallback(callback) {
+    this.consumer.registerSuggestChangedCallback(callback);
+  }
 
   dispose() {
+    this.arc.unregisterInstantiatePlanCallback(this.arcCallback);
     this.consumer.dispose();
   }
 
-  static async _initStore(arc, {userid, protocol}) {
+  getLastActivatedPlan() {
+    return {plan: this.lastActivatedPlan};
+  }
+
+  _onPlanInstantiated(plan) {
+    this.lastActivatedPlan = plan;
+    this.requestPlanning();
+  }
+
+  static async _initStore(arc, {userid, protocol, arcKey}) {
     assert(userid, 'Missing user id.');
     let storage = arc.storageProviderFactory._storageForKey(arc.storageKey);
     const storageKey = storage.parseStringAsKey(arc.storageKey);
     if (protocol) {
       storageKey.protocol = protocol;
     }
-    storageKey.location = storageKey.location.replace('/arcs/', `/users/${userid}/suggestions/`);
+    storageKey.location = storageKey.location
+        .replace(/\/arcs\/([a-zA-Z0-9_\-]+)$/, `/users/${userid}/suggestions/${arcKey || '$1'}`);
     const storageKeyStr = storageKey.toString();
     storage = arc.storageProviderFactory._storageForKey(storageKeyStr);
     const schema = new Schema({names: ['Suggestions'], fields: {current: 'Object'}});
@@ -100,5 +127,18 @@ export class Planificator {
       default:
         assert(false, `Unsupported protocol '${protocol}'`);
     }
+  }
+
+  isArcPopulated() {
+    if (this.arc.recipes.length === 0) return false;
+    if (this.arc.recipes.length === 1) {
+      const [recipe] = this.arc.recipes;
+      if (recipe.particles.length === 0 ||
+          (recipe.particles.length === 1 && recipe.particles[0].name === 'Launcher')) {
+        // TODO: Check for Launcher is hacky, find a better way.
+        return false;
+      }
+    }
+    return true;
   }
 }

--- a/runtime/ts/plan/planificator.ts
+++ b/runtime/ts/plan/planificator.ts
@@ -1,0 +1,104 @@
+// Copyright (c) 2018 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+import {assert} from '../../../platform/assert-web.js';
+import {Arc} from '../arc';
+import {now} from '../../../platform/date-web.js';
+import {PlanConsumer} from './plan-consumer';
+import {PlanProducer} from './plan-producer';
+import {Schema} from '../schema';
+import {SuggestionComposer} from '../../suggestion-composer.js';
+import {Type} from '../type';
+
+export class Planificator {
+  static async create(arc, {userid, protocol}) {
+    const store = await Planificator._initStore(arc, {userid, protocol});
+    const planificator = new Planificator(arc, store);
+    return planificator;
+  }
+
+  arc: Arc;
+  consumer: PlanConsumer;
+  producer: PlanProducer;
+  search: string|null = null;
+  suggestionComposer: SuggestionComposer|null = null;
+
+  constructor(arc, store) {
+    this.arc = arc;
+    this.producer = new PlanProducer(arc, store);
+    this.consumer = new PlanConsumer(arc, store);
+
+    // create suggestion composer and register for a callback.
+    const composer = arc.pec.slotComposer;
+    if (composer) {
+      if (composer.findContextById('rootslotid-suggestions')) {
+        this.suggestionComposer = new SuggestionComposer(composer);
+        this.registerSuggestChangedCallback((suggestions) => this.suggestionComposer.setSuggestions(suggestions));
+      }
+    }
+  }
+
+  async requestPlanning(options) {
+    await this.producer.runPlanner(options);
+  }
+
+  setSearch(search) {
+    search = search ? search.toLowerCase().trim() : null;
+    search = (search !== '') ? search : null;
+    if (this.search !== search) {
+      this.search = search;
+      const showAll = this.search === '*';
+      const filter = showAll ? null : this.search;
+      this.consumer.setSuggestFilter(showAll, filter);
+    }
+  }
+
+  registerPlansChangedCallback(callback) { this.consumer.plansChangeCallbacks.push(callback); }
+  registerSuggestChangedCallback(callback) { this.consumer.suggestionsChangeCallbacks.push(callback); }
+
+  dispose() {
+    this.consumer.dispose();
+  }
+
+  static async _initStore(arc, {userid, protocol}) {
+    assert(userid, 'Missing user id.');
+    let storage = arc.storageProviderFactory._storageForKey(arc.storageKey);
+    const storageKey = storage.parseStringAsKey(arc.storageKey);
+    if (protocol) {
+      storageKey.protocol = protocol;
+    }
+    storageKey.location = storageKey.location.replace('/arcs/', `/users/${userid}/suggestions/`);
+    const storageKeyStr = storageKey.toString();
+    storage = arc.storageProviderFactory._storageForKey(storageKeyStr);
+    const schema = new Schema({names: ['Suggestions'], fields: {current: 'Object'}});
+    const type = Type.newEntity(schema);
+
+    // TODO: unify initialization of suggestions storage.
+    const id = 'suggestions-id';
+    let store = null;
+    switch (storageKey.protocol) {
+      case 'firebase':
+        return storage._join(id, type, storageKeyStr, /* shoudExist= */ 'unknown', /* referenceMode= */ false);
+      case 'volatile':
+        try {
+          store = await storage.construct(id, type, storageKeyStr);
+        } catch(e) {
+          store = await storage.connect(id, type, storageKeyStr);
+        }
+        assert(store, `Failed initializing '${protocol}' store.`);
+        store.referenceMode = false;
+        return store;
+      case 'pouchdb':
+        store = storage.construct(id, type, storageKeyStr);
+        assert(store, `Failed initializing '${protocol}' store.`);
+        store.referenceMode = false;
+        return store;
+      default:
+        assert(false, `Unsupported protocol '${protocol}'`);
+    }
+  }
+}

--- a/runtime/ts/plan/planificator.ts
+++ b/runtime/ts/plan/planificator.ts
@@ -15,10 +15,11 @@ import {PlanConsumer} from './plan-consumer';
 import {PlanProducer} from './plan-producer';
 import {Recipe} from '../recipe/recipe';
 import {Schema} from '../schema';
+import {StorageProviderBase} from '../storage/storage-provider-base';
 import {Type} from '../type';
 
 export class Planificator {
-  static async create(arc, {userid, protocol}) {
+  static async create(arc: Arc, {userid, protocol}) {
     const store = await Planificator._initStore(arc, {userid, protocol, arcKey: null});
     const planificator = new Planificator(arc, userid, store);
     planificator.requestPlanning();
@@ -38,7 +39,7 @@ export class Planificator {
   arcCallback: ({}) => void;
   lastActivatedPlan: Recipe|null;
 
-  constructor(arc, userid, store) {
+  constructor(arc: Arc, userid: string, store: StorageProviderBase) {
     this.arc = arc;
     this.userid = userid;
     this.producer = new PlanProducer(arc, store);
@@ -85,12 +86,12 @@ export class Planificator {
     return {plan: this.lastActivatedPlan};
   }
 
-  _onPlanInstantiated(plan) {
+  private _onPlanInstantiated(plan) {
     this.lastActivatedPlan = plan;
     this.requestPlanning();
   }
 
-  static async _initStore(arc, {userid, protocol, arcKey}) {
+  private static async _initStore(arc, {userid, protocol, arcKey}) {
     assert(userid, 'Missing user id.');
     let storage = arc.storageProviderFactory._storageForKey(arc.storageKey);
     const storageKey = storage.parseStringAsKey(arc.storageKey);

--- a/runtime/ts/plan/planning-result.ts
+++ b/runtime/ts/plan/planning-result.ts
@@ -11,7 +11,7 @@
 import {assert} from '../../../platform/assert-web.js';
 import {Arc} from '../arc';
 import {now} from '../../../platform/date-web.js';
-import {Manifest} from '../../manifest.js';
+import {Manifest} from '../manifest';
 import {RecipeResolver} from '../recipe/recipe-resolver';
 
 export class PlanningResult {
@@ -92,9 +92,9 @@ export class PlanningResult {
   async _planFromString(planString) {
     const manifest = await Manifest.parse(
         planString, {loader: this.arc.loader, context: this.arc.context, fileName: ''});
-    assert(manifest._recipes.length === 1);
-    let plan = manifest._recipes[0];
-    assert(plan.normalize(), `can't normalize deserialized suggestion: ${plan.toString()}`);
+    assert(manifest.recipes.length === 1);
+    let plan = manifest.recipes[0];
+    assert(plan.normalize({}), `can't normalize deserialized suggestion: ${plan.toString()}`);
     if (!plan.isResolved()) {
       const resolvedPlan = await this.recipeResolver.resolve(plan);
       assert(resolvedPlan, `can't resolve plan: ${plan.toString({showUnresolved: true})}`);
@@ -106,7 +106,7 @@ export class PlanningResult {
       // If recipe has hosted particles, manifest will have stores with hosted
       // particle specs. Moving these stores into the current arc's context.
       // TODO: This is a hack, find a proper way of doing this.
-      this.arc.context._addStore(store);
+      this.arc.context._addStore(store, []);
     }
     return plan;
   }

--- a/runtime/ts/plan/planning-result.ts
+++ b/runtime/ts/plan/planning-result.ts
@@ -1,0 +1,164 @@
+// Copyright (c) 2018 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+import {assert} from '../../../platform/assert-web.js';
+import {Arc} from '../arc';
+import {now} from '../../../platform/date-web.js';
+import {Manifest} from '../../manifest.js';
+import {RecipeResolver} from '../../recipe/recipe-resolver.js';
+
+export class PlanningResult {
+  arc: Arc;
+  recipeResolver: RecipeResolver;
+  plans: {}[];
+  lastUpdated: Date;
+  generations: {}[];
+
+  constructor(arc, result = {}) {
+    // const {plans, lastUpdated, generations} = result;
+    assert(arc, 'Arc cannot be null');
+    this.arc = arc;
+    this.recipeResolver = new RecipeResolver(this.arc);
+    this.plans = result['plans'] || [];
+    this.lastUpdated = result['lastUpdated'] || new Date(null);
+    this.generations = result['generations'] || [];
+  }
+
+  set({plans, lastUpdated = new Date(), generations = []}) {
+    if (this.isEquivalent(plans)) {
+      return false;
+    }
+    this.plans = plans;
+    this.generations = generations;
+    this.lastUpdated = lastUpdated;
+    return true;
+  }
+
+  append({plans, lastUpdated = new Date(), generations = []}) {
+    const newPlans = plans.filter(newPlan => !this.plans.find(plan => PlanningResult.isEquivalentPlan(plan, newPlan.hash)));
+    if (newPlans.length === 0) {
+      return false;
+    }
+    this.plans.push(...newPlans);
+    // TODO: filter out generations of other plans.
+    this.generations.push(...generations);
+    this.lastUpdated = lastUpdated;
+    return true;
+  }
+
+  olderThan(other) {
+    return this.lastUpdated < other.lastUpdated;
+  }
+
+  isEquivalent(plans) {
+    return PlanningResult.isEquivalent(this.plans, plans);
+  }
+
+  static isEquivalent(oldPlans, newPlans) {
+    assert(newPlans, `New plans cannot be null.`);
+    return oldPlans &&
+        oldPlans.length === newPlans.length &&
+        oldPlans.every(plan => newPlans.find(newPlan => PlanningResult.isEquivalentPlan(plan, newPlan)));
+  }
+
+  static isEquivalentPlan(plan1, plan2) {
+    return (plan1.hash === plan2.hash) && (plan1.descriptionText === plan2.descriptionText);
+  }
+
+  async deserialize({plans, lastUpdated}) {
+    const deserializedPlans = [];
+    for (const {descriptionText, recipe, hash, rank, suggestionContent} of plans) {
+      try {
+        deserializedPlans.push({
+          plan: await this._planFromString(recipe),
+          descriptionText,
+          hash,
+          rank,
+          suggestionContent
+        });
+      } catch (e) {
+        console.error(`Failed to parse plan ${e}.`);
+      }
+    }
+    return this.set({plans: deserializedPlans, lastUpdated: new Date(lastUpdated)});
+  }
+
+  async _planFromString(planString) {
+    const manifest = await Manifest.parse(
+        planString, {loader: this.arc.loader, context: this.arc.context, fileName: ''});
+    assert(manifest._recipes.length === 1);
+    let plan = manifest._recipes[0];
+    assert(plan.normalize(), `can't normalize deserialized suggestion: ${plan.toString()}`);
+    if (!plan.isResolved()) {
+      const resolvedPlan = await this.recipeResolver.resolve(plan);
+      assert(resolvedPlan, `can't resolve plan: ${plan.toString({showUnresolved: true})}`);
+      if (resolvedPlan) {
+        plan = resolvedPlan;
+      }
+    }
+    for (const store of manifest.stores) {
+      // If recipe has hosted particles, manifest will have stores with hosted
+      // particle specs. Moving these stores into the current arc's context.
+      // TODO: This is a hack, find a proper way of doing this.
+      this.arc.context._addStore(store);
+    }
+    return plan;
+  }
+
+  serialize() {
+    const serializedPlans = [];
+    for (const plan of this.plans) {
+      serializedPlans.push({
+        recipe: this._planToString(plan['plan']),
+        hash: plan['hash'],
+        rank: plan['rank'],
+        // TODO: handle description
+        descriptionText: plan['descriptionText'],
+        suggestionContent: {template: plan['descriptionText'], model: {}}
+      });
+    }
+    return {plans: serializedPlans, lastUpdated: this.lastUpdated.toString()};
+  }
+
+  _planToString(plan) {
+    // Special handling is only needed for plans (1) with hosted particles or
+    // (2) local slot (ie missing slot IDs).
+    if (!plan.handles.some(h => h.id && h.id.includes('particle-literal')) &&
+        plan.slots.every(slot => Boolean(slot.id))) {
+      return plan.toString();
+    }
+
+    // TODO: This is a transformation particle hack for plans resolved by
+    // FindHostedParticle strategy. Find a proper way to do this.
+    // Update hosted particle handles and connections.
+    const planClone = plan.clone();
+    planClone.slots.forEach(slot => slot.id = slot.id || `slotid-${this.arc.generateID()}`);
+
+    const hostedParticleSpecs = [];
+    for (let i = 0; i < planClone.handles.length; ++i) {
+      const handle = planClone.handles[i];
+      if (handle.id && handle.id.includes('particle-literal')) {
+        const hostedParticleName = handle.id.substr(handle.id.lastIndexOf(':') + 1);
+        // Add particle spec to the list.
+        const hostedParticleSpec = this.arc.context.findParticleByName(hostedParticleName);
+        assert(hostedParticleSpec, `Cannot find spec for particle '${hostedParticleName}'.`);
+        hostedParticleSpecs.push(hostedParticleSpec.toString());
+
+        // Override handle conenctions with particle name as local name.
+        Object.values(handle.connections).forEach(conn => {
+          assert(conn['type'].isInterface);
+          conn['_handle'] = {localName: hostedParticleName};
+        });
+
+        // Remove the handle.
+        planClone.handles.splice(i, 1);
+        --i;
+      }
+    }
+    return `${hostedParticleSpecs.join('\n')}\n${planClone.toString()}`;
+  }
+}

--- a/runtime/ts/plan/planning-result.ts
+++ b/runtime/ts/plan/planning-result.ts
@@ -92,8 +92,8 @@ export class PlanningResult {
   async _planFromString(planString) {
     const manifest = await Manifest.parse(
         planString, {loader: this.arc.loader, context: this.arc.context, fileName: ''});
-    assert(manifest.recipes.length === 1);
-    let plan = manifest.recipes[0];
+    assert(manifest._recipes.length === 1);
+    let plan = manifest._recipes[0];
     assert(plan.normalize({}), `can't normalize deserialized suggestion: ${plan.toString()}`);
     if (!plan.isResolved()) {
       const resolvedPlan = await this.recipeResolver.resolve(plan);

--- a/runtime/ts/plan/planning-result.ts
+++ b/runtime/ts/plan/planning-result.ts
@@ -1,15 +1,18 @@
-// Copyright (c) 2018 Google Inc. All rights reserved.
-// This code may only be used under the BSD style license found at
-// http://polymer.github.io/LICENSE.txt
-// Code distributed by Google as part of this project is also
-// subject to an additional IP rights grant found at
-// http://polymer.github.io/PATENTS.txt
+/**
+ * @license
+ * Copyright (c) 2018 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
 
 import {assert} from '../../../platform/assert-web.js';
 import {Arc} from '../arc';
 import {now} from '../../../platform/date-web.js';
 import {Manifest} from '../../manifest.js';
-import {RecipeResolver} from '../../recipe/recipe-resolver.js';
+import {RecipeResolver} from '../recipe/recipe-resolver';
 
 export class PlanningResult {
   arc: Arc;
@@ -19,7 +22,6 @@ export class PlanningResult {
   generations: {}[];
 
   constructor(arc, result = {}) {
-    // const {plans, lastUpdated, generations} = result;
     assert(arc, 'Arc cannot be null');
     this.arc = arc;
     this.recipeResolver = new RecipeResolver(this.arc);

--- a/runtime/ts/plan/planning-result.ts
+++ b/runtime/ts/plan/planning-result.ts
@@ -92,8 +92,8 @@ export class PlanningResult {
   async _planFromString(planString) {
     const manifest = await Manifest.parse(
         planString, {loader: this.arc.loader, context: this.arc.context, fileName: ''});
-    assert(manifest._recipes.length === 1);
-    let plan = manifest._recipes[0];
+    assert(manifest.recipes.length === 1);
+    let plan = manifest.recipes[0];
     assert(plan.normalize({}), `can't normalize deserialized suggestion: ${plan.toString()}`);
     if (!plan.isResolved()) {
       const resolvedPlan = await this.recipeResolver.resolve(plan);

--- a/shell/apps/remote-planning/index.js
+++ b/shell/apps/remote-planning/index.js
@@ -14,7 +14,7 @@ import {ShellPlanningInterface} from './interface.js';
 
 let userId =  process.env['ARCS_USER_ID'];
 if (!userId) {
-  console.log('No ARCS_USER_ID environment variable, using test user "Cletus"');
   userId = ShellPlanningInterface.USER_ID_CLETUS;
+  console.log(`No ARCS_USER_ID environment variable, using test user "${userId}"`);
 }
 ShellPlanningInterface.start('../../../', userId);

--- a/shell/apps/remote-planning/user-planner.js
+++ b/shell/apps/remote-planning/user-planner.js
@@ -90,7 +90,6 @@ class UserPlanner {
     const planificator = await Planificator.create(arc, {userid}); /*, protocol: 'pouchdb' or 'volatile' */
     planificator.registerPlansChangedCallback(current => this.showPlansForArc(key, current.plans));
     // planificator.registerSuggestChangedCallback(suggestions => this.showSuggestionsForArc(key, suggestions));
-    planificator.requestPlanning();
     return planificator;
   }
   showPlansForArc(key, metaplans) {

--- a/shell/apps/remote-planning/user-planner.js
+++ b/shell/apps/remote-planning/user-planner.js
@@ -1,6 +1,6 @@
 import {FbUser} from './shell/FbUser.js';
 import {Firebase} from './shell/firebase.js';
-import {Planificator} from '../../../runtime/planificator.js';
+import {Planificator} from '../../../runtime/ts-build/plan/planificator.js';
 
 class UserPlanner {
   constructor(factory, context, userid) {
@@ -66,7 +66,7 @@ class UserPlanner {
     console.log(`Arc[${key}]: marshaling for user [${userid}]`);
     try {
       const arc = await this.deserializeArc(serialization);
-      const planificator = this.createPlanificator(userid, key, arc);
+      const planificator = await this.createPlanificator(userid, key, arc);
       this.runners[key] = {arc, planificator};
     } catch (x) {
       // console.log('exception under: ==============================================');
@@ -86,11 +86,11 @@ class UserPlanner {
     }
     return await this.factory.deserialize(this.context, serialization);
   }
-  createPlanificator(userid, key, arc) {
-    const planificator = new Planificator(arc, {userid, mode: 'producer'});
+  async createPlanificator(userid, key, arc) {
+    const planificator = await Planificator.create(arc, {userid}); /*, protocol: 'pouchdb' or 'volatile' */
     planificator.registerPlansChangedCallback(current => this.showPlansForArc(key, current.plans));
     // planificator.registerSuggestChangedCallback(suggestions => this.showSuggestionsForArc(key, suggestions));
-    planificator._requestPlanning();
+    planificator.requestPlanning();
     return planificator;
   }
   showPlansForArc(key, metaplans) {

--- a/shell/source/ArcsLib.js
+++ b/shell/source/ArcsLib.js
@@ -12,6 +12,7 @@ import {Runtime} from '../../runtime/ts-build/runtime.js';
 
 // The following will be pulled into Runtime.
 import {Arc} from '../../runtime/ts-build/arc.js';
+import {Planificator as PlanificatorNew} from '../../runtime/ts-build/plan/planificator.js';
 import {Planificator} from '../../runtime/planificator.js';
 import {SlotComposer} from '../../runtime/ts-build/slot-composer.js';
 import {Type} from '../../runtime/ts-build/type.js';
@@ -37,6 +38,7 @@ const Arcs = {
   Manifest,
   Runtime,
   Planificator,
+  PlanificatorNew,
   SlotComposer,
   Type,
   BrowserLoader,


### PR DESCRIPTION
Remote planning:
- to trigger remote planner, run arcs/shell/apps/remote-planning/serve.sh (or debug.sh). Note: set the right user ID (default is Cletus). Currently uses FB store.

Shell:
- new planificator is behind flag
- to enable it, add `?planificator=new` to the URL
- to use in-memory storage for suggestions, add `?planificator=new&planificatorProtocol=volatile` to the URL
  - this change also includes pouchDB support (in theory): https://github.com/PolymerLabs/arcs/pull/2060, but i only tested for FB and volatile)

Next steps (in arbitrary order):
- trigger replanning, when arc/context handles change
- support search and contextual planning
- cleanup deleted arcs suggestions
- optimized behavior for empty arc plans