### PR TITLE
Replace Type's primitiveType getter with getContainedType

### DIFF
--- a/src/runtime/multiplexer-dom-particle.js
+++ b/src/runtime/multiplexer-dom-particle.js
@@ -96,7 +96,7 @@ export class MultiplexerDomParticle extends TransformationDomParticle {
       }
 
       const itemHandlePromise =
-          arc.createHandle(type.primitiveType(), 'item' + index);
+          arc.createHandle(type.getContainedType(), 'item' + index);
       this.handleIds[item.id] = itemHandlePromise;
 
       const itemHandle = await itemHandlePromise;

--- a/src/runtime/storage/firebase-storage.ts
+++ b/src/runtime/storage/firebase-storage.ts
@@ -688,7 +688,7 @@ class FirebaseCollection extends FirebaseStorageProvider implements CollectionSt
   }
 
   backingType() {
-    return this.type.primitiveType();
+    return this.type.getContainedType();
   }
 
   remoteStateChanged(dataSnapshot) {
@@ -904,7 +904,7 @@ class FirebaseCollection extends FirebaseStorageProvider implements CollectionSt
     let effective;
     // 1. Apply the change to the local model.
     if (this.referenceMode) {
-      const referredType = this.type.primitiveType();
+      const referredType = this.type.getContainedType();
       const storageKey = this.storageEngine.baseStorageKey(referredType, this.storageKey);
       effective = this.model.add(id, {id, storageKey}, keys);
       this.version++;
@@ -1048,7 +1048,7 @@ class FirebaseCollection extends FirebaseStorageProvider implements CollectionSt
       if (items.length === 0) {
         return [];
       }
-      const referredType = this.type.primitiveType();
+      const referredType = this.type.getContainedType();
 
       const refSet = new Set();
 
@@ -1320,7 +1320,7 @@ class FirebaseBigCollection extends FirebaseStorageProvider implements BigCollec
   }
 
   backingType() {
-    return this.type.primitiveType();
+    return this.type.getContainedType();
   }
 
   enableReferenceMode() {

--- a/src/runtime/storage/pouchdb/pouch-db-big-collection.ts
+++ b/src/runtime/storage/pouchdb/pouch-db-big-collection.ts
@@ -9,7 +9,7 @@ export class PouchDbBigCollection extends PouchDbStorageProvider implements BigC
   }
 
   backingType() {
-    return this.type.primitiveType();
+    return this.type.getContainedType();
   }
 
   async get(id: string) {

--- a/src/runtime/storage/pouchdb/pouch-db-collection.ts
+++ b/src/runtime/storage/pouchdb/pouch-db-collection.ts
@@ -60,7 +60,7 @@ export class PouchDbCollection extends PouchDbStorageProvider implements Collect
 
   /** @inheritDoc */
   backingType() {
-    return this.type.primitiveType();
+    return this.type.getContainedType();
   }
 
   // TODO(lindner): write tests
@@ -196,7 +196,7 @@ export class PouchDbCollection extends PouchDbStorageProvider implements Collect
     const item = {value, keys, effective: false};
 
     if (this.referenceMode) {
-      const referredType = this.type.primitiveType();
+      const referredType = this.type.getContainedType();
       const storageKey = this.storageEngine.baseStorageKey(referredType, this.storageKey);
 
       // Update the referred data

--- a/src/runtime/storage/volatile-storage.ts
+++ b/src/runtime/storage/volatile-storage.ts
@@ -203,7 +203,7 @@ class VolatileCollection extends VolatileStorageProvider implements CollectionSt
   }
 
   backingType() {
-    return this.type.primitiveType();
+    return this.type.getContainedType();
   }
 
   clone() {
@@ -301,7 +301,7 @@ class VolatileCollection extends VolatileStorageProvider implements CollectionSt
 
     const item = {value, keys, effective: undefined};
     if (this.referenceMode) {
-      const referredType = this.type.primitiveType();
+      const referredType = this.type.getContainedType();
 
       const storageKey = this.backingStore ? this.backingStore.storageKey : this.storageEngine.baseStorageKey(referredType);
 
@@ -534,7 +534,7 @@ class VolatileBigCollection extends VolatileStorageProvider implements BigCollec
   }
 
   backingType() {
-    return this.type.primitiveType();
+    return this.type.getContainedType();
   }
 
   async get(id: string) {

--- a/src/runtime/test/artifacts/Products/test/source/ProductFilter.js
+++ b/src/runtime/test/artifacts/Products/test/source/ProductFilter.js
@@ -17,7 +17,7 @@ defineParticle(({Particle}) => {
       this._products = null;
       this._hostedParticle = null;
       this._resultsHandle = handles.get('results');
-      this._productType = handles.get('products').type.primitiveType();
+      this._productType = handles.get('products').type.getContainedType();
       this._arc = await this.constructInnerArc();
     }
     async onHandleSync(handle, model) {

--- a/src/runtime/test/artifacts/transformations/test-multiplex-slots-particle.js
+++ b/src/runtime/test/artifacts/transformations/test-multiplex-slots-particle.js
@@ -38,7 +38,7 @@ defineParticle(({TransformationDomParticle}) => {
           // The element already exists.
           continue;
         }
-        const fooHandle = await arc.createHandle(type.primitiveType(), 'foo' + index);
+        const fooHandle = await arc.createHandle(type.getContainedType(), 'foo' + index);
         this._handleIds.add(foo.id);
         const hostedSlotName = [...hostedParticle.slots.keys()][0];
         const slotName = [...this.spec.slots.values()][0].name;

--- a/src/runtime/test/description-test.ts
+++ b/src/runtime/test/description-test.ts
@@ -791,7 +791,7 @@ recipe
       arc,
       recipe,
       fooStore,
-      DescriptionType: descriptionStore.type.primitiveType().entitySchema.entityClass(),
+      DescriptionType: descriptionStore.type.getContainedType().entitySchema.entityClass(),
       descriptionHandle: handleFor(descriptionStoreProxy)
     };
   }

--- a/src/runtime/test/particle-api-test.ts
+++ b/src/runtime/test/particle-api-test.ts
@@ -581,8 +581,8 @@ describe('particle-api', () => {
               if (handle.name !== 'inputs')
                 return;
               for (let input of model) {
-                let inHandle = await this.arc.createHandle(this.resHandle.type.primitiveType(), 'the-in');
-                let outHandle = await this.arc.createHandle(this.resHandle.type.primitiveType(), 'the-out', this);
+                let inHandle = await this.arc.createHandle(this.resHandle.type.getContainedType(), 'the-in');
+                let outHandle = await this.arc.createHandle(this.resHandle.type.getContainedType(), 'the-out', this);
                 try {
                   let done = await this.arc.loadRecipe(\`
                     schema Result

--- a/src/runtime/test/type-test.ts
+++ b/src/runtime/test/type-test.ts
@@ -329,8 +329,8 @@ describe('types', () => {
       assert(recipe.normalize());
       assert(recipe.isResolved());
       assert.equal(recipe.handles.length, 1);
-      assert.equal(recipe.handles[0].type.primitiveType().canReadSubset.entitySchema.name, 'Lego');
-      assert.equal(recipe.handles[0].type.primitiveType().canWriteSuperset.entitySchema.name, 'Product');
+      assert.equal(recipe.handles[0].type.getContainedType().canReadSubset.entitySchema.name, 'Lego');
+      assert.equal(recipe.handles[0].type.getContainedType().canWriteSuperset.entitySchema.name, 'Product');
     });
 
     it('a subtype matches to a supertype that wants to be read when a handle exists', async () => {
@@ -343,7 +343,7 @@ describe('types', () => {
       assert(recipe.normalize());
       assert(recipe.isResolved());
       assert.lengthOf(recipe.handles, 1);
-      assert.equal(recipe.handles[0].type.primitiveType().entitySchema.name, 'Product');
+      assert.equal(recipe.handles[0].type.getContainedType().entitySchema.name, 'Product');
     });
 
     it('a subtype matches to a supertype that wants to be read when a handle exists', async () => {
@@ -356,7 +356,7 @@ describe('types', () => {
       assert(recipe.normalize());
       assert(recipe.isResolved());
       assert.lengthOf(recipe.handles, 1);
-      assert.equal(recipe.handles[0].type.primitiveType().entitySchema.name, 'Lego');
+      assert.equal(recipe.handles[0].type.getContainedType().entitySchema.name, 'Lego');
     });
   });
 });

--- a/src/runtime/type.ts
+++ b/src/runtime/type.ts
@@ -121,10 +121,6 @@ export abstract class Type {
     return this._applyExistenceTypeTest(type => type instanceof TypeVariable && !type.variable.isResolved());
   }
 
-  primitiveType() {
-    return null;
-  }
-
   getContainedType() {
     return null;
   }
@@ -401,11 +397,6 @@ export class CollectionType<T extends Type> extends Type {
 
   _applyExistenceTypeTest(test: (type: Type) => boolean): boolean {
     return this.collectionType._applyExistenceTypeTest(test);
-  }
-
-  // TODO: remove this in favor of a renamed collectionType
-  primitiveType(): T {
-    return this.collectionType;
   }
 
   getContainedType(): T {


### PR DESCRIPTION
Removes the deprecated primiveType getter and replace it's usage with the newer getContainedType.
This simplifies our Type interface reducing possible future errors in returning a different type from primitiveType to getContainedType.