### PR TITLE
Adds syntax support for datastore claims.

### DIFF
--- a/src/runtime/manifest-ast-nodes.ts
+++ b/src/runtime/manifest-ast-nodes.ts
@@ -111,7 +111,7 @@ export interface Import extends BaseNode {
 export interface ManifestStorage extends BaseNode {
   kind: 'store';
   name: string;
-  type: string;
+  type: ManifestStorageType;
   id: string|null;
   originalId: string|null;
   version: number;
@@ -119,6 +119,14 @@ export interface ManifestStorage extends BaseNode {
   source: string;
   origin: string;
   description: string|null;
+  claim: ManifestStorageClaim;
+}
+
+export type ManifestStorageType = SchemaInline | CollectionType | BigCollectionType | TypeName;
+
+export interface ManifestStorageClaim extends BaseNode {
+  kind: 'manifest-storage-claim';
+  tags: string[];
 }
 
 export interface ManifestStorageSource {
@@ -563,7 +571,6 @@ export type Annotation = string;
 export type Indent = number;
 export type LocalName = string;
 export type Manifest = ManifestItem[];
-export type ManifestStorageItem = string;
 export type ManifestStorageDescription = string;
 export type Modality = string;
 export type ReservedWord = string;

--- a/src/runtime/manifest-parser.peg
+++ b/src/runtime/manifest-parser.peg
@@ -117,6 +117,25 @@ ManifestStorage
     items:(Indent (SameIndent ManifestStorageItem)+)?
   {
     items = optional(items, extractIndented, []);
+    let description: string | null = null;
+    let claim: AstNode.ManifestStorageClaim | null = null;
+
+    for (const item of items) {
+      if (item[0] === 'description') {
+        if (description) {
+          error('You cannot provide more than one description.');
+        }
+        description = item[2];
+      } else if (item['kind'] === 'manifest-storage-claim') {
+        if (claim) {
+          error('You cannot provide more than one claim.');
+        }
+        claim = item;
+      } else {
+        error(`Unknown ManifestStorageItem: ${item}`);
+      }
+    }
+
     return {
       kind: 'store',
       location: location(),
@@ -128,7 +147,8 @@ ManifestStorage
       tags: optional(tags, tags => tags[1], null),
       source: source.source,
       origin: source.origin,
-      description: items.length > 0 ? items[0][2] : null
+      description,
+      claim,
     } as AstNode.ManifestStorage;
   }
 
@@ -149,9 +169,20 @@ ManifestStorageStorageSource
 
 ManifestStorageItem
   = ManifestStorageDescription
+  / ManifestStorageClaim
 
 ManifestStorageDescription
   = 'description' whiteSpace backquotedString eolWhiteSpace
+
+ManifestStorageClaim
+  = 'claim' whiteSpace 'is' whiteSpace tag:lowerIdent rest:(whiteSpace 'and' whiteSpace 'is' whiteSpace lowerIdent)* eolWhiteSpace
+  {
+    return {
+      kind: 'manifest-storage-claim',
+      location: location(),
+      tags: [tag, ...rest.map(item => item[5])],
+    } as AstNode.ManifestStorageClaim;
+  }
 
 Import
   = 'import' whiteSpace path:id eolWhiteSpace

--- a/src/runtime/recipe/handle.ts
+++ b/src/runtime/recipe/handle.ts
@@ -14,12 +14,12 @@ import {Schema} from '../schema.js';
 import {TypeVariableInfo} from '../type-variable-info.js';
 import {Type, SlotType} from '../type.js';
 import {SlotInfo} from '../slot-info.js';
-
 import {HandleConnection} from './handle-connection.js';
 import {Recipe, CloneMap, RecipeComponent, IsResolvedOptions, IsValidOptions, ToStringOptions, VariableMap} from './recipe.js';
 import {TypeChecker} from './type-checker.js';
 import {compareArrays, compareComparables, compareStrings, Comparable} from './comparable.js';
 import {Fate} from '../manifest-ast-nodes.js';
+import {ClaimIsTag, ClaimExpression} from '../particle-claim.js';
 
 export class Handle implements Comparable<Handle> {
   private readonly _recipe: Recipe;
@@ -39,6 +39,7 @@ export class Handle implements Comparable<Handle> {
   // Value assigned in the immediate mode, E.g. hostedParticle = ShowProduct
   // Currently only supports ParticleSpec.
   private _immediateValue: ParticleSpec | undefined = undefined;
+  claim: ClaimExpression | undefined = undefined;
 
   constructor(recipe: Recipe) {
     assert(recipe);
@@ -158,7 +159,7 @@ export class Handle implements Comparable<Handle> {
     }
     this._id = id;
   }
-  mapToStorage(storage: {id: string, type: Type, originalId?: string, storageKey?: string}) {
+  mapToStorage(storage: {id: string, type: Type, originalId?: string, storageKey?: string, claims?: ClaimIsTag[]}) {
     if (!storage) {
       throw new Error(`Cannot map to undefined storage`);
     }
@@ -167,6 +168,14 @@ export class Handle implements Comparable<Handle> {
     this._type = undefined;
     this._mappedType = storage.type;
     this._storageKey = storage.storageKey;
+
+    if (storage.claims) {
+      // TODO: Support multiple tag claims.
+      assert(storage.claims.length <= 1, 'Multiple tag claims is not supported yet.');
+      if (storage.claims.length === 1) {
+        this.claim = storage.claims[0];
+      }
+    }
   }
   get localName() { return this._localName; }
   set localName(name: string) { this._localName = name; }

--- a/src/runtime/storage/storage-provider-base.ts
+++ b/src/runtime/storage/storage-provider-base.ts
@@ -18,6 +18,7 @@ import {KeyBase} from './key-base.js';
 import {Store, BigCollectionStore, CollectionStore, SingletonStore} from '../store.js';
 import {PropagatedException} from '../arc-exceptions.js';
 import {Dictionary, Consumer} from '../hot.js';
+import {ClaimIsTag} from '../particle-claim.js';
 
 enum EventKind {
   change = 'Change'
@@ -120,6 +121,8 @@ export abstract class StorageProviderBase implements Comparable<StorageProviderB
   name: string;
   readonly source: string|null;
   description: string;
+  /** Trust tags claimed by this data store. */
+  claims: ClaimIsTag[];
 
   protected constructor(type: Type, name: string, id: string, key: string) {
     assert(id, 'id must be provided when constructing StorageProviders');
@@ -225,6 +228,9 @@ export abstract class StorageProviderBase implements Comparable<StorageProviderB
       handleStr.push(`in '${this.source}'`);
     }
     results.push(handleStr.join(' '));
+    if (this.claims && this.claims.length > 0) {
+      results.push(`  claim is ${this.claims.map(claim => claim.tag).join(' and is ')}`);
+    }
     if (this.description) {
       results.push(`  description \`${this.description}\``);
     }

--- a/src/runtime/test/manifest-test.ts
+++ b/src/runtime/test/manifest-test.ts
@@ -2138,6 +2138,23 @@ resource SomeName
         ]));
     });
 
+    it('data stores can make claims', async () => {
+      const manifest = await Manifest.parse(`
+        store NobId of NobIdStore {Text nobId} in NobIdJson
+          claim is property1 and is property2
+        resource NobIdJson
+          start
+          [{"nobId": "12345"}]
+      `);
+      assert.lengthOf(manifest.stores, 1);
+      const store = manifest.stores[0];
+      assert.lengthOf(store.claims, 2);
+      assert.equal(store.claims[0].tag, 'property1');
+      assert.equal(store.claims[1].tag, 'property2');
+
+      assert.include(manifest.toString(), '  claim is property1 and is property2');
+    });
+
     it(`doesn't allow mixing 'and' and 'or' operations without nesting`, async () => {
       assertThrowsAsync(async () => await Manifest.parse(`
         particle A
@@ -2146,7 +2163,7 @@ resource SomeName
       `), `You cannot combine 'and' and 'or' operations in a single check expression.`);
     });
 
-    it('can round-trip checks and claims', async () => {
+    it('can round-trip particles with checks and claims', async () => {
       const manifestString = `particle TestParticle in 'a.js'
   in T {} input1
   in T {} input2
@@ -2164,7 +2181,7 @@ resource SomeName
     provide childSlot`;
     
       const manifest = await Manifest.parse(manifestString);
-      assert.equal(manifestString, manifest.toString());
+      assert.equal(manifest.toString(), manifestString);
     });
 
     it('fails for unknown handle names', async () => {


### PR DESCRIPTION
Syntax only, analyser in a follow up PR.

I was able to reuse some of the existing Claim classes, but had to add
new AST nodes for datastore claims, because the syntax is slightly
different (there's no handle name, and "derives from" is not supported).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/polymerlabs/arcs/3281)
<!-- Reviewable:end -->
