### PR TITLE
Rename 'shape' to 'interface' in manifests.

### DIFF
--- a/artifacts/Common/List.manifest
+++ b/artifacts/Common/List.manifest
@@ -6,14 +6,14 @@
 // subject to an additional IP rights grant found at
 // http://polymer.github.io/PATENTS.txt
 
-shape HostedParticleShape
+interface HostedParticleInterface
   in ~a *
   consume item
 
 // row lists
 
 particle ItemMultiplexer in 'source/Multiplexer.js'
-  host HostedParticleShape hostedParticle
+  host HostedParticleInterface hostedParticle
   in [~a] list
   consume set of item
 
@@ -46,12 +46,12 @@ particle SelectableList in 'source/List.js'
 
 // tile lists
 
-shape HostedTileParticleShape
+interface HostedTileParticleInterface
   in ~a *
   consume tile
 
 particle TileMultiplexer in 'source/Multiplexer.js'
-  host HostedTileParticleShape hostedParticle
+  host HostedTileParticleInterface hostedParticle
   in [~a] list
   consume set of tile
 

--- a/artifacts/Common/Multiplexer.manifest
+++ b/artifacts/Common/Multiplexer.manifest
@@ -6,25 +6,25 @@
 // subject to an additional IP rights grant found at
 // http://polymer.github.io/PATENTS.txt
 
-shape HostedParticleShape
+interface HostedParticleInterface
   in ~a *
   consume
 
 // TODO: This particle should use generic slot name.
 particle Multiplexer in 'source/Multiplexer.js'
-  host HostedParticleShape hostedParticle
+  host HostedParticleInterface hostedParticle
   in [~a] list
   consume set of annotation
   description `${hostedParticle} for ${list}`
 
 // Same as Multiplexer above, but with an additional connection.
-shape HostedParticleShape2
+interface HostedParticleInterface2
   in ~a *
   in [~a] *
   consume
 
 particle Multiplexer2 in 'source/Multiplexer.js'
-  host HostedParticleShape2 hostedParticle
+  host HostedParticleInterface2 hostedParticle
   in [~a] list
   in [~a] others
   consume set of annotation

--- a/artifacts/Social/Particles.manifest
+++ b/artifacts/Social/Particles.manifest
@@ -47,7 +47,7 @@ particle WritePosts in 'source/WritePosts.js'
   description `write posts`
 
 particle EditPost in 'source/EditPost.js'
-  host HostedParticleShape renderParticle
+  host HostedParticleInterface renderParticle
   inout Post post
   inout [Post] posts
   in Person user

--- a/artifacts/TVMaze/TVMazeDemo.recipes
+++ b/artifacts/TVMaze/TVMazeDemo.recipes
@@ -25,13 +25,13 @@ particle TVMazeShowActions in './source/TVMazeShowActions.js'
   inout [TVMazeShow] shows
   consume action
 
-shape HostedActionParticleShape
+interface HostedActionParticleInterface
   in TVMazeShow show
   inout [TVMazeShow] shows
   consume action
 
 particle ActionMultiplexer in '../Common/source/Multiplexer.js'
-  host HostedActionParticleShape hostedParticle
+  host HostedActionParticleInterface hostedParticle
   in [~a] list
   in [TVMazeShow] shows
   consume set of action

--- a/artifacts/Words/GamePane.manifest
+++ b/artifacts/Words/GamePane.manifest
@@ -15,7 +15,7 @@ import 'Move.schema'
 import 'Stats.schema'
 
 particle GamePane in 'source/GamePane.js'
-  host HostedParticleShape renderParticle
+  host HostedParticleInterface renderParticle
   in Person person
   inout Board board
   inout Move move

--- a/particles/Demo/TVMazeDemo.recipes
+++ b/particles/Demo/TVMazeDemo.recipes
@@ -25,13 +25,13 @@ particle TVMazeShowActions in '../TVMaze/source/TVMazeShowActions.js'
   inout [TVMazeShow] shows
   consume action
 
-shape HostedActionParticleShape
+interface HostedActionParticleInterface
   in TVMazeShow show
   inout [TVMazeShow] shows
   consume action
 
 particle ActionMultiplexer in '../List/source/Multiplexer.js'
-  host HostedActionParticleShape hostedParticle
+  host HostedActionParticleInterface hostedParticle
   in [~a] list
   in [TVMazeShow] shows
   consume set of action

--- a/particles/List/Annotations.recipes
+++ b/particles/List/Annotations.recipes
@@ -6,7 +6,7 @@
 // subject to an additional IP rights grant found at
 // http://polymer.github.io/PATENTS.txt
 
-shape HostedAnnotationShape
+interface HostedAnnotationInterface
   in ~any *
   inout ~anyOther *
   consume annotation
@@ -14,19 +14,19 @@ shape HostedAnnotationShape
 particle AnnotationMultiplexer in 'source/Multiplexer.js'
   in [~any] list
   inout ~anyOther annotation
-  host HostedAnnotationShape hostedParticle
+  host HostedAnnotationInterface hostedParticle
   consume set of annotation
 
