### PR TITLE
add relevance to suggestions

### DIFF
--- a/runtime/test/manifest-integration-test.js
+++ b/runtime/test/manifest-integration-test.js
@@ -45,7 +45,8 @@ describe('manifest integration', () => {
   });
   it('can produce a recipe that can be speculated', async () => {
     const {arc, recipe} = await setup();
-    const relevance = await new Speculator().speculate(arc, recipe);
-    assert.equal(relevance.calcRelevanceScore(), 1);
+    const hash = ((hash) => hash.substring(hash.length - 4))(await recipe.digest());
+    const suggestion = await new Speculator().speculate(arc, recipe, hash);
+    assert.equal(suggestion.rank, 1);
   });
 });

--- a/runtime/test/plan/plan-consumer-test.js
+++ b/runtime/test/plan/plan-consumer-test.js
@@ -13,6 +13,7 @@ import {TestHelper} from '../../testing/test-helper.js';
 import {PlanConsumer} from '../../ts-build/plan/plan-consumer.js';
 import {Planificator} from '../../ts-build/plan/planificator.js';
 import {PlanningResult} from '../../ts-build/plan/planning-result.js';
+import {Relevance} from '../../ts-build/relevance.js';
 
 
 // Run test suite for each storageKeyBase
@@ -56,6 +57,7 @@ recipe
       assert.isEmpty(consumer.getCurrentSuggestions());
 
       const storeResults = async (suggestions) => {
+        suggestions.forEach(s => s.relevance = Relevance.create(helper.arc, s.plan));
         const result = new PlanningResult(helper.arc);
         result.set({suggestions});
         await store.set(result.serialize());

--- a/runtime/test/plan/plan-producer-test.js
+++ b/runtime/test/plan/plan-producer-test.js
@@ -12,6 +12,7 @@ import {Recipe} from '../../ts-build/recipe/recipe.js';
 import {TestHelper} from '../../testing/test-helper.js';
 import {PlanProducer} from '../../ts-build/plan/plan-producer.js';
 import {Planificator} from '../../ts-build/plan/planificator.js';
+import {Relevance} from '../../ts-build/relevance.js';
 import {Suggestion} from '../../ts-build/plan/suggestion.js';
 
 class TestPlanProducer extends PlanProducer {
@@ -67,7 +68,10 @@ class TestPlanProducer extends PlanProducer {
         plan.newSlot('slot0').id = 'id0';
       }
       plan.normalize();
-      const suggestion = new Suggestion(plan, info.hash, info.rank || 0, this.arc);
+      const relevance = Relevance.create(this.arc, plan);
+      relevance.apply(new Map([[plan.particles[0], [info.rank || 0]]]));
+      const suggestion = new Suggestion(plan, info.hash, relevance, this.arc);
+      suggestion.relevance = Relevance.create(this.arc, plan);
       suggestions.push(suggestion);
     });
     this.plannerReturnResults(suggestions);

--- a/runtime/test/plan/suggestion-test.js
+++ b/runtime/test/plan/suggestion-test.js
@@ -11,10 +11,15 @@ import {assert} from '../chai-web.js';
 import {TestHelper} from '../../testing/test-helper.js';
 import {Suggestion} from '../../ts-build/plan/suggestion.js';
 import {Search} from '../../ts-build/recipe/search.js';
+import {Relevance} from '../../ts-build/relevance.js';
 
 describe('suggestion', function() {
   function createSuggestion(hash, descriptionText) {
-    const suggestion = new Suggestion(/* plan= */ {}, hash, /* rank= */ 1, /* arc= */ {});
+    const suggestion = new Suggestion(
+      /* plan= */ {},
+      hash,
+      Relevance.deserialize({versionByStore: '{}', relevanceMap: new Map()}),
+      /* arc= */ {});
     suggestion.descriptionByModality['text'] = descriptionText;
     return suggestion;
   }

--- a/runtime/test/speculator-tests.js
+++ b/runtime/test/speculator-tests.js
@@ -21,8 +21,9 @@ describe('speculator', function() {
     const manifest = await Manifest.load('./runtime/test/artifacts/test.manifest', loader);
     const recipe = manifest.recipes[0];
     assert(recipe.normalize());
+    const hash = ((hash) => hash.substring(hash.length - 4))(await recipe.digest());
     const speculator = new Speculator();
-    const relevance = await speculator.speculate(arc, recipe);
-    assert.equal(relevance.calcRelevanceScore(), 1);
+    const suggestion = await speculator.speculate(arc, recipe, hash);
+    assert.equal(suggestion.rank, 1);
   });
 });

--- a/runtime/ts/arc.ts
+++ b/runtime/ts/arc.ts
@@ -40,7 +40,7 @@ type ArcOptions = {
   recipeIndex?: RecipeIndex;
 };
 
-type PlanCallback = (recipe: Recipe) => void;
+export type PlanCallback = (recipe: Recipe) => void;
 
 type SerializeContext = {handles: string, resources: string, interfaces: string, dataResources: Map<string, string>};
 
