### PR TITLE
Upgrade to ts-pegjs 0.2.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11583,9 +11583,9 @@
       "dev": true
     },
     "ts-pegjs": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/ts-pegjs/-/ts-pegjs-0.2.2.tgz",
-      "integrity": "sha512-7PUw/w9pFNk/kiv1x7e2lu4WUetQYnaCXjxiRJTEWoLSXpjsg8VKMZpUwa+zACNuWPCL7tcI+1IaC9mm3Pqb7Q==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/ts-pegjs/-/ts-pegjs-0.2.6.tgz",
+      "integrity": "sha512-mIX/dMQ6a1EHAEhvCLS6Z41+O700zlLiwB4V5ZSlKFLZKLDE93reik5IFw/HJsKgs488UiLx144yeEWWyu7YIw==",
       "dev": true,
       "requires": {
         "pegjs": "^0.10.0"

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "rollup-plugin-node-resolve": "^4.0.0",
     "rollup-plugin-typescript2": "^0.21.1",
     "sloc": "^0.2.1",
-    "ts-pegjs": "^0.2.2",
+    "ts-pegjs": "^0.2.6",
     "tslint": "^5.18.0",
     "type-coverage": "^2.0.1",
     "typedoc": "^0.15.0",


### PR DESCRIPTION
- Includes many fixes noImplicitAny and more.
- Improves type coverage by 0.3 points
- Includes my PR metadevpro/ts-pegjs#38
- Prepares for 0.11 of pegjs (when it is released)