### PR TITLE
sigh: fix optional dependencies and improve UX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ bazel-javaharness
 bazel-out
 bazel-testlogs
 .ijwb
+.sighdeps


### PR DESCRIPTION
- workaround for npm's automatic removal of --no-save installed packages
- add global --install flag to auto-install optional dependencies