### PR TITLE
Pluggable storage providers

### DIFF
--- a/shells/web-shell/index.html
+++ b/shells/web-shell/index.html
@@ -24,12 +24,9 @@ http://polymer.github.io/PATENTS.txt
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Google+Sans:400,700">
   <link rel="stylesheet" href="../configuration/index.css">
 
-  <script src="..//lib/build/pouchdb.js"></script>
-  <script src="../lib/build/firebase.js"></script>
   <script src="../../node_modules/sourcemapped-stacktrace/dist/sourcemapped-stacktrace.js"></script>
-  
+
   <script type="module" src="./index.js"></script>
-  <script type="module" src="../configuration/whitelisted.js"></script>
   <script type="module" src="./elements/web-shell.js"></script>
 
 </head>

--- a/shells/web-shell/index.js
+++ b/shells/web-shell/index.js
@@ -1,5 +1,13 @@
 import {Xen} from '../lib/xen.js';
 import {DevtoolsConnection} from '../../build/runtime/debug/devtools-connection.js';
+// optional firebase support
+import '../lib/build/firebase.js';
+import '../../build/runtime/storage/firebase/firebase-provider.js';
+// optional pouchdb support
+import '../lib/build/pouchdb.js';
+import '../../build/runtime/storage/pouchdb/pouchdb-provider.js';
+// whitelist components
+import '../configuration/whitelisted.js';
 
 const params = (new URL(document.location)).searchParams;
 const logLevel = params.get('logLevel') || (params.has('log') ? 2 : Xen.Debug.level);
@@ -17,5 +25,5 @@ window.debugLevel = Xen.Debug.level = logLevel;
   // configure root path
   Object.assign(document.querySelector('web-shell'), {
     root: '../..' // path to arcs/
-  });  
+  });
 })();

--- a/src/planning/test/plan/plan-consumer-test.ts
+++ b/src/planning/test/plan/plan-consumer-test.ts
@@ -7,6 +7,8 @@
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
+import '../../../runtime/storage/firebase/firebase-provider.js';
+import '../../../runtime/storage/pouchdb/pouchdb-provider.js';
 import {assert} from '../../../platform/chai-web.js';
 import {Modality} from '../../../runtime/modality.js';
 import {Relevance} from '../../../runtime/relevance.js';
@@ -125,7 +127,7 @@ describe('plan consumer', () => {
         slotComposer: new MockSlotComposer({
           modalityName,
           modalityHandler: PlanningModalityHandler.createHeadlessHandler()
-        }), 
+        }),
         manifestString: `
   particle ParticleDom in './src/runtime/test/artifacts/consumer-particle.js'
     consume root

--- a/src/runtime/manual_tests/firebase-tests.ts
+++ b/src/runtime/manual_tests/firebase-tests.ts
@@ -13,7 +13,7 @@ import {Arc} from '../arc.js';
 import {Id} from '../id.js';
 import {Loader} from '../loader.js';
 import {Manifest} from '../manifest.js';
-import {resetStorageForTesting} from '../storage/firebase-storage.js';
+import {resetStorageForTesting} from '../storage/firebase/firebase-storage.js';
 import {BigCollectionStorageProvider, CollectionStorageProvider, VariableStorageProvider} from '../storage/storage-provider-base.js';
 import {StorageProviderFactory} from '../storage/storage-provider-factory.js';
 import {CallbackTracker} from '../testing/callback-tracker.js';
@@ -113,10 +113,10 @@ describe('firebase', function() {
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const key1 = newStoreKey('varPtr');
-  
+
       const var1 = await storage.construct('test0', barType, key1) as VariableStorageProvider;
       await var1.set({id: 'id1', value: 'underlying'});
-      
+
       const result = await var1.get();
       assert.equal(result.value, 'underlying');
 
@@ -177,7 +177,7 @@ describe('firebase', function() {
 
       await var1.clear();
       await var2.set(bar(3));
-     
+
       assert.isNull(await var1.get());
       assert.deepEqual(await var2.get(), bar(3));
       assert.sameDeepMembers(await backing.toList(), [bar(1), bar(2), bar(3)]);
@@ -269,12 +269,12 @@ describe('firebase', function() {
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const key1 = newStoreKey('colPtr');
-  
+
       const collection1 = await storage.construct('test0', barType.collectionOf(), key1) as CollectionStorageProvider;
-  
+
       await collection1.store({id: 'id1', value: 'value1'}, ['key1']);
       await collection1.store({id: 'id2', value: 'value2'}, ['key2']);
-      
+
       let result = await collection1.get('id1');
       assert.equal(result.value, 'value1');
       result = await collection1.get('id2');
@@ -292,18 +292,18 @@ describe('firebase', function() {
         schema Bar
           Text value
       `);
