### PR TITLE
Wasm: handle content types in renderSlot

### DIFF
--- a/src/runtime/api-channel.ts
+++ b/src/runtime/api-channel.ts
@@ -18,6 +18,7 @@ import {Particle} from './particle.js';
 import * as recipeHandle from './recipe/handle.js';
 import * as recipeParticle from './recipe/particle.js';
 import {StorageProxy} from './storage-proxy.js';
+import {Content} from './slot-consumer.js';
 import {SerializedModelEntry} from './storage/crdt-collection-model.js';
 import {StorageProviderBase} from './storage/storage-provider-base.js';
 import {Type} from './type.js';
@@ -443,7 +444,7 @@ export abstract class PECOuterPort extends APIPort {
   StartRender(@Mapped particle: recipeParticle.Particle, @Direct slotName: string, @ObjectMap(MappingType.Direct, MappingType.Direct) providedSlots: Map<string, string>, @List(MappingType.Direct) contentTypes: string[]) {}
   StopRender(@Mapped particle: recipeParticle.Particle, @Direct slotName: string) {}
 
-  abstract onRender(particle: recipeParticle.Particle, slotName: string, content: string);
+  abstract onRender(particle: recipeParticle.Particle, slotName: string, content: Content);
   abstract onInitializeProxy(handle: StorageProviderBase, callback: number);
   abstract onSynchronizeProxy(handle: StorageProviderBase, callback: number);
   abstract onHandleGet(handle: StorageProviderBase, callback: number);
@@ -506,7 +507,7 @@ export abstract class PECInnerPort extends APIPort {
   abstract onStartRender(particle: Particle, slotName: string, providedSlots: Map<string, string>, contentTypes: string[]);
   abstract onStopRender(particle: Particle, slotName: string);
 
-  Render(@Mapped particle: Particle, @Direct slotName: string, @Direct content: string) {}
+  Render(@Mapped particle: Particle, @Direct slotName: string, @Direct content: Content) {}
   InitializeProxy(@Mapped handle: StorageProxy, @LocalMapped callback: (data: {version: number}) => void) {}
   SynchronizeProxy(@Mapped handle: StorageProxy, @LocalMapped callback: (data: {version: number, model: SerializedModelEntry[]}) => void) {}
   HandleGet(@Mapped handle: StorageProxy, @LocalMapped callback: (data: {id: string}) => void) {}

--- a/src/runtime/dom-particle-base.ts
+++ b/src/runtime/dom-particle-base.ts
@@ -12,6 +12,7 @@ import {Entity} from './entity.js';
 import {BigCollection, Collection, Singleton} from './handle.js';
 import {Particle} from './particle.js';
 import {SlotProxy} from './slot-proxy.js';
+import {Content} from './slot-consumer.js';
 
 export type RenderModel = object;
 
@@ -72,7 +73,7 @@ export class DomParticleBase extends Particle {
     contentTypes.forEach(ct => slot.requestedContentTypes.add(ct));
     // TODO(sjmiles): redundant, same answer for every slot
     if (this.shouldRender(...stateArgs)) {
-      const content: {templateName?, template?, model?} = {};
+      const content: Content = {};
       if (slot.requestedContentTypes.has('template')) {
         content.template = this.getTemplate(slot.slotName);
       }

--- a/src/runtime/particle-execution-host.ts
+++ b/src/runtime/particle-execution-host.ts
@@ -60,7 +60,7 @@ export class ParticleExecutionHost {
 
     this._apiPort = new class extends PECOuterPort {
 
-      onRender(particle: Particle, slotName: string, content: string) {
+      onRender(particle: Particle, slotName: string, content: Content) {
         if (pec.slotComposer) {
           pec.slotComposer.renderSlot(particle, slotName, content);
         }

--- a/src/runtime/slot-composer.ts
+++ b/src/runtime/slot-composer.ts
@@ -15,7 +15,7 @@ import {Description} from './description.js';
 import {ModalityHandler} from './modality-handler.js';
 import {Modality} from './modality.js';
 import {Particle} from './recipe/particle.js';
-import {SlotConsumer} from './slot-consumer.js';
+import {SlotConsumer, Content} from './slot-consumer.js';
 import {HostedSlotContext, ProvidedSlotContext, SlotContext} from './slot-context.js';
 
 export type SlotComposerOptions = {
@@ -165,7 +165,7 @@ export class SlotComposer {
     }
   }
 
-  renderSlot(particle: Particle, slotName: string, content) {
+  renderSlot(particle: Particle, slotName: string, content: Content) {
     const slotConsumer = this.getSlotConsumer(particle, slotName);
     assert(slotConsumer, `Cannot find slot (or hosted slot) ${slotName} for particle ${particle.name}`);
 

--- a/src/runtime/slot-consumer.ts
+++ b/src/runtime/slot-consumer.ts
@@ -17,13 +17,14 @@ import {Particle} from './recipe/particle.js';
 import {SlotConnection} from './recipe/slot-connection.js';
 import {HostedSlotContext, ProvidedSlotContext, SlotContext} from './slot-context.js';
 import {StartRenderOptions, StopRenderOptions} from './particle-execution-host.js';
+import {Dictionary} from './hot.js';
 
 export interface Content {
   templateName?: string | Map<string, string>;
   // tslint:disable-next-line: no-any
-  model?: {models: any, hash: string};
+  model?: Dictionary<any>;
   descriptions?: Map<string, Description>;
-  template?: string | Map<string, string>;
+  template?: string | Dictionary<string>;
 }
 
 export interface Rendering {
@@ -33,7 +34,7 @@ export interface Rendering {
   container?: any;
   // The data to be used in templating.
   // tslint:disable-next-line: no-any
-  model?: any;
+  model?: Dictionary<any>;
   // Specifies a particular template from the set of templates available to the
   // slot.
   templateName?: string;

--- a/src/runtime/slot-proxy.ts
+++ b/src/runtime/slot-proxy.ts
@@ -10,6 +10,7 @@
 
 import {Particle} from './particle';
 import {PECInnerPort} from './api-channel';
+import {Content} from './slot-consumer.js';
 
 /**
  * A representation of a consumed slot. Retrieved from a particle using
@@ -39,7 +40,7 @@ export class SlotProxy {
   /**
    * renders content to the slot.
    */
-  render(content): void {
+  render(content: Content): void {
     this.apiPort.Render(this.particle, this.slotName, content);
 
     Object.keys(content).forEach(key => { this.requestedContentTypes.delete(key); });

--- a/src/wasm/cpp/test-particle.cc
+++ b/src/wasm/cpp/test-particle.cc
@@ -19,16 +19,16 @@ public:
 
   void onHandleSync(arcs::Handle* handle, bool all_synced) override {
     if (all_synced) {
-      requestRender("root");
+      renderSlot("root", false, true);
     }
   }
 
   void onHandleUpdate(arcs::Handle* handle) override {
-    requestRender("root");
+    renderSlot("root", false, true);
   }
 
-  void requestRender(const std::string& slot_name) override {
-    std::string content = R"(
+  std::string getTemplate(const std::string& slot_name) override {
+    return R"(
       <style>
         #panel { margin: 10px; }
         #panel pre { margin-left: 20px; }
@@ -39,7 +39,7 @@ public:
         <button on-click="in_sng:get">get</button>
         <button on-click="in_sng:set">set (!)</button>
         <button on-click="in_sng:clear">clear (!)</button>
-        <pre>)" + arcs::entity_to_str(in_sng_.get(), "\n") + R"(</pre>
+        <pre>{{in_sng}}</pre>
 
         <b>[out Singleton]</b>
         <button on-click="ot_sng:get">get (!)</button>
@@ -51,7 +51,7 @@ public:
         <button on-click="io_sng:get">get</button>
         <button on-click="io_sng:set">set</button>
         <button on-click="io_sng:clear">clear</button>
-        <pre>)" + arcs::entity_to_str(io_sng_.get(), "\n") + R"(</pre>
+        <pre>{{io_sng}}</pre>
 
         <b>[in Collection]</b>
         <button on-click="in_col:size">size</button>
@@ -61,7 +61,7 @@ public:
         <button on-click="in_col:store">store (!)</button>
         <button on-click="in_col:remove">remove (!)</button>
         <button on-click="in_col:clear">clear (!)</button>
-        <pre>)" + collectionToStr(in_col_) + R"(</pre>
+        <pre>{{in_col}}</pre>
 
         <b>[out Collection]</b>
         <button on-click="ot_col:size">size (!)</button>
@@ -81,7 +81,7 @@ public:
         <button on-click="io_col:store">store</button>
         <button on-click="io_col:remove">remove</button>
         <button on-click="io_col:clear">clear</button>
-        <pre>)" + collectionToStr(io_col_) + R"(</pre>
+        <pre>{{io_col}}</pre>
 
         <b>Errors</b>
         <button on-click="_:throw">throw</button>
@@ -89,7 +89,14 @@ public:
         <button on-click="_:abort">abort</button>
         <button on-click="_:exit">exit</button>
       </div>)";
-    renderSlot(slot_name.c_str(), content.c_str());
+  }
+
+  void populateModel(const std::string& slot_name,
+                     std::function<void(const std::string&, const std::string&)> add) override {
+    add("in_sng", arcs::entity_to_str(in_sng_.get(), "\n"));
+    add("io_sng", arcs::entity_to_str(io_sng_.get(), "\n"));
+    add("in_col", collectionToStr(in_col_));
+    add("io_col", collectionToStr(io_col_));
   }
 
   std::string collectionToStr(const TestCollection& col) {
@@ -122,7 +129,7 @@ public:
     } else if (action == "exit") {
       exit(1);
     }
-    requestRender("root");
+    renderSlot("root", false, true);
   }
 
   void processSingleton(TestSingleton* handle, const std::string& action) {


### PR DESCRIPTION
This provides more limited functionality compared to JS particles: the model is a simple key:value string dictionary (where JS particles can have aribtrarily complex models).

@cromwellian This changes the wasm API for renderSlot.