### PR TITLE
Added a DeepSet implementation

### DIFF
--- a/src/dataflow/analysis/deep-set.ts
+++ b/src/dataflow/analysis/deep-set.ts
@@ -1,0 +1,78 @@
+/**
+ * @license
+ * Copyright 2019 Google LLC.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+interface UniqueStringable {
+  /**
+   * Returns a unique string representation of this object, with the property
+   * that A deep equals B iff A.toUniqueString() == B.toUniqueString().
+   */
+  toUniqueString(): string;
+}
+
+/**
+ * A Set implementation that performs deep equality of its elements instead of
+ * strict equality. Every element needs to have a unique string representation,
+ * which will be used as a simple way to compute deep equality.
+ */
+export class DeepSet<T extends UniqueStringable> implements Iterable<T> {
+  /** All elements stored in the set. */
+  private readonly elementSet: Set<T> = new Set();
+
+  /** The unique string representation of every element in the set. */
+  private readonly stringSet: Set<string> = new Set();
+
+  constructor(...elements: T[]) {
+    elements.forEach(e => this.add(e));
+  }
+
+  add(element: T) {
+    const repr = element.toUniqueString();
+    if (this.stringSet.has(repr)) {
+      return;
+    }
+    this.stringSet.add(repr);
+    this.elementSet.add(element);
+  }
+
+  addAll(other: DeepSet<T>) {
+    other.elementSet.forEach(e => this.add(e));
+  }
+
+  map(transform: (value: T) => T): DeepSet<T> {
+    const result = new DeepSet<T>();
+    for (const elem of this) {
+      result.add(transform(elem));
+    }
+    return result;
+  }
+
+  [Symbol.iterator]() {
+    return this.elementSet[Symbol.iterator]();
+  }
+
+  asSet(): ReadonlySet<T> {
+    return this.elementSet;
+  }
+
+  toArray(): T[] {
+    return [...this.elementSet];
+  }
+
+  get size(): number {
+    return this.elementSet.size;
+  }
+
+  /** Unique string representation of this DeepSet. */
+  toUniqueString(): string {
+    const strings = [...this.stringSet];
+    strings.sort();
+    return '{' + strings.join(', ') + '}';
+  }
+}

--- a/src/dataflow/analysis/tests/deep-set-test.ts
+++ b/src/dataflow/analysis/tests/deep-set-test.ts
@@ -1,0 +1,88 @@
+/**
+ * @license
+ * Copyright 2019 Google LLC.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {DeepSet} from '../deep-set.js';
+import {assert} from '../../../platform/chai-web.js';
+
+class TestElement {
+  constructor(readonly elem: number) {}
+
+  toUniqueString() {
+    return this.elem + '!';
+  }
+}
+
+/** Wraps each given number element into a TestElement, and then creates a new DeepSet out of them. */
+function newTestSet(...elements: number[]): DeepSet<TestElement> {
+  return new DeepSet(...elements.map(e => new TestElement(e)));
+}
+
+/** Takes the given DeepSet, and unwraps every TestElement object inside it into a raw number. */
+function unwrapSet(set: DeepSet<TestElement>): number[] {
+  return set.toArray().map(e => e.elem);
+}
+
+describe('DeepSet', () => {
+  it('can construct an empty set', () => {
+    const set = newTestSet();
+    assert.isEmpty(set.asSet());
+    assert.equal(set.size, 0);
+  });
+
+  it('can construct a set from given elements', () => {
+    const set = newTestSet(1, 2, 3);
+    assert.deepEqual(unwrapSet(set), [1, 2, 3]);
+  });
+
+  it('ignores duplicates when constructing the set', () => {
+    const set = newTestSet(1, 1, 2);
+    assert.deepEqual(unwrapSet(set), [1, 2]);
+  });
+
+  it('ignores duplicates when adding elements', () => {
+    const set = newTestSet(1, 2);
+    assert.equal(set.size, 2);
+    set.add(new TestElement(3));
+    assert.equal(set.size, 3);
+    set.add(new TestElement(3));
+    assert.equal(set.size, 3);
+  });
+
+  it('ignores duplicates when adding sets of elements', () => {
+    const set1 = newTestSet(1, 2);
+    const set2 = newTestSet(2, 3);
+
+    set1.addAll(set2);
+
+    assert.deepEqual(unwrapSet(set1), [1, 2, 3]);
+  });
+
+  it('is iterable', () => {
+    const set = newTestSet(1, 2, 3);
+    const result: TestElement[] = [];
+    for (const elem of set) {
+      result.push(elem);
+    }
+    assert.deepEqual(result, [new TestElement(1), new TestElement(2), new TestElement(3)]);
+  });
+
+  it('map() creates a transformed copy without duplicates', () => {
+    const original = newTestSet(1, 2, 3, 4, 5);
+    const halved = original.map(e => new TestElement(Math.floor(e.elem / 2)));
+
+    assert.deepEqual(unwrapSet(original), [1, 2, 3, 4, 5]);
+    assert.deepEqual(unwrapSet(halved), [0, 1, 2]);
+  });
+
+  it('has a unique string representation', () => {
+    const set = newTestSet(3, 2, 1);
+    assert.equal(set.toUniqueString(), '{1!, 2!, 3!}');
+  });
+});


### PR DESCRIPTION
This is like a regular Set, except instead of using pointer equality to
determine whether elements are in the set, it uses value equality. Value
equality is implemented via a toUniqueString() hack, for
simplicity/efficiency. Every element in the set has a unique string
representation, and the string representation is used to determine
whether other elements are duplicates.

Also adds some new methods to Flow and FlowModifier, and adds FlowSet
and FlowModifierSet using DeepSet.