### PR TITLE
Fixing bugs in parsing slots in the manifest

### DIFF
--- a/src/planning/test/strategies/find-required-particle-test.ts
+++ b/src/planning/test/strategies/find-required-particle-test.ts
@@ -24,7 +24,7 @@ describe('FindRequiredParticles', () => {
     const manifest = (await Manifest.parse(`
       particle A in 'A.js'
         consume root
-          provide c
+          provide x
     
       particle C
         consume c 
@@ -33,7 +33,7 @@ describe('FindRequiredParticles', () => {
         require
           A
             consume root
-              provide c as s0
+              provide x as s0
         C
           consume c as s0
       

--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -852,6 +852,7 @@ ${e.message}
             if (existingSlot !== undefined) {
               slotConn.providedSlots[ps.param] = existingSlot;
               existingSlot.sourceConnection = slotConn;
+              existingSlot.name = ps.param;
             }
           }
           let providedSlot = slotConn.providedSlots[ps.param];

--- a/src/runtime/recipe/slot-connection.ts
+++ b/src/runtime/recipe/slot-connection.ts
@@ -123,7 +123,7 @@ export class SlotConnection {
       return false;
     }
 
-    if (this.getSlotSpec().isRequired) {
+    if (this.getSlotSpec() == undefined || this.getSlotSpec().isRequired) {
       if (!this.targetSlot || !(this.targetSlot.id || this.targetSlot.sourceConnection.isConnected())) {
         // The required connection has no target slot
         // or its target slot it not resolved (has no ID or source connection).
@@ -136,6 +136,8 @@ export class SlotConnection {
     if (!this.targetSlot) {
       return true;
     }
+
+    if (this.getSlotSpec() == undefined) return true;
 
     return this.getSlotSpec().providedSlots.every(providedSlot => {
       if (providedSlot.isRequired && this.providedSlots[providedSlot.name].consumeConnections.length === 0) {


### PR DESCRIPTION
Ensure slot names are named after the provided slot connection. 

Also modified slot connection isResolved() method to consider when there isn't a slot spec. 