-shape HostedSimpleAnnotationShape
+interface HostedSimpleAnnotationInterface
   in ~any *
   consume annotation
 
 particle SimpleAnnotationMultiplexer in 'source/Multiplexer.js'
   in [~any] list
-  host HostedSimpleAnnotationShape hostedParticle
+  host HostedSimpleAnnotationInterface hostedParticle
   consume set of annotation
 
-shape HostedCombinedAnnotationShape
+interface HostedCombinedAnnotationInterface
   in ~any *
   in [~anyOther] *
   consume annotation
@@ -34,7 +34,7 @@ shape HostedCombinedAnnotationShape
 particle CombinedAnnotationMultiplexer in 'source/Multiplexer.js'
   in [~any] list
   in [~anyOther] choices
-  host HostedCombinedAnnotationShape hostedParticle
+  host HostedCombinedAnnotationInterface hostedParticle
   consume set of annotation
 
 //recipe AnnotationMultiplexer

--- a/particles/List/Choices.recipes
+++ b/particles/List/Choices.recipes
@@ -6,7 +6,7 @@
 // subject to an additional IP rights grant found at
 // http://polymer.github.io/PATENTS.txt
 
-shape HostedChoiceShape
+interface HostedChoiceInterface
   in ~any *
   in [~anyOther] *
   consume choice
@@ -14,5 +14,5 @@ shape HostedChoiceShape
 particle ChoicesMultiplexer in 'source/Multiplexer.js'
   in [~any] list
   in [~anyOther] choices
-  host HostedChoiceShape hostedParticle
+  host HostedChoiceInterface hostedParticle
   consume set of choice

--- a/particles/List/Items.recipes
+++ b/particles/List/Items.recipes
@@ -6,18 +6,18 @@
 // subject to an additional IP rights grant found at
 // http://polymer.github.io/PATENTS.txt
 
-shape HostedItemShape
+interface HostedItemInterface
   in ~any *
   // TODO(sjmiles): using slot-type for form-factor
-  // all Shapes are the same in List/* except for the slot
+  // all Interfaces are the same in List/* except for the slot
   consume item
 
 particle ItemMultiplexer in 'source/Multiplexer.js'
   // TODO(sjmiles): redundancies:
-  // 1. slot is declared in HostedItemShape and as `consume set of` here
-  // 2. ~any is declared in HostedItemShape and as `[~any]` here
+  // 1. slot is declared in HostedItemInterface and as `consume set of` here
+  // 2. ~any is declared in HostedItemInterface and as `[~any]` here
   in [~any] list
-  host HostedItemShape hostedParticle
+  host HostedItemInterface hostedParticle
   consume set of item
 
 // TODO(sjmiles): recipe is the minimum coalescable artifact, which is good because we need to be able specify

--- a/particles/List/Tiles.recipes
+++ b/particles/List/Tiles.recipes
@@ -6,13 +6,13 @@
 // subject to an additional IP rights grant found at
 // http://polymer.github.io/PATENTS.txt
 
-shape HostedTileShape
+interface HostedTileInterface
   in ~any *
   consume tile
 
 particle TileMultiplexer in 'source/Multiplexer.js'
   in [~any] list
-  host HostedTileShape hostedParticle
+  host HostedTileInterface hostedParticle
   consume set of tile
 
 //recipe TileMultiplexer

--- a/src/runtime/interface-info.ts
+++ b/src/runtime/interface-info.ts
@@ -132,9 +132,8 @@ export class InterfaceInfo {
       .join('\n');
   }
   // TODO: Include name as a property of the interface and normalize this to just toString()
