### PR TITLE
 Activate strictBindCallApply and strictFunctionTypes compiler rules

### DIFF
--- a/config/tsconfig.base.json
+++ b/config/tsconfig.base.json
@@ -11,6 +11,8 @@
     "noImplicitThis": true,
     "module": "es2015",
     "moduleResolution": "Node",
+    "strictBindCallApply": true,
+    "strictFunctionTypes": true,
 
     "allowJs": false,
     "sourceMap": true,

--- a/src/runtime/arc-exceptions.ts
+++ b/src/runtime/arc-exceptions.ts
@@ -10,7 +10,7 @@ import {Particle} from './particle';
  * http://polymer.github.io/PATENTS.txt
  */
 
-type SerializedPropagatedException = {
+export type SerializedPropagatedException = {
   exceptionType: string,
   cause: {name: string, message: string, stack: string},  // Serialized Error.
   method: string,

--- a/src/runtime/particle-execution-host.ts
+++ b/src/runtime/particle-execution-host.ts
@@ -21,6 +21,18 @@ import {SlotComposer} from './slot-composer.js';
 import {StorageProviderBase} from './storage/storage-provider-base.js';
 import {Type} from './type.js';
 
+export type StartRenderOptions = {
+  particle: Particle;
+  slotName: string;
+  providedSlots: Map<string, string>;
+  contentTypes: string[];
+};
+
+export type StopRenderOptions = {
+  particle: Particle;
+  slotName: string;
+};
+
 export class ParticleExecutionHost {
   private _apiPort : PECOuterPort;
   close : () => void;
@@ -281,11 +293,11 @@ export class ParticleExecutionHost {
     this._apiPort.InstantiateParticle(particle, particle.id.toString(), particle.spec, stores);
   }
 
-  startRender({particle, slotName, providedSlots, contentTypes}: {particle: Particle, slotName: string, providedSlots: {[index: string]: string}, contentTypes: string[]}) {
+  startRender({particle, slotName, providedSlots, contentTypes}: StartRenderOptions): void {
     this._apiPort.StartRender(particle, slotName, providedSlots, contentTypes);
   }
 
-  stopRender({particle, slotName}: {particle: Particle, slotName: string}) {
+  stopRender({particle, slotName}: StopRenderOptions): void {
     this._apiPort.StopRender(particle, slotName);
   }
 

--- a/src/runtime/particle-spec.ts
+++ b/src/runtime/particle-spec.ts
@@ -144,7 +144,7 @@ export class ProvideSlotConnectionSpec {
   }
 }
 
-type SerializedParticleSpec = {
+export type SerializedParticleSpec = {
   name: string,
   id?: string,
   verbs: string[],

--- a/src/runtime/slot-consumer.ts
+++ b/src/runtime/slot-consumer.ts
@@ -12,8 +12,10 @@ import {assert} from '../platform/assert-web.js';
 
 import {Arc} from './arc.js';
 import {Description} from './description.js';
+import {Particle} from './recipe/particle.js';
 import {SlotConnection} from './recipe/slot-connection.js';
 import {HostedSlotContext, ProvidedSlotContext, SlotContext} from './slot-context.js';
+import {StartRenderOptions, StopRenderOptions} from './particle-execution-host.js';
 
 export interface Content {
   templateName?: string | Map<string, string>;
@@ -41,8 +43,8 @@ export class SlotConsumer {
   slotContext: SlotContext;
   readonly directlyProvidedSlotContexts: ProvidedSlotContext[] = [];
   readonly hostedSlotContexts: HostedSlotContext[] = [];
-  startRenderCallback: ({}) => void;
-  stopRenderCallback: ({}) => void;
+  startRenderCallback: (options: StartRenderOptions) => void;
+  stopRenderCallback: (options: StopRenderOptions) => void;
   eventHandler: ({}) => void;
   readonly containerKind?: string;
   // Contains `container` and other modality specific rendering information
@@ -149,10 +151,12 @@ export class SlotConsumer {
 
   startRender() {
     if (this.consumeConn && this.startRenderCallback) {
+      const providedSlots = new Map(this.allProvidedSlotContexts.map(context => ([context.name, context.id] as [string, string])));
+
       this.startRenderCallback({
         particle: this.consumeConn.particle,
         slotName: this.consumeConn.name,
-        providedSlots: new Map(this.allProvidedSlotContexts.map(context => ([context.name, context.id] as [string, string]))),
+        providedSlots,
         contentTypes: this.constructRenderRequest()
       });
     }

--- a/src/runtime/storage/firebase/firebase-storage.ts
+++ b/src/runtime/storage/firebase/firebase-storage.ts
@@ -374,7 +374,7 @@ class FirebaseVariable extends FirebaseStorageProvider implements VariableStorag
   private pendingWrites: {storageKey: string, value: {}}[] = [];
   wasConnect: boolean; // for debugging
   private resolveInitialized: () => void;
-  private readonly valueChangeCallback: ({}) => void;
+  private readonly valueChangeCallback: (dataSnapshot: firebase.database.DataSnapshot, s?: string) => void;
 
   constructor(type, storageEngine, id, reference, firebaseKey, shouldExist) {
     super(type, storageEngine, id, reference, firebaseKey);
@@ -651,7 +651,7 @@ class FirebaseCollection extends FirebaseStorageProvider implements CollectionSt
   private pendingWrites: {value: {}, storageKey: string}[] = [];
   private resolveInitialized: () => void;
   private localKeyId = Date.now();
-  private readonly valueChangeCallback: ({}) => void;
+  private readonly valueChangeCallback: (dataSnapshot: firebase.database.DataSnapshot, s?: string) => void;
 
   constructor(type, storageEngine, id, reference, firebaseKey) {
     super(type, storageEngine, id, reference, firebaseKey);


### PR DESCRIPTION
- Improves types in api-channel and slot-consumer
- Introduce option types for startRender and stopRender
- Fix mismatched Map/object types in providedSlots
- Use specific types in Literalizer
