### PR TITLE
Massively simplify DeviceClientPipe (thanks Berni!)

### DIFF
--- a/particles/Demo/Demo.recipes
+++ b/particles/Demo/Demo.recipes
@@ -1,0 +1,4 @@
+import 'RestaurantsDemo.recipes'
+import 'TVMazeDemo.recipes'
+import 'ProductsDemo.recipe'
+import 'DemoData.manifest'

--- a/particles/Demo/TVMazeDemo.recipes
+++ b/particles/Demo/TVMazeDemo.recipes
@@ -86,7 +86,7 @@ recipe TVMazeDemo
   // all shows I've looked at on my device
   map 'PROFILE_all_piped-all_tv_shows' as allPipedShows
   // most recent show(s)
-  map 'PROFILE_piped-tv_show' as pipedShows
+  //map 'PROFILE_piped-tv_show' as pipedShows
   // selected show (for detail)
   create #nosync #selected as selected
   // shows that this arc wants to be part of BOXED_shows-tile (if this arc is shared)
@@ -108,7 +108,7 @@ recipe TVMazeDemo
     user = user
     boxedShows = boxedShows
     selected = selected
-    recentShows = pipedShows
+    //recentShows = pipedShows
     foundShows = foundshows
     boxedUserNames = boxedUserNames
     friends = friends

--- a/particles/Music/Artist.recipes
+++ b/particles/Music/Artist.recipes
@@ -1,0 +1,36 @@
+// @license
+// Copyright (c) 2018 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+schema ArtistFind
+  Text name
+
+schema ArtistMusic
+  Text artistid
+  Text type
+  Text name
+  URL url
+  URL imageUrl
+  Text description
+  Text detailedDescription
+
+particle ArtistFinder in 'source/ArtistFinder.js'
+  in ArtistFind find
+  out ArtistMusic artist
+
+particle ArtistShow in 'source/ArtistShow.js'
+  in ArtistMusic artist
+  consume content
+  description `Learn more about ${artist}`
+
+recipe ArtistInfo
+  slot 'rootslotid-root' as root
+  use #artist as artist
+  ArtistShow
+    consume content as root
+    artist = artist
+  description `${ArtistShow}`

--- a/particles/Music/Music.recipes
+++ b/particles/Music/Music.recipes
@@ -1,1 +1,2 @@
 import 'Playlist.recipe'
+import 'Artist.recipes'

--- a/particles/Music/source/ArtistFinder.js
+++ b/particles/Music/source/ArtistFinder.js
@@ -1,0 +1,62 @@
+// @license
+// Copyright (c) 2017 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+'use strict';
+
+/* global defineParticle, importScripts */
+defineParticle(({DomParticle, log}) => {
+
+  /* global service */
+  const service = 'https://kgsearch.googleapis.com/v1/entities:search?key=AIzaSyDVu27xQSI7fQ-_VvZpCH6sdVMe1mueN54&limit=1';
+
+  return class extends DomParticle {
+    get template() {
+      return '&nbsp;'; //html`Searching`;
+    }
+    update({find}, state) {
+      // If we are asynchronously populating data, wait until this is done before
+      // handling additional updates.
+      if (find && !state.receiving) {
+        if (find.length) {
+          find = find[0];
+        }
+        if (find && find !== state.find) {
+          state.find = find;
+          this.fetchArtist(find);
+        }
+      }
+    }
+    async fetchArtist(find) {
+      this.setState({receiving: true});
+      const response = await fetch(`${service}&query=${encodeURI(find.name)}`);
+      const artists = await response.json();
+      this.setState({receiving: false});
+      this.receiveArtists(artists);
+    }
+    async receiveArtists(artists) {
+      log(artists);
+      if (artists.error) {
+        console.log(artists.error);
+      } else if (artists.itemListElement.length === 0) {
+        console.log('No results in the knowledge graph.');
+      } else {
+        const artist = artists.itemListElement[0].result;
+        log(artist);
+        this.updateVariable('artist', {
+          artistid: artist['@id'],
+          type: artist['@type'].join(','),
+          name: artist.name,
+          description: artist.description,
+          imageUrl: artist.image && artist.image.contentUrl,
+          detailedDescription: artist.detailedDescription && artist.detailedDescription.articleBody
+        });
+        //this.setParticleDescription(artist.summary);
+      }
+    }
+  };
+});

