### PR TITLE
Wasm C++: first step for supporting reference-typed schema fields.

### DIFF
--- a/src/runtime/wasm.ts
+++ b/src/runtime/wasm.ts
@@ -353,7 +353,7 @@ class EmscriptenWasmDriver implements WasmDriver {
       abortOnCannotGrowMemory: (size)  => { throw new Error(`abortOnCannotGrowMemory(${size})`); },
 
       // Logging
-      _setLogInfo: (file, line) => this.logInfo = [container.read(file), line],
+      _setLogInfo: (file, line) => this.logInfo = [container.read(file).split(/[/\\]/).pop(), line],
       ___syscall146: (which, varargs) => this.sysWritev(container, which, varargs),
     });
   }

--- a/src/tools/schema2kotlin.ts
+++ b/src/tools/schema2kotlin.ts
@@ -22,12 +22,12 @@ const keywords = [
   'suspend', 'tailrec', 'vararg', 'field', 'it'
 ];
 
-// type-char to [kotlin-type, default-value, decode-function]
 const typeMap = {
-  'T': ['String', '""', 'decodeText()'],
-  'U': ['String', '""', 'decodeText()'],
-  'N': ['Double', '0.0', 'decodeNum()'],
-  'B': ['Boolean', 'false', 'decodeBool()'],
+  'T': {type: 'String',  defaultVal: '""',    decodeFn: 'decodeText()'},
+  'U': {type: 'String',  defaultVal: '""',    decodeFn: 'decodeText()'},
+  'N': {type: 'Double',  defaultVal: '0.0',   decodeFn: 'decodeNum()'},
+  'B': {type: 'Boolean', defaultVal: 'false', decodeFn: 'decodeBool()'},
+  'R': {type: '',        defaultVal: '',      decodeFn: ''},
 };
 
 export class Schema2Kotlin extends Schema2Base {
@@ -57,17 +57,20 @@ package arcs
     const encode: string[] = [];
     const decode: string[] = [];
 
-    const fieldCount = this.processSchema(schema, (field: string, typeChar: string) => {
-      const type = typeMap[typeChar][0];
-      const defaultVal = typeMap[typeChar][1];
-      const decodeType = typeMap[typeChar][2];
+    const fieldCount = this.processSchema(schema, (field: string, typeChar: string, refName: string) => {
+      if (typeChar === 'R') {
+        console.log('TODO: support reference types in kotlin');
+        process.exit(1);
+      }
+
+      const {type, defaultVal, decodeFn} = typeMap[typeChar];
       const fixed = field + (keywords.includes(field) ? '_' : '');
 
       fields.push(`var ${fixed}: ${type} = ${defaultVal}`);
 
       decode.push(`"${field}" -> {`,
                   `  decoder.validate("${typeChar}")`,
-                  `  this.${fixed} = decoder.${decodeType}`,
+                  `  this.${fixed} = decoder.${decodeFn}`,
                   `}`,
       );
 

--- a/src/wasm/cpp/arcs.cc
+++ b/src/wasm/cpp/arcs.cc
@@ -172,11 +172,6 @@ void StringDecoder::validate(const std::string& token) {
   }
 }
 
-template<typename T>
-void StringDecoder::decode(T& val) {
-  static_assert(sizeof(T) == 0, "Unsupported type for entity fields");
-}
-
 template<>
 void StringDecoder::decode(std::string& text) {
   int len = getInt(':');
@@ -220,11 +215,6 @@ Dictionary StringDecoder::decodeDictionary(const char* str) {
 }
 
 // StringEncoder
-template<typename T>
-void StringEncoder::encode(const char* prefix, const T& val) {
-  static_assert(sizeof(T) == 0, "Unsupported type for entity fields");
-}
-
 template<>
 void StringEncoder::encode(const char* prefix, const std::string& str) {
   str_ += prefix + std::to_string(str.size()) + ":" + str + "|";
@@ -263,11 +253,6 @@ void StringPrinter::addId(const std::string& id) {
 
 void StringPrinter::add(const char* literal) {
   parts_.push_back(literal);
-}
-
-template<typename T>
-void StringPrinter::add(const char* prefix, const T& val) {
-  static_assert(sizeof(T) == 0, "Unsupported type for entity fields");
 }
 
 template<>

--- a/src/wasm/cpp/arcs.h
+++ b/src/wasm/cpp/arcs.h
@@ -61,6 +61,7 @@ public:
   std::string chomp(int len);
   void validate(const std::string& token);
   template<typename T> void decode(T& val);
+  template<typename T> void decode(Ref<T>& ref) {}  // TODO
 
   static void decodeList(const char* str, std::function<void(const std::string&)> callback);
   static Dictionary decodeDictionary(const char* str);
@@ -79,6 +80,7 @@ public:
   StringEncoder& operator=(const StringEncoder&) = delete;
 
   template<typename T> void encode(const char* prefix, const T& val);
+  template<typename T> void encode(const char* prefix, const Ref<T>& ref) {}  // TODO
   std::string result();
 
   static std::string encodeDictionary(const Dictionary& dict);
@@ -100,6 +102,7 @@ public:
   void addId(const std::string& id);
   void add(const char* literal);
   template<typename T> void add(const char* prefix, const T& val);
+  template<typename T> void add(const char* prefix, const Ref<T>& ref);
   std::string result(const char* join);
 
 private:
@@ -174,7 +177,15 @@ public:
     entity->_internal_id_ = id;
   }
 
-  // Ref-based versions of all of the above; implemented below the Ref class definition.
+  template<typename T>
+  static Ref<T> make_ref(const std::string& id, const std::string& key) {
+    Ref<T> ref;
+    ref._internal_id_ = id;
+    ref.storage_key_ = key;
+    return ref;
+  }
+
+  // Ref-based versions of the above; implemented below the Ref class definition.
   template<typename T> static Ref<T> clone_entity(const Ref<T>& ref);
   template<typename T> static size_t hash_entity(const Ref<T>& ref);
   template<typename T> static bool fields_equal(const Ref<T>& a, const Ref<T>& b);
@@ -423,9 +434,14 @@ private:
 // Arcs-style reference to an entity.
 template<typename T>
 class Ref {
+  struct Payload {
+    T entity;
+    bool dereferenced = false;
+  };
+
 public:
   // References are copyable and share a pointer to the underlying entity data.
-  Ref(Handle* handle = nullptr) : handle_(handle), dereferenced_(false),  entity_(new T()) {}
+  Ref(Handle* handle = nullptr) : handle_(handle), payload_(new Payload()) {}
 
   // Retrieve the referenced entity data from the backing store. The first time this is called,
   // the given continuation will be executed *asynchronously* - i.e. after the calling function has
@@ -445,12 +461,12 @@ public:
   // This method needs to be const because the object is returned as const from handles, but it does
   // modify the internal state of this object to update a local copy of the retrieved entity data.
   void dereference(std::function<void()> continuation) const {
-    if (dereferenced_) {
+    if (payload_->dereferenced) {
       continuation();
     } else if (handle_ != nullptr) {
       auto wrapped = [this, fn = std::move(continuation)](const char* encoded) {
-        internal::Accessor::decode_entity(entity_.get(), encoded);
-        dereferenced_ = true;
+        internal::Accessor::decode_entity(&payload_->entity, encoded);
+        payload_->dereferenced = true;
         fn();
       };
       // The handle simply bounces this to its owning particle, adding itself as a parameter.
@@ -458,10 +474,14 @@ public:
     }
   }
 
+  bool is_dereferenced() const {
+    return payload_->dereferenced;
+  }
+
   // Returns the underlying entity data. If this object has not been dereferenced yet,
   // this will be an empty instance of the entity type T.
   const T& entity() const {
-    return *entity_;
+    return payload_->entity;
   }
 
   // Unlike the generated entity classes, arcs::fields_equal and operator== are equivalent for Refs.
@@ -483,10 +503,7 @@ private:
   std::string _internal_id_;
   std::string storage_key_;
   Handle* handle_;
-
-  // Mutable because dereference() needs to be const but still modifies this.
-  mutable bool dereferenced_;
-  std::shared_ptr<T> entity_;
+  std::shared_ptr<Payload> payload_;
 
   friend class Singleton<Ref<T>>;
   friend class Collection<Ref<T>>;
@@ -516,7 +533,10 @@ inline std::string internal::Accessor::entity_to_str(const Ref<T>& ref, const ch
   internal::StringPrinter printer;
   printer.add("REF<", ref._internal_id_);
   if (!ref.storage_key_.empty()) {
-    printer.add(":", ref.storage_key_);
+    printer.add("|", ref.storage_key_);
+  }
+  if (ref.is_dereferenced()) {
+    printer.add("|", entity_to_str(ref.entity(), ", "));
   }
   printer.add(">");
   return printer.result("");
@@ -549,6 +569,11 @@ inline const std::string& internal::Accessor::get_id(const Ref<T>& ref) {
 template<typename T>
 inline void internal::Accessor::set_id(Ref<T>* ref, const std::string& id) {
   ref->_internal_id_ = id;
+}
+
+template<typename T>
+inline void internal::StringPrinter::add(const char* prefix, const Ref<T>& ref) {
+  parts_.push_back(prefix + entity_to_str(ref));
 }
 
 }  // namespace arcs

--- a/src/wasm/cpp/tests/entity-class-test.cc
+++ b/src/wasm/cpp/tests/entity-class-test.cc
@@ -6,8 +6,16 @@
 using arcs::internal::Accessor;
 
 template<typename T>
-size_t hash(const T& d) {
+static size_t hash(const T& d) {
   return std::hash<T>()(d);
+}
+
+static arcs::Ref<arcs::Foo> make_ref(const std::string& id, const std::string& key) {
+  return Accessor::make_ref<arcs::Foo>(id, key);
+}
+
+static auto converter() {
+  return [](const arcs::Data& d) { return arcs::entity_to_str(d); };
 }
 
 
@@ -20,6 +28,7 @@ public:
     RUN(test_text_field_equality);
     RUN(test_url_field_equality);
     RUN(test_boolean_field_equality);
+    RUN(test_reference_field_equality);
     RUN(test_entity_equality);
     RUN(test_clone_entity);
     RUN(test_entity_to_str);
@@ -74,6 +83,19 @@ public:
     d.set_flg(false);
     IS_TRUE(d.has_flg());
     IS_FALSE(d.flg());
+
+    arcs::Ref<arcs::Foo> empty;
+    arcs::Ref<arcs::Foo> populated = make_ref("id", "key");
+    IS_FALSE(d.has_ref());
+    EQUAL(d.ref(), empty);
+    d.set_ref(populated);
+    IS_TRUE(d.has_ref());
+    EQUAL(d.ref(), populated);
+    d.clear_ref();
+    IS_FALSE(d.has_ref());
+    d.set_ref(empty);
+    IS_TRUE(d.has_ref());
+    EQUAL(d.ref(), empty);
   }
 
   void test_id_equality() {
@@ -261,6 +283,47 @@ public:
     NOT_LESS(d2, d1);
   }
 
+  void test_reference_field_equality() {
+    arcs::Data d1, d2;
+    arcs::Ref<arcs::Foo> empty;
+
+    // unset vs default value
+    d2.set_ref({});
+    NOT_EQUAL(d1, d2);
+    LESS(d1, d2);
+    NOT_LESS(d2, d1);
+
+    // unset vs other value
+    d2.set_ref(make_ref("id1", "key1"));
+    NOT_EQUAL(d1, d2);
+    LESS(d1, d2);
+    NOT_LESS(d2, d1);
+
+    // default vs default
+    d1.set_ref(empty);
+    d2.set_ref(empty);
+    EQUAL(d1, d2);
+    NOT_LESS(d1, d2);
+    NOT_LESS(d2, d1);
+
+    // value vs value
+    d1.set_ref(make_ref("id5", "key5"));
+    d2.set_ref(make_ref("id7", "key7"));
+    NOT_EQUAL(d1, d2);
+    LESS(d1, d2);
+    NOT_LESS(d2, d1);
+
+    d1.set_ref(make_ref("id7", "key7"));
+    EQUAL(d1, d2);
+    NOT_LESS(d1, d2);
+    NOT_LESS(d2, d1);
+
+    d2.set_ref(make_ref("id3", "key3"));
+    NOT_EQUAL(d1, d2);
+    NOT_LESS(d1, d2);
+    LESS(d2, d1);
+  }
+
   void test_entity_equality() {
     arcs::Data d1, d2;
 
@@ -356,6 +419,9 @@ public:
     IS_TRUE(arcs::fields_equal(d2, src));
     EQUAL(hash(d2), hash(src));
 
+    // Cloned references should still refer to the same underlying entity.
+    EQUAL(&(d2.ref().entity()), &(src.ref().entity()));
+
     // Cloning doesn't include the internal id.
     Accessor::set_id(&src, "id");
     arcs::Data d3 = arcs::clone_entity(src);
@@ -377,7 +443,8 @@ public:
 
     Accessor::set_id(&d, "id");
     d.clear_flg();
-    EQUAL(arcs::entity_to_str(d), "{id}, num: 6, txt: boo");
+    d.set_ref(make_ref("i12", "k34"));
+    EQUAL(arcs::entity_to_str(d), "{id}, num: 6, txt: boo, ref: REF<i12|k34>");
   }
 
   void test_stl_vector() {
@@ -391,15 +458,12 @@ public:
     v.push_back(std::move(d2));
     v.push_back(std::move(d3));
 
-    auto converter = [](const arcs::Data& d) {
-      return arcs::entity_to_str(d);
-    };
     std::vector<std::string> expected = {
       "{}, num: 12",
       "{}, num: 12",
       "{id}"
     };
-    CHECK_ORDERED(v, converter, expected);
+    CHECK_ORDERED(v, converter(), expected);
   }
 
   void test_stl_set() {
@@ -434,15 +498,12 @@ public:
     s.insert(std::move(d4));
     s.insert(std::move(d5));
 
-    auto converter = [](const arcs::Data& d) {
-      return arcs::entity_to_str(d);
-    };
     std::vector<std::string> expected = {
       "{id}, flg: false",
       "{id}, num: 45, txt: woop",
       "{}, num: 45, txt: woop"
     };
-    CHECK_UNORDERED(s, converter, expected);
+    CHECK_UNORDERED(s, converter(), expected);
   }
 
   void test_stl_unordered_set() {
@@ -477,15 +538,12 @@ public:
     s.insert(std::move(d4));
     s.insert(std::move(d5));
 
-    auto converter = [](const arcs::Data& d) {
-      return arcs::entity_to_str(d);
-    };
     std::vector<std::string> expected = {
       "{id}, flg: false",
       "{id}, num: 45, txt: woop",
       "{}, num: 45, txt: woop"
     };
-    CHECK_UNORDERED(s, converter, expected);
+    CHECK_UNORDERED(s, converter(), expected);
   }
 };
 

--- a/src/wasm/cpp/tests/schemas.arcs
+++ b/src/wasm/cpp/tests/schemas.arcs
@@ -1,8 +1,12 @@
+schema Foo
+  Text dummy
+
 schema Data
   Number num
   Text txt
   URL lnk
   Boolean flg
+  Reference<Foo> ref
 
 schema RenderFlags
   Boolean template


### PR DESCRIPTION
- Adds handling of references to the schema2pkg tool
- Improves C++ Ref implementation so copies of a Ref instance are aware of dereferencing.
