### PR TITLE
restrict SpecEx to recipes that use type [Description]

### DIFF
--- a/particles/Layout/Layout.arcs
+++ b/particles/Layout/Layout.arcs
@@ -1,5 +1,2 @@
 import 'Detail.arcs'
 import 'TabbedLayout.arcs'
-import 'AnimatedTiles.arcs'
-import 'BottomScrollTest.arcs'
-

--- a/particles/Processing/recipes/ImageClassifier.arcs
+++ b/particles/Processing/recipes/ImageClassifier.arcs
@@ -14,7 +14,7 @@ import '../ModelSelector.arcs'
 
 import './ClassifierStatics.arcs'
 
-recipe ImageClassifierUI-NoSpec
+recipe ImageClassifierUINoSpec
   // since we `use`, this recipe is incomplete and coalescer is triggered
   use as imgUrl
   use as predictions
@@ -27,7 +27,7 @@ recipe ImageClassifierUI-NoSpec
 
   description `image classification`
 
-recipe ImageClassifierRoutine
+recipe ImageClassifierRoutineNoSpec
   // find a model specification
   map as modelSpec
 
@@ -87,4 +87,3 @@ recipe ImageClassifierRoutine
     predictions -> predictions
 
   description `${LoadGraphModel.modelSpec}`
-

--- a/particles/Processing/recipes/ImageClassifier.arcs
+++ b/particles/Processing/recipes/ImageClassifier.arcs
@@ -14,7 +14,7 @@ import '../ModelSelector.arcs'
 
 import './ClassifierStatics.arcs'
 
-recipe ImageClassifierUI
+recipe ImageClassifierUI-NoSpec
   // since we `use`, this recipe is incomplete and coalescer is triggered
   use as imgUrl
   use as predictions

