### PR TITLE
Adds claim and check statements to the manifest parser

### DIFF
--- a/src/runtime/manifest-ast-nodes.ts
+++ b/src/runtime/manifest-ast-nodes.ts
@@ -165,6 +165,8 @@ export interface Particle extends BaseNode {
   slots?: ParticleSlot[];    // not used in RecipeParticle
   description?: Description;  // not used in RecipeParticle
   hasParticleArgument?: boolean;  // not used in RecipeParticle
+  trustChecks?: ParticleTrustCheck[];
+  trustClaims?: ParticleTrustClaim[];
 
   // fields in RecipeParticle only
   ref?: ParticleRef | '*';
@@ -172,6 +174,17 @@ export interface Particle extends BaseNode {
   slotConnections?: RecipeParticleSlotConnection[];
 }
 
+export interface ParticleTrustClaim extends BaseNode {
+  kind: 'particle-trust-claim';
+  handle: string;
+  trustTag: string;
+}
+
+export interface ParticleTrustCheck extends BaseNode {
+  kind: 'particle-trust-check';
+  handle: string;
+  trustTag: string;
+}
 
 export interface ParticleModality extends BaseNode {
   kind: 'particle-modality';

--- a/src/runtime/manifest-parser.peg
+++ b/src/runtime/manifest-parser.peg
@@ -233,6 +233,8 @@ Particle
     let args: AstNode.ParticleArgument[] = [];
     const modality: string[] = [];
     const slotConnections: AstNode.RecipeParticleSlotConnection[] = [];
+    const trustClaims: AstNode.ParticleTrustClaim[] = [];
+    const trustChecks: AstNode.ParticleTrustCheck[] = [];
     let description: AstNode.Description | null = null;
     let hasParticleArgument = false;
     verbs = optional(verbs, parsedOutput => parsedOutput[1], []);
@@ -255,6 +257,10 @@ Particle
           location: location() // TODO: FIXME Get the locations of the item descriptions.
         } as AstNode.Description;
         item.description.forEach(d => description[d.name] = d.pattern || d.patterns[0]);
+      } else if (item.kind === 'particle-trust-claim') {
+        trustClaims.push(item);
+      } else if (item.kind === 'particle-trust-check') {
+        trustChecks.push(item);
       } else if (item.modality) {
         modality.push(item.modality);
       } else {
@@ -276,7 +282,9 @@ Particle
       modality,
       slotConnections,
       description,
-      hasParticleArgument
+      hasParticleArgument,
+      trustClaims,
+      trustChecks,
     } as AstNode.Particle;
   }
 
@@ -285,6 +293,30 @@ ParticleItem "a particle item"
   / ParticleSlot
   / Description
   / ParticleHandle
+  / ParticleTrustClaim
+  / ParticleTrustCheck
+
+ParticleTrustClaim
+  = 'claim' whiteSpace handle:lowerIdent whiteSpace 'is' whiteSpace trustTag:lowerIdent eolWhiteSpace
+  {
+    return {
+      kind: 'particle-trust-claim',
+      location: location(),
+      handle,
+      trustTag,
+    } as AstNode.ParticleTrustClaim;
+  }
+
+ParticleTrustCheck
+  = 'check' whiteSpace handle:lowerIdent whiteSpace 'is' whiteSpace trustTag:lowerIdent eolWhiteSpace
+  {
+    return {
+      kind: 'particle-trust-check',
+      location: location(),
+      handle,
+      trustTag,
+    } as AstNode.ParticleTrustCheck;
+  }
 
 ParticleHandle
   = arg:ParticleArgument eolWhiteSpace dependentConnections:(Indent (SameIndent ParticleHandle)*)?

--- a/src/runtime/particle-spec.ts
+++ b/src/runtime/particle-spec.ts
@@ -193,8 +193,8 @@ export class ParticleSpec {
       });
     });
 
