### PR TITLE
Adds first versions of planning and planning-testing interface files

### DIFF
--- a/shells/lib/debug-listeners.js
+++ b/shells/lib/debug-listeners.js
@@ -1,5 +1,5 @@
 import {defaultCoreDebugListeners} from '../../build/runtime/debug/arc-debug-handler.js';
-import {defaultPlanningDebugListeners} from '../../build/planning/debug/arc-planner-invoker.js';
+import {defaultPlanningDebugListeners} from '../../build/planning/arcs-planning.js';
 
 // Debug-channel listeners are injected, so that the runtime need not know about them.
 export const debugListeners = [

--- a/shells/lib/dom-slot-composer.js
+++ b/shells/lib/dom-slot-composer.js
@@ -1,5 +1,5 @@
 import {Modality} from '../../build/runtime/modality.js';
-import {PlanningModalityHandler} from '../../build/planning/planning-modality-handler.js';
+import {PlanningModalityHandler} from '../../build/planning/arcs-planning.js';
 import {SlotComposer} from '../../build/runtime/slot-composer.js';
 
 const domModality = {

--- a/shells/lib/ram-slot-composer.js
+++ b/shells/lib/ram-slot-composer.js
@@ -7,7 +7,7 @@
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
-import {PlanningModalityHandler} from '../../build/planning/planning-modality-handler.js';
+import {PlanningModalityHandler} from '../../build/planning/arcs-planning.js';
 import {SlotComposer} from '../../build/runtime/slot-composer.js';
 
 export class RamSlotComposer extends SlotComposer {

--- a/shells/lib/user-planner.js
+++ b/shells/lib/user-planner.js
@@ -9,7 +9,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 */
 
 import {logFactory} from '../../build/platform/log-web.js';
-import {Planificator} from '../../build/planning/plan/planificator.js';
+import {Planificator} from '../../build/planning/arcs-planning.js';
 
 const log = logFactory('UserPlanner', '#4f0433');
 const warn = logFactory('UserPlanner', '#4f0433', 'warn');

--- a/shells/web-shell/elements/web-planner.js
+++ b/shells/web-shell/elements/web-planner.js
@@ -9,7 +9,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 */
 
 import {Xen} from '../../lib/xen.js';
-import {Planificator} from '../../../build/planning/plan/planificator.js';
+import {Planificator} from '../../../build/planning/arcs-planning.js';
 
 const log = Xen.logFactory('WebPlanner', '#104a91');
 //const error = Xen.logFactory('WebPlanner', '#104a91', 'error');

--- a/src/planning/arcs-planning.ts
+++ b/src/planning/arcs-planning.ts
@@ -1,0 +1,21 @@
+/**
+ * @license
+ * Copyright (c) 2019 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {Planner} from './planner.js';
+import {Planificator} from './plan/planificator.js';
+import {PlanningModalityHandler} from './planning-modality-handler.js';
+import {defaultPlanningDebugListeners} from './debug/arc-planner-invoker.js';
+
+export {
+  Planner,
+  Planificator,
+  PlanningModalityHandler,
+  defaultPlanningDebugListeners
+};

--- a/src/planning/testing/arcs-planning-testing.ts
+++ b/src/planning/testing/arcs-planning-testing.ts
@@ -1,0 +1,17 @@
+/**
+ * @license
+ * Copyright (c) 2019 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {PlanningTestHelper} from './planning-test-helper.js';
+import {StrategyTestHelper} from '../test/strategies/strategy-test-helper.js';
+
+export {
+  PlanningTestHelper,
+  StrategyTestHelper
+};

--- a/src/tests/arc-integration-tests.ts
+++ b/src/tests/arc-integration-tests.ts
@@ -11,7 +11,7 @@
 import {assert} from '../platform/chai-web.js';
 import {Arc} from '../runtime/arc.js';
 import {StubLoader} from '../runtime/testing/stub-loader.js';
-import {PlanningTestHelper} from '../planning/testing/planning-test-helper.js';
+import {PlanningTestHelper} from '../planning/testing/arcs-planning-testing.js';
 
 describe('Arc integration', () => {
   it('copies store tags', async () => {

--- a/src/tests/demo-flow-test.ts
+++ b/src/tests/demo-flow-test.ts
@@ -11,7 +11,7 @@
 import {assert} from '../platform/chai-web.js';
 import {Loader} from '../runtime/loader.js';
 import {Manifest} from '../runtime/manifest.js';
-import {PlanningTestHelper} from '../planning/testing/planning-test-helper.js';
+import {PlanningTestHelper} from '../planning/testing/arcs-planning-testing.js';
 
 describe('demo flow', () => {
   it('can load the recipe manifest', async () => {

--- a/src/tests/multiplexer-integration-test.ts
+++ b/src/tests/multiplexer-integration-test.ts
@@ -15,7 +15,7 @@ import {HostedSlotContext} from '../runtime/slot-context.js';
 import {SlotDomConsumer} from '../runtime/slot-dom-consumer.js';
 import {CollectionStorageProvider} from '../runtime/storage/storage-provider-base.js';
 import {FakeSlotComposer} from '../runtime/testing/fake-slot-composer.js';
-import {PlanningTestHelper} from '../planning/testing/planning-test-helper.js';
+import {PlanningTestHelper} from '../planning/testing/arcs-planning-testing.js';
 
 describe('Multiplexer', () => {
   it('renders polymorphic multiplexed slots', async () => {

--- a/src/tests/particles/common-test.ts
+++ b/src/tests/particles/common-test.ts
@@ -10,7 +10,7 @@
 
 import {assert} from '../../platform/chai-web.js';
 import {Manifest} from '../../runtime/manifest.js';
-import {PlanningTestHelper} from '../../planning/testing/planning-test-helper.js';
+import {PlanningTestHelper} from '../../planning/testing/arcs-planning-testing.js';
 
 describe('common particles test', () => {
   it('resolves after cloning', async () => {

--- a/src/tests/particles/multi-slot-test.ts
+++ b/src/tests/particles/multi-slot-test.ts
@@ -9,7 +9,7 @@
  */
 
 import {assert} from '../../platform/chai-web.js';
-import {PlanningTestHelper} from '../../planning/testing/planning-test-helper.js';
+import {PlanningTestHelper} from '../../planning/testing/arcs-planning-testing.js';
 
 describe('multi-slot test', () => {
   async function init() {

--- a/src/tests/particles/products-test.ts
+++ b/src/tests/particles/products-test.ts
@@ -9,7 +9,7 @@
  */
 
 import {assert} from '../../platform/chai-web.js';
-import {PlanningTestHelper} from '../../planning/testing/planning-test-helper.js';
+import {PlanningTestHelper} from '../../planning/testing/arcs-planning-testing.js';
 
 describe('products test', () => {
   const manifestFilename = './src/tests/particles/artifacts/products-test.recipes';

--- a/src/tests/particles/transformation-slots-test.ts
+++ b/src/tests/particles/transformation-slots-test.ts
@@ -8,7 +8,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {PlanningTestHelper} from '../../planning/testing/planning-test-helper.js';
+import {PlanningTestHelper} from '../../planning/testing/arcs-planning-testing.js';
 
 describe('transformation slots', () => {
   it('combines hosted particles provided singleton slots into transformation provided set slot', async () => {

--- a/src/tests/recipe-descriptions-test.ts
+++ b/src/tests/recipe-descriptions-test.ts
@@ -12,7 +12,7 @@ import {assert} from '../platform/chai-web.js';
 import {DescriptionDomFormatter} from '../runtime/description-dom-formatter.js';
 import {Recipe} from '../runtime/recipe/recipe.js';
 import {StubLoader} from '../runtime/testing/stub-loader.js';
-import {PlanningTestHelper} from '../planning/testing/planning-test-helper.js';
+import {PlanningTestHelper} from '../planning/testing/arcs-planning-testing.js';
 
 describe('recipe descriptions test', () => {
   // Avoid initialising non-POD variables globally, since they would be constructed even when

--- a/src/tests/slot-composer-tests.ts
+++ b/src/tests/slot-composer-tests.ts
@@ -8,8 +8,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {Planner} from '../planning/planner.js';
-import {StrategyTestHelper} from '../planning/test/strategies/strategy-test-helper.js';
+import {Planner} from '../planning/arcs-planning.js';
 import {assert} from '../platform/chai-web.js';
 import {Arc} from '../runtime/arc.js';
 import {HeadlessSlotDomConsumer} from '../runtime/headless-slot-dom-consumer.js';
@@ -19,7 +18,7 @@ import {HostedSlotContext, ProvidedSlotContext} from '../runtime/slot-context.js
 import {MockSlotComposer} from '../runtime/testing/mock-slot-composer.js';
 import {StubLoader} from '../runtime/testing/stub-loader.js';
 import {TestHelper} from '../runtime/testing/test-helper.js';
-import {PlanningTestHelper} from '../planning/testing/planning-test-helper.js';
+import {PlanningTestHelper, StrategyTestHelper} from '../planning/testing/arcs-planning-testing.js';
 
 async function initSlotComposer(recipeStr) {
   const slotComposer = new MockSlotComposer().newExpectations();


### PR DESCRIPTION
All imports from src/planning into files outside src/planning now go through the two interface files.

Most reviewers are for FYI.

This completes the separation of the planning code into it's own module. Ensuring that a build doesn't pull any of it in still needs a bit more work.