### PR TITLE
Show slandles in PEC overview

### DIFF
--- a/devtools/src/arcs-overview.js
+++ b/devtools/src/arcs-overview.js
@@ -263,7 +263,15 @@ class ArcsOverview extends MessengerMixin(PolymerElement) {
                 });
               }
 
-              for (const [name, id] of Object.entries(m.pecMsgBody.stores)) {
+              // TODO: FIXME: This is a workaround for slandles not having stores.
+              // Use for (const [name, id] of Object.entries(m.pecMsgBody)) when slandles have stores.
+              for (const handle of spec.args) {
+                const name = handle.name;
+                const matchingStores = Object.entries(m.pecMsgBody.stores).map(
+                  ([store_name, id]) => store_name == name ? id : undefined
+                ).filter(id => id);
+                const id = matchingStores.length == 1 ? matchingStores[0] : `#missing-store-for-${name}`;
+
                 this._handles.set(id, {
                   id: id,
                   label: `"${name}"`,
@@ -276,9 +284,27 @@ class ArcsOverview extends MessengerMixin(PolymerElement) {
                 let color;
                 let arrows;
                 switch (connSpec.direction) {
+                  case '`consume':
+                    arrows = {
+                      from: {
+                        enabled: true,
+                        type: 'circle'
+                      }
+                    };
+                    color = this._cssVar('--green');
+                    break;
                   case 'in':
                     arrows = 'from';
                     color = this._cssVar('--dark-green');
+                    break;
+                  case '`provide':
+                    arrows = {
+                      to: {
+                        enabled: true,
+                        type: 'circle'
+                      }
+                    };
+                    color = this._cssVar('--red');
                     break;
                   case 'out':
                     arrows = 'to';
@@ -308,7 +334,9 @@ class ArcsOverview extends MessengerMixin(PolymerElement) {
                   color: {color},
                   details: {
                     direction: connSpec.direction,
-                    handleConnection: name
+                    handleConnection: name,
+                    type_tag: connSpec.type.tag,
+                    type_names: connSpec.type.data.names
                   }
                 });
               }

--- a/devtools/src/arcs-shared.js
+++ b/devtools/src/arcs-shared.js
@@ -21,7 +21,9 @@ $_documentContainer.innerHTML = `<dom-module id="shared-styles">
         --focus-blue: #03a9f4;
         --light-focus-blue: #e4f6ff;
         --dark-red: #b71c1c;
+        --red: #ff0000;
         --dark-green: #09ba12;
+        --green: #00ff00;
         --darker-green: #08780e;
 
         --devtools-purple: rgb(136, 19, 145);


### PR DESCRIPTION
Note: This won't work until https://github.com/PolymerLabs/arcs/pull/3340 is merged as there won't be any slandles to view.