### PR TITLE
Send planning generated in a previous session to StrategyExplorer

### DIFF
--- a/src/planning/plan/plan-consumer.ts
+++ b/src/planning/plan/plan-consumer.ts
@@ -49,6 +49,7 @@ export class PlanConsumer {
     if (DevtoolsConnection.isConnected) {
       this.devtoolsChannel = DevtoolsConnection.get().forArc(this.arc);
     }
+    this._maybeUpdateStrategyExplorer();
   }
 
   registerSuggestionsChangedCallback(callback) { this.suggestionsChangeCallbacks.push(callback); }
@@ -66,11 +67,7 @@ export class PlanConsumer {
   onSuggestionsChanged() {
     this._onSuggestionsChanged();
     this._onMaybeSuggestionsChanged();
-
-    if (this.result.generations.length) {
-      StrategyExplorerAdapter.processGenerations(
-          this.result.generations, this.devtoolsChannel, {label: 'Plan Consumer', keep: true});
-    }
+    this._maybeUpdateStrategyExplorer();
   }
 
   getCurrentSuggestions(): Suggestion[] {
@@ -139,6 +136,13 @@ export class PlanConsumer {
       this.suggestionComposer = new SuggestionComposer(this.arc, composer);
       this.registerVisibleSuggestionsChangedCallback(
           (suggestions) => this.suggestionComposer.setSuggestions(suggestions));
+    }
+  }
+
+  _maybeUpdateStrategyExplorer() {
+    if (this.result.generations.length) {
+      StrategyExplorerAdapter.processGenerations(
+          this.result.generations, this.devtoolsChannel, {label: 'Plan Consumer', keep: true});
     }
   }
 }


### PR DESCRIPTION
Currently the initial planning result, which is passed in through the constructor is never sent to the StrategyExplorer tool. This fixes it.