### PR TITLE
fix hardcoded arcs-project project-id in cloud setup

### DIFF
--- a/server/deployment/environment.sh
+++ b/server/deployment/environment.sh
@@ -1,8 +1,8 @@
 
-export PROJECT_ID=arcs-project
+export PROJECT_ID=arcs-project-223901
 export COMPUTE_ZONE=us-central1-a
 export CLUSTER_NAME=personal-cloud
-export BUILD_LABEL=gcr.io/arcs-project/deployment:latest
+export BUILD_LABEL=gcr.io/${PROJECT_ID}/deployment:latest
 export SERVICE_ACCOUNT=arcs-sa@${PROJECT_ID}.iam.gserviceaccount.com
 export DNS_ZONE=skarabrae.org
 export DNS_ZONE_NAME=skarabrae

--- a/server/deployment/setup_helm.sh
+++ b/server/deployment/setup_helm.sh
@@ -6,6 +6,7 @@ source ./configure_helm_permissions.sh
 echo "Initialing Helm"
 helm init --wait  --service-account tiller 
 helm repo update
+helm dep build ./arcs
 
 # Needed by external-dns
 kubectl create clusterrolebinding default-admin --clusterrole cluster-admin --serviceaccount=default:default
@@ -18,10 +19,10 @@ gcloud iam service-accounts create prod-clouddns-svc-acct-secret \
   --project=${PROJECT_ID}
 
 gcloud iam service-accounts keys create ./prod-clouddns-service-account.json \
---iam-account=prod-clouddns-svc-acct-secret@arcs-project.iam.gserviceaccount.com \
+--iam-account=prod-clouddns-svc-acct-secret@${PROJECT_ID}.iam.gserviceaccount.com \
 --project=${PROJECT_ID}
 
-gcloud projects add-iam-policy-binding arcs-project \
+gcloud projects add-iam-policy-binding ${PROJECT_ID} \
 --member=serviceAccount:prod-clouddns-svc-acct-secret@${PROJECT_ID}.iam.gserviceaccount.com \
 --role=roles/dns.admin
 
@@ -31,7 +32,7 @@ kubectl create secret generic prod-clouddns-svc-acct-secret \
 helm install ./arcs \
   --set domain=${DNS_ZONE} \
   --set arcs=${SERVICE_ACCOUNT} \
-  --set project=${PROJECT_ID}
-
+  --set project=${PROJECT_ID} \
+  --set image.repository=gcr.io/${PROJECT_ID}/deployment
 
 


### PR DESCRIPTION
After setting up the cloud cluster again, with a different project-id on GCP, I noticed 'arcs-project' was hardcoded in a few places.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/polymerlabs/arcs/2334)
<!-- Reviewable:end -->
