### PR TITLE
make renderSlot sync

### DIFF
--- a/shells/lib/ram-slot-composer.js
+++ b/shells/lib/ram-slot-composer.js
@@ -25,8 +25,8 @@ export class RamSlotComposer extends SlotComposer {
     this.pec.sendEvent(particles[0], slotName, {handler: event, data});
   }
 
-  async renderSlot(particle, slotName, content) {
-    await super.renderSlot(particle, slotName, content);
+  renderSlot(particle, slotName, content) {
+    super.renderSlot(particle, slotName, content);
     const slotConsumer = this.getSlotConsumer(particle, slotName);
     if (slotConsumer) {
       slotConsumer.updateProvidedContexts();

--- a/src/planning/headless-suggest-dom-consumer.ts
+++ b/src/planning/headless-suggest-dom-consumer.ts
@@ -49,8 +49,8 @@ export class HeadlessSuggestDomConsumer extends SuggestDomConsumer {
     return undefined;
   }
 
-  async setContent(content, handler) {
-    await super.setContent(content, handler);
+  setContent(content, handler) {
+    super.setContent(content, handler);
 
     // Mimics the behaviour of DomSlotConsumer::setContent, where template is only set at first,
     // and model is overriden every time.

--- a/src/runtime/arc.ts
+++ b/src/runtime/arc.ts
@@ -568,7 +568,7 @@ ${this.activeRecipe.toString()}`;
 
     if (this.pec.slotComposer) {
       // TODO: pass slot-connections instead
-      this.pec.slotComposer.initializeRecipe(this, particles);
+      await this.pec.slotComposer.initializeRecipe(this, particles);
     }
 
     if (!this.isSpeculative) { // Note: callbacks not triggered for speculative arcs.

--- a/src/runtime/headless-slot-dom-consumer.ts
+++ b/src/runtime/headless-slot-dom-consumer.ts
@@ -23,7 +23,7 @@ export class HeadlessSlotDomConsumer extends SlotDomConsumer {
     this.contentAvailable = new Promise(resolve => this._contentAvailableResolve = resolve);
   }
 
-  setContent(content, handler, description) {
+  setContent(content, handler) {
     super.setContent(content, handler);
 
     // Mimics the behaviour of DomSlotConsumer::setContent, where template is only set at first,

--- a/src/runtime/slot-context.ts
+++ b/src/runtime/slot-context.ts
@@ -38,7 +38,7 @@ export abstract class SlotContext {
     this.slotConsumers.length = 0;
   }
 
-  abstract onRenderSlot(consumer: SlotConsumer, content, handler, description?: Description);
+  abstract onRenderSlot(consumer: SlotConsumer, content, handler);
   abstract get containerAvailable(): boolean;
 }
 
@@ -132,8 +132,8 @@ export class ProvidedSlotContext extends SlotContext {
       : [];
   }
 
-  onRenderSlot(consumer: SlotConsumer, content, handler, description?: Description) {
-    consumer.setContent(content, handler, description);
+  onRenderSlot(consumer: SlotConsumer, content, handler) {
+    consumer.setContent(content, handler);
   }
 
   get container() { return this._container; }

--- a/src/runtime/slot-dom-consumer.ts
+++ b/src/runtime/slot-dom-consumer.ts
@@ -13,6 +13,7 @@ import {Template} from '../../modalities/dom/components/xen/xen-template.js';
 import {assert} from '../platform/assert-web.js';
 
 import {Arc} from './arc.js';
+import {Description} from './description.js';
 import {SlotConnection} from './recipe/slot-connection.js';
 import {SlotConsumer} from './slot-consumer.js';
 import {ProvidedSlotContext} from './slot-context.js';

--- a/src/runtime/testing/fake-slot-composer.ts
+++ b/src/runtime/testing/fake-slot-composer.ts
@@ -10,6 +10,7 @@
 
 import {PlanningModalityHandler} from '../../planning/planning-modality-handler.js';
 import {SlotComposer, SlotComposerOptions} from '../slot-composer.js';
+import {SlotContext} from '../slot-context.js';
 
 /**
  * A helper class for NodeJS tests that mimics SlotComposer without relying on DOM APIs.
@@ -22,8 +23,8 @@ export class FakeSlotComposer extends SlotComposer {
       ...options});
   }
 
-  async renderSlot(particle, slotName, content) {
-    await super.renderSlot(particle, slotName, content);
+  renderSlot(particle, slotName, content) {
+    super.renderSlot(particle, slotName, content);
 
     // In production updateProvidedContexts() is done in DOM Mutation Observer.
     // We don't have it in tests, so we do it here.
@@ -31,7 +32,7 @@ export class FakeSlotComposer extends SlotComposer {
     if (slotConsumer) slotConsumer.updateProvidedContexts();
   }
   // Accessors for testing.
-  get contexts() {
+  get contexts(): SlotContext[] {
     return this._contexts;
   }
 }

--- a/src/runtime/testing/mock-slot-composer.ts
+++ b/src/runtime/testing/mock-slot-composer.ts
@@ -234,7 +234,7 @@ export class MockSlotComposer extends FakeSlotComposer {
     return found;
   }
 
-  async renderSlot(particle, slotName, content) {
+  renderSlot(particle, slotName, content) {
     this._addDebugMessages(`    renderSlot ${particle.name} ${((names) => names.length > 0 ? `(${names.join(',')}) ` : '')(this._getHostedParticleNames(particle))}: ${slotName} - ${Object.keys(content).join(', ')}`);
     assert.isAbove(this.expectQueue.length, 0,
       `Got a renderSlot from ${particle.name}:${slotName} (content types: ${Object.keys(content).join(', ')}), but not expecting anything further. Enable {strict: false, logging: true} to diagnose`);
@@ -242,7 +242,7 @@ export class MockSlotComposer extends FakeSlotComposer {
     // renderSlot must happen before _verifyRenderContent, because the latter removes this call from expectations,
     // and potentially making mock-slot-composer idle before the renderSlot has actualy complete.
     // TODO: split _verifyRenderContent to separate method for checking and then resolving expectations.
-    await super.renderSlot(particle, slotName, content);
+    super.renderSlot(particle, slotName, content);
 
     const found = this._verifyRenderContent(particle, slotName, content);
     if (!found) {


### PR DESCRIPTION
initialize description on recipe instantiation
fixes: https://github.com/PolymerLabs/arcs/issues/2701

(longer term i want descriptions be more integral part of the arc, so that descriptions won't need to be explicitly reinitialized, but this short term fix should address the particular problem)