### PR TITLE
Disable local DevTools if remote one is requested

### DIFF
--- a/devtools/src/contentScript.js
+++ b/devtools/src/contentScript.js
@@ -7,6 +7,10 @@ try {
   return;
 }
 
+// Don't execute if Shell is requesting remote Arcs Explorer.
+// TODO: Send a message to Arcs Explorer in Chrome DevTools that it should be disabled?
+if (new URLSearchParams(window.location.search).has('remote-explore-key')) return;
+
 const startupTime = Date.now();
 
 const log = console.log.bind(console,


### PR DESCRIPTION
Remote Exploring is not yet checked in, but this will allow it to work nicely from ToT Arcs Explorer extension loaded to the browser when hacked branch with remote exploring is served from another URL. With this, the devtools connection is opened to the local Arcs Explorer even when we're waiting for remote one to appear.