### PR TITLE
 Add helper methods for portable json and promise

### DIFF
--- a/src/javaharness/java/arcs/api/PECInnerPortImpl.java
+++ b/src/javaharness/java/arcs/api/PECInnerPortImpl.java
@@ -191,9 +191,9 @@ public class PECInnerPortImpl implements PECInnerPort {
     }
 
     private PortableJson constructMessage(String messageType) {
-        PortableJson message = jsonParser.emptyJson();
+        PortableJson message = jsonParser.emptyObject();
         message.put(MESSAGE_TYPE_FIELD, messageType);
-        message.put(MESSAGE_BODY_FIELD, jsonParser.emptyJson());
+        message.put(MESSAGE_BODY_FIELD, jsonParser.emptyObject());
         return message;
     }
 
@@ -214,7 +214,7 @@ public class PECInnerPortImpl implements PECInnerPort {
     }
 
     private void postMessage(PortableJson message) {
-        PortableJson json = jsonParser.emptyJson();
+        PortableJson json = jsonParser.emptyObject();
         json.put(MESSAGE_PEC_MESSAGE_KEY, MESSAGE_PEC_PEC_VALUE);
         json.put(MESSAGE_PEC_ID_FIELD, this.id);
         json.put(MESSAGE_PEC_ENTITY_KEY, message);

--- a/src/javaharness/java/arcs/api/PortableJson.java
+++ b/src/javaharness/java/arcs/api/PortableJson.java
@@ -26,6 +26,8 @@ public interface PortableJson {
     // Iterator methods.
     void forEach(Consumer<String> callback);
     List<String> keys();
+    List<String> asStringArray();
+    List<PortableJson> asObjectArray();
 
     // Object setters
     PortableJson put(String key, int num);

--- a/src/javaharness/java/arcs/api/PortableJsonParser.java
+++ b/src/javaharness/java/arcs/api/PortableJsonParser.java
@@ -1,10 +1,16 @@
 package arcs.api;
 
+import java.util.Collection;
+
 /**
  * Portable JSON parser that works on either JS or Android environment.
  */
 public interface PortableJsonParser {
     PortableJson parse(String json);
-    PortableJson emptyJson();
     String stringify(PortableJson json);
+
+    PortableJson emptyObject();
+    PortableJson emptyArray();
+    PortableJson fromStringArray(Collection<String> collection);
+    PortableJson fromObjectArray(Collection<PortableJson> collection);
 }

--- a/src/javaharness/java/arcs/api/PortablePromiseFactory.java
+++ b/src/javaharness/java/arcs/api/PortablePromiseFactory.java
@@ -8,4 +8,5 @@ import java.util.function.Consumer;
  */
 public interface PortablePromiseFactory {
   <T> PortablePromise<T> newPromise(PortablePromise.PortablePromiseExecutor<T> executor);
+  <T> PortablePromise<T> newPromise(T value);
 }

--- a/src/javaharness/java/arcs/api/SingletonProxy.java
+++ b/src/javaharness/java/arcs/api/SingletonProxy.java
@@ -1,29 +1,29 @@
-package arcs.api;
+// package arcs.api;
 
-public class SingletonProxy extends StorageProxy implements SingletonStore {
-  public SingletonProxy(String id, Type type, PECInnerPort port, String name) {
-    super(id, type, port, name);
-  }
+// public class SingletonProxy extends StorageProxy implements SingletonStore {
+//   public SingletonProxy(String id, Type type, PECInnerPort port, String name) {
+//     super(id, type, port, name);
+//   }
 
-  @Override
-  protected boolean synchronizeModel(int version, PortableJson model) {
-    // TODO: implement
-    throw new AssertionError("SingletonProxy::updateModel not implemented");
-  }
+//   @Override
+//   protected boolean synchronizeModel(int version, PortableJson model) {
+//     // TODO: implement
+//     throw new AssertionError("SingletonProxy::updateModel not implemented");
+//   }
 
-  @Override
-  protected boolean updateModel(int version, PortableJson data) {
-    // TODO: implement
-    throw new AssertionError("SingletonProxy::updateModel not implemented");
-  }
+//   @Override
+//   protected boolean updateModel(int version, PortableJson data) {
+//     // TODO: implement
+//     throw new AssertionError("SingletonProxy::updateModel not implemented");
+//   }
 
-  // TODO: add parameters and return values, and implement.
-  @Override
-  public void get() {}
+//   // TODO: add parameters and return values, and implement.
+//   @Override
+//   public void get() {}
 
-  @Override
-  public void set() {}
+//   @Override
+//   public void set() {}
 
-  @Override
-  public void clear() {}
-}
+//   @Override
+//   public void clear() {}
+// }

--- a/src/javaharness/java/arcs/api/StorageProxyFactory.java
+++ b/src/javaharness/java/arcs/api/StorageProxyFactory.java
@@ -5,7 +5,8 @@ public class StorageProxyFactory {
         if (type.isCollection()) {
             return new CollectionProxy(id, type, port, name);
         }
-        throw new AssertionError("SingletonProxy not yet supported in Java.");
+        // TODO: Uncomment when SingletonProxy is implemented.
         // return new SingletonProxy(id, type, port, name);
+        throw new AssertionError("SingletonProxy not yet supported in Java.");
     }
 }

--- a/src/javaharness/java/arcs/api/StorageProxyFactory.java
+++ b/src/javaharness/java/arcs/api/StorageProxyFactory.java
@@ -5,6 +5,7 @@ public class StorageProxyFactory {
         if (type.isCollection()) {
             return new CollectionProxy(id, type, port, name);
         }
-        return new SingletonProxy(id, type, port, name);
+        throw new AssertionError("SingletonProxy not yet supported in Java.");
+        // return new SingletonProxy(id, type, port, name);
     }
 }

