### PR TITLE
Ability to consume a SetSlot as a SingletonSlot

### DIFF
--- a/runtime/test/particle-shape-loading-with-slots-test.js
+++ b/runtime/test/particle-shape-loading-with-slots-test.js
@@ -29,6 +29,7 @@ describe('particle-shape-loading-with-slots', function() {
       return channel.port2;
     };
     const slotComposer = new MockSlotComposer({rootContainer: {'set-slotid-0': contextContainer || {}}});
+    slotComposer._contexts[0].spec.isSet = true; // MultiplexSlotsParticle expects a Set Slot root.
     const manifest = await Manifest.parse(`
       import './runtime/test/artifacts/transformations/test-slots-particles.manifest'
 

--- a/runtime/test/slot-consumer-tests.js
+++ b/runtime/test/slot-consumer-tests.js
@@ -14,8 +14,9 @@ import {SlotConsumer} from '../ts-build/slot-consumer.js';
 
 describe('slot consumer', function() {
   it('setting container', async () => {
-    const slot = new SlotConsumer({name: 'dummy-consumeConn', slotSpec: {}});
-    slot.slotContext = {};
+    const spec = {isSet: false};
+    const slot = new SlotConsumer({name: 'dummy-consumeConn', slotSpec: {spec}});
+    slot.slotContext = {spec};
     let startRenderCount = 0;
     let stopRenderCount = 0;
     slot.startRenderCallback = () => { ++startRenderCount; };

--- a/runtime/ts/slot-consumer.ts
+++ b/runtime/ts/slot-consumer.ts
@@ -44,7 +44,7 @@ export class SlotConsumer {
 
     if (newContainer !== originalContainer) {
       const contextContainerBySubId = new Map();
-      if (this.consumeConn && this.consumeConn.slotSpec.isSet) {
+      if (this.slotContext && this.slotContext.spec.isSet) {
         Object.keys(this.slotContext.container || {}).forEach(subId => contextContainerBySubId.set(subId, this.slotContext.container[subId]));
       } else {
         contextContainerBySubId.set(undefined, this.slotContext.container);
@@ -156,7 +156,7 @@ export class SlotConsumer {
   deleteContainer(container) {}
   clearContainer(rendering) {}
   setContainerContent(rendering, content, subId) {}
-  formatContent(content, subId) {}
+  formatContent(content, subId): object { return null; }
   formatHostedContent(hostedSlot, content): {} { return null; }
   static clear(container) {}
 }

--- a/runtime/ts/slot-dom-consumer.ts
+++ b/runtime/ts/slot-dom-consumer.ts
@@ -68,26 +68,25 @@ export class SlotDomConsumer extends SlotConsumer {
     }
   }
 
-  formatContent(content, subId) {
+  formatContent(content, subId): object {
     const newContent: {model?: string | {}, templateName?: string | {}, template?: string | {}} = {};
 
     // Format model.
     if (Object.keys(content).indexOf('model') >= 0) {
       if (content.model) {
-        // Merge descriptions into model.
-        newContent.model = Object.assign({}, content.model, content.descriptions);
-
-        // Replace items list by an single item corresponding to the given subId.
-        if (subId && content.model.items) {
-          assert(this.consumeConn.slotSpec.isSet);
-          const item = content.model.items.find(item => item.subId === subId);
-          if (item) {
-            newContent.model = Object.assign({}, newContent.model, item);
-            delete newContent.model['items'];
-          } else {
-            newContent.model = undefined;
-          }
+        
+        let formattedModel;
+        if (this.slotContext.spec.isSet && this.consumeConn.slotSpec.isSet) {
+          formattedModel = this._modelForSetSlotConsumedAsSetSlot(content.model, subId);
+        } else if (this.slotContext.spec.isSet && !this.consumeConn.slotSpec.isSet) {
+          formattedModel = this._modelForSetSlotConsumedAsSingletonSlot(content.model, subId);
+        } else {
+          formattedModel = this._modelForSingletonSlot(content.model, subId);
         }
+        if (!formattedModel) return null;
+
+        // Merge descriptions into model.
+        newContent.model = Object.assign({}, formattedModel, content.descriptions);
       } else {
         newContent.model = undefined;
       }
@@ -104,13 +103,30 @@ export class SlotDomConsumer extends SlotConsumer {
     return newContent;
   }
 
+  _modelForSingletonSlot(model, subId) {
+    assert(!subId, 'subId should be absent for a Singleton Slot');
+    return model;
+  }
+
+  _modelForSetSlotConsumedAsSetSlot(model, subId) {
+    assert(model.items && model.items.every(item => item.subId),
+        'model for a Set Slot consumed as a Set Slot needs to have items array, with every element having subId');
+    return model.items.find(item => item.subId === subId);
+  }
+
+  _modelForSetSlotConsumedAsSingletonSlot(model, subId) {
+    assert(model.subId, 'model for a Set Slot consumed as a Singleton Slot needs to have subId');
+    return subId === model.subId ? model : null;
+  }
+
   setContainerContent(rendering, content, subId) {
     if (!rendering.container) {
       return;
     }
 
-    if (Object.keys(content).length === 0) {
+    if (!content || Object.keys(content).length === 0) {
       this.clearContainer(rendering);
+      rendering.model = null;
       return;
     }
 


### PR DESCRIPTION
I don't like the explicit setting of isSet in the particle-shape-loading-with-slots-test.js, but fixing it properly (i.e. allowing to change the root to isSet via configuration) would require some major plumbing changes. Please advise if you have ideas how to do this better.