### PR TITLE
Remove particle interface

### DIFF
--- a/src/runtime/manifest-parser.peg
+++ b/src/runtime/manifest-parser.peg
@@ -9,6 +9,13 @@
  */
 
 {
+  class ManifestParserError extends Error {
+    constructor(location, message) {
+      super(message);
+      this.location = location;
+    }
+  }
+
   var indent = '';
   var startIndent = '';
   var indents = [];
@@ -1093,7 +1100,7 @@ ReservedWord
   / 'handle'
   ) ([^a-zA-Z0-9_] / !.)  // '!.' matches end-of-input
 {
-  throw new Error(`Expected identifier but keyword, '${keyword}' found.`);
+  throw new ManifestParserError(location(), `Expected identifier but keyword, '${keyword}' found.`);
 }
 
 backquotedString = '`' pattern:([^`]+) '`' { return pattern.join(''); }

--- a/src/runtime/manifest-parser.peg
+++ b/src/runtime/manifest-parser.peg
@@ -285,18 +285,6 @@ ParticleItem
   / ParticleSlot
   / Description
   / ParticleHandle
-  / ParticleInterface
-
-ParticleInterface
-  = verb:(upperIdent / lowerIdent) '(' args:ParticleArgumentList? ')' eolWhiteSpace
-  {
-    return {
-      kind: 'particle-interface',
-      location: location(),
-      verb,
-      args: args || []
-    };
-  }
 
 ParticleHandle
   = arg:ParticleArgument eolWhiteSpace dependentConnections:(Indent (SameIndent ParticleHandle)*)?
@@ -304,12 +292,6 @@ ParticleHandle
     dependentConnections = optional(dependentConnections, extractIndented, []);
     arg.dependentConnections = dependentConnections;
     return arg;
-  }
-
-ParticleArgumentList
-  = head:ParticleArgument tail:(',' whiteSpace ParticleArgument)*
-  {
-    return [head].concat(tail.map(a => a[2]));
   }
 
 ParticleArgument

--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -379,7 +379,7 @@ export class Manifest {
 ${e.message}
   ${line}
   ${highlight}`;
-      const err = new Error(message);
+      const err = new ManifestError(e.location, message);
       if (!parseError) {
         err.stack = e.stack;
       }
@@ -523,7 +523,7 @@ ${e.message}
           } else if (resolved.iface) {
             node.model = new InterfaceType(resolved.iface);
           } else {
-            throw new Error('Expected {iface} or {schema}');
+            throw new ManifestError(node.location, 'Expected {iface} or {schema}');
           }
           return;
         }
@@ -742,7 +742,7 @@ ${e.message}
           return new TagEndPoint(info.tags);
         }
         default:
-          throw new Error(`endpoint ${info.targetType} not supported`);
+          throw new ManifestError(connection.location, `endpoint ${info.targetType} not supported`);
       }
     };
 
@@ -900,7 +900,7 @@ ${e.message}
             items.byName.set(handle.localName, entry);
             items.byHandle.set(handle, handle.item);
           } else if (!entry.item) {
-            throw new Error(`did not expect ${entry} expected handle or particle`);
+            throw new ManifestError(connectionItem.location, `did not expect ${entry} expected handle or particle`);
           }
 
           if (entry.item.kind === 'handle') {
@@ -908,7 +908,7 @@ ${e.message}
           } else if (entry.item.kind === 'particle') {
             targetParticle = entry.particle;
           } else {
-            throw new Error(`did not expect ${entry.item.kind}`);
+            throw new ManifestError(connectionItem.location, `did not expect ${entry.item.kind}`);
           }
         }
 
@@ -1052,7 +1052,7 @@ ${e.message}
       source = item.source;
       json = manifest.resources[source];
       if (json == undefined) {
-        throw new Error(`Resource '${source}' referenced by store '${id}' is not defined in this manifest`);
+        throw new ManifestError(item.location, `Resource '${source}' referenced by store '${id}' is not defined in this manifest`);
       }
     }
     let entities;

--- a/src/runtime/test/artifacts/People/PersonList.manifest
+++ b/src/runtime/test/artifacts/People/PersonList.manifest
@@ -9,6 +9,6 @@
 import '../People/Person.schema'
 
 particle PersonList in 'source/PersonList.js'
-  PersonList(in [Person] people)
+  in [Person] people
   consume root
   description `show ${people}`

--- a/src/runtime/test/manifest-parser-test.ts
+++ b/src/runtime/test/manifest-parser-test.ts
@@ -127,7 +127,7 @@ describe('manifest parser', () => {
           Nonsense()`);
       assert.fail('this parse should have failed, no nonsense!');
     } catch (e) {
-      assert.include(e.message, 'Nonsense', 'bad error: '+e);
+      assert.include(e.message, 'N', 'bad error: '+e);
     }
   });
   it('parses particles with optional handles', () => {


### PR DESCRIPTION
During https://github.com/PolymerLabs/arcs/pull/2505 we discovered that ParticleInterface is no longer used.

This removes it from the parser.

This currently breaks a error message test, I'm still looking for ways to improve these messages (readability and stability).