### PR TITLE
pipes-shell-2: performance improvements

### DIFF
--- a/particles/PipeApps/source/RandomArtist.js
+++ b/particles/PipeApps/source/RandomArtist.js
@@ -16,9 +16,9 @@ defineParticle(({DomParticle, html, log}) => {
     update({randomArtist}) {
       if (randomArtist) {
         const entities = [
-          {type: 'artist', name: 'Taylor Swift', source: 'com.weaseldev.fortunecookies'},
-          {type: 'artist', name: 'Stone Sour', source: 'com.weaseldev.fortunecookies'},
-          {type: 'artist', name: 'Metallica', source: 'com.weaseldev.fortunecookies'}
+          {type: 'artist', name: 'Taylor Swift', source: 'com.unknown'},
+          {type: 'artist', name: 'Stone Sour', source: 'com.unknown'},
+          {type: 'artist', name: 'Metallica', source: 'com.unknown'}
         ];
         const artist = entities[Math.floor(randomArtist.next * entities.length)];
         this.updateSingleton('artist', artist);

--- a/particles/PipeApps2/ArtistAutofill.recipes
+++ b/particles/PipeApps2/ArtistAutofill.recipes
@@ -3,7 +3,6 @@ import './PipeEntity.schema'
 import '../Services/schemas/RandomData.schema'
 import '../Services/particles/Random.particle'
 
-
 schema Artist
   Text type
   Text name
@@ -21,10 +20,10 @@ particle SuggestArtist in './source/SuggestArtist.js'
 particle RequireQuery in './source/Noop.js'
   in PipeEntity query
 
-recipe AutofillSpotifyMusic &autofill
+recipe AutofillSpotifyMusic &artist_autofill
   create as artist
   create as suggestion
-  use #autofill_com_spotify_music as query
+  use #artist_autofill as query
   RequireQuery
     query = query
   RandomParticle

--- a/particles/PipeApps2/ArtistAutofill.recipes
+++ b/particles/PipeApps2/ArtistAutofill.recipes
@@ -34,4 +34,4 @@ recipe AutofillSpotifyMusic &artist_autofill
   SuggestArtist
     artist = artist
     suggestion = suggestion
-  description `autofill artist`
+  description `suggest artist`

--- a/particles/PipeApps2/Caption.recipes
+++ b/particles/PipeApps2/Caption.recipes
@@ -6,8 +6,8 @@ particle CaptionThis in './source/CaptionThis.js'
   out Json output
   consume content
 
-recipe CaptionThis &caption
-  use #caption_ as query
+recipe CaptionThis &pipe_caption
+  use #pipe_caption as query
   create as suggestion
   CaptionThis
     query = query

--- a/particles/PipeApps2/MapsAutofill.recipes
+++ b/particles/PipeApps2/MapsAutofill.recipes
@@ -9,8 +9,8 @@ particle SuggestAddress in './source/SuggestAddress.js'
 particle RequireQuery in './source/Noop.js'
   in PipeEntity query
 
-recipe AutofillMaps &autofill
-  use #autofill_com_google_android_apps_maps as query
+recipe AutofillMaps &address_autofill
+  use #address_autofill as query
   map 'pipe-entities' as recentEntities
   create as suggestion
   RequireQuery

--- a/particles/PipeApps2/source/CaptionThis.js
+++ b/particles/PipeApps2/source/CaptionThis.js
@@ -18,7 +18,6 @@ defineParticle(({DomParticle, html, log}) => {
     }
     render({query}) {
       if (query) {
-        log('update');
         const text = query.name.split(' ');
         const json = JSON.stringify(text);
         this.updateSingleton('output', {json});

--- a/particles/PipeApps2/source/RandomArtist.js
+++ b/particles/PipeApps2/source/RandomArtist.js
@@ -16,9 +16,9 @@ defineParticle(({DomParticle, html, log}) => {
     update({randomArtist}) {
       if (randomArtist) {
         const entities = [
-          {type: 'artist', name: 'Taylor Swift', source: 'com.weaseldev.fortunecookies'},
-          {type: 'artist', name: 'Stone Sour', source: 'com.weaseldev.fortunecookies'},
-          {type: 'artist', name: 'Metallica', source: 'com.weaseldev.fortunecookies'}
+          {type: 'artist', name: 'Taylor Swift', source: 'com.unknown'},
+          {type: 'artist', name: 'Stone Sour', source: 'com.unknown'},
+          {type: 'artist', name: 'Metallica', source: 'com.unknown'}
         ];
         const artist = entities[Math.floor(randomArtist.next * entities.length)];
         this.updateSingleton('artist', artist);

--- a/shells/lib/runtime/utils.js
+++ b/shells/lib/runtime/utils.js
@@ -48,21 +48,31 @@ const parse = async (content, options) => {
 };
 
 const resolve = async (arc, recipe) =>{
-  if (!recipe.normalize()) {
-    warn('failed to normalize:\n', recipe.toString());
-  } else {
+  if (normalize(recipe)) {
     let plan = recipe;
     if (!plan.isResolved()) {
       const resolver = new RecipeResolver(arc);
       plan = await resolver.resolve(recipe);
       if (!plan || !plan.isResolved()) {
         warn('failed to resolve:\n', (plan || recipe).toString({showUnresolved: true}));
-        log(arc.context, arc, arc.context.storeTags);
+        //log(arc.context, arc, arc.context.storeTags);
         plan = null;
       }
     }
     return plan;
   }
+};
+
+const normalize = async (recipe) =>{
+  if (isNormalized(recipe) || recipe.normalize()) {
+    return true;
+  }
+  warn('failed to normalize:\n', recipe.toString());
+  return false;
+};
+
+const isNormalized = recipe => {
+  return Object.isFrozen(recipe);
 };
 
 const spawn = async ({id, serialization, context, composer, storage}) => {

--- a/shells/pipes-shell-2/api/autofill.js
+++ b/shells/pipes-shell-2/api/autofill.js
@@ -1,0 +1,89 @@
+/**
+ * @license
+ * Copyright 2019 Google LLC.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {generateId} from '../../../modalities/dom/components/generate-id.js';
+import {Utils} from '../../lib/runtime/utils.js';
+import {recipeByName, marshalOutput/*, instantiateRecipe*/} from '../lib/utils.js';
+import {logsFactory} from '../../../build/runtime/log-factory.js';
+
+const {warn} = logsFactory('pipe');
+
+export const autofill = async (msg, tid, bus, composerFactory, storage, context) => {
+  if (validateAutofillMsg(msg)) {
+    const entity = msg.entity;
+    const type = entity.type;
+    // arc
+    const composer = composerFactory(msg.modality);
+    const arc = await Utils.spawn({id: generateId(), composer, context/*, storage*/});
+    // recipe
+    const source = entity.source ? entity.source.replace(/\./g, '_') : '';
+    const tag = `${entity.type}_autofill`;
+    const name = entity.name;
+    const recipe = await marshalPipeRecipe({type, source, name, tag});
+    // instantiate
+    if (await instantiateRecipe(arc, recipe)) {
+      const handler = context.allRecipes.find(r => r.verbs.includes(tag));
+      if (!handler) {
+        // complain
+      }
+      else if (await instantiateRecipe(arc, handler)) {
+        // watch for output, deliver to bus
+        observeOutput(tid, bus, arc);
+      }
+    }
+  }
+};
+
+const validateAutofillMsg = msg => {
+  if (msg.entity && msg.entity.type) {
+    return true;
+  }
+  // TODO(sjmiles): complain
+  return false;
+};
+
+const instantiateRecipe = async (arc, recipe) => {
+  const plan = await Utils.resolve(arc, recipe);
+  if (!plan) {
+    warn('failed to resolve recipe', recipe);
+    return false;
+  }
+  await arc.instantiate(plan);
+  return true;
+};
+
+const marshalPipeRecipe = async ({type, source, name, tag}) => {
+  const manifestContent = buildEntityManifest({type, source, name}, tag);
+  const manifest = await Utils.parse(manifestContent);
+  return recipeByName(manifest, 'Pipe');
+};
+
+const buildEntityManifest = ({type, source, name}, tag) => `
+import 'https://$particles/PipeApps2/Trigger.recipes'
+resource PipeEntityResource
+  start
+  [{"type": "${type}", "name": "${name}", "source": "${source}"}]
+store LivePipeEntity of PipeEntity 'LivePipeEntity' @0 #pipe_entity #${tag} in PipeEntityResource
+recipe Pipe
+  use 'LivePipeEntity' #pipe_entity #${tag} as pipe
+  Trigger
+    pipe = pipe
+`;
+
+export const observeOutput = async (tid, bus, arc) => {
+  // TODO(sjmiles): need better system than 20-and-out
+  for (let i=0; i<20; i++) {
+    const entity = await marshalOutput(arc);
+    if (entity) {
+      const data = JSON.parse(entity.rawData.json);
+      bus.send({message: 'data', tid, data});
+    }
+  }
+};

--- a/shells/pipes-shell-2/api/autofill.js
+++ b/shells/pipes-shell-2/api/autofill.js
@@ -10,7 +10,7 @@
 
 import {generateId} from '../../../modalities/dom/components/generate-id.js';
 import {Utils} from '../../lib/runtime/utils.js';
-import {recipeByName, marshalOutput/*, instantiateRecipe*/} from '../lib/utils.js';
+import {recipeByName, marshalOutput} from '../lib/utils.js';
 import {logsFactory} from '../../../build/runtime/log-factory.js';
 
 const {warn} = logsFactory('pipe');

--- a/shells/pipes-shell-2/api/caption.js
+++ b/shells/pipes-shell-2/api/caption.js
@@ -1,0 +1,90 @@
+/**
+ * @license
+ * Copyright 2019 Google LLC.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {generateId} from '../../../modalities/dom/components/generate-id.js';
+import {Utils} from '../../lib/runtime/utils.js';
+import {recipeByName, marshalOutput} from '../lib/utils.js';
+import {logsFactory} from '../../../build/runtime/log-factory.js';
+
+const {warn} = logsFactory('pipe');
+
+export const caption = async (msg, tid, bus, composerFactory, storage, context) => {
+  if (validateAutofillMsg(msg)) {
+    const entity = msg.entity;
+    const type = entity.type;
+    const tag = `pipe_caption`;
+    const handler = context.allRecipes.find(r => r.verbs.includes(tag));
+    if (!handler) {
+      warn(`found no autofill verbs matching [${tag}]`);
+    } else {
+      // arc
+      const composer = composerFactory(msg.modality);
+      const arc = await Utils.spawn({id: generateId(), composer, context/*, storage*/});
+      // recipe
+      const source = entity.source ? entity.source.replace(/\./g, '_') : '';
+      const name = entity.name;
+      const recipe = await marshalPipeRecipe({type, source, name, tag});
+      // instantiate
+      if (await instantiateRecipe(arc, recipe)) {
+        if (await instantiateRecipe(arc, handler)) {
+          // watch for output, deliver to bus
+          observeOutput(tid, bus, arc);
+        }
+      }
+    }
+  }
+};
+
+const validateAutofillMsg = msg => {
+  if (msg.entity && msg.entity.type) {
+    return true;
+  }
+  // TODO(sjmiles): complain
+  return false;
+};
+
+const instantiateRecipe = async (arc, recipe) => {
+  const plan = await Utils.resolve(arc, recipe);
+  if (!plan) {
+    warn('failed to resolve recipe', recipe);
+    return false;
+  }
+  await arc.instantiate(plan);
+  return true;
+};
+
+const marshalPipeRecipe = async ({type, source, name, tag}) => {
+  const manifestContent = buildEntityManifest({type, source, name}, tag);
+  const manifest = await Utils.parse(manifestContent);
+  return recipeByName(manifest, 'Pipe');
+};
+
+const buildEntityManifest = ({type, source, name}, tag) => `
+import 'https://$particles/PipeApps2/Trigger.recipes'
+resource PipeEntityResource
+  start
+  [{"type": "${type}", "name": "${name}", "source": "${source}"}]
+store LivePipeEntity of PipeEntity 'LivePipeEntity' @0 #pipe_entity #${tag} in PipeEntityResource
+recipe Pipe
+  use 'LivePipeEntity' #pipe_entity #${tag} as pipe
+  Trigger
+    pipe = pipe
+`;
+
+export const observeOutput = async (tid, bus, arc) => {
+  // TODO(sjmiles): need better system than 20-and-out
+  for (let i=0; i<20; i++) {
+    const entity = await marshalOutput(arc);
+    if (entity) {
+      const data = JSON.parse(entity.rawData.json);
+      bus.send({message: 'data', tid, data});
+    }
+  }
+};

--- a/shells/pipes-shell-2/api/pipes-api.js
+++ b/shells/pipes-shell-2/api/pipes-api.js
@@ -18,20 +18,29 @@ let pipeStore;
 let contextPipeStore;
 
 export const marshalPipesArc = async (storage, context) => {
+  // canonical arc to hold observed pipes entities
   pipes = await requirePipesArc(storage);
+  // access the pipe store directly
   pipeStore = storeByTag(pipes, 'pipeEntities');
+  // create a context store
   contextPipeStore = await initPipeStore(context);
+  // mirror pipeStore entities into contextPipeStore, emulating
+  // the sharing mechanism implemented in fancier context impls
   mirrorStore(pipeStore, contextPipeStore);
   console.log('mirroring pipeStore into contextPipeStore');
 };
 
-export const addPipeEntity = async (data) => {
+export const addPipeEntity = async data => {
+  // ensure there is a timestamp
   data.timestamp = data.timestamp || Date.now();
+  // ensure there is a source value
   data.source = data.source || 'com.unknown';
+  // construct an Entity
   const entity = {
     id: generateId(),
     rawData: data
   };
+  // add to pipeStore
   console.log('adding pipeEntity', entity);
   await pipeStore.store(entity, [generateId()]);
 };

--- a/shells/pipes-shell-2/api/spawn-api.js
+++ b/shells/pipes-shell-2/api/spawn-api.js
@@ -62,6 +62,32 @@ export const observeOutput = async (tid, bus, arc) => {
   }
 };
 
+export const ingestSuggestion = async (arc, suggestionText) => {
+  if (suggestionText) {
+    const suggestion = arc._pipe_suggestions.find(suggestion => suggestion.descriptionText == suggestionText);
+    if (!suggestion) {
+      log(`failed to find suggestion [${suggestionText}]`);
+    } else {
+      // instantiate requested recipe
+      await arc.instantiate(suggestion.plan);
+      log(`instantiated suggestion [${suggestionText}]`);
+    }
+  }
+};
+
+export const ingestRecipe = async (arc, recipeName) => {
+  if (recipeName) {
+    const recipe = recipeByName(arc.context, recipeName);
+    if (!recipe) {
+      log(`failed to find recipe [${recipeName}]`);
+    } else {
+      // instantiate requested recipe
+      await instantiateRecipe(arc, recipe);
+      log(`instantiated recipe [${recipeName}]`);
+    }
+  }
+};
+
 export const ingestEntity = async (arc, entity) => {
   // instantiate bespoke recipe for entity
   const recipe = await marshalPipeRecipe(entity);
@@ -88,28 +114,3 @@ recipe Pipe
     pipe = pipe
 `;
 
-export const ingestSuggestion = async (arc, suggestionText) => {
-  if (suggestionText) {
-    const suggestion = arc._pipe_suggestions.find(suggestion => suggestion.descriptionText == suggestionText);
-    if (!suggestion) {
-      log(`failed to find suggestion [${suggestionText}]`);
-    } else {
-      // instantiate requested recipe
-      await arc.instantiate(suggestion.plan);
-      log(`instantiated suggestion [${suggestionText}]`);
-    }
-  }
-};
-
-export const ingestRecipe = async (arc, recipeName) => {
-  if (recipeName) {
-    const recipe = recipeByName(arc.context, recipeName);
-    if (!recipe) {
-      log(`failed to find recipe [${recipeName}]`);
-    } else {
-      // instantiate requested recipe
-      await instantiateRecipe(arc, recipe);
-      log(`instantiated recipe [${recipeName}]`);
-    }
-  }
-};

--- a/shells/pipes-shell-2/lib/utils.js
+++ b/shells/pipes-shell-2/lib/utils.js
@@ -40,7 +40,8 @@ export const createPlanificator = async arc => {
     storageKeyBase: 'volatile',
     onlyConsumer: false,
     debug: true,
-    inspectorFactory: devtoolsPlannerInspectorFactory
+    inspectorFactory: devtoolsPlannerInspectorFactory,
+    noSpecEx: true
   };
   const planificator = await Planificator.create(arc, options);
   //
@@ -87,7 +88,6 @@ export const marshalOutput = async arc => {
     }
   });
 };
-
 
 export const findContainers = tree => {
   const containers = {};

--- a/shells/pipes-shell-2/node/node.js
+++ b/shells/pipes-shell-2/node/node.js
@@ -37,8 +37,6 @@ const client = global.DeviceClient || {};
   const bus = await initPipe(client, paths, storage, composerFactory);
   // export bus
   global.ShellApi = bus;
-  // notify client
-  bus.send({message: 'ready'});
   // run smokeTest if requested
   if (test) {
     smokeTest(bus);

--- a/shells/pipes-shell-2/pipe.js
+++ b/shells/pipes-shell-2/pipe.js
@@ -14,10 +14,11 @@ import {Utils} from '../lib/runtime/utils.js';
 import {requireContext} from './context.js';
 import {marshalPipesArc, addPipeEntity} from './api/pipes-api.js';
 import {marshalArc, installPlanner, deliverSuggestions, ingestEntity, ingestRecipe, ingestSuggestion, observeOutput} from './api/spawn-api.js';
-import {autofill} from './api/autofill.js';
 import {dispatcher} from './dispatcher.js';
 import {Bus} from './bus.js';
 import {initPlanner} from './planner.js';
+import {autofill} from './api/autofill.js';
+import {caption} from './api/caption.js';
 
 const {log, warn} = logsFactory('pipe');
 
@@ -46,6 +47,9 @@ const populateDispatcher = (dispatcher, api, composerFactory, storage, context) 
     },
     autofill: async (msg, tid, bus) => {
       return await autofill(msg, tid, bus, composerFactory, storage, context);
+    },
+    caption: async (msg, tid, bus) => {
+      return await caption(msg, tid, bus, composerFactory, storage, context);
     },
     ingest: async (msg, tid, bus) => {
       if (msg.tid) {

--- a/shells/pipes-shell-2/pipe.js
+++ b/shells/pipes-shell-2/pipe.js
@@ -36,7 +36,16 @@ export const initPipe = async (client, paths, storage, composerFactory) => {
   // marshal dispatcher
   populateDispatcher(dispatcher, api, composerFactory, storage, context);
   // create bus
-  return new Bus(dispatcher, client);
+  const bus = new Bus(dispatcher, client);
+  // send pipe identifiers to client
+  identifyPipe(context, bus);
+  // return bus
+  return bus;
+};
+
+const identifyPipe = async (context, bus) => {
+  const recipes = context.allRecipes.map(r => r.name);
+  bus.send({message: 'ready', recipes});
 };
 
 const populateDispatcher = (dispatcher, api, composerFactory, storage, context) => {

--- a/shells/pipes-shell-2/planner.js
+++ b/shells/pipes-shell-2/planner.js
@@ -1,0 +1,13 @@
+/**
+ * @license
+ * Copyright 2019 Google LLC.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+export const initPlanner = (context) => {
+  const names = context.allRecipes.map(r => r.name);
+  console.warn(names);
+};

--- a/shells/pipes-shell-2/smoke.js
+++ b/shells/pipes-shell-2/smoke.js
@@ -24,7 +24,8 @@ export const smokeTest = async bus => {
   //
   const spotifyAutofill = () => {
     // request autofill for com.spotify.music
-    bus.receive({message: 'ingest', modality: 'dom', entity: {type: 'autofill', source: 'com.spotify.music'}});
+    //bus.receive({message: 'ingest', modality: 'dom', entity: {type: 'autofill', source: 'com.spotify.music'}});
+    bus.receive({message: 'autofill', modality: 'dom', entity: {type: 'artist'}});
   };
   //
   const mapsAutofill = () => {
@@ -62,7 +63,7 @@ export const smokeTest = async bus => {
     };
   };
   //
-  const enqueue = tests => {
+  const enqueue = (tests, delay) => {
     console.warn(`busish: starting new task...(remaining ${tests.length})`);
     (tests.shift())();
     if (tests.length) {
@@ -70,17 +71,18 @@ export const smokeTest = async bus => {
       // to simulate (more) serial task requests
       // and make it possible to read the console.
       // (should work in parallel also)
-      setTimeout(() => enqueue(tests), 3000);
+      setTimeout(() => enqueue(tests), delay);
     }
   };
   //
   enqueue([
     captureData,
-    ingestEntity,
+    //ingestEntity,
     spotifyAutofill,
-    mapsAutofill,
-    tapToCaption,
-    longRunning,
-    customArc
-  ]);
+    //mapsAutofill,
+    //tapToCaption,
+    //longRunning,
+    //customArc
+  //], 3000);
+  ], 0);
 };

--- a/shells/pipes-shell-2/smoke.js
+++ b/shells/pipes-shell-2/smoke.js
@@ -30,7 +30,8 @@ export const smokeTest = async bus => {
   //
   const mapsAutofill = () => {
     // request autofill for com.google.android.apps.maps
-    bus.receive({message: 'ingest', modality: 'dom', entity: {type: 'autofill', source: 'com.google.android.apps.maps'}});
+    //bus.receive({message: 'ingest', modality: 'dom', entity: {type: 'autofill', source: 'com.google.android.apps.maps'}});
+    bus.receive({message: 'autofill', modality: 'dom', entity: {type: 'address'}});
   };
   //
   const tapToCaption = () => {
@@ -79,7 +80,7 @@ export const smokeTest = async bus => {
     captureData,
     //ingestEntity,
     spotifyAutofill,
-    //mapsAutofill,
+    mapsAutofill,
     //tapToCaption,
     //longRunning,
     //customArc

--- a/shells/pipes-shell-2/smoke.js
+++ b/shells/pipes-shell-2/smoke.js
@@ -36,7 +36,7 @@ export const smokeTest = async bus => {
   //
   const tapToCaption = () => {
     // request tap-to-caption resolution for 'Dogs are awesome'
-    bus.receive({message: 'ingest', modality: 'dom', entity: {type: 'caption', name: 'Dogs are awesome'}});
+    bus.receive({message: 'caption', modality: 'dom', entity: {type: 'caption', name: 'Dogs are awesome'}});
   };
   //
   const longRunning = () => {
@@ -72,7 +72,7 @@ export const smokeTest = async bus => {
       // to simulate (more) serial task requests
       // and make it possible to read the console.
       // (should work in parallel also)
-      setTimeout(() => enqueue(tests), delay);
+      setTimeout(() => enqueue(tests, delay), delay);
     }
   };
   //
@@ -81,9 +81,9 @@ export const smokeTest = async bus => {
     //ingestEntity,
     spotifyAutofill,
     mapsAutofill,
-    //tapToCaption,
+    tapToCaption,
     //longRunning,
     //customArc
-  //], 3000);
-  ], 0);
+  ], 500);
+  //], 0);
 };

--- a/shells/pipes-shell-2/web/web.js
+++ b/shells/pipes-shell-2/web/web.js
@@ -49,8 +49,6 @@ const client = window.DeviceClient || {};
   const bus = await initPipe(client, paths, storage, composerFactory);
   // export bus
   window.ShellApi = bus;
-  // notify client
-  bus.send({message: 'ready'});
   // run smokeTest if requested
   if (test) {
     smokeTest(bus);

--- a/src/planning/plan/plan-producer.ts
+++ b/src/planning/plan/plan-producer.ts
@@ -45,10 +45,11 @@ export class PlanProducer {
   searchStore?: SingletonStorageProvider;
   searchStoreCallback: ({}) => void;
   debug: boolean;
+  noSpecEx: boolean;
   inspector?: PlannerInspector;
 
-  constructor(arc: Arc, result: PlanningResult, searchStore?: SingletonStorageProvider, inspector?: PlannerInspector, {debug = false} = {}) {
-    assert(result, 'result cannot be null');                
+  constructor(arc: Arc, result: PlanningResult, searchStore?: SingletonStorageProvider, inspector?: PlannerInspector, {debug = false, noSpecEx = false} = {}) {
+    assert(result, 'result cannot be null');
     assert(arc, 'arc cannot be null');
     this.arc = arc;
     this.result = result;
@@ -61,6 +62,7 @@ export class PlanProducer {
       this.searchStore.on('change', this.searchStoreCallback, this);
     }
     this.debug = debug;
+    this.noSpecEx = noSpecEx;
   }
 
   get isPlanning() { return this._isPlanning; }
@@ -134,6 +136,7 @@ export class PlanProducer {
 
     this.needReplan = true;
     this.replanOptions = options;
+
     if (this.isPlanning) {
       return;
     }
@@ -161,7 +164,7 @@ export class PlanProducer {
           contextual: this.replanOptions['contextual']}, this.arc)) {
         // Store suggestions to store.
         await this.result.flush();
-        
+
         if (this.inspector) this.inspector.updatePlanningResults(this.result, options['metadata']);
       } else {
         // Add skipped result to devtools.
@@ -188,6 +191,7 @@ export class PlanProducer {
         recipeIndex: this.recipeIndex
       },
       speculator: this.speculator,
+      noSpecEx: this.noSpecEx
     });
 
     suggestions = await this.planner.suggest(options['timeout'] || defaultTimeoutMs, generations);

--- a/src/planning/planner.ts
+++ b/src/planning/planner.ts
@@ -219,22 +219,26 @@ export class Planner implements InspectablePlanner {
     }
     let relevance: Relevance|null = null;
     let description: Description|null = null;
-    if (this.speculator) {
-      const result = await this.speculator.speculate(this.arc, plan, hash);
-      if (!result) {
-        return undefined;
-      }
-      const speculativeArc = result.speculativeArc;
-      relevance = result.relevance;
-      description = await Description.create(speculativeArc, relevance);
-    } else {
-      description = await Description.createForPlan(plan);
-    }
+    // if (this.speculator) {
+    //   const result = await this.speculator.speculate(this.arc, plan, hash);
+    //   if (!result) {
+    //     return undefined;
+    //   }
+    //   const speculativeArc = result.speculativeArc;
+    //   relevance = result.relevance;
+    //   description = await Description.create(speculativeArc, relevance);
+    // } else {
+    //   description = await Description.createForPlan(arc, plan);
+    // }
+    description = await Description.createForPlan(arc, plan);
     const suggestion = Suggestion.create(plan, hash, relevance);
     suggestion.setDescription(
         description,
         this.arc.modality,
-        this.arc.pec.slotComposer ? this.arc.pec.slotComposer.modalityHandler.descriptionFormatter : undefined);
+        this.arc.pec.slotComposer ?
+          this.arc.pec.slotComposer.modalityHandler.descriptionFormatter
+          : undefined
+    );
     suggestionByHash().set(hash, suggestion);
     return suggestion;
   }

--- a/src/planning/planner.ts
+++ b/src/planning/planner.ts
@@ -65,6 +65,7 @@ export interface PlannerInitOptions {
   strategyArgs?: {};
   speculator?: Speculator;
   inspectorFactory?: PlannerInspectorFactory;
+  noSpecEx?: boolean;
 }
 
 export class Planner implements InspectablePlanner {
@@ -73,9 +74,10 @@ export class Planner implements InspectablePlanner {
   strategizer: Strategizer;
   speculator: Speculator|null;
   inspector?: PlannerInspector;
+  noSpecEx: boolean;
 
   // TODO: Use context.arc instead of arc
-  init(arc: Arc, {strategies = Planner.AllStrategies, ruleset = Rulesets.Empty, strategyArgs = {}, speculator = null, inspectorFactory = null}: PlannerInitOptions) {
+  init(arc: Arc, {strategies = Planner.AllStrategies, ruleset = Rulesets.Empty, strategyArgs = {}, speculator = null, inspectorFactory = null, noSpecEx = false}: PlannerInitOptions) {
     strategyArgs = Object.freeze({...strategyArgs});
     this.arc = arc;
     const strategyImpls = strategies.map(strategy => new strategy(arc, strategyArgs));
@@ -84,6 +86,7 @@ export class Planner implements InspectablePlanner {
     if (inspectorFactory) {
       this.inspector = inspectorFactory.create(this);
     }
+    this.noSpecEx = noSpecEx;
   }
 
   // Specify a timeout value less than zero to disable timeouts.
@@ -219,18 +222,17 @@ export class Planner implements InspectablePlanner {
     }
     let relevance: Relevance|null = null;
     let description: Description|null = null;
-    // if (this.speculator) {
-    //   const result = await this.speculator.speculate(this.arc, plan, hash);
-    //   if (!result) {
-    //     return undefined;
-    //   }
-    //   const speculativeArc = result.speculativeArc;
-    //   relevance = result.relevance;
-    //   description = await Description.create(speculativeArc, relevance);
-    // } else {
-    //   description = await Description.createForPlan(arc, plan);
-    // }
-    description = await Description.createForPlan(arc, plan);
+    if (this.speculator && !this.noSpecEx) {
+      const result = await this.speculator.speculate(this.arc, plan, hash);
+      if (!result) {
+        return undefined;
+      }
+      const speculativeArc = result.speculativeArc;
+      relevance = result.relevance;
+      description = await Description.create(speculativeArc, relevance);
+    } else {
+      description = await Description.createForPlan(arc, plan);
+    }
     const suggestion = Suggestion.create(plan, hash, relevance);
     suggestion.setDescription(
         description,

--- a/src/runtime/description-formatter.ts
+++ b/src/runtime/description-formatter.ts
@@ -78,7 +78,7 @@ export class DescriptionFormatter {
 
   // TODO(mmandlis): the override of this function in subclasses also overrides the output. We'll need to unify
   // this into an output type hierarchy before we can assign a useful type to the output of this function.
-  // tslint:disable-next-line: no-any 
+  // tslint:disable-next-line: no-any
   _combineSelectedDescriptions(selectedDescriptions: ParticleDescription[], options: CombinedDescriptionsOptions = {}) {
     const suggestions = [];
     selectedDescriptions.map(particle => {
@@ -99,7 +99,7 @@ export class DescriptionFormatter {
 
   // TODO(mmandlis): the override of this function in subclasses also overrides the output. We'll need to unify
   // this into an output type hierarchy before we can assign a useful type to the output of this function.
-  // tslint:disable-next-line: no-any 
+  // tslint:disable-next-line: no-any
   _joinDescriptions(strings): any {
     const nonEmptyStrings = strings.filter(str => str);
     const count = nonEmptyStrings.length;
@@ -211,7 +211,7 @@ export class DescriptionFormatter {
         extra,
         _handleConn: handleConn,
         value: particleDescription._connections[handleConn.name].value
-      }];  
+      }];
     }
 
     // slot connection
@@ -384,7 +384,7 @@ export class DescriptionFormatter {
 
   // TODO(mmandlis): the override of this function in subclasses also overrides the output. We'll need to unify
   // this into an output type hierarchy before we can assign a useful type to the output of this function.
-  // tslint:disable-next-line: no-any 
+  // tslint:disable-next-line: no-any
   _formatBigCollection(handleName, firstValue): any {
     return `collection of items like ${firstValue.rawData.name}`;
   }
@@ -398,7 +398,7 @@ export class DescriptionFormatter {
         valueDescription = valueDescription.replace(matches[0], entityValue[matches[1]]);
       }
       return valueDescription;
-    } 
+    }
     if (entityValue['name']) {
       return entityValue['name'];
     }
@@ -456,7 +456,10 @@ export class DescriptionFormatter {
       // Choose connections with patterns (manifest-based or dynamic).
       const connectionSpec = connection.spec;
       const particleDescription = this.particleDescriptions.find(desc => desc._particle === connection.particle);
-      return !!connectionSpec.pattern || !!particleDescription._connections[connection.name].pattern;
+      // TODO(sjmiles): added particleDescription null-check for
+      // the moment, but we need to root cause this problem
+      return !!connectionSpec.pattern ||
+        (!!particleDescription && !!particleDescription._connections[connection.name].pattern);
     });
 
     possibleConnections.sort((c1, c2) => {

--- a/src/runtime/description.ts
+++ b/src/runtime/description.ts
@@ -29,9 +29,23 @@ export class Description {
       private readonly particleDescriptions: ParticleDescription[] = []) {
   }
 
-  static async createForPlan(plan: Recipe): Promise<Description> {
+  static async XcreateForPlan(plan: Recipe): Promise<Description> {
     const particleDescriptions = await Description.initDescriptionHandles(plan.particles);
     return new Description({}, [{patterns: plan.patterns, particles: plan.particles}], particleDescriptions);
+  }
+
+  static async createForPlan(arc: Arc, plan: Recipe): Promise<Description> {
+    const allParticles = plan.particles;
+    const particleDescriptions = await Description.initDescriptionHandles(allParticles, arc);
+    const storeDescById: {[id: string]: string} = {};
+    for (const {id} of plan.handles) {
+      const store = arc.findStoreById(id);
+      if (store && store instanceof StorageProviderBase) {
+        storeDescById[id] = arc.getStoreDescription(store);
+      }
+    }
+    // ... and pass to the private constructor.
+    return new Description(storeDescById, [{patterns: plan.patterns, particles: plan.particles}], particleDescriptions);
   }
 
   /**

--- a/src/runtime/description.ts
+++ b/src/runtime/description.ts
@@ -23,10 +23,10 @@ import {Dictionary} from './hot.js';
 
 export class Description {
   private constructor(
-      private readonly storeDescById: Dictionary<string> = {},
-      // TODO(mmandlis): replace Particle[] with serializable json objects.
-      private readonly arcRecipes: {patterns: string[], particles: Particle[]}[],
-      private readonly particleDescriptions: ParticleDescription[] = []) {
+    private readonly storeDescById: Dictionary<string> = {},
+    // TODO(mmandlis): replace Particle[] with serializable json objects.
+    private readonly arcRecipes: {patterns: string[], particles: Particle[]}[],
+    private readonly particleDescriptions: ParticleDescription[] = []) {
   }
 
   static async XcreateForPlan(plan: Recipe): Promise<Description> {


### PR DESCRIPTION
- round-trip time for autofill using Planner is ~1s (which isn't bad)
- disabling SpecEx didn't make a practical difference (for this recipe corpus)
- short-circuiting Planner entirely reduced autofill time to 120ms

Also:
- simplify api: use [verb] in `{message: [verb], entity: [data]}` more explicitly instead of overloading verb `ingest`
- new verb: `autofill`: matches recipes of the form `autofill_[type]` (where `type` is a property of `[data]`)
- new verb `caption`: matches recipes of the form `pipe_caption`
- added list of loaded recipe names to `ready` signal data