### PR TITLE
Added Flow, FlowCondition, FlowCheck, FlowModifier classes.

### DIFF
--- a/src/dataflow/analysis/flow-graph.ts
+++ b/src/dataflow/analysis/flow-graph.ts
@@ -135,11 +135,11 @@ export class FlowGraph {
     if (expression.type === 'and' || expression.type === 'or') {
       return {
         originalCheck,
-        expression: expression.type,
+        operator: expression.type,
         children: expression.children.map(child => this.createFlowCheck(originalCheck, child)),
       };
     } else {
-      return {originalCheck, expression: this.createFlowCondition(expression as CheckCondition)};
+      return {...this.createFlowCondition(expression as CheckCondition), originalCheck};
     }
   }
 

--- a/src/dataflow/analysis/flow-graph.ts
+++ b/src/dataflow/analysis/flow-graph.ts
@@ -12,10 +12,11 @@ import {Recipe} from '../../runtime/recipe/recipe.js';
 import {ParticleNode, createParticleNodes} from './particle-node.js';
 import {HandleNode, createHandleNodes, addHandleConnection} from './handle-node.js';
 import {SlotNode, createSlotNodes, addSlotConnection} from './slot-node.js';
-import {Node, Edge} from './graph-internals.js';
+import {Node, Edge, FlowCondition, FlowCheck} from './graph-internals.js';
 import {Manifest} from '../../runtime/manifest.js';
 import {assert} from '../../platform/assert-web.js';
-import {StoreReference} from '../../runtime/particle-check.js';
+import {StoreReference, CheckIsFromHandle, CheckIsFromStore, CheckType, CheckCondition, CheckExpression, Check} from '../../runtime/particle-check.js';
+import {HandleConnectionSpec} from '../../runtime/particle-spec.js';
 
 /**
  * Data structure for representing the connectivity graph of a recipe. Used to perform static analysis on a resolved recipe.
@@ -30,6 +31,9 @@ export class FlowGraph {
   /** Maps from particle name to node. */
   readonly particleMap: Map<string, ParticleNode>;
 
+  /** Maps from HandleConnectionSpec to edge. */
+  private readonly handleSpecMap: Map<HandleConnectionSpec, Edge> = new Map();
+
   private readonly manifest: Manifest;
 
   constructor(recipe: Recipe, manifest: Manifest) {
@@ -42,6 +46,13 @@ export class FlowGraph {
     const handleNodes = createHandleNodes(recipe.handles);
     const slotNodes = createSlotNodes(recipe.slots);
 
+    this.particles = [...particleNodes.values()];
+    this.handles = [...handleNodes.values()];
+    this.slots = [...slotNodes.values()];
+    this.nodes = [...this.particles, ...this.handles, ...this.slots];
+    this.particleMap = new Map(this.particles.map(n => [n.name, n]));
+    this.manifest = manifest;
+
     let edgeIdCounter = 0;
 
     // Add edges to the nodes.
@@ -51,6 +62,7 @@ export class FlowGraph {
       const edgeId = 'E' + edgeIdCounter++;
       const edge = addHandleConnection(particleNode, handleNode, connection, edgeId);
       this.edges.push(edge);
+      this.handleSpecMap.set(connection.spec, edge);
     });
 
     // Add edges from particles to the slots that they consume (one-way only, for now).
@@ -67,16 +79,18 @@ export class FlowGraph {
       for (const providedSlotSpec of connection.getSlotSpec().provideSlotConnections) {
         const providedSlot = connection.providedSlots[providedSlotSpec.name];
         const providedSlotNode = slotNodes.get(providedSlot);
-        providedSlotNode.check = providedSlotSpec.check;
+        providedSlotNode.check = providedSlotSpec.check ? this.createFlowCheck(providedSlotSpec.check) : null;
       }
     });
 
