### PR TITLE
add `id` to Chooser data model

### DIFF
--- a/particles/Products/source/Chooser.js
+++ b/particles/Products/source/Chooser.js
@@ -130,6 +130,7 @@ defineParticle(({DomParticle, html, resolver, log}) => {
       return data.map((entity, index) =>
         Object.assign(entity.dataClone(), {
           subId: entity.id,
+          id: entity.id,
           image: resolver ? resolver(entity.image) : entity.image,
           index
         })


### PR DESCRIPTION
I filed https://github.com/PolymerLabs/arcs/issues/2471 to revisit this, 
but for now this fixes remote planning for products demo.