### PR TITLE
Introduces TestSlotComposer

### DIFF
--- a/runtime/testing/fake-slot-composer.js
+++ b/runtime/testing/fake-slot-composer.js
@@ -1,0 +1,34 @@
+/**
+ * @license
+ * Copyright (c) 2018 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+'use strict';
+
+import {SlotComposer} from '../ts-build/slot-composer.js';
+
+/** @class FakeSlotComposer
+ * A helper class for NodeJS tests that mimics SlotComposer without relying on DOM APIs.
+ */
+export class FakeSlotComposer extends SlotComposer {
+
+  constructor(options = {}) {
+    super(Object.assign({
+      rootContainer: {'root': 'root-context'},
+      affordance: 'mock'
+    }, options));
+  }
+
+  async renderSlot(particle, slotName, content) {
+    await super.renderSlot(particle, slotName, content);
+
+    // In production updateProvidedContexts() is done in DOM Mutation Observer.
+    // We don't have it in tests, so we do it here.
+    const slotConsumer = this.getSlotConsumer(particle, slotName);
+    if (slotConsumer) slotConsumer.updateProvidedContexts();
+  }
+}

--- a/runtime/testing/mock-slot-composer.js
+++ b/runtime/testing/mock-slot-composer.js
@@ -10,14 +10,14 @@
 'use strict';
 
 import {assert} from '../test/chai-web.js';
-import {SlotComposer} from '../ts-build/slot-composer.js';
+import {FakeSlotComposer} from './fake-slot-composer.js';
 import {SlotDomConsumer} from '../ts-build/slot-dom-consumer.js';
 
 const logging = false;
 const log = (!logging || global.logging === false) ? () => {} : console.log.bind(console, '---------- MockSlotComposer::');
 
 /** @class MockSlotComposer
- * Helper class to test with slot composer.
+ * A helper SlotComposer allowing expressing and asserting expectations on slot rendering.
  * Usage example:
  *   mockSlotComposer
  *       .newExpectations()
@@ -28,14 +28,13 @@ const log = (!logging || global.logging === false) ? () => {} : console.log.bind
  *   mockSlotComposer.sendEvent('MyParticle1', 'mySlot1', '_onMyEvent', {key: 'value'});
  *   await mockSlotComposer.expectationsCompleted();
  */
-export class MockSlotComposer extends SlotComposer {
+export class MockSlotComposer extends FakeSlotComposer {
   /**
    * |options| may contain:
    * - strict: whether unexpected render slot requests cause an assert or a warning log (default: true)
    */
-  constructor(options) {
-    options = options || {};
-    super({rootContainer: options.rootContainer || {'root': 'root-context'}, affordance: 'mock'});
+  constructor(options = {}) {
+    super(options);
     this.expectQueue = [];
     this.onExpectationsComplete = () => undefined;
     this.strict = options.strict != undefined ? options.strict : true;
@@ -238,14 +237,6 @@ export class MockSlotComposer extends SlotComposer {
     }
 
     this._expectationsMet();
-
-    const slotConsumer = this.getSlotConsumer(particle, slotName);
-    if (slotConsumer) {
-      slotConsumer.updateProvidedContexts();
-    } else {
-      // Slots of particles hosted in transformation particles.
-    }
-
     this.detailedLogDebug();
   }
 


### PR DESCRIPTION
The intention is:
- use `TestSlotComposer` when you want something that works without asserting on what are the render calls.
- use `MockSlotComposer` when you want to express assertions on render calls (more fine grained testing).

MockSlotComposer extends TestSlotComposer extends SlotComposer.

Over time both classes can grow with test utilities, but I would like to keep the invariant that TestSlotComposer just works without need to set the expectations.