### PR TITLE
Simplify reserved words test

### DIFF
--- a/runtime/test/manifest-parser-test.js
+++ b/runtime/test/manifest-parser-test.js
@@ -88,21 +88,16 @@ describe('manifest parser', function() {
       store Store2 of BigCollection<Person> in 'population.json'`);
   });
   it('fails to parse an argument list that use a reserved word as an identifier', () => {
-    const reservedWords = ['inout', 'in', 'out', 'host', '`consume', '`provide',
-                           'provide', 'consume', '?', 'use', 'map', 'create', 'copy',
-                           '`slot'];
-    reservedWords.map(reserved => {
-      try {
-        parse(`
-          particle MyParticle
-            in MyThing ${reserved}
-            out? BigCollection<MyThing> output`);
-        assert.fail('this parse should have failed, identifiers should not be reserved words!');
-      } catch (e) {
-        assert.include(e.message, 'Expected',
-            `bad error: '${e}'`);
-      }
-    });
+    try {
+      parse(`
+        particle MyParticle
+          in MyThing particle
+          out? BigCollection<MyThing> output`);
+      assert.fail('this parse should have failed, identifiers should not be reserved words!');
+    } catch (e) {
+      assert.include(e.message, 'Expected',
+          `bad error: '${e}'`);
+    }
   });
   it('fails to parse a nonsense argument list', () => {
     try {

--- a/runtime/test/manifest-parser-test.js
+++ b/runtime/test/manifest-parser-test.js
@@ -91,7 +91,7 @@ describe('manifest parser', function() {
     try {
       parse(`
         particle MyParticle
-          in MyThing particle
+          in MyThing consume
           out? BigCollection<MyThing> output`);
       assert.fail('this parse should have failed, identifiers should not be reserved words!');
     } catch (e) {


### PR DESCRIPTION
Talked to @shans today about the reserved word list test. We decided that this test is not clear and in some ways way more of a test for pegjs rather than our parser.

This simplifies the test and should make maintaining the reserved words list easier.