### PR TITLE
Pipes-shell notifies outer process for supported Autofill types

### DIFF
--- a/shells/pipes-shell/device.js
+++ b/shells/pipes-shell/device.js
@@ -29,13 +29,13 @@ let userContext;
 let testMode;
 let recipeManifest;
 
-export const DeviceApiFactory = async (storage, manifest, deviceClient) => {
+export const ShellApiFactory = async (storage, manifest, deviceClient) => {
   recipeManifest = manifest || defaultManifest;
   client = deviceClient;
   await marshalRecipeContext();
   userContext = new Context(storage);
   await signalClientWhenReady(deviceClient);
-  return deviceApi;
+  return shellApi;
 };
 
 const signalClientWhenReady = async client => {
@@ -53,14 +53,14 @@ const marshalRecipeContext = async () => {
   const manifest = await Utils.parse(recipeManifest);
   recipes = manifest.findRecipesByVerb('autofill');
   const types = recipes.map(recipe => recipe.name.toLowerCase().replace(/_/g, '.'));
-  //log('supported types:', types);
-  log(`> DeviceClient.notifyAutofillTypes('${JSON.stringify(types)}')`);
+  const json = JSON.stringify(types);
+  log(`> DeviceClient.notifyAutofillTypes('${json}')`);
   if (client) {
-    client.notifyAutofillTypes(JSON.stringify(types));
+    client.notifyAutofillTypes(json);
   }
 };
 
-const deviceApi = {
+const shellApi = {
   receiveEntity(json) {
     const id = trackTransactionId(() => receiveJsonEntity(json));
     log(`[${id}]: received entity`, json);

--- a/shells/pipes-shell/device.js
+++ b/shells/pipes-shell/device.js
@@ -39,18 +39,25 @@ export const DeviceApiFactory = async (storage, manifest, deviceClient) => {
 };
 
 const signalClientWhenReady = async client => {
-  // inform client when shell is ready
-  const ready = client && client.shellReady;
-  if (ready) {
-    await userContext.isReady;
-    ready.call(client);
+  // inform client when shell is ready, if possible
+  if (client) {
+    const ready = client.shellReady;
+    if (ready) {
+      await userContext.isReady;
+      ready.call(client);
+    }
   }
 };
 
 const marshalRecipeContext = async () => {
   const manifest = await Utils.parse(recipeManifest);
   recipes = manifest.findRecipesByVerb('autofill');
-  log('supported types:', recipes.map(recipe => recipe.name.toLowerCase().replace(/_/g, '.')));
+  const types = recipes.map(recipe => recipe.name.toLowerCase().replace(/_/g, '.'));
+  //log('supported types:', types);
+  log(`> DeviceClient.notifyAutofillTypes('${JSON.stringify(types)}')`);
+  if (client) {
+    client.notifyAutofillTypes(JSON.stringify(types));
+  }
 };
 
 const deviceApi = {

--- a/shells/pipes-shell/web/web.js
+++ b/shells/pipes-shell/web/web.js
@@ -19,7 +19,7 @@ import '../../lib/firebase-support.js';
 //import '../../../node_modules/sourcemapped-stacktrace/dist/sourcemapped-stacktrace.js';
 
 import {Utils} from '../../lib/utils.js';
-import {DeviceApiFactory} from '../device.js';
+import {ShellApiFactory} from '../device.js';
 import {DevtoolsSupport} from '../../lib/devtools-support.js';
 
 // usage:
@@ -58,6 +58,6 @@ console.log(`${version} -- ${storage}`);
   // configure arcs environment
   Utils.init(paths.root, paths.map);
   // configure ShellApi (window.DeviceClient is bound in by outer process, otherwise undefined)
-  window.ShellApi = await DeviceApiFactory(storage, manifest, window.DeviceClient);
+  window.ShellApi = await ShellApiFactory(storage, manifest, window.DeviceClient);
 })();
 


### PR DESCRIPTION
Example of the invocation internal to pipes-shell:
```
DeviceClient.notifyAutofillTypes('["com.google.android.apps.maps","com.google.android.gm","com.music.spotify"]')
```