### PR TITLE
Parse type and resource

### DIFF
--- a/src/runtime/manifest-parser.peg
+++ b/src/runtime/manifest-parser.peg
@@ -366,7 +366,7 @@ TypeVariable "a type variable (e.g. ~foo)"
   }
 
 SlotType
-  = 'Slot' &whiteSpace fields:(whiteSpace '{' (SlotField (',' whiteSpace SlotField)*)? '}')?
+  = 'Slot' &([^a-z0-9_]i) fields:(whiteSpace '{' (SlotField (',' whiteSpace SlotField)*)? '}')?
 {
   fields = optional(fields, fields => {
     const data = fields[2];

--- a/src/runtime/manifest-parser.peg
+++ b/src/runtime/manifest-parser.peg
@@ -102,7 +102,7 @@ Resource = 'resource' whiteSpace name:upperIdent eolWhiteSpace Indent SameIndent
   } as AstNode.Resource;
 }
 
-ResourceStart = 'start' eolWhiteSpace { startIndent = indent; }
+ResourceStart = 'start' eol { startIndent = indent; }
 
 ResourceBody = lines:(SameOrMoreIndent ResourceLine)+ {
   return lines.map(line => line[0].substring(startIndent.length) + line[1]).join('');
@@ -1110,7 +1110,7 @@ fieldName "a field name (e.g. foo9)"
   = [a-z][a-z0-9_]i* { return text(); }
 whiteSpace "one or more whitespace characters"
   = " "+
-eolWhiteSpace "a new line"
+eolWhiteSpace "a group of new lines (and optionally comments)"
   = [ ]* !.
   / [ ]* '//' [^\n]* eolWhiteSpace
   / [ ]* eol eolWhiteSpace?

--- a/src/runtime/test/manifest-parser-test.ts
+++ b/src/runtime/test/manifest-parser-test.ts
@@ -298,4 +298,55 @@ describe('manifest parser', () => {
         in Sloturnicus s
     `);
   });
+  it('does not parse comment at start of manifest resource', () => {
+    let data;
+    assert.throws(() => {
+      const manifestAst = parse(`
+        import '../Pipes/PipeEntity.schema'
+
+        resource PipeEntityResource
+          start
+          //[{"type": "tv_show", "name": "star trek"}]
+          [{"type": "artist", "name": "in this moment"}]
+
+        store ExamplePipeEntity of PipeEntity 'ExamplePipeEntity' @0 in PipeEntityResource
+      `);
+      data = JSON.parse(manifestAst[1].data);
+    }, `Unexpected token / in JSON at position 0`);
+    assert.equal(data, undefined);
+  });
+  it('does not parse comment inside manifest resource', () => {
+    let data;
+    assert.throws(() => {
+      const manifestAst = parse(`
+        import '../Pipes/PipeEntity.schema'
+
+        resource PipeEntityResource
+          start
+          [{"type": "artist", "name": "in this moment"}]
+          //[{"type": "tv_show", "name": "star trek"}]
+
+        store ExamplePipeEntity of PipeEntity 'ExamplePipeEntity' @0 in PipeEntityResource
+      `);
+      data = JSON.parse(manifestAst[1].data);
+    }, `Unexpected token / in JSON at position 47`);
+    assert.equal(data, undefined);
+  });
+  it('ignores comments inside manifest resource', () => {
+    const manifestAst = parse(`
+      import '../Pipes/PipeEntity.schema'
+
+      resource PipeEntityResource
+        start
+        [{"type": "artist", "name": "in this moment"}]
+      //[{"type": "tv_show", "name": "star trek"}]
+
+      store ExamplePipeEntity of PipeEntity 'ExamplePipeEntity' @0 in PipeEntityResource
+    `);
+    assert.lengthOf(manifestAst, 3, 'Incorrectly parsed manifest');
+    assert.deepEqual(
+      JSON.stringify(JSON.parse(manifestAst[1].data)),
+      '[{"type":"artist","name":"in this moment"}]'
+    );
+  });
 });


### PR DESCRIPTION
Fixes for parsing comments in resources https://github.com/PolymerLabs/arcs/issues/2467 and improved fix for parsing `Slot` type (not also handles types containing Slots) https://github.com/PolymerLabs/arcs/issues/2961