### PR TITLE
Refactor ArcsServiceBridge.

### DIFF
--- a/src/javaharness/java/arcs/android/api/IArcsService.aidl
+++ b/src/javaharness/java/arcs/android/api/IArcsService.aidl
@@ -22,6 +22,6 @@ interface IArcsService {
 
   void stopArc(String arcId, String pecId);
 
-  void registerRenderers(in List<String> modalities, IRemoteOutputCallback callback);
+  void registerRenderer(String modality, IRemoteOutputCallback callback);
 }
 

--- a/src/javaharness/java/arcs/android/client/AndroidUiBroker.java
+++ b/src/javaharness/java/arcs/android/client/AndroidUiBroker.java
@@ -1,17 +1,11 @@
 package arcs.android.client;
 
-import android.os.RemoteException;
 import arcs.android.api.IRemoteOutputCallback;
 import arcs.api.PortableJson;
 import arcs.api.PortableJsonParser;
 import arcs.api.UiBrokerImpl;
 import arcs.api.UiRenderer;
-
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
-import java.util.Map;
-import java.util.List;
 import javax.inject.Inject;
 
 public class AndroidUiBroker extends UiBrokerImpl {
@@ -29,7 +23,7 @@ public class AndroidUiBroker extends UiBrokerImpl {
 
   @Inject
   AndroidUiBroker(ArcsServiceBridge bridge, PortableJsonParser jsonParser) {
-    super(new HashMap<String, UiRenderer>());
+    super(new HashMap<>());
     this.bridge = bridge;
     this.jsonParser = jsonParser;
   }
@@ -37,20 +31,6 @@ public class AndroidUiBroker extends UiBrokerImpl {
   @Override
   public void registerRenderer(String modality, UiRenderer renderer) {
     super.registerRenderer(modality, renderer);
-    remoteRegister(Arrays.asList(modality));
-  }
-
-  private void remoteRegister(List<String> modalities) {
-    bridge
-        .connectToArcsService()
-        .thenAccept(
-            service -> {
-              try {
-                service.registerRenderers(modalities, callback);
-              } catch (RemoteException e) {
-                throw new RuntimeException(e);
-              }
-            }
-    );
+    bridge.registerRenderer(modality, callback);
   }
 }

--- a/src/javaharness/java/arcs/android/client/RemotePec.java
+++ b/src/javaharness/java/arcs/android/client/RemotePec.java
@@ -39,7 +39,9 @@ public class RemotePec {
     this.jsonParser = jsonParser;
   }
 
-  public Id getArcId() { return arcId; }
+  public Id getArcId() {
+    return arcId;
+  }
   /**
    * Starts a new arc running the given recipe. The given particle implementation is attached to
    * that arc.
@@ -62,22 +64,8 @@ public class RemotePec {
         pecInnerPortFactory.createPECInnerPort(pecId.toString(), idGenerator.getSessionId());
     pecInnerPort.mapParticle(particle);
 
-    bridge
-        .connectToArcsService()
-        .thenAccept(
-            service -> {
-              try {
-                service.startArc(
-                    arcId.toString(),
-                    pecId.toString(),
-                    recipe,
-                    particle.getId(),
-                    particle.getName(),
-                    callback);
-              } catch (RemoteException e) {
-                throw new RuntimeException(e);
-              }
-            });
+    bridge.startArc(
+        arcId.toString(), pecId.toString(), recipe, particle.getId(), particle.getName(), callback);
   }
 
   /** Shuts down the running arc and remote PEC. */
@@ -91,15 +79,6 @@ public class RemotePec {
     String arcId = this.arcId.toString();
     this.arcId = null;
 
-    bridge
-        .connectToArcsService()
-        .thenAccept(
-            service -> {
-              try {
-                service.stopArc(arcId, pecId);
-              } catch (RemoteException e) {
-                throw new RuntimeException(e);
-              }
-            });
+    bridge.stopArc(arcId, pecId);
   }
 }

--- a/src/javaharness/java/arcs/android/demo/service/ArcsService.java
+++ b/src/javaharness/java/arcs/android/demo/service/ArcsService.java
@@ -112,18 +112,15 @@ public class ArcsService extends Service {
       }
 
       @Override
-      public void registerRenderers(List<String> modalities, IRemoteOutputCallback callback) {
-        modalities.forEach(modality -> uiBroker.registerRenderer(modality, new UiRenderer() {
-          @Override
-          public boolean render(PortableJson content) {
-            try {
-              callback.onOutput(jsonParser.stringify(content));
-            } catch (RemoteException e) {
-              throw new RuntimeException(e);
-            }
-            return true;
+      public void registerRenderer(String modality, IRemoteOutputCallback callback) {
+        uiBroker.registerRenderer(modality, content -> {
+          try {
+            callback.onOutput(jsonParser.stringify(content));
+          } catch (RemoteException e) {
+            throw new RuntimeException(e);
           }
-        }));
+          return true;
+        });
       }
     };
   }

--- a/src/javaharness/java/arcs/api/ArcsEnvironment.java
+++ b/src/javaharness/java/arcs/api/ArcsEnvironment.java
@@ -31,32 +31,32 @@ public interface ArcsEnvironment {
    * Fires an event to notify listener when given transaction-id data is available.
    * TODO: DataListeners are deprecated, remove.
    */
-  void fireDataEvent(String tid, String data);
+  default void fireDataEvent(String tid, String data) {}
 
   /**
    * A callback when Arcs is ready to for interaction.
    *
    * @param listener a callback interface for suggestions.
    */
-  void addReadyListener(ReadyListener listener);
+  default void addReadyListener(ReadyListener listener) {}
 
   /**
    * Fires an event to notify listeners when Arcs is ready for interaction.
    */
-  void fireReadyEvent(List<String> recipes);
+  default void fireReadyEvent(List<String> recipes) {}
 
   /** Initialize Arcs */
-  void init();
+  default void init() {}
 
   /** Reset Arcs to the Launcher state. */
-  void reset();
+  default void reset() {}
 
   /** Tear down any resources used by the environment. */
-  void destroy();
+  default void destroy() {}
 
   /** Cause Arcs full screen UI to be shown. */
-  void show();
+  default void show() {}
 
   /** Cause Arcs full screen UI to be hidden. */
-  void hide();
+  default void hide() {}
 }


### PR DESCRIPTION
It used to swallow up exceptions, due to the way the futures were being
used (the return values were being ignored). Now it uses a thread pool
executor, and exceptions get thrown correctly.

Also cleaned up a lot of the boilerplate for catching and rethrowing RemoteException. Now the Bridge class does all that for you.

Also refactored registerRenderers to only accept a single modality.