### PR TITLE
Slandles delegation

### DIFF
--- a/particles/Tutorial/Javascript/4_RenderSlots/RenderSlandles.arcs
+++ b/particles/Tutorial/Javascript/4_RenderSlots/RenderSlandles.arcs
@@ -1,0 +1,19 @@
+// Tutorial 4: Render Slots
+// Creates two particles, and renders one inside the other using render slots.
+
+particle SlandleParentParticle in 'parent.js'
+  `consume Slot root
+    `provide Slot mySlot
+
+particle SlandleChildParticle in 'child.js'
+  `consume Slot childSlot
+
+recipe SlandleRenderSlotsRecipe
+  `slot 'rootslotid-root' as root
+  SlandleParentParticle
+    root consume root
+      mySlot provide shared
+  SlandleChildParticle
+    childSlot consume shared
+
+  description `Tutorial 4: Render Slandles`

--- a/src/planning/plan/suggestion.ts
+++ b/src/planning/plan/suggestion.ts
@@ -244,8 +244,7 @@ export class Suggestion {
       }
     };
     const slandles = this.plan.handles.filter(
-      handle => handle.type.isSlot()
-    || handle.type.isCollectionType() && handle.type.collectionType.isSlot()
+      handle => handle.fate === '`slot'
     ).length;
     if (slandles + this.plan.slots.length === 0) {
       logReason(`No slots`);

--- a/src/planning/strategies/match-free-handles-to-connections.ts
+++ b/src/planning/strategies/match-free-handles-to-connections.ts
@@ -9,6 +9,7 @@
  */
 
 import {Recipe} from '../../runtime/recipe/recipe.js';
+import {Handle} from '../../runtime/recipe/handle.js';
 import {StrategizerWalker, Strategy} from '../strategizer.js';
 
 /*
@@ -18,15 +19,15 @@ import {StrategizerWalker, Strategy} from '../strategizer.js';
 export class MatchFreeHandlesToConnections extends Strategy {
   async generate(inputParams) {
     return StrategizerWalker.over(this.getResults(inputParams), new class extends StrategizerWalker {
-      onHandle(recipe, handle) {
+      onHandle(recipe: Recipe, handle: Handle) {
         if (handle.connections.length > 0) {
-          return;
+          return undefined;
         }
 
         const matchingConnections = recipe.getFreeConnections();
 
         return matchingConnections.map(({particle, connSpec}) => {
-          return (recipe, handle) => {
+          return (recipe: Recipe, handle: Handle) => {
             const cloneParticle = recipe.updateToClone({particle}).particle;
             const newConnection = cloneParticle.addConnectionName(connSpec.name);
             newConnection.connectToHandle(handle);

--- a/src/runtime/arc.ts
+++ b/src/runtime/arc.ts
@@ -572,9 +572,14 @@ ${this.activeRecipe.toString()}`;
     const {handles, particles, slots} = recipe.mergeInto(this._activeRecipe);
     this._recipeDeltas.push({particles, handles, slots, patterns: recipe.patterns});
 
-    // TODO(mmandlis): Get rid of populating the missing local slot IDs here,
+    // TODO(mmandlis, jopra): Get rid of populating the missing local slot & slandle IDs here,
     // it should be done at planning stage.
-    slots.forEach(slot => slot.id = slot.id || `slotid-${this.generateID().toString()}`);
+    slots.forEach(slot => slot.id = slot.id || this.generateID('slot').toString());
+    handles.forEach(handle => {
+      if (handle.toSlot()) {
+        handle.id = handle.id || this.generateID('slandle').toString();
+      }
+    });
 
     for (const recipeHandle of handles) {
       const store = this.context.findStoreById(recipeHandle.id);

--- a/src/runtime/manifest-ast-nodes.ts
+++ b/src/runtime/manifest-ast-nodes.ts
@@ -367,6 +367,7 @@ export interface RecipeParticleConnection extends BaseNode {
   param: string;
   dir: DirectionArrow;
   target: ParticleConnectionTargetComponents;
+  dependentConnections: RecipeParticleConnection[];
 }
 
 export type RecipeParticleItem = RecipeParticleSlotConnection | RecipeParticleConnection;

--- a/src/runtime/particle-execution-host.ts
+++ b/src/runtime/particle-execution-host.ts
@@ -296,7 +296,7 @@ class PECOuterPortImpl extends PECOuterPort {
     let recipe0 = manifest.recipes[0];
     if (recipe0) {
       for (const slot of recipe0.slots) {
-        slot.id = slot.id || `slotid-${arc.generateID()}`;
+        slot.id = slot.id || arc.generateID('slot').toString();
         if (slot.sourceConnection) {
           const particlelocalName = slot.sourceConnection.particle.localName;
           if (particlelocalName) {

--- a/src/runtime/particle-spec.ts
+++ b/src/runtime/particle-spec.ts
@@ -39,14 +39,14 @@ function asTypeLiteral(t: Type | TypeLiteral) : TypeLiteral {
   return (t instanceof Type) ? t.toLiteral() : t;
 }
 
-export function isRoot({name, tags, id, type}: {name: string, tags: string[], id?: string, type?: Type}): boolean {
+export function isRoot({name, tags, id, type, fate}: {name: string, tags: string[], id?: string, type?: Type, fate?: string}): boolean {
   const rootNames: string[] = [
     'root',
     'toproot',
     'modal'
   ];
 
-  if (type && !type.slandleType()) {
+  if ((fate && fate !== '`slot') || (type && !type.slandleType())) {
     // If this is a handle that is not a Slandle, it cannot be a root slot.
     return false;
   }
@@ -113,9 +113,9 @@ export class HandleConnectionSpec {
       isRequired: !this.isOptional, // TODO: Remove duplicated data isRequired vs isOptional (prefer isOptional)
       isSet,
       type: slotType,
-      handles: [slotInfo.handle],
+      handles: slotInfo.handle ? [slotInfo.handle] : [],
       formFactor: slotInfo.formFactor,
-      provideSlotConnections: [],
+      provideSlotConnections: this.dependentConnections.map(conn => conn.toSlotConnectionSpec()),
     };
   }
 

--- a/src/runtime/recipe/handle-connection.ts
+++ b/src/runtime/recipe/handle-connection.ts
@@ -152,7 +152,7 @@ export class HandleConnection implements Comparable<HandleConnection> {
         if (!conn) return;
         const slandleConn = conn.toSlotConnection();
         if (!slandleConn) return;
-        assert(!slandle.providedSlots[conn.spec.name], `provided slot '${conn.spec.name}'already exists`);
+        assert(!slandle.providedSlots[conn.spec.name], `provided slot '${conn.spec.name}' already exists`);
         slandle.providedSlots[conn.spec.name] = slandleConn.targetSlot;
       });
     }

--- a/src/runtime/recipe/handle-connection.ts
+++ b/src/runtime/recipe/handle-connection.ts
@@ -146,6 +146,16 @@ export class HandleConnection implements Comparable<HandleConnection> {
     const slandle: SlotConnection = new SlotConnection(this.name, this.particle);
     slandle.tags = this.tags;
     slandle.targetSlot = this.handle && this.handle.toSlot();
+    if (this.spec) {
+      this.spec.dependentConnections.forEach(connSpec => {
+        const conn = this.particle.getConnectionByName(connSpec.name);
+        if (!conn) return;
+        const slandleConn = conn.toSlotConnection();
+        if (!slandleConn) return;
+        assert(!slandle.providedSlots[conn.spec.name], `provided slot '${conn.spec.name}'already exists`);
+        slandle.providedSlots[conn.spec.name] = slandleConn.targetSlot;
+      });
+    }
     return slandle;
   }
 

--- a/src/runtime/recipe/particle.ts
+++ b/src/runtime/recipe/particle.ts
@@ -279,7 +279,7 @@ export class Particle implements Comparable<Particle> {
 
   getSlandleConnections(): SlotConnection[] {
     // TODO(jopra): Revisit when slots are removed.
-    return [...Object.values(this._consumedSlotConnections), ...this.allConnections().map(conn => conn.toSlotConnection()).filter(conn => conn)];
+    return [...Object.values(this._consumedSlotConnections), ...this.allConnections().map(conn => conn.direction === '`consume' && conn.toSlotConnection()).filter(conn => conn)];
   }
 
   getSlotConnections(): SlotConnection[] {

--- a/src/runtime/recipe/particle.ts
+++ b/src/runtime/recipe/particle.ts
@@ -176,8 +176,7 @@ export class Particle implements Comparable<Particle> {
       return false;
     }
     const slandleConnections = Object.values(this.connections).filter(
-      connection => connection.type.isSlot()
-        || (connection.type.isCollectionType() && connection.type.getContainedType().isSlot())
+      connection => Boolean(connection.type.slandleType())
     );
     if (slandleConnections.length ===0 && this.spec.slotConnections.size > 0) {
       const fulfilledSlotConnections = this.getSlotConnections().filter(connection => connection.targetSlot !== undefined);

--- a/src/runtime/recipe/recipe-resolver.ts
+++ b/src/runtime/recipe/recipe-resolver.ts
@@ -113,7 +113,7 @@ export class ResolveWalker extends RecipeWalker {
       // Tracked at https://github.com/PolymerLabs/arcs/issues/3389
       return error('The only handles matching the requested type and tags are already present in this recipe');
     }
-    return mappable.map(store => ((recipe, updateHandle) => {
+    return mappable.map(store => ((recipe, updateHandle: Handle) => {
       updateHandle.mapToStorage(store);
       return 0;
     }));

--- a/src/runtime/recipe/recipe-resolver.ts
+++ b/src/runtime/recipe/recipe-resolver.ts
@@ -39,6 +39,12 @@ export class ResolveWalker extends RecipeWalker {
       }
       return [];
     };
+    if (handle.fate === '`slot') {
+      return [];
+    }
+    if (handle.type.slandleType()) {
+      return [];
+    }
     const arc = this.arc;
     if (handle.connections.length === 0 ||
         (handle.id && handle.storageKey) || (!handle.type) ||
@@ -59,7 +65,6 @@ export class ResolveWalker extends RecipeWalker {
           mappable = arc.context.findStoresByType(handle.type, {tags: handle.tags, subtype: true});
           break;
         case 'create':
-        case '`slot':
         case '?':
           mappable = [];
           break;
@@ -78,7 +83,6 @@ export class ResolveWalker extends RecipeWalker {
           storeById = arc.context.findStoreById(handle.id);
           break;
         case 'create':
-        case '`slot':
         case '?':
           break;
         default:

--- a/src/runtime/recipe/recipe.ts
+++ b/src/runtime/recipe/recipe.ts
@@ -200,8 +200,7 @@ export class Recipe implements Cloneable<Recipe> {
       let atLeastOneSlotConnection = false;
       let usesSlandles = false;
       for (const handleSpec of Object.values(particle.spec.connections)) {
-        if (handleSpec.type.isSlot() ||
-          (handleSpec.type.isCollectionType() && handleSpec.type.collectionType.isSlot())) {
+        if (handleSpec.type.slandleType()) {
           usesSlandles = true;
         }
       }

--- a/src/runtime/slot-composer.ts
+++ b/src/runtime/slot-composer.ts
@@ -112,7 +112,7 @@ export class SlotComposer {
     assert(transformationSlotConsumer,
         `Transformation particle ${transformationParticle.name} with consumed ${transformationSlotName} not found`);
 
-    const hostedSlotId = innerArc.generateID().toString();
+    const hostedSlotId = innerArc.generateID('slot').toString();
     this._contexts.push(new HostedSlotContext(hostedSlotId, transformationSlotConsumer, storeId));
     return hostedSlotId;
   }

--- a/src/runtime/slot-consumer.ts
+++ b/src/runtime/slot-consumer.ts
@@ -74,7 +74,7 @@ export class SlotConsumer {
   }
 
   addHostedSlotContexts(context: HostedSlotContext): void {
-    context.containerAvailable = Boolean(this.slotContext.containerAvailable);
+    context.containerAvailable = Boolean(this.slotContext && this.slotContext.containerAvailable);
     this.hostedSlotContexts.push(context);
   }
 

--- a/src/runtime/tests/manifest-test.ts
+++ b/src/runtime/tests/manifest-test.ts
@@ -769,6 +769,57 @@ ${particleStr1}
     await parseRecipe({label: '3', isRequiredSlotA: false, isRequiredSlotB: true, expectedIsResolved: false});
     await parseRecipe({label: '4', isRequiredSlotA: true, isRequiredSlotB: true, expectedIsResolved: false});
   });
+
+  it('SLANDLES resolves with dependent slandles', async () => {
+    const manifest = await Manifest.parse(`
+      particle Parent in 'parent.js'
+        \`consume Slot root
+          \`provide Slot mySlot
+
+      particle Child in 'child.js'
+        \`consume Slot childSlot
+
+      recipe SlandleRenderSlotsRecipe
+        Parent
+          root consume root
+            mySlot provide shared
+        Child
+          childSlot consume shared
+    `);
+    // verify particle spec
+    assert.lengthOf(manifest.particles, 2);
+    assert.lengthOf(manifest.recipes, 1);
+    const recipe = manifest.recipes[0];
+    recipe.normalize();
+    assert.lengthOf(recipe.handles, 2);
+    console.log(recipe.handles.map(h => h.type));
+    assert.isTrue(recipe.isResolved());
+  });
+
+  it('SLANDLES doesn\'t resolve mismatching dependencies dependent slandles', async () => {
+    const manifest = await Manifest.parse(`
+      particle Parent in 'parent.js'
+        \`consume Slot root
+          \`provide Slot mySlot
+
+      particle Child in 'child.js'
+        \`consume Slot childSlot
+
+      recipe SlandleRenderSlotsRecipe
+        Parent
+          root consume root
+        Child
+          childSlot consume shared
+    `);
+    // verify particle spec
+    assert.lengthOf(manifest.particles, 2);
+    assert.lengthOf(manifest.recipes, 1);
+    const recipe = manifest.recipes[0];
+    recipe.normalize();
+    assert.lengthOf(recipe.handles, 2);
+    assert.isFalse(recipe.isResolved());
+  });
+
   it('recipe slots with tags', async () => {
     const manifest = await Manifest.parse(`
       particle SomeParticle in 'some-particle.js'

--- a/src/runtime/tests/manifest-test.ts
+++ b/src/runtime/tests/manifest-test.ts
@@ -792,7 +792,6 @@ ${particleStr1}
     const recipe = manifest.recipes[0];
     recipe.normalize();
     assert.lengthOf(recipe.handles, 2);
-    console.log(recipe.handles.map(h => h.type));
     assert.isTrue(recipe.isResolved());
   });
 

--- a/src/runtime/tests/particle-api-test.ts
+++ b/src/runtime/tests/particle-api-test.ts
@@ -1100,8 +1100,8 @@ describe('particle-api', () => {
 
     const sessionId = innerArc.idGeneratorForTesting.currentSessionIdForTesting;
     assert.strictEqual(innerArc.activeRecipe.toString(), `recipe
-  slot '!${sessionId}:demo:inner2:1' as slot0
-  slot 'slotid-!${sessionId}:demo:inner2:2' as slot1
+  slot '!${sessionId}:demo:inner2:slot1' as slot0
+  slot '!${sessionId}:demo:inner2:slot2' as slot1
   A as particle0
     consume content as slot0
       provide detail as slot1

--- a/src/runtime/ui-slot-composer.ts
+++ b/src/runtime/ui-slot-composer.ts
@@ -128,7 +128,7 @@ export class UiSlotComposer {
     // who renderered the slot (i.e. the dom node or other container). The renderer identifies these
     // slots by entity-id (`subid`) instead. But `subid` is not unique, we need more information to
     // locate the output slot, so we embed the muxed-slot's id into our output-slot-id.
-    const hostedSlotId = `${slotConsumer.slotContext.id}___${innerArc.generateID()}`;
+    const hostedSlotId = `${slotConsumer.slotContext.id}___${innerArc.generateID('slot')}`;
     //this._contexts.push(new HostedSlotContext(hostedSlotId, slotConsumer, storeId));
     return hostedSlotId;
   }

--- a/src/tests/slot-composer-test.ts
+++ b/src/tests/slot-composer-test.ts
@@ -311,7 +311,7 @@ recipe
     assert.deepEqual(rootSlotConsumer._content, {
       model: {
         a: 'A content/intercepted-model',
-        '$detail': `slotid-!${detailSlotConsumer.arc.id.root}:demo:inner2:2`
+        '$detail': `!${detailSlotConsumer.arc.id.root}:demo:inner2:slot2`
       },
       template: `<div>intercepted-template<div><span>{{a}}</span><div slotid$="{{$detail}}"></div></div></div>`,
       templateName: 'A::content::default/intercepted'


### PR DESCRIPTION
Creates slot contexts and consumers for delegated slot connections.

It also adds a small change that ensures that slots receive ids with the slot prefix in the suffix of their id.
Correspondingly slandle ids are marked slandles (this can be changed to slots, but has been kept for debugging purposes).