### PR TITLE
Volatile driver

### DIFF
--- a/config/eslintrc.json
+++ b/config/eslintrc.json
@@ -39,7 +39,8 @@
     "comma-dangle": "off",
     "linebreak-style": "off",
     "no-multi-spaces": "off",
-    "keyword-spacing": [1, {"before": true, "after": true}]
+    "keyword-spacing": [1, {"before": true, "after": true}],
+    "no-constant-condition": "off"
   },
   "env": {
     "browser": true,

--- a/config/tsconfig.base.json
+++ b/config/tsconfig.base.json
@@ -6,7 +6,6 @@
     "alwaysStrict": true,
     "declaration": true,
     "esModuleInterop": true,
-    "noFallthroughCasesInSwitch": true,
     "noImplicitReturns": true,
     "noImplicitThis": true,
     "module": "es2015",

--- a/config/tslint.base.json
+++ b/config/tslint.base.json
@@ -35,6 +35,7 @@
     "no-namespace": [true, "allow-declarations"],
     "no-reference": true,
     "no-string-throw": true,
+    "no-switch-case-fallthrough": true,
     "no-unsafe-finally": true,
     "no-unused-expression": true,
     "no-var-keyword": true,

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -20,6 +20,7 @@ import {StorageProviderFactory} from './storage/storage-provider-factory.js';
 import {ArcInspectorFactory} from './arc-inspector.js';
 import {assert} from '../platform/assert-web.js';
 import {FakeSlotComposer} from './testing/fake-slot-composer.js';
+import {VolatileMemory} from './storageNG/drivers/volatile.js';
 
 export type RuntimeArcOptions = Readonly<{
   pecFactory?: PecFactory;
@@ -38,6 +39,7 @@ export class Runtime {
   private loader: Loader | null;
   private composerClass: new () => SlotComposer | null;
   private context: Manifest;
+  private readonly volatileMemory: VolatileMemory;
 
   static getRuntime() {
     if (runtime == null) {
@@ -62,11 +64,16 @@ export class Runtime {
     this.loader = loader;
     this.composerClass = composerClass;
     this.context = context || new Manifest({id: 'manifest:default'});
+    this.volatileMemory = new VolatileMemory();
     // user information. One persona per runtime for now.
   }
 
   getCacheService() {
     return this.cacheService;
+  }
+
+  getVolatileMemory(): VolatileMemory {
+    return this.volatileMemory;
   }
 
   destroy() {

--- a/src/runtime/storageNG/drivers/driver-factory.ts
+++ b/src/runtime/storageNG/drivers/driver-factory.ts
@@ -1,3 +1,5 @@
+import {StorageKey} from "../storage-key";
+
 /**
  * @license
  * Copyright (c) 2019 Google Inc. All rights reserved.
@@ -15,14 +17,14 @@ export type ReceiveMethod<T> = (model: T) => void;
 export interface StorageDriverProvider {
   // information on the StorageDriver and characteristics
   // of the Storage
-  willSupport(storageKey: string): boolean;
-  driver<Data>(storageKey: string, exists: Exists): Driver<Data>;
+  willSupport(storageKey: StorageKey): boolean;
+  driver<Data>(storageKey: StorageKey, exists: Exists): Driver<Data>;
 }
 
 export abstract class Driver<Data> {
-  storageKey: string;
+  storageKey: StorageKey;
   exists: Exists;
-  constructor(storageKey: string, exists: Exists) {
+  constructor(storageKey: StorageKey, exists: Exists) {
     this.storageKey = storageKey;
     this.exists = exists;
   }
@@ -32,9 +34,9 @@ export abstract class Driver<Data> {
   // these methods only available to Backing Stores and will
   // be removed once entity mutation is performed on CRDTs
   // tslint:disable-next-line: no-any
-  abstract async write(key: string, value: any): Promise<void>;
+  abstract async write(key: StorageKey, value: any): Promise<void>;
   // tslint:disable-next-line: no-any  
-  abstract async read(key: string): Promise<any>;
+  abstract async read(key: StorageKey): Promise<any>;
 }
 
 export class DriverFactory {
@@ -42,7 +44,7 @@ export class DriverFactory {
     this.providers = [];
   }
   static providers: StorageDriverProvider[] = [];
-  static driverInstance<Data>(storageKey: string, exists: Exists): Driver<Data> {
+  static driverInstance<Data>(storageKey: StorageKey, exists: Exists): Driver<Data> {
     for (const provider of this.providers) {
       if (provider.willSupport(storageKey)) {
         return provider.driver<Data>(storageKey, exists);
@@ -55,7 +57,7 @@ export class DriverFactory {
     this.providers.push(storageDriverProvider);
   }
 
-  static willSupport(storageKey: string): boolean {
+  static willSupport(storageKey: StorageKey): boolean {
     for (const provider of this.providers) {
       if (provider.willSupport(storageKey)) {
         return true;

--- a/src/runtime/storageNG/drivers/driver-factory.ts
+++ b/src/runtime/storageNG/drivers/driver-factory.ts
@@ -1,5 +1,3 @@
-import {StorageKey} from "../storage-key";
-
 /**
  * @license
  * Copyright (c) 2019 Google Inc. All rights reserved.
@@ -9,6 +7,8 @@ import {StorageKey} from "../storage-key";
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
+
+import {StorageKey} from '../storage-key.js';
 
 export enum Exists {ShouldExist, ShouldCreate, MayExist}
 

--- a/src/runtime/storageNG/drivers/driver-factory.ts
+++ b/src/runtime/storageNG/drivers/driver-factory.ts
@@ -12,7 +12,7 @@ import {StorageKey} from '../storage-key.js';
 
 export enum Exists {ShouldExist, ShouldCreate, MayExist}
 
-export type ReceiveMethod<T> = (model: T) => void;
+export type ReceiveMethod<T> = (model: T, version: number) => void;
 
 export interface StorageDriverProvider {
   // information on the StorageDriver and characteristics
@@ -29,7 +29,7 @@ export abstract class Driver<Data> {
     this.exists = exists;
   }
   abstract registerReceiver(receiver: ReceiveMethod<Data>): void;
-  abstract async send(model: Data): Promise<boolean>;
+  abstract async send(model: Data, version: number): Promise<boolean>;
 
   // these methods only available to Backing Stores and will
   // be removed once entity mutation is performed on CRDTs

--- a/src/runtime/storageNG/drivers/tests/volatile-test.ts
+++ b/src/runtime/storageNG/drivers/tests/volatile-test.ts
@@ -1,0 +1,44 @@
+/**
+ * @license
+ * Copyright (c) 2019 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {assert} from '../../../../platform/chai-web.js';
+import {VolatileDriver, VolatileStorageKey} from '../volatile.js';
+import {Exists} from '../driver-factory.js';
+import {Runtime} from '../../../runtime.js';
+
+describe('Volatile Driver', async () => {
+
+  afterEach(() => {
+    Runtime.clearRuntimeForTesting();
+  })
+
+  it('can be multiply instantiated against the same storage location', () => {
+    const volatileKey = new VolatileStorageKey('unique');
+    const volatile1 = new VolatileDriver(volatileKey, Exists.ShouldCreate);
+    const volatile2 = new VolatileDriver(volatileKey, Exists.ShouldExist);
+  });
+
+  it(`can't be instantiated as ShouldExist if the storage location doesn't yet exist`, () => {
+    const volatileKey = new VolatileStorageKey('unique');
+    assert.throws(() => new VolatileDriver(volatileKey, Exists.ShouldExist), `location doesn't exist`);
+  });
+
+  it(`can't be instantiated as ShouldCreate if the storage location already exists`, () => {
+    const volatileKey = new VolatileStorageKey('unique');
+    const volatile1 = new VolatileDriver(volatileKey, Exists.ShouldCreate);
+    assert.throws(() => new VolatileDriver(volatileKey, Exists.ShouldCreate), 'location already exists');
+  });
+
+  it('can be instantiated either as a creation or as a connection using MayExist', () => {
+    const volatileKey = new VolatileStorageKey('unique');
+    const volatile1 = new VolatileDriver(volatileKey, Exists.MayExist);
+    const volatile2 = new VolatileDriver(volatileKey, Exists.MayExist);
+  });
+});

--- a/src/runtime/storageNG/drivers/tests/volatile-test.ts
+++ b/src/runtime/storageNG/drivers/tests/volatile-test.ts
@@ -17,7 +17,7 @@ describe('Volatile Driver', async () => {
 
   afterEach(() => {
     Runtime.clearRuntimeForTesting();
-  })
+  });
 
   it('can be multiply instantiated against the same storage location', () => {
     const volatileKey = new VolatileStorageKey('unique');

--- a/src/runtime/storageNG/drivers/volatile.ts
+++ b/src/runtime/storageNG/drivers/volatile.ts
@@ -1,0 +1,56 @@
+import {Driver, ReceiveMethod, StorageDriverProvider, Exists, DriverFactory} from "./driver-factory";
+import {StorageKey} from "../storage-key";
+
+/**
+ * @license
+ * Copyright (c) 2019 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+class VolatileMemory {
+  
+}
+
+export class VolatileDriver<Data> extends Driver<Data> {
+
+  constructor(storageKey: StorageKey, exists: Exists) {
+    super(storageKey, exists);
+  }
+
+  registerReceiver(receiver: ReceiveMethod<Data>) {
+    throw new Error("Method not implemented.");
+  }
+  
+  async send(model: Data): Promise<boolean> {
+    throw new Error("Method not implemented.");
+  }
+  
+  async write(key: StorageKey, value: Data): Promise<void> {
+    throw new Error("Method not implemented.");
+  }
+  
+  async read(key: StorageKey): Promise<Data> {
+    throw new Error("Method not implemented.");
+  }
+}
+
+class VolatileStorageDriverProvider implements StorageDriverProvider {
+  
+  willSupport(storageKey: StorageKey): boolean {
+    return storageKey.protocol === 'volatile';
+  }
+  
+  driver<Data>(storageKey: StorageKey, exists: Exists): Driver<Data> {
+    if (!this.willSupport(storageKey)) {
+      throw new Error(`This provider does not support storageKey ${storageKey.toString()}`);
+    }
+
+    return new VolatileDriver<Data>(storageKey, exists);
+  }
+}
+
+DriverFactory.register(new VolatileStorageDriverProvider());

--- a/src/runtime/storageNG/storage-key.ts
+++ b/src/runtime/storageNG/storage-key.ts
@@ -1,5 +1,5 @@
 // @
-// Copyright (c) 2017 Google Inc. All rights reserved.
+// Copyright (c) 2019 Google Inc. All rights reserved.
 // This code may only be used under the BSD style license found at
 // http://polymer.github.io/LICENSE.txt
 // Code distributed by Google as part of this project is also

--- a/src/runtime/storageNG/storage-key.ts
+++ b/src/runtime/storageNG/storage-key.ts
@@ -8,4 +8,8 @@
 
 export abstract class StorageKey {
   readonly protocol: string;
+
+  constructor(protocol: string) {
+    this.protocol = protocol;
+  }
 }

--- a/src/runtime/storageNG/storage-key.ts
+++ b/src/runtime/storageNG/storage-key.ts
@@ -1,0 +1,11 @@
+// @
+// Copyright (c) 2017 Google Inc. All rights reserved.
+// This code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt
+// Code distributed by Google as part of this project is also
+// subject to an additional IP rights grant found at
+// http://polymer.github.io/PATENTS.txt
+
+export abstract class StorageKey {
+  readonly protocol: string;
+}

--- a/src/runtime/storageNG/store.ts
+++ b/src/runtime/storageNG/store.ts
@@ -70,6 +70,7 @@ export class DirectStore<T extends CRDTTypeRecord> extends ActiveStore<T> {
   driver: Driver<T['data']>;
   inSync = true;
   private nextCallbackID = 1;
+  private version = 0;
 
   constructor(storageKey: StorageKey, exists: Exists, type: Type, mode: StorageMode, modelConstructor: new () => CRDTModel<T>) {
     super(storageKey, exists, type, mode, modelConstructor);
@@ -81,23 +82,25 @@ export class DirectStore<T extends CRDTTypeRecord> extends ActiveStore<T> {
     this.driver.registerReceiver(this.onReceive.bind(this));
   }
   // The driver will invoke this method when it has an updated remote model
-  async onReceive(model: T['data']): Promise<void> {
+  async onReceive(model: T['data'], version: number): Promise<void> {
     const {modelChange, otherChange} = this.localModel.merge(model);
-    await this.processModelChange(modelChange, otherChange, true);
+    await this.processModelChange(modelChange, otherChange, version, true);
   }
   
-  private async processModelChange(thisChange: CRDTChange<T>, otherChange: CRDTChange<T>, messageFromDriver) {
+  private async processModelChange(thisChange: CRDTChange<T>, otherChange: CRDTChange<T>, version, messageFromDriver) {
     if (thisChange.changeType === ChangeType.Operations && thisChange.operations.length > 0) {
       this.callbacks.forEach((cb, id) => cb({type: ProxyMessageType.Operations, operations: thisChange.operations, id}));
     } else if (thisChange.changeType === ChangeType.Model) {
       this.callbacks.forEach((cb, id) => cb({type: ProxyMessageType.ModelUpdate, model: thisChange.modelPostChange, id}));
     }
-    
+       
     // Don't send to the driver if we're already in sync and there are no driver-side changes.
-    if (this.inSync && this.driverSideChanges(thisChange, otherChange, messageFromDriver)) {
+    if (this.inSync && this.noDriverSideChanges(thisChange, otherChange, messageFromDriver)) {
       return;
     }
-    this.inSync = await this.driver.send(this.localModel.getData());
+
+    this.version = version + 1;
+    this.inSync = await this.driver.send(this.localModel.getData(), this.version);
   }
 
   // Note that driver-side changes are stored in 'otherChange' when the merged operations/model is sent
@@ -105,7 +108,7 @@ export class DirectStore<T extends CRDTTypeRecord> extends ActiveStore<T> {
   // In the former case, we want to look at what has changed between what the driver sent us and what
   // we now have. In the latter, the driver is only as up-to-date as our local model before we've
   // applied the operations.
-  private driverSideChanges(thisChange: CRDTChange<T>, otherChange: CRDTChange<T>, messageFromDriver: boolean) {
+  private noDriverSideChanges(thisChange: CRDTChange<T>, otherChange: CRDTChange<T>, messageFromDriver: boolean) {
     if (messageFromDriver) {
       return otherChange.changeType === ChangeType.Operations && otherChange.operations.length === 0;
     } else {
@@ -129,11 +132,11 @@ export class DirectStore<T extends CRDTTypeRecord> extends ActiveStore<T> {
             return false;
           }
         }
-        await this.processModelChange({changeType: ChangeType.Operations, operations: message.operations}, null, false);
+        await this.processModelChange({changeType: ChangeType.Operations, operations: message.operations}, null, this.version, false);
         return true;
       case ProxyMessageType.ModelUpdate: {
         const {modelChange, otherChange} = this.localModel.merge(message.model);
-        await this.processModelChange(modelChange, otherChange, false);
+        await this.processModelChange(modelChange, otherChange, this.version, false);
         return true;
       }
       default:

--- a/src/runtime/storageNG/store.ts
+++ b/src/runtime/storageNG/store.ts
@@ -8,9 +8,10 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {CRDTModel, CRDTTypeRecord, CRDTChange, ChangeType, CRDTError} from '../crdt/crdt.js';
-import {Type} from '../type.js';
-import {Exists, Driver, DriverFactory} from './drivers/driver-factory.js';
+import {CRDTModel, CRDTTypeRecord, CRDTChange, ChangeType, CRDTError} from "../crdt/crdt.js";
+import {Type} from "../type.js";
+import {Exists, Driver, DriverFactory} from "./drivers/driver-factory.js";
+import {StorageKey} from "./storage-key.js";
 
 export enum StorageMode {Direct, Backing, ReferenceMode}
 
@@ -28,7 +29,7 @@ type ProxyCallback<T extends CRDTTypeRecord> = (message: ProxyMessage<T>) => boo
 //
 // Calling 'activate() will generate an interactive store and return it. 
 export class Store<T extends CRDTTypeRecord> {
-  readonly storageKey: string;
+  readonly storageKey: StorageKey;
   exists: Exists;
   readonly type: Type;
   readonly mode: StorageMode;
@@ -38,7 +39,7 @@ export class Store<T extends CRDTTypeRecord> {
                                    [StorageMode.ReferenceMode, null]]);
   modelConstructor: new () => CRDTModel<T>;
 
-  constructor(storageKey: string, exists: Exists, type: Type, mode: StorageMode, modelConstructor: new () => CRDTModel<T>) {
+  constructor(storageKey: StorageKey, exists: Exists, type: Type, mode: StorageMode, modelConstructor: new () => CRDTModel<T>) {
     this.storageKey = storageKey;
     this.exists = exists;
     this.type = type;
@@ -70,7 +71,7 @@ export class DirectStore<T extends CRDTTypeRecord> extends ActiveStore<T> {
   inSync = true;
   private nextCallbackID = 1;
 
-  constructor(storageKey: string, exists: Exists, type: Type, mode: StorageMode, modelConstructor: new () => CRDTModel<T>) {
+  constructor(storageKey: StorageKey, exists: Exists, type: Type, mode: StorageMode, modelConstructor: new () => CRDTModel<T>) {
     super(storageKey, exists, type, mode, modelConstructor);
     this.localModel = new modelConstructor();
     this.driver = DriverFactory.driverInstance(storageKey, exists);

--- a/src/runtime/storageNG/store.ts
+++ b/src/runtime/storageNG/store.ts
@@ -8,10 +8,10 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {CRDTModel, CRDTTypeRecord, CRDTChange, ChangeType, CRDTError} from "../crdt/crdt.js";
-import {Type} from "../type.js";
-import {Exists, Driver, DriverFactory} from "./drivers/driver-factory.js";
-import {StorageKey} from "./storage-key.js";
+import {CRDTModel, CRDTTypeRecord, CRDTChange, ChangeType, CRDTError} from '../crdt/crdt.js';
+import {Type} from '../type.js';
+import {Exists, Driver, DriverFactory} from './drivers/driver-factory.js';
+import {StorageKey} from './storage-key.js';
 
 export enum StorageMode {Direct, Backing, ReferenceMode}
 

--- a/src/runtime/storageNG/tests/store-sequence-test.ts
+++ b/src/runtime/storageNG/tests/store-sequence-test.ts
@@ -42,9 +42,12 @@ class MockStorageKey extends StorageKey {
   }
 }
 
-const testKey = new MockStorageKey();
+let testKey: StorageKey;
 
 describe('Store Flow', async () => {
+
+  before(() => {testKey = new MockStorageKey();});
+
   // Tests a model resync request happening synchronously with model updates from the driver
   it('services a model request and applies 2 models', async () => {
     const sequenceTest = new SequenceTest<ActiveStore<CRDTCountTypeRecord>>();

--- a/src/runtime/storageNG/tests/store-sequence-test.ts
+++ b/src/runtime/storageNG/tests/store-sequence-test.ts
@@ -37,7 +37,9 @@ class MockStorageDriverProvider implements StorageDriverProvider {
 }
 
 class MockStorageKey extends StorageKey {
-  protocol = 'testing';
+  constructor() {
+    super('testing');
+  }
 }
 
 const testKey = new MockStorageKey();

--- a/src/runtime/storageNG/tests/store-sequence-test.ts
+++ b/src/runtime/storageNG/tests/store-sequence-test.ts
@@ -13,11 +13,12 @@ import {Store, StorageMode, ActiveStore, ProxyMessageType, ProxyMessage} from '.
 import {SequenceTest, ExpectedResponse, SequenceOutput} from '../../testing/sequence.js';
 import {CRDTCountTypeRecord, CRDTCount, CountOpTypes, CountData} from '../../crdt/crdt-count.js';
 import {DriverFactory, Driver, ReceiveMethod, StorageDriverProvider, Exists} from '../drivers/driver-factory.js';
+import {StorageKey} from '../storage-key.js';
 
 class MockDriver<Data> extends Driver<Data> {
   receiver: ReceiveMethod<Data>;
-  async read(key: string) { throw new Error('unimplemented'); }
-  async write(key: string, value: {}) { throw new Error('unimplemented'); }
+  async read(key: StorageKey) { throw new Error('unimplemented'); }
+  async write(key: StorageKey, value: {}) { throw new Error('unimplemented'); }
   registerReceiver(receiver: ReceiveMethod<Data>) {
     this.receiver = receiver;
   }
@@ -27,13 +28,19 @@ class MockDriver<Data> extends Driver<Data> {
 }
 
 class MockStorageDriverProvider implements StorageDriverProvider {
-  willSupport(storageKey: string) {
+  willSupport(storageKey: StorageKey) {
     return true;
   }
-  driver<Data>(storageKey: string, exists: Exists): Driver<Data> {
+  driver<Data>(storageKey: StorageKey, exists: Exists): Driver<Data> {
     return new MockDriver<Data>(storageKey, exists);
   }
 }
+
+class MockStorageKey extends StorageKey {
+  protocol = 'testing';
+}
+
+const testKey = new MockStorageKey();
 
 describe('Store Flow', async () => {
   // Tests a model resync request happening synchronously with model updates from the driver
@@ -43,7 +50,7 @@ describe('Store Flow', async () => {
       DriverFactory.clearRegistrationsForTesting();
       DriverFactory.register(new MockStorageDriverProvider());
     
-      const store = new Store('string', Exists.ShouldCreate, null, StorageMode.Direct, CRDTCount);
+      const store = new Store(testKey, Exists.ShouldCreate, null, StorageMode.Direct, CRDTCount);
       const activeStore = store.activate();
       return activeStore;
     });    
@@ -111,7 +118,7 @@ describe('Store Flow', async () => {
       DriverFactory.clearRegistrationsForTesting();
       DriverFactory.register(new MockStorageDriverProvider());
     
-      const store = new Store('string', Exists.ShouldCreate, null, StorageMode.Direct, CRDTCount);
+      const store = new Store(testKey, Exists.ShouldCreate, null, StorageMode.Direct, CRDTCount);
       const activeStore = store.activate();
       return activeStore;
     });    

--- a/src/runtime/storageNG/tests/store-sequence-test.ts
+++ b/src/runtime/storageNG/tests/store-sequence-test.ts
@@ -93,8 +93,8 @@ describe('Store Flow', async () => {
         }
       }, SequenceOutput.Register, idVar);
       
-    const storageProxyChanges: {inputFn: () => ProxyMessage<CRDTCountTypeRecord>, variable: {}}[] 
-      = [{inputFn: () => ({type: ProxyMessageType.SyncRequest, id: sequenceTest.getVariable(idVar)}), 
+    const storageProxyChanges: {inputFn: () => [ProxyMessage<CRDTCountTypeRecord>], variable: {}}[] 
+      = [{inputFn: () => [{type: ProxyMessageType.SyncRequest, id: sequenceTest.getVariable(idVar)}], 
           variable: {[isSyncRequest]: true}}]; 
 
     const makeModel = (meCount: number, themCount: number, meVersion: number, themVersion: number): CountData => 
@@ -102,9 +102,9 @@ describe('Store Flow', async () => {
           version: new Map([['me', meVersion], ['them', themVersion]])});
     const driverChanges = [
       {output: {[send]: false}},
-      {input: makeModel(7, 12, 3, 4), output: {[send]: true}},
+      {input: [makeModel(7, 12, 3, 4)], output: {[send]: true}},
       {output: {[send]: false}},
-      {input: makeModel(8, 12, 4, 4), output: {[send]: true}}
+      {input: [makeModel(8, 12, 4, 4)], output: {[send]: true}}
     ];
 
     sequenceTest.setChanges(onProxyMessage, storageProxyChanges);
@@ -151,7 +151,7 @@ describe('Store Flow', async () => {
         operations: [{type: CountOpTypes.Increment, actor, version: {from, to: from + 1}}],
         id: 1
       });
-    const storageProxyChanges = [{input: incOp('me', 0)}, {input: incOp('me', 1)}, {input: incOp('me', 2)}];
+    const storageProxyChanges = [{input: [incOp('me', 0)]}, {input: [incOp('me', 1)]}, {input: [incOp('me', 2)]}];
 
     const makeModel = (meCount: number, themCount: number, meVersion: number, themVersion: number): CountData => 
         ({values: new Map([['me', meCount], ['them', themCount]]), 
@@ -159,9 +159,9 @@ describe('Store Flow', async () => {
     const driverChanges = [
       {output: {[send]: false}}, // at some point data arrives at the driver
       // the sendCount at driverChanges[0] is the inc count for ‘me’ 
-      {inputFn: () => makeModel(sequenceTest.getVariable(meCount), 1, sequenceTest.getVariable(meCount), 1), output: {[send]: true}},
+      {inputFn: () => [makeModel(sequenceTest.getVariable(meCount), 1, sequenceTest.getVariable(meCount), 1), 1], output: {[send]: true}},
       {output: {[send]: false}}, // more data arrives
-      {inputFn: () => makeModel(sequenceTest.getVariable(meCount), 2, sequenceTest.getVariable(meCount), 2), output: {[send]: true}}
+      {inputFn: () => [makeModel(sequenceTest.getVariable(meCount), 2, sequenceTest.getVariable(meCount), 2), 2], output: {[send]: true}}
     ];
 
     sequenceTest.setChanges(onProxyMessage, storageProxyChanges);

--- a/src/runtime/storageNG/tests/store-test.ts
+++ b/src/runtime/storageNG/tests/store-test.ts
@@ -42,11 +42,12 @@ class MockStorageKey extends StorageKey {
   }
 }
 
-const testKey = new MockStorageKey();
+let testKey: StorageKey;
 
 describe('Store', async () => {
 
   beforeEach(() => {
+    testKey = new MockStorageKey();
     DriverFactory.clearRegistrationsForTesting();
   });
 

--- a/src/runtime/storageNG/tests/store-test.ts
+++ b/src/runtime/storageNG/tests/store-test.ts
@@ -37,7 +37,9 @@ class MockStorageDriverProvider implements StorageDriverProvider {
 }
 
 class MockStorageKey extends StorageKey {
-  protocol = 'testing';
+  constructor() {
+    super('testing');
+  }
 }
 
 const testKey = new MockStorageKey();

--- a/src/runtime/storageNG/tests/store-test.ts
+++ b/src/runtime/storageNG/tests/store-test.ts
@@ -16,8 +16,8 @@ import {StorageKey} from '../storage-key.js';
 
 class MockDriver<Data> extends Driver<Data> {
   receiver: ReceiveMethod<Data>;
-  async read(key: StorageKey) { throw new Error("unimplemented"); }
-  async write(key: StorageKey, value: {}) { throw new Error("unimplemented"); }
+  async read(key: StorageKey) { throw new Error('unimplemented'); }
+  async write(key: StorageKey, value: {}) { throw new Error('unimplemented'); }
   registerReceiver(receiver: ReceiveMethod<Data>) {
     this.receiver = receiver;
   }

--- a/src/runtime/storageNG/tests/store-test.ts
+++ b/src/runtime/storageNG/tests/store-test.ts
@@ -186,7 +186,7 @@ describe('Store', async () => {
       });
   
       const driver = activeStore['driver'] as MockDriver<CountData>;
-      await driver.receiver(count.getData());
+      await driver.receiver(count.getData(), 1);
     });
   });
 
@@ -204,7 +204,7 @@ describe('Store', async () => {
 
     // Note that this assumes no asynchrony inside store.ts. This is guarded by the following
     // test, which will fail if driver.receiver() doesn't synchronously invoke driver.send(). 
-    await driver.receiver(remoteCount.getData());
+    await driver.receiver(remoteCount.getData(), 1);
   });
 
   it('will resend failed driver updates after merging', async () => {
@@ -233,7 +233,7 @@ describe('Store', async () => {
     let capturedModel: CountData = null;
     driver.send = async model => {sendInvoked = true; capturedModel = model; return true;};
 
-    await driver.receiver(remoteCount.getData());
+    await driver.receiver(remoteCount.getData(), 1);
     assert.isTrue(sendInvoked);
 
     count.merge(remoteCount.getData());

--- a/src/runtime/storageNG/tests/store-test.ts
+++ b/src/runtime/storageNG/tests/store-test.ts
@@ -12,11 +12,12 @@ import {assert} from '../../../platform/chai-web.js';
 import {Store, StorageMode, DirectStore, ProxyMessageType} from '../store.js';
 import {Exists, DriverFactory, StorageDriverProvider, Driver, ReceiveMethod} from '../drivers/driver-factory.js';
 import {CRDTCount, CountOpTypes, CountData, CountOperation} from '../../crdt/crdt-count.js';
+import {StorageKey} from '../storage-key.js';
 
 class MockDriver<Data> extends Driver<Data> {
   receiver: ReceiveMethod<Data>;
-  async read(key: string) { throw new Error('unimplemented'); }
-  async write(key: string, value: {}) { throw new Error('unimplemented'); }
+  async read(key: StorageKey) { throw new Error("unimplemented"); }
+  async write(key: StorageKey, value: {}) { throw new Error("unimplemented"); }
   registerReceiver(receiver: ReceiveMethod<Data>) {
     this.receiver = receiver;
   }
@@ -27,13 +28,19 @@ class MockDriver<Data> extends Driver<Data> {
 
 class MockStorageDriverProvider implements StorageDriverProvider {
 
-  willSupport(storageKey: string) {
+  willSupport(storageKey: StorageKey) {
     return true;
   }
-  driver<Data>(storageKey: string, exists: Exists): Driver<Data> {
+  driver<Data>(storageKey: StorageKey, exists: Exists): Driver<Data> {
     return new MockDriver<Data>(storageKey, exists);
   }
 }
+
+class MockStorageKey extends StorageKey {
+  protocol = 'testing';
+}
+
+const testKey = new MockStorageKey();
 
 describe('Store', async () => {
 
@@ -42,14 +49,14 @@ describe('Store', async () => {
   });
 
   it(`will throw an exception if an appropriate driver can't be found`, async () => {
-    const store = new Store('string', Exists.ShouldCreate, null, StorageMode.Direct, CRDTCount);
+    const store = new Store(testKey, Exists.ShouldCreate, null, StorageMode.Direct, CRDTCount);
     assert.throws(() => store.activate(), 'No driver exists');
   });
 
   it('will construct Direct stores when required', async () => {
     DriverFactory.register(new MockStorageDriverProvider());
 
-    const store = new Store('string', Exists.ShouldCreate, null, StorageMode.Direct, CRDTCount);
+    const store = new Store(testKey, Exists.ShouldCreate, null, StorageMode.Direct, CRDTCount);
     const activeStore = store.activate();
 
     assert.equal(activeStore.constructor, DirectStore);
@@ -58,7 +65,7 @@ describe('Store', async () => {
   it('will propagate model updates from proxies to drivers', async () => {
     DriverFactory.register(new MockStorageDriverProvider());
 
-    const store = new Store('string', Exists.ShouldCreate, null, StorageMode.Direct, CRDTCount);
+    const store = new Store(testKey, Exists.ShouldCreate, null, StorageMode.Direct, CRDTCount);
     const activeStore = store.activate();
 
     const driver = activeStore['driver'] as MockDriver<CountData>;    
@@ -77,7 +84,7 @@ describe('Store', async () => {
   it('will apply and propagate operation updates from proxies to drivers', async () => {
     DriverFactory.register(new MockStorageDriverProvider());
 
-    const store = new Store('string', Exists.ShouldCreate, null, StorageMode.Direct, CRDTCount);
+    const store = new Store(testKey, Exists.ShouldCreate, null, StorageMode.Direct, CRDTCount);
     const activeStore = store.activate();
 
     const driver = activeStore['driver'] as MockDriver<CountData>;
@@ -98,7 +105,7 @@ describe('Store', async () => {
   it('will respond to a model request from a proxy with a model', async () => {
     DriverFactory.register(new MockStorageDriverProvider());
 
-    const store = new Store('string', Exists.ShouldCreate, null, StorageMode.Direct, CRDTCount);
+    const store = new Store(testKey, Exists.ShouldCreate, null, StorageMode.Direct, CRDTCount);
     const activeStore = store.activate();
 
     const driver = activeStore['driver'] as MockDriver<CountData>;
@@ -134,7 +141,7 @@ describe('Store', async () => {
   it('will only send a model response to the requesting proxy', async () => {
     DriverFactory.register(new MockStorageDriverProvider());
 
-    const store = new Store('string', Exists.ShouldCreate, null, StorageMode.Direct, CRDTCount);
+    const store = new Store(testKey, Exists.ShouldCreate, null, StorageMode.Direct, CRDTCount);
     const activeStore = store.activate();
     
     return new Promise(async (resolve, reject) => {
@@ -157,7 +164,7 @@ describe('Store', async () => {
   it('will propagate updates from drivers to proxies', async () => {
     DriverFactory.register(new MockStorageDriverProvider());
 
-    const store = new Store('string', Exists.ShouldCreate, null, StorageMode.Direct, CRDTCount);
+    const store = new Store(testKey, Exists.ShouldCreate, null, StorageMode.Direct, CRDTCount);
     const activeStore = store.activate();
 
     const count = new CRDTCount();
@@ -184,7 +191,7 @@ describe('Store', async () => {
   it(`won't send an update to the driver after driver-originated messages`, async () => {
     DriverFactory.register(new MockStorageDriverProvider());
 
-    const store = new Store('string', Exists.ShouldCreate, null, StorageMode.Direct, CRDTCount);
+    const store = new Store(testKey, Exists.ShouldCreate, null, StorageMode.Direct, CRDTCount);
     const activeStore = store.activate();
 
     const remoteCount = new CRDTCount();
@@ -201,7 +208,7 @@ describe('Store', async () => {
   it('will resend failed driver updates after merging', async () => {
     DriverFactory.register(new MockStorageDriverProvider());
 
-    const store = new Store('string', Exists.ShouldCreate, null, StorageMode.Direct, CRDTCount);
+    const store = new Store(testKey, Exists.ShouldCreate, null, StorageMode.Direct, CRDTCount);
     const activeStore = store.activate();
 
     // local count from proxy

--- a/src/runtime/testing/sequence.ts
+++ b/src/runtime/testing/sequence.ts
@@ -39,8 +39,8 @@ export interface OutputResponseObject {
 
 export interface SequenceChange {
   variable?: any;
-  input?: any;
-  inputFn?: () => any;
+  input?: any[];
+  inputFn?: () => any[];
   output?: {[index: string]: any};
   id?: string;
 }
@@ -604,8 +604,10 @@ export class SequenceTest<T> {
 
         if (item.change.input || item.change.inputFn) {
           const value = item.change.input ? item.change.input : item.change.inputFn();
-          this.interleavingLog = this.interleavingLog.concat(['<-', value, '\n']);
-          input.results.push(obj[input.name](value));
+          this.interleavingLog.push('<-');
+          this.interleavingLog = this.interleavingLog.concat(value);
+          this.interleavingLog.push(']');
+          input.results.push(obj[input.name](...value));
         }
 
         this.interleavingLog.push('\n');

--- a/src/runtime/testing/test/sequence-test.ts
+++ b/src/runtime/testing/test/sequence-test.ts
@@ -31,7 +31,7 @@ describe('Sequence testing infrastructure', async () => {
         {type: ExpectedResponse.Constant, response: true});
     const total = flowTest.registerSensor('total');
 
-    const inputChanges = [{input: 1}, {input: 2}];
+    const inputChanges = [{input: [1]}, {input: [2]}];
     flowTest.setChanges(input, inputChanges);
 
     flowTest.setEndInvariant(total, (value) => assert.equal(value, 3));
@@ -51,7 +51,7 @@ describe('Sequence testing infrastructure', async () => {
         {type: ExpectedResponse.Void});
     const total = flowTest.registerSensor('total');
 
-    const inputChanges = [{input: 1}, {input: 2}];
+    const inputChanges = [{input: [1]}, {input: [2]}];
     flowTest.setChanges(input, inputChanges);
 
     flowTest.setEndInvariant(total, (value) => assert.equal(value, 3));
@@ -71,7 +71,7 @@ describe('Sequence testing infrastructure', async () => {
         {type: ExpectedResponse.Void});
     const total = flowTest.registerSensor('total');
 
-    const inputChanges = [{input: 1}];
+    const inputChanges = [{input: [1]}];
     flowTest.setChanges(input, inputChanges);
 
     flowTest.setEndInvariant(total, (value) => assert.equal(value, 1));

--- a/tools/sigh.ts
+++ b/tools/sigh.ts
@@ -816,7 +816,7 @@ function runSteps(command: string, args: string[]): boolean {
   } catch (e) {
     console.error(e);
   } finally {
-    console.log(result ? '🎉' : '😱');
+    console.log(result ? '🎉 SUCCESS' : '😱 FAILURE');
   }
   return result;
 }


### PR DESCRIPTION
Implements a simple volatile driver. This tracks a version for each storage key location, and refuses to accept non-version-incrementing updates. Initially, the version tracking was going to be entirely internal to the driver but I realized while writing this code that I needed to thread it through the store's update mechanism; otherwise there is no way of telling whether a given model is the version that came out of merging the latest update from the driver.

This complicates things a little bit and will require some decent integration testing. I'll do that next, along with some sequence tests, and might also add some unit tests that demonstrate different storage keys not interfering with one another too.

There's a grab-bag of other adjustments in here, sorry. I can probably separate them out if reviewing the lot is too discombobulating:
 - storage keys: I've decided to try to make these objects rather than strings for layoutNG, as I think it'll end up cleaner to do so
 - sequence testing: I uh .. didn't allow for multiple input arguments to functions. That's now fixed.
 - linting: removed no-constant-condition because it wasn't working. Moved switch case fallthrough checking from a compile failure to a lint error as this actually allows fallthrough if explicitly commented.
  - sigh: finally got sick of not being able to tell success/failure on my poor, second-class non-unicode terminal.