### PR TITLE
Syntax support for arbitrary boolean check expressions ('and', 'or')

### DIFF
--- a/src/dataflow/analysis/tests/flow-graph-tests.ts
+++ b/src/dataflow/analysis/tests/flow-graph-tests.ts
@@ -141,8 +141,7 @@ describe('FlowGraph', () => {
     assert.equal(node.checks.size, 1);
     const check = node.checks.get('foo');
     assert.equal(check.handle.name, 'foo');
-    assert.lengthOf(check.conditions, 1);
-    assert.equal((check.conditions[0] as CheckHasTag).tag, 'trusted');
+    assert.deepEqual(check.expression, new CheckHasTag('trusted'));
     assert.isEmpty(node.claims);
 
     assert.lengthOf(graph.edges, 1);

--- a/src/runtime/manifest-ast-nodes.ts
+++ b/src/runtime/manifest-ast-nodes.ts
@@ -202,8 +202,16 @@ export type ParticleClaimStatement = ParticleClaimIsTag | ParticleClaimDerivesFr
 export interface ParticleCheckStatement extends BaseNode {
   kind: 'particle-trust-check';
   handle: string;
-  conditions: ParticleCheckCondition[];
+  expression: ParticleCheckExpression;
 }
+
+export interface ParticleCheckBooleanExpression extends BaseNode {
+  kind: 'particle-trust-check-boolean-expression';
+  operator: 'and' | 'or';
+  children: ParticleCheckExpression[];
+}
+
+export type ParticleCheckExpression = ParticleCheckBooleanExpression | ParticleCheckCondition;
 
 export type ParticleCheckCondition = ParticleCheckHasTag | ParticleCheckIsFromHandle;
 

--- a/src/runtime/manifest-parser.peg
+++ b/src/runtime/manifest-parser.peg
@@ -327,16 +327,40 @@ ParticleClaimDerivesFrom
   }
 
 ParticleCheckStatement
-  = 'check' whiteSpace handle:lowerIdent whiteSpace first:ParticleCheckCondition rest:(whiteSpace 'or' whiteSpace ParticleCheckCondition)* eolWhiteSpace
+  = 'check' whiteSpace handle:lowerIdent whiteSpace expression:ParticleCheckExpressionBody eolWhiteSpace
   {
-    const conditions: AstNode.ParticleCheckCondition[] = [first, ...rest.map(item => item[3])];
     return {
       kind: 'particle-trust-check',
       location: location(),
       handle,
-      conditions,
+      expression,
     } as AstNode.ParticleCheckStatement;
   }
+
+// A series of check conditions using `and`/`or` operations (doesn't need to be surrounded by parentheses).
+ParticleCheckExpressionBody
+  = left:ParticleCheckExpression rest:(whiteSpace ('or'/'and') whiteSpace ParticleCheckExpression)*
+  {
+    if (rest.length === 0) {
+      return left;
+    }
+    const operators: Set<string> = new Set(rest.map(item => item[1]));
+    if (operators.size > 1) {
+      expected(`You cannot combine 'and' and 'or' operations in a single check expression. You must nest them inside parentheses.`);
+    }
+    const operator = rest[0][1];
+    return {
+      kind: 'particle-trust-check-boolean-expression',
+      location: location(),
+      operator,
+      children: [left, ...rest.map(item => item[3])],
+    } as AstNode.ParticleCheckExpression;
+  }
+
+// Can be either a single check condition, or a series of conditions using `and`/`or` operations surrounded by parentheses.
+ParticleCheckExpression
+  = condition:ParticleCheckCondition { return condition; }
+  / '(' whiteSpace? condition:ParticleCheckExpressionBody whiteSpace? ')' { return condition; }
 
 ParticleCheckCondition
   = ParticleCheckIsFromHandle
@@ -354,7 +378,7 @@ ParticleCheckHasTag
   }
 
 ParticleCheckIsFromHandle
-  = 'is from handle' whiteSpace parentHandle:lowerIdent
+  = 'is' whiteSpace 'from' whiteSpace 'handle' whiteSpace parentHandle:lowerIdent
   {
     return {
       kind: 'particle-trust-check-is-from-handle',


### PR DESCRIPTION
Syntax only. Updating the analyser to support them will be done in a follow up PR.