### PR TITLE
Improved error messages on failed parse

### DIFF
--- a/src/runtime/manifest-parser.peg
+++ b/src/runtime/manifest-parser.peg
@@ -85,9 +85,10 @@ ManifestItem
   / Meta
   / Resource
 
-Annotation = '@' annotation:lowerIdent { return annotation; }
+Annotation "an annotation (e.g. @foo)"
+  = '@' annotation:lowerIdent { return annotation; }
 
-Resource = 'resource' whiteSpace name:TopLevelIdent eolWhiteSpace Indent SameIndent ResourceStart body:ResourceBody eolWhiteSpace? {
+Resource = 'resource' whiteSpace name:upperIdent eolWhiteSpace Indent SameIndent ResourceStart body:ResourceBody eolWhiteSpace? {
   return {
     kind: 'resource',
     name,
@@ -106,7 +107,7 @@ ResourceLine = [^\n]* eol { return text(); }
 
 // TODO: Entity syntax.
 ManifestStorage
-  = 'store' whiteSpace name:TopLevelIdent whiteSpace 'of' whiteSpace type:ManifestStorageType id:(whiteSpace id)? originalId:('!!' id)?
+  = 'store' whiteSpace name:upperIdent whiteSpace 'of' whiteSpace type:ManifestStorageType id:(whiteSpace id)? originalId:('!!' id)?
     version:(whiteSpace Version)? tags:(whiteSpace TagList)? whiteSpace source:ManifestStorageSource eolWhiteSpace
     items:(Indent (SameIndent ManifestStorageItem)+)?
   {
@@ -136,7 +137,7 @@ ManifestStorageFileSource
   = 'in' whiteSpace source:id { return {origin: 'file', source }; }
 
 ManifestStorageResourceSource
-  = 'in' whiteSpace source:TopLevelIdent { return {origin: 'resource', source }; }
+  = 'in' whiteSpace source:upperIdent { return {origin: 'resource', source }; }
 
 ManifestStorageStorageSource
   = 'at' whiteSpace source:id { return {origin: 'storage', source }; }
@@ -157,8 +158,8 @@ Import
     };
   }
 
-Interface
-  = 'interface' whiteSpace name:TopLevelIdent typeVars:(whiteSpace? '<' whiteSpace? TypeVariableList whiteSpace? '>')? eolWhiteSpace items:(Indent (SameIndent InterfaceItem)*)? eolWhiteSpace?
+Interface "an interface"
+  = 'interface' whiteSpace name:upperIdent typeVars:(whiteSpace? '<' whiteSpace? TypeVariableList whiteSpace? '>')? eolWhiteSpace items:(Indent (SameIndent InterfaceItem)*)? eolWhiteSpace?
   {
     return {
       kind: 'interface',
@@ -227,7 +228,7 @@ MetaStorageKey = 'storageKey' whiteSpace? ':' whiteSpace? key:id eolWhiteSpace
 };
 
 ParticleDefinition
-  = 'particle' whiteSpace name:TopLevelIdent verbs:(whiteSpace VerbList)? implFile:(whiteSpace 'in' whiteSpace id)? eolWhiteSpace items:(Indent (SameIndent ParticleItem)*)? eolWhiteSpace?
+  = 'particle' whiteSpace name:upperIdent verbs:(whiteSpace VerbList)? implFile:(whiteSpace 'in' whiteSpace id)? eolWhiteSpace items:(Indent (SameIndent ParticleItem)*)? eolWhiteSpace?
   {
     let args = [];
     let modality = [];
@@ -280,7 +281,7 @@ ParticleDefinition
     };
   }
 
-ParticleItem
+ParticleItem "a particle item"
   = ParticleModality
   / ParticleSlot
   / Description
@@ -309,7 +310,7 @@ ParticleArgument
     };
   }
 
-ParticleArgumentDirection
+ParticleArgumentDirection "a direction (e.g. inout, in, out, host, `consume, `provide)"
   = 'inout' / 'in' / 'out' / 'host' / '`consume' / '`provide'
   {
     return text();
@@ -354,7 +355,7 @@ ReferenceType
     };
   }
 
