### PR TITLE
Inject devtools endpoints into Arc constructor and deserialize method

### DIFF
--- a/shells/lib/debug-listeners.js
+++ b/shells/lib/debug-listeners.js
@@ -1,0 +1,9 @@
+import {defaultCoreDebugListeners} from '../../build/runtime/debug/arc-debug-handler.js';
+import {defaultPlanningDebugListeners} from '../../build/planning/debug/arc-planner-invoker.js';
+
+// Debug-channel listeners are injected, so that the runtime need not know about them.
+export const debugListeners = [
+  ...defaultPlanningDebugListeners, // This should change for a shell w/out planning
+  ...defaultCoreDebugListeners
+  ];
+

--- a/shells/lib/utils.js
+++ b/shells/lib/utils.js
@@ -3,8 +3,7 @@ import {Arc} from '../../build/runtime/arc.js';
 import {RecipeResolver} from '../../build/runtime/recipe/recipe-resolver.js';
 import {PlatformLoader} from '../../build/platform/loader-web.js';
 import {PecIndustry} from '../../build/platform/pec-industry-web.js';
-import {defaultCoreDebugListeners} from '../../build/runtime/debug/arc-debug-handler.js';
-import {ArcPlannerInvoker, defaultPlanningDebugListeners} from '../../build/planning/debug/arc-planner-invoker.js';
+import {debugListeners} from './debug-listeners.js';
 
 const log = console.log.bind(console);
 const warn = console.warn.bind(console);
@@ -54,16 +53,6 @@ const resolve = async (arc, recipe) =>{
   }
 };
 
