### PR TITLE
UnifiedStore refactor: StoreInfo object, toManifestString()

### DIFF
--- a/shells/lib/stores.js
+++ b/shells/lib/stores.js
@@ -37,9 +37,9 @@ export class Stores {
 const ManifestPatch = {
   async createStore(type, name, id, tags, claims, storageKey) {
     const store = await this.storageProviderFactory.construct(id, type, storageKey || `volatile://${this.id}`);
+    claims = claims || [];
     //assert(store.version !== null);
-    store.name = name;
-    store.claims = claims || [];
+    store.storeInfo = {...store.storeInfo, name, claims};
     //this.storeManifestUrls.set(store.id, this.fileName);
     return ManifestPatch.addStore.call(this, store, tags);
   },

--- a/src/runtime/arc.ts
+++ b/src/runtime/arc.ts
@@ -634,7 +634,7 @@ ${this.activeRecipe.toString()}`;
           const activeStore = await newStore.activate();
           await activeStore.cloneFrom(copiedStore);
           this._tagStore(newStore, this.context.findStoreTags(copiedStoreRef));
-          newStore.name = copiedStore.name && `Copy of ${copiedStore.name}`;
+          newStore.storeInfo.name = copiedStore.name && `Copy of ${copiedStore.name}`;
           const copiedStoreDesc = this.getStoreDescription(copiedStore);
           if (copiedStoreDesc) {
             this.storeDescriptions.set(newStore, copiedStoreDesc);
@@ -728,7 +728,7 @@ ${this.activeRecipe.toString()}`;
       }
       store = await this.storageProviderFactory.construct(id, type, storageKey);
       assert(store, `failed to create store with id [${id}]`);
-      store.name = name;
+      store.storeInfo.name = name;
     }
     await this._registerStore(store, tags);
     return store;
@@ -870,7 +870,7 @@ ${this.activeRecipe.toString()}`;
     const results: string[] = [];
     const stores = [...this.storesById.values()].sort(compareComparables);
     stores.forEach(store => {
-      results.push(store.toString([...this.storeTags.get(store)]));
+      results.push(store.toManifestString([...this.storeTags.get(store)]));
     });
 
     // TODO: include stores entities

--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -244,8 +244,7 @@ export class Manifest {
       if (typeof storageKey === 'string') {
         storageKey = StorageKeyParser.parse(storageKey);
       }
-      // TODO: Need to handle all of the additional options (claims, source,
-      // description, etc.)
+      // TODO: Need to handle additional options: version, model.
       store = new Store({...opts, storageKey, exists: Exists.ShouldCreate});
     } else {
       if (opts.storageKey instanceof StorageKey) {

--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -1322,7 +1322,7 @@ ${e.message}
 
     const stores = [...this.stores].sort(compareComparables);
     stores.forEach(store => {
-      results.push(store.toString(this.storeTags.get(store).map(a => `#${a}`)));
+      results.push(store.toManifestString(this.storeTags.get(store).map(a => `#${a}`)));
     });
 
     return results.join('\n');

