### PR TITLE
Improve dependency handling in sigh.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4849,8 +4849,8 @@
       "dev": true
     },
     "emsdk-npm": {
-      "version": "github:mykmartin/emsdk-npm#a4f338d54c97dfb61550d05defbc1a77847bb0ea",
-      "from": "github:mykmartin/emsdk-npm#travis-workaround",
+      "version": "github:mykmartin/emsdk-npm#3c00a39444bb384ec7640b44e0a57981f91f05ae",
+      "from": "github:mykmartin/emsdk-npm#arcs",
       "dev": true
     },
     "encodeurl": {
@@ -12172,46 +12172,6 @@
       "requires": {
         "indexof": "0.0.1"
       }
-    },
-    "vscode-jsonrpc": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-4.0.0.tgz",
-      "integrity": "sha512-perEnXQdQOJMTDFNv+UF3h1Y0z4iSiaN9jIlb0OqIYgosPCZGYh/MCUlkFtV2668PL69lRDO32hmvL2yiidUYg==",
-      "optional": true
-    },
-    "vscode-languageserver": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-5.2.1.tgz",
-      "integrity": "sha512-GuayqdKZqAwwaCUjDvMTAVRPJOp/SLON3mJ07eGsx/Iq9HjRymhKWztX41rISqDKhHVVyFM+IywICyZDla6U3A==",
-      "optional": true,
-      "requires": {
-        "vscode-languageserver-protocol": "3.14.1",
-        "vscode-uri": "^1.0.6"
-      }
-    },
-    "vscode-languageserver-protocol": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.14.1.tgz",
-      "integrity": "sha512-IL66BLb2g20uIKog5Y2dQ0IiigW0XKrvmWiOvc0yXw80z3tMEzEnHjaGAb3ENuU7MnQqgnYJ1Cl2l9RvNgDi4g==",
-      "optional": true,
-      "requires": {
-        "vscode-jsonrpc": "^4.0.0",
-        "vscode-languageserver-types": "3.14.0"
-      },
-      "dependencies": {
-        "vscode-languageserver-types": {
-          "version": "3.14.0",
-          "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.14.0.tgz",
-          "integrity": "sha512-lTmS6AlAlMHOvPQemVwo3CezxBp0sNB95KNPkqp3Nxd5VFEnuG1ByM0zlRWos0zjO3ZWtkvhal0COgiV1xIA4A==",
-          "optional": true
-        }
-      }
-    },
-    "vscode-uri": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.8.tgz",
-      "integrity": "sha512-obtSWTlbJ+a+TFRYGaUumtVwb+InIUVI0Lu0VBUAPmj2cU5JutEXg3xUE0c2J5Tcy7h2DEKVJBFi+Y9ZSFzzPQ==",
-      "optional": true
     },
     "vuvuzela": {
       "version": "1.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1989,16 +1989,6 @@
         "color-convert": "^1.9.0"
       }
     },
-    "anymatch": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
-      "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
-      "dev": true,
-      "requires": {
-        "micromatch": "^3.1.4",
-        "normalize-path": "^2.1.1"
-      }
-    },
     "aproba": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
@@ -2392,12 +2382,6 @@
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
       "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
