### PR TITLE
Added BUILD rules for C++ wasm compilation with Emscripten

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,4 @@
+load("//build_defs/emscripten:repo.bzl", "emsdk_repo")
+
+# Install Emscripten via the emsdk.
+emsdk_repo()

--- a/build_defs/emscripten/BUILD
+++ b/build_defs/emscripten/BUILD
@@ -1,0 +1,7 @@
+# Wrapper script around Emscripten command line tools (e.g. em++).
+sh_binary(
+    name = "emsdk_wrapper",
+    srcs = ["emsdk_wrapper.sh"],
+    data = ["@emsdk//:all_files"],
+    visibility = ["//visibility:public"],
+)

--- a/build_defs/emscripten/build_defs.bzl
+++ b/build_defs/emscripten/build_defs.bzl
@@ -20,6 +20,9 @@ _emscripten_args = [
     "EXPORTED_FUNCTIONS=['_malloc','_free']",
     "-s",
     "EMIT_EMSCRIPTEN_METADATA",
+    # For workspace-relative #includes:
+    "-I",
+    ".",
 ]
 
 def _collect_deps(srcs, hdrs, deps):
@@ -37,9 +40,6 @@ def _collect_deps(srcs, hdrs, deps):
 def _cc_wasm_binary(ctx):
     args = ctx.actions.args()
     args.add_all(_emscripten_args)
-
-    # For workspace-relative #includes.
-    args.add("-I", ".")
 
     # For generated #includes.
     args.add("-I", ctx.genfiles_dir.path)

--- a/build_defs/emscripten/build_defs.bzl
+++ b/build_defs/emscripten/build_defs.bzl
@@ -84,10 +84,10 @@ cc_wasm_binary = rule(
     doc = "Builds a wasm binary from C++",
 )
 
