### PR TITLE
Check for cyclic messages sent to DevTools

### DIFF
--- a/src/runtime/debug/abstract-devtools-channel.ts
+++ b/src/runtime/debug/abstract-devtools-channel.ts
@@ -20,6 +20,7 @@ export class AbstractDevtoolsChannel {
   }
 
   send(message) {
+    this.ensureNoCycle(message);
     this.debouncedMessages.push(message);
     if (!this.debouncing) {
       this.debouncing = true;
@@ -56,6 +57,16 @@ export class AbstractDevtoolsChannel {
 
   _flush(messages) {
     throw new Error('Not implemented in an abstract class');
+  }
+
+  ensureNoCycle(object, objectPath = []) {
+    if (!object || typeof object !== 'object') return;
+    assert(objectPath.indexOf(object) === -1, 'Message cannot contain a cycle');
+
+    objectPath.push(object);
+    (Array.isArray(object) ? object : Object.values(object)).forEach(
+        element => this.ensureNoCycle(element, objectPath));
+    objectPath.pop();
   }
 }
 


### PR DESCRIPTION
It turns out `chrome.runtime.sendMessage` dies silently if passed a circular object - which it turns out we do from PlanConsumer. Let's fix this, and then @mmandlis can take a look at PlanConsumer fix.