### PR TITLE
Added arcs_ts_test and run_in_repo_test BUILD rules.

### DIFF
--- a/build_defs/build_defs.bzl
+++ b/build_defs/build_defs.bzl
@@ -1,4 +1,4 @@
-load(":run_in_repo.bzl", "run_in_repo")
+load(":run_in_repo.bzl", "EXECUTION_REQUIREMENTS_TAGS", "run_in_repo", "run_in_repo_test")
 
 def arcs_cc_schema(name, src, out = None):
     """Generates a C++ header file for the given .arcs schema file.
@@ -24,4 +24,13 @@ def arcs_cc_schema(name, src, out = None):
               "--outfile $(basename {OUT}) " +
               "{SRC}",
         progress_message = "Generating C++ entity schemas",
+    )
+
+def arcs_ts_test(name, src):
+    """Runs a TypeScript test file using `sigh test`."""
+    run_in_repo_test(
+        name = name,
+        srcs = [src],
+        cmd = "./tools/sigh test --file {SRC}",
+        tags = EXECUTION_REQUIREMENTS_TAGS,
     )

--- a/build_defs/build_defs.bzl
+++ b/build_defs/build_defs.bzl
@@ -26,11 +26,12 @@ def arcs_cc_schema(name, src, out = None):
         progress_message = "Generating C++ entity schemas",
     )
 
-def arcs_ts_test(name, src):
+def arcs_ts_test(name, src, deps):
     """Runs a TypeScript test file using `sigh test`."""
     run_in_repo_test(
         name = name,
         srcs = [src],
         cmd = "./tools/sigh test --file {SRC}",
         tags = EXECUTION_REQUIREMENTS_TAGS,
+        deps = deps,
     )

--- a/build_defs/run_in_repo.bzl
+++ b/build_defs/run_in_repo.bzl
@@ -63,7 +63,7 @@ def _write_shell_script(ctx, run_script):
     if run_script:
         ctx.actions.run(
             executable = script_file,
-            inputs = input_files,
+            inputs = depset(input_files, transitive = ctx.attr.deps),
             outputs = output_files,
             progress_message = ctx.attr.progress_message,
             use_default_shell_env = True,
@@ -80,7 +80,7 @@ def _run_in_repo_test(ctx):
 
     return [DefaultInfo(
         executable = script_file,
-        runfiles = ctx.runfiles(files = ctx.files.srcs),
+        runfiles = ctx.runfiles(files = ctx.files.srcs + ctx.files.deps),
     )]
 
 # Attributes for the run_in_repo rule.
@@ -108,6 +108,7 @@ output file respectively.
     "progress_message": attr.string(
         doc = "Message to display when running the command.",
     ),
+    "deps": attr.label_list(),
     "_template": attr.label(
         default = "run_in_repo_template.sh",
         allow_single_file = True,

--- a/build_defs/run_in_repo.bzl
+++ b/build_defs/run_in_repo.bzl
@@ -1,8 +1,26 @@
+# Execution requirements for running commands in the repo root.
+EXECUTION_REQUIREMENTS_TAGS = [
+    "no-sandbox",
+    "no-cache",
+    "no-remote",
+    "local",
+]
+
+# Same as the above, but as a dictionary.
+EXECUTION_REQUIREMENTS_DICT = dict([(k, "1") for k in EXECUTION_REQUIREMENTS_TAGS])
+
 def _absolute_path(repo_root, path):
     """Converts path relative to the repo root into an absolute file path."""
     return repo_root + "/" + path
 
-def _run_in_repo(ctx):
+def _write_shell_script(ctx, run_script):
+    """Writes out a script for running a command in the repo root.
+
+    If run_script is true, this function will also run the script.
+
+    Returns the created script as a File object.
+    """
+
     # Extract the repo root directory from .bazelrc
     if "repo_root" not in ctx.var:
         fail(
@@ -41,26 +59,34 @@ def _run_in_repo(ctx):
         },
     )
 
-    # Run the shell script.
-    ctx.actions.run(
-        executable = script_file,
-        inputs = input_files,
-        outputs = output_files,
-        progress_message = ctx.attr.progress_message,
-        use_default_shell_env = True,
-        execution_requirements = {
-            "no-sandbox": "1",
-            "no-cache": "1",
-            "no-remote": "1",
-            "local": "1",
-        },
-    )
+    # Optionally run the shell script.
+    if run_script:
+        ctx.actions.run(
+            executable = script_file,
+            inputs = input_files,
+            outputs = output_files,
+            progress_message = ctx.attr.progress_message,
+            use_default_shell_env = True,
+            execution_requirements = EXECUTION_REQUIREMENTS_DICT,
+        )
 
-run_in_repo = rule(
-    implementation = _run_in_repo,
-    attrs = {
-        "cmd": attr.string(
-            doc = """
+    return script_file
+
+def _run_in_repo(ctx):
+    _write_shell_script(ctx = ctx, run_script = True)
+
+def _run_in_repo_test(ctx):
+    script_file = _write_shell_script(ctx = ctx, run_script = False)
+
+    return [DefaultInfo(
+        executable = script_file,
+        runfiles = ctx.runfiles(files = ctx.files.srcs),
+    )]
+
+# Attributes for the run_in_repo rule.
+_RUN_RULE_ATTRS = {
+    "cmd": attr.string(
+        doc = """
 Command to run in the repo root. You can use standard python format placeholders
 of the form \{SRCS\}, which will be substituted when the command is run.
 Placeholders are:
@@ -69,24 +95,28 @@ Placeholders are:
 You can also use SRC and OUT, provided you have supplied only a single input or
 output file respectively.
 """,
-        ),
-        "outs": attr.output_list(
-            allow_empty = False,
-            mandatory = True,
-            doc = "Output file(s) created by this rule.",
-        ),
-        "srcs": attr.label_list(
-            allow_files = True,
-            doc = "Input file(s) used by this rule.",
-        ),
-        "progress_message": attr.string(
-            doc = "Message to display when running the command.",
-        ),
-        "_template": attr.label(
-            default = "run_in_repo_template.sh",
-            allow_single_file = True,
-        ),
-    },
+    ),
+    "outs": attr.output_list(
+        allow_empty = False,
+        mandatory = True,
+        doc = "Output file(s) created by this rule.",
+    ),
+    "srcs": attr.label_list(
+        allow_files = True,
+        doc = "Input file(s) used by this rule.",
+    ),
+    "progress_message": attr.string(
+        doc = "Message to display when running the command.",
+    ),
+    "_template": attr.label(
+        default = "run_in_repo_template.sh",
+        allow_single_file = True,
+    ),
+}
+
+run_in_repo = rule(
+    implementation = _run_in_repo,
+    attrs = _RUN_RULE_ATTRS,
     doc = """
 Runs the given shell command in the root directory of the respository. This lets
 you read/write files directly from the repository (as opposed to the bazel
@@ -94,4 +124,19 @@ sandbox), so it can be destructive and can overwrite existing files.
 
 Useful for invoking sigh commands.
 """,
+)
+
+# Attributes for the run_in_repo_test rule. Same as above, but with no outputs.
+_TEST_RULE_ATTRS = dict(_RUN_RULE_ATTRS)
+_TEST_RULE_ATTRS["outs"] = attr.output_list(
+    allow_empty = True,
+    mandatory = False,
+    doc = "Output file(s) created by this rule.",
+)
+
+run_in_repo_test = rule(
+    implementation = _run_in_repo_test,
+    attrs = _TEST_RULE_ATTRS,
+    test = True,
+    doc = "Equivalent to run_in_repo, but for tests.",
 )

