### PR TITLE
Added more comprehensive unit tests for dataflow algorithm

### DIFF
--- a/src/dataflow/analysis/analysis.ts
+++ b/src/dataflow/analysis/analysis.ts
@@ -23,7 +23,7 @@ export class ValidationResult {
 
 /** Returns true if all checks in the graph pass. */
 export function validateGraph(graph: FlowGraph): ValidationResult {
-  const solver = new Solver(graph);
+  const solver = new Solver(graph.edges);
   solver.resolve();
   return solver.validateAllChecks();
 }
@@ -34,7 +34,7 @@ export function validateGraph(graph: FlowGraph): ValidationResult {
  * parent edge, and a set of modifiers which should be applied to the flow from
  * that edge.
  */
-class EdgeExpression {
+export class EdgeExpression {
   /** The edge we're talking about. */
   readonly edge: Edge;
 
@@ -81,7 +81,7 @@ class EdgeExpression {
       `Can't substitute parent edge, it's not an unresolved parent.`);
     assert(!parentExpr.unresolvedFlows.has(this.edge), `Cycles aren't supported (yet).`);  
 
-    // Remove unresolved parent, and replace with inherited unresolved parents.
+    // Remove unresolved parent, and replace with unresolved grandparents.
     const modifierSet = this.unresolvedFlows.get(parentExpr.edge);
     this.unresolvedFlows.delete(parentExpr.edge);
 
@@ -118,7 +118,7 @@ class EdgeExpression {
     }
     for (const [edge, modifierSets] of this.unresolvedFlows) {
       for (const modifiers of modifierSets) {
-        result.push(`  ${edge.label} + ${modifiers.toString()}`);
+        result.push(`  EdgeExpression(${edge.label}) + ${modifiers.toUniqueString()}`);
       }
     }
     result.push('}');
@@ -126,24 +126,24 @@ class EdgeExpression {
   }
 }
 
-class Solver {
-  readonly graph: FlowGraph;
+export class Solver {
+  readonly edges: Edge[];
 
   /** Maps from an edge to a "expression" for it. */
   readonly edgeExpressions: Map<Edge, EdgeExpression> = new Map();
 
-  /** Maps from an edge to the set of edges which depends upon it. */
-  readonly dependentEdges: Map<Edge, Set<Edge>>;
+  /** Maps from an edge to the set of edge expressions which depends upon it. */
+  readonly dependentExpressions: Map<Edge, Set<EdgeExpression>>;
 
   private _isResolved = false;
 
-  constructor(graph: FlowGraph) {
-    this.graph = graph;
+  constructor(edges: Edge[]) {
+    this.edges = edges;
 
     // Fill dependentEdges map with empty sets.
-    this.dependentEdges = new Map();
-    for (const edge of graph.edges) {
-      this.dependentEdges.set(edge, new Set());
+    this.dependentExpressions = new Map();
+    for (const edge of edges) {
+      this.dependentExpressions.set(edge, new Set());
     }
   }
 
@@ -160,7 +160,7 @@ class Solver {
     assert(this._isResolved, 'Graph must be resolved before checks can be validated.');
 
     const finalResult = new ValidationResult();
-    for (const edge of this.graph.edges) {
+    for (const edge of this.edges) {
       if (edge.check) {
         const result = this.validateCheckOnEdge(edge);
         result.failures.forEach(f => finalResult.failures.add(f));
@@ -198,14 +198,14 @@ class Solver {
       return;
     }
 
-    for (const edge of this.graph.edges) {
+    for (const edge of this.edges) {
       this.processEdge(edge);
     }
 
     // Verify that all edges are fully resolved.
-    const numEdges = this.graph.edges.length;
+    const numEdges = this.edges.length;
     assert(this.edgeExpressions.size === numEdges);
-    assert(this.dependentEdges.size === numEdges);
+    assert(this.dependentExpressions.size === numEdges);
     for (const edgeExpression of this.edgeExpressions.values()) {
       assert(edgeExpression.isResolved, `Unresolved edge expression: ${edgeExpression.toString()}`);
     }
@@ -218,49 +218,46 @@ class Solver {
    * many of its unresolved parents as is possible. The edge expression might
    * still not be fully resolved at the end of this function.
    */
-  processEdge(edge: Edge) {
-    if (this.edgeExpressions.has(edge)) {
+  processEdge(edge: Edge): EdgeExpression {
+    let edgeExpression = this.edgeExpressions.get(edge);
+    if (edgeExpression) {
       // Edge has already been processed.
-      return;
+      return edgeExpression;
     }
 
-    const edgeExpression = new EdgeExpression(edge);
+    edgeExpression = new EdgeExpression(edge);
     this.edgeExpressions.set(edge, edgeExpression);
 
     // Try to expand all of the parents we already know about.
     for (const parent of edgeExpression.parents) {
       // Indicate that edge depends on parent.
-      this.dependentEdges.get(parent).add(edge);
+      this.dependentExpressions.get(parent).add(edgeExpression);
 
       this.tryExpandParent(edgeExpression, parent);
     }
+
+    // Now go through and expand this edge in the edges which depend on it.
+    for (const dependentExpression of this.dependentExpressions.get(edge)) {
+      this.tryExpandParent(dependentExpression, edge);
+    }
+
+    return edgeExpression;
   }
 
   /**
    * Takes an edge expression with an unresolved parent edge, and tries to
    * expand out that parent edge using the parent edge's own expression.
    */
-  tryExpandParent(expression: EdgeExpression, parentEdge: Edge) {
+  private tryExpandParent(expression: EdgeExpression, parentEdge: Edge) {
     if (!expression.unresolvedFlows.has(parentEdge)) {
       return;
     }
-    const edge = expression.edge;
     const parentExpression = this.edgeExpressions.get(parentEdge);
     if (parentExpression) {
-      this.dependentEdges.get(parentEdge).delete(edge);
+      this.dependentExpressions.get(parentEdge).delete(expression);
       expression.expandParent(parentExpression);
-
-      // Try expanding further.
-      for (const newParent of parentExpression.parents) {
-        this.dependentEdges.get(newParent).add(edge);
-        this.tryExpandParent(expression, newParent);
-      }
-    }
-
-    // Now go through and expand this edge in the edges which depend on it.
-    for (const dependentEdge of this.dependentEdges.get(edge)) {
-      const dependentEdgeExpression = this.edgeExpressions.get(dependentEdge);
-      this.tryExpandParent(dependentEdgeExpression, edge);
+      // Note down new dependencies from the grandparents to this edge.
+      parentExpression.parents.forEach(grandparent => this.dependentExpressions.get(grandparent).add(expression));
     }
   }
 }

--- a/src/dataflow/analysis/testing/flow-graph-testing.ts
+++ b/src/dataflow/analysis/testing/flow-graph-testing.ts
@@ -12,7 +12,7 @@ import {assert} from '../../../platform/chai-web.js';
 import {Manifest} from '../../../runtime/manifest.js';
 import {FlowGraph} from '../flow-graph.js';
 import {CheckCondition} from '../../../runtime/particle-check.js';
-import {Edge, Node} from '../graph-internals.js';
+import {Edge, Node, FlowModifier} from '../graph-internals.js';
 
 /** Constructs a FlowGraph from the recipe in the given manifest. */
 export async function buildFlowGraph(manifestContent: string): Promise<FlowGraph> {
@@ -45,15 +45,18 @@ export class TestNode extends Node {
   }
 
   inEdgesFromOutEdge(outEdge: Edge): readonly Edge[] {
-    throw new Error('Unimplemented.');
+    return this.inEdges;
   }
 }
 
 export class TestEdge implements Edge {
   readonly edgeId: string;
   readonly connectionName = 'connectionName';
+  modifier?: FlowModifier;
 
   constructor(readonly start: TestNode, readonly end: TestNode, readonly label: string) {
     this.edgeId = label;
+    start.outEdges.push(this);
+    end.inEdges.push(this);
   }
 }

--- a/src/dataflow/analysis/tests/analysis-test.ts
+++ b/src/dataflow/analysis/tests/analysis-test.ts
@@ -71,7 +71,7 @@ describe('EdgeExpression', () => {
     expectedFlowSet.add(new Flow());
     assert.deepEqual(expression.resolvedFlows, expectedFlowSet);
 
-    assert.equal(expression.toString(), `EdgeExpression(AB) {
+    assert.equal(expression.toString(), `EdgeExpression(A->B) {
   {}
 }`);
   });
@@ -89,7 +89,7 @@ describe('EdgeExpression', () => {
     flow.tags.add('t1');
     assert.deepEqual(expression.resolvedFlows, new FlowSet(flow));
 
-    assert.equal(expression.toString(), `EdgeExpression(AB) {
+    assert.equal(expression.toString(), `EdgeExpression(A->B) {
   {tag:t1}
 }`);
   });
@@ -106,8 +106,8 @@ describe('EdgeExpression', () => {
     assert.deepEqual(expression.unresolvedFlows.get(parentEdge), new FlowModifierSet(addsTagT1));
     assert.sameMembers(expression.parents, [parentEdge]);
 
-    assert.equal(expression.toString(), `EdgeExpression(BC) {
-  EdgeExpression(AB) + {+tag:t1}
+    assert.equal(expression.toString(), `EdgeExpression(B->C) {
+  EdgeExpression(A->B) + {+tag:t1}
 }`);
   });
 

--- a/src/dataflow/analysis/tests/analysis-test.ts
+++ b/src/dataflow/analysis/tests/analysis-test.ts
@@ -8,9 +8,10 @@
  * http://polymer.github.io/PATENTS.txt
  */
 import {assert} from '../../../platform/chai-web.js';
-import {validateGraph, ValidationResult} from '../analysis.js';
-import {buildFlowGraph} from '../testing/flow-graph-testing.js';
+import {validateGraph, ValidationResult, Solver, EdgeExpression} from '../analysis.js';
+import {buildFlowGraph, TestEdge, TestNode} from '../testing/flow-graph-testing.js';
 import {assertThrowsAsync} from '../../../runtime/testing/test-util.js';
+import {FlowSet, Flow, FlowModifier, TagOperation, FlowModifierSet} from '../graph-internals.js';
 
 /** Checks that the given ValidationResult failed with the expected failure messages. */
 function assertFailures(result: ValidationResult, expectedFailures: string[]) {
@@ -27,6 +28,245 @@ function assertFailures(result: ValidationResult, expectedFailures: string[]) {
 
   assert.sameMembers([...result.failures], [...expectedFailuresWithoutPaths]);
 }
+
+/**
+ * Creates test nodes and edges in a chain, using the given node IDs. e.g.
+ * createChainOfEdges('A', 'B', 'C') will return an array of two edges: AB, BC.
+ */
+function createChainOfEdges(...nodeIds: string[]) {
+  assert(nodeIds.length >= 2);
+  const nodes = nodeIds.map(nodeId => new TestNode(nodeId));
+  const edges: TestEdge[] = [];
+  for (let i = 1; i < nodes.length; i++) {
+    const firstNode = nodes[i - 1];
+    const secondNode = nodes[i];
+    edges.push(new TestEdge(firstNode, secondNode, firstNode.nodeId + secondNode.nodeId));
+  }
+  return edges;
+}
+
+// FlowModifier constants.
+const addsTagT1 = new FlowModifier();
+addsTagT1.tagOperations.set('t1', TagOperation.Add);
+
+const addsTagT2 = new FlowModifier();
+addsTagT2.tagOperations.set('t2', TagOperation.Add);
+
+const addsTagsT1AndT2 = addsTagT1.copyAndModify(addsTagT2);
+
+const removesTagT1 = new FlowModifier();
+removesTagT1.tagOperations.set('t1', TagOperation.Remove);
+
+describe('EdgeExpression', () => {
+  it('can construct an edge with no parents and no modifier', () => {
+    const [edge] = createChainOfEdges('A', 'B');
+    const expression = new EdgeExpression(edge);
+
+    assert.strictEqual(expression.edge, edge);
+    assert.isTrue(expression.isResolved);
+    assert.isEmpty(expression.unresolvedFlows);
+    assert.isEmpty(expression.parents);
+
+    const expectedFlowSet = new FlowSet();
+    expectedFlowSet.add(new Flow());
+    assert.deepEqual(expression.resolvedFlows, expectedFlowSet);
+
+    assert.equal(expression.toString(), `EdgeExpression(AB) {
+  {}
+}`);
+  });
+
+  it('can construct an edge with no parents and a modifier', () => {
+    const [edge] = createChainOfEdges('A', 'B');
+    edge.modifier = addsTagT1;
+    const expression = new EdgeExpression(edge);
+
+    assert.isTrue(expression.isResolved);
+    assert.isEmpty(expression.unresolvedFlows);
+    assert.isEmpty(expression.parents);
+
+    const flow = new Flow();
+    flow.tags.add('t1');
+    assert.deepEqual(expression.resolvedFlows, new FlowSet(flow));
+
+    assert.equal(expression.toString(), `EdgeExpression(AB) {
+  {tag:t1}
+}`);
+  });
+
+  it('can construct an edge with parent and a modifier', () => {
+    const [parentEdge, edge] = createChainOfEdges('A', 'B', 'C');
+
+    edge.modifier = addsTagT1;
+    const expression = new EdgeExpression(edge);
+
+    assert.isFalse(expression.isResolved);
+    assert.equal(expression.resolvedFlows.size, 0);
+    assert.hasAllKeys(expression.unresolvedFlows, [parentEdge]);
+    assert.deepEqual(expression.unresolvedFlows.get(parentEdge), new FlowModifierSet(addsTagT1));
+    assert.sameMembers(expression.parents, [parentEdge]);
+
+    assert.equal(expression.toString(), `EdgeExpression(BC) {
+  EdgeExpression(AB) + {+tag:t1}
+}`);
+  });
+
+  it('can substitute a resolved parent', () => {
+    const [parentEdge, edge] = createChainOfEdges('A', 'B', 'C');
+    parentEdge.modifier = addsTagT1;
+    edge.modifier = addsTagT2;
+    const parentExpression = new EdgeExpression(parentEdge);
+    const expression = new EdgeExpression(edge);
+    
+    expression.expandParent(parentExpression);
+    
+    assert.isTrue(expression.isResolved);
+    assert.deepEqual(expression.resolvedFlows, new FlowSet(addsTagsT1AndT2.toFlow()));
+  });
+
+  it('can substitute an unresolved parent', () => {
+    const [grandparentEdge, parentEdge, edge] = createChainOfEdges('A', 'B', 'C', 'D');
+    parentEdge.modifier = addsTagT1;
+    edge.modifier = addsTagT2;
+    const parentExpression = new EdgeExpression(parentEdge);
+    const expression = new EdgeExpression(edge);    
+    
+    expression.expandParent(parentExpression);
+    
+    assert.isFalse(expression.isResolved);
+    assert.hasAllDeepKeys(expression.unresolvedFlows, grandparentEdge);
+    assert.deepEqual(expression.unresolvedFlows.get(grandparentEdge), new FlowModifierSet(addsTagsT1AndT2));
+  });
+
+  it('can depend on a parent with multiple different modifiers', () => {
+    const [parentEdge, edge] = createChainOfEdges('A', 'B', 'C');
+    edge.modifier = addsTagT1;
+    const expression = new EdgeExpression(edge);
+
+    // Add another modifier manually. This could have come from expanding
+    // another parent, for instance.
+    expression.unresolvedFlows.get(parentEdge).add(addsTagT2);
+
+    expression.expandParent(new EdgeExpression(parentEdge));
+    assert.isTrue(expression.isResolved);
+    assert.deepEqual(expression.resolvedFlows, new FlowSet(addsTagT1.toFlow(), addsTagT2.toFlow()));
+  });
+  
+  it('can depend on a grandparent with multiple different modifiers', () => {
+    const [grandparentEdge, parentEdge1, edge] = createChainOfEdges('A', 'B', 'C', 'D');
+    const parentEdge2 = new TestEdge(parentEdge1.start, parentEdge1.end, 'BC2');
+    parentEdge1.modifier = addsTagT1;
+    parentEdge2.modifier = addsTagT2;
+
+    const expression = new EdgeExpression(edge);
+    expression.expandParent(new EdgeExpression(parentEdge1));
+    expression.expandParent(new EdgeExpression(parentEdge2));
+
+    assert.hasAllDeepKeys(expression.unresolvedFlows, grandparentEdge);
+    assert.deepEqual(expression.unresolvedFlows.get(grandparentEdge), new FlowModifierSet(addsTagT1, addsTagT2));
+  });
+
+  it('applies child modifier after parent modifier', () => {
+    const [parentEdge, edge] = createChainOfEdges('A', 'B', 'C');
+    parentEdge.modifier = addsTagsT1AndT2;
+    edge.modifier = removesTagT1;
+
+    const expression = new EdgeExpression(edge);
+    expression.expandParent(new EdgeExpression(parentEdge));
+
+    assert.isTrue(expression.isResolved);
+    assert.deepEqual(expression.resolvedFlows, new FlowSet(addsTagT2.toFlow()));
+  });
+});
+
+describe('Solver', () => {
+  it('starts with empty edge expressions and dependencies', () => {
+    const edges = createChainOfEdges('A', 'B', 'C');
+    const solver = new Solver(edges);
+
+    assert.isFalse(solver.isResolved);
+    assert.isEmpty(solver.edgeExpressions);
+    assert.hasAllDeepKeys(solver.dependentExpressions, edges);
+    for (const dependencies of solver.dependentExpressions.values()) {
+      assert.isEmpty(dependencies);
+    }
+  });
+
+  describe('processEdge', () => {
+    it('adds edge expression and dependency', () => {
+      const [parentEdge, edge] = createChainOfEdges('A', 'B', 'C');
+      const solver = new Solver([parentEdge, edge]);
+
+      const expression = solver.processEdge(edge);
+
+      assert.strictEqual(solver.edgeExpressions.get(edge), expression);
+      assert.hasAllKeys(solver.edgeExpressions, [edge]);
+      assert.strictEqual(expression.edge, edge);
+      assert.sameMembers(expression.parents, [parentEdge]);
+      assert.isEmpty(solver.dependentExpressions.get(edge));
+      const parentDeps = solver.dependentExpressions.get(parentEdge);
+      assert.hasAllKeys(parentDeps, [expression]);
+    });
+
+    it('expands known resolved parent', () => {
+      const [parentEdge, edge] = createChainOfEdges('A', 'B', 'C');
+      parentEdge.modifier = addsTagT1;
+      edge.modifier = addsTagT2;
+      const solver = new Solver([parentEdge, edge]);
+      
+      const parentExpression = solver.processEdge(parentEdge);
+      assert.isTrue(parentExpression.isResolved);
+      assert.deepEqual(parentExpression.resolvedFlows, new FlowSet(addsTagT1.toFlow()));
+      
+      const expression = solver.processEdge(edge);
+      assert.isTrue(expression.isResolved);
+      assert.deepEqual(expression.resolvedFlows, new FlowSet(addsTagsT1AndT2.toFlow()));
+      assert.isEmpty(solver.dependentExpressions.get(parentEdge));
+    });
+
+    it('expands known unresolved parent', () => {
+      const [grandparentEdge, parentEdge, edge] = createChainOfEdges('A', 'B', 'C', 'D');
+      const solver = new Solver([grandparentEdge, parentEdge, edge]);
+      
+      const parentExpression = solver.processEdge(parentEdge);
+      const expression = solver.processEdge(edge);
+
+      assert.sameMembers(expression.parents, [grandparentEdge]);
+      assert.isEmpty(solver.dependentExpressions.get(parentEdge));
+      assert.hasAllKeys(solver.dependentExpressions.get(grandparentEdge), [parentExpression, expression]);
+    });
+
+    it('expands the current edge into its dependent edges', () => {
+      const [edge, childEdge] = createChainOfEdges('A', 'B', 'C');
+      edge.modifier = addsTagT1;
+      childEdge.modifier = addsTagT2;
+      const solver = new Solver([edge, childEdge]);
+
+      const childExpression = solver.processEdge(childEdge);
+      assert.isFalse(childExpression.isResolved);
+      assert.hasAllKeys(solver.dependentExpressions.get(edge), [childExpression]);
+      
+      const expression = solver.processEdge(edge);
+      assert.isEmpty(solver.dependentExpressions.get(edge));
+      assert.isTrue(expression.isResolved);
+      assert.isTrue(childExpression.isResolved);
+    });
+  });
+
+  describe('resolve', () => {
+    it('fully resolves all edges', () => {
+      const edges = createChainOfEdges('A', 'B', 'C', 'D');
+      const solver = new Solver(edges);
+      
+      solver.resolve();
+
+      assert.isTrue(solver.isResolved);
+      for (const expression of solver.edgeExpressions.values()) {
+        assert.isTrue(expression.isResolved);
+      }
+    });
+  });
+});
 
 describe('FlowGraph validation', () => {
   it('succeeds when there are no checks', async () => {

--- a/src/dataflow/analysis/tests/analysis-test.ts
+++ b/src/dataflow/analysis/tests/analysis-test.ts
@@ -40,7 +40,7 @@ function createChainOfEdges(...nodeIds: string[]) {
   for (let i = 1; i < nodes.length; i++) {
     const firstNode = nodes[i - 1];
     const secondNode = nodes[i];
-    edges.push(new TestEdge(firstNode, secondNode, firstNode.nodeId + secondNode.nodeId));
+    edges.push(new TestEdge(firstNode, secondNode, firstNode.nodeId + '->' + secondNode.nodeId));
   }
   return edges;
 }


### PR DESCRIPTION
These unit tests are for the individual steps of the algorithm (testing
Solver methods and EdgeExpression methods directly). We already have a
comprehensive suite of tests for full recipes.

Made some slight adjustments to the API to make it easier to test.

Algorithm implementation was in PR #3339