### PR TITLE
Migrate suggestion-composer-tests to typescript

### DIFF
--- a/src/runtime/suggestion-composer.ts
+++ b/src/runtime/suggestion-composer.ts
@@ -19,7 +19,9 @@ export class SuggestionComposer {
   private readonly _slotComposer: SlotComposer;
   private readonly arc: Arc;
   private _suggestions: Suggestion[] = [];
-  private _suggestConsumers: SuggestDomConsumer[] = [];
+
+  // used in tests
+  protected readonly _suggestConsumers: SuggestDomConsumer[] = [];
 
   constructor(arc: Arc, slotComposer: SlotComposer) {
     this._container = slotComposer.findContainerByName('suggestions');
@@ -34,7 +36,7 @@ export class SuggestionComposer {
       this.modalityHandler.slotConsumerClass.clear(this._container);
     }
     this._suggestConsumers.forEach(consumer => consumer.dispose());
-    this._suggestConsumers = [];
+    this._suggestConsumers.length = 0;
   }
 
   setSuggestions(suggestions: Suggestion[]) {

--- a/src/runtime/test/suggestion-composer-tests.ts
+++ b/src/runtime/test/suggestion-composer-tests.ts
@@ -37,7 +37,7 @@ describe('suggestion composer', () => {
     assert.isEmpty(suggestionComposer.suggestConsumers);
 
     slotComposer.newExpectations()
-      .expectRenderSlot('MakeCake', 'item', {'contentTypes': ['template', 'model', 'templateName']})
+      .expectRenderSlot('MakeCake', 'item', {'contentTypes': ['template', 'model', 'templateName']});
 
     // Accept suggestion and replan: a suggestion consumer is created, but its content is empty.
     await helper.acceptSuggestion({particles: ['MakeCake']});
@@ -87,7 +87,7 @@ describe('suggestion composer', () => {
 
     await suggestionComposer.setSuggestions(helper.suggestions);
     assert.lengthOf(suggestionComposer.suggestConsumers, 1);
-    const suggestConsumer = suggestionComposer.suggestConsumers[0] as MockSuggestDomConsumer;;
+    const suggestConsumer = suggestionComposer.suggestConsumers[0] as MockSuggestDomConsumer;
     assert.isTrue(suggestConsumer._content.template.includes('Light candles on Tiramisu cake'));
 
     // TODO(mmandlis): Better support in test-helper for instantiating suggestions in inner arcs.

--- a/src/runtime/test/suggestion-composer-tests.ts
+++ b/src/runtime/test/suggestion-composer-tests.ts
@@ -9,96 +9,105 @@
  */
 
 import {assert} from './chai-web.js';
+
+import {Arc} from '../arc.js';
+import {SlotComposer} from '../slot-composer.js';
 import {SuggestionComposer} from '../suggestion-composer.js';
-import {FakeSlotComposer} from '../testing/fake-slot-composer.js';
+import {MockSlotComposer} from '../testing/mock-slot-composer.js';
+import {MockSuggestDomConsumer} from '../testing/mock-suggest-dom-consumer.js';
 import {TestHelper} from '../testing/test-helper.js';
 
 class TestSuggestionComposer extends SuggestionComposer {
-  constructor() {
-    super(null, new FakeSlotComposer({containers: {suggestions: {}}}));
-    this.suggestions = [];
-    this.updatesCount = 0;
-    this.updateResolve = null;
-  }
-
-  setSuggestions(suggestions) {
-    this.suggestions = suggestions;
+  get suggestConsumers() {
+    return this._suggestConsumers;
   }
 }
 
-describe('suggestion composer', function() {
-  it('sets suggestions', async () => {
-    const suggestionComposer = new TestSuggestionComposer();
-    assert.isEmpty(suggestionComposer.suggestions);
-
-    // Sets suggestions
-    await suggestionComposer.setSuggestions([1, 2, 3]);
-    assert.lengthOf(suggestionComposer.suggestions, 3);
-
-    await suggestionComposer.setSuggestions([4, 5]);
-    assert.lengthOf(suggestionComposer.suggestions, 2);
-
-    await suggestionComposer.setSuggestions([6, 7, 8]);
-    await suggestionComposer.setSuggestions([]);
-    assert.isEmpty(suggestionComposer.suggestions);
-  });
-
+describe('suggestion composer', () => {
   it('singleton suggestion slots', async () => {
-    const slotComposer = new FakeSlotComposer();
+    const slotComposer = new MockSlotComposer().newExpectations('debug');
+
     const helper = await TestHelper.createAndPlan({
       manifestFilename: './src/runtime/test/artifacts/suggestions/Cake.recipes',
       slotComposer
     });
-    const suggestionComposer = new SuggestionComposer(helper.arc, slotComposer);
+    const suggestionComposer = new TestSuggestionComposer(helper.arc, slotComposer);
     await suggestionComposer.setSuggestions(helper.suggestions);
     assert.lengthOf(helper.suggestions, 1);
-    assert.isEmpty(suggestionComposer._suggestConsumers);
+    assert.isEmpty(suggestionComposer.suggestConsumers);
+
+    slotComposer.newExpectations()
+      .expectRenderSlot('MakeCake', 'item', {'contentTypes': ['template', 'model', 'templateName']})
 
     // Accept suggestion and replan: a suggestion consumer is created, but its content is empty.
     await helper.acceptSuggestion({particles: ['MakeCake']});
+
     await helper.makePlans();
+
     assert.lengthOf(helper.suggestions, 1);
     await suggestionComposer.setSuggestions(helper.suggestions);
-    assert.lengthOf(suggestionComposer._suggestConsumers, 1);
-    const suggestConsumer = suggestionComposer._suggestConsumers[0];
+    assert.lengthOf(suggestionComposer.suggestConsumers, 1);
+    const suggestConsumer = suggestionComposer.suggestConsumers[0] as MockSuggestDomConsumer;
     assert.isTrue(suggestConsumer._content.template.includes('Light candles on Tiramisu cake'));
+
+    slotComposer.newExpectations()
+      .expectRenderSlot('LightCandles', 'candles', {'contentTypes': ['template', 'model', 'templateName']});
 
     await helper.acceptSuggestion({particles: ['LightCandles']});
     await helper.makePlans();
     assert.isEmpty(helper.suggestions);
     await suggestionComposer.setSuggestions(helper.suggestions);
-    assert.isEmpty(suggestionComposer._suggestConsumers);
+    assert.isEmpty(suggestionComposer.suggestConsumers);
+    await slotComposer.expectationsCompleted();
   });
 
   it('suggestion set-slots', async () => {
-    const slotComposer = new FakeSlotComposer();
+    const slotComposer = new MockSlotComposer().newExpectations('debug');
+
     const helper = await TestHelper.createAndPlan({
       manifestFilename: './src/runtime/test/artifacts/suggestions/Cakes.recipes',
       slotComposer
     });
-    const suggestionComposer = new SuggestionComposer(helper.arc, slotComposer);
+    const suggestionComposer = new TestSuggestionComposer(helper.arc, slotComposer);
     await suggestionComposer.setSuggestions(helper.suggestions);
     assert.lengthOf(helper.suggestions, 1);
-    assert.isEmpty(suggestionComposer._suggestConsumers);
+    assert.isEmpty(suggestionComposer.suggestConsumers);
+
+    slotComposer.newExpectations()
+      .expectRenderSlot('List', 'root', {'contentTypes': ['template', 'model', 'templateName']})
+      .expectRenderSlot('MakeCake', 'item', {'contentTypes': ['template', 'model', 'templateName']})
+      .expectRenderSlot('MakeCake', 'item', {'contentTypes': ['template', 'model', 'templateName']})
+      .expectRenderSlot('MakeCake', 'item', {'contentTypes': ['template', 'model', 'templateName']})
+      .expectRenderSlot('CakeMuxer', 'item', {'contentTypes': ['template', 'model', 'templateName']});
 
     await helper.acceptSuggestion({particles: ['List', 'CakeMuxer']});
+
     await helper.makePlans({includeInnerArcs: true});
     assert.lengthOf(helper.suggestions.filter(s => s.descriptionText === 'Light candles on Tiramisu cake.'), 1);
+
     await suggestionComposer.setSuggestions(helper.suggestions);
-    assert.lengthOf(suggestionComposer._suggestConsumers, 1);
-    const suggestConsumer = suggestionComposer._suggestConsumers[0];
+    assert.lengthOf(suggestionComposer.suggestConsumers, 1);
+    const suggestConsumer = suggestionComposer.suggestConsumers[0] as MockSuggestDomConsumer;;
     assert.isTrue(suggestConsumer._content.template.includes('Light candles on Tiramisu cake'));
 
     // TODO(mmandlis): Better support in test-helper for instantiating suggestions in inner arcs.
     // Instantiate inner arc's suggestion.
     const innerSuggestion = helper.findSuggestionByParticleNames(['LightCandles'])[0];
     const innerArc = helper.arc.innerArcs[0];
+
     await innerSuggestion.instantiate(innerArc);
+
+    slotComposer.newExpectations()
+      .expectRenderSlot('LightCandles', 'candles', {'contentTypes': ['template', 'model', 'templateName']});
     await helper.idle();
+
 
     await helper.makePlans();
     assert.isEmpty(helper.suggestions);
+
     await suggestionComposer.setSuggestions(helper.suggestions);
-    assert.isEmpty(suggestionComposer._suggestConsumers);
+    assert.isEmpty(suggestionComposer.suggestConsumers);
+
+    await slotComposer.expectationsCompleted();
   });
 });

--- a/src/runtime/testing/fake-slot-composer.ts
+++ b/src/runtime/testing/fake-slot-composer.ts
@@ -19,7 +19,6 @@ export class FakeSlotComposer extends SlotComposer {
   constructor(options: SlotComposerOptions = {}) {
     super({
       rootContainer: {'root': 'root-context'},
-      modalityName: options.modalityName,
       modalityHandler: ModalityHandler.createHeadlessHandler(),
       ...options});
   }

--- a/src/runtime/testing/mock-slot-composer.ts
+++ b/src/runtime/testing/mock-slot-composer.ts
@@ -174,7 +174,7 @@ export class MockSlotComposer extends FakeSlotComposer {
     return this;
   }
 
-  _canIgnore(particleName, slotName, content) {
+  _canIgnore(particleName: string, slotName: string, content): boolean {
     // TODO: add support for ignoring specific particles and/or slots.
     return this.expectQueue.find(e => e.type === 'render' && e.ignoreUnexpected);
   }
@@ -236,7 +236,7 @@ export class MockSlotComposer extends FakeSlotComposer {
   async renderSlot(particle, slotName, content) {
     this._addDebugMessages(`    renderSlot ${particle.name} ${((names) => names.length > 0 ? `(${names.join(',')}) ` : '')(this._getHostedParticleNames(particle))}: ${slotName} - ${Object.keys(content).join(', ')}`);
     assert.isAbove(this.expectQueue.length, 0,
-      `Got a renderSlot from ${particle.name}:${slotName} (content types: ${Object.keys(content).join(', ')}), but not expecting anything further.`);
+      `Got a renderSlot from ${particle.name}:${slotName} (content types: ${Object.keys(content).join(', ')}), but not expecting anything further. Enable {strict: false, logging: true} to diagnose`);
 
     // renderSlot must happen before _verifyRenderContent, because the latter removes this call from expectations,
     // and potentially making mock-slot-composer idle before the renderSlot has actualy complete.
@@ -248,6 +248,8 @@ export class MockSlotComposer extends FakeSlotComposer {
       const canIgnore = this._canIgnore(particle.name, slotName, content);
       if (canIgnore) {
         console.log(`Skipping unexpected render slot request: ${particle.name}:${slotName} (content types: ${Object.keys(content).join(', ')})`);
+        console.log('expected? add this line:');
+        console.log(`  .expectRenderSlot('${particle.name}', '${slotName}', {'contentTypes': ['${Object.keys(content).join('\', \'')}']})`);
       }
       assert(canIgnore, `Unexpected render slot ${slotName} for particle ${particle.name} (content types: ${Object.keys(content).join(',')})`);
     }
@@ -292,7 +294,7 @@ export class MockSlotComposer extends FakeSlotComposer {
     }
   }
 
-  debugMessagesToString() {
+  debugMessagesToString(): string {
     const result = [];
     result.push('--------------------------------------------');
     this.debugMessages.forEach(debug => {

--- a/src/runtime/testing/test-helper.ts
+++ b/src/runtime/testing/test-helper.ts
@@ -15,6 +15,7 @@ import {Loader} from '../loader.js';
 import {Manifest} from '../manifest.js';
 import {MessageChannel} from '../message-channel.js';
 import {MockSlotComposer} from '../testing/mock-slot-composer.js';
+import {FakeSlotComposer} from '../testing/fake-slot-composer.js';
 import {MockSlotDomConsumer} from '../testing/mock-slot-dom-consumer.js';
 import {ParticleExecutionContext} from '../particle-execution-context.js';
 import {Planner} from '../planner.js';

--- a/tools/reducethislist
+++ b/tools/reducethislist
@@ -68,7 +68,6 @@ src/runtime/test/reference-test.js
 src/runtime/test/schema-tests.js
 src/runtime/test/slot-consumer-tests.js
 src/runtime/test/storage-proxy-test.js
-src/runtime/test/suggestion-composer-tests.js
 src/runtime/test/type-checker-tests.js
 src/runtime/test/volatile-storage-test.js
 


### PR DESCRIPTION
- Also cleans up usage of MockSlotComposer
- Adds useful error messages to make it easier to migrate to MockSlotComposer