### PR TITLE
Re-enable StrategyExplorer for tests

### DIFF
--- a/src/runtime/plan/plan-consumer.ts
+++ b/src/runtime/plan/plan-consumer.ts
@@ -61,7 +61,8 @@ export class PlanConsumer {
     this._onMaybeSuggestionsChanged();
 
     if (this.result.generations.length && DevtoolsConnection.isConnected) {
-      StrategyExplorerAdapter.processGenerations(this.result.generations, DevtoolsConnection.get().forArc(this.arc), {label: 'Planning'});
+      StrategyExplorerAdapter.processGenerations(this.result.generations,
+          DevtoolsConnection.get().forArc(this.arc), {label: 'Plan Consumer', keep: true});
     }
   }
 

--- a/src/runtime/plan/plan-producer.ts
+++ b/src/runtime/plan/plan-producer.ts
@@ -39,9 +39,10 @@ export class PlanProducer {
   search: string;
   searchStore?: VariableStorageProvider;
   searchStoreCallback: ({}) => void;
-  debug = false;
+  debug: boolean;
+  blockDevtools: boolean;
 
-  constructor(arc: Arc, result: PlanningResult, searchStore?: VariableStorageProvider, {debug = false} = {}) {
+  constructor(arc: Arc, result: PlanningResult, searchStore?: VariableStorageProvider, {debug = false, blockDevtools = false} = {}) {
     assert(result, 'result cannot be null');                
     assert(arc, 'arc cannot be null');
     this.arc = arc;
@@ -54,6 +55,7 @@ export class PlanProducer {
       this.searchStore.on('change', this.searchStoreCallback, this);
     }
     this.debug = debug;
+    this.blockDevtools = blockDevtools;
   }
 
   get isPlanning() { return this._isPlanning; }
@@ -159,7 +161,8 @@ export class PlanProducer {
         contextual: options['contextual'],
         search: options['search'],
         recipeIndex: this.recipeIndex
-      }
+      },
+      blockDevtools: this.blockDevtools
     });
 
     suggestions = await this.planner.suggest(options['timeout'] || defaultTimeoutMs, generations, this.speculator);

--- a/src/runtime/plan/planificator.ts
+++ b/src/runtime/plan/planificator.ts
@@ -63,7 +63,7 @@ export class Planificator {
     this.searchStore = searchStore;
     this.result = new PlanningResult(store);
     if (!onlyConsumer) {
-      this.producer = new PlanProducer(this.arc, this.result, searchStore, {debug});
+      this.producer = new PlanProducer(this.arc, this.result, searchStore, {debug, blockDevtools: true /* handled by consumer */});
       this.replanQueue = new ReplanQueue(this.producer);
       this.dataChangeCallback = () => this.replanQueue.addChange();
       this._listenToArcStores();

--- a/src/runtime/planner.ts
+++ b/src/runtime/planner.ts
@@ -33,22 +33,26 @@ import {Speculator} from './speculator.js';
 import {Suggestion} from './plan/suggestion.js';
 import {Tracing} from '../tracelib/trace.js';
 import {DevtoolsConnection} from './debug/devtools-connection.js';
+import {StrategyExplorerAdapter} from './debug/strategy-explorer-adapter.js';
+import {PlanningResult} from './plan/planning-result.js';
 
 export class Planner {
   private _arc: Arc;
   // public for debug tools
   strategizer: Strategizer;
+  blockDevtools: boolean;
 
   // TODO: Use context.arc instead of arc
-  init(arc: Arc, {strategies = Planner.AllStrategies, ruleset = Rulesets.Empty, strategyArgs = {}} = {}) {
+  init(arc: Arc, {strategies = Planner.AllStrategies, ruleset = Rulesets.Empty, strategyArgs = {}, blockDevtools = false} = {}) {
     strategyArgs = Object.freeze({...strategyArgs});
     this._arc = arc;
     const strategyImpls = strategies.map(strategy => new strategy(arc, strategyArgs));
     this.strategizer = new Strategizer(strategyImpls, [], ruleset);
+    this.blockDevtools = blockDevtools;
   }
 
   // Specify a timeout value less than zero to disable timeouts.
-  async plan(timeout?: number, generations?) {
+  async plan(timeout?: number, generations = []) {
     const trace = Tracing.start({cat: 'planning', name: 'Planner::plan', overview: true, args: {timeout}});
     timeout = timeout || -1;
     const allResolved = [];
@@ -76,6 +80,12 @@ export class Planner {
       }
     } while (this.strategizer.generated.length + this.strategizer.terminal.length > 0);
     trace.end();
+
+    if (generations.length && !this.blockDevtools && DevtoolsConnection.isConnected) {
+      StrategyExplorerAdapter.processGenerations(
+        PlanningResult.formatSerializableGenerations(generations),
+        DevtoolsConnection.get().forArc(this._arc), {label: 'Planner', keep: true});
+    }
     return allResolved;
   }
 
@@ -119,7 +129,6 @@ export class Planner {
 
   async suggest(timeout?: number, generations: {}[] = [], speculator?: Speculator) : Promise<Suggestion[]> {
     const trace = Tracing.start({cat: 'planning', name: 'Planner::suggest', overview: true, args: {timeout}});
-    if (!generations && DevtoolsConnection.isConnected) generations = [];
     const plans = await trace.wait(this.plan(timeout, generations));
     const suggestions = [];
     speculator = speculator || new Speculator();

--- a/src/runtime/testing/test-helper.ts
+++ b/src/runtime/testing/test-helper.ts
@@ -13,14 +13,10 @@ import {Arc} from '../arc.js';
 import {InterfaceType} from '../type.js';
 import {Loader} from '../loader.js';
 import {Manifest} from '../manifest.js';
-import {MessageChannel} from '../message-channel.js';
 import {MockSlotComposer} from '../testing/mock-slot-composer.js';
-import {FakeSlotComposer} from '../testing/fake-slot-composer.js';
 import {MockSlotDomConsumer} from '../testing/mock-slot-dom-consumer.js';
-import {ParticleExecutionContext} from '../particle-execution-context.js';
 import {Planner} from '../planner.js';
 import {RecipeIndex} from '../recipe-index.js';
-import {SlotComposer} from '../slot-composer.js';
 import {Suggestion} from '../plan/suggestion.js';
 
 type TestHelperOptions = {


### PR DESCRIPTION
Re-adds the DevTools communication to Planner, but needs to sprinkle `blockDevtools` boolean for Planificator -> PlanProducer -> Planner codepath, as for PlanConsumer+PlanProducer case we send generations from the PlanConsumer. Suggestions how to limit the amount of boilerplate are welcome

Intended result:

* StrategyExplorer works once more with `./tools/sigh test --explore`, unblocks @AliceLetitia .
* StrategyExplorer works when connected to the remote planner, where consumer is not present (I think).