### PR TITLE
Convert suggest-dom-consumer to typescript

### DIFF
--- a/runtime/ts/modality.ts
+++ b/runtime/ts/modality.ts
@@ -9,7 +9,7 @@
  */
 import {assert} from '../../platform/assert-web.js';
 import {SlotDomConsumer} from './slot-dom-consumer.js';
-import {SuggestDomConsumer} from '../suggest-dom-consumer.js';
+import {SuggestDomConsumer} from './suggest-dom-consumer.js';
 import {MockSlotDomConsumer} from '../testing/mock-slot-dom-consumer.js';
 import {MockSuggestDomConsumer} from '../testing/mock-suggest-dom-consumer.js';
 import {DescriptionDomFormatter} from './description-dom-formatter.js';

--- a/runtime/ts/slot-consumer.ts
+++ b/runtime/ts/slot-consumer.ts
@@ -9,30 +9,35 @@
  */
 
 import {assert} from '../../platform/assert-web.js';
+import {Arc} from './arc.js';
 import {SlotContext} from './slot-context.js';
 import {SlotConnection} from './recipe/slot-connection.js';
 import {HostedSlotConsumer} from './hosted-slot-consumer.js';
 
 export class SlotConsumer {
-  _consumeConn: SlotConnection;
+  _consumeConn?: SlotConnection;
   slotContext: SlotContext;
   providedSlotContexts: SlotContext[] = [];
   startRenderCallback: ({}) => void;
   stopRenderCallback: ({}) => void;
   eventHandler: ({}) => void;
-  readonly containerKind: string;
+  readonly containerKind?: string;
   // Contains `container` and other modality specific rendering information
   // (eg for `dom`: model, template for dom renderer) by sub id. Key is `undefined` for singleton slot.
-  private _renderingBySubId: Map<string, {container?: {}}> = new Map();
+  private _renderingBySubId: Map<string|undefined, {container?: {}}> = new Map();
   private innerContainerBySlotId: {} = {};
 
-  constructor(consumeConn, containerKind) {
+  constructor(consumeConn?: SlotConnection, containerKind?: string) {
     this._consumeConn = consumeConn;
     this.containerKind = containerKind;
   }
   get consumeConn() { return this._consumeConn; }
+
   getRendering(subId) { return this._renderingBySubId.get(subId); } 
   get renderings() { return [...this._renderingBySubId.entries()]; }
+  addRenderingBySubId(subId: string|undefined, rendering) {
+    this._renderingBySubId.set(subId, rendering);
+  }
 
   onContainerUpdate(newContainer, originalContainer) {
     if (Boolean(newContainer) !== Boolean(originalContainer)) {
@@ -101,7 +106,7 @@ export class SlotConsumer {
     }
   }
 
-  async setContent(content, handler, arc) {
+  async setContent(content, handler, arc?: Arc) {
     if (content && Object.keys(content).length > 0) {
       if (arc) {
         content.descriptions = await this.populateHandleDescriptions(arc);

--- a/runtime/ts/slot-dom-consumer.ts
+++ b/runtime/ts/slot-dom-consumer.ts
@@ -12,13 +12,14 @@ import {assert} from '../../platform/assert-web.js';
 import {SlotConsumer} from './slot-consumer.js';
 import Template from '../../shell/components/xen/xen-template.js';
 import IconStyles from '../../shell/components/icons.css.js';
+import {SlotConnection} from './recipe/slot-connection.js';
 
 const templateByName = new Map();
 
 export class SlotDomConsumer extends SlotConsumer {
   private readonly _observer: MutationObserver;
 
-  constructor(consumeConn, containerKind) {
+  constructor(consumeConn?: SlotConnection, containerKind?: string) {
     super(consumeConn, containerKind);
 
     this._observer = this._initMutationObserver();

--- a/runtime/ts/suggest-dom-consumer.ts
+++ b/runtime/ts/suggest-dom-consumer.ts
@@ -7,32 +7,40 @@
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
-'use strict';
 
-import {assert} from '../platform/assert-web.js';
-import {SlotDomConsumer} from './ts-build/slot-dom-consumer.js';
+import {assert} from '../../platform/assert-web.js';
+import {SlotDomConsumer} from './slot-dom-consumer.js';
+import {Suggestion} from './plan/suggestion.js';
 
 export class SuggestDomConsumer extends SlotDomConsumer {
-  constructor(containerKind, suggestion, suggestionContent, eventHandler) {
+  _suggestion: Suggestion;
+  _suggestionContent;
+  _eventHandler;
+
+  constructor(containerKind: string, suggestion: Suggestion, suggestionContent, eventHandler) {
     super(/* consumeConn= */null, containerKind);
     this._suggestion = suggestion;
     this._suggestionContent = suggestionContent;
     this._eventHandler = eventHandler;
   }
 
-  get suggestion() { return this._suggestion; }
+  get suggestion(): Suggestion {
+    return this._suggestion;
+  }
 
-  get templatePrefix() { return 'suggest'; }
+  get templatePrefix(): string {
+    return 'suggest';
+  }
 
   formatContent(content) {
     return {
       template: `<suggestion-element inline key="{{hash}}" on-click="">${content.template}</suggestion-element>`,
       templateName: 'suggestion',
-      model: Object.assign({hash: this.suggestion.hash}, content.model)
+      model: {hash: this.suggestion.hash, ...content.model}
     };
   }
 
-  onContainerUpdate(container, originalContainer) {
+  onContainerUpdate(container, originalContainer): void {
     super.onContainerUpdate(container, originalContainer);
 
     if (container) {
@@ -40,13 +48,13 @@ export class SuggestDomConsumer extends SlotDomConsumer {
     }
   }
 
-  static render(container, plan, content) {
-    const consumer = new SlotDomConsumer();
+  static render(container, plan, content): SlotDomConsumer {
     const suggestionContainer = Object.assign(document.createElement('suggestion-element'), {plan});
     container.appendChild(suggestionContainer, container.firstElementChild);
     const rendering = {container: suggestionContainer, model: content.model};
-    consumer._renderingBySubId.set(undefined, rendering);
-    consumer._eventHandler = (() => {});
+    const consumer = new SlotDomConsumer();
+    consumer.addRenderingBySubId(undefined, rendering);
+    consumer.eventHandler = (() => {});
     consumer._stampTemplate(rendering, consumer.createTemplateElement(content.template));
     consumer._onUpdate(rendering);
     return consumer;

--- a/runtime/ts/suggestion-composer.ts
+++ b/runtime/ts/suggestion-composer.ts
@@ -9,8 +9,8 @@
  */
 import {Modality} from './modality.js';
 import {SlotComposer} from './slot-composer.js';
-import {Suggestion} from './plan/suggestion';
-import {SuggestDomConsumer} from '../suggest-dom-consumer.js';
+import {Suggestion} from './plan/suggestion.js';
+import {SuggestDomConsumer} from './suggest-dom-consumer.js';
 
 export class SuggestionComposer {
   private _modality: Modality;
@@ -18,7 +18,7 @@ export class SuggestionComposer {
 
   private readonly _slotComposer: SlotComposer;
   private _suggestions: Suggestion[] = []; 
-  private _suggestConsumers: SuggestDomConsumer = [];
+  private _suggestConsumers: SuggestDomConsumer[] = [];
   
   constructor(slotComposer: SlotComposer) {
     this._modality = Modality.forName(slotComposer.modality);


### PR DESCRIPTION
- Adjust SlotConsumer to take optional arguments in places.
- Use spread instead of Object.assign
- introduce addRenderingBySubId to avoid exposing private instance variables
- Fix incorrect typing in suggestion-composer

Addresses #1765 