### PR TITLE
Webpack config for packaging src/tools with their deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -920,7 +920,7 @@
     "arr-flatten": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
       "dev": true
     },
     "arr-union": {
@@ -10108,7 +10108,7 @@
         },
         "external-editor": {
           "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
           "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
           "dev": true,
           "requires": {
@@ -10374,6 +10374,11 @@
           }
         }
       }
+    },
+    "webpack-node-externals": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/webpack-node-externals/-/webpack-node-externals-1.7.2.tgz",
+      "integrity": "sha512-ajerHZ+BJKeCLviLUUmnyd5B4RavLF76uv3cs6KNuO8W+HuQaEs0y0L7o40NQxdPy5w0pcv8Ew7yPUAQG0UdCg=="
     },
     "webpack-sources": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "s-test-shells": "run-s --print-name --continue-on-error test-wdio-shells",
     "build:tsc": "tsc",
     "watch:tsc": "tsc -w",
-    "build:webpack": "webpack",
+    "build:webpack": "webpack && webpack --config ./src/tools/webpack.config.js",
     "watch:webpack": "webpack --watch",
     "watch": "concurrently npm:watch:*"
   },
@@ -73,7 +73,8 @@
     "wdio-spec-reporter": "^0.1.5",
     "webdriverio": "^4.14.1",
     "webpack": "^4.29.3",
-    "webpack-cli": "^3.2.3"
+    "webpack-cli": "^3.2.3",
+    "webpack-node-externals": "^1.7.2"
   },
   "dependencies": {
     "assert": "^1.4.1",

--- a/src/tools/webpack.config.js
+++ b/src/tools/webpack.config.js
@@ -1,0 +1,26 @@
+const path = require('path');
+const webpack = require('webpack');
+const nodeExternals = require('webpack-node-externals');
+
+const buildDir = './build/tools';
+
+// Package Tools CLIs into self contained .js files to be used with plain node.
+module.exports = {
+  target: 'node',
+  mode: 'production',
+  entry: {
+    'bundle-cli': `${buildDir}/bundle-cli.js`
+  },
+  output: {
+    filename: '[name].js',
+    path: path.resolve(__dirname, `../../dist/tools`)
+  },
+  externals: [nodeExternals()],
+  plugins: [
+    new webpack.NormalModuleReplacementPlugin(
+      // Replace all the web variants with node ones.
+      /\/platform\/.*-web.js$/,
+      resource =>  resource.request = resource.request.replace(/-web.js$/, '-node.js')
+    )
+  ]
+};

--- a/tools/sigh.ts
+++ b/tools/sigh.ts
@@ -80,7 +80,7 @@ const eslintCache = '.eslint_sigh_cache';
 const coverageDir = 'coverage';
 // Files to be deleted by clean, if they aren't in one of the cleanDirs.
 const cleanFiles = ['manifest-railroad.html', 'flow-assertion-railroad.html', eslintCache];
-const cleanDirs = ['shell/build', 'shells/lib/build', 'build', 'src/gen', 'test-output', coverageDir];
+const cleanDirs = ['shell/build', 'shells/lib/build', 'build', 'dist', 'src/gen', 'test-output', coverageDir];
 
 // RE pattern to exclude when finding within project source files.
 const srcExclude = /\b(node_modules|deps|build|third_party)\b/;


### PR DESCRIPTION
I propose `/dist/tools/` to contain standalone versions of tools for end-developers. Opinions?

The new webpack config for tools needs to be separate from the one for the shell dependencies as it is targeting node as opposed to the web.