### PR TITLE
Small test fixes

### DIFF
--- a/runtime/test/manifest-test.js
+++ b/runtime/test/manifest-test.js
@@ -735,11 +735,11 @@ ${particleStr1}
       particle SomeParticle in 'some-particle.js'
         consume slotA #aaa
           provide slotB #bbb
-        recipe
-          slot 'slot-id0' #aa #aaa as s0
-          SomeParticle
-            consume slotA #aa #hello as s0
-              provide slotB
+      recipe
+        slot 'slot-id0' #aa #aaa as s0
+        SomeParticle
+          consume slotA #aa #hello as s0
+            provide slotB
     `);
     // verify particle spec
     assert.lengthOf(manifest.particles, 1);
@@ -769,11 +769,11 @@ ${particleStr1}
       particle SomeParticle in 'some-particle.js'
         \`consume Slot slotA #aaa
           \`provide Slot slotB #bbb
-        recipe
-          \`slot 'slot-id0' #aa #aaa as s0
-          SomeParticle
-            slotA consume s0 #aa #hello
-            slotB provide
+      recipe
+        \`slot 'slot-id0' #aa #aaa as s0
+        SomeParticle
+          slotA consume s0 #aa #hello
+          slotB provide
     `);
     // verify particle spec
     assert.lengthOf(manifest.particles, 1);

--- a/runtime/test/planner-tests.js
+++ b/runtime/test/planner-tests.js
@@ -156,21 +156,21 @@ describe('Planner', function() {
 
 describe('AssignOrCopyRemoteHandles', function() {
   const particlesSpec = `
-  schema Foo
+      schema Foo
 
-  particle A in 'A.js'
-    in [Foo] list
-    consume root
+      particle A in 'A.js'
+        in [Foo] list
+        consume root
 
-  particle B in 'A.js'
-    inout [Foo] list
-    consume root
+      particle B in 'A.js'
+        inout [Foo] list
+        consume root
   `;
   const testManifest = async (recipeManifest, expectedResults) => {
     const manifest = (await Manifest.parse(`
-      ${particlesSpec}
+${particlesSpec}
 
-      ${recipeManifest}
+${recipeManifest}
     `));
 
     const schema = manifest.findSchemaByName('Foo');

--- a/runtime/test/shape-test.js
+++ b/runtime/test/shape-test.js
@@ -168,7 +168,7 @@ describe('shape', function() {
     assert.isTrue(constrainedType2.isResolved());
   });
 
-  it('restricted type constraints type variables in the recipe', async () => {
+  it('restricted type constrains type variables in the recipe', async () => {
     const manifest = await Manifest.parse(`
       particle Transformer
         in [~a] input

--- a/runtime/test/strategies/group-handle-connections-tests.js
+++ b/runtime/test/strategies/group-handle-connections-tests.js
@@ -15,29 +15,29 @@ import {assert} from '../chai-web.js';
 
 describe('GroupHandleConnections', function() {
   const schemaAndParticlesStr = `
-    schema Thing
-    schema OtherThing
-    particle A
-      in Thing ithingA1
-    particle B
-      in Thing ithingB1
-      in Thing ithingB2
-      in [OtherThing] iotherthingB1
-    particle C
-      in Thing ithingC1
-      out Thing othingC2
-      inout [OtherThing] iootherthingC1
-    particle D
-      in Thing ithingD1
-      in Thing ithingD2
-      out Thing othingD3
-    particle E
-      out Thing othingE1
+      schema Thing
+      schema OtherThing
+      particle A
+        in Thing ithingA1
+      particle B
+        in Thing ithingB1
+        in Thing ithingB2
+        in [OtherThing] iotherthingB1
+      particle C
+        in Thing ithingC1
+        out Thing othingC2
+        inout [OtherThing] iootherthingC1
+      particle D
+        in Thing ithingD1
+        in Thing ithingD2
+        out Thing othingD3
+      particle E
+        out Thing othingE1
       `;
   it('group in and out handle connections', async () => {
     // TODO: add another Type handle connections to the recipe!
     const manifest = (await Manifest.parse(`
-      ${schemaAndParticlesStr}
+${schemaAndParticlesStr}
       recipe
         A
         B

--- a/runtime/test/strategies/map-slots-tests.js
+++ b/runtime/test/strategies/map-slots-tests.js
@@ -18,17 +18,17 @@ import {assert} from '../chai-web.js';
 
 describe('MapSlots', function() {
   const particlesSpec = `
-    particle A in 'A.js'
-      consume root
+      particle A in 'A.js'
+        consume root
 
-    particle B in 'B.js'
-      consume root`;
+      particle B in 'B.js'
+        consume root`;
 
   const testManifest = async (recipeManifest, expectedSlots) => {
     const manifest = (await Manifest.parse(`
-      ${particlesSpec}
+${particlesSpec}
 
-      ${recipeManifest}
+${recipeManifest}
     `));
     const arc = StrategyTestHelper.createTestArc('test-plan-arc', manifest, 'dom');
     const recipe = await runMapSlotsAndResolveRecipe(arc, manifest.recipes[0]);


### PR DESCRIPTION
Primarily this PR fixes a set of incorrectly indented manifests (mostly due to string formatting).
The manifests involved seem to have been passing tests due to some leniency in the parser (that I haven't tracked down).

@shans , can you explain how this was working? It seems like it should have failed tests.
I have another change which can make the parser less lenient, which should make it easier to see when a manifest does something strange like this.

It also fixes a small typo in test:
 "restricted type constrain[t]s type variables in the recipe"
s/constraints/constrains/