### PR TITLE
Make the manifest parser output more consistent for primitive schema types

### DIFF
--- a/src/runtime/manifest-ast-nodes.ts
+++ b/src/runtime/manifest-ast-nodes.ts
@@ -370,11 +370,13 @@ export interface SchemaField extends BaseNode {
   name: string;
 }
 
-export type SchemaPrimitiveType =
-    'Text'|'URL'|'Number'|'Boolean'|'Bytes'|'Object';
-
 export type SchemaType = SchemaReferenceType|SchemaCollectionType|
     SchemaPrimitiveType|SchemaUnionType|SchemaTupleType;
+
+export interface SchemaPrimitiveType extends BaseNode {
+  kind: 'schema-primitive';
+  type: 'Text'|'URL'|'Number'|'Boolean'|'Bytes'|'Object';
+}
 
 export interface SchemaCollectionType extends BaseNode {
   kind: 'schema-collection';

--- a/src/runtime/manifest-parser.peg
+++ b/src/runtime/manifest-parser.peg
@@ -1008,7 +1008,14 @@ SchemaReferenceType = 'Reference<' whiteSpace* schema:(SchemaInline / TypeName) 
   }
 
 SchemaPrimitiveType
-  = 'Text' / 'URL' / 'Number' / 'Boolean' / 'Bytes' / 'Object'
+  = type:('Text' / 'URL' / 'Number' / 'Boolean' / 'Bytes' / 'Object')
+  {
+    return {
+      kind: 'schema-primitive',
+      location: location(),
+      type
+    } as AstNode.SchemaPrimitiveType;
+  }
 
 SchemaUnionType
   = '(' whiteSpace? first:SchemaPrimitiveType rest:(whiteSpace 'or' whiteSpace SchemaPrimitiveType)+ whiteSpace? ')'

--- a/src/runtime/test/manifest-test.ts
+++ b/src/runtime/test/manifest-test.ts
@@ -24,6 +24,12 @@ async function assertRecipeParses(input, result) {
   assert.deepEqual((await Manifest.parse(input)).recipes[0].toString(), target);
 }
 
