### PR TITLE
Renames the claim/check AST node classes

### DIFF
--- a/src/dataflow/analysis/flow-graph.ts
+++ b/src/dataflow/analysis/flow-graph.ts
@@ -7,13 +7,13 @@
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
-import {Recipe} from '../runtime/recipe/recipe';
-import {Particle} from '../runtime/recipe/particle';
-import {Handle} from '../runtime/recipe/handle';
-import {HandleConnection} from '../runtime/recipe/handle-connection';
-import {assert} from '../platform/assert-web';
-import {ParticleClaimStatement, ParticleClaimIsTag} from '../runtime/manifest-ast-nodes';
-import {ClaimType} from '../runtime/particle-claim';
+import {Recipe} from '../../runtime/recipe/recipe';
+import {Particle} from '../../runtime/recipe/particle';
+import {Handle} from '../../runtime/recipe/handle';
+import {HandleConnection} from '../../runtime/recipe/handle-connection';
+import {assert} from '../../platform/assert-web';
+import {ParticleClaimStatement, ParticleClaimIsTag} from '../../runtime/manifest-ast-nodes';
+import {ClaimType} from '../../runtime/particle-claim';
 
 /**
  * Data structure for representing the connectivity graph of a recipe. Used to perform static analysis on a resolved recipe.

--- a/src/dataflow/analysis/flow-graph.ts
+++ b/src/dataflow/analysis/flow-graph.ts
@@ -7,12 +7,13 @@
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
-import {Recipe} from '../../runtime/recipe/recipe';
-import {Particle} from '../../runtime/recipe/particle';
-import {Handle} from '../../runtime/recipe/handle';
-import {HandleConnection} from '../../runtime/recipe/handle-connection';
-import {assert} from '../../platform/assert-web';
-import {ParticleTrustClaim, ParticleTrustClaimType, ParticleTrustClaimIsTag} from '../../runtime/manifest-ast-nodes';
+import {Recipe} from '../runtime/recipe/recipe';
+import {Particle} from '../runtime/recipe/particle';
+import {Handle} from '../runtime/recipe/handle';
+import {HandleConnection} from '../runtime/recipe/handle-connection';
+import {assert} from '../platform/assert-web';
+import {ParticleClaimStatement, ParticleClaimIsTag} from '../runtime/manifest-ast-nodes';
+import {ClaimType} from '../runtime/particle-claim';
 
 /**
  * Data structure for representing the connectivity graph of a recipe. Used to perform static analysis on a resolved recipe.
@@ -218,7 +219,7 @@ export class Check {
       readonly acceptedTags: readonly string[]) {}
 
   /** Returns true if the given claim satisfies the check condition. */
