### PR TITLE
Add Repeat and Retry functionality to sigh test

### DIFF
--- a/devtools/package-lock.json
+++ b/devtools/package-lock.json
@@ -52,11 +52,6 @@
         "@polymer/polymer": "^3.0.0"
       }
     },
-    "@polymer/font-roboto": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@polymer/font-roboto/-/font-roboto-3.0.2.tgz",
-      "integrity": "sha512-tx5TauYSmzsIvmSqepUPDYbs4/Ejz2XbZ1IkD7JEGqkdNUJlh+9KU85G56Tfdk/xjEZ8zorFfN09OSwiMrIQWA=="
-    },
     "@polymer/iron-a11y-keys-behavior": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@polymer/iron-a11y-keys-behavior/-/iron-a11y-keys-behavior-3.0.1.tgz",
@@ -95,16 +90,6 @@
         "@polymer/polymer": "^3.0.0"
       }
     },
-    "@polymer/iron-checked-element-behavior": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@polymer/iron-checked-element-behavior/-/iron-checked-element-behavior-3.0.1.tgz",
-      "integrity": "sha512-aDr0cbCNVq49q+pOqa6CZutFh+wWpwPMLpEth9swx+GkAj+gCURhuQkaUYhIo5f2egDbEioR1aeHMnPlU9dQZA==",
-      "requires": {
-        "@polymer/iron-form-element-behavior": "^3.0.0-pre.26",
-        "@polymer/iron-validatable-behavior": "^3.0.0-pre.26",
-        "@polymer/polymer": "^3.0.0"
-      }
-    },
     "@polymer/iron-dropdown": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@polymer/iron-dropdown/-/iron-dropdown-3.0.1.tgz",
@@ -128,14 +113,6 @@
       "version": "3.0.0-pre.25",
       "resolved": "https://registry.npmjs.org/@polymer/iron-flex-layout/-/iron-flex-layout-3.0.0-pre.25.tgz",
       "integrity": "sha512-ykYxrF6UlnWP0jcbXV51BG3Ts6XD6BWg7HOzkt60YWNkB69QUf3grESUkfT/SERj7WySlGom4no/tdpOPRtwAw==",
-      "requires": {
-        "@polymer/polymer": "^3.0.0"
-      }
-    },
-    "@polymer/iron-form-element-behavior": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@polymer/iron-form-element-behavior/-/iron-form-element-behavior-3.0.1.tgz",
-      "integrity": "sha512-G/e2KXyL5AY7mMjmomHkGpgS0uAf4ovNpKhkuUTRnMuMJuf589bKqE85KN4ovE1Tzhv2hJoh/igyD6ekHiYU1A==",
       "requires": {
         "@polymer/polymer": "^3.0.0"
       }
@@ -206,26 +183,6 @@
         "@polymer/polymer": "^3.0.0"
       }
     },
-    "@polymer/iron-input": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@polymer/iron-input/-/iron-input-3.0.1.tgz",
-      "integrity": "sha512-WLx13kEcbH9GKbj9+pWR6pbJkA5kxn3796ynx6eQd2rueMyUfVTR3GzOvadBKsciUuIuzrxpBWZ2+3UcueVUQQ==",
-      "requires": {
-        "@polymer/iron-a11y-announcer": "^3.0.0-pre.26",
-        "@polymer/iron-validatable-behavior": "^3.0.0-pre.26",
-        "@polymer/polymer": "^3.0.0"
-      },
-      "dependencies": {
-        "@polymer/iron-a11y-announcer": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/@polymer/iron-a11y-announcer/-/iron-a11y-announcer-3.0.1.tgz",
-          "integrity": "sha512-Xiqmpz0AEEbMNGYPpbrXBIrcI/xaR4tn77pmSLfxVKGGwjEUR/YrRgyIwXp4EN7lvst1dFC8kyl2hLga0uDIVQ==",
-          "requires": {
-            "@polymer/polymer": "^3.0.0"
-          }
-        }
-      }
-    },
     "@polymer/iron-list": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@polymer/iron-list/-/iron-list-3.0.1.tgz",
