### PR TITLE
Refactor StorageProviderBase.on() and .off()

### DIFF
--- a/src/devtools-connector/arc-stores-fetcher.ts
+++ b/src/devtools-connector/arc-stores-fetcher.ts
@@ -46,13 +46,16 @@ export class ArcStoresFetcher {
     for (const store of this.arc._stores) {
       if (!this.watchedHandles.has(store.id)) {
         this.watchedHandles.add(store.id);
-        store.on(async () => this.arcDevtoolsChannel.send({
-          messageType: 'store-value-changed',
-          messageBody: {
-            id: store.id.toString(),
-            value: await this.dereference(store)
-          }
-        }));
+        store.on(async () => {
+          this.arcDevtoolsChannel.send({
+            messageType: 'store-value-changed',
+            messageBody: {
+              id: store.id.toString(),
+              value: await this.dereference(store)
+            }
+          });
+          return true;
+        });
       }
     }
   }

--- a/src/planning/plan/plan-producer.ts
+++ b/src/planning/plan/plan-producer.ts
@@ -51,7 +51,7 @@ export class PlanProducer {
   stateChangedCallbacks: ((isPlanning: boolean) => void)[] = [];
   search: string;
   searchStore?: SingletonStorageProvider;
-  searchStoreCallback: Consumer<{}>;
+  searchStoreCallbackId: number;
   debug: boolean;
   noSpecEx: boolean;
   inspector?: PlannerInspector;
@@ -66,8 +66,10 @@ export class PlanProducer {
     this.searchStore = searchStore;
     this.inspector = inspector;
     if (this.searchStore) {
-      this.searchStoreCallback = () => this.onSearchChanged();
-      this.searchStore.on(this.searchStoreCallback);
+      this.searchStoreCallbackId = this.searchStore.on(async () => {
+        await this.onSearchChanged();
+        return true;
+      });
     }
     this.debug = debug;
     this.noSpecEx = noSpecEx;
@@ -123,11 +125,12 @@ export class PlanProducer {
 
   dispose() {
     if (this.searchStore) {
-      this.searchStore.off(this.searchStoreCallback);
+      this.searchStore.off(this.searchStoreCallbackId);
     }
   }
 
   async produceSuggestions(options: SuggestionOptions = {}) {
+    console.log(`produceSuggestions()`);
     if (options.cancelOngoingPlanning && this.isPlanning) {
       this._cancelPlanning();
     }

--- a/src/planning/plan/planning-result.ts
+++ b/src/planning/plan/planning-result.ts
@@ -36,7 +36,7 @@ export class PlanningResult {
   generations: SerializableGeneration[] = [];
   contextual = true;
   store?: SingletonStorageProvider;
-  private storeCallback: Consumer<{}>;
+  private storeCallbackId: number;
   private changeCallbacks: Runnable[] = [];
   private envOptions: EnvOptions;
 
@@ -46,8 +46,7 @@ export class PlanningResult {
     assert(envOptions.loader, `loader cannot be null`);
     this.store = store;
     if (this.store) {
-      this.storeCallback = () => this.load();
-      this.store.on(this.storeCallback);
+      this.storeCallbackId = this.store.on(() => this.load());
     }
   }
 
@@ -86,7 +85,7 @@ export class PlanningResult {
 
   dispose() {
     this.changeCallbacks = [];
-    this.store.off(this.storeCallback);
+    this.store.off(this.storeCallbackId);
     this.store.dispose();
   }
 

--- a/src/planning/plan/tests/planificator-test.ts
+++ b/src/planning/plan/tests/planificator-test.ts
@@ -92,8 +92,7 @@ describe('remote planificator', () => {
   }
 
   async function verifyReplanning(producePlanificator, expectedSuggestions, expectedDescriptions = []) {
-    assert.isTrue(producePlanificator.producer.isPlanning);
-    // Wait for the planner finish.
+    // Wait for the planner to finish.
     while (producePlanificator.producer.isPlanning) {
       await delay(100);
     }

--- a/src/runtime/arc.ts
+++ b/src/runtime/arc.ts
@@ -738,10 +738,7 @@ ${this.activeRecipe.toString()}`;
     this.storeTags.set(store, new Set(tags));
 
     this.storageKeys[store.id] = store.storageKey;
-    store.on(async () => {
-      this._onDataChange();
-      return true;
-    });
+    store.on(async () => this._onDataChange());
 
     Runtime.getRuntime().registerStore(store, tags);
   }
@@ -753,10 +750,11 @@ ${this.activeRecipe.toString()}`;
     tags.forEach(tag => storeTags.add(tag));
   }
 
-  _onDataChange(): void {
+  _onDataChange(): boolean {
     for (const callback of this.dataChangeCallbacks.values()) {
       callback();
     }
+    return true;
   }
 
   onDataChange(callback: Runnable, registration: object): void {

--- a/src/runtime/arc.ts
+++ b/src/runtime/arc.ts
@@ -738,7 +738,10 @@ ${this.activeRecipe.toString()}`;
     this.storeTags.set(store, new Set(tags));
 
     this.storageKeys[store.id] = store.storageKey;
-    store.on(() => this._onDataChange());
+    store.on(async () => {
+      this._onDataChange();
+      return true;
+    });
 
     Runtime.getRuntime().registerStore(store, tags);
   }

--- a/src/runtime/manual_tests/firebase-test.ts
+++ b/src/runtime/manual_tests/firebase-test.ts
@@ -77,7 +77,7 @@ describe('firebase', function() {
       const variable = await storage.construct('test0', barType, newStoreKey('variable')) as SingletonStorageProvider;
 
       let events = 0;
-      variable.on(() => events++);
+      variable.legacyOn(() => events++);
 
       await variable.set({id: 'test0:test', value});
       const result = await variable.get();
@@ -199,7 +199,7 @@ describe('firebase', function() {
       const collection = await storage.construct('test1', barType.collectionOf(), newStoreKey('collection')) as CollectionStorageProvider;
 
       let events = 0;
-      collection.on(() => events++);
+      collection.legacyOn(() => events++);
 
       await collection.store({id: 'id0', value: value1}, ['key0']);
       await collection.store({id: 'id1', value: value2}, ['key1']);

--- a/src/runtime/particle-execution-host.ts
+++ b/src/runtime/particle-execution-host.ts
@@ -181,7 +181,7 @@ class PECOuterPortImpl extends PECOuterPort {
 
   onInitializeProxy(handle: StorageProviderBase, callback: number) {
     const target = {};
-    handle.on(data => this.SimpleCallback(callback, data));
+    handle.legacyOn(data => this.SimpleCallback(callback, data));
   }
 
   async onSynchronizeProxy(handle: StorageProviderBase, callback: number) {

--- a/src/runtime/storage-stub.ts
+++ b/src/runtime/storage-stub.ts
@@ -10,11 +10,11 @@
 import {assert} from '../platform/assert-web.js';
 import {compareStrings} from './recipe/comparable.js';
 import {ClaimIsTag} from './particle-claim.js';
-import {StorageProviderBase} from './storage/storage-provider-base.js';
 import {StorageProviderFactory} from './storage/storage-provider-factory.js';
 import {Type} from './type.js';
 import {VolatileStorageProvider} from './storage/volatile-storage.js';
 import {UnifiedStore} from './storageNG/unified-store.js';
+import {ProxyCallback} from './storageNG/store.js';
 
 // TODO(shans): Make sure that after refactor Storage objects have a lifecycle and can be directly used
 // deflated rather than requiring this stub.
@@ -36,6 +36,15 @@ export class StorageStub extends UnifiedStore {
               public readonly model?: {}[]) {
     super();
   }
+
+  // No-op implementations for `on` and `off`.
+  // TODO: These methods should not live on UnifiedStore; they only work on
+  // active stores (e.g. StorageProviderBase). Move them to a new
+  // UnifiedActiveStore interface.
+  on(callback: ProxyCallback<null>): number {
+    return -1;
+  }
+  off(callback: number): void {}
 
   async inflate(storageProviderFactory?: StorageProviderFactory) {
     const factory = storageProviderFactory || this.storageProviderFactory;
@@ -107,7 +116,7 @@ export class StorageStub extends UnifiedStore {
     return results.join('\n');
   }
 
-  _compareTo(other: StorageProviderBase): number {
+  _compareTo(other: UnifiedStore): number {
     let cmp: number;
     cmp = compareStrings(this.name, other.name);
     if (cmp !== 0) return cmp;

--- a/src/runtime/storage/firebase/firebase-storage.ts
+++ b/src/runtime/storage/firebase/firebase-storage.ts
@@ -1596,7 +1596,7 @@ class FirebaseBackingStore extends FirebaseStorageProvider implements Collection
     throw new Error('FirebaseBackingStore does not implement ensureBackingStore');
   }
 
-  on(callback) {
+  on(callback): number {
     throw new Error('FirebaseBackingStore does not implement on');
   }
 

--- a/src/runtime/storage/synthetic-storage.ts
+++ b/src/runtime/storage/synthetic-storage.ts
@@ -150,7 +150,7 @@ class SyntheticCollection extends StorageProviderBase implements CollectionStora
     this.initialized = (async () => {
       const data = await targetStore.get();
       await this.process(data, false);
-      targetStore.on(details => this.process(details.data, true));
+      targetStore.legacyOn(details => this.process(details.data, true));
     })();
   }
 

--- a/src/runtime/storageNG/store.ts
+++ b/src/runtime/storageNG/store.ts
@@ -53,7 +53,11 @@ export class Store<T extends CRDTTypeRecord> extends UnifiedStore implements Sto
     throw new Error('Method not implemented.');
   }
 
-  on(fn: Consumer<{}>): void {
+  on(callback: ProxyCallback<null>): number {
+    throw new Error('Method not implemented.');
+  }
+
+  off(callbackId: number) {
     throw new Error('Method not implemented.');
   }
 

--- a/src/runtime/storageNG/unified-store.ts
+++ b/src/runtime/storageNG/unified-store.ts
@@ -16,6 +16,7 @@ import {StorageStub} from '../storage-stub.js';
 import {assert} from '../../platform/assert-web.js';
 import {Store as OldStore} from '../store.js';
 import {PropagatedException} from '../arc-exceptions.js';
+import {ProxyCallback} from './store.js';
 
 /**
  * This is a temporary interface used to unify old-style stores (storage/StorageProviderBase) and new-style stores (storageNG/Store).
@@ -59,8 +60,10 @@ export abstract class UnifiedStore implements Comparable<UnifiedStore>, OldStore
   async modelForSynchronization(): Promise<{}> {
     return await this.toLiteral();
   }
-  on(fn: Consumer<{}>): void {}
-  off(fn: Consumer<{}>): void {}
+
+  // TODO: Make this match the type of the `on` method in ActiveStore.
+  abstract on(callback: ProxyCallback<null>): number;
+  abstract off(callback: number): void;
 
   /**
    * Hack to cast this UnifiedStore to the old-style class StorageStub.

--- a/src/runtime/testing/callback-tracker.ts
+++ b/src/runtime/testing/callback-tracker.ts
@@ -28,7 +28,10 @@ export class CallbackTracker {
   events: Dictionary<any>[] = [];
 
   constructor(storageProvider: UnifiedStore, public expectedEvents = 0) {
-    storageProvider.on((val) => this.changeEvent(val));
+    storageProvider.on(async val => {
+      this.changeEvent(val);
+      return true;
+    });
   }
 
   // called for each change event

--- a/src/runtime/testing/callback-tracker.ts
+++ b/src/runtime/testing/callback-tracker.ts
@@ -28,16 +28,14 @@ export class CallbackTracker {
   events: Dictionary<any>[] = [];
 
   constructor(storageProvider: UnifiedStore, public expectedEvents = 0) {
-    storageProvider.on(async val => {
-      this.changeEvent(val);
-      return true;
-    });
+    storageProvider.on(async val => this.changeEvent(val));
   }
 
   // called for each change event
   // tslint:disable-next-line: no-any
-  public changeEvent(c: Dictionary<any>): void {
+  public changeEvent(c: Dictionary<any>): boolean {
     this.events.push(c);
+    return true;
   }
 
   /**

--- a/src/runtime/tests/handle-test.ts
+++ b/src/runtime/tests/handle-test.ts
@@ -42,7 +42,7 @@ describe('Handle', () => {
     const arc = new Arc({id: ArcId.newForTest('test'), context: manifest, loader});
     const store = await arc.createStore(manifest.schemas.Bar.type) as SingletonStorageProvider;
     let version = 0;
-    store.on(() => version++);
+    store.legacyOn(() => version++);
     assert.strictEqual(version, 0);
     const bar1 = {id: 'an id', value: 'a Bar'};
     await store.set(bar1);
@@ -58,7 +58,7 @@ describe('Handle', () => {
     const arc = new Arc({id: ArcId.newForTest('test'), context: manifest, loader});
     const barStore = await arc.createStore(manifest.schemas.Bar.type.collectionOf()) as CollectionStorageProvider;
     let version = 0;
-    barStore.on(({add: [{effective}]}) => {if (effective) version++;});
+    barStore.legacyOn(({add: [{effective}]}) => {if (effective) version++;});
     assert.strictEqual(barStore.version, 0);
     const bar1 = {id: 'an id', value: 'a Bar'};
     await barStore.store(bar1, ['key1']);

--- a/src/runtime/tests/synthetic-storage-test.ts
+++ b/src/runtime/tests/synthetic-storage-test.ts
@@ -110,7 +110,7 @@ describe('synthetic storage ', () => {
         use Store0 #taggy #waggy as handle0
         use Store1 as handle1`);
 
-    synth.on(() => assert.fail('change event should not fire for initial value'));
+    synth.legacyOn(() => assert.fail('change event should not fire for initial value'));
 
     const list = await synth.toList();
     assert.deepEqual(list.map(h => flatten(h)),
@@ -133,7 +133,7 @@ describe('synthetic storage ', () => {
     // and the only way to detect this is the change event fired by the synthetic collection.
     let resolver;
     const eventPromise = new Promise<ChangeEvent>(resolve => resolver = resolve);
-    synth.on(e => resolver(e));
+    synth.legacyOn(e => resolver(e));
 
     await targetStore.set(new ArcType().newInstance(id, `
       schema Bar


### PR DESCRIPTION
These methods now have the same API as the new storage stack's on and
off methods. The old behaviour is preserved in legacyOn and legacyOff
methods (there's a bunch of tests that rely on that old behaviour, but
they are all specific to the old storage stack and so will be deleted
later).