--- a/src/javaharness/java/arcs/webimpl/PortableJsonJsImpl.java
+++ b/src/javaharness/java/arcs/webimpl/PortableJsonJsImpl.java
@@ -92,6 +92,22 @@ public class PortableJsonJsImpl implements PortableJson {
     }
 
     @Override
+    public List<String> asStringArray() {
+        List<String> list = new ArrayList<>();
+        forEach(str -> list.add(str));
+        return list;
+    }
+
+    @Override
+    public List<PortableJson> asObjectArray() {
+        List<PortableJson> list = new ArrayList<>();
+        for (int i = 0; i < getLength(); ++i) {
+            list.add(getObject(i));
+        }
+        return list;
+    }
+
+    @Override
     public boolean equals(Object other) {
         return other instanceof PortableJsonJsImpl && hashCode() == other.hashCode();
     }

--- a/src/javaharness/java/arcs/webimpl/PortableJsonParserImpl.java
+++ b/src/javaharness/java/arcs/webimpl/PortableJsonParserImpl.java
@@ -2,6 +2,7 @@ package arcs.webimpl;
 
 import arcs.api.PortableJson;
 import arcs.api.PortableJsonParser;
+import java.util.Collection;
 import jsinterop.annotations.JsType;
 import jsinterop.base.Any;
 import jsinterop.base.Js;
@@ -25,12 +26,32 @@ public class PortableJsonParserImpl implements PortableJsonParser {
     }
 
     @Override
-    public PortableJson emptyJson() {
+    public String stringify(PortableJson json) {
+        return JSON.stringify(((PortableJsonJsImpl) json).getRawObj());
+    }
+
+    @Override
+    public PortableJson emptyObject() {
         return parse("{}");
     }
 
     @Override
-    public String stringify(PortableJson json) {
-        return JSON.stringify(((PortableJsonJsImpl) json).getRawObj());
+    public PortableJson emptyArray() {
+        return parse("[]");
     }
+
+    @Override
+    public PortableJson fromStringArray(Collection<String> collection) {
+        PortableJson json = emptyArray();
+        collection.forEach(str -> json.put(json.getLength(), str));
+        return json;
+    }
+
+    @Override
+    public PortableJson fromObjectArray(Collection<PortableJson> collection) {
+        PortableJson json = emptyArray();
+        collection.forEach(obj -> json.put(json.getLength(), obj));
+        return json;
+    }
+
 }

--- a/src/javaharness/java/arcs/webimpl/PortablePromiseFactoryImpl.java
+++ b/src/javaharness/java/arcs/webimpl/PortablePromiseFactoryImpl.java
@@ -16,4 +16,8 @@ public class PortablePromiseFactoryImpl implements PortablePromiseFactory {
   public <T> PortablePromise<T> newPromise(PortablePromise.PortablePromiseExecutor<T> executor) {
     return new PortablePromiseJsImpl(executor);
   }
+  @Override
+  public <T> PortablePromise<T> newPromise(T value) {
+    return new PortablePromiseJsImpl(value);
+  }
 }

--- a/src/javaharness/java/arcs/webimpl/PortablePromiseJsImpl.java
+++ b/src/javaharness/java/arcs/webimpl/PortablePromiseJsImpl.java
@@ -9,7 +9,6 @@ import java.util.function.Consumer;
 
 
 class PortablePromiseJsImpl<T> implements PortablePromise<T> {
-  private final PortablePromise.PortablePromiseExecutor<T> executor;
   private Promise<T> promise;
 
   public PortablePromiseJsImpl(PortablePromise.PortablePromiseExecutor<T> executor) {
@@ -17,7 +16,10 @@ class PortablePromiseJsImpl<T> implements PortablePromise<T> {
       executor.doInvoke((T value) -> resolve.onInvoke(value),
                         (Object error) -> reject.onInvoke(error));
     });
-    this.executor = executor;
+  }
+
+  public PortablePromiseJsImpl(T value) {
+    this.promise = Promise.resolve(value);
   }
 
   @Override


### PR DESCRIPTION
* Add helper methods for portable json and promise (these methods will be used in the storage proxy implementation in the upcoming PRs)
* Comment out SingletonProxy (it wont be used for v0)