### PR TITLE
Syntax parsing for recipe selection triggers

### DIFF
--- a/src/recipe-selector/recipe-selector.ts
+++ b/src/recipe-selector/recipe-selector.ts
@@ -1,0 +1,25 @@
+/**
+ * @license
+ * Copyright 2019 Google LLC.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {Recipe} from '../runtime/recipe/recipe.js';
+import {Dictionary} from '../runtime/hot.js';
+
+export class RecipeSelector {
+    // Only recipes with “@trigger” annotations get included in the lookup table.
+    // Other recipes are silently ignored.
+    // If two triggers could match a request (one trigger is a subset of another) an exception is
+    // thrown.
+    constructor(readonly recipes: Recipe[]) {
+    }
+    // Returns a Recipe or null if no trigger matches the request)
+    select(trigger: [string][]) : Recipe | null {
+      return null;
+    }
+}

--- a/src/recipe-selector/recipe-selector.ts
+++ b/src/recipe-selector/recipe-selector.ts
@@ -14,8 +14,7 @@ import {Dictionary} from '../runtime/hot.js';
 export class RecipeSelector {
     // Only recipes with “@trigger” annotations get included in the lookup table.
     // Other recipes are silently ignored.
-    // If two triggers could match a request (one trigger is a subset of another) an exception is
-    // thrown.
+    // Specific semantics of overlapping triggers are still TBD.
     constructor(readonly recipes: Recipe[]) {
     }
     // Returns a Recipe or null if no trigger matches the request)

--- a/src/recipe-selector/tests/recipe-selector-test.ts
+++ b/src/recipe-selector/tests/recipe-selector-test.ts
@@ -30,7 +30,7 @@ describe('recipe-selector', () => {
     const r = checkDefined(manifest.recipes[0]);
     assert.lengthOf(manifest.recipes, 1);
     assert.lengthOf(manifest.recipes[0].triggers, 1);
-    assert.deepEqual(manifest.recipes[0].triggers[0], ['key1', 'value1'])
+    assert.deepEqual(manifest.recipes[0].triggers[0], ['key1', 'value1']);
   });
   it('trigger annotations parse with multipe key-value pairs', async () => {
     const manifest = await Manifest.parse(`

--- a/src/recipe-selector/tests/recipe-selector-test.ts
+++ b/src/recipe-selector/tests/recipe-selector-test.ts
@@ -1,0 +1,55 @@
+/**
+ * @license
+ * Copyright (c) 2017 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {assert} from '../../platform/chai-web.js';
+import {checkDefined} from '../../runtime/testing/preconditions.js';
+import {Manifest} from '../../runtime/manifest.js';
+
+describe('recipe-selector', () => {
+  it('trigger annotations parse with one key-value pair', async () => {
+    const manifest = await Manifest.parse(`
+      particle P1
+        out Foo {} foo
+      particle P2
+        in Foo {} bar
+      @trigger
+        key1 value1
+      recipe R
+        P1
+          foo -> h
+        P2
+          bar <- h
+    `);
+    const r = checkDefined(manifest.recipes[0]);
+    assert.lengthOf(manifest.recipes, 1);
+    assert.lengthOf(manifest.recipes[0].triggers, 1);
+    assert.deepEqual(manifest.recipes[0].triggers[0], ['key1', 'value1'])
+  });
+  it('trigger annotations parse with multipe key-value pairs', async () => {
+    const manifest = await Manifest.parse(`
+      particle P1
+        out Foo {} foo
+      particle P2
+        in Foo {} bar
+      @trigger
+        key1 value1
+        key2 value2
+      recipe R
+        P1
+          foo -> h
+        P2
+          bar <- h
+    `);
+    const r = checkDefined(manifest.recipes[0]);
+    assert.lengthOf(manifest.recipes, 1);
+    assert.lengthOf(manifest.recipes[0].triggers, 2);
+    assert.deepEqual(manifest.recipes[0].triggers, [['key1', 'value1'], ['key2', 'value2']]);
+  });
+});

--- a/src/recipe-selector/tests/recipe-selector-test.ts
+++ b/src/recipe-selector/tests/recipe-selector-test.ts
@@ -30,7 +30,8 @@ describe('recipe-selector', () => {
     const r = checkDefined(manifest.recipes[0]);
     assert.lengthOf(manifest.recipes, 1);
     assert.lengthOf(manifest.recipes[0].triggers, 1);
-    assert.deepEqual(manifest.recipes[0].triggers[0], ['key1', 'value1']);
+    assert.lengthOf(manifest.recipes[0].triggers[0], 1);
+    assert.deepEqual(manifest.recipes[0].triggers[0][0], ['key1', 'value1']);
   });
   it('trigger annotations parse with multipe key-value pairs', async () => {
     const manifest = await Manifest.parse(`
@@ -49,7 +50,33 @@ describe('recipe-selector', () => {
     `);
     const r = checkDefined(manifest.recipes[0]);
     assert.lengthOf(manifest.recipes, 1);
-    assert.lengthOf(manifest.recipes[0].triggers, 2);
-    assert.deepEqual(manifest.recipes[0].triggers, [['key1', 'value1'], ['key2', 'value2']]);
+    assert.lengthOf(manifest.recipes[0].triggers, 1);
+    assert.lengthOf(manifest.recipes[0].triggers[0], 2);
+    assert.deepEqual(manifest.recipes[0].triggers[0], [['key1', 'value1'], ['key2', 'value2']]);
   });
-});
+  it('trigger annotations parse with multipe triggers on one recipe', async () => {
+    const manifest = await Manifest.parse(`
+      particle P1
+        out Foo {} foo
+      particle P2
+        in Foo {} bar
+      @trigger
+        key1 value1
+        key2 value2
+      @trigger
+        key3 value3
+      recipe R
+        P1
+          foo -> h
+        P2
+          bar <- h
+    `);
+    const r = checkDefined(manifest.recipes[0]);
+    assert.lengthOf(manifest.recipes, 1);
+    assert.lengthOf(manifest.recipes[0].triggers, 2);
+    assert.lengthOf(manifest.recipes[0].triggers[0], 2);
+    assert.deepEqual(manifest.recipes[0].triggers[0], [['key1', 'value1'], ['key2', 'value2']]);
+    assert.lengthOf(manifest.recipes[0].triggers[1], 1);
+    assert.deepEqual(manifest.recipes[0].triggers[1][0], ['key3', 'value3']);
+  });
+}); 

--- a/src/runtime/manifest-ast-nodes.ts
+++ b/src/runtime/manifest-ast-nodes.ts
@@ -590,7 +590,7 @@ export interface NameAndTagList {
 
 // Aliases to simplify ts-pegjs returnTypes requirement in sigh.
 export type Annotation = string;
-export type Triggers = [string][];
+export type Triggers = [string][][];
 export type Indent = number;
 export type LocalName = string;
 export type Manifest = ManifestItem[];

--- a/src/runtime/manifest-ast-nodes.ts
+++ b/src/runtime/manifest-ast-nodes.ts
@@ -336,6 +336,7 @@ export interface RecipeNode extends BaseNode {
   verbs: VerbList;
   items: RecipeItem[];
   annotation: Annotation;
+  triggers: Triggers;
 }
 
 export interface RecipeParticle extends BaseNode {
@@ -589,6 +590,7 @@ export interface NameAndTagList {
 
 // Aliases to simplify ts-pegjs returnTypes requirement in sigh.
 export type Annotation = string;
+export type Triggers = [string][];
 export type Indent = number;
 export type LocalName = string;
 export type Manifest = ManifestItem[];

--- a/src/runtime/manifest-parser.peg
+++ b/src/runtime/manifest-parser.peg
@@ -72,7 +72,11 @@ Manifest
   {
     const result: AstNode.ManifestItem[] = items.map(item => {
       const manifestItem = item[2];
-      manifestItem.annotation = optional(item[0], a => a[1], null);
+      const annotation = optional(item[0], a => a[1], null);
+      if (Array.isArray(annotation)) {
+        manifestItem.triggers = annotation;
+      }
+      manifestItem.annotation = annotation;
       return manifestItem;
     });
     checkNormal(result);
@@ -90,7 +94,17 @@ ManifestItem
   / Meta
   / Resource
 
-Annotation "an annotation (e.g. @foo)"
+Annotation = Trigger / SimpleAnnotation
+
+Trigger "a trigger for a recipe"
+  = '@trigger' eolWhiteSpace Indent pairs:(eolWhiteSpace? SameIndent lowerIdent whiteSpace lowerIdent)+ {
+  return pairs.map(pair => {
+    return [pair[2], pair[4]];
+  });
+}
+
+
+SimpleAnnotation "an annotation (e.g. @foo)"
   = '@' annotation:lowerIdent { return annotation; }
 
 Resource = 'resource' whiteSpace name:upperIdent eolWhiteSpace Indent SameIndent ResourceStart body:ResourceBody eolWhiteSpace? {

--- a/src/runtime/manifest-parser.peg
+++ b/src/runtime/manifest-parser.peg
@@ -68,15 +68,13 @@
 }
 
 Manifest
-  = eolWhiteSpace? Indent? items:((SameIndent Annotation eolWhiteSpace)? SameIndent ManifestItem)*
+  = eolWhiteSpace? Indent? items:(Annotation SameIndent ManifestItem)*
   {
     const result: AstNode.ManifestItem[] = items.map(item => {
       const manifestItem = item[2];
-      const annotation = optional(item[0], a => a[1], null);
-      if (Array.isArray(annotation)) {
-        manifestItem.triggers = annotation;
-      }
-      manifestItem.annotation = annotation;
+      const annotations = item[0];
+      manifestItem.triggers = annotations.triggerSet;
+      manifestItem.annotation = annotations.simpleAnnotation;
       return manifestItem;
     });
     checkNormal(result);
@@ -94,7 +92,13 @@ ManifestItem
   / Meta
   / Resource
 
-Annotation = Trigger / SimpleAnnotation
+Annotation = triggerSet:(SameIndent Trigger eolWhiteSpace)* simpleAnnotation:(SameIndent SimpleAnnotation eolWhiteSpace)?
+  {
+    return {
+      triggerSet: triggerSet.map(trigger => trigger[1]),
+      simpleAnnotation: optional(simpleAnnotation, s => s[1], null),
+    };
+  }
 
 Trigger "a trigger for a recipe"
   = '@trigger' eolWhiteSpace Indent pairs:(eolWhiteSpace? SameIndent lowerIdent whiteSpace lowerIdent)+ {

--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -696,6 +696,9 @@ ${e.message}
     if (recipeItem.annotation) {
       recipe.annotation = recipeItem.annotation;
     }
+    if (recipeItem.triggers) {
+      recipe.triggers = recipeItem.triggers;
+    }
     if (recipeItem.verbs) {
       recipe.verbs = recipeItem.verbs;
     }

--- a/src/runtime/recipe/recipe.ts
+++ b/src/runtime/recipe/recipe.ts
@@ -47,7 +47,7 @@ export class Recipe implements Cloneable<Recipe> {
   private _cloneMap: CloneMap;
 
   annotation: string | undefined = undefined;
-  triggers: [string][] | undefined = undefined
+  triggers: [string][] | undefined = undefined;
 
   // TODO: Recipes should be collections of records that are tagged
   // with a type. Strategies should register the record types they

--- a/src/runtime/recipe/recipe.ts
+++ b/src/runtime/recipe/recipe.ts
@@ -47,6 +47,7 @@ export class Recipe implements Cloneable<Recipe> {
   private _cloneMap: CloneMap;
 
   annotation: string | undefined = undefined;
+  triggers: [string][] | undefined = undefined
 
   // TODO: Recipes should be collections of records that are tagged
   // with a type. Strategies should register the record types they

--- a/src/runtime/recipe/recipe.ts
+++ b/src/runtime/recipe/recipe.ts
@@ -47,7 +47,7 @@ export class Recipe implements Cloneable<Recipe> {
   private _cloneMap: CloneMap;
 
   annotation: string | undefined = undefined;
-  triggers: [string][] | undefined = undefined;
+  triggers: [string][][] = [];
 
   // TODO: Recipes should be collections of records that are tagged
   // with a type. Strategies should register the record types they


### PR DESCRIPTION
Includes basic tests for parsing, though it could use more (e.g. tests for rejection of invalid triggers).
Also includes a stub of the RecipeSelector.
Bot the above will be addressed in a later PR.
