### PR TITLE
Node 10 LTS is coming.  Switch build to use it and update docs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "9"
+  - "10"
 env:
   global:
     # an encrypted 'GITHUB_TOKEN=<token>' for the PolymerLabs/arcs repo
@@ -14,7 +14,7 @@ addons:
 script: "cd ${TRAVIS_BUILD_DIR} && npm install && npm run test-with-start"
 
 before_install:
-  - npm install -g npm@6.0.1
+  - npm install -g npm@6.4.1
   - node --version
   - npm --version
 

--- a/README.md
+++ b/README.md
@@ -28,12 +28,12 @@ https://polymerlabs.github.io/arcs-live/shell/apps/web/.
 
 ## Install
 
-Arcs is developed with a recent version of Node (v9.4.0 at the time of this
+Arcs is developed with a recent version of Node (v10.0.0 at the time of this
 writing), in particular as we use new ES6 features. You can check our [Travis
 config](https://github.com/PolymerLabs/arcs/blob/master/.travis.yml) to see what
 version is used for automated build status. More recent versions should work,
 but if for example you see test errors on a version that's a full release later
-(ex. v10+) you may want to try rolling back to an earlier version. We welcome
+(ex. v11+) you may want to try rolling back to an earlier version. We welcome
 patches that will allow more recent versions to operate, ideally without
 requiring an upgrade to our current version.
 

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "url": "https://github.com/PolymerLabs/arcs/issues"
   },
   "engines": {
-    "node": ">= 9.4.0",
-    "npm": ">= 5.7.1"
+    "node": ">= 10.0.0",
+    "npm": ">= 6.4.0"
   }
 }


### PR DESCRIPTION
Addresses #2093

Background: https://medium.com/@nodejs/october-brings-node-js-10-x-to-lts-and-node-js-11-to-current-ae19f8f12b51