### PR TITLE
Added the concept of "ingress" into nodes.

### DIFF
--- a/src/dataflow/analysis/analysis.ts
+++ b/src/dataflow/analysis/analysis.ts
@@ -56,7 +56,8 @@ export class EdgeExpression {
       // Indicate that this edge inherits from its parents (and apply 
       // modifiers).
       parentEdges.forEach(e => this.inheritFromEdge(e, modifier));
-    } else {
+    }
+    if (edge.start.ingress) {
       this.resolvedFlows.add(modifier.toFlow());
     }
   }
@@ -178,6 +179,12 @@ export class Solver {
 
     const edgeExpression = this.edgeExpressions.get(edge);
     const flows = edgeExpression.resolvedFlows;
+
+    if (flows.size === 0) {
+      // There is no ingress into this edge, so there's nothing to check.
+      finalResult.failures.add(`'${check.originalCheck.toManifestString()}' failed: no data ingress.`);
+      return finalResult;
+    }
 
     for (const flow of flows) {
       if (!flow.evaluateCheck(check)) {

--- a/src/dataflow/analysis/deep-set.ts
+++ b/src/dataflow/analysis/deep-set.ts
@@ -69,6 +69,10 @@ export class DeepSet<T extends UniqueStringable> implements Iterable<T> {
     return this.elementSet.size;
   }
 
+  get isEmpty(): boolean {
+    return this.size === 0;
+  }
+
   /** Unique string representation of this DeepSet. */
   toUniqueString(): string {
     const strings = [...this.stringSet];

--- a/src/dataflow/analysis/graph-internals.ts
+++ b/src/dataflow/analysis/graph-internals.ts
@@ -220,6 +220,12 @@ export abstract class Node {
   /** A unique ID for this node. No other node in this graph can have this ID. */
   abstract readonly nodeId: string;
 
+  /**
+   * Boolean indicating whether this node has direct ingress or not (e.g. from a
+   * external datastore).
+   */
+  ingress: boolean;
+
   abstract readonly inEdges: readonly Edge[];
   abstract readonly outEdges: readonly Edge[];
 

--- a/src/dataflow/analysis/handle-node.ts
+++ b/src/dataflow/analysis/handle-node.ts
@@ -8,10 +8,8 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {Node, Edge, FlowCheck} from './graph-internals.js';
+import {Node, Edge} from './graph-internals.js';
 import {ParticleOutput, ParticleInput, ParticleNode} from './particle-node.js';
-import {HandleConnectionSpec} from '../../runtime/particle-spec.js';
-import {CheckIsFromHandle} from '../../runtime/particle-check.js';
 import {HandleConnection} from '../../runtime/recipe/handle-connection.js';
 import {assert} from '../../platform/assert-web.js';
 import {Handle} from '../../runtime/recipe/handle.js';


### PR DESCRIPTION
Currently there is no way to detect ingress automatically. It has to be
done manually in the tests themselves. In the future, ingress nodes will
be handles with the create or map fate (i.e. pointing to external data
sources), and possibly others too.

A check will now fail if there is no ingress into the edge. "No ingress"
is just the case when there's no flow (empty FlowSet).