### PR TITLE
Finding functionality for an object-explorer

### DIFF
--- a/devtools/package-lock.json
+++ b/devtools/package-lock.json
@@ -234,6 +234,27 @@
         }
       }
     },
+    "@polymer/iron-list": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@polymer/iron-list/-/iron-list-3.0.1.tgz",
+      "integrity": "sha512-RNMCtOiROJxge8fXla7m0cjyDbDIn8jRylL/1BAAbmTQqcbN4IU26oi4mPHxtaxx9MR+IIV5yzCY2kflsYY4Og==",
+      "requires": {
+        "@polymer/iron-a11y-keys-behavior": "^3.0.0-pre.26",
+        "@polymer/iron-resizable-behavior": "^3.0.0-pre.26",
+        "@polymer/iron-scroll-target-behavior": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      },
+      "dependencies": {
+        "@polymer/iron-resizable-behavior": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/@polymer/iron-resizable-behavior/-/iron-resizable-behavior-3.0.1.tgz",
+          "integrity": "sha512-FyHxRxFspVoRaeZSWpT3y0C9awomb4tXXolIJcZ7RvXhMP632V5lez+ch5G5SwK0LpnAPkg35eB0LPMFv+YMMQ==",
+          "requires": {
+            "@polymer/polymer": "^3.0.0"
+          }
+        }
+      }
+    },
     "@polymer/iron-location": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@polymer/iron-location/-/iron-location-3.0.1.tgz",

--- a/devtools/package.json
+++ b/devtools/package.json
@@ -13,6 +13,7 @@
     "@polymer/app-route": "^3.0.1",
     "@polymer/iron-a11y-keys-behavior": "^3.0.1",
     "@polymer/iron-icons": "^3.0.1",
+    "@polymer/iron-list": "^3.0.1",
     "@polymer/iron-pages": "^3.0.1",
     "@polymer/iron-selector": "^3.0.1",
     "@polymer/paper-dropdown-menu": "^3.0.1",

--- a/devtools/src/arcs-overview.js
+++ b/devtools/src/arcs-overview.js
@@ -2,7 +2,6 @@ import {PolymerElement} from '../deps/@polymer/polymer/polymer-element.js';
 import '../deps/@vaadin/vaadin-split-layout/vaadin-split-layout.js';
 import {MessengerMixin} from './arcs-shared.js';
 import '../deps/@vaadin/vaadin-split-layout/vaadin-split-layout.js';
