### PR TITLE
make more java crdt classes public (and move to their own files)

### DIFF
--- a/src/javaharness/java/arcs/crdt/CRDT.java
+++ b/src/javaharness/java/arcs/crdt/CRDT.java
@@ -1,14 +1,8 @@
 package arcs.crdt;
 
-import java.util.HashMap;
 import java.util.Optional;
-import java.util.Map;
 
 // Classes and interfaces copied from src/runtime/crdt/crdt.ts
-class VersionMap extends HashMap<String, Integer> {}
-
-interface CRDTOperation {}
-
 class CRDTData {
   VersionMap version;
 }

--- a/src/javaharness/java/arcs/crdt/CRDTCollection.java
+++ b/src/javaharness/java/arcs/crdt/CRDTCollection.java
@@ -6,53 +6,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 // Classes and interfaces copied from src/runtime/crdt/crdt-collection.ts
-interface Referenceable {
-  String getId();
-}
-
-class VersionedValue<T> {
-  T value;
-  VersionMap version;
-  VersionedValue(T value, VersionMap version) {
-    this.value = value;
-    this.version = version;
-  }
-}
-
-class CollectionData<T extends Referenceable> extends CRDTData {
-   Map<String, VersionedValue<T>> values = new HashMap<>();
-   VersionMap version = new VersionMap();
-}
-
-enum CollectionOpTypes { ADD, REMOVE }
-
-class CollectionOperation<T> implements CRDTOperation {
-  CollectionOpTypes type;
-  Optional<T> added;
-  Optional<T> removed;
-  VersionMap clock;
-  String actor;
-
-  CollectionOperation(CollectionOpTypes type, T t, VersionMap clock, String actor) {
-    this.type = type;
-    switch (type) {
-      case ADD:
-        this.added = Optional.of(t);
-        break;
-      case REMOVE:
-        this.removed = Optional.of(t);
-        break;
-      default:
-        throw new AssertionError("Unsupported CollectionOpType " + type);
-    }
-    this.clock = clock;
-    this.actor = actor;
-  }
-}
 
 class RawCollection<T> extends HashSet<T> implements CRDTConsumerType {
   RawCollection() {}

--- a/src/javaharness/java/arcs/crdt/CRDTOperation.java
+++ b/src/javaharness/java/arcs/crdt/CRDTOperation.java
@@ -1,0 +1,6 @@
+package arcs.crdt;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public interface CRDTOperation {}

--- a/src/javaharness/java/arcs/crdt/CRDTOperation.java
+++ b/src/javaharness/java/arcs/crdt/CRDTOperation.java
@@ -1,6 +1,3 @@
 package arcs.crdt;
 
-import java.util.HashMap;
-import java.util.Map;
-
 public interface CRDTOperation {}

--- a/src/javaharness/java/arcs/crdt/CollectionData.java
+++ b/src/javaharness/java/arcs/crdt/CollectionData.java
@@ -1,0 +1,9 @@
+package arcs.crdt;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class CollectionData<T extends Referenceable> extends CRDTData {
+   Map<String, VersionedValue<T>> values = new HashMap<>();
+   VersionMap version = new VersionMap();
+}

--- a/src/javaharness/java/arcs/crdt/CollectionDataTest.java
+++ b/src/javaharness/java/arcs/crdt/CollectionDataTest.java
@@ -37,14 +37,14 @@ public class CollectionDataTest {
     // can add two different items from the same actor
     CRDTCollection<Data> set = new CRDTCollection<>();
     assert set.applyOperation(new CollectionOperation<Data>(
-        CollectionOpTypes.ADD,
+        CollectionOperation.Type.ADD,
         new Data("one"),
         new VersionMap(){{ put("me", 1); }},
         "me"
     ));
 
     assert set.applyOperation(new CollectionOperation<Data>(
-        CollectionOpTypes.ADD,
+        CollectionOperation.Type.ADD,
         new Data("two"),
         new VersionMap(){{ put("me", 2); }},
         "me"
@@ -57,13 +57,13 @@ public class CollectionDataTest {
     // can add the same value from two actors
     CRDTCollection<Data> set = new CRDTCollection<>();
     assert set.applyOperation(new CollectionOperation<Data>(
-        CollectionOpTypes.ADD,
+        CollectionOperation.Type.ADD,
         new Data("one"),
         new VersionMap() {{ put("me", 1); }},
         "me"
     ));
     assert set.applyOperation(new CollectionOperation<Data>(
-        CollectionOpTypes.ADD,
+        CollectionOperation.Type.ADD,
         new Data("one"),
         new VersionMap() {{ put("them", 1); }},
         "them"
@@ -76,25 +76,25 @@ public class CollectionDataTest {
     // rejects add operations not in sequence
     CRDTCollection<Data> set = new CRDTCollection<>();
     assert set.applyOperation(new CollectionOperation<Data>(
-      CollectionOpTypes.ADD,
+      CollectionOperation.Type.ADD,
       new Data("one"),
       new VersionMap() {{ put("me", 1); }},
       "me"
     ));
     assert !set.applyOperation(new CollectionOperation<Data>(
-      CollectionOpTypes.ADD,
+      CollectionOperation.Type.ADD,
       new Data("two"),
       new VersionMap() {{ put("me", 0); }},
       "me"
     ));
     assert !set.applyOperation(new CollectionOperation<Data>(
-      CollectionOpTypes.ADD,
+      CollectionOperation.Type.ADD,
       new Data("two"),
       new VersionMap() {{ put("me", 1); }},
       "me"
     ));
     assert !set.applyOperation(new CollectionOperation<Data>(
-      CollectionOpTypes.ADD,
+      CollectionOperation.Type.ADD,
       new Data("two"),
       new VersionMap() {{ put("me", 3); }},
       "me"
@@ -105,14 +105,14 @@ public class CollectionDataTest {
     // can remove an item
     CRDTCollection<Data> set = new CRDTCollection<>();
     assert set.applyOperation(new CollectionOperation<Data>(
-      CollectionOpTypes.ADD,
+      CollectionOperation.Type.ADD,
       new Data("one"),
       new VersionMap() {{ put("me", 1); }},
       "me"
     ));
     verifySize(set, 1);
     assert set.applyOperation(new CollectionOperation<Data>(
-      CollectionOpTypes.REMOVE,
+      CollectionOperation.Type.REMOVE,
       new Data("one"),
       new VersionMap() {{ put("me", 1); }},
       "me"
@@ -124,19 +124,19 @@ public class CollectionDataTest {
     // rejects remove operations if version mismatch
     CRDTCollection<Data> set = new CRDTCollection<>();
     assert set.applyOperation(new CollectionOperation<Data>(
-      CollectionOpTypes.ADD,
+      CollectionOperation.Type.ADD,
       new Data("one"),
       new VersionMap() {{ put("me", 1); }},
       "me"
     ));
     assert !set.applyOperation(new CollectionOperation<Data>(
-      CollectionOpTypes.REMOVE,
+      CollectionOperation.Type.REMOVE,
       new Data("one"),
       new VersionMap() {{ put("me", 2); }},
       "me"
     ));
     assert !set.applyOperation(new CollectionOperation<Data>(
-      CollectionOpTypes.REMOVE,
+      CollectionOperation.Type.REMOVE,
       new Data("one"),
       new VersionMap() {{ put("me", 0); }},
       "me"
@@ -147,13 +147,13 @@ public class CollectionDataTest {
     // rejects remove value not in collection
     CRDTCollection<Data> set = new CRDTCollection<>();
     assert set.applyOperation(new CollectionOperation<Data>(
-      CollectionOpTypes.ADD,
+      CollectionOperation.Type.ADD,
       new Data("one"),
       new VersionMap() {{ put("me", 1); }},
       "me"
     ));
     assert !set.applyOperation(new CollectionOperation<Data>(
-      CollectionOpTypes.REMOVE,
+      CollectionOperation.Type.REMOVE,
       new Data("two"),
       new VersionMap() {{ put("me", 1); }},
       "me"
@@ -164,27 +164,27 @@ public class CollectionDataTest {
     // rejects remove version too old
     CRDTCollection<Data> set = new CRDTCollection<>();
     assert set.applyOperation(new CollectionOperation<Data>(
-      CollectionOpTypes.ADD,
+      CollectionOperation.Type.ADD,
       new Data("one"),
       new VersionMap() {{ put("me", 1); }},
       "me"
     ));
     assert set.applyOperation(new CollectionOperation<Data>(
-      CollectionOpTypes.ADD,
+      CollectionOperation.Type.ADD,
       new Data("two"),
       new VersionMap() {{ put("you", 1); }},
       "you"
     ));
     // This succeeds because the op clock is up to date wrt to the value "one" (whose version is me:1).
     assert set.applyOperation(new CollectionOperation<Data>(
-      CollectionOpTypes.REMOVE,
+      CollectionOperation.Type.REMOVE,
       new Data("one"),
       new VersionMap() {{ put("me", 1); }},
       "them"
     ));
     // This fails because the op clock is not up to date wrt to the actor "you" (whose version is you:1).
     assert !set.applyOperation(new CollectionOperation<Data>(
-      CollectionOpTypes.REMOVE,
+      CollectionOperation.Type.REMOVE,
       new Data("two"),
       new VersionMap() {{ put("me", 1); }},
       "them"
@@ -195,26 +195,26 @@ public class CollectionDataTest {
     // can merge two models
     CRDTCollection<Data> set1 = new CRDTCollection<>();
     assert set1.applyOperation(new CollectionOperation<Data>(
-      CollectionOpTypes.ADD,
+      CollectionOperation.Type.ADD,
       new Data("one"),
       new VersionMap() {{ put("me", 1); }},
       "me"
     ));
     assert set1.applyOperation(new CollectionOperation<Data>(
-      CollectionOpTypes.ADD,
+      CollectionOperation.Type.ADD,
       new Data("two"),
       new VersionMap() {{ put("me", 2); }},
       "me"
     ));
     CRDTCollection<Data> set2 = new CRDTCollection<>();
     assert set2.applyOperation(new CollectionOperation<Data>(
-      CollectionOpTypes.ADD,
+      CollectionOperation.Type.ADD,
       new Data("three"),
       new VersionMap() {{ put("you", 1); }},
       "you"
     ));
     assert set2.applyOperation(new CollectionOperation<Data>(
-      CollectionOpTypes.ADD,
+      CollectionOperation.Type.ADD,
       new Data("one"),
       new VersionMap() {{ put("you", 2); }},
       "you"
@@ -239,7 +239,7 @@ public class CollectionDataTest {
 
     // Test removes also work in merge.
     set1.applyOperation(new CollectionOperation<Data>(
-      CollectionOpTypes.REMOVE,
+      CollectionOperation.Type.REMOVE,
       new Data("one"),
       new VersionMap() {{ put("me", 2); put("you", 2); }},
       "me"

--- a/src/javaharness/java/arcs/crdt/CollectionOperation.java
+++ b/src/javaharness/java/arcs/crdt/CollectionOperation.java
@@ -1,0 +1,29 @@
+package arcs.crdt;
+
+import java.util.Optional;
+
+public class CollectionOperation<T> implements CRDTOperation {
+  public static enum Type { ADD, REMOVE }
+
+  Type type;
+  Optional<T> added;
+  Optional<T> removed;
+  VersionMap clock;
+  String actor;
+
+  CollectionOperation(Type type, T t, VersionMap clock, String actor) {
+    this.type = type;
+    switch (type) {
+      case ADD:
+        this.added = Optional.of(t);
+        break;
+      case REMOVE:
+        this.removed = Optional.of(t);
+        break;
+      default:
+        throw new AssertionError("Unsupported CollectionOperation.Type " + type);
+    }
+    this.clock = clock;
+    this.actor = actor;
+  }
+}

--- a/src/javaharness/java/arcs/crdt/Referenceable.java
+++ b/src/javaharness/java/arcs/crdt/Referenceable.java
@@ -1,0 +1,5 @@
+package arcs.crdt;
+
+public interface Referenceable {
+  String getId();
+}

--- a/src/javaharness/java/arcs/crdt/VersionMap.java
+++ b/src/javaharness/java/arcs/crdt/VersionMap.java
@@ -1,0 +1,5 @@
+package arcs.crdt;
+
+import java.util.HashMap;
+
+public class VersionMap extends HashMap<String, Integer> {}

--- a/src/javaharness/java/arcs/crdt/VersionedValue.java
+++ b/src/javaharness/java/arcs/crdt/VersionedValue.java
@@ -1,0 +1,10 @@
+package arcs.crdt;
+
+public class VersionedValue<T> {
+  T value;
+  VersionMap version;
+  VersionedValue(T value, VersionMap version) {
+    this.value = value;
+    this.version = version;
+  }
+}


### PR DESCRIPTION
i'll be using these classes from the arcs.api package in the follow up PR, but figured doing the refactoring separately is easier to review.