### PR TITLE
Unified, slot+slandle isRoot

### DIFF
--- a/src/planning/plan/suggestion.ts
+++ b/src/planning/plan/suggestion.ts
@@ -22,6 +22,7 @@ import {Recipe} from '../../runtime/recipe/recipe.js';
 import {Search} from '../../runtime/recipe/search.js';
 import {Relevance} from '../../runtime/relevance.js';
 import {SuggestFilter} from './suggest-filter.js';
+import {isRoot} from '../../runtime/particle-spec.js';
 
 
 export type DescriptionProperties = {
@@ -269,7 +270,7 @@ export class Suggestion {
       return true;
     }
 
-    if (!this.plan.slots.find(s => s.isRoot()) &&
+    if (!this.plan.slots.find(isRoot) &&
         !((this.plan.slotConnections || []).find(sc => sc.name === 'root'))) {
       // suggestion uses only non 'root' slots.
       // TODO: should check agains slot-composer's root contexts instead.
@@ -292,7 +293,7 @@ export class Suggestion {
     }
     let hasRootSlot = false;
     const usesRemoteNonRootSlots = this.plan.slots.some(slot => {
-      const isRootSlot = slot.isRoot();
+      const isRootSlot = isRoot(slot);
       if (isRootSlot) {
         hasRootSlot = true;
       }

--- a/src/runtime/description-formatter.ts
+++ b/src/runtime/description-formatter.ts
@@ -10,7 +10,7 @@
 
 import {assert} from '../platform/assert-web.js';
 
-import {ParticleSpec} from './particle-spec.js';
+import {ParticleSpec, isRoot} from './particle-spec.js';
 import {HandleConnection} from './recipe/handle-connection.js';
 import {Handle} from './recipe/handle.js';
 import {Particle} from './recipe/particle.js';
@@ -483,8 +483,8 @@ export class DescriptionFormatter {
 
   static sort(p1: ParticleDescription, p2: ParticleDescription) {
     // Root slot comes first.
-    const hasRoot1 = [...p1._particle.spec.slotConnections.values()].some(slotSpec => slotSpec.isRoot());
-    const hasRoot2 = [...p2._particle.spec.slotConnections.values()].some(slotSpec => slotSpec.isRoot());
+    const hasRoot1 = [...p1._particle.spec.slotConnections.values()].some(slotSpec => isRoot(slotSpec));
+    const hasRoot2 = [...p2._particle.spec.slotConnections.values()].some(slotSpec => isRoot(slotSpec));
     if (hasRoot1 !== hasRoot2) {
       return hasRoot1 ? -1 : 1;
     }

--- a/src/runtime/recipe/slot.ts
+++ b/src/runtime/recipe/slot.ts
@@ -33,11 +33,6 @@ export class Slot implements Comparable<Slot> {
     this._name = name;
   }
 
-  isRoot(): boolean {
-    // TODO: Revisit slot naming.
-    return this.name.includes('root') || this.tags.includes('root') || (this.id && this.id.includes('root'));
-  }
-
   get recipe(): Recipe { return this._recipe; }
   get id(): string|undefined { return this._id; }
   set id(id: string) { this._id = id; }


### PR DESCRIPTION
Changes the behavior of checking for root slots (and slandles).

Previously slot names including the substring 'root' would be considered root slots.
I don't believe this is intended, though I believe false positives are very unlikely in english.

This changes the check to look for 'root', 'toproot' and 'modal' and allows slandles and slots to use the same function.

We also check that (if there is a known type) it is either a slot or a collection of slot, this prevents non-slandle handles from being considered roots.