### PR TITLE
Optimize Description Calculation

### DIFF
--- a/src/runtime/description-formatter.ts
+++ b/src/runtime/description-formatter.ts
@@ -397,7 +397,7 @@ export class DescriptionFormatter {
     }
   }
 
-  _formatDescription(handleConnection): string {
+  _formatDescription(handleConnection) {
     return this._formatDescriptionPattern(handleConnection) ||
            this._formatStoreDescription(handleConnection) ||
            this._formatHandleType(handleConnection);

--- a/src/runtime/description-formatter.ts
+++ b/src/runtime/description-formatter.ts
@@ -22,6 +22,7 @@ export type ParticleDescription = {
   _connections: {[index: string]: HandleDescription},
   _rank?: number
 };
+
 export type HandleDescription = {pattern: string, _handleConn: HandleConnection, value: DescriptionValue};
 export type DescriptionValue = {entityValue?: string|{}, valueDescription?: string, collectionValues?: string[], bigCollectionValues?: string[], interfaceValue?: string | {}};
 
@@ -396,13 +397,13 @@ export class DescriptionFormatter {
     }
   }
 
-  _formatDescription(handleConnection) {
+  _formatDescription(handleConnection): string {
     return this._formatDescriptionPattern(handleConnection) ||
            this._formatStoreDescription(handleConnection) ||
            this._formatHandleType(handleConnection);
   }
 
-  _formatDescriptionPattern(handleConnection) {
+  _formatDescriptionPattern(handleConnection): string|undefined {
     let chosenConnection = handleConnection;
 
     // For "out" connection, use its own description
@@ -436,7 +437,7 @@ export class DescriptionFormatter {
     }
     return undefined;
   }
-  _formatHandleType(handleConnection) {
+  _formatHandleType(handleConnection): string {
     const type = handleConnection.handle && handleConnection.handle.type.isResolved() ? handleConnection.handle.type : handleConnection.type;
     return type.toPrettyString().toLowerCase();
   }

--- a/src/runtime/slot-composer.ts
+++ b/src/runtime/slot-composer.ts
@@ -161,7 +161,7 @@ export class SlotComposer {
 
     // ... and apply to each consumer
     for (const consumer of this.consumers) {
-      consumer.setDescription(consumerByArc.get(consumer.arc));
+      consumer.description = consumerByArc.get(consumer.arc);
     }
   }
 

--- a/src/runtime/slot-composer.ts
+++ b/src/runtime/slot-composer.ts
@@ -11,6 +11,7 @@
 import {assert} from '../platform/assert-web.js';
 
 import {Arc} from './arc.js';
+import {Description} from './description.js';
 import {ModalityHandler} from './modality-handler.js';
 import {Modality} from './modality.js';
 import {Particle} from './recipe/particle.js';
@@ -110,7 +111,7 @@ export class SlotComposer {
     const transformationSlotConsumer = this.getSlotConsumer(transformationParticle, transformationSlotName);
     assert(transformationSlotConsumer,
         `Transformation particle ${transformationParticle.name} with consumed ${transformationSlotName} not found`);
-    
+
     const hostedSlotId = innerArc.generateID().toString();
     this._contexts.push(new HostedSlotContext(hostedSlotId, transformationSlotConsumer, storeId));
     return hostedSlotId;
@@ -148,7 +149,20 @@ export class SlotComposer {
       context.addSlotConsumer(consumer);
     });
 
-    await Promise.all(this.consumers.map(async consumer => await consumer.resetDescription()));
+    // Calculate the Descriptions only once per-Arc
+    const allArcs = this.consumers.map(consumer => consumer.arc);
+    const uniqueArcs = [...new Set(allArcs).values()];
+
+    // get arc -> description
+    const descriptions = await Promise.all(uniqueArcs.map(arc => Description.create(arc)));
+
+    // create a mapping from the zipped uniqueArcs and descriptions
+    const consumerByArc = new Map(descriptions.map((description, index) => [uniqueArcs[index], description]));
+
+    // ... and apply to each consumer
+    for (const consumer of this.consumers) {
+      consumer.setDescription(consumerByArc.get(consumer.arc));
+    }
   }
 
   renderSlot(particle: Particle, slotName: string, content) {
@@ -180,7 +194,7 @@ export class SlotComposer {
                     hostedConsumer.consumeConn.particle,
                     hostedConsumer.consumeConn.name,
                     eventlet);
-              }    
+              }
             });
           }
         }

