### PR TITLE
Makes SlotComposer capable of multi-arc composition

### DIFF
--- a/src/runtime/arc.ts
+++ b/src/runtime/arc.ts
@@ -27,7 +27,6 @@ import {PECInnerPort} from './api-channel.js';
 import {Particle} from './recipe/particle.js';
 import {SlotComposer} from './slot-composer.js';
 import {Modality} from './modality.js';
-import {ModalityHandler} from './modality-handler.js';
 
 type ArcOptions = {
   id: string;
@@ -90,9 +89,6 @@ export class Arc {
     const pecId = this.generateID();
     const innerPecPort = this.pecFactory(pecId);
     this.pec = new ParticleExecutionHost(innerPecPort, slotComposer, this);
-    if (slotComposer) {
-      slotComposer.arc = this;
-    }
     this.storageProviderFactory = storageProviderFactory || new StorageProviderFactory(this.id);
     this.arcId = this.storageKey ? this.storageProviderFactory.parseStringAsKey(this.storageKey).arcId : '';
     this._description = new Description(this);
@@ -131,7 +127,7 @@ export class Arc {
     // TODO: disconnect all assocated store event handlers
     this.pec.close();
     if (this.pec.slotComposer) {
-      this.pec.slotComposer.dispose();
+      this.pec.slotComposer.dispose(this);
     }
   }
 
@@ -545,7 +541,7 @@ ${this.activeRecipe.toString()}`;
 
     if (this.pec.slotComposer) {
       // TODO: pass slot-connections instead
-      this.pec.slotComposer.initializeRecipe(particles);
+      this.pec.slotComposer.initializeRecipe(this, particles);
     }
 
     if (!this.isSpeculative && !innerArc) {

--- a/src/runtime/hosted-slot-consumer.ts
+++ b/src/runtime/hosted-slot-consumer.ts
@@ -19,21 +19,17 @@ export class HostedSlotConsumer extends SlotConsumer {
   readonly hostedSlotName: string;
   readonly hostedSlotId: string;
   readonly storeId: string;
-  readonly _arc: Arc;
   renderCallback: ({}, {}, {}, {}) => void;
 
-  constructor(transformationSlotConsumer, hostedParticleName, hostedSlotName, hostedSlotId, storeId, arc) {
-    super(null, null);
+  constructor(arc: Arc, transformationSlotConsumer, hostedParticleName, hostedSlotName, hostedSlotId, storeId) {
+    super(arc, null, null);
     this.transformationSlotConsumer = transformationSlotConsumer;
     this.hostedParticleName = hostedParticleName;
     this.hostedSlotName = hostedSlotName, 
     this.hostedSlotId = hostedSlotId;
     // TODO: should this be a list?
     this.storeId = storeId;
-    this._arc = arc;
   }
-
-  get arc() { return this._arc; }
 
   get consumeConn() { return this._consumeConn; }
   set consumeConn(consumeConn) {
@@ -47,7 +43,7 @@ export class HostedSlotConsumer extends SlotConsumer {
     this._consumeConn = consumeConn;
   }
 
-  async setContent(content, handler, arc) {
+  async setContent(content, handler) {
     if (this.renderCallback) {
       this.renderCallback(
         this.transformationSlotConsumer.consumeConn.particle,

--- a/src/runtime/plan/plan-consumer.ts
+++ b/src/runtime/plan/plan-consumer.ts
@@ -124,7 +124,7 @@ export class PlanConsumer {
   _initSuggestionComposer() {
     const composer = this.arc.pec.slotComposer;
     if (composer && composer.findContextById('rootslotid-suggestions')) {
-      this.suggestionComposer = new SuggestionComposer(composer);
+      this.suggestionComposer = new SuggestionComposer(this.arc, composer);
       this.registerVisibleSuggestionsChangedCallback(
           (suggestions) => this.suggestionComposer.setSuggestions(suggestions));
     }

--- a/src/runtime/slot-dom-consumer.ts
+++ b/src/runtime/slot-dom-consumer.ts
@@ -10,6 +10,7 @@
 
 import {assert} from '../platform/assert-web.js';
 import {SlotConsumer} from './slot-consumer.js';
+import {Arc} from './arc.js';
 import {SlotConnection} from './recipe/slot-connection.js';
 import {Template} from '../../modalities/dom/components/xen/xen-template.js';
 import IconStyles from '../../modalities/dom/components/icons.css.js';
@@ -19,8 +20,8 @@ const templateByName = new Map();
 export class SlotDomConsumer extends SlotConsumer {
   private readonly _observer: MutationObserver;
 
-  constructor(consumeConn?: SlotConnection, containerKind?: string) {
-    super(consumeConn, containerKind);
+  constructor(arc: Arc, consumeConn?: SlotConnection, containerKind?: string) {
+    super(arc, consumeConn, containerKind);
 
     this._observer = this._initMutationObserver();
   }

--- a/src/runtime/suggest-dom-consumer.ts
+++ b/src/runtime/suggest-dom-consumer.ts
@@ -10,14 +10,15 @@
 
 import {SlotDomConsumer} from './slot-dom-consumer.js';
 import {Suggestion} from './plan/suggestion.js';
+import {Arc} from './arc.js';
 
 export class SuggestDomConsumer extends SlotDomConsumer {
   _suggestion: Suggestion;
   _suggestionContent;
   _eventHandler;
 
-  constructor(containerKind: string, suggestion: Suggestion, suggestionContent, eventHandler) {
-    super(/* consumeConn= */null, containerKind);
+  constructor(arc: Arc, containerKind: string, suggestion: Suggestion, suggestionContent, eventHandler) {
+    super(arc, /* consumeConn= */null, containerKind);
     this._suggestion = suggestion;
     this._suggestionContent = suggestionContent;
     this._eventHandler = eventHandler;
@@ -47,11 +48,11 @@ export class SuggestDomConsumer extends SlotDomConsumer {
     }
   }
 
-  static render(container, plan, content): SlotDomConsumer {
+  static render(arc: Arc, container, plan, content): SlotDomConsumer {
     const suggestionContainer = Object.assign(document.createElement('suggestion-element'), {plan});
     container.appendChild(suggestionContainer, container.firstElementChild);
     const rendering = {container: suggestionContainer, model: content.model};
-    const consumer = new SlotDomConsumer();
+    const consumer = new SlotDomConsumer(arc);
     consumer.addRenderingBySubId(undefined, rendering);
     consumer.eventHandler = (() => {});
     consumer._stampTemplate(rendering, consumer.createTemplateElement(content.template));

--- a/src/runtime/suggestion-composer.ts
+++ b/src/runtime/suggestion-composer.ts
@@ -9,6 +9,7 @@
  */
 import {ModalityHandler} from './modality-handler.js';
 import {SlotComposer} from './slot-composer.js';
+import {Arc} from './arc.js';
 import {Suggestion} from './plan/suggestion.js';
 import {SuggestDomConsumer} from './suggest-dom-consumer.js';
 
@@ -16,12 +17,14 @@ export class SuggestionComposer {
   private _container: HTMLElement | undefined; // eg div element.
 
   private readonly _slotComposer: SlotComposer;
+  private readonly arc: Arc;
   private _suggestions: Suggestion[] = [];
   private _suggestConsumers: SuggestDomConsumer[] = [];
 
-  constructor(slotComposer: SlotComposer) {
+  constructor(arc: Arc, slotComposer: SlotComposer) {
     this._container = slotComposer.findContainerByName('suggestions');
     this._slotComposer = slotComposer;
+    this.arc = arc;
   }
 
   get modalityHandler(): ModalityHandler { return this._slotComposer.modalityHandler; }
@@ -46,7 +49,7 @@ export class SuggestionComposer {
       }
 
       if (this._container) {
-        this.modalityHandler.suggestionConsumerClass.render(this._container, suggestion, suggestionContent);
+        this.modalityHandler.suggestionConsumerClass.render(this.arc, this._container, suggestion, suggestionContent);
       }
 
       this._addInlineSuggestion(suggestion, suggestionContent);
@@ -86,7 +89,7 @@ export class SuggestionComposer {
       return;
     }
 
-    const suggestConsumer = new this.modalityHandler.suggestionConsumerClass(this._slotComposer.containerKind, suggestion, suggestionContent, (eventlet) => {
+    const suggestConsumer = new this.modalityHandler.suggestionConsumerClass(this.arc, this._slotComposer.containerKind, suggestion, suggestionContent, (eventlet) => {
       const suggestion = this._suggestions.find(s => s.hash === eventlet.data.key);
       suggestConsumer.dispose();
       if (suggestion) {
@@ -96,7 +99,7 @@ export class SuggestionComposer {
         }
         this._suggestConsumers.splice(index, 1);
 
-        suggestion.instantiate(this._slotComposer.arc);
+        suggestion.instantiate(this.arc);
       }
     });
     context.addSlotConsumer(suggestConsumer);

--- a/src/runtime/test/arc-tests.js
+++ b/src/runtime/test/arc-tests.js
@@ -240,9 +240,9 @@ describe('Arc', function() {
 
     let slotsCreated = 0;
 
-    slotComposer.createHostedSlot = (a, b, c, d) => {
+    slotComposer.createHostedSlot = (...args) => {
       slotsCreated++;
-      return slotComposer_createHostedSlot.apply(slotComposer, [a, b, c, d]);
+      return slotComposer_createHostedSlot.apply(slotComposer, args);
     };
 
     const arc = new Arc({id: 'test', context: manifest, slotComposer});
@@ -259,8 +259,8 @@ describe('Arc', function() {
 
     const serialization = await arc.serialize();
     arc.stop();
+    arc.dispose();
 
-    slotComposer.dispose();
     const newArc = await Arc.deserialize({serialization, loader, slotComposer, fileName: './manifest.manifest'});
     await newArc.idle;
     store = newArc.storesById.get(store.id);

--- a/src/runtime/test/multiplexer-test.js
+++ b/src/runtime/test/multiplexer-test.js
@@ -48,9 +48,9 @@ describe('Multiplexer', function() {
 
     let slotsCreated = 0;
 
-    slotComposer.createHostedSlot = (a, b, c, d) => {
+    slotComposer.createHostedSlot = (...args) => {
       slotsCreated++;
-      return slotComposer_createHostedSlot.apply(slotComposer, [a, b, c, d]);
+      return slotComposer_createHostedSlot.apply(slotComposer, args);
     };
 
     const arc = new Arc({id: 'test', context: manifest, slotComposer});

--- a/src/runtime/test/particle-interface-loading-with-slots-test.js
+++ b/src/runtime/test/particle-interface-loading-with-slots-test.js
@@ -74,7 +74,7 @@ describe('particle interface loading with slots', function() {
       .expectRenderSlot('MultiplexSlotsParticle', 'annotationsSet', {contentTypes: ['model'], times: 2, isOptional: true});
 
     const inStore = await instantiateRecipeAndStore(arc, recipe, manifest);
-    await slotComposer.arc.pec.idle;
+    await arc.pec.idle;
     await slotComposer.expectationsCompleted();
 
     // Verify slot template and models.
@@ -92,7 +92,7 @@ describe('particle interface loading with slots', function() {
       .expectRenderSlot('SingleSlotParticle', 'annotation', {contentTypes: ['model']})
       .expectRenderSlot('MultiplexSlotsParticle', 'annotationsSet', {contentTypes: ['model']})
       .expectRenderSlot('MultiplexSlotsParticle', 'annotationsSet', {contentTypes: ['model'], times: 2, isOptional: true});
-    await slotComposer.arc.pec.idle;
+    await arc.pec.idle;
     await slotComposer.expectationsCompleted();
 
     verifyFooItems(slot, {'subid-1': 'foo1', 'subid-2': 'foo2', 'subid-3': 'foo3'});
@@ -125,7 +125,7 @@ describe('particle interface loading with slots', function() {
     slotComposer._contexts[0].container = {'subid-1': 'dummy-container1', 'subid-2': 'dummy-container2', 'subid-3': 'dummy-container3'};
     slotComposer.consumers[0].onContainerUpdate({});
 
-    await slotComposer.arc.pec.idle;
+    await arc.pec.idle;
     await slotComposer.expectationsCompleted();
 
     // Verify slot template and models.
@@ -140,7 +140,7 @@ describe('particle interface loading with slots', function() {
       .expectRenderSlot('SingleSlotParticle', 'annotation', {contentTypes: ['model']})
       .expectRenderSlot('MultiplexSlotsParticle', 'annotationsSet', {contentTypes: ['model']})
       .expectRenderSlot('MultiplexSlotsParticle', 'annotationsSet', {contentTypes: ['model'], times: 2, isOptional: true});
-    await slotComposer.arc.pec.idle;
+    await arc.pec.idle;
     await slotComposer.expectationsCompleted();
 
     // Verify slot template and models.

--- a/src/runtime/test/slot-consumer-tests.js
+++ b/src/runtime/test/slot-consumer-tests.js
@@ -15,7 +15,7 @@ import {SlotConsumer} from '../slot-consumer.js';
 describe('slot consumer', function() {
   it('setting container', async () => {
     const spec = {isSet: false};
-    const slot = new SlotConsumer({name: 'dummy-consumeConn', slotSpec: {spec}});
+    const slot = new SlotConsumer(null /* arc */, {name: 'dummy-consumeConn', slotSpec: {spec}});
     slot.slotContext = {spec};
     let startRenderCount = 0;
     let stopRenderCount = 0;

--- a/src/runtime/test/suggestion-composer-tests.js
+++ b/src/runtime/test/suggestion-composer-tests.js
@@ -11,12 +11,11 @@
 import {assert} from './chai-web.js';
 import {SuggestionComposer} from '../suggestion-composer.js';
 import {FakeSlotComposer} from '../testing/fake-slot-composer.js';
-import {SlotComposer} from '../slot-composer.js';
 import {TestHelper} from '../testing/test-helper.js';
 
 class TestSuggestionComposer extends SuggestionComposer {
   constructor() {
-    super(new FakeSlotComposer({containers: {suggestions: {}}}));
+    super(null, new FakeSlotComposer({containers: {suggestions: {}}}));
     this.suggestions = [];
     this.updatesCount = 0;
     this.updateResolve = null;
@@ -50,7 +49,7 @@ describe('suggestion composer', function() {
       manifestFilename: './src/runtime/test/artifacts/suggestions/Cake.recipes',
       slotComposer
     });
-    const suggestionComposer = new SuggestionComposer(slotComposer);
+    const suggestionComposer = new SuggestionComposer(helper.arc, slotComposer);
     await suggestionComposer.setSuggestions(helper.suggestions);
     assert.lengthOf(helper.suggestions, 1);
     assert.isEmpty(suggestionComposer._suggestConsumers);
@@ -79,7 +78,7 @@ describe('suggestion composer', function() {
       manifestFilename: './src/runtime/test/artifacts/suggestions/Cakes.recipes',
       slotComposer
     });
-    const suggestionComposer = new SuggestionComposer(slotComposer);
+    const suggestionComposer = new SuggestionComposer(helper.arc, slotComposer);
     await suggestionComposer.setSuggestions(helper.suggestions);
     assert.lengthOf(helper.suggestions, 1);
     assert.isEmpty(suggestionComposer._suggestConsumers);

--- a/src/runtime/testing/mock-slot-composer.js
+++ b/src/runtime/testing/mock-slot-composer.js
@@ -172,7 +172,8 @@ export class MockSlotComposer extends FakeSlotComposer {
     return Object.values(particle.connections)
         .filter(conn => conn.type instanceof InterfaceType)
         .map(conn => {
-          const store = this.arc.findStoreById(conn.handle.id);
+          const allArcs = this.consumers.reduce((arcs, consumer) => arcs.add(consumer.arc), new Set());
+          const store = [...allArcs].map(arc => arc.findStoreById(conn.handle.id)).find(store => !!store);
           if (store.referenceMode) {
             return store.backingStore._model.getValue(store._stored.id).name;
           }

--- a/src/runtime/testing/mock-slot-dom-consumer.js
+++ b/src/runtime/testing/mock-slot-dom-consumer.js
@@ -13,8 +13,8 @@ import {assert} from '../../platform/assert-web.js';
 import {SlotDomConsumer} from '../slot-dom-consumer.js';
 
 export class MockSlotDomConsumer extends SlotDomConsumer {
-  constructor(consumeConn) {
-    super(consumeConn);
+  constructor(arc, consumeConn) {
+    super(arc, consumeConn);
     this._content = {};
     this.contentAvailable = new Promise(resolve => this._contentAvailableResolve = resolve);
   }

--- a/src/runtime/testing/mock-suggest-dom-consumer.js
+++ b/src/runtime/testing/mock-suggest-dom-consumer.js
@@ -8,13 +8,12 @@
  * http://polymer.github.io/PATENTS.txt
  */
 'use strict';
-import {assert} from '../../platform/assert-web.js';
 import {MockSlotDomConsumer} from './mock-slot-dom-consumer.js';
 
 // Should this class instead extend SuggestDomConsumer?
 export class MockSuggestDomConsumer extends MockSlotDomConsumer {
-  constructor(containerKind, suggestion, suggestionContent, eventHandler) {
-    super(/* consumeConn= */null, containerKind);
+  constructor(arc, containerKind, suggestion, suggestionContent, eventHandler) {
+    super(arc, /* consumeConn= */null, containerKind);
     this._suggestion = suggestion;
     this._suggestionContent = suggestionContent.template ? suggestionContent : {
       template: `<dummy-suggestion>${suggestionContent}</dummy-element>`,


### PR DESCRIPTION
This patch paves the way to having inner arcs represented as its own Arc instances, which fixes one of the tech debt items.

SlotComposer no longer holds a reference to an arc, instead SlotConsumers hold this reference. This allows for SlotComposer to compose slots from multiple arcs (e.g. outer + inner arcs, but other options are also possible). An interesting cleanup is that HostedSlotComposer no longer needs to hold a reference to an arc, as its superclass does that.

Having a SlotComposer per "display" rather than per arc turns out to be conceptually simpler than having multiple SlotComposers coordinating a single "display" together.