### PR TITLE
Trim down the number of import functions for wasm instantiation.

### DIFF
--- a/src/wasm/build.sh
+++ b/src/wasm/build.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 
+set -e
+
 invoke() {
   # export EMCC_DEBUG=1 for debug info
-  em++ -s EMIT_EMSCRIPTEN_METADATA -std=c++17 -O3 test-particle.cc -o $1
+  em++ -s "EXPORTED_FUNCTIONS=['_malloc', '_free']" -s EMIT_EMSCRIPTEN_METADATA \
+       -std=c++17 -O3 test-particle.cc -o $1
 }
 
 if [[ $1 = -g ]]; then

--- a/src/wasm/test-particle.cc
+++ b/src/wasm/test-particle.cc
@@ -1,4 +1,3 @@
-#include <emscripten.h>
 #include "arcs.h"
 #include "entity-data.h"
 #include "entity-info.h"
@@ -13,6 +12,7 @@ public:
 
   void onHandleSync(arcs::Handle* handle, bool allSynced) override {
     if (allSynced) {
+      console("All handles synced\n");
       requestRender("root");
     }
   }
@@ -22,31 +22,6 @@ public:
       updated_ = 1;
     } else if (handle->name() == "info") {
       updated_ = 2;
-    }
-    requestRender("root");
-  }
-
-  void fireEvent(const std::string& slotName, const std::string& handler) override {
-    if (handler == "set") {
-      arcs::Data res = data_.get();
-      res.set_num(res.num() * 2);
-      res.set_txt(res.txt() + "!!!!!!");
-      res.clear_lnk();
-      res_.set(res);
-    } else if (handler == "vclear") {
-      res_.clear();
-    } else if (handler == "store") {
-      arcs::Info info;
-      info._internal_id = "wasm" + std::to_string(++store_count_);
-      info.set_val(info_.size() + store_count_);
-      info_.store(info);
-    } else if (handler == "remove") {
-      auto it = info_.begin();
-      if (it != info_.end()) {
-        info_.remove(*it);
-      }
-    } else if (handler == "cclear") {
-      info_.clear();
     }
     requestRender("root");
   }
@@ -72,7 +47,7 @@ public:
         #info {)" + info_col + R"(}
         #panel { margin: 10px; }
         #panel pre { margin-left: 20px; }
-        th,td { padding: 4px 10px; }
+        th,td { padding: 4px 16px; }
       </style>
       <div id="panel">
         <b id="data">[data]</b>
@@ -84,15 +59,23 @@ public:
         <tr>
           <th>Singleton</th>
           <th>Collection</th>
-          <th></th>
+          <th>Errors</th>
         </tr>
         <tr>
           <td><button on-click="set">Set</button></td>
           <td><button on-click="store">Store</button></td>
+          <td>
+            <button on-click="throw">Throw</button> &nbsp;
+            <button on-click="abort">Abort</button>
+          </td>
         </tr>
         <tr>
           <td><button on-click="vclear">Clear</button></td>
           <td><button on-click="remove">Remove</button></td>
+          <td>
+            <button on-click="assert">Assert</button> &nbsp;
+            <button on-click="exit">Exit</button>
+          </td>
         </tr>
         <tr>
           <td></td>
@@ -101,6 +84,39 @@ public:
       </table>)";
 
     renderSlot(slotName.c_str(), content.c_str());
+  }
+
+  void fireEvent(const std::string& slotName, const std::string& handler) override {
+    if (handler == "set") {
+      arcs::Data res = data_.get();
+      res.set_num(res.num() * 2);
+      res.set_txt(res.txt() + "!!!!!!");
+      res.clear_lnk();
+      res_.set(res);
+    } else if (handler == "vclear") {
+      res_.clear();
+    } else if (handler == "store") {
+      arcs::Info info;
+      info._internal_id = "wasm" + std::to_string(++store_count_);
+      info.set_val(info_.size() + store_count_);
+      info_.store(info);
+    } else if (handler == "remove") {
+      auto it = info_.begin();
+      if (it != info_.end()) {
+        info_.remove(*it);
+      }
+    } else if (handler == "cclear") {
+      info_.clear();
+    } else if (handler == "throw") {
+      throw std::invalid_argument("this message doesn't get passed (yet?)");
+    } else if (handler == "assert") {
+      assert(2 + 2 == 3);
+    } else if (handler == "abort") {
+      abort();
+    } else if (handler == "exit") {
+      exit(1);
+    }
+    requestRender("root");
   }
 
   arcs::Singleton<arcs::Data> data_;


### PR DESCRIPTION
They're defined as C++ stubs which mostly redirect to a single error callback, with a couple that just implement the appropriate logic.

Weirdly, this doesn't work for one of the abort functions (there's 'abort' and '_abort') nor for abortOnCannotGrowMemory.