### PR TITLE
Added a new chat demo

### DIFF
--- a/particles/PipeApps/AndroidChat.arcs
+++ b/particles/PipeApps/AndroidChat.arcs
@@ -1,0 +1,19 @@
+schema Message
+  Number index
+  Text text
+
+particle ChatParticle in './source/ChatParticle.java'
+  out [Message] messages
+  in [Message] happy
+
+particle SmileyAdder in './source/SmileyAdder.js'
+  in [Message] messages
+  out [Message] happy
+
+recipe AndroidChat
+  ChatParticle
+    messages -> messages
+    happy <- happy
+  SmileyAdder
+    messages <- messages
+    happy -> happy

--- a/particles/PipeApps/source/SmileyAdder.js
+++ b/particles/PipeApps/source/SmileyAdder.js
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright (c) 2019 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+'use strict';
+
+// A silly particle which adds a smiley to the end of every chat message.
+defineParticle(({Particle}) => {
+  return class SmileyAdder extends Particle {
+    onHandleSync(handle, model) {
+      super.onHandleSync(handle, model);
+      if (handle.name !== 'messages') {
+        return;
+      }
+      this.messages = model;
+      for (const message of this.messages) {
+        this._addASmiley(message);
+      }
+    }
+
+    onHandleUpdate(handle, update) {
+      super.onHandleUpdate(handle, update);
+      if (handle.name !== 'messages' || !update.added) {
+        return;
+      }
+      for (const message of update.added) {
+        this._addASmiley(message);
+      }
+    }
+
+    /** Modifies a Message entity to add a smiley face to the end. */
+    _addASmiley(message) {
+      if (message.text.endsWith('🙂')) {
+        return;
+      }
+      const happyHandle = this.handles.get('happy');
+      const happyEntity = new happyHandle.entityClass({
+        index: message.index,
+        text: message.text + ' 🙂',
+      });
+      happyHandle.store(happyEntity);
+    }
+  };
+});

--- a/shells/pipes-shell/source/pipe.js
+++ b/shells/pipes-shell/source/pipe.js
@@ -29,6 +29,7 @@ const manifest = `
 import 'https://$particles/PipeApps/RenderNotification.arcs'
 import 'https://$particles/PipeApps/Ingestion.arcs'
 import 'https://$particles/PipeApps/AndroidAutofill.arcs'
+import 'https://$particles/PipeApps/AndroidChat.arcs'
 // UIBroker/demo particles below here
 import 'https://$particles/Pipes/Pipes.arcs'
 `;

--- a/src/javaharness/java/arcs/android/demo/chat/AndroidManifest.xml
+++ b/src/javaharness/java/arcs/android/demo/chat/AndroidManifest.xml
@@ -1,0 +1,15 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="arcs.android.demo.chat"
+    android:versionCode="1"
+    android:versionName="1.0">
+
+  <uses-sdk
+      android:minSdkVersion="29"
+      android:targetSdkVersion="29"/>
+
+  <application>
+    <activity
+        android:name="arcs.android.demo.chat.ChatActivity"
+        android:label="Long-running Arc Demo" />
+  </application>
+</manifest>

