### PR TITLE
Fix syntax of multiple 'derives from' claims

### DIFF
--- a/src/runtime/manifest-parser.peg
+++ b/src/runtime/manifest-parser.peg
@@ -313,7 +313,7 @@ ParticleClaimIsTag
   }
 
 ParticleClaimDerivesFrom
-  = 'claim' whiteSpace handle:lowerIdent whiteSpace 'derives from' whiteSpace first:lowerIdent rest:(whiteSpace 'and' whiteSpace lowerIdent)* eolWhiteSpace
+  = 'claim' whiteSpace handle:lowerIdent whiteSpace 'derives from' whiteSpace first:lowerIdent rest:(whiteSpace 'and derives from' whiteSpace lowerIdent)* eolWhiteSpace
   {
     const parentHandles: string[] = [first, ...rest.map(item => item[3])];
     return {

--- a/src/runtime/test/manifest-test.ts
+++ b/src/runtime/test/manifest-test.ts
@@ -1996,7 +1996,7 @@ resource SomeName
           in T {} input1
           in T {} input2
           out T {} output
-          claim output derives from input1 and input2
+          claim output derives from input1 and derives from input2
       `);
       assert.lengthOf(manifest.particles, 1);
       const particle = manifest.particles[0];


### PR DESCRIPTION
Syntax was "derives from foo and bar". Now it's "derives from foo and derives from bar".