### PR TITLE
Slots and slot connections are no longer eagerly created

### DIFF
--- a/src/runtime/recipe-index.ts
+++ b/src/runtime/recipe-index.ts
@@ -31,6 +31,8 @@ import {assert} from '../platform/assert-web.js';
 import {PlanningResult} from './plan/planning-result.js';
 import {Modality} from './modality.js';
 import {ModalityHandler} from './modality-handler.js';
+import {ProvidedSlotSpec, SlotSpec} from './particle-spec.js';
+import {Particle} from './recipe/particle.js';
 
 class RelevantContextRecipes extends Strategy {
   private _recipes: Recipe[] = [];
@@ -222,48 +224,42 @@ export class RecipeIndex {
   }
 
   /**
-   * Given a slot, find consume slot connections that could be connected to it.
+   * Given a particle and a slot spec for a slot that particle could provide, find consume slot connections that 
+   * could be connected to the potential slot.
    */
-  findConsumeSlotConnectionMatch(slot: Slot) {
+  findConsumeSlotConnectionMatch(particle: Particle, providedSlotSpec: ProvidedSlotSpec) {
     this.ensureReady();
 
     const consumeConns = [];
     for (const recipe of this._recipes) {
-      if (recipe.particles.some(particle => !particle.name)) {
+      if (recipe.particles.some(recipeParticle => !recipeParticle.name)) {
         // Skip recipes where not all verbs are resolved to specific particles
         // to avoid trying to coalesce a recipe with itself.
         continue;
       }
-      for (const slotConn of recipe.slotConnections) {
-        if (!slotConn.targetSlot && MapSlots.specMatch(slotConn, slot) && MapSlots.tagsOrNameMatch(slotConn, slot)) {
-          const matchingHandles = [];
-          if (!MapSlots.handlesMatch(slotConn, slot)) {
-            // Find potential handle connections to coalesce
-            slot.handleConnections.forEach(slotHandleConn => {
-              const matchingConns = Object.values(slotConn.particle.connections).filter(particleConn => {
-                return particleConn.direction !== 'host'
-                    && (!particleConn.handle || !particleConn.handle.id || particleConn.handle.id === slotHandleConn.handle.id)
-                    && Handle.effectiveType(slotHandleConn.handle.mappedType, [particleConn]);
-              });
-              matchingConns.forEach(matchingConn => {
-                if (this._fatesAndDirectionsMatch(slotHandleConn, matchingConn)) {
-                  matchingHandles.push({handle: slotHandleConn.handle, matchingConn});
-                }
-              });
-            });
-
-            if (matchingHandles.length === 0) {
-              continue;
+      for (const recipeParticle of recipe.particles) {
+        if (!recipeParticle.spec) continue;
+        for (const [name, slotSpec] of recipeParticle.spec.slots) {
+          const recipeSlotConn = recipeParticle.getSlotConnectionByName(name);
+          if (recipeSlotConn && recipeSlotConn.targetSlot) continue;
+          if (MapSlots.specMatch(slotSpec, providedSlotSpec) && MapSlots.tagsOrNameMatch(slotSpec, providedSlotSpec)){
+            const slotConn = particle.getSlotConnectionByName(providedSlotSpec.name);
+            let matchingHandles = [];
+            if (providedSlotSpec.handles.length !== 0 || (slotConn && !MapSlots.handlesMatch(recipeParticle, slotConn))) {
+              matchingHandles = this._getMatchingHandles(recipeParticle, particle, providedSlotSpec);
+              if (matchingHandles.length === 0) {
+                continue;
+              }
             }
+            consumeConns.push({recipeParticle, slotSpec, matchingHandles});
           }
-          consumeConns.push({slotConn, matchingHandles});
         }
       }
     }
     return consumeConns;
   }
-
-  findProvidedSlot(slotConn: SlotConnection): Slot[] {
+  
+  findProvidedSlot(particle: Particle, slotSpec: SlotSpec): Slot[] {
     this.ensureReady();
 
     const providedSlots: Slot[] = [];
@@ -275,13 +271,33 @@ export class RecipeIndex {
       }
       for (const consumeConn of recipe.slotConnections) {
         for (const providedSlot of Object.values(consumeConn.providedSlots)) {
-          if (MapSlots.slotMatches(slotConn, providedSlot)) {
+          if (MapSlots.slotMatches(particle, slotSpec, providedSlot)) {
             providedSlots.push(providedSlot);
           }
         }
       }
     }
     return providedSlots;
+  }
+
+  private _getMatchingHandles(particle: Particle, providingParticle: Particle, providedSlotSpec: ProvidedSlotSpec) {
+    const matchingHandles = [];
+    for (const slotHandleConnName of providedSlotSpec.handles) {
+      const providedHandleConn = providingParticle.getConnectionByName(slotHandleConnName);
+      if (!providedHandleConn) continue;
+
+      const matchingConns = Object.values(particle.connections).filter(handleConn => {
+        return handleConn.direction !== 'host'
+          && (!handleConn.handle || !handleConn.handle.id || handleConn.handle.id === providedHandleConn.handle.id)
+          && Handle.effectiveType(providedHandleConn.handle.mappedType, [handleConn]);
+      });  
+      matchingConns.forEach(matchingConn => {
+        if (this._fatesAndDirectionsMatch(providedHandleConn, matchingConn)) {
+          matchingHandles.push({handle: providedHandleConn.handle, matchingConn});
+        }
+      }); 
+    }
+    return matchingHandles;
   }
 
   /**

--- a/src/runtime/recipe-index.ts
+++ b/src/runtime/recipe-index.ts
@@ -33,6 +33,13 @@ import {Modality} from './modality.js';
 import {ModalityHandler} from './modality-handler.js';
 import {ProvidedSlotSpec, SlotSpec} from './particle-spec.js';
 import {Particle} from './recipe/particle.js';
+import {HandleConnection} from './recipe/handle-connection.js';
+
+type ConsumeSlotConnectionMatch = {
+  recipeParticle: Particle,
+  slotSpec: SlotSpec,
+  matchingHandles: {handle:Handle, matchingConn: HandleConnection}[]
+};
 
 class RelevantContextRecipes extends Strategy {
   private _recipes: Recipe[] = [];
@@ -227,7 +234,7 @@ export class RecipeIndex {
    * Given a particle and a slot spec for a slot that particle could provide, find consume slot connections that 
    * could be connected to the potential slot.
    */
-  findConsumeSlotConnectionMatch(particle: Particle, providedSlotSpec: ProvidedSlotSpec) {
+  findConsumeSlotConnectionMatch(particle: Particle, providedSlotSpec: ProvidedSlotSpec): ConsumeSlotConnectionMatch[] {
     this.ensureReady();
 
     const consumeConns = [];

--- a/src/runtime/recipe/particle.ts
+++ b/src/runtime/recipe/particle.ts
@@ -220,10 +220,8 @@ export class Particle {
   }
 
   addSlotConnection(name: string) : SlotConnection {
-    assert(!(name in this._consumedSlotConnections));
-    if (this.spec) {
-      assert(this.spec.slots.has(name));
-    }
+    assert(!(name in this._consumedSlotConnections), "slot connection already exists");
+    assert(!this.spec || this.spec.slots.has(name), "slot connection not in particle spec");
     const slotConn = new SlotConnection(name, this);
     this._consumedSlotConnections[name] = slotConn;
 
@@ -278,8 +276,8 @@ export class Particle {
   }
 
   getSlotSpecs() : Map<string,SlotSpec> {
-    if (!this.spec) return new Map();
-    return this.spec.slots;
+    if (this.spec) return this.spec.slots;
+    return new Map();
   }
 
   toString(nameMap, options) {

--- a/src/runtime/recipe/particle.ts
+++ b/src/runtime/recipe/particle.ts
@@ -10,7 +10,8 @@ import {SlotConnection} from './slot-connection.js';
 import {HandleConnection} from './handle-connection.js';
 import {compareComparables, compareStrings, compareArrays} from './util.js';
 import {Recipe} from './recipe.js';
-import {ParticleSpec} from '../particle-spec.js';
+import {ParticleSpec, ProvidedSlotSpec, SlotSpec} from '../particle-spec.js';
+import {Slot} from './slot.js';
 
 export class Particle {
   private readonly _recipe: Recipe;
@@ -173,12 +174,7 @@ export class Particle {
       connection.type = speccedConnection.type;
       connection.direction = speccedConnection.direction;
     }
-    spec.slots.forEach(slotSpec => {
-      if (this._consumedSlotConnections[slotSpec.name] == undefined) {
-        this.addSlotConnection(slotSpec.name);
-      }
-      this._consumedSlotConnections[slotSpec.name].slotSpec = slotSpec;
-    });
+
   }
 
   addUnnamedConnection() {
@@ -223,7 +219,34 @@ export class Particle {
     this._unnamedConnections.splice(idx, 1);
   }
 
-  addSlotConnection(name) {
+  addSlotConnection(name: string) : SlotConnection {
+    assert(!(name in this._consumedSlotConnections));
+    if (this.spec) {
+      assert(this.spec.slots.has(name));
+    }
+    const slotConn = new SlotConnection(name, this);
+    this._consumedSlotConnections[name] = slotConn;
+
+    const slotSpec = this.getSlotSpecByName(name);
+    if (slotSpec) {
+      slotSpec.providedSlots.forEach(providedSlot => {
+        const slot = this.recipe.newSlot(providedSlot.name);
+        slot.sourceConnection = slotConn;
+        slotConn.providedSlots[providedSlot.name] = slot;
+        // TODO: hook the handles up
+
+        assert(slot.handleConnections.length === 0, 'Handle connections must be empty');
+        providedSlot.handles.forEach(handle => slot.handleConnections.push(this.connections[handle]));
+      });
+    }
+    return slotConn;
+  }
+
+  addSlotConnectionAsCopy(name: string) : SlotConnection {
+    // Called when a recipe and all of it's contents are being cloned. 
+    // Each slot connection in the existing recipe has to be created for the clone, 
+    // This method must not create slots for provided slot connections otherwise there 
+    // will be duplicate slots.
     const slotConn = new SlotConnection(name, this);
     this._consumedSlotConnections[name] = slotConn;
     return slotConn;
@@ -236,6 +259,27 @@ export class Particle {
 
   remove() {
     this.recipe.removeParticle(this);
+  }
+
+  getSlotConnectionBySpec(spec: SlotSpec) {
+    return Object.values(this._consumedSlotConnections).find(slotConn => slotConn.getSlotSpec() === spec);
+  }
+
+  getSlotSpecByName(name: string) : SlotSpec {
+    return this.spec && this.spec.slots.get(name);
+  }
+
+  getSlotConnectionByName(name: string) : SlotConnection {
+    return this._consumedSlotConnections[name];
+  }
+
+  getProvidedSlotByName(consumeName: string, name: string) : Slot {
+    return this.consumedSlotConnections[consumeName] && this.consumedSlotConnections[consumeName].providedSlots[name];
+  }
+
+  getSlotSpecs() : Map<string,SlotSpec> {
+    if (!this.spec) return new Map();
+    return this.spec.slots;
   }
 
   toString(nameMap, options) {

--- a/src/runtime/recipe/recipe.ts
+++ b/src/runtime/recipe/recipe.ts
@@ -157,7 +157,7 @@ export class Recipe {
   allRequiredSlotsPresent() {
     // All required slots and at least one consume slot for each particle must be present in order for the 
     // recipe to be considered resolved. 
-    for (const particle of this._particles) {
+    for (const particle of this.particles) {
       if (particle.spec.slots.size === 0) {
         continue;
       }

--- a/src/runtime/recipe/recipe.ts
+++ b/src/runtime/recipe/recipe.ts
@@ -137,6 +137,7 @@ export class Recipe {
         && this._handles.every(handle => handle.isResolved())
         && this._particles.every(particle => particle.isResolved())
         && this.modality.isResolved()
+        && this.allRequiredSlotsPresent()
         && this._slots.every(slot => slot.isResolved())
         && this.handleConnections.every(connection => connection.isResolved())
         && this.slotConnections.every(slotConnection => slotConnection.isResolved());
@@ -151,6 +152,38 @@ export class Recipe {
   get modality(): Modality {
     return this.particles.filter(p => Boolean(p.spec && p.spec.slots.size > 0)).map(p => p.spec.modality)
       .reduce((modality, total) => modality.intersection(total), Modality.all);
+  }
+
+  allRequiredSlotsPresent() {
+    // All required slots and at least one consume slot for each particle must be present in order for the 
+    // recipe to be considered resolved. 
+    for (const particle of this._particles) {
+      if (particle.spec.slots.size === 0) {
+        continue;
+      }
+
+      let atLeastOneSlotConnection = false;
+      for (const [name, slotSpec] of particle.spec.slots) {
+        if (slotSpec.isRequired && !particle.consumedSlotConnections[name]) {
+          return false;
+        }
+        // required provided slots are only required when the corresponding consume slot connection is present
+        if (particle.consumedSlotConnections[name]) {
+          for (const providedSlotSpec of slotSpec.providedSlots) {
+            if (providedSlotSpec.isRequired && !particle.getProvidedSlotByName(name, providedSlotSpec.name)) {
+              return false;
+            }
+          }
+        }
+        if (particle.consumedSlotConnections[name]) {
+          atLeastOneSlotConnection = true;
+        }
+      }
+      if (!atLeastOneSlotConnection) {
+        return false;
+      }
+    }
+    return true;
   }
 
   _findDuplicate(items, options) {

--- a/src/runtime/recipe/slot-connection.ts
+++ b/src/runtime/recipe/slot-connection.ts
@@ -16,7 +16,6 @@ export class SlotConnection {
   private readonly _recipe: Recipe;
   private readonly _particle: Particle;
   private readonly _name: string;
-  private _slotSpec: SlotSpec | undefined = undefined;
   private _targetSlot: Slot | undefined = undefined;
   private _providedSlots: {[index: string]: Slot} = {};
   private _tags = <string[]>[];
@@ -38,7 +37,6 @@ export class SlotConnection {
   get particle() { return this._particle; }
   get name() { return this._name; }
   getQualifiedName() { return `${this.particle.name}::${this.name}`; }
-  get slotSpec() { return this._slotSpec; }
   get targetSlot() { return this._targetSlot; }
   set targetSlot(targetSlot: Slot | undefined) { this._targetSlot = targetSlot; }
   
@@ -46,23 +44,8 @@ export class SlotConnection {
   get tags() { return this._tags; }
   set tags(tags) { this._tags = tags; }
 
-  set slotSpec(slotSpec) {
-    assert(this.name === slotSpec.name);
-    this._slotSpec = slotSpec;
-    slotSpec.providedSlots.forEach(providedSlot => {
-      let slot = this.providedSlots[providedSlot.name];
-      if (slot == undefined) {
-        slot = this.recipe.newSlot(providedSlot.name);
-        slot._sourceConnection = this;
-        slot._name = providedSlot.name;
-        this.providedSlots[providedSlot.name] = slot;
-      }
-      assert(slot.handleConnections.length === 0, 'Handle connections must be empty');
-      providedSlot.handles.forEach(handle => slot.handleConnections.push(this.particle.connections[handle]));
-      assert(slot._name === providedSlot.name);
-      assert(!slot.formFactor);
-      slot.formFactor = providedSlot.formFactor;
-    });
+  getSlotSpec() {
+    return this.particle.spec && this.particle.spec.getSlotSpec(this.name);
   }
 
   connectToSlot(targetSlot) {
@@ -86,11 +69,8 @@ export class SlotConnection {
       return cloneMap.get(this);
     }
 
-    const slotConnection = particle.addSlotConnection(this.name);
+    const slotConnection = particle.addSlotConnectionAsCopy(this.name);
     slotConnection.tags = this.tags;
-    if (this.slotSpec) {
-      slotConnection._slotSpec = particle.spec.getSlotSpec(this.name);
-    }
 
     cloneMap.set(this, slotConnection);
     return slotConnection;
@@ -142,7 +122,7 @@ export class SlotConnection {
       return false;
     }
 
-    if (this.slotSpec.isRequired) {
+    if (this.getSlotSpec().isRequired) {
       if (!this.targetSlot || !(this.targetSlot.id || this.targetSlot.sourceConnection.isConnected())) {
         // The required connection has no target slot
         // or its target slot it not resolved (has no ID or source connection).
@@ -156,7 +136,7 @@ export class SlotConnection {
       return true;
     }
 
-    return this.slotSpec.providedSlots.every(providedSlot => {
+    return this.getSlotSpec().providedSlots.every(providedSlot => {
       if (providedSlot.isRequired && this.providedSlots[providedSlot.name].consumeConnections.length === 0) {
         if (options) {
           options.details = 'missing consuming slot';
@@ -203,8 +183,8 @@ export class SlotConnection {
       
       // Only assert that there's a spec for this provided slot if there's a spec for
       // the consumed slot .. otherwise this is just a constraint.
-      if (this.slotSpec) {
-        const providedSlotSpec = this.slotSpec.getProvidedSlotSpec(psName);
+      if (this.getSlotSpec()) {
+        const providedSlotSpec = this.getSlotSpec().getProvidedSlotSpec(psName);
         assert(providedSlotSpec, `Cannot find providedSlotSpec for ${psName}`);
       }
       provideRes.push(`${psName} as ${(nameMap && nameMap.get(providedSlot)) || providedSlot}`);

--- a/src/runtime/recipe/slot.ts
+++ b/src/runtime/recipe/slot.ts
@@ -47,7 +47,7 @@ export class Slot {
   get spec() {
     // TODO: should this return something that indicates this isn't available yet instead of
     // the constructed {isSet: false, tags: []}?
-    return (this.sourceConnection && this.sourceConnection.slotSpec) ? this.sourceConnection.slotSpec.getProvidedSlotSpec(this.name) : {isSet: false, tags: []};
+    return (this.sourceConnection && this.sourceConnection.getSlotSpec()) ? this.sourceConnection.getSlotSpec().getProvidedSlotSpec(this.name) : {isSet: false, tags: []};
   }
   get handles() {
     return this.handleConnections.map(connection => connection.handle).filter(a => a !== undefined);

--- a/src/runtime/recipe/walker-base.ts
+++ b/src/runtime/recipe/walker-base.ts
@@ -101,9 +101,9 @@ export abstract class WalkerBase extends StrategizerWalker {
               const cloneMap = new Map();
               const newRecipe = recipe.clone(cloneMap);
               if (context) {
-                score += f(newRecipe, ...context.map(c => cloneMap.get(c) || c));
+                score = f(newRecipe, ...context.map(c => cloneMap.get(c) || c));
               } else {
-                score += f(newRecipe);
+                score = f(newRecipe);
               }
               newRecipes.push({recipe: newRecipe, score});
             });

--- a/src/runtime/recipe/walker-base.ts
+++ b/src/runtime/recipe/walker-base.ts
@@ -77,7 +77,11 @@ export abstract class WalkerBase extends StrategizerWalker {
               continue;
             }
             permutation.forEach(({f, context}) => {
-              score += f(newRecipe, cloneMap.get(context));
+              if (context) {
+                score = f(newRecipe, ...context.map(c => cloneMap.get(c) || c));
+              } else {
+                score = f(newRecipe);
+              }
             });
 
             newRecipes.push({recipe: newRecipe, score});
@@ -89,13 +93,18 @@ export abstract class WalkerBase extends StrategizerWalker {
             if (typeof continuation === 'function') {
               continuation = [continuation];
             }
+            let score = 0;
             continuation.forEach(f => {
               if (f == null) {
                 f = () => 0;
               }
               const cloneMap = new Map();
               const newRecipe = recipe.clone(cloneMap);
-              const score = f(newRecipe, cloneMap.get(context));
+              if (context) {
+                score += f(newRecipe, ...context.map(c => cloneMap.get(c) || c));
+              } else {
+                score += f(newRecipe);
+              }
               newRecipes.push({recipe: newRecipe, score});
             });
           });

--- a/src/runtime/slot-composer.ts
+++ b/src/runtime/slot-composer.ts
@@ -126,7 +126,7 @@ export class SlotComposer {
     recipeParticles.forEach(p => {
       Object.values(p.consumedSlotConnections).forEach(cs => {
         if (!cs.targetSlot) {
-          assert(!cs.slotSpec.isRequired, `No target slot for particle's ${p.name} required consumed slot: ${cs.name}.`);
+          assert(!cs.getSlotSpec().isRequired, `No target slot for particle's ${p.name} required consumed slot: ${cs.name}.`);
           return;
         }
 

--- a/src/runtime/slot-consumer.ts
+++ b/src/runtime/slot-consumer.ts
@@ -110,7 +110,7 @@ export class SlotConsumer {
   }
 
   createProvidedContexts() {
-    return this.consumeConn.slotSpec.providedSlots.map(
+    return this.consumeConn.getSlotSpec().providedSlots.map(
       spec => new ProvidedSlotContext(this.consumeConn.providedSlots[spec.name].id, spec.name, /* tags=*/ [], /* container= */ null, spec, this));
   }
 

--- a/src/runtime/slot-dom-consumer.ts
+++ b/src/runtime/slot-dom-consumer.ts
@@ -79,9 +79,9 @@ export class SlotDomConsumer extends SlotConsumer {
       if (content.model) {
 
         let formattedModel;
-        if (contextSpec.isSet && this.consumeConn.slotSpec.isSet) {
+        if (contextSpec.isSet && this.consumeConn.getSlotSpec().isSet) {
           formattedModel = this._modelForSetSlotConsumedAsSetSlot(content.model, subId);
-        } else if (contextSpec.isSet && !this.consumeConn.slotSpec.isSet) {
+        } else if (contextSpec.isSet && !this.consumeConn.getSlotSpec().isSet) {
           formattedModel = this._modelForSetSlotConsumedAsSingletonSlot(content.model, subId);
         } else {
           formattedModel = this._modelForSingletonSlot(content.model, subId);
@@ -245,7 +245,7 @@ export class SlotDomConsumer extends SlotConsumer {
       const slotId = this.getNodeValue(innerContainer, 'slotid');
       const providedContext = this.findProvidedContext(ctx => ctx.id === slotId);
       if (!providedContext) {
-        console.warn(`Slot ${this.consumeConn.slotSpec.name} has unexpected inner slot ${slotId}`);
+        console.warn(`Slot ${this.consumeConn.getSlotSpec().name} has unexpected inner slot ${slotId}`);
         return;
       }
       const subId = this.getNodeValue(innerContainer, 'subid');

--- a/src/runtime/strategies/init-population.ts
+++ b/src/runtime/strategies/init-population.ts
@@ -48,9 +48,14 @@ export class InitPopulation extends Strategy {
 
   private _contextualResults(): ScoredRecipe[] {
     const results: ScoredRecipe[] = [];
-    for (const slot of this.arc.activeRecipe.slots.filter(s => s.sourceConnection)) {
-      results.push(...this._recipeIndex.findConsumeSlotConnectionMatch(slot).map(
-          ({slotConn}) => ({recipe: slotConn.recipe})));
+    for (const particle of this.arc.activeRecipe.particles) {
+      for (const [name, slotSpec] of particle.spec.slots) {
+        for (const providedSlotSpec of slotSpec.providedSlots) {
+          results.push(...this._recipeIndex.findConsumeSlotConnectionMatch(particle, providedSlotSpec).map(
+            ({recipeParticle}) => ({recipe: recipeParticle.recipe})
+          ));
+        }
+      }
     }
     for (const handle of [].concat(...this.arc.allDescendingArcs.map(arc => arc.activeRecipe.handles))) {
       results.push(...this._recipeIndex.findHandleMatch(handle, ['use', '?']).map(

--- a/src/runtime/strategies/map-slots.ts
+++ b/src/runtime/strategies/map-slots.ts
@@ -9,6 +9,9 @@ import {Strategizer, Strategy} from '../../planning/strategizer.js';
 import {Recipe} from '../recipe/recipe.js';
 import {Walker} from '../recipe/walker.js';
 import {SlotConnection} from '../recipe/slot-connection.js';
+import {Particle} from '../recipe/particle.js';
+import {SlotSpec, ProvidedSlotSpec} from '../particle-spec.js';
+import {Slot} from '../recipe/slot.js';
 
 import {assert} from '../../platform/assert-web.js';
 
@@ -17,21 +20,45 @@ export class MapSlots extends Strategy {
     const arc = this.arc;
 
     return Strategizer.over(this.getResults(inputParams), new class extends Walker {
+      onPotentialSlotConnection(recipe: Recipe, particle: Particle, slotSpec: SlotSpec) {
+        const {local, remote} = MapSlots.findAllSlotCandidates(particle, slotSpec, arc); 
+        // ResolveRecipe handles one-slot case.
+        if (local.length + remote.length < 2) {
+          return undefined;
+        }
+
+        // If there are any local slots, prefer them over remote slots.
+        // TODO: There should not be any preference over local slots vs. remote slots.
+        // Strategies should be responsible for making all possible recipes. Ranking of 
+        // recipes is done later. 
+        const slotList = local.length > 0 ? local : remote;
+        return slotList.map(slot => ((recipe: Recipe, particle: Particle, slotSpec: SlotSpec) => {
+          const newSlotConnection = particle.addSlotConnection(slotSpec.name);
+          MapSlots.connectSlotConnection(newSlotConnection, slot);
+          return 1;
+        }));
+      }
+
+      // TODO: this deals with cases where a SlotConnection has been
+      // created during parsing, so that provided slots inside the 
+      // connection can be connected to consume connections.
+      // Long term, we shouldn't have to do this, so we won't need
+      // to deal with the case of a disconnected SlotConnection.
       onSlotConnection(recipe: Recipe, slotConnection: SlotConnection) {
         // don't try to connect verb constraints
         // TODO: is this right? Should constraints be connectible, in order to precompute the
         // recipe side once the verb is substituted?
-        if (slotConnection.slotSpec == undefined) {
+        if (slotConnection.getSlotSpec() == undefined) {
           return undefined;
         }
 
         if (slotConnection.isConnected()) {
-          return undefined;
+          return;
         }
+        const slotSpec = slotConnection.getSlotSpec();
+        const particle = slotConnection.particle;
 
-        const {local, remote} = MapSlots.findAllSlotCandidates(slotConnection, arc);
-
-        // ResolveRecipe handles one-slot case.
+        const {local, remote} = MapSlots.findAllSlotCandidates(particle, slotSpec, arc);
         if (local.length + remote.length < 2) {
           return undefined;
         }
@@ -66,7 +93,7 @@ export class MapSlots extends Strategy {
     }
 
     assert(!selectedSlot.id || !slotConnection.targetSlot.id || (selectedSlot.id === slotConnection.targetSlot.id),
-           `Cannot override slot id '${slotConnection.targetSlot.id}' with '${selectedSlot.id}'`);
+            `Cannot override slot id '${slotConnection.targetSlot.id}' with '${selectedSlot.id}'`);
     slotConnection.targetSlot.id = selectedSlot.id || slotConnection.targetSlot.id;
 
     // TODO: need to concat to existing tags and dedup?
@@ -74,19 +101,20 @@ export class MapSlots extends Strategy {
   }
 
   // Returns all possible slot candidates, sorted by "quality"
-  static findAllSlotCandidates(slotConnection, arc) {
+  static findAllSlotCandidates(particle: Particle, slotSpec: SlotSpec, arc) {
+    const slotConn = particle.getSlotConnectionByName(slotSpec.name);
     return {
       // Note: during manfiest parsing, target slot is only set in slot connection, if the slot exists in the recipe.
       // If this slot is internal to the recipe, it has the sourceConnection set to the providing connection
       // (and hence the consuming connection is considered connected already). Otherwise, this may only be a remote slot.
-      local: !slotConnection.targetSlot ? MapSlots._findSlotCandidates(slotConnection, slotConnection.recipe.slots) : [],
-      remote: MapSlots._findSlotCandidates(slotConnection, arc.pec.slotComposer.getAvailableContexts())
+      local: !slotConn || !slotConn.targetSlot ? MapSlots._findSlotCandidates(particle, slotSpec, particle.recipe.slots) : [],
+      remote: MapSlots._findSlotCandidates(particle, slotSpec, arc.pec.slotComposer.getAvailableContexts())
     };
   }
 
   // Returns the given slot candidates, sorted by "quality".
-  static _findSlotCandidates(slotConnection: SlotConnection, slots) {
-    const possibleSlots = slots.filter(s => this.slotMatches(slotConnection, s));
+  static _findSlotCandidates(particle: Particle, slotSpec: SlotSpec, slots) {
+    const possibleSlots = slots.filter(s => this.slotMatches(particle, slotSpec, s));
     possibleSlots.sort((slot1, slot2) => {
         // TODO: implement.
         return slot1.name < slot2.name;
@@ -95,50 +123,58 @@ export class MapSlots extends Strategy {
   }
 
   // Returns true, if the given slot is a viable candidate for the slotConnection.
-  static slotMatches(slotConnection: SlotConnection, slot) {
-    if (!MapSlots.specMatch(slotConnection, slot)) {
+  static slotMatches(particle: Particle, slotSpec: SlotSpec, slot) {
+    if (!MapSlots.specMatch(slotSpec, slot.spec)) {
       return false;
     }
 
-    if (!MapSlots.tagsOrNameMatch(slotConnection, slot)) {
+    const potentialSlotConn = particle.getSlotConnectionBySpec(slotSpec);
+    if (!MapSlots.tagsOrNameMatch(slotSpec, slot.spec, potentialSlotConn, slot)) {
       return false;
     }
 
     // Match handles of the provided slot with the slot-connection particle's handles.
-    if (!MapSlots.handlesMatch(slotConnection, slot)) {
+    if (!MapSlots.handlesMatch(particle, slot)) {
       return false;
     }
     return true;
   }
 
-  static specMatch(slotConnection, slot) {
-    return slotConnection.slotSpec && // if there's no slotSpec, this is just a slot constraint on a verb
-          slot.spec && // if there is no spec on the slot, it is a hosted slot in the inner arc
-          slotConnection.slotSpec.isSet === slot.spec.isSet;
-  }
-
-  // Returns true, if the slot connection's tags intersection with slot's tags is nonempty.
-  // TODO: replace with generic tag matcher
-  static tagsOrNameMatch(slotConnection, slot) {
-    const consumeConnTags = [].concat(slotConnection.slotSpec.tags || [], slotConnection.tags, slotConnection.targetSlot ? slotConnection.targetSlot.tags : []);
-    const slotTags = new Set([].concat(slot.tags, slot.spec.tags || [], [slot.name]));
-    // Consume connection tags aren't empty and intersection with the slot isn't empty.
-    if (consumeConnTags.length > 0 && consumeConnTags.some(t => slotTags.has(t))) {
-      return true;
-    }
-    // For backward compatibility support explicit slot names matching.
-    return (slotConnection.name === slot.name);
+  static specMatch(slotSpec, providedSlotSpec) {
+    return slotSpec && // if there's no slotSpec, this is just a slot constraint on a verb
+            providedSlotSpec &&      
+            slotSpec.isSet === providedSlotSpec.isSet;
   }
 
   // Returns true, if the providing slot handle restrictions are satisfied by the consuming slot connection.
   // TODO: should we move some of this logic to the recipe? Or type matching?
-  static handlesMatch(slotConnection: SlotConnection, slot): boolean {
+  static handlesMatch(particle: Particle, slot): boolean {
     if (slot.handles.length === 0) {
       return true; // slot is not limited to specific handles
     }
-    return !!Object.values(slotConnection.particle.connections).find(handleConn => {
+    return !!Object.values(particle.connections).find(handleConn => {
       return slot.handles.includes(handleConn.handle) ||
               (handleConn.handle && handleConn.handle.id && slot.handles.map(sh => sh.id).includes(handleConn.handle.id));
     });
+  }
+
+  static tagsOrNameMatch(consumeSlotSpec: SlotSpec, provideSlotSpec: ProvidedSlotSpec, consumeSlotConn: SlotConnection = undefined, provideSlot: Slot = undefined) {
+    const consumeTags = [].concat(
+      consumeSlotSpec.tags || [], 
+      consumeSlotConn ? consumeSlotConn.tags : [], 
+      consumeSlotConn && consumeSlotConn.targetSlot ? consumeSlotConn.targetSlot.tags : []
+    );
+
+    const provideTags = [].concat(
+      provideSlotSpec.tags || [], 
+      provideSlot ? provideSlot.tags : [], 
+      provideSlot ? provideSlot.name : (provideSlotSpec.name ? provideSlotSpec.name : [])
+    );
+
+    if (consumeTags.length > 0 && consumeTags.some(t => provideTags.includes(t))) {
+      return true;
+    }
+
+    return consumeSlotSpec.name === (provideSlot ? provideSlot.name : provideSlotSpec.name);
   }
 }

--- a/src/runtime/strategies/resolve-recipe.ts
+++ b/src/runtime/strategies/resolve-recipe.ts
@@ -90,10 +90,8 @@ export class ResolveRecipe extends Strategy {
           return undefined;
         }
 
-
         const slotSpec = slotConnection.getSlotSpec();
         const particle = slotConnection.particle;
-
         const {local, remote} = MapSlots.findAllSlotCandidates(particle, slotSpec, arc);
 
         const allSlots = [...local, ...remote];
@@ -111,7 +109,6 @@ export class ResolveRecipe extends Strategy {
       }
 
       onPotentialSlotConnection(recipe: Recipe, particle: Particle, slotSpec: SlotSpec) {
-
         const {local, remote} = MapSlots.findAllSlotCandidates(particle, slotSpec, arc);
         const allSlots = [...local, ...remote];
 

--- a/src/runtime/strategies/resolve-recipe.ts
+++ b/src/runtime/strategies/resolve-recipe.ts
@@ -11,6 +11,9 @@ import {Recipe} from '../recipe/recipe.js';
 import {RecipeUtil} from '../recipe/recipe-util.js';
 import {MapSlots} from './map-slots.js';
 import {Handle} from '../recipe/handle';
+import {SlotConnection} from '../recipe/slot-connection.js';
+import {Particle} from '../recipe/particle.js';
+import {SlotSpec} from '../particle-spec.js';
 
 export class ResolveRecipe extends Strategy {
 
@@ -82,12 +85,17 @@ export class ResolveRecipe extends Strategy {
         return undefined;
       }
 
-      onSlotConnection(recipe: Recipe, slotConnection) {
+      onSlotConnection(recipe: Recipe, slotConnection: SlotConnection) {
         if (slotConnection.isConnected()) {
           return undefined;
         }
 
-        const {local, remote} = MapSlots.findAllSlotCandidates(slotConnection, arc);
+
+        const slotSpec = slotConnection.getSlotSpec();
+        const particle = slotConnection.particle;
+
+        const {local, remote} = MapSlots.findAllSlotCandidates(particle, slotSpec, arc);
+
         const allSlots = [...local, ...remote];
 
         // MapSlots handles a multi-slot case.
@@ -98,6 +106,24 @@ export class ResolveRecipe extends Strategy {
         const selectedSlot = allSlots[0];
         return (recipe, slotConnection) => {
           MapSlots.connectSlotConnection(slotConnection, selectedSlot);
+          return 1;
+        };
+      }
+
+      onPotentialSlotConnection(recipe: Recipe, particle: Particle, slotSpec: SlotSpec) {
+
+        const {local, remote} = MapSlots.findAllSlotCandidates(particle, slotSpec, arc);
+        const allSlots = [...local, ...remote];
+
+        // MapSlots handles a multi-slot case.
+        if (allSlots.length !== 1) {
+          return undefined;
+        }
+
+        const selectedSlot = allSlots[0];
+        return (recipe, particle, slotSpec) => {
+          const newSlotConnection = particle.addSlotConnection(slotSpec.name);
+          MapSlots.connectSlotConnection(newSlotConnection, selectedSlot);
           return 1;
         };
       }

--- a/src/runtime/test/recipe-index-test.ts
+++ b/src/runtime/test/recipe-index-test.ts
@@ -87,6 +87,7 @@ describe('RecipeIndex', () => {
 
       recipe
         A
+          consume root
         B
     `), [
 `recipe

--- a/src/runtime/test/strategies/map-slots-tests.ts
+++ b/src/runtime/test/strategies/map-slots-tests.ts
@@ -125,7 +125,9 @@ ${recipeManifest}
 
       recipe
         A
+          consume root 
         B
+          consume root
         C
     `));
     const inputParams = {generated: [{result: manifest.recipes[0], score: 1}]};
@@ -192,6 +194,7 @@ ${recipeManifest}
     await assertActionSlotTags(`
       recipe
         A
+          consume root
         B`,
       []);
   });

--- a/src/runtime/test/strategies/resolve-recipe-test.ts
+++ b/src/runtime/test/strategies/resolve-recipe-test.ts
@@ -151,6 +151,7 @@ describe('resolve recipe', () => {
         consume info
       recipe
         A
+          consume master #root
         B
           consume info #detail
     `));

--- a/src/runtime/test/strategies/strategy-sequence-test.ts
+++ b/src/runtime/test/strategies/strategy-sequence-test.ts
@@ -39,6 +39,11 @@ describe('A Strategy Sequence', () => {
     const arc = createTestArc(manifest);
 
     recipe = await onlyResult(arc, MatchRecipeByVerb, recipe);
+    // In this example, the first run of the ResolveRecipe strategy will map potential
+    // consume slot connections to remote slots, which exposes the corresponding provide
+    // slots. The second run of the ResolveRecipe strategy will map potential consume
+    // slots to these recently created provided slots.
+    recipe = await onlyResult(arc, ResolveRecipe, recipe);
     recipe = await onlyResult(arc, ResolveRecipe, recipe);
 
     assert.isTrue(recipe.isResolved());
@@ -72,6 +77,7 @@ describe('A Strategy Sequence', () => {
 
     recipe = await onlyResult(arc, MatchRecipeByVerb, recipe);
     recipe = await onlyResult(arc, ConvertConstraintsToConnections, recipe);
+    recipe = await onlyResult(arc, ResolveRecipe, recipe);
     recipe = await onlyResult(arc, ResolveRecipe, recipe);
 
     assert.isTrue(recipe.isResolved());
@@ -110,6 +116,7 @@ describe('A Strategy Sequence', () => {
 
     recipe = await onlyResult(arc, MatchRecipeByVerb, recipe);
     recipe = await onlyResult(arc, ConvertConstraintsToConnections, recipe);
+    recipe = await onlyResult(arc, ResolveRecipe, recipe);
     recipe = await onlyResult(arc, ResolveRecipe, recipe);
 
     assert.isTrue(recipe.isResolved());


### PR DESCRIPTION
Modified how/when slot connections and slots are added to a particle/recipe. Slots and slot connections that are specified in the recipe are created. Slots and slot connections that are specified in specs but not in the recipe are only created once they are needed by strategies who are responsible for mapping slot connections to slots. These strategies must take into account potential slots and slot connections that may not exist yet.