### PR TITLE
exclude undefined versions from suggestions

### DIFF
--- a/src/runtime/plan/suggestion.ts
+++ b/src/runtime/plan/suggestion.ts
@@ -79,6 +79,13 @@ export class Suggestion {
     this.hash = hash;
     this.rank = rank;
     this.versionByStore = versionByStore;
+    // TODO(mmandlis): backward compatility for existing suggestions that include undefined
+    // versions. Code can be deleted, after we upgrade above 0_6 or wipe out the storage.
+    for (const store in this.versionByStore) {
+      if (this.versionByStore[store] === undefined) {
+        delete this.versionByStore[store];
+      }
+    }
   }
 
   get descriptionText() {

--- a/src/runtime/relevance.ts
+++ b/src/runtime/relevance.ts
@@ -23,7 +23,7 @@ export class Relevance {
     const relevance = new Relevance();
     const versionByStore = arc.getVersionByStore({includeArc: true, includeContext: true});
     recipe.handles.forEach(handle => {
-      if (handle.id) {
+      if (handle.id && versionByStore[handle.id] !== undefined) {
         relevance.versionByStore[handle.id] = versionByStore[handle.id];
       }
     });


### PR DESCRIPTION
- skip when generating versionByStore map in Relevance
- for backward compatibility, omit in undefined version in Suggestion constructor
(for example, this happens for hosted particle stores)

This fixes assert that fires in https://github.com/PolymerLabs/arcs/pull/2466