### PR TITLE
Adds a BackwardsPath class, for nicely traversing FlowGraphs backwards

### DIFF
--- a/src/dataflow/flow-graph.ts
+++ b/src/dataflow/flow-graph.ts
@@ -119,9 +119,15 @@ class ParticleNode extends Node {
   readonly outEdges: ParticleOutput[] = [];
   readonly name: string;
 
+  // Maps from handle names to tags.
+  readonly claims: Map<string, string>;
+  readonly checks: Map<string, string>;
+
   constructor(particle: Particle) {
     super();
     this.name = particle.name;
+    this.claims = particle.spec.trustClaims;
+    this.checks = particle.spec.trustChecks;
   }
 }
 
@@ -130,10 +136,14 @@ class ParticleInput implements Edge {
   readonly end: ParticleNode;
   readonly label: string;
 
+  /* Optional check on this input. */
+  readonly check?: string;
+
   constructor(particleNode: ParticleNode, otherEnd: Node, inputName: string) {
     this.start = otherEnd;
     this.end = particleNode;
     this.label = `${particleNode.name}.${inputName}`;
+    this.check = particleNode.checks.get(inputName);
   }
 }
 
@@ -142,10 +152,14 @@ class ParticleOutput implements Edge {
   readonly end: Node;
   readonly label: string;
 
+  /* Optional claim on this output. */
+  readonly claim?: string;
+
   constructor(particleNode: ParticleNode, otherEnd: Node, outputName: string) {
     this.start = particleNode;
     this.end = otherEnd;
     this.label = `${particleNode.name}.${outputName}`;
+    this.claim = particleNode.claims.get(outputName);
   }
 }
 

--- a/src/dataflow/flow-graph.ts
+++ b/src/dataflow/flow-graph.ts
@@ -57,6 +57,40 @@ export class FlowGraph {
   }
 }
 
+/**
+ * A path that walks backwards through the graph, i.e. it walks along the directed edges in the reverse direction. The path is described by the
+ * nodes in the path. 
+ */
+export class BackwardsPath {
+  private constructor(readonly nodes: Node[]) {}
+
+  static fromEdge(edge: Edge) {
+    return new BackwardsPath([edge.end, edge.start]);
+  }
+
+  appendEdge(edge: Edge): BackwardsPath {
+    // Flip the edge around.
+    const edgeStart = edge.end;
+    const edgeEnd = edge.start;
+
+    if (edgeStart !== this.endNode) {
+      throw new Error('Edge must connect to end of path.');
+    }
+    if (this.nodes.includes(edgeEnd)) {
+      throw new Error('Path must not include cycles.');
+    }
+    return new BackwardsPath([...this.nodes, edgeEnd]);
+  }
+
+  get startNode(): Node {
+    return this.nodes[0];
+  }
+
+  get endNode(): Node {
+    return this.nodes[this.nodes.length - 1];
+  }
+}
+
 /** Creates a new node for every given particle. */
 function createParticleNodes(particles: Particle[]) {
   const nodes: Map<Particle, ParticleNode> = new Map();
@@ -97,7 +131,7 @@ function addHandleConnection(particleNode: ParticleNode, handleNode: HandleNode,
   }
 }
 
-abstract class Node {
+export abstract class Node {
   abstract readonly inEdges: Edge[];
   abstract readonly outEdges: Edge[];
 
@@ -110,7 +144,7 @@ abstract class Node {
   }
 }
 
-interface Edge {
+export interface Edge {
   readonly start: Node;
   readonly end: Node;
   readonly label: string;

--- a/src/tests/flow-graph-tests.ts
+++ b/src/tests/flow-graph-tests.ts
@@ -104,4 +104,40 @@ describe('FlowGraph', () => {
     assert.hasAllKeys(graph.particleMap, ['P1', 'P2', 'P3']);
     assert.sameMembers(graph.connectionsAsStrings, ['P1.foo -> P2.bar', 'P1.foo -> P3.baz']);
   });
+
+  it('copies particle claims to particle nodes and out-edges', async () => {
+    const graph = await buildFlowGraph(`
+      particle P
+        out Foo {} foo
+        claim foo is trusted
+      recipe R
+        P
+          foo -> h
+    `);
+    const node = graph.particleMap.get('P');
+    assert.equal(node.claims.size, 1);
+    assert.equal(node.claims.get('foo'), 'trusted');
+    assert.isEmpty(node.checks);
+
+    assert.lengthOf(node.outEdges, 1);
+    assert.equal(node.outEdges[0].claim, 'trusted');
+  });
+
+  it('copies particle checks to particle nodes and in-edges', async () => {
+    const graph = await buildFlowGraph(`
+      particle P
+        in Foo {} foo
+        check foo is trusted
+      recipe R
+        P
+          foo <- h
+    `);
+    const node = graph.particleMap.get('P');
+    assert.equal(node.checks.size, 1);
+    assert.equal(node.checks.get('foo'), 'trusted');
+    assert.isEmpty(node.claims);
+
+    assert.lengthOf(node.inEdges, 1);
+    assert.equal(node.inEdges[0].check, 'trusted');
+  });
 });

--- a/src/tests/flow-graph-tests.ts
+++ b/src/tests/flow-graph-tests.ts
@@ -119,8 +119,8 @@ describe('FlowGraph', () => {
     assert.equal(node.claims.get('foo'), 'trusted');
     assert.isEmpty(node.checks);
 
-    assert.lengthOf(node.outEdges, 1);
-    assert.equal(node.outEdges[0].claim, 'trusted');
+    assert.lengthOf(graph.edges, 1);
+    assert.equal(graph.edges[0].claim, 'trusted');
   });
 
   it('copies particle checks to particle nodes and in-edges', async () => {
@@ -137,7 +137,7 @@ describe('FlowGraph', () => {
     assert.equal(node.checks.get('foo'), 'trusted');
     assert.isEmpty(node.claims);
 
-    assert.lengthOf(node.inEdges, 1);
-    assert.equal(node.inEdges[0].check, 'trusted');
+    assert.lengthOf(graph.edges, 1);
+    assert.equal(graph.edges[0].check, 'trusted');
   });
 });


### PR DESCRIPTION
This isn't used anywhere yet, but has tests. It'll be used in a follow-up PR to actually traverse the graph and validate checks against claims.

Diffbase against https://github.com/PolymerLabs/arcs/pull/3139 (first two commits are from there)