### PR TITLE
Restore Words tests, manual only atm

### DIFF
--- a/particles/Words/test/boardsolver-tst.js
+++ b/particles/Words/test/boardsolver-tst.js
@@ -1,0 +1,53 @@
+// Copyright (c) 2017 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+describe('BoardSolver', function() {
+  describe('#getValidWords()', function() {
+    it('should return empty list with no valid words', function() {
+      const dictionary = new Dictionary('cat');
+      let letters = '';
+      for (let i = 0; i < TILE_COUNT; i++) {
+        letters += 'Z' + Tile.StyleToNumber[Tile.Style.NORMAL];
+      }
+      const board = new TileBoard({letters, shuffleAvailableCount: 0});
+      const solver = new BoardSolver(dictionary, board);
+      assert.isEmpty(solver.getValidWords());
+    });
+
+    // TODO(wkorman): Move this to a board test utility class.
+    lettersToBoardString =
+        (letters) => {
+          let lettersWithStyle = '';
+          const normalStyle = Tile.StyleToNumber[Tile.Style.NORMAL];
+          for (let i = 0; i < letters.length; i++) {
+            lettersWithStyle += `${letters.charAt(i)}${normalStyle}`;
+          }
+          return lettersWithStyle;
+        };
+
+    it('should return single word', function() {
+      const dictionary = new Dictionary('cat');
+      const board = new TileBoard({
+        letters: lettersToBoardString(
+            'ZZZZZZZ' +
+            'ZZZZZZZ' +
+            'ZZZCZZZ' +
+            'ZZZAZZZ' +
+            'ZZZTZZZ' +
+            'ZZZZZZZ' +
+            'ZZZZZZZ'),
+        shuffleAvailableCount: 0
+      });
+      const solver = new BoardSolver(dictionary, board);
+      const validWords = solver.getValidWords();
+      assert.lengthOf(validWords, 1);
+      assert.equal(validWords[0].text, 'CAT');
+    });
+  });
+
+  // TODO(wkorman): Add robust set of solver tests.
+});

--- a/particles/Words/test/dictionary-tst.js
+++ b/particles/Words/test/dictionary-tst.js
@@ -1,0 +1,42 @@
+// Copyright (c) 2017 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+describe('Dictionary', function() {
+  const dictionary = new Dictionary('foo\nbar\n baz ');
+
+  describe('#contains()', function() {
+    it('should report present words', function() {
+      assert.isTrue(dictionary.contains('foo'));
+      assert.isTrue(dictionary.contains('bar'));
+      assert.isTrue(dictionary.contains('baz'));
+    });
+
+    it('should not report absent words', function() {
+      assert.isFalse(dictionary.contains('burrito'));
+    });
+
+    it('should ignore case on lookup', function() {
+      assert.isTrue(dictionary.contains('foo'));
+      assert.isTrue(dictionary.contains('FOO'));
+    });
+
+    it('should ignore case on construction', function() {
+      const altDictionary = new Dictionary('FOO');
+      assert.isTrue(dictionary.contains('foo'));
+      assert.isTrue(dictionary.contains('FOO'));
+    });
+  });
+
+  describe('#size', function() {
+    it('should report non-empty size correctly', function() {
+      assert.equal(dictionary.size, 3);
+    });
+    it('should report empty size correctly', function() {
+      assert.equal(new Dictionary('').size, 0);
+    });
+  });
+});

