### PR TITLE
Make Arcs work on Safari 

### DIFF
--- a/modalities/dom/components/elements/corellia-xen/cx-tab-slider.js
+++ b/modalities/dom/components/elements/corellia-xen/cx-tab-slider.js
@@ -53,64 +53,44 @@ class CorelliaXenTabSlider extends Xen.Base {
     this._fire('tab-slider-done');
   }
   async _animatedMove(fromTab, toTab) {
-    if (typeof this.animate !== 'function') return;
-    if (fromTab === undefined || toTab === undefined) return;
-    this.setAttribute('animating', '');
-    if (this.offsetParent) {
-      Object.assign(this.style, {
-        top: '0px',
-        right: '0px',
-        bottom: '0px',
-        left: '0px',
-      });
-      const originBox = this.offsetParent.getBoundingClientRect();
-      const fromBox = fromTab.getBoundingClientRect();
-      const toBox = toTab.getBoundingClientRect();
-      const easing = 'ease-in-out';
-      const duration = 50;
-      const fill = 'both';
-      const edgeDelay = 50;
-      const animations = [
-        this.animate([
-            {top: `${fromBox.top - originBox.top}px`},
-            {top: `${toBox.top - originBox.top}px`},
-          ], {
-            delay: (fromBox.top < toBox.top && fromBox.bottom < toBox.bottom) ? edgeDelay : 0,
-            duration,
-            easing,
-            fill,
-          }),
-        this.animate([
-            {right: `${originBox.right - fromBox.right}px`},
-            {right: `${originBox.right - toBox.right}px`},
-          ], {
-            delay: (fromBox.left > toBox.left && fromBox.right > toBox.right) ? edgeDelay : 0,
-            duration,
-            easing,
-            fill,
-          }),
-        this.animate([
-            {bottom: `${originBox.bottom - fromBox.bottom}px`},
-            {bottom: `${originBox.bottom - toBox.bottom}px`},
-          ], {
-            delay: (fromBox.top > toBox.top && fromBox.bottom > toBox.bottom) ? edgeDelay : 0,
-            duration,
-            easing,
-            fill,
-          }),
-        this.animate([
-            {left: `${fromBox.left - originBox.left}px`},
-            {left: `${toBox.left - originBox.left}px`},
-          ], {
-            delay: (fromBox.left < toBox.left && fromBox.right < toBox.right) ? edgeDelay : 0,
-            duration,
-            easing,
-            fill,
-          }),
-      ];
-      await Promise.all(animations.map(a => new Promise(resolve => a.onfinish = resolve)));
+    if (this._supportsAnimation()) {
+      if (fromTab !== undefined && toTab !== undefined) {
+        this.setAttribute('animating', '');
+        if (this.offsetParent) {
+          await this._implementAnimation(fromTab, toTab);
+        }
+        this.removeAttribute('animating');
+      }
     }
-    this.removeAttribute('animating');
+  }
+  _supportsAnimation() {
+    return (typeof this.animate === 'function');
+  }
+  async _implementAnimation(fromTab, toTab) {
+    Object.assign(this.style, {
+      top: '0px',
+      right: '0px',
+      bottom: '0px',
+      left: '0px',
+    });
+    const origin = this.offsetParent.getBoundingClientRect();
+    const from = fromTab.getBoundingClientRect();
+    const to = toTab.getBoundingClientRect();
+    const easing = 'ease-in-out';
+    const duration = 50;
+    const fill = 'both';
+    const edgeDelay = 50;
+    const ord = (name, start, end, edge) => this.animate(
+      [{[name]: `${start}px`}, {[name]: `${end}px`}],
+      {duration, easing, fill, delay: edge ? edgeDelay : 0}
+    );
+    const animations = [
+      ord('top', from.top - origin.top, to.top - origin.top, from.top < to.top && from.bottom < to.bottom),
+      ord('right', origin.right - from.right, origin.right - to.right, from.left > to.left && from.right > to.right),
+      ord('bottom', origin.bottom - from.bottom, origin.bottom - to.bottom, from.top > to.top && from.bottom > to.bottom),
+      ord('left', from.left - origin.left, to.left - origin.left, from.left < to.left && from.right < to.right)
+    ];
+    await Promise.all(animations.map(a => new Promise(resolve => a.onfinish = resolve)));
   }
 }
 customElements.define('cx-tab-slider', CorelliaXenTabSlider);

