### PR TITLE
Migrate github pages to use https://live.arcs.dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,10 @@ before_deploy:
   # Temporarily push node_modules to arcs-live,
   # with the exception of exe files as Github complains about them.
   - cd ${TRAVIS_BUILD_DIR} && sed -i.sedbackup -e 's/^\*\*\/node_modules$/\*\*\/node_modules\/\*\*\/\*\.exe/' .gitignore
+  # Configure for live.arcs.dev domain name and default web-shells redirect
+  - echo "live.arcs.dev" > CNAME
+  - echo '<head><meta http-equiv="refresh" content="0;/shells/web-shell/"></head>' > index.html
+
 
 deploy:
   provider: pages

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 A hosted version of Arcs is available in both tagged and bleeding edge forms.
 Neither is stable -- the runtime, database and front-end are all iterating rapidly.
 
-[TypeDoc](https://polymerlabs.github.io/arcs-live/dist/apidocs/)
+[TypeDoc](https://live.arcs.dev/dist/apidocs/)
 generated documentation is available for Arcs Runtime.
 
 ## Tagged Releases
@@ -20,8 +20,8 @@ Tagged release URLs have the form
 path due to a previous version of shell code) is
 [v0.4.1](https://cdn.rawgit.com/PolymerLabs/arcs-live/v0.4.1/shell/apps/web/index.html).
 
-Bleeding edge often works and is available via github pages:
-https://polymerlabs.github.io/arcs-live/shells/web-shell
+Bleeding edge often works and is available on:
+https://live.arcs.dev/
 
 
 

--- a/extension/redirect-to-arcs.html
+++ b/extension/redirect-to-arcs.html
@@ -23,5 +23,5 @@ http://polymer.github.io/PATENTS.txt
   the redirect above, and uncomment this one:
 
 <meta http-equiv="refresh"
-      content="0; https://polymerlabs.github.io/arcs-live/shell/apps/chrome-extension/?arc=*">
+      content="0; https://live.arcs.dev/shell/apps/chrome-extension/?arc=*">
 -->

--- a/shells/web-shell/README.md
+++ b/shells/web-shell/README.md
@@ -1,6 +1,6 @@
 ## web-shell Flags
 
-e.g. https://polymerlabs.github.io/arcs-live/shells/web-shell/?storage=pouchdb&user=barney
+e.g. https://live.arcs.dev/shells/web-shell/?storage=pouchdb&user=barney
 
 ### Setting Storage Provider
 

--- a/src/planning/plan/README.md
+++ b/src/planning/plan/README.md
@@ -1,29 +1,29 @@
 # Planning in the Shell
 
 By default plans are produced and consumed locally in the browser.
-When using [arcs-live](https://polymerlabs.github.io/arcs-live/shells/web-shell) default suggestions storage is `volatile`.
+When using [arcs-live](https://live.arcs.dev/shells/web-shell/) default suggestions storage is `volatile`.
 
 ## URL params
-Suggestions storage can be controlled by **plannerStorage** url param. 
+Suggestions storage can be controlled by **plannerStorage** url param.
 
-* Navigate to the Arcs page and use **volatile** storage for suggestion:  
-https://polymerlabs.github.io/arcs-live/shells/web-shell?plannerStorage=volatile
+* Navigate to the Arcs page and use **volatile** storage for suggestion:
+https://live.arcs.dev/shells/web-shell/?plannerStorage=volatile
 
-* Navigate to the Arcs page and use **PouchDb** storage for suggestion:  
-https://polymerlabs.github.io/arcs-live/shells/web-shell?plannerStorage=pouchdb://local/random-db-name  
+* Navigate to the Arcs page and use **PouchDb** storage for suggestion:
+https://live.arcs.dev/shells/web-shell?plannerStorage=pouchdb://local/random-db-name
 The suggestion values will be found in Chrome's inspector, under Application > Storage > Local Storage.
 
-Arcs storage can be controlled by **storage** url param. 
-* Navigate to the Arcs page and use **PouchDb** storage for both - arcs and suggestions:  
+Arcs storage can be controlled by **storage** url param.
+* Navigate to the Arcs page and use **PouchDb** storage for both - arcs and suggestions:
 https://localhost:8080/shells/web-shell?storage=pouchdb://localhost:8080/user/&plannerStorage=pouchdb://localhost:8080/user/
 
 
-To populate Arcs Extension strategy explorer, add the **plannerDebug** url param:  
-https://polymerlabs.github.io/arcs-live/shells/web-shell?plannerDebug
+To populate Arcs Extension strategy explorer, add the **plannerDebug** url param:
+https://live.arcs.dev/shells/web-shell/?plannerDebug
 
-# Remote Planning 
-To consume plans produced on the server, disable shell planning with an **plannerOnlyConsumer** url param, ie:  
-https://polymerlabs.github.io/arcs-live/shells/web-shell?plannerOnlyConsumer=true
+# Remote Planning
+To consume plans produced on the server, disable shell planning with an **plannerOnlyConsumer** url param, ie:
+https://live.arcs.dev/shells/web-shell/?plannerOnlyConsumer=true
 
 ## Firebase
 To run planning on the server use the following command:
@@ -43,7 +43,7 @@ or debug with:
 /shells/planner-shell $ debug.sh
 ```
 
-The remote planning is performed per user for all their arcs.  
+The remote planning is performed per user for all their arcs.
 The default user is **planner** (currently to override, set environment variable or update code [link](https://github.com/PolymerLabs/arcs/blob/master/shells/planner-shell/index.js#L23)).
 
 ## PouchDB
@@ -53,7 +53,7 @@ To test remote planning with Pouch you will need to run a Pouch Server instance 
 ```
 /server $ npm run server
 ```
-2. Start the server on port 8080 by running 
+2. Start the server on port 8080 by running
 ```
 /server $ env {args} npm run server:start
 ```
@@ -72,17 +72,17 @@ More information on how to bring up a Pouch server on a Personal Cloud Server: [
 To browse at Arcs data, go to firebase console.
 
 The default storage key is:
-https://firebase.corp.google.com/u/0/project/arcs-storage/database/arcs-storage/data/0_6_0/  
+https://firebase.corp.google.com/u/0/project/arcs-storage/database/arcs-storage/data/0_6_0/
 In Firebase the arcs are serialized at:
-`/0_6_0/userid--arckey`  
+`/0_6_0/userid--arckey`
 for example:
 `/0_6_0/maria--LT0GE_Jn6C-uGHHiWA7`
 
-Suggestions are serialized at: `/0_6_0/userid/suggestions/arckey`  
+Suggestions are serialized at: `/0_6_0/userid/suggestions/arckey`
 for example:
 `/0_6_0/maria/suggestions/LT0GE_Jn6C-uGHHiWA7`
 
-Search is serialized at: `/0_6_0/userid/search/`  
+Search is serialized at: `/0_6_0/userid/search/`
 for example: `/0_6_0/maria/search`
 
 ## PouchDB


### PR DESCRIPTION
- Adds CNAME generation and top-level redirect to travis deploy
- Updates URLs in most places