### PR TITLE
Wasm: allow multiple particles to be launched in one container

### DIFF
--- a/src/wasm/cpp/test-particle.cc
+++ b/src/wasm/cpp/test-particle.cc
@@ -182,6 +182,7 @@ public:
     }
   }
 
+private:
   TestSingleton in_sng_;
   TestSingleton ot_sng_;
   TestSingleton io_sng_;
@@ -193,4 +194,45 @@ public:
   std::vector<arcs::Data> stored_;
 };
 
+
+class SimpleParticle : public arcs::Particle {
+public:
+  SimpleParticle() {
+    registerHandle("info", info_);
+  }
+
+  void onHandleSync(arcs::Handle* handle, bool all_synced) override {
+    onHandleUpdate(handle);
+  }
+
+  void onHandleUpdate(arcs::Handle* handle) override {
+    local_ = arcs::clone_entity(info_.get());
+    renderSlot("root", false, true);
+  }
+
+  std::string getTemplate(const std::string& slot_name) override {
+    return R"(<div on-click="click"><i>{{first}}</i> : <b>{{second}}</b></div>)";
+  }
+
+  void populateModel(const std::string& slot_name,
+                     std::function<void(const std::string&, const std::string&)> add) override {
+    add("first", local_._for());
+    add("second", arcs::num_to_str(local_.internal_id()));
+  }
+
+  void fireEvent(const std::string& slot_name, const std::string& handler) override {
+    if (local_.has_for()) {
+      local_.set_for(local_._for() + "*");
+    }
+    if (local_.has_internal_id()) {
+      local_.set_internal_id(local_.internal_id() + 1);
+    }
+    renderSlot("root", false, true);
+  }
+
+  arcs::Singleton<arcs::Info> info_;
+  arcs::Info local_;
+};
+
 DEFINE_PARTICLE(TestParticle)
+DEFINE_PARTICLE(SimpleParticle)

--- a/src/wasm/cpp/wasm.manifest
+++ b/src/wasm/cpp/wasm.manifest
@@ -63,3 +63,18 @@ recipe
     in_col <- h4
     ot_col -> h5
     io_col = h6
+
+
+resource DataResource7
+  start
+  [{"for": "text", "internal_id": 55}]
+store InfoStore of Info in DataResource7
+
+particle SimpleParticle in 'output.wasm'
+  consume root
+  in Info info
+
+recipe
+  use InfoStore as h1
+  SimpleParticle
+    info <- h1


### PR DESCRIPTION
@cromwellian @alxrsngrtn Some more wasm API changes: wasm handles now need to track the particle with which they are associated and pass that in storage calls.