### PR TITLE
Make devtools arc selector more selective

### DIFF
--- a/devtools/index.html
+++ b/devtools/index.html
@@ -14,6 +14,7 @@
     <script src="deps/web-animations-js/web-animations-next-lite.min.js"></script>
     <script src="src/standalone-message-passing.js"></script>
     <script src='src/arcs-devtools-app.js' type='module'></script>
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
     <style>
       body {
         margin: 0;

--- a/devtools/src/arcs-environment.js
+++ b/devtools/src/arcs-environment.js
@@ -32,12 +32,6 @@ class ArcsEnvironment extends MessengerMixin(PolymerElement) {
       [content] {
         border-bottom: 1px solid var(--mid-gray);
       }
-      [empty] {
-        text-align: center;
-        font-style: italic;
-        color: var(--mid-gray);
-        white-space: nowrap;
-      }
       object-explorer[find]:not([found-inside]) {
         display: none;
       }
@@ -55,7 +49,7 @@ class ArcsEnvironment extends MessengerMixin(PolymerElement) {
         </object-explorer>
       </template>
       <template is="dom-if" if="{{!recipes.length}}">
-        <div empty>No recipes</div>
+        <div class="empty-label">No recipes</div>
       </template>
     </div>
     <div title>Particles</div>
@@ -66,7 +60,7 @@ class ArcsEnvironment extends MessengerMixin(PolymerElement) {
         </object-explorer>
       </template>
       <template is="dom-if" if="{{!particles.length}}">
-        <div empty>No particles</div>
+        <div class="empty-label">No particles</div>
       </template>
     </div>`;
   }

--- a/devtools/src/arcs-planning.js
+++ b/devtools/src/arcs-planning.js
@@ -33,12 +33,6 @@ class ArcsPlanning extends MessengerMixin(PolymerElement) {
       object-explorer {
         margin: 2px 4px;
       }
-      .empty {
-        text-align: center;
-        font-style: italic;
-        color: var(--mid-gray);
-        white-space: nowrap;
-      }
       .refresh {
         -webkit-mask-position: -165px 0px;
         cursor: pointer;
@@ -119,7 +113,7 @@ class ArcsPlanning extends MessengerMixin(PolymerElement) {
         </object-explorer>
       </template>
       <template is="dom-if" if="{{!lastPlanning.suggestions.length}}">
-        <div class="empty">No suggestions in last planning</div>
+        <div class="empty-label">No suggestions in last planning</div>
       </template>
     </div>
 
@@ -135,7 +129,7 @@ class ArcsPlanning extends MessengerMixin(PolymerElement) {
         </object-explorer>
       </template>
       <template is="dom-if" if="{{!planningSessions.length}}">
-        <div class="empty">No planning sessions</div>
+        <div class="empty-label">No planning sessions</div>
       </template>
     </div>
 

--- a/devtools/src/arcs-shared.js
+++ b/devtools/src/arcs-shared.js
@@ -108,6 +108,36 @@ $_documentContainer.innerHTML = `<dom-module id="shared-styles">
         box-shadow: var(--drop-shadow);
         background-color: white;
       }
+      .material-icons {
+        font-family: 'Material Icons';
+        font-weight: normal;
+        font-style: normal;
+        font-size: 24px;  /* Preferred icon size */
+        display: inline-block;
+        line-height: 1;
+        text-transform: none;
+        letter-spacing: normal;
+        word-wrap: normal;
+        white-space: nowrap;
+        direction: ltr;
+      
+        /* Support for all WebKit browsers. */
+        -webkit-font-smoothing: antialiased;
+        /* Support for Safari and Chrome. */
+        text-rendering: optimizeLegibility;
+      
+        /* Support for Firefox. */
+        -moz-osx-font-smoothing: grayscale;
+      
+        /* Support for IE. */
+        font-feature-settings: 'liga';
+      }
+      .empty-label {
+        text-align: center;
+        font-style: italic;
+        color: var(--mid-gray);
+        white-space: nowrap;
+      }
     </style>
   </template>
 </dom-module>`;

--- a/devtools/src/arcs-stores.js
+++ b/devtools/src/arcs-stores.js
@@ -36,12 +36,6 @@ class ArcsStores extends MessengerMixin(PolymerElement) {
       object-explorer {
         margin: 2px 4px;
       }
-      .empty {
-        text-align: center;
-        font-style: italic;
-        color: var(--mid-gray);
-        white-space: nowrap;
-      }
       [name]:not(:empty) {
         color: var(--devtools-purple);
         margin-right: 1ch;
@@ -79,7 +73,7 @@ class ArcsStores extends MessengerMixin(PolymerElement) {
           </object-explorer>
         </template>
         <template is="dom-if" if="{{!item.items.length}}">
-          <div class="empty">No stores</div>
+          <div class="empty-label">No stores</div>
         </template>
       </div>
     </template>`;

--- a/src/runtime/debug/arc-debug-handler.ts
+++ b/src/runtime/debug/arc-debug-handler.ts
@@ -51,7 +51,8 @@ export class ArcDebugHandler {
       this.arcDevtoolsChannel.send({
         messageType: 'arc-available',
         messageBody: {
-          speculative: arc.isSpeculative
+          speculative: arc.isSpeculative,
+          inner: arc.isInnerArc
         }
       });
 


### PR DESCRIPTION
Primary change:
* Send the `isInner` bit from runtime to devtools to signify inner arcs.
* Add a bit nicer icons for inner and speculative arcs.
* Add the ability to show/hide inner and speculative arcs in devtools.

<img width="377" alt="Screen Shot 2019-04-08 at 4 04 06 PM" src="https://user-images.githubusercontent.com/26159485/55701938-4aabd180-5a18-11e9-88da-76b9bf817339.png">

Extra small thing:
* Move the C&P CSS for the "Empty panel/section" into the shared CSS file.