### PR TITLE
Plumb ArcType into the shells environment

### DIFF
--- a/shells/env/arcs.js
+++ b/shells/env/arcs.js
@@ -3,6 +3,7 @@ const g = (typeof window === 'undefined') ? global : window;
 const {
   version,
   Arc,
+  ArcType,
   Manifest,
   Planificator,
   SlotComposer,
@@ -19,6 +20,7 @@ const {
 export {
   version,
   Arc,
+  ArcType,
   Manifest,
   Planificator,
   SlotComposer,

--- a/shells/env/source/arcs.js
+++ b/shells/env/source/arcs.js
@@ -12,7 +12,7 @@ import {Arc} from '../../../build/runtime/arc.js';
 import {Planificator} from '../../../build/runtime/plan/planificator.js';
 import {SlotComposer} from '../../../build/runtime/slot-composer.js';
 import {SlotDomConsumer} from '../../../build/runtime/slot-dom-consumer.js';
-import {Type} from '../../../build/runtime/type.js';
+import {Type, ArcType} from '../../../build/runtime/type.js';
 import {Manifest} from '../../../build/runtime/manifest.js';
 import {ParticleExecutionContext} from '../../../build/runtime/particle-execution-context.js';
 import {StorageProviderFactory} from '../../../build/runtime/storage/storage-provider-factory.js';
@@ -24,6 +24,7 @@ import {BrowserLoader} from './browser-loader.js';
 const Arcs = {
   version: '0.6',
   Arc,
+  ArcType,
   Manifest,
   Planificator,
   SlotComposer,


### PR DESCRIPTION
arc-host.js tries to import ArcHost from env/arcs.js and fails.