### PR TITLE
skip flaky test

### DIFF
--- a/src/planning/test/plan/planificator-test.ts
+++ b/src/planning/test/plan/planificator-test.ts
@@ -169,7 +169,7 @@ describe('remote planificator', () => {
       await verifyConsumerResults(5);
     });
   });
-  it(`merges remotely produced suggestions`, async () => {
+  it.skip(`merges remotely produced suggestions`, async () => {
     const userid = 'test-user';
     const storageKey = 'volatile://!123:demo^^abcdef';
 


### PR DESCRIPTION
`merges remotely produced suggestions` has been failing frequently (AppVeyor worse than Travis), so I'm skipping it for now.

See #2836