### PR TITLE
Added support for "claim ... derives from ..." statements

### DIFF
--- a/src/dataflow/flow-graph.ts
+++ b/src/dataflow/flow-graph.ts
@@ -12,6 +12,7 @@ import {Particle} from '../runtime/recipe/particle';
 import {Handle} from '../runtime/recipe/handle';
 import {HandleConnection} from '../runtime/recipe/handle-connection';
 import {assert} from '../platform/assert-web';
+import {ParticleTrustClaim, ParticleTrustClaimType, ParticleTrustClaimTag} from '../runtime/manifest-ast-nodes';
 
 /**
  * Data structure for representing the connectivity graph of a recipe. Used to perform static analysis on a resolved recipe.
@@ -193,14 +194,14 @@ function addHandleConnection(particleNode: ParticleNode, handleNode: HandleNode,
   switch (connection.direction) {
     case 'in': {
       const edge = new ParticleInput(particleNode, handleNode, connection.name);
-      particleNode.inEdges.push(edge);
-      handleNode.outEdges.push(edge);
+      particleNode.addInEdge(edge);
+      handleNode.addOutEdge(edge);
       return edge;
     }
     case 'out': {
       const edge = new ParticleOutput(particleNode, handleNode, connection.name);
-      particleNode.outEdges.push(edge);
-      handleNode.inEdges.push(edge);
+      particleNode.addOutEdge(edge);
+      handleNode.addInEdge(edge);
       return edge;
     }
     case 'inout': // TODO: Handle inout directions.
@@ -217,9 +218,9 @@ export class Check {
       readonly acceptedTags: readonly string[]) {}
 
   /** Returns true if the given claim satisfies the check condition. */
