### PR TITLE
Added 'check foo is from handle bar' syntax

### DIFF
--- a/src/runtime/manifest-ast-nodes.ts
+++ b/src/runtime/manifest-ast-nodes.ts
@@ -8,6 +8,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 import {ClaimType} from './particle-claim';
+import {CheckType} from './particle-check';
 
 /**
  * Complete set of tokens used by `manifest-parser.peg`. To use this you
@@ -200,7 +201,23 @@ export type ParticleClaimStatement = ParticleClaimIsTag | ParticleClaimDerivesFr
 export interface ParticleCheckStatement extends BaseNode {
   kind: 'particle-trust-check';
   handle: string;
-  trustTags: string[];
+  conditions: ParticleCheckCondition[];
+}
+
+export type ParticleCheckCondition = ParticleCheckHasTag | ParticleCheckIsFromHandle;
+
+export interface ParticleCheckHasTag extends BaseNode {
+  kind: 'particle-trust-check-has-tag';
+  checkType: CheckType.HasTag;
+  handle: string;
+  tag: string;
+}
+
+export interface ParticleCheckIsFromHandle extends BaseNode {
+  kind: 'particle-trust-check-is-from-handle';
+  checkType: CheckType.IsFromHandle;
+  handle: string;
+  parentHandle: string;
 }
 
 export interface ParticleModality extends BaseNode {

--- a/src/runtime/manifest-parser.peg
+++ b/src/runtime/manifest-parser.peg
@@ -326,21 +326,41 @@ ParticleClaimDerivesFrom
   }
 
 ParticleCheckStatement
-  = 'check' whiteSpace handle:lowerIdent whiteSpace first:ParticleCheckCondition rest:('or' whiteSpace ParticleCheckCondition)* eolWhiteSpace
+  = 'check' whiteSpace handle:lowerIdent whiteSpace first:ParticleCheckCondition rest:(whiteSpace 'or' whiteSpace ParticleCheckCondition)* eolWhiteSpace
   {
-    const trustTags: string[] = [first, ...rest.map(item => item[2])];
+    const conditions: AstNode.ParticleCheckCondition[] = [first, ...rest.map(item => item[3])];
     return {
       kind: 'particle-trust-check',
       location: location(),
       handle,
-      trustTags,
+      conditions,
     } as AstNode.ParticleCheckStatement;
   }
 
 ParticleCheckCondition
-  = 'is' whiteSpace trustTag:lowerIdent whiteSpace?
+  = ParticleCheckIsFromHandle
+  / ParticleCheckHasTag
+
+ParticleCheckHasTag
+  = 'is' whiteSpace tag:lowerIdent
   {
-    return trustTag;
+    return {
+      kind: 'particle-trust-check-has-tag',
+      checkType: 'has-tag',
+      location: location(),
+      tag,
+    } as AstNode.ParticleCheckHasTag;
+  }
+
+ParticleCheckIsFromHandle
+  = 'is from handle' whiteSpace parentHandle:lowerIdent
+  {
+    return {
+      kind: 'particle-trust-check-is-from-handle',
+      checkType: 'is-from-handle',
+      location: location(),
+      parentHandle,
+    } as AstNode.ParticleCheckIsFromHandle;
   }
 
 ParticleHandle

--- a/src/runtime/particle-check.ts
+++ b/src/runtime/particle-check.ts
@@ -59,7 +59,6 @@ export class CheckIsFromHandle {
   }
 }
 
-
 export function createCheck(
     handle: HandleConnectionSpec,
     astNode: ParticleCheckStatement,
@@ -71,7 +70,7 @@ export function createCheck(
       case CheckType.IsFromHandle:
         return CheckIsFromHandle.fromASTNode(condition, handleConnectionMap);
       default:
-        throw new Error('Unknown claim type.');
+        throw new Error('Unknown check type.');
     }
   });
   return new Check(handle, conditions);

--- a/src/runtime/particle-check.ts
+++ b/src/runtime/particle-check.ts
@@ -7,21 +7,72 @@
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
-import {ParticleCheckStatement} from './manifest-ast-nodes';
+
+import {ParticleCheckStatement, ParticleCheckHasTag, ParticleCheckIsFromHandle} from './manifest-ast-nodes';
 import {HandleConnectionSpec} from './particle-spec';
 
-export class Check {
-  constructor(readonly handle: HandleConnectionSpec, readonly acceptedTags: readonly string[]) {}
+/** The different types of trust checks that particles can make. */
+export enum CheckType {
+  HasTag = 'has-tag',
+  IsFromHandle = 'is-from-handle',
+}
 
