### PR TITLE
Initial implementation of SimplePlanner to accompany RecipeSelector

### DIFF
--- a/src/recipe-selector/recipe-selector.ts
+++ b/src/recipe-selector/recipe-selector.ts
@@ -8,8 +8,9 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {Recipe} from '../runtime/recipe/recipe.js';
-import {Dictionary} from '../runtime/hot.js';
+import {Arc} from '../runtime/arc.js';
+import {Recipe, IsValidOptions} from '../runtime/recipe/recipe.js';
+import {RecipeResolver} from '../runtime/recipe/recipe-resolver.js';
 
 // One entry in the lookup table, i.e. one trigger and the recipe it invokes.
 export class Match {
@@ -61,4 +62,30 @@ export class RecipeSelector {
       if (found) return found.recipe;
       return null;
     }
+}
+
+export class SimplePlanner {
+  private _selector: RecipeSelector;
+  
+  constructor(readonly recipes: Recipe[]) {
+    this._selector = new RecipeSelector(recipes);
+  }
+  
+  async plan(arc: Arc, request:  [string, string][]): Promise<Recipe> {
+    const resolver = new RecipeResolver(arc);
+    const recipe = this._selector.select(request);
+    if (recipe) {
+      const options: IsValidOptions = {errors: new Map()};
+      const resolved = await resolver.resolve(recipe, options);
+      if (resolved) {
+        return resolved;
+      } else {
+        console.log(`could not resolve selected recipe: ${[...options.errors.values()].join('\n')}`);
+        throw new Error('Resolution failed');
+      }
+    } else {
+      throw new Error('Selection failed');
+    }
+  }
+  
 }

--- a/src/recipe-selector/recipe-selector.ts
+++ b/src/recipe-selector/recipe-selector.ts
@@ -75,17 +75,9 @@ export class SimplePlanner {
     const resolver = new RecipeResolver(arc);
     const recipe = this._selector.select(request);
     if (recipe) {
-      const options: IsValidOptions = {errors: new Map()};
-      const resolved = await resolver.resolve(recipe, options);
-      if (resolved) {
-        return resolved;
-      } else {
-        console.log(`could not resolve selected recipe: ${[...options.errors.values()].join('\n')}`);
-        throw new Error('Resolution failed');
-      }
-    } else {
-      throw new Error('Selection failed');
+      return await resolver.resolve(recipe);
     }
+    return null;
   }
   
 }

--- a/src/recipe-selector/tests/recipe-selector-test.ts
+++ b/src/recipe-selector/tests/recipe-selector-test.ts
@@ -296,7 +296,6 @@ describe('simple planner', () => {
       particle P1
         out Foo {} foo
         consume root
-        modality dom
       particle P2
         in Foo {} bar
       @trigger

--- a/src/recipe-selector/tests/recipe-selector-test.ts
+++ b/src/recipe-selector/tests/recipe-selector-test.ts
@@ -10,8 +10,12 @@
 
 import {assert} from '../../platform/chai-web.js';
 import {checkDefined} from '../../runtime/testing/preconditions.js';
+import {Arc} from '../../runtime/arc.js';
+import {Loader} from '../../runtime/loader.js';
 import {Manifest} from '../../runtime/manifest.js';
-import {Match, RecipeSelector} from '../recipe-selector.js';
+import {Match, RecipeSelector, SimplePlanner} from '../recipe-selector.js';
+import {FakeSlotComposer} from '../../runtime/testing/fake-slot-composer.js';
+import {Id, ArcId} from '../../runtime/id.js';
 
 describe('trigger parsing', () => {
   it('trigger annotations parse with one key-value pair', async () => {
@@ -283,3 +287,29 @@ describe('recipe-selector', () => {
     assert.isNull(rs.select([['key1', 'value1']]));
   });
 }); 
+
+describe('simple planner', () => {
+  const createArc = (manifest) => new Arc({id: ArcId.newForTest('test'), slotComposer: new FakeSlotComposer(), loader: new Loader(), context: manifest});
+
+  it('works with one trigger with one key-value pair and one recipe', async () => {
+    const manifest = await Manifest.parse(`
+      particle P1
+        out Foo {} foo
+        consume root
+        modality dom
+      particle P2
+        in Foo {} bar
+      @trigger
+        key1 value1
+      recipe R
+        P1
+          foo -> h
+        P2
+          bar <- h
+    `);
+    const planner = new SimplePlanner(manifest.recipes);
+    const arc = createArc(manifest);
+    const result = await planner.plan(arc, [['key1', 'value1']]);
+    assert.isNotNull(result);
+  });
+});


### PR DESCRIPTION
With a working test.

This is preliminary. There are still outstanding issues to be resolved in the next PR:

- Modality isn't handled at all. It might not need to be, if we agree that modality should be part of the trigger and request.
- There is no attempt to bind a provided slot id to the recipe yet. That will come once I figure out how to do it.
- Given the the external-facing object is now SimplePlanner, the file should be moved to the planning directory and renamed simple-planner.ts, and only the SimplePlanner should be exposed in the api file.