### PR TITLE
Allow for non-intercepted rendering inside transformations

### DIFF
--- a/runtime/test/suggestion-composer-tests.js
+++ b/runtime/test/suggestion-composer-tests.js
@@ -10,6 +10,7 @@
 
 import {assert} from './chai-web.js';
 import {SuggestionComposer} from '../suggestion-composer.js';
+import {RamSlotComposer} from '../../shell_0_6_0/lib/ram-slot-composer.js';
 import {SlotComposer} from '../ts-build/slot-composer.js';
 import {TestHelper} from '../testing/test-helper.js';
 
@@ -63,7 +64,7 @@ describe('suggestion composer', function() {
   });
 
   it('singleton suggestion slots', async () => {
-    const slotComposer = new SlotComposer({affordance: 'mock', rootContainer: {'root': 'dummy-container'}});
+    const slotComposer = new RamSlotComposer();
     const helper = await TestHelper.createAndPlan({
       manifestFilename: './runtime/test/artifacts/suggestions/Cake.recipes',
       slotComposer
@@ -81,11 +82,6 @@ describe('suggestion composer', function() {
     assert.lengthOf(suggestionComposer._suggestConsumers, 1);
     const suggestConsumer = suggestionComposer._suggestConsumers[0];
     assert.isEmpty(suggestConsumer._content);
-
-    // set the container of the suggestion context, resulting in the suggestion being rendered.
-    const suggestContext = slotComposer._contexts.find(context => context.slotConsumers.find(consumer => consumer == suggestConsumer));
-    assert.isNull(suggestContext.container);
-    suggestContext.container = 'dummy-container';
     await suggestConsumer._setContentPromise;
     assert.isTrue(suggestConsumer._content.template.includes('Light candles on Tiramisu cake'));
 
@@ -97,7 +93,7 @@ describe('suggestion composer', function() {
   });
 
   it('suggestion set-slots', async () => {
-    const slotComposer = new SlotComposer({affordance: 'mock', rootContainer: {'root': 'dummy-container'}});
+    const slotComposer = new RamSlotComposer();
     const helper = await TestHelper.createAndPlan({
       manifestFilename: './runtime/test/artifacts/suggestions/Cakes.recipes',
       slotComposer
@@ -110,8 +106,6 @@ describe('suggestion composer', function() {
     await helper.acceptSuggestion({particles: ['List', 'CakeMuxer']});
     await helper.makePlans();
     assert.lengthOf(helper.plans, 1);
-    const suggestContext = suggestionComposer._slotComposer._contexts.find(h => h.id == helper.plans[0].plan.slots[0].id);
-    suggestContext.sourceSlotConsumer.getInnerContainer = (name) => 'dummy-container';
     await suggestionComposer._updateSuggestions(helper.plans);
     assert.lengthOf(suggestionComposer._suggestConsumers, 1);
     const suggestConsumer = suggestionComposer._suggestConsumers[0];

--- a/runtime/testing/mock-slot-dom-consumer.js
+++ b/runtime/testing/mock-slot-dom-consumer.js
@@ -16,6 +16,7 @@ export class MockSlotDomConsumer extends SlotDomConsumer {
   constructor(consumeConn) {
     super(consumeConn);
     this._content = {};
+    this.contentAvailable = new Promise(resolve => this._contentAvailableResolve = resolve);
   }
 
   async setContent(content, handler) {
@@ -29,10 +30,12 @@ export class MockSlotDomConsumer extends SlotDomConsumer {
         this._content.template = content.template;
       }
       this._content.model = content.model;
+      this._contentAvailableResolve();
     } else {
       this._content = {};
     }
-  }  
+  }
+
   createNewContainer(container, subId) {
     return container;
   }
@@ -43,7 +46,7 @@ export class MockSlotDomConsumer extends SlotDomConsumer {
 
   getInnerContainer(innerSlotName) {
     const model = this.renderings.map(([subId, {model}]) => model)[0];
-    const providedSlotSpec = this.consumeConn.slotSpec.getProvidedSlotSpec(innerSlotName);
+    const providedSlotSpec = this._findProvidedSlotSpec(innerSlotName);
     if (!providedSlotSpec) {
       console.warn(`Cannot find provided spec for ${innerSlotName} in ${this.consumeConn.getQualifiedName()}`);
       return;

--- a/runtime/ts/hosted-slot-consumer.ts
+++ b/runtime/ts/hosted-slot-consumer.ts
@@ -78,9 +78,9 @@ export class HostedSlotConsumer extends SlotConsumer {
 
   createProvidedContexts() {
     assert(this.consumeConn, `Cannot create provided context without consume connection for hosted slot ${this.hostedSlotId}`);
-    return this.consumeConn.slotSpec.providedSlots.map(providedSpec => {
-      return new HostedSlotContext(this.arc.generateID(), providedSpec, this);
-    });
+    return this.consumeConn.slotSpec.providedSlots.map(providedSpec =>
+      new HostedSlotContext(this.consumeConn.providedSlots[providedSpec.name].id, providedSpec, this)
+    );
   }
 
   updateProvidedContexts() {

--- a/runtime/ts/hosted-slot-context.ts
+++ b/runtime/ts/hosted-slot-context.ts
@@ -24,7 +24,4 @@ export class HostedSlotContext extends SlotContext {
       this.handles = [{id: hostedSourceSlotConsumer.storeId} as Handle];
     }
   }
-  get container() {
-    return this.sourceSlotConsumer.getInnerContainer(this.name) || null;
-  }
 }

--- a/runtime/ts/slot-composer.ts
+++ b/runtime/ts/slot-composer.ts
@@ -116,16 +116,22 @@ export class SlotComposer {
         }
 
         let slotConsumer = this.consumers.find(slot => slot instanceof HostedSlotConsumer && slot.hostedSlotId === cs.targetSlot.id);
+        let transformationSlotConsumer = null;
 
-        if (slotConsumer &&  slotConsumer instanceof HostedSlotConsumer) {
+        if (slotConsumer && slotConsumer instanceof HostedSlotConsumer) {
           assert(!slotConsumer.consumeConn);
           slotConsumer.consumeConn = cs;
+          transformationSlotConsumer = slotConsumer.transformationSlotConsumer;
         } else {
           slotConsumer = new this._affordance.slotConsumerClass(cs, this._containerKind);
           newConsumers.push(slotConsumer);
         }
 
-        this._contexts = this._contexts.concat(slotConsumer.createProvidedContexts());
+        const providedContexts = slotConsumer.createProvidedContexts();
+        this._contexts = this._contexts.concat(providedContexts);
+
+        // Slot contexts provided by the HostedSlotConsumer are managed by the transformation.
+        if (transformationSlotConsumer) transformationSlotConsumer.providedSlotContexts.push(...providedContexts);
       });
     });
 

--- a/runtime/ts/slot-consumer.ts
+++ b/runtime/ts/slot-consumer.ts
@@ -11,6 +11,7 @@
 import {assert} from '../../platform/assert-web.js';
 import {SlotContext} from './slot-context.js';
 import {SlotConnection} from './recipe/slot-connection.js';
+import {HostedSlotConsumer} from './hosted-slot-consumer.js';
 
 export class SlotConsumer {
   _consumeConn: SlotConnection;
@@ -148,6 +149,13 @@ export class SlotConsumer {
   }
 
   isSameContainer(container, contextContainer) { return container === contextContainer; }
+
+  get hostedConsumers(): HostedSlotConsumer[] {
+    return this.providedSlotContexts
+        .filter(context => context.constructor.name === 'HostedSlotContext')
+        .map(context => context.sourceSlotConsumer)
+        .filter(consumer => consumer !== this) as HostedSlotConsumer[];
+  }
 
   // abstract
   constructRenderRequest(hostedSlotConsumer = null): string[] { return []; }

--- a/runtime/ts/slot-dom-consumer.ts
+++ b/runtime/ts/slot-dom-consumer.ts
@@ -244,7 +244,7 @@ export class SlotDomConsumer extends SlotConsumer {
         return;
       }
       const slotId = this.getNodeValue(innerContainer, 'slotid');
-      const providedSlotSpec = this.consumeConn.slotSpec.getProvidedSlotSpec(slotId);
+      const providedSlotSpec = this._findProvidedSlotSpec(slotId);
       if (!providedSlotSpec) { // Skip non-declared slots
         console.warn(`Slot ${this.consumeConn.slotSpec.name} has unexpected inner slot ${slotId}`);
         return;
@@ -254,6 +254,14 @@ export class SlotDomConsumer extends SlotConsumer {
         `Sub-id ${subId} for slot ${providedSlotSpec.name} doesn't match set spec: ${providedSlotSpec.isSet}`);
       this._initInnerSlotContainer(slotId, subId, innerContainer);
     });
+  }
+
+  // TODO: Implement better way of distinguishing slots between different hosted consumers.
+  //       E.g. 'particle-id::slot-name'
+  _findProvidedSlotSpec(slotName) {
+    return [this, ...this.hostedConsumers]
+        .map(consumer => consumer.consumeConn.slotSpec.getProvidedSlotSpec(slotName))
+        .find(spec => Boolean(spec));
   }
 
   // get a value from node that could be an attribute, if not a property


### PR DESCRIPTION
When a transformation renders content captured from a hosted slot, which itself contains slots, this patch allows the latter slot to be handled without transformation intercepting it.

An example (from the test):

`TransformationParticle` renders into `root`. It creates an inner arc with `A` rendering into a hosted slot and `B` rendering into a slot provided by `A`. `TransformationParticle` can intercept template and model rendered by `A`, but when it renders a template with a slots provided by `A`, content rendered by `B` will show up there without `TransformationParticle` being able to intercept it.

An improvement that should happen one day is namespacing the slot names with particleIds, so that when names collide between slots provided by the transformation and a particle rendering to a hosted slot (or between multiple consumers of the hosted slot), we can distinguish them. I didn't want to complicate this patch too much though.

Implementation wise, slots contexts provided by the HostedSlotConsumer correspond to containers created by the transformation SlotConsumer and are handed over to be managed by the latter.

RamSlotComposer is used where it simplifies tests, as it is closer to prod code thanks to calling updateProvidedContexts(). It is  being moved to runtime/testing in #2190