--- a/src/runtime/slot-consumer.ts
+++ b/src/runtime/slot-consumer.ts
@@ -52,20 +52,12 @@ export class SlotConsumer {
   private _renderingBySubId: Map<string|undefined, Rendering> = new Map();
   private innerContainerBySlotId: {} = {};
   public readonly arc: Arc;
-  private _description: Description;
+  public description: Description;
 
   constructor(arc: Arc, consumeConn?: SlotConnection, containerKind?: string) {
     this.arc = arc;
     this.consumeConn = consumeConn;
     this.containerKind = containerKind;
-  }
-
-  async resetDescription() {
-    this._description = await Description.create(this.arc);
-  }
-
-  setDescription(description: Description) {
-    this._description = description;
   }
 
   getRendering(subId?): Rendering { return this._renderingBySubId.get(subId); }
@@ -172,8 +164,8 @@ export class SlotConsumer {
   }
 
   setContent(content: Content, handler) {
-    if (content && Object.keys(content).length > 0 && this._description) {
-      content.descriptions = this.populateHandleDescriptions();
+    if (content && Object.keys(content).length > 0 && this.description) {
+      content.descriptions = this._populateHandleDescriptions();
     }
     this.eventHandler = handler;
     for (const [subId, rendering] of this.renderings) {
@@ -181,13 +173,13 @@ export class SlotConsumer {
     }
   }
 
-  private populateHandleDescriptions(): Map<string, Description> {
+  private _populateHandleDescriptions(): Map<string, Description> {
     if (!this.consumeConn) return null; // TODO: remove null ability
     const descriptions: Map<string, Description> = new Map();
     Object.values(this.consumeConn.particle.connections).map(handleConn => {
       if (handleConn.handle) {
         descriptions[`${handleConn.name}.description`] =
-            this._description.getHandleDescription(handleConn.handle).toString();
+            this.description.getHandleDescription(handleConn.handle).toString();
       }
     });
     return descriptions;

--- a/src/runtime/slot-consumer.ts
+++ b/src/runtime/slot-consumer.ts
@@ -60,9 +60,12 @@ export class SlotConsumer {
     this.containerKind = containerKind;
   }
 
-  get description() { return this._description; }
   async resetDescription() {
     this._description = await Description.create(this.arc);
+  }
+
+  setDescription(description: Description) {
+    this._description = description;
   }
 
   getRendering(subId?): Rendering { return this._renderingBySubId.get(subId); }
@@ -169,7 +172,7 @@ export class SlotConsumer {
   }
 
   setContent(content: Content, handler) {
-    if (content && Object.keys(content).length > 0 && this.description) {
+    if (content && Object.keys(content).length > 0 && this._description) {
       content.descriptions = this.populateHandleDescriptions();
     }
     this.eventHandler = handler;
@@ -178,13 +181,13 @@ export class SlotConsumer {
     }
   }
 
-  populateHandleDescriptions(): Map<string, Description> {
+  private populateHandleDescriptions(): Map<string, Description> {
     if (!this.consumeConn) return null; // TODO: remove null ability
     const descriptions: Map<string, Description> = new Map();
     Object.values(this.consumeConn.particle.connections).map(handleConn => {
       if (handleConn.handle) {
         descriptions[`${handleConn.name}.description`] =
-            this.description.getHandleDescription(handleConn.handle).toString();
+            this._description.getHandleDescription(handleConn.handle).toString();
       }
     });
     return descriptions;


### PR DESCRIPTION
- In Slot Composer only calculate the Descriptions once per Arc.  This reduces storage calls by about 10x on the restaurant list.
- Add many more Typescript types.
- Refactor Description
  - add private
  - remove this usage for static methods
  - move non-async init code to constructor.
  - readability and docs.