### PR TITLE
Added back proper dataflow error messages, so it tells you the failing paths

### DIFF
--- a/src/dataflow/cli/flowcheck.ts
+++ b/src/dataflow/cli/flowcheck.ts
@@ -45,7 +45,7 @@ import {validateGraph} from '../analysis/analysis.js';
       if (result.isValid) {
         console.log('    Data-flow checks passed.');
       } else {
-        for (const failure of result.failures) {
+        for (const failure of result.getFailureMessages(graph)) {
           console.error('    ' + failure);
         }
       }


### PR DESCRIPTION
This uses the edgeIds SortedSet to recover (some of) the paths from a failing Flow.

Note that, when cycles are involved, not every single failing path will be shown. Particularly when multiple cycles are involved, there are lots of different paths you can take that will end up covering the same edges. Some of these will be deduped when solving the graph, since the set of tags are equivalent, so not all of them will be reported back to the user. But that's probably a good thing, because there would be lots of failing paths otherwise, and it would get quite noisy.