### PR TITLE
Remove primitive type accessor and use getContainedType in its place

### DIFF
--- a/src/runtime/multiplexer-dom-particle.js
+++ b/src/runtime/multiplexer-dom-particle.js
@@ -96,7 +96,7 @@ export class MultiplexerDomParticle extends TransformationDomParticle {
       }
 
       const itemHandlePromise =
-          arc.createHandle(type.primitiveType(), 'item' + index);
+          arc.createHandle(type.getContainedType(), 'item' + index);
       this.handleIds[item.id] = itemHandlePromise;
 
       const itemHandle = await itemHandlePromise;

--- a/src/runtime/storage/firebase/firebase-storage.ts
+++ b/src/runtime/storage/firebase/firebase-storage.ts
@@ -697,7 +697,7 @@ class FirebaseCollection extends FirebaseStorageProvider implements CollectionSt
   }
 
   backingType() {
-    return this.type.primitiveType();
+    return this.type.getContainedType();
   }
 
   remoteStateChanged(dataSnapshot) {
@@ -912,7 +912,7 @@ class FirebaseCollection extends FirebaseStorageProvider implements CollectionSt
     let effective;
     // 1. Apply the change to the local model.
     if (this.referenceMode) {
-      const referredType = this.type.primitiveType();
+      const referredType = this.type.getContainedType();
       const storageKey = this.storageEngine.baseStorageKey(referredType, this.storageKey);
       effective = this.model.add(id, {id, storageKey}, keys);
       this.version++;
@@ -1056,7 +1056,7 @@ class FirebaseCollection extends FirebaseStorageProvider implements CollectionSt
       if (items.length === 0) {
         return [];
       }
-      const referredType = this.type.primitiveType();
+      const referredType = this.type.getContainedType();
 
       const refSet = new Set();
 
@@ -1328,7 +1328,7 @@ class FirebaseBigCollection extends FirebaseStorageProvider implements BigCollec
   }
 
   backingType() {
-    return this.type.primitiveType();
+    return this.type.getContainedType();
   }
 
   enableReferenceMode() {

--- a/src/runtime/storage/pouchdb/pouch-db-big-collection.ts
+++ b/src/runtime/storage/pouchdb/pouch-db-big-collection.ts
@@ -10,7 +10,7 @@ export class PouchDbBigCollection extends PouchDbStorageProvider implements BigC
   }
 
   backingType() {
-    return this.type.primitiveType();
+    return this.type.getContainedType();
   }
 
   async get(id: string) {

--- a/src/runtime/storage/pouchdb/pouch-db-collection.ts
+++ b/src/runtime/storage/pouchdb/pouch-db-collection.ts
@@ -61,7 +61,7 @@ export class PouchDbCollection extends PouchDbStorageProvider implements Collect
 
   /** @inheritDoc */
   backingType() {
-    return this.type.primitiveType();
+    return this.type.getContainedType();
   }
 
   // TODO(lindner): write tests
@@ -197,7 +197,7 @@ export class PouchDbCollection extends PouchDbStorageProvider implements Collect
     const item = {value, keys, effective: false};
 
     if (this.referenceMode) {
-      const referredType = this.type.primitiveType();
+      const referredType = this.type.getContainedType();
       const storageKey = this.storageEngine.baseStorageKey(referredType, this.storageKey);
 
       // Update the referred data

--- a/src/runtime/storage/volatile-storage.ts
+++ b/src/runtime/storage/volatile-storage.ts
@@ -204,7 +204,7 @@ class VolatileCollection extends VolatileStorageProvider implements CollectionSt
   }
 
   backingType() {
-    return this.type.primitiveType();
+    return this.type.getContainedType();
   }
 
   clone() {
@@ -301,7 +301,7 @@ class VolatileCollection extends VolatileStorageProvider implements CollectionSt
 
     const item = {value, keys, effective: undefined};
     if (this.referenceMode) {
-      const referredType = this.type.primitiveType();
+      const referredType = this.type.getContainedType();
 
       const storageKey = this.backingStore ? this.backingStore.storageKey : this.storageEngine.baseStorageKey(referredType);
 
@@ -533,7 +533,7 @@ class VolatileBigCollection extends VolatileStorageProvider implements BigCollec
   }
 
   backingType() {
-    return this.type.primitiveType();
+    return this.type.getContainedType();
   }
 
   async get(id: string) {

--- a/src/runtime/test/artifacts/Products/test/source/ProductFilter.js
+++ b/src/runtime/test/artifacts/Products/test/source/ProductFilter.js
@@ -17,7 +17,7 @@ defineParticle(({Particle}) => {
       this._products = null;
       this._hostedParticle = null;
       this._resultsHandle = handles.get('results');
-      this._productType = handles.get('products').type.primitiveType();
+      this._productType = handles.get('products').type.getContainedType();
       this._arc = await this.constructInnerArc();
     }
     async onHandleSync(handle, model) {

--- a/src/runtime/test/artifacts/transformations/test-multiplex-slots-particle.js
+++ b/src/runtime/test/artifacts/transformations/test-multiplex-slots-particle.js
@@ -38,7 +38,7 @@ defineParticle(({TransformationDomParticle}) => {
           // The element already exists.
           continue;
         }
-        const fooHandle = await arc.createHandle(type.primitiveType(), 'foo' + index);
+        const fooHandle = await arc.createHandle(type.getContainedType(), 'foo' + index);
         this._handleIds.add(foo.id);
         const hostedSlotName = [...hostedParticle.slots.keys()][0];
         const slotName = [...this.spec.slots.values()][0].name;

--- a/src/runtime/test/description-test.ts
+++ b/src/runtime/test/description-test.ts
@@ -791,7 +791,7 @@ recipe
       arc,
       recipe,
       fooStore,
-      DescriptionType: descriptionStore.type.primitiveType().entitySchema.entityClass(),
+      DescriptionType: descriptionStore.type.getContainedType().entitySchema.entityClass(),
       descriptionHandle: handleFor(descriptionStoreProxy)
     };
   }

--- a/src/runtime/test/particle-api-test.ts
+++ b/src/runtime/test/particle-api-test.ts
@@ -581,8 +581,8 @@ describe('particle-api', () => {
               if (handle.name !== 'inputs')
                 return;
               for (let input of model) {
-                let inHandle = await this.arc.createHandle(this.resHandle.type.primitiveType(), 'the-in');
-                let outHandle = await this.arc.createHandle(this.resHandle.type.primitiveType(), 'the-out', this);
+                let inHandle = await this.arc.createHandle(this.resHandle.type.getContainedType(), 'the-in');
+                let outHandle = await this.arc.createHandle(this.resHandle.type.getContainedType(), 'the-out', this);
                 try {
                   let done = await this.arc.loadRecipe(\`
                     schema Result

--- a/src/runtime/test/recipe-test.ts
+++ b/src/runtime/test/recipe-test.ts
@@ -671,23 +671,23 @@ describe('recipe', () => {
     const verifyRecipe = (recipe, errorPrefix) => {
       const errors = [];
       const resolvedType = recipe.handleConnections[0].type.resolvedType();
-      if (resolvedType !== recipe.handleConnections[1].type.primitiveType().resolvedType()) {
+      if (resolvedType !== recipe.handleConnections[1].type.getContainedType().resolvedType()) {
         errors.push(`${errorPrefix}: handle connection types mismatch`);
       }
       if (resolvedType !== recipe.handles[0].type.resolvedType()) {
         errors.push(`${errorPrefix}: handle0 type mismatch with handle-connection`);
       }
-      if (resolvedType !== recipe.handles[1].type.primitiveType().resolvedType()) {
+      if (resolvedType !== recipe.handles[1].type.getContainedType().resolvedType()) {
         errors.push(`${errorPrefix}: handle1 type mismatch with handle-connection`);
       }
-      if (recipe.handles[0].type.resolvedType() !== recipe.handles[1].type.primitiveType().resolvedType()) {
+      if (recipe.handles[0].type.resolvedType() !== recipe.handles[1].type.getContainedType().resolvedType()) {
         errors.push(`${errorPrefix}: handles type mismatch`);
       }
       assert.lengthOf(errors, 0, `\ndetailed errors: [\n${errors.join('\n')}\n]\n`);
       return resolvedType;
     };
     assert.isTrue(recipe.normalize());
-    assert.equal(recipe.handleConnections[0].type, recipe.handleConnections[1].type.primitiveType());
+    assert.equal(recipe.handleConnections[0].type, recipe.handleConnections[1].type.getContainedType());
     const recipeResolvedType = verifyRecipe(recipe, 'recipe');
     const type = recipe.handleConnections[0].type;
 

--- a/src/runtime/test/type-test.ts
+++ b/src/runtime/test/type-test.ts
@@ -326,8 +326,8 @@ describe('types', () => {
       assert(recipe.normalize());
       assert(recipe.isResolved());
       assert.equal(recipe.handles.length, 1);
-      assert.equal(recipe.handles[0].type.primitiveType().canReadSubset.entitySchema.name, 'Lego');
-      assert.equal(recipe.handles[0].type.primitiveType().canWriteSuperset.entitySchema.name, 'Product');
+      assert.equal(recipe.handles[0].type.getContainedType().canReadSubset.entitySchema.name, 'Lego');
+      assert.equal(recipe.handles[0].type.getContainedType().canWriteSuperset.entitySchema.name, 'Product');
     });
 
     it('a subtype matches to a supertype that wants to be read when a handle exists', async () => {
@@ -340,7 +340,7 @@ describe('types', () => {
       assert(recipe.normalize());
       assert(recipe.isResolved());
       assert.lengthOf(recipe.handles, 1);
-      assert.equal(recipe.handles[0].type.primitiveType().entitySchema.name, 'Product');
+      assert.equal(recipe.handles[0].type.getContainedType().entitySchema.name, 'Product');
     });
 
     it('a subtype matches to a supertype that wants to be read when a handle exists', async () => {
@@ -353,7 +353,7 @@ describe('types', () => {
       assert(recipe.normalize());
       assert(recipe.isResolved());
       assert.lengthOf(recipe.handles, 1);
-      assert.equal(recipe.handles[0].type.primitiveType().entitySchema.name, 'Lego');
+      assert.equal(recipe.handles[0].type.getContainedType().entitySchema.name, 'Lego');
     });
   });
 });

--- a/src/runtime/type.ts
+++ b/src/runtime/type.ts
@@ -121,10 +121,6 @@ export abstract class Type {
     return this._applyExistenceTypeTest(type => type instanceof TypeVariable && !type.variable.isResolved());
   }
 
-  primitiveType() {
-    return null;
-  }
-
   getContainedType() {
     return null;
   }
@@ -402,18 +398,13 @@ export class CollectionType<T extends Type> extends Type {
   }
 
   mergeTypeVariablesByName(variableMap: Map<string, Type>): CollectionType<Type> {
-    const primitiveType = this.collectionType;
-    const result = primitiveType.mergeTypeVariablesByName(variableMap);
-    return (result === primitiveType) ? this : result.collectionOf();
+    const collectionType = this.collectionType;
+    const result = collectionType.mergeTypeVariablesByName(variableMap);
+    return (result === collectionType) ? this : result.collectionOf();
   }
 
   _applyExistenceTypeTest(test: (type: Type) => boolean): boolean {
     return this.collectionType._applyExistenceTypeTest(test);
-  }
-
-  // TODO: remove this in favor of a renamed collectionType
-  primitiveType(): T {
-    return this.collectionType;
   }
 
   getContainedType(): T {
@@ -425,9 +416,9 @@ export class CollectionType<T extends Type> extends Type {
   }
 
   resolvedType(): CollectionType<Type> {
-    const primitiveType = this.collectionType;
-    const resolvedPrimitiveType = primitiveType.resolvedType();
-    return (primitiveType !== resolvedPrimitiveType) ? resolvedPrimitiveType.collectionOf() : this;
+    const collectionType = this.collectionType;
+    const resolvedCollectionType = collectionType.resolvedType();
+    return (collectionType !== resolvedCollectionType) ? resolvedCollectionType.collectionOf() : this;
   }
 
   _canEnsureResolved() {
@@ -486,9 +477,9 @@ export class BigCollectionType<T extends Type> extends Type {
   }
 
   mergeTypeVariablesByName(variableMap: Map<string, Type>): BigCollectionType<Type> {
-    const primitiveType = this.bigCollectionType;
-    const result = primitiveType.mergeTypeVariablesByName(variableMap);
-    return (result === primitiveType) ? this : result.bigCollectionOf();
+    const collectionType = this.bigCollectionType;
+    const result = collectionType.mergeTypeVariablesByName(variableMap);
+    return (result === collectionType) ? this : result.bigCollectionOf();
   }
 
   _applyExistenceTypeTest(test): boolean {
@@ -504,9 +495,9 @@ export class BigCollectionType<T extends Type> extends Type {
   }
 
   resolvedType(): BigCollectionType<Type> {
-    const primitiveType = this.bigCollectionType;
-    const resolvedPrimitiveType = primitiveType.resolvedType();
-    return (primitiveType !== resolvedPrimitiveType) ? resolvedPrimitiveType.bigCollectionOf() : this;
+    const collectionType = this.bigCollectionType;
+    const resolvedCollectionType = collectionType.resolvedType();
+    return (collectionType !== resolvedCollectionType) ? resolvedCollectionType.bigCollectionOf() : this;
   }
 
   _canEnsureResolved() {
@@ -733,9 +724,9 @@ export class ReferenceType extends Type {
   }
 
   resolvedType() {
-    const primitiveType = this.referredType;
-    const resolvedPrimitiveType = primitiveType.resolvedType();
-    return (primitiveType !== resolvedPrimitiveType) ? new ReferenceType(resolvedPrimitiveType) : this;
+    const referredType = this.referredType;
+    const resolvedReferredType = referredType.resolvedType();
+    return (referredType !== resolvedReferredType) ? new ReferenceType(resolvedReferredType) : this;
   }
 
   _canEnsureResolved() {


### PR DESCRIPTION
This should make future changes to improve the type class's api by removing the deprecated 'primitiveType' getter. 