### PR TITLE
Refactors the ParticleClaimStatement AST node.

### DIFF
--- a/src/dataflow/analysis/analysis.ts
+++ b/src/dataflow/analysis/analysis.ts
@@ -73,12 +73,13 @@ function computeTagClaimsInPath(path: BackwardsPath): Set<string> {
   const tags: Set<string> = new Set<string>();
   // We traverse the path in the forward direction, so we can cancel correctly.
   const edgesInPath = path.edgesInForwardDirection();
-  edgesInPath.forEach(e => {
-    if (!e.claim || e.claim.type !== ClaimType.IsTag) {
+  edgesInPath.forEach(edge => {
+    if (!edge.claim || edge.claim.expression.type !== ClaimType.IsTag) {
       return;
     }
-    if (!e.claim.isNot) {
-      tags.add(e.claim.tag);
+    const expression = edge.claim.expression;
+    if (!expression.isNot) {
+      tags.add(expression.tag);
       return;
     }
     // Our current claim is a "not" tag claim. 
@@ -86,7 +87,7 @@ function computeTagClaimsInPath(path: BackwardsPath): Set<string> {
     if (tags.size === 0) {
       return;
     }
-    tags.delete(e.claim.tag);
+    tags.delete(expression.tag);
   });
   return tags;
 }

--- a/src/dataflow/analysis/analysis.ts
+++ b/src/dataflow/analysis/analysis.ts
@@ -74,12 +74,12 @@ function computeTagClaimsInPath(path: BackwardsPath): Set<string> {
   // We traverse the path in the forward direction, so we can cancel correctly.
   const edgesInPath = path.edgesInForwardDirection();
   edgesInPath.forEach(edge => {
-    if (!edge.claim || edge.claim.expression.type !== ClaimType.IsTag) {
+    const claim = edge.claim;
+    if (!claim || claim.type !== ClaimType.IsTag) {
       return;
     }
-    const expression = edge.claim.expression;
-    if (!expression.isNot) {
-      tags.add(expression.tag);
+    if (!claim.isNot) {
+      tags.add(claim.tag);
       return;
     }
     // Our current claim is a "not" tag claim. 
@@ -87,7 +87,7 @@ function computeTagClaimsInPath(path: BackwardsPath): Set<string> {
     if (tags.size === 0) {
       return;
     }
-    tags.delete(expression.tag);
+    tags.delete(claim.tag);
   });
   return tags;
 }

--- a/src/dataflow/analysis/graph-internals.ts
+++ b/src/dataflow/analysis/graph-internals.ts
@@ -18,7 +18,7 @@
  * of Node/Edge like ParticleNode, etc.
  */
 
-import {Claim} from '../../runtime/particle-claim.js';
+import {Claim, ClaimExpression} from '../../runtime/particle-claim.js';
 import {Check} from '../../runtime/particle-check.js';
 
 /** Represents a node in a FlowGraph. Can be a particle, handle, etc. */
@@ -57,6 +57,6 @@ export interface Edge {
    */
   readonly label: string;
 
-  readonly claim?: Claim;
+  readonly claim?: ClaimExpression;
   readonly check?: Check;
 }

--- a/src/dataflow/analysis/particle-node.ts
+++ b/src/dataflow/analysis/particle-node.ts
@@ -9,7 +9,7 @@
  */
 
 import {Node, Edge} from './graph-internals.js';
-import {Claim, ClaimType} from '../../runtime/particle-claim.js';
+import {Claim, ClaimType, ClaimExpression} from '../../runtime/particle-claim.js';
 import {Check} from '../../runtime/particle-check.js';
 import {Particle} from '../../runtime/recipe/particle.js';
 import {assert} from '../../platform/assert-web.js';
@@ -56,9 +56,9 @@ export class ParticleNode extends Node {
   inEdgesFromOutEdge(outEdge: Edge): readonly ParticleInput[] {
     assert(this.outEdges.includes(outEdge), 'Particle does not have the given out-edge.');
 
-    if (outEdge.claim && outEdge.claim.expression.type === ClaimType.DerivesFrom) {
+    if (outEdge.claim && outEdge.claim.type === ClaimType.DerivesFrom) {
       const result: ParticleInput[] = [];
-      for (const parentHandle of outEdge.claim.expression.parentHandles) {
+      for (const parentHandle of outEdge.claim.parentHandles) {
         const inEdge = this.inEdgesByName.get(parentHandle.name);
         assert(!!inEdge, `Claim derives from unknown handle: ${parentHandle}.`);
         result.push(inEdge);
@@ -97,7 +97,7 @@ export class ParticleOutput implements Edge {
   readonly connectionName: string;
   readonly connectionSpec: HandleConnectionSpec;
 
-  readonly claim?: Claim;
+  readonly claim?: ClaimExpression;
 
   constructor(particleNode: ParticleNode, otherEnd: Node, connection: HandleConnection) {
     this.start = particleNode;
@@ -105,7 +105,9 @@ export class ParticleOutput implements Edge {
     this.connectionName = connection.name;
     this.connectionSpec = connection.spec;
     this.label = `${particleNode.name}.${this.connectionName}`;
-    this.claim = particleNode.claims.get(this.connectionName);
+    
+    const claim = particleNode.claims.get(this.connectionName);
+    this.claim = claim ? claim.expression : null;
   }
 }
 

--- a/src/dataflow/analysis/particle-node.ts
+++ b/src/dataflow/analysis/particle-node.ts
@@ -56,9 +56,9 @@ export class ParticleNode extends Node {
   inEdgesFromOutEdge(outEdge: Edge): readonly ParticleInput[] {
     assert(this.outEdges.includes(outEdge), 'Particle does not have the given out-edge.');
 
-    if (outEdge.claim && outEdge.claim.type === ClaimType.DerivesFrom) {
+    if (outEdge.claim && outEdge.claim.expression.type === ClaimType.DerivesFrom) {
       const result: ParticleInput[] = [];
-      for (const parentHandle of outEdge.claim.parentHandles) {
+      for (const parentHandle of outEdge.claim.expression.parentHandles) {
         const inEdge = this.inEdgesByName.get(parentHandle.name);
         assert(!!inEdge, `Claim derives from unknown handle: ${parentHandle}.`);
         result.push(inEdge);

--- a/src/dataflow/analysis/tests/flow-graph-test.ts
+++ b/src/dataflow/analysis/tests/flow-graph-test.ts
@@ -118,7 +118,7 @@ describe('FlowGraph', () => {
     assert.isEmpty(node.checks);
 
     assert.lengthOf(graph.edges, 1);
-    assert.equal(graph.edges[0].claim, claim);
+    assert.equal(graph.edges[0].claim, claim.expression);
   });
 
   it('copies particle checks to particle nodes and in-edges', async () => {

--- a/src/dataflow/analysis/tests/flow-graph-test.ts
+++ b/src/dataflow/analysis/tests/flow-graph-test.ts
@@ -112,9 +112,9 @@ describe('FlowGraph', () => {
     `);
     const node = checkDefined(graph.particleMap.get('P'));
     assert.equal(node.claims.size, 1);
-    const claim = node.claims.get('foo') as ClaimIsTag;
+    const claim = node.claims.get('foo');
     assert.equal(claim.handle.name, 'foo');
-    assert.equal(claim.tag, 'trusted');
+    assert.equal((claim.expression as ClaimIsTag).tag, 'trusted');
     assert.isEmpty(node.checks);
 
     assert.lengthOf(graph.edges, 1);

--- a/src/runtime/manifest-ast-nodes.ts
+++ b/src/runtime/manifest-ast-nodes.ts
@@ -163,7 +163,7 @@ export interface Particle extends BaseNode {
   implFile?: string;          // not used in RecipeParticle
   verbs?: VerbList;           // not used in RecipeParticle
   args?: ParticleArgument[];  // not used in RecipeParticle
-  modality?: string[];      // not used in RecipePartcile
+  modality?: string[];      // not used in RecipeParticle
   slots?: ParticleSlot[];    // not used in RecipeParticle
   description?: Description;  // not used in RecipeParticle
   hasParticleArgument?: boolean;  // not used in RecipeParticle
@@ -176,11 +176,19 @@ export interface Particle extends BaseNode {
   slotConnections?: RecipeParticleSlotConnection[];
 }
 
+/** A trust claim made by a particle about one of its handles. */
+export interface ParticleClaimStatement extends BaseNode {
+  kind: 'particle-trust-claim';
+  handle: string;
+  expression: ParticleClaimExpression;
+}
+
+export type ParticleClaimExpression = ParticleClaimIsTag | ParticleClaimDerivesFrom;
+
 /** A claim made by a particle, saying that one of its outputs has a particular trust tag (e.g. "claim output is foo"). */
 export interface ParticleClaimIsTag extends BaseNode {
   kind: 'particle-trust-claim-is-tag';
   claimType: ClaimType.IsTag;
-  handle: string;
   isNot: boolean;
   tag: string;
 }
@@ -192,12 +200,8 @@ export interface ParticleClaimIsTag extends BaseNode {
 export interface ParticleClaimDerivesFrom extends BaseNode {
   kind: 'particle-trust-claim-derives-from';
   claimType: ClaimType.DerivesFrom;
-  handle: string;
   parentHandles: string[];
 }
-
-/** A trust claim made by a particle. */
-export type ParticleClaimStatement = ParticleClaimIsTag | ParticleClaimDerivesFrom;
 
 export interface ParticleCheckStatement extends BaseNode {
   kind: 'particle-trust-check';

--- a/src/runtime/manifest-parser.peg
+++ b/src/runtime/manifest-parser.peg
@@ -257,7 +257,7 @@ Particle
           location: location() // TODO: FIXME Get the locations of the item descriptions.
         } as AstNode.Description;
         item.description.forEach(d => description[d.name] = d.pattern || d.patterns[0]);
-      } else if (item.kind === 'particle-trust-claim' || item.kind === 'particle-trust-claim') {
+      } else if (item.kind === 'particle-trust-claim') {
         trustClaims.push(item);
       } else if (item.kind === 'particle-trust-check') {
         trustChecks.push(item);

--- a/src/runtime/manifest-parser.peg
+++ b/src/runtime/manifest-parser.peg
@@ -257,14 +257,14 @@ Particle
           location: location() // TODO: FIXME Get the locations of the item descriptions.
         } as AstNode.Description;
         item.description.forEach(d => description[d.name] = d.pattern || d.patterns[0]);
-      } else if (item.kind === 'particle-trust-claim-is-tag' || item.kind === 'particle-trust-claim-derives-from') {
+      } else if (item.kind === 'particle-trust-claim' || item.kind === 'particle-trust-claim') {
         trustClaims.push(item);
       } else if (item.kind === 'particle-trust-check') {
         trustChecks.push(item);
       } else if (item.modality) {
         modality.push(item.modality);
       } else {
-        error(`Particle ${name} contains an unknown element: ${item.name}`);
+        error(`Particle ${name} contains an unknown element: ${item.name} / ${item.kind}`);
       }
     });
     if (modality.length === 0) {
@@ -297,31 +297,40 @@ ParticleItem "a particle item"
   / ParticleCheckStatement
 
 ParticleClaimStatement
+  = 'claim' whiteSpace handle:lowerIdent whiteSpace expression:ParticleClaimExpression eolWhiteSpace
+  {
+    return {
+      kind: 'particle-trust-claim',
+      location: location(),
+      handle,
+      expression,
+    } as AstNode.ParticleClaimStatement;
+  }
+
+ParticleClaimExpression
   = ParticleClaimIsTag
   / ParticleClaimDerivesFrom
 
 ParticleClaimIsTag
-  = 'claim' whiteSpace handle:lowerIdent whiteSpace 'is' whiteSpace not:('not' whiteSpace)? tag:lowerIdent eolWhiteSpace
+  = 'is' whiteSpace not:('not' whiteSpace)? tag:lowerIdent
   {
     return {
       kind: 'particle-trust-claim-is-tag',
       claimType: 'is-tag',
       location: location(),
-      handle,
       isNot: not != null,
       tag,
     } as AstNode.ParticleClaimIsTag;
   }
 
 ParticleClaimDerivesFrom
-  = 'claim' whiteSpace handle:lowerIdent whiteSpace 'derives from' whiteSpace first:lowerIdent rest:(whiteSpace 'and derives from' whiteSpace lowerIdent)* eolWhiteSpace
+  = 'derives from' whiteSpace first:lowerIdent rest:(whiteSpace 'and derives from' whiteSpace lowerIdent)*
   {
     const parentHandles: string[] = [first, ...rest.map(item => item[3])];
     return {
       kind: 'particle-trust-claim-derives-from',
       claimType: 'derives-from',
       location: location(),
-      handle,
       parentHandles,
     } as AstNode.ParticleClaimDerivesFrom;
   }

--- a/src/runtime/particle-claim.ts
+++ b/src/runtime/particle-claim.ts
@@ -10,7 +10,6 @@
 
 import {HandleConnectionSpec} from './particle-spec';
 import {ParticleClaimIsTag, ParticleClaimDerivesFrom, ParticleClaimStatement} from './manifest-ast-nodes';
-import {browserLocalStorage} from '@tensorflow/tfjs-core/dist/io/local_storage';
 
 /** The different types of trust claims that particles can make. */
 export enum ClaimType {

--- a/src/runtime/particle-claim.ts
+++ b/src/runtime/particle-claim.ts
@@ -10,6 +10,7 @@
 
 import {HandleConnectionSpec} from './particle-spec';
 import {ParticleClaimIsTag, ParticleClaimDerivesFrom, ParticleClaimStatement} from './manifest-ast-nodes';
+import {browserLocalStorage} from '@tensorflow/tfjs-core/dist/io/local_storage';
 
 /** The different types of trust claims that particles can make. */
 export enum ClaimType {
@@ -17,29 +18,36 @@ export enum ClaimType {
   DerivesFrom = 'derives-from',
 }
 
-export type Claim = ClaimIsTag | ClaimDerivesFrom;
+export class Claim {
+  constructor(readonly handle: HandleConnectionSpec, readonly expression: ClaimExpression) {}
+
+  toManifestString() {
+    return `claim ${this.handle.name} ${this.expression.toManifestString()}`;
+  }
+}
+
+export type ClaimExpression = ClaimIsTag | ClaimDerivesFrom;
 
 export class ClaimIsTag {
   readonly type: ClaimType.IsTag = ClaimType.IsTag;
 
-  constructor(readonly handle: HandleConnectionSpec, readonly isNot: boolean, readonly tag: string) {}
+  constructor(readonly isNot: boolean, readonly tag: string) {}
 
-  static fromASTNode(handle: HandleConnectionSpec, astNode: ParticleClaimIsTag) {
-    return new ClaimIsTag(handle, astNode.isNot, astNode.tag);
+  static fromASTNode(astNode: ParticleClaimIsTag) {
+    return new ClaimIsTag(astNode.isNot, astNode.tag);
   }
 
   toManifestString() {
-    return `claim ${this.handle.name} is ${this.isNot ? 'not ' : ''}${this.tag}`;
+    return `is ${this.isNot ? 'not ' : ''}${this.tag}`;
   }
 }
 
 export class ClaimDerivesFrom {
   readonly type: ClaimType.DerivesFrom = ClaimType.DerivesFrom;
   
-  constructor(readonly handle: HandleConnectionSpec, readonly parentHandles: readonly HandleConnectionSpec[]) {}
+  constructor(readonly parentHandles: readonly HandleConnectionSpec[]) {}
   
   static fromASTNode(
-      handle: HandleConnectionSpec,
       astNode: ParticleClaimDerivesFrom,
       handleConnectionMap: Map<string, HandleConnectionSpec>) {
     
@@ -52,11 +60,11 @@ export class ClaimDerivesFrom {
       return parentHandle;
     });
 
-    return new ClaimDerivesFrom(handle, parentHandles);
+    return new ClaimDerivesFrom(parentHandles);
   }
 
   toManifestString() {
-    return `claim ${this.handle.name} derives from ${this.parentHandles.map(h => h.name).join(' and ')}`;
+    return `derives from ${this.parentHandles.map(h => h.name).join(' and ')}`;
   }
 }
 
@@ -64,12 +72,16 @@ export function createClaim(
     handle: HandleConnectionSpec,
     astNode: ParticleClaimStatement,
     handleConnectionMap: Map<string, HandleConnectionSpec>): Claim {
-  switch (astNode.claimType) {
+  let expression: ClaimExpression;
+  switch (astNode.expression.claimType) {
     case ClaimType.IsTag:
-      return ClaimIsTag.fromASTNode(handle, astNode);
+      expression = ClaimIsTag.fromASTNode(astNode.expression);
+      break;
     case ClaimType.DerivesFrom:
-      return ClaimDerivesFrom.fromASTNode(handle, astNode, handleConnectionMap);
+      expression = ClaimDerivesFrom.fromASTNode(astNode.expression, handleConnectionMap);
+      break;
     default:
       throw new Error('Unknown claim type.');
   }
+  return new Claim(handle, expression);
 }

--- a/src/runtime/test/manifest-test.ts
+++ b/src/runtime/test/manifest-test.ts
@@ -1980,13 +1980,13 @@ resource SomeName
       assert.isEmpty(particle.trustChecks);
       assert.equal(particle.trustClaims.size, 2);
       
-      const claim1 = particle.trustClaims.get('output1') as ClaimIsTag;
+      const claim1 = particle.trustClaims.get('output1');
       assert.equal(claim1.handle.name, 'output1');
-      assert.equal(claim1.tag, 'property1');
+      assert.equal((claim1.expression as ClaimIsTag).tag, 'property1');
 
-      const claim2 = particle.trustClaims.get('output2') as ClaimIsTag;
+      const claim2 = particle.trustClaims.get('output2');
       assert.equal(claim2.handle.name, 'output2');
-      assert.equal(claim2.tag, 'property2');
+      assert.equal((claim2.expression as ClaimIsTag).tag, 'property2');
     });
 
     it('supports "is not" tag claims', async () => {
@@ -2001,10 +2001,10 @@ resource SomeName
       assert.isEmpty(particle.trustChecks);
       assert.equal(particle.trustClaims.size, 1);
 
-      const claim1 = particle.trustClaims.get('output1') as ClaimIsTag;
+      const claim1 = particle.trustClaims.get('output1');
       assert.equal(claim1.handle.name, 'output1');
-      assert.equal(claim1.isNot, true);
-      assert.equal(claim1.tag, 'property1');
+      assert.equal((claim1.expression as ClaimIsTag).isNot, true);
+      assert.equal((claim1.expression as ClaimIsTag).tag, 'property1');
      });
 
     it('supports "derives from" claims with multiple parents', async () => {
@@ -2020,9 +2020,9 @@ resource SomeName
       assert.isEmpty(particle.trustChecks);
       assert.equal(particle.trustClaims.size, 1);
       
-      const claim = particle.trustClaims.get('output') as ClaimDerivesFrom;
+      const claim = particle.trustClaims.get('output');
       assert.equal(claim.handle.name, 'output');
-      assert.sameMembers(claim.parentHandles.map(h => h.name), ['input1', 'input2']);
+      assert.sameMembers((claim.expression as ClaimDerivesFrom).parentHandles.map(h => h.name), ['input1', 'input2']);
     });
 
     it('supports multiple check statements', async () => {


### PR DESCRIPTION
This pulls out an Expression field, similar to what we did for Checks.
This makes the code reusable for datastore claims (since they don't have handles), and will be useful for building boolean expressions in claims.

Also changes the Edge.claim field from being a Claim object to being a ClaimExpression object. Edges don't really need the full Claim object (the handle field doesn't apply to them), and this will become important for datastore claims, which need to make claims about edges, but won't have a handle field.