### PR TITLE
Fixes issues with StrategyExplorer results disappearing

### DIFF
--- a/src/runtime/debug/arc-planner-invoker.ts
+++ b/src/runtime/debug/arc-planner-invoker.ts
@@ -62,7 +62,7 @@ export class ArcPlannerInvoker {
 
   private async invokePlanner(manifestString: string, method: string) {
     if (!this.recipeIndex) {
-      this.recipeIndex = RecipeIndex.create(this.arc);
+      this.recipeIndex = RecipeIndex.create(this.arc, {reportGenerations: false});
       await this.recipeIndex.ready;
     }
 

--- a/src/runtime/plan/plan-consumer.ts
+++ b/src/runtime/plan/plan-consumer.ts
@@ -61,7 +61,7 @@ export class PlanConsumer {
     this._onMaybeSuggestionsChanged();
 
     if (this.result.generations.length && DevtoolsConnection.isConnected) {
-      StrategyExplorerAdapter.processGenerations(this.result.generations, DevtoolsConnection.get().forArc(this.arc));
+      StrategyExplorerAdapter.processGenerations(this.result.generations, DevtoolsConnection.get().forArc(this.arc), {label: 'Planning'});
     }
   }
 

--- a/src/runtime/recipe-index.ts
+++ b/src/runtime/recipe-index.ts
@@ -84,7 +84,7 @@ export class RecipeIndex {
   private _recipes: Recipe[];
   private _isReady = false;
 
-  constructor(arc: Arc) {
+  constructor(arc: Arc, {reportGenerations = true} = {}) {
     const trace = Tracing.start({cat: 'indexing', name: 'RecipeIndex::constructor', overview: true});
     const arcStub = new Arc({
       id: 'index-stub',
@@ -113,12 +113,11 @@ export class RecipeIndex {
         generations.push({record, generated: strategizer.generated});
       } while (strategizer.generated.length + strategizer.terminal.length > 0);
 
-      // TODO: This is workaround for #2546. Uncomment, when properly fixed.
-      // if (DevtoolsConnection.isConnected) {
-      //   StrategyExplorerAdapter.processGenerations(
-      //       PlanningResult.formatSerializableGenerations(generations),
-      //       DevtoolsConnection.get().forArc(arc), {label: 'Index', keep: true});
-      // }
+      if (reportGenerations && DevtoolsConnection.isConnected) {
+        StrategyExplorerAdapter.processGenerations(
+            PlanningResult.formatSerializableGenerations(generations),
+            DevtoolsConnection.get().forArc(arc), {label: 'Index', keep: true});
+      }
 
       const population = strategizer.population;
       const candidates = new Set(population);
@@ -133,8 +132,8 @@ export class RecipeIndex {
     }));
   }
 
-  static create(arc: Arc): RecipeIndex {
-    return new RecipeIndex(arc);
+  static create(arc: Arc, options = {}): RecipeIndex {
+    return new RecipeIndex(arc, options);
   }
 
   get recipes(): Recipe[] {


### PR DESCRIPTION
There are 2 fixes to 2 issues here:

1) Plan producer was first parsing the already serialized suggestions, and only then finishing constructing the index. This caused the strategizing of the serialized planning being overridden by the strategizing of the index in the StrategyExplorer. I've added a change to keep the previous results available for selection in the StrategyExplorer (UI in the top-right).

2) RecipeIndex created by recipe-editor devtools tool was sending its index construction strategization, which should not be happening. Added an option to RecipeIndex to disallow this.

Fixes #2546