### PR TITLE
Make structure names generate a parse failure if used as identifiers

### DIFF
--- a/runtime/manifest-parser.peg
+++ b/runtime/manifest-parser.peg
@@ -1091,15 +1091,25 @@ SameOrMoreIndent = &(i:" "* &{
 TopLevelIdent
   = upperIdent
 
+// Should only be used as a negative match.
 ReservedWord
-  = Direction
+  = (Direction
   / ParticleArgumentDirection
   / RecipeHandleFate
+  / 'particle'
+  / 'recipe'
+  / 'import'
+  / 'shape'
+  / 'schema'
+  ) (whiteSpace / eolWhiteSpace)
+{
+  throw new Error(`Expected identifier but keyword, '${text()}' found.`);
+}
 
 backquotedString = '`' pattern:([^`]+) '`' { return pattern.join(''); }
 id = "'" id:[^']+ "'" {return id.join('')}
 upperIdent = ident:([A-Z][a-z0-9_]i*) {return text()}
-lowerIdent = ident:(!(ReservedWord (whiteSpace / eolWhiteSpace))[a-z][a-z0-9_]i*) {return text()}
+lowerIdent = ident:((!ReservedWord)([a-z][a-z0-9_]i*)) {return text()}
 whiteSpace
   = " "+
 eolWhiteSpace


### PR DESCRIPTION
Takes advantage of the reordering of attempted parses to increase parsing strictness.

This now throws an error if it discovers an unexpected reserved word.

Should fix https://github.com/PolymerLabs/arcs/issues/513