### PR TITLE
use FakeSlotComposer everywhere in tests

### DIFF
--- a/src/runtime/test/data-layer-test.js
+++ b/src/runtime/test/data-layer-test.js
@@ -10,8 +10,8 @@
 
 import {assert} from './chai-web.js';
 import {Arc} from '../arc.js';
+import {FakeSlotComposer} from '../testing/fake-slot-composer.js';
 import {Schema} from '../schema.js';
-import {SlotComposer} from '../slot-composer.js';
 import {EntityType} from '../type.js';
 import {handleFor} from '../handle.js';
 
@@ -19,7 +19,7 @@ describe('entity', async function() {
   it('can be created, stored, and restored', async () => {
     const schema = new Schema(['TestSchema'], {value: 'Text'});
 
-    const arc = new Arc({slotComposer: new SlotComposer({rootContainer: 'test', modality: 'mock-dom'}), id: 'test'});
+    const arc = new Arc({slotComposer: new FakeSlotComposer(), id: 'test'});
     const entity = new (schema.entityClass())({value: 'hello world'});
     assert.isDefined(entity);
     const storage = await arc.createStore(new EntityType(schema).collectionOf());

--- a/src/runtime/test/description-test.js
+++ b/src/runtime/test/description-test.js
@@ -15,10 +15,10 @@ import {DescriptionDomFormatter} from '../description-dom-formatter.js';
 import {handleFor} from '../handle.js';
 import {Manifest} from '../manifest.js';
 import {Relevance} from '../relevance.js';
-import {SlotComposer} from '../slot-composer.js';
+import {FakeSlotComposer} from '../testing/fake-slot-composer.js';
 
 function createTestArc() {
-  const slotComposer = new SlotComposer({rootContainer: 'test', modality: 'mock-dom'});
+  const slotComposer = new FakeSlotComposer();
   const arc = new Arc({slotComposer, id: 'test'});
   return arc;
 }

--- a/src/runtime/test/handle-test.js
+++ b/src/runtime/test/handle-test.js
@@ -11,7 +11,6 @@
 
 import {Arc} from '../arc.js';
 import {assert} from './chai-web.js';
-import {SlotComposer} from '../slot-composer.js';
 import {handleFor} from '../handle.js';
 import {EntityType, InterfaceType} from '../type.js';
 import {Manifest} from '../manifest.js';
@@ -19,9 +18,9 @@ import {Loader} from '../loader.js';
 import {Schema} from '../schema.js';
 import {StorageProviderFactory} from '../storage/storage-provider-factory.js';
 import {assertThrowsAsync} from '../testing/test-util.js';
+import {FakeSlotComposer} from '../testing/fake-slot-composer.js';
 
 describe('Handle', function() {
-
   let Bar;
   let loader;
   before(() => {
@@ -29,11 +28,8 @@ describe('Handle', function() {
     loader = new Loader();
   });
 
-  const createSlotComposer = () => new SlotComposer({rootContainer: 'test', modality: 'mock-dom'});
-
   it('clear singleton store', async () => {
-    const slotComposer = createSlotComposer();
-    const arc = new Arc({slotComposer, id: 'test'});
+    const arc = new Arc({slotComposer: new FakeSlotComposer(), id: 'test'});
     const barStore = await arc.createStore(Bar.type);
     await barStore.set({id: 'an id', value: 'a Bar'});
     await barStore.clear();
@@ -44,8 +40,7 @@ describe('Handle', function() {
     // NOTE: Until entity mutation is distinct from collection modification,
     // referenceMode stores *can't* ignore duplicate stores of the same
     // entity value.
-    const slotComposer = createSlotComposer();
-    const arc = new Arc({slotComposer, id: 'test'});
+    const arc = new Arc({slotComposer: new FakeSlotComposer(), id: 'test'});
     const store = await arc.createStore(Bar.type);
     let version = 0;
     store.on('change', () => version++, {});
@@ -61,8 +56,7 @@ describe('Handle', function() {
   });
 
   it('ignores duplicate stores of the same entity value (collection)', async () => {
-    const slotComposer = createSlotComposer();
-    const arc = new Arc({slotComposer, id: 'test'});
+    const arc = new Arc({slotComposer: new FakeSlotComposer(), id: 'test'});
     const barStore = await arc.createStore(Bar.type.collectionOf());
     let version = 0;
     barStore.on('change', ({add: [{effective}]}) => {if (effective) version++;}, {});
@@ -79,8 +73,7 @@ describe('Handle', function() {
   });
 
   it('dedupes common user-provided ids', async () => {
-    const slotComposer = createSlotComposer();
-    const arc = new Arc({slotComposer, id: 'test'});
+    const arc = new Arc({slotComposer: new FakeSlotComposer(), id: 'test'});
 
     const manifest = await Manifest.load('./src/runtime/test/artifacts/test-particles.manifest', loader);
     const Foo = manifest.schemas.Foo.entityClass();
@@ -93,8 +86,7 @@ describe('Handle', function() {
   });
 
   it('allows updates with same user-provided ids but different value (collection)', async () => {
-    const slotComposer = createSlotComposer();
-    const arc = new Arc({slotComposer, id: 'test'});
+    const arc = new Arc({slotComposer: new FakeSlotComposer(), id: 'test'});
 
     const manifest = await Manifest.load('./src/runtime/test/artifacts/test-particles.manifest', loader);
     const Foo = manifest.schemas.Foo.entityClass();
@@ -107,8 +99,7 @@ describe('Handle', function() {
   });
 
   it('allows updates with same user-provided ids but different value (variable)', async () => {
-    const slotComposer = createSlotComposer();
-    const arc = new Arc({slotComposer, id: 'test'});
+    const arc = new Arc({slotComposer: new FakeSlotComposer(), id: 'test'});
 
     const manifest = await Manifest.load('./src/runtime/test/artifacts/test-particles.manifest', loader);
     const Foo = manifest.schemas.Foo.entityClass();
@@ -121,8 +112,7 @@ describe('Handle', function() {
   });
 
   it('remove entry from store', async () => {
-    const slotComposer = createSlotComposer();
-    const arc = new Arc({slotComposer, id: 'test'});
+    const arc = new Arc({slotComposer: new FakeSlotComposer(), id: 'test'});
     const barStore = await arc.createStore(Bar.type.collectionOf());
     const bar = new Bar({id: 0, value: 'a Bar'});
     barStore.store(bar, ['key1']);
@@ -131,8 +121,7 @@ describe('Handle', function() {
   });
 
   it('can store a particle in an interface store', async () => {
-    const slotComposer = createSlotComposer();
-    const arc = new Arc({slotComposer, id: 'test'});
+    const arc = new Arc({slotComposer: new FakeSlotComposer(), id: 'test'});
     const manifest = await Manifest.load('./src/runtime/test/artifacts/test-particles.manifest', loader);
 
     const iface = InterfaceType.make('Test', [
@@ -147,8 +136,7 @@ describe('Handle', function() {
   });
 
   it('createHandle only allows valid tags & types in stores', async () => {
-    const slotComposer = createSlotComposer();
-    const arc = new Arc({slotComposer, id: 'test'});
+    const arc = new Arc({slotComposer: new FakeSlotComposer(), id: 'test'});
     const manifest = await Manifest.load('./src/runtime/test/artifacts/test-particles.manifest', loader);
 
     await assertThrowsAsync(async () => await arc.createStore('not a type'), /isn't a Type/);

--- a/src/runtime/test/multiplexer-test.js
+++ b/src/runtime/test/multiplexer-test.js
@@ -14,8 +14,8 @@ import {Arc} from '../arc.js';
 import {Loader} from '../loader.js';
 import {Manifest} from '../manifest.js';
 import {SlotConsumer} from '../slot-consumer.js';
-import {SlotComposer} from '../slot-composer.js';
 import {SlotDomConsumer} from '../slot-dom-consumer.js';
+import {FakeSlotComposer} from '../testing/fake-slot-composer.js';
 import {MockSlotDomConsumer} from '../testing/mock-slot-dom-consumer.js';
 import {HostedSlotConsumer} from '../hosted-slot-consumer.js';
 import {TestHelper} from '../testing/test-helper.js';
@@ -42,7 +42,7 @@ describe('Multiplexer', function() {
 
     const barType = manifest.findTypeByName('Bar');
 
-    const slotComposer = new SlotComposer({modality: 'mock-dom', rootContainer: {'slotid': 'dummy-container'}});
+    const slotComposer = new FakeSlotComposer({rootContainer: {'slotid': 'dummy-container'}});
 
     const slotComposer_createHostedSlot = slotComposer.createHostedSlot;
 

--- a/src/runtime/test/planner-tests.js
+++ b/src/runtime/test/planner-tests.js
@@ -24,7 +24,7 @@ async function planFromManifest(manifest, {arcFactory, testSteps}={}) {
     manifest = await Manifest.parse(manifest, {loader, fileName});
   }
 
-  arcFactory = arcFactory || ((manifest) => StrategyTestHelper.createTestArc('test', manifest, 'dom'));
+  arcFactory = arcFactory || ((manifest) => StrategyTestHelper.createTestArc(manifest));
   testSteps = testSteps || ((planner) => planner.plan(Infinity, []));
 
   const arc = await arcFactory(manifest);
@@ -176,7 +176,7 @@ ${recipeManifest}
     manifest.createStore(schema.type.collectionOf(), 'Test2', 'test-2', ['tag2']);
     manifest.createStore(schema.type.collectionOf(), 'Test2', 'test-3', []);
 
-    const arc = StrategyTestHelper.createTestArc('test-plan-arc', manifest, 'dom');
+    const arc = StrategyTestHelper.createTestArc(manifest);
 
     const planner = new Planner();
     const options = {strategyArgs: StrategyTestHelper.createTestStrategyArgs(arc)};
@@ -342,7 +342,7 @@ describe('Type variable resolution', function() {
     };
     const manifest = (await Manifest.parse(manifestStr, {loader}));
 
-    const arc = StrategyTestHelper.createTestArc('test-plan-arc', manifest, 'dom');
+    const arc = StrategyTestHelper.createTestArc(manifest);
     const planner = new Planner();
     const options = {strategyArgs: StrategyTestHelper.createTestStrategyArgs(arc)};
     planner.init(arc, options);
@@ -570,7 +570,7 @@ describe('Automatic resolution', function() {
   const loadAndPlan = async (manifestStr, arcCreatedCallback) => {
     return planFromManifest(manifestStr, {
       arcFactory: async manifest => {
-        const arc = StrategyTestHelper.createTestArc('test', manifest, 'dom');
+        const arc = StrategyTestHelper.createTestArc(manifest);
         if (arcCreatedCallback) await arcCreatedCallback(arc, manifest);
         return arc;
       }
@@ -723,7 +723,7 @@ describe('Automatic resolution', function() {
     assert.equal(composedRecipes[0].toString(), `recipe
   create #items as handle0 // [Thing {}]
   create #selected as handle1 // Thing {}
-  slot 'r0' #root as slot1
+  slot 'rootslotid-root' #root as slot1
   ItemMultiplexer as particle0
     hostedParticle = ThingRenderer
     list <- handle0
@@ -759,7 +759,7 @@ describe('Automatic resolution', function() {
     assert.equal(recipes[0].toString(), `recipe SelectableUseListRecipe
   use 'test-store' #items as handle0 // [Thing {}]
   create #selected as handle1 // Thing {}
-  slot 'r0' #root as slot1
+  slot 'rootslotid-root' #root as slot1
   ItemMultiplexer as particle0
     hostedParticle = ThingRenderer
     list <- handle0

--- a/src/runtime/test/runtime-tests.js
+++ b/src/runtime/test/runtime-tests.js
@@ -11,14 +11,13 @@
 import {assert} from './chai-web.js';
 import {Arc} from '../arc.js';
 import {Description} from '../description.js';
+import {FakeSlotComposer} from '../testing/fake-slot-composer';
 import {Loader} from '../loader.js';
 import {Manifest} from '../manifest.js';
 import {Runtime} from '../runtime.js';
-import {SlotComposer} from '../slot-composer.js';
 
 function createTestArc() {
-  const slotComposer = new SlotComposer({rootContainer: 'test', modality: 'mock-dom'});
-  const arc = new Arc({slotComposer, id: 'test'});
+  const arc = new Arc({slotComposer: new FakeSlotComposer(), id: 'test'});
   return arc;
 }
 

--- a/src/runtime/test/strategies/add-missing-handles-test.ts
+++ b/src/runtime/test/strategies/add-missing-handles-test.ts
@@ -18,9 +18,8 @@ async function runStrategy(manifestStr) {
   const manifest = await Manifest.parse(manifestStr);
   const recipes = manifest.recipes;
   recipes.forEach(recipe => recipe.normalize());
-  const arc = StrategyTestHelper.createTestArc('test-plan-arc', manifest, 'dom');
   const inputParams = {generated: recipes.map(recipe => ({result: recipe, score: 1}))};
-  const strategy = new AddMissingHandles(arc);
+  const strategy = new AddMissingHandles(StrategyTestHelper.createTestArc(manifest));
   return (await strategy.generate(inputParams)).map(r => r.result);
 }
 

--- a/src/runtime/test/strategies/coalesce-recipes-test.js
+++ b/src/runtime/test/strategies/coalesce-recipes-test.js
@@ -19,9 +19,9 @@ async function tryCoalesceRecipes(manifestStr) {
   const recipes = manifest.recipes;
   assert.isTrue(recipes.every(recipe => recipe.normalize()));
   assert.isFalse(recipes.every(recipe => recipe.isResolved()));
-  const arc = StrategyTestHelper.createTestArc('test-plan-arc', manifest, 'dom');
-  const inputParams = {generated: [], terminal: recipes.map(recipe => ({result: recipe, score: 1}))};
+  const arc = StrategyTestHelper.createTestArc(manifest);
   const strategy = new CoalesceRecipes(arc, StrategyTestHelper.createTestStrategyArgs(arc));
+  const inputParams = {generated: [], terminal: recipes.map(recipe => ({result: recipe, score: 1}))};
   return await strategy.generate(inputParams);
 }
 async function doNotCoalesceRecipes(manifestStr) {

--- a/src/runtime/test/strategies/find-hosted-particle-tests.js
+++ b/src/runtime/test/strategies/find-hosted-particle-tests.js
@@ -21,9 +21,8 @@ async function runStrategy(manifestStr) {
   const manifest = await Manifest.parse(manifestStr);
   const recipes = manifest.recipes;
   recipes.forEach(recipe => recipe.normalize());
-  const arc = StrategyTestHelper.createTestArc('test-arc', manifest, 'dom');
   const inputParams = {generated: recipes.map(recipe => ({result: recipe, score: 1}))};
-  const strategy = new FindHostedParticle(arc);
+  const strategy = new FindHostedParticle(StrategyTestHelper.createTestArc(manifest));
   return (await strategy.generate(inputParams)).map(r => r.result);
 }
 

--- a/src/runtime/test/strategies/init-population-tests.js
+++ b/src/runtime/test/strategies/init-population-tests.js
@@ -121,7 +121,7 @@ describe('InitPopulation', async () => {
           burger -> burger
     `);
 
-    const arc = StrategyTestHelper.createTestArc('test-plan-arc', manifest, 'dom');
+    const arc = StrategyTestHelper.createTestArc(manifest);
 
     async function openRestaurantWith(foodType) {
       const restaurant = manifest.recipes.find(recipe => recipe.name === `${foodType}Restaurant`);

--- a/src/runtime/test/strategies/map-slots-tests.js
+++ b/src/runtime/test/strategies/map-slots-tests.js
@@ -10,6 +10,7 @@
 'use strict';
 
 import {Arc} from '../../arc.js';
+import {FakeSlotComposer} from '../../testing/fake-slot-composer.js';
 import {Manifest} from '../../manifest.js';
 import {StrategyTestHelper} from './strategy-test-helper.js';
 import {MapSlots} from '../../strategies/map-slots.js';
@@ -30,7 +31,7 @@ ${particlesSpec}
 
 ${recipeManifest}
     `));
-    const arc = StrategyTestHelper.createTestArc('test-plan-arc', manifest, 'dom');
+    const arc = StrategyTestHelper.createTestArc(manifest);
     const recipe = await runMapSlotsAndResolveRecipe(arc, manifest.recipes[0]);
 
     if (expectedSlots >= 0) {
@@ -104,7 +105,7 @@ ${recipeManifest}
         A
     `));
 
-    const arc = StrategyTestHelper.createTestArc('test-plan-arc', manifest, 'dom');
+    const arc = StrategyTestHelper.createTestArc(manifest);
     await StrategyTestHelper.onlyResult(arc, ResolveRecipe, manifest.recipes[0]);
   });
 
@@ -127,7 +128,7 @@ ${recipeManifest}
         C
     `));
     const inputParams = {generated: [{result: manifest.recipes[0], score: 1}]};
-    const arc = StrategyTestHelper.createTestArc('test-plan-arc', manifest, 'dom');
+    const arc = StrategyTestHelper.createTestArc(manifest);
 
     const strategy = new MapSlots(arc);
     let results = await strategy.generate(inputParams);
@@ -150,13 +151,10 @@ ${recipeManifest}
 
   it('prefers local slots if available', async () => {
     // Arc has both a 'root' and an 'action' slot.
-    const arc = new Arc({id: 'test-plan-arc', slotComposer: {
-      modality: 'dom',
-      getAvailableContexts: (() => [
-        {name: 'root', id: 'r0', tags: ['#root'], handles: [], handleConnections: [], spec: {isSet: false}},
-        {name: 'action', id: 'r1', tags: ['#remote'], handles: [], handleConnections: [], spec: {isSet: false}},
-      ])
-    }});
+    const arc = new Arc({
+      id: 'test-plan-arc',
+      slotComposer: new FakeSlotComposer({containers: {root: {}, action: {}}})
+    });
 
     const particles = `
       particle A in 'A.js'
@@ -184,7 +182,7 @@ ${recipeManifest}
     await assertActionSlotTags(`
       recipe
         B`,
-      ['#remote']);
+      ['action']);
 
     // 'action' slot of particle B will bind to the local slot
     // provided by particle A if available.

--- a/src/runtime/test/strategies/match-particle-by-verb-tests.js
+++ b/src/runtime/test/strategies/match-particle-by-verb-tests.js
@@ -50,7 +50,7 @@ describe('MatchParticleByVerb', function() {
 
   it('particles by verb strategy', async () => {
     const manifest = (await Manifest.parse(manifestStr));
-    const arc = StrategyTestHelper.createTestArc('test-plan-arc', manifest, 'dom');
+    const arc = StrategyTestHelper.createTestArc(manifest);
     // Apply MatchParticleByVerb strategy.
     const inputParams = {generated: [{result: manifest.recipes[0], score: 1}]};
     const mpv = new MatchParticleByVerb(arc, StrategyTestHelper.createTestStrategyArgs(arc));
@@ -66,7 +66,7 @@ describe('MatchParticleByVerb', function() {
     recipe.handles[0].mapToStorage({id: 'test1', type: manifest.findSchemaByName('Height').entityClass().type});
     recipe.handles[1].mapToStorage({id: 'test2', type: manifest.findSchemaByName('Energy').entityClass().type});
 
-    const arc = StrategyTestHelper.createTestArc('test-plan-arc', manifest, 'dom');
+    const arc = StrategyTestHelper.createTestArc(manifest);
 
     // Apply all strategies to resolve recipe where particles are referenced by verbs.
     const planner = new Planner();

--- a/src/runtime/test/strategies/match-recipe-by-verb-tests.ts
+++ b/src/runtime/test/strategies/match-recipe-by-verb-tests.ts
@@ -37,7 +37,7 @@ describe('MatchRecipeByVerb', () => {
         JumpingBoots.e <- NuclearReactor.e
     `);
 
-    const arc = StrategyTestHelper.createTestArc('test-plan-arc', manifest, 'dom');
+    const arc = StrategyTestHelper.createTestArc(manifest);
     const inputParams = {generated: [{result: manifest.recipes[0], score: 1}]};
     const mrv = new MatchRecipeByVerb(arc);
     const results = await mrv.generate(inputParams);
@@ -61,7 +61,7 @@ describe('MatchRecipeByVerb', () => {
         P
     `);
 
-    const arc = StrategyTestHelper.createTestArc('test-plan-arc', manifest, 'dom');
+    const arc = StrategyTestHelper.createTestArc(manifest);
     const inputParams = {generated: [{result: manifest.recipes[0], score: 1}]};
     const mrv = new MatchRecipeByVerb(arc);
     let results = await mrv.generate(inputParams);
@@ -124,7 +124,7 @@ describe('MatchRecipeByVerb', () => {
         * -> handle0
     `);
 
-    const arc = StrategyTestHelper.createTestArc('test-plan-arc', manifest, 'dom');
+    const arc = StrategyTestHelper.createTestArc(manifest);
     let inputParams = {generated: [{result: manifest.recipes[4], score: 1}]};
     const mrv = new MatchRecipeByVerb(arc);
     let results = await mrv.generate(inputParams);
@@ -188,7 +188,7 @@ describe('MatchRecipeByVerb', () => {
             provide bar
     `);
 
-    const arc = StrategyTestHelper.createTestArc('test-plan-arc', manifest, 'dom');
+    const arc = StrategyTestHelper.createTestArc(manifest);
     let inputParams = {generated: [{result: manifest.recipes[3], score: 1}]};
     const mrv = new MatchRecipeByVerb(arc);
     let results = await mrv.generate(inputParams);
@@ -228,7 +228,7 @@ describe('MatchRecipeByVerb', () => {
           b -> handle0
     `);
 
-    const arc = StrategyTestHelper.createTestArc('test-plan-arc', manifest, 'dom');
+    const arc = StrategyTestHelper.createTestArc(manifest);
     const inputParams = {generated: [{result: manifest.recipes[1], score: 1}]};
     const mrv = new MatchRecipeByVerb(arc);
     const results = await mrv.generate(inputParams);
@@ -258,7 +258,7 @@ describe('MatchRecipeByVerb', () => {
           b -> handle0
     `);
 
-    const arc = StrategyTestHelper.createTestArc('test-plan-arc', manifest, 'dom');
+    const arc = StrategyTestHelper.createTestArc(manifest);
     const inputParams = {generated: [{result: manifest.recipes[1], score: 1}]};
     const mrv = new MatchRecipeByVerb(arc);
     const results = await mrv.generate(inputParams);
@@ -295,7 +295,7 @@ describe('MatchRecipeByVerb', () => {
           b -> handle0
     `);
 
-    const arc = StrategyTestHelper.createTestArc('test-plan-arc', manifest, 'dom');
+    const arc = StrategyTestHelper.createTestArc(manifest);
     const inputParams = {generated: [{result: manifest.recipes[1], score: 1}]};
     const mrv = new MatchRecipeByVerb(arc);
     const results = await mrv.generate(inputParams);
@@ -333,7 +333,7 @@ describe('MatchRecipeByVerb', () => {
             provide foo as s0
     `);
 
-    const arc = StrategyTestHelper.createTestArc('test-plan-arc', manifest, 'dom');
+    const arc = StrategyTestHelper.createTestArc(manifest);
     let inputParams = {generated: [{result: manifest.recipes[1], score: 1}]};
     const mrv = new MatchRecipeByVerb(arc);
     let results = await mrv.generate(inputParams);
@@ -388,7 +388,7 @@ describe('MatchRecipeByVerb', () => {
         consume foo as s0
   `);
 
-  const arc = StrategyTestHelper.createTestArc('test-plan-arc', manifest, 'dom');
+  const arc = StrategyTestHelper.createTestArc(manifest);
   let inputParams = {generated: [{result: manifest.recipes[1], score: 1}]};
   const mrv = new MatchRecipeByVerb(arc);
   let results = await mrv.generate(inputParams);

--- a/src/runtime/test/strategies/resolve-recipe-test.js
+++ b/src/runtime/test/strategies/resolve-recipe-test.js
@@ -36,11 +36,10 @@ describe('resolve recipe', function() {
         []
     `);
 
-    const arc = createTestArc('test-plan-arc', manifest, 'dom');
     const [recipe] = manifest.recipes;
     assert.isTrue(recipe.normalize());
 
-    await noResult(arc, ResolveRecipe, recipe);
+    await noResult(createTestArc(manifest), ResolveRecipe, recipe);
   });
 
   it('resolves a mapping of a handle with a less specific entity type', async () => {
@@ -64,11 +63,10 @@ describe('resolve recipe', function() {
         []
     `);
 
-    const arc = createTestArc('test-plan-arc', manifest, 'dom');
     let [recipe] = manifest.recipes;
     assert.isTrue(recipe.normalize());
 
-    recipe = await onlyResult(arc, ResolveRecipe, recipe);
+    recipe = await onlyResult(createTestArc(manifest), ResolveRecipe, recipe);
     assert.isTrue(recipe.isResolved());
   });
 
@@ -93,11 +91,10 @@ describe('resolve recipe', function() {
         []
     `);
 
-    const arc = createTestArc('test-plan-arc', manifest, 'dom');
     let [recipe] = manifest.recipes;
     assert.isTrue(recipe.normalize());
 
-    recipe = await onlyResult(arc, ResolveRecipe, recipe);
+    recipe = await onlyResult(createTestArc(manifest), ResolveRecipe, recipe);
     assert.isTrue(recipe.isResolved());
   });
 
@@ -122,11 +119,10 @@ describe('resolve recipe', function() {
         []
     `);
 
-    const arc = createTestArc('test-plan-arc', manifest, 'dom');
     let [recipe] = manifest.recipes;
     assert.isTrue(recipe.normalize());
 
-    recipe = await onlyResult(arc, ResolveRecipe, recipe);
+    recipe = await onlyResult(createTestArc(manifest), ResolveRecipe, recipe);
     assert.isTrue(recipe.isResolved());
   });
 
@@ -140,11 +136,9 @@ describe('resolve recipe', function() {
         A
     `));
     let [recipe] = manifest.recipes;
-    const arc = createTestArc('test-plan-arc', manifest, 'dom');
     assert.isTrue(recipe.normalize());
 
-
-    recipe = await onlyResult(arc, ResolveRecipe, recipe);
+    recipe = await onlyResult(createTestArc(manifest), ResolveRecipe, recipe);
     assert.isTrue(recipe.isResolved());
   });
 
@@ -160,9 +154,8 @@ describe('resolve recipe', function() {
         B
           consume info #detail
     `));
-    const arc = StrategyTestHelper.createTestArc('test-plan-arc', manifest, 'dom');
 
-    const strategy = new ResolveRecipe(arc);
+    const strategy = new ResolveRecipe(createTestArc(manifest));
     const results = await strategy.generate({generated: [{result: manifest.recipes[0], score: 1}]});
     assert.lengthOf(results, 1);
 
@@ -182,7 +175,6 @@ describe('resolve recipe', function() {
         start
         []
     `);
-    const arc = StrategyTestHelper.createTestArc('test-plan-arc', context, 'mock-dom');
 
     // Separating context from the recipe as otherwise
     // manifest parser maps to storage all by itself itself.
@@ -202,7 +194,7 @@ describe('resolve recipe', function() {
     recipe.normalize();
     assert.isUndefined(recipe.handles[0].storageKey);
 
-    const strategy = new ResolveRecipe(arc);
+    const strategy = new ResolveRecipe(createTestArc(context));
     const results = await strategy.generate({generated: [{result: recipe, score: 1}]});
     assert.lengthOf(results, 1);
 
@@ -226,7 +218,7 @@ describe('resolve recipe', function() {
           param <- h0
     `);
 
-    const arc = StrategyTestHelper.createTestArc('test-plan-arc', manifest, 'mock-dom');
+    const arc = createTestArc(manifest);
 
     const Car = manifest.findSchemaByName('Car').entityClass();
     await arc.createStore(Car.type, /* name= */ null, 'batmobile');

--- a/src/runtime/test/strategies/rulesets-tests.js
+++ b/src/runtime/test/strategies/rulesets-tests.js
@@ -98,7 +98,7 @@ describe('Rulesets', () => {
   });
 
   const planAndComputeStats = async options => {
-    const arc = StrategyTestHelper.createTestArc('test-plan-arc', options.context, 'mock-dom');
+    const arc = StrategyTestHelper.createTestArc(options.context);
     const planner = new Planner();
     planner.init(arc, options);
     const generations = [];

--- a/src/runtime/test/strategies/search-tokens-to-handles-test.ts
+++ b/src/runtime/test/strategies/search-tokens-to-handles-test.ts
@@ -35,7 +35,7 @@ describe('SearchTokensToHandles', () => {
         [{}]
     `));
 
-    const arc = StrategyTestHelper.createTestArc('test-plan-arc', manifest, 'dom');
+    const arc = StrategyTestHelper.createTestArc(manifest);
     arc._registerStore(arc._context.stores[0], ['mything']);
 
     const recipe = manifest.recipes[0];
@@ -75,7 +75,7 @@ recipe
     inFoos <- h0
     outFoo -> h1
     `, {loader, fileName: ''}));
-    const arc = StrategyTestHelper.createTestArc('test-plan-arc', manifest, 'dom');
+    const arc = StrategyTestHelper.createTestArc(manifest);
     arc._context.imports.push(storeManifest);
     const recipe = manifest.recipes[0];
     assert(recipe.normalize());

--- a/src/runtime/test/strategies/search-tokens-to-particles-tests.ts
+++ b/src/runtime/test/strategies/search-tokens-to-particles-tests.ts
@@ -25,7 +25,7 @@ describe('SearchTokensToParticles', () => {
       recipe
         search \`jump or fly or run and rester\`
     `));
-    const arc = StrategyTestHelper.createTestArc('test-plan-arc', manifest, 'dom');
+    const arc = StrategyTestHelper.createTestArc(manifest);
     const recipe = manifest.recipes[0];
     assert(recipe.normalize());
     assert(!recipe.isResolved());
@@ -50,7 +50,7 @@ describe('SearchTokensToParticles', () => {
       recipe
         search \`galaxy flyer\`
     `));
-    const arc = StrategyTestHelper.createTestArc('test-plan-arc', manifest, 'dom');
+    const arc = StrategyTestHelper.createTestArc(manifest);
     const recipes = manifest.recipes;
     recipes.forEach(recipe => {
       assert(recipe.normalize());
@@ -77,7 +77,7 @@ describe('SearchTokensToParticles', () => {
       recipe
         search \`galaxy running and more\`
     `));
-    const arc = StrategyTestHelper.createTestArc('test-plan-arc', manifest, 'dom');
+    const arc = StrategyTestHelper.createTestArc(manifest);
     const recipe = manifest.recipes[1];
     assert(recipe.normalize());
     assert(!recipe.isResolved());
@@ -106,7 +106,7 @@ describe('SearchTokensToParticles', () => {
       recipe
         search \`jump and flight\`
     `));
-    const arc = StrategyTestHelper.createTestArc('test-plan-arc', manifest, 'dom');
+    const arc = StrategyTestHelper.createTestArc(manifest);
     const recipes = manifest.recipes.slice(1);
     recipes.forEach((recipe, index) => {
       assert(recipe.normalize());

--- a/src/runtime/test/strategies/strategy-sequence-test.ts
+++ b/src/runtime/test/strategies/strategy-sequence-test.ts
@@ -37,7 +37,7 @@ describe('A Strategy Sequence', () => {
     `);
 
     let recipe = manifest.recipes[1];
-    const arc = createTestArc('test-plan-arc', manifest, 'dom');
+    const arc = createTestArc(manifest);
 
     recipe = await onlyResult(arc, MatchRecipeByVerb, recipe);
     recipe = await onlyResult(arc, ResolveRecipe, recipe);
@@ -69,7 +69,7 @@ describe('A Strategy Sequence', () => {
     `);
 
     let recipe = manifest.recipes[1];
-    const arc = createTestArc('test-plan-arc', manifest, 'dom');
+    const arc = createTestArc(manifest);
 
     recipe = await onlyResult(arc, MatchRecipeByVerb, recipe);
     recipe = await onlyResult(arc, ConvertConstraintsToConnections, recipe);
@@ -107,7 +107,7 @@ describe('A Strategy Sequence', () => {
     `);
 
     let recipe = manifest.recipes[1];
-    const arc = createTestArc('test-plan-arc', manifest, 'dom');
+    const arc = createTestArc(manifest);
 
     recipe = await onlyResult(arc, MatchRecipeByVerb, recipe);
     recipe = await onlyResult(arc, ConvertConstraintsToConnections, recipe);
@@ -206,7 +206,7 @@ describe('A Strategy Sequence', () => {
     `);
 
     let recipe = manifest.recipes[1];
-    const arc = createTestArc('test-plan-arc', manifest, 'dom');
+    const arc = createTestArc(manifest);
 
     recipe = await onlyResult(arc, MatchRecipeByVerb, recipe);
     const recipes = await theResults(arc, ConvertConstraintsToConnections, recipe);
@@ -225,7 +225,7 @@ describe('A Strategy Sequence', () => {
     `);
 
     let recipe = manifest.recipes[0];
-    const arc = createTestArc('test-plan-arc', manifest, 'dom');
+    const arc = createTestArc(manifest);
 
     recipe = await onlyResult(arc, ConvertConstraintsToConnections, recipe);
     recipe = await onlyResult(arc, CreateHandleGroup, recipe);
@@ -246,7 +246,7 @@ describe('A Strategy Sequence', () => {
     `);
 
     let recipe = manifest.recipes[0];
-    const arc = createTestArc('test-plan-arc', manifest, 'dom');
+    const arc = createTestArc(manifest);
 
     recipe = await onlyResult(arc, ConvertConstraintsToConnections, recipe);
     await noResult(arc, ResolveRecipe, recipe);
@@ -269,7 +269,7 @@ describe('A Strategy Sequence', () => {
     `);
 
     let recipe = manifest.recipes[0];
-    const arc = createTestArc('test-plan-arc', manifest, 'dom');
+    const arc = createTestArc(manifest);
 
     recipe = await onlyResult(arc, ConvertConstraintsToConnections, recipe);
     recipe = await onlyResult(arc, CreateHandleGroup, recipe);

--- a/src/runtime/test/strategies/strategy-test-helper.js
+++ b/src/runtime/test/strategies/strategy-test-helper.js
@@ -13,16 +13,14 @@ import {Arc} from '../../arc.js';
 import {assert} from '../chai-web.js';
 import {Modality} from '../../modality.js';
 import {RecipeIndex} from '../../recipe-index.js';
+import {FakeSlotComposer} from '../../testing/fake-slot-composer.js';
 
 export class StrategyTestHelper {
-  static createTestArc(id, context, modality) {
+  static createTestArc(context, options = {}) {
     return new Arc({
-      id,
+      id: options.arcId || 'test-arc',
       context,
-      slotComposer: {
-        modality: Modality.forName(modality),
-        getAvailableContexts: (() => { return [{name: 'root', id: 'r0', tags: ['root'], handles: [], handleConnections: [], spec: {isSet: false}}]; })
-      }
+      slotComposer: new FakeSlotComposer(options),
     });
   }
   static createTestStrategyArgs(arc, args) {

--- a/src/runtime/test/suggestion-composer-tests.js
+++ b/src/runtime/test/suggestion-composer-tests.js
@@ -16,7 +16,7 @@ import {TestHelper} from '../testing/test-helper.js';
 
 class TestSuggestionComposer extends SuggestionComposer {
   constructor() {
-    super({modality: 'mock-dom', findContainerByName: () => '<div></div>'});
+    super(new FakeSlotComposer({containers: {suggestions: {}}}));
     this.suggestions = [];
     this.updatesCount = 0;
     this.updateResolve = null;


### PR DESCRIPTION
This is for the purpose of cleaning the tests code, but mainly to reduce the number of places where modalities are used as hardcoded strings: https://github.com/PolymerLabs/arcs/issues/2393