### PR TITLE
Fix Java tests: add missing java dep

### DIFF
--- a/src/javaharness/java/arcs/api/BUILD
+++ b/src/javaharness/java/arcs/api/BUILD
@@ -20,6 +20,7 @@ android_library(
         "//java/arcs/crdt:crdt-android",
         "@com_google_dagger",
         "@javax_inject_source//jar",
+        "@org_json//jar",
     ],
 )
 


### PR DESCRIPTION
This missing dep was causing the java test to fail (but oddly doesn't seem to be necessary when building the android targets...)

Running `bazel test ...` now passes!