### PR TITLE
Add ParticleArgumentDirections to the ReservedWord list

### DIFF
--- a/runtime/manifest-parser.peg
+++ b/runtime/manifest-parser.peg
@@ -1119,6 +1119,7 @@ TopLevelIdent
 //TODO Add ParticleArgumentDirection (rewrite recipes to not use directions as identifiers.
 ReservedWord
   = Direction
+  / ParticleArgumentDirection
 
 backquotedString = '`' pattern:([^`]+) '`' { return pattern.join(''); }
 id = "'" id:[^']+ "'" {return id.join('')}

--- a/runtime/manifest-parser.peg
+++ b/runtime/manifest-parser.peg
@@ -1116,7 +1116,6 @@ SameOrMoreIndent = &(i:" "* &{
 TopLevelIdent
   = upperIdent
 
-//TODO Add ParticleArgumentDirection (rewrite recipes to not use directions as identifiers.
 ReservedWord
   = Direction
   / ParticleArgumentDirection

--- a/runtime/test/manifest-parser-test.js
+++ b/runtime/test/manifest-parser-test.js
@@ -87,29 +87,21 @@ describe('manifest parser', function() {
       store Store1 of Person 'some-id' @7 in 'person.json'
       store Store2 of BigCollection<Person> in 'population.json'`);
   });
-  it('fails to parse an argument list that use reserved word \'consume\' as an identifier', () => {
-    try {
-      parse(`
-        particle MyParticle
-          in MyThing consume
-          out BigCollection<MyThing>? out`);
-      assert.fail('this parse should have failed, identifiers should not be reserved words!');
-    } catch (e) {
-      assert.include(e.message, 'Expected',
-          `bad error: '${e}'`);
-    }
-  });
-  it('fails to parse an argument list that use reserved word \'provide\' as an identifier', () => {
-    try {
-      parse(`
-        particle MyParticle
-          in MyThing provide
-          out BigCollection<MyThing>? out`);
-      assert.fail('this parse should have failed, identifiers should not be reserved words!');
-    } catch (e) {
-      assert.include(e.message, 'Expected',
-          `bad error: '${e}'`);
-    }
+  it('fails to parse an argument list that use a reserved word as an identifier', () => {
+    const reservedWords = ['inout', 'in', 'out', 'host', '`consume',
+      '`provide', 'provide', 'consume'];
+    reservedWords.map(reserved => {
+      try {
+        parse(`
+          particle MyParticle
+            in MyThing ${reserved}
+            out BigCollection<MyThing>? output`);
+        assert.fail('this parse should have failed, identifiers should not be reserved words!');
+      } catch (e) {
+        assert.include(e.message, 'Expected',
+            `bad error: '${e}'`);
+      }
+    });
   });
   it('fails to parse a nonsense argument list', () => {
     try {


### PR DESCRIPTION
Identifiers were previously not checked against the ParticleArgumentDirections.
This rewrites a set of reserved words tests into a test over a list of reserved words and adds ParticleArgumentDirections to the reserved words list.

Was previously #2214 

Depends on #2224