### PR TITLE
Slandles demos

### DIFF
--- a/particles/Arcs/SLANDLESLauncher.recipe
+++ b/particles/Arcs/SLANDLESLauncher.recipe
@@ -1,0 +1,20 @@
+// Copyright (c) 2019 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+
+import 'ArcMeta.schema'
+
+particle SlandleLauncher in 'source/Launcher.js'
+  inout [ArcMeta] arcs
+  `consume Slot root
+  description `arcs launcher`
+
+recipe SlandleLauncher
+  create 'SYSTEM_arcs' as arcs
+  slot 'rootslotid-root' as root
+  SlandleLauncher
+    arcs = arcs
+    consume root as root
+

--- a/particles/Arcs/SLANDLESLauncher.recipe
+++ b/particles/Arcs/SLANDLESLauncher.recipe
@@ -13,8 +13,7 @@ particle SlandleLauncher in 'source/Launcher.js'
 
 recipe SlandleLauncher
   create 'SYSTEM_arcs' as arcs
-  slot 'rootslotid-root' as root
+  `slot 'rootslotid-root' as root
   SlandleLauncher
     arcs = arcs
-    consume root as root
-
+    root consume root

--- a/particles/Arcs/SLANDLESLogin.recipe
+++ b/particles/Arcs/SLANDLESLogin.recipe
@@ -14,8 +14,8 @@ particle SlandleSlandleLogin in 'source/Login.js'
 
 recipe SlandleSlandleLogin &login
   create as key
-  slot 'rootslotid-root' as root
+  `slot 'rootslotid-root' as root
   SlandleSlandleLogin
     key = key
-    consume root as root
+    root consume root
   description `user sign in`

--- a/particles/Arcs/SLANDLESLogin.recipe
+++ b/particles/Arcs/SLANDLESLogin.recipe
@@ -1,0 +1,21 @@
+// Copyright (c) 2019 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+schema StorageKey
+  Text key
+
+particle SlandleSlandleLogin in 'source/Login.js'
+  out StorageKey key
+  `consume Slot root
+
+recipe SlandleSlandleLogin &login
+  create as key
+  slot 'rootslotid-root' as root
+  SlandleSlandleLogin
+    key = key
+    consume root as root
+  description `user sign in`

--- a/particles/Demo/SLANDLESDemo.recipes
+++ b/particles/Demo/SLANDLESDemo.recipes
@@ -1,0 +1,4 @@
+import 'SLANDLESDemoData.manifest'
+
+//import 'SLANDLESRestaurantsDemo.recipes'
+//import 'SLANDLESProductsDemo.recipe'

--- a/particles/Demo/SLANDLESDemoData.manifest
+++ b/particles/Demo/SLANDLESDemoData.manifest
@@ -1,0 +1,11 @@
+import '../Music/Playlist.schema'
+store DemoPlaylists of [Playlist] 'demo-playlists' #items in './playlists.json'
+
+import '../Products/Product.schema'
+store PageProducts of [Product] #shoplist in 'products.json'
+  description `products from your browsing context`
+
+import '../People/Person.schema'
+store ClairesWishlist of [Product] #items #wishlist in 'wishlist.json'
+  description `wishlist`
+store Claire of Person #claire in 'Claire.json'

--- a/particles/Demo/SLANDLESProductsDemo.recipe
+++ b/particles/Demo/SLANDLESProductsDemo.recipe
@@ -17,14 +17,14 @@ recipe SlandleProducts
   copy #shoplist as shoplist
   create #selected as selected
   SlandleSelectableItems
-    consume root
-      provide annotation as annotationSlot
-      provide action as actionSlot
+    root consume
+      annotation provide annotationSlot
+      action provide actionSlot
     list = shoplist
     selected = selected
   SlandleItemMultiplexer
     list = shoplist
-    hostedParticle = ProductItem
+    hostedParticle = SlandleProductItem
   //
   // &shopForOccasion
   map #claire as person
@@ -32,18 +32,18 @@ recipe SlandleProducts
     person = person
   SlandleSimpleAnnotationMultiplexer
     list = shoplist
-    hostedParticle = Arrivinator
-    consume annotation as annotationSlot
+    hostedParticle = SlandleArrivinator
+    annotation consume annotationSlot
   //
   // &addFromWishlist
   map #wishlist as wishlist
   create #volatile as recommendations
   // annotates shoplist
   SlandleChoicesMultiplexer
-    consume choice as annotationSlot
+    choice consume annotationSlot
     list = shoplist
     choices = wishlist
-    hostedParticle = AlsoOn
+    hostedParticle = SlandleAlsoOn
   // recommend products from wishlist
   SlandleRecommend
     population = wishlist
@@ -51,7 +51,7 @@ recipe SlandleProducts
     recommendations = recommendations
   // present recommendations for adding to shoplist
   SlandleChooser
-    consume action as actionSlot
+    action consume actionSlot
     person = person
     choices = recommendations
     resultList = shoplist
@@ -59,7 +59,7 @@ recipe SlandleProducts
   // &manufacturerInfo
   SlandleSimpleAnnotationMultiplexer
     list = shoplist
-    hostedParticle = ManufacturerInfo
+    hostedParticle = SlandleManufacturerInfo
   //
   // &productInterests
   SlandleInterests

--- a/particles/Demo/SLANDLESProductsDemo.recipe
+++ b/particles/Demo/SLANDLESProductsDemo.recipe
@@ -1,0 +1,67 @@
+// Copyright (c) 2019 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+import '../List/SLANDLESList.recipes'
+import '../Products/SLANDLESProducts.recipe'
+import '../Products/SLANDLESGifts.recipe'
+import '../Products/SLANDLESRecommend.recipe'
+import '../Products/SLANDLESManufacturer.recipe'
+import '../Products/SLANDLESInterests.recipe'
+
+recipe SlandleProducts
+  // &displayProducts
+  copy #shoplist as shoplist
+  create #selected as selected
+  SlandleSelectableItems
+    consume root
+      provide annotation as annotationSlot
+      provide action as actionSlot
+    list = shoplist
+    selected = selected
+  SlandleItemMultiplexer
+    list = shoplist
+    hostedParticle = ProductItem
+  //
+  // &shopForOccasion
+  map #claire as person
+  SlandleGiftList
+    person = person
+  SlandleSimpleAnnotationMultiplexer
+    list = shoplist
+    hostedParticle = Arrivinator
+    consume annotation as annotationSlot
+  //
+  // &addFromWishlist
+  map #wishlist as wishlist
+  create #volatile as recommendations
+  // annotates shoplist
+  SlandleChoicesMultiplexer
+    consume choice as annotationSlot
+    list = shoplist
+    choices = wishlist
+    hostedParticle = AlsoOn
+  // recommend products from wishlist
+  SlandleRecommend
+    population = wishlist
+    known = shoplist
+    recommendations = recommendations
+  // present recommendations for adding to shoplist
+  SlandleChooser
+    consume action as actionSlot
+    person = person
+    choices = recommendations
+    resultList = shoplist
+  //
+  // &manufacturerInfo
+  SlandleSimpleAnnotationMultiplexer
+    list = shoplist
+    hostedParticle = ManufacturerInfo
+  //
+  // &productInterests
+  SlandleInterests
+    list = shoplist
+    person = person

--- a/particles/Demo/SLANDLESRestaurantsDemo.recipes
+++ b/particles/Demo/SLANDLESRestaurantsDemo.recipes
@@ -18,11 +18,11 @@ recipe SlandleRestaurantsDemo
   create #restaurant as selected
   create #event as event
   create as descriptions
-  slot #toproot as toproot
+  `slot #toproot as toproot
   SlandleReservationForm
     restaurant = selected
     event = event
-    consume action as toproot
+    action consume toproot
   SlandleGeolocate
     location = location
   SlandleRestaurantFind
@@ -33,19 +33,19 @@ recipe SlandleRestaurantsDemo
     selected = selected
   SlandleTileMultiplexer
     list = restaurants
-    hostedParticle = RestaurantTile
+    hostedParticle = SlandleRestaurantTile
   SlandleAnnotationMultiplexer
     list = restaurants
     annotation = event
-    hostedParticle = ReservationAnnotation
+    hostedParticle = SlandleReservationAnnotation
   SlandleDetailSlider
     selected = selected
   SlandleRestaurantDetail
     restaurant = selected
-    consume content
-      provide detailAction as actionSlot
+    content consume
+      detailAction provide actionSlot
   SlandleReservationForm
     restaurant = selected
     event = event
-    consume action as actionSlot
+    action consume actionSlot
   description `[demo] find restaurants and make reservations near ${RestaurantFind.location}`

--- a/particles/Demo/SLANDLESRestaurantsDemo.recipes
+++ b/particles/Demo/SLANDLESRestaurantsDemo.recipes
@@ -1,0 +1,51 @@
+// Copyright (c) 2019 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+import '../List/SLANDLESList.recipes'
+import '../Layout/SLANDLESLayout.recipes'
+import '../Profile/SLANDLESGeolocate.recipe'
+import '../Restaurants/SLANDLESRestaurantFind.recipes'
+import '../Restaurants/SLANDLESRestaurantDisplay.recipes'
+import '../Restaurants/SLANDLESReservations.recipes'
+
+recipe SlandleRestaurantsDemo
+  create as location
+  create as restaurants
+  create #restaurant as selected
+  create #event as event
+  create as descriptions
+  slot #toproot as toproot
+  SlandleReservationForm
+    restaurant = selected
+    event = event
+    consume action as toproot
+  SlandleGeolocate
+    location = location
+  SlandleRestaurantFind
+    location = location
+    restaurants = restaurants
+  SlandleSelectableTiles
+    list = restaurants
+    selected = selected
+  SlandleTileMultiplexer
+    list = restaurants
+    hostedParticle = RestaurantTile
+  SlandleAnnotationMultiplexer
+    list = restaurants
+    annotation = event
+    hostedParticle = ReservationAnnotation
+  SlandleDetailSlider
+    selected = selected
+  SlandleRestaurantDetail
+    restaurant = selected
+    consume content
+      provide detailAction as actionSlot
+  SlandleReservationForm
+    restaurant = selected
+    event = event
+    consume action as actionSlot
+  description `[demo] find restaurants and make reservations near ${RestaurantFind.location}`

--- a/particles/Events/SLANDLESEvents.recipes
+++ b/particles/Events/SLANDLESEvents.recipes
@@ -1,0 +1,15 @@
+// Copyright (c) 2018 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+import 'Event.schema'
+import '../Common/Description.schema'
+
+particle SlandleSlandleCalendar in 'source/Calendar.js'
+  inout Event event
+  out [Description] descriptions
+  `consume Slot action
+  description `Select a time from your calendar`

--- a/particles/Events/SLANDLESEvents.recipes
+++ b/particles/Events/SLANDLESEvents.recipes
@@ -8,7 +8,7 @@
 import 'Event.schema'
 import '../Common/Description.schema'
 
