### PR TITLE
Clean up unecessary usage of "use strict"

### DIFF
--- a/config/eslintrc.json
+++ b/config/eslintrc.json
@@ -88,6 +88,7 @@
       },
       "rules": {
         // add typescript specific rules here
+        "strict": "error"
       }
     },
     {

--- a/src/planning/test/planner-tests.ts
+++ b/src/planning/test/planner-tests.ts
@@ -7,7 +7,7 @@
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
- 'use strict';
+ 
 
 import {assert} from '../../platform/chai-web.js';
 import {Arc} from '../../runtime/arc.js';

--- a/src/planning/test/strategies/coalesce-recipes-test.ts
+++ b/src/planning/test/strategies/coalesce-recipes-test.ts
@@ -7,7 +7,7 @@
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
-'use strict';
+
 
 import {assert} from '../../../platform/chai-web.js';
 import {Manifest} from '../../../runtime/manifest.js';

--- a/src/planning/test/strategies/find-hosted-particle-tests.ts
+++ b/src/planning/test/strategies/find-hosted-particle-tests.ts
@@ -7,7 +7,7 @@
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
-'use strict';
+
 
 import {assert} from '../../../platform/chai-web.js';
 import {Arc} from '../../../runtime/arc.js';

--- a/src/planning/test/strategies/find-required-particle-test.ts
+++ b/src/planning/test/strategies/find-required-particle-test.ts
@@ -7,7 +7,7 @@
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
-'use strict';
+
 
 import {assert} from '../../../platform/chai-web.js';
 import {Manifest} from '../../../runtime/manifest.js';

--- a/src/planning/test/strategies/init-population-tests.ts
+++ b/src/planning/test/strategies/init-population-tests.ts
@@ -7,7 +7,7 @@
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
-'use strict';
+
 
 import {assert} from '../../../platform/chai-web.js';
 import {Arc} from '../../../runtime/arc.js';

--- a/src/planning/test/strategies/map-slots-tests.ts
+++ b/src/planning/test/strategies/map-slots-tests.ts
@@ -7,7 +7,7 @@
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
-'use strict';
+
 
 import {assert} from '../../../platform/chai-web.js';
 import {Arc} from '../../../runtime/arc.js';

--- a/src/planning/test/strategies/match-particle-by-verb-tests.ts
+++ b/src/planning/test/strategies/match-particle-by-verb-tests.ts
@@ -7,7 +7,7 @@
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
-'use strict';
+
 
 import {assert} from '../../../platform/chai-web.js';
 import {Manifest} from '../../../runtime/manifest.js';

--- a/src/planning/test/strategies/strategy-test-helper.ts
+++ b/src/planning/test/strategies/strategy-test-helper.ts
@@ -7,7 +7,7 @@
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
-'use strict';
+
 
 import {assert} from '../../../platform/chai-web.js';
 import {Arc} from '../../../runtime/arc.js';

--- a/src/runtime/test/handle-test.ts
+++ b/src/runtime/test/handle-test.ts
@@ -7,7 +7,7 @@
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
-'use strict';
+
 
 import {assert} from '../../platform/chai-web.js';
 import {Arc} from '../arc.js';

--- a/src/runtime/test/storage-proxy-test.ts
+++ b/src/runtime/test/storage-proxy-test.ts
@@ -7,7 +7,7 @@
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
-'use strict';
+
 
 import {assert} from '../../platform/chai-web.js';
 import {handleFor, Handle, Variable, Collection} from '../handle.js';


### PR DESCRIPTION
- Adds 'strict' eslint rule to typescript config
- Removes usages