### PR TITLE
Update Bash Setup Script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ script:
 
 cache: npm
 
+# Thinking about adding steps to the install script? Why not modify the tools/setup script instead?
 install:
   - ./tools/setup
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ script:
 
 cache: npm
 
-# Thinking about adding steps to the install script? Why not modify the tools/setup script instead?
+# Thinking about adding install steps? Why not modify the tools/setup script instead?
 install:
   - ./tools/setup
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ cache: npm
 
 install:
   - ./tools/setup
-  - npm run sigh-install chokidar
 
 
 before_deploy:

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ requiring an upgrade to our current version.
    $ ./tools/setup
    ```
 
-2) That's it! (You can skip the next two sections.)
+2) That's it! (You can skip the next section.)
 
 
 ### Installing from scratch

--- a/src/wasm/cpp/README.md
+++ b/src/wasm/cpp/README.md
@@ -6,8 +6,8 @@ Our C++ code is built by Bazel. You will need to install Bazel, and use it to
 build and run the wasm code/tests (everything under `src/wasm/`).
 
 1. **Installing Bazel:** run the `tools/setup` script to install Bazel on Linux
-   (or otherwise look at that script to see which version of Bazel to download
-   and how to set it up).
+   and MacOS (or otherwise look at that script to see which version of Bazel to 
+   download and how to set it up).
 
 ## Build
 

--- a/tools/setup
+++ b/tools/setup
@@ -81,19 +81,17 @@ status "4.1. Install sigh dependencies"
 
 status "5. Install Bazel"
 
-status "5.1. Downloading install script"
-curl -O -L -s "$BAZEL_DEP" --output "$BAZEL_SCRIPT_NAME" || fail "Failed to download Bazel binary"
-ls
-status "5.2. Running install script"
-chmod +x $BAZEL_SCRIPT_NAME
-. $BAZEL_SCRIPT_NAME --user || source $BAZEL_SCRIPT_NAME --user || fail "Failed to install Bazel"
-echo 'export PATH="$PATH:$HOME/bin"'  >> ~/.profile || warn 'Failed to add "$HOME/bin" to $PATH'
-
-status "5.3. Clean up"
+status "5.1. Downloading and running install script"
+curl -L -s -O "$BAZEL_DEP" --output "$BAZEL_SCRIPT_NAME"
+chmod +x "$BAZEL_SCRIPT_NAME"
+"./$BAZEL_SCRIPT_NAME" --user || fail "Failed to install Bazel"
 rm "$BAZEL_SCRIPT_NAME"
 
-status "5.4. Set up the .bazelrc file"
-(cd $ROOT && echo "build --define=repo_root=$(pwd)" >> .bazelrc)
+status "5.2. Updating PATH"
+append_once 'export PATH="$PATH:$HOME/bin"' ~/.profile
+
+status "5.3. Set up the .bazelrc file"
+(cd $ROOT && append_once "build --define=repo_root=$(pwd)" .bazelrc)
 
 
 echo "$GRN$BLD\n\nSETUP COMPLETE\n$END"

--- a/tools/setup
+++ b/tools/setup
@@ -10,7 +10,6 @@ GRN="\033[92m"
 MAG="\033[95m"
 BLD="\033[1m"
 END="\033[0m"
-
 CMD="$BLD$YLW"
 
 warn() {
@@ -39,6 +38,8 @@ case $(uname | tr '[:upper:]' '[:lower:]') in
   msys*)
     OS_NAME=windows
     BAZEL_DEP="https://github.com/bazelbuild/bazel/releases/download/$BAZEL_VERSION/bazel-$BAZEL_VERSION-windows-x86_64.exe"
+    # TODO(alxr) investigate windows compatability
+    fail "Windows is currently unsupported. Please follow install instructions in the README."
     ;;
   *)
     OS_NAME=notset
@@ -65,7 +66,9 @@ status "1.1 ensure nvm is in your current process"
 . ~/.nvm/nvm.sh || source ~/.nvm/nvm.sh
 
 status "2. Install node"
-(cd $ROOT && nvm install && nvm use) || fail 'Failed to install target node version.'
+pushd .
+cd $ROOT && nvm install && nvm use || fail 'Failed to install target node version.'
+popd
 
 status "3. Update npm to latest version"
 nvm install-latest-npm  || fail 'Failed to update npm to latest version.'

--- a/tools/setup
+++ b/tools/setup
@@ -42,6 +42,9 @@ nvm install-latest-npm  || fail 'Failed to update npm to latest version.'
 status "4. Install dependencies"
 (cd $ROOT && npm ci && npm --prefix=server ci) || fail 'Failed to install dependencies.'
 
+status "4.1. Install sigh dependencies"
+(cd $ROOT && ./tools/sigh install) || fail 'Failed to install sigh dependencies.'
+
 status "5. Install bazel"
 (wget "$BAZEL_DEB" && set -x && sudo dpkg -i $BAZEL_PKG_NAME)
 

--- a/tools/setup
+++ b/tools/setup
@@ -25,6 +25,14 @@ status() {
     echo "$MAG$1$END"
 }
 
+append_once() {
+  if grep -Fxq "$1" "$2"; then
+    status "Already updated."
+  else
+    echo "$1" >> "$2" || warn "Failed to update $2"
+  fi
+}
+
 # Detect Platform
 case $(uname | tr '[:upper:]' '[:lower:]') in
   linux*)
@@ -50,10 +58,10 @@ esac
 BAZEL_SCRIPT_NAME=$(basename "$BAZEL_DEP")
 
 status "0. Pre-requisites"
-if  "$OS_NAME" == "linux"; then
+if [ "$OS_NAME" = "linux" ]; then
   status "0.1 Installing pre-requisites for Bazel"
   sudo apt-get install pkg-config zip g++ zlib1g-dev unzip python3
-elif "$OS_NAME" == "osx"; then
+elif [ "$OS_NAME" = "osx" ]; then
   status "0.1. Checking for Command Line Tools"
   xcode-select --version || xcode-select --install || fail "Unable to install Command Line Tools"
 fi
@@ -63,12 +71,12 @@ curl -L -s -o- "https://raw.githubusercontent.com/creationix/nvm/$NVM_VERSION/in
     fail "Failed to download nvm version $NVM_VERSION."
 
 status "1.1 ensure nvm is in your current process"
-. ~/.nvm/nvm.sh || source ~/.nvm/nvm.sh
+# shellcheck disable=SC1090
+. ~/.nvm/nvm.sh
 
 status "2. Install node"
-pushd .
 cd $ROOT && nvm install && nvm use || fail 'Failed to install target node version.'
-popd
+cd -
 
 status "3. Update npm to latest version"
 nvm install-latest-npm  || fail 'Failed to update npm to latest version.'

--- a/tools/setup
+++ b/tools/setup
@@ -29,7 +29,7 @@ status() {
 case $(uname | tr '[:upper:]' '[:lower:]') in
   linux*)
     OS_NAME=linux
-    BAZEL_DEP="https://github.com/bazelbuild/bazel/releases/download/$BAZEL_VERSION/bazel_$BAZEL_VERSION-installer-linux-x86_64.sh"
+    BAZEL_DEP="https://github.com/bazelbuild/bazel/releases/download/$BAZEL_VERSION/bazel-$BAZEL_VERSION-installer-linux-x86_64.sh"
     ;;
   darwin*)
     OS_NAME=osx

--- a/tools/setup
+++ b/tools/setup
@@ -1,11 +1,8 @@
 #!/bin/sh
 
 ROOT=$(dirname $0)/..
-
 NVM_VERSION="v0.34.0"
-
-BAZEL_DEB="https://github.com/bazelbuild/bazel/releases/download/0.29.0/bazel_0.29.0-linux-x86_64.deb"
-BAZEL_PKG_NAME=$(basename "$BAZEL_DEB")
+BAZEL_VERSION="0.29.0"
 
 YLW="\033[33m"
 RED="\033[91m"
@@ -16,9 +13,12 @@ END="\033[0m"
 
 CMD="$BLD$YLW"
 
+warn() {
+    echo "$RED$BLD$1$END"
+}
 
 fail() {
-    echo "$RED$BLD$1$END"
+    warn $1
     exit 1
 }
 
@@ -26,8 +26,39 @@ status() {
     echo "$MAG$1$END"
 }
 
+# Detect Platform
+case $(uname | tr '[:upper:]' '[:lower:]') in
+  linux*)
+    OS_NAME=linux
+    BAZEL_DEP="https://github.com/bazelbuild/bazel/releases/download/$BAZEL_VERSION/bazel_$BAZEL_VERSION-installer-linux-x86_64.sh"
+    ;;
+  darwin*)
+    OS_NAME=osx
+    BAZEL_DEP="https://github.com/bazelbuild/bazel/releases/download/$BAZEL_VERSION/bazel-$BAZEL_VERSION-installer-darwin-x86_64.sh"
+    ;;
+  msys*)
+    OS_NAME=windows
+    BAZEL_DEP="https://github.com/bazelbuild/bazel/releases/download/$BAZEL_VERSION/bazel-$BAZEL_VERSION-windows-x86_64.exe"
+    ;;
+  *)
+    OS_NAME=notset
+    warn "Can't detect host OS"
+    ;;
+esac
+
+BAZEL_PKG_NAME=$(basename "$BAZEL_DEP")
+
+status "0. Pre-requisites"
+if [ "$OS_NAME" == "linux" ]; then
+  status "0.1 Installing pre-requisites for Bazel"
+  sudo apt-get install pkg-config zip g++ zlib1g-dev unzip python3
+elif [ "$OS_NAME" == "osx" ]; then
+  status "0.1. Checking for Command Line Tools"
+  xcode-select --version || xcode-select --install || fail "Unable to install Command Line Tools"
+fi
+
 status "1. Install nvm"
-curl -o- "https://raw.githubusercontent.com/creationix/nvm/$NVM_VERSION/install.sh" | sh || \
+curl -L -o- "https://raw.githubusercontent.com/creationix/nvm/$NVM_VERSION/install.sh" | sh || \
     fail "Failed to download nvm version $NVM_VERSION."
 
 status "1.1 ensure nvm is in your current process"
@@ -45,10 +76,20 @@ status "4. Install dependencies"
 status "4.1. Install sigh dependencies"
 (cd $ROOT && ./tools/sigh install) || fail 'Failed to install sigh dependencies.'
 
-status "5. Install bazel"
-(wget "$BAZEL_DEB" && set -x && sudo dpkg -i $BAZEL_PKG_NAME)
+status "5. Install Bazel"
 
-status "5.1. Set up the .bazelrc file"
+status "5.1. Downloading install script"
+curl -O -L "$BAZEL_DEP" || fail "Failed to download Bazel binary"
+
+status "5.2. Running install script"
+(chmod +x $BAZEL_PKG_NAME && set -x && ( . $BAZEL_PKG_NAME --user || source $BAZEL_PKG_NAME --user)) \
+ || fail "Failed to install Bazel"
+echo 'export PATH="$PATH:$HOME/bin"'  >> ~/.profile || warn 'Failed to add "$HOME/bin" to $PATH'
+
+status "5.3. Clean up"
+rm "$BAZEL_PKG_NAME"
+
+status "5.4. Set up the .bazelrc file"
 (cd $ROOT && echo "build --define=repo_root=$(pwd)" >> .bazelrc)
 
 
@@ -57,6 +98,8 @@ echo "node --version"
 node --version
 echo "npm --version"
 npm --version
+echo "bazel --version"
+bazel --version
 echo "\nNext, try the following:\n"
 echo "- Setup git hooks: $CMD\`git config core.hooksPath tools/hooks\`$END"
 echo "- Serve the project: $CMD\`npm start\`$END"

--- a/tools/setup
+++ b/tools/setup
@@ -43,7 +43,7 @@ case $(uname | tr '[:upper:]' '[:lower:]') in
     ;;
   *)
     OS_NAME=notset
-    warn "Can't detect host OS"
+    fail "Can't detect host OS"
     ;;
 esac
 

--- a/tools/setup
+++ b/tools/setup
@@ -47,7 +47,7 @@ case $(uname | tr '[:upper:]' '[:lower:]') in
     ;;
 esac
 
-BAZEL_PKG_NAME=$(basename "$BAZEL_DEP")
+BAZEL_SCRIPT_NAME=$(basename "$BAZEL_DEP")
 
 status "0. Pre-requisites"
 if [ "$OS_NAME" == "linux" ]; then
@@ -85,12 +85,12 @@ status "5.1. Downloading install script"
 curl -O -L "$BAZEL_DEP" || fail "Failed to download Bazel binary"
 
 status "5.2. Running install script"
-(chmod +x $BAZEL_PKG_NAME && ( . $BAZEL_PKG_NAME --user || source $BAZEL_PKG_NAME --user)) \
+(chmod +x $BAZEL_SCRIPT_NAME && ( . $BAZEL_SCRIPT_NAME --user || source $BAZEL_SCRIPT_NAME --user)) \
  || fail "Failed to install Bazel"
 echo 'export PATH="$PATH:$HOME/bin"'  >> ~/.profile || warn 'Failed to add "$HOME/bin" to $PATH'
 
 status "5.3. Clean up"
-rm "$BAZEL_PKG_NAME"
+rm "$BAZEL_SCRIPT_NAME"
 
 status "5.4. Set up the .bazelrc file"
 (cd $ROOT && echo "build --define=repo_root=$(pwd)" >> .bazelrc)

--- a/tools/setup
+++ b/tools/setup
@@ -82,7 +82,7 @@ status "5.1. Downloading install script"
 curl -O -L "$BAZEL_DEP" || fail "Failed to download Bazel binary"
 
 status "5.2. Running install script"
-(chmod +x $BAZEL_PKG_NAME && set -x && ( . $BAZEL_PKG_NAME --user || source $BAZEL_PKG_NAME --user)) \
+(chmod +x $BAZEL_PKG_NAME && ( . $BAZEL_PKG_NAME --user || source $BAZEL_PKG_NAME --user)) \
  || fail "Failed to install Bazel"
 echo 'export PATH="$PATH:$HOME/bin"'  >> ~/.profile || warn 'Failed to add "$HOME/bin" to $PATH'
 

--- a/tools/setup
+++ b/tools/setup
@@ -50,16 +50,16 @@ esac
 BAZEL_SCRIPT_NAME=$(basename "$BAZEL_DEP")
 
 status "0. Pre-requisites"
-if [ "$OS_NAME" == "linux" ]; then
+if  "$OS_NAME" == "linux"; then
   status "0.1 Installing pre-requisites for Bazel"
   sudo apt-get install pkg-config zip g++ zlib1g-dev unzip python3
-elif [ "$OS_NAME" == "osx" ]; then
+elif "$OS_NAME" == "osx"; then
   status "0.1. Checking for Command Line Tools"
   xcode-select --version || xcode-select --install || fail "Unable to install Command Line Tools"
 fi
 
 status "1. Install nvm"
-curl -L -o- "https://raw.githubusercontent.com/creationix/nvm/$NVM_VERSION/install.sh" | sh || \
+curl -L -s -o- "https://raw.githubusercontent.com/creationix/nvm/$NVM_VERSION/install.sh" | sh || \
     fail "Failed to download nvm version $NVM_VERSION."
 
 status "1.1 ensure nvm is in your current process"
@@ -82,8 +82,8 @@ status "4.1. Install sigh dependencies"
 status "5. Install Bazel"
 
 status "5.1. Downloading install script"
-curl -O -L "$BAZEL_DEP" || fail "Failed to download Bazel binary"
-
+curl -O -L -s "$BAZEL_DEP" --output "$BAZEL_SCRIPT_NAME" || fail "Failed to download Bazel binary"
+ls
 status "5.2. Running install script"
 (chmod +x $BAZEL_SCRIPT_NAME && ( . $BAZEL_SCRIPT_NAME --user || source $BAZEL_SCRIPT_NAME --user)) \
  || fail "Failed to install Bazel"

--- a/tools/setup
+++ b/tools/setup
@@ -85,7 +85,7 @@ status "4. Install dependencies"
 (cd $ROOT && npm ci && npm --prefix=server ci) || fail 'Failed to install dependencies.'
 
 status "4.1. Install sigh dependencies"
-(cd $ROOT && ./tools/sigh install) || fail 'Failed to install sigh dependencies.'
+(cd $ROOT && ./tools/sigh install chokidar) || fail 'Failed to install sigh dependencies.'
 
 status "5. Install Bazel"
 

--- a/tools/setup
+++ b/tools/setup
@@ -85,8 +85,8 @@ status "5.1. Downloading install script"
 curl -O -L -s "$BAZEL_DEP" --output "$BAZEL_SCRIPT_NAME" || fail "Failed to download Bazel binary"
 ls
 status "5.2. Running install script"
-(chmod +x $BAZEL_SCRIPT_NAME && ( . $BAZEL_SCRIPT_NAME --user || source $BAZEL_SCRIPT_NAME --user)) \
- || fail "Failed to install Bazel"
+chmod +x $BAZEL_SCRIPT_NAME
+. $BAZEL_SCRIPT_NAME --user || source $BAZEL_SCRIPT_NAME --user || fail "Failed to install Bazel"
 echo 'export PATH="$PATH:$HOME/bin"'  >> ~/.profile || warn 'Failed to add "$HOME/bin" to $PATH'
 
 status "5.3. Clean up"


### PR DESCRIPTION
Addressing an issue raised by @SHeimlich and Hanhua@ ([see doc](https://docs.google.com/document/d/1wkcb8QIU7QBYf7WbCAwAMTUlNjXg-2f-dEY8gvsr-dA/edit?ts=5d83ea92#heading=h.bwzgqirwra2n)) 

## Summary of Changes: 
- Added pre-req step to install command-line-tools for mac or several packages for Bazel on Linux. 
- Added MacOS support for the Bazel install. Changed Linux Bazel install for consistency
- Added a step to install sigh dependencies (issue raised by Hanhua@)
- Fixed bug: Will now install correct version of node (before, it wasn't paying attention to .nvmrc). 