--- a/tools/sigh.ts
+++ b/tools/sigh.ts
@@ -865,7 +865,6 @@ function runTests(args: string[]): boolean {
     }
 
     for (const test of tests) {
-      console.log('testing file: ' + test);
       chain.push(`
         import {mocha} from '${mochaInstanceFile}';
         mocha.suite.emit('pre-require', global, '${test}', mocha);

--- a/tools/sigh.ts
+++ b/tools/sigh.ts
@@ -856,8 +856,8 @@ function runTests(args: string[]): boolean {
     // from the repo root.
     let tests: Iterable<string>;
     if (options.file) {
-      // Switch from "src/abc/foo-test.ts" to "../build/abc/foo-test.js
-      let filename = options.file.replace(/^src\//, "../build/").replace(/\.ts$/, ".js");
+      // Switch from "src/abc/foo-test.ts" to "../build/abc/foo-test.js"
+      let filename = options.file.replace(/^src\//, '../build/').replace(/\.ts$/, '.js');
       filename = fixPathForWindows(path.resolve(__dirname, filename));
       tests = [filename];
     } else {

--- a/tools/sigh.ts
+++ b/tools/sigh.ts
@@ -409,7 +409,7 @@ function cleanObsolete() {
     } else {
       // wasm outputs - look for a corresponding wasm.json config, and check if the module or
       // genfile names match.
-      
+
       // build/path/to/module.wasm -> src/path/to/wasm.json
       const configFile = path.join('src', path.dirname(file).slice(6), 'wasm.json');
       const baseName = path.basename(file);
@@ -805,7 +805,7 @@ function runTestsOrHealthOnCron(args: string[]): boolean {
 
 function runTests(args: string[]): boolean {
   const options = minimist(args, {
-    string: ['grep'],
+    string: ['grep', 'file'],
     inspect: ['inspect'],
     explore: ['explore'],
     coverage: ['coverage'],
@@ -850,7 +850,22 @@ function runTests(args: string[]): boolean {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sigh-'));
     const chain = [];
     const mochaInstanceFile = fixPathForWindows(path.resolve(__dirname, '../build/platform/mocha-node.js'));
-    for (const test of testsInDir(process.cwd())) {
+
+    // If a specific test file was provided, run it directly. Otherwise run all
+    // the tests we can find. Expected file is the relative path to a .ts file
+    // from the repo root.
+    let tests: Iterable<string>;
+    if (options.file) {
+      // Switch from "src/abc/foo-test.ts" to "../build/abc/foo-test.js
+      let filename = options.file.replace(/^src\//, "../build/").replace(/\.ts$/, ".js");
+      filename = fixPathForWindows(path.resolve(__dirname, filename));
+      tests = [filename];
+    } else {
+      tests = testsInDir(process.cwd());
+    }
+
+    for (const test of tests) {
+      console.log('testing file: ' + test);
       chain.push(`
         import {mocha} from '${mochaInstanceFile}';
         mocha.suite.emit('pre-require', global, '${test}', mocha);


### PR DESCRIPTION
This lets us run TypeScript tests using Bazel (which just invokes sigh).

Defining a test in bazel using this rule is really simple. Here's an example:

```
load("//build_defs:build_defs.bzl", "arcs_ts_test")

arcs_ts_test(
    name = "flow_graph_test",
    src = "flow-graph-test.ts",
)
```