### PR TITLE
Clean up all non-whitespace eslint rules for typescript

### DIFF
--- a/config/eslintrc.json
+++ b/config/eslintrc.json
@@ -101,7 +101,6 @@
         "no-irregular-whitespace": "off",
         "no-multiple-empty-lines": "off",
         "no-unreachable": "off",
-        "no-useless-escape": "off",
         "object-curly-spacing": "off",
         "semi-spacing": "off",
         "space-before-blocks": "off",

--- a/config/eslintrc.json
+++ b/config/eslintrc.json
@@ -95,7 +95,6 @@
         "key-spacing": "off",
         "keyword-spacing": "off",
         "quotes": "off",
-        "no-constant-condition": "off",
         "no-irregular-whitespace": "off",
         "no-multiple-empty-lines": "off",
         "object-curly-spacing": "off",

--- a/config/eslintrc.json
+++ b/config/eslintrc.json
@@ -100,7 +100,6 @@
         "no-extra-boolean-cast": "off",
         "no-irregular-whitespace": "off",
         "no-multiple-empty-lines": "off",
-        "no-unreachable": "off",
         "object-curly-spacing": "off",
         "semi-spacing": "off",
         "space-before-blocks": "off",

--- a/config/eslintrc.json
+++ b/config/eslintrc.json
@@ -98,7 +98,6 @@
         "no-constant-condition": "off",
         "no-empty": "off",
         "no-extra-boolean-cast": "off",
-        "no-inner-declarations": "off",
         "no-irregular-whitespace": "off",
         "no-multiple-empty-lines": "off",
         "no-unreachable": "off",

--- a/config/eslintrc.json
+++ b/config/eslintrc.json
@@ -88,7 +88,6 @@
       },
       "rules": {
         // eliminate these as usage is cleaned up
-        "no-invalid-this": "off",
         "comma-spacing": "off",
         "func-call-spacing": "off",
         "generator-star-spacing": "off",
@@ -101,6 +100,13 @@
         "semi-spacing": "off",
         "space-before-blocks": "off",
         "space-before-function-paren": "off"
+      }
+    },
+    {
+      "files": ["**/*test*/**/*.[jt]s"],
+      "rules": {
+        // disable for mocha usages
+        "no-invalid-this": "off"
       }
     }
   ]

--- a/config/eslintrc.json
+++ b/config/eslintrc.json
@@ -96,7 +96,6 @@
         "keyword-spacing": "off",
         "quotes": "off",
         "no-constant-condition": "off",
-        "no-empty": "off",
         "no-extra-boolean-cast": "off",
         "no-irregular-whitespace": "off",
         "no-multiple-empty-lines": "off",

--- a/config/eslintrc.json
+++ b/config/eslintrc.json
@@ -96,7 +96,6 @@
         "keyword-spacing": "off",
         "quotes": "off",
         "no-constant-condition": "off",
-        "no-extra-boolean-cast": "off",
         "no-irregular-whitespace": "off",
         "no-multiple-empty-lines": "off",
         "object-curly-spacing": "off",

--- a/package-lock.json
+++ b/package-lock.json
@@ -147,7 +147,7 @@
         },
         "whatwg-fetch": {
           "version": "2.0.4",
-          "resolved": "http://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+          "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
           "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
         }
       }
@@ -5589,7 +5589,7 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "dev": true
     },
     "is-builtin-module": {
@@ -6654,7 +6654,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
@@ -7022,7 +7022,7 @@
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-      "integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
+      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
         "hosted-git-info": "^2.1.4",
@@ -9104,7 +9104,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
@@ -9137,7 +9137,7 @@
         },
         "readable-stream": {
           "version": "1.0.33",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
           "integrity": "sha1-OjYN1mwbHX/UcFOJhg7aHQ9hEmw=",
           "requires": {
             "core-util-is": "~1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -147,7 +147,7 @@
         },
         "whatwg-fetch": {
           "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+          "resolved": "http://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
           "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
         }
       }