--- a/particles/Words/test/index.test.html
+++ b/particles/Words/test/index.test.html
@@ -1,0 +1,42 @@
+<!--
+Copyright (c) 2017 Google Inc. All rights reserved.
+This code may only be used under the BSD style license found at
+http://polymer.github.io/LICENSE.txt
+Code distributed by Google as part of this project is also
+subject to an additional IP rights grant found at
+http://polymer.github.io/PATENTS.txt
+-->
+<!DOCTYPE html>
+<head>
+  <meta charset="utf-8">
+  <title>Words Mocha Tests</title>
+  <link href="../../../node_modules/mocha/mocha.css" rel="stylesheet" />
+</head>
+<div id="mocha"></div>
+<div id="target"></div>
+<script src="../../../node_modules/chai/chai.js"></script>
+<script src="../../../node_modules/mocha/mocha.js"></script>
+<script>mocha.setup('bdd')</script>
+
+<script>
+  const assert = chai.assert;
+</script>
+
+<script src="../source/Dictionary.js"></script>
+<script src="../test/dictionary-tst.js"></script>
+
+<script src="../source/Scoring.js"></script>
+<script src="../test/scoring-tst.js"></script>
+
+<script src="../source/Tile.js"></script>
+<script src="../test/tile-tst.js"></script>
+
+<script src="../source/TileBoard.js"></script>
+<script src="../test/tileboard-tst.js"></script>
+
+<script src="../source/BoardSolver.js"></script>
+<script src="../test/boardsolver-tst.js"></script>
+<script>
+mocha.checkLeaks();
+mocha.run();
+</script>

