### PR TITLE
Added ArcId class, made Id constructor protected.

### DIFF
--- a/shells/lib/utils.js
+++ b/shells/lib/utils.js
@@ -4,7 +4,7 @@ import {RecipeResolver} from '../../build/runtime/recipe/recipe-resolver.js';
 import {PlatformLoader} from '../../build/platform/loader-web.js';
 import {PecIndustry} from '../../build/platform/pec-industry-web.js';
 import {debugListeners} from './debug-listeners.js';
-import {Id} from '../../build/runtime/id.js';
+import {IdGenerator} from '../../build/runtime/id.js';
 
 const log = console.log.bind(console);
 const warn = console.warn.bind(console);
@@ -56,8 +56,9 @@ const resolve = async (arc, recipe) =>{
 };
 
 const spawn = async ({id, serialization, context, composer, storage}) => {
+  const arcId = IdGenerator.newSession().createArcId(id);
   const params = {
-    id: new Id(id),
+    id: arcId,
     fileName: './serialized.manifest',
     serialization,
     context,

--- a/shells/lib/utils.js
+++ b/shells/lib/utils.js
@@ -56,7 +56,7 @@ const resolve = async (arc, recipe) =>{
 };
 
 const spawn = async ({id, serialization, context, composer, storage}) => {
-  const arcId = IdGenerator.newSession().createArcId(id);
+  const arcId = IdGenerator.newSession().newArcId(id);
   const params = {
     id: arcId,
     fileName: './serialized.manifest',

--- a/src/planning/recipe-index.ts
+++ b/src/planning/recipe-index.ts
@@ -98,11 +98,10 @@ export class RecipeIndex {
 
   constructor(arc: Arc, {reportGenerations = false} = {}) {
     const trace = Tracing.start({cat: 'indexing', name: 'RecipeIndex::constructor', overview: true});
-    // TODO: Inject an IdGenerator instead of starting a new session here.
     const idGenerator = IdGenerator.newSession();
     const arcStub = new Arc({
-      id: idGenerator.createArcId('index-stub'),
-      context: new Manifest({id: idGenerator.createArcId('empty-context')}),
+      id: idGenerator.newArcId('index-stub'),
+      context: new Manifest({id: idGenerator.newArcId('empty-context')}),
       loader: arc.loader,
       slotComposer: new SlotComposer({
         modalityHandler: PlanningModalityHandler.createHeadlessHandler(),

--- a/src/planning/recipe-index.ts
+++ b/src/planning/recipe-index.ts
@@ -36,7 +36,7 @@ import {CreateHandleGroup} from './strategies/create-handle-group.js';
 import {MatchFreeHandlesToConnections} from './strategies/match-free-handles-to-connections.js';
 import {ResolveRecipe} from './strategies/resolve-recipe.js';
 import * as Rulesets from './strategies/rulesets.js';
-import {Id} from '../runtime/id.js';
+import {Id, ArcId, IdGenerator} from '../runtime/id.js';
 
 type ConsumeSlotConnectionMatch = {
   recipeParticle: Particle,
@@ -98,9 +98,11 @@ export class RecipeIndex {
 
   constructor(arc: Arc, {reportGenerations = false} = {}) {
     const trace = Tracing.start({cat: 'indexing', name: 'RecipeIndex::constructor', overview: true});
+    // TODO: Inject an IdGenerator instead of starting a new session here.
+    const idGenerator = IdGenerator.newSession();
     const arcStub = new Arc({
-      id: new Id('index-stub'),
-      context: new Manifest({id: new Id('empty-context')}),
+      id: idGenerator.createArcId('index-stub'),
+      context: new Manifest({id: idGenerator.createArcId('empty-context')}),
       loader: arc.loader,
       slotComposer: new SlotComposer({
         modalityHandler: PlanningModalityHandler.createHeadlessHandler(),

--- a/src/planning/test/plan/plan-producer-test.ts
+++ b/src/planning/test/plan/plan-producer-test.ts
@@ -18,7 +18,7 @@ import {PlanProducer} from '../../plan/plan-producer.js';
 import {Planificator} from '../../plan/planificator.js';
 import {PlanningResult} from '../../plan/planning-result.js';
 import {Suggestion} from '../../plan/suggestion.js';
-import {Id} from '../../../runtime/id.js';
+import {Id, ArcId} from '../../../runtime/id.js';
 
 class TestPlanProducer extends PlanProducer {
   options;
@@ -164,7 +164,7 @@ describe('plan producer - search', () => {
       schema Bar
         Text value
     `);
-    const arc = new Arc({slotComposer: new FakeSlotComposer(), loader, context: manifest, id: new Id('test'),
+    const arc = new Arc({slotComposer: new FakeSlotComposer(), loader, context: manifest, id: ArcId.newArcIdForTest('test'),
                          storageKey: 'volatile://test^^123'});
     const searchStore = await Planificator['_initSearchStore'](arc, /* userid= */ 'TestUser');
 

--- a/src/planning/test/plan/plan-producer-test.ts
+++ b/src/planning/test/plan/plan-producer-test.ts
@@ -164,7 +164,7 @@ describe('plan producer - search', () => {
       schema Bar
         Text value
     `);
-    const arc = new Arc({slotComposer: new FakeSlotComposer(), loader, context: manifest, id: ArcId.newArcIdForTest('test'),
+    const arc = new Arc({slotComposer: new FakeSlotComposer(), loader, context: manifest, id: ArcId.newForTest('test'),
                          storageKey: 'volatile://test^^123'});
     const searchStore = await Planificator['_initSearchStore'](arc, /* userid= */ 'TestUser');
 

--- a/src/planning/test/plan/replan-queue-test.ts
+++ b/src/planning/test/plan/replan-queue-test.ts
@@ -40,7 +40,7 @@ async function init(options?) {
     schema Bar
       Text value
   `);
-  const arc = new Arc({slotComposer: new FakeSlotComposer(), loader, context: manifest, id: ArcId.newArcIdForTest('test')});
+  const arc = new Arc({slotComposer: new FakeSlotComposer(), loader, context: manifest, id: ArcId.newForTest('test')});
 
   const producer = new TestPlanProducer(arc);
   const queue = new ReplanQueue(producer, options);

--- a/src/planning/test/plan/replan-queue-test.ts
+++ b/src/planning/test/plan/replan-queue-test.ts
@@ -15,7 +15,7 @@ import {FakeSlotComposer} from '../../../runtime/testing/fake-slot-composer.js';
 import {PlanProducer} from '../../plan/plan-producer.js';
 import {PlanningResult} from '../../plan/planning-result.js';
 import {ReplanQueue} from '../../plan/replan-queue.js';
-import {Id} from '../../../runtime/id.js';
+import {Id, ArcId} from '../../../runtime/id.js';
 
 class TestPlanProducer extends PlanProducer {
   produceSuggestionsCalled = 0;
@@ -40,7 +40,7 @@ async function init(options?) {
     schema Bar
       Text value
   `);
-  const arc = new Arc({slotComposer: new FakeSlotComposer(), loader, context: manifest, id: new Id('test')});
+  const arc = new Arc({slotComposer: new FakeSlotComposer(), loader, context: manifest, id: ArcId.newArcIdForTest('test')});
 
   const producer = new TestPlanProducer(arc);
   const queue = new ReplanQueue(producer, options);

--- a/src/planning/test/planner-tests.ts
+++ b/src/planning/test/planner-tests.ts
@@ -17,7 +17,7 @@ import {StubLoader} from '../../runtime/testing/stub-loader.js';
 import {Planner} from '../planner.js';
 
 import {StrategyTestHelper} from './strategies/strategy-test-helper.js';
-import {Id} from '../../runtime/id.js';
+import {Id, ArcId} from '../../runtime/id.js';
 
 async function planFromManifest(manifest, {arcFactory, testSteps}: {arcFactory?, testSteps?} = {}) {
   const loader = new Loader();
@@ -74,7 +74,7 @@ const loadTestArcAndRunSpeculation = async (manifest, manifestLoadedCallback) =>
   const loadedManifest = await Manifest.load('manifest', loader, {registry});
   manifestLoadedCallback(loadedManifest);
 
-  const arc = new Arc({id: new Id('test-plan-arc'), context: loadedManifest, loader});
+  const arc = new Arc({id: ArcId.newArcIdForTest('test-plan-arc'), context: loadedManifest, loader});
   const planner = new Planner();
   const options = {strategyArgs: StrategyTestHelper.createTestStrategyArgs(arc)};
   planner.init(arc, options);

--- a/src/planning/test/planner-tests.ts
+++ b/src/planning/test/planner-tests.ts
@@ -74,7 +74,7 @@ const loadTestArcAndRunSpeculation = async (manifest, manifestLoadedCallback) =>
   const loadedManifest = await Manifest.load('manifest', loader, {registry});
   manifestLoadedCallback(loadedManifest);
 
-  const arc = new Arc({id: ArcId.newArcIdForTest('test-plan-arc'), context: loadedManifest, loader});
+  const arc = new Arc({id: ArcId.newForTest('test-plan-arc'), context: loadedManifest, loader});
   const planner = new Planner();
   const options = {strategyArgs: StrategyTestHelper.createTestStrategyArgs(arc)};
   planner.init(arc, options);

--- a/src/planning/test/recipe-index-test.ts
+++ b/src/planning/test/recipe-index-test.ts
@@ -15,7 +15,7 @@ import {Manifest} from '../../runtime/manifest.js';
 import {MockSlotComposer} from '../../runtime/testing/mock-slot-composer.js';
 import {TestHelper} from '../../runtime/testing/test-helper.js';
 import {RecipeIndex} from '../recipe-index.js';
-import {Id} from '../../runtime/id.js';
+import {Id, ArcId} from '../../runtime/id.js';
 
 describe('RecipeIndex', () => {
   async function createIndex(manifestContent) {
@@ -25,7 +25,7 @@ describe('RecipeIndex', () => {
     }
     const loader = new Loader();
     const arc = new Arc({
-      id: new Id('test-plan-arc'),
+      id: ArcId.newArcIdForTest('test-plan-arc'),
       context: manifest,
       loader,
       slotComposer: new MockSlotComposer()

--- a/src/planning/test/recipe-index-test.ts
+++ b/src/planning/test/recipe-index-test.ts
@@ -25,7 +25,7 @@ describe('RecipeIndex', () => {
     }
     const loader = new Loader();
     const arc = new Arc({
-      id: ArcId.newArcIdForTest('test-plan-arc'),
+      id: ArcId.newForTest('test-plan-arc'),
       context: manifest,
       loader,
       slotComposer: new MockSlotComposer()

--- a/src/planning/test/speculator-tests.ts
+++ b/src/planning/test/speculator-tests.ts
@@ -18,7 +18,7 @@ import {Id, ArcId} from '../../runtime/id.js';
 describe('speculator', () => {
   it('can speculatively produce a relevance', async () => {
     const loader = new Loader();
-    const arc = new Arc({id: ArcId.newArcIdForTest('test'), loader, context: new Manifest({id: ArcId.newArcIdForTest('test')})});
+    const arc = new Arc({id: ArcId.newForTest('test'), loader, context: new Manifest({id: ArcId.newForTest('test')})});
     const manifest = await Manifest.load('./src/runtime/test/artifacts/test.manifest', loader);
     const recipe = manifest.recipes[0];
     assert(recipe.normalize());

--- a/src/planning/test/speculator-tests.ts
+++ b/src/planning/test/speculator-tests.ts
@@ -13,12 +13,12 @@ import {Arc} from '../../runtime/arc.js';
 import {Loader} from '../../runtime/loader.js';
 import {Manifest} from '../../runtime/manifest.js';
 import {Speculator} from '../speculator.js';
-import {Id} from '../../runtime/id.js';
+import {Id, ArcId} from '../../runtime/id.js';
 
 describe('speculator', () => {
   it('can speculatively produce a relevance', async () => {
     const loader = new Loader();
-    const arc = new Arc({id: new Id('test'), loader, context: new Manifest({id: new Id('test')})});
+    const arc = new Arc({id: ArcId.newArcIdForTest('test'), loader, context: new Manifest({id: ArcId.newArcIdForTest('test')})});
     const manifest = await Manifest.load('./src/runtime/test/artifacts/test.manifest', loader);
     const recipe = manifest.recipes[0];
     assert(recipe.normalize());

--- a/src/planning/test/strategies/convert-constraints-to-connections-tests.ts
+++ b/src/planning/test/strategies/convert-constraints-to-connections-tests.ts
@@ -20,7 +20,7 @@ import {ArcId} from '../../../runtime/id.js';
 describe('ConvertConstraintsToConnections', async () => {
   const newArc = (manifest: Manifest) => {
     return new Arc({
-      id: ArcId.newArcIdForTest('test-plan-arc'),
+      id: ArcId.newForTest('test-plan-arc'),
       slotComposer: new FakeSlotComposer(),
       context: manifest,
       loader: new Loader()
@@ -300,7 +300,7 @@ describe('ConvertConstraintsToConnections', async () => {
     `);
     const inputParams = {generated: [{result: manifest.recipes[0], score: 1, derivation: [], hash: '0', valid: true}, {result: manifest.recipes[1], score: 1, derivation: [], hash: '0', valid: true}]};
     const cctc = new ConvertConstraintsToConnections(new Arc({
-      id: ArcId.newArcIdForTest('test-plan-arc'),
+      id: ArcId.newForTest('test-plan-arc'),
       slotComposer: new FakeSlotComposer({modalityName: Modality.Name.Vr}),
       context: manifest,
       loader: new Loader()

--- a/src/planning/test/strategies/convert-constraints-to-connections-tests.ts
+++ b/src/planning/test/strategies/convert-constraints-to-connections-tests.ts
@@ -14,13 +14,13 @@ import {Manifest} from '../../../runtime/manifest.js';
 import {Modality} from '../../../runtime/modality.js';
 import {FakeSlotComposer} from '../../../runtime/testing/fake-slot-composer.js';
 import {ConvertConstraintsToConnections} from '../../strategies/convert-constraints-to-connections.js';
-import {Id} from '../../../runtime/id.js';
-import { InstanceEndPoint } from '../../../runtime/recipe/connection-constraint.js';
+import {InstanceEndPoint} from '../../../runtime/recipe/connection-constraint.js';
+import {ArcId} from '../../../runtime/id.js';
 
 describe('ConvertConstraintsToConnections', async () => {
   const newArc = (manifest: Manifest) => {
     return new Arc({
-      id: new Id('test-plan-arc'),
+      id: ArcId.newArcIdForTest('test-plan-arc'),
       slotComposer: new FakeSlotComposer(),
       context: manifest,
       loader: new Loader()
@@ -300,7 +300,7 @@ describe('ConvertConstraintsToConnections', async () => {
     `);
     const inputParams = {generated: [{result: manifest.recipes[0], score: 1, derivation: [], hash: '0', valid: true}, {result: manifest.recipes[1], score: 1, derivation: [], hash: '0', valid: true}]};
     const cctc = new ConvertConstraintsToConnections(new Arc({
-      id: new Id('test-plan-arc'),
+      id: ArcId.newArcIdForTest('test-plan-arc'),
       slotComposer: new FakeSlotComposer({modalityName: Modality.Name.Vr}),
       context: manifest,
       loader: new Loader()

--- a/src/planning/test/strategies/find-hosted-particle-tests.ts
+++ b/src/planning/test/strategies/find-hosted-particle-tests.ts
@@ -157,7 +157,7 @@ describe('FindHostedParticle', () => {
           output = h0
     `, {loader, fileName: process.cwd() + '/input.manifest'});
 
-    const arc = new Arc({id: ArcId.newArcIdForTest('test'), context: manifest, loader});
+    const arc = new Arc({id: ArcId.newForTest('test'), context: manifest, loader});
     const strategy = new FindHostedParticle(arc);
 
     const inRecipe = manifest.recipes[0];

--- a/src/planning/test/strategies/find-hosted-particle-tests.ts
+++ b/src/planning/test/strategies/find-hosted-particle-tests.ts
@@ -18,7 +18,7 @@ import {InterfaceType} from '../../../runtime/type.js';
 import {FindHostedParticle} from '../../strategies/find-hosted-particle.js';
 
 import {StrategyTestHelper} from './strategy-test-helper.js';
-import {Id} from '../../../runtime/id.js';
+import {Id, ArcId} from '../../../runtime/id.js';
 
 async function runStrategy(manifestStr) {
   const manifest = await Manifest.parse(manifestStr);
@@ -157,7 +157,7 @@ describe('FindHostedParticle', () => {
           output = h0
     `, {loader, fileName: process.cwd() + '/input.manifest'});
 
-    const arc = new Arc({id: new Id('test'), context: manifest, loader});
+    const arc = new Arc({id: ArcId.newArcIdForTest('test'), context: manifest, loader});
     const strategy = new FindHostedParticle(arc);
 
     const inRecipe = manifest.recipes[0];

--- a/src/planning/test/strategies/init-population-tests.ts
+++ b/src/planning/test/strategies/init-population-tests.ts
@@ -35,7 +35,7 @@ describe('InitPopulation', async () => {
     });
     const recipe = manifest.recipes[0];
     assert(recipe.normalize());
-    const arc = new Arc({id: ArcId.newArcIdForTest('test-plan-arc'), context: manifest, loader});
+    const arc = new Arc({id: ArcId.newForTest('test-plan-arc'), context: manifest, loader});
 
     async function scoreOfInitPopulationOutput() {
       const results = await new InitPopulation(arc, StrategyTestHelper.createTestStrategyArgs(
@@ -62,8 +62,8 @@ describe('InitPopulation', async () => {
       'A.js': 'defineParticle(({Particle}) => class extends Particle {})'
     });
     const arc = new Arc({
-      id: ArcId.newArcIdForTest('test-plan-arc'),
-      context: new Manifest({id: ArcId.newArcIdForTest('test')}),
+      id: ArcId.newForTest('test-plan-arc'),
+      context: new Manifest({id: ArcId.newForTest('test')}),
       loader
     });
 

--- a/src/planning/test/strategies/init-population-tests.ts
+++ b/src/planning/test/strategies/init-population-tests.ts
@@ -16,7 +16,7 @@ import {StubLoader} from '../../../runtime/testing/stub-loader.js';
 import {InitPopulation} from '../../strategies/init-population.js';
 
 import {StrategyTestHelper} from './strategy-test-helper.js';
-import {Id} from '../../../runtime/id.js';
+import {Id, ArcId} from '../../../runtime/id.js';
 
 describe('InitPopulation', async () => {
   it('penalizes resolution of particles that already exist in the arc', async () => {
@@ -35,7 +35,7 @@ describe('InitPopulation', async () => {
     });
     const recipe = manifest.recipes[0];
     assert(recipe.normalize());
-    const arc = new Arc({id: new Id('test-plan-arc'), context: manifest, loader});
+    const arc = new Arc({id: ArcId.newArcIdForTest('test-plan-arc'), context: manifest, loader});
 
     async function scoreOfInitPopulationOutput() {
       const results = await new InitPopulation(arc, StrategyTestHelper.createTestStrategyArgs(
@@ -62,8 +62,8 @@ describe('InitPopulation', async () => {
       'A.js': 'defineParticle(({Particle}) => class extends Particle {})'
     });
     const arc = new Arc({
-      id: new Id('test-plan-arc'),
-      context: new Manifest({id: new Id('test')}),
+      id: ArcId.newArcIdForTest('test-plan-arc'),
+      context: new Manifest({id: ArcId.newArcIdForTest('test')}),
       loader
     });
 

--- a/src/planning/test/strategies/map-slots-tests.ts
+++ b/src/planning/test/strategies/map-slots-tests.ts
@@ -157,9 +157,9 @@ ${recipeManifest}
   it('prefers local slots if available', async () => {
     // Arc has both a 'root' and an 'action' slot.
     const arc = new Arc({
-      id: ArcId.newArcIdForTest('test-plan-arc'),
+      id: ArcId.newForTest('test-plan-arc'),
       loader: new Loader(),
-      context: new Manifest({id: ArcId.newArcIdForTest('test')}),
+      context: new Manifest({id: ArcId.newForTest('test')}),
       slotComposer: new FakeSlotComposer({containers: {root: {}, action: {}}})
     });
 

--- a/src/planning/test/strategies/map-slots-tests.ts
+++ b/src/planning/test/strategies/map-slots-tests.ts
@@ -18,7 +18,7 @@ import {MapSlots} from '../../strategies/map-slots.js';
 import {ResolveRecipe} from '../../strategies/resolve-recipe.js';
 
 import {StrategyTestHelper} from './strategy-test-helper.js';
-import {Id} from '../../../runtime/id.js';
+import {Id, ArcId} from '../../../runtime/id.js';
 
 describe('MapSlots', () => {
   const particlesSpec = `
@@ -157,9 +157,9 @@ ${recipeManifest}
   it('prefers local slots if available', async () => {
     // Arc has both a 'root' and an 'action' slot.
     const arc = new Arc({
-      id: new Id('test-plan-arc'),
+      id: ArcId.newArcIdForTest('test-plan-arc'),
       loader: new Loader(),
-      context: new Manifest({id: new Id('test')}),
+      context: new Manifest({id: ArcId.newArcIdForTest('test')}),
       slotComposer: new FakeSlotComposer({containers: {root: {}, action: {}}})
     });
 

--- a/src/planning/test/strategies/strategy-test-helper.ts
+++ b/src/planning/test/strategies/strategy-test-helper.ts
@@ -16,12 +16,12 @@ import {Manifest} from '../../../runtime/manifest.js';
 import {Modality} from '../../../runtime/modality.js';
 import {FakeSlotComposer} from '../../../runtime/testing/fake-slot-composer.js';
 import {RecipeIndex} from '../../recipe-index.js';
-import {Id} from '../../../runtime/id.js';
+import {Id, ArcId} from '../../../runtime/id.js';
 
 export class StrategyTestHelper {
   static createTestArc(context: Manifest, options: {arcId?: Id, modalityName?: string, loader?: Loader} = {}) {
     return new Arc({
-      id: options.arcId || new Id('test-arc'),
+      id: options.arcId || ArcId.newArcIdForTest('test-arc'),
       loader: options.loader || new Loader(),
       context,
       slotComposer: new FakeSlotComposer(options)

--- a/src/planning/test/strategies/strategy-test-helper.ts
+++ b/src/planning/test/strategies/strategy-test-helper.ts
@@ -21,7 +21,7 @@ import {Id, ArcId} from '../../../runtime/id.js';
 export class StrategyTestHelper {
   static createTestArc(context: Manifest, options: {arcId?: Id, modalityName?: string, loader?: Loader} = {}) {
     return new Arc({
-      id: options.arcId || ArcId.newArcIdForTest('test-arc'),
+      id: options.arcId || ArcId.newForTest('test-arc'),
       loader: options.loader || new Loader(),
       context,
       slotComposer: new FakeSlotComposer(options)

--- a/src/runtime/arc.ts
+++ b/src/runtime/arc.ts
@@ -442,7 +442,7 @@ ${this.activeRecipe.toString()}`;
   }
 
   generateID(component: string = ''): Id {
-    return this.idGenerator.createChildId(this.id, component);
+    return this.idGenerator.newChildId(this.id, component);
   }
 
   get _stores(): (StorageProviderBase)[] {

--- a/src/runtime/arc.ts
+++ b/src/runtime/arc.ts
@@ -14,7 +14,7 @@ import {PECInnerPort} from './api-channel.js';
 import {ArcDebugListenerDerived} from './debug/abstract-devtools-channel.js';
 import {ArcDebugHandler} from './debug/arc-debug-handler.js';
 import {FakePecFactory} from './fake-pec-factory.js';
-import {Id, IdGenerator} from './id.js';
+import {Id, IdGenerator, ArcId} from './id.js';
 import {Loader} from './loader.js';
 import {Manifest, StorageStub} from './manifest.js';
 import {Modality} from './modality.js';
@@ -103,7 +103,7 @@ export class Arc {
       console.error(
           `Arc created with string ID ${id}!!! This should be an object of type Id instead. This warning will turn into an ` +
           `exception soon (end of April 2019).`);
-      this.id = new Id(id);
+      this.id = ArcId.fromString(id);
     } else {
       this.id = id;
     }

--- a/src/runtime/id.ts
+++ b/src/runtime/id.ts
@@ -36,6 +36,10 @@ export class IdGenerator {
   static createWithSessionIdForTesting(sessionId: string) {
     return new IdGenerator(sessionId);
   }
+  
+  createArcId(name: string): ArcId {
+    return ArcId._createArcIdInternal(this._currentSessionId, name);
+  }
 
   /**
    * Creates a new ID, as a child of the given parentId. The given subcomponent will be appended to the component hierarchy of the given ID, but
@@ -44,7 +48,7 @@ export class IdGenerator {
   createChildId(parentId: Id, subcomponent: string = '') {
     // Append (and increment) a counter to the subcomponent, to ensure that it is unique.
     subcomponent += this._nextComponentId++;
-    return new Id(this._currentSessionId, [...parentId.idTree, subcomponent]);
+    return Id._createIdInternal(this._currentSessionId, [...parentId.idTree, subcomponent]);
   }
 
   get currentSessionIdForTesting() {
@@ -65,11 +69,18 @@ export class Id {
   /** The components of the idTree. */
   readonly idTree: string[] = [];
 
-  constructor(root: string, idTree: string[] = []) {
+  /** Protected constructor. Use IdGenerator to create new IDs instead. */
+  protected constructor(root: string, idTree: string[] = []) {
     this.root = root;
     this.idTree = idTree;
   }
 
+  /** Creates a new ID. Use IdGenerator to create new IDs instead. */
+  static _createIdInternal(root: string, idTree: string[] = []): Id {
+    return new Id(root, idTree);
+  }
+
+  /** Parses a string representation of an ID (see toString). */
   static fromString(str: string): Id {
     const bits = str.split(':');
 
@@ -102,5 +113,17 @@ export class Id {
       }
     }
     return true;
+  }
+}
+
+export class ArcId extends Id {
+  /** Creates a new Arc ID. Use IdGenerator to create new IDs instead. */
+  static _createArcIdInternal(root: string, name: string): ArcId {
+    return new ArcId(root, [name]);
+  }
+
+  /** Creates a new Arc ID with the given name. For convenience in unit testing only; otherwise use IdGenerator to create new IDs instead. */
+  static newArcIdForTest(id: string): ArcId {
+    return IdGenerator.newSession().createArcId(id);
   }
 }

--- a/src/runtime/id.ts
+++ b/src/runtime/id.ts
@@ -37,6 +37,7 @@ export class IdGenerator {
     return new IdGenerator(sessionId);
   }
   
+  /** Creates a new ArcId. */
   createArcId(name: string): ArcId {
     return ArcId._createArcIdInternal(this._currentSessionId, name);
   }

--- a/src/runtime/id.ts
+++ b/src/runtime/id.ts
@@ -37,19 +37,18 @@ export class IdGenerator {
     return new IdGenerator(sessionId);
   }
   
-  /** Creates a new ArcId. */
-  createArcId(name: string): ArcId {
-    return ArcId._createArcIdInternal(this._currentSessionId, name);
+  newArcId(name: string): ArcId {
+    return ArcId._newArcIdInternal(this._currentSessionId, name);
   }
 
   /**
    * Creates a new ID, as a child of the given parentId. The given subcomponent will be appended to the component hierarchy of the given ID, but
    * the generator's random session ID will be used as the ID's root.
    */
-  createChildId(parentId: Id, subcomponent: string = '') {
+  newChildId(parentId: Id, subcomponent: string = '') {
     // Append (and increment) a counter to the subcomponent, to ensure that it is unique.
     subcomponent += this._nextComponentId++;
-    return Id._createIdInternal(this._currentSessionId, [...parentId.idTree, subcomponent]);
+    return Id._newIdInternal(this._currentSessionId, [...parentId.idTree, subcomponent]);
   }
 
   get currentSessionIdForTesting() {
@@ -77,7 +76,7 @@ export class Id {
   }
 
   /** Creates a new ID. Use IdGenerator to create new IDs instead. */
-  static _createIdInternal(root: string, idTree: string[] = []): Id {
+  static _newIdInternal(root: string, idTree: string[] = []): Id {
     return new Id(root, idTree);
   }
 
@@ -119,12 +118,12 @@ export class Id {
 
 export class ArcId extends Id {
   /** Creates a new Arc ID. Use IdGenerator to create new IDs instead. */
-  static _createArcIdInternal(root: string, name: string): ArcId {
+  static _newArcIdInternal(root: string, name: string): ArcId {
     return new ArcId(root, [name]);
   }
 
   /** Creates a new Arc ID with the given name. For convenience in unit testing only; otherwise use IdGenerator to create new IDs instead. */
-  static newArcIdForTest(id: string): ArcId {
-    return IdGenerator.newSession().createArcId(id);
+  static newForTest(id: string): ArcId {
+    return IdGenerator.newSession().newArcId(id);
   }
 }

--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -183,7 +183,7 @@ export class Manifest {
       // from the file, this is the 'manifest' phrase.
       // TODO: Figure out if this is ok, and stop using internal Id APIs.
       const components = id.split(':');
-      this._id = Id._createIdInternal(components[0], components.slice(1));
+      this._id = Id._newIdInternal(components[0], components.slice(1));
     }
   }
   get id() {
@@ -356,7 +356,7 @@ export class Manifest {
   }
   // TODO: Unify ID handling to use ID instances, not strings. Change return type here to ID.
   generateID(): string {
-    return this._idGenerator.createChildId(this.id).toString();
+    return this._idGenerator.newChildId(this.id).toString();
   }
 
   static async load(fileName: string, loader: {loadResource}, options?): Promise<Manifest> {

--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -12,7 +12,7 @@ import {parse, SyntaxError} from '../gen/runtime/manifest-parser.js';
 import {assert} from '../platform/assert-web.js';
 import {digest} from '../platform/digest-web.js';
 
-import {Id, IdGenerator} from './id.js';
+import {Id, IdGenerator, ArcId} from './id.js';
 import {InterfaceInfo} from './interface-info.js';
 import {ManifestMeta} from './manifest-meta.js';
 import * as AstNode from './manifest-ast-nodes.js';
@@ -181,9 +181,9 @@ export class Manifest {
     } else {
       // We use the first component of an ID as a session ID, for manifests parsed
       // from the file, this is the 'manifest' phrase.
-      // TODO: Figure out if this is ok.
+      // TODO: Figure out if this is ok, and stop using internal Id APIs.
       const components = id.split(':');
-      this._id = new Id(components[0], components.slice(1));
+      this._id = Id._createIdInternal(components[0], components.slice(1));
     }
   }
   get id() {

--- a/src/runtime/manual_tests/firebase-tests.ts
+++ b/src/runtime/manual_tests/firebase-tests.ts
@@ -69,7 +69,7 @@ describe('firebase', function() {
         schema Bar
           Text value
       `);
-      const arc = new Arc({id: ArcId.newArcIdForTest('test'), loader: new Loader(), context: manifest});
+      const arc = new Arc({id: ArcId.newForTest('test'), loader: new Loader(), context: manifest});
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const value = 'Hi there' + Math.random();
@@ -91,15 +91,15 @@ describe('firebase', function() {
         schema Bar
           Text value
       `);
-      const arc = new Arc({id: ArcId.newArcIdForTest('test'), loader: new Loader(), context: manifest});
+      const arc = new Arc({id: ArcId.newForTest('test'), loader: new Loader(), context: manifest});
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const key = newStoreKey('variable');
       const var1 = await storage.construct('test0', barType, key) as VariableStorageProvider;
       const var2 = await storage.connect('test0', barType, key) as VariableStorageProvider;
 
-      var1.set({id: ArcId.newArcIdForTest('id1'), value: 'value1'});
-      var2.set({id: ArcId.newArcIdForTest('id2'), value: 'value2'});
+      var1.set({id: ArcId.newForTest('id1'), value: 'value1'});
+      var2.set({id: ArcId.newForTest('id2'), value: 'value2'});
       await synchronized(var1, var2);
       assert.deepEqual(await var1.get(), await var2.get());
     });
@@ -109,13 +109,13 @@ describe('firebase', function() {
         schema Bar
           Text value
       `);
-      const arc = new Arc({id: ArcId.newArcIdForTest('test'), loader: new Loader(), context: manifest});
+      const arc = new Arc({id: ArcId.newForTest('test'), loader: new Loader(), context: manifest});
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const key1 = newStoreKey('varPtr');
 
       const var1 = await storage.construct('test0', barType, key1) as VariableStorageProvider;
-      await var1.set({id: ArcId.newArcIdForTest('id1'), value: 'underlying'});
+      await var1.set({id: ArcId.newForTest('id1'), value: 'underlying'});
 
       const result = await var1.get();
       assert.equal(result.value, 'underlying');
@@ -131,14 +131,14 @@ describe('firebase', function() {
         schema Bar
           Text value
       `);
-      const arc = new Arc({id: ArcId.newArcIdForTest('test'), loader: new Loader(), context: manifest});
+      const arc = new Arc({id: ArcId.newForTest('test'), loader: new Loader(), context: manifest});
 
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const key1 = newStoreKey('varPtr');
 
       const var1 = await storage.construct('test0', new ReferenceType(barType), key1) as VariableStorageProvider;
-      await var1.set({id: ArcId.newArcIdForTest('id1'), storageKey: 'underlying'});
+      await var1.set({id: ArcId.newForTest('id1'), storageKey: 'underlying'});
 
       const result = await var1.get();
       assert.equal(result.storageKey, 'underlying');
@@ -155,13 +155,13 @@ describe('firebase', function() {
           Text data
       `);
       const barType = new EntityType(manifest.schemas.Bar1);
-      const arc = new Arc({id: ArcId.newArcIdForTest('test'), loader: new Loader(), context: manifest});
+      const arc = new Arc({id: ArcId.newForTest('test'), loader: new Loader(), context: manifest});
       const storage = createStorage(arc.id);
 
       const var1 = await storage.construct('test1', barType, newStoreKey('variable')) as VariableStorageProvider;
       const var2 = await storage.construct('test2', barType, newStoreKey('variable')) as VariableStorageProvider;
 
-      const bar = n => ({id: ArcId.newArcIdForTest('id') + n, data: 'd' + n});
+      const bar = n => ({id: ArcId.newForTest('id') + n, data: 'd' + n});
       await var1.set(bar(1));
       await var2.set(bar(2));
 
@@ -190,7 +190,7 @@ describe('firebase', function() {
         schema Bar
           Text value
       `);
-      const arc = new Arc({id: ArcId.newArcIdForTest('test'), loader: new Loader(), context: manifest});
+      const arc = new Arc({id: ArcId.newForTest('test'), loader: new Loader(), context: manifest});
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const value1 = 'Hi there' + Math.random();
@@ -200,12 +200,12 @@ describe('firebase', function() {
       let events = 0;
       collection.on('change', () => events++, this);
 
-      await collection.store({id: ArcId.newArcIdForTest('id0'), value: value1}, ['key0']);
-      await collection.store({id: ArcId.newArcIdForTest('id1'), value: value2}, ['key1']);
+      await collection.store({id: ArcId.newForTest('id0'), value: value1}, ['key0']);
+      await collection.store({id: ArcId.newForTest('id1'), value: value2}, ['key1']);
       let result = await collection.get('id0');
       assert.equal(result.value, value1);
       result = await collection.toList();
-      assert.deepEqual(result, [{id: ArcId.newArcIdForTest('id0'), value: value1}, {id: ArcId.newArcIdForTest('id1'), value: value2}]);
+      assert.deepEqual(result, [{id: ArcId.newForTest('id0'), value: value1}, {id: ArcId.newForTest('id1'), value: value2}]);
 
       assert.equal(collection.version, 2);
       assert.equal(events, 2);
@@ -216,14 +216,14 @@ describe('firebase', function() {
         schema Bar
           Text value
       `);
-      const arc = new Arc({id: ArcId.newArcIdForTest('test'), loader: new Loader(), context: manifest});
+      const arc = new Arc({id: ArcId.newForTest('test'), loader: new Loader(), context: manifest});
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const key = newStoreKey('collection');
       const collection1 = await storage.construct('test1', barType.collectionOf(), key) as CollectionStorageProvider;
       const collection2 = await storage.connect('test1', barType.collectionOf(), key) as CollectionStorageProvider;
-      collection1.store({id: ArcId.newArcIdForTest('id1'), value: 'value'}, ['key1']);
-      await collection2.store({id: ArcId.newArcIdForTest('id1'), value: 'value'}, ['key2']);
+      collection1.store({id: ArcId.newForTest('id1'), value: 'value'}, ['key1']);
+      await collection2.store({id: ArcId.newForTest('id1'), value: 'value'}, ['key2']);
       await synchronized(collection1, collection2);
       assert.deepEqual(await collection1.toList(), await collection2.toList());
     });
@@ -233,14 +233,14 @@ describe('firebase', function() {
         schema Bar
           Text value
       `);
-      const arc = new Arc({id: ArcId.newArcIdForTest('test'), loader: new Loader(), context: manifest});
+      const arc = new Arc({id: ArcId.newForTest('test'), loader: new Loader(), context: manifest});
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const key = newStoreKey('collection');
       const collection1 = await storage.construct('test1', barType.collectionOf(), key) as CollectionStorageProvider;
       const collection2 = await storage.connect('test1', barType.collectionOf(), key) as CollectionStorageProvider;
-      collection1.store({id: ArcId.newArcIdForTest('id1'), value: 'value'}, ['key1']);
-      collection2.store({id: ArcId.newArcIdForTest('id1'), value: 'value'}, ['key2']);
+      collection1.store({id: ArcId.newForTest('id1'), value: 'value'}, ['key1']);
+      collection2.store({id: ArcId.newForTest('id1'), value: 'value'}, ['key2']);
       collection1.remove('id1', ['key1']);
       collection2.remove('id1', ['key2']);
       await synchronized(collection1, collection2);
@@ -253,14 +253,14 @@ describe('firebase', function() {
         schema Bar
           Text value
       `);
-      const arc = new Arc({id: ArcId.newArcIdForTest('test'), loader: new Loader(), context: manifest});
+      const arc = new Arc({id: ArcId.newForTest('test'), loader: new Loader(), context: manifest});
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const key = newStoreKey('collection');
       const collection1 = await storage.construct('test1', barType.collectionOf(), key) as CollectionStorageProvider;
       const collection2 = await storage.connect('test1', barType.collectionOf(), key) as CollectionStorageProvider;
-      await collection1.store({id: ArcId.newArcIdForTest('id1'), value: 'value1'}, ['key1']);
-      await collection2.store({id: ArcId.newArcIdForTest('id2'), value: 'value2'}, ['key2']);
+      await collection1.store({id: ArcId.newForTest('id1'), value: 'value1'}, ['key1']);
+      await collection2.store({id: ArcId.newForTest('id2'), value: 'value2'}, ['key2']);
       await synchronized(collection1, collection2);
       assert.lengthOf(await collection1.toList(), 2);
       assert.sameDeepMembers(await collection1.toList(), await collection2.toList());
@@ -272,15 +272,15 @@ describe('firebase', function() {
           Text value
       `);
 
-      const arc = new Arc({id: ArcId.newArcIdForTest('test'), loader: new Loader(), context: manifest});
+      const arc = new Arc({id: ArcId.newForTest('test'), loader: new Loader(), context: manifest});
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const key1 = newStoreKey('colPtr');
 
       const collection1 = await storage.construct('test0', barType.collectionOf(), key1) as CollectionStorageProvider;
 
-      await collection1.store({id: ArcId.newArcIdForTest('id1'), value: 'value1'}, ['key1']);
-      await collection1.store({id: ArcId.newArcIdForTest('id2'), value: 'value2'}, ['key2']);
+      await collection1.store({id: ArcId.newForTest('id1'), value: 'value1'}, ['key1']);
+      await collection1.store({id: ArcId.newForTest('id2'), value: 'value2'}, ['key2']);
 
       let result = await collection1.get('id1');
       assert.equal(result.value, 'value1');
@@ -300,14 +300,14 @@ describe('firebase', function() {
           Text value
       `);
 
-      const arc = new Arc({id: ArcId.newArcIdForTest('test'), loader: new Loader(), context: manifest});
+      const arc = new Arc({id: ArcId.newForTest('test'), loader: new Loader(), context: manifest});
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const key1 = newStoreKey('colPtr');
 
       const collection1 = await storage.construct('test0', new ReferenceType(barType).collectionOf(), key1) as CollectionStorageProvider;
-      await collection1.store({id: ArcId.newArcIdForTest('id1'), storageKey: 'value1'}, ['key1']);
-      await collection1.store({id: ArcId.newArcIdForTest('id2'), storageKey: 'value2'}, ['key2']);
+      await collection1.store({id: ArcId.newForTest('id1'), storageKey: 'value1'}, ['key1']);
+      await collection1.store({id: ArcId.newForTest('id2'), storageKey: 'value2'}, ['key2']);
 
       let result = await collection1.get('id1');
       assert.equal(result.storageKey, 'value1');
@@ -323,15 +323,15 @@ describe('firebase', function() {
         schema Bar
           Text value
       `);
-      const arc = new Arc({id: ArcId.newArcIdForTest('test'), loader: new Loader(), context: manifest});
+      const arc = new Arc({id: ArcId.newForTest('test'), loader: new Loader(), context: manifest});
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const key = newStoreKey('collection');
       const collection = await storage.construct('test1', barType.collectionOf(), key) as CollectionStorageProvider;
-      await collection.store({id: ArcId.newArcIdForTest('id1'), value: 'value'}, ['key1']);
-      await collection.store({id: ArcId.newArcIdForTest('id2'), value: 'value'}, ['key2']);
+      await collection.store({id: ArcId.newForTest('id1'), value: 'value'}, ['key1']);
+      await collection.store({id: ArcId.newForTest('id2'), value: 'value'}, ['key2']);
       await collection.removeMultiple([
-        {id: ArcId.newArcIdForTest('id1'), keys: ['key1']}, {id: ArcId.newArcIdForTest('id2'), keys: ['key2']}
+        {id: ArcId.newForTest('id1'), keys: ['key1']}, {id: ArcId.newForTest('id2'), keys: ['key2']}
       ]);
       assert.isEmpty(await collection.toList());
     });
@@ -344,13 +344,13 @@ describe('firebase', function() {
           Text data
       `);
       const barType = new EntityType(manifest.schemas.Bar2);
-      const arc = new Arc({id: ArcId.newArcIdForTest('test'), loader: new Loader(), context: manifest});
+      const arc = new Arc({id: ArcId.newForTest('test'), loader: new Loader(), context: manifest});
       const storage = createStorage(arc.id);
 
       const col1 = await storage.construct('test1', barType.collectionOf(), newStoreKey('collection')) as CollectionStorageProvider;
       const col2 = await storage.construct('test2', barType.collectionOf(), newStoreKey('collection')) as CollectionStorageProvider;
 
-      const bar = n => ({id: ArcId.newArcIdForTest('id') + n, data: 'd' + n});
+      const bar = n => ({id: ArcId.newForTest('id') + n, data: 'd' + n});
       await col1.store(bar(1), ['key1']);
       await col2.store(bar(2), ['key2']);
       await col1.store(bar(3), ['key3']);
@@ -367,7 +367,7 @@ describe('firebase', function() {
       assert.sameDeepMembers(await backing.toList(), [bar(1), bar(2), bar(3)]);
 
       // Removing one of col2's ids from col1 should have no effect.
-      await col1.removeMultiple([{id: ArcId.newArcIdForTest('id1'), keys: []}, {id: ArcId.newArcIdForTest('id2'), keys: []}]);
+      await col1.removeMultiple([{id: ArcId.newForTest('id1'), keys: []}, {id: ArcId.newForTest('id2'), keys: []}]);
       assert.sameDeepMembers(await col1.toList(), [bar(3)]);
       assert.sameDeepMembers(await col2.toList(), [bar(2)]);
 
@@ -407,7 +407,7 @@ describe('firebase', function() {
         schema Bar
           Text data
       `);
-      const arc = new Arc({id: ArcId.newArcIdForTest('test'), loader: new Loader(), context: manifest});
+      const arc = new Arc({id: ArcId.newForTest('test'), loader: new Loader(), context: manifest});
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const key = newStoreKey('bigcollection');
@@ -416,8 +416,8 @@ describe('firebase', function() {
 
       // Concurrent writes to different ids.
       await Promise.all([
-        collection1.store({id: ArcId.newArcIdForTest('id1'), data: 'ab'}, ['k34']),
-        collection2.store({id: ArcId.newArcIdForTest('id2'), data: 'cd'}, ['k12'])
+        collection1.store({id: ArcId.newForTest('id1'), data: 'ab'}, ['k34']),
+        collection2.store({id: ArcId.newForTest('id2'), data: 'cd'}, ['k12'])
       ]);
       assert.equal((await collection2.get('id1')).data, 'ab');
       assert.equal((await collection1.get('id2')).data, 'cd');
@@ -427,8 +427,8 @@ describe('firebase', function() {
 
       // Concurrent writes to the same id.
       await Promise.all([
-        collection1.store({id: ArcId.newArcIdForTest('id3'), data: 'xx'}, ['k65']),
-        collection2.store({id: ArcId.newArcIdForTest('id3'), data: 'yy'}, ['k87'])
+        collection1.store({id: ArcId.newForTest('id3'), data: 'xx'}, ['k65']),
+        collection2.store({id: ArcId.newForTest('id3'), data: 'yy'}, ['k87'])
       ]);
       assert.include(['xx', 'yy'], (await collection1.get('id3')).data);
 
@@ -482,7 +482,7 @@ describe('firebase', function() {
         schema Bar
           Text data
       `);
-      const arc = new Arc({id: ArcId.newArcIdForTest('test'), loader: new Loader(), context: manifest});
+      const arc = new Arc({id: ArcId.newForTest('test'), loader: new Loader(), context: manifest});
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const col = await storage.construct('test0', barType.bigCollectionOf(), newStoreKey('bigcollection')) as BigCollectionStorageProvider;
@@ -559,7 +559,7 @@ describe('firebase', function() {
         schema Bar
           Text data
       `);
-      const arc = new Arc({id: ArcId.newArcIdForTest('test'), loader: new Loader(), context: manifest});
+      const arc = new Arc({id: ArcId.newForTest('test'), loader: new Loader(), context: manifest});
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const col = await storage.construct('test0', barType.bigCollectionOf(), newStoreKey('bigcollection')) as BigCollectionStorageProvider;
@@ -728,7 +728,7 @@ describe('firebase', function() {
         `
       });
       const manifest = await Manifest.load('manifest', loader);
-      const arc = new Arc({id: ArcId.newArcIdForTest('test'), loader, context: manifest});
+      const arc = new Arc({id: ArcId.newForTest('test'), loader, context: manifest});
       const storage = createStorage(arc.id);
       const dataType = new EntityType(manifest.schemas.Data);
 
@@ -737,9 +737,9 @@ describe('firebase', function() {
       const bigStore = await storage.construct('test2', dataType.bigCollectionOf(), newStoreKey('bigcollection')) as BigCollectionStorageProvider;
 
       // Populate the stores, run the arc and get its serialization.
-      await varStore.set({id: ArcId.newArcIdForTest('i1'), rawData: {value: 'v1'}});
-      await colStore.store({id: ArcId.newArcIdForTest('i2'), rawData: {value: 'v2'}}, ['k2']);
-      await bigStore.store({id: ArcId.newArcIdForTest('i3'), rawData: {value: 'v3'}}, ['k3']);
+      await varStore.set({id: ArcId.newForTest('i1'), rawData: {value: 'v1'}});
+      await colStore.store({id: ArcId.newForTest('i2'), rawData: {value: 'v2'}}, ['k2']);
+      await bigStore.store({id: ArcId.newForTest('i3'), rawData: {value: 'v3'}}, ['k3']);
 
       const recipe = manifest.recipes[0];
       recipe.handles[0].mapToStorage(varStore);
@@ -753,9 +753,9 @@ describe('firebase', function() {
       arc.dispose();
 
       // Update the stores between serializing and deserializing.
-      await varStore.set({id: ArcId.newArcIdForTest('i4'), rawData: {value: 'v4'}});
-      await colStore.store({id: ArcId.newArcIdForTest('i5'), rawData: {value: 'v5'}}, ['k5']);
-      await bigStore.store({id: ArcId.newArcIdForTest('i6'), rawData: {value: 'v6'}}, ['k6']);
+      await varStore.set({id: ArcId.newForTest('i4'), rawData: {value: 'v4'}});
+      await colStore.store({id: ArcId.newForTest('i5'), rawData: {value: 'v5'}}, ['k5']);
+      await bigStore.store({id: ArcId.newForTest('i6'), rawData: {value: 'v6'}}, ['k6']);
 
       const arc2 = await Arc.deserialize({serialization, loader, fileName: '', pecFactory:undefined, slotComposer: undefined, context: manifest});
       const varStore2 = arc2.findStoreById(varStore.id) as VariableStorageProvider;
@@ -788,13 +788,13 @@ describe('firebase', function() {
           Text data
       `);
       const barType = new EntityType(manifest.schemas.Bar3);
-      const arc = new Arc({id: ArcId.newArcIdForTest('test'), loader: new Loader(), context: manifest});
+      const arc = new Arc({id: ArcId.newForTest('test'), loader: new Loader(), context: manifest});
       const storage = createStorage(arc.id);
       const col = await storage.construct('test1', barType.collectionOf(), newStoreKey('collection')) as CollectionStorageProvider;
       const backing = await col.ensureBackingStore();
       backing.maxConcurrentRequests = 3;
 
-      const bar = n => ({id: ArcId.newArcIdForTest('id') + n, data: 'd' + n});
+      const bar = n => ({id: ArcId.newForTest('id') + n, data: 'd' + n});
 
       // store, storeMultiple
       await backing.store(bar(1), ['key1']);
@@ -830,10 +830,10 @@ describe('firebase', function() {
 
       // removeMultiple: safe to use non-existent keys and ids
       await backing.removeMultiple([
-        {id: ArcId.newArcIdForTest('id1'), keys: ['key1']},
-        {id: ArcId.newArcIdForTest('id4'), keys: ['keyM']},
-        {id: ArcId.newArcIdForTest('id5'), keys: ['not-a-key']},
-        {id: ArcId.newArcIdForTest('not-an-id'), keys: []}
+        {id: ArcId.newForTest('id1'), keys: ['key1']},
+        {id: ArcId.newForTest('id4'), keys: ['keyM']},
+        {id: ArcId.newForTest('id5'), keys: ['not-a-key']},
+        {id: ArcId.newForTest('not-an-id'), keys: []}
       ]);
       assert.sameDeepMembers(await backing.toList(), [bar(3), bar(5)]);
 
@@ -841,8 +841,8 @@ describe('firebase', function() {
       await backing.store(bar(7), ['key7a', 'key7b', 'key7c']);
       await backing.store(bar(8), ['key8a', 'key8b', 'key8c']);
       await backing.removeMultiple([
-        {id: ArcId.newArcIdForTest('id7'), keys: []},
-        {id: ArcId.newArcIdForTest('id8'), keys: ['key8b', 'key8c']},
+        {id: ArcId.newForTest('id7'), keys: []},
+        {id: ArcId.newForTest('id8'), keys: ['key8b', 'key8c']},
       ]);
       assert.sameDeepMembers(await backing.toList(), [bar(3), bar(5), bar(8)]);
 

--- a/src/runtime/manual_tests/firebase-tests.ts
+++ b/src/runtime/manual_tests/firebase-tests.ts
@@ -11,7 +11,7 @@
 import '../storage/firebase/firebase-provider.js';
 import {assert} from '../../platform/chai-web.js';
 import {Arc} from '../arc.js';
-import {Id} from '../id.js';
+import {Id, ArcId} from '../id.js';
 import {Loader} from '../loader.js';
 import {Manifest} from '../manifest.js';
 import {resetStorageForTesting} from '../storage/firebase/firebase-storage.js';
@@ -69,7 +69,7 @@ describe('firebase', function() {
         schema Bar
           Text value
       `);
-      const arc = new Arc({id: new Id('test'), loader: new Loader(), context: manifest});
+      const arc = new Arc({id: ArcId.newArcIdForTest('test'), loader: new Loader(), context: manifest});
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const value = 'Hi there' + Math.random();
@@ -91,15 +91,15 @@ describe('firebase', function() {
         schema Bar
           Text value
       `);
-      const arc = new Arc({id: new Id('test'), loader: new Loader(), context: manifest});
+      const arc = new Arc({id: ArcId.newArcIdForTest('test'), loader: new Loader(), context: manifest});
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const key = newStoreKey('variable');
       const var1 = await storage.construct('test0', barType, key) as VariableStorageProvider;
       const var2 = await storage.connect('test0', barType, key) as VariableStorageProvider;
 
-      var1.set({id: new Id('id1'), value: 'value1'});
-      var2.set({id: new Id('id2'), value: 'value2'});
+      var1.set({id: ArcId.newArcIdForTest('id1'), value: 'value1'});
+      var2.set({id: ArcId.newArcIdForTest('id2'), value: 'value2'});
       await synchronized(var1, var2);
       assert.deepEqual(await var1.get(), await var2.get());
     });
@@ -109,13 +109,13 @@ describe('firebase', function() {
         schema Bar
           Text value
       `);
-      const arc = new Arc({id: new Id('test'), loader: new Loader(), context: manifest});
+      const arc = new Arc({id: ArcId.newArcIdForTest('test'), loader: new Loader(), context: manifest});
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const key1 = newStoreKey('varPtr');
 
       const var1 = await storage.construct('test0', barType, key1) as VariableStorageProvider;
-      await var1.set({id: new Id('id1'), value: 'underlying'});
+      await var1.set({id: ArcId.newArcIdForTest('id1'), value: 'underlying'});
 
       const result = await var1.get();
       assert.equal(result.value, 'underlying');
@@ -131,14 +131,14 @@ describe('firebase', function() {
         schema Bar
           Text value
       `);
-      const arc = new Arc({id: new Id('test'), loader: new Loader(), context: manifest});
+      const arc = new Arc({id: ArcId.newArcIdForTest('test'), loader: new Loader(), context: manifest});
 
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const key1 = newStoreKey('varPtr');
 
       const var1 = await storage.construct('test0', new ReferenceType(barType), key1) as VariableStorageProvider;
-      await var1.set({id: new Id('id1'), storageKey: 'underlying'});
+      await var1.set({id: ArcId.newArcIdForTest('id1'), storageKey: 'underlying'});
 
       const result = await var1.get();
       assert.equal(result.storageKey, 'underlying');
@@ -155,13 +155,13 @@ describe('firebase', function() {
           Text data
       `);
       const barType = new EntityType(manifest.schemas.Bar1);
-      const arc = new Arc({id: new Id('test'), loader: new Loader(), context: manifest});
+      const arc = new Arc({id: ArcId.newArcIdForTest('test'), loader: new Loader(), context: manifest});
       const storage = createStorage(arc.id);
 
       const var1 = await storage.construct('test1', barType, newStoreKey('variable')) as VariableStorageProvider;
       const var2 = await storage.construct('test2', barType, newStoreKey('variable')) as VariableStorageProvider;
 
-      const bar = n => ({id: new Id('id') + n, data: 'd' + n});
+      const bar = n => ({id: ArcId.newArcIdForTest('id') + n, data: 'd' + n});
       await var1.set(bar(1));
       await var2.set(bar(2));
 
@@ -190,7 +190,7 @@ describe('firebase', function() {
         schema Bar
           Text value
       `);
-      const arc = new Arc({id: new Id('test'), loader: new Loader(), context: manifest});
+      const arc = new Arc({id: ArcId.newArcIdForTest('test'), loader: new Loader(), context: manifest});
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const value1 = 'Hi there' + Math.random();
@@ -200,12 +200,12 @@ describe('firebase', function() {
       let events = 0;
       collection.on('change', () => events++, this);
 
-      await collection.store({id: new Id('id0'), value: value1}, ['key0']);
-      await collection.store({id: new Id('id1'), value: value2}, ['key1']);
+      await collection.store({id: ArcId.newArcIdForTest('id0'), value: value1}, ['key0']);
+      await collection.store({id: ArcId.newArcIdForTest('id1'), value: value2}, ['key1']);
       let result = await collection.get('id0');
       assert.equal(result.value, value1);
       result = await collection.toList();
-      assert.deepEqual(result, [{id: new Id('id0'), value: value1}, {id: new Id('id1'), value: value2}]);
+      assert.deepEqual(result, [{id: ArcId.newArcIdForTest('id0'), value: value1}, {id: ArcId.newArcIdForTest('id1'), value: value2}]);
 
       assert.equal(collection.version, 2);
       assert.equal(events, 2);
@@ -216,14 +216,14 @@ describe('firebase', function() {
         schema Bar
           Text value
       `);
-      const arc = new Arc({id: new Id('test'), loader: new Loader(), context: manifest});
+      const arc = new Arc({id: ArcId.newArcIdForTest('test'), loader: new Loader(), context: manifest});
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const key = newStoreKey('collection');
       const collection1 = await storage.construct('test1', barType.collectionOf(), key) as CollectionStorageProvider;
       const collection2 = await storage.connect('test1', barType.collectionOf(), key) as CollectionStorageProvider;
-      collection1.store({id: new Id('id1'), value: 'value'}, ['key1']);
-      await collection2.store({id: new Id('id1'), value: 'value'}, ['key2']);
+      collection1.store({id: ArcId.newArcIdForTest('id1'), value: 'value'}, ['key1']);
+      await collection2.store({id: ArcId.newArcIdForTest('id1'), value: 'value'}, ['key2']);
       await synchronized(collection1, collection2);
       assert.deepEqual(await collection1.toList(), await collection2.toList());
     });
@@ -233,14 +233,14 @@ describe('firebase', function() {
         schema Bar
           Text value
       `);
-      const arc = new Arc({id: new Id('test'), loader: new Loader(), context: manifest});
+      const arc = new Arc({id: ArcId.newArcIdForTest('test'), loader: new Loader(), context: manifest});
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const key = newStoreKey('collection');
       const collection1 = await storage.construct('test1', barType.collectionOf(), key) as CollectionStorageProvider;
       const collection2 = await storage.connect('test1', barType.collectionOf(), key) as CollectionStorageProvider;
-      collection1.store({id: new Id('id1'), value: 'value'}, ['key1']);
-      collection2.store({id: new Id('id1'), value: 'value'}, ['key2']);
+      collection1.store({id: ArcId.newArcIdForTest('id1'), value: 'value'}, ['key1']);
+      collection2.store({id: ArcId.newArcIdForTest('id1'), value: 'value'}, ['key2']);
       collection1.remove('id1', ['key1']);
       collection2.remove('id1', ['key2']);
       await synchronized(collection1, collection2);
@@ -253,14 +253,14 @@ describe('firebase', function() {
         schema Bar
           Text value
       `);
-      const arc = new Arc({id: new Id('test'), loader: new Loader(), context: manifest});
+      const arc = new Arc({id: ArcId.newArcIdForTest('test'), loader: new Loader(), context: manifest});
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const key = newStoreKey('collection');
       const collection1 = await storage.construct('test1', barType.collectionOf(), key) as CollectionStorageProvider;
       const collection2 = await storage.connect('test1', barType.collectionOf(), key) as CollectionStorageProvider;
-      await collection1.store({id: new Id('id1'), value: 'value1'}, ['key1']);
-      await collection2.store({id: new Id('id2'), value: 'value2'}, ['key2']);
+      await collection1.store({id: ArcId.newArcIdForTest('id1'), value: 'value1'}, ['key1']);
+      await collection2.store({id: ArcId.newArcIdForTest('id2'), value: 'value2'}, ['key2']);
       await synchronized(collection1, collection2);
       assert.lengthOf(await collection1.toList(), 2);
       assert.sameDeepMembers(await collection1.toList(), await collection2.toList());
@@ -272,15 +272,15 @@ describe('firebase', function() {
           Text value
       `);
 
-      const arc = new Arc({id: new Id('test'), loader: new Loader(), context: manifest});
+      const arc = new Arc({id: ArcId.newArcIdForTest('test'), loader: new Loader(), context: manifest});
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const key1 = newStoreKey('colPtr');
 
       const collection1 = await storage.construct('test0', barType.collectionOf(), key1) as CollectionStorageProvider;
 
-      await collection1.store({id: new Id('id1'), value: 'value1'}, ['key1']);
-      await collection1.store({id: new Id('id2'), value: 'value2'}, ['key2']);
+      await collection1.store({id: ArcId.newArcIdForTest('id1'), value: 'value1'}, ['key1']);
+      await collection1.store({id: ArcId.newArcIdForTest('id2'), value: 'value2'}, ['key2']);
 
       let result = await collection1.get('id1');
       assert.equal(result.value, 'value1');
@@ -300,14 +300,14 @@ describe('firebase', function() {
           Text value
       `);
 
-      const arc = new Arc({id: new Id('test'), loader: new Loader(), context: manifest});
+      const arc = new Arc({id: ArcId.newArcIdForTest('test'), loader: new Loader(), context: manifest});
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const key1 = newStoreKey('colPtr');
 
       const collection1 = await storage.construct('test0', new ReferenceType(barType).collectionOf(), key1) as CollectionStorageProvider;
-      await collection1.store({id: new Id('id1'), storageKey: 'value1'}, ['key1']);
-      await collection1.store({id: new Id('id2'), storageKey: 'value2'}, ['key2']);
+      await collection1.store({id: ArcId.newArcIdForTest('id1'), storageKey: 'value1'}, ['key1']);
+      await collection1.store({id: ArcId.newArcIdForTest('id2'), storageKey: 'value2'}, ['key2']);
 
       let result = await collection1.get('id1');
       assert.equal(result.storageKey, 'value1');
@@ -323,15 +323,15 @@ describe('firebase', function() {
         schema Bar
           Text value
       `);
-      const arc = new Arc({id: new Id('test'), loader: new Loader(), context: manifest});
+      const arc = new Arc({id: ArcId.newArcIdForTest('test'), loader: new Loader(), context: manifest});
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const key = newStoreKey('collection');
       const collection = await storage.construct('test1', barType.collectionOf(), key) as CollectionStorageProvider;
-      await collection.store({id: new Id('id1'), value: 'value'}, ['key1']);
-      await collection.store({id: new Id('id2'), value: 'value'}, ['key2']);
+      await collection.store({id: ArcId.newArcIdForTest('id1'), value: 'value'}, ['key1']);
+      await collection.store({id: ArcId.newArcIdForTest('id2'), value: 'value'}, ['key2']);
       await collection.removeMultiple([
-        {id: new Id('id1'), keys: ['key1']}, {id: new Id('id2'), keys: ['key2']}
+        {id: ArcId.newArcIdForTest('id1'), keys: ['key1']}, {id: ArcId.newArcIdForTest('id2'), keys: ['key2']}
       ]);
       assert.isEmpty(await collection.toList());
     });
@@ -344,13 +344,13 @@ describe('firebase', function() {
           Text data
       `);
       const barType = new EntityType(manifest.schemas.Bar2);
-      const arc = new Arc({id: new Id('test'), loader: new Loader(), context: manifest});
+      const arc = new Arc({id: ArcId.newArcIdForTest('test'), loader: new Loader(), context: manifest});
       const storage = createStorage(arc.id);
 
       const col1 = await storage.construct('test1', barType.collectionOf(), newStoreKey('collection')) as CollectionStorageProvider;
       const col2 = await storage.construct('test2', barType.collectionOf(), newStoreKey('collection')) as CollectionStorageProvider;
 
-      const bar = n => ({id: new Id('id') + n, data: 'd' + n});
+      const bar = n => ({id: ArcId.newArcIdForTest('id') + n, data: 'd' + n});
       await col1.store(bar(1), ['key1']);
       await col2.store(bar(2), ['key2']);
       await col1.store(bar(3), ['key3']);
@@ -367,7 +367,7 @@ describe('firebase', function() {
       assert.sameDeepMembers(await backing.toList(), [bar(1), bar(2), bar(3)]);
 
       // Removing one of col2's ids from col1 should have no effect.
-      await col1.removeMultiple([{id: new Id('id1'), keys: []}, {id: new Id('id2'), keys: []}]);
+      await col1.removeMultiple([{id: ArcId.newArcIdForTest('id1'), keys: []}, {id: ArcId.newArcIdForTest('id2'), keys: []}]);
       assert.sameDeepMembers(await col1.toList(), [bar(3)]);
       assert.sameDeepMembers(await col2.toList(), [bar(2)]);
 
@@ -407,7 +407,7 @@ describe('firebase', function() {
         schema Bar
           Text data
       `);
-      const arc = new Arc({id: new Id('test'), loader: new Loader(), context: manifest});
+      const arc = new Arc({id: ArcId.newArcIdForTest('test'), loader: new Loader(), context: manifest});
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const key = newStoreKey('bigcollection');
@@ -416,8 +416,8 @@ describe('firebase', function() {
 
       // Concurrent writes to different ids.
       await Promise.all([
-        collection1.store({id: new Id('id1'), data: 'ab'}, ['k34']),
-        collection2.store({id: new Id('id2'), data: 'cd'}, ['k12'])
+        collection1.store({id: ArcId.newArcIdForTest('id1'), data: 'ab'}, ['k34']),
+        collection2.store({id: ArcId.newArcIdForTest('id2'), data: 'cd'}, ['k12'])
       ]);
       assert.equal((await collection2.get('id1')).data, 'ab');
       assert.equal((await collection1.get('id2')).data, 'cd');
@@ -427,8 +427,8 @@ describe('firebase', function() {
 
       // Concurrent writes to the same id.
       await Promise.all([
-        collection1.store({id: new Id('id3'), data: 'xx'}, ['k65']),
-        collection2.store({id: new Id('id3'), data: 'yy'}, ['k87'])
+        collection1.store({id: ArcId.newArcIdForTest('id3'), data: 'xx'}, ['k65']),
+        collection2.store({id: ArcId.newArcIdForTest('id3'), data: 'yy'}, ['k87'])
       ]);
       assert.include(['xx', 'yy'], (await collection1.get('id3')).data);
 
@@ -482,7 +482,7 @@ describe('firebase', function() {
         schema Bar
           Text data
       `);
-      const arc = new Arc({id: new Id('test'), loader: new Loader(), context: manifest});
+      const arc = new Arc({id: ArcId.newArcIdForTest('test'), loader: new Loader(), context: manifest});
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const col = await storage.construct('test0', barType.bigCollectionOf(), newStoreKey('bigcollection')) as BigCollectionStorageProvider;
@@ -559,7 +559,7 @@ describe('firebase', function() {
         schema Bar
           Text data
       `);
-      const arc = new Arc({id: new Id('test'), loader: new Loader(), context: manifest});
+      const arc = new Arc({id: ArcId.newArcIdForTest('test'), loader: new Loader(), context: manifest});
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const col = await storage.construct('test0', barType.bigCollectionOf(), newStoreKey('bigcollection')) as BigCollectionStorageProvider;
@@ -728,7 +728,7 @@ describe('firebase', function() {
         `
       });
       const manifest = await Manifest.load('manifest', loader);
-      const arc = new Arc({id: new Id('test'), loader, context: manifest});
+      const arc = new Arc({id: ArcId.newArcIdForTest('test'), loader, context: manifest});
       const storage = createStorage(arc.id);
       const dataType = new EntityType(manifest.schemas.Data);
 
@@ -737,9 +737,9 @@ describe('firebase', function() {
       const bigStore = await storage.construct('test2', dataType.bigCollectionOf(), newStoreKey('bigcollection')) as BigCollectionStorageProvider;
 
       // Populate the stores, run the arc and get its serialization.
-      await varStore.set({id: new Id('i1'), rawData: {value: 'v1'}});
-      await colStore.store({id: new Id('i2'), rawData: {value: 'v2'}}, ['k2']);
-      await bigStore.store({id: new Id('i3'), rawData: {value: 'v3'}}, ['k3']);
+      await varStore.set({id: ArcId.newArcIdForTest('i1'), rawData: {value: 'v1'}});
+      await colStore.store({id: ArcId.newArcIdForTest('i2'), rawData: {value: 'v2'}}, ['k2']);
+      await bigStore.store({id: ArcId.newArcIdForTest('i3'), rawData: {value: 'v3'}}, ['k3']);
 
       const recipe = manifest.recipes[0];
       recipe.handles[0].mapToStorage(varStore);
@@ -753,9 +753,9 @@ describe('firebase', function() {
       arc.dispose();
 
       // Update the stores between serializing and deserializing.
-      await varStore.set({id: new Id('i4'), rawData: {value: 'v4'}});
-      await colStore.store({id: new Id('i5'), rawData: {value: 'v5'}}, ['k5']);
-      await bigStore.store({id: new Id('i6'), rawData: {value: 'v6'}}, ['k6']);
+      await varStore.set({id: ArcId.newArcIdForTest('i4'), rawData: {value: 'v4'}});
+      await colStore.store({id: ArcId.newArcIdForTest('i5'), rawData: {value: 'v5'}}, ['k5']);
+      await bigStore.store({id: ArcId.newArcIdForTest('i6'), rawData: {value: 'v6'}}, ['k6']);
 
       const arc2 = await Arc.deserialize({serialization, loader, fileName: '', pecFactory:undefined, slotComposer: undefined, context: manifest});
       const varStore2 = arc2.findStoreById(varStore.id) as VariableStorageProvider;
@@ -788,13 +788,13 @@ describe('firebase', function() {
           Text data
       `);
       const barType = new EntityType(manifest.schemas.Bar3);
-      const arc = new Arc({id: new Id('test'), loader: new Loader(), context: manifest});
+      const arc = new Arc({id: ArcId.newArcIdForTest('test'), loader: new Loader(), context: manifest});
       const storage = createStorage(arc.id);
       const col = await storage.construct('test1', barType.collectionOf(), newStoreKey('collection')) as CollectionStorageProvider;
       const backing = await col.ensureBackingStore();
       backing.maxConcurrentRequests = 3;
 
-      const bar = n => ({id: new Id('id') + n, data: 'd' + n});
+      const bar = n => ({id: ArcId.newArcIdForTest('id') + n, data: 'd' + n});
 
       // store, storeMultiple
       await backing.store(bar(1), ['key1']);
@@ -830,10 +830,10 @@ describe('firebase', function() {
 
       // removeMultiple: safe to use non-existent keys and ids
       await backing.removeMultiple([
-        {id: new Id('id1'), keys: ['key1']},
-        {id: new Id('id4'), keys: ['keyM']},
-        {id: new Id('id5'), keys: ['not-a-key']},
-        {id: new Id('not-an-id'), keys: []}
+        {id: ArcId.newArcIdForTest('id1'), keys: ['key1']},
+        {id: ArcId.newArcIdForTest('id4'), keys: ['keyM']},
+        {id: ArcId.newArcIdForTest('id5'), keys: ['not-a-key']},
+        {id: ArcId.newArcIdForTest('not-an-id'), keys: []}
       ]);
       assert.sameDeepMembers(await backing.toList(), [bar(3), bar(5)]);
 
@@ -841,8 +841,8 @@ describe('firebase', function() {
       await backing.store(bar(7), ['key7a', 'key7b', 'key7c']);
       await backing.store(bar(8), ['key8a', 'key8b', 'key8c']);
       await backing.removeMultiple([
-        {id: new Id('id7'), keys: []},
-        {id: new Id('id8'), keys: ['key8b', 'key8c']},
+        {id: ArcId.newArcIdForTest('id7'), keys: []},
+        {id: ArcId.newArcIdForTest('id8'), keys: ['key8b', 'key8c']},
       ]);
       assert.sameDeepMembers(await backing.toList(), [bar(3), bar(5), bar(8)]);
 

--- a/src/runtime/particle-execution-context.ts
+++ b/src/runtime/particle-execution-context.ts
@@ -124,7 +124,7 @@ export class ParticleExecutionContext {
   }
 
   generateID() {
-    return this.idGenerator.createChildId(this.pecId).toString();
+    return this.idGenerator.newChildId(this.pecId).toString();
   }
 
   innerArcHandle(arcId: string, particleId: string) {

--- a/src/runtime/test/arc-tests.ts
+++ b/src/runtime/test/arc-tests.ts
@@ -14,7 +14,7 @@ import {assert} from '../../platform/chai-web.js';
 import {Arc} from '../arc.js';
 import {handleFor, Variable} from '../handle.js';
 import {HeadlessSlotDomConsumer} from '../headless-slot-dom-consumer.js';
-import {Id} from '../id.js';
+import {Id, ArcId} from '../id.js';
 import {Loader} from '../loader.js';
 import {Manifest} from '../manifest.js';
 import {BigCollectionStorageProvider, CollectionStorageProvider, VariableStorageProvider, StorageProviderBase} from '../storage/storage-provider-base.js';
@@ -38,7 +38,7 @@ async function setup() {
         foo <- handle0
         bar -> handle1
   `, {loader, fileName: process.cwd() + '/input.manifest'});
-  const arc = new Arc({slotComposer: new FakeSlotComposer(), loader, id: new Id('test'), context: manifest});
+  const arc = new Arc({slotComposer: new FakeSlotComposer(), loader, id: ArcId.newArcIdForTest('test'), context: manifest});
   return {
     arc,
     recipe: manifest.recipes[0],
@@ -69,7 +69,7 @@ async function setupSlandlesWithOptional(cProvided, dProvided) {
         ${cProvided ? 'c <- maybeSlotC' : ''}
         ${dProvided ? 'd -> maybeSlotD' : ''}
   `, {loader, fileName: process.cwd() + '/input.manifest'});
-  const arc = new Arc({slotComposer: new FakeSlotComposer(), loader, id: new Id('test'), context: manifest});
+  const arc = new Arc({slotComposer: new FakeSlotComposer(), loader, id: ArcId.newArcIdForTest('test'), context: manifest});
 
   const slotType = manifest.findSchemaByName('Slot').entityClass().type;
   const aStore = await arc.createStore(slotType, 'aStore', 'test:1');
@@ -99,7 +99,7 @@ describe('Arc', () => {
         schema Bar
           Text value
       `);
-    const arc = new Arc({slotComposer: new FakeSlotComposer(), loader: new Loader(), id: new Id('test'), context: manifest});
+    const arc = new Arc({slotComposer: new FakeSlotComposer(), loader: new Loader(), id: ArcId.newArcIdForTest('test'), context: manifest});
     const f = async () => { await arc.idle; };
     await Promise.all([f(), f()]);
   });
@@ -153,7 +153,7 @@ describe('Arc', () => {
           a <- thingA
           b -> thingB
     `, {loader, fileName: process.cwd() + '/input.manifest'});
-    const arc = new Arc({slotComposer: new FakeSlotComposer(), loader, context: manifest, id: new Id('test')});
+    const arc = new Arc({slotComposer: new FakeSlotComposer(), loader, context: manifest, id: ArcId.newArcIdForTest('test')});
 
     const thingClass = manifest.findSchemaByName('Thing').entityClass();
     const aStore = await arc.createStore(thingClass.type, 'aStore', 'test:1');
@@ -200,7 +200,7 @@ describe('Arc', () => {
           a <- thingA
           b -> thingB
     `, {loader, fileName: process.cwd() + '/input.manifest'});
-    const arc = new Arc({slotComposer: new FakeSlotComposer(), loader, context: manifest, id: new Id('test')});
+    const arc = new Arc({slotComposer: new FakeSlotComposer(), loader, context: manifest, id: ArcId.newArcIdForTest('test')});
 
     const thingClass = manifest.findSchemaByName('Thing').entityClass();
     const aStore = await arc.createStore(thingClass.type, 'aStore', 'test:1');
@@ -249,7 +249,7 @@ describe('Arc', () => {
             b -> thingB
             d -> maybeThingD
       `, {loader, fileName: process.cwd() + '/input.manifest'});
-      const arc = new Arc({slotComposer: new FakeSlotComposer(), loader, context: manifest, id: new Id('test')});
+      const arc = new Arc({slotComposer: new FakeSlotComposer(), loader, context: manifest, id: ArcId.newArcIdForTest('test')});
 
       const thingClass = manifest.findSchemaByName('Thing').entityClass();
       const aStore = await arc.createStore(thingClass.type, 'aStore', 'test:1');
@@ -292,7 +292,7 @@ describe('Arc', () => {
             b -> thingB
             d -> maybeThingD
       `, {loader, fileName: process.cwd() + '/input.manifest'});
-      const arc = new Arc({slotComposer: new FakeSlotComposer(), loader, context: manifest, id: new Id('test')});
+      const arc = new Arc({slotComposer: new FakeSlotComposer(), loader, context: manifest, id: ArcId.newArcIdForTest('test')});
 
       const thingClass = manifest.findSchemaByName('Thing').entityClass();
       const aStore = await arc.createStore(thingClass.type, 'aStore', 'test:1');
@@ -334,7 +334,7 @@ describe('Arc', () => {
           b -> thingB
           c <- maybeThingC
     `, {loader, fileName: process.cwd() + '/input.manifest'});
-    const arc = new Arc({slotComposer: new FakeSlotComposer(), loader, context: manifest, id: new Id('test')});
+    const arc = new Arc({slotComposer: new FakeSlotComposer(), loader, context: manifest, id: ArcId.newArcIdForTest('test')});
 
     const thingClass = manifest.findSchemaByName('Thing').entityClass();
     const aStore = await arc.createStore(thingClass.type, 'aStore', 'test:1');
@@ -382,7 +382,7 @@ describe('Arc', () => {
             b -> thingB
             c <- maybeThingC
       `, {loader, fileName: process.cwd() + '/input.manifest'});
-      const arc = new Arc({slotComposer: new FakeSlotComposer(), loader, context: manifest, id: new Id('test')});
+      const arc = new Arc({slotComposer: new FakeSlotComposer(), loader, context: manifest, id: ArcId.newArcIdForTest('test')});
 
       const thingClass = manifest.findSchemaByName('Thing').entityClass();
       const aStore = await arc.createStore(thingClass.type, 'aStore', 'test:1');
@@ -425,7 +425,7 @@ describe('Arc', () => {
           c <- maybeThingC
           d -> maybeThingD
     `, {loader, fileName: process.cwd() + '/input.manifest'});
-    const arc = new Arc({slotComposer: new FakeSlotComposer(), loader, context: manifest, id: new Id('test')});
+    const arc = new Arc({slotComposer: new FakeSlotComposer(), loader, context: manifest, id: ArcId.newArcIdForTest('test')});
 
     const thingClass = manifest.findSchemaByName('Thing').entityClass();
     const aStore = await arc.createStore(thingClass.type, 'aStore', 'test:1');
@@ -473,7 +473,7 @@ describe('Arc', () => {
           c <- maybeThingC
           d -> maybeThingD
     `, {loader, fileName: process.cwd() + '/input.manifest'});
-    const arc = new Arc({slotComposer: new FakeSlotComposer(), loader, context: manifest, id: new Id('test')});
+    const arc = new Arc({slotComposer: new FakeSlotComposer(), loader, context: manifest, id: ArcId.newArcIdForTest('test')});
 
     const thingClass = manifest.findSchemaByName('Thing').entityClass();
     const aStore = await arc.createStore(thingClass.type, 'aStore', 'test:1');
@@ -615,7 +615,7 @@ describe('Arc', () => {
     });
     const manifest = await Manifest.load('manifest', loader);
     const dataClass = manifest.findSchemaByName('Data').entityClass();
-    const arc = new Arc({id: new Id('test'), loader, context: manifest});
+    const arc = new Arc({id: ArcId.newArcIdForTest('test'), loader, context: manifest});
 
     const varStore = await arc.createStore(dataClass.type, undefined, 'test:0') as VariableStorageProvider;
     const colStore = await arc.createStore(dataClass.type.collectionOf(), undefined, 'test:1') as CollectionStorageProvider;
@@ -697,7 +697,7 @@ describe('Arc', () => {
     });
 
     const manifest = await Manifest.load('manifest', loader);
-    const arc = new Arc({id: new Id('test'), loader, context: manifest});
+    const arc = new Arc({id: ArcId.newArcIdForTest('test'), loader, context: manifest});
     const recipe = manifest.recipes[0];
     assert(recipe.normalize());
     assert(recipe.isResolved());
@@ -723,7 +723,7 @@ describe('Arc', () => {
 
   ['volatile://', 'pouchdb://memory/user/'].forEach((storageKeyPrefix) => {
     it('persist serialization for ' + storageKeyPrefix, async () => {
-      const id = new Id('123', ['test']);
+      const id = ArcId.newArcIdForTest('test');
       const manifest = await Manifest.parse(`
       schema Data
         Text value
@@ -737,8 +737,8 @@ describe('Arc', () => {
       await arc.persistSerialization(serialization);
 
       const key = storageKeyPrefix.includes('volatile')
-            ? storageKeyPrefix + '!123:test^^arc-info'
-            : storageKeyPrefix + '!123:test/arc-info';
+            ? storageKeyPrefix + `${id}^^arc-info`
+            : storageKeyPrefix + `${id}/arc-info`;
 
       const store = await arc.storageProviderFactory.connect('id', new ArcType(), key) as VariableStorageProvider;
       const callbackTracker = new CallbackTracker(store, 0);
@@ -751,8 +751,8 @@ describe('Arc', () => {
       // The serialization tends to have lots of whitespace in it; squash it for easier comparison.
       data.serialization = data.serialization.trim().replace(/[\n ]+/g, ' ');
 
-      const expected = `meta name: '!123:test' storageKey: '${storageKeyPrefix}!123:test' @active recipe description \`abc\``;
-      assert.deepEqual({id: '!123:test', serialization: expected}, data);
+      const expected = `meta name: '${id}' storageKey: '${storageKeyPrefix}${id}' @active recipe description \`abc\``;
+      assert.deepEqual({id: id.toString(), serialization: expected}, data);
 
       // TODO Simulate a cold-load to catch reference mode issues.
       // in the interim you can disable the provider cache in pouch-db-storage.ts
@@ -838,7 +838,7 @@ describe('Arc', () => {
 
   ['volatile://', 'pouchdb://memory/user/'].forEach((storageKeyPrefix) => {
     it('handles serialization/deserialization of empty arcs handles ' + storageKeyPrefix, async () => {
-      const id = new Id('123', ['test']);
+      const id = ArcId.newArcIdForTest('test');
       const loader = new Loader();
 
       const manifest = await Manifest.parse(`

--- a/src/runtime/test/arc-tests.ts
+++ b/src/runtime/test/arc-tests.ts
@@ -38,7 +38,7 @@ async function setup() {
         foo <- handle0
         bar -> handle1
   `, {loader, fileName: process.cwd() + '/input.manifest'});
-  const arc = new Arc({slotComposer: new FakeSlotComposer(), loader, id: ArcId.newArcIdForTest('test'), context: manifest});
+  const arc = new Arc({slotComposer: new FakeSlotComposer(), loader, id: ArcId.newForTest('test'), context: manifest});
   return {
     arc,
     recipe: manifest.recipes[0],
@@ -69,7 +69,7 @@ async function setupSlandlesWithOptional(cProvided, dProvided) {
         ${cProvided ? 'c <- maybeSlotC' : ''}
         ${dProvided ? 'd -> maybeSlotD' : ''}
   `, {loader, fileName: process.cwd() + '/input.manifest'});
-  const arc = new Arc({slotComposer: new FakeSlotComposer(), loader, id: ArcId.newArcIdForTest('test'), context: manifest});
+  const arc = new Arc({slotComposer: new FakeSlotComposer(), loader, id: ArcId.newForTest('test'), context: manifest});
 
   const slotType = manifest.findSchemaByName('Slot').entityClass().type;
   const aStore = await arc.createStore(slotType, 'aStore', 'test:1');
@@ -99,7 +99,7 @@ describe('Arc', () => {
         schema Bar
           Text value
       `);
-    const arc = new Arc({slotComposer: new FakeSlotComposer(), loader: new Loader(), id: ArcId.newArcIdForTest('test'), context: manifest});
+    const arc = new Arc({slotComposer: new FakeSlotComposer(), loader: new Loader(), id: ArcId.newForTest('test'), context: manifest});
     const f = async () => { await arc.idle; };
     await Promise.all([f(), f()]);
   });
@@ -153,7 +153,7 @@ describe('Arc', () => {
           a <- thingA
           b -> thingB
     `, {loader, fileName: process.cwd() + '/input.manifest'});
-    const arc = new Arc({slotComposer: new FakeSlotComposer(), loader, context: manifest, id: ArcId.newArcIdForTest('test')});
+    const arc = new Arc({slotComposer: new FakeSlotComposer(), loader, context: manifest, id: ArcId.newForTest('test')});
 
     const thingClass = manifest.findSchemaByName('Thing').entityClass();
     const aStore = await arc.createStore(thingClass.type, 'aStore', 'test:1');
@@ -200,7 +200,7 @@ describe('Arc', () => {
           a <- thingA
           b -> thingB
     `, {loader, fileName: process.cwd() + '/input.manifest'});
-    const arc = new Arc({slotComposer: new FakeSlotComposer(), loader, context: manifest, id: ArcId.newArcIdForTest('test')});
+    const arc = new Arc({slotComposer: new FakeSlotComposer(), loader, context: manifest, id: ArcId.newForTest('test')});
 
     const thingClass = manifest.findSchemaByName('Thing').entityClass();
     const aStore = await arc.createStore(thingClass.type, 'aStore', 'test:1');
@@ -249,7 +249,7 @@ describe('Arc', () => {
             b -> thingB
             d -> maybeThingD
       `, {loader, fileName: process.cwd() + '/input.manifest'});
-      const arc = new Arc({slotComposer: new FakeSlotComposer(), loader, context: manifest, id: ArcId.newArcIdForTest('test')});
+      const arc = new Arc({slotComposer: new FakeSlotComposer(), loader, context: manifest, id: ArcId.newForTest('test')});
 
       const thingClass = manifest.findSchemaByName('Thing').entityClass();
       const aStore = await arc.createStore(thingClass.type, 'aStore', 'test:1');
@@ -292,7 +292,7 @@ describe('Arc', () => {
             b -> thingB
             d -> maybeThingD
       `, {loader, fileName: process.cwd() + '/input.manifest'});
-      const arc = new Arc({slotComposer: new FakeSlotComposer(), loader, context: manifest, id: ArcId.newArcIdForTest('test')});
+      const arc = new Arc({slotComposer: new FakeSlotComposer(), loader, context: manifest, id: ArcId.newForTest('test')});
 
       const thingClass = manifest.findSchemaByName('Thing').entityClass();
       const aStore = await arc.createStore(thingClass.type, 'aStore', 'test:1');
@@ -334,7 +334,7 @@ describe('Arc', () => {
           b -> thingB
           c <- maybeThingC
     `, {loader, fileName: process.cwd() + '/input.manifest'});
-    const arc = new Arc({slotComposer: new FakeSlotComposer(), loader, context: manifest, id: ArcId.newArcIdForTest('test')});
+    const arc = new Arc({slotComposer: new FakeSlotComposer(), loader, context: manifest, id: ArcId.newForTest('test')});
 
     const thingClass = manifest.findSchemaByName('Thing').entityClass();
     const aStore = await arc.createStore(thingClass.type, 'aStore', 'test:1');
@@ -382,7 +382,7 @@ describe('Arc', () => {
             b -> thingB
             c <- maybeThingC
       `, {loader, fileName: process.cwd() + '/input.manifest'});
-      const arc = new Arc({slotComposer: new FakeSlotComposer(), loader, context: manifest, id: ArcId.newArcIdForTest('test')});
+      const arc = new Arc({slotComposer: new FakeSlotComposer(), loader, context: manifest, id: ArcId.newForTest('test')});
 
       const thingClass = manifest.findSchemaByName('Thing').entityClass();
       const aStore = await arc.createStore(thingClass.type, 'aStore', 'test:1');
@@ -425,7 +425,7 @@ describe('Arc', () => {
           c <- maybeThingC
           d -> maybeThingD
     `, {loader, fileName: process.cwd() + '/input.manifest'});
-    const arc = new Arc({slotComposer: new FakeSlotComposer(), loader, context: manifest, id: ArcId.newArcIdForTest('test')});
+    const arc = new Arc({slotComposer: new FakeSlotComposer(), loader, context: manifest, id: ArcId.newForTest('test')});
 
     const thingClass = manifest.findSchemaByName('Thing').entityClass();
     const aStore = await arc.createStore(thingClass.type, 'aStore', 'test:1');
@@ -473,7 +473,7 @@ describe('Arc', () => {
           c <- maybeThingC
           d -> maybeThingD
     `, {loader, fileName: process.cwd() + '/input.manifest'});
-    const arc = new Arc({slotComposer: new FakeSlotComposer(), loader, context: manifest, id: ArcId.newArcIdForTest('test')});
+    const arc = new Arc({slotComposer: new FakeSlotComposer(), loader, context: manifest, id: ArcId.newForTest('test')});
 
     const thingClass = manifest.findSchemaByName('Thing').entityClass();
     const aStore = await arc.createStore(thingClass.type, 'aStore', 'test:1');
@@ -615,7 +615,7 @@ describe('Arc', () => {
     });
     const manifest = await Manifest.load('manifest', loader);
     const dataClass = manifest.findSchemaByName('Data').entityClass();
-    const arc = new Arc({id: ArcId.newArcIdForTest('test'), loader, context: manifest});
+    const arc = new Arc({id: ArcId.newForTest('test'), loader, context: manifest});
 
     const varStore = await arc.createStore(dataClass.type, undefined, 'test:0') as VariableStorageProvider;
     const colStore = await arc.createStore(dataClass.type.collectionOf(), undefined, 'test:1') as CollectionStorageProvider;
@@ -697,7 +697,7 @@ describe('Arc', () => {
     });
 
     const manifest = await Manifest.load('manifest', loader);
-    const arc = new Arc({id: ArcId.newArcIdForTest('test'), loader, context: manifest});
+    const arc = new Arc({id: ArcId.newForTest('test'), loader, context: manifest});
     const recipe = manifest.recipes[0];
     assert(recipe.normalize());
     assert(recipe.isResolved());
@@ -723,7 +723,7 @@ describe('Arc', () => {
 
   ['volatile://', 'pouchdb://memory/user/'].forEach((storageKeyPrefix) => {
     it('persist serialization for ' + storageKeyPrefix, async () => {
-      const id = ArcId.newArcIdForTest('test');
+      const id = ArcId.newForTest('test');
       const manifest = await Manifest.parse(`
       schema Data
         Text value
@@ -838,7 +838,7 @@ describe('Arc', () => {
 
   ['volatile://', 'pouchdb://memory/user/'].forEach((storageKeyPrefix) => {
     it('handles serialization/deserialization of empty arcs handles ' + storageKeyPrefix, async () => {
-      const id = ArcId.newArcIdForTest('test');
+      const id = ArcId.newForTest('test');
       const loader = new Loader();
 
       const manifest = await Manifest.parse(`

--- a/src/runtime/test/data-layer-test.ts
+++ b/src/runtime/test/data-layer-test.ts
@@ -16,13 +16,13 @@ import {Schema} from '../schema.js';
 import {CollectionStorageProvider} from '../storage/storage-provider-base.js';
 import {FakeSlotComposer} from '../testing/fake-slot-composer.js';
 import {EntityType} from '../type.js';
-import {Id} from '../id.js';
+import {Id, ArcId} from '../id.js';
 
 describe('entity', async () => {
   it('can be created, stored, and restored', async () => {
     const schema = new Schema(['TestSchema'], {value: 'Text'});
 
-    const arc = new Arc({slotComposer: new FakeSlotComposer(), id: new Id('test'), context: null, loader: new Loader()});
+    const arc = new Arc({slotComposer: new FakeSlotComposer(), id: ArcId.newArcIdForTest('test'), context: null, loader: new Loader()});
     const entity = new (schema.entityClass())({value: 'hello world'});
     assert.isDefined(entity);
 

--- a/src/runtime/test/data-layer-test.ts
+++ b/src/runtime/test/data-layer-test.ts
@@ -22,7 +22,7 @@ describe('entity', async () => {
   it('can be created, stored, and restored', async () => {
     const schema = new Schema(['TestSchema'], {value: 'Text'});
 
-    const arc = new Arc({slotComposer: new FakeSlotComposer(), id: ArcId.newArcIdForTest('test'), context: null, loader: new Loader()});
+    const arc = new Arc({slotComposer: new FakeSlotComposer(), id: ArcId.newForTest('test'), context: null, loader: new Loader()});
     const entity = new (schema.entityClass())({value: 'hello world'});
     assert.isDefined(entity);
 

--- a/src/runtime/test/description-test.ts
+++ b/src/runtime/test/description-test.ts
@@ -24,7 +24,7 @@ import {Id, ArcId} from '../id.js';
 
 function createTestArc(recipe: Recipe, manifest: Manifest) {
   const slotComposer = new FakeSlotComposer();
-  const arc = new Arc({slotComposer, id: ArcId.newArcIdForTest('test'), context: manifest, loader: new Loader()});
+  const arc = new Arc({slotComposer, id: ArcId.newForTest('test'), context: manifest, loader: new Loader()});
   // TODO(lindner) stop messing with arc internal state, or provide a way to supply in constructor..
   arc['_activeRecipe'] = recipe;
   arc['_recipeDeltas'].push({particles: recipe.particles, handles: recipe.handles, slots: recipe.slots, patterns: recipe.patterns});

--- a/src/runtime/test/description-test.ts
+++ b/src/runtime/test/description-test.ts
@@ -20,11 +20,11 @@ import {Relevance} from '../relevance.js';
 import {CollectionStorageProvider, VariableStorageProvider} from '../storage/storage-provider-base.js';
 import {FakeSlotComposer} from '../testing/fake-slot-composer.js';
 import {EntityType} from '../type.js';
-import {Id} from '../id.js';
+import {Id, ArcId} from '../id.js';
 
 function createTestArc(recipe: Recipe, manifest: Manifest) {
   const slotComposer = new FakeSlotComposer();
-  const arc = new Arc({slotComposer, id: new Id('test'), context: manifest, loader: new Loader()});
+  const arc = new Arc({slotComposer, id: ArcId.newArcIdForTest('test'), context: manifest, loader: new Loader()});
   // TODO(lindner) stop messing with arc internal state, or provide a way to supply in constructor..
   arc['_activeRecipe'] = recipe;
   arc['_recipeDeltas'].push({particles: recipe.particles, handles: recipe.handles, slots: recipe.slots, patterns: recipe.patterns});

--- a/src/runtime/test/handle-test.ts
+++ b/src/runtime/test/handle-test.ts
@@ -19,7 +19,7 @@ import {CollectionStorageProvider, VariableStorageProvider} from '../storage/sto
 import {FakeSlotComposer} from '../testing/fake-slot-composer.js';
 import {assertThrowsAsync} from '../testing/test-util.js';
 import {EntityType, InterfaceType} from '../type.js';
-import {Id} from '../id.js';
+import {Id, ArcId} from '../id.js';
 
 describe('Handle', () => {
   // Avoid initialising non-POD variables globally, since they would be constructed even when
@@ -34,7 +34,7 @@ describe('Handle', () => {
   const manifestFile = './src/runtime/test/artifacts/test-particles.manifest';
 
   it('clear singleton store', async () => {
-    const arc = new Arc({slotComposer: new FakeSlotComposer(), id: new Id('test'), context: undefined, loader: new Loader()});
+    const arc = new Arc({slotComposer: new FakeSlotComposer(), id: ArcId.newArcIdForTest('test'), context: undefined, loader: new Loader()});
     const barStore = await arc.createStore(Bar.type) as VariableStorageProvider;
     await barStore.set({id: 'an id', value: 'a Bar'});
     await barStore.clear();

--- a/src/runtime/test/handle-test.ts
+++ b/src/runtime/test/handle-test.ts
@@ -34,7 +34,7 @@ describe('Handle', () => {
   const manifestFile = './src/runtime/test/artifacts/test-particles.manifest';
 
   it('clear singleton store', async () => {
-    const arc = new Arc({slotComposer: new FakeSlotComposer(), id: ArcId.newArcIdForTest('test'), context: undefined, loader: new Loader()});
+    const arc = new Arc({slotComposer: new FakeSlotComposer(), id: ArcId.newForTest('test'), context: undefined, loader: new Loader()});
     const barStore = await arc.createStore(Bar.type) as VariableStorageProvider;
     await barStore.set({id: 'an id', value: 'a Bar'});
     await barStore.clear();

--- a/src/runtime/test/id-test.ts
+++ b/src/runtime/test/id-test.ts
@@ -9,8 +9,11 @@
  */
 
 import {assert} from '../../platform/chai-web.js';
-import {Id, IdGenerator} from '../id.js';
-import { Random } from '../random.js';
+import {Id, IdGenerator, ArcId} from '../id.js';
+import {Random} from '../random.js';
+
+// Alias for the Id factory method. IdGenerators should usually be used to create new IDs, but doing so in these tests is cumbersome.
+const createId = Id._createIdInternal;
 
 describe('IdGenerator', () => {
   describe('#newSession', () => {
@@ -33,19 +36,19 @@ describe('IdGenerator', () => {
     });
 
     it('creates child IDs using its session ID', () => {
-      const parentId = new Id('root');
+      const parentId = createId('root');
       const childId = idGenerator.createChildId(parentId);
       assert.equal(childId.root, 'sessionId');
     });
     
     it('appends subcomponents when creating child IDs', () => {
-      const parentId = new Id('root', ['x', 'y']);
+      const parentId = createId('root', ['x', 'y']);
       const childId = idGenerator.createChildId(parentId, 'z');
       assert.deepEqual(childId.idTree, ['x', 'y', 'z0']);
     });
 
     it('increments its counter', () => {
-      const parentId = new Id('root', ['x', 'y']);
+      const parentId = createId('root', ['x', 'y']);
       assert.deepEqual(idGenerator.createChildId(parentId, 'z').idTree, ['x', 'y', 'z0']);
       assert.deepEqual(idGenerator.createChildId(parentId, 'z').idTree, ['x', 'y', 'z1']);
       assert.deepEqual(idGenerator.createChildId(parentId, 'z').idTree, ['x', 'y', 'z2']);
@@ -55,23 +58,23 @@ describe('IdGenerator', () => {
 
 describe('Id', () => {
   it('parses IDs from strings with exclamation marks', () => {
-    assert.deepEqual(Id.fromString('!root'), new Id('root'));
-    assert.deepEqual(Id.fromString('!root:'), new Id('root'));
-    assert.deepEqual(Id.fromString('!root:x:y'), new Id('root', ['x', 'y']));
+    assert.deepEqual(Id.fromString('!root'), createId('root'));
+    assert.deepEqual(Id.fromString('!root:'), createId('root'));
+    assert.deepEqual(Id.fromString('!root:x:y'), createId('root', ['x', 'y']));
   });
 
   it('parses IDs from strings without exclamation marks', () => {
-    assert.deepEqual(Id.fromString('x'), new Id('',['x']));
-    assert.deepEqual(Id.fromString('x:y'), new Id('', ['x', 'y']));
+    assert.deepEqual(Id.fromString('x'), createId('',['x']));
+    assert.deepEqual(Id.fromString('x:y'), createId('', ['x', 'y']));
   });
 
   it('encodes to a string', () => {
-    assert.equal(new Id('root').toString(), '!root:');
-    assert.equal(new Id('root', ['x', 'y']).toString(), '!root:x:y');
+    assert.equal(createId('root').toString(), '!root:');
+    assert.equal(createId('root', ['x', 'y']).toString(), '!root:x:y');
   });
 
   it('encodes its ID tree', () => {
-    assert.equal(new Id('root').idTreeAsString(), '');
-    assert.equal(new Id('root', ['x', 'y']).idTreeAsString(), 'x:y');
+    assert.equal(createId('root').idTreeAsString(), '');
+    assert.equal(createId('root', ['x', 'y']).idTreeAsString(), 'x:y');
   });
 });

--- a/src/runtime/test/id-test.ts
+++ b/src/runtime/test/id-test.ts
@@ -54,6 +54,15 @@ describe('IdGenerator', () => {
       assert.deepEqual(idGenerator.createChildId(parentId, 'z').idTree, ['x', 'y', 'z2']);
     });
   });
+
+  describe('#createArcId', () => {
+    it('creates a valid ArcId using its session ID', () => {
+      const idGenerator = IdGenerator.createWithSessionIdForTesting('sessionId');
+      const arcId = idGenerator.createArcId('foo');
+      assert(arcId instanceof ArcId);
+      assert.equal(arcId.toString(), '!sessionId:foo');
+    });
+  });
 });
 
 describe('Id', () => {

--- a/src/runtime/test/id-test.ts
+++ b/src/runtime/test/id-test.ts
@@ -13,7 +13,7 @@ import {Id, IdGenerator, ArcId} from '../id.js';
 import {Random} from '../random.js';
 
 // Alias for the Id factory method. IdGenerators should usually be used to create new IDs, but doing so in these tests is cumbersome.
-const createId = Id._createIdInternal;
+const createId = Id._newIdInternal;
 
 describe('IdGenerator', () => {
   describe('#newSession', () => {
@@ -28,7 +28,7 @@ describe('IdGenerator', () => {
     });
   });
 
-  describe('#createChildId', () => {
+  describe('#newChildId', () => {
     let idGenerator: IdGenerator;
 
     beforeEach(() => {
@@ -37,28 +37,28 @@ describe('IdGenerator', () => {
 
     it('creates child IDs using its session ID', () => {
       const parentId = createId('root');
-      const childId = idGenerator.createChildId(parentId);
+      const childId = idGenerator.newChildId(parentId);
       assert.equal(childId.root, 'sessionId');
     });
     
     it('appends subcomponents when creating child IDs', () => {
       const parentId = createId('root', ['x', 'y']);
-      const childId = idGenerator.createChildId(parentId, 'z');
+      const childId = idGenerator.newChildId(parentId, 'z');
       assert.deepEqual(childId.idTree, ['x', 'y', 'z0']);
     });
 
     it('increments its counter', () => {
       const parentId = createId('root', ['x', 'y']);
-      assert.deepEqual(idGenerator.createChildId(parentId, 'z').idTree, ['x', 'y', 'z0']);
-      assert.deepEqual(idGenerator.createChildId(parentId, 'z').idTree, ['x', 'y', 'z1']);
-      assert.deepEqual(idGenerator.createChildId(parentId, 'z').idTree, ['x', 'y', 'z2']);
+      assert.deepEqual(idGenerator.newChildId(parentId, 'z').idTree, ['x', 'y', 'z0']);
+      assert.deepEqual(idGenerator.newChildId(parentId, 'z').idTree, ['x', 'y', 'z1']);
+      assert.deepEqual(idGenerator.newChildId(parentId, 'z').idTree, ['x', 'y', 'z2']);
     });
   });
 
-  describe('#createArcId', () => {
+  describe('#newArcId', () => {
     it('creates a valid ArcId using its session ID', () => {
       const idGenerator = IdGenerator.createWithSessionIdForTesting('sessionId');
-      const arcId = idGenerator.createArcId('foo');
+      const arcId = idGenerator.newArcId('foo');
       assert(arcId instanceof ArcId);
       assert.equal(arcId.toString(), '!sessionId:foo');
     });

--- a/src/runtime/test/multiplexer-test.ts
+++ b/src/runtime/test/multiplexer-test.ts
@@ -14,7 +14,7 @@ import {Loader} from '../loader.js';
 import {CollectionStorageProvider} from '../storage/storage-provider-base.js';
 import {FakeSlotComposer} from '../testing/fake-slot-composer.js';
 import {TestHelper} from '../testing/test-helper.js';
-import {Id} from '../id.js';
+import {Id, ArcId} from '../id.js';
 
 describe('Multiplexer', () => {
   it('Processes multiple inputs', async () => {
@@ -46,7 +46,7 @@ describe('Multiplexer', () => {
       return slotComposerCreateHostedSlot.apply(slotComposer, args);
     };
 
-    const arc = new Arc({id: new Id('test'), context: manifest, slotComposer, loader: new Loader()});
+    const arc = new Arc({id: ArcId.newArcIdForTest('test'), context: manifest, slotComposer, loader: new Loader()});
     const barStore = await arc.createStore(barType.collectionOf(), null, 'test:1') as CollectionStorageProvider;
     recipe.handles[0].mapToStorage(barStore);
     assert(recipe.normalize());

--- a/src/runtime/test/multiplexer-test.ts
+++ b/src/runtime/test/multiplexer-test.ts
@@ -46,7 +46,7 @@ describe('Multiplexer', () => {
       return slotComposerCreateHostedSlot.apply(slotComposer, args);
     };
 
-    const arc = new Arc({id: ArcId.newArcIdForTest('test'), context: manifest, slotComposer, loader: new Loader()});
+    const arc = new Arc({id: ArcId.newForTest('test'), context: manifest, slotComposer, loader: new Loader()});
     const barStore = await arc.createStore(barType.collectionOf(), null, 'test:1') as CollectionStorageProvider;
     recipe.handles[0].mapToStorage(barStore);
     assert(recipe.normalize());

--- a/src/runtime/test/particle-interface-loading-test.js
+++ b/src/runtime/test/particle-interface-loading-test.js
@@ -59,7 +59,7 @@ describe('particle interface loading', function() {
             };
           });`});
 
-    const arc = new Arc({id: ArcId.newArcIdForTest('test'), loader});
+    const arc = new Arc({id: ArcId.newForTest('test'), loader});
 
     const manifest = await Manifest.load('./src/runtime/test/artifacts/test-particles.manifest', loader);
 
@@ -125,7 +125,7 @@ describe('particle interface loading', function() {
           input <- h1
       `, {loader, fileName: './test.manifest'});
 
-    const arc = new Arc({id: ArcId.newArcIdForTest('test'), context: manifest});
+    const arc = new Arc({id: ArcId.newForTest('test'), context: manifest});
 
     const fooType = manifest.findTypeByName('Foo');
     const barType = manifest.findTypeByName('Bar');
@@ -202,7 +202,7 @@ describe('particle interface loading', function() {
         });
       `
     });
-    const arc = new Arc({id: ArcId.newArcIdForTest('test'), context: manifest, loader});
+    const arc = new Arc({id: ArcId.newForTest('test'), context: manifest, loader});
     const fooType = manifest.findTypeByName('Foo');
     const fooStore = await arc.createStore(fooType);
     recipe.handles[0].mapToStorage(fooStore);

--- a/src/runtime/test/particle-interface-loading-test.js
+++ b/src/runtime/test/particle-interface-loading-test.js
@@ -17,7 +17,7 @@ import {StubLoader} from '../testing/stub-loader.js';
 import {Recipe} from '../recipe/recipe.js';
 import {EntityType, InterfaceType} from '../type.js';
 import {ParticleSpec} from '../particle-spec.js';
-import {Id} from '../id.js';
+import {ArcId} from '../id.js';
 
 describe('particle interface loading', function() {
 
@@ -59,7 +59,7 @@ describe('particle interface loading', function() {
             };
           });`});
 
-    const arc = new Arc({id: new Id('test'), loader});
+    const arc = new Arc({id: ArcId.newArcIdForTest('test'), loader});
 
     const manifest = await Manifest.load('./src/runtime/test/artifacts/test-particles.manifest', loader);
 
@@ -125,7 +125,7 @@ describe('particle interface loading', function() {
           input <- h1
       `, {loader, fileName: './test.manifest'});
 
-    const arc = new Arc({id: new Id('test'), context: manifest});
+    const arc = new Arc({id: ArcId.newArcIdForTest('test'), context: manifest});
 
     const fooType = manifest.findTypeByName('Foo');
     const barType = manifest.findTypeByName('Bar');
@@ -202,7 +202,7 @@ describe('particle interface loading', function() {
         });
       `
     });
-    const arc = new Arc({id: new Id('test'), context: manifest, loader});
+    const arc = new Arc({id: ArcId.newArcIdForTest('test'), context: manifest, loader});
     const fooType = manifest.findTypeByName('Foo');
     const fooStore = await arc.createStore(fooType);
     recipe.handles[0].mapToStorage(fooStore);

--- a/src/runtime/test/particle-interface-loading-with-slots-test.js
+++ b/src/runtime/test/particle-interface-loading-with-slots-test.js
@@ -15,7 +15,7 @@ import {MockSlotComposer} from '../testing/mock-slot-composer.js';
 import {SlotDomConsumer} from '../slot-dom-consumer.js';
 import {TestHelper} from '../testing/test-helper.js';
 import {ProvidedSlotContext, HostedSlotContext} from '../slot-context.js';
-import {Id} from '../id.js';
+import {ArcId} from '../id.js';
 
 describe('particle interface loading with slots', function() {
   async function initializeManifestAndArc(contextContainer) {
@@ -35,7 +35,7 @@ describe('particle interface loading with slots', function() {
       `, loader);
     const recipe = manifest.recipes[0];
 
-    const arc = new Arc({id: new Id('test'), slotComposer, context: manifest});
+    const arc = new Arc({id: ArcId.newArcIdForTest('test'), slotComposer, context: manifest});
 
     assert(recipe.normalize(), `can't normalize recipe`);
     assert(recipe.isResolved(), `recipe isn't resolved`);

--- a/src/runtime/test/particle-interface-loading-with-slots-test.js
+++ b/src/runtime/test/particle-interface-loading-with-slots-test.js
@@ -35,7 +35,7 @@ describe('particle interface loading with slots', function() {
       `, loader);
     const recipe = manifest.recipes[0];
 
-    const arc = new Arc({id: ArcId.newArcIdForTest('test'), slotComposer, context: manifest});
+    const arc = new Arc({id: ArcId.newForTest('test'), slotComposer, context: manifest});
 
     assert(recipe.normalize(), `can't normalize recipe`);
     assert(recipe.isResolved(), `recipe isn't resolved`);

--- a/src/runtime/test/recipe-resolver-test.ts
+++ b/src/runtime/test/recipe-resolver-test.ts
@@ -15,7 +15,7 @@ import {Manifest} from '../manifest.js';
 import {RecipeResolver} from '../recipe/recipe-resolver.js';
 import {FakeSlotComposer} from '../testing/fake-slot-composer.js';
 import {StubLoader} from '../testing/stub-loader.js';
-import {Id} from '../id.js';
+import {Id, ArcId} from '../id.js';
 
 describe('RecipeResolver', () => {
   const buildManifest = async (content) => {
@@ -24,7 +24,7 @@ describe('RecipeResolver', () => {
     return await Manifest.load('manifest', loader, {registry});
   };
 
-  const createArc = (manifest) => new Arc({id: new Id('test'), slotComposer: new FakeSlotComposer(), loader: new Loader(), context: manifest});
+  const createArc = (manifest) => new Arc({id: ArcId.newArcIdForTest('test'), slotComposer: new FakeSlotComposer(), loader: new Loader(), context: manifest});
 
   it('resolves a recipe', async () => {
     const manifest = await buildManifest({

--- a/src/runtime/test/recipe-resolver-test.ts
+++ b/src/runtime/test/recipe-resolver-test.ts
@@ -24,7 +24,7 @@ describe('RecipeResolver', () => {
     return await Manifest.load('manifest', loader, {registry});
   };
 
-  const createArc = (manifest) => new Arc({id: ArcId.newArcIdForTest('test'), slotComposer: new FakeSlotComposer(), loader: new Loader(), context: manifest});
+  const createArc = (manifest) => new Arc({id: ArcId.newForTest('test'), slotComposer: new FakeSlotComposer(), loader: new Loader(), context: manifest});
 
   it('resolves a recipe', async () => {
     const manifest = await buildManifest({

--- a/src/runtime/test/runtime-tests.ts
+++ b/src/runtime/test/runtime-tests.ts
@@ -31,8 +31,8 @@ function assertManifestsEqual(actual: Manifest, expected: Manifest) {
 
 describe('Runtime', () => {
   it('gets an arc description for an arc', async () => {
-    const arc = new Arc({slotComposer: new FakeSlotComposer(), id: ArcId.newArcIdForTest('test'), loader: new Loader(),
-                         context: new Manifest({id: ArcId.newArcIdForTest('test')})});
+    const arc = new Arc({slotComposer: new FakeSlotComposer(), id: ArcId.newForTest('test'), loader: new Loader(),
+                         context: new Manifest({id: ArcId.newForTest('test')})});
     const description = await Description.create(arc);
     const expected = await description.getArcDescription();
     const actual = await Runtime.getArcDescription(arc);

--- a/src/runtime/test/runtime-tests.ts
+++ b/src/runtime/test/runtime-tests.ts
@@ -15,7 +15,7 @@ import {Loader} from '../loader.js';
 import {Manifest} from '../manifest.js';
 import {Runtime} from '../runtime.js';
 import {FakeSlotComposer} from '../testing/fake-slot-composer';
-import {Id} from '../id.js';
+import {Id, ArcId} from '../id.js';
 
 // tslint:disable-next-line: no-any
 function unsafe<T>(value: T): any { return value; }
@@ -31,8 +31,8 @@ function assertManifestsEqual(actual: Manifest, expected: Manifest) {
 
 describe('Runtime', () => {
   it('gets an arc description for an arc', async () => {
-    const arc = new Arc({slotComposer: new FakeSlotComposer(), id: new Id('test'), loader: new Loader(),
-                         context: new Manifest({id: new Id('test')})});
+    const arc = new Arc({slotComposer: new FakeSlotComposer(), id: ArcId.newArcIdForTest('test'), loader: new Loader(),
+                         context: new Manifest({id: ArcId.newArcIdForTest('test')})});
     const description = await Description.create(arc);
     const expected = await description.getArcDescription();
     const actual = await Runtime.getArcDescription(arc);

--- a/src/runtime/test/storage-proxy-test.ts
+++ b/src/runtime/test/storage-proxy-test.ts
@@ -190,7 +190,7 @@ class TestEngine {
   _arcId: ArcId;
   
   constructor(arcId: string) {
-    this._arcId = ArcId.newArcIdForTest(arcId);
+    this._arcId = ArcId.newForTest(arcId);
   }
 
   newVariable(name) {
@@ -316,7 +316,7 @@ describe('storage-proxy', () => {
     // and TestVariable will need to be updated to match.
     const engine = new TestEngine('!arc-id');
     const entity = engine.newEntity('abc');
-    const realStorage = new VolatileStorage(ArcId.newArcIdForTest('arc-id'));
+    const realStorage = new VolatileStorage(ArcId.newForTest('arc-id'));
     let testEvent;
     let realEvent;
 
@@ -343,7 +343,7 @@ describe('storage-proxy', () => {
     // and TestCollection will need to be updated to match.
     const engine = new TestEngine('arc-id');
     const entity = engine.newEntity('abc');
-    const realStorage = new VolatileStorage(ArcId.newArcIdForTest('arc-id'));
+    const realStorage = new VolatileStorage(ArcId.newForTest('arc-id'));
     let testEvent;
     let realEvent;
 

--- a/src/runtime/test/storage-proxy-test.ts
+++ b/src/runtime/test/storage-proxy-test.ts
@@ -11,7 +11,7 @@
 
 import {assert} from '../../platform/chai-web.js';
 import {handleFor, Handle, Variable, Collection} from '../handle.js';
-import {Id} from '../id.js';
+import {Id, ArcId} from '../id.js';
 import {Schema} from '../schema.js';
 import {StorageProxy, StorageProxyScheduler, CollectionProxy, BigCollectionProxy, VariableProxy} from '../storage-proxy.js';
 import {CrdtCollectionModel} from '../storage/crdt-collection-model.js';
@@ -124,7 +124,7 @@ class TestCollection {
     const effective = this._model.remove(id, keys);
     this._version = (version !== undefined) ? version : this._version + 1;
     if (sendEvent) {
-      const item = {value: {id, storageKey: `volatile://${this._arcId}:^^volatile-Thing {Text value}`}, effective, keys};
+      const item = {value: {id, storageKey: `volatile://${this._arcId}^^volatile-Thing {Text value}`}, effective, keys};
       // Hard coding the storageKey here is a bit cheeky, but the TestEngine class 
       // enforces the schema and arcID is plumbed through.
       const event = {remove: [item], version: this._version, originatorId};
@@ -187,10 +187,10 @@ class TestEngine {
   _syncCallbacks = new Map();
   _events = [];
   _scheduler = new StorageProxyScheduler();
-  _arcId;
+  _arcId: ArcId;
   
-  constructor(arcId) {
-    this._arcId = arcId;
+  constructor(arcId: string) {
+    this._arcId = ArcId.newArcIdForTest(arcId);
   }
 
   newVariable(name) {
@@ -316,7 +316,7 @@ describe('storage-proxy', () => {
     // and TestVariable will need to be updated to match.
     const engine = new TestEngine('!arc-id');
     const entity = engine.newEntity('abc');
-    const realStorage = new VolatileStorage(new Id('arc-id'));
+    const realStorage = new VolatileStorage(ArcId.newArcIdForTest('arc-id'));
     let testEvent;
     let realEvent;
 
@@ -341,9 +341,9 @@ describe('storage-proxy', () => {
   it('verify that the test storage API matches the real storage (collection)', async () => {
     // If this fails, most likely the VolatileStorage classes have been changed
     // and TestCollection will need to be updated to match.
-    const engine = new TestEngine('!arc-id');
+    const engine = new TestEngine('arc-id');
     const entity = engine.newEntity('abc');
-    const realStorage = new VolatileStorage(new Id('arc-id'));
+    const realStorage = new VolatileStorage(ArcId.newArcIdForTest('arc-id'));
     let testEvent;
     let realEvent;
 
@@ -366,7 +366,7 @@ describe('storage-proxy', () => {
   });
 
   it('notifies for updates to initially empty handles', async () => {
-    const engine = new TestEngine('!arc-id');
+    const engine = new TestEngine('arc-id');
     const fooStore = engine.newVariable('foo');
     const barStore = engine.newCollection('bar');
     const particle = engine.newParticle();

--- a/src/runtime/test/storage/pouchdb/pouch-db-tests.ts
+++ b/src/runtime/test/storage/pouchdb/pouch-db-tests.ts
@@ -18,7 +18,7 @@ import {PouchDbVariable} from '../../../storage/pouchdb/pouch-db-variable.js';
 import {StorageProviderFactory} from '../../../storage/storage-provider-factory.js';
 import {CallbackTracker} from '../../../testing/callback-tracker.js';
 import {EntityType, ReferenceType} from '../../../type.js';
-import {Id} from '../../../id.js';
+import {Id, ArcId} from '../../../id.js';
 
 const testUrl = 'pouchdb://memory/user-test';
 
@@ -61,7 +61,7 @@ describe('pouchdb', () => {
         schema Bar
           Text value
       `);
-      const arc = new Arc({id: new Id('test'), context: manifest, loader: new Loader()});
+      const arc = new Arc({id: ArcId.newArcIdForTest('test'), context: manifest, loader: new Loader()});
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const value = 'Hi there' + Math.random();
@@ -79,7 +79,7 @@ describe('pouchdb', () => {
         schema Bar
           Text value
       `);
-      const arc = new Arc({id: new Id('test'), context: manifest, loader: new Loader()});
+      const arc = new Arc({id: ArcId.newArcIdForTest('test'), context: manifest, loader: new Loader()});
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const key = newStoreKey('variable');
@@ -111,7 +111,7 @@ describe('pouchdb', () => {
           Text value
       `);
 
-      const arc = new Arc({id: new Id('test'), context: manifest, loader: new Loader()});
+      const arc = new Arc({id: ArcId.newArcIdForTest('test'), context: manifest, loader: new Loader()});
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const key1 = newStoreKey('varPtr');
@@ -134,7 +134,7 @@ describe('pouchdb', () => {
           Text value
       `);
 
-      const arc = new Arc({id: new Id('test'),  context: manifest, loader: new Loader()});
+      const arc = new Arc({id: ArcId.newArcIdForTest('test'),  context: manifest, loader: new Loader()});
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const key1 = newStoreKey('varPtr');
@@ -156,7 +156,7 @@ describe('pouchdb', () => {
         schema Bar
           Text value
       `);
-      const arc = new Arc({id: new Id('test'), context: manifest, loader: new Loader()});
+      const arc = new Arc({id: ArcId.newArcIdForTest('test'), context: manifest, loader: new Loader()});
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const value1 = 'Hi there' + Math.random();
@@ -174,7 +174,7 @@ describe('pouchdb', () => {
         schema Bar
           Text value
       `);
-      const arc = new Arc({id: new Id('test'), context: manifest, loader: new Loader()});
+      const arc = new Arc({id: ArcId.newArcIdForTest('test'), context: manifest, loader: new Loader()});
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const key = newStoreKey('collection');
@@ -195,7 +195,7 @@ describe('pouchdb', () => {
         schema Bar
           Text value
       `);
-      const arc = new Arc({id: new Id('test'), context: manifest, loader: new Loader()});
+      const arc = new Arc({id: ArcId.newArcIdForTest('test'), context: manifest, loader: new Loader()});
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const key = newStoreKey('collection');
@@ -215,7 +215,7 @@ describe('pouchdb', () => {
         schema Bar
           Text value
       `);
-      const arc = new Arc({id: new Id('test'), context: manifest, loader: new Loader()});
+      const arc = new Arc({id: ArcId.newArcIdForTest('test'), context: manifest, loader: new Loader()});
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const key = newStoreKey('collection');
@@ -237,7 +237,7 @@ describe('pouchdb', () => {
           Text value
       `);
 
-      const arc = new Arc({id: new Id('test'), context: manifest, loader: new Loader()});
+      const arc = new Arc({id: ArcId.newArcIdForTest('test'), context: manifest, loader: new Loader()});
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const key1 = newStoreKey('colPtr');
@@ -264,7 +264,7 @@ describe('pouchdb', () => {
         schema Bar
           Text value
       `);
-      const arc = new Arc({id: new Id('test'), context: manifest, loader: new Loader()});
+      const arc = new Arc({id: ArcId.newArcIdForTest('test'), context: manifest, loader: new Loader()});
       const storage = new StorageProviderFactory(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const key = newStoreKey('collectionRemoveMultiple');
@@ -285,7 +285,7 @@ describe('pouchdb', () => {
           Text value
       `);
 
-      const arc = new Arc({id: new Id('test'), context: manifest, loader: new Loader()});
+      const arc = new Arc({id: ArcId.newArcIdForTest('test'), context: manifest, loader: new Loader()});
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const key1 = newStoreKey('colPtr');
@@ -310,7 +310,7 @@ describe('pouchdb', () => {
         schema Bar
           Text value
       `);
-      const arc = new Arc({id: new Id('test'), context: manifest, loader: new Loader()});
+      const arc = new Arc({id: ArcId.newArcIdForTest('test'), context: manifest, loader: new Loader()});
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const key = newStoreKey('collection');

--- a/src/runtime/test/storage/pouchdb/pouch-db-tests.ts
+++ b/src/runtime/test/storage/pouchdb/pouch-db-tests.ts
@@ -61,7 +61,7 @@ describe('pouchdb', () => {
         schema Bar
           Text value
       `);
-      const arc = new Arc({id: ArcId.newArcIdForTest('test'), context: manifest, loader: new Loader()});
+      const arc = new Arc({id: ArcId.newForTest('test'), context: manifest, loader: new Loader()});
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const value = 'Hi there' + Math.random();
@@ -79,7 +79,7 @@ describe('pouchdb', () => {
         schema Bar
           Text value
       `);
-      const arc = new Arc({id: ArcId.newArcIdForTest('test'), context: manifest, loader: new Loader()});
+      const arc = new Arc({id: ArcId.newForTest('test'), context: manifest, loader: new Loader()});
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const key = newStoreKey('variable');
@@ -111,7 +111,7 @@ describe('pouchdb', () => {
           Text value
       `);
 
-      const arc = new Arc({id: ArcId.newArcIdForTest('test'), context: manifest, loader: new Loader()});
+      const arc = new Arc({id: ArcId.newForTest('test'), context: manifest, loader: new Loader()});
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const key1 = newStoreKey('varPtr');
@@ -134,7 +134,7 @@ describe('pouchdb', () => {
           Text value
       `);
 
-      const arc = new Arc({id: ArcId.newArcIdForTest('test'),  context: manifest, loader: new Loader()});
+      const arc = new Arc({id: ArcId.newForTest('test'),  context: manifest, loader: new Loader()});
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const key1 = newStoreKey('varPtr');
@@ -156,7 +156,7 @@ describe('pouchdb', () => {
         schema Bar
           Text value
       `);
-      const arc = new Arc({id: ArcId.newArcIdForTest('test'), context: manifest, loader: new Loader()});
+      const arc = new Arc({id: ArcId.newForTest('test'), context: manifest, loader: new Loader()});
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const value1 = 'Hi there' + Math.random();
@@ -174,7 +174,7 @@ describe('pouchdb', () => {
         schema Bar
           Text value
       `);
-      const arc = new Arc({id: ArcId.newArcIdForTest('test'), context: manifest, loader: new Loader()});
+      const arc = new Arc({id: ArcId.newForTest('test'), context: manifest, loader: new Loader()});
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const key = newStoreKey('collection');
@@ -195,7 +195,7 @@ describe('pouchdb', () => {
         schema Bar
           Text value
       `);
-      const arc = new Arc({id: ArcId.newArcIdForTest('test'), context: manifest, loader: new Loader()});
+      const arc = new Arc({id: ArcId.newForTest('test'), context: manifest, loader: new Loader()});
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const key = newStoreKey('collection');
@@ -215,7 +215,7 @@ describe('pouchdb', () => {
         schema Bar
           Text value
       `);
-      const arc = new Arc({id: ArcId.newArcIdForTest('test'), context: manifest, loader: new Loader()});
+      const arc = new Arc({id: ArcId.newForTest('test'), context: manifest, loader: new Loader()});
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const key = newStoreKey('collection');
@@ -237,7 +237,7 @@ describe('pouchdb', () => {
           Text value
       `);
 
-      const arc = new Arc({id: ArcId.newArcIdForTest('test'), context: manifest, loader: new Loader()});
+      const arc = new Arc({id: ArcId.newForTest('test'), context: manifest, loader: new Loader()});
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const key1 = newStoreKey('colPtr');
@@ -264,7 +264,7 @@ describe('pouchdb', () => {
         schema Bar
           Text value
       `);
-      const arc = new Arc({id: ArcId.newArcIdForTest('test'), context: manifest, loader: new Loader()});
+      const arc = new Arc({id: ArcId.newForTest('test'), context: manifest, loader: new Loader()});
       const storage = new StorageProviderFactory(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const key = newStoreKey('collectionRemoveMultiple');
@@ -285,7 +285,7 @@ describe('pouchdb', () => {
           Text value
       `);
 
-      const arc = new Arc({id: ArcId.newArcIdForTest('test'), context: manifest, loader: new Loader()});
+      const arc = new Arc({id: ArcId.newForTest('test'), context: manifest, loader: new Loader()});
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const key1 = newStoreKey('colPtr');
@@ -310,7 +310,7 @@ describe('pouchdb', () => {
         schema Bar
           Text value
       `);
-      const arc = new Arc({id: ArcId.newArcIdForTest('test'), context: manifest, loader: new Loader()});
+      const arc = new Arc({id: ArcId.newForTest('test'), context: manifest, loader: new Loader()});
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const key = newStoreKey('collection');

--- a/src/runtime/test/synthetic-storage-test.ts
+++ b/src/runtime/test/synthetic-storage-test.ts
@@ -7,7 +7,7 @@
 // http://polymer.github.io/PATENTS.txt
 
 import {assert} from '../../platform/chai-web.js';
-import {Id} from '../id.js';
+import {Id, ArcId} from '../id.js';
 import {ChangeEvent, CollectionStorageProvider, VariableStorageProvider} from '../storage/storage-provider-base.js';
 import {StorageProviderFactory} from '../storage/storage-provider-factory.js';
 import {resetVolatileStorageForTesting} from '../storage/volatile-storage.js';
@@ -21,7 +21,7 @@ describe('synthetic storage ', () => {
   });
 
   async function setup(serialization): Promise<{id: Id, targetStore: VariableStorageProvider, synth: CollectionStorageProvider}> {
-    const id = new Id('123', ['test']);
+    const id = ArcId.newArcIdForTest('test');
     const storage = new StorageProviderFactory(id);
     const type = new ArcType();
     const key = storage.parseStringAsKey(`volatile://${id}`).childKeyForArcInfo().toString();
@@ -37,7 +37,7 @@ describe('synthetic storage ', () => {
   }
 
   it('invalid synthetic keys', async () => {
-    const storage = new StorageProviderFactory(new Id('123', ['test']));
+    const storage = new StorageProviderFactory(ArcId.newArcIdForTest('test'));
     const check = (key, msg) => assertThrowsAsync(() => storage.connect('id1', null, key), msg);
 
     check('simplistic://arc/handles/volatile', 'unknown storage protocol');
@@ -49,7 +49,7 @@ describe('synthetic storage ', () => {
   });
 
   it('non-existent target key', async () => {
-    const storage = new StorageProviderFactory(new Id('123', ['test']));
+    const storage = new StorageProviderFactory(ArcId.newArcIdForTest('test'));
     const synth = await storage.connect('id1', null, `synthetic://arc/handles/volatile://nope`);
     assert.isNull(synth);
   });

--- a/src/runtime/test/synthetic-storage-test.ts
+++ b/src/runtime/test/synthetic-storage-test.ts
@@ -21,7 +21,7 @@ describe('synthetic storage ', () => {
   });
 
   async function setup(serialization): Promise<{id: Id, targetStore: VariableStorageProvider, synth: CollectionStorageProvider}> {
-    const id = ArcId.newArcIdForTest('test');
+    const id = ArcId.newForTest('test');
     const storage = new StorageProviderFactory(id);
     const type = new ArcType();
     const key = storage.parseStringAsKey(`volatile://${id}`).childKeyForArcInfo().toString();
@@ -37,7 +37,7 @@ describe('synthetic storage ', () => {
   }
 
   it('invalid synthetic keys', async () => {
-    const storage = new StorageProviderFactory(ArcId.newArcIdForTest('test'));
+    const storage = new StorageProviderFactory(ArcId.newForTest('test'));
     const check = (key, msg) => assertThrowsAsync(() => storage.connect('id1', null, key), msg);
 
     check('simplistic://arc/handles/volatile', 'unknown storage protocol');
@@ -49,7 +49,7 @@ describe('synthetic storage ', () => {
   });
 
   it('non-existent target key', async () => {
-    const storage = new StorageProviderFactory(ArcId.newArcIdForTest('test'));
+    const storage = new StorageProviderFactory(ArcId.newForTest('test'));
     const synth = await storage.connect('id1', null, `synthetic://arc/handles/volatile://nope`);
     assert.isNull(synth);
   });

--- a/src/runtime/test/volatile-storage-test.ts
+++ b/src/runtime/test/volatile-storage-test.ts
@@ -16,7 +16,7 @@ import {BigCollectionStorageProvider, CollectionStorageProvider, VariableStorage
 import {StorageProviderFactory} from '../storage/storage-provider-factory.js';
 import {resetVolatileStorageForTesting} from '../storage/volatile-storage.js';
 import {EntityType, ReferenceType} from '../type.js';
-import {Id} from '../id.js';
+import {Id, ArcId} from '../id.js';
 
 // Resolves when the two stores are synchronzied with each other:
 // * same version
@@ -44,7 +44,7 @@ describe('volatile', () => {
         schema Bar
           Text value
       `);
-      const arc = new Arc({id: new Id('test'), loader: new Loader(), context: manifest});
+      const arc = new Arc({id: ArcId.newArcIdForTest('test'), loader: new Loader(), context: manifest});
       const storage = new StorageProviderFactory(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const value = 'Hi there' + Math.random();
@@ -59,7 +59,7 @@ describe('volatile', () => {
         schema Bar
           Text value
       `);
-      const arc = new Arc({id: new Id('test'), loader: new Loader(), context: manifest});
+      const arc = new Arc({id: ArcId.newArcIdForTest('test'), loader: new Loader(), context: manifest});
       const storage = new StorageProviderFactory(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const var1 = await storage.construct('test0', barType, storeKey) as VariableStorageProvider;
@@ -74,7 +74,7 @@ describe('volatile', () => {
           Text value
       `);
 
-      const arc = new Arc({id: new Id('test'), loader: new Loader(), context: manifest});
+      const arc = new Arc({id: ArcId.newArcIdForTest('test'), loader: new Loader(), context: manifest});
       const storage = new StorageProviderFactory(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
 
@@ -96,7 +96,7 @@ describe('volatile', () => {
           Text value
       `);
 
-      const arc = new Arc({id: new Id('test'), loader: new Loader(), context: manifest});
+      const arc = new Arc({id: ArcId.newArcIdForTest('test'), loader: new Loader(), context: manifest});
       const storage = new StorageProviderFactory(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
 
@@ -118,7 +118,7 @@ describe('volatile', () => {
         schema Bar
           Text value
       `);
-      const arc = new Arc({id: new Id('test'), loader: new Loader(), context: manifest});
+      const arc = new Arc({id: ArcId.newArcIdForTest('test'), loader: new Loader(), context: manifest});
       const storage = new StorageProviderFactory(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const value1 = 'Hi there' + Math.random();
@@ -136,7 +136,7 @@ describe('volatile', () => {
         schema Bar
           Text value
       `);
-      const arc = new Arc({id: new Id('test'), loader: new Loader(), context: manifest});
+      const arc = new Arc({id: ArcId.newArcIdForTest('test'), loader: new Loader(), context: manifest});
       const storage = new StorageProviderFactory(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const collection1 = await storage.construct('test1', barType.collectionOf(), storeKey) as CollectionStorageProvider;
@@ -151,7 +151,7 @@ describe('volatile', () => {
         schema Bar
           Text value
       `);
-      const arc = new Arc({id: new Id('test'), loader: new Loader(), context: manifest});
+      const arc = new Arc({id: ArcId.newArcIdForTest('test'), loader: new Loader(), context: manifest});
       const storage = new StorageProviderFactory(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const collection1 = await storage.construct('test1', barType.collectionOf(), storeKey) as CollectionStorageProvider;
@@ -169,7 +169,7 @@ describe('volatile', () => {
         schema Bar
           Text value
       `);
-      const arc = new Arc({id: new Id('test'), loader: new Loader(), context: manifest});
+      const arc = new Arc({id: ArcId.newArcIdForTest('test'), loader: new Loader(), context: manifest});
       const storage = new StorageProviderFactory(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const collection1 = await storage.construct('test1', barType.collectionOf(), storeKey) as CollectionStorageProvider;
@@ -186,7 +186,7 @@ describe('volatile', () => {
           Text value
       `);
 
-      const arc = new Arc({id: new Id('test'), loader: new Loader(), context: manifest});
+      const arc = new Arc({id: ArcId.newArcIdForTest('test'), loader: new Loader(), context: manifest});
       const storage = new StorageProviderFactory(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
   
@@ -210,7 +210,7 @@ describe('volatile', () => {
         schema Bar
           Text value
       `);
-      const arc = new Arc({id: new Id('test'), loader: new Loader(), context: manifest});
+      const arc = new Arc({id: ArcId.newArcIdForTest('test'), loader: new Loader(), context: manifest});
       const storage = new StorageProviderFactory(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const collection = await storage.construct('test1', barType.collectionOf(), storeKey) as CollectionStorageProvider;
@@ -227,7 +227,7 @@ describe('volatile', () => {
           Text value
       `);
   
-      const arc = new Arc({id: new Id('test'), loader: new Loader(), context: manifest});
+      const arc = new Arc({id: ArcId.newArcIdForTest('test'), loader: new Loader(), context: manifest});
       const storage = new StorageProviderFactory(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
   
@@ -252,7 +252,7 @@ describe('volatile', () => {
         schema Bar
           Text data
       `);
-      const arc = new Arc({id: new Id('test'), loader: new Loader(), context: manifest});
+      const arc = new Arc({id: ArcId.newArcIdForTest('test'), loader: new Loader(), context: manifest});
       const storage = new StorageProviderFactory(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const collection1 = await storage.construct('test0', barType.bigCollectionOf(), storeKey) as CollectionStorageProvider;
@@ -301,7 +301,7 @@ describe('volatile', () => {
         schema Bar
           Text data
       `);
-      const arc = new Arc({id: new Id('test'), loader: new Loader(), context: manifest});
+      const arc = new Arc({id: ArcId.newArcIdForTest('test'), loader: new Loader(), context: manifest});
       const storage = new StorageProviderFactory(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const col = await storage.construct('test0', barType.bigCollectionOf(), storeKey) as BigCollectionStorageProvider;
@@ -344,7 +344,7 @@ describe('volatile', () => {
         schema Bar
           Text data
       `);
-      const arc = new Arc({id: new Id('test'), context: manifest, loader: new Loader()});
+      const arc = new Arc({id: ArcId.newArcIdForTest('test'), context: manifest, loader: new Loader()});
       const storage = new StorageProviderFactory(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const col = await storage.construct('test0', barType.bigCollectionOf(), storeKey) as BigCollectionStorageProvider;

--- a/src/runtime/test/volatile-storage-test.ts
+++ b/src/runtime/test/volatile-storage-test.ts
@@ -44,7 +44,7 @@ describe('volatile', () => {
         schema Bar
           Text value
       `);
-      const arc = new Arc({id: ArcId.newArcIdForTest('test'), loader: new Loader(), context: manifest});
+      const arc = new Arc({id: ArcId.newForTest('test'), loader: new Loader(), context: manifest});
       const storage = new StorageProviderFactory(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const value = 'Hi there' + Math.random();
@@ -59,7 +59,7 @@ describe('volatile', () => {
         schema Bar
           Text value
       `);
-      const arc = new Arc({id: ArcId.newArcIdForTest('test'), loader: new Loader(), context: manifest});
+      const arc = new Arc({id: ArcId.newForTest('test'), loader: new Loader(), context: manifest});
       const storage = new StorageProviderFactory(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const var1 = await storage.construct('test0', barType, storeKey) as VariableStorageProvider;
@@ -74,7 +74,7 @@ describe('volatile', () => {
           Text value
       `);
 
-      const arc = new Arc({id: ArcId.newArcIdForTest('test'), loader: new Loader(), context: manifest});
+      const arc = new Arc({id: ArcId.newForTest('test'), loader: new Loader(), context: manifest});
       const storage = new StorageProviderFactory(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
 
@@ -96,7 +96,7 @@ describe('volatile', () => {
           Text value
       `);
 
-      const arc = new Arc({id: ArcId.newArcIdForTest('test'), loader: new Loader(), context: manifest});
+      const arc = new Arc({id: ArcId.newForTest('test'), loader: new Loader(), context: manifest});
       const storage = new StorageProviderFactory(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
 
@@ -118,7 +118,7 @@ describe('volatile', () => {
         schema Bar
           Text value
       `);
-      const arc = new Arc({id: ArcId.newArcIdForTest('test'), loader: new Loader(), context: manifest});
+      const arc = new Arc({id: ArcId.newForTest('test'), loader: new Loader(), context: manifest});
       const storage = new StorageProviderFactory(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const value1 = 'Hi there' + Math.random();
@@ -136,7 +136,7 @@ describe('volatile', () => {
         schema Bar
           Text value
       `);
-      const arc = new Arc({id: ArcId.newArcIdForTest('test'), loader: new Loader(), context: manifest});
+      const arc = new Arc({id: ArcId.newForTest('test'), loader: new Loader(), context: manifest});
       const storage = new StorageProviderFactory(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const collection1 = await storage.construct('test1', barType.collectionOf(), storeKey) as CollectionStorageProvider;
@@ -151,7 +151,7 @@ describe('volatile', () => {
         schema Bar
           Text value
       `);
-      const arc = new Arc({id: ArcId.newArcIdForTest('test'), loader: new Loader(), context: manifest});
+      const arc = new Arc({id: ArcId.newForTest('test'), loader: new Loader(), context: manifest});
       const storage = new StorageProviderFactory(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const collection1 = await storage.construct('test1', barType.collectionOf(), storeKey) as CollectionStorageProvider;
@@ -169,7 +169,7 @@ describe('volatile', () => {
         schema Bar
           Text value
       `);
-      const arc = new Arc({id: ArcId.newArcIdForTest('test'), loader: new Loader(), context: manifest});
+      const arc = new Arc({id: ArcId.newForTest('test'), loader: new Loader(), context: manifest});
       const storage = new StorageProviderFactory(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const collection1 = await storage.construct('test1', barType.collectionOf(), storeKey) as CollectionStorageProvider;
@@ -186,7 +186,7 @@ describe('volatile', () => {
           Text value
       `);
 
-      const arc = new Arc({id: ArcId.newArcIdForTest('test'), loader: new Loader(), context: manifest});
+      const arc = new Arc({id: ArcId.newForTest('test'), loader: new Loader(), context: manifest});
       const storage = new StorageProviderFactory(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
   
@@ -210,7 +210,7 @@ describe('volatile', () => {
         schema Bar
           Text value
       `);
-      const arc = new Arc({id: ArcId.newArcIdForTest('test'), loader: new Loader(), context: manifest});
+      const arc = new Arc({id: ArcId.newForTest('test'), loader: new Loader(), context: manifest});
       const storage = new StorageProviderFactory(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const collection = await storage.construct('test1', barType.collectionOf(), storeKey) as CollectionStorageProvider;
@@ -227,7 +227,7 @@ describe('volatile', () => {
           Text value
       `);
   
-      const arc = new Arc({id: ArcId.newArcIdForTest('test'), loader: new Loader(), context: manifest});
+      const arc = new Arc({id: ArcId.newForTest('test'), loader: new Loader(), context: manifest});
       const storage = new StorageProviderFactory(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
   
@@ -252,7 +252,7 @@ describe('volatile', () => {
         schema Bar
           Text data
       `);
-      const arc = new Arc({id: ArcId.newArcIdForTest('test'), loader: new Loader(), context: manifest});
+      const arc = new Arc({id: ArcId.newForTest('test'), loader: new Loader(), context: manifest});
       const storage = new StorageProviderFactory(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const collection1 = await storage.construct('test0', barType.bigCollectionOf(), storeKey) as CollectionStorageProvider;
@@ -301,7 +301,7 @@ describe('volatile', () => {
         schema Bar
           Text data
       `);
-      const arc = new Arc({id: ArcId.newArcIdForTest('test'), loader: new Loader(), context: manifest});
+      const arc = new Arc({id: ArcId.newForTest('test'), loader: new Loader(), context: manifest});
       const storage = new StorageProviderFactory(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const col = await storage.construct('test0', barType.bigCollectionOf(), storeKey) as BigCollectionStorageProvider;
@@ -344,7 +344,7 @@ describe('volatile', () => {
         schema Bar
           Text data
       `);
-      const arc = new Arc({id: ArcId.newArcIdForTest('test'), context: manifest, loader: new Loader()});
+      const arc = new Arc({id: ArcId.newForTest('test'), context: manifest, loader: new Loader()});
       const storage = new StorageProviderFactory(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const col = await storage.construct('test0', barType.bigCollectionOf(), storeKey) as BigCollectionStorageProvider;

--- a/src/runtime/testing/manifest-integration-test-setup.ts
+++ b/src/runtime/testing/manifest-integration-test-setup.ts
@@ -12,14 +12,14 @@ import {assert} from '../../platform/chai-web.js';
 import {Arc} from '../arc.js';
 import {Loader} from '../loader.js';
 import {Manifest} from '../manifest.js';
-import {Id} from '../id.js';
+import {Id, ArcId} from '../id.js';
 
 export async function manifestTestSetup() {
   const registry = {};
   const loader = new Loader();
   const manifest = await Manifest.load('./src/runtime/test/artifacts/test.manifest', loader, registry);
   assert(manifest);
-  const arc = new Arc({id: new Id('test'), context: manifest, loader});
+  const arc = new Arc({id: ArcId.newArcIdForTest('test'), context: manifest, loader});
   const recipe = manifest.recipes[0];
   assert(recipe.normalize());
   assert(recipe.isResolved());

--- a/src/runtime/testing/manifest-integration-test-setup.ts
+++ b/src/runtime/testing/manifest-integration-test-setup.ts
@@ -19,7 +19,7 @@ export async function manifestTestSetup() {
   const loader = new Loader();
   const manifest = await Manifest.load('./src/runtime/test/artifacts/test.manifest', loader, registry);
   assert(manifest);
-  const arc = new Arc({id: ArcId.newArcIdForTest('test'), context: manifest, loader});
+  const arc = new Arc({id: ArcId.newForTest('test'), context: manifest, loader});
   const recipe = manifest.recipes[0];
   assert(recipe.normalize());
   assert(recipe.isResolved());

--- a/src/tests/slot-composer-tests.ts
+++ b/src/tests/slot-composer-tests.ts
@@ -28,7 +28,7 @@ async function initSlotComposer(recipeStr) {
     '*': `defineParticle(({Particle}) => { return class P extends Particle {} });`
   });
   const arc = new Arc({
-    id: ArcId.newArcIdForTest('test-plan-arc'),
+    id: ArcId.newForTest('test-plan-arc'),
     context: manifest,
     slotComposer,
     loader

--- a/src/tests/slot-composer-tests.ts
+++ b/src/tests/slot-composer-tests.ts
@@ -18,7 +18,7 @@ import {MockSlotComposer} from '../runtime/testing/mock-slot-composer.js';
 import {StubLoader} from '../runtime/testing/stub-loader.js';
 import {TestHelper} from '../runtime/testing/test-helper.js';
 import {PlanningTestHelper, StrategyTestHelper} from '../planning/testing/arcs-planning-testing.js';
-import {Id} from '../runtime/id.js';
+import {Id, ArcId} from '../runtime/id.js';
 
 async function initSlotComposer(recipeStr) {
   const slotComposer = new MockSlotComposer().newExpectations();
@@ -28,7 +28,7 @@ async function initSlotComposer(recipeStr) {
     '*': `defineParticle(({Particle}) => { return class P extends Particle {} });`
   });
   const arc = new Arc({
-    id: new Id('test-plan-arc'),
+    id: ArcId.newArcIdForTest('test-plan-arc'),
     context: manifest,
     slotComposer,
     loader


### PR DESCRIPTION
Main goal is to make it harder to accidentally create a bad ID, by hiding the constructor of the Id class. (Previously, the constructor was public, to allow you to easily create IDs in tests by going `new Id('test')`. Now, you can use the helper method `ArcId.newArcIdForTest('test')`.)

Also added some more type safety by adding ArcId as a new subclass of Id. Possibly there will be more later for other top-level IDs (ManifestId maybe?).