### PR TITLE
Create a hooks directory to run sigh lint and sigh check

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -37,6 +37,7 @@ module.exports = {
     "comma-dangle": "off",
     "linebreak-style": "off",
     "no-multi-spaces": "off",
+    "keyword-spacing": [1, {"before": true, "after": true}]
   },
   env: {
     browser: true,

--- a/README.md
+++ b/README.md
@@ -74,6 +74,16 @@ $ ./tools/sigh
 re-run infrequently as new dependencies are included, and usually a build
 failure will be the signal for that.
 
+## Git Setup
+
+You may also find it helpful to have sigh lint and type check your work locally
+before you commit it. To do this, you can setup git to run presubmit checks
+using:
+
+```
+$ git config core.hooksPath tools/hooks
+```
+
 ### Windows Installation Notes
 
 - [Git for Windows](https://git-scm.com/downloads) is one of many Git options.

--- a/tools/hooks/pre-commit
+++ b/tools/hooks/pre-commit
@@ -1,0 +1,3 @@
+#!/bin/bash
+./tools/sigh lint
+./tools/sigh check

--- a/tools/sigh.js
+++ b/tools/sigh.js
@@ -625,7 +625,7 @@ async function watch([arg, ...moreArgs]) {
   const funs = steps[arg || 'webpack'];
   const funsAndArgs = funs.map(fun => [fun, fun == funs[funs.length - 1] ? moreArgs : []]);
   const watcher = chokidar.watch('.', {
-    ignored: /(node_modules|build\/|\.git)/,
+    ignored: new RegExp('(node_modules|build/|.git|'+eslintCache+')'),
     persistent: true
   });
   let timerId = 0;

--- a/tools/sigh.js
+++ b/tools/sigh.js
@@ -625,7 +625,7 @@ async function watch([arg, ...moreArgs]) {
   const funs = steps[arg || 'webpack'];
   const funsAndArgs = funs.map(fun => [fun, fun == funs[funs.length - 1] ? moreArgs : []]);
   const watcher = chokidar.watch('.', {
-    ignored: new RegExp('(node_modules|build/|.git|'+eslintCache+')'),
+    ignored: new RegExp(`(node_modules|build/|.git|${eslintCache})`),
     persistent: true
   });
   let timerId = 0;


### PR DESCRIPTION
Makes it easier for developers to have linting and checking performed before git commit.
Adds keyword spacing to our eslint rules.