### PR TITLE
Use BlobUrls to cache Particle implementations

### DIFF
--- a/shells/configuration/csp.js
+++ b/shells/configuration/csp.js
@@ -32,6 +32,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   const content = `
     script-src
         'self'
+        blob:
         wss://*.firebase.io wss://*.firebaseio.com
         https://*.firebaseio.com
         https://*.firebase.io

--- a/shells/lib/components/context/context-stores.js
+++ b/shells/lib/components/context/context-stores.js
@@ -8,7 +8,6 @@
  */
 
 import {crackStorageKey} from './context-utils.js';
-import {Reference} from '../../../../build/runtime/reference.js';
 
 const pendingStores = {};
 
@@ -52,7 +51,7 @@ const ContextStoresImpl = class {
     const id = this.getDecoratedId(entity, uid);
     const decoratedEntity = {id, rawData: entity.rawData};
     // context stores are always Collection
-    store.store(decoratedEntity, [store.generateID()]);
+    store.store(decoratedEntity, [String(Math.random())]);
   }
   removeEntityWithUid(store, entity, uid) {
     const id = this.getDecoratedId(entity, uid);

--- a/src/cli/spotify-importer.ts
+++ b/src/cli/spotify-importer.ts
@@ -112,7 +112,7 @@ import '../runtime/storage/pouchdb-provider.js';
     // First two entries in argv are the node binary and this file.
     const args = process.argv.slice(2);
 
-    if (args[0] == '--list') {
+    if (args[0] === '--list') {
       if (args.length === 1) {
         await showPlaylists(await connect());
       } else {

--- a/src/platform/loader-web.js
+++ b/src/platform/loader-web.js
@@ -55,25 +55,8 @@ export class PlatformLoader extends Loader {
     //log(`resolve(${path}) = ${url}`);
     return url;
   }
-  async provisionParticleSpecBlobUrl(spec) {
-    // if needed, construct spec.implBlobUrl for spec.implFile
-    if (!spec.implBlobUrl) {
-      spec.setImplBlobUrl(await this.provisionObjectUrl(spec.implFile));
-    }
-  }
   async provisionObjectUrl(fileName) {
-    const raw = await this.loadResource(fileName);
-    /*
-    // TODO(sjmiles): can manipulate/examine code before executing, right here
-    // ... consider automarshalling `defineParticle` boilerplate
-    const code = !fileName.includes('Launcher') ? raw :
-`'use strict';
-defineParticle(({Particle, DomParticle, MultiplexerDomParticle, TransformationDomParticle, resolver, log, html}) => {
-${raw}
-return AParticle;
-});`;
-    */
-    const code = raw;
+    const code = await this.loadResource(fileName);
     return URL.createObjectURL(new Blob([code], {type: 'application/javascript'}));
   }
   // Below here invoked from inside Worker

--- a/src/platform/pec-industry-web.ts
+++ b/src/platform/pec-industry-web.ts
@@ -1,18 +1,40 @@
+/**
+ * Copyright (c) 2019 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
 const WORKER_PATH = `https://$build/worker.js`;
+
+let workerUrl;
+let workerBlobUrl;
 
 const pecIndustry = loader => {
   // worker paths are relative to worker location, remap urls from there to here
   const remap = _expandUrls(loader._urlMap);
-  const workerFactory = workerIndustry(loader);
+  // get real path from meta path
+  const workerUrl = loader._resolve(WORKER_PATH);
+  // provision (cached) Blob url (async)
+  let workerBlobUrl;
+  loader.provisionObjectUrl(workerUrl).then((url: string) => workerBlobUrl = url);
   return id => {
-    const worker = workerFactory();
-    //worker.onmessage = e => log(e.data);
-    //worker.onerror = e => console.error(e);
+    if (!workerBlobUrl) {
+      console.warn('wokerBlob not available, falling back to network URL');
+    }
+    const worker = new Worker(workerBlobUrl || workerUrl);
     const channel = new MessageChannel();
     worker.postMessage({id: `${id}:inner`, base: remap}, [channel.port1]);
     return channel.port2;
   };
 };
