### PR TITLE
UIParticle Core

### DIFF
--- a/modalities/dom/components/xen/xen-template.js
+++ b/modalities/dom/components/xen/xen-template.js
@@ -88,19 +88,21 @@ const locateNodes = function(root, locator, map) {
 /* Annotation Producer */
 // must return `true` for any node whose key we wish to track
 const annotatorImpl = function(node, key, notes, opts) {
+  let tracking = false;
   // hook
   if (opts.annotator && opts.annotator(node, key, notes, opts)) {
-    return true;
+    tracking = true;
   }
   // default
   switch (node.nodeType) {
     case Node.DOCUMENT_FRAGMENT_NODE:
-      return;
+      break;
     case Node.ELEMENT_NODE:
-      return annotateElementNode(node, key, notes);
+      return tracking || annotateElementNode(node, key, notes);
     case Node.TEXT_NODE:
-      return annotateTextNode(node, key, notes);
+      return tracking || annotateTextNode(node, key, notes);
   }
+  return tracking;
 };
 
 const annotateTextNode = function(node, key, notes) {
@@ -197,6 +199,8 @@ const listen = function(controller, node, eventName, handlerName) {
   node.addEventListener(eventName, function(e) {
     if (controller[handlerName]) {
       return controller[handlerName](e, e.detail);
+    } else if (controller.defaultHandler) {
+      return controller.defaultHandler(handlerName, e);
     }
   });
 };
@@ -406,5 +410,6 @@ const createTemplate = innerHTML => {
 export const Template = {
   createTemplate,
   setBoolAttribute,
-  stamp
+  stamp,
+  takeNote
 };

--- a/particles/Arcs/source/Login.js
+++ b/particles/Arcs/source/Login.js
@@ -8,7 +8,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-defineParticle(({DomParticle, html, log, resolver}) => {
+defineParticle(({UiParticle, html, log, resolver}) => {
 
   const host = 'login';
 
@@ -113,7 +113,7 @@ defineParticle(({DomParticle, html, log, resolver}) => {
 </div>
     `;
 
-  return class extends DomParticle {
+  return class extends UiParticle {
     get template() {
       return template;
     }

--- a/shells/lib/xen-renderer.js
+++ b/shells/lib/xen-renderer.js
@@ -1,0 +1,256 @@
+/**
+ * @license
+ * Copyright 2019 Google LLC.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+import {Xen} from '../lib/components/xen.js';
+import {logFactory} from '../../build/runtime/log-factory.js';
+import IconStyles from '../../modalities/dom/components/icons.css.js';
+
+const log = logFactory('Renderer', 'tomato');
+//const warn = logFactory('Renderer', 'tomato', 'warn');
+//const groupCollapsed = logFactory('Renderer', 'tomato', 'groupCollapsed');
+
+const slotId = id => `[slotid="${queryId(id)}"]`;
+const queryId = id => `${id.replace(/[:!]/g, '_')}`;
+
+export const SlotObserver = class {
+  constructor(root) {
+    this.root = root;
+    this.pendingSlots = [];
+  }
+  disposeParticleOutput() {
+    this.root.querySelectorAll(':host > [slotid]').forEach(n => n.innerText = '');
+  }
+  observe(slot) {
+    this.render(slot);
+  }
+  render(slot) {
+    if (typeof slot === 'string') {
+      slot = JSON.parse(slot);
+    }
+    // capture the slot, even if we can't process it yet, only keep the latest slot info per outputId
+    const i = this.pendingSlots.findIndex(s => s.outputSlotId === slot.outputSlotId);
+    if (i >= 0) {
+      this.pendingSlots[i] = slot;
+    } else {
+      this.pendingSlots.unshift(slot);
+    }
+    // begin processing slots, unless we are already
+    this.processSlots();
+  }
+  async processSlots() {
+    // `renderSlots` is async, so prevent re-entrancy
+    if (!this.processSlots.working) {
+      this.processSlots.working = true;
+      try {
+        await this.renderSlots();
+      } finally {
+        this.processSlots.working = false;
+        log('pendingSlots:', this.pendingSlots.length);
+        //if (!this.pendingSlots.length) {
+        //  log('ALL slots rendered');
+        //}
+        //if (this.pendingSlots.length) {
+        //  log('SLOTS remaining after one pass:', this.pendingSlots.length);
+        //}
+      }
+    }
+  }
+  async renderSlots() {
+    // track slots that didn't render yet
+    let skips;
+    // if we rendered anything, we should revisit skipped slots
+    let haveRendered;
+    do {
+      // fresh pass
+      skips = [];
+      haveRendered = false;
+      // loop is asynchronous, more pendingSlots could have arrived while awaiting
+      while (this.pendingSlots.length) {
+        // process these slots
+        const slots = this.pendingSlots;
+        // allow new slots to enter pending state while we are rendering
+        this.pendingSlots = [];
+        // try to render each slot, accumulate skipped slots
+        for (const slot of slots) {
+          if (await this.renderSlot(slot)) {
+            haveRendered = true;
+          } else {
+            skips.push(slot);
+          }
+        }
+      }
+      // return left-over slots to pending
+      this.pendingSlots = skips;
+    // perform another pass if we rendered something and there are still pending slots
+    } while (haveRendered && skips.length);
+    // pendingSlots will not be empty if none of them will render yet
+  }
+  async renderSlot(slot) {
+    let success;
+    if (isEmptySlot(slot)) {
+      // empty, just pretend it rendered
+      success = true;
+    } else if (slot.model && slot.model.json) {
+      success = await this.renderDataSlot(slot);
+    } else {
+      success = await this.renderXenSlot(slot);
+    }
+    log(`render [${slot.particle.name}]: ${success ? `ok` : `skipped`}`);
+    //if (!success) {
+      //groupCollapsed(`[${slot.particle.name}]: FAILED render`);
+      //log(slot);
+      //console.groupEnd();
+    //}
+    // else {
+    //   log(`[${slot.particle.name}]: rendered`);
+    // }
+    return success;
+  }
+  async renderDataSlot(slot) {
+    const data = document.querySelector(slotId('droot'));
+    if (data) {
+      data.innerHTML += `<pre style="white-space: pre-wrap;">${slot.model.json}</pre>`;
+    }
+    // groupCollapsed('got output data');
+    // log(slot.model.json);
+    // console.groupEnd();
+    return true;
+  }
+  async renderXenSlot(output) {
+    const {outputSlotId, containerSlotName, containerSlotId, slotMap, model} = output;
+    const root = this.root || document.body;
+    let slotNode;
+    const data = model || Object;
+    if (containerSlotId) {
+      // TODO(sjmiles):
+      // muxed slots have the format [muxerSlotId___muxedSlotId]
+      const delim = `___`;
+      const muxerSlotId = containerSlotId.includes(delim) && containerSlotId.split(delim)[0];
+      if (muxerSlotId) {
+        // we use muxerSlot and subId to locate muxed nodes
+        const selector = `${slotId(muxerSlotId)}[subid="${data.subid}"]`;
+        slotNode = deepQuerySelector(root, selector);
+        //console.warn('muxedNode:', muxedNode);
+        //log('RenderEx:found multiplexed slot for', containerSlotName, data.subid);
+        if (!slotNode) {
+          log(`couldn't find muxed slotNode`);
+          return false;
+        }
+      } else {
+        slotNode =
+          // TODO(sjmiles): memoize containerSlotId => node mappings?
+          // slotId's are unique in the tree
+          deepQuerySelector(root, slotId(containerSlotId))
+          // use `containerSlotName` to catch root slots (not deep!)
+          || root.querySelector(slotId(containerSlotName))
+          || root.querySelector(`#${queryId(containerSlotId)}`)
+          ;
+      }
+      //log(rawData);
+      if (slotNode && outputSlotId) {
+        const domOutputSlotId = `${queryId(outputSlotId)}`;
+        let node = slotNode.querySelector(`#${domOutputSlotId}`);
+        if (node) {
+          //log('RenderEx: using existing node', outputSlotId);
+        } else {
+          //log('RenderEx: found no node in the container, making one', outputSlotId);
+          const dispatcher = (...args) => this.dispatch(...args);
+          node = stampDom(output, slotNode, domOutputSlotId, dispatcher);
+        }
+        if (node && node.xen) {
+          // TODO(sjmiles): hackity hack hack
+          if (data && data.items && data.items.models) {
+            const slotModel = {};
+            Object.keys(slotMap).forEach(key => {
+              slotModel[`${key}_slot`] = queryId(slotMap[key]);
+            });
+            data.items.models.forEach(model => Object.assign(model, slotModel));
+          }
+          node.xen.set(data);
+        }
+        return true;
+      }
+    }
+  }
+  dispatch(pid, eventlet) {
+    log(`caught event [${eventlet.name}] for target [${pid}], dispatch not implemented`);
+  }
+};
+
+export const attachRenderer = (composer, containers) => {
+  return composer.slotObserver = new SlotObserver(composer.root);
+};
+
+const isEmptySlot = slot =>
+  (!slot.template || slot.template === '') && (!slot.model || !Object.keys(slot.model).length);
+
+const deepQuerySelector = (root, selector) => {
+  const find = (element, selector) => {
+    let result;
+    while (element && !result) {
+      result =
+          (element.matches && element.matches(selector) ? element : null)
+          || find(element.firstElementChild, selector)
+          || (element.shadowRoot && find(element.shadowRoot.firstElementChild, selector))
+          ;
+      element = element.nextElementSibling;
+    }
+    return result;
+  };
+  return find(root || document.body, selector);
+};
+
+const stampDom = (output, slotNode, slotId, dispatch) => {
+  const {template, particle: {name}, slotMap} = output;
+  // create container node
+  const container = slotNode.appendChild(document.createElement('div'));
+  container.id = slotId;
+  // just for humans
+  container.setAttribute('particle', name);
+  // establish shadow root
+  const root = container.attachShadow({mode: `open`});
+  // provision boilerplate stylesheet
+  if (!stampDom.styleTemplate) {
+    stampDom.styleTemplate = Xen.Template.createTemplate(`<style>${IconStyles}</style>`);
+  }
+  Xen.Template.stamp(stampDom.styleTemplate).appendTo(root);
+  // custom annotator that takes note of `slotid` bindings so
+  // we can convert slotids from local-names to global-ids
+  const opts = {annotator: (node, key, notes) => {
+    if (node.nodeType === Node.ELEMENT_NODE) {
+      const localId = node.getAttribute('slotid');
+      if (localId) {
+        Xen.Template.takeNote(notes, key, 'mustaches', 'slotid$', `${localId}_slot`);
+        log('annotating slot: ', node.localName, localId);
+        return true;
+      }
+    }
+    return false;
+  }};
+  // build event controller
+  const controller = {
+    defaultHandler: (handler, e) => {
+      const {key, value} = e.currentTarget;
+      const eventlet = {name, handler, data: {key, value}};
+      if (dispatch) {
+        dispatch(output.particle.id, eventlet);
+      }
+    }
+  };
+  // stamp template, attach listeners, add to DOM
+  container.xen = Xen.Template.stamp(template, opts).events(controller).appendTo(root);
+  // install slotids
+  const slotModel = {};
+  Object.keys(slotMap).forEach(key => {
+    slotModel[`${key}_slot`] = queryId(slotMap[key]);
+  });
+  container.xen.set(slotModel);
+  // finished container
+  return container;
+};

--- a/shells/smoke-shell/app.js
+++ b/shells/smoke-shell/app.js
@@ -14,7 +14,7 @@ export const App = async (composer) => {
   const arc = await Utils.spawn({id: 'smoke-arc', composer});
   console.log(`arc [${arc.id}]`);
 
-  const manifest = await Utils.parse(`import 'https://$particles/Arcs/Login.recipe'`);
+  const manifest = await Utils.parse(`import 'https://$particles/Arcs/Login.arcs'`);
   console.log(`manifest [${manifest.id}]`);
 
   const recipe = manifest.findRecipesByVerb('login')[0];

--- a/shells/smoke-shell/smoke.html
+++ b/shells/smoke-shell/smoke.html
@@ -1,15 +1,18 @@
 <!doctype html>
 
 <!-- could be `import`ed -->
-<script src="../lib/build/pouchdb.js"></script>
-<script src="../lib/build/firebase.js"></script>
+<!-- <script src="../lib/build/pouchdb.js"></script> -->
+<!-- <script src="../lib/build/firebase.js"></script> -->
 <!-- cannot be `import`ed (tries to use `this`) -->
-<script src="../../node_modules/sourcemapped-stacktrace/dist/sourcemapped-stacktrace.js"></script>
+<!-- <script src="../../node_modules/sourcemapped-stacktrace/dist/sourcemapped-stacktrace.js"></script> -->
+
+<div slotid="rootslotid-root"></div>
 
 <script type="module">
   import {App} from './app.js';
   import {Utils} from '../lib/utils.js';
-  import {DomSlotComposer} from '../lib/components/dom-slot-composer.js';
+  import {UiSlotComposer} from '../../build/runtime/ui-slot-composer.js';
+  import {attachRenderer} from '../lib/xen-renderer.js';
 
   // run
   (async () => {
@@ -17,11 +20,30 @@
       // configure arcs environment
       Utils.init('../..');
       // construct renderer
-      const composer = new DomSlotComposer({rootContainer: document.body});
+      const composer = new UiSlotComposer();
+      composer.root = document.body;
+      attachRenderer(composer).dispatch = (pid, eventlet) => {
+        console.log('ui-broker/composer dispatch for pid', pid, eventlet);
+        this.firePecEvent(composer, pid, eventlet);
+      };
       // start app
       await App(composer);
     } catch (x) {
       console.error(x);
     }
   })();
+  //
+  const firePecEvent = (composer, pid, eventlet) => {
+    if (composer && composer.arc) {
+      const particle = composer.arc.activeRecipe.particles.find(
+        particle => String(particle.id) === String(pid)
+      );
+      if (particle) {
+        log('firing PEC event for', particle.name);
+        // TODO(sjmiles): we need `arc` and `particle` here even though
+        // the two are bound together, figure out how to simplify
+        composer.arc.pec.sendEvent(particle, /*slotName*/'', eventlet);
+      }
+    }
+  };
 </script>

--- a/shells/smoke-shell/smoke.js
+++ b/shells/smoke-shell/smoke.js
@@ -9,7 +9,7 @@
  */
 import {App} from './app.js';
 import {Utils} from '../lib/utils.js';
-import {RamSlotComposer} from '../lib/components/ram-slot-composer.js';
+import {UiSlotComposer} from '../../../build/runtime/ui-slot-composer.js';
 
 // notify user we are live
 console.log('\n--- Arcs Shell ---\n');
@@ -19,8 +19,8 @@ console.log('\n--- Arcs Shell ---\n');
   try {
     // configure arcs environment
     Utils.init('../..');
-    // create a composer configured for node
-    const composer = new RamSlotComposer();
+    // create a composer
+    const composer = new UiSlotComposer();
     await App(composer);
   } catch (x) {
     console.error(x);

--- a/src/platform/loader-platform.ts
+++ b/src/platform/loader-platform.ts
@@ -13,6 +13,8 @@ import {Particle} from '../runtime/particle.js';
 import {DomParticle} from '../runtime/dom-particle.js';
 import {MultiplexerDomParticle} from '../runtime/multiplexer-dom-particle.js';
 import {TransformationDomParticle} from '../runtime/transformation-dom-particle.js';
+import {UiParticle} from '../runtime/ui-particle.js';
+import {UiMultiplexerParticle} from '../runtime/ui-multiplexer-particle.js';
 
 const html = (strings, ...values) => (strings[0] + values.map((v, i) => v + strings[i + 1]).join('')).trim();
 
@@ -52,19 +54,21 @@ export class PlatformLoaderBase extends Loader {
       this._urlMap[name] = resolved;
     }
     this._urlMap['$here'] = resolved;
+    this._urlMap['$module'] = resolved;
   }
   unwrapParticle(particleWrapper, log?) {
-    // TODO(sjmiles): regarding `resolver`:
-    //  resolve method allows particles to request remapping of assets paths
-    //  for use in DOM
-    const resolver = this.resolve.bind(this);
     return particleWrapper({
+      // Particle base
       Particle,
+      // Dom-flavored Particles (deprecated?)
       DomParticle,
       MultiplexerDomParticle,
-      SimpleParticle: DomParticle,
       TransformationDomParticle,
-      resolver,
+      // Ui-flavored Particles
+      UiParticle,
+      UiMultiplexerParticle,
+      // utilities
+      resolver: this.resolve.bind(this), // allows particles to use relative paths and macros
       log: log || (() => {}),
       html
     });

--- a/src/runtime/api-channel.ts
+++ b/src/runtime/api-channel.ts
@@ -197,7 +197,7 @@ class ThingMapper {
       }
       this._idMap.set(id, thing);
     }
-    
+
     if (thing instanceof Promise) {
       assert(continuation == null);
       await this.establishThingMapping(id, await thing);
@@ -541,6 +541,9 @@ export abstract class PECInnerPort extends APIPort {
   abstract onStopRender(particle: Particle, slotName: string);
 
   Render(@Mapped particle: Particle, @Direct slotName: string, @Direct content: Content) {}
+  // TODO(sjmiles): alternate render path for slotObserver (UiBroker)
+  Output(@Mapped particle: Particle, @Direct content: {}) {}
+
   InitializeProxy(@Mapped handle: StorageProxy, @LocalMapped callback: Consumer<{version: number}>) {}
   SynchronizeProxy(@Mapped handle: StorageProxy, @LocalMapped callback: Consumer<{version: number, model: SerializedModelEntry[]}>) {}
   HandleGet(@Mapped handle: StorageProxy, @LocalMapped callback: Consumer<{id: string}>) {}

--- a/src/runtime/arc.ts
+++ b/src/runtime/arc.ts
@@ -106,6 +106,11 @@ constructor({id, context, pecFactories, slotComposer, loader, storageKey, storag
     // TODO: pecFactories should not be optional. update all callers and fix here.
     this.pecFactories = pecFactories && pecFactories.length > 0 ? pecFactories.slice() : [FakePecFactory(loader).bind(null)];
 
+    // TODO(sjmiles): currently slotObserver recovers arc from composer (find a fix)
+    if (slotComposer && !slotComposer['arc']) {
+      slotComposer['arc'] = this;
+    }
+
     if (typeof id === 'string') {
       // TODO(csilvestrini): Replace this warning with an exception.
       console.error(
@@ -125,7 +130,7 @@ constructor({id, context, pecFactories, slotComposer, loader, storageKey, storag
     const ports = this.pecFactories.map(f => f(this.generateID(), this.idGenerator));
     this.pec = new ParticleExecutionHost(slotComposer, this, ports);
     this.storageProviderFactory = storageProviderFactory || new StorageProviderFactory(this.id);
-    
+
     this.volatileStorageDriverProvider = new VolatileStorageDriverProvider(this);
     DriverFactory.register(this.volatileStorageDriverProvider);
   }
@@ -289,7 +294,7 @@ constructor({id, context, pecFactories, slotComposer, loader, storageKey, storag
           const storeId = context.dataResources.get(storageKey);
           serializedData.forEach(a => {a.storageKey = storeId;});
         }
-        
+
         const indent = '  ';
         const data = JSON.stringify(serializedData);
 

--- a/src/runtime/arc.ts
+++ b/src/runtime/arc.ts
@@ -106,11 +106,6 @@ constructor({id, context, pecFactories, slotComposer, loader, storageKey, storag
     // TODO: pecFactories should not be optional. update all callers and fix here.
     this.pecFactories = pecFactories && pecFactories.length > 0 ? pecFactories.slice() : [FakePecFactory(loader).bind(null)];
 
-    // TODO(sjmiles): currently slotObserver recovers arc from composer (find a fix)
-    if (slotComposer && !slotComposer['arc']) {
-      slotComposer['arc'] = this;
-    }
-
     if (typeof id === 'string') {
       // TODO(csilvestrini): Replace this warning with an exception.
       console.error(

--- a/src/runtime/modality-handler.ts
+++ b/src/runtime/modality-handler.ts
@@ -24,6 +24,11 @@ export class ModalityHandler {
 
   static readonly headlessHandler : ModalityHandler = new ModalityHandler(HeadlessSlotDomConsumer);
 
+  static readonly basicHandler : ModalityHandler = new ModalityHandler(
+    SlotConsumer,
+    DescriptionFormatter
+  );
+
   static readonly domHandler : ModalityHandler = new ModalityHandler(
     SlotDomConsumer,
     DescriptionDomFormatter

--- a/src/runtime/particle-execution-context.ts
+++ b/src/runtime/particle-execution-context.ts
@@ -202,6 +202,10 @@ export class ParticleExecutionContext {
       // TODO(sjmiles): experimental `services` impl
       serviceRequest: (particle, args, callback) => {
         this.apiPort.ServiceRequest(particle, args, callback);
+      },
+      // TODO(sjmiles): alternate render path via slotObserver (UiBroker)
+      output: (particle, content) => {
+        this.apiPort.Output(particle, content);
       }
     };
     if (hasInnerArcs) {
@@ -275,7 +279,7 @@ export class ParticleExecutionContext {
         // Transfer the slot proxies from the old particle to the new one
         for (const name of oldParticle.getSlotNames()) {
           oldParticle.getSlot(name).rewire(particle);
-        }      
+        }
       }]);
     }
     return result;

--- a/src/runtime/particle-execution-host.ts
+++ b/src/runtime/particle-execution-host.ts
@@ -346,6 +346,14 @@ class PECOuterPortImpl extends PECOuterPort {
     this.SimpleCallback(callback, error ? {error} : successResponse);
   }
 
+  // TODO(sjmiles): experimental `output` impl
+  onOutput(particle: Particle, content: {}) {
+    const composer = this.arc.pec.slotComposer;
+    if (composer && composer["delegateOutput"]) {
+      composer["delegateOutput"](particle, content);
+    }
+  }
+
   onReportExceptionInHost(exception: PropagatedException) {
     if (!exception.particleName) {
       exception.particleName = this.arc.loadedParticleInfo.get(exception.particleId).spec.name;

--- a/src/runtime/particle-execution-host.ts
+++ b/src/runtime/particle-execution-host.ts
@@ -349,8 +349,8 @@ class PECOuterPortImpl extends PECOuterPort {
   // TODO(sjmiles): experimental `output` impl
   onOutput(particle: Particle, content: {}) {
     const composer = this.arc.pec.slotComposer;
-    if (composer && composer["delegateOutput"]) {
-      composer["delegateOutput"](particle, content);
+    if (composer && composer['delegateOutput']) {
+      composer['delegateOutput'](particle, content);
     }
   }
 

--- a/src/runtime/particle-execution-host.ts
+++ b/src/runtime/particle-execution-host.ts
@@ -350,7 +350,7 @@ class PECOuterPortImpl extends PECOuterPort {
   onOutput(particle: Particle, content: {}) {
     const composer = this.arc.pec.slotComposer;
     if (composer && composer['delegateOutput']) {
-      composer['delegateOutput'](particle, content);
+      composer['delegateOutput'](this.arc, particle, content);
     }
   }
 

--- a/src/runtime/particle.ts
+++ b/src/runtime/particle.ts
@@ -22,6 +22,8 @@ import {Entity, EntityRawData, MutableEntityData} from './entity.js';
 export interface Capabilities {
   constructInnerArc?: (particle: Particle) => Promise<InnerArcHandle>;
   serviceRequest?: (particle: Particle, args, callback) => void;
+  // TODO(sjmiles): missing type info
+  output?
 }
 
 /**
@@ -270,6 +272,14 @@ export class Particle {
 
   mutate(entity: Entity, mutation: Consumer<MutableEntityData> | {}): void {
     Entity.mutate(entity, mutation);
+  }
+
+  // TODO(sjmiles): alternate render path for UiBroker
+  output(content) {
+    const {output} = this.capabilities;
+    if (output) {
+      output(this, content);
+    }
   }
 
   // abstract

--- a/src/runtime/particle.ts
+++ b/src/runtime/particle.ts
@@ -23,7 +23,7 @@ export interface Capabilities {
   constructInnerArc?: (particle: Particle) => Promise<InnerArcHandle>;
   serviceRequest?: (particle: Particle, args, callback) => void;
   // TODO(sjmiles): missing type info
-  output?
+  output?;
 }
 
 /**

--- a/src/runtime/ui-multiplexer-particle.ts
+++ b/src/runtime/ui-multiplexer-particle.ts
@@ -1,0 +1,201 @@
+/**
+ * Copyright (c) 2017 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {ParticleSpec} from './particle-spec.js';
+import {UiTransformationParticle} from './ui-transformation-particle.js';
+import {Handle} from './handle.js';
+import {InnerArcHandle} from './particle-execution-context.js';
+import {Type} from './type.js';
+
+export class UiMultiplexerParticle extends UiTransformationParticle {
+
+  plexeds: any[];
+
+  async setHandles(handles: ReadonlyMap<string, Handle>): Promise<void> {
+    this.plexeds = [];
+    const arc = await this.constructInnerArc();
+    const listHandleName = 'list';
+    const particleHandleName = 'hostedParticle';
+    const particleHandle = handles.get(particleHandleName);
+    let hostedParticle: ParticleSpec | null = null;
+    let otherMappedHandles: string[] = [];
+    let otherConnections: string[] = [];
+    if (particleHandle) {
+      hostedParticle = await particleHandle["get"]();
+      if (hostedParticle) {
+        ({otherMappedHandles, otherConnections} =
+            await this._mapParticleConnections(listHandleName, particleHandleName, hostedParticle, handles, arc));
+      }
+    }
+    this.setState({
+      arc,
+      type: handles.get(listHandleName).type,
+      hostedParticle,
+      otherMappedHandles,
+      otherConnections
+    });
+    await super.setHandles(handles);
+  }
+
+  async update({list}, {arc, type, hostedParticle, otherMappedHandles, otherConnections}: {
+    arc: InnerArcHandle,
+    type: Type,
+    hostedParticle: ParticleSpec,
+    otherMappedHandles: string[],
+    otherConnections: string[]
+  }, oldProps, oldState) {
+    //console.warn(`[${this.spec.name}]::update`, list, arc);
+    if (!list || !arc) {
+      return;
+    }
+    if (oldProps.list === list && oldState.arc === arc) {
+      return;
+    }
+    if (list.length > 0) {
+      this.relevance = 0.1;
+    }
+    // TODO(sjmiles): needs safety for re-entrant update
+    //const slotIds = [];
+    for (const [index, item] of this.getListEntries(list)) {
+      //const id = await this.updateEntry(index, item, {arc, type, hostedParticle, otherConnections, otherMappedHandles});
+      //slotIds.push(id);
+      await this.updateEntry(index, item, {arc, type, hostedParticle, otherConnections, otherMappedHandles});
+    }
+    //console.warn('m-d-p', slotIds);
+    // clear data from unused particles/handles
+    for (let i=list.length, plexed; (plexed=this.plexeds[i]); i++) {
+      plexed.then(plexed => plexed.handle["clear"]());
+    }
+  }
+
+  async updateEntry(index, item, {hostedParticle, arc, type, otherConnections, otherMappedHandles}) {
+    if (!hostedParticle && !item.renderParticleSpec) {
+      // If we're muxing on behalf of an item with an embedded recipe, the
+      // hosted particle should be retrievable from the item itself. Else we
+      // just skip this item.
+      return;
+    }
+    //console.log(`RenderEx:updateEntry: %c[${index}]`, 'color: #A00; font-weight: bold;');
+    // Map innerArc/slot by index. Index maps closely to rendering contexts.
+    // Rendering contexts are expensive, we want maximal coherence.
+    const plexed = await this.requirePlexed(index, item,
+      {hostedParticle, arc, type, otherConnections, otherMappedHandles});
+    // TODO(sjmiles): work out a proper cast (and conditional), or fix upstream type
+    plexed.handle["set"](item);
+    return plexed.slotId;
+  }
+
+  async requirePlexed(index, item, {arc, type, hostedParticle, otherConnections, otherMappedHandles}) {
+    let promise = this.plexeds[index];
+    if (!promise) {
+      promise = new Promise(async resolve => {
+        const handle = await this.acquireItemHandle(index, {arc, item, type});
+        const hosting = await this.resolveHosting(item, {arc, hostedParticle, otherConnections, otherMappedHandles});
+        const result = {arc, handle, hosting, slotId: null};
+        result.slotId = await this.createInnards(item, result);
+        resolve(result);
+      });
+      this.plexeds[index] = promise;
+    }
+    return await promise;
+  }
+
+  async resolveHosting(item, {arc, hostedParticle, otherConnections, otherMappedHandles}) {
+    return hostedParticle ?
+      {hostedParticle, otherConnections, otherMappedHandles}
+        : await this.resolveHostedParticle(item, arc);
+  }
+
+  async acquireItemHandle(index, {arc, item, type}) {
+    const handlePromise = arc.createHandle(type.getContainedType(), `item${index}`);
+    return await handlePromise;
+  }
+
+  async resolveHostedParticle(item, arc) {
+    const hostedParticle = ParticleSpec.fromLiteral(JSON.parse(item.renderParticleSpec));
+    // Re-map compatible handles and compute the connections specific
+    // to this item's render particle.
+    const listHandleName = 'list';
+    const particleHandleName = 'renderParticle';
+    const {otherConnections, otherMappedHandles} =
+      await this._mapParticleConnections(listHandleName, particleHandleName, hostedParticle, this.handles, arc);
+    return {otherConnections, otherMappedHandles, hostedParticle};
+  }
+
+  async _mapParticleConnections(
+      listHandleName: string,
+      particleHandleName: string,
+      hostedParticle: ParticleSpec,
+      handles: ReadonlyMap<string, Handle>,
+      arc: InnerArcHandle) {
+    const otherMappedHandles: string[] = [];
+    const otherConnections: string[] = [];
+    let index = 2;
+    const skipConnectionNames = [listHandleName, particleHandleName];
+
+    for (const [connectionName, otherHandle] of handles) {
+      if (!skipConnectionNames.includes(connectionName)) {
+        // TODO(wkorman): For items with embedded recipes we may need a map
+        // (perhaps id to index) to make sure we don't map a handle into the inner
+        // arc multiple times unnecessarily.
+
+        // TODO(lindner): type erasure to avoid mismatch of Store vs Handle in arc.mapHandle
+        // tslint:disable-next-line: no-any
+        const otherHandleStore = otherHandle.storage as any;
+        otherMappedHandles.push(`use '${await arc.mapHandle(otherHandleStore)}' as v${index}`);
+        //
+        const hostedOtherConnection =
+          hostedParticle.handleConnections.find(conn => conn.isCompatibleType(otherHandle.type));
+        if (hostedOtherConnection) {
+          otherConnections.push(`${hostedOtherConnection.name} = v${index++}`);
+          // TODO(wkorman): For items with embedded recipes where we may have a
+          // different particle rendering each item, we need to track
+          // |connByHostedConn| keyed on the particle type.
+          //this._connByHostedConn.set(hostedOtherConnection.name, connectionName);
+        }
+      }
+    }
+    return {otherMappedHandles, otherConnections};
+  }
+
+  async createInnards(item, {arc, handle, hosting: {hostedParticle, otherMappedHandles, otherConnections}}) {
+    const hostedSlotName = [...hostedParticle.slotConnections.keys()][0];
+    const slotName = [...this.spec.slotConnections.values()][0].name;
+    const slotId = await arc.createSlot(this, slotName, handle._id);
+    if (slotId) {
+      try {
+        const recipe = this.constructInnerRecipe(
+          hostedParticle, item, handle,
+          {name: hostedSlotName, id: slotId},
+          {connections: otherConnections, handles: otherMappedHandles}
+        );
+        await arc.loadRecipe(recipe);
+      }
+      catch (e) {
+        console.warn(e);
+      }
+    }
+    return slotId;
+  }
+
+  // Called with the list of items and by default returns the direct result of
+  // `Array.entries()`. Subclasses can override this method to alter the item
+  // order or otherwise permute the items as desired before their slots are
+  // created and contents are rendered.
+  getListEntries(list: {}[]) {
+    return list.entries();
+  }
+
+  // Abstract method below.
+  // Called to produce a full interpolated recipe for loading into an inner
+  // arc for each item. Subclasses should override this method as by default
+  // it does nothing and so no recipe will be returned and content will not
+  // be loaded successfully into the inner arc.
+  constructInnerRecipe?(hostedParticle, item, itemHandle, slot, other): string;
+}

--- a/src/runtime/ui-multiplexer-particle.ts
+++ b/src/runtime/ui-multiplexer-particle.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright (c) 2017 Google Inc. All rights reserved.
  * This code may only be used under the BSD style license found at
  * http://polymer.github.io/LICENSE.txt
@@ -15,7 +16,7 @@ import {Type} from './type.js';
 
 export class UiMultiplexerParticle extends UiTransformationParticle {
 
-  plexeds: any[];
+  plexeds; //: any[];
 
   async setHandles(handles: ReadonlyMap<string, Handle>): Promise<void> {
     this.plexeds = [];
@@ -27,7 +28,7 @@ export class UiMultiplexerParticle extends UiTransformationParticle {
     let otherMappedHandles: string[] = [];
     let otherConnections: string[] = [];
     if (particleHandle) {
-      hostedParticle = await particleHandle["get"]();
+      hostedParticle = await particleHandle['get']();
       if (hostedParticle) {
         ({otherMappedHandles, otherConnections} =
             await this._mapParticleConnections(listHandleName, particleHandleName, hostedParticle, handles, arc));
@@ -70,7 +71,7 @@ export class UiMultiplexerParticle extends UiTransformationParticle {
     //console.warn('m-d-p', slotIds);
     // clear data from unused particles/handles
     for (let i=list.length, plexed; (plexed=this.plexeds[i]); i++) {
-      plexed.then(plexed => plexed.handle["clear"]());
+      plexed.then(plexed => plexed.handle['clear']());
     }
   }
 
@@ -87,13 +88,14 @@ export class UiMultiplexerParticle extends UiTransformationParticle {
     const plexed = await this.requirePlexed(index, item,
       {hostedParticle, arc, type, otherConnections, otherMappedHandles});
     // TODO(sjmiles): work out a proper cast (and conditional), or fix upstream type
-    plexed.handle["set"](item);
+    plexed.handle['set'](item);
     return plexed.slotId;
   }
 
   async requirePlexed(index, item, {arc, type, hostedParticle, otherConnections, otherMappedHandles}) {
     let promise = this.plexeds[index];
     if (!promise) {
+      // eslint-disable-next-line no-async-promise-executor
       promise = new Promise(async resolve => {
         const handle = await this.acquireItemHandle(index, {arc, item, type});
         const hosting = await this.resolveHosting(item, {arc, hostedParticle, otherConnections, otherMappedHandles});

--- a/src/runtime/ui-particle.ts
+++ b/src/runtime/ui-particle.ts
@@ -1,0 +1,180 @@
+/**
+ * Copyright (c) 2017 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {XenStateMixin} from '../../modalities/dom/components/xen/xen-state.js';
+import {UiSimpleParticle, RenderModel} from './ui-simple-particle.js';
+import {Handle, Collection, Singleton} from './handle.js';
+import {Runnable} from './hot.js';
+
+export interface UiStatefulParticle extends UiSimpleParticle {
+  // add type info for XenState members here
+  _invalidate(): void;
+}
+
+// binds implementation below to interface above
+export interface UiParticle extends UiStatefulParticle {
+}
+
+/**
+ * Particle that interoperates with DOM and uses a simple state system
+ * to handle updates.
+ */
+// TODO(sjmiles): seems like this is really `UiStatefulParticle` but it's
+// used so often, I went with the simpler name
+export class UiParticle extends XenStateMixin(UiSimpleParticle) {
+  /**
+   * Override if necessary, to do things when props change.
+   * Avoid if possible, use `update` instead.
+   */
+  willReceiveProps(...args): void {
+  }
+
+  // affordance so subclasses can avoid `_`
+  _willReceiveProps(...args): void {
+    this.willReceiveProps(...args);
+  }
+
+  /**
+   * Override to do things when props or state change.
+   */
+  update(...args): void {
+  }
+
+  /**
+   * Override to return a dictionary to map into the template.
+   */
+  render(...args): RenderModel {
+    return {};
+  }
+
+  /**
+   * Copy values from `state` into the particle's internal state,
+   * triggering an update cycle unless currently updating.
+   */
+  setState(state): boolean | undefined {
+    return this._setState(state);
+  }
+
+  /**
+   * Getters and setters for working with state/props.
+   */
+  get state() {
+    return this._state;
+  }
+
+  /**
+   * Syntactic sugar: `this.state = {state}` is equivalent to `this.setState(state)`.
+   * This is actually a merge, not an assignment.
+   */
+  set state(state) {
+    this.setState(state);
+  }
+
+  get props() {
+    return this._props;
+  }
+
+  _update(...args): void {
+    this.update(...args);
+    //
+    if (this.shouldRender(...args)) { // TODO: should shouldRender be slot specific?
+      this.relevance = 1; // TODO: improve relevance signal.
+      this.renderOutput(...args);
+    }
+  }
+
+  _async(fn) {
+    // asynchrony in Particle code must be bookended with start/doneBusy
+    this.startBusy();
+    const done = () => {
+      try {
+        fn.call(this);
+      } finally {
+        this.doneBusy();
+      }
+    };
+    // TODO(sjmiles): superclass uses Promise.resolve(),
+    // but here use a short timeout for a wider debounce
+    return setTimeout(done, 10);
+  }
+
+  async setHandles(handles: ReadonlyMap<string, Handle>): Promise<void> {
+    this.configureHandles(handles);
+    this.handles = handles;
+    // TODO(sjmiles): we must invalidate at least once, is there a way to know
+    // whether handleSync/update will be called?
+    this._invalidate();
+  }
+
+  /**
+   * This is called once during particle setup. Override to control sync and update
+   * configuration on specific handles (via their configure() method).
+   * `handles` is a map from names to handle instances.
+   */
+  configureHandles(handles: ReadonlyMap<string, Handle>): void {
+    // Example: handles.get('foo').configure({keepSynced: false});
+  }
+
+  async onHandleSync(handle: Handle, model: RenderModel): Promise<void> {
+    this._setProperty(handle.name, model);
+  }
+
+  async onHandleUpdate({name}: Handle, {data, added, removed}): Promise<void> {
+    if (data !== undefined) {
+      //console.log('update.data:', JSON.stringify(data, null, '  '));
+      this._setProps({[name]: data});
+    }
+    if (added) {
+      //console.log('update.added:', JSON.stringify(added, null, '  '));
+      const prop = (this.props[name] || []).concat(added);
+      // TODO(sjmiles): generally improper to set `this._props` directly, this is a special case
+      this._props[name] = prop;
+      this._setProps({[name]: prop});
+    }
+    if (removed) {
+      //console.log('update.removed:', JSON.stringify(removed, null, '  '));
+      const prop = this.props[name];
+      if (Array.isArray(prop)) {
+        removed.forEach(removed => {
+          // TODO(sjmiles): linear search is inefficient
+          const index = prop.findIndex(entry => this.idFor(entry) === this.idFor(removed));
+          if (index >= 0) {
+            prop.splice(index, 1);
+          } else {
+            console.warn(`dom-particle::onHandleUpdate: couldn't find item to remove`);
+          }
+        });
+        this._setProps({[name]: prop});
+      }
+    }
+  }
+
+  fireEvent(slotName: string, {handler, data}) {
+    if (this[handler]) {
+      // TODO(sjmiles): remove deprecated `this._state` parameter
+      this[handler]({data}, this._state);
+    }
+  }
+
+  debounce(key: string, func: Runnable, delay: number) {
+    const subkey = `_debounce_${key}`;
+    const state = this.state;
+    if (!state[subkey]) {
+      state[subkey] = true;
+      this.startBusy();
+    }
+    const idleThenFunc = () => {
+      this.doneBusy();
+      func();
+      state[subkey] = null;
+    };
+    // TODO(sjmiles): rewrite Xen debounce so caller has idle control
+    super._debounce(key, idleThenFunc, delay);
+  }
+}

--- a/src/runtime/ui-particle.ts
+++ b/src/runtime/ui-particle.ts
@@ -1,4 +1,5 @@
 /**
+ * @license
  * Copyright (c) 2017 Google Inc. All rights reserved.
  * This code may only be used under the BSD style license found at
  * http://polymer.github.io/LICENSE.txt

--- a/src/runtime/ui-simple-particle.ts
+++ b/src/runtime/ui-simple-particle.ts
@@ -1,0 +1,270 @@
+/**
+ * @license
+ * Copyright (c) 2017 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {Entity} from './entity.js';
+import {BigCollection, Collection, Singleton} from './handle.js';
+import {Particle} from './particle.js';
+import {SlotProxy} from './slot-proxy.js';
+//import {Content} from './slot-consumer.js';
+
+export interface UiParticleConfig {
+  handleNames: string[];
+  slotNames: string[];
+}
+
+export type RenderModel = object;
+
+/**
+ * Particle that can render and process events.
+ */
+export class UiSimpleParticle extends Particle {
+  private currentSlotName: string | undefined;
+
+  /**
+   * Override if necessary, to modify superclass config.
+   */
+  get config(): UiParticleConfig {
+    // TODO(sjmiles): getter that does work is a bad idea, this is temporary
+    return {
+      handleNames: this.spec.inputs.map(i => i.name),
+      // TODO(mmandlis): this.spec needs to be replaced with a particle-spec loaded from
+      // .arcs files, instead of .ptcl ones.
+      slotNames: this.spec.slandleConnectionNames()
+    };
+  }
+
+  /**
+   * Override to return a template.
+   */
+  get template(): string {
+    return '';
+  }
+
+  /**
+   * Override to return a String defining primary markup for the given slot name.
+   */
+  // getTemplate(slotName: string): string {
+  //   // TODO: only supports a single template for now. add multiple templates support.
+  //   return this.template;
+  // }
+
+  /**
+   * Override to return a String defining the name of the template for the given slot name.
+   */
+  // getTemplateName(slotName: string): string {
+  //   // TODO: only supports a single template for now. add multiple templates support.
+  //   return `default`;
+  // }
+
+  /**
+   * Override to return false if the Particle isn't ready to `render()`
+   */
+  shouldRender(...args): boolean {
+    return true;
+  }
+
+  renderOutput(...args): void {
+    const renderModel = this.render(...args);
+    if (renderModel) {
+      this.renderModel(renderModel);
+    }
+  }
+
+  // This is the default output 'packet', other implementations (modalities) could
+  // output other things, or choose different output packets based on hints from 'model'
+  renderModel(model) {
+    this.output({
+      template: this.template,
+      model
+    });
+  }
+
+  /**
+   * Override to return a dictionary to map into the template.
+   */
+  render(stateArgs?): RenderModel {
+    return {};
+  }
+
+  protected _getStateArgs() {
+    return [];
+  }
+
+  // forceRenderTemplate(slotName: string = ''): void {
+  //   this.slotProxiesByName.forEach((slot: SlotProxy, name: string) => {
+  //     if (!slotName || (name === slotName)) {
+  //       slot.requestedContentTypes.add('template');
+  //     }
+  //   });
+  // }
+
+  fireEvent(slotName: string, {handler, data}): void {
+    if (this[handler]) {
+      this[handler]({data});
+    }
+  }
+
+  async setParticleDescription(pattern: string | {template, model: {}}): Promise<boolean | undefined> {
+    if (typeof pattern === 'string') {
+      return super.setParticleDescription(pattern);
+    }
+    if (pattern.template && pattern.model) {
+      await super.setDescriptionPattern('_template_', pattern.template);
+      await super.setDescriptionPattern('_model_', JSON.stringify(pattern.model));
+      return undefined;
+    } else {
+      throw new Error('Description pattern must either be string or have template and model');
+    }
+  }
+
+  /**
+   * Remove all entities from named handle.
+   */
+  async clearHandle(handleName: string): Promise<void> {
+    const handle = this.handles.get(handleName);
+    if (handle instanceof Singleton || handle instanceof Collection) {
+      await handle.clear();
+    } else {
+      throw new Error('Singleton/Collection required');
+    }
+  }
+
+  /**
+   * Merge entities from Array into named handle.
+   */
+  async mergeEntitiesToHandle(handleName: string, entities: Entity[]): Promise<void> {
+    const idMap = {};
+    const handle = this.handles.get(handleName);
+    if (handle instanceof Collection) {
+      const handleEntities = await handle.toList();
+      handleEntities.forEach(entity => idMap[entity.id] = entity);
+      for (const entity of entities) {
+        if (!idMap[this.idFor(entity)]) {
+          await handle.store(entity);
+        }
+      }
+    } else {
+      throw new Error('Collection required');
+    }
+  }
+
+  /**
+   * Append entities from Array to named handle.
+   */
+  async appendEntitiesToHandle(handleName: string, entities: Entity[]): Promise<void> {
+    const handle = this.handles.get(handleName);
+    if (handle) {
+      if (handle instanceof Collection || handle instanceof BigCollection) {
+        await Promise.all(entities.map(entity => handle.store(entity)));
+      } else {
+        throw new Error('Collection required');
+      }
+    }
+  }
+
+  /**
+   * Create an entity from each rawData, and append to named handle.
+   */
+  async appendRawDataToHandle(handleName: string, rawDataArray): Promise<void> {
+    const handle = this.handles.get(handleName);
+    if (handle && handle.entityClass) {
+      if (handle instanceof Collection || handle instanceof BigCollection) {
+        const entityClass = handle.entityClass;
+        await Promise.all(rawDataArray.map(raw => handle.store(new entityClass(raw))));
+      } else {
+        throw new Error('Collection required');
+      }
+    }
+  }
+
+  /**
+   * Modify value of named handle. A new entity is created
+   * from `rawData` (`new [EntityClass](rawData)`).
+   */
+  async updateSingleton(handleName: string, rawData) {
+    const handle = this.handles.get(handleName);
+    if (handle && handle.entityClass) {
+      if (handle instanceof Singleton) {
+        const entity = new handle.entityClass(rawData);
+        await handle.set(entity);
+        return entity;
+      } else {
+        throw new Error('Singleton required');
+      }
+    }
+    return undefined;
+  }
+
+  /**
+   * Modify or insert `entity` into named handle.
+   * Modification is done by removing the old entity and reinserting the new one.
+   */
+  async updateCollection(handleName: string, entity: Entity): Promise<void> {
+    // Set the entity into the right place in the set. If we find it
+    // already present replace it, otherwise, add it.
+    // TODO(dstockwell): Replace this with happy entity mutation approach.
+    const handle = this.handles.get(handleName);
+    if (handle) {
+      if (handle instanceof Collection || handle instanceof BigCollection) {
+        await handle.remove(entity);
+        await handle.store(entity);
+      } else {
+        throw new Error('Collection required');
+      }
+    }
+  }
+
+  // TODO(sjmiles): experimental: high-level handle set
+  async set(name, value) {
+    const handle = this.handles.get(name);
+    if (handle) {
+      // TODO(sjmiles): cannot test class of `handle` because I have no
+      // references to those classes, i.e. `handle is Singleton`, throws
+      // because Singleton is undefined.
+      if (handle.type['isEntity']) {
+        const entity = value.entityClass ? value : new (handle.entityClass)(value);
+        return await handle['set'](entity);
+      }
+      else if (handle.type['isCollection']) {
+        if (Array.isArray(value)) {
+          await this.clearHandle(name);
+          await this.appendRawDataToHandle(name, value);
+        }
+      }
+    }
+  }
+
+  /**
+   * Return array of Entities dereferenced from array of Share-Type Entities
+   */
+  async derefShares(shares): Promise<Entity[]> {
+    let entities = [];
+    this.startBusy();
+    try {
+      const derefPromises = shares.map(async share => share.ref.dereference());
+      entities = await Promise.all(derefPromises);
+    } finally {
+      this.doneBusy();
+    }
+    return entities;
+  }
+
+  /**
+   * Returns array of Entities found in BOXED data `box` that are owned by `userid`
+   */
+  async boxQuery(box, userid): Promise<{}[]> {
+    if (!box) {
+      return [];
+    } else {
+      const matches = box.filter(item => userid === item.fromKey);
+      return await this.derefShares(matches);
+    }
+  }
+}

--- a/src/runtime/ui-slot-composer.ts
+++ b/src/runtime/ui-slot-composer.ts
@@ -1,0 +1,257 @@
+/**
+ * @license
+ * Copyright (c) 2017 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {assert} from '../platform/assert-web.js';
+import {Arc} from './arc.js';
+import {Description} from './description.js';
+import {ModalityHandler} from './modality-handler.js';
+import {Modality} from './modality.js';
+import {Particle} from './recipe/particle.js';
+import {SlotConsumer} from './slot-consumer.js';
+import {ProvidedSlotContext, SlotContext} from './slot-context.js';
+import {logsFactory} from './log-factory.js';
+
+const {log, warn} = logsFactory('UiSlotComposer', 'brown');
+
+export type SlotComposerOptions = {
+  modalityName?: string;
+  modalityHandler?: ModalityHandler;
+  noRoot?: boolean;
+  rootContainer?;
+  rootContext?;
+  containerKind?: string;
+  containers?;
+};
+
+export class UiSlotComposer {
+  private readonly _containerKind: string;
+  readonly modality: Modality;
+  readonly modalityHandler: ModalityHandler;
+  private readonly _consumers: SlotConsumer[] = [];
+  protected _contexts: SlotContext[] = [];
+
+  /**
+   * |options| must contain:
+   * - modalityName: the UI modality the slot-composer renders to (for example: dom).
+   * - modalityHandler: the handler for UI modality the slot-composer renders to.
+   * - rootContainer: the top level container to be used for slots.
+   * and may contain:
+   * - containerKind: the type of container wrapping each slot-context's container  (for example, div).
+   */
+  constructor(options: SlotComposerOptions) {
+    const opts = Object.assign({
+      containers: {'root': 'root-context'},
+      modalityHandler: ModalityHandler.basicHandler
+    }, options);
+
+    // TODO: Support rootContext for backward compatibility, remove when unused.
+    // options.rootContainer = options.rootContainer || options.rootContext || (options.containers || Object).root;
+    // assert((options.rootContainer !== undefined)
+    //        !==
+    //        (options.noRoot === true),
+    //   'Root container is mandatory unless it is explicitly skipped');
+    // this._containerKind = options.containerKind;
+    // if (options.modalityName) {
+    //   this.modality = Modality.create([options.modalityName]);
+    // }
+    this.modalityHandler = opts.modalityHandler;
+
+    //if (opts.noRoot) {
+    //  return;
+    //}
+
+    const containerByName =
+        opts.containers
+        //|| this.findRootContainers(options.rootContainer)
+        //|| {}
+        ;
+    //if (Object.keys(containerByName).length === 0) {
+      // fallback to single 'root' slot using the rootContainer.
+      //containerByName['root'] = opts.rootContainer;
+    //}
+
+    Object.keys(containerByName).forEach(slotName => {
+      this._contexts.push(ProvidedSlotContext.createContextForContainer(
+        `rootslotid-${slotName}`, slotName, containerByName[slotName], [`${slotName}`]));
+    });
+  }
+
+  // findRootContainers(rootContainer) {
+  //   return this.modalityHandler.slotConsumerClass.findRootContainers(rootContainer)
+  // }
+
+  get consumers(): SlotConsumer[] {
+    return this._consumers;
+  }
+  get containerKind(): string {
+    return this._containerKind;
+  }
+
+  getSlotConsumer(particle: Particle, slotName: string): SlotConsumer {
+    return this.consumers.find(s => s.consumeConn.particle === particle && s.consumeConn.name === slotName);
+  }
+
+  findContainerByName(name: string): HTMLElement | undefined  {
+    // const contexts = this.findContextsByName(name);
+    // if (contexts.length === 0) {
+    //   // TODO this is a no-op, but throwing here breaks tests
+    //   console.warn(`No containers for '${name}'`);
+    // } else if (contexts.length === 1) {
+    //   return contexts[0].container;
+    // }
+    // console.warn(`Ambiguous containers for '${name}'`);
+    return undefined;
+  }
+
+  // TODO(sjmiles): only returns ProvidedSlotContexts, why is it called 'findContexts'?
+  findContextsByName(name: string): ProvidedSlotContext[] {
+    const filter = ctx => (ctx instanceof ProvidedSlotContext) && (ctx.name === name);
+    return this._contexts.filter(filter) as ProvidedSlotContext[];
+  }
+
+  findContextById(slotId: string): any {
+    return this._contexts.find(({id}) => id === slotId) || {};
+  }
+
+  createHostedSlot(innerArc: Arc, particle: Particle, slotName: string, storeId: string): string {
+    const slotConsumer = this.getSlotConsumer(particle, slotName);
+    assert(slotConsumer, `Transformation particle ${particle.name} with consumed ${slotName} not found`);
+    // TODO(sjmiles): this slot-id is created dynamically and was not available to the particle
+    // who renderered the slot (i.e. the dom node or other container). The renderer identifies these
+    // slots by entity-id (`subid`) instead. But `subid` is not unique, we need more information to
+    // locate the output slot, so we embed the muxed-slot's id into our output-slot-id.
+    const hostedSlotId = `${slotConsumer.slotContext.id}___${innerArc.generateID()}`;
+    //this._contexts.push(new HostedSlotContext(hostedSlotId, slotConsumer, storeId));
+    return hostedSlotId;
+  }
+
+  _addSlotConsumer(slot: SlotConsumer) {
+    const pec = slot.arc.pec;
+    slot.startRenderCallback = pec.startRender.bind(pec);
+    slot.stopRenderCallback = pec.stopRender.bind(pec);
+    this._consumers.push(slot);
+  }
+
+  async initializeRecipe(arc: Arc, recipeParticles: Particle[]) {
+    const newConsumers = <SlotConsumer[]>[];
+
+    // Create slots for each of the recipe's particles slot connections.
+    recipeParticles.forEach(p => {
+      p.getSlandleConnections().forEach(cs => {
+        if (!cs.targetSlot) {
+          assert(!cs.getSlotSpec().isRequired, `No target slot for particle's ${p.name} required consumed slot: ${cs.name}.`);
+          return;
+        }
+
+        const slotConsumer = new this.modalityHandler.slotConsumerClass(arc, cs, this._containerKind);
+        const providedContexts = slotConsumer.createProvidedContexts();
+        this._contexts = this._contexts.concat(providedContexts);
+        newConsumers.push(slotConsumer);
+      });
+    });
+
+    // Set context for each of the slots.
+    newConsumers.forEach(consumer => {
+      this._addSlotConsumer(consumer);
+      const context = this.findContextById(consumer.consumeConn.targetSlot.id);
+      // TODO(sjmiles): disabling this assert for now because rendering to unregistered slots
+      // is allowed under new rendering factorisation. Maybe we bring this back as a validity
+      // test in the future, but it's not a requirement atm.
+      //assert(context, `No context found for ${consumer.consumeConn.getQualifiedName()}`);
+      if (context && context.addSlotConsumer) {
+        context.addSlotConsumer(consumer);
+      }
+    });
+
+    // Calculate the Descriptions only once per-Arc
+    const allArcs = this.consumers.map(consumer => consumer.arc);
+    const uniqueArcs = [...new Set(allArcs).values()];
+
+    // get arc -> description
+    const descriptions = await Promise.all(uniqueArcs.map(arc => Description.create(arc)));
+
+    // create a mapping from the zipped uniqueArcs and descriptions
+    const consumerByArc = new Map(descriptions.map((description, index) => [uniqueArcs[index], description]));
+
+    // ... and apply to each consumer
+    for (const consumer of this.consumers) {
+      consumer.description = consumerByArc.get(consumer.arc);
+    }
+  }
+
+  renderSlot(particle: Particle, slotName: string, content) {
+    warn('[unsupported] renderSlot', particle.spec.name);
+  }
+
+  getAvailableContexts(): SlotContext[] {
+    return this._contexts;
+  }
+
+  dispose(): void {
+    this.disposeConsumers();
+    this.disposeContexts();
+    this.disposeObserver();
+  }
+
+  disposeConsumers() {
+    this._consumers.forEach(consumer => consumer.dispose());
+    this._consumers.length = 0;
+  }
+
+  disposeContexts() {
+    this._contexts.forEach(context => {
+      context.clearSlotConsumers();
+      if (context instanceof ProvidedSlotContext && context.container) {
+        this.modalityHandler.slotConsumerClass.clear(context.container);
+      }
+    });
+    this._contexts = this._contexts.filter(c => !c.sourceSlotConsumer);
+  }
+
+  // TODO(sjmiles): experimental slotObserver stuff below here
+
+  // TODO(sjmiles): maybe better implemented as a slot dispose (arc dispose?) notification to
+  // let client code clean up (so `slotObserver` details [like dispose()] can be hidden here)
+  disposeObserver() {
+    const observer = this['slotObserver'];
+    if (observer) {
+      observer.dispose();
+    }
+  }
+
+  delegateOutput(particle: Particle, content: any) {
+    const observer = this['slotObserver'];
+    if (observer && content) {
+      const connections = particle._consumedSlotConnections;
+      // build slot id map
+      const slotMap = {};
+      Object.values(connections).forEach(({providedSlots}) => {
+        Object.values(providedSlots).map(({name, id}) => slotMap[name] = id);
+      });
+      // identify parent container
+      const container = Object.values(connections)[0];
+      if (container) {
+        Object.assign(content, {
+          containerSlotName: container.targetSlot.name,
+          containerSlotId: container.targetSlot.id
+        });
+      }
+      Object.assign(content, {
+        particle,
+        slotMap,
+        outputSlotId: particle.id.toString()
+      });
+      //
+      //console.log(`RenderEx:delegateOutput for %c[${particle.spec.name}]::[${particle.id}]`, 'color: darkgreen; font-weight: bold;');
+      observer.observe(content, this["arc"]);
+    }
+  }
+
+}

--- a/src/runtime/ui-slot-composer.ts
+++ b/src/runtime/ui-slot-composer.ts
@@ -251,7 +251,7 @@ export class UiSlotComposer {
       });
       //
       //console.log(`RenderEx:delegateOutput for %c[${particle.spec.name}]::[${particle.id}]`, 'color: darkgreen; font-weight: bold;');
-      observer.observe(content, this["arc"]);
+      observer.observe(content, this['arc']);
     }
   }
 

--- a/src/runtime/ui-slot-composer.ts
+++ b/src/runtime/ui-slot-composer.ts
@@ -46,10 +46,11 @@ export class UiSlotComposer {
    * - containerKind: the type of container wrapping each slot-context's container  (for example, div).
    */
   constructor(options: SlotComposerOptions) {
-    const opts = Object.assign({
+    const opts = {
       containers: {'root': 'root-context'},
-      modalityHandler: ModalityHandler.basicHandler
-    }, options);
+      modalityHandler: ModalityHandler.basicHandler,
+      ...options
+    };
 
     // TODO: Support rootContext for backward compatibility, remove when unused.
     // options.rootContainer = options.rootContainer || options.rootContext || (options.containers || Object).root;
@@ -116,7 +117,7 @@ export class UiSlotComposer {
     return this._contexts.filter(filter) as ProvidedSlotContext[];
   }
 
-  findContextById(slotId: string): any {
+  findContextById(slotId: string) {
     return this._contexts.find(({id}) => id === slotId) || {};
   }
 
@@ -165,8 +166,8 @@ export class UiSlotComposer {
       // is allowed under new rendering factorisation. Maybe we bring this back as a validity
       // test in the future, but it's not a requirement atm.
       //assert(context, `No context found for ${consumer.consumeConn.getQualifiedName()}`);
-      if (context && context.addSlotConsumer) {
-        context.addSlotConsumer(consumer);
+      if (context && context['addSlotConsumer']) {
+        context['addSlotConsumer'](consumer);
       }
     });
 
@@ -226,7 +227,7 @@ export class UiSlotComposer {
     }
   }
 
-  delegateOutput(particle: Particle, content: any) {
+  delegateOutput(particle: Particle, content) {
     const observer = this['slotObserver'];
     if (observer && content) {
       const connections = particle._consumedSlotConnections;

--- a/src/runtime/ui-slot-composer.ts
+++ b/src/runtime/ui-slot-composer.ts
@@ -227,7 +227,7 @@ export class UiSlotComposer {
     }
   }
 
-  delegateOutput(particle: Particle, content) {
+  delegateOutput(arc: Arc, particle: Particle, content) {
     const observer = this['slotObserver'];
     if (observer && content) {
       const connections = particle._consumedSlotConnections;
@@ -251,7 +251,7 @@ export class UiSlotComposer {
       });
       //
       //console.log(`RenderEx:delegateOutput for %c[${particle.spec.name}]::[${particle.id}]`, 'color: darkgreen; font-weight: bold;');
-      observer.observe(content, this['arc']);
+      observer.observe(content, arc);
     }
   }
 

--- a/src/runtime/ui-transformation-particle.ts
+++ b/src/runtime/ui-transformation-particle.ts
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright (c) 2017 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {UiParticle} from './ui-particle.js';
+import {Entity} from './entity.js';
+
+/**
+ * Particle that does transformation.
+ */
+export class UiTransformationParticle extends UiParticle {
+
+  getTemplate(slotName: string) {
+    // TODO: add support for multiple slots.
+    return this.state.template;
+  }
+
+  getTemplateName(slotName: string) {
+    // TODO: add support for multiple slots.
+    return this.state.templateName;
+  }
+
+  render(props, state) {
+    return state.renderModel;
+  }
+
+  shouldRender(props, state): boolean {
+    return Boolean((state.template || state.templateName) && state.renderModel);
+  }
+
+  // Helper methods that may be reused in transformation particles to combine hosted content.
+  static propsToItems(propsValues) {
+    return propsValues ? propsValues.map(e => ({subId: Entity.id(e), ...e})) : [];
+  }
+}


### PR DESCRIPTION
- xen-template is tweaked to fix the pluggable annotator (I use pluggable annotator in xen-renderer to find local slot-names)
- xen-renderer is the (messy atm, but highly portable) module for reifying render-packets into DOM 
- smoke-shell and the one recipe it uses (Login.arcs) are updated to test the new pipeline
- loader is updated to supply UIParticle and friends to `defineParticle`
- api-channel.ts, pec.ts, peh.ts, and particle.ts are changed to plumb `output` method into Particle (that method delegates to capabilities.output [if it exists] which ends up calling onOutput in the PEH, which in turn calls composer.delegateOutput [if it exists]).
- lastly are the ui-* forks ... mostly these are just tweaked duplicates of the dom-* versions (e.g. ui-multiplexer-particle started as a copy of multiplex-dom-particle)

These changes are still invisible unless using smoke-shell: this PR is the camel's nose only.