### PR TITLE
Only allow collections to hold references in manifest grammar

### DIFF
--- a/src/runtime/manifest-parser.peg
+++ b/src/runtime/manifest-parser.peg
@@ -996,7 +996,7 @@ SchemaField
 SchemaType
   = SchemaReferenceType / SchemaCollectionType / SchemaPrimitiveType / SchemaUnionType / SchemaTupleType
 
-SchemaCollectionType = '[' whiteSpace* schema:SchemaType whiteSpace* ']'
+SchemaCollectionType = '[' whiteSpace* schema:SchemaReferenceType whiteSpace* ']'
   {
     return {
       kind: 'schema-collection',

--- a/src/runtime/test/wasm-tests.ts
+++ b/src/runtime/test/wasm-tests.ts
@@ -11,6 +11,8 @@
 import {assert} from '../../platform/chai-web.js';
 import {EntityProtoConverter, EntityPackager} from '../wasm.js';
 import {Manifest} from '../manifest.js';
+import {EntityType, ReferenceType} from '../type.js';
+import {Reference} from '../reference.js';
 import {toProtoFile} from '../../tools/wasm-tools.js';
 
 describe('wasm', () => {
@@ -22,12 +24,8 @@ describe('wasm', () => {
         Text      txt
         URL       lnk
         Number    num
-        Boolean   flg
-        [Text]    c_txt
-        [URL]     c_lnk
-        [Number]  c_num
-        [Boolean] c_flg`);
-    schema = manifest.findSchemaByName('Foo');
+        Boolean   flg`);
+    schema = manifest.schemas.Foo
   });
 
   it('entity to proto conversion supports basic types', async () => {
@@ -36,11 +34,7 @@ describe('wasm', () => {
       txt: 'abc',
       lnk: 'http://def',
       num: 37,
-      flg: true,
-      c_txt: ['gh', 'i:jk|'],
-      c_lnk: ['http://lmn', 'https://opq/rst?u=vw&x=y'],
-      c_num: [-51, 73.8, 26, -0.82],
-      c_flg: [false, true]
+      flg: true
     });
 
     const epc = new EntityProtoConverter(schema);
@@ -51,7 +45,7 @@ describe('wasm', () => {
 
   it('entity to proto conversion supports partially assigned values', async () => {
     const entityClass = schema.entityClass();
-    const foo = new entityClass({txt: 'abc', c_num: [51, 73]});
+    const foo = new entityClass({txt: 'abc', num: -5.1});
 
     const epc = new EntityProtoConverter(schema);
     const buffer = epc.encode(foo);
@@ -65,11 +59,7 @@ describe('wasm', () => {
       txt: '',
       lnk: '',
       num: 0,
-      flg: false,
-      c_txt: new Set(),
-      c_lnk: new Set(),
-      c_num: new Set(),
-      c_flg: new Set()
+      flg: false
     });
 
     const epc = new EntityProtoConverter(schema);
@@ -92,16 +82,6 @@ describe('wasm', () => {
         (Text or URL or Number) foo
       schema TupleFail
         (Text, URL, Number) foo
-      schema BytesCollectionFail
-        [Bytes] foo
-      schema ObjectCollectionFail
-        [Object] foo
-      schema UnionCollectionFail
-        [(Text or Bytes)] foo
-      schema TupleCollectionFail
-        [(Number, Object)] foo
-      schema NestedCollectionFail
-        [[Text]] foo
       schema NamedRefFail
         Reference<BytesFail> foo
       schema InlineRefFail
@@ -118,11 +98,7 @@ describe('wasm', () => {
       txt: 'abc',
       lnk: 'http://def',
       num: 37,
-      flg: true,
-      c_txt: ['gh', 'i:jk|'],
-      c_lnk: ['http://lmn', 'https://opq/rst?u=vw&x=y'],
-      c_num: [-51, 73.8, 26, -0.82],
-      c_flg: [false, true]
+      flg: true
     });
 
     const packager = new EntityPackager(schema);
@@ -132,7 +108,7 @@ describe('wasm', () => {
 
   it('entity packaging supports partially assigned values', async () => {
     const entityClass = schema.entityClass();
-    const foo = new entityClass({txt: 'abc', c_num: [5.1, 73]});
+    const foo = new entityClass({txt: 'abc', num: -5.1});
 
     const packager = new EntityPackager(schema);
     const encoded = packager.encode(foo);
@@ -145,11 +121,7 @@ describe('wasm', () => {
       txt: '',
       lnk: '',
       num: 0,
-      flg: false,
-      c_txt: new Set(),
-      c_lnk: new Set(),
-      c_num: new Set(),
-      c_flg: new Set()
+      flg: false
     });
 
     const packager = new EntityPackager(schema);
@@ -167,36 +139,24 @@ describe('wasm', () => {
         (Text or URL or Number) foo
       schema TupleFail
         (Text, Number) foo
-      schema BytesCollectionFail
-        [Bytes] foo
-      schema ObjectCollectionFail
-        [Object] foo
-      schema UnionCollectionFail
-        [(Text or Bytes)] foo
-      schema TupleCollectionFail
-        [(Number, Object)] foo
-      schema NestedCollectionFail
-        [[Text]] foo
-      // TODO
-      //schema NamedRefFail
-      //  Reference<BytesFail> foo
-      //schema InlineRefFail
-      //  Reference<Bar {Text val}> foo`);
+      schema NamedRefFail
+        Reference<BytesFail> foo
+      schema InlineRefFail
+        Reference<Bar {Text val}> foo`);
 
     const verify = (schema, value) => {
       const entity = new (schema.entityClass())({foo: value});
       assert.throws(() => new EntityPackager(schema).encode(entity), 'not yet supported');
     };
 
+    const makeRef = entityType => new Reference({id: 'i', storageKey: 'k'}, new ReferenceType(entityType), null);
+
     verify(manifest.schemas.BytesFail, new Uint8Array([2]));
     verify(manifest.schemas.ObjectFail, {x: 1});
     verify(manifest.schemas.UnionFail, 12);
     verify(manifest.schemas.TupleFail, ['abc', 78]);
-    verify(manifest.schemas.BytesCollectionFail, new Set().add(new Uint8Array([6])));
-    verify(manifest.schemas.ObjectCollectionFail, [{y: 2}]);
-    verify(manifest.schemas.UnionCollectionFail, ['def']);
-    verify(manifest.schemas.TupleCollectionFail, [[44, {z: 3}]]);
-    verify(manifest.schemas.NestedCollectionFail, [['ghi']]);
+    verify(manifest.schemas.NamedRefFail, makeRef(new EntityType(manifest.schemas.BytesFail)));
+    verify(manifest.schemas.InlineRefFail, makeRef(EntityType.make(['Bar'], {val: 'Text'})));
   });
 
   it('schema to .proto file conversion supports basic types', async () => {
@@ -208,14 +168,10 @@ package arcs;
 
 message Foo {
 
-    repeated bool c_flg = 1;
-    repeated Url c_lnk = 2;
-    repeated double c_num = 3;
-    repeated string c_txt = 4;
-    optional bool flg = 5;
-    optional Url lnk = 6;
-    optional double num = 7;
-    optional string txt = 8;
+    optional bool flg = 1;
+    optional Url lnk = 2;
+    optional double num = 3;
+    optional string txt = 4;
 }
 
 message Url {

--- a/src/runtime/test/wasm-tests.ts
+++ b/src/runtime/test/wasm-tests.ts
@@ -25,7 +25,7 @@ describe('wasm', () => {
         URL       lnk
         Number    num
         Boolean   flg`);
-    schema = manifest.schemas.Foo
+    schema = manifest.schemas.Foo;
   });
 
   it('entity to proto conversion supports basic types', async () => {

--- a/src/wasm/wasm.manifest
+++ b/src/wasm/wasm.manifest
@@ -3,17 +3,11 @@ schema Data
   Text txt
   URL lnk
   Boolean flg
-  [Number] c_num
-  [Text] c_txt
-  [URL] c_lnk
-  [Boolean] c_flg
 
 resource DataResource
   start
   [
-    {"num": 73, "txt": "abc", "lnk": "http://xyz", "flg": true,
-     "c_txt": ["a", "b"], "c_num": [12.5, 0, 27], "c_flg": [true, false],
-     "c_lnk": ["http://abc"] }
+    {"num": 73, "txt": "abc", "lnk": "http://xyz", "flg": true}
   ]
 
 store DataStore of Data in DataResource

--- a/src/wasm/working.cc
+++ b/src/wasm/working.cc
@@ -28,35 +28,10 @@ public:
   void sync(const char* encoded) {
     console("sync %s [%s]\n", name_, encoded);
     data_ = arcs::Data::decode(encoded);
-
     console("txt: %s\n", data_.txt.c_str());
     console("lnk: %s\n", data_.lnk.href.c_str());
     console("num: %.2f\n", data_.num);
     console("flg: %d\n", data_.flg);
-
-    console("c_txt:");
-    for (const auto& v : data_.c_txt) {
-      console(" [%s]", v.c_str());
-    }
-    console("\n");
-
-    console("c_lnk:");
-    for (const auto& v : data_.c_lnk) {
-      console(" [%s]", v.href.c_str());
-    }
-    console("\n");
-
-    console("c_num:");
-    for (const auto& v : data_.c_num) {
-      console(" %.2f", v);
-    }
-    console("\n");
-
-    console("c_flg:");
-    for (const auto& v : data_.c_flg) {
-      console(" %s", v ? "true" : "false");
-    }
-    console("\n");
   }
 
   const char* name_;


### PR DESCRIPTION
This was always the intent, but collections of any schema type would parse, and the wasm schema handling was built accordingly.

I'll leave the logic for handling collections of other types in place for the wasm serialization code, but it won't be used for the time being.