-particle SlandleSlandleCalendar in 'source/Calendar.js'
+particle SlandleCalendar in 'source/Calendar.js'
   inout Event event
   out [Description] descriptions
   `consume Slot action

--- a/particles/Layout/SLANDLESAnimatedTiles.recipes
+++ b/particles/Layout/SLANDLESAnimatedTiles.recipes
@@ -1,0 +1,13 @@
+particle SlandleAnimatedTiles in 'source/AnimatedTiles.js'
+  `consume Slot root
+  description `animated tiles`
+
+recipe SlandleAnimatedTiles
+  SlandleAnimatedTiles
+
+particle SlandleRepeaterTiles in 'source/RepeaterTiles.js'
+  `consume Slot root
+  description `repeater tiles`
+
+recipe SlandleRepeaterTiles
+  SlandleRepeaterTiles

--- a/particles/Layout/SLANDLESBottomScrollTest.recipes
+++ b/particles/Layout/SLANDLESBottomScrollTest.recipes
@@ -1,0 +1,6 @@
+particle SlandleBottomScrollTest in 'source/BottomScrollTest.js'
+  `consume Slot root
+  description `bottom scroller`
+
+recipe SlandleBottomScrollTest
+  SlandleBottomScrollTest

--- a/particles/Layout/SLANDLESDetail.recipes
+++ b/particles/Layout/SLANDLESDetail.recipes
@@ -1,0 +1,9 @@
+particle SlandleDetailSlider in 'source/DetailSlider.js'
+  inout ~a selected
+  `consume? Slot modal
+    `provide Slot {handle: selected} content
+
+recipe SlandleDetailSlider
+  use #selected as selected
+  SlandleDetailSlider
+    selected = selected

--- a/particles/Layout/SLANDLESLayout.recipes
+++ b/particles/Layout/SLANDLESLayout.recipes
@@ -1,0 +1,5 @@
+import 'SLANDLESDetail.recipes'
+import 'SLANDLESTabbedLayout.recipes'
+import 'SLANDLESAnimatedTiles.recipes'
+import 'SLANDLESBottomScrollTest.recipes'
+

--- a/particles/Layout/SLANDLESTabbedLayout.recipes
+++ b/particles/Layout/SLANDLESTabbedLayout.recipes
@@ -1,0 +1,8 @@
+particle SlandleTabbedLayout in 'source/Tabbed.js'
+  `consume Slot root
+    `provide Slot content
+  description `tabbed layout`
+
+recipe SlandleTabbedLayout
+  SlandleTabbedLayout
+

--- a/particles/List/SLANDLESAnnotations.recipes
+++ b/particles/List/SLANDLESAnnotations.recipes
@@ -1,0 +1,45 @@
+// @license
+// Copyright (c) 2019 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+interface SlandleHostedAnnotationInterface
+  in ~any *
+  inout ~anyOther *
+  `consume Slot annotation
+
+particle SlandleAnnotationMultiplexer in 'source/Multiplexer.js'
+  in [~any] list
+  inout ~anyOther annotation
+  host SlandleHostedAnnotationInterface hostedParticle
+  `consume [Slot] annotation
+
+interface SlandleHostedSimpleAnnotationInterface
+  in ~any *
+  `consume Slot annotation
+
+particle SlandleSimpleAnnotationMultiplexer in 'source/Multiplexer.js'
+  in [~any] list
+  host SlandleHostedSimpleAnnotationInterface hostedParticle
+  `consume [Slot] annotation
+
+interface SlandleHostedCombinedAnnotationInterface
+  in ~any *
+  in [~anyOther] *
+  `consume Slot annotation
+
+particle SlandleCombinedAnnotationMultiplexer in 'source/Multiplexer.js'
+  in [~any] list
+  in [~anyOther] choices
+  host SlandleHostedCombinedAnnotationInterface hostedParticle
+  `consume [Slot] annotation
+
+//recipe SlandleAnnotationMultiplexer
+//  use #items as list
+//  use #annotation as annotation
+//  SlandleAnnotationMultiplexer
+//    list = list
+//    annotation = annotation

--- a/particles/List/SLANDLESChoices.recipes
+++ b/particles/List/SLANDLESChoices.recipes
@@ -1,0 +1,18 @@
+// @license
+// Copyright (c) 2019 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+interface SlandleHostedChoiceInterface
+  in ~any *
+  in [~anyOther] *
+  `consume Slot choice
+
+particle SlandleChoicesMultiplexer in 'source/Multiplexer.js'
+  in [~any] list
+  in [~anyOther] choices
+  host SlandleHostedChoiceInterface hostedParticle
+  `consume [Slot] choice

--- a/particles/List/SLANDLESItems.recipes
+++ b/particles/List/SLANDLESItems.recipes
@@ -1,0 +1,85 @@
+// @license
+// Copyright (c) 2019 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+interface SlandleHostedItemInterface
+  in ~any *
+  // TODO(sjmiles): using slot-type for form-factor
+  // all Interfaces are the same in List/* except for the slot
+  `consume Slot item
+
+particle SlandleItemMultiplexer in 'source/Multiplexer.js'
+  // TODO(sjmiles): redundancies:
+  // 1. slot is declared in HostedItemInterface and as `consume [Slot]  here
+  // 2. ~any is declared in HostedItemInterface and as `[~any]` here
+  in [~any] list
+  host SlandleHostedItemInterface hostedParticle
+  `consume [Slot] item
+
+// TODO(sjmiles): recipe is the minimum coalescable artifact, which is good because we need to be able specify
+// handle fates before colascing ... is there a way to combine the declarations when the recipe has only one Particle?
+//recipe SlandleItemMultiplexer
+  // TODO(sjmiles): restricting fate
+  // TODO(sjmiles): without `#items` this recipe doesn't coalese, why?
+//  use #items as list
+//  SlandleItemMultiplexer
+//    list = list
+
+//particle SlandleList in 'source/List.js'
+//  in [~any] list
+//  `consume Slot root #items
+//    `provide? [Slot {handle: items}] item
+//  description `show ${list}`
+
+//recipe SlandleList
+//  use #items as items
+//  SlandleList
+//    items = items
+//  SlandleItemMultiplexer
+//    list = items
+
+particle SlandleItems in 'source/Items.js'
+  in [~any] list
+  `consume Slot root #items
+    `provide? Slot preamble
+    `provide? [Slot {handle: list}] item
+    `provide? [Slot {handle: list}] annotation
+    `provide? Slot action
+    `provide? Slot postamble
+  description `display ${list}`
+
+particle SlandleSelectableItems in 'source/Items.js'
+  in [~any] list
+  inout? ~any selected
+  `consume Slot root #items
+    `provide? Slot preamble
+    `provide [Slot {handle: list}] item
+    `provide? [Slot {handle: list}] annotation
+    `provide? Slot action
+    `provide? Slot postamble
+  description `display ${list}`
+
+// TODO(sjmiles): nearly duplicate recipes here because we want to support `use` and `copy` but not `create`,
+// maybe there should be a fate for this, or require `create` to be explicit
+
+//recipe SlandleSelectableCopyItemsRecipe
+//  copy #items as items
+//  create #selected as selected
+//  SlandleSelectableItems
+//    items = items
+//    selected = selected
+//  SlandleItemMultiplexer
+//    list = items
+
+//recipe SlandleSelectableUseItemsRecipe
+//  use #items as items
+//  create #selected as selected
+//  SlandleSelectableItems
+//    items = items
+//    selected = selected
+//  SlandleItemMultiplexer
+//    list = items

--- a/particles/List/SLANDLESList.recipes
+++ b/particles/List/SLANDLESList.recipes
@@ -1,0 +1,12 @@
+// @license
+// Copyright (c) 2019 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+import 'SLANDLESTiles.recipes'
+import 'SLANDLESItems.recipes'
+import 'SLANDLESAnnotations.recipes'
+import 'SLANDLESChoices.recipes'

--- a/particles/List/SLANDLESTiles.recipes
+++ b/particles/List/SLANDLESTiles.recipes
@@ -1,0 +1,45 @@
+// @license
+// Copyright (c) 2019 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+interface SlandleHostedTileInterface
+  in ~any *
+  `consume Slot tile
+
+particle SlandleTileMultiplexer in 'source/Multiplexer.js'
+  in [~any] list
+  host SlandleHostedTileInterface hostedParticle
+  `consume [Slot] tile
+
+//recipe SlandleTileMultiplexer
+//  use #tile as list
+//  TileMultiplexer
+//    list = list
+
+particle SlandleSelectableTiles in 'source/Tiles.js'
+  in [~any] list
+  inout ~any selected
+  `consume Slot root #tiles
+    `provide [Slot] tile
+    `provide? [Slot] annotation
+    `provide? Slot action
+
+//recipe SlandleSelectableCopyTilesRecipe
+//  copy #items as items
+//  create #selected as selected
+//  SelectableTiles
+//    items = items
+//    selected = selected
+//  description `show ${SelectableTiles.items}`
+
+//recipe SlandleSelectableUseTilesRecipe
+//  use #items as items
+//  create #selected as selected
+//  SelectableTiles
+//    items = items
+//    selected = selected
+//  description `show ${SelectableTiles.items}`

--- a/particles/Music/SLANDLESArtist.recipes
+++ b/particles/Music/SLANDLESArtist.recipes
@@ -1,0 +1,38 @@
+// @license
+// Copyright (c) 2019 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+import '../Common/Description.schema'
+
+schema ArtistFind
+  Text name
+
+schema ArtistMusic
+  Text artistid
+  Text type
+  Text name
+  URL url
+  URL imageUrl
+  Text description
+  Text detailedDescription
+
+particle SlandleArtistFinder in 'source/ArtistFinder.js'
+  in ArtistFind find
+  out ArtistMusic artist
+  out [Description] descriptions
+  description `Learn more about ${artist}`
+
+particle SlandleArtistShow in 'source/ArtistShow.js'
+  in ArtistMusic artist
+  `consume Slot content
+  description `Learn more about ${artist}`
+
+recipe SlandleArtistInfo
+  use #artist as artist
+  SlandleArtistShow
+    artist = artist
+  description `${ArtistShow}`

--- a/particles/Music/SLANDLESArtistPipe.recipes
+++ b/particles/Music/SLANDLESArtistPipe.recipes
@@ -1,0 +1,21 @@
+import '../PipeApps/PipeEntity.schema'
+import 'SLANDLESArtist.recipes'
+
+particle SlandleArtistPipe in './source/ArtistPipe.js'
+  in PipeEntity pipe
+  out ArtistFind find
+  `consume Slot pipes
+    `provide Slot content
+
+recipe SlandleArtistPipe
+  use #pipe_artist as pipe
+  create as find
+  create #piped #artist as artist
+  create as descriptions
+  SlandleArtistPipe
+    pipe = pipe
+    find = find
+  SlandleArtistFinder
+    find = find
+    artist = artist
+    descriptions = descriptions

--- a/particles/Music/SLANDLESMusic.recipes
+++ b/particles/Music/SLANDLESMusic.recipes
@@ -1,0 +1,2 @@
+import 'SLANDLESPlaylist.recipe'
+import 'SLANDLESArtist.recipes'

--- a/particles/Music/SLANDLESPlaylist.recipe
+++ b/particles/Music/SLANDLESPlaylist.recipe
@@ -1,0 +1,27 @@
+// @license
+// Copyright (c) 2019 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+import '../List/SLANDLESList.recipes'
+import './Playlist.schema'
+
+// has to be baked into context in order to be available
+// as hostedParticle below
+
+particle SlandlePlaylistItem in 'source/PlaylistItem.js'
+  in Playlist playlist
+  `consume Slot item
+
+recipe SlandlePlaylistView
+  map #items as items
+  create #selected as selected
+  SlandleItemMultiplexer
+    list = items
+    hostedParticle = PlaylistItem
+  SlandleSelectableItems
+    list = items
+    selected = selected

