### PR TITLE
Adds arcs_kt_schema BUILD rule.

### DIFF
--- a/build_defs/build_defs.bzl
+++ b/build_defs/build_defs.bzl
@@ -1,7 +1,7 @@
 load(":run_in_repo.bzl", "EXECUTION_REQUIREMENTS_TAGS", "run_in_repo", "run_in_repo_test")
 
-def arcs_cc_schema(name, src, out = None):
-    """Generates a C++ header file for the given .arcs schema file.
+def _run_schema2pkg(name, src, out, language_name, language_flag, file_extension):
+    """Generates source code for the given .arcs schema file.
 
     Runs sigh schema2pkg to generate the output.
     """
@@ -11,7 +11,7 @@ def arcs_cc_schema(name, src, out = None):
 
     if out == None:
         # Clean up the output name.
-        out = src.replace(".arcs", "").replace("_", "-").replace(".", "-") + ".h"
+        out = src.replace(".arcs", "").replace("_", "-").replace(".", "-") + file_extension
 
     run_in_repo(
         name = name,
@@ -19,11 +19,34 @@ def arcs_cc_schema(name, src, out = None):
         outs = [out],
         # TODO: generated header guard should contain whole workspace-relative
         # path to file.
-        cmd = "./tools/sigh schema2pkg --cpp " +
+        cmd = "./tools/sigh schema2pkg " +
+              language_flag + " " +
               "--outdir $(dirname {OUT}) " +
               "--outfile $(basename {OUT}) " +
               "{SRC}",
-        progress_message = "Generating C++ entity schemas",
+        progress_message = "Generating {} entity schemas".format(language_name),
+    )
+
+def arcs_cc_schema(name, src, out = None):
+    """Generates a C++ header file for the given .arcs schema file."""
+    _run_schema2pkg(
+        name = name,
+        src = src,
+        out = out,
+        language_name = "C++",
+        language_flag = "--cpp",
+        file_extension = ".h",
+    )
+
+def arcs_kt_schema(name, src, out = None):
+    """Generates a Kotlin file for the given .arcs schema file."""
+    _run_schema2pkg(
+        name = name,
+        src = src,
+        out = out,
+        language_name = "Kotlin",
+        language_flag = "--kotlin",
+        file_extension = ".kt",
     )
 
 def arcs_ts_test(name, src, deps):

--- a/src/wasm/kotlin/BUILD
+++ b/src/wasm/kotlin/BUILD
@@ -1,0 +1,9 @@
+load("//build_defs:build_defs.bzl", "arcs_kt_schema")
+
+# Example for how to generate Kotlin code from a .arcs schema.
+# TODO: This is not used anywhere yet. Hook it up to something.
+arcs_kt_schema(
+    name = "wasm_schemas",
+    src = "wasm.arcs",
+    out = "schemas.kt",
+)


### PR DESCRIPTION
This works the same way as arcs_cc_schema, but generates Kotlin files
instead of C++ files. Just invokes `sigh schema2pkg`.