### PR TITLE
Direction type conversion

### DIFF
--- a/particles/List/Annotations.recipes
+++ b/particles/List/Annotations.recipes
@@ -1,30 +1,30 @@
 interface HostedAnnotationInterface
-  in ~any *
+  in ~anyType *
   inout ~anyOther *
   consume annotation
 
 particle AnnotationMultiplexer in 'source/Multiplexer.js'
-  in [~any] list
+  in [~anyType] list
   inout ~anyOther annotation
   host HostedAnnotationInterface hostedParticle
   consume set of annotation
 
 interface HostedSimpleAnnotationInterface
-  in ~any *
+  in ~anyType *
   consume annotation
 
 particle SimpleAnnotationMultiplexer in 'source/Multiplexer.js'
-  in [~any] list
+  in [~anyType] list
   host HostedSimpleAnnotationInterface hostedParticle
   consume set of annotation
 
 interface HostedCombinedAnnotationInterface
-  in ~any *
+  in ~anyType *
   in [~anyOther] *
   consume annotation
 
 particle CombinedAnnotationMultiplexer in 'source/Multiplexer.js'
-  in [~any] list
+  in [~anyType] list
   in [~anyOther] choices
   host HostedCombinedAnnotationInterface hostedParticle
   consume set of annotation

--- a/particles/List/Choices.recipes
+++ b/particles/List/Choices.recipes
@@ -7,12 +7,12 @@
 // http://polymer.github.io/PATENTS.txt
 
 interface HostedChoiceInterface
-  in ~any *
+  in ~anyType *
   in [~anyOther] *
   consume choice
 
 particle ChoicesMultiplexer in 'source/Multiplexer.js'
-  in [~any] list
+  in [~anyType] list
   in [~anyOther] choices
   host HostedChoiceInterface hostedParticle
   consume set of choice

--- a/particles/List/Items.recipes
+++ b/particles/List/Items.recipes
@@ -7,7 +7,7 @@
 // http://polymer.github.io/PATENTS.txt
 
 interface HostedItemInterface
-  in ~any *
+  in ~anyType *
   // TODO(sjmiles): using slot-type for form-factor
   // all Interfaces are the same in List/* except for the slot
   consume item
@@ -15,8 +15,8 @@ interface HostedItemInterface
 particle ItemMultiplexer in 'source/Multiplexer.js'
   // TODO(sjmiles): redundancies:
   // 1. slot is declared in HostedItemInterface and as `consume set of` here
-  // 2. ~any is declared in HostedItemInterface and as `[~any]` here
-  in [~any] list
+  // 2. ~anyType is declared in HostedItemInterface and as `[~anyType]` here
+  in [~anyType] list
   host HostedItemInterface hostedParticle
   consume set of item
 
@@ -30,7 +30,7 @@ particle ItemMultiplexer in 'source/Multiplexer.js'
 //    list = list
 
 //particle List in 'source/List.js'
-//  in [~any] list
+//  in [~anyType] list
 //  consume root #items
 //    must provide set of item
 //      handle items
@@ -44,7 +44,7 @@ particle ItemMultiplexer in 'source/Multiplexer.js'
 //    list = items
 
 particle Items in 'source/Items.js'
-  in [~any] list
+  in [~anyType] list
   consume root #items
     provide preamble
     must provide set of item
@@ -57,8 +57,8 @@ particle Items in 'source/Items.js'
   description `display ${list}`
 
 particle SelectableItems in 'source/Items.js'
-  in [~any] list
-  inout? ~any selected
+  in [~anyType] list
+  inout? ~anyType selected
   consume root #items
     provide preamble
     must provide set of item

--- a/particles/List/SLANDLESAnnotations.recipes
+++ b/particles/List/SLANDLESAnnotations.recipes
@@ -7,32 +7,32 @@
 // http://polymer.github.io/PATENTS.txt
 
 interface SlandleHostedAnnotationInterface
-  in ~any *
+  in ~anyType *
   inout ~anyOther *
   `consume Slot annotation
 
 particle SlandleAnnotationMultiplexer in 'source/Multiplexer.js'
-  in [~any] list
+  in [~anyType] list
   inout ~anyOther annotation
   host SlandleHostedAnnotationInterface hostedParticle
   `consume [Slot] annotation
 
 interface SlandleHostedSimpleAnnotationInterface
-  in ~any *
+  in ~anyType *
   `consume Slot annotation
 
 particle SlandleSimpleAnnotationMultiplexer in 'source/Multiplexer.js'
-  in [~any] list
+  in [~anyType] list
   host SlandleHostedSimpleAnnotationInterface hostedParticle
   `consume [Slot] annotation
 
 interface SlandleHostedCombinedAnnotationInterface
-  in ~any *
+  in ~anyType *
   in [~anyOther] *
   `consume Slot annotation
 
 particle SlandleCombinedAnnotationMultiplexer in 'source/Multiplexer.js'
-  in [~any] list
+  in [~anyType] list
   in [~anyOther] choices
   host SlandleHostedCombinedAnnotationInterface hostedParticle
   `consume [Slot] annotation

--- a/particles/List/SLANDLESChoices.recipes
+++ b/particles/List/SLANDLESChoices.recipes
@@ -7,12 +7,12 @@
 // http://polymer.github.io/PATENTS.txt
 
 interface SlandleHostedChoiceInterface
-  in ~any *
+  in ~anyType *
   in [~anyOther] *
   `consume Slot choice
 
 particle SlandleChoicesMultiplexer in 'source/Multiplexer.js'
-  in [~any] list
+  in [~anyType] list
   in [~anyOther] choices
   host SlandleHostedChoiceInterface hostedParticle
   `consume Slot choice

--- a/particles/List/SLANDLESItems.recipes
+++ b/particles/List/SLANDLESItems.recipes
@@ -7,7 +7,7 @@
 // http://polymer.github.io/PATENTS.txt
 
 interface SlandleHostedItemInterface
-  in ~any *
+  in ~anyType *
   // TODO(sjmiles): using slot-type for form-factor
   // all Interfaces are the same in List/* except for the slot
   `consume Slot item
@@ -15,8 +15,8 @@ interface SlandleHostedItemInterface
 particle SlandleItemMultiplexer in 'source/Multiplexer.js'
   // TODO(sjmiles): redundancies:
   // 1. slot is declared in HostedItemInterface and as `consume [Slot]  here
-  // 2. ~any is declared in HostedItemInterface and as `[~any]` here
-  in [~any] list
+  // 2. ~anyType is declared in HostedItemInterface and as `[~anyType]` here
+  in [~anyType] list
   host SlandleHostedItemInterface hostedParticle
   `consume [Slot] item
 
@@ -30,7 +30,7 @@ particle SlandleItemMultiplexer in 'source/Multiplexer.js'
 //    list = list
 
 //particle SlandleList in 'source/List.js'
-//  in [~any] list
+//  in [~anyType] list
 //  `consume Slot root #items
 //    `provide? [Slot {handle: items}] item
 //  description `show ${list}`
@@ -43,7 +43,7 @@ particle SlandleItemMultiplexer in 'source/Multiplexer.js'
 //    list = items
 
 particle SlandleItems in 'source/Items.js'
-  in [~any] list
+  in [~anyType] list
   `consume Slot root #items
     `provide? Slot preamble
     `provide? [Slot {handle: list}] item
@@ -53,8 +53,8 @@ particle SlandleItems in 'source/Items.js'
   description `display ${list}`
 
 particle SlandleSelectableItems in 'source/Items.js'
-  in [~any] list
-  inout? ~any selected
+  in [~anyType] list
+  inout? ~anyType selected
   `consume Slot root #items
     `provide? Slot preamble
     `provide [Slot {handle: list}] item

--- a/particles/List/SLANDLESTiles.recipes
+++ b/particles/List/SLANDLESTiles.recipes
@@ -7,11 +7,11 @@
 // http://polymer.github.io/PATENTS.txt
 
 interface SlandleHostedTileInterface
-  in ~any *
+  in ~anyType *
   `consume Slot tile
 
 particle SlandleTileMultiplexer in 'source/Multiplexer.js'
-  in [~any] list
+  in [~anyType] list
   host SlandleHostedTileInterface hostedParticle
   `consume [Slot] tile
 
