### PR TITLE
Freezes messages coming across the pec as a defence against divergence.

### DIFF
--- a/src/devtools-connector/devtools-arc-inspector.ts
+++ b/src/devtools-connector/devtools-arc-inspector.ts
@@ -106,6 +106,13 @@ class DevtoolsArcInspector implements ArcInspector {
   public pecMessage(name: string, pecMsgBody: object, pecMsgCount: number, stackString: string) {
     if (!DevtoolsConnection.isConnected) return;
     
+    // Modifying pec messages is a problem as they are transmited to DevTools with a delay. If the
+    // object representing a message is modified, it appears as if a different messages travelled
+    // across the pec. We could have made a deep copy of the message object, but agreed that these
+    // objects should not be modified as a matter of principle. We are freezing them as a defensive
+    // measure, but only if DevTools is connected, as freezing has performance penalty.
+    deepFreeze(pecMsgBody);
+
     const stack = this._extractStackFrames(stackString);
     this.arcDevtoolsChannel.send({
       messageType: 'PecLog',
@@ -206,4 +213,15 @@ class DevtoolsArcInspector implements ArcInspector {
       }
     });
   }
+}
+
+function deepFreeze(object: object) {
+  for (const name of Object.getOwnPropertyNames(object)) {
+    const value = object[name];
+    if (value && typeof value === 'object') {
+      deepFreeze(value);
+    }
+  }
+
+  Object.freeze(object);
 }

--- a/src/devtools-connector/tests/devtools-arc-inspector-test.ts
+++ b/src/devtools-connector/tests/devtools-arc-inspector-test.ts
@@ -51,12 +51,13 @@ describe('DevtoolsArcInspector', () => {
     const instantiateParticleCall = DevtoolsForTests.channel.messages.find(m =>
       m.messageType === 'PecLog' && m.messageBody.name === 'InstantiateParticle').messageBody;
 
-    // Type is a complex object to reproduce, let's skip asserting on it.
-    delete instantiateParticleCall.pecMsgBody.spec.args[0].type;
+    // Type on the particle spec is a complex object to reproduce, let's skip asserting on it.
+    const pecMsgBody = JSON.parse(JSON.stringify(instantiateParticleCall.pecMsgBody));
+    delete pecMsgBody.spec.args[0].type;
 
     const sessionId = arc.idGeneratorForTesting.currentSessionIdForTesting;
 
-    assert.deepEqual(instantiateParticleCall.pecMsgBody, {
+    assert.deepEqual(pecMsgBody, {
       id: `!${sessionId}:demo:particle1`,
       identifier: `!${sessionId}:demo:particle1`,
       stores: {
@@ -65,7 +66,6 @@ describe('DevtoolsArcInspector', () => {
       spec: {
         name: 'P',
         description: {},
-        implBlobUrl: undefined,
         implFile: 'p.js',
         modality: ['dom'],
         slotConnections: [],

--- a/src/runtime/slot-composer.ts
+++ b/src/runtime/slot-composer.ts
@@ -169,6 +169,10 @@ export class SlotComposer {
     const slotConsumer = this.getSlotConsumer(particle, slotName);
     assert(slotConsumer, `Cannot find slot (or hosted slot) ${slotName} for particle ${particle.name}`);
 
+    // Content object as received by the particle execution host is frozen.
+    // SlotComposer attach properties to this object, so we need to clone it at the top level.
+    content = {...content};
+
     slotConsumer.slotContext.onRenderSlot(slotConsumer, content, async (eventlet) => {
       slotConsumer.arc.pec.sendEvent(particle, slotName, eventlet);
       // This code is a temporary hack implemented in #2011 which allows to route UI events from


### PR DESCRIPTION
pec messages are scheduled to be forwarded to arcs explorer. If they get modified in the meantime, that can confuse the debugging or even break the serialisation process.