### PR TITLE
Upgrade to Typescript 3.4, and enable --incremental builds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9484,9 +9484,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.3.tgz",
-      "integrity": "sha512-Y21Xqe54TBVp+VDSNbuDYdGw0BpoR/Q6wo/+35M8PAU0vipahnyduJWirxxdxjsAkS7hue53x2zp8gz7F05u0A=="
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.2.tgz",
+      "integrity": "sha512-Og2Vn6Mk7JAuWA1hQdDQN/Ekm/SchX80VzLhjKN9ETYrIepBFAd8PkOdOTK2nKt0FCkmMZKBJvQ1dV1gIxPu/A=="
     },
     "uglify-js": {
       "version": "2.8.29",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "pouchdb-debug": "^7.0.0",
     "source-map-support": "^0.5.9",
     "sourcemapped-stacktrace": "^1.1.9",
-    "typescript": "^3.3.3",
+    "typescript": "^3.4.2",
     "ws": "^4.1.0"
   },
   "repository": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "outDir": "build",
     "declaration": true,
     "experimentalDecorators": true,
+    "incremental": true,
   },
   "exclude": [
     "build/**/*",


### PR DESCRIPTION
Incremental builds now take 1.8 seconds instead of  6 seconds (for no-op builds, or very small changes).
Clean builds still take 6 seconds.