### PR TITLE
change default web-shell storage to volatile

### DIFF
--- a/shells/configuration/constants.js
+++ b/shells/configuration/constants.js
@@ -20,7 +20,7 @@ export const Const = {
     firebaseStorageKey: firebase,
     pouchdbStorageKey: pouchdb,
     volatileStorageKey: volatile,
-    storageKey: pouchdb, //firebase,
+    storageKey: volatile, //pouchdb, //firebase,
     plannerStorageKey: 'volatile',
     manifest: `https://$particles/canonical.arcs`,
     launcherId: 'arc-launcher'


### PR DESCRIPTION
There are pouch specific bugs that occur, for example: "select favorite food" recipe - select some foods, then try to unselect - there is a warning in the log, and the store isn't updated any more ever
