### PR TITLE
DO NOT MERGE: Slandlesv1 - Mirror Handles as Slots

### DIFF
--- a/particles/Demo/SLANDLESRestaurantsDemo.recipes
+++ b/particles/Demo/SLANDLESRestaurantsDemo.recipes
@@ -1,0 +1,51 @@
+// Copyright (c) 2018 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+import '../List/SLANDLESList.recipes'
+import '../Layout/SLANDLESLayout.recipes'
+import '../Profile/SLANDLESGeolocate.recipe'
+import '../Restaurants/SLANDLESRestaurantFind.recipes'
+import '../Restaurants/SLANDLESRestaurantDisplay.recipes'
+import '../Restaurants/SLANDLESReservations.recipes'
+
+recipe RestaurantsDemo
+  create as location
+  create as restaurants
+  create #restaurant as selected
+  create #event as event
+  create as descriptions
+  slot #toproot as toproot
+  ReservationForm
+    restaurant = selected
+    event = event
+    consume action as toproot
+  Geolocate
+    location = location
+  RestaurantFind
+    location = location
+    restaurants = restaurants
+  SelectableTiles
+    list = restaurants
+    selected = selected
+  TileMultiplexer
+    list = restaurants
+    hostedParticle = RestaurantTile
+  AnnotationMultiplexer
+    list = restaurants
+    annotation = event
+    hostedParticle = ReservationAnnotation
+  DetailSlider
+    selected = selected
+  RestaurantDetail
+    restaurant = selected
+    consume content
+      provide detailAction as actionSlot
+  ReservationForm
+    restaurant = selected
+    event = event
+    consume action as actionSlot
+  description `[demo] find restaurants and make reservations near ${RestaurantFind.location}`

--- a/particles/Layout/SLANDLESAnimatedTiles.recipes
+++ b/particles/Layout/SLANDLESAnimatedTiles.recipes
@@ -1,0 +1,13 @@
+particle AnimatedTiles in 'source/AnimatedTiles.js'
+  `consume Slot root
+  description `animated tiles`
+
+recipe AnimatedTiles
+  AnimatedTiles
+
+particle RepeaterTiles in 'source/RepeaterTiles.js'
+  `consume Slot root
+  description `repeater tiles`
+
+recipe RepeaterTiles
+  RepeaterTiles

