### PR TITLE
Fixes to ui-slot-composer (event, content object)

### DIFF
--- a/shells/broker-shell/index.js
+++ b/shells/broker-shell/index.js
@@ -22,11 +22,13 @@ const Application = {
   },
   // handle packets that were not otherwised consumed
   receive(packet) {
+    const {content: slot} = packet;
     // TODO(sjmiles): UiParticles that do not implement `render` return no content(?)
-    if (packet.content) {
+    if (slot) {
+      const {model} = slot.content;
       // if we get a slot-render request for 'notification' modality, make a toast for it
-      if (packet.content.model.modality === 'notification') {
-        addToast(packet.content.model.text);
+      if (model.modality === 'notification') {
+        addToast(model.text);
       }
     }
   },

--- a/shells/broker-shell/lib/platform.js
+++ b/shells/broker-shell/lib/platform.js
@@ -43,8 +43,8 @@ export const connectToPlatform = async Application => {
   // uiBroker communicates with the ui surface
   const uiBroker = {
     render(packet) {
-      const {content} = packet;
-      switch (content.model && content.model.modality) {
+      const {content: slot} = packet;
+      switch (slot.content.model && slot.content.model.modality) {
         case 'notification':
           // delegate to Application
           Application.receive(packet);
@@ -61,7 +61,7 @@ export const connectToPlatform = async Application => {
     // locate the renderer
     const {renderer} = renderSurface;
     // extract packet data
-    const {content, tid} = packet;
+    const {content: slot, tid} = packet;
     // attach an event dispatcher
     if (!tid) {
       console.warn('slot packet missing `tid`: so events are not supported');
@@ -71,7 +71,7 @@ export const connectToPlatform = async Application => {
       };
     }
     // send message to renderer
-    renderer.render(content);
+    renderer.render(slot);
   };
   // forward toast events to application
   renderToasts.onclick = toast => Application.notificationClick(toast);

--- a/shells/lib/xen-renderer.js
+++ b/shells/lib/xen-renderer.js
@@ -8,12 +8,10 @@
  * http://polymer.github.io/PATENTS.txt
  */
 import {Xen} from '../lib/components/xen.js';
-import {logFactory} from '../../build/runtime/log-factory.js';
+import {logsFactory} from '../../build/runtime/log-factory.js';
 import IconStyles from '../../modalities/dom/components/icons.css.js';
 
-const log = logFactory('Renderer', 'tomato');
-//const warn = logFactory('Renderer', 'tomato', 'warn');
-//const groupCollapsed = logFactory('Renderer', 'tomato', 'groupCollapsed');
+const {log} = logsFactory('Renderer', 'tomato');
 
 const slotId = id => `[slotid="${queryId(id)}"]`;
 const queryId = id => `${id.replace(/[:!]/g, '_')}`;
@@ -99,8 +97,6 @@ export const SlotObserver = class {
     if (isEmptySlot(slot)) {
       // empty, just pretend it rendered
       success = true;
-    } else if (slot.model && slot.model.json) {
-      success = await this.renderDataSlot(slot);
     } else {
       success = await this.renderXenSlot(slot);
     }
@@ -115,18 +111,8 @@ export const SlotObserver = class {
     // }
     return success;
   }
-  async renderDataSlot(slot) {
-    const data = document.querySelector(slotId('droot'));
-    if (data) {
-      data.innerHTML += `<pre style="white-space: pre-wrap;">${slot.model.json}</pre>`;
-    }
-    // groupCollapsed('got output data');
-    // log(slot.model.json);
-    // console.groupEnd();
-    return true;
-  }
   async renderXenSlot(output) {
-    const {outputSlotId, containerSlotName, containerSlotId, slotMap, model} = output;
+    const {outputSlotId, containerSlotName, containerSlotId, slotMap, content: {model}} = output;
     const root = this.root || document.body;
     let slotNode;
     const data = model || Object;
@@ -186,12 +172,12 @@ export const SlotObserver = class {
   }
 };
 
-export const attachRenderer = (composer, containers) => {
-  return composer.slotObserver = new SlotObserver(composer.root);
-};
+// export const attachRenderer = (composer, containers) => {
+//   return composer.slotObserver = new SlotObserver(composer.root);
+// };
 
-const isEmptySlot = slot =>
-  (!slot.template || slot.template === '') && (!slot.model || !Object.keys(slot.model).length);
+const isEmptySlot = ({content}) =>
+  (!content.template || content.template === '') && (!content.model || !Object.keys(content.model).length);
 
 const deepQuerySelector = (root, selector) => {
   const find = (element, selector) => {
@@ -210,7 +196,7 @@ const deepQuerySelector = (root, selector) => {
 };
 
 const stampDom = (output, slotNode, slotId, dispatch) => {
-  const {template, particle: {name}, slotMap} = output;
+  const {content: {template}, particle: {name}, slotMap} = output;
   // create container node
   const container = slotNode.appendChild(document.createElement('div'));
   container.id = slotId;

--- a/shells/pipes-shell/source/verbs/event.js
+++ b/shells/pipes-shell/source/verbs/event.js
@@ -16,6 +16,6 @@ export const event = async (msg, tid, bus) => {
   // find the arc from the tid in the message (not the tid for this request)
   const arc = await bus.getAsyncValue(msg.tid);
   if (arc) {
-    arc.pec.slotComposer.sendEvent(msg.pid, msg.eventlet)
+    arc.pec.slotComposer.sendEvent(msg.pid, msg.eventlet);
   }
 };

--- a/shells/pipes-shell/source/verbs/event.js
+++ b/shells/pipes-shell/source/verbs/event.js
@@ -16,15 +16,6 @@ export const event = async (msg, tid, bus) => {
   // find the arc from the tid in the message (not the tid for this request)
   const arc = await bus.getAsyncValue(msg.tid);
   if (arc) {
-    // find the particle from the pid in the message
-    const particle = arc.activeRecipe.particles.find(
-      particle => String(particle.id) === msg.pid
-    );
-    if (particle) {
-      log('firing PEC event for', particle.name);
-      // TODO(sjmiles): we need `arc` and `particle` here even though
-      // the two are bound together, figure out how to simplify
-      arc.pec.sendEvent(particle, /*slotName*/'', msg.eventlet);
-    }
+    arc.pec.slotComposer.sendEvent(msg.pid, msg.eventlet)
   }
 };

--- a/shells/pipes-shell/surface/surface.html
+++ b/shells/pipes-shell/surface/surface.html
@@ -18,7 +18,7 @@
 
 <link rel="stylesheet" href="./index.css">
 
-<div slotid="top" id="rootslotid-top"></div>
+<div slotid="toproot" id="rootslotid-toproot"></div>
 <div slotid="root" id="rootslotid-root"></div>
 <div slotid="modal" id="rootslotid-modal"></div>
 

--- a/src/runtime/ui-slot-composer.ts
+++ b/src/runtime/ui-slot-composer.ts
@@ -249,9 +249,13 @@ export class UiSlotComposer {
     }
   }
 
+  // TODO(sjmiles): needs factoring
   delegateOutput(arc: Arc, particle: Particle, content) {
     const observer = this['slotObserver'];
     if (observer && content) {
+      // assemble a renderPacket to send to slot observer
+      const packet = {};
+      // we scan connections for container and slotMap
       const connections = particle.getSlotConnections();
       // build slot id map
       const slotMap = {};
@@ -261,29 +265,34 @@ export class UiSlotComposer {
       // identify parent container
       const container = connections[0];
       if (container) {
-        Object.assign(content, {
+        Object.assign(packet, {
           containerSlotName: container.targetSlot.name,
           containerSlotId: container.targetSlot.id,
         });
       }
-      if (!content.modality) {
-        // Set modality according to particle spec, unless already set by the particle.
-        const modality = particle.recipe.modality;
-        if (!modality.all) {
-          Object.assign(content, {
-            modality: modality.names.join(',')
-          });
-        }
+      // Set modality according to particle spec, unless already set by the particle.
+      const modality = particle.recipe.modality;
+      if (!modality.all) {
+        Object.assign(packet, {
+          modality: modality.names.join(',')
+        });
       }
-      Object.assign(content, {
-        particle,
+      // finalize packet
+      const pid = particle.id.toString();
+      Object.assign(packet, {
+        particle: {
+          name: particle.name,
+          id: pid
+        },
         slotMap,
-        outputSlotId: particle.id.toString(),
+        // TODO(sjmiles): there is no clear concept for a particle's output channel, so there is no proper ID
+        // to use. The `particle.id` works for now, but it probably should be a combo of `particle.id` and the
+        // consumed slot id (neither of which are unique by themselves).
+        outputSlotId: pid,
+        content
       });
-      //
       //console.log(`RenderEx:delegateOutput for %c[${particle.spec.name}]::[${particle.id}]`, 'color: darkgreen; font-weight: bold;');
-      observer.observe(content, arc);
+      observer.observe(packet, arc);
     }
   }
-
 }

--- a/src/runtime/ui-slot-composer.ts
+++ b/src/runtime/ui-slot-composer.ts
@@ -265,7 +265,8 @@ export class UiSlotComposer {
           containerSlotId: container.targetSlot.id,
         });
       }
-      // Set modality according to particle spec, unless already set by the particle.
+      // Set modality according to particle spec
+      // TODO(sjmiles): in the short term, Particle may also include modality hints in `content`
       const modality = particle.recipe.modality;
       if (!modality.all) {
         Object.assign(packet, {

--- a/src/runtime/ui-slot-composer.ts
+++ b/src/runtime/ui-slot-composer.ts
@@ -229,11 +229,9 @@ export class UiSlotComposer {
     }
   }
 
-  sendEvent(particleId, eventlet) {
+  sendEvent(particleId: string, eventlet) {
     log('sendEvent:', particleId, eventlet);
-    const findConsumer = id => this.consumers.find(
-        consumer => consumer.consumeConn.particle.id.toString() === id);
-    const consumer = findConsumer(particleId.toString());
+    const consumer = this._findConsumer(particleId);
     if (consumer) {
       const particle = consumer.consumeConn.particle;
       const arc = consumer.arc;
@@ -247,6 +245,10 @@ export class UiSlotComposer {
     } else {
       warn('...found no consumer!');
     }
+  }
+
+  _findConsumer(id) {
+    return this.consumers.find(consumer => consumer.consumeConn.particle.id.toString() === id);
   }
 
   // TODO(sjmiles): needs factoring

--- a/src/runtime/ui-slot-composer.ts
+++ b/src/runtime/ui-slot-composer.ts
@@ -253,15 +253,10 @@ export class UiSlotComposer {
   delegateOutput(arc: Arc, particle: Particle, content) {
     const observer = this['slotObserver'];
     if (observer && content) {
-      // assemble a renderPacket to send to slot observer
-      const packet = {};
       // we scan connections for container and slotMap
       const connections = particle.getSlotConnections();
-      // build slot id map
-      const slotMap = {};
-      connections.forEach(({providedSlots}) => {
-        Object.values(providedSlots).forEach(({name, id}) => slotMap[name] = id);
-      });
+      // assemble a renderPacket to send to slot observer
+      const packet = {};
       // identify parent container
       const container = connections[0];
       if (container) {
@@ -277,6 +272,11 @@ export class UiSlotComposer {
           modality: modality.names.join(',')
         });
       }
+      // build slot id map
+      const slotMap = {};
+      connections.forEach(({providedSlots}) => {
+        Object.values(providedSlots).forEach(({name, id}) => slotMap[name] = id);
+      });
       // finalize packet
       const pid = particle.id.toString();
       Object.assign(packet, {

--- a/src/runtime/ui-slot-composer.ts
+++ b/src/runtime/ui-slot-composer.ts
@@ -233,7 +233,7 @@ export class UiSlotComposer {
     log('sendEvent:', particleId, eventlet);
     const findConsumer = id => this.consumers.find(
         consumer => consumer.consumeConn.particle.id.toString() === id);
-    const consumer = findConsumer(particleId);
+    const consumer = findConsumer(particleId.toString());
     if (consumer) {
       const particle = consumer.consumeConn.particle;
       const arc = consumer.arc;


### PR DESCRIPTION
- Events were not mapping to Particles because Particle.id is no longer a simple String (requires casting before comparison).
- ui-slot-composer was mutating the `content` object that a Particle produced, which was wrong on several levels. 
- ui-slot-composer was putting non-serializable `particle` object onto the render packet.
- ui-slot-composer changes need matching updates in renderers/brokers. I've updated xen-renderer. 

New slot-render-packet structure (formerly the outer fields were mixed into `content`):
```
{
  content <- the packet produced by the Particle, now unmodified
  containerSlotName, 
  containerSlotId,
  outputSlotId,
  slotMap,
  modality,
  particle: {
    name,
    id
  }
}
```