### PR TITLE
Factored out a ClientReference subclass

### DIFF
--- a/src/runtime/entity.ts
+++ b/src/runtime/entity.ts
@@ -33,6 +33,7 @@ export interface EntityInterface {
   toLiteral(): EntityRawData;
   toJSON(): EntityRawData;
   dataClone(): EntityRawData;
+  entityClass: EntityClass;
 
   // Used to access dynamic properties, but also may allow access to
   // rawData and other internal state for tests..
@@ -143,12 +144,18 @@ export abstract class Entity implements EntityInterface {
     return clone;
   }
 
+  abstract entityClass: EntityClass;
+
   /** Dynamically constructs a new JS class for the entity type represented by the given schema. */
   static createEntityClass(schema: Schema, context: ParticleExecutionContext): EntityClass {
     // Create a new class which extends the Entity base class, and implement all of the required static methods/properties.
     const clazz = class extends Entity {
       constructor(data: EntityRawData, userIDComponent?: string) {
         super(data, schema, context, userIDComponent);
+      }
+
+      get entityClass(): EntityClass {
+        return clazz;
       }
 
       static get type(): Type {

--- a/src/runtime/loader.ts
+++ b/src/runtime/loader.ts
@@ -17,7 +17,7 @@ import {DomParticle} from './dom-particle.js';
 import {MultiplexerDomParticle} from './multiplexer-dom-particle.js';
 import {ParticleExecutionContext} from './particle-execution-context.js';
 import {Particle} from './particle.js';
-import {Reference} from './reference.js';
+import {ClientReference} from './reference.js';
 import {TransformationDomParticle} from './transformation-dom-particle.js';
 
 const html = (strings, ...values) => (strings[0] + values.map((v, i) => v + strings[i + 1]).join('')).trim();
@@ -119,6 +119,6 @@ export class Loader {
 
   unwrapParticle(particleWrapper) {
     assert(this.pec);
-    return particleWrapper({Particle, DomParticle, TransformationDomParticle, MultiplexerDomParticle, Reference: Reference.newClientReference(this.pec), html});
+    return particleWrapper({Particle, DomParticle, TransformationDomParticle, MultiplexerDomParticle, Reference: ClientReference.newClientReference(this.pec), html});
   }
 }


### PR DESCRIPTION
This gives us a little bit more typing information about ClientReferences (as opposed to regular References). Previously all of this was hidden away in the newClientReference factory method, so Typescript didn't know about any of those properties.