### PR TITLE
Improve CI testing, fix and add server tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,21 +6,29 @@ env:
     # an encrypted 'GITHUB_TOKEN=<token>' for the PolymerLabs/arcs repo
     secure: "qFfvf0YAK5NWkH5fj708Z+1qIHtOFrmNhslB+n14rt5J3fJjY0A/4lbLbhx2jACYME+OU2m66maxh5abEZCF4ZGi4zpJa01IUYesTTa3qdM9kozB2TfFcl0d1xffuGpAh9kPchaadCvx/BU9fYFzkd8CLD5mQWCybwqM+6xpoO/KULDXhlcOPGbzg65xmPJANZH+ldH0NgfVLqofeFUg1j0bke1n+7DLf+Oh4ZiYZavciJjhuYx561TkkSEd1gqQGImEfkmKmhz82E8curx6uJW+kD9WagNbLj4FvEsBETIM7BSE8sei2vOVO42OnzvCej+P98IUelEqBS6sTeUNp79f8cC8n7nSYUJwTpshturBFoIFfcVQNoebdaao6gWpnxhUEnsc36AMl0DpIT0DsA9SxZQRjqhAEZmAWmASJMc5t/jWIjmJrqQxDy80HGJPEhIMTOAZfAiFqwyQwYTvJ0tOTW+jk2P9oriLHwi0Pr88uPGD5HWS6ULPoAutQAWMKCYgb5PoOiB8vbUZT9RTXfdLkHLkpw0ICaj5sam2o32CMLm8KZzfNVLJ/kUgdnkYUpC0vo+PGfguiJX8fvZxB06+niljW9iHteqVuoP1tADQwby4jS2ob3eL7TgCGuGk6gQkvHkLmOzlagKeXu1YZ0ow5vq6C+vSEfKEzIDrhXk="
 
+
 # todo: remove this once travis fixes their upstream issue (travis-ci/travis-ci#8836)
 sudo: required
 addons:
   chrome: stable
 
-script: "cd ${TRAVIS_BUILD_DIR} && npm ci && npm run test-with-start"
+script:
+  - npm run test-with-start
+  - npm run build:rollup
+  - npm --prefix=server test
 
 before_install:
   - npm install -g npm@6.4.1
   - node --version
   - npm --version
 
+install:
+  - npm ci
+  - npm --prefix=server ci
+
 before_deploy:
   # build apidocs
-  - cd ${TRAVIS_BUILD_DIR} && npm run build:typedoc 
+  - cd ${TRAVIS_BUILD_DIR} && npm run build:typedoc
   # Travis pages deploys skips artifacts from .gitignore. We need some of those, so
   # remove them from .gitignore.
   - cd ${TRAVIS_BUILD_DIR} && sed -i.sedbackup -e '/^shell\/build$/d' .gitignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,14 +15,14 @@ WORKDIR /usr/src/app
 # use the 'npm ci' command to get reproducable builds
 COPY package.json package-lock.json ./
 COPY server/package.json server/package-lock.json server/
-RUN npm ci && npm --prefix server ci 
+RUN npm ci && npm --prefix=server ci
 
 # Copy Everything Else
 COPY . .
 
 # Build and test everything
 RUN ./tools/sigh && npm run build:rollup
-RUN npm --prefix server test
+RUN npm --prefix=server test
 
 EXPOSE 8080
-CMD [ "npm", "--prefix", "server", "start" ]
+CMD [ "npm", "--prefix=server", "start" ]

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -16,4 +16,4 @@ steps:
   '-t', 'gcr.io/$PROJECT_ID/$REPO_NAME:latest',
   '--cache-from', 'gcr.io/$PROJECT_ID/$REPO_NAME:latest',
   '.']
-
+images: ['gcr.io/$PROJECT_ID/$REPO_NAME']

--- a/server/src/pouch-db-app.ts
+++ b/server/src/pouch-db-app.ts
@@ -40,7 +40,7 @@ class PouchDbApp extends AppBase {
       userId = ShellPlanningInterface.USER_ID_CLETUS;
     }
 
-    let storageKeyBase = process.env['STORAGE_KEY_BASE'] || 'pouchdb://localhost:8080/user';
+    const storageKeyBase = process.env['STORAGE_KEY_BASE'] || 'pouchdb://localhost:8080/user';
 
     // TODO(plindner): extract this into a separate coroutine instead
     // of starting it here.


### PR DESCRIPTION
- Enable cached builds for travis which removes the slow npm install step
- Use --prefix=server syntax in Docker/travis
- Add missing images config to store completed builds for cloudbuild