### PR TITLE
Ensure a busy signal when particle methods are invoked.

### DIFF
--- a/src/runtime/handle.ts
+++ b/src/runtime/handle.ts
@@ -386,7 +386,7 @@ export class BigCollection extends Handle {
   async _notify(kind: string, particle: Particle, details) {
     assert(this.canRead, '_notify should not be called for non-readable handles');
     assert(kind === 'sync', 'BigCollection._notify only supports sync events');
-    particle.callOnHandleSync(this, [], e => this.reportUserExceptionInHost(e, particle, 'onHandleSync'));
+    await particle.callOnHandleSync(this, [], e => this.reportUserExceptionInHost(e, particle, 'onHandleSync'));
   }
 
   /**

--- a/src/runtime/particle-execution-context.ts
+++ b/src/runtime/particle-execution-context.ts
@@ -23,6 +23,7 @@ import {Type} from './type.js';
 import {MessagePort} from './message-channel.js';
 import {WasmParticle} from './wasm.js';
 import {Dictionary} from './hot.js';
+import {UserException} from './arc-exceptions.js';
 
 export type PecFactory = (pecId: Id, idGenerator: IdGenerator) => MessagePort;
 
@@ -208,7 +209,7 @@ export class ParticleExecutionContext {
     const p = new Promise<void>(res => resolve = res);
     this.pendingLoads.push(p);
 
-    let particle;
+    let particle: Particle;
     if (spec.implFile && spec.implFile.endsWith('.wasm')) {
       particle = await this.loadWasmParticle(spec);
       particle.setCapabilities({});
@@ -233,7 +234,10 @@ export class ParticleExecutionContext {
     });
 
     return [particle, async () => {
-      await particle.setHandles(handleMap);
+      await particle.callSetHandles(handleMap, err => {
+        const exc = new UserException(err, 'setHandles', id, spec.name);
+        this.apiPort.ReportExceptionInHost(exc);
+      });
       registerList.forEach(({proxy, particle, handle}) => proxy.register(particle, handle));
       const idx = this.pendingLoads.indexOf(p);
       this.pendingLoads.splice(idx, 1);

--- a/src/runtime/test/particle-api-test.ts
+++ b/src/runtime/test/particle-api-test.ts
@@ -849,6 +849,7 @@ describe('particle-api', () => {
               this.out = handles.get('far');
             }
             async onHandleSync(handle, model) {
+              await handle.get();
               this.startBusy();
               setTimeout(async () => {
                 await this.out.set(new this.out.entityClass({result: 'hi'}));
@@ -899,6 +900,7 @@ describe('particle-api', () => {
               this.out = handles.get('far');
             }
             async onHandleUpdate(handle, update) {
+              await handle.get();
               this.startBusy();
               setTimeout(async () => {
                 await this.out.set(new this.out.entityClass({result: 'hi'}));

--- a/src/runtime/test/storage-proxy-test.ts
+++ b/src/runtime/test/storage-proxy-test.ts
@@ -145,11 +145,11 @@ class TestParticle {
     this._report = report;
   }
 
-  onHandleSync(handle, model) {
+  callOnHandleSync(handle, model) {
     this._report(['onHandleSync', this.id, handle.name, this._toString(model)].join(':'));
   }
 
-  onHandleUpdate(handle, update) {
+  callOnHandleUpdate(handle, update) {
     let details = '';
     if ('data' in update) {
       details += this._toString(update.data);
@@ -169,7 +169,7 @@ class TestParticle {
     this._report(['onHandleUpdate', this.id, handle.name, details].join(':'));
   }
 
-  onHandleDesync(handle) {
+  callOnHandleDesync(handle) {
     this._report(['onHandleDesync', this.id, handle.name].join(':'));
   }
 


### PR DESCRIPTION
This is a fix for #2945.

Note that it mightn't prevent the issue altogether, but it *should* prevent startBusy calls from being reached within particle API methods and subsequently not taking effect.

@sjmiles would you mind testing to see if this makes your problem go away? If it doesn't we need to look more closely at dom-particle and see what else needs startBusy/doneBusy guarding.

The technical details:
This patch wraps all invocations of particle API methods with startBusy / doneBusy. Effectively, this means that a particle will be considered busy if its invoking an API method, which I think is sensible..

Because we also want thread all API methods with user exception collection, I did that at the same time.