### PR TITLE
MockSlotDomConsumer -> HeadlessSlotDomConsumer

### DIFF
--- a/src/planning/planning-modality-handler.ts
+++ b/src/planning/planning-modality-handler.ts
@@ -9,9 +9,9 @@
  */
 import {DescriptionDomFormatter} from '../runtime/description-dom-formatter.js';
 import {DescriptionFormatter} from '../runtime/description-formatter.js';
+import {HeadlessSlotDomConsumer} from '../runtime/headless-slot-dom-consumer.js';
 import {ModalityHandler} from '../runtime/modality-handler.js';
 import {SlotDomConsumer} from '../runtime/slot-dom-consumer.js';
-import {MockSlotDomConsumer} from '../runtime/testing/mock-slot-dom-consumer.js';
 
 import {SuggestDomConsumer} from './suggest-dom-consumer.js';
 import {MockSuggestDomConsumer} from './testing/mock-suggest-dom-consumer.js';
@@ -25,7 +25,7 @@ export class PlanningModalityHandler extends ModalityHandler{
   }
 
   static createHeadlessHandler(): PlanningModalityHandler {
-    return new PlanningModalityHandler(MockSlotDomConsumer, MockSuggestDomConsumer);
+    return new PlanningModalityHandler(HeadlessSlotDomConsumer, MockSuggestDomConsumer);
   }
 
   static readonly domHandler : PlanningModalityHandler = new PlanningModalityHandler(

--- a/src/runtime/headless-slot-dom-consumer.ts
+++ b/src/runtime/headless-slot-dom-consumer.ts
@@ -8,10 +8,11 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {assert} from '../../platform/assert-web.js';
-import {SlotDomConsumer} from '../slot-dom-consumer.js';
+import {assert} from '../platform/assert-web.js';
 
-export class MockSlotDomConsumer extends SlotDomConsumer {
+import {SlotDomConsumer} from './slot-dom-consumer.js';
+
+export class HeadlessSlotDomConsumer extends SlotDomConsumer {
   _content;
   contentAvailable;
   _contentAvailableResolve;

--- a/src/runtime/modality-handler.ts
+++ b/src/runtime/modality-handler.ts
@@ -10,15 +10,15 @@
 
 import {DescriptionDomFormatter} from './description-dom-formatter.js';
 import {DescriptionFormatter} from './description-formatter.js';
+import {HeadlessSlotDomConsumer} from './headless-slot-dom-consumer.js';
 import {SlotDomConsumer} from './slot-dom-consumer.js';
-import {MockSlotDomConsumer} from './testing/mock-slot-dom-consumer.js';
 
 export class ModalityHandler {
   constructor(public readonly slotConsumerClass: typeof SlotDomConsumer,
               public readonly descriptionFormatter?: typeof DescriptionFormatter){}
 
   static createHeadlessHandler(): ModalityHandler {
-    return new ModalityHandler(MockSlotDomConsumer);
+    return new ModalityHandler(HeadlessSlotDomConsumer);
   }
 
   static readonly domHandler : ModalityHandler = new ModalityHandler(

--- a/src/runtime/test/arc-tests.ts
+++ b/src/runtime/test/arc-tests.ts
@@ -11,6 +11,7 @@
 import {assert} from '../../platform/chai-web.js';
 import {Arc} from '../arc.js';
 import {handleFor} from '../handle.js';
+import {HeadlessSlotDomConsumer} from '../headless-slot-dom-consumer.js';
 import {Id} from '../id.js';
 import {Loader} from '../loader.js';
 import {Manifest} from '../manifest.js';
@@ -18,7 +19,6 @@ import {BigCollectionStorageProvider, CollectionStorageProvider, VariableStorage
 import {CallbackTracker} from '../testing/callback-tracker.js';
 import {FakeSlotComposer} from '../testing/fake-slot-composer.js';
 import {MockSlotComposer} from '../testing/mock-slot-composer.js';
-import {MockSlotDomConsumer} from '../testing/mock-slot-dom-consumer.js';
 import {StubLoader} from '../testing/stub-loader.js';
 import {TestHelper} from '../testing/test-helper.js';
 import * as util from '../testing/test-util.js';
@@ -575,7 +575,7 @@ describe('Arc', () => {
     recipe.normalize();
     await arc.instantiate(recipe);
 
-    const rootSlotConsumer = slotComposer.consumers.find(c => !c.arc.isInnerArc) as MockSlotDomConsumer;
+    const rootSlotConsumer = slotComposer.consumers.find(c => !c.arc.isInnerArc) as HeadlessSlotDomConsumer;
     await rootSlotConsumer.contentAvailable;
     assert.equal(rootSlotConsumer._content.template, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ');
   });

--- a/src/runtime/test/particle-execution-context-test.ts
+++ b/src/runtime/test/particle-execution-context-test.ts
@@ -9,8 +9,8 @@
  */
 
 import {assert} from '../../platform/chai-web.js';
+import {HeadlessSlotDomConsumer} from '../headless-slot-dom-consumer.js';
 import {MockSlotComposer} from '../testing/mock-slot-composer.js';
-import {MockSlotDomConsumer} from '../testing/mock-slot-dom-consumer.js';
 import {StubLoader} from '../testing/stub-loader.js';
 import {TestHelper} from '../testing/test-helper.js';
 
@@ -41,7 +41,7 @@ describe('Particle Execution Context', () => {
     recipe.normalize();
     await arc.instantiate(recipe);
 
-    const slotConsumer = slotComposer.consumers[0] as MockSlotDomConsumer;
+    const slotConsumer = slotComposer.consumers[0] as HeadlessSlotDomConsumer;
     const detailContext = slotConsumer.directlyProvidedSlotContexts.find(ctx => ctx.name === 'detail');
     const annotationContext = slotConsumer.directlyProvidedSlotContexts.find(ctx => ctx.name === 'annotation');
 

--- a/src/runtime/test/slot-composer-tests.ts
+++ b/src/runtime/test/slot-composer-tests.ts
@@ -12,11 +12,11 @@ import {Planner} from '../../planning/planner.js';
 import {StrategyTestHelper} from '../../planning/test/strategies/strategy-test-helper.js';
 import {assert} from '../../platform/chai-web.js';
 import {Arc} from '../arc.js';
+import {HeadlessSlotDomConsumer} from '../headless-slot-dom-consumer.js';
 import {Loader} from '../loader.js';
 import {Random} from '../random.js';
 import {HostedSlotContext, ProvidedSlotContext} from '../slot-context.js';
 import {MockSlotComposer} from '../testing/mock-slot-composer.js';
-import {MockSlotDomConsumer} from '../testing/mock-slot-dom-consumer.js';
 import {StubLoader} from '../testing/stub-loader.js';
 import {TestHelper} from '../testing/test-helper.js';
 
@@ -302,10 +302,10 @@ recipe
     recipe.normalize();
     await arc.instantiate(recipe);
 
-    const rootSlotConsumer = slotComposer.consumers.find(consumer => consumer.consumeConn.name === 'root') as MockSlotDomConsumer;
+    const rootSlotConsumer = slotComposer.consumers.find(consumer => consumer.consumeConn.name === 'root') as HeadlessSlotDomConsumer;
     await rootSlotConsumer.contentAvailable;
 
-    const detailSlotConsumer = slotComposer.consumers.find(consumer => consumer.consumeConn.name === 'detail') as MockSlotDomConsumer;
+    const detailSlotConsumer = slotComposer.consumers.find(consumer => consumer.consumeConn.name === 'detail') as HeadlessSlotDomConsumer;
     await detailSlotConsumer.contentAvailable;
 
     assert.deepEqual(rootSlotConsumer._content, {

--- a/src/runtime/testing/test-helper.ts
+++ b/src/runtime/testing/test-helper.ts
@@ -13,10 +13,10 @@ import {Planner} from '../../planning/planner.js';
 import {RecipeIndex} from '../../planning/recipe-index.js';
 import {assert} from '../../platform/chai-web.js';
 import {Arc} from '../arc.js';
+import {HeadlessSlotDomConsumer} from '../headless-slot-dom-consumer.js';
 import {Loader} from '../loader.js';
 import {Manifest} from '../manifest.js';
 import {MockSlotComposer} from '../testing/mock-slot-composer.js';
-import {MockSlotDomConsumer} from '../testing/mock-slot-dom-consumer.js';
 import {InterfaceType} from '../type.js';
 
 type TestHelperOptions = {
@@ -266,7 +266,7 @@ export class TestHelper {
 
   verifySlots(numConsumers: number, verifyHandler) {
     assert.lengthOf(this.slotComposer.consumers, numConsumers);
-    for (const consumer of this.slotComposer.consumers as MockSlotDomConsumer[]) {
+    for (const consumer of this.slotComposer.consumers as HeadlessSlotDomConsumer[]) {
       verifyHandler(consumer.consumeConn.particle.name, consumer.consumeConn.name, consumer._content);
     }
   }


### PR DESCRIPTION
This class isn't just a mock, as it is used during preplanning and other situations requiring a dom slot consumer without an actual dom. Also, before this change production code depended on test code, which should not be the case.