### PR TITLE
Add SLANDLES test for 'incomplete aliasing'

### DIFF
--- a/runtime/test/manifest-test.js
+++ b/runtime/test/manifest-test.js
@@ -759,8 +759,6 @@ ${particleStr1}
     const slotConn = recipe.particles[0].connections['slotA'];
     assert(slotConn);
     assert.deepEqual(['aa', 'hello'], slotConn.tags);
-    //TODO(jopra): Give recipes the dependentConnections syntax+handling
-    // assert.lengthOf(Object.keys(slotConn.providedSlots), 1);
   });
   it('recipe slots with different names', async () => {
     const manifest = await Manifest.parse(`
@@ -917,9 +915,6 @@ ${particleStr1}
     assert.lengthOf(directions, 2);
     assert.include(directions, "`provide");
     assert.include(directions, "`consume");
-
-    // TODO(jopra): Would like some guidance on if this check makes sense.
-    // assert.equal(slotB.sourceConnection, slotConnA);
   });
   it('parses local slots with IDs', async () => {
     const recipe = (await Manifest.parse(`

--- a/runtime/test/manifest-test.js
+++ b/runtime/test/manifest-test.js
@@ -913,8 +913,8 @@ ${particleStr1}
 
     const directions = slotB._connections.map(c => c._direction);
     assert.lengthOf(directions, 2);
-    assert.include(directions, "`provide");
-    assert.include(directions, "`consume");
+    assert.include(directions, '`provide');
+    assert.include(directions, '`consume');
   });
   it('parses local slots with IDs', async () => {
     const recipe = (await Manifest.parse(`

--- a/runtime/test/manifest-test.js
+++ b/runtime/test/manifest-test.js
@@ -918,8 +918,6 @@ ${particleStr1}
     assert.include(directions, "`provide");
     assert.include(directions, "`consume");
 
-    console.log(slotB._connections[0]);
-    console.log(slotB._connections[1]);
     // TODO(jopra): Would like some guidance on if this check makes sense.
     // assert.equal(slotB.sourceConnection, slotConnA);
   });


### PR DESCRIPTION
Adds Slandles version of the 'incomplete aliasing' test.

I have not found an equivalent of the
`assert.equal(slotB.sourceConnection, slotConnA);` assertion. I think it makes sense to remove it for slandles but I wanted to get that reviewed.