### PR TITLE
Ignore directories generated by tests

### DIFF
--- a/tools/sigh.ts
+++ b/tools/sigh.ts
@@ -623,7 +623,7 @@ function watch(args: string[]): boolean {
   }
   const command = args.shift() || 'webpack';
   const watcher = chokidar.watch('.', {
-    ignored: new RegExp(`(node_modules|build/|.git|${eslintCache})`),
+    ignored: new RegExp(`(node_modules|build/|.git|user-test/|test-output/|${eslintCache})`),
     persistent: true
   });
   let timeout = null;


### PR DESCRIPTION
It seems that some tests are generating new directories.
This ignores these from the watch command in sigh (they were already ignored in git).

Possibly we should ignore all .gitignore[d] files in sigh, but this is a larger, more magic, change.