### PR TITLE
gracefully handle undefined optional target-slot

### DIFF
--- a/src/runtime/debug/arc-debug-handler.ts
+++ b/src/runtime/debug/arc-debug-handler.ts
@@ -45,11 +45,13 @@ export class ArcDebugHandler {
     const truncate = ({id, name}) => ({id, name});
     const slotConnections = [];
     particles.forEach(p => Object.values(p.consumedSlotConnections).forEach(cs => {
-      slotConnections.push({
-        particleId: cs.particle.id,
-        consumed: truncate(cs.targetSlot),
-        provided: Object.values(cs.providedSlots).map(slot  => truncate(slot)),
-      });
+      if (cs.targetSlot) {
+        slotConnections.push({
+          particleId: cs.particle.id,
+          consumed: truncate(cs.targetSlot),
+          provided: Object.values(cs.providedSlots).map(slot  => truncate(slot)),
+        });
+      }
     }));
     this.arcDevtoolsChannel.send({
       messageType: 'recipe-instantiated',


### PR DESCRIPTION
fixes: https://github.com/PolymerLabs/arcs/issues/2576
IIUC the particle has 2 consume-connections and only one is resolved (which is valid, but needs to be handled in the extension)