--- a/particles/Music/SLANDLESPlaylist.recipe
+++ b/particles/Music/SLANDLESPlaylist.recipe
@@ -21,7 +21,7 @@ recipe SlandlePlaylistView
   create #selected as selected
   SlandleItemMultiplexer
     list = items
-    hostedParticle = PlaylistItem
+    hostedParticle = SlandlePlaylistItem
   SlandleSelectableItems
     list = items
     selected = selected

--- a/particles/Native/SLANDLESnative.recipes
+++ b/particles/Native/SLANDLESnative.recipes
@@ -1,0 +1,1 @@
+import 'Java/SLANDLESj2cl.recipes'

--- a/particles/PipeApps/SLANDLESArtistAutofill.recipes
+++ b/particles/PipeApps/SLANDLESArtistAutofill.recipes
@@ -1,0 +1,23 @@
+import './Json.schema'
+
+schema Artist
+  Text type
+  Text name
+  Text source
+
+particle SlandleRandomArtist in './source/RandomArtist.js'
+  out Artist artist
+
+particle SlandleSuggestArtist in './source/SuggestArtist.js'
+  in Artist artist
+  out Json suggestion
+  `consume Slot app
+
+recipe SlandleCom_spotify_music &autofill
+  create as artist
+  create as suggestion
+  SlandleRandomArtist
+    artist = artist
+  SlandleSuggestArtist
+    artist = artist
+    suggestion = suggestion

--- a/particles/PipeApps/SLANDLESBackgroundPipes.recipes
+++ b/particles/PipeApps/SLANDLESBackgroundPipes.recipes
@@ -1,0 +1,9 @@
+import 'PipeEntity.schema'
+
+particle SlandleBackgroundPipes in './source/Noop.js'
+  in [PipeEntity] entities
+
+recipe SlandleBackgroundPipes
+  create #pipeEntities as entities
+  SlandleBackgroundPipes
+    entities = entities

--- a/particles/PipeApps/SLANDLESMapsAutofill.recipes
+++ b/particles/PipeApps/SLANDLESMapsAutofill.recipes
@@ -1,0 +1,14 @@
+import './PipeEntity.schema'
+import './Json.schema'
+
+particle SlandleSuggestAddress in './source/SuggestAddress.js'
+  in [PipeEntity] recentEntities
+  out Json suggestion
+  `consume Slot app
+
+recipe SlandleCom_google_android_apps_maps &autofill
+  map 'pipe-entities' as recentEntities
+  create as suggestion
+  SlandleSuggestAddress
+    recentEntities = recentEntities
+    suggestion = suggestion

--- a/particles/PipeApps/SLANDLESPeopleAutofill.recipes
+++ b/particles/PipeApps/SLANDLESPeopleAutofill.recipes
@@ -1,0 +1,14 @@
+import './PipeEntity.schema'
+import './Json.schema'
+
+particle SlandleSuggestPerson in './source/SuggestAddress.js'
+  in [PipeEntity] recentEntities
+  out Json suggestion
+  `consume Slot app
+
+recipe SlandleCom_google_android_gm &autofill
+  map 'pipe-entities' as recentEntities
+  create as suggestion
+  SlandleSuggestPerson
+    recentEntities = recentEntities
+    suggestion = suggestion

--- a/particles/PipeApps/SLANDLESPipeApps.recipes
+++ b/particles/PipeApps/SLANDLESPipeApps.recipes
@@ -1,0 +1,2 @@
+import 'SLANDLESMapsAutofill.recipes'
+import 'SLANDLESPeopleAutofill.recipes'

--- a/particles/PipeApps/SLANDLESTrigger.recipes
+++ b/particles/PipeApps/SLANDLESTrigger.recipes
@@ -1,0 +1,6 @@
+import './PipeEntity.schema'
+
+particle SlandleTrigger in './source/Noop.js'
+  in PipeEntity pipe
+  `consume Slot root
+    `provide Slot app

--- a/particles/PipeApps/SLANDLEScanonical.recipes
+++ b/particles/PipeApps/SLANDLEScanonical.recipes
@@ -1,0 +1,1 @@
+import 'SLANDLESPipeApps.recipes'

--- a/particles/Products/SLANDLESGifts.recipe
+++ b/particles/Products/SLANDLESGifts.recipe
@@ -36,11 +36,11 @@ particle SlandleAlternateShipping in 'source/AlternateShipping.js'
 //  Multiplexer
 //    list = shoplist
 //    hostedParticle = Arrivinator
-//    `consume Slot annotation as annotationSlot
+//    annotation consume annotationSlot
 //  Multiplexer
 //    list = shoplist
 //    hostedParticle = AlternateShipping
-//    `consume Slot annotation as annotationSlot
+//    annotation consume annotationSlot
 //  description `check shipping for ${GiftList.person}'s ${GiftList.person.occasion} on ${GiftList.person.date}`
 
 

--- a/particles/Products/SLANDLESGifts.recipe
+++ b/particles/Products/SLANDLESGifts.recipe
@@ -1,0 +1,46 @@
+// @license
+// Copyright (c) 2019 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+import '../People/Person.schema'
+import 'Product.schema'
+
+particle SlandleGiftList in 'source/GiftList.js'
+  in Person person
+  `consume Slot preamble
+  description `buy gifts for ${person}'s ${person.occasion} on ${person.date}`
+
+particle SlandleArrivinator in 'source/Arrivinator.js'
+  in Product product
+  `consume Slot annotation
+  description `estimate arrival date`
+  // TODO: add support for patterns:
+  //description `estimate ${product} arrival date`
+    //product `my best product`
+
+particle SlandleAlternateShipping in 'source/AlternateShipping.js'
+  in Product product
+  `consume Slot annotation
+  description `find alternate shipping for products which won't make it on time`
+
+// Buying for [person]'s [occasion] in [timeframe]? Product [X] arrives too late.
+//recipe SlandleMakeIntoGiftList
+//  use #shoplist as shoplist
+//  copy as person
+//  GiftList
+//    person = person
+//  Multiplexer
+//    list = shoplist
+//    hostedParticle = Arrivinator
+//    `consume Slot annotation as annotationSlot
+//  Multiplexer
+//    list = shoplist
+//    hostedParticle = AlternateShipping
+//    `consume Slot annotation as annotationSlot
+//  description `check shipping for ${GiftList.person}'s ${GiftList.person.occasion} on ${GiftList.person.date}`
+
+

--- a/particles/Products/SLANDLESInterests.recipe
+++ b/particles/Products/SLANDLESInterests.recipe
@@ -1,0 +1,31 @@
+// @license
+// Copyright (c) 2019 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+import '../People/Person.schema'
+import 'Product.schema'
+
+particle SlandleInterests in 'source/Interests.js'
+  in [Product] list
+  in Person person
+  `consume Slot postamble
+  description `find out about ${person.name}'s interests`
+
+// Recommendations based on Claire's interest in field hockey.
+//recipe SlandleInterestRecipe
+//  map #wishlist as wishlist
+//  use as person
+//  Interests
+//    list = wishlist
+//    person = person
+
+recipe SlandleProductInterests
+  use as list
+  use as person
+  SlandleInterests
+    list = list
+    person = person

--- a/particles/Products/SLANDLESManufacturer.recipe
+++ b/particles/Products/SLANDLESManufacturer.recipe
@@ -18,5 +18,5 @@ recipe SlandleProductManufacturerInfo
   use as shoplist
   SlandleSimpleAnnotationMultiplexer
     list = shoplist
-    hostedParticle = ManufacturerInfo
+    hostedParticle = SlandleManufacturerInfo
   description `check manufacturer information`

--- a/particles/Products/SLANDLESManufacturer.recipe
+++ b/particles/Products/SLANDLESManufacturer.recipe
@@ -1,0 +1,22 @@
+// @license
+// Copyright (c) 2019 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+import '../List/SLANDLESList.recipes'
+import 'Product.schema'
+
+particle SlandleManufacturerInfo in 'source/ManufacturerInfo.js'
+  in Product product
+  `consume Slot annotation
+
+// Check manufacturer information for products.
+recipe SlandleProductManufacturerInfo
+  use as shoplist
+  SlandleSimpleAnnotationMultiplexer
+    list = shoplist
+    hostedParticle = ManufacturerInfo
+  description `check manufacturer information`

--- a/particles/Products/SLANDLESProductItem.recipe
+++ b/particles/Products/SLANDLESProductItem.recipe
@@ -1,0 +1,5 @@
+import 'Product.schema'
+
+particle SlandleProductItem in 'source/ProductItem.js'
+  in Product product
+  `consume Slot item

--- a/particles/Products/SLANDLESProducts.recipe
+++ b/particles/Products/SLANDLESProducts.recipe
@@ -19,7 +19,7 @@ recipe SlandleProducts
     list = products
   SlandleItemMultiplexer
     list = products
-    hostedParticle = ProductItem
+    hostedParticle = SlandleProductItem
 
 recipe SlandleCreateShoppingList
   copy as products
@@ -27,7 +27,7 @@ recipe SlandleCreateShoppingList
     list = products
   SlandleItemMultiplexer
     list = products
-    hostedParticle = ProductItem
+    hostedParticle = SlandleProductItem
   description `create shopping list from ${Items.list}`
 
 recipe SlandleShopForOccasion
@@ -37,8 +37,8 @@ recipe SlandleShopForOccasion
     person = person
   SlandleSimpleAnnotationMultiplexer
     list = shoplist
-    hostedParticle = Arrivinator
-    consume annotation as annotationSlot
+    hostedParticle = SlandleArrivinator
+    annotation consume annotationSlot
 
 recipe SlandleUseWishlist
   map #wishlist as wishlist
@@ -48,11 +48,11 @@ recipe SlandleUseWishlist
   // annotates shoplist
   SlandleChoicesMultiplexer
     // This is probably wrong, but it works now (instead of annotationSlot)
-    // consume choice as annotationSlot
-    consume choice as actionSlot
+    // choice consume annotationSlot
+    choice consume actionSlot
     list = shoplist
     choices = wishlist
-    hostedParticle = AlsoOn
+    hostedParticle = SlandleAlsoOn
   // recommend products from wishlist
   SlandleRecommend
     population = wishlist
@@ -60,7 +60,7 @@ recipe SlandleUseWishlist
     recommendations = recommendations
   // present recommendations for adding to shoplist
   SlandleChooser
