### PR TITLE
restrict handle-conn variable type according to hosted particle spec in a serialized manifest

### DIFF
--- a/runtime/ts/manifest.ts
+++ b/runtime/ts/manifest.ts
@@ -939,6 +939,26 @@ ${e.message}
           store.referenceMode = false;
           await store.set(hostedParticleLiteral);
           targetHandle.mapToStorage(store);
+        } else if (connection.type && connection.type.isInterface) {
+          let hostedParticleStore = manifest.findStoreById(targetHandle.id);
+          if (!hostedParticleStore) {
+            throw new ManifestError(
+              connectionItem.target.location,
+              `Hosted particle spec store '${targetHandle.id}' cannot be found.`);
+          }
+          let hostedParticleSpec = await hostedParticleStore.get();
+          if (!hostedParticleSpec) {
+            throw new ManifestError(
+              connectionItem.target.location,
+              `Hosted particle spec '${targetHandle.id}' is null.`);
+          }
+          const hostedParticle = manifest.findParticleByName(hostedParticleSpec.name);
+          // Parsing a serialized manifest, where the hosted particle is already a handle.
+          if (!connection.type.interfaceShape.restrictType(hostedParticle)) {
+            throw new ManifestError(
+                connectionItem.target.location,
+                `Hosted particle '${hostedParticle.name}' does not match shape '${connection.name}'`);
+          }
         }
 
         if (targetParticle) {


### PR DESCRIPTION
This is the recipe: 
```
recipe RestaurantsDemo
  **create #event as handle0 // Event {...}**
  create as handle1 // [Restaurant {...}]
  create as handle2 // Geolocation {...}
  create #restaurant as handle3 // Restaurant {...}
  copy **'manifest:https://$artifacts/Demo/RestaurantsDemo.recipes::1:b4129aa7f46135eda1c93b1aeb95d4d7bc90d507:ReservationAnnotation' as handle4 // HostedAnnotationShape**
  copy 'manifest:https://$artifacts/Demo/RestaurantsDemo.recipes::0:42d66d84c65e9d8aa514f99db59e74d8907f35bf:RestaurantTile' as handle5 // HostedTileShape
  slot 'rootslotid-root' #root as slot1
  AnnotationMultiplexer as particle0
    **annotation = handle0**
    **hostedParticle = handle4**
    list <- handle1
    consume annotation as slot0
  FindRestaurants as particle1
    location <- handle2
    restaurants = handle1
  Geolocate as particle2
    location -> handle2
    consume root as slot1
  SelectableTiles as particle3
    list <- handle1
    selected = handle3
    consume root as slot1
      provide action as slot2
      provide annotation as slot0
      provide tile as slot3
  TileMultiplexer as particle4
    hostedParticle = handle5
    list <- handle1
    consume tile as slot3
  description `find restaurants and make reservations near ${FindRestaurants.location}`"
```
note that `#event` handle is only used in `AnnotationMultiplexer` and its type is determined by the hosted particle `ReservationAnnotation`.

The way recipe is initially written in the manifest file:
```
 ... 
  AnnotationMultiplexer as particle0
    annotation = event
    hostedParticle = ReservationAnnotation
 ...
```
The `event` handle type is handled by https://github.com/PolymerLabs/arcs/blob/master/runtime/ts/manifest.ts#L920

However the serialized-deserialized manifest (see above) isn't handled - this PR should address it.

----------------
If this seems reasonable, I'll fix the existing tests and add a special test for this case to manifest-tests. Please, let me know what you think.