### PR TITLE
Created SystemException and UserException types.

### DIFF
--- a/src/planning/test/plan/test-environment-test.ts
+++ b/src/planning/test/plan/test-environment-test.ts
@@ -2,14 +2,12 @@ import {registerSystemExceptionHandler} from '../../../runtime/arc-exceptions.js
 
 let exceptions = [];
 
-beforeEach(() => registerSystemExceptionHandler((exception, name, particle) => exceptions.push({ exception, name, particle })));
+beforeEach(() => registerSystemExceptionHandler((exception) => exceptions.push(exception)));
 
 afterEach(function () {
   if (exceptions.length > 0) {
-    for (const { exception, name, particle } of exceptions) {
-      const error = new Error(`${exception.name} when invoking system function ${name} on behalf of ${particle}`);
-      error.stack = exception.stack;
-      this.test.ctx.currentTest.err = error; // eslint-disable-line no-invalid-this
+    for (const exception of exceptions) {
+      this.test.ctx.currentTest.err = exception; // eslint-disable-line no-invalid-this
     }
     exceptions = [];
   }

--- a/src/runtime/api-channel.ts
+++ b/src/runtime/api-channel.ts
@@ -22,6 +22,7 @@ import {StorageProxy} from './storage-proxy.js';
 import { SerializedModelEntry } from './storage/crdt-collection-model.js';
 import {StorageProviderBase} from './storage/storage-provider-base.js';
 import {Type} from './type.js';
+import { PropagatedException } from './arc-exceptions.js';
 
 enum MappingType {Mapped, LocalMapped, RemoteMapped, Direct, ObjectMap, List, ByLiteral}
 
@@ -449,7 +450,7 @@ export abstract class PECOuterPort extends APIPort {
   InnerArcRender(@Mapped transformationParticle: recipeParticle.Particle, @Direct transformationSlotName: string, @Direct hostedSlotId: string, @Direct content: {}) {}
 
   abstract onArcLoadRecipe(arc: Arc, recipe: string, callback: number);
-  abstract onRaiseSystemException(exception: {}, methodName: string, particleId: string);
+  abstract onReportExceptionInHost(exception: PropagatedException);
 
   // We need an API call to tell the context side that DevTools has been connected, so it can start sending
   // stack traces attached to the API calls made from that side.
@@ -510,7 +511,7 @@ export abstract class PECInnerPort extends APIPort {
 
   ArcLoadRecipe(@RemoteMapped arc: {}, @Direct recipe: string, @LocalMapped callback: (data: {error?: string}) => void) {}
 
-  RaiseSystemException(@Direct exception: {}, @Direct methodName: string, @Direct particleId: string) {}
+  ReportExceptionInHost(@Direct exception: PropagatedException) {}
 
     // To show stack traces for calls made inside the context, we need to capture the trace at the call point and
     // send it along with the message. We only want to do this after a DevTools connection has been detected, which

--- a/src/runtime/api-channel.ts
+++ b/src/runtime/api-channel.ts
@@ -511,7 +511,7 @@ export abstract class PECInnerPort extends APIPort {
 
   ArcLoadRecipe(@RemoteMapped arc: {}, @Direct recipe: string, @LocalMapped callback: (data: {error?: string}) => void) {}
 
-  ReportExceptionInHost(@Direct exception: PropagatedException) {}
+  ReportExceptionInHost(@ByLiteral(PropagatedException) exception: PropagatedException) {}
 
     // To show stack traces for calls made inside the context, we need to capture the trace at the call point and
     // send it along with the message. We only want to do this after a DevTools connection has been detected, which

--- a/src/runtime/arc-exceptions.ts
+++ b/src/runtime/arc-exceptions.ts
@@ -1,3 +1,5 @@
+import {Particle} from './particle';
+
 /**
  * @license
  * Copyright (c) 2018 Google Inc. All rights reserved.
@@ -8,28 +10,56 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-const systemHandlers = [];
-
-export function reportSystemException(exception, methodName, particle) {
-  for (const handler of systemHandlers) {
-    handler(exception, methodName, particle);
+/** An exception that is to be propagated back to the host. */
+export class PropagatedException extends Error {
+  constructor(public cause: Error, public method: string, public particleId: string, public particleName?: string) {
+    super();
+    this.stack = cause.stack;
   }
 }
 
-export function registerSystemExceptionHandler(handler) {
+/** An exception thrown in Arcs runtime code. */
+export class SystemException extends PropagatedException {
+  get message(): string {
+    const particleName = this.particleName ? this.particleName : this.particleId;
+    return `SystemException: exception ${this.cause.name} raised when invoking system function ${this.method} on behalf of particle ${
+        particleName}: ${this.cause.message}`;
+  }
+}
+
+/** An exception thrown in the user particle code (as opposed to an error in the Arcs runtime). */
+export class UserException extends PropagatedException {
+  get message(): string {
+    const particleName = this.particleName ? this.particleName : this.particleId;
+    return `UserException: exception ${this.cause.name} raised when invoking function ${this.method} on particle ${particleName}: ${
+        this.cause.message}`;
+  }
+}
+
+type ExceptionHandler = (exception: PropagatedException) => void;
+
+const systemHandlers = <ExceptionHandler[]>[];
+
+export function reportSystemException(exception: PropagatedException) {
+  for (const handler of systemHandlers) {
+    handler(exception);
+  }
+}
+
+export function registerSystemExceptionHandler(handler: ExceptionHandler) {
   if (!systemHandlers.includes(handler)) {
     systemHandlers.push(handler);
   }
 }
 
-export function removeSystemExceptionHandler(handler) {
+export function removeSystemExceptionHandler(handler: ExceptionHandler) {
   const idx = systemHandlers.indexOf(handler);
   if (idx > -1) {
     systemHandlers.splice(idx, 1);
   }
 }
 
-registerSystemExceptionHandler((exception, methodName, particle) => {
-  console.log(methodName, particle);
+registerSystemExceptionHandler((exception) => {
+  console.log(exception.method, exception.particleName);
   throw exception;
 });

--- a/src/runtime/particle-execution-host.ts
+++ b/src/runtime/particle-execution-host.ts
@@ -11,7 +11,7 @@
 import {assert} from '../platform/assert-web.js';
 
 import {PECOuterPort} from './api-channel.js';
-import {reportSystemException} from './arc-exceptions.js';
+import {reportSystemException, PropagatedException} from './arc-exceptions.js';
 import {Arc} from './arc.js';
 import {Manifest} from './manifest.js';
 import { Handle } from './recipe/handle.js';
@@ -236,9 +236,11 @@ export class ParticleExecutionHost {
         this.SimpleCallback(callback, error ? {error} : successResponse);
       }
 
-      onRaiseSystemException(exception: {}, methodName: string, particleId: string) {
-      const particle = pec.arc.particleHandleMaps.get(particleId).spec.name;
-        reportSystemException(exception, methodName, particle);
+      onReportExceptionInHost(exception: PropagatedException) {
+        if (!exception.particleName) {
+          exception.particleName = pec.arc.particleHandleMaps.get(exception.particleId).spec.name;
+        }
+        reportSystemException(exception);
       }
     }(port, arc);
   }

--- a/src/runtime/storage-proxy.ts
+++ b/src/runtime/storage-proxy.ts
@@ -91,8 +91,8 @@ export abstract class StorageProxy {
   reportExceptionInHost(exception: PropagatedException) {
     // TODO: Encapsulate source-mapping of the stack trace once there are more users of the port.RaiseSystemException() call.
     if (mapStackTrace) {
-      mapStackTrace(exception.stack, mappedStack => {
-        exception.stack = mappedStack;
+      mapStackTrace(exception.cause.stack, mappedStack => {
+        exception.cause.stack = mappedStack;
         this.port.ReportExceptionInHost(exception);
       });
     } else {

--- a/src/runtime/storage-proxy.ts
+++ b/src/runtime/storage-proxy.ts
@@ -12,6 +12,7 @@ import {assert} from '../platform/assert-web.js';
 import {mapStackTrace} from '../platform/sourcemapped-stacktrace-web.js';
 
 import {CursorNextValue, PECInnerPort} from './api-channel.js';
+import {PropagatedException, SystemException} from './arc-exceptions.js';
 import {Handle, HandleOptions} from './handle.js';
 import {ParticleExecutionContext} from './particle-execution-context.js';
 import {Particle} from './particle.js';
@@ -87,14 +88,15 @@ export abstract class StorageProxy {
   abstract _synchronizeModel(version: number, model: SerializedModelEntry[]): boolean;
   abstract _processUpdate(update: {version: number}, apply?: boolean): {};
 
-  raiseSystemException(exception, methodName, particleId) {
+  reportExceptionInHost(exception: PropagatedException) {
     // TODO: Encapsulate source-mapping of the stack trace once there are more users of the port.RaiseSystemException() call.
-    const {message, stack, name} = exception;
-    const raise = stack => this.port.RaiseSystemException({message, stack, name}, methodName, particleId);
-    if (!mapStackTrace) {
-      raise(stack);
+    if (mapStackTrace) {
+      mapStackTrace(exception.stack, mappedStack => {
+        exception.stack = mappedStack;
+        this.port.ReportExceptionInHost(exception);
+      });
     } else {
-      mapStackTrace(stack, mappedStack => raise(mappedStack.join('\n')));
+      this.port.ReportExceptionInHost(exception);
     }
   }
 
@@ -617,7 +619,7 @@ export class StorageProxyScheduler {
             handle._notify(...args);
           } catch (e) {
             console.error('Error dispatching to particle', e);
-            handle._proxy.raiseSystemException(e, 'StorageProxyScheduler::_dispatch', handle._particleId);
+            handle._proxy.reportExceptionInHost(new SystemException(e, handle._particleId, 'StorageProxyScheduler::_dispatch'));
           }
         }
       }

--- a/src/runtime/test/test-environment-test.ts
+++ b/src/runtime/test/test-environment-test.ts
@@ -2,14 +2,12 @@ import {registerSystemExceptionHandler} from '../arc-exceptions.js';
 
 let exceptions = [];
 
-beforeEach(() => registerSystemExceptionHandler((exception, name, particle) => exceptions.push({ exception, name, particle })));
+beforeEach(() => registerSystemExceptionHandler((exception) => exceptions.push(exception)));
 
 afterEach(function () {
   if (exceptions.length > 0) {
-    for (const { exception, name, particle } of exceptions) {
-      const error = new Error(`${exception.name} when invoking system function ${name} on behalf of ${particle}`);
-      error.stack = exception.stack;
-      this.test.ctx.currentTest.err = error; // eslint-disable-line no-invalid-this
+    for (const exception of exceptions) {
+      this.test.ctx.currentTest.err = exception; // eslint-disable-line no-invalid-this
     }
     exceptions = [];
   }

--- a/src/tests/particles/test-environment-test.ts
+++ b/src/tests/particles/test-environment-test.ts
@@ -2,14 +2,12 @@ import {registerSystemExceptionHandler} from '../../runtime/arc-exceptions.js';
 
 let exceptions = [];
 
-beforeEach(() => registerSystemExceptionHandler((exception, name, particle) => exceptions.push({ exception, name, particle })));
+beforeEach(() => registerSystemExceptionHandler((exception) => exceptions.push(exception)));
 
 afterEach(function () {
   if (exceptions.length > 0) {
-    for (const { exception, name, particle } of exceptions) {
-      const error = new Error(`${exception.name} when invoking system function ${name} on behalf of ${particle}`);
-      error.stack = exception.stack;
-      this.test.ctx.currentTest.err = error; // eslint-disable-line no-invalid-this
+    for (const exception of exceptions) {
+      this.test.ctx.currentTest.err = exception; // eslint-disable-line no-invalid-this
     }
     exceptions = [];
   }


### PR DESCRIPTION
These exceptions get propagated back to the host, and wrap the real
exception that occurred. Orignal exception, message and stack are
retained. Other useful info like the particle that caused it is given as
well.

Fixes #2764