### PR TITLE
Remove traps on id/rawData/dataClone field names in Entity.

### DIFF
--- a/src/runtime/entity.ts
+++ b/src/runtime/entity.ts
@@ -218,12 +218,6 @@ export abstract class Entity implements Storable {
     return `${this.constructor.name} { ${fields.join(', ')} }`;
   }
 
-  // TODO: remove ASAP, once we're satisfied there are no lingering direct accesses on these fields
-  // Note that this breaks any schemas that have an 'id' field (or rawData/dataClone).
-  get id() { throw new Error('entity.id is no longer valid; use Entity.id() or Particle.idFor()'); }
-  get rawData() { throw new Error('entity.rawData is no longer valid; use plain .field access or spread notation'); }
-  get dataClone() { throw new Error('entity.dataClone() is no longer valid; use use Entity.dataClone() or Particle.dataClone()'); }
-
   // Dynamically constructs a new JS class for the entity type represented by the given schema.
   // This creates a new class which extends the Entity base class and implements the required
   // static properties, then returns a Proxy wrapping that to guard against incorrect field writes.

--- a/src/runtime/tests/entity-test.ts
+++ b/src/runtime/tests/entity-test.ts
@@ -80,8 +80,7 @@ describe('Entity', () => {
     assert.strictEqual(entityClass.schema, schema);
   });
 
-  // TODO: restore this test the temporary id/rawData/dataClone traps are gone
-  it.skip('schema fields can use the same names as internal fields and methods', async () => {
+  it('schema fields can use the same names as internal fields and methods', async () => {
     const manifest = await Manifest.parse(`
       schema Shadow
         // internal fields
@@ -101,7 +100,7 @@ describe('Entity', () => {
     Entity.identify(e, 'arcs-id');
 
     // Reading the schema fields should match the input data fields.
-    // TODO: [restore] assert.strictEqual(e.id, 'schema-id');
+    assert.strictEqual(e.id, 'schema-id');
     assert.isFalse(e.mutable);
     assert.strictEqual(e.schema, 'url');
     assert.strictEqual(e.type, 81);


### PR DESCRIPTION
These were set up (#3195) to catch incorrect usage of the old Entity interface. It should be safe to clean them up now.