### PR TITLE
Enable promise-function-async rule, fix usages

### DIFF
--- a/config/tslint.base.json
+++ b/config/tslint.base.json
@@ -46,6 +46,7 @@
     //"ordered-imports": [true, {"grouped-imports": true}],
     "prefer-const": [true, {"destructuring": "all"}],
     "prefer-object-spread": true,
+    "promise-function-async": true,
     "radix": true,
     "semicolon": [true, "always", "ignore-bound-class-methods"],
     "switch-default": true,

--- a/server/src/deployment/gcp/gcpdisk.ts
+++ b/server/src/deployment/gcp/gcpdisk.ts
@@ -103,7 +103,7 @@ class GCPDisk implements Disk {
     return GCE_PERSISTENT_DISK_TYPE;
   }
 
-  wrappedKeyFor(fingerprint:string): Promise<string> {
+  async wrappedKeyFor(fingerprint:string): Promise<string> {
     return Promise.resolve(JSON.parse(this.diskApi.metadata.description)[arcsKeyFor(fingerprint)]);
   }
 }

--- a/src/planning/strategizer.ts
+++ b/src/planning/strategizer.ts
@@ -70,7 +70,7 @@ export class Strategizer {
   async generate() {
     // Generate
     const generation = this.generation + 1;
-    const generatedResults = await Promise.all(this._strategies.map(strategy => {
+    const generatedResults = await Promise.all(this._strategies.map(async strategy => {
       const recipeFilter = (recipe: Descendant<Recipe>) => this._ruleset.isAllowed(strategy, recipe);
       return strategy.generate({
         generation: this.generation,
@@ -174,7 +174,7 @@ export class Strategizer {
       return 0;
     });
 
-    const evaluations = await Promise.all(this._evaluators.map(strategy => {
+    const evaluations = await Promise.all(this._evaluators.map(async strategy => {
       return strategy.evaluate(this, generated);
     }));
     const fitness = Strategizer._mergeEvaluations(evaluations, generated);

--- a/src/planning/test/plan/plan-producer-test.ts
+++ b/src/planning/test/plan/plan-producer-test.ts
@@ -152,7 +152,7 @@ describe('plan producer - search', () => {
       this.options = options;
     }
 
-    setNextSearch(search: string) {
+    async setNextSearch(search: string) {
       this.searchStore.set([{arc: this.arc.id.idTreeAsString(), search}]);
       return this.onSearchChanged();
     }

--- a/src/runtime/arc.ts
+++ b/src/runtime/arc.ts
@@ -173,7 +173,7 @@ export class Arc {
       const innerArcs = this.innerArcs;
 
       // tslint:disable-next-line: no-any
-      await Promise.all([this.pec.idle as Promise<any>, ...innerArcs.map(arc => arc.idle)]);
+      await Promise.all([this.pec.idle as Promise<any>, ...innerArcs.map(async arc => arc.idle)]);
 
       // We're idle if no new inner arcs appeared and this.pec had exactly 2 messages,
       // one requesting the idle status, and one answering it.

--- a/src/runtime/keymgmt/webcrypto.ts
+++ b/src/runtime/keymgmt/webcrypto.ts
@@ -315,7 +315,7 @@ export class WebCryptoKeyGenerator implements KeyGenerator {
             }, true, ["encrypt", "wrapKey"]).then(ikey => new WebCryptoPublicKey(ikey));
     }
 
-    importWrappedKey(wrappedKey: string, wrappedBy: PublicKey):Promise<WrappedKey> {
+    async importWrappedKey(wrappedKey: string, wrappedBy: PublicKey):Promise<WrappedKey> {
       const decodedKey = decode(wrappedKey);
       return Promise.resolve(new WebCryptoWrappedKey(decodedKey, wrappedBy));
     }
@@ -351,7 +351,7 @@ export class WebCryptoKeyIndexedDBStorage implements KeyStorage {
     }
 
     async find(keyId: string): Promise<Key|null> {
-        const result:KeyRecord = await this.runOnStore(store => {
+        const result:KeyRecord = await this.runOnStore(async store => {
             return store.get(keyId);
         });
 
@@ -374,7 +374,7 @@ export class WebCryptoKeyIndexedDBStorage implements KeyStorage {
     async write(keyFingerPrint: string, key: DeviceKey|WrappedKey): Promise<string> {
         if (key instanceof WebCryptoStorableKey) {
             const skey = key as WebCryptoStorableKey<CryptoKey>;
-            await this.runOnStore(store => {
+            await this.runOnStore(async store => {
                 return store.put({keyFingerPrint, key: skey.storableKey()});
             });
             return keyFingerPrint;
@@ -382,7 +382,7 @@ export class WebCryptoKeyIndexedDBStorage implements KeyStorage {
             const wrappedKey = key as WebCryptoWrappedKey;
             const wrappingKeyFingerprint = await wrappedKey.wrappedBy.fingerprint();
 
-            await this.runOnStore(store => {
+            await this.runOnStore(async store => {
                 return store.put({keyFingerPrint, key:wrappedKey.wrappedKeyData,
                     wrappingKeyFingerprint});
             });

--- a/src/runtime/loader.ts
+++ b/src/runtime/loader.ts
@@ -59,14 +59,14 @@ export class Loader {
     return path;
   }
 
-  loadResource(file: string): Promise<string> {
+  async loadResource(file: string): Promise<string> {
     if (/^https?:\/\//.test(file)) {
       return this._loadURL(file);
     }
     return this._loadFile(file);
   }
 
-  _loadFile(file: string): Promise<string> {
+  async _loadFile(file: string): Promise<string> {
     return new Promise((resolve, reject) => {
       fs.readFile(file, (err, data) => {
         if (err) {
@@ -78,7 +78,7 @@ export class Loader {
     });
   }
 
-  _loadURL(url: string): Promise<string> {
+  async _loadURL(url: string): Promise<string> {
     if (/\/\/schema.org\//.test(url)) {
       if (url.endsWith('/Thing')) {
         return fetch('https://schema.org/Product.jsonld').then(res => res.text()).then(data => JsonldToManifest.convert(data, {'@id': 'schema:Thing'}));

--- a/src/runtime/manual_tests/firebase-tests.ts
+++ b/src/runtime/manual_tests/firebase-tests.ts
@@ -436,7 +436,7 @@ describe('firebase', function() {
 
     // Stores a new item for each id in both col and items, with data and key derived
     // from the numerical part of the id in a lexicographically "random" manner.
-    function store(col, items, ...ids) {
+    async function store(col, items, ...ids) {
       const promises = [];
       for (const id of ids) {
         const n = Number(id.slice(1));

--- a/src/runtime/particle-execution-context.ts
+++ b/src/runtime/particle-execution-context.ts
@@ -79,7 +79,7 @@ export class ParticleExecutionContext {
         }
       }
 
-      onInstantiateParticle(id: string, spec: ParticleSpec, proxies: ReadonlyMap<string, StorageProxy>) {
+      async onInstantiateParticle(id: string, spec: ParticleSpec, proxies: ReadonlyMap<string, StorageProxy>) {
         return pec._instantiateParticle(id, spec, proxies);
       }
 
@@ -138,7 +138,7 @@ export class ParticleExecutionContext {
   innerArcHandle(arcId: string, particleId: string): InnerArcHandle {
     const pec = this;
     return {
-      createHandle(type: Type, name: string, hostParticle?: Particle) {
+      async createHandle(type: Type, name: string, hostParticle?: Particle) {
         return new Promise((resolve, reject) =>
           pec.apiPort.ArcCreateHandle(proxy => {
             const handle = handleFor(proxy, pec.idGenerator, name, particleId);
@@ -148,20 +148,20 @@ export class ParticleExecutionContext {
             }
           }, arcId, type, name));
       },
-      mapHandle(handle: Handle) {
+      async mapHandle(handle: Handle) {
         return new Promise((resolve, reject) =>
           pec.apiPort.ArcMapHandle(id => {
             resolve(id);
           }, arcId, handle));  // recipe handle vs not?
       },
-      createSlot(transformationParticle, transformationSlotName, handleId) {
+      async createSlot(transformationParticle, transformationSlotName, handleId) {
         // handleId: the ID of a handle (returned by `createHandle` above) this slot is rendering; null - if not applicable.
         // TODO: support multiple handle IDs.
         return new Promise((resolve, reject) =>
           pec.apiPort.ArcCreateSlot(hostedSlotId => resolve(hostedSlotId), arcId, transformationParticle, transformationSlotName, handleId)
           );
       },
-      loadRecipe(recipe: string) {
+      async loadRecipe(recipe: string) {
         // TODO: do we want to return a promise on completion?
         return new Promise((resolve, reject) => pec.apiPort.ArcLoadRecipe(arcId, recipe, response => {
           if (response.error) {
@@ -188,7 +188,7 @@ export class ParticleExecutionContext {
 
   defaultCapabilitySet() {
     return {
-      constructInnerArc: particle => {
+      constructInnerArc: async particle => {
         return new Promise<InnerArcHandle>((resolve, reject) =>
           this.apiPort.ConstructInnerArc(arcId => resolve(this.innerArcHandle(arcId, particle.id)), particle));
       }
@@ -255,7 +255,7 @@ export class ParticleExecutionContext {
     if (!this.busy) {
       return Promise.resolve();
     }
-    const busyParticlePromises = this.particles.filter(particle => particle.busy).map(particle => particle.idle);
+    const busyParticlePromises = this.particles.filter(async particle => particle.busy).map(async particle => particle.idle);
     return Promise.all([this.scheduler.idle, ...this.pendingLoads, ...busyParticlePromises]).then(() => this.idle);
   }
 }

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -36,7 +36,7 @@ export class Runtime {
    * Parse a textual manifest and return a Manifest object. See the Manifest
    * class for the options accepted.
    */
-  static parseManifest(content: string, options?): Promise<Manifest> {
+  static async parseManifest(content: string, options?): Promise<Manifest> {
     return Manifest.parse(content, options);
   }
 
@@ -45,7 +45,7 @@ export class Runtime {
    * a Manifest object. The loader determines the semantics of the fileName. See
    * the Manifest class for details.
    */
-  static loadManifest(fileName, loader, options) : Promise<Manifest> {
+  static async loadManifest(fileName, loader, options) : Promise<Manifest> {
     return Manifest.load(fileName, loader, options);
   }
 

--- a/src/runtime/storage-proxy.ts
+++ b/src/runtime/storage-proxy.ts
@@ -312,7 +312,7 @@ export class CollectionProxy extends StorageProxy implements CollectionStore {
 
   // Read ops: if we're synchronized we can just return the local copy of the data.
   // Otherwise, send a request to the backing store.
-  toList() {
+  async toList() {
     if (this.synchronized === SyncState.full) {
       return Promise.resolve(this.model.toList());
     } else {
@@ -323,7 +323,7 @@ export class CollectionProxy extends StorageProxy implements CollectionStore {
     }
   }
 
-  get(id: string) {
+  async get(id: string) {
     if (this.synchronized === SyncState.full) {
       return Promise.resolve(this.model.getValue(id));
     } else {
@@ -333,7 +333,7 @@ export class CollectionProxy extends StorageProxy implements CollectionStore {
   }
 
   // tslint:disable-next-line: no-any
-  store(value: any, keys: string[], particleId: string): Promise<void> {
+  async store(value: any, keys: string[], particleId: string): Promise<void> {
     const id = value.id;
     const data = {value, keys};
     this.port.HandleStore(this, () => {}, data, particleId);
@@ -349,7 +349,7 @@ export class CollectionProxy extends StorageProxy implements CollectionStore {
     return Promise.resolve();
   }
 
-  clear(particleId): Promise<void> {
+  async clear(particleId): Promise<void> {
     if (this.synchronized !== SyncState.full) {
       this.port.HandleRemoveMultiple(this, () => {}, [], particleId);
     }
@@ -365,7 +365,7 @@ export class CollectionProxy extends StorageProxy implements CollectionStore {
     return Promise.resolve();
   }
 
-  remove(id, keys, particleId): Promise<void> {
+  async remove(id, keys, particleId): Promise<void> {
     if (this.synchronized !== SyncState.full) {
       const data = {id, keys: []};
       this.port.HandleRemove(this, () => {}, data, particleId);
@@ -452,7 +452,7 @@ export class VariableProxy extends StorageProxy implements VariableStore {
   // Otherwise, send a request to the backing store.
   // TODO: in synchronized mode, these should integrate with SynchronizeProxy rather than
   //       sending a parallel request
-  get() {
+  async get() {
     if (this.synchronized === SyncState.full) {
       return Promise.resolve(this.model);
     } else {
@@ -461,7 +461,7 @@ export class VariableProxy extends StorageProxy implements VariableStore {
     }
   }
 
-  set(entity: {}, particleId: string): Promise<void> {
+  async set(entity: {}, particleId: string): Promise<void> {
     assert(entity !== undefined);
     if (JSON.stringify(this.model) === JSON.stringify(entity)) {
       return Promise.resolve();
@@ -487,7 +487,7 @@ export class VariableProxy extends StorageProxy implements VariableStore {
     return Promise.resolve();
   }
 
-  clear(particleId: string): Promise<void> {
+  async clear(particleId: string): Promise<void> {
     if (this.model == null) {
       return Promise.resolve();
     }
@@ -547,7 +547,7 @@ export class BigCollectionProxy extends StorageProxy implements BigCollectionSto
       this.port.StreamCursorNext(this, resolve, cursorId));
   }
 
-  cursorClose(cursorId): Promise<void> {
+  async cursorClose(cursorId): Promise<void> {
     this.port.StreamCursorClose(this, cursorId);
     return Promise.resolve();
   }

--- a/src/runtime/storage/firebase/firebase-storage.ts
+++ b/src/runtime/storage/firebase/firebase-storage.ts
@@ -1512,7 +1512,7 @@ class FirebaseBackingStore extends FirebaseStorageProvider implements Collection
     }
   }
 
-  private storeSingle(value, keys: string[]) {
+  private async storeSingle(value, keys: string[]) {
     return this.childRef(value.id).transaction(data => {
       if (data === null) {
         data = {value, keys: {}};
@@ -1543,7 +1543,7 @@ class FirebaseBackingStore extends FirebaseStorageProvider implements Collection
     }
   }
 
-  private removeSingle(id: string, keys: string[]) {
+  private async removeSingle(id: string, keys: string[]) {
     return this.childRef(id).transaction(data => {
       if (data === null) {
         return null;
@@ -1612,7 +1612,7 @@ class FirebaseBackingStore extends FirebaseStorageProvider implements Collection
     throw new Error('FirebaseBackingStore does not implement toLiteral');
   }
 
-  cloneFrom(store: StorageProviderBase): Promise<void> {
+  async cloneFrom(store: StorageProviderBase): Promise<void> {
     throw new Error('FirebaseBackingStore does not implement cloneFrom');
   }
 }

--- a/src/runtime/storage/pouchdb/pouch-db-big-collection.ts
+++ b/src/runtime/storage/pouchdb/pouch-db-big-collection.ts
@@ -42,7 +42,7 @@ export class PouchDbBigCollection extends PouchDbStorageProvider implements BigC
   async cursorNext(cursorId: number) {
     throw new Error('NotImplemented');
   }
-  cursorClose(cursorId: number): Promise<void> {
+  async cursorClose(cursorId: number): Promise<void> {
     throw new Error('NotImplemented');
   }
   cursorVersion(cursorId: number) {
@@ -53,7 +53,7 @@ export class PouchDbBigCollection extends PouchDbStorageProvider implements BigC
     throw new Error('NotImplemented');
   }
 
-  cloneFrom(): Promise<void> {
+  async cloneFrom(): Promise<void> {
     throw new Error('NotImplemented');
   }
 

--- a/src/runtime/storage/pouchdb/pouch-db-storage.ts
+++ b/src/runtime/storage/pouchdb/pouch-db-storage.ts
@@ -208,7 +208,7 @@ export class PouchDbStorage extends StorageBase {
             return {_id: row.id, _rev: row.doc._rev, _deleted: true};
           });
         })
-        .then(deleteDocs => {
+        .then(async deleteDocs => {
           return db.bulkDocs(deleteDocs);
         });
     }

--- a/src/runtime/storage/synthetic-storage.ts
+++ b/src/runtime/storage/synthetic-storage.ts
@@ -190,7 +190,7 @@ class SyntheticCollection extends StorageProviderBase implements CollectionStora
     throw new Error('unimplemented');
   }
 
-  cloneFrom(): Promise<void> {
+  async cloneFrom(): Promise<void> {
     throw new Error('cloneFrom should never be called on SyntheticCollection!');
   }
 
@@ -208,7 +208,7 @@ class SyntheticCollection extends StorageProviderBase implements CollectionStora
     throw new Error('unimplemented');
   }
 
-  removeMultiple(items, originatorId: string) : Promise<void> {
+  async removeMultiple(items, originatorId: string) : Promise<void> {
     throw new Error('unimplemented');
   }
 

--- a/src/runtime/test/mutex-test.ts
+++ b/src/runtime/test/mutex-test.ts
@@ -12,7 +12,7 @@ import {assert} from '../../platform/chai-web.js';
 import {Mutex} from '../mutex.js';
 
 describe('Mutex', () => {
-  const delay = (ms: number) => new Promise(r => setTimeout(r, ms));
+  const delay = async (ms: number) => new Promise(r => setTimeout(r, ms));
 
   it('correctly calculates lock status', async () => {
     const mutex = new Mutex();


### PR DESCRIPTION
https://palantir.github.io/tslint/rules/promise-function-async/

Requires any function or method that returns a promise to be marked async.

Ensures that each function is only capable of:

1. returning a rejected promise, or
2. throwing an Error object.

In contrast, non-async Promise-returning functions are technically capable of either.
This practice removes a requirement for consuming code to handle both cases.