### PR TITLE
Clear generations before force re-plan

### DIFF
--- a/src/planning/debug/planning-explorer-adapter.ts
+++ b/src/planning/debug/planning-explorer-adapter.ts
@@ -63,6 +63,7 @@ import {Suggestion} from '../plan/suggestion';
       const devtoolsChannel = DevtoolsConnection.get().forArc(planificator.arc);
       devtoolsChannel.listen('force-replan', async () => {
         planificator.consumer.result.suggestions = [];
+        planificator.consumer.result.generations = [];
         await planificator.consumer.result.flush();
         await planificator.requestPlanning({metadata: {trigger: Trigger.Forced}});
         await planificator.loadSuggestions();


### PR DESCRIPTION
Otherwise we get a concatenation of previous and new generations in the Strategy Explorer.