### PR TITLE
Copy store names when cloning.

### DIFF
--- a/src/runtime/arc.ts
+++ b/src/runtime/arc.ts
@@ -574,6 +574,7 @@ ${this.activeRecipe.toString()}`;
           assert(copiedStore.version !== null, `Copied store ${recipeHandle.id} doesn't have version.`);
           await newStore.cloneFrom(copiedStore);
           this._tagStore(newStore, this.context.findStoreTags(copiedStoreRef as StorageStub));
+          newStore.name = copiedStore.name && `Copy of ${copiedStore.name}`;
           const copiedStoreDesc = this.getStoreDescription(copiedStore);
           if (copiedStoreDesc) {
             this.storeDescriptions.set(newStore, copiedStoreDesc);


### PR DESCRIPTION
This allows the DevShell to display a more meaningful identifier for manifest-provided stores.