### PR TITLE
Improve continuous integration and docker build performance

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,7 +9,7 @@ init:
 install:
   - ps: Install-Product node $env:nodejs_version
   - npm install -g npm@6.4.1
-  - appveyor-retry npm install
+  - appveyor-retry npm ci
 
 build: off
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,7 +9,7 @@ init:
 install:
   - ps: Install-Product node $env:nodejs_version
   - npm install -g npm@6.4.1
-  - appveyor-retry npm ci
+  - appveyor-retry npm install
 
 build: off
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ sudo: required
 addons:
   chrome: stable
 
-script: "cd ${TRAVIS_BUILD_DIR} && npm install && npm run test-with-start"
+script: "cd ${TRAVIS_BUILD_DIR} && npm ci && npm run test-with-start"
 
 before_install:
   - npm install -g npm@6.4.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,5 @@ COPY . .
 RUN ./tools/sigh && npm run build:rollup
 RUN npm --prefix server test
 
-#RUN npm install --no-package-lock && npm install --package-lock-only
-
 EXPOSE 8080
 CMD [ "npm", "--prefix", "server", "start" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,23 +3,21 @@ FROM node:10
 # Create app directory
 WORKDIR /usr/src/app
 
-# copy output
+# First copy over the just the package.json files
+# so we can build a cached base image that only has node_modules
+# use the 'npm ci' command to get reproducable builds
+COPY package.json package-lock.json ./
+COPY server/package.json server/package-lock.json server/
+RUN npm ci && npm --prefix server ci 
+
+# Copy Everything Else
 COPY . .
 
-# Install npm packages
-# TODO use --only=production flag
-#
-RUN npm install
-
+# Build and test everything
 RUN ./tools/sigh && npm run build:rollup
+RUN npm --prefix server test
 
-WORKDIR /usr/src/app/server
-
-# This odd npm syntax solves a problem installing with an empty
-# node_modules directory: See https://npm.community/t/518
-RUN npm install --no-package-lock && npm install --package-lock-only
-
-RUN npm test
+#RUN npm install --no-package-lock && npm install --package-lock-only
 
 EXPOSE 8080
-CMD [ "npm", "start" ]
+CMD [ "npm", "--prefix", "server", "start" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,10 @@
+# Copyright (c) 2018 The Polymer Project Authors. All rights reserved.
+# This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+# The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+# The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+# Code distributed by Google as part of the polymer project is also
+# subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+
 FROM node:10
 
 # Create app directory

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -16,3 +16,4 @@ steps:
   '-t', 'gcr.io/$PROJECT_ID/$REPO_NAME:latest',
   '--cache-from', 'gcr.io/$PROJECT_ID/$REPO_NAME:latest',
   '.']
+

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -9,13 +9,9 @@
 
 steps:
 - name: 'gcr.io/cloud-builders/docker'
-  args: [ 'build', '-t', 'gcr.io/$PROJECT_ID/quickstart-image', '.' ]
-images:
-- 'gcr.io/$PROJECT_ID/quickstart-image'
-steps:
-- name: 'gcr.io/cloud-builders/docker'
   args: ['pull', 'gcr.io/$PROJECT_ID/$REPO_NAME:latest']
 - name: 'gcr.io/cloud-builders/docker'
   args: ['build',
   '-t', 'gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA',
-  '-t', 'gcr.io/
+  '-t', 'gcr.io/$PROJECT_ID/$REPO_NAME:latest',
+  '.']

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -6,12 +6,13 @@
 # subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 
 # Fetches the latest build and uses that as a cache to improve build times.
-#- name: 'gcr.io/cloud-builders/docker'
-#  args: ['pull', 'gcr.io/$PROJECT_ID/$REPO_NAME:latest']
 
 steps:
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['pull', 'gcr.io/$PROJECT_ID/$REPO_NAME:latest']
 - name: 'gcr.io/cloud-builders/docker'
   args: ['build',
   '-t', 'gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA',
   '-t', 'gcr.io/$PROJECT_ID/$REPO_NAME:latest',
+  '--cache-from', 'gcr.io/$PROJECT_ID/$REPO_NAME:latest',
   '.']

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,21 @@
+# Copyright (c) 2018 The Polymer Project Authors. All rights reserved.
+# This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+# The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+# The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+# Code distributed by Google as part of the polymer project is also
+# subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+
+# Fetches the latest build and uses that as a cache to improve build times.
+
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  args: [ 'build', '-t', 'gcr.io/$PROJECT_ID/quickstart-image', '.' ]
+images:
+- 'gcr.io/$PROJECT_ID/quickstart-image'
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['pull', 'gcr.io/$PROJECT_ID/$REPO_NAME:latest']
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build',
+  '-t', 'gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA',
+  '-t', 'gcr.io/

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -6,10 +6,10 @@
 # subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 
 # Fetches the latest build and uses that as a cache to improve build times.
+#- name: 'gcr.io/cloud-builders/docker'
+#  args: ['pull', 'gcr.io/$PROJECT_ID/$REPO_NAME:latest']
 
 steps:
-- name: 'gcr.io/cloud-builders/docker'
-  args: ['pull', 'gcr.io/$PROJECT_ID/$REPO_NAME:latest']
 - name: 'gcr.io/cloud-builders/docker'
   args: ['build',
   '-t', 'gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA',


### PR DESCRIPTION
- Use npm ci instead of npm install so we get reproducable builds from package-lock.json
- Explicitly install node_modules using npm ci as the first step in the Docker build.
  This allows for that step to be cached leading to much, much faster builds.