### PR TITLE
Adds oldData property to Variable change events.

### DIFF
--- a/src/runtime/handle.ts
+++ b/src/runtime/handle.ts
@@ -257,7 +257,9 @@ export class Variable extends Handle {
         return;
       case 'update': {
         try {
-          await particle.onHandleUpdate(this, {data: this._restore(details.data)});
+          const data = this._restore(details.data);
+          const oldData = this._restore(details.oldData);
+          await particle.onHandleUpdate(this, {data, oldData});
         } catch (e) {
           this.reportUserExceptionInHost(e, particle, 'onHandleUpdate');
         }
@@ -290,7 +292,7 @@ export class Variable extends Handle {
   }
 
   _restore(model) {
-    if (model === null) {
+    if (model == null) {
       return null;
     }
     if (this.type instanceof EntityType) {

--- a/src/runtime/particle.ts
+++ b/src/runtime/particle.ts
@@ -81,11 +81,12 @@ export class Particle {
    * @param handle The Handle instance that was updated.
    * @param update An object containing one of the following fields:
    *  - data: The full Entity for a Variable-backed Handle.
+   *  - oldData: The previous value of a Variable before it was updated.
    *  - added: An Array of Entities added to a Collection-backed Handle.
    *  - removed: An Array of Entities removed from a Collection-backed Handle.
    */
   // tslint:disable-next-line: no-any
-  onHandleUpdate(handle: Handle, update: {data?: any, added?: any, removed?: any, originator?: any}) {
+  onHandleUpdate(handle: Handle, update: {data?: any, oldData?: any, added?: any, removed?: any, originator?: any}) {
   }
 
   /**

--- a/src/runtime/test/particle-api-test.ts
+++ b/src/runtime/test/particle-api-test.ts
@@ -93,12 +93,17 @@ describe('particle-api', () => {
     await fooStore.set({id: 'id2', rawData: {value: 'v2'}});
     fooStore._fire = fireFn;
     await fooStore.set({id: 'id3', rawData: {value: 'v3'}});
-    await inspector.verify('update:{"data":{"value":"v1"}}',
+    await inspector.verify('update:{"data":{"value":"v1"},"oldData":null}',
                            'desync',
                            'sync:{"value":"v3"}');
 
+    // Check it includes the previous value (v3) in updates.
+    await fooStore.set({id: 'id4', rawData: {value: 'v4'}});
+    await inspector.verify('update:{"data":{"value":"v4"},"oldData":{"value":"v3"}}');
+
+    // Check clearing the store.
     await fooStore.clear();
-    await inspector.verify('update:{"data":null}');
+    await inspector.verify('update:{"data":null,"oldData":{"value":"v4"}}');
   });
 
   it('can sync/update and store/remove with collections', async () => {

--- a/src/runtime/test/storage-proxy-test.ts
+++ b/src/runtime/test/storage-proxy-test.ts
@@ -18,6 +18,7 @@ import {CrdtCollectionModel} from '../storage/crdt-collection-model.js';
 import {VolatileStorage} from '../storage/volatile-storage.js';
 import {EntityType} from '../type.js';
 import {EntityInterface} from '../entity.js';
+import {Particle} from '../particle.js';
 
 const CAN_READ = true;
 const CAN_WRITE = true;
@@ -153,6 +154,9 @@ class TestParticle {
     if ('data' in update) {
       details += this._toString(update.data);
     }
+    if ('oldData' in update && update.oldData !== null) {
+      details += `:(was:${this._toString(update.oldData)})`;
+    }
     if ('added' in update) {
       details += '+' + this._toString(update.added);
     }
@@ -208,8 +212,8 @@ class TestEngine {
     return store;
   }
 
-  newParticle() {
-    return new TestParticle('P' + this._idCounters[0]++, x => this._events.push(x));
+  newParticle(): Particle {
+    return new TestParticle('P' + this._idCounters[0]++, x => this._events.push(x)) as unknown as Particle;
   }
 
   newProxy(store): CollectionProxy | BigCollectionProxy | VariableProxy {
@@ -390,7 +394,7 @@ describe('storage-proxy', () => {
 
     fooStore.clear();
     barStore.remove('i1');
-    await engine.verify('onHandleUpdate:P1:foo:(null)', 'onHandleUpdate:P1:bar:-[hai]');
+    await engine.verify('onHandleUpdate:P1:foo:(null):(was:oh)', 'onHandleUpdate:P1:bar:-[hai]');
   });
 
   it('notifies for updates to initially populated handles', async () => {
@@ -417,11 +421,11 @@ describe('storage-proxy', () => {
 
     fooStore.set(engine.newEntity('gday'));
     barStore.store('i3', engine.newEntity('mate'));
-    await engine.verify('onHandleUpdate:P1:foo:gday', 'onHandleUpdate:P1:bar:+[mate]');
+    await engine.verify('onHandleUpdate:P1:foo:gday:(was:well)', 'onHandleUpdate:P1:bar:+[mate]');
 
     fooStore.clear();
     barStore.remove('i2');
-    await engine.verify('onHandleUpdate:P1:foo:(null)', 'onHandleUpdate:P1:bar:-[there]');
+    await engine.verify('onHandleUpdate:P1:foo:(null):(was:gday)', 'onHandleUpdate:P1:bar:-[there]');
   });
 
   it('handles dropped updates on a Variable with immediate resync', async () => {
@@ -707,7 +711,7 @@ describe('storage-proxy', () => {
     // Write to handle modifies the model directly, dispatches update and store write.
     const changed = engine.newEntity('changed');
     fooHandle.set(changed);
-    await engine.verifySubsequence('onHandleUpdate:P1:foo:changed');
+    await engine.verifySubsequence('onHandleUpdate:P1:foo:changed:(was:start)');
     await engine.verify('HandleSet:foo:changed');
 
     // Read the handle again; the read should still be able to complete locally.
@@ -725,7 +729,7 @@ describe('storage-proxy', () => {
 
     // Subsequent updates should be visible in the handle.
     fooStore.set(engine.newEntity('subsequent'));
-    await engine.verify('onHandleUpdate:P1:foo:subsequent');
+    await engine.verify('onHandleUpdate:P1:foo:subsequent:(was:changed)');
   });
 
   it('multiple particles observing one proxy', async () => {
@@ -783,7 +787,7 @@ describe('storage-proxy', () => {
                         'onHandleSync:P1:foo:Huey', 'onHandleSync:P2:foo:Huey');
 
     fooStore.set(engine.newEntity('Dewey'));
-    await engine.verify('onHandleUpdate:P1:foo:Dewey', 'onHandleUpdate:P2:foo:Dewey');
+    await engine.verify('onHandleUpdate:P1:foo:Dewey:(was:Huey)', 'onHandleUpdate:P2:foo:Dewey:(was:Huey)');
 
     const particle3 = engine.newParticle();
     const fooHandle3 = engine.newHandle(fooStore, fooProxy, particle3, CAN_READ, CAN_WRITE);
@@ -791,8 +795,8 @@ describe('storage-proxy', () => {
     await engine.verify('onHandleSync:P3:foo:Dewey');
 
     fooStore.set(engine.newEntity('Louie'));
-    await engine.verify('onHandleUpdate:P1:foo:Louie', 'onHandleUpdate:P2:foo:Louie',
-                        'onHandleUpdate:P3:foo:Louie');
+    await engine.verify('onHandleUpdate:P1:foo:Louie:(was:Dewey)', 'onHandleUpdate:P2:foo:Louie:(was:Dewey)',
+                        'onHandleUpdate:P3:foo:Louie:(was:Dewey)');
   });
 
   it('multiple particles with different handle configurations', async () => {


### PR DESCRIPTION
Now Variable update events come with two lots of entity data: `{data, oldData}`. `oldData` tells you what was inside the Variable before it got replaced (or null, if there was nothing there).

This allows you to figure out when entities get "deleted" -- see #2877.