@@ -253,27 +210,6 @@
       "integrity": "sha512-almb+p/fdSi4bxG+vyXjY51fDZxHMxwiug51Lfvr86wZRXN/u21Y6BapxG5n9f0hPSy9fimjIAvaYmozi7VjyQ==",
       "requires": {
         "@polymer/polymer": "^3.0.0"
-      }
-    },
-    "@polymer/iron-menu-behavior": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@polymer/iron-menu-behavior/-/iron-menu-behavior-3.0.1.tgz",
-      "integrity": "sha512-yIIBopb9ZaJBzvk20OFRaAXuTEuBw8d19Ja7r0Rfc3sTMt73UHGccBBeH51wCLLhQzNEBfwaQKOGg4INhl3unw==",
-      "requires": {
-        "@polymer/iron-a11y-keys-behavior": "^3.0.0-pre.26",
-        "@polymer/iron-flex-layout": "^3.0.0-pre.26",
-        "@polymer/iron-selector": "^3.0.0-pre.26",
-        "@polymer/polymer": "^3.0.0"
-      },
-      "dependencies": {
-        "@polymer/iron-flex-layout": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/@polymer/iron-flex-layout/-/iron-flex-layout-3.0.1.tgz",
-          "integrity": "sha512-7gB869czArF+HZcPTVSgvA7tXYFze9EKckvM95NB7SqYF+NnsQyhoXgKnpFwGyo95lUjUW9TFDLUwDXnCYFtkw==",
-          "requires": {
-            "@polymer/polymer": "^3.0.0"
-          }
-        }
       }
     },
     "@polymer/iron-meta": {
@@ -382,201 +318,6 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/@polymer/iron-resizable-behavior/-/iron-resizable-behavior-3.0.1.tgz",
           "integrity": "sha512-FyHxRxFspVoRaeZSWpT3y0C9awomb4tXXolIJcZ7RvXhMP632V5lez+ch5G5SwK0LpnAPkg35eB0LPMFv+YMMQ==",
-          "requires": {
-            "@polymer/polymer": "^3.0.0"
-          }
-        }
-      }
-    },
-    "@polymer/paper-behaviors": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@polymer/paper-behaviors/-/paper-behaviors-3.0.1.tgz",
-      "integrity": "sha512-6knhj69fPJejv8qR0kCSUY+Q0XjaUf0OSnkjRjmTJPAwSrRYtgqE+l6P1FfA+py1X/cUjgne9EF5rMZAKJIg1g==",
-      "requires": {
-        "@polymer/iron-behaviors": "^3.0.0-pre.26",
-        "@polymer/iron-checked-element-behavior": "^3.0.0-pre.26",
-        "@polymer/paper-ripple": "^3.0.0-pre.26",
-        "@polymer/polymer": "^3.0.0"
-      }
-    },
-    "@polymer/paper-dropdown-menu": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@polymer/paper-dropdown-menu/-/paper-dropdown-menu-3.0.1.tgz",
-      "integrity": "sha512-GBFzoP8SC+MTcLgKAflmGEvfjboCFVNkJd39fBEoNHAV3KU92ugmR4sl9iFaIaaGuxJ7QdjsLa2zQPlcS4lr6Q==",
-      "requires": {
-        "@polymer/iron-a11y-keys-behavior": "^3.0.0-pre.26",
-        "@polymer/iron-form-element-behavior": "^3.0.0-pre.26",
-        "@polymer/iron-icon": "^3.0.0-pre.26",
-        "@polymer/iron-iconset-svg": "^3.0.0-pre.26",
-        "@polymer/iron-validatable-behavior": "^3.0.0-pre.26",
-        "@polymer/paper-behaviors": "^3.0.0-pre.27",
-        "@polymer/paper-input": "^3.0.0-pre.26",
-        "@polymer/paper-menu-button": "^3.0.0-pre.26",
-        "@polymer/paper-ripple": "^3.0.0-pre.26",
-        "@polymer/paper-styles": "^3.0.0-pre.26",
-        "@polymer/polymer": "^3.0.0"
-      },
-      "dependencies": {
-        "@polymer/iron-flex-layout": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/@polymer/iron-flex-layout/-/iron-flex-layout-3.0.1.tgz",
-          "integrity": "sha512-7gB869czArF+HZcPTVSgvA7tXYFze9EKckvM95NB7SqYF+NnsQyhoXgKnpFwGyo95lUjUW9TFDLUwDXnCYFtkw==",
-          "requires": {
-            "@polymer/polymer": "^3.0.0"
-          }
-        },
-        "@polymer/iron-icon": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/@polymer/iron-icon/-/iron-icon-3.0.1.tgz",
-          "integrity": "sha512-QLPwirk+UPZNaLnMew9VludXA4CWUCenRewgEcGYwdzVgDPCDbXxy6vRJjmweZobMQv/oVLppT2JZtJFnPxX6g==",
-          "requires": {
-            "@polymer/iron-flex-layout": "^3.0.0-pre.26",
-            "@polymer/iron-meta": "^3.0.0-pre.26",
-            "@polymer/polymer": "^3.0.0"
-          }
-        },
-        "@polymer/iron-iconset-svg": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/@polymer/iron-iconset-svg/-/iron-iconset-svg-3.0.1.tgz",
-          "integrity": "sha512-XNwURbNHRw6u2fJe05O5fMYye6GSgDlDqCO+q6K1zAnKIrpgZwf2vTkBd5uCcZwsN0FyCB3mvNZx4jkh85dRDw==",
-          "requires": {
-            "@polymer/iron-meta": "^3.0.0-pre.26",
-            "@polymer/polymer": "^3.0.0"
-          }
-        },
-        "@polymer/iron-meta": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/@polymer/iron-meta/-/iron-meta-3.0.1.tgz",
-          "integrity": "sha512-pWguPugiLYmWFV9UWxLWzZ6gm4wBwQdDy4VULKwdHCqR7OP7u98h+XDdGZsSlDPv6qoryV/e3tGHlTIT0mbzJA==",
-          "requires": {
-            "@polymer/polymer": "^3.0.0"
-          }
-        }
-      }
-    },
-    "@polymer/paper-fab": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@polymer/paper-fab/-/paper-fab-3.0.1.tgz",
-      "integrity": "sha512-LO8ckgd72MnAtC1WiPd5CFR27WC/dEuY/lOIQuHYdEjwI62+iiV7Bmr7uoQ9wvvV71qMFdMIOyq/03KklsuAzw==",
-      "requires": {
-        "@polymer/iron-flex-layout": "^3.0.0-pre.26",
-        "@polymer/iron-icon": "^3.0.0-pre.26",
-        "@polymer/paper-behaviors": "^3.0.0-pre.27",
-        "@polymer/paper-styles": "^3.0.0-pre.26",
-        "@polymer/polymer": "^3.0.0"
-      },
-      "dependencies": {
-        "@polymer/iron-flex-layout": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/@polymer/iron-flex-layout/-/iron-flex-layout-3.0.1.tgz",
-          "integrity": "sha512-7gB869czArF+HZcPTVSgvA7tXYFze9EKckvM95NB7SqYF+NnsQyhoXgKnpFwGyo95lUjUW9TFDLUwDXnCYFtkw==",
-          "requires": {
-            "@polymer/polymer": "^3.0.0"
-          }
-        },
-        "@polymer/iron-icon": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/@polymer/iron-icon/-/iron-icon-3.0.1.tgz",
-          "integrity": "sha512-QLPwirk+UPZNaLnMew9VludXA4CWUCenRewgEcGYwdzVgDPCDbXxy6vRJjmweZobMQv/oVLppT2JZtJFnPxX6g==",
-          "requires": {
-            "@polymer/iron-flex-layout": "^3.0.0-pre.26",
-            "@polymer/iron-meta": "^3.0.0-pre.26",
-            "@polymer/polymer": "^3.0.0"
-          }
-        },
-        "@polymer/iron-meta": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/@polymer/iron-meta/-/iron-meta-3.0.1.tgz",
-          "integrity": "sha512-pWguPugiLYmWFV9UWxLWzZ6gm4wBwQdDy4VULKwdHCqR7OP7u98h+XDdGZsSlDPv6qoryV/e3tGHlTIT0mbzJA==",
-          "requires": {
-            "@polymer/polymer": "^3.0.0"
-          }
-        }
-      }
-    },
-    "@polymer/paper-input": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@polymer/paper-input/-/paper-input-3.0.1.tgz",
-      "integrity": "sha512-th6fuP6PyQEBJSWVtJQ/ZsoQp8Zysq4bRIOg2uGZsNX6gfm6AVoMph5pXOlS8RHoVDDYDG9GRjQib7JPSWKkrw==",
-      "requires": {
-        "@polymer/iron-a11y-keys-behavior": "^3.0.0-pre.26",
-        "@polymer/iron-autogrow-textarea": "^3.0.0-pre.26",
-        "@polymer/iron-behaviors": "^3.0.0-pre.26",
-        "@polymer/iron-form-element-behavior": "^3.0.0-pre.26",
-        "@polymer/iron-input": "^3.0.0-pre.26",
-        "@polymer/paper-styles": "^3.0.0-pre.26",
-        "@polymer/polymer": "^3.0.0"
-      }
-    },
-    "@polymer/paper-item": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@polymer/paper-item/-/paper-item-3.0.1.tgz",
-      "integrity": "sha512-KTk2N+GsYiI/HuubL3sxebZ6tteQbBOAp4QVLAnbjSPmwl+mJSDWk+omuadesU0bpkCwaWVs3fHuQsmXxy4pkw==",
-      "requires": {
-        "@polymer/iron-behaviors": "^3.0.0-pre.26",
-        "@polymer/iron-flex-layout": "^3.0.0-pre.26",
-        "@polymer/paper-styles": "^3.0.0-pre.26",
-        "@polymer/polymer": "^3.0.0"
-      },
-      "dependencies": {
-        "@polymer/iron-flex-layout": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/@polymer/iron-flex-layout/-/iron-flex-layout-3.0.1.tgz",
-          "integrity": "sha512-7gB869czArF+HZcPTVSgvA7tXYFze9EKckvM95NB7SqYF+NnsQyhoXgKnpFwGyo95lUjUW9TFDLUwDXnCYFtkw==",
-          "requires": {
-            "@polymer/polymer": "^3.0.0"
-          }
-        }
-      }
-    },
-    "@polymer/paper-listbox": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@polymer/paper-listbox/-/paper-listbox-3.0.1.tgz",
-      "integrity": "sha512-vMLWFpYcggAPmEDBmK+96fFefacOG3GLB1EguTn8+ZkqI+328hNfw1MzHjH68rgCIIUtjmm+9qgB1Sy/MN0a/A==",
-      "requires": {
-        "@polymer/iron-behaviors": "^3.0.0-pre.26",
-        "@polymer/iron-menu-behavior": "^3.0.0-pre.26",
-        "@polymer/paper-styles": "^3.0.0-pre.26",
-        "@polymer/polymer": "^3.0.0"
-      }
-    },
-    "@polymer/paper-menu-button": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@polymer/paper-menu-button/-/paper-menu-button-3.0.1.tgz",
-      "integrity": "sha512-Rxte2Fp7N2BMI2FMM7tB25IkvD11DhjMklcg97JP1jnlHbJNrXPh5SSX2bdtabz49UE8vejIsrxZ+AGsB5nqIQ==",
-      "requires": {
-        "@polymer/iron-a11y-keys-behavior": "^3.0.0-pre.26",
-        "@polymer/iron-behaviors": "^3.0.0-pre.26",
-        "@polymer/iron-dropdown": "^3.0.0-pre.26",
-        "@polymer/iron-fit-behavior": "^3.0.0-pre.26",
-        "@polymer/neon-animation": "^3.0.0-pre.26",
-        "@polymer/paper-styles": "^3.0.0-pre.26",
-        "@polymer/polymer": "^3.0.0"
-      }
-    },
-    "@polymer/paper-ripple": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@polymer/paper-ripple/-/paper-ripple-3.0.1.tgz",
-      "integrity": "sha512-dgOe12GyCF1VZBLUQqnzGWlf3xb255FajNCVB1VFj/AtskYtoamnafa7m3a+1vs+C8qbg4Benn5KwgxVDSW4cg==",
-      "requires": {
-        "@polymer/iron-a11y-keys-behavior": "^3.0.0-pre.26",
-        "@polymer/polymer": "^3.0.0"
-      }
-    },
-    "@polymer/paper-styles": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@polymer/paper-styles/-/paper-styles-3.0.1.tgz",
-      "integrity": "sha512-y6hmObLqlCx602TQiSBKHqjwkE7xmDiFkoxdYGaNjtv4xcysOTdVJsDR/R9UHwIaxJ7gHlthMSykir1nv78++g==",
-      "requires": {
-        "@polymer/font-roboto": "^3.0.1",
-        "@polymer/iron-flex-layout": "^3.0.0-pre.26",
-        "@polymer/polymer": "^3.0.0"
-      },
-      "dependencies": {
-        "@polymer/iron-flex-layout": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/@polymer/iron-flex-layout/-/iron-flex-layout-3.0.1.tgz",
-          "integrity": "sha512-7gB869czArF+HZcPTVSgvA7tXYFze9EKckvM95NB7SqYF+NnsQyhoXgKnpFwGyo95lUjUW9TFDLUwDXnCYFtkw==",
           "requires": {
             "@polymer/polymer": "^3.0.0"
           }

--- a/devtools/package-lock.json
+++ b/devtools/package-lock.json
@@ -52,6 +52,11 @@
         "@polymer/polymer": "^3.0.0"
       }
     },
