### PR TITLE
Decouples AutoValue deps from J2CL libs

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -155,3 +155,17 @@ http_archive(
     strip_prefix = "rules_android-0.1.1",
     urls = ["https://github.com/bazelbuild/rules_android/archive/v0.1.1.zip"],
 )
+
+AUTO_VALUE_VERSION = "1.7"
+
+maven_jar(
+    name = "autovalue",
+    artifact = "com.google.auto.value:auto-value:" + AUTO_VALUE_VERSION,
+    sha1 = "fe8387764ed19460eda4f106849c664f51c07121",
+)
+
+maven_jar(
+    name = "autovalue_annotations",
+    artifact = "com.google.auto.value:auto-value-annotations:" + AUTO_VALUE_VERSION,
+    sha1 = "5be124948ebdc7807df68207f35a0f23ce427f29",
+)

--- a/javaharness/BUILD
+++ b/javaharness/BUILD
@@ -1,3 +1,15 @@
 package(default_visibility = ["//visibility:public"])
 
+# Standalone deps of Java libraries and plugins
+java_plugin(
+    name = "autovalue_plugin",
+    processor_class = "com.google.auto.value.processor.AutoValueProcessor",
+    deps = ["@autovalue//jar"],
+)
 
+java_library(
+    name = "autovalue",
+    exported_plugins = [":autovalue_plugin"],
+    neverlink = 1,  # Only used at compilation rather than at run-time.
+    exports = ["@autovalue_annotations//jar"],
+)

--- a/javaharness/java/arcs/android/impl/BUILD
+++ b/javaharness/java/arcs/android/impl/BUILD
@@ -17,8 +17,8 @@ android_library(
     javacopts = ["-Xep:AndroidJdkLibsChecker:OFF"],
     manifest = "AndroidManifest.xml",
     deps = [
+        "//javaharness:autovalue",
         "//javaharness/java/arcs/api:api-android",
-        "@com_google_auto_value",
         "@com_google_dagger",
         "@flogger//jar",
         "@flogger_system_backend//jar",


### PR DESCRIPTION
Needs standalone build rules of AutoValue libraries and plugins
for eaiser ports and clearer deps.

Use "//javaharness:autovalue" for all AutoValue annotations.