### PR TITLE
serialize plan as json string

### DIFF
--- a/src/runtime/plan/suggestion.ts
+++ b/src/runtime/plan/suggestion.ts
@@ -141,7 +141,8 @@ export class Suggestion {
 
   toLiteral() {
     return {
-      plan: this.plan,
+      // Needs to JSON.strigify to avoid emitting empty strings and arrays.
+      plan: JSON.stringify(this.plan),
       hash: this.hash,
       rank: this.rank,
       // Needs to JSON.strigify because store IDs may contain invalid FB key symbols.
@@ -152,7 +153,7 @@ export class Suggestion {
   }
 
   static fromLiteral({plan, hash, rank, versionByStore, searchGroups, descriptionByModality}) {
-    const suggestion = new Suggestion(plan, hash, rank, JSON.parse(versionByStore || '{}'));
+    const suggestion = new Suggestion(JSON.parse(plan), hash, rank, JSON.parse(versionByStore || '{}'));
     suggestion.searchGroups = searchGroups || [];
     suggestion.descriptionByModality = descriptionByModality;
     return suggestion;

--- a/src/runtime/test/plan/suggestion-test.js
+++ b/src/runtime/test/plan/suggestion-test.js
@@ -49,10 +49,10 @@ describe('suggestion', function() {
   });
 
   it('deserialize empty', async () => {
-    const suggestion1 = Suggestion.fromLiteral({plan: 'recipe', hash: '123', rank: 1});
+    const suggestion1 = Suggestion.fromLiteral({plan: '{"serialization" : "recipe"}', hash: '123', rank: 1});
     assert.isTrue(Boolean(suggestion1.plan));
     const suggestion2 =
-        Suggestion.fromLiteral({plan: 'recipe', hash: '123', rank: 1, versionByStore: '{}', searchGroups: [], descriptionByModality: {}}, {}, {});
+        Suggestion.fromLiteral({plan: '{"serialization" : "recipe"}', hash: '123', rank: 1, versionByStore: '{}', searchGroups: [], descriptionByModality: {}}, {}, {});
     assert.isTrue(Boolean(suggestion2.plan));
     assert.deepEqual(suggestion2.toLiteral(), Suggestion.fromLiteral(suggestion2.toLiteral()).toLiteral());
   });


### PR DESCRIPTION
Fixes arcs-live error:
```
Uncaught (in promise) TypeError: Cannot read property 'length' of undefined
    at suggestions.result.suggestions.filter.suggestion (plan-consumer.js:51)
    at Array.filter (<anonymous>)
    at PlanConsumer.getCurrentSuggestions (plan-consumer.js:51)
    at PlanConsumer._onMaybeSuggestionsChanged (plan-consumer.js:90)
    at PlanConsumer.onSuggestionsChanged (plan-consumer.js:45)
    at PlanConsumer.result.registerChangeCallback (plan-consumer.js:31)
    at PlanningResult.onChanged (planning-result.js:31)
```