### PR TITLE
java library refactoring and cleanup (1st pr of some)

### DIFF
--- a/shells/pipes-shell/source/pipe.js
+++ b/shells/pipes-shell/source/pipe.js
@@ -18,7 +18,7 @@ import {requireIngestionArc} from './ingestion-arc.js';
 import {dispatcher} from './dispatcher.js';
 import {Bus} from './bus.js';
 import {pec} from './verbs/pec.js';
-import {runArc} from './verbs/run-arc.js';
+import {runArc, stopArc} from './verbs/run-arc.js';
 import {event} from './verbs/event.js';
 import {spawn} from './verbs/spawn.js';
 import {ingest} from './verbs/ingest.js';
@@ -72,6 +72,9 @@ const populateDispatcher = (dispatcher, storage, context, env) => {
     // API call, to not affect existing demos.
     runArc: async (msg, tid, bus) => {
       return await runArc(msg, tid, bus, runtime, env);
+    },
+    stopArc: async (msg, tid, bus) => {
+      return await stopArc(msg, runtime);
     },
     // TODO(sjmiles): below here are "live context" tools (remove when other context options are viable)
     ingest: async (msg, tid, bus) => {

--- a/shells/pipes-shell/source/verbs/run-arc.js
+++ b/shells/pipes-shell/source/verbs/run-arc.js
@@ -17,7 +17,7 @@ import {portIndustry} from '../pec-port.js';
 const {log, warn} = logsFactory('pipe');
 
 // The implementation was forked from verbs/spawn.js
-export const runArc = async (msg, tid, bus, runtime, env) => {
+export const runArc = async (msg, bus, runtime, env) => {
   const {recipe, arcId, storageKeyPrefix, pecId, particleId, particleName, providedSlotId} = msg;
   const action = runtime.context.allRecipes.find(r => r.name === recipe);
   if (!arcId) {
@@ -111,4 +111,8 @@ const updateParticleInPlan = (plan, particleId, particleName, providedSlotId) =>
     }
   }
   return plan;
+};
+
+export const stopArc = async ({arcId}, runtime) => {
+  runtime.stopArc(arcId);
 };

--- a/src/javaharness/java/arcs/android/client/ArcsServiceBridge.java
+++ b/src/javaharness/java/arcs/android/client/ArcsServiceBridge.java
@@ -58,13 +58,7 @@ class ArcsServiceBridge implements ArcsEnvironment, ServiceConnection {
   }
 
   @Override
-  public void sendMessageToArcs(String message, DataListener listener) {
-    if (listener != null) {
-      // TODO: Add support for listeners.
-      throw new UnsupportedOperationException(
-          "listeners are not yet supported by the ArcsServiceBridge.");
-    }
-
+  public void sendMessageToArcs(String message) {
     runServiceMethod(service -> service.sendMessageToArcs(message));
   }
 

--- a/src/javaharness/java/arcs/android/impl/AndroidShellApiImpl.java
+++ b/src/javaharness/java/arcs/android/impl/AndroidShellApiImpl.java
@@ -4,8 +4,10 @@ import android.os.Handler;
 import android.os.Looper;
 import android.util.Log;
 import android.webkit.WebView;
-import arcs.api.ShellApi;
+
 import javax.inject.Inject;
+
+import arcs.api.ShellApi;
 
 /** Exposes Shell (Window) scope methods into Java from JS. */
 public class AndroidShellApiImpl implements ShellApi {
@@ -25,16 +27,8 @@ public class AndroidShellApiImpl implements ShellApi {
     Log.e("Arcs", "Receive called " + script);
 
     if (webView != null) {
-      // TODO(cromwellian): receive() should take a callback since the
-      // TID cannot be provided synchronously on Android
       new Handler(Looper.getMainLooper())
-          .post(
-              () ->
-                  webView.evaluateJavascript(
-                      script,
-                      (String tid) -> {
-                        // TODO: deprecated tid callback.
-                      }));
+          .post(() -> webView.evaluateJavascript(script, (String unused) -> {}));
     } else {
       Log.e("Arcs", "webView is null");
     }

--- a/src/javaharness/java/arcs/api/ArcsEnvironment.java
+++ b/src/javaharness/java/arcs/api/ArcsEnvironment.java
@@ -8,11 +8,6 @@ import java.util.List;
  */
 public interface ArcsEnvironment {
 
-  /** Called by ArcsEnvironment when data is sent from Arcs. */
-  interface DataListener {
-    void onData(String arcId, String data);
-  }
-
   /** Called by ArcsEnvironment when the Arcs runtime is ready. */
   interface ReadyListener {
     void onReady(List<String> recipes);
@@ -25,13 +20,7 @@ public interface ArcsEnvironment {
    * @param msg a message in JSON format
    * @param listener an optional callback, triggered when Arcs replies to this message.
    */
-  void sendMessageToArcs(String msg, DataListener listener);
-
-  /**
-   * Fires an event to notify listener when given transaction-id data is available.
-   * TODO: DataListeners are deprecated, remove.
-   */
-  default void fireDataEvent(String tid, String data) {}
+  void sendMessageToArcs(String msg);
 
   /**
    * A callback when Arcs is ready to for interaction.

--- a/src/javaharness/java/arcs/api/DeviceClientImpl.java
+++ b/src/javaharness/java/arcs/api/DeviceClientImpl.java
@@ -45,10 +45,6 @@ public class DeviceClientImpl implements DeviceClient {
         break;
       case MESSAGE_DATA:
         logger.warning("logger: Received deprecated 'data' message");
-        PortableJson dataJson = content.getObject(FIELD_DATA);
-        environment.fireDataEvent(
-            String.valueOf(content.getInt(FIELD_TRANSACTION_ID)),
-            dataJson == null ? null : jsonParser.stringify(dataJson));
         break;
       case MESSAGE_PEC:
         deliverPecMessage(content.getObject(FIELD_DATA));
@@ -85,7 +81,7 @@ public class DeviceClientImpl implements DeviceClient {
     }
 
     createPecForParticle(request.getString("pecId"), particle);
-    environment.sendMessageToArcs(jsonParser.stringify(request), null);
+    environment.sendMessageToArcs(jsonParser.stringify(request));
   }
 
   private void createPecForParticle(String pecId, Particle particle) {

--- a/src/javaharness/java/arcs/api/PECInnerPortImpl.java
+++ b/src/javaharness/java/arcs/api/PECInnerPortImpl.java
@@ -269,6 +269,6 @@ public class PECInnerPortImpl implements PECInnerPort {
     json.put(MESSAGE_PEC_MESSAGE_KEY, MESSAGE_PEC_PEC_VALUE);
     json.put(MESSAGE_PEC_ID_FIELD, this.id);
     json.put(MESSAGE_PEC_ENTITY_KEY, message);
-    environment.sendMessageToArcs(jsonParser.stringify(json), null);
+    environment.sendMessageToArcs(jsonParser.stringify(json));
   }
 }

--- a/src/javaharness/java/arcs/api/Particle.java
+++ b/src/javaharness/java/arcs/api/Particle.java
@@ -33,5 +33,5 @@ public interface Particle {
 
   void setOutput(Consumer<PortableJson> output);
 
-  void renderModel();
+  void output();
 }

--- a/src/javaharness/java/arcs/api/ParticleBase.java
+++ b/src/javaharness/java/arcs/api/ParticleBase.java
@@ -10,7 +10,7 @@ public class ParticleBase implements Particle {
   public ParticleSpec spec;
   public PortableJsonParser jsonParser;
   protected Map<String, Handle> handleByName = new HashMap<>();
-  protected Consumer<PortableJson> output;
+  protected Consumer<PortableJson> outputConsumer;
 
   @Override
   public String getId() {
@@ -73,13 +73,13 @@ public class ParticleBase implements Particle {
 
   @Override
   public void setOutput(Consumer<PortableJson> output) {
-    this.output = output;
+    this.outputConsumer = output;
   }
 
   @Override
-  public void renderModel() {
-    if (this.output != null) {
-      this.output.accept(jsonParser.emptyObject()
+  public void output() {
+    if (this.outputConsumer != null) {
+      this.outputConsumer.accept(jsonParser.emptyObject()
           // TODO: add support for slotName.
           .put("template", getTemplate(""))
           .put("model", getModel()));

--- a/src/javaharness/java/arcs/api/ShellApiBasedArcsEnvironment.java
+++ b/src/javaharness/java/arcs/api/ShellApiBasedArcsEnvironment.java
@@ -17,7 +17,6 @@ public class ShellApiBasedArcsEnvironment implements ArcsEnvironment {
 
   private static final Logger logger = Logger.getLogger(ShellApiBasedArcsEnvironment.class.getName());
 
-  private final Map<String, DataListener> inProgress = new HashMap<>();
   private final List<ReadyListener> readyListeners = new ArrayList<>();
   private ShellApi shellApi;
 
@@ -27,22 +26,8 @@ public class ShellApiBasedArcsEnvironment implements ArcsEnvironment {
   }
 
   @Override
-  public void sendMessageToArcs(String msg, DataListener listener) {
-    String transactionId = String.valueOf(shellApi.receive(msg));
-    if (listener != null) {
-      logger.warning("Deprecated use of `listener` in msg: " + msg);
-      inProgress.put(transactionId, listener);
-    }
-  }
-
-  @Override
-  public void fireDataEvent(String tid, String data) {
-    if (inProgress.containsKey(tid)) {
-      if (data != null) {
-        inProgress.get(tid).onData(tid, data);
-      }
-      inProgress.remove(tid);
-    }
+  public void sendMessageToArcs(String msg) {
+    shellApi.receive(msg);
   }
 
   @Override

--- a/src/javaharness/java/arcs/demo/particles/RenderText.java
+++ b/src/javaharness/java/arcs/demo/particles/RenderText.java
@@ -20,13 +20,13 @@ public class RenderText extends ParticleBase {
   @Override
   public void setHandles(Map<String, Handle> handleByName) {
     super.setHandles(handleByName);
-    this.renderModel();
+    this.output();
   }
 
   @Override
   public void setOutput(Consumer<PortableJson> output) {
     super.setOutput(output);
-    renderModel();
+    this.output();
   }
 
   @Override

--- a/src/javaharness/java/arcs/web/impl/WebHarnessController.java
+++ b/src/javaharness/java/arcs/web/impl/WebHarnessController.java
@@ -95,22 +95,13 @@ public class WebHarnessController implements HarnessController {
 
     document.body.appendChild(
         makeInputElement(
-            "Autofill Address Entity",
-            val ->
-                environment.sendMessageToArcs(
-                    "{\"message\": \"autofill\", \"modality\": \"dom\", \"entity\": {\"type\": \"address\"}}",
-                    (id, result) -> dataParagraph.append("Test: " + result))));
-
-    document.body.appendChild(
-        makeInputElement(
             "DEMO UI renderers",
             val ->
                 environment.sendMessageToArcs(
                     jsonParser.stringify(jsonParser.emptyObject()
                         .put("message", "spawn")
                         // .put("modality", "log")
-                        .put("recipe", "DemoText")),
-                    null)));
+                        .put("recipe", "DemoText")))));
     document.body.appendChild(dataParagraph);
 
     // TODO: get rid of this once crdt tests are built and run properly as unittests.


### PR DESCRIPTION
- rename particle `renderModel` to `output` (consistent with js particle)
- remove unused transaction id and listeners