-  
+
       const arc = new Arc({id: 'test', loader: new Loader(), context: manifest});
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const key1 = newStoreKey('colPtr');
-  
+
       const collection1 = await storage.construct('test0', new ReferenceType(barType).collectionOf(), key1) as CollectionStorageProvider;
       const callbackTracker = new CallbackTracker(collection1, 4);
-  
+
       await collection1.store({id: 'id1', storageKey: 'value1'}, ['key1']);
       await collection1.store({id: 'id2', storageKey: 'value2'}, ['key2']);
-      
+
       let result = await collection1.get('id1');
       assert.equal(result.storageKey, 'value1');
       result = await collection1.get('id2');
@@ -312,7 +312,7 @@ describe('firebase', function() {
       assert.isFalse(collection1.referenceMode);
       assert.isNull(collection1.backingStore);
       callbackTracker.verify();
-    }); 
+    });
 
     it('supports removeMultiple', async () => {
       const manifest = await Manifest.parse(`
@@ -368,7 +368,7 @@ describe('firebase', function() {
       await col1.removeMultiple([{id: 'id1', keys: []}, {id: 'id2', keys: []}]);
       assert.sameDeepMembers(await col1.toList(), [bar(3)]);
       assert.sameDeepMembers(await col2.toList(), [bar(2)]);
-      
+
       // Remove ops are *not* currently propagated to the backing.
       assert.sameDeepMembers(await backing.toList(), [bar(1), bar(2), bar(3)]);
 
@@ -758,8 +758,8 @@ describe('firebase', function() {
       const arc2 = await Arc.deserialize({serialization, loader, fileName: '', pecFactory:undefined, slotComposer: undefined, context: manifest});
       const varStore2 = arc2.findStoreById(varStore.id) as VariableStorageProvider;
       const colStore2 = arc2.findStoreById(colStore.id) as CollectionStorageProvider;
-      const bigStore2 = arc2.findStoreById(bigStore.id) as BigCollectionStorageProvider; 
-      
+      const bigStore2 = arc2.findStoreById(bigStore.id) as BigCollectionStorageProvider;
+
       // New storage providers should have been created.
       assert.notStrictEqual(varStore2, varStore);
       assert.notStrictEqual(colStore2, colStore);
@@ -843,7 +843,7 @@ describe('firebase', function() {
         {id: 'id8', keys: ['key8b', 'key8c']},
       ]);
       assert.sameDeepMembers(await backing.toList(), [bar(3), bar(5), bar(8)]);
-    
+
       // removeMultiple: empty item list deletes everything
       await backing.removeMultiple([]);
       assert.isEmpty(await backing.toList());

--- a/src/runtime/storage/firebase/firebase-provider.ts
+++ b/src/runtime/storage/firebase/firebase-provider.ts
@@ -1,0 +1,12 @@
+// @
+// Copyright (c) 2017 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+import {StorageProviderFactory} from '../storage-provider-factory.js';
+import {FirebaseStorage} from './firebase-storage.js';
+
+StorageProviderFactory.register('firebase', {storage: FirebaseStorage, isPersistent: true});

--- a/src/runtime/storage/firebase/firebase-storage.ts
+++ b/src/runtime/storage/firebase/firebase-storage.ts
@@ -6,17 +6,17 @@
 // subject to an additional IP rights grant found at
 // http://polymer.github.io/PATENTS.txt
 
-import {assert} from '../../platform/assert-web.js';
-import {atob} from '../../platform/atob-web.js';
-import {btoa} from '../../platform/btoa-web.js';
-import {firebase} from '../../platform/firebase-web.js';
-import {Id} from '../id.js';
-import {BigCollectionType, CollectionType, ReferenceType, Type, TypeVariable} from '../type.js';
-import {setDiff} from '../util.js';
+import {assert} from '../../../platform/assert-web.js';
+import {atob} from '../../../platform/atob-web.js';
+import {btoa} from '../../../platform/btoa-web.js';
+import {firebase} from '../../../platform/firebase-web.js';
+import {Id} from '../../id.js';
+import {BigCollectionType, CollectionType, ReferenceType, Type, TypeVariable} from '../../type.js';
+import {setDiff} from '../../util.js';
 
-import {CrdtCollectionModel} from './crdt-collection-model.js';
-import {KeyBase} from './key-base.js';
-import {BigCollectionStorageProvider, ChangeEvent, CollectionStorageProvider, StorageBase, StorageProviderBase, VariableStorageProvider} from './storage-provider-base.js';
+import {CrdtCollectionModel} from '../crdt-collection-model.js';
+import {KeyBase} from '../key-base.js';
+import {BigCollectionStorageProvider, ChangeEvent, CollectionStorageProvider, StorageBase, StorageProviderBase, VariableStorageProvider} from '../storage-provider-base.js';
 
 export async function resetStorageForTesting(key) {
   key = new FirebaseKey(key);
@@ -1560,7 +1560,7 @@ class FirebaseBackingStore extends FirebaseStorageProvider implements Collection
     }
     return values;
   }
- 
+
   async toList() {
     const snapshot = await this.reference.child('items').once('value');
     // tslint:disable-next-line: no-any

--- a/src/runtime/storage/pouchdb/pouchdb-provider.ts
+++ b/src/runtime/storage/pouchdb/pouchdb-provider.ts
@@ -1,0 +1,12 @@
+// @
+// Copyright (c) 2017 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+import {StorageProviderFactory} from '../storage-provider-factory.js';
+import {PouchDbStorage} from './pouch-db-storage.js';
+
+StorageProviderFactory.register('pouchdb', {storage: PouchDbStorage, isPersistent: true});

--- a/src/runtime/test/arc-tests.ts
+++ b/src/runtime/test/arc-tests.ts
@@ -8,6 +8,8 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
+import '../storage/firebase/firebase-provider.js';
+import '../storage/pouchdb/pouchdb-provider.js';
 import {assert} from '../../platform/chai-web.js';
 import {Arc} from '../arc.js';
 import {handleFor} from '../handle.js';

--- a/src/runtime/test/storage/pouchdb/pouch-db-tests.ts
+++ b/src/runtime/test/storage/pouchdb/pouch-db-tests.ts
@@ -99,7 +99,7 @@ describe('pouchdb', () => {
       const v1 = await var1.get();
       const v2 = await var2.get();
       assert.deepEqual(v1, v2);
-      
+
       var1Callbacks.verify();
       var2Callbacks.verify();
     });

--- a/tools/spotify-importer.js
+++ b/tools/spotify-importer.js
@@ -12,7 +12,7 @@ import fs from 'fs';
 import {Manifest} from '../build/runtime/manifest.js';
 import {EntityType} from '../build/runtime/type.js';
 import {StorageProviderFactory} from '../build/runtime/storage/storage-provider-factory.js';
-import {resetStorageForTesting} from '../build/runtime/storage/firebase-storage.js';
+import {resetStorageForTesting} from '../build/runtime/storage/firebase/firebase-storage.js';
 
 // Imports Spotify playlists from JSON files, formatted as per the API
 // described on https://developer.spotify.com/console/get-playlist


### PR DESCRIPTION
- instead of statically linking all storage providers directly in storage-provider-factory.ts, allow providers to register themselves with the StorageProviderFactory class at runtime
- build pouchdb-provider.ts and firebase-provider.ts: imports that link in support for the named storage 
- moved firebase files to a firebase/ folder to match pouchdb