--- a/particles/Music/source/ArtistShow.js
+++ b/particles/Music/source/ArtistShow.js
@@ -1,0 +1,122 @@
+// @license
+// Copyright (c) 2018 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+'use strict';
+
+defineParticle(({DomParticle, html}) => {
+
+  const template = html`
+
+<style>
+  :host {
+    border-radius: 16px;
+    border: 1px solid #ddd;
+    overflow: hidden;
+    margin: 8px;
+  }
+  [header] {
+    position: relative;
+    min-height: 35vh;
+    padding: 24px;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    background: cadetblue;
+    color: white;
+    font-size: 24px;
+    z-index: 0;
+  }
+  [cover] {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    z-index: -1;
+  }
+  [photo] {
+    background-size: cover;
+    background-repeat: no-repeat;
+    background-position: center center;
+  }
+  [scrim] {
+    background: rgba(0, 0, 0, 0) linear-gradient(to bottom, rgba(0, 0, 0, 0) 25%, rgba(0, 0, 0, 1)) repeat 0 0;
+  }
+  [name] {
+    margin: 4px 0 8px;
+  }
+  [description] {
+    font-size: 16px;
+  }
+  [now-playing] {
+    border-top: 1px solid #ddd;
+    padding: 24px 24px 16px;
+  }
+  [now-playing] [list] {
+    margin: 0 -8px;
+  }
+</style>
+
+<div header>
+  <model-img cover photo url="{{imgUrl}}"></model-img>
+  <div cover scrim></div>
+  <div description>{{description}}</div>
+  <div name>{{name}}</div>
+  <div description>{{detailedDescription}}</div>
+</div>
+
+<!-- <div slotid="nearbyShows"></div>
+<div now-playing>
+  From <b>Now playing</b>
+  <div list slotid="nowPlayingList"></div>
+</div>
+<div slotid="extrasForArtist"></div> -->
+
+  `;
+  return class extends DomParticle {
+    get template() {
+      return template;
+    }
+    shouldRender({artist}) {
+      return Boolean(artist);
+    }
+    // update({artist, artistPlayHistory}) {
+    //   if (artistPlayHistory.length && artist) {
+    //     let mostRecent = artistPlayHistory[0];
+    //     for (const song of artistPlayHistory) {
+    //       if (Number(song.dateTime) > Number(mostRecent.dateTime)) mostRecent = song;
+    //     }
+    //     this.setParticleDescription({
+    //         template: `You listened to <b>${mostRecent.song}</b> by <b>${artist.name}</b> ${this.formatTime(Number(mostRecent.dateTime))}`,
+    //         model: {}
+    //     });
+    //   }
+    // }
+    // formatTime(dateTime) {
+    //   const delta = Date.now() - dateTime;
+    //   if (delta < 60 * 60 * 1000) {
+    //     let minutes =  Math.round(delta / (60 * 1000));
+    //     if (minutes === 0) minutes = 1;
+    //     return `${minutes} minute${minutes === 1 ? '' : 's'} ago`;
+    //   } else if (delta < 24 * 60 * 60 * 1000) {
+    //     const hours =  Math.round(delta / (60 * 60 * 1000));
+    //     return `${hours} hour${hours === 1 ? '' : 's'} ago`;
+    //   } else {
+    //     return `on ${new Date(Number(dateTime)).toLocaleDateString()}`;
+    //   }
+    // }
+    render({artist}) {
+      return {
+        name: artist.name,
+        description: artist.description,
+        detailedDescription: artist.detailedDescription || '',
+        imgUrl: artist.imageUrl || ''
+      };
+    }
+  };
+});

