### PR TITLE
Convert dev-shell to UiBroker

### DIFF
--- a/particles/Tutorial/Javascript/1_HelloWorld/hello-world.js
+++ b/particles/Tutorial/Javascript/1_HelloWorld/hello-world.js
@@ -12,8 +12,8 @@
 // is a subclass of Particle that provides convenient methods for rendering to the DOM. (There are other more basic ways to render to the DOM,
 // but DomParticle provides a nice abstraction for it, similar to React).
 
-defineParticle(({DomParticle, html}) => {
-  return class extends DomParticle {
+defineParticle(({SimpleParticle, html}) => {
+  return class extends SimpleParticle {
     // Getter function which returns static HTML to display. In later tutorials we'll see how to use the templating functionality this provides.
     get template() {
       // You can use the html helper like so to render HTML:

--- a/shells/dev-shell/index.js
+++ b/shells/dev-shell/index.js
@@ -11,7 +11,6 @@ import './file-pane.js';
 import './output-pane.js';
 import '../configuration/whitelisted.js';
 import {DevShellLoader} from './loader.js';
-import {createUiComposer} from './ui-composer.js';
 
 import {Runtime} from '../../build/runtime/runtime.js';
 import {Arc} from '../../build/runtime/arc.js';
@@ -20,6 +19,8 @@ import {PecIndustry} from '../../build/platform/pec-industry-web.js';
 import {RecipeResolver} from '../../build/runtime/recipe/recipe-resolver.js';
 import {StorageProviderFactory} from '../../build/runtime/storage/storage-provider-factory.js';
 import {devtoolsArcInspectorFactory} from '../../build/devtools-connector/devtools-arc-inspector.js';
+import {UiSlotComposer} from '../../build/runtime/ui-slot-composer.js';
+import {SlotObserver} from '../lib/xen-renderer.js';
 
 import '../../build/services/ml5-service.js';
 import '../../build/services/random-service.js';
@@ -118,7 +119,9 @@ async function wrappedExecute() {
       continue;
     }
 
-    const slotComposer = createUiComposer(arcPanel.shadowRoot);
+    const slotComposer = new UiSlotComposer();
+    slotComposer.observeSlots(new SlotObserver(arcPanel.shadowRoot));
+
     const storage = new StorageProviderFactory(id);
     const arc = new Arc({
       id,

--- a/shells/dev-shell/index.js
+++ b/shells/dev-shell/index.js
@@ -11,16 +11,13 @@ import './file-pane.js';
 import './output-pane.js';
 import '../configuration/whitelisted.js';
 import {DevShellLoader} from './loader.js';
+import {createUiComposer} from './ui-composer.js';
 
 import {Runtime} from '../../build/runtime/runtime.js';
 import {Arc} from '../../build/runtime/arc.js';
 import {IdGenerator} from '../../build/runtime/id.js';
-import {Modality} from '../../build/runtime/modality.js';
-import {ModalityHandler} from '../../build/runtime/modality-handler.js';
 import {PecIndustry} from '../../build/platform/pec-industry-web.js';
 import {RecipeResolver} from '../../build/runtime/recipe/recipe-resolver.js';
-import {SlotComposer} from '../../build/runtime/slot-composer.js';
-import {SlotDomConsumer} from '../../build/runtime/slot-dom-consumer.js';
 import {StorageProviderFactory} from '../../build/runtime/storage/storage-provider-factory.js';
 import {devtoolsArcInspectorFactory} from '../../build/devtools-connector/devtools-arc-inspector.js';
 
@@ -30,6 +27,7 @@ import '../../build/services/random-service.js';
 const files = document.getElementById('file-pane');
 const output = document.getElementById('output-pane');
 const popup = document.getElementById('popup');
+
 init();
 
 function init() {
@@ -68,9 +66,9 @@ recipe
   P
     data <- h0`;
 
-    const exampleParticle = `\
-defineParticle(({DomParticle, html, log}) => {
-  return class extends DomParticle {
+    const exampleParticle = `
+defineParticle(({SimpleParticle, html, log}) => {
+  return class extends SimpleParticle {
     get template() {
       log(\`Add '?log' to the URL to enable particle logging\`);
       return html\`<span>{{num}}</span> : <span>{{str}}</span>\`;
@@ -90,7 +88,6 @@ function execute() {
 }
 
 async function wrappedExecute() {
-  SlotDomConsumer.clearCache();  // prevent caching of template strings
   document.dispatchEvent(new Event('clear-arcs-explorer'));
   output.reset();
 
@@ -121,15 +118,7 @@ async function wrappedExecute() {
       continue;
     }
 
-    const slotComposer = new SlotComposer({
-      modalityName: Modality.Name.Dom,
-      modalityHandler: ModalityHandler.domHandler,
-      containers: {
-        toproot: arcPanel.arcToproot,
-        root: arcPanel.arcRoot,
-        modal: arcPanel.arcModal,
-      }
-    });
+    const slotComposer = createUiComposer(arcPanel.shadowRoot);
     const storage = new StorageProviderFactory(id);
     const arc = new Arc({
       id,

--- a/shells/dev-shell/loader.js
+++ b/shells/dev-shell/loader.js
@@ -7,8 +7,8 @@
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
-import {PlatformLoader} from '../../../build/platform/loader-web.js';
-import {Utils} from '../../shells/lib/utils.js';
+import {PlatformLoader} from '../../build/platform/loader-web.js';
+import {Utils} from '../lib/utils.js';
 
 export class DevShellLoader extends PlatformLoader {
   constructor(fileMap) {

--- a/shells/dev-shell/output-pane.js
+++ b/shells/dev-shell/output-pane.js
@@ -145,9 +145,9 @@ const arcTemplate = `
     <span id="kill">✘</span>
   </div>
   <div id="slots">
-    <div id="arc-toproot"></div>
-    <div id="arc-root"></div>
-    <div id="arc-modal"></div>
+    <div id="arc-toproot" slotid="rootslotid-toproot"></div>
+    <div id="arc-root" slotid="rootslotid-root"></div>
+    <div id="arc-modal" slotid="rootslotid-modal"></div>
     <div id="expand"/></div>
   </div>
   <span class="controls-container">

--- a/shells/dev-shell/ui-composer.js
+++ b/shells/dev-shell/ui-composer.js
@@ -1,9 +1,0 @@
-import {SlotObserver} from '../lib/xen-renderer.js';
-import {UiSlotComposer} from '../../build/runtime/ui-slot-composer.js';
-
-export const createUiComposer = domRoot => {
-  const composer = new UiSlotComposer();
-  const observer = new SlotObserver(domRoot);
-  composer.observeSlots(observer);
-  return composer;
-};

--- a/shells/dev-shell/ui-composer.js
+++ b/shells/dev-shell/ui-composer.js
@@ -1,0 +1,9 @@
+import {SlotObserver} from '../lib/xen-renderer.js';
+import {UiSlotComposer} from '../../build/runtime/ui-slot-composer.js';
+
+export const createUiComposer = domRoot => {
+  const composer = new UiSlotComposer();
+  const observer = new SlotObserver(domRoot);
+  composer.observeSlots(observer);
+  return composer;
+};

--- a/src/platform/loader-platform.ts
+++ b/src/platform/loader-platform.ts
@@ -67,6 +67,9 @@ export class PlatformLoaderBase extends Loader {
       // Ui-flavored Particles
       UiParticle,
       UiMultiplexerParticle,
+      // Aliasing
+      ReactiveParticle: UiParticle,
+      SimpleParticle: UiParticle,
       // utilities
       resolver: this.resolve.bind(this), // allows particles to use relative paths and macros
       log: log || (() => {}),


### PR DESCRIPTION
UiBroker apps use `ui-slot-composer` instead of one of the other slot-composer classes. `ui-slot-composer` delegates rendering/event work to a `slotObserver` (which will allow us to remove all `*-dom-*` modules from the core dependency tree).

In this PR, the `slotObserver` is implemented via `shells/lib/xen-renderer.js` which implements the same DOM template renderer we've been using from the beginning (but again pulls it out of `runtime` proper).

NB: applications that use `ui-slot-composer` work with `UiParticle` (or it's alias `SimpleParticle`). Some of the corpus of Particles still reference the old DomParticle, and those particles will not render properly. `web-shell` and Android apps (via `pipes-shell`) all use `ui-slot-composer` so I plan to batch s/DomParticle/SimpleParticle in a follow up PR.

Aside: shells/lib contains middleware code to make building shells easier, but I see how dev-shell was wedged by needing the ability to modify loader. I'll take a pass at aligning these things as a tertiary task, if you (@mykmartin) don't mind.