### PR TITLE
Add wasm particle API tests; currently C++ only

### DIFF
--- a/particles/WasmTemplate/wasm.json
+++ b/particles/WasmTemplate/wasm.json
@@ -2,7 +2,6 @@
   "module.wasm": {
     "manifest": "example.arcs",
     "src": ["example.cc"],
-    "outDir": "$here",
-    "linkManifest": false
+    "outDir": "$here"
   }
 }

--- a/src/runtime/fake-pec-factory.ts
+++ b/src/runtime/fake-pec-factory.ts
@@ -19,10 +19,8 @@ import {Id, IdGenerator} from './id.js';
 export function FakePecFactory(loader: Loader): PecFactory {
   return (pecId: Id, idGenerator: IdGenerator) => {
     const channel = new MessageChannel();
-    // Each PEC should get its own loader. Only a StubLoader knows how to be cloned,
-    // so its either a clone of a Stub or a new Loader.
-    const loaderToUse = loader instanceof StubLoader ? (loader as StubLoader).clone() : new Loader();
-    const pec = new ParticleExecutionContext(channel.port1, pecId, idGenerator, loaderToUse);
+    // Each PEC should get its own loader.
+    const pec = new ParticleExecutionContext(channel.port1, pecId, idGenerator, loader.clone());
     return channel.port2;
   };
 }

--- a/src/runtime/loader.ts
+++ b/src/runtime/loader.ts
@@ -162,4 +162,8 @@ export class Loader {
     assert(this.pec);
     return particleWrapper({Particle, DomParticle, TransformationDomParticle, MultiplexerDomParticle, Reference: ClientReference.newClientReference(this.pec), html});
   }
+
+  clone(): Loader {
+    return new Loader();
+  }
 }

--- a/src/runtime/storage/volatile-storage.ts
+++ b/src/runtime/storage/volatile-storage.ts
@@ -445,7 +445,7 @@ export class VolatileSingleton extends VolatileStorageProvider implements Single
     return this._stored;
   }
 
