### PR TITLE
Devtools: Show why a suggestion is not visible

### DIFF
--- a/src/planning/debug/planning-explorer-adapter.ts
+++ b/src/planning/debug/planning-explorer-adapter.ts
@@ -10,10 +10,13 @@
 import {DevtoolsConnection} from '../../devtools-connector/devtools-connection.js';
 import {Trigger} from '../plan/plan-producer.js';
 import {Planificator} from '../plan/planificator.js';
-import {Suggestion} from '../plan/suggestion';
+import {PlanningResult} from '../plan/planning-result.js';
+import {Suggestion} from '../plan/suggestion.js';
+import {VisibilityOptions} from '../plan/plan-consumer.js';
+import {ArcDevtoolsChannel} from '../../devtools-connector/abstract-devtools-channel.js';
 
  export class PlanningExplorerAdapter {
-  static updatePlanningResults(result, metadata, devtoolsChannel) {
+  static updatePlanningResults(result: PlanningResult, metadata, devtoolsChannel: ArcDevtoolsChannel) {
     if (devtoolsChannel) {
       devtoolsChannel.send({
         messageType: 'suggestions-changed',
@@ -25,18 +28,23 @@ import {Suggestion} from '../plan/suggestion';
       });
     }
   }
-  static updateVisibleSuggestions(visibleSuggestions, devtoolsChannel) {
+  static updateVisibleSuggestions(visibleSuggestions: Suggestion[],
+                                  options: VisibilityOptions,
+                                  devtoolsChannel: ArcDevtoolsChannel) {
     if (devtoolsChannel) {
       devtoolsChannel.send({
         messageType: 'visible-suggestions-changed',
         messageBody: {
-          visibleSuggestionHashes: visibleSuggestions.map(s => s.hash)
+          visibleSuggestionHashes: visibleSuggestions.map(s => s.hash),
+          visibilityReasons: options ? [...options.reasons.entries()].map(e => Object.assign({hash: e[0]}, e[1])) : undefined
         }
       });
     }
   }
 
-  static updatePlanningAttempt(suggestions: Suggestion[], metadata: {}, devtoolsChannel) {
+  static updatePlanningAttempt(suggestions: Suggestion[],
+                               metadata: {},
+                               devtoolsChannel: ArcDevtoolsChannel) {
     if (devtoolsChannel) {
       devtoolsChannel.send({
         messageType: 'planning-attempt',

--- a/src/planning/debug/planning-explorer-adapter.ts
+++ b/src/planning/debug/planning-explorer-adapter.ts
@@ -36,7 +36,7 @@ import {ArcDevtoolsChannel} from '../../devtools-connector/abstract-devtools-cha
         messageType: 'visible-suggestions-changed',
         messageBody: {
           visibleSuggestionHashes: visibleSuggestions.map(s => s.hash),
-          visibilityReasons: options ? [...options.reasons.entries()].map(e => Object.assign({hash: e[0]}, e[1])) : undefined
+          visibilityReasons: options ? [...options.reasons.entries()].map(e => ({hash: e[0], ...e[1]})) : undefined
         }
       });
     }

--- a/src/planning/plan/suggest-filter.ts
+++ b/src/planning/plan/suggest-filter.ts
@@ -1,0 +1,19 @@
+/**
+ * @license
+ * Copyright (c) 2019 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+import {assert} from '../../platform/assert-web.js';
+
+export class SuggestFilter {
+  constructor(public readonly showAll: boolean, public readonly search?: string) {
+    assert(!(showAll && search), `Cannot set search string for 'show-all' filter`);
+  }
+  isEquivalent(showAll: boolean, search?: string): boolean {
+    return (this.showAll === showAll) && (this.search === search);
+  }
+}

--- a/src/planning/test/plan/plan-consumer-test.ts
+++ b/src/planning/test/plan/plan-consumer-test.ts
@@ -19,6 +19,7 @@ import {Planificator} from '../../plan/planificator.js';
 import {PlanningResult} from '../../plan/planning-result.js';
 import {Suggestion} from '../../plan/suggestion.js';
 import {PlanningModalityHandler} from '../../planning-modality-handler.js';
+import {SuggestFilter} from '../../plan/suggest-filter.js';
 
 async function createPlanConsumer(userid, arcKey, storageKeyBase, helper) {
   helper.arc.storageKey = 'volatile://!158405822139616:demo^^volatile-0';
@@ -155,7 +156,7 @@ describe('plan consumer', () => {
       }));
       assert.lengthOf(consumer.result.suggestions, 4);
       assert.isEmpty(consumer.getCurrentSuggestions());
-      consumer.suggestFilter.showAll = true;
+      consumer.suggestFilter = new SuggestFilter(true);
       return consumer;
     };
 


### PR DESCRIPTION
- refactor suggestion to determine visibility
- fix last planning display - support empty description text
- show visibility reasons in Arcs devtools Planner page

fixes: https://github.com/PolymerLabs/arcs/issues/3109
the reason is visible when expanding the suggestion's object explorer:
<img width="1255" alt="Screen Shot 2019-06-04 at 12 58 30 PM" src="https://user-images.githubusercontent.com/25067830/58915859-d23f5500-86d6-11e9-8898-803ffdd938f1.png">
