### PR TITLE
rename mock- modalities and use real object in composers

### DIFF
--- a/src/runtime/arc.ts
+++ b/src/runtime/arc.ts
@@ -103,7 +103,7 @@ export class Arc {
   }
 
   get modality() { 
-    return this.pec.slotComposer && this.pec.slotComposer.modality;
+    return this.pec.slotComposer && this.pec.slotComposer.modality.name;
   }
 
   registerInstantiatePlanCallback(callback: PlanCallback) {

--- a/src/runtime/modality.ts
+++ b/src/runtime/modality.ts
@@ -28,7 +28,7 @@ export class Modality {
     assert(!Modality._modalities[name], `Modality '${name}' already exists`);
     Modality._modalities[name] = new Modality(name, slotConsumerClass, suggestionConsumerClass, descriptionFormatter);
     Modality._modalities[`mock-${name}`] =
-        new Modality(`mock-${name}`, MockSlotDomConsumer, MockSuggestDomConsumer);
+        new Modality(name, MockSlotDomConsumer, MockSuggestDomConsumer);
   }
 
   static init() {

--- a/src/runtime/slot-composer.ts
+++ b/src/runtime/slot-composer.ts
@@ -59,7 +59,7 @@ export class SlotComposer {
     });
   }
 
-  get modality(): string { return this._modality.name; }
+  get modality(): Modality { return this._modality; }
   get consumers(): SlotConsumer[] { return this._consumers; }
   get containerKind(): string { return this._containerKind; }
 

