### PR TITLE
Update test for reservedWord to use new isOptional syntax

### DIFF
--- a/runtime/test/manifest-parser-test.js
+++ b/runtime/test/manifest-parser-test.js
@@ -96,7 +96,7 @@ describe('manifest parser', function() {
         parse(`
           particle MyParticle
             in MyThing ${reserved}
-            out BigCollection<MyThing>? output`);
+            out? BigCollection<MyThing> output`);
         assert.fail('this parse should have failed, identifiers should not be reserved words!');
       } catch (e) {
         assert.include(e.message, 'Expected',


### PR DESCRIPTION
Missed a test that was using the old syntax for isOptional, this moves the question mark.