### PR TITLE
Move recipe logic from strategies to Recipe class pt.3

### DIFF
--- a/src/runtime/recipe/recipe.ts
+++ b/src/runtime/recipe/recipe.ts
@@ -558,11 +558,6 @@ export class Recipe {
     return this.handles.filter(handle => handle.connections.length === 0);
   }
 
-  getDisconnectedConnections() {
-    return this.handleConnections.filter(
-        hc => hc.handle == null && !hc.isOptional && hc.name !== 'descriptions' && hc.direction !== 'host');
-  }
-
   getFreeConnections() {
     return this.handleConnections.filter(hc => !hc.handle && !hc.isOptional);
   }
@@ -582,15 +577,16 @@ export class Recipe {
     });
   }
 
-  getParticlesByImplFile(particleSet) {
-    return this.particles.filter(particle => particle.spec && particleSet.has(particle.spec.implFile));
+  getParticlesByImplFile(files: Set<string>) {
+    return this.particles.filter(particle => particle.spec && files.has(particle.spec.implFile));
   }
 
   findSlotByID(id) {
     return this.slots.find(s => s.id === id);
   }
 
-  getMatchingConnections() {
-    return this.handleConnections.filter(connection => connection.handle == undefined && connection.name !== 'description');
+  getDisconnectedConnections() {
+    return this.handleConnections.filter(
+        hc => hc.handle == null && !hc.isOptional && hc.name !== 'descriptions' && hc.direction !== 'host');
   }
 }

--- a/src/runtime/recipe/recipe.ts
+++ b/src/runtime/recipe/recipe.ts
@@ -590,7 +590,7 @@ export class Recipe {
     return this.slots.find(s => s.id === id);
   }
 
-  getMachingConnections() {
-    return this.handleConnections.filer(connection => connection.handle == undefined && connection.name !== 'description');
+  getMatchingConnections() {
+    return this.handleConnections.filter(connection => connection.handle == undefined && connection.name !== 'description');
   }
 }

--- a/src/runtime/recipe/recipe.ts
+++ b/src/runtime/recipe/recipe.ts
@@ -582,5 +582,15 @@ export class Recipe {
     });
   }
 
+  getParticlesByImplFile(particleSet) {
+    return this.particles.filter(particle => particle.spec && particleSet.has(particle.spec.implFile));
+  }
 
+  findSlotByID(id) {
+    return this.slots.find(s => s.id === id);
+  }
+
+  getMachingConnections() {
+    return this.handleConnections.filer(connection => connection.handle == undefined && connection.name !== 'description');
+  }
 }

--- a/src/runtime/strategies/init-population.ts
+++ b/src/runtime/strategies/init-population.ts
@@ -19,7 +19,7 @@ export class InitPopulation extends Strategy {
   _contextual: boolean;
   _recipeIndex: RecipeIndex;
   _loadedParticles: Set<string>;
-  
+
   constructor(arc: Arc, {contextual = false, recipeIndex}) {
     super(arc, {contextual});
     this._contextual = contextual;
@@ -68,8 +68,7 @@ export class InitPopulation extends Strategy {
   private _allResults(): ScoredRecipe[] {
     return this._recipeIndex.recipes.map(recipe => ({
       recipe,
-      score: 1 - recipe.particles.filter(
-          particle => particle.spec && this._loadedParticles.has(particle.spec.implFile)).length
+      score: 1 - recipe.getParticlesByImplFile(this._loadedParticles).length
     }));
   }
 }

--- a/src/runtime/strategies/map-slots.ts
+++ b/src/runtime/strategies/map-slots.ts
@@ -55,7 +55,9 @@ export class MapSlots extends Strategy {
       let clonedSlot = recipe.updateToClone({selectedSlot}).selectedSlot;
 
       if (!clonedSlot) {
-        clonedSlot = recipe.slots.find(s => selectedSlot.id && selectedSlot.id === s.id);
+        if (selectedSlot.id) {
+          clonedSlot = recipe.findSlotByID(selectedSlot.id);
+        }
         if (clonedSlot == undefined) {
           clonedSlot = recipe.newSlot(selectedSlot.name);
           clonedSlot.id = selectedSlot.id;

--- a/src/runtime/strategies/match-free-handles-to-connections.ts
+++ b/src/runtime/strategies/match-free-handles-to-connections.ts
@@ -21,7 +21,7 @@ export class MatchFreeHandlesToConnections extends Strategy {
           return;
         }
 
-        const matchingConnections = recipe.getMatchingConnections();
+        const matchingConnections = recipe.getDisconnectedConnections();
 
         return matchingConnections.map(connection => {
           return (recipe, handle) => {

--- a/src/runtime/strategies/match-free-handles-to-connections.ts
+++ b/src/runtime/strategies/match-free-handles-to-connections.ts
@@ -21,7 +21,7 @@ export class MatchFreeHandlesToConnections extends Strategy {
           return;
         }
 
-        const matchingConnections = recipe.handleConnections.filter(connection => connection.handle == undefined && connection.name !== 'descriptions');
+        const matchingConnections = recipe.getMatchingConnections();
 
         return matchingConnections.map(connection => {
           return (recipe, handle) => {


### PR DESCRIPTION
Moved recipe logic from 'init population', 'map slots' and 'match free handles to connections' to the Recipe class.