--- a/particles/Words/test/scoring-tst.js
+++ b/particles/Words/test/scoring-tst.js
@@ -1,0 +1,245 @@
+// Copyright (c) 2017 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+describe('Scoring', function() {
+  describe('#isMinimumWordLength()', function() {
+    it('should report word length requirements correctly', function() {
+      assert.isFalse(Scoring.isMinimumWordLength(0));
+      assert.isTrue(Scoring.isMinimumWordLength(3));
+      assert.isTrue(Scoring.isMinimumWordLength(30));
+    });
+  });
+
+  describe('#pointsForLetter()', function() {
+    it('should report letter points correctly', function() {
+      assert.equal(Scoring.pointsForLetter('A'), 1);
+      assert.equal(Scoring.pointsForLetter('O'), 1);
+      assert.equal(Scoring.pointsForLetter('Z'), 3);
+    });
+  });
+
+  describe('#wordScore()', function() {
+    function tilesForWord(word) {
+      let tiles = [];
+      for (let i = 0; i < word.length; i++) {
+        tiles.push(new Tile(i, word.charAt(i)));
+      }
+      return tiles;
+    }
+    it('should score a basic word correctly', function() {
+      assert.equal(Scoring.wordScore(tilesForWord('ABC')), 7);
+      assert.equal(Scoring.wordScore(tilesForWord('ABCD')), 18);
+    });
+    it('should score a word with a multiplier correctly', function() {
+      assert.equal(Scoring.wordScore(tilesForWord('ABCD')), 18);
+    });
+    it('should score a word with exactly the maximum multiplier correctly',
+       function() {
+         assert.equal(Scoring.wordScore(tilesForWord('ABCDABCDABCD')), 135);
+       });
+    it('should score a word with more chars than specified by the maximum multiplier correctly',
+       function() {
+         assert.equal(Scoring.wordScore(tilesForWord('ABCDABCDABCDABCD')), 180);
+       });
+  });
+
+  describe('#longestWordText()', function() {
+    it('should report none for empty stats or word', function() {
+      assert.equal(Scoring.longestWordText(undefined), '--');
+      assert.equal(
+          Scoring.longestWordText({longestWord: undefined}), '--');
+      assert.equal(Scoring.longestWordText({longestWord: ''}), '--');
+    });
+
+    it('should report formatted text when values present', function() {
+      assert.equal(
+          Scoring.longestWordText({longestWord: 'foo', longestWordScore: 42}),
+          'foo (42)');
+    });
+  });
+
+  describe('#highestScoringWordText()', function() {
+    it('should report none for empty stats or word', function() {
+      assert.equal(Scoring.highestScoringWordText(undefined), '--');
+      assert.equal(
+          Scoring.highestScoringWordText({highestScoringWord: undefined}),
+          '--');
+      assert.equal(
+          Scoring.highestScoringWordText({highestScoringWord: ''}),
+          '--');
+    });
+
+    it('should report formatted text when values present', function() {
+      assert.equal(
+          Scoring.highestScoringWordText(
+              {highestScoringWord: 'foo', highestScoringWordScore: 42}),
+          'foo (42)');
+    });
+  });
+
+  describe('#applyMoveStats()', function() {
+    const validateStats = (actual, expected) => {
+      let actualCopy = Object.assign({}, actual);
+      // TODO(wkorman): We hack in Post data currently. Revisit this and add
+      // specific relevant tests.
+      delete actualCopy.author;
+      delete actualCopy.createdTimestamp;
+      delete actualCopy.message;
+      assert.deepEqual(actualCopy, expected);
+    };
+
+    it('should persist existing stats', function() {
+      const stats = {
+        highestScoringWord: 'highest',
+        highestScoringWordScore: 43,
+        longestWord: 'longest',
+        longestWordScore: 56,
+        score: 0,
+        moveCount: 0,
+        startstamp: 7331
+      };
+      const gameId = '8118';
+      const user = {id: '42'};
+      const actual = Scoring.applyMoveStats(gameId, user, stats, 'short', 38);
+      validateStats(actual, {
+        gameId,
+        highestScoringWord: 'highest',
+        highestScoringWordScore: 43,
+        longestWord: 'longest',
+        longestWordScore: 56,
+        score: 38,
+        moveCount: 1,
+        startstamp: 7331
+      });
+    });
+
+    it('should update existing highest scoring word', function() {
+      const stats = {
+        highestScoringWord: 'highest',
+        highestScoringWordScore: 43,
+        longestWord: 'longest',
+        longestWordScore: 56,
+        score: 0,
+        moveCount: 0,
+        startstamp: 7331
+      };
+      const gameId = '8118';
+      const user = {id: '42'};
+      const actual = Scoring.applyMoveStats(gameId, user, stats, 'higher', 100);
+      validateStats(actual, {
+        gameId,
+        highestScoringWord: 'higher',
+        highestScoringWordScore: 100,
+        longestWord: 'longest',
+        longestWordScore: 56,
+        score: 100,
+        moveCount: 1,
+        startstamp: 7331
+      });
+    });
+
+    it('should update undefined highest scoring word', function() {
+      const stats = {
+        highestScoringWord: undefined,
+        highestScoringWordScore: undefined,
+        longestWord: 'longest',
+        longestWordScore: 56,
+        score: 0,
+        moveCount: 0,
+        startstamp: 7331
+      };
+      const gameId = '8118';
+      const user = {id: '42'};
+      const actual = Scoring.applyMoveStats(gameId, user, stats, 'higher', 100);
+      validateStats(actual, {
+        gameId,
+        highestScoringWord: 'higher',
+        highestScoringWordScore: 100,
+        longestWord: 'longest',
+        longestWordScore: 56,
+        score: 100,
+        moveCount: 1,
+        startstamp: 7331
+      });
+    });
+
+    it('should update existing longest word', function() {
+      const stats = {
+        highestScoringWord: 'highest',
+        highestScoringWordScore: 43,
+        longestWord: 'longest',
+        longestWordScore: 56,
+        score: 0,
+        moveCount: 0,
+        startstamp: 7331
+      };
+      const gameId = '8118';
+      const user = {id: '42'};
+      const actual = Scoring.applyMoveStats(gameId, user, stats, 'evenlonger', 23);
+      validateStats(actual, {
+        gameId,
+        highestScoringWord: 'highest',
+        highestScoringWordScore: 43,
+        longestWord: 'evenlonger',
+        longestWordScore: 23,
+        score: 23,
+        moveCount: 1,
+        startstamp: 7331
+      });
+    });
+
+    it('should update undefined longest word', function() {
+      const stats = {
+        highestScoringWord: 'highest',
+        highestScoringWordScore: 43,
+        longestWord: undefined,
+        longestWordScore: undefined,
+        score: 0,
+        moveCount: 0,
+        startstamp: 7331
+      };
+      const gameId = '8118';
+      const user = {id: '42'};
+      const actual = Scoring.applyMoveStats(gameId, user, stats, 'evenlonger', 23);
+      validateStats(actual, {
+        gameId,
+        highestScoringWord: 'highest',
+        highestScoringWordScore: 43,
+        longestWord: 'evenlonger',
+        longestWordScore: 23,
+        score: 23,
+        moveCount: 1,
+        startstamp: 7331
+      });
+    });
+
+    it('should update all of the things', function() {
+      const stats = {
+        highestScoringWord: 'highest',
+        highestScoringWordScore: 43,
+        longestWord: 'longest',
+        longestWordScore: 56,
+        score: 8118,
+        moveCount: 345,
+        startstamp: 7331
+      };
+      const gameId = '8118';
+      const user = {id: '42'};
+      const actual = Scoring.applyMoveStats(gameId, user, stats, 'evenlonger', 2300);
+      validateStats(actual, {
+        gameId,
+        highestScoringWord: 'evenlonger',
+        highestScoringWordScore: 2300,
+        longestWord: 'evenlonger',
+        longestWordScore: 2300,
+        score: 10418,
+        moveCount: 346,
+        startstamp: 7331
+      });
+    });
+  });
+});

