### PR TITLE
default filter out non-root slots rely on slot connection name too

### DIFF
--- a/src/runtime/plan/plan-consumer.ts
+++ b/src/runtime/plan/plan-consumer.ts
@@ -96,7 +96,8 @@ export class PlanConsumer {
                Boolean(this.arc.pec.slotComposer.findContextById(slot.id));
       });
       const onlyUsesNonRootSlots =
-          !suggestion.plan.slots.find(s => s.name.includes('root') || s.tags.includes('root'));
+          !suggestion.plan.slots.find(s => s.name.includes('root') || s.tags.includes('root')) &&
+          !((suggestion.plan.slotConnections || []).find(sc => sc.name === 'root'));
       return (usesHandlesFromActiveRecipe && usesRemoteNonRootSlots) || onlyUsesNonRootSlots;
     });
   }

--- a/src/runtime/plan/suggestion.ts
+++ b/src/runtime/plan/suggestion.ts
@@ -34,18 +34,23 @@ type FromLiteralOptions = {
 export class Plan {
   constructor(public readonly serialization: string,
               public readonly name: string,
-              public readonly particles: {name: string, connections: {}[]}[],
+              public readonly particles: {name: string, connections: {}[], slotConnections: {}[]}[],
               public readonly handles: {id: string, tags: string[]}[],
               public readonly handleConnections: {name: string, direction: string, particle: {}}[],
+              public readonly slotConnections: {name: string, particle: {}}[],
               public readonly slots: {id: string, name: string, tags: string[]}[],
               public readonly modality: {name: string}[]) {}
 
   static create(plan: Recipe): Plan {
     return new Plan(plan.toString(),
         plan.name,
-        plan.particles.map(p => ({name: p.name, connections: Object.keys(p.connections).map(pcName => ({name: pcName}))})),
+        plan.particles.map(p => ({
+          name: p.name,
+          connections: Object.keys(p.connections).map(pcName => ({name: pcName})),
+          slotConnections: Object.keys(p.consumedSlotConnections)})),
         plan.handles.map(h => ({id: h.id, tags: h.tags})),
         plan.handleConnections.map(hc => ({name: hc.name, direction: hc.direction, particle: {name: hc.particle.name}})),
+        plan.slotConnections.map(sc => ({name: sc.name, particle: sc.particle.name})),
         plan.slots.map(s => ({id: s.id, name: s.name, tags: s.tags})),
         plan.modality.names.map(n => ({name: n})));
   }


### PR DESCRIPTION
prevents irrelevant suggestions showing by default in a non-null arc, when a `root` slot connection is mapped to a non-root slot context.