### PR TITLE
Add nodes for slots in the overview graph

### DIFF
--- a/devtools/src/arcs-shared.js
+++ b/devtools/src/arcs-shared.js
@@ -14,6 +14,7 @@ $_documentContainer.innerHTML = `<dom-module id="shared-styles">
         --highlight-blue: #3879d9;
         --dark-red: #b71c1c;
         --dark-green: #09ba12;
+        --darker-green: #08780e;
 
         --devtools-purple: rgb(136, 19, 145);
         --devtools-blue: rgb(13, 34, 170);


### PR DESCRIPTION
Finally adds slots to the graph of particles in devtools and displays connections between the transformation particle and slots and handles it creates programatically.

The code in arcs-overview will need to be cleaned-up / unified at one point, but I'll do this in a follow-up patch where I'll move the handle connection to the new instantiate-recipe call. The graph-thingy right now relies on messages from the old data-flow tool, which will disappear soon, so I'll clean it up then.

Graph for viewing products from the browsing context:
<img width="687" alt="screen shot 2018-11-15 at 8 11 39 am" src="https://user-images.githubusercontent.com/26159485/48519409-ea798f00-e8c0-11e8-857a-5fa4516a9159.png">
