### PR TITLE
Require names for all ShapeArguments

### DIFF
--- a/runtime/manifest-parser.peg
+++ b/runtime/manifest-parser.peg
@@ -192,7 +192,7 @@ ShapeInterface
   }
 
 ShapeArgumentItem
-  = arg:ShapeArgumentWithName eolWhiteSpace
+  = arg:ShapeArgument eolWhiteSpace
   {
     return arg;
   }
@@ -204,28 +204,6 @@ ShapeArgumentList
   }
 
 ShapeArgument
-  = direction:(ParticleArgumentDirection whiteSpace)? type:(ParticleArgumentType whiteSpace)? name:(lowerIdent)?
-  {
-    if(direction) {
-      direction = direction[0]
-    }
-    if(type) {
-      type = type[0]
-    }
-    if (direction == 'host') {
-      error(`Shape cannot have arguments with a 'host' direction.`);
-    }
-
-    return {
-      kind: 'shape-argument',
-      location: location(),
-      direction,
-      type,
-      name,
-    };
-  }
-
-ShapeArgumentWithName
   = direction:(ParticleArgumentDirection whiteSpace)? type:(ParticleArgumentType whiteSpace)? name:(lowerIdent / '*')
   {
     if(direction) {

--- a/runtime/manifest-parser.peg
+++ b/runtime/manifest-parser.peg
@@ -1119,6 +1119,7 @@ TopLevelIdent
 //TODO Add ParticleArgumentDirection (rewrite recipes to not use directions as identifiers.
 ReservedWord
   = Direction
+  / ParticleArgumentDirection
 
 backquotedString = '`' pattern:([^`]+) '`' { return pattern.join(''); }
 id = "'" id:[^']+ "'" {return id.join('')}

--- a/runtime/manifest-parser.peg
+++ b/runtime/manifest-parser.peg
@@ -1116,7 +1116,6 @@ SameOrMoreIndent = &(i:" "* &{
 TopLevelIdent
   = upperIdent
 
-//TODO Add ParticleArgumentDirection (rewrite recipes to not use directions as identifiers.
 ReservedWord
   = Direction
   / ParticleArgumentDirection

--- a/runtime/test/manifest-parser-test.js
+++ b/runtime/test/manifest-parser-test.js
@@ -87,29 +87,21 @@ describe('manifest parser', function() {
       store Store1 of Person 'some-id' @7 in 'person.json'
       store Store2 of BigCollection<Person> in 'population.json'`);
   });
-  it('fails to parse an argument list that use reserved word \'consume\' as an identifier', () => {
-    try {
-      parse(`
-        particle MyParticle
-          in MyThing consume
-          out BigCollection<MyThing>? out`);
-      assert.fail('this parse should have failed, identifiers should not be reserved words!');
-    } catch (e) {
-      assert.include(e.message, 'Expected',
-          `bad error: '${e}'`);
-    }
-  });
-  it('fails to parse an argument list that use reserved word \'provide\' as an identifier', () => {
-    try {
-      parse(`
-        particle MyParticle
-          in MyThing provide
-          out BigCollection<MyThing>? out`);
-      assert.fail('this parse should have failed, identifiers should not be reserved words!');
-    } catch (e) {
-      assert.include(e.message, 'Expected',
-          `bad error: '${e}'`);
-    }
+  it('fails to parse an argument list that use a reserved word as an identifier', () => {
+    const reservedWords = ['inout', 'in', 'out', 'host', '`consume',
+      '`provide', 'provide', 'consume'];
+    reservedWords.map(reserved => {
+      try {
+        parse(`
+          particle MyParticle
+            in MyThing ${reserved}
+            out BigCollection<MyThing>? output`);
+        assert.fail('this parse should have failed, identifiers should not be reserved words!');
+      } catch (e) {
+        assert.include(e.message, 'Expected',
+            `bad error: '${e}'`);
+      }
+    });
   });
   it('fails to parse a nonsense argument list', () => {
     try {


### PR DESCRIPTION
Removes ShapeArgument (with optional name) and renames ShapeArgumentWithName to ShapeArgument.

This improves cases where ShapeArguments can be created accidentally.

Motivation:
ShapeArgument used to be made up of:
- an optional (Direction followed by whiteSpace)
- an optional (Type followed by whiteSpace)
- an optional Name

This means that the empty string "" was technically a valid ShapeArgument.

ShapeArgumentLists are made up of ShapeArguments separated by "," and whitespace, a line of commas interspersed with whiteSpace.

This implies that a trailing ", " in a ShapeArgumentList actually creates an additional ShapeArgument, which I do not believe is intended.

Requiring 'unnamed' ShapeArguments to use the '*' wildcard name mitigates this risk without requiring developers to create directions, types or names for every ShapeArgument they use.