### PR TITLE
Added RamDisk storage to storageNG.

### DIFF
--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -39,7 +39,7 @@ export class Runtime {
   private loader: Loader | null;
   private composerClass: new () => SlotComposer | null;
   private context: Manifest;
-  private readonly volatileMemory: VolatileMemory;
+  private readonly ramDiskMemory: VolatileMemory;
 
   static getRuntime() {
     if (runtime == null) {
@@ -64,7 +64,7 @@ export class Runtime {
     this.loader = loader;
     this.composerClass = composerClass;
     this.context = context || new Manifest({id: 'manifest:default'});
-    this.volatileMemory = new VolatileMemory();
+    this.ramDiskMemory = new VolatileMemory();
     runtime = this;
     // user information. One persona per runtime for now.
   }
@@ -73,8 +73,8 @@ export class Runtime {
     return this.cacheService;
   }
 
-  getVolatileMemory(): VolatileMemory {
-    return this.volatileMemory;
+  getRamDiskMemory(): VolatileMemory {
+    return this.ramDiskMemory;
   }
 
   destroy() {

--- a/src/runtime/storageNG/drivers/driver-factory.ts
+++ b/src/runtime/storageNG/drivers/driver-factory.ts
@@ -50,9 +50,9 @@ export abstract class Driver<Data> {
 
 export class DriverFactory {
   static clearRegistrationsForTesting() {
-    this.providers = [];
+    this.providers = new Set();
   }
-  static providers: StorageDriverProvider[] = [];
+  static providers: Set<StorageDriverProvider> = new Set();
   static async driverInstance<Data>(storageKey: StorageKey, exists: Exists) {
     for (const provider of this.providers) {
       if (provider.willSupport(storageKey)) {
@@ -63,7 +63,11 @@ export class DriverFactory {
   }
 
   static register(storageDriverProvider: StorageDriverProvider) {
-    this.providers.push(storageDriverProvider);
+    this.providers.add(storageDriverProvider);
+  }
+
+  static unregister(storageDriverProvider: StorageDriverProvider) {
+    this.providers.delete(storageDriverProvider);
   }
 
   static willSupport(storageKey: StorageKey) {

--- a/src/runtime/storageNG/drivers/ramdisk.ts
+++ b/src/runtime/storageNG/drivers/ramdisk.ts
@@ -1,0 +1,65 @@
+/**
+ * @license
+ * Copyright (c) 2019 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {StorageKey} from '../storage-key';
+import {Runtime} from '../../runtime';
+import {StorageDriverProvider, Exists, DriverFactory} from './driver-factory';
+import {VolatileDriver} from './volatile';
+
+export class RamDiskStorageKey extends StorageKey {
+  readonly unique: string;
+
+  constructor(unique: string) {
+    super('ramdisk');
+    this.unique = unique;
+  }
+
+  toString() {
+    return `${this.protocol}://${this.unique}`;
+  }
+
+  childWithComponent(component: string) {
+    return new RamDiskStorageKey(`${this.unique}/${component}`);
+  }
+}
+
+/**
+ * Provides RamDisk storage drivers. RamDisk storage is shared amongst all Arcs,
+ * and will persist for as long as the Arcs Runtime does.
+ * 
+ * This works in the exact same way as Volatile storage, but the memory is not
+ * tied to a specific running Arc.
+ */
+export class RamDiskStorageDriverProvider implements StorageDriverProvider {
+  
+  willSupport(storageKey: StorageKey): boolean {
+    return storageKey.protocol === 'ramdisk';
+  }
+  
+  async driver<Data>(storageKey: StorageKey, exists: Exists) {
+    if (!this.willSupport(storageKey)) {
+      throw new Error(`This provider does not support storageKey ${storageKey.toString()}`);
+    }
+
+    // Use a VolatileDriver backed by the Runtime's RamDisk memory instance.
+    const memory = Runtime.getRuntime().getRamDiskMemory();
+    return new VolatileDriver<Data>(storageKey, exists, memory);
+  }
+
+  static register() {
+    DriverFactory.register(new RamDiskStorageDriverProvider());
+  }
+}
+
+// Note that this will automatically register for any production code
+// that uses ramdisk drivers; but it won't automatically register in 
+// testing; for safety, call RamDiskStorageDriverProvider.register()
+// from your test code somewhere.
+RamDiskStorageDriverProvider.register();

--- a/src/runtime/storageNG/drivers/tests/ramdisk-test.ts
+++ b/src/runtime/storageNG/drivers/tests/ramdisk-test.ts
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright 2019 Google LLC.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+import {RamDiskStorageDriverProvider, RamDiskStorageKey} from '../ramdisk.js';
+import {VolatileStorageKey} from '../volatile.js';
+import {assert} from '../../../../platform/chai-web.js';
+import {ArcId} from '../../../id.js';
+
+// NOTE: Only testing RamDiskStorageDriverProvider. There is no RamDiskDriver
+// (it uses VolatileDriver instead, which is already tested).
+describe('RamDiskStorageDriverProvider', () => {
+  it('supports RamDiskStorageKeys', () => {
+    const provider = new RamDiskStorageDriverProvider();
+    const storageKey = new RamDiskStorageKey('unique');
+    assert.isTrue(provider.willSupport(storageKey));
+  });
+
+  it('does not support VolatileStorageKeys', () => {
+    const provider = new RamDiskStorageDriverProvider();
+    const storageKey = new VolatileStorageKey(ArcId.newForTest('arc'), 'unique');
+    assert.isFalse(provider.willSupport(storageKey));
+  });
+});

--- a/src/runtime/storageNG/drivers/tests/volatile-test.ts
+++ b/src/runtime/storageNG/drivers/tests/volatile-test.ts
@@ -9,53 +9,60 @@
  */
 
 import {assert} from '../../../../platform/chai-web.js';
-import {VolatileDriver, VolatileStorageKey} from '../volatile.js';
+import {VolatileDriver, VolatileStorageKey, VolatileMemory, VolatileStorageDriverProvider} from '../volatile.js';
 import {Exists} from '../driver-factory.js';
 import {Runtime} from '../../../runtime.js';
+import {ArcId} from '../../../id.js';
+import {RamDiskStorageKey} from '../ramdisk.js';
+import {assertThrowsAsync} from '../../../testing/test-util.js';
 
 describe('Volatile Driver', async () => {
 
+  const arcId = ArcId.newForTest('arc');
+  const memory = new VolatileMemory();
+
   afterEach(() => {
+    memory.entries.clear();
     Runtime.clearRuntimeForTesting();
   });
 
   it('can be multiply instantiated against the same storage location', () => {
-    const volatileKey = new VolatileStorageKey('unique');
-    const volatile1 = new VolatileDriver(volatileKey, Exists.ShouldCreate);
-    const volatile2 = new VolatileDriver(volatileKey, Exists.ShouldExist);
+    const volatileKey = new VolatileStorageKey(arcId, 'unique');
+    const volatile1 = new VolatileDriver(volatileKey, Exists.ShouldCreate, memory);
+    const volatile2 = new VolatileDriver(volatileKey, Exists.ShouldExist, memory);
   });
 
   it('treats keys constructed separately as the same if the details are the same', async () => {
-    const key1 = new VolatileStorageKey('test-location');
-    const key2 = new VolatileStorageKey('test-location');
+    const key1 = new VolatileStorageKey(arcId, 'test-location');
+    const key2 = new VolatileStorageKey(arcId, 'test-location');
 
-    const volatile1 = new VolatileDriver(key1, Exists.ShouldCreate);
-    const volatile2 = new VolatileDriver(key2, Exists.ShouldExist);
+    const volatile1 = new VolatileDriver(key1, Exists.ShouldCreate, memory);
+    const volatile2 = new VolatileDriver(key2, Exists.ShouldExist, memory);
   });
 
   it(`can't be instantiated as ShouldExist if the storage location doesn't yet exist`, () => {
-    const volatileKey = new VolatileStorageKey('unique');
-    assert.throws(() => new VolatileDriver(volatileKey, Exists.ShouldExist), `location doesn't exist`);
+    const volatileKey = new VolatileStorageKey(arcId, 'unique');
+    assert.throws(() => new VolatileDriver(volatileKey, Exists.ShouldExist, memory), `location doesn't exist`);
   });
 
   it(`can't be instantiated as ShouldCreate if the storage location already exists`, () => {
-    const volatileKey = new VolatileStorageKey('unique');
-    const volatile1 = new VolatileDriver(volatileKey, Exists.ShouldCreate);
-    assert.throws(() => new VolatileDriver(volatileKey, Exists.ShouldCreate), 'location already exists');
+    const volatileKey = new VolatileStorageKey(arcId, 'unique');
+    const volatile1 = new VolatileDriver(volatileKey, Exists.ShouldCreate, memory);
+    assert.throws(() => new VolatileDriver(volatileKey, Exists.ShouldCreate, memory), 'location already exists');
   });
 
   it('can be instantiated either as a creation or as a connection using MayExist', () => {
-    const volatileKey = new VolatileStorageKey('unique');
-    const volatile1 = new VolatileDriver(volatileKey, Exists.MayExist);
-    const volatile2 = new VolatileDriver(volatileKey, Exists.MayExist);
+    const volatileKey = new VolatileStorageKey(arcId, 'unique');
+    const volatile1 = new VolatileDriver(volatileKey, Exists.MayExist, memory);
+    const volatile2 = new VolatileDriver(volatileKey, Exists.MayExist, memory);
   });
 
   it('transmits a write to a connected driver', async () => {
-    const volatileKey = new VolatileStorageKey('unique');
-    const volatile1 = new VolatileDriver<number>(volatileKey, Exists.ShouldCreate);
+    const volatileKey = new VolatileStorageKey(arcId, 'unique');
+    const volatile1 = new VolatileDriver<number>(volatileKey, Exists.ShouldCreate, memory);
     const recvQueue1: {model: number, version: number}[] = [];
     volatile1.registerReceiver((model: number, version: number) => recvQueue1.push({model, version}));
-    const volatile2 = new VolatileDriver<number>(volatileKey, Exists.ShouldExist);
+    const volatile2 = new VolatileDriver<number>(volatileKey, Exists.ShouldExist, memory);
     const recvQueue2: {model: number, version: number}[] = [];
     volatile2.registerReceiver((model: number, version: number) => recvQueue2.push({model, version}));
 
@@ -65,8 +72,8 @@ describe('Volatile Driver', async () => {
   });
 
   it(`won't accept out-of-date writes`, async () => {
-    const volatileKey = new VolatileStorageKey('unique');
-    const volatile1 = new VolatileDriver<number>(volatileKey, Exists.ShouldCreate);
+    const volatileKey = new VolatileStorageKey(arcId, 'unique');
+    const volatile1 = new VolatileDriver<number>(volatileKey, Exists.ShouldCreate, memory);
 
     assert.strictEqual(true, await volatile1.send(3, 1));
     assert.strictEqual(false, await volatile1.send(4, 0));
@@ -76,11 +83,11 @@ describe('Volatile Driver', async () => {
   });
 
   it('will only accept a given version from one connected driver', async () => {
-    const volatileKey = new VolatileStorageKey('unique');
-    const volatile1 = new VolatileDriver<number>(volatileKey, Exists.ShouldCreate);
+    const volatileKey = new VolatileStorageKey(arcId, 'unique');
+    const volatile1 = new VolatileDriver<number>(volatileKey, Exists.ShouldCreate, memory);
     const recvQueue1: {model: number, version: number}[] = [];
     volatile1.registerReceiver((model: number, version: number) => recvQueue1.push({model, version}));
-    const volatile2 = new VolatileDriver<number>(volatileKey, Exists.ShouldExist);
+    const volatile2 = new VolatileDriver<number>(volatileKey, Exists.ShouldExist, memory);
     const recvQueue2: {model: number, version: number}[] = [];
     volatile2.registerReceiver((model: number, version: number) => recvQueue2.push({model, version}));
 
@@ -91,5 +98,44 @@ describe('Volatile Driver', async () => {
     assert.deepEqual([true, false], results);
     assert.strictEqual(recvQueue1.length, 0);
     assert.deepEqual(recvQueue2, [{model: 3, version: 1}]);
+  });
+});
+
+describe('VolatileStorageDriverProvider', () => {
+  const runtime = Runtime.newForNodeTesting();
+
+  it('supports VolatileStorageKeys for the same Arc ID', () => {
+    const arc = runtime.newArc('arc', 'prefix');
+    const provider = new VolatileStorageDriverProvider(arc);
+    const storageKey = new VolatileStorageKey(arc.id, 'unique');
+    assert.isTrue(provider.willSupport(storageKey));
+  });
+
+  it('does not support VolatileStorageKeys with a different Arc ID', () => {
+    const arc = runtime.newArc('arc', 'prefix');
+    const provider = new VolatileStorageDriverProvider(arc);
+    const storageKey = new VolatileStorageKey(ArcId.newForTest('some-other-arc'), 'unique');
+    assert.isFalse(provider.willSupport(storageKey));
+  });
+
+  it('does not support RamDiskStorageKeys', () => {
+    const arc = runtime.newArc('arc', 'prefix');
+    const provider = new VolatileStorageDriverProvider(arc);
+    const storageKey = new RamDiskStorageKey('unique');
+    assert.isFalse(provider.willSupport(storageKey));
+  });
+
+  it('uses separate memory for each arc', async () => {
+    const arc1 = runtime.newArc('arc1', 'prefix');
+    const arc2 = runtime.newArc('arc2', 'prefix');
+    const provider1 = new VolatileStorageDriverProvider(arc1);
+    const provider2 = new VolatileStorageDriverProvider(arc2);
+    const storageKey1 = new VolatileStorageKey(arc1.id, 'unique');
+    const storageKey2 = new VolatileStorageKey(arc2.id, 'unique');
+
+    await provider1.driver(storageKey1, Exists.ShouldCreate);
+    await provider2.driver(storageKey2, Exists.ShouldCreate);
+    assertThrowsAsync(async () => await provider1.driver(storageKey1, Exists.ShouldCreate));
+    assertThrowsAsync(async () => await provider2.driver(storageKey2, Exists.ShouldCreate));
   });
 });

--- a/src/runtime/storageNG/tests/ramdisk-backing-store-integration-test.ts
+++ b/src/runtime/storageNG/tests/ramdisk-backing-store-integration-test.ts
@@ -11,11 +11,10 @@
 import {assert} from '../../../platform/chai-web.js';
 import {StorageMode, ProxyMessageType, ProxyMessage} from '../store.js';
 import {CRDTCountTypeRecord, CRDTCount, CountOpTypes} from '../../crdt/crdt-count.js';
-import {VolatileStorageKey, VolatileStorageDriverProvider} from '../drivers/volatile.js';
+import {RamDiskStorageKey, RamDiskStorageDriverProvider} from '../drivers/ramdisk';
 import {Exists, DriverFactory} from '../drivers/driver-factory.js';
 import {Runtime} from '../../runtime.js';
 import {BackingStore} from '../backing-store.js';
-import {deepEqual} from 'assert';
 
 function assertHasModel(message: ProxyMessage<CRDTCountTypeRecord>, model: CRDTCount) {
   if (message.type === ProxyMessageType.ModelUpdate) {
@@ -25,10 +24,10 @@ function assertHasModel(message: ProxyMessage<CRDTCountTypeRecord>, model: CRDTC
   }
 }
 
-describe('Volatile + Backing Store Integration', async () => {
+describe('RamDisk + Backing Store Integration', async () => {
 
   beforeEach(() => {
-    VolatileStorageDriverProvider.register();
+    RamDiskStorageDriverProvider.register();
   });
 
   afterEach(() => {
@@ -37,7 +36,7 @@ describe('Volatile + Backing Store Integration', async () => {
 
   it('will allow storage of a number of objects', async () => {
     const runtime = new Runtime();
-    const storageKey = new VolatileStorageKey('unique');
+    const storageKey = new RamDiskStorageKey('unique');
     const store = await BackingStore.construct<CRDTCountTypeRecord>(storageKey, Exists.ShouldCreate, null, StorageMode.Backing, CRDTCount);
 
     const count1 = new CRDTCount();

--- a/src/runtime/storageNG/tests/ramdisk-store-integration-test.ts
+++ b/src/runtime/storageNG/tests/ramdisk-store-integration-test.ts
@@ -11,14 +11,14 @@
 import {assert} from '../../../platform/chai-web.js';
 import {Store, StorageMode, ProxyMessageType} from '../store.js';
 import {CRDTCountTypeRecord, CRDTCount, CountOpTypes} from '../../crdt/crdt-count.js';
-import {VolatileStorageKey, VolatileStorageDriverProvider} from '../drivers/volatile.js';
+import {RamDiskStorageKey, RamDiskStorageDriverProvider} from '../drivers/ramdisk';
 import {Exists, DriverFactory} from '../drivers/driver-factory.js';
 import {Runtime} from '../../runtime.js';
 
-describe('Volatile + Store Integration', async () => {
+describe('RamDisk + Store Integration', async () => {
 
   beforeEach(() => {
-    VolatileStorageDriverProvider.register();
+    RamDiskStorageDriverProvider.register();
   });
 
   afterEach(() => {
@@ -27,7 +27,7 @@ describe('Volatile + Store Integration', async () => {
 
   it('will store a sequence of model and operation updates as models', async () => {
     const runtime = new Runtime();
-    const storageKey = new VolatileStorageKey('unique');
+    const storageKey = new RamDiskStorageKey('unique');
     const store = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldCreate, null, StorageMode.Direct, CRDTCount);
     const activeStore = await store.activate();
 
@@ -42,14 +42,14 @@ describe('Volatile + Store Integration', async () => {
       {type: CountOpTypes.Increment, actor: 'them', version: {from: 0, to: 1}}
     ], id: 1});
 
-    const volatileEntry = runtime.getVolatileMemory().entries.get(storageKey.toString());
+    const volatileEntry = runtime.getRamDiskMemory().entries.get(storageKey.toString());
     assert.deepEqual(volatileEntry.data, activeStore['localModel'].getData());
     assert.strictEqual(volatileEntry.version, 3);
   });
 
   it('will store operation updates from multiple sources', async () => {
     const runtime = new Runtime();
-    const storageKey = new VolatileStorageKey('unique');
+    const storageKey = new RamDiskStorageKey('unique');
     const store1 = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldCreate, null, StorageMode.Direct, CRDTCount);
     const activeStore1 = await store1.activate();
 
@@ -82,7 +82,7 @@ describe('Volatile + Store Integration', async () => {
     await activeStore1.idle();
     await activeStore2.idle();
 
-    const volatileEntry = runtime.getVolatileMemory().entries.get(storageKey.toString());
+    const volatileEntry = runtime.getRamDiskMemory().entries.get(storageKey.toString());
     assert.deepEqual(volatileEntry.data, activeStore1['localModel'].getData());
     assert.strictEqual(volatileEntry.version, 3);
   });
@@ -90,7 +90,7 @@ describe('Volatile + Store Integration', async () => {
   it('will store operation updates from multiple sources with some timing delays', async () => {
     // store1.onProxyMessage, DELAY, DELAY, DELAY, store1.onProxyMessage, store2.onProxyMessage, DELAY, DELAY, DELAY, store2.onProxyMessage, DELAY, DELAY, DELAY, DELAY, DELAY
     const runtime = new Runtime();
-    const storageKey = new VolatileStorageKey('unique');
+    const storageKey = new RamDiskStorageKey('unique');
     const store1 = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldCreate, null, StorageMode.Direct, CRDTCount);
     const activeStore1 = await store1.activate();
 
@@ -127,7 +127,7 @@ describe('Volatile + Store Integration', async () => {
     await activeStore1.idle();
     await activeStore2.idle();
 
-    const volatileEntry = runtime.getVolatileMemory().entries.get(storageKey.toString());
+    const volatileEntry = runtime.getRamDiskMemory().entries.get(storageKey.toString());
     assert.deepEqual(volatileEntry.data, activeStore1['localModel'].getData());
     assert.strictEqual(volatileEntry.version, 4);
   });

--- a/src/runtime/storageNG/tests/store-sequence-test.ts
+++ b/src/runtime/storageNG/tests/store-sequence-test.ts
@@ -20,6 +20,7 @@ import {Dictionary} from '../../hot.js';
 import {MockFirebaseStorageDriverProvider} from '../testing/mock-firebase.js';
 import {FirebaseStorageKey} from '../drivers/firebase.js';
 import {MockStorageKey, MockStorageDriverProvider} from '../testing/test-storage.js';
+import {Arc} from '../../arc.js';
 
 let testKey: StorageKey;
 
@@ -171,9 +172,10 @@ describe('Store Sequence', async () => {
     const sequenceTest = new SequenceTest<{store1: ActiveStore<CRDTCountTypeRecord>, store2: ActiveStore<CRDTCountTypeRecord>}>();
     sequenceTest.setTestConstructor(async () => {
       const runtime = new Runtime();
+      const arc = runtime.newArc('arc', 'volatile://');
       DriverFactory.clearRegistrationsForTesting();
-      VolatileStorageDriverProvider.register();
-      const storageKey = new VolatileStorageKey('unique');
+      VolatileStorageDriverProvider.register(arc);
+      const storageKey = new VolatileStorageKey(arc.id, 'unique');
       const store1 = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldCreate, null, StorageMode.Direct, CRDTCount);
       const activeStore1 = await store1.activate();
   
@@ -275,9 +277,10 @@ describe('Store Sequence', async () => {
     const sequenceTest = new SequenceTest();
     sequenceTest.setTestConstructor(async () => {
       const runtime = new Runtime();
+      const arc = runtime.newArc('arc', 'volatile://');
       DriverFactory.clearRegistrationsForTesting();
-      VolatileStorageDriverProvider.register();
-      const storageKey = new VolatileStorageKey('unique');
+      VolatileStorageDriverProvider.register(arc);
+      const storageKey = new VolatileStorageKey(arc.id, 'unique');
       const store1 = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldCreate, null, StorageMode.Direct, CRDTCount);
       const activeStore1 = await store1.activate();
   


### PR DESCRIPTION
VolatileDriver now takes a memory argument, which tells it where to
write to.

The existing Volatile driver was actually using storage scoped to the
whole Arcs Runtime (i.e. it was actually RamDisk storage). I pulled that
out into its own thing (RamDiskStorageKey/RamDiskStorageDriverProvider).
It uses VolatileDriver to do all its dirty work.

Modified VolatileStorageKey/VolatileStorageDriverProvider to operate on
a single Arc, and gave each Arc instance its own volatile memory
instance.

Now Volatile storage is correctly scoped to a running Arc, and RamDisk
storage is scoped to the Arcs Runtime.