### PR TITLE
Make innerArc.loadRecipe(...) return ids of provided slots.

### DIFF
--- a/runtime/ts/api-channel.ts
+++ b/runtime/ts/api-channel.ts
@@ -510,7 +510,7 @@ export abstract class PECInnerPort extends APIPort {
   abstract onCreateSlotCallback(callback: (value: string) => void, hostedSlotId: string);
   abstract onInnerArcRender(transformationParticle: Particle, transformationSlotName: string, hostedSlotID: string, content: string);
 
-  ArcLoadRecipe(@RemoteMapped arc: {}, @Direct recipe: string, @LocalMapped callback: (data: {}) => void) {}
+  ArcLoadRecipe(@RemoteMapped arc: {}, @Direct recipe: string, @LocalMapped callback: (data: {error?: string}) => void) {}
 
   RaiseSystemException(@Direct exception: {}, @Direct methodName: string, @Direct particleId: string) {}
 

--- a/runtime/ts/particle-execution-context.ts
+++ b/runtime/ts/particle-execution-context.ts
@@ -209,11 +209,11 @@ export class ParticleExecutionContext {
       },
       loadRecipe(recipe) {
         // TODO: do we want to return a promise on completion?
-        return new Promise((resolve, reject) => pec.apiPort.ArcLoadRecipe(arcId, recipe, a => {
-          if (a == undefined) {
-            resolve();
+        return new Promise((resolve, reject) => pec.apiPort.ArcLoadRecipe(arcId, recipe, response => {
+          if (response.error) {
+            reject(response.error);
           } else {
-            reject(a);
+            resolve(response);            
           }
         }));
       }


### PR DESCRIPTION
Required to iteratively build recipes inside innerArcs on top of previously loaded ones.

(To get there fully we'll also need to return ids of instantiated handles (i.e. `create` handles), but that's a story for another PR.)

Short term this will unlock CollectionRenderer (#2236) to operate on mutable collections of items.

Proposal in slightly more detail:
When loading a recipe, transformation particle gets back a ids of slots provided by particles in the recipe in the format `'particleLocalName.slotConnectionName'` => `id`. This does require the loaded recipe to put local names on particles to receive the slot IDs back - which is required to disambiguate between multiple instances of the same particle in the most particle-developer friendly way.