### PR TITLE
Fixes to session handling in Ids and Id handling in the Manifest.

### DIFF
--- a/runtime/test/id-test.js
+++ b/runtime/test/id-test.js
@@ -1,0 +1,33 @@
+/**
+ * @license
+ * Copyright (c) 2018 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {Id} from '../ts-build/id.js';
+import {Random} from '../ts-build/random.js';
+import {assert} from '../../platform/assert-web.js';
+
+describe('Id', function() {
+  it('parses id from string representation', async () => {
+    Random.seedForTests();
+
+    const initialId = Id.newSessionId().fromString('test');
+
+    assert.equal('!158405822139616:test', initialId.toString(),
+        'Both Session ID and the component should be part of the serialized ID');
+    assert.equal('!158405822139616:test:0', initialId.createId().toString(),
+        'Session ID should remain the same in the newly created sub-ID');
+
+    const deserializedInNewSession = Id.newSessionId().fromString(initialId.toString());
+    
+    assert.equal('!158405822139616:test', deserializedInNewSession.toString(),
+        'Original session ID should be present in the serialized form of a deserialized ID');
+    assert.equal('!130690574120708:test:0', deserializedInNewSession.createId().toString(),
+        'Sub-ID created inside a new session should be serialized with a new Session ID');
+  });
+});

--- a/runtime/test/manifest-test.js
+++ b/runtime/test/manifest-test.js
@@ -1072,7 +1072,7 @@ ${particleStr1}
     assert(store);
     assert.deepEqual(await store.toList(), [
       {
-        id: 'manifest:the.manifest::0',
+        id: '!manifest:the.manifest::0',
         rawData: {someProp: 'someValue'},
       }, {
         id: 'entity-id',
@@ -1114,7 +1114,7 @@ Error parsing JSON from 'EntityList' (Unexpected token h in JSON at position 1)'
     assert(store);
     assert.deepEqual(await store.toList(), [
       {
-        id: 'manifest:the.manifest::0',
+        id: '!manifest:the.manifest::0',
         rawData: {someProp: 'someValue'},
       }, {
         id: 'entity-id',
@@ -1145,7 +1145,7 @@ Error parsing JSON from 'EntityList' (Unexpected token h in JSON at position 1)'
     };
     const manifest = await Manifest.load('the.manifest', loader);
     const recipe = manifest.recipes[0];
-    assert.deepEqual(recipe.toString(), 'recipe\n  map \'manifest:the.manifest:store0:97d170e1550eee4afc0af065b78cda302a97674c\' as myStore');
+    assert.deepEqual(recipe.toString(), 'recipe\n  map \'!manifest:the.manifest:store0:97d170e1550eee4afc0af065b78cda302a97674c\' as myStore');
   });
   it('has prettyish syntax errors', async () => {
     try {

--- a/runtime/ts/id.ts
+++ b/runtime/ts/id.ts
@@ -11,7 +11,11 @@
 import {Random} from './random.js';
 
 export class Id {
-  private readonly session: string;
+  // Session at which a logical object (e.g. an Arc) got created.
+  // Part of the stable, permanent ID of this object.
+  private session: string;
+  // Current session. E.g. In which an Arc got deserialized and inflated.
+  // This is used to spawn new ids based on this instance.
   private readonly currentSession: string;
   private nextIdComponent = 0;
   private readonly components: string[] = [];
@@ -27,15 +31,23 @@ export class Id {
     return new Id(session);
   }
 
+  /**
+   * When used in the following way:
+   *   const id = Id.newSessionId().fromString(stringId);
+   * 
+   * The resulting id will receive a newly generated session id in the currentSession field,
+   * while maintaining an original session from the string representation in the session field.
+   */
   fromString(str: string): Id {
-    let components = str.split(':');
-    let session = this.currentSession;
+    const newId = new Id(this.currentSession);
 
+    let components = str.split(':');
     if (components[0][0] === '!') {
-      session = components[0].slice(1);
+      newId.session = components[0].slice(1);
       components = components.slice(1);
     }
-    return new Id(session, components);
+    newId.components.push(...components);
+    return newId;
   }
 
   toString(): string {

--- a/server/src/app-base.ts
+++ b/server/src/app-base.ts
@@ -86,8 +86,8 @@ export abstract class AppBase {
         text -> handleA`;
 
       try {
-        const manifest = await Runtime.parseManifest(content, {});
-        res.json({ id: manifest.id, text: manifest.toString() });
+        const manifest = await Runtime.parseManifest(content, {fileName: 'manifest'});
+        res.json({ id: manifest.id.toString(), text: manifest.toString() });
       } catch (err) {
         next(err);
       }

--- a/server/test/server.test.ts
+++ b/server/test/server.test.ts
@@ -47,7 +47,7 @@ describe('baseRoute', () => {
       .request(app.express)
       .get('/arcs/manifest')
       .then(res => {
-        expect(res.body.id).to.equal('manifest:undefined:');
+        expect(res.body.id).to.equal('!manifest:manifest:');
         expect(res.body.text).to.include('schema Text');
       });
   });


### PR DESCRIPTION
Fixes #2313 - where newly generated session ID have been overwritten by the parsed session, causing ID collisions.

Big TODO Tech Debt Item: Unify ID usage to Id class.