### PR TITLE
Clean up PlanProducer after PR #2560

### DIFF
--- a/src/runtime/plan/plan-producer.ts
+++ b/src/runtime/plan/plan-producer.ts
@@ -40,9 +40,8 @@ export class PlanProducer {
   searchStore?: VariableStorageProvider;
   searchStoreCallback: ({}) => void;
   debug: boolean;
-  blockDevtools: boolean;
 
-  constructor(arc: Arc, result: PlanningResult, searchStore?: VariableStorageProvider, {debug = false, blockDevtools = false} = {}) {
+  constructor(arc: Arc, result: PlanningResult, searchStore?: VariableStorageProvider, {debug = false} = {}) {
     assert(result, 'result cannot be null');                
     assert(arc, 'arc cannot be null');
     this.arc = arc;
@@ -55,7 +54,6 @@ export class PlanProducer {
       this.searchStore.on('change', this.searchStoreCallback, this);
     }
     this.debug = debug;
-    this.blockDevtools = blockDevtools;
   }
 
   get isPlanning() { return this._isPlanning; }
@@ -162,7 +160,7 @@ export class PlanProducer {
         search: options['search'],
         recipeIndex: this.recipeIndex
       },
-      blockDevtools: this.blockDevtools
+      blockDevtools: true // Devtools communication is handled by PlanConsumer in Producer+Consumer setup.
     });
 
     suggestions = await this.planner.suggest(options['timeout'] || defaultTimeoutMs, generations, this.speculator);

--- a/src/runtime/plan/planificator.ts
+++ b/src/runtime/plan/planificator.ts
@@ -63,7 +63,7 @@ export class Planificator {
     this.searchStore = searchStore;
     this.result = new PlanningResult(store);
     if (!onlyConsumer) {
-      this.producer = new PlanProducer(this.arc, this.result, searchStore, {debug, blockDevtools: true /* handled by consumer */});
+      this.producer = new PlanProducer(this.arc, this.result, searchStore, {debug});
       this.replanQueue = new ReplanQueue(this.producer);
       this.dataChangeCallback = () => this.replanQueue.addChange();
       this._listenToArcStores();


### PR DESCRIPTION
Given that PlanProducer implies PlanConsumer, this patch simplifies the cruft introduced in #2560.

We can still use DevTools StrategyExplorer with:

* Tests (test-helper planning in particular).
* Remote Planner
* Web Shell in both consumer-only and consumer+producer modes.