### PR TITLE
Move static helpers from MapSlots to SlotUtils

### DIFF
--- a/src/runtime/recipe-index.ts
+++ b/src/runtime/recipe-index.ts
@@ -21,7 +21,7 @@ import {ResolveRecipe} from './strategies/resolve-recipe.js';
 import {CreateHandleGroup} from './strategies/create-handle-group.js';
 import {AddMissingHandles} from './strategies/add-missing-handles.js';
 import * as Rulesets from './strategies/rulesets.js';
-import {MapSlots} from './strategies/map-slots.js';
+import {SlotUtils} from './recipe/slot-utils.js';
 import {DevtoolsConnection} from './debug/devtools-connection.js';
 import {Recipe} from './recipe/recipe.js';
 import {RecipeUtil} from './recipe/recipe-util.js';
@@ -250,10 +250,10 @@ export class RecipeIndex {
         for (const [name, slotSpec] of recipeParticle.spec.slots) {
           const recipeSlotConn = recipeParticle.getSlotConnectionByName(name);
           if (recipeSlotConn && recipeSlotConn.targetSlot) continue;
-          if (MapSlots.specMatch(slotSpec, providedSlotSpec) && MapSlots.tagsOrNameMatch(slotSpec, providedSlotSpec)){
+          if (SlotUtils.specMatch(slotSpec, providedSlotSpec) && SlotUtils.tagsOrNameMatch(slotSpec, providedSlotSpec)){
             const slotConn = particle.getSlotConnectionByName(providedSlotSpec.name);
             let matchingHandles = [];
-            if (providedSlotSpec.handles.length !== 0 || (slotConn && !MapSlots.handlesMatch(recipeParticle, slotConn))) {
+            if (providedSlotSpec.handles.length !== 0 || (slotConn && !SlotUtils.handlesMatch(recipeParticle, slotConn))) {
               matchingHandles = this._getMatchingHandles(recipeParticle, particle, providedSlotSpec);
               if (matchingHandles.length === 0) {
                 continue;
@@ -279,7 +279,7 @@ export class RecipeIndex {
       }
       for (const consumeConn of recipe.slotConnections) {
         for (const providedSlot of Object.values(consumeConn.providedSlots)) {
-          if (MapSlots.slotMatches(particle, slotSpec, providedSlot)) {
+          if (SlotUtils.slotMatches(particle, slotSpec, providedSlot)) {
             providedSlots.push(providedSlot);
           }
         }

--- a/src/runtime/recipe/slot-utils.ts
+++ b/src/runtime/recipe/slot-utils.ts
@@ -1,0 +1,122 @@
+// Copyright (c) 2019 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+import {Recipe} from './recipe.js';
+import {SlotConnection} from './slot-connection.js';
+import {Particle} from './particle.js';
+import {SlotSpec, ProvidedSlotSpec} from '../particle-spec.js';
+import {Slot} from './slot.js';
+
+import {assert} from '../../platform/assert-web.js';
+
+export class SlotUtils {
+  // Helper methods.
+  // Connect the given slot connection to the selectedSlot, create the slot, if needed.
+  static connectSlotConnection(slotConnection, selectedSlot) {
+    const recipe = slotConnection.recipe;
+    if (!slotConnection.targetSlot) {
+      let clonedSlot = recipe.updateToClone({selectedSlot}).selectedSlot;
+
+      if (!clonedSlot) {
+        if (selectedSlot.id) {
+          clonedSlot = recipe.findSlotByID(selectedSlot.id);
+        }
+        if (clonedSlot == undefined) {
+          clonedSlot = recipe.newSlot(selectedSlot.name);
+          clonedSlot.id = selectedSlot.id;
+        }
+      }
+      slotConnection.connectToSlot(clonedSlot);
+    }
+
+    assert(!selectedSlot.id || !slotConnection.targetSlot.id || (selectedSlot.id === slotConnection.targetSlot.id),
+            `Cannot override slot id '${slotConnection.targetSlot.id}' with '${selectedSlot.id}'`);
+    slotConnection.targetSlot.id = selectedSlot.id || slotConnection.targetSlot.id;
+
+    // TODO: need to concat to existing tags and dedup?
+    slotConnection.targetSlot.tags = [...selectedSlot.tags];
+  }
+
+  // Returns all possible slot candidates, sorted by "quality"
+  static findAllSlotCandidates(particle: Particle, slotSpec: SlotSpec, arc) {
+    const slotConn = particle.getSlotConnectionByName(slotSpec.name);
+    return {
+      // Note: during manfiest parsing, target slot is only set in slot connection, if the slot exists in the recipe.
+      // If this slot is internal to the recipe, it has the sourceConnection set to the providing connection
+      // (and hence the consuming connection is considered connected already). Otherwise, this may only be a remote slot.
+      local: !slotConn || !slotConn.targetSlot ? SlotUtils._findSlotCandidates(particle, slotSpec, particle.recipe.slots) : [],
+      remote: SlotUtils._findSlotCandidates(particle, slotSpec, arc.pec.slotComposer.getAvailableContexts())
+    };
+  }
+
+  // Returns the given slot candidates, sorted by "quality".
+  static _findSlotCandidates(particle: Particle, slotSpec: SlotSpec, slots) {
+    const possibleSlots = slots.filter(s => this.slotMatches(particle, slotSpec, s));
+    possibleSlots.sort((slot1, slot2) => {
+        // TODO: implement.
+        return slot1.name < slot2.name;
+    });
+    return possibleSlots;
+  }
+
+  // Returns true, if the given slot is a viable candidate for the slotConnection.
+  static slotMatches(particle: Particle, slotSpec: SlotSpec, slot) {
+    if (!SlotUtils.specMatch(slotSpec, slot.spec)) {
+      return false;
+    }
+
+    const potentialSlotConn = particle.getSlotConnectionBySpec(slotSpec);
+    if (!SlotUtils.tagsOrNameMatch(slotSpec, slot.spec, potentialSlotConn, slot)) {
+      return false;
+    }
+
+    // Match handles of the provided slot with the slot-connection particle's handles.
+    if (!SlotUtils.handlesMatch(particle, slot)) {
+      return false;
+    }
+    return true;
+  }
+
+  static specMatch(slotSpec, providedSlotSpec) {
+    return slotSpec && // if there's no slotSpec, this is just a slot constraint on a verb
+            providedSlotSpec &&      
+            slotSpec.isSet === providedSlotSpec.isSet;
+  }
+
+  // Returns true, if the providing slot handle restrictions are satisfied by the consuming slot connection.
+  // TODO: should we move some of this logic to the recipe? Or type matching?
+  static handlesMatch(particle: Particle, slot): boolean {
+    if (slot.handles.length === 0) {
+      return true; // slot is not limited to specific handles
+    }
+    return !!Object.values(particle.connections).find(handleConn => {
+      return slot.handles.includes(handleConn.handle) ||
+              (handleConn.handle && handleConn.handle.id && slot.handles.map(sh => sh.id).includes(handleConn.handle.id));
+    });
+  }
+
+  static tagsOrNameMatch(consumeSlotSpec: SlotSpec, provideSlotSpec: ProvidedSlotSpec, consumeSlotConn: SlotConnection = undefined, provideSlot: Slot = undefined) {
+    const consumeTags = [].concat(
+      consumeSlotSpec.tags || [], 
+      consumeSlotConn ? consumeSlotConn.tags : [], 
+      consumeSlotConn && consumeSlotConn.targetSlot ? consumeSlotConn.targetSlot.tags : []
+    );
+
+    const provideTags = [].concat(
+      provideSlotSpec.tags || [], 
+      provideSlot ? provideSlot.tags : [], 
+      provideSlot ? provideSlot.name : (provideSlotSpec.name ? provideSlotSpec.name : [])
+    );
+
+    if (consumeTags.length > 0 && consumeTags.some(t => provideTags.includes(t))) {
+      return true;
+    }
+
+    return consumeSlotSpec.name === (provideSlot ? provideSlot.name : provideSlotSpec.name);
+  }
+}
+

--- a/src/runtime/strategies/map-slots.ts
+++ b/src/runtime/strategies/map-slots.ts
@@ -11,6 +11,7 @@ import {SlotConnection} from '../recipe/slot-connection.js';
 import {Particle} from '../recipe/particle.js';
 import {SlotSpec, ProvidedSlotSpec} from '../particle-spec.js';
 import {Slot} from '../recipe/slot.js';
+import {SlotUtils} from '../recipe/slot-utils.js';
 
 import {assert} from '../../platform/assert-web.js';
 
@@ -20,7 +21,7 @@ export class MapSlots extends Strategy {
 
     return StrategizerWalker.over(this.getResults(inputParams), new class extends StrategizerWalker {
       onPotentialSlotConnection(recipe: Recipe, particle: Particle, slotSpec: SlotSpec) {
-        const {local, remote} = MapSlots.findAllSlotCandidates(particle, slotSpec, arc); 
+        const {local, remote} = SlotUtils.findAllSlotCandidates(particle, slotSpec, arc); 
         // ResolveRecipe handles one-slot case.
         if (local.length + remote.length < 2) {
           return undefined;
@@ -33,7 +34,7 @@ export class MapSlots extends Strategy {
         const slotList = local.length > 0 ? local : remote;
         return slotList.map(slot => ((recipe: Recipe, particle: Particle, slotSpec: SlotSpec) => {
           const newSlotConnection = particle.addSlotConnection(slotSpec.name);
-          MapSlots.connectSlotConnection(newSlotConnection, slot);
+          SlotUtils.connectSlotConnection(newSlotConnection, slot);
           return 1;
         }));
       }
@@ -57,7 +58,7 @@ export class MapSlots extends Strategy {
         const slotSpec = slotConnection.getSlotSpec();
         const particle = slotConnection.particle;
 
-        const {local, remote} = MapSlots.findAllSlotCandidates(particle, slotSpec, arc);
+        const {local, remote} = SlotUtils.findAllSlotCandidates(particle, slotSpec, arc);
         if (local.length + remote.length < 2) {
           return undefined;
         }
@@ -65,115 +66,11 @@ export class MapSlots extends Strategy {
         // If there are any local slots, prefer them over remote slots.
         const slotList = local.length > 0 ? local : remote;
         return slotList.map(slot => ((recipe, slotConnection) => {
-          MapSlots.connectSlotConnection(slotConnection, slot);
+          SlotUtils.connectSlotConnection(slotConnection, slot);
           return 1;
         }));
       }
     }(StrategizerWalker.Permuted), this);
   }
 
-  // Helper methods.
-  // Connect the given slot connection to the selectedSlot, create the slot, if needed.
-  static connectSlotConnection(slotConnection, selectedSlot) {
-    const recipe = slotConnection.recipe;
-    if (!slotConnection.targetSlot) {
-      let clonedSlot = recipe.updateToClone({selectedSlot}).selectedSlot;
-
-      if (!clonedSlot) {
-        if (selectedSlot.id) {
-          clonedSlot = recipe.findSlotByID(selectedSlot.id);
-        }
-        if (clonedSlot == undefined) {
-          clonedSlot = recipe.newSlot(selectedSlot.name);
-          clonedSlot.id = selectedSlot.id;
-        }
-      }
-      slotConnection.connectToSlot(clonedSlot);
-    }
-
-    assert(!selectedSlot.id || !slotConnection.targetSlot.id || (selectedSlot.id === slotConnection.targetSlot.id),
-            `Cannot override slot id '${slotConnection.targetSlot.id}' with '${selectedSlot.id}'`);
-    slotConnection.targetSlot.id = selectedSlot.id || slotConnection.targetSlot.id;
-
-    // TODO: need to concat to existing tags and dedup?
-    slotConnection.targetSlot.tags = [...selectedSlot.tags];
-  }
-
-  // Returns all possible slot candidates, sorted by "quality"
-  static findAllSlotCandidates(particle: Particle, slotSpec: SlotSpec, arc) {
-    const slotConn = particle.getSlotConnectionByName(slotSpec.name);
-    return {
-      // Note: during manfiest parsing, target slot is only set in slot connection, if the slot exists in the recipe.
-      // If this slot is internal to the recipe, it has the sourceConnection set to the providing connection
-      // (and hence the consuming connection is considered connected already). Otherwise, this may only be a remote slot.
-      local: !slotConn || !slotConn.targetSlot ? MapSlots._findSlotCandidates(particle, slotSpec, particle.recipe.slots) : [],
-      remote: MapSlots._findSlotCandidates(particle, slotSpec, arc.pec.slotComposer.getAvailableContexts())
-    };
-  }
-
-  // Returns the given slot candidates, sorted by "quality".
-  static _findSlotCandidates(particle: Particle, slotSpec: SlotSpec, slots) {
-    const possibleSlots = slots.filter(s => this.slotMatches(particle, slotSpec, s));
-    possibleSlots.sort((slot1, slot2) => {
-        // TODO: implement.
-        return slot1.name < slot2.name;
-    });
-    return possibleSlots;
-  }
-
-  // Returns true, if the given slot is a viable candidate for the slotConnection.
-  static slotMatches(particle: Particle, slotSpec: SlotSpec, slot) {
-    if (!MapSlots.specMatch(slotSpec, slot.spec)) {
-      return false;
-    }
-
-    const potentialSlotConn = particle.getSlotConnectionBySpec(slotSpec);
-    if (!MapSlots.tagsOrNameMatch(slotSpec, slot.spec, potentialSlotConn, slot)) {
-      return false;
-    }
-
-    // Match handles of the provided slot with the slot-connection particle's handles.
-    if (!MapSlots.handlesMatch(particle, slot)) {
-      return false;
-    }
-    return true;
-  }
-
-  static specMatch(slotSpec, providedSlotSpec) {
-    return slotSpec && // if there's no slotSpec, this is just a slot constraint on a verb
-            providedSlotSpec &&      
-            slotSpec.isSet === providedSlotSpec.isSet;
-  }
-
-  // Returns true, if the providing slot handle restrictions are satisfied by the consuming slot connection.
-  // TODO: should we move some of this logic to the recipe? Or type matching?
-  static handlesMatch(particle: Particle, slot): boolean {
-    if (slot.handles.length === 0) {
-      return true; // slot is not limited to specific handles
-    }
-    return !!Object.values(particle.connections).find(handleConn => {
-      return slot.handles.includes(handleConn.handle) ||
-              (handleConn.handle && handleConn.handle.id && slot.handles.map(sh => sh.id).includes(handleConn.handle.id));
-    });
-  }
-
-  static tagsOrNameMatch(consumeSlotSpec: SlotSpec, provideSlotSpec: ProvidedSlotSpec, consumeSlotConn: SlotConnection = undefined, provideSlot: Slot = undefined) {
-    const consumeTags = [].concat(
-      consumeSlotSpec.tags || [], 
-      consumeSlotConn ? consumeSlotConn.tags : [], 
-      consumeSlotConn && consumeSlotConn.targetSlot ? consumeSlotConn.targetSlot.tags : []
-    );
-
-    const provideTags = [].concat(
-      provideSlotSpec.tags || [], 
-      provideSlot ? provideSlot.tags : [], 
-      provideSlot ? provideSlot.name : (provideSlotSpec.name ? provideSlotSpec.name : [])
-    );
-
-    if (consumeTags.length > 0 && consumeTags.some(t => provideTags.includes(t))) {
-      return true;
-    }
-
-    return consumeSlotSpec.name === (provideSlot ? provideSlot.name : provideSlotSpec.name);
-  }
 }

--- a/src/runtime/strategies/resolve-recipe.ts
+++ b/src/runtime/strategies/resolve-recipe.ts
@@ -8,7 +8,7 @@
 import {StrategizerWalker, Strategy} from '../../planning/strategizer.js';
 import {Recipe} from '../recipe/recipe.js';
 import {RecipeUtil} from '../recipe/recipe-util.js';
-import {MapSlots} from './map-slots.js';
+import {SlotUtils} from '../recipe/slot-utils.js';
 import {Handle} from '../recipe/handle';
 import {SlotConnection} from '../recipe/slot-connection.js';
 import {Particle} from '../recipe/particle.js';
@@ -91,27 +91,27 @@ export class ResolveRecipe extends Strategy {
 
         const slotSpec = slotConnection.getSlotSpec();
         const particle = slotConnection.particle;
-        const {local, remote} = MapSlots.findAllSlotCandidates(particle, slotSpec, arc);
+        const {local, remote} = SlotUtils.findAllSlotCandidates(particle, slotSpec, arc);
 
         const allSlots = [...local, ...remote];
 
-        // MapSlots handles a multi-slot case.
+        // SlotUtils handles a multi-slot case.
         if (allSlots.length !== 1) {
           return undefined;
         }
 
         const selectedSlot = allSlots[0];
         return (recipe, slotConnection) => {
-          MapSlots.connectSlotConnection(slotConnection, selectedSlot);
+          SlotUtils.connectSlotConnection(slotConnection, selectedSlot);
           return 1;
         };
       }
 
       onPotentialSlotConnection(recipe: Recipe, particle: Particle, slotSpec: SlotSpec) {
-        const {local, remote} = MapSlots.findAllSlotCandidates(particle, slotSpec, arc);
+        const {local, remote} = SlotUtils.findAllSlotCandidates(particle, slotSpec, arc);
         const allSlots = [...local, ...remote];
 
-        // MapSlots handles a multi-slot case.
+        // SlotUtils handles a multi-slot case.
         if (allSlots.length !== 1) {
           return undefined;
         }
@@ -119,7 +119,7 @@ export class ResolveRecipe extends Strategy {
         const selectedSlot = allSlots[0];
         return (recipe, particle, slotSpec) => {
           const newSlotConnection = particle.addSlotConnection(slotSpec.name);
-          MapSlots.connectSlotConnection(newSlotConnection, selectedSlot);
+          SlotUtils.connectSlotConnection(newSlotConnection, selectedSlot);
           return 1;
         };
       }


### PR DESCRIPTION
These utility functions are used outside of strategy and planning, specifically by resolving, so they need to be separated from strategies.