### PR TITLE
Bindings version bump

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -521,7 +521,7 @@
       "requires": {
         "@tensorflow/tfjs": "~1.1.2",
         "adm-zip": "^0.4.11",
-        "bindings": "~1.3.0",
+        "bindings": "~1.3.1",
         "https-proxy-agent": "^2.2.1",
         "progress": "^2.0.0",
         "rimraf": "^2.6.2",


### PR DESCRIPTION
I have a theory that the master breakage was due to having two different versions of the bindings package installed. Not entirely sure about this but it seems to have passed the previous failing async tests on Travis.