### PR TITLE
More pre-move cleanups for strategies

### DIFF
--- a/runtime/strategies/add-missing-handles.js
+++ b/runtime/strategies/add-missing-handles.js
@@ -16,12 +16,12 @@ export class AddMissingHandles extends Strategy {
       onRecipe(recipe) {
         // Don't add use handles while there are outstanding constraints
         if (recipe.connectionConstraints.length > 0) {
-          return;
+          return undefined;
         }
         // Don't add use handles to a recipe with free handles
         const freeHandles = recipe.handles.filter(handle => handle.connections.length === 0);
         if (freeHandles.length > 0) {
-          return;
+          return undefined;
         }
 
         // TODO: "description" handles are always created, and in the future they need to be "optional" (blocked by optional handles
@@ -29,7 +29,7 @@ export class AddMissingHandles extends Strategy {
         const disconnectedConnections = recipe.handleConnections.filter(
             hc => hc.handle == null && !hc.isOptional && hc.name !== 'descriptions' && hc.direction !== 'host');
         if (disconnectedConnections.length === 0) {
-          return;
+          return undefined;
         }
 
         return recipe => {

--- a/runtime/strategies/coalesce-recipes.js
+++ b/runtime/strategies/coalesce-recipes.js
@@ -39,14 +39,14 @@ export class CoalesceRecipes extends Strategy {
       // Find a provided slot for unfulfilled consume connection.
       onSlotConnection(recipe, slotConnection) {
         if (slotConnection.isResolved()) {
-          return;
+          return undefined;
         }
         if (!slotConnection.name || !slotConnection.particle) {
-          return;
+          return undefined;
         }
 
         if (slotConnection.targetSlot) {
-          return;
+          return undefined;
         }
 
         // TODO: also support a consume slot connection that is NOT required,
@@ -88,10 +88,10 @@ export class CoalesceRecipes extends Strategy {
       onSlot(recipe, slot) {
         // Find slots that according to their provided-spec must be consumed, but have no consume connection.
         if (slot.consumeConnections.length > 0) {
-          return; // slot has consume connections.
+          return undefined; // slot has consume connections.
         }
         if (!slot.sourceConnection || !slot.sourceConnection.slotSpec.getProvidedSlotSpec(slot.name).isRequired) {
-          return; // either a remote slot (no source connection), or a not required one.
+          return undefined; // either a remote slot (no source connection), or a not required one.
         }
 
         const results = [];
@@ -150,13 +150,14 @@ export class CoalesceRecipes extends Strategy {
         if (results.length > 0) {
           return results;
         }
+        return undefined;
       }
 
       onHandle(recipe, handle) {
         if (!index.coalescableFates.includes(handle.fate)
             || handle.id
             || handle.connections.length === 0
-            || handle.name === 'descriptions') return;
+            || handle.name === 'descriptions') return undefined;
         const results = [];
 
         for (const otherHandle of index.findHandleMatch(handle, index.coalescableFates)) {

--- a/runtime/strategies/create-description-handle.js
+++ b/runtime/strategies/create-description-handle.js
@@ -14,10 +14,10 @@ export class CreateDescriptionHandle extends Strategy {
     return Recipe.over(this.getResults(inputParams), new class extends Walker {
       onHandleConnection(recipe, handleConnection) {
         if (handleConnection.handle) {
-          return;
+          return undefined;
         }
         if (handleConnection.name !== 'descriptions') {
-          return;
+          return undefined;
         }
 
         return (recipe, handleConnection) => {

--- a/runtime/strategies/create-handle-group.js
+++ b/runtime/strategies/create-handle-group.js
@@ -16,7 +16,7 @@ export class CreateHandleGroup extends Strategy {
     return Recipe.over(this.getResults(inputParams), new class extends Walker {
       onRecipe(recipe) {
         // Resolve constraints before assuming connections are free.
-        if (recipe.connectionConstraints.length > 0) return;
+        if (recipe.connectionConstraints.length > 0) return undefined;
 
         const freeConnections = recipe.handleConnections.filter(hc => !hc.handle && !hc.isOptional);
         let maximalGroup = null;
@@ -64,6 +64,7 @@ export class CreateHandleGroup extends Strategy {
             }
           };
         }
+        return undefined;
       }
     }(Walker.Independent), this);
   }

--- a/runtime/strategies/find-hosted-particle.js
+++ b/runtime/strategies/find-hosted-particle.js
@@ -22,7 +22,7 @@ export class FindHostedParticle extends Strategy {
     const arc = this._arc;
     return Recipe.over(this.getResults(inputParams), new class extends Walker {
       onHandleConnection(recipe, connection) {
-        if (connection.direction !== 'host' || connection.handle) return;
+        if (connection.direction !== 'host' || connection.handle) return undefined;
         assert(connection.type.isInterface);
 
         const results = [];
@@ -59,7 +59,7 @@ export class FindHostedParticle extends Strategy {
               if (handle.id === id && handle.fate === 'copy'
                   && handle._mappedType && handle._mappedType.equals(handleType)) {
                 hc.connectToHandle(handle);
-                return;
+                return undefined;
               }
             }
 

--- a/runtime/strategies/group-handle-connections.js
+++ b/runtime/strategies/group-handle-connections.js
@@ -18,7 +18,7 @@ export class GroupHandleConnections extends Strategy {
       onRecipe(recipe) {
         // Only apply this strategy if ALL handle connections are named and have types.
         if (recipe.handleConnections.find(hc => !hc.type || !hc.name || hc.isOptional)) {
-          return;
+          return undefined;
         }
         // Find all unique types used in the recipe that have unbound handle connections.
         const types = new Set();
@@ -104,6 +104,7 @@ export class GroupHandleConnections extends Strategy {
             // TODO: score!
           };
         }
+        return undefined;
       }
     }(Walker.Permuted);
   }

--- a/runtime/strategies/map-slots.js
+++ b/runtime/strategies/map-slots.js
@@ -24,18 +24,18 @@ export class MapSlots extends Strategy {
         // TODO: is this right? Should constraints be connectible, in order to precompute the
         // recipe side once the verb is substituted?
         if (slotConnection.slotSpec == undefined) {
-          return;
+          return undefined;
         }
 
         if (slotConnection.isConnected()) {
-          return;
+          return undefined;
         }
 
         const {local, remote} = MapSlots.findAllSlotCandidates(slotConnection, arc);
 
         // ResolveRecipe handles one-slot case.
         if (local.length + remote.length < 2) {
-          return;
+          return undefined;
         }
 
         // If there are any local slots, prefer them over remote slots.

--- a/runtime/strategies/match-free-handles-to-connections.js
+++ b/runtime/strategies/match-free-handles-to-connections.js
@@ -15,8 +15,6 @@ import {Recipe} from '../ts-build/recipe/recipe.js';
  */
 export class MatchFreeHandlesToConnections extends Strategy {
   async generate(inputParams) {
-    const self = this;
-
     return Recipe.over(this.getResults(inputParams), new class extends Walker {
       onHandle(recipe, handle) {
         if (handle.connections.length > 0) {

--- a/runtime/strategies/match-particle-by-verb.js
+++ b/runtime/strategies/match-particle-by-verb.js
@@ -21,7 +21,7 @@ export class MatchParticleByVerb extends Strategy {
       onParticle(recipe, particle) {
         if (particle.name) {
           // Particle already has explicit name.
-          return;
+          return undefined;
         }
 
         const particleSpecs = arc.context.findParticlesByVerb(particle.primaryVerb)

--- a/runtime/strategies/match-recipe-by-verb.js
+++ b/runtime/strategies/match-recipe-by-verb.js
@@ -34,7 +34,7 @@ export class MatchRecipeByVerb extends Strategy {
       onParticle(recipe, particle) {
         if (particle.name) {
           // Particle already has explicit name.
-          return;
+          return undefined;
         }
 
         let recipes = arc.context.findRecipesByVerb(particle.primaryVerb);

--- a/runtime/strategies/resolve-recipe.js
+++ b/runtime/strategies/resolve-recipe.js
@@ -24,7 +24,7 @@ export class ResolveRecipe extends Strategy {
         if (handle.connections.length === 0 ||
             (handle.id && handle.storageKey) || (!handle.type) ||
             (!handle.fate)) {
-          return;
+          return undefined;
         }
 
         let mappable;
@@ -86,7 +86,7 @@ export class ResolveRecipe extends Strategy {
 
       onSlotConnection(recipe, slotConnection) {
         if (slotConnection.isConnected()) {
-          return;
+          return undefined;
         }
 
         const {local, remote} = MapSlots.findAllSlotCandidates(slotConnection, arc);
@@ -94,7 +94,7 @@ export class ResolveRecipe extends Strategy {
 
         // MapSlots handles a multi-slot case.
         if (allSlots.length !== 1) {
-          return;
+          return undefined;
         }
 
         const selectedSlot = allSlots[0];

--- a/runtime/strategies/search-tokens-to-handles.js
+++ b/runtime/strategies/search-tokens-to-handles.js
@@ -35,10 +35,10 @@ export class SearchTokensToHandles extends Strategy {
     return Recipe.over(this.getResults(inputParams), new class extends Walker {
       onHandle(recipe, handle) {
         if (!recipe.search || recipe.search.unresolvedTokens.length === 0) {
-          return;
+          return undefined;
         }
         if (handle.isResolved() || handle.connections.length === 0) {
-          return;
+          return undefined;
         }
 
         const possibleMatches = [];
@@ -46,7 +46,7 @@ export class SearchTokensToHandles extends Strategy {
           possibleMatches.push(...findMatchingStores(token, handle));
         }
         if (possibleMatches.length === 0) {
-          return;
+          return undefined;
         }
         return possibleMatches.map(match => {
           return (recipe, handle) => {

--- a/runtime/strategies/search-tokens-to-particles.js
+++ b/runtime/strategies/search-tokens-to-particles.js
@@ -30,7 +30,7 @@ export class SearchTokensToParticles extends Strategy {
 
       onRecipe(recipe) {
         if (!recipe.search || !recipe.search.unresolvedTokens.length) {
-          return;
+          return undefined;
         }
 
         const byToken = {};
@@ -60,7 +60,7 @@ export class SearchTokensToParticles extends Strategy {
         }
 
         if (resolvedTokens.size === 0) {
-          return;
+          return undefined;
         }
 
         const flatten = (arr) => [].concat(...arr);

--- a/runtime/ts/recipe/constraint-walker.ts
+++ b/runtime/ts/recipe/constraint-walker.ts
@@ -6,14 +6,19 @@
 // http://polymer.github.io/PATENTS.txt
 
 import {WalkerBase} from './walker-base.js';
+import {Recipe} from './recipe';
+import {ConnectionConstraint} from './connection-constraint.js';
 
 export class ConstraintWalker extends WalkerBase {
+  // Optional handler
+  onConstraint?(recipe: Recipe, constraint: ConnectionConstraint);
+  
   onResult(result) {
     super.onResult(result);
-    const recipe = result.result;
+    const recipe: Recipe = result.result as Recipe;
     const updateList = [];
 
-    recipe._connectionConstraints.forEach(constraint => {
+    recipe.connectionConstraints.forEach(constraint => {
       if (this.onConstraint) {
         const result = this.onConstraint(recipe, constraint);
         if (result) {

--- a/runtime/ts/recipe/recipe.ts
+++ b/runtime/ts/recipe/recipe.ts
@@ -13,6 +13,7 @@ import {Particle} from './particle.js';
 import {Search} from './search.js';
 import {Slot} from './slot.js';
 import {Handle} from './handle.js';
+import {HandleConnection} from './handle-connection.js';
 import {compareComparables} from './util.js';
 
 export class Recipe {
@@ -193,7 +194,7 @@ export class Recipe {
     return slotConnections;
   }
 
-  get handleConnections() {
+  get handleConnections(): HandleConnection[] {
     const handleConnections = [];
     this._particles.forEach(particle => {
       handleConnections.push(...Object.values(particle.connections));
@@ -247,7 +248,7 @@ export class Recipe {
     return digest(this.toString());
   }
 
-  normalize(options) {
+  normalize(options?) {
     if (Object.isFrozen(this)) {
       if (options && options.errors) {
         options.errors.set(this, 'already normalized');

--- a/strategizer/strategizer.js
+++ b/strategizer/strategizer.js
@@ -142,7 +142,6 @@ export class Strategizer {
       return 0;
     });
 
-    // Evaluate
     const evaluations = await Promise.all(this._evaluators.map(strategy => {
       return strategy.evaluate(this, generated);
     }));

--- a/strategizer/strategizer.js
+++ b/strategizer/strategizer.js
@@ -40,7 +40,7 @@ export class Strategizer {
   async generate() {
     // Generate
     const generation = this.generation + 1;
-    let generated = await Promise.all(this._strategies.map(strategy => {
+    const generatedResults = await Promise.all(this._strategies.map(strategy => {
       const recipeFilter = recipe => this._ruleset.isAllowed(strategy, recipe);
       return strategy.generate({
         generation: this.generation,
@@ -55,14 +55,16 @@ export class Strategizer {
     record.sizeOfLastGeneration = this.generated.length;
     record.generatedDerivationsByStrategy = {};
     for (let i = 0; i < this._strategies.length; i++) {
-      record.generatedDerivationsByStrategy[this._strategies[i].constructor.name] = generated[i].length;
+      record.generatedDerivationsByStrategy[this._strategies[i].constructor.name] = generatedResults[i].length;
     }
 
-    generated = [].concat(...generated);
+    let generated = [].concat(...generatedResults);
 
     // TODO: get rid of this additional asynchrony
     generated = await Promise.all(generated.map(async result => {
-      if (result.hash) result.hash = await result.hash;
+      if (result.hash) {
+        result.hash = await result.hash;
+      }
       return result;
     }));
 
@@ -87,7 +89,7 @@ export class Strategizer {
               record.nullDerivationsByStrategy[strategy] = 0;
             }
             record.nullDerivationsByStrategy[strategy]++;
-          } else if (existingResult.derivation.map(a => a.parent).indexOf(result.derivation[0].parent) != -1) {
+          } else if (existingResult.derivation.map(a => a.parent).indexOf(result.derivation[0].parent) !== -1) {
             record.duplicateSameParentDerivations += 1;
             if (record.duplicateSameParentDerivationsByStrategy[strategy] ==
                 undefined) {
@@ -114,19 +116,19 @@ export class Strategizer {
       return true;
     });
 
-    let terminal = new Map();
+    const terminalMap = new Map();
     for (const candidate of this.generated) {
-      terminal.set(candidate.result, candidate);
+      terminalMap.set(candidate.result, candidate);
     }
     // TODO(piotrs): This is inefficient, improve at some point.
     for (const result of this.populationHash.values()) {
       for (const {parent} of result.derivation) {
-        if (parent && terminal.has(parent.result)) {
-          terminal.delete(parent.result);
+        if (parent && terminalMap.has(parent.result)) {
+          terminalMap.delete(parent.result);
         }
       }
     }
-    terminal = [...terminal.values()];
+    const terminal = [...terminalMap.values()];
 
     record.survivingDerivations = generated.length;
 
@@ -140,13 +142,13 @@ export class Strategizer {
       return 0;
     });
 
-    // Evalute
+    // Evaluate
     const evaluations = await Promise.all(this._evaluators.map(strategy => {
       return strategy.evaluate(this, generated);
     }));
     const fitness = Strategizer._mergeEvaluations(evaluations, generated);
 
-    assert(fitness.length == generated.length);
+    assert(fitness.length === generated.length);
     for (let i = 0; i < fitness.length; i++) {
       this._internalPopulation.push({
         fitness: fitness[i],


### PR DESCRIPTION
- Explictly return values to comply with noImplicitReturns rule.
- More triple-equals cleanups
- Fix variable shadowing.  Remove uses where a variable is used for
  two explicit types.
- Replace for..in loops with for..of Object.keys(...)
- Add the optional onConstraint signature to constraint-walker
- Use public vs private _connectionConstraints method
- Recipe normalize method has an optional argument
- misc spelling