### PR TITLE
Changes for slandles

### DIFF
--- a/src/runtime/manifest-ast-nodes.ts
+++ b/src/runtime/manifest-ast-nodes.ts
@@ -51,6 +51,9 @@ export interface CollectionType extends BaseNode {
   kind: 'collection-type';
   type: ParticleArgumentType;
 }
+export function isCollectionType(node: BaseNode): node is CollectionType {
+  return node.kind === 'collection-type';
+}
 
 export interface ReferenceType extends BaseNode {
   kind: 'reference-type';
@@ -62,13 +65,28 @@ export interface TypeVariable extends BaseNode {
   name: string;
   constraint: ParticleArgument;
 }
+export function isTypeVariable(node: BaseNode): node is TypeVariable {
+  return node.kind === 'variable-type';
+}
 
 export interface SlotType extends BaseNode {
   kind: 'slot-type';
   fields: SlotField[];
+  model: {formFactor: string, handle: string};
+}
+export function isSlotType(node: BaseNode): node is SlotType {
+  return node.kind === 'slot-type';
+}
+export function slandleType(arg: ParticleArgument): SlotType | undefined {
+  if(isSlotType(arg.type)) {
+    return arg.type;
+  }
+  if(isCollectionType(arg.type) && isSlotType(arg.type.type)) {
+    return arg.type.type;
+  }
+  return undefined;
 }
 // END PARTICLE TYPES
-
 
 export interface Description extends BaseNode {
   kind: 'description';
@@ -163,7 +181,7 @@ export interface ParticleArgument extends BaseNode {
   direction: Direction;
   type: ParticleArgumentType;
   isOptional: boolean;
-  dependentConnections: string[];
+  dependentConnections: ParticleHandle[];
   name: string;
   tags: TagList;
 }
@@ -200,8 +218,6 @@ export interface ParticleProvidedSlot extends BaseNode {
   isSet: boolean;
   formFactor: SlotFormFactor;
   handles: ParticleProvidedSlotHandle[];
-
-  param: string;
 }
 
 export interface ParticleProvidedSlotHandle extends BaseNode {
@@ -213,9 +229,10 @@ export interface ParticleRef extends BaseNode {
   kind: 'particle-ref';
   name: string;
   verbs: VerbList;
+  tags: TagList;
 }
 
-export interface Recipe extends BaseNode {
+export interface RecipeNode extends BaseNode {
   kind: 'recipe';
   name: string;
   verbs: VerbList;
@@ -255,13 +272,6 @@ export interface RecipeParticleConnection extends BaseNode {
 
 export interface ParticleConnectionTargetComponents extends BaseNode {
   kind: 'handle-connection-components';
-  name: string|null;
-  particle: string|null;
-  tags: TagList;
-}
-
-export interface ParticleConnnectionTargetComponents extends BaseNode {
-  kind: 'hanlde-connection-components';
   name: string|null;
   particle: string|null;
   tags: TagList;
@@ -476,7 +486,7 @@ export interface NameAndTagList {
 // Aliases to simplify ts-pegjs returnTypes requirement in sigh.
 export type Annotation = string;
 export type LocalName = string;
-export type Manifest = ManifestStorageItem[];
+export type Manifest = ManifestItem[];
 export type ManifestStorageItem = string;
 export type ParticleArgumentDirection = string;
 export type ResourceStart = string;
@@ -511,4 +521,4 @@ export type All = Import|Meta|MetaName|MetaStorageKey|Particle|ParticleArgument|
     InterfaceSlot;
 
 export type ManifestItem =
-    Recipe|Particle|Import|Schema|ManifestStorage|Interface|Meta|Resource;
+    RecipeNode|Particle|Import|Schema|ManifestStorage|Interface|Meta|Resource;

--- a/src/runtime/manifest-ast-nodes.ts
+++ b/src/runtime/manifest-ast-nodes.ts
@@ -78,10 +78,10 @@ export function isSlotType(node: BaseNode): node is SlotType {
   return node.kind === 'slot-type';
 }
 export function slandleType(arg: ParticleArgument): SlotType | undefined {
-  if(isSlotType(arg.type)) {
+  if (isSlotType(arg.type)) {
     return arg.type;
   }
-  if(isCollectionType(arg.type) && isSlotType(arg.type.type)) {
+  if (isCollectionType(arg.type) && isSlotType(arg.type.type)) {
     return arg.type.type;
   }
   return undefined;

--- a/src/runtime/manifest-parser.peg
+++ b/src/runtime/manifest-parser.peg
@@ -289,8 +289,7 @@ ParticleItem "a particle item"
 ParticleHandle
   = arg:ParticleArgument eolWhiteSpace dependentConnections:(Indent (SameIndent ParticleHandle)*)?
   {
-    dependentConnections = optional(dependentConnections, extractIndented, []);
-    arg.dependentConnections = dependentConnections;
+    arg.dependentConnections = optional(dependentConnections, extractIndented, []);
     return arg as AstNode.ParticleHandle;
   }
 
@@ -303,7 +302,7 @@ ParticleArgument
       direction,
       type: type,
       isOptional: !!isOptional,
-      dependentConnections: [],
+      dependentConnections: [] as AstNode.ParticleHandle[],
       name: nametag.name,
       tags: nametag.tags,
     } as AstNode.ParticleArgument;
@@ -366,7 +365,7 @@ TypeVariable "a type variable (e.g. ~foo)"
   }
 
 SlotType
-  = 'Slot' &([^a-z0-9_]i) fields:(whiteSpace '{' (SlotField (',' whiteSpace SlotField)*)? '}')?
+  = 'Slot' &([^a-z0-9_]i) fields:(whiteSpace? '{' (SlotField (',' whiteSpace SlotField)*)? '}')?
 {
   fields = optional(fields, fields => {
     const data = fields[2];
@@ -562,7 +561,7 @@ Recipe
       name: optional(name, name => name[1], null),
       verbs,
       items: optional(items, extractIndented, []),
-    } as AstNode.Recipe;
+    } as AstNode.RecipeNode;
   }
 
 // RequireHandleSection is intended to replace RecipeHandle but for now we allow for both ways to create a handle.
@@ -867,6 +866,7 @@ ParticleRef
       location: location(),
       name,
       verbs: [],
+      tags: []
     } as AstNode.ParticleRef;
   }
   / verb:Verb
@@ -875,6 +875,7 @@ ParticleRef
       kind: 'particle-ref',
       location: location(),
       verbs: [verb],
+      tags: []
     } as AstNode.ParticleRef;
   }
 
@@ -1106,7 +1107,7 @@ upperIdent "an uppercase identifier (e.g. Foo)"
   = [A-Z][a-z0-9_]i* { return text(); }
 lowerIdent "a lowercase identifier (e.g. foo)"
   = !ReservedWord [a-z][a-z0-9_]i* { return text(); }
-fieldName "a field name (e.g. foo9)"
+fieldName "a field name (e.g. foo9)" // Current handle and formFactor.
   = [a-z][a-z0-9_]i* { return text(); }
 whiteSpace "one or more whitespace characters"
   = " "+

--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -728,7 +728,7 @@ ${e.message}
   }
 
   // TODO(cypher): Remove loader dependency.
-  private static _processRecipe(manifest: Manifest, recipeItem: AstNode.Recipe, loader) {
+  private static _processRecipe(manifest: Manifest, recipeItem: AstNode.RecipeNode, loader) {
     const recipe = manifest._newRecipe(recipeItem.name);
 
     if (recipeItem.annotation) {

--- a/src/runtime/recipe/particle.ts
+++ b/src/runtime/recipe/particle.ts
@@ -26,6 +26,7 @@ export class Particle {
   private _localName?: string = undefined;
   spec?: ParticleSpec = undefined;
   private _verbs: string[] = [];
+  private _tags: string[] = [];
   private _connections: {[index: string]: HandleConnection} = {};
   
   // TODO: replace with constraint connections on the recipe
@@ -44,6 +45,7 @@ export class Particle {
     const particle = recipe.newParticle(this._name);
     particle._id = this._id;
     particle._verbs = [...this._verbs];
+    particle._tags = [...this._tags];
     particle.spec = this.spec ? this.spec.cloneWithResolutions(variableMap) : undefined;
 
     Object.keys(this._connections).forEach(key => {
@@ -91,6 +93,7 @@ export class Particle {
   _startNormalize(): void {
     this._localName = null;
     this._verbs.sort();
+    this._tags.sort();
     const normalizedConnections = {};
     for (const key of (Object.keys(this._connections).sort())) {
       normalizedConnections[key] = this._connections[key];
@@ -116,6 +119,7 @@ export class Particle {
     if ((cmp = compareStrings(this._localName, other._localName)) !== 0) return cmp;
     // TODO: spec?
     if ((cmp = compareArrays(this._verbs, other._verbs, compareStrings)) !== 0) return cmp;
+    if ((cmp = compareArrays(this._tags, other._tags, compareStrings)) !== 0) return cmp;
     // TODO: slots
     return 0;
   }
@@ -219,6 +223,7 @@ export class Particle {
   get consumedSlotConnections() { return this._consumedSlotConnections; }
   get primaryVerb() { return (this._verbs.length > 0) ? this._verbs[0] : undefined; }
   set verbs(verbs) { this._verbs = verbs; }
+  set tags(tags) { this._tags = tags; }
 
   addUnnamedConnection() {
     const connection = new HandleConnection(undefined, this);

--- a/src/runtime/recipe/recipe-util.ts
+++ b/src/runtime/recipe/recipe-util.ts
@@ -116,7 +116,7 @@ export class RecipeUtil {
           continue;
         }
 
-        const acceptedDirections = {'in': ['in', 'inout'], 'out': ['out', 'inout'], '=': ['in', 'out', 'inout'], 'inout': ['inout'], 'host': ['host']};
+        const acceptedDirections = {'in': ['in', 'inout'], 'out': ['out', 'inout'], '=': ['in', 'out', 'inout'], 'inout': ['inout'], 'host': ['host'], '`consume': ['consume'], '`provide': ['provide']};
         if (recipeConnSpec.direction) {
           assert(Object.keys(acceptedDirections).includes(shapeHC.direction), `${shapeHC.direction} not in ${Object.keys(acceptedDirections)}`);
           if (!acceptedDirections[shapeHC.direction].includes(recipeConnSpec.direction)) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,13 +1,13 @@
 {
   "extends": "./config/tsconfig.base.json",
   "include": [
-    "src/**/*.ts",
+    "src/**/*.ts"
   ],
   "compilerOptions": {
     "outDir": "build",
     "declaration": true,
     "experimentalDecorators": true,
-    "incremental": true,
+    "incremental": true
   },
   "exclude": [
     "build/**/*",


### PR DESCRIPTION
This is part of breaking up the SLANDLES tests I'm working on at the moment.

It introduces some new type guards, renames AstNode.Recipe to AstNode.RecipeNode and removed a duplicate (typoed) AstNode type.