### PR TITLE
dont clear slot-dom-consumer cache to support multiple arcs

### DIFF
--- a/shells/web-shell/elements/web-shell.js
+++ b/shells/web-shell/elements/web-shell.js
@@ -23,9 +23,6 @@ import './web-planner.js';
 import './ui/web-shell-ui.js';
 import './pipes/device-client-pipe.js';
 
-// disable flushing template cache on dispose
-SlotDomConsumer.multitenant = true;
-
 const manifests = {
   context: `
     import 'https://$particles/canonical.manifest'

--- a/src/runtime/slot-composer.ts
+++ b/src/runtime/slot-composer.ts
@@ -208,7 +208,6 @@ export class SlotComposer {
 
   dispose() {
     this.consumers.forEach(consumer => consumer.dispose());
-    this.modalityHandler.slotConsumerClass.dispose();
     this._contexts.forEach(context => {
       context.clearSlotConsumers();
       if (context.container) {

--- a/src/runtime/slot-dom-consumer.ts
+++ b/src/runtime/slot-dom-consumer.ts
@@ -159,13 +159,8 @@ export class SlotDomConsumer extends SlotConsumer {
     container.textContent = '';
   }
 
-  static dispose() {
-    // TODO(sjmiles): dumping the template cache causes errors when running parallel arcs
-    // in shell. Disable for now, the corpus of templates is static at this time.
-    // empty template cache
-    if (!SlotDomConsumer['multitenant']) {
-      templateByName.clear();
-    }
+  static clearCache() {
+    templateByName.clear();
   }
 
   static findRootContainers(topContainer) {

--- a/src/runtime/testing/mock-slot-composer.ts
+++ b/src/runtime/testing/mock-slot-composer.ts
@@ -56,7 +56,7 @@ export class MockSlotComposer extends FakeSlotComposer {
     this.debugMessages = [];
 
     // Clear all cached templates
-    SlotDomConsumer.dispose();
+    SlotDomConsumer.clearCache();
   }
 
    // Overriding this method to investigate AppVeyor failures.


### PR DESCRIPTION
get rid of the `multitenant` workaround.
fixes: https://github.com/PolymerLabs/arcs/issues/2089