### PR TITLE
Revert to using string ids for entities in firebase manual tests.

### DIFF
--- a/src/runtime/manual_tests/firebase-tests.ts
+++ b/src/runtime/manual_tests/firebase-tests.ts
@@ -98,8 +98,8 @@ describe('firebase', function() {
       const var1 = await storage.construct('test0', barType, key) as VariableStorageProvider;
       const var2 = await storage.connect('test0', barType, key) as VariableStorageProvider;
 
-      var1.set({id: ArcId.newForTest('id1'), value: 'value1'});
-      var2.set({id: ArcId.newForTest('id2'), value: 'value2'});
+      var1.set({id: 'id1', value: 'value1'});
+      var2.set({id: 'id2', value: 'value2'});
       await synchronized(var1, var2);
       assert.deepEqual(await var1.get(), await var2.get());
     });
@@ -115,7 +115,7 @@ describe('firebase', function() {
       const key1 = newStoreKey('varPtr');
 
       const var1 = await storage.construct('test0', barType, key1) as VariableStorageProvider;
-      await var1.set({id: ArcId.newForTest('id1'), value: 'underlying'});
+      await var1.set({id: 'id1', value: 'underlying'});
 
       const result = await var1.get();
       assert.equal(result.value, 'underlying');
@@ -138,7 +138,7 @@ describe('firebase', function() {
       const key1 = newStoreKey('varPtr');
 
       const var1 = await storage.construct('test0', new ReferenceType(barType), key1) as VariableStorageProvider;
-      await var1.set({id: ArcId.newForTest('id1'), storageKey: 'underlying'});
+      await var1.set({id: 'id1', storageKey: 'underlying'});
 
       const result = await var1.get();
       assert.equal(result.storageKey, 'underlying');
@@ -161,7 +161,7 @@ describe('firebase', function() {
       const var1 = await storage.construct('test1', barType, newStoreKey('variable')) as VariableStorageProvider;
       const var2 = await storage.construct('test2', barType, newStoreKey('variable')) as VariableStorageProvider;
 
-      const bar = n => ({id: ArcId.newForTest('id') + n, data: 'd' + n});
+      const bar = n => ({id: 'id' + n, data: 'd' + n});
       await var1.set(bar(1));
       await var2.set(bar(2));
 
@@ -200,12 +200,12 @@ describe('firebase', function() {
       let events = 0;
       collection.on('change', () => events++, this);
 
-      await collection.store({id: ArcId.newForTest('id0'), value: value1}, ['key0']);
-      await collection.store({id: ArcId.newForTest('id1'), value: value2}, ['key1']);
+      await collection.store({id: 'id0', value: value1}, ['key0']);
+      await collection.store({id: 'id1', value: value2}, ['key1']);
       let result = await collection.get('id0');
       assert.equal(result.value, value1);
       result = await collection.toList();
-      assert.deepEqual(result, [{id: ArcId.newForTest('id0'), value: value1}, {id: ArcId.newForTest('id1'), value: value2}]);
+      assert.deepEqual(result, [{id: 'id0', value: value1}, {id: 'id1', value: value2}]);
 
       assert.equal(collection.version, 2);
       assert.equal(events, 2);
@@ -222,8 +222,8 @@ describe('firebase', function() {
       const key = newStoreKey('collection');
       const collection1 = await storage.construct('test1', barType.collectionOf(), key) as CollectionStorageProvider;
       const collection2 = await storage.connect('test1', barType.collectionOf(), key) as CollectionStorageProvider;
-      collection1.store({id: ArcId.newForTest('id1'), value: 'value'}, ['key1']);
-      await collection2.store({id: ArcId.newForTest('id1'), value: 'value'}, ['key2']);
+      collection1.store({id: 'id1', value: 'value'}, ['key1']);
+      await collection2.store({id: 'id1', value: 'value'}, ['key2']);
       await synchronized(collection1, collection2);
       assert.deepEqual(await collection1.toList(), await collection2.toList());
     });
@@ -239,8 +239,8 @@ describe('firebase', function() {
       const key = newStoreKey('collection');
       const collection1 = await storage.construct('test1', barType.collectionOf(), key) as CollectionStorageProvider;
       const collection2 = await storage.connect('test1', barType.collectionOf(), key) as CollectionStorageProvider;
-      collection1.store({id: ArcId.newForTest('id1'), value: 'value'}, ['key1']);
-      collection2.store({id: ArcId.newForTest('id1'), value: 'value'}, ['key2']);
+      collection1.store({id: 'id1', value: 'value'}, ['key1']);
+      collection2.store({id: 'id1', value: 'value'}, ['key2']);
       collection1.remove('id1', ['key1']);
       collection2.remove('id1', ['key2']);
       await synchronized(collection1, collection2);
@@ -259,8 +259,8 @@ describe('firebase', function() {
       const key = newStoreKey('collection');
       const collection1 = await storage.construct('test1', barType.collectionOf(), key) as CollectionStorageProvider;
       const collection2 = await storage.connect('test1', barType.collectionOf(), key) as CollectionStorageProvider;
-      await collection1.store({id: ArcId.newForTest('id1'), value: 'value1'}, ['key1']);
-      await collection2.store({id: ArcId.newForTest('id2'), value: 'value2'}, ['key2']);
+      await collection1.store({id: 'id1', value: 'value1'}, ['key1']);
+      await collection2.store({id: 'id2', value: 'value2'}, ['key2']);
       await synchronized(collection1, collection2);
       assert.lengthOf(await collection1.toList(), 2);
       assert.sameDeepMembers(await collection1.toList(), await collection2.toList());
@@ -279,8 +279,8 @@ describe('firebase', function() {
 
       const collection1 = await storage.construct('test0', barType.collectionOf(), key1) as CollectionStorageProvider;
 
-      await collection1.store({id: ArcId.newForTest('id1'), value: 'value1'}, ['key1']);
-      await collection1.store({id: ArcId.newForTest('id2'), value: 'value2'}, ['key2']);
+      await collection1.store({id: 'id1', value: 'value1'}, ['key1']);
+      await collection1.store({id: 'id2', value: 'value2'}, ['key2']);
 
       let result = await collection1.get('id1');
       assert.equal(result.value, 'value1');
@@ -306,8 +306,8 @@ describe('firebase', function() {
       const key1 = newStoreKey('colPtr');
 
       const collection1 = await storage.construct('test0', new ReferenceType(barType).collectionOf(), key1) as CollectionStorageProvider;
-      await collection1.store({id: ArcId.newForTest('id1'), storageKey: 'value1'}, ['key1']);
-      await collection1.store({id: ArcId.newForTest('id2'), storageKey: 'value2'}, ['key2']);
+      await collection1.store({id: 'id1', storageKey: 'value1'}, ['key1']);
+      await collection1.store({id: 'id2', storageKey: 'value2'}, ['key2']);
 
       let result = await collection1.get('id1');
       assert.equal(result.storageKey, 'value1');
@@ -328,11 +328,9 @@ describe('firebase', function() {
       const barType = new EntityType(manifest.schemas.Bar);
       const key = newStoreKey('collection');
       const collection = await storage.construct('test1', barType.collectionOf(), key) as CollectionStorageProvider;
-      await collection.store({id: ArcId.newForTest('id1'), value: 'value'}, ['key1']);
-      await collection.store({id: ArcId.newForTest('id2'), value: 'value'}, ['key2']);
-      await collection.removeMultiple([
-        {id: ArcId.newForTest('id1'), keys: ['key1']}, {id: ArcId.newForTest('id2'), keys: ['key2']}
-      ]);
+      await collection.store({id: 'id1', value: 'value'}, ['key1']);
+      await collection.store({id: 'id2', value: 'value'}, ['key2']);
+      await collection.removeMultiple([{id: 'id1', keys: ['key1']}, {id: 'id2', keys: ['key2']}]);
       assert.isEmpty(await collection.toList());
     });
 
@@ -350,7 +348,7 @@ describe('firebase', function() {
       const col1 = await storage.construct('test1', barType.collectionOf(), newStoreKey('collection')) as CollectionStorageProvider;
       const col2 = await storage.construct('test2', barType.collectionOf(), newStoreKey('collection')) as CollectionStorageProvider;
 
-      const bar = n => ({id: ArcId.newForTest('id') + n, data: 'd' + n});
+      const bar = n => ({id: 'id' + n, data: 'd' + n});
       await col1.store(bar(1), ['key1']);
       await col2.store(bar(2), ['key2']);
       await col1.store(bar(3), ['key3']);
@@ -367,7 +365,7 @@ describe('firebase', function() {
       assert.sameDeepMembers(await backing.toList(), [bar(1), bar(2), bar(3)]);
 
       // Removing one of col2's ids from col1 should have no effect.
-      await col1.removeMultiple([{id: ArcId.newForTest('id1'), keys: []}, {id: ArcId.newForTest('id2'), keys: []}]);
+      await col1.removeMultiple([{id: 'id1', keys: []}, {id: 'id2', keys: []}]);
       assert.sameDeepMembers(await col1.toList(), [bar(3)]);
       assert.sameDeepMembers(await col2.toList(), [bar(2)]);
 
@@ -416,8 +414,8 @@ describe('firebase', function() {
 
       // Concurrent writes to different ids.
       await Promise.all([
-        collection1.store({id: ArcId.newForTest('id1'), data: 'ab'}, ['k34']),
-        collection2.store({id: ArcId.newForTest('id2'), data: 'cd'}, ['k12'])
+        collection1.store({id: 'id1', data: 'ab'}, ['k34']),
+        collection2.store({id: 'id2', data: 'cd'}, ['k12'])
       ]);
       assert.equal((await collection2.get('id1')).data, 'ab');
       assert.equal((await collection1.get('id2')).data, 'cd');
@@ -427,8 +425,8 @@ describe('firebase', function() {
 
       // Concurrent writes to the same id.
       await Promise.all([
-        collection1.store({id: ArcId.newForTest('id3'), data: 'xx'}, ['k65']),
-        collection2.store({id: ArcId.newForTest('id3'), data: 'yy'}, ['k87'])
+        collection1.store({id: 'id3', data: 'xx'}, ['k65']),
+        collection2.store({id: 'id3', data: 'yy'}, ['k87'])
       ]);
       assert.include(['xx', 'yy'], (await collection1.get('id3')).data);
 
@@ -737,9 +735,9 @@ describe('firebase', function() {
       const bigStore = await storage.construct('test2', dataType.bigCollectionOf(), newStoreKey('bigcollection')) as BigCollectionStorageProvider;
 
       // Populate the stores, run the arc and get its serialization.
-      await varStore.set({id: ArcId.newForTest('i1'), rawData: {value: 'v1'}});
-      await colStore.store({id: ArcId.newForTest('i2'), rawData: {value: 'v2'}}, ['k2']);
-      await bigStore.store({id: ArcId.newForTest('i3'), rawData: {value: 'v3'}}, ['k3']);
+      await varStore.set({id: 'i1', rawData: {value: 'v1'}});
+      await colStore.store({id: 'i2', rawData: {value: 'v2'}}, ['k2']);
+      await bigStore.store({id: 'i3', rawData: {value: 'v3'}}, ['k3']);
 
       const recipe = manifest.recipes[0];
       recipe.handles[0].mapToStorage(varStore);
@@ -753,9 +751,9 @@ describe('firebase', function() {
       arc.dispose();
 
       // Update the stores between serializing and deserializing.
-      await varStore.set({id: ArcId.newForTest('i4'), rawData: {value: 'v4'}});
-      await colStore.store({id: ArcId.newForTest('i5'), rawData: {value: 'v5'}}, ['k5']);
-      await bigStore.store({id: ArcId.newForTest('i6'), rawData: {value: 'v6'}}, ['k6']);
+      await varStore.set({id: 'i4', rawData: {value: 'v4'}});
+      await colStore.store({id: 'i5', rawData: {value: 'v5'}}, ['k5']);
+      await bigStore.store({id: 'i6', rawData: {value: 'v6'}}, ['k6']);
 
       const arc2 = await Arc.deserialize({serialization, loader, fileName: '', pecFactory:undefined, slotComposer: undefined, context: manifest});
       const varStore2 = arc2.findStoreById(varStore.id) as VariableStorageProvider;
@@ -794,7 +792,7 @@ describe('firebase', function() {
       const backing = await col.ensureBackingStore();
       backing.maxConcurrentRequests = 3;
 
-      const bar = n => ({id: ArcId.newForTest('id') + n, data: 'd' + n});
+      const bar = n => ({id: 'id' + n, data: 'd' + n});
 
       // store, storeMultiple
       await backing.store(bar(1), ['key1']);
@@ -830,10 +828,10 @@ describe('firebase', function() {
 
       // removeMultiple: safe to use non-existent keys and ids
       await backing.removeMultiple([
-        {id: ArcId.newForTest('id1'), keys: ['key1']},
-        {id: ArcId.newForTest('id4'), keys: ['keyM']},
-        {id: ArcId.newForTest('id5'), keys: ['not-a-key']},
-        {id: ArcId.newForTest('not-an-id'), keys: []}
+        {id: 'id1', keys: ['key1']},
+        {id: 'id4', keys: ['keyM']},
+        {id: 'id5', keys: ['not-a-key']},
+        {id: 'not-an-id', keys: []}
       ]);
       assert.sameDeepMembers(await backing.toList(), [bar(3), bar(5)]);
 
@@ -841,8 +839,8 @@ describe('firebase', function() {
       await backing.store(bar(7), ['key7a', 'key7b', 'key7c']);
       await backing.store(bar(8), ['key8a', 'key8b', 'key8c']);
       await backing.removeMultiple([
-        {id: ArcId.newForTest('id7'), keys: []},
-        {id: ArcId.newForTest('id8'), keys: ['key8b', 'key8c']},
+        {id: 'id7', keys: []},
+        {id: 'id8', keys: ['key8b', 'key8c']},
       ]);
       assert.sameDeepMembers(await backing.toList(), [bar(3), bar(5), bar(8)]);
 


### PR DESCRIPTION
The storage provider APIs haven't been updated to using Id objects yet, so the tests still need to pass in strings.