### PR TITLE
Bazel arcs_cc_schema rule for generating C++ headers from .arcs schemas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,5 +43,7 @@ bazel-genfiles
 bazel-javaharness
 bazel-out
 bazel-testlogs
+bazel-arcs
+.bazelrc
 .ijwb
 .sighdeps

--- a/build_defs/BUILD
+++ b/build_defs/BUILD
@@ -1,0 +1,1 @@
+exports_files(["run_in_repo_template.sh"])

--- a/build_defs/build_defs.bzl
+++ b/build_defs/build_defs.bzl
@@ -1,0 +1,22 @@
+load(":run_in_repo.bzl", "run_in_repo")
+
+def arcs_cc_schema(name, src, out = None):
+    """Generates a C++ header file for the given .arcs schema file.
+
+    Runs sigh schema2pkg to generate the output.
+    """
+
+    if not src.endswith(".arcs"):
+        fail("src must be a .arcs file")
+
+    if out == None:
+        # Clean up the output name.
+        out = src.replace(".arcs", "").replace("_", "-").replace(".", "-") + ".h"
+
+    run_in_repo(
+        name = name,
+        srcs = [src],
+        outs = [out],
+        cmd = "./tools/sigh schema2pkg --cpp --outdir / --outfile {OUT} {SRC}",
+        progress_message = "Generating C++ entity schemas",
+    )

--- a/build_defs/build_defs.bzl
+++ b/build_defs/build_defs.bzl
@@ -17,6 +17,11 @@ def arcs_cc_schema(name, src, out = None):
         name = name,
         srcs = [src],
         outs = [out],
-        cmd = "./tools/sigh schema2pkg --cpp --outdir / --outfile {OUT} {SRC}",
+        # TODO: generated header guard should contain whole workspace-relative
+        # path to file.
+        cmd = "./tools/sigh schema2pkg --cpp " +
+              "--outdir $(dirname {OUT}) " +
+              "--outfile $(basename {OUT}) " +
+              "{SRC}",
         progress_message = "Generating C++ entity schemas",
     )

--- a/build_defs/run_in_repo.bzl
+++ b/build_defs/run_in_repo.bzl
@@ -1,0 +1,96 @@
+_RUNNER_SCRIPT = """#!/bin/sh
+set -e
+cd "{repo_root}"
+{cmd}
+"""
+
+def _absolute_path(repo_root, path):
+    """Converts path relative to the repo root into an absolute file path."""
+    return repo_root + "/" + path
+
+def _run_in_repo(ctx):
+    # Extract the repo root directory from .bazelrc
+    if "repo_root" not in ctx.var:
+        fail(
+            "\n*****\n" +
+            "repo_root is not defined. Run the following command from the root " +
+            "of your workspace:\n\n" +
+            "echo \"build --define=repo_root=$(pwd)\" >> .bazelrc\n" +
+            "*****\n\n",
+        )
+    repo_root = ctx.var["repo_root"]
+
+    # Collect input and output files, and compute string substitutions.
+    input_files = ctx.files.srcs
+    input_paths = [f.path for f in input_files]
+    SRCS = " ".join(input_paths)
+    SRC = input_paths[0] if len(input_paths) == 1 else None
+
+    output_files = ctx.outputs.outs
+    output_paths = [_absolute_path(repo_root, f.path) for f in output_files]
+    OUTS = " ".join(output_paths)
+    OUT = output_paths[0] if len(output_paths) == 1 else None
+
+    # Perform cmd string substitutions.
+    cmd = ctx.attr.cmd
+    cmd = cmd.format(SRC = SRC, SRCS = SRCS, OUT = OUT, OUTS = OUTS)
+
+    # Write a shell script to perform the command.
+    script_name = ctx.attr.name + ".sh"
+    script_file = ctx.actions.declare_file(script_name)
+    ctx.actions.write(
+        output = script_file,
+        content = _RUNNER_SCRIPT.format(repo_root = repo_root, cmd = cmd),
+        is_executable = True,
+    )
+
+    # Run the shell script.
+    ctx.actions.run(
+        executable = script_file,
+        inputs = input_files,
+        outputs = output_files,
+        progress_message = ctx.attr.progress_message,
+        use_default_shell_env = True,
+        execution_requirements = {
+            "no-sandbox": "1",
+            "no-cache": "1",
+            "no-remote": "1",
+            "local": "1",
+        },
+    )
+
+run_in_repo = rule(
+    implementation = _run_in_repo,
+    attrs = {
+        "cmd": attr.string(
+            doc = """
+Command to run in the repo root. You can use standard python format placeholders
+of the form \{SRCS\}, which will be substituted when the command is run.
+Placeholders are:
+ * SRCS: list of input source files (relative to repo root).
+ * OUTS: list of output files (absolute filesystem paths).
+You can also use SRC and OUT, provided you have supplied only a single input or
+output file respectively.
+""",
+        ),
+        "outs": attr.output_list(
+            allow_empty = False,
+            mandatory = True,
+            doc = "Output file(s) created by this rule.",
+        ),
+        "srcs": attr.label_list(
+            allow_files = True,
+            doc = "Input file(s) used by this rule.",
+        ),
+        "progress_message": attr.string(
+            doc = "Message to display when running the command.",
+        ),
+    },
+    doc = """
+Runs the given shell command in the root directory of the respository. This lets
+you read/write files directly from the repository (as opposed to the bazel
+sandbox), so it can be destructive and can overwrite existing files.
+
+Useful for invoking sigh commands.
+""",
+)

--- a/build_defs/run_in_repo_template.sh
+++ b/build_defs/run_in_repo_template.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+# cd to repo root first before running command.
+cd "{repo_root}"
+{cmd}

--- a/src/wasm/cpp/tests/BUILD
+++ b/src/wasm/cpp/tests/BUILD
@@ -1,0 +1,7 @@
+load("//build_defs:build_defs.bzl", "arcs_cc_schema")
+
+arcs_cc_schema(
+    name = "schemas",
+    src = "schemas.arcs",
+    out = "entities.h",
+)


### PR DESCRIPTION
This works by running the sigh schema2pkg command in the repository root
directory, and writing the results into the expected bazel-out folder.

Other sigh commands can be trivially wrapped in the same way.