### PR TITLE
treat null and undefined as same container in slot-context and slot-consumer

### DIFF
--- a/src/runtime/slot-consumer.ts
+++ b/src/runtime/slot-consumer.ts
@@ -184,7 +184,9 @@ export class SlotConsumer {
     });
   }
 
-  isSameContainer(container, contextContainer) { return container === contextContainer; }
+  isSameContainer(container, contextContainer) {
+    return (!container === !contextContainer) && (container === contextContainer);
+  }
 
   // abstract
   constructRenderRequest(): string[] { return []; }

--- a/src/runtime/slot-context.ts
+++ b/src/runtime/slot-context.ts
@@ -155,7 +155,7 @@ export class ProvidedSlotContext extends SlotContext {
              Object.values(this.container).every(
                 currentContainer => Object.values(container).some(newContainer => newContainer === currentContainer));
     }
-    return this.container === container;
+    return (!container === !this.container) || (this.container === container);
   }
 
   set container(container) {


### PR DESCRIPTION
addresses an assert on arc refresh, as described in:
https://github.com/PolymerLabs/arcs/issues/2581