-    this.particles = [...particleNodes.values()];
-    this.handles = [...handleNodes.values()];
-    this.slots = [...slotNodes.values()];
-    this.nodes = [...this.particles, ...this.handles, ...this.slots];
-    this.particleMap = new Map(this.particles.map(n => [n.name, n]));
-    this.manifest = manifest;
+    // Attach check objects to edges. Must be done in a separate pass after all
+    // edges have been created, since checks can reference other nodes/edges.
+    recipe.handleConnections.forEach(connection => {
+      if (connection.spec.check) {
+        const edge = this.handleSpecMap.get(connection.spec);
+        edge.check = this.createFlowCheck(connection.spec.check);
+      }
+    });
   }
 
   /** Returns a list of all pairwise particle connections, in string form: 'P1.foo -> P2.bar'. */
@@ -88,6 +102,21 @@ export class FlowGraph {
     return connections;
   }
 
+  /** Converts an "is from handle" check into the node ID that we need to search for. */
+  handleCheckToNodeId(check: CheckIsFromHandle): string {
+    const parentEdge = this.handleSpecMap.get(check.parentHandle);
+    return parentEdge.start.nodeId;
+  }
+
+  /** Converts an "is from store" check into the node ID that we need to search for. */
+  storeCheckToNodeId(check: CheckIsFromStore): string {
+    const storeId = this.resolveStoreRefToID(check.storeRef);
+    const handle = this.handles.find(h => h.storeId === storeId);
+    assert(handle, `Store with id ${storeId} is not connected by a handle.`);
+    return handle.nodeId;
+  }
+
+  /** Converts a StoreReference into a store ID. */
   resolveStoreRefToID(storeRef: StoreReference): string {
     if (storeRef.type === 'id') {
       const store = this.manifest.findStoreById(storeRef.store);
@@ -97,6 +126,34 @@ export class FlowGraph {
       const store = this.manifest.findStoreByName(storeRef.store);
       assert(store, `Store with name ${storeRef.store} not found.`);
       return store.id;
+    }
+  }
+
+  /** Converts a particle Check object into a FlowCheck object (the internal representation used by FlowGraph). */
+  createFlowCheck(originalCheck: Check, expression?: CheckExpression): FlowCheck {
+    expression = expression || originalCheck.expression;
+    if (expression.type === 'and' || expression.type === 'or') {
+      return {
+        originalCheck,
+        expression: expression.type,
+        children: expression.children.map(child => this.createFlowCheck(originalCheck, child)),
+      };
+    } else {
+      return {originalCheck, expression: this.createFlowCondition(expression as CheckCondition)};
+    }
+  }
+
+  /** Converts a particle CheckCondition into a FlowCondition object (the internal representation used by FlowGraph). */
+  private createFlowCondition(condition: CheckCondition): FlowCondition {
+    switch (condition.type) {
+      case CheckType.HasTag:
+        return {type: 'tag', value: condition.tag};
+      case CheckType.IsFromHandle:
+        return {type: 'node', value: this.handleCheckToNodeId(condition)};
+      case CheckType.IsFromStore:
+        return {type: 'node', value: this.storeCheckToNodeId(condition)};
+      default:
+        throw new Error('Unknown CheckType');
     }
   }
 }

