### PR TITLE
Fix comformance errors, exported must be explicitly specified

### DIFF
--- a/src/javaharness/java/arcs/android/demo/service/AndroidManifest.xml
+++ b/src/javaharness/java/arcs/android/demo/service/AndroidManifest.xml
@@ -15,7 +15,8 @@
     <service
         android:name=".ArcsAutofillService"
         android:label="Arcs Demo Autofill Service"
-        android:permission="android.permission.BIND_AUTOFILL_SERVICE">
+        android:permission="android.permission.BIND_AUTOFILL_SERVICE"
+        android:exported="true">
       <intent-filter>
         <action android:name="android.service.autofill.AutofillService" />
       </intent-filter>

--- a/src/javaharness/java/arcs/android/demo/ui/AndroidManifest.xml
+++ b/src/javaharness/java/arcs/android/demo/ui/AndroidManifest.xml
@@ -12,7 +12,8 @@
   <application>
     <activity
       android:name=".MainActivity"
-      android:label="ArcsHarnessApp">
+      android:label="ArcsHarnessApp"
+      android:exported="false">
       <intent-filter>
         <action android:name="android.intent.action.MAIN"/>
         <category android:name="android.intent.category.LAUNCHER"/>
@@ -21,10 +22,12 @@
 
     <activity
       android:name=".AutofillDemoActivity"
-      android:label="Autofill Demo" />
+      android:label="Autofill Demo"
+      android:exported="false" />
 
     <activity
         android:name=".NotificationDemoActivity"
-        android:label="Notification Demo" />
+        android:label="Notification Demo"
+        android:exported="false" />
   </application>
 </manifest>


### PR DESCRIPTION

Internal conformance checks don't allow manifests with default exported services.  The attribute's value
must be explicitly provided.