--- a/src/planning/planner.ts
+++ b/src/planning/planner.ts
@@ -257,15 +257,14 @@ export class Planner implements InspectablePlanner {
     if (!this.speculator || this.noSpecEx) {
       return false;
     }
-    const hasDescriptionConnection =
-        plan.handleConnections.some(
-          ({type}) => type.toString() === `[Description {Text key, Text value}]`);
+    if (plan.handleConnections.some(({type}) => type.toString() === `[Description {Text key, Text value}]`)) {
+      return true;
+    }
     const planPatternsWithTokens = plan.patterns.filter(p => p.includes('${'));
     const particlesWithTokens = plan.particles.filter(p => !!p.spec.pattern && p.spec.pattern.includes('${'));
-    if (!hasDescriptionConnection && planPatternsWithTokens.length === 0 && particlesWithTokens.length === 0) {
+    if (planPatternsWithTokens.length === 0 && particlesWithTokens.length === 0) {
       return false;
     }
-
     // Check if recipe description use out handle connections.
     for (const pattern of planPatternsWithTokens) {
       const allTokens = Description.getAllTokens(pattern);
@@ -278,7 +277,6 @@ export class Planner implements InspectablePlanner {
         }
       }
     }
-
     // Check if particle descriptions use out handle connections.
     for (const particle of particlesWithTokens) {
       const allTokens = Description.getAllTokens(particle.spec.pattern);

--- a/src/planning/planner.ts
+++ b/src/planning/planner.ts
@@ -222,7 +222,7 @@ export class Planner implements InspectablePlanner {
     }
     let relevance: Relevance|undefined = undefined;
     let description: Description|null = null;
-    if (this.speculator && !this.noSpecEx && this._doesPlanUseDescriptions(plan)) {
+    if (this._shouldSpeculate(plan)) {
       const result = await this.speculator.speculate(this.arc, plan, hash);
       if (!result) {
         return undefined;
@@ -246,11 +246,15 @@ export class Planner implements InspectablePlanner {
     return suggestion;
   }
 
-  _doesPlanUseDescriptions(plan) {
-    return plan.handleConnections.some(
-        ({type}) => type.toString() === `[Description {Text key, Text value}]`) ||
-      plan.patterns.some(p => p.includes('${')) ||
-      plan.particles.some(p => !!p.spec.pattern && p.spec.pattern.includes('${'));
+  _shouldSpeculate(plan) {
+    if (!this.speculator && this.noSpecEx) {
+      return false;
+    }
+    return !plan.name.toLowerCase().includes('nospec');
+    // return plan.handleConnections.some(
+    //     ({type}) => type.toString() === `[Description {Text key, Text value}]`) ||
+    //   plan.patterns.some(p => p.includes('${')) ||
+    //   plan.particles.some(p => !!p.spec.pattern && p.spec.pattern.includes('${'));
   }
 
   _updateGeneration(generations: Generation[], hash: string, handler: (_: AnnotatedDescendant) => void) {

--- a/src/planning/planner.ts
+++ b/src/planning/planner.ts
@@ -222,7 +222,9 @@ export class Planner implements InspectablePlanner {
     }
     let relevance: Relevance|undefined = undefined;
     let description: Description|null = null;
-    if (this.speculator && !this.noSpecEx) {
+    // TODO(sjmiles): for now, restrict SpecEx to recipes that use
+    // Description handles, so we can avoid computations we aren't using atm
+    if (this.speculator && !this.noSpecEx && this._doesPlanUseDescriptions(plan)) {
       const result = await this.speculator.speculate(this.arc, plan, hash);
       if (!result) {
         return undefined;
@@ -243,6 +245,12 @@ export class Planner implements InspectablePlanner {
     );
     suggestionByHash().set(hash, suggestion);
     return suggestion;
+  }
+
+  _doesPlanUseDescriptions(plan) {
+    return plan.handleConnections.some(
+      ({type}) => type.toString() === `[Description {Text key, Text value}]`
+    );
   }
 
   _updateGeneration(generations: Generation[], hash: string, handler: (_: AnnotatedDescendant) => void) {

--- a/src/runtime/arc.ts
+++ b/src/runtime/arc.ts
@@ -530,8 +530,7 @@ ${this.activeRecipe.toString()}`;
     }
   }
 
-  // Critical section for instantiate,
-  private async _doInstantiate(recipe: Recipe): Promise<void> {
+  async mergeIntoActiveRecipe(recipe: Recipe) {
     const {handles, particles, slots} = recipe.mergeInto(this._activeRecipe);
     this._recipeDeltas.push({particles, handles, slots, patterns: recipe.patterns});
 
@@ -606,6 +605,13 @@ ${this.activeRecipe.toString()}`;
         this._registerStore(store, recipeHandle.tags);
       }
     }
+
+    return {handles, particles, slots};
+  }
+
+  // Critical section for instantiate,
+  private async _doInstantiate(recipe: Recipe): Promise<void> {
+    const {handles, particles, slots} = await this.mergeIntoActiveRecipe(recipe);
 
     await Promise.all(particles.map(recipeParticle => this._instantiateParticle(recipeParticle)));
 

--- a/src/runtime/description-formatter.ts
+++ b/src/runtime/description-formatter.ts
@@ -135,11 +135,14 @@ export class DescriptionFormatter {
     return undefined;
   }
 
+  static readonly TokensRegex = /\${[a-zA-Z0-9.]+}(?:\.[_a-zA-Z]+)?/g;
+  static readonly TokensInnerRegex = /\${([a-zA-Z0-9.]+)}(?:\.([_a-zA-Z]+))?/;
+
   _initTokens(pattern: string, particleDescription) {
     pattern = pattern.replace(/</g, '&lt;');
     let results = [];
     while (pattern.length > 0) {
-      const tokens = pattern.match(/\${[a-zA-Z0-9.]+}(?:\.[_a-zA-Z]+)?/g);
+      const tokens = pattern.match(DescriptionFormatter.TokensRegex);
       let firstToken;
       let tokenIndex;
       if (tokens) {
@@ -163,7 +166,7 @@ export class DescriptionFormatter {
   }
 
   _initSubTokens(pattern, particleDescription): {}[] {
-    const valueTokens = pattern.match(/\${([a-zA-Z0-9.]+)}(?:\.([_a-zA-Z]+))?/);
+    const valueTokens = pattern.match(DescriptionFormatter.TokensInnerRegex);
     const handleNames = valueTokens[1].split('.');
     const extra = valueTokens.length === 3 ? valueTokens[2] : undefined;
 

--- a/src/runtime/description-formatter.ts
+++ b/src/runtime/description-formatter.ts
@@ -135,14 +135,14 @@ export class DescriptionFormatter {
     return undefined;
   }
 
-  static readonly TokensRegex = /\${[a-zA-Z0-9.]+}(?:\.[_a-zA-Z]+)?/g;
-  static readonly TokensInnerRegex = /\${([a-zA-Z0-9.]+)}(?:\.([_a-zA-Z]+))?/;
+  static readonly tokensRegex = /\${[a-zA-Z0-9.]+}(?:\.[_a-zA-Z]+)?/g;
+  static readonly tokensInnerRegex = /\${([a-zA-Z0-9.]+)}(?:\.([_a-zA-Z]+))?/;
 
   _initTokens(pattern: string, particleDescription) {
     pattern = pattern.replace(/</g, '&lt;');
     let results = [];
     while (pattern.length > 0) {
-      const tokens = pattern.match(DescriptionFormatter.TokensRegex);
+      const tokens = pattern.match(DescriptionFormatter.tokensRegex);
       let firstToken;
       let tokenIndex;
       if (tokens) {
@@ -166,7 +166,7 @@ export class DescriptionFormatter {
   }
 
   _initSubTokens(pattern, particleDescription): {}[] {
-    const valueTokens = pattern.match(DescriptionFormatter.TokensInnerRegex);
+    const valueTokens = pattern.match(DescriptionFormatter.tokensInnerRegex);
     const handleNames = valueTokens[1].split('.');
     const extra = valueTokens.length === 3 ? valueTokens[2] : undefined;
 

--- a/src/runtime/description.ts
+++ b/src/runtime/description.ts
@@ -147,7 +147,7 @@ export class Description {
   }
 
   private static async _prepareStoreValue(store: StorageProviderBase | StorageStub): Promise<DescriptionValue>|undefined {
-    if (!store) {
+    if (!store || (store instanceof StorageStub)) {
       return undefined;
     }
     if (store.type instanceof CollectionType) {

--- a/src/runtime/description.ts
+++ b/src/runtime/description.ts
@@ -96,6 +96,15 @@ export class Description {
     return formatter.getHandleDescription(recipeHandle);
   }
 
+  public static getAllTokens(pattern: string): string[][] {
+    const allTokens = [];
+    const tokens = pattern.match(DescriptionFormatter.TokensRegex);
+    for (let i = 0; i < tokens.length; ++i) {
+      allTokens[i] = tokens[i].match(DescriptionFormatter.TokensInnerRegex)[1].split('.');
+    }
+    return allTokens;
+  }
+
   private static async initDescriptionHandles(allParticles: Particle[], arc?: Arc, relevance?: Relevance): Promise<ParticleDescription[]> {
     return await Promise.all(
       allParticles.map(particle => Description._createParticleDescription(particle, arc, relevance)));

--- a/src/runtime/description.ts
+++ b/src/runtime/description.ts
@@ -98,9 +98,9 @@ export class Description {
 
   public static getAllTokens(pattern: string): string[][] {
     const allTokens = [];
-    const tokens = pattern.match(DescriptionFormatter.TokensRegex);
+    const tokens = pattern.match(DescriptionFormatter.tokensRegex);
     for (let i = 0; i < tokens.length; ++i) {
-      allTokens[i] = tokens[i].match(DescriptionFormatter.TokensInnerRegex)[1].split('.');
+      allTokens[i] = tokens[i].match(DescriptionFormatter.tokensInnerRegex)[1].split('.');
     }
     return allTokens;
   }

--- a/src/runtime/tests/artifacts/suggestions/Cake.manifest
+++ b/src/runtime/tests/artifacts/suggestions/Cake.manifest
@@ -20,6 +20,8 @@ particle MakeCake in 'source/MakeCake.js'
   description `Make a ${cake} cake`
 
 particle LightCandles in 'source/LightCandles.js'
-  in Cake birthdayCake
+  // Note: birthday cake should is an input connection.
+  // It is only made 'inout' to force speculative execution.
+  inout Cake birthdayCake
   consume candles #special
   description `Light candles on ${birthdayCake} cake`


### PR DESCRIPTION
For now, restrict SpecEx to recipes that use [Description] handles, so we can avoid expensive computations we aren't using.

In particular, the ML recipes are costly to spin up and today we just discard the results.

Post-mortem: took some time to craft a more sophisticated version of the Description test to include implicit uses via recipe description macros. 