### PR TITLE
Use RamDiskStorageKey for manifest local storage

### DIFF
--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -42,9 +42,10 @@ import {StorageStub} from './storage-stub.js';
 import {Flags} from './flags.js';
 import {Store} from './storageNG/store.js';
 import {StorageKey} from './storageNG/storage-key.js';
-import {Exists} from './storageNG/drivers/driver-factory.js';
+import {Exists, DriverFactory} from './storageNG/drivers/driver-factory.js';
 import {StorageKeyParser} from './storageNG/storage-key-parser.js';
 import {VolatileStorageKey} from './storageNG/drivers/volatile.js';
+import {RamDiskStorageKey} from './storageNG/drivers/ramdisk.js';
 
 export enum ErrorSeverity {
   Error = 'error',
@@ -1162,9 +1163,13 @@ ${e.message}
     return null;
   }
 
-  private createVolatileStorageKey(): string | VolatileStorageKey {
+  /**
+   * Creates a new storage key for data local to the manifest itself (e.g.
+   * from embedded JSON data, or an external JSON file).
+   */
+  private createLocalDataStorageKey(): string | RamDiskStorageKey {
     if (Flags.useNewStorageStack) {
-      return new VolatileStorageKey(this.id, this.generateID('volatile').toString());
+      return new RamDiskStorageKey(this.generateID('local-data').toString());
     } else {
       return (this.storageProviderFactory._storageForKey('volatile') as VolatileStorage).constructKey('volatile');
     }
@@ -1298,7 +1303,7 @@ ${e.message}
         type,
         name,
         id,
-        storageKey: manifest.createVolatileStorageKey(),
+        storageKey: manifest.createLocalDataStorageKey(),
         tags,
         originalId,
         claims,

--- a/src/runtime/tests/manifest-test.ts
+++ b/src/runtime/tests/manifest-test.ts
@@ -23,10 +23,10 @@ import {CheckHasTag, CheckBooleanExpression, CheckCondition, CheckIsFromStore} f
 import {ProvideSlotConnectionSpec} from '../particle-spec.js';
 import {Flags} from '../flags.js';
 import {Store} from '../storageNG/store.js';
-import {VolatileStorageKey} from '../storageNG/drivers/volatile.js';
 import {StorageStub} from '../storage-stub.js';
 import {collectionHandleForTest} from '../testing/handle-for-test.js';
 import {Entity} from '../entity.js';
+import {RamDiskStorageKey} from '../storageNG/drivers/ramdisk.js';
 
 function verifyPrimitiveType(field, type) {
   const copy = {...field};
@@ -2965,7 +2965,7 @@ resource NobIdJson
 
     assert.instanceOf(store, Store);
     assert.strictEqual(store.name, 'NobId');
-    assert.instanceOf(store.storageKey, VolatileStorageKey);
+    assert.instanceOf(store.storageKey, RamDiskStorageKey);
     const schema = store.type.getEntitySchema();
     assert.sameMembers(schema.names, ['NobIdStore']);
   });


### PR DESCRIPTION
JSON data stored inside a manifest (or loaded from a file) should live
in RamDisk storage, not Volatile storage. There is no arc present at the
time the manifest is parsed, so there's no VolatileStorageProvider
available (since its tied to the Arc) and we need to use RamDisk
instead.