### PR TITLE
Fix build errors in javaharness j2cl

### DIFF
--- a/src/javaharness/java/arcs/android/demo/service/ArcsService.java
+++ b/src/javaharness/java/arcs/android/demo/service/ArcsService.java
@@ -3,6 +3,7 @@ package arcs.android.demo.service;
 import android.app.Service;
 import android.content.Intent;
 import android.os.IBinder;
+import android.os.RemoteException;
 import android.util.Log;
 import android.view.View;
 import android.webkit.WebView;
@@ -59,7 +60,16 @@ public class ArcsService extends Service {
 
       @Override
       public void registerRemotePec(String pecId, IRemotePecCallback callback) {
-        RemotePecPort remotePecPort = new RemotePecPort(callback, jsonParser);
+        RemotePecPort remotePecPort =
+            new RemotePecPort(
+                message -> {
+                  try {
+                    callback.onMessage(message);
+                  } catch (RemoteException e) {
+                    throw new RuntimeException(e);
+                  }
+                },
+                jsonParser);
         pecPortManager.addRemotePecPort(pecId, remotePecPort);
       }
 

--- a/src/javaharness/java/arcs/api/PecPortManager.java
+++ b/src/javaharness/java/arcs/api/PecPortManager.java
@@ -40,8 +40,7 @@ public class PecPortManager {
     } else if (port instanceof PECInnerPort) {
       return (PECInnerPort) port;
     } else {
-      throw new IllegalArgumentException(
-          String.format("PEC with ID %s is not an inner port: ", pecId));
+      throw new IllegalArgumentException("PEC with ID %s is not an inner port: " + pecId);
     }
   }
 

--- a/src/javaharness/java/arcs/api/RemotePecPort.java
+++ b/src/javaharness/java/arcs/api/RemotePecPort.java
@@ -1,7 +1,6 @@
 package arcs.api;
 
-import android.os.RemoteException;
-import arcs.android.api.IRemotePecCallback;
+import java.util.function.Consumer;
 
 /**
  * A proxy PEC port implementation. It receives PEC messages and forwards them to a real
@@ -9,20 +8,16 @@ import arcs.android.api.IRemotePecCallback;
  */
 public class RemotePecPort implements PecMessageReceiver {
 
-  private final IRemotePecCallback callback;
+  private final Consumer<String> callback;
   private final PortableJsonParser jsonParser;
 
-  public RemotePecPort(IRemotePecCallback callback, PortableJsonParser jsonParser) {
+  public RemotePecPort(Consumer<String> callback, PortableJsonParser jsonParser) {
     this.callback = callback;
     this.jsonParser = jsonParser;
   }
 
   @Override
   public void onReceivePecMessage(PortableJson message) {
-    try {
-      callback.onMessage(jsonParser.stringify(message));
-    } catch (RemoteException e) {
-      throw new RuntimeException(e);
-    }
+    callback.accept(jsonParser.stringify(message));
   }
 }


### PR DESCRIPTION
Error was that I was referencing an android interface IRemotePecCallback from the arcs.api package. I switched to a Consumer<String> instead.

Javaharness now builds with `bazel build ...` without errors