### PR TITLE
Fixes bug when computing 'derives from' edges.

### DIFF
--- a/src/dataflow/analysis/flow-graph.ts
+++ b/src/dataflow/analysis/flow-graph.ts
@@ -97,12 +97,19 @@ export class FlowGraph {
       }
     });
 
-    // Attach check objects to particle in-edges. Must be done in a separate
-    // pass after all edges have been created, since checks can reference other
-    // nodes/edges.
     this.edges.forEach(edge => {
+      // Attach check objects to particle in-edges. Must be done in a separate
+      // pass after all edges have been created, since checks can reference
+      // other nodes/edges.
       if (edge instanceof ParticleInput && edge.connectionSpec.check) {
         edge.check = this.createFlowCheck(edge.connectionSpec.check);
+      }
+      
+      // Compute the list of 'derived from' edges for all out-edges. This must
+      // also be done in a separate pass since we can't guarantee the ordering
+      // in which the edges were created.
+      if (edge instanceof ParticleOutput) {
+        edge.computeDerivedFromEdges();
       }
     });
   }

--- a/src/dataflow/analysis/graph-internals.ts
+++ b/src/dataflow/analysis/graph-internals.ts
@@ -290,7 +290,6 @@ export interface Edge {
    */
   readonly label: string;
 
-  readonly derivesFrom?: Edge[];
   readonly modifier?: FlowModifier;
   check?: FlowCheck;
 }

--- a/src/dataflow/analysis/tests/flow-graph-test.ts
+++ b/src/dataflow/analysis/tests/flow-graph-test.ts
@@ -10,7 +10,7 @@
 
 import {assert} from '../../../platform/chai-web.js';
 import {checkDefined} from '../../../runtime/testing/preconditions.js';
-import {ParticleNode} from '../particle-node.js';
+import {ParticleNode, ParticleOutput, ParticleInput} from '../particle-node.js';
 import {buildFlowGraph} from '../testing/flow-graph-testing.js';
 import {FlowModifier} from '../graph-internals.js';
 
@@ -299,5 +299,31 @@ describe('FlowGraph', () => {
     assert.isTrue((await runForHandleWithFate('use MyStore')).ingress);
     assert.isTrue((await runForHandleWithFate('map MyStore')).ingress);
     assert.isTrue((await runForHandleWithFate('copy MyStore')).ingress);
+  });
+
+  it('supports circular "derives from" statements', async () => {
+    // Regression test for a race condition bug where the order in which edges
+    // were created was important ('claim foo1 derives from foo2' required that
+    // and edge for foo2 had already been created).
+    const graph = await buildFlowGraph(`
+      particle P
+        inout Foo {} foo1
+        inout Foo {} foo2
+        claim foo1 derives from foo2
+        claim foo2 derives from foo1
+      recipe R
+        P
+          foo1 <-> h1
+          foo2 <-> h2
+    `);
+    assert.lengthOf(graph.edges, 4);
+    const foo1Out = graph.edges.find(e => e instanceof ParticleOutput && e.label === 'P.foo1') as ParticleOutput;
+    const foo2Out = graph.edges.find(e => e instanceof ParticleOutput && e.label === 'P.foo2') as ParticleOutput;
+    const foo1In = graph.edges.find(e => e instanceof ParticleInput && e.label === 'P.foo1') as ParticleInput;
+    const foo2In = graph.edges.find(e => e instanceof ParticleInput && e.label === 'P.foo2') as ParticleInput;
+    assert.lengthOf(foo1Out.derivesFrom, 1);
+    assert.strictEqual(foo1Out.derivesFrom[0], foo2In);
+    assert.lengthOf(foo2Out.derivesFrom, 1);
+    assert.strictEqual(foo2Out.derivesFrom[0], foo1In);
   });
 });


### PR DESCRIPTION
The bug arises when processing a claim like 'claim foo derives from
bar'. If the edge 'bar' has not been created yet, then we can't store it
in the derivesFrom list for the edge 'foo' (and instead store
undefined).

Now, we compute the derivesFrom list in a separate pass after all edges
have been constructed.