### PR TITLE
Fix race condition when calling start ArcsService.startArc().

### DIFF
--- a/src/javaharness/java/arcs/api/ShellApiBasedArcsEnvironment.java
+++ b/src/javaharness/java/arcs/api/ShellApiBasedArcsEnvironment.java
@@ -6,11 +6,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
 /**
  * Web based ArcsEnvironment using ShellApi. The Android version of this will different only in not
  * needing to use the ShellApi + Web runtime.
  */
+@Singleton
 public class ShellApiBasedArcsEnvironment implements ArcsEnvironment {
 
   private static final Logger logger = Logger.getLogger(ShellApiBasedArcsEnvironment.class.getName());


### PR DESCRIPTION
If the ArcsService was not already fully started (i.e. ready event received from Arcs), then the runArc message would fail. Now we wait until onReady has been called before trying to start the arc.