### PR TITLE
Reload function

### DIFF
--- a/src/runtime/particle-execution-context.ts
+++ b/src/runtime/particle-execution-context.ts
@@ -11,7 +11,7 @@
 import {assert} from '../platform/assert-web.js';
 
 import {PECInnerPort} from './api-channel.js';
-import {Handle, handleFor} from './handle.js';
+import {Handle, handleFor, HandleOld} from './handle.js';
 import {Id, IdGenerator} from './id.js';
 import {Runnable} from './hot.js';
 import {Loader} from './loader.js';
@@ -25,6 +25,7 @@ import {MessagePort} from './message-channel.js';
 import {WasmContainer, WasmParticle} from './wasm.js';
 import {Dictionary} from './hot.js';
 import {UserException} from './arc-exceptions.js';
+import {Store} from './store.js';
 
 export type PecFactory = (pecId: Id, idGenerator: IdGenerator) => MessagePort;
 
@@ -37,7 +38,7 @@ export type InnerArcHandle = {
 
 export class ParticleExecutionContext {
   private readonly apiPort : PECInnerPort;
-  private readonly particles = <Particle[]>[];
+  private readonly particles = new Map<string, Particle>();
   private readonly pecId: Id;
   private readonly loader: Loader;
   private readonly pendingLoads = <Promise<void>[]>[];
@@ -219,8 +220,81 @@ export class ParticleExecutionContext {
     const p = new Promise<void>(res => resolve = res);
     this.pendingLoads.push(p);
 
+    const particle: Particle = await this.createParticleFromSpec(id, spec);
+
+    const handleMap = new Map();
+    const registerList: {proxy: Store, particle: Particle, handle: Handle}[] = [];
+
+    proxies.forEach((proxy, name) => {
+      this.createHandle(particle, spec, id, name, proxy, handleMap, registerList);
+    });
+
+    return [particle, async () => {
+      await this.assignHandle(particle, spec, id, handleMap, registerList, p);
+      resolve();
+    }];
+  }
+
+  private async reloadParticle(id: string) {
+    let resolve: Runnable;
+    const p = new Promise<void>(res => resolve = res);
+    this.pendingLoads.push(p);
+
+    // Get the old particle based on the given id and delete the old particle's cache
+    const oldParticle = this.particles.get(id);
+    delete oldParticle.spec.implBlobUrl;
+
+    // Create a new particle and replace the old one
+    const particle: Particle = await this.createParticleFromSpec(id, oldParticle.spec);
+
+    const handleMap = new Map();
+    const registerList: {proxy: Store, particle: Particle, handle: Handle}[] = [];
+    // Create new handles and disable the handles of the old particles
+    oldParticle.handles.forEach((oldHandle) => {
+      this.createHandle(particle, oldParticle.spec, id, oldHandle.name, oldHandle.storage, handleMap, registerList);
+      if (oldHandle instanceof HandleOld) oldHandle.disable(oldParticle);
+    });
+
+    return [particle, async () => {
+      // Set the new handles to the new particle
+      await this.assignHandle(particle, oldParticle.spec, id, handleMap, registerList, p);
+      resolve();
+
+      // Transfer the slot proxies from the old particle to the new one
+      for (const name of oldParticle.getSlotNames()) {
+        oldParticle.getSlot(name).rewire(particle);
+      }      
+    }];
+  }
+
+  private createHandle(particle: Particle, spec: ParticleSpec, id: string, name: string, proxy,
+                       handleMap, registerList: {proxy: Store, particle: Particle, handle: Handle}[]) {
+    const connSpec = spec.handleConnectionMap.get(name);
+    const handle = handleFor(proxy, this.idGenerator, name, id, connSpec.isInput, connSpec.isOutput);
+    handleMap.set(name, handle);
+
+    // Defer registration of handles with proxies until after particles have a chance to
+    // configure them in setHandles.
+    registerList.push({proxy, particle, handle});
+  }
+
+  private async assignHandle(particle: Particle, spec: ParticleSpec, id: string, handleMap, 
+                             registerList: {proxy: Store, particle: Particle, handle: Handle}[], p) {
+    await particle.callSetHandles(handleMap, err => {
+      const exc = new UserException(err, 'setHandles', id, spec.name);
+      this.apiPort.ReportExceptionInHost(exc);
+    });
+    registerList.forEach(({proxy, particle, handle}) => {
+      if (proxy instanceof StorageProxy) proxy.register(particle, handle);
+    });
+    const idx = this.pendingLoads.indexOf(p);
+    this.pendingLoads.splice(idx, 1);
+  }
+
+  private async createParticleFromSpec(id: string, spec: ParticleSpec): Promise<Particle> {
     let particle: Particle;
     if (spec.implFile && spec.implFile.endsWith('.wasm')) {
+      // TODO(sherrypra): Make reloading WASM particle re-instantiate the entire container from scratch
       particle = await this.loadWasmParticle(spec);
       particle.setCapabilities(this.capabilities(false));
     } else {
@@ -231,35 +305,9 @@ export class ParticleExecutionContext {
       particle = new clazz();
       particle.setCapabilities(this.capabilities(true));
     }
-    this.particles.push(particle);
+    this.particles.set(id, particle);
 
-    const handleMap = new Map();
-    const registerList: {proxy: StorageProxy, particle: Particle, handle: Handle}[] = [];
-
-    proxies.forEach((proxy, name) => {
-      const connSpec = spec.handleConnectionMap.get(name);
-      const handle = handleFor(proxy, this.idGenerator, name, id, connSpec.isInput, connSpec.isOutput);
-      handleMap.set(name, handle);
-
-      // Defer registration of handles with proxies until after particles have a chance to
-      // configure them in setHandles.
-      registerList.push({proxy, particle, handle});
-    });
-
-    return [particle, async () => {
-      await particle.callSetHandles(handleMap, err => {
-        const exc = new UserException(err, 'setHandles', id, spec.name);
-        this.apiPort.ReportExceptionInHost(exc);
-      });
-      registerList.forEach(({proxy, particle, handle}) => proxy.register(particle, handle));
-      const idx = this.pendingLoads.indexOf(p);
-      this.pendingLoads.splice(idx, 1);
-      resolve();
-    }];
-  }
-
-  private async reloadParticle(id: string) {
-    // TODO(sherrypra): Implement this method.
+    return particle;
   }
 
   private async loadWasmParticle(spec: ParticleSpec) {
@@ -300,7 +348,7 @@ export class ParticleExecutionContext {
     if (this.pendingLoads.length > 0 || this.scheduler.busy) {
       return true;
     }
-    if (this.particles.filter(particle => particle.busy).length > 0) {
+    if ([...this.particles.values()].filter(particle => particle.busy).length > 0) {
       return true;
     }
     return false;
@@ -310,7 +358,7 @@ export class ParticleExecutionContext {
     if (!this.busy) {
       return Promise.resolve();
     }
-    const busyParticlePromises = this.particles.filter(async particle => particle.busy).map(async particle => particle.idle);
+    const busyParticlePromises = [...this.particles.values()].filter(async particle => particle.busy).map(async particle => particle.idle);
     return Promise.all([this.scheduler.idle, ...this.pendingLoads, ...busyParticlePromises]).then(() => this.idle);
   }
 }

--- a/src/runtime/particle.ts
+++ b/src/runtime/particle.ts
@@ -217,6 +217,10 @@ export class Particle {
     return this.slotProxiesByName.get(name);
   }
 
+  getSlotNames(): string[] {
+    return [...this.slotProxiesByName.keys()];
+  }
+
   static buildManifest(strings: string[], ...bits): string {
     const output: string[] = [];
     for (let i = 0; i < bits.length; i++) {


### PR DESCRIPTION
- Built on top of the slotProxy rewire PR
- The reload function overall:
    > Create a new particle and replace the old particle in PEC with the newparticle
    > Create new handles for the new particle and disable the old ones
    > Set the new handles to the new particles
    > Transfer the old particle's slotProxies to the new particle