+function verifyPrimitiveType(field, type) {
+  const copy = {...field};
+  delete copy.location;
+  assert.deepEqual(copy, {kind: 'schema-primitive', type});
+}
+
 describe('manifest', () => {
   it('can parse a manifest containing a recipe', async () => {
     const manifest = await Manifest.parse(`
@@ -225,7 +231,7 @@ ${particleStr1}
     const manifest = await Manifest.parse(`
       schema Bar
         Text value`);
-    const verify = (manifest) => assert.equal(manifest.schemas.Bar.fields.value, 'Text');
+    const verify = (manifest) => verifyPrimitiveType(manifest.schemas.Bar.fields.value, 'Text');
     verify(manifest);
     verify(await Manifest.parse(manifest.toString(), {}));
   });
@@ -234,7 +240,7 @@ ${particleStr1}
       schema Foo
         Text value
       schema Bar extends Foo`);
-    const verify = (manifest) => assert.equal(manifest.schemas.Bar.fields.value, 'Text');
+    const verify = (manifest) => verifyPrimitiveType(manifest.schemas.Bar.fields.value, 'Text');
     verify(manifest);
     verify(await Manifest.parse(manifest.toString(), {}));
   });
@@ -474,7 +480,7 @@ ${particleStr1}
             Text value`
     });
     const manifest = await Manifest.load('a', loader, {registry});
-    assert.equal(manifest.schemas.Bar.fields['value'], 'Text');
+    verifyPrimitiveType(manifest.schemas.Bar.fields.value, 'Text');
   });
   it('can find all imported recipes', async () => {
     const loader = new StubLoader({
@@ -499,9 +505,12 @@ ${particleStr1}
     const verify = (manifest) => {
       const opt = manifest.schemas.Foo.fields;
       assert.equal(opt.u.kind, 'schema-union');
-      assert.deepEqual(opt.u.types, ['Text', 'URL']);
+      verifyPrimitiveType(opt.u.types[0], 'Text');
+      verifyPrimitiveType(opt.u.types[1], 'URL');
       assert.equal(opt.t.kind, 'schema-tuple');
-      assert.deepEqual(opt.t.types, ['Number', 'Number', 'Boolean']);
+      verifyPrimitiveType(opt.t.types[0], 'Number');
+      verifyPrimitiveType(opt.t.types[1], 'Number');
+      verifyPrimitiveType(opt.t.types[2], 'Boolean');
     };
     verify(manifest);
     verify(await Manifest.parse(manifest.toString()));
@@ -1449,7 +1458,7 @@ resource SomeName
     assert(recipe.isResolved());
     const schema = recipe.particles[0].connections.bar.type.getEntitySchema();
     const innerSchema = schema.fields.foo.schema.model.getEntitySchema();
-    assert.deepEqual(innerSchema.fields, {far: 'Text'});
+    verifyPrimitiveType(innerSchema.fields.far, 'Text');
 
     assert.equal(manifest.particles[0].toString(),
 `particle P in 'null'
@@ -1472,7 +1481,7 @@ resource SomeName
     assert(recipe.isResolved());
     const schema = recipe.particles[0].connections.bar.type.getEntitySchema();
     const innerSchema = schema.fields.foo.schema.model.getEntitySchema();
-    assert.deepEqual(innerSchema.fields, {far: 'Text'});
+    verifyPrimitiveType(innerSchema.fields.far, 'Text');
 
     assert.equal(manifest.particles[0].toString(),
 `particle P in 'null'
@@ -1496,7 +1505,7 @@ resource SomeName
     assert(recipe.isResolved());
     const schema = recipe.particles[0].connections.bar.type.getEntitySchema();
     const innerSchema = schema.fields.foo.schema.schema.model.getEntitySchema();
-    assert.deepEqual(innerSchema.fields, {far: 'Text'});
+    verifyPrimitiveType(innerSchema.fields.far, 'Text');
 
     assert.equal(manifest.particles[0].toString(),
 `particle P in 'null'
@@ -1518,7 +1527,7 @@ resource SomeName
     assert(recipe.isResolved());
     const schema = recipe.particles[0].connections.bar.type.getEntitySchema();
     const innerSchema = schema.fields.foo.schema.schema.model.getEntitySchema();
-    assert.deepEqual(innerSchema.fields, {far: 'Text'});
+    verifyPrimitiveType(innerSchema.fields.far, 'Text');
 
     assert.equal(manifest.particles[0].toString(),
 `particle P in 'null'
@@ -1585,8 +1594,11 @@ resource SomeName
     // and {Text value, Text value3}. Hence, the recipe is valid and the type
     // of the handle is * {Text value, Text value2, Text value3};
     assert(suspiciouslyValidRecipe.normalize());
-    const suspiciouslyValidFields = suspiciouslyValidRecipe.handles[0].type.canWriteSuperset.getEntitySchema().fields;
-    assert.deepEqual(suspiciouslyValidFields, {value: 'Text', value2: 'Text', value3: 'Text'});
+    const suspiciouslyValidFields =
+        suspiciouslyValidRecipe.handles[0].type.canWriteSuperset.getEntitySchema().fields;
+    verifyPrimitiveType(suspiciouslyValidFields.value, 'Text');
+    verifyPrimitiveType(suspiciouslyValidFields.value2, 'Text');
+    verifyPrimitiveType(suspiciouslyValidFields.value3, 'Text');
     assert(!invalidRecipe.normalize());
   });
 

--- a/src/runtime/test/schema-tests.ts
+++ b/src/runtime/test/schema-tests.ts
@@ -19,6 +19,14 @@ import {Schema} from '../schema.js';
 import {StubLoader} from '../testing/stub-loader.js';
 import {EntityType, ReferenceType} from '../type.js';
 
+// Modifies the schema in-place.
+function deleteLocations(schema: Schema): Schema {
+  for (const [name, type] of Object.entries(schema.fields)) {
+    delete type.location;
+  }
+  return schema;
+}
+
 describe('schema', () => {
   // Avoid initialising non-POD variables globally, since they would be constructed even when
   // these tests are not going to be executed (i.e. another test file uses 'only').
@@ -52,12 +60,24 @@ describe('schema', () => {
   it('schemas load recursively', async () => {
     const manifest = await Manifest.load('Product.schema', loader);
     const schema = manifest.findSchemaByName('Product');
-    assert.deepEqual(schema.fields, {description: 'Text', image: 'URL', category: 'Text',
-                                     price: 'Text', seller: 'Text', shipDays: 'Number',
-                                     url: 'URL', identifier: 'Text', isReal: 'Boolean',
-                                     brand: 'Object', name: 'Text'});
     assert.equal(schema.name, 'Product');
     assert.include(schema.names, 'Thing');
+
+    const kind = 'schema-primitive';
+    const expected = {
+      description: {kind, type: 'Text'},
+      image:       {kind, type: 'URL'},
+      category:    {kind, type: 'Text'},
+      price:       {kind, type: 'Text'},
+      seller:      {kind, type: 'Text'},
+      shipDays:    {kind, type: 'Number'},
+      url:         {kind, type: 'URL'},
+      identifier:  {kind, type: 'Text'},
+      isReal:      {kind, type: 'Boolean'},
+      brand:       {kind, type: 'Object'},
+      name:        {kind, type: 'Text'}
+    };
+    assert.deepEqual(deleteLocations(schema).fields, expected);
   });
 
   it('constructs an appropriate entity subclass', async () => {
@@ -333,7 +353,9 @@ describe('schema', () => {
     const Animal = manifest.findSchemaByName('Animal');
 
     const fields = {...Person.fields, ...Animal.fields};
-    assert.deepEqual(Schema.union(Person, Animal), new Schema(['Person', 'Animal', 'Thing'], fields));
+    const expected = deleteLocations(new Schema(['Person', 'Animal', 'Thing'], fields));
+    const actual = deleteLocations(Schema.union(Person, Animal));
+    assert.deepEqual(actual, expected);
   });
 
   it('handles field type conflict in schema unions', async () => {
@@ -361,7 +383,9 @@ describe('schema', () => {
     const Animal = manifest.findSchemaByName('Animal');
 
     const fields = {...Thing.fields, isReal: 'Boolean'};
-    assert.deepEqual(Schema.intersect(Animal, Product), new Schema(['Thing'], fields));
+    const expected = deleteLocations(new Schema(['Thing'], fields));
+    const actual = deleteLocations(Schema.intersect(Animal, Product));
+    assert.deepEqual(actual, expected);
   });
 
   it('handles schema intersection if no shared supertype and a conflicting field', async () => {
@@ -375,7 +399,9 @@ describe('schema', () => {
     assert.isFalse(Schema.typesEqual(Person.fields.price, Product.fields.price));
     assert.isUndefined(intersection.fields.price);
 
-    assert.deepEqual(Schema.intersect(Person, Product), new Schema([], {name: 'Text'}));
+    const expected = deleteLocations(new Schema([], {name: 'Text'}));
+    const actual = deleteLocations(Schema.intersect(Person, Product));
+    assert.deepEqual(actual, expected);
   });
 
   it('handles empty schema intersection as empty object', async () => {

--- a/src/runtime/test/type-test.ts
+++ b/src/runtime/test/type-test.ts
@@ -35,7 +35,7 @@ describe('types', () => {
       const entity = EntityType.make(['Foo'], {value: 'Text'});
       deepEqual(entity.toLiteral(), {
         tag: 'Entity',
-        data: {names: ['Foo'], fields: {value: 'Text'}, description: {}}
+        data: {names: ['Foo'], fields: {value: {kind: 'schema-primitive', type: 'Text'}}, description: {}}
       });
       deepEqual(entity, Type.fromLiteral(entity.toLiteral()));
       deepEqual(entity, entity.clone(new Map()));

--- a/src/runtime/wasm.ts
+++ b/src/runtime/wasm.ts
@@ -14,7 +14,7 @@ import {EntityInterface} from './entity.js';
 import protobufjs from 'protobufjs';
 
 function jsonBaseType(type) {
-  const kind = type.kind || type;
+  const kind = (type.kind === 'schema-primitive') ? type.type : type.kind;
   switch (kind) {
     case 'Text':
       return 'string';
@@ -84,7 +84,7 @@ export class EntityProtoConverter {
 
   encode(entity: EntityInterface): Uint8Array {
     const proto = this.message.create();
-    const scalar = (field, value) => (field === 'URL') ? {href: value} : value;
+    const scalar = (field, value) => (field.type === 'URL') ? {href: value} : value;
     for (const [name, value] of Object.entries(entity.toLiteral())) {
       const field = this.schema.fields[name];
       if (field.kind === 'schema-collection') {
@@ -99,7 +99,7 @@ export class EntityProtoConverter {
 
   decode(buffer: Uint8Array): EntityInterface {
     const proto = this.message.decode(buffer);
-    const scalar = (field, value) => (field === 'URL') ? value.href : value;
+    const scalar = (field, value) => (field.type === 'URL') ? value.href : value;
     const data = {};
     for (const [name, value] of Object.entries(proto.toJSON()) as [string, []][]) {
       const field = this.schema.fields[name];


### PR DESCRIPTION
Currently the parser outputs a plain string as the 'type' node for primitive fields (Text, Number, etc.) and an object with kind, location and other fields for collections, unions, etc. This complicates the processing of schema types and will make dynamic proto generation harder as we add support for the more complex types.

This CL makes the parser produce objects like {kind: 'schema-primitive', type: 'Text'}.