### PR TITLE
Add tests and change instantiation checks for handle-connection optionality

### DIFF
--- a/src/runtime/arc.ts
+++ b/src/runtime/arc.ts
@@ -420,19 +420,10 @@ ${this.activeRecipe.toString()}`;
     this.particleHandleMaps.set(recipeParticle.id, handleMap);
 
     for (const [name, connection] of Object.entries(recipeParticle.connections)) {
-      if (!connection.handle) {
-        assert(connection.isOptional);
-        continue;
-      }
       const handle = this.findStoreById(connection.handle.id);
       assert(handle, `can't find handle of id ${connection.handle.id}`);
       this._connectParticleToHandle(recipeParticle, name, handle);
     }
-
-    // At least all non-optional connections must be resolved
-    assert(handleMap.handles.size >= handleMap.spec.connections.filter(c => !c.isOptional).length,
-           `Not all mandatory connections are resolved for {$particle}`);
-
     this.pec.instantiate(recipeParticle, handleMap.spec, handleMap.handles);
   }
 

--- a/src/runtime/recipe/handle-connection.ts
+++ b/src/runtime/recipe/handle-connection.ts
@@ -169,13 +169,42 @@ export class HandleConnection {
   isResolved(options?): boolean {
     assert(Object.isFrozen(this));
 
-    if (this.isOptional) {
-      return true;
-    }
-
     let parent;
     if (this.spec && this.spec.parentConnection) {
       parent = this.particle.connections[this.spec.parentConnection.name];
+    }
+
+    if (parent && !parent.handle) {
+      // Our parent doesn't resolve, we don't need to resolve.
+      return true;
+    }
+
+    if(!this.handle) {
+      if(this.isOptional) {
+        // We're optional we don't need to resolve.
+        return true;
+      }
+      // We're not optional we do need to resolve.
+      if (options) {
+        options.details = 'missing handle';
+      }
+      return false;
+    }
+
+    if (this.spec) {
+      if (this.spec.parentConnection && (!parent || !parent.handle)) {
+        if (options) {
+          options.details = 'parent connection missing handle';
+        }
+        return false;
+      }
+    }
+
+    if (!this.direction) {
+      if (options) {
+        options.details = 'missing direction';
+      }
+      return false;
     }
 
     // TODO: This should use this._type, or possibly not consider type at all.
@@ -184,28 +213,6 @@ export class HandleConnection {
         options.details = 'missing type';
       }
       return false;
-    }
-    if (!this.direction) {
-      if (options) {
-        options.details = 'missing direction';
-      }
-      return false;
-    }
-    if (!this.handle) {
-      if (parent && parent.isOptional && !parent.handle) {
-        return true;
-      }
-      if (options) {
-        options.details = 'missing handle';
-      }
-      return false;
-    } else if (this.spec) {
-      if (this.spec.parentConnection && (!parent || !parent.handle)) {
-        if (options) {
-          options.details = 'parent connection missing handle';
-        }
-        return false;
-      }
     }
     return true;
   }

--- a/src/runtime/recipe/handle-connection.ts
+++ b/src/runtime/recipe/handle-connection.ts
@@ -172,6 +172,12 @@ export class HandleConnection {
     let parent;
     if (this.spec && this.spec.parentConnection) {
       parent = this.particle.connections[this.spec.parentConnection.name];
+      if (!parent || !parent.handle) {
+        if (options) {
+          options.details = 'parent connection missing handle';
+        }
+        return false;
+      }
     }
 
     if (parent && !parent.handle) {
@@ -189,15 +195,6 @@ export class HandleConnection {
         options.details = 'missing handle';
       }
       return false;
-    }
-
-    if (this.spec) {
-      if (this.spec.parentConnection && (!parent || !parent.handle)) {
-        if (options) {
-          options.details = 'parent connection missing handle';
-        }
-        return false;
-      }
     }
 
     if (!this.direction) {

--- a/src/runtime/recipe/handle-connection.ts
+++ b/src/runtime/recipe/handle-connection.ts
@@ -180,11 +180,6 @@ export class HandleConnection {
       }
     }
 
-    if (parent && !parent.handle) {
-      // Our parent doesn't resolve, we don't need to resolve.
-      return true;
-    }
-
     if(!this.handle) {
       if(this.isOptional) {
         // We're optional we don't need to resolve.

--- a/src/runtime/recipe/handle-connection.ts
+++ b/src/runtime/recipe/handle-connection.ts
@@ -180,8 +180,8 @@ export class HandleConnection {
       }
     }
 
-    if(!this.handle) {
-      if(this.isOptional) {
+    if (!this.handle) {
+      if (this.isOptional) {
         // We're optional we don't need to resolve.
         return true;
       }

--- a/src/runtime/test/arc-tests.ts
+++ b/src/runtime/test/arc-tests.ts
@@ -306,7 +306,7 @@ describe('Arc', () => {
     /.*unresolved handle-connection: parent connection missing handle/)
   );
 
-  it('optional provided handles are not required to resolve with depedencies', async () => {
+  it('optional provided handles are not required to resolve with dependencies', async () => {
     const loader = new Loader();
     const manifest = await Manifest.parse(`
       schema Thing
@@ -353,7 +353,7 @@ describe('Arc', () => {
     await util.assertSingletonWillChangeTo(arc, dStore, 'value', '(null)');
   });
 
-  it('required provided handles must resolve with depedencies', async () =>
+  it('required provided handles must resolve with dependencies', async () =>
     await assertThrowsAsync(async () => {
       const loader = new Loader();
       const manifest = await Manifest.parse(`


### PR DESCRIPTION
- Removes previous instantiation time checks that handles are correctly resolved.
- Adds tests for provided handle optionality.
- Updates isResolved to check that:
  - optional and required handle-connections can only resolve when they have no parent or their parent's handle is connected
  - additionally, unconnected required handle-connections cannot be resolved.
  - type and direction are checked after connections are checked (this ensures that disconnected handle-connections do not cause failures).