### PR TITLE
Fixes for ts_library/tsetse builds

### DIFF
--- a/src/planning/strategies/match-recipe-by-verb.ts
+++ b/src/planning/strategies/match-recipe-by-verb.ts
@@ -19,6 +19,7 @@ import {GenerateParams, Descendant} from '../../runtime/recipe/walker.js';
 import {Direction} from '../../runtime/manifest-ast-nodes.js';
 import {Type} from '../../runtime/type.js';
 import {HandleConnection} from '../../runtime/recipe/handle-connection.js';
+import {Dictionary} from '../../runtime/hot.js';
 
 // This strategy substitutes '&verb' declarations with recipes,
 // according to the following conditions:
@@ -32,7 +33,7 @@ import {HandleConnection} from '../../runtime/recipe/handle-connection.js';
 // this strategy currently only connects the first instance of the pattern up
 // if there are multiple instances.
 type HandleConstraint = {handle: Handle, direction: Direction};
-type SlotConstraint = {targetSlot: Slot, providedSlots: Dict<Slot>};
+type SlotConstraint = {targetSlot: Slot, providedSlots: Dictionary<Slot>};
 
 export class MatchRecipeByVerb extends Strategy {
 
@@ -52,7 +53,7 @@ export class MatchRecipeByVerb extends Strategy {
         //
         // Note that slots are only included if connected to other components of the recipe - e.g.
         // the target slot has a source connection.
-        const slotConstraints: Dict<SlotConstraint> = {};
+        const slotConstraints: Dictionary<SlotConstraint> = {};
         for (const consumeSlot of particle.getSlotConnections()) {
           const targetSlot = consumeSlot.targetSlot && consumeSlot.targetSlot.sourceConnection ? consumeSlot.targetSlot : null;
           slotConstraints[consumeSlot.name] = {targetSlot, providedSlots: {}};
@@ -177,7 +178,7 @@ export class MatchRecipeByVerb extends Strategy {
     }(StrategizerWalker.Permuted), this);
   }
 
-  static satisfiesHandleConstraints(recipe: Recipe, handleConstraints: {named: Dict<HandleConstraint>, unnamed: HandleConstraint[]}) {
+  static satisfiesHandleConstraints(recipe: Recipe, handleConstraints: {named: Dictionary<HandleConstraint>, unnamed: HandleConstraint[]}) {
     for (const handleName in handleConstraints.named) {
       if (!MatchRecipeByVerb.satisfiesHandleConnection(
               recipe, handleName, handleConstraints.named[handleName])) {
@@ -250,7 +251,7 @@ export class MatchRecipeByVerb extends Strategy {
     return Boolean(Handle.effectiveType(handleConstraint.handle.mappedType, connections));
   }
 
-  static satisfiesSlotConstraints(recipe: Recipe, slotConstraints: Dict<SlotConstraint>): boolean {
+  static satisfiesSlotConstraints(recipe: Recipe, slotConstraints: Dictionary<SlotConstraint>): boolean {
     for (const slotName in slotConstraints) {
       if (!MatchRecipeByVerb.satisfiesSlotConnection(
               recipe, slotName, slotConstraints[slotName])) {

--- a/src/runtime/description-formatter.ts
+++ b/src/runtime/description-formatter.ts
@@ -81,7 +81,7 @@ export class DescriptionFormatter {
   // tslint:disable-next-line: no-any
   _combineSelectedDescriptions(selectedDescriptions: ParticleDescription[], options: CombinedDescriptionsOptions = {}) {
     const suggestions = [];
-    selectedDescriptions.map(particle => {
+    selectedDescriptions.forEach(particle => {
       if (!this.seenParticles.has(particle._particle)) {
         suggestions.push(this.patternToSuggestion(particle.pattern, particle));
       }

--- a/src/runtime/description.ts
+++ b/src/runtime/description.ts
@@ -155,7 +155,7 @@ export class Description {
     return {};
   }
 
-  private static async _prepareStoreValue(store: StorageProviderBase | StorageStub): Promise<DescriptionValue>|undefined {
+  private static async _prepareStoreValue(store: StorageProviderBase | StorageStub): Promise<DescriptionValue|undefined> {
     if (!store || (store instanceof StorageStub)) {
       return undefined;
     }

--- a/src/runtime/interface-info.ts
+++ b/src/runtime/interface-info.ts
@@ -151,7 +151,7 @@ export class InterfaceInfo {
   }
 
   mergeTypeVariablesByName(variableMap: Map<string, Type>) {
-    this.typeVars.map(({object, field}) => object[field] = (object[field] as Type).mergeTypeVariablesByName(variableMap));
+    this.typeVars.forEach(({object, field}) => object[field] = (object[field] as Type).mergeTypeVariablesByName(variableMap));
   }
 
   get canReadSubset() {

--- a/src/runtime/recipe/recipe-util.ts
+++ b/src/runtime/recipe/recipe-util.ts
@@ -394,7 +394,7 @@ export class RecipeUtil {
         newMatches = newMatches.concat(
             RecipeUtil._assignHandlesToEmptyPosition(shape, match, [thisHandle], nullHandles));
       } else {
-        newMatches.concat(match);
+        newMatches = newMatches.concat(match);
       }
     }
     return newMatches;

--- a/src/runtime/recipe/recipe.ts
+++ b/src/runtime/recipe/recipe.ts
@@ -116,7 +116,7 @@ export class Recipe implements Cloneable<Recipe> {
     const idx = this._particles.indexOf(particle);
     assert(idx > -1);
     this._particles.splice(idx, 1);
-    particle.getSlotConnections().map(conn => conn.remove());
+    particle.getSlotConnections().forEach(conn => conn.remove());
   }
 
   newHandle(): Handle {
@@ -580,11 +580,11 @@ export class Recipe implements Cloneable<Recipe> {
     };
 
     i = 0;
-    this.particles.map(particle => mapName(particle, 'particle'));
+    this.particles.forEach(particle => mapName(particle, 'particle'));
     i = 0;
-    this.handles.map(handle => mapName(handle, 'handle'));
+    this.handles.forEach(handle => mapName(handle, 'handle'));
     i = 0;
-    this.slots.map(slot => mapName(slot, 'slot'));
+    this.slots.forEach(slot => mapName(slot, 'slot'));
 
     return nameMap;
   }

--- a/src/runtime/slot-consumer.ts
+++ b/src/runtime/slot-consumer.ts
@@ -184,7 +184,7 @@ export class SlotConsumer {
   private _populateHandleDescriptions(): Map<string, Description> {
     if (!this.consumeConn) return null; // TODO: remove null ability
     const descriptions: Map<string, Description> = new Map();
-    Object.values(this.consumeConn.particle.connections).map(handleConn => {
+    Object.values(this.consumeConn.particle.connections).forEach(handleConn => {
       if (handleConn.handle) {
         descriptions[`${handleConn.name}.description`] =
             this.description.getHandleDescription(handleConn.handle).toString();

--- a/src/runtime/storageNG/direct-store.ts
+++ b/src/runtime/storageNG/direct-store.ts
@@ -214,12 +214,14 @@ export class DirectStore<T extends CRDTTypeRecord> extends ActiveStore<T> {
           }
         }
         const change: CRDTChange<T> = {changeType: ChangeType.Operations, operations: message.operations};
-        void this.processModelChange(change, null, this.version, false);
+        // to make tsetse checks happy
+        const noAwait = this.processModelChange(change, null, this.version, false);
         return true;
       }
       case ProxyMessageType.ModelUpdate: {
         const {modelChange, otherChange} = this.localModel.merge(message.model);
-        void this.processModelChange(modelChange, otherChange, this.version, false);
+        // to make tsetse checks happy
+        const noAwait = this.processModelChange(modelChange, otherChange, this.version, false);
         return true;
       }
       default:

--- a/src/runtime/storageNG/direct-store.ts
+++ b/src/runtime/storageNG/direct-store.ts
@@ -14,6 +14,7 @@ import {Type} from '../type.js';
 import {Exists, Driver, DriverFactory} from './drivers/driver-factory.js';
 import {StorageKey} from './storage-key.js';
 import {ActiveStore, ProxyCallback, StorageMode, ProxyMessageType, ProxyMessage} from './store-interface.js';
+import {noAwait} from '../util.js';
 
 export enum DirectStoreState {Idle = 'Idle', AwaitingResponse = 'AwaitingResponse', AwaitingResponseDirty = 'AwaitingResponseDirty', AwaitingDriverModel = 'AwaitingDriverModel'}
 
@@ -215,13 +216,13 @@ export class DirectStore<T extends CRDTTypeRecord> extends ActiveStore<T> {
         }
         const change: CRDTChange<T> = {changeType: ChangeType.Operations, operations: message.operations};
         // to make tsetse checks happy
-        const noAwait = this.processModelChange(change, null, this.version, false);
+        noAwait(this.processModelChange(change, null, this.version, false));
         return true;
       }
       case ProxyMessageType.ModelUpdate: {
         const {modelChange, otherChange} = this.localModel.merge(message.model);
         // to make tsetse checks happy
-        const noAwait = this.processModelChange(modelChange, otherChange, this.version, false);
+        noAwait(this.processModelChange(modelChange, otherChange, this.version, false));
         return true;
       }
       default:

--- a/src/runtime/ui-slot-composer.ts
+++ b/src/runtime/ui-slot-composer.ts
@@ -234,7 +234,7 @@ export class UiSlotComposer {
       // build slot id map
       const slotMap = {};
       Object.values(connections).forEach(({providedSlots}) => {
-        Object.values(providedSlots).map(({name, id}) => slotMap[name] = id);
+        Object.values(providedSlots).forEach(({name, id}) => slotMap[name] = id);
       });
       // identify parent container
       const container = Object.values(connections)[0];

--- a/src/runtime/util.ts
+++ b/src/runtime/util.ts
@@ -74,3 +74,14 @@ export function setDiffCustom<T, U>(from: T[], to: T[], keyFn: (T) => U): {add: 
  * TODO: Remove all usages of this function and then delete it.
  */
 export function floatingPromiseToAudit<T>(promise: Promise<T>) {}
+
+/**
+ * Noop function that can be used to supress the tsetse must-use-promises rule.
+ *
+ * Example Usage:
+ *   async function x() {
+ *     await doA();
+ *     noAwait(doB());
+ *   }
+ */
+export function noAwait(result: {then: Function}) {}


### PR DESCRIPTION
Make blaze/bazel ts_library lint checker (tsetse) happy

1) methods which return a value but the value is ignored (in one instance, it appears to have found an honest to goodness bug?)

2) must-use-promises. If you're not going to await and async method, you have to assign it to a variable to silence the check

This PR enables blaze to build and run code in tools/ like flowcheck
