### PR TITLE
Refactor planning-result to fetch directly from store, and consumer&producer reuse the same result object

### DIFF
--- a/src/runtime/plan/suggestion.ts
+++ b/src/runtime/plan/suggestion.ts
@@ -164,7 +164,7 @@ export class Suggestion {
 
       return plan;
     } catch (e) {
-      console.error(`Failed to parse suggestion ${e}.`);
+      console.error(`Failed to parse suggestion ${e}\n${planString}.`);
     }
     return null;
   }

--- a/src/runtime/test/plan/plan-consumer-test.js
+++ b/src/runtime/test/plan/plan-consumer-test.js
@@ -45,7 +45,7 @@ recipe
       helper.arc.storageKey = 'volatile://!158405822139616:demo^^volatile-0';
       const store = await Planificator._initSuggestStore(helper.arc, userid, storageKeyBase);
       assert.isNotNull(store);
-      const consumer = new PlanConsumer(helper.arc, store);
+      const consumer = new PlanConsumer(new PlanningResult(helper.arc, store));
 
       let suggestionsChangeCount = 0;
       const suggestionsCallback = (suggestions) => { ++suggestionsChangeCount; };
@@ -57,9 +57,8 @@ recipe
 
       const storeResults = async (suggestions) => {
         suggestions.forEach(s => s.relevance = Relevance.create(helper.arc, s.plan));
-        const result = new PlanningResult(helper.arc);
-        result.set({suggestions});
-        await store.set(result.serialize());
+        assert.isTrue(consumer.result.set({suggestions}));
+        await consumer.result.flush();
         await new Promise(resolve => setTimeout(resolve, 100));
       };
       // Updates suggestions.

--- a/src/runtime/test/plan/planning-result-test.js
+++ b/src/runtime/test/plan/planning-result-test.js
@@ -22,7 +22,8 @@ describe('planning result', function() {
       s.relevance = Relevance.create(helper.arc, s.plan);
       s.relevance.apply(new Map([[s.plan.particles[0], [1]]]));
     });
-    const result = new PlanningResult(helper.arc, {suggestions: helper.suggestions});
+    const result = new PlanningResult(helper.arc);
+    result.set({suggestions: helper.suggestions});
 
     const serialization = result.serialize();
     assert(serialization.suggestions);

--- a/src/runtime/test/plan/replan-queue-test.js
+++ b/src/runtime/test/plan/replan-queue-test.js
@@ -9,11 +9,12 @@
  */
 import {assert} from '../chai-web.js';
 import {PlanProducer} from '../../plan/plan-producer.js';
+import {PlanningResult} from '../../plan/planning-result.js';
 import {ReplanQueue} from '../../plan/replan-queue.js';
 
 class TestPlanProducer extends PlanProducer {
   constructor() {
-    super({context: {allRecipes: []}}, {});
+    super(new PlanningResult({context: {allRecipes: []}}, {on: () =>{}}));
     this.produceSuggestionsCalled = 0;
   }
   produceSuggestions() {


### PR DESCRIPTION
part of https://github.com/PolymerLabs/arcs/issues/2400