### PR TITLE
Introduce Arcs Runtime Settings

### DIFF
--- a/javaharness/java/arcs/android/impl/AndroidHarnessController.java
+++ b/javaharness/java/arcs/android/impl/AndroidHarnessController.java
@@ -8,22 +8,31 @@ import android.webkit.WebViewClient;
 import arcs.api.ArcsEnvironment;
 import arcs.api.DeviceClient;
 import arcs.api.HarnessController;
+import arcs.api.RuntimeSettings;
+import java.util.logging.Logger;
 import javax.inject.Inject;
+import javax.inject.Provider;
 
 public class AndroidHarnessController implements HarnessController {
+  private static final Logger logger =
+      Logger.getLogger(AndroidHarnessController.class.getName());
 
   private ArcsEnvironment environment;
   private DeviceClient deviceClient;
   private WebView webView;
+  // Fetches the up-to-date properties on every get().
+  private Provider<RuntimeSettings> runtimeSettings;
 
   @Inject
   AndroidHarnessController(
       ArcsEnvironment environment,
       DeviceClient deviceClient,
-      WebView webView) {
+      WebView webView,
+      Provider<RuntimeSettings> runtimeSettings) {
     this.environment = environment;
     this.deviceClient = deviceClient;
     this.webView = webView;
+    this.runtimeSettings = runtimeSettings;
   }
 
   @Override
@@ -52,15 +61,21 @@ public class AndroidHarnessController implements HarnessController {
         return super.shouldInterceptRequest(view, request);
       }
     });
-    webView.loadUrl("file:///android_asset/index.html?log");
 
-    // TODO: add a boolean flag to controll these.
+    RuntimeSettings settings = runtimeSettings.get();
 
-    // Uncomment this to view Arcs in devtools extension:
-    // webView.loadUrl("file:///android_asset/index.html?explore-proxy");
-    // Uncomment this to load pipes-shell from localhost and to view Arcs in devtools extension:
-    // webView.loadUrl("http://localhost:8786/shells/pipes-shell/web/deploy/dist/?log=2&explore-proxy");
-    // Also add to <application> in service/AndroidManifest.xml:
+    // If using any of the host shells, i.e. pipe-shells at the host:
+    // http://localhost:8786/shells/pipes-shell/web/deploy/dist/?
+    // adding the following attribute to allow HTTP connection(s) at
+    // <application> in service/AndroidManifest.xml:
     //    android:usesCleartextTraffic="true"
+    String url = settings.shellUrl();
+    url += "log=" + settings.logLevel();
+    if (settings.useDevServerProxy()) {
+      url += "&explore-proxy";
+    }
+
+    logger.info("runtime url: " + url);
+    webView.loadUrl(url);
   }
 }

--- a/javaharness/java/arcs/android/impl/AndroidHarnessModule.java
+++ b/javaharness/java/arcs/android/impl/AndroidHarnessModule.java
@@ -4,6 +4,7 @@ import arcs.api.Arcs;
 import arcs.api.ArcsEnvironment;
 import arcs.api.DeviceClient;
 import arcs.api.HarnessController;
+import arcs.api.RuntimeSettings;
 import arcs.api.ShellApi;
 import arcs.api.ShellApiBasedArcsEnvironment;
 import dagger.Binds;
@@ -32,4 +33,7 @@ public abstract class AndroidHarnessModule {
 
   @Binds
   public abstract HarnessController providesHarnessController(AndroidHarnessController impl);
+
+  @Binds
+  public abstract RuntimeSettings providesRuntimeSettings(RuntimeSettingsAndroidJsImpl impl);
 }

