### PR TITLE
Rename Shape to InterfaceInfo, within the type system scope.

### DIFF
--- a/runtime/test/handle-test.js
+++ b/runtime/test/handle-test.js
@@ -13,7 +13,7 @@ import {Arc} from '../ts-build/arc.js';
 import {assert} from './chai-web.js';
 import {SlotComposer} from '../ts-build/slot-composer.js';
 import {handleFor} from '../ts-build/handle.js';
-import {Shape} from '../ts-build/shape.js';
+import {InterfaceInfo} from '../ts-build/interface-info.js';
 import {Type} from '../ts-build/type.js';
 import {Manifest} from '../ts-build/manifest.js';
 import {Loader} from '../ts-build/loader.js';
@@ -131,18 +131,20 @@ describe('Handle', function() {
     assert.isEmpty((await barStore.toList()));
   });
 
-  it('can store a particle in a shape store', async () => {
+  it('can store a particle in an interface store', async () => {
     const slotComposer = createSlotComposer();
     const arc = new Arc({slotComposer, id: 'test'});
     const manifest = await Manifest.load('./runtime/test/artifacts/test-particles.manifest', loader);
 
-    const shape = new Shape('Test', [{type: Type.newEntity(manifest.schemas.Foo)},
-                           {type: Type.newEntity(manifest.schemas.Bar)}], []);
-    assert(shape.particleMatches(manifest.particles[0]));
+    const iface = new InterfaceInfo('Test', [
+      {type: Type.newEntity(manifest.schemas.Foo)},
+      {type: Type.newEntity(manifest.schemas.Bar)}
+    ], []);
+    assert(iface.particleMatches(manifest.particles[0]));
 
-    const shapeStore = await arc.createStore(Type.newInterface(shape));
-    await shapeStore.set(manifest.particles[0]);
-    assert.equal(await shapeStore.get(), manifest.particles[0]);
+    const ifaceStore = await arc.createStore(Type.newInterface(iface));
+    await ifaceStore.set(manifest.particles[0]);
+    assert.equal(await ifaceStore.get(), manifest.particles[0]);
   });
 
   it('createHandle only allows valid tags & types in stores', async () => {

--- a/runtime/test/particle-shape-loading-test.js
+++ b/runtime/test/particle-shape-loading-test.js
@@ -16,10 +16,10 @@ import {Loader} from '../ts-build/loader.js';
 import {StubLoader} from '../testing/stub-loader.js';
 import {Recipe} from '../ts-build/recipe/recipe.js';
 import {Type} from '../ts-build/type.js';
-import {Shape} from '../ts-build/shape.js';
+import {InterfaceInfo} from '../ts-build/interface-info.js';
 import {ParticleSpec} from '../ts-build/particle-spec.js';
 
-describe('particle-shape-loading', function() {
+describe('particle-interface-loading', function() {
 
   it('loads interfaces into particles', async () => {
     const loader = new StubLoader({
@@ -66,22 +66,22 @@ describe('particle-shape-loading', function() {
     const fooType = Type.newEntity(manifest.schemas.Foo);
     const barType = Type.newEntity(manifest.schemas.Bar);
 
-    const shape = new Shape('Test', [{type: fooType}, {type: barType}], []);
+    const iface = new InterfaceInfo('Test', [{type: fooType}, {type: barType}], []);
 
-    const shapeType = Type.newInterface(shape);
+    const ifaceType = Type.newInterface(iface);
 
     const outerParticleSpec = new ParticleSpec({
       name: 'outerParticle',
       implFile: 'outer-particle.js',
       args: [
-        {direction: 'host', type: shapeType, name: 'particle0', dependentConnections: []},
+        {direction: 'host', type: ifaceType, name: 'particle0', dependentConnections: []},
         {direction: 'in', type: fooType, name: 'input', dependentConnections: []},
         {direction: 'out', type: barType, name: 'output', dependentConnections: []}
       ],
     });
 
-    const shapeStore = await arc.createStore(shapeType);
-    await shapeStore.set(manifest.particles[0].toLiteral());
+    const ifaceStore = await arc.createStore(ifaceType);
+    await ifaceStore.set(manifest.particles[0].toLiteral());
     const outStore = await arc.createStore(barType);
     const inStore = await arc.createStore(fooType);
     await inStore.set({id: 'id', rawData: {value: 'a foo'}});
@@ -90,10 +90,10 @@ describe('particle-shape-loading', function() {
     const particle = recipe.newParticle('outerParticle');
     particle.spec = outerParticleSpec;
 
-    const recipeShapeHandle = recipe.newHandle();
-    particle.connections['particle0'].connectToHandle(recipeShapeHandle);
-    recipeShapeHandle.fate = 'use';
-    recipeShapeHandle.mapToStorage(shapeStore);
+    const recipeInterfaceHandle = recipe.newHandle();
+    particle.connections['particle0'].connectToHandle(recipeInterfaceHandle);
+    recipeInterfaceHandle.fate = 'use';
+    recipeInterfaceHandle.mapToStorage(ifaceStore);
 
     const recipeOutHandle = recipe.newHandle();
     particle.connections['output'].connectToHandle(recipeOutHandle);
@@ -113,7 +113,7 @@ describe('particle-shape-loading', function() {
     await util.assertSingletonWillChangeTo(arc, outStore, 'value', 'a foo1');
   });
 
-  it('loads shapes into particles declaratively', async () => {
+  it('loads interfaces into particles declaratively', async () => {
     const loader = new Loader();
     const manifest = await Manifest.parse(`
       import './runtime/test/artifacts/test-particles.manifest'

--- a/runtime/test/recipe/particle-tests.js
+++ b/runtime/test/recipe/particle-tests.js
@@ -32,7 +32,7 @@ describe('Recipe Particle', function() {
       const [recipeParticle] = recipe.particles;
       const hostedParticleConn = recipeParticle.connections['hostedParticle'];
       const listConn = recipeParticle.connections['list'];
-      const shapeVariable = hostedParticleConn.type.interfaceShape.handles[0].type;
+      const shapeVariable = hostedParticleConn.type.interfaceInfo.handles[0].type;
       const listUnpackedVariable = listConn.type.collectionType;
       assert.strictEqual(shapeVariable.variable, listUnpackedVariable.variable);
     }
@@ -42,7 +42,7 @@ describe('Recipe Particle', function() {
       const recipeParticle = recipe.particles[0];
       const hostedParticleConn = recipeParticle.connections['hostedParticle'];
       const listConn = recipeParticle.connections['list'];
-      const shapeVariable = hostedParticleConn.type.interfaceShape.handles[0].type;
+      const shapeVariable = hostedParticleConn.type.interfaceInfo.handles[0].type;
       const listUnpackedVariable = listConn.type.collectionType;
       assert.strictEqual(shapeVariable.variable, listUnpackedVariable.variable);
     }

--- a/runtime/test/strategies/find-hosted-particle-tests.js
+++ b/runtime/test/strategies/find-hosted-particle-tests.js
@@ -61,7 +61,7 @@ describe('FindHostedParticle', function() {
     assert.isDefined(handle.id);
     assert.isTrue(handle.type instanceof InterfaceType);
     assert.isTrue(handle.type.isResolved());
-    assert.equal(handle.type.interfaceShape.name, 'HostedShape');
+    assert.equal(handle.type.interfaceInfo.name, 'HostedShape');
   });
   it(`respects type system constraints`, async () => {
     const results = await runStrategy(`

--- a/runtime/test/type-test.js
+++ b/runtime/test/type-test.js
@@ -10,7 +10,7 @@ import {assert} from './chai-web.js';
 import {Type} from '../ts-build/type.js';
 import {Schema} from '../ts-build/schema.js';
 import {TypeVariableInfo} from '../ts-build/type-variable-info.js';
-import {Shape} from '../ts-build/shape.js';
+import {InterfaceInfo} from '../ts-build/interface-info.js';
 import {SlotInfo} from '../ts-build/slot-info.js';
 import {Manifest} from '../ts-build/manifest.js';
 
@@ -20,7 +20,7 @@ import {Manifest} from '../ts-build/manifest.js';
 //   CollectionType    : Type
 //   BigCollectionType : Type
 //   RelationType      : [Type]
-//   InterfaceType     : Shape
+//   InterfaceType     : InterfaceInfo
 //   SlotType          : SlotInfo
 //   ReferenceType     : Type
 //   ArcType           : none
@@ -127,11 +127,11 @@ describe('types', () => {
       const variable = Type.newVariable(new TypeVariableInfo('a', null, null));
       const col      = Type.newCollection(entity);
       const iface    = Type.newInterface(
-          new Shape('s', [{type: entity}, {type: variable}, {type: col}], [{name: 'x'}]));
+          new InterfaceInfo('i', [{type: entity}, {type: variable}, {type: col}], [{name: 'x'}]));
       deepEqual(iface.toLiteral(), {
         tag: 'Interface',
         data: {
-          name: 's',
+          name: 'i',
           handles: [{type: entity.toLiteral()}, {type: variable.toLiteral()}, {type: col.toLiteral()}],
           slots: [{name: 'x'}]
         }
@@ -197,7 +197,8 @@ describe('types', () => {
       const entity     = Type.newEntity(new Schema({names: ['Foo'], fields: {value: 'Text'}}));
       const variable   = Type.newVariable(new TypeVariableInfo('a', null, null));
       const arcInfo    = Type.newArcInfo();
-      const iface      = Type.newInterface(new Shape('s', [{type: entity}, {type: variable}, {type: arcInfo}], []));
+      const iface      = Type.newInterface(
+          new InterfaceInfo('i', [{type: entity}, {type: variable}, {type: arcInfo}], []));
 
       const handleInfo = Type.newHandleInfo();
 

--- a/runtime/ts/arc.ts
+++ b/runtime/ts/arc.ts
@@ -162,7 +162,7 @@ export class Arc {
   async _serializeHandle(handle: StorageProviderBase, context: SerializeContext, id: string): Promise<void> {
     const type = handle.type.getContainedType() || handle.type;
     if (type instanceof InterfaceType) {
-      context.interfaces += type.interfaceShape.toString() + '\n';
+      context.interfaces += type.interfaceInfo.toString() + '\n';
     }
     const key = this.storageProviderFactory.parseStringAsKey(handle.storageKey);
     const tags = this.storeTags.get(handle) || [];
@@ -280,7 +280,7 @@ export class Arc {
     particleSpecs.forEach(spec => {
       for (const connection of spec.connections) {
         if (connection.type instanceof InterfaceType) {
-          results.push(connection.type.interfaceShape.toString());
+          results.push(connection.type.interfaceInfo.toString());
         }
       }
       results.push(spec.toString());
@@ -492,7 +492,7 @@ ${this.activeRecipe.toString()}`;
           const particleSpec = recipeHandle.immediateValue;
           const type = recipeHandle.type;
           
-          assert(type instanceof InterfaceType && type.interfaceShape.particleMatches(particleSpec));
+          assert(type instanceof InterfaceType && type.interfaceInfo.particleMatches(particleSpec));
           const particleClone = particleSpec.clone().toLiteral();
           particleClone.id = newStore.id;
           // TODO(shans): clean this up when we have interfaces for Variable, Collection, etc.
@@ -639,10 +639,10 @@ ${this.activeRecipe.toString()}`;
       }
     } else if (type instanceof EntityType) {
       return type.entitySchema.name;
-    } else if (type.isShape) {
-      // TODO we need to fix this too, otherwise all handles of shape type will
+    } else if (type instanceof InterfaceType) {
+      // TODO we need to fix this too, otherwise all handles of interface type will
       // be of the 'same type' when searching by type.
-      return type.shapeShape;
+      return type.interfaceInfo;
     } else if (type instanceof TypeVariable && type.isResolved()) {
       return Arc._typeToKey(type.resolvedType());
     }

--- a/runtime/ts/interface-info.ts
+++ b/runtime/ts/interface-info.ts
@@ -42,7 +42,7 @@ interface Slot {
   isSet: boolean;
 }
 
-export class Shape {
+export class InterfaceInfo {
   name: string;
   handles: Handle[];
   slots: Slot[];
@@ -59,7 +59,7 @@ export class Shape {
     this.typeVars = [];
     for (const handle of handles) {
       for (const field of handleFields) {
-        if (Shape.isTypeVar(handle[field])) {
+        if (InterfaceInfo.isTypeVar(handle[field])) {
           this.typeVars.push({object: handle, field});
         }
       }
@@ -67,7 +67,7 @@ export class Shape {
 
     for (const slot of slots) {
       for (const field of slotFields) {
-        if (Shape.isTypeVar(slot[field])) {
+        if (InterfaceInfo.isTypeVar(slot[field])) {
           this.typeVars.push({object: slot, field});
         }
       }
@@ -75,7 +75,7 @@ export class Shape {
   }
 
   toPrettyString() {
-    return 'SHAAAAPE';
+    return 'InterfaceInfo';
   }
 
   mergeTypeVariablesByName(variableMap) {
@@ -131,8 +131,8 @@ export class Shape {
       .map(slot => `  ${slot.direction} ${slot.isSet ? 'set of ' : ''}${slot.name ? slot.name + ' ' : ''}`)
       .join('\n');
   }
-  // TODO: Include name as a property of the shape and normalize this to just
-  // toString().
+  // TODO: Include name as a property of the interface and normalize this to just toString()
+  // TODO: Update when 'shape' keyword isn't used in manifests
   toString() {
     return `shape ${this.name}
 ${this._handlesToManifestString()}
@@ -143,7 +143,7 @@ ${this._slotsToManifestString()}
   static fromLiteral(data) {
     const handles = data.handles.map(handle => ({type: _fromLiteral(handle.type), name: _fromLiteral(handle.name), direction: _fromLiteral(handle.direction)}));
     const slots = data.slots.map(slot => ({name: _fromLiteral(slot.name), direction: _fromLiteral(slot.direction), isRequired: _fromLiteral(slot.isRequired), isSet: _fromLiteral(slot.isSet)}));
-    return new Shape(data.name, handles, slots);
+    return new InterfaceInfo(data.name, handles, slots);
   }
 
   toLiteral() {
@@ -152,10 +152,10 @@ ${this._slotsToManifestString()}
     return {name: this.name, handles, slots};
   }
 
-  clone(variableMap) : Shape {
+  clone(variableMap) : InterfaceInfo {
     const handles = this.handles.map(({name, direction, type}) => ({name, direction, type: type ? type.clone(variableMap) : undefined}));
     const slots = this.slots.map(({name, direction, isRequired, isSet}) => ({name, direction, isRequired, isSet}));
-    return new Shape(this.name, handles, slots);
+    return new InterfaceInfo(this.name, handles, slots);
   }
 
   cloneWithResolutions(variableMap) {
@@ -165,7 +165,7 @@ ${this._slotsToManifestString()}
   _cloneWithResolutions(variableMap) {
     const handles = this.handles.map(({name, direction, type}) => ({name, direction, type: type ? type._cloneWithResolutions(variableMap) : undefined}));
     const slots = this.slots.map(({name, direction, isRequired, isSet}) => ({name, direction, isRequired, isSet}));
-    return new Shape(this.name, handles, slots);
+    return new InterfaceInfo(this.name, handles, slots);
   }
 
   canEnsureResolved() {
@@ -240,7 +240,7 @@ ${this._slotsToManifestString()}
       handleList.push({name: handle.name || otherHandle.name, direction: handle.direction || otherHandle.direction, type: resultType});
     }
     const slots = this.slots.map(({name, direction, isRequired, isSet}) => ({name, direction, isRequired, isSet}));
-    return new Shape(this.name, handleList, slots);
+    return new InterfaceInfo(this.name, handleList, slots);
   }
 
   resolvedType() {
@@ -290,7 +290,7 @@ ${this._slotsToManifestString()}
 
   _cloneAndUpdate(update) {
     const copy = this.clone(new Map());
-    copy.typeVars.forEach(typeVar => Shape._updateTypeVar(typeVar, update));
+    copy.typeVars.forEach(typeVar => InterfaceInfo._updateTypeVar(typeVar, update));
     return copy;
   }
 
@@ -303,54 +303,54 @@ ${this._slotsToManifestString()}
   }
 
   static mustMatch(reference) {
-    return !(reference == undefined || Shape.isTypeVar(reference));
+    return !(reference == undefined || InterfaceInfo.isTypeVar(reference));
   }
 
-  static handlesMatch(shapeHandle, particleHandle) {
-    if (Shape.mustMatch(shapeHandle.name) &&
-        shapeHandle.name !== particleHandle.name) {
+  static handlesMatch(interfaceHandle, particleHandle) {
+    if (InterfaceInfo.mustMatch(interfaceHandle.name) &&
+        interfaceHandle.name !== particleHandle.name) {
       return false;
     }
     // TODO: direction subsetting?
-    if (Shape.mustMatch(shapeHandle.direction) &&
-        shapeHandle.direction !== particleHandle.direction) {
+    if (InterfaceInfo.mustMatch(interfaceHandle.direction) &&
+        interfaceHandle.direction !== particleHandle.direction) {
       return false;
     }
-    if (shapeHandle.type == undefined) {
+    if (interfaceHandle.type == undefined) {
       return true;
     }
-    const [left, right] = Type.unwrapPair(shapeHandle.type, particleHandle.type);
+    const [left, right] = Type.unwrapPair(interfaceHandle.type, particleHandle.type);
     if (left instanceof TypeVariable) {
-      return [{var: left, value: right, direction: shapeHandle.direction}];
+      return [{var: left, value: right, direction: interfaceHandle.direction}];
     } else {
       return left.equals(right);
     }
 
   }
 
-  static slotsMatch(shapeSlot, particleSlot) {
-    if (Shape.mustMatch(shapeSlot.name) &&
-        shapeSlot.name !== particleSlot.name) {
+  static slotsMatch(interfaceSlot, particleSlot) {
+    if (InterfaceInfo.mustMatch(interfaceSlot.name) &&
+        interfaceSlot.name !== particleSlot.name) {
       return false;
     }
-    if (Shape.mustMatch(shapeSlot.direction) &&
-        shapeSlot.direction !== particleSlot.direction) {
+    if (InterfaceInfo.mustMatch(interfaceSlot.direction) &&
+        interfaceSlot.direction !== particleSlot.direction) {
       return false;
     }
-    if (Shape.mustMatch(shapeSlot.isRequired) &&
-        shapeSlot.isRequired !== particleSlot.isRequired) {
+    if (InterfaceInfo.mustMatch(interfaceSlot.isRequired) &&
+        interfaceSlot.isRequired !== particleSlot.isRequired) {
       return false;
     }
-    if (Shape.mustMatch(shapeSlot.isSet) &&
-        shapeSlot.isSet !== particleSlot.isSet) {
+    if (InterfaceInfo.mustMatch(interfaceSlot.isSet) &&
+        interfaceSlot.isSet !== particleSlot.isSet) {
       return false;
     }
     return true;
   }
 
   particleMatches(particleSpec) {
-    const shape = this.cloneWithResolutions(new Map());
-    return shape.restrictType(particleSpec) !== false;
+    const interfaceInfo = this.cloneWithResolutions(new Map());
+    return interfaceInfo.restrictType(particleSpec) !== false;
   }
 
   restrictType(particleSpec) {
@@ -359,9 +359,10 @@ ${this._slotsToManifestString()}
 
   _restrictThis(particleSpec) {
 
-    const handleMatches = this.handles.map(
-      handle => particleSpec.connections.map(connection => ({match: connection, result: Shape.handlesMatch(handle, connection)}))
-                                      .filter(a => a.result !== false));
+    const handleMatches = this.handles.map(h =>
+      particleSpec.connections.map(c => ({match: c, result: InterfaceInfo.handlesMatch(h, c)}))
+                              .filter(a => a.result !== false)
+    );
 
     const particleSlots: {}[] = [];
     particleSpec.slots.forEach(consumedSlot => {
@@ -370,7 +371,7 @@ ${this._slotsToManifestString()}
         particleSlots.push({name: providedSlot.name, direction: 'provide', isRequired: false, isSet: providedSlot.isSet});
       });
     });
-    let slotMatches = this.slots.map(slot => particleSlots.filter(particleSlot => Shape.slotsMatch(slot, particleSlot)));
+    let slotMatches = this.slots.map(slot => particleSlots.filter(particleSlot => InterfaceInfo.slotsMatch(slot, particleSlot)));
     slotMatches = slotMatches.map(matchList => matchList.map(slot => ({match: slot, result: true})));
 
     const exclusions = [];

--- a/runtime/ts/manifest.ts
+++ b/runtime/ts/manifest.ts
@@ -16,7 +16,7 @@ import {Handle} from './recipe/handle.js';
 import {ParticleSpec} from './particle-spec.js';
 import {Schema} from './schema.js';
 import {Search} from './recipe/search.js';
-import {Shape} from './shape.js';
+import {InterfaceInfo} from './interface-info.js';
 import {Type, EntityType, CollectionType, BigCollectionType, InterfaceType} from './type.js';
 import {compareComparables} from './recipe/util.js';
 import {StorageProviderBase} from './storage/storage-provider-base.js';
@@ -108,11 +108,12 @@ type ManifestFinderGenerator<a> = ((manifest: Manifest) => IterableIterator<a>) 
 export class Manifest {
   private _recipes = <Recipe[]>[];
   private _imports = <Manifest[]>[];
-    // TODO: These should be lists, possibly with a separate flattened map.
+  // TODO: These should be lists, possibly with a separate flattened map.
   private _particles: {[index: string]: ParticleSpec} = {};
   private _schemas: {[index: string]: Schema} = {};
   private _stores = <StorageProviderBase[]>[];
-  private _shapes = <Shape[]>[];
+  // TODO: rename _shapes when 'shape' isn't used as a keyword in manifests
+  private _shapes = <InterfaceInfo[]>[];
   storeTags: Map<StorageProviderBase, string[]> = new Map();
   private _fileName: string|null = null;
   private readonly _id: Id;
@@ -668,7 +669,7 @@ ${e.message}
       });
     }
     // TODO: move shape to recipe/ and add shape builder?
-    const shape = new Shape(shapeItem.name, handles, slots);
+    const shape = new InterfaceInfo(shapeItem.name, handles, slots);
     manifest._shapes.push(shape);
   }
   static async _processRecipe(manifest, recipeItem, loader) {

--- a/runtime/ts/particle-spec.ts
+++ b/runtime/ts/particle-spec.ts
@@ -10,7 +10,7 @@
 
 import {Type, TypeLiteral} from './type.js';
 import {TypeChecker} from './recipe/type-checker.js';
-import {Shape} from './shape.js';
+import {InterfaceInfo} from './interface-info.js';
 import {assert} from '../../platform/assert-web.js';
 import { Direction } from './recipe/handle-connection.js';
 
@@ -259,15 +259,11 @@ export class ParticleSpec {
   }
 
   toInterface() {
-    return Type.newInterface(this._toShape());
-  }
-
-  _toShape() {
     // TODO: wat do?
-    assert(!this.slots.size, 'please implement slots toShape');
+    assert(!this.slots.size, 'please implement slots toInterface');
     const handles = this.model.args.map(({type, name, direction}) => ({type: asType(type), name, direction}));
     const slots = [];
-    return new Shape(this.name, handles, slots);
+    return Type.newInterface(new InterfaceInfo(this.name, handles, slots));
   }
 
   toString() {

--- a/runtime/ts/recipe/recipe-util.ts
+++ b/runtime/ts/recipe/recipe-util.ts
@@ -359,7 +359,7 @@ export class RecipeUtil {
     assert(connection.type instanceof InterfaceType);
     
     if (!(connection.type instanceof InterfaceType) ||
-        !connection.type.interfaceShape.restrictType(particleSpec)) {
+        !connection.type.interfaceInfo.restrictType(particleSpec)) {
       // Type of the connection does not match the ParticleSpec.
       return null;
     }

--- a/runtime/ts/recipe/type-checker.ts
+++ b/runtime/ts/recipe/type-checker.ts
@@ -111,7 +111,7 @@ export class TypeChecker {
       primitiveOnto.variable.resolution = primitiveBase;
       return onto;
     } else if (primitiveBase instanceof InterfaceType && primitiveOnto instanceof InterfaceType) {
-      const result = primitiveBase.interfaceShape.tryMergeTypeVariablesWith(primitiveOnto.interfaceShape);
+      const result = primitiveBase.interfaceInfo.tryMergeTypeVariablesWith(primitiveOnto.interfaceInfo);
       if (result == null) {
         return null;
       }
@@ -257,7 +257,7 @@ export class TypeChecker {
     // TODO: we need a generic way to evaluate type compatibility
     //       shapes + entities + etc
     if (leftType instanceof InterfaceType && rightType instanceof InterfaceType) {
-      if (leftType.interfaceShape.equals(rightType.interfaceShape)) {
+      if (leftType.interfaceInfo.equals(rightType.interfaceInfo)) {
         return true;
       }
     }

--- a/runtime/ts/strategies/find-hosted-particle.ts
+++ b/runtime/ts/strategies/find-hosted-particle.ts
@@ -28,7 +28,7 @@ export class FindHostedParticle extends Strategy {
         for (const particle of arc.context.particles) {
           // This is what shape.particleMatches() does, but we also do
           // canEnsureResolved at the end:
-          const shapeClone = iface.interfaceShape.cloneWithResolutions(new Map());
+          const shapeClone = iface.interfaceInfo.cloneWithResolutions(new Map());
           // If particle doesn't match the requested shape.
           if (shapeClone.restrictType(particle) === false) continue;
           // If we still have unresolvable shape after matching a particle.

--- a/runtime/ts/type.ts
+++ b/runtime/ts/type.ts
@@ -8,7 +8,7 @@
 
 import {Schema} from './schema.js';
 import {TypeVariableInfo} from './type-variable-info.js';
-import {Shape} from './shape.js';
+import {InterfaceInfo} from './interface-info.js';
 import {SlotInfo} from './slot-info.js';
 import {TypeChecker} from './recipe/type-checker.js';
 import {ArcInfo} from './synthetic-types.js';
@@ -46,7 +46,7 @@ export abstract class Type {
     return new RelationType(relation);
   }
 
-  static newInterface(iface : Shape) {
+  static newInterface(iface : InterfaceInfo) {
     return new InterfaceType(iface);
   }
 
@@ -79,7 +79,7 @@ export abstract class Type {
       case 'Relation':
         return new RelationType(literal.data.map(t => Type.fromLiteral(t)));
       case 'Interface':
-        return new InterfaceType(Shape.fromLiteral(literal.data));
+        return new InterfaceType(InterfaceInfo.fromLiteral(literal.data));
       case 'Slot':
         return new SlotType(SlotInfo.fromLiteral(literal.data));
       case 'Reference':
@@ -600,11 +600,11 @@ export class RelationType extends Type {
 
 
 export class InterfaceType extends Type {
-  readonly interfaceShape: Shape;
+  readonly interfaceInfo: InterfaceInfo;
 
-  constructor(iface: Shape) {
+  constructor(iface: InterfaceInfo) {
     super('Interface');
-    this.interfaceShape = iface;
+    this.interfaceInfo = iface;
   }
 
   get isInterface() {
@@ -612,59 +612,59 @@ export class InterfaceType extends Type {
   }
 
   mergeTypeVariablesByName(variableMap: Map<string, Type>) {
-    const shape = this.interfaceShape.clone(new Map());
-    shape.mergeTypeVariablesByName(variableMap);
+    const interfaceInfo = this.interfaceInfo.clone(new Map());
+    interfaceInfo.mergeTypeVariablesByName(variableMap);
     // TODO: only build a new type when a variable is modified
-    return new InterfaceType(shape);
+    return new InterfaceType(interfaceInfo);
   }
 
   _applyExistenceTypeTest(test) {
-    return this.interfaceShape._applyExistenceTypeTest(test);
+    return this.interfaceInfo._applyExistenceTypeTest(test);
   }
 
   resolvedType() {
-    return new InterfaceType(this.interfaceShape.resolvedType());
+    return new InterfaceType(this.interfaceInfo.resolvedType());
   }
 
   _canEnsureResolved() {
-    return this.interfaceShape.canEnsureResolved();
+    return this.interfaceInfo.canEnsureResolved();
   }
 
   maybeEnsureResolved() {
-    return this.interfaceShape.maybeEnsureResolved();
+    return this.interfaceInfo.maybeEnsureResolved();
   }
 
   get canWriteSuperset() {
-    return new InterfaceType(this.interfaceShape.canWriteSuperset);
+    return new InterfaceType(this.interfaceInfo.canWriteSuperset);
   }
 
   get canReadSubset() {
-    return new InterfaceType(this.interfaceShape.canReadSubset);
+    return new InterfaceType(this.interfaceInfo.canReadSubset);
   }
 
   _isMoreSpecificThan(type) {
-    return this.interfaceShape.isMoreSpecificThan(type.interfaceShape);
+    return this.interfaceInfo.isMoreSpecificThan(type.interfaceInfo);
   }
 
   _clone(variableMap) {
-    const data = this.interfaceShape.clone(variableMap).toLiteral();
+    const data = this.interfaceInfo.clone(variableMap).toLiteral();
     return Type.fromLiteral({tag: this.tag, data});
   }
 
   _cloneWithResolutions(variableMap) {
-    return new InterfaceType(this.interfaceShape._cloneWithResolutions(variableMap));
+    return new InterfaceType(this.interfaceInfo._cloneWithResolutions(variableMap));
   }
 
   toLiteral() {
-    return {tag: this.tag, data: this.interfaceShape.toLiteral()};
+    return {tag: this.tag, data: this.interfaceInfo.toLiteral()};
   }
 
   toString(options = undefined) {
-    return this.interfaceShape.name;
+    return this.interfaceInfo.name;
   }
 
   toPrettyString() {
-    return this.interfaceShape.toPrettyString();
+    return this.interfaceInfo.toPrettyString();
   }
 }
 


### PR DESCRIPTION
This does not rename shapes in manifests, or most of the corresponding shape-related code under the recipe dir.

Part of #2369