### PR TITLE
Separate particles and allParticles getters on Manifest

### DIFF
--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -154,8 +154,10 @@ export class Manifest {
   get activeRecipe() {
     return this._recipes.find(recipe => recipe.annotation === 'active');
   }
-
   get particles() {
+    return Object.values(this._particles);
+  }
+  get allParticles() {
     return [...new Set(this._findAll(manifest => Object.values(manifest._particles)))];
   }
   get imports() {

--- a/src/runtime/strategies/find-hosted-particle.ts
+++ b/src/runtime/strategies/find-hosted-particle.ts
@@ -25,7 +25,7 @@ export class FindHostedParticle extends Strategy {
         const iface = connection.type as InterfaceType;
 
         const results = [];
-        for (const particle of arc.context.particles) {
+        for (const particle of arc.context.allParticles) {
           // This is what interfaceInfo.particleMatches() does, but we also do
           // canEnsureResolved at the end:
           const ifaceClone = iface.interfaceInfo.cloneWithResolutions(new Map());

--- a/src/runtime/strategies/search-tokens-to-particles.ts
+++ b/src/runtime/strategies/search-tokens-to-particles.ts
@@ -21,7 +21,7 @@ export class SearchTokensToParticles extends Strategy {
     const thingByToken = {};
     const thingByPhrase = {};
 
-    arc.context.particles.forEach(p => {
+    arc.context.allParticles.forEach(p => {
       this._addThing(p.name, {spec: p}, thingByToken, thingByPhrase);
       p.verbs.forEach(verb => this._addThing(verb, {spec: p}, thingByToken, thingByPhrase));
     });

--- a/src/runtime/test/manifest-test.ts
+++ b/src/runtime/test/manifest-test.ts
@@ -107,7 +107,7 @@ ${schemaStr}
 ${particleStr0}
 ${particleStr1}
     `);
-    const verify = (manifest) => {
+    const verify = (manifest: Manifest) => {
       assert.lengthOf(manifest.particles, 2);
       assert.equal(particleStr0, manifest.particles[0].toString());
       assert.equal(particleStr1, manifest.particles[1].toString());
@@ -144,7 +144,7 @@ ${schemaStr}
 ${particleStr0}
 ${particleStr1}
     `);
-    const verify = (manifest) => {
+    const verify = (manifest: Manifest) => {
       assert.lengthOf(manifest.particles, 2);
       assert.equal(particleStr0, manifest.particles[0].toString());
       assert.equal(particleStr1, manifest.particles[1].toString());
@@ -1477,7 +1477,7 @@ resource SomeName
         create as handle0 // [Something]
         Thing
           inThing <- handle0`);
-    const verify = (manifest) => {
+    const verify = (manifest: Manifest) => {
       assert.isFalse(manifest.particles[0].connections[0].isOptional);
       assert.isTrue(manifest.particles[0].connections[1].isOptional);
 


### PR DESCRIPTION
Follows the pattern set by `stores`/`allStores` `recipes`/`allRecipes`. Sometimes you do want the distinction between this particular manifest and all recursive manifests, and this is what I need in a follow-up patch.