### PR TITLE
Converted UnifiedStore interface to base class

### DIFF
--- a/src/devtools-connector/arc-stores-fetcher.ts
+++ b/src/devtools-connector/arc-stores-fetcher.ts
@@ -8,13 +8,14 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {Arc, UnifiedStore} from '../runtime/arc.js';
+import {Arc} from '../runtime/arc.js';
 import {ArcDevtoolsChannel} from './abstract-devtools-channel.js';
 import {Manifest} from '../runtime/manifest.js';
 import {StorageStub} from '../runtime/storage-stub.js';
-import {StorageProviderBase, SingletonStorageProvider, CollectionStorageProvider} from '../runtime/storage/storage-provider-base.js';
+import {SingletonStorageProvider, CollectionStorageProvider} from '../runtime/storage/storage-provider-base.js';
 import {Type} from '../runtime/type.js';
 import {StorageKey} from '../runtime/storageNG/storage-key.js';
+import {UnifiedStore} from '../runtime/storageNG/unified-store.js';
 
 type Result = {
   name: string,
@@ -31,7 +32,7 @@ export class ArcStoresFetcher {
   private arc: Arc;
   private arcDevtoolsChannel: ArcDevtoolsChannel;
   private watchedHandles: Set<string> = new Set();
-  
+
   constructor(arc: Arc, arcDevtoolsChannel: ArcDevtoolsChannel) {
     this.arc = arc;
     this.arcDevtoolsChannel = arcDevtoolsChannel;

--- a/src/planning/strategies/assign-handles.ts
+++ b/src/planning/strategies/assign-handles.ts
@@ -10,11 +10,9 @@
 
 import {assert} from '../../platform/assert-web.js';
 import {RecipeUtil} from '../../runtime/recipe/recipe-util.js';
-import {Recipe} from '../../runtime/recipe/recipe.js';
-import {StorageProviderBase} from '../../runtime/storage/storage-provider-base.js';
 import {StrategizerWalker, Strategy} from '../strategizer.js';
 import {StorageStub} from '../../runtime/storage-stub.js';
-import {UnifiedStore} from '../../runtime/arc.js';
+import {UnifiedStore} from '../../runtime/storageNG/unified-store.js';
 
 export class AssignHandles extends Strategy {
   async generate(inputParams) {

--- a/src/planning/strategies/search-tokens-to-handles.ts
+++ b/src/planning/strategies/search-tokens-to-handles.ts
@@ -8,12 +8,10 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {Arc, UnifiedStore} from '../../runtime/arc.js';
 import {RecipeUtil} from '../../runtime/recipe/recipe-util.js';
-import {Recipe} from '../../runtime/recipe/recipe.js';
 import {StrategizerWalker, Strategy} from '../strategizer.js';
-import {StorageProviderBase} from '../../runtime/storage/storage-provider-base.js';
 import {StorageStub} from '../../runtime/storage-stub.js';
+import {UnifiedStore} from '../../runtime/storageNG/unified-store.js';
 
 export class SearchTokensToHandles extends Strategy {
 

--- a/src/runtime/api-channel.ts
+++ b/src/runtime/api-channel.ts
@@ -9,8 +9,8 @@
  */
 
 import {assert} from '../platform/assert-web.js';
-
-import {Arc, UnifiedStore} from './arc.js';
+import {Arc} from './arc.js';
+import {UnifiedStore} from './storageNG/unified-store.js';
 import {ArcInspector} from './arc-inspector.js';
 import {Handle} from './handle.js';
 import {ParticleSpec} from './particle-spec.js';

--- a/src/runtime/arc.ts
+++ b/src/runtime/arc.ts
@@ -14,7 +14,7 @@ import {ArcInspector, ArcInspectorFactory} from './arc-inspector.js';
 import {FakePecFactory} from './fake-pec-factory.js';
 import {Id, IdGenerator, ArcId} from './id.js';
 import {Loader} from './loader.js';
-import {Runnable, Consumer} from './hot.js';
+import {Runnable} from './hot.js';
 import {Manifest} from './manifest.js';
 import {MessagePort} from './message-channel.js';
 import {Modality} from './modality.js';
@@ -38,8 +38,9 @@ import {Runtime} from './runtime.js';
 import {VolatileMemory, VolatileStorageDriverProvider} from './storageNG/drivers/volatile.js';
 import {DriverFactory, Exists} from './storageNG/drivers/driver-factory.js';
 import {StorageKey} from './storageNG/storage-key.js';
-import {Store, StorageMode} from './storageNG/store.js';
+import {Store} from './storageNG/store.js';
 import {KeyBase} from './storage/key-base.js';
+import {UnifiedStore} from './storageNG/unified-store.js';
 
 export type ArcOptions = Readonly<{
   id: Id;
@@ -67,39 +68,6 @@ type DeserializeArcOptions = Readonly<{
 }>;
 
 type SerializeContext = {handles: string, resources: string, interfaces: string, dataResources: Map<string, string>};
-
-/**
- * This is a temporary interface used to unify old-style stores (storage/StorageProviderBase) and new-style stores (storageNG/Store).
- * We should be able to remove this once we've switched across to the NG stack.
- *
- * Note that for old-style stores, StorageStubs are used *sometimes* to represent storage which isn't activated. For new-style stores,
- * Store itself represents an inactive store, and needs to be activated using activate(). This will present some integration
- * challenges :)
- *
- * Note also that old-style stores use strings for Storage Keys, while NG storage uses storageNG/StorageKey subclasses. This provides
- * a simple test for determining whether a store is old or new.
- */
-export interface UnifiedStore {
-  id: string;
-  name: string;
-  source: string;
-  type: Type;
-  storageKey: string | StorageKey;
-  version?: number; // TODO(shans): This needs to be a version vector for new storage.
-  referenceMode: boolean;
-  _compareTo(other: UnifiedStore): number;
-  toString(tags: string[]): string; // TODO(shans): This shouldn't be called toString as toString doesn't take arguments.
-  // TODO(shans): toLiteral is currently used in _serializeStore, during recipe serialization. It's used when volatile
-  // stores need to be written out as resources into the manifest. Problem is, it expects a particular CRDT model shape;
-  // for new storage we probably need to extract the model from the store instead and have the CRDT directly produce a
-  // JSON representation for insertion into the serialization.
-  // tslint:disable-next-line no-any
-  toLiteral: () => Promise<any>;
-  cloneFrom(store: UnifiedStore): void;
-  modelForSynchronization(): {};
-  on(type: string, fn: Consumer<{}>, target: {}): void;
-  description: string;
-}
 
 export class Arc {
   private readonly _context: Manifest;

--- a/src/runtime/description.ts
+++ b/src/runtime/description.ts
@@ -9,8 +9,8 @@
  */
 
 import {assert} from '../platform/assert-web.js';
-
-import {Arc, UnifiedStore} from './arc.js';
+import {Arc} from './arc.js';
+import {UnifiedStore} from './storageNG/unified-store.js';
 import {DescriptionFormatter, DescriptionValue, ParticleDescription} from './description-formatter.js';
 import {Particle} from './recipe/particle.js';
 import {Relevance} from './relevance.js';

--- a/src/runtime/particle-execution-host.ts
+++ b/src/runtime/particle-execution-host.ts
@@ -10,9 +10,9 @@
 
 import {assert} from '../platform/assert-web.js';
 
-import {PECOuterPort, APIPort} from './api-channel.js';
+import {PECOuterPort} from './api-channel.js';
 import {reportSystemException, PropagatedException} from './arc-exceptions.js';
-import {Arc, UnifiedStore} from './arc.js';
+import {UnifiedStore} from './storageNG/unified-store.js';
 import {Runnable} from './hot.js';
 import {Manifest} from './manifest.js';
 import {StorageStub} from './storage-stub.js';
@@ -26,6 +26,7 @@ import {BigCollectionStorageProvider, CollectionStorageProvider, StorageProvider
 import {Type} from './type.js';
 import {Services} from './services.js';
 import {floatingPromiseToAudit} from './util.js';
+import {Arc} from './arc.js';
 
 export type StartRenderOptions = {
   particle: Particle;

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -12,19 +12,18 @@ import {assert} from '../platform/assert-web.js';
 
 import {Description} from './description.js';
 import {Manifest} from './manifest.js';
-import {Arc, UnifiedStore} from './arc.js';
+import {Arc} from './arc.js';
+import {UnifiedStore} from './storageNG/unified-store.js';
 import {RuntimeCacheService} from './runtime-cache.js';
-import {Id, IdGenerator, ArcId} from './id.js';
+import {IdGenerator, ArcId} from './id.js';
 import {PecFactory} from './particle-execution-context.js';
-import {Handle} from './recipe/handle.js';
 import {SlotComposer} from './slot-composer.js';
 import {Loader} from './loader.js';
 import {StorageStub} from './storage-stub.js';
-import {StorageProviderBase} from './storage/storage-provider-base.js';
 import {StorageProviderFactory} from './storage/storage-provider-factory.js';
 import {ArcInspectorFactory} from './arc-inspector.js';
 import {FakeSlotComposer} from './testing/fake-slot-composer.js';
-import {VolatileMemory, VolatileStorageKey} from './storageNG/drivers/volatile.js';
+import {VolatileMemory} from './storageNG/drivers/volatile.js';
 import {StorageKey} from './storageNG/storage-key.js';
 
 export type RuntimeArcOptions = Readonly<{

--- a/src/runtime/storage/storage-provider-base.ts
+++ b/src/runtime/storage/storage-provider-base.ts
@@ -10,16 +10,16 @@
 
 import {assert} from '../../platform/assert-web.js';
 import {Id} from '../id.js';
-import {Comparable, compareNumbers, compareStrings} from '../recipe/comparable.js';
+import {compareNumbers, compareStrings} from '../recipe/comparable.js';
 import {Type} from '../type.js';
 import {StorageStub} from '../storage-stub.js';
-import {ModelValue, SerializedModelEntry} from './crdt-collection-model.js';
+import {SerializedModelEntry} from './crdt-collection-model.js';
 import {KeyBase} from './key-base.js';
 import {Store, BigCollectionStore, CollectionStore, SingletonStore} from '../store.js';
 import {PropagatedException} from '../arc-exceptions.js';
 import {Dictionary, Consumer} from '../hot.js';
 import {ClaimIsTag} from '../particle-claim.js';
-import {UnifiedStore} from '../arc.js';
+import {UnifiedStore} from '../storageNG/unified-store.js';
 
 enum EventKind {
   change = 'Change'
@@ -108,7 +108,7 @@ export class ChangeEvent {
 /**
  * Docs TBD
  */
-export abstract class StorageProviderBase implements Comparable<StorageProviderBase>, Store, UnifiedStore {
+export abstract class StorageProviderBase extends UnifiedStore implements Store {
   private listeners: Map<EventKind, Map<Callback, {target: {}}>>;
   private nextLocalID: number;
   private readonly _type: Type;
@@ -126,6 +126,7 @@ export abstract class StorageProviderBase implements Comparable<StorageProviderB
   claims: ClaimIsTag[];
 
   protected constructor(type: Type, name: string, id: string, key: string) {
+    super();
     assert(id, 'id must be provided when constructing StorageProviders');
     assert(!type.hasUnresolvedVariable, 'Storage types must be concrete');
     this._type = type;
@@ -196,19 +197,6 @@ export abstract class StorageProviderBase implements Comparable<StorageProviderB
     for (const callback of callbacks) {
       callback(details);
     }
-  }
-
-  _compareTo(other: UnifiedStore): number {
-    let cmp;
-    cmp = compareStrings(this.name, other.name);
-    if (cmp !== 0) return cmp;
-    cmp = compareNumbers(this.version, other.version);
-    if (cmp !== 0) return cmp;
-    cmp = compareStrings(this.source, other.source);
-    if (cmp !== 0) return cmp;
-    cmp = compareStrings(this.id, other.id);
-    if (cmp !== 0) return cmp;
-    return 0;
   }
 
   toString(handleTags?: string[]): string {

--- a/src/runtime/storageNG/store.ts
+++ b/src/runtime/storageNG/store.ts
@@ -15,7 +15,7 @@ import {StorageKey} from './storage-key.js';
 import {StoreInterface, StorageMode, ActiveStore, ProxyMessageType, ProxyMessage, ProxyCallback} from './store-interface.js';
 import {DirectStore} from './direct-store.js';
 import {ReferenceModeStore, ReferenceModeStorageKey} from './reference-mode-store.js';
-import {UnifiedStore} from '../arc.js';
+import {UnifiedStore} from './unified-store.js';
 import {Consumer} from '../hot.js';
 
 export {StorageMode, ActiveStore, ProxyMessageType, ProxyMessage, ProxyCallback};
@@ -29,11 +29,8 @@ type StoreConstructor = {
 // StorageProxy objects, and no data will be read or written.
 //
 // Calling 'activate()' will generate an interactive store and return it.
-export class Store<T extends CRDTTypeRecord> implements StoreInterface<T>, UnifiedStore {
-  source: string;
-  _compareTo(other: UnifiedStore): number {
-    throw new Error('Method not implemented.');
-  }
+export class Store<T extends CRDTTypeRecord> extends UnifiedStore implements StoreInterface<T> {
+
   toString(tags: string[]): string {
     throw new Error('Method not implemented.');
   }
@@ -52,6 +49,8 @@ export class Store<T extends CRDTTypeRecord> implements StoreInterface<T>, Unifi
   on(type: string, fn: Consumer<{}>, target: {}): void {
     throw new Error('Method not implemented.');
   }
+
+  source: string;
   description: string;
   readonly storageKey: StorageKey;
   exists: Exists;
@@ -68,6 +67,7 @@ export class Store<T extends CRDTTypeRecord> implements StoreInterface<T>, Unifi
   ]);
 
   constructor(storageKey: StorageKey, exists: Exists, type: Type, id: string, name: string = '') {
+    super();
     this.storageKey = storageKey;
     this.exists = exists;
     this.type = type;

--- a/src/runtime/storageNG/unified-store.ts
+++ b/src/runtime/storageNG/unified-store.ts
@@ -1,0 +1,64 @@
+/**
+ * @license
+ * Copyright (c) 2019 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {Comparable, compareStrings, compareNumbers} from '../recipe/comparable.js';
+import {Type} from '../type.js';
+import {StorageKey} from './storage-key.js';
+import {Consumer} from '../hot.js';
+
+/**
+ * This is a temporary interface used to unify old-style stores (storage/StorageProviderBase) and new-style stores (storageNG/Store).
+ * We should be able to remove this once we've switched across to the NG stack.
+ *
+ * Note that for old-style stores, StorageStubs are used *sometimes* to represent storage which isn't activated. For new-style stores,
+ * Store itself represents an inactive store, and needs to be activated using activate(). This will present some integration
+ * challenges :)
+ *
+ * Note also that old-style stores use strings for Storage Keys, while NG storage uses storageNG/StorageKey subclasses. This provides
+ * a simple test for determining whether a store is old or new.
+ *
+ * Common functionality between old- and new-style stores goes in this class.
+ * Once the old-style stores are deleted, this class can be merged into the new
+ * Store class.
+ */
+export abstract class UnifiedStore implements Comparable<UnifiedStore> {
+  abstract id: string;
+  abstract name: string;
+  abstract source: string;
+  abstract type: Type;
+  // TODO: Once the old storage stack is gone, this should only be of type StorageKey.
+  abstract storageKey: string | StorageKey;
+  abstract version?: number; // TODO(shans): This needs to be a version vector for new storage.
+  abstract referenceMode: boolean;
+  abstract toString(tags?: string[]): string; // TODO(shans): This shouldn't be called toString as toString doesn't take arguments.
+  // TODO(shans): toLiteral is currently used in _serializeStore, during recipe serialization. It's used when volatile
+  // stores need to be written out as resources into the manifest. Problem is, it expects a particular CRDT model shape;
+  // for new storage we probably need to extract the model from the store instead and have the CRDT directly produce a
+  // JSON representation for insertion into the serialization.
+  // tslint:disable-next-line no-any
+  abstract toLiteral(): Promise<any>;
+  abstract cloneFrom(store: UnifiedStore): void;
+  abstract modelForSynchronization(): {};
+  abstract on(type: string, fn: Consumer<{}>, target: {}): void;
+  abstract description: string;
+
+  _compareTo(other: UnifiedStore): number {
+    let cmp: number;
+    cmp = compareStrings(this.name, other.name);
+    if (cmp !== 0) return cmp;
+    cmp = compareNumbers(this.version, other.version);
+    if (cmp !== 0) return cmp;
+    cmp = compareStrings(this.source, other.source);
+    if (cmp !== 0) return cmp;
+    cmp = compareStrings(this.id, other.id);
+    if (cmp !== 0) return cmp;
+    return 0;
+  }
+}


### PR DESCRIPTION
Common functionality for old- and new-style stores will be moved to this
base class (starting with _compareTo in this PR). Other common methods
will be added there as well.