### PR TITLE
Migrate more unit tests to handleForTest methods

### DIFF
--- a/src/runtime/entity.ts
+++ b/src/runtime/entity.ts
@@ -286,6 +286,7 @@ export abstract class Entity implements Storable {
 
   static identify(entity: Entity, identifier: string) {
     getInternals(entity).identify(identifier);
+    return entity;
   }
 
   static createIdentity(entity: Entity, parentId: Id, idGenerator: IdGenerator) {

--- a/src/runtime/testing/handle-for-test.ts
+++ b/src/runtime/testing/handle-for-test.ts
@@ -17,6 +17,7 @@ import {handleFor, Singleton, Storable, Collection} from '../handle.js';
 import {Referenceable, CRDTCollectionTypeRecord} from '../crdt/crdt-collection.js';
 import {CRDTTypeRecord} from '../crdt/crdt.js';
 import {CRDTSingletonTypeRecord} from '../crdt/crdt-singleton.js';
+import {Manifest} from '../manifest.js';
 
 /**
  * Creates a singleton handle for a store for testing purposes. Returns an
@@ -24,18 +25,18 @@ import {CRDTSingletonTypeRecord} from '../crdt/crdt-singleton.js';
  */
 // TODO: Can we correctly type the result here?
 // tslint:disable-next-line: no-any
-export async function singletonHandleForTest(arc: Arc, store: UnifiedStore): Promise<SingletonHandle<any>> {
+export async function singletonHandleForTest(arcOrManifest: Arc | Manifest, store: UnifiedStore): Promise<SingletonHandle<any>> {
   if (Flags.useNewStorageStack) {
     return new SingletonHandle(
-      arc.generateID('test-handle').toString(),
-      await createStorageProxyForTest<CRDTSingletonTypeRecord<Referenceable>>(arc, store),
-      arc.idGeneratorForTesting,
+      arcOrManifest.generateID('test-handle').toString(),
+      await createStorageProxyForTest<CRDTSingletonTypeRecord<Referenceable>>(arcOrManifest, store),
+      arcOrManifest.idGeneratorForTesting,
       /* particle= */ null, // TODO: We don't have a particle here.
       /* canRead= */ true,
       /* canWrite= */ true,
       /* name?= */ null);
   } else {
-    const handle = handleFor(store, arc.idGeneratorForTesting);
+    const handle = handleFor(store, arcOrManifest.idGeneratorForTesting);
     if (handle instanceof Singleton) {
       // tslint:disable-next-line: no-any
       return handle as unknown as SingletonHandle<any>;
@@ -51,18 +52,18 @@ export async function singletonHandleForTest(arc: Arc, store: UnifiedStore): Pro
  */
 // TODO: Can we correctly type the result here?
 // tslint:disable-next-line: no-any
-export async function collectionHandleForTest(arc: Arc, store: UnifiedStore): Promise<CollectionHandle<any>> {
+export async function collectionHandleForTest(arcOrManifest: Arc | Manifest, store: UnifiedStore): Promise<CollectionHandle<any>> {
   if (Flags.useNewStorageStack) {
     return new CollectionHandle(
-      arc.generateID('test-handle').toString(),
-      await createStorageProxyForTest<CRDTCollectionTypeRecord<Referenceable>>(arc, store),
-      arc.idGeneratorForTesting,
+      arcOrManifest.generateID('test-handle').toString(),
+      await createStorageProxyForTest<CRDTCollectionTypeRecord<Referenceable>>(arcOrManifest, store),
+      arcOrManifest.idGeneratorForTesting,
       /* particle= */ null, // TODO: We don't have a particle here.
       /* canRead= */ true,
       /* canWrite= */ true,
       /* name?= */ null);
   } else {
-    const handle = handleFor(store, arc.idGeneratorForTesting);
+    const handle = handleFor(store, arcOrManifest.idGeneratorForTesting);
     if (handle instanceof Collection) {
       return collectionHandleWrapper(handle);
     } else {
@@ -71,12 +72,13 @@ export async function collectionHandleForTest(arc: Arc, store: UnifiedStore): Pr
   }
 }
 
-async function createStorageProxyForTest<T extends CRDTTypeRecord>(arc: Arc, store: UnifiedStore): Promise<StorageProxy<T>> {
+async function createStorageProxyForTest<T extends CRDTTypeRecord>(
+    arcOrManifest: Arc | Manifest, store: UnifiedStore): Promise<StorageProxy<T>> {
   const activeStore = await store.activate();
   if (!(activeStore instanceof ActiveStore)) {
     throw new Error('Expected an ActiveStore.');
   }
-  return new StorageProxy(arc.generateID('test-proxy').toString(), activeStore, store.type);
+  return new StorageProxy(arcOrManifest.generateID('test-proxy').toString(), activeStore, store.type);
 }
 
 /**

--- a/src/runtime/tests/data-layer-test.ts
+++ b/src/runtime/tests/data-layer-test.ts
@@ -13,10 +13,10 @@ import {Arc} from '../arc.js';
 import {handleFor, Collection} from '../handle.js';
 import {Loader} from '../loader.js';
 import {Schema} from '../schema.js';
-import {CollectionStorageProvider} from '../storage/storage-provider-base.js';
 import {FakeSlotComposer} from '../testing/fake-slot-composer.js';
 import {EntityType} from '../type.js';
 import {ArcId, IdGenerator} from '../id.js';
+import {collectionHandleForTest} from '../testing/handle-for-test.js';
 
 describe('entity', () => {
   it('can be created, stored, and restored', async () => {
@@ -32,11 +32,11 @@ describe('entity', () => {
     const handle = handleFor(storage, IdGenerator.newSession()) as Collection;
     await handle.store(entity);
 
-    const collection = arc.findStoresByType(collectionType)[0] as CollectionStorageProvider;
+    const collection = await collectionHandleForTest(arc, arc.findStoresByType(collectionType)[0]);
     const list = await collection.toList();
     const clone = list[0];
     assert.isDefined(clone);
-    assert.deepEqual(clone.rawData, {value: 'hello world'});
+    assert.deepEqual(clone, {value: 'hello world'});
 
     // TODO(https://github.com/PolymerLabs/arcs/pull/2916#discussion_r277793505)
     // Test that clone/entity are not deeply equal.  Revisit once we

--- a/src/runtime/tests/multiplexer-test.ts
+++ b/src/runtime/tests/multiplexer-test.ts
@@ -10,12 +10,12 @@
 
 import {assert} from '../../platform/chai-web.js';
 import {Arc} from '../arc.js';
-import {Id, ArcId} from '../id.js';
+import {ArcId} from '../id.js';
 import {Loader} from '../loader.js';
 import {Manifest} from '../manifest.js';
 import {checkDefined} from '../testing/preconditions.js';
-import {CollectionStorageProvider} from '../storage/storage-provider-base.js';
 import {FakeSlotComposer} from '../testing/fake-slot-composer.js';
+import {collectionHandleForTest} from '../testing/handle-for-test.js';
 
 describe('Multiplexer', () => {
   it('Processes multiple inputs', async () => {
@@ -48,7 +48,8 @@ describe('Multiplexer', () => {
     };
 
     const arc = new Arc({id: ArcId.newForTest('test'), context: manifest, slotComposer, loader: new Loader()});
-    const barStore = await arc.createStore(barType.collectionOf(), null, 'test:1') as CollectionStorageProvider;
+    const barStore = await arc.createStore(barType.collectionOf(), null, 'test:1');
+    const barHandle = await collectionHandleForTest(arc, barStore);
     recipe.handles[0].mapToStorage(barStore);
     assert(recipe.normalize(), 'normalize');
     assert(recipe.isResolved());
@@ -57,9 +58,9 @@ describe('Multiplexer', () => {
 
     await arc.idle;
 
-    await barStore.store({id: 'a', rawData: {value: 'one'}}, ['key1']);
-    await barStore.store({id: 'b', rawData: {value: 'two'}}, ['key2']);
-    await barStore.store({id: 'c', rawData: {value: 'three'}}, ['key3']);
+    await barHandle.add(new barHandle.entityClass({value: 'one'}));
+    await barHandle.add(new barHandle.entityClass({value: 'two'}));
+    await barHandle.add(new barHandle.entityClass({value: 'three'}));
 
     await arc.idle;
 
@@ -96,7 +97,8 @@ describe('Multiplexer', () => {
     };
 
     const arc = new Arc({id: ArcId.newForTest('test'), context: manifest, slotComposer, loader: new Loader()});
-    const barStore = await arc.createStore(barType.collectionOf(), null, 'test:1') as CollectionStorageProvider;
+    const barStore = await arc.createStore(barType.collectionOf(), null, 'test:1');
+    const barHandle = await collectionHandleForTest(arc, barStore);
     recipe.handles[0].mapToStorage(barStore);
     const options = {errors: new Map()};
     const n = recipe.normalize(options);
@@ -108,9 +110,9 @@ describe('Multiplexer', () => {
 
     await arc.idle;
 
-    await barStore.store({id: 'a', rawData: {value: 'one'}}, ['key1']);
-    await barStore.store({id: 'b', rawData: {value: 'two'}}, ['key2']);
-    await barStore.store({id: 'c', rawData: {value: 'three'}}, ['key3']);
+    await barHandle.add(new barHandle.entityClass({value: 'one'}));
+    await barHandle.add(new barHandle.entityClass({value: 'two'}));
+    await barHandle.add(new barHandle.entityClass({value: 'three'}));
 
     await arc.idle;
 

--- a/src/tests/multiplexer-integration-test.ts
+++ b/src/tests/multiplexer-integration-test.ts
@@ -9,14 +9,12 @@
  */
 
 import {assert} from '../platform/chai-web.js';
-import {Arc} from '../runtime/arc.js';
-import {Loader} from '../runtime/loader.js';
 import {HostedSlotContext} from '../runtime/slot-context.js';
 import {HeadlessSlotDomConsumer} from '../runtime/headless-slot-dom-consumer.js';
-import {CollectionStorageProvider} from '../runtime/storage/storage-provider-base.js';
-import {FakeSlotComposer} from '../runtime/testing/fake-slot-composer.js';
 import {checkDefined} from '../runtime/testing/preconditions.js';
 import {PlanningTestHelper} from '../planning/testing/arcs-planning-testing.js';
+import {collectionHandleForTest} from '../runtime/testing/handle-for-test.js';
+import {Entity} from '../runtime/entity.js';
 
 describe('Multiplexer', () => {
   it('renders polymorphic multiplexed slots', async () => {
@@ -77,8 +75,9 @@ describe('Multiplexer', () => {
         .expectRenderSlot('PostMuxer', 'item', {contentTypes: ['templateName', 'model']})
         .expectRenderSlot('ShowOne', 'item', {contentTypes: ['templateName', 'model']})
         .expectRenderSlot('PostMuxer', 'item', {contentTypes: ['templateName', 'model']});
-    const postsStore = helper.arc.findStoreById(helper.arc.activeRecipe.handles[0].id) as CollectionStorageProvider;
-    await postsStore.store({id: '4', rawData: {message: 'w', renderRecipe: recipeOne, renderParticleSpec: showOneSpec}}, ['key1']);
+    const postsStore = await collectionHandleForTest(helper.arc, helper.arc.findStoreById(helper.arc.activeRecipe.handles[0].id));
+    await postsStore.add(
+        Entity.identify(new postsStore.entityClass({message: 'w', renderRecipe: recipeOne, renderParticleSpec: showOneSpec}), '4'));
     await helper.idle();
     assert.lengthOf(helper.slotComposer.contexts.filter(ctx => ctx instanceof HostedSlotContext), 4);
     assert.lengthOf(helper.slotComposer.consumers, 6);


### PR DESCRIPTION
Still a few more references to CollectionStorageProvider in unit tests that need to be migrated. These were the next lowest-hanging fruit.