--- a/src/javaharness/java/arcs/android/demo/chat/BUILD
+++ b/src/javaharness/java/arcs/android/demo/chat/BUILD
@@ -15,6 +15,7 @@ android_library(
     deps = [
         "//java/arcs/android/api",
         "//java/arcs/android/client",
+        "//java/arcs/android/demo/service",
         "//java/arcs/android/impl",
         "//java/arcs/api:api-android",
         "//java/arcs/demo/particles:particles-android",

--- a/src/javaharness/java/arcs/android/demo/chat/BUILD
+++ b/src/javaharness/java/arcs/android/demo/chat/BUILD
@@ -1,0 +1,26 @@
+package(default_visibility = [
+    "//java/arcs/android/demo:__subpackages__",
+    "//javatests/arcs/android/demo:__subpackages__",
+])
+
+licenses(["notice"])
+
+load("@build_bazel_rules_android//android:rules.bzl", "android_binary", "android_library")
+
+android_library(
+    name = "chat",
+    srcs = glob(["*.java"]),
+    manifest = "AndroidManifest.xml",
+    resource_files = glob(["res/**"]),
+    deps = [
+        "//java/arcs/android/api",
+        "//java/arcs/android/client",
+        "//java/arcs/android/impl",
+        "//java/arcs/api:api-android",
+        "//java/arcs/demo/particles:particles-android",
+        "//java/arcs/demo/services:services-android",
+        "//java/arcs/demo/ui:ui-android",
+        "@com_google_dagger",
+        "@javax_inject_source//jar",
+    ],
+)

--- a/src/javaharness/java/arcs/android/demo/chat/ChatActivity.java
+++ b/src/javaharness/java/arcs/android/demo/chat/ChatActivity.java
@@ -1,0 +1,61 @@
+package arcs.android.demo.chat;
+
+import android.app.Activity;
+import android.content.Context;
+import android.os.Bundle;
+import android.view.KeyEvent;
+import android.view.inputmethod.EditorInfo;
+import android.view.inputmethod.InputMethodManager;
+import android.widget.Button;
+import android.widget.EditText;
+import android.widget.TextView;
+
+/**
+ * Demo activity of a long-running arc (chat app). Demo lets you simulate
+ * starting/stopping/rejoining an arc.
+ */
+public class ChatActivity extends Activity {
+
+  private InputMethodManager inputMethodManager;
+  private String chatLog = "";
+
+  @Override
+  public void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+
+    setContentView(R.layout.chat_demo_layout);
+
+    inputMethodManager = (InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE);
+
+    Button submitButton = findViewById(R.id.chat_submit_button);
+    submitButton.setOnClickListener(view -> onSubmit());
+
+    EditText editText = findViewById(R.id.chat_message);
+    editText.setOnEditorActionListener(
+        (TextView v, int actionId, KeyEvent event) -> {
+          if (actionId == EditorInfo.IME_ACTION_DONE) {
+            onSubmit();
+            return true;
+          }
+          return false;
+        });
+  }
+
+  private void onSubmit() {
+    EditText editText = findViewById(R.id.chat_message);
+    String message = editText.getText().toString();
+
+    editText.setText("");
+    inputMethodManager.hideSoftInputFromWindow(editText.getApplicationWindowToken(), 0);
+
+    addMessageToChatLog(message);
+  }
+
+  private void addMessageToChatLog(String message) {
+    // TODO: Use Arcs for the chat log.
+    chatLog += message + "\n";
+
+    TextView chatView = findViewById(R.id.chat_log);
+    chatView.setText(chatLog);
+  }
+}

--- a/src/javaharness/java/arcs/android/demo/chat/ChatActivityComponent.java
+++ b/src/javaharness/java/arcs/android/demo/chat/ChatActivityComponent.java
@@ -1,0 +1,24 @@
+package arcs.android.demo.chat;
+
+import android.content.Context;
+import arcs.android.api.Annotations.AppContext;
+import arcs.android.client.AndroidClientModule;
+import arcs.android.demo.service.ArcsServiceModule;
+import dagger.BindsInstance;
+import dagger.Component;
+import javax.inject.Singleton;
+
+@Singleton
+@Component(modules = {AndroidClientModule.class, ArcsServiceModule.class})
+public interface ChatActivityComponent {
+
+  void inject(ChatActivity chatActivity);
+
+  @Component.Builder
+  interface Builder {
+    @BindsInstance
+    ChatActivityComponent.Builder appContext(@AppContext Context appContext);
+
+    ChatActivityComponent build();
+  }
+}

--- a/src/javaharness/java/arcs/android/demo/chat/ChatParticle.java
+++ b/src/javaharness/java/arcs/android/demo/chat/ChatParticle.java
@@ -1,0 +1,80 @@
+package arcs.android.demo.chat;
+
+import arcs.api.Collection;
+import arcs.api.Handle;
+import arcs.api.ParticleBase;
+import arcs.api.PortableJson;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.function.Consumer;
+
+public class ChatParticle extends ParticleBase {
+
+  private Collection messagesHandle;
+  private final Consumer<String> callback;
+  private SortedMap<Integer, String> chatMessages = new TreeMap<>();
+  private int nextIndex = 0;
+
+  ChatParticle(Consumer<String> callback) {
+    this.callback = callback;
+  }
+
+  public void addChatMessage(String message) {
+    PortableJson data = jsonParser.emptyObject();
+    data.put("index", nextIndex++);
+    data.put("text", message);
+    messagesHandle.store(jsonParser.emptyObject().put("rawData", data));
+  }
+
+  @Override
+  public void setHandles(Map<String, Handle> handleByName) {
+    super.setHandles(handleByName);
+    messagesHandle = (Collection) handleByName.get("messages");
+  }
+
+  @Override
+  public void onHandleSync(Handle handle, PortableJson model) {
+    super.onHandleSync(handle, model);
+
+    for (int i = 0; i < model.getLength(); i++) {
+      PortableJson entity = model.getObject(i);
+      addMessageFromHandle(handle, entity);
+    }
+    onChatUpdate();
+  }
+
+  @Override
+  public void onHandleUpdate(Handle handle, PortableJson update) {
+    super.onHandleUpdate(handle, update);
+
+    if (!handle.name.equals("happy")) {
+      return;
+    }
+
+    if (update.hasKey("added")) {
+      PortableJson added = update.getArray("added");
+      for (int i = 0; i < added.getLength(); i++) {
+        PortableJson entity = added.getObject(i).getObject("rawData");
+        addMessageFromHandle(handle, entity);
+      }
+    }
+
+    onChatUpdate();
+  }
+
+  private void addMessageFromHandle(Handle handle, PortableJson entity) {
+    // Messages from the happy handle should overwrite unhappy messages.
+    boolean shouldOverwrite = handle.name.equals("happy");
+
+    int index = entity.getInt("index");
+    String text = entity.getString("text");
+    if (shouldOverwrite || !chatMessages.containsKey(index)) {
+      chatMessages.put(index, text);
+    }
+  }
+
+  private void onChatUpdate() {
+    callback.accept(String.join("\n", chatMessages.values()));
+  }
+}

--- a/src/javaharness/java/arcs/android/demo/chat/res/layout/chat_demo_layout.xml
+++ b/src/javaharness/java/arcs/android/demo/chat/res/layout/chat_demo_layout.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical" android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+  <LinearLayout
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:orientation="horizontal">
+
+    <Button
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="aaaa" />
+
+  </LinearLayout>
+
+  <View
+      android:layout_width="match_parent"
+      android:layout_height="1dp"
+      android:background="?android:attr/listDivider" />
+
+  <TextView
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:layout_marginHorizontal="10dp"
+      android:text="Chat history:"
+      android:textAppearance="@android:style/TextAppearance.Material.Body1" />
+
+  <ScrollView
+      android:layout_width="match_parent"
+      android:layout_height="match_parent"
+      android:layout_marginHorizontal="10dp"
+      android:layout_weight="1">
+    <TextView
+        android:id="@+id/chat_log"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+  </ScrollView>
+
+  <View
+      android:layout_width="match_parent"
+      android:layout_height="1dp"
+      android:background="?android:attr/listDivider" />
+
+  <LinearLayout
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:orientation="horizontal">
+
+    <EditText
+        android:id="@+id/chat_message"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:ems="12"
+        android:hint="Message"
+        android:inputType="text"
+        android:singleLine="true"
+        android:imeOptions="actionDone" />
+
+    <Button
+        android:id="@+id/chat_submit_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Submit"/>
+
+  </LinearLayout>
+</LinearLayout>

--- a/src/javaharness/java/arcs/android/demo/ui/AndroidManifest.xml
+++ b/src/javaharness/java/arcs/android/demo/ui/AndroidManifest.xml
@@ -20,7 +20,7 @@
     </activity>
 
     <activity
-      android:name=".AutofillDemoActivity"
-      android:label="Autofill Demo" />
+        android:name=".AutofillDemoActivity"
+        android:label="Autofill Demo" />
   </application>
 </manifest>

--- a/src/javaharness/java/arcs/android/demo/ui/BUILD
+++ b/src/javaharness/java/arcs/android/demo/ui/BUILD
@@ -13,6 +13,7 @@ android_library(
     manifest = "AndroidManifest.xml",
     resource_files = glob(["res/**"]),
     deps = [
+        "//java/arcs/android/demo/chat",
         "//java/arcs/android/demo/service",
         "@com_google_dagger",
         "@flogger//jar",

--- a/src/javaharness/java/arcs/android/demo/ui/MainActivity.java
+++ b/src/javaharness/java/arcs/android/demo/ui/MainActivity.java
@@ -8,6 +8,7 @@ import android.os.Bundle;
 import android.os.IBinder;
 import android.util.Log;
 import android.widget.Button;
+import arcs.android.demo.chat.ChatActivity;
 import arcs.android.demo.service.ArcsService;
 
 /**
@@ -50,6 +51,9 @@ public class MainActivity extends Activity {
     Button autofillDemoButton = findViewById(R.id.autofill_demo_button);
     autofillDemoButton.setOnClickListener(v -> startAutofillDemo());
 
+    Button longRunningArcDemoButton = findViewById(R.id.long_arc_demo_button);
+    longRunningArcDemoButton.setOnClickListener(v -> startLongRunningArcDemo());
+
     updateBtn();
   }
 
@@ -73,6 +77,11 @@ public class MainActivity extends Activity {
 
   private void startAutofillDemo() {
     Intent intent = new Intent(this, AutofillDemoActivity.class);
+    startActivity(intent);
+  }
+
+  private void startLongRunningArcDemo() {
+    Intent intent = new Intent(this, ChatActivity.class);
     startActivity(intent);
   }
 }

--- a/src/javaharness/java/arcs/android/demo/ui/res/layout/activity_main.xml
+++ b/src/javaharness/java/arcs/android/demo/ui/res/layout/activity_main.xml
@@ -24,7 +24,7 @@
         android:id="@+id/long_arc_demo_button"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Long-running Arc Demo" />
+        android:text="Chat Demo" />
 
   </LinearLayout>
 

--- a/src/javaharness/java/arcs/android/demo/ui/res/layout/activity_main.xml
+++ b/src/javaharness/java/arcs/android/demo/ui/res/layout/activity_main.xml
@@ -20,6 +20,12 @@
         android:layout_height="wrap_content"
         android:text="Autofill Demo" />
 
+    <Button
+        android:id="@+id/long_arc_demo_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Long-running Arc Demo" />
+
   </LinearLayout>
 
 </FrameLayout>


### PR DESCRIPTION
This is meant to demo a long-running arc, that can be reattached and deattached.

The ChatParticle works. You can add chat messages, and then the JS particle will add smiley faces to the end of them :-) There's a placeholder aaaa button at the top of the screen to show where some buttons will go later on. We'll add a start/stop button there so that you can interrupt the ArcsService lifecycle and see what happens (hopefully you'll be able to post new messages, and when you restart the service they'll automatically get smileys added to them).

Still need to add the buttons to start/stop, and also actually implement the ability to reattach to an existing arc.

Diffbase against #3606

![Screenshot from 2019-09-23 17-34-15](https://user-images.githubusercontent.com/15258378/65408355-63723d00-de28-11e9-9acf-438e426b5236.png)
