### PR TITLE
Attempt #2 to make devtools work from arcs-live

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,12 +34,11 @@ before_deploy:
   # remove them from .gitignore.
   - cd ${TRAVIS_BUILD_DIR} && sed -i.sedbackup -e '/^shells\/env\/build$/d' .gitignore
   - cd ${TRAVIS_BUILD_DIR} && sed -i.sedbackup -e '/^build$/d' .gitignore
+  - cd ${TRAVIS_BUILD_DIR} && sed -i.sedbackup -e '/^devtools/deps$/d' .gitignore
   - cd ${TRAVIS_BUILD_DIR} && sed -i.sedbackup -e '/^\*\*\/dist$/d' .gitignore
   - cd ${TRAVIS_BUILD_DIR} && git log -n 1 > VERSION
   # remove an inaccurate README from arcs-live
   - cd ${TRAVIS_BUILD_DIR} && rm README.md
-  # makes devtools/ useable from arcs-live instance
-  - cd ${TRAVIS_BUILD_DIR}/devtools && npm install
 
 deploy:
   provider: pages

--- a/devtools/index.html
+++ b/devtools/index.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <title>Arcs Explorer</title>
-    <script src="node_modules/vis/dist/vis.min.js"></script>
-    <script src="node_modules/diff/dist/diff.min.js"></script>
-    <script src="node_modules/web-animations-js/web-animations-next-lite.min.js"></script>
+    <script src="deps/vis/dist/vis.min.js"></script>
+    <script src="deps/diff/dist/diff.min.js"></script>
+    <script src="deps/web-animations-js/web-animations-next-lite.min.js"></script>
     <script src="src/standalone-message-passing.js"></script>
     <script src='src/arcs-devtools-app.js' type='module'></script>
     <style>

--- a/devtools/package.json
+++ b/devtools/package.json
@@ -30,7 +30,7 @@
     "cross-env": "^5.1.3"
   },
   "scripts": {
-    "postinstall": "cross-env empathy install -a deps --ignore diff vis web-animations-js && cross-env tools/css-module-wrap ./node_modules/vis/dist/vis-timeline-graph2d.min.css"
+    "postinstall": "cross-env empathy install -a deps && cross-env tools/css-module-wrap ./node_modules/vis/dist/vis-timeline-graph2d.min.css"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
It turns out the trick is not in 'building' devtools, but in removing its deps from .gitignore.