### PR TITLE
Moves RamSlotComposer to runtime/testing

### DIFF
--- a/runtime/testing/ram-slot-composer.js
+++ b/runtime/testing/ram-slot-composer.js
@@ -9,7 +9,7 @@
  */
 'use strict';
 
-import {SlotComposer} from '../../runtime/ts-build/slot-composer.js';
+import {SlotComposer} from '../ts-build/slot-composer.js';
 
 export class RamSlotComposer extends SlotComposer {
   constructor(options) {

--- a/shell_0_6_0/context-shell/index.js
+++ b/shell_0_6_0/context-shell/index.js
@@ -1,4 +1,4 @@
-import {RamSlotComposer} from '../lib/ram-slot-composer.js';
+import {RamSlotComposer} from '../../runtime/testing/ram-slot-composer.js';
 import {ArcsEnvNode} from '../lib/node/arcs-env-node.js';
 import {App} from './app.js';
 

--- a/shell_0_6_0/smoke-shell/node/smoke.js
+++ b/shell_0_6_0/smoke-shell/node/smoke.js
@@ -1,4 +1,4 @@
-import {RamSlotComposer} from '../../../lib/ram-slot-composer.js';
+import {RamSlotComposer} from '../../../runtime/testing/ram-slot-composer.js';
 import {ArcsEnvNode} from '../../../lib/node/arcs-env-node.js';
 import {App} from '../app.js';
 


### PR DESCRIPTION
For your consideration. I would like to use RamSlotComposer in `runtime/test`. WDYT?