--- a/particles/Layout/SLANDLESBottomScrollTest.recipes
+++ b/particles/Layout/SLANDLESBottomScrollTest.recipes
@@ -1,0 +1,6 @@
+particle BottomScrollTest in 'source/BottomScrollTest.js'
+  `consume Slot root
+  description `bottom scroller`
+
+recipe BottomScrollTest
+  BottomScrollTest

--- a/particles/Layout/SLANDLESDetail.recipes
+++ b/particles/Layout/SLANDLESDetail.recipes
@@ -1,0 +1,9 @@
+particle DetailSlider in 'source/DetailSlider.js'
+  inout ~a selected
+  `consume? Slot modal
+    `provide Slot {handle: selected} content
+
+recipe DetailSlider
+  use #selected as selected
+  DetailSlider
+    selected = selected

--- a/particles/Layout/SLANDLESLayout.recipes
+++ b/particles/Layout/SLANDLESLayout.recipes
@@ -1,0 +1,5 @@
+import 'SLANDLESDetail.recipes'
+import 'SLANDLESTabbedLayout.recipes'
+import 'SLANDLESAnimatedTiles.recipes'
+import 'SLANDLESBottomScrollTest.recipes'
+

--- a/particles/Layout/SLANDLESTabbedLayout.recipes
+++ b/particles/Layout/SLANDLESTabbedLayout.recipes
@@ -1,0 +1,8 @@
+particle TabbedLayout in 'source/Tabbed.js'
+  `consume Slot root
+    `provide Slot content
+  description `tabbed layout`
+
+recipe TabbedLayout
+  TabbedLayout
+

--- a/particles/List/SLANDLESAnnotations.recipes
+++ b/particles/List/SLANDLESAnnotations.recipes
@@ -1,0 +1,45 @@
+// @license
+// Copyright (c) 2018 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+interface HostedAnnotationInterface
+  in ~any *
+  inout ~anyOther *
+  `consume Slot annotation
+
+particle AnnotationMultiplexer in 'source/Multiplexer.js'
+  in [~any] list
+  inout ~anyOther annotation
+  host HostedAnnotationInterface hostedParticle
+  `consume [Slot] annotation
+
+interface HostedSimpleAnnotationInterface
+  in ~any *
+  `consume Slot annotation
+
+particle SimpleAnnotationMultiplexer in 'source/Multiplexer.js'
+  in [~any] list
+  host HostedSimpleAnnotationInterface hostedParticle
+  `consume [Slot] annotation
+
+interface HostedCombinedAnnotationInterface
+  in ~any *
+  in [~anyOther] *
+  `consume Slot annotation
+
+particle CombinedAnnotationMultiplexer in 'source/Multiplexer.js'
+  in [~any] list
+  in [~anyOther] choices
+  host HostedCombinedAnnotationInterface hostedParticle
+  `consume [Slot] annotation
+
+//recipe AnnotationMultiplexer
+//  use #items as list
+//  use #annotation as annotation
+//  AnnotationMultiplexer
+//    list = list
+//    annotation = annotation

--- a/particles/List/SLANDLESChoices.recipes
+++ b/particles/List/SLANDLESChoices.recipes
@@ -1,0 +1,18 @@
+// @license
+// Copyright (c) 2018 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+interface HostedChoiceInterface
+  in ~any *
+  in [~anyOther] *
+  `consume Slot choice
+
+particle ChoicesMultiplexer in 'source/Multiplexer.js'
+  in [~any] list
+  in [~anyOther] choices
+  host HostedChoiceInterface hostedParticle
+  `consume [Slot] choice

--- a/particles/List/SLANDLESItems.recipes
+++ b/particles/List/SLANDLESItems.recipes
@@ -1,0 +1,85 @@
+// @license
+// Copyright (c) 2018 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+interface HostedItemInterface
+  in ~any *
+  // TODO(sjmiles): using slot-type for form-factor
+  // all Interfaces are the same in List/* except for the slot
+  `consume Slot item
+
+particle ItemMultiplexer in 'source/Multiplexer.js'
+  // TODO(sjmiles): redundancies:
+  // 1. slot is declared in HostedItemInterface and as `consume [Slot]  here
+  // 2. ~any is declared in HostedItemInterface and as `[~any]` here
+  in [~any] list
+  host HostedItemInterface hostedParticle
+  `consume [Slot] item
+
+// TODO(sjmiles): recipe is the minimum coalescable artifact, which is good because we need to be able specify
+// handle fates before colascing ... is there a way to combine the declarations when the recipe has only one Particle?
+//recipe ItemMultiplexer
+  // TODO(sjmiles): restricting fate
+  // TODO(sjmiles): without `#items` this recipe doesn't coalese, why?
+//  use #items as list
+//  ItemMultiplexer
+//    list = list
+
+//particle List in 'source/List.js'
+//  in [~any] list
+//  `consume Slot root #items
+//    `provide? [Slot {handle: items}] item
+//  description `show ${list}`
+
+//recipe List
+//  use #items as items
+//  List
+//    items = items
+//  ItemMultiplexer
+//    list = items
+
+particle Items in 'source/Items.js'
+  in [~any] list
+  `consume Slot root #items
+    `provide? Slot preamble
+    `provide? [Slot {handle: list}] item
+    `provide? [Slot {handle: list}] annotation
+    `provide? Slot action
+    `provide? Slot postamble
+  description `display ${list}`
+
+particle SelectableItems in 'source/Items.js'
+  in [~any] list
+  inout? ~any selected
+  `consume Slot root #items
+    `provide? Slot preamble
+    `provide [Slot {handle: list}] item
+    `provide? [Slot {handle: list}] annotation
+    `provide? Slot action
+    `provide? Slot postamble
+  description `display ${list}`
+
+// TODO(sjmiles): nearly duplicate recipes here because we want to support `use` and `copy` but not `create`,
+// maybe there should be a fate for this, or require `create` to be explicit
+
+//recipe SelectableCopyItemsRecipe
+//  copy #items as items
+//  create #selected as selected
+//  SelectableItems
+//    items = items
+//    selected = selected
+//  ItemMultiplexer
+//    list = items
+
+//recipe SelectableUseItemsRecipe
+//  use #items as items
+//  create #selected as selected
+//  SelectableItems
+//    items = items
+//    selected = selected
+//  ItemMultiplexer
+//    list = items

--- a/particles/List/SLANDLESList.recipes
+++ b/particles/List/SLANDLESList.recipes
@@ -1,0 +1,12 @@
+// @license
+// Copyright (c) 2018 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+import 'SLANDLESTiles.recipes'
+import 'SLANDLESItems.recipes'
+import 'SLANDLESAnnotations.recipes'
+import 'SLANDLESChoices.recipes'

--- a/particles/List/SLANDLESTiles.recipes
+++ b/particles/List/SLANDLESTiles.recipes
@@ -1,0 +1,45 @@
+// @license
+// Copyright (c) 2018 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+interface HostedTileInterface
+  in ~any *
+  `consume Slot tile
+
+particle TileMultiplexer in 'source/Multiplexer.js'
+  in [~any] list
+  host HostedTileInterface hostedParticle
+  `consume [Slot] tile
+
+//recipe TileMultiplexer
+//  use #tile as list
+//  TileMultiplexer
+//    list = list
+
+particle SelectableTiles in 'source/Tiles.js'
+  in [~any] list
+  inout ~any selected
+  `consume Slot root #tiles
+    `provide [Slot] tile
+    `provide? [Slot] annotation
+    `provide? Slot action
+
+//recipe SelectableCopyTilesRecipe
+//  copy #items as items
+//  create #selected as selected
+//  SelectableTiles
+//    items = items
+//    selected = selected
+//  description `show ${SelectableTiles.items}`
+
+//recipe SelectableUseTilesRecipe
+//  use #items as items
+//  create #selected as selected
+//  SelectableTiles
+//    items = items
+//    selected = selected
+//  description `show ${SelectableTiles.items}`

