### PR TITLE
Remove .prettierrc config and npm package dep.

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,0 @@
-{
-  bracketSpacing: false,
-  singleQuote: true,
-  printWidth: 144
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7764,12 +7764,6 @@
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
       "dev": true
     },
-    "prettier": {
-      "version": "1.16.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.16.4.tgz",
-      "integrity": "sha512-ZzWuos7TI5CKUeQAtFd6Zhm2s6EpAD/ZLApIhsF9pRvRtM1RFo61dM/4MSRUA0SuLugA/zgrZD8m0BaY46Og7g==",
-      "dev": true
-    },
     "process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "node-webcrypto-ossl": "^1.0.39",
     "npm-run-all": "^4.1.5",
     "pegjs": "^0.10.0",
-    "prettier": "^1.16.4",
     "request": "^2.88.0",
     "rollup": "^1.1.2",
     "rollup-plugin-commonjs": "^9.2.0",


### PR DESCRIPTION
We've not standardized on JS (not TS) style/formatting. We were using
clang-format previously and it would provide a smoother path to
adopting some subset of Google style which would be more likely.