### PR TITLE
Use References to build Context stores and encode provenance data

### DIFF
--- a/modalities/dom/components/elements/data-item.js
+++ b/modalities/dom/components/elements/data-item.js
@@ -33,13 +33,18 @@ const template = html`
     font-size: 0.8em;
   }
   right {
-    display: block;
+    display: flex;
+    align-items: center;
   }
   [expand] {
-    padding-top: 2px;
+    padding-bottom: 3px;
   }
   data-explorer:not([hidden]) {
     padding-left: 32px;
+  }
+  [type="object"] {
+    font-weight: bold;
+    font-size: 0.9em;
   }
   [type="number"] {
     color: blue;
@@ -99,7 +104,7 @@ class DataItem extends Xen.Base {
     return {
       type,
       name,
-      value: isnull || isobject ? '(null)' : isbool ? value : String(value),
+      value: isnull || isobject ? 'null' : isbool ? value : String(value),
       isobject: isobject && state.expanded,
       notstring: !isstring,
       notbool: !isbool,

--- a/particles/Profile/Avatar.schema
+++ b/particles/Profile/Avatar.schema
@@ -1,2 +1,6 @@
 schema Avatar
   URL url
+
+import 'Share.schema'
+schema AvatarShare extends Share
+  Reference<Avatar> ref

--- a/particles/Profile/BasicProfile.recipe
+++ b/particles/Profile/BasicProfile.recipe
@@ -8,8 +8,8 @@ particle UserNameForm in 'source/UserNameForm.js'
 
 particle FriendsPicker in 'source/FriendsPicker.js'
   inout [Friend] friends
-  in [Avatar] avatars
-  in [UserName] userNames
+  in [AvatarShare] avatars
+  in [UserNameShare] userNames
   consume friends
   description `select friends`
 

--- a/particles/Profile/Friend.schema
+++ b/particles/Profile/Friend.schema
@@ -1,2 +1,6 @@
 schema Friend
   Text publicKey
+
+import 'Share.schema'
+schema FriendShare extends Share
+  Reference<Friend> ref

--- a/particles/Profile/Share.schema
+++ b/particles/Profile/Share.schema
@@ -1,0 +1,3 @@
+schema Share
+  Text fromKey
+  Text fromArc 

--- a/particles/Profile/Sharing.recipe
+++ b/particles/Profile/Sharing.recipe
@@ -4,31 +4,31 @@ import 'UserName.schema'
 resource PROFILE_avatarResource
   start
   []
-store PROFILE_avatar of [Avatar] 'PROFILE_avatar' @0 #profile in PROFILE_avatarResource
+store PROFILE_avatar of [AvatarShare] 'PROFILE_avatar' @0 #profile in PROFILE_avatarResource
 
 resource PROFILE_userNameResource
   start
   []
-store PROFILE_userName of [UserName] 'PROFILE_userName' @0 #profile in PROFILE_userNameResource
+store PROFILE_userName of [UserNameShare] 'PROFILE_userName' @0 #profile in PROFILE_userNameResource
 
 resource BOXED_avatarResource
   start
   []
-store BOXED_avatar of [Avatar] 'BOXED_avatar' @0 #boxed in BOXED_avatarResource
+store BOXED_avatar of [AvatarShare] 'BOXED_avatar' @0 #boxed in BOXED_avatarResource
 
 resource BOXED_userNameResource
   start
   []
-store BOXED_userName of [UserName] 'BOXED_userName' @0 #boxed in BOXED_userNameResource
+store BOXED_userName of [UserNameShare] 'BOXED_userName' @0 #boxed in BOXED_userNameResource
 
 // the below is required to make the arc aware of these stores
 
 particle Sharing in './source/Sharing.js'
-  in [Avatar] boxedAvatar
-  in [Avatar] profileAvatar
+  in [AvatarShare] boxedAvatar
+  in [AvatarShare] profileAvatar
   //
-  in [UserName] profileUserName
-  in [UserName] boxedUserName
+  in [UserNameShare] profileUserName
+  in [UserNameShare] boxedUserName
 
 recipe Sharing
   use 'PROFILE_avatar' as profileAvatar

--- a/particles/Profile/UserName.schema
+++ b/particles/Profile/UserName.schema
@@ -1,3 +1,6 @@
 schema UserName
   Text userName
 
+import 'Share.schema'
+schema UserNameShare extends Share
+  Reference<UserName> ref

--- a/shells/configuration/constants.js
+++ b/shells/configuration/constants.js
@@ -18,7 +18,8 @@ export const Const = {
   LOCALSTORAGE: {
     user: `${version}-user`,
     storage: `${version}-storage`,
-    plannerStorage: `${version}-plannerStorage`
+    plannerStorage: `${version}-plannerStorage`,
+    userHistory: `${version}-userHistory`
   },
   SHARE: {
     private: 1,

--- a/shells/configuration/constants.js
+++ b/shells/configuration/constants.js
@@ -1,4 +1,4 @@
-const version = '0_6_0';
+const version = '0_7_0';
 const firebase = `firebase://arcs-storage.firebaseio.com/AIzaSyBme42moeI-2k8WgXh-6YK_wYyjEXo4Oz8/${version}`;
 const pouchdb = `pouchdb://local/arcs/${version}`;
 const volatile = 'volatile://';

