### PR TITLE
Add fates to keyword list

### DIFF
--- a/runtime/manifest-parser.peg
+++ b/runtime/manifest-parser.peg
@@ -1119,6 +1119,7 @@ TopLevelIdent
 //TODO Add ParticleArgumentDirection (rewrite recipes to not use directions as identifiers.
 ReservedWord
   = Direction
+  / ParticleArgumentDirection
 
 backquotedString = '`' pattern:([^`]+) '`' { return pattern.join(''); }
 id = "'" id:[^']+ "'" {return id.join('')}

--- a/runtime/manifest-parser.peg
+++ b/runtime/manifest-parser.peg
@@ -1116,7 +1116,6 @@ SameOrMoreIndent = &(i:" "* &{
 TopLevelIdent
   = upperIdent
 
-//TODO Add ParticleArgumentDirection (rewrite recipes to not use directions as identifiers.
 ReservedWord
   = Direction
   / ParticleArgumentDirection

--- a/runtime/manifest-parser.peg
+++ b/runtime/manifest-parser.peg
@@ -830,8 +830,16 @@ ConnectionTargetHandleComponents
     }
   }
 
+RecipeHandleFate
+  = '?'
+  / 'use'
+  / 'map'
+  / 'create'
+  / 'copy'
+  / '`slot'
+
 RecipeHandle
-  = type:('?' / 'use' / 'map' / 'create' / 'copy' / '`slot') ref:(whiteSpace HandleOrSlotRef)? name:(whiteSpace LocalName)? eolWhiteSpace
+  = type:RecipeHandleFate ref:(whiteSpace HandleOrSlotRef)? name:(whiteSpace LocalName)? eolWhiteSpace
   {
     return {
       kind: 'handle',
@@ -1119,6 +1127,7 @@ TopLevelIdent
 ReservedWord
   = Direction
   / ParticleArgumentDirection
+  / RecipeHandleFate
 
 backquotedString = '`' pattern:([^`]+) '`' { return pattern.join(''); }
 id = "'" id:[^']+ "'" {return id.join('')}

--- a/runtime/test/manifest-parser-test.js
+++ b/runtime/test/manifest-parser-test.js
@@ -87,29 +87,21 @@ describe('manifest parser', function() {
       store Store1 of Person 'some-id' @7 in 'person.json'
       store Store2 of BigCollection<Person> in 'population.json'`);
   });
-  it('fails to parse an argument list that use reserved word \'consume\' as an identifier', () => {
-    try {
-      parse(`
-        particle MyParticle
-          in MyThing consume
-          out BigCollection<MyThing>? out`);
-      assert.fail('this parse should have failed, identifiers should not be reserved words!');
-    } catch (e) {
-      assert.include(e.message, 'Expected',
-          `bad error: '${e}'`);
-    }
-  });
-  it('fails to parse an argument list that use reserved word \'provide\' as an identifier', () => {
-    try {
-      parse(`
-        particle MyParticle
-          in MyThing provide
-          out BigCollection<MyThing>? out`);
-      assert.fail('this parse should have failed, identifiers should not be reserved words!');
-    } catch (e) {
-      assert.include(e.message, 'Expected',
-          `bad error: '${e}'`);
-    }
+  it('fails to parse an argument list that use a reserved word as an identifier', () => {
+    const reservedWords = ['inout', 'in', 'out', 'host', '`consume',
+      '`provide', 'provide', 'consume'];
+    reservedWords.map(reserved => {
+      try {
+        parse(`
+          particle MyParticle
+            in MyThing ${reserved}
+            out BigCollection<MyThing>? output`);
+        assert.fail('this parse should have failed, identifiers should not be reserved words!');
+      } catch (e) {
+        assert.include(e.message, 'Expected',
+            `bad error: '${e}'`);
+      }
+    });
   });
   it('fails to parse a nonsense argument list', () => {
     try {

--- a/runtime/test/manifest-parser-test.js
+++ b/runtime/test/manifest-parser-test.js
@@ -89,7 +89,9 @@ describe('manifest parser', function() {
   });
   it('fails to parse an argument list that use a reserved word as an identifier', () => {
     const reservedWords = ['inout', 'in', 'out', 'host', '`consume',
-      '`provide', 'provide', 'consume'];
+      '`provide', 'provide', 'consume', '?', 'use', 'map', 'create', 'copy',
+      '`slot'
+    ];
     reservedWords.map(reserved => {
       try {
         parse(`


### PR DESCRIPTION
This ensures that we don't reuse fate keywords as identifiers.

It also creates RecipeHandleFate which is lists accepted fate keywords.

Depends on #2225