--- a/particles/Profile/SLANDLESFavoriteFood.recipes
+++ b/particles/Profile/SLANDLESFavoriteFood.recipes
@@ -1,0 +1,21 @@
+// Copyright (c) 2017 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+schema FavoriteFood
+  Text food
+
+particle FavoriteFoodPicker in 'source/FavoriteFoodPicker.js'
+  inout [FavoriteFood] foods
+  `consume Slot root
+  description `select favorite foods`
+    foods `favorite foods`
+
+recipe FavoriteFood
+  create #favoriteFoods as foods
+  FavoriteFoodPicker
+    foods = foods
+

--- a/particles/Profile/SLANDLESGeolocate.recipe
+++ b/particles/Profile/SLANDLESGeolocate.recipe
@@ -1,0 +1,12 @@
+import './Geolocation.schema'
+
+particle Geolocate in './source/Geolocate.js'
+  `consume Slot root
+  out Geolocation location
+  description `you`
+    location `you`
+
+recipe Geolocate
+  create as location
+  Geolocate
+    location = location

--- a/particles/Restaurants/SLANDLESFavoriteFoodAnnotation.recipes
+++ b/particles/Restaurants/SLANDLESFavoriteFoodAnnotation.recipes
@@ -1,0 +1,28 @@
+// @license
+// Copyright (c) 2017 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+import '../List/SLANDLESList.recipes'
+import '../Profile/SLANDLESFavoriteFood.recipes'
+import './Restaurant.schema'
+import '../Events/Event.schema'
+import './SLANDLESReservations.recipes'
+
+particle FavoriteFoodAnnotation in 'source/FavoriteFoodAnnotation.js'
+  in Restaurant restaurant
+  in [FavoriteFood] foods
+  `consume Slot annotation
+
+recipe FavoriteFoodAnnotation
+  use as restaurants
+  map 'PROFILE_favoriteFoods' as foods
+  CombinedAnnotationMultiplexer
+    list = restaurants
+    choices = foods
+    hostedParticle = FavoriteFoodAnnotation
+  description `[inline] check restaurants for favorite foods`
+

--- a/particles/Restaurants/SLANDLESReservations.recipes
+++ b/particles/Restaurants/SLANDLESReservations.recipes
@@ -1,0 +1,71 @@
+// Copyright (c) 2018 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+import '../List/List.recipes'
+import '../Layout/Layout.recipes'
+import '../Events/Events.recipes'
+import '../Restaurants/Restaurant.schema'
+import '../Common/Description.schema'
+
+particle ReservationForm in 'source/ReservationForm.js'
+  inout Event event
+  in Restaurant restaurant
+  `consume Slot action
+    `provide Slot annotation
+
+// TODO(sjmiles): couldn't find a way to project ReservationForm into detailAction slot,
+// so fork the particle
+particle DetailReservationForm in 'source/ReservationForm.js'
+  inout Event event
+  in Restaurant restaurant
+  `consume Slot detailAction
+    `provide? Slot annotation
+
+particle ReservationAnnotation in 'source/ReservationAnnotation.js'
+  in Restaurant restaurant
+  inout Event event
+  out [Description] descriptions
+  `consume? Slot annotation
+
+// TODO(sjmiles): we don't have optional handles yet, so fork the particle
+// rather than having every instance generate descriptions
+particle ReservationMultiAnnotation in 'source/ReservationAnnotation.js'
+  in Restaurant restaurant
+  inout Event event
+  `consume? Slot annotation
+
+recipe MakeReservations
+  use as restaurants
+  use #selected as restaurant
+  create #reservation as event
+  create #volatile as calendarDescriptions
+  create #volatile as annotationDescriptions
+  slot 'rootslotid-toproot' as toproot
+  Calendar
+    event = event
+    descriptions = calendarDescriptions
+  // top-of-frame event editor
+  ReservationForm
+    restaurant = restaurant
+    event = event
+    consume action as toproot
+  // per-restaurant tile scheduler
+  AnnotationMultiplexer
+    list = restaurants
+    annotation = event
+    hostedParticle = ReservationMultiAnnotation
+  // event editor (+scheduler) on restaurant detail
+  DetailReservationForm
+     restaurant = restaurant
+     event = event
+     consume detailAction
+       provide annotation as detailAnnotation
+  ReservationAnnotation
+    restaurant = restaurant
+    event = event
+    descriptions = annotationDescriptions
+    consume annotation as detailAnnotation

--- a/particles/Restaurants/SLANDLESRestaurantDisplay.recipes
+++ b/particles/Restaurants/SLANDLESRestaurantDisplay.recipes
@@ -1,0 +1,19 @@
+// Copyright (c) 2018 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+import 'Restaurant.schema'
+
+particle RestaurantTile in 'source/RestaurantTile.js'
+  in Restaurant restaurant
+  `consume Slot tile
+    `provide Slot annotation
+
+particle RestaurantDetail in 'source/RestaurantDetail.js'
+  in Restaurant restaurant
+  `consume Slot content
+    `provide Slot detailAction
+

--- a/particles/Restaurants/SLANDLESRestaurantFind.recipes
+++ b/particles/Restaurants/SLANDLESRestaurantFind.recipes
@@ -1,0 +1,21 @@
+// Copyright (c) 2018 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+import 'Restaurant.schema'
+import '../Profile/SLANDLESGeolocate.recipe'
+
+particle RestaurantFind in 'source/RestaurantFind.js'
+  in Geolocation location
+  inout [Restaurant] restaurants
+
+// TODO: see what happens if we decimate Restaurants.recipes::Recipes into smaller pieces like this
+//recipe RestaurantFind
+//  create #tiles as restaurants
+//  RestaurantFind
+//    restaurants = restaurants
+//  description `find restaurants near ${RestaurantFind.location}`
+

--- a/particles/Restaurants/SLANDLESRestaurants.recipes
+++ b/particles/Restaurants/SLANDLESRestaurants.recipes
@@ -1,0 +1,34 @@
+// Copyright (c) 2018 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+import 'SLANDLESRestaurantFind.recipes'
+import 'SLANDLESRestaurantDisplay.recipes'
+import 'SLANDLESReservations.recipes'
+import 'SLANDLESFavoriteFoodAnnotation.recipes'
+import '../List/SLANDLESList.recipes'
+import '../Profile/SLANDLESGeolocate.recipe'
+
+recipe Restaurants
+  create #volatile as location
+  create as restaurants
+  create #volatile #selected as selected
+  Geolocate
+    location = location
+  RestaurantFind
+    location = location
+    restaurants = restaurants
+  SelectableTiles
+    list = restaurants
+    selected = selected
+  TileMultiplexer
+    list = restaurants
+    hostedParticle = RestaurantTile
+  DetailSlider
+    selected = selected
+  RestaurantDetail
+    restaurant = selected
+  description `find restaurants near ${RestaurantFind.location}`

--- a/particles/Words/SLANDLESGamePane.manifest
+++ b/particles/Words/SLANDLESGamePane.manifest
@@ -1,0 +1,26 @@
+// @license
+// Copyright (c) 2017 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+import '../List/SLANDLESList.recipes'
+import '../People/Person.schema'
+//import '../Social/Post.schema'
+import 'Board.schema'
+import 'Move.schema'
+import 'Stats.schema'
+
+particle GamePane in 'source/GamePane.js'
+  //host HostedParticleInterface renderParticle
+  in Person person
+  inout Board board
+  inout Move move
+  inout Stats stats
+  //inout [Post] posts
+  //inout Post post
+  //in Theme shellTheme
+  `consume Slot root
+  description `play Words`

