### PR TITLE
pipes-shell: glitch support

### DIFF
--- a/particles/PipeApps/source/RandomArtist.js
+++ b/particles/PipeApps/source/RandomArtist.js
@@ -8,7 +8,6 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-
 'use strict';
 
 defineParticle(({DomParticle, html, log}) => {

--- a/shells/pipes-shell/device.js
+++ b/shells/pipes-shell/device.js
@@ -1,6 +1,7 @@
 import {SyntheticStores} from '../lib/synthetic-stores.js';
 import {Context} from './context.js';
 import {Pipe} from './pipe.js';
+import {Utils} from '../lib/utils.js';
 
 // TODO(sjmiles): why not automatic?
 SyntheticStores.init();
@@ -12,18 +13,24 @@ let testMode;
 export const DeviceApiFactory = (storage, deviceClient) => {
   client = deviceClient;
   userContext = new Context(storage);
-  return {
-    receiveEntity(json) {
-      console.log('received entity...');
-      receiveJsonEntity(json);
-      return true;
-    },
-    observeEntity(json) {
-      console.log('observing entity...');
-      observeJsonEntity(json);
-      return true;
-    }
-  };
+  return deviceApi;
+};
+
+const deviceApi = {
+  receiveEntity(json) {
+    console.log('received entity...');
+    receiveJsonEntity(json);
+    return true;
+  },
+  observeEntity(json) {
+    console.log('observing entity...');
+    observeJsonEntity(json);
+    return true;
+  },
+  flush() {
+    console.log('flushing caches...');
+    Utils.env.loader.flushCaches();
+  }
 };
 
 const callback = text => {

--- a/shells/pipes-shell/pipe.js
+++ b/shells/pipes-shell/pipe.js
@@ -59,7 +59,8 @@ const dispatch = async (type, arc, callback) => {
 };
 
 pipeHandlers.com_music_spotify = async (arc, callback) => {
-  const manifest = await Utils.parse(`import 'https://$particles/PipeApps/ArtistAutofill.recipes'`);
+  //const manifest = await Utils.parse(`import 'https://$particles/PipeApps/ArtistAutofill.recipes'`);
+  const manifest = await Utils.parse(`import 'https://thorn-egret.glitch.me/ArtistAutofill.recipes'`);
   // accrete recipe
   if (await instantiateRecipe(arc, manifest, 'ArtistAutofill')) {
     // wait for data to appear

--- a/shells/pipes-shell/pipe.js
+++ b/shells/pipes-shell/pipe.js
@@ -3,13 +3,9 @@ import {RamSlotComposer} from '../lib/ram-slot-composer.js';
 import {generateId} from '../../modalities/dom/components/generate-id.js';
 import {now} from '../../build/platform/date-web.js';
 
-let t0;
+const log = console.log.bind(console);
 
-const log = (...args) => {
-  //console.log(args.join(' '));
-  console.log(...args);
-  //document.body.appendChild(document.createElement('div')).innerText = args.join();
-};
+let t0;
 
 export const Pipe = {
   async observeEntity(store, json) {
@@ -52,38 +48,37 @@ const extractType = json => {
   return (entity ? entity.type : 'com.music.spotify').replace(/\./g, '_');
 };
 
+const pipeHandlers = {};
+
 const dispatch = async (type, arc, callback) => {
-  await instantiatePipeRecipe(arc, type);
-  switch (type) {
-    case 'com_google_android_apps_maps':
-      await com_google_android_apps_maps(arc, callback);
-      break;
-    default:
-    case 'com_music_spotify':
-      await com_music_spotify(arc, callback);
-      break;
+  const handler = pipeHandlers[type];
+  if (handler) {
+    await instantiatePipeRecipe(arc, type);
+    await handler(arc, callback);
   }
 };
 
-const com_music_spotify = async (arc, callback) => {
+pipeHandlers.com_music_spotify = async (arc, callback) => {
   const manifest = await Utils.parse(`import 'https://$particles/PipeApps/ArtistAutofill.recipes'`);
   // accrete recipe
-  await instantiateRecipe(arc, manifest, 'ArtistAutofill');
-  // wait for data to appear
-  const store = arc._stores[2];
-  watchOneChange(store, callback, arc);
-  //await dumpStores(arc._stores);
+  if (await instantiateRecipe(arc, manifest, 'ArtistAutofill')) {
+    // wait for data to appear
+    const store = arc._stores[2];
+    watchOneChange(store, callback, arc);
+    //await dumpStores(arc._stores);
+  }
 };
 
-const com_google_android_apps_maps = async (arc, callback) => {
+pipeHandlers.com_google_android_apps_maps = async (arc, callback) => {
   const manifest = await Utils.parse(`import 'https://$particles/PipeApps/MapsAutofill.recipes'`);
   // accrete recipe
-  await instantiateRecipe(arc, manifest, 'MapsAutofill');
-  // wait for data to appear
-  const store = arc._stores[2];
-  watchOneChange(store, callback, arc);
-  //await dumpStores(arc.context._stores);
-  //await dumpStores(arc._stores);
+  if (await instantiateRecipe(arc, manifest, 'MapsAutofill')) {
+    // wait for data to appear
+    const store = arc._stores[2];
+    watchOneChange(store, callback, arc);
+    //await dumpStores(arc.context._stores);
+    //await dumpStores(arc._stores);
+  }
 };
 
 const instantiatePipeRecipe = async (arc, type) => {
@@ -114,6 +109,7 @@ const instantiateRecipe = async (arc, manifest, name) => {
     await arc.instantiate(plan);
     // TODO(sjmiles): necessary for iOS (!?)
     //await logArc(arc);
+    return true;
   }
 };
 

--- a/src/platform/loader-web.js
+++ b/src/platform/loader-web.js
@@ -17,12 +17,15 @@ import {logFactory} from '../platform/log-web.js';
 
 const html = (strings, ...values) => (strings[0] + values.map((v, i) => v + strings[i + 1]).join('')).trim();
 
-const dumbCache = {};
+let dumbCache = {};
 
 export class PlatformLoader extends Loader {
   constructor(urlMap) {
     super();
     this._urlMap = urlMap || [];
+  }
+  flushCaches() {
+    dumbCache = {};
   }
   _loadURL(url) {
     const resolved = this._resolve(url);


### PR DESCRIPTION
- uses `ArtistAutofill.recipes` from https://thorn-egret.glitch.me/ 
- `ShellApi.flush()` added to clear caches (let changes to the glitch go into effect)
- tries to fail gracefully if `ArtistAutofill` isn't available (I may have missed some flavors of _not available_)

Well-lit path:
- edit `ArtistAutofill.recipes` and change the name of `ArtistAutofill` recipe to control availability of autofill. e.g.
  - set the recipe name to `NoArtistAutofill` (and restart shell or execute `ShellApi.flush()`) to disable artist autofill
  - set the recipe name to `ArtistAutofill` (and restart shell or execute `ShellApi.flush()`) to enable artist autofill

Note that the files in the glitch are copies of files in `particles/PipesApps` folder in the main repository (iow, they won't get lost if the glitch is blown up).