@@ -21,8 +21,8 @@ particle SlandleTileMultiplexer in 'source/Multiplexer.js'
 //    list = list
 
 particle SlandleSelectableTiles in 'source/Tiles.js'
-  in [~any] list
-  inout ~any selected
+  in [~anyType] list
+  inout ~anyType selected
   `consume Slot root #tiles
     `provide [Slot] tile
     `provide? [Slot] annotation

--- a/particles/List/Tiles.recipes
+++ b/particles/List/Tiles.recipes
@@ -1,9 +1,9 @@
 interface HostedTileInterface
-  in ~any *
+  in ~anyType *
   consume tile
 
 particle TileMultiplexer in 'source/Multiplexer.js'
-  in [~any] list
+  in [~anyType] list
   host HostedTileInterface hostedParticle
   consume set of tile
 
@@ -13,8 +13,8 @@ particle TileMultiplexer in 'source/Multiplexer.js'
 //    list = list
 
 particle SelectableTiles in 'source/Tiles.js'
-  in [~any] list
-  inout ~any selected
+  in [~anyType] list
+  inout ~anyType selected
   consume root #tiles
     must provide set of tile
     provide set of annotation

--- a/particles/Restaurants/FavoriteFoodAnnotation.recipes
+++ b/particles/Restaurants/FavoriteFoodAnnotation.recipes
@@ -17,13 +17,13 @@ particle SharesFrom in 'source/SharesFrom.js'
   out [Description] descriptions
 
 interface AnnotationInterfaceThree
-  in ~any *
+  in ~anyType *
   in [~otherOne] *
   in [~otherTwo] names
   consume annotation
 
 particle AnnotationMultiplexerThree in '../List/source/Multiplexer.js'
-  in [~any] list
+  in [~anyType] list
   in [~otherOne] choices
   in [~otherTwo] names
   host AnnotationInterfaceThree hostedParticle

--- a/src/planning/strategies/assign-handles.ts
+++ b/src/planning/strategies/assign-handles.ts
@@ -41,7 +41,7 @@ export class AssignHandles extends Strategy {
         // Once validation of recipes generates type information on the handle
         // we should switch to using that instead.
         const counts = RecipeUtil.directionCounts(handle);
-        if (counts.unknown > 0) {
+        if (counts['any'] > 0) { // Number of unknown handle directions.
           return undefined;
         }
 

--- a/src/planning/strategies/convert-constraints-to-connections.ts
+++ b/src/planning/strategies/convert-constraints-to-connections.ts
@@ -13,12 +13,13 @@ import {RecipeUtil, HandleRepr} from '../../runtime/recipe/recipe-util.js';
 import {Recipe} from '../../runtime/recipe/recipe.js';
 import {StrategizerWalker, Strategy, StrategyParams} from '../strategizer.js';
 import {ParticleSpec} from '../../runtime/particle-spec.js';
-import {Direction} from '../../runtime/manifest-ast-nodes.js';
+import {reverseArrow} from '../../runtime/recipe/recipe-util.js';
+import {DirectionArrow} from '../../runtime/manifest-ast-nodes.js';
 import {Descendant} from '../../runtime/recipe/walker.js';
 import {Handle} from '../../runtime/recipe/handle.js';
 import {Dictionary} from '../../runtime/hot.js';
 
-type Obligation = {from: EndPoint, to: EndPoint, direction: Direction};
+type Obligation = {from: EndPoint, to: EndPoint, direction: DirectionArrow};
 
 export class ConvertConstraintsToConnections extends Strategy {
   async generate(inputParams: StrategyParams): Promise<Descendant<Recipe>[]> {
@@ -72,8 +73,6 @@ export class ConvertConstraintsToConnections extends Strategy {
             return undefined;
           }
 
-          const reverse = {'->': '<-', '=': '=', '<-': '->'};
-
           // Set up initial mappings & input to RecipeUtil.
           let handle: HandleRepr;
           let handleIsConcrete = false;
@@ -93,7 +92,7 @@ export class ConvertConstraintsToConnections extends Strategy {
             }
           }
           if (from instanceof HandleEndPoint) {
-            handle = {handle: nameForHandle(from.handle, handleNames), direction: reverse[constraint.direction], localName: from.handle.localName};
+            handle = {handle: nameForHandle(from.handle, handleNames), direction: reverseArrow(constraint.direction), localName: from.handle.localName};
             handles.add(handle.handle);
           }
           if (to instanceof ParticleEndPoint) {
@@ -164,7 +163,7 @@ export class ConvertConstraintsToConnections extends Strategy {
             }
           }
 
-          direction = reverse[constraint.direction];
+          direction = reverseArrow(constraint.direction);
           if (to instanceof ParticleEndPoint) {
             const connection = to.connection;
             if (connection) {

--- a/src/planning/test/planner-tests.ts
+++ b/src/planning/test/planner-tests.ts
@@ -678,7 +678,7 @@ describe('Automatic resolution', () => {
       recipe
         ? as location
         D
-          location = location
+          location <-> location
 `);
 
     assert.equal(`recipe
@@ -694,7 +694,7 @@ describe('Automatic resolution', () => {
     location <- handle2
     something <- handle1
   D as particle3
-    location = handle2`, result.toString({hideFields: false}));
+    location <-> handle2`, result.toString({hideFields: false}));
   });
 
   it('uses existing handle from the arc', async () => {
@@ -749,8 +749,8 @@ describe('Automatic resolution', () => {
     list <- handle0
     consume item as slot0
   SelectableList as particle1
-    items = handle0
-    selected = handle1
+    items <-> handle0
+    selected <-> handle1
     consume root as slot1
       provide action as slot2
       provide annotation as slot3
@@ -787,8 +787,8 @@ describe('Automatic resolution', () => {
     list <- handle0
     consume item as slot0
   SelectableList as particle1
-    items = handle0
-    selected = handle1
+    items <-> handle0
+    selected <-> handle1
     consume root as slot1
       provide action as slot2
       provide annotation as slot3

--- a/src/planning/test/recipe-index-test.ts
+++ b/src/planning/test/recipe-index-test.ts
@@ -74,7 +74,7 @@ describe('RecipeIndex', () => {
 `recipe
   create as handle0 // Person {}
   A as particle0
-    person = handle0`
+    person <-> handle0`
     ]);
   });
 

