### PR TITLE
Write default data for pouch collection/variable storage keys

### DIFF
--- a/src/planning/test/plan/planificator-test.ts
+++ b/src/planning/test/plan/planificator-test.ts
@@ -120,7 +120,7 @@ describe('remote planificator', () => {
     return {consumePlanificator, producePlanificator};
   }
 
-  [null, 'pouchdb://memory/user/'].forEach(plannerStorageKeyBase => {
+  ['volatile', 'pouchdb://memory/user/'].forEach(plannerStorageKeyBase => {
     it(`consumes remotely produced gifts demo from ${plannerStorageKeyBase}`, async () => {
       let {consumePlanificator, producePlanificator} = await init(
           plannerStorageKeyBase,

--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -53,6 +53,7 @@ export class StorageStub {
 
   async inflate() {
     const store = await this.storageProviderFactory.connect(this.id, this.type, this.storageKey);
+    assert(store != null, 'inflating missing storageKey ' + this.storageKey);
     store.originalId = this.originalId;
     return store;
   }

--- a/src/runtime/storage/pouchdb/pouch-db-collection.ts
+++ b/src/runtime/storage/pouchdb/pouch-db-collection.ts
@@ -43,7 +43,7 @@ export class PouchDbCollection extends PouchDbStorageProvider implements Collect
 
     this._model = new CrdtCollectionModel();
 
-    // Insure that the underlying database item is created.
+    // Ensure that the underlying database item is created.
     this.db.get(this.pouchDbKey.location).catch((err) => {
       if (err.name === 'not_found') {
         this.db.put({
@@ -51,7 +51,7 @@ export class PouchDbCollection extends PouchDbStorageProvider implements Collect
           model: this._model.toLiteral(),
           referenceMode: this.referenceMode,
           type: this.type.toLiteral()
-        }).catch((e) => {console.log('error init', e);});
+        }).catch((e) => {console.warn('error init', e);});
       }
     });
 

--- a/src/runtime/storage/pouchdb/pouch-db-collection.ts
+++ b/src/runtime/storage/pouchdb/pouch-db-collection.ts
@@ -42,6 +42,19 @@ export class PouchDbCollection extends PouchDbStorageProvider implements Collect
     super(type, storageEngine, name, id, key);
 
     this._model = new CrdtCollectionModel();
+
+    // Insure that the underlying database item is created.
+    this.db.get(this.pouchDbKey.location).catch((err) => {
+      if (err.name === 'not_found') {
+        this.db.put({
+          _id: this.pouchDbKey.location,
+          model: this._model.toLiteral(),
+          referenceMode: this.referenceMode,
+          type: this.type.toLiteral()
+        }).catch((e) => {console.log('error init', e);});
+      }
+    });
+
     assert(this.version !== null);
   }
 
@@ -308,7 +321,7 @@ export class PouchDbCollection extends PouchDbStorageProvider implements Collect
    * Provides a way to apply changes to the model in a way that will result in the
    * crdt being written to the underlying PouchDB.
    *
-   * - A new entry is stored if it doesn't exists.
+   * - A new entry is stored if it doesn't exist.
    * - If the existing entry is available it is fetched and the
    *   internal state is updated.
    * - A copy of the CRDT model is passed to the modelMutator, which may change it.

--- a/src/runtime/storage/pouchdb/pouch-db-variable.ts
+++ b/src/runtime/storage/pouchdb/pouch-db-variable.ts
@@ -44,6 +44,18 @@ export class PouchDbVariable extends PouchDbStorageProvider implements VariableS
   constructor(type: Type, storageEngine: PouchDbStorage, name: string, id: string, key: string) {
     super(type, storageEngine, name, id, key);
     this.backingStore = null;
+
+    // Insure that there's a value stored.
+    this.db.get(this.pouchDbKey.location).catch((err) => {
+      if (err.name === 'not_found') {
+        this.db.put({
+          _id: this.pouchDbKey.location,
+          value: null,
+          version: 0,
+          referenceMode: this.referenceMode
+        }).catch((e) => {console.log('error init', e);});
+      }
+    });
   }
 
   backingType(): Type {

--- a/src/runtime/test/arc-tests.ts
+++ b/src/runtime/test/arc-tests.ts
@@ -578,24 +578,24 @@ describe('Arc', () => {
   });
 
   ['volatile://', 'pouchdb://memory/user/'].forEach((storageKeyPrefix) => {
-    it('handles serialization/deserializatoin of empty arcs handles ' + storageKeyPrefix, async () => {
+    it('handles serialization/deserialization of empty arcs handles ' + storageKeyPrefix, async () => {
       const id = new Id('123', ['test']).toString();
       const loader = new Loader();
 
       const manifest = await Manifest.parse(`
-schema FavoriteFood
-  Text food
+        schema FavoriteFood
+          Text food
 
-particle FavoriteFoodPicker in 'particles/Profile/source/FavoriteFoodPicker.js'
-  inout [FavoriteFood] foods
-  description \`select favorite foods\`
-    foods \`favorite foods\`
+        particle FavoriteFoodPicker in 'particles/Profile/source/FavoriteFoodPicker.js'
+          inout [FavoriteFood] foods
+          description \`select favorite foods\`
+            foods \`favorite foods\`
 
-recipe FavoriteFood
-  create #favoriteFoods as foods
-  FavoriteFoodPicker
-    foods = foods
-`, {loader, fileName: process.cwd() + '/input.manifest'});
+        recipe FavoriteFood
+          create #favoriteFoods as foods
+          FavoriteFoodPicker
+            foods = foods
+        `, {loader, fileName: process.cwd() + '/input.manifest'});
 
       const arc = new Arc({id, storageKey: `${storageKeyPrefix}${id}`, loader: new Loader(), context: manifest});
       assert.isNotNull(arc);

--- a/src/runtime/test/arc-tests.ts
+++ b/src/runtime/test/arc-tests.ts
@@ -505,7 +505,7 @@ describe('Arc', () => {
   //
   // B performs the same thing, but puts C in its inner arc. C puts D etc. The whole affair stops
   // with Z, which just renders 'Z'.
-  // 
+  //
   // As aresult we get 26 arcs in total, the first one is an outer arc and each next is an inner arc
   // of a preceding one. A ends up rendering 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.
   it('handles recursive inner arcs', async () => {
@@ -515,31 +515,31 @@ describe('Arc', () => {
       const next = String.fromCharCode(current.charCodeAt(0) + 1);
       sources[`${current}.js`] = `defineParticle(({DomParticle}) => {
         return class extends DomParticle {
-          async setHandles(handles) { 
+          async setHandles(handles) {
             super.setHandles(handles);
 
             const innerArc = await this.constructInnerArc();
             const hostedSlotId = await innerArc.createSlot(this, 'root');
-      
+
             innerArc.loadRecipe(\`
               particle ${next} in '${next}.js'
                 consume root
-              
+
               recipe
                 slot '\` + hostedSlotId + \`' as hosted
                 ${next}
                   consume root as hosted
             \`);
           }
-      
+
           renderHostedSlot(slotName, hostedSlotId, content) {
             this.setState(content);
           }
-      
+
           shouldRender() {
             return Boolean(this.state.template);
           }
-      
+
           getTemplate() {
             return '${current}' + this.state.template;
           }
@@ -552,12 +552,12 @@ describe('Arc', () => {
       manifestString: `
         particle A in 'A.js'
           consume root
-    
+
         recipe
           slot 'rootslotid-root' as root
           A
             consume root as root`,
-      loader: new StubLoader({        
+      loader: new StubLoader({
         ...sources,
         'Z.js': `defineParticle(({DomParticle}) => {
           return class extends DomParticle {
@@ -576,4 +576,57 @@ describe('Arc', () => {
     await rootSlotConsumer.contentAvailable;
     assert.equal(rootSlotConsumer._content.template, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ');
   });
+
+  ['volatile://', 'pouchdb://memory/user/'].forEach((storageKeyPrefix) => {
+    it('handles serialization/deserializatoin of empty arcs handles ' + storageKeyPrefix, async () => {
+      const id = new Id('123', ['test']).toString();
+      const loader = new Loader();
+
+      const manifest = await Manifest.parse(`
+schema FavoriteFood
+  Text food
+
+particle FavoriteFoodPicker in 'particles/Profile/source/FavoriteFoodPicker.js'
+  inout [FavoriteFood] foods
+  description \`select favorite foods\`
+    foods \`favorite foods\`
+
+recipe FavoriteFood
+  create #favoriteFoods as foods
+  FavoriteFoodPicker
+    foods = foods
+`, {loader, fileName: process.cwd() + '/input.manifest'});
+
+      const arc = new Arc({id, storageKey: `${storageKeyPrefix}${id}`, loader: new Loader(), context: manifest});
+      assert.isNotNull(arc);
+
+      const favoriteFoodClass = manifest.findSchemaByName('FavoriteFood').entityClass();
+      assert.isNotNull(favoriteFoodClass);
+
+      const recipe = manifest.recipes[0];
+      assert.isNotNull(recipe);
+
+      const foodStore = await arc.createStore(favoriteFoodClass.type.collectionOf(), undefined, 'test:1') as CollectionStorageProvider;
+      assert.isNotNull(foodStore);
+      recipe.handles[0].mapToStorage(foodStore);
+
+      const favoriteFoodType = manifest.findTypeByName('FavoriteFood') ;
+      assert.isNotNull(favoriteFoodType, 'FavoriteFood type is found');
+
+      const options = {errors: new Map()};
+      const normalized = recipe.normalize(options);
+      assert(normalized, 'not normalized ' + options.errors);
+      assert(recipe.isResolved());
+      await arc.instantiate(recipe);
+
+      const serialization = await arc.serialize();
+
+      const slotComposer = new FakeSlotComposer();
+
+      const newArc = await Arc.deserialize({serialization, loader, slotComposer, context: undefined, fileName: 'foo.manifest'});
+      assert.equal(newArc._stores.length, 1);
+      assert.equal(newArc.activeRecipe.toString(), arc.activeRecipe.toString());
+      assert.equal(newArc.id.toStringWithoutSessionForTesting(), 'test');
+    });
+  });  // end forEach(storageKeyPrefix)
 });


### PR DESCRIPTION
Note: the pouch driver keeps a consistent view of the underlying data, so
starting an async write in the constructor is okay.

Fixes #2605