### PR TITLE
Support typed-values in wasm::StringDecoder (for nested dictionaries)

### DIFF
--- a/src/runtime/tests/wasm-decoder-test.ts
+++ b/src/runtime/tests/wasm-decoder-test.ts
@@ -12,27 +12,44 @@ import {assert} from '../../platform/chai-web.js';
 import {StringDecoder} from '../wasm.js';
 
 //  <value> depends on the field type:
-//    Text       <name>:T<length>:<text>
-//    URL        <name>:U<length>:<text>
-//    Number     <name>:N<number>:
-//    Boolean    <name>:B<zero-or-one>
+//    Text       T<length>:<text>
+//    URL        U<length>:<text>
+//    Number     N<number>:
+//    Boolean    B<zero-or-one>
 //<size>:<key-len>:<key><value-len>:<value><key-len>:<key><value-len>:<value>
 
 describe('wasm::StringDecoder', () => {
-  it('decodes encoded values in dictionaries', () => {
+  it('decodes string values in dictionary', () => {
+    const dec = new StringDecoder();
+    const enc = '1:3:foo3:bar';
+    const dic = dec.decodeDictionary(enc);
+    //console.log(`${enc} => ${JSON.stringify(dic, null, '  ')}`);
+    assert.deepEqual(dic, {foo: "bar"});
+  });
+  it('decodes encoded values in dictionary', () => {
     const dec = new StringDecoder();
     const enc = '1:3:fooT3:bar';
     const dic = dec.decodeDictionary(enc);
-    assert.isNotNull(dic);
+    //console.log(`${enc} => ${JSON.stringify(dic, null, '  ')}`);
+    assert.deepEqual(dic, {foo: "bar"});
   });
   it('decodes nested dictionaries', () => {
     const dec = new StringDecoder();
-    const enc = '1:3:fooT3:bar';
-    const nestedEnc = `1:3:fooD${enc.length}:${enc}`;
-    const nestedEnc2 = `1:3:fooD${nestedEnc.length}:${nestedEnc}`;
-    const dic = dec.decodeDictionary(nestedEnc2);
-    console.log(`${nestedEnc2} =>`);
-    console.log(JSON.stringify(dic, null, '  '));
-    assert.isNotNull(dic);
+    const base = '1:3:fooT3:bar';
+    const nestedEnc = `1:3:fooD${base.length}:${base}`;
+    const enc = `1:3:fooD${nestedEnc.length}:${nestedEnc}`;
+    const dic = dec.decodeDictionary(enc);
+    //console.log(`${enc} => ${JSON.stringify(dic, null, '  ')}`);
+    assert.deepEqual<{}>(dic, {foo: {foo: {foo: 'bar'}}});
+  });
+  it('decodes complex dictionary', () => {
+    const dec = new StringDecoder();
+    const data = '2:okB13:numN42:3:fooT3:bar';
+    const base = `3:${data}`;
+    const nestedEnc = `4:${data}3:bazD${base.length}:${base}`;
+    const enc = `2:3:zotT3:zoo3:fooD${nestedEnc.length}:${nestedEnc}`;
+    const dic = dec.decodeDictionary(enc);
+    //console.log(`${enc} => ${JSON.stringify(dic, null, '  ')}`);
+    assert.deepEqual<{}>(dic, {zot: "zoo", foo: {ok: true, num: 42, foo: "bar", baz: {ok: true, num: 42, foo: 'bar'}}});
   });
 });

--- a/src/runtime/tests/wasm-decoder-test.ts
+++ b/src/runtime/tests/wasm-decoder-test.ts
@@ -26,7 +26,7 @@ describe('wasm::StringDecoder', () => {
     //console.log(`${enc} => ${JSON.stringify(dic, null, '  ')}`);
     assert.deepEqual(dic, {foo: "bar"});
   });
-  it('decodes encoded values in dictionary', () => {
+  it('decodes type-coded values in dictionary', () => {
     const dec = new StringDecoder();
     const enc = '1:3:fooT3:bar';
     const dic = dec.decodeDictionary(enc);

--- a/src/runtime/tests/wasm-decoder-test.ts
+++ b/src/runtime/tests/wasm-decoder-test.ts
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright (c) 2019 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {assert} from '../../platform/chai-web.js';
+import {StringDecoder} from '../wasm.js';
+
+//  <value> depends on the field type:
+//    Text       <name>:T<length>:<text>
+//    URL        <name>:U<length>:<text>
+//    Number     <name>:N<number>:
+//    Boolean    <name>:B<zero-or-one>
+//<size>:<key-len>:<key><value-len>:<value><key-len>:<key><value-len>:<value>
+
+describe('wasm::StringDecoder', () => {
+  it('decodes encoded values in dictionaries', () => {
+    const dec = new StringDecoder();
+    const enc = '1:3:fooT3:bar';
+    const dic = dec.decodeDictionary(enc);
+    assert.isNotNull(dic);
+  });
+  it('decodes nested dictionaries', () => {
+    const dec = new StringDecoder();
+    const enc = '1:3:fooT3:bar';
+    const nestedEnc = `1:3:fooD${enc.length}:${enc}`;
+    const nestedEnc2 = `1:3:fooD${nestedEnc.length}:${nestedEnc}`;
+    const dic = dec.decodeDictionary(nestedEnc2);
+    console.log(`${nestedEnc2} =>`);
+    console.log(JSON.stringify(dic, null, '  '));
+    assert.isNotNull(dic);
+  });
+});

--- a/src/runtime/tests/wasm-decoder-test.ts
+++ b/src/runtime/tests/wasm-decoder-test.ts
@@ -24,14 +24,14 @@ describe('wasm::StringDecoder', () => {
     const enc = '1:3:foo3:bar';
     const dic = dec.decodeDictionary(enc);
     //console.log(`${enc} => ${JSON.stringify(dic, null, '  ')}`);
-    assert.deepEqual(dic, {foo: "bar"});
+    assert.deepEqual(dic, {foo: 'bar'});
   });
   it('decodes type-coded values in dictionary', () => {
     const dec = new StringDecoder();
     const enc = '1:3:fooT3:bar';
     const dic = dec.decodeDictionary(enc);
     //console.log(`${enc} => ${JSON.stringify(dic, null, '  ')}`);
-    assert.deepEqual(dic, {foo: "bar"});
+    assert.deepEqual(dic, {foo: 'bar'});
   });
   it('decodes nested dictionaries', () => {
     const dec = new StringDecoder();
@@ -50,6 +50,6 @@ describe('wasm::StringDecoder', () => {
     const enc = `2:3:zotT3:zoo3:fooD${nestedEnc.length}:${nestedEnc}`;
     const dic = dec.decodeDictionary(enc);
     //console.log(`${enc} => ${JSON.stringify(dic, null, '  ')}`);
-    assert.deepEqual<{}>(dic, {zot: "zoo", foo: {ok: true, num: 42, foo: "bar", baz: {ok: true, num: 42, foo: 'bar'}}});
+    assert.deepEqual<{}>(dic, {zot: 'zoo', foo: {ok: true, num: 42, foo: 'bar', baz: {ok: true, num: 42, foo: 'bar'}}});
   });
 });

--- a/src/runtime/wasm.ts
+++ b/src/runtime/wasm.ts
@@ -252,11 +252,12 @@ export class StringDecoder {
       case 'B':
         return Boolean(this.chomp(1) === '1');
 
-      case 'D':
+      case 'D': {
         const len = Number(this.upTo(':'));
         const dictionary = this.chomp(len);
         return this.decodeDictionary(dictionary);
-
+      }
+      
       default:
         throw new Error(`Packaged entity decoding fail: unknown or unsupported primitive value type '${typeChar}'`);
     }

--- a/src/runtime/wasm.ts
+++ b/src/runtime/wasm.ts
@@ -33,18 +33,23 @@ import {ParticleExecutionContext} from './particle-execution-context.js';
 //    Number       N<number>:
 //    Boolean      B<zero-or-one>
 //    Dictionary   D<length>:<dictionary format>
-
+//
 //  <collection> = <num-entities>:<length>:<encoded><length>:<encoded> ...
 //
 //  <reference> = <length>:<id>|<length>:<storage-key>|
+//
+// The encoder classes also supports two "Dictionary" formats of key:value string pairs.
+//
+// The first format supports only string-type values:
+//   <size>:<key-len>:<key><value-len>:<value><key-len>:<key><value-len>:<value>...
+// alternate format supports typed-values using <value> syntax defined above
+//   <size>:<key-len>:<key><value><key-len>:<key><value>...
 //
 // Examples:
 //   Singleton:   4:id05|txt:T3:abc|lnk:U10:http://def|num:N37:|flg:B1|
 //   Collection:  3:29:4:id12|txt:T4:qwer|num:N9.2:|18:6:id2670|num:N-7:|15:5:id501|flg:B0|
 //   Reference:   5:id461|65:volatile://!684596363489092:example^^volatile-Result {Text value}|
 //
-// The encoder classes also support a "Dictionary" format of key:value string pairs:
-//   <size>:<key-len>:<key><value-len>:<value><key-len>:<key><value-len>:<value>...
 export class EntityPackager {
   private encoder: StringEncoder;
   private decoder: StringDecoder;
@@ -193,10 +198,17 @@ export class StringDecoder {
     while (num--) {
       const klen = Number(this.upTo(':'));
       const key = this.chomp(klen);
+      // TODO(sjmiles): be backward compatible with encoders that only encode string values
       const typeChar = this.chomp(1);
-      dict[key] = this.decodeValue(typeChar);
-      //const vlen = Number(this.upTo(':'));
-      //dict[key] = this.chomp(vlen);
+      // if typeChar is a digit, it's part of a length specifier
+      if (typeChar >= '0' && typeChar <= '9') {
+        const vlen = Number(`${typeChar}${this.upTo(':')}`);
+        dict[key] = this.chomp(vlen);
+      }
+      // otherwise typeChar is value-type specifier
+      else {
+        dict[key] = this.decodeValue(typeChar);
+      }
     }
     return dict;
   }


### PR DESCRIPTION
Original implementation supported dictionaries formatted thusly:
`<size>:<key-len>:<key><value-len>:<value><key-len>:<key><value-len>:<value>...`

This patch adds support for another format:
`<size>:<key-len>:<key><value><key-len>:<key><value>...`

In the second format, the `<value>` expressions are evaluated by the existing typed-value decoder.

E.g.
`1:3:foo3:bar`
is equivalent to
`1:3:fooT3:bar`

We also allow the typed-value decoder to accept Dictionary values encoded with `D` type-char.

In combination, these changes allow decoding nested dictionaries while also maintaining backward-compatibility with existing formats.