-    consume action as actionSlot
+    action consume actionSlot
     person = person
     choices = recommendations
     resultList = shoplist

--- a/particles/Products/SLANDLESProducts.recipe
+++ b/particles/Products/SLANDLESProducts.recipe
@@ -1,0 +1,68 @@
+// @license
+// Copyright (c) 2019 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+import '../List/SLANDLESList.recipes'
+import 'SLANDLESProductItem.recipe'
+import 'SLANDLESGifts.recipe'
+import 'SLANDLESRecommend.recipe'
+import 'SLANDLESManufacturer.recipe'
+import 'SLANDLESInterests.recipe'
+
+recipe SlandleProducts
+  use as products
+  SlandleItems
+    list = products
+  SlandleItemMultiplexer
+    list = products
+    hostedParticle = ProductItem
+
+recipe SlandleCreateShoppingList
+  copy as products
+  SlandleItems
+    list = products
+  SlandleItemMultiplexer
+    list = products
+    hostedParticle = ProductItem
+  description `create shopping list from ${Items.list}`
+
+recipe SlandleShopForOccasion
+  use as shoplist
+  map as person
+  SlandleGiftList
+    person = person
+  SlandleSimpleAnnotationMultiplexer
+    list = shoplist
+    hostedParticle = Arrivinator
+    consume annotation as annotationSlot
+
+recipe SlandleUseWishlist
+  map #wishlist as wishlist
+  create #volatile as recommendations
+  use as person
+  use as shoplist
+  // annotates shoplist
+  SlandleChoicesMultiplexer
+    // This is probably wrong, but it works now (instead of annotationSlot)
+    // consume choice as annotationSlot
+    consume choice as actionSlot
+    list = shoplist
+    choices = wishlist
+    hostedParticle = AlsoOn
+  // recommend products from wishlist
+  SlandleRecommend
+    population = wishlist
+    known = shoplist
+    recommendations = recommendations
+  // present recommendations for adding to shoplist
+  SlandleChooser
+    consume action as actionSlot
+    person = person
+    choices = recommendations
+    resultList = shoplist
+
+

--- a/particles/Products/SLANDLESRecommend.recipe
+++ b/particles/Products/SLANDLESRecommend.recipe
@@ -1,0 +1,34 @@
+// @license
+// Copyright (c) 2019 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+import 'Product.schema'
+import '../People/Person.schema'
+import '../List/SLANDLESList.recipes'
+
+particle SlandleRecommend in 'source/Recommend.js'
+  in [Product] known
+  in [Product] population
+  out [Product] recommendations
+  description `recommend products from ${known} and ${population}`
+    //recommendations `products recommended based on ${known}._name_ and ${population}._name_`
+    recommendations `${population}._name_`
+
+particle SlandleChooser in 'source/Chooser.js'
+  in Person person
+  in [~a] choices
+  inout [~a] resultList
+  `consume Slot action
+    `provide [Slot{handle: choices}] annotation
+  description `add items from ${person}'s ${choices}`
+
+particle SlandleAlsoOn in 'source/AlsoOn.js'
+  in Product product
+  in [Product] choices
+  `consume Slot choice
+
+

--- a/particles/Profile/SLANDLESBasicProfile.recipe
+++ b/particles/Profile/SLANDLESBasicProfile.recipe
@@ -1,0 +1,36 @@
+import 'Friend.schema'
+import 'UserName.schema'
+import 'Avatar.schema'
+
+particle SlandleUserNameForm in 'source/UserNameForm.js'
+  inout UserName userName
+  `consume Slot userName
+
+particle SlandleFriendsPicker in 'source/FriendsPicker.js'
+  inout [Friend] friends
+  in [Avatar] avatars
+  in [UserName] userNames
+  `consume Slot friends
+  description `select friends`
+
+particle SlandleBasicProfile in 'source/BasicProfile.js'
+  inout Avatar avatar
+  `consume Slot root
+    `provide Slot userName
+    `provide Slot friends
+
+recipe SlandleBasicProfile
+  create #avatar as avatar
+  create #userName as userName
+  create #friends as friends
+  map 'BOXED_avatar' as avatars
+  map 'BOXED_userName' as userNames
+  SlandleBasicProfile
+    avatar = avatar
+  SlandleUserNameForm
+    userName = userName
+  SlandleFriendsPicker
+    friends = friends
+    avatars = avatars
+    userNames = userNames
+  description `edit user profile (name, avatar, and friends)`

--- a/particles/Profile/SLANDLESEchoUser.recipe
+++ b/particles/Profile/SLANDLESEchoUser.recipe
@@ -1,0 +1,10 @@
+import 'User.schema'
+
+particle SlandleEchoUser in './source/EchoUser.js'
+  `consume Slot root
+  in User user
+
+recipe SlandleEchoUser
+  map 'SYSTEM_user' as user
+  SlandleEchoUser
+    user = user

--- a/particles/Profile/SLANDLESFavoriteFood.recipes
+++ b/particles/Profile/SLANDLESFavoriteFood.recipes
@@ -1,0 +1,21 @@
+// Copyright (c) 2019 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+schema FavoriteFood
+  Text food
+
+particle SlandleFavoriteFoodPicker in 'source/FavoriteFoodPicker.js'
+  inout [FavoriteFood] foods
+  `consume Slot root
+  description `select favorite foods`
+    foods `favorite foods`
+
+recipe SlandleFavoriteFood
+  create #favoriteFoods as foods
+  SlandleFavoriteFoodPicker
+    foods = foods
+

--- a/particles/Profile/SLANDLESGeolocate.recipe
+++ b/particles/Profile/SLANDLESGeolocate.recipe
@@ -1,0 +1,12 @@
+import './Geolocation.schema'
+
+particle SlandleGeolocate in './source/Geolocate.js'
+  `consume Slot root
+  out Geolocation location
+  description `you`
+    location `you`
+
+recipe SlandleGeolocate
+  create as location
+  SlandleGeolocate
+    location = location

--- a/particles/Profile/SLANDLESProfile.recipes
+++ b/particles/Profile/SLANDLESProfile.recipes
@@ -1,0 +1,2 @@
+import 'SLANDLESBasicProfile.recipe'
+import 'SLANDLESFavoriteFood.recipes'

--- a/particles/Profile/SLANDLESSharing.recipe
+++ b/particles/Profile/SLANDLESSharing.recipe
@@ -1,0 +1,45 @@
+import 'Avatar.schema'
+import 'UserName.schema'
+
+resource PROFILE_avatarResource
+  start
+  []
+store PROFILE_avatar of [Avatar] 'PROFILE_avatar' @0 #profile in PROFILE_avatarResource
+
+resource PROFILE_userNameResource
+  start
+  []
+store PROFILE_userName of [UserName] 'PROFILE_userName' @0 #profile in PROFILE_userNameResource
+
+resource BOXED_avatarResource
+  start
+  []
+store BOXED_avatar of [Avatar] 'BOXED_avatar' @0 #boxed in BOXED_avatarResource
+
+resource BOXED_userNameResource
+  start
+  []
+store BOXED_userName of [UserName] 'BOXED_userName' @0 #boxed in BOXED_userNameResource
+
+// the below is required to make the arc aware of these stores
+
+particle SlandleSharing in './source/Sharing.js'
+  in [Avatar] boxedAvatar
+  in [Avatar] profileAvatar
+  //
+  in [UserName] profileUserName
+  in [UserName] boxedUserName
+
+recipe SlandleSharing
+  use 'PROFILE_avatar' as profileAvatar
+  use 'BOXED_avatar' as boxedAvatar
+  //
+  use 'PROFILE_userName' as profileUserName
+  use 'BOXED_userName' as boxedUserName
+  //
+  SlandleSharing
+    profileAvatar = profileAvatar
+    boxedAvatar = boxedAvatar
+    //
+    profileUserName = profileUserName
+    boxedUserName = boxedUserName

--- a/particles/Restaurants/SLANDLESFavoriteFoodAnnotation.recipes
+++ b/particles/Restaurants/SLANDLESFavoriteFoodAnnotation.recipes
@@ -1,0 +1,28 @@
+// @license
+// Copyright (c) 2019 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+import '../List/SLANDLESList.recipes'
+import '../Profile/SLANDLESFavoriteFood.recipes'
+import './Restaurant.schema'
+import '../Events/Event.schema'
+import './SLANDLESReservations.recipes'
+
+particle SlandleFavoriteFoodAnnotation in 'source/FavoriteFoodAnnotation.js'
+  in Restaurant restaurant
+  in [FavoriteFood] foods
+  `consume Slot annotation
+
+recipe SlandleFavoriteFoodAnnotation
+  use as restaurants
+  map 'PROFILE_favoriteFoods' as foods
+  SlandleCombinedAnnotationMultiplexer
+    list = restaurants
+    choices = foods
+    hostedParticle = FavoriteFoodAnnotation
+  description `[inline] check restaurants for favorite foods`
+

--- a/particles/Restaurants/SLANDLESFavoriteFoodAnnotation.recipes
+++ b/particles/Restaurants/SLANDLESFavoriteFoodAnnotation.recipes
@@ -23,6 +23,6 @@ recipe SlandleFavoriteFoodAnnotation
   SlandleCombinedAnnotationMultiplexer
     list = restaurants
     choices = foods
-    hostedParticle = FavoriteFoodAnnotation
+    hostedParticle = SlandleFavoriteFoodAnnotation
   description `[inline] check restaurants for favorite foods`
 

--- a/particles/Restaurants/SLANDLESReservations.recipes
+++ b/particles/Restaurants/SLANDLESReservations.recipes
@@ -5,9 +5,9 @@
 // subject to an additional IP rights grant found at
 // http://polymer.github.io/PATENTS.txt
 
-import '../List/List.recipes'
-import '../Layout/Layout.recipes'
-import '../Events/Events.recipes'
+import '../List/SLANDLESList.recipes'
+import '../Layout/SLANDLESLayout.recipes'
+import '../Events/SLANDLESEvents.recipes'
 import '../Restaurants/Restaurant.schema'
 import '../Common/Description.schema'
 
@@ -44,7 +44,7 @@ recipe SlandleMakeReservations
   create #reservation as event
   create #volatile as calendarDescriptions
   create #volatile as annotationDescriptions
