### PR TITLE
pass options to planificator and update URL params

### DIFF
--- a/shells/lib/user-planner.js
+++ b/shells/lib/user-planner.js
@@ -15,10 +15,11 @@ const log = logFactory('UserPlanner', '#4f0433');
 const warn = logFactory('UserPlanner', '#4f0433', 'warn');
 
 export class UserPlanner {
-  constructor(userid, hostFactory) {
+  constructor(userid, hostFactory, options) {
     this.runners = [];
     this.userid = userid;
     this.hostFactory = hostFactory;
+    this.options = options;
   }
   onArc({add, remove}) {
     //log(add, remove);
@@ -57,9 +58,9 @@ export class UserPlanner {
   async createPlanificator(userid, key, arc) {
     log(`createPlanificator for [${key}]`);
     const options = {
-      //storageKeyBase: config.plannerStorage,
+      storageKeyBase: this.options.plannerStorage,
       //onlyConsumer: config.plannerOnlyConsumer,
-      //debug: config.plannerDebug,
+      debug: this.options.debug,
       userid
     };
     const planificator = await Planificator.create(arc, options);

--- a/shells/planner-shell/index.js
+++ b/shells/planner-shell/index.js
@@ -26,4 +26,6 @@ if (!userId) {
   console.log(`No ARCS_USER_ID environment variable, using default:\n\t[${userId}]`);
 }
 
-PlannerShellInterface.start('../../', storage, userId, debug);
+const plannerStorage = process.env['ARCS_PLANNER_STORAGE'];
+
+PlannerShellInterface.start('../../', storage, userId, {plannerStorage, debug});

--- a/shells/planner-shell/planner-shell.js
+++ b/shells/planner-shell/planner-shell.js
@@ -45,7 +45,7 @@ export class PlannerShellInterface {
    * @param storageKeyBase Plans will be stored in a key that begins with this prefix.
    *   If not specified use a key based on the Launcher Arc.
    */
-  static async start(assetsPath, storage, userid, debug) {
+  static async start(assetsPath, storage, userid, options) {
     if (!assetsPath || !userid || !storage) {
       throw new Error('assetsPath, userid, and storage required');
     }
@@ -74,7 +74,7 @@ export class PlannerShellInterface {
         return host;
       };
       // instantiate planner
-      userPlanner = new UserPlanner(userid, hostFactory);
+      userPlanner = new UserPlanner(userid, hostFactory, options);
       // subscribe planner to changes in user arcs
       userArcs.subscribe(change => userPlanner.onArc(change));
     }, 4000);

--- a/shells/web-shell/elements/web-config.js
+++ b/shells/web-shell/elements/web-config.js
@@ -56,9 +56,9 @@ export class WebConfig extends Xen.Debug(Xen.Async, log) {
       userid: params.get('user') || localStorage.getItem(Const.LOCALSTORAGE.user),
       arckey: params.get('arc'),
       search: params.get('search') || '',
-      plannerStorage: params.get('plannerStorage') || params.get('plannerStorageKeyBase') || params.get('storageKeyBase'),
+      plannerStorage: params.get('plannerStorage'),
       plannerDebug: params.get('plannerDebug'),
-      plannerOnlyConsumer: params.get('plannerOnlyConsumer') || params.get('onlyConsumer') === 'true',
+      plannerOnlyConsumer: params.get('plannerOnlyConsumer'),
       //urls: window.shellUrls || {},
       //useStorage: !params.has('legacy') && !params.has('legacy-store'),
       //useSerialization: !params.has('legacy')


### PR DESCRIPTION
https://github.com/PolymerLabs/arcs/issues/2413

- removed the keyBase suffix
- 'true' no longer needed for the boolean params
- removed old params support (@sjmiles you suggested we keep backward compatibility, but i don't think any one was using them)
