### PR TITLE
Log warnings for Particle Specs using external schemas

### DIFF
--- a/src/runtime/tests/artifacts/test.manifest
+++ b/src/runtime/tests/artifacts/test.manifest
@@ -9,7 +9,7 @@ schema Text
   Text value
 
 particle Hello in 'hello.js'
-  out Text text
+  out Text {value} text
 
 recipe
   create as handleA

--- a/src/runtime/tests/manifest-test.ts
+++ b/src/runtime/tests/manifest-test.ts
@@ -2926,6 +2926,17 @@ resource SomeName
       });
     });
   });
+  it('warns about using external schemas', async () => {
+    const manifest = await Manifest.parse(`
+schema Thing
+  Text value
+
+particle A
+  in Thing thing
+    `);
+    assert.lengthOf(manifest.errors, 1);
+    assert.equal(manifest.errors[0].key, 'externalSchemas');
+  });
 });
 
 describe('Manifest storage migration', () => {

--- a/src/runtime/tests/runtime-test.ts
+++ b/src/runtime/tests/runtime-test.ts
@@ -45,7 +45,7 @@ describe('Runtime', () => {
       Text value
 
     particle Hello in 'hello.js'
-      out Text text
+      out Text {value} text
 
     recipe
       create as handleA


### PR DESCRIPTION
With this change we will see warnings about non-inline schemas if we add `?logManifestWarnings` to the URL, or if we're in web-based pipes-shell, where they are turned on by default.

@sjmiles can you advise how to plug things correctly through shells?