### PR TITLE
Added support for cycles to the dataflow analyser!

### DIFF
--- a/src/dataflow/analysis/deep-set.ts
+++ b/src/dataflow/analysis/deep-set.ts
@@ -73,6 +73,14 @@ export class DeepSet<T extends UniqueStringable> implements Iterable<T> {
     return this.size === 0;
   }
 
+  /**
+   * Returns true if this DeepSet is equal to the other DeepSet (deep equals,
+   * computed via toUniqueString() for each DeepSet).
+   */
+  equals(other: DeepSet<T>): boolean {
+    return this.toUniqueString() === other.toUniqueString();
+  }
+
   /** Unique string representation of this DeepSet. */
   toUniqueString(): string {
     const strings = [...this.stringSet];

--- a/src/dataflow/analysis/particle-node.ts
+++ b/src/dataflow/analysis/particle-node.ts
@@ -104,7 +104,7 @@ export class ParticleOutput implements Edge {
       this.derivesFrom = [];
       for (const claim of connection.spec.claims) {
         if (claim.type === ClaimType.DerivesFrom) {
-          this.derivesFrom.push(particleNode.inEdgesByName[claim.parentHandle.name]);
+          this.derivesFrom.push(particleNode.inEdgesByName.get(claim.parentHandle.name));
         }
       }
     }


### PR DESCRIPTION
Cycles are dealt with by the new removeSelfReference() method. Self-modifiers are applied to copies of all other resolved and unresolved flows in the EdgeExpression. Dealing correctly with ingress falls out naturally from the other EdgeExpression operations; we don't have to do anything in particular for that.

Added lots and lots of tests: unit tests for the removeSelfReference method, and tests involving recipes with cycles.