-  slot 'rootslotid-toproot' as toproot
+  `slot 'rootslotid-toproot' as toproot
   SlandleCalendar
     event = event
     descriptions = calendarDescriptions
@@ -52,20 +52,20 @@ recipe SlandleMakeReservations
   SlandleReservationForm
     restaurant = restaurant
     event = event
-    consume action as toproot
+    action consume toproot
   // per-restaurant tile scheduler
   SlandleAnnotationMultiplexer
     list = restaurants
     annotation = event
-    hostedParticle = ReservationMultiAnnotation
+    hostedParticle = SlandleReservationMultiAnnotation
   // event editor (+scheduler) on restaurant detail
   SlandleDetailReservationForm
      restaurant = restaurant
      event = event
-     consume detailAction
-       provide annotation as detailAnnotation
+     detailAction consume
+       annotation provide detailAnnotation
   SlandleReservationAnnotation
     restaurant = restaurant
     event = event
     descriptions = annotationDescriptions
-    consume annotation as detailAnnotation
+    annotation consume detailAnnotation

--- a/particles/Restaurants/SLANDLESReservations.recipes
+++ b/particles/Restaurants/SLANDLESReservations.recipes
@@ -1,0 +1,71 @@
+// Copyright (c) 2019 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+import '../List/List.recipes'
+import '../Layout/Layout.recipes'
+import '../Events/Events.recipes'
+import '../Restaurants/Restaurant.schema'
+import '../Common/Description.schema'
+
+particle SlandleReservationForm in 'source/ReservationForm.js'
+  inout Event event
+  in Restaurant restaurant
+  `consume Slot action
+    `provide Slot annotation
+
+// TODO(sjmiles): couldn't find a way to project ReservationForm into detailAction slot,
+// so fork the particle
+particle SlandleDetailReservationForm in 'source/ReservationForm.js'
+  inout Event event
+  in Restaurant restaurant
+  `consume Slot detailAction
+    `provide? Slot annotation
+
+particle SlandleReservationAnnotation in 'source/ReservationAnnotation.js'
+  in Restaurant restaurant
+  inout Event event
+  out [Description] descriptions
+  `consume? Slot annotation
+
+// TODO(sjmiles): we don't have optional handles yet, so fork the particle
+// rather than having every instance generate descriptions
+particle SlandleReservationMultiAnnotation in 'source/ReservationAnnotation.js'
+  in Restaurant restaurant
+  inout Event event
+  `consume? Slot annotation
+
+recipe SlandleMakeReservations
+  use as restaurants
+  use #selected as restaurant
+  create #reservation as event
+  create #volatile as calendarDescriptions
+  create #volatile as annotationDescriptions
+  slot 'rootslotid-toproot' as toproot
+  SlandleCalendar
+    event = event
+    descriptions = calendarDescriptions
+  // top-of-frame event editor
+  SlandleReservationForm
+    restaurant = restaurant
+    event = event
+    consume action as toproot
+  // per-restaurant tile scheduler
+  SlandleAnnotationMultiplexer
+    list = restaurants
+    annotation = event
+    hostedParticle = ReservationMultiAnnotation
+  // event editor (+scheduler) on restaurant detail
+  SlandleDetailReservationForm
+     restaurant = restaurant
+     event = event
+     consume detailAction
+       provide annotation as detailAnnotation
+  SlandleReservationAnnotation
+    restaurant = restaurant
+    event = event
+    descriptions = annotationDescriptions
+    consume annotation as detailAnnotation

--- a/particles/Restaurants/SLANDLESRestaurantDisplay.recipes
+++ b/particles/Restaurants/SLANDLESRestaurantDisplay.recipes
@@ -1,0 +1,19 @@
+// Copyright (c) 2019 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+import 'Restaurant.schema'
+
+particle SlandleRestaurantTile in 'source/RestaurantTile.js'
+  in Restaurant restaurant
+  `consume Slot tile
+    `provide Slot annotation
+
+particle SlandleRestaurantDetail in 'source/RestaurantDetail.js'
+  in Restaurant restaurant
+  `consume Slot content
+    `provide Slot detailAction
+

--- a/particles/Restaurants/SLANDLESRestaurantFind.recipes
+++ b/particles/Restaurants/SLANDLESRestaurantFind.recipes
@@ -1,0 +1,21 @@
+// Copyright (c) 2019 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+import 'Restaurant.schema'
+import '../Profile/SLANDLESGeolocate.recipe'
+
+particle SlandleRestaurantFind in 'source/RestaurantFind.js'
+  in Geolocation location
+  inout [Restaurant] restaurants
+
+// TODO: see what happens if we decimate Restaurants.recipes::Recipes into smaller pieces like this
+//recipe SlandleRestaurantFind
+//  create #tiles as restaurants
+//  RestaurantFind
+//    restaurants = restaurants
+//  description `find restaurants near ${RestaurantFind.location}`
+

--- a/particles/Restaurants/SLANDLESRestaurants.recipes
+++ b/particles/Restaurants/SLANDLESRestaurants.recipes
@@ -26,7 +26,7 @@ recipe SlandleRestaurants
     selected = selected
   SlandleTileMultiplexer
     list = restaurants
-    hostedParticle = RestaurantTile
+    hostedParticle = SlandleRestaurantTile
   SlandleDetailSlider
     selected = selected
   SlandleRestaurantDetail

--- a/particles/Restaurants/SLANDLESRestaurants.recipes
+++ b/particles/Restaurants/SLANDLESRestaurants.recipes
@@ -1,0 +1,34 @@
+// Copyright (c) 2019 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+import 'SLANDLESRestaurantFind.recipes'
+import 'SLANDLESRestaurantDisplay.recipes'
+import 'SLANDLESReservations.recipes'
+import 'SLANDLESFavoriteFoodAnnotation.recipes'
+import '../List/SLANDLESList.recipes'
+import '../Profile/SLANDLESGeolocate.recipe'
+
+recipe SlandleRestaurants
+  create #volatile as location
+  create as restaurants
+  create #volatile #selected as selected
+  SlandleGeolocate
+    location = location
+  SlandleRestaurantFind
+    location = location
+    restaurants = restaurants
+  SlandleSelectableTiles
+    list = restaurants
+    selected = selected
+  SlandleTileMultiplexer
+    list = restaurants
+    hostedParticle = RestaurantTile
+  SlandleDetailSlider
+    selected = selected
+  SlandleRestaurantDetail
+    restaurant = selected
+  description `find restaurants near ${RestaurantFind.location}`

--- a/particles/Services/SLANDLESMl5.recipes
+++ b/particles/Services/SLANDLESMl5.recipes
@@ -1,4 +1,4 @@
-import 'particles/Ml5.particle'
+import 'particles/SLANDLESMl5.particle'
 recipe SlandleMl5
   SlandleMl5
   description `image classification using ml5 (service)`

--- a/particles/Services/SLANDLESMl5.recipes
+++ b/particles/Services/SLANDLESMl5.recipes
@@ -1,0 +1,4 @@
+import 'particles/Ml5.particle'
+recipe SlandleMl5
+  SlandleMl5
+  description `image classification using ml5 (service)`

--- a/particles/Services/SLANDLESServiceTest.recipes
+++ b/particles/Services/SLANDLESServiceTest.recipes
@@ -1,4 +1,4 @@
-import 'particles/ServiceTest.particle'
+import 'particles/SLANDLESServiceTest.particle'
 recipe SlandleServiceTest
   SlandleServiceTest
   description `test service infrastructure`

--- a/particles/Services/SLANDLESServiceTest.recipes
+++ b/particles/Services/SLANDLESServiceTest.recipes
@@ -1,0 +1,4 @@
+import 'particles/ServiceTest.particle'
+recipe SlandleServiceTest
+  SlandleServiceTest
+  description `test service infrastructure`

--- a/particles/Services/SLANDLESServices.recipes
+++ b/particles/Services/SLANDLESServices.recipes
@@ -1,0 +1,4 @@
+import 'SLANDLESTfjs.recipes'
+import 'SLANDLESMl5.recipes'
+import 'SLANDLESServiceTest.recipes'
+

--- a/particles/Services/SLANDLESTfjs.recipes
+++ b/particles/Services/SLANDLESTfjs.recipes
@@ -1,0 +1,4 @@
+import 'particles/SLANDLESTfjs.particle'
+recipe SlandleTfjs
+  SlandleTfjs
+  description `linear regression example using TensorFlowJs (service)`

--- a/particles/Services/particles/SLANDLESMl5.particle
+++ b/particles/Services/particles/SLANDLESMl5.particle
@@ -1,0 +1,2 @@
+particle SlandleMl5 in './js/Ml5.js'
+  `consume Slot root

--- a/particles/Services/particles/SLANDLESServiceTest.particle
+++ b/particles/Services/particles/SLANDLESServiceTest.particle
@@ -1,0 +1,2 @@
+particle SlandleServiceTest in './js/ServiceTest.js'
+  consume root

--- a/particles/Services/particles/SLANDLESTfjs.particle
+++ b/particles/Services/particles/SLANDLESTfjs.particle
@@ -1,2 +1,2 @@
-particle Tfjs in './js/Tfjs.js'
+particle SlandleTfjs in './js/Tfjs.js'
   `consume Slot root

--- a/particles/Services/particles/SLANDLESTfjs.particle
+++ b/particles/Services/particles/SLANDLESTfjs.particle
@@ -1,0 +1,2 @@
+particle Tfjs in './js/Tfjs.js'
+  `consume Slot root

--- a/particles/TVMaze/SLANDLESTVMaze.recipes
+++ b/particles/TVMaze/SLANDLESTVMaze.recipes
@@ -1,0 +1,2 @@
+import 'SLANDLESTVMazeSearchPanel.recipes'
+import 'SLANDLESTVMazeApp.recipes'

--- a/particles/TVMaze/SLANDLESTVMazeApp.recipes
+++ b/particles/TVMaze/SLANDLESTVMazeApp.recipes
@@ -48,11 +48,11 @@ recipe SlandleTVMazeApp
     watchers = watchers
     watcherText = alsoWatch
     descriptions = descriptions
-    consume root as root
-      provide recommended as recommended
-      provide shows as shows
-      provide searchbar as searchbar
-      provide search as search
+    root consume root
+      recommended provide recommended
+      shows provide shows
+      searchbar provide searchbar
+      search provide search
   //
   // slot `shows` holds my primary show list
   create #volatile #uniqueProfile as uniqueProfileShows
@@ -60,15 +60,15 @@ recipe SlandleTVMazeApp
     shows = profileShows
     uniqueShows = uniqueProfileShows
   SlandleSelectableTiles
-    consume root as shows
-      provide tile as tile1
-      provide annotation as action1
+    root consume shows
+      tile provide tile1
+      annotation provide action1
     list = uniqueProfileShows
     selected = selected
   SlandleTileMultiplexer
     list = uniqueProfileShows
-    hostedParticle = TVMazeShowTile
-    consume tile as tile1
+    hostedParticle = SlandleTVMazeShowTile
+    tile consume tile1
   //
   // slot `recommended` holds recommendations
   // which are pulled from `allPipedShows`
@@ -77,42 +77,42 @@ recipe SlandleTVMazeApp
     shows = allPipedShows
     uniqueShows = uniquePipedShows
   SlandleSelectableTiles
-    consume root as recommended
-      provide tile as tile2
-      provide annotation as action2
+    root consume recommended
+      tile provide tile2
+      annotation provide action2
     list = uniquePipedShows
     selected = selected
   SlandleTileMultiplexer
-    consume tile as tile2
+    tile consume tile2
     list = uniquePipedShows
-    hostedParticle = TVMazeShowTile
+    hostedParticle = SlandleTVMazeShowTile
   SlandleActionMultiplexer
-    consume action as action2
+    action consume action2
     list = uniquePipedShows
     shows = myshows
