### PR TITLE
Remove incorrect/ineffective calls to Manifest.parse

### DIFF
--- a/src/runtime/test/arc-tests.ts
+++ b/src/runtime/test/arc-tests.ts
@@ -843,7 +843,7 @@ describe('Arc ' + storageKeyPrefix, () => {
           slot 'rootslotid-root' as root
           A
             consume root as root
-    `, loader);
+    `);
     const arc = new Arc({id: IdGenerator.newSession().newArcId('arcid'),
       storageKey: 'key', loader, slotComposer, context});
 

--- a/src/runtime/test/debug/outer-port-attachments-tests.ts
+++ b/src/runtime/test/debug/outer-port-attachments-tests.ts
@@ -37,7 +37,7 @@ describe('OuterPortAttachment', () => {
       recipe
         use as foo
         P
-          foo = foo`, loader);
+          foo = foo`);
     const runtime = new Runtime(loader, MockSlotComposer, context);
     const arc = runtime.newArc('demo', 'volatile://', {inspectorFactory: devtoolsArcInspectorFactory});
 

--- a/src/runtime/test/manifest-test.ts
+++ b/src/runtime/test/manifest-test.ts
@@ -341,15 +341,6 @@ ${particleStr1}
         P1 as p1
           x -> thingHandle
         P2
-          x -> thingHandle`,
-      `particle P1
-      particle P2
-
-      recipe
-        ? #things as thingHandle
-        P1 as p1
-          x -> thingHandle
-        P2 as particle0
           x -> thingHandle`);
     const deserializedManifest = (await Manifest.parse(manifest.toString(), {}));
   });

--- a/src/tests/arc-integration-tests.ts
+++ b/src/tests/arc-integration-tests.ts
@@ -38,7 +38,7 @@ describe('Arc integration', () => {
           {"name": "mything"}
         ]
       store ThingStore of Thing 'mything' #best in ThingResource
-    `, loader);
+    `);
 
     const runtime = new Runtime(loader, FakeSlotComposer, manifest);
     const arc = runtime.newArc('demo', 'volatile://');


### PR DESCRIPTION
- Options is an object, calling with loader causes issues.
- Passing loader causes issues with filenames, so omit unused arg.