-// Debug-channel listeners must now be injected, so that the runtime need
-// not know about them. The refactoring that established that put these here,
-// but this will need to change when we build a shell that actually doesn't
-// include planning.
-// TODO: move these to a more appropriate place when that place is clear.
-const debugListenerClasses = [
-    ...defaultPlanningDebugListeners,
-    ...defaultCoreDebugListeners
-  ];
-
 const spawn = async ({id, serialization, context, composer, storage}) => {
   const params = {
     id,
@@ -74,7 +63,7 @@ const spawn = async ({id, serialization, context, composer, storage}) => {
     slotComposer: composer,
     pecFactory: env.pecFactory,
     loader: env.loader,
-    listenerClasses: debugListenerClasses
+    listenerClasses: debugListeners
   };
   Object.assign(params, env.params);
   return serialization ? Arc.deserialize(params) : new Arc(params);

--- a/shells/lib/utils.js
+++ b/shells/lib/utils.js
@@ -3,6 +3,8 @@ import {Arc} from '../../build/runtime/arc.js';
 import {RecipeResolver} from '../../build/runtime/recipe/recipe-resolver.js';
 import {PlatformLoader} from '../../build/platform/loader-web.js';
 import {PecIndustry} from '../../build/platform/pec-industry-web.js';
+import {defaultCoreDebugListeners} from '../../build/runtime/debug/arc-debug-handler.js';
+import {ArcPlannerInvoker, defaultPlanningDebugListeners} from '../../build/planning/debug/arc-planner-invoker.js';
 
 const log = console.log.bind(console);
 const warn = console.warn.bind(console);
@@ -52,6 +54,16 @@ const resolve = async (arc, recipe) =>{
   }
 };
 
+// Debug-channel listeners must now be injected, so that the runtime need
+// not know about them. The refactoring that established that put these here,
+// but this will need to change when we build a shell that actually doesn't
+// include planning.
+// TODO: move these to a more appropriate place when that place is clear.
+const debugListenerClasses = [
+    ...defaultPlanningDebugListeners,
+    ...defaultCoreDebugListeners
+  ];
+
 const spawn = async ({id, serialization, context, composer, storage}) => {
   const params = {
     id,
@@ -61,7 +73,8 @@ const spawn = async ({id, serialization, context, composer, storage}) => {
     storageKey: storage,
     slotComposer: composer,
     pecFactory: env.pecFactory,
-    loader: env.loader
+    loader: env.loader,
+    listenerClasses: debugListenerClasses
   };
   Object.assign(params, env.params);
   return serialization ? Arc.deserialize(params) : new Arc(params);

--- a/src/planning/debug/arc-planner-invoker.ts
+++ b/src/planning/debug/arc-planner-invoker.ts
@@ -17,7 +17,7 @@ import {Strategizer, Strategy, StrategyDerived} from '../strategizer.js';
 import * as Rulesets from '../strategies/rulesets.js';
 import {Manifest} from '../../runtime/manifest.js';
 import {Recipe} from '../../runtime/recipe/recipe.js';
-import {ArcDevtoolsChannel} from '../../runtime/debug/abstract-devtools-channel.js';
+import {ArcDevtoolsChannel, ArcDebugListener, ArcDebugListenerDerived} from '../../runtime/debug/abstract-devtools-channel.js';
 
 class InitialRecipe extends Strategy {
   private recipe: Recipe;
@@ -42,11 +42,12 @@ class InitialRecipe extends Strategy {
   }
 }
 
-export class ArcPlannerInvoker {
+export class ArcPlannerInvoker extends ArcDebugListener {
   private arc: Arc;
   private recipeIndex: RecipeIndex;
   
   constructor(arc: Arc, arcDevtoolsChannel: ArcDevtoolsChannel) {
+    super(arc, arcDevtoolsChannel);
     this.arc = arc;
 
     arcDevtoolsChannel.listen('fetch-strategies', () => arcDevtoolsChannel.send({
@@ -209,3 +210,8 @@ export class ArcPlannerInvoker {
     return depth;
   }
 }
+
+// TODO: This should move to the planning interface file when it exists. 
+export const defaultPlanningDebugListeners: ArcDebugListenerDerived[] = [
+  ArcPlannerInvoker
+];

--- a/src/runtime/debug/abstract-devtools-channel.ts
+++ b/src/runtime/debug/abstract-devtools-channel.ts
@@ -89,4 +89,16 @@ export class ArcDevtoolsChannel {
   listen(messageType, callback) {
     this.channel.listen(this.arcId, messageType, callback);
   }
+
+  static instantiateListener(listenerClass: ArcDebugListenerDerived, 
+                             arc: Arc,
+                             channel: ArcDevtoolsChannel): ArcDebugListener {
+    return new listenerClass(arc, channel);
+  }
 }
+
+export abstract class ArcDebugListener {
+  constructor(arc: Arc, channel: ArcDevtoolsChannel) {}
+}
+type ArcDebugListenerClass = typeof ArcDebugListener;
+export interface ArcDebugListenerDerived extends ArcDebugListenerClass {}

--- a/src/runtime/debug/arc-debug-handler.ts
+++ b/src/runtime/debug/arc-debug-handler.ts
@@ -41,6 +41,8 @@ export class ArcDebugHandler {
       this.arcDevtoolsChannel = devtoolsChannel.forArc(arc);
 
       if (!!listenerClasses) { // undefined => false
+      	// TODO: This should just be a foreach, as there is no need to keep
+      	// the results.
         const listeners = listenerClasses.map(l => {
           ArcDevtoolsChannel.instantiateListener(l, arc, this.arcDevtoolsChannel);
         });

--- a/src/runtime/debug/arc-debug-handler.ts
+++ b/src/runtime/debug/arc-debug-handler.ts
@@ -10,21 +10,22 @@
 
 import {enableTracingAdapter} from './tracing-adapter.js';
 import {Arc} from '../arc.js';
-import {ArcPlannerInvoker} from '../../planning/debug/arc-planner-invoker.js';
-import {ArcStoresFetcher} from './arc-stores-fetcher.js';
+import {ArcDevtoolsChannel, ArcDebugListenerDerived} from '../../runtime/debug/abstract-devtools-channel.js';
 import {DevtoolsChannel} from '../../platform/devtools-channel-web.js';
 import {DevtoolsConnection} from './devtools-connection.js';
 import {Particle} from '../recipe/particle.js';
+import {ArcStoresFetcher} from './arc-stores-fetcher.js';
 
 // Arc-independent handlers for devtools logic.
 DevtoolsConnection.onceConnected.then(devtoolsChannel => {
   enableTracingAdapter(devtoolsChannel);
 });
 
+
 export class ArcDebugHandler {
   private arcDevtoolsChannel: DevtoolsChannel = null;
   
-  constructor(arc: Arc) {
+  constructor(arc: Arc, listenerClasses: ArcDebugListenerDerived[]) {
     if (arc.isStub) return;
 
     const connectedOnInstantiate = DevtoolsConnection.isConnected;
@@ -39,9 +40,11 @@ export class ArcDebugHandler {
 
       this.arcDevtoolsChannel = devtoolsChannel.forArc(arc);
 
-      // Message handles go here.
-      const arcPlannerInvoker = new ArcPlannerInvoker(arc, this.arcDevtoolsChannel);
-      const arcStoresFetcher = new ArcStoresFetcher(arc, this.arcDevtoolsChannel);
+      if (!!listenerClasses) { // undefined => false
+        const listeners = listenerClasses.map(l => {
+          ArcDevtoolsChannel.instantiateListener(l, arc, this.arcDevtoolsChannel);
+        });
+      }
 
       this.arcDevtoolsChannel.send({
         messageType: 'arc-available',
@@ -72,3 +75,8 @@ export class ArcDebugHandler {
     });
   }
 }
+
+// TODO: This should move to the core interface file when it exists. 
+export const defaultCoreDebugListeners: ArcDebugListenerDerived[] = [
+  ArcStoresFetcher
+];

--- a/src/runtime/debug/arc-stores-fetcher.ts
+++ b/src/runtime/debug/arc-stores-fetcher.ts
@@ -9,11 +9,13 @@
  */
 
 import {Arc} from '../arc.js';
+import {ArcDevtoolsChannel, ArcDebugListener} from './abstract-devtools-channel.js';
 
-export class ArcStoresFetcher {
+export class ArcStoresFetcher extends ArcDebugListener {
   private arc: Arc;
   
   constructor(arc, arcDevtoolsChannel) {
+    super(arc, arcDevtoolsChannel);    
     this.arc = arc;
 
     arcDevtoolsChannel.listen('fetch-stores', async () => arcDevtoolsChannel.send({


### PR DESCRIPTION
Also keeps the injected class strings for use by the cloneForSpeculativeExecution method.

This breaks the runtime debugging dependency on planning. All tests pass, though it's worth noting that the devtools channel code does not have unit tests. This change has been tested manually to ensure that devtools connections are working properly.

Including sjmiles as reviewer because this affects how the shell instantiates an Arc, and piotrswigon and mmandlis as it changes planning code.