### PR TITLE
Rename structures that use structure names

### DIFF
--- a/runtime/test/artifacts/outer-particle.js
+++ b/runtime/test/artifacts/outer-particle.js
@@ -21,7 +21,7 @@ defineParticle(({Particle}) => {
       if (handle.name === 'input' && model) {
         this.inHandle.set(model);
       }
-      if (handle.name === 'particle') {
+      if (handle.name === 'particle0') {
         await this.arc.loadRecipe(Particle.buildManifest`
           ${model}
 

--- a/runtime/test/artifacts/test-particles.manifest
+++ b/runtime/test/artifacts/test-particles.manifest
@@ -21,7 +21,7 @@ shape TestShape
   out Bar bar
 
 particle OuterParticle in 'outer-particle.js'
-  host TestShape particle
+  host TestShape particle0
   in Foo input
   out Bar output
 

--- a/runtime/test/artifacts/transformations/test-multiplex-slots-particle.js
+++ b/runtime/test/artifacts/transformations/test-multiplex-slots-particle.js
@@ -22,7 +22,7 @@ defineParticle(({TransformationDomParticle}) => {
 
     async setHandles(handles) {
       const arc = await this.constructInnerArc();
-      const hostedParticle = await handles.get('particle').get();
+      const hostedParticle = await handles.get('particle0').get();
 
       this.setState({arc, hostedParticle, type: handles.get('foos').type});
 

--- a/runtime/test/artifacts/transformations/test-slots-particles.manifest
+++ b/runtime/test/artifacts/transformations/test-slots-particles.manifest
@@ -12,14 +12,14 @@ schema Foo
 particle SingleSlotParticle in 'test-single-slot-particle.js'
   in Foo foo
   consume annotation
-  description `test slot particle`
+  description `test slot particle0`
 
 shape HostedParticleShape
   in Foo foo
   consume annotation
 
 particle MultiplexSlotsParticle in 'test-multiplex-slots-particle.js'
-  host HostedParticleShape particle
+  host HostedParticleShape particle0
   in [Foo] foos
   consume set of annotationsSet
-  description `outer test slot particle`
+  description `outer test slot particle0`

--- a/runtime/test/manifest-test.js
+++ b/runtime/test/manifest-test.js
@@ -1432,11 +1432,11 @@ resource SomeName
       shape Shape
         in Foo foo
       particle ShapeParticle
-        host Shape shape
+        host Shape shape0
       recipe
         create as handle0
         ShapeParticle
-          shape = handle0`);
+          shape0 = handle0`);
     assert(manifest.findShapeByName('Shape'));
     assert(manifest.recipes[0].normalize());
   });
@@ -1446,11 +1446,11 @@ resource SomeName
       shape Shape
         in Foo foo
       particle ShapeParticle
-        host Shape shape
+        host Shape shape0
       recipe
         create as handle0
         ShapeParticle
-          shape = handle0
+          shape0 = handle0
     `);
     assert(manifest.findShapeByName('Shape'));
     assert(manifest.recipes[0].normalize());

--- a/runtime/test/particle-shape-loading-test.js
+++ b/runtime/test/particle-shape-loading-test.js
@@ -40,7 +40,7 @@ describe('particle-shape-loading', function() {
                 if (handle.name === 'input') {
                   this.inHandle.set(model);
                 }
-                if (handle.name === 'particle') {
+                if (handle.name === 'particle0') {
                   await this.arc.loadRecipe(Particle.buildManifest\`
                     \${model}
 
@@ -82,7 +82,7 @@ describe('particle-shape-loading', function() {
       name: 'outerParticle',
       implFile: 'outer-particle.js',
       args: [
-        {direction: 'host', type: shapeType, name: 'particle', dependentConnections: []},
+        {direction: 'host', type: shapeType, name: 'particle0', dependentConnections: []},
         {direction: 'in', type: fooType, name: 'input', dependentConnections: []},
         {direction: 'out', type: barType, name: 'output', dependentConnections: []}
       ],
@@ -99,7 +99,7 @@ describe('particle-shape-loading', function() {
     particle.spec = outerParticleSpec;
 
     const recipeShapeHandle = recipe.newHandle();
-    particle.connections['particle'].connectToHandle(recipeShapeHandle);
+    particle.connections['particle0'].connectToHandle(recipeShapeHandle);
     recipeShapeHandle.fate = 'use';
     recipeShapeHandle.mapToStorage(shapeStore);
 
@@ -137,7 +137,7 @@ describe('particle-shape-loading', function() {
         create as h0
         create as h1
         OuterParticle
-          particle <- TestParticle
+          particle0 <- TestParticle
           output -> h0
           input <- h1
       `, {loader, fileName: './test.manifest'});

--- a/runtime/test/particle-shape-loading-with-slots-test.js
+++ b/runtime/test/particle-shape-loading-with-slots-test.js
@@ -37,7 +37,7 @@ describe('particle-shape-loading-with-slots', function() {
         create as handle0
         slot 'rootslotid-set-slotid-0' as slot0
         MultiplexSlotsParticle
-          particle = SingleSlotParticle
+          particle0 = SingleSlotParticle
           foos <- handle0
           consume annotationsSet as slot0
       `, {loader, fileName: './test.manifest'});

--- a/runtime/test/shape-test.js
+++ b/runtime/test/shape-test.js
@@ -170,6 +170,7 @@ describe('shape', function() {
 
   it('restricted type constraints type variables in the recipe', async () => {
     const manifest = await Manifest.parse(`
+      schema Burrito
       particle Transformer
         in [~a] input
         out [~a] output
@@ -190,7 +191,6 @@ describe('shape', function() {
         Multiplexer
           items = transformed
 
-        schema Burrito
         particle BurritoDisplayer
           in Burrito burrito
     `);

--- a/runtime/test/shape-test.js
+++ b/runtime/test/shape-test.js
@@ -170,7 +170,6 @@ describe('shape', function() {
 
   it('restricted type constraints type variables in the recipe', async () => {
     const manifest = await Manifest.parse(`
-      schema Burrito
       particle Transformer
         in [~a] input
         out [~a] output
@@ -191,8 +190,9 @@ describe('shape', function() {
         Multiplexer
           items = transformed
 
-        particle BurritoDisplayer
-          in Burrito burrito
+      schema Burrito
+      particle BurritoDisplayer
+        in Burrito burrito
     `);
 
     const recipe = manifest.recipes[0];

--- a/runtime/test/type-checker-tests.js
+++ b/runtime/test/type-checker-tests.js
@@ -213,13 +213,13 @@ describe('TypeChecker', () => {
         in Product {} item
 
       particle Transformation
-        host Shape particle
+        host Shape particle0
         in [~a] collection
 
       recipe
         create as h0
         Transformation
-          particle <- Concrete
+          particle0 <- Concrete
           collection <- h0
     `);
 


### PR DESCRIPTION
This allows us to make structure names (such as 'schema', 'particle' and 'recipe') invalid identifier names and should improve our error messages and avoid accidentally parsing these structures as if they were handles.

This change renames:
'particle' to 'particle0'
'shape' to 'shape0'

It also moves a schema definition from inside a recipe (where it was incorrectly being parsed as a handle with no direction or type, named 'schema')