### PR TITLE
Make StorageStub extend UnifiedStore, and use in Manifest parsing

### DIFF
--- a/src/devtools-connector/arc-stores-fetcher.ts
+++ b/src/devtools-connector/arc-stores-fetcher.ts
@@ -11,7 +11,6 @@
 import {Arc} from '../runtime/arc.js';
 import {ArcDevtoolsChannel} from './abstract-devtools-channel.js';
 import {Manifest} from '../runtime/manifest.js';
-import {StorageStub} from '../runtime/storage-stub.js';
 import {SingletonStorageProvider, CollectionStorageProvider} from '../runtime/storage/storage-provider-base.js';
 import {Type} from '../runtime/type.js';
 import {StorageKey} from '../runtime/storageNG/storage-key.js';
@@ -59,7 +58,7 @@ export class ArcStoresFetcher {
   }
 
   private async listStores() {
-    const find = (manifest: Manifest): [StorageStub, string[]][] => {
+    const find = (manifest: Manifest): [UnifiedStore, string[]][] => {
       let tags = [...manifest.storeTags];
       if (manifest.imports) {
         manifest.imports.forEach(imp => tags = tags.concat(find(imp)));
@@ -72,7 +71,7 @@ export class ArcStoresFetcher {
     };
   }
 
-  private async digestStores(stores: [UnifiedStore | StorageStub, string[] | Set<string>][]) {
+  private async digestStores(stores: [UnifiedStore, string[] | Set<string>][]) {
     const result: Result[] = [];
     for (const [store, tags] of stores) {
       result.push({
@@ -89,7 +88,7 @@ export class ArcStoresFetcher {
   }
 
   // tslint:disable-next-line: no-any
-  private async dereference(store: UnifiedStore | StorageStub): Promise<any> {
+  private async dereference(store: UnifiedStore): Promise<any> {
     if ((store as CollectionStorageProvider).toList) {
       return (store as CollectionStorageProvider).toList();
     } else if ((store as SingletonStorageProvider).get) {

--- a/src/planning/strategies/tests/search-tokens-to-handles-test.ts
+++ b/src/planning/strategies/tests/search-tokens-to-handles-test.ts
@@ -35,7 +35,7 @@ describe('SearchTokensToHandles', () => {
     `));
 
     const arc = StrategyTestHelper.createTestArc(manifest);
-    arc._registerStore((await arc.context.stores[0].inflate()) as StorageProviderBase, ['mything']);
+    arc._registerStore((await arc.context.stores[0].castToStorageStub().inflate()) as StorageProviderBase, ['mything']);
 
     const recipe = manifest.recipes[0];
     assert(recipe.normalize());

--- a/src/runtime/arc.ts
+++ b/src/runtime/arc.ts
@@ -432,7 +432,7 @@ ${this.activeRecipe.toString()}`;
     });
     await Promise.all(manifest.stores.map(async storeStub => {
       const tags = manifest.storeTags.get(storeStub);
-      const store: UnifiedStore = await storeStub.inflate();
+      const store: UnifiedStore = await storeStub.castToStorageStub().inflate();
       arc._registerStore(store, tags);
     }));
     const recipe = manifest.activeRecipe.clone();

--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -32,13 +32,13 @@ import {Recipe, RequireSection} from './recipe/recipe.js';
 import {Search} from './recipe/search.js';
 import {TypeChecker} from './recipe/type-checker.js';
 import {Schema} from './schema.js';
-import {StorageProviderBase} from './storage/storage-provider-base.js';
 import {StorageProviderFactory} from './storage/storage-provider-factory.js';
 import {BigCollectionType, CollectionType, EntityType, InterfaceType, ReferenceType, SlotType, Type, TypeVariable} from './type.js';
 import {Dictionary} from './hot.js';
 import {ClaimIsTag} from './particle-claim.js';
-import {StorageStub} from './storage-stub.js';
 import {VolatileStorage} from './storage/volatile-storage.js';
+import {UnifiedStore} from './storageNG/unified-store.js';
+import {StorageStub} from './storage-stub.js';
 
 export class ManifestError extends Error {
   location: AstNode.SourceLocation;
@@ -111,9 +111,9 @@ export class Manifest {
   // TODO: These should be lists, possibly with a separate flattened map.
   private _particles: Dictionary<ParticleSpec> = {};
   private _schemas: Dictionary<Schema> = {};
-  private _stores: StorageStub[] = [];
+  private _stores: UnifiedStore[] = [];
   private _interfaces = <InterfaceInfo[]>[];
-  storeTags: Map<StorageStub, string[]> = new Map();
+  storeTags: Map<UnifiedStore, string[]> = new Map();
   private _fileName: string|null = null;
   private readonly _id: Id;
   // TODO(csilvestrini): Inject an IdGenerator instance instead of creating a new one.
@@ -180,7 +180,7 @@ export class Manifest {
   get fileName() {
     return this._fileName;
   }
-  get stores(): StorageStub[] {
+  get stores(): UnifiedStore[] {
     return this._stores;
   }
   get allStores() {
@@ -205,17 +205,17 @@ export class Manifest {
   }
   // TODO: newParticle, Schema, etc.
   // TODO: simplify() / isValid().
-  async createStore(type: Type, name: string, id: string, tags: string[], claims?: ClaimIsTag[], storageKey?: string) : Promise<StorageProviderBase | StorageStub> {
-    return this.newStorageStub(type, name, id, storageKey, tags, null, claims);
+  async createStore(type: Type, name: string, id: string, tags: string[], claims?: ClaimIsTag[], storageKey?: string) : Promise<UnifiedStore> {
+    return this.newStore(type, name, id, storageKey, tags, null, claims);
   }
 
-  _addStore(store: StorageStub, tags: string[]) {
+  _addStore(store: UnifiedStore, tags: string[]) {
     this._stores.push(store);
     this.storeTags.set(store, tags ? tags : []);
     return store;
   }
 
-  newStorageStub(type: Type, name: string, id: string, storageKey: string, tags: string[],
+  newStore(type: Type, name: string, id: string, storageKey: string, tags: string[],
                  originalId: string, claims: ClaimIsTag[], description?: string, version?: number,
                  source?: string, referenceMode?: boolean, model?: {}[]) {
     if (source) {
@@ -270,16 +270,16 @@ export class Manifest {
   findStoreById(id: string) {
     return this._find(manifest => manifest._stores.find(store => store.id === id));
   }
-  findStoreTags(store: StorageStub) : Set<string> {
+  findStoreTags(store: UnifiedStore) : Set<string> {
     return new Set(this._find(manifest => manifest.storeTags.get(store)));
   }
   findManifestUrlForHandleId(id: string) {
     return this._find(manifest => manifest.storeManifestUrls.get(id));
   }
-  findStoresByType(type: Type, options = {tags: <string[]>[], subtype: false}): StorageStub[] {
+  findStoresByType(type: Type, options = {tags: <string[]>[], subtype: false}): UnifiedStore[] {
     const tags = options.tags || [];
     const subtype = options.subtype || false;
-    function typePredicate(store: StorageStub) {
+    function typePredicate(store: UnifiedStore) {
       const resolvedType = type.resolvedType();
       if (!resolvedType.isResolved()) {
         return (type instanceof CollectionType) === (store.type instanceof CollectionType) &&
@@ -296,7 +296,7 @@ export class Manifest {
 
       return TypeChecker.compareTypes({type: store.type}, {type});
     }
-    function tagPredicate(manifest: Manifest, store: StorageStub) {
+    function tagPredicate(manifest: Manifest, store: UnifiedStore) {
       return tags.filter(tag => !manifest.storeTags.get(store).includes(tag)).length === 0;
     }
 
@@ -1118,7 +1118,7 @@ ${e.message}
     // Instead of creating links to remote firebase during manifest parsing,
     // we generate storage stubs that contain the relevant information.
     if (item.origin === 'storage') {
-      return manifest.newStorageStub(type, name, id, item.source, tags, originalId, claims, item.description, item.version);
+      return manifest.newStore(type, name, id, item.source, tags, originalId, claims, item.description, item.version);
     }
 
     let json: string;
@@ -1212,7 +1212,7 @@ ${e.message}
     }
     const version = item.version || 0;
     const storageKey = (manifest.storageProviderFactory._storageForKey('volatile') as VolatileStorage).constructKey('volatile');
-    return manifest.newStorageStub(
+    return manifest.newStore(
         type, name, id, storageKey, tags, originalId, claims, item.description, version, item.source, referenceMode, model);
   }
 

--- a/src/runtime/storage-stub.ts
+++ b/src/runtime/storage-stub.ts
@@ -15,11 +15,12 @@ import {StorageProviderBase} from './storage/storage-provider-base.js';
 import {StorageProviderFactory} from './storage/storage-provider-factory.js';
 import {Type} from './type.js';
 import {VolatileStorageProvider} from './storage/volatile-storage.js';
+import {UnifiedStore} from './storageNG/unified-store.js';
 
 // TODO(shans): Make sure that after refactor Storage objects have a lifecycle and can be directly used
 // deflated rather than requiring this stub.
-export class StorageStub {
-  constructor(public readonly type: Type, 
+export class StorageStub extends UnifiedStore {
+  constructor(public readonly type: Type,
               public readonly id: string,
               public readonly name: string,
               public readonly storageKey: string,
@@ -31,7 +32,9 @@ export class StorageStub {
               public readonly version?: number,
               public readonly source?: string,
               public referenceMode: boolean = false,
-              public readonly model?: {}[]) {}
+              public readonly model?: {}[]) {
+    super();
+  }
 
   async inflate(storageProviderFactory?: StorageProviderFactory) {
     const factory = storageProviderFactory || this.storageProviderFactory;

--- a/src/runtime/storage-stub.ts
+++ b/src/runtime/storage-stub.ts
@@ -8,7 +8,6 @@
  * http://polymer.github.io/PATENTS.txt
  */
 import {assert} from '../platform/assert-web.js';
-
 import {compareStrings} from './recipe/comparable.js';
 import {ClaimIsTag} from './particle-claim.js';
 import {StorageProviderBase} from './storage/storage-provider-base.js';
@@ -20,6 +19,8 @@ import {UnifiedStore} from './storageNG/unified-store.js';
 // TODO(shans): Make sure that after refactor Storage objects have a lifecycle and can be directly used
 // deflated rather than requiring this stub.
 export class StorageStub extends UnifiedStore {
+  protected unifiedStoreType: 'StorageStub' = 'StorageStub';
+
   constructor(public readonly type: Type,
               public readonly id: string,
               public readonly name: string,

--- a/src/runtime/storage/storage-provider-base.ts
+++ b/src/runtime/storage/storage-provider-base.ts
@@ -105,6 +105,8 @@ export class ChangeEvent {
  * Docs TBD
  */
 export abstract class StorageProviderBase extends UnifiedStore implements Store {
+  protected unifiedStoreType: 'StorageProviderBase';
+
   private readonly listeners: Set<Callback> = new Set();
   private readonly _type: Type;
 

--- a/src/runtime/storageNG/store.ts
+++ b/src/runtime/storageNG/store.ts
@@ -30,6 +30,7 @@ type StoreConstructor = {
 //
 // Calling 'activate()' will generate an interactive store and return it.
 export class Store<T extends CRDTTypeRecord> extends UnifiedStore implements StoreInterface<T> {
+  protected unifiedStoreType: 'Store' = 'Store';
 
   toString(tags: string[]): string {
     throw new Error('Method not implemented.');

--- a/src/runtime/storageNG/store.ts
+++ b/src/runtime/storageNG/store.ts
@@ -43,9 +43,7 @@ export class Store<T extends CRDTTypeRecord> extends UnifiedStore implements Sto
   cloneFrom(store: UnifiedStore): void {
     throw new Error('Method not implemented.');
   }
-  modelForSynchronization(): {} {
-    throw new Error('Method not implemented.');
-  }
+
   on(fn: Consumer<{}>): void {
     throw new Error('Method not implemented.');
   }

--- a/src/runtime/storageNG/unified-store.ts
+++ b/src/runtime/storageNG/unified-store.ts
@@ -62,7 +62,11 @@ export abstract class UnifiedStore implements Comparable<UnifiedStore> {
    * delete.
    */
   castToStorageStub(): StorageStub {
-    return this as unknown as StorageStub;
+    if (this instanceof StorageStub) {
+      return this;
+    } else {
+      throw new Error('Not a StorageStub!');
+    }
   }
 
   _compareTo(other: UnifiedStore): number {

--- a/src/runtime/storageNG/unified-store.ts
+++ b/src/runtime/storageNG/unified-store.ts
@@ -12,8 +12,8 @@ import {Comparable, compareStrings, compareNumbers} from '../recipe/comparable.j
 import {Type} from '../type.js';
 import {StorageKey} from './storage-key.js';
 import {Consumer} from '../hot.js';
-import {StorageProviderBase} from '../storage/storage-provider-base.js';
 import {StorageStub} from '../storage-stub.js';
+import {assert} from '../../platform/assert-web.js';
 
 /**
  * This is a temporary interface used to unify old-style stores (storage/StorageProviderBase) and new-style stores (storageNG/Store).
@@ -31,6 +31,9 @@ import {StorageStub} from '../storage-stub.js';
  * Store class.
  */
 export abstract class UnifiedStore implements Comparable<UnifiedStore> {
+  // Tags for all subclasses of UnifiedStore.
+  protected abstract unifiedStoreType: 'Store' | 'StorageStub' | 'StorageProviderBase';
+
   abstract id: string;
   abstract name: string;
   abstract type: Type;
@@ -54,7 +57,7 @@ export abstract class UnifiedStore implements Comparable<UnifiedStore> {
   async modelForSynchronization(): Promise<{}> {
     return await this.toLiteral();
   }
-  abstract on(fn: Consumer<{}>): void;
+  on(fn: Consumer<{}>): void {}
 
   /**
    * Hack to cast this UnifiedStore to the old-style class StorageStub.
@@ -62,11 +65,9 @@ export abstract class UnifiedStore implements Comparable<UnifiedStore> {
    * delete.
    */
   castToStorageStub(): StorageStub {
-    if (this instanceof StorageStub) {
-      return this;
-    } else {
-      throw new Error('Not a StorageStub!');
-    }
+    // Can't use instanceof; causes circular dependencies.
+    assert(this.unifiedStoreType === 'StorageStub', 'Not a StorageStub!');
+    return this as unknown as StorageStub;
   }
 
   _compareTo(other: UnifiedStore): number {

--- a/src/runtime/storageNG/unified-store.ts
+++ b/src/runtime/storageNG/unified-store.ts
@@ -12,6 +12,8 @@ import {Comparable, compareStrings, compareNumbers} from '../recipe/comparable.j
 import {Type} from '../type.js';
 import {StorageKey} from './storage-key.js';
 import {Consumer} from '../hot.js';
+import {StorageProviderBase} from '../storage/storage-provider-base.js';
+import {StorageStub} from '../storage-stub.js';
 
 /**
  * This is a temporary interface used to unify old-style stores (storage/StorageProviderBase) and new-style stores (storageNG/Store).
@@ -31,7 +33,6 @@ import {Consumer} from '../hot.js';
 export abstract class UnifiedStore implements Comparable<UnifiedStore> {
   abstract id: string;
   abstract name: string;
-  abstract source: string;
   abstract type: Type;
   // TODO: Once the old storage stack is gone, this should only be of type StorageKey.
   abstract storageKey: string | StorageKey;
@@ -44,10 +45,25 @@ export abstract class UnifiedStore implements Comparable<UnifiedStore> {
   // JSON representation for insertion into the serialization.
   // tslint:disable-next-line no-any
   abstract toLiteral(): Promise<any>;
-  abstract cloneFrom(store: UnifiedStore): void;
-  abstract modelForSynchronization(): {};
-  abstract on(fn: Consumer<{}>): void;
+
+  // TODO: These properties/methods do not belong on UnifiedStore. They should
+  // probably go on some other abstraction like UnifiedActiveStore or similar.
+  abstract source?: string;
   abstract description: string;
+  cloneFrom(store: UnifiedStore): void {}
+  async modelForSynchronization(): Promise<{}> {
+    return await this.toLiteral();
+  }
+  abstract on(fn: Consumer<{}>): void;
+
+  /**
+   * Hack to cast this UnifiedStore to the old-style class StorageStub.
+   * TODO: Fix all usages of this method to handle new-style stores, and then
+   * delete.
+   */
+  castToStorageStub(): StorageStub {
+    return this as unknown as StorageStub;
+  }
 
   _compareTo(other: UnifiedStore): number {
     let cmp: number;

--- a/src/runtime/tests/manifest-test.ts
+++ b/src/runtime/tests/manifest-test.ts
@@ -1313,7 +1313,7 @@ ${particleStr1}
         return `${path} ${file}`;
       }
     }();
-        
+
     const manifest = await Manifest.load('somewhere/a', loader, {registry});
     assert(registry['somewhere/a path/b']);
   });
@@ -1367,7 +1367,7 @@ ${particleStr1}
     const manifest = await Manifest.load('the.manifest', loader);
     const storageStub = manifest.findStoreByName('Store0');
     assert(storageStub);
-    const store = await storageStub.inflate() as CollectionStorageProvider;
+    const store = await storageStub.castToStorageStub().inflate() as CollectionStorageProvider;
     assert(store);
 
     const sessionId = manifest.idGeneratorForTesting.currentSessionIdForTesting;
@@ -1412,7 +1412,7 @@ Error parsing JSON from 'EntityList' (Unexpected token h in JSON at position 1)'
 
       store Store0 of [Thing] in EntityList
     `, {fileName: 'the.manifest'});
-    const store = (await manifest.findStoreByName('Store0').inflate()) as CollectionStorageProvider;
+    const store = (await manifest.findStoreByName('Store0').castToStorageStub().inflate()) as CollectionStorageProvider;
     assert(store);
 
     const sessionId = manifest.idGeneratorForTesting.currentSessionIdForTesting;
@@ -2278,18 +2278,18 @@ resource SomeName
     const recipe = manifest.recipes[0];
     assert.strictEqual(recipe.particles[0].connections.a.handle, recipe.particles[1].connections.b.handle);
   });
-  
+
   it('can parse recipes with a require section', async () => {
     const manifest = await Manifest.parse(`
       particle P1
         out S {} a
-        consume root 
+        consume root
           provide details
       particle P2
         in S {} b
           consume details
-      
-      recipe 
+
+      recipe
         require
           handle as h0
           slot as s0
@@ -2305,7 +2305,7 @@ resource SomeName
     const recipe = manifest.recipes[0];
     assert(recipe.requires.length === 1, 'could not parse require section');
   });
- 
+
   it('recipe resolution checks the require sections', async () => {
     const manifest = await Manifest.parse(`
 
@@ -2337,7 +2337,7 @@ resource SomeName
       const particle = manifest.particles[0];
       assert.isEmpty(particle.trustChecks);
       assert.lengthOf(particle.trustClaims, 2);
-      
+
       const claim1 = particle.trustClaims.find(claim => claim.handle.name === 'output1');
       assert.isNotNull(claim1);
       assert.strictEqual((claim1.claims[0] as ClaimIsTag).tag, 'property1');
@@ -2357,7 +2357,7 @@ resource SomeName
       const particle = manifest.particles[0];
       assert.isEmpty(particle.trustChecks);
       assert.lengthOf(particle.trustClaims, 1);
-      
+
       const claim = particle.trustClaims.find(claim => claim.handle.name === 'output1');
       assert.isNotNull(claim);
       assert.sameMembers((claim.claims as ClaimIsTag[]).map(claim => claim.tag), ['property1', 'property2']);
@@ -2393,7 +2393,7 @@ resource SomeName
       const particle = manifest.particles[0];
       assert.isEmpty(particle.trustChecks);
       assert.strictEqual(particle.trustClaims.length, 1);
-      
+
       const claim = particle.trustClaims.find(claim => claim.handle.name === 'output');
       assert.isNotNull(claim);
       assert.sameMembers((claim.claims as ClaimDerivesFrom[]).map(claim => claim.parentHandle.name), ['input1', 'input2']);
@@ -2411,7 +2411,7 @@ resource SomeName
       const particle = manifest.particles[0];
       assert.isEmpty(particle.trustChecks);
       assert.lengthOf(particle.trustClaims, 1);
-      
+
       const claim = particle.trustClaims.find(claim => claim.handle.name === 'output1');
       assert.isNotNull(claim);
       assert.lengthOf(claim.claims, 5);
@@ -2424,7 +2424,7 @@ resource SomeName
       assert.lengthOf(derivesClaims, 2);
       assert.sameMembers(derivesClaims.map(claim => claim.parentHandle.name), ['input1', 'input2']);
     });
-    
+
     it('supports multiple check statements', async () => {
       const manifest = await Manifest.parse(`
         particle A
@@ -2437,7 +2437,7 @@ resource SomeName
       const particle = manifest.particles[0];
       assert.isEmpty(particle.trustClaims);
       assert.lengthOf(particle.trustChecks, 2);
-      
+
       const check1 = checkDefined(particle.trustChecks[0]);
       assert.strictEqual(check1.toManifestString(), 'check input1 is property1');
       assert.strictEqual(check1.target.name, 'input1');
@@ -2461,7 +2461,7 @@ resource SomeName
       const particle = manifest.particles[0];
       assert.isEmpty(particle.trustClaims);
       assert.lengthOf(particle.trustChecks, 2);
-      
+
       const check1 = checkDefined(particle.trustChecks[0]);
       assert.strictEqual(check1.toManifestString(), 'check input1 is from store MyStore');
       assert.strictEqual(check1.target.name, 'input1');
@@ -2487,7 +2487,7 @@ resource SomeName
       const particle = manifest.particles[0];
       assert.isEmpty(particle.trustClaims);
       assert.lengthOf(particle.trustChecks, 2);
-      
+
       const check1 = checkDefined(particle.trustChecks[0]);
       assert.strictEqual(check1.toManifestString(), 'check input1 is from output output1');
       assert.strictEqual(check1.target.name, 'input1');
@@ -2509,7 +2509,7 @@ resource SomeName
       const particle = manifest.particles[0];
       assert.isEmpty(particle.trustClaims);
       assert.lengthOf(particle.trustChecks, 1);
-      
+
       const check = particle.trustChecks[0];
       assert.strictEqual(check.toManifestString(), 'check mySlot data is trusted');
       assert.isTrue(check.target instanceof ProvideSlotConnectionSpec);
@@ -2596,7 +2596,7 @@ resource SomeName
           [{"nobId": "12345"}]
       `);
       assert.lengthOf(manifest.stores, 1);
-      const store = manifest.stores[0];
+      const store = manifest.stores[0].castToStorageStub();
       assert.lengthOf(store.claims, 2);
       assert.strictEqual(store.claims[0].tag, 'property1');
       assert.strictEqual(store.claims[1].tag, 'property2');
@@ -2632,7 +2632,7 @@ resource SomeName
   modality dom
   consume parentSlot
     provide childSlot`;
-    
+
       const manifest = await Manifest.parse(manifestString);
       assert.strictEqual(manifest.toString(), manifestString);
     });
@@ -2745,7 +2745,7 @@ resource SomeName
         assert.isEmpty(result[0].fields);
         assert.lengthOf(result[0].names, 1);
         assert.deepEqual(result[0].names, ['Foo']);
-    
+
       });
       it('handles a schema with fields', async () => {
         const manifest = await Manifest.parse(`
@@ -2828,9 +2828,9 @@ resource SomeName
         schema Foo
           Text name
           Number age
-        
+
         store FooStore of Foo in 'b'
-        
+
         particle Bar
           recipe Food
             Bar`;

--- a/src/tests/multiplexer-integration-test.ts
+++ b/src/tests/multiplexer-integration-test.ts
@@ -31,7 +31,7 @@ describe('Multiplexer', () => {
     const showTwoSpec = JSON.stringify(showTwoParticle.toLiteral());
     const recipeOne = `${showOneParticle.toString()}\nrecipe\n  use '{{item_id}}' as v1\n  slot '{{slot_id}}' as s1\n  ShowOne\n    post <- v1\n    consume item as s1`;
     const recipeTwo = `${showTwoParticle.toString()}\nrecipe\n  use '{{item_id}}' as v1\n  slot '{{slot_id}}' as s1\n  ShowTwo\n    post <- v1\n    consume item as s1`;
-    const postsStub = context.stores[0];
+    const postsStub = context.stores[0].castToStorageStub();
     postsStub.model.push({
       id: '1',
       keys: ['key1'],


### PR DESCRIPTION
Also added a new hacky method to cast from UnifiedStore to StorageStub.
This will make it easier to track down all the places we need to update
to handle the new storage api.