### PR TITLE
Decouple planning from speculative execution

### DIFF
--- a/src/planning/plan/plan-producer.ts
+++ b/src/planning/plan/plan-producer.ts
@@ -25,6 +25,7 @@ import {StrategyDerived} from '../strategizer.js';
 
 import {PlanningResult} from './planning-result.js';
 import {Suggestion} from './suggestion.js';
+import {SuggestionCache} from './suggestion-cache.js';
 
 const defaultTimeoutMs = 5000;
 
@@ -41,6 +42,7 @@ export class PlanProducer {
   planner: Planner|null = null;
   recipeIndex: RecipeIndex;
   speculator: Speculator;
+  suggestionCache: SuggestionCache;
   needReplan = false;
   replanOptions: {};
   _isPlanning = false;
@@ -57,7 +59,8 @@ export class PlanProducer {
     this.arc = arc;
     this.result = result;
     this.recipeIndex = RecipeIndex.create(this.arc);
-    this.speculator = new Speculator(this.result);
+    this.speculator = new Speculator();
+    this.suggestionCache = new SuggestionCache(this.result);
     this.searchStore = searchStore;
     if (this.searchStore) {
       this.searchStoreCallback = () => this.onSearchChanged();
@@ -191,10 +194,12 @@ export class PlanProducer {
         search: options['search'],
         recipeIndex: this.recipeIndex
       },
+      speculator: this.speculator,
+      suggestionCache: this.suggestionCache,
       blockDevtools: true // Devtools communication is handled by PlanConsumer in Producer+Consumer setup.
     });
 
-    suggestions = await this.planner.suggest(options['timeout'] || defaultTimeoutMs, generations, this.speculator);
+    suggestions = await this.planner.suggest(options['timeout'] || defaultTimeoutMs, generations);
     if (this.planner) {
       this.planner = null;
       return suggestions;

--- a/src/planning/plan/suggestion-cache.ts
+++ b/src/planning/plan/suggestion-cache.ts
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright (c) 2019 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {PlanningResult} from './planning-result.js';
+import {Suggestion} from './suggestion.js';
+import {Arc} from '../../runtime/arc.js';
+import {Recipe} from '../../runtime/recipe/recipe.js';
+
+export class SuggestionCache {
+  public readonly suggestionByHash: {[hash: string]: Suggestion} = {};
+
+  constructor(planningResult?: PlanningResult) {
+    if (planningResult) {
+      for (const suggestion of planningResult.suggestions) {
+        this.suggestionByHash[suggestion.hash] = suggestion;
+      }
+    }
+  }
+
+  getSuggestion(hash: string, plan: Recipe, arc: Arc): Suggestion|undefined {
+    const suggestion = this.suggestionByHash[hash];
+    if (suggestion) {
+      const arcVersionByStoreId = arc.getVersionByStore({includeArc: true, includeContext: true});      
+      if (plan.handles.every(handle => arcVersionByStoreId[handle.id] === suggestion.versionByStore[handle.id])) {
+        return suggestion;
+      }
+    }
+    return undefined;
+  }
+
+  setSuggestion(hash: string, suggestion: Suggestion) {
+    this.suggestionByHash[hash] = suggestion;
+  }
+}

--- a/src/planning/plan/suggestion.ts
+++ b/src/planning/plan/suggestion.ts
@@ -55,9 +55,11 @@ export class Suggestion {
   static create(plan: Recipe, hash: string, relevance: Relevance): Suggestion {
     assert(plan, `plan cannot be null`);
     assert(hash, `hash cannot be null`);
-    assert(relevance, `relevance cannot be null`);
-    const suggestion = new Suggestion(plan, hash, relevance.calcRelevanceScore(),
-        relevance.versionByStore);
+    const suggestion = new Suggestion(
+        plan,
+        hash,
+        relevance ? relevance.calcRelevanceScore() : 0,
+        relevance ? relevance.versionByStore : {});
     suggestion.setSearch(plan.search);
     return suggestion;
   }

--- a/src/planning/test/planner-tests.ts
+++ b/src/planning/test/planner-tests.ts
@@ -16,6 +16,7 @@ import {Loader} from '../../runtime/loader.js';
 import {Manifest} from '../../runtime/manifest.js';
 import {StubLoader} from '../../runtime/testing/stub-loader.js';
 import {Planner} from '../planner.js';
+import {Speculator} from '../speculator.js';
 
 import {StrategyTestHelper} from './strategies/strategy-test-helper.js';
 import {Id, ArcId} from '../../runtime/id.js';
@@ -78,7 +79,7 @@ const loadTestArcAndRunSpeculation = async (manifest, manifestLoadedCallback) =>
 
   const arc = new Arc({id: ArcId.newForTest('test-plan-arc'), context: loadedManifest, loader});
   const planner = new Planner();
-  const options = {strategyArgs: StrategyTestHelper.createTestStrategyArgs(arc)};
+  const options = {strategyArgs: StrategyTestHelper.createTestStrategyArgs(arc), speculator: new Speculator()};
   planner.init(arc, options);
 
   const plans = await planner.suggest(Infinity);

--- a/src/planning/test/planning-manifest-integration-test.ts
+++ b/src/planning/test/planning-manifest-integration-test.ts
@@ -16,7 +16,8 @@ describe('planning manifest integration', () => {
   it('can produce a recipe that can be speculated', async () => {
     const {arc, recipe} = await manifestTestSetup();
     const hash = ((hash) => hash.substring(hash.length - 4))(await recipe.digest());
-    const suggestion = await new Speculator().speculate(arc, recipe, hash);
-    assert.equal(suggestion.rank, 1);
+    const {speculativeArc, relevance} = await new Speculator().speculate(arc, recipe, hash);
+    assert.equal(relevance.calcRelevanceScore(), 1);
+    assert.lengthOf(speculativeArc.recipeDeltas, 1);
   });
 });

--- a/src/planning/test/speculator-tests.ts
+++ b/src/planning/test/speculator-tests.ts
@@ -24,7 +24,8 @@ describe('speculator', () => {
     assert(recipe.normalize());
     const hash = ((hash) => hash.substring(hash.length - 4))(await recipe.digest());
     const speculator = new Speculator();
-    const suggestion = await speculator.speculate(arc, recipe, hash);
-    assert.equal(suggestion.rank, 1);
+    const {speculativeArc, relevance} = await speculator.speculate(arc, recipe, hash);
+    assert.equal(relevance.calcRelevanceScore(), 1);
+    assert.lengthOf(speculativeArc.recipeDeltas, 1);
   });
 });

--- a/src/planning/testing/planning-test-helper.ts
+++ b/src/planning/testing/planning-test-helper.ts
@@ -11,6 +11,7 @@
 import {Suggestion} from '../plan/suggestion.js';
 import {Planner} from '../planner.js';
 import {RecipeIndex} from '../recipe-index.js';
+import {Speculator} from '../speculator.js';
 import {assert} from '../../platform/chai-web.js';
 import {Arc} from '../../runtime/arc.js';
 import {HeadlessSlotDomConsumer} from '../../runtime/headless-slot-dom-consumer.js';
@@ -69,12 +70,12 @@ export class PlanningTestHelper extends TestHelper{
    */
   async makePlans(options?: TestHelperPlanOptions): Promise<PlanningTestHelper> {
     const planner = new Planner();
-    planner.init(this.arc, {strategyArgs: {recipeIndex: this.recipeIndex}});
+    planner.init(this.arc, {strategyArgs: {recipeIndex: this.recipeIndex}, speculator: new Speculator()});
     this.suggestions = await planner.suggest();
     if (options && options.includeInnerArcs) {
       for (const innerArc of this.arc.innerArcs) {
         const innerPlanner = new Planner();
-        innerPlanner.init(innerArc, {strategyArgs: {recipeIndex: this.recipeIndex}});
+        innerPlanner.init(innerArc, {strategyArgs: {recipeIndex: this.recipeIndex}, speculator: new Speculator()});
         this.suggestions = this.suggestions.concat(await innerPlanner.suggest());
       }
     }

--- a/src/runtime/description-formatter.ts
+++ b/src/runtime/description-formatter.ts
@@ -201,7 +201,7 @@ export class DescriptionFormatter {
 
     const handleConn = particle.connections[handleNames[0]];
     if (handleConn) { // handle connection
-      assert(handleConn.handle && handleConn.handle.id, 'Missing id???');
+      assert(handleConn.handle, 'Missing handle???');
       return [{
         fullName: valueTokens[0],
         handleName: handleConn.name,
@@ -210,8 +210,7 @@ export class DescriptionFormatter {
         extra,
         _handleConn: handleConn,
         value: particleDescription._connections[handleConn.name].value
-      }];
-        
+      }];  
     }
 
     // slot connection
@@ -267,6 +266,9 @@ export class DescriptionFormatter {
 
         // Transformation's hosted particle.
         if (token._handleConn.type instanceof InterfaceType) {
+          if (!token.value) {
+            return undefined;
+          }
           assert(token.value.interfaceValue, `Missing interface type value for '${token._handleConn.type}'.`);
           const particleSpec = ParticleSpec.fromLiteral(token.value.interfaceValue);
           // TODO: call this.patternToSuggestion(...) to resolved expressions in the pattern template.
@@ -431,7 +433,9 @@ export class DescriptionFormatter {
 
   _formatStoreDescription(handleConn): string|undefined {
     if (handleConn.handle) {
-      assert(handleConn.handle.id, `no id for ${handleConn.name}?`);
+      if (!handleConn.handle.id) {
+        return undefined;
+      }
       const storeDescription = this.storeDescById[handleConn.handle.id];
       const handleType = this._formatHandleType(handleConn);
       // Use the handle description available in the arc (if it is different than type name).


### PR DESCRIPTION
Support Planner running with no speculator, and description construction without an arc

After putting this together I noticed this: https://github.com/PolymerLabs/arcs/pull/3043, which i can probably reuse for my caching here (will send a followup PR, once that is merged.