-      "dev": true
-    },
-    "binary-extensions": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
-      "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
       "dev": true
     },
     "bl": {
@@ -3245,582 +3229,6 @@
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
       "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
       "dev": true
-    },
-    "chokidar": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.6.tgz",
-      "integrity": "sha512-V2jUo67OKkc6ySiRpJrjlpJKl9kDuG+Xb8VgsGzb+aEouhgS1D0weyPU4lEzdAcsCAvrih2J2BqyXqHWvVLw5g==",
-      "dev": true,
-      "requires": {
-        "anymatch": "^2.0.0",
-        "async-each": "^1.0.1",
-        "braces": "^2.3.2",
-        "fsevents": "^1.2.7",
-        "glob-parent": "^3.1.0",
-        "inherits": "^2.0.3",
-        "is-binary-path": "^1.0.0",
-        "is-glob": "^4.0.0",
-        "normalize-path": "^3.0.0",
-        "path-is-absolute": "^1.0.0",
-        "readdirp": "^2.2.1",
-        "upath": "^1.1.1"
-      },
-      "dependencies": {
-        "fsevents": {
-          "version": "1.2.9",
-          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
-          "integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "nan": "^2.12.1",
-            "node-pre-gyp": "^0.12.0"
-          },
-          "dependencies": {
-            "abbrev": {
-              "version": "1.1.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "ansi-regex": {
-              "version": "2.1.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "aproba": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "are-we-there-yet": {
-              "version": "1.1.5",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "delegates": "^1.0.0",
-                "readable-stream": "^2.0.6"
-              }
-            },
-            "balanced-match": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "brace-expansion": {
-              "version": "1.1.11",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
-              }
-            },
-            "chownr": {
-              "version": "1.1.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "code-point-at": {
-              "version": "1.1.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "concat-map": {
-              "version": "0.0.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "console-control-strings": {
-              "version": "1.1.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "core-util-is": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "debug": {
-              "version": "4.1.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "ms": "^2.1.1"
-              }
-            },
-            "deep-extend": {
-              "version": "0.6.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "delegates": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "detect-libc": {
-              "version": "1.0.3",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "fs-minipass": {
-              "version": "1.2.5",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "minipass": "^2.2.1"
-              }
-            },
-            "fs.realpath": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "gauge": {
-              "version": "2.7.4",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "aproba": "^1.0.3",
-                "console-control-strings": "^1.0.0",
-                "has-unicode": "^2.0.0",
-                "object-assign": "^4.1.0",
-                "signal-exit": "^3.0.0",
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1",
-                "wide-align": "^1.1.0"
-              }
-            },
-            "glob": {
-              "version": "7.1.3",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-              }
-            },
-            "has-unicode": {
-              "version": "2.0.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "iconv-lite": {
-              "version": "0.4.24",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "safer-buffer": ">= 2.1.2 < 3"
-              }
-            },
-            "ignore-walk": {
-              "version": "3.0.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "minimatch": "^3.0.4"
-              }
-            },
-            "inflight": {
-              "version": "1.0.6",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "once": "^1.3.0",
-                "wrappy": "1"
-              }
-            },
-            "inherits": {
-              "version": "2.0.3",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "ini": {
-              "version": "1.3.5",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "is-fullwidth-code-point": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "number-is-nan": "^1.0.0"
-              }
-            },
-            "isarray": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "minimatch": {
-              "version": "3.0.4",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "brace-expansion": "^1.1.7"
-              }
-            },
-            "minimist": {
-              "version": "0.0.8",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "minipass": {
-              "version": "2.3.5",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "safe-buffer": "^5.1.2",
-                "yallist": "^3.0.0"
-              }
-            },
-            "minizlib": {
-              "version": "1.2.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "minipass": "^2.2.1"
-              }
-            },
-            "mkdirp": {
-              "version": "0.5.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "minimist": "0.0.8"
-              }
-            },
-            "ms": {
-              "version": "2.1.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "needle": {
-              "version": "2.3.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "debug": "^4.1.0",
-                "iconv-lite": "^0.4.4",
-                "sax": "^1.2.4"
-              }
-            },
-            "node-pre-gyp": {
-              "version": "0.12.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "detect-libc": "^1.0.2",
-                "mkdirp": "^0.5.1",
-                "needle": "^2.2.1",
-                "nopt": "^4.0.1",
-                "npm-packlist": "^1.1.6",
-                "npmlog": "^4.0.2",
-                "rc": "^1.2.7",
-                "rimraf": "^2.6.1",
-                "semver": "^5.3.0",
-                "tar": "^4"
-              }
-            },
-            "nopt": {
-              "version": "4.0.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "abbrev": "1",
-                "osenv": "^0.1.4"
-              }
-            },
-            "npm-bundled": {
-              "version": "1.0.6",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "npm-packlist": {
-              "version": "1.4.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "ignore-walk": "^3.0.1",
-                "npm-bundled": "^1.0.1"
-              }
-            },
-            "npmlog": {
-              "version": "4.1.2",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "are-we-there-yet": "~1.1.2",
-                "console-control-strings": "~1.1.0",
-                "gauge": "~2.7.3",
-                "set-blocking": "~2.0.0"
-              }
-            },
-            "number-is-nan": {
-              "version": "1.0.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "object-assign": {
-              "version": "4.1.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "once": {
-              "version": "1.4.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "wrappy": "1"
-              }
-            },
-            "os-homedir": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "os-tmpdir": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "osenv": {
-              "version": "0.1.5",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "os-homedir": "^1.0.0",
-                "os-tmpdir": "^1.0.0"
-              }
-            },
-            "path-is-absolute": {
-              "version": "1.0.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "process-nextick-args": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "rc": {
-              "version": "1.2.8",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "deep-extend": "^0.6.0",
-                "ini": "~1.3.0",
-                "minimist": "^1.2.0",
-                "strip-json-comments": "~2.0.1"
-              },
-              "dependencies": {
-                "minimist": {
-                  "version": "1.2.0",
-                  "bundled": true,
-                  "dev": true,
-                  "optional": true
-                }
-              }
-            },
-            "readable-stream": {
-              "version": "2.3.6",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-              }
-            },
-            "rimraf": {
-              "version": "2.6.3",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "glob": "^7.1.3"
-              }
-            },
-            "safe-buffer": {
-              "version": "5.1.2",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "safer-buffer": {
-              "version": "2.1.2",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "sax": {
-              "version": "1.2.4",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "semver": {
-              "version": "5.7.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "set-blocking": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "signal-exit": {
-              "version": "3.0.2",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "string-width": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
-              }
-            },
-            "string_decoder": {
-              "version": "1.1.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "safe-buffer": "~5.1.0"
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "ansi-regex": "^2.0.0"
-              }
-            },
-            "strip-json-comments": {
-              "version": "2.0.1",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "tar": {
-              "version": "4.4.8",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "chownr": "^1.1.1",
-                "fs-minipass": "^1.2.5",
-                "minipass": "^2.3.4",
-                "minizlib": "^1.1.1",
-                "mkdirp": "^0.5.0",
-                "safe-buffer": "^5.1.2",
-                "yallist": "^3.0.2"
-              }
-            },
-            "util-deprecate": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "wide-align": {
-              "version": "1.1.3",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "string-width": "^1.0.2 || 2"
-              }
-            },
-            "wrappy": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "yallist": {
-              "version": "3.0.3",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "normalize-path": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-          "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-          "dev": true
-        }
-      }
     },
     "chrome-launcher": {
       "version": "0.10.5",
@@ -4846,11 +4254,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
       "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
-      "dev": true
-    },
-    "emsdk-npm": {
-      "version": "github:mykmartin/emsdk-npm#3c00a39444bb384ec7640b44e0a57981f91f05ae",
-      "from": "github:mykmartin/emsdk-npm#arcs",
       "dev": true
     },
     "encodeurl": {
@@ -7163,15 +6566,6 @@
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
-    },
-    "is-binary-path": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
-      "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
-      "dev": true,
-      "requires": {
-        "binary-extensions": "^1.0.0"
-      }
     },
     "is-buffer": {
       "version": "1.1.6",
@@ -10116,24 +9510,24 @@
       },
       "dependencies": {
         "mime-db": {
-          "version": "1.36.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.36.0.tgz",
-          "integrity": "sha512-L+xvyD9MkoYMXb1jAmzI/lWYAxAMCPvIBSWur0PZ5nOf5euahRLVqH//FKW9mWp2lkqUgYiXPgkzfMUFi4zVDw==",
+          "version": "1.40.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
+          "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
           "dev": true
         },
         "mime-types": {
-          "version": "2.1.20",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz",
-          "integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
+          "version": "2.1.24",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
+          "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
           "dev": true,
           "requires": {
-            "mime-db": "~1.36.0"
+            "mime-db": "1.40.0"
           }
         },
         "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
           "dev": true
         },
         "tough-cookie": {
@@ -12187,6 +11581,618 @@
         "chokidar": "^2.0.2",
         "graceful-fs": "^4.1.2",
         "neo-async": "^2.5.0"
+      },
+      "dependencies": {
+        "anymatch": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+          "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+          "dev": true,
+          "requires": {
+            "micromatch": "^3.1.4",
+            "normalize-path": "^2.1.1"
+          },
+          "dependencies": {
+            "normalize-path": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+              "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+              "dev": true,
+              "requires": {
+                "remove-trailing-separator": "^1.0.1"
+              }
+            }
+          }
+        },
+        "binary-extensions": {
+          "version": "1.13.1",
+          "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
+          "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
+          "dev": true
+        },
+        "chokidar": {
+          "version": "2.1.6",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.6.tgz",
+          "integrity": "sha512-V2jUo67OKkc6ySiRpJrjlpJKl9kDuG+Xb8VgsGzb+aEouhgS1D0weyPU4lEzdAcsCAvrih2J2BqyXqHWvVLw5g==",
+          "dev": true,
+          "requires": {
+            "anymatch": "^2.0.0",
+            "async-each": "^1.0.1",
+            "braces": "^2.3.2",
+            "fsevents": "^1.2.7",
+            "glob-parent": "^3.1.0",
+            "inherits": "^2.0.3",
+            "is-binary-path": "^1.0.0",
+            "is-glob": "^4.0.0",
+            "normalize-path": "^3.0.0",
+            "path-is-absolute": "^1.0.0",
+            "readdirp": "^2.2.1",
+            "upath": "^1.1.1"
+          }
+        },
+        "fsevents": {
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
+          "integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "nan": "^2.12.1",
+            "node-pre-gyp": "^0.12.0"
+          },
+          "dependencies": {
+            "abbrev": {
+              "version": "1.1.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "ansi-regex": {
+              "version": "2.1.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "aproba": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "are-we-there-yet": {
+              "version": "1.1.5",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "delegates": "^1.0.0",
+                "readable-stream": "^2.0.6"
+              }
+            },
+            "balanced-match": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "brace-expansion": {
+              "version": "1.1.11",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+              }
+            },
+            "chownr": {
+              "version": "1.1.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "code-point-at": {
+              "version": "1.1.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "concat-map": {
+              "version": "0.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "console-control-strings": {
+              "version": "1.1.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "core-util-is": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "debug": {
+              "version": "4.1.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            },
+            "deep-extend": {
+              "version": "0.6.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "delegates": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "detect-libc": {
+              "version": "1.0.3",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "fs-minipass": {
+              "version": "1.2.5",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "minipass": "^2.2.1"
+              }
+            },
+            "fs.realpath": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "gauge": {
+              "version": "2.7.4",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "aproba": "^1.0.3",
+                "console-control-strings": "^1.0.0",
+                "has-unicode": "^2.0.0",
+                "object-assign": "^4.1.0",
+                "signal-exit": "^3.0.0",
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wide-align": "^1.1.0"
+              }
+            },
+            "glob": {
+              "version": "7.1.3",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            },
+            "has-unicode": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "iconv-lite": {
+              "version": "0.4.24",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "safer-buffer": ">= 2.1.2 < 3"
+              }
+            },
+            "ignore-walk": {
+              "version": "3.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "minimatch": "^3.0.4"
+              }
+            },
+            "inflight": {
+              "version": "1.0.6",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+              }
+            },
+            "inherits": {
+              "version": "2.0.3",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "ini": {
+              "version": "1.3.5",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "number-is-nan": "^1.0.0"
+              }
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "brace-expansion": "^1.1.7"
+              }
+            },
+            "minimist": {
+              "version": "0.0.8",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "minipass": {
+              "version": "2.3.5",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.0"
+              }
+            },
+            "minizlib": {
+              "version": "1.2.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "minipass": "^2.2.1"
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "minimist": "0.0.8"
+              }
+            },
+            "ms": {
+              "version": "2.1.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "needle": {
+              "version": "2.3.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "debug": "^4.1.0",
+                "iconv-lite": "^0.4.4",
+                "sax": "^1.2.4"
+              }
+            },
+            "node-pre-gyp": {
+              "version": "0.12.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "detect-libc": "^1.0.2",
+                "mkdirp": "^0.5.1",
+                "needle": "^2.2.1",
+                "nopt": "^4.0.1",
+                "npm-packlist": "^1.1.6",
+                "npmlog": "^4.0.2",
+                "rc": "^1.2.7",
+                "rimraf": "^2.6.1",
+                "semver": "^5.3.0",
+                "tar": "^4"
+              }
+            },
+            "nopt": {
+              "version": "4.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "abbrev": "1",
+                "osenv": "^0.1.4"
+              }
+            },
+            "npm-bundled": {
+              "version": "1.0.6",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "npm-packlist": {
+              "version": "1.4.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "ignore-walk": "^3.0.1",
+                "npm-bundled": "^1.0.1"
+              }
+            },
+            "npmlog": {
+              "version": "4.1.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "are-we-there-yet": "~1.1.2",
+                "console-control-strings": "~1.1.0",
+                "gauge": "~2.7.3",
+                "set-blocking": "~2.0.0"
+              }
+            },
+            "number-is-nan": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "once": {
+              "version": "1.4.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "wrappy": "1"
+              }
+            },
+            "os-homedir": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "os-tmpdir": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "osenv": {
+              "version": "0.1.5",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "os-homedir": "^1.0.0",
+                "os-tmpdir": "^1.0.0"
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "process-nextick-args": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "rc": {
+              "version": "1.2.8",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "deep-extend": "^0.6.0",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~2.0.1"
+              },
+              "dependencies": {
+                "minimist": {
+                  "version": "1.2.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                }
+              }
+            },
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "rimraf": {
+              "version": "2.6.3",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "glob": "^7.1.3"
+              }
+            },
+            "safe-buffer": {
+              "version": "5.1.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "safer-buffer": {
+              "version": "2.1.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "sax": {
+              "version": "1.2.4",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "semver": {
+              "version": "5.7.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "set-blocking": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "signal-exit": {
+              "version": "3.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "ansi-regex": "^2.0.0"
+              }
+            },
+            "strip-json-comments": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "tar": {
+              "version": "4.4.8",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "chownr": "^1.1.1",
+                "fs-minipass": "^1.2.5",
+                "minipass": "^2.3.4",
+                "minizlib": "^1.1.1",
+                "mkdirp": "^0.5.0",
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.2"
+              }
+            },
+            "util-deprecate": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "wide-align": {
+              "version": "1.1.3",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "string-width": "^1.0.2 || 2"
+              }
+            },
+            "wrappy": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "yallist": {
+              "version": "3.0.3",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "is-binary-path": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+          "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+          "dev": true,
+          "requires": {
+            "binary-extensions": "^1.0.0"
+          }
+        },
+        "normalize-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+          "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+          "dev": true
+        }
       }
     },
     "wdio-chromedriver-service": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "chromedriver": "^75.1.0",
     "concurrently": "^4.1.0",
     "cross-env": "^5.2.0",
