### PR TITLE
Protect node_modules/sourcemapped-stacktrace/dist from being removed by travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,8 @@ before_deploy:
   - cd ${TRAVIS_BUILD_DIR} && git log -n 1 > VERSION
   # remove an inaccurate README from arcs-live
   - cd ${TRAVIS_BUILD_DIR} && rm README.md
+  # Temporarily push node_modules to arcs-live.
+  - cd ${TRAVIS_BUILD_DIR} && sed -i.sedbackup -e '/^\*\*\/node_modules/d' .gitignore
 
 deploy:
   provider: pages


### PR DESCRIPTION
So that web-shell can depend on it and work on arcs-live.