-    this.trustClaims = this._parseTrustClaims(model.trustClaims);
-    this.trustChecks = this._parseTrustChecks(model.trustChecks);
+    this.trustClaims = this.validateTrustClaims(model.trustClaims);
+    this.trustChecks = this.validateTrustChecks(model.trustChecks);
   }
 
   createConnection(arg: SerializedHandleConnectionSpec, typeVarMap: Map<string, Type>): HandleConnectionSpec {
@@ -367,7 +367,7 @@ export class ParticleSpec {
     return this.toString();
   }
 
-  private _parseTrustClaims(claims: SerializedParticleTrustClaimSpec[]): Map<string, string> {
+  private validateTrustClaims(claims: SerializedParticleTrustClaimSpec[]): Map<string, string> {
     const results: Map<string, string> = new Map();
     if (claims) {
       claims.forEach(claim => {
@@ -380,7 +380,7 @@ export class ParticleSpec {
     return results;
   }
 
-  private _parseTrustChecks(checks?: SerializedParticleTrustCheckSpec[]): Map<string, string> {
+  private validateTrustChecks(checks?: SerializedParticleTrustCheckSpec[]): Map<string, string> {
     const results: Map<string, string> = new Map();
     if (checks) {
       checks.forEach(check => {

--- a/src/runtime/particle-spec.ts
+++ b/src/runtime/particle-spec.ts
@@ -124,6 +124,16 @@ export class ConsumeSlotConnectionSpec {
 
 export class ProvideSlotConnectionSpec extends ConsumeSlotConnectionSpec {}
 
+export interface SerializedParticleTrustClaimSpec extends Literal {
+  handle: string;
+  trustTag: string;
+}
+
+export interface SerializedParticleTrustCheckSpec extends Literal {
+  handle: string;
+  trustTag: string;
+}
+
 export interface SerializedParticleSpec extends Literal {
   name: string;
   id?: string;
@@ -134,6 +144,8 @@ export interface SerializedParticleSpec extends Literal {
   implBlobUrl: string | null;
   modality: string[];
   slotConnections: SerializedSlotConnectionSpec[];
+  trustClaims?: SerializedParticleTrustClaimSpec[];
+  trustChecks?: SerializedParticleTrustCheckSpec[];
 }
 
 export class ParticleSpec {
@@ -147,7 +159,11 @@ export class ParticleSpec {
   modality: Modality;
   slotConnections: Map<string, ConsumeSlotConnectionSpec>;
 
-  constructor(model : SerializedParticleSpec) {
+  // Trust claims/checks: maps from handle name to a "trust tag".
+  trustClaims: Map<string, string>;
+  trustChecks: Map<string, string>;
+
+  constructor(model: SerializedParticleSpec) {
     this.model = model;
     this.name = model.name;
     this.verbs = model.verbs;
@@ -176,6 +192,9 @@ export class ParticleSpec {
         ps.handles.forEach(v => assert(this.handleConnectionMap.has(v), 'Cannot provide slot for nonexistent handle constraint ' + v));
       });
     });
+
+    this.trustClaims = this._parseTrustClaims(model.trustClaims);
+    this.trustChecks = this._parseTrustChecks(model.trustChecks);
   }
 
   createConnection(arg: SerializedHandleConnectionSpec, typeVarMap: Map<string, Type>): HandleConnectionSpec {
@@ -232,19 +251,19 @@ export class ParticleSpec {
   }
 
   toLiteral(): SerializedParticleSpec {
-    const {args, name, verbs, description, implFile, implBlobUrl, modality, slotConnections} = this.model;
+    const {args, name, verbs, description, implFile, implBlobUrl, modality, slotConnections, trustClaims, trustChecks} = this.model;
     const connectionToLiteral : (input: SerializedHandleConnectionSpec) => SerializedHandleConnectionSpec =
       ({type, direction, name, isOptional, dependentConnections}) => ({type: asTypeLiteral(type), direction, name, isOptional, dependentConnections: dependentConnections.map(connectionToLiteral)});
     const argsLiteral = args.map(a => connectionToLiteral(a));
-    return {args: argsLiteral, name, verbs, description, implFile, implBlobUrl, modality, slotConnections};
+    return {args: argsLiteral, name, verbs, description, implFile, implBlobUrl, modality, slotConnections, trustClaims, trustChecks};
   }
 
   static fromLiteral(literal: SerializedParticleSpec): ParticleSpec {
-    let {args, name, verbs, description, implFile, implBlobUrl, modality, slotConnections} = literal;
+    let {args, name, verbs, description, implFile, implBlobUrl, modality, slotConnections, trustClaims, trustChecks} = literal;
     const connectionFromLiteral = ({type, direction, name, isOptional, dependentConnections}) =>
       ({type: asType(type), direction, name, isOptional, dependentConnections: dependentConnections ? dependentConnections.map(connectionFromLiteral) : []});
     args = args.map(connectionFromLiteral);
-    return new ParticleSpec({args, name, verbs: verbs || [], description, implFile, implBlobUrl, modality, slotConnections});
+    return new ParticleSpec({args, name, verbs: verbs || [], description, implFile, implBlobUrl, modality, slotConnections, trustClaims, trustChecks});
   }
 
   // Note: this method shouldn't be called directly.
@@ -346,5 +365,31 @@ export class ParticleSpec {
 
   toManifestString(): string {
     return this.toString();
+  }
+
+  private _parseTrustClaims(claims: SerializedParticleTrustClaimSpec[]): Map<string, string> {
+    const results: Map<string, string> = new Map();
+    if (claims) {
+      claims.forEach(claim => {
+        assert(this.handleConnectionMap.has(claim.handle), `Can't make a claim on unknown handle ${claim.handle}.`);
+        const handle = this.handleConnectionMap.get(claim.handle);
+        assert(handle.isOutput, `Can't make a claim on handle ${claim.handle} (not an output handle).`);
+        results.set(claim.handle, claim.trustTag);
+      });
+    }
+    return results;
+  }
+
+  private _parseTrustChecks(checks?: SerializedParticleTrustCheckSpec[]): Map<string, string> {
+    const results: Map<string, string> = new Map();
+    if (checks) {
+      checks.forEach(check => {
+        assert(this.handleConnectionMap.has(check.handle), `Can't make a check on unknown handle ${check.handle}.`);
+        const handle = this.handleConnectionMap.get(check.handle);
+        assert(handle.isInput, `Can't make a check on handle ${check.handle} (not an input handle).`);
+        results.set(check.handle, check.trustTag);
+      });
+    }
+    return results;
   }
 }

--- a/src/runtime/test/debug/outer-port-attachments-tests.ts
+++ b/src/runtime/test/debug/outer-port-attachments-tests.ts
@@ -70,6 +70,8 @@ describe('OuterPortAttachment', () => {
         modality: ['dom'],
         slotConnections: [],
         verbs: [],
+        trustClaims: [],
+        trustChecks: [],
         args: [{
           dependentConnections: [],
           direction: 'inout',

--- a/src/runtime/test/manifest-test.ts
+++ b/src/runtime/test/manifest-test.ts
@@ -17,6 +17,7 @@ import {Schema} from '../schema.js';
 import {CollectionStorageProvider} from '../storage/storage-provider-base.js';
 import {StubLoader} from '../testing/stub-loader.js';
 import {Dictionary} from '../hot.js';
+import {assertThrowsAsync} from '../testing/test-util.js';
 
 async function assertRecipeParses(input: string, result: string) : Promise<void> {
   // Strip common leading whitespace.
@@ -1914,48 +1915,114 @@ resource SomeName
 
     const recipe = manifest.recipes[0];
     assert.equal(recipe.particles[0].connections.a.handle, recipe.particles[1].connections.b.handle);
- });
- it('can parse recipes with a require section', async () => {
-  const manifest = await Manifest.parse(`
-    particle P1
-      out S {} a
-      consume root 
-        provide details
-    particle P2
-      in S {} b
-        consume details
-    
-    recipe 
-      require
-        handle as h0
-        slot as s0
-        P1
-          * -> h0
-          consume root
-            provide details as s0
-        P2
-          * <- h0
+  });
+  
+  it('can parse recipes with a require section', async () => {
+    const manifest = await Manifest.parse(`
+      particle P1
+        out S {} a
+        consume root 
+          provide details
+      particle P2
+        in S {} b
           consume details
-      P1
-  `);
-  const recipe = manifest.recipes[0];
-  assert(recipe.requires.length === 1, 'could not parse require section');
- });
- it('recipe resolution checks the require sections', async () => {
-   const manifest = await Manifest.parse(`
+      
+      recipe 
+        require
+          handle as h0
+          slot as s0
+          P1
+            * -> h0
+            consume root
+              provide details as s0
+          P2
+            * <- h0
+            consume details
+        P1
+    `);
+    const recipe = manifest.recipes[0];
+    assert(recipe.requires.length === 1, 'could not parse require section');
+  });
+ 
+  it('recipe resolution checks the require sections', async () => {
+    const manifest = await Manifest.parse(`
 
-    particle A
-      in S {} input
-    particle B
-      out S {} output
+      particle A
+        in S {} input
+      particle B
+        out S {} output
 
-    recipe
-      require
-        A
-        B
-   `);
-   const recipe = manifest.recipes[0];
-   recipe.normalize();
-   assert.isFalse(recipe.isResolved(), 'recipe with a require section is resolved');
- });
+      recipe
+        require
+          A
+          B
+    `);
+    const recipe = manifest.recipes[0];
+    recipe.normalize();
+    assert.isFalse(recipe.isResolved(), 'recipe with a require section is resolved');
+  });
+
+  describe('trust claims and checks', () => {
+    it('supports multiple claim statements', async () => {
+      const manifest = await Manifest.parse(`
+        particle A
+          out T {} output1
+          out T {} output2
+          claim output1 is property1
+          claim output2 is property2
+      `);
+      assert.lengthOf(manifest.particles, 1);
+      const particle = manifest.particles[0];
+      assert.equal(particle.trustClaims.size, 2);
+      assert.equal(particle.trustClaims.get('output1'), 'property1');
+      assert.equal(particle.trustClaims.get('output2'), 'property2');
+      assert.isEmpty(particle.trustChecks);
+    });
+
+    it('supports multiple check statements', async () => {
+      const manifest = await Manifest.parse(`
+        particle A
+          in T {} input1
+          in T {} input2
+          check input1 is property1
+          check input2 is property2
+      `);
+      assert.lengthOf(manifest.particles, 1);
+      const particle = manifest.particles[0];
+      assert.equal(particle.trustChecks.size, 2);
+      assert.equal(particle.trustChecks.get('input1'), 'property1');
+      assert.equal(particle.trustChecks.get('input2'), 'property2');
+      assert.isEmpty(particle.trustClaims);
+    });
+
+    it('fails for unknown handle names', async () => {
+      assertThrowsAsync(async () => await Manifest.parse(`
+        particle A
+          out T {} output
+          claim oops is trusted
+      `), `Can't make a claim on unknown handle oops`);
+
+      assertThrowsAsync(async () => await Manifest.parse(`
+        particle A
+          in T {} input
+          check oops is trusted
+      `), `Can't make a check on unknown handle oops`);
+    });
+
+    it(`doesn't allow claims on inputs`, async () => {
+      assertThrowsAsync(async () => await Manifest.parse(`
+        particle A
+          in T {} foo
+          claim foo is trusted
+      `), `Can't make a claim on handle foo (not an output handle)`);
+    });
+
+    it(`doesn't allow checks on outputs`, async () => {
+      assertThrowsAsync(async () => await Manifest.parse(`
+        particle A
+          out T {} foo
+          check foo is trusted
+      `), `Can't make a check on handle foo (not an input handle)`);
+    });
+  });
 });


### PR DESCRIPTION
These statements only support a single tag for the moment, e.g.:
```
check input is trusted
claim output is trusted
```

The tags are collected into properties on the ParticleSpec, but aren't used for anything yet.