### PR TITLE
Type Cleanups, focused mostly on Slots and Particles

### DIFF
--- a/src/runtime/arc.ts
+++ b/src/runtime/arc.ts
@@ -32,7 +32,7 @@ import {PecFactory} from './particle-execution-context.js';
 import {InterfaceInfo} from './interface-info.js';
 import {Mutex} from './mutex.js';
 
-type ArcOptions = {
+type ArcOptions = Readonly<{
   id: Id;
   context: Manifest;
   pecFactory?: PecFactory;
@@ -44,9 +44,9 @@ type ArcOptions = {
   innerArc?: boolean;
   stub?: boolean
   listenerClasses?: ArcDebugListenerDerived[];
-};
+}>;
 
-type DeserializeArcOptions = {
+type DeserializeArcOptions = Readonly<{
   serialization: string;
   pecFactory?: PecFactory;
   slotComposer?: SlotComposer;
@@ -54,7 +54,7 @@ type DeserializeArcOptions = {
   fileName: string;
   context: Manifest;
   listenerClasses?: ArcDebugListenerDerived[];
-};
+}>;
 
 export type PlanCallback = (recipe: Recipe) => void;
 
@@ -147,7 +147,7 @@ export class Arc {
     return false;
   }
 
-  dispose() {
+  dispose(): void {
     for (const innerArc of this.innerArcs) {
       innerArc.dispose();
     }
@@ -167,7 +167,7 @@ export class Arc {
 
   // Returns a promise that spins sending a single `AwaitIdle` message until it
   // sees no other messages were sent.
-  async _waitForIdle() {
+  async _waitForIdle(): Promise<void> {
     while (true) {
       const messageCount = this.pec.messageCount;
       const innerArcs = this.innerArcs;
@@ -382,7 +382,7 @@ ${this.activeRecipe.toString()}`;
   // Writes `serialization` to the ArcInfo child key under the Arc's storageKey.
   // This does not directly use serialize() as callers may want to modify the
   // contents of the serialized arc before persisting.
-  async persistSerialization(serialization: string) {
+  async persistSerialization(serialization: string): Promise<void> {
     const storage = this.storageProviderFactory;
     const key = storage.parseStringAsKey(this.storageKey).childKeyForArcInfo();
     const arcInfoType = new ArcType();
@@ -422,9 +422,9 @@ ${this.activeRecipe.toString()}`;
     return this._context;
   }
 
-  get activeRecipe() { return this._activeRecipe; }
-  get allRecipes() { return [this.activeRecipe].concat(this.context.allRecipes); }
-  get recipes() { return [this.activeRecipe]; }
+  get activeRecipe(): Recipe { return this._activeRecipe; }
+  get allRecipes(): Recipe[] { return [this.activeRecipe].concat(this.context.allRecipes); }
+  get recipes(): Recipe[] { return [this.activeRecipe]; }
   get recipeDeltas() { return this._recipeDeltas; }
 
   loadedParticleSpecs() {
@@ -448,7 +448,7 @@ ${this.activeRecipe.toString()}`;
     this.pec.instantiate(recipeParticle, info.stores);
   }
 
-  async _provisionSpecUrl(spec: ParticleSpec) {
+  private async _provisionSpecUrl(spec: ParticleSpec): Promise<void> {
     if (!spec.implBlobUrl) {
       // if supported, construct spec.implBlobUrl for spec.implFile
       if (this.loader && this.loader['provisionObjectUrl']) {
@@ -466,7 +466,7 @@ ${this.activeRecipe.toString()}`;
   }
 
   // Makes a copy of the arc used for speculative execution.
-  async cloneForSpeculativeExecution() {
+  async cloneForSpeculativeExecution(): Promise<Arc> {
     const arc = new Arc({id: this.generateID(),
                          pecFactory: this.pecFactory,
                          context: this.context,
@@ -628,7 +628,7 @@ ${this.activeRecipe.toString()}`;
     this.debugHandler.recipeInstantiated({particles, activeRecipe: this.activeRecipe.toString()});
   }
 
-  async createStore(type: Type, name?: string, id?: string, tags?: string[], storageKey: string = undefined) {
+  async createStore(type: Type, name?: string, id?: string, tags?: string[], storageKey: string = undefined): Promise<StorageProviderBase> {
     assert(type instanceof Type, `can't createStore with type ${type} that isn't a Type`);
 
     if (type instanceof RelationType) {
@@ -660,7 +660,7 @@ ${this.activeRecipe.toString()}`;
     return store;
   }
 
-  _registerStore(store: StorageProviderBase, tags?: string[]) {
+  _registerStore(store: StorageProviderBase, tags?: string[]): void {
     assert(!this.storesById.has(store.id), `Store already registered '${store.id}'`);
     tags = tags || [];
     tags = Array.isArray(tags) ? tags : [tags];
@@ -804,11 +804,11 @@ ${this.activeRecipe.toString()}`;
     return results.join('\n');
   }
 
-  get apiChannelMappingId() {
+  get apiChannelMappingId(): string {
     return this.id.toString();
   }
 
-  get idGeneratorForTesting() {
+  get idGeneratorForTesting(): IdGenerator {
     return this.idGenerator;
   }
 }

--- a/src/runtime/arc.ts
+++ b/src/runtime/arc.ts
@@ -422,9 +422,9 @@ ${this.activeRecipe.toString()}`;
     return this._context;
   }
 
-  get activeRecipe(): Recipe { return this._activeRecipe; }
-  get allRecipes(): Recipe[] { return [this.activeRecipe].concat(this.context.allRecipes); }
-  get recipes(): Recipe[] { return [this.activeRecipe]; }
+  get activeRecipe() { return this._activeRecipe; }
+  get allRecipes() { return [this.activeRecipe].concat(this.context.allRecipes); }
+  get recipes() { return [this.activeRecipe]; }
   get recipeDeltas() { return this._recipeDeltas; }
 
   loadedParticleSpecs() {
@@ -804,7 +804,7 @@ ${this.activeRecipe.toString()}`;
     return results.join('\n');
   }
 
-  get apiChannelMappingId(): string {
+  get apiChannelMappingId() {
     return this.id.toString();
   }
 

--- a/src/runtime/headless-slot-dom-consumer.ts
+++ b/src/runtime/headless-slot-dom-consumer.ts
@@ -10,6 +10,8 @@
 
 import {assert} from '../platform/assert-web.js';
 
+import {Arc} from './arc.js';
+import {SlotConnection} from './recipe/slot-connection.js';
 import {SlotDomConsumer} from './slot-dom-consumer.js';
 
 export class HeadlessSlotDomConsumer extends SlotDomConsumer {
@@ -17,7 +19,7 @@ export class HeadlessSlotDomConsumer extends SlotDomConsumer {
   contentAvailable;
   _contentAvailableResolve;
 
-  constructor(arc, consumeConn) {
+  constructor(arc: Arc, consumeConn: SlotConnection) {
     super(arc, consumeConn);
     this._content = {};
     this.contentAvailable = new Promise(resolve => this._contentAvailableResolve = resolve);

--- a/src/runtime/particle-execution-context.ts
+++ b/src/runtime/particle-execution-context.ts
@@ -152,7 +152,7 @@ export class ParticleExecutionContext {
         return new Promise((resolve, reject) =>
           pec.apiPort.ArcMapHandle(id => {
             resolve(id);
-          }, arcId, handle));
+          }, arcId, handle));  // recipe handle vs not?
       },
       createSlot(transformationParticle, transformationSlotName, handleId) {
         // handleId: the ID of a handle (returned by `createHandle` above) this slot is rendering; null - if not applicable.

--- a/src/runtime/particle-spec.ts
+++ b/src/runtime/particle-spec.ts
@@ -65,16 +65,16 @@ export class HandleConnectionSpec {
     }
   }
 
-  get isInput(): boolean {
+  get isInput() {
     // TODO: we probably don't really want host to be here.
     return this.direction === 'in' || this.direction === 'inout' || this.direction === 'host';
   }
 
-  get isOutput(): boolean {
+  get isOutput() {
     return this.direction === 'out' || this.direction === 'inout';
   }
 
-  isCompatibleType(type: Type): boolean {
+  isCompatibleType(type: Type) {
     return TypeChecker.compareTypes({type}, {type: this.type, direction: this.direction});
   }
 }
@@ -218,7 +218,7 @@ export class ParticleSpec {
     return this.slotConnections.get(slotName);
   }
 
-  get primaryVerb(): string {
+  get primaryVerb(): string|undefined {
     return (this.verbs.length > 0) ? this.verbs[0] : undefined;
   }
 

--- a/src/runtime/particle-spec.ts
+++ b/src/runtime/particle-spec.ts
@@ -57,25 +57,24 @@ export class HandleConnectionSpec {
     this.dependentConnections = [];
   }
 
-  instantiateDependentConnections(particle, typeVarMap: Map<string, Type>) {
+  instantiateDependentConnections(particle, typeVarMap: Map<string, Type>): void {
     for (const dependentArg of this.rawData.dependentConnections) {
       const dependentConnection = particle.createConnection(dependentArg, typeVarMap);
       dependentConnection.parentConnection = this;
       this.dependentConnections.push(dependentConnection);
     }
-
   }
 
-  get isInput() {
+  get isInput(): boolean {
     // TODO: we probably don't really want host to be here.
     return this.direction === 'in' || this.direction === 'inout' || this.direction === 'host';
   }
 
-  get isOutput() {
+  get isOutput(): boolean {
     return this.direction === 'out' || this.direction === 'inout';
   }
 
-  isCompatibleType(type: Type) {
+  isCompatibleType(type: Type): boolean {
     return TypeChecker.compareTypes({type}, {type: this.type, direction: this.direction});
   }
 }
@@ -116,10 +115,10 @@ export class ConsumeSlotConnectionSpec {
   }
 
   // Getters to 'fake' being a Handle.
-  get isOptional() { return !this.isRequired; }
-  get direction() { return '`consume'; }
-  get type() { return SlotType.make(this.formFactor, null); } //TODO(jopra): FIX THIS NULL!
-  get dependentConnections() { return this.provideSlotConnections; }
+  get isOptional(): boolean { return !this.isRequired; }
+  get direction(): string { return '`consume'; }
+  get type(): SlotType { return SlotType.make(this.formFactor, null); } //TODO(jopra): FIX THIS NULL!
+  get dependentConnections(): ProvideSlotConnectionSpec[] { return this.provideSlotConnections; }
 }
 
 export class ProvideSlotConnectionSpec extends ConsumeSlotConnectionSpec {}
@@ -178,7 +177,7 @@ export class ParticleSpec {
     });
   }
 
-  createConnection(arg: SerializedHandleConnectionSpec, typeVarMap: Map<string, Type>) {
+  createConnection(arg: SerializedHandleConnectionSpec, typeVarMap: Map<string, Type>): HandleConnectionSpec {
     const connection = new HandleConnectionSpec(arg, typeVarMap);
     this.handleConnectionMap.set(connection.name, connection);
     connection.instantiateDependentConnections(this, typeVarMap);
@@ -201,12 +200,12 @@ export class ParticleSpec {
     return this.connections.filter(a => a.isOutput);
   }
 
-  isInput(param: string) {
+  isInput(param: string): boolean {
     const connection = this.handleConnectionMap.get(param);
     return connection && connection.isInput;
   }
 
-  isOutput(param: string) {
+  isOutput(param: string): boolean {
     const connection = this.handleConnectionMap.get(param);
     return connection && connection.isOutput;
   }
@@ -219,7 +218,7 @@ export class ParticleSpec {
     return this.slotConnections.get(slotName);
   }
 
-  get primaryVerb() {
+  get primaryVerb(): string {
     return (this.verbs.length > 0) ? this.verbs[0] : undefined;
   }
 
@@ -227,11 +226,11 @@ export class ParticleSpec {
     return this.slotConnections.size === 0 || this.modality.intersection(modality).isResolved();
   }
 
-  setImplBlobUrl(url: string) {
+  setImplBlobUrl(url: string): void {
     this.model.implBlobUrl = this.implBlobUrl = url;
   }
 
-  toLiteral() : SerializedParticleSpec {
+  toLiteral(): SerializedParticleSpec {
     const {args, name, verbs, description, implFile, implBlobUrl, modality, slotConnections} = this.model;
     const connectionToLiteral : (input: SerializedHandleConnectionSpec) => SerializedHandleConnectionSpec =
       ({type, direction, name, isOptional, dependentConnections}) => ({type: asTypeLiteral(type), direction, name, isOptional, dependentConnections: dependentConnections.map(connectionToLiteral)});
@@ -239,7 +238,7 @@ export class ParticleSpec {
     return {args: argsLiteral, name, verbs, description, implFile, implBlobUrl, modality, slotConnections};
   }
 
-  static fromLiteral(literal: SerializedParticleSpec) {
+  static fromLiteral(literal: SerializedParticleSpec): ParticleSpec {
     let {args, name, verbs, description, implFile, implBlobUrl, modality, slotConnections} = literal;
     const connectionFromLiteral = ({type, direction, name, isOptional, dependentConnections}) =>
       ({type: asType(type), direction, name, isOptional, dependentConnections: dependentConnections ? dependentConnections.map(connectionFromLiteral) : []});
@@ -261,17 +260,17 @@ export class ParticleSpec {
     return spec;
   }
 
-  equals(other) {
+  equals(other): boolean {
     return JSON.stringify(this.toLiteral()) === JSON.stringify(other.toLiteral());
   }
 
-  validateDescription(description) {
+  validateDescription(description): void {
     Object.keys(description || []).forEach(d => {
       assert(['kind', 'location', 'pattern'].includes(d) || this.handleConnectionMap.has(d), `Unexpected description for ${d}`);
     });
   }
 
-  toInterface() {
+  toInterface(): InterfaceType {
     // TODO: wat do?
     assert(!this.slotConnections.size, 'please implement slots toInterface');
     const handles = this.model.args.map(({type, name, direction}) => ({type: asType(type), name, direction}));
@@ -279,7 +278,7 @@ export class ParticleSpec {
     return InterfaceType.make(this.name, handles, slots);
   }
 
-  toString() {
+  toString(): string {
     const results = [];
     let verbs = '';
     if (this.verbs.length > 0) {
@@ -354,7 +353,7 @@ export class ParticleSpec {
     return results.join('\n');
   }
 
-  toManifestString() {
+  toManifestString(): string {
     return this.toString();
   }
 }

--- a/src/runtime/particle.ts
+++ b/src/runtime/particle.ts
@@ -11,6 +11,7 @@
 import {BigCollection} from './handle.js';
 import {Collection} from './handle.js';
 import {Handle} from './handle.js';
+import {InnerArcHandle} from './particle-execution-context.js';
 import {HandleConnectionSpec, ParticleSpec} from './particle-spec.js';
 import {Relevance} from './relevance.js';
 import {SlotProxy} from './slot-proxy.js';
@@ -24,14 +25,14 @@ export class Particle {
     public spec: ParticleSpec;
     public readonly extraData: boolean;
     public readonly relevances: (Relevance | number)[] = [];
-    public handles: Map<string, Handle>;
+    public handles: ReadonlyMap<string, Handle>;
 
     private _idle: Promise<void> = Promise.resolve();
     private _idleResolver: (() => void);
     private _busy = 0;
 
     protected slotProxiesByName: Map<string, SlotProxy> = new Map();
-    private capabilities: {constructInnerArc?: Function};
+  private capabilities: {constructInnerArc?: (Particle) => Promise<InnerArcHandle>};
 
   constructor() {
     // Typescript only sees this.constructor as a Function type.
@@ -46,7 +47,7 @@ export class Particle {
    * This sets the capabilities for this particle.  This can only
    * be called once.
    */
-  setCapabilities(capabilities: {constructInnerArc?: Function}): void {
+  setCapabilities(capabilities: {constructInnerArc?: (particle: Particle) => Promise<InnerArcHandle>}): void {
     if (this.capabilities) {
       // Capabilities already set, throw an error.
       throw new Error('capabilities should only be set once');
@@ -63,7 +64,7 @@ export class Particle {
    *
    * @param handles a map from handle names to store handles.
    */
-  setHandles(handles: Map<string, Handle>) {
+  async setHandles(handles: ReadonlyMap<string, Handle>): Promise<void> {
   }
 
   /**
@@ -98,7 +99,7 @@ export class Particle {
    *  - removed: An Array of Entities removed from a Collection-backed Handle.
    */
   // tslint:disable-next-line: no-any
-  onHandleUpdate(handle: Handle, update: {data?: any, oldData?: any, added?: any, removed?: any, originator?: any}) {
+  async onHandleUpdate(handle: Handle, update: {data?: any, oldData?: any, added?: any, removed?: any, originator?: any}): Promise<void> {
   }
 
   /**
@@ -110,10 +111,10 @@ export class Particle {
    *
    * @param handle The Handle instance that was desynchronized.
    */
-  onHandleDesync(handle: Handle) {
+  async onHandleDesync(handle: Handle): Promise<void> {
   }
 
-  constructInnerArc() {
+  async constructInnerArc(): Promise<InnerArcHandle> {
     if (!this.capabilities.constructInnerArc) {
       throw new Error('This particle is not allowed to construct inner arcs');
     }
@@ -154,31 +155,31 @@ export class Particle {
     return this.spec.outputs;
   }
 
-  hasSlotProxy(name: string) {
+  hasSlotProxy(name: string): boolean {
     return this.slotProxiesByName.has(name);
   }
 
-  addSlotProxy(slotlet: SlotProxy) {
+  addSlotProxy(slotlet: SlotProxy): void {
     this.slotProxiesByName.set(slotlet.slotName, slotlet);
   }
 
-  removeSlotProxy(name: string) {
+  removeSlotProxy(name: string): void {
     this.slotProxiesByName.delete(name);
   }
 
   /**
    * Returns the slot with provided name.
    */
-  getSlot(name) {
+  getSlot(name: string): SlotProxy {
     return this.slotProxiesByName.get(name);
   }
 
   static buildManifest(strings: string[], ...bits): string {
-    const output:string[] = [];
+    const output: string[] = [];
     for (let i = 0; i < bits.length; i++) {
         const str = strings[i];
         const indent = / *$/.exec(str)[0];
-        let bitStr;
+        let bitStr: string;
         if (typeof bits[i] === 'string') {
           bitStr = bits[i];
         } else {
@@ -211,7 +212,7 @@ export class Particle {
   }
 
   // abstract
-  renderSlot(slotName: string, contentTypes: string[]) {}
-  renderHostedSlot(slotName: string, hostedSlotId: string, content: string) {}
-  fireEvent(slotName: string, event: {}) {}
+  renderSlot(slotName: string, contentTypes: string[]): void {}
+  renderHostedSlot(slotName: string, hostedSlotId: string, content: string): void {}
+  fireEvent(slotName: string, event: {}): void {}
 }

--- a/src/runtime/particle.ts
+++ b/src/runtime/particle.ts
@@ -21,18 +21,18 @@ import {SlotProxy} from './slot-proxy.js';
  * instead use DOMParticle.
  */
 export class Particle {
-    public static spec: ParticleSpec;
-    public spec: ParticleSpec;
-    public readonly extraData: boolean;
-    public readonly relevances: (Relevance | number)[] = [];
-    public handles: ReadonlyMap<string, Handle>;
+  public static spec: ParticleSpec;
+  public spec: ParticleSpec;
+  public readonly extraData: boolean;
+  public readonly relevances: (Relevance | number)[] = [];
+  public handles: ReadonlyMap<string, Handle>;
 
-    private _idle: Promise<void> = Promise.resolve();
-    private _idleResolver: (() => void);
-    private _busy = 0;
+  private _idle: Promise<void> = Promise.resolve();
+  private _idleResolver: (() => void);
+  private _busy = 0;
 
-    protected slotProxiesByName: Map<string, SlotProxy> = new Map();
-  private capabilities: {constructInnerArc?: (Particle) => Promise<InnerArcHandle>};
+  protected slotProxiesByName: Map<string, SlotProxy> = new Map();
+  private capabilities: {constructInnerArc?: (particle: Particle) => Promise<InnerArcHandle>};
 
   constructor() {
     // Typescript only sees this.constructor as a Function type.

--- a/src/runtime/reference.ts
+++ b/src/runtime/reference.ts
@@ -18,7 +18,7 @@ import {SerializedEntity} from './storage-proxy.js';
 enum ReferenceMode {Unstored, Stored}
 
 export class Reference implements Storable {
-  public entity = null;
+  public entity: Entity|null = null;
   public type: ReferenceType;
 
   protected readonly id: string;
@@ -26,6 +26,7 @@ export class Reference implements Storable {
   private readonly context: ParticleExecutionContext;
   private storageProxy = null;
   protected handle = null;
+
   constructor(data: {id: string, storageKey: string | null}, type: ReferenceType, context: ParticleExecutionContext) {
     this.id = data.id;
     this.storageKey = data.storageKey;
@@ -45,7 +46,7 @@ export class Reference implements Storable {
     }
   }
 
-  async dereference(): Promise<void> {
+  async dereference(): Promise<Entity|null> {
     assert(this.context, "Must have context to dereference");
 
     if (this.entity) {
@@ -93,7 +94,7 @@ export abstract class ClientReference extends Reference {
     this.mode = ReferenceMode.Stored;
   }
 
-  async dereference() {
+  async dereference(): Promise<Entity|null> {
     if (this.mode === ReferenceMode.Unstored) {
       return null;
     }

--- a/src/runtime/relevance.ts
+++ b/src/runtime/relevance.ts
@@ -20,7 +20,7 @@ export class Relevance {
 
   private constructor() {}
 
-  static create(arc: Arc, recipe: Recipe) {
+  static create(arc: Arc, recipe: Recipe): Relevance {
     const relevance = new Relevance();
     const versionByStore = arc.getVersionByStore({includeArc: true, includeContext: true});
     recipe.handles.forEach(handle => {
@@ -31,7 +31,7 @@ export class Relevance {
     return relevance;
   }
 
-  apply(relevance: ReadonlyMap<Particle, number[]>) {
+  apply(relevance: ReadonlyMap<Particle, number[]>): void {
     for (const key of relevance.keys()) {
       if (this.relevanceMap.has(key)) {
         this.relevanceMap.set(
@@ -42,7 +42,7 @@ export class Relevance {
     }
   }
 
-  calcRelevanceScore() {
+  calcRelevanceScore(): number {
     let relevance = 1;
     let hasNegative = false;
     for (const rList of this.relevanceMap.values()) {
@@ -56,7 +56,7 @@ export class Relevance {
   }
 
   // Returns false, if at least one of the particles relevance lists ends with a negative score.
-  isRelevant(plan: Recipe) {
+  isRelevant(plan: Recipe): boolean {
     const hasUi = plan.particles.some(p => Object.keys(p.consumedSlotConnections).length > 0);
     let rendersUi = false;
 
@@ -73,7 +73,7 @@ export class Relevance {
     return hasUi === rendersUi;
   }
 
-  static scaleRelevance(relevance: number) {
+  static scaleRelevance(relevance: number): number {
     if (relevance == undefined) {
       relevance = 5;
     }
@@ -82,7 +82,7 @@ export class Relevance {
     return relevance / 5;
   }
 
-  static particleRelevance(relevanceList: number[]) {
+  static particleRelevance(relevanceList: number[]): number {
     let relevance = 1;
     let hasNegative = false;
     relevanceList.forEach(r => {
@@ -95,7 +95,7 @@ export class Relevance {
     return relevance * (hasNegative ? -1 : 1);
   }
 
-  calcParticleRelevance(particle: Particle) {
+  calcParticleRelevance(particle: Particle): number {
     if (this.relevanceMap.has(particle)) {
       return Relevance.particleRelevance(this.relevanceMap.get(particle));
     }

--- a/src/runtime/schema.ts
+++ b/src/runtime/schema.ts
@@ -18,14 +18,14 @@ export class Schema {
   readonly names: string[];
   // tslint:disable-next-line: no-any
   readonly fields: {[index: string]: any};
-  description: {[index: string]: string};
+  description: {[index: string]: string} = {};
   isAlias: boolean;
 
   // tslint:disable-next-line: no-any
   constructor(names: string[], fields: {[index: string]: any}, description?) {
     this.names = names;
     this.fields = fields;
-    this.description = {};
+
     if (description) {
       description.description.forEach(desc => this.description[desc.name] = desc.pattern || desc.patterns[0]);
     }

--- a/src/runtime/slot-consumer.ts
+++ b/src/runtime/slot-consumer.ts
@@ -195,7 +195,7 @@ export class SlotConsumer {
     return this.innerContainerBySlotId[slotId];
   }
 
-  _initInnerSlotContainer(slotId, subId, container) {
+  _initInnerSlotContainer(slotId, subId, container): void {
     if (subId) {
       if (!this.innerContainerBySlotId[slotId]) {
         this.innerContainerBySlotId[slotId] = {};
@@ -206,7 +206,8 @@ export class SlotConsumer {
       this.innerContainerBySlotId[slotId] = container;
     }
   }
-  _clearInnerSlotContainers(subIds): void {
+
+  protected _clearInnerSlotContainers(subIds): void {
     subIds.forEach(subId => {
       if (subId) {
         Object.values(this.innerContainerBySlotId).forEach(inner => delete inner[subId]);
@@ -224,9 +225,9 @@ export class SlotConsumer {
   constructRenderRequest(): string[] { return []; }
   dispose(): void {}
   createNewContainer(contextContainer, subId): {} { return null; }
-  deleteContainer(container) {}
-  clearContainer(rendering) {}
-  setContainerContent(rendering, content: Content, subId) {}
+  deleteContainer(container): void {}
+  clearContainer(rendering): void {}
+  setContainerContent(rendering, content: Content, subId): void {}
   formatContent(content: Content, subId): Content { return null; }
   formatHostedContent(content: Content): {} { return null; }
   static clear(container): void {}

--- a/src/runtime/slot-context.ts
+++ b/src/runtime/slot-context.ts
@@ -28,12 +28,12 @@ export abstract class SlotContext {
     this.sourceSlotConsumer = sourceSlotConsumer;
   }
 
-  addSlotConsumer(slotConsumer: SlotConsumer) {
+  addSlotConsumer(slotConsumer: SlotConsumer): void {
     this.slotConsumers.push(slotConsumer);
     slotConsumer.slotContext = this;
   }
 
-  clearSlotConsumers() {
+  clearSlotConsumers(): void {
     this.slotConsumers.forEach(slotConsumer => slotConsumer.slotContext = null);
     this.slotConsumers.length = 0;
   }
@@ -69,7 +69,7 @@ export class HostedSlotContext extends SlotContext {
     transformationSlotConsumer.addHostedSlotContexts(this);
   }
 
-  onRenderSlot(consumer: SlotConsumer, content: Content, handler) {
+  onRenderSlot(consumer: SlotConsumer, content: Content, handler): void {
     this.sourceSlotConsumer.arc.pec.innerArcRender(
         this.sourceSlotConsumer.consumeConn.particle,
         this.sourceSlotConsumer.consumeConn.name,
@@ -77,7 +77,7 @@ export class HostedSlotContext extends SlotContext {
         consumer.formatHostedContent(content));
   }
 
-  addSlotConsumer(consumer: SlotConsumer) {
+  addSlotConsumer(consumer: SlotConsumer): void {
     super.addSlotConsumer(consumer);
     if (this.containerAvailable) consumer.startRender();
   }
@@ -136,10 +136,15 @@ export class ProvidedSlotContext extends SlotContext {
     consumer.setContent(content, handler);
   }
 
-  get container() { return this._container; }
-  get containerAvailable() { return !!this._container; }
+  get container(): HTMLElement {
+    return this._container;
+  }
 
-  static createContextForContainer(id, name, container, tags) {
+  get containerAvailable(): boolean {
+    return !!this._container;
+  }
+
+  static createContextForContainer(id, name, container, tags): ProvidedSlotContext {
     return new ProvidedSlotContext(id, name, tags, container, null);
   }
 
@@ -159,7 +164,7 @@ export class ProvidedSlotContext extends SlotContext {
     return (!container && !this.container) || (this.container === container);
   }
 
-  set container(container) {
+  set container(container: HTMLElement) {
     if (this.isSameContainer(container)) {
       return;
     }
@@ -169,7 +174,7 @@ export class ProvidedSlotContext extends SlotContext {
     this.slotConsumers.forEach(slotConsumer => slotConsumer.onContainerUpdate(this.container, originalContainer));
   }
 
-  addSlotConsumer(slotConsumer) {
+  addSlotConsumer(slotConsumer): void {
     super.addSlotConsumer(slotConsumer);
 
     if (this.container) {

--- a/src/runtime/slot-context.ts
+++ b/src/runtime/slot-context.ts
@@ -141,7 +141,7 @@ export class ProvidedSlotContext extends SlotContext {
   }
 
   get containerAvailable(): boolean {
-    return !!this._container;
+    return Boolean(this._container);
   }
 
   static createContextForContainer(id, name, container, tags): ProvidedSlotContext {

--- a/src/runtime/slot-dom-consumer.ts
+++ b/src/runtime/slot-dom-consumer.ts
@@ -21,8 +21,7 @@ export interface DomRendering extends Rendering {
   liveDom?: Template;
 }
 
-// tslint:disable-next-line: no-any
-const templateByName = new Map<string, any>();
+const templateByName = new Map<string, HTMLElement>();
 
 // this style sheet is installed in every particle shadow-root
 let commonStyleTemplate;
@@ -45,7 +44,7 @@ export class SlotDomConsumer extends SlotConsumer {
     return request;
   }
 
-  static hasTemplate(templatePrefix) {
+  static hasTemplate(templatePrefix: string): string {
     return [...templateByName.keys()].find(key => key.startsWith(templatePrefix));
   }
 
@@ -160,11 +159,11 @@ export class SlotDomConsumer extends SlotConsumer {
     this.renderings.forEach(([subId, {container}]) => this.deleteContainer(container));
   }
 
-  static clear(container) {
+  static clear(container): void {
     container.textContent = '';
   }
 
-  static clearCache() {
+  static clearCache(): void {
     templateByName.clear();
   }
 

--- a/src/runtime/slot-dom-consumer.ts
+++ b/src/runtime/slot-dom-consumer.ts
@@ -21,7 +21,8 @@ export interface DomRendering extends Rendering {
   liveDom?: Template;
 }
 
-const templateByName = new Map();
+// tslint:disable-next-line: no-any
+const templateByName = new Map<string, any>();
 
 // this style sheet is installed in every particle shadow-root
 let commonStyleTemplate;

--- a/src/runtime/slot-info.ts
+++ b/src/runtime/slot-info.ts
@@ -15,11 +15,11 @@ export class SlotInfo {
     this.handle = handle;
   }
 
-  toLiteral() {
+  toLiteral(): SlotInfo {
     return this;
   }
 
-  static fromLiteral(data) {
-    return new SlotInfo(data.formFactor, data.handle);
+  static fromLiteral({formFactor, handle}: {formFactor: string, handle: string}) {
+    return new SlotInfo(formFactor, handle);
   }
 }

--- a/src/runtime/slot-proxy.ts
+++ b/src/runtime/slot-proxy.ts
@@ -31,7 +31,7 @@ export class SlotProxy {
     this.providedSlots = providedSlots;
   }
 
-  get isRendered(): boolean {
+  get isRendered() {
     return this._isRendered;
   }
 

--- a/src/runtime/slot-proxy.ts
+++ b/src/runtime/slot-proxy.ts
@@ -1,3 +1,13 @@
+/**
+ * @license
+ * Copyright (c) 2017 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
 import { Particle } from './particle';
 import { PECInnerPort } from './api-channel';
 
@@ -20,31 +30,37 @@ export class SlotProxy {
     this.particle = particle;
     this.providedSlots = providedSlots;
   }
-  get isRendered() { return this._isRendered; }
+
+  get isRendered(): boolean {
+    return this._isRendered;
+  }
 
   /**
    * renders content to the slot.
    */
-  render(content) {  
+  render(content): void {
     this.apiPort.Render(this.particle, this.slotName, content);
 
     Object.keys(content).forEach(key => { this.requestedContentTypes.delete(key); });
     // Slot is considered rendered, if a non-empty content was sent and all requested content types were fullfilled.
     this._isRendered = this.requestedContentTypes.size === 0 && (Object.keys(content).length > 0);
   }
-  /** @method registerEventHandler(name, f)
+
+  /**
    * registers a callback to be invoked when 'name' event happens.
    */
-  registerEventHandler(name, f) {
+  registerEventHandler(name: string, f): void {
     if (!this.handlers.has(name)) {
       this.handlers.set(name, []);
     }
     this.handlers.get(name).push(f);
   }
-  clearEventHandlers(name) {
+
+  clearEventHandlers(name: string): void {
     this.handlers.set(name, []);
   }
-  fireEvent(event) {
+
+  fireEvent(event): void {
     for (const handler of this.handlers.get(event.handler) || []) {
       handler(event);
     }

--- a/src/runtime/transformation-dom-particle.ts
+++ b/src/runtime/transformation-dom-particle.ts
@@ -7,44 +7,49 @@
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
-'use strict';
 
 import {DomParticle} from './dom-particle.js';
 
 // Regex to separate style and template.
 const re = /<style>((?:.|[\r\n])*)<\/style>((?:.|[\r\n])*)/;
 
-/** @class TransformationDomParticle
+/**
  * Particle that does transformation stuff with DOM.
  */
 export class TransformationDomParticle extends DomParticle {
 
-  getTemplate(slotName) {
+  getTemplate(slotName: string) {
     // TODO: add support for multiple slots.
     return this._state.template;
   }
-  getTemplateName(slotName) {
+
+  getTemplateName(slotName: string) {
     // TODO: add support for multiple slots.
     return this._state.templateName;
   }
+
   render(props, state) {
     return state.renderModel;
   }
-  shouldRender(props, state) {
+
+  shouldRender(props, state): boolean {
     return Boolean((state.template || state.templateName) && state.renderModel);
   }
-  renderHostedSlot(slotName, hostedSlotId, content) {
+
+  renderHostedSlot(slotName, hostedSlotId, content): void {
     this.combineHostedTemplate(slotName, hostedSlotId, content);
     this.combineHostedModel(slotName, hostedSlotId, content);
   }
+
   // abstract
-  combineHostedTemplate(slotName, hostedSlotId, content) { 
+  combineHostedTemplate(slotName: string, hostedSlotId, content): void {
   }
-  combineHostedModel(slotName, hostedSlotId, content) {
+
+  combineHostedModel(slotName, hostedSlotId, content): void {
   }
+
   // Helper methods that may be reused in transformation particles to combine hosted content.
   static propsToItems(propsValues) {
     return propsValues ? propsValues.map(({rawData, id}) => ({...rawData, subId: id })) : [];
   }
 }
-//# sourceMappingURL=transformation-dom-particle.js.map

--- a/src/runtime/type-variable-info.ts
+++ b/src/runtime/type-variable-info.ts
@@ -35,7 +35,7 @@ export class TypeVariableInfo {
    * of two variables together. Use this when two separate type variables need to resolve
    * to the same value.
    */
-  maybeMergeConstraints(variable: TypeVariableInfo) {
+  maybeMergeConstraints(variable: TypeVariableInfo): boolean {
     if (!this.maybeMergeCanReadSubset(variable.canReadSubset)) {
       return false;
     }
@@ -103,7 +103,7 @@ export class TypeVariableInfo {
     return false;
   }
 
-  isSatisfiedBy(type: Type) {
+  isSatisfiedBy(type: Type): boolean {
     const constraint = this._canWriteSuperset;
     if (!constraint) {
       return true;
@@ -232,7 +232,7 @@ export class TypeVariableInfo {
         data.canReadSubset ? Type.fromLiteral(data.canReadSubset) : null);
   }
 
-  isResolved() {
+  isResolved(): boolean {
     return (this._resolution && this._resolution.isResolved());
   }
 }

--- a/src/runtime/type.ts
+++ b/src/runtime/type.ts
@@ -16,12 +16,13 @@ import {TypeVariableInfo} from './type-variable-info.js';
 
 // tslint:disable-next-line: no-any
 export type TypeLiteral = {tag: string, data?: any};
+export type Tag = 'Entity' | 'TypeVariable' | 'Collection' | 'BigCollection' | 'Relation' |
+  'Interface' | 'Slot' | 'Reference' | 'Arc' | 'Handle';
 
 export abstract class Type {
-  tag: 'Entity' | 'TypeVariable' | 'Collection' | 'BigCollection' | 'Relation' |
-       'Interface' | 'Slot' | 'Reference' | 'Arc' | 'Handle';
+  tag: Tag;
 
-  protected constructor(tag) {
+  protected constructor(tag: Tag) {
     this.tag = tag;
   }
 
@@ -52,7 +53,7 @@ export abstract class Type {
     }
   }
 
-  abstract toLiteral() : TypeLiteral;
+  abstract toLiteral(): TypeLiteral;
 
   static unwrapPair(type1: Type, type2: Type): [Type, Type] {
     if (type1.tag === type2.tag) {
@@ -69,7 +70,7 @@ export abstract class Type {
     return Type._canMergeCanReadSubset(type1, type2) && Type._canMergeCanWriteSuperset(type1, type2);
   }
 
-  static _canMergeCanReadSubset(type1, type2) {
+  static _canMergeCanReadSubset(type1, type2): boolean {
     if (type1.canReadSubset && type2.canReadSubset) {
       if (type1.canReadSubset.tag !== type2.canReadSubset.tag) {
         return false;
@@ -82,7 +83,7 @@ export abstract class Type {
     return true;
   }
 
-  static _canMergeCanWriteSuperset(type1, type2) {
+  static _canMergeCanWriteSuperset(type1, type2): boolean {
     if (type1.canWriteSuperset && type2.canWriteSuperset) {
       if (type1.canWriteSuperset.tag !== type2.canWriteSuperset.tag) {
         return false;
@@ -108,13 +109,15 @@ export abstract class Type {
     return this instanceof BigCollectionType;
   }
 
-  // TODO: update call sites to use the type checker instead (since they will
-  // have additional information about direction etc.)
-  equals(type) {
+  /**
+   * @deprecated use the type checker instead (since they will have
+   * additional information about direction etc.)
+   */
+  equals(type): boolean {
     return TypeChecker.compareTypes({type: this}, {type});
   }
 
-  isResolved() {
+  isResolved(): boolean {
     // TODO: one of these should not exist.
     return !this.hasUnresolvedVariable;
   }
@@ -127,11 +130,11 @@ export abstract class Type {
     return test(this);
   }
 
-  get hasVariable() {
+  get hasVariable(): boolean {
     return this._applyExistenceTypeTest(type => type instanceof TypeVariable);
   }
 
-  get hasUnresolvedVariable() {
+  get hasUnresolvedVariable(): boolean {
     return this._applyExistenceTypeTest(type => type instanceof TypeVariable && !type.variable.isResolved());
   }
 
@@ -139,7 +142,7 @@ export abstract class Type {
     return null;
   }
 
-  isTypeContainer() {
+  isTypeContainer(): boolean {
     return false;
   }
 
@@ -151,31 +154,31 @@ export abstract class Type {
     return new BigCollectionType(this);
   }
 
-  resolvedType() : Type {
+  resolvedType(): Type {
     return this;
   }
 
-  canEnsureResolved() {
+  canEnsureResolved(): boolean {
     return this.isResolved() || this._canEnsureResolved();
   }
 
-  protected _canEnsureResolved() {
+  protected _canEnsureResolved(): boolean {
     return true;
   }
 
-  maybeEnsureResolved() {
+  maybeEnsureResolved(): boolean {
     return true;
   }
 
-  get canWriteSuperset() : Type {
+  get canWriteSuperset(): Type {
     throw new Error(`canWriteSuperset not implemented for ${this}`);
   }
 
-  get canReadSubset() : Type {
+  get canReadSubset(): Type {
     throw new Error(`canReadSubset not implemented for ${this}`);
   }
 
-  isMoreSpecificThan(type: Type) {
+  isMoreSpecificThan(type: Type): boolean {
     return this.tag === type.tag && this._isMoreSpecificThan(type);
   }
 
@@ -208,23 +211,23 @@ export abstract class Type {
   }
 
   // TODO: is this the same as _applyExistenceTypeTest
-  hasProperty(property) {
+  hasProperty(property): boolean {
     return property(this) || this._hasProperty(property);
   }
 
-  protected _hasProperty(property) {
+  protected _hasProperty(property): boolean {
     return false;
   }
 
-  toString(options = undefined) : string {
+  toString(options = undefined): string {
     return this.tag;
   }
 
-  getEntitySchema() {
+  getEntitySchema(): Schema|null {
     return null;
   }
 
-  toPrettyString() {
+  toPrettyString(): string|null {
     return null;
   }
 }
@@ -243,31 +246,31 @@ export class EntityType extends Type {
   }
 
   // These type identifier methods are being left in place for non-runtime code.
-  get isEntity() {
+  get isEntity(): boolean {
     return true;
   }
 
-  get canWriteSuperset() {
+  get canWriteSuperset(): EntityType {
     return this;
   }
 
-  get canReadSubset() {
+  get canReadSubset(): EntityType {
     return this;
   }
 
-  _isMoreSpecificThan(type) {
+  _isMoreSpecificThan(type): boolean {
     return this.entitySchema.isMoreSpecificThan(type.entitySchema);
   }
 
-  toLiteral() {
+  toLiteral(): TypeLiteral {
     return {tag: this.tag, data: this.entitySchema.toLiteral()};
   }
 
-  toString(options = undefined) {
+  toString(options = undefined): string {
     return this.entitySchema.toInlineSchemaString(options);
   }
 
-  getEntitySchema() {
+  getEntitySchema(): Schema {
     return this.entitySchema;
   }
 
@@ -305,11 +308,11 @@ export class TypeVariable extends Type {
     this.variable = variable;
   }
 
-  static make(name: string, canWriteSuperset?: Type, canReadSubset?: Type) {
+  static make(name: string, canWriteSuperset?: Type, canReadSubset?: Type): TypeVariable {
     return new TypeVariable(new TypeVariableInfo(name, canWriteSuperset, canReadSubset));
   }
 
-  get isVariable() {
+  get isVariable(): boolean {
     return true;
   }
 
@@ -334,11 +337,11 @@ export class TypeVariable extends Type {
     return this.variable.resolution || this;
   }
 
-  _canEnsureResolved() {
+  _canEnsureResolved(): boolean {
     return this.variable.canEnsureResolved();
   }
 
-  maybeEnsureResolved() {
+  maybeEnsureResolved(): boolean {
     return this.variable.maybeEnsureResolved();
   }
 
@@ -380,20 +383,20 @@ export class TypeVariable extends Type {
     }
   }
 
-  toLiteral() {
+  toLiteral(): TypeLiteral {
     return this.variable.resolution ? this.variable.resolution.toLiteral()
                                     : {tag: this.tag, data: this.variable.toLiteral()};
   }
 
-  toString(options = undefined) {
+  toString(options = undefined): string {
     return `~${this.variable.name}`;
   }
 
-  getEntitySchema() {
+  getEntitySchema(): Schema {
     return this.variable.isResolved() ? this.resolvedType().getEntitySchema() : null;
   }
 
-  toPrettyString() {
+  toPrettyString(): string {
     return this.variable.isResolved() ? this.resolvedType().toPrettyString() : `[~${this.variable.name}]`;
   }
 }
@@ -435,7 +438,7 @@ export class CollectionType<T extends Type> extends Type {
     return (collectionType !== resolvedCollectionType) ? resolvedCollectionType.collectionOf() : this;
   }
 
-  _canEnsureResolved() {
+  _canEnsureResolved(): boolean {
     return this.collectionType.canEnsureResolved();
   }
 
@@ -452,7 +455,7 @@ export class CollectionType<T extends Type> extends Type {
     return new CollectionType(this.collectionType._cloneWithResolutions(variableMap));
   }
 
-  toLiteral() {
+  toLiteral(): TypeLiteral {
     return {tag: this.tag, data: this.collectionType.toLiteral()};
   }
 
@@ -514,7 +517,7 @@ export class BigCollectionType<T extends Type> extends Type {
     return (collectionType !== resolvedCollectionType) ? resolvedCollectionType.bigCollectionOf() : this;
   }
 
-  _canEnsureResolved() {
+  _canEnsureResolved(): boolean {
     return this.bigCollectionType.canEnsureResolved();
   }
 
@@ -531,7 +534,7 @@ export class BigCollectionType<T extends Type> extends Type {
     return new BigCollectionType(this.bigCollectionType._cloneWithResolutions(variableMap));
   }
 
-  toLiteral() {
+  toLiteral(): TypeLiteral {
     return {tag: this.tag, data: this.bigCollectionType.toLiteral()};
   }
 
@@ -558,7 +561,7 @@ export class BigCollectionType<T extends Type> extends Type {
 
 
 export class RelationType extends Type {
-  readonly relationEntities: Type[];
+  private readonly relationEntities: Type[];
 
   constructor(relation: Type[]) {
     super('Relation');
@@ -569,11 +572,11 @@ export class RelationType extends Type {
     return true;
   }
 
-  toLiteral() {
+  toLiteral(): TypeLiteral {
     return {tag: this.tag, data: this.relationEntities.map(t => t.toLiteral())};
   }
 
-  toPrettyString() {
+  toPrettyString(): string {
     return JSON.stringify(this.relationEntities);
   }
 }
@@ -611,11 +614,11 @@ export class InterfaceType extends Type {
     return new InterfaceType(this.interfaceInfo.resolvedType());
   }
 
-  _canEnsureResolved() {
+  _canEnsureResolved(): boolean {
     return this.interfaceInfo.canEnsureResolved();
   }
 
-  maybeEnsureResolved() {
+  maybeEnsureResolved(): boolean {
     return this.interfaceInfo.maybeEnsureResolved();
   }
 
@@ -640,22 +643,22 @@ export class InterfaceType extends Type {
     return new InterfaceType(this.interfaceInfo._cloneWithResolutions(variableMap));
   }
 
-  toLiteral() {
+  toLiteral(): TypeLiteral {
     return {tag: this.tag, data: this.interfaceInfo.toLiteral()};
   }
 
-  toString(options = undefined) {
+  toString(options = undefined): string {
     return this.interfaceInfo.name;
   }
 
-  toPrettyString() {
+  toPrettyString(): string {
     return this.interfaceInfo.toPrettyString();
   }
 }
 
 
 export class SlotType extends Type {
-  readonly slot: SlotInfo;
+  private readonly slot: SlotInfo;
 
   constructor(slot: SlotInfo) {
     super('Slot');
@@ -670,7 +673,7 @@ export class SlotType extends Type {
     return true;
   }
 
-  get canWriteSuperset() {
+  get canWriteSuperset(): SlotType {
     return this;
   }
 
@@ -683,11 +686,11 @@ export class SlotType extends Type {
     return true;
   }
 
-  toLiteral() {
+  toLiteral(): TypeLiteral {
     return {tag: this.tag, data: this.slot.toLiteral()};
   }
 
-  toString(options = undefined) {
+  toString(options = undefined): string {
     const fields = [];
     for (const key of Object.keys(this.slot)) {
       if (this.slot[key] !== undefined) {
@@ -701,7 +704,7 @@ export class SlotType extends Type {
     return `Slot${fieldsString}`;
   }
 
-  toPrettyString() {
+  toPrettyString(): string {
     const fields = [];
     for (const key of Object.keys(this.slot)) {
       if (this.slot[key] !== undefined) {
@@ -725,15 +728,15 @@ export class ReferenceType extends Type {
     this.referredType = reference;
   }
 
-  get isReference() {
+  get isReference(): boolean {
     return true;
   }
 
-  getContainedType() {
+  getContainedType(): Type {
     return this.referredType;
   }
 
-  isTypeContainer() {
+  isTypeContainer(): boolean {
     return true;
   }
 
@@ -743,11 +746,11 @@ export class ReferenceType extends Type {
     return (referredType !== resolvedReferredType) ? new ReferenceType(resolvedReferredType) : this;
   }
 
-  _canEnsureResolved() {
+  _canEnsureResolved(): boolean {
     return this.referredType.canEnsureResolved();
   }
 
-  maybeEnsureResolved() {
+  maybeEnsureResolved(): boolean {
     return this.referredType.maybeEnsureResolved();
   }
 
@@ -764,11 +767,11 @@ export class ReferenceType extends Type {
     return new ReferenceType(this.referredType._cloneWithResolutions(variableMap));
   }
 
-  toLiteral() {
+  toLiteral(): TypeLiteral {
     return {tag: this.tag, data: this.referredType.toLiteral()};
   }
 
-  toString(options = undefined) {
+  toString(options = undefined): string {
     return 'Reference<' + this.referredType.toString() + '>';
   }
 }
@@ -779,15 +782,15 @@ export class ArcType extends Type {
     super('Arc');
   }
 
-  get isArc() {
+  get isArc(): boolean {
     return true;
   }
 
-  newInstance(arcId: Id, serialization: string) {
+  newInstance(arcId: Id, serialization: string): ArcInfo {
     return new ArcInfo(arcId, serialization);
   }
 
-  toLiteral() {
+  toLiteral(): TypeLiteral {
     return {tag: this.tag};
   }
 }
@@ -798,11 +801,11 @@ export class HandleType extends Type {
     super('Handle');
   }
 
-  get isHandle() {
+  get isHandle(): boolean {
     return true;
   }
 
-  toLiteral() {
+  toLiteral(): TypeLiteral {
     return {tag: this.tag};
   }
 }

--- a/src/runtime/type.ts
+++ b/src/runtime/type.ts
@@ -130,7 +130,7 @@ export abstract class Type {
     return test(this);
   }
 
-  get hasVariable(): boolean {
+  get hasVariable() {
     return this._applyExistenceTypeTest(type => type instanceof TypeVariable);
   }
 
@@ -337,7 +337,7 @@ export class TypeVariable extends Type {
     return this.variable.resolution || this;
   }
 
-  _canEnsureResolved(): boolean {
+  _canEnsureResolved() {
     return this.variable.canEnsureResolved();
   }
 
@@ -388,7 +388,7 @@ export class TypeVariable extends Type {
                                     : {tag: this.tag, data: this.variable.toLiteral()};
   }
 
-  toString(options = undefined): string {
+  toString(options = undefined) {
     return `~${this.variable.name}`;
   }
 


### PR DESCRIPTION
- Add return types in many places
- Convert some types to use Readonly<>
- Make private methods private
- Remove 'use strict' from typescript
- Remove non typedoc jsdoc (@class/@method)
- Remove vestigal sourceMappingURL comments
- Add missing async to setHandles/onHandleDesync/onHandleUpdate/etc in particle.ts and fix callers
- Add missing license boilerplate