### PR TITLE
Unify Store construction.

### DIFF
--- a/src/runtime/crdt/crdt-entity.ts
+++ b/src/runtime/crdt/crdt-entity.ts
@@ -31,8 +31,8 @@ type SingletonEntityData<S extends Identified> = {[P in keyof S]: CRDTSingletonT
 type CollectionEntityData<S extends Identified> = {[P in keyof S]: CRDTCollectionTypeRecord<S[P]>['data']};
 
 // These extend actual CRDT objects across an entity structure.
-type SingletonEntityModel<S extends Identified> = {[P in keyof S]: CRDTSingleton<S[P]>};
-type CollectionEntityModel<S extends Identified> = {[P in keyof S]: CRDTCollection<S[P]>};
+export type SingletonEntityModel<S extends Identified> = {[P in keyof S]: CRDTSingleton<S[P]>};
+export type CollectionEntityModel<S extends Identified> = {[P in keyof S]: CRDTCollection<S[P]>};
 
 // The data view of an entity.
 export type EntityData<S extends Identified, C extends Identified> = 
@@ -71,7 +71,11 @@ type EntityModel<S extends Identified, C extends Identified> = CRDTModel<CRDTEnt
 type EntityChange<S extends Identified, C extends Identified> = CRDTChange<CRDTEntityTypeRecord<S, C>>;
 
 export class CRDTEntity<S extends Identified, C extends Identified> implements EntityModel<S, C> {
-  private model: EntityInternalModel<S, C>;
+  // Note that this should really be private, but it can't be because subclasses need to be
+  // automatically constructed (which means constructed in a function) and anonymous subclasses
+  // can't be returned from a function if they have private or protected members because of
+  // TS4094 (see e.g. https://github.com/Microsoft/TypeScript/issues/30355 for Microsoft's take on the issue)
+  model: EntityInternalModel<S, C>;
   
   constructor(singletons: SingletonEntityModel<S>, collections: CollectionEntityModel<C>) {
     this.model = {singletons, collections, version: {}};

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -85,7 +85,8 @@ export class Runtime {
   newArc(name: string, storageKeyPrefix: string, options?: RuntimeArcOptions): Arc {
     const id = IdGenerator.newSession().newArcId(name);
     const storageKey = storageKeyPrefix + id.toString();
-    return new Arc({id, storageKey, loader: this.loader, slotComposer: new this.composerClass(), context: this.context, ...options});
+    const slotComposer = this.composerClass ? new this.composerClass() : null;
+    return new Arc({id, storageKey, loader: this.loader, slotComposer, context: this.context, ...options});
   }
 
   // Stuff the shell needs

--- a/src/runtime/schema.ts
+++ b/src/runtime/schema.ts
@@ -14,6 +14,10 @@ import {EntityClass, Entity} from './entity.js';
 import {ParticleExecutionContext} from './particle-execution-context.js';
 import {EntityType, Type} from './type.js';
 import {Dictionary} from './hot.js';
+import {CRDTEntity, SingletonEntityModel, CollectionEntityModel} from './crdt/crdt-entity.js';
+import {Referenceable} from './crdt/crdt-collection.js';
+import {Singleton} from './handle.js';
+import {CRDTSingleton} from './crdt/crdt-singleton.js';
 
 export class Schema {
   readonly names: string[];
@@ -176,6 +180,24 @@ export class Schema {
 
   entityClass(context: ParticleExecutionContext|null = null): EntityClass {
     return Entity.createEntityClass(this, context);
+  }
+
+  crdtConstructor<S extends Dictionary<Referenceable>, C extends Dictionary<Referenceable>>() {
+    const singletons = {};
+    const collections = {};
+    // TODO(shans) do this properly
+    for (const [field, {type}] of Object.entries(this.fields)) {
+      if (type === 'Text') {
+        singletons[field] = new CRDTSingleton<{id: string}>();
+      } else if (type === 'Number') {
+        singletons[field] = new CRDTSingleton<{id: string, value: number}>();
+      }
+    }
+    return class EntityCRDT extends CRDTEntity<S, C> {
+      constructor() {
+        super(singletons as SingletonEntityModel<S>, collections as CollectionEntityModel<C>);
+      }
+    };
   }
 
   toInlineSchemaString(options?: {hideFields?: boolean}): string {

--- a/src/runtime/schema.ts
+++ b/src/runtime/schema.ts
@@ -191,6 +191,8 @@ export class Schema {
         singletons[field] = new CRDTSingleton<{id: string}>();
       } else if (type === 'Number') {
         singletons[field] = new CRDTSingleton<{id: string, value: number}>();
+      } else {
+        throw new Error(`Big Scary Exception: entity field ${field} of type ${type} doesn't yet have a CRDT mapping implemented`);
       }
     }
     return class EntityCRDT extends CRDTEntity<S, C> {

--- a/src/runtime/storageNG/backing-store.ts
+++ b/src/runtime/storageNG/backing-store.ts
@@ -33,8 +33,7 @@ export class BackingStore<T extends CRDTTypeRecord>  {
     public storageKey: StorageKey,
     private exists: Exists,
     private type: Type,
-    private mode: StorageMode,
-    public modelConstructor: new () => CRDTModel<T>) {
+    private mode: StorageMode) {
   }
 
   on(callback: MultiplexedProxyCallback<T>): number {
@@ -61,7 +60,7 @@ export class BackingStore<T extends CRDTTypeRecord>  {
   }
 
   private async setupStore(muxId: string): Promise<{type: 'record', store: DirectStore<T>, id: number}> {
-    const store = await DirectStore.construct(this.storageKey.childWithComponent(muxId), this.exists, this.type, this.mode, this.modelConstructor);
+    const store = await DirectStore.construct<T>(this.storageKey.childWithComponent(muxId), this.exists, this.type, this.mode);
     const id = store.on(msg => this.processStoreCallback(muxId, msg));
     const record: StoreRecord<T> = {store, id, type: 'record'};
     this.stores[muxId] = record;
@@ -81,8 +80,8 @@ export class BackingStore<T extends CRDTTypeRecord>  {
     return store.onProxyMessage(message);
   }
 
-  static async construct<T extends CRDTTypeRecord>(storageKey: StorageKey, exists: Exists, type: Type, mode: StorageMode, modelConstructor: new () => CRDTModel<T>) {
-    return new BackingStore<T>(storageKey, exists, type, mode, modelConstructor);
+  static async construct<T extends CRDTTypeRecord>(storageKey: StorageKey, exists: Exists, type: Type, mode: StorageMode) {
+    return new BackingStore<T>(storageKey, exists, type, mode);
   }
 
   async idle() {

--- a/src/runtime/storageNG/direct-store.ts
+++ b/src/runtime/storageNG/direct-store.ts
@@ -32,8 +32,8 @@ export class DirectStore<T extends CRDTTypeRecord> extends ActiveStore<T> {
   /*
    * This class should only ever be constructed via the static construct method
    */
-  private constructor(storageKey: StorageKey, exists: Exists, type: Type, mode: StorageMode, modelConstructor: new () => CRDTModel<T>) {
-    super(storageKey, exists, type, mode, modelConstructor);
+  private constructor(storageKey: StorageKey, exists: Exists, type: Type, mode: StorageMode) {
+    super(storageKey, exists, type, mode);
   }
 
   async idle() {
@@ -67,9 +67,9 @@ export class DirectStore<T extends CRDTTypeRecord> extends ActiveStore<T> {
     }
   }
 
-  static async construct<T extends CRDTTypeRecord>(storageKey: StorageKey, exists: Exists, type: Type, mode: StorageMode, modelConstructor: new () => CRDTModel<T>) {
-    const me = new DirectStore<T>(storageKey, exists, type, mode, modelConstructor);
-    me.localModel = new modelConstructor();
+  static async construct<T extends CRDTTypeRecord>(storageKey: StorageKey, exists: Exists, type: Type, mode: StorageMode) {
+    const me = new DirectStore<T>(storageKey, exists, type, mode);
+    me.localModel = new (type.crdtInstanceConstructor<T>())();
     me.driver = await DriverFactory.driverInstance(storageKey, exists);
     if (me.driver == null) {
       throw new CRDTError(`No driver exists to support storage key ${storageKey}`);

--- a/src/runtime/storageNG/reference-mode-store.ts
+++ b/src/runtime/storageNG/reference-mode-store.ts
@@ -10,14 +10,14 @@
 
 import {CRDTSingletonTypeRecord, SingletonOperation, SingletonOpTypes, CRDTSingleton, SingletonOperationSet, SingletonOperationClear} from '../crdt/crdt-singleton.js';
 import {CRDTCollectionTypeRecord, Referenceable, CollectionOpTypes, CollectionOperation, CRDTCollection, CollectionOperationAdd, CollectionOperationRemove} from '../crdt/crdt-collection.js';
-import {ActiveStore, ProxyCallback, ProxyMessage, ProxyMessageType, StorageMode} from './store.js';
+import {ActiveStore, ProxyCallback, ProxyMessage, ProxyMessageType, StorageMode} from './store-interface.js';
 import {BackingStore} from './backing-store.js';
 import {CRDTEntityTypeRecord, CRDTEntity, EntityData} from '../crdt/crdt-entity.js';
 import {DirectStore} from './direct-store.js';
 import {StorageKey} from './storage-key.js';
-import {VersionMap, CRDTModel, CRDTTypeRecord} from '../crdt/crdt.js';
+import {VersionMap, CRDTTypeRecord} from '../crdt/crdt.js';
 import {Exists} from './drivers/driver-factory.js';
-import {Type} from '../type.js';
+import {Type, CollectionType, ReferenceType} from '../type.js';
 import {Producer, Consumer, Runnable, Dictionary} from '../hot.js';
 import {PropagatedException} from '../arc-exceptions.js';
 
@@ -38,6 +38,23 @@ type EnqueuedMessage<Container extends CRDTTypeRecord, Entity extends CRDTTypeRe
 
 type BlockableRunnable = {fn: Runnable, block?: string};
 
+export class ReferenceModeStorageKey extends StorageKey {
+  constructor(public backingKey: StorageKey, public storageKey: StorageKey) {
+    super('reference-mode');
+  }
+
+  embedKey(key: StorageKey) {
+    return key.toString().replace(/\{/g, '{{').replace(/\}/g, '}}');
+  }
+
+  toString(): string {
+    return `${this.protocol}://{${this.embedKey(this.backingKey)}}{${this.embedKey(this.storageKey)}}`;
+  }
+
+  childWithComponent(component: string): StorageKey {
+    return new ReferenceModeStorageKey(this.backingKey, this.storageKey.childWithComponent(component));
+  }
+}
 
 /**
  * ReferenceModeStores adapt between a collection (CRDTCollection or CRDTSingleton) of entities from the perspective of their public API,
@@ -111,11 +128,17 @@ export class ReferenceModeStore<Entity extends Referenceable, S extends Dictiona
   static async construct<Entity extends Referenceable, S extends Dictionary<Referenceable>, C extends Dictionary<Referenceable>,
                          ReferenceContainer extends CRDTSingletonTypeRecord<Reference> | CRDTCollectionTypeRecord<Reference>,
                          Container extends CRDTSingletonTypeRecord<Entity> | CRDTCollectionTypeRecord<Entity>>(
-      backingKey: StorageKey, storageKey: StorageKey, exists: Exists, type: Type, backingConstructor: new () => CRDTModel<CRDTEntityTypeRecord<S, C>>,
-      referenceConstructor: new () => CRDTModel<ReferenceContainer>, modelConstructor: new () => CRDTModel<Container>) {
-    const result = new ReferenceModeStore<Entity, S, C, ReferenceContainer, Container>(storageKey, exists, type, StorageMode.ReferenceMode, modelConstructor);
-    result.backingStore = await BackingStore.construct(backingKey, exists, type, StorageMode.Backing, backingConstructor);
-    result.containerStore = await DirectStore.construct(storageKey, exists, type, StorageMode.Direct, referenceConstructor);
+      storageKey: ReferenceModeStorageKey, exists: Exists, type: Type) {
+    const result = new ReferenceModeStore<Entity, S, C, ReferenceContainer, Container>(storageKey, exists, type, StorageMode.ReferenceMode);
+    result.backingStore = await BackingStore.construct(storageKey.backingKey, exists, type.getContainedType(), StorageMode.Backing);
+    let refType;
+    if (type.isCollectionType()) {
+      refType = new CollectionType(new ReferenceType(type.getContainedType()));
+    } else {
+      // TODO(shans) probably need a singleton type here now.
+      refType = new ReferenceType(type.getContainedType());
+    }
+    result.containerStore = await DirectStore.construct(storageKey.storageKey, exists, type, StorageMode.Direct);
     result.registerStoreCallbacks();
     return result;
   }
@@ -406,7 +429,7 @@ export class ReferenceModeStore<Entity extends Referenceable, S extends Dictiona
       this.versions[entity.id] = {};
     }
     const entityVersion = this.versions[entity.id];
-    const model = new this.backingStore.modelConstructor().getData();
+    const model = this.newBackingInstance().getData();
     let maxVersion = 0;
     for (const key of Object.keys(entity)) {
       if (key === 'id') {
@@ -490,7 +513,7 @@ export class ReferenceModeStore<Entity extends Referenceable, S extends Dictiona
       const model = {values: {}, version: this.cloneMap(data.version)} as Container['data'];
       for (const id of Object.keys(data.values)) {
         const version = data.values[id].value.version;
-        const entity = Object.keys(version).length === 0 ? new this.backingStore.modelConstructor() : this.backingStore.getLocalModel(id);
+        const entity = Object.keys(version).length === 0 ? this.newBackingInstance() : this.backingStore.getLocalModel(id);
         model.values[id] = {value: this.entityFromModel(entity.getData(), id), version: data.values[id].version};
       }
       return model;
@@ -526,6 +549,11 @@ export class ReferenceModeStore<Entity extends Referenceable, S extends Dictiona
   private async updateBackingStore(entity: Entity) {
     const model = this.entityToModel(entity);
     return this.backingStore.onProxyMessage({type: ProxyMessageType.ModelUpdate, model, id: 1}, entity.id);
+  }
+
+  private newBackingInstance() {
+    const instanceConstructor = this.type.getContainedType().crdtInstanceConstructor<CRDTEntityTypeRecord<S, C>>();
+    return new instanceConstructor();
   }
 
   /**

--- a/src/runtime/storageNG/reference-mode-store.ts
+++ b/src/runtime/storageNG/reference-mode-store.ts
@@ -131,7 +131,7 @@ export class ReferenceModeStore<Entity extends Referenceable, S extends Dictiona
       storageKey: ReferenceModeStorageKey, exists: Exists, type: Type) {
     const result = new ReferenceModeStore<Entity, S, C, ReferenceContainer, Container>(storageKey, exists, type, StorageMode.ReferenceMode);
     result.backingStore = await BackingStore.construct(storageKey.backingKey, exists, type.getContainedType(), StorageMode.Backing);
-    let refType;
+    let refType: Type;
     if (type.isCollectionType()) {
       refType = new CollectionType(new ReferenceType(type.getContainedType()));
     } else {

--- a/src/runtime/storageNG/store-interface.ts
+++ b/src/runtime/storageNG/store-interface.ts
@@ -35,7 +35,6 @@ export type StoreInterface<T extends CRDTTypeRecord> = {
   exists: Exists;
   readonly type: Type;
   readonly mode: StorageMode;
-  modelConstructor: new () => CRDTModel<T>;
 };
 
 // A representation of an active store. Subclasses of this class provide specific
@@ -45,14 +44,12 @@ export abstract class ActiveStore<T extends CRDTTypeRecord> implements StoreInte
   exists: Exists;
   readonly type: Type;
   readonly mode: StorageMode;
-  modelConstructor: new () => CRDTModel<T>;
 
-  constructor(storageKey: StorageKey, exists: Exists, type: Type, mode: StorageMode, modelConstructor: new () => CRDTModel<T>) {
+  constructor(storageKey: StorageKey, exists: Exists, type: Type, mode: StorageMode) {
     this.storageKey = storageKey;
     this.exists = exists;
     this.type = type;
     this.mode = mode;
-    this.modelConstructor = modelConstructor;
   }
   
   async idle() {

--- a/src/runtime/storageNG/testing/test-storage.ts
+++ b/src/runtime/storageNG/testing/test-storage.ts
@@ -19,6 +19,7 @@ import {Handle} from '../handle.js';
 import {StorageKey} from '../storage-key.js';
 import {StorageProxy} from '../storage-proxy.js';
 import {ActiveStore, ProxyCallback, ProxyMessage, StorageMode} from '../store.js';
+import {Type, ReferenceType, CountType} from '../../type.js';
 
 
 /**
@@ -48,7 +49,7 @@ export class MockStore<T extends CRDTTypeRecord> extends ActiveStore<T> {
   lastCapturedMessage: ProxyMessage<T> = null;
   lastCapturedException: PropagatedException = null;
   constructor() {
-    super(new MockStorageKey(), Exists.ShouldCreate, null, StorageMode.Direct, CRDTSingleton);
+    super(new MockStorageKey(), Exists.ShouldCreate, new CountType(), StorageMode.Direct);
   }
   on(callback: ProxyCallback<T>): number {
     return 1;

--- a/src/runtime/storageNG/tests/firebase-store-integration-test.ts
+++ b/src/runtime/storageNG/tests/firebase-store-integration-test.ts
@@ -14,6 +14,7 @@ import {CRDTCountTypeRecord, CRDTCount, CountOpTypes} from '../../crdt/crdt-coun
 import {Exists, DriverFactory} from '../drivers/driver-factory.js';
 import {Runtime} from '../../runtime.js';
 import {MockFirebaseStorageDriverProvider, MockFirebaseStorageKey} from '../testing/mock-firebase.js';
+import {CountType} from '../../type.js';
 
 describe('Firebase + Store Integration', async () => {
 
@@ -29,7 +30,7 @@ describe('Firebase + Store Integration', async () => {
   it('will store a sequence of model and operation updates as models', async () => {
     const runtime = new Runtime();
     const storageKey = new MockFirebaseStorageKey('location');
-    const store = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldCreate, null, StorageMode.Direct, CRDTCount);
+    const store = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldCreate, new CountType(), StorageMode.Direct);
     const activeStore = await store.activate();
 
     const count = new CRDTCount();
@@ -52,10 +53,10 @@ describe('Firebase + Store Integration', async () => {
   it('will store operation updates from multiple sources', async () => {
     const runtime = new Runtime();
     const storageKey = new MockFirebaseStorageKey('unique');
-    const store1 = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldCreate, null, StorageMode.Direct, CRDTCount);
+    const store1 = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldCreate, new CountType(), StorageMode.Direct);
     const activeStore1 = await store1.activate();
 
-    const store2 = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldExist, null, StorageMode.Direct, CRDTCount);
+    const store2 = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldExist, new CountType(), StorageMode.Direct);
     const activeStore2 = await store2.activate();
 
     const count1 = new CRDTCount();
@@ -92,10 +93,10 @@ describe('Firebase + Store Integration', async () => {
   it('will store operation updates from multiple sources with some delays', async () => {
     const runtime = new Runtime();
     const storageKey = new MockFirebaseStorageKey('unique');
-    const store1 = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldCreate, null, StorageMode.Direct, CRDTCount);
+    const store1 = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldCreate, new CountType(), StorageMode.Direct);
     const activeStore1 = await store1.activate();
 
-    const store2 = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldExist, null, StorageMode.Direct, CRDTCount);
+    const store2 = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldExist, new CountType(), StorageMode.Direct);
     const activeStore2 = await store2.activate();
 
     void activeStore1.onProxyMessage({type: ProxyMessageType.Operations, id: 1, operations: [
@@ -134,10 +135,10 @@ describe('Firebase + Store Integration', async () => {
   it(`doesn't deadlock given a particular timing pattern`, async () => {
     const runtime = new Runtime();
     const storageKey = new MockFirebaseStorageKey('unique');
-    const store1 = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldCreate, null, StorageMode.Direct, CRDTCount);
+    const store1 = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldCreate, new CountType(), StorageMode.Direct);
     const activeStore1 = await store1.activate();
 
-    const store2 = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldExist, null, StorageMode.Direct, CRDTCount);
+    const store2 = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldExist, new CountType(), StorageMode.Direct);
     const activeStore2 = await store2.activate();
 
     void activeStore1.onProxyMessage({type: ProxyMessageType.Operations, id: 1, operations: [

--- a/src/runtime/storageNG/tests/firebase-store-integration-test.ts
+++ b/src/runtime/storageNG/tests/firebase-store-integration-test.ts
@@ -30,7 +30,7 @@ describe('Firebase + Store Integration', async () => {
   it('will store a sequence of model and operation updates as models', async () => {
     const runtime = new Runtime();
     const storageKey = new MockFirebaseStorageKey('location');
-    const store = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldCreate, new CountType(), StorageMode.Direct);
+    const store = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldCreate, new CountType(), 'an-id');
     const activeStore = await store.activate();
 
     const count = new CRDTCount();
@@ -53,10 +53,10 @@ describe('Firebase + Store Integration', async () => {
   it('will store operation updates from multiple sources', async () => {
     const runtime = new Runtime();
     const storageKey = new MockFirebaseStorageKey('unique');
-    const store1 = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldCreate, new CountType(), StorageMode.Direct);
+    const store1 = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldCreate, new CountType(), 'an-id');
     const activeStore1 = await store1.activate();
 
-    const store2 = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldExist, new CountType(), StorageMode.Direct);
+    const store2 = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldExist, new CountType(), 'an-id');
     const activeStore2 = await store2.activate();
 
     const count1 = new CRDTCount();
@@ -93,10 +93,10 @@ describe('Firebase + Store Integration', async () => {
   it('will store operation updates from multiple sources with some delays', async () => {
     const runtime = new Runtime();
     const storageKey = new MockFirebaseStorageKey('unique');
-    const store1 = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldCreate, new CountType(), StorageMode.Direct);
+    const store1 = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldCreate, new CountType(), 'an-id');
     const activeStore1 = await store1.activate();
 
-    const store2 = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldExist, new CountType(), StorageMode.Direct);
+    const store2 = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldExist, new CountType(), 'an-id');
     const activeStore2 = await store2.activate();
 
     void activeStore1.onProxyMessage({type: ProxyMessageType.Operations, id: 1, operations: [
@@ -135,10 +135,10 @@ describe('Firebase + Store Integration', async () => {
   it(`doesn't deadlock given a particular timing pattern`, async () => {
     const runtime = new Runtime();
     const storageKey = new MockFirebaseStorageKey('unique');
-    const store1 = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldCreate, new CountType(), StorageMode.Direct);
+    const store1 = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldCreate, new CountType(), 'an-id');
     const activeStore1 = await store1.activate();
 
-    const store2 = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldExist, new CountType(), StorageMode.Direct);
+    const store2 = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldExist, new CountType(), 'an-id');
     const activeStore2 = await store2.activate();
 
     void activeStore1.onProxyMessage({type: ProxyMessageType.Operations, id: 1, operations: [

--- a/src/runtime/storageNG/tests/ramdisk-backing-store-integration-test.ts
+++ b/src/runtime/storageNG/tests/ramdisk-backing-store-integration-test.ts
@@ -15,6 +15,7 @@ import {RamDiskStorageKey, RamDiskStorageDriverProvider} from '../drivers/ramdis
 import {Exists, DriverFactory} from '../drivers/driver-factory.js';
 import {Runtime} from '../../runtime.js';
 import {BackingStore} from '../backing-store.js';
+import {CountType} from '../../type.js';
 
 function assertHasModel(message: ProxyMessage<CRDTCountTypeRecord>, model: CRDTCount) {
   if (message.type === ProxyMessageType.ModelUpdate) {
@@ -37,7 +38,7 @@ describe('RamDisk + Backing Store Integration', async () => {
   it('will allow storage of a number of objects', async () => {
     const runtime = new Runtime();
     const storageKey = new RamDiskStorageKey('unique');
-    const store = await BackingStore.construct<CRDTCountTypeRecord>(storageKey, Exists.ShouldCreate, null, StorageMode.Backing, CRDTCount);
+    const store = await BackingStore.construct<CRDTCountTypeRecord>(storageKey, Exists.ShouldCreate, new CountType(), StorageMode.Backing);
 
     const count1 = new CRDTCount();
     count1.applyOperation({type: CountOpTypes.Increment, actor: 'me', version: {from: 0, to: 1}});

--- a/src/runtime/storageNG/tests/ramdisk-store-integration-test.ts
+++ b/src/runtime/storageNG/tests/ramdisk-store-integration-test.ts
@@ -14,6 +14,7 @@ import {CRDTCountTypeRecord, CRDTCount, CountOpTypes} from '../../crdt/crdt-coun
 import {RamDiskStorageKey, RamDiskStorageDriverProvider} from '../drivers/ramdisk';
 import {Exists, DriverFactory} from '../drivers/driver-factory.js';
 import {Runtime} from '../../runtime.js';
+import {CountType} from '../../type.js';
 
 describe('RamDisk + Store Integration', async () => {
 
@@ -28,7 +29,7 @@ describe('RamDisk + Store Integration', async () => {
   it('will store a sequence of model and operation updates as models', async () => {
     const runtime = new Runtime();
     const storageKey = new RamDiskStorageKey('unique');
-    const store = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldCreate, null, StorageMode.Direct, CRDTCount);
+    const store = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldCreate, new CountType(), StorageMode.Direct);
     const activeStore = await store.activate();
 
     const count = new CRDTCount();
@@ -50,10 +51,10 @@ describe('RamDisk + Store Integration', async () => {
   it('will store operation updates from multiple sources', async () => {
     const runtime = new Runtime();
     const storageKey = new RamDiskStorageKey('unique');
-    const store1 = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldCreate, null, StorageMode.Direct, CRDTCount);
+    const store1 = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldCreate, new CountType(), StorageMode.Direct);
     const activeStore1 = await store1.activate();
 
-    const store2 = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldExist, null, StorageMode.Direct, CRDTCount);
+    const store2 = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldExist, new CountType(), StorageMode.Direct);
     const activeStore2 = await store2.activate();
 
     const count1 = new CRDTCount();
@@ -91,10 +92,10 @@ describe('RamDisk + Store Integration', async () => {
     // store1.onProxyMessage, DELAY, DELAY, DELAY, store1.onProxyMessage, store2.onProxyMessage, DELAY, DELAY, DELAY, store2.onProxyMessage, DELAY, DELAY, DELAY, DELAY, DELAY
     const runtime = new Runtime();
     const storageKey = new RamDiskStorageKey('unique');
-    const store1 = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldCreate, null, StorageMode.Direct, CRDTCount);
+    const store1 = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldCreate, new CountType(), StorageMode.Direct);
     const activeStore1 = await store1.activate();
 
-    const store2 = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldExist, null, StorageMode.Direct, CRDTCount);
+    const store2 = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldExist, new CountType(), StorageMode.Direct);
     const activeStore2 = await store2.activate();
 
     const opReply1 = activeStore1.onProxyMessage({type: ProxyMessageType.Operations, operations: [

--- a/src/runtime/storageNG/tests/ramdisk-store-integration-test.ts
+++ b/src/runtime/storageNG/tests/ramdisk-store-integration-test.ts
@@ -29,7 +29,7 @@ describe('RamDisk + Store Integration', async () => {
   it('will store a sequence of model and operation updates as models', async () => {
     const runtime = new Runtime();
     const storageKey = new RamDiskStorageKey('unique');
-    const store = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldCreate, new CountType(), StorageMode.Direct);
+    const store = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldCreate, new CountType(), 'an-id');
     const activeStore = await store.activate();
 
     const count = new CRDTCount();
@@ -51,10 +51,10 @@ describe('RamDisk + Store Integration', async () => {
   it('will store operation updates from multiple sources', async () => {
     const runtime = new Runtime();
     const storageKey = new RamDiskStorageKey('unique');
-    const store1 = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldCreate, new CountType(), StorageMode.Direct);
+    const store1 = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldCreate, new CountType(), 'an-id');
     const activeStore1 = await store1.activate();
 
-    const store2 = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldExist, new CountType(), StorageMode.Direct);
+    const store2 = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldExist, new CountType(), 'an-id');
     const activeStore2 = await store2.activate();
 
     const count1 = new CRDTCount();
@@ -92,10 +92,10 @@ describe('RamDisk + Store Integration', async () => {
     // store1.onProxyMessage, DELAY, DELAY, DELAY, store1.onProxyMessage, store2.onProxyMessage, DELAY, DELAY, DELAY, store2.onProxyMessage, DELAY, DELAY, DELAY, DELAY, DELAY
     const runtime = new Runtime();
     const storageKey = new RamDiskStorageKey('unique');
-    const store1 = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldCreate, new CountType(), StorageMode.Direct);
+    const store1 = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldCreate, new CountType(), 'an-id');
     const activeStore1 = await store1.activate();
 
-    const store2 = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldExist, new CountType(), StorageMode.Direct);
+    const store2 = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldExist, new CountType(), 'an-id');
     const activeStore2 = await store2.activate();
 
     const opReply1 = activeStore1.onProxyMessage({type: ProxyMessageType.Operations, operations: [

--- a/src/runtime/storageNG/tests/reference-mode-store-test.ts
+++ b/src/runtime/storageNG/tests/reference-mode-store-test.ts
@@ -11,18 +11,18 @@
 import {assert} from '../../../platform/chai-web.js';
 import {Store, StorageMode, ProxyMessageType} from '../store.js';
 import {Exists, DriverFactory} from '../drivers/driver-factory.js';
-import {CRDTCount, CountOpTypes, CountData, CountOperation} from '../../crdt/crdt-count.js';
-import {StorageKey} from '../storage-key.js';
 import {DirectStore} from '../direct-store.js';
-import {MockStorageKey, MockStorageDriverProvider, MockDriver, MockHierarchicalStorageKey} from '../testing/test-storage.js';
-import {ReferenceModeStore, ReferenceCollection, Reference} from '../reference-mode-store.js';
+import {MockStorageDriverProvider, MockDriver, MockHierarchicalStorageKey} from '../testing/test-storage.js';
+import {ReferenceModeStore, ReferenceCollection, Reference, ReferenceModeStorageKey} from '../reference-mode-store.js';
 import {CRDTEntity, EntityOpTypes, CRDTEntityTypeRecord} from '../../crdt/crdt-entity.js';
 import {CRDTCollection, CollectionOpTypes, CollectionData, CollectionOperation} from '../../crdt/crdt-collection.js';
 import {CRDTSingleton} from '../../crdt/crdt-singleton.js';
+import {CountType, CollectionType, EntityType} from '../../type.js';
+import {Schema} from '../../schema.js';
 
 /* eslint-disable no-async-promise-executor */
 
-let testKey: StorageKey;
+let testKey: ReferenceModeStorageKey;
 
 class MyEntityModel extends CRDTEntity<{name: {id: string}, age: {id: string, value: number}}, {}> {
   constructor() {
@@ -38,10 +38,13 @@ class MyEntity {
 
 class MyEntityCollection extends CRDTCollection<MyEntity> {}
 
-describe('Reference Mode Store', async () => {
+const schema = new Schema(['Thing'], {name: 'Text', age: 'Number'});
+const collectionType = new CollectionType(new EntityType(schema));
+
+describe.only('Reference Mode Store', async () => {
 
   beforeEach(() => {
-    testKey = new MockHierarchicalStorageKey();
+    testKey = new ReferenceModeStorageKey(new MockHierarchicalStorageKey(), new MockHierarchicalStorageKey());
     DriverFactory.clearRegistrationsForTesting();
   });
 
@@ -49,8 +52,8 @@ describe('Reference Mode Store', async () => {
     DriverFactory.clearRegistrationsForTesting();
   });
 
-  it.skip(`will throw an exception if an appropriate driver can't be found`, async () => {
-    const store = new Store(testKey, Exists.ShouldCreate, null, StorageMode.Direct, CRDTCount);
+  it(`will throw an exception if an appropriate driver can't be found`, async () => {
+    const store = new Store(testKey, Exists.ShouldCreate, new CountType(), 'an-id');
     try {
       await store.activate();
       assert.fail('store.activate() should not have succeeded');
@@ -59,22 +62,19 @@ describe('Reference Mode Store', async () => {
     }
   });
 
-  it.skip('will construct Direct stores when required', async () => {
+  it('will construct ReferenceMode stores when required', async () => {
     DriverFactory.register(new MockStorageDriverProvider());
 
-    const store = new Store(testKey, Exists.ShouldCreate, null, StorageMode.Direct, CRDTCount);
+    const store = new Store(testKey, Exists.ShouldCreate, new CountType(), 'an-id');
     const activeStore = await store.activate();
 
-    assert.equal(activeStore.constructor, DirectStore);
+    assert.equal(activeStore.constructor, ReferenceModeStore);
   });
 
   it('will propagate model updates from proxies to drivers', async () => {
     DriverFactory.register(new MockStorageDriverProvider());
 
-    const activeStore = await ReferenceModeStore.construct(testKey, testKey, Exists.ShouldCreate, null, 
-      MyEntityModel, 
-      ReferenceCollection,
-      MyEntityCollection);
+    const activeStore = await ReferenceModeStore.construct(testKey, Exists.ShouldCreate, collectionType);
 
     const driver = activeStore.containerStore['driver'] as MockDriver<CollectionData<Reference>>;    
     let capturedModel: CollectionData<Reference> = null;
@@ -107,10 +107,7 @@ describe('Reference Mode Store', async () => {
   it('will apply and propagate operation updates from proxies to drivers', async () => {
     DriverFactory.register(new MockStorageDriverProvider());
 
-    const activeStore = await ReferenceModeStore.construct(testKey, testKey, Exists.ShouldCreate, null, 
-      MyEntityModel, 
-      ReferenceCollection,
-      MyEntityCollection);
+    const activeStore = await ReferenceModeStore.construct(testKey, Exists.ShouldCreate, collectionType);
 
     const driver = activeStore.containerStore['driver'] as MockDriver<CollectionData<Reference>>;    
     let capturedModel: CollectionData<Reference> = null;
@@ -145,10 +142,7 @@ describe('Reference Mode Store', async () => {
   it('will respond to a model request from a proxy with a model', async () => {
     DriverFactory.register(new MockStorageDriverProvider());
 
-    const activeStore = await ReferenceModeStore.construct(testKey, testKey, Exists.ShouldCreate, null, 
-      MyEntityModel, 
-      ReferenceCollection,
-      MyEntityCollection);
+    const activeStore = await ReferenceModeStore.construct(testKey, Exists.ShouldCreate, collectionType);
 
     const driver = activeStore.containerStore['driver'] as MockDriver<CollectionData<Reference>>;    
     driver.send = async model => true;
@@ -188,10 +182,7 @@ describe('Reference Mode Store', async () => {
   it('will only send a model response to the requesting proxy', async () => {
     DriverFactory.register(new MockStorageDriverProvider());
 
-    const activeStore = await ReferenceModeStore.construct(testKey, testKey, Exists.ShouldCreate, null, 
-      MyEntityModel, 
-      ReferenceCollection,
-      MyEntityCollection);
+    const activeStore = await ReferenceModeStore.construct(testKey, Exists.ShouldCreate, collectionType);
     
     return new Promise(async (resolve, reject) => {
       // requesting store
@@ -213,10 +204,7 @@ describe('Reference Mode Store', async () => {
   it('will propagate updates from drivers to proxies', async () => {
     DriverFactory.register(new MockStorageDriverProvider());
 
-    const activeStore = await ReferenceModeStore.construct(testKey, testKey, Exists.ShouldCreate, null, 
-      MyEntityModel, 
-      ReferenceCollection,
-      MyEntityCollection);
+    const activeStore = await ReferenceModeStore.construct(testKey, Exists.ShouldCreate, collectionType);
 
     const collection = new MyEntityCollection();
     const entity = new MyEntity();
@@ -256,10 +244,7 @@ describe('Reference Mode Store', async () => {
   it.skip(`won't send an update to the driver after driver-originated messages`, async () => {
     DriverFactory.register(new MockStorageDriverProvider());
 
-    const activeStore = await ReferenceModeStore.construct(testKey, testKey, Exists.ShouldCreate, null, 
-      MyEntityModel, 
-      ReferenceCollection,
-      MyEntityCollection);
+    const activeStore = await ReferenceModeStore.construct(testKey, Exists.ShouldCreate, collectionType);
 
     const referenceCollection = new ReferenceCollection();
     const reference: Reference = {storageKey: new MockHierarchicalStorageKey(''), id: 'an-id', version: {me: 1}};
@@ -276,10 +261,7 @@ describe('Reference Mode Store', async () => {
   it('will resend failed driver updates after merging', async () => {
     DriverFactory.register(new MockStorageDriverProvider());
 
-    const activeStore = await ReferenceModeStore.construct(testKey, testKey, Exists.ShouldCreate, null, 
-      MyEntityModel, 
-      ReferenceCollection,
-      MyEntityCollection);
+    const activeStore = await ReferenceModeStore.construct(testKey, Exists.ShouldCreate, collectionType);
 
     // local model from proxy
     const collection = new MyEntityCollection();
@@ -321,10 +303,7 @@ describe('Reference Mode Store', async () => {
   it('resolves a combination of messages from the proxy and the driver', async () => {
     DriverFactory.register(new MockStorageDriverProvider());
 
-    const activeStore = await ReferenceModeStore.construct(testKey, testKey, Exists.ShouldCreate, null, 
-      MyEntityModel, 
-      ReferenceCollection,
-      MyEntityCollection);
+    const activeStore = await ReferenceModeStore.construct(testKey, Exists.ShouldCreate, collectionType);
 
     const driver = activeStore.containerStore['driver'] as MockDriver<CollectionData<Reference>>;
     let lastModel = null;
@@ -362,10 +341,7 @@ describe('Reference Mode Store', async () => {
   it('holds onto a container update until the relevant backing data arrives', async () => {
     DriverFactory.register(new MockStorageDriverProvider());
 
-    const activeStore = await ReferenceModeStore.construct(testKey, testKey, Exists.ShouldCreate, null, 
-      MyEntityModel, 
-      ReferenceCollection,
-      MyEntityCollection);
+    const activeStore = await ReferenceModeStore.construct(testKey, Exists.ShouldCreate, collectionType);
 
     const actor = activeStore['crdtKey'];
     

--- a/src/runtime/storageNG/tests/reference-mode-store-test.ts
+++ b/src/runtime/storageNG/tests/reference-mode-store-test.ts
@@ -41,7 +41,7 @@ class MyEntityCollection extends CRDTCollection<MyEntity> {}
 const schema = new Schema(['Thing'], {name: 'Text', age: 'Number'});
 const collectionType = new CollectionType(new EntityType(schema));
 
-describe.only('Reference Mode Store', async () => {
+describe('Reference Mode Store', async () => {
 
   beforeEach(() => {
     testKey = new ReferenceModeStorageKey(new MockHierarchicalStorageKey(), new MockHierarchicalStorageKey());

--- a/src/runtime/storageNG/tests/store-sequence-test.ts
+++ b/src/runtime/storageNG/tests/store-sequence-test.ts
@@ -21,6 +21,7 @@ import {MockFirebaseStorageDriverProvider} from '../testing/mock-firebase.js';
 import {FirebaseStorageKey} from '../drivers/firebase.js';
 import {MockStorageKey, MockStorageDriverProvider} from '../testing/test-storage.js';
 import {Arc} from '../../arc.js';
+import {CountType} from '../../type.js';
 
 let testKey: StorageKey;
 
@@ -56,7 +57,7 @@ describe('Store Sequence', async () => {
       DriverFactory.clearRegistrationsForTesting();
       DriverFactory.register(new MockStorageDriverProvider());
 
-      const store = new Store(testKey, Exists.ShouldCreate, null, StorageMode.Direct, CRDTCount);
+      const store = new Store<CRDTCountTypeRecord>(testKey, Exists.ShouldCreate, new CountType(), StorageMode.Direct);
       const activeStore = store.activate();
       return activeStore;
     });
@@ -123,7 +124,7 @@ describe('Store Sequence', async () => {
       DriverFactory.clearRegistrationsForTesting();
       DriverFactory.register(new MockStorageDriverProvider());
 
-      const store = new Store(testKey, Exists.ShouldCreate, null, StorageMode.Direct, CRDTCount);
+      const store = new Store<CRDTCountTypeRecord>(testKey, Exists.ShouldCreate, new CountType(), StorageMode.Direct);
       const activeStore = store.activate();
       return activeStore;
     });
@@ -176,10 +177,10 @@ describe('Store Sequence', async () => {
       DriverFactory.clearRegistrationsForTesting();
       VolatileStorageDriverProvider.register(arc);
       const storageKey = new VolatileStorageKey(arc.id, 'unique');
-      const store1 = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldCreate, null, StorageMode.Direct, CRDTCount);
+      const store1 = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldCreate, new CountType(), StorageMode.Direct);
       const activeStore1 = await store1.activate();
   
-      const store2 = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldExist, null, StorageMode.Direct, CRDTCount);
+      const store2 = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldExist, new CountType(), StorageMode.Direct);
       const activeStore2 = await store2.activate();
       return {store1: activeStore1, store2: activeStore2};
     });
@@ -229,10 +230,10 @@ describe('Store Sequence', async () => {
       DriverFactory.clearRegistrationsForTesting();
       MockFirebaseStorageDriverProvider.register();
       const storageKey = new FirebaseStorageKey('test', 'test.domain', 'testKey', 'foo');
-      const store1 = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldCreate, null, StorageMode.Direct, CRDTCount);
+      const store1 = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldCreate, new CountType(), StorageMode.Direct);
       const activeStore1 = await store1.activate();
   
-      const store2 = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldExist, null, StorageMode.Direct, CRDTCount);
+      const store2 = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldExist, new CountType(), StorageMode.Direct);
       const activeStore2 = await store2.activate();
       sequenceTest.setVariable(store1V, activeStore1);
       sequenceTest.setVariable(store2V, activeStore2);
@@ -281,10 +282,10 @@ describe('Store Sequence', async () => {
       DriverFactory.clearRegistrationsForTesting();
       VolatileStorageDriverProvider.register(arc);
       const storageKey = new VolatileStorageKey(arc.id, 'unique');
-      const store1 = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldCreate, null, StorageMode.Direct, CRDTCount);
+      const store1 = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldCreate, new CountType(), StorageMode.Direct);
       const activeStore1 = await store1.activate();
   
-      const store2 = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldExist, null, StorageMode.Direct, CRDTCount);
+      const store2 = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldExist, new CountType(), StorageMode.Direct);
       const activeStore2 = await store2.activate();
       return {store1: activeStore1, store2: activeStore2};
     });

--- a/src/runtime/storageNG/tests/store-sequence-test.ts
+++ b/src/runtime/storageNG/tests/store-sequence-test.ts
@@ -57,7 +57,7 @@ describe('Store Sequence', async () => {
       DriverFactory.clearRegistrationsForTesting();
       DriverFactory.register(new MockStorageDriverProvider());
 
-      const store = new Store<CRDTCountTypeRecord>(testKey, Exists.ShouldCreate, new CountType(), StorageMode.Direct);
+      const store = new Store<CRDTCountTypeRecord>(testKey, Exists.ShouldCreate, new CountType(), 'an-id');
       const activeStore = store.activate();
       return activeStore;
     });
@@ -124,7 +124,7 @@ describe('Store Sequence', async () => {
       DriverFactory.clearRegistrationsForTesting();
       DriverFactory.register(new MockStorageDriverProvider());
 
-      const store = new Store<CRDTCountTypeRecord>(testKey, Exists.ShouldCreate, new CountType(), StorageMode.Direct);
+      const store = new Store<CRDTCountTypeRecord>(testKey, Exists.ShouldCreate, new CountType(), 'an-id');
       const activeStore = store.activate();
       return activeStore;
     });
@@ -172,15 +172,15 @@ describe('Store Sequence', async () => {
   it('applies operations to two stores connected by a volatile driver', async () => {
     const sequenceTest = new SequenceTest<{store1: ActiveStore<CRDTCountTypeRecord>, store2: ActiveStore<CRDTCountTypeRecord>}>();
     sequenceTest.setTestConstructor(async () => {
-      const runtime = new Runtime();
+      const runtime = Runtime.newForNodeTesting();
       const arc = runtime.newArc('arc', 'volatile://');
       DriverFactory.clearRegistrationsForTesting();
       VolatileStorageDriverProvider.register(arc);
       const storageKey = new VolatileStorageKey(arc.id, 'unique');
-      const store1 = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldCreate, new CountType(), StorageMode.Direct);
+      const store1 = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldCreate, new CountType(), 'an-id');
       const activeStore1 = await store1.activate();
   
-      const store2 = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldExist, new CountType(), StorageMode.Direct);
+      const store2 = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldExist, new CountType(), 'an-id');
       const activeStore2 = await store2.activate();
       return {store1: activeStore1, store2: activeStore2};
     });
@@ -230,10 +230,10 @@ describe('Store Sequence', async () => {
       DriverFactory.clearRegistrationsForTesting();
       MockFirebaseStorageDriverProvider.register();
       const storageKey = new FirebaseStorageKey('test', 'test.domain', 'testKey', 'foo');
-      const store1 = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldCreate, new CountType(), StorageMode.Direct);
+      const store1 = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldCreate, new CountType(), 'an-id');
       const activeStore1 = await store1.activate();
   
-      const store2 = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldExist, new CountType(), StorageMode.Direct);
+      const store2 = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldExist, new CountType(), 'an-id');
       const activeStore2 = await store2.activate();
       sequenceTest.setVariable(store1V, activeStore1);
       sequenceTest.setVariable(store2V, activeStore2);
@@ -277,15 +277,15 @@ describe('Store Sequence', async () => {
   it('applies model against operations to two stores connected by a volatile driver', async () => {
     const sequenceTest = new SequenceTest();
     sequenceTest.setTestConstructor(async () => {
-      const runtime = new Runtime();
+      const runtime = Runtime.newForNodeTesting();
       const arc = runtime.newArc('arc', 'volatile://');
       DriverFactory.clearRegistrationsForTesting();
       VolatileStorageDriverProvider.register(arc);
       const storageKey = new VolatileStorageKey(arc.id, 'unique');
-      const store1 = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldCreate, new CountType(), StorageMode.Direct);
+      const store1 = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldCreate, new CountType(), 'an-id');
       const activeStore1 = await store1.activate();
   
-      const store2 = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldExist, new CountType(), StorageMode.Direct);
+      const store2 = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldExist, new CountType(), 'an-id');
       const activeStore2 = await store2.activate();
       return {store1: activeStore1, store2: activeStore2};
     });

--- a/src/runtime/storageNG/tests/store-test.ts
+++ b/src/runtime/storageNG/tests/store-test.ts
@@ -15,6 +15,7 @@ import {CRDTCount, CountOpTypes, CountData, CountOperation} from '../../crdt/crd
 import {StorageKey} from '../storage-key.js';
 import {DirectStore} from '../direct-store.js';
 import {MockStorageKey, MockStorageDriverProvider, MockDriver} from '../testing/test-storage.js';
+import {CountType} from '../../type.js';
 
 let testKey: StorageKey;
 
@@ -30,7 +31,7 @@ describe('Store', async () => {
   });
 
   it(`will throw an exception if an appropriate driver can't be found`, async () => {
-    const store = new Store(testKey, Exists.ShouldCreate, null, StorageMode.Direct, CRDTCount);
+    const store = new Store(testKey, Exists.ShouldCreate, new CountType(), 'an-id');
     try {
       await store.activate();
       assert.fail('store.activate() should not have succeeded');
@@ -42,7 +43,7 @@ describe('Store', async () => {
   it('will construct Direct stores when required', async () => {
     DriverFactory.register(new MockStorageDriverProvider());
 
-    const store = new Store(testKey, Exists.ShouldCreate, null, StorageMode.Direct, CRDTCount);
+    const store = new Store(testKey, Exists.ShouldCreate, new CountType(), 'an-id');
     const activeStore = await store.activate();
 
     assert.strictEqual(activeStore.constructor, DirectStore);
@@ -51,7 +52,7 @@ describe('Store', async () => {
   it('will propagate model updates from proxies to drivers', async () => {
     DriverFactory.register(new MockStorageDriverProvider());
 
-    const store = new Store(testKey, Exists.ShouldCreate, null, StorageMode.Direct, CRDTCount);
+    const store = new Store(testKey, Exists.ShouldCreate, new CountType(), 'an-id');
     const activeStore = await store.activate();
 
     const driver = activeStore['driver'] as MockDriver<CountData>;    
@@ -70,7 +71,7 @@ describe('Store', async () => {
   it('will apply and propagate operation updates from proxies to drivers', async () => {
     DriverFactory.register(new MockStorageDriverProvider());
 
-    const store = new Store(testKey, Exists.ShouldCreate, null, StorageMode.Direct, CRDTCount);
+    const store = new Store(testKey, Exists.ShouldCreate, new CountType(), 'an-id');
     const activeStore = await store.activate();
 
     const driver = activeStore['driver'] as MockDriver<CountData>;
@@ -91,7 +92,7 @@ describe('Store', async () => {
   it('will respond to a model request from a proxy with a model', async () => {
     DriverFactory.register(new MockStorageDriverProvider());
 
-    const store = new Store(testKey, Exists.ShouldCreate, null, StorageMode.Direct, CRDTCount);
+    const store = new Store(testKey, Exists.ShouldCreate, new CountType(), 'an-id');
     const activeStore = await store.activate();
 
     const driver = activeStore['driver'] as MockDriver<CountData>;
@@ -127,7 +128,7 @@ describe('Store', async () => {
   it('will only send a model response to the requesting proxy', async () => {
     DriverFactory.register(new MockStorageDriverProvider());
 
-    const store = new Store(testKey, Exists.ShouldCreate, null, StorageMode.Direct, CRDTCount);
+    const store = new Store(testKey, Exists.ShouldCreate, new CountType(), 'an-id');
     const activeStore = await store.activate();
     
     return new Promise((resolve, reject) => {
@@ -150,7 +151,7 @@ describe('Store', async () => {
   it('will propagate updates from drivers to proxies', async () => {
     DriverFactory.register(new MockStorageDriverProvider());
 
-    const store = new Store(testKey, Exists.ShouldCreate, null, StorageMode.Direct, CRDTCount);
+    const store = new Store(testKey, Exists.ShouldCreate, new CountType(), 'an-id');
     const activeStore = await store.activate();
 
     const count = new CRDTCount();
@@ -177,7 +178,7 @@ describe('Store', async () => {
   it(`won't send an update to the driver after driver-originated messages`, async () => {
     DriverFactory.register(new MockStorageDriverProvider());
 
-    const store = new Store(testKey, Exists.ShouldCreate, null, StorageMode.Direct, CRDTCount);
+    const store = new Store(testKey, Exists.ShouldCreate, new CountType(), 'an-id');
     const activeStore = await store.activate();
 
     const remoteCount = new CRDTCount();
@@ -194,7 +195,7 @@ describe('Store', async () => {
   it('will resend failed driver updates after merging', async () => {
     DriverFactory.register(new MockStorageDriverProvider());
 
-    const store = new Store(testKey, Exists.ShouldCreate, null, StorageMode.Direct, CRDTCount);
+    const store = new Store(testKey, Exists.ShouldCreate, new CountType(), 'an-id');
     const activeStore = await store.activate();
 
     // local count from proxy
@@ -227,7 +228,7 @@ describe('Store', async () => {
   
   it('resolves a combination of messages from the proxy and the driver', async () => {
     DriverFactory.register(new MockStorageDriverProvider());
-    const store = new Store(testKey, Exists.ShouldCreate, null, StorageMode.Direct, CRDTCount);
+    const store = new Store(testKey, Exists.ShouldCreate, new CountType(), 'an-id');
     const activeStore = await store.activate();
     const driver = activeStore['driver'] as MockDriver<CountData>;
     let lastModel = null;

--- a/src/runtime/type.ts
+++ b/src/runtime/type.ts
@@ -10,7 +10,6 @@
   
 import {Id} from './id.js';
 import {InterfaceInfo, HandleConnection, Slot} from './interface-info.js';
-import {TypeChecker} from './recipe/type-checker.js';
 import {Schema} from './schema.js';
 import {SlotInfo} from './slot-info.js';
 import {ArcInfo} from './synthetic-types.js';
@@ -18,7 +17,6 @@ import {TypeVariableInfo} from './type-variable-info.js';
 import {Predicate, Literal} from './hot.js';
 import {CRDTTypeRecord, CRDTModel} from './crdt/crdt.js';
 import {CRDTCount} from './crdt/crdt-count.js';
-import {ReferenceCollection} from './storageNG/reference-mode-store.js';
 import {CRDTCollection} from './crdt/crdt-collection.js';
 
 
@@ -532,10 +530,6 @@ export class CollectionType<T extends Type> extends Type {
   }
 
   crdtInstanceConstructor() {
-    if (this.getContainedType().isReference) {
-      return ReferenceCollection;
-    }
-    
     return CRDTCollection;
   }
 }


### PR DESCRIPTION
* Move constructors for CRDTs into the type objects rather than passing them in as parameters of Stores
* Use type logic to determine the appropriate constructors inside ReferenceModeStore
* Add a ReferenceModeStorageKey so we don't need to pass multiple storage keys into ReferenceModeStores.
* Remove the requirement that a Mode argument be explicitly provided to Store constructor.