### PR TITLE
Simplify StorageProviderBase methods: on, off, _fire

### DIFF
--- a/shells/dev-shell/store-panel.js
+++ b/shells/dev-shell/store-panel.js
@@ -133,7 +133,7 @@ export class StorePanel extends HTMLElement {
     }
     await this.update(true);
     this.updateCallback = () => this.update(false);
-    store.on('change', this.updateCallback, this);
+    store.on(this.updateCallback);
   }
 
   interceptCtrlEnter(event) {
@@ -200,9 +200,9 @@ export class StorePanel extends HTMLElement {
     if (!this.saveBtn.classList.contains('enabled')) {
       return;
     }
-    this.store.off('change', this.updateCallback);
+    this.store.off(this.updateCallback);
     const ok = await this.writeToStore(this.contents.value.trim());
-    this.store.on('change', this.updateCallback, this);
+    this.store.on(this.updateCallback);
     if (ok) {
       this.saveBtn.classList.remove('enabled');
       this.update(true);
@@ -269,7 +269,7 @@ export class StorePanel extends HTMLElement {
 
   dispose() {
     if (this.updateCallback) {
-      this.store.off('change', this.updateCallback);
+      this.store.off(this.updateCallback);
     }
   }
 }

--- a/shells/lib/context-utils.js
+++ b/shells/lib/context-utils.js
@@ -10,7 +10,7 @@
 
 export const listenToStore = (store, onchange) => {
   // observe changes
-  store.on('change', onchange, store);
+  store.on(onchange);
   // record ability to stop observation
   return () => store.off(onchange);
 };

--- a/shells/pipes-shell/source/context.js
+++ b/shells/pipes-shell/source/context.js
@@ -27,7 +27,7 @@ export const mirrorStore = async (sourceStore, contextStore) => {
     cloneStoreChange(contextStore, change);
   };
   cloneStore(sourceStore, contextStore);
-  sourceStore.on('change', change, {});
+  sourceStore.on(change);
 };
 
 const cloneStore = async (sourceStore, contextStore) => {

--- a/shells/pipes-shell/source/lib/utils.js
+++ b/shells/pipes-shell/source/lib/utils.js
@@ -70,7 +70,7 @@ export const marshalOutput = async arc => {
       const change = ({data}) => {
         resolve(data);
       };
-      store.on('change', change, {});
+      store.on(change);
     }
   });
 };

--- a/shells/planner-shell/single-user-context.js
+++ b/shells/planner-shell/single-user-context.js
@@ -90,7 +90,7 @@ export const SingleUserContext = class {
     if (observer) {
       this.observers[key] = null;
       //log(`UNobserving [${key}]`);
-      observer.store.off('change', observer.cb);
+      observer.store.off(observer.cb);
     }
   }
   async observeStore(store, key, cb) {
@@ -113,7 +113,7 @@ export const SingleUserContext = class {
             cb({data});
           }
         }
-        this.observers[key] = {key, store, cb: store.on('change', cb, this)};
+        this.observers[key] = {key, store, cb: store.on(cb)};
       }
     }
   }

