### PR TITLE
Adds support for "is not" for tag claims (syntax only)

### DIFF
--- a/src/runtime/manifest-ast-nodes.ts
+++ b/src/runtime/manifest-ast-nodes.ts
@@ -181,6 +181,7 @@ export interface ParticleClaimIsTag extends BaseNode {
   kind: 'particle-trust-claim-is-tag';
   claimType: ClaimType.IsTag;
   handle: string;
+  isNot: boolean;
   tag: string;
 }
 

--- a/src/runtime/manifest-parser.peg
+++ b/src/runtime/manifest-parser.peg
@@ -301,7 +301,7 @@ ParticleClaimStatement
   / ParticleClaimDerivesFrom
 
 ParticleClaimIsTag
-  = 'claim' whiteSpace handle:lowerIdent whiteSpace 'is' whiteSpace tag:lowerIdent eolWhiteSpace
+  = 'claim' whiteSpace handle:lowerIdent whiteSpace 'is' not:'not'? whiteSpace tag:lowerIdent eolWhiteSpace
   {
     return {
       kind: 'particle-trust-claim-is-tag',

--- a/src/runtime/manifest-parser.peg
+++ b/src/runtime/manifest-parser.peg
@@ -301,13 +301,14 @@ ParticleClaimStatement
   / ParticleClaimDerivesFrom
 
 ParticleClaimIsTag
-  = 'claim' whiteSpace handle:lowerIdent whiteSpace 'is' not:'not'? whiteSpace tag:lowerIdent eolWhiteSpace
+  = 'claim' whiteSpace handle:lowerIdent whiteSpace 'is' not:(' not')? whiteSpace tag:lowerIdent eolWhiteSpace
   {
     return {
       kind: 'particle-trust-claim-is-tag',
       claimType: 'is-tag',
       location: location(),
       handle,
+      isNot: not != null,
       tag,
     } as AstNode.ParticleClaimIsTag;
   }

--- a/src/runtime/manifest-parser.peg
+++ b/src/runtime/manifest-parser.peg
@@ -301,7 +301,7 @@ ParticleClaimStatement
   / ParticleClaimDerivesFrom
 
 ParticleClaimIsTag
-  = 'claim' whiteSpace handle:lowerIdent whiteSpace 'is' not:(' not')? whiteSpace tag:lowerIdent eolWhiteSpace
+  = 'claim' whiteSpace handle:lowerIdent whiteSpace 'is' whiteSpace not:('not' whiteSpace)? tag:lowerIdent eolWhiteSpace
   {
     return {
       kind: 'particle-trust-claim-is-tag',

--- a/src/runtime/particle-claim.ts
+++ b/src/runtime/particle-claim.ts
@@ -22,14 +22,14 @@ export type Claim = ClaimIsTag | ClaimDerivesFrom;
 export class ClaimIsTag {
   readonly type: ClaimType.IsTag = ClaimType.IsTag;
 
-  constructor(readonly handle: HandleConnectionSpec, readonly tag: string) {}
+  constructor(readonly handle: HandleConnectionSpec, readonly isNot: boolean, readonly tag: string) {}
 
   static fromASTNode(handle: HandleConnectionSpec, astNode: ParticleClaimIsTag) {
-    return new ClaimIsTag(handle, astNode.tag);
+    return new ClaimIsTag(handle, astNode.isNot, astNode.tag);
   }
 
   toManifestString() {
-    return `claim ${this.handle.name} is ${this.tag}`;
+    return `claim ${this.handle.name} is ${this.isNot ? 'not ' : ''}${this.tag}`;
   }
 }
 

--- a/src/runtime/test/manifest-test.ts
+++ b/src/runtime/test/manifest-test.ts
@@ -2008,6 +2008,25 @@ resource SomeName
       assert.sameMembers(claim.parentHandles.map(h => h.name), ['input1', 'input2']);
     });
 
+    it('supports "is not" tag claims', async () => {
+      const manifest = await Manifest.parse(`
+        particle A
+          out T {} output1
+          out T {} output2
+          claim output1 is not property1
+      `);
+      assert.lengthOf(manifest.particles, 1);
+      const particle = manifest.particles[0];
+      assert.isEmpty(particle.trustChecks);
+      assert.equal(particle.trustClaims.size, 1);
+
+// How should 'not' differ?
+      const claim1 = particle.trustClaims.get('output1') as ClaimIsTag;
+      assert.equal(claim1.handle.name, 'output1');
+      assert.equal(claim1.tag, 'property1');
+
+     });
+
     it('supports multiple check statements', async () => {
       const manifest = await Manifest.parse(`
         particle A

--- a/src/runtime/test/manifest-test.ts
+++ b/src/runtime/test/manifest-test.ts
@@ -2006,7 +2006,6 @@ resource SomeName
       assert.equal(claim1.handle.name, 'output1');
       assert.equal(claim1.isNot, true);
       assert.equal(claim1.tag, 'property1');
-
      });
 
     it('supports "derives from" claims with multiple parents', async () => {
@@ -2078,8 +2077,10 @@ resource SomeName
   in T {} input2
   out T {} output1
   out T {} output2
+  out T {} output3
   claim output1 is trusted
   claim output2 derives from input2
+  claim output3 is not dangerous
   check input1 is trusted or is from handle input2
   check input2 is extraTrusted
   modality dom`;

--- a/src/runtime/test/manifest-test.ts
+++ b/src/runtime/test/manifest-test.ts
@@ -1990,6 +1990,25 @@ resource SomeName
       assert.equal(claim2.tag, 'property2');
     });
 
+    it('supports "is not" tag claims', async () => {
+      const manifest = await Manifest.parse(`
+        particle A
+          out T {} output1
+          out T {} output2
+          claim output1 is not property1
+      `);
+      assert.lengthOf(manifest.particles, 1);
+      const particle = manifest.particles[0];
+      assert.isEmpty(particle.trustChecks);
+      assert.equal(particle.trustClaims.size, 1);
+
+      const claim1 = particle.trustClaims.get('output1') as ClaimIsTag;
+      assert.equal(claim1.handle.name, 'output1');
+      assert.equal(claim1.isNot, true);
+      assert.equal(claim1.tag, 'property1');
+
+     });
+
     it('supports "derives from" claims with multiple parents', async () => {
       const manifest = await Manifest.parse(`
         particle A
@@ -2007,25 +2026,6 @@ resource SomeName
       assert.equal(claim.handle.name, 'output');
       assert.sameMembers(claim.parentHandles.map(h => h.name), ['input1', 'input2']);
     });
-
-    it('supports "is not" tag claims', async () => {
-      const manifest = await Manifest.parse(`
-        particle A
-          out T {} output1
-          out T {} output2
-          claim output1 is not property1
-      `);
-      assert.lengthOf(manifest.particles, 1);
-      const particle = manifest.particles[0];
-      assert.isEmpty(particle.trustChecks);
-      assert.equal(particle.trustClaims.size, 1);
-
-// How should 'not' differ?
-      const claim1 = particle.trustClaims.get('output1') as ClaimIsTag;
-      assert.equal(claim1.handle.name, 'output1');
-      assert.equal(claim1.tag, 'property1');
-
-     });
 
     it('supports multiple check statements', async () => {
       const manifest = await Manifest.parse(`


### PR DESCRIPTION
This PR adds just the syntax and parsing. Changes to traversal and checking will come in a subsequent PR.