### PR TITLE
Create UnifiedActiveStore interface

### DIFF
--- a/src/devtools-connector/arc-stores-fetcher.ts
+++ b/src/devtools-connector/arc-stores-fetcher.ts
@@ -42,11 +42,11 @@ export class ArcStoresFetcher {
     }));
   }
 
-  onRecipeInstantiated() {
+  async onRecipeInstantiated() {
     for (const store of this.arc._stores) {
       if (!this.watchedHandles.has(store.id)) {
         this.watchedHandles.add(store.id);
-        store.on(async () => {
+        (await store.activate()).on(async () => {
           this.arcDevtoolsChannel.send({
             messageType: 'store-value-changed',
             messageBody: {

--- a/src/devtools-connector/devtools-arc-inspector.ts
+++ b/src/devtools-connector/devtools-arc-inspector.ts
@@ -79,9 +79,9 @@ class DevtoolsArcInspector implements ArcInspector {
     });
   }
 
-  public recipeInstantiated(particles: Particle[], activeRecipe: string) {
+  public async recipeInstantiated(particles: Particle[], activeRecipe: string) {
     if (!DevtoolsConnection.isConnected) return;
-    this.storesFetcher.onRecipeInstantiated();
+    await this.storesFetcher.onRecipeInstantiated();
 
     type TruncatedSlot = {id: string, name: string};
     const truncate = ({id, name}: Slot) => ({id, name});

--- a/src/planning/plan/planificator.ts
+++ b/src/planning/plan/planificator.ts
@@ -137,8 +137,8 @@ export class Planificator {
   private _listenToArcStores() {
     this.arc.onDataChange(this.dataChangeCallback, this);
     this.storeCallbackIds = new Map();
-    this.arc.context.allStores.map(store => {
-      const callbackId = store.on(async () => {
+    this.arc.context.allStores.forEach(async store => {
+      const callbackId = (await store.activate()).on(async () => {
         this.replanQueue.addChange();
         return true;
       });
@@ -148,9 +148,9 @@ export class Planificator {
 
   private _unlistenToArcStores() {
     this.arc.clearDataChange(this);
-    this.arc.context.allStores.forEach(store => {
+    this.arc.context.allStores.forEach(async store => {
       const callbackId = this.storeCallbackIds.get(store);
-      store.off(callbackId);
+      (await store.activate()).off(callbackId);
     });
   }
 

--- a/src/planning/strategies/tests/search-tokens-to-handles-test.ts
+++ b/src/planning/strategies/tests/search-tokens-to-handles-test.ts
@@ -33,7 +33,7 @@ describe('SearchTokensToHandles', () => {
     `));
 
     const arc = StrategyTestHelper.createTestArc(manifest);
-    arc._registerStore(await arc.context.stores[0].castToStorageStub().inflate(), ['mything']);
+    await arc._registerStore(await arc.context.stores[0].castToStorageStub().inflate(), ['mything']);
 
     const recipe = manifest.recipes[0];
     assert(recipe.normalize());

--- a/src/runtime/arc-inspector.ts
+++ b/src/runtime/arc-inspector.ts
@@ -34,7 +34,7 @@ export interface ArcInspector {
    * @param particles particles instantiated in the arc
    * @param activeRecipe resulting active recipe that the arc holds
    */
-  recipeInstantiated(particles: Particle[], activeRecipe: string): void;
+  recipeInstantiated(particles: Particle[], activeRecipe: string): Promise<void>;
 
   /**
    * Notifies of a message exchanged over the Particle Execution Context.

--- a/src/runtime/arc.ts
+++ b/src/runtime/arc.ts
@@ -40,7 +40,7 @@ import {DriverFactory, Exists} from './storageNG/drivers/driver-factory.js';
 import {StorageKey} from './storageNG/storage-key.js';
 import {Store} from './storageNG/store.js';
 import {KeyBase} from './storage/key-base.js';
-import {UnifiedStore} from './storageNG/unified-store.js';
+import {UnifiedStore, UnifiedActiveStore} from './storageNG/unified-store.js';
 
 export type ArcOptions = Readonly<{
   id: Id;
@@ -270,7 +270,8 @@ constructor({id, context, pecFactories, slotComposer, loader, storageKey, storag
         let serializedData: {storageKey: string}[] | null = [];
         if (!volatile) {
           // TODO: include keys in serialized [big]collections?
-          serializedData = (await store.toLiteral()).model.map((model) => {
+          const activeStore = await store.activate();
+          serializedData = (await activeStore.toLiteral()).model.map((model) => {
             const {id, value} = model;
             const index = model['index']; // TODO: Invalid Type
 
@@ -521,8 +522,8 @@ ${this.activeRecipe.toString()}`;
                          inspectorFactory: this.inspectorFactory});
     const storeMap: Map<UnifiedStore, UnifiedStore> = new Map();
     for (const store of this._stores) {
-      const clone = await arc.storageProviderFactory.construct(store.id, store.type, 'volatile') as UnifiedStore;
-      await clone.cloneFrom(store);
+      const clone = await arc.storageProviderFactory.construct(store.id, store.type, 'volatile');
+      await clone.cloneFrom(await store.activate());
       storeMap.set(store, clone);
       if (this.storeDescriptions.has(store)) {
         arc.storeDescriptions.set(clone, this.storeDescriptions.get(store));
@@ -628,7 +629,8 @@ ${this.activeRecipe.toString()}`;
           const copiedStore = await copiedStoreRef.castToStorageStub().inflate(this.storageProviderFactory);
           assert(copiedStore, `Cannot find store ${recipeHandle.id}`);
           assert(copiedStore.version !== null, `Copied store ${recipeHandle.id} doesn't have version.`);
-          await newStore.cloneFrom(copiedStore);
+          const activeStore = await newStore.activate();
+          await activeStore.cloneFrom(copiedStore);
           this._tagStore(newStore, this.context.findStoreTags(copiedStoreRef));
           newStore.name = copiedStore.name && `Copy of ${copiedStore.name}`;
           const copiedStoreDesc = this.getStoreDescription(copiedStore);
@@ -683,7 +685,7 @@ ${this.activeRecipe.toString()}`;
     }
 
     if (this.inspector) {
-      this.inspector.recipeInstantiated(particles, this.activeRecipe.toString());
+      await this.inspector.recipeInstantiated(particles, this.activeRecipe.toString());
     }
   }
 
@@ -712,22 +714,19 @@ ${this.activeRecipe.toString()}`;
       storageKey = 'volatile';
     }
 
+    let store: UnifiedStore;
     if (typeof storageKey === 'string') {
-      const store = await this.storageProviderFactory.construct(id, type, storageKey);
+      store = await this.storageProviderFactory.construct(id, type, storageKey);
       assert(store, `failed to create store with id [${id}]`);
       store.name = name;
-
-      this._registerStore(store, tags);
-      return store;
     } else {
-      const store = new Store(storageKey, Exists.ShouldCreate, type, id, name);
-
-      this._registerStore(store, tags);
-      return store;
+      store = new Store(storageKey, Exists.ShouldCreate, type, id, name);
     }
+    await this._registerStore(store, tags);
+    return store;
   }
 
-  _registerStore(store: UnifiedStore, tags?: string[]): void {
+  async _registerStore(store: UnifiedStore, tags?: string[]): Promise<void> {
     assert(!this.storesById.has(store.id), `Store already registered '${store.id}'`);
     tags = tags || [];
     tags = Array.isArray(tags) ? tags : [tags];
@@ -738,7 +737,9 @@ ${this.activeRecipe.toString()}`;
     this.storeTags.set(store, new Set(tags));
 
     this.storageKeys[store.id] = store.storageKey;
-    store.on(async () => this._onDataChange());
+
+    const activeStore = await store.activate();
+    activeStore.on(async () => this._onDataChange());
 
     Runtime.getRuntime().registerStore(store, tags);
   }

--- a/src/runtime/arc.ts
+++ b/src/runtime/arc.ts
@@ -434,7 +434,7 @@ ${this.activeRecipe.toString()}`;
     await Promise.all(manifest.stores.map(async storeStub => {
       const tags = manifest.storeTags.get(storeStub);
       const store = await storeStub.castToStorageStub().inflate();
-      arc._registerStore(store, tags);
+      await arc._registerStore(store, tags);
     }));
     const recipe = manifest.activeRecipe.clone();
     const options: IsValidOptions = {errors: new Map()};
@@ -552,7 +552,7 @@ ${this.activeRecipe.toString()}`;
 
     for (const v of storeMap.values()) {
       // FIXME: Tags
-      arc._registerStore(v, []);
+      await arc._registerStore(v, []);
     }
     return arc;
   }
@@ -663,7 +663,7 @@ ${this.activeRecipe.toString()}`;
         if (typeof storageKey === 'string') {
           const store = await this.storageProviderFactory.connect(recipeHandle.id, type, storageKey);
           assert(store, `store '${recipeHandle.id}' was not found (${storageKey})`);
-          this._registerStore(store, recipeHandle.tags);
+          await this._registerStore(store, recipeHandle.tags);
         } else {
           throw new Error('Need to implement storageNG code path here!');
         }

--- a/src/runtime/particle-execution-host.ts
+++ b/src/runtime/particle-execution-host.ts
@@ -353,9 +353,9 @@ class PECOuterPortImpl extends PECOuterPort {
             // in Arc.deserialize.
             for (const store of manifest.stores) {
               if (store instanceof StorageStub) {
-                this.arc._registerStore(await store.inflate(), []);
+                await this.arc._registerStore(await store.inflate(), []);
               } else {
-                this.arc._registerStore(store, []);
+                await this.arc._registerStore(store, []);
               }
             }
             // TODO: Awaiting this promise causes tests to fail...

--- a/src/runtime/storage-stub.ts
+++ b/src/runtime/storage-stub.ts
@@ -13,7 +13,7 @@ import {ClaimIsTag} from './particle-claim.js';
 import {StorageProviderFactory} from './storage/storage-provider-factory.js';
 import {Type} from './type.js';
 import {VolatileStorageProvider} from './storage/volatile-storage.js';
-import {UnifiedStore} from './storageNG/unified-store.js';
+import {UnifiedStore, UnifiedActiveStore} from './storageNG/unified-store.js';
 import {ProxyCallback} from './storageNG/store.js';
 
 // TODO(shans): Make sure that after refactor Storage objects have a lifecycle and can be directly used
@@ -45,6 +45,10 @@ export class StorageStub extends UnifiedStore {
     return -1;
   }
   off(callback: number): void {}
+
+  async activate(): Promise<UnifiedActiveStore> {
+    return this.inflate();
+  }
 
   async inflate(storageProviderFactory?: StorageProviderFactory) {
     const factory = storageProviderFactory || this.storageProviderFactory;

--- a/src/runtime/storage/volatile-storage.ts
+++ b/src/runtime/storage/volatile-storage.ts
@@ -102,12 +102,12 @@ export class VolatileStorage extends StorageBase {
 
   async _construct(id, type, keyFragment) {
     const key = this.constructKey(keyFragment);
-    // TODO(shanestephens): should pass in factory, not 'this' here.
-    const provider = VolatileStorageProvider.newProvider(type, this, undefined, id, key);
-    if (this._memoryMap[key] !== undefined) {
-      return null;
+    let provider = this._memoryMap[key];
+    if (!provider) {
+      // TODO(shanestephens): should pass in factory, not 'this' here.
+      provider = VolatileStorageProvider.newProvider(type, this, undefined, id, key);
+      this._memoryMap[key] = provider;
     }
-    this._memoryMap[key] = provider;
     return provider;
   }
 

--- a/src/runtime/storageNG/direct-store.ts
+++ b/src/runtime/storageNG/direct-store.ts
@@ -15,6 +15,7 @@ import {Exists, Driver, DriverFactory} from './drivers/driver-factory.js';
 import {StorageKey} from './storage-key.js';
 import {ActiveStore, ProxyCallback, StorageMode, ProxyMessageType, ProxyMessage} from './store-interface.js';
 import {noAwait} from '../util.js';
+import {Store} from './store.js';
 
 export enum DirectStoreState {Idle = 'Idle', AwaitingResponse = 'AwaitingResponse', AwaitingResponseDirty = 'AwaitingResponseDirty', AwaitingDriverModel = 'AwaitingDriverModel'}
 
@@ -32,8 +33,8 @@ export class DirectStore<T extends CRDTTypeRecord> extends ActiveStore<T> {
   /*
    * This class should only ever be constructed via the static construct method
    */
-  private constructor(storageKey: StorageKey, exists: Exists, type: Type, mode: StorageMode) {
-    super(storageKey, exists, type, mode);
+  private constructor(storageKey: StorageKey, exists: Exists, type: Type, mode: StorageMode, baseStore: Store<T>) {
+    super(storageKey, exists, type, mode, baseStore);
   }
 
   async idle() {
@@ -67,8 +68,8 @@ export class DirectStore<T extends CRDTTypeRecord> extends ActiveStore<T> {
     }
   }
 
-  static async construct<T extends CRDTTypeRecord>(storageKey: StorageKey, exists: Exists, type: Type, mode: StorageMode) {
-    const me = new DirectStore<T>(storageKey, exists, type, mode);
+  static async construct<T extends CRDTTypeRecord>(storageKey: StorageKey, exists: Exists, type: Type, mode: StorageMode, baseStore: Store<T>) {
+    const me = new DirectStore<T>(storageKey, exists, type, mode, baseStore);
     me.localModel = new (type.crdtInstanceConstructor<T>())();
     me.driver = await DriverFactory.driverInstance(storageKey, exists);
     if (me.driver == null) {

--- a/src/runtime/storageNG/store-interface.ts
+++ b/src/runtime/storageNG/store-interface.ts
@@ -14,6 +14,8 @@ import {Type} from '../type.js';
 import {Exists} from './drivers/driver-factory.js';
 import {StorageKey} from './storage-key.js';
 import {StorageProxy} from './storage-proxy.js';
+import {UnifiedActiveStore} from './unified-store.js';
+import {Store} from './store.js';
 
 /**
  * This file exists to break a circular dependency between Store and the ActiveStore implementations.
@@ -51,21 +53,38 @@ export interface StorageCommunicationEndpointProvider<T extends CRDTTypeRecord> 
 
 // A representation of an active store. Subclasses of this class provide specific
 // behaviour as controlled by the provided StorageMode.
-export abstract class ActiveStore<T extends CRDTTypeRecord> implements StoreInterface<T>, StorageCommunicationEndpointProvider<T> {
+export abstract class ActiveStore<T extends CRDTTypeRecord>
+    implements StoreInterface<T>, StorageCommunicationEndpointProvider<T>, UnifiedActiveStore {
   readonly storageKey: StorageKey;
   exists: Exists;
   readonly type: Type;
   readonly mode: StorageMode;
+  readonly baseStore: Store<T>;
 
-  constructor(storageKey: StorageKey, exists: Exists, type: Type, mode: StorageMode) {
+  // TODO: Lots of these params can be pulled from baseStore.
+  constructor(storageKey: StorageKey, exists: Exists, type: Type, mode: StorageMode, baseStore: Store<T>) {
     this.storageKey = storageKey;
     this.exists = exists;
     this.type = type;
     this.mode = mode;
+    this.baseStore = baseStore;
   }
 
   async idle() {
     return Promise.resolve();
+  }
+
+  // tslint:disable-next-line no-any
+  async toLiteral(): Promise<any> {
+    throw new Error('Method not implemented.');
+  }
+
+  async cloneFrom(store: UnifiedActiveStore): Promise<void> {
+    throw new Error('Method not implemented.');
+  }
+
+  async modelForSynchronization(): Promise<{}> {
+    return this.toLiteral();
   }
 
   abstract on(callback: ProxyCallback<T>): number;

--- a/src/runtime/storageNG/testing/test-storage.ts
+++ b/src/runtime/storageNG/testing/test-storage.ts
@@ -48,7 +48,7 @@ export class MockStore<T extends CRDTTypeRecord> extends ActiveStore<T> {
   lastCapturedMessage: ProxyMessage<T> = null;
   lastCapturedException: PropagatedException = null;
   constructor() {
-    super(new MockStorageKey(), Exists.ShouldCreate, new CountType(), StorageMode.Direct);
+    super(new MockStorageKey(), Exists.ShouldCreate, new CountType(), StorageMode.Direct, /* baseStore= */ null);
   }
   on(callback: ProxyCallback<T>): number {
     return 1;

--- a/src/runtime/storageNG/tests/ramdisk-backing-store-integration-test.ts
+++ b/src/runtime/storageNG/tests/ramdisk-backing-store-integration-test.ts
@@ -9,7 +9,7 @@
  */
 
 import {assert} from '../../../platform/chai-web.js';
-import {StorageMode, ProxyMessageType, ProxyMessage} from '../store.js';
+import {StorageMode, ProxyMessageType, ProxyMessage, Store} from '../store.js';
 import {CRDTCountTypeRecord, CRDTCount, CountOpTypes} from '../../crdt/crdt-count.js';
 import {RamDiskStorageKey, RamDiskStorageDriverProvider} from '../drivers/ramdisk.js';
 import {Exists, DriverFactory} from '../drivers/driver-factory.js';
@@ -38,7 +38,9 @@ describe('RamDisk + Backing Store Integration', async () => {
   it('will allow storage of a number of objects', async () => {
     const runtime = new Runtime();
     const storageKey = new RamDiskStorageKey('unique');
-    const store = await BackingStore.construct<CRDTCountTypeRecord>(storageKey, Exists.ShouldCreate, new CountType(), StorageMode.Backing);
+    const baseStore = new Store<CRDTCountTypeRecord>(storageKey, Exists.ShouldCreate, new CountType(), 'base-store-id');
+    const store = await BackingStore.construct<CRDTCountTypeRecord>(
+        storageKey, Exists.ShouldCreate, new CountType(), StorageMode.Backing, baseStore);
 
     const count1 = new CRDTCount();
     count1.applyOperation({type: CountOpTypes.Increment, actor: 'me', version: {from: 0, to: 1}});

--- a/src/runtime/testing/callback-tracker.ts
+++ b/src/runtime/testing/callback-tracker.ts
@@ -27,8 +27,13 @@ export class CallbackTracker {
   // tslint:disable-next-line: no-any
   events: Dictionary<any>[] = [];
 
-  constructor(storageProvider: UnifiedStore, public expectedEvents = 0) {
-    storageProvider.on(async val => this.changeEvent(val));
+  private constructor(public expectedEvents: number) {}
+
+  static async create(store: UnifiedStore, expectedEvents = 0): Promise<CallbackTracker> {
+    const tracker = new CallbackTracker(expectedEvents);
+    const activeStore = await store.activate();
+    activeStore.on(async val => tracker.changeEvent(val));
+    return tracker;
   }
 
   // called for each change event

--- a/src/runtime/tests/arc-test.ts
+++ b/src/runtime/tests/arc-test.ts
@@ -598,7 +598,7 @@ describe('Arc ' + storageKeyPrefix, () => {
 
     const {arc, recipe, Foo, Bar, loader} = await setup(storageKeyPrefix);
     let fooStore = await arc.createStore(Foo.type, undefined, 'test:1') as SingletonStorageProvider;
-    const fooStoreCallbacks = new CallbackTracker(fooStore, 1);
+    const fooStoreCallbacks = await CallbackTracker.create(fooStore, 1);
 
     await getSingletonHandle(fooStore).set(new Foo({value: 'a Foo'}));
     let barStore = await arc.createStore(Bar.type, undefined, 'test:2', ['tag1', 'tag2']) as SingletonStorageProvider;
@@ -837,7 +837,7 @@ describe('Arc ' + storageKeyPrefix, () => {
       : storageKeyPrefix + `${id}/arc-info`;
 
     const store = await arc.storageProviderFactory.connect('id', new ArcType(), key) as SingletonStorageProvider;
-    const callbackTracker = new CallbackTracker(store, 0);
+    const callbackTracker = await CallbackTracker.create(store, 0);
 
     assert.isNotNull(store, 'got a valid store');
     const data = await store.get();

--- a/src/runtime/tests/storage/pouchdb/pouch-db-test.ts
+++ b/src/runtime/tests/storage/pouchdb/pouch-db-test.ts
@@ -72,7 +72,7 @@ describe('pouchdb for ' + testUrl, () => {
       const barType = new EntityType(manifest.schemas.Bar);
       const value = 'Hi there' + Math.random();
       const variable = await storage.construct('test0', barType, newStoreKey('variable')) as PouchDbSingleton;
-      const callbackTracker = new CallbackTracker(variable, 1);
+      const callbackTracker = await CallbackTracker.create(variable, 1);
 
       await variable.set({id: 'test0:test', value});
       const result = await variable.get();
@@ -90,7 +90,7 @@ describe('pouchdb for ' + testUrl, () => {
       const barType = new EntityType(manifest.schemas.Bar);
       const key = newStoreKey('variable');
       const var1 = await storage.construct('test0', barType, key) as PouchDbSingleton;
-      const var1Callbacks = new CallbackTracker(var1, 2);
+      const var1Callbacks = await CallbackTracker.create(var1, 2);
 
       assert.isNotNull(var1);
       const var2 = await storage.connect(
@@ -99,7 +99,7 @@ describe('pouchdb for ' + testUrl, () => {
         key
       ) as PouchDbSingleton;
       assert.isNotNull(var2);
-      const var2Callbacks = new CallbackTracker(var2, 2);
+      const var2Callbacks = await CallbackTracker.create(var2, 2);
 
       await var1.set({id: 'id1', value: 'value1'});
       await var2.set({id: 'id2', value: 'value2'});
@@ -276,7 +276,7 @@ describe('pouchdb for ' + testUrl, () => {
       const barType = new EntityType(manifest.schemas.Bar);
       const key = newStoreKey('collectionRemoveMultiple');
       const collection = await storage.construct('test1', barType.collectionOf(), key) as PouchDbCollection;
-      const collectionCallbacks = new CallbackTracker(collection, 3);
+      const collectionCallbacks = await CallbackTracker.create(collection, 3);
       await collection.store({id: 'id1', value: 'value'}, ['key1']);
       await collection.store({id: 'id2', value: 'value'}, ['key2']);
       await collection.removeMultiple([
@@ -298,7 +298,7 @@ describe('pouchdb for ' + testUrl, () => {
       const key1 = newStoreKey('colPtr');
 
       const collection1 = await storage.construct('test0', new ReferenceType(barType).collectionOf(), key1) as PouchDbCollection;
-      const callbackTracker = new CallbackTracker(collection1, 2);
+      const callbackTracker = await CallbackTracker.create(collection1, 2);
 
       await collection1.store({id: 'id1', storageKey: 'value1'}, ['key1']);
       await collection1.store({id: 'id2', storageKey: 'value2'}, ['key2']);


### PR DESCRIPTION
There are now two main "Unified" classes/interfaces:
1. UnifiedStore: contains information about a store, can be "activated"
into a...
2. UnifiedActiveStore: a store which has been connected to storage. Each
active store remembers its "base store", i.e. the UnifiedStore from
which is was activated.

In the new world, UnifiedStore == Store, UnifiedActiveStore ==
ActiveStore.

It's always possible to go back to the UnifiedStore instance (which
contains most of the interesting properties like name, id, type, etc.).
Activating a store more than once should produce the same instance
again.

In the old world, StorageProviderBase acts as both a UnifiedStore and a
UnifiedActiveStore. Throughout the codebase, we interchange between
active/inactive stores at will, so cleaning this up is going to be
interesting...

There are some properties on UnifiedStore that should be on
UnifiedActiveStore, and there are a bunch of duplicates in
UnifiedActiveStore that should be deleted.