### PR TITLE
Refactor server for better background processing abstraction

### DIFF
--- a/server/src/app-base.ts
+++ b/server/src/app-base.ts
@@ -47,6 +47,15 @@ export abstract class AppBase {
   }
 
   /**
+   * Override this method to execute code after the server starts listening.
+   * Used to run background processes like Shell Planning.
+   */
+  public startBackgroundProcessing(): void {
+    // optional method that starts background processing.
+    console.log("Running optional background process");
+  }
+
+  /**
    * Adds handlers for static content.  The public directory is
    * checked first.  If not found then the legacy arcs directory is searched.
    */
@@ -56,8 +65,6 @@ export abstract class AppBase {
     // see https://github.com/pouchdb/pouchdb-fauxton/issues/18
     this.express.use(express.static('node_modules/arcs'));
   }
-
-
 
   /**
    * Endpoints that end up mapped under /arcs are defined here.

--- a/server/src/arcs-master-app.ts
+++ b/server/src/arcs-master-app.ts
@@ -6,7 +6,7 @@
 // subject to an additional IP rights grant found at
 // http://polymer.github.io/PATENTS.txt
 
-import {AppBase} from "./app";
+import {AppBase} from "./app-base";
 import {CloudManager} from "./deployment/cloud";
 import {Container, DeploymentStatus} from "./deployment/containers";
 import express from "express";
@@ -194,4 +194,4 @@ class ArcsMasterApp extends AppBase {
   }
 }
 
-export const app = new ArcsMasterApp().express;
+export const app = new ArcsMasterApp();

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -11,8 +11,9 @@ import http from 'http';
 
 import {app as dbapp} from './pouch-db-app';
 import {app as masterapp} from './arcs-master-app';
+import {AppBase} from './app-base';
 
-const app = process.env.ARCS_MASTER ? masterapp : dbapp;
+const app: AppBase = process.env.ARCS_MASTER ? masterapp : dbapp;
 
 /**
  * Basic code that sets up and configures a Arcs Cloud Instance.
@@ -21,9 +22,9 @@ const app = process.env.ARCS_MASTER ? masterapp : dbapp;
 debug('ts-express:server');
 
 const port = normalizePort(process.env.PORT || 8080);
-app.set('port', port);
+app.express.set('port', port);
 
-const server = http.createServer(app);
+const server = http.createServer(app.express);
 server.listen(port);
 server.on('error', onError);
 server.on('listening', onListening);
@@ -61,4 +62,7 @@ function onListening(): void {
   const bind = typeof addr === 'string' ? `pipe ${addr}` : `port ${addr.port}`;
   debug(`Listening on ${bind}`);
   console.log(`Arcs Server listening on ${bind}`);
+  setTimeout(() => {
+    app.startBackgroundProcessing();
+  });
 }

--- a/server/test/server.test.ts
+++ b/server/test/server.test.ts
@@ -17,7 +17,7 @@ chai.use(chaiHttp);
 describe('baseRoute', () => {
   it.skip('/ should be static html', () => {
     return chai
-      .request(app)
+      .request(app.express)
       .get('/')
       .then(res => {
         expect(res.type).to.eql('text/html');
@@ -26,7 +26,7 @@ describe('baseRoute', () => {
 
   it.skip('/ should have a welcome message', () => {
     return chai
-      .request(app)
+      .request(app.express)
       .get('/')
       .then(res => {
         expect(res.text).to.include('Welcome to Arcs');
@@ -35,7 +35,7 @@ describe('baseRoute', () => {
 
   it('/shell/apps/web/index.html should be static html', () => {
     return chai
-      .request(app)
+      .request(app.express)
       .get('/shell/apps/web/index.html')
       .then(res => {
         expect(res.type).to.eql('text/html');
@@ -44,7 +44,7 @@ describe('baseRoute', () => {
 
   it('/arcs/manifest should return id and text', () => {
     return chai
-      .request(app)
+      .request(app.express)
       .get('/arcs/manifest')
       .then(res => {
         expect(res.body.id).to.equal('manifest:undefined:');


### PR DESCRIPTION
- Move AppBase to app-base.ts for consistency
- Create a new lifecycle method on AppBase for background processing
- Return AppBase to top level controller instead of express object.
- Call background processing in the onListening callback