-  // TODO: Update when 'shape' keyword isn't used in manifests
   toString() {
-    return `shape ${this.name}
+    return `interface ${this.name}
 ${this._handlesToManifestString()}
 ${this._slotsToManifestString()}
 `;

--- a/src/runtime/manifest-parser.peg
+++ b/src/runtime/manifest-parser.peg
@@ -74,7 +74,7 @@ ManifestItem
   / SchemaDefinition
   / SchemaAliasDefinition
   / ManifestStorage
-  / Shape
+  / Interface
   / Meta
   / Resource
 
@@ -150,23 +150,23 @@ Import
     };
   }
 
-Shape
-  = 'shape' whiteSpace name:TopLevelIdent typeVars:(whiteSpace? '<' whiteSpace? TypeVariableList whiteSpace? '>')? eolWhiteSpace items:(Indent (SameIndent ShapeItem)*)? eolWhiteSpace?
+Interface
+  = 'interface' whiteSpace name:TopLevelIdent typeVars:(whiteSpace? '<' whiteSpace? TypeVariableList whiteSpace? '>')? eolWhiteSpace items:(Indent (SameIndent InterfaceItem)*)? eolWhiteSpace?
   {
     return {
-      kind: 'shape',
+      kind: 'interface',
       location: location(),
       name,
-      args: optional(items, extractIndented, []).filter(item => item.kind == 'shape-argument'),
-      slots: optional(items, extractIndented, []).filter(item => item.kind == 'shape-slot'),
+      args: optional(items, extractIndented, []).filter(item => item.kind == 'interface-argument'),
+      slots: optional(items, extractIndented, []).filter(item => item.kind == 'interface-slot'),
     };
   }
 
-ShapeItem
-  = ShapeSlot
-  / ShapeArgument
+InterfaceItem
+  = InterfaceSlot
+  / InterfaceArgument
 
-ShapeArgument
+InterfaceArgument
   = direction:(ParticleArgumentDirection whiteSpace)? type:(ParticleArgumentType whiteSpace)? name:(lowerIdent / '*') eolWhiteSpace
   {
     if (direction) {
@@ -176,10 +176,10 @@ ShapeArgument
       type = type[0]
     }
     if (direction == 'host') {
-      error(`Shape cannot have arguments with a 'host' direction.`);
+      error(`Interface cannot have arguments with a 'host' direction.`);
     }
     return {
-      kind: 'shape-argument',
+      kind: 'interface-argument',
       location: location(),
       direction,
       type,
@@ -187,11 +187,11 @@ ShapeArgument
     };
   }
 
-ShapeSlot
+InterfaceSlot
   = isRequired:('must' whiteSpace)? direction:('consume' / 'provide') isSet:(whiteSpace 'set of')? name:(whiteSpace lowerIdent)? eolWhiteSpace
   {
     return {
-      kind: 'shape-slot',
+      kind: 'interface-slot',
       location: location(),
       name: optional(name, isRequired => name[1], null),
       isRequired: optional(isRequired, isRequired => isRequired[0] == 'must', false),
@@ -230,7 +230,7 @@ ParticleDefinition
     verbs = optional(verbs, parsedOutput => parsedOutput[1], []);
     items = items ? extractIndented(items) : [];
     items.forEach(item => {
-      if (item.kind == 'interface') {
+      if (item.kind == 'particle-interface') {
         if (/[A-Z]/.test(item.verb[0]) && item.verb != name) {
           error(`Verb ${item.verb} must start with a lower case character or be same as particle name.`);
         }
@@ -285,7 +285,7 @@ ParticleInterface
   = verb:(upperIdent / lowerIdent) '(' args:ParticleArgumentList? ')' eolWhiteSpace
   {
     return {
-      kind: 'interface',
+      kind: 'particle-interface',
       location: location(),
       verb,
       args: args || []
@@ -1074,7 +1074,7 @@ ReservedWord
   / 'particle'
   / 'recipe'
   / 'import'
-  / 'shape'
+  / 'interface'
   / 'schema'
   / 'require'
   / 'handle'

--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -112,8 +112,7 @@ export class Manifest {
   private _particles: {[index: string]: ParticleSpec} = {};
   private _schemas: {[index: string]: Schema} = {};
   private _stores = <StorageProviderBase[]>[];
-  // TODO: rename _shapes when 'shape' isn't used as a keyword in manifests
-  private _shapes = <InterfaceInfo[]>[];
+  private _interfaces = <InterfaceInfo[]>[];
   storeTags: Map<StorageProviderBase, string[]> = new Map();
   private _fileName: string|null = null;
   private readonly _id: Id;
@@ -176,8 +175,8 @@ export class Manifest {
   get allStores() {
     return [...this._findAll(manifest => manifest._stores)];
   }
-  get shapes() {
-    return this._shapes;
+  get interfaces() {
+    return this._interfaces;
   }
   get meta() {
     return this._meta;
@@ -239,9 +238,9 @@ export class Manifest {
     if (schema) {
       return new EntityType(schema);
     }
-    const shape = this.findShapeByName(name);
-    if (shape) {
-      return new InterfaceType(shape);
+    const iface = this.findInterfaceByName(name);
+    if (iface) {
+      return new InterfaceType(iface);
     }
     return null;
   }
@@ -294,8 +293,8 @@ export class Manifest {
     return stores.filter(s => !!Handle.effectiveType(
       type, [{type: s.type, direction: (s.type instanceof InterfaceType) ? 'host' : 'inout'}]));
   }
-  findShapeByName(name) {
-    return this._find(manifest => manifest._shapes.find(shape => shape.name === name));
+  findInterfaceByName(name) {
+    return this._find(manifest => manifest._interfaces.find(iface => iface.name === name));
   }
   findRecipesByVerb(verb) {
     return [...this._findAll(manifest => manifest._recipes.filter(recipe => recipe.verbs.includes(verb)))];
@@ -431,7 +430,7 @@ ${e.message}
       // similarly, resources may be referenced from other parts of the manifest.
       await processItems('resource', item => this._processResource(manifest, item));
       await processItems('schema', item => this._processSchema(manifest, item));
-      await processItems('shape', item => this._processShape(manifest, item));
+      await processItems('interface', item => this._processInterface(manifest, item));
       await processItems('particle', item => this._processParticle(manifest, item, loader));
       await processItems('store', item => this._processStore(manifest, item, loader));
       await processItems('recipe', item => this._processRecipe(manifest, item, loader));
@@ -520,10 +519,10 @@ ${e.message}
           }
           if (resolved.schema) {
             node.model = new EntityType(resolved.schema);
-          } else if (resolved.shape) {
-            node.model = new InterfaceType(resolved.shape);
+          } else if (resolved.iface) {
+            node.model = new InterfaceType(resolved.iface);
           } else {
-            throw new Error('Expected {shape} or {schema}');
+            throw new Error('Expected {iface} or {schema}');
           }
           return;
         }
@@ -634,9 +633,9 @@ ${e.message}
     manifest._particles[particleItem.name] = particleSpec;
   }
   // TODO: Move this to a generic pass over the AST and merge with resolveTypeName.
-  static _processShape(manifest, shapeItem) {
+  static _processInterface(manifest, interfaceItem) {
     const handles = [];
-    for (const arg of shapeItem.args) {
+    for (const arg of interfaceItem.args) {
       const handle = {name: undefined, type: undefined, direction: arg.direction};
       if (arg.name !== '*') {
         handle.name = arg.name;
@@ -647,7 +646,7 @@ ${e.message}
       handles.push(handle);
     }
     const slots = [];
-    for (const slotItem of shapeItem.slots) {
+    for (const slotItem of interfaceItem.slots) {
       slots.push({
         direction: slotItem.direction,
         name: slotItem.name,
@@ -655,9 +654,9 @@ ${e.message}
         isSet: slotItem.isSet
       });
     }
-    // TODO: move shape to recipe/ and add shape builder?
-    const shape = new InterfaceInfo(shapeItem.name, handles, slots);
-    manifest._shapes.push(shape);
+    // TODO: move interface to recipe/ and add interface builder?
+    const ifaceInfo = new InterfaceInfo(interfaceItem.name, handles, slots);
+    manifest._interfaces.push(ifaceInfo);
   }
   static async _processRecipe(manifest, recipeItem, loader) {
     // TODO: annotate other things too
@@ -910,7 +909,7 @@ ${e.message}
           if (!targetHandle) {
             throw new ManifestError(
                 connectionItem.target.location,
-                `Hosted particle '${hostedParticle.name}' does not match shape '${connection.name}'`);
+                `Hosted particle '${hostedParticle.name}' does not match interface '${connection.name}'`);
           }
         }
 
@@ -991,9 +990,9 @@ ${e.message}
     if (schema) {
       return {schema};
     }
-    const shape = this.findShapeByName(name);
-    if (shape) {
-      return {shape};
+    const iface = this.findInterfaceByName(name);
+    if (iface) {
+      return {iface};
     }
     return null;
   }

--- a/src/runtime/recipe/type-checker.ts
+++ b/src/runtime/recipe/type-checker.ts
@@ -233,7 +233,7 @@ export class TypeChecker {
 
     if (leftType instanceof TypeVariable || rightType instanceof TypeVariable) {
       // TODO: everything should use this, eventually. Need to implement the
-      // right functionality in Shapes first, though.
+      // right functionality in Interfaces first, though.
       return Type.canMergeConstraints(leftType, rightType);
     }
 
@@ -253,7 +253,7 @@ export class TypeChecker {
     }
 
     // TODO: we need a generic way to evaluate type compatibility
-    //       shapes + entities + etc
+    //       interfaces + entities + etc
     if (leftType instanceof InterfaceType && rightType instanceof InterfaceType) {
       if (leftType.interfaceInfo.equals(rightType.interfaceInfo)) {
         return true;

--- a/src/runtime/test/arc-tests.js
+++ b/src/runtime/test/arc-tests.js
@@ -289,11 +289,11 @@ describe('Arc', function() {
   it('serializes immediate value handles correctly', async () => {
     const loader = new StubLoader({
       manifest: `
-        shape HostedShape
+        interface HostedInterface
           in ~a *
 
         particle A in 'a.js'
-          host HostedShape hosts
+          host HostedInterface hosts
 
         particle B in 'b.js'
           in Entity {} val
@@ -318,8 +318,8 @@ describe('Arc', function() {
     assert.isEmpty(serialization.stores, 'Immediate value store should not be serialized');
     assert.deepEqual(['A', 'B'], serialization.particles.map(p => p.name),
         'Spec of a particle referenced in an immediate mode should be serialized');
-    assert.deepEqual(['HostedShape'], serialization.shapes.map(s => s.name),
-        'Hosted connection shape should be serialized');
+    assert.deepEqual(['HostedInterface'], serialization.interfaces.map(s => s.name),
+        'Hosted connection interface should be serialized');
 
     const recipeHCs = serialization.recipes[0].handleConnections;
     assert.lengthOf(recipeHCs, 1);

--- a/src/runtime/test/artifacts/Common/List.manifest
+++ b/src/runtime/test/artifacts/Common/List.manifest
@@ -6,14 +6,14 @@
 // subject to an additional IP rights grant found at
 // http://polymer.github.io/PATENTS.txt
 
-shape HostedParticleShape
+interface HostedParticleInterface
   in ~a *
   consume item
 
 // row lists
 
 particle ItemMultiplexer in 'source/Multiplexer.js'
-  host HostedParticleShape hostedParticle
+  host HostedParticleInterface hostedParticle
   in [~a] list
   consume set of item
 
@@ -46,12 +46,12 @@ particle SelectableList in 'source/List.js'
 
 // tile lists
 
-shape HostedTileParticleShape
+interface HostedTileParticleInterface
   in ~a *
   consume tile
 
 particle TileMultiplexer in 'source/Multiplexer.js'
-  host HostedTileParticleShape hostedParticle
+  host HostedTileParticleInterface hostedParticle
   in [~a] list
   consume set of tile
 

--- a/src/runtime/test/artifacts/Common/Multiplexer.manifest
+++ b/src/runtime/test/artifacts/Common/Multiplexer.manifest
@@ -6,25 +6,25 @@
 // subject to an additional IP rights grant found at
 // http://polymer.github.io/PATENTS.txt
 
-shape HostedParticleShape
+interface HostedParticleInterface
   in ~a *
   consume
 
 // TODO: This particle should use generic slot name.
 particle Multiplexer in 'source/Multiplexer.js'
-  host HostedParticleShape hostedParticle
+  host HostedParticleInterface hostedParticle
   in [~a] list
   consume set of annotation
   description `${hostedParticle} for ${list}`
 
 // Same as Multiplexer above, but with an additional connection.
-shape HostedParticleShape2
+interface HostedParticleInterface2
   in ~a *
   in [~a] *
   consume
 
 particle Multiplexer2 in 'source/Multiplexer.js'
-  host HostedParticleShape2 hostedParticle
+  host HostedParticleInterface2 hostedParticle
   in [~a] list
   in [~a] others
   consume set of annotation

--- a/src/runtime/test/artifacts/Products/test/ProductFilter.manifest
+++ b/src/runtime/test/artifacts/Products/test/ProductFilter.manifest
@@ -8,13 +8,13 @@
 
 import '../Product.schema'
 
-shape HostedParticleShape
+interface HostedParticleInterface
   in Product *
   out Product *
 
 // TODO: This particle should use generic handle type and slot name.
 particle ProductFilter in 'source/ProductFilter.js'
-  host HostedParticleShape hostedParticle
+  host HostedParticleInterface hostedParticle
   in [Product] products
   out [Product] results
   description `show filtered products`

--- a/src/runtime/test/artifacts/Social/Particles.manifest
+++ b/src/runtime/test/artifacts/Social/Particles.manifest
@@ -47,7 +47,7 @@ particle WritePosts in 'source/WritePosts.js'
   description `write posts`
 
 particle EditPost in 'source/EditPost.js'
-  host HostedParticleShape renderParticle
+  host HostedParticleInterface renderParticle
   inout Post post
   inout [Post] posts
   in Person user

--- a/src/runtime/test/artifacts/Words/GamePane.manifest
+++ b/src/runtime/test/artifacts/Words/GamePane.manifest
@@ -15,7 +15,7 @@ import 'Move.schema'
 import 'Stats.schema'
 
 particle GamePane in 'source/GamePane.js'
-  host HostedParticleShape renderParticle
+  host HostedParticleInterface renderParticle
   in Person person
   inout Board board
   inout Move move

--- a/src/runtime/test/artifacts/suggestions/Cakes.recipes
+++ b/src/runtime/test/artifacts/suggestions/Cakes.recipes
@@ -17,13 +17,13 @@ particle List in '../Common/source/List.js'
       handle items
   description `show ${items}`
 
-shape MakeCakeShape
+interface MakeCakeInterface
   in Cake *
   consume item
   provide special
 
 particle CakeMuxer in '../Common/source/Multiplexer.js'
-  host MakeCakeShape hostedParticle
+  host MakeCakeInterface hostedParticle
   in [Cake] list
   consume set of item
     provide set of special
@@ -37,12 +37,12 @@ recipe &makeCakes
     hostedParticle = MakeCake
   description `show ${List.items}`
 
-shape LightCandleShape
+interface LightCandleInterface
   in Cake *
   consume candles
 
 particle CandleMuxer in '../Common/source/Multiplexer.js'
-  host LightCandleShape hostedParticle
+  host LightCandleInterface hostedParticle
   in [Cake] list
   consume set of candles
 

--- a/src/runtime/test/artifacts/test-particles.manifest
+++ b/src/runtime/test/artifacts/test-particles.manifest
@@ -16,12 +16,12 @@ particle TestParticle in 'test-particle.js'
   out Bar bar
   description `test particle`
 
-shape TestShape
+interface TestInterface
   in Foo foo
   out Bar bar
 
 particle OuterParticle in 'outer-particle.js'
-  host TestShape particle0
+  host TestInterface particle0
   in Foo input
   out Bar output
 

--- a/src/runtime/test/artifacts/transformations/test-slots-particles.manifest
+++ b/src/runtime/test/artifacts/transformations/test-slots-particles.manifest
@@ -14,12 +14,12 @@ particle SingleSlotParticle in 'test-single-slot-particle.js'
   consume annotation
   description `test slot particle0`
 
-shape HostedParticleShape
+interface HostedParticleInterface
   in Foo foo
   consume annotation
 
 particle MultiplexSlotsParticle in 'test-multiplex-slots-particle.js'
-  host HostedParticleShape particle0
+  host HostedParticleInterface particle0
   in [Foo] foos
   consume set of annotationsSet
   description `outer test slot particle0`

--- a/src/runtime/test/description-test.js
+++ b/src/runtime/test/description-test.js
@@ -648,10 +648,10 @@ recipe
   tests.forEach((test) => {
     it('capitalizes when some particles do not have descriptions ' + test.name, async () => {
       const manifest = (await Manifest.parse(`
-shape DummyShape
+interface DummyInterface
 particle NoDescription
 particle NoDescMuxer
-  host DummyShape hostedParticle
+  host DummyInterface hostedParticle
   consume root
     provide myslot
   description \`\${hostedParticle} description\`

--- a/src/runtime/test/interface-info-test.js
+++ b/src/runtime/test/interface-info-test.js
@@ -162,11 +162,11 @@ describe('interface', function() {
         in [~a] input
         out [~a] output
 
-      shape HostedShape
+      interface HostedInterface
         in ~a *
 
       particle Multiplexer
-        host HostedShape hostedParticle
+        host HostedInterface hostedParticle
         in [~a] items
 
       recipe
@@ -229,10 +229,10 @@ describe('interface', function() {
       particle Upper
         out Gibson output
 
-      shape HostedShape
+      interface HostedInterface
         inout ~a *
       particle Host
-        host HostedShape hosted
+        host HostedInterface hosted
         inout ~a item
 
       recipe

--- a/src/runtime/test/manifest-test.js
+++ b/src/runtime/test/manifest-test.js
@@ -1400,62 +1400,62 @@ resource SomeName
 `, {});
     assert.deepEqual(manifest.resources['SomeName'], `{'foo': 'bar'}\nhello\n`);
   });
-  it('can parse a manifest containing incomplete shapes', async () => {
+  it('can parse a manifest containing incomplete interfaces', async () => {
     const manifest = await Manifest.parse(`
       schema Foo
-      shape FullShape
+      interface FullInterface
         in Foo foo
         consume root
         provide action
-      shape ShapeNoHandleName
+      interface NoHandleName
         in Foo *
-      shape ShapeNoHandleType
+      interface NoHandleType
         inout foo
-      shape ShapeNoHandleDirection
+      interface NoHandleDirection
         Foo foo
-      shape ShapeOnlyHandleDirection
+      interface OnlyHandleDirection
         out *
-      shape ShapeManyHandles
+      interface ManyHandles
         in Foo *
         out [~a] *
-      shape ShapeConsumeNoName
+      interface ConsumeNoName
         consume
-      shape ShapeConsumeRequiredSetSlot
+      interface ConsumeRequiredSetSlot
         must consume set of
         must provide
-      shape ShapeOnlyProvideSlots
+      interface OnlyProvideSlots
         provide action
     `);
-    assert.lengthOf(manifest.shapes, 9);
-    assert(manifest.findShapeByName('FullShape'));
+    assert.lengthOf(manifest.interfaces, 9);
+    assert(manifest.findInterfaceByName('FullInterface'));
   });
-  it('can parse a manifest containing shapes', async () => {
+  it('can parse a manifest containing interfaces', async () => {
     const manifest = await Manifest.parse(`
       schema Foo
-      shape Shape
+      interface Bar
         in Foo foo
-      particle ShapeParticle
-        host Shape shape0
+      particle HostingParticle
+        host Bar iface0
       recipe
         create as handle0
-        ShapeParticle
-          shape0 = handle0`);
-    assert(manifest.findShapeByName('Shape'));
+        HostingParticle
+          iface0 = handle0`);
+    assert(manifest.findInterfaceByName('Bar'));
     assert(manifest.recipes[0].normalize());
   });
-  it('can parse shapes using new-style body syntax', async () => {
+  it('can parse interfaces using new-style body syntax', async () => {
     const manifest = await Manifest.parse(`
       schema Foo
-      shape Shape
+      interface Bar
         in Foo foo
-      particle ShapeParticle
-        host Shape shape0
+      particle HostingParticle
+        host Bar iface0
       recipe
         create as handle0
-        ShapeParticle
-          shape0 = handle0
+        HostingParticle
+          iface0 = handle0
     `);
-    assert(manifest.findShapeByName('Shape'));
+    assert(manifest.findInterfaceByName('Bar'));
     assert(manifest.recipes[0].normalize());
   });
   it('can resolve optional handles', async () => {
@@ -1482,7 +1482,7 @@ resource SomeName
   it('can resolve an immediate handle specified by a particle target', async () => {
     const manifest = await Manifest.parse(`
       schema S
-      shape HostedShape
+      interface HostedInterface
         in S foo
 
       particle Hosted
@@ -1490,7 +1490,7 @@ resource SomeName
         in S bar
 
       particle Transformation &work in '...js'
-        host HostedShape hosted
+        host HostedInterface hosted
 
       recipe
         Transformation

--- a/src/runtime/test/particle-interface-loading-test.js
+++ b/src/runtime/test/particle-interface-loading-test.js
@@ -19,7 +19,7 @@ import {EntityType, InterfaceType} from '../type.js';
 import {InterfaceInfo} from '../interface-info.js';
 import {ParticleSpec} from '../particle-spec.js';
 
-describe('particle-interface-loading', function() {
+describe('particle interface loading', function() {
 
   it('loads interfaces into particles', async () => {
     const loader = new StubLoader({

--- a/src/runtime/test/particle-interface-loading-with-slots-test.js
+++ b/src/runtime/test/particle-interface-loading-with-slots-test.js
@@ -16,7 +16,7 @@ import {MockSlotComposer} from '../testing/mock-slot-composer.js';
 import {SlotDomConsumer} from '../slot-dom-consumer.js';
 import {HostedSlotConsumer} from '../hosted-slot-consumer.js';
 
-describe('particle-shape-loading-with-slots', function() {
+describe('particle interface loading with slots', function() {
   async function initializeManifestAndArc(contextContainer) {
     const loader = new Loader();
     const slotComposer = new MockSlotComposer({rootContainer: {'set-slotid-0': contextContainer || {}}});

--- a/src/runtime/test/particles/artifacts/provide-hosted-particle-slots.manifest
+++ b/src/runtime/test/particles/artifacts/provide-hosted-particle-slots.manifest
@@ -18,23 +18,23 @@ particle ShowFooAnnotation in 'source/ShowFooAnnotation.js'
   in Foo foo
   consume annotation
 
-shape FooShape
+interface FooInterface
   in Foo *
   consume
   provide
 
-shape FooAnnotationShape
+interface FooAnnotationInterface
   in Foo *
   consume
 
 particle Fooxer in '../../artifacts/Common/source/Multiplexer.js'
-  host FooShape hostedParticle
+  host FooInterface hostedParticle
   in [Foo] list
   consume set of item
     provide set of annotation
 
 particle FooAnnotationMuxer in '../../artifacts/Common/source/Multiplexer.js'
-  host FooAnnotationShape hostedParticle
+  host FooAnnotationInterface hostedParticle
   in [Foo] list
   consume set of annotation
 

--- a/src/runtime/test/planner-tests.js
+++ b/src/runtime/test/planner-tests.js
@@ -459,12 +459,12 @@ describe('Type variable resolution', function() {
 
   it('transformation particles type variable resolution', async () => {
     const particleSpecs = `
-shape HostedShape
+interface HostedInterface
   in ~a *
 particle P1
   in Thing1 input
 particle Muxer in 'Muxer.js'
-  host HostedShape hostedParticle
+  host HostedInterface hostedParticle
   in [~a] list
 `;
 
@@ -818,13 +818,13 @@ describe('Automatic resolution', function() {
           accountTransactions = accountTransactions
       store TransationList of [Transaction] 'myTransactions' in './src/runtime/test/artifacts/Things/empty.json'
 
-      shape HostedShape
+      interface HostedInterface
         in ~a *
       particle ShowTransation
         in Transaction transaction
 
       particle ItemMultiplexer
-        host HostedShape hostedParticle
+        host HostedInterface hostedParticle
         in [~a] list
 
       particle List

--- a/src/runtime/test/recipe-test.js
+++ b/src/runtime/test/recipe-test.js
@@ -212,14 +212,14 @@ describe('recipe', function() {
 
   it('generates the same hash on manifest re-parse for immediates', async () => {
     const manifestContent = `
-      shape HostedParticleShape
+      interface HostedParticleInterface
         in ~a *
         consume
 
       schema Foo
 
       particle A in 'A.js'
-        host HostedParticleShape hostedParticle
+        host HostedParticleInterface hostedParticle
         consume set of annotation
 
       particle B in 'B.js'

--- a/src/runtime/test/recipe/particle-tests.js
+++ b/src/runtime/test/recipe/particle-tests.js
@@ -14,11 +14,11 @@ import {assert} from '../chai-web.js';
 describe('Recipe Particle', function() {
   it('cloning maints type variable mapping', async () => {
     const manifest = await Manifest.parse(`
-      shape HostedShape
+      interface HostedInterface
         in ~a *
 
       particle Multiplexer
-        host HostedShape hostedParticle
+        host HostedInterface hostedParticle
         in [~a] list
 
       recipe
@@ -32,9 +32,9 @@ describe('Recipe Particle', function() {
       const [recipeParticle] = recipe.particles;
       const hostedParticleConn = recipeParticle.connections['hostedParticle'];
       const listConn = recipeParticle.connections['list'];
-      const shapeVariable = hostedParticleConn.type.interfaceInfo.handles[0].type;
+      const ifaceVariable = hostedParticleConn.type.interfaceInfo.handles[0].type;
       const listUnpackedVariable = listConn.type.collectionType;
-      assert.strictEqual(shapeVariable.variable, listUnpackedVariable.variable);
+      assert.strictEqual(ifaceVariable.variable, listUnpackedVariable.variable);
     }
 
     recipe = recipe.clone();
@@ -42,9 +42,9 @@ describe('Recipe Particle', function() {
       const recipeParticle = recipe.particles[0];
       const hostedParticleConn = recipeParticle.connections['hostedParticle'];
       const listConn = recipeParticle.connections['list'];
-      const shapeVariable = hostedParticleConn.type.interfaceInfo.handles[0].type;
+      const ifaceVariable = hostedParticleConn.type.interfaceInfo.handles[0].type;
       const listUnpackedVariable = listConn.type.collectionType;
-      assert.strictEqual(shapeVariable.variable, listUnpackedVariable.variable);
+      assert.strictEqual(ifaceVariable.variable, listUnpackedVariable.variable);
     }
   });
 });

--- a/src/runtime/test/strategies/add-missing-handles-test.js
+++ b/src/runtime/test/strategies/add-missing-handles-test.js
@@ -72,11 +72,11 @@ describe('AddMissingHandles', function() {
   it(`doesn't add handles to host connections`, async () => {
     const results = await runStrategy(`
       schema Thing
-      shape HostedShape
+      interface HostedInterface
         in ~a *
       particle P1
         in Thing thing
-        host HostedShape hosted
+        host HostedInterface hosted
       recipe
         P1
     `);

--- a/src/runtime/test/strategies/coalesce-recipes-test.js
+++ b/src/runtime/test/strategies/coalesce-recipes-test.js
@@ -119,10 +119,10 @@ describe('CoalesceRecipes', function() {
           must provide foo
             handle thing
 
-      shape HostedShape
+      interface HostedInterface
         in ~a *
       particle P2
-        host HostedShape hostedParticle
+        host HostedInterface hostedParticle
         in Thing thing
         consume foo
 

--- a/src/runtime/test/strategies/find-hosted-particle-tests.js
+++ b/src/runtime/test/strategies/find-hosted-particle-tests.js
@@ -42,11 +42,11 @@ describe('FindHostedParticle', function() {
       particle AlsoDoesNotMatch
         in OtherThing thingy
 
-      shape HostedShape
+      interface HostedInterface
         in Thing *
 
       particle Host
-        host HostedShape hosted
+        host HostedInterface hosted
 
       recipe
         Host
@@ -61,7 +61,7 @@ describe('FindHostedParticle', function() {
     assert.isDefined(handle.id);
     assert.isTrue(handle.type instanceof InterfaceType);
     assert.isTrue(handle.type.isResolved());
-    assert.equal(handle.type.interfaceInfo.name, 'HostedShape');
+    assert.equal(handle.type.interfaceInfo.name, 'HostedInterface');
   });
   it(`respects type system constraints`, async () => {
     const results = await runStrategy(`
@@ -77,11 +77,11 @@ describe('FindHostedParticle', function() {
       particle Upper
         out Gibson output
 
-      shape HostedShape
+      interface HostedInterface
         inout ~a *
         consume foo
       particle Host
-        host HostedShape hosted
+        host HostedInterface hosted
         inout ~a item
 
       recipe
@@ -132,11 +132,11 @@ describe('FindHostedParticle', function() {
       particle Matches
         in ~a thingy
 
-      shape HostedShape
+      interface HostedInterface
         in ~a *
 
       particle Host
-        host HostedShape hosted
+        host HostedInterface hosted
 
       recipe
         Host

--- a/src/runtime/test/strategies/strategy-sequence-test.js
+++ b/src/runtime/test/strategies/strategy-sequence-test.js
@@ -148,12 +148,12 @@ describe('A Strategy Sequence', function() {
         in [Thing] choices
         consume annotation
   
-      shape HostedParticleShape
+      interface HostedParticleInterface
         in ~a *
         consume
   
       particle Multiplexer in 'source/Multiplexer.js'
-        host HostedParticleShape hostedParticle
+        host HostedParticleInterface hostedParticle
         in [~a] list
         consume set of annotation
   
@@ -169,13 +169,13 @@ describe('A Strategy Sequence', function() {
         in [Product] population
         out [Product] recommendations
   
-      shape HostedParticleShape2
+      interface HostedParticleInterface2
         in ~a *
         in [~a] *
         consume
         
       particle Multiplexer2 in 'source/Multiplexer.js'
-        host HostedParticleShape2 hostedParticle
+        host HostedParticleInterface2 hostedParticle
         in [~a] list
         in [~a] others
         consume set of annotation

--- a/src/runtime/test/type-checker-tests.js
+++ b/src/runtime/test/type-checker-tests.js
@@ -213,14 +213,14 @@ describe('TypeChecker', () => {
 
   it('correctly applies then resolves a one-sided Entity constraint', async () => {
     const manifest = await Manifest.parse(`
-      shape Shape
+      interface Interface
         in ~a item
 
       particle Concrete
         in Product {} item
 
       particle Transformation
-        host Shape particle0
+        host Interface particle0
         in [~a] collection
 
       recipe

--- a/tools/reducethislist
+++ b/tools/reducethislist
@@ -82,8 +82,8 @@ src/runtime/test/manifest-test.js
 src/runtime/test/multiplexer-test.js
 src/runtime/test/particle-api-test.js
 src/runtime/test/particle-execution-context-test.js
-src/runtime/test/particle-shape-loading-test.js
-src/runtime/test/particle-shape-loading-with-slots-test.js
+src/runtime/test/particle-interface-loading-test.js
+src/runtime/test/particle-interface-loading-with-slots-test.js
 src/runtime/test/planner-tests.js
 src/runtime/test/recipe-descriptions-test.js
 src/runtime/test/recipe-index-test.js


### PR DESCRIPTION
There is still a Shape class in the recipe code, but that's a somewhat different and internal concept used for matching recipes, so I've left that as is.