### PR TITLE
Serve standalone DevTools from devtools/ path

### DIFF
--- a/devtools/README.md
+++ b/devtools/README.md
@@ -11,17 +11,21 @@ Open up the Chrome and navigate to `chrome://extensions/`.
 Ensure "Developer Mode" is checked and click the "Load unpacked extension..." button.
 Select `arcs/devtools` directory. `Arcs` tab will be now available in Chrome DevTools.
 
-## Using with NodeJS
+## Using with NodeJS (Tests or Planner Shell)
 
 It is possible to use the tool directly against a NodeJS instance.
 To do that, run a test with `--explore` flag:
 ```
 ./tools/sigh test -g "demo flow" --explore
 ```
+or
+```
+cd shells/planner-shell/ && ./serve.sh --explore
+```
 
 You should see a message `Waiting for Arcs Explorer`.
-Navigate to the `devtools/src/index.html` directory in the browser
-(e.g. `localhost:5005/devtools/src/index.html`, assuming port `5005` and the server serving
+Navigate to the `devtools/` directory in the browser
+(e.g. `localhost:5005/devtools/`, assuming port `5005` and the server serving
 files from the repo).
 
 ## Development

--- a/devtools/index.html
+++ b/devtools/index.html
@@ -3,11 +3,11 @@
   <head>
     <meta charset="utf-8">
     <title>Arcs Explorer</title>
-    <script src="../node_modules/vis/dist/vis.min.js"></script>
-    <script src="../node_modules/diff/dist/diff.min.js"></script>
-    <script src="../node_modules/web-animations-js/web-animations-next-lite.min.js"></script>
-    <script src="./standalone-message-passing.js"></script>
-    <script src='./arcs-devtools-app.js' type='module'></script>
+    <script src="node_modules/vis/dist/vis.min.js"></script>
+    <script src="node_modules/diff/dist/diff.min.js"></script>
+    <script src="node_modules/web-animations-js/web-animations-next-lite.min.js"></script>
+    <script src="src/standalone-message-passing.js"></script>
+    <script src='src/arcs-devtools-app.js' type='module'></script>
     <style>
       body {
         margin: 0;

--- a/devtools/manifest.json
+++ b/devtools/manifest.json
@@ -1,7 +1,7 @@
 {
   "name" : "Arcs Explorer",
   "version" : "0.1",
-  "description" : "Helps debug Arcs particles.",
+  "description" : "Inspection tools for Arcs Runtime.",
   "devtools_page": "src/devtools.html",
   "background" : {
     "scripts": ["src/background.js"]

--- a/devtools/src/arcs-shared.js
+++ b/devtools/src/arcs-shared.js
@@ -28,8 +28,8 @@ $_documentContainer.innerHTML = `<dom-module id="shared-styles">
         width: 28px;
         height: 24px;
         -webkit-mask-image: -webkit-image-set(
-            url(../img/devtools_icons_1x.png) 1x,
-            url(../img/devtools_icons_2x.png) 2x);
+            url(img/devtools_icons_1x.png) 1x,
+            url(img/devtools_icons_2x.png) 2x);
         background-color: rgb(110, 110, 110);
       }
       .devtools-small-icon {
@@ -38,15 +38,15 @@ $_documentContainer.innerHTML = `<dom-module id="shared-styles">
         height: 10px;
         min-width: 10px;
         -webkit-mask-image: -webkit-image-set(
-            url(../img/devtools_icons_color_1x.png) 1x,
-            url(../img/devtools_icons_color_2x.png) 2x);
+            url(img/devtools_icons_color_1x.png) 1x,
+            url(img/devtools_icons_color_2x.png) 2x);
         background-color: rgb(110, 110, 110);
       }
       .devtools-icon-color {
         display: inline-block;
         background-image: -webkit-image-set(
-            url(../img/devtools_icons_color_1x.png) 1x,
-            url(../img/devtools_icons_color_2x.png) 2x);
+            url(img/devtools_icons_color_1x.png) 1x,
+            url(img/devtools_icons_color_2x.png) 2x);
         width: 10px;
         height: 10px;
       }

--- a/devtools/src/devtools.js
+++ b/devtools/src/devtools.js
@@ -19,7 +19,7 @@
     // Add the panel for devtools, and flush the events to it once it's shown.
     chrome.devtools.panels.create('Arcs',
       null,
-      './src/index.html',
+      'index.html',
       panel => panel.onShown.addListener(panelWindow => initializeWindow(panelWindow)));
   } else {
     // Fire on a regular window without queueing in the standalone scenario.

--- a/devtools/src/standalone-message-passing.js
+++ b/devtools/src/standalone-message-passing.js
@@ -1,6 +1,6 @@
 // If not in DevTools, run devtools.js script for message passing.
 if (!chrome || !chrome.devtools) {
   const script = document.createElement('script');
-  script.setAttribute('src', 'devtools.js');
+  script.setAttribute('src', 'src/devtools.js');
   document.getElementsByTagName('head')[0].appendChild(script);
 }


### PR DESCRIPTION
Standalone devtools from `devtools/` path instead of `devtools/src/` which was weird.