### PR TITLE
minor fixups

### DIFF
--- a/particles/List/source/Items.js
+++ b/particles/List/source/Items.js
@@ -24,13 +24,8 @@ defineParticle(({DomParticle, resolver, html}) => {
     [${host}] > [items] {
       background-color: white;
     }
-    [${host}] > [items] > [item] {
-      /* no padding/margin/etc so the item can use full bleed */
-      border-top: 1px solid #eeeeee;
-    }
-    [${host}] > [items] > [item]:last-child {
-      border-bottom: 1px solid #eeeeee;
-    }
+    /* note: avoid padding/margin/etc on [item] so the children can use the full bleed */
+    /* TODO(sjmiles): provide css-variables for customizing selection */
     [${host}] > [items] > [item][selected] {
       background-color: whitesmoke;
     }

--- a/particles/Music/source/PlaylistItem.js
+++ b/particles/Music/source/PlaylistItem.js
@@ -18,7 +18,6 @@ defineParticle(({DomParticle, html}) => {
     <style>
       [${host}] {
         padding: 8px 0;
-        margin: -1px 0; /* removing the borders from the styling of the List.js */
         background-color: white;
         display: flex;
         height: 60px;

--- a/particles/Restaurants/Restaurants.recipes
+++ b/particles/Restaurants/Restaurants.recipes
@@ -14,7 +14,7 @@ import '../Profile/Geolocate.recipe'
 
 recipe Restaurants
   create #volatile as location
-  create as restaurants
+  create #volatile as restaurants
   create #volatile #selected as selected
   Geolocate
     location = location

--- a/shells/lib/runtime/utils.js
+++ b/shells/lib/runtime/utils.js
@@ -72,7 +72,7 @@ const spawn = async ({id, serialization, context, composer, storage}) => {
     fileName: './serialized.manifest',
     serialization,
     context,
-    storageKey: storage,
+    storageKey: storage || 'volatile',
     slotComposer: composer,
     pecFactory: env.pecFactory,
     loader: env.loader,

--- a/src/platform/pec-industry-web.ts
+++ b/src/platform/pec-industry-web.ts
@@ -10,31 +10,23 @@
 
 const WORKER_PATH = `https://$build/worker.js`;
 
-let workerUrl;
-let workerBlobUrl;
-
 const pecIndustry = loader => {
   // worker paths are relative to worker location, remap urls from there to here
   const remap = _expandUrls(loader._urlMap);
   // get real path from meta path
   const workerUrl = loader._resolve(WORKER_PATH);
-  // provision (cached) Blob url (async)
+  // provision (cached) Blob url (async, same workerBlobUrl is captured in both closures)
   let workerBlobUrl;
   loader.provisionObjectUrl(workerUrl).then((url: string) => workerBlobUrl = url);
   return id => {
     if (!workerBlobUrl) {
-      console.warn('wokerBlob not available, falling back to network URL');
+      console.warn('workerBlob not available, falling back to network URL');
     }
     const worker = new Worker(workerBlobUrl || workerUrl);
     const channel = new MessageChannel();
     worker.postMessage({id: `${id}:inner`, base: remap}, [channel.port1]);
     return channel.port2;
   };
-};
-
-const provisionWorkersUrls = loader => {
-  workerUrl = loader._resolve(WORKER_PATH);
-  loader.provisionObjectUrl(workerUrl).then((url: string) => workerBlobUrl = url);
 };
 
 const _expandUrls = urlMap => {

--- a/src/runtime/log-factory.ts
+++ b/src/runtime/log-factory.ts
@@ -1,0 +1,18 @@
+/**
+ * @license
+ * Copyright 2019 Google LLC.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+import {logFactory} from '../platform/log-web.js';
+
+export {logFactory};
+
+export const logsFactory = (preamble, color) => ({
+  log: logFactory(preamble, color, 'log'),
+  warn: logFactory(preamble, color, 'warn'),
+  error: logFactory(preamble, color, 'error')
+});

--- a/src/runtime/testing/mock-slot-composer.ts
+++ b/src/runtime/testing/mock-slot-composer.ts
@@ -253,10 +253,12 @@ export class MockSlotComposer extends FakeSlotComposer {
     const found = this._verifyRenderContent(particle, slotName, content);
     if (!found) {
       const canIgnore = this._canIgnore(particle.name, slotName, content);
-      if (canIgnore) {
+      if (canIgnore && !MockSlotComposer['warnedIgnore']) {
+        MockSlotComposer['warnedIgnore'] = true;
         console.log(`Skipping unexpected render slot request: ${particle.name}:${slotName} (content types: ${Object.keys(content).join(', ')})`);
         console.log('expected? add this line:');
         console.log(`  .expectRenderSlot('${particle.name}', '${slotName}', {'contentTypes': ['${Object.keys(content).join('\', \'')}']})`);
+        console.log(`(additional warnings are suppressed)`);
       }
       assert(canIgnore, `Unexpected render slot ${slotName} for particle ${particle.name} (content types: ${Object.keys(content).join(',')})`);
     }


### PR DESCRIPTION
- remove default styling from Items.js, it should be as blank as possible
- remove work-around for default styling in Items.js
- suppress slot-expectation warnings after the first one
- make restaurant list store volatile
- remove dead code from pec-industry-web
- add log-factory.ts that wraps platform/log-factory-* and allows creating each of log/warn/error loggers in one step