### PR TITLE
Don't swallow errors in ALDS

### DIFF
--- a/src/tools/dev_server/dev-server.ts
+++ b/src/tools/dev_server/dev-server.ts
@@ -36,14 +36,8 @@ async function launch() {
 
   const proxy = new ExplorerProxy();
   const hotReloadServer = new HotReloadServer(hotReloadPort);
-  try {
-    await hotReloadServer.init();
-  } catch (e) {
-    // Shouldn't be reachable if invoking from sigh.
-    console.error(`HotReloadServer failed to initialize - run 'tools/sigh devServer' for details`);
-    process.exit(1);
-  }
-
+  await hotReloadServer.init();
+  
   const app = express();
   if (options['verbose']) {
     app.use(morgan(':method :url :status - :response-time ms, :res[content-length] bytes'));


### PR DESCRIPTION
`npm start` is invoking sigh, which recommends using  `--install` even without this try catch, and this try catch can obscure errors as the caught error is not printed out, it's best to remove it now.
