### PR TITLE
sigh: don't use shell:true when bootstrapping sigh

### DIFF
--- a/tools/bootstrap.js
+++ b/tools/bootstrap.js
@@ -10,7 +10,7 @@ const path = require('path');
 const child_process = require('child_process');
 
 function spawn(cmd, ...args) {
-  const res = child_process.spawnSync(path.normalize(cmd), args, {shell: true,  stdio: 'inherit'});
+  const res = child_process.spawnSync(path.normalize(cmd), args, {stdio: 'inherit'});
   return res.status === 0 && !res.error;
 }
 


### PR DESCRIPTION
This causes arguments with spaces to be tokenized: `sigh test -g 'foo bar'` ends up as `'test', '-g', 'foo', 'bar'`.