### PR TITLE
Trivial stardate calculator for The Original Series.

### DIFF
--- a/particles/Stardate/Stardate.recipes
+++ b/particles/Stardate/Stardate.recipes
@@ -1,0 +1,13 @@
+import '../Common/Description.schema'
+import './StardateTOS.particle'
+import './StardateDisplay.particle'
+
+recipe StardateTOS
+  create as stardate
+  create as destination
+  StardateTOS
+    stardate = stardate
+    destination = destination
+  StardateDisplay
+    stardate = stardate
+    destination = destination

--- a/particles/Stardate/StardateDisplay.particle
+++ b/particles/Stardate/StardateDisplay.particle
@@ -1,0 +1,4 @@
+particle StardateDisplay in './js/StardateDisplay.js'
+  consume root
+  in DestinationPlanet {Text name} destination
+  in ScriptDate {Text date} stardate

--- a/particles/Stardate/StardateTOS.particle
+++ b/particles/Stardate/StardateTOS.particle
@@ -1,0 +1,4 @@
+particle StardateTOS in './js/StardateTOS.js'
+  out DestinationPlanet {Text name} destination
+  out ScriptDate {Text date} stardate
+  description `stardate ${stardate.date}, orbiting ${destination.name}`

--- a/particles/Stardate/js/StardateDisplay.js
+++ b/particles/Stardate/js/StardateDisplay.js
@@ -1,0 +1,26 @@
+'use strict';
+
+ /* global defineParticle */
+
+ defineParticle(({DomParticle, html, log}) => {
+  const template = html`
+ <div style="padding: 8px;">
+  Captain's log, stardate <b>{{stardate}}</b>.
+  Our destination is <b>{{destination}}</b>.
+</div>
+   `;
+
+   return class extends DomParticle {
+    get template() {
+      return template;
+    }
+    render({stardate, destination}, state) {
+      if (stardate && destination) {
+        return {
+          stardate: stardate.date,
+          destination: destination.name
+        };
+      }
+    }
+  };
+});

--- a/particles/Stardate/js/StardateTOS.js
+++ b/particles/Stardate/js/StardateTOS.js
@@ -1,0 +1,39 @@
+'use strict';
+
+/* global defineParticle */
+
+defineParticle(({DomParticle, html, log}) => {
+  const MIN_STARDATE = 1000;
+  const MAX_STARDATE = 9999;
+  // Via https://nasa.tumblr.com/post/150044040289/top-10-star-trek-planets-chosen-by-our-scientists
+  const PLANETS = [
+    'Vulcan', 'Andoria', 'Risa', '"Shore Leave" planet, Omicron Delta region', 'Nibiru',
+    'Wolf 359', 'Eminar VII', 'Remus', 'Janus VI', 'Earth'
+  ];
+
+  return class extends DomParticle {
+    update() {
+      const {stardate, destination} = this.computeStardate();
+      this.updateVariable('stardate', {date: stardate});
+      this.updateVariable('destination', {name: destination});
+    }
+    computeStardate() {
+      // Aims to follow logic per https://en.wikipedia.org/wiki/Stardate#The_Original_Series_era
+
+      // TODO(wkorman): Intent was to keep track of the "last stardate" within
+      // an arc and use that as the initial prefix. However, we need to find
+      // a way to do this that doesn't break with SpecEx, so for now it's a
+      // new date every time.
+
+      const prefix = MIN_STARDATE;
+      const remainder = MAX_STARDATE - prefix;
+      const stardate = prefix + Math.floor(Math.random() * remainder);
+      const intraday = Math.trunc((new Date().getHours() / 24) * 10);
+      const destination = PLANETS[Math.floor(Math.random() * (PLANETS.length - 1))];
+      return {
+        stardate: `${stardate}.${intraday}`,
+        destination
+      };
+    }
+  };
+});

--- a/particles/canonical.manifest
+++ b/particles/canonical.manifest
@@ -7,6 +7,7 @@ import 'Music/Music.recipes'
 import 'TVMaze/TVMaze.recipes'
 import 'Words/Words.recipes'
 import 'Services/Services.recipes'
+import 'Stardate/Stardate.recipes'
 import 'Demo/Demo.recipes'
 
 // Uncomment to enable tutorial recipes. See Tutorial/tutorial.md for details.


### PR DESCRIPTION
Looking for a way to update the handles for current stardate and destination, and to include the stardate (and perhaps destination) in the description, without having to move away from inline schemas.

If it's not possible this could catalyze filing specific issues with this as a repro case.