### PR TITLE
Refactor manifest integration tests into runtime and planning tests

### DIFF
--- a/src/planning/test/planning-manifest-integration-test.ts
+++ b/src/planning/test/planning-manifest-integration-test.ts
@@ -1,0 +1,22 @@
+/**
+ * @license
+ * Copyright (c) 2017 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {assert} from '../../platform/chai-web.js';
+import {manifestTestSetup} from '../../runtime/testing/manifest-integration-test-setup.js';
+import {Speculator} from '../speculator.js';
+
+describe('planning manifest integration', () => {
+  it('can produce a recipe that can be speculated', async () => {
+    const {arc, recipe} = await manifestTestSetup();
+    const hash = ((hash) => hash.substring(hash.length - 4))(await recipe.digest());
+    const suggestion = await new Speculator().speculate(arc, recipe, hash);
+    assert.equal(suggestion.rank, 1);
+  });
+});

--- a/src/runtime/test/runtime-manifest-integration-test.ts
+++ b/src/runtime/test/runtime-manifest-integration-test.ts
@@ -8,29 +8,18 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {Speculator} from '../../planning/speculator.js';
 import {assert} from '../../platform/chai-web.js';
 import {Arc} from '../arc.js';
 import {handleFor} from '../handle.js';
 import {Loader} from '../loader.js';
 import {Manifest} from '../manifest.js';
 import {StorageProxy} from '../storage-proxy.js';
+import {manifestTestSetup} from '../testing/manifest-integration-test-setup.js';
 
-async function setup() {
-  const registry = {};
-  const loader = new Loader();
-  const manifest = await Manifest.load('./src/runtime/test/artifacts/test.manifest', loader, registry);
-  assert(manifest);
-  const arc = new Arc({id: 'test', context: manifest, loader});
-  const recipe = manifest.recipes[0];
-  assert(recipe.normalize());
-  assert(recipe.isResolved());
-  return {arc, recipe};
-}
 
-describe('manifest integration', () => {
+describe('runtime manifest integration', () => {
   it('can produce a recipe that can be instantiated in an arc', async () => {
-    const {arc, recipe} = await setup();
+    const {arc, recipe} = await manifestTestSetup();
     await arc.instantiate(recipe);
     await arc.idle;
     const type = recipe.handles[0].type;
@@ -46,12 +35,5 @@ describe('manifest integration', () => {
     type.maybeEnsureResolved();
     const result = await handle.get();
     assert.equal(result.value, 'Hello, world!');
-  });
-
-  it('can produce a recipe that can be speculated', async () => {
-    const {arc, recipe} = await setup();
-    const hash = ((hash) => hash.substring(hash.length - 4))(await recipe.digest());
-    const suggestion = await new Speculator().speculate(arc, recipe, hash);
-    assert.equal(suggestion.rank, 1);
   });
 });

--- a/src/runtime/testing/manifest-integration-test-setup.ts
+++ b/src/runtime/testing/manifest-integration-test-setup.ts
@@ -1,0 +1,26 @@
+/**
+ * @license
+ * Copyright (c) 2017 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {assert} from '../../platform/chai-web.js';
+import {Arc} from '../arc.js';
+import {Loader} from '../loader.js';
+import {Manifest} from '../manifest.js';
+
+export async function manifestTestSetup() {
+  const registry = {};
+  const loader = new Loader();
+  const manifest = await Manifest.load('./src/runtime/test/artifacts/test.manifest', loader, registry);
+  assert(manifest);
+  const arc = new Arc({id: 'test', context: manifest, loader});
+  const recipe = manifest.recipes[0];
+  assert(recipe.normalize());
+  assert(recipe.isResolved());
+  return {arc, recipe};
+}


### PR DESCRIPTION
Also splits out the shared setup function into it's own file with a clearer name.