### PR TITLE
Update log prefix for clock-service to `clock-service`.

### DIFF
--- a/src/services/clock-service.ts
+++ b/src/services/clock-service.ts
@@ -35,7 +35,7 @@ type ClockServiceNowOptions = {
   timeUnit: string;
 };
 
-const log = logFactory('tfjs-service');
+const log = logFactory('clock-service');
 
 Services.register('clock', {
   now: ({timeUnit}: ClockServiceNowOptions) => {


### PR DESCRIPTION
### Background
Previously we had a wrong log prefix `tfjs-service` for clock-service, which should actually be `clock-service`. 