### PR TITLE
Replace uses of is<Type> with instanceof checks in the runtime.

### DIFF
--- a/runtime/suggestion-storage.js
+++ b/runtime/suggestion-storage.js
@@ -15,7 +15,7 @@ import {assert} from '../platform/assert-web.js';
 import {Manifest} from './ts-build/manifest.js';
 import {RecipeResolver} from './ts-build/recipe/recipe-resolver.js';
 import {Schema} from './ts-build/schema.js';
-import {Type} from './ts-build/type.js';
+import {InterfaceType} from './ts-build/type.js';
 
 export class SuggestionStorage {
   constructor(arc, userid) {
@@ -178,7 +178,7 @@ export class SuggestionStorage {
 
         // Override handle conenctions with particle name as local name.
         Object.values(handle.connections).forEach(conn => {
-          assert(conn.type.isInterface);
+          assert(conn.type instanceof InterfaceType);
           conn._handle = {localName: hostedParticleName};
         });
 

--- a/runtime/test/reference-test.js
+++ b/runtime/test/reference-test.js
@@ -13,7 +13,7 @@ import {Manifest} from '../ts-build/manifest.js';
 import {MessageChannel} from '../ts-build/message-channel.js';
 import {ParticleExecutionContext} from '../ts-build/particle-execution-context.js';
 import {StubLoader} from '../testing/stub-loader.js';
-import {Type} from '../ts-build/type.js';
+import {Type, ReferenceType} from '../ts-build/type.js';
 import {Arc} from '../ts-build/arc.js';
 import {assertSingletonWillChangeTo} from '../testing/test-util.js';
 
@@ -47,7 +47,7 @@ describe('references', function() {
     assert.isTrue(recipe.isResolved());
     assert.equal(recipe.handles[0].id, 'reference:1');
     recipe.handles[0].type.maybeEnsureResolved();
-    assert.isTrue(recipe.handles[0].type.isReference);
+    assert.isTrue(recipe.handles[0].type instanceof ReferenceType);
     assert.equal(recipe.handles[0].type.resolvedType().referredType.data.name, 'Result');
   });
 
@@ -102,7 +102,7 @@ describe('references', function() {
     assert.isTrue(recipe.isResolved());
     await arc.instantiate(recipe);
 
-    assert.isTrue(arc._stores[0]._type.isReference);
+    assert.isTrue(arc._stores[0]._type instanceof ReferenceType);
 
     const volatileEngine = arc.storageProviderFactory._storageInstances['volatile'].storage;
     const backingStore = await volatileEngine.baseStorageFor(arc._stores[1]._type, volatileEngine.baseStorageKey(arc._stores[1]._type));

--- a/runtime/test/shape-test.js
+++ b/runtime/test/shape-test.js
@@ -10,7 +10,7 @@
 
 import {assert} from './chai-web.js';
 import {Shape} from '../ts-build/shape.js';
-import {Type} from '../ts-build/type.js';
+import {Type, EntityType, VariableType} from '../ts-build/type.js';
 import {Manifest} from '../ts-build/manifest.js';
 import {TypeChecker} from '../ts-build/recipe/type-checker.js';
 import {Schema} from '../ts-build/schema.js';
@@ -207,7 +207,7 @@ describe('shape', function() {
     for (const handle of recipe.handles) {
       const collectionType = handle.type.collectionType;
       const resolved = collectionType.resolvedType();
-      assert.isTrue(resolved.isVariable);
+      assert.isTrue(resolved instanceof VariableType);
       assert.isFalse(resolved.canEnsureResolved());
     }
 
@@ -219,10 +219,10 @@ describe('shape', function() {
     for (const handle of recipe.handles) {
       const collectionType = handle.type.collectionType;
       const resolved = collectionType.resolvedType();
-      assert.isTrue(collectionType.isVariable);
+      assert.isTrue(collectionType instanceof VariableType);
       assert.isTrue(resolved.canEnsureResolved());
       const canWriteSuperset = resolved.canWriteSuperset;
-      assert.isTrue(canWriteSuperset.isEntity);
+      assert.isTrue(canWriteSuperset instanceof EntityType);
       assert.equal(canWriteSuperset.entitySchema.name, 'Burrito');
     }
   });

--- a/runtime/test/strategies/find-hosted-particle-tests.js
+++ b/runtime/test/strategies/find-hosted-particle-tests.js
@@ -14,6 +14,7 @@ import {StrategyTestHelper} from './strategy-test-helper.js';
 import {Loader} from '../../ts-build/loader.js';
 import {Arc} from '../../ts-build/arc.js';
 import {FindHostedParticle} from '../../ts-build/strategies/find-hosted-particle.js';
+import {InterfaceType} from '../../ts-build/type.js';
 import {assert} from '../chai-web.js';
 
 async function runStrategy(manifestStr) {
@@ -58,7 +59,7 @@ describe('FindHostedParticle', function() {
     const handle = recipe.handles[0];
     assert.equal(handle.fate, 'copy');
     assert.isTrue(handle.id.toString().endsWith(':test-arc:particle-literal:Matches'));
-    assert.isTrue(handle.type.isInterface);
+    assert.isTrue(handle.type instanceof InterfaceType);
     assert.isTrue(handle.type.isResolved());
     assert.equal(handle.type.interfaceShape.name, 'HostedShape');
   });
@@ -89,7 +90,7 @@ describe('FindHostedParticle', function() {
     const handle = recipe.handles[0];
     assert.equal(handle.fate, 'copy');
     assert.isTrue(handle.id.toString().endsWith(':test-arc:particle-literal:Matches'));
-    assert.isTrue(handle.type.isInterface);
+    assert.isTrue(handle.type instanceof InterfaceType);
     assert.equal(handle.type.interfaceShape.name, 'HostedShape');
 
     const connections = Object.values(recipe.particles[0].connections);
@@ -205,7 +206,7 @@ describe('FindHostedParticle', function() {
 
     assert.isEmpty(arc._stores);
     await arc.instantiate(outRecipe);
-    const particleSpecStore = arc._stores.find(store => store.type.isInterface);
+    const particleSpecStore = arc._stores.find(store => store.type instanceof InterfaceType);
     const particleSpec = await particleSpecStore.get();
     assert.isNotNull(particleSpec.id, 'particleSpec stored in handle should have an id');
     delete particleSpec.id;

--- a/runtime/test/type-checker-tests.js
+++ b/runtime/test/type-checker-tests.js
@@ -13,7 +13,7 @@
 import {assert} from './chai-web.js';
 
 import {Schema} from '../ts-build/schema.js';
-import {Type} from '../ts-build/type.js';
+import {Type, SlotType} from '../ts-build/type.js';
 import {SlotInfo} from '../ts-build/slot-info.js';
 import {TypeChecker} from '../ts-build/recipe/type-checker.js';
 import {TypeVariable} from '../ts-build/type-variable.js';
@@ -358,6 +358,6 @@ describe('TypeChecker', () => {
     assert(result.canEnsureResolved());
     result.maybeEnsureResolved();
     assert(result.isResolved());
-    assert(result.resolvedType().isSlot);
+    assert(result.resolvedType() instanceof SlotType);
   });
 });

--- a/runtime/testing/mock-slot-composer.js
+++ b/runtime/testing/mock-slot-composer.js
@@ -12,6 +12,7 @@
 import {assert} from '../test/chai-web.js';
 import {FakeSlotComposer} from './fake-slot-composer.js';
 import {SlotDomConsumer} from '../ts-build/slot-dom-consumer.js';
+import {InterfaceType} from '../ts-build/type.js';
 
 const logging = false;
 const log = (!logging || global.logging === false) ? () => {} : console.log.bind(console, '---------- MockSlotComposer::');
@@ -169,7 +170,7 @@ export class MockSlotComposer extends FakeSlotComposer {
   // exists - should await ensureBackingStore() before accessing it.
   _getHostedParticleNames(particle) {
     return Object.values(particle.connections)
-        .filter(conn => conn.type.isInterface)
+        .filter(conn => conn.type instanceof InterfaceType)
         .map(conn => {
           const store = this.arc.findStoreById(conn.handle.id);
           if (store.referenceMode) {

--- a/runtime/testing/test-helper.js
+++ b/runtime/testing/test-helper.js
@@ -17,6 +17,7 @@ import {Planner} from '../ts-build/planner.js';
 import {MockSlotComposer} from '../testing/mock-slot-composer.js';
 import {MessageChannel} from '../ts-build/message-channel.js';
 import {ParticleExecutionContext} from '../ts-build/particle-execution-context.js';
+import {InterfaceType} from '../ts-build/type.js';
 
 /** @class TestHelper
  * Helper class to recipe instantiation and replanning.
@@ -135,7 +136,7 @@ export class TestHelper {
         if (options.hostedParticles) {
           suggestions = suggestions.filter(p => {
             return options.hostedParticles.every(hosted => {
-              const interfaceHandles = p.plan.handles.filter(h => h.type.isInterface);
+              const interfaceHandles = p.plan.handles.filter(h => h.type instanceof InterfaceType);
               return interfaceHandles.find(handle => this.arc.findStoreById(handle.id)._stored.name == hosted);
             });
           });

--- a/runtime/testing/test-util.js
+++ b/runtime/testing/test-util.js
@@ -11,6 +11,7 @@
  'use strict';
 
 import {assert} from '../test/chai-web.js';
+import {CollectionType} from '../ts-build/type.js';
 
 // Helper class for testing a Collection-based store that collects messages from a particle.
 // This detects when too few or too many messages are sent in addition to matching the message
@@ -50,7 +51,7 @@ export class ResultInspector {
   // store: a Collection-based store that should be connected as an output for the particle
   // field: the field within store's contained Entity type that this inspector should observe
   constructor(arc, store, field) {
-    assert(store.type.isCollection, `ResultInspector given non-Collection store: ${store}`);
+    assert(store.type instanceof CollectionType, `ResultInspector given non-Collection store: ${store}`);
     this._arc = arc;
     this._store = store;
     this._field = field;

--- a/runtime/ts/description.ts
+++ b/runtime/ts/description.ts
@@ -17,6 +17,7 @@ import {Handle} from './recipe/handle.js';
 import {Particle} from './recipe/particle.js';
 import {HandleConnection} from './recipe/handle-connection.js';
 import {StorageProviderBase} from './storage/storage-provider-base.js';
+import {CollectionType, BigCollectionType, InterfaceType} from './type.js';
 
 export class Description {
   relevance: {} | null = null;
@@ -374,7 +375,7 @@ export class DescriptionFormatter {
         assert(!token.extra, `Unrecognized extra ${token.extra}`);
 
         // Transformation's hosted particle.
-        if (token._handleConn.type.isInterface) {
+        if (token._handleConn.type instanceof InterfaceType) {
           const particleSpec = ParticleSpec.fromLiteral(await token._store.get());
           // TODO: call this.patternToSuggestion(...) to resolved expressions in the pattern template.
           return particleSpec.pattern;
@@ -391,8 +392,10 @@ export class DescriptionFormatter {
         const storeValue = await this._formatStoreValue(token.handleName, token._store);
         if (!description) {
           // For singleton handle, if there is no real description (the type was used), use the plain value for description.
-          // TODO: should this look at type.getContainedType() (which includes references), or maybe just type.isEntity?
-          if (storeValue && !this.excludeValues && !token._store.type.isCollection && !token._store.type.isBigCollection) {
+          // TODO: should this look at type.getContainedType() (which includes references), or maybe just check for EntityType?
+          const storeType = token._store.type;
+          if (storeValue && !this.excludeValues &&
+              !(storeType instanceof CollectionType) && !(storeType instanceof BigCollectionType)) {
             return storeValue;
           }
         }
@@ -434,7 +437,7 @@ export class DescriptionFormatter {
   }
 
   async _propertyTokenToString(handleName, store, properties) {
-    assert(!store.type.isCollection && !store.type.isBigCollection,
+    assert(!(store.type instanceof CollectionType) && !(store.type instanceof BigCollectionType),
            `Cannot return property ${properties.join(',')} for Collection or BigCollection`);
     // Use singleton value's property (eg. "09/15" for person's birthday)
     const valueVar = await store.get();
@@ -459,12 +462,12 @@ export class DescriptionFormatter {
     if (!store) {
       return;
     }
-    if (store.type.isCollection) {
+    if (store.type instanceof CollectionType) {
       const values = await store.toList();
       if (values && values.length > 0) {
         return this._formatCollection(handleName, values);
       }
-    } else if (store.type.isBigCollection) {
+    } else if (store.type instanceof BigCollectionType) {
       const cursorId = await store.stream(1);
       const {value, done} = await store.cursorNext(cursorId);
       store.cursorClose(cursorId);

--- a/runtime/ts/handle.ts
+++ b/runtime/ts/handle.ts
@@ -12,7 +12,8 @@ import {Symbols} from './symbols.js';
 import {assert} from '../../platform/assert-web.js';
 import {ParticleSpec} from './particle-spec.js';
 import {StorageProxy, CollectionProxy, VariableProxy, BigCollectionProxy} from './storage-proxy.js';
-import { Particle } from './particle.js';
+import {Particle} from './particle.js';
+import {EntityType, CollectionType, BigCollectionType, InterfaceType, ReferenceType} from './type.js';
 
 // TODO: This won't be needed once runtime is transferred between contexts.
 function cloneData(data) {
@@ -284,13 +285,13 @@ class Variable extends Handle {
     if (model === null) {
       return null;
     }
-    if (this.type.isEntity) {
+    if (this.type instanceof EntityType) {
       return restore(model, this.entityClass);
     }
-    if (this.type.isInterface) {
+    if (this.type instanceof InterfaceType) {
       return ParticleSpec.fromLiteral(model);
     }
-    if (this.type.isReference) {
+    if (this.type instanceof ReferenceType) {
       return new Reference(model, this.type, this._proxy.pec);
     }
     assert(false, `Don't know how to deliver handle data of type ${this.type}`);
@@ -432,16 +433,16 @@ class BigCollection extends Handle {
 
 export function handleFor(proxy: StorageProxy, name: string = null, particleId = 0, canRead = true, canWrite = true) {
   let handle;
-  if (proxy.type.isCollection) {
+  if (proxy.type instanceof CollectionType) {
     handle = new Collection(proxy, name, particleId, canRead, canWrite);
-  } else if (proxy.type.isBigCollection) {
+  } else if (proxy.type instanceof BigCollectionType) {
     handle = new BigCollection(proxy, name, particleId, canRead, canWrite);
   } else {
     handle = new Variable(proxy, name, particleId, canRead, canWrite);
   }
 
   const type = proxy.type.getContainedType() || proxy.type;
-  if (type.isEntity) {
+  if (type instanceof EntityType) {
     handle.entityClass = type.entitySchema.entityClass(proxy.pec);
   }
   return handle;

--- a/runtime/ts/plan/suggestion.ts
+++ b/runtime/ts/plan/suggestion.ts
@@ -22,6 +22,7 @@ import {StorageProviderBase} from '../storage/storage-provider-base.js';
 import {Recipe} from '../recipe/recipe.js';
 import {RecipeResolver} from '../recipe/recipe-resolver.js';
 import {Relevance} from '../relevance.js';
+import {InterfaceType} from '../type.js';
 
 export class Suggestion {
   arc: Arc;
@@ -107,7 +108,7 @@ export class Suggestion {
 
         // Override handle conenctions with particle name as local name.
         Object.values(handle.connections).forEach(conn => {
-          assert(conn['type'].isInterface);
+          assert(conn['type'] instanceof InterfaceType);
           conn['_handle'] = {localName: hostedParticleName};
         });
 

--- a/runtime/ts/recipe/recipe.ts
+++ b/runtime/ts/recipe/recipe.ts
@@ -15,6 +15,7 @@ import {Slot} from './slot.js';
 import {Handle} from './handle.js';
 import {HandleConnection} from './handle-connection.js';
 import {compareComparables} from './util.js';
+import {InterfaceType} from '../type.js';
 
 export class Recipe {
   private _particles = <Particle[]>[];
@@ -314,7 +315,9 @@ export class Recipe {
     const slots = [];
     // Reorder connections so that interfaces come last.
     // TODO: update handle-connection comparison method instead?
-    for (const connection of connections.filter(c => !c.type || !c.type.isInterface).concat(connections.filter(c => !!c.type && !!c.type.isInterface))) {
+    let ordered = connections.filter(c => !c.type || !(c.type instanceof InterfaceType));
+    ordered = ordered.concat(connections.filter(c => !!c.type && !!(c.type instanceof InterfaceType)));
+    for (const connection of ordered) {
       if (!seenParticles.has(connection.particle)) {
         particles.push(connection.particle);
         seenParticles.add(connection.particle);

--- a/runtime/ts/recipe/type-checker.ts
+++ b/runtime/ts/recipe/type-checker.ts
@@ -5,7 +5,7 @@
 // subject to an additional IP rights grant found at
 // http://polymer.github.io/PATENTS.txt
 
-import {Type} from '../type.js';
+import {Type, EntityType, VariableType, CollectionType, BigCollectionType, InterfaceType, SlotType} from '../type.js';
 import {TypeVariable} from '../type-variable.js';
 
 export class TypeChecker {
@@ -55,7 +55,7 @@ export class TypeChecker {
     }
 
     const getResolution = candidate => {
-      if (candidate.isVariable === false) {
+      if (!(candidate instanceof VariableType)) {
         return candidate;
       }
       if (candidate.canReadSubset == null || candidate.canWriteSuperset == null) {
@@ -72,11 +72,11 @@ export class TypeChecker {
 
     const candidate = baseType.resolvedType();
 
-    if (candidate.isCollection) {
+    if (candidate instanceof CollectionType) {
       const resolution = getResolution(candidate.collectionType);
       return (resolution !== null) ? resolution.collectionOf() : null;
     }
-    if (candidate.isBigCollection) {
+    if (candidate instanceof BigCollectionType) {
       const resolution = getResolution(candidate.bigCollectionType);
       return (resolution !== null) ? resolution.bigCollectionOf() : null;
     }
@@ -87,8 +87,8 @@ export class TypeChecker {
   static _tryMergeTypeVariable(base, onto) {
     const [primitiveBase, primitiveOnto] = Type.unwrapPair(base.resolvedType(), onto.resolvedType());
 
-    if (primitiveBase.isVariable) {
-      if (primitiveOnto.isVariable) {
+    if (primitiveBase instanceof VariableType) {
+      if (primitiveOnto instanceof VariableType) {
         // base, onto both variables.
         const result = primitiveBase.variable.maybeMergeConstraints(primitiveOnto.variable);
         if (result === false) {
@@ -102,11 +102,11 @@ export class TypeChecker {
         primitiveBase.variable.resolution = primitiveOnto;
       }
       return base;
-    } else if (primitiveOnto.isVariable) {
+    } else if (primitiveOnto instanceof VariableType) {
       // onto variable, base not.
       primitiveOnto.variable.resolution = primitiveBase;
       return onto;
-    } else if (primitiveBase.isInterface && primitiveOnto.isInterface) {
+    } else if (primitiveBase instanceof InterfaceType && primitiveOnto instanceof InterfaceType) {
       const result = primitiveBase.interfaceShape.tryMergeTypeVariablesWith(primitiveOnto.interfaceShape);
       if (result == null) {
         return null;
@@ -122,7 +122,7 @@ export class TypeChecker {
 
   static _tryMergeConstraints(handleType, {type, direction}) {
     let [primitiveHandleType, primitiveConnectionType] = Type.unwrapPair(handleType.resolvedType(), type.resolvedType());
-    if (primitiveHandleType.isVariable) {
+    if (primitiveHandleType instanceof VariableType) {
       while (primitiveConnectionType.isTypeContainer()) {
         if (primitiveHandleType.variable.resolution != null
             || primitiveHandleType.variable.canReadSubset != null
@@ -134,8 +134,14 @@ export class TypeChecker {
         // allowed because this variable could represent anything, and it needs to represent this structure
         // in order for type resolution to succeed.
         const newVar = Type.newVariable(new TypeVariable('a', null, null));
-        primitiveHandleType.variable.resolution = 
-            primitiveConnectionType.isCollection ? Type.newCollection(newVar) : (primitiveConnectionType.isBigCollection ? Type.newBigCollection(newVar) : Type.newReference(newVar));
+        if (primitiveConnectionType instanceof CollectionType) {
+          primitiveHandleType.variable.resolution = Type.newCollection(newVar);
+        } else if (primitiveConnectionType instanceof BigCollectionType) {
+          primitiveHandleType.variable.resolution = Type.newBigCollection(newVar);
+        } else {
+          primitiveHandleType.variable.resolution = Type.newReference(newVar);
+        }
+
         const unwrap = Type.unwrapPair(primitiveHandleType.resolvedType(), primitiveConnectionType);
         [primitiveHandleType, primitiveConnectionType] = unwrap;
       }
@@ -216,14 +222,14 @@ export class TypeChecker {
     const [leftType, rightType] = Type.unwrapPair(resolvedLeft, resolvedRight);
 
     // a variable is compatible with a set only if it is unconstrained.
-    if (leftType.isVariable && rightType.isTypeContainer()) {
+    if (leftType instanceof VariableType && rightType.isTypeContainer()) {
       return !(leftType.variable.canReadSubset || leftType.variable.canWriteSuperset);
     }
-    if (rightType.isVariable && leftType.isTypeContainer()) {
+    if (rightType instanceof VariableType && leftType.isTypeContainer()) {
       return !(rightType.variable.canReadSubset || rightType.variable.canWriteSuperset);
     }
 
-    if (leftType.isVariable || rightType.isVariable) {
+    if (leftType instanceof VariableType || rightType instanceof VariableType) {
       // TODO: everything should use this, eventually. Need to implement the
       // right functionality in Shapes first, though.
       return Type.canMergeConstraints(leftType, rightType);
@@ -240,19 +246,19 @@ export class TypeChecker {
       return false;
     }
 
-    if (leftType.isSlot) {
+    if (leftType instanceof SlotType) {
       return true;
     }
 
     // TODO: we need a generic way to evaluate type compatibility
     //       shapes + entities + etc
-    if (leftType.isInterface && rightType.isInterface) {
+    if (leftType instanceof InterfaceType && rightType instanceof InterfaceType) {
       if (leftType.interfaceShape.equals(rightType.interfaceShape)) {
         return true;
       }
     }
 
-    if (!leftType.isEntity || !rightType.isEntity) {
+    if (!(leftType instanceof EntityType) || !(rightType instanceof EntityType)) {
       return false;
     }
 

--- a/runtime/ts/reference.ts
+++ b/runtime/ts/reference.ts
@@ -23,11 +23,10 @@ export class Reference {
   private readonly context: ParticleExecutionContext;
   private storageProxy = null;
   protected handle = null;
-  constructor(data : {id: string, storageKey: string | null}, type, context: ParticleExecutionContext) {
+  constructor(data: {id: string, storageKey: string | null}, type: ReferenceType, context: ParticleExecutionContext) {
     this.id = data.id;
     this.storageKey = data.storageKey;
     this.context = context;
-    assert(type.isReference);
     this.type = type;
   }
 

--- a/runtime/ts/shape.ts
+++ b/runtime/ts/shape.ts
@@ -9,6 +9,7 @@
  */
 
 import {assert} from '../../platform/assert-web.js';
+import {VariableType} from './type.js';
 
 // ShapeHandle {name, direction, type}
 // Slot {name, direction, isRequired, isSet}
@@ -300,7 +301,7 @@ ${this._slotsToManifestString()}
   }
 
   static isTypeVar(reference) {
-    return (reference instanceof Type) && reference.hasProperty(r => r.isVariable);
+    return (reference instanceof Type) && reference.hasProperty(r => r instanceof VariableType);
   }
 
   static mustMatch(reference) {
@@ -321,7 +322,7 @@ ${this._slotsToManifestString()}
       return true;
     }
     const [left, right] = Type.unwrapPair(shapeHandle.type, particleHandle.type);
-    if (left.isVariable) {
+    if (left instanceof VariableType) {
       return [{var: left, value: right, direction: shapeHandle.direction}];
     } else {
       return left.equals(right);
@@ -407,7 +408,7 @@ ${this._slotsToManifestString()}
     for (const constraint of handleOptions) {
       if (!constraint.var.variable.resolution) {
         constraint.var.variable.resolution = constraint.value;
-      } else if (constraint.var.variable.resolution.isVariable) {
+      } else if (constraint.var.variable.resolution instanceof VariableType) {
         // TODO(shans): revisit how this should be done,
         // consider reusing tryMergeTypeVariablesWith(other).
         if (!TypeChecker.processTypeList(constraint.var, [{

--- a/runtime/ts/storage-proxy.ts
+++ b/runtime/ts/storage-proxy.ts
@@ -11,7 +11,7 @@
 
 import {assert} from '../../platform/assert-web.js';
 import {CrdtCollectionModel, SerializedModelEntry} from './storage/crdt-collection-model.js';
-import {Type} from './type.js';
+import {Type, CollectionType, BigCollectionType} from './type.js';
 import {PECInnerPort} from '../api-channel.js';
 import {ParticleExecutionContext} from './particle-execution-context.js';
 import {Particle} from './particle.js';
@@ -40,10 +40,10 @@ enum SyncState {none, pending, full}
  */
 export abstract class StorageProxy {
   static newProxy(id: string, type: Type, port: PECInnerPort, pec: ParticleExecutionContext, scheduler, name: string) {
-    if (type.isCollection) {
+    if (type instanceof CollectionType) {
       return new CollectionProxy(id, type, port, pec, scheduler, name);
     }
-    if (type.isBigCollection) {
+    if (type instanceof BigCollectionType) {
       return new BigCollectionProxy(id, type, port, pec, scheduler, name);
     }
     return new VariableProxy(id, type, port, pec, scheduler, name);

--- a/runtime/ts/storage/firebase-storage.ts
+++ b/runtime/ts/storage/firebase-storage.ts
@@ -19,7 +19,7 @@ import {atob} from '../../../platform/atob-web.js';
 import {btoa} from '../../../platform/btoa-web.js';
 import {CrdtCollectionModel} from './crdt-collection-model.js';
 import {Id} from '../id.js';
-import {Type} from '../type.js';
+import {Type, VariableType, CollectionType, BigCollectionType, ReferenceType} from '../type.js';
 import {setDiff} from '../util.js';
 
 export async function resetStorageForTesting(key) {
@@ -108,10 +108,10 @@ export class FirebaseStorage extends StorageBase {
   }
 
   async construct(id: string, type: Type, keyFragment: string) : Promise<FirebaseStorageProvider> {
-    let referenceMode = !type.isReference;
-    if (type.isBigCollection) {
+    let referenceMode = !(type instanceof ReferenceType);
+    if (type instanceof BigCollectionType) {
       referenceMode = false;
-    } else if (type.isTypeContainer() && type.getContainedType().isReference) {
+    } else if (type.isTypeContainer() && type.getContainedType() instanceof ReferenceType) {
       referenceMode = false;
     }
     return this._join(id, type, keyFragment, false, referenceMode);
@@ -159,8 +159,8 @@ export class FirebaseStorage extends StorageBase {
   // referenceMode is only referred to if shouldExist is false, or if shouldExist is 'unknown'
   // but this _join creates the storage location.
   async _join(id: string, type: Type, keyString: string, shouldExist: boolean | 'unknown', referenceMode = false) {
-    assert(!type.isVariable);
-    assert(!type.isTypeContainer() || !type.getContainedType().isVariable);
+    assert(!(type instanceof VariableType));
+    assert(!type.isTypeContainer() || !(type.getContainedType() instanceof VariableType));
     const fbKey = new FirebaseKey(keyString);
     // TODO: is it ever going to be possible to autoconstruct new firebase datastores?
     if (fbKey.databaseUrl == undefined || fbKey.apiKey == undefined) {
@@ -266,10 +266,10 @@ abstract class FirebaseStorageProvider extends StorageProviderBase {
   abstract backingType() : Type;
 
   static newProvider(type, storageEngine, id, reference, key, shouldExist) {
-    if (type.isCollection) {
+    if (type instanceof CollectionType) {
       return new FirebaseCollection(type, storageEngine, id, reference, key);
     }
-    if (type.isBigCollection) {
+    if (type instanceof BigCollectionType) {
       return new FirebaseBigCollection(type, storageEngine, id, reference, key);
     }
     return new FirebaseVariable(type, storageEngine, id, reference, key, shouldExist);

--- a/runtime/ts/storage/pouchdb/pouch-db-storage.ts
+++ b/runtime/ts/storage/pouchdb/pouch-db-storage.ts
@@ -10,7 +10,7 @@ import {assert} from '../../../../platform/assert-web.js';
 import {StorageBase} from '../storage-provider-base.js';
 import {PouchDbKey} from './pouch-db-key.js';
 import {Id} from '../../id.js';
-import {Type} from '../../type.js';
+import {Type, CollectionType, BigCollectionType, ReferenceType} from '../../type.js';
 import {PouchDbCollection} from './pouch-db-collection.js';
 import {PouchDbStorageProvider} from './pouch-db-storage-provider.js';
 import {PouchDbBigCollection} from './pouch-db-big-collection.js';
@@ -47,10 +47,10 @@ export class PouchDbStorage extends StorageBase {
    */
   async construct(id: string, type: Type, keyFragment: string): Promise<PouchDbStorageProvider> {
     const provider = await this._construct(id, type, keyFragment);
-    if (type.isReference) {
+    if (type instanceof ReferenceType) {
       return provider;
     }
-    if (type.isTypeContainer() && type.getContainedType().isReference) {
+    if (type.isTypeContainer() && type.getContainedType() instanceof ReferenceType) {
       return provider;
     }
     provider.enableReferenceMode();
@@ -138,10 +138,10 @@ export class PouchDbStorage extends StorageBase {
 
   /** Creates a new Variable or Collection given basic parameters */
   newProvider(type: Type, name, id, key): PouchDbStorageProvider {
-    if (type.isCollection) {
+    if (type instanceof CollectionType) {
       return new PouchDbCollection(type, this, name, id, key);
     }
-    if (type.isBigCollection) {
+    if (type instanceof BigCollectionType) {
       return new PouchDbBigCollection(type, this, name, id, key);
     }
     return new PouchDbVariable(type, this, name, id, key);

--- a/runtime/ts/storage/volatile-storage.ts
+++ b/runtime/ts/storage/volatile-storage.ts
@@ -12,7 +12,7 @@ import {StorageBase, StorageProviderBase, ChangeEvent} from './storage-provider-
 import {KeyBase} from './key-base.js';
 import {CrdtCollectionModel} from './crdt-collection-model.js';
 import {Id} from '../id.js';
-import {Type} from '../type.js';
+import {Type, CollectionType, BigCollectionType, ReferenceType} from '../type.js';
 
 export function resetVolatileStorageForTesting() {
   for (const key of Object.keys(__storageCache)) {
@@ -71,10 +71,10 @@ export class VolatileStorage extends StorageBase {
 
   async construct(id: string, type: Type, keyFragment: string) : Promise<VolatileStorageProvider> {
     const provider = await this._construct(id, type, keyFragment);
-    if (type.isReference || type.isBigCollection) {
+    if (type instanceof ReferenceType || type instanceof BigCollectionType) {
       return provider;
     }
-    if (type.isTypeContainer() && type.getContainedType().isReference) {
+    if (type.isTypeContainer() && type.getContainedType() instanceof ReferenceType) {
       return provider;
     }
     provider.enableReferenceMode();
@@ -145,10 +145,10 @@ abstract class VolatileStorageProvider extends StorageProviderBase {
   protected storageEngine: VolatileStorage;
   private pendingBackingStore: Promise<VolatileCollection>|null = null;
   static newProvider(type, storageEngine, name, id, key) {
-    if (type.isCollection) {
+    if (type instanceof CollectionType) {
       return new VolatileCollection(type, storageEngine, name, id, key);
     }
-    if (type.isBigCollection) {
+    if (type instanceof BigCollectionType) {
       return new VolatileBigCollection(type, storageEngine, name, id, key);
     }
     return new VolatileVariable(type, storageEngine, name, id, key);

--- a/runtime/ts/strategies/coalesce-recipes.ts
+++ b/runtime/ts/strategies/coalesce-recipes.ts
@@ -10,7 +10,7 @@ import {Recipe} from '../recipe/recipe.js';
 import {RecipeUtil} from '../recipe/recipe-util.js';
 import {Walker} from '../recipe/walker.js';
 import {Handle} from '../recipe/handle.js';
-import {Type} from '../type.js';
+import {VariableType} from '../type.js';
 import {assert} from '../../../platform/assert-web.js';
 import {Arc} from '../arc.js';
 
@@ -168,7 +168,7 @@ export class CoalesceRecipes extends Strategy {
             let resolved = otherHandle.type.resolvedType();
             // TODO: getContainedType returns non-null for references ... is that correct here?
             resolved = resolved.getContainedType() || resolved;
-            if (resolved.isVariable && !resolved.canReadSubset) continue;
+            if (resolved instanceof VariableType && !resolved.canReadSubset) continue;
           }
 
           if (RecipeUtil.matchesRecipe(arc.activeRecipe, otherHandle.recipe)) {

--- a/runtime/ts/strategies/find-hosted-particle.ts
+++ b/runtime/ts/strategies/find-hosted-particle.ts
@@ -21,7 +21,7 @@ export class FindHostedParticle extends Strategy {
     return Recipe.over(this.getResults(inputParams), new class extends Walker {
       onHandleConnection(recipe: Recipe, connection: HandleConnection) {
         if (connection.direction !== 'host' || connection.handle) return undefined;
-        assert(connection.type.isInterface);
+        assert(connection.type instanceof InterfaceType);
         const iface = connection.type as InterfaceType;
 
         const results = [];

--- a/runtime/ts/type-variable.ts
+++ b/runtime/ts/type-variable.ts
@@ -6,7 +6,7 @@
 // subject to an additional IP rights grant found at
 // http://polymer.github.io/PATENTS.txt
 
-import {Type, VariableType} from './type.js';
+import {Type, EntityType, VariableType, SlotType} from './type.js';
 import {assert} from '../../platform/assert-web.js';
 import {Schema} from './schema.js';
 
@@ -49,7 +49,7 @@ export class TypeVariable {
       return true;
     }
 
-    if (this.canReadSubset.isSlot && constraint.isSlot) {
+    if (this.canReadSubset instanceof SlotType && constraint instanceof SlotType) {
       // TODO: formFactor compatibility, etc.
       return true;
     }
@@ -77,7 +77,7 @@ export class TypeVariable {
       return true;
     }
 
-    if (this.canWriteSuperset.isSlot && constraint.isSlot) {
+    if (this.canWriteSuperset instanceof SlotType && constraint instanceof SlotType) {
       // TODO: formFactor compatibility, etc.
       return true;
     }
@@ -96,7 +96,7 @@ export class TypeVariable {
     if (!constraint) {
       return true;
     }
-    if (!constraint.isEntity || !type.isEntity) {
+    if (!(constraint instanceof EntityType) || !(type instanceof EntityType)) {
       throw new Error(`constraint checking not implemented for ${this} and ${type}`);
     }
     return type.getEntitySchema().isMoreSpecificThan(constraint.getEntitySchema());
@@ -112,7 +112,7 @@ export class TypeVariable {
   set resolution(value: Type) {
     assert(!this._resolution);
     const elementType = value.resolvedType().getContainedType();
-    if (elementType !== null && elementType.isVariable) {
+    if (elementType instanceof VariableType) {
       assert(elementType.variable !== this, 'variable cannot resolve to collection of itself');
     }
 

--- a/runtime/ts/type.ts
+++ b/runtime/ts/type.ts
@@ -24,18 +24,6 @@ export class Type {
     this.data = data;
   }
 
-  // TODO: replace with instanceof checks
-  get isEntity()        { return false; }
-  get isVariable()      { return false; }
-  get isCollection()    { return false; }
-  get isBigCollection() { return false; }
-  get isRelation()      { return false; }
-  get isInterface()     { return false; }
-  get isSlot()          { return false; }
-  get isReference()     { return false; }
-  get isArcInfo()       { return false; }
-  get isHandleInfo()    { return false; }
-
   // TODO: remove these; callers can directly construct the classes now
   static newEntity(entity : Schema) {
     return new EntityType(entity);
@@ -164,11 +152,11 @@ export class Type {
   }
 
   get hasVariable() {
-    return this._applyExistenceTypeTest(type => type.isVariable);
+    return this._applyExistenceTypeTest(type => type instanceof VariableType);
   }
 
   get hasUnresolvedVariable() {
-    return this._applyExistenceTypeTest(type => type.isVariable && !type.variable.isResolved());
+    return this._applyExistenceTypeTest(type => type instanceof VariableType && !type.variable.isResolved());
   }
 
   primitiveType() {
@@ -293,6 +281,7 @@ export class EntityType extends Type {
     super('Entity', schema);
   }
 
+  // These type identifier methods are being left in place for non-runtime code.
   get isEntity() {
     return true;
   }


### PR DESCRIPTION
I've left the is* methods on the type classes so non-runtime code can use them for now.