--- a/javaharness/java/arcs/android/impl/BUILD
+++ b/javaharness/java/arcs/android/impl/BUILD
@@ -18,6 +18,7 @@ android_library(
     manifest = "AndroidManifest.xml",
     deps = [
         "//javaharness/java/arcs/api:api-android",
+        "@com_google_auto_value",
         "@com_google_dagger",
         "@flogger//jar",
         "@flogger_system_backend//jar",

--- a/javaharness/java/arcs/android/impl/RuntimeSettingsAndroidJsImpl.java
+++ b/javaharness/java/arcs/android/impl/RuntimeSettingsAndroidJsImpl.java
@@ -1,0 +1,112 @@
+package arcs.android.impl;
+
+import arcs.api.RuntimeSettings;
+import com.google.auto.value.AutoValue;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.logging.Logger;
+import javax.inject.Inject;
+
+/** For Javascript-based Arcs runtime. */
+public final class RuntimeSettingsAndroidJsImpl implements RuntimeSettings {
+  // Equivalent to &log parameter
+  private static final String LOG_LEVEL_PROPERTY = "debug.arcs.runtime.log";
+  // Equivalent to &explore-proxy parameter
+  private static final String USE_DEV_SERVER_PROXY_PROPERTY = "debug.arcs.runtime.use_alds";
+  // The target shell to be loaded (on-device) or be connected (on-host)
+  private static final String SHELL_URL_PROPERTY = "debug.arcs.runtime.shell_url";
+
+  // Default settings:
+  // Logs the most information, loads the on-device pipes-shell
+  // and connects to Arcs Local Development Server (ALDS)
+  private static final int DEFAULT_LOG_LEVEL = 2;
+  private static final boolean DEFAULT_USE_DEV_SERVER = true;
+  private static final String DEFAULT_SHELL_URL = "file:///android_asset/index.html?";
+
+  private static final Logger logger = Logger.getLogger(
+      RuntimeSettingsAndroidJsImpl.class.getName());
+
+  @AutoValue
+  abstract static class Settings {
+    abstract int logLevel();
+    abstract boolean useDevServerProxy();
+    abstract String shellUrl();
+
+    static Builder builder() {
+      return new AutoValue_RuntimeSettingsAndroidJsImpl_Settings.Builder();
+    }
+
+    @AutoValue.Builder
+    abstract static class Builder {
+      abstract Builder setLogLevel(int level);
+      abstract Builder setUseDevServerProxy(boolean useDevServerProxy);
+      abstract Builder setShellUrl(String shellUrl);
+      abstract Settings build();
+    }
+  }
+
+  // Immutable configurations for this runtime settings instance.
+  private final Settings settings;
+
+  @Inject
+  public RuntimeSettingsAndroidJsImpl() {
+    settings = Settings.builder()
+        .setLogLevel(
+            getProperty(LOG_LEVEL_PROPERTY, Integer::valueOf, DEFAULT_LOG_LEVEL))
+        .setUseDevServerProxy(
+            getProperty(USE_DEV_SERVER_PROXY_PROPERTY, Boolean::valueOf, DEFAULT_USE_DEV_SERVER))
+        .setShellUrl(
+            getProperty(SHELL_URL_PROPERTY, String::valueOf, DEFAULT_SHELL_URL))
+        .build();
+  }
+
+  @Override
+  public int logLevel() {
+    return settings.logLevel();
+  }
+
+  @Override
+  public boolean useDevServerProxy() {
+    return settings.useDevServerProxy();
+  }
+
+  @Override
+  public String shellUrl() {
+    return settings.shellUrl();
+  }
+
+  /**
+   * This API reads the specified <var>property</var>, converts the content to
+   * the type of <var>T</var> via the <var>converter</var>, then returns the
+   * result.
+   *
+   * If the result cannot be resolved i.e. thrown exception, the <var>defaultValue</var>
+   * is returned instead.
+   *
+   * @param property Android property name to read.
+   * @param converter Converts the type of property content from String to T.
+   * @param defaultValue The returned data when either the property does not exist
+   *                     or it's in ill format.
+   * @param <T> The expected type of returned data.
+   * @return the resolved content of property in type T.
+   */
+  private <T> T getProperty(String property, Function<String, T> converter, T defaultValue) {
+    try {
+      // Property-read is granted at the public domain of selinux policies.
+      Process process = Runtime.getRuntime().exec("getprop " + property);
+      BufferedReader input = new BufferedReader(new InputStreamReader(process.getInputStream()));
+      Optional<String> propertyValue = Optional.ofNullable(input.readLine());
+      input.close();
+      // The specified property does not exist.
+      if (propertyValue.isPresent() && propertyValue.get().isEmpty()) {
+        propertyValue = Optional.ofNullable(null);
+      }
+      return propertyValue.map(converter).orElse(defaultValue);
+    } catch (Exception e) {
+      logger.warning("illegal value of " + property);
+    }
+    return defaultValue;
+  }
+}

--- a/javaharness/java/arcs/api/RuntimeSettings.java
+++ b/javaharness/java/arcs/api/RuntimeSettings.java
@@ -1,0 +1,23 @@
+package arcs.api;
+
+/** The configurations of Arcs runtime. */
+public interface RuntimeSettings {
+  // Used by Javascript-based and/or other types of Arcs runtime(s).
+  // Equivalent to the &log=<level> parameter at JS Arcs runtime.
+  default int logLevel() {
+    return 0;
+  }
+
+  // Used mainly by Javascript-based Arcs runtime to establish WebSocket
+  // connection to the host from the device during runtime initialization.
+  // Equivalent to the &explore-proxy parameter at JS Arcs runtime.
+  default boolean useDevServerProxy() {
+    return false;
+  }
+
+  // Used only by Javascript-based Arcs runtime to specify which shell
+  // either on-device or on-host to connect with.
+  default String shellUrl() {
+    return "";
+  }
+}


### PR DESCRIPTION
Aim to free developers from rebuilding app while tweaking settings,
i.e. switch shell, use Arcs Local Development Server, change logging level, etc.

For Javascript-based Arcs runtime, the settings can be changed
dynamically via android properties as:
"debug.arcs.runtime.log": logging level (default: 2)
"debug.arcs.runtime.use_alds": use ALDS devServer (default: true)
"debug.arcs.runtime.shell_url": the target shell url (default: file:///android_asset/index.html?)