-  checkAgainstClaim(claim: ParticleTrustClaimIsTag): boolean {
+  checkAgainstClaim(claim: ParticleClaimIsTag): boolean {
     for (const tag of this.acceptedTags) {
       if (tag === claim.tag) {
         return true;
@@ -260,7 +261,7 @@ export interface Edge {
   /** The qualified name of the handle this edge represents, e.g. "MyParticle.output1". */
   readonly label: string;
 
-  readonly claim?: ParticleTrustClaim;
+  readonly claim?: ParticleClaimStatement;
   readonly check?: Check;
 }
 
@@ -271,7 +272,7 @@ class ParticleNode extends Node {
   readonly name: string;
 
   // Maps from handle names to tags.
-  readonly claims: Map<string, ParticleTrustClaim>;
+  readonly claims: Map<string, ParticleClaimStatement>;
   readonly checks: Map<string, Check> = new Map();
 
   constructor(particle: Particle) {
@@ -307,7 +308,7 @@ class ParticleNode extends Node {
     const claim = this.claims.get(edgeToCheck.handleName);
     if (claim) {
       switch (claim.claimType) {
-        case ParticleTrustClaimType.IsTag: {
+        case ClaimType.IsTag: {
           // The particle has claimed a specific tag for its output. Check if that tag passes the check, otherwise fail.
           if (check.checkAgainstClaim(claim)) {
             return {type: CheckResultType.Success};
@@ -318,7 +319,7 @@ class ParticleNode extends Node {
             };
           }
         }
-        case ParticleTrustClaimType.DerivesFrom: {
+        case ClaimType.DerivesFrom: {
           // The particle's output derives from some of its inputs. Continue searching the graph from those inputs.
           const checkNext: BackwardsPath[] = [];
           for (const handle of claim.parentHandles) {
@@ -368,7 +369,7 @@ class ParticleOutput implements Edge {
   readonly handleName: string;
 
   /* Optional claim on this output. */
-  readonly claim?: ParticleTrustClaim;
+  readonly claim?: ParticleClaimStatement;
 
   constructor(particleNode: ParticleNode, otherEnd: Node, outputName: string) {
     this.start = particleNode;

--- a/src/dataflow/analysis/tests/flow-graph-tests.ts
+++ b/src/dataflow/analysis/tests/flow-graph-tests.ts
@@ -7,11 +7,11 @@
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
-import {Manifest} from '../../../runtime/manifest.js';
-import {assert} from '../../../platform/chai-web.js';
-import {checkDefined} from '../../../runtime/testing/preconditions.js';
-import {FlowGraph, Node, Edge, CheckResult, CheckResultType, BackwardsPath, Check} from '../flow-graph.js';
-import {ParticleTrustClaimType, ParticleTrustClaim} from '../../../runtime/manifest-ast-nodes.js';
+import {Manifest} from '../runtime/manifest.js';
+import {assert} from '../platform/chai-web.js';
+import {checkDefined} from '../runtime/testing/preconditions.js';
+import {FlowGraph, Node, Edge, CheckResult, CheckResultType, BackwardsPath, Check} from '../dataflow/flow-graph.js';
+import {ClaimType} from '../runtime/particle-claim.js';
 
 async function buildFlowGraph(manifestContent: string): Promise<FlowGraph> {
   const manifest = await Manifest.parse(manifestContent);
@@ -118,7 +118,7 @@ describe('FlowGraph', () => {
     `);
     const node = checkDefined(graph.particleMap.get('P'));
     assert.equal(node.claims.size, 1);
-    const expectedClaim = {claimType: ParticleTrustClaimType.IsTag, handle: 'foo', tag: 'trusted'};
+    const expectedClaim = {claimType: ClaimType.IsTag, handle: 'foo', tag: 'trusted'};
     assert.deepNestedInclude(node.claims.get('foo'), expectedClaim);
     assert.isEmpty(node.checks);
 

--- a/src/dataflow/analysis/tests/flow-graph-tests.ts
+++ b/src/dataflow/analysis/tests/flow-graph-tests.ts
@@ -7,11 +7,11 @@
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
-import {Manifest} from '../runtime/manifest.js';
-import {assert} from '../platform/chai-web.js';
-import {checkDefined} from '../runtime/testing/preconditions.js';
-import {FlowGraph, Node, Edge, CheckResult, CheckResultType, BackwardsPath, Check} from '../dataflow/flow-graph.js';
-import {ClaimType} from '../runtime/particle-claim.js';
+import {Manifest} from '../../../runtime/manifest.js';
+import {assert} from '../../../platform/chai-web.js';
+import {checkDefined} from '../../../runtime/testing/preconditions.js';
+import {FlowGraph, Node, Edge, CheckResult, CheckResultType, BackwardsPath, Check} from '../flow-graph.js';
+import {ClaimType} from '../../../runtime/particle-claim.js';
 
 async function buildFlowGraph(manifestContent: string): Promise<FlowGraph> {
   const manifest = await Manifest.parse(manifestContent);

--- a/src/runtime/manifest-ast-nodes.ts
+++ b/src/runtime/manifest-ast-nodes.ts
@@ -1,12 +1,13 @@
 /**
  * @license
- * Copyright (c) 2019 Google Inc. All rights reserved.
+ * Copyright 2019 Google LLC.
  * This code may only be used under the BSD style license found at
  * http://polymer.github.io/LICENSE.txt
  * Code distributed by Google as part of this project is also
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
+import {ClaimType} from './particle-claim';
 
 /**
  * Complete set of tokens used by `manifest-parser.peg`. To use this you
@@ -165,8 +166,8 @@ export interface Particle extends BaseNode {
   slots?: ParticleSlot[];    // not used in RecipeParticle
   description?: Description;  // not used in RecipeParticle
   hasParticleArgument?: boolean;  // not used in RecipeParticle
-  trustChecks?: ParticleTrustCheck[];
-  trustClaims?: ParticleTrustClaim[];
+  trustChecks?: ParticleCheckStatement[];
+  trustClaims?: ParticleClaimStatement[];
 
   // fields in RecipeParticle only
   ref?: ParticleRef | '*';
@@ -174,16 +175,10 @@ export interface Particle extends BaseNode {
   slotConnections?: RecipeParticleSlotConnection[];
 }
 
-/** The different types of trust claims that particles can make. */
-export enum ParticleTrustClaimType {
-  IsTag,
-  DerivesFrom,
-}
-
 /** A claim made by a particle, saying that one of its outputs has a particular trust tag (e.g. "claim output is foo"). */
-export interface ParticleTrustClaimIsTag extends BaseNode {
+export interface ParticleClaimIsTag extends BaseNode {
   kind: 'particle-trust-claim-is-tag';
-  claimType: ParticleTrustClaimType.IsTag;
+  claimType: ClaimType.IsTag;
   handle: string;
   tag: string;
 }
@@ -192,17 +187,17 @@ export interface ParticleTrustClaimIsTag extends BaseNode {
  * A claim made by a particle, saying that one of its outputs derives from one/some of its inputs (e.g. "claim output derives from input1 and
  * input2").
  */
-export interface ParticleTrustClaimDerivesFrom extends BaseNode {
+export interface ParticleClaimDerivesFrom extends BaseNode {
   kind: 'particle-trust-claim-derives-from';
-  claimType: ParticleTrustClaimType.DerivesFrom;
+  claimType: ClaimType.DerivesFrom;
   handle: string;
   parentHandles: string[];
 }
 
 /** A trust claim made by a particle. */
-export type ParticleTrustClaim = ParticleTrustClaimIsTag | ParticleTrustClaimDerivesFrom;
+export type ParticleClaimStatement = ParticleClaimIsTag | ParticleClaimDerivesFrom;
 
-export interface ParticleTrustCheck extends BaseNode {
+export interface ParticleCheckStatement extends BaseNode {
   kind: 'particle-trust-check';
   handle: string;
   trustTags: string[];

--- a/src/runtime/manifest-parser.peg
+++ b/src/runtime/manifest-parser.peg
@@ -233,8 +233,8 @@ Particle
     let args: AstNode.ParticleArgument[] = [];
     const modality: string[] = [];
     const slotConnections: AstNode.RecipeParticleSlotConnection[] = [];
-    const trustClaims: AstNode.ParticleTrustClaim[] = [];
-    const trustChecks: AstNode.ParticleTrustCheck[] = [];
+    const trustClaims: AstNode.ParticleClaimStatement[] = [];
+    const trustChecks: AstNode.ParticleCheckStatement[] = [];
     let description: AstNode.Description | null = null;
     let hasParticleArgument = false;
     verbs = optional(verbs, parsedOutput => parsedOutput[1], []);
@@ -293,40 +293,40 @@ ParticleItem "a particle item"
   / ParticleSlot
   / Description
   / ParticleHandle
-  / ParticleTrustClaim
-  / ParticleTrustCheck
+  / ParticleClaimStatement
+  / ParticleCheckStatement
 
-ParticleTrustClaim
-  = ParticleTrustClaimIsTag
-  / ParticleTrustClaimDerivesFrom
+ParticleClaimStatement
+  = ParticleClaimIsTag
+  / ParticleClaimDerivesFrom
 
-ParticleTrustClaimIsTag
+ParticleClaimIsTag
   = 'claim' whiteSpace handle:lowerIdent whiteSpace 'is' whiteSpace tag:lowerIdent eolWhiteSpace
   {
     return {
       kind: 'particle-trust-claim-is-tag',
-      claimType: AstNode.ParticleTrustClaimType.IsTag,
+      claimType: 'is-tag',
       location: location(),
       handle,
       tag,
-    } as AstNode.ParticleTrustClaimIsTag;
+    } as AstNode.ParticleClaimIsTag;
   }
 
-ParticleTrustClaimDerivesFrom
+ParticleClaimDerivesFrom
   = 'claim' whiteSpace handle:lowerIdent whiteSpace 'derives from' whiteSpace first:lowerIdent rest:(whiteSpace 'and' whiteSpace lowerIdent)* eolWhiteSpace
   {
     const parentHandles: string[] = [first, ...rest.map(item => item[3])];
     return {
       kind: 'particle-trust-claim-derives-from',
-      claimType: AstNode.ParticleTrustClaimType.DerivesFrom,
+      claimType: 'derives-from',
       location: location(),
       handle,
       parentHandles,
-    } as AstNode.ParticleTrustClaimDerivesFrom;
+    } as AstNode.ParticleClaimDerivesFrom;
   }
 
-ParticleTrustCheck
-  = 'check' whiteSpace handle:lowerIdent whiteSpace first:ParticleTrustCheckCondition rest:('or' whiteSpace ParticleTrustCheckCondition)* eolWhiteSpace
+ParticleCheckStatement
+  = 'check' whiteSpace handle:lowerIdent whiteSpace first:ParticleCheckCondition rest:('or' whiteSpace ParticleCheckCondition)* eolWhiteSpace
   {
     const trustTags: string[] = [first, ...rest.map(item => item[2])];
     return {
@@ -334,10 +334,10 @@ ParticleTrustCheck
       location: location(),
       handle,
       trustTags,
-    } as AstNode.ParticleTrustCheck;
+    } as AstNode.ParticleCheckStatement;
   }
 
-ParticleTrustCheckCondition
+ParticleCheckCondition
   = 'is' whiteSpace trustTag:lowerIdent whiteSpace?
   {
     return trustTag;

--- a/src/runtime/particle-claim.ts
+++ b/src/runtime/particle-claim.ts
@@ -1,0 +1,15 @@
+/**
+ * @license
+ * Copyright 2019 Google LLC.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+/** The different types of trust claims that particles can make. */
+export enum ClaimType {
+  IsTag = 'is-tag',
+  DerivesFrom = 'derives-from',
+}

--- a/src/runtime/particle-spec.ts
+++ b/src/runtime/particle-spec.ts
@@ -10,7 +10,7 @@
 
 import {assert} from '../platform/assert-web.js';
 import {Modality} from './modality.js';
-import {Direction, ParticleTrustClaim, ParticleTrustCheck, ParticleTrustClaimType} from './manifest-ast-nodes.js';
+import {Direction, ParticleClaimStatement, ParticleCheckStatement} from './manifest-ast-nodes.js';
 import {TypeChecker} from './recipe/type-checker.js';
 import {Schema} from './schema.js';
 import {TypeVariableInfo} from './type-variable-info.js';
@@ -133,8 +133,8 @@ export interface SerializedParticleSpec extends Literal {
   implBlobUrl: string | null;
   modality: string[];
   slotConnections: SerializedSlotConnectionSpec[];
-  trustClaims?: ParticleTrustClaim[];
-  trustChecks?: ParticleTrustCheck[];
+  trustClaims?: ParticleClaimStatement[];
+  trustChecks?: ParticleCheckStatement[];
 }
 
 export class ParticleSpec {
@@ -149,7 +149,7 @@ export class ParticleSpec {
   slotConnections: Map<string, ConsumeSlotConnectionSpec>;
 
   // Trust claims/checks: maps from handle name to a "trust tag".
-  trustClaims: Map<string, ParticleTrustClaim>;
+  trustClaims: Map<string, ParticleClaimStatement>;
   trustChecks: Map<string, string[]>;
 
   constructor(model: SerializedParticleSpec) {
@@ -360,8 +360,8 @@ export class ParticleSpec {
     return this.toString();
   }
 
-  private validateTrustClaims(claims: ParticleTrustClaim[]): Map<string, ParticleTrustClaim> {
-    const results: Map<string, ParticleTrustClaim> = new Map();
+  private validateTrustClaims(claims: ParticleClaimStatement[]): Map<string, ParticleClaimStatement> {
+    const results: Map<string, ParticleClaimStatement> = new Map();
     if (claims) {
       claims.forEach(claim => {
         if (results.has(claim.handle)) {
@@ -380,7 +380,7 @@ export class ParticleSpec {
     return results;
   }
 
-  private validateTrustChecks(checks?: ParticleTrustCheck[]): Map<string, string[]> {
+  private validateTrustChecks(checks?: ParticleCheckStatement[]): Map<string, string[]> {
     const results: Map<string, string[]> = new Map();
     if (checks) {
       checks.forEach(check => {

--- a/src/runtime/test/manifest-test.ts
+++ b/src/runtime/test/manifest-test.ts
@@ -19,7 +19,7 @@ import {checkDefined, checkNotNull} from '../testing/preconditions.js';
 import {StubLoader} from '../testing/stub-loader.js';
 import {Dictionary} from '../hot.js';
 import {assertThrowsAsync} from '../testing/test-util.js';
-import {ParticleTrustClaimType} from '../manifest-ast-nodes.js';
+import {ClaimType} from '../particle-claim.js';
 
 async function assertRecipeParses(input: string, result: string) : Promise<void> {
   // Strip common leading whitespace.
@@ -1979,12 +1979,12 @@ resource SomeName
       const particle = manifest.particles[0];
       assert.equal(particle.trustClaims.size, 2);
       assert.deepNestedInclude(particle.trustClaims.get('output1'), {
-        claimType: ParticleTrustClaimType.IsTag,
+        claimType: ClaimType.IsTag,
         handle: 'output1',
         tag: 'property1',
       });
       assert.deepNestedInclude(particle.trustClaims.get('output2'), {
-        claimType: ParticleTrustClaimType.IsTag,
+        claimType: ClaimType.IsTag,
         handle: 'output2',
         tag: 'property2',
       });
@@ -2003,7 +2003,7 @@ resource SomeName
       const particle = manifest.particles[0];
       assert.equal(particle.trustClaims.size, 1);
       assert.deepNestedInclude(particle.trustClaims.get('output'), {
-        claimType: ParticleTrustClaimType.DerivesFrom,
+        claimType: ClaimType.DerivesFrom,
         handle: 'output',
         parentHandles: ['input1', 'input2'],
       });


### PR DESCRIPTION
These names are now a bit shorter, and should help make it easier to
disambiguate between the AST class names and the "real" classes that
we'll add shortly.

Also moved the ClaimType enum to its own file, so that it can be shared
between the AST and real classes (real classes will be added to that
same file, particle-claim.ts)