### PR TITLE
Stabilize flaky tests

### DIFF
--- a/src/planning/test/plan/planificator-test.ts
+++ b/src/planning/test/plan/planificator-test.ts
@@ -120,7 +120,7 @@ describe('remote planificator', () => {
     return {consumePlanificator, producePlanificator};
   }
 
-  ['volatile', 'pouchdb://memory/user-test/', 'pouchdb://local/user-test/'].forEach(plannerStorageKeyBase => {
+  ['volatile', 'pouchdb://memory/user-test/'].forEach(plannerStorageKeyBase => {
     it(`consumes remotely produced gifts demo from ${plannerStorageKeyBase}`, async () => {
       let {consumePlanificator, producePlanificator} = await init(
           plannerStorageKeyBase,

--- a/src/runtime/test/arc-tests.ts
+++ b/src/runtime/test/arc-tests.ts
@@ -303,6 +303,10 @@ describe('Arc ' + storageKeyPrefix, () => {
     );
 
   it('optional provided handles are not required to resolve with dependencies', async () => {
+    if (!storageKeyPrefix.startsWith('volatile')) {
+      // TODO(lindner): fix pouch/firebase timing
+      this.skip();
+    }
     const loader = new Loader();
     const manifest = await Manifest.parse(`
       schema Thing

--- a/src/runtime/test/arc-tests.ts
+++ b/src/runtime/test/arc-tests.ts
@@ -302,7 +302,7 @@ describe('Arc ' + storageKeyPrefix, () => {
     /.*unresolved handle-connection: parent connection missing handle/)
     );
 
-  it('optional provided handles are not required to resolve with dependencies', async () => {
+  it('optional provided handles are not required to resolve with dependencies', async function() {
     if (!storageKeyPrefix.startsWith('volatile')) {
       // TODO(lindner): fix pouch/firebase timing
       this.skip();


### PR DESCRIPTION
- disable tests that use on-disk for planificiator until a clean procedure is added.
 - disable arc test that was flaky.