### PR TITLE
Add ActiveRecipe panel to Arcs Explorer

### DIFF
--- a/devtools/src/arcs-environment.js
+++ b/devtools/src/arcs-environment.js
@@ -32,7 +32,7 @@ class ArcsEnvironment extends MessengerMixin(PolymerElement) {
       [content] {
         border-bottom: 1px solid var(--mid-gray);
       }
-      object-explorer[find]:not([found-inside]) {
+      object-explorer[find]:not([found]) {
         display: none;
       }
     </style>
@@ -41,7 +41,11 @@ class ArcsEnvironment extends MessengerMixin(PolymerElement) {
         <filter-input filter="{{searchParams}}"></filter-input>
       </div>
     </header>
-    <div title>Recipes</div>
+    <div title>Active Recipe</div>
+    <div content>
+      <object-explorer object=[[activeRecipe]]></object-explorer>
+    </div>
+    <div title>Context Recipes</div>
     <div content>
       <template is="dom-repeat" items="{{recipes}}">
         <object-explorer object="{{item}}">
@@ -52,7 +56,7 @@ class ArcsEnvironment extends MessengerMixin(PolymerElement) {
         <div class="empty-label">No recipes</div>
       </template>
     </div>
-    <div title>Particles</div>
+    <div title>Context Particles</div>
     <div content>
       <template is="dom-repeat" items="{{particles}}">
         <object-explorer object="{{item}}">
@@ -67,8 +71,7 @@ class ArcsEnvironment extends MessengerMixin(PolymerElement) {
 
   constructor() {
     super();
-    this.recipes = [];
-    this.particles = [];
+    this.clear();
   }
 
   static get properties() {
@@ -78,6 +81,12 @@ class ArcsEnvironment extends MessengerMixin(PolymerElement) {
         observer: '_onSearchChanged'
       }
     };
+  }
+
+  clear() {
+    this.recipes = [];
+    this.particles = [];
+    this.activeRecipe = '';
   }
 
   _onSearchChanged(params) {
@@ -94,10 +103,12 @@ class ArcsEnvironment extends MessengerMixin(PolymerElement) {
         this.particles = msg.messageBody.particles.slice();
         this.particles.sort(nameCompare);
         break;
+      case 'recipe-instantiated':
+        this.activeRecipe = msg.messageBody.activeRecipe;
+        break;
       case 'arc-selected':
       case 'page-refresh':
-        this.recipes = [];
-        this.particles = [];
+        this.clear();
         break;
     }
   }

--- a/devtools/src/arcs-stores.js
+++ b/devtools/src/arcs-stores.js
@@ -50,7 +50,7 @@ class ArcsStores extends MessengerMixin(PolymerElement) {
       [id] {
         color: var(--devtools-red);
       }
-      object-explorer[find]:not([found-inside]) {
+      object-explorer[find]:not([found]) {
         display: none;
       }
     </style>

--- a/devtools/src/common/object-explorer.js
+++ b/devtools/src/common/object-explorer.js
@@ -81,7 +81,7 @@ export class ObjectExplorer extends PolymerElement {
       :host([inner]:not([folded])) {
         padding-left: 10px;
       }
-      :host([inner][found-inside]:not([expanded]):not([folded])) {
+      :host([inner][found]:not([expanded]):not([folded])) {
         padding-left: 0;
         border-left: 10px solid yellow;
       }
@@ -243,7 +243,6 @@ export class ObjectExplorer extends PolymerElement {
       for (const inner of data.props) {
         foundInside = this._findInternal(inner, params) || foundInside;
       }
-      data.foundInside = foundInside;
       data.found = foundInKey || foundInside; 
     } else {
       const [displayValue, foundInValue] = this._highlight(String(data.value), params);
@@ -346,10 +345,10 @@ export class ObjectExplorer extends PolymerElement {
         value: null,
         observer: '_onFindChanged'
       },
-      foundInside: {
+      found: {
         type: Boolean,
         reflectToAttribute: true,
-        computed: '_id(data.foundInside)'
+        computed: '_id(data.found)'
       },
     };
   }
@@ -390,7 +389,7 @@ export class ObjectExplorer extends PolymerElement {
     ObjectExplorer.find(this.data, params);
     this.notifyPath('data.displayKey');
     this.notifyPath('data.displayValue');
-    this.notifyPath('data.foundInside');
+    this.notifyPath('data.found');
   }
 }
 

--- a/src/runtime/arc.ts
+++ b/src/runtime/arc.ts
@@ -625,7 +625,7 @@ ${this.activeRecipe.toString()}`;
       this.instantiatePlanCallbacks.forEach(callback => callback(recipe));
     }
 
-    this.debugHandler.recipeInstantiated({particles});
+    this.debugHandler.recipeInstantiated({particles, activeRecipe: this.activeRecipe.toString()});
   }
 
   async createStore(type: Type, name?: string, id?: string, tags?: string[], storageKey: string = undefined) {

--- a/src/runtime/debug/arc-debug-handler.ts
+++ b/src/runtime/debug/arc-debug-handler.ts
@@ -60,7 +60,7 @@ export class ArcDebugHandler {
     });
   }
 
-  recipeInstantiated({particles}: {particles: Particle[]}) {
+  recipeInstantiated({particles, activeRecipe}: {particles: Particle[], activeRecipe: string}) {
     if (!this.arcDevtoolsChannel) return;
 
     type TruncatedSlot = {id: string, name: string};
@@ -77,7 +77,7 @@ export class ArcDebugHandler {
     }));
     this.arcDevtoolsChannel.send({
       messageType: 'recipe-instantiated',
-      messageBody: {slotConnections}
+      messageBody: {slotConnections, activeRecipe}
     });
   }
 


### PR DESCRIPTION
Requested by @sjmiles 

A small change to `object-explorer` to make searching work when a single string is given to it.

`Environment` tab is maybe not the best place, but I'm thinking of collapsing all of Environment and Storage into a single column on a right hand side with collapsible sections, which may work better? We'll see.

![Screen Shot 2019-05-06 at 11 21 29 AM](https://user-images.githubusercontent.com/26159485/57203188-4c55be80-6ff1-11e9-901f-324128f1fdbb.png)
