### PR TITLE
Added PecPortManager and RemotePecPort

### DIFF
--- a/src/javaharness/java/arcs/android/impl/AndroidHarnessModule.java
+++ b/src/javaharness/java/arcs/android/impl/AndroidHarnessModule.java
@@ -1,13 +1,6 @@
 package arcs.android.impl;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
-
-import javax.inject.Singleton;
-
 import arcs.api.ArcsEnvironment;
-import arcs.api.ArcsEnvironment.DataListener;
 import arcs.api.DeviceClient;
 import arcs.api.HandleFactory;
 import arcs.api.HandleFactoryImpl;
@@ -16,7 +9,6 @@ import arcs.api.PECInnerPortFactory;
 import arcs.api.PECInnerPortFactoryImpl;
 import arcs.api.ParticleExecutionContext;
 import arcs.api.ParticleExecutionContextImpl;
-import arcs.api.ParticleFactory;
 import arcs.api.ParticleLoader;
 import arcs.api.ParticleLoaderImpl;
 import arcs.api.PortableJsonParser;
@@ -25,7 +17,7 @@ import arcs.api.ShellApi;
 import arcs.api.ShellApiBasedArcsEnvironment;
 import dagger.Binds;
 import dagger.Module;
-import dagger.Provides;
+import javax.inject.Singleton;
 
 @Module
 public abstract class AndroidHarnessModule {
@@ -65,4 +57,8 @@ public abstract class AndroidHarnessModule {
   @Binds
   public abstract PortablePromiseFactory providesPortablePromiseFactory(
       PortablePromiseFactoryAndroidImpl impl);
+  //
+  // @Binds
+  // @Singleton
+  // public abstract PecPortManager
 }

--- a/src/javaharness/java/arcs/android/impl/AndroidHarnessModule.java
+++ b/src/javaharness/java/arcs/android/impl/AndroidHarnessModule.java
@@ -1,6 +1,13 @@
 package arcs.android.impl;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import javax.inject.Singleton;
+
 import arcs.api.ArcsEnvironment;
+import arcs.api.ArcsEnvironment.DataListener;
 import arcs.api.DeviceClient;
 import arcs.api.HandleFactory;
 import arcs.api.HandleFactoryImpl;
@@ -9,6 +16,7 @@ import arcs.api.PECInnerPortFactory;
 import arcs.api.PECInnerPortFactoryImpl;
 import arcs.api.ParticleExecutionContext;
 import arcs.api.ParticleExecutionContextImpl;
+import arcs.api.ParticleFactory;
 import arcs.api.ParticleLoader;
 import arcs.api.ParticleLoaderImpl;
 import arcs.api.PortableJsonParser;
@@ -17,7 +25,7 @@ import arcs.api.ShellApi;
 import arcs.api.ShellApiBasedArcsEnvironment;
 import dagger.Binds;
 import dagger.Module;
-import javax.inject.Singleton;
+import dagger.Provides;
 
 @Module
 public abstract class AndroidHarnessModule {
@@ -57,8 +65,4 @@ public abstract class AndroidHarnessModule {
   @Binds
   public abstract PortablePromiseFactory providesPortablePromiseFactory(
       PortablePromiseFactoryAndroidImpl impl);
-  //
-  // @Binds
-  // @Singleton
-  // public abstract PecPortManager
 }

--- a/src/javaharness/java/arcs/android/impl/DeviceClientAndroidImpl.java
+++ b/src/javaharness/java/arcs/android/impl/DeviceClientAndroidImpl.java
@@ -3,9 +3,8 @@ package arcs.android.impl;
 import android.util.Log;
 import android.webkit.JavascriptInterface;
 import arcs.api.ArcsEnvironment;
-import arcs.api.ArcsEnvironment.DataListener;
 import arcs.api.DeviceClientImpl;
-import arcs.api.PECInnerPortFactory;
+import arcs.api.PecPortManager;
 import arcs.api.PortableJsonParser;
 import arcs.api.UiBroker;
 import javax.inject.Inject;
@@ -16,9 +15,9 @@ public class DeviceClientAndroidImpl extends DeviceClientImpl {
   public DeviceClientAndroidImpl(
       PortableJsonParser jsonParser,
       ArcsEnvironment environment,
-      PECInnerPortFactory portFactory,
+      PecPortManager pecPortManager,
       UiBroker uiBroker) {
-    super(jsonParser, environment, portFactory, uiBroker);
+    super(jsonParser, environment, pecPortManager, uiBroker);
   }
 
   @JavascriptInterface

--- a/src/javaharness/java/arcs/api/PECInnerPort.java
+++ b/src/javaharness/java/arcs/api/PECInnerPort.java
@@ -2,8 +2,7 @@ package arcs.api;
 
 import java.util.function.Consumer;
 
-public interface PECInnerPort {
-  void processMessage(PortableJson message);
+public interface PECInnerPort extends PecMessageReceiver {
 
   void mapParticle(Particle particle);
 

--- a/src/javaharness/java/arcs/api/PECInnerPortImpl.java
+++ b/src/javaharness/java/arcs/api/PECInnerPortImpl.java
@@ -1,8 +1,6 @@
 package arcs.api;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 import java.util.logging.Logger;
@@ -74,7 +72,7 @@ public class PECInnerPortImpl implements PECInnerPort {
 
   @SuppressWarnings("unchecked")
   @Override
-  public void processMessage(PortableJson message) {
+  public void onReceivePecMessage(PortableJson message) {
     String messageType = message.getString(MESSAGE_TYPE_FIELD);
     PortableJson messageBody = message.getObject(MESSAGE_BODY_FIELD);
     switch (messageType) {

--- a/src/javaharness/java/arcs/api/PecMessageReceiver.java
+++ b/src/javaharness/java/arcs/api/PecMessageReceiver.java
@@ -1,0 +1,8 @@
+package arcs.api;
+
+/** Receives PEC messages. Implemented by PECInnerPort and RemotePecPort classes. */
+public interface PecMessageReceiver {
+
+  /** Called with a message intended for the PEC. */
+  void onReceivePecMessage(PortableJson message);
+}

--- a/src/javaharness/java/arcs/api/PecPortManager.java
+++ b/src/javaharness/java/arcs/api/PecPortManager.java
@@ -1,0 +1,60 @@
+package arcs.api;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+@Singleton
+public class PecPortManager {
+
+  private final Map<String, PecMessageReceiver> allPorts = new HashMap<>();
+  private final Map<String, RemotePecPort> remotePorts = new HashMap<>();
+  private final Map<String, PECInnerPort> innerPorts = new HashMap<>();
+  private final PECInnerPortFactory portFactory;
+
+  @Inject
+  PecPortManager(PECInnerPortFactory portFactory) {
+    this.portFactory = portFactory;
+  }
+
+  public void deliverPecMessage(String pecId, String sessionId, PortableJson message) {
+    PecMessageReceiver port = allPorts.get(pecId);
+    if (port == null) {
+      // Create a new inner PEC port for this pecId.
+      port = createInnerPecPort(pecId, sessionId);
+    }
+
+    port.onReceivePecMessage(message);
+  }
+
+  // TODO(csilvestrini): Hook this up to IArcsService.
+  public RemotePecPort createRemotePecPort(String pecId) {
+    if (allPorts.containsKey(pecId)) {
+      throw new IllegalArgumentException("pecId already exists: " + pecId);
+    }
+    RemotePecPort remotePecPort = new RemotePecPort();
+    remotePorts.put(pecId, remotePecPort);
+    allPorts.put(pecId, remotePecPort);
+    return remotePecPort;
+  }
+
+  public PECInnerPort getOrCreateInnerPort(String pecId, String sessionId) {
+    PECInnerPort pecInnerPort = innerPorts.get(pecId);
+    if (pecInnerPort != null) {
+      return pecInnerPort;
+    }
+    if (remotePorts.containsKey(pecId)) {
+      throw new IllegalArgumentException("pecId is a remote PEC port, not an inner port: " + pecId);
+    }
+
+    return createInnerPecPort(pecId, sessionId);
+  }
+
+  private PECInnerPort createInnerPecPort(String pecId, String sessionId) {
+    PECInnerPort pecInnerPort = portFactory.createPECInnerPort(pecId, sessionId);
+    innerPorts.put(pecId, pecInnerPort);
+    allPorts.put(pecId, pecInnerPort);
+    return pecInnerPort;
+  }
+}

--- a/src/javaharness/java/arcs/api/RemotePecPort.java
+++ b/src/javaharness/java/arcs/api/RemotePecPort.java
@@ -1,0 +1,18 @@
+package arcs.api;
+
+import javax.inject.Inject;
+
+/**
+ * A proxy PEC port implementation. It receives PEC messages and forwards them to a real
+ * PECInnerPort implementation that lives elsewhere (e.g. in another Android service).
+ */
+public class RemotePecPort implements PecMessageReceiver {
+
+  @Inject
+  RemotePecPort() {}
+
+  @Override
+  public void onReceivePecMessage(PortableJson message) {
+    // TODO(csilvestrini): Forward message through the IArcsService back to the actual remote PEC.
+  }
+}

--- a/src/javaharness/java/arcs/web/impl/DeviceClientJsImpl.java
+++ b/src/javaharness/java/arcs/web/impl/DeviceClientJsImpl.java
@@ -3,9 +3,9 @@ package arcs.web.impl;
 import arcs.api.ArcsEnvironment;
 import arcs.api.DeviceClientImpl;
 import arcs.api.PECInnerPortFactory;
+import arcs.api.PecPortManager;
 import arcs.api.PortableJsonParser;
 import arcs.api.UiBroker;
-import arcs.api.UiRenderer;
 import javax.inject.Inject;
 import jsinterop.annotations.JsType;
 
@@ -15,9 +15,9 @@ public class DeviceClientJsImpl extends DeviceClientImpl {
   public DeviceClientJsImpl(
       PortableJsonParser jsonParser,
       ArcsEnvironment environment,
-      PECInnerPortFactory portFactory,
+      PecPortManager pecPortManager,
       UiBroker uiBroker) {
-    super(jsonParser, environment, portFactory, uiBroker);
+    super(jsonParser, environment, pecPortManager, uiBroker);
   }
 
   @Override


### PR DESCRIPTION
RemotePecPort is a analogous class to PECInnerPort, but it doesn't actually do anything (yet). It should proxy all of the messages it receives across the Android service bridge, to be delivered to another real PEC implementation. The RemotePecPort is hosted inside a PecPortManager, which figures out which PEC port should receive which message.

The RemotePecPort will be implemented and used in a follow-up PR.