### PR TITLE
Fix misreport due to backtracking3019

### DIFF
--- a/src/runtime/manifest-parser.peg
+++ b/src/runtime/manifest-parser.peg
@@ -41,7 +41,7 @@
       return;
     }
     if (result === undefined) {
-      throw new SyntaxError(`result was undefined`, [], "", location());
+      error(`result was undefined`);
     }
     if (Array.isArray(result)) {
       for (const item of result) {
@@ -50,13 +50,13 @@
       return;
     }
     if (result.model) {
-      throw new SyntaxError(`unexpected 'model' in ${JSON.stringify(result)}`, [], "", location());
+      error(`unexpected 'model' in ${JSON.stringify(result)}`);
     }
     if (!result.location) {
-      throw new SyntaxError(`no 'location' in ${JSON.stringify(result)}`, [], "", location());
+      error(`no 'location' in ${JSON.stringify(result)}`);
     }
     if (!result.kind) {
-      throw new SyntaxError(`no 'kind' in ${JSON.stringify(result)}`, [], "", location());
+      error(`no 'kind' in ${JSON.stringify(result)}`);
     }
     for (const key of Object.keys(result)) {
       if (['location', 'kind'].includes(key)) {
@@ -608,7 +608,7 @@ RecipeItem
   / Description
 
 LocalName
-  = 'as' whiteSpace name:lowerIdent
+  = 'as' whiteSpace name:(lowerIdent / [a-zA-Z0-9]* { expected(`lower identifier`); })
   {
     return name;
   }
@@ -1128,7 +1128,7 @@ ReservedWord
   / 'handle'
   ) ([^a-zA-Z0-9_] / !.)  // '!.' matches end-of-input
 {
-  throw new SyntaxError(`Expected identifier but keyword, '${keyword}' found.`, [], "", location());
+  expected(`identifier`);
 }
 
 backquotedString "a `backquoted string`"

--- a/tools/aml-language-server
+++ b/tools/aml-language-server
@@ -1,3 +1,3 @@
 #!/bin/sh
-cd $(dirname "$(readlink "$0")")/..
+cd $(dirname "$(readlink "$0")")
 node './dist/tools/aml-language-server.js' $@


### PR DESCRIPTION
Should fix #3019 with a manually generated error message.

This should be an example of the PEGjs error generation that will allow us to improve the errors generated by the parser.