### PR TITLE
Added an IdGenerator to Handle.

### DIFF
--- a/src/runtime/entity.ts
+++ b/src/runtime/entity.ts
@@ -16,11 +16,7 @@ import {Reference} from './reference.js';
 import {TypeChecker} from './recipe/type-checker.js';
 import {Storable} from './handle.js';
 import {SerializedEntity} from './storage-proxy.js';
-
-export type EntityIdComponents = {
-  base: string,
-  component: () => number,
-};
+import {Id, IdGenerator} from './id.js';
 
 export type EntityRawData = {};
 
@@ -30,7 +26,7 @@ export type EntityRawData = {};
 export interface EntityInterface extends Storable {
   isIdentified(): boolean;
   identify(identifier: string): void;
-  createIdentity(components: EntityIdComponents): void;
+  createIdentity(parentId: Id, idGenerator: IdGenerator): void;
   toLiteral(): EntityRawData;
   toJSON(): EntityRawData;
   dataClone(): EntityRawData;
@@ -159,13 +155,14 @@ export abstract class Entity implements EntityInterface {
     }
   }
 
-  createIdentity(components: EntityIdComponents) {
+  createIdentity(parentId: Id, idGenerator: IdGenerator) {
     assert(!this.isIdentified());
     let id: string;
     if (this.userIDComponent) {
-      id = `${components.base}:uid:${this.userIDComponent}`;
+      // TODO: Stop creating IDs by manually concatenating strings.
+      id = `${parentId.toString()}:uid:${this.userIDComponent}`;
     } else {
-      id = `${components.base}:${components.component()}`;
+      id = idGenerator.newChildId(parentId).toString();
     }
     setEntityId(this, id);
   }

--- a/src/runtime/particle-execution-context.ts
+++ b/src/runtime/particle-execution-context.ts
@@ -34,12 +34,13 @@ export class ParticleExecutionContext {
   private apiPort : PECInnerPort;
   private particles = <Particle[]>[];
   private readonly pecId: Id;
-  private readonly idGenerator: IdGenerator;
   private loader: Loader;
   private pendingLoads = <Promise<void>[]>[]; 
   private scheduler: StorageProxyScheduler = new StorageProxyScheduler();
   private keyedProxies: { [index: string]: StorageProxy | Promise<StorageProxy>} = {};
-
+  
+  readonly idGenerator: IdGenerator;
+  
   constructor(port, pecId: Id, idGenerator: IdGenerator, loader: Loader) {
     const pec = this;
 
@@ -140,7 +141,7 @@ export class ParticleExecutionContext {
       createHandle(type: Type, name: string, hostParticle?: Particle) {
         return new Promise((resolve, reject) =>
           pec.apiPort.ArcCreateHandle(proxy => {
-            const handle = handleFor(proxy, name, particleId);
+            const handle = handleFor(proxy, pec.idGenerator, name, particleId);
             resolve(handle);
             if (hostParticle) {
               proxy.register(hostParticle, handle);
@@ -209,7 +210,7 @@ export class ParticleExecutionContext {
     const registerList = [];
     proxies.forEach((proxy, name) => {
       const connSpec = spec.handleConnectionMap.get(name);
-      const handle = handleFor(proxy, name, id, connSpec.isInput, connSpec.isOutput);
+      const handle = handleFor(proxy, this.idGenerator, name, id, connSpec.isInput, connSpec.isOutput);
       handleMap.set(name, handle);
 
       // Defer registration of handles with proxies until after particles have a chance to

--- a/src/runtime/reference.ts
+++ b/src/runtime/reference.ts
@@ -36,7 +36,7 @@ export class Reference implements Storable {
   protected async ensureStorageProxy(): Promise<void> {
     if (this.storageProxy == null) {
       this.storageProxy = await this.context.getStorageProxy(this.storageKey, this.type.referredType);
-      this.handle = handleFor(this.storageProxy);
+      this.handle = handleFor(this.storageProxy, this.context.idGenerator);
       if (this.storageKey) {
         assert(this.storageKey === this.storageProxy.storageKey);
       } else {

--- a/src/runtime/storage-proxy.ts
+++ b/src/runtime/storage-proxy.ts
@@ -247,10 +247,6 @@ export abstract class StorageProxy implements Store {
   generateID() {
     return `${this.baseForNewID}:${this.localIDComponent++}`;
   }
-
-  generateIDComponents() {
-    return {base: this.baseForNewID, component: () => this.localIDComponent++};
-  }
 }
 
 /**

--- a/src/runtime/storage/storage-provider-base.ts
+++ b/src/runtime/storage/storage-provider-base.ts
@@ -146,10 +146,6 @@ export abstract class StorageProviderBase implements Comparable<StorageProviderB
     return `${this.id}:${this.nextLocalID++}`;
   }
 
-  generateIDComponents() {
-    return {base: this.id, component: () => this.nextLocalID++};
-  }
-
   get type(): Type {
     return this._type;
   }

--- a/src/runtime/store.ts
+++ b/src/runtime/store.ts
@@ -1,6 +1,5 @@
 import {PropagatedException} from "./arc-exceptions";
 import {Type} from "./type";
-import {EntityIdComponents} from "./entity";
 import {ParticleExecutionContext} from "./particle-execution-context";
 
 /**
@@ -17,7 +16,6 @@ export interface Store {
 
   reportExceptionInHost(exception: PropagatedException): void;
   generateID(): string;
-  generateIDComponents(): EntityIdComponents;
 }
 
 export interface VariableStore extends Store {

--- a/src/runtime/test/arc-tests.ts
+++ b/src/runtime/test/arc-tests.ts
@@ -14,7 +14,7 @@ import {assert} from '../../platform/chai-web.js';
 import {Arc} from '../arc.js';
 import {handleFor, Variable} from '../handle.js';
 import {HeadlessSlotDomConsumer} from '../headless-slot-dom-consumer.js';
-import {Id, ArcId} from '../id.js';
+import {Id, ArcId, IdGenerator} from '../id.js';
 import {Loader} from '../loader.js';
 import {Manifest} from '../manifest.js';
 import {BigCollectionStorageProvider, CollectionStorageProvider, VariableStorageProvider, StorageProviderBase} from '../storage/storage-provider-base.js';
@@ -89,7 +89,7 @@ async function setupSlandlesWithOptional(cProvided, dProvided) {
 }
 
 function getVariableHandle(store: StorageProviderBase): Variable {
-  return handleFor(store) as Variable;
+  return handleFor(store, IdGenerator.newSession()) as Variable;
 }
 
 describe('Arc', () => {

--- a/src/runtime/test/data-layer-test.ts
+++ b/src/runtime/test/data-layer-test.ts
@@ -10,13 +10,13 @@
 
 import {assert} from '../../platform/chai-web.js';
 import {Arc} from '../arc.js';
-import {handleFor, Variable, Collection} from '../handle.js';
+import {handleFor, Collection} from '../handle.js';
 import {Loader} from '../loader.js';
 import {Schema} from '../schema.js';
 import {CollectionStorageProvider} from '../storage/storage-provider-base.js';
 import {FakeSlotComposer} from '../testing/fake-slot-composer.js';
 import {EntityType} from '../type.js';
-import {Id, ArcId} from '../id.js';
+import {ArcId, IdGenerator} from '../id.js';
 
 describe('entity', async () => {
   it('can be created, stored, and restored', async () => {
@@ -29,7 +29,7 @@ describe('entity', async () => {
     const collectionType = new EntityType(schema).collectionOf();
     
     const storage = await arc.createStore(collectionType);
-    const handle = handleFor(storage) as Collection;
+    const handle = handleFor(storage, IdGenerator.newSession()) as Collection;
     await handle.store(entity);
 
     const collection = arc.findStoresByType(collectionType)[0] as CollectionStorageProvider;

--- a/src/runtime/test/description-test.ts
+++ b/src/runtime/test/description-test.ts
@@ -20,7 +20,7 @@ import {Relevance} from '../relevance.js';
 import {CollectionStorageProvider, VariableStorageProvider} from '../storage/storage-provider-base.js';
 import {FakeSlotComposer} from '../testing/fake-slot-composer.js';
 import {EntityType} from '../type.js';
-import {Id, ArcId} from '../id.js';
+import {Id, ArcId, IdGenerator} from '../id.js';
 
 function createTestArc(recipe: Recipe, manifest: Manifest) {
   const slotComposer = new FakeSlotComposer();
@@ -789,7 +789,7 @@ recipe
       recipe,
       fooStore,
       DescriptionType: (descriptionStore.type.getContainedType() as EntityType).entitySchema.entityClass(),
-      descriptionHandle: handleFor(descriptionStore) as Collection,
+      descriptionHandle: handleFor(descriptionStore, IdGenerator.newSession()) as Collection,
     };
   }
 

--- a/src/runtime/test/handle-test.ts
+++ b/src/runtime/test/handle-test.ts
@@ -19,7 +19,7 @@ import {CollectionStorageProvider, VariableStorageProvider} from '../storage/sto
 import {FakeSlotComposer} from '../testing/fake-slot-composer.js';
 import {assertThrowsAsync} from '../testing/test-util.js';
 import {EntityType, InterfaceType} from '../type.js';
-import {Id, ArcId} from '../id.js';
+import {Id, ArcId, IdGenerator} from '../id.js';
 
 describe('Handle', () => {
   // Avoid initialising non-POD variables globally, since they would be constructed even when
@@ -83,7 +83,7 @@ describe('Handle', () => {
 
     // tslint:disable-next-line: variable-name
     const Foo = manifest.schemas.Foo.entityClass();
-    const fooHandle = handleFor(await arc.createStore(Foo.type.collectionOf())) as Collection;
+    const fooHandle = handleFor(await arc.createStore(Foo.type.collectionOf()), IdGenerator.newSession()) as Collection;
 
     await fooHandle.store(new Foo({value: 'a Foo'}, 'first'));
     await fooHandle.store(new Foo({value: 'another Foo'}, 'second'));
@@ -97,7 +97,7 @@ describe('Handle', () => {
 
     // tslint:disable-next-line: variable-name
     const Foo = manifest.schemas.Foo.entityClass();
-    const fooHandle = handleFor(await arc.createStore(Foo.type.collectionOf())) as Collection;
+    const fooHandle = handleFor(await arc.createStore(Foo.type.collectionOf()), IdGenerator.newSession()) as Collection;
 
     await fooHandle.store(new Foo({value: '1'}, 'id1'));
     await fooHandle.store(new Foo({value: '2'}, 'id1'));
@@ -111,7 +111,7 @@ describe('Handle', () => {
     // tslint:disable-next-line: variable-name
     const Foo = manifest.schemas.Foo.entityClass();
 
-    const fooHandle = handleFor(await arc.createStore(Foo.type)) as Variable;
+    const fooHandle = handleFor(await arc.createStore(Foo.type), IdGenerator.newSession()) as Variable;
 
     await fooHandle.set(new Foo({value: '1'}, 'id1'));
     await fooHandle.set(new Foo({value: '2'}, 'id1'));

--- a/src/runtime/test/runtime-manifest-integration-test.ts
+++ b/src/runtime/test/runtime-manifest-integration-test.ts
@@ -9,13 +9,9 @@
  */
 
 import {assert} from '../../platform/chai-web.js';
-import {Arc} from '../arc.js';
 import {handleFor, Variable} from '../handle.js';
-import {Loader} from '../loader.js';
-import {Manifest} from '../manifest.js';
-import {StorageProxy} from '../storage-proxy.js';
 import {manifestTestSetup} from '../testing/manifest-integration-test-setup.js';
-
+import {IdGenerator} from '../id.js';
 
 describe('runtime manifest integration', () => {
   it('can produce a recipe that can be instantiated in an arc', async () => {
@@ -25,7 +21,7 @@ describe('runtime manifest integration', () => {
     const type = recipe.handles[0].type;
     const [store] = arc.findStoresByType(type);
 
-    const handle = handleFor(store) as Variable;
+    const handle = handleFor(store, IdGenerator.newSession()) as Variable;
     // TODO: This should not be necessary.
     type.maybeEnsureResolved();
     const result = await handle.get();

--- a/src/runtime/test/storage-proxy-test.ts
+++ b/src/runtime/test/storage-proxy-test.ts
@@ -11,7 +11,7 @@
 
 import {assert} from '../../platform/chai-web.js';
 import {handleFor, Handle, Variable, Collection} from '../handle.js';
-import {ArcId} from '../id.js';
+import {ArcId, IdGenerator} from '../id.js';
 import {Schema} from '../schema.js';
 import {StorageProxy, StorageProxyScheduler, CollectionProxy, BigCollectionProxy, VariableProxy} from '../storage-proxy.js';
 import {CrdtCollectionModel} from '../storage/crdt-collection-model.js';
@@ -193,6 +193,7 @@ class TestEngine {
   _events = [];
   _scheduler = new StorageProxyScheduler();
   _arcId: ArcId;
+  _idGenerator = IdGenerator.newSession();
   
   constructor(arcId: string) {
     this._arcId = ArcId.newForTest(arcId);
@@ -228,7 +229,7 @@ class TestEngine {
   }
 
   newHandle(store, proxy, particle, canRead, canWrite): Handle {
-    return handleFor(proxy, store.name, particle.id, canRead, canWrite);
+    return handleFor(proxy, this._idGenerator, store.name, particle.id, canRead, canWrite);
   }
 
   newEntity(value): EntityInterface {


### PR DESCRIPTION
This lets us correctly generate new Entity IDs, rather than using the
bizarre EntityIDComponents construction.

There's still one remaining TODO for Entity IDs that use `uid` -- we'll have to come back to fix this later when IDs have better support for adding custom data.