### PR TITLE
Add rules for arcs_manifest/particle/deployable

### DIFF
--- a/build_defs/build_defs.bzl
+++ b/build_defs/build_defs.bzl
@@ -100,7 +100,7 @@ def arcs_manifest(name, srcs, deps = []):
 
 def arcs_kt_particle(name, srcs, deps = []):
     """Declares kotlin library targets for Kotlin particle sources."""
-    _android_and_wasm_library(name, srcs, deps)
+    _android_and_wasm_library(name, srcs, ["//src/wasm/kotlin:arcs"] + deps)
 
 def arcs_kt_wasm_binary(name, deps):
     """Performs final compilation of wasm and bundling if necessary."""

--- a/build_defs/build_defs.bzl
+++ b/build_defs/build_defs.bzl
@@ -2,6 +2,8 @@ load(":run_in_repo.bzl", "EXECUTION_REQUIREMENTS_TAGS", "run_in_repo", "run_in_r
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_android_library")
 load("//build_defs/kotlin_native:build_defs.bzl", "kt_wasm_binary", "kt_wasm_library")
 
+_ANDROID_TARGETS = False
+
 def _output_name(src, file_extension = ""):
     return src.replace(".arcs", "").replace("_", "-").replace(".", "-") + file_extension
 
@@ -44,18 +46,25 @@ def arcs_cc_schema(name, src, out = None):
         file_extension = ".h",
     )
 
+def _android_name(name):
+    return name + "_android"
+
+def _android_deps(deps):
+    return [_android_name(dep) for dep in deps]
+
 def _wasm_name(name):
     return name + "_wasm"
 
 def _wasm_deps(deps):
     return [_wasm_name(dep) for dep in deps]
 
