### PR TITLE
ALDS should be off by default for the demo app

### DIFF
--- a/javaharness/java/arcs/android/impl/RuntimeSettingsAndroidJsImpl.java
+++ b/javaharness/java/arcs/android/impl/RuntimeSettingsAndroidJsImpl.java
@@ -20,9 +20,9 @@ public final class RuntimeSettingsAndroidJsImpl implements RuntimeSettings {
 
   // Default settings:
   // Logs the most information, loads the on-device pipes-shell
-  // and connects to Arcs Local Development Server (ALDS)
+  // and not uses ALDS proxy.
   private static final int DEFAULT_LOG_LEVEL = 2;
-  private static final boolean DEFAULT_USE_DEV_SERVER = true;
+  private static final boolean DEFAULT_USE_DEV_SERVER = false;
   private static final String DEFAULT_SHELL_URL = "file:///android_asset/index.html?";
 
   private static final Logger logger = Logger.getLogger(


### PR DESCRIPTION
With default on, the demo app would wait until the Arcs Explorer
at the host connects to the ALDS since the Arcs runtime at the
device blocks waiting for the ready signal of the Arcs Explorer
at its initialization path by design of explore-proxy parameter.

The android property "debug.arcs.runtime.use_alds" has been ready
in place to switch the ALDS proxy dynamically, so we can deem
ALDS on/off as an option as of now.