### PR TITLE
Migrates C++ wasm code and tests to bazel

### DIFF
--- a/build_defs/build_defs.bzl
+++ b/build_defs/build_defs.bzl
@@ -31,7 +31,7 @@ def arcs_ts_test(name, src, deps):
     run_in_repo_test(
         name = name,
         srcs = [src],
-        cmd = "./tools/sigh test --file {SRC}",
+        cmd = "./tools/sigh test --bazel --file {SRC}",
         tags = EXECUTION_REQUIREMENTS_TAGS,
         deps = deps,
     )

--- a/src/tests/BUILD
+++ b/src/tests/BUILD
@@ -1,0 +1,10 @@
+load("//build_defs:build_defs.bzl", "arcs_ts_test")
+
+arcs_ts_test(
+    name = "hotreload-integration-test",
+    src = "hotreload-integration-test.ts",
+    deps = [
+        "//src/tests/source:wasm-particle-new",
+        "//src/tests/source:wasm-particle-old",
+    ],
+)

--- a/src/tests/hotreload-integration-test.ts
+++ b/src/tests/hotreload-integration-test.ts
@@ -22,8 +22,8 @@ class StubWasmLoader extends Loader {
   public reloaded = false;
 
   async loadWasmBinary(spec): Promise<ArrayBuffer> {
-    const file = this.reloaded ? 'test-module-new.wasm' : 'test-module-old.wasm';
-    return super.loadWasmBinary({implFile: `build/tests/source/${file}`});
+    const file = this.reloaded ? 'wasm-particle-new.wasm' : 'wasm-particle-old.wasm';
+    return super.loadWasmBinary({implFile: `bazel-bin/src/tests/source/${file}`});
   }
 
   clone(): StubWasmLoader {
@@ -92,10 +92,10 @@ describe('Hot Code Reload for WASM Particle', async () => {
   });
 
   it('updates model and template', async () => {
-    // StubWasmLoader returns test-module-old.wasm or test-module-new.wasm instead of
-    // test-module.wasm based on the reloaded flag
+    // StubWasmLoader returns wasm-particle-old.wasm or wasm-particle-new.wasm instead of
+    // wasm-particle.wasm based on the reloaded flag
     const context = await Manifest.parse(`
-      particle HotReloadTest in 'build/tests/source/test-module.wasm'
+      particle HotReloadTest in 'bazel-bin/src/tests/source/wasm-particle.wasm'
         consume root
 
       recipe

--- a/src/tests/hotreload-integration-test.ts
+++ b/src/tests/hotreload-integration-test.ts
@@ -86,7 +86,7 @@ describe('Hot Code Reload for JS Particle', async () => {
 
 describe('Hot Code Reload for WASM Particle', async () => {
   before(function() {
-    if (!global['testFlags'].enableWasm) {
+    if (!global['testFlags'].bazel) {
       this.skip();
     }
   });
@@ -108,7 +108,7 @@ describe('Hot Code Reload for WASM Particle', async () => {
     const pecFactories = [FakePecFactory(loader).bind(null)];
     const slotComposer = new FakeSlotComposer();
     const arc = new Arc({id, pecFactories, slotComposer, loader, context});
-  
+
     const [recipe] = arc.context.recipes;
     assert.isTrue(recipe.normalize() && recipe.isResolved());
     await arc.instantiate(recipe);

--- a/src/tests/source/BUILD
+++ b/src/tests/source/BUILD
@@ -1,0 +1,15 @@
+load("//build_defs/emscripten:build_defs.bzl", "cc_wasm_binary")
+
+package(default_visibility = ["//src/tests:__pkg__"])
+
+cc_wasm_binary(
+    name = "wasm-particle-old",
+    srcs = ["wasm-particle-old.cc"],
+    deps = ["//src/wasm/cpp:arcs"],
+)
+
+cc_wasm_binary(
+    name = "wasm-particle-new",
+    srcs = ["wasm-particle-new.cc"],
+    deps = ["//src/wasm/cpp:arcs"],
+)

--- a/src/tests/source/wasm-particle-new.cc
+++ b/src/tests/source/wasm-particle-new.cc
@@ -1,4 +1,4 @@
-#include <arcs.h>
+#include "src/wasm/cpp/arcs.h"
 
 class HotReloadTest : public arcs::Particle {
   std::string getTemplate(const std::string& slot_name) override {

--- a/src/tests/source/wasm-particle-old.cc
+++ b/src/tests/source/wasm-particle-old.cc
@@ -1,4 +1,4 @@
-#include <arcs.h>
+#include "src/wasm/cpp/arcs.h"
 
 class HotReloadTest : public arcs::Particle {
   std::string getTemplate(const std::string& slot_name) override {

--- a/src/wasm/cpp/BUILD
+++ b/src/wasm/cpp/BUILD
@@ -1,0 +1,8 @@
+load("//build_defs/emscripten:build_defs.bzl", "cc_wasm_library")
+
+cc_wasm_library(
+    name = "arcs",
+    srcs = ["arcs.cc"],
+    hdrs = ["arcs.h"],
+    visibility = ["//visibility:public"],
+)

--- a/src/wasm/cpp/arcs.cc
+++ b/src/wasm/cpp/arcs.cc
@@ -1,5 +1,6 @@
-#include <arcs.h>
 #include <cstring>
+
+#include "src/wasm/cpp/arcs.h"
 
 namespace arcs {
 namespace internal {

--- a/src/wasm/cpp/tests/BUILD
+++ b/src/wasm/cpp/tests/BUILD
@@ -1,7 +1,34 @@
-load("//build_defs:build_defs.bzl", "arcs_cc_schema")
+load("//build_defs:build_defs.bzl", "arcs_cc_schema", "arcs_ts_test")
+load("//build_defs/emscripten:build_defs.bzl", "cc_wasm_binary")
 
 arcs_cc_schema(
     name = "schemas",
     src = "schemas.arcs",
     out = "entities.h",
+)
+
+cc_wasm_binary(
+    name = "test-module",
+    srcs = [
+        "entity-class.cc",
+        "particle-api.cc",
+    ],
+    hdrs = ["entities.h"],
+    deps = [
+        "//src/wasm/cpp:arcs",
+    ],
+)
+
+cc_wasm_binary(
+    name = "schemaless",
+    srcs = ["schemaless.cc"],
+    deps = [
+        "//src/wasm/cpp:arcs",
+    ],
+)
+
+arcs_ts_test(
+    name = "wasm-cpp-test",
+    src = "wasm-cpp-test.ts",
+    deps = [":test-module"],
 )

--- a/src/wasm/cpp/tests/BUILD
+++ b/src/wasm/cpp/tests/BUILD
@@ -14,17 +14,13 @@ cc_wasm_binary(
         "particle-api.cc",
     ],
     hdrs = ["entities.h"],
-    deps = [
-        "//src/wasm/cpp:arcs",
-    ],
+    deps = ["//src/wasm/cpp:arcs"],
 )
 
 cc_wasm_binary(
     name = "schemaless",
     srcs = ["schemaless.cc"],
-    deps = [
-        "//src/wasm/cpp:arcs",
-    ],
+    deps = ["//src/wasm/cpp:arcs"],
 )
 
 arcs_ts_test(

--- a/src/wasm/cpp/tests/entity-class.cc
+++ b/src/wasm/cpp/tests/entity-class.cc
@@ -3,8 +3,9 @@
 #include <map>
 #include <algorithm>
 #include <functional>
-#include <arcs.h>
-#include <entities.h>
+
+#include "src/wasm/cpp/arcs.h"
+#include "src/wasm/cpp/tests/entities.h"
 
 class InternalsTestBase : public arcs::Particle {
 public:

--- a/src/wasm/cpp/tests/particle-api.cc
+++ b/src/wasm/cpp/tests/particle-api.cc
@@ -1,5 +1,5 @@
-#include <arcs.h>
-#include <entities.h>
+#include "src/wasm/cpp/arcs.h"
+#include "src/wasm/cpp/tests/entities.h"
 
 class HandleSyncUpdateTest : public arcs::Particle {
 public:

--- a/src/wasm/cpp/tests/schemaless.cc
+++ b/src/wasm/cpp/tests/schemaless.cc
@@ -1,4 +1,4 @@
-#include <arcs.h>
+#include "src/wasm/cpp/arcs.h"
 
 class SchemalessTest : public arcs::Particle {
 public:

--- a/src/wasm/cpp/tests/wasm-cpp-test.ts
+++ b/src/wasm/cpp/tests/wasm-cpp-test.ts
@@ -15,6 +15,11 @@ import {RozSlotComposer} from '../../../runtime/testing/fake-slot-composer.js';
 import {VolatileSingleton, VolatileCollection} from '../../../runtime/storage/volatile-storage.js';
 import {assertThrowsAsync} from '../../../runtime/testing/test-util.js';
 
+// Import some service definition files for their side-effects (the services get
+// registered automatically).
+import '../../../services/clock-service.js';
+import '../../../services/random-service.js';
+
 const schemasFile = 'src/wasm/cpp/tests/schemas.arcs';
 const buildDir = 'bazel-bin/src/wasm/cpp/tests';
 

--- a/src/wasm/cpp/tests/wasm-cpp-test.ts
+++ b/src/wasm/cpp/tests/wasm-cpp-test.ts
@@ -49,6 +49,12 @@ async function setup(manifestString) {
 }
 
 describe('wasm tests (C++)', () => {
+  before(function() {
+    if (!global['testFlags'].bazel) {
+      this.skip();
+    }
+  });
+
   it('onHandleSync / onHandleUpdate', async () => {
     const {arc, stores} = await setup(`
       import '${schemasFile}'

--- a/src/wasm/cpp/tests/wasm-cpp-test.ts
+++ b/src/wasm/cpp/tests/wasm-cpp-test.ts
@@ -16,7 +16,7 @@ import {VolatileSingleton, VolatileCollection} from '../../../runtime/storage/vo
 import {assertThrowsAsync} from '../../../runtime/testing/test-util.js';
 
 const schemasFile = 'src/wasm/cpp/tests/schemas.arcs';
-const buildDir = 'build/wasm/cpp/tests';
+const buildDir = 'bazel-bin/src/wasm/cpp/tests';
 
 class TestLoader extends Loader {
   resolve(path: string) {
@@ -44,13 +44,6 @@ async function setup(manifestString) {
 }
 
 describe('wasm tests (C++)', () => {
-  // TODO: https://github.com/PolymerLabs/arcs/issues/3418
-  before(function() {
-    if (!global['testFlags'].enableWasm) {
-      this.skip();
-    }
-  });
-
   it('onHandleSync / onHandleUpdate', async () => {
     const {arc, stores} = await setup(`
       import '${schemasFile}'

--- a/tools/sigh.ts
+++ b/tools/sigh.ts
@@ -51,8 +51,12 @@ const buildLS = buildPath('./src/tools/language-server', () => {
 });
 const webpackLS = webpackPkg('webpack-languageserver');
 
-const wasmOptional = args => wasm(true, args);
-const wasmRequired = args => wasm(false, args);
+// TODO(csilvestrini): Remove wasm support from sigh entirely.
+// const wasmOptional = args => wasm(true, args);
+// const wasmRequired = args => wasm(false, args);
+const wasmOptional = args => true;
+const wasmRequired = args => true;
+
 
 const steps: {[index: string]: ((args?: string[]) => boolean)[]} = {
   languageServer: [peg, build, buildLS, webpackLS],

--- a/tools/sigh.ts
+++ b/tools/sigh.ts
@@ -106,7 +106,10 @@ const isTravisDaily = (process.env.TRAVIS_EVENT_TYPE === 'cron');
 
 // Flags for unit tests; use `global['testFlags'].foo` to access them.
 const testFlags = {
+  // TODO(csilvestrini): Delete this flag.
   enableWasm: false,
+  /** If true, runs tests flagged as bazel tests. */
+  bazel: false,
 };
 
 // tslint:disable-next-line: no-any
@@ -808,10 +811,21 @@ function runTests(args: string[]): boolean {
     explore: ['explore'],
     coverage: ['coverage'],
     exceptions: ['exceptions'],
-    boolean: ['manual', 'sequence', 'all'],
+    boolean: ['manual', 'sequence', 'all', 'bazel'],
     repeat: ['repeat'],
     alias: {g: 'grep'},
   });
+
+  if (options.bazel) {
+    if (!options.file) {
+      console.error('If the --bazel flag is set then the --file flag must be supplied too.');
+      return false;
+    }
+    // Enables unit tests that are marked as requiring bazel. These tests are
+    // usually skipped; they should generally only be supplied by bazel when it
+    // invokes sigh directly.
+    testFlags.bazel = true;
+  }
 
   const testsInDir = dir => findProjectFiles(dir, buildExclude, fullPath => {
     // TODO(wkorman): Integrate shell testing more deeply into sigh testing. For

--- a/tools/sigh.ts
+++ b/tools/sigh.ts
@@ -51,12 +51,9 @@ const buildLS = buildPath('./src/tools/language-server', () => {
 });
 const webpackLS = webpackPkg('webpack-languageserver');
 
-// TODO(csilvestrini): Remove wasm support from sigh entirely.
-// const wasmOptional = args => wasm(true, args);
-// const wasmRequired = args => wasm(false, args);
-const wasmOptional = args => true;
-const wasmRequired = args => true;
-
+// TODO(csilvestrini): Remove wasm stuff from sigh entirely.
+const wasmOptional = args => wasm(true, args);
+const wasmRequired = args => wasm(false, args);
 
 const steps: {[index: string]: ((args?: string[]) => boolean)[]} = {
   languageServer: [peg, build, buildLS, webpackLS],


### PR DESCRIPTION
All C++ wasm code now uses bazel to build/test.

Build: `bazel build //src/wasm/...`
Test: `bazel test //src/wasm/...`

TODO in follow-up PRs:
* Add README instructions for installing/running bazel: #3550
* Get travis to run bazel tests: #3551
* Delete leftover wasm stuff from sigh: #3553
* Delete leftover wasm .json files: #3552