### PR TITLE
Fixes variable name conflict in schema2kotlin

### DIFF
--- a/src/tools/schema2kotlin.ts
+++ b/src/tools/schema2kotlin.ts
@@ -67,7 +67,7 @@ package arcs
 
       decode.push(`"${fixed}" -> {`,
                   `  decoder.validate("${typeChar}")`,
-                  `  ${fixed} = decoder.${decodeType}`,
+                  `  this.${fixed} = decoder.${decodeType}`,
                   `}`,
       );
 


### PR DESCRIPTION
Example Issue:
<img width="497" alt="Screen Shot 2019-07-27 at 1 34 54 pm" src="https://user-images.githubusercontent.com/26159485/61989714-dbb1c180-b076-11e9-8d01-560cb23e65c5.png">
