### PR TITLE
fix contextual planning-result deserialization

### DIFF
--- a/src/runtime/plan/planning-result.ts
+++ b/src/runtime/plan/planning-result.ts
@@ -281,7 +281,7 @@ export class PlanningResult {
            oldSuggestions.every(suggestion => newSuggestions.find(newSuggestion => suggestion.isEquivalent(newSuggestion)));
   }
 
-  async fromLiteral({suggestions, generations, lastUpdated}: {suggestions, generations?, lastUpdated?: Date}) {
+  async fromLiteral({suggestions, generations, lastUpdated, contextual}: {suggestions, generations?, lastUpdated?: Date, contextual?: boolean}) {
     const deserializedSuggestions: Suggestion[] = [];
     for (const suggestion of suggestions) {
       deserializedSuggestions.push(await Suggestion.fromLiteral(suggestion, this.envOptions));
@@ -290,7 +290,7 @@ export class PlanningResult {
       suggestions: deserializedSuggestions,
       generations: JSON.parse(generations || '[]'),
       lastUpdated: new Date(lastUpdated),
-      contextual: suggestions.contextual
+      contextual
     });
   }
 

--- a/src/runtime/test/plan/planificator-test.ts
+++ b/src/runtime/test/plan/planificator-test.ts
@@ -197,12 +197,17 @@ particle ShowProduct in 'show-product.js'
     const restaurantsPlanificator = new Planificator(
         await createArc({manifestString: restaurantsManifestString}, storageKey),
         userid, productsPlanificator.result.store, productsPlanificator.searchStore);
+    assert.isTrue(restaurantsPlanificator.producer.result.contextual);
     await restaurantsPlanificator.loadSuggestions();
+    assert.isFalse(restaurantsPlanificator.producer.result.contextual);
     assert.lengthOf(restaurantsPlanificator.result.suggestions, 1);
     assert.isTrue(restaurantsPlanificator.result.suggestions[0].descriptionText.includes(showProductsDescription));
 
     // Trigger replanning with restaurants context.
     await restaurantsPlanificator.setSearch('*');
+    // result is NOT contextual, so re-planning is not automatically triggered.
+    assert.isTrue(!restaurantsPlanificator.producer.isPlanning);
+    restaurantsPlanificator.requestPlanning();
     await verifyReplanning(restaurantsPlanificator, 5, [
       showProductsDescription,
       'Extract person\'s location.',


### PR DESCRIPTION
It is possible, that the planificator test is related to this: https://github.com/PolymerLabs/arcs/issues/2603