+    "@polymer/font-roboto": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@polymer/font-roboto/-/font-roboto-3.0.2.tgz",
+      "integrity": "sha512-tx5TauYSmzsIvmSqepUPDYbs4/Ejz2XbZ1IkD7JEGqkdNUJlh+9KU85G56Tfdk/xjEZ8zorFfN09OSwiMrIQWA=="
+    },
     "@polymer/iron-a11y-keys-behavior": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@polymer/iron-a11y-keys-behavior/-/iron-a11y-keys-behavior-3.0.1.tgz",
@@ -90,6 +95,16 @@
         "@polymer/polymer": "^3.0.0"
       }
     },
+    "@polymer/iron-checked-element-behavior": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@polymer/iron-checked-element-behavior/-/iron-checked-element-behavior-3.0.1.tgz",
+      "integrity": "sha512-aDr0cbCNVq49q+pOqa6CZutFh+wWpwPMLpEth9swx+GkAj+gCURhuQkaUYhIo5f2egDbEioR1aeHMnPlU9dQZA==",
+      "requires": {
+        "@polymer/iron-form-element-behavior": "^3.0.0-pre.26",
+        "@polymer/iron-validatable-behavior": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
     "@polymer/iron-dropdown": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@polymer/iron-dropdown/-/iron-dropdown-3.0.1.tgz",
@@ -113,6 +128,14 @@
       "version": "3.0.0-pre.25",
       "resolved": "https://registry.npmjs.org/@polymer/iron-flex-layout/-/iron-flex-layout-3.0.0-pre.25.tgz",
       "integrity": "sha512-ykYxrF6UlnWP0jcbXV51BG3Ts6XD6BWg7HOzkt60YWNkB69QUf3grESUkfT/SERj7WySlGom4no/tdpOPRtwAw==",
+      "requires": {
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@polymer/iron-form-element-behavior": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@polymer/iron-form-element-behavior/-/iron-form-element-behavior-3.0.1.tgz",
+      "integrity": "sha512-G/e2KXyL5AY7mMjmomHkGpgS0uAf4ovNpKhkuUTRnMuMJuf589bKqE85KN4ovE1Tzhv2hJoh/igyD6ekHiYU1A==",
       "requires": {
         "@polymer/polymer": "^3.0.0"
       }
@@ -183,6 +206,26 @@
         "@polymer/polymer": "^3.0.0"
       }
     },
