### PR TITLE
Move isOptional ('?') to direction for ShapeArgument

### DIFF
--- a/runtime/manifest-parser.peg
+++ b/runtime/manifest-parser.peg
@@ -853,14 +853,9 @@ SpaceTagList
 NameAndTagList
    = name:lowerIdent tags:(whiteSpace TagList)?
    {
-     if(tags) {
-      tags = tags[1];
-     } else {
-      tags = [];
-     }
      return {
        name: name,
-       tags: tags
+       tags: tags = optional(tags, list => list[1], [])
      }
    }
    / whiteSpace name:lowerIdent

--- a/runtime/manifest-parser.peg
+++ b/runtime/manifest-parser.peg
@@ -345,7 +345,7 @@ ParticleArgumentList
   }
 
 ParticleArgument
-  = direction:ParticleArgumentDirection whiteSpace type:ParticleArgumentType nametag:NameAndTagList isOptional:'?'?
+  = direction:ParticleArgumentDirection isOptional:'?'? whiteSpace type:ParticleArgumentType whiteSpace nametag:NameAndTagList
   {
     return {
       kind: 'particle-argument',
@@ -851,10 +851,12 @@ SpaceTagList
 // - If name is not specified the first tag is used for the name
 // - Syntax error if no name or taglist are provided.
 NameAndTagList
-   = whiteSpace name:lowerIdent tags:(whiteSpace TagList)?
+   = name:lowerIdent tags:(whiteSpace TagList)?
    {
      if(tags) {
       tags = tags[1];
+     } else {
+      tags = [];
      }
      return {
        name: name,

--- a/runtime/manifest-parser.peg
+++ b/runtime/manifest-parser.peg
@@ -345,7 +345,7 @@ ParticleArgumentList
   }
 
 ParticleArgument
-  = direction:ParticleArgumentDirection whiteSpace type:ParticleArgumentType isOptional:'?'? nametag:NameAndTagList
+  = direction:ParticleArgumentDirection whiteSpace type:ParticleArgumentType nametag:NameAndTagList isOptional:'?'?
   {
     return {
       kind: 'particle-argument',
@@ -851,8 +851,11 @@ SpaceTagList
 // - If name is not specified the first tag is used for the name
 // - Syntax error if no name or taglist are provided.
 NameAndTagList
-   = whiteSpace name:lowerIdent whiteSpace tags:TagList
+   = whiteSpace name:lowerIdent tags:(whiteSpace TagList)?
    {
+     if(tags) {
+      tags = tags[1];
+     }
      return {
        name: name,
        tags: tags

--- a/runtime/test/manifest-parser-test.js
+++ b/runtime/test/manifest-parser-test.js
@@ -119,9 +119,9 @@ describe('manifest parser', function() {
     parse(`
       particle MyParticle
         in MyThing mandatory
-        in MyThing? optional1
-        out [MyThing]? optional2
-        out BigCollection<MyThing>? optional3`);
+        in? MyThing optional1
+        out? [MyThing] optional2
+        out? BigCollection<MyThing> optional3`);
   });
   it('parses manifests with search', () => {
     parse(`

--- a/runtime/test/manifest-test.js
+++ b/runtime/test/manifest-test.js
@@ -714,8 +714,8 @@ ${particleStr1}
     const parseRecipe = async (args) => {
       const recipe = (await Manifest.parse(`
         particle SomeParticle in 'some-particle.js'
-          \`consume Slot slotA${args.isRequiredSlotA ? '' : '?'}
-          \`consume Slot slotB${args.isRequiredSlotB ? '' : '?'}
+          \`consume${args.isRequiredSlotA ? '' : '?'} Slot slotA
+          \`consume${args.isRequiredSlotB ? '' : '?'} Slot slotB
 
         recipe
           \`slot 'slota-0' as s0
@@ -1460,7 +1460,7 @@ resource SomeName
       schema Something
       particle Thing in 'thing.js'
         in [Something] inThing
-        out [Something] maybeOutThings?
+        out? [Something] maybeOutThings
       recipe
         create as handle0 // [Something]
         Thing
@@ -1852,13 +1852,13 @@ resource SomeName
     assert.equal(recipe.handles[0]._connections[0], slotConnection);
   });
 
-  it('can parse particle arguments with tags and optional names', async () => {
+  it('can parse particle arguments with tags', async () => {
     const manifest = await Manifest.parse(`
       schema Dog
       schema Sled
       schema DogSled
       particle DogSledMaker in 'thing.js'
-        in Dog #leader
+        in Dog leader #leader
         in [Dog] team
         in Sled sled #dogsled
         out DogSled dogsled #multidog #winter #sled

--- a/runtime/test/manifest-test.js
+++ b/runtime/test/manifest-test.js
@@ -714,8 +714,8 @@ ${particleStr1}
     const parseRecipe = async (args) => {
       const recipe = (await Manifest.parse(`
         particle SomeParticle in 'some-particle.js'
-          \`consume Slot${args.isRequiredSlotA ? '' : '?'} slotA
-          \`consume Slot${args.isRequiredSlotB ? '' : '?'} slotB
+          \`consume Slot slotA${args.isRequiredSlotA ? '' : '?'}
+          \`consume Slot slotB${args.isRequiredSlotB ? '' : '?'}
 
         recipe
           \`slot 'slota-0' as s0
@@ -1460,7 +1460,7 @@ resource SomeName
       schema Something
       particle Thing in 'thing.js'
         in [Something] inThing
-        out [Something]? maybeOutThings
+        out [Something] maybeOutThings?
       recipe
         create as handle0 // [Something]
         Thing

--- a/runtime/test/recipe-test.js
+++ b/runtime/test/recipe-test.js
@@ -141,7 +141,7 @@ describe('recipe', function() {
   it(`is resolved if an optional handle with dependents is not connected`, async () => {
     const manifest = await Manifest.parse(`
       particle A in 'A.js'
-        in [Foo {}]? optionalIn
+        in [Foo {}] optionalIn?
           out [Foo {}] dependentOut
 
       recipe
@@ -156,7 +156,7 @@ describe('recipe', function() {
   it(`is not resolved if a handle is connected but its parent isn't`, async () => {
     const manifest = await Manifest.parse(`
       particle A in 'A.js'
-        in [Foo {}]? optionalIn
+        in [Foo {}] optionalIn?
           out [Foo {}] dependentOut
 
       particle B in 'B.js'

--- a/runtime/test/recipe-test.js
+++ b/runtime/test/recipe-test.js
@@ -141,7 +141,7 @@ describe('recipe', function() {
   it(`is resolved if an optional handle with dependents is not connected`, async () => {
     const manifest = await Manifest.parse(`
       particle A in 'A.js'
-        in [Foo {}] optionalIn?
+        in? [Foo {}] optionalIn
           out [Foo {}] dependentOut
 
       recipe
@@ -156,7 +156,7 @@ describe('recipe', function() {
   it(`is not resolved if a handle is connected but its parent isn't`, async () => {
     const manifest = await Manifest.parse(`
       particle A in 'A.js'
-        in [Foo {}] optionalIn?
+        in? [Foo {}] optionalIn
           out [Foo {}] dependentOut
 
       particle B in 'B.js'

--- a/runtime/ts/particle-spec.ts
+++ b/runtime/ts/particle-spec.ts
@@ -236,7 +236,7 @@ export class ParticleSpec {
     const indent = '  ';
     const writeConnection = (connection, indent) => {
       const tags = connection.tags.map((tag) => ` #${tag}`).join('');
-      results.push(`${indent}${connection.direction} ${connection.type.toString()} ${connection.name}${tags}${connection.isOptional ? '?' : ''}`);
+      results.push(`${indent}${connection.direction}${connection.isOptional ? '?' : ''} ${connection.type.toString()} ${connection.name}${tags}`);
       for (const dependent of connection.dependentConnections) {
         writeConnection(dependent, indent + '  ');
       }

--- a/runtime/ts/particle-spec.ts
+++ b/runtime/ts/particle-spec.ts
@@ -236,7 +236,7 @@ export class ParticleSpec {
     const indent = '  ';
     const writeConnection = (connection, indent) => {
       const tags = connection.tags.map((tag) => ` #${tag}`).join('');
-      results.push(`${indent}${connection.direction} ${connection.type.toString()}${connection.isOptional ? '?' : ''} ${connection.name}${tags}`);
+      results.push(`${indent}${connection.direction} ${connection.type.toString()} ${connection.name}${tags}${connection.isOptional ? '?' : ''}`);
       for (const dependent of connection.dependentConnections) {
         writeConnection(dependent, indent + '  ');
       }


### PR DESCRIPTION
This changes the syntax of ShapeArguments so that the question mark for isOptional comes after the associated direction, rather than after the type. This makes it clearer that the type is not an option type / optional but that the handle may or may not exist.

e.g. From:
```
in Dog? leader #leader
```

To:
```
in? Dog leader #leader
```
