### PR TITLE
Notify ALDS upon app disconnection

### DIFF
--- a/javaharness/java/arcs/android/impl/AndroidHarnessController.java
+++ b/javaharness/java/arcs/android/impl/AndroidHarnessController.java
@@ -34,6 +34,14 @@ public class AndroidHarnessController implements HarnessController {
     }
   }
 
+  @Override
+  public void deInit() {
+    if (webView != null) {
+      // Clean up content/context thus the host devServer can be aware of the disconnection.
+      webView.loadUrl("about:blank");
+    }
+  }
+
   private void setWebViewSettings() {
     WebSettings arcsSettings = webView.getSettings();
     arcsSettings.setDatabaseEnabled(true);

--- a/javaharness/java/arcs/android/service/ArcsService.java
+++ b/javaharness/java/arcs/android/service/ArcsService.java
@@ -81,6 +81,7 @@ public class ArcsService extends IntentService {
   @Override
   public void onDestroy() {
     Log.d(TAG, "onDestroy()");
+    harnessController.deInit();
     super.onDestroy();
   }
 

--- a/javaharness/java/arcs/api/HarnessController.java
+++ b/javaharness/java/arcs/api/HarnessController.java
@@ -2,4 +2,5 @@ package arcs.api;
 
 public interface HarnessController {
   void init();
+  default void deInit() {};
 }


### PR DESCRIPTION
Currently the disconnection can be awared by ALDS only when the app
is killed. The in-app disconnection would only unbind and destroy
the Arcs service implies the web content/context is still breathing
there. The stale web content/context needs to be cleaned up bundled
with the service death.