### PR TITLE
Fix sigh watch test re-running after build

### DIFF
--- a/tools/sigh.js
+++ b/tools/sigh.js
@@ -619,7 +619,7 @@ async function watch([arg, ...moreArgs]) {
   const funs = steps[arg || 'webpack'];
   const funsAndArgs = funs.map(fun => [fun, fun == funs[funs.length - 1] ? moreArgs : []]);
   const watcher = chokidar.watch('.', {
-    ignored: /(node_modules|\/build\/|\.git)/,
+    ignored: /(node_modules|build\/|\.git)/,
     persistent: true
   });
   let timerId = 0;


### PR DESCRIPTION
Something changed in the way that sigh sees the path for the build directory leading to the watcher not ignoring build files and then the watch command constantly rebuilding.

Removing the '\/' seems to fix this.