-    "emsdk-npm": "github:mykmartin/emsdk-npm#arcs",
     "eslint": "^6.0.1",
     "eslint-config-google": "^0.13.0",
     "eslint-plugin-header": "^3.0.0",
@@ -71,7 +70,6 @@
     "node-webcrypto-ossl": "^1.0.39",
     "npm-run-all": "^4.1.5",
     "pegjs": "^0.10.0",
-    "request": "^2.88.0",
     "rollup": "^1.17.0",
     "rollup-plugin-commonjs": "^9.3.4",
     "rollup-plugin-ignore": "^1.0.5",
@@ -105,6 +103,13 @@
     "sourcemapped-stacktrace": "^1.1.9",
     "typescript": "^3.4.5",
     "ws": "~6.0.0"
+  },
+  "sighDependencies": {
+    "chokidar": "^3.0.2",
+    "emsdk-npm": "github:mykmartin/emsdk-npm#arcs",
+    "request": "^2.88.0",
+    "vscode-jsonrpc": "^4.0.0",
+    "vscode-languageserver": "^5.2.1"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "chromedriver": "^75.1.0",
     "concurrently": "^4.1.0",
     "cross-env": "^5.2.0",
-    "emsdk-npm": "github:mykmartin/emsdk-npm#travis-workaround",
+    "emsdk-npm": "github:mykmartin/emsdk-npm#arcs",
     "eslint": "^6.0.1",
     "eslint-config-google": "^0.13.0",
     "eslint-plugin-header": "^3.0.0",
@@ -120,9 +120,5 @@
     "node": ">= 10.13.0",
     "npm": ">= 6.9.0",
     "emsdk": ">= 1.38.34"
-  },
-  "optionalDependencies": {
-    "vscode-jsonrpc": "^4.0.0",
-    "vscode-languageserver": "^5.2.1"
   }
 }