--- a/modalities/dom/components/elements/corellia-xen/cx-tab-slider.js
+++ b/modalities/dom/components/elements/corellia-xen/cx-tab-slider.js
@@ -49,68 +49,68 @@ class CorelliaXenTabSlider extends Xen.Base {
     }
   }
   async _move(fromTab, toTab) {
+    await this._animatedMove(fromTab, toTab);
+    this._fire('tab-slider-done');
+  }
+  async _animatedMove(fromTab, toTab) {
     if (typeof this.animate !== 'function') return;
     if (fromTab === undefined || toTab === undefined) return;
     this.setAttribute('animating', '');
-    if (!this.offsetParent) {
-      this.removeAttribute('animating');
-      return;
+    if (this.offsetParent) {
+      Object.assign(this.style, {
+        top: '0px',
+        right: '0px',
+        bottom: '0px',
+        left: '0px',
+      });
+      const originBox = this.offsetParent.getBoundingClientRect();
+      const fromBox = fromTab.getBoundingClientRect();
+      const toBox = toTab.getBoundingClientRect();
+      const easing = 'ease-in-out';
+      const duration = 50;
+      const fill = 'both';
+      const edgeDelay = 50;
+      const animations = [
+        this.animate([
+            {top: `${fromBox.top - originBox.top}px`},
+            {top: `${toBox.top - originBox.top}px`},
+          ], {
+            delay: (fromBox.top < toBox.top && fromBox.bottom < toBox.bottom) ? edgeDelay : 0,
+            duration,
+            easing,
+            fill,
+          }),
+        this.animate([
+            {right: `${originBox.right - fromBox.right}px`},
+            {right: `${originBox.right - toBox.right}px`},
+          ], {
+            delay: (fromBox.left > toBox.left && fromBox.right > toBox.right) ? edgeDelay : 0,
+            duration,
+            easing,
+            fill,
+          }),
+        this.animate([
+            {bottom: `${originBox.bottom - fromBox.bottom}px`},
+            {bottom: `${originBox.bottom - toBox.bottom}px`},
+          ], {
+            delay: (fromBox.top > toBox.top && fromBox.bottom > toBox.bottom) ? edgeDelay : 0,
+            duration,
+            easing,
+            fill,
+          }),
+        this.animate([
+            {left: `${fromBox.left - originBox.left}px`},
+            {left: `${toBox.left - originBox.left}px`},
+          ], {
+            delay: (fromBox.left < toBox.left && fromBox.right < toBox.right) ? edgeDelay : 0,
+            duration,
+            easing,
+            fill,
+          }),
+      ];
+      await Promise.all(animations.map(a => new Promise(resolve => a.onfinish = resolve)));
     }
-    Object.assign(this.style, {
-      top: '0px',
-      right: '0px',
-      bottom: '0px',
-      left: '0px',
-    });
-    const originBox = this.offsetParent.getBoundingClientRect();
-    const fromBox = fromTab.getBoundingClientRect();
-    const toBox = toTab.getBoundingClientRect();
-    const easing = 'ease-in-out';
-    const duration = 50;
-    const fill = 'both';
-    const edgeDelay = 50;
-    const animations = [
-      this.animate([
-          {top: `${fromBox.top - originBox.top}px`},
-          {top: `${toBox.top - originBox.top}px`},
-        ], {
-          delay: (fromBox.top < toBox.top && fromBox.bottom < toBox.bottom) ? edgeDelay : 0,
-          duration,
-          easing,
-          fill,
-        }),
-      this.animate([
-          {right: `${originBox.right - fromBox.right}px`},
-          {right: `${originBox.right - toBox.right}px`},
-        ], {
-          delay: (fromBox.left > toBox.left && fromBox.right > toBox.right) ? edgeDelay : 0,
-          duration,
-          easing,
-          fill,
-        }),
-      this.animate([
-          {bottom: `${originBox.bottom - fromBox.bottom}px`},
-          {bottom: `${originBox.bottom - toBox.bottom}px`},
-        ], {
-          delay: (fromBox.top > toBox.top && fromBox.bottom > toBox.bottom) ? edgeDelay : 0,
-          duration,
-          easing,
-          fill,
-        }),
-      this.animate([
-          {left: `${fromBox.left - originBox.left}px`},
-          {left: `${toBox.left - originBox.left}px`},
-        ], {
-          delay: (fromBox.left < toBox.left && fromBox.right < toBox.right) ? edgeDelay : 0,
-          duration,
-          easing,
-          fill,
-        }),
-    ];
-    await Promise.all(animations.map(a => new Promise(resolve => a.onfinish = resolve)));
-    //await Promise.all(animations.map(a => a.finished));
     this.removeAttribute('animating');
-    this._fire('tab-slider-done');
   }
 }
 customElements.define('cx-tab-slider', CorelliaXenTabSlider);

--- a/src/platform/loader-web.js
+++ b/src/platform/loader-web.js
@@ -64,7 +64,6 @@ export class PlatformLoader extends Loader {
     return this.unwrapParticle(particles[0], this.provisionLogger(fileName));
   }
   loadWrappedParticle(url) {
-    // load wrapped particle
     const result = [];
     // MUST be synchronous from here until deletion
     // of self.defineParticle because we share this

--- a/src/platform/loader-web.js
+++ b/src/platform/loader-web.js
@@ -66,8 +66,8 @@ export class PlatformLoader extends Loader {
   loadWrappedParticle(url) {
     // load wrapped particle
     const result = [];
-    // MUST be synchronous from here until
-    // deletion self.defineParticle because we share this
+    // MUST be synchronous from here until deletion
+    // of self.defineParticle because we share this
     // scope with other particles
     self.defineParticle = function(particleWrapper) {
       result.push(particleWrapper);

--- a/src/platform/log-web.js
+++ b/src/platform/log-web.js
@@ -1,10 +1,11 @@
-// Copyright (c) 2018 Google Inc. All rights reserved.
-// This code may only be used under the BSD style license found at
-// http://polymer.github.io/LICENSE.txt
-// Code distributed by Google as part of this project is also
-// subject to an additional IP rights grant found at
-// http://polymer.github.io/PATENTS.txt
-
+/**
+ * Copyright (c) 2019 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
 const _factory = (preamble, color, log='log') => console[log].bind(console, `%c${preamble}`, `background: ${color || 'gray'}; color: white; padding: 1px 6px 2px 7px; border-radius: 6px;`);
 
 // when punting, use full logging


### PR DESCRIPTION
Main problem was that loader-web was using `await` between set-up and tear-down of `defineParticle` which is a major no-no (if two particles share that context, they can cross the streams). This was easily repaired once discovered (credit to @piotrswigon for the sleuthing!)

I factored out the critical synchronous bit into a method and added comments to explain the requirement.

Ironically, the method I `await`ed wasn't even async (ahem). 

It's not clear why this bug didn't affect Chrome (unless it was the fact that the callee wasn't async at all).

Also includes a fix to cx-tab-slider to make it work in the absence of WebAnimations API.

Fixes #2812.
