### PR TITLE
Add slot related helper interfaces

### DIFF
--- a/src/planning/headless-suggest-dom-consumer.ts
+++ b/src/planning/headless-suggest-dom-consumer.ts
@@ -70,7 +70,7 @@ export class HeadlessSuggestDomConsumer extends SuggestDomConsumer {
     return container === contextContainer;
   }
   getInnerContainer(slotId) {
-    const model = this.renderings.map(([subId, {model}]) => model)[0];
+    const model = Array.from(this.renderings, ([_, {model}]) => model)[0];
     const providedContext = this.findProvidedContext(ctx => ctx.id === slotId);
     if (!providedContext) {
       console.warn(`Cannot find provided spec for ${slotId} in ${this.consumeConn.getQualifiedName()}`);

--- a/src/planning/suggest-dom-consumer.ts
+++ b/src/planning/suggest-dom-consumer.ts
@@ -10,8 +10,8 @@
 
 import {Arc} from '../runtime/arc.js';
 import {Modality} from '../runtime/modality.js';
-import {SlotDomConsumer} from '../runtime/slot-dom-consumer.js';
-import {Content, Rendering} from '../runtime/slot-consumer.js';
+import {SlotDomConsumer, DomRendering} from '../runtime/slot-dom-consumer.js';
+import {Content} from '../runtime/slot-consumer.js';
 import {Suggestion} from './plan/suggestion.js';
 
 export class SuggestDomConsumer extends SlotDomConsumer {
@@ -61,7 +61,7 @@ export class SuggestDomConsumer extends SlotDomConsumer {
     }
     const suggestionContainer = Object.assign(document.createElement('suggestion-element'), {plan: suggestion});
     container.appendChild(suggestionContainer, container.firstElementChild);
-    const rendering: Rendering = {container: suggestionContainer, model: content.model};
+    const rendering: DomRendering = {container: suggestionContainer, model: content.model};
     const consumer = new SlotDomConsumer(arc);
     consumer.addRenderingBySubId(undefined, rendering);
     consumer.eventHandler = (() => {});

--- a/src/planning/suggest-dom-consumer.ts
+++ b/src/planning/suggest-dom-consumer.ts
@@ -11,7 +11,7 @@
 import {Arc} from '../runtime/arc.js';
 import {Modality} from '../runtime/modality.js';
 import {SlotDomConsumer} from '../runtime/slot-dom-consumer.js';
-
+import {Content, Render} from '../runtime/slot-consumer.js';
 import {Suggestion} from './plan/suggestion.js';
 
 export class SuggestDomConsumer extends SlotDomConsumer {
@@ -34,7 +34,7 @@ export class SuggestDomConsumer extends SlotDomConsumer {
     return 'suggest';
   }
 
-  formatContent(content) {
+  formatContent(content: Content): Content | undefined {
     return {
       template: `<suggestion-element inline key="{{hash}}" on-click="">${content.template}</suggestion-element>`,
       templateName: 'suggestion',
@@ -61,7 +61,7 @@ export class SuggestDomConsumer extends SlotDomConsumer {
     }
     const suggestionContainer = Object.assign(document.createElement('suggestion-element'), {plan: suggestion});
     container.appendChild(suggestionContainer, container.firstElementChild);
-    const rendering = {container: suggestionContainer, model: content.model};
+    const rendering: Render = {container: suggestionContainer, model: content.model};
     const consumer = new SlotDomConsumer(arc);
     consumer.addRenderingBySubId(undefined, rendering);
     consumer.eventHandler = (() => {});

--- a/src/planning/suggest-dom-consumer.ts
+++ b/src/planning/suggest-dom-consumer.ts
@@ -11,7 +11,7 @@
 import {Arc} from '../runtime/arc.js';
 import {Modality} from '../runtime/modality.js';
 import {SlotDomConsumer} from '../runtime/slot-dom-consumer.js';
-import {Content, Render} from '../runtime/slot-consumer.js';
+import {Content, Rendering} from '../runtime/slot-consumer.js';
 import {Suggestion} from './plan/suggestion.js';
 
 export class SuggestDomConsumer extends SlotDomConsumer {
@@ -61,7 +61,7 @@ export class SuggestDomConsumer extends SlotDomConsumer {
     }
     const suggestionContainer = Object.assign(document.createElement('suggestion-element'), {plan: suggestion});
     container.appendChild(suggestionContainer, container.firstElementChild);
-    const rendering: Render = {container: suggestionContainer, model: content.model};
+    const rendering: Rendering = {container: suggestionContainer, model: content.model};
     const consumer = new SlotDomConsumer(arc);
     consumer.addRenderingBySubId(undefined, rendering);
     consumer.eventHandler = (() => {});

--- a/src/runtime/headless-slot-dom-consumer.ts
+++ b/src/runtime/headless-slot-dom-consumer.ts
@@ -49,7 +49,7 @@ export class HeadlessSlotDomConsumer extends SlotDomConsumer {
   }
 
   getInnerContainer(slotId) {
-    const model = this.renderings.map(([subId, {model}]) => model)[0];
+    const model = Array.from(this.renderings, ([_, {model}]) => model)[0];
     const providedContext = this.findProvidedContext(ctx => ctx.id === slotId);
     if (!providedContext) {
       console.warn(`Cannot find provided spec for ${slotId} in ${this.consumeConn.getQualifiedName()}`);

--- a/src/runtime/recipe/slot-connection.ts
+++ b/src/runtime/recipe/slot-connection.ts
@@ -39,7 +39,7 @@ export class SlotConnection {
   getQualifiedName() { return `${this.particle.name}::${this.name}`; }
   get targetSlot() { return this._targetSlot; }
   set targetSlot(targetSlot: Slot | undefined) { this._targetSlot = targetSlot; }
-  
+
   get providedSlots() { return this._providedSlots; }
   get tags() { return this._tags; }
   set tags(tags) { this._tags = tags; }
@@ -63,7 +63,7 @@ export class SlotConnection {
       this._targetSlot = undefined;
     }
   }
-  
+
   _clone(particle, cloneMap) {
     if (cloneMap.has(this)) {
       return cloneMap.get(this);

--- a/src/runtime/slot-consumer.ts
+++ b/src/runtime/slot-consumer.ts
@@ -15,6 +15,23 @@ import {Description} from './description.js';
 import {SlotConnection} from './recipe/slot-connection.js';
 import {HostedSlotContext, ProvidedSlotContext, SlotContext} from './slot-context.js';
 
+export interface Model {
+  id: string;
+}
+
+export interface Content {
+  templateName?: string | Map<string, string>;
+  model?: {models: Model, hash: string};
+  descriptions?: Map<string, Description>;
+  template?: string | Map<string, {}>;
+}
+
+export interface Render {
+  container?: {};
+  model?: {items: {models: Model[]}, subId: {}, message: {}};
+  templateName?: string;
+}
+
 export class SlotConsumer {
   public readonly consumeConn?: SlotConnection;
   slotContext: SlotContext;
@@ -26,7 +43,7 @@ export class SlotConsumer {
   readonly containerKind?: string;
   // Contains `container` and other modality specific rendering information
   // (eg for `dom`: model, template for dom renderer) by sub id. Key is `undefined` for singleton slot.
-  private _renderingBySubId: Map<string|undefined, {container?: {}, model?, templateName?: string}> = new Map();
+  private _renderingBySubId: Map<string|undefined, Render> = new Map();
   private innerContainerBySlotId: {} = {};
   public readonly arc: Arc;
   private _description: Description;
@@ -42,9 +59,9 @@ export class SlotConsumer {
     this._description = await Description.create(this.arc);
   }
 
-  getRendering(subId?) { return this._renderingBySubId.get(subId); }
-  get renderings() { return [...this._renderingBySubId.entries()]; }
-  addRenderingBySubId(subId: string|undefined, rendering) {
+  getRendering(subId?): Render { return this._renderingBySubId.get(subId); }
+  get renderings(): [string, Render][] { return [...this._renderingBySubId.entries()]; }
+  addRenderingBySubId(subId: string|undefined, rendering: Render) {
     this._renderingBySubId.set(subId, rendering);
   }
 
@@ -143,7 +160,7 @@ export class SlotConsumer {
     }
   }
 
-  setContent(content, handler) {
+  setContent(content: Content, handler) {
     if (content && Object.keys(content).length > 0 && this.description) {
       content.descriptions = this.populateHandleDescriptions();
     }
@@ -153,9 +170,9 @@ export class SlotConsumer {
     }
   }
 
-  populateHandleDescriptions() {
-    if (!this.consumeConn) return null;
-    const descriptions = {};
+  populateHandleDescriptions(): Map<string, Description> {
+    if (!this.consumeConn) return null; // TODO: remove null ability
+    const descriptions: Map<string, Description> = new Map();
     Object.values(this.consumeConn.particle.connections).map(handleConn => {
       if (handleConn.handle) {
         descriptions[`${handleConn.name}.description`] =
@@ -200,8 +217,8 @@ export class SlotConsumer {
   createNewContainer(contextContainer, subId): {} { return null; }
   deleteContainer(container) {}
   clearContainer(rendering) {}
-  setContainerContent(rendering, content, subId) {}
-  formatContent(content, subId): object { return null; }
-  formatHostedContent(content): {} { return null; }
+  setContainerContent(rendering, content: Content, subId) {}
+  formatContent(content: Content, subId): Content { return null; }
+  formatHostedContent(content: Content): {} { return null; }
   static clear(container) {}
 }

--- a/src/runtime/slot-consumer.ts
+++ b/src/runtime/slot-consumer.ts
@@ -17,6 +17,7 @@ import {HostedSlotContext, ProvidedSlotContext, SlotContext} from './slot-contex
 
 export interface Content {
   templateName?: string | Map<string, string>;
+  // tslint:disable-next-line: no-any
   model?: {models: any, hash: string};
   descriptions?: Map<string, Description>;
   template?: string | Map<string, string>;

--- a/src/runtime/slot-consumer.ts
+++ b/src/runtime/slot-consumer.ts
@@ -15,20 +15,23 @@ import {Description} from './description.js';
 import {SlotConnection} from './recipe/slot-connection.js';
 import {HostedSlotContext, ProvidedSlotContext, SlotContext} from './slot-context.js';
 
-export interface Model {
-  id: string;
-}
-
 export interface Content {
   templateName?: string | Map<string, string>;
-  model?: {models: Model, hash: string};
+  model?: {models: any, hash: string};
   descriptions?: Map<string, Description>;
-  template?: string | Map<string, {}>;
+  template?: string | Map<string, string>;
 }
 
-export interface Render {
-  container?: {};
-  model?: {items: {models: Model[]}, subId: {}, message: {}};
+export interface Rendering {
+  // The 'parent' or owning object in the UI.
+  // TODO(jopra): At some point we should write an interface for this.
+  // tslint:disable-next-line: no-any
+  container?: any;
+  // The data to be used in templating.
+  // tslint:disable-next-line: no-any
+  model?: any;
+  // Specifies a particular template from the set of templates available to the
+  // slot.
   templateName?: string;
 }
 
@@ -43,7 +46,7 @@ export class SlotConsumer {
   readonly containerKind?: string;
   // Contains `container` and other modality specific rendering information
   // (eg for `dom`: model, template for dom renderer) by sub id. Key is `undefined` for singleton slot.
-  private _renderingBySubId: Map<string|undefined, Render> = new Map();
+  private _renderingBySubId: Map<string|undefined, Rendering> = new Map();
   private innerContainerBySlotId: {} = {};
   public readonly arc: Arc;
   private _description: Description;
@@ -59,9 +62,9 @@ export class SlotConsumer {
     this._description = await Description.create(this.arc);
   }
 
-  getRendering(subId?): Render { return this._renderingBySubId.get(subId); }
-  get renderings(): [string, Render][] { return [...this._renderingBySubId.entries()]; }
-  addRenderingBySubId(subId: string|undefined, rendering: Render) {
+  getRendering(subId?): Rendering { return this._renderingBySubId.get(subId); }
+  get renderings(): [string, Rendering][] { return [...this._renderingBySubId.entries()]; }
+  addRenderingBySubId(subId: string|undefined, rendering: Rendering) {
     this._renderingBySubId.set(subId, rendering);
   }
 

--- a/src/runtime/slot-context.ts
+++ b/src/runtime/slot-context.ts
@@ -13,7 +13,7 @@ import {assert} from '../platform/assert-web.js';
 import {Description} from './description.js';
 import {ProvidedSlotSpec} from './particle-spec.js';
 import {Handle} from './recipe/handle.js';
-import {SlotConsumer} from './slot-consumer.js';
+import {SlotConsumer, Content} from './slot-consumer.js';
 
 /**
  * Represents a single slot in the rendering system.
@@ -38,7 +38,7 @@ export abstract class SlotContext {
     this.slotConsumers.length = 0;
   }
 
-  abstract onRenderSlot(consumer: SlotConsumer, content, handler);
+  abstract onRenderSlot(consumer: SlotConsumer, content: Content, handler);
   abstract get containerAvailable(): boolean;
 }
 
@@ -69,12 +69,12 @@ export class HostedSlotContext extends SlotContext {
     transformationSlotConsumer.addHostedSlotContexts(this);
   }
 
-  onRenderSlot(consumer: SlotConsumer, content, handler) {
+  onRenderSlot(consumer: SlotConsumer, content: Content, handler) {
     this.sourceSlotConsumer.arc.pec.innerArcRender(
         this.sourceSlotConsumer.consumeConn.particle,
         this.sourceSlotConsumer.consumeConn.name,
         this.id,
-        consumer.formatHostedContent(content));    
+        consumer.formatHostedContent(content));
   }
 
   addSlotConsumer(consumer: SlotConsumer) {
@@ -132,7 +132,7 @@ export class ProvidedSlotContext extends SlotContext {
       : [];
   }
 
-  onRenderSlot(consumer: SlotConsumer, content, handler) {
+  onRenderSlot(consumer: SlotConsumer, content: Content, handler) {
     consumer.setContent(content, handler);
   }
 

--- a/src/runtime/slot-dom-consumer.ts
+++ b/src/runtime/slot-dom-consumer.ts
@@ -15,8 +15,12 @@ import {assert} from '../platform/assert-web.js';
 import {Arc} from './arc.js';
 import {Description} from './description.js';
 import {SlotConnection} from './recipe/slot-connection.js';
-import {SlotConsumer, Content} from './slot-consumer.js';
+import {SlotConsumer, Content, Rendering} from './slot-consumer.js';
 import {ProvidedSlotContext} from './slot-context.js';
+
+export interface DomRendering extends Rendering {
+  liveDom?: Template;
+}
 
 const templateByName = new Map();
 
@@ -124,7 +128,7 @@ export class SlotDomConsumer extends SlotConsumer {
     return subId === model.subId ? model : null;
   }
 
-  setContainerContent(rendering, content: Content, subId) {
+  setContainerContent(rendering: DomRendering, content: Content, subId) {
     if (!rendering.container) {
       return;
     }
@@ -141,7 +145,7 @@ export class SlotDomConsumer extends SlotConsumer {
     this._onUpdate(rendering);
   }
 
-  clearContainer(rendering) {
+  clearContainer(rendering: DomRendering) {
     if (rendering.liveDom) {
       rendering.liveDom.root.textContent = '';
     }
@@ -183,7 +187,7 @@ export class SlotDomConsumer extends SlotConsumer {
     return this.consumeConn.getQualifiedName();
   }
 
-  _setTemplate(rendering, templatePrefix, templateName, template) {
+  _setTemplate(rendering: DomRendering, templatePrefix, templateName, template) {
     if (templateName) {
       rendering.templateName = [templatePrefix, templateName].filter(s => s).join('::');
       if (template) {
@@ -197,7 +201,7 @@ export class SlotDomConsumer extends SlotConsumer {
     }
   }
 
-  _onUpdate(rendering) {
+  _onUpdate(rendering: DomRendering) {
     this._observe(rendering.container);
 
     if (rendering.templateName) {
@@ -221,7 +225,7 @@ export class SlotDomConsumer extends SlotConsumer {
     }
   }
 
-  _stampTemplate(rendering, template) {
+  _stampTemplate(rendering: DomRendering, template) {
     if (!rendering.liveDom) {
       // TODO(sjmiles): hack to allow subtree elements (e.g. x-list) to marshal events
       rendering.container._eventMapper = this._eventMapper.bind(this, this.eventHandler);
@@ -232,7 +236,7 @@ export class SlotDomConsumer extends SlotConsumer {
     }
   }
 
-  _updateModel(rendering) {
+  _updateModel(rendering: DomRendering) {
     if (rendering.liveDom) {
       rendering.liveDom.set(rendering.model);
     }

--- a/src/runtime/slot-dom-consumer.ts
+++ b/src/runtime/slot-dom-consumer.ts
@@ -15,7 +15,7 @@ import {assert} from '../platform/assert-web.js';
 import {Arc} from './arc.js';
 import {Description} from './description.js';
 import {SlotConnection} from './recipe/slot-connection.js';
-import {SlotConsumer} from './slot-consumer.js';
+import {SlotConsumer, Content} from './slot-consumer.js';
 import {ProvidedSlotContext} from './slot-context.js';
 
 const templateByName = new Map();
@@ -71,10 +71,10 @@ export class SlotDomConsumer extends SlotConsumer {
     }
   }
 
-  formatContent(content, subId): object {
+  formatContent(content: Content, subId: string): Content | undefined {
     assert(this.slotContext instanceof ProvidedSlotContext, 'Content formatting can only be done for provided SlotContext');
     const contextSpec = (this.slotContext as ProvidedSlotContext).spec;
-    const newContent: {model?: string | {}, templateName?: string | {}, template?: string | {}} = {};
+    const newContent: Content = {};
 
     // Format model.
     if (Object.keys(content).indexOf('model') >= 0) {
@@ -88,7 +88,7 @@ export class SlotDomConsumer extends SlotConsumer {
         } else {
           formattedModel = this._modelForSingletonSlot(content.model, subId);
         }
-        if (!formattedModel) return null;
+        if (!formattedModel) return undefined;
 
         // Merge descriptions into model.
         newContent.model = {...formattedModel, ...content.descriptions};
@@ -124,7 +124,7 @@ export class SlotDomConsumer extends SlotConsumer {
     return subId === model.subId ? model : null;
   }
 
-  setContainerContent(rendering, content, subId) {
+  setContainerContent(rendering, content: Content, subId) {
     if (!rendering.container) {
       return;
     }
@@ -331,7 +331,7 @@ export class SlotDomConsumer extends SlotConsumer {
     });
   }
 
-  formatHostedContent(content): {} {
+  formatHostedContent(content: Content): {} {
     if (content.templateName) {
       if (typeof content.templateName === 'string') {
         content.templateName = `${this.consumeConn.getQualifiedName()}::${content.templateName}`;


### PR DESCRIPTION
This adds Content and Render, two interfaces that should help us ensure the correct types are passed to our slot code. This is a first pass only and does not fix all instances of content and renderings.