### PR TITLE
Insure pipes-shell existence at compilation

### DIFF
--- a/javaharness/java/arcs/BUILD
+++ b/javaharness/java/arcs/BUILD
@@ -13,6 +13,10 @@ filegroup(
     name = "pipes-shell-dist",
     srcs = glob(
         ["pipes-shell/web/deploy/dist/**/*"],
+        # The pipes-shell and the Arcs runtime MUST be in place.
+        # Otherwise all webview-based runtime services/bus/devtools
+        # would malfunction.
+        allow_empty = False,
     ),
 )
 


### PR DESCRIPTION
Build would fail if pipes-shell has not been webpacked and deployed.