### PR TITLE
Slandles set test

### DIFF
--- a/particles/Products/SLANDLESProducts.arcs
+++ b/particles/Products/SLANDLESProducts.arcs
@@ -23,12 +23,14 @@ recipe SlandleProducts
 
 recipe SlandleCreateShoppingList
   copy as products
+  `slot 'rootslotid-root' as root
   SlandleItems
+    root consume root
     list = products
   SlandleItemMultiplexer
     list = products
     hostedParticle = SlandleProductItem
-  description `create shopping list from ${Items.list}`
+  description `create shopping list from ${SlandleItems.list} using Slandles`
 
 recipe SlandleShopForOccasion
   use as shoplist

--- a/particles/Products/SLANDLESRecommend.arcs
+++ b/particles/Products/SLANDLESRecommend.arcs
@@ -23,7 +23,7 @@ particle SlandleChooser in 'source/Chooser.js'
   in [~a] choices
   inout [~a] resultList
   `consume Slot action
-    `provide [Slot{handle: choices}] annotation
+    `provide? [Slot{handle: choices}] annotation
   description `add items from ${person}'s ${choices}`
 
 particle SlandleAlsoOn in 'source/AlsoOn.js'

--- a/src/runtime/recipe/recipe.ts
+++ b/src/runtime/recipe/recipe.ts
@@ -254,13 +254,16 @@ export class Recipe implements Cloneable<Recipe> {
   }
 
   _isValid(options: IsValidOptions = undefined): boolean {
+    const checkAllValid = (list: {_isValid: (options: IsValidOptions) => boolean}[]) => list.every(
+      item => item._isValid(options)
+    );
     return !this._findDuplicate(this._handles, options)
         && !this._findDuplicate(this._slots, options)
-        && this._handles.every(handle => handle._isValid(options))
-        && this._particles.every(particle => particle._isValid(options))
-        && this._slots.every(slot => slot._isValid(options))
-        && this.handleConnections.every(connection => connection._isValid(options))
-        && this.slotConnections.every(connection => connection._isValid(options))
+        && checkAllValid(this._handles)
+        && checkAllValid(this._particles)
+        && checkAllValid(this._slots)
+        && checkAllValid(this.handleConnections)
+        && checkAllValid(this.slotConnections)
         && (!this.search || this.search.isValid());
   }
 

--- a/src/runtime/tests/manifest-test.ts
+++ b/src/runtime/tests/manifest-test.ts
@@ -650,7 +650,7 @@ ${particleStr1}
           SomeParticle
             consume slotA as s0
       `)).recipes[0];
-      recipe.normalize();
+      assert.isTrue(recipe.normalize(), 'normalizes');
       const options = {errors: new Map(), details: '', showUnresolved: true};
       assert.strictEqual(recipe.isResolved(options), arg.expectedIsResolved, `${arg.label}: Expected recipe to be ${arg.expectedIsResolved ? '' : 'un'}resolved.\nErrors: ${JSON.stringify([...options.errors, options.details])}`);
     };
@@ -672,7 +672,28 @@ ${particleStr1}
             slotA consume s0
       `)).recipes[0];
       const options = {errors: new Map(), details: '', showUnresolved: true};
-      recipe.normalize(options);
+      assert.isTrue(recipe.normalize(options), 'normalizes');
+      assert.strictEqual(recipe.isResolved(options), arg.expectedIsResolved, `${arg.label}: Expected recipe to be ${arg.expectedIsResolved ? '' : 'un'}resolved.\nErrors: ${JSON.stringify([...options.errors, options.details])}`);
+    };
+    await parseRecipe({label: '1', isRequiredSlotA: false, isRequiredSlotB: false, expectedIsResolved: true});
+    await parseRecipe({label: '2', isRequiredSlotA: true, isRequiredSlotB: false, expectedIsResolved: true});
+    await parseRecipe({label: '3', isRequiredSlotA: false, isRequiredSlotB: true, expectedIsResolved: false});
+    await parseRecipe({label: '4', isRequiredSlotA: true, isRequiredSlotB: true, expectedIsResolved: false});
+  });
+  it('SLANDLES consumes multiple set slots', async () => {
+    const parseRecipe = async (arg: {label: string, isRequiredSlotA: boolean, isRequiredSlotB: boolean, expectedIsResolved: boolean}) => {
+      const recipe = (await Manifest.parse(`
+        particle SomeParticle in 'some-particle.js'
+          \`consume${arg.isRequiredSlotA ? '' : '?'} [Slot] slotA
+          \`consume${arg.isRequiredSlotB ? '' : '?'} [Slot] slotB
+
+        recipe
+          \`slot 'slota-0' as s0
+          SomeParticle
+            slotA consume s0
+      `)).recipes[0];
+      const options = {errors: new Map(), details: '', showUnresolved: true};
+      assert.isTrue(recipe.normalize(options), `should normalizes ${JSON.stringify([...options.errors.values()])} ${JSON.stringify(options.details)}`);
       assert.strictEqual(recipe.isResolved(options), arg.expectedIsResolved, `${arg.label}: Expected recipe to be ${arg.expectedIsResolved ? '' : 'un'}resolved.\nErrors: ${JSON.stringify([...options.errors, options.details])}`);
     };
     await parseRecipe({label: '1', isRequiredSlotA: false, isRequiredSlotB: false, expectedIsResolved: true});
@@ -792,7 +813,7 @@ ${particleStr1}
       checkDefined(recipe.particles.find(p => p.name === 'ParticleB')).connections['slotB2'].handle);
 
     const options = {errors: new Map(), details: '', showUnresolved: true};
-    recipe.normalize(options);
+    assert.isTrue(recipe.normalize(options), 'normalizes');
     assert.isTrue(recipe.isResolved(options), `Expected recipe to be resolved.\n\t ${JSON.stringify([...options.errors])}`);
   });
   it('recipe provided slot with no local name', async () => {

--- a/src/runtime/tests/manifest-test.ts
+++ b/src/runtime/tests/manifest-test.ts
@@ -621,12 +621,46 @@ ${particleStr1}
     assert.lengthOf(recipe.slotConnections, 2);
     assert.isEmpty(recipe.slots);
   });
