### PR TITLE
Allow dotted values in triggers

### DIFF
--- a/src/recipe-selector/tests/recipe-selector-test.ts
+++ b/src/recipe-selector/tests/recipe-selector-test.ts
@@ -80,6 +80,26 @@ describe('trigger parsing', () => {
     assert.lengthOf(manifest.recipes[0].triggers[1], 1);
     assert.deepEqual(manifest.recipes[0].triggers[1][0], ['key3', 'value3']);
   });
+  it('trigger value can have dots', async () => {
+    const manifest = await Manifest.parse(`
+      particle P1
+        out Foo {} foo
+      particle P2
+        in Foo {} bar
+      @trigger
+        app com.spotify.music
+      recipe R
+        P1
+          foo -> h
+        P2
+          bar <- h
+    `);
+    const recipe = checkDefined(manifest.recipes[0]);
+    assert.lengthOf(manifest.recipes, 1);
+    assert.lengthOf(manifest.recipes[0].triggers, 1);
+    assert.lengthOf(manifest.recipes[0].triggers[0], 1);
+    assert.deepEqual(manifest.recipes[0].triggers[0][0], ['app', 'com.spotify.music']);
+  });
 });
 
 describe('recipe-selector', () => {

--- a/src/runtime/manifest-parser.peg
+++ b/src/runtime/manifest-parser.peg
@@ -101,7 +101,7 @@ Annotation = triggerSet:(SameIndent Trigger eolWhiteSpace)* simpleAnnotation:(Sa
   }
 
 Trigger "a trigger for a recipe"
-  = '@trigger' eolWhiteSpace Indent pairs:(eolWhiteSpace? SameIndent lowerIdent whiteSpace lowerIdent)+ {
+  = '@trigger' eolWhiteSpace Indent pairs:(eolWhiteSpace? SameIndent simpleName whiteSpace dottedName)+ {
   return pairs.map(pair => {
     return [pair[2], pair[4]];
   });
@@ -1029,14 +1029,14 @@ RequireHandleSection
   }
 
 Tag
-  = '#' [a-zA-Z][a-zA-Z0-9_]* {return text().substring(1);}
+  = '#' tag:simpleName {return tag;}
 
 TagList
   = head:Tag tail:(whiteSpace TagList)?
   { return [head, ...(tail && tail[1] || [])]; }
 
 Verb "a verb (e.g. &Verb)"
-  = '&' [a-zA-Z][a-zA-Z0-9_]* {return text().substring(1);}
+  = '&' verb:simpleName {return verb;}
 
 VerbList
   = head:Verb tail:(whiteSpace VerbList)?
@@ -1327,6 +1327,10 @@ lowerIdent "a lowercase identifier (e.g. foo)"
   = !ReservedWord [a-z][a-z0-9_]i* { return text(); }
 fieldName "a field name (e.g. foo9)" // Current handle and formFactor.
   = [a-z][a-z0-9_]i* { return text(); }
+dottedName "a name conforming to the rules of an android app name, per https://developer.android.com/guide/topics/manifest/manifest-element.html#package"
+  = $ (simpleName ("." simpleName)*) // Note that a single simpleName matches too
+simpleName "a name starting with a letter and containing letters, digits and underscores"
+  = [a-zA-Z][a-zA-Z0-9_]* {return text();}
 whiteSpace "one or more whitespace characters"
   = " "+
 eolWhiteSpace "a group of new lines (and optionally comments)"


### PR DESCRIPTION
Dotted values syntax conform to https://developer.android.com/guide/topics/manifest/manifest-element.html#package.

Also tags and verbs share a new "simpleName" used for parts of dotted names, simplifying code a bit and reducing redundancy.

All tests pass, including a new one for dotted trigger values.