### PR TITLE
in Arc use Id class getter instead of extracting `arcId` from storageKey

### DIFF
--- a/src/planning/plan/plan-producer.ts
+++ b/src/planning/plan/plan-producer.ts
@@ -83,7 +83,7 @@ export class PlanProducer {
 
   async onSearchChanged() {
     const values = await this.searchStore.get() || [];
-    const arcId = this.arc.arcId;
+    const arcId = this.arc.id.toStringWithoutSession();
     const value = values.find(value => value.arc === arcId);
     if (!value) {
       return;
@@ -154,7 +154,7 @@ export class PlanProducer {
     time = ((now() - time) / 1000).toFixed(2);
 
     if (suggestions) {
-      log(`[${this.arc.arcId}] Produced ${suggestions.length} suggestions [elapsed=${time}s].`);
+      log(`[${this.arc.id.toStringWithoutSession()}] Produced ${suggestions.length} suggestions [elapsed=${time}s].`);
       this.isPlanning = false;
 
       if (this.result.merge({

--- a/src/planning/plan/plan-producer.ts
+++ b/src/planning/plan/plan-producer.ts
@@ -83,7 +83,7 @@ export class PlanProducer {
 
   async onSearchChanged() {
     const values = await this.searchStore.get() || [];
-    const arcId = this.arc.id.toStringWithoutSession();
+    const arcId = this.arc.id.idTreeAsString();
     const value = values.find(value => value.arc === arcId);
     if (!value) {
       return;
@@ -154,7 +154,7 @@ export class PlanProducer {
     time = ((now() - time) / 1000).toFixed(2);
 
     if (suggestions) {
-      log(`[${this.arc.id.toStringWithoutSession()}] Produced ${suggestions.length} suggestions [elapsed=${time}s].`);
+      log(`[${this.arc.id.idTreeAsString()}] Produced ${suggestions.length} suggestions [elapsed=${time}s].`);
       this.isPlanning = false;
 
       if (this.result.merge({

--- a/src/planning/plan/planificator.ts
+++ b/src/planning/plan/planificator.ts
@@ -193,7 +193,7 @@ export class Planificator {
 
   async _storeSearch(): Promise<void> {
     const values = await this.searchStore.get() || [];
-    const arcKey = this.arc.id.toStringWithoutSession();
+    const arcKey = this.arc.id.idTreeAsString();
     const newValues = [];
     for (const {arc, search} of values) {
       if (arc === arcKey) {

--- a/src/planning/plan/planificator.ts
+++ b/src/planning/plan/planificator.ts
@@ -193,7 +193,7 @@ export class Planificator {
 
   async _storeSearch(): Promise<void> {
     const values = await this.searchStore.get() || [];
-    const arcKey = this.arc.arcId;
+    const arcKey = this.arc.id.toStringWithoutSession();
     const newValues = [];
     for (const {arc, search} of values) {
       if (arc === arcKey) {

--- a/src/planning/test/plan/plan-producer-test.ts
+++ b/src/planning/test/plan/plan-producer-test.ts
@@ -154,7 +154,7 @@ describe('plan producer - search', () => {
     }
 
     setNextSearch(search: string) {
-      this.searchStore.set([{arc: this.arc.id.toStringWithoutSession(), search}]);
+      this.searchStore.set([{arc: this.arc.id.idTreeAsString(), search}]);
       return this.onSearchChanged();
     }
   }

--- a/src/planning/test/plan/plan-producer-test.ts
+++ b/src/planning/test/plan/plan-producer-test.ts
@@ -83,7 +83,7 @@ class TestPlanProducer extends PlanProducer {
     async function createProducer(manifestFilename) {
       const helper = await PlanningTestHelper.createAndPlan({
         manifestFilename: './src/runtime/test/artifacts/Products/Products.recipes',
-        storageKey: 'firebase://xxx.firebaseio.com/yyy/serialization/zzz'
+        storageKey: 'firebase://xxx.firebaseio.com/yyy/serialization/demo'
       });
       const store = await Planificator['_initSuggestStore'](helper.arc, /* userid= */ 'TestUser', storageKeyBase);
       assert.isNotNull(store);
@@ -154,7 +154,7 @@ describe('plan producer - search', () => {
     }
 
     setNextSearch(search: string) {
-      this.searchStore.set([{arc: this.arc.arcId, search}]);
+      this.searchStore.set([{arc: this.arc.id.toStringWithoutSession(), search}]);
       return this.onSearchChanged();
     }
   }

--- a/src/planning/test/plan/planificator-test.ts
+++ b/src/planning/test/plan/planificator-test.ts
@@ -18,7 +18,7 @@ import {PlanningResult} from '../../plan/planning-result.js';
 describe('planificator', () => {
   it('constructs suggestion and search storage keys for fb arc', async () => {
     const helper = await PlanningTestHelper.create(
-      {storageKey: 'firebase://arcs-storage.firebaseio.com/AIzaSyBme42moeI-2k8WgXh-6YK_wYyjEXo4Oz8/0_6_0/testuser--LT97ssVNw_ttCZtjlMT'});
+      {storageKey: 'firebase://arcs-storage.firebaseio.com/AIzaSyBme42moeI-2k8WgXh-6YK_wYyjEXo4Oz8/0_6_0/demo'});
     const arc = helper.arc;
 
     const verifySuggestion = (storageKeyBase) => {

--- a/src/runtime/arc.ts
+++ b/src/runtime/arc.ts
@@ -74,7 +74,6 @@ export class Arc {
   // storage keys for referenced handles
   private storageKeys: {[index: string]: string} = {};
   readonly storageKey: string;
-  readonly arcId: string;
   storageProviderFactory: StorageProviderFactory;
   // Map from each store to a set of tags. public for debug access
   public storeTags = new Map<StorageProviderBase, Set<string>>();
@@ -109,7 +108,6 @@ export class Arc {
     const innerPecPort = this.pecFactory(pecId);
     this.pec = new ParticleExecutionHost(innerPecPort, slotComposer, this);
     this.storageProviderFactory = storageProviderFactory || new StorageProviderFactory(this.id);
-    this.arcId = this.storageKey ? this.storageProviderFactory.parseStringAsKey(this.storageKey).arcId : '';
     this.listenerClasses = listenerClasses;
     this.debugHandler = new ArcDebugHandler(this, listenerClasses);
   }

--- a/src/runtime/id.ts
+++ b/src/runtime/id.ts
@@ -10,6 +10,7 @@
 
 import {Random} from './random.js';
 
+// Id consists of 2 component: a session and an idTree.
 export class Id {
   // Session at which a logical object (e.g. an Arc) got created.
   // Part of the stable, permanent ID of this object.
@@ -50,11 +51,13 @@ export class Id {
     return newId;
   }
 
+  // Returns the full Id string.
   toString(): string {
     return `!${this.session}:${this.components.join(':')}`;
   }
 
-  toStringWithoutSession(): string {
+  // Returns the idTree as string (without the session component).
+  idTreeAsString(): string {
     return this.components.join(':');
   }
 

--- a/src/runtime/id.ts
+++ b/src/runtime/id.ts
@@ -54,8 +54,7 @@ export class Id {
     return `!${this.session}:${this.components.join(':')}`;
   }
 
-  // Only use this for testing!
-  toStringWithoutSessionForTesting(): string {
+  toStringWithoutSession(): string {
     return this.components.join(':');
   }
 

--- a/src/runtime/test/arc-tests.ts
+++ b/src/runtime/test/arc-tests.ts
@@ -213,7 +213,7 @@ describe('Arc', () => {
     const newArc = await Arc.deserialize({serialization, loader, slotComposer, context: undefined, fileName: 'foo.manifest'});
     assert.equal(newArc._stores.length, 0);
     assert.equal(newArc.activeRecipe.toString(), arc.activeRecipe.toString());
-    assert.equal(newArc.id.toStringWithoutSessionForTesting(), 'test');
+    assert.equal(newArc.id.toStringWithoutSession(), 'test');
   });
 
   it('deserializing a simple serialized arc produces that arc', async () => {
@@ -448,7 +448,6 @@ describe('Arc', () => {
             ? storageKeyPrefix + '!123:test^^arc-info'
             : storageKeyPrefix + '!123:test/arc-info';
 
-
       const store = await arc.storageProviderFactory.connect('id', new ArcType(), key) as VariableStorageProvider;
       const callbackTracker = new CallbackTracker(store, 0);
 
@@ -594,7 +593,7 @@ describe('Arc', () => {
       const newArc = await Arc.deserialize({serialization, loader, slotComposer, context: undefined, fileName: 'foo.manifest'});
       assert.equal(newArc._stores.length, 1);
       assert.equal(newArc.activeRecipe.toString(), arc.activeRecipe.toString());
-      assert.equal(newArc.id.toStringWithoutSessionForTesting(), 'test');
+      assert.equal(newArc.id.toStringWithoutSession(), 'test');
     });
   });  // end forEach(storageKeyPrefix)
 });

--- a/src/runtime/test/arc-tests.ts
+++ b/src/runtime/test/arc-tests.ts
@@ -213,7 +213,7 @@ describe('Arc', () => {
     const newArc = await Arc.deserialize({serialization, loader, slotComposer, context: undefined, fileName: 'foo.manifest'});
     assert.equal(newArc._stores.length, 0);
     assert.equal(newArc.activeRecipe.toString(), arc.activeRecipe.toString());
-    assert.equal(newArc.id.toStringWithoutSession(), 'test');
+    assert.equal(newArc.id.idTreeAsString(), 'test');
   });
 
   it('deserializing a simple serialized arc produces that arc', async () => {
@@ -593,7 +593,7 @@ describe('Arc', () => {
       const newArc = await Arc.deserialize({serialization, loader, slotComposer, context: undefined, fileName: 'foo.manifest'});
       assert.equal(newArc._stores.length, 1);
       assert.equal(newArc.activeRecipe.toString(), arc.activeRecipe.toString());
-      assert.equal(newArc.id.toStringWithoutSession(), 'test');
+      assert.equal(newArc.id.idTreeAsString(), 'test');
     });
   });  // end forEach(storageKeyPrefix)
 });

--- a/src/runtime/test/handle-test.ts
+++ b/src/runtime/test/handle-test.ts
@@ -168,8 +168,8 @@ describe('Handle', () => {
     schema Bar
       Text value
     `);
-    const arc = new Arc({id: 'test', storageKey: 'pouchdb://memory/yyy/', context: manifest, loader: new Loader()});
+    const arc = new Arc({id: 'test', storageKey: 'pouchdb://memory/yyy/test', context: manifest, loader: new Loader()});
     const variable = await arc.createStore(manifest.schemas.Bar.type, 'foo', 'test1') as VariableStorageProvider;
-    assert.equal(variable.storageKey, 'pouchdb://memory/yyy/handles/test1');
+    assert.equal(variable.storageKey, 'pouchdb://memory/yyy/test/handles/test1');
   });
 });


### PR DESCRIPTION
I know you said, you'll come up with a better name for `toStringWithoutSession` getter, I'll rename once you do. Otherwise this PR is ready.