### PR TITLE
Replicating the disable handle function from HandleOld to HandleNG

### DIFF
--- a/src/runtime/particle-execution-context.ts
+++ b/src/runtime/particle-execution-context.ts
@@ -11,7 +11,7 @@
 import {assert} from '../platform/assert-web.js';
 
 import {PECInnerPort} from './api-channel.js';
-import {Handle, handleFor, HandleOld} from './handle.js';
+import {Handle, handleFor} from './handle.js';
 import {Id, IdGenerator} from './id.js';
 import {Runnable} from './hot.js';
 import {Loader} from './loader.js';
@@ -252,7 +252,7 @@ export class ParticleExecutionContext {
     // Create new handles and disable the handles of the old particles
     oldParticle.handles.forEach((oldHandle) => {
       this.createHandle(particle, oldParticle.spec, id, oldHandle.name, oldHandle.storage, handleMap, registerList);
-      if (oldHandle instanceof HandleOld) oldHandle.disable(oldParticle);
+      oldHandle.disable(oldParticle);
     });
 
     return [particle, async () => {

--- a/src/runtime/storageNG/handle.ts
+++ b/src/runtime/storageNG/handle.ts
@@ -18,7 +18,7 @@ import {Entity, EntityClass} from '../entity.js';
 import {IdGenerator, Id} from '../id.js';
 import {EntityType, Type} from '../type.js';
 
-import {StorageProxy} from './storage-proxy';
+import {StorageProxy, NoOpStorageProxy} from './storage-proxy';
 
 export interface HandleOptions {
   keepSynced: boolean;
@@ -111,6 +111,11 @@ export abstract class Handle<T extends CRDTTypeRecord> {
     await this.particle.callOnHandleDesync(
         this,
         e => this.reportUserExceptionInHost(e, this.particle, 'onHandleDesync'));
+  }
+
+  disable(particle?: Particle) {
+    this.storageProxy.deregisterHandle(this);
+    this.storageProxy = new NoOpStorageProxy();
   }
 }
 


### PR DESCRIPTION
- Added disable function in storageNG/handle.ts
- Added deregisterHandle function in storageNG/storage-proxy.ts
- Added a dummy version of StorageProxy (NoOpStorageProxy)
- Added a unit test to make sure that NoOpStoragProxy overrides all
StorageProxy's functions