### PR TITLE
Adds support for multiple check tags

### DIFF
--- a/src/runtime/manifest-ast-nodes.ts
+++ b/src/runtime/manifest-ast-nodes.ts
@@ -183,7 +183,7 @@ export interface ParticleTrustClaim extends BaseNode {
 export interface ParticleTrustCheck extends BaseNode {
   kind: 'particle-trust-check';
   handle: string;
-  trustTag: string;
+  trustTags: string[];
 }
 
 export interface ParticleModality extends BaseNode {

--- a/src/runtime/manifest-parser.peg
+++ b/src/runtime/manifest-parser.peg
@@ -308,14 +308,21 @@ ParticleTrustClaim
   }
 
 ParticleTrustCheck
-  = 'check' whiteSpace handle:lowerIdent whiteSpace 'is' whiteSpace trustTag:lowerIdent eolWhiteSpace
+  = 'check' whiteSpace handle:lowerIdent whiteSpace first:ParticleTrustCheckCondition rest:('or' whiteSpace ParticleTrustCheckCondition)* eolWhiteSpace
   {
+    const trustTags: string[] = [first, ...rest.map(item => item[2])];
     return {
       kind: 'particle-trust-check',
       location: location(),
       handle,
-      trustTag,
+      trustTags,
     } as AstNode.ParticleTrustCheck;
+  }
+
+ParticleTrustCheckCondition
+  = 'is' whiteSpace trustTag:lowerIdent whiteSpace?
+  {
+    return trustTag;
   }
 
 ParticleHandle

--- a/src/runtime/particle-spec.ts
+++ b/src/runtime/particle-spec.ts
@@ -131,7 +131,7 @@ export interface SerializedParticleTrustClaimSpec extends Literal {
 
 export interface SerializedParticleTrustCheckSpec extends Literal {
   handle: string;
-  trustTag: string;
+  trustTags: string[];
 }
 
 export interface SerializedParticleSpec extends Literal {
@@ -161,7 +161,7 @@ export class ParticleSpec {
 
   // Trust claims/checks: maps from handle name to a "trust tag".
   trustClaims: Map<string, string>;
-  trustChecks: Map<string, string>;
+  trustChecks: Map<string, string[]>;
 
   constructor(model: SerializedParticleSpec) {
     this.model = model;
@@ -380,14 +380,14 @@ export class ParticleSpec {
     return results;
   }
 
-  private validateTrustChecks(checks?: SerializedParticleTrustCheckSpec[]): Map<string, string> {
-    const results: Map<string, string> = new Map();
+  private validateTrustChecks(checks?: SerializedParticleTrustCheckSpec[]): Map<string, string[]> {
+    const results: Map<string, string[]> = new Map();
     if (checks) {
       checks.forEach(check => {
         assert(this.handleConnectionMap.has(check.handle), `Can't make a check on unknown handle ${check.handle}.`);
         const handle = this.handleConnectionMap.get(check.handle);
         assert(handle.isInput, `Can't make a check on handle ${check.handle} (not an input handle).`);
-        results.set(check.handle, check.trustTag);
+        results.set(check.handle, check.trustTags);
       });
     }
     return results;

--- a/src/runtime/test/manifest-test.ts
+++ b/src/runtime/test/manifest-test.ts
@@ -1990,8 +1990,21 @@ resource SomeName
       assert.lengthOf(manifest.particles, 1);
       const particle = manifest.particles[0];
       assert.equal(particle.trustChecks.size, 2);
-      assert.equal(particle.trustChecks.get('input1'), 'property1');
-      assert.equal(particle.trustChecks.get('input2'), 'property2');
+      assert.sameMembers(particle.trustChecks.get('input1'), ['property1']);
+      assert.sameMembers(particle.trustChecks.get('input2'), ['property2']);
+      assert.isEmpty(particle.trustClaims);
+    });
+
+    it('supports checks with multiple tags', async () => {
+      const manifest = await Manifest.parse(`
+        particle A
+          in T {} input
+          check input is property1 or is property2
+      `);
+      assert.lengthOf(manifest.particles, 1);
+      const particle = manifest.particles[0];
+      assert.equal(particle.trustChecks.size, 1);
+      assert.sameMembers(particle.trustChecks.get('input'), ['property1', 'property2']);
       assert.isEmpty(particle.trustClaims);
     });
 


### PR DESCRIPTION
Now you can write checks like `check foo is public or is trusted`, and the dataflow analyser will understand that correctly.