-# cc_wasm_library just holds on to source / header files. It doesn't try to
-# compile anything.
-# TODO(team): Consider implementing support for the dynamic linking spec;
-# then built libraries could be re-used rather than passing sources around.
+# cc_wasm_library just collects sources and headers, it doesn't actually build
+# anything.
+# TODO: make this build some sort of static/dynamic library that we can link
+# into the final binary.
 def _cc_wasm_library(ctx):
     srcs, hdrs = _collect_deps(
         srcs = ctx.files.srcs,

--- a/build_defs/emscripten/build_defs.bzl
+++ b/build_defs/emscripten/build_defs.bzl
@@ -1,0 +1,111 @@
+# Rules for compiling C++ to wasm using Emscripten.
+
+WasmLibInfo = provider(fields = [
+    "srcs",
+    "hdrs",
+])
+
+WasmBinInfo = provider(fields = [
+    "wasm",
+])
+
+# Default arguments to use when compiling wasm binaries with Emscripten.
+# Additional context-specific args will be added in the cc_wasm_binary rule
+# below.
+_emscripten_args = [
+    "em++",
+    "-std=c++17",
+    "-Os",
+    "-s",
+    "EXPORTED_FUNCTIONS=['_malloc','_free']",
+    "-s",
+    "EMIT_EMSCRIPTEN_METADATA",
+]
+
+def _collect_deps(srcs, hdrs, deps):
+    """Builds depsets out of the given srcs, hdrs and deps."""
+    src_depset = depset(
+        srcs,
+        transitive = [dep[WasmLibInfo].srcs for dep in deps],
+    )
+    hdr_depset = depset(
+        hdrs,
+        transitive = [dep[WasmLibInfo].hdrs for dep in deps],
+    )
+    return src_depset, hdr_depset
+
+def _cc_wasm_binary(ctx):
+    args = ctx.actions.args()
+    args.add_all(_emscripten_args)
+
+    # For workspace-relative #includes.
+    args.add("-I", ".")
+
+    # For generated #includes.
+    args.add("-I", ctx.genfiles_dir.path)
+
+    # Output a wasm file.
+    args.add("-o", ctx.outputs.wasm)
+
+    # Inputs
+    srcs, hdrs = _collect_deps(
+        srcs = ctx.files.srcs,
+        hdrs = ctx.files.hdrs,
+        deps = ctx.attr.deps,
+    )
+
+    args.add_all(srcs)
+
+    ctx.actions.run(
+        progress_message = "Compiling C++ to WebAssembly: %s" % ctx.label.name,
+        inputs = depset(transitive = [srcs, hdrs]),
+        outputs = [ctx.outputs.wasm],
+        arguments = [args],
+        executable = ctx.executable.emsdk_wrapper,
+    )
+
+    return [WasmBinInfo(wasm = ctx.outputs.wasm)]
+
+cc_wasm_binary = rule(
+    implementation = _cc_wasm_binary,
+    outputs = {
+        "wasm": "%{name}.wasm",
+    },
+    attrs = {
+        "srcs": attr.label_list(allow_files = True),
+        "hdrs": attr.label_list(allow_files = True),
+        "deps": attr.label_list(providers = [WasmLibInfo]),
+        "emsdk_wrapper": attr.label(
+            default = Label("//build_defs/emscripten:emsdk_wrapper"),
+            executable = True,
+            cfg = "host",
+        ),
+    },
+    doc = "Builds a wasm binary from C++",
+)
+
+# cc_wasm_library just holds on to source / header files. It doesn't try to
+# compile anything.
+# TODO(team): Consider implementing support for the dynamic linking spec;
+# then built libraries could be re-used rather than passing sources around.
+def _cc_wasm_library(ctx):
+    srcs, hdrs = _collect_deps(
+        srcs = ctx.files.srcs,
+        hdrs = ctx.files.hdrs,
+        deps = ctx.attr.deps,
+    )
+    return [WasmLibInfo(srcs = srcs, hdrs = hdrs)]
+
+cc_wasm_library = rule(
+    implementation = _cc_wasm_library,
+    outputs = {},
+    attrs = {
+        "srcs": attr.label_list(allow_files = True),
+        "hdrs": attr.label_list(allow_files = True),
+        "deps": attr.label_list(providers = [WasmLibInfo]),
+    },
+    doc = """
+Just collects .cc and .h files, doesn't actually build anything. Wasm output is
+only actually built by the cc_wasm_binary rule.
+""",
+)

--- a/build_defs/emscripten/emsdk.BUILD
+++ b/build_defs/emscripten/emsdk.BUILD
@@ -1,0 +1,12 @@
+# BUILD file to use for the emsdk git repo. This just makes the contents of the
+# emsdk repo available to use by Bazel.
+
+# Ignore files with spaces, they cause issues (and probably aren't actually
+# needed).
+_files_without_spaces = [f for f in glob(["**"]) if " " not in f]
+
+filegroup(
+    name = "all_files",
+    srcs = _files_without_spaces,
+    visibility = ["//visibility:public"],
+)

--- a/build_defs/emscripten/emsdk_wrapper.sh
+++ b/build_defs/emscripten/emsdk_wrapper.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+#
+# Script to run Emscripten tools from within the emsdk repo. Pass in command
+# line args that you want to run. The first arg should be the name of the tool
+# you want to run, e.g. "em++".
+
+repo_rel=${BASH_SOURCE[0]}.runfiles/emsdk
+repo=$(python -c '
+import sys
+import os.path
+print(os.path.abspath(sys.argv[1]))' "$repo_rel")
+
+# Set up the required environment variables. This is equivalent to running:
+#   source "$repo/emsdk_env.sh"
+export PATH="$PATH:$repo"
+export PATH="$PATH:$repo/fastcomp/emscripten"
+export PATH="$PATH:$repo/node/12.9.1_64bit/bin"
+export EMSDK="$repo"
+export EM_CONFIG="$repo/.emscripten"
+export EMSDK_NODE="$repo/node/12.9.1_64bit/bin/node"
+
+# Use a different location for emscripten's cache folder. The default one, which
+# is inside the emsdk folder, is read-only.
+export EM_CACHE="/tmp/bazel_emscripten"
+
+# Run the command line args that were passed to this script.
+exec "$@"

--- a/build_defs/emscripten/repo.bzl
+++ b/build_defs/emscripten/repo.bzl
@@ -1,0 +1,30 @@
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
+
+# The version of Emscripten to use. Upgrade instructions:
+# 1. Point to a new commit hash for the emsdk git repo.
+# 2. Choose a newer version of Emscripten to install. Versions numbers are
+#    listed here: https://github.com/emscripten-core/emsdk/blob/master/emscripten-releases-tags.txt
+## The directory structure might change between versions without warning, so
+# the emsdk.BUILD file might need updating too (also, the bundled version of
+# node might change too).
+_emsdk_commit_hash = "efc64876db1473312587a3f346be000a733bc16d"
+_emscripten_version = "1.38.43"
+
+def emsdk_repo():
+    """Clones the emsdk repo, and "installs" an Emscripten toolchain.
+
+    Emscripten is used to compile C++ to wasm. This rule clones the official
+    emsdk repo, installs a version of Emscripten, and patches it with a simple
+    BUILD rule. You can define new macros to invoke the Emscripten build tools.
+    """
+    new_git_repository(
+        name = "emsdk",
+        commit = _emsdk_commit_hash,
+        shallow_since = "1567538206 -0700",
+        remote = "https://github.com/emscripten-core/emsdk.git",
+        build_file = "//build_defs/emscripten:emsdk.BUILD",
+        patch_cmds = [
+            "./emsdk --embedded install %s" % _emscripten_version,
+            "./emsdk --embedded activate %s" % _emscripten_version,
+        ],
+    )


### PR DESCRIPTION
Not actually used anywhere yet.

This commit is an example of how it is used: https://github.com/PolymerLabs/arcs/pull/3525/commits/62dfc71af4d4457554c9d5dc3aeda22fd52f1501