### PR TITLE
Separate search box per devtools-tab

### DIFF
--- a/devtools/src/arcs-devtools-app.js
+++ b/devtools/src/arcs-devtools-app.js
@@ -6,8 +6,6 @@ import '../deps/@polymer/iron-icons/social-icons.js';
 import '../deps/@polymer/iron-icons/communication-icons.js';
 import '../deps/@polymer/iron-pages/iron-pages.js';
 import '../deps/@polymer/iron-selector/iron-selector.js';
-import {IronA11yKeysBehavior} from '../deps/@polymer/iron-a11y-keys-behavior/iron-a11y-keys-behavior.js';
-import {mixinBehaviors} from '../deps/@polymer/polymer/lib/legacy/class.js';
 import {PolymerElement} from '../deps/@polymer/polymer/polymer-element.js';
 import './arcs-overview.js';
 import './arcs-stores.js';
@@ -22,7 +20,7 @@ import './strategy-explorer/strategy-explorer.js';
 import './arcs-recipe-editor.js';
 import {html} from '../deps/@polymer/polymer/lib/utils/html-tag.js';
 
-class ArcsDevtoolsApp extends mixinBehaviors([IronA11yKeysBehavior], MessengerMixin(PolymerElement)) {
+class ArcsDevtoolsApp extends MessengerMixin(PolymerElement) {
   static get template() {
     return html`
     <style include="shared-styles">
@@ -67,7 +65,7 @@ class ArcsDevtoolsApp extends mixinBehaviors([IronA11yKeysBehavior], MessengerMi
       iron-selector a:not(.iron-selected):hover {
         background-color: #eaeaea;
       }
-      @media (max-width: 800px) {
+      @media (max-width: 600px) {
         .header iron-selector a {
           font-size: 0;
           padding: 0;
@@ -76,6 +74,10 @@ class ArcsDevtoolsApp extends mixinBehaviors([IronA11yKeysBehavior], MessengerMi
           display: inline-block;
           margin: 0;
         }
+      }
+      .header iron-selector a [tab-header] {
+        vertical-align: middle;
+        line-height: 27px;
       }
       iron-pages {
         grid-area: main;
@@ -87,21 +89,6 @@ class ArcsDevtoolsApp extends mixinBehaviors([IronA11yKeysBehavior], MessengerMi
         bottom: 0;
         left: 0;
         right: 0;
-      }
-      #search {
-        outline: 0;
-        border: 1px solid white;
-        padding: 2px;
-        margin: 0 6px 0 3px;
-      }
-      #search:hover {
-        border-color: var(--mid-gray);
-      }
-      #search:focus {
-        border-color: var(--focus-blue);
-      }
-      .invalidRegex {
-        color: red;
       }
       arcs-notifications:not([visible])  + [divider] {
         display: none;
@@ -119,26 +106,22 @@ class ArcsDevtoolsApp extends mixinBehaviors([IronA11yKeysBehavior], MessengerMi
           <arcs-selector active-page="[[routeData.page]]"></arcs-selector>
           <div divider></div>
           <iron-selector selected="[[routeData.page]]" attr-for-selected="name" role="navigation">
-            <a name="overview" href="#overview"><iron-icon icon="timeline" title="Overview"></iron-icon>Overview</a>
-            <a name="stores" href="#stores"><iron-icon icon="device:sd-storage" title="Storage"></iron-icon>Storage</label></a>
-            <a name="pecLog" href="#pecLog"><iron-icon icon="swap-horiz" title="Execution Log"></iron-icon>Execution Log</a>
-            <a name="strategyExplorer" href="#strategyExplorer"><iron-icon icon="settings-applications" title="Strategizer"></iron-icon>Strategizer</a>
-            <a name="planning" href="#planning"><iron-icon icon="line-weight" title="Planner"></iron-icon>Planner</a>
-            <a name="traces" href="#traces"><iron-icon icon="communication:clear-all" title="Tracing"></iron-icon>Tracing</a>
-            <a name="recipeEditor" href="#recipeEditor"><iron-icon icon="image:edit" title="Editor"></iron-icon>Editor</a>
+            <a name="overview" href="#overview"><iron-icon icon="timeline" title="Overview"></iron-icon><span tab-header>Overview</span></a>
+            <a name="stores" href="#stores"><iron-icon icon="device:sd-storage" title="Storage"></iron-icon><span tab-header>Storage</span></a>
+            <a name="pecLog" href="#pecLog"><iron-icon icon="swap-horiz" title="Execution Log"></iron-icon><span tab-header>Execution Log</span></a>
+            <a name="strategyExplorer" href="#strategyExplorer"><iron-icon icon="settings-applications" title="Strategizer"></iron-icon><span tab-header>Strategizer</span></a>
+            <a name="planning" href="#planning"><iron-icon icon="line-weight" title="Planner"></iron-icon><span tab-header>Planner</span></a>
+            <a name="traces" href="#traces"><iron-icon icon="communication:clear-all" title="Tracing"></iron-icon><span tab-header>Tracing</span></a>
+            <a name="recipeEditor" href="#recipeEditor"><iron-icon icon="image:edit" title="Editor"></iron-icon><span tab-header>Editor</span></a>
           </iron-selector>
-          <div divider></div>
-          <input placeholder="Filter" id="search" value="{{searchTextInput::input}}" title="Focus: ctrl+f, Clear: ctrl+esc, Regex: ctrl+x">
-          <input type="checkbox" id="regex" checked="{{searchRegexInput::change}}">
-          <label for="regex">Regex</label>
         </div>
       </header>
       <iron-pages selected="[[routeData.page]]" attr-for-selected="name" selected-attribute="active" role="main" id="pages">
         <arcs-overview name="overview"></arcs-overview>
-        <arcs-stores name="stores" search-params="[[searchParams]]"></arcs-stores>
+        <arcs-stores name="stores"></arcs-stores>
         <arcs-tracing name="traces"></arcs-tracing>
-        <arcs-pec-log name="pecLog" search-params="[[searchParams]]"></arcs-pec-log>
-        <strategy-explorer name="strategyExplorer" search-params="[[searchParams]]"></strategy-explorer>
+        <arcs-pec-log name="pecLog"></arcs-pec-log>
+        <strategy-explorer name="strategyExplorer"></strategy-explorer>
         <arcs-planning name="planning"></arcs-planning>
         <arcs-recipe-editor name="recipeEditor"></arcs-recipe-editor>
       </iron-pages>
@@ -148,83 +131,11 @@ class ArcsDevtoolsApp extends mixinBehaviors([IronA11yKeysBehavior], MessengerMi
 
   static get is() { return 'arcs-devtools-app'; }
 
-  static get properties() {
-    return {
-      searchTextInput: String,
-      searchRegexInput: Boolean,
-      searchParams: {
-        type: Object,
-        value: null,
-      },
-      keyEventTarget: {
-        type: Object,
-        value: function() {
-          return document.body;
-        }
-      }
-    };
-  }
-
-  static get observers() {
-    return ['_onSearchChanged(searchTextInput, searchRegexInput)'];
-  }
-
   ready() {
     super.ready();
     if (!this.routeData.page) {
       this.set('routeData.page', 'overview');
     }
-  }
-
-  // TODO: you can't enter '?' in the search field; it displays the console prefs page instead :-/
-  // See https://bugs.chromium.org/p/chromium/issues/detail?id=923338
-  _onSearchChanged(text, isRegex) {
-    if (this.searchDebounce) {
-      clearTimeout(this.searchDebounce);
-    }
-    this.searchDebounce = setTimeout(() => {
-      this.searchDebounce = null;
-      this.$.search.classList.remove('invalidRegex');
-      if (!text) {
-        this.searchParams = null;
-      } else if (isRegex) {
-        // Test that the regex is valid. Note that we don't pass the compiled RegExp in the params
-        // because different receivers may use different flags for their searches.
-        try {
-          new RegExp(text);
-        } catch (error) {
-          this.$.search.classList.add('invalidRegex');
-          return;
-        }
-        this.searchParams = {phrase: null, regex: text};
-      } else {
-        this.searchParams = {phrase: text.toLowerCase(), regex: null};
-      }
-    }, 100);
-  }
-
-  get keyBindings() {
-    return {
-      'ctrl+f': '_focus',
-      // CTRL to avoid clashing with devtools toolbar showing/hiding, which I cannot supress.
-      'ctrl+esc': '_clear',
-      'ctrl+x': '_regex'
-    };
-  }
-
-  _focus() {
-    this.$.search.focus();
-  }
-
-  _clear() {
-    this.$.search.value = '';
-    this.searchTextInput = null;
-    this.$.search.blur();
-  }
-
-  _regex() {
-    this.$.regex.checked = !this.$.regex.checked;
-    this.searchRegexInput = this.$.regex.checked;
   }
 }
 

--- a/devtools/src/arcs-pec-log.js
+++ b/devtools/src/arcs-pec-log.js
@@ -1,32 +1,22 @@
 import {PolymerElement} from '../deps/@polymer/polymer/polymer-element.js';
 import {html} from '../deps/@polymer/polymer/lib/utils/html-tag.js';
 import '../deps/@polymer/iron-list/iron-list.js';
-import {ObjectExplorer} from './object-explorer.js';
+import {ObjectExplorer} from './common/object-explorer.js';
+import './common/filter-input.js';
 import {formatTime, MessengerMixin} from './arcs-shared.js';
 
 class ArcsPecLog extends MessengerMixin(PolymerElement) {
   static get template() {
     return html`
-    <style>
+    <style include="shared-styles">
       :host {
         display: block;
       }
-      iron-list {
-        height: calc(100vh - 27px);
-      }
       #download {
-        position: absolute;
-        top: 10px;
-        right: 20px;
-        z-index: 1;
-        color: rgb(200, 200, 200);
-        cursor: default;
-        --iron-icon-height: 32px;
-        --iron-icon-width: 32px;
+        height: 20px;
       }
-      #download[enabled] {
-        color: rgb(90, 90, 90);
-        cursor: pointer;
+      iron-list {
+        height: calc(100vh - 54px);
       }
       [noPointer] {
         cursor: default;
@@ -96,7 +86,13 @@ class ArcsPecLog extends MessengerMixin(PolymerElement) {
         margin: 2px;
       }
     </style>
-    <iron-icon id="download" enabled$="{{downloadEnabled}}" icon="file-download" title="Download log" on-click="downloadLog"></iron-icon>
+    <header class="header">
+      <div section>
+        <iron-icon id="download" disabled$="{{!downloadEnabled}}" icon="file-download" title="Download log" on-click="downloadLog"></iron-icon>
+        <div divider></div>
+        <filter-input filter="{{searchParams}}"></filter-input>
+      </div>
+    </header>
     <iron-list id="list" items="{{filteredEntries}}">
       <template>
         <div entry>

--- a/devtools/src/arcs-planning.js
+++ b/devtools/src/arcs-planning.js
@@ -1,6 +1,6 @@
 import {PolymerElement} from '../deps/@polymer/polymer/polymer-element.js';
 import {formatTime, MessengerMixin} from './arcs-shared.js';
-import './object-explorer.js';
+import './common/object-explorer.js';
 import {html} from '../deps/@polymer/polymer/lib/utils/html-tag.js';
 
 class ArcsPlanning extends MessengerMixin(PolymerElement) {

--- a/devtools/src/arcs-shared.js
+++ b/devtools/src/arcs-shared.js
@@ -41,6 +41,9 @@ $_documentContainer.innerHTML = `<dom-module id="shared-styles">
         height: 24px;
         color: rgb(110, 110, 110);
       }
+      header.header iron-icon[disabled] {
+        color: rgb(180, 180, 180);
+      }
       header.header iron-icon:not([disabled]):not([active]):hover {
         color: rgb(51, 51, 51);
       }

--- a/devtools/src/arcs-stores.js
+++ b/devtools/src/arcs-stores.js
@@ -1,6 +1,6 @@
 import {PolymerElement} from '../deps/@polymer/polymer/polymer-element.js';
 import {MessengerMixin} from './arcs-shared.js';
-import './object-explorer.js';
+import './common/object-explorer.js';
 import {html} from '../deps/@polymer/polymer/lib/utils/html-tag.js';
 
 class ArcsStores extends MessengerMixin(PolymerElement) {
@@ -14,10 +14,10 @@ class ArcsStores extends MessengerMixin(PolymerElement) {
         overflow-y: scroll;
       }
       .title {
-        background-color: var(--light-gray);
+        padding: 0 8px;
+        height: 26px;
         border-bottom: 1px solid var(--mid-gray);
-        padding: 0 4px;
-        vertical-align: middle;
+        background-color: var(--light-gray);
       }
       .refresh {
         -webkit-mask-position: -84px 48px;
@@ -29,7 +29,6 @@ class ArcsStores extends MessengerMixin(PolymerElement) {
         transform: rotate(1turn);
       }
       .content {
-        background-color: white;
         border-bottom: 1px solid var(--mid-gray);
         display: flex;
         flex-direction: column;
@@ -61,11 +60,15 @@ class ArcsStores extends MessengerMixin(PolymerElement) {
         display: none;
       }
     </style>
-    <template is="dom-repeat" items="{{storeGroups}}">
-      <div class="title">
-        {{item.label}}
+    <header class="header">
+      <div section>
         <span class="devtools-icon refresh" on-click="_fetchStores"></span>
+        <div divider></div>
+        <filter-input filter="{{searchParams}}"></filter-input>
       </div>
+    </header>
+    <template is="dom-repeat" items="{{storeGroups}}">
+      <div class="title">{{item.label}}</div>
       <div class="content">
         <template is="dom-repeat" items="{{item.items}}">
           <object-explorer object="{{item}}">

--- a/devtools/src/common/filter-input.js
+++ b/devtools/src/common/filter-input.js
@@ -1,0 +1,117 @@
+import {IronA11yKeysBehavior} from '../../deps/@polymer/iron-a11y-keys-behavior/iron-a11y-keys-behavior.js';
+import {mixinBehaviors} from '../../deps/@polymer/polymer/lib/legacy/class.js';
+import {PolymerElement} from '../../deps/@polymer/polymer/polymer-element.js';
+import {html} from '../../deps/@polymer/polymer/lib/utils/html-tag.js';
+
+export class FilterInput extends mixinBehaviors([IronA11yKeysBehavior], PolymerElement) {
+  static get template() {
+    return html`
+    <style include="shared-styles">
+      :host {
+        display: block;
+      }
+      #search {
+        outline: 0;
+        border: 1px solid white;
+        padding: 2px;
+        margin-left: 3px;
+      }
+      #search:hover {
+        border-color: var(--mid-gray);
+      }
+      #search:focus {
+        border-color: var(--focus-blue);
+      }
+      .invalidRegex {
+        color: red;
+      }
+      span {
+        display: inline-block;
+      }
+    </style>
+    <input placeholder="Filter" id="search" value="{{searchTextInput::input}}" title="Focus: ctrl+f, Clear: ctrl+esc, Regex: ctrl+x">
+    <span>
+      <input type="checkbox" id="regex" checked="{{searchRegexInput::change}}">
+      <label for="regex">Regex</label>
+    </span>
+    `;
+  }
+
+  static get properties() {
+    return {
+      searchTextInput: String,
+      searchRegexInput: Boolean,
+      filter: {
+        type: Object,
+        value: null,
+        notify: true
+      },
+      keyEventTarget: {
+        type: Object,
+        value: function() {
+          return document.body;
+        }
+      }
+    };
+  }
+
+  get keyBindings() {
+    return {
+      'ctrl+f': '_focus',
+      // CTRL to avoid clashing with devtools toolbar showing/hiding, which I cannot supress.
+      'ctrl+esc': '_clear',
+      'ctrl+x': '_regex'
+    };
+  } 
+
+  static get observers() {
+    return ['_onSearchChanged(searchTextInput, searchRegexInput)'];
+  }
+
+
+  // TODO: you can't enter '?' in the search field; it displays the console prefs page instead :-/
+  // See https://bugs.chromium.org/p/chromium/issues/detail?id=923338
+  _onSearchChanged(text, isRegex) {
+    if (this.searchDebounce) {
+      clearTimeout(this.searchDebounce);
+    }
+    this.searchDebounce = setTimeout(() => {
+      this.searchDebounce = null;
+      this.$.search.classList.remove('invalidRegex');
+      if (!text) {
+        this.filter = null;
+      } else if (isRegex) {
+        // Test that the regex is valid. Note that we don't pass the compiled RegExp in the params
+        // because different receivers may use different flags for their searches.
+        try {
+          new RegExp(text);
+        } catch (error) {
+          this.$.search.classList.add('invalidRegex');
+          return;
+        }
+        this.filter = {phrase: null, regex: text};
+      } else {
+        this.filter = {phrase: text.toLowerCase(), regex: null};
+      }
+    }, 100);
+  }
+
+  _focus() {
+    this.$.search.focus();
+  }
+
+  _clear() {
+    this.$.search.value = '';
+    this.searchTextInput = null;
+    this.$.search.blur();
+  }
+
+  _regex() {
+    this.$.regex.checked = !this.$.regex.checked;
+    this.searchRegexInput = this.$.regex.checked;
+  }
+
+  static get is() { return 'filter-input'; }
+}
+
+window.customElements.define(FilterInput.is, FilterInput);

--- a/devtools/src/common/object-explorer.js
+++ b/devtools/src/common/object-explorer.js
@@ -1,5 +1,5 @@
-import {PolymerElement} from '../deps/@polymer/polymer/polymer-element.js';
-import {html} from '../deps/@polymer/polymer/lib/utils/html-tag.js';
+import {PolymerElement} from '../../deps/@polymer/polymer/polymer-element.js';
+import {html} from '../../deps/@polymer/polymer/lib/utils/html-tag.js';
 
 /**
  * ..:: Read Before Modifying ::..

--- a/devtools/src/strategy-explorer/strategy-explorer.js
+++ b/devtools/src/strategy-explorer/strategy-explorer.js
@@ -13,6 +13,7 @@ import './se-legend.js';
 import './se-recipe-view.js';
 import './se-stats.js';
 import './se-compare-populations.js';
+import '../common/filter-input.js';
 import {MessengerMixin} from '../arcs-shared.js';
 import '../../deps/@vaadin/vaadin-split-layout/vaadin-split-layout.js';
 import {PolymerElement} from '../../deps/@polymer/polymer/polymer-element.js';
@@ -38,6 +39,7 @@ class StrategyExplorer extends MessengerMixin(PolymerElement) {
         <se-explorer results="{{results}}"></se-explorer>
       </div>
       <aside style="flex: .3" class="paddedBlocks">
+        <filter-input filter="{{searchParams}}"></filter-input>
         <se-compare-populations results="{{results}}" id='compare'></se-compare-populations>
         <se-recipe-view></se-recipe-view>
         <!--<se-arc-view></se-arc-view> this is disconnected today, PRs welcome-->


### PR DESCRIPTION
Per @sjmiles request, this extracts the search/filter box and creates a separate instance per-tool.

This does make sense for the UX, as search phrases wary between tools, also we increasingly need to have per-tool bar with options, so this is also a step in this direction.

Example:
<img width="640" alt="Screen Shot 2019-03-16 at 11 33 09 AM" src="https://user-images.githubusercontent.com/26159485/54468442-acde3180-47e0-11e9-8129-799b0d1277ea.png">

While I'm there, I also fixed some positioning issues with the new "tabbed" tool switching layout.