### PR TITLE
fixups to Xen event handling

### DIFF
--- a/modalities/dom/components/xen/xen-html-import-compat.js
+++ b/modalities/dom/components/xen/xen-html-import-compat.js
@@ -1,0 +1,15 @@
+// HTMLImports compatibility stuff, delete soonish
+if (typeof document !== 'undefined' && !('currentImport' in document)) {
+  Object.defineProperty(document, 'currentImport', {
+    get() {
+      const script = this.currentScript;
+      let doc = script.ownerDocument || this;
+      // this code for CEv1 compatible HTMLImports polyfill (aka modern)
+      if (window['HTMLImports']) {
+        doc = window.HTMLImports.importForElement(script);
+        doc.URL = script.parentElement.href;
+      }
+      return doc;
+    }
+  });
+}

--- a/shells/planner-shell/config.js
+++ b/shells/planner-shell/config.js
@@ -1,1 +1,1 @@
-global.debugLevel = 2;
+global.logLevel = 2;

--- a/src/platform/log-node.js
+++ b/src/platform/log-node.js
@@ -12,6 +12,6 @@ const _logFactory = (preamble, color, log='log') => {
   return console[log].bind(console, `(${preamble})`);
 };
 
-const factory = global.debugLevel < 1 ? () => () => {} : _logFactory;
+const factory = global.logLevel < 1 ? () => () => {} : _logFactory;
 
 export const logFactory = (...args) => factory(...args);

--- a/src/platform/log-web.js
+++ b/src/platform/log-web.js
@@ -5,21 +5,18 @@
 // subject to an additional IP rights grant found at
 // http://polymer.github.io/PATENTS.txt
 
-let logLevel = 0;
+const _factory = (preamble, color, log='log') => console[log].bind(console, `%c${preamble}`, `background: ${color}; color: white; padding: 1px 6px 2px 7px; border-radius: 6px;`);
+
+// when punting, use full logging
+let logLevel = 2;
+// TODO(sjmiles): worker.js uses log-web, but has no Window; we need to plumb the
+// global configuration into the worker.
+// there should always be `window`, we are log-web; if not, use punt value above
 if (typeof window !== 'undefined') {
-  logLevel = ('logLevel' in window) ? window.logLevel : logLevel;
+  // use specified logLevel otherwise 0
+  logLevel = ('logLevel' in window) ? window.logLevel : 0;
   console.log(`log-web: binding logFactory to level [${logLevel}]`);
 }
 
-const _factory = (preamble, color, log='log') => console[log].bind(console, `%c${preamble}`, `background: ${color}; color: white; padding: 1px 6px 2px 7px; border-radius: 6px;`);
 const factory = logLevel > 0 ? _factory : () => () => {};
-let logFactory;
-logFactory = (...args) => factory(...args);
-
-if (typeof window !== 'undefined') {
-  //logFactory = () => (...args) => document.body.appendChild(document.createElement('div')).innerText = args.join();
-} else {
-  logFactory = () => (...args) => postMessage(args.join());
-}
-
-export {logFactory};
+export const logFactory = (...args) => factory(...args);


### PR DESCRIPTION
Implement improved support for forwarding events from sub-template stamping objects (to support arcs-private).

...and continued fumbling with log-*: logging in Workers is not configurable because the global scope is not available, at least now it will log by default.