### PR TITLE
Ensure that errors in URL requests produce proper errors in particles

### DIFF
--- a/src/runtime/loader.ts
+++ b/src/runtime/loader.ts
@@ -98,7 +98,7 @@ export class Loader {
   }
 
   async _loadURL(url: string): Promise<string> {
-    const fetcher = (url: string) => fetch(url).then(async res => res.ok ? res.text() : undefined);
+    const fetcher = (url: string) => fetch(url).then(async res => res.ok ? res.text() : Promise.reject(new Error(`HTTP ${res.status}: ${res.statusText}`)));
     if (/\/\/schema.org\//.test(url)) {
       if (url.endsWith('/Thing')) {
         return fetcher('https://schema.org/Product.jsonld').then(data => JsonldToManifest.convert(data, {'@id': 'schema:Thing'}));

--- a/src/runtime/particle-execution-context.ts
+++ b/src/runtime/particle-execution-context.ts
@@ -321,7 +321,7 @@ export class ParticleExecutionContext {
     } else {
       const clazz = await this.loader.loadParticleClass(spec);
       if (!clazz) {
-        return Promise.reject(new Error(`Could not load particle ${id} ${spec.name}`));
+        return Promise.reject(new Error(`Unknown error loading particle ${id} ${spec.name}`));
       }
       particle = new clazz();
       particle.setCapabilities(this.capabilities(true));


### PR DESCRIPTION
Hoping to make particle development easier (by improving the error messages on failure to load particles over http).

This was found while investigating https://github.com/PolymerLabs/arcs/issues/3603 but may not fix it.

It may also improve the situation around #2570 