### PR TITLE
Fix invisible pec-log

### DIFF
--- a/devtools/src/arcs-pec-log.js
+++ b/devtools/src/arcs-pec-log.js
@@ -145,6 +145,11 @@ class ArcsPecLog extends MessengerMixin(PolymerElement) {
 
   static get properties() {
     return {
+      active: {
+        type: Boolean,
+        observer: '_onActiveChanged',
+        reflectToAttribute: true
+      },
       searchParams: {
         type: Object,
         observer: '_onSearchChanged'
@@ -325,6 +330,13 @@ class ArcsPecLog extends MessengerMixin(PolymerElement) {
     }
 
     event.stopPropagation();
+  }
+
+  _onActiveChanged(active) {
+    if (active) {
+      // Iron-list needs to be notified that the panel got shown, so that it draws itself.
+      this.$.list.fire('iron-resize');
+    }
   }
 }
 


### PR DESCRIPTION
The issue got introduce with golden-layout - the library which allows dragging panels around.

As initially the element holding the list is 0x0, we need to tell the list to resize itself when the panel becomes active. Somehow the list doesn't catch it itself.