-    hostedParticle = TVMazeShowActions
+    hostedParticle = SlandleTVMazeShowActions
   //
   // slot `search` contains search ui
   create #volatile #query as query
   SlandleTVMazeSearchBar
-    consume toproot as searchbar
+    toproot consume searchbar
     query = query
   SlandleTVMazeSearchShows
     query = query
     shows = foundshows
   SlandleSelectableTiles
-    consume root as search
-      provide tile as tile3
-      provide annotation as action3
+    root consume search
+      tile provide tile3
+      annotation provide action3
     list = foundshows
     selected = selected
   SlandleTileMultiplexer
-    consume tile as tile3
-    hostedParticle = TVMazeShowTile
+    tile consume tile3
+    hostedParticle = SlandleTVMazeShowTile
     list = foundshows
   SlandleActionMultiplexer
-    consume action as action3
-    hostedParticle = TVMazeShowActions
+    action consume action3
+    hostedParticle = SlandleTVMazeShowActions
     list = foundshows
     shows = myshows
   //

--- a/particles/TVMaze/SLANDLESTVMazeApp.recipes
+++ b/particles/TVMaze/SLANDLESTVMazeApp.recipes
@@ -1,0 +1,126 @@
+import 'particles/SLANDLESTVMazeSearchBar.particle'
+import 'particles/SLANDLESTVMazeSearchShows.particle'
+import 'particles/SLANDLESTVMazeShowTile.particle'
+import 'particles/SLANDLESTVMazeShowPanel.particle'
+import 'particles/SLANDLESTVMazeShowActions.particle'
+import 'particles/SLANDLESTVMazeDeduplicate.particle'
+import 'particles/SLANDLESTVMazeAppShell.particle'
+import '../List/SLANDLESList.recipes'
+import '../Layout/SLANDLESDetail.recipes'
+
+recipe SlandleTVMazeApp
+  // all shows shared with me
+  map 'BOXED_shows-tiles' as boxedShows
+  // filter out 'my' shows from boxedShows using user.id
+  map 'SYSTEM_user' as user
+  // why not just use profile instead of above?
+  map 'PROFILE_shows-tiles' as profileShows
+  // all shows I've looked at on my device
+  map 'PROFILE_all_piped-all_tv_shows' as allPipedShows
+  // most recent show(s)
+  //map 'PROFILE_piped-tv_show' as pipedShows
+  create #volatile as pipedShows
+  // selected show (for detail)
+  create #volatile #selected as selected
+  // shows that this arc wants to be part of BOXED_shows-tile (if this arc is shared)
+  create #shows #tiles as myshows
+  // search results
+  create #volatile #found as foundshows
+  // friends ids
+  map 'PROFILE_friends' as friends
+  // all the userNames
+  map 'BOXED_userName' as boxedUserNames
+  // friends also watching selected show
+  create #volatile #watchers as watchers
+  // text about friends watching selected show
+  create #volatile #alsoWatch as alsoWatch
+  // internal description storage
+  create #volatile as descriptions
+  //
+  SlandleTVMazeAppShell
+    user = user
+    boxedShows = boxedShows
+    selected = selected
+    recentShows = pipedShows
+    foundShows = foundshows
+    boxedUserNames = boxedUserNames
+    friends = friends
+    watchers = watchers
+    watcherText = alsoWatch
+    descriptions = descriptions
+    consume root as root
+      provide recommended as recommended
+      provide shows as shows
+      provide searchbar as searchbar
+      provide search as search
+  //
+  // slot `shows` holds my primary show list
+  create #volatile #uniqueProfile as uniqueProfileShows
+  SlandleTVMazeDeduplicate
+    shows = profileShows
+    uniqueShows = uniqueProfileShows
+  SlandleSelectableTiles
+    consume root as shows
+      provide tile as tile1
+      provide annotation as action1
+    list = uniqueProfileShows
+    selected = selected
+  SlandleTileMultiplexer
+    list = uniqueProfileShows
+    hostedParticle = TVMazeShowTile
+    consume tile as tile1
+  //
+  // slot `recommended` holds recommendations
+  // which are pulled from `allPipedShows`
+  create #volatile #uniquePiped as uniquePipedShows
+  SlandleTVMazeDeduplicate
+    shows = allPipedShows
+    uniqueShows = uniquePipedShows
+  SlandleSelectableTiles
+    consume root as recommended
+      provide tile as tile2
+      provide annotation as action2
+    list = uniquePipedShows
+    selected = selected
+  SlandleTileMultiplexer
+    consume tile as tile2
+    list = uniquePipedShows
+    hostedParticle = TVMazeShowTile
+  SlandleActionMultiplexer
+    consume action as action2
+    list = uniquePipedShows
+    shows = myshows
+    hostedParticle = TVMazeShowActions
+  //
+  // slot `search` contains search ui
+  create #volatile #query as query
+  SlandleTVMazeSearchBar
+    consume toproot as searchbar
+    query = query
+  SlandleTVMazeSearchShows
+    query = query
+    shows = foundshows
+  SlandleSelectableTiles
+    consume root as search
+      provide tile as tile3
+      provide annotation as action3
+    list = foundshows
+    selected = selected
+  SlandleTileMultiplexer
+    consume tile as tile3
+    hostedParticle = TVMazeShowTile
+    list = foundshows
+  SlandleActionMultiplexer
+    consume action as action3
+    hostedParticle = TVMazeShowActions
+    list = foundshows
+    shows = myshows
+  //
+  // standard slot 'modal' holds detail view
+  SlandleDetailSlider
+    selected = selected
+  SlandleTVMazeShowPanel
+    show = selected
+    alsoWatch = alsoWatch
+  //
+  description `${TVMazeAppShell}`

--- a/particles/TVMaze/SLANDLESTVMazeSearchPanel.recipes
+++ b/particles/TVMaze/SLANDLESTVMazeSearchPanel.recipes
@@ -24,14 +24,14 @@ recipe SlandleTVMazeShowTiles
   use as shows
   create #selected as selected
   SlandleSelectableTiles
-    consume root
-      provide tile
-      provide annotation as action
+    root consume
+      tile provide
+      annotation provide action
     list = shows
     selected = selected
   SlandleTileMultiplexer
     hostedParticle = SlandleTVMazeShowTile
-    consume tile
+    tile consume
     list = shows
   description `show information about ${SelectableTiles.list}`
 

--- a/particles/TVMaze/SLANDLESTVMazeSearchPanel.recipes
+++ b/particles/TVMaze/SLANDLESTVMazeSearchPanel.recipes
@@ -1,0 +1,44 @@
+import 'particles/SLANDLESTVMazeSearchBar.particle'
+import 'particles/SLANDLESTVMazeSearchShows.particle'
+import 'particles/SLANDLESTVMazeShowTile.particle'
+import 'particles/SLANDLESTVMazeShowPanel.particle'
+import 'particles/SLANDLESTVMazeShowActions.particle'
+
+import '../List/SLANDLESList.recipes'
+import '../Layout/SLANDLESLayout.recipes'
+
+recipe SlandleTVMazeSearchBar
+  create #volatile as query
+  SlandleTVMazeSearchBar
+    query = query
+
+recipe SlandleTVMazeSearchShows
+  use as query
+  create #tiles #shows as shows
+  SlandleTVMazeSearchShows
+    query = query
+    shows = shows
+  description `use TVMaze(tm) to search for TV shows`
+
+recipe SlandleTVMazeShowTiles
+  use as shows
+  create #selected as selected
+  SlandleSelectableTiles
+    consume root
+      provide tile
+      provide annotation as action
+    list = shows
+    selected = selected
+  SlandleTileMultiplexer
+    hostedParticle = SlandleTVMazeShowTile
+    consume tile
+    list = shows
+  description `show information about ${SelectableTiles.list}`
+
+recipe SlandleTVMazeShowPanel
+  use as show
+  create #volatile as descriptions
+  SlandleTVMazeShowPanel
+    show = show
+    descriptions = descriptions
+

--- a/particles/TVMaze/particles/SLANDLESTVMazeAppShell.particle
+++ b/particles/TVMaze/particles/SLANDLESTVMazeAppShell.particle
@@ -1,0 +1,25 @@
+import '../../Profile/User.schema'
+import '../../Profile/UserName.schema'
+import '../../Common/Description.schema'
+import '../schemas/TVMazeShow.schema'
+import '../schemas/Text.schema'
+
+particle SlandleTVMazeAppShell in './js/TVMazeAppShell.js'
+  in [TVMazeShow] recentShows
+  inout TVMazeShow selected
+  in User user
+  in [TVMazeShow] boxedShows
+  in [TVMazeShow] foundShows
+  in [User] friends
+  in [UserName] boxedUserNames
+  inout [User] watchers
+  out Text watcherText
+  out [Description] descriptions
+  `consume Slot root
+    `provide Slot shows
+    `provide Slot recommended
+    `provide Slot searchbar
+    `provide Slot search
+  // TODO: add better description,
+  // or fix recipe description to  not crash if one is missing.
+  description `manage my TV shows (using TVMaze)`

--- a/particles/TVMaze/particles/SLANDLESTVMazeDeduplicate.particle
+++ b/particles/TVMaze/particles/SLANDLESTVMazeDeduplicate.particle
@@ -1,0 +1,5 @@
+import '../schemas/TVMazeShow.schema'
+
+particle SlandleTVMazeDeduplicate in './js/TVMazeDeduplicate.js'
+  in [TVMazeShow] shows
+  inout [TVMazeShow] uniqueShows

--- a/particles/TVMaze/particles/SLANDLESTVMazeSearchBar.particle
+++ b/particles/TVMaze/particles/SLANDLESTVMazeSearchBar.particle
@@ -1,0 +1,5 @@
+import '../schemas/TVMazeQuery.schema'
+
+particle SlandleTVMazeSearchBar in './js/TVMazeSearchBar.js'
+  out TVMazeQuery query
+  `consume Slot toproot

--- a/particles/TVMaze/particles/SLANDLESTVMazeSearchShows.particle
+++ b/particles/TVMaze/particles/SLANDLESTVMazeSearchShows.particle
@@ -1,0 +1,6 @@
+import '../schemas/TVMazeQuery.schema'
+import '../schemas/TVMazeShow.schema'
+
+particle SlandleTVMazeSearchShows in './js/TVMazeSearchShows.js'
+  in TVMazeQuery query
+  inout [TVMazeShow] shows

--- a/particles/TVMaze/particles/SLANDLESTVMazeShowActions.particle
+++ b/particles/TVMaze/particles/SLANDLESTVMazeShowActions.particle
@@ -14,5 +14,4 @@ particle SlandleActionMultiplexer in '../../List/source/Multiplexer.js'
   host SlandleHostedActionParticleInterface hostedParticle
   in [~a] list
   in [TVMazeShow] shows