--- a/tools/sigh.ts
+++ b/tools/sigh.ts
@@ -113,7 +113,7 @@ function getOptionalDependencies(deps: string[], prefix): any[] {
     }
   }
   if (missing.length) {
-    throw new Error(`${prefix} requires extra dependencies: run 'sigh install ${missing.join(' ')}' to install`);
+    throw new Error(`${prefix} requires extra dependencies: run 'tools/sigh install ${missing.join(' ')}' to install`);
   }
   return result;
 }
@@ -176,8 +176,9 @@ function targetIsUpToDate(relativeTarget: string, relativeDeps: string[], quiet 
 }
 
 function check(): boolean {
-  const nodeRequiredVersion = require('../package.json').engines.node;
-  const npmRequiredVersion = require('../package.json').engines.npm;
+  const engines = require('../package.json').engines;
+  const nodeRequiredVersion = engines.node;
+  const npmRequiredVersion = engines.npm;
 
   if (!semver.satisfies(process.version, nodeRequiredVersion)) {
     throw new Error(`at least node ${nodeRequiredVersion} is required, you have ${process.version}`);

--- a/tools/sigh.ts
+++ b/tools/sigh.ts
@@ -11,22 +11,12 @@
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const minimist = require('minimist');
+const semver = require('semver');
 
 // Use saneSpawn or saneSpawnWithOutput instead, this is not cross-platform.
 // tslint:disable-next-line: variable-name
 const _DO_NOT_USE_spawn = require('child_process').spawnSync;
-const minimist = require('minimist');
-const chokidar = try_require('chokidar');
-const semver = require('semver');
-const request = try_require('request');
-
-function try_require(dep) {
-  try {
-    return require(dep);
-  } catch (e) {
-    return null;
-  }
-}
 
 const projectRoot = path.resolve(__dirname, '..');
 process.chdir(projectRoot);
@@ -51,18 +41,18 @@ import * as AstNode from '../../runtime/manifest-ast-nodes.js';
   }]
 };
 
