### PR TITLE
Add rudimentary magenta-js service.

### DIFF
--- a/particles/Magenta/PlayDemo.arcs
+++ b/particles/Magenta/PlayDemo.arcs
@@ -1,0 +1,6 @@
+particle PlayDemoParticle in './js/PlayDemo.js'
+  consume root
+
+recipe PlayDemoRecipe
+  PlayDemoParticle
+  description `Play a simple demo song with Magenta`

--- a/particles/Magenta/js/PlayDemo.js
+++ b/particles/Magenta/js/PlayDemo.js
@@ -1,0 +1,26 @@
+/**
+ * @license
+ * Copyright (c) 2019 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+defineParticle(({DomParticle, html, log, resolver}) => {
+  const template = html`
+  <button id="button-play" on-click="onPlay">Play</button>
+`;
+
+  return class extends DomParticle {
+    get template() {
+      return template;
+    }
+
+    async onPlay(e, state) {
+      log('onPlay');
+      await this.service({call: 'magenta.loadAndPlayMusic'});
+    }
+  };
+});

--- a/shells/configuration/whitelisted.js
+++ b/shells/configuration/whitelisted.js
@@ -27,5 +27,6 @@ import '../lib/database/firebase-upload.js';
 // services for particle use
 // TODO(sjmiles): TensorFlowJs (tfjs, also part of ml5) uses `new Function()` which requires `unsafe-eval` csp
 import '../services/textclassifier-service.js';
+import '../lib/services/magenta.js';
 import '../lib/services/tf.js';
 import '../../build/services/random-service.js';

--- a/shells/lib/services/magenta.js
+++ b/shells/lib/services/magenta.js
@@ -1,0 +1,10 @@
+/**
+ * @license
+ * Copyright 2019 Google LLC.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+import '../../../build/services/magenta-service.js';

--- a/src/services/magenta-service.ts
+++ b/src/services/magenta-service.ts
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright 2019 Google LLC.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+import {dynamicScript} from '../platform/dynamic-script-web.js';
+import {Services} from '../runtime/services.js';
+
+const magentaUrl = 'https://cdn.jsdelivr.net/npm/@magenta/music@^1.0.0';
+
+export const requireMagenta = async () => {
+  if (!window['mm']) {
+    await dynamicScript(magentaUrl);
+  }
+  console.log('Theoretically loaded magenta.');
+  return window['mm'];
+};
+
+export const loadAndPlayMusic = async () => {
+  const magenta = await requireMagenta();
+  const model = new magenta.MusicVAE(
+    'https://storage.googleapis.com/magentadata/js/checkpoints/music_vae/trio_4bar');
+  const player = new magenta.Player();
+  player.resumeContext(); // enable audio
+  model.sample(1)
+    .then((samples) => player.start(samples[0], 80));
+};
+
+Services.register('magenta', {
+  loadAndPlayMusic
+});


### PR DESCRIPTION
To follow:
* use reference manager to store heavyweight model for reuse.
* parameterize model loading.
* make more useful lower level primitives for interacting with Magenta vs the trivial starter `loadAndPlayMusic`.