### PR TITLE
Storage Cleanups resulting from PouchDB timing changes

### DIFF
--- a/src/runtime/storage/crdt-collection-model.ts
+++ b/src/runtime/storage/crdt-collection-model.ts
@@ -37,7 +37,7 @@ interface ModelEntry {
 export class CrdtCollectionModel {
   private items: Map<string, ModelEntry>;
 
-  constructor(model = undefined) {
+  constructor(model?: SerializedModelEntry[]) {
     // id => {value, Set[keys]}
     this.items = new Map();
     if (model) {
@@ -49,12 +49,13 @@ export class CrdtCollectionModel {
       }
     }
   }
+
   /**
    * Adds membership, `keys`, of `value` indexed by `id` to this collection.
    * Returns whether the change is effective (`id` is new to the collection,
    * or `value` is different to the value previously stored).
    */
-  add(id: string, value, keys: string[]): boolean {
+  add(id: string, value: ModelValue, keys: string[]): boolean {
     // Ensure that keys is actually an array, not a single string.
     // TODO(shans): remove this when all callers are implemented in typeScript.
     assert(keys.length > 0 && typeof keys === 'object', 'add requires a list of keys');
@@ -81,7 +82,7 @@ export class CrdtCollectionModel {
     return effective;
   }
 
-  _equals(value1: string|{}, value2: string|{}) {
+  _equals(value1: string|{}, value2: string|{}): boolean {
     if (Boolean(value1) !== Boolean(value2)) {
       return false;
     }
@@ -122,16 +123,16 @@ export class CrdtCollectionModel {
     return effective;
   }
 
-  // [{id, value, keys: []}]
+  // Serialized ModelEntry is [{id, value, keys: []}]
   toLiteral(): SerializedModelEntry[] {
-    const result: {id, value, keys}[] = [];
+    const result: SerializedModelEntry[] = [];
     for (const [id, {value, keys}] of this.items.entries()) {
       result.push({id, value, keys: [...keys]});
     }
     return result;
   }
 
-  toList() {
+  toList(): ModelValue[] {
     return [...this.items.values()].map(item => item.value);
   }
 
@@ -144,7 +145,7 @@ export class CrdtCollectionModel {
     return item ? [...item.keys] : [];
   }
 
-  getValue(id: string) {
+  getValue(id: string): ModelValue|null {
     const item = this.items.get(id);
     return item ? item.value : null;
   }
@@ -153,3 +154,4 @@ export class CrdtCollectionModel {
     return this.items.size;
   }
 }
+

--- a/src/runtime/storage/crdt-collection-model.ts
+++ b/src/runtime/storage/crdt-collection-model.ts
@@ -123,7 +123,6 @@ export class CrdtCollectionModel {
     return effective;
   }
 
-  // Serialized ModelEntry is [{id, value, keys: []}]
   toLiteral(): SerializedModelEntry[] {
     const result: SerializedModelEntry[] = [];
     for (const [id, {value, keys}] of this.items.entries()) {

--- a/src/runtime/storage/firebase/firebase-storage.ts
+++ b/src/runtime/storage/firebase/firebase-storage.ts
@@ -552,7 +552,7 @@ class FirebaseVariable extends FirebaseStorageProvider implements VariableStorag
     return this.set(null, originatorId, barrier);
   }
 
-  async cloneFrom(handle) {
+  async cloneFrom(handle): Promise<void> {
     this.referenceMode = handle.referenceMode;
     const literal = await handle.toLiteral();
     const data = literal.model[0].value;
@@ -599,7 +599,7 @@ class FirebaseVariable extends FirebaseStorageProvider implements VariableStorag
     return {version: this.version, model};
   }
 
-  fromLiteral({version, model}) {
+  private fromLiteral({version, model}) {
     const value = model.length === 0 ? null : model[0].value;
     assert(value !== undefined);
     assert(this.referenceMode || !value.storageKey);
@@ -1113,7 +1113,7 @@ class FirebaseCollection extends FirebaseStorageProvider implements CollectionSt
     await this._persistChanges();
   }
 
-  async cloneFrom(handle) {
+  async cloneFrom(handle): Promise<void>{
     this.referenceMode = handle.referenceMode;
     const literal = await handle.toLiteral();
     if (this.referenceMode && literal.model.length > 0) {
@@ -1147,7 +1147,7 @@ class FirebaseCollection extends FirebaseStorageProvider implements CollectionSt
     };
   }
 
-  fromLiteral({version, model}) {
+  private fromLiteral({version, model}) {
     this.version = version;
     this.model = new CrdtCollectionModel(model);
   }
@@ -1467,7 +1467,7 @@ class FirebaseBigCollection extends FirebaseStorageProvider implements BigCollec
   // A cloned instance will probably need to reference the same Firebase URL but collect all
   // modifications locally for speculative execution.
 
-  async cloneFrom(handle) {
+  async cloneFrom(handle): Promise<void> {
     throw new Error('FirebaseBigCollection does not yet implement cloneFrom');
   }
 
@@ -1475,7 +1475,7 @@ class FirebaseBigCollection extends FirebaseStorageProvider implements BigCollec
     throw new Error('FirebaseBigCollection does not yet implement toLiteral');
   }
 
-  fromLiteral({version, model}) {
+  private fromLiteral({version, model}) {
     throw new Error('FirebaseBigCollection does not yet implement fromLiteral');
   }
 
@@ -1607,7 +1607,7 @@ class FirebaseBackingStore extends FirebaseStorageProvider implements Collection
     throw new Error('FirebaseBackingStore does not implement toLiteral');
   }
 
-  cloneFrom(store: StorageProviderBase) {
+  cloneFrom(store: StorageProviderBase): Promise<void> {
     throw new Error('FirebaseBackingStore does not implement cloneFrom');
   }
 }

--- a/src/runtime/storage/firebase/firebase-storage.ts
+++ b/src/runtime/storage/firebase/firebase-storage.ts
@@ -1098,7 +1098,7 @@ class FirebaseCollection extends FirebaseStorageProvider implements CollectionSt
     return ids.map(id => this.model.getValue(id));
   }
 
-  async storeMultiple(values, keys: string[], originatorId=null) {
+  async storeMultiple(values, keys: string[], originatorId=null): Promise<void> {
     assert(!this.referenceMode, 'storeMultiple not implemented for referenceMode stores');
     values.map(value => {
       this.model.add(value.id, value, keys);
@@ -1500,7 +1500,7 @@ class FirebaseBackingStore extends FirebaseStorageProvider implements Collection
     await this.storeSingle(value, keys);
   }
 
-  async storeMultiple(values, keys: string[]) {
+  async storeMultiple(values, keys: string[]): Promise<void> {
     while (values.length > 0) {
       const chunk = values.splice(0, this.maxConcurrentRequests);
       await Promise.all(chunk.map(value => this.storeSingle(value, keys)));

--- a/src/runtime/storage/pouchdb/pouch-db-big-collection.ts
+++ b/src/runtime/storage/pouchdb/pouch-db-big-collection.ts
@@ -42,7 +42,7 @@ export class PouchDbBigCollection extends PouchDbStorageProvider implements BigC
     throw new Error('NotImplemented');
   }
 
-  cloneFrom() {
+  cloneFrom(): Promise<void> {
     throw new Error('NotImplemented');
   }
 

--- a/src/runtime/storage/pouchdb/pouch-db-collection.ts
+++ b/src/runtime/storage/pouchdb/pouch-db-collection.ts
@@ -1,7 +1,7 @@
 import {assert} from '../../../platform/assert-web.js';
 import {PouchDB} from '../../../platform/pouchdb-web.js';
 import {Type, TypeLiteral} from '../../type.js';
-import {CrdtCollectionModel, SerializedModelEntry} from '../crdt-collection-model.js';
+import {CrdtCollectionModel, SerializedModelEntry, ModelValue} from '../crdt-collection-model.js';
 import {ChangeEvent, CollectionStorageProvider} from '../storage-provider-base.js';
 
 import {PouchDbStorage} from './pouch-db-storage';
@@ -122,7 +122,7 @@ export class PouchDbCollection extends PouchDbStorageProvider implements Collect
   /** @inheritDoc */
   // Returns {version, model: [{id, value, keys: []}]}
   // TODO(lindner): this is async, but the base class isn't....
-  async toLiteral() {
+  async toLiteral(): Promise<{version: number, model: SerializedModelEntry[]}> {
     await this.initialized;
     return {
       version: this.version,
@@ -130,7 +130,7 @@ export class PouchDbCollection extends PouchDbStorageProvider implements Collect
     };
   }
 
-  private async _toList() {
+  private async _toList(): Promise<SerializedModelEntry[]> {
     if (this.referenceMode) {
       const items = (await this.getModel()).toLiteral();
       if (items.length === 0) {
@@ -171,7 +171,7 @@ export class PouchDbCollection extends PouchDbStorageProvider implements Collect
    * @param ids items to fetch from the underlying CRDT model.
    * @return an array of values from the underlying CRDT
    */
-  async getMultiple(ids: string[]) {
+  async getMultiple(ids: string[]): Promise<ModelValue[]>  {
     await this.initialized;
     assert(!this.referenceMode, 'getMultiple not implemented for referenceMode stores');
     const model = await this.getModel();
@@ -182,7 +182,7 @@ export class PouchDbCollection extends PouchDbStorageProvider implements Collect
    * Store multiple values with the given keys in the Collection.
    * TODO(lindner): document originatorId, which is unused.
    */
-  async storeMultiple(values, keys, originatorId = null) {
+  async storeMultiple(values, keys, originatorId = null): Promise<void> {
     await this.initialized;
     assert(!this.referenceMode, 'storeMultiple not implemented for referenceMode stores');
 

--- a/src/runtime/storage/pouchdb/pouch-db-key.ts
+++ b/src/runtime/storage/pouchdb/pouch-db-key.ts
@@ -72,15 +72,15 @@ export class PouchDbKey extends KeyBase {
     return this.buildChildKey('arc-info');
   }
 
-  childKeyForSuggestions(userId, arcId): KeyBase {
+  childKeyForSuggestions(userId: string, arcId: string): KeyBase {
     return this.buildChildKey(`${userId}/suggestions/${arcId}`);
   }
 
-  childKeyForSearch(userId): KeyBase {
+  childKeyForSearch(userId: string): KeyBase {
     return this.buildChildKey(`${userId}/search`);
   }
 
-  private buildChildKey(leaf) {
+  private buildChildKey(leaf: string) {
     let location = '';
     if (this.location != undefined && this.location.length > 0) {
       location = this.location + '/';

--- a/src/runtime/storage/pouchdb/pouch-db-storage.ts
+++ b/src/runtime/storage/pouchdb/pouch-db-storage.ts
@@ -146,7 +146,7 @@ export class PouchDbStorage extends StorageBase {
   }
 
   /** Creates a new Variable or Collection given basic parameters */
-  newProvider(type: Type, name, id, key): PouchDbStorageProvider {
+  newProvider(type: Type, name: string, id: string, key: string): PouchDbStorageProvider {
     if (type instanceof CollectionType) {
       return new PouchDbCollection(type, this, name, id, key);
     }
@@ -157,7 +157,7 @@ export class PouchDbStorage extends StorageBase {
   }
 
   /** Removes everything that a test could have created. */
-  static async resetPouchDbStorageForTesting() {
+  static async resetPouchDbStorageForTesting(): Promise<void> {
     for (const db of PouchDbStorage.dbLocationToInstance.values()) {
       await db
         .allDocs({include_docs: true})

--- a/src/runtime/storage/synthetic-storage.ts
+++ b/src/runtime/storage/synthetic-storage.ts
@@ -188,7 +188,7 @@ class SyntheticCollection extends StorageProviderBase implements CollectionStora
     return this.toList();
   }
 
-  cloneFrom() {
+  cloneFrom(): Promise<void> {
     throw new Error('cloneFrom should never be called on SyntheticCollection!');
   }
 

--- a/src/runtime/storage/volatile-storage.ts
+++ b/src/runtime/storage/volatile-storage.ts
@@ -212,7 +212,7 @@ class VolatileCollection extends VolatileStorageProvider implements CollectionSt
     return handle;
   }
 
-  async cloneFrom(handle) {
+  async cloneFrom(handle): Promise<void> {
     this.referenceMode = handle.referenceMode;
     const literal = await handle.toLiteral();
     if (this.referenceMode && literal.model.length > 0) {
@@ -234,7 +234,7 @@ class VolatileCollection extends VolatileStorageProvider implements CollectionSt
     return {version: this.version, model: this._model.toLiteral()};
   }
 
-  fromLiteral({version, model}) {
+  private fromLiteral({version, model}) {
     this.version = version;
     this._model = new CrdtCollectionModel(model);
   }
@@ -369,7 +369,7 @@ class VolatileVariable extends VolatileStorageProvider implements VariableStorag
     return variable;
   }
 
-  async cloneFrom(handle) {
+  async cloneFrom(handle): Promise<void> {
     this.referenceMode = handle.referenceMode;
     // TODO(shans): if the handle has local modifications then cloning can fail because
     // underlying backingStore data isn't yet available to be read. However, checking the
@@ -411,7 +411,7 @@ class VolatileVariable extends VolatileStorageProvider implements VariableStorag
     return {version: this.version, model};
   }
 
-  fromLiteral({version, model}) {
+  private fromLiteral({version, model}) {
     const value = model.length === 0 ? null : model[0].value;
     if (this.referenceMode && value && value.rawData) {
       assert(false, `shouldn't have rawData ${JSON.stringify(value.rawData)} here`);
@@ -582,7 +582,7 @@ class VolatileBigCollection extends VolatileStorageProvider implements BigCollec
     return cursor ? cursor.version : null;
   }
 
-  async cloneFrom(handle) {
+  async cloneFrom(handle): Promise<void> {
     // TODO: clone from non-volatile versions
     if (handle.items) {
       this.fromLiteral(handle.toLiteral());
@@ -598,7 +598,7 @@ class VolatileBigCollection extends VolatileStorageProvider implements BigCollec
     return {version: this.version, model};
   }
 
-  fromLiteral({version, model}) {
+  private fromLiteral({version, model}) {
     this.version = version;
     this.items.clear();
     for (const {id, index, value, keys} of model) {

--- a/src/runtime/storage/volatile-storage.ts
+++ b/src/runtime/storage/volatile-storage.ts
@@ -272,7 +272,7 @@ class VolatileCollection extends VolatileStorageProvider implements CollectionSt
     return ids.map(id => this._model.getValue(id));
   }
 
-  async storeMultiple(values, keys: string[], originatorId: string = null) {
+  async storeMultiple(values, keys: string[], originatorId: string = null): Promise<void> {
     assert(!this.referenceMode, "storeMultiple not implemented for referenceMode stores");
     values.map(value => this._model.add(value.id, value, keys));
     this.version++;

--- a/src/runtime/test/storage/crdt-collection-model-test.ts
+++ b/src/runtime/test/storage/crdt-collection-model-test.ts
@@ -6,43 +6,45 @@
 // http://polymer.github.io/PATENTS.txt
 
 import {assert} from '../../../platform/chai-web.js';
-import { CrdtCollectionModel } from '../../storage/crdt-collection-model.js';
+import { CrdtCollectionModel, ModelValue } from '../../storage/crdt-collection-model.js';
 
 describe('crdt-collection-model', () => {
   it('can add values', async () => {
+    const value: ModelValue = {id: 'value'};
     const model = new CrdtCollectionModel();
-    const effective = model.add('id', 'value', ['key1', 'key2']);
+    const effective = model.add('id', value, ['key1', 'key2']);
     assert.isTrue(effective);
     assert.equal(model.size, 1);
-    assert.equal(model.getValue('id'), 'value' as unknown);
+    assert.equal(model.getValue('id'), value);
     assert.sameMembers(model.getKeys('id'), ['key1', 'key2']);
   });
   it('can remove values', async () => {
     const model = new CrdtCollectionModel();
-    model.add('id', 'value', ['key1', 'key2']);
+    model.add('id', {id: 'value'}, ['key1', 'key2']);
     const effective = model.remove('id', ['key1', 'key2']);
     assert.isTrue(effective);
     assert.equal(model.size, 0);
   });
   it('treats add with different keys as idempotent', async () => {
+    const value: ModelValue = {id: 'value'};
     const model = new CrdtCollectionModel();
-    model.add('id', 'value', ['key1']);
-    const effective = model.add('id', 'value', ['key2']);
+    model.add('id', value, ['key1']);
+    const effective = model.add('id', {id: 'value'}, ['key2']);
     assert.isFalse(effective);
     assert.equal(model.size, 1);
-    assert.equal(model.getValue('id'), 'value' as unknown);
+    assert.equal(model.getValue('id'), value);
     assert.sameMembers(model.getKeys('id'), ['key1', 'key2']);
   });
   it('treats remove as idempotent', async () => {
     const model = new CrdtCollectionModel();
-    model.add('id', 'value', ['key1', 'key2']);
+    model.add('id', {id: 'value'}, ['key1', 'key2']);
     model.remove('id', ['key1', 'key2']);
     const effective = model.remove('id', ['key1', 'key2']);
     assert.isFalse(effective);
   });
   it('doesnt treat value as removed until all keys are removed', async () => {
     const model = new CrdtCollectionModel();
-    model.add('id', 'value', ['key1', 'key2']);
+    model.add('id', {id: 'value'}, ['key1', 'key2']);
     let effective = model.remove('id', ['key1']);
     assert.isFalse(effective);
     assert.equal(model.size, 1);
@@ -52,25 +54,27 @@ describe('crdt-collection-model', () => {
     assert.equal(model.size, 0);
   });
   it('allows a value to be updated', async () => {
+    const value2: ModelValue = {id: 'value2'};
+
     const model = new CrdtCollectionModel();
-    model.add('id', 'value', ['key1', 'key2']);
-    const effective = model.add('id', 'value2', ['key3']);
+    model.add('id', {id: 'value'}, ['key1', 'key2']);
+    const effective = model.add('id', value2, ['key3']);
     assert.isTrue(effective);
-    assert.equal(model.getValue('id'), 'value2' as unknown);
+    assert.equal(model.getValue('id'), value2);
   });
   it('does not allow a value to be updated unless new keys are added', async () => {
     const model = new CrdtCollectionModel();
-    model.add('id', 'value', ['key1', 'key2']);
-    assert.throws(() => model.add('id', 'value2', ['key1']), /cannot add without new keys/);
+    model.add('id', {id: 'value'}, ['key1', 'key2']);
+    assert.throws(() => model.add('id', {id: 'value2'}, ['key1']), /cannot add without new keys/);
   });
   it('does not allow a value to be added without keys', async () => {
     const model = new CrdtCollectionModel();
-    assert.throws(() => model.add('id', 'value', []), /add requires a list of keys/);
+    assert.throws(() => model.add('id', {id: 'value'}, []), /add requires a list of keys/);
   });
   it('allows keys to be initialized empty', async () => {
     const model = new CrdtCollectionModel([
-      { id: 'nokeys', 'value': 'value' },
-      { id: 'keys', 'value': 'value', keys: ['key1'] },
+      { id: 'nokeys', value: {id: 'value'}, keys: [] },
+      { id: 'keys', value: {id: 'value'}, keys: ['key1'] },
     ]);
     assert.equal(model.size, 2);
     assert.isEmpty(model.getKeys('nokeys'));

--- a/src/runtime/test/storage/crdt-collection-model-test.ts
+++ b/src/runtime/test/storage/crdt-collection-model-test.ts
@@ -10,7 +10,7 @@ import { CrdtCollectionModel, ModelValue } from '../../storage/crdt-collection-m
 
 describe('crdt-collection-model', () => {
   it('can add values', async () => {
-    const value: ModelValue = {id: 'value'};
+    const value: ModelValue = {id: 'id', rawData: 'value'};
     const model = new CrdtCollectionModel();
     const effective = model.add('id', value, ['key1', 'key2']);
     assert.isTrue(effective);
@@ -20,16 +20,17 @@ describe('crdt-collection-model', () => {
   });
   it('can remove values', async () => {
     const model = new CrdtCollectionModel();
-    model.add('id', {id: 'value'}, ['key1', 'key2']);
+    const value: ModelValue = {id: 'id', rawData: 'value'};
+    model.add('id', value, ['key1', 'key2']);
     const effective = model.remove('id', ['key1', 'key2']);
     assert.isTrue(effective);
     assert.equal(model.size, 0);
   });
   it('treats add with different keys as idempotent', async () => {
-    const value: ModelValue = {id: 'value'};
+    const value: ModelValue = {id: 'id', rawData: 'value'};
     const model = new CrdtCollectionModel();
     model.add('id', value, ['key1']);
-    const effective = model.add('id', {id: 'value'}, ['key2']);
+    const effective = model.add('id', value, ['key2']);
     assert.isFalse(effective);
     assert.equal(model.size, 1);
     assert.equal(model.getValue('id'), value);
@@ -37,14 +38,16 @@ describe('crdt-collection-model', () => {
   });
   it('treats remove as idempotent', async () => {
     const model = new CrdtCollectionModel();
-    model.add('id', {id: 'value'}, ['key1', 'key2']);
+    const value: ModelValue = {id: 'id', rawData: 'value'};
+    model.add('id', value, ['key1', 'key2']);
     model.remove('id', ['key1', 'key2']);
     const effective = model.remove('id', ['key1', 'key2']);
     assert.isFalse(effective);
   });
   it('doesnt treat value as removed until all keys are removed', async () => {
     const model = new CrdtCollectionModel();
-    model.add('id', {id: 'value'}, ['key1', 'key2']);
+    const value: ModelValue = {id: 'id', rawData: 'value'};
+    model.add('id', value, ['key1', 'key2']);
     let effective = model.remove('id', ['key1']);
     assert.isFalse(effective);
     assert.equal(model.size, 1);
@@ -54,27 +57,30 @@ describe('crdt-collection-model', () => {
     assert.equal(model.size, 0);
   });
   it('allows a value to be updated', async () => {
-    const value2: ModelValue = {id: 'value2'};
+    const value1: ModelValue = {id: 'id1', rawData: 'value1'};
+    const value2: ModelValue = {id: 'id2', rawData: 'value2'};
 
     const model = new CrdtCollectionModel();
-    model.add('id', {id: 'value'}, ['key1', 'key2']);
+    model.add('id', value1, ['key1', 'key2']);
     const effective = model.add('id', value2, ['key3']);
     assert.isTrue(effective);
     assert.equal(model.getValue('id'), value2);
   });
   it('does not allow a value to be updated unless new keys are added', async () => {
     const model = new CrdtCollectionModel();
-    model.add('id', {id: 'value'}, ['key1', 'key2']);
-    assert.throws(() => model.add('id', {id: 'value2'}, ['key1']), /cannot add without new keys/);
+    const value: ModelValue = {id: 'id', rawData: 'value'};
+    model.add('id', value, ['key1', 'key2']);
+    assert.throws(() => model.add('id', {id: 'id2', rawData: 'value2'}, ['key1']), /cannot add without new keys/);
   });
   it('does not allow a value to be added without keys', async () => {
     const model = new CrdtCollectionModel();
-    assert.throws(() => model.add('id', {id: 'value'}, []), /add requires a list of keys/);
+    const value: ModelValue = {id: 'id', rawData: 'value'};
+    assert.throws(() => model.add('id', value, []), /add requires a list of keys/);
   });
   it('allows keys to be initialized empty', async () => {
     const model = new CrdtCollectionModel([
-      { id: 'nokeys', value: {id: 'value'}, keys: [] },
-      { id: 'keys', value: {id: 'value'}, keys: ['key1'] },
+      { id: 'nokeys', value: {id: 'id', rawData: 'value'}, keys: [] },
+      { id: 'keys', value: {id: 'id', rawData: 'value'}, keys: ['key1'] },
     ]);
     assert.equal(model.size, 2);
     assert.isEmpty(model.getKeys('nokeys'));


### PR DESCRIPTION
Storage Cleanups resulting from PouchDB timing

- Tighten up CRDT/Storage Typescript Types
- make resolveInitialized a scoped variable
- Make fromLiteral private, add Promise<void> for cloneFrom

1.5 points