--- a/src/runtime/manifest-ast-nodes.ts
+++ b/src/runtime/manifest-ast-nodes.ts
@@ -51,6 +51,9 @@ export interface CollectionType extends BaseNode {
   kind: 'collection-type';
   type: ParticleArgumentType;
 }
+export function isCollectionType(node: BaseNode): node is CollectionType {
+  return node.kind === 'collection-type';
+}
 
 export interface ReferenceType extends BaseNode {
   kind: 'reference-type';
@@ -62,10 +65,16 @@ export interface TypeVariable extends BaseNode {
   name: string;
   constraint: ParticleArgument;
 }
+export function isTypeVariable(node: BaseNode): node is TypeVariable {
+  return node.kind === 'variable-type';
+}
 
 export interface SlotType extends BaseNode {
   kind: 'slot-type';
   fields: SlotField[];
+}
+export function isSlotType(node: BaseNode): node is SlotType {
+  return node.kind === 'slot-type';
 }
 // END PARTICLE TYPES
 
@@ -163,7 +172,7 @@ export interface ParticleArgument extends BaseNode {
   direction: Direction;
   type: ParticleArgumentType;
   isOptional: boolean;
-  dependentConnections: string[];
+  dependentConnections: ParticleHandle[];
   name: string;
   tags: TagList;
 }
@@ -200,8 +209,6 @@ export interface ParticleProvidedSlot extends BaseNode {
   isSet: boolean;
   formFactor: SlotFormFactor;
   handles: ParticleProvidedSlotHandle[];
-
-  param: string;
 }
 
 export interface ParticleProvidedSlotHandle extends BaseNode {

--- a/src/runtime/manifest-ast-nodes.ts
+++ b/src/runtime/manifest-ast-nodes.ts
@@ -213,9 +213,10 @@ export interface ParticleRef extends BaseNode {
   kind: 'particle-ref';
   name: string;
   verbs: VerbList;
+  tags: TagList;
 }
 
-export interface Recipe extends BaseNode {
+export interface RecipeNode extends BaseNode {
   kind: 'recipe';
   name: string;
   verbs: VerbList;
@@ -476,7 +477,7 @@ export interface NameAndTagList {
 // Aliases to simplify ts-pegjs returnTypes requirement in sigh.
 export type Annotation = string;
 export type LocalName = string;
-export type Manifest = ManifestStorageItem[];
+export type Manifest = ManifestItem[];
 export type ManifestStorageItem = string;
 export type ParticleArgumentDirection = string;
 export type ResourceStart = string;
@@ -511,4 +512,4 @@ export type All = Import|Meta|MetaName|MetaStorageKey|Particle|ParticleArgument|
     InterfaceSlot;
 
 export type ManifestItem =
-    Recipe|Particle|Import|Schema|ManifestStorage|Interface|Meta|Resource;
+    RecipeNode|Particle|Import|Schema|ManifestStorage|Interface|Meta|Resource;

--- a/src/runtime/manifest-ast-nodes.ts
+++ b/src/runtime/manifest-ast-nodes.ts
@@ -261,13 +261,6 @@ export interface ParticleConnectionTargetComponents extends BaseNode {
   tags: TagList;
 }
 
-export interface ParticleConnnectionTargetComponents extends BaseNode {
-  kind: 'hanlde-connection-components';
-  name: string|null;
-  particle: string|null;
-  tags: TagList;
-}
-
 export interface RecipeHandle extends BaseNode {
   kind: 'handle';
   name: string|null;

--- a/src/runtime/manifest-parser.peg
+++ b/src/runtime/manifest-parser.peg
@@ -289,8 +289,7 @@ ParticleItem "a particle item"
 ParticleHandle
   = arg:ParticleArgument eolWhiteSpace dependentConnections:(Indent (SameIndent ParticleHandle)*)?
   {
-    dependentConnections = optional(dependentConnections, extractIndented, []);
-    arg.dependentConnections = dependentConnections;
+    arg.dependentConnections = optional(dependentConnections, extractIndented, []);
     return arg as AstNode.ParticleHandle;
   }
 
@@ -303,7 +302,7 @@ ParticleArgument
       direction,
       type: type,
       isOptional: !!isOptional,
-      dependentConnections: [],
+      dependentConnections: [] as AstNode.ParticleHandle[],
       name: nametag.name,
       tags: nametag.tags,
     } as AstNode.ParticleArgument;
@@ -1108,7 +1107,7 @@ upperIdent "an uppercase identifier (e.g. Foo)"
   = [A-Z][a-z0-9_]i* { return text(); }
 lowerIdent "a lowercase identifier (e.g. foo)"
   = !ReservedWord [a-z][a-z0-9_]i* { return text(); }
-fieldName "a field name (e.g. foo9)"
+fieldName "a field name (e.g. foo9)" // Current handle and formFactor.
   = [a-z][a-z0-9_]i* { return text(); }
 whiteSpace "one or more whitespace characters"
   = " "+

--- a/src/runtime/manifest-parser.peg
+++ b/src/runtime/manifest-parser.peg
@@ -562,7 +562,7 @@ Recipe
       name: optional(name, name => name[1], null),
       verbs,
       items: optional(items, extractIndented, []),
-    } as AstNode.Recipe;
+    } as AstNode.RecipeNode;
   }
 
 // RequireHandleSection is intended to replace RecipeHandle but for now we allow for both ways to create a handle.
@@ -867,6 +867,7 @@ ParticleRef
       location: location(),
       name,
       verbs: [],
+      tags: []
     } as AstNode.ParticleRef;
   }
   / verb:Verb
