### PR TITLE
Test that all schemas/recipes/manifests are parsed successfully

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "cross-env": "^5.2.0",
     "eslint": "^5.13.0",
     "eslint-config-google": "^0.12.0",
+    "glob": "^7.1.2",
     "grammkit": "0.7.0",
     "http-server": "^0.11.1",
     "minimist": "^1.2.0",

--- a/src/tests/particles/particles-test.ts
+++ b/src/tests/particles/particles-test.ts
@@ -1,0 +1,31 @@
+import { fs } from '../../platform/fs-web.js';
+import { Manifest } from '../../runtime/manifest.js';
+import glob from 'glob';
+import { Loader } from '../../runtime/loader.js';
+
+// Skip these files, they do not compile successfully.
+// TODO: Figure out why.
+const FILES_TO_SKIP = new Set([
+  'particles/Demo/PipeDemo.recipe',
+  'particles/Demo/RestaurantsDemo.recipes',
+  'particles/Music/ArtistPipe.recipes',
+  'particles/TVMaze/TVMazePipe.recipes',
+  'particles/TVMaze/TVMazePipe.recipes',
+  'particles/Words/ShowSingleStats.manifest',
+]);
+
+/** Tests that all .schema, .recipe(s) and .manifest files in the particles folder compile successfully. */
+describe('Particle definitions', () => {
+  const loader = new Loader();
+  const filenames = glob.sync('particles/**/*.{manifest,schema,recipe,recipes}');
+
+  filenames
+    .filter(filename => !FILES_TO_SKIP.has(filename))
+    .forEach(filename => {
+      const contents = fs.readFileSync(filename, 'utf8');
+
+      it(`parses successfully: ${filename}`, async () => {
+        await Manifest.parse(contents, { fileName: filename, loader });
+      });
+    });
+});

--- a/tools/sigh.js
+++ b/tools/sigh.js
@@ -302,7 +302,7 @@ function railroad() {
 
 async function build() {
   if (await tsc() == false) {
-    console.log('build::twsc failed');
+    console.log('build::tsc failed');
     return false;
   }
 


### PR DESCRIPTION
The test checks files under particles/**

It only checks that the files can be parsed successfully (i.e. no exceptions are thrown).

There are a few files that have errors, I've excluded those from the test, but I'll have another look later on.