### PR TITLE
Improve error reporting for dev shell and runtime loader

### DIFF
--- a/shells/dev-shell/index.js
+++ b/shells/dev-shell/index.js
@@ -48,6 +48,10 @@ async function wrappedExecute() {
     return;
   }
 
+  if (manifest.allRecipes.length == 0) {
+    output.showError('No recipes found in Manifest.parse');
+  }
+
   let arcIndex = 1;
   for (const recipe of manifest.allRecipes) {
     const id = IdGenerator.newSession().newArcId('arc' + arcIndex++);

--- a/src/runtime/loader.ts
+++ b/src/runtime/loader.ts
@@ -89,13 +89,14 @@ export class Loader {
   }
 
   async _loadURL(url: string): Promise<string> {
+    const fetcher = (url: string) => fetch(url).then(async res => res.ok ? res.text() : undefined);
     if (/\/\/schema.org\//.test(url)) {
       if (url.endsWith('/Thing')) {
-        return fetch('https://schema.org/Product.jsonld').then(res => res.text()).then(data => JsonldToManifest.convert(data, {'@id': 'schema:Thing'}));
+        return fetcher('https://schema.org/Product.jsonld').then(data => JsonldToManifest.convert(data, {'@id': 'schema:Thing'}));
       }
-      return fetch(url + '.jsonld').then(res => res.text()).then(data => JsonldToManifest.convert(data));
+      return fetcher(url + '.jsonld').then(data => JsonldToManifest.convert(data));
     }
-    return fetch(url).then(res => res.text());
+    return fetcher(url);
   }
 
   /**


### PR DESCRIPTION
Fixes two small issues in the dev-shell and the runtime loader.
The first being that the dev-shell needs a recipe to work and has been silently failing if none has been provided (one day we should attempt to lift particles so that we can run them without a recipe, but this is out of scope).

The second is that the runtime loader was ignoring the success or failure of its fetches and attempting to load 404/500 html pages as particles (which would produce surprising errors). 