--- a/src/runtime/storage-stub.ts
+++ b/src/runtime/storage-stub.ts
@@ -21,20 +21,19 @@ import {ProxyCallback} from './storageNG/store.js';
 export class StorageStub extends UnifiedStore {
   protected unifiedStoreType: 'StorageStub' = 'StorageStub';
 
-  constructor(public readonly type: Type,
-              public readonly id: string,
-              public readonly name: string,
+  constructor(type: Type,
+              id: string,
+              name: string,
               public readonly storageKey: string,
               public readonly storageProviderFactory: StorageProviderFactory,
-              public readonly originalId: string,
-                /** Trust tags claimed by this data store. */
-              public readonly claims: ClaimIsTag[],
-              public readonly description: string,
+              originalId: string,
+              claims: ClaimIsTag[],
+              description: string,
               public readonly version?: number,
-              public readonly source?: string,
+              source?: string,
               public referenceMode: boolean = false,
               public readonly model?: {}[]) {
-    super();
+    super({type, id, name, originalId, claims, description, source});
   }
 
   // No-op implementations for `on` and `off`.
@@ -65,10 +64,7 @@ export class StorageStub extends UnifiedStore {
       this.referenceMode = store.referenceMode;
     }
 
-    store.originalId = this.originalId;
-    store.name = this.name;
-    store.source = this.source;
-    store.description = this.description;
+    store.storeInfo = {...this.storeInfo};
     if (this.isBackedByManifest()) {
       await (store as VolatileStorageProvider).fromLiteral({version: this.version, model: this.model});
     }
@@ -81,43 +77,6 @@ export class StorageStub extends UnifiedStore {
 
   isBackedByManifest(): boolean {
     return (this.version !== undefined && !!this.model);
-  }
-
-  toString(handleTags: string[]): string {
-    const results: string[] = [];
-    const handleStr: string[] = [];
-    handleStr.push(`store`);
-    if (this.name) {
-      handleStr.push(`${this.name}`);
-    }
-    handleStr.push(`of ${this.type.toString()}`);
-    if (this.id) {
-      handleStr.push(`'${this.id}'`);
-    }
-    if (this.originalId) {
-      handleStr.push(`!!${this.originalId}`);
-    }
-    if (this.version !== undefined) {
-      handleStr.push(`@${this.version}`);
-    }
-    if (handleTags && handleTags.length) {
-      handleStr.push(`${handleTags.join(' ')}`);
-    }
-    if (this.source) {
-      handleStr.push(`in '${this.source}'`);
-    } else if (this.storageKey) {
-      handleStr.push(`at '${this.storageKey}'`);
-    }
-    // TODO(shans): there's a 'this.source' in StorageProviderBase which is sometimes
-    // serialized here too - could it ever be part of StorageStub?
-    results.push(handleStr.join(' '));
-    if (this.claims.length > 0) {
-      results.push(`  claim is ${this.claims.map(claim => claim.tag).join(' and is ')}`);
-    }
-    if (this.description) {
-      results.push(`  description \`${this.description}\``);
-    }
-    return results.join('\n');
   }
 
   _compareTo(other: UnifiedStore): number {

--- a/src/runtime/storage/storage-provider-base.ts
+++ b/src/runtime/storage/storage-provider-base.ts
@@ -17,7 +17,7 @@ import {Store, BigCollectionStore, CollectionStore, SingletonStore} from '../sto
 import {PropagatedException} from '../arc-exceptions.js';
 import {Dictionary, Consumer} from '../hot.js';
 import {ClaimIsTag} from '../particle-claim.js';
-import {UnifiedStore, UnifiedActiveStore} from '../storageNG/unified-store.js';
+import {UnifiedStore, UnifiedActiveStore, StoreInfo} from '../storageNG/unified-store.js';
 import {ProxyCallback} from '../storageNG/store.js';
 
 // tslint:disable-next-line: no-any
@@ -109,27 +109,18 @@ export abstract class StorageProviderBase extends UnifiedStore implements Store,
   private readonly legacyListeners: Set<Callback> = new Set();
   private nextCallbackId = 0;
   private readonly listeners: Map<number, ProxyCallback<null>> = new Map();
-  private readonly _type: Type;
 
   protected readonly _storageKey: string;
   referenceMode = false;
 
   version: number|null;
-  readonly id: string;
-  originalId: string|null;
-  name: string;
-  source: string|null;
-  description: string;
+  storeInfo: StoreInfo;
 
   protected constructor(type: Type, name: string, id: string, key: string) {
-    super();
+    super({type, name, id});
     assert(id, 'id must be provided when constructing StorageProviders');
     assert(!type.hasUnresolvedVariable, 'Storage types must be concrete');
-    this._type = type;
-    this.name = name;
     this.version = 0;
-    this.id = id;
-    this.source = null;
     this._storageKey = key;
   }
 
@@ -146,10 +137,6 @@ export abstract class StorageProviderBase extends UnifiedStore implements Store,
 
   get storageKey(): string {
     return this._storageKey;
-  }
-
-  get type(): Type {
-    return this._type;
   }
 
   reportExceptionInHost(exception: PropagatedException) {
@@ -201,30 +188,6 @@ export abstract class StorageProviderBase extends UnifiedStore implements Store,
       // have here. Just pass null, what could go wrong!
       await callback(null);
     }
-  }
-
-  toString(handleTags?: string[]): string {
-    const results: string[] = [];
-    const handleStr: string[] = [];
-    handleStr.push(`store`);
-    if (this.name) {
-      handleStr.push(`${this.name}`);
-    }
-    handleStr.push(`of ${this.type.toString()}`);
-    if (this.id) {
-      handleStr.push(`'${this.id}'`);
-    }
-    if (handleTags && handleTags.length) {
-      handleStr.push(`${handleTags.join(' ')}`);
-    }
-    if (this.source) {
-      handleStr.push(`in '${this.source}'`);
-    }
-    results.push(handleStr.join(' '));
-    if (this.description) {
-      results.push(`  description \`${this.description}\``);
-    }
-    return results.join('\n');
   }
 
   get apiChannelMappingId() {

--- a/src/runtime/storageNG/store.ts
+++ b/src/runtime/storageNG/store.ts
@@ -15,7 +15,7 @@ import {StorageKey} from './storage-key.js';
 import {StoreInterface, StorageMode, ActiveStore, ProxyMessageType, ProxyMessage, ProxyCallback, StorageCommunicationEndpoint, StorageCommunicationEndpointProvider, StoreConstructor} from './store-interface.js';
 import {DirectStore} from './direct-store.js';
 import {ReferenceModeStore, ReferenceModeStorageKey} from './reference-mode-store.js';
-import {UnifiedStore} from './unified-store.js';
+import {UnifiedStore, StoreInfo} from './unified-store.js';
 
 export {
   ActiveStore,
@@ -35,18 +35,9 @@ export {
 export class Store<T extends CRDTTypeRecord> extends UnifiedStore implements StoreInterface<T> {
   protected unifiedStoreType: 'Store' = 'Store';
 
-  toString(tags: string[]): string {
-    throw new Error('Method not implemented.');
-  }
-
-  source: string;
-  description: string;
   readonly storageKey: StorageKey;
   exists: Exists;
-  readonly type: Type;
   readonly mode: StorageMode;
-  readonly id: string;
-  readonly name: string;
   readonly version: number = 0; // TODO(shans): Needs to become the version vector, and is also probably only available on activated storage?
   modelConstructor: new () => CRDTModel<T>;
 
@@ -57,14 +48,11 @@ export class Store<T extends CRDTTypeRecord> extends UnifiedStore implements Sto
     [StorageMode.ReferenceMode, ReferenceModeStore as StoreConstructor]
   ]);
 
-  constructor(opts: {storageKey: StorageKey, exists: Exists, type: Type, id: string, name?: string}) {
-    super();
+  constructor(opts: StoreInfo & {storageKey: StorageKey, exists: Exists}) {
+    super(opts);
     this.storageKey = opts.storageKey;
     this.exists = opts.exists;
-    this.type = opts.type;
     this.mode = opts.storageKey instanceof ReferenceModeStorageKey ? StorageMode.ReferenceMode : StorageMode.Direct;
-    this.id = opts.id;
-    this.name = opts.name || '';
   }
 
   async activate(): Promise<ActiveStore<T>> {

--- a/src/runtime/storageNG/unified-store.ts
+++ b/src/runtime/storageNG/unified-store.ts
@@ -90,6 +90,7 @@ export abstract class UnifiedStore implements Comparable<UnifiedStore>, OldStore
     return 0;
   }
 
+  // TODO: Make these tags live inside StoreInfo.
   toManifestString(handleTags: string[]): string {
     const results: string[] = [];
     const handleStr: string[] = [];

--- a/src/runtime/storageNG/unified-store.ts
+++ b/src/runtime/storageNG/unified-store.ts
@@ -11,12 +11,12 @@
 import {Comparable, compareStrings, compareNumbers} from '../recipe/comparable.js';
 import {Type} from '../type.js';
 import {StorageKey} from './storage-key.js';
-import {Consumer} from '../hot.js';
 import {StorageStub} from '../storage-stub.js';
 import {assert} from '../../platform/assert-web.js';
 import {Store as OldStore} from '../store.js';
 import {PropagatedException} from '../arc-exceptions.js';
 import {ProxyCallback} from './store.js';
+import {ClaimIsTag} from '../particle-claim.js';
 
 /**
  * This is a temporary interface used to unify old-style stores (storage/StorageProviderBase) and new-style stores (storageNG/Store).
@@ -37,22 +37,28 @@ export abstract class UnifiedStore implements Comparable<UnifiedStore>, OldStore
   // Tags for all subclasses of UnifiedStore.
   protected abstract unifiedStoreType: 'Store' | 'StorageStub' | 'StorageProviderBase';
 
-  abstract id: string;
-  abstract name: string;
-  abstract type: Type;
-  // TODO: Once the old storage stack is gone, this should only be of type StorageKey.
+  // TODO: Once the old storage stack is gone, this should only be of type
+  // StorageKey, and can be moved into StoreInfo.
   abstract storageKey: string | StorageKey;
   abstract version?: number; // TODO(shans): This needs to be a version vector for new storage.
   abstract referenceMode: boolean;
 
-  abstract toString(tags?: string[]): string; // TODO(shans): This shouldn't be called toString as toString doesn't take arguments.
+  storeInfo: StoreInfo;
+
+  constructor(storeInfo: StoreInfo) {
+    this.storeInfo = storeInfo;
+  }
+
+  // Series of StoreInfo getters to make migration easier.
+  get id() { return this.storeInfo.id; }
+  get name() { return this.storeInfo.name; }
+  get type() { return this.storeInfo.type; }
+  get originalId() { return this.storeInfo.originalId; }
+  get source() { return this.storeInfo.source; }
+  get description() { return this.storeInfo.description; }
+  get claims() { return this.storeInfo.claims; }
 
   abstract activate(): Promise<UnifiedActiveStore>;
-
-  // TODO: These properties/methods do not belong on UnifiedStore. They should
-  // probably go on some other abstraction like UnifiedActiveStore or similar.
-  abstract source?: string;
-  abstract description: string;
 
   /**
    * Hack to cast this UnifiedStore to the old-style class StorageStub.
@@ -83,6 +89,44 @@ export abstract class UnifiedStore implements Comparable<UnifiedStore>, OldStore
     if (cmp !== 0) return cmp;
     return 0;
   }
+
+  toManifestString(handleTags: string[]): string {
+    const results: string[] = [];
+    const handleStr: string[] = [];
+    handleStr.push(`store`);
+    if (this.name) {
+      handleStr.push(`${this.name}`);
+    }
+    handleStr.push(`of ${this.type.toString()}`);
+    if (this.id) {
+      handleStr.push(`'${this.id}'`);
+    }
+    if (this.originalId) {
+      handleStr.push(`!!${this.originalId}`);
+    }
+    if (this.version !== undefined) {
+      handleStr.push(`@${this.version}`);
+    }
+    if (handleTags && handleTags.length) {
+      handleStr.push(`${handleTags.join(' ')}`);
+    }
+    if (this.source) {
+      handleStr.push(`in '${this.source}'`);
+    } else if (this.storageKey) {
+      handleStr.push(`at '${this.storageKey}'`);
+    }
+    // TODO(shans): there's a 'this.source' in StorageProviderBase which is sometimes
+    // serialized here too - could it ever be part of StorageStub?
+    results.push(handleStr.join(' '));
+    if (this.claims.length > 0) {
+      results.push(`  claim is ${this.claims.map(claim => claim.tag).join(' and is ')}`);
+    }
+    if (this.description) {
+      results.push(`  description \`${this.description}\``);
+    }
+    return results.join('\n');
+  }
+
 }
 
 export interface UnifiedActiveStore {
@@ -103,3 +147,16 @@ export interface UnifiedActiveStore {
   on(callback: ProxyCallback<null>): number;
   off(callback: number): void;
 }
+
+/** Assorted properties about a store. */
+export type StoreInfo = {
+  readonly id: string;
+  name?: string;  // TODO: Find a way to make this readonly.
+  readonly type: Type;
+  readonly originalId?: string;
+  readonly source?: string;
+  readonly description?: string;
+
+  /** Trust tags claimed by this data store. */
+  readonly claims?: ClaimIsTag[];
+};

--- a/src/runtime/store.ts
+++ b/src/runtime/store.ts
@@ -19,7 +19,7 @@ import {ModelValue} from './storage/crdt-collection-model.js';
  * without knowing whether you are talking to a storage provider or proxy.
  */
 export interface Store {
-  name: string;
+  readonly name: string;
   readonly id: string;
   readonly type: Type;
   readonly pec?: ParticleExecutionContext;

--- a/src/runtime/tests/manifest-test.ts
+++ b/src/runtime/tests/manifest-test.ts
@@ -1678,8 +1678,8 @@ Expected a verb (e.g. &Verb) or an uppercase identifier (e.g. Foo) but "?" found
       assert.deepEqual(['wishlist'], manifest.storeTags.get(manifest.stores[0]));
     };
     verify(manifest);
-    assert.strictEqual(manifest.stores[0].toString([]),
-                 (await Manifest.parse(manifest.stores[0].toString([]), {loader})).toString());
+    assert.strictEqual(manifest.stores[0].toManifestString([]),
+                 (await Manifest.parse(manifest.stores[0].toManifestString([]), {loader})).toString());
     verify(await Manifest.parse(manifest.toString(), {loader}));
   });
   it('can parse a manifest containing resources', async () => {
@@ -2026,8 +2026,8 @@ resource SomeName
     const [validRecipe] = manifest.recipes;
     assert.isTrue(validRecipe.normalize());
     assert.isTrue(validRecipe.isResolved());
-    assert.strictEqual(manifest.stores[0].toString([]),
-                 (await Manifest.parse(manifest.stores[0].toString([]))).toString());
+    assert.strictEqual(manifest.stores[0].toManifestString([]),
+                 (await Manifest.parse(manifest.stores[0].toManifestString([]))).toString());
   });
 
   it('can process a schema alias', async () => {


### PR DESCRIPTION
Made a few changes to UnifiedStore and its subclasses:

1. StorageStub.toString() became UnifiedStore.toManifestString():
  * toString() shouldn't take arguments, but this one needs to have one
  * StorageProviderBase had a different, unused, implementation of
    toString(). Deleted.
  * Moving it to UnifiedStore means we don't need to duplicate the logic
    over in the new Store class.

2. Added missing properties to UnifiedStore, to make toManifestString()
work. It needed things like claims, originalId, etc.

3. Moved all of the "information about the store" properties into a new
StoreInfo type. This makes it easier to share and copy store properties
around.