### PR TITLE
Update README.md with correct node version to install

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ requiring an upgrade to our current version.
 1) Install node.
 
    ```
-   $ nvm install 9.4
+   $ nvm install 10
    ```
 
 1) If you need to update npm to a later version (our build checks for the


### PR DESCRIPTION
Part of the readme was stale. It turns out node 9.4 has some different behavior that actually breaks the 'singleton suggestion slots' test., updating to 10.13.0 fixes the test.