### PR TITLE
'describe' functions in tests should not be async.

### DIFF
--- a/src/planning/test/plan/replan-queue-test.ts
+++ b/src/planning/test/plan/replan-queue-test.ts
@@ -50,7 +50,7 @@ async function init(options?) {
   return {producer, queue};
 }
 
-describe('replan queue', async () => {
+describe('replan queue', () => {
   it('triggers planning', async () => {
     const {producer, queue} = await init();
     queue.addChange();

--- a/src/planning/test/planner-tests.ts
+++ b/src/planning/test/planner-tests.ts
@@ -547,7 +547,7 @@ store MyThings2 of [Thing2] #mythings2 in 'things.json'`);
   });
 });
 
-describe('Description', async () => {
+describe('Description', () => {
   it('description generated from speculative execution arc', async () => {
     const manifest = `
     schema Thing

--- a/src/planning/test/strategies/convert-constraints-to-connections-tests.ts
+++ b/src/planning/test/strategies/convert-constraints-to-connections-tests.ts
@@ -17,7 +17,7 @@ import {ConvertConstraintsToConnections} from '../../strategies/convert-constrai
 import {InstanceEndPoint} from '../../../runtime/recipe/connection-constraint.js';
 import {ArcId} from '../../../runtime/id.js';
 
-describe('ConvertConstraintsToConnections', async () => {
+describe('ConvertConstraintsToConnections', () => {
   const newArc = (manifest: Manifest) => {
     return new Arc({
       id: ArcId.newForTest('test-plan-arc'),

--- a/src/planning/test/strategies/init-population-tests.ts
+++ b/src/planning/test/strategies/init-population-tests.ts
@@ -18,7 +18,7 @@ import {InitPopulation} from '../../strategies/init-population.js';
 import {StrategyTestHelper} from './strategy-test-helper.js';
 import {Id, ArcId} from '../../../runtime/id.js';
 
-describe('InitPopulation', async () => {
+describe('InitPopulation', () => {
   it('penalizes resolution of particles that already exist in the arc', async () => {
     const manifest = await Manifest.parse(`
       schema Product

--- a/src/planning/test/strategies/init-search-tests.ts
+++ b/src/planning/test/strategies/init-search-tests.ts
@@ -11,7 +11,7 @@
 import {assert} from '../../../platform/chai-web.js';
 import {InitSearch} from '../../strategies/init-search.js';
 
-describe('InitSearch', async () => {
+describe('InitSearch', () => {
   it('initializes the search recipe', async () => {
     const initSearch = new InitSearch(null, {search: 'search'});
     const inputParams = {generated: [], generation: 0};

--- a/src/runtime/test/data-layer-test.ts
+++ b/src/runtime/test/data-layer-test.ts
@@ -18,7 +18,7 @@ import {FakeSlotComposer} from '../testing/fake-slot-composer.js';
 import {EntityType} from '../type.js';
 import {ArcId, IdGenerator} from '../id.js';
 
-describe('entity', async () => {
+describe('entity', () => {
   it('can be created, stored, and restored', async () => {
     const schema = new Schema(['TestSchema'], {value: 'Text'});
 

--- a/src/runtime/test/entity-test.ts
+++ b/src/runtime/test/entity-test.ts
@@ -3,20 +3,21 @@ import {Manifest} from '../manifest.js';
 import {Entity, MutableEntityData} from '../entity.js';
 
 describe('Entity', () => {
-  describe('mutability', async () => {
-    // Define an interface for the Foo schema.
-    interface FooEntity extends Entity {
-      bar: string;
-    }
-    const manifest = await Manifest.parse(`
-      schema Foo
-        Text bar
-    `);
-    const schema = manifest.findSchemaByName('Foo');
-    const entityClass = schema.entityClass();
+  describe('mutability', () => {
 
-    // Helper function to create new Foo entities.
-    const newFooEntity = (bar: string) => new entityClass({bar}) as FooEntity;
+    let entityClass;
+
+    before(async () => {
+      const manifest = await Manifest.parse(`
+        schema Foo
+          Text bar
+      `);
+      entityClass = manifest.findSchemaByName('Foo').entityClass();
+    });
+
+    function newFooEntity(bar) {
+      return new entityClass({bar});
+    }
 
     it('is mutable by default', () => {
       const entity = newFooEntity('abc');


### PR DESCRIPTION
Awaiting anything inside the describe function (but not in a test function) interferes with some of the mocha invocation logic. When another test is marked '.only', the tests inside the awaited async describe are still executed (when they shouldn't be).