-def _jvm_and_wasm_library(name, srcs, deps):
-    kt_android_library(
-        name = name,
-        srcs = srcs,
-        deps = deps
-    )
+def _android_and_wasm_library(name, srcs, deps):
+    if _ANDROID_TARGETS:
+      kt_android_library(
+          name = _android_name(name),
+          srcs = srcs,
+          deps = _android_deps(deps)
+      )
 
     kt_wasm_library(
         name = _wasm_name(name),
@@ -83,17 +92,17 @@ def arcs_manifest(name, srcs, deps = []):
     outs = [arcs_kt_schema(_output_name(src), src, deps) for src in srcs]
     deps = ["//src/wasm/kotlin:arcs"] + deps
 
-    _jvm_and_wasm_library(
+    _android_and_wasm_library(
         name,
         outs,
         deps
     )
 
 def arcs_kt_particle(name, srcs, deps = []):
-    """Declares kotlin library/wasm targets for Kotlin particle sources."""
-    _jvm_and_wasm_library(name, srcs, deps)
+    """Declares kotlin library targets for Kotlin particle sources."""
+    _android_and_wasm_library(name, srcs, deps)
 
-def arcs_deployable(name, deps):
+def arcs_kt_wasm_binary(name, deps):
     """Performs final compilation of wasm and bundling if necessary."""
     # TODO: add bundling step
     kt_wasm_binary(name = name, srcs = [], deps = _wasm_deps(deps))

--- a/build_defs/build_defs.bzl
+++ b/build_defs/build_defs.bzl
@@ -1,4 +1,9 @@
 load(":run_in_repo.bzl", "EXECUTION_REQUIREMENTS_TAGS", "run_in_repo", "run_in_repo_test")
+load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_android_library")
+load("//build_defs/kotlin_native:build_defs.bzl", "kt_wasm_binary", "kt_wasm_library")
+
+def _output_name(src, file_extension = ""):
+    return src.replace(".arcs", "").replace("_", "-").replace(".", "-") + file_extension
 
 def _run_schema2pkg(name, src, out, language_name, language_flag, file_extension):
     """Generates source code for the given .arcs schema file.
@@ -11,7 +16,7 @@ def _run_schema2pkg(name, src, out, language_name, language_flag, file_extension
 
     if out == None:
         # Clean up the output name.
-        out = src.replace(".arcs", "").replace("_", "-").replace(".", "-") + file_extension
+        out = _output_name(src, file_extension)
 
     run_in_repo(
         name = name,
@@ -39,16 +44,59 @@ def arcs_cc_schema(name, src, out = None):
         file_extension = ".h",
     )
 
-def arcs_kt_schema(name, src, out = None):
-    """Generates a Kotlin file for the given .arcs schema file."""
-    _run_schema2pkg(
+def _wasm_name(name):
+    return name + "_wasm"
+
+def _wasm_deps(deps):
+    return [_wasm_name(dep) for dep in deps]
+
+def _jvm_and_wasm_library(name, srcs, deps):
+    kt_android_library(
         name = name,
+        srcs = srcs,
+        deps = deps
+    )
+
+    kt_wasm_library(
+        name = _wasm_name(name),
+        srcs = srcs,
+        deps = _wasm_deps(deps)
+    )
+
+def arcs_kt_schema(name, src, out = None, deps = [], wasm_deps = []):
+    """Generates a Kotlin file for the given .arcs schema file."""
+    out = out or _output_name(src, ".kt")
+    _run_schema2pkg(
+        name = name + "_genrule",
         src = src,
         out = out,
         language_name = "Kotlin",
         language_flag = "--kotlin",
         file_extension = ".kt",
     )
+
+    return out
+
+def arcs_manifest(name, srcs, deps = []):
+    """Generates Kotlin+Wasm Library targets from .arcs file translated to Kotlin."""
+    # TODO: when converted to rule()+provider() verify deps are arcs_manifest rules
+    outs = [arcs_kt_schema(_output_name(src), src, deps) for src in srcs]
+    deps = ["//src/wasm/kotlin:arcs"] + deps
+
+    _jvm_and_wasm_library(
+        name,
+        outs,
+        deps
+    )
+
+def arcs_kt_particle(name, srcs, deps = []):
+    """Declares kotlin library/wasm targets for Kotlin particle sources."""
+    _jvm_and_wasm_library(name, srcs, deps)
+
+def arcs_deployable(name, deps):
+    """Performs final compilation of wasm and bundling if necessary."""
+    # TODO: add bundling step
+    kt_wasm_binary(name = name, srcs = [], deps = _wasm_deps(deps))
 
 def arcs_ts_test(name, src, deps):
     """Runs a TypeScript test file using `sigh test`."""

--- a/particles/Native/Wasm/BUILD
+++ b/particles/Native/Wasm/BUILD
@@ -1,6 +1,6 @@
 load("//build_defs/kotlin_native:build_defs.bzl", "kt_wasm_binary", "kt_wasm_library")
 load("//build_defs/emscripten:build_defs.bzl", "cc_wasm_binary")
-load("//build_defs:build_defs.bzl", "arcs_kt_schema", "arcs_cc_schema", "arcs_ts_test")
+load("//build_defs:build_defs.bzl", "arcs_manifest", "arcs_kt_particle", "arcs_cc_schema", "arcs_ts_test", "arcs_deployable")
 
 
 arcs_cc_schema(
@@ -16,23 +16,34 @@ cc_wasm_binary(
     deps = ["//src/wasm/cpp:arcs"],
 )
 
-arcs_kt_schema(
+arcs_manifest(
     name = "wasm_schemas",
-    src = "Harness.arcs",
-    out = "Entities.kt",
+    srcs = ["Harness.arcs"],
 )
 
-kt_wasm_binary(
-    name = "service_particle",
+
+arcs_kt_particle(
+    name = "service_particle_lib",
     srcs = ["source/ServiceParticle.kt"],
-    deps = ["//src/wasm/kotlin:arcs_wasm"],
 )
 
-kt_wasm_binary(
-    name = "test_harness",
+arcs_kt_particle(
+    name = "test_particle_lib",
     srcs = [
         "source/TestParticle.kt",
-        ":wasm_schemas",
+ 
     ],
-    deps = ["//src/wasm/kotlin:arcs_wasm"],
+    deps = [    
+        ":wasm_schemas",
+    ]
 )
+
+arcs_deployable(
+   name = "service_particle",
+   deps = [":service_particle_lib"])
+
+
+arcs_deployable(
+   name = "test_particle",
+   deps = [":test_particle_lib"])
+

--- a/particles/Native/Wasm/BUILD
+++ b/particles/Native/Wasm/BUILD
@@ -1,6 +1,6 @@
 load("//build_defs/kotlin_native:build_defs.bzl", "kt_wasm_binary", "kt_wasm_library")
 load("//build_defs/emscripten:build_defs.bzl", "cc_wasm_binary")
-load("//build_defs:build_defs.bzl", "arcs_manifest", "arcs_kt_particle", "arcs_cc_schema", "arcs_ts_test", "arcs_deployable")
+load("//build_defs:build_defs.bzl", "arcs_manifest", "arcs_kt_particle", "arcs_cc_schema", "arcs_ts_test", "arcs_kt_wasm_binary")
 
 
 arcs_cc_schema(
@@ -38,12 +38,12 @@ arcs_kt_particle(
     ]
 )
 
-arcs_deployable(
+arcs_kt_wasm_binary(
    name = "service_particle",
    deps = [":service_particle_lib"])
 
 
-arcs_deployable(
+arcs_kt_wasm_binary(
    name = "test_particle",
    deps = [":test_particle_lib"])
 


### PR DESCRIPTION
Adds arcs_manifest/arcs_kt_particle/arcs_deployable for compiling schemas, kotlin to both JVM and WASM.

Dataflow piece to follow.