-  async set(value : {id: string}, originatorId: string = null, barrier: string = null): Promise<void> {
+  async set(value, originatorId: string = null, barrier: string = null): Promise<void> {
     assert(value !== undefined);
     if (this.referenceMode && value) {
       // Even if this value is identical to the previously written one,
@@ -459,7 +459,7 @@ export class VolatileSingleton extends VolatileStorageProvider implements Single
 
       // It's important to store locally first, as the upstream consumers
       // are set up to assume all writes are processed (at least locally) synchronously.
-      this._stored = {id: value.id, storageKey} as {id: string};
+      this._stored = {id: value.id, storageKey};
 
       await this.ensureBackingStore();
 

--- a/src/runtime/testing/fake-slot-composer.ts
+++ b/src/runtime/testing/fake-slot-composer.ts
@@ -11,6 +11,8 @@
 import {ModalityHandler} from '../modality-handler.js';
 import {SlotComposer, SlotComposerOptions} from '../slot-composer.js';
 import {SlotContext} from '../slot-context.js';
+import {Particle} from '../recipe/particle.js';
+import {Content} from '../slot-consumer.js';
 
 /**
  * A helper class for NodeJS tests that mimics SlotComposer without relying on DOM APIs.
@@ -25,7 +27,7 @@ export class FakeSlotComposer extends SlotComposer {
       ...options});
   }
 
-  renderSlot(particle, slotName, content) {
+  renderSlot(particle: Particle, slotName: string, content: Content) {
     super.renderSlot(particle, slotName, content);
 
     // In production updateProvidedContexts() is done in DOM Mutation Observer.
@@ -50,7 +52,7 @@ export class RozSlotComposer extends FakeSlotComposer {
   // tslint:disable-next-line: no-any
   public received: [string, string, any][] = [];
 
-  renderSlot(particle, slotName, content) {
+  renderSlot(particle: Particle, slotName: string, content: Content) {
     // super.renderSlot may modify 'content', so record a copy of it before calling that.
     const copy = JSON.parse(JSON.stringify(content));
     if (copy.templateName) {

--- a/src/runtime/testing/fake-slot-composer.ts
+++ b/src/runtime/testing/fake-slot-composer.ts
@@ -38,3 +38,31 @@ export class FakeSlotComposer extends SlotComposer {
     return this._contexts;
   }
 }
+
+/**
+ * A helper SlotComposer that records renderSlot calls.
+ *
+ *   I'm watching you, Wazowski. Always watching...
+ */
+export class RozSlotComposer extends FakeSlotComposer {
+  // To make test assertions more concise, renderSlot calls are recorded as tuples of
+  // (particle-name, slot-name, render-content) rather than objects with similarly named keys.
+  // tslint:disable-next-line: no-any
+  public received: [string, string, any][] = [];
+
+  renderSlot(particle, slotName, content) {
+    // super.renderSlot may modify 'content', so record a copy of it before calling that.
+    const copy = JSON.parse(JSON.stringify(content));
+    if (copy.templateName) {
+      // Currently templateName can only ever be 'default'; no need to keep checking that in tests.
+      // If this ever changes, blow up here so we catch the change early.
+      if (copy.templateName !== 'default') {
+        throw new Error(`renderSlot called with templateName set to '${copy.templateName}' ` +
+                        `instead of 'default'; some unit tests will probably need updating`);
+      }
+      delete copy.templateName;
+    }
+    this.received.push([particle.name, slotName, copy]);
+    super.renderSlot(particle, slotName, content);
+  }
+}

--- a/src/runtime/wasm.ts
+++ b/src/runtime/wasm.ts
@@ -509,7 +509,7 @@ export class WasmParticle extends Particle {
   private revHandleMap = new Map<WasmAddress, Handle>();
   private converters = new Map<Handle, EntityPackager>();
 
-  constructor(id:string, container: WasmContainer) {
+  constructor(id: string, container: WasmContainer) {
     super();
     this.id = id;
     this.container = container;

--- a/src/runtime/wasm.ts
+++ b/src/runtime/wasm.ts
@@ -16,6 +16,8 @@ import {Handle, Singleton, Collection} from './handle.js';
 import {Content} from './slot-consumer.js';
 import {Dictionary} from './hot.js';
 import {Loader} from './loader.js';
+import {PECInnerPort} from './api-channel.js';
+import {UserException} from './arc-exceptions.js';
 
 // Encodes/decodes the wire format for transferring entities over the wasm boundary.
 // Note that entities must have an id before serializing for use in a wasm particle.
@@ -405,6 +407,7 @@ type WasmAddress = number;
 // Holds an instance of a running wasm module, which may contain multiple particles.
 export class WasmContainer {
   loader: Loader;
+  apiPort: PECInnerPort;
   memory: WebAssembly.Memory;
   heapU8: Uint8Array;
   heap32: Int32Array;
@@ -413,8 +416,9 @@ export class WasmContainer {
   exports: any;
   particleMap = new Map<WasmAddress, WasmParticle>();
 
-  constructor(loader: Loader) {
+  constructor(loader: Loader, apiPort: PECInnerPort) {
     this.loader = loader;
+    this.apiPort = apiPort;
   }
 
   async initialize(buffer: ArrayBuffer) {
@@ -496,6 +500,7 @@ export class WasmContainer {
 
 // Creates and interfaces to a particle inside a WasmContainer's module.
 export class WasmParticle extends Particle {
+  private id: string;
   private container: WasmContainer;
   // tslint:disable-next-line: no-any
   private exports: any;
@@ -504,8 +509,9 @@ export class WasmParticle extends Particle {
   private revHandleMap = new Map<WasmAddress, Handle>();
   private converters = new Map<Handle, EntityPackager>();
 
-  constructor(container: WasmContainer) {
+  constructor(id:string, container: WasmContainer) {
     super();
+    this.id = id;
     this.container = container;
     this.exports = container.exports;
 
@@ -634,7 +640,10 @@ export class WasmParticle extends Particle {
   private getHandle(wasmHandle: WasmAddress) {
     const handle = this.revHandleMap.get(wasmHandle);
     if (!handle) {
-      throw new Error(`wasm particle '${this.spec.name}' attempted to write to unconnected handle`);
+      const err = new Error(`wasm particle '${this.spec.name}' attempted to write to unconnected handle`);
+      const userException = new UserException(err, 'WasmParticle::getHandle', this.id, this.spec.name);
+      this.container.apiPort.ReportExceptionInHost(userException);
+      throw err;
     }
     return handle;
   }

--- a/src/wasm/cpp/README.md
+++ b/src/wasm/cpp/README.md
@@ -10,11 +10,10 @@ See [here](particles/WasmTemplate) for a working example.
   
   ```json5
   {
-    "module.wasm": {                // output filename for the compiled wasm module
-      "manifest": "example.arcs",   // manifest file; defines the recipe, particle spec and schemas
-      "src": ["example.cc"],        // only a single source file is supported for now
-      "outDir": "$here",            // location of wasm module (and schema2packager output)
-      "linkManifest": false         // true for unit tests
+    "module.wasm": {               // output filename for the compiled wasm module
+      "manifest": "example.arcs",  // manifest file; defines the recipe, particle spec and schemas
+      "src": ["example.cc"],       // only a single source file is supported for now
+      "outDir": "$here"            // location of wasm module and schema2packager output
     }
   }
   ```

--- a/src/wasm/cpp/tests/particles.cc
+++ b/src/wasm/cpp/tests/particles.cc
@@ -1,29 +1,159 @@
 #include <arcs.h>
-#include <test-arcs.h>
+#include <schemas-arcs.h>
 
-class PassThrough : public arcs::Particle {
+class HandleSyncUpdateTest : public arcs::Particle {
 public:
-  PassThrough() {
-    registerHandle("input", input_);
+  HandleSyncUpdateTest() {
+    registerHandle("input1", input1_);
+    registerHandle("input2", input2_);
     registerHandle("output", output_);
   }
 
-  void onHandleSync(arcs::Handle* handle, bool all_synced) override {
-    onHandleUpdate(handle);
+  void onHandleSync(const std::string& name, bool all_synced) override {
+    arcs::Data out;
+    out.set_txt("sync:" + name);
+    out.set_flg(all_synced);
+    output_.store(&out);
   }
 
-  void onHandleUpdate(arcs::Handle* handle) override {
-    const arcs::Data& data = input_.get();
+  void onHandleUpdate(const std::string& name) override {
     arcs::Data out;
-    if (data.has_num()) out.set_num(data.num() * 2);
-    if (data.has_txt()) out.set_txt(data.txt() + "!");
-    if (data.has_lnk()) out.set_lnk(data.lnk() + "#");
-    if (data.has_flg()) out.set_flg(!data.flg());
+    if (auto input = getSingleton<arcs::Data>(name)) {
+      out.set_txt("update:" + name);
+      out.set_num(input->get().num());
+    } else {
+      out.set_txt("unexpected handle name: " + name);
+    }
+    output_.store(&out);
+  }
+
+  arcs::Singleton<arcs::Data> input1_;
+  arcs::Singleton<arcs::Data> input2_;
+  arcs::Collection<arcs::Data> output_;
+};
+
+DEFINE_PARTICLE(HandleSyncUpdateTest)
+
+
+class RenderTest : public arcs::Particle {
+public:
+  RenderTest() {
+    registerHandle("flags", flags_);
+  }
+
+  std::string getTemplate(const std::string& slot_name) override {
+    return "abc";
+  }
+
+  void populateModel(const std::string& slot_name, arcs::Dictionary* model) override {
+    model->emplace("foo", "bar");
+  }
+
+  void onHandleUpdate(const std::string& name) override {
+    const arcs::RenderFlags& flags = flags_.get();
+    renderSlot("root", flags._template(), flags.model());
+  }
+
+  arcs::Singleton<arcs::RenderFlags> flags_;
+};
+
+DEFINE_PARTICLE(RenderTest)
+
+
+class AutoRenderTest : public arcs::Particle {
+public:
+  AutoRenderTest() {
+    registerHandle("data", data_);
+    autoRender();
+  }
+
+  std::string getTemplate(const std::string& slot_name) override {
+    const arcs::Data& data = data_.get();
+    return data.has_txt() ? data.txt() : "empty";
+  }
+
+  arcs::Singleton<arcs::Data> data_;
+};
+
+DEFINE_PARTICLE(AutoRenderTest)
+
+
+class EventsTest : public arcs::Particle {
+public:
+  EventsTest() {
+    registerHandle("output", output_);
+  }
+
+  void fireEvent(const std::string& slot_name, const std::string& handler) override {
+    arcs::Data out;
+    out.set_txt("event:" + slot_name + ":" + handler);
     output_.set(&out);
   }
 
-  arcs::Singleton<arcs::Data> input_;
+private:
   arcs::Singleton<arcs::Data> output_;
 };
 
-DEFINE_PARTICLE(PassThrough)
+DEFINE_PARTICLE(EventsTest)
+
+
+class ServicesTest : public arcs::Particle {
+public:
+  ServicesTest() {
+    registerHandle("output", output_);
+  }
+
+  void init() override {
+    std::string url = resolveUrl("$resolve-me");
+    arcs::ServiceResponse out;
+    out.set_call("resolveUrl");
+    out.set_payload(url);
+    output_.store(&out);
+
+    serviceRequest("random.next", {}, "first");
+    serviceRequest("random.next", {}, "second");
+    serviceRequest("clock.now", {{"timeUnit", "DAYS"}});
+  }
+
+  void serviceResponse(const std::string& call, const arcs::Dictionary& response, const std::string& tag) override {
+    std::string payload;
+    for (const auto& pair : response) {
+      payload += pair.first + ":" + pair.second + ";";
+    }
+
+    arcs::ServiceResponse out;
+    out.set_call(call);
+    out.set_tag(tag);
+    out.set_payload(payload);
+    output_.store(&out);
+  }
+
+private:
+  arcs::Collection<arcs::ServiceResponse> output_;
+};
+
+DEFINE_PARTICLE(ServicesTest)
+
+
+class MissingRegisterHandleTest : public arcs::Particle {
+};
+
+DEFINE_PARTICLE(MissingRegisterHandleTest)
+
+
+class UnconnectedHandlesTest : public arcs::Particle {
+public:
+  UnconnectedHandlesTest() {
+    registerHandle("data", data_);
+  }
+
+  void fireEvent(const std::string& slot_name, const std::string& handler) override {
+    arcs::Data data;
+    data_.set(&data);
+  }
+
+private:
+  arcs::Singleton<arcs::Data> data_;
+};
+
+DEFINE_PARTICLE(UnconnectedHandlesTest)

--- a/src/wasm/cpp/tests/schemas.arcs
+++ b/src/wasm/cpp/tests/schemas.arcs
@@ -1,0 +1,14 @@
+schema Data
+  Number num
+  Text txt
+  URL lnk
+  Boolean flg
+
+schema RenderFlags
+  Boolean template
+  Boolean model
+
+schema ServiceResponse
+  Text call
+  Text tag
+  Text payload

--- a/src/wasm/cpp/tests/test.arcs
+++ b/src/wasm/cpp/tests/test.arcs
@@ -1,9 +1,0 @@
-schema Data
-  Number num
-  Text txt
-  URL lnk
-  Boolean flg
-
-particle PassThrough in 'test-module.wasm'
-  in Data input
-  out Data output

--- a/src/wasm/cpp/tests/wasm-cpp-test.ts
+++ b/src/wasm/cpp/tests/wasm-cpp-test.ts
@@ -11,11 +11,39 @@ import {assert} from '../../../platform/chai-web.js';
 import {Loader} from '../../../runtime/loader.js';
 import {Manifest} from '../../../runtime/manifest.js';
 import {Runtime} from '../../../runtime/runtime.js';
-import {FakeSlotComposer} from '../../../runtime/testing/fake-slot-composer.js';
-import {SingletonStorageProvider} from '../../../runtime/storage/storage-provider-base.js';
-import * as util from '../../../runtime/testing/test-util.js';
+import {RozSlotComposer} from '../../../runtime/testing/fake-slot-composer.js';
+import {VolatileSingleton, VolatileCollection} from '../../../runtime/storage/volatile-storage.js';
+import {assertThrowsAsync} from '../../../runtime/testing/test-util.js';
 
-describe('wasm C++ tests', () => {
+const schemasFile = 'src/wasm/cpp/tests/schemas.arcs';
+const wasmFile = 'build/wasm/cpp/tests/test-module.wasm';
+
+class TestLoader extends Loader {
+  resolve(path: string) {
+    return (path[0] === '$') ? `RESOLVED(${path})`: path;
+  }
+
+  clone(): TestLoader {
+    return this;
+  }
+}
+
+async function setup(manifestString) {
+  const loader = new TestLoader();
+  const manifest = await Manifest.parse(manifestString, {loader, fileName: process.cwd() + '/input.arcs'});
+  const runtime = new Runtime(loader, RozSlotComposer, manifest);
+  const arc = runtime.newArc('wasm-test', 'volatile://');
+
+  const recipe = arc.context.recipes[0];
+  recipe.normalize();
+  await arc.instantiate(recipe);
+  await arc.idle;
+
+  const [info] = arc.loadedParticleInfo.values();
+  return {arc, stores: info.stores, slotComposer: arc.pec.slotComposer as RozSlotComposer};
+}
+
+describe('wasm tests (C++)', () => {
   // TODO: https://github.com/PolymerLabs/arcs/issues/3418
   before(function() {
     if (!global['testFlags'].enableWasm) {
@@ -23,44 +51,180 @@ describe('wasm C++ tests', () => {
     }
   });
 
-  it('simple entity passthrough', async () => {
-    const loader = new Loader();
-    const manifest = await Manifest.parse(`
-      import 'build/wasm/cpp/tests/test.arcs'
+  it('onHandleSync / onHandleUpdate', async () => {
+    const {arc, stores} = await setup(`
+      import '${schemasFile}'
+
+      particle HandleSyncUpdateTest in '${wasmFile}'
+        in Data input1
+        in Data input2
+        out [Data] output
+
       recipe
-        PassThrough
-          input <- h0
+        HandleSyncUpdateTest
+          input1 <- h1
+          input2 <- h2
+          output -> h3
+      `);
+    const input1 = stores.get('input1') as VolatileSingleton;
+    const input2 = stores.get('input2') as VolatileSingleton;
+    const output = stores.get('output') as VolatileCollection;
+
+    // onHandleSync: txt = 'sync:<handle-name>'; flag = all_synced
+    // The order in which handles are synchronized isn't guaranteed, so allow for either result.
+    const syncs = (await output.toList()).map(e => e.rawData);
+    const expected = ['sync:input1', 'sync:input2'];
+    if (syncs[0].txt === expected[0]) {
+      assert.deepStrictEqual(syncs, [{txt: expected[0], flg: false}, {txt: expected[1], flg: true}]);
+    } else {
+      assert.deepStrictEqual(syncs, [{txt: expected[1], flg: false}, {txt: expected[0], flg: true}]);
+    }
+    await output.clearItemsForTesting();
+
+    await input1.set({id: 'i1', rawData: {num: 3}});
+    await input2.set({id: 'i2', rawData: {num: 7}});
+    await arc.idle;
+
+    // onHandleUpdate: txt = 'update:<handle-name>'; num = input.num
+    // The updates order should match the set() calls above.
+    const updates = (await output.toList()).map(e => e.rawData);
+    assert.deepStrictEqual(updates, [{txt: 'update:input1', num: 3}, {txt: 'update:input2', num: 7}]);
+  });
+
+  it('getTemplate / populateModel / renderSlot', async () => {
+    const {arc, stores, slotComposer} = await setup(`
+      import '${schemasFile}'
+
+      particle RenderTest in '${wasmFile}'
+        consume root
+        in RenderFlags flags
+
+      recipe
+        slot 'rootslotid-root' as slot1
+        RenderTest
+          consume root as slot1
+          flags <- h1
+      `);
+    const flags = stores.get('flags') as VolatileSingleton;
+
+    await flags.set({id: 'i1', rawData: {template: false, model: true}});
+    await arc.idle;
+
+    await flags.set({id: 'i2', rawData: {template: true, model: false}});
+    await arc.idle;
+
+    await flags.set({id: 'i3', rawData: {template: true, model: true}});
+    await arc.idle;
+
+    // First renderSlot call is initiated by the runtime; remaining ones are triggered by writing
+    // to the 'flags' handle.
+    assert.deepStrictEqual(slotComposer.received, [
+      ['RenderTest', 'root', {template: 'abc', model: {foo: 'bar'}}],
+      ['RenderTest', 'root', {model: {foo: 'bar'}}],
+      ['RenderTest', 'root', {template: 'abc'}],
+      ['RenderTest', 'root', {template: 'abc', model: {foo: 'bar'}}]
+    ]);
+  });
+
+  it('autoRender', async () => {
+    const {arc, stores, slotComposer} = await setup(`
+      import '${schemasFile}'
+
+      resource DataResource
+        start
+        [{"txt": "initial"}]
+      store DataStore of Data in DataResource
+
+      particle AutoRenderTest in '${wasmFile}'
+        consume root
+        in Data data
+
+      recipe
+        copy DataStore as h1
+        slot 'rootslotid-root' as slot1
+        AutoRenderTest
+          consume root as slot1
+          data <- h1
+      `);
+    const data = stores.get('data') as VolatileSingleton;
+
+    await data.set({id: 'i1', rawData: {txt: 'update'}});
+    await arc.idle;
+
+    // First renderSlot call is initiated by the runtime, before handles are synced.
+    // With auto-render enabled, the second call occurs after sync and the third on handle update.
+    assert.deepStrictEqual(slotComposer.received, [
+      ['AutoRenderTest', 'root', {template: 'empty', model: {}}],
+      ['AutoRenderTest', 'root', {template: 'initial', model: {}}],
+      ['AutoRenderTest', 'root', {template: 'update', model: {}}],
+    ]);
+  });
+
+  it('fireEvent', async () => {
+    const {arc, stores, slotComposer} = await setup(`
+      import '${schemasFile}'
+
+      particle EventsTest in '${wasmFile}'
+        consume root
+        out Data output
+
+      recipe
+        slot 'rootslotid-root' as slot1
+        EventsTest
+          consume root as slot1
           output -> h1
-      `, {loader, fileName: process.cwd() + '/input.arcs'});
+      `);
+    const output = stores.get('output') as VolatileSingleton;
 
-    const runtime = new Runtime(loader, FakeSlotComposer, manifest);
-    const arc = runtime.newArc('wasm-test', 'volatile://');
-    const recipe = arc.context.recipes[0];
-    recipe.normalize();
-    await arc.instantiate(recipe);
+    const particle = slotComposer.consumers[0].consumeConn.particle;
+    arc.pec.sendEvent(particle, 'root', {handler: 'icanhazclick', data: 'ignored'});
     await arc.idle;
 
-    const [info] = arc.loadedParticleInfo.values();
-    const input = info.stores.get('input') as SingletonStorageProvider;
-    const output = info.stores.get('output') as SingletonStorageProvider;
+    assert.deepStrictEqual((await output.get()).rawData, {txt: 'event:root:icanhazclick'});
+  });
 
-    const empty = await output.get();
-    assert.deepEqual(empty.rawData, {});
+  it('serviceRequest / serviceResponse / resolveUrl', async () => {
+    const {stores} = await setup(`
+      import '${schemasFile}'
 
-    // Set all fields on the input.
-    await input.set({id: 'i0', rawData: {num: 12, txt: 'abc', lnk: 'http://def', flg: true}});
-    await arc.idle;
-    const all = await output.get();
-    assert.notEqual(all.id, '', 'output entity should have an id');
-    assert.notEqual(all.id, 'i0', 'output id should not be the same as the input');
-    assert.deepEqual(all.rawData, {num: 24, txt: 'abc!', lnk: 'http://def#', flg: false});
+      particle ServicesTest in '${wasmFile}'
+        out [ServiceResponse] output
 
-    // Set some fields on the input.
-    await input.set({id: 'i1', rawData: {txt: 'abc', flg: false}});
-    await arc.idle;
-    const some = await output.get();
-    assert.notEqual(some.id, '', 'output entity should have an id');
-    assert.notEqual(some.id, 'i1', 'output id should not be the same as the input');
-    assert.deepEqual(some.rawData, {txt: 'abc!', flg: true});
+      recipe
+        ServicesTest
+          output -> h1
+      `);
+    const output = stores.get('output') as VolatileCollection;
+
+    const results = (await output.toList()).map(e => e.rawData);
+    assert.lengthOf(results, 4);
+
+    assert.deepStrictEqual(results[0], {call: 'resolveUrl', payload: 'RESOLVED($resolve-me)'});
+
+    const verifyRandom = (result, tag) => {
+      assert.strictEqual(result.call, 'random.next');
+      assert.strictEqual(result.tag, tag);
+      assert.match(result.payload, /^value:0\.[0-9]+;$/);  // eg. 'value:0.33731562467426324;'
+    };
+    verifyRandom(results[1], 'first');
+    verifyRandom(results[2], 'second');
+
+    const clock = results[3];
+    assert.strictEqual(clock.call, 'clock.now');
+    assert.strictEqual(clock.tag, '');
+    assert.match(clock.payload, /^value:20[0-9]{2}-[0-9]{2}-[0-9]{2};$/);  // eg. 'value:2019-11-07;'
+  });
+
+  it('missing registerHandle', async () => {
+    assertThrowsAsync(async () => await setup(`
+      import '${schemasFile}'
+
+      particle MissingRegisterHandleTest in '${wasmFile}'
+        in Data input
+
+      recipe
+        MissingRegisterHandleTest
+          input <- h1
+    `), `Wasm particle failed to connect handle 'input'`);
   });
 });

--- a/src/wasm/cpp/tests/wasm-cpp-test.ts
+++ b/src/wasm/cpp/tests/wasm-cpp-test.ts
@@ -199,17 +199,17 @@ describe('wasm tests (C++)', () => {
     const results = (await output.toList()).map(e => e.rawData);
     assert.lengthOf(results, 4);
 
-    assert.deepStrictEqual(results[0], {call: 'resolveUrl', payload: 'RESOLVED($resolve-me)'});
+    const resolve = results.shift();
+    assert.deepStrictEqual(resolve, {call: 'resolveUrl', payload: 'RESOLVED($resolve-me)'});
 
-    const verifyRandom = (result, tag) => {
-      assert.strictEqual(result.call, 'random.next');
-      assert.strictEqual(result.tag, tag);
-      assert.match(result.payload, /^value:0\.[0-9]+;$/);  // eg. 'value:0.33731562467426324;'
-    };
-    verifyRandom(results[1], 'first');
-    verifyRandom(results[2], 'second');
+    for (const tag of ['first', 'second']) {
+      const random = results.shift();
+      assert.strictEqual(random.call, 'random.next');
+      assert.strictEqual(random.tag, tag);
+      assert.match(random.payload, /^value:0\.[0-9]+;$/);  // eg. 'value:0.33731562467426324;'
+    }
 
-    const clock = results[3];
+    const clock = results.shift();
     assert.strictEqual(clock.call, 'clock.now');
     assert.strictEqual(clock.tag, '');
     assert.match(clock.payload, /^value:20[0-9]{2}-[0-9]{2}-[0-9]{2};$/);  // eg. 'value:2019-11-07;'

--- a/src/wasm/cpp/tests/wasm.json
+++ b/src/wasm/cpp/tests/wasm.json
@@ -1,8 +1,7 @@
 {
   "test-module.wasm": {
-    "manifest": "test.arcs",
+    "manifest": "schemas.arcs",
     "src": ["particles.cc"],
-    "outDir": "build/wasm/cpp/tests",
-    "linkManifest": true
+    "outDir": "build/wasm/cpp/tests"
   }
 }

--- a/src/wasm/cpp/wasm.json
+++ b/src/wasm/cpp/wasm.json
@@ -2,7 +2,6 @@
   "output.wasm": {
     "manifest": "working.arcs",
     "src": ["working.cc"],
-    "outDir": "$here",
-    "linkManifest": false
+    "outDir": "$here"
   }
 }


### PR DESCRIPTION
- only executed when invoked via 'sigh wasmTest'; more work required to merge into the standard 'test'
- removes the somewhat magic 'linkManifest' option in wasm.json; tests just use explicit file paths
- adds RozSlotComposer to simply record renderSlot calls for after-the-fact verification
- sets up more versatile Loader.clone() so tests can make custom Loaders more easily
- some API tweaks inside the C++ particle code