--- a/shells/planner-shell/user-arcs.js
+++ b/shells/planner-shell/user-arcs.js
@@ -75,7 +75,7 @@ export class UserArcs {
   async foundArcsStore(store) {
     log('foundArcsStore', Boolean(store));
     await this.publishInitialChanges(this.listeners);
-    store.on('change', changes => this.arcsStoreChange(changes), this);
+    store.on(changes => this.arcsStoreChange(changes));
   }
   arcsStoreChange(changes) {
     this.publish(changes, this.listeners);

--- a/shells/planner-shell/user-context.js
+++ b/shells/planner-shell/user-context.js
@@ -127,7 +127,7 @@ export class UserContext {
   // async updateFriends({storage, userid, context}, state) {
   //   if (state.friendsStore) {
   //     log('discarding old PROFILE_friends');
-  //     state.friendsStore.off('change', state.friendsStoreCb);
+  //     state.friendsStore.off(state.friendsStoreCb);
   //     state.friendsStore = null;
   //   }
   //   const friendsStore = await context.findStoreById('PROFILE_friends');
@@ -137,7 +137,7 @@ export class UserContext {
   //     // get current data
   //     const friends = await friendsStore.toList();
   //     // listen for changes
-  //     friendsStore.on('change', friendsStoreCb, this);
+  //     friendsStore.on(friendsStoreCb);
   //     // process friends already in store
   //     this.onFriendsChange(storage, context, {add: friends.map(f => ({value: f}))});
   //     this.state = {friendsStore, friendsStoreCb};

--- a/shells/web-shell/elements/web-shell.js
+++ b/shells/web-shell/elements/web-shell.js
@@ -193,7 +193,7 @@ export class WebShell extends Xen.Debug(Xen.Async, log) {
       const store = launcherArc.findStoresByType(shareSchema.type.collectionOf()).pop();
       if (store) {
         this.state = {store: store};
-        store.on('change', info => this.state = {info}, this);
+        store.on(info => this.state = {info});
         return;
       }
     }

--- a/src/devtools-connector/arc-stores-fetcher.ts
+++ b/src/devtools-connector/arc-stores-fetcher.ts
@@ -47,13 +47,13 @@ export class ArcStoresFetcher {
     for (const store of this.arc._stores) {
       if (!this.watchedHandles.has(store.id)) {
         this.watchedHandles.add(store.id);
-        store.on('change', async () => this.arcDevtoolsChannel.send({
+        store.on(async () => this.arcDevtoolsChannel.send({
           messageType: 'store-value-changed',
           messageBody: {
             id: store.id.toString(),
             value: await this.dereference(store)
           }
-        }), this);
+        }));
       }
     }
   }

--- a/src/planning/plan/plan-producer.ts
+++ b/src/planning/plan/plan-producer.ts
@@ -67,7 +67,7 @@ export class PlanProducer {
     this.inspector = inspector;
     if (this.searchStore) {
       this.searchStoreCallback = () => this.onSearchChanged();
-      this.searchStore.on('change', this.searchStoreCallback, this);
+      this.searchStore.on(this.searchStoreCallback);
     }
     this.debug = debug;
     this.noSpecEx = noSpecEx;
@@ -123,7 +123,7 @@ export class PlanProducer {
 
   dispose() {
     if (this.searchStore) {
-      this.searchStore.off('change', this.searchStoreCallback);
+      this.searchStore.off(this.searchStoreCallback);
     }
   }
 

--- a/src/planning/plan/planificator.ts
+++ b/src/planning/plan/planificator.ts
@@ -136,7 +136,7 @@ export class Planificator {
     this.arc.onDataChange(this.dataChangeCallback, this);
     this.arc.context.allStores.forEach(store => {
       if (store instanceof StorageProviderBase) {
-        store.on('change', this.dataChangeCallback, this);
+        store.on(this.dataChangeCallback);
       }
     });
   }
@@ -145,7 +145,7 @@ export class Planificator {
     this.arc.clearDataChange(this);
     this.arc.context.allStores.forEach(store => {
       if (store instanceof StorageProviderBase) {
-        store.off('change', this.dataChangeCallback);
+        store.off(this.dataChangeCallback);
       }
     });
   }

--- a/src/planning/plan/planning-result.ts
+++ b/src/planning/plan/planning-result.ts
@@ -47,7 +47,7 @@ export class PlanningResult {
     this.store = store;
     if (this.store) {
       this.storeCallback = () => this.load();
-      this.store.on('change', this.storeCallback, this);
+      this.store.on(this.storeCallback);
     }
   }
 
@@ -86,10 +86,10 @@ export class PlanningResult {
 
   dispose() {
     this.changeCallbacks = [];
-    this.store.off('change', this.storeCallback);
+    this.store.off(this.storeCallback);
     this.store.dispose();
   }
-  
+
   static formatSerializableGenerations(generations): SerializableGeneration[] {
     // Make a copy of everything and assign IDs to recipes.
     const idMap = new Map(); // Recipe -> ID

--- a/src/runtime/arc.ts
+++ b/src/runtime/arc.ts
@@ -738,7 +738,7 @@ ${this.activeRecipe.toString()}`;
     this.storeTags.set(store, new Set(tags));
 
     this.storageKeys[store.id] = store.storageKey;
-    store.on('change', () => this._onDataChange(), this);
+    store.on(() => this._onDataChange());
 
     Runtime.getRuntime().registerStore(store, tags);
   }

--- a/src/runtime/manual_tests/firebase-test.ts
+++ b/src/runtime/manual_tests/firebase-test.ts
@@ -77,7 +77,7 @@ describe('firebase', function() {
       const variable = await storage.construct('test0', barType, newStoreKey('variable')) as SingletonStorageProvider;
 
       let events = 0;
-      variable.on('change', () => events++, this);
+      variable.on(() => events++);
 
       await variable.set({id: 'test0:test', value});
       const result = await variable.get();
@@ -199,7 +199,7 @@ describe('firebase', function() {
       const collection = await storage.construct('test1', barType.collectionOf(), newStoreKey('collection')) as CollectionStorageProvider;
 
       let events = 0;
-      collection.on('change', () => events++, this);
+      collection.on(() => events++);
 
       await collection.store({id: 'id0', value: value1}, ['key0']);
       await collection.store({id: 'id1', value: value2}, ['key1']);

--- a/src/runtime/particle-execution-host.ts
+++ b/src/runtime/particle-execution-host.ts
@@ -179,7 +179,7 @@ class PECOuterPortImpl extends PECOuterPort {
 
   onInitializeProxy(handle: UnifiedStore, callback: number) {
     const target = {};
-    handle.on('change', data => this.SimpleCallback(callback, data), target);
+    handle.on(data => this.SimpleCallback(callback, data));
   }
 
   async onSynchronizeProxy(handle: UnifiedStore, callback: number) {

--- a/src/runtime/storage/firebase/firebase-storage.ts
+++ b/src/runtime/storage/firebase/firebase-storage.ts
@@ -440,10 +440,10 @@ class FirebaseVariable extends FirebaseStorageProvider implements SingletonStora
       const version = this.version;
       await this.ensureBackingStore().then(async store => {
         const data = await store.get(this.value.id);
-        await this._fire('change', new ChangeEvent({data, version}));
+        await this._fire(new ChangeEvent({data, version}));
       });
     } else {
-      await this._fire('change', new ChangeEvent({data: data.value || null, version: this.version}));
+      await this._fire(new ChangeEvent({data: data.value || null, version: this.version}));
     }
   }
 
@@ -547,7 +547,7 @@ class FirebaseVariable extends FirebaseStorageProvider implements SingletonStora
 
     await this._persistChanges();
 
-    await this._fire('change', new ChangeEvent({data: value, version, originatorId, barrier}));
+    await this._fire(new ChangeEvent({data: value, version, originatorId, barrier}));
   }
 
   async clear(originatorId:string = null, barrier: string = null) {
@@ -568,7 +568,7 @@ class FirebaseVariable extends FirebaseStorageProvider implements SingletonStora
     this.localModified = true;
     this.resolveInitialized();
     // TODO: do we need to fire an event here?
-    await this._fire('change', new ChangeEvent({data: this.referenceMode ? data : this.value, version: this.version}));
+    await this._fire(new ChangeEvent({data: this.referenceMode ? data : this.value, version: this.version}));
     await this._persistChanges();
   }
 
@@ -817,11 +817,11 @@ class FirebaseCollection extends FirebaseStorageProvider implements CollectionSt
         values.forEach(value => valueMap[value.id] = value);
         const addPrimitives = add.map(({value, keys, effective}) => ({value: valueMap[value.id], keys, effective}));
         const removePrimitives = remove.map(({value, keys, effective}) => ({value: valueMap[value.id], keys, effective}));
-        await this._fire('change', new ChangeEvent({add: addPrimitives, remove: removePrimitives, version: this.version}));
+        await this._fire(new ChangeEvent({add: addPrimitives, remove: removePrimitives, version: this.version}));
       });
 
     } else {
-      await this._fire('change', new ChangeEvent({add, remove, version: this.version}));
+      await this._fire(new ChangeEvent({add, remove, version: this.version}));
     }
   }
 
@@ -865,7 +865,7 @@ class FirebaseCollection extends FirebaseStorageProvider implements CollectionSt
 
     // 2. Notify listeners.
     items = items.filter(item => item.value);
-    await this._fire('change', new ChangeEvent({remove: items, version: this.version, originatorId}));
+    await this._fire(new ChangeEvent({remove: items, version: this.version, originatorId}));
 
     // 3. Add this modification to the set of local changes that need to be persisted.
     items.forEach(item => {
@@ -900,7 +900,7 @@ class FirebaseCollection extends FirebaseStorageProvider implements CollectionSt
     this.version++;
 
     // 2. Notify listeners.
-    await this._fire('change', new ChangeEvent({remove: [{value, keys, effective}], version: this.version, originatorId}));
+    await this._fire(new ChangeEvent({remove: [{value, keys, effective}], version: this.version, originatorId}));
 
     // 3. Add this modification to the set of local changes that need to be persisted.
     if (!this.localChanges.has(id)) {
@@ -933,7 +933,7 @@ class FirebaseCollection extends FirebaseStorageProvider implements CollectionSt
     }
 
     // 2. Notify listeners.
-    await this._fire('change', new ChangeEvent({add: [{value, keys, effective}], version: this.version, originatorId}));
+    await this._fire(new ChangeEvent({add: [{value, keys, effective}], version: this.version, originatorId}));
 
     // 3. Add this modification to the set of local changes that need to be persisted.
     if (!this.localChanges.has(id)) {
@@ -1596,11 +1596,11 @@ class FirebaseBackingStore extends FirebaseStorageProvider implements Collection
     throw new Error('FirebaseBackingStore does not implement ensureBackingStore');
   }
 
-  on(kindStr, callback, target) {
+  on(callback) {
     throw new Error('FirebaseBackingStore does not implement on');
   }
 
-  off(kindStr, callback) {
+  off(callback) {
     throw new Error('FirebaseBackingStore does not implement off');
   }
 

--- a/src/runtime/storage/pouchdb/pouch-db-collection.ts
+++ b/src/runtime/storage/pouchdb/pouch-db-collection.ts
@@ -92,7 +92,7 @@ export class PouchDbCollection extends PouchDbStorageProvider implements Collect
     const updatedCrdtModelLiteral = doc.model;
     const dataToFire = updatedCrdtModelLiteral.length === 0 ? null : updatedCrdtModelLiteral[0].value;
 
-    await this._fire('change', new ChangeEvent({data: dataToFire, version: this.version}));
+    await this._fire(new ChangeEvent({data: dataToFire, version: this.version}));
   }
 
   /** @inheritDoc */
@@ -255,7 +255,7 @@ export class PouchDbCollection extends PouchDbStorageProvider implements Collect
     }
 
     // Notify Listeners
-    await this._fire('change', new ChangeEvent({add: [item], version: this.version, originatorId}));
+    await this._fire(new ChangeEvent({add: [item], version: this.version, originatorId}));
   }
 
   async removeMultiple(items, originatorId?: string): Promise<void> {
@@ -281,7 +281,7 @@ export class PouchDbCollection extends PouchDbStorageProvider implements Collect
       return doc;
     });
 
-    await this._fire('change', new ChangeEvent({remove: items, version: this.version, originatorId}));
+    await this._fire(new ChangeEvent({remove: items, version: this.version, originatorId}));
   }
 
   /**
@@ -303,7 +303,7 @@ export class PouchDbCollection extends PouchDbStorageProvider implements Collect
         const effective = crdtmodel.remove(id, keys);
         // TODO(lindner): isolate side effects...
 
-        await this._fire('change', new ChangeEvent({remove: [{value, keys, effective}], version: this.version, originatorId}));
+        await this._fire(new ChangeEvent({remove: [{value, keys, effective}], version: this.version, originatorId}));
       }
       doc.model = crdtmodel.toLiteral();
       return doc;
@@ -326,7 +326,7 @@ export class PouchDbCollection extends PouchDbStorageProvider implements Collect
     // TODO(lindner): handle referenceMode
     // TODO(lindner): calculate added/removed keys from previousModel/model
     // TODO(lindner): fire change events here?
-    //   this._fire('change', new ChangeEvent({add, remove, version: this.version}));
+    //   this._fire(new ChangeEvent({add, remove, version: this.version}));
   }
 
   /**

--- a/src/runtime/storage/pouchdb/pouch-db-singleton.ts
+++ b/src/runtime/storage/pouchdb/pouch-db-singleton.ts
@@ -101,7 +101,7 @@ export class PouchDbSingleton extends PouchDbStorageProvider implements Singleto
         });
       }
 
-      await this._fire('change', new ChangeEvent({data: newvalue, version: this.version}));
+      await this._fire(new ChangeEvent({data: newvalue, version: this.version}));
     }
   }
 
@@ -262,7 +262,7 @@ export class PouchDbSingleton extends PouchDbStorageProvider implements Singleto
     this.bumpVersion();
 
     const data = this.referenceMode ? value : stored.value;
-    await this._fire('change', new ChangeEvent({data, version: this.version, originatorId, barrier}));
+    await this._fire(new ChangeEvent({data, version: this.version, originatorId, barrier}));
   }
 
   /**
@@ -294,11 +294,11 @@ export class PouchDbSingleton extends PouchDbStorageProvider implements Singleto
           console.log('PouchDbSingleton.onRemoteSynced: possible race condition for id=' + value.id);
           return;
         }
-        await this._fire('change', new ChangeEvent({data, version: this.version}));
+        await this._fire(new ChangeEvent({data, version: this.version}));
       });
     } else {
       if (value != null) {
-        await this._fire('change', new ChangeEvent({data: value, version: this.version}));
+        await this._fire(new ChangeEvent({data: value, version: this.version}));
       }
     }
   }

--- a/src/runtime/storage/synthetic-storage.ts
+++ b/src/runtime/storage/synthetic-storage.ts
@@ -150,7 +150,7 @@ class SyntheticCollection extends StorageProviderBase implements CollectionStora
     this.initialized = (async () => {
       const data = await targetStore.get();
       await this.process(data, false);
-      targetStore.on('change', details => this.process(details.data, true), this);
+      targetStore.on(details => this.process(details.data, true));
     })();
   }
 
@@ -180,7 +180,7 @@ class SyntheticCollection extends StorageProviderBase implements CollectionStora
       const diff = setDiffCustom(oldModel, this.model, JSON.stringify);
       const add = diff.add.map(arcHandle => ({value: arcHandle}));
       const remove = diff.remove.map(arcHandle => ({value: arcHandle}));
-      await this._fire('change', new ChangeEvent({add, remove}));
+      await this._fire(new ChangeEvent({add, remove}));
     }
   }
 

--- a/src/runtime/storage/volatile-storage.ts
+++ b/src/runtime/storage/volatile-storage.ts
@@ -321,7 +321,7 @@ export class VolatileCollection extends VolatileStorageProvider implements Colle
     }
 
     this.version++;
-    await this._fire('change', new ChangeEvent({add: [item], version: this.version, originatorId}));
+    await this._fire(new ChangeEvent({add: [item], version: this.version, originatorId}));
   }
 
   async removeMultiple(items, originatorId: string = null): Promise<void> {
@@ -339,7 +339,7 @@ export class VolatileCollection extends VolatileStorageProvider implements Colle
     });
     this.version++;
 
-    await this._fire('change', new ChangeEvent({remove: items, version: this.version, originatorId}));
+    await this._fire(new ChangeEvent({remove: items, version: this.version, originatorId}));
   }
 
   async remove(id, keys:string[] = [], originatorId=null) {
@@ -350,7 +350,7 @@ export class VolatileCollection extends VolatileStorageProvider implements Colle
     if (value !== null) {
       const effective = this._model.remove(id, keys);
       this.version++;
-      await this._fire('change', new ChangeEvent({remove: [{value, keys, effective}], version: this.version, originatorId}));
+      await this._fire(new ChangeEvent({remove: [{value, keys, effective}], version: this.version, originatorId}));
     }
   }
 
@@ -479,7 +479,7 @@ export class VolatileSingleton extends VolatileStorageProvider implements Single
     }
     this.version++;
     const data = this.referenceMode ? value : this._stored;
-    await this._fire('change', new ChangeEvent({data, version: this.version, originatorId, barrier}));
+    await this._fire(new ChangeEvent({data, version: this.version, originatorId, barrier}));
   }
 
   async clear(originatorId: string = null, barrier: string = null): Promise<void> {

--- a/src/runtime/storageNG/store.ts
+++ b/src/runtime/storageNG/store.ts
@@ -46,7 +46,7 @@ export class Store<T extends CRDTTypeRecord> extends UnifiedStore implements Sto
   modelForSynchronization(): {} {
     throw new Error('Method not implemented.');
   }
-  on(type: string, fn: Consumer<{}>, target: {}): void {
+  on(fn: Consumer<{}>): void {
     throw new Error('Method not implemented.');
   }
 

--- a/src/runtime/storageNG/unified-store.ts
+++ b/src/runtime/storageNG/unified-store.ts
@@ -46,7 +46,7 @@ export abstract class UnifiedStore implements Comparable<UnifiedStore> {
   abstract toLiteral(): Promise<any>;
   abstract cloneFrom(store: UnifiedStore): void;
   abstract modelForSynchronization(): {};
-  abstract on(type: string, fn: Consumer<{}>, target: {}): void;
+  abstract on(fn: Consumer<{}>): void;
   abstract description: string;
 
   _compareTo(other: UnifiedStore): number {

--- a/src/runtime/testing/callback-tracker.ts
+++ b/src/runtime/testing/callback-tracker.ts
@@ -28,7 +28,7 @@ export class CallbackTracker {
   events: Dictionary<any>[] = [];
 
   constructor(storageProvider: StorageProviderBase, public expectedEvents = 0) {
-    storageProvider.on('change', (val) => this.changeEvent(val), {});
+    storageProvider.on((val) => this.changeEvent(val));
   }
 
   // called for each change event

--- a/src/runtime/tests/handle-test.ts
+++ b/src/runtime/tests/handle-test.ts
@@ -42,7 +42,7 @@ describe('Handle', () => {
     const arc = new Arc({id: ArcId.newForTest('test'), context: manifest, loader});
     const store = await arc.createStore(manifest.schemas.Bar.type) as SingletonStorageProvider;
     let version = 0;
-    store.on('change', () => version++, {});
+    store.on(() => version++);
     assert.strictEqual(version, 0);
     const bar1 = {id: 'an id', value: 'a Bar'};
     await store.set(bar1);
@@ -58,7 +58,7 @@ describe('Handle', () => {
     const arc = new Arc({id: ArcId.newForTest('test'), context: manifest, loader});
     const barStore = await arc.createStore(manifest.schemas.Bar.type.collectionOf()) as CollectionStorageProvider;
     let version = 0;
-    barStore.on('change', ({add: [{effective}]}) => {if (effective) version++;}, {});
+    barStore.on(({add: [{effective}]}) => {if (effective) version++;});
     assert.strictEqual(barStore.version, 0);
     const bar1 = {id: 'an id', value: 'a Bar'};
     await barStore.store(bar1, ['key1']);

--- a/src/runtime/tests/synthetic-storage-test.ts
+++ b/src/runtime/tests/synthetic-storage-test.ts
@@ -110,7 +110,7 @@ describe('synthetic storage ', () => {
         use Store0 #taggy #waggy as handle0
         use Store1 as handle1`);
 
-    synth.on('change', () => assert.fail('change event should not fire for initial value'), {});
+    synth.on(() => assert.fail('change event should not fire for initial value'));
 
     const list = await synth.toList();
     assert.deepEqual(list.map(h => flatten(h)),
@@ -133,7 +133,7 @@ describe('synthetic storage ', () => {
     // and the only way to detect this is the change event fired by the synthetic collection.
     let resolver;
     const eventPromise = new Promise<ChangeEvent>(resolve => resolver = resolve);
-    synth.on('change', e => resolver(e), {});
+    synth.on(e => resolver(e));
 
     await targetStore.set(new ArcType().newInstance(id, `
       schema Bar

--- a/src/tools/dev_server/hot-reload-server.ts
+++ b/src/tools/dev_server/hot-reload-server.ts
@@ -66,7 +66,7 @@ export class HotReloadServer {
             console.log(`Watching: ${local}`);
           }
           this.filesToWatch.push(file);
-          
+
           let watcher;
           if (local.endsWith('.wasm')) {
             watcher = this.chokidar.watch(local, {


### PR DESCRIPTION
They didn't need the change/target params. This will make it fit better
with the new store's API