@@ -875,6 +876,7 @@ ParticleRef
       kind: 'particle-ref',
       location: location(),
       verbs: [verb],
+      tags: []
     } as AstNode.ParticleRef;
   }
 

--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -726,7 +726,7 @@ ${e.message}
   }
 
   // TODO(cypher): Remove loader dependency.
-  private static _processRecipe(manifest: Manifest, recipeItem: AstNode.Recipe, loader) {
+  private static _processRecipe(manifest: Manifest, recipeItem: AstNode.RecipeNode, loader) {
     const recipe = manifest._newRecipe(recipeItem.name);
 
     if (recipeItem.annotation) {
@@ -849,30 +849,30 @@ ${e.message}
     }
 
     // TODO: disambiguate.
-    for (const item of items.particles) {
-      const particle = recipe.newParticle(item.ref.name);
-      particle.verbs = item.ref.verbs;
+    for (const particleItem of items.particles) {
+      const particle = recipe.newParticle(particleItem.ref.name);
+      particle.verbs = particleItem.ref.verbs;
 
       if (!(recipe instanceof RequireSection)) {
-        if (item.ref.name) {
-          const spec = manifest.findParticleByName(item.ref.name);
+        if (particleItem.ref.name) {
+          const spec = manifest.findParticleByName(particleItem.ref.name);
           if (!spec) {
-            throw new ManifestError(item.location, `could not find particle ${item.ref.name}`);
+            throw new ManifestError(particleItem.location, `could not find particle ${particleItem.ref.name}`);
           }
           particle.spec = spec.clone();
         }
       }
-      if (item.name) {
+      if (particleItem.name) {
         // TODO: errors.
-        assert(!items.byName.has(item.name));
-        particle.localName = item.name;
-        items.byName.set(item.name, {item, particle});
+        assert(!items.byName.has(particleItem.name));
+        particle.localName = particleItem.name;
+        items.byName.set(particleItem.name, {particleItem, particle});
       }
-      items.byParticle.set(particle, item);
+      items.byParticle.set(particle, particleItem);
 
-      for (const slotConnectionItem of item.slotConnections) {
+      for (const slotConnectionItem of particleItem.slotConnections) {
         if (slotConnectionItem.direction === 'provide') {
-          throw new ManifestError(item.location, `invalid slot connection: provide slot must be dependent`);
+          throw new ManifestError(particleItem.location, `invalid slot connection: provide slot must be dependent`);
         }
         let slotConn = particle.consumedSlotConnections[slotConnectionItem.param];
         if (!slotConn) {
@@ -899,10 +899,10 @@ ${e.message}
         slotConn.tags = slotConnectionItem.tags || [];
         slotConnectionItem.dependentSlotConnections.forEach(ps => {
           if (ps.direction === 'consume') {
-            throw new ManifestError(item.location, `invalid slot connection: consume slot must not be dependent`);
+            throw new ManifestError(particleItem.location, `invalid slot connection: consume slot must not be dependent`);
           }
           if (ps.dependentSlotConnections.length !== 0) {
-            throw new ManifestError(item.location, `invalid slot connection: provide slot must not have dependencies`);
+            throw new ManifestError(particleItem.location, `invalid slot connection: provide slot must not have dependencies`);
           }
           if (recipe instanceof RequireSection) {
             // replace provided slot if it already exist in recipe.

--- a/src/runtime/recipe/particle.ts
+++ b/src/runtime/recipe/particle.ts
@@ -25,6 +25,7 @@ export class Particle {
   private _localName?: string = undefined;
   spec?: ParticleSpec = undefined;
   private _verbs: string[] = [];
+  private _tags: string[] = [];
   private _connections: {[index: string]: HandleConnection} = {};
   
   // TODO: replace with constraint connections on the recipe
@@ -43,6 +44,7 @@ export class Particle {
     const particle = recipe.newParticle(this._name);
     particle._id = this._id;
     particle._verbs = [...this._verbs];
+    particle._tags = [...this._tags];
     particle.spec = this.spec ? this.spec.cloneWithResolutions(variableMap) : undefined;
 
     Object.keys(this._connections).forEach(key => {
@@ -90,6 +92,7 @@ export class Particle {
   _startNormalize(): void {
     this._localName = null;
     this._verbs.sort();
+    this._tags.sort();
     const normalizedConnections = {};
     for (const key of (Object.keys(this._connections).sort())) {
       normalizedConnections[key] = this._connections[key];
@@ -115,6 +118,7 @@ export class Particle {
     if ((cmp = compareStrings(this._localName, other._localName)) !== 0) return cmp;
     // TODO: spec?
     if ((cmp = compareArrays(this._verbs, other._verbs, compareStrings)) !== 0) return cmp;
+    if ((cmp = compareArrays(this._tags, other._tags, compareStrings)) !== 0) return cmp;
     // TODO: slots
     return 0;
   }
@@ -218,6 +222,7 @@ export class Particle {
   get consumedSlotConnections() { return this._consumedSlotConnections; }
   get primaryVerb() { return (this._verbs.length > 0) ? this._verbs[0] : undefined; }
   set verbs(verbs) { this._verbs = verbs; }
+  set tags(tags) { this._tags = tags; }
 
   addUnnamedConnection() {
     const connection = new HandleConnection(undefined, this);

--- a/src/runtime/recipe/recipe-util.ts
+++ b/src/runtime/recipe/recipe-util.ts
@@ -116,7 +116,7 @@ export class RecipeUtil {
           continue;
         }
 
-        const acceptedDirections = {'in': ['in', 'inout'], 'out': ['out', 'inout'], '=': ['in', 'out', 'inout'], 'inout': ['inout'], 'host': ['host']};
+        const acceptedDirections = {'in': ['in', 'inout'], 'out': ['out', 'inout'], '=': ['in', 'out', 'inout'], 'inout': ['inout'], 'host': ['host'], '`consume': ['consume'], '`provide': ['provide']};
         if (recipeConnSpec.direction) {
           assert(Object.keys(acceptedDirections).includes(shapeHC.direction), `${shapeHC.direction} not in ${Object.keys(acceptedDirections)}`);
           if (!acceptedDirections[shapeHC.direction].includes(recipeConnSpec.direction)) {

--- a/src/runtime/test/artifacts/Events/SLANDLESCalendar.manifest
+++ b/src/runtime/test/artifacts/Events/SLANDLESCalendar.manifest
@@ -1,0 +1,17 @@
+// @license
+// Copyright (c) 2017 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+import 'Event.schema'
+import '../Common/Description.schema'
+
+particle Calendar in 'source/Calendar.js'
+  inout Event event
+  out [Description] descriptions
+  `consume Slot action
+  `consume Slot modifier
+  description `Select a time from your calendar`

--- a/src/runtime/test/artifacts/Events/SLANDLESEvents.recipes
+++ b/src/runtime/test/artifacts/Events/SLANDLESEvents.recipes
@@ -1,0 +1,17 @@
+// Copyright (c) 2017 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+import 'SLANDLESCalendar.manifest'
+
+recipe
+  Calendar
+
+//import 'EmbeddedCalendar.manifest'
+//recipe
+//  create as event
+//  EmbeddedCalendar
+//    event = event

--- a/src/runtime/test/artifacts/Events/SLANDLESPartySize.manifest
+++ b/src/runtime/test/artifacts/Events/SLANDLESPartySize.manifest
@@ -1,0 +1,16 @@
+// @license
+// Copyright (c) 2017 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+import 'Event.schema'
+
+particle PartySize in 'source/PartySize.js'
+  inout Event event
+  modality dom
+  `consume Slot modifier
+// removing description for now to clean up suggestions
+//  description `number of people`

--- a/src/runtime/test/artifacts/Places/SLANDLESExtractLocation.manifest
+++ b/src/runtime/test/artifacts/Places/SLANDLESExtractLocation.manifest
@@ -1,0 +1,16 @@
+// @license
+// Copyright (c) 2018 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+import '../People/Person.schema'
+import '../Things/GeoCoordinates.schema'
+
+particle ExtractLocation in 'source/ExtractLocation.js'
+  in Person person
+  out GeoCoordinates location
+  description `extract ${person}'s location`
+    location `${person}'s location`

--- a/src/runtime/test/artifacts/Restaurants/SLANDLESFavoriteFoodAnnotation.manifest
+++ b/src/runtime/test/artifacts/Restaurants/SLANDLESFavoriteFoodAnnotation.manifest
@@ -1,0 +1,16 @@
+// @license
+// Copyright (c) 2017 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+import 'Restaurant.schema'
+import '../Profile/FavoriteFood.schema'
+
+particle FavoriteFoodAnnotation in 'source/FavoriteFoodAnnotation.js'
+  in [Restaurant] restaurants
+  in FavoriteFood food
+  `consume [Slot] annotation
+  description `check restaurants for ${food}._name_ ${food.food}`

--- a/src/runtime/test/artifacts/Restaurants/SLANDLESFindRestaurants.manifest
+++ b/src/runtime/test/artifacts/Restaurants/SLANDLESFindRestaurants.manifest
@@ -1,0 +1,18 @@
+// @license
+// Copyright (c) 2017 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+import '../Things/GeoCoordinates.schema'
+import 'Restaurant.schema'
+
+particle FindRestaurants in 'source/FindRestaurants.js'
+  in GeoCoordinates location
+  inout [Restaurant] restaurants
+  modality dom
+  `consume Slot root
+    `provide Slot {handle: restaurants} masterdetail
+  description `find restaurants near ${location}`

--- a/src/runtime/test/artifacts/Restaurants/SLANDLESReservationAnnotation.manifest
+++ b/src/runtime/test/artifacts/Restaurants/SLANDLESReservationAnnotation.manifest
@@ -1,0 +1,16 @@
+// @license
+// Copyright (c) 2017 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+import 'Restaurant.schema'
+import '../Events/Event.schema'
+
+particle ReservationAnnotation in 'source/ReservationAnnotation.js'
+  in [Restaurant] list
+  inout Event event
+  `consume [Slot] annotation
+  //description `reservation details`

--- a/src/runtime/test/artifacts/Restaurants/SLANDLESReservationForm.manifest
+++ b/src/runtime/test/artifacts/Restaurants/SLANDLESReservationForm.manifest
@@ -1,0 +1,19 @@
+// @license
+// Copyright (c) 2017 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+import 'Restaurant.schema'
+import '../Events/Event.schema'
+import '../Common/Description.schema'
+
+particle ReservationForm in 'source/ReservationForm.js'
+  in Restaurant selected
+  inout Event event
+  out [Description] descriptions
+  `consume Slot action
+  description `make a reservation`
+    event `reservation`

--- a/src/runtime/test/artifacts/Restaurants/SLANDLESRestaurantDetail.manifest
+++ b/src/runtime/test/artifacts/Restaurants/SLANDLESRestaurantDetail.manifest
@@ -1,0 +1,17 @@
+// @license
+// Copyright (c) 2017 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+import 'Restaurant.schema'
+
+particle RestaurantDetail in 'source/RestaurantDetail.js'
+  in Restaurant selected
+  modality dom
+  `consume Slot detail
+    `provide Slot action
+// removing description for now to clean up suggestions
+//  description `show restaurant details`

--- a/src/runtime/test/artifacts/Restaurants/SLANDLESRestaurantList.manifest
+++ b/src/runtime/test/artifacts/Restaurants/SLANDLESRestaurantList.manifest
@@ -1,0 +1,18 @@
+// @license
+// Copyright (c) 2017 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+import 'Restaurant.schema'
+
+particle RestaurantList in 'source/RestaurantList.js'
+  in [Restaurant] list
+  inout Restaurant selected
+  `consume Slot master
+    `provide Slot modifier
+    `provide [Slot {handle: list}] annotation
+// removing description for now to clean up suggestions
+//  description `show ${list}`

--- a/src/runtime/test/artifacts/Restaurants/SLANDLESRestaurantMasterDetail.manifest
+++ b/src/runtime/test/artifacts/Restaurants/SLANDLESRestaurantMasterDetail.manifest
@@ -1,0 +1,16 @@
+// @license
+// Copyright (c) 2017 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+import 'Restaurant.schema'
+
+particle RestaurantMasterDetail in '../Common/source/MasterDetail.js'
+  in [Restaurant] list
+  inout Restaurant selected
+  `consume Slot masterdetail
+    `provide Slot {handle: list} master
+    `provide Slot {handle: selected} detail

--- a/src/runtime/test/artifacts/Restaurants/SLANDLESRestaurants.recipes
+++ b/src/runtime/test/artifacts/Restaurants/SLANDLESRestaurants.recipes
@@ -1,0 +1,57 @@
+// Copyright (c) 2017 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+import 'SLANDLESFindRestaurants.manifest'
+import 'SLANDLESRestaurantMasterDetail.manifest'
+import 'SLANDLESRestaurantList.manifest'
+import 'SLANDLESRestaurantDetail.manifest'
+import '../Places/SLANDLESExtractLocation.manifest'
+
+recipe &displayRestaurants
+  ? as list
+  RestaurantMasterDetail.selected -> RestaurantList.selected
+  RestaurantDetail.selected -> RestaurantList.selected
+  RestaurantMasterDetail.list -> RestaurantList.list
+  RestaurantList
+    list <- list
+
+recipe
+  create as location
+  ExtractLocation
+    location -> location
+
+recipe &nearbyRestaurants
+  create #restaurants #volatile as restaurants
+  FindRestaurants
+    restaurants = restaurants
+
+import '../Events/Event.schema'
+import '../Events/SLANDLESPartySize.manifest'
+import 'SLANDLESReservationForm.manifest'
+import 'SLANDLESReservationAnnotation.manifest'
+
+recipe &makeReservation
+  create #event as event
+  use #restaurants as list
+  ReservationForm
+    event = event
+  ReservationAnnotation
+    event = event
+    list = list
+  PartySize
+    event = event
+
+import '../Events/SLANDLESEvents.recipes'
+
+import 'SLANDLESFavoriteFoodAnnotation.manifest'
+
+recipe
+  map #favorite as food
+  use as restaurants
+  FavoriteFoodAnnotation
+    restaurants <- restaurants
+    food <- food

--- a/src/runtime/test/manifest-parser-test.ts
+++ b/src/runtime/test/manifest-parser-test.ts
@@ -292,4 +292,42 @@ describe('manifest parser', () => {
           input <- h0
     `);
   });
+  it('parses comment on manifest resource start line', () => {
+    const manifestAst = parse(`
+      import '../Pipes/PipeEntity.schema'
+
+      resource PipeEntityResource
+        start //[{"type": "tv_show", "name": "star trek"}]
+        [{"type": "artist", "name": "in this moment"}]
+
+      store ExamplePipeEntity of PipeEntity 'ExamplePipeEntity' @0 in PipeEntityResource
+    `);
+    console.log(manifestAst);
+  });
+  it('parses comment after manifest resource start line', () => {
+    const manifestAst = parse(`
+      import '../Pipes/PipeEntity.schema'
+
+      resource PipeEntityResource
+        start
+        //[{"type": "tv_show", "name": "star trek"}]
+        [{"type": "artist", "name": "in this moment"}]
+
+      store ExamplePipeEntity of PipeEntity 'ExamplePipeEntity' @0 in PipeEntityResource
+    `);
+    console.log(manifestAst);
+  });
+  it('ignores comments inside manifest resource', () => {
+    const manifestAst = parse(`
+      import '../Pipes/PipeEntity.schema'
+
+      resource PipeEntityResource
+        start
+        [{"type": "artist", "name": "in this moment"}]
+        //[{"type": "tv_show", "name": "star trek"}]
+
+      store ExamplePipeEntity of PipeEntity 'ExamplePipeEntity' @0 in PipeEntityResource
+    `);
+    console.log(manifestAst);
+  });
 });

--- a/src/runtime/test/manifest-test.ts
+++ b/src/runtime/test/manifest-test.ts
@@ -219,8 +219,8 @@ ${particleStr1}
     const manifestString = `particle TestParticle in 'a.js'
   in [Product {}] input
     out [Product {}] output
-  \`consume Slot thing
-    \`provide Slot otherThing
+  \`consume? Slot thing
+    \`provide? Slot otherThing
   modality dom`;
 
     const manifest = await Manifest.parse(manifestString);


### PR DESCRIPTION
This is a work in progress change, still failing tests, but I hoped to get some feedback on the direction I am heading.

This change copies some of our test and demo recipes and converts them to use the SLANDLES v1 syntax, it also implements a very basic form of slandle conversion (from handles with type Slot and [Slot] to slots and set slots) and some tests using the recipes mentioned previously.