+  it('unnamed consume set slots', async () => {
+    const manifest = await Manifest.parse(`
+      particle SomeParticle &work in 'some-particle.js'
+        consume set of slotA
+      particle SomeParticle1 &rest in 'some-particle.js'
+        consume set of slotC
+
+      recipe
+        SomeParticle
+          consume slotA
+        SomeParticle1
+          consume slotC
+    `);
+    const recipe = manifest.recipes[0];
+    assert.lengthOf(recipe.slotConnections, 2);
+    assert.isEmpty(recipe.slots);
+  });
   it('SLANDLES unnamed consume slots', async () => {
     const manifest = await Manifest.parse(`
       particle SomeParticle &work in 'some-particle.js'
         \`consume Slot slotA
       particle SomeParticle1 &rest in 'some-particle.js'
         \`consume Slot slotC
+
+      recipe
+        SomeParticle
+          slotA consume
+        SomeParticle1
+          slotC consume
+    `);
+    const recipe = manifest.recipes[0];
+    assert.lengthOf(recipe.handleConnections, 2);
+    assert.isEmpty(recipe.handles);
+  });
+  it('SLANDLES unnamed consume set slots', async () => {
+    const manifest = await Manifest.parse(`
+      particle SomeParticle &work in 'some-particle.js'
+        \`consume [Slot] slotA
+      particle SomeParticle1 &rest in 'some-particle.js'
+        \`consume [Slot] slotC
 
       recipe
         SomeParticle
@@ -816,6 +850,84 @@ ${particleStr1}
     assert.isTrue(recipe.normalize(options), 'normalizes');
     assert.isTrue(recipe.isResolved(options), `Expected recipe to be resolved.\n\t ${JSON.stringify([...options.errors])}`);
   });
+  it('SLANDLES recipe set slots with different names (passing a single slot to a set slot)', async () => {
+    const manifest = await Manifest.parse(`
+      particle ParticleA in 'some-particle.js'
+        \`consume [Slot] slotA
+      particle ParticleB in 'some-particle.js'
+        \`consume Slot slotB1
+          \`provide Slot slotB2
+      recipe
+        \`slot 'slot-id0' as s0
+        ParticleA
+          slotA consume mySlot
+        ParticleB
+          slotB1 consume s0
+          slotB2 provide mySlot
+    `);
+    assert.lengthOf(manifest.particles, 2);
+    assert.lengthOf(manifest.recipes, 1);
+    const recipe = manifest.recipes[0];
+    assert.lengthOf(recipe.handles, 2);
+    assert.strictEqual(
+      checkDefined(recipe.particles.find(p => p.name === 'ParticleA')).connections['slotA'].handle,
+      checkDefined(recipe.particles.find(p => p.name === 'ParticleB')).connections['slotB2'].handle);
+    assert.isFalse(recipe.normalize(), 'does not normalize');
+  });
+  it('SLANDLES recipe set slots with different names (passing a slot as a set slot)', async () => {
+    const manifest = await Manifest.parse(`
+      particle ParticleA in 'some-particle.js'
+        \`consume [Slot] slotA
+      particle ParticleB in 'some-particle.js'
+        \`consume Slot slotB1
+          \`provide [Slot] slotB2
+      recipe
+        \`slot 'slot-id0' as s0
+        ParticleA
+          slotA consume mySlot
+        ParticleB
+          slotB1 consume s0
+          slotB2 provide mySlot
+    `);
+    assert.lengthOf(manifest.particles, 2);
+    assert.lengthOf(manifest.recipes, 1);
+    const recipe = manifest.recipes[0];
+    assert.lengthOf(recipe.handles, 2);
+    assert.strictEqual(
+      checkDefined(recipe.particles.find(p => p.name === 'ParticleA')).connections['slotA'].handle,
+      checkDefined(recipe.particles.find(p => p.name === 'ParticleB')).connections['slotB2'].handle);
+
+    const options = {errors: new Map(), details: '', showUnresolved: true};
+    assert.isTrue(recipe.normalize(options), 'normalizes');
+    assert.isTrue(recipe.isResolved(options), `Expected recipe to be resolved.\n\t ${JSON.stringify([...options.errors])}`);
+  });
+  it('SLANDLES recipe set slots with different names (passing set slots)', async () => {
+    const manifest = await Manifest.parse(`
+      particle ParticleA in 'some-particle.js'
+        \`consume [Slot] slotA
+      particle ParticleB in 'some-particle.js'
+        \`consume [Slot] slotB1
+          \`provide [Slot] slotB2
+      recipe
+        \`slot 'slot-id0' as s0
+        ParticleA
+          slotA consume mySlot
+        ParticleB
+          slotB1 consume s0
+          slotB2 provide mySlot
+    `);
+    assert.lengthOf(manifest.particles, 2);
+    assert.lengthOf(manifest.recipes, 1);
+    const recipe = manifest.recipes[0];
+    assert.lengthOf(recipe.handles, 2);
+    assert.strictEqual(
+      checkDefined(recipe.particles.find(p => p.name === 'ParticleA')).connections['slotA'].handle,
+      checkDefined(recipe.particles.find(p => p.name === 'ParticleB')).connections['slotB2'].handle);
+
+    const options = {errors: new Map(), details: '', showUnresolved: true};
+    assert.isTrue(recipe.normalize(options), 'normalizes');
+    assert.isTrue(recipe.isResolved(options), `Expected recipe to be resolved.\n\t ${JSON.stringify([...options.errors])}`);
+  });
   it('recipe provided slot with no local name', async () => {
     const manifest = await Manifest.parse(`
       particle ParticleA in 'some-particle.js'
@@ -840,6 +952,36 @@ ${particleStr1}
       particle ParticleA in 'some-particle.js'
         \`consume Slot slotA1
           \`provide Slot slotA2
+      recipe
+        ParticleA
+          slotA1 consume
+          slotA2 provide
+    `);
+    // Check that the manifest was parsed in the way we expect.
+    assert.lengthOf(manifest.particles, 1);
+    assert.lengthOf(manifest.recipes, 1);
+
+    const recipe = manifest.recipes[0];
+    // Check that the parser found the handleConnections
+    assert.lengthOf(recipe.handleConnections, 2);
+    assert.strictEqual('slotA1', recipe.handleConnections[0].name);
+    assert.strictEqual('slotA2', recipe.handleConnections[1].name);
+
+    // Check that the handle connection
+    // wasn't resolved to a handle (even though it was parsed).
+    assert.isUndefined(recipe.handleConnections[0].handle);
+    assert.isUndefined(recipe.handleConnections[1].handle);
+
+    // The recipe shouldn't resolve (as there is nothing providing slotA1 or
+    // consuming slotA2).
+    recipe.normalize();
+    assert.isFalse(recipe.isResolved());
+  });
+  it('SLANDLES recipe provided set slots with no local name', async () => {
+    const manifest = await Manifest.parse(`
+      particle ParticleA in 'some-particle.js'
+        \`consume [Slot] slotA1
+          \`provide [Slot] slotA2
       recipe
         ParticleA
           slotA1 consume

--- a/src/runtime/tests/recipe-test.ts
+++ b/src/runtime/tests/recipe-test.ts
@@ -38,7 +38,7 @@ describe('recipe', () => {
 
     recipe.normalize(options);
 
-    assert.strictEqual(4, options.errors.size);
+    assert.strictEqual(4, options.errors.size, 'expects four errors');
     recipe.handles.forEach(handle => assert.isTrue(options.errors.has(handle)));
     options.errors.has(recipe.slots[1]);
   });

--- a/src/runtime/type-variable-info.ts
+++ b/src/runtime/type-variable-info.ts
@@ -235,7 +235,7 @@ export class TypeVariableInfo {
   }
 
   isResolved(): boolean {
-    return (this._resolution && this._resolution.isResolved());
+    return this._resolution && this._resolution.isResolved();
   }
 }
 


### PR DESCRIPTION
Realised I hadn't written set slot resolution tests, leading me to fix a bug I'd introduced which assumed that the '`slot' fate implies Slot type.

Also cleans up some repetitive code and adds a root slots to SLANDLESProducts demo.