### PR TITLE
Replace bundle-manifest.mf with __bundle_entry.manifest

### DIFF
--- a/src/tools/bundle.ts
+++ b/src/tools/bundle.ts
@@ -30,6 +30,10 @@ export type BundleEntry = {
 export async function bundle(entryPoints: string[], bundleName: string, verbose: boolean) {
   const listing = await bundleListing(...entryPoints);
 
+  if (listing.some(file => file.bundlePath === '__bundle_entry.manifest')) {
+    throw new Error('Error: Top-level \'__bundle_entry.manifest\' file found. Please remove it.');
+  }
+
   if (verbose) {
     console.log('Bundled files:');
     listing.forEach(f => console.log(f.filePath));
@@ -48,9 +52,9 @@ export async function bundle(entryPoints: string[], bundleName: string, verbose:
         // Some unpackers have issues with 0-byte files.
         {createFolders: false});
     }
-    archive.file('bundle-manifest.mf', listing
+    archive.file('__bundle_entry.manifest', listing
         .filter(f => f.entryPoint)
-        .map(f => `entry-point: ${f.bundlePath}\n`)
+        .map(f => `import '${f.bundlePath}'\n`)
         .join(''));
     // Don't use {streamFiles: true}.
     // Java ZipInputStream does not accept the data descriptors that it generates.

--- a/src/tools/tests/bundle-test.ts
+++ b/src/tools/tests/bundle-test.ts
@@ -88,6 +88,14 @@ describe('Bundle Tool', () => {
           done();
         });
   });
+  it('fails for a top-level __bundle_entry.manifest file', done => {
+    bundle(['src/tools/tests/test-data/invalid/__bundle_entry.manifest'], 'test-output/bundle/nope.zip', false)
+        .then(_ => assert.fail('should have failed'))
+        .catch(e => {
+          assert.include(e.message, `Top-level '__bundle_entry.manifest' file found`);
+          done();
+        });
+  });
   it('bundles Products demo', async () => {
     await bundle(['src/runtime/test/artifacts/Products/Products.recipes'], 'test-output/bundle/products.zip', false);
     const data = fs.readFileSync('test-output/bundle/products.zip');
@@ -122,7 +130,7 @@ describe('Bundle Tool', () => {
       'Products/source/Recommend.js',
       'Products/source/ShowProduct.js',
       'Things/Thing.schema',
-      'bundle-manifest.mf'
+      '__bundle_entry.manifest'
     ]);
 
     // Sanity check.
@@ -132,7 +140,7 @@ describe('Bundle Tool', () => {
     );
 
     assert.equal(
-        await zip.file('bundle-manifest.mf').async('text'),
-        'entry-point: Products/Products.recipes\n');
+        await zip.file('__bundle_entry.manifest').async('text'),
+        `import 'Products/Products.recipes'\n`);
   });
 });

--- a/src/tools/tests/test-data/invalid/__bundle_entry.manifest
+++ b/src/tools/tests/test-data/invalid/__bundle_entry.manifest
@@ -1,0 +1,2 @@
+schema Thing
+  Text name


### PR DESCRIPTION
Makes it easier to compose a canonical manifest from a set of bundles, as it doesn't require processing the .mf files.

As @yuangu-google suggested.