### PR TITLE
Throw import error on failed particle import

### DIFF
--- a/src/platform/loader-web.ts
+++ b/src/platform/loader-web.ts
@@ -68,14 +68,22 @@ export class PlatformLoader extends PlatformLoaderBase {
       // multiple particles not supported: last particle wins
       result = particleWrapper;
     };
+    let err;
     try {
       // import (execute) particle code
       importScripts(url);
     } catch (x) {
-      error(`Error loading Particle from [${path}]`, x);
+      // Note: This error not thrown here to ensure that defineParticle is
+      // deleted.
+      // TODO(jopra): Throwing should ensure that self is never used.
+      // Can this be simplified?
+      err = new Error(`Failed to load particle from '${path}'\n` + x);
     }
     // clean up
     delete self['defineParticle'];
+    if (err) {
+      throw err;
+    }
     return result;
   }
   provisionLogger(fileName: string) {

--- a/src/platform/loader-web.ts
+++ b/src/platform/loader-web.ts
@@ -68,21 +68,14 @@ export class PlatformLoader extends PlatformLoaderBase {
       // multiple particles not supported: last particle wins
       result = particleWrapper;
     };
-    let err;
     try {
       // import (execute) particle code
       importScripts(url);
     } catch (x) {
-      // Note: This error not thrown here to ensure that defineParticle is
-      // deleted.
-      // TODO(jopra): Throwing should ensure that self is never used.
-      // Can this be simplified?
-      err = new Error(`Failed to load particle from '${path}'\n` + x);
-    }
-    // clean up
-    delete self['defineParticle'];
-    if (err) {
-      throw err;
+      throw new Error(`Failed to load particle from '${path}'\n` + x);
+    } finally {
+      // clean up
+      delete self['defineParticle'];
     }
     return result;
   }

--- a/src/runtime/particle-execution-context.ts
+++ b/src/runtime/particle-execution-context.ts
@@ -320,9 +320,6 @@ export class ParticleExecutionContext {
       particle.setCapabilities(this.capabilities(false));
     } else {
       const clazz = await this.loader.loadParticleClass(spec);
-      if (!clazz) {
-        return Promise.reject(new Error(`Unknown error loading particle ${id} ${spec.name}`));
-      }
       particle = new clazz();
       particle.setCapabilities(this.capabilities(true));
     }


### PR DESCRIPTION
Working on improving the error messages when importing particles that are somehow malformed.

Discovered in https://github.com/PolymerLabs/arcs/issues/3603.