### PR TITLE
Refactor ModalityHandler to not depend on Suggestions.

### DIFF
--- a/shells/lib/dom-slot-composer.js
+++ b/shells/lib/dom-slot-composer.js
@@ -1,10 +1,10 @@
 import {Modality} from '../../build/runtime/modality.js';
-import {ModalityHandler} from '../../build/runtime/modality-handler.js';
+import {PlanningModalityHandler} from '../../build/runtime/planning-modality-handler.js';
 import {SlotComposer} from '../../build/runtime/slot-composer.js';
 
 const domModality = {
   modalityName: Modality.Name.Dom,
-  modalityHandler: ModalityHandler.domHandler
+  modalityHandler: PlanningModalityHandler.domHandler
 };
 
 export const DomSlotComposer = class extends SlotComposer {

--- a/shells/lib/ram-slot-composer.js
+++ b/shells/lib/ram-slot-composer.js
@@ -7,7 +7,7 @@
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
-import {ModalityHandler} from '../../build/runtime/modality-handler.js';
+import {PlanningModalityHandler} from '../../build/runtime/planning-modality-handler.js';
 import {SlotComposer} from '../../build/runtime/slot-composer.js';
 
 export class RamSlotComposer extends SlotComposer {
@@ -15,7 +15,7 @@ export class RamSlotComposer extends SlotComposer {
     super({
       rootContainer: options.rootContainer || {'root': 'root-context'},
       modalityName: options.modalityName,
-      modalityHandler: ModalityHandler.createHeadlessHandler()
+      modalityHandler: PlanningModalityHandler.createHeadlessHandler()
     });
   }
 

--- a/shells/single-shell/index.html
+++ b/shells/single-shell/index.html
@@ -43,7 +43,7 @@ http://polymer.github.io/PATENTS.txt
 
   const composer = new SlotComposer({
     modalityName: Modality.Name.Dom,
-    modalityHandler: ModalityHandler.domHandler,
+    modalityHandler: PlanningModalityHandler.domHandler,
     rootContainer: document.body
   });
 

--- a/src/runtime/modality-handler.ts
+++ b/src/runtime/modality-handler.ts
@@ -9,23 +9,19 @@
  */
 import {assert} from '../platform/assert-web.js';
 import {SlotDomConsumer} from './slot-dom-consumer.js';
-import {SuggestDomConsumer} from './suggest-dom-consumer.js';
 import {MockSlotDomConsumer} from './testing/mock-slot-dom-consumer.js';
-import {MockSuggestDomConsumer} from './testing/mock-suggest-dom-consumer.js';
 import {DescriptionFormatter} from './description-formatter.js';
 import {DescriptionDomFormatter} from './description-dom-formatter.js';
 
 export class ModalityHandler {
   constructor(public readonly slotConsumerClass: typeof SlotDomConsumer,
-              public readonly suggestionConsumerClass: typeof SuggestDomConsumer,
-              public readonly descriptionFormatter?: typeof DescriptionFormatter) {}
+              public readonly descriptionFormatter?: typeof DescriptionFormatter){}
 
   static createHeadlessHandler(): ModalityHandler {
-    return new ModalityHandler(MockSlotDomConsumer, MockSuggestDomConsumer);
+    return new ModalityHandler(MockSlotDomConsumer);
   }
 
-  static readonly domHandler = new ModalityHandler(
+  static readonly domHandler : ModalityHandler = new ModalityHandler(
     SlotDomConsumer,
-    SuggestDomConsumer,
     DescriptionDomFormatter);
 }

--- a/src/runtime/planning-modality-handler.ts
+++ b/src/runtime/planning-modality-handler.ts
@@ -1,0 +1,34 @@
+/**
+ * @license
+ * Copyright (c) 2019 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+import {SlotDomConsumer} from './slot-dom-consumer.js';
+import {SuggestDomConsumer} from './suggest-dom-consumer.js';
+import {MockSlotDomConsumer} from './testing/mock-slot-dom-consumer.js';
+import {MockSuggestDomConsumer} from './testing/mock-suggest-dom-consumer.js';
+import {ModalityHandler} from './modality-handler.js';
+import {DescriptionFormatter} from './description-formatter.js';
+import {DescriptionDomFormatter} from './description-dom-formatter.js';
+
+
+export class PlanningModalityHandler extends ModalityHandler{
+  constructor(slotConsumerClass: typeof SlotDomConsumer,
+              public readonly suggestionConsumerClass: typeof SuggestDomConsumer,
+              descriptionFormatter?: typeof DescriptionFormatter){
+    super(slotConsumerClass, descriptionFormatter);
+  }
+
+  static createHeadlessHandler(): PlanningModalityHandler {
+    return new PlanningModalityHandler(MockSlotDomConsumer, MockSuggestDomConsumer);
+  }
+
+  static readonly domHandler : PlanningModalityHandler = new PlanningModalityHandler(
+    SlotDomConsumer,
+    SuggestDomConsumer,
+    DescriptionDomFormatter);
+}

--- a/src/runtime/recipe-index.ts
+++ b/src/runtime/recipe-index.ts
@@ -31,7 +31,7 @@ import {Handle} from './recipe/handle.js';
 import {assert} from '../platform/assert-web.js';
 import {PlanningResult} from './plan/planning-result.js';
 import {Modality} from './modality.js';
-import {ModalityHandler} from './modality-handler.js';
+import {PlanningModalityHandler} from './planning-modality-handler.js';
 import {ProvidedSlotSpec, SlotSpec} from './particle-spec.js';
 import {Particle} from './recipe/particle.js';
 import {HandleConnection} from './recipe/handle-connection.js';
@@ -101,7 +101,7 @@ export class RecipeIndex {
       context: new Manifest({id: 'empty-context'}),
       loader: arc.loader,
       slotComposer: new SlotComposer({
-        modalityHandler: ModalityHandler.createHeadlessHandler(),
+        modalityHandler: PlanningModalityHandler.createHeadlessHandler(),
         noRoot: true
       }),
       // TODO: Not speculative really, figure out how to mark it so DevTools doesn't pick it up.

--- a/src/runtime/slot-composer.ts
+++ b/src/runtime/slot-composer.ts
@@ -43,7 +43,9 @@ export class SlotComposer {
    * - containerKind: the type of container wrapping each slot-context's container  (for example, div).
    */
   constructor(options: SlotComposerOptions) {
-    assert(options.modalityHandler && options.modalityHandler.constructor === ModalityHandler,
+//    assert(options.modalityHandler && options.modalityHandler.constructor === ModalityHandler,
+//           `Missing or invalid modality handler: ${options.modalityHandler}`);
+    assert(options.modalityHandler,
            `Missing or invalid modality handler: ${options.modalityHandler}`);
     // TODO: Support rootContext for backward compatibility, remove when unused.
     options.rootContainer = options.rootContainer || options.rootContext || (options.containers || Object).root;

--- a/src/runtime/suggestion-composer.ts
+++ b/src/runtime/suggestion-composer.ts
@@ -7,7 +7,7 @@
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
-import {ModalityHandler} from './modality-handler.js';
+import {PlanningModalityHandler} from './planning-modality-handler.js';
 import {SlotComposer} from './slot-composer.js';
 import {Arc} from './arc.js';
 import {Suggestion} from './plan/suggestion.js';
@@ -30,7 +30,7 @@ export class SuggestionComposer {
     this.arc = arc;
   }
 
-  get modalityHandler(): ModalityHandler { return this._slotComposer.modalityHandler; }
+  get modalityHandler(): PlanningModalityHandler { return this._slotComposer.modalityHandler as PlanningModalityHandler; }
 
   clear(): void {
     if (this._container) {

--- a/src/runtime/test/plan/plan-consumer-test.ts
+++ b/src/runtime/test/plan/plan-consumer-test.ts
@@ -10,7 +10,7 @@
 import {assert} from '../../../platform/chai-web.js';
 import {MockSlotComposer} from '../../testing/mock-slot-composer.js';
 import {Modality} from '../../modality.js';
-import {ModalityHandler} from '../../modality-handler.js';
+import {PlanningModalityHandler} from '../../planning-modality-handler.js';
 import {PlanConsumer} from '../../plan/plan-consumer.js';
 import {Planificator} from '../../plan/planificator.js';
 import {PlanningResult} from '../../plan/planning-result.js';
@@ -124,7 +124,7 @@ describe('plan consumer', () => {
       const helper = await TestHelper.create({
         slotComposer: new MockSlotComposer({
           modalityName,
-          modalityHandler: ModalityHandler.createHeadlessHandler()
+          modalityHandler: PlanningModalityHandler.createHeadlessHandler()
         }), 
         manifestString: `
   particle ParticleDom in './src/runtime/test/artifacts/consumer-particle.js'

--- a/src/runtime/testing/fake-slot-composer.ts
+++ b/src/runtime/testing/fake-slot-composer.ts
@@ -9,7 +9,7 @@
  */
 
 import {Modality} from '../modality.js';
-import {ModalityHandler} from '../modality-handler.js';
+import {PlanningModalityHandler} from '../planning-modality-handler.js';
 import {SlotComposer, SlotComposerOptions} from '../slot-composer.js';
 
 /**
@@ -19,7 +19,7 @@ export class FakeSlotComposer extends SlotComposer {
   constructor(options: SlotComposerOptions = {}) {
     super({
       rootContainer: {'root': 'root-context'},
-      modalityHandler: ModalityHandler.createHeadlessHandler(),
+      modalityHandler: PlanningModalityHandler.createHeadlessHandler(),
       ...options});
   }
 


### PR DESCRIPTION
Part of preparing to split off all Planning and Strategizing from the runtime code.

ModalityHandler is now a base class and PlanningModalityHandler is a subclass
that does know about Suggestions.