+
+const provisionWorkersUrls = loader => {
+  workerUrl = loader._resolve(WORKER_PATH);
+  loader.provisionObjectUrl(workerUrl).then((url: string) => workerBlobUrl = url);
+}
 
 const _expandUrls = urlMap => {
   const remap = {};
@@ -28,13 +50,6 @@ const _expandUrls = urlMap => {
     remap[k] = path;
   });
   return remap;
-};
-
-const workerIndustry = loader => {
-  // default url
-  const workerUrl = loader._resolve(WORKER_PATH);
-  // return Worker factory
-  return () => new Worker(workerUrl);
 };
 
 export {pecIndustry as PecIndustry};

--- a/src/runtime/arc.ts
+++ b/src/runtime/arc.ts
@@ -10,7 +10,6 @@
 
 import {assert} from '../platform/assert-web.js';
 
-import {PECInnerPort} from './api-channel.js';
 import {ArcDebugListenerDerived} from './debug/abstract-devtools-channel.js';
 import {ArcDebugHandler} from './debug/arc-debug-handler.js';
 import {FakePecFactory} from './fake-pec-factory.js';
@@ -435,7 +434,7 @@ ${this.activeRecipe.toString()}`;
     const info = {spec: recipeParticle.spec, stores: new Map<string, StorageProviderBase>()};
     this.loadedParticleInfo.set(recipeParticle.id.toString(), info);
 
-    // provide particle caching via a BloblUrl representing spec.implFile
+    // if supported, provide particle caching via a BloblUrl representing spec.implFile
     await this._provisionSpecUrl(recipeParticle.spec);
 
     for (const [name, connection] of Object.entries(recipeParticle.connections)) {
@@ -448,9 +447,11 @@ ${this.activeRecipe.toString()}`;
   }
 
   async _provisionSpecUrl(spec: ParticleSpec) {
-    // if supported, construct spec.implBlobUrl for spec.implFile
-    if (this.loader && this.loader['provisionParticleSpecBlobUrl']) {
-      await this.loader['provisionParticleSpecBlobUrl'](spec);
+    if (!spec.implBlobUrl) {
+      // if supported, construct spec.implBlobUrl for spec.implFile
+      if (this.loader && this.loader['provisionObjectUrl']) {
+        spec.setImplBlobUrl(await this.loader['provisionObjectUrl'](spec.implFile));
+      }
     }
   }
 

--- a/src/runtime/particle-spec.ts
+++ b/src/runtime/particle-spec.ts
@@ -151,6 +151,7 @@ export type SerializedParticleSpec = {
   args: SerializedHandleConnectionSpec[],
   description: {pattern?: string},
   implFile: string,
+  implBlobUrl: string | null,
   modality: string[],
   slotConnections: SerializedConsumeSlotConnectionSpec[]
 };
@@ -165,6 +166,7 @@ export class ParticleSpec {
   outputs: HandleConnectionSpec[];
   pattern: string;
   implFile: string;
+  implBlobUrl: string | null;
   modality: Modality;
   slotConnections: Map<string, ConsumeSlotConnectionSpec>;
 
@@ -189,6 +191,7 @@ export class ParticleSpec {
     });
 
     this.implFile = model.implFile;
+    this.implBlobUrl = model.implBlobUrl;
     this.modality = Modality.create(model.modality || []);
     this.slotConnections = new Map();
     if (model.slotConnections) {
@@ -235,20 +238,24 @@ export class ParticleSpec {
     return this.slotConnections.size === 0 || this.modality.intersection(modality).isResolved();
   }
 
+  setImplBlobUrl(url: string) {
+    this.model.implBlobUrl = this.implBlobUrl = url;
+  }
+
   toLiteral() : SerializedParticleSpec {
-    const {args, name, verbs, description, implFile, modality, slotConnections} = this.model;
+    const {args, name, verbs, description, implFile, implBlobUrl, modality, slotConnections} = this.model;
     const connectionToLiteral : (input: SerializedHandleConnectionSpec) => SerializedHandleConnectionSpec =
       ({type, direction, name, isOptional, dependentConnections}) => ({type: asTypeLiteral(type), direction, name, isOptional, dependentConnections: dependentConnections.map(connectionToLiteral)});
     const argsLiteral = args.map(a => connectionToLiteral(a));
-    return {args: argsLiteral, name, verbs, description, implFile, modality, slotConnections};
+    return {args: argsLiteral, name, verbs, description, implFile, implBlobUrl, modality, slotConnections};
   }
 
   static fromLiteral(literal: SerializedParticleSpec) {
-    let {args, name, verbs, description, implFile, modality, slotConnections} = literal;
+    let {args, name, verbs, description, implFile, implBlobUrl, modality, slotConnections} = literal;
     const connectionFromLiteral = ({type, direction, name, isOptional, dependentConnections}) =>
       ({type: asType(type), direction, name, isOptional, dependentConnections: dependentConnections ? dependentConnections.map(connectionFromLiteral) : []});
     args = args.map(connectionFromLiteral);
-    return new ParticleSpec({args, name, verbs: verbs || [], description, implFile, modality, slotConnections});
+    return new ParticleSpec({args, name, verbs: verbs || [], description, implFile, implBlobUrl, modality, slotConnections});
   }
 
   // Note: this method shouldn't be called directly.

--- a/src/runtime/test/reference-test.ts
+++ b/src/runtime/test/reference-test.ts
@@ -22,7 +22,7 @@ describe('references', () => {
   it('can parse & validate a recipe containing references', async () => {
     const manifest = await Manifest.parse(`
         schema Result
-          Text value  
+          Text value
 
         particle Referencer in 'referencer.js'
           in Result inResult
@@ -31,7 +31,7 @@ describe('references', () => {
         particle Dereferencer in 'dereferencer.js'
           in Reference<Result> inResult
           out Result outResult
-        
+
         recipe
           create 'input:1' as handle0
           create 'reference:1' as handle1
@@ -57,11 +57,11 @@ describe('references', () => {
       manifest: `
         schema Result
           Text value
-        
+
         particle Dereferencer in 'dereferencer.js'
           in Reference<Result> inResult
           out Result outResult
-        
+
         recipe
           create 'input:1' as handle0
           create 'output:1' as handle1
@@ -92,7 +92,7 @@ describe('references', () => {
 
     const manifest = await Manifest.load('manifest', loader);
     const arc = new Arc({id: Id.fromString('test:0'), loader, context: manifest});
-    const recipe = manifest.recipes[0];    
+    const recipe = manifest.recipes[0];
     assert.isTrue(recipe.normalize());
     assert.isTrue(recipe.isResolved());
     await arc.instantiate(recipe);
@@ -114,11 +114,11 @@ describe('references', () => {
       manifest: `
         schema Result
           Text value
-        
+
         particle Referencer in 'referencer.js'
           in Result inResult
           out Reference<Result> outResult
-        
+
         recipe
           create 'input:1' as handle0
           create 'output:1' as handle1
@@ -152,7 +152,7 @@ describe('references', () => {
     const manifest = await Manifest.load('manifest', loader);
     const arc = new Arc({id: Id.fromString('test:0'), loader, context: manifest});
 
-    const recipe = manifest.recipes[0];    
+    const recipe = manifest.recipes[0];
     assert.isTrue(recipe.normalize());
     assert.isTrue(recipe.isResolved());
     await arc.instantiate(recipe);
@@ -162,7 +162,7 @@ describe('references', () => {
 
     const refStore = arc._stores[1];
     const baseStoreType = new EntityType(manifest.schemas.Result);
-    await assertSingletonWillChangeTo(arc, refStore, 'storageKey', 
+    await assertSingletonWillChangeTo(arc, refStore, 'storageKey',
                                       arc.storageProviderFactory.baseStorageKey(baseStoreType, 'volatile'));
   });
 
@@ -171,11 +171,11 @@ describe('references', () => {
       manifest: `
         schema Result
           Text value
-        
+
         particle ExtractReference in 'extractReference.js'
           in Foo {Reference<Result> result} referenceIn
           out Result rawOut
-          
+
         recipe
           create 'input:1' as handle0
           create 'output:1' as handle1
@@ -210,7 +210,7 @@ describe('references', () => {
 
     const manifest = await Manifest.load('manifest', loader);
     const arc = new Arc({id: Id.fromString('test:0'), loader, context: manifest});
-    const recipe = manifest.recipes[0];    
+    const recipe = manifest.recipes[0];
     assert.isTrue(recipe.normalize());
     assert.isTrue(recipe.isResolved());
     await arc.instantiate(recipe);
@@ -219,7 +219,7 @@ describe('references', () => {
     const baseStoreType = new EntityType(manifest.schemas.Result);
     const backingStore = await volatileEngine.baseStorageFor(baseStoreType, volatileEngine.baseStorageKey(baseStoreType)) as CollectionStorageProvider;
     await backingStore.store({id: 'id:1', rawData: {value: 'what a result!'}}, ['totes a key']);
-    
+
     const refStore = arc._stores[1] as VariableStorageProvider;
     assert.equal((refStore.type as EntityType).entitySchema.name, 'Foo');
     await refStore.set({id: 'id:2', rawData: {result: {id: 'id:1', storageKey: backingStore.storageKey}}});
@@ -239,12 +239,12 @@ describe('references', () => {
       manifest: `
         schema Result
           Text value
-        
+
         particle Referencer in 'referencer.js'
           in [Result] inResult
           in Foo {Reference<Result> result, Text shortForm} inFoo
           inout [Foo {Reference<Result> result, Text shortForm}] outResult
-        
+
         recipe
           create 'input:1' as handle0
           create 'input:2' as handle1
@@ -267,7 +267,9 @@ describe('references', () => {
               if (handle.name == 'inResult') {
                 update.added.forEach(item => this.models.push(item));
               } else {
-                update.added.forEach(item => this.foos.push(item));
+                if (update.added) {
+                  update.added.forEach(item => this.foos.push(item));
+                }
               }
               this.maybeGenerateOutput();
             }
@@ -308,7 +310,7 @@ describe('references', () => {
 
     const manifest = await Manifest.load('manifest', loader);
     const arc = new Arc({id: Id.fromString('test:0'), loader, context: manifest});
-    const recipe = manifest.recipes[0];    
+    const recipe = manifest.recipes[0];
     assert.isTrue(recipe.normalize());
     assert.isTrue(recipe.isResolved());
     await arc.instantiate(recipe);
@@ -345,11 +347,11 @@ describe('references', () => {
       manifest: `
         schema Result
           Text value
-        
+
         particle ExtractReferences in 'extractReferences.js'
           in Foo {[Reference<Result>] result} referenceIn
           out [Result] rawOut
-          
+
         recipe
           create 'input:1' as handle0
           create 'output:1' as handle1
@@ -385,7 +387,7 @@ describe('references', () => {
 
     const manifest = await Manifest.load('manifest', loader);
     const arc = new Arc({id: Id.fromString('test:0'), loader, context: manifest});
-    const recipe = manifest.recipes[0];    
+    const recipe = manifest.recipes[0];
     assert.isTrue(recipe.normalize());
     assert.isTrue(recipe.isResolved());
     await arc.instantiate(recipe);
@@ -414,11 +416,11 @@ describe('references', () => {
       manifest: `
         schema Result
           Text value
-        
+
         particle ConstructReferenceCollection in 'constructReferenceCollection.js'
           out Foo {[Reference<Result>] result} referenceOut
           in [Result] rawIn
-          
+
         recipe
           create 'input:1' as handle0
           create 'output:1' as handle1
@@ -468,7 +470,7 @@ describe('references', () => {
 
     const manifest = await Manifest.load('manifest', loader);
     const arc = new Arc({id: Id.fromString('test:0'), loader, context: manifest});
-    const recipe = manifest.recipes[0];    
+    const recipe = manifest.recipes[0];
     assert.isTrue(recipe.normalize());
     assert.isTrue(recipe.isResolved());
     await arc.instantiate(recipe);


### PR DESCRIPTION
Experimental

- added `implBlobUrl` to Particle Spec
- outer PEC initializes `implBlobUrl` in anticipation of needing an impl (performs a fetch)
- importScript calls in workers use implBlobUrl to pull impl out of browser cache

Downside: particle files at runtime are visible in DevTools as opaque Blob URLs (e.g. `blob:http://localhost/0b7a918f-d20a-4a40-b66a-42a520b7be1e`) instead of human readable names (e.g. `https://.../ArtistAutofill.js`).