### PR TITLE
handleForTest helper methods

### DIFF
--- a/src/runtime/testing/handle-for-test.ts
+++ b/src/runtime/testing/handle-for-test.ts
@@ -1,0 +1,103 @@
+/**
+ * @license
+ * Copyright 2019 Google LLC.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+import {UnifiedStore} from '../storageNG/unified-store.js';
+import {Arc} from '../arc.js';
+import {SingletonHandle, CollectionHandle} from '../storageNG/handle.js';
+import {ActiveStore} from '../storageNG/store.js';
+import {Flags} from '../flags.js';
+import {StorageProxy} from '../storageNG/storage-proxy.js';
+import {handleFor, Singleton, Storable, Collection} from '../handle.js';
+import {Referenceable, CRDTCollectionTypeRecord} from '../crdt/crdt-collection.js';
+import {CRDTTypeRecord} from '../crdt/crdt.js';
+import {CRDTSingletonTypeRecord} from '../crdt/crdt-singleton.js';
+
+/**
+ * Creates a singleton handle for a store for testing purposes. Returns an
+ * appropriate OldHandle/HandleNG type depending on the storage migration flag.
+ */
+// TODO: Can we correctly type the result here?
+// tslint:disable-next-line: no-any
+export async function singletonHandleForTest(arc: Arc, store: UnifiedStore): Promise<SingletonHandle<any>> {
+  if (Flags.useNewStorageStack) {
+    return new SingletonHandle(
+      arc.generateID('test-handle').toString(),
+      await createStorageProxyForTest<CRDTSingletonTypeRecord<Referenceable>>(arc, store),
+      arc.idGeneratorForTesting,
+      /* particle= */ null, // TODO: We don't have a particle here.
+      /* canRead= */ true,
+      /* canWrite= */ true,
+      /* name?= */ null);
+  } else {
+    const handle = handleFor(store, arc.idGeneratorForTesting);
+    if (handle instanceof Singleton) {
+      // tslint:disable-next-line: no-any
+      return handle as unknown as SingletonHandle<any>;
+    } else {
+      throw new Error('Expected Singleton.');
+    }
+  }
+}
+
+/**
+ * Creates a collection handle for a store for testing purposes. Returns an
+ * appropriate OldHandle/HandleNG type depending on the storage migration flag.
+ */
+// TODO: Can we correctly type the result here?
+// tslint:disable-next-line: no-any
+export async function collectionHandleForTest(arc: Arc, store: UnifiedStore): Promise<CollectionHandle<any>> {
+  if (Flags.useNewStorageStack) {
+    return new CollectionHandle(
+      arc.generateID('test-handle').toString(),
+      await createStorageProxyForTest<CRDTCollectionTypeRecord<Referenceable>>(arc, store),
+      arc.idGeneratorForTesting,
+      /* particle= */ null, // TODO: We don't have a particle here.
+      /* canRead= */ true,
+      /* canWrite= */ true,
+      /* name?= */ null);
+  } else {
+    const handle = handleFor(store, arc.idGeneratorForTesting);
+    if (handle instanceof Collection) {
+      return collectionHandleWrapper(handle);
+    } else {
+      throw new Error('Expected Collection.');
+    }
+  }
+}
+
+async function createStorageProxyForTest<T extends CRDTTypeRecord>(arc: Arc, store: UnifiedStore): Promise<StorageProxy<T>> {
+  const activeStore = await store.activate();
+  if (!(activeStore instanceof ActiveStore)) {
+    throw new Error('Expected an ActiveStore.');
+  }
+  return new StorageProxy(arc.generateID('test-proxy').toString(), activeStore, store.type);
+}
+
+/**
+ * Hacky function which converts an old-style singleton handle into the new
+ * style. Most of the properties/methods are the same, but not all. Some of the
+ * methods expect slightly different arguments, so we will cast between the
+ * expected types recklessly.
+ *
+ * Can be deleted after we've migrated to the new storage stack.
+ */
+function collectionHandleWrapper<T extends Referenceable>(oldHandle: Collection): CollectionHandle<T> {
+  const handle = oldHandle as unknown as CollectionHandle<T>;
+
+  handle.add = async (entity: T): Promise<boolean> => {
+    await oldHandle.store(entity as unknown as Storable);
+    return true;
+  };
+
+  handle.addMultiple = async (entities: T[]): Promise<boolean> => {
+    return Promise.all(entities.map(e => handle.add(e))).then(array => array.every(Boolean));
+  };
+
+  return handle;
+}