--- a/particles/Pipes/TVMazePipe.recipes
+++ b/particles/Pipes/TVMazePipe.recipes
@@ -1,4 +1,3 @@
-import '../Profile/User.schema'
 import '../TVMaze/TVMazeShow.schema'
 import '../Common/Description.schema'
 

--- a/particles/TVMaze/TVMazeShow.recipes
+++ b/particles/TVMaze/TVMazeShow.recipes
@@ -6,6 +6,7 @@
 // subject to an additional IP rights grant found at
 // http://polymer.github.io/PATENTS.txt
 
+import '../Arcs/Description.schema'
 import 'TVMazeShow.schema'
 
 particle TVMazeShowTile in './source/TVMazeShowTile.js'
@@ -15,14 +16,17 @@ particle TVMazeShowTile in './source/TVMazeShowTile.js'
 
 particle TVMazeShowPanel in './source/TVMazeShowPanel.js'
   in TVMazeShow show
+  out [Description] descriptions
   consume content
     provide action
     provide items
-  description `${show} details`
+  description `TV show information from TVMaze`
 
-// TODO(sjmiles): temporarily hide from coalescer
-//recipe TVMazeShowPanel
-  // TODO(sjmiles): force #selected; otherwise, it tries to map to multiplexer items
-  //use #selected as show
-  //TVMazeShowPanel
-  //  show = show
+recipe TVMazeShowPanel
+  use #tv_show as show
+  create #nosync as descriptions
+  slot 'rootslotid-root' as root
+  TVMazeShowPanel
+    consume content as root
+    show = show
+    descriptions = descriptions

