### PR TITLE
Clean up TODOs

### DIFF
--- a/src/planning/testing/planning-test-helper.ts
+++ b/src/planning/testing/planning-test-helper.ts
@@ -16,6 +16,7 @@ import {assert} from '../../platform/chai-web.js';
 import {Manifest} from '../../runtime/manifest.js';
 import {Recipe} from '../../runtime/recipe/recipe.js';
 import {Relevance} from '../../runtime/relevance.js';
+import {VolatileSingleton} from '../../runtime/storage/volatile-storage.js';
 import {InterfaceType} from '../../runtime/type.js';
 import {TestHelperOptions, TestHelper} from '../../runtime/testing/test-helper.js';
 import {devtoolsPlannerInspectorFactory} from '../../devtools-connector/devtools-planner-inspector.js';
@@ -124,7 +125,7 @@ export class PlanningTestHelper extends TestHelper {
           suggestions = suggestions.filter(p => {
             return options.hostedParticles.every(hosted => {
               const interfaceHandles = p.plan.handles.filter(h => h.type instanceof InterfaceType);
-              return interfaceHandles.find(handle => this.arc.findStoreById(handle.id)._stored.name === hosted) !== undefined;
+              return interfaceHandles.find(handle => (this.arc.findStoreById(handle.id) as VolatileSingleton)._stored['name'] === hosted) !== undefined;
             });
           });
         }

--- a/src/runtime/modality-handler.ts
+++ b/src/runtime/modality-handler.ts
@@ -16,7 +16,7 @@ import {SlotDomConsumer} from './slot-dom-consumer.js';
 
 export class ModalityHandler {
   constructor(public readonly slotConsumerClass: typeof SlotConsumer,
-              public readonly descriptionFormatter?: typeof DescriptionFormatter) {}
+              public descriptionFormatter?: typeof DescriptionFormatter) {}
 
   static createHeadlessHandler(): ModalityHandler {
     return new ModalityHandler(HeadlessSlotDomConsumer);

--- a/src/runtime/recipe/handle-connection.ts
+++ b/src/runtime/recipe/handle-connection.ts
@@ -24,7 +24,7 @@ import {Direction} from '../manifest-ast-nodes.js';
 
 export class HandleConnection implements Comparable<HandleConnection> {
   private readonly _recipe: Recipe;
-  public _name: string; // TODO(lindner): make private, used in particle.ts
+  private _name: string;
   private _tags: string[] = [];
   private resolvedType?: Type = undefined;
   private _direction: Direction = 'any';

--- a/src/runtime/storage/volatile-storage.ts
+++ b/src/runtime/storage/volatile-storage.ts
@@ -202,7 +202,7 @@ export abstract class VolatileStorageProvider extends StorageProviderBase {
   fromLiteral({version, model}) {}
 }
 
-class VolatileCollection extends VolatileStorageProvider implements CollectionStorageProvider {
+export class VolatileCollection extends VolatileStorageProvider implements CollectionStorageProvider {
   _model: CrdtCollectionModel;
   constructor(type, storageEngine, name, id, key) {
     super(type, name, id, key);
@@ -359,7 +359,7 @@ class VolatileCollection extends VolatileStorageProvider implements CollectionSt
   }
 }
 
-class VolatileSingleton extends VolatileStorageProvider implements SingletonStorageProvider {
+export class VolatileSingleton extends VolatileStorageProvider implements SingletonStorageProvider {
   _stored: {id: string, storageKey?: string}|null;
   private localKeyId = 0;
   constructor(type, storageEngine, name, id, key) {

--- a/src/runtime/testing/test-helper.ts
+++ b/src/runtime/testing/test-helper.ts
@@ -32,8 +32,7 @@ export class TestHelper {
   logging?: boolean;
   loader?: Loader;
   timeout;
-  // TODO(lindner): adding the type here causes many compilation errors.
-  arc;
+  arc: Arc;
   slotComposer: MockSlotComposer;
 
   static async setupOptions(options: TestHelperOptions): Promise<void> {

--- a/src/tests/multiplexer-integration-test.ts
+++ b/src/tests/multiplexer-integration-test.ts
@@ -23,7 +23,7 @@ describe('Multiplexer', () => {
     const helper = await PlanningTestHelper.create({
       manifestFilename: './src/tests/particles/artifacts/polymorphic-muxing.recipes'
     });
-    const context = helper.arc._context;
+    const context = helper.arc.context;
 
     const showOneParticle = context.particles.find(p => p.name === 'ShowOne');
     const showTwoParticle = context.particles.find(p => p.name === 'ShowTwo');
@@ -57,7 +57,7 @@ describe('Multiplexer', () => {
       }
     });
     postsStub['referenceMode'] = false;
-    postsStub['version'] = '1';
+    // version could be set here, but doesn't matter for tests.
     await helper.makePlans();
 
     // Render 3 posts
@@ -77,7 +77,7 @@ describe('Multiplexer', () => {
         .expectRenderSlot('PostMuxer', 'item', {contentTypes: ['templateName', 'model']})
         .expectRenderSlot('ShowOne', 'item', {contentTypes: ['templateName', 'model']})
         .expectRenderSlot('PostMuxer', 'item', {contentTypes: ['templateName', 'model']});
-    const postsStore = helper.arc.findStoreById(helper.arc.activeRecipe.handles[0].id);
+    const postsStore = helper.arc.findStoreById(helper.arc.activeRecipe.handles[0].id) as CollectionStorageProvider;
     await postsStore.store({id: '4', rawData: {message: 'w', renderRecipe: recipeOne, renderParticleSpec: showOneSpec}}, ['key1']);
     await helper.idle();
     assert.lengthOf(helper.slotComposer.contexts.filter(ctx => ctx instanceof HostedSlotContext), 4);

--- a/src/tests/particles/common-test.ts
+++ b/src/tests/particles/common-test.ts
@@ -11,6 +11,7 @@
 import {assert} from '../../platform/chai-web.js';
 import {Manifest} from '../../runtime/manifest.js';
 import {PlanningTestHelper} from '../../planning/testing/arcs-planning-testing.js';
+import {VolatileCollection} from '../../runtime/storage/volatile-storage.js';
 
 describe('common particles test', () => {
   it('resolves after cloning', async () => {
@@ -75,6 +76,7 @@ describe('common particles test', () => {
     await helper.acceptSuggestion({particles: ['CopyCollection', 'CopyCollection']});
 
     // Copied 2 and 3 entities from two collections.
-    assert.strictEqual(5, helper.arc._stores[2]._model.size);
+    const collection = helper.arc._stores[2] as VolatileCollection;
+    assert.strictEqual(5, collection._model.size);
   });
 });


### PR DESCRIPTION
- _name in HandleConnection can now be private
- Allow descriptionFormatter to be mutable in ModalityHandler (for tests)
- Make arc types in test-helper, fix usages
  - export VolatileSingleton/Collection for use in tests
- Don't set readonly version number in Multiplexer Integration test