### PR TITLE
Puts slot name -> ID mapping into the model

### DIFF
--- a/runtime/test/particle-execution-context-test.js
+++ b/runtime/test/particle-execution-context-test.js
@@ -16,7 +16,7 @@ import {StubLoader} from '../testing/stub-loader.js';
 import {TestHelper} from '../testing/test-helper.js';
 
 describe('Particle Execution Context', function() {
-  it('substitutes slot names in templates for slot ids', async () => {
+  it('substitutes slot names for model references', async () => {
     const {arc, slotComposer} = await TestHelper.create({
       manifestString: `
         particle A in 'A.js'
@@ -31,7 +31,7 @@ describe('Particle Execution Context', function() {
       loader: new StubLoader({
         'A.js': `defineParticle(({DomParticle}) => {
           return class extends DomParticle {
-            get template() { return '<div><div slotid="detail"></div><div slotid="annotation"></div></div>'; }
+            get template() { return '<div><div slotid$="{{$detail}}"></div><div slotid="annotation"></div></div>'; }
           };
         });`
       }),
@@ -48,7 +48,11 @@ describe('Particle Execution Context', function() {
 
     await slotConsumer.contentAvailable;
     assert.deepEqual(
-        `<div><div slotid="${detailContext.id}"></div><div slotid="${annotationContext.id}"></div></div>`,
+        `<div><div slotid$="{{$detail}}"></div><div slotid$="{{$annotation}}"></div></div>`,
         slotConsumer._content.template);
+    assert.deepEqual({
+      '$annotation': annotationContext.id,
+      '$detail': detailContext.id
+    }, slotConsumer._content.model);
   });
 });

--- a/runtime/test/particles/multi-slot-test.js
+++ b/runtime/test/particles/multi-slot-test.js
@@ -58,7 +58,7 @@ describe('multi-slot test', function() {
 
     helper.slotComposer
       .newExpectations()
-      .expectRenderSlot('ShowHints', 'root', {verify: (content) => content.template.length > 0 && !content.model})
+      .expectRenderSlot('ShowHints', 'root', {verify: (content) => content.template.length > 0})
       .expectRenderSlot('ShowHints', 'root', {isOptional: true, verify: (content) => Object.keys(content).length == 0})
       .expectRenderSlot('AskAndAnswer', 'question', {contentTypes: ['template', 'model']})
       .expectRenderSlot('AskAndAnswer', 'hints', {contentTypes: ['template', 'model'], verify: (content) => {

--- a/runtime/test/slot-composer-tests.js
+++ b/runtime/test/slot-composer-tests.js
@@ -18,6 +18,7 @@ import {Manifest} from '../ts-build/manifest.js';
 import {Planner} from '../ts-build/planner.js';
 import {StubLoader} from '../testing/stub-loader.js';
 import {TestHelper} from '../testing/test-helper.js';
+import {Random} from '../ts-build/random.js';
 
 async function initSlotComposer(recipeStr) {
   const slotComposer = new FakeSlotComposer();
@@ -198,6 +199,7 @@ recipe
   });
 
   it('renders inner slots in transformations without intercepting', async () => {
+    Random.seedForTests();
     const {arc, slotComposer} = await TestHelper.create({
       manifestString: `
         particle TransformationParticle in 'TransformationParticle.js'
@@ -290,16 +292,19 @@ recipe
     const detailSlotConsumer = slotComposer._contexts.find(c => c.name === 'detail').slotConsumers.find(sc => sc.constructor === MockSlotDomConsumer);
     await detailSlotConsumer.contentAvailable;
     
-    assert.deepEqual({
-      model: {a: 'A content/intercepted-model'},
-      template: `<div>intercepted-template<div><span>{{a}}</span><div slotid="${detailSlotConsumer.slotContext.id}"></div></div></div>`,
+    assert.deepEqual(rootSlotConsumer._content, {
+      model: {
+        a: 'A content/intercepted-model',
+        '$detail': 'slotid-!85915497922560:demo:3'
+      },
+      template: `<div>intercepted-template<div><span>{{a}}</span><div slotid$="{{$detail}}"></div></div></div>`,
       templateName: 'A::content::default/intercepted'
-    }, rootSlotConsumer._content);
+    });
 
-    assert.deepEqual({
+    assert.deepEqual(detailSlotConsumer._content, {
       model: {b: 'B content'},
       template: '<div>{{b}}</div>',
       templateName: 'default',
-    }, detailSlotConsumer._content);
+    });
   });
 });


### PR DESCRIPTION
Fixes #2332. I.e. Allows for template caching again.

Implements Step 1 from the new proposal in:
https://docs.google.com/document/d/1rSUsQQwyQPDNuOgOIrh6vdXto1FjUkWQZl_zvmfkKR0/edit