-const build = buildPath('.', cleanObsolete, []);
+const build = buildPath('.', cleanObsolete);
 const webpack = webpackPkg('webpack');
 const webpackTools = webpackPkg('webpack-tools');
 
-const buildLS = buildPath('./src/tools/language-server', null, ['vscode-jsonrpc', 'vscode-languageserver']);
+const buildLS = buildPath('./src/tools/language-server', checkLanguageServerDeps);
 const webpackLS = webpackPkg('webpack-languageserver');
 
 const steps: {[index: string]: ((args?: string[]) => boolean)[]} = {
   languageServer: [peg, build, buildLS, webpackLS, languageServer],
   peg: [peg, railroad],
   railroad: [railroad],
-  test: [peg, railroad, build, wasm, runTests],
+  test: [peg, railroad, build, runTests],
   webpack: [peg, railroad, build, webpack],
   webpackTools: [peg, build, webpackTools],
   build: [peg, build],
@@ -79,7 +69,7 @@ const steps: {[index: string]: ((args?: string[]) => boolean)[]} = {
   devServer: [peg, build, devServer],
   flowcheck: [peg, build, flowcheck],
   licenses: [build],
-  default: [check, peg, railroad, build, wasm, runTestsOrHealthOnCron, webpack, webpackTools, lint, tslint],
+  default: [check, peg, railroad, build, runTestsOrHealthOnCron, webpack, webpackTools, lint, tslint],
 };
 
 const eslintCache = '.eslint_sigh_cache';
@@ -100,10 +90,24 @@ const nodeFlags = [
   '--loader', fixPathForWindows(path.join(__dirname, '../tools/custom-loader.mjs'))
 ];
 
+// The 'cron' env type indicates the daily build in Travis.
+const isTravisDaily = (process.env.TRAVIS_EVENT_TYPE === 'cron');
+
 // Flags for unit tests; use `global['testFlags'].foo` to access them.
 const testFlags = {
   enableWasm: false,
 };
+
+function getOptionalDependency(dep, prefix = null) {
+  try {
+    return require(dep);
+  } catch (e) {
+    if (prefix) {
+      console.log(`${prefix} requires extra dependencies: run 'npm install --no-save ${dep}' to install`);
+    }
+    return null;
+  }
+}
 
 function* findProjectFiles(dir: string, exclude: RegExp|null, include: RegExp|((path: string) => boolean)): Iterable<string> {
   const predicate = (include instanceof RegExp) ? (fullPath => include.test(fullPath)) : include;
@@ -167,46 +171,6 @@ function check(): boolean {
   const npmVersion = saneSpawnWithOutput('npm', ['-v']).stdout;
   if (!semver.satisfies(npmVersion, npmRequiredVersion)) {
     throw new Error(`at least npm ${npmRequiredVersion} is required, you have ${npmVersion}`);
-  }
-
-  return true;
-}
-
-// emsdk-npm's installation process is not idempotent, so it fails if we put this in the npm
-// postinstall step. This is invoked by the wasm build step and will generally only be required
-// at the same cadence as npm install.
-function installAndCheckEmsdk(): boolean {
-  if (!fs.existsSync('node_modules/emsdk-npm')) {
-    console.error(`emsdk-npm not found - run 'npm install'`);
-    return false;
-  }
-  if (fs.existsSync('node_modules/emsdk-npm/emsdk')) {
-    return true;
-  }
-
-  console.log('-- Installing emsdk --');
-  if (!saneSpawn('npx', ['emsdk-checkout']) ||
-      !saneSpawn('npx', ['emsdk', 'install', 'latest']) ||
-      !saneSpawn('npx', ['emsdk', 'activate', 'latest'])) {
-    console.error('emsdk installation failed');
-    return false;
-  }
-
-  const emsdkRequiredVersion = require('../package.json').engines.emsdk;
-
-  // This call generates a bunch of unrelated output (emsdk env setup, plus the version output
-  // itself is quite verbose). The regex extracts the version from a line that looks like:
-  //   emcc (Emscripten gcc/clang-like replacement) 1.38.38 (4965260 Tue Jul 9 13:29:04 2019 ...
-  const emsdkResult = saneSpawnWithOutput('npx', ['emsdk-run', 'em++', '--version']);
-  const match = emsdkResult.stdout.match(/\nemcc [^0-9.]+ ([0-9.]+) /);
-  if (match === null) {
-    console.error('Failed to extract emsdk version');
-    return false;
-  }
-  const emsdkVersion = match[1];
-  if (!semver.satisfies(emsdkVersion, emsdkRequiredVersion)) {
-    console.error(`emsdk version check failed: at least ${emsdkRequiredVersion} is required, you have ${emsdkVersion}`);
-    return false;
   }
 
   return true;
@@ -378,7 +342,7 @@ function railroad(): boolean {
 
 // Removes .js files in the build dir that don't have a corresponding source file (.js or .ts) in src.
 // Also removes the generated source map and type def files if they exist.
-function cleanObsolete() {
+function cleanObsolete(): boolean {
   const exts = ['js', 'js.map', 'd.ts'];
   for (const file of [...findProjectFiles('build', /javaharness|sigh\.js/, /\.js$/)]) {
     const buildBase = file.slice(0, -2);  // drop 'js' extension
@@ -393,18 +357,27 @@ function cleanObsolete() {
       });
     }
   }
+  return true;
 }
 
-function buildPath(path: string, preprocess: () => void, deps: string[]): () => boolean {
+function checkLanguageServerDeps(): boolean {
+  const missing = ['vscode-jsonrpc', 'vscode-languageserver'].filter(dep => !getOptionalDependency(dep));
+  if (missing.length) {
+    console.log(`The languageServer command requires extra dependencies: ` +
+                `run 'npm install --no-save ${missing.join(' ')}' to install`);
+    return false;
+  }
+  return true;
+}
+
+function buildPath(path: string, preprocess: () => boolean): () => boolean {
   const fn = () => {
-    if (preprocess) {
-      preprocess();
+    if (!preprocess()) {
+      return false;
     }
+
     if (!tsc(path)) {
       console.error('build::tsc failed');
-      if (deps.length > 0) {
-        console.error(`The following dependencies may be required${deps.map(s=>` ${s}`)}`);
-      }
       return false;
     }
 
@@ -474,6 +447,73 @@ function link(srcFiles: Iterable<string>): boolean {
   return success;
 }
 
+// With no args, finds all 'wasm.json' files to generate C++ headers and compile wasm modules.
+// Otherwise only the requested configs are processed (e.g. tools/sigh wasm src/wasm/cpp/wasm.json)
+// Other options: --trace to show commands used, --force to disable timestamp checks
+function wasm(args: string[]): boolean {
+  // TODO: https://github.com/PolymerLabs/arcs/issues/3418
+  if (process.platform !== 'linux') {
+    console.log(`Skipping step; wasm builds are not yet supported on ${process.platform}`);
+    return true;
+  }
+  const emsdk = setupEmsdk();
+  if (!emsdk) {
+    if (isTravisDaily) {
+      console.log('Disabling wasm builds for Travis execution');
+      return true;
+    }
+    return false;
+  }
+  testFlags.enableWasm = true;
+
+  const options = minimist(args, {
+    boolean: ['trace', 'force'],
+  });
+  const specified = (options._.length > 0);
+  const targets = specified ? options._ : findProjectFiles('src', null, /[/\\]wasm\.json$/);
+  let success = true;
+  for (const configFile of targets) {
+    if (specified && !fs.existsSync(configFile)) {
+      console.error(`wasm config not found: ${configFile}`);
+      success = false;
+      continue;
+    }
+    success = success && buildWasmModule(emsdk, configFile, options.trace, options.force);
+  }
+  return success;
+}
+
+// Attempts to install emsdk and verify that the version is correct.
+function setupEmsdk() {
+  const emsdk = getOptionalDependency('emsdk-npm', 'The wasm command');
+  if (!emsdk) {
+    return null;
+  }
+
+  // Downloads and installs emsdk/emscripten as required.
+  emsdk.install();
+
+  // Verify the emsdk version. This also checks that em++ can be executed. The call generates a
+  // bunch of unrelated output (emsdk env setup, plus the version output itself is quite verbose),
+  // so the regex extracts the version from a line that looks like:
+  //   emcc (Emscripten gcc/clang-like replacement) 1.38.38 (4965260 Tue Jul 9 13:29:04 2019 ...
+  const result = emsdk.run('em++', ['--version']);
+  const match = result.stdout.match(/\nemcc [^0-9.]+ ([0-9.]+) /);
+  if (match === null) {
+    console.error('Failed to extract emsdk version');
+    console.error(result.stdout);
+    console.error(result.stderr);
+    return null;
+  }
+  const emsdkVersion = match[1];
+  const emsdkRequired = require('../package.json').engines.emsdk;
+  if (!semver.satisfies(emsdkVersion, emsdkRequired)) {
+    console.error(`emsdk version check failed: at least ${emsdkRequired} is required, you have ${emsdkVersion}`);
+    return null;
+  }
+  return emsdk;
+}
+
 // Config for building wasm modules.
 interface WasmConfig {
   [key: string]: {         // The target filename for the module.
@@ -485,7 +525,7 @@ interface WasmConfig {
 }
 
 // TODO: detect old headers/wasm modules/manifests in cleanObsolete()
-function buildWasmModule(configFile: string, logCmd: boolean, force: boolean): boolean {
+function buildWasmModule(emsdk, configFile: string, logCmd: boolean, force: boolean): boolean {
   const srcDir = path.dirname(configFile);
   const json = JSON.parse(fs.readFileSync(configFile, 'utf-8')) as WasmConfig;
   let success = true;
@@ -502,7 +542,7 @@ function buildWasmModule(configFile: string, logCmd: boolean, force: boolean): b
 
     // Generate the entity class header file from the manifest.
     const updateFlag = force ? [] : ['--update'];
-    let result = saneSpawnWithOutput('node', [
+    const spawnResult = saneSpawnWithOutput('node', [
         ...nodeFlags,
         '--no-warnings',
         'build/tools/schema2packager.js',
@@ -511,20 +551,20 @@ function buildWasmModule(configFile: string, logCmd: boolean, force: boolean): b
         '-o', cfg.outDir,
         manifestPath
       ], {logCmd});
-    if (!result.success) {
-      console.error(result.stderr);
+    if (!spawnResult.success) {
+      console.error(spawnResult.stderr);
       success = false;
       continue;
     }
 
-    const headerPath = result.stdout.trim();
+    const headerPath = spawnResult.stdout.trim();
     if (!force && targetIsUpToDate(wasmPath, ['src/wasm/cpp/arcs.h', headerPath, srcPath], true)) {
       continue;
     }
 
     // Compile the wasm module.
-    result = saneSpawnWithOutput('npx', [
-        'emsdk-run', 'em++', '-std=c++17', '-O3',
+    const emsdkResult = emsdk.run('em++', [
+        '-std=c++17', '-O3',
         '-s', `EXPORTED_FUNCTIONS=['_malloc','_free']`,
         '-s', 'EMIT_EMSCRIPTEN_METADATA',
         '-I', 'src/wasm/cpp',  // for arcs.h
@@ -532,10 +572,10 @@ function buildWasmModule(configFile: string, logCmd: boolean, force: boolean): b
         '-o', wasmPath,
         srcPath
       ], {logCmd});
-    if (!result.success) {
+    if (emsdkResult.status !== 0) {
       console.error('\n------------------------------------------------------------------------');
       console.error(`Compilation failed for ${name} in ${configFile}\n`);
-      console.error(result.stderr);
+      console.error(emsdkResult.stderr);
       console.error('------------------------------------------------------------------------\n');
       success = false;
       continue;
@@ -550,38 +590,6 @@ function buildWasmModule(configFile: string, logCmd: boolean, force: boolean): b
         return false;
       }
     }
-  }
-  return success;
-}
-
-// With no args, finds all 'wasm.json' files to generate C++ headers and compile wasm modules.
-// Otherwise only the requested configs are processed (e.g. tools/sigh wasm src/wasm/cpp/wasm.json)
-// Other options: --trace to show commands used, --force to disable timestamp checks
-function wasm(args: string[]): boolean {
-  // TODO: https://github.com/PolymerLabs/arcs/issues/3418
-  if (process.platform !== 'linux') {
-    console.log(`Skipping step; wasm builds are not yet supported on ${process.platform}`);
-    return true;
-  }
-  if (!installAndCheckEmsdk()) {
-    console.log('Disabling wasm builds and tests due to emsdk installation failure');
-    return true;
-  }
-  testFlags.enableWasm = true;
-
-  const options = minimist(args, {
-    boolean: ['trace', 'force'],
-  });
-  const specified = (options._.length > 0);
-  const targets = specified ? options._ : findProjectFiles('src', null, /[/\\]wasm\.json$/);
-  let success = true;
-  for (const configFile of targets) {
-    if (specified && !fs.existsSync(configFile)) {
-      console.error(`wasm config not found: ${configFile}`);
-      success = false;
-      continue;
-    }
-    success = success && buildWasmModule(configFile, options.trace, options.force);
   }
   return success;
 }
@@ -711,9 +719,8 @@ function saneSpawnWithOutput(cmd: string, args: string[], opts?: SpawnOptions): 
 }
 
 function runTestsOrHealthOnCron(args: string[]): boolean {
-  // The 'cron' env check indicates the daily build in Travis.
-  if (process.env.TRAVIS_EVENT_TYPE === 'cron') {
-    // The cron job should add the following arguments when running the health command.
+  if (isTravisDaily) {
+    // The travis cron job should add the following arguments when running the health command.
     args.push('--all', '--uploadCodeHealthStats');
     return health(args);
   }
@@ -868,8 +875,8 @@ function watch(args: string[]): boolean {
     stopEarly: true,  // Allow options to be used in the command; 'sigh watch --dir src test -g foo'
   });
 
-  if (chokidar === null) {
-    console.log('\nthe sigh watch subcommand requires chokidar to be installed. Please run \'npm install --no-save chokidar\' then try again\n');
+  const chokidar = getOptionalDependency('chokidar', 'The watch command');
+  if (!chokidar) {
     return false;
   }
 
@@ -1005,12 +1012,13 @@ function health(args: string[]): boolean {
 }
 
 function uploadCodeHealthStats(data: string[]) {
-  console.log('Uploading health data');
-  const trigger = 'https://us-central1-arcs-screenshot-uploader.cloudfunctions.net/arcs-health-uploader';
-
+  const request = getOptionalDependency('request', 'Uploading health data');
   if (!request) {
     return false;
   }
+
+  console.log('Uploading health data');
+  const trigger = 'https://us-central1-arcs-screenshot-uploader.cloudfunctions.net/arcs-health-uploader';
 
   const branchTo = process.env.TRAVIS_BRANCH || 'unknown-branch';
   const branchFrom = process.env.TRAVIS_PULL_REQUEST_BRANCH || 'unknown-branch';


### PR DESCRIPTION
- All commands that require optional npm modules will check first and print a helpful message if the dependency is not found.
- emsk-npm updated to allow directly calling from a module (rather than using 'npx')

Note that optionalDependencies doesn't behave the way you might expect; see #3440 