### PR TITLE
Provided slots are owned by their particle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ enclave/toolchains
 enclave/host/storage/db.img
 enclave/host/storage/key
 build
+src/gen
 coverage
 .vscode
 devtools/build

--- a/src/planning/strategies/create-handle-group.ts
+++ b/src/planning/strategies/create-handle-group.ts
@@ -53,19 +53,19 @@ export class CreateHandleGroup extends Strategy {
           }
         }
 
-        if (maximalGroup) {
-          return recipe => {
-            const newHandle = recipe.newHandle();
-            newHandle.fate = 'create';
-            for (const {particle, connSpec} of maximalGroup) {
-              const cloneParticle = recipe.updateToClone({particle}).particle;
-              const conn = cloneParticle.addConnectionName(connSpec.name);
-              conn.connectToHandle(newHandle);
-            }
-            return 0;
-          };
+        if (!maximalGroup) {
+          return undefined;
         }
-        return undefined;
+        return (recipe: Recipe) => {
+          const newHandle = recipe.newHandle();
+          newHandle.fate = 'create';
+          for (const {particle, connSpec} of maximalGroup) {
+            const cloneParticle = recipe.updateToClone({particle}).particle;
+            const conn = cloneParticle.addConnectionName(connSpec.name);
+            conn.connectToHandle(newHandle);
+          }
+          return 0;
+        };
       }
     }(StrategizerWalker.Independent), this);
   }

--- a/src/platform/pec-industry-web.ts
+++ b/src/platform/pec-industry-web.ts
@@ -34,7 +34,7 @@ const pecIndustry = loader => {
 const provisionWorkersUrls = loader => {
   workerUrl = loader._resolve(WORKER_PATH);
   loader.provisionObjectUrl(workerUrl).then((url: string) => workerBlobUrl = url);
-}
+};
 
 const _expandUrls = urlMap => {
   const remap = {};

--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -880,7 +880,7 @@ ${e.message}
                   `Consumed slot '${slotConnectionItem.param}' is not defined by '${particle.name}'`);
             }
             slotConnectionItem.dependentSlotConnections.forEach(ps => {
-              if (!particle.spec.slotConnections.get(slotConnectionItem.param).getProvidedSlotSpec(ps.param)) {
+              if (!particle.getSlotSpecByName(ps.param)) {
                 throw new ManifestError(
                     ps.location,
                     `Provided slot '${ps.param}' is not defined by '${particle.name}'`);

--- a/src/runtime/recipe/particle.ts
+++ b/src/runtime/recipe/particle.ts
@@ -6,7 +6,7 @@
 // http://polymer.github.io/PATENTS.txt
 
 import {assert} from '../../platform/assert-web.js';
-import {HandleConnectionSpec, ParticleSpec, ProvideSlotConnectionSpec, ConsumeSlotConnectionSpec} from '../particle-spec.js';
+import {ParticleSpec, ProvideSlotConnectionSpec, ConsumeSlotConnectionSpec} from '../particle-spec.js';
 import {Schema} from '../schema.js';
 import {TypeVariableInfo} from '../type-variable-info.js';
 import {InterfaceType, Type} from '../type.js';
@@ -313,7 +313,17 @@ export class Particle {
   }
 
   getSlotSpecByName(name: string) : ConsumeSlotConnectionSpec {
-    return this.spec && this.spec.slotConnections.get(name);
+    if(!this.spec) return undefined;
+    const slot = this.spec.slotConnections.get(name);
+    if(slot) return slot;
+
+    // TODO(jopra): Provided slots should always be listed in the particle spec.
+    for (const slot of this.spec.slotConnections.values()) {
+      for(const provided of slot.provideSlotConnections) {
+        if(provided.name === name) return provided;
+      }
+    }
+    return undefined;
   }
 
   getSlotConnectionByName(name: string) : SlotConnection {

--- a/src/runtime/recipe/recipe-walker.ts
+++ b/src/runtime/recipe/recipe-walker.ts
@@ -47,7 +47,7 @@ export class RecipeWalker extends Walker<Recipe> {
     if (this.onPotentialHandleConnection) {
       for (const particle of recipe.particles) {
         if (particle.spec) {
-          for (const connectionSpec of particle.spec.handleConnections) {
+          for (const connectionSpec of particle.spec.handleConnectionMap.values()) {
             if (particle.connections[connectionSpec.name]) {
               continue;
             }

--- a/src/runtime/recipe/recipe.ts
+++ b/src/runtime/recipe/recipe.ts
@@ -638,9 +638,8 @@ export class Recipe {
   }
 
   get allSpecifiedConnections(): {particle: Particle, connSpec: HandleConnectionSpec}[] {
-    return [].concat(...
-        this.particles.filter(p => p.spec && p.spec.handleConnections.length > 0)
-                      .map(particle => particle.spec.handleConnections.map(connSpec => ({particle, connSpec}))));
+    return [].concat(...this.particles.filter(p => p.spec && p.spec.connections).map(
+      particle => particle.spec.connections.map(connSpec => ({particle, connSpec}))));
   }
 
   getFreeConnections(type?: Type): {particle: Particle, connSpec: HandleConnectionSpec}[] {

--- a/src/runtime/recipe/slot-connection.ts
+++ b/src/runtime/recipe/slot-connection.ts
@@ -182,11 +182,11 @@ export class SlotConnection {
       const providedSlot = this.providedSlots[psName];
       const provideRes = [];
       provideRes.push('  provide');
-      
+
       // Only assert that there's a spec for this provided slot if there's a spec for
       // the consumed slot .. otherwise this is just a constraint.
       if (this.getSlotSpec()) {
-        const providedSlotSpec = this.getSlotSpec().getProvidedSlotSpec(psName);
+        const providedSlotSpec = this.particle.getSlotSpecByName(psName);
         assert(providedSlotSpec, `Cannot find providedSlotSpec for ${psName}`);
       }
       provideRes.push(`${psName} as ${(nameMap && nameMap.get(providedSlot)) || providedSlot}`);

--- a/src/runtime/recipe/slot.ts
+++ b/src/runtime/recipe/slot.ts
@@ -46,12 +46,12 @@ export class Slot {
   get spec() {
     // TODO: should this return something that indicates this isn't available yet instead of
     // the constructed {isSet: false, tags: []}?
-    return (this.sourceConnection && this.sourceConnection.getSlotSpec()) ? this.sourceConnection.getSlotSpec().getProvidedSlotSpec(this.name) : {isSet: false, tags: []};
+    return (this.sourceConnection && this.sourceConnection.getSlotSpec()) ? this.sourceConnection.particle.getSlotSpecByName(this.name) : {isSet: false, tags: []};
   }
   get handles(): Handle[] {
     const handles = [];
     if (this.sourceConnection && this.sourceConnection.getSlotSpec()) {
-      for (const handleName of this.sourceConnection.getSlotSpec().getProvidedSlotSpec(this.name).handles) {
+      for (const handleName of this.sourceConnection.particle.getSlotSpecByName(this.name).handles) {
         const handleConn = this.sourceConnection.particle.connections[handleName];
         if (handleConn || handleConn.handle) {
           handles.push(handleConn.handle);


### PR DESCRIPTION
Preparation work for slandles and interface types as the particle is the 'source of truth' for provided slots (as it is for handles).

This
- Merges the concepts of ProvideSlotSpec[s] and SlotSpec[s]
- Makes the fields of SlotSpec optional (they aren't expected to exist in a few cases, but were required).