### PR TITLE
Improve error reporting for in-particle syntax-errors

### DIFF
--- a/src/platform/loader-web.ts
+++ b/src/platform/loader-web.ts
@@ -71,11 +71,13 @@ export class PlatformLoader extends PlatformLoaderBase {
     try {
       // import (execute) particle code
       importScripts(url);
-    } catch (x) {
-      error(`Error loading Particle from [${path}]`, x);
+    } catch (e) {
+      e.message = `Error loading Particle from '${path}': ${e.message}`;
+      throw e;
+    } finally {
+      // clean up
+      delete self['defineParticle'];
     }
-    // clean up
-    delete self['defineParticle'];
     return result;
   }
   provisionLogger(fileName: string) {


### PR DESCRIPTION
Fixes #3603, at least that's the intention.

Before:
<img width="1094" alt="Screen Shot 2019-09-30 at 10 51 11 pm" src="https://user-images.githubusercontent.com/26159485/65937547-16b4d600-e3d5-11e9-8dab-a7555e855a0e.png">

After:
<img width="1376" alt="Screen Shot 2019-09-30 at 10 47 18 pm" src="https://user-images.githubusercontent.com/26159485/65937551-19afc680-e3d5-11e9-9172-0bc4e67088aa.png">