-  // `consume [Slot] action
-  consume set of action
+  `consume [Slot] action

--- a/particles/TVMaze/particles/SLANDLESTVMazeShowActions.particle
+++ b/particles/TVMaze/particles/SLANDLESTVMazeShowActions.particle
@@ -1,0 +1,18 @@
+import '../schemas/TVMazeShow.schema'
+
+particle SlandleTVMazeShowActions in './js/TVMazeShowActions.js'
+  in TVMazeShow show
+  inout [TVMazeShow] shows
+  `consume Slot action
+
+interface SlandleHostedActionParticleInterface
+  in TVMazeShow show
+  inout [TVMazeShow] shows
+  `consume Slot action
+
+particle SlandleActionMultiplexer in '../../List/source/Multiplexer.js'
+  host SlandleHostedActionParticleInterface hostedParticle
+  in [~a] list
+  in [TVMazeShow] shows
+  // `consume [Slot] action
+  consume set of action

--- a/particles/TVMaze/particles/SLANDLESTVMazeShowPanel.particle
+++ b/particles/TVMaze/particles/SLANDLESTVMazeShowPanel.particle
@@ -1,0 +1,12 @@
+import '../../Common/Description.schema'
+import '../schemas/TVMazeShow.schema'
+import '../schemas/Text.schema'
+
+particle SlandleTVMazeShowPanel in './js/TVMazeShowPanel.js'
+  in TVMazeShow show
+  in? Text alsoWatch
+  out [Description] descriptions
+  `consume Slot content #tv_show_panel
+    `provide Slot action
+    `provide Slot items
+  description `${show} details`

--- a/particles/TVMaze/particles/SLANDLESTVMazeShowTile.particle
+++ b/particles/TVMaze/particles/SLANDLESTVMazeShowTile.particle
@@ -1,0 +1,6 @@
+import '../schemas/TVMazeShow.schema'
+
+particle SlandleTVMazeShowTile in './js/TVMazeShowTile.js'
+  in TVMazeShow show
+  `consume Slot tile
+    `provide [Slot] action

--- a/particles/WASM/SLANDLESWASM.recipes
+++ b/particles/WASM/SLANDLESWASM.recipes
@@ -7,7 +7,7 @@ particle SlandleWasmTest in 'source/WasmTest.js'
 
 recipe SlandleWasmTest
   create as thunk
-  slot 'rootslotid-root' as root
+  `slot 'rootslotid-root' as root
   SlandleWasmTest
     thunk = thunk
-    consume root as root
+    root consume root

--- a/particles/WASM/SLANDLESWASM.recipes
+++ b/particles/WASM/SLANDLESWASM.recipes
@@ -1,0 +1,13 @@
+schema Thunk
+  Text thunk
+
+particle SlandleWasmTest in 'source/WasmTest.js'
+  `consume Slot root
+  in Thunk thunk
+
+recipe SlandleWasmTest
+  create as thunk
+  slot 'rootslotid-root' as root
+  SlandleWasmTest
+    thunk = thunk
+    consume root as root

--- a/particles/Words/SLANDLESGamePane.manifest
+++ b/particles/Words/SLANDLESGamePane.manifest
@@ -1,0 +1,26 @@
+// @license
+// Copyright (c) 2017 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+import '../List/SLANDLESList.recipes'
+import '../People/Person.schema'
+//import '../Social/Post.schema'
+import 'Board.schema'
+import 'Move.schema'
+import 'Stats.schema'
+
+particle SlandleGamePane in 'source/GamePane.js'
+  //host HostedParticleInterface renderParticle
+  in Person person
+  inout Board board
+  inout Move move
+  inout Stats stats
+  //inout [Post] posts
+  //inout Post post
+  //in Theme shellTheme
+  `consume Slot root
+  description `play Words`

--- a/particles/Words/SLANDLESWords.recipes
+++ b/particles/Words/SLANDLESWords.recipes
@@ -1,0 +1,29 @@
+// Copyright (c) 2019 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+import 'SLANDLESGamePane.manifest'
+import 'Stats.schema'
+
+recipe SlandleWords
+  //use #user as person
+  create #board as board
+  create #move as move
+  create #stats as stats
+  //use #shelltheme as shellTheme
+  // TODO(wkorman): We only need one post but currently we need a set to produce
+  // the right boxing aggregation.
+  //create #posts as posts
+  //create as post
+  SlandleGamePane
+    move = move
+    board = board
+    stats = stats
+    //posts = posts
+    //post = post
+    //person = person
+    //renderParticle = ShowSingleStats
+    //shellTheme = shellTheme

