### PR TITLE
Adds a new Storable interface for things stored in Handles

### DIFF
--- a/src/runtime/entity.ts
+++ b/src/runtime/entity.ts
@@ -33,6 +33,7 @@ export interface EntityInterface {
   toLiteral(): EntityRawData;
   toJSON(): EntityRawData;
   dataClone(): EntityRawData;
+  entityClass: EntityClass;
 
   // Used to access dynamic properties, but also may allow access to
   // rawData and other internal state for tests..
@@ -143,12 +144,18 @@ export abstract class Entity implements EntityInterface {
     return clone;
   }
 
+  abstract entityClass: EntityClass;
+
   /** Dynamically constructs a new JS class for the entity type represented by the given schema. */
   static createEntityClass(schema: Schema, context: ParticleExecutionContext): EntityClass {
     // Create a new class which extends the Entity base class, and implement all of the required static methods/properties.
     const clazz = class extends Entity {
       constructor(data: EntityRawData, userIDComponent?: string) {
         super(data, schema, context, userIDComponent);
+      }
+
+      get entityClass(): EntityClass {
+        return clazz;
       }
 
       static get type(): Type {

--- a/src/runtime/entity.ts
+++ b/src/runtime/entity.ts
@@ -14,6 +14,8 @@ import {Type, ReferenceType, EntityType} from './type.js';
 import {ParticleExecutionContext} from './particle-execution-context.js';
 import {Reference} from './reference.js';
 import {TypeChecker} from './recipe/type-checker.js';
+import {Storable} from './handle.js';
+import {SerializedEntity} from './storage-proxy.js';
 
 type EntityIdComponents = {
   base: string,
@@ -25,7 +27,7 @@ export type EntityRawData = {};
 /**
  * Regular interface for Entities.
  */
-export interface EntityInterface {
+export interface EntityInterface extends Storable {
   isIdentified(): boolean;
   id: string;
   identify(identifier: string): void;
@@ -71,7 +73,7 @@ export abstract class Entity implements EntityInterface {
   // TODO(shans): Remove this dependency on ParticleExecutionContext, so that you can construct entities without one.
   protected constructor(data: EntityRawData, schema: Schema, context: ParticleExecutionContext, userIDComponent?: string) {
     assert(!userIDComponent || userIDComponent.indexOf(':') === -1, 'user IDs must not contain the \':\' character');
-    this[Symbols.identifier] = undefined;
+    setEntityId(this, undefined);
     this.userIDComponent = userIDComponent;
     this.schema = schema;
 
@@ -90,18 +92,18 @@ export abstract class Entity implements EntityInterface {
   }
 
   isIdentified(): boolean {
-    return this[Symbols.identifier] !== undefined;
+    return getEntityId(this) !== undefined;
   }
 
   // TODO: entity should not be exposing its IDs.
   get id() {
     assert(!!this.isIdentified());
-    return this[Symbols.identifier];
+    return getEntityId(this);
   }
 
   identify(identifier: string) {
     assert(!this.isIdentified());
-    this[Symbols.identifier] = identifier;
+    setEntityId(this, identifier);
     const components = identifier.split(':');
     if (components[components.length - 2] === 'uid') {
       this.userIDComponent = components[components.length - 1];
@@ -116,7 +118,7 @@ export abstract class Entity implements EntityInterface {
     } else {
       id = `${components.base}:${components.component()}`;
     }
-    this[Symbols.identifier] = id;
+    setEntityId(this, id);
   }
 
   toLiteral(): EntityRawData {
@@ -142,6 +144,12 @@ export abstract class Entity implements EntityInterface {
       }
     }
     return clone;
+  }
+
+  serialize(): SerializedEntity {
+    const id = getEntityId(this);
+    const rawData = this.dataClone();
+    return {id, rawData};
   }
 
   abstract entityClass: EntityClass;
@@ -345,4 +353,24 @@ function createRawDataProxy(schema: Schema) {
       return true;
     }
   });
+}
+
+/**
+ * Returns the ID of the given entity. This is a function private to this file instead of a method on the Entity class, so that developers can't
+ * get access to it.
+ */
+function getEntityId(entity: Entity): string {
+  // Typescript doesn't let us use symbols as indexes, so cast to any first.
+  // tslint:disable-next-line: no-any
+  return entity[Symbols.identifier as any];
+}
+
+/**
+ * Sets the ID of the given entity. This is a function private to this file instead of a method on the Entity class, so that developers can't
+ * get access to it.
+ */
+function setEntityId(entity: Entity, id: string) {
+  // Typescript doesn't let us use symbols as indexes, so cast to any first.
+  // tslint:disable-next-line: no-any
+  entity[Symbols.identifier as any] = id;
 }

--- a/src/runtime/loader.ts
+++ b/src/runtime/loader.ts
@@ -17,7 +17,7 @@ import {DomParticle} from './dom-particle.js';
 import {MultiplexerDomParticle} from './multiplexer-dom-particle.js';
 import {ParticleExecutionContext} from './particle-execution-context.js';
 import {Particle} from './particle.js';
-import {Reference} from './reference.js';
+import {ClientReference} from './reference.js';
 import {TransformationDomParticle} from './transformation-dom-particle.js';
 
 const html = (strings, ...values) => (strings[0] + values.map((v, i) => v + strings[i + 1]).join('')).trim();
@@ -119,6 +119,6 @@ export class Loader {
 
   unwrapParticle(particleWrapper) {
     assert(this.pec);
-    return particleWrapper({Particle, DomParticle, TransformationDomParticle, MultiplexerDomParticle, Reference: Reference.newClientReference(this.pec), html});
+    return particleWrapper({Particle, DomParticle, TransformationDomParticle, MultiplexerDomParticle, Reference: ClientReference.newClientReference(this.pec), html});
   }
 }

--- a/src/runtime/reference.ts
+++ b/src/runtime/reference.ts
@@ -9,18 +9,19 @@
 
 import {assert} from '../platform/assert-web.js';
 
-import {handleFor} from './handle.js';
+import {handleFor, Storable} from './handle.js';
 import {ParticleExecutionContext} from './particle-execution-context.js';
 import {ReferenceType} from './type.js';
 import {Entity} from './entity.js';
+import {SerializedEntity} from './storage-proxy.js';
 
 enum ReferenceMode {Unstored, Stored}
 
-export class Reference {
+export class Reference implements Storable {
   public entity = null;
   public type: ReferenceType;
 
-  private readonly id: string;
+  protected readonly id: string;
   private storageKey: string;
   private readonly context: ParticleExecutionContext;
   private storageProxy = null;
@@ -60,9 +61,16 @@ export class Reference {
   dataClone(): {storageKey: string, id: string} {
     return {storageKey: this.storageKey, id: this.id};
   }
+
+  serialize(): SerializedEntity {
+    return {
+      id: this.id,
+      rawData: this.dataClone(),
+    };
+  }
 }
 
-/** A subclass of Reference that clients can create. Supports storing in handles.  */
+/** A subclass of Reference that clients can create. */
 export abstract class ClientReference extends Reference {
   private mode = ReferenceMode.Unstored;
   public stored: Promise<undefined>;

--- a/src/runtime/storage-proxy.ts
+++ b/src/runtime/storage-proxy.ts
@@ -18,8 +18,11 @@ import {ParticleExecutionContext} from './particle-execution-context.js';
 import {Particle} from './particle.js';
 import {CrdtCollectionModel, SerializedModelEntry} from './storage/crdt-collection-model.js';
 import {BigCollectionType, CollectionType, Type} from './type.js';
+import {EntityRawData} from './entity.js';
 
 enum SyncState {none, pending, full}
+
+export type SerializedEntity = {id: string, rawData: EntityRawData};
 
 /**
  * Mediates between one or more Handles and the backing store outside the PEC.

--- a/src/runtime/test/storage-proxy-test.ts
+++ b/src/runtime/test/storage-proxy-test.ts
@@ -11,12 +11,13 @@
 
 import {assert} from '../../platform/chai-web.js';
 import {handleFor, Handle, Variable, Collection} from '../handle.js';
-import {Id, ArcId} from '../id.js';
+import {ArcId} from '../id.js';
 import {Schema} from '../schema.js';
 import {StorageProxy, StorageProxyScheduler, CollectionProxy, BigCollectionProxy, VariableProxy} from '../storage-proxy.js';
 import {CrdtCollectionModel} from '../storage/crdt-collection-model.js';
 import {VolatileStorage} from '../storage/volatile-storage.js';
 import {EntityType} from '../type.js';
+import {EntityInterface} from '../entity.js';
 
 const CAN_READ = true;
 const CAN_WRITE = true;
@@ -226,7 +227,7 @@ class TestEngine {
     return handleFor(proxy, store.name, particle.id, canRead, canWrite);
   }
 
-  newEntity(value) {
+  newEntity(value): EntityInterface {
     const entity = new (this.schema.entityClass())({value});
     entity.identify('E' + this._idCounters[2]++);
     return entity;


### PR DESCRIPTION
Storable represents both Entities and References, since both can be stored in Handles. Adds some type safety to these Handle methods (previously things were working on References mostly by accident).

NB: this PR is branched off https://github.com/PolymerLabs/arcs/pull/2869 -- will submit that first.