+    "@polymer/iron-input": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@polymer/iron-input/-/iron-input-3.0.1.tgz",
+      "integrity": "sha512-WLx13kEcbH9GKbj9+pWR6pbJkA5kxn3796ynx6eQd2rueMyUfVTR3GzOvadBKsciUuIuzrxpBWZ2+3UcueVUQQ==",
+      "requires": {
+        "@polymer/iron-a11y-announcer": "^3.0.0-pre.26",
+        "@polymer/iron-validatable-behavior": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      },
+      "dependencies": {
+        "@polymer/iron-a11y-announcer": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/@polymer/iron-a11y-announcer/-/iron-a11y-announcer-3.0.1.tgz",
+          "integrity": "sha512-Xiqmpz0AEEbMNGYPpbrXBIrcI/xaR4tn77pmSLfxVKGGwjEUR/YrRgyIwXp4EN7lvst1dFC8kyl2hLga0uDIVQ==",
+          "requires": {
+            "@polymer/polymer": "^3.0.0"
+          }
+        }
+      }
+    },
     "@polymer/iron-list": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@polymer/iron-list/-/iron-list-3.0.1.tgz",
@@ -210,6 +253,27 @@
       "integrity": "sha512-almb+p/fdSi4bxG+vyXjY51fDZxHMxwiug51Lfvr86wZRXN/u21Y6BapxG5n9f0hPSy9fimjIAvaYmozi7VjyQ==",
       "requires": {
         "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@polymer/iron-menu-behavior": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@polymer/iron-menu-behavior/-/iron-menu-behavior-3.0.1.tgz",
+      "integrity": "sha512-yIIBopb9ZaJBzvk20OFRaAXuTEuBw8d19Ja7r0Rfc3sTMt73UHGccBBeH51wCLLhQzNEBfwaQKOGg4INhl3unw==",
+      "requires": {
+        "@polymer/iron-a11y-keys-behavior": "^3.0.0-pre.26",
+        "@polymer/iron-flex-layout": "^3.0.0-pre.26",
+        "@polymer/iron-selector": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      },
+      "dependencies": {
+        "@polymer/iron-flex-layout": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/@polymer/iron-flex-layout/-/iron-flex-layout-3.0.1.tgz",
+          "integrity": "sha512-7gB869czArF+HZcPTVSgvA7tXYFze9EKckvM95NB7SqYF+NnsQyhoXgKnpFwGyo95lUjUW9TFDLUwDXnCYFtkw==",
+          "requires": {
+            "@polymer/polymer": "^3.0.0"
+          }
+        }
       }
     },
     "@polymer/iron-meta": {
@@ -318,6 +382,201 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/@polymer/iron-resizable-behavior/-/iron-resizable-behavior-3.0.1.tgz",
           "integrity": "sha512-FyHxRxFspVoRaeZSWpT3y0C9awomb4tXXolIJcZ7RvXhMP632V5lez+ch5G5SwK0LpnAPkg35eB0LPMFv+YMMQ==",
+          "requires": {
+            "@polymer/polymer": "^3.0.0"
+          }
+        }
+      }
+    },
+    "@polymer/paper-behaviors": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@polymer/paper-behaviors/-/paper-behaviors-3.0.1.tgz",
+      "integrity": "sha512-6knhj69fPJejv8qR0kCSUY+Q0XjaUf0OSnkjRjmTJPAwSrRYtgqE+l6P1FfA+py1X/cUjgne9EF5rMZAKJIg1g==",
+      "requires": {
+        "@polymer/iron-behaviors": "^3.0.0-pre.26",
+        "@polymer/iron-checked-element-behavior": "^3.0.0-pre.26",
+        "@polymer/paper-ripple": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@polymer/paper-dropdown-menu": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@polymer/paper-dropdown-menu/-/paper-dropdown-menu-3.0.1.tgz",
+      "integrity": "sha512-GBFzoP8SC+MTcLgKAflmGEvfjboCFVNkJd39fBEoNHAV3KU92ugmR4sl9iFaIaaGuxJ7QdjsLa2zQPlcS4lr6Q==",
+      "requires": {
+        "@polymer/iron-a11y-keys-behavior": "^3.0.0-pre.26",
+        "@polymer/iron-form-element-behavior": "^3.0.0-pre.26",
+        "@polymer/iron-icon": "^3.0.0-pre.26",
+        "@polymer/iron-iconset-svg": "^3.0.0-pre.26",
+        "@polymer/iron-validatable-behavior": "^3.0.0-pre.26",
+        "@polymer/paper-behaviors": "^3.0.0-pre.27",
+        "@polymer/paper-input": "^3.0.0-pre.26",
+        "@polymer/paper-menu-button": "^3.0.0-pre.26",
+        "@polymer/paper-ripple": "^3.0.0-pre.26",
+        "@polymer/paper-styles": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      },
+      "dependencies": {
+        "@polymer/iron-flex-layout": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/@polymer/iron-flex-layout/-/iron-flex-layout-3.0.1.tgz",
+          "integrity": "sha512-7gB869czArF+HZcPTVSgvA7tXYFze9EKckvM95NB7SqYF+NnsQyhoXgKnpFwGyo95lUjUW9TFDLUwDXnCYFtkw==",
+          "requires": {
+            "@polymer/polymer": "^3.0.0"
+          }
+        },
+        "@polymer/iron-icon": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/@polymer/iron-icon/-/iron-icon-3.0.1.tgz",
+          "integrity": "sha512-QLPwirk+UPZNaLnMew9VludXA4CWUCenRewgEcGYwdzVgDPCDbXxy6vRJjmweZobMQv/oVLppT2JZtJFnPxX6g==",
+          "requires": {
+            "@polymer/iron-flex-layout": "^3.0.0-pre.26",
+            "@polymer/iron-meta": "^3.0.0-pre.26",
+            "@polymer/polymer": "^3.0.0"
+          }
+        },
+        "@polymer/iron-iconset-svg": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/@polymer/iron-iconset-svg/-/iron-iconset-svg-3.0.1.tgz",
+          "integrity": "sha512-XNwURbNHRw6u2fJe05O5fMYye6GSgDlDqCO+q6K1zAnKIrpgZwf2vTkBd5uCcZwsN0FyCB3mvNZx4jkh85dRDw==",
+          "requires": {
+            "@polymer/iron-meta": "^3.0.0-pre.26",
+            "@polymer/polymer": "^3.0.0"
+          }
+        },
+        "@polymer/iron-meta": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/@polymer/iron-meta/-/iron-meta-3.0.1.tgz",
+          "integrity": "sha512-pWguPugiLYmWFV9UWxLWzZ6gm4wBwQdDy4VULKwdHCqR7OP7u98h+XDdGZsSlDPv6qoryV/e3tGHlTIT0mbzJA==",
+          "requires": {
+            "@polymer/polymer": "^3.0.0"
+          }
+        }
+      }
+    },
+    "@polymer/paper-fab": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@polymer/paper-fab/-/paper-fab-3.0.1.tgz",
+      "integrity": "sha512-LO8ckgd72MnAtC1WiPd5CFR27WC/dEuY/lOIQuHYdEjwI62+iiV7Bmr7uoQ9wvvV71qMFdMIOyq/03KklsuAzw==",
+      "requires": {
+        "@polymer/iron-flex-layout": "^3.0.0-pre.26",
+        "@polymer/iron-icon": "^3.0.0-pre.26",
+        "@polymer/paper-behaviors": "^3.0.0-pre.27",
+        "@polymer/paper-styles": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      },
+      "dependencies": {
+        "@polymer/iron-flex-layout": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/@polymer/iron-flex-layout/-/iron-flex-layout-3.0.1.tgz",
+          "integrity": "sha512-7gB869czArF+HZcPTVSgvA7tXYFze9EKckvM95NB7SqYF+NnsQyhoXgKnpFwGyo95lUjUW9TFDLUwDXnCYFtkw==",
+          "requires": {
+            "@polymer/polymer": "^3.0.0"
+          }
+        },
+        "@polymer/iron-icon": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/@polymer/iron-icon/-/iron-icon-3.0.1.tgz",
+          "integrity": "sha512-QLPwirk+UPZNaLnMew9VludXA4CWUCenRewgEcGYwdzVgDPCDbXxy6vRJjmweZobMQv/oVLppT2JZtJFnPxX6g==",
+          "requires": {
+            "@polymer/iron-flex-layout": "^3.0.0-pre.26",
+            "@polymer/iron-meta": "^3.0.0-pre.26",
+            "@polymer/polymer": "^3.0.0"
+          }
+        },
+        "@polymer/iron-meta": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/@polymer/iron-meta/-/iron-meta-3.0.1.tgz",
+          "integrity": "sha512-pWguPugiLYmWFV9UWxLWzZ6gm4wBwQdDy4VULKwdHCqR7OP7u98h+XDdGZsSlDPv6qoryV/e3tGHlTIT0mbzJA==",
+          "requires": {
+            "@polymer/polymer": "^3.0.0"
+          }
+        }
+      }
+    },
+    "@polymer/paper-input": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@polymer/paper-input/-/paper-input-3.0.1.tgz",
+      "integrity": "sha512-th6fuP6PyQEBJSWVtJQ/ZsoQp8Zysq4bRIOg2uGZsNX6gfm6AVoMph5pXOlS8RHoVDDYDG9GRjQib7JPSWKkrw==",
+      "requires": {
+        "@polymer/iron-a11y-keys-behavior": "^3.0.0-pre.26",
+        "@polymer/iron-autogrow-textarea": "^3.0.0-pre.26",
+        "@polymer/iron-behaviors": "^3.0.0-pre.26",
+        "@polymer/iron-form-element-behavior": "^3.0.0-pre.26",
+        "@polymer/iron-input": "^3.0.0-pre.26",
+        "@polymer/paper-styles": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@polymer/paper-item": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@polymer/paper-item/-/paper-item-3.0.1.tgz",
+      "integrity": "sha512-KTk2N+GsYiI/HuubL3sxebZ6tteQbBOAp4QVLAnbjSPmwl+mJSDWk+omuadesU0bpkCwaWVs3fHuQsmXxy4pkw==",
+      "requires": {
+        "@polymer/iron-behaviors": "^3.0.0-pre.26",
+        "@polymer/iron-flex-layout": "^3.0.0-pre.26",
+        "@polymer/paper-styles": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      },
+      "dependencies": {
+        "@polymer/iron-flex-layout": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/@polymer/iron-flex-layout/-/iron-flex-layout-3.0.1.tgz",
+          "integrity": "sha512-7gB869czArF+HZcPTVSgvA7tXYFze9EKckvM95NB7SqYF+NnsQyhoXgKnpFwGyo95lUjUW9TFDLUwDXnCYFtkw==",
+          "requires": {
+            "@polymer/polymer": "^3.0.0"
+          }
+        }
+      }
+    },
+    "@polymer/paper-listbox": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@polymer/paper-listbox/-/paper-listbox-3.0.1.tgz",
+      "integrity": "sha512-vMLWFpYcggAPmEDBmK+96fFefacOG3GLB1EguTn8+ZkqI+328hNfw1MzHjH68rgCIIUtjmm+9qgB1Sy/MN0a/A==",
+      "requires": {
+        "@polymer/iron-behaviors": "^3.0.0-pre.26",
+        "@polymer/iron-menu-behavior": "^3.0.0-pre.26",
+        "@polymer/paper-styles": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@polymer/paper-menu-button": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@polymer/paper-menu-button/-/paper-menu-button-3.0.1.tgz",
+      "integrity": "sha512-Rxte2Fp7N2BMI2FMM7tB25IkvD11DhjMklcg97JP1jnlHbJNrXPh5SSX2bdtabz49UE8vejIsrxZ+AGsB5nqIQ==",
+      "requires": {
+        "@polymer/iron-a11y-keys-behavior": "^3.0.0-pre.26",
+        "@polymer/iron-behaviors": "^3.0.0-pre.26",
+        "@polymer/iron-dropdown": "^3.0.0-pre.26",
+        "@polymer/iron-fit-behavior": "^3.0.0-pre.26",
+        "@polymer/neon-animation": "^3.0.0-pre.26",
+        "@polymer/paper-styles": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@polymer/paper-ripple": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@polymer/paper-ripple/-/paper-ripple-3.0.1.tgz",
+      "integrity": "sha512-dgOe12GyCF1VZBLUQqnzGWlf3xb255FajNCVB1VFj/AtskYtoamnafa7m3a+1vs+C8qbg4Benn5KwgxVDSW4cg==",
+      "requires": {
+        "@polymer/iron-a11y-keys-behavior": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@polymer/paper-styles": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@polymer/paper-styles/-/paper-styles-3.0.1.tgz",
+      "integrity": "sha512-y6hmObLqlCx602TQiSBKHqjwkE7xmDiFkoxdYGaNjtv4xcysOTdVJsDR/R9UHwIaxJ7gHlthMSykir1nv78++g==",
+      "requires": {
+        "@polymer/font-roboto": "^3.0.1",
+        "@polymer/iron-flex-layout": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      },
+      "dependencies": {
+        "@polymer/iron-flex-layout": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/@polymer/iron-flex-layout/-/iron-flex-layout-3.0.1.tgz",
+          "integrity": "sha512-7gB869czArF+HZcPTVSgvA7tXYFze9EKckvM95NB7SqYF+NnsQyhoXgKnpFwGyo95lUjUW9TFDLUwDXnCYFtkw==",
           "requires": {
             "@polymer/polymer": "^3.0.0"
           }

--- a/tools/sigh.js
+++ b/tools/sigh.js
@@ -538,7 +538,7 @@ function test(args) {
         mocha.suite.emit('require', null, '${test}', mocha);
         mocha.suite.emit('post-require', global, '${test}', mocha);
       `);
-      if (options.retries) {
+      if (options.retries && !isNaN(options.retries)) {
         chain.push(`
           import {mocha} from '${mochaInstanceFile}';
           mocha.suite.retries(${JSON.stringify(options.retries)})

--- a/tools/sigh.js
+++ b/tools/sigh.js
@@ -589,9 +589,12 @@ function test(args) {
   }
 
   const runner = buildTestRunner();
-  for (var i = 0; i < JSON.stringify(options.repeat || 1); i++) {
-    console.log('RUN %s:', i+1);
-    saneSpawn(
+  // Spawn processes as needed to repeat tests specified by 'repeat' flag.
+  const repeatCount = JSON.stringify(options.repeat || 1);
+  const testResults = [];
+  for (let i = 0; i < repeatCount; i++) {
+    console.log('RUN %s [%s]:', i+1, (new Date).toLocaleTimeString());
+    testResults.push(saneSpawn(
         'node',
         [
           '--experimental-modules',
@@ -604,8 +607,10 @@ function test(args) {
           'source-map-support/register.js',
           runner
         ],
-        {stdio: 'inherit'});
+        {stdio: 'inherit'})
+    );
   }
+  return testResults;
 }
 
 async function importSpotify(args) {


### PR DESCRIPTION
Adding the option to allow retries and repeat tests. I initially tried adding repeat functionality directly into mocha by encapsulating `runner.run()` which would allow test pass/fail/end hooks to be added more easily. However, I ran into a mocha implementation [issue](https://github.com/mochajs/mocha/issues/2706) that requires the entire mocha instance to be re-instantiated and the 'require' cache cleared in between runs. 

I removed the return from `test()` -- not sure where it's being used.

Also, not sure if the package.lock should be excluded // how to auto-exclude it from future commits.