### PR TITLE
Fix slandles

### DIFF
--- a/shells/lib/xen-renderer.js
+++ b/shells/lib/xen-renderer.js
@@ -137,7 +137,7 @@ export const SlotObserver = class {
           // slotId's are unique in the tree
           deepQuerySelector(root, slotId(containerSlotId))
           // use `containerSlotName` to catch root slots (not deep!)
-          || root.querySelector(slotId(containerSlotName))
+          || containerSlotName && root.querySelector(slotId(containerSlotName))
           || root.querySelector(`#${queryId(containerSlotId)}`)
           ;
       }

--- a/src/runtime/recipe/handle-connection.ts
+++ b/src/runtime/recipe/handle-connection.ts
@@ -146,6 +146,7 @@ export class HandleConnection implements Comparable<HandleConnection> {
     const slandle: SlotConnection = new SlotConnection(this.name, this.particle);
     slandle.tags = this.tags;
     slandle.targetSlot = this.handle && this.handle.toSlot();
+    slandle.targetSlot.name = slandle.targetSlot.name || this.name;
     if (this.spec) {
       this.spec.dependentConnections.forEach(connSpec => {
         const conn = this.particle.getConnectionByName(connSpec.name);

--- a/src/runtime/ui-slot-composer.ts
+++ b/src/runtime/ui-slot-composer.ts
@@ -256,7 +256,7 @@ export class UiSlotComposer {
     const observer = this['slotObserver'];
     if (observer && content) {
       // we scan connections for container and slotMap
-      const connections = particle.getSlotConnections();
+      const connections = particle.getSlandleConnections();
       // assemble a renderPacket to send to slot observer
       const packet = {};
       // identify parent container


### PR DESCRIPTION
Small changes that fix the tutorials for Slandles after recent breakages due to updates to the runtime.

Note: I believe these don't break the current functionality and just unbreak slandles.