### PR TITLE
Create unifiedHandleFor function

### DIFF
--- a/src/runtime/handle.ts
+++ b/src/runtime/handle.ts
@@ -19,8 +19,9 @@ import {EntityClass, Entity} from './entity.js';
 import {Store, SingletonStore, CollectionStore, BigCollectionStore} from './store.js';
 import {IdGenerator, Id} from './id.js';
 import {SYMBOL_INTERNALS} from './symbols.js';
-import {Handle as HandleNG} from './storageNG/handle.js';
+import {Handle as HandleNG, handleNGFor} from './storageNG/handle.js';
 import {CRDTTypeRecord} from './crdt/crdt.js';
+import {StorageProxy as StorageProxyNG} from './storageNG/storage-proxy.js';
 
 // While transitioning to the NG storage stack, we define Handle as either the
 // "old" handle (before migration) or the NG handle. After migration the handle
@@ -509,4 +510,34 @@ export function handleFor(storage: Store, idGenerator: IdGenerator, name: string
     handle.entityClass = schema.entityClass(storage.pec);
   }
   return handle;
+}
+
+/** Creates either a new- or old-style Handle for the given storage proxy. */
+export function unifiedHandleFor(opts: {
+    proxy: Store|StorageProxyNG<CRDTTypeRecord>,
+    idGenerator: IdGenerator,
+    name?: string,
+    particleId?: string,
+    particle?: Particle,
+    canRead?: boolean,
+    canWrite?: boolean}) {
+  const defaultOpts = {particleId: '', canRead: true, canWrite: true};
+  opts = {...defaultOpts, ...opts};
+  if (opts.proxy instanceof StorageProxyNG) {
+    return handleNGFor(
+        opts.particleId,
+        opts.proxy,
+        opts.idGenerator,
+        opts.particle,
+        opts.canRead,
+        opts.canWrite,
+        opts.name);
+  } else {
+    return handleFor(opts.proxy,
+        opts.idGenerator,
+        opts.name,
+        opts.particleId,
+        opts.canRead,
+        opts.canWrite);
+  }
 }

--- a/src/runtime/handle.ts
+++ b/src/runtime/handle.ts
@@ -524,6 +524,7 @@ export function unifiedHandleFor(opts: {
   const defaultOpts = {particleId: '', canRead: true, canWrite: true};
   opts = {...defaultOpts, ...opts};
   if (opts.proxy instanceof StorageProxyNG) {
+    assert(opts.particleId.length, 'NG Handles require a particle ID');
     return handleNGFor(
         opts.particleId,
         opts.proxy,

--- a/src/runtime/tests/data-layer-test.ts
+++ b/src/runtime/tests/data-layer-test.ts
@@ -10,12 +10,11 @@
 
 import {assert} from '../../platform/chai-web.js';
 import {Arc} from '../arc.js';
-import {handleFor, Collection} from '../handle.js';
 import {Loader} from '../loader.js';
 import {Schema} from '../schema.js';
 import {FakeSlotComposer} from '../testing/fake-slot-composer.js';
 import {EntityType} from '../type.js';
-import {ArcId, IdGenerator} from '../id.js';
+import {ArcId} from '../id.js';
 import {collectionHandleForTest} from '../testing/handle-for-test.js';
 
 describe('entity', () => {
@@ -29,8 +28,8 @@ describe('entity', () => {
     const collectionType = new EntityType(schema).collectionOf();
 
     const storage = await arc.createStore(collectionType);
-    const handle = handleFor(storage, IdGenerator.newSession()) as Collection;
-    await handle.store(entity);
+    const handle = await collectionHandleForTest(arc, storage);
+    await handle.add(entity);
 
     const collection = await collectionHandleForTest(arc, arc.findStoresByType(collectionType)[0]);
     const list = await collection.toList();

--- a/src/runtime/tests/runtime-manifest-integration-test.ts
+++ b/src/runtime/tests/runtime-manifest-integration-test.ts
@@ -9,9 +9,8 @@
  */
 
 import {assert} from '../../platform/chai-web.js';
-import {handleFor, Singleton} from '../handle.js';
 import {manifestTestSetup} from '../testing/manifest-integration-test-setup.js';
-import {IdGenerator} from '../id.js';
+import {singletonHandleForTest} from '../testing/handle-for-test.js';
 
 describe('runtime manifest integration', () => {
   it('can produce a recipe that can be instantiated in an arc', async () => {
@@ -21,7 +20,7 @@ describe('runtime manifest integration', () => {
     const type = recipe.handles[0].type;
     const [store] = arc.findStoresByType(type);
 
-    const handle = handleFor(store, IdGenerator.newSession()) as Singleton;
+    const handle = await singletonHandleForTest(arc, store);
     // TODO: This should not be necessary.
     type.maybeEnsureResolved();
     const result = await handle.get();


### PR DESCRIPTION
Migrates the remaining non-deprecated usages of handleFor to this new
function, which creates the correct type of new- vs old-style Handle.