### PR TITLE
Show Speculative Arcs with Suggestion text in Arcs Explorer

### DIFF
--- a/src/planning/recipe-index.ts
+++ b/src/planning/recipe-index.ts
@@ -104,8 +104,7 @@ export class RecipeIndex {
         modalityHandler: PlanningModalityHandler.createHeadlessHandler(),
         noRoot: true
       }),
-      // TODO: Not speculative really, figure out how to mark it so DevTools doesn't pick it up.
-      speculative: true
+      stub: true
     });
     const strategizer = new Strategizer(
       [

--- a/src/planning/speculator.ts
+++ b/src/planning/speculator.ts
@@ -15,6 +15,8 @@ import {PlanningResult} from './plan/planning-result.js';
 import {Recipe} from '../runtime/recipe/recipe.js';
 import {Relevance} from '../runtime/relevance.js';
 import {Suggestion} from './plan/suggestion.js';
+import {DevtoolsChannel} from '../platform/devtools-channel-web.js';
+import {DevtoolsConnection} from '../runtime/debug/devtools-connection.js';
 
 export class Speculator {
   private suggestionByHash: {} = {};
@@ -55,6 +57,15 @@ export class Speculator {
         arc.modality,
         arc.pec.slotComposer ? arc.pec.slotComposer.modalityHandler.descriptionFormatter : undefined);
     this.suggestionByHash[hash] = suggestion;
+
+    // TODO: Find a better way to associate arcs with descriptions.
+    //       Ideally, a way that works also for non-speculative arcs.
+    if (DevtoolsConnection.isConnected) {
+      DevtoolsConnection.get().forArc(speculativeArc).send({
+        messageType: 'arc-description',
+        messageBody: suggestion.descriptionText
+      });
+    }
     return suggestion;
   }
 

--- a/src/runtime/arc.ts
+++ b/src/runtime/arc.ts
@@ -38,6 +38,7 @@ type ArcOptions = {
   storageProviderFactory?: StorageProviderFactory;
   speculative?: boolean;
   innerArc?: boolean;
+  stub?: boolean
 };
 
 type DeserializeArcOptions = {
@@ -58,6 +59,7 @@ export class Arc {
   private readonly pecFactory: (id: string) => PECInnerPort;
   public readonly isSpeculative: boolean;
   public readonly isInnerArc: boolean;
+  public readonly isStub: boolean;
   private _activeRecipe = new Recipe();
   // TODO: rename: these are just tuples of {particles, handles, slots, pattern} of instantiated recipes merged into active recipe.
   private _recipes: {handles: Handle[], particles: Particle[], slots: Slot[], patterns: string[]}[] = [];
@@ -84,7 +86,7 @@ export class Arc {
   particleHandleMaps = new Map<string, {spec: ParticleSpec, handles: Map<string, StorageProviderBase>}>();
   pec: ParticleExecutionHost;
 
-  constructor({id, context, pecFactory, slotComposer, loader, storageKey, storageProviderFactory, speculative, innerArc} : ArcOptions) {
+  constructor({id, context, pecFactory, slotComposer, loader, storageKey, storageProviderFactory, speculative, innerArc, stub} : ArcOptions) {
     // TODO: context should not be optional.
     this._context = context || new Manifest({id});
     // TODO: pecFactory should not be optional. update all callers and fix here.
@@ -94,6 +96,7 @@ export class Arc {
     this.id = Id.newSessionId().fromString(id);
     this.isSpeculative = !!speculative; // undefined => false
     this.isInnerArc = !!innerArc; // undefined => false
+    this.isStub = !!stub;
     this._loader = loader;
 
     this.storageKey = storageKey;

--- a/src/runtime/debug/arc-debug-handler.ts
+++ b/src/runtime/debug/arc-debug-handler.ts
@@ -25,8 +25,7 @@ export class ArcDebugHandler {
   private arcDevtoolsChannel: DevtoolsChannel = null;
   
   constructor(arc: Arc) {
-    // Currently no support for speculative arcs.
-    if (arc.isSpeculative) return;
+    if (arc.isStub) return;
 
     const connectedOnInstantiate = DevtoolsConnection.isConnected;
 
@@ -44,7 +43,12 @@ export class ArcDebugHandler {
       const arcPlannerInvoker = new ArcPlannerInvoker(arc, this.arcDevtoolsChannel);
       const arcStoresFetcher = new ArcStoresFetcher(arc, this.arcDevtoolsChannel);
 
-      this.arcDevtoolsChannel.send({messageType: 'arc-available'});
+      this.arcDevtoolsChannel.send({
+        messageType: 'arc-available',
+        messageBody: {
+          speculative: arc.isSpeculative
+        }
+      });
     });
   }
 

--- a/src/runtime/debug/outer-port-attachment.ts
+++ b/src/runtime/debug/outer-port-attachment.ts
@@ -12,17 +12,12 @@ import {mapStackTrace} from '../../platform/sourcemapped-stacktrace-web.js';
 
 export class OuterPortAttachment {
   private arcDevtoolsChannel;
-  private speculative: boolean;
 
   constructor(arc, devtoolsChannel) {
     this.arcDevtoolsChannel = devtoolsChannel.forArc(arc);
-    this.speculative = arc.isSpeculative;
   }
 
   handlePecMessage(name, pecMsgBody, pecMsgCount, stackString) {
-    // Skip speculative arcs for now.
-    if (this.speculative) return;
-
     const stack = this._extractStackFrames(stackString);
     this.arcDevtoolsChannel.send({
       messageType: 'PecLog',


### PR DESCRIPTION
A quick addition to enable showing SpecEx during the demo tomorrow.

There are sub-optimal bits:
* New property on arc "isStub" - stub arc is only used as an arc given to strategies in recipe-index.
* Speculator sends messages associating a speculative arc with suggestion text to DevTools. I don't know where else to put it as Arc has no idea of what its description is.

<img width="647" alt="screen shot 2019-02-05 at 1 47 51 pm" src="https://user-images.githubusercontent.com/26159485/52250722-3f232800-294d-11e9-9193-a698b0f67f74.png">