--- a/particles/TVMaze/source/TVMazeDemoShell.js
+++ b/particles/TVMaze/source/TVMazeDemoShell.js
@@ -77,16 +77,16 @@ defineParticle(({DomParticle, html, log}) => {
     get template() {
       return template;
     }
-    update({user, boxedShows, recentShows, boxedUserNames, friends}, state) {
-      if (recentShows) {
-        const show = recentShows[0];
-        if (show && (!state.lastShow || show.showid !== state.lastShow.showid)) {
-          this.updateDescription(show, boxedShows, boxedUserNames, friends);
-          state.lastShow = show;
-          log('selecting', show);
-          this.handles.get('selected').set(show);
-        }
-      }
+    update({user, boxedShows, /*recentShows,*/ boxedUserNames, friends}, state) {
+      // if (recentShows) {
+      //   const show = recentShows[0];
+      //   if (show && (!state.lastShow || show.showid !== state.lastShow.showid)) {
+      //     this.updateDescription(show, boxedShows, boxedUserNames, friends);
+      //     state.lastShow = show;
+      //     log('selecting', show);
+      //     this.handles.get('selected').set(show);
+      //   }
+      // }
       if (user === null) {
         user = {id: 'gomer'};
       }

--- a/particles/TVMaze/source/TVMazeFindEpisodes.js
+++ b/particles/TVMaze/source/TVMazeFindEpisodes.js
@@ -9,7 +9,7 @@
 'use strict';
 
 /* global defineParticle, importScripts */
-defineParticle(({DomParticle, _fetch, resolver}) => {
+defineParticle(({DomParticle}) => {
 
   /* global service */
   //importScripts(resolver('TVMazeFindShow/TvMaze.js'));
@@ -35,7 +35,7 @@ defineParticle(({DomParticle, _fetch, resolver}) => {
     }
     async fetchEpisodes(show) {
       this.setState({count: -1});
-      const response = await _fetch(`${service}/shows/${show.showid}/episodes`);
+      const response = await fetch(`${service}/shows/${show.showid}/episodes`);
       const episodes = await response.json();
       this.receiveEpisodes(episodes);
     }

--- a/particles/TVMaze/source/TVMazeFindShow.js
+++ b/particles/TVMaze/source/TVMazeFindShow.js
@@ -9,7 +9,7 @@
 'use strict';
 
 /* global defineParticle, importScripts */
-defineParticle(({DomParticle, _fetch, resolver, log}) => {
+defineParticle(({DomParticle, log}) => {
 
   /* global service */
   //importScripts(resolver('TVMazeFindShow/TvMaze.js'));
@@ -37,7 +37,7 @@ defineParticle(({DomParticle, _fetch, resolver, log}) => {
     async fetchShow(find) {
       this.setState({receiving: true});
       log(`searching for [${find.name}]`);
-      const response = await _fetch(`${service}/search/shows?q=${find.name}`);
+      const response = await fetch(`${service}/search/shows?q=${find.name}`);
       const shows = await response.json();
       if (shows && shows.length) {
         this.receiveShow(shows[0]);

--- a/particles/TVMaze/source/TVMazeSearchShows.js
+++ b/particles/TVMaze/source/TVMazeSearchShows.js
@@ -9,7 +9,7 @@
 'use strict';
 
 /* global defineParticle, importScripts */
-defineParticle(({DomParticle, _fetch, resolver, log}) => {
+defineParticle(({DomParticle, log}) => {
 
   const service = `https://api.tvmaze.com`;
   /* global service */
@@ -32,7 +32,7 @@ defineParticle(({DomParticle, _fetch, resolver, log}) => {
       }
     }
     async fetchShows(query, shows) {
-      const response = await _fetch(`${service}/search/shows?q=${query.query}`);
+      const response = await fetch(`${service}/search/shows?q=${query.query}`);
       const data = await response.json();
       this.receiveShows(data, shows);
       this.setState({receiving: false});

--- a/particles/TVMaze/source/TVMazeShowPanel.js
+++ b/particles/TVMaze/source/TVMazeShowPanel.js
@@ -12,31 +12,29 @@
 
 defineParticle(({DomParticle, html, log}) => {
 
-  const host = `tv-maze-show-panel`;
-
   const template = html`
 
-<div ${host} hidden="{{hidden}}">
-  <style>
-    [${host}] {
-      padding: 16px;
-    }
-    [${host}] > [slotid=action] {
-      margin-right: 40px;
-    }
-    [${host}] > [columns] {
-      /* display: flex; */
-      align-items: start;
-      padding-bottom: 8px;
-    }
-    [${host}] [img] {
-      vertical-align: middle;
-      padding-right: 8px;
-    }
-    [${host}] > [description] p {
-      margin: 0;
-    }
-  </style>
+<style>
+  :host {
+    padding: 16px;
+  }
+  [slotid=action] {
+    margin-right: 40px;
+  }
+  [columns] {
+    align-items: start;
+    padding-bottom: 8px;
+  }
+  [img] {
+    vertical-align: middle;
+    padding-right: 8px;
+  }
+  [description] p {
+    margin-top: 0;
+  }
+</style>
+
+<div tv-maze-show-panel hidden="{{hidden}}">
   <div slotid="action"></div>
   <div columns>
     <img src="{{image}}">
@@ -50,8 +48,8 @@ defineParticle(({DomParticle, html, log}) => {
   <!-- <div>
     <icon>{{glyph}}</icon>
   </div> -->
-  <div style="padding-top: 16px;" unsafe-html="{{alsoWatch}}"></div>
-  <div description style="padding: 16px 0;" unsafe-html="{{description}}"></div>
+  <div style="margin-top: 16px;" unsafe-html="{{alsoWatch}}"></div>
+  <div description style="margin: 16px 0;" unsafe-html="{{description}}"></div>
   <!-- <div style="color: #333; font-size: 1.5em; margin: 16px 0;">Episodes</div> -->
   <div slotid="items"></div>
 </div>
@@ -68,6 +66,13 @@ defineParticle(({DomParticle, html, log}) => {
           show = show[0];
         }
         state.show = show;
+        const description = `${
+          show.name} is on ${
+          show.network}${
+          show.time ? ` at ${show.time}` : ''}${
+          show.day ? ` on ${show.day}` : ''
+        }`;
+        this.setParticleDescription(description);
       }
     }
     render({alsoWatch}, {show}) {

--- a/particles/canonical.manifest
+++ b/particles/canonical.manifest
@@ -1,10 +1,7 @@
 import 'List/List.recipes'
+import 'Profile/Profile.recipes'
 import 'Products/Products.recipe'
 import 'Restaurants/Restaurants.recipes'
 import 'Music/Music.recipes'
-import 'Profile/Profile.recipes'
-
-import 'Demo/RestaurantsDemo.recipes'
-import 'Demo/TVMazeDemo.recipes'
-import 'Demo/ProductsDemo.recipe'
-import 'Demo/DemoData.manifest'
+import 'TVMaze/TVMaze.recipes'
+import 'Demo/Demo.recipes'

--- a/shells/env/node/node-loader.js
+++ b/shells/env/node/node-loader.js
@@ -62,8 +62,6 @@ export class NodeLoader extends Loader {
     //  _resolve method allows particles to request remapping of assets paths
     //  for use in DOM
     const resolver = this._resolve.bind(this);
-    // TODO(sjmiles): hack to plumb `fetch` into Particle space under node
-    //const _fetch = NodeLoader.fetch || fetch;
     return particleWrapper({
       Particle,
       DomParticle,
@@ -72,8 +70,7 @@ export class NodeLoader extends Loader {
       TransformationDomParticle,
       resolver,
       log: log || (() => {}),
-      html,
-      //_fetch
+      html
     });
   }
 }

--- a/shells/env/source/browser-loader.js
+++ b/shells/env/source/browser-loader.js
@@ -81,8 +81,6 @@ export class BrowserLoader extends Loader {
     //  _resolve method allows particles to request remapping of assets paths
     //  for use in DOM
     const resolver = this._resolve.bind(this);
-    // TODO(sjmiles): hack to plumb `fetch` into Particle space under node
-    const _fetch = BrowserLoader.fetch || fetch;
     return particleWrapper({
       Particle,
       DomParticle,
@@ -91,8 +89,7 @@ export class BrowserLoader extends Loader {
       TransformationDomParticle,
       resolver,
       log,
-      html,
-      _fetch
+      html
     });
   }
 }

--- a/shells/lib/arc-host.js
+++ b/shells/lib/arc-host.js
@@ -75,13 +75,13 @@ export class ArcHost {
     log('instantiateDefaultRecipe');
     try {
       manifest = await env.parse(manifest);
+      const recipe = manifest.allRecipes[0];
+      const plan = await env.resolve(arc, recipe);
+      if (plan) {
+        this.instantiatePlan(arc, plan);
+      }
     } catch (x) {
       error(x);
-    }
-    const recipe = manifest.allRecipes[0];
-    const plan = await env.resolve(arc, recipe);
-    if (plan) {
-      this.instantiatePlan(arc, plan);
     }
   }
   async instantiatePlan(arc, plan) {

--- a/shells/test/specs/demo-tests.js
+++ b/shells/test/specs/demo-tests.js
@@ -30,12 +30,14 @@ describe('pipes', function() {
   });
   it('receives', async function() {
     await openNewArc(this.test.fullTitle());
-    const bodyguardIsOn = `[title^="Bodyguard is on BBC One"]`;
+    const tvInfo = `[title^="TV show information"]`;
+    //const bodyguardIsOn = `[title^="Bodyguard is on BBC One"]`;
     // TODO(sjmiles): wait for context to prepare, need a signal instead
     await browser.pause(seconds(5));
     await receiveEntity({type: 'tv_show', name: 'bodyguard'});
-    await searchFor('*');
-    await waitFor(bodyguardIsOn);
+    await waitFor(tvInfo);
+    //await searchFor('*');
+    //await waitFor(bodyguardIsOn);
   });
 });
 

--- a/shells/test/utils.js
+++ b/shells/test/utils.js
@@ -12,9 +12,10 @@ I'm still a newb, but I stumbled on these things:
 */
 
 exports.seconds = s => s * 1e3;
-
 exports.defaultTimeout = exports.seconds(60);
 exports.shellUrl = `shells/web-shell`;
+
+const storageKey = `firebase://arcs-storage-test.firebaseio.com/AIzaSyBme42moeI-2k8WgXh-6YK_wYyjEXo4Oz8`;
 
 function deepQuerySelector(selector) {
   return browser.execute(function(selector) {
@@ -86,13 +87,14 @@ exports.openNewArc = async function(testTitle, useSolo) {
     browser.close(tabToClose);
   });
   // setup url params
-  //let firebaseKey = new Date().toISOString() + testTitle;
-  //firebaseKey = firebaseKey.replace(/\W+/g, '-').replace(/\./g, '_');
+  const suffix = `${new Date().toISOString()}_${testTitle}`.replace(/\W+/g, '-').replace(/\./g, '_');
+  const storage = `${storageKey}/${suffix}`;
   //console.log(`running test "${testTitle}" with firebaseKey "${firebaseKey}"`);
-  console.log(`running test "${testTitle}"`);
+  console.log(`running test "${testTitle}" [${storage}]`);
   const urlParams = [
     //`testFirebaseKey=${firebaseKey}`,
     //`log`,
+    `storage=${storage}`,
     'user=selenium'
   ];
   if (useSolo) {

--- a/shells/web-shell/elements/pipes/pipe-sinks.js
+++ b/shells/web-shell/elements/pipes/pipe-sinks.js
@@ -1,0 +1,47 @@
+
+export const getEntityManifest = entity => {
+  switch (entity.type) {
+    case 'tv_show':
+      return getTVMazeManifest(entity);
+    case 'artist':
+      return getArtistManifest(entity);
+  }
+};
+
+const getTVMazeManifest = entity => {
+  return `
+import 'https://$particles/Pipes/TVMazePipe.recipes'
+
+resource FindShowResource
+  start
+  [{"name": "${entity.name}"}]
+
+store FindShow of TVMazeFind 'findShow' in FindShowResource
+
+recipe TVShowFindInfo
+  use 'findShow' as find
+  create #piped #tv_show as show
+  TVMazeFindShow
+    find = find
+    show = show
+    `;
+};
+
+const getArtistManifest = entity => {
+  return `
+import 'https://$particles/Music/Artist.recipes'
+
+resource ArtistFindResource
+  start
+  [{"name": "${entity.name}"}]
+
+store FindArtist of ArtistFind 'findArtist' in ArtistFindResource
+
+recipe ArtistFindInfo
+  use 'findArtist' as find
+  create #piped #artist as artist
+  ArtistFinder
+    find = find
+    artist = artist
+    `;
+};

--- a/shells/web-shell/elements/web-arc.js
+++ b/shells/web-shell/elements/web-arc.js
@@ -40,6 +40,8 @@ const template = Xen.Template.html`
  * `manifest` is used by WebArc to add a recipe
  */
 
+// config = {id, [serialization], [manifest]}
+
 export class WebArc extends Xen.Debug(Xen.Async, log) {
   static get observedAttributes() {
     return ['env', 'context', 'storage', 'composer', 'config', 'manifest', 'plan'];

--- a/shells/web-shell/elements/web-planner.js
+++ b/shells/web-shell/elements/web-planner.js
@@ -14,15 +14,9 @@ import {Planificator} from '../../env/arcs.js';
 const log = Xen.logFactory('WebPlanner', '#104a91');
 //const error = Xen.logFactory('WebPlanner', '#104a91', 'error');
 
-// proposed:
-// metaplans -> map of plans, generations
-// metaplan -> map of plans, generations, plan
-// suggestions -> filtered array of (simple-)plans
-// suggestion -> (simple-)plan
-
 class WebPlanner extends Xen.Debug(Xen.Async, log) {
   static get observedAttributes() {
-    return ['env', 'config', 'userid', 'arc', 'suggestion', 'search'];
+    return ['config', 'userid', 'arc', 'search'];
   }
   getInitialState() {
     return {
@@ -57,7 +51,7 @@ class WebPlanner extends Xen.Debug(Xen.Async, log) {
     planificator.registerSuggestionsChangedCallback(current => this._plansChanged(current, planificator.getLastActivatedPlan()));
     planificator.registerVisibleSuggestionsChangedCallback(suggestions => this._suggestionsChanged(suggestions));
     planificator.loadSuggestions && await planificator.loadSuggestions();
-    window.planificator = planificator; // for debugging only
+    window.planificator = window.planificator || planificator; // for debugging only
     return planificator;
   }
   _plansChanged(metaplans, metaplan) {

--- a/shells/web-shell/elements/web-shell.js
+++ b/shells/web-shell/elements/web-shell.js
@@ -77,7 +77,7 @@ const template = Xen.Template.html`
     </div>
   </web-shell-ui>
   <!-- data pipes -->
-  <device-client-pipe env="{{env}}" userid="{{userid}}" context="{{context}}" storage="{{storage}}" on-arc="onPipesArc" metaplans="{{metaplans}}" suggestions="{{suggestions}}" on-search="onState"></device-client-pipe>
+  <device-client-pipe env="{{env}}" userid="{{userid}}" context="{{context}}" storage="{{storage}}" on-arc="onPipesArc" suggestions="{{suggestions}}" on-search="onState" on-client-arc="onPipeClientArc" on-suggestion="onChooseSuggestion" on-spawn="onSpawn" on-reset="onReset"></device-client-pipe>
 `;
 
 const log = Xen.logFactory('WebShell', '#6660ac');
@@ -313,6 +313,43 @@ export class WebShell extends Xen.Debug(Xen.Async, log) {
   onChooseSuggestion(e, suggestion) {
     log('onChooseSuggestion', suggestion);
     this.state = {suggestion};
+  }
+  onPipeClientArc(e, arc) {
+    // TODO(sjmiles): `arc.key` is ad-hoc data from device-client-pipe
+    const key = arc.key;
+    this.recordArcMeta({
+      key: key,
+      href: `?arc=${key}`,
+      description: `Piped Data Arc`,
+      color: 'purple',
+      touched: Date.now()
+    });
+  }
+  onSpawn(e, {id, manifest, description}) {
+    log(id, manifest);
+    const color = ['purple', 'blue', 'green', 'orange', 'brown'][Math.floor(Math.random()*5)];
+    const arcMeta = {
+      key: id,
+      href: `?arc=${id}`,
+      description,
+      color,
+      touched: Date.now()
+    };
+    this.state = {
+      arc: null,
+      arckey: id,
+      arcMeta,
+      // TODO(sjmiles): see web-arc.js for why there are two things called `manifest`
+      arcConfig: {
+        id: id,
+        manifest,
+        suggestionContainer: this.getSuggestionSlot()
+      },
+      manifest: null
+    };
+  }
+  onReset() {
+    this.state = {arckey: null};
   }
 }
 

--- a/shells/web-shell/elements/web-shell.js
+++ b/shells/web-shell/elements/web-shell.js
@@ -118,10 +118,10 @@ export class WebShell extends Xen.Debug(Xen.Async, log) {
       this.waitForStore(10);
     }
     // initialize pipes once we have arcs-store
-    if (state.store && !state.pipesInit) {
-      state.pipesInit = true;
-      this.recordPipesArc(state.userid);
-    }
+    // if (state.store && !state.pipesInit) {
+    //   state.pipesInit = true;
+    //   this.recordPipesArc(state.userid);
+    // }
     if (!state.launcherConfig && state.env && state.userid) {
       // spin up launcher arc
       this.spawnLauncher(state.userid);
@@ -270,17 +270,17 @@ export class WebShell extends Xen.Debug(Xen.Async, log) {
   getSuggestionSlot() {
     return this._dom.$('[slotid="suggestions"]');
   }
-  recordPipesArc(userid) {
-    const pipesKey = `${userid}-pipes`;
-    this.recordArcMeta({
-      key: pipesKey,
-      href: `?arc=${pipesKey}`,
-      description: `Pipes!`,
-      color: 'silver',
-      // pretend to be really old
-      touched: 0 //Date.now()
-    });
-  }
+  // recordPipesArc(userid) {
+  //   const pipesKey = `${userid}-pipes`;
+  //   this.recordArcMeta({
+  //     key: pipesKey,
+  //     href: `?arc=${pipesKey}`,
+  //     description: `Pipes!`,
+  //     color: 'silver',
+  //     // pretend to be really old
+  //     touched: 0 //Date.now()
+  //   });
+  // }
   recordNullArc(userid) {
     const nullKey = `${userid}-null`;
     this.recordArcMeta({

--- a/shells/web-shell/index.html
+++ b/shells/web-shell/index.html
@@ -24,8 +24,8 @@ http://polymer.github.io/PATENTS.txt
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Google+Sans:400,700">
   <link rel="stylesheet" href="../configuration/index.css">
 
-  <script type="module" src="./index.js"></script>
   <script type="module" src="../env/web/arcs.js"></script>
+  <script type="module" src="./index.js"></script>
   <script type="module" src="../configuration/whitelisted.js"></script>
   <script type="module" src="./elements/web-shell.js"></script>
 

--- a/shells/web-shell/index.js
+++ b/shells/web-shell/index.js
@@ -1,7 +1,10 @@
 import {Xen} from '../lib/xen.js';
-
 const params = (new URL(document.location)).searchParams;
-Xen.Debug.level = params.get('logLevel') || (params.has('log') ? 2 : Xen.Debug.level);
+const logLevel = params.get('logLevel') || (params.has('log') ? 2 : Xen.Debug.level);
+Xen.Debug.level = logLevel;
+
+import {Xen as XD} from '../env/arcs.js';
+XD.Debug.level = logLevel;
 
 // configure root path
 Object.assign(document.querySelector('web-shell'), {

--- a/src/platform/log-web.js
+++ b/src/platform/log-web.js
@@ -9,6 +9,6 @@ import {Debug, logFactory as _logFactory} from '../../modalities/dom/components/
 
 const _nopFactory = () => () => {};
 
-// TODO(sjmiles): problem with timing Debug.level or duplicate modules?
-export const logFactory = (...args) => Debug.level < 1 ? _nopFactory() : _logFactory(...args);
-//export const logFactory = _logFactory;
+// TODO(sjmiles): problems with timing Debug.level and duplicate modules
+//export const logFactory = (...args) => Debug.level < 1 ? _nopFactory() : _logFactory(...args);
+export const logFactory = _logFactory;


### PR DESCRIPTION
A mental model that considers DeviceClientPipe as driving the shell UI allows existing suggestion-logic to sort out planning results.

@cromwellian Now the `type` requests are working and the generic `search` is not, which is a reversal. Sorry for any confusion, I'll restore `search` asap.

@cromwellian and @mmandlis The 'tv show' example tends to generate two suggestion iterations, one that is generic (e.g. 'TVShow information') and then moments later a richer suggestion (e.g. 'Star Trek is on USA...`).  I believe we did some work on being able to block descriptions that need asynchronous fetch, but I didn't have the details handy and thought it might be interesting to see how it integrates as is.

working incantations:
```
[id =] ShellApi.receiveEntity(`{"type": "tv_show", "name": "killing eve"}`)
ShellApi.chooseSuggestion(`Killing Eve is on BBC America at 20:00 on Sunday.`)
```
```
[id =] ShellApi.receiveEntity(`{"type": "artist", "name": "stone sour"}`)
ShellApi.chooseSuggestion(`Learn more about Stone Sour.`)
```
not working (yet):
```
ShellApi.receiveEntity(`{"type": "search", "query": "restaurants"}`)
ShellApi.receiveEntity(`{"type": "playRecord", ?}`)
```