--- a/src/runtime/tests/particle-api-test.ts
+++ b/src/runtime/tests/particle-api-test.ts
@@ -649,6 +649,7 @@ describe('particle-api', () => {
     await inputsHandle.add(new inputsHandle.entityClass({value: 'hello'}));
     await inputsHandle.add(new inputsHandle.entityClass({value: 'world'}));
     const resultsStore = await arc.createStore(result.type.collectionOf(), undefined, 'test:2');
+    const resultsHandle = await collectionHandleForTest(arc, resultsStore);
     const inspector = new util.ResultInspector(arc, resultsStore, 'value');
     const recipe = arc.context.recipes[0];
     recipe.handles[0].mapToStorage(inputsStore);
@@ -656,10 +657,8 @@ describe('particle-api', () => {
     recipe.normalize();
     await arc.instantiate(recipe);
     await arc.idle;
+    assert.sameMembers((await resultsHandle.toList()).map(item => item.value), ['done', 'done', 'HELLO', 'WORLD']);
     await inspector.verify('done', 'done', 'HELLO', 'WORLD');
-
-    // TODO: how do i listen to inner arc's outStore handle-changes?
-    // await util.assertCollectionWillChangeTo(resultsStore, Result, "value", ["HELLO", "WORLD"]);
 
     const [innerArc] = arc.findInnerArcs(arc.activeRecipe.particles[0]);
     const innerArcStores = innerArc.findStoresByType(result.type);

--- a/src/runtime/tests/particle-api-test.ts
+++ b/src/runtime/tests/particle-api-test.ts
@@ -23,6 +23,7 @@ import {Runtime} from '../runtime.js';
 import {SingletonStore} from '../store.js';
 import {Speculator} from '../../planning/speculator.js';
 import {SingletonStorageProvider, CollectionStorageProvider, BigCollectionStorageProvider} from '../storage/storage-provider-base.js';
+import {collectionHandleForTest} from '../testing/handle-for-test.js';
 
 async function loadFilesIntoNewArc(fileMap: {[index:string]: string, manifest: string}): Promise<Arc> {
   const manifest = await Manifest.parse(fileMap.manifest);
@@ -145,13 +146,14 @@ describe('particle-api', () => {
     });
 
     const result = arc.context.findSchemaByName('Result').entityClass();
-    const resultStore = await arc.createStore(result.type.collectionOf(), undefined, 'result-handle') as CollectionStorageProvider;
+    const resultStore = await arc.createStore(result.type.collectionOf(), undefined, 'result-handle');
+    const resultHandle = await collectionHandleForTest(arc, resultStore);
     const recipe = arc.context.recipes[0];
     recipe.normalize();
     await arc.instantiate(recipe);
     await arc.idle;
-    const values = (await resultStore.toList()).map(item => item.rawData.value);
-    assert.deepEqual(values, ['two']);
+    const values = await resultHandle.toList();
+    assert.deepEqual(values, [{value: 'two'}]);
   });
 
   it('contains a constructInnerArc call', async () => {
@@ -642,9 +644,10 @@ describe('particle-api', () => {
     });
 
     const result = arc.context.findSchemaByName('Result').entityClass();
-    const inputsStore = await arc.createStore(result.type.collectionOf(), undefined, 'test:1') as CollectionStorageProvider;
-    await inputsStore.store({id: '1', rawData: {value: 'hello'}}, ['key1']);
-    await inputsStore.store({id: '2', rawData: {value: 'world'}}, ['key2']);
+    const inputsStore = await arc.createStore(result.type.collectionOf(), undefined, 'test:1');
+    const inputsHandle = await collectionHandleForTest(arc, inputsStore);
+    await inputsHandle.add(new inputsHandle.entityClass({value: 'hello'}));
+    await inputsHandle.add(new inputsHandle.entityClass({value: 'world'}));
     const resultsStore = await arc.createStore(result.type.collectionOf(), undefined, 'test:2');
     const inspector = new util.ResultInspector(arc, resultsStore, 'value');
     const recipe = arc.context.recipes[0];


### PR DESCRIPTION
These new helper methods creates handles of the given type
(singleton/collection), and use Flags.useNewStorageStack to decide which
handle class to use.

I've migrated two unit tests to use the new helper methods so you can
see how they are used in practice. There's lots more tests that need to
be migrated...