### PR TITLE
Make chokidar non-optional.

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,6 @@
     "ws": "~6.0.0"
   },
   "sighDependencies": {
-    "chokidar": "^3.0.2",
     "emsdk-npm": "github:mykmartin/emsdk-npm#arcs",
     "request": "^2.88.0",
     "vscode-jsonrpc": "^4.0.0",

--- a/tools/sigh.ts
+++ b/tools/sigh.ts
@@ -13,6 +13,7 @@ const os = require('os');
 const path = require('path');
 const minimist = require('minimist');
 const semver = require('semver');
+const chokidar = require('chokidar');
 
 // Use saneSpawn or saneSpawnWithOutput instead, this is not cross-platform.
 // tslint:disable-next-line: variable-name
@@ -885,8 +886,6 @@ function runTests(args: string[]): boolean {
 
 // Watches for file changes, then runs the steps for the first item in args, passing the remaining items.
 function watch(args: string[]): boolean {
-  const [chokidar] = getOptionalDependencies(['chokidar'], 'The watch command');
-
   const options = minimist(args, {
     string: ['dir'],
     default: {dir: '.'},


### PR DESCRIPTION
The hot code reload server needs this module, and dynamic imports don't seem to work when a module isn't actually installed (fails on TypeScript static build step).