### PR TITLE
Uses Mersenne Twister PRNG in tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6568,6 +6568,12 @@
         }
       }
     },
+    "mersenne-twister": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/mersenne-twister/-/mersenne-twister-1.1.0.tgz",
+      "integrity": "sha1-+RZhjuQ9cXnvz2Qb7EUx65Zwl4o=",
+      "dev": true
+    },
     "micromatch": {
       "version": "3.1.10",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "eslint-config-google": "^0.11.0",
     "grammkit": "0.6.2",
     "http-server": "^0.11.1",
+    "mersenne-twister": "^1.1.0",
     "minimist": "^1.2.0",
     "mocha": "^5.2.0",
     "mocha-chrome": "^1.1.0",

--- a/runtime/test/debug/outer-port-attachments-tests.js
+++ b/runtime/test/debug/outer-port-attachments-tests.js
@@ -57,8 +57,8 @@ describe('OuterPortAttachment', function() {
 
     assert.deepEqual(instantiateParticleCall.pecMsgBody, {
       // IDs are stable thanks to Random.seedForTests().
-      id: '!158405822139616:demo:particle1',
-      identifier: '!158405822139616:demo:particle1',
+      id: '!85915497922560:demo:particle1',
+      identifier: '!85915497922560:demo:particle1',
       handles: {
         foo: 'fooStore'
       },

--- a/runtime/test/id-test.js
+++ b/runtime/test/id-test.js
@@ -18,16 +18,16 @@ describe('Id', function() {
 
     const initialId = Id.newSessionId().fromString('test');
 
-    assert.equal('!158405822139616:test', initialId.toString(),
+    assert.equal('!85915497922560:test', initialId.toString(),
         'Both Session ID and the component should be part of the serialized ID');
-    assert.equal('!158405822139616:test:0', initialId.createId().toString(),
+    assert.equal('!85915497922560:test:0', initialId.createId().toString(),
         'Session ID should remain the same in the newly created sub-ID');
 
     const deserializedInNewSession = Id.newSessionId().fromString(initialId.toString());
     
-    assert.equal('!158405822139616:test', deserializedInNewSession.toString(),
+    assert.equal('!85915497922560:test', deserializedInNewSession.toString(),
         'Original session ID should be present in the serialized form of a deserialized ID');
-    assert.equal('!130690574120708:test:0', deserializedInNewSession.createId().toString(),
+    assert.equal('!255961043304448:test:0', deserializedInNewSession.createId().toString(),
         'Sub-ID created inside a new session should be serialized with a new Session ID');
   });
 });

--- a/runtime/ts/random.ts
+++ b/runtime/ts/random.ts
@@ -8,6 +8,8 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
+import MersenneTwister from 'mersenne-twister';
+
 abstract class RNG {
   abstract next() : number;
 }
@@ -25,10 +27,9 @@ class MathRandomRNG extends RNG {
  * Provides a deterministic Random Number Generator for Tests
  */
 class SeededRNG extends RNG {
-  private seed = 0;
+  private generator = new MersenneTwister(7);
   next(): number {
-    this.seed = Math.pow(this.seed + Math.E, Math.PI) % 1;
-    return this.seed;
+    return this.generator.random();
   }
 }
 


### PR DESCRIPTION
Fixes the problem with different OSes using different precessions (64 vs 80 bits) for calculating our seeded random for tests, causing different values on AppVeyor vs Travis.