### PR TITLE
Use npm config port

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "config": {
-    "port": "8786",
-    "host": "localhost"
+    "port": "8786"
   },
   "browser": "dist/webmain.js",
   "module": "dist/webmain.js",
@@ -19,8 +18,8 @@
     "test-health": "cross-env tools/sigh health",
     "test-extension": "mocha-chrome extension/test/index.test.html",
     "test:licenses": "jsgl --local . && npm --prefix devtools run test:licenses && npm --prefix server run test:licenses",
-    "start": "./tools/sigh devServer",
-    "test-wdio-shells": "wdio -b http://localhost:8786/ shells/test/wdio.conf.js",
+    "start": "./tools/sigh devServer --port $npm_package_config_port",
+    "test-wdio-shells": "wdio -b http://localhost:${npm_package_config_port}/ shells/test/wdio.conf.js",
     "build:rollup": "rollup -c --sourcemap",
     "watch:rollup": "rollup -c --sourcemap --watch",
     "build:typedoc": "typedoc --ignoreCompilerErrors --mode file --target ES2017 --downLevelIteration -out dist/apidocs",


### PR DESCRIPTION
This is a good first step to make basic thing working if your system has 8786 taken etc.

There are still some hardcoded defaults in Arcs Explorer website and runtime, but they can be overridden with URL parameters.

This is aimed to help with #3286