### PR TITLE
add modality to ui-slot-composer rendering content packet

### DIFF
--- a/src/javaharness/java/arcs/android/demo/ui/AndroidManifest.xml
+++ b/src/javaharness/java/arcs/android/demo/ui/AndroidManifest.xml
@@ -13,7 +13,7 @@
     <activity
       android:name=".MainActivity"
       android:label="ArcsHarnessApp"
-      android:exported="false">
+      android:exported="true">
       <intent-filter>
         <action android:name="android.intent.action.MAIN"/>
         <category android:name="android.intent.category.LAUNCHER"/>

--- a/src/runtime/ui-slot-composer.ts
+++ b/src/runtime/ui-slot-composer.ts
@@ -262,7 +262,13 @@ export class UiSlotComposer {
       if (container) {
         Object.assign(content, {
           containerSlotName: container.targetSlot.name,
-          containerSlotId: container.targetSlot.id
+          containerSlotId: container.targetSlot.id,
+        });
+      }
+      const modality = particle.recipe.modality;
+      if (!modality.all) {
+        Object.assign(content, {
+          modality: modality.names.join(',')
         });
       }
       Object.assign(content, {

--- a/src/runtime/ui-slot-composer.ts
+++ b/src/runtime/ui-slot-composer.ts
@@ -265,11 +265,14 @@ export class UiSlotComposer {
           containerSlotId: container.targetSlot.id,
         });
       }
-      const modality = particle.recipe.modality;
-      if (!modality.all) {
-        Object.assign(content, {
-          modality: modality.names.join(',')
-        });
+      if (!content.modality) {
+        // Set modality according to particle spec, unless already set by the particle.
+        const modality = particle.recipe.modality;
+        if (!modality.all) {
+          Object.assign(content, {
+            modality: modality.names.join(',')
+          });
+        }
       }
       Object.assign(content, {
         particle,


### PR DESCRIPTION
- some of the existing particles include the modality in their rendering content
- in the current android demo we just default to rendering in all available renderers, if no modality is specified.

but it should be slot-composer's job to add modality to the rendering content imo.

FYI @yuangu-google 