-import './arcs-stores.js';
 import {html} from '../deps/@polymer/polymer/lib/utils/html-tag.js';
 
 class ArcsOverview extends MessengerMixin(PolymerElement) {
@@ -87,32 +86,27 @@ class ArcsOverview extends MessengerMixin(PolymerElement) {
         background-color: var(--light-gray);
       }
     </style>
-    <vaadin-split-layout>
-      <div id="graphContainer" style="flex: .5">
-        <div class="legend">
-          <div><span node style="background: var(--highlight-blue)"></span> Particle</div>
-          <div><span node style="background: var(--light-gray)"></span> Handle</div>
-          <div><span node style="background: var(--dark-green)"></span> Slot</div>
-          <div><span node style="background: var(--darker-green)"></span> Hosted Slot</div>
-          <div><span edge arrow-right style="background: var(--dark-green); border-color: var(--dark-green);"></span> Read</div>
-          <div><span edge arrow-right style="background: var(--dark-red); border-color: var(--dark-red);"></span> Write</div>
-          <div><span edge arrow-left arrow-right style="background: var(--highlight-blue); border-color: var(--highlight-blue);"></span> Read-Write</div>
-          <div><span edge circle style="background: var(--dark-gray)"></span> Hosted</div>
-          <div><span edge circle style="background: var(--dark-green)"></span> Consume</div>
-          <div><span edge circle style="background: var(--dark-red); border-color: var(--dark-red);"></span> Provide</div>
-        </div>
-        <div id="popup">
-          <pre id="popupText"></pre>
-          <div class="nav-list">
-            <a id="dataflowLink" href=""><iron-icon icon="swap-horiz"></iron-icon>Show in Dataflow</a>
-          </div>
-        </div>
-        <div id="graph"></div>
+    <div id="graphContainer">
+      <div class="legend">
+        <div><span node style="background: var(--highlight-blue)"></span> Particle</div>
+        <div><span node style="background: var(--light-gray)"></span> Handle</div>
+        <div><span node style="background: var(--dark-green)"></span> Slot</div>
+        <div><span node style="background: var(--darker-green)"></span> Hosted Slot</div>
+        <div><span edge arrow-right style="background: var(--dark-green); border-color: var(--dark-green);"></span> Read</div>
+        <div><span edge arrow-right style="background: var(--dark-red); border-color: var(--dark-red);"></span> Write</div>
+        <div><span edge arrow-left arrow-right style="background: var(--highlight-blue); border-color: var(--highlight-blue);"></span> Read-Write</div>
+        <div><span edge circle style="background: var(--dark-gray)"></span> Hosted</div>
+        <div><span edge circle style="background: var(--dark-green)"></span> Consume</div>
+        <div><span edge circle style="background: var(--dark-red); border-color: var(--dark-red);"></span> Provide</div>
       </div>
-      <aside style="flex: .5">
-        <arcs-stores></arcs-stores>
-      </aside>
-    </vaadin-split-layout>
+      <div id="popup">
+        <pre id="popupText"></pre>
+        <div class="nav-list">
+          <a id="dataflowLink" href=""><iron-icon icon="swap-horiz"></iron-icon>Show in Dataflow</a>
+        </div>
+      </div>
+      <div id="graph"></div>
+    </div>
 `;
   }
 
@@ -144,7 +138,7 @@ class ArcsOverview extends MessengerMixin(PolymerElement) {
       const {height, width} = rects[0].contentRect;
       this.$.graph.style.width = `${width}px`;
       this.$.graph.style.height = `${height}px`;
-    }).observe(this.$.graphContainer);
+    }).observe(this);
     this.$.popup.addEventListener('mouseleave', e => {
       this.$.popup.style.display = 'none';
     });
@@ -439,7 +433,7 @@ class ArcsOverview extends MessengerMixin(PolymerElement) {
     this._operations.clear();
     this._innerArcToTransformationParticle.clear();
     this._callbackIdToPecMsg.clear();
-    this._redraw();
+    if (this.active) this._redraw();
   }
 
   _cssVar(name) {

--- a/devtools/src/arcs-shared.js
+++ b/devtools/src/arcs-shared.js
@@ -12,6 +12,7 @@ $_documentContainer.innerHTML = `<dom-module id="shared-styles">
         --mid-gray: #ccc;
         --dark-gray: #888;
         --highlight-blue: #3879d9;
+        --focus-blue: #03a9f4;
         --dark-red: #b71c1c;
         --dark-green: #09ba12;
         --darker-green: #08780e;

--- a/devtools/src/object-explorer.js
+++ b/devtools/src/object-explorer.js
@@ -1,7 +1,62 @@
 import {PolymerElement} from '../deps/@polymer/polymer/polymer-element.js';
 import {html} from '../deps/@polymer/polymer/lib/utils/html-tag.js';
 
-class ObjectExplorer extends PolymerElement {
+/**
+ * ..:: Read Before Modifying ::..
+ * 
+ * ObjectExplorer is implemented to work well within an IronList,
+ * which efficiently displays large collections by recycling DOM.
+ * 
+ * The above constraint means that we CANNOT do following:
+ *   - Call functions from the template.
+ *     E.g. <span>[[_helperFunction(item)]]</span>
+ *   - Store information on DOM elements.
+ *     E.g. information about state of expansion needs to be in the data model.
+ * 
+ * ..:: Read Before Using ::..
+ * 
+ * There are 2 parallel APIs to the ObjectExplorer.
+ * 
+ * 1) When using as a standalone custom element:
+ *   
+ *   Pass the object to explore through an 'object' attribute:
+ *     <object-explorer object="[[objectToExplore]]"></object-explorer>
+ * 
+ *   Trigger searching through a 'find' attribute:
+ *     <object-explorer object="[[objectToExplore]]" find="[[searchPhrase]]">
+ *     or:
+ *     this.$.explorer.find = searchPhrase;
+ * 
+ * 2) When using inside an IronList:
+ * 
+ *   There is more data in your list than actual DOM elements, so you need to
+ *   prepare the underlying ObjectExplorer data structure yourself. You co do it
+ *   with a ObjectExplorer.prepareData static method and pass the result into
+ *   a 'data' attribute of the object-explorer.
+ * 
+ *   this.items = objects.map(obj => ObjectExplorer.prepareData(obj));
+ * 
+ *   <iron-list items="[[items]]">
+ *     <object-explorer data="[[item]]"></object-explorer>
+ *   </iron-list>
+ * 
+ *   To perform a search, we need to manually trigger search change in the underlying
+ *   data model, as there is more data than ObjectExplorer DOM elements. We do it with
+ *   ObjectExplorer.find(data, phrase) method.
+ *     
+ *     this.items.forEach(item => ObjectExplorer.find(item, searchPhrase));
+ * 
+ *   As the ObjectExplorer DOM elements have not been notified of the underlying data
+ *   changes, we need to also notify them manually. We can do it by setting a 'find'
+ *   attribute.
+ * 
+ *     for (const explorer of this.shadowRoot.querySelectorAll('iron-list object-explorer')) {
+ *       explorer.find = phrase;
+ *     }
+ * 
+ *   When in doubt, talk to piotrswigon@github / piotrs@google.
+ */
+export class ObjectExplorer extends PolymerElement {
   static get template() {
     return html`
     <style include="shared-styles">
@@ -22,6 +77,10 @@ class ObjectExplorer extends PolymerElement {
       }
       :host([inner]:not([folded])) {
         padding-left: 10px;
+      }
+      :host([inner][found-inside]:not([expanded]):not([folded])) {
+        padding-left: 0;
+        border-left: 10px solid yellow;
       }
       .header {
         display: inline-flex;
@@ -47,10 +106,6 @@ class ObjectExplorer extends PolymerElement {
         color: var(--dark-gray);
         margin-right: 1ch;
       }
-      [asString]:not(:empty) {
-        font-style: italic;
-        margin-right: 1ch;
-      }
       [prop] {
         max-width: 100%;
       }
@@ -61,68 +116,180 @@ class ObjectExplorer extends PolymerElement {
         content: ',';
         width: 2ch;
       }
-      [string] {
+      [type=string] {
         color: var(--devtools-red);
         word-break: break-all;
         width: initial;
       }
-      :host(:not([folded])) [string] {
+      [type=string]::before {
+        content: '"';
+      }
+      [type=string]::after {
+        content: '"';
+      }
+      :host(:not([folded])) [type=string] {
         white-space: pre-wrap;
       }
-      [numberOrBool] {
+      [type=number], [type=boolean] {
         color: var(--devtools-blue);
       }
-      [function] {
+      [type=null], [type=undefined] {
+        color: var(--dark-gray);
+      }
+      [type=function] {
         font-style: italic;
+      }
+      [type=function]::before {
+        content: 'ƒ ';
+        color: var(--devtools-blue);
       }
       [hidden] {
         display: none;
       }
+      [highlight] {
+        background-color: yellow;
+        border-radius: 5px;
+        padding: 3px 0;
+        box-shadow: 1px 1px 1px 1px rgba(0, 0, 0, .2);
+      }
     </style>
-    <span class="header" expandable$=[[_expandable(folded)]] on-click="_handleExpand" inner$=[[inner]] hidden$=[[skipHeader]]>
+    <span class="header" expandable$=[[data.expandable]] on-click="_handleExpand" inner$=[[inner]]>
       <slot></slot>
-      <span class="triangle devtools-small-icon" expanded$="[[expanded]]" hidden$=[[folded]]></span>
-      <template is="dom-if" if="[[!skipKey]]"><span key>[[key]]</span><span keySeparator>[[_separator(key)]]</span></template is="dom-if">
-      <span meta>[[_describe(folded)]]</span>
-      <span asString>[[_asString(data)]]</span>
+      <span class="triangle devtools-small-icon" expanded$="[[data.expanded]]" hidden$=[[folded]]></span>
+      <template is="dom-if" if="[[!skipKey]]"><span key inner-h-t-m-l="[[data.displayKey]]"></span><span keySeparator hidden="[[!data.key]]">:</span></template is="dom-if">
+      <template is="dom-if" if="[[!folded]]"><span meta>[[data.meta]]</span></template>
     </span>
-    <template is="dom-if" if="[[_isObject()]]">
-      [[_begin(data, expanded, folded)]]<!--
-   --><template is="dom-if" if="[[!folded]]"><!--
-     --><template is="dom-repeat" items="[[_props(data)]]">
-          <div prop folded$="[[!expanded]]">
-            <object-explorer inner folded$="[[!expanded]]" key="[[item.key]]" data="[[item.value]]" skip-key="[[_skipKey(expanded)]]"></object-explorer>
+    <template is="dom-if" if="[[data.object]]">
+      <template is="dom-if" if="[[!folded]]"><!--
+     -->[[data.begin]]<!--
+     --><template is="dom-repeat" items="[[data.props]]">
+          <div prop folded$="[[!data.expanded]]">
+            <object-explorer inner data="[[item]]" find="[[find]]" skip-key="[[data.skipInnerKey]]" folded$="[[!data.expanded]]" on-expand="_innerExpand"></object-explorer>
           </div>
         </template><!--
+   -->[[data.end]]<!--
    --></template is="dom-if"><!--
-   --><template is="dom-if" if="[[folded]]">...</template><!--
- -->[[_end(data, expanded, folded)]]
+   --><template is="dom-if" if="[[folded]]">[[data.folded]]</template>
     </template>
-    <template is="dom-if" if="[[_isString()]]">
-      <span string>"[[data]]"</span>
-    </template>
-    <template is="dom-if" if="[[_isNumberOrBoolean()]]">
-      <span numberOrBool>[[data]]</span>
-    </template>
-    <template is="dom-if" if="[[_isFunction()]]">
-      <span function>ƒ [[data.name]]()</span>
-    </template>
-    <template is="dom-if" if="[[_isNullOrUndefined()]]">
-      <span>[[_toString()]]</span>
+    <template is="dom-if" if="[[!data.object]]">
+      <span type$="[[data.type]]" inner-h-t-m-l="[[data.displayValue]]"></span>
     </template>
 `;
   }
 
   static get is() { return 'object-explorer'; }
 
+  static prepareData(ref, key = '') {
+    const data = {
+      type: ref === null ? 'null' : typeof ref,
+      key,
+      displayKey: this._escape(key)
+    };
+    switch (data.type) {
+      case 'object': {
+        const isArray = Array.isArray(ref);
+        const entries = Object.entries(ref);
+        Object.assign(data, {
+          object: true,
+          expanded: false,
+          expandable: entries.length > 0,
+          isArray,
+          meta: isArray ? `Array(${ref.length})` : ref.constructor.name,
+          folded: isArray ? `Array(${entries.length})` : `{${entries.length > 0 ? '…' : ''}}`,
+          props: entries.map(([key, value]) => this.prepareData(value, key)),  
+        });
+        Object.assign(data, this._expandedDependentProps(data));
+        break;
+      }
+      default:
+        Object.assign(data, {
+          meta: '',
+          value: ref,
+          displayValue: this._escape(ref)
+        });
+        break;
+    }
+    return data;
+  }
+
+  static find(data, phrase) {
+    // As _onFindChanged is called on object explorer in the order
+    // from leafs to the root, this allows to skip O(n^2).
+    if (data.findPhrase === phrase) return data.found;
+
+    const [displayKey, foundInKey] = this._highlight(phrase, data.key);
+    data.displayKey = displayKey;
+
+    if (data.type === 'object') {
+      let foundInside = false;
+      for (const inner of data.props) {
+        foundInside = this.find(inner, phrase) || foundInside;
+      }
+      data.foundInside = foundInside;
+      data.found = foundInKey || foundInside; 
+    } else {
+      const [displayValue, foundInValue] = this._highlight(phrase, String(data.value));
+      data.displayValue = displayValue;
+      data.found = foundInKey || foundInValue; 
+    }
+    data.findPhrase = phrase;
+
+    return data.found;
+  }
+
+  static _expandedDependentProps(data) {
+    return {
+      begin: data.expanded ? '' : (data.isArray ? '[' : '{'),
+      end: data.expanded ? '' : (data.isArray ? ']' : '}'),
+      skipInnerKey: data.isArray && !data.expanded
+    };
+  }
+
+  // Turns HTML strings into escaped ones, so that we can add
+  // HTML for highlighting and put the string as innerHTML.
+  static _escape(str) {
+    if (typeof str !== 'string') str = String(str);
+    return str.replace(/[\u00A0-\u9999<>\\&]/gim, i => ('&#' + i.charCodeAt(0) + ';'));
+  }
+
+  static _highlight(phrase, value) {
+    if (!phrase) {
+      return [this._escape(value), false];
+    }
+    const lcPhrase = phrase.toLowerCase();
+    const lcValue = value.toLowerCase();
+
+    const parts = [];
+    let i = 0;
+    let found = false;
+    while (i < value.length) {
+      const pi = lcValue.indexOf(lcPhrase, i);
+      parts.push(this._escape(value.substring(i, pi !== -1 ? pi : value.length)));
+      if (pi === -1) break;
+      parts.push(`<span highlight>${this._escape(value.substring(pi, pi + phrase.length))}</span>`);
+      found = true;
+      i = pi + phrase.length;
+    }
+
+    return [parts.join(''), found];
+  }
+
   static get properties() {
     return {
       data: Object,
-      key: String,
+      object: {
+        type: Object,
+        observer: '_objectProvided'
+      },
       expanded: {
         type: Boolean,
         reflectToAttribute: true,
-        value: false
+        computed: '_id(data.expanded)'
+      },
+      expandable: {
+        type: Boolean,
+        reflectToAttribute: true,
+        computed: '_id(data.expandable)'
       },
       inner: {
         type: Boolean,
@@ -135,74 +302,57 @@ class ObjectExplorer extends PolymerElement {
         value: false
       },
       skipKey: Boolean,
-      skipHeader: Boolean
+      find: {
+        type: String,
+        reflectToAttribute: true,
+        value: null,
+        observer: '_onFindChanged'
+      },
+      foundInside: {
+        type: Boolean,
+        reflectToAttribute: true,
+        computed: '_id(data.foundInside)'
+      },
     };
   }
 
-  _isObject() {
-    return this.data && typeof this.data === 'object';
+  _id(value) {
+    return value;
   }
 
-  _isString() {
-    return typeof this.data === 'string';
+  _objectProvided(object) {
+    this.set('data', ObjectExplorer.prepareData(object));
   }
 
-  _isNumberOrBoolean() {
-    return typeof this.data === 'number' || typeof this.data === 'boolean';
+  _switchExpanded(newExpanded) {
+    this.set(`data.expanded`, newExpanded);
+    const props = Object.entries(ObjectExplorer._expandedDependentProps(this.data));
+    for (const [key, value] of props) {
+      this.set(`data.${key}`, value);
+    }
   }
 
-  _isNullOrUndefined() {
-    return this.data == null;
+  _handleExpand() {
+    if (!this.data || !this.data.expandable) return;
+    let newExpand = !this.data.expanded;
+    if (this.folded) newExpand = true;
+    // TODO: Can we get around the need for a double event?
+    this.dispatchEvent(new CustomEvent('expand', {detail: this.data}));
+    this._switchExpanded(newExpand);
+    this.dispatchEvent(new CustomEvent('expand', {detail: this.data}));
   }
 
-  _isFunction() {
-    return typeof this.data === 'function';
+  _innerExpand() {
+    this._switchExpanded(true);
+    this.dispatchEvent(new CustomEvent('expand', {detail: this.data}));
   }
 
-  _expandable(folded) {
-    return this._isObject() && !folded;
-  }
-
-  _skipKey(expanded) {
-    return !expanded && this.data && Array.isArray(this.data);
-  }
-
-  _toString() {
-    return String(this.data);
-  }
-
-  _asString(object) {
-    if (object && object.hasOwnProperty('toString') && typeof object.toString === 'function') {
-      return `'${object.toString()}'`;
-    } else return '';
-  }
-
-  _props(data) {
-    return Object.entries(data).map(([key, value]) => ({key, value}));
-  }
-
-  _describe(folded) {
-    if (folded || !this._isObject()) return '';
-    return Array.isArray(this.data)
-        ? `Array(${this.data.length})`
-        : this.data.constructor.name;
-  }
-
-  _begin(data, expanded, folded) {
-    return expanded && !folded ? '' : (Array.isArray(data) ? '[' : '{');
-  }
-
-  _end(data, expanded, folded) {
-    return expanded && !folded ? '' : (Array.isArray(data) ? ']' : '}');
-  }
-
-  _separator(key) {
-    return key ? ': ' : '';
-  }
-
-  _handleExpand(e) {
-    if (!this.data || !this._isObject() || this.folded) return;
-    this.expanded = !this.expanded;
+  _onFindChanged(find) {
+    if (!this.data) return;
+    ObjectExplorer.find(this.data, find);
+    this.notifyPath('data.displayKey');
+    this.notifyPath('data.displayValue');
+    this.notifyPath('data.foundInside');
   }
 }
 


### PR DESCRIPTION
Number of related changes in this patch, sorry for a large-ish scope:
* Adds Find+Highlight functionality for <object-explorer> element.
* Makes <object-explorer> suitable to be used with <iron-list> with recycles DOM.
* Moves PEC-Log from dom-repeat to iron-list, which makes it usable with bigger/busier arcs, e.g. TVMaze demo.
* Plugs search phrase into PEC Log and Stores-Explorer.
* Moves Stores-Explorer from inside the Overview section (where the graph sits) to its own tab and simplifies it.

There's still much more to be done, short/mid term:
* Retire DataFlow tool and all related code in runtime - PEC Log should be sufficient now.
* Add capability to easily expand Find+Highlight to the headers of elements (E.g. name of the API call). I envision another custom element with similar API, to be used when we just want to search in strings, not in JSON.
* Introduce searching for more than one token, E.g. `DefineHandle !hjkbiufgyg6kgui:bhjfjgvk:11` would get a DefineHandle call with this id inside.
* Consider searching with regex.

But for now this patch gets us somewhere.