--- a/src/runtime/suggestion-composer.ts
+++ b/src/runtime/suggestion-composer.ts
@@ -13,7 +13,6 @@ import {Suggestion} from './plan/suggestion.js';
 import {SuggestDomConsumer} from './suggest-dom-consumer.js';
 
 export class SuggestionComposer {
-  private _modality: Modality;
   private _container: HTMLElement | undefined; // eg div element.
 
   private readonly _slotComposer: SlotComposer;
@@ -21,14 +20,15 @@ export class SuggestionComposer {
   private _suggestConsumers: SuggestDomConsumer[] = [];
 
   constructor(slotComposer: SlotComposer) {
-    this._modality = Modality.forName(slotComposer.modality);
     this._container = slotComposer.findContainerByName('suggestions');
     this._slotComposer = slotComposer;
   }
 
+  get modality() { return this._slotComposer.modality; }
+
   clear(): void {
     if (this._container) {
-      this._modality.slotConsumerClass.clear(this._container);
+      this.modality.slotConsumerClass.clear(this._container);
     }
     this._suggestConsumers.forEach(consumer => consumer.dispose());
     this._suggestConsumers = [];
@@ -46,7 +46,7 @@ export class SuggestionComposer {
       }
 
       if (this._container) {
-        this._modality.suggestionConsumerClass.render(this._container, suggestion, suggestionContent);
+        this.modality.suggestionConsumerClass.render(this._container, suggestion, suggestionContent);
       }
 
       this._addInlineSuggestion(suggestion, suggestionContent);
@@ -86,7 +86,7 @@ export class SuggestionComposer {
       return;
     }
 
-    const suggestConsumer = new this._modality.suggestionConsumerClass(this._slotComposer.containerKind, suggestion, suggestionContent, (eventlet) => {
+    const suggestConsumer = new this.modality.suggestionConsumerClass(this._slotComposer.containerKind, suggestion, suggestionContent, (eventlet) => {
       const suggestion = this._suggestions.find(s => s.hash === eventlet.data.key);
       suggestConsumer.dispose();
       if (suggestion) {

--- a/src/runtime/test/artifacts/transformations/test-multiplex-slots-particle.js
+++ b/src/runtime/test/artifacts/transformations/test-multiplex-slots-particle.js
@@ -50,7 +50,6 @@ defineParticle(({TransformationDomParticle}) => {
           particle ${hostedParticle.name} in '${hostedParticle.implFile}'
             in Foo foo
             consume ${hostedSlotName}
-            modality mock-dom
 
           recipe
             use '${fooHandle._id}' as handle1

--- a/src/runtime/test/debug/outer-port-attachments-tests.ts
+++ b/src/runtime/test/debug/outer-port-attachments-tests.ts
@@ -66,7 +66,7 @@ describe('OuterPortAttachment', () => {
         name: 'P',
         description: {},
         implFile: 'p.js',
-        modality: ['dom', 'mock-dom'],
+        modality: ['dom'],
         slots: [],
         verbs: [],
         args: [{

--- a/src/runtime/test/particle-api-test.ts
+++ b/src/runtime/test/particle-api-test.ts
@@ -785,7 +785,6 @@ describe('particle-api', () => {
                 particle A in 'A.js'
                   consume content
                     provide detail
-                  modality mock-dom
    
                 recipe
                   slot '\` + hostedSlotId + \`' as hosted
@@ -796,7 +795,6 @@ describe('particle-api', () => {
               await innerArc.loadRecipe(\`
                 particle B in 'B.js'
                   consume detail
-                  modality mock-dom
                 
                 recipe
                   slot '\` + providedSlotIds['a.detail'] + \`' as detail

--- a/src/runtime/test/recipe-descriptions-test.ts
+++ b/src/runtime/test/recipe-descriptions-test.ts
@@ -75,14 +75,14 @@ store BoxesStore of [Box] 'allboxes' in AllBoxes` : ''}
   }
 
   async function generateRecipeDescription(options) {
-    const originalFormatter = Modality.forName('mock-dom').descriptionFormatter;
-    Modality.forName('mock-dom').descriptionFormatter = options.formatter;
+    const originalFormatter = Modality.forName('dom').descriptionFormatter;
+    Modality.forName('dom').descriptionFormatter = options.formatter;
     const helper = await TestHelper.createAndPlan({
       manifestString: options.manifestString || createManifestString(options), loader
     });
     assert.lengthOf(helper.suggestions, 1);
-    Modality.forName('mock-dom').descriptionFormatter = originalFormatter;
-    return helper.suggestions[0].getDescription('mock-dom');
+    Modality.forName('dom').descriptionFormatter = originalFormatter;
+    return helper.suggestions[0].getDescription('dom');
   }
   async function testRecipeDescription(options, expectedDescription) {
     const description = await generateRecipeDescription(options);

--- a/src/runtime/test/slot-composer-tests.ts
+++ b/src/runtime/test/slot-composer-tests.ts
@@ -224,11 +224,9 @@ recipe
                 particle A in 'A.js'
                   consume content
                     provide detail
-                  modality mock-dom
                 
                 particle B in 'B.js'
                   consume detail
-                  modality mock-dom
                 
                 recipe
                   slot '\` + hostedSlotId + \`' as hosted

--- a/src/runtime/test/strategies/resolve-recipe-test.js
+++ b/src/runtime/test/strategies/resolve-recipe-test.js
@@ -182,7 +182,7 @@ describe('resolve recipe', function() {
         start
         []
     `);
-    const arc = StrategyTestHelper.createTestArc('test-plan-arc', context, 'mock');
+    const arc = StrategyTestHelper.createTestArc('test-plan-arc', context, 'mock-dom');
 
     // Separating context from the recipe as otherwise
     // manifest parser maps to storage all by itself itself.
@@ -226,7 +226,7 @@ describe('resolve recipe', function() {
           param <- h0
     `);
 
-    const arc = StrategyTestHelper.createTestArc('test-plan-arc', manifest, 'mock');
+    const arc = StrategyTestHelper.createTestArc('test-plan-arc', manifest, 'mock-dom');
 
     const Car = manifest.findSchemaByName('Car').entityClass();
     await arc.createStore(Car.type, /* name= */ null, 'batmobile');

--- a/src/runtime/test/strategies/rulesets-tests.js
+++ b/src/runtime/test/strategies/rulesets-tests.js
@@ -98,7 +98,7 @@ describe('Rulesets', () => {
   });
 
   const planAndComputeStats = async options => {
-    const arc = StrategyTestHelper.createTestArc('test-plan-arc', options.context, 'mock');
+    const arc = StrategyTestHelper.createTestArc('test-plan-arc', options.context, 'mock-dom');
     const planner = new Planner();
     planner.init(arc, options);
     const generations = [];

--- a/src/runtime/test/strategies/strategy-test-helper.js
+++ b/src/runtime/test/strategies/strategy-test-helper.js
@@ -11,6 +11,7 @@
 
 import {Arc} from '../../arc.js';
 import {assert} from '../chai-web.js';
+import {Modality} from '../../modality.js';
 import {RecipeIndex} from '../../recipe-index.js';
 
 export class StrategyTestHelper {
@@ -19,7 +20,7 @@ export class StrategyTestHelper {
       id,
       context,
       slotComposer: {
-        modality,
+        modality: Modality.forName(modality),
         getAvailableContexts: (() => { return [{name: 'root', id: 'r0', tags: ['root'], handles: [], handleConnections: [], spec: {isSet: false}}]; })
       }
     });

--- a/src/runtime/testing/test-helper.js
+++ b/src/runtime/testing/test-helper.js
@@ -43,7 +43,7 @@ export class TestHelper {
     const loader = options.loader || new Loader();
     if (options.manifestFilename) {
       assert(!options.context, 'context should not be provided if manifestFilename is given');
-      options.context = await TestHelper.loadManifest(options.manifestFilename, loader);
+      options.context = await Manifest.load(options.manifestFilename, loader);
     }
     if (options.manifestString) {
       assert(!options.context, 'context should not be provided if manifestString is given');
@@ -67,34 +67,8 @@ export class TestHelper {
     return helper;
   }
 
-  static async loadManifest(manifestFilename, loader) {
-    const manifest = await Manifest.load(manifestFilename, loader);
-    TestHelper._addMockModalities(manifest);
-    return manifest;
-  }
-
   static async parseManifest(manifestString, loader) {
-    const manifest = await Manifest.parse(manifestString, {loader, fileName: ''});
-    TestHelper._addMockModalities(manifest);
-    return manifest;
-  }
-
-  static addParticleMockModality(particleSpec) {
-    const mockModalities = [];
-    for (const modality of particleSpec.modality) {
-      if (!modality.startsWith('mock-')) {
-        mockModalities.push(`mock-${modality}`);
-      }
-    }
-    for (const mockModality of mockModalities) {
-      particleSpec.modality.push(mockModality);
-    }
-  }
-
-  static _addMockModalities(manifest) {
-    for (const particleSpec of manifest.particles) {
-      TestHelper.addParticleMockModality(particleSpec);
-    }
+    return await Manifest.parse(manifestString, {loader, fileName: ''});
   }
 
   /**


### PR DESCRIPTION
fixes remote planner to actually produce suggestions for mock- modality.
https://github.com/PolymerLabs/arcs/issues/2393