--- a/src/dataflow/analysis/graph-internals.ts
+++ b/src/dataflow/analysis/graph-internals.ts
@@ -42,14 +42,16 @@ export class Flow {
 
   /** Evaluates the given FlowCheck against the current Flow. */
   evaluateCheck(check: FlowCheck): boolean {
-    if (check.expression === 'or') {
-      // Only one child expression needs to pass.
-      return check.children.some(childExpr => this.evaluateCheck(childExpr));
-    } else if (check.expression === 'and') {
-      // Every child expression needs to pass.
-      return check.children.every(childExpr => this.evaluateCheck(childExpr));
+    if ('operator' in check) {
+      if (check.operator === 'or') {
+        // Only one child expression needs to pass.
+        return check.children.some(childExpr => this.evaluateCheck(childExpr));
+      } else {
+        // 'and' operator. Every child expression needs to pass.
+        return check.children.every(childExpr => this.evaluateCheck(childExpr));
+      }
     } else {
-      return this.checkCondition(check.expression);
+      return this.checkCondition(check);
     }
   }
 
@@ -125,17 +127,11 @@ export type FlowCondition = {
   value: string
 };
 
-/** An equivalent of a particle Check statement, used internally by FlowGraph. */
-export type FlowCheck = {
-  /** Either a boolean operator, or a FlowCondition. */
-  expression: 'and' | 'or' | FlowCondition,
-
-  /** The elements of the boolean expression. Only set if expression is 'and' or 'or. */
-  children?: readonly FlowCheck[],
-
-  /** The original Check object, from which this FlowCheck was created. */
-  originalCheck: Check,
-};
+/** An equivalent of a particle Check statement, used internally by FlowGraph. Either a FlowCondition, or a boolean expression. */
+export type FlowCheck = 
+    (FlowCondition | {operator: 'or' | 'and', children: readonly FlowCheck[]})
+    /** Optional Check object from which this FlowCheck was constructed. */
+    & {originalCheck?: Check};
 
 /** Represents a node in a FlowGraph. Can be a particle, handle, etc. */
 export abstract class Node {

--- a/src/dataflow/analysis/graph-internals.ts
+++ b/src/dataflow/analysis/graph-internals.ts
@@ -18,8 +18,124 @@
  * of Node/Edge like ParticleNode, etc.
  */
 
-import {Claim} from '../../runtime/particle-claim.js';
+import {Claim, ClaimType} from '../../runtime/particle-claim.js';
 import {Check} from '../../runtime/particle-check.js';
+
+/** Represents the accumulation of tags/nodes/edges that flow along a path in the graph. */
+export class Flow {
+  readonly nodeIds: Set<string> = new Set();
+  readonly edgeIds: Set<string> = new Set();
+  readonly tags: Set<string> = new Set();
+
+  /** Modifies the current Flow (in place) by applying the given FlowModifier. */
+  modify(modifier: FlowModifier) {
+    modifier.nodeIds.forEach(n => this.nodeIds.add(n));
+    modifier.edgeIds.forEach(e => this.edgeIds.add(e));
+    modifier.tagOperations.forEach((operation, tag) => {
+      if (operation === 'add') {
+        this.tags.add(tag);
+      } else {
+        this.tags.delete(tag);
+      }
+    });
+  }
+
+  /** Evaluates the given FlowCheck against the current Flow. */
+  evaluateCheck(check: FlowCheck): boolean {
+    if (check.expression === 'or') {
+      // Only one child expression needs to pass.
+      return check.children.some(childExpr => this.evaluateCheck(childExpr));
+    } else if (check.expression === 'and') {
+      // Every child expression needs to pass.
+      return check.children.every(childExpr => this.evaluateCheck(childExpr));
+    } else {
+      return this.checkCondition(check.expression);
+    }
+  }
+
+  /** Evaluates the given CheckCondition against the current Flow. */
+  private checkCondition(condition: FlowCondition): boolean {
+    switch (condition.type) {
+      case 'node':
+        return this.nodeIds.has(condition.value);
+      case 'edge':
+        return this.edgeIds.has(condition.value);
+      case 'tag':
+        return this.tags.has(condition.value);
+      default:
+        throw new Error('Unknown condition type.');
+    }
+  }
+}
+
+export enum TagOperation {
+  Add = 'add',
+  Remove = 'remove',
+}
+
+/** Represents a sequence of modifications that can be made to a flow. */
+export class FlowModifier {
+  /** Node IDs to add. */
+  readonly nodeIds: Set<string> = new Set();
+
+  /** Edge IDs to add. */
+  readonly edgeIds: Set<string> = new Set();
+
+  /** Tags to add/remove. Maps from tag name to operation. */
+  readonly tagOperations: Map<string, TagOperation> = new Map();
+
+  static fromConditions(...conditions: FlowCondition[]): FlowModifier {
+    const modifier = new FlowModifier();
+    for (const condition of conditions) {
+      switch (condition.type) {
+        case 'tag':
+          modifier.tagOperations.set(condition.value, TagOperation.Add);
+          break;
+        case 'node':
+          modifier.nodeIds.add(condition.value);
+          break;
+        case 'edge':
+          modifier.edgeIds.add(condition.value);
+          break;
+        default:
+          throw new Error('Unknown FlowCondition type.');
+      }
+    }
+    return modifier;
+  }
+
+  static fromClaims(edge: Edge, claims: Claim[]): FlowModifier {
+    const modifier = new FlowModifier();
+    if (claims) {
+      for (const claim of claims) {
+        if (claim.type === ClaimType.IsTag) {
+          modifier.tagOperations.set(claim.tag, claim.isNot ? TagOperation.Remove : TagOperation.Add);
+        }
+      }
+    }
+    modifier.edgeIds.add(edge.edgeId);
+    modifier.nodeIds.add(edge.start.nodeId);
+    return modifier;
+  }
+}
+
+/** An equivalent of a particle CheckCondition, used internally by FlowGraph. */
+export type FlowCondition = {
+  type: 'node' | 'edge' | 'tag',
+  value: string
+};
+
+/** An equivalent of a particle Check statement, used internally by FlowGraph. */
+export type FlowCheck = {
+  /** Either a boolean operator, or a FlowCondition. */
+  expression: 'and' | 'or' | FlowCondition,
+
+  /** The elements of the boolean expression. Only set if expression is 'and' or 'or. */
+  children?: readonly FlowCheck[],
+
+  /** The original Check object, from which this FlowCheck was created. */
+  originalCheck: Check,
+};
 
 /** Represents a node in a FlowGraph. Can be a particle, handle, etc. */
 export abstract class Node {
@@ -63,6 +179,7 @@ export interface Edge {
    */
   readonly label: string;
 
-  readonly claims?: Claim[];
-  readonly check?: Check;
+  readonly derivesFrom?: Edge[];
+  readonly modifier?: FlowModifier;
+  check?: FlowCheck;
 }

--- a/src/dataflow/analysis/graph-internals.ts
+++ b/src/dataflow/analysis/graph-internals.ts
@@ -21,7 +21,10 @@
 import {Claim, ClaimType} from '../../runtime/particle-claim.js';
 import {Check} from '../../runtime/particle-check.js';
 
-/** Represents the accumulation of tags/nodes/edges that flow along a path in the graph. */
+/**
+ * Represents the set of implicit and explicit claims that flow along a path in
+ * the graph, i.e. tags, node IDs and edge IDs.
+ */
 export class Flow {
   readonly nodeIds: Set<string> = new Set();
   readonly edgeIds: Set<string> = new Set();

--- a/src/dataflow/analysis/handle-node.ts
+++ b/src/dataflow/analysis/handle-node.ts
@@ -8,7 +8,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {Node, Edge} from './graph-internals.js';
+import {Node, Edge, FlowCheck} from './graph-internals.js';
 import {ParticleOutput, ParticleInput, ParticleNode} from './particle-node.js';
 import {HandleConnectionSpec} from '../../runtime/particle-spec.js';
 import {CheckIsFromHandle} from '../../runtime/particle-check.js';
@@ -20,7 +20,6 @@ export class HandleNode extends Node {
   readonly nodeId: string;
   readonly inEdges: ParticleOutput[] = [];
   readonly outEdges: ParticleInput[] = [];
-  readonly connectionSpecs: Set<HandleConnectionSpec> = new Set();
   readonly storeId: string;
 
   constructor(nodeId: string, handle: Handle) {
@@ -42,22 +41,15 @@ export class HandleNode extends Node {
 
   addInEdge(edge: ParticleOutput) {
     this.inEdges.push(edge);
-    this.connectionSpecs.add(edge.connectionSpec);
   }
 
   addOutEdge(edge: ParticleInput) {
     this.outEdges.push(edge);
-    this.connectionSpecs.add(edge.connectionSpec);
   }
 
   inEdgesFromOutEdge(outEdge: ParticleInput): readonly ParticleOutput[] {
     assert(this.outEdges.includes(outEdge), 'Handle does not have the given out-edge.');
     return this.inEdges;
-  }
-
-  validateIsFromHandleCheck(condition: CheckIsFromHandle): boolean {
-    // Check if this handle node has the desired HandleConnectionSpec. If so, it is the right handle.
-    return this.connectionSpecs.has(condition.parentHandle);
   }
 }
 

--- a/src/dataflow/analysis/slot-node.ts
+++ b/src/dataflow/analysis/slot-node.ts
@@ -8,7 +8,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {Node, Edge} from './graph-internals.js';
+import {Node, Edge, FlowModifier, FlowCheck} from './graph-internals.js';
 import {Check} from '../../runtime/particle-check.js';
 import {Slot} from '../../runtime/interface-info.js';
 import {ParticleNode} from './particle-node.js';
@@ -23,7 +23,7 @@ export class SlotNode extends Node {
   readonly nodeId: string;
 
   // Optional check on the data entering this slot. The check is defined by the particle which provided this slot.
-  check?: Check;
+  check?: FlowCheck;
 
   constructor(nodeId: string, slot: Slot) {
     super();
@@ -58,7 +58,7 @@ class SlotInput implements Edge {
     this.label = `${particleNode.name}.${this.connectionName}`;
   }
 
-  get check(): Check | undefined {
+  get check(): FlowCheck | undefined {
     return this.end.check;
   }
 }

--- a/src/dataflow/analysis/tests/flow-graph-test.ts
+++ b/src/dataflow/analysis/tests/flow-graph-test.ts
@@ -10,11 +10,9 @@
 
 import {assert} from '../../../platform/chai-web.js';
 import {checkDefined} from '../../../runtime/testing/preconditions.js';
-import {ClaimIsTag, ClaimType} from '../../../runtime/particle-claim.js';
-import {CheckHasTag} from '../../../runtime/particle-check.js';
-import {ProvideSlotConnectionSpec} from '../../../runtime/particle-spec.js';
 import {ParticleNode} from '../particle-node.js';
 import {buildFlowGraph} from '../testing/flow-graph-testing.js';
+import {FlowModifier} from '../graph-internals.js';
 
 describe('FlowGraph', () => {
   it('works with empty recipe', async () => {
@@ -118,13 +116,12 @@ describe('FlowGraph', () => {
           input <- s
     `);
     assert.lengthOf(graph.edges, 1);
-    assert.lengthOf(graph.edges[0].claims, 1);
-    const claim = graph.edges[0].claims[0];
-    assert.strictEqual(claim.type, ClaimType.IsTag);
-    assert.strictEqual((claim as ClaimIsTag).tag, 'trusted');
+    const modifier = graph.edges[0].modifier;
+    assert.strictEqual(modifier.tagOperations.size, 1);
+    assert.strictEqual(modifier.tagOperations.get('trusted'), 'add');
   });
 
-  it('copies particle claims to particle nodes and out-edges', async () => {
+  it('copies particle claims to particle out-edges as a flow modifier', async () => {
     const graph = await buildFlowGraph(`
       particle P
         out Foo {} foo
@@ -133,15 +130,12 @@ describe('FlowGraph', () => {
         P
           foo -> h
     `);
-    const node = checkDefined(graph.particleMap.get('P'));
-    assert.strictEqual(node.claims.length, 1);
-    const particleClaim = node.claims.find(pclaim => pclaim.handle.name === 'foo');
-    assert.isNotNull(particleClaim);
-    assert.strictEqual((particleClaim.claims[0] as ClaimIsTag).tag, 'trusted');
-    assert.isEmpty(node.checks);
-
     assert.lengthOf(graph.edges, 1);
-    assert.strictEqual(graph.edges[0].claims[0], particleClaim.claims[0]);
+    assert.isNotNull(graph.edges[0].modifier);
+    assert.deepEqual(graph.edges[0].modifier, FlowModifier.fromConditions(
+        {type: 'node', value: 'P0'},
+        {type: 'edge', value: 'E0'},
+        {type: 'tag', value: 'trusted'}));
   });
 
   it('copies particle checks to particle nodes and in-edges', async () => {
@@ -153,15 +147,10 @@ describe('FlowGraph', () => {
         P
           foo <- h
     `);
-    const node = checkDefined(graph.particleMap.get('P'));
-    assert.lengthOf(node.checks, 1);
-    const check = node.checks[0];
-    assert.strictEqual(check.target.name, 'foo');
-    assert.deepEqual(check.expression, new CheckHasTag('trusted'));
-    assert.isEmpty(node.claims);
-
     assert.lengthOf(graph.edges, 1);
-    assert.strictEqual(graph.edges[0].check, check);
+    const check = graph.edges[0].check;
+    assert.deepEqual(check.expression, {type: 'tag', value: 'trusted'});
+    assert.isUndefined(check.children);
   });
 
   it('supports making checks on slots', async () => {
@@ -196,10 +185,7 @@ describe('FlowGraph', () => {
     assert.strictEqual(slot2.inEdges[0].connectionName, 'slotToConsume');
     assert.strictEqual((slot2.inEdges[0].start as ParticleNode).name, 'P2');
     const check = slot2.inEdges[0].check;
-    assert.instanceOf(check.target, ProvideSlotConnectionSpec);
-    assert.strictEqual(check.target.name, 'slotToProvide');
-    assert.deepEqual(check.expression, new CheckHasTag('trusted'));
-    assert.strictEqual(check, slot2.check);
+    assert.deepEqual(check.expression, {type: 'tag', value: 'trusted'});
   });
 
   it('resolves data store names and IDs', async () => {

--- a/src/dataflow/analysis/tests/flow-graph-test.ts
+++ b/src/dataflow/analysis/tests/flow-graph-test.ts
@@ -149,8 +149,7 @@ describe('FlowGraph', () => {
     `);
     assert.lengthOf(graph.edges, 1);
     const check = graph.edges[0].check;
-    assert.deepEqual(check.expression, {type: 'tag', value: 'trusted'});
-    assert.isUndefined(check.children);
+    assert.deepNestedInclude(check, {type: 'tag', value: 'trusted'});
   });
 
   it('supports making checks on slots', async () => {
@@ -185,7 +184,7 @@ describe('FlowGraph', () => {
     assert.strictEqual(slot2.inEdges[0].connectionName, 'slotToConsume');
     assert.strictEqual((slot2.inEdges[0].start as ParticleNode).name, 'P2');
     const check = slot2.inEdges[0].check;
-    assert.deepEqual(check.expression, {type: 'tag', value: 'trusted'});
+    assert.deepNestedInclude(check, {type: 'tag', value: 'trusted'});
   });
 
   it('resolves data store names and IDs', async () => {


### PR DESCRIPTION
These classes are all essentially eqivalent to the
Check/CheckCondition/Claim classes we already have on the ParticleSpec
class. However, instead of pointing to complex objects like
HandleConnectionSpec, they are now just all strings (using nodeId,
edgeId, tag strings).

This will be incredibly useful for testing the new Hindley-Milner
algorithm, since we won't need to create complex Handle/Particle
objects, but can operate on simple nodes with strings instead.

It also makes some of the code simpler and more efficient (all of the
'is from handle'/'is from store' checks now get evaluated only once,
whereas before they were evaluated for every path).

Also note that the Flow object is going to be especially useful for HM.
It currently represents a path, but in HM it's going to be used to
represent the accumulated set of claims for every edge (with few/no
changes to its internal structure at all).