-  static fromASTNode(handle: HandleConnectionSpec, astNode: ParticleCheckStatement) {
-    return new Check(handle, astNode.trustTags);
+export class Check {
+  constructor(readonly handle: HandleConnectionSpec, readonly conditions: readonly CheckCondition[]) {}
+
+  toManifestString() {
+    return `check ${this.handle.name} ${this.conditions.map(c => c.toManifestString()).join(' or ')}`;
+  }
+}
+
+export type CheckCondition = CheckHasTag | CheckIsFromHandle;
+
+export class CheckHasTag {
+  readonly type: CheckType.HasTag = CheckType.HasTag;
+
+  constructor(readonly tag: string) {}
+
+  static fromASTNode(astNode: ParticleCheckHasTag) {
+    return new CheckHasTag(astNode.tag);
   }
 
   toManifestString() {
-    return `check ${this.handle.name} is ${this.acceptedTags.join(' or is ')}`;
+    return `is ${this.tag}`;
+  }
+}
+
+export class CheckIsFromHandle {
+  readonly type: CheckType.IsFromHandle = CheckType.IsFromHandle;
+
+  constructor(readonly parentHandle: HandleConnectionSpec) {}
+
+  static fromASTNode(astNode: ParticleCheckIsFromHandle, handleConnectionMap: Map<string, HandleConnectionSpec>) {
+    const parentHandle = handleConnectionMap.get(astNode.parentHandle);
+    if (!parentHandle) {
+      throw new Error(`Unknown "check is from handle" handle name: ${parentHandle}.`);
+    }
+    return new CheckIsFromHandle(parentHandle);
   }
 
-  toShortString() {
-    return this.acceptedTags.join('|');
+  toManifestString() {
+    return `is from handle ${this.parentHandle}`;
   }
+}
+
+
+export function createCheck(
+    handle: HandleConnectionSpec,
+    astNode: ParticleCheckStatement,
+    handleConnectionMap: Map<string, HandleConnectionSpec>): Check {
+  const conditions = astNode.conditions.map(condition => {
+    switch (condition.checkType) {
+      case CheckType.HasTag:
+        return CheckHasTag.fromASTNode(condition);
+      case CheckType.IsFromHandle:
+        return CheckIsFromHandle.fromASTNode(condition, handleConnectionMap);
+      default:
+        throw new Error('Unknown claim type.');
+    }
+  });
+  return new Check(handle, conditions);
 }

--- a/src/runtime/particle-claim.ts
+++ b/src/runtime/particle-claim.ts
@@ -8,7 +8,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
- import {HandleConnectionSpec} from './particle-spec';
+import {HandleConnectionSpec} from './particle-spec';
 import {ParticleClaimIsTag, ParticleClaimDerivesFrom, ParticleClaimStatement} from './manifest-ast-nodes';
 
 /** The different types of trust claims that particles can make. */

--- a/src/runtime/particle-spec.ts
+++ b/src/runtime/particle-spec.ts
@@ -16,7 +16,7 @@ import {Schema} from './schema.js';
 import {TypeVariableInfo} from './type-variable-info.js';
 import {InterfaceType, SlotType, Type, TypeLiteral} from './type.js';
 import {Literal} from './hot.js';
-import {Check} from './particle-check.js';
+import {Check, createCheck} from './particle-check.js';
 import {Claim, createClaim} from './particle-claim.js';
 
 // TODO: clean up the real vs. literal separation in this file
@@ -398,7 +398,7 @@ export class ParticleSpec {
         if (handle.check) {
           throw new Error(`Can't make multiple checks on the same input (${check.handle}).`); 
         }
-        handle.check = Check.fromASTNode(handle, check);
+        handle.check = createCheck(handle, check, this.handleConnectionMap);
         results.set(check.handle, handle.check);
       });
     }

--- a/src/runtime/test/manifest-test.ts
+++ b/src/runtime/test/manifest-test.ts
@@ -20,6 +20,7 @@ import {StubLoader} from '../testing/stub-loader.js';
 import {Dictionary} from '../hot.js';
 import {assertThrowsAsync} from '../testing/test-util.js';
 import {ClaimType, ClaimIsTag, ClaimDerivesFrom} from '../particle-claim.js';
+import {CheckHasTag} from '../particle-check.js';
 
 async function assertRecipeParses(input: string, result: string) : Promise<void> {
   // Strip common leading whitespace.
@@ -2017,11 +2018,20 @@ resource SomeName
       `);
       assert.lengthOf(manifest.particles, 1);
       const particle = manifest.particles[0];
+      assert.isEmpty(particle.trustClaims);
       assert.equal(particle.trustChecks.size, 2);
       
-      assert.sameMembers(particle.trustChecks.get('input1').acceptedTags as string[], ['property1']);
-      assert.sameMembers(particle.trustChecks.get('input2').acceptedTags as string[], ['property2']);
-      assert.isEmpty(particle.trustClaims);
+      const check1 = particle.trustChecks.get('input1');
+      assert.equal(check1.toManifestString(), 'check input1 is property1');
+      assert.equal(check1.handle.name, 'input1');
+      assert.lengthOf(check1.conditions, 1);
+      assert.equal((check1.conditions[0] as CheckHasTag).tag, 'property1');
+
+      const check2 = particle.trustChecks.get('input2');
+      assert.equal(check2.toManifestString(), 'check input2 is property2');
+      assert.equal(check2.handle.name, 'input2');
+      assert.lengthOf(check2.conditions, 1);
+      assert.equal((check2.conditions[0] as CheckHasTag).tag, 'property2');
     });
 
     it('supports checks with multiple tags', async () => {
@@ -2032,9 +2042,15 @@ resource SomeName
       `);
       assert.lengthOf(manifest.particles, 1);
       const particle = manifest.particles[0];
-      assert.equal(particle.trustChecks.size, 1);
-      assert.sameMembers(particle.trustChecks.get('input').acceptedTags as string[], ['property1', 'property2']);
       assert.isEmpty(particle.trustClaims);
+      assert.equal(particle.trustChecks.size, 1);
+
+      const check = particle.trustChecks.get('input');
+      assert.equal(check.toManifestString(), 'check input is property1 or is property2');
+      assert.equal(check.handle.name, 'input');
+      assert.lengthOf(check.conditions, 2);
+      assert.equal((check.conditions[0] as CheckHasTag).tag, 'property1');
+      assert.equal((check.conditions[1] as CheckHasTag).tag, 'property2');
     });
 
     it('fails for unknown handle names', async () => {


### PR DESCRIPTION
Updated the Check class to support having different types of conditions
(HasTag, IsFromHandle). They are all implicitly OR'd together.

The handle checks are not actually verified by the analyser yet. Follow
up PR for that.