@@ -5589,7 +5589,7 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
       "dev": true
     },
     "is-builtin-module": {
@@ -6654,7 +6654,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
@@ -7022,7 +7022,7 @@
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
       "dev": true,
       "requires": {
         "hosted-git-info": "^2.1.4",
@@ -9104,7 +9104,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
@@ -9137,7 +9137,7 @@
         },
         "readable-stream": {
           "version": "1.0.33",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
           "integrity": "sha1-OjYN1mwbHX/UcFOJhg7aHQ9hEmw=",
           "requires": {
             "core-util-is": "~1.0.0",

--- a/server/src/deployment/utils.ts
+++ b/server/src/deployment/utils.ts
@@ -69,6 +69,7 @@ async function wait(timeout: number) {
    try {
      await rejectAfter(timeout);
    } catch(e) {
+     // ignored
    }
 }
 

--- a/shells/test/specs/demo-tests.js
+++ b/shells/test/specs/demo-tests.js
@@ -9,7 +9,6 @@
  */
 
 /* global browser */
-/* eslint-disable no-invalid-this */
 
 const {/*seconds,*/waitFor, click, keys, openNewArc} = require('../utils.js');
 

--- a/src/planning/plan/planificator.ts
+++ b/src/planning/plan/planificator.ts
@@ -77,7 +77,7 @@ export class Planificator {
     }
   }
 
-  get consumerOnly() { return !Boolean(this.producer); }
+  get consumerOnly(): boolean { return !this.producer; }
 
   async loadSuggestions() {
     return this.result.load();

--- a/src/planning/test/plan/test-environment-test.ts
+++ b/src/planning/test/plan/test-environment-test.ts
@@ -7,7 +7,7 @@ beforeEach(() => registerSystemExceptionHandler((exception) => exceptions.push(e
 afterEach(function () {
   if (exceptions.length > 0) {
     for (const exception of exceptions) {
-      this.test.ctx.currentTest.err = exception; // eslint-disable-line no-invalid-this
+      this.test.ctx.currentTest.err = exception;
     }
     exceptions = [];
   }

--- a/src/runtime/api-channel.ts
+++ b/src/runtime/api-channel.ts
@@ -319,6 +319,7 @@ function AutoConstruct<S extends {prototype: {}}>(target: S) {
         // as the requestedId for mapping below.
         const requestedId = descriptor.findIndex(d => d.identifier);
 
+        /** @this APIPort */
         const impl = function(this: APIPort, ...args) {
           const messageBody = {};
           for (let i = 0; i < descriptor.length; i++) {
@@ -344,6 +345,7 @@ function AutoConstruct<S extends {prototype: {}}>(target: S) {
         };
 
 
+        /** @this APIPort */
         const before = async function before(this: APIPort, messageBody) {
           const args = [];
           const promises = [];

--- a/src/runtime/api-channel.ts
+++ b/src/runtime/api-channel.ts
@@ -319,7 +319,7 @@ function AutoConstruct<S extends {prototype: {}}>(target: S) {
         // as the requestedId for mapping below.
         const requestedId = descriptor.findIndex(d => d.identifier);
 
-        function impl(this: APIPort, ...args) {
+        const impl = function(this: APIPort, ...args) {
           const messageBody = {};
           for (let i = 0; i < descriptor.length; i++) {
             if (i === initializer) {
@@ -341,10 +341,10 @@ function AutoConstruct<S extends {prototype: {}}>(target: S) {
           }
 
           this.send(f, messageBody);
-        }
+        };
 
 
-        async function before(this: APIPort, messageBody) {
+        const before = async function before(this: APIPort, messageBody) {
           const args = [];
           const promises = [];
           for (let i = 0; i < descriptor.length; i++) {
@@ -375,7 +375,7 @@ function AutoConstruct<S extends {prototype: {}}>(target: S) {
             assert(messageBody['identifier']);
             await this._mapper.establishThingMapping(messageBody['identifier'], result);
           }
-        }
+        };
 
         Object.defineProperty(me.prototype, f, {
           get() {

--- a/src/runtime/arc.ts
+++ b/src/runtime/arc.ts
@@ -151,6 +151,7 @@ export class Arc {
   // Returns a promise that spins sending a single `AwaitIdle` message until it
   // sees no other messages were sent.
   async _waitForIdle(): Promise<void> {
+    // eslint-disable-next-line no-constant-condition
     while (true) {
       const messageCount = this.pec.messageCount;
       const innerArcs = this.innerArcs;

--- a/src/runtime/debug/arc-debug-handler.ts
+++ b/src/runtime/debug/arc-debug-handler.ts
@@ -42,7 +42,7 @@ export class ArcDebugHandler {
 
       this.arcDevtoolsChannel = devtoolsChannel.forArc(arc);
 
-      if (!!listenerClasses) { // undefined -> false
+      if (listenerClasses) { // undefined -> false
         listenerClasses.forEach(l => ArcDevtoolsChannel.instantiateListener(l, 
           arc, this.arcDevtoolsChannel));
       }

--- a/src/runtime/dom-particle-base.ts
+++ b/src/runtime/dom-particle-base.ts
@@ -116,7 +116,7 @@ export class DomParticleBase extends Particle {
       // TODO: This is a simple string replacement right now,
       // ensuring that 'slotid' is an attribute on an HTML element would be an improvement.
       // TODO(sjmiles): clone original id as `slotname` for human readability
-      template = template.replace(new RegExp(`slotid=\"${slotName}\"`, 'gi'), `slotname="${slotName}" slotid$="{{$${slotName}}}"`);
+      template = template.replace(new RegExp(`slotid="${slotName}"`, 'gi'), `slotname="${slotName}" slotid$="{{$${slotName}}}"`);
     });
     return template;
   }

--- a/src/runtime/manual_tests/firebase-tests.ts
+++ b/src/runtime/manual_tests/firebase-tests.ts
@@ -37,7 +37,7 @@ async function synchronized(store1, store2, delay=1) {
 }
 
 describe('firebase', function() {
-  this.timeout(10000); // eslint-disable-line no-invalid-this
+  this.timeout(10000);
 
   let lastStoreId = 0;
   function newStoreKey(name) {

--- a/src/runtime/test/test-environment-test.ts
+++ b/src/runtime/test/test-environment-test.ts
@@ -7,7 +7,7 @@ beforeEach(() => registerSystemExceptionHandler((exception) => exceptions.push(e
 afterEach(function () {
   if (exceptions.length > 0) {
     for (const exception of exceptions) {
-      this.test.ctx.currentTest.err = exception; // eslint-disable-line no-invalid-this
+      this.test.ctx.currentTest.err = exception;
     }
     exceptions = [];
   }

--- a/src/tests/particles/test-environment-test.ts
+++ b/src/tests/particles/test-environment-test.ts
@@ -7,7 +7,7 @@ beforeEach(() => registerSystemExceptionHandler((exception) => exceptions.push(e
 afterEach(function () {
   if (exceptions.length > 0) {
     for (const exception of exceptions) {
-      this.test.ctx.currentTest.err = exception; // eslint-disable-line no-invalid-this
+      this.test.ctx.currentTest.err = exception;
     }
     exceptions = [];
   }

--- a/tools/sigh.ts
+++ b/tools/sigh.ts
@@ -663,7 +663,7 @@ function health(args: string[]): boolean {
 
     // Read and parse existing TsLint config.
     const tsLintConfig = fs.readFileSync(pathToTsLintConfig, 'utf-8');
-    const tsLintConfigNoComments = tsLintConfig.replace(/\ *\/\/.*\n/g, '');
+    const tsLintConfigNoComments = tsLintConfig.replace(/ *\/\/.*\n/g, '');
     const parsedConfig = JSON.parse(tsLintConfigNoComments);
 
     modifier(parsedConfig);


### PR DESCRIPTION
- Re-enable no-invalid-this, disable for all code in tests directories
- Re-enable no-constant-condition, whitelist usage
- Re-enable no-extra-boolean-cast
- Re-enable no-empty
- Re-enable no-unreachable
- Re-enable no-useless-escape, fix useless escapes
- Re-enable no-inner-declarations, fix api-channel.ts

Addresses #3017 