### PR TITLE
Add UnifiedStore interface

### DIFF
--- a/src/devtools-connector/arc-stores-fetcher.ts
+++ b/src/devtools-connector/arc-stores-fetcher.ts
@@ -8,18 +8,19 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {Arc} from '../runtime/arc.js';
+import {Arc, UnifiedStore} from '../runtime/arc.js';
 import {ArcDevtoolsChannel} from './abstract-devtools-channel.js';
 import {Manifest} from '../runtime/manifest.js';
 import {StorageStub} from '../runtime/storage-stub.js';
 import {StorageProviderBase, SingletonStorageProvider, CollectionStorageProvider} from '../runtime/storage/storage-provider-base.js';
 import {Type} from '../runtime/type.js';
+import {StorageKey} from '../runtime/storageNG/storage-key.js';
 
 type Result = {
   name: string,
   tags: string[],
   id: string,
-  storage: string,
+  storage: string | StorageKey,
   type: Type,
   description: string,
   // tslint:disable-next-line: no-any
@@ -70,7 +71,7 @@ export class ArcStoresFetcher {
     };
   }
 
-  private async digestStores(stores: [StorageProviderBase | StorageStub, string[] | Set<string>][]) {
+  private async digestStores(stores: [UnifiedStore | StorageStub, string[] | Set<string>][]) {
     const result: Result[] = [];
     for (const [store, tags] of stores) {
       result.push({
@@ -87,7 +88,7 @@ export class ArcStoresFetcher {
   }
 
   // tslint:disable-next-line: no-any
-  private async dereference(store: StorageProviderBase | StorageStub): Promise<any> {
+  private async dereference(store: UnifiedStore | StorageStub): Promise<any> {
     if ((store as CollectionStorageProvider).toList) {
       return (store as CollectionStorageProvider).toList();
     } else if ((store as SingletonStorageProvider).get) {

--- a/src/planning/plan/planificator.ts
+++ b/src/planning/plan/planificator.ts
@@ -151,12 +151,18 @@ export class Planificator {
   }
 
   static constructSuggestionKey(arc: Arc, storageKeyBase?: string): KeyBase {
+    if (typeof arc.storageKey !== 'string') {
+      throw new Error(`Planner doesn't work with new-style storage yet!`);
+    }
     const arcStorageKey = arc.storageProviderFactory.parseStringAsKey(arc.storageKey);
     const keybase = arc.storageProviderFactory.parseStringAsKey(storageKeyBase || arcStorageKey.base());
     return keybase.childKeyForSuggestions(planificatorId, arcStorageKey.arcId);
   }
 
   static constructSearchKey(arc: Arc): KeyBase {
+    if (typeof arc.storageKey !== 'string') {
+      throw new Error(`Planner doesn't work with new-style storage yet!`);
+    }
     const arcStorageKey = arc.storageProviderFactory.parseStringAsKey(arc.storageKey);
     const keybase = arc.storageProviderFactory.parseStringAsKey(arcStorageKey.base());
     return keybase.childKeyForSearch(planificatorId);

--- a/src/planning/strategies/assign-handles.ts
+++ b/src/planning/strategies/assign-handles.ts
@@ -14,6 +14,7 @@ import {Recipe} from '../../runtime/recipe/recipe.js';
 import {StorageProviderBase} from '../../runtime/storage/storage-provider-base.js';
 import {StrategizerWalker, Strategy} from '../strategizer.js';
 import {StorageStub} from '../../runtime/storage-stub.js';
+import {UnifiedStore} from '../../runtime/arc.js';
 
 export class AssignHandles extends Strategy {
   async generate(inputParams) {
@@ -96,8 +97,8 @@ export class AssignHandles extends Strategy {
     }(StrategizerWalker.Permuted), this);
   }
 
-  getMappableStores(fate, type, tags: string[], counts): Map<StorageProviderBase | StorageStub, string> {
-    const stores: Map<StorageProviderBase | StorageStub, string> = new Map();
+  getMappableStores(fate, type, tags: string[], counts): Map<UnifiedStore | StorageStub, string> {
+    const stores: Map<UnifiedStore | StorageStub, string> = new Map();
 
     if (fate === 'use' || fate === '?') {
       this.arc.findStoresByType(type, {tags}).forEach(store => stores.set(store, 'use'));

--- a/src/planning/strategies/search-tokens-to-handles.ts
+++ b/src/planning/strategies/search-tokens-to-handles.ts
@@ -8,7 +8,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {Arc} from '../../runtime/arc.js';
+import {Arc, UnifiedStore} from '../../runtime/arc.js';
 import {RecipeUtil} from '../../runtime/recipe/recipe-util.js';
 import {Recipe} from '../../runtime/recipe/recipe.js';
 import {StrategizerWalker, Strategy} from '../strategizer.js';
@@ -23,7 +23,7 @@ export class SearchTokensToHandles extends Strategy {
     // which are not already mapped into the provided handle's recipe
     const findMatchingStores = (token, handle) => {
       const counts = RecipeUtil.directionCounts(handle);
-      let stores: (StorageProviderBase | StorageStub)[];
+      let stores: (UnifiedStore | StorageStub)[];
       stores = arc.findStoresByType(handle.type, {tags: [`${token}`]});
       let fate = 'use';
       if (stores.length === 0) {

--- a/src/runtime/api-channel.ts
+++ b/src/runtime/api-channel.ts
@@ -10,7 +10,7 @@
 
 import {assert} from '../platform/assert-web.js';
 
-import {Arc} from './arc.js';
+import {Arc, UnifiedStore} from './arc.js';
 import {ArcInspector} from './arc-inspector.js';
 import {Handle} from './handle.js';
 import {ParticleSpec} from './particle-spec.js';
@@ -466,9 +466,9 @@ export abstract class PECOuterPort extends APIPort {
   }
 
   @NoArgs Stop() {}
-  DefineHandle(@RedundantInitializer store: StorageProviderBase, @ByLiteral(Type) type: Type, @Direct name: string) {}
-  InstantiateParticle(@Initializer particle: recipeParticle.Particle, @Identifier @Direct id: string, @ByLiteral(ParticleSpec) spec: ParticleSpec, @ObjectMap(MappingType.Direct, MappingType.Mapped) stores: Map<string, StorageProviderBase>) {}
-  ReinstantiateParticle(@Identifier @Direct id: string, @ByLiteral(ParticleSpec) spec: ParticleSpec, @ObjectMap(MappingType.Direct, MappingType.Mapped) stores: Map<string, StorageProviderBase>) {}
+  DefineHandle(@RedundantInitializer store: UnifiedStore, @ByLiteral(Type) type: Type, @Direct name: string) {}
+  InstantiateParticle(@Initializer particle: recipeParticle.Particle, @Identifier @Direct id: string, @ByLiteral(ParticleSpec) spec: ParticleSpec, @ObjectMap(MappingType.Direct, MappingType.Mapped) stores: Map<string, UnifiedStore>) {}
+  ReinstantiateParticle(@Identifier @Direct id: string, @ByLiteral(ParticleSpec) spec: ParticleSpec, @ObjectMap(MappingType.Direct, MappingType.Mapped) stores: Map<string, UnifiedStore>) {}
   ReloadParticles(@OverridingInitializer particles: recipeParticle.Particle[], @List(MappingType.Direct) ids: string[]) {}
 
   UIEvent(@Mapped particle: recipeParticle.Particle, @Direct slotName: string, @Direct event: {}) {}
@@ -478,8 +478,8 @@ export abstract class PECOuterPort extends APIPort {
   StopRender(@Mapped particle: recipeParticle.Particle, @Direct slotName: string) {}
 
   abstract onRender(particle: recipeParticle.Particle, slotName: string, content: Content);
-  abstract onInitializeProxy(handle: StorageProviderBase, callback: number);
-  abstract onSynchronizeProxy(handle: StorageProviderBase, callback: number);
+  abstract onInitializeProxy(handle: UnifiedStore, callback: number);
+  abstract onSynchronizeProxy(handle: UnifiedStore, callback: number);
   abstract onHandleGet(handle: StorageProviderBase, callback: number);
   abstract onHandleToList(handle: StorageProviderBase, callback: number);
   abstract onHandleSet(handle: StorageProviderBase, data: {}, particleId: string, barrier: string);
@@ -494,13 +494,13 @@ export abstract class PECOuterPort extends APIPort {
   abstract onIdle(version: number, relevance: Map<recipeParticle.Particle, number[]>);
 
   abstract onGetBackingStore(callback: number, storageKey: string, type: Type);
-  GetBackingStoreCallback(@Initializer store: StorageProviderBase, @RemoteMapped callback: number, @ByLiteral(Type) type: Type, @Direct name: string, @Identifier @Direct id: string, @Direct storageKey: string) {}
+  GetBackingStoreCallback(@Initializer store: UnifiedStore, @RemoteMapped callback: number, @ByLiteral(Type) type: Type, @Direct name: string, @Identifier @Direct id: string, @Direct storageKey: string) {}
 
   abstract onConstructInnerArc(callback: number, particle: recipeParticle.Particle);
   ConstructArcCallback(@RemoteMapped callback: number, @LocalMapped arc: {}) {}
 
   abstract onArcCreateHandle(callback: number, arc: {}, type: Type, name: string);
-  CreateHandleCallback(@Initializer handle: StorageProviderBase, @RemoteMapped callback: number, @ByLiteral(Type) type: Type, @Direct name: string, @Identifier @Direct id: string) {}
+  CreateHandleCallback(@Initializer handle: UnifiedStore, @RemoteMapped callback: number, @ByLiteral(Type) type: Type, @Direct name: string, @Identifier @Direct id: string) {}
   abstract onArcMapHandle(callback: number, arc: Arc, handle: recipeHandle.Handle);
   MapHandleCallback(@RemoteIgnore @Initializer newHandle: {}, @RemoteMapped callback: number, @Direct id: string) {}
 

--- a/src/runtime/arc.ts
+++ b/src/runtime/arc.ts
@@ -71,11 +71,11 @@ type SerializeContext = {handles: string, resources: string, interfaces: string,
 /**
  * This is a temporary interface used to unify old-style stores (storage/StorageProviderBase) and new-style stores (storageNG/Store).
  * We should be able to remove this once we've switched across to the NG stack.
- * 
+ *
  * Note that for old-style stores, StorageStubs are used *sometimes* to represent storage which isn't activated. For new-style stores,
  * Store itself represents an inactive store, and needs to be activated using activate(). This will present some integration
  * challenges :)
- * 
+ *
  * Note also that old-style stores use strings for Storage Keys, while NG storage uses storageNG/StorageKey subclasses. This provides
  * a simple test for determining whether a store is old or new.
  */
@@ -748,7 +748,7 @@ ${this.activeRecipe.toString()}`;
       return store;
     } else {
       const store = new Store(storageKey, Exists.ShouldCreate, type, id, name);
-      
+
       this._registerStore(store, tags);
       return store;
     }
@@ -856,9 +856,9 @@ ${this.activeRecipe.toString()}`;
     return store;
   }
 
-  findStoreTags(store: StorageProviderBase | StorageStub): Set<string> {
-    if (this.storeTags.has(store as StorageProviderBase)) {
-      return this.storeTags.get(store as StorageProviderBase);
+  findStoreTags(store: UnifiedStore | StorageStub): Set<string> {
+    if (this.storeTags.has(store as UnifiedStore)) {
+      return this.storeTags.get(store as UnifiedStore);
     }
     return this._context.findStoreTags(store as StorageStub);
   }

--- a/src/runtime/arc.ts
+++ b/src/runtime/arc.ts
@@ -14,7 +14,7 @@ import {ArcInspector, ArcInspectorFactory} from './arc-inspector.js';
 import {FakePecFactory} from './fake-pec-factory.js';
 import {Id, IdGenerator, ArcId} from './id.js';
 import {Loader} from './loader.js';
-import {Runnable} from './hot.js';
+import {Runnable, Consumer} from './hot.js';
 import {Manifest} from './manifest.js';
 import {MessagePort} from './message-channel.js';
 import {Modality} from './modality.js';
@@ -36,7 +36,10 @@ import {Mutex} from './mutex.js';
 import {Dictionary} from './hot.js';
 import {Runtime} from './runtime.js';
 import {VolatileMemory, VolatileStorageDriverProvider} from './storageNG/drivers/volatile.js';
-import {DriverFactory} from './storageNG/drivers/driver-factory.js';
+import {DriverFactory, Exists} from './storageNG/drivers/driver-factory.js';
+import {StorageKey} from './storageNG/storage-key.js';
+import {Store, StorageMode} from './storageNG/store.js';
+import {KeyBase} from './storage/key-base.js';
 
 export type ArcOptions = Readonly<{
   id: Id;
@@ -44,7 +47,7 @@ export type ArcOptions = Readonly<{
   pecFactories?: PecFactory[];
   slotComposer?: SlotComposer;
   loader: Loader;
-  storageKey?: string;
+  storageKey?: string | StorageKey;
   storageProviderFactory?: StorageProviderFactory;
   speculative?: boolean;
   innerArc?: boolean;
@@ -60,10 +63,43 @@ type DeserializeArcOptions = Readonly<{
   loader: Loader;
   fileName: string;
   context: Manifest;
-  inspectorFactory?: ArcInspectorFactory
+  inspectorFactory?: ArcInspectorFactory;
 }>;
 
 type SerializeContext = {handles: string, resources: string, interfaces: string, dataResources: Map<string, string>};
+
+/**
+ * This is a temporary interface used to unify old-style stores (storage/StorageProviderBase) and new-style stores (storageNG/Store).
+ * We should be able to remove this once we've switched across to the NG stack.
+ * 
+ * Note that for old-style stores, StorageStubs are used *sometimes* to represent storage which isn't activated. For new-style stores,
+ * Store itself represents an inactive store, and needs to be activated using activate(). This will present some integration
+ * challenges :)
+ * 
+ * Note also that old-style stores use strings for Storage Keys, while NG storage uses storageNG/StorageKey subclasses. This provides
+ * a simple test for determining whether a store is old or new.
+ */
+export interface UnifiedStore {
+  id: string;
+  name: string;
+  source: string;
+  type: Type;
+  storageKey: string | StorageKey;
+  version?: number; // TODO(shans): This needs to be a version vector for new storage.
+  referenceMode: boolean;
+  _compareTo(other: UnifiedStore): number;
+  toString(tags: string[]): string; // TODO(shans): This shouldn't be called toString as toString doesn't take arguments.
+  // TODO(shans): toLiteral is currently used in _serializeStore, during recipe serialization. It's used when volatile
+  // stores need to be written out as resources into the manifest. Problem is, it expects a particular CRDT model shape;
+  // for new storage we probably need to extract the model from the store instead and have the CRDT directly produce a
+  // JSON representation for insertion into the serialization.
+  // tslint:disable-next-line no-any
+  toLiteral: () => Promise<any>;
+  cloneFrom(store: UnifiedStore): void;
+  modelForSynchronization(): {};
+  on(type: string, fn: Consumer<{}>, target: {}): void;
+  description: string;
+}
 
 export class Arc {
   private readonly _context: Manifest;
@@ -77,15 +113,15 @@ export class Arc {
   public readonly _loader: Loader;
   private readonly dataChangeCallbacks = new Map<object, Runnable>();
   // All the stores, mapped by store ID
-  private readonly storesById = new Map<string, StorageProviderBase>();
+  private readonly storesById = new Map<string, UnifiedStore>();
   // storage keys for referenced handles
-  private storageKeys: Dictionary<string> = {};
-  public readonly storageKey?: string;
+  private storageKeys: Dictionary<string | StorageKey> = {};
+  public readonly storageKey?: string | StorageKey;
   storageProviderFactory: StorageProviderFactory;
   // Map from each store to a set of tags. public for debug access
-  public readonly storeTags = new Map<StorageProviderBase, Set<string>>();
+  public readonly storeTags = new Map<UnifiedStore, Set<string>>();
   // Map from each store to its description (originating in the manifest).
-  private readonly storeDescriptions = new Map<StorageProviderBase, string>();
+  private readonly storeDescriptions = new Map<UnifiedStore, string>();
   private waitForIdlePromise: Promise<void> | null;
   private readonly inspectorFactory?: ArcInspectorFactory;
   public readonly inspector?: ArcInspector;
@@ -94,7 +130,7 @@ export class Arc {
 
   readonly id: Id;
   private readonly idGenerator: IdGenerator = IdGenerator.newSession();
-  loadedParticleInfo = new Map<string, {spec: ParticleSpec, stores: Map<string, StorageProviderBase>}>();
+  loadedParticleInfo = new Map<string, {spec: ParticleSpec, stores: Map<string, UnifiedStore>}>();
   readonly pec: ParticleExecutionHost;
 
   // Volatile storage local to this Arc instance.
@@ -234,18 +270,23 @@ constructor({id, context, pecFactories, slotComposer, loader, storageKey, storag
     return innerArc;
   }
 
-  private async _serializeHandle(handle: StorageProviderBase, context: SerializeContext, id: string): Promise<void> {
-    const type = handle.type.getContainedType() || handle.type;
+  private async _serializeStore(store: UnifiedStore, context: SerializeContext, id: string): Promise<void> {
+    const type = store.type.getContainedType() || store.type;
     if (type instanceof InterfaceType) {
       context.interfaces += type.interfaceInfo.toString() + '\n';
     }
-    const key = this.storageProviderFactory.parseStringAsKey(handle.storageKey);
-    const tags: Set<string> = this.storeTags.get(handle) || new Set();
+    let key: StorageKey | KeyBase;
+    if (typeof store.storageKey === 'string') {
+      key = this.storageProviderFactory.parseStringAsKey(store.storageKey);
+    } else {
+      key = store.storageKey;
+    }
+    const tags: Set<string> = this.storeTags.get(store) || new Set();
     const handleTags = [...tags].map(a => `#${a}`).join(' ');
 
-    const actualHandle = this.activeRecipe.findHandle(handle.id);
+    const actualHandle = this.activeRecipe.findHandle(store.id);
     const originalId = actualHandle ? actualHandle.originalId : null;
-    let combinedId = `'${handle.id}'`;
+    let combinedId = `'${store.id}'`;
     if (originalId) {
       combinedId += `!!'${originalId}'`;
     }
@@ -253,7 +294,7 @@ constructor({id, context, pecFactories, slotComposer, loader, storageKey, storag
     switch (key.protocol) {
       case 'firebase':
       case 'pouchdb':
-        context.handles += `store ${id} of ${handle.type.toString()} ${combinedId} @${handle.version === null ? 0 : handle.version} ${handleTags} at '${handle.storageKey}'\n`;
+        context.handles += `store ${id} of ${store.type.toString()} ${combinedId} @${store.version === null ? 0 : store.version} ${handleTags} at '${store.storageKey}'\n`;
         break;
       case 'volatile': {
         // TODO(sjmiles): emit empty data for stores marked `volatile`: shell will supply data
@@ -261,7 +302,7 @@ constructor({id, context, pecFactories, slotComposer, loader, storageKey, storag
         let serializedData: {storageKey: string}[] | null = [];
         if (!volatile) {
           // TODO: include keys in serialized [big]collections?
-          serializedData = (await handle.toLiteral()).model.map((model) => {
+          serializedData = (await store.toLiteral()).model.map((model) => {
             const {id, value} = model;
             const index = model['index']; // TODO: Invalid Type
 
@@ -284,16 +325,16 @@ constructor({id, context, pecFactories, slotComposer, loader, storageKey, storag
             return result;
           });
         }
-        if (handle.referenceMode && serializedData.length > 0) {
+        if (store.referenceMode && serializedData.length > 0) {
           const storageKey = serializedData[0].storageKey;
           if (!context.dataResources.has(storageKey)) {
             const storeId = `${id}_Data`;
             context.dataResources.set(storageKey, storeId);
             // TODO: can't just reach into the store for the backing Store like this, should be an
             // accessor that loads-on-demand in the storage objects.
-            if (handle instanceof StorageProviderBase) {
-              await handle.ensureBackingStore();
-              await this._serializeHandle(handle.backingStore, context, storeId);
+            if (store instanceof StorageProviderBase) {
+              await store.ensureBackingStore();
+              await this._serializeStore(store.backingStore, context, storeId);
             }
           }
           const storeId = context.dataResources.get(storageKey);
@@ -308,7 +349,7 @@ constructor({id, context, pecFactories, slotComposer, loader, storageKey, storag
           + data.split('\n').map(line => indent + line).join('\n')
           + '\n';
 
-        context.handles += `store ${id} of ${handle.type.toString()} ${combinedId} @${handle.version || 0} ${handleTags} in ${id}Resource\n`;
+        context.handles += `store ${id} of ${store.type.toString()} ${combinedId} @${store.version || 0} ${handleTags} in ${id}Resource\n`;
         break;
       }
       default:
@@ -337,12 +378,12 @@ constructor({id, context, pecFactories, slotComposer, loader, storageKey, storag
       context.resources += `import '${url}'\n`;
     }
 
-    for (const handle of this._stores) {
-      if (!handlesToSerialize.has(handle.id) || contextSet.has(handle.id)) {
+    for (const store of this._stores) {
+      if (!handlesToSerialize.has(store.id) || contextSet.has(store.id)) {
         continue;
       }
 
-      await this._serializeHandle(handle, context, `Store${id++}`);
+      await this._serializeStore(store, context, `Store${id++}`);
     }
 
     return context.resources + context.interfaces + context.handles;
@@ -396,7 +437,12 @@ ${this.activeRecipe.toString()}`;
   // contents of the serialized arc before persisting.
   async persistSerialization(serialization: string): Promise<void> {
     const storage = this.storageProviderFactory;
-    const key = storage.parseStringAsKey(this.storageKey).childKeyForArcInfo();
+    let key: KeyBase | StorageKey;
+    if (typeof this.storageKey === 'string') {
+      key = storage.parseStringAsKey(this.storageKey).childKeyForArcInfo();
+    } else {
+      key = this.storageKey.childKeyForArcInfo();
+    }
     const arcInfoType = new ArcType();
     const store = await storage.connectOrConstruct('store', arcInfoType, key.toString()) as SingletonStorageProvider;
     store.referenceMode = false;
@@ -418,7 +464,7 @@ ${this.activeRecipe.toString()}`;
     });
     await Promise.all(manifest.stores.map(async storeStub => {
       const tags = manifest.storeTags.get(storeStub);
-      const store = await storeStub.inflate();
+      const store: UnifiedStore = await storeStub.inflate();
       arc._registerStore(store, tags);
     }));
     const recipe = manifest.activeRecipe.clone();
@@ -454,8 +500,8 @@ ${this.activeRecipe.toString()}`;
     this.pec.instantiate(recipeParticle, info.stores);
   }
 
-  async _getParticleInstantiationInfo(recipeParticle: Particle): Promise<{spec: ParticleSpec, stores: Map<string, StorageProviderBase>}> {
-    const info = {spec: recipeParticle.spec, stores: new Map<string, StorageProviderBase>()};
+  async _getParticleInstantiationInfo(recipeParticle: Particle): Promise<{spec: ParticleSpec, stores: Map<string, UnifiedStore>}> {
+    const info = {spec: recipeParticle.spec, stores: new Map<string, UnifiedStore>()};
     this.loadedParticleInfo.set(recipeParticle.id.toString(), info);
 
     // if supported, provide particle caching via a BlobUrl representing spec.implFile
@@ -468,7 +514,7 @@ ${this.activeRecipe.toString()}`;
         const store = this.findStoreById(connection.handle.id);
         assert(store, `can't find store of id ${connection.handle.id}`);
         assert(info.spec.handleConnectionMap.get(name) !== undefined, 'can\'t connect handle to a connection that doesn\'t exist');
-        info.stores.set(name, store as StorageProviderBase);
+        info.stores.set(name, store as UnifiedStore);
       }
     }
     return info;
@@ -492,7 +538,7 @@ ${this.activeRecipe.toString()}`;
     return this.idGenerator.newChildId(this.id, component);
   }
 
-  get _stores(): (StorageProviderBase)[] {
+  get _stores(): UnifiedStore[] {
     return [...this.storesById.values()];
   }
 
@@ -505,9 +551,9 @@ ${this.activeRecipe.toString()}`;
                          speculative: true,
                          innerArc: this.isInnerArc,
                          inspectorFactory: this.inspectorFactory});
-    const storeMap: Map<StorageProviderBase, StorageProviderBase> = new Map();
+    const storeMap: Map<UnifiedStore, UnifiedStore> = new Map();
     for (const store of this._stores) {
-      const clone = await arc.storageProviderFactory.construct(store.id, store.type, 'volatile');
+      const clone = await arc.storageProviderFactory.construct(store.id, store.type, 'volatile') as UnifiedStore;
       await clone.cloneFrom(store);
       storeMap.set(store, clone);
       if (this.storeDescriptions.has(store)) {
@@ -516,7 +562,7 @@ ${this.activeRecipe.toString()}`;
     }
 
     this.loadedParticleInfo.forEach((info, id) => {
-      const stores: Map<string, StorageProviderBase> = new Map();
+      const stores: Map<string, UnifiedStore> = new Map();
       info.stores.forEach((store, name) => stores.set(name, storeMap.get(store)));
       arc.loadedParticleInfo.set(id, {spec: info.spec, stores});
     });
@@ -639,9 +685,13 @@ ${this.activeRecipe.toString()}`;
         assert(storageKey, `couldn't find storage key for handle '${recipeHandle}'`);
         const type = recipeHandle.type.resolvedType();
         assert(type.isResolved());
-        const store = await this.storageProviderFactory.connect(recipeHandle.id, type, storageKey);
-        assert(store, `store '${recipeHandle.id}' was not found (${storageKey})`);
-        this._registerStore(store, recipeHandle.tags);
+        if (typeof storageKey === 'string') {
+          const store = await this.storageProviderFactory.connect(recipeHandle.id, type, storageKey);
+          assert(store, `store '${recipeHandle.id}' was not found (${storageKey})`);
+          this._registerStore(store, recipeHandle.tags);
+        } else {
+          throw new Error('Need to implement storageNG code path here!');
+        }
       }
     }
 
@@ -664,7 +714,7 @@ ${this.activeRecipe.toString()}`;
     }
   }
 
-  async createStore(type: Type, name?: string, id?: string, tags?: string[], storageKey?: string): Promise<StorageProviderBase> {
+  async createStore(type: Type, name?: string, id?: string, tags?: string[], storageKey?: string | StorageKey): Promise<UnifiedStore> {
     assert(type instanceof Type, `can't createStore with type ${type} that isn't a Type`);
 
     if (type instanceof RelationType) {
@@ -675,11 +725,12 @@ ${this.activeRecipe.toString()}`;
       id = this.generateID().toString();
     }
 
-    if (storageKey == undefined && this.storageKey) {
-      storageKey =
-          this.storageProviderFactory.parseStringAsKey(this.storageKey)
-              .childKeyForHandle(id)
-              .toString();
+    if (storageKey == undefined) {
+      if (typeof this.storageKey === 'string') {
+        storageKey = this.storageProviderFactory.parseStringAsKey(this.storageKey).childKeyForHandle(id).toString();
+      } else if (this.storageKey) {
+        storageKey = this.storageKey.childKeyForHandle(id);
+      }
     }
 
     // TODO(sjmiles): use `volatile` for volatile stores
@@ -688,15 +739,22 @@ ${this.activeRecipe.toString()}`;
       storageKey = 'volatile';
     }
 
-    const store = await this.storageProviderFactory.construct(id, type, storageKey);
-    assert(store, `failed to create store with id [${id}]`);
-    store.name = name;
+    if (typeof storageKey === 'string') {
+      const store = await this.storageProviderFactory.construct(id, type, storageKey);
+      assert(store, `failed to create store with id [${id}]`);
+      store.name = name;
 
-    this._registerStore(store, tags);
-    return store;
+      this._registerStore(store, tags);
+      return store;
+    } else {
+      const store = new Store(storageKey, Exists.ShouldCreate, type, id, name);
+      
+      this._registerStore(store, tags);
+      return store;
+    }
   }
 
-  _registerStore(store: StorageProviderBase, tags?: string[]): void {
+  _registerStore(store: UnifiedStore, tags?: string[]): void {
     assert(!this.storesById.has(store.id), `Store already registered '${store.id}'`);
     tags = tags || [];
     tags = Array.isArray(tags) ? tags : [tags];
@@ -712,7 +770,7 @@ ${this.activeRecipe.toString()}`;
     Runtime.getRuntime().registerStore(store, tags);
   }
 
-  _tagStore(store: StorageProviderBase, tags: Set<string>): void {
+  _tagStore(store: UnifiedStore, tags: Set<string>): void {
     assert(this.storesById.has(store.id) && this.storeTags.has(store), `Store not registered '${store.id}'`);
     const storeTags = this.storeTags.get(store);
     tags = tags || new Set();
@@ -758,7 +816,7 @@ ${this.activeRecipe.toString()}`;
     return null;
   }
 
-  findStoresByType(type: Type, options?: {tags: string[]}): StorageProviderBase[] {
+  findStoresByType(type: Type, options?: {tags: string[]}): UnifiedStore[] {
     const typeKey = Arc._typeToKey(type);
     let stores = [...this.storesById.values()].filter(handle => {
       if (typeKey) {
@@ -790,7 +848,7 @@ ${this.activeRecipe.toString()}`;
       type, [{type: s.type, direction: (s.type instanceof InterfaceType) ? 'host' : 'inout'}]));
   }
 
-  findStoreById(id: string): StorageProviderBase | StorageStub {
+  findStoreById(id: string): UnifiedStore | StorageStub {
     const store = this.storesById.get(id);
     if (store == null) {
       return this._context.findStoreById(id);
@@ -821,7 +879,7 @@ ${this.activeRecipe.toString()}`;
     return versionById;
   }
 
-  keyForId(id: string): string {
+  keyForId(id: string): string | StorageKey {
     return this.storageKeys[id];
   }
 

--- a/src/runtime/description.ts
+++ b/src/runtime/description.ts
@@ -10,7 +10,7 @@
 
 import {assert} from '../platform/assert-web.js';
 
-import {Arc} from './arc.js';
+import {Arc, UnifiedStore} from './arc.js';
 import {DescriptionFormatter, DescriptionValue, ParticleDescription} from './description-formatter.js';
 import {Particle} from './recipe/particle.js';
 import {Relevance} from './relevance.js';
@@ -155,7 +155,7 @@ export class Description {
     return {};
   }
 
-  private static async _prepareStoreValue(store: StorageProviderBase | StorageStub): Promise<DescriptionValue|undefined> {
+  private static async _prepareStoreValue(store: UnifiedStore | StorageStub): Promise<DescriptionValue|undefined> {
     if (!store || (store instanceof StorageStub)) {
       return undefined;
     }

--- a/src/runtime/recipe/handle.ts
+++ b/src/runtime/recipe/handle.ts
@@ -22,6 +22,7 @@ import {TypeChecker} from './type-checker.js';
 import {compareArrays, compareComparables, compareStrings, Comparable} from './comparable.js';
 import {Fate, Direction} from '../manifest-ast-nodes.js';
 import {ClaimIsTag, Claim} from '../particle-claim.js';
+import {StorageKey} from '../storageNG/storage-key.js';
 
 export class Handle implements Comparable<Handle> {
   private readonly _recipe: Recipe;
@@ -36,7 +37,7 @@ export class Handle implements Comparable<Handle> {
   private _originalId: string | null = null;
   private _connections: HandleConnection[] = [];
   private _mappedType: Type | undefined = undefined;
-  private _storageKey: string | undefined = undefined;
+  private _storageKey: string | StorageKey | undefined = undefined;
   private _pattern: string | undefined = undefined;
   // Value assigned in the immediate mode, E.g. hostedParticle = ShowProduct
   // Currently only supports ParticleSpec.
@@ -183,7 +184,7 @@ export class Handle implements Comparable<Handle> {
     }
     this._id = id;
   }
-  mapToStorage(storage: {id: string, type: Type, originalId?: string, storageKey?: string, claims?: ClaimIsTag[]}) {
+  mapToStorage(storage: {id: string, type: Type, originalId?: string, storageKey?: string | StorageKey, claims?: ClaimIsTag[]}) {
     if (!storage) {
       throw new Error(`Cannot map to undefined storage`);
     }
@@ -199,7 +200,7 @@ export class Handle implements Comparable<Handle> {
   set localName(name: string) { this._localName = name; }
   get connections() { return this._connections; } // HandleConnection*
   get storageKey() { return this._storageKey; }
-  set storageKey(key: string) { this._storageKey = key; }
+  set storageKey(key: string | StorageKey) { this._storageKey = key; }
   get pattern() { return this._pattern; }
   set pattern(pattern: string) { this._pattern = pattern; }
   get mappedType() { return this._mappedType; }

--- a/src/runtime/storage/storage-provider-base.ts
+++ b/src/runtime/storage/storage-provider-base.ts
@@ -19,6 +19,7 @@ import {Store, BigCollectionStore, CollectionStore, SingletonStore} from '../sto
 import {PropagatedException} from '../arc-exceptions.js';
 import {Dictionary, Consumer} from '../hot.js';
 import {ClaimIsTag} from '../particle-claim.js';
+import {UnifiedStore} from '../arc.js';
 
 enum EventKind {
   change = 'Change'
@@ -107,7 +108,7 @@ export class ChangeEvent {
 /**
  * Docs TBD
  */
-export abstract class StorageProviderBase implements Comparable<StorageProviderBase>, Store {
+export abstract class StorageProviderBase implements Comparable<StorageProviderBase>, Store, UnifiedStore {
   private listeners: Map<EventKind, Map<Callback, {target: {}}>>;
   private nextLocalID: number;
   private readonly _type: Type;
@@ -197,7 +198,7 @@ export abstract class StorageProviderBase implements Comparable<StorageProviderB
     }
   }
 
-  _compareTo(other: StorageProviderBase): number {
+  _compareTo(other: UnifiedStore): number {
     let cmp;
     cmp = compareStrings(this.name, other.name);
     if (cmp !== 0) return cmp;
@@ -249,7 +250,7 @@ export abstract class StorageProviderBase implements Comparable<StorageProviderB
    */
   abstract async toLiteral(): Promise<{version: number, model: SerializedModelEntry[]}>;
 
-  abstract cloneFrom(store: StorageProviderBase | StorageStub);
+  abstract cloneFrom(store: UnifiedStore | StorageStub): void;
 
   // TODO(shans): remove this when it's possible to.
   abstract async ensureBackingStore();

--- a/src/runtime/storage/synthetic-storage.ts
+++ b/src/runtime/storage/synthetic-storage.ts
@@ -169,7 +169,11 @@ class SyntheticCollection extends StorageProviderBase implements CollectionStora
     this.model = [];
     for (const handle of handles || []) {
       if (this.storageFactory.isPersistent(handle.storageKey)) {
-        this.model.push(new ArcHandle(handle.id, handle.storageKey, handle.mappedType, handle.tags));
+        if (typeof handle.storageKey === 'string') {
+          this.model.push(new ArcHandle(handle.id, handle.storageKey, handle.mappedType, handle.tags));
+        } else {
+          throw new Error(`Can't use old storage stack with NG StorageKey objects`);
+        }
       }
     }
     if (fireEvent) {

--- a/src/runtime/storageNG/storage-key.ts
+++ b/src/runtime/storageNG/storage-key.ts
@@ -18,4 +18,12 @@ export abstract class StorageKey {
   abstract toString(): string;
 
   abstract childWithComponent(component: string): StorageKey; 
+
+  childKeyForArcInfo() {
+    return this.childWithComponent('arc-info');
+  }
+
+  childKeyForHandle(id: string) {
+    return this.childWithComponent(`handle/${id}`);
+  }
 }

--- a/src/runtime/storageNG/store.ts
+++ b/src/runtime/storageNG/store.ts
@@ -15,6 +15,8 @@ import {StorageKey} from './storage-key.js';
 import {StoreInterface, StorageMode, ActiveStore, ProxyMessageType, ProxyMessage, ProxyCallback} from './store-interface.js';
 import {DirectStore} from './direct-store.js';
 import {ReferenceModeStore, ReferenceModeStorageKey} from './reference-mode-store.js';
+import {UnifiedStore} from '../arc.js';
+import {Consumer} from '../hot.js';
 
 export {StorageMode, ActiveStore, ProxyMessageType, ProxyMessage, ProxyCallback};
 
@@ -26,8 +28,31 @@ type StoreConstructor = {
 // inactive - it will not connect to a driver, will not accept connections from
 // StorageProxy objects, and no data will be read or written.
 //
-// Calling 'activate() will generate an interactive store and return it.
-export class Store<T extends CRDTTypeRecord> implements StoreInterface<T> {
+// Calling 'activate()' will generate an interactive store and return it.
+export class Store<T extends CRDTTypeRecord> implements StoreInterface<T>, UnifiedStore {
+  source: string;
+  _compareTo(other: UnifiedStore): number {
+    throw new Error('Method not implemented.');
+  }
+  toString(tags: string[]): string {
+    throw new Error('Method not implemented.');
+  }
+
+  // tslint:disable-next-line no-any
+  async toLiteral(): Promise<any> {
+    throw new Error('Method not implemented.');
+  }
+
+  cloneFrom(store: UnifiedStore): void {
+    throw new Error('Method not implemented.');
+  }
+  modelForSynchronization(): {} {
+    throw new Error('Method not implemented.');
+  }
+  on(type: string, fn: Consumer<{}>, target: {}): void {
+    throw new Error('Method not implemented.');
+  }
+  description: string;
   readonly storageKey: StorageKey;
   exists: Exists;
   readonly type: Type;
@@ -62,5 +87,10 @@ export class Store<T extends CRDTTypeRecord> implements StoreInterface<T> {
     const activeStore = await constructor.construct<T>(this.storageKey, this.exists, this.type, this.mode);
     this.exists = Exists.ShouldExist;
     return activeStore;
+  }
+
+  // TODO(shans): DELETEME once we've switched to this storage stack
+  get referenceMode() {
+    return this.mode === StorageMode.ReferenceMode;
   }
 }

--- a/src/runtime/tests/arc-test.ts
+++ b/src/runtime/tests/arc-test.ts
@@ -60,6 +60,13 @@ function getSingletonHandle(store: StorageProviderBase): Singleton {
 // TODO(lindner): add fireBase
 //  const testUrl = 'firebase://arcs-storage-test.firebaseio.com/AIzaSyBLqThan3QCOICj0JZ-nEwk27H4gmnADP8/firebase-storage-test/arc-1';
 
+describe('Arc new storage', () => {
+  it('applies existing stores to a particle', async () => {
+    const runtime = Runtime.newForNodeTesting();
+    const arc = runtime.newArc('test', arcId => new VolatileStorageKey(arcId, ''));
+  });
+});
+
 ['volatile://', 'pouchdb://memory/user-test/'].forEach((storageKeyPrefix) => {
 describe('Arc ' + storageKeyPrefix, () => {
   it('idle can safely be called multiple times ', async () => {
@@ -76,8 +83,8 @@ describe('Arc ' + storageKeyPrefix, () => {
     }
 
     const {arc, recipe, Foo, Bar} = await setup(storageKeyPrefix);
-    const fooStore = await arc.createStore(Foo.type, undefined, 'test:1');
-    const barStore = await arc.createStore(Bar.type, undefined, 'test:2');
+    const fooStore = await arc.createStore(Foo.type, undefined, 'test:1') as StorageProviderBase;
+    const barStore = await arc.createStore(Bar.type, undefined, 'test:2') as StorageProviderBase;
     await getSingletonHandle(fooStore).set(new Foo({value: 'a Foo'}));
     recipe.handles[0].mapToStorage(fooStore);
     recipe.handles[1].mapToStorage(barStore);
@@ -93,7 +100,7 @@ describe('Arc ' + storageKeyPrefix, () => {
     }
 
     const {arc, recipe, Foo, Bar} = await setup(storageKeyPrefix);
-    const fooStore = await arc.createStore(Foo.type, undefined, 'test:1');
+    const fooStore = await arc.createStore(Foo.type, undefined, 'test:1') as StorageProviderBase;
     const barStore = await arc.createStore(Bar.type, undefined, 'test:2');
     recipe.handles[0].mapToStorage(fooStore);
     recipe.handles[1].mapToStorage(barStore);
@@ -136,9 +143,9 @@ describe('Arc ' + storageKeyPrefix, () => {
     const arc = new Arc({slotComposer: new FakeSlotComposer(), loader, context: manifest, id, storageKey});
 
     const thingClass = manifest.findSchemaByName('Thing').entityClass();
-    const aStore = await arc.createStore(thingClass.type, 'aStore', 'test:1');
+    const aStore = await arc.createStore(thingClass.type, 'aStore', 'test:1') as StorageProviderBase;
     const bStore = await arc.createStore(thingClass.type, 'bStore', 'test:2');
-    const cStore = await arc.createStore(thingClass.type, 'cStore', 'test:3');
+    const cStore = await arc.createStore(thingClass.type, 'cStore', 'test:3') as StorageProviderBase;
     const dStore = await arc.createStore(thingClass.type, 'dStore', 'test:4');
 
     const recipe = manifest.recipes[0];
@@ -253,9 +260,9 @@ describe('Arc ' + storageKeyPrefix, () => {
     const arc = new Arc({slotComposer: new FakeSlotComposer(), loader, context: manifest, id, storageKey});
 
     const thingClass = manifest.findSchemaByName('Thing').entityClass();
-    const aStore = await arc.createStore(thingClass.type, 'aStore', 'test:1');
+    const aStore = await arc.createStore(thingClass.type, 'aStore', 'test:1') as StorageProviderBase;
     const bStore = await arc.createStore(thingClass.type, 'bStore', 'test:2');
-    const cStore = await arc.createStore(thingClass.type, 'cStore', 'test:3');
+    const cStore = await arc.createStore(thingClass.type, 'cStore', 'test:3') as StorageProviderBase;
     const dStore = await arc.createStore(thingClass.type, 'dStore', 'test:4');
 
     const recipe = manifest.recipes[0];
@@ -396,9 +403,9 @@ describe('Arc ' + storageKeyPrefix, () => {
     const arc = new Arc({slotComposer: new FakeSlotComposer(), loader, context: manifest, id, storageKey});
 
     const thingClass = manifest.findSchemaByName('Thing').entityClass();
-    const aStore = await arc.createStore(thingClass.type, 'aStore', 'test:1');
+    const aStore = await arc.createStore(thingClass.type, 'aStore', 'test:1') as StorageProviderBase;
     const bStore = await arc.createStore(thingClass.type, 'bStore', 'test:2');
-    const cStore = await arc.createStore(thingClass.type, 'cStore', 'test:3');
+    const cStore = await arc.createStore(thingClass.type, 'cStore', 'test:3') as StorageProviderBase;
     const dStore = await arc.createStore(thingClass.type, 'dStore', 'test:4');
 
     const recipe = manifest.recipes[0];
@@ -497,9 +504,9 @@ describe('Arc ' + storageKeyPrefix, () => {
     const arc = new Arc({slotComposer: new FakeSlotComposer(), loader, context: manifest, id, storageKey});
 
     const thingClass = manifest.findSchemaByName('Thing').entityClass();
-    const aStore = await arc.createStore(thingClass.type, 'aStore', 'test:1');
+    const aStore = await arc.createStore(thingClass.type, 'aStore', 'test:1') as StorageProviderBase;
     const bStore = await arc.createStore(thingClass.type, 'bStore', 'test:2');
-    const cStore = await arc.createStore(thingClass.type, 'cStore', 'test:3');
+    const cStore = await arc.createStore(thingClass.type, 'cStore', 'test:3') as StorageProviderBase;
     const dStore = await arc.createStore(thingClass.type, 'dStore', 'test:4');
 
     const recipe = manifest.recipes[0];
@@ -549,9 +556,9 @@ describe('Arc ' + storageKeyPrefix, () => {
     const arc = new Arc({slotComposer: new FakeSlotComposer(), loader, context: manifest, id, storageKey});
 
     const thingClass = manifest.findSchemaByName('Thing').entityClass();
-    const aStore = await arc.createStore(thingClass.type, 'aStore', 'test:1');
+    const aStore = await arc.createStore(thingClass.type, 'aStore', 'test:1') as StorageProviderBase;
     const bStore = await arc.createStore(thingClass.type, 'bStore', 'test:2');
-    const cStore = await arc.createStore(thingClass.type, 'cStore', 'test:3');
+    const cStore = await arc.createStore(thingClass.type, 'cStore', 'test:3') as StorageProviderBase;
     const dStore = await arc.createStore(thingClass.type, 'dStore', 'test:4');
 
     const recipe = manifest.recipes[0];

--- a/src/runtime/tests/data-layer-test.ts
+++ b/src/runtime/tests/data-layer-test.ts
@@ -13,7 +13,7 @@ import {Arc} from '../arc.js';
 import {handleFor, Collection} from '../handle.js';
 import {Loader} from '../loader.js';
 import {Schema} from '../schema.js';
-import {CollectionStorageProvider} from '../storage/storage-provider-base.js';
+import {CollectionStorageProvider, StorageProviderBase} from '../storage/storage-provider-base.js';
 import {FakeSlotComposer} from '../testing/fake-slot-composer.js';
 import {EntityType} from '../type.js';
 import {ArcId, IdGenerator} from '../id.js';
@@ -28,7 +28,7 @@ describe('entity', () => {
 
     const collectionType = new EntityType(schema).collectionOf();
     
-    const storage = await arc.createStore(collectionType);
+    const storage = await arc.createStore(collectionType) as StorageProviderBase;
     const handle = handleFor(storage, IdGenerator.newSession()) as Collection;
     await handle.store(entity);
 

--- a/src/runtime/tests/description-test.ts
+++ b/src/runtime/tests/description-test.ts
@@ -17,7 +17,7 @@ import {Loader} from '../loader.js';
 import {Manifest} from '../manifest.js';
 import {Recipe} from '../recipe/recipe.js';
 import {Relevance} from '../relevance.js';
-import {CollectionStorageProvider, SingletonStorageProvider} from '../storage/storage-provider-base.js';
+import {CollectionStorageProvider, SingletonStorageProvider, StorageProviderBase} from '../storage/storage-provider-base.js';
 import {FakeSlotComposer} from '../testing/fake-slot-composer.js';
 import {EntityType} from '../type.js';
 import {Id, ArcId, IdGenerator} from '../id.js';
@@ -812,7 +812,7 @@ recipe
     assert.isTrue(recipe.isResolved());
     const arc = createTestArc(recipe, manifest);
     const fooStore = await arc.createStore(fooType, undefined, 'test:1') as SingletonStorageProvider;
-    const descriptionStore = await arc.createStore(descriptionType.collectionOf(), undefined, 'test:2');
+    const descriptionStore = await arc.createStore(descriptionType.collectionOf(), undefined, 'test:2') as StorageProviderBase;
 
     return {
       arc,

--- a/src/runtime/tests/handle-test.ts
+++ b/src/runtime/tests/handle-test.ts
@@ -13,7 +13,7 @@ import {handleFor, Collection, Singleton} from '../handle.js';
 import {Loader} from '../loader.js';
 import {Manifest} from '../manifest.js';
 import {Schema} from '../schema.js';
-import {CollectionStorageProvider, SingletonStorageProvider} from '../storage/storage-provider-base.js';
+import {CollectionStorageProvider, SingletonStorageProvider, StorageProviderBase} from '../storage/storage-provider-base.js';
 import {EntityType, InterfaceType} from '../type.js';
 import {Id, ArcId, IdGenerator} from '../id.js';
 import {NoOpStorageProxy} from '../storage-proxy.js';
@@ -76,7 +76,7 @@ describe('Handle', () => {
 
     // tslint:disable-next-line: variable-name
     const Foo = manifest.schemas.Foo.entityClass();
-    const fooHandle = handleFor(await arc.createStore(Foo.type.collectionOf()), IdGenerator.newSession()) as Collection;
+    const fooHandle = handleFor(await arc.createStore(Foo.type.collectionOf()) as StorageProviderBase, IdGenerator.newSession()) as Collection;
 
     await fooHandle.store(new Foo({value: 'a Foo'}, 'first'));
     await fooHandle.store(new Foo({value: 'another Foo'}, 'second'));
@@ -89,7 +89,7 @@ describe('Handle', () => {
 
     // tslint:disable-next-line: variable-name
     const Foo = manifest.schemas.Foo.entityClass();
-    const fooHandle = handleFor(await arc.createStore(Foo.type.collectionOf()), IdGenerator.newSession()) as Collection;
+    const fooHandle = handleFor(await arc.createStore(Foo.type.collectionOf()) as StorageProviderBase, IdGenerator.newSession()) as Collection;
 
     await fooHandle.store(new Foo({value: '1'}, 'id1'));
     await fooHandle.store(new Foo({value: '2'}, 'id1'));
@@ -102,7 +102,7 @@ describe('Handle', () => {
 
     // tslint:disable-next-line: variable-name
     const Foo = manifest.schemas.Foo.entityClass();
-    const fooHandle = handleFor(await arc.createStore(Foo.type), IdGenerator.newSession()) as Singleton;
+    const fooHandle = handleFor(await arc.createStore(Foo.type) as StorageProviderBase, IdGenerator.newSession()) as Singleton;
 
     await fooHandle.set(new Foo({value: '1'}, 'id1'));
     await fooHandle.set(new Foo({value: '2'}, 'id1'));
@@ -115,7 +115,7 @@ describe('Handle', () => {
 
     // tslint:disable-next-line: variable-name
     const Foo = manifest.schemas.Foo.entityClass();
-    const fooStorage = await arc.createStore(Foo.type);
+    const fooStorage = await arc.createStore(Foo.type) as StorageProviderBase;
     const fooHandle = handleFor(fooStorage, IdGenerator.newSession()) as Singleton;
 
     assert(!(fooHandle.storage instanceof NoOpStorageProxy));

--- a/src/runtime/tests/runtime-manifest-integration-test.ts
+++ b/src/runtime/tests/runtime-manifest-integration-test.ts
@@ -12,6 +12,7 @@ import {assert} from '../../platform/chai-web.js';
 import {handleFor, Singleton} from '../handle.js';
 import {manifestTestSetup} from '../testing/manifest-integration-test-setup.js';
 import {IdGenerator} from '../id.js';
+import {StorageProviderBase} from '../storage/storage-provider-base.js';
 
 describe('runtime manifest integration', () => {
   it('can produce a recipe that can be instantiated in an arc', async () => {
@@ -21,7 +22,7 @@ describe('runtime manifest integration', () => {
     const type = recipe.handles[0].type;
     const [store] = arc.findStoresByType(type);
 
-    const handle = handleFor(store, IdGenerator.newSession()) as Singleton;
+    const handle = handleFor(store as StorageProviderBase, IdGenerator.newSession()) as Singleton;
     // TODO: This should not be necessary.
     type.maybeEnsureResolved();
     const result = await handle.get();

--- a/src/tests/particles/products-test.ts
+++ b/src/tests/particles/products-test.ts
@@ -16,6 +16,7 @@ import {Manifest} from '../../runtime/manifest.js';
 import {Runtime} from '../../runtime/runtime.js';
 import {MockSlotComposer} from '../../runtime/testing/mock-slot-composer.js';
 import {FakeSlotComposer} from '../../runtime/testing/fake-slot-composer.js';
+import {StorageProviderBase} from '../../runtime/storage/storage-provider-base.js';
 
 describe('products test', () => {
   const manifestFilename = './src/tests/particles/artifacts/products-test.recipes';
@@ -65,7 +66,7 @@ describe('products test', () => {
               // fix. It's particularly bad here as there's no guarantee that the backingStore
               // exists - should await ensureBackingStore() before accessing it.
               const reference = arc._stores[0]['_model'].getValue(content.model.items.models[0].id);
-              const store = arc._stores[0].backingStore;
+              const store = (arc._stores[0] as StorageProviderBase).backingStore;
               assert.equal(store.storageKey, reference.storageKey);
               assert.equal('Harry Potter', store['_model'].getValue(reference.id).rawData.name);
             }


### PR DESCRIPTION
Lots of callsites migrated to use the UnifiedStore interface instead of
talking to the old storage directly. This will let us migrate to the new
storage more easily.

Cloned from Shane's PR #3633