@@ -693,11 +693,13 @@ ${this.activeRecipe.toString()}`;
     return this.storeDescriptions.get(store) || store.description;
   }
 
-  getStoresState(options) {
-    const versionById = new Map();
-    this.storesById.forEach((handle, id) => versionById.set(id, handle.version));
-    if ((options || {}).includeContext) {
-      this._context.allStores.forEach(handle => versionById.set(handle.id, handle.version));
+  getVersionByStore({includeArc=true, includeContext=false}) {
+    const versionById = {};
+    if (includeArc) {
+      this.storesById.forEach((handle, id) => versionById[id] = handle.version);
+    }
+    if (includeContext) {
+      this._context.allStores.forEach(handle => versionById[handle.id] = handle.version);
     }
     return versionById;
   }

--- a/runtime/ts/plan/plan-producer.ts
+++ b/runtime/ts/plan/plan-producer.ts
@@ -17,7 +17,7 @@ import {Planner} from '../planner.js';
 import {PlanningResult} from './planning-result.js';
 import {Speculator} from '../speculator.js';
 import {StorageProviderBase} from '../storage/storage-provider-base.js';
-import {Strategy, StrategyDerived} from '../strategizer/strategizer';
+import {Strategy, StrategyDerived} from '../strategizer/strategizer.js';
 
 const defaultTimeoutMs = 5000;
 
@@ -45,7 +45,7 @@ export class PlanProducer {
     this.arc = arc;
     this.result = new PlanningResult(arc);
     this.store = store;
-    this.speculator = new Speculator();
+    this.speculator = new Speculator(this.result);
     this.searchStore = searchStore;
     if (this.searchStore) {
       this.searchStoreCallback = () => this.onSearchChanged();
@@ -91,7 +91,6 @@ export class PlanProducer {
       strategies?: StrategyDerived[],
       append?: boolean,
       contextual?: boolean} = {
-
         cancelOngoingPlanning: this.result.suggestions.length > 0,
         search: this.search
       };
@@ -175,9 +174,9 @@ export class PlanProducer {
 
   private _cancelPlanning() {
     if (this.planner) {
-      this.planner.dispose();
       this.planner = null;
     }
+    this.speculator.dispose();
     this.needReplan = false;
     this.isPlanning = false; // using the setter method to trigger callbacks.
     log(`Cancel planning`);

--- a/runtime/ts/plan/planning-result.ts
+++ b/runtime/ts/plan/planning-result.ts
@@ -9,10 +9,10 @@
  */
 
 import {assert} from '../../../platform/assert-web.js';
-import {Arc} from '../arc';
+import {Arc} from '../arc.js';
 import {now} from '../../../platform/date-web.js';
-import {RecipeResolver} from '../recipe/recipe-resolver';
-import {Suggestion} from './suggestion';
+import {RecipeResolver} from '../recipe/recipe-resolver.js';
+import {Suggestion} from './suggestion.js';
 
 export class PlanningResult {
   arc: Arc;
@@ -160,7 +160,7 @@ export class PlanningResult {
     });
   }
 
-  serialize() {
+  serialize(): {} {
     return {
       suggestions: this.suggestions.map(suggestion => suggestion.serialize()),
       generations: JSON.stringify(this.generations),

--- a/runtime/ts/plan/replan-queue.ts
+++ b/runtime/ts/plan/replan-queue.ts
@@ -11,7 +11,7 @@
 
 import {assert} from '../../../platform/assert-web.js';
 import {now} from '../../../platform/date-web.js';
-import {PlanProducer} from './plan-producer';
+import {PlanProducer} from './plan-producer.js';
 
 const defaultDefaultReplanDelayMs = 3000;
 
@@ -62,7 +62,7 @@ export class ReplanQueue {
   private _scheduleReplan(intervalMs) {
     this._cancelReplanIfScheduled();
     this.replanTimer = setTimeout(
-        () => this.planProducer.produceSuggestions({contextual: this.planProducer.result.contextual},),
+        () => this.planProducer.produceSuggestions({contextual: this.planProducer.result.contextual}),
         intervalMs);
   }
 

--- a/runtime/ts/plan/suggestion.ts
+++ b/runtime/ts/plan/suggestion.ts
@@ -38,12 +38,13 @@ export class Suggestion {
   // List of search resolved token groups, this suggestion corresponds to.
   searchGroups: string[][] = [];
 
-  constructor(plan: Recipe, hash: string, rank: number, arc: Arc) {
+  constructor(plan: Recipe, hash: string, relevance: Relevance, arc: Arc) {
     assert(plan, `plan cannot be null`);
     assert(hash, `hash cannot be null`);
     this.plan = plan;
     this.hash = hash;
-    this.rank = rank;
+    this.rank = relevance.calcRelevanceScore();
+    this.relevance = relevance;
     this.arc = arc;
   }
 
@@ -116,15 +117,16 @@ export class Suggestion {
       plan: this._planToString(this.plan),
       hash: this.hash,
       rank: this.rank,
+      relevance: this.relevance.serialize(),
       searchGroups: this.searchGroups,
       descriptionByModality: this.descriptionByModality
     };
   }
 
-  static async deserialize({plan, hash, rank, searchGroups, descriptionByModality}, arc, recipeResolver): Promise<Suggestion> {
+  static async deserialize({plan, hash, relevance, searchGroups, descriptionByModality}, arc, recipeResolver): Promise<Suggestion> {
     const deserializedPlan = await Suggestion._planFromString(plan, arc, recipeResolver);
     if (deserializedPlan) {
-      const suggestion = new Suggestion(deserializedPlan, hash, rank, arc);
+      const suggestion = new Suggestion(deserializedPlan, hash, Relevance.deserialize(relevance, deserializedPlan), arc);
       suggestion.searchGroups = searchGroups;
       suggestion.descriptionByModality = descriptionByModality;
       return suggestion;


### PR DESCRIPTION
- relevance object de/serialized as part of Suggestion
- Relevance objects of previously generated suggestions reused to skip speculative execution, if the stores haven't changed
- speculative arcs are now encapsulated in speculator (decoupled from Relevance and not exposed to planner)