### PR TITLE
Exposes immediate mode in recipe format and unifies its store instantiation

### DIFF
--- a/runtime/test/planner-tests.js
+++ b/runtime/test/planner-tests.js
@@ -719,10 +719,9 @@ describe('Automatic resolution', function() {
     assert.equal(composedRecipes[0].toString(), `recipe
   create #items as handle0 // [Thing {}]
   create #selected as handle1 // Thing {}
-  copy '${arc.id}:particle-literal:ThingRenderer' as handle2 // HostedParticleShape
   slot 'r0' #root as slot1
   ItemMultiplexer as particle0
-    hostedParticle = handle2
+    hostedParticle = ThingRenderer
     list <- handle0
     consume item as slot0
   SelectableList as particle1
@@ -756,10 +755,9 @@ describe('Automatic resolution', function() {
     assert.equal(recipes[0].toString(), `recipe SelectableUseListRecipe
   use 'test-store' #items as handle0 // [Thing {}]
   create #selected as handle1 // Thing {}
-  copy '${arc.id}:particle-literal:ThingRenderer' as handle2 // HostedParticleShape
   slot 'r0' #root as slot1
   ItemMultiplexer as particle0
-    hostedParticle = handle2
+    hostedParticle = ThingRenderer
     list <- handle0
     consume item as slot0
   SelectableList as particle1

--- a/runtime/test/strategies/find-hosted-particle-tests.js
+++ b/runtime/test/strategies/find-hosted-particle-tests.js
@@ -58,44 +58,10 @@ describe('FindHostedParticle', function() {
     assert.lengthOf(recipe.handles, 1);
     const handle = recipe.handles[0];
     assert.equal(handle.fate, 'copy');
-    assert.isTrue(handle.id.toString().endsWith(':test-arc:particle-literal:Matches'));
+    assert.isDefined(handle.id);
     assert.isTrue(handle.type instanceof InterfaceType);
     assert.isTrue(handle.type.isResolved());
     assert.equal(handle.type.interfaceShape.name, 'HostedShape');
-  });
-  it(`reuses the handle holding particle spec`, async () => {
-    const results = await runStrategy(`
-      schema Thing
-      schema OtherThing
-
-      particle Matches
-        in Thing thingy
-
-      shape HostedShape
-        in Thing *
-
-      particle Host
-        host HostedShape hosted1
-        host HostedShape hosted2
-
-      recipe
-        Host
-    `);
-
-    assert.lengthOf(results, 1);
-    const recipe = results[0];
-    assert.isTrue(recipe.isResolved());
-
-    assert.lengthOf(recipe.handles, 1);
-    const handle = recipe.handles[0];
-    assert.equal(handle.fate, 'copy');
-    assert.isTrue(handle.id.toString().endsWith(':test-arc:particle-literal:Matches'));
-    assert.isTrue(handle.type instanceof InterfaceType);
-    assert.equal(handle.type.interfaceShape.name, 'HostedShape');
-
-    const connections = Object.values(recipe.particles[0].connections);
-    assert.lengthOf(connections, 2);
-    assert.isTrue(connections.every(hc => hc.handle === handle));
   });
   it(`respects type system constraints`, async () => {
     const results = await runStrategy(`
@@ -150,8 +116,7 @@ describe('FindHostedParticle', function() {
 
     assert.lengthOf(results, 3);
     const particleMatches = results.map(recipe => {
-      const particleSpecHandle = recipe.handles.find(h => h.fate === 'copy');
-      return particleSpecHandle.id.match(/:particle-literal:([a-zA-Z]+)$/)[1];
+      return recipe.handles.find(h => h.fate === 'copy').immediateValue.name;
     });
     particleMatches.sort();
     assert.deepEqual(particleMatches, [
@@ -201,7 +166,7 @@ describe('FindHostedParticle', function() {
     const outRecipe = results[0].result;
 
     const particleSpecHandle = outRecipe.handles.find(h => h.fate === 'copy');
-    assert(particleSpecHandle.id.endsWith(':test:particle-literal:TestParticle'));
+    assert.equal('TestParticle', particleSpecHandle.immediateValue.name);
     assert(outRecipe.isResolved());
 
     assert.isEmpty(arc._stores);

--- a/runtime/ts/plan/suggestion.ts
+++ b/runtime/ts/plan/suggestion.ts
@@ -82,42 +82,15 @@ export class Suggestion {
     }
   }
 
-  _planToString(plan): string {
-    // Special handling is only needed for plans (1) with hosted particles or
-    // (2) local slot (ie missing slot IDs).
-    if (!plan.handles.some(h => h.id && h.id.includes('particle-literal')) &&
-        plan.slots.every(slot => Boolean(slot.id))) {
+  _planToString(plan) {
+    if (plan.slots.every(slot => Boolean(slot.id))) {
       return plan.toString();
     }
 
-    // TODO: This is a transformation particle hack for plans resolved by
-    // FindHostedParticle strategy. Find a proper way to do this.
-    // Update hosted particle handles and connections.
+    // Special handling needed for plans with local slot (ie missing slot IDs).
     const planClone = plan.clone();
     planClone.slots.forEach(slot => slot.id = slot.id || `slotid-${this.arc.generateID()}`);
-
-    const hostedParticleSpecs = [];
-    for (let i = 0; i < planClone.handles.length; ++i) {
-      const handle = planClone.handles[i];
-      if (handle.id && handle.id.includes('particle-literal')) {
-        const hostedParticleName = handle.id.substr(handle.id.lastIndexOf(':') + 1);
-        // Add particle spec to the list.
-        const hostedParticleSpec = this.arc.context.findParticleByName(hostedParticleName);
-        assert(hostedParticleSpec, `Cannot find spec for particle '${hostedParticleName}'.`);
-        hostedParticleSpecs.push(hostedParticleSpec.toString());
-
-        // Override handle conenctions with particle name as local name.
-        Object.values(handle.connections).forEach(conn => {
-          assert(conn['type'] instanceof InterfaceType);
-          conn['_handle'] = {localName: hostedParticleName};
-        });
-
-        // Remove the handle.
-        planClone.handles.splice(i, 1);
-        --i;
-      }
-    }
-    return `${hostedParticleSpecs.join('\n')}\n${planClone.toString()}`;
+    return planClone.toString();
   }
 
   static async _planFromString(planString, arc, recipeResolver) {

--- a/runtime/ts/recipe/handle-connection.ts
+++ b/runtime/ts/recipe/handle-connection.ts
@@ -215,7 +215,11 @@ export class HandleConnection {
     // TODO: better deal with unspecified direction.
     result.push({'in': '<-', 'out': '->', 'inout': '=', 'host': '=', '`consume': '<-', '`provide': '->'}[this.direction] || this.direction || '=');
     if (this.handle) {
-      result.push(`${(nameMap && nameMap.get(this.handle)) || this.handle.localName}`);
+      if (this.handle.immediateValue) {
+        result.push(this.handle.immediateValue.name);
+      } else {
+        result.push(`${(nameMap && nameMap.get(this.handle)) || this.handle.localName}`);
+      }
     }
     result.push(...this.tags.map(a => `#${a}`));
 

--- a/runtime/ts/recipe/recipe-util.ts
+++ b/runtime/ts/recipe/recipe-util.ts
@@ -10,6 +10,8 @@ import {assert} from '../../../platform/assert-web.js';
 import {Particle} from './particle.js';
 import {Handle} from './handle.js';
 import {HandleConnection} from './handle-connection.js';
+import {InterfaceType} from '../type.js';
+import {ParticleSpec} from '../particle-spec.js';
 
 class Shape {
   recipe: Recipe;
@@ -141,12 +143,21 @@ export class RecipeUtil {
             continue;
           }
           // Check whether shapeHC and recipeHC reference the same handle.
-          // Note: the id of a handle with 'copy' fate changes during recipe instantiation, hence comparing to original id too.
-          // Skip the check if handles have 'create' fate (their ids are arbitrary).
-          if ((shapeHC.handle.fate !== 'create' || (recipeHC.handle.fate !== 'create' && recipeHC.handle.originalFate !== 'create')) &&
-              shapeHC.handle.id !== recipeHC.handle.id && shapeHC.handle.id !== recipeHC.handle.originalId) {
-            // this is a different handle.
-            continue;
+          if (shapeHC.handle.fate !== 'create' || (recipeHC.handle.fate !== 'create' && recipeHC.handle.originalFate !== 'create')) {
+            if (Boolean(shapeHC.handle.immediateValue) !== Boolean(recipeHC.handle.immediateValue)) {
+              continue; // One is an immediate value handle and the other is not.
+            }
+            if (recipeHC.handle.immediateValue) {
+              if (!recipeHC.handle.immediateValue.equals(shapeHC.handle.immediateValue)) {
+                continue; // Immediate values are different.
+              }
+            } else {
+              // Note: the id of a handle with 'copy' fate changes during recipe instantiation, hence comparing to original id too.
+              // Skip the check if handles have 'create' fate (their ids are arbitrary).
+              if (shapeHC.handle.id !== recipeHC.handle.id && shapeHC.handle.id !== recipeHC.handle.originalId) {
+                continue; // This is a different handle.
+              }
+            }
           }
         }
 
@@ -343,6 +354,33 @@ export class RecipeUtil {
     });
   }
 
+  static constructImmediateValueHandle(
+      connection: HandleConnection, particleSpec: ParticleSpec, id: string): Handle {
+    assert(connection.type instanceof InterfaceType);
+    
+    if (!(connection.type instanceof InterfaceType) ||
+        !connection.type.interfaceShape.restrictType(particleSpec)) {
+      // Type of the connection does not match the ParticleSpec.
+      return null;
+    }
+    
+    // The connection type may have type variables:
+    // E.g. if connection shape requires `in ~a *`
+    //      and particle has `in Entity input`
+    //      then type system has to ensure ~a is at least Entity.
+    // The type of a handle hosting the particle literal has to be
+    // concrete, so we concretize connection type with maybeEnsureResolved().
+    const handleType = connection.type.clone(new Map());
+    handleType.maybeEnsureResolved();
+
+    const handle = connection.recipe.newHandle();
+    handle.id = id;
+    handle.mappedType = handleType;
+    handle.fate = 'copy';
+    handle.immediateValue = particleSpec;
+
+    return handle;
+  }
 
   static directionCounts(handle): DirectionCounts {
     const counts: DirectionCounts = {in: 0, out: 0, inout: 0, unknown: 0};

--- a/runtime/ts/recipe/recipe.ts
+++ b/runtime/ts/recipe/recipe.ts
@@ -502,9 +502,10 @@ export class Recipe {
       }
       result.push(constraintStr);
     }
-    for (const handle of this.handles) {
-      result.push(handle.toString(nameMap, options).replace(/^|(\n)/g, '$1  '));
-    }
+    result.push(...this.handles
+        .map(h => h.toString(nameMap, options))
+        .filter(strValue => strValue)
+        .map(strValue => strValue.replace(/^|(\n)/g, '$1  ')));
     for (const slot of this.slots) {
       const slotString = slot.toString(nameMap, options);
       if (slotString) {

--- a/runtime/ts/strategies/find-hosted-particle.ts
+++ b/runtime/ts/strategies/find-hosted-particle.ts
@@ -13,6 +13,7 @@ import {Arc} from '../arc.js';
 import {assert} from '../../../platform/assert-web.js';
 import {HandleConnection} from '../recipe/handle-connection.js';
 import {InterfaceType} from '../type.js';
+import {RecipeUtil} from '../recipe/recipe-util.js';
 
 export class FindHostedParticle extends Strategy {
 
@@ -38,38 +39,9 @@ export class FindHostedParticle extends Strategy {
           if (!shapeClone.canEnsureResolved()) continue;
 
           results.push((recipe, hc) => {
-            // Restricting the type of the connection to the concrete particle
-            // may restrict type variable across the recipe.
-            hc.type.interfaceShape.restrictType(particle);
-
-            // The connection type may still have type variables:
-            // E.g. if shape requires `in ~a *`
-            //      and particle has `in Entity input`
-            //      then type system has to ensure ~a is at least Entity.
-            // The type of a handle hosting the particle literal has to be
-            // concrete, so we concretize connection type with maybeEnsureResolved().
-            const handleType = hc.type.clone(new Map());
-            handleType.maybeEnsureResolved();
-
-            const id = `${arc.id}:particle-literal:${particle.name}`;
-
-            // Reuse a handle if we already hold this particle spec in the recipe.
-            for (const handle of recipe.handles) {
-              if (handle.id === id && handle.fate === 'copy'
-                  && handle._mappedType && handle._mappedType.equals(handleType)) {
-                hc.connectToHandle(handle);
-                return undefined;
-              }
-            }
-
-            // TODO: Add a digest of a particle literal to the ID, so that we
-            //       can ensure we load the correct particle. It is currently
-            //       hard as digest is asynchronous and recipe walker is
-            //       synchronous.
-            const handle = recipe.newHandle();
-            handle._mappedType = handleType;
-            handle.fate = 'copy';
-            handle.id = id;
+            const handle = RecipeUtil.constructImmediateValueHandle(
+              hc, particle, arc.generateID());
+            assert(handle); // Type matching should have been ensure by the checks above;
             hc.connectToHandle(handle);
           });
         }


### PR DESCRIPTION
Introduce `immediateValue` for a recipe handle and uses it for the immediate particle reference.

Design + rationale: https://docs.google.com/document/d/1MvfyJygCv6yc-pegajp1SHDj0e6I2woij04pDxEwFV0/edit#

Some changes:
* Unifies handling of immediate mode in the manifest and in strategies.
* Ensures backing handles are volatile and not serialized.
* Cleans up special handling in the suggestion serialization.

Should fix #2105 and #2274 if we understand them correctly. 