### PR TITLE
Explicitly setting the handles field in a particle:

### DIFF
--- a/src/runtime/particle.ts
+++ b/src/runtime/particle.ts
@@ -77,6 +77,7 @@ export class Particle {
   }
 
   async callSetHandles(handles: ReadonlyMap<string, Handle>, onException: Consumer<Error>) {
+    this.handles = handles;
     await this.invokeSafely(async p => p.setHandles(handles), onException);
   }
 

--- a/src/runtime/wasm.ts
+++ b/src/runtime/wasm.ts
@@ -546,8 +546,6 @@ export class WasmParticle extends Particle {
       this.converters.set(handle, new EntityPackager(handle.entityClass.schema));
     }
     this.exports._init(this.innerParticle);
-    // Setting this.handles since reload function needs to be able to grab all particle's handles
-    this.handles = handles;
   }
 
   async onHandleSync(handle: Handle, model) {

--- a/src/tests/hotreload-integration-test.ts
+++ b/src/tests/hotreload-integration-test.ts
@@ -111,7 +111,6 @@ describe('Hot Code Reload for JS Particle', async () => {
       'A.js': `defineParticle(({Particle}) => {
         return class extends Particle {
           async setHandles(handles) {
-            this.handles = handles;
             this.handleOut = handles.get('personOut');
           }
           onHandleSync(handle, model) {
@@ -147,7 +146,6 @@ describe('Hot Code Reload for JS Particle', async () => {
     loader._fileMap['A.js'] = `defineParticle(({Particle}) => {
       return class extends Particle {
         async setHandles(handles) {
-          this.handles = handles;
           this.handleOut = handles.get('personOut');
         }
         onHandleSync(handle, model) {


### PR DESCRIPTION
- Hot code reload functionality depends on this field to get all the
handles and create copies of them
- Avoid always having to define handles in while overriding setHandles