--- a/particles/Words/test/tile-tst.js
+++ b/particles/Words/test/tile-tst.js
@@ -1,0 +1,48 @@
+// Copyright (c) 2017 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+describe('Tile', function() {
+  describe('#x', function() {
+    it('should compute x coordinate correctly', function() {
+      const tile00 = new Tile(0, 'A');
+      assert.equal(0, tile00.x);
+      const tile66 = new Tile(48, 'A');
+      assert.equal(6, tile66.x);
+      const tile42 = new Tile(30, 'A');
+      assert.equal(2, tile42.x);
+    });
+  });
+
+  describe('#y', function() {
+    it('should compute y coordinate correctly', function() {
+      const tile00 = new Tile(0, 'A');
+      assert.equal(0, tile00.y);
+      const tile66 = new Tile(48, 'A');
+      assert.equal(6, tile66.y);
+      const tile42 = new Tile(30, 'A');
+      assert.equal(4, tile42.y);
+    });
+  });
+
+  describe('#isShiftedDown', function() {
+    it('should report alternating tile columns from zero on as shifted down',
+       function() {
+         assert.isTrue(new Tile(0, 'A').isShiftedDown);
+         assert.isFalse(new Tile(1, 'B').isShiftedDown);
+         assert.isTrue(new Tile(2, 'C').isShiftedDown);
+       });
+  });
+
+  describe('#toString', function() {
+    it('should include all member data', function() {
+      const tile = new Tile(0, 'A');
+      assert.equal(
+          '[charIndex=0, letter=A, style=Symbol(normal), x=0, y=0]',
+          tile.toString());
+    });
+  });
+});

