### PR TITLE
fix description for null entity property

### DIFF
--- a/src/runtime/description-formatter.ts
+++ b/src/runtime/description-formatter.ts
@@ -122,7 +122,7 @@ export class DescriptionFormatter {
     assert(sentence);
     // "Capitalize, punctuate." (if the sentence doesn't end with a punctuation character).
     const last = sentence.length - 1;
-    return `${sentence[0].toUpperCase()}${sentence.slice(1, last)}${sentence[last]}${sentence[last].match(/[a-z0-9()'>\]]/i) ? '.' : ''}`;
+    return `${sentence[0].toUpperCase()}${sentence.slice(1, last)}${sentence[last]}${sentence[last].match(/[a-z0-9()' >\]]/i) ? '.' : ''}`;
   }
 
   patternToSuggestion(pattern, particleDescription) {
@@ -329,6 +329,9 @@ export class DescriptionFormatter {
   }
 
   _propertyTokenToString(handleName: string, value: DescriptionValue, properties: string[]) {
+    if (!value) {
+      return '';
+    }
     assert(value.entityValue, `Cannot return property ${properties.join(',')} for non EntityType.`);
     // Use singleton value's property (eg. "09/15" for person's birthday)
     const valueVar = value.entityValue;

--- a/src/runtime/test/description-test.ts
+++ b/src/runtime/test/description-test.ts
@@ -534,12 +534,12 @@ recipe
       `;
       const manifest = (await Manifest.parse(manifestStr));
       const recipe = manifest.recipes[0];
-      const ScriptDate = manifest.findSchemaByName('ScriptDate').entityClass().type;
-      recipe.handles[0].mapToStorage({id: 'test:1', type: ScriptDate});
+      const scriptDateType = manifest.findSchemaByName('ScriptDate').entityClass().type;
+      recipe.handles[0].mapToStorage({id: 'test:1', type: scriptDateType});
       assert.isTrue(recipe.normalize());
       assert.isTrue(recipe.isResolved());
       const arc = createTestArc(recipe, manifest);
-      const store = await arc.createStore(ScriptDate, undefined, 'test:1') as VariableStorageProvider;
+      const store = await arc.createStore(scriptDateType, undefined, 'test:1') as VariableStorageProvider;
       await test.verifySuggestion({arc}, 'Stardate .');
 
       await store.set({id: 1, rawData: {date: 'June 31'}});

--- a/src/runtime/test/description-test.ts
+++ b/src/runtime/test/description-test.ts
@@ -493,7 +493,7 @@ recipe
   });
 
   tests.forEach((test) => {
-    it('sanisize description ' + test.name, async () => {
+    it('sanitize description ' + test.name, async () => {
       const {arc, recipe} = (await prepareRecipeAndArc(`
 ${schemaManifest}
 particle A
@@ -516,6 +516,36 @@ recipe
     });
   });
 
+  tests.forEach((test) => {
+    it('uses store value property ' + test.name, async () => {
+      const manifestStr = `
+      schema ScriptDate
+        Text date
+      particle Stardate in './source/Stardate.js'
+        inout ScriptDate stardate
+        consume root
+        description \`stardate \${stardate.date}\`
+      recipe
+        create as stardateHandle
+        slot 'slotid' as slot0
+        Stardate
+          stardate = stardateHandle
+          consume root as slot0
+      `;
+      const manifest = (await Manifest.parse(manifestStr));
+      const recipe = manifest.recipes[0];
+      const ScriptDate = manifest.findSchemaByName('ScriptDate').entityClass().type;
+      recipe.handles[0].mapToStorage({id: 'test:1', type: ScriptDate});
+      assert.isTrue(recipe.normalize());
+      assert.isTrue(recipe.isResolved());
+      const arc = createTestArc(recipe, manifest);
+      const store = await arc.createStore(ScriptDate, undefined, 'test:1') as VariableStorageProvider;
+      await test.verifySuggestion({arc}, 'Stardate .');
+
+      await store.set({id: 1, rawData: {date: 'June 31'}});
+      await test.verifySuggestion({arc}, 'Stardate June 31.');
+    });
+  });
   tests.forEach((test) => {
     it('multiword type and no name property in description ' + test.name, async () => {
       const manifestStr = `
@@ -724,7 +754,7 @@ schema GitHubDash`));
       recipe
         Foo
         description \`Hello \${Bar.things}\`
-    `, `Hello `);
+    `, `Hello .`);
 
     await verifyNoAssert(`
       particle Foo in 'foo.js'


### PR DESCRIPTION
particle description referencing a property of entity with no value currently causes:
```
Uncaught (in promise) TypeError: Cannot read property 'entityValue' of undefined
    at DescriptionFormatter._propertyTokenToString (description-formatter.ts:335)
    at DescriptionFormatter._handleTokenToString (description-formatter.ts:278)
    at DescriptionFormatter.tokenToString (description-formatter.ts:246)
    at description-formatter.ts:130
    at Array.map (<anonymous>)
    at DescriptionFormatter.patternToSuggestion (description-formatter.ts:130)
    at description-formatter.ts:85
    at Array.map (<anonymous>)
    at DescriptionFormatter._combineSelectedDescriptions (description-formatter.ts:83)
    at DescriptionFormatter.getDescription (description-formatter.ts:64)
```