--- a/shells/lib/components/context/context-listeners.js
+++ b/shells/lib/components/context/context-listeners.js
@@ -82,6 +82,12 @@ export const ShareListener = class extends AbstractListener {
     return logFactory(`ShareListener`, 'blue');
   }
   async add(entity, store) {
+    // TODO(sjmiles): roll this into 'metrics'?
+    let backingStorageKey = store.storageKey;
+    if (store.backingStore) {
+      // TODO(sjmiles): property is not called 'storageKey' for pouchdb
+      backingStorageKey = store.backingStore.storageKey;
+    }
     const handle = store.handle;
     const metrics = ContextStores.getHandleMetrics(handle, this.isProfile);
     if (metrics) {
@@ -98,7 +104,7 @@ export const ShareListener = class extends AbstractListener {
         share.shareStorePromise = ContextStores.getShareStore(this.context, metrics.type, metrics.storeName, metrics.storeId, ['shared']);
       }
       const shareStore = await share.shareStorePromise;
-      ContextStores.storeEntityWithUid(shareStore, entity, userid);
+      ContextStores.storeEntityWithUid(shareStore, entity, backingStorageKey, userid);
       //
       let box = boxes[metrics.boxStoreId];
       if (!box) {
@@ -106,7 +112,7 @@ export const ShareListener = class extends AbstractListener {
         box.boxStorePromise = ContextStores.getShareStore(this.context, metrics.type, metrics.boxStoreId, metrics.boxStoreId, ['shared']);
       }
       const boxStore = await box.boxStorePromise;
-      ContextStores.storeEntityWithUid(boxStore, entity, userid);
+      ContextStores.storeEntityWithUid(boxStore, entity, backingStorageKey, userid);
     }
   }
   async remove(entity, store) {

--- a/shells/lib/components/context/context-listeners.js
+++ b/shells/lib/components/context/context-listeners.js
@@ -46,7 +46,11 @@ const AbstractListener = class {
 };
 
 export const ArcHandleListener = class extends AbstractListener {
+  createLogger() {
+    return logFactory(`ArcHandleListener`, `#4040FF`);
+  }
   async add(handle) {
+    //this.log('add', handle);
     const store = await SyntheticStores.getHandleStore(handle);
     // TODO(sjmiles): sketchy
     store.handle = handle;
@@ -82,6 +86,7 @@ export const ShareListener = class extends AbstractListener {
     return logFactory(`ShareListener`, 'blue');
   }
   async add(entity, store) {
+    //this.log('add', entity);
     // TODO(sjmiles): roll this into 'metrics'?
     let backingStorageKey = store.storageKey;
     if (store.backingStore) {
@@ -116,7 +121,7 @@ export const ShareListener = class extends AbstractListener {
     }
   }
   async remove(entity, store) {
-    this.log('removing entity', entity);
+    //this.log('removing entity', entity);
     const {base: userid} = crackStorageKey(store.storageKey);
     const metrics = ContextStores.getHandleMetrics(store.handle, this.isProfile);
     if (metrics) {
@@ -145,6 +150,7 @@ export const ProfileListener = class extends ShareListener {
     return (simpleNameOfType(store.type) === 'Friend' && store.type.isCollection);
   }
   async add(entity, store) {
+    //this.log('add', entity);
     await super.add(entity, store);
     if (this.isFriendStore(store)) {
       const launcher = await getLauncherStore(entity.rawData.publicKey);

--- a/shells/lib/components/context/context-stores.js
+++ b/shells/lib/components/context/context-stores.js
@@ -7,7 +7,13 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {crackStorageKey} from './context-utils.js';
+import {crackStorageKey, simpleNameOfType} from './context-utils.js';
+import {Reference} from '../../../../build/runtime/reference.js';
+import {Type} from '../../../../build/runtime/type.js';
+import {logFactory} from '../../../../build/platform/log-web.js';
+import {generateId} from '../../../../modalities/dom/components/generate-id.js';
+
+const log = logFactory('ContextStores', 'lime');
 
 const pendingStores = {};
 
@@ -31,12 +37,12 @@ const ContextStoresImpl = class {
     // cache and return promises in case of re-entrancy
     let promise = pendingStores[id];
     if (!promise) {
-      promise = new Promise(async (resolve) => {
+      promise = new Promise(async resolve => {
         const store = await context.findStoreById(id);
         if (store) {
           resolve(store);
         } else {
-          const store = await context.createStore(type, name, id, tags);
+          const store = await this.createReferenceStore(context, type, name, id, tags);
           resolve(store);
         }
       });
@@ -47,15 +53,49 @@ const ContextStoresImpl = class {
   getDecoratedId(entity, uid) {
     return `${entity.id}:uid:${uid}`;
   }
-  async storeEntityWithUid(store, entity, uid) {
-    const id = this.getDecoratedId(entity, uid);
-    const decoratedEntity = {id, rawData: entity.rawData};
-    // context stores are always Collection
-    store.store(decoratedEntity, [String(Math.random())]);
+  async storeEntityWithUid(store, entity, backingStorageKey, uid) {
+    this.storeEntityReference(store, entity, backingStorageKey, uid);
   }
   removeEntityWithUid(store, entity, uid) {
-    const id = this.getDecoratedId(entity, uid);
-    store.remove(id);
+    // TODO(sjmiles): implement
+    //const id = this.getDecoratedId(entity, uid);
+    //store.remove(id);
+  }
+  async createReferenceStore(context, type, name, id, tags) {
+    const shareType = this.generateReferenceType(type).collectionOf();
+    const store = await context.createStore(shareType, name, `${id}Ref`, tags);
+    return store;
+  }
+  async storeEntityReference(store, entity, backingStorageKey, uid) {
+    // TODO(sjmiles): storageKey will be baked into entity in future
+    entity.storageKey = backingStorageKey;
+    const ref = new Reference(entity);
+    await ref.stored;
+    const refEntity = {
+      id: generateId(),
+      rawData: {
+        ref: ref,
+        fromKey: uid
+      }
+    };
+    store.store(refEntity, [String(Math.random())]);
+  }
+  generateReferenceType(type) {
+    // TODO(sjmiles): note there need to be matching* types in Particles
+    // (*matching is fuzzy based on the current capabilities of the type system)
+    const refType = simpleNameOfType(type);
+    const literalShareType = {
+      tag: `Entity`,
+      data: {
+        names: [`${refType}Share`],
+        fields: {
+          entity: `Reference<${refType}>`,
+          fromKey: `Text`,
+          fromArc: `Text`
+        }
+      }
+    };
+    return Type.fromLiteral(literalShareType);
   }
 };
 

--- a/shells/lib/components/context/context-stores.js
+++ b/shells/lib/components/context/context-stores.js
@@ -57,9 +57,7 @@ const ContextStoresImpl = class {
     this.storeEntityReference(store, entity, backingStorageKey, uid);
   }
   removeEntityWithUid(store, entity, uid) {
-    // TODO(sjmiles): implement
-    //const id = this.getDecoratedId(entity, uid);
-    //store.remove(id);
+    store.remove(`shared-${entity.id}`);
   }
   async createReferenceStore(context, type, name, id, tags) {
     const shareType = this.generateReferenceType(type).collectionOf();
@@ -72,7 +70,7 @@ const ContextStoresImpl = class {
     const ref = new Reference(entity);
     await ref.stored;
     const refEntity = {
-      id: generateId(),
+      id: `shared-${entity.id}`,
       rawData: {
         ref: ref,
         fromKey: uid

--- a/shells/lib/components/context/store-observer.js
+++ b/shells/lib/components/context/store-observer.js
@@ -26,11 +26,13 @@ export class StoreObserver {
     // dispose should await a ready condition
     this._connect(store);
   }
-  async _connect(store, resolveReady) {
+  async _connect(store) {
+    //this.log('connect', store);
+    const observe = change => this.onChange(change);
     // observe addition of all entities
-    await simulateInitialChanges(store, change => this.onChange(change));
+    await simulateInitialChanges(store, observe);
     // observe future changes (and record ability to stop observation)
-    this.off = listenToStore(store, change => this.onChange(change));
+    this.off = listenToStore(store, observe);
     // notify that connection is ready
     this._resolveReady();
   }
@@ -45,25 +47,20 @@ export class StoreObserver {
     await forEachEntity(this.store, value => this.remove(value));
   }
   async onChange(change) {
-    //this.log('onChange', change);
+    //this.log('onChange', change, this.listener);
     const {add, remove, data} = change;
     if (data) {
-      // TODO(sjmiles): strip off version indicator (kosher?)
-      //data.id = data.id.split(':').slice(0, -1).join(':');
-      //this.log('removed version tag from data.id', data.id);
       this.add(data);
     }
     if (add) {
       for (let i=0, record; (record=add[i]); i++) {
         await this.add(record.value);
       }
-      //add.forEach(({value}) => this.add(value));
     }
     if (remove) {
       for (let i=0, record; (record=remove[i]); i++) {
         await this.remove(record.value);
       }
-      //remove.forEach(({value}) => this.remove(value));
     }
   }
   async add(value) {

--- a/shells/lib/elements/launcher-arc.js
+++ b/shells/lib/elements/launcher-arc.js
@@ -26,7 +26,7 @@ const log = logFactory('LauncherArc', '#cb23a6');
 const LauncherArcElement = class extends ArcElement {
   // get config() {
   //   return {
-  //     id: `${userid}${Const.launcherSuffix}`,
+  //     id: `${userid}${Const.DEFAULT.launcherSuffix}`,
   //     manifest: manifests.launcher
   //   };
   // }

--- a/shells/web-shell/README.md
+++ b/shells/web-shell/README.md
@@ -1,28 +1,38 @@
-## web-shell Flags
+# web-shell Flags
 
-e.g. https://polymerlabs.github.io/arcs-live/shells/web-shell/?storage=pouchdb&user=barney
+e.g. https://polymerlabs.github.io/arcs-live/shells/web-shell/?storage=$firebase/scott
 
-### Setting Storage Provider
+## Setting User-Persona/Storage-Key
+
+### Today, the User-Persona is identified exactly by a Storage-Key: you are where your stuff is.
+
+* persona=[storage-key]
+  * use `storage-key`
+
+#### To create a custom Persona for one of the existing servers, macros are provided:
+
+* persona=$firebase/[name]
+  * appends [name] to the arcs-owned firebase instance key, e.g. firebase://arcs-storage.firebaseio.com.../[name]
+* persona=$pouchdb/[name]
+  * appends [name] to the default pouchdb key, e.g. pouchdb://local/arcs/[name]
+
+#### other options:
 
 * no flag
   * use the same storage as last time, otherwise `default`
-* storage=pouchdb
+* persona=pouchdb
   * local pouch storage, e.g. pouchdb://local/arcs
-* storage=firebase
+* persona=firebase
   * arcs-owned firebase instance, e.g. firebase://arcs-storage.firebaseio.com...
-* storage=default
+* persona=default
   * use the default (currently `pouchdb`)
-* storage=[storage-key]
-  * use `storage-key`
 
-### User
+#### Aliases
 
-* no flag
-  * use the same user as last time, otherwise `user`
-* user=[user]
-  * use `[user]`, created as needed
+* storage=...
+  * For backward compatibility, you can use `storage` in place of `persona`.
 
-### Logging
+## Logging
 
 * no flag
   * set logging level to 0

--- a/shells/web-shell/elements/ui/panel-ui.js
+++ b/shells/web-shell/elements/ui/panel-ui.js
@@ -84,13 +84,19 @@ const template = Xen.Template.html`
     }
     settings-panel {
       display: none;
-      padding: 24px;
+      padding: 0 24px;
     }
     settings-panel[open] {
       display: block;
     }
-    settings-panel > pre {
+    settings-panel pre {
       white-space: pre-wrap;
+      margin: 0.5em 0;
+    }
+    settings-panel h3 {
+      font-size: 1em;
+      margin-block-start: 1em;
+      margin-block-end: 0em;
     }
   </style>
   <div toolbars on-click="onToolbarsClick">
@@ -115,7 +121,7 @@ const template = Xen.Template.html`
       <slot on-plan-choose="onChooseSuggestion"></slot>
     </div>
     <settings-panel settings content open$="{{settingsContentOpen}}" key="{{key}}" arc="{{arc}}" users="{{users}}" user="{{user}}" friends="{{friends}}" avatars="{{avatars}}" share="{{share}}" user_picker_open="{{userPickerOpen}}" on-user="onSelectUser" on-share="onShare" on-click="onSettingsPanelClick">
-      <pre unsafe-html="{{settings}}"></pre>
+      <div unsafe-html="{{settings}}"></div>
     </settings-panel>
   </div>
 `;
@@ -166,9 +172,14 @@ export class PanelUi extends Xen.Debug(Xen.Async, log) {
       return short;
     });
     return Xen.html`
-<select><option>${users.join('</option><option>')}</option></select>
+<h3>Version</h3>
+<pre>${WebConfig.config.version}</pre>
 <h3>Storage</h3>
-<div>${WebConfig.config.storage}</div>
+<pre>${WebConfig.config.storage}</pre>
+<h3>Planner Storage</h3>
+<pre>${WebConfig.config.plannerStorage}</pre>
+<h3>Recent Users</h3>
+<select><option>${users.join('</option><option>')}</option></select>
     `;
   }
   commitSearch(search) {

--- a/shells/web-shell/elements/ui/panel-ui.js
+++ b/shells/web-shell/elements/ui/panel-ui.js
@@ -114,7 +114,7 @@ const template = Xen.Template.html`
     <div suggestions content open$="{{suggestionsContentOpen}}">
       <slot on-plan-choose="onChooseSuggestion"></slot>
     </div>
-    <settings-panel settings content open$="{{settingsContentOpen}}" key="{{key}}" arc="{{arc}}" users="{{users}}" user="{{user}}" friends="{{friends}}" avatars="{{avatars}}" share="{{share}}" user_picker_open="{{userPickerOpen}}" on-user="onSelectUser" on-share="onShare">
+    <settings-panel settings content open$="{{settingsContentOpen}}" key="{{key}}" arc="{{arc}}" users="{{users}}" user="{{user}}" friends="{{friends}}" avatars="{{avatars}}" share="{{share}}" user_picker_open="{{userPickerOpen}}" on-user="onSelectUser" on-share="onShare" on-click="onSettingsPanelClick">
       <pre unsafe-html="{{settings}}"></pre>
     </settings-panel>
   </div>
@@ -161,6 +161,7 @@ export class PanelUi extends Xen.Debug(Xen.Async, log) {
   renderSettings() {
     //return JSON.stringify(WebConfig.config, null, '  ');
     return Xen.html`
+<select><option>${WebConfig.config.userHistory.join('</option><option>')}</option></select>
 <h3>Storage</h3>
 <div>${WebConfig.config.storage}</div>
     `;
@@ -181,6 +182,9 @@ export class PanelUi extends Xen.Debug(Xen.Async, log) {
   onContentsClick(e) {
     e.stopPropagation();
     this.fire('open', false);
+  }
+  onSettingsPanelClick(e) {
+    e.stopPropagation();
   }
   onSearchChange(e) {
     const search = e.target.value;

--- a/shells/web-shell/elements/ui/panel-ui.js
+++ b/shells/web-shell/elements/ui/panel-ui.js
@@ -160,8 +160,13 @@ export class PanelUi extends Xen.Debug(Xen.Async, log) {
   }
   renderSettings() {
     //return JSON.stringify(WebConfig.config, null, '  ');
+    const users = WebConfig.config.userHistory.map(url => {
+      const parts = url.split('/');
+      const short = `${parts.slice(0, 3).join('/')}...${parts.slice(-1).join('/')}`;
+      return short;
+    });
     return Xen.html`
-<select><option>${WebConfig.config.userHistory.join('</option><option>')}</option></select>
+<select><option>${users.join('</option><option>')}</option></select>
 <h3>Storage</h3>
 <div>${WebConfig.config.storage}</div>
     `;

--- a/shells/web-shell/elements/ui/panel-ui.js
+++ b/shells/web-shell/elements/ui/panel-ui.js
@@ -178,8 +178,8 @@ export class PanelUi extends Xen.Debug(Xen.Async, log) {
 <pre>${WebConfig.config.storage}</pre>
 <h3>Planner Storage</h3>
 <pre>${WebConfig.config.plannerStorage}</pre>
-<h3>Recent Users</h3>
-<select><option>${users.join('</option><option>')}</option></select>
+<!-- <h3>Recent Users</h3>
+<select><option>${users.join('</option><option>')}</option></select> -->
     `;
   }
   commitSearch(search) {

--- a/shells/web-shell/elements/web-config.js
+++ b/shells/web-shell/elements/web-config.js
@@ -66,6 +66,7 @@ export class WebConfig extends Xen.Debug(Xen.Async, log) {
     if (!config) {
       const params = (new URL(document.location)).searchParams;
       config = ProcessConfig.processConfig(configOptions, params);
+      config.version = Const.version;
       config.plannerDebug = !config.plannerNoDebug;
       config.userid = Const.DEFAULT.userId;
       config.storage = this.expandStorageMacro(config.storage);

--- a/shells/web-shell/elements/web-config.js
+++ b/shells/web-shell/elements/web-config.js
@@ -14,13 +14,15 @@ import {Const} from '../../configuration/constants.js';
 const log = Xen.logFactory('WebConfig', '#60ac66');
 
 const configOptions = {
-  //configPropertyName: {
-  //  aliases: [...] // aliases for configPropertyName
-  //  default: ... // default value
-  //  map: { ... } // map human parameter names to actual config values
-  //  localStorageKey: "..." // key for persisting to/from localStorage
-  //  persistToUrl: <Boolean> // whether parameter should be written into URL
-  //},
+  /*
+    configPropertyName: {
+      aliases: [...] // aliases for configPropertyName
+      default: ... // default value
+      map: { ... } // map human parameter names to actual config values
+      localStorageKey: "..." // key for persisting to/from localStorage
+      persistToUrl: <Boolean> // whether parameter should be written into URL
+    }
+  */
   storage: {
     aliases: ['storageKey'],
     default: Const.DEFAULT.storageKey,
@@ -33,11 +35,6 @@ const configOptions = {
     },
     localStorageKey: Const.LOCALSTORAGE.storage
   },
-  userid: {
-    aliases: ['user'],
-    default: Const.DEFAULT.userId,
-    localStorageKey: Const.LOCALSTORAGE.user
-  },
   arc: {
     aliases: ['arckey'],
     persistToUrl: true
@@ -45,8 +42,9 @@ const configOptions = {
   search: {
   },
   plannerStorage: {
-    localStorageKey: Const.LOCALSTORAGE.plannerStorage,
-    default: Const.DEFAULT.plannerStorageKey
+    aliases: ['planner'],
+    default: Const.DEFAULT.plannerStorageKey,
+    localStorageKey: Const.LOCALSTORAGE.plannerStorage
   },
   plannerNoDebug: {
     boolean: true
@@ -58,21 +56,19 @@ const configOptions = {
 
 export class WebConfig extends Xen.Debug(Xen.Async, log) {
   static get observedAttributes() {
-    return ['userid', 'arckey'];
+    return ['arckey'];
   }
-  update({userid, arckey}, state) {
+  update({arckey}, state) {
     if (!state.config) {
       const params = (new URL(document.location)).searchParams;
       state.config = ProcessConfig.processConfig(configOptions, params);
       state.config.plannerDebug = !state.config.plannerNoDebug;
       state.config.storage = this.expandStorageMacro(state.config.storage);
+      state.config.userid = Const.DEFAULT.userId;
       this._fire('config', state.config);
     }
     if (arckey !== undefined) {
       state.config.arc = arckey;
-    }
-    if (userid !== undefined) {
-      state.config.userid = userid;
     }
     ProcessConfig.persistParams(configOptions, state.config);
     // TODO(sjmiles): only works if config is a Highlander

--- a/shells/web-shell/elements/web-config.js
+++ b/shells/web-shell/elements/web-config.js
@@ -24,7 +24,7 @@ const configOptions = {
     }
   */
   storage: {
-    aliases: ['storageKey'],
+    aliases: ['storageKey', 'user'],
     default: Const.DEFAULT.storageKey,
     map: {
       'firebase': Const.DEFAULT.firebaseStorageKey,
@@ -34,6 +34,10 @@ const configOptions = {
       'default': Const.DEFAULT.storageKey
     },
     localStorageKey: Const.LOCALSTORAGE.storage
+  },
+  userHistoryJson: {
+    default: '[]',
+    localStorageKey: Const.LOCALSTORAGE.userHistory
   },
   arc: {
     aliases: ['arckey'],
@@ -58,22 +62,33 @@ export class WebConfig extends Xen.Debug(Xen.Async, log) {
   static get observedAttributes() {
     return ['arckey'];
   }
-  update({arckey}, state) {
-    if (!state.config) {
+  update({arckey}, {config}) {
+    if (!config) {
       const params = (new URL(document.location)).searchParams;
-      const config = ProcessConfig.processConfig(configOptions, params);
+      config = ProcessConfig.processConfig(configOptions, params);
       config.plannerDebug = !config.plannerNoDebug;
       config.userid = Const.DEFAULT.userId;
       config.storage = this.expandStorageMacro(config.storage);
-      state.config = config;
-      this._fire('config', config);
+      this.state = {config};
     }
     if (arckey !== undefined) {
-      state.config.arc = arckey;
+      config.arc = arckey;
     }
-    ProcessConfig.persistParams(configOptions, state.config);
-    // TODO(sjmiles): only works if config is a Highlander
-    WebConfig.config = state.config;
+    this.updateUserHistory(config);
+    log(config.userHistory);
+    ProcessConfig.persistParams(configOptions, config);
+    // TODO(sjmiles): only works if config is Highlander
+    WebConfig.config = config;
+    this._fire('config', config);
+  }
+  updateUserHistory(config) {
+    const {userHistoryJson, storage} = config;
+    const userHistory = JSON.parse(userHistoryJson);
+    if (userHistory.indexOf(storage) < 0) {
+      userHistory.push(storage);
+    }
+    config.userHistory = userHistory;
+    config.userHistoryJson = JSON.stringify(userHistory);
   }
   // TODO(sjmiles): make this a ProcessConfig ability(?)
   // support some macros in storage keys

--- a/shells/web-shell/elements/web-config.js
+++ b/shells/web-shell/elements/web-config.js
@@ -61,11 +61,12 @@ export class WebConfig extends Xen.Debug(Xen.Async, log) {
   update({arckey}, state) {
     if (!state.config) {
       const params = (new URL(document.location)).searchParams;
-      state.config = ProcessConfig.processConfig(configOptions, params);
-      state.config.plannerDebug = !state.config.plannerNoDebug;
-      state.config.storage = this.expandStorageMacro(state.config.storage);
-      state.config.userid = Const.DEFAULT.userId;
-      this._fire('config', state.config);
+      const config = ProcessConfig.processConfig(configOptions, params);
+      config.plannerDebug = !config.plannerNoDebug;
+      config.userid = Const.DEFAULT.userId;
+      config.storage = this.expandStorageMacro(config.storage);
+      state.config = config;
+      this._fire('config', config);
     }
     if (arckey !== undefined) {
       state.config.arc = arckey;

--- a/shells/web-shell/elements/web-config.js
+++ b/shells/web-shell/elements/web-config.js
@@ -24,7 +24,7 @@ const configOptions = {
     }
   */
   storage: {
-    aliases: ['storageKey', 'user'],
+    aliases: ['storageKey', 'persona'],
     default: Const.DEFAULT.storageKey,
     map: {
       'firebase': Const.DEFAULT.firebaseStorageKey,

--- a/src/runtime/dom-particle-base.ts
+++ b/src/runtime/dom-particle-base.ts
@@ -270,7 +270,15 @@ export class DomParticleBase extends Particle {
   /**
    * Returns array of Entities found in BOXED data `box` that are owned by `userid`
    */
-  boxQuery(box, userid: string) {
-    return box && box.filter(item => userid === item.getUserID().split('|')[0]);
+  async boxQuery(box, userid) {
+    let results = [];
+    if (box) {
+      const matches = box.filter(item => userid === item.fromKey);
+      results = await Promise.all(matches.map(async match => {
+        await match.ref.dereference();
+        return match.ref.entity;
+      }));
+    }
+    return results;
   }
 }

--- a/src/runtime/particle-execution-host.ts
+++ b/src/runtime/particle-execution-host.ts
@@ -139,7 +139,7 @@ export class ParticleExecutionHost {
         //
         // Without an auditor on the runtime side that inspects what is being fetched from
         // this store, particles with a reference can access any data of that reference's type.
-        this.GetBackingStoreCallback(store, callback, type.collectionOf(), type.toString(), store.id, storageKey);
+        this.GetBackingStoreCallback(store, callback, type.collectionOf(), type.toString(), String(Math.random())/*store.id*/, storageKey);
       }
 
       onConstructInnerArc(callback: number, particle: Particle) {

--- a/src/runtime/particle-execution-host.ts
+++ b/src/runtime/particle-execution-host.ts
@@ -139,7 +139,9 @@ export class ParticleExecutionHost {
         //
         // Without an auditor on the runtime side that inspects what is being fetched from
         // this store, particles with a reference can access any data of that reference's type.
-        this.GetBackingStoreCallback(store, callback, type.collectionOf(), type.toString(), String(Math.random())/*store.id*/, storageKey);
+        //
+        // TOODO(sjmiles): randomizing the id as a workaround for https://github.com/PolymerLabs/arcs/issues/2936
+        this.GetBackingStoreCallback(store, callback, type.collectionOf(), type.toString(), `${store.id}:${`String(Math.random())`.slice(2, 9)}`, storageKey);
       }
 
       onConstructInnerArc(callback: number, particle: Particle) {


### PR DESCRIPTION
Previously when an Entity was shared from user A to user B, the Entity was copied and it's id was decorated with provenance information, e.g. the source User and source Arc. 

In this PR, shared Entities are presented using share-types that encode a reference to the original Entity and provenance data as proper fields.

For example, `AvatarShare` entities look like:

```
schema AvatarShare extends Share
  Reference<Avatar> ref
  Text fromUser
  Text fromArc
```

Using the references avoids duplication of data in the BackingStore, removes hacky id-encoding, and avoids fetching the contents of `ref` until explicit dereference.  Also, using References.