--- a/src/planning/test/strategies/convert-constraints-to-connections-tests.ts
+++ b/src/planning/test/strategies/convert-constraints-to-connections-tests.ts
@@ -45,9 +45,9 @@ describe('ConvertConstraintsToConnections', () => {
 `recipe
   create as handle0 // S {}
   A as particle0
-    b = handle0
+    b <-> handle0
   C as particle1
-    d = handle0`);
+    d <-> handle0`);
   });
 
   it('does not cause an input only handle to be created', async () => {
@@ -137,9 +137,9 @@ describe('ConvertConstraintsToConnections', () => {
 `recipe
   create as handle0 // S {}
   A as particle0
-    b = handle0
+    b <-> handle0
   C as particle1
-    d = handle0`);
+    d <-> handle0`);
   });
 
   it('fills out a constraint, reusing a single particle (2)', async () => {
@@ -162,9 +162,9 @@ describe('ConvertConstraintsToConnections', () => {
 `recipe
   create as handle0 // S {}
   A as particle0
-    b = handle0
+    b <-> handle0
   C as particle1
-    d = handle0`);
+    d <-> handle0`);
   });
 
 
@@ -189,9 +189,9 @@ describe('ConvertConstraintsToConnections', () => {
 `recipe
   create as handle0 // S {}
   A as particle0
-    b = handle0
+    b <-> handle0
   C as particle1
-    d = handle0`);
+    d <-> handle0`);
   });
 
   it('fills out a constraint, reusing two particles and a handle', async () => {
@@ -206,7 +206,7 @@ describe('ConvertConstraintsToConnections', () => {
         A.b -> C.d
         use as handle1
         C
-          d = handle1
+          d <-> handle1
         A`);
     const generated = [{result: manifest.recipes[0], score: 1, derivation: [], hash: '0', valid: true}];
     const cctc = new ConvertConstraintsToConnections(newArc(manifest));
@@ -217,9 +217,9 @@ describe('ConvertConstraintsToConnections', () => {
 `recipe
   use as handle0 // S {}
   A as particle0
-    b = handle0
+    b <-> handle0
   C as particle1
-    d = handle0`);
+    d <-> handle0`);
   });
 
   it('fills out a constraint, reusing two particles and a handle (2)', async () => {
@@ -245,9 +245,9 @@ describe('ConvertConstraintsToConnections', () => {
 `recipe
   use as handle0 // S {}
   A as particle0
-    b = handle0
+    b <-> handle0
   C as particle1
-    d = handle0`);
+    d <-> handle0`);
   });
 
   it('removes an already fulfilled constraint', async () => {
@@ -262,9 +262,9 @@ describe('ConvertConstraintsToConnections', () => {
         A.b -> C.d
         use as handle1
         C
-          d = handle1
+          d <-> handle1
         A
-          b = handle1`);
+          b <-> handle1`);
     const generated = [{result: manifest.recipes[0], score: 1, derivation: [], hash: '0', valid: true}];
     const cctc = new ConvertConstraintsToConnections(newArc(manifest));
     const results = await cctc.generateFrom(generated);
@@ -273,9 +273,9 @@ describe('ConvertConstraintsToConnections', () => {
     assert.deepEqual(result.toString(), `recipe
   use as handle0 // S {}
   A as particle0
-    b = handle0
+    b <-> handle0
   C as particle1
-    d = handle0`);
+    d <-> handle0`);
   });
 
   it('verifies modality', async () => {
@@ -542,7 +542,7 @@ describe('ConvertConstraintsToConnections', () => {
       in S {} i
       out T {} o
     recipe
-      A = B
+      A <-> B
     `);
     const generated = [{result: manifest.recipes[0], score: 1, derivation: [], hash: '0', valid: true}];
     const cctc = new ConvertConstraintsToConnections(newArc(manifest));

--- a/src/runtime/manifest-ast-nodes.ts
+++ b/src/runtime/manifest-ast-nodes.ts
@@ -331,7 +331,7 @@ export type RecipeItem = RecipeParticle | RecipeHandle | RequireHandleSection | 
 export interface RecipeParticleConnection extends BaseNode {
   kind: 'handle-connection';
   param: string;
-  dir: string;
+  dir: DirectionArrow;
   target: ParticleConnectionTargetComponents;
 }
 
@@ -370,7 +370,7 @@ export interface RecipeSlotConnectionRef extends BaseNode {
 
 export interface RecipeConnection extends BaseNode {
   kind: 'connection';
-  direction: Direction;
+  direction: DirectionArrow;
   from: ConnectionTarget;
   to: ConnectionTarget;
 }
@@ -562,7 +562,6 @@ export type Manifest = ManifestItem[];
 export type ManifestStorageItem = string;
 export type ManifestStorageDescription = string;
 export type Modality = string;
-export type ParticleArgumentDirection = string;
 export type ReservedWord = string;
 export type ResourceStart = string;
 export type ResourceBody = string;
@@ -587,7 +586,10 @@ export type eolWhiteSpace = string;
 export type eol = string;
 
 // String-based enums.
-export type Direction = 'in' | 'out' | 'inout' | 'host';
+// TODO: convert to actual enums so that they can be iterated over.
+export type Direction = 'in' | 'out' | 'inout' | 'host' | '`consume' | '`provide' | 'any';
+export type DirectionArrow = '<-' | '->' | '<->' | 'consume' | 'provide' | '=';
+
 export type SlotDirection = 'provide' | 'consume';
 export type Fate = 'use' | 'create' | 'map' | 'copy' | '?' | '`slot';
 

--- a/src/runtime/manifest-parser.peg
+++ b/src/runtime/manifest-parser.peg
@@ -180,9 +180,9 @@ InterfaceItem
   / InterfaceArgument
 
 InterfaceArgument
-  = direction:(ParticleArgumentDirection whiteSpace)? type:(ParticleArgumentType whiteSpace)? name:(lowerIdent / '*') eolWhiteSpace
+  = direction:(Direction whiteSpace)? type:(ParticleArgumentType whiteSpace)? name:(lowerIdent / '*') eolWhiteSpace
   {
-    direction = optional(direction, dir => dir[0], null);
+    direction = optional(direction, dir => dir[0], 'any');
     if (direction === 'host') {
       error(`Interface cannot have arguments with a 'host' direction.`);
     }
@@ -407,7 +407,7 @@ ParticleHandle
   }
 
 ParticleArgument
-  = direction:ParticleArgumentDirection isOptional:'?'? whiteSpace type:ParticleArgumentType whiteSpace nametag:NameAndTagList
+  = direction:Direction isOptional:'?'? whiteSpace type:ParticleArgumentType whiteSpace nametag:NameAndTagList
   {
     return {
       kind: 'particle-argument',
@@ -421,10 +421,23 @@ ParticleArgument
     } as AstNode.ParticleArgument;
   }
 
-ParticleArgumentDirection "a direction (e.g. inout, in, out, host, `consume, `provide)"
-  = 'inout' / 'in' / 'out' / 'host' / '`consume' / '`provide'
+Direction "a direction (e.g. inout, in, out, host, `consume, `provide, any)"
+  = 'inout' / 'in' / 'out' / 'host' / '`consume' / '`provide' / 'any'
   {
-    return text() as AstNode.Direction;
+    const dir = text() as AstNode.Direction;
+    if(dir === null) {
+      expected('a direction');
+    }
+    return dir;
+  }
+
+DirectionArrow "a direction arrow (e.g. <-, ->, <->, =, consume, provide)"
+  = '<->' / '<-' / '->' / '=' / 'consume' / 'provide' {
+    const dir = text() as AstNode.DirectionArrow;
+    if(dir === null) {
+      expected('a direction arrow');
+    }
+    return dir;
   }
 
 ParticleArgumentType
@@ -728,7 +741,7 @@ RecipeParticle
 RecipeParticleItem = RecipeParticleSlotConnection / RecipeParticleConnection
 
 RecipeParticleConnection
-  = param:(lowerIdent / '*') whiteSpace dir:Direction target:(whiteSpace ParticleConnectionTargetComponents)? eolWhiteSpace dependentConnections:(Indent (SameIndent RecipeParticleConnection)*)?
+  = param:(lowerIdent / '*') whiteSpace dir:DirectionArrow target:(whiteSpace ParticleConnectionTargetComponents)? eolWhiteSpace dependentConnections:(Indent (SameIndent RecipeParticleConnection)*)?
   {
     return {
       kind: 'handle-connection',
@@ -792,7 +805,7 @@ SlotDirection
   = 'provide' / 'consume'
 
 RecipeConnection
-  = from:ConnectionTarget whiteSpace direction:Direction whiteSpace to:ConnectionTarget eolWhiteSpace
+  = from:ConnectionTarget whiteSpace direction:DirectionArrow whiteSpace to:ConnectionTarget eolWhiteSpace
   {
     return {
       kind: 'connection',
@@ -814,9 +827,6 @@ RecipeSearch
       tokens: optional(tokens, tokens => tokens[1][2].map(t => t[1]), null)
     } as AstNode.RecipeSearch;
   }
-
-Direction
-  = dir:('<-' / '->' / '=' / 'consume' / 'provide')
 
 ConnectionTarget
   = VerbConnectionTarget / TagConnectionTarget / ParticleConnectionTarget / NameConnectionTarget
@@ -1197,8 +1207,8 @@ SameOrMoreIndent "same or more indentation" = &(i:" "* &{
 
 // Should only be used as a negative match.
 ReservedWord
-  = keyword:(Direction
-  / ParticleArgumentDirection
+  = keyword:(DirectionArrow
+  / Direction
   / RecipeHandleFate
   / 'particle'
   / 'recipe'

--- a/src/runtime/recipe/connection-constraint.ts
+++ b/src/runtime/recipe/connection-constraint.ts
@@ -11,7 +11,7 @@
 import {assert} from '../../platform/assert-web.js';
 import {ParticleSpec} from '../particle-spec.js';
 
-import {Direction} from '../manifest-ast-nodes.js';
+import {Direction, DirectionArrow} from '../manifest-ast-nodes.js';
 import {Handle} from './handle.js';
 import {Comparable, compareArrays, compareComparables, compareStrings} from './comparable.js';
 import {Recipe, RecipeComponent, CloneMap, ToStringOptions} from './recipe.js';
@@ -19,7 +19,7 @@ import {Particle} from './particle.js';
 
 export abstract class EndPoint implements Comparable<EndPoint> {
   abstract _compareTo(other: EndPoint): number;
-  abstract _clone(cloneMap?: CloneMap);
+  abstract _clone(cloneMap?: CloneMap): EndPoint;
   abstract toString(nameMap?: ReadonlyMap<RecipeComponent, string>): string;
 }
 
@@ -123,6 +123,7 @@ export class TagEndPoint extends EndPoint {
     return 0;
   }
 
+  // TODO: nameMap is not used. Remove it?
   toString(nameMap: ReadonlyMap<RecipeComponent, string> = undefined): string {
     return this.tags.map(a => `#${a}`).join(' ');
   }
@@ -133,10 +134,10 @@ export class TagEndPoint extends EndPoint {
 export class ConnectionConstraint implements Comparable<ConnectionConstraint> {
   from: EndPoint;
   to: EndPoint;
-  direction: Direction;
+  direction: DirectionArrow;
   type: 'constraint' | 'obligation';
 
-  constructor(fromConnection: EndPoint, toConnection: EndPoint, direction: Direction, type: 'constraint' | 'obligation') {
+  constructor(fromConnection: EndPoint, toConnection: EndPoint, direction: DirectionArrow, type: 'constraint' | 'obligation') {
     assert(direction);
     assert(type);
     this.from = fromConnection;
@@ -149,7 +150,7 @@ export class ConnectionConstraint implements Comparable<ConnectionConstraint> {
   _copyInto(recipe: Recipe, cloneMap: CloneMap) {
     if (this.type === 'constraint') {
       if (this.from instanceof InstanceEndPoint || this.to instanceof InstanceEndPoint) {
-        assert(!`Can't have connection constraints of type constraint with InstanceEndPoints`);
+        assert(false, `Can't have connection constraints of type constraint with InstanceEndPoints`);
       } else {
         return recipe.newConnectionConstraint(
             this.from._clone(), this.to._clone(), this.direction);

--- a/src/runtime/recipe/recipe-resolver.ts
+++ b/src/runtime/recipe/recipe-resolver.ts
@@ -17,6 +17,7 @@ import {Particle} from './particle.js';
 import {RecipeUtil} from './recipe-util.js';
 import {RecipeWalker} from './recipe-walker.js';
 import {Recipe, IsValidOptions} from './recipe.js';
+import {ConnectionConstraint, InstanceEndPoint} from './connection-constraint.js';
 import {SlotConnection} from './slot-connection.js';
 import {SlotUtils} from './slot-utils.js';
 
@@ -139,12 +140,11 @@ export class ResolveWalker extends RecipeWalker {
     };
   }
   // TODO(lindner): add typeof checks here and figure out where handle is coming from.
-  onObligation(recipe: Recipe, obligation: {from, to, direction: Direction}) {
-    const fromParticle = obligation.from.instance;
-    const toParticle = obligation.to.instance;
+  onObligation(recipe: Recipe, obligation: ConnectionConstraint) {
+    const fromParticle: Particle = (obligation.from as InstanceEndPoint).instance;
+    const toParticle: Particle = (obligation.to as InstanceEndPoint).instance;
     for (const fromConnection of Object.values(fromParticle.connections)) {
       for (const toConnection of Object.values(toParticle.connections)) {
-        // @ts-ignore
         if (fromConnection.handle && fromConnection.handle === toConnection.handle) {
           return (recipe, obligation) => {
             recipe.removeObligation(obligation);

--- a/src/runtime/recipe/recipe-util.ts
+++ b/src/runtime/recipe/recipe-util.ts
@@ -13,12 +13,105 @@ import {ParticleSpec, HandleConnectionSpec} from '../particle-spec.js';
 import {InterfaceType} from '../type.js';
 
 import {HandleConnection} from './handle-connection.js';
-import {Direction} from '../manifest-ast-nodes.js';
+import {Direction, DirectionArrow} from '../manifest-ast-nodes.js';
 import {Handle} from './handle.js';
 import {Particle} from './particle.js';
 import {Recipe, RecipeComponent} from './recipe.js';
 import {Id} from '../id.js';
 import {Dictionary} from '../hot.js';
+
+export function directionToArrow(direction: Direction): DirectionArrow {
+  // Use switch for totality checking.
+  switch (direction) {
+    case 'out':
+      return '->';
+    case 'in':
+      return '<-';
+    case 'inout':
+      return '<->';
+    case '`consume':
+      return 'consume';
+    case '`provide':
+      return 'provide';
+    case 'host':
+      return '='; // TODO(cypher1): Check this
+    case 'any':
+      return '=';
+    default:
+      throw new Error(`Bad direction ${direction}`);
+  }
+}
+
+export function arrowToDirection(arrow: DirectionArrow): Direction {
+  // Use switch for totality checking.
+  switch (arrow) {
+    case '->':
+      return 'out';
+    case '<-':
+      return 'in';
+    case '<->':
+      return 'inout';
+    case 'consume':
+      return '`consume';
+    case 'provide':
+      return '`provide';
+    case '=':
+      return 'any';
+    default:
+      throw new Error(`Bad arrow ${arrow}`);
+  }
+}
+
+export function reverseArrow(arrow: DirectionArrow): DirectionArrow {
+  switch (arrow) {
+    case '->':
+      return '<-';
+    case '<-':
+      return '->';
+    case '<->':
+      return '<->';
+    case 'consume':
+      return 'provide';
+    case 'provide':
+      return 'consume';
+    case '=':
+      return '=';
+    default:
+      // Catch nulls and unsafe values from javascript.
+      throw new Error(`Bad arrow ${arrow}`);
+  }
+}
+
+export function connectionMatchesHandleDirection(connectionDirection: Direction, handleDirection: Direction): boolean {
+  return acceptedDirections(connectionDirection).includes(handleDirection);
+}
+
+export function acceptedDirections(direction: Direction): Direction[] {
+  // @param direction: the direction of a handleconnection.
+  // @return acceptedDirections: the list of directions a handle can have that
+  // are allowed with this handle connection.
+  //
+  switch (direction) {
+    case 'any':
+      return ['any', 'in', 'out', 'inout', 'host', '`consume', '`provide'];
+    case 'in':
+      return ['any', 'in', 'inout', 'host', '`consume'];
+    case 'out':
+      return ['any', 'out', 'inout', '`provide'];
+    case 'inout':
+      return ['any', 'inout'];
+    case 'host':
+      return ['any', 'host'];
+    case '`consume':
+      return ['any', '`consume'];
+    case '`provide':
+      return ['any', '`provide'];
+    default:
+      // Catch nulls and unsafe values from javascript.
+      throw new Error(`Bad direction ${direction}`);
+  }
+}
+
 
 class Shape {
   recipe: Recipe;
@@ -41,16 +134,16 @@ class Shape {
     }
   }
 }
-type DirectionCounts = {in: number; out: number; inout: number; unknown: number;};
+type DirectionCounts = {[K in Direction]: number};
 
-export type HandleRepr = {localName?: string, handle: string, tags?: string[], direction?: string};
+export type HandleRepr = {localName?: string, handle: string, tags?: string[], direction?: DirectionArrow};
 
 type RecipeUtilComponent = RecipeComponent | HandleConnectionSpec;
 
 type Match = {forward: Map<RecipeComponent, RecipeUtilComponent>, reverse: Map<RecipeUtilComponent, RecipeComponent>, score: number};
 
 export class RecipeUtil {
-  static makeShape(particles: string[], handles: string[], map: Dictionary<Dictionary<HandleRepr>>, recipe?: Recipe) {
+  static makeShape(particles: string[], handles: string[], map: Dictionary<Dictionary<HandleRepr>>, recipe?: Recipe): Shape {
     recipe = recipe || new Recipe();
     const pMap: Dictionary<Particle> = {};
     const hMap: Map<string, Handle> = new Map();
@@ -59,23 +152,16 @@ export class RecipeUtil {
     handles.forEach(handle => hMap.set(handle, recipe.newHandle()));
     Object.keys(map).forEach(key => {
       Object.keys(map[key]).forEach(name => {
-        const handle = map[key][name];
-        // NOTE: for now, '=' on the shape means "accept anything". This is going
-        // to change when we redo capabilities; for now it's modeled by mapping '=' to
-        // '=' rather than to 'inout'.
-        let direction: Direction | '=' = '=';
-        if (handle.direction) {
-          direction = {'->': 'out', '<-': 'in', '=': '='}[handle.direction];
-        }
+        const handle: HandleRepr = map[key][name];
         const tags: string[] = handle.tags || [];
-        if (handle['localName']) {
+        if (handle.localName) {
           hMap.get(handle.handle).localName = handle.localName;
         }
 
         const connection = pMap[key].addConnectionName(name);
-        // TODO(shans): work out a cleaner way to encode "accept anything" - 
-        // this is an abuse of the type system. 
-        connection.direction = direction as Direction;
+        // NOTE: for now, 'any' on the connection and '=' on the shape means 'accept anything'.
+        connection.direction = arrowToDirection(handle.direction || '=');
+
         hMap.get(handle.handle).tags = tags;
         connection.connectToHandle(hMap.get(handle.handle));
         hcMap[key + ':' + name] = pMap[key].connections[name];
@@ -95,230 +181,227 @@ export class RecipeUtil {
     return new Shape(recipe, particles, handles, hcs);
   }
 
-  static find(recipe: Recipe, shape: Shape) {
+  static _buildNewHCMatches(recipe: Recipe, shapeHC: HandleConnection, match: Match, outputList: Match[]) {
+    const {forward, reverse, score} = match;
+    let matchFound = false;
+    for (const recipeParticle of recipe.particles) {
+      if (!recipeParticle.spec) {
+        continue;
+      }
+      for (const recipeConnSpec of recipeParticle.spec.handleConnections) {
+      // TODO are there situations where multiple handleConnections should
+      // be allowed to point to the same one in the recipe?
+      if (reverse.has(recipeConnSpec)) {
+        continue;
+      }
 
-    function _buildNewHCMatches(recipe: Recipe, shapeHC: HandleConnection, match: Match, outputList: Match[]) {
-      const {forward, reverse, score} = match;
-      let matchFound = false;
-      for (const recipeParticle of recipe.particles) {
-        if (!recipeParticle.spec) {
+      // TODO support unnamed shape particles.
+      if (recipeParticle.name !== shapeHC.particle.name) {
+        continue;
+      }
+
+      if (shapeHC.name && shapeHC.name !== recipeConnSpec.name) {
+        continue;
+      }
+
+      if (recipeConnSpec.direction) {
+        if (!connectionMatchesHandleDirection(shapeHC.direction, recipeConnSpec.direction)) {
           continue;
         }
-        for (const recipeConnSpec of recipeParticle.spec.handleConnections) {
-        // TODO are there situations where multiple handleConnections should
-        // be allowed to point to the same one in the recipe?
-        if (reverse.has(recipeConnSpec)) {
+      }
+
+      const recipeHC = recipeParticle.connections[recipeConnSpec.name];
+      if (shapeHC.handle && recipeHC && recipeHC.handle && shapeHC.handle.localName &&
+          shapeHC.handle.localName !== recipeHC.handle.localName) {
+        continue;
+      }
+
+      // recipeHC is a candidate for shapeHC. shapeHC references a
+      // particle, so recipeHC must reference the matching particle,
+      // or a particle that isn't yet mapped from shape.
+      if (reverse.has(recipeParticle)) {
+        if (reverse.get(recipeParticle) !== shapeHC.particle) {
           continue;
         }
+      } else if (forward.has(shapeHC.particle)) {
+        // we've already mapped the particle referenced by shapeHC
+        // and it doesn't match recipeHC's particle as recipeHC's
+        // particle isn't mapped
+        continue;
+      }
 
-        // TODO support unnamed shape particles.
-        if (recipeParticle.name !== shapeHC.particle.name) {
-          continue;
-        }
-
-        if (shapeHC.name && shapeHC.name !== recipeConnSpec.name) {
-          continue;
-        }
-
-        const acceptedDirections = {'in': ['in', 'inout'], 'out': ['out', 'inout'], '=': ['in', 'out', 'inout'], 'inout': ['inout'], 'host': ['host'], '`consume': ['consume'], '`provide': ['provide']};
-        if (recipeConnSpec.direction) {
-          assert(Object.keys(acceptedDirections).includes(shapeHC.direction), `${shapeHC.direction} not in ${Object.keys(acceptedDirections)}`);
-          if (!acceptedDirections[shapeHC.direction].includes(recipeConnSpec.direction)) {
+      // shapeHC doesn't necessarily reference a handle, but if it does
+      // then recipeHC needs to reference the matching handle, or one
+      // that isn't yet mapped, or no handle yet.
+      if (shapeHC.handle && recipeHC && recipeHC.handle) {
+        if (reverse.has(recipeHC.handle)) {
+          if (reverse.get(recipeHC.handle) !== shapeHC.handle) {
             continue;
           }
-        }
-
-        const recipeHC = recipeParticle.connections[recipeConnSpec.name];
-        if (shapeHC.handle && recipeHC && recipeHC.handle && shapeHC.handle.localName &&
-            shapeHC.handle.localName !== recipeHC.handle.localName) {
+        } else if (forward.has(shapeHC.handle) && forward.get(shapeHC.handle) !== null) {
           continue;
         }
-
-        // recipeHC is a candidate for shapeHC. shapeHC references a
-        // particle, so recipeHC must reference the matching particle,
-        // or a particle that isn't yet mapped from shape.
-        if (reverse.has(recipeParticle)) {
-          if (reverse.get(recipeParticle) !== shapeHC.particle) {
-            continue;
+        // Check whether shapeHC and recipeHC reference the same handle.
+        if (shapeHC.handle.fate !== 'create' || (recipeHC.handle.fate !== 'create' && recipeHC.handle.originalFate !== 'create')) {
+          if (Boolean(shapeHC.handle.immediateValue) !== Boolean(recipeHC.handle.immediateValue)) {
+            continue; // One is an immediate value handle and the other is not.
           }
-        } else if (forward.has(shapeHC.particle)) {
-          // we've already mapped the particle referenced by shapeHC
-          // and it doesn't match recipeHC's particle as recipeHC's
-          // particle isn't mapped
-          continue;
-        }
-
-        // shapeHC doesn't necessarily reference a handle, but if it does
-        // then recipeHC needs to reference the matching handle, or one
-        // that isn't yet mapped, or no handle yet.
-        if (shapeHC.handle && recipeHC && recipeHC.handle) {
-          if (reverse.has(recipeHC.handle)) {
-            if (reverse.get(recipeHC.handle) !== shapeHC.handle) {
-              continue;
-            }
-          } else if (forward.has(shapeHC.handle) && forward.get(shapeHC.handle) !== null) {
-            continue;
-          }
-          // Check whether shapeHC and recipeHC reference the same handle.
-          if (shapeHC.handle.fate !== 'create' || (recipeHC.handle.fate !== 'create' && recipeHC.handle.originalFate !== 'create')) {
-            if (Boolean(shapeHC.handle.immediateValue) !== Boolean(recipeHC.handle.immediateValue)) {
-              continue; // One is an immediate value handle and the other is not.
-            }
-            if (recipeHC.handle.immediateValue) {
-              if (!recipeHC.handle.immediateValue.equals(shapeHC.handle.immediateValue)) {
-                continue; // Immediate values are different.
-              }
-            } else {
-              // Note: the id of a handle with 'copy' fate changes during recipe instantiation, hence comparing to original id too.
-              // Skip the check if handles have 'create' fate (their ids are arbitrary).
-              if (shapeHC.handle.id !== recipeHC.handle.id && shapeHC.handle.id !== recipeHC.handle.originalId) {
-                continue; // This is a different handle.
-              }
-            }
-          }
-        }
-
-        // clone forward and reverse mappings and establish new components.
-        const newMatch = {forward: new Map(forward), reverse: new Map(reverse), score};
-        assert(!newMatch.reverse.has(recipeParticle) || newMatch.reverse.get(recipeParticle) === shapeHC.particle);
-        assert(!newMatch.forward.has(shapeHC.particle) || newMatch.forward.get(shapeHC.particle) === recipeParticle);
-        newMatch.forward.set(shapeHC.particle, recipeParticle);
-        newMatch.reverse.set(recipeParticle, shapeHC.particle);
-        if (shapeHC.handle) {
-          if (!recipeHC || !recipeHC.handle) {
-            if (!newMatch.forward.has(shapeHC.handle)) {
-              newMatch.forward.set(shapeHC.handle, null);
-              newMatch.score -= 2;
+          if (recipeHC.handle.immediateValue) {
+            if (!recipeHC.handle.immediateValue.equals(shapeHC.handle.immediateValue)) {
+              continue; // Immediate values are different.
             }
           } else {
-            newMatch.forward.set(shapeHC.handle, recipeHC.handle);
-            newMatch.reverse.set(recipeHC.handle, shapeHC.handle);
+            // Note: the id of a handle with 'copy' fate changes during recipe instantiation, hence comparing to original id too.
+            // Skip the check if handles have 'create' fate (their ids are arbitrary).
+            if (shapeHC.handle.id !== recipeHC.handle.id && shapeHC.handle.id !== recipeHC.handle.originalId) {
+              continue; // This is a different handle.
+            }
           }
         }
-        newMatch.forward.set(shapeHC, recipeConnSpec);
-        newMatch.reverse.set(recipeConnSpec, shapeHC);
-        outputList.push(newMatch);
-        matchFound = true;
-      }
       }
 
-      if (matchFound === false) {
-        // Non-null particle in the `forward` map means that some of the particle
-        // handle connections were successful matches, but some couldn't be matched.
-        // It means that this match in invalid.
-        if (match.forward.get(shapeHC.particle)) {
-          return;
-        }
-        // The current handle connection from the shape doesn't match anything
-        // in the recipe. Find (or create) a particle for it.
-        const newMatches: Match[] = [];
-        _buildNewParticleMatches(recipe, shapeHC.particle, match, newMatches);
-        newMatches.forEach(newMatch => {
-          // the shape references a handle, might also need to create a recipe
-          // handle for it (if there isn't already one from a previous match).
-          if (shapeHC.handle && !newMatch.forward.has(shapeHC.handle)) {
+      // clone forward and reverse mappings and establish new components.
+      const newMatch = {forward: new Map(forward), reverse: new Map(reverse), score};
+      assert(!newMatch.reverse.has(recipeParticle) || newMatch.reverse.get(recipeParticle) === shapeHC.particle);
+      assert(!newMatch.forward.has(shapeHC.particle) || newMatch.forward.get(shapeHC.particle) === recipeParticle);
+      newMatch.forward.set(shapeHC.particle, recipeParticle);
+      newMatch.reverse.set(recipeParticle, shapeHC.particle);
+      if (shapeHC.handle) {
+        if (!recipeHC || !recipeHC.handle) {
+          if (!newMatch.forward.has(shapeHC.handle)) {
             newMatch.forward.set(shapeHC.handle, null);
             newMatch.score -= 2;
           }
-          newMatch.forward.set(shapeHC, null);
-          newMatch.score -= 1;
-          outputList.push(newMatch);
-        });
+        } else {
+          newMatch.forward.set(shapeHC.handle, recipeHC.handle);
+          newMatch.reverse.set(recipeHC.handle, shapeHC.handle);
+        }
       }
+      newMatch.forward.set(shapeHC, recipeConnSpec);
+      newMatch.reverse.set(recipeConnSpec, shapeHC);
+      outputList.push(newMatch);
+      matchFound = true;
+    }
     }
 
-    function _buildNewParticleMatches(recipe: Recipe, shapeParticle: Particle, match: Match, newMatches: Match[]) {
+    if (matchFound === false) {
+      // Non-null particle in the `forward` map means that some of the particle
+      // handle connections were successful matches, but some couldn't be matched.
+      // It means that this match in invalid.
+      if (match.forward.get(shapeHC.particle)) {
+        return;
+      }
+      // The current handle connection from the shape doesn't match anything
+      // in the recipe. Find (or create) a particle for it.
+      const newMatches: Match[] = [];
+      RecipeUtil._buildNewParticleMatches(recipe, shapeHC.particle, match, newMatches);
+      newMatches.forEach(newMatch => {
+        // the shape references a handle, might also need to create a recipe
+        // handle for it (if there isn't already one from a previous match).
+        if (shapeHC.handle && !newMatch.forward.has(shapeHC.handle)) {
+          newMatch.forward.set(shapeHC.handle, null);
+          newMatch.score -= 2;
+        }
+        newMatch.forward.set(shapeHC, null);
+        newMatch.score -= 1;
+        outputList.push(newMatch);
+      });
+    }
+  }
+
+  static _buildNewParticleMatches(recipe: Recipe, shapeParticle: Particle, match: Match, newMatches: Match[]) {
+    const {forward, reverse, score} = match;
+    let matchFound = false;
+    for (const recipeParticle of recipe.particles) {
+      if (reverse.has(recipeParticle)) {
+        continue;
+      }
+
+      if (recipeParticle.name !== shapeParticle.name) {
+        continue;
+      }
+
+      let handleNamesMatch = true;
+      for (const connectionName of Object.keys(recipeParticle.connections)) {
+        const recipeConnection = recipeParticle.connections[connectionName];
+        if (!recipeConnection.handle) {
+          continue;
+        }
+        const shapeConnection = shapeParticle.connections[connectionName];
+        if (shapeConnection && shapeConnection.handle && shapeConnection.handle.localName && shapeConnection.handle.localName !== recipeConnection.handle.localName) {
+          handleNamesMatch = false;
+          break;
+        }
+      }
+
+      if (!handleNamesMatch) {
+        continue;
+      }
+
+      const newMatch = {forward: new Map(forward), reverse: new Map(reverse), score};
+      assert(!newMatch.forward.has(shapeParticle) || newMatch.forward.get(shapeParticle) === recipeParticle);
+      assert(!newMatch.reverse.has(recipeParticle) || newMatch.reverse.get(recipeParticle) === shapeParticle);
+      newMatch.forward.set(shapeParticle, recipeParticle);
+      newMatch.reverse.set(recipeParticle, shapeParticle);
+      newMatches.push(newMatch);
+      matchFound = true;
+    }
+    if (matchFound === false) {
+      const newMatch: Match = {forward: new Map(), reverse: new Map(), score: 0};
+      forward.forEach((value, key) => {
+        assert(!newMatch.forward.has(key) || newMatch.forward.get(key) === value);
+        newMatch.forward.set(key, value);
+      });
+      reverse.forEach((value, key) => {
+        assert(!newMatch.reverse.has(key) || newMatch.reverse.get(key) === value);
+        newMatch.reverse.set(key, value);
+      });
+      if (!newMatch.forward.has(shapeParticle)) {
+        newMatch.forward.set(shapeParticle, null);
+        newMatch.score = match.score - 1;
+      }
+      newMatches.push(newMatch);
+    }
+  }
+
+  static _assignHandlesToEmptyPosition(shape: Shape, match: Match, emptyHandles: Handle[], nullHandles: Handle[]) {
+    if (emptyHandles.length === 1) {
+      const matches: Match[] = [];
       const {forward, reverse, score} = match;
-      let matchFound = false;
-      for (const recipeParticle of recipe.particles) {
-        if (reverse.has(recipeParticle)) {
-          continue;
-        }
-
-        if (recipeParticle.name !== shapeParticle.name) {
-          continue;
-        }
-
-        let handleNamesMatch = true;
-        for (const connectionName of Object.keys(recipeParticle.connections)) {
-          const recipeConnection = recipeParticle.connections[connectionName];
-          if (!recipeConnection.handle) {
-            continue;
-          }
-          const shapeConnection = shapeParticle.connections[connectionName];
-          if (shapeConnection && shapeConnection.handle && shapeConnection.handle.localName && shapeConnection.handle.localName !== recipeConnection.handle.localName) {
-            handleNamesMatch = false;
+      for (const nullHandle of nullHandles) {
+        let tagsMatch = true;
+        for (const tag of nullHandle.tags) {
+          if (!emptyHandles[0].tags.includes(tag)) {
+            tagsMatch = false;
             break;
           }
         }
-
-        if (!handleNamesMatch) {
+        if (!tagsMatch) {
           continue;
         }
-
-        const newMatch = {forward: new Map(forward), reverse: new Map(reverse), score};
-        assert(!newMatch.forward.has(shapeParticle) || newMatch.forward.get(shapeParticle) === recipeParticle);
-        assert(!newMatch.reverse.has(recipeParticle) || newMatch.reverse.get(recipeParticle) === shapeParticle);
-        newMatch.forward.set(shapeParticle, recipeParticle);
-        newMatch.reverse.set(recipeParticle, shapeParticle);
-        newMatches.push(newMatch);
-        matchFound = true;
+        const newMatch = {forward: new Map(forward), reverse: new Map(reverse), score: score + 1};
+        newMatch.forward.set(nullHandle, emptyHandles[0]);
+        newMatch.reverse.set(emptyHandles[0], nullHandle);
+        matches.push(newMatch);
       }
-      if (matchFound === false) {
-        const newMatch: Match = {forward: new Map(), reverse: new Map(), score: 0};
-        forward.forEach((value, key) => {
-          assert(!newMatch.forward.has(key) || newMatch.forward.get(key) === value);
-          newMatch.forward.set(key, value);
-        });
-        reverse.forEach((value, key) => {
-          assert(!newMatch.reverse.has(key) || newMatch.reverse.get(key) === value);
-          newMatch.reverse.set(key, value);
-        });
-        if (!newMatch.forward.has(shapeParticle)) {
-          newMatch.forward.set(shapeParticle, null);
-          newMatch.score = match.score - 1;
-        }
-        newMatches.push(newMatch);
+      return matches;
+    }
+    const thisHandle = emptyHandles.pop();
+    const matches: Match[] = RecipeUtil._assignHandlesToEmptyPosition(shape, match, emptyHandles, nullHandles);
+    let newMatches: Match[] = [];
+    for (const match of matches) {
+      const nullHandles = [...shape.handles.values()].filter(handle => match.forward.get(handle) === null);
+      if (nullHandles.length > 0) {
+        newMatches = newMatches.concat(
+            RecipeUtil._assignHandlesToEmptyPosition(shape, match, [thisHandle], nullHandles));
+      } else {
+        newMatches.concat(match);
       }
     }
+    return newMatches;
+  }
 
-    function _assignHandlesToEmptyPosition(match: Match, emptyHandles: Handle[], nullHandles: Handle[]) {
-      if (emptyHandles.length === 1) {
-        const matches: Match[] = [];
-        const {forward, reverse, score} = match;
-        for (const nullHandle of nullHandles) {
-          let tagsMatch = true;
-          for (const tag of nullHandle.tags) {
-            if (!emptyHandles[0].tags.includes(tag)) {
-              tagsMatch = false;
-              break;
-            }
-          }
-          if (!tagsMatch) {
-            continue;
-          }
-          const newMatch = {forward: new Map(forward), reverse: new Map(reverse), score: score + 1};
-          newMatch.forward.set(nullHandle, emptyHandles[0]);
-          newMatch.reverse.set(emptyHandles[0], nullHandle);
-          matches.push(newMatch);
-        }
-        return matches;
-      }
-      const thisHandle = emptyHandles.pop();
-      const matches: Match[] = _assignHandlesToEmptyPosition(match, emptyHandles, nullHandles);
-      let newMatches: Match[] = [];
-      for (const match of matches) {
-        const nullHandles = [...shape.handles.values()].filter(handle => match.forward.get(handle) === null);
-        if (nullHandles.length > 0) {
-          newMatches = newMatches.concat(
-              _assignHandlesToEmptyPosition(match, [thisHandle], nullHandles));
-        } else {
-          newMatches.concat(match);
-        }
-      }
-      return newMatches;
-    }
-
+  static find(recipe: Recipe, shape: Shape): {match: Dict<RecipeUtilComponent>, score: number}[] {
     // Particles and Handles are initially stored by a forward map from
     // shape component to recipe component.
     // Handle connections, particles and handles are also stored by a reverse map
@@ -330,7 +413,7 @@ export class RecipeUtil {
       const newMatches: Match[] = [];
       for (const match of matches) {
         // collect matching handle connections into a new matches list
-        _buildNewHCMatches(recipe, shapeHC, match, newMatches);
+        RecipeUtil._buildNewHCMatches(recipe, shapeHC, match, newMatches);
       }
       matches = newMatches;
     }
@@ -344,7 +427,7 @@ export class RecipeUtil {
       }
       const newMatches: Match[] = [];
       for (const match of matches) {
-        _buildNewParticleMatches(recipe, shapeParticle, match, newMatches);
+        RecipeUtil._buildNewParticleMatches(recipe, shapeParticle, match, newMatches);
       }
       matches = newMatches;
     }
@@ -357,7 +440,7 @@ export class RecipeUtil {
         const nullHandles = [...shape.handles.values()].filter(handle => match.forward.get(handle) === null);
         if (nullHandles.length > 0) {
           newMatches = newMatches.concat(
-              _assignHandlesToEmptyPosition(match, emptyHandles, nullHandles));
+              RecipeUtil._assignHandlesToEmptyPosition(shape, match, emptyHandles, nullHandles));
         } else {
           newMatches = newMatches.concat(match);
         }
@@ -365,10 +448,10 @@ export class RecipeUtil {
       matches = newMatches;
     }
 
-    return matches.map(({forward, score}) => {
-      const match = {};
-      forward.forEach((value, key) => match[shape.reverse.get(key)] = value);
-      return {match, score};
+    return matches.map((match: {forward: Map<RecipeComponent, RecipeUtilComponent>, score: number}) => {
+      const result: Dict<RecipeUtilComponent> = {};
+      match.forward.forEach((value: RecipeUtilComponent, key: RecipeComponent) => result[shape.reverse.get(key)] = value);
+      return {match: result, score: match.score};
     });
   }
 
@@ -401,13 +484,9 @@ export class RecipeUtil {
   }
 
   static directionCounts(handle: Handle): DirectionCounts {
-    const counts: DirectionCounts = {in: 0, out: 0, inout: 0, unknown: 0};
+    const counts: DirectionCounts = {'in': 0, 'out': 0, 'inout': 0, 'host': 0, '`consume': 0, '`provide': 0, 'any': 0};
     for (const connection of handle.connections) {
-      let direction: Direction | 'unknown' = connection.direction;
-      if (counts[direction] === undefined) {
-        direction = 'unknown';
-      }
-      counts[direction]++;
+      counts[connection.direction]++;
     }
     counts.in += counts.inout;
     counts.out += counts.inout;

--- a/src/runtime/recipe/recipe.ts
+++ b/src/runtime/recipe/recipe.ts
@@ -15,7 +15,7 @@ import {HandleConnectionSpec} from '../particle-spec.js';
 import {InterfaceType, Type} from '../type.js';
 
 import {ConnectionConstraint, EndPoint} from './connection-constraint.js';
-import {Direction} from '../manifest-ast-nodes.js';
+import {Direction, DirectionArrow} from '../manifest-ast-nodes.js';
 import {HandleConnection} from './handle-connection.js';
 import {Handle} from './handle.js';
 import {Particle} from './particle.js';
@@ -71,13 +71,13 @@ export class Recipe implements Cloneable<Recipe> {
     this._name = name;
   }
 
-  newConnectionConstraint(from: EndPoint, to: EndPoint, direction: Direction): ConnectionConstraint {
+  newConnectionConstraint(from: EndPoint, to: EndPoint, direction: DirectionArrow): ConnectionConstraint {
     const result = new ConnectionConstraint(from, to, direction, 'constraint');
     this._connectionConstraints.push(result);
     return result;
   }
 
-  newObligation(from: EndPoint, to: EndPoint, direction: Direction): ConnectionConstraint {
+  newObligation(from: EndPoint, to: EndPoint, direction: DirectionArrow): ConnectionConstraint {
     const result = new ConnectionConstraint(from, to, direction, 'obligation');
     this._obligations.push(result);
     return result;
@@ -673,6 +673,8 @@ export class Recipe implements Cloneable<Recipe> {
   }
 
   getFreeConnections(type?: Type): {particle: Particle, connSpec: HandleConnectionSpec}[] {
+    // TODO(jopra): Check that this works for required connections that are
+    // dependent on optional connections.
     return this.allSpecifiedConnections.filter(
         ({particle, connSpec}) => !connSpec.isOptional &&
                                   connSpec.name !== 'descriptions' &&

--- a/src/runtime/test/manifest-test.ts
+++ b/src/runtime/test/manifest-test.ts
@@ -1116,7 +1116,8 @@ Expected a verb (e.g. &Verb) or an uppercase identifier (e.g. Foo) but "?" found
       await Manifest.parse(manifest);
       assert.fail();
     } catch (e) {
-      assert.match(e.message, /'->' not compatible with 'in' param of 'TestParticle'/);
+      console.error(e.message);
+      assert.match(e.message, /'->' \(out\) not compatible with 'in' param of 'TestParticle'/);
     }
   });
 
@@ -1134,6 +1135,7 @@ Expected a verb (e.g. &Verb) or an uppercase identifier (e.g. Foo) but "?" found
       await Manifest.parse(manifest);
       assert.fail();
     } catch (e) {
+      console.error(e.message);
       assert.match(e.message, /param 'b' is not defined by 'TestParticle'/);
     }
   });

--- a/src/runtime/test/recipe-test.ts
+++ b/src/runtime/test/recipe-test.ts
@@ -394,13 +394,13 @@ describe('recipe', () => {
     const manifest = await Manifest.parse(`
       schema Thing
       particle Generic
-        in ~a any
+        in ~a anyA
       particle Specific
         in Thing thing
       recipe
         map as thingHandle
         Generic
-          any <- thingHandle
+          anyA <- thingHandle
         Specific
           thing <- thingHandle
       store MyThings of Thing 'my-things' in ThingsJson
@@ -416,13 +416,13 @@ describe('recipe', () => {
     assert.equal(`recipe
   map 'my-things' as handle0 // ~
   Generic as particle0
-    any <- handle0
+    anyA <- handle0
   Specific as particle1
     thing <- handle0`, recipe.toString());
     assert.equal(`recipe
   map 'my-things' as handle0 // ~ // Thing {}  // unresolved handle: unresolved type
   Generic as particle0
-    any <- handle0
+    anyA <- handle0
   Specific as particle1
     thing <- handle0`, recipe.toString({showUnresolved: true}));
     const hash = await recipe.digest();
@@ -439,7 +439,7 @@ describe('recipe', () => {
     assert.equal(`recipe
   map 'my-things' as handle0 // Thing {}
   Generic as particle0
-    any <- handle0
+    anyA <- handle0
   Specific as particle1
     thing <- handle0`, recipeClone.toString());
     assert.equal(recipeClone.toString(), recipeClone.toString({showUnresolved: true}));

--- a/src/runtime/test/recipe-util-tests.ts
+++ b/src/runtime/test/recipe-util-tests.ts
@@ -11,6 +11,8 @@
 import {assert} from '../../platform/chai-web.js';
 import {Manifest} from '../manifest.js';
 import {RecipeUtil} from '../recipe/recipe-util.js';
+import {Particle} from '../recipe/particle.js';
+import {Handle} from '../recipe/handle.js';
 
 describe('recipe-util', () => {
   it('can produce a shape match to a simple recipe', async () => {
@@ -33,9 +35,28 @@ describe('recipe-util', () => {
     const results = RecipeUtil.find(recipe, shape);
     assert.lengthOf(results, 1);
     assert.equal(results[0].score, 0);
-    assert.equal(results[0].match['A'].name, 'A');
-    assert.equal(results[0].match['B'].name, 'B');
-    assert.equal(results[0].match['v'].localName, 'handle1');
+    assert.equal((results[0].match['A'] as Particle).name, 'A');
+    assert.equal((results[0].match['B'] as Particle).name, 'B');
+    assert.equal((results[0].match['v'] as Handle).localName, 'handle1');
+  });
+
+  it('cannot produce a shape match to a non-matching recipe', async () => {
+    const manifest = await Manifest.parse(`
+      schema S
+      particle B
+        out S b
+
+      recipe Recipe
+        map as handle1
+        B
+          b -> handle1`);
+    const recipe = manifest.recipes[0];
+    const shape = RecipeUtil.makeShape(['A', 'B'], ['v'],
+      {'A': {'a': {handle: 'v'}}, 'B': {'b': {handle: 'v'}}});
+    const results = RecipeUtil.find(recipe, shape);
+    // TODO: It may be better to not return a result than providing partially
+    // resolved results.
+    assert.equal(results[0].match['A'], null);
   });
 
   it('can produce multiple partial shape matches to a simple recipe', async () => {
@@ -65,15 +86,15 @@ describe('recipe-util', () => {
     const results = RecipeUtil.find(recipe, shape);
     assert.lengthOf(results, 2);
     assert.equal(results[0].score, -1);
-    assert.equal(results[0].match['A'].name, 'A');
-    assert.equal(results[0].match['B'].name, 'B');
-    assert.equal(results[0].match['C'].name, 'C');
-    assert.equal(results[0].match['v'].localName, 'handle1');
+    assert.equal((results[0].match['A'] as Particle).name, 'A');
+    assert.equal((results[0].match['B'] as Particle).name, 'B');
+    assert.equal((results[0].match['C'] as Particle).name, 'C');
+    assert.equal((results[0].match['v'] as Handle).localName, 'handle1');
     assert.equal(results[1].score, -1);
-    assert.equal(results[1].match['A'].name, 'A');
-    assert.equal(results[1].match['B'].name, 'B');
-    assert.equal(results[1].match['C'].name, 'C');
-    assert.equal(results[1].match['v'].localName, 'handle2');
+    assert.equal((results[1].match['A'] as Particle).name, 'A');
+    assert.equal((results[1].match['B'] as Particle).name, 'B');
+    assert.equal((results[1].match['C'] as Particle).name, 'C');
+    assert.equal((results[1].match['v'] as Handle).localName, 'handle2');
   });
 
   it('can match a free handle', async () => {
@@ -91,7 +112,7 @@ describe('recipe-util', () => {
     const results = RecipeUtil.find(recipe, shape);
     assert.lengthOf(results, 1);
     assert.equal(results[0].score, -3);
-    assert.equal(results[0].match['v'].localName, 'h1');
+    assert.equal((results[0].match['v'] as Handle).localName, 'h1');
   });
 
   it('can match dangling handle connections', async () => {
@@ -115,9 +136,9 @@ describe('recipe-util', () => {
     const results = RecipeUtil.find(recipe, shape);
     assert.lengthOf(results, 1);
     assert.equal(results[0].score, -1);
-    assert.equal(results[0].match['h'].localName, 'h1');
-    assert.equal(results[0].match['A:a'].name, 'a');
-    assert.equal(results[0].match['B:b'].name, 'b');
+    assert.equal((results[0].match['h'] as Handle).localName, 'h1');
+    assert.equal((results[0].match['A:a'] as Particle).name, 'a');
+    assert.equal((results[0].match['B:b'] as Particle).name, 'b');
   });
 
   it('matches duplicate particles', async () => {


### PR DESCRIPTION
Converts some cases where directions where represented as strings to more explicit Direction (in/out/inout/`consume/`provide) and what I'm calling DirectionArrow(<-/->/=/consume/provide).This facilitates control conversion between the two more cleanly.

One side effect of doing this that we now use undefined to represent 'any direction' instead of '=' which was not a valid Direction (but is a valid DirectionArrow). Another is that I've moved some of our direction conversion maps and converted them to functions using switch statements (which the compiler can check for totality).

This also adds some type annotations to the shape matching code, adds a test for non-matching. 