### PR TITLE
Default to `debug=true` planificator, if using volatile storage.

### DIFF
--- a/runtime/ts/plan/planificator.ts
+++ b/runtime/ts/plan/planificator.ts
@@ -21,6 +21,7 @@ import {Type} from '../type.js';
 
 export class Planificator {
   static async create(arc: Arc, {userid, protocol, onlyConsumer, debug = false}) {
+    debug = debug || (protocol === 'volatile');
     const store = await Planificator._initSuggestStore(arc, {userid, protocol, arcKey: null});
     const searchStore = await Planificator._initSearchStore(arc, {userid});
     const planificator = new Planificator(arc, userid, store, searchStore, onlyConsumer, debug);


### PR DESCRIPTION
I'm not sure - probably cleaner to keep this in shell, but easier to use this way. WDYT?
addresses some of: https://github.com/PolymerLabs/arcs/issues/2305