--- a/particles/Words/test/tileboard-tst.js
+++ b/particles/Words/test/tileboard-tst.js
@@ -1,0 +1,434 @@
+// Copyright (c) 2017 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+describe('TileBoard', function() {
+  const savePickCharWithFrequencies = TileBoard.pickCharWithFrequencies;
+
+  const lettersToBoardString =
+      (letters) => {
+        let lettersWithStyle = '';
+        const normalStyle = Tile.StyleToNumber[Tile.Style.NORMAL];
+        for (let i = 0; i < letters.length; i++) {
+          lettersWithStyle += `${letters.charAt(i)}${normalStyle}`;
+        }
+        return lettersWithStyle;
+      };
+
+  function createDefaultBoard(shuffleCount) {
+    if (shuffleCount == undefined) {
+      shuffleCount = 1;
+    }
+    const letters = 'ABCDEFG' +
+        'HIJKLMN' +
+        'OPQRSTU' +
+        'VWXYZAB' +
+        'CDEFGHI' +
+        'JKLMNOP' +
+        'QRSTUVW';
+    return new TileBoard({
+      letters: lettersToBoardString(letters),
+      shuffleAvailableCount: shuffleCount
+    });
+  }
+
+  describe('#size', function() {
+    it('should return the total tile count', function() {
+      assert.equal(createDefaultBoard().size, 49);
+    });
+  });
+
+  describe('#tileAt()', function() {
+    it('should return tiles at specific x/y coordinates', function() {
+      const board = createDefaultBoard();
+      const tile00 = board.tileAt(0, 0);
+      assert.equal(tile00.x, 0);
+      assert.equal(tile00.y, 0);
+      assert.equal(tile00.letter, 'A');
+      const tile35 = board.tileAt(3, 5);
+      assert.equal(tile35.x, 3);
+      assert.equal(tile35.y, 5);
+      assert.equal(tile35.letter, 'M');
+      const tile66 = board.tileAt(6, 6);
+      assert.equal(tile66.x, 6);
+      assert.equal(tile66.y, 6);
+      assert.equal(tile66.letter, 'W');
+    });
+  });
+
+  describe('#tileAtIndex()', function() {
+    it('should return tiles at specific indexes', function() {
+      const board = createDefaultBoard();
+      const tile0 = board.tileAtIndex(0);
+      assert.equal(tile0.x, 0);
+      assert.equal(tile0.y, 0);
+      assert.equal(tile0.letter, 'A');
+      const tile38 = board.tileAtIndex(38);
+      assert.equal(tile38.x, 3);
+      assert.equal(tile38.y, 5);
+      assert.equal(tile38.letter, 'M');
+      const tile48 = board.tileAtIndex(48);
+      assert.equal(tile48.x, 6);
+      assert.equal(tile48.y, 6);
+      assert.equal(tile48.letter, 'W');
+    });
+  });
+
+  describe('#applyMove()', function() {
+    before(function() {
+      TileBoard.pickCharWithFrequencies = () => {
+        return '=';
+      };
+    });
+
+    after(function() {
+      TileBoard.pickCharWithFrequencies = savePickCharWithFrequencies;
+    });
+
+    it('should destroy tiles at top left corner of board correctly',
+       function() {
+         const board = createDefaultBoard();
+         const tiles = [new Tile(0, 'A'), new Tile(1, 'B'), new Tile(2, 'C')];
+         board.applyMove(tiles);
+         const expectedBoard = lettersToBoardString(
+             '===DEFG' +
+             'HIJKLMN' +
+             'OPQRSTU' +
+             'VWXYZAB' +
+             'CDEFGHI' +
+             'JKLMNOP' +
+             'QRSTUVW');
+         assert.equal(board.toString(), expectedBoard);
+       });
+
+    it('should destroy all tiles at top of board correctly', function() {
+      const board = createDefaultBoard();
+      const tiles = [
+        new Tile(0, 'A'),
+        new Tile(1, 'B'),
+        new Tile(2, 'C'),
+        new Tile(3, 'D'),
+        new Tile(4, 'E'),
+        new Tile(5, 'F'),
+        new Tile(6, 'G')
+      ];
+      board.applyMove(tiles);
+      const expectedBoard = lettersToBoardString(
+          '=======' +
+          'HIJKLMN' +
+          'OPQRSTU' +
+          'VWXYZAB' +
+          'CDEFGHI' +
+          'JKLMNOP' +
+          'QRSTUVW');
+      assert.equal(board.toString(), expectedBoard);
+    });
+
+    it('should destroy tiles mid-board correctly', function() {
+      const board = createDefaultBoard();
+      const tiles = [new Tile(16, 'Q'), new Tile(17, 'R'), new Tile(18, 'S')];
+      board.applyMove(tiles);
+      const expectedBoard = lettersToBoardString(
+          'AB===FG' +
+          'HICDEMN' +
+          'OPJKLTU' +
+          'VWXYZAB' +
+          'CDEFGHI' +
+          'JKLMNOP' +
+          'QRSTUVW');
+      assert.equal(board.toString(), expectedBoard);
+    });
+
+    it('should destroy tiles mid-board multi-row correctly', function() {
+      const board = createDefaultBoard();
+      const tiles = [
+        new Tile(16, 'Q'),
+        new Tile(17, 'R'),
+        new Tile(18, 'S'),
+        new Tile(11, 'L')
+      ];
+      board.applyMove(tiles);
+      const expectedBoard = lettersToBoardString(
+          'AB===FG' +
+          'HICD=MN' +
+          'OPJKETU' +
+          'VWXYZAB' +
+          'CDEFGHI' +
+          'JKLMNOP' +
+          'QRSTUVW');
+      assert.equal(board.toString(), expectedBoard);
+    });
+
+    it('should destroy tiles mid-board multi-row and looping back correctly',
+       function() {
+         const board = createDefaultBoard();
+         const tiles = [
+           new Tile(16, 'Q'),
+           new Tile(17, 'R'),
+           new Tile(18, 'S'),
+           new Tile(11, 'L'),
+           new Tile(10, 'K'),
+           new Tile(9, 'J')
+         ];
+         board.applyMove(tiles);
+         const expectedBoard = lettersToBoardString(
+             'AB===FG' +
+             'HI===MN' +
+             'OPCDETU' +
+             'VWXYZAB' +
+             'CDEFGHI' +
+             'JKLMNOP' +
+             'QRSTUVW');
+         assert.equal(board.toString(), expectedBoard);
+       });
+
+    it('should destroy tiles mid-board multi-row-interspersed and looping back correctly',
+       function() {
+         const board = createDefaultBoard();
+         const tiles = [
+           new Tile(16, 'Q'),
+           new Tile(17, 'R'),
+           new Tile(18, 'S'),
+           new Tile(11, 'L'),
+           new Tile(4, 'E'),
+           new Tile(3, 'D'),
+           new Tile(2, 'C')
+         ];
+         board.applyMove(tiles);
+         const expectedBoard = lettersToBoardString(
+             'AB===FG' +
+             'HI===MN' +
+             'OPJK=TU' +
+             'VWXYZAB' +
+             'CDEFGHI' +
+             'JKLMNOP' +
+             'QRSTUVW');
+         assert.equal(board.toString(), expectedBoard);
+       });
+
+    it('should destroy tiles at bottom right corner of board correctly',
+       function() {
+         const board = createDefaultBoard();
+         const tiles =
+             [new Tile(46, 'U'), new Tile(47, 'V'), new Tile(48, 'W')];
+         board.applyMove(tiles);
+         const expectedBoard = lettersToBoardString(
+             'ABCD===' +
+             'HIJKEFG' +
+             'OPQRLMN' +
+             'VWXYSTU' +
+             'CDEFZAB' +
+             'JKLMGHI' +
+             'QRSTNOP');
+         assert.equal(board.toString(), expectedBoard);
+       });
+
+    it('should destroy all tiles at bottom of board correctly', function() {
+      const board = createDefaultBoard();
+      const tiles = [
+        new Tile(42, 'Q'),
+        new Tile(43, 'R'),
+        new Tile(44, 'S'),
+        new Tile(45, 'T'),
+        new Tile(46, 'U'),
+        new Tile(47, 'V'),
+        new Tile(48, 'W')
+      ];
+      board.applyMove(tiles);
+      const expectedBoard = lettersToBoardString(
+          '=======' +
+          'ABCDEFG' +
+          'HIJKLMN' +
+          'OPQRSTU' +
+          'VWXYZAB' +
+          'CDEFGHI' +
+          'JKLMNOP');
+      assert.equal(board.toString(), expectedBoard);
+    });
+  });
+
+  describe('#pickCharWithFrequencies()', function() {
+    it('should return a single caps alpha character', function() {
+      let result = TileBoard.pickCharWithFrequencies();
+      assert.lengthOf(result, 1);
+      assert.match(result, /[A-Z]/);
+    });
+  });
+
+  describe('#indexToX()', function() {
+    it('should compute x for index correctly', function() {
+      assert.equal(TileBoard.indexToX(0), 0);
+      assert.equal(TileBoard.indexToX(6), 6);
+      assert.equal(TileBoard.indexToX(7), 0);
+      assert.equal(TileBoard.indexToX(48), 6);
+    });
+  });
+
+  describe('#indexToY()', function() {
+    it('should compute y for index correctly', function() {
+      assert.equal(TileBoard.indexToY(0), 0);
+      assert.equal(TileBoard.indexToY(6), 0);
+      assert.equal(TileBoard.indexToY(7), 1);
+      assert.equal(TileBoard.indexToY(48), 6);
+    });
+  });
+
+  describe('#shuffle()', function() {
+    it('should not shuffle board with no shuffles remaining', function() {
+      let board = createDefaultBoard(0);
+      let letters = board.toString();
+      assert.equal(board.shuffleAvailableCount, 0);
+      assert.isFalse(board.shuffle());
+      assert.equal(letters, board.toString());
+    });
+
+    it('should shuffle board with a shuffle remaining', function() {
+      let board = createDefaultBoard(1);
+      let letters = board.toString();
+      assert.equal(board.shuffleAvailableCount, 1);
+      assert.isTrue(board.shuffle());
+      assert.notEqual(letters, board.toString());
+      assert.equal(board.shuffleAvailableCount, 0);
+    });
+  });
+
+  describe('#toString', function() {
+    it('should concatenate all tiles into a single string', function() {
+      const board = new TileBoard({
+        letters: lettersToBoardString(
+            'ABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVW')
+      });
+      assert.equal(
+          lettersToBoardString(
+              'ABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVW'),
+          board.toString());
+    });
+  });
+
+  describe('#isMoveValid()', function() {
+    it('should consider initial moves valid', function() {
+      const board = createDefaultBoard();
+      assert.isTrue(board.isMoveValid([], new Tile(0, 'A')));
+    });
+
+    it('should allow selecting the last selected tile', function() {
+      const board = createDefaultBoard();
+      const tile = new Tile(0, 'A');
+      assert.isTrue(board.isMoveValid([tile], tile));
+    });
+
+    it('should allow selecting any touching tile from top left corner',
+       function() {
+         const board = createDefaultBoard();
+         const tile = new Tile(0, 'A');
+         // Right.
+         assert.isTrue(board.isMoveValid([tile], new Tile(1, 'B')));
+         // Right and offset below.
+         assert.isTrue(board.isMoveValid([tile], new Tile(8, 'I')));
+         // Below.
+         assert.isTrue(board.isMoveValid([tile], new Tile(7, 'H')));
+
+         assert.isFalse(board.isMoveValid([tile], new Tile(2, 'C')));
+         assert.isFalse(board.isMoveValid([tile], new Tile(6, 'G')));
+         assert.isFalse(board.isMoveValid([tile], new Tile(9, 'J')));
+       });
+
+    it('should allow selecting any touching tile from top right corner',
+       function() {
+         const board = createDefaultBoard();
+         const tile = new Tile(6, 'G');
+         // Left.
+         assert.isTrue(board.isMoveValid([tile], new Tile(5, 'F')));
+         // Left and offset below.
+         assert.isTrue(board.isMoveValid([tile], new Tile(12, 'M')));
+         // Below.
+         assert.isTrue(board.isMoveValid([tile], new Tile(13, 'N')));
+
+         assert.isFalse(board.isMoveValid([tile], new Tile(4, 'E')));
+         assert.isFalse(board.isMoveValid([tile], new Tile(7, 'H')));
+         assert.isFalse(board.isMoveValid([tile], new Tile(11, 'L')));
+         assert.isFalse(board.isMoveValid([tile], new Tile(14, 'O')));
+       });
+
+    it('should allow selecting any touching tile from bottom right corner',
+       function() {
+         const board = createDefaultBoard();
+         const tile = new Tile(48, 'W');
+         // Above.
+         assert.isTrue(board.isMoveValid([tile], new Tile(41, 'P')));
+         // Left.
+         assert.isTrue(board.isMoveValid([tile], new Tile(47, 'V')));
+
+         assert.isFalse(board.isMoveValid([tile], new Tile(40, 'O')));
+         assert.isFalse(board.isMoveValid([tile], new Tile(46, 'U')));
+       });
+
+    it('should allow selecting any touching tile from bottom left corner',
+       function() {
+         const board = createDefaultBoard();
+         const tile = new Tile(42, 'Q');
+         // Above.
+         assert.isTrue(board.isMoveValid([tile], new Tile(35, 'J')));
+         // Right.
+         assert.isTrue(board.isMoveValid([tile], new Tile(43, 'R')));
+
+         assert.isFalse(board.isMoveValid([tile], new Tile(34, 'I')));
+         assert.isFalse(board.isMoveValid([tile], new Tile(36, 'K')));
+         assert.isFalse(board.isMoveValid([tile], new Tile(44, 'S')));
+       });
+
+    it('should allow selecting any touching tile from an unshifted column in center region',
+       function() {
+         const board = createDefaultBoard();
+         const tile = new Tile(22, 'Y');
+         assert.isFalse(tile.isShiftedDown);
+         // Above.
+         assert.isTrue(board.isMoveValid([tile], new Tile(15, 'R')));
+         // Below.
+         assert.isTrue(board.isMoveValid([tile], new Tile(29, 'F')));
+         // Right.
+         assert.isTrue(board.isMoveValid([tile], new Tile(23, 'Z')));
+         // Right and offset above.
+         assert.isTrue(board.isMoveValid([tile], new Tile(16, 'S')));
+         // Left.
+         assert.isTrue(board.isMoveValid([tile], new Tile(21, 'X')));
+         // Left and offset above.
+         assert.isTrue(board.isMoveValid([tile], new Tile(14, 'Q')));
+
+         // Right and offset below.
+         assert.isFalse(board.isMoveValid([tile], new Tile(30, 'G')));
+         // Left and offset below.
+         assert.isFalse(board.isMoveValid([tile], new Tile(28, 'E')));
+       });
+
+    it('should allow selecting any touching tile from a shifted column in center region',
+       function() {
+         const board = createDefaultBoard();
+         const tile = new Tile(23, 'Z');
+         assert.isTrue(tile.isShiftedDown);
+         // Above.
+         assert.isTrue(board.isMoveValid([tile], new Tile(16, 'S')));
+         // Below.
+         assert.isTrue(board.isMoveValid([tile], new Tile(30, 'G')));
+         // Right.
+         assert.isTrue(board.isMoveValid([tile], new Tile(24, 'A')));
+         // Right and offset below.
+         assert.isTrue(board.isMoveValid([tile], new Tile(31, 'H')));
+         // Left.
+         assert.isTrue(board.isMoveValid([tile], new Tile(22, 'Y')));
+         // Left and offset below.
+         assert.isTrue(board.isMoveValid([tile], new Tile(29, 'F')));
+
+         // Right and offset above.
+         assert.isFalse(board.isMoveValid([tile], new Tile(17, 'T')));
+         // Left and offset above.
+         assert.isFalse(board.isMoveValid([tile], new Tile(15, 'R')));
+       });
+  });
+
+  // TODO(wkorman): Add tests for game-end on burning tiles, and
+  // burning tile behavior on move application when not at bottom.
+});


### PR DESCRIPTION
These tests runs correctly via loading `index.test.html` in the browser, but it wasn't obvious how to make them work via sigh/test because the dependencies (code to test) is never loaded.

I renamed -test to -tst to prevent sigh trying to run them.