### PR TITLE
Avoid running expensive ML tasks at SpecEx time

### DIFF
--- a/particles/Services/particles/js/Ml5.js
+++ b/particles/Services/particles/js/Ml5.js
@@ -28,22 +28,28 @@ defineParticle(({DomParticle, log, html, resolver}) => {
       return template;
     }
     update({}, state) {
+      // TODO(sjmiles): update() is called during SpecEx, while
+      // render() is not. We'll put our processing code in render()
+      // to avoid being expensive at SpecEx time.
+    }
+    render({}, state) {
+      // formerly update
       if (!state.classified) {
         state.classified = true;
         this.classify(url);
       }
-    }
-    async classify(imageUrl) {
-      const response = await this.service({call: 'ml5.classifyImage', imageUrl});
-      this.setState({response});
-    }
-    render({}, {response}) {
+      // render proper
+      let {response} = state;
       response = response || {label: '<working>', probability: '<working>'};
       return {
         label: response.label,
         probability: response.probability,
         imageUrl: url
       };
+    }
+    async classify(imageUrl) {
+      const response = await this.service({call: 'ml5.classifyImage', imageUrl});
+      this.setState({response});
     }
   };
 

--- a/particles/Services/particles/js/Tfjs.js
+++ b/particles/Services/particles/js/Tfjs.js
@@ -45,6 +45,12 @@ defineParticle(({DomParticle, log, html, resolver}) => {
       return template;
     }
     update({}, state) {
+      // TODO(sjmiles): update() is called during SpecEx, while
+      // render() is not. We'll put our processing code in render()
+      // to avoid being expensive at SpecEx time.
+    }
+    render({}, state) {
+      // formerly update
       if (!state.run) {
         state.run = true;
         state.training = [
@@ -57,6 +63,14 @@ defineParticle(({DomParticle, log, html, resolver}) => {
         state.fits = 100;
         this.run(state);
       }
+      // render proper
+      const {training, query, fits, response} = state;
+      return {
+        training: JSON.stringify(training),
+        query,
+        fits,
+        outputs: response || 'training...'
+      };
     }
     async run({training, query, fits}) {
       const tf = new Tf(this);
@@ -64,14 +78,6 @@ defineParticle(({DomParticle, log, html, resolver}) => {
       const response = await tf.linearRegression(model, training, fits, query);
       tf.dispose(model);
       this.setState({response});
-    }
-    render({}, {training, query, fits, response}) {
-      return {
-        training: JSON.stringify(training),
-        query,
-        fits,
-        outputs: response || 'training...'
-      };
     }
   };
 


### PR DESCRIPTION
For DomParticle `update()` is called during SpecEx, but `render()` never is (because there is no slot composer in the speculative arc).

By moving expensive logic from `update()` into `render()` I can avoid SpecEx costs.

This is a hack, but without it, Planner time is severely compromised. 

We should have more explicit control over these things.
