### PR TITLE
Blanket replace `DomParticle` with `SimpleParticle`

### DIFF
--- a/particles/Cats/source/DomCat.js
+++ b/particles/Cats/source/DomCat.js
@@ -8,15 +8,15 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-defineParticle(({DomParticle, html, resolver}) => {
-    return class extends DomParticle {
+defineParticle(({SimpleParticle, html, resolver}) => {
+    return class extends SimpleParticle {
         get template() {
             const notification = this.handles.get('notification');
             if (notification) {
                 if (notification.triggered) {
                     return html`Today's cat is <span>{{name}}</span>! This cat is: <span>{{description}}</span>!`;
                 }
-            } 
+            }
             return html``;
         }
         update({cat, notification}) {

--- a/particles/Cats/source/ShowCat.js
+++ b/particles/Cats/source/ShowCat.js
@@ -56,8 +56,8 @@ const template = html`
 });
 
 
-/*defineParticle(({DomParticle, html, resolver}) => {
-    return class extends DomParticle {
+/*defineParticle(({SimpleParticle, html, resolver}) => {
+    return class extends SimpleParticle {
 
         get template() {
             return 'Today\'s cat is <span>{{name}}</span>!';

--- a/particles/Common/source/Noop.js
+++ b/particles/Common/source/Noop.js
@@ -10,8 +10,8 @@
 
 'use strict';
 
-defineParticle(({DomParticle}) => {
-  return class extends DomParticle {
+defineParticle(({SimpleParticle}) => {
+  return class extends SimpleParticle {
     get template() {
       return '&nbsp;';
     }

--- a/particles/Common/source/SearchBar.js
+++ b/particles/Common/source/SearchBar.js
@@ -12,7 +12,7 @@
 
 /* global defineParticle */
 
-defineParticle(({DomParticle, resolver, html}) => {
+defineParticle(({SimpleParticle, resolver, html}) => {
 
   const template = html`
 <style>
@@ -43,7 +43,7 @@ defineParticle(({DomParticle, resolver, html}) => {
 
   `;
 
-  return class extends DomParticle {
+  return class extends SimpleParticle {
     get template() {
       return template;
     }

--- a/particles/Common/source/StyleSheet.js
+++ b/particles/Common/source/StyleSheet.js
@@ -13,7 +13,7 @@
 
 /* global defineParticle */
 
-defineParticle(({DomParticle, html}) => {
+defineParticle(({SimpleParticle, html}) => {
 
   const template = html`
 
@@ -28,7 +28,7 @@ defineParticle(({DomParticle, html}) => {
 
   `;
 
-  return class extends DomParticle {
+  return class extends SimpleParticle {
     get template() {
       return template;
     }

--- a/particles/Layout/source/AnimatedTiles.js
+++ b/particles/Layout/source/AnimatedTiles.js
@@ -8,7 +8,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-defineParticle(({DomParticle, html, log, resolver}) => {
+defineParticle(({SimpleParticle, html, log, resolver}) => {
 
   const template = html`
 
@@ -100,7 +100,7 @@ defineParticle(({DomParticle, html, log, resolver}) => {
     }
   };
 
-  return class extends DomParticle {
+  return class extends SimpleParticle {
     get template() {
       return template;
     }

--- a/particles/Layout/source/BottomScrollTest.js
+++ b/particles/Layout/source/BottomScrollTest.js
@@ -8,7 +8,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-defineParticle(({DomParticle, html, log, resolver}) => {
+defineParticle(({SimpleParticle, html, log, resolver}) => {
 
   const template = html`
 
@@ -44,7 +44,7 @@ defineParticle(({DomParticle, html, log, resolver}) => {
 
   `;
 
-  return class extends DomParticle {
+  return class extends SimpleParticle {
     get template() {
       return template;
     }

--- a/particles/Layout/source/RepeaterTiles.js
+++ b/particles/Layout/source/RepeaterTiles.js
@@ -8,7 +8,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-defineParticle(({DomParticle, html, log, resolver}) => {
+defineParticle(({SimpleParticle, html, log, resolver}) => {
 
   const template = html`
 
@@ -97,7 +97,7 @@ defineParticle(({DomParticle, html, log, resolver}) => {
     }
   };
 
-  return class extends DomParticle {
+  return class extends SimpleParticle {
     get template() {
       return template;
     }

--- a/particles/Layout/source/Tabbed.js
+++ b/particles/Layout/source/Tabbed.js
@@ -8,7 +8,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-defineParticle(({DomParticle, html, log, resolver}) => {
+defineParticle(({SimpleParticle, html, log, resolver}) => {
 
   const template = html`
 
@@ -16,7 +16,7 @@ defineParticle(({DomParticle, html, log, resolver}) => {
 
   `;
 
-  return class extends DomParticle {
+  return class extends SimpleParticle {
     get template() {
       return template;
     }

--- a/particles/Magenta/source/PlayDemo.js
+++ b/particles/Magenta/source/PlayDemo.js
@@ -8,12 +8,12 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-defineParticle(({DomParticle, html, log, resolver}) => {
+defineParticle(({SimpleParticle, html, log, resolver}) => {
   const template = html`
   <button id="button-play" on-click="onPlay">Play</button>
 `;
 
-  return class extends DomParticle {
+  return class extends SimpleParticle {
     get template() {
       return template;
     }

--- a/particles/Magenta/source/Visualizer.js
+++ b/particles/Magenta/source/Visualizer.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-defineParticle(({DomParticle, html, log, resolver}) => {
+defineParticle(({SimpleParticle, html, log, resolver}) => {
   const template = html`
     <magenta-visualizer notes="{{notes}}"></magenta-visualizer>
   `;
@@ -30,12 +30,12 @@ defineParticle(({DomParticle, html, log, resolver}) => {
       {pitch: 64, startTime: 5.5, endTime: 6.0},
       {pitch: 62, startTime: 6.0, endTime: 6.5},
       {pitch: 62, startTime: 6.5, endTime: 7.0},
-      {pitch: 60, startTime: 7.0, endTime: 8.0},  
+      {pitch: 60, startTime: 7.0, endTime: 8.0},
     ],
     totalTime: 8
   };
 
-  return class extends DomParticle {
+  return class extends SimpleParticle {
     get template() {
       return template;
     }

--- a/particles/Music/source/ArtistFinder.js
+++ b/particles/Music/source/ArtistFinder.js
@@ -12,12 +12,12 @@
 'use strict';
 
 /* global defineParticle */
-defineParticle(({DomParticle, log}) => {
+defineParticle(({SimpleParticle, log}) => {
 
   /* global service */
   const service = 'https://kgsearch.googleapis.com/v1/entities:search?key=AIzaSyDVu27xQSI7fQ-_VvZpCH6sdVMe1mueN54&limit=1';
 
-  return class extends DomParticle {
+  return class extends SimpleParticle {
     get template() {
       return '&nbsp;';
     }

--- a/particles/Music/source/ArtistPipe.js
+++ b/particles/Music/source/ArtistPipe.js
@@ -10,9 +10,9 @@
 
 'use strict';
 
-defineParticle(({DomParticle, log}) => {
+defineParticle(({SimpleParticle, log}) => {
 
-  return class extends DomParticle {
+  return class extends SimpleParticle {
     get template() {
       return '<div slotid="content"></div>';
     }

--- a/particles/Music/source/ArtistShow.js
+++ b/particles/Music/source/ArtistShow.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-defineParticle(({DomParticle, html}) => {
+defineParticle(({SimpleParticle, html}) => {
 
   const template = html`
 
@@ -83,7 +83,7 @@ defineParticle(({DomParticle, html}) => {
 <div slotid="extrasForArtist"></div> -->
 
   `;
-  return class extends DomParticle {
+  return class extends SimpleParticle {
     get template() {
       return template;
     }

--- a/particles/Native/Kotlin/src/wasm/arcs/WasmParticle.js
+++ b/particles/Native/Kotlin/src/wasm/arcs/WasmParticle.js
@@ -1,4 +1,4 @@
-defineParticle(({DomParticle, html, log, resolver}) => {
+defineParticle(({SimpleParticle, html, log, resolver}) => {
 
     /**
      * This looks a bit odd, because it has to fit into the auto-generated setup that Kotlin-native

--- a/particles/PipeApps/source/ArtistPipe.js
+++ b/particles/PipeApps/source/ArtistPipe.js
@@ -10,9 +10,9 @@
 
 'use strict';
 
-defineParticle(({DomParticle, log}) => {
+defineParticle(({SimpleParticle, log}) => {
 
-  return class extends DomParticle {
+  return class extends SimpleParticle {
     get template() {
       return `<span></span>`;
     }

--- a/particles/PipeApps/source/CaptionThis.js
+++ b/particles/PipeApps/source/CaptionThis.js
@@ -10,9 +10,9 @@
 
 'use strict';
 
-defineParticle(({DomParticle, html, log}) => {
+defineParticle(({SimpleParticle, html, log}) => {
 
-  return class extends DomParticle {
+  return class extends SimpleParticle {
     get template() {
       return `<span>{{json}}</span>`;
     }

--- a/particles/PipeApps/source/Noop.js
+++ b/particles/PipeApps/source/Noop.js
@@ -10,8 +10,8 @@
 
 'use strict';
 
-defineParticle(({DomParticle}) => {
-  return class extends DomParticle {
+defineParticle(({SimpleParticle}) => {
+  return class extends SimpleParticle {
     get template() {
       return '&nbsp;';
     }

--- a/particles/PipeApps/source/RandomArtist.js
+++ b/particles/PipeApps/source/RandomArtist.js
@@ -10,9 +10,9 @@
 
 'use strict';
 
-defineParticle(({DomParticle, html, log}) => {
+defineParticle(({SimpleParticle, html, log}) => {
 
-  return class extends DomParticle {
+  return class extends SimpleParticle {
     update({randomArtist}) {
       if (randomArtist) {
         const entities = [

--- a/particles/PipeApps/source/SuggestAddress.js
+++ b/particles/PipeApps/source/SuggestAddress.js
@@ -10,8 +10,8 @@
 
 'use strict';
 
-defineParticle(({DomParticle, html, log}) => {
-  return class extends DomParticle {
+defineParticle(({SimpleParticle, html, log}) => {
+  return class extends SimpleParticle {
     get template() {
       return html`<span>{{json}}</span>`;
     }

--- a/particles/PipeApps/source/SuggestArtist.js
+++ b/particles/PipeApps/source/SuggestArtist.js
@@ -10,9 +10,9 @@
 
 'use strict';
 
-defineParticle(({DomParticle}) => {
+defineParticle(({SimpleParticle}) => {
 
-  return class extends DomParticle {
+  return class extends SimpleParticle {
     get template() {
       return `<span>{{json}}</span>`;
     }

--- a/particles/PipeApps/source/SuggestPerson.js
+++ b/particles/PipeApps/source/SuggestPerson.js
@@ -10,8 +10,8 @@
 
 'use strict';
 
-defineParticle(({DomParticle, html, log}) => {
-  return class extends DomParticle {
+defineParticle(({SimpleParticle, html, log}) => {
+  return class extends SimpleParticle {
     get template() {
       return html`<span></span>`;
     }

--- a/particles/PipeApps/source/Trigger.js
+++ b/particles/PipeApps/source/Trigger.js
@@ -10,8 +10,8 @@
 
 'use strict';
 
-defineParticle(({DomParticle, html}) => {
-  return class extends DomParticle {
+defineParticle(({SimpleParticle, html}) => {
+  return class extends SimpleParticle {
     get template() {
       return html`<div slotid="content"></div>`;
     }

--- a/particles/PipeApps/source/UpdateMe.js
+++ b/particles/PipeApps/source/UpdateMe.js
@@ -10,9 +10,9 @@
 
 'use strict';
 
-defineParticle(({DomParticle, html, log}) => {
+defineParticle(({SimpleParticle, html, log}) => {
 
-  return class extends DomParticle {
+  return class extends SimpleParticle {
     get template() {
       return `<span>{{json}}<span>`;
     }

--- a/particles/Processing/js/Dispose.js
+++ b/particles/Processing/js/Dispose.js
@@ -8,11 +8,11 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-defineParticle(({DomParticle, resolver, log}) => {
+defineParticle(({SimpleParticle, resolver, log}) => {
 
   importScripts(resolver(`$here/tf.js`));
 
-  return class extends self.TfMixin(DomParticle) {
+  return class extends self.TfMixin(SimpleParticle) {
     async update({resource}) {
       if (resource) {
         log('Disposing...');

--- a/particles/Processing/js/ExpandDims.js
+++ b/particles/Processing/js/ExpandDims.js
@@ -8,11 +8,11 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-defineParticle(({DomParticle, resolver, log}) => {
+defineParticle(({SimpleParticle, resolver, log}) => {
 
   importScripts(resolver(`$here/tf.js`));
 
-  return class extends self.TfMixin(DomParticle) {
+  return class extends self.TfMixin(SimpleParticle) {
     async update({tensor, axis}) {
       if (tensor && axis) {
         log('Expanding Dimensions...');

--- a/particles/Processing/js/ImageSelector.js
+++ b/particles/Processing/js/ImageSelector.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-defineParticle(({DomParticle, html, resolver, log}) => {
+defineParticle(({SimpleParticle, html, resolver, log}) => {
 
   const template_ = html`
     <div style="padding: 16px;">
@@ -25,7 +25,7 @@ defineParticle(({DomParticle, html, resolver, log}) => {
 
   const defaultImage = resolver(`https://$particles/Services/assets/waltbird.jpg`);
 
-  return class extends DomParticle {
+  return class extends SimpleParticle {
     get template() {
       return template_;
     }

--- a/particles/Processing/js/ImageToTensor.js
+++ b/particles/Processing/js/ImageToTensor.js
@@ -8,11 +8,11 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-defineParticle(({DomParticle, resolver, log}) => {
+defineParticle(({SimpleParticle, resolver, log}) => {
 
   importScripts(resolver(`$here/tf.js`));
 
-  return class extends self.TfMixin(DomParticle) {
+  return class extends self.TfMixin(SimpleParticle) {
     async update({image}) {
       if (image) {
         log('Converting image URL to Tensor...', image);

--- a/particles/Processing/js/Infer.js
+++ b/particles/Processing/js/Infer.js
@@ -8,11 +8,11 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-defineParticle(({DomParticle, resolver, log}) => {
+defineParticle(({SimpleParticle, resolver, log}) => {
 
   importScripts(resolver(`$here/tf.js`));
 
-  return class extends self.TfMixin(DomParticle) {
+  return class extends self.TfMixin(SimpleParticle) {
     async update({tensor, model}) {
       if (model && tensor) {
         log('Classifying...');

--- a/particles/Processing/js/LoadGraphModel.js
+++ b/particles/Processing/js/LoadGraphModel.js
@@ -8,11 +8,11 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-defineParticle(({DomParticle, log, resolver}) => {
+defineParticle(({SimpleParticle, log, resolver}) => {
 
   importScripts(resolver(`$here/tf.js`));
 
-  return class extends self.TfMixin(DomParticle) {
+  return class extends self.TfMixin(SimpleParticle) {
     async update({modelSpec}) {
       if (modelSpec) {
         const model = await this.tf.loadGraphModel(resolver(modelSpec.location), modelSpec.options);

--- a/particles/Processing/js/LoadLayersModel.js
+++ b/particles/Processing/js/LoadLayersModel.js
@@ -8,11 +8,11 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-defineParticle(({DomParticle, log, resolver}) => {
+defineParticle(({SimpleParticle, log, resolver}) => {
 
   importScripts(resolver(`$here/tf.js`));
 
-  return class extends self.TfMixin(DomParticle) {
+  return class extends self.TfMixin(SimpleParticle) {
     async update({modelSpec}) {
       if (modelSpec) {
         const model = await this.tf.loadLayersModel(modelSpec.location, modelSpec.options);

--- a/particles/Processing/js/ModelSelector.js
+++ b/particles/Processing/js/ModelSelector.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-defineParticle(({DomParticle, html, resolver}) => {
+defineParticle(({SimpleParticle, html, resolver}) => {
 
   const tmpl = html`
   <div style="padding: 16px;">
@@ -20,12 +20,12 @@ defineParticle(({DomParticle, html, resolver}) => {
     <h4>Input the path/to/labels.txt</h4>
     <input style="width: 80%; padding: 8px;" value="{{inputLabelsUrl}}" on-change="onLabelsChange">
     <button on-click="onSubmit">Submit</button>
-    
+
     <div slotid="resultsView"></div>
   </div>
   `;
 
-  return class extends DomParticle {
+  return class extends SimpleParticle {
     get template() {
       return tmpl;
     }

--- a/particles/Processing/js/Normalize.js
+++ b/particles/Processing/js/Normalize.js
@@ -8,11 +8,11 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-defineParticle(({DomParticle, resolver, log}) => {
+defineParticle(({SimpleParticle, resolver, log}) => {
 
   importScripts(resolver(`$here/tf.js`));
 
-  return class extends self.TfMixin(DomParticle) {
+  return class extends self.TfMixin(SimpleParticle) {
     async update({tensor, range}) {
       if (tensor && range) {
         log('Normalizing...');

--- a/particles/Processing/js/ParseLabels.js
+++ b/particles/Processing/js/ParseLabels.js
@@ -8,11 +8,11 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-defineParticle(({DomParticle, log, resolver}) => {
+defineParticle(({SimpleParticle, log, resolver}) => {
 
   importScripts(resolver(`$here/tf.js`));
 
-  return class extends self.TfMixin(DomParticle) {
+  return class extends self.TfMixin(SimpleParticle) {
     async update({url}) {
       if (url) {
         log('Parsing labels file...');

--- a/particles/Processing/js/PresentLabel.js
+++ b/particles/Processing/js/PresentLabel.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-defineParticle(({DomParticle, html}) => {
+defineParticle(({SimpleParticle, html}) => {
 
   const template_ = html`
 
@@ -23,7 +23,7 @@ defineParticle(({DomParticle, html}) => {
 
   <h3>Top <span>{{k}}</span> Labels</h3>
   <div>{{things}}</div>
-  
+
   <template thing>
     <tr>
       <td><b>{{label}}</b></td>
@@ -34,7 +34,7 @@ defineParticle(({DomParticle, html}) => {
 
   `;
 
-  return class extends DomParticle {
+  return class extends SimpleParticle {
     get template() {
       return template_;
     }

--- a/particles/Processing/js/Reshape.js
+++ b/particles/Processing/js/Reshape.js
@@ -8,11 +8,11 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-defineParticle(({DomParticle, resolver, log}) => {
+defineParticle(({SimpleParticle, resolver, log}) => {
 
   importScripts(resolver(`$here/tf.js`));
 
-  return class extends self.TfMixin(DomParticle) {
+  return class extends self.TfMixin(SimpleParticle) {
     async update({tensor, shape}) {
       if (tensor && shape) {
         log('Reshaping...');

--- a/particles/Processing/js/ResizeBilinear.js
+++ b/particles/Processing/js/ResizeBilinear.js
@@ -8,11 +8,11 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-defineParticle(({DomParticle, resolver, log}) => {
+defineParticle(({SimpleParticle, resolver, log}) => {
 
   importScripts(resolver(`$here/tf.js`));
 
-  return class extends self.TfMixin(DomParticle) {
+  return class extends self.TfMixin(SimpleParticle) {
     async update({images, size, options}) {
       if (images && size) {
         log('Resizing...');

--- a/particles/Processing/js/TopLabels.js
+++ b/particles/Processing/js/TopLabels.js
@@ -8,11 +8,11 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-defineParticle(({DomParticle, resolver, log}) => {
+defineParticle(({SimpleParticle, resolver, log}) => {
 
   importScripts(resolver(`$here/tf.js`));
 
-  return class extends self.TfMixin(DomParticle) {
+  return class extends self.TfMixin(SimpleParticle) {
     async update({yHat, labels, k}) {
       if (yHat && labels) {
         const topK = k || 5;

--- a/particles/Profile/source/BasicProfile.js
+++ b/particles/Profile/source/BasicProfile.js
@@ -8,7 +8,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-defineParticle(({DomParticle, html, resolver}) => {
+defineParticle(({SimpleParticle, html, resolver}) => {
 
   const host = `basic-profile`;
 
@@ -71,7 +71,7 @@ defineParticle(({DomParticle, html, resolver}) => {
 
   `;
 
-  return class extends DomParticle {
+  return class extends SimpleParticle {
     get template() {
       return template;
     }

--- a/particles/Profile/source/FavoriteFoodPicker.js
+++ b/particles/Profile/source/FavoriteFoodPicker.js
@@ -8,7 +8,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-defineParticle(({DomParticle, html, resolver}) => {
+defineParticle(({SimpleParticle, html, resolver}) => {
 
   const notoPath = `/../assets/noto-emoji-128/emoji_u`;
   const allFoods = {
@@ -89,7 +89,7 @@ defineParticle(({DomParticle, html, resolver}) => {
 
   const nar = [];
 
-  return class extends DomParticle {
+  return class extends SimpleParticle {
     get template() {
       return template;
     }

--- a/particles/Profile/source/FriendsPicker.js
+++ b/particles/Profile/source/FriendsPicker.js
@@ -8,7 +8,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-defineParticle(({DomParticle, html, resolver, log}) => {
+defineParticle(({SimpleParticle, html, resolver, log}) => {
 
   const template = html`
 
@@ -106,7 +106,7 @@ defineParticle(({DomParticle, html, resolver, log}) => {
 
   `;
 
-  return class extends DomParticle {
+  return class extends SimpleParticle {
     get template() {
       return template;
     }

--- a/particles/Profile/source/Sharing.js
+++ b/particles/Profile/source/Sharing.js
@@ -8,9 +8,9 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-defineParticle(({DomParticle, log}) => {
+defineParticle(({SimpleParticle, log}) => {
 
-  return class extends DomParticle {
+  return class extends SimpleParticle {
   };
 
 });

--- a/particles/Profile/source/UserNameForm.js
+++ b/particles/Profile/source/UserNameForm.js
@@ -8,7 +8,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-defineParticle(({DomParticle, html}) => {
+defineParticle(({SimpleParticle, html}) => {
 
   const host = `user-name-form`;
 
@@ -43,7 +43,7 @@ defineParticle(({DomParticle, html}) => {
 
   `;
 
-  return class extends DomParticle {
+  return class extends SimpleParticle {
     get template() {
       return template;
     }

--- a/particles/Profile/source/UserPerson.js
+++ b/particles/Profile/source/UserPerson.js
@@ -8,9 +8,9 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-defineParticle(({DomParticle, log}) => {
+defineParticle(({SimpleParticle, log}) => {
 
-  return class extends DomParticle {
+  return class extends SimpleParticle {
     update({user, names, avatars, person}) {
       if (user) {
         const neo = person || {};

--- a/particles/Services/particles/js/ImageClassifier.js
+++ b/particles/Services/particles/js/ImageClassifier.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-defineParticle(({DomParticle, log, html, resolver}) => {
+defineParticle(({SimpleParticle, log, html, resolver}) => {
 
   const template_ = html`
 <div>
@@ -27,7 +27,7 @@ defineParticle(({DomParticle, log, html, resolver}) => {
   const modelUrl = 'https://tfhub.dev/google/imagenet/mobilenet_v1_100_224/classification/1';
   const labelUrl = resolver(`ImageClassifier/../../assets/ImageNetLabels.txt`);
 
-  return class extends DomParticle {
+  return class extends SimpleParticle {
     get template() {
       return template_;
     }

--- a/particles/Services/particles/js/Ml5.js
+++ b/particles/Services/particles/js/Ml5.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-defineParticle(({DomParticle, log, html, resolver}) => {
+defineParticle(({SimpleParticle, log, html, resolver}) => {
 
   const template = html`
 <div>
@@ -25,7 +25,7 @@ defineParticle(({DomParticle, log, html, resolver}) => {
 
   const url = resolver(`Ml5/../../assets/waltbird.jpg`);
 
-  return class extends DomParticle {
+  return class extends SimpleParticle {
     get template() {
       return template;
     }

--- a/particles/Services/particles/js/MobileNet.js
+++ b/particles/Services/particles/js/MobileNet.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-defineParticle(({DomParticle, log, html, resolver}) => {
+defineParticle(({SimpleParticle, log, html, resolver}) => {
 
   const template_ = html`
 <div>
@@ -25,7 +25,7 @@ defineParticle(({DomParticle, log, html, resolver}) => {
 
   const url = resolver(`MobileNet/../../assets/waltbird.jpg`);
 
-  return class extends DomParticle {
+  return class extends SimpleParticle {
     get template() {
       return template_;
     }

--- a/particles/Services/particles/js/Random.js
+++ b/particles/Services/particles/js/Random.js
@@ -10,10 +10,10 @@
 
 'use strict';
 
-defineParticle(({DomParticle, log, html, resolver}) => {
+defineParticle(({SimpleParticle, log, html, resolver}) => {
   const handleName = 'randomData';
 
-  return class extends DomParticle {
+  return class extends SimpleParticle {
     /**
      * Sets the 'randomData' handle to a RandomData schema object
      * containing a number value fetched from the Random service.

--- a/particles/Services/particles/js/ServiceTest.js
+++ b/particles/Services/particles/js/ServiceTest.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-defineParticle(({DomParticle, log, html, resolver}) => {
+defineParticle(({SimpleParticle, log, html, resolver}) => {
 
   const template = html`
 
@@ -21,7 +21,7 @@ defineParticle(({DomParticle, log, html, resolver}) => {
 
   `;
 
-  return class extends DomParticle {
+  return class extends SimpleParticle {
     get template() {
       return template;
     }

--- a/particles/Stardate/js/StardateDisplay.js
+++ b/particles/Stardate/js/StardateDisplay.js
@@ -11,7 +11,7 @@
 
  /* global defineParticle */
 
- defineParticle(({DomParticle, html, log}) => {
+ defineParticle(({SimpleParticle, html, log}) => {
   const template = html`
  <div style="padding: 8px;">
   Captain's log, stardate <b>{{stardate}}</b>.
@@ -19,7 +19,7 @@
 </div>
    `;
 
-   return class extends DomParticle {
+   return class extends SimpleParticle {
     get template() {
       return template;
     }

--- a/particles/Stardate/js/StardateTOS.js
+++ b/particles/Stardate/js/StardateTOS.js
@@ -11,7 +11,7 @@
 
 /* global defineParticle */
 
-defineParticle(({DomParticle, html, log}) => {
+defineParticle(({SimpleParticle, html, log}) => {
   const MIN_STARDATE = 1000;
   const MAX_STARDATE = 9999;
   // Via https://nasa.tumblr.com/post/150044040289/top-10-star-trek-planets-chosen-by-our-scientists
@@ -20,7 +20,7 @@ defineParticle(({DomParticle, html, log}) => {
     'Wolf 359', 'Eminar VII', 'Remus', 'Janus VI', 'Earth'
   ];
 
-  return class extends DomParticle {
+  return class extends SimpleParticle {
 
     /**
      * @inheritDoc

--- a/particles/TMDB/source/TMDBSearch.js
+++ b/particles/TMDB/source/TMDBSearch.js
@@ -11,11 +11,11 @@
 'use strict';
 
 /* global defineParticle */
-defineParticle(({DomParticle, log}) => {
+defineParticle(({SimpleParticle, log}) => {
 
   const service = `http://xenonjs.com/services/http/php/tmdb.php`;
 
-  return class extends DomParticle {
+  return class extends SimpleParticle {
     update({query}, state) {
       // If we are asynchronously populating data, wait until this is done before
       // handling additional updates.

--- a/particles/TMDB/source/TMDBTile.js
+++ b/particles/TMDB/source/TMDBTile.js
@@ -12,7 +12,7 @@
 
 /* global defineParticle */
 
-defineParticle(({DomParticle, html, log}) => {
+defineParticle(({SimpleParticle, html, log}) => {
 
   const template = html`
     <style>
@@ -69,7 +69,7 @@ defineParticle(({DomParticle, html, log}) => {
     </div>
   `;
 
-  return class extends DomParticle {
+  return class extends SimpleParticle {
     get template() {
       return template;
     }

--- a/particles/TVMaze/particles/js/TVMazeAppShell.js
+++ b/particles/TVMaze/particles/js/TVMazeAppShell.js
@@ -12,7 +12,7 @@
 
 /* global defineParticle */
 
-defineParticle(({DomParticle, html, log}) => {
+defineParticle(({SimpleParticle, html, log}) => {
 
   const host = `tv-maze-demo-shell`;
 
@@ -78,7 +78,7 @@ defineParticle(({DomParticle, html, log}) => {
     </div>
   `;
 
-  return class extends DomParticle {
+  return class extends SimpleParticle {
     get template() {
       return template;
     }

--- a/particles/TVMaze/particles/js/TVMazeDeduplicate.js
+++ b/particles/TVMaze/particles/js/TVMazeDeduplicate.js
@@ -12,8 +12,8 @@
 
 /* global defineParticle */
 
-defineParticle(({DomParticle, log}) => {
-  return class extends DomParticle {
+defineParticle(({SimpleParticle, log}) => {
+  return class extends SimpleParticle {
     async onHandleUpdate(handle, update) {
       if (handle.name !== 'uniqueShows') {
         super.onHandleUpdate(handle, update);

--- a/particles/TVMaze/particles/js/TVMazeEpisodeItem.js
+++ b/particles/TVMaze/particles/js/TVMazeEpisodeItem.js
@@ -12,7 +12,7 @@
 
 /* global defineParticle */
 
-defineParticle(({DomParticle, html, resolver, log}) => {
+defineParticle(({SimpleParticle, html, resolver, log}) => {
 
   const host = `tv-maze-episode-item`;
 
@@ -34,7 +34,7 @@ defineParticle(({DomParticle, html, resolver, log}) => {
     </div>
   `;
 
-  return class extends DomParticle {
+  return class extends SimpleParticle {
     get template() {
       return template;
     }

--- a/particles/TVMaze/particles/js/TVMazeFindEpisodes.js
+++ b/particles/TVMaze/particles/js/TVMazeFindEpisodes.js
@@ -11,20 +11,20 @@
 'use strict';
 
 /* global defineParticle */
-defineParticle(({DomParticle}) => {
+defineParticle(({SimpleParticle}) => {
 
   /* global service */
   //importScripts(resolver('TVMazeFindShow/TvMaze.js'));
   const service = `https://api.tvmaze.com`;
 
-  return class extends DomParticle {
+  return class extends SimpleParticle {
     // get template() {
     //   return ' ';
     // }
     update({episodes, show}, state) {
       // If we are asynchronously populating episodes, wait until this is done before
       // handling additional updates.
-      // TODO(sjmiles): Maybe generalize this notion into DomParticle?
+      // TODO(sjmiles): Maybe generalize this notion into SimpleParticle?
       if (!state.recieving) {
         if (show && show.showid !== state.showid) {
           state.count = 0;

--- a/particles/TVMaze/particles/js/TVMazeFindShow.js
+++ b/particles/TVMaze/particles/js/TVMazeFindShow.js
@@ -11,13 +11,13 @@
 'use strict';
 
 /* global defineParticle */
-defineParticle(({DomParticle, log, html}) => {
+defineParticle(({SimpleParticle, log, html}) => {
 
   /* global service */
   //importScripts(resolver('TVMazeFindShow/TvMaze.js'));
   const service = `https://api.tvmaze.com`;
 
-  return class extends DomParticle {
+  return class extends SimpleParticle {
     get template() {
       return html`<div slotid="content"></div>`;
       //return '--find show lives--'; // '&nbsp;'; //html`Searching`;

--- a/particles/TVMaze/particles/js/TVMazeSearchBar.js
+++ b/particles/TVMaze/particles/js/TVMazeSearchBar.js
@@ -12,7 +12,7 @@
 
 /* global defineParticle */
 
-defineParticle(({DomParticle, resolver, html}) => {
+defineParticle(({SimpleParticle, resolver, html}) => {
 
   const template = html`
 <style>
@@ -42,7 +42,7 @@ defineParticle(({DomParticle, resolver, html}) => {
 
   `;
 
-  return class extends DomParticle {
+  return class extends SimpleParticle {
     get template() {
       return template;
     }

--- a/particles/TVMaze/particles/js/TVMazeSearchShows.js
+++ b/particles/TVMaze/particles/js/TVMazeSearchShows.js
@@ -11,13 +11,13 @@
 'use strict';
 
 /* global defineParticle */
-defineParticle(({DomParticle, log}) => {
+defineParticle(({SimpleParticle, log}) => {
 
   const service = `https://api.tvmaze.com`;
   /* global service */
   //importScripts(resolver('TVMazeSearchShows/TvMaze.js'));
 
-  return class extends DomParticle {
+  return class extends SimpleParticle {
     get template() {
       return '&nbsp;'; //html`Searching`;
     }

--- a/particles/TVMaze/particles/js/TVMazeShowActions.js
+++ b/particles/TVMaze/particles/js/TVMazeShowActions.js
@@ -12,7 +12,7 @@
 
 /* global defineParticle */
 
-defineParticle(({DomParticle, html}) => {
+defineParticle(({SimpleParticle, html}) => {
 
   const host = `tvmaze-show-actions`;
 
@@ -41,7 +41,7 @@ defineParticle(({DomParticle, html}) => {
     </div>
   `;
 
-  return class extends DomParticle {
+  return class extends SimpleParticle {
     get template() {
       return template;
     }

--- a/particles/TVMaze/particles/js/TVMazeShowPanel.js
+++ b/particles/TVMaze/particles/js/TVMazeShowPanel.js
@@ -12,7 +12,7 @@
 
 /* global defineParticle */
 
-defineParticle(({DomParticle, html, log}) => {
+defineParticle(({SimpleParticle, html, log}) => {
 
   const template = html`
 
@@ -58,7 +58,7 @@ defineParticle(({DomParticle, html, log}) => {
 
   `;
 
-  return class extends DomParticle {
+  return class extends SimpleParticle {
     get template() {
       return template;
     }

--- a/particles/TVMaze/particles/js/TVMazeShowPipe.js
+++ b/particles/TVMaze/particles/js/TVMazeShowPipe.js
@@ -10,9 +10,9 @@
 
 'use strict';
 
-defineParticle(({DomParticle, log}) => {
+defineParticle(({SimpleParticle, log}) => {
 
-  return class extends DomParticle {
+  return class extends SimpleParticle {
     // get template() {
     //   return '<div slotid="content"></div>';
     // }

--- a/particles/TVMaze/particles/js/TVMazeShowTile.js
+++ b/particles/TVMaze/particles/js/TVMazeShowTile.js
@@ -12,7 +12,7 @@
 
 /* global defineParticle */
 
-defineParticle(({DomParticle, html, log}) => {
+defineParticle(({SimpleParticle, html, log}) => {
 
   // TODO(sjmiles): encode expected aspect-ratio using div-padding trick, this way the box will be properly sized
   // even if there is no image.
@@ -57,7 +57,7 @@ defineParticle(({DomParticle, html, log}) => {
     <div show-tile trigger$="{{trigger}}" style%="{{image}}"></div>
   `;
 
-  return class extends DomParticle {
+  return class extends SimpleParticle {
     get template() {
       return template;
     }

--- a/particles/TicTacToe/particles/js/DebugShowBoard.js
+++ b/particles/TicTacToe/particles/js/DebugShowBoard.js
@@ -7,7 +7,7 @@
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
-defineParticle(({DomParticle, html, log}) => {
+defineParticle(({SimpleParticle, html, log}) => {
 
   const template = html`
   <style>
@@ -15,7 +15,7 @@ defineParticle(({DomParticle, html, log}) => {
     display: grid;
     grid-template-rows: 1fr 1fr 1fr;
     grid-template-columns: 1fr 1fr 1fr;
-    grid-gap: 2vw; 
+    grid-gap: 2vw;
   }
 
   .grid div {
@@ -33,7 +33,7 @@ defineParticle(({DomParticle, html, log}) => {
     </div>
   </div>`;
 
-  return class extends DomParticle {
+  return class extends SimpleParticle {
     get template() {
       return template;
     }

--- a/particles/Tutorial/Javascript/1_HelloWorld/hello-world.js
+++ b/particles/Tutorial/Javascript/1_HelloWorld/hello-world.js
@@ -8,9 +8,9 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-// The JavaScript code for the Hello World particle. This is mostly boilerplate for defining a new particle using the DomParticle class, which
+// The JavaScript code for the Hello World particle. This is mostly boilerplate for defining a new particle using the SimpleParticle class, which
 // is a subclass of Particle that provides convenient methods for rendering to the DOM. (There are other more basic ways to render to the DOM,
-// but DomParticle provides a nice abstraction for it, similar to React).
+// but SimpleParticle provides a nice abstraction for it, similar to React).
 
 defineParticle(({SimpleParticle, html}) => {
   return class extends SimpleParticle {

--- a/particles/Tutorial/Javascript/2_BasicTemplates/basic-template.js
+++ b/particles/Tutorial/Javascript/2_BasicTemplates/basic-template.js
@@ -7,8 +7,8 @@
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
-defineParticle(({DomParticle, html}) => {   
-  return class extends DomParticle {
+defineParticle(({SimpleParticle, html}) => {
+  return class extends SimpleParticle {
     get template() {
       // You can set placeholders in your template like so: {{name}}. The render function is where these placeholders are overridden.
       // NOTE: Each placeholder needs to be enclosed inside its own HTML element (here, a <span>).

--- a/particles/Tutorial/Javascript/3_JsonStore/json-store.js
+++ b/particles/Tutorial/Javascript/3_JsonStore/json-store.js
@@ -7,8 +7,8 @@
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
-defineParticle(({DomParticle, html}) => {   
-  return class extends DomParticle {
+defineParticle(({SimpleParticle, html}) => {
+  return class extends SimpleParticle {
     get template() {
       return html`Hello <span>{{name}}</span>, aged <span>{{age}}</span>!`;
     }

--- a/particles/Tutorial/Javascript/4_RenderSlots/child.js
+++ b/particles/Tutorial/Javascript/4_RenderSlots/child.js
@@ -7,8 +7,8 @@
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
-defineParticle(({DomParticle, html}) => {
-  return class extends DomParticle {
+defineParticle(({SimpleParticle, html}) => {
+  return class extends SimpleParticle {
     get template() {
       return html`Child`;
     }

--- a/particles/Tutorial/Javascript/4_RenderSlots/parent.js
+++ b/particles/Tutorial/Javascript/4_RenderSlots/parent.js
@@ -7,8 +7,8 @@
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
-defineParticle(({DomParticle, html}) => {
-  return class extends DomParticle {
+defineParticle(({SimpleParticle, html}) => {
+  return class extends SimpleParticle {
     get template() {
       // The parent particle needs to provide a div with slotid "mySlot". This is where the child particle will be rendered.
       return html`

--- a/particles/Tutorial/Javascript/5_Collections/collections.js
+++ b/particles/Tutorial/Javascript/5_Collections/collections.js
@@ -7,15 +7,15 @@
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
-defineParticle(({DomParticle, html}) => {   
-  return class extends DomParticle {
+defineParticle(({SimpleParticle, html}) => {
+  return class extends SimpleParticle {
     get template() {
       // This template defines a subtemplate called "person". By filling in the "people" placeholder with a special construction given below in
       // the render() method, we can apply the "person" template on every element in our input list (which here turns it into an <li> element).
       return html`
         Hello to everyone:
         <ul>{{people}}</ul>
-      
+
         <template person>
           <!-- This template is given a model object. It can access the properties on that model via the usual placeholder syntax. -->
           <li>Hello <span>{{name}}</span>, age <span>{{age}}</span>!</li>

--- a/particles/Tutorial/Javascript/6_Handles/source/DisplayGreeting.js
+++ b/particles/Tutorial/Javascript/6_Handles/source/DisplayGreeting.js
@@ -12,11 +12,11 @@
 
 /* global defineParticle */
 
-defineParticle(({DomParticle, html}) => {   
+defineParticle(({SimpleParticle, html}) => {
 
 const template = html`Hello, <span>{{name}}</span>!`;
 
-  return class extends DomParticle {
+  return class extends SimpleParticle {
     get template() {
       return template;
     }
@@ -31,6 +31,6 @@ const template = html`Hello, <span>{{name}}</span>!`;
         name: person.name,
       };
     }
-    
+
   };
 });

--- a/particles/Tutorial/Javascript/6_Handles/source/GetPerson.js
+++ b/particles/Tutorial/Javascript/6_Handles/source/GetPerson.js
@@ -10,14 +10,14 @@
 
  /* global defineParticle */
 
- defineParticle(({DomParticle, html}) => {
+ defineParticle(({SimpleParticle, html}) => {
 
     const template = html`
   <input value="{{name}}" placeholder="Enter your name" spellcheck="false" on-change="onNameInputChange">
   <div slotid="greetingSlot"></div>
     `;
 
-  return class extends DomParticle {
+  return class extends SimpleParticle {
     get template() {
       return template;
     }

--- a/particles/Words/source/ShowSingleStats.js
+++ b/particles/Words/source/ShowSingleStats.js
@@ -9,7 +9,7 @@
  */
 'use strict';
 
-defineParticle(({DomParticle, html, log, resolver}) => {
+defineParticle(({SimpleParticle, html, log, resolver}) => {
   function importLibrary(clazzType, filename) {
     // TODO(wkorman): The use of a `cdn` url below is a surprising workaround to
     // allow code sharing with the main Words game logic. This particle runs,
@@ -253,7 +253,7 @@ defineParticle(({DomParticle, html, log, resolver}) => {
 </template>
     `;
 
-  return class extends DomParticle {
+  return class extends SimpleParticle {
     get template() {
       return template;
     }

--- a/src/runtime/loader.ts
+++ b/src/runtime/loader.ts
@@ -160,7 +160,15 @@ export class Loader {
    */
   unwrapParticle(particleWrapper): typeof Particle {
     assert(this.pec);
-    return particleWrapper({Particle, DomParticle, TransformationDomParticle, MultiplexerDomParticle, Reference: ClientReference.newClientReference(this.pec), html});
+    return particleWrapper({
+      Particle,
+      DomParticle,
+      SimpleParticle: DomParticle,
+      TransformationDomParticle,
+      MultiplexerDomParticle,
+      Reference: ClientReference.newClientReference(this.pec),
+      html
+    });
   }
 
   clone(): Loader {

--- a/src/runtime/tests/artifacts/Words/source/GamePane.js
+++ b/src/runtime/tests/artifacts/Words/source/GamePane.js
@@ -11,7 +11,7 @@
 
 /* global defineParticle */
 
-defineParticle(({SimpleParticle, html, log, resolver}) => {
+defineParticle(({DomParticle, html, log, resolver}) => {
   function importLibrary(filename) {
     importScripts(resolver(`GamePane/${filename}`));
   }
@@ -306,7 +306,7 @@ defineParticle(({SimpleParticle, html, log, resolver}) => {
       '%cGamePane',
       `background: #ff69b4; color: white; padding: 1px 6px 2px 7px; border-radius: 6px;`);
 
-  return class extends SimpleParticle {
+  return class extends DomParticle {
     get template() {
       return template;
     }
@@ -364,7 +364,7 @@ defineParticle(({SimpleParticle, html, log, resolver}) => {
       }
     }
     buildRenderRecipe(renderParticle, gameId) {
-      return SimpleParticle
+      return DomParticle
           .buildManifest`
 ${renderParticle}
 


### PR DESCRIPTION
Essentially this converts the Particle corpus to UiBroker API.

`SimpleParticle` is the alias we agreed on for `UiParticle`.

`web-shell`, `pipes-shell`, and `dev-shell` (after #3673) are updated to consume output from `SimpleParticle`.

NB: my expectation is that `SimpleParticle` supports functional particles, non-rendering particles, and full featured particles equally well out-of-the-box. I will produce demonstration Particles next.