### PR TITLE
Have Devtools built and ready to use on arcs-live

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,8 @@ before_deploy:
   - cd ${TRAVIS_BUILD_DIR} && git log -n 1 > VERSION
   # remove an inaccurate README from arcs-live
   - cd ${TRAVIS_BUILD_DIR} && rm README.md
+  # makes devtools/ useable from arcs-live instance
+  - cd ${TRAVIS_BUILD_DIR}/devtools && npm install
 
 deploy:
   provider: pages


### PR DESCRIPTION
I want arcs-live to contain the usable devtools WebApp. It will be good to have that, so that one can connect to tests running in node or (coming soon hopefully) Arcs in WebView in AiAi without having local arcs checkout and an HTTP server for it.

Disclaimer: I don't really know Travis.