--- a/src/planning/test/planner-tests.ts
+++ b/src/planning/test/planner-tests.ts
@@ -591,18 +591,18 @@ describe('Automatic resolution', () => {
     const plans = await loadAndPlan(manifestStr, arcCreatedCallback);
     for (const plan of plans) {
       plan.normalize();
-      assert.isTrue(plan.isResolved());
+      assert.isTrue(plan.isResolved(), `Plans were not able to be resolved from ${manifestStr}.`);
     }
     return plans;
   };
   const verifyResolvedPlan = async (manifestStr: string, arcCreatedCallback?) => {
     const plans = await verifyResolvedPlans(manifestStr, arcCreatedCallback);
-    assert.lengthOf(plans, 1);
+    assert.lengthOf(plans, 1, `Plan was not able to be resolved from ${manifestStr}.`);
     return plans[0];
   };
   const verifyUnresolvedPlan = async (manifestStr: string, arcCreatedCallback?) => {
     const plans = await loadAndPlan(manifestStr, arcCreatedCallback);
-    assert.isEmpty(plans);
+    assert.isEmpty(plans, `Plan was unexpectedly able to be resolved from ${manifestStr}`);
   };
 
   it('introduces create handles for particle communication', async () => {
@@ -877,7 +877,7 @@ describe('Automatic resolution', () => {
     `, () => {});
 
     recipes = recipes.filter(recipe => recipe.search);
-    assert.lengthOf(recipes, 1);
+    assert.lengthOf(recipes, 1, 'Expected the recipe list to contain a search.');
     return recipes[0];
   };
 

--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -475,11 +475,11 @@ ${e.message}
         }
       }));
 
-      const processItems = async (kind, f) => {
+      const processItems = async (kind: string, f: Function) => {
         for (const item of items) {
           if (item.kind === kind) {
             Manifest._augmentAstWithTypes(manifest, item);
-            await f(item);
+            await f(item);  // TODO(cypher1): Use Promise.all here.
           }
         }
       };

--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -1007,7 +1007,7 @@ ${e.message}
             items.byName.set(handle.localName, entry);
             items.byHandle.set(handle, handle['item']);
           } else if (!entry.item) {
-            throw new ManifestError(connectionItem.location, `did not expect ${entry} expected handle or particle`);
+            throw new ManifestError(connectionItem.location, `did not expect '${entry}' expected handle or particle`);
           }
 
           if (entry.item.kind === 'handle' || entry.item.kind === 'requireHandle') {

--- a/src/runtime/particle-spec.ts
+++ b/src/runtime/particle-spec.ts
@@ -289,7 +289,7 @@ export class ParticleSpec {
     const indent = '  ';
     const writeConnection = (connection, indent) => {
       const tags = connection.tags.map((tag) => ` #${tag}`).join('');
-      results.push(`${indent}${connection.direction}${connection.isOptional ? '?' : ''} ${connection.type.toString(options)} ${connection.name}${tags}`);
+      results.push(`${indent}${connection.direction}${connection.isOptional ? '?' : ''} ${connection.type.toString()} ${connection.name}${tags}`);
       for (const dependent of connection.dependentConnections) {
         writeConnection(dependent, indent + '  ');
       }

--- a/src/runtime/particle-spec.ts
+++ b/src/runtime/particle-spec.ts
@@ -320,7 +320,9 @@ export class ParticleSpec {
       if (s.formFactor) {
         results.push(`${indent}  formFactor ${s.formFactor}`);
       }
--     s.handles.forEach(handle => results.push(`${indent}  handle ${handle}`));
+      for (const handle of s.handles) {
+        results.push(`${indent}  handle ${handle}`);
+      }
       if (s.provideSlotConnections) {
         // Provided slots.
         s.provideSlotConnections.forEach(p => slotToString(p, 'provide', indent+'  '));

--- a/src/runtime/particle-spec.ts
+++ b/src/runtime/particle-spec.ts
@@ -321,14 +321,14 @@ export class ParticleSpec {
         results.push(`${indent}  formFactor ${s.formFactor}`);
       }
 -     s.handles.forEach(handle => results.push(`${indent}  handle ${handle}`));
-      if(s.provideSlotConnections) {
+      if (s.provideSlotConnections) {
         // Provided slots.
-        s.provideSlotConnections.forEach(p => slotToString(p, 'provide', indent+"  "));
+        s.provideSlotConnections.forEach(p => slotToString(p, 'provide', indent+'  '));
       }
     };
 
     this.slotConnections.forEach(
-      s => slotToString(s, 'consume', "  ")
+      s => slotToString(s, 'consume', '  ')
     );
     // Description
     if (this.pattern) {

--- a/src/runtime/test/artifacts/Events/SLANDLESCalendar.manifest
+++ b/src/runtime/test/artifacts/Events/SLANDLESCalendar.manifest
@@ -1,0 +1,17 @@
+// @license
+// Copyright (c) 2017 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+import 'Event.schema'
+import '../Common/Description.schema'
+
+particle SlandleCalendar in 'source/Calendar.js'
+  inout Event event
+  out [Description] descriptions
+  `consume Slot action
+  `consume Slot modifier
+  description `Select a time from your calendar`

--- a/src/runtime/test/artifacts/Events/SLANDLESEmbeddedCalendar.manifest
+++ b/src/runtime/test/artifacts/Events/SLANDLESEmbeddedCalendar.manifest
@@ -1,0 +1,15 @@
+// @license
+// Copyright (c) 2019 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+import 'Event.schema'
+
+particle SlandleEmbeddedCalendar in 'source/Calendar.js'
+  inout [Event] event
+  consume action
+  consume modifier
+  description `embedded calendar`

--- a/src/runtime/test/artifacts/Events/SLANDLESEvents.recipes
+++ b/src/runtime/test/artifacts/Events/SLANDLESEvents.recipes
@@ -1,0 +1,17 @@
+// Copyright (c) 2017 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+import 'SLANDLESCalendar.manifest'
+
+recipe
+  SlandleCalendar
+
+//import 'SLANDLESEmbeddedCalendar.manifest'
+//recipe
+//  create as event
+//  SlandleEmbeddedCalendar
+//    event = event

--- a/src/runtime/test/artifacts/Events/SLANDLESPartySize.manifest
+++ b/src/runtime/test/artifacts/Events/SLANDLESPartySize.manifest
@@ -1,0 +1,16 @@
+// @license
+// Copyright (c) 2017 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+import 'Event.schema'
+
+particle SlandlePartySize in 'source/PartySize.js'
+  inout Event event
+  modality dom
+  `consume Slot modifier
+// removing description for now to clean up suggestions
+//  description `number of people`

--- a/src/runtime/test/artifacts/Places/SLANDLESExtractLocation.manifest
+++ b/src/runtime/test/artifacts/Places/SLANDLESExtractLocation.manifest
@@ -1,0 +1,16 @@
+// @license
+// Copyright (c) 2018 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+import '../People/Person.schema'
+import '../Things/GeoCoordinates.schema'
+
+particle SlandleExtractLocation in 'source/ExtractLocation.js'
+  in Person person
+  out GeoCoordinates location
+  description `extract ${person}'s location`
+    location `${person}'s location`

--- a/src/runtime/test/artifacts/Restaurants/SLANDLESFavoriteFoodAnnotation.manifest
+++ b/src/runtime/test/artifacts/Restaurants/SLANDLESFavoriteFoodAnnotation.manifest
@@ -1,0 +1,16 @@
+// @license
+// Copyright (c) 2017 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+import 'Restaurant.schema'
+import '../Profile/FavoriteFood.schema'
+
+particle SlandleFavoriteFoodAnnotation in 'source/FavoriteFoodAnnotation.js'
+  in [Restaurant] restaurants
+  in FavoriteFood food
+  `consume [Slot] annotation
+  description `check restaurants for ${food}._name_ ${food.food}`

--- a/src/runtime/test/artifacts/Restaurants/SLANDLESFindRestaurants.manifest
+++ b/src/runtime/test/artifacts/Restaurants/SLANDLESFindRestaurants.manifest
@@ -1,0 +1,18 @@
+// @license
+// Copyright (c) 2017 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+import '../Things/GeoCoordinates.schema'
+import 'Restaurant.schema'
+
+particle SlandleFindRestaurants in 'source/FindRestaurants.js'
+  in GeoCoordinates location
+  inout [Restaurant] restaurants
+  modality dom
+  `consume Slot root
+    `provide Slot {handle: restaurants} masterdetail
+  description `find restaurants near ${location}`

--- a/src/runtime/test/artifacts/Restaurants/SLANDLESReservationAnnotation.manifest
+++ b/src/runtime/test/artifacts/Restaurants/SLANDLESReservationAnnotation.manifest
@@ -1,0 +1,16 @@
+// @license
+// Copyright (c) 2017 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+import 'Restaurant.schema'
+import '../Events/Event.schema'
+
+particle SlandleReservationAnnotation in 'source/ReservationAnnotation.js'
+  in [Restaurant] list
+  inout Event event
+  `consume [Slot] annotation
+  //description `reservation details`

--- a/src/runtime/test/artifacts/Restaurants/SLANDLESReservationForm.manifest
+++ b/src/runtime/test/artifacts/Restaurants/SLANDLESReservationForm.manifest
@@ -1,0 +1,19 @@
+// @license
+// Copyright (c) 2017 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+import 'Restaurant.schema'
+import '../Events/Event.schema'
+import '../Common/Description.schema'
+
+particle SlandleReservationForm in 'source/ReservationForm.js'
+  in Restaurant selected
+  inout Event event
+  out [Description] descriptions
+  `consume Slot action
+  description `make a reservation`
+    event `reservation`

--- a/src/runtime/test/artifacts/Restaurants/SLANDLESRestaurantDetail.manifest
+++ b/src/runtime/test/artifacts/Restaurants/SLANDLESRestaurantDetail.manifest
@@ -1,0 +1,17 @@
+// @license
+// Copyright (c) 2017 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+import 'Restaurant.schema'
+
+particle SlandleRestaurantDetail in 'source/RestaurantDetail.js'
+  in Restaurant selected
+  modality dom
+  `consume Slot detail
+    `provide Slot action
+// removing description for now to clean up suggestions
+//  description `show restaurant details`

--- a/src/runtime/test/artifacts/Restaurants/SLANDLESRestaurantList.manifest
+++ b/src/runtime/test/artifacts/Restaurants/SLANDLESRestaurantList.manifest
@@ -1,0 +1,18 @@
+// @license
+// Copyright (c) 2017 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+import 'Restaurant.schema'
+
+particle SlandleRestaurantList in 'source/RestaurantList.js'
+  in [Restaurant] list
+  inout Restaurant selected
+  `consume Slot master
+    `provide Slot modifier
+    `provide [Slot {handle: list}] annotation
+// removing description for now to clean up suggestions
+//  description `show ${list}`

--- a/src/runtime/test/artifacts/Restaurants/SLANDLESRestaurantMasterDetail.manifest
+++ b/src/runtime/test/artifacts/Restaurants/SLANDLESRestaurantMasterDetail.manifest
@@ -1,0 +1,16 @@
+// @license
+// Copyright (c) 2017 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+import 'Restaurant.schema'
+
+particle SlandleRestaurantMasterDetail in '../Common/source/MasterDetail.js'
+  in [Restaurant] list
+  inout Restaurant selected
+  `consume Slot masterdetail
+    `provide Slot {handle: list} master
+    `provide Slot {handle: selected} detail

--- a/src/runtime/test/artifacts/Restaurants/SLANDLESRestaurants.recipes
+++ b/src/runtime/test/artifacts/Restaurants/SLANDLESRestaurants.recipes
@@ -1,0 +1,57 @@
+// Copyright (c) 2017 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+import 'SLANDLESFindRestaurants.manifest'
+import 'SLANDLESRestaurantMasterDetail.manifest'
+import 'SLANDLESRestaurantList.manifest'
+import 'SLANDLESRestaurantDetail.manifest'
+import '../Places/SLANDLESExtractLocation.manifest'
+
+recipe &displayRestaurants
+  ? as list
+  SlandleRestaurantMasterDetail.selected -> SlandleRestaurantList.selected
+  SlandleRestaurantDetail.selected -> SlandleRestaurantList.selected
+  SlandleRestaurantMasterDetail.list -> SlandleRestaurantList.list
+  SlandleRestaurantList
+    list <- list
+
+recipe
+  create as location
+  SlandleExtractLocation
+    location -> location
+
+recipe &nearbyRestaurants
+  create #restaurants #volatile as restaurants
+  SlandleFindRestaurants
+    restaurants = restaurants
+
+import '../Events/Event.schema'
+import '../Events/SLANDLESPartySize.manifest'
+import 'SLANDLESReservationForm.manifest'
+import 'SLANDLESReservationAnnotation.manifest'
+
+recipe &makeReservation
+  create #event as event
+  use #restaurants as list
+  SlandleReservationForm
+    event = event
+  SlandleReservationAnnotation
+    event = event
+    list = list
+  SlandlePartySize
+    event = event
+
+import '../Events/SLANDLESEvents.recipes'
+
+import 'SLANDLESFavoriteFoodAnnotation.manifest'
+
+recipe
+  map #favorite as food
+  use as restaurants
+  SlandleFavoriteFoodAnnotation
+    restaurants <- restaurants
+    food <- food

--- a/src/runtime/test/manifest-test.ts
+++ b/src/runtime/test/manifest-test.ts
@@ -1822,6 +1822,48 @@ resource SomeName
     const manifestString = `particle TestParticle in 'a.js'
   in [Product {}] input
     out [Product {}] output
+  modality dom
+  consume thing #main #tagname
+    provide otherThing #testtag`;
+
+    const manifest = await Manifest.parse(manifestString);
+    assert.lengthOf(manifest.particles, 1);
+    assert.equal(manifestString, manifest.particles[0].toString());
+  });
+
+  it('can round-trip particles with fields', async () => {
+    const manifestString = `particle TestParticle in 'a.js'
+  in [Product {}] input
+    out [Product {}] output
+  in ~a thingy
+  modality dom
+  must consume thing #main #tagname
+    formFactor big
+    must provide otherThing #testtag
+      handle thingy`;
+
+    const manifest = await Manifest.parse(manifestString);
+    assert.lengthOf(manifest.particles, 1);
+    assert.equal(manifestString, manifest.particles[0].toString());
+  });
+
+  it('SLANDLES can round-trip particles with tags', async () => {
+    const manifestString = `particle TestParticle in 'a.js'
+  in [Product {}] input
+    out [Product {}] output
+  \`consume Slot {formFactor:big} thing #main #tagname
+    \`provide Slot {handle:thingy} otherThing #testtag
+  modality dom`;
+
+    const manifest = await Manifest.parse(manifestString);
+    assert.lengthOf(manifest.particles, 1);
+    assert.equal(manifestString, manifest.particles[0].toString());
+  });
+  it('SLANDLES can round-trip particles with fields', async () => {
+    const manifestString = `particle TestParticle in 'a.js'
+  in [Product {}] input
+    out [Product {}] output
+  in ~a thingy
   \`consume Slot {formFactor:big} thing #main #tagname
     \`provide Slot {handle:thingy} otherThing #testtag
   modality dom`;
@@ -1831,7 +1873,19 @@ resource SomeName
     assert.equal(manifestString, manifest.particles[0].toString());
   });
 
-  it('can round-trip particles with fields', async () => {
+  it('SLANDLES can round-trip particles with tags', async () => {
+    const manifestString = `particle TestParticle in 'a.js'
+  in [Product {}] input
+    out [Product {}] output
+  \`consume Slot thing #main #tagname
+    \`provide Slot otherThing #testtag
+  modality dom`;
+
+    const manifest = await Manifest.parse(manifestString);
+    assert.lengthOf(manifest.particles, 1);
+    assert.equal(manifestString, manifest.particles[0].toString());
+  });
+  it('SLANDLES can round-trip particles with fields', async () => {
     const manifestString = `particle TestParticle in 'a.js'
   in [Product {}] input
     out [Product {}] output

--- a/src/runtime/test/manifest-test.ts
+++ b/src/runtime/test/manifest-test.ts
@@ -137,8 +137,8 @@ schema Person
     \`provide Slot {formFactor:medium} preamble
     \`provide Slot annotation
   \`consume Slot other
-    \`provide [~cell] myProvidedSetCell
-  \`consume [~cell] mySetCell
+    \`provide [Slot] myProvidedSetCell
+  \`consume [Slot] mySetCell
   modality dom
   modality dom-touch
   description \`hello world \${list}\`
@@ -220,8 +220,8 @@ ${particleStr1}
     const manifestString = `particle TestParticle in 'a.js'
   in [Product {}] input
     out [Product {}] output
-  \`consume Slot thing
-    \`provide Slot otherThing
+  \`consume? Slot thing
+    \`provide? Slot otherThing
   modality dom`;
 
     const manifest = await Manifest.parse(manifestString);
@@ -675,7 +675,8 @@ ${particleStr1}
             slotA consume s0
       `)).recipes[0];
       recipe.normalize();
-      assert.equal(args.expectedIsResolved, recipe.isResolved());
+      assert.equal(args.expectedIsResolved, recipe.isResolved(),
+                   `Expected recipe to be ${args.expectedIsResolved ? '' : 'un'}resolved`);
     };
     await parseRecipe({isRequiredSlotA: false, isRequiredSlotB: false, expectedIsResolved: true});
     await parseRecipe({isRequiredSlotA: true, isRequiredSlotB: false, expectedIsResolved: true});


### PR DESCRIPTION
This is primarily adding Slandles versions of our demo and test recipes, there should now not be a single 'classic' slot, recipe slot or recipe slot connection left in the files with the SLANDLES prefix.

I also fixed a slandles test that I wrote without making a non-slandle version and reduced some duplication in the toString code in particle spec.