-TypeVariable
+TypeVariable "a type variable (e.g. ~foo)"
   = '~' name:lowerIdent constraint:(whiteSpace 'with' whiteSpace type:ParticleArgumentType)?
   {
     return {
@@ -551,7 +552,7 @@ ParticleHandleDescription
   }
 
 Recipe
-  = 'recipe' name:(whiteSpace TopLevelIdent)? verbs:(whiteSpace VerbList)? eolWhiteSpace items:(Indent (SameIndent RecipeItem)*)?
+  = 'recipe' name:(whiteSpace upperIdent)? verbs:(whiteSpace VerbList)? eolWhiteSpace items:(Indent (SameIndent RecipeItem)*)?
   {
     verbs = optional(verbs, parsedOutput => parsedOutput[1], []);
     return {
@@ -813,7 +814,7 @@ TagList
   = head:Tag tail:(whiteSpace TagList)?
   { return [head, ...(tail && tail[1] || [])]; }
 
-Verb
+Verb "a verb (e.g. &Verb)"
   = '&' [a-zA-Z][a-zA-Z0-9_]* {return text().substring(1);}
 
 VerbList
@@ -932,7 +933,7 @@ SchemaInlineField
   }
 
 SchemaSpec
-  = 'schema' names:(whiteSpace ('*' / TopLevelIdent))+ parents:SchemaExtends?
+  = 'schema' names:(whiteSpace ('*' / upperIdent))+ parents:SchemaExtends?
   {
     return {
       names: names.map(name => name[1]).filter(name => name != '*'),
@@ -1030,13 +1031,13 @@ SchemaTupleType
     return {kind: 'schema-tuple', location: location(), types};
   }
 
-Version
+Version "a version number (e.g. @012)"
   = '@' version:[0-9]+
   {
     return Number(version.join(''));
   }
 
-Indent = &(i:" "+ &{
+Indent "indentation" = &(i:" "+ &{
   i = i.join('');
   if (i.length > indent.length) {
     indents.push(indent);
@@ -1045,7 +1046,7 @@ Indent = &(i:" "+ &{
   }
 })
 
-SameIndent = &(i:" "* &{
+SameIndent "same indentation" = &(i:" "* &{
   i = i.join('');
   if (i.length == indent.length) {
     return true;
@@ -1055,7 +1056,7 @@ SameIndent = &(i:" "* &{
   }
 }) " "*
 
-SameOrMoreIndent = &(i:" "* &{
+SameOrMoreIndent "same or more indentation" = &(i:" "* &{
   i = i.join('');
   if (i.length >= indent.length) {
     return true;
@@ -1064,9 +1065,6 @@ SameOrMoreIndent = &(i:" "* &{
     return false;
   }
 }) " "* { return text(); }
-
-TopLevelIdent
-  = upperIdent
 
 // Should only be used as a negative match.
 ReservedWord
@@ -1085,16 +1083,21 @@ ReservedWord
   throw new ManifestParserError(location(), `Expected identifier but keyword, '${keyword}' found.`);
 }
 
-backquotedString = '`' pattern:([^`]+) '`' { return pattern.join(''); }
-id = "'" id:[^']+ "'" { return id.join(''); }
-upperIdent = [A-Z][a-z0-9_]i* { return text(); }
-lowerIdent = !ReservedWord [a-z][a-z0-9_]i* { return text(); }
-fieldName = [a-z][a-z0-9_]i* { return text(); }
-whiteSpace
+backquotedString "a `backquoted string`"
+  = '`' pattern:([^`]+) '`' { return pattern.join(''); }
+id "an identifier (e.g. 'id')"
+  = "'" id:[^']+ "'" { return id.join(''); }
+upperIdent "an uppercase identifier (e.g. Foo)"
+  = [A-Z][a-z0-9_]i* { return text(); }
+lowerIdent "a lowercase identifier (e.g. foo)"
+  = !ReservedWord [a-z][a-z0-9_]i* { return text(); }
+fieldName "a field name (e.g. foo9)"
+  = [a-z][a-z0-9_]i* { return text(); }
+whiteSpace "one or more whitespace characters"
   = " "+
-eolWhiteSpace
+eolWhiteSpace "a new line"
   = [ ]* !.
   / [ ]* '//' [^\n]* eolWhiteSpace
   / [ ]* eol eolWhiteSpace?
-eol
+eol "a new line"
   = "\r"? "\n" "\r"?

--- a/src/runtime/manifest-parser.peg
+++ b/src/runtime/manifest-parser.peg
@@ -9,6 +9,13 @@
  */
 
 {
+  class ManifestParserError extends Error {
+    constructor(location, message) {
+      super(message);
+      this.location = location;
+    }
+  }
+
   var indent = '';
   var startIndent = '';
   var indents = [];
@@ -1093,7 +1100,7 @@ ReservedWord
   / 'handle'
   ) ([^a-zA-Z0-9_] / !.)  // '!.' matches end-of-input
 {
-  throw new Error(`Expected identifier but keyword, '${keyword}' found.`);
+  throw new ManifestParserError(location(), `Expected identifier but keyword, '${keyword}' found.`);
 }
 
 backquotedString = '`' pattern:([^`]+) '`' { return pattern.join(''); }

--- a/src/runtime/manifest-parser.peg
+++ b/src/runtime/manifest-parser.peg
@@ -285,18 +285,6 @@ ParticleItem
   / ParticleSlot
   / Description
   / ParticleHandle
-  / ParticleInterface
-
-ParticleInterface
-  = verb:(upperIdent / lowerIdent) '(' args:ParticleArgumentList? ')' eolWhiteSpace
-  {
-    return {
-      kind: 'particle-interface',
-      location: location(),
-      verb,
-      args: args || []
-    };
-  }
 
 ParticleHandle
   = arg:ParticleArgument eolWhiteSpace dependentConnections:(Indent (SameIndent ParticleHandle)*)?
@@ -304,12 +292,6 @@ ParticleHandle
     dependentConnections = optional(dependentConnections, extractIndented, []);
     arg.dependentConnections = dependentConnections;
     return arg;
-  }
-
-ParticleArgumentList
-  = head:ParticleArgument tail:(',' whiteSpace ParticleArgument)*
-  {
-    return [head].concat(tail.map(a => a[2]));
   }
 
 ParticleArgument

--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -379,7 +379,7 @@ export class Manifest {
 ${e.message}
   ${line}
   ${highlight}`;
-      const err = new Error(message);
+      const err = new ManifestError(e.location, message);
       if (!parseError) {
         err.stack = e.stack;
       }
@@ -523,7 +523,7 @@ ${e.message}
           } else if (resolved.iface) {
             node.model = new InterfaceType(resolved.iface);
           } else {
-            throw new Error('Expected {iface} or {schema}');
+            throw new ManifestError(node.location, 'Expected {iface} or {schema}');
           }
           return;
         }
@@ -742,7 +742,7 @@ ${e.message}
           return new TagEndPoint(info.tags);
         }
         default:
-          throw new Error(`endpoint ${info.targetType} not supported`);
+          throw new ManifestError(connection.location, `endpoint ${info.targetType} not supported`);
       }
     };
 
@@ -900,7 +900,7 @@ ${e.message}
             items.byName.set(handle.localName, entry);
             items.byHandle.set(handle, handle.item);
           } else if (!entry.item) {
-            throw new Error(`did not expect ${entry} expected handle or particle`);
+            throw new ManifestError(connectionItem.location, `did not expect ${entry} expected handle or particle`);
           }
 
           if (entry.item.kind === 'handle') {
@@ -908,7 +908,7 @@ ${e.message}
           } else if (entry.item.kind === 'particle') {
             targetParticle = entry.particle;
           } else {
-            throw new Error(`did not expect ${entry.item.kind}`);
+            throw new ManifestError(connectionItem.location, `did not expect ${entry.item.kind}`);
           }
         }
 
@@ -1052,7 +1052,7 @@ ${e.message}
       source = item.source;
       json = manifest.resources[source];
       if (json == undefined) {
-        throw new Error(`Resource '${source}' referenced by store '${id}' is not defined in this manifest`);
+        throw new ManifestError(item.location, `Resource '${source}' referenced by store '${id}' is not defined in this manifest`);
       }
     }
     let entities;

--- a/src/runtime/test/artifacts/People/PersonList.manifest
+++ b/src/runtime/test/artifacts/People/PersonList.manifest
@@ -9,6 +9,6 @@
 import '../People/Person.schema'
 
 particle PersonList in 'source/PersonList.js'
-  PersonList(in [Person] people)
+  in [Person] people
   consume root
   description `show ${people}`

--- a/src/runtime/test/manifest-parser-test.ts
+++ b/src/runtime/test/manifest-parser-test.ts
@@ -127,7 +127,7 @@ describe('manifest parser', () => {
           Nonsense()`);
       assert.fail('this parse should have failed, no nonsense!');
     } catch (e) {
-      assert.include(e.message, 'Nonsense', 'bad error: '+e);
+      assert.include(e.message, 'N', 'bad error: '+e);
     }
   });
   it('parses particles with optional handles', () => {

--- a/src/runtime/test/manifest-test.ts
+++ b/src/runtime/test/manifest-test.ts
@@ -1162,7 +1162,7 @@ Error parsing JSON from 'EntityList' (Unexpected token h in JSON at position 1)'
       assert(false);
     } catch (e) {
       assert.deepEqual(e.message, `Parse error in 'bad-file' line 1.
-Expected " ", "&", "//", "\\n", "\\r", [ ], or [A-Z] but "?" found.
+Expected a verb (e.g. &Verb) or an uppercase identifier (e.g. Foo) but "?" found.
   recipe ?
          ^`);
     }


### PR DESCRIPTION
This improves error messages by replacing the list of string literals that are possible options for the next parse step with human readable labels.

e.g. Instead of showing 
```
Expected..... "@"...
```
we get
```
Expected..... an annotation (e.g. @foo), ...
```

For instance in the following:
```
     AssertionError: bad error: SyntaxError: Expected "alias", "import", "meta", "particle", "recipe", "resource", "schema", "store", a particle item, an annotation (e.g. @foo), or an interface but "N" found.
```