-  checkAgainstClaim(claim: string): boolean {
+  checkAgainstClaim(claim: ParticleTrustClaimTag): boolean {
     for (const tag of this.acceptedTags) {
-      if (tag === claim) {
+      if (tag === claim.tag) {
         return true;
       }
     }
@@ -232,8 +233,11 @@ export class Check {
 }
 
 export abstract class Node {
-  abstract readonly inEdges: Edge[];
-  abstract readonly outEdges: Edge[];
+  abstract readonly inEdges: readonly Edge[];
+  abstract readonly outEdges: readonly Edge[];
+
+  abstract addInEdge(edge: Edge): void;
+  abstract addOutEdge(edge: Edge): void;
 
   abstract evaluateCheck(check: Check, edgeToCheck: Edge, path: BackwardsPath): CheckResult;
 
@@ -256,17 +260,18 @@ export interface Edge {
   /** The qualified name of the handle this edge represents, e.g. "MyParticle.output1". */
   readonly label: string;
 
-  readonly claim?: string;
+  readonly claim?: ParticleTrustClaim;
   readonly check?: Check;
 }
 
 class ParticleNode extends Node {
-  readonly inEdges: ParticleInput[] = [];
-  readonly outEdges: ParticleOutput[] = [];
+  readonly inEdgesByName: Map<string, ParticleInput> = new Map();
+  readonly outEdgesByName: Map<string, ParticleOutput> = new Map();
+
   readonly name: string;
 
   // Maps from handle names to tags.
-  readonly claims: Map<string, string>;
+  readonly claims: Map<string, ParticleTrustClaim>;
   readonly checks: Map<string, Check> = new Map();
 
   constructor(particle: Particle) {
@@ -278,6 +283,22 @@ class ParticleNode extends Node {
       this.checks.set(handle, new Check(tags));
     });
   }
+    
+  addInEdge(edge: ParticleInput) {
+    this.inEdgesByName.set(edge.handleName, edge);
+  }
+  
+  addOutEdge(edge: ParticleOutput) {
+    this.outEdgesByName.set(edge.handleName, edge);
+  }
+  
+  get inEdges(): readonly Edge[] {
+    return [...this.inEdgesByName.values()];
+  }
+
+  get outEdges(): readonly Edge[] {
+    return [...this.outEdgesByName.values()];
+  }
 
   evaluateCheck(check: Check, edgeToCheck: ParticleOutput, path: BackwardsPath): CheckResult {
     assert(this.outEdges.includes(edgeToCheck), 'Particles can only check their own out-edges.');
@@ -285,10 +306,26 @@ class ParticleNode extends Node {
     // First check if this particle makes an explicit claim on this out-edge.
     const claim = this.claims.get(edgeToCheck.handleName);
     if (claim) {
-      if (check.checkAgainstClaim(claim)) {
-        return {type: CheckResultType.Success};
-      } else {
-        return {type: CheckResultType.Failure, reason: `Check '${check}' failed: found claim '${claim}' on '${edgeToCheck.label}' instead.`};
+      switch (claim.claimType) {
+        case ParticleTrustClaimType.Tag:
+          if (check.checkAgainstClaim(claim)) {
+            return {type: CheckResultType.Success};
+          } else {
+            return {
+              type: CheckResultType.Failure,
+              reason: `Check '${check}' failed: found claim '${claim.tag}' on '${edgeToCheck.label}' instead.`,
+            };
+          }
+        case ParticleTrustClaimType.DerivesFrom:
+          const checkNext: BackwardsPath[] = [];
+          for (const handle of claim.parentHandles) {
+            const edge = this.inEdgesByName.get(handle);
+            assert(!!edge, `Claim derives from unknown handle: ${handle}.`);
+            checkNext.push(path.withNewEdge(edge));
+          }
+          return {type: CheckResultType.KeepGoing, checkNext};
+        default:
+          assert(false, 'Unknown claim type.');
       }
     }
 
@@ -327,7 +364,7 @@ class ParticleOutput implements Edge {
   readonly handleName: string;
 
   /* Optional claim on this output. */
-  readonly claim?: string;
+  readonly claim?: ParticleTrustClaim;
 
   constructor(particleNode: ParticleNode, otherEnd: Node, outputName: string) {
     this.start = particleNode;
@@ -355,6 +392,14 @@ class HandleNode extends Node {
       });
     });
     return connections;
+  }
+
+  addInEdge(edge: ParticleOutput) {
+    this.inEdges.push(edge);
+  }
+
+  addOutEdge(edge: ParticleInput) {
+    this.outEdges.push(edge);
   }
 
   evaluateCheck(check: Check, edgeToCheck: ParticleInput, path: BackwardsPath): CheckResult {

--- a/src/runtime/manifest-ast-nodes.ts
+++ b/src/runtime/manifest-ast-nodes.ts
@@ -174,11 +174,26 @@ export interface Particle extends BaseNode {
   slotConnections?: RecipeParticleSlotConnection[];
 }
 
-export interface ParticleTrustClaim extends BaseNode {
-  kind: 'particle-trust-claim';
-  handle: string;
-  trustTag: string;
+export enum ParticleTrustClaimType {
+  Tag = 'is',
+  DerivesFrom = 'derives from',
 }
+
+export interface ParticleTrustClaimTag {
+  claimType: ParticleTrustClaimType.Tag;
+  handle: string;
+  tag: string;
+}
+
+export interface ParticleTrustClaimDerivesFrom {
+  claimType: ParticleTrustClaimType.DerivesFrom;
+  handle: string;
+  parentHandles: string[];
+}
+
+export type ParticleTrustClaim = ParticleTrustClaimTag | ParticleTrustClaimDerivesFrom;
+
+export type ParticleTrustClaimNode = ParticleTrustClaim & BaseNode & {kind: 'particle-trust-claim'};
 
 export interface ParticleTrustCheck extends BaseNode {
   kind: 'particle-trust-check';

--- a/src/runtime/manifest-ast-nodes.ts
+++ b/src/runtime/manifest-ast-nodes.ts
@@ -174,26 +174,33 @@ export interface Particle extends BaseNode {
   slotConnections?: RecipeParticleSlotConnection[];
 }
 
+/** The different types of trust claims that particles can make. */
 export enum ParticleTrustClaimType {
-  Tag = 'is',
-  DerivesFrom = 'derives from',
+  IsTag,
+  DerivesFrom,
 }
 
-export interface ParticleTrustClaimTag {
-  claimType: ParticleTrustClaimType.Tag;
+/** A claim made by a particle, saying that one of its outputs has a particular trust tag (e.g. "claim output is foo"). */
+export interface ParticleTrustClaimIsTag extends BaseNode {
+  kind: 'particle-trust-claim-is-tag';
+  claimType: ParticleTrustClaimType.IsTag;
   handle: string;
   tag: string;
 }
 
-export interface ParticleTrustClaimDerivesFrom {
+/**
+ * A claim made by a particle, saying that one of its outputs derives from one/some of its inputs (e.g. "claim output derives from input1 and
+ * input2").
+ */
+export interface ParticleTrustClaimDerivesFrom extends BaseNode {
+  kind: 'particle-trust-claim-derives-from';
   claimType: ParticleTrustClaimType.DerivesFrom;
   handle: string;
   parentHandles: string[];
 }
 
-export type ParticleTrustClaim = ParticleTrustClaimTag | ParticleTrustClaimDerivesFrom;
-
-export type ParticleTrustClaimNode = ParticleTrustClaim & BaseNode & {kind: 'particle-trust-claim'};
+/** A trust claim made by a particle. */
+export type ParticleTrustClaim = ParticleTrustClaimIsTag | ParticleTrustClaimDerivesFrom;
 
 export interface ParticleTrustCheck extends BaseNode {
   kind: 'particle-trust-check';

--- a/src/runtime/manifest-parser.peg
+++ b/src/runtime/manifest-parser.peg
@@ -297,15 +297,62 @@ ParticleItem "a particle item"
   / ParticleTrustCheck
 
 ParticleTrustClaim
-  = 'claim' whiteSpace handle:lowerIdent whiteSpace 'is' whiteSpace trustTag:lowerIdent eolWhiteSpace
+  = 'claim' whiteSpace handle:lowerIdent whiteSpace operation:('is' / 'derives from') whiteSpace first:lowerIdent rest:(whiteSpace 'and' whiteSpace lowerIdent)* eolWhiteSpace
   {
-    return {
+    const baseNode = {
       kind: 'particle-trust-claim',
       location: location(),
-      handle,
-      trustTag,
-    } as AstNode.ParticleTrustClaim;
+    };
+    switch (operation) {
+      case 'is':
+        if (rest.length) {
+          error('Claims can only have one tag.');
+        }
+        return {
+          ...baseNode,
+          claimType: AstNode.ParticleTrustClaimType.Tag,
+          tag: first,
+          handle,
+        } as AstNode.ParticleTrustClaim;
+      case 'derives from':
+        const parentHandles: string[] = [first, ...rest.map(item => item[3])];
+        return {
+          ...baseNode,
+          claimType: AstNode.ParticleTrustClaimType.DerivesFrom,
+          handle,
+          parentHandles,
+        } as AstNode.ParticleTrustClaim;
+      default:
+        return error(`unknown claim type: '${operation}'.`);
+    }
   }
+
+//ParticleTrustClaim
+//  = ParticleTrustClaimIsTag
+//  / ParticleTrustClaimDerivesFrom
+//
+//ParticleTrustClaimIsTag
+//  = 'claim' whiteSpace handle:lowerIdent whiteSpace 'is' whiteSpace trustTag:lowerIdent eolWhiteSpace
+//  {
+//    return {
+//      kind: 'particle-trust-claim-is-tag',
+//      location: location(),
+//      handle,
+//      trustTag,
+//    } as AstNode.ParticleTrustClaimIsTag;
+//  }
+//
+//ParticleTrustClaimDerivesFrom
+//  = 'claim' whiteSpace handle:lowerIdent whiteSpace 'derives from' whiteSpace first:lowerIdent rest:(whiteSpace 'and' whiteSpace lowerIdent)* eolWhiteSpace
+//  {
+//    const parentHandles: string[] = [first, ...rest.map(item => item[3])];
+//    return {
+//      claimType: 'particles-trust-claim-derives-from',
+//      location: location(),
+//      handle,
+//      parentHandles,
+//    };
+//  }
 
 ParticleTrustCheck
   = 'check' whiteSpace handle:lowerIdent whiteSpace first:ParticleTrustCheckCondition rest:('or' whiteSpace ParticleTrustCheckCondition)* eolWhiteSpace

--- a/src/runtime/manifest-parser.peg
+++ b/src/runtime/manifest-parser.peg
@@ -257,7 +257,7 @@ Particle
           location: location() // TODO: FIXME Get the locations of the item descriptions.
         } as AstNode.Description;
         item.description.forEach(d => description[d.name] = d.pattern || d.patterns[0]);
-      } else if (item.kind === 'particle-trust-claim') {
+      } else if (item.kind === 'particle-trust-claim-is-tag' || item.kind === 'particle-trust-claim-derives-from') {
         trustClaims.push(item);
       } else if (item.kind === 'particle-trust-check') {
         trustChecks.push(item);
@@ -297,62 +297,33 @@ ParticleItem "a particle item"
   / ParticleTrustCheck
 
 ParticleTrustClaim
-  = 'claim' whiteSpace handle:lowerIdent whiteSpace operation:('is' / 'derives from') whiteSpace first:lowerIdent rest:(whiteSpace 'and' whiteSpace lowerIdent)* eolWhiteSpace
+  = ParticleTrustClaimIsTag
+  / ParticleTrustClaimDerivesFrom
+
+ParticleTrustClaimIsTag
+  = 'claim' whiteSpace handle:lowerIdent whiteSpace 'is' whiteSpace tag:lowerIdent eolWhiteSpace
   {
-    const baseNode = {
-      kind: 'particle-trust-claim',
+    return {
+      kind: 'particle-trust-claim-is-tag',
+      claimType: AstNode.ParticleTrustClaimType.IsTag,
       location: location(),
-    };
-    switch (operation) {
-      case 'is':
-        if (rest.length) {
-          error('Claims can only have one tag.');
-        }
-        return {
-          ...baseNode,
-          claimType: AstNode.ParticleTrustClaimType.Tag,
-          tag: first,
-          handle,
-        } as AstNode.ParticleTrustClaim;
-      case 'derives from':
-        const parentHandles: string[] = [first, ...rest.map(item => item[3])];
-        return {
-          ...baseNode,
-          claimType: AstNode.ParticleTrustClaimType.DerivesFrom,
-          handle,
-          parentHandles,
-        } as AstNode.ParticleTrustClaim;
-      default:
-        return error(`unknown claim type: '${operation}'.`);
-    }
+      handle,
+      tag,
+    } as AstNode.ParticleTrustClaimIsTag;
   }
 
-//ParticleTrustClaim
-//  = ParticleTrustClaimIsTag
-//  / ParticleTrustClaimDerivesFrom
-//
-//ParticleTrustClaimIsTag
-//  = 'claim' whiteSpace handle:lowerIdent whiteSpace 'is' whiteSpace trustTag:lowerIdent eolWhiteSpace
-//  {
-//    return {
-//      kind: 'particle-trust-claim-is-tag',
-//      location: location(),
-//      handle,
-//      trustTag,
-//    } as AstNode.ParticleTrustClaimIsTag;
-//  }
-//
-//ParticleTrustClaimDerivesFrom
-//  = 'claim' whiteSpace handle:lowerIdent whiteSpace 'derives from' whiteSpace first:lowerIdent rest:(whiteSpace 'and' whiteSpace lowerIdent)* eolWhiteSpace
-//  {
-//    const parentHandles: string[] = [first, ...rest.map(item => item[3])];
-//    return {
-//      claimType: 'particles-trust-claim-derives-from',
-//      location: location(),
-//      handle,
-//      parentHandles,
-//    };
-//  }
+ParticleTrustClaimDerivesFrom
+  = 'claim' whiteSpace handle:lowerIdent whiteSpace 'derives from' whiteSpace first:lowerIdent rest:(whiteSpace 'and' whiteSpace lowerIdent)* eolWhiteSpace
+  {
+    const parentHandles: string[] = [first, ...rest.map(item => item[3])];
+    return {
+      kind: 'particle-trust-claim-derives-from',
+      claimType: AstNode.ParticleTrustClaimType.DerivesFrom,
+      location: location(),
+      handle,
+      parentHandles,
+    } as AstNode.ParticleTrustClaimDerivesFrom;
+  }
 
 ParticleTrustCheck
   = 'check' whiteSpace handle:lowerIdent whiteSpace first:ParticleTrustCheckCondition rest:('or' whiteSpace ParticleTrustCheckCondition)* eolWhiteSpace

--- a/src/runtime/particle-spec.ts
+++ b/src/runtime/particle-spec.ts
@@ -9,7 +9,6 @@
  */
 
 import {assert} from '../platform/assert-web.js';
-
 import {Modality} from './modality.js';
 import {Direction, ParticleTrustClaim, ParticleTrustCheck, ParticleTrustClaimType} from './manifest-ast-nodes.js';
 import {TypeChecker} from './recipe/type-checker.js';
@@ -361,10 +360,16 @@ export class ParticleSpec {
     const results: Map<string, ParticleTrustClaim> = new Map();
     if (claims) {
       claims.forEach(claim => {
-        assert(!results.has(claim.handle), `Can't make multiple claims on the same output (${claim.handle}).`);
-        assert(this.handleConnectionMap.has(claim.handle), `Can't make a claim on unknown handle ${claim.handle}.`);
+        if (results.has(claim.handle)) {
+          throw new Error(`Can't make multiple claims on the same output (${claim.handle}).`);
+        }
+        if (!this.handleConnectionMap.has(claim.handle)) {
+          throw new Error(`Can't make a claim on unknown handle ${claim.handle}.`);
+        }
         const handle = this.handleConnectionMap.get(claim.handle);
-        assert(handle.isOutput, `Can't make a claim on handle ${claim.handle} (not an output handle).`);
+        if (!handle.isOutput) {
+          throw new Error(`Can't make a claim on handle ${claim.handle} (not an output handle).`);
+        }
         results.set(claim.handle, claim);
       });
     }
@@ -375,10 +380,16 @@ export class ParticleSpec {
     const results: Map<string, string[]> = new Map();
     if (checks) {
       checks.forEach(check => {
-        assert(!results.has(check.handle), `Can't make multiple checks on the same input (${check.handle}).`);
-        assert(this.handleConnectionMap.has(check.handle), `Can't make a check on unknown handle ${check.handle}.`);
+        if (results.has(check.handle)) {
+          throw new Error(`Can't make multiple checks on the same input (${check.handle}).`);
+        }
+        if (!this.handleConnectionMap.has(check.handle)) {
+          throw new Error(`Can't make a check on unknown handle ${check.handle}.`);
+        }
         const handle = this.handleConnectionMap.get(check.handle);
-        assert(handle.isInput, `Can't make a check on handle ${check.handle} (not an input handle).`);
+        if (!handle.isInput) {
+          throw new Error(`Can't make a check on handle ${check.handle} (not an input handle).`);
+        }
         results.set(check.handle, check.trustTags);
       });
     }

--- a/src/runtime/test/manifest-test.ts
+++ b/src/runtime/test/manifest-test.ts
@@ -19,6 +19,7 @@ import {checkDefined, checkNotNull} from '../testing/preconditions.js';
 import {StubLoader} from '../testing/stub-loader.js';
 import {Dictionary} from '../hot.js';
 import {assertThrowsAsync} from '../testing/test-util.js';
+import {ParticleTrustClaimType, ParticleTrustClaimTag, ParticleTrustClaim} from '../manifest-ast-nodes.js';
 
 async function assertRecipeParses(input: string, result: string) : Promise<void> {
   // Strip common leading whitespace.
@@ -1973,8 +1974,30 @@ resource SomeName
       assert.lengthOf(manifest.particles, 1);
       const particle = manifest.particles[0];
       assert.equal(particle.trustClaims.size, 2);
-      assert.equal(particle.trustClaims.get('output1'), 'property1');
-      assert.equal(particle.trustClaims.get('output2'), 'property2');
+      const expectedClaim1: ParticleTrustClaim = {claimType: ParticleTrustClaimType.Tag, handle: 'output1', tag: 'property1'};
+      assert.deepNestedInclude(particle.trustClaims.get('output1'), expectedClaim1);
+      const expectedClaim2: ParticleTrustClaim = {claimType: ParticleTrustClaimType.Tag, handle: 'output2', tag: 'property2'};
+      assert.deepNestedInclude(particle.trustClaims.get('output2'), expectedClaim2);
+      assert.isEmpty(particle.trustChecks);
+    });
+
+    it('supports "derives from" claims with multiple parents', async () => {
+      const manifest = await Manifest.parse(`
+        particle A
+          in T {} input1
+          in T {} input2
+          out T {} output
+          claim output derives from input1 and input2
+      `);
+      assert.lengthOf(manifest.particles, 1);
+      const particle = manifest.particles[0];
+      assert.equal(particle.trustClaims.size, 1);
+      const expectedClaim: ParticleTrustClaim = {
+        claimType: ParticleTrustClaimType.DerivesFrom,
+        handle: 'output',
+        parentHandles: ['input1', 'input2'],
+      };
+      assert.deepNestedInclude(particle.trustClaims.get('output'), expectedClaim);
       assert.isEmpty(particle.trustChecks);
     });
 
@@ -2035,6 +2058,32 @@ resource SomeName
           out T {} foo
           check foo is trusted
       `), `Can't make a check on handle foo (not an input handle)`);
+    });
+
+    it(`doesn't allow multiple different claims for the same output`, async () => {
+      assertThrowsAsync(async () => await Manifest.parse(`
+        particle A
+          out T {} foo
+          claim foo is trusted
+          claim foo is trusted
+      `), `Can't make multiple claims on the same output (foo)`);
+    });
+
+    it(`doesn't allow multiple different checks for the same input`, async () => {
+      assertThrowsAsync(async () => await Manifest.parse(`
+        particle A
+          in T {} foo
+          check foo is trusted
+          check foo is trusted
+      `), `Can't make multiple checks on the same input (foo)`);
+    });
+
+    it(`doesn't allow claims to specify more than one tag`, async () => {
+      assertThrowsAsync(async () => await Manifest.parse(`
+        particle A
+          out T {} output
+          claim output is tag1 and tag2
+      `, 'asgfasedfgasf'));
     });
   });
 });

--- a/src/runtime/test/manifest-test.ts
+++ b/src/runtime/test/manifest-test.ts
@@ -19,7 +19,7 @@ import {checkDefined, checkNotNull} from '../testing/preconditions.js';
 import {StubLoader} from '../testing/stub-loader.js';
 import {Dictionary} from '../hot.js';
 import {assertThrowsAsync} from '../testing/test-util.js';
-import {ParticleTrustClaimType, ParticleTrustClaimTag, ParticleTrustClaim} from '../manifest-ast-nodes.js';
+import {ParticleTrustClaimType} from '../manifest-ast-nodes.js';
 
 async function assertRecipeParses(input: string, result: string) : Promise<void> {
   // Strip common leading whitespace.
@@ -1974,10 +1974,16 @@ resource SomeName
       assert.lengthOf(manifest.particles, 1);
       const particle = manifest.particles[0];
       assert.equal(particle.trustClaims.size, 2);
-      const expectedClaim1: ParticleTrustClaim = {claimType: ParticleTrustClaimType.Tag, handle: 'output1', tag: 'property1'};
-      assert.deepNestedInclude(particle.trustClaims.get('output1'), expectedClaim1);
-      const expectedClaim2: ParticleTrustClaim = {claimType: ParticleTrustClaimType.Tag, handle: 'output2', tag: 'property2'};
-      assert.deepNestedInclude(particle.trustClaims.get('output2'), expectedClaim2);
+      assert.deepNestedInclude(particle.trustClaims.get('output1'), {
+        claimType: ParticleTrustClaimType.IsTag,
+        handle: 'output1',
+        tag: 'property1',
+      });
+      assert.deepNestedInclude(particle.trustClaims.get('output2'), {
+        claimType: ParticleTrustClaimType.IsTag,
+        handle: 'output2',
+        tag: 'property2',
+      });
       assert.isEmpty(particle.trustChecks);
     });
 
@@ -1992,12 +1998,11 @@ resource SomeName
       assert.lengthOf(manifest.particles, 1);
       const particle = manifest.particles[0];
       assert.equal(particle.trustClaims.size, 1);
-      const expectedClaim: ParticleTrustClaim = {
+      assert.deepNestedInclude(particle.trustClaims.get('output'), {
         claimType: ParticleTrustClaimType.DerivesFrom,
         handle: 'output',
         parentHandles: ['input1', 'input2'],
-      };
-      assert.deepNestedInclude(particle.trustClaims.get('output'), expectedClaim);
+      });
       assert.isEmpty(particle.trustChecks);
     });
 

--- a/src/tests/flow-graph-tests.ts
+++ b/src/tests/flow-graph-tests.ts
@@ -118,7 +118,7 @@ describe('FlowGraph', () => {
     `);
     const node = checkDefined(graph.particleMap.get('P'));
     assert.equal(node.claims.size, 1);
-    const expectedClaim: ParticleTrustClaim = {claimType: ParticleTrustClaimType.Tag, handle: 'foo', tag: 'trusted'};
+    const expectedClaim = {claimType: ParticleTrustClaimType.IsTag, handle: 'foo', tag: 'trusted'};
     assert.deepNestedInclude(node.claims.get('foo'), expectedClaim);
     assert.isEmpty(node.checks);
 

--- a/src/tests/flow-graph-tests.ts
+++ b/src/tests/flow-graph-tests.ts
@@ -11,6 +11,7 @@ import {Manifest} from '../runtime/manifest.js';
 import {assert} from '../platform/chai-web.js';
 import {checkDefined} from '../runtime/testing/preconditions.js';
 import {FlowGraph, Node, Edge, CheckResult, CheckResultType, BackwardsPath, Check} from '../dataflow/flow-graph.js';
+import {ParticleTrustClaimType, ParticleTrustClaim} from '../runtime/manifest-ast-nodes.js';
 
 async function buildFlowGraph(manifestContent: string): Promise<FlowGraph> {
   const manifest = await Manifest.parse(manifestContent);
@@ -117,11 +118,12 @@ describe('FlowGraph', () => {
     `);
     const node = checkDefined(graph.particleMap.get('P'));
     assert.equal(node.claims.size, 1);
-    assert.equal(node.claims.get('foo'), 'trusted');
+    const expectedClaim: ParticleTrustClaim = {claimType: ParticleTrustClaimType.Tag, handle: 'foo', tag: 'trusted'};
+    assert.deepNestedInclude(node.claims.get('foo'), expectedClaim);
     assert.isEmpty(node.checks);
 
     assert.lengthOf(graph.edges, 1);
-    assert.equal(graph.edges[0].claim, 'trusted');
+    assert.deepNestedInclude(graph.edges[0].claim, expectedClaim);
   });
 
   it('copies particle checks to particle nodes and in-edges', async () => {
@@ -430,8 +432,16 @@ class TestNode extends Node {
   readonly inEdges: TestEdge[] = [];
   readonly outEdges: TestEdge[] = [];
   
+  addInEdge() {
+    throw new Error('Unimplemented.');
+  }
+
+  addOutEdge() {
+    throw new Error('Unimplemented.');
+  }
+
   evaluateCheck(check: Check, edge: Edge): CheckResult {
-    return {type: CheckResultType.Success};
+    throw new Error('Unimplemented.');
   }
 }
 


### PR DESCRIPTION
Refactored claims to no longer be raw strings, they are now their own proper type (a union of the two different types of claims):

```
type ParticleTrustClaim = ParticleTrustClaimTag | ParticleTrustClaimDerivesFrom;
```

Also removed `SerializedParticleTrustCheckSpec`, etc., since these types were just complete copies of the existing AST nodes and didn't really add anything.