### PR TITLE
pipes-shell: automatically match recipes to entity types for autofill

### DIFF
--- a/particles/PipeApps/MapsAutofill.recipes
+++ b/particles/PipeApps/MapsAutofill.recipes
@@ -8,13 +8,6 @@ particle SuggestAddress in './source/SuggestAddress.js'
   out Json suggestion
   consume app
 
-recipe MapsAutofill
-  map 'pipe-entities' as recentEntities
-  create as suggestion
-  SuggestAddress
-    recentEntities = recentEntities
-    suggestion = suggestion
-
 recipe Com_google_android_apps_maps &autofill
   map 'pipe-entities' as recentEntities
   create as suggestion

--- a/particles/PipeApps/MapsAutofill.recipes
+++ b/particles/PipeApps/MapsAutofill.recipes
@@ -14,3 +14,10 @@ recipe MapsAutofill
   SuggestAddress
     recentEntities = recentEntities
     suggestion = suggestion
+
+recipe Com_google_android_apps_maps &autofill
+  map 'pipe-entities' as recentEntities
+  create as suggestion
+  SuggestAddress
+    recentEntities = recentEntities
+    suggestion = suggestion

--- a/shells/lib/utils.js
+++ b/shells/lib/utils.js
@@ -37,7 +37,9 @@ const parse = async (content, options) => {
 };
 
 const resolve = async (arc, recipe) =>{
-  if (recipe.normalize()) {
+  if (!recipe.normalize()) {
+    warn('failed to normalize:\n', recipe.toString());
+  } else {
     let plan = recipe;
     if (!plan.isResolved()) {
       const resolver = new RecipeResolver(arc);

--- a/shells/pipes-shell/README.md
+++ b/shells/pipes-shell/README.md
@@ -34,3 +34,11 @@ pipes-shell/web/index.html?log[=[0..2]]&remote-explore-key=[key]
 
 - remote-explore-key
   - used to connect to remote devtools (aka Arcs Explorer)
+
+## Glitch Support
+
+- pipes-shell imports `custom.recipes` from https://thorn-egret.glitch.me/
+- `ShellApi.flush()` available clear caches (let changes to the glitch go into effect)
+- tries to fail gracefully if `ArtistAutofill` isn't available
+
+Note that the files in the glitch are copies of files in `particles/PipesApps` folder in the main repository (iow, they won't get lost if the glitch is blown up).

--- a/shells/pipes-shell/context.js
+++ b/shells/pipes-shell/context.js
@@ -29,10 +29,9 @@ export const Context = class {
   }
   async initPipesArc(storage) {
     console.log('Context::initPipesArc');
+    const host = new ArcHost(null, storage, new RamSlotComposer());
     const id = 'pipes-arc';
     const manifest = `import 'https://$particles/PipeApps/BackgroundPipes.recipes'`;
-    const composer = new RamSlotComposer();
-    const host = new ArcHost(null, storage, composer);
     this.pipesArc = await host.spawn({id, manifest});
     // TODO(sjmiles): findById would be better,
     // but I can't get the id to materialize via manifest

--- a/shells/pipes-shell/device.js
+++ b/shells/pipes-shell/device.js
@@ -6,14 +6,25 @@ import {Utils} from '../lib/utils.js';
 // TODO(sjmiles): why not automatic?
 SyntheticStores.init();
 
-let userContext;
+let recipes;
 let client;
+let userContext;
 let testMode;
 
-export const DeviceApiFactory = (storage, deviceClient) => {
+export const DeviceApiFactory = async (storage, deviceClient) => {
+  recipes = await marshalRecipeContext();
+  console.log('supported types:', recipes.map(recipe => recipe.name.toLowerCase().replace(/_/g, '.')));
   client = deviceClient;
   userContext = new Context(storage);
   return deviceApi;
+};
+
+const marshalRecipeContext = async () => {
+  const recipeManifest = await Utils.parse(`
+import 'https://thorn-egret.glitch.me/custom.recipes'
+import 'https://$particles/PipeApps/MapsAutofill.recipes'
+  `);
+  return recipeManifest.findRecipesByVerb('autofill');
 };
 
 const deviceApi = {
@@ -30,16 +41,6 @@ const deviceApi = {
   flush() {
     console.log('flushing caches...');
     Utils.env.loader.flushCaches();
-  },
-  async test() {
-    const manifest = await Utils.parse(`
-import 'https://thorn-egret.glitch.me/ArtistAutofill.recipes'
-import 'https://$particles/PipeApps/MapsAutofill.recipes'
-    `);
-    const recipes = manifest.findRecipesByVerb('autofill');
-    const names = recipes.map(recipe => recipe.name.toLowerCase());
-    console.log('autofill recipes: ', names);
-    return manifest;
   }
 };
 
@@ -58,7 +59,7 @@ const receiveJsonEntity = async json => {
   try {
     testMode = !json;
     if (userContext.pipesArc) {
-      return await Pipe.receiveEntity(userContext.context, callback, json);
+      return await Pipe.receiveEntity(userContext.context, recipes, callback, json);
     }
   } catch (x) {
     console.error(x);

--- a/shells/pipes-shell/device.js
+++ b/shells/pipes-shell/device.js
@@ -30,6 +30,16 @@ const deviceApi = {
   flush() {
     console.log('flushing caches...');
     Utils.env.loader.flushCaches();
+  },
+  async test() {
+    const manifest = await Utils.parse(`
+import 'https://thorn-egret.glitch.me/ArtistAutofill.recipes'
+import 'https://$particles/PipeApps/MapsAutofill.recipes'
+    `);
+    const recipes = manifest.findRecipesByVerb('autofill');
+    const names = recipes.map(recipe => recipe.name.toLowerCase());
+    console.log('autofill recipes: ', names);
+    return manifest;
   }
 };
 

--- a/shells/pipes-shell/node/node.js
+++ b/shells/pipes-shell/node/node.js
@@ -27,12 +27,12 @@ import {DeviceApiFactory} from '../device.js';
 //
 // results returned via `DeviceClient.foundSuggestions(json)` (if it exists)
 
-global.ShellApi = DeviceApiFactory(`volatile://`, global.DeviceClient);
-
-console.log(`version: feb-27.0`);
-
-// configure arcs environment
-Utils.init(global.envPaths.root, global.envPaths.map);
+(async () => {
+  console.log(`version: feb-27.0`);
+  global.ShellApi = await DeviceApiFactory(`volatile://`, global.DeviceClient);
+  // configure arcs environment
+  Utils.init(global.envPaths.root, global.envPaths.map);
+})();
 
 // test it
 

--- a/shells/pipes-shell/web/devtools.js
+++ b/shells/pipes-shell/web/devtools.js
@@ -1,0 +1,12 @@
+
+import {DevtoolsConnection} from '../../../build/runtime/debug/devtools-connection.js';
+
+// TODO(sjmiles): move into a module?
+export const devtools = async () => {
+  const params = (new URL(document.location)).searchParams;
+  if (params.has('remote-explore-key')) {
+    // Wait for the remote Arcs Explorer to connect before starting the Shell.
+    DevtoolsConnection.ensure();
+    await DevtoolsConnection.onceConnected;
+  }
+};

--- a/shells/pipes-shell/web/web.js
+++ b/shells/pipes-shell/web/web.js
@@ -18,7 +18,7 @@ import '../../lib/firebase-support.js';
 
 import {Utils} from '../../lib/utils.js';
 import {DeviceApiFactory} from '../device.js';
-import {DevtoolsConnection} from '../../../build/runtime/debug/devtools-connection.js';
+import {devtools} from './devtools.js';
 
 // usage:
 //
@@ -29,25 +29,18 @@ import {DevtoolsConnection} from '../../../build/runtime/debug/devtools-connecti
 //
 // results returned via `DeviceClient.foundSuggestions(json)` (if it exists)
 
-console.log(`version: feb-27.0`);
+const storage = `pouchdb://local/arcs/`;
+const version = `version: mar-06`;
 
- // TODO(sjmiles): move into a module?
-const devToolsHandshake = async () => {
-  const params = (new URL(document.location)).searchParams;
-  if (params.has('remote-explore-key')) {
-    // Wait for the remote Arcs Explorer to connect before starting the Shell.
-    DevtoolsConnection.ensure();
-    await DevtoolsConnection.onceConnected;
-  }
-};
+console.log(version);
 
 (async () => {
   // if remote DevTools are requested, wait for connect
-  await devToolsHandshake();
+  await devtools();
   // configure arcs environment
   Utils.init(window.envPaths.root, window.envPaths.map);
   // configure ShellApi (window.DeviceClient is bound in by outer process, otherwise undefined)
-  window.ShellApi = DeviceApiFactory('pouchdb://local/arcs/', window.DeviceClient);
+  window.ShellApi = await DeviceApiFactory(storage, window.DeviceClient);
   // for testing
   window.onclick = () => {
     window.ShellApi.receiveEntity();


### PR DESCRIPTION
- Instead of hard mapping `entity.type` to handlers, pipes-shell locates recipes with verb `autofill` and type-appropriate names.
- Glitch entry-point switched back to `custom.recipes` so it can provide any custom artifacts (formerly `ArtistAutofill.recipes`).
- minor refactoring

