### PR TITLE
Ensure 'use' StorageStubs are inflated during Arc instantiation.

### DIFF
--- a/src/runtime/arc.ts
+++ b/src/runtime/arc.ts
@@ -585,6 +585,8 @@ ${this.activeRecipe.toString()}`;
         continue;
         // TODO: move the call to ParticleExecutionHost's DefineHandle to here
       } else if (recipeHandle.fate === 'use' && isInflatable) {
+        // The new unit test fails with this approach because the storage instance still isn't
+        // plumbed into the arc. Not sure of the correct fix...
         store = await store.inflate();
       }
 


### PR DESCRIPTION
Without this, 'use' handles that reference a manifest-based data store don't work.

You can see this failing at http://localhost:8786/shells/dev-shell/?m=https://$arcs/src/wasm/cpp/example.manifest (without this change, of course).

I'm not completely sure this is the right approach, but it does work...