### PR TITLE
Create CrdtSet.

### DIFF
--- a/src_kt/java/arcs/crdt/CrdtCount.kt
+++ b/src_kt/java/arcs/crdt/CrdtCount.kt
@@ -99,7 +99,7 @@ class CrdtCount : CrdtModel<CrdtCount.Data, CrdtCount.Operation, Int> {
     private var currentVersion = _data.versionMap[actor]
     private var nextVersion = currentVersion + 1
 
-    fun withCurrentVersion(version: Version) = apply { nextVersion = version }
+    fun withCurrentVersion(version: Version) = apply { currentVersion = version }
     fun withNextVersion(version: Version) = apply { nextVersion = version }
 
     operator fun plusAssign(delta: Int) {

--- a/src_kt/java/arcs/crdt/CrdtCount.kt
+++ b/src_kt/java/arcs/crdt/CrdtCount.kt
@@ -26,20 +26,6 @@ class CrdtCount : CrdtModel<CrdtCount.Data, CrdtCount.Operation, Int> {
 
   fun forActor(actor: Actor) = Scoped(actor)
 
-  inner class Scoped(private val actor: Actor) {
-    private var currentVersion = _data.versionMap[actor]
-    private var nextVersion = currentVersion + 1
-
-    fun withCurrentVersion(version: Version) = apply { nextVersion = version }
-    fun withNextVersion(version: Version) = apply { nextVersion = version }
-
-    operator fun plusAssign(delta: Int) {
-      applyOperation(
-        Operation.MultiIncrement(actor, currentVersion to nextVersion, delta)
-      )
-    }
-  }
-
   override fun merge(other: Data): MergeChanges<Data, Operation> {
     val myChanges = CrdtChange.Operations<Data, Operation>()
     val otherChanges = CrdtChange.Operations<Data, Operation>()
@@ -107,6 +93,22 @@ class CrdtCount : CrdtModel<CrdtCount.Data, CrdtCount.Operation, Int> {
   override fun updateData(newData: Data) {
     _data = newData
   }
+
+  /** Scoped access to this [CrdtCount], where all ops will be marked as performed by [actor]. */
+  inner class Scoped(private val actor: Actor) {
+    private var currentVersion = _data.versionMap[actor]
+    private var nextVersion = currentVersion + 1
+
+    fun withCurrentVersion(version: Version) = apply { nextVersion = version }
+    fun withNextVersion(version: Version) = apply { nextVersion = version }
+
+    operator fun plusAssign(delta: Int) {
+      applyOperation(
+        Operation.MultiIncrement(actor, currentVersion to nextVersion, delta)
+      )
+    }
+  }
+
 
   /** Internal representation of the count information. */
   data class Data(

--- a/src_kt/java/arcs/crdt/CrdtModel.kt
+++ b/src_kt/java/arcs/crdt/CrdtModel.kt
@@ -103,8 +103,10 @@ data class MergeChanges<Data : CrdtData, Op : CrdtOperation>(
  */
 sealed class CrdtChange<Data : CrdtData, Op : CrdtOperation> {
   /** Representation of a change as a series of [CrdtOperation]s. */
-  class Operations<Data : CrdtData, Op : CrdtOperation>
-    : CrdtChange<Data, Op>(), MutableList<Op> by mutableListOf()
+  data class Operations<Data : CrdtData, Op : CrdtOperation>(
+    /** Series of [Op]s required to complete the [CrdtChange]. */
+    val ops: MutableList<Op> = mutableListOf()
+  ) : CrdtChange<Data, Op>(), MutableList<Op> by ops
 
   /**
    * Representation of a change where a series of [CrdtOperation]s is not possible - contains the

--- a/src_kt/java/arcs/crdt/CrdtSet.kt
+++ b/src_kt/java/arcs/crdt/CrdtSet.kt
@@ -1,0 +1,223 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.crdt
+
+import arcs.crdt.internal.Actor
+import arcs.crdt.internal.Referencable
+import arcs.crdt.internal.ReferenceId
+import arcs.crdt.internal.VersionMap
+
+/** A [CrdtModel] capable of managing a set of items [T]. */
+class CrdtSet<T : Referencable> : CrdtModel<CrdtSet.Data<T>, CrdtSet.Operation<T>, Set<T>> {
+  private var _data: Data<T> = Data()
+  override val data: Data<T>
+    get() = _data.copy(versionMap = VersionMap(_data.versionMap), values = HashMap(_data.values))
+
+  override val consumerView: Set<T>
+    get() = HashSet<T>().apply { addAll(_data.values.values.map { it.value }) }
+
+  override fun merge(other: Data<T>): MergeChanges<Data<T>, Operation<T>> {
+    val newClock = _data.versionMap mergeWith other.versionMap
+    val mergedData = Data<T>(newClock)
+    val fastForwardOp = Operation.FastForward<T>(other.versionMap, newClock)
+
+    other.values.values.forEach { (otherVersion: VersionMap, otherValue: T) ->
+      val id = otherValue.id
+      val myEntry = _data.values[id]
+
+      if (myEntry != null) {
+        val (myVersion, myValue) = myEntry
+
+        if (myVersion == otherVersion) {
+          // Both models have the same value at the same version. Add it to the merge.
+          mergedData.values[id] = myEntry
+        } else {
+          // Models have different versions for the same value. Merge the versions,
+          // and update other.
+          DataValue(
+            myVersion mergeWith otherVersion,
+            myValue
+          ).also {
+            mergedData.values[id] = it
+            fastForwardOp.added += it
+          }
+        }
+      } else if (_data.versionMap dominates otherVersion) {
+        // Value was deleted by this model.
+        fastForwardOp.removed += otherValue
+      } else {
+        // Value was added by the other model.
+        mergedData.values[id] = DataValue(otherVersion, otherValue)
+      }
+    }
+
+    _data.values.forEach { (id, myEntry) ->
+      if (id !in other.values && other.versionMap isDominatedBy myEntry.versionMap) {
+        // Value was added by this model.
+        mergedData.values[id] = myEntry
+        fastForwardOp.added += myEntry
+      }
+    }
+
+    this._data = mergedData
+
+    val otherOperations =
+      CrdtChange.Operations<Data<T>, Operation<T>>(fastForwardOp.simplify().toMutableList())
+
+    return MergeChanges(modelChange = CrdtChange.Data(mergedData), otherChange = otherOperations)
+  }
+
+  override fun applyOperation(op: Operation<T>): Boolean = op.applyTo(_data)
+
+  override fun updateData(newData: Data<T>) {
+    _data = newData
+  }
+
+  /** Representation of the data managed by [CrdtSet]. */
+  data class Data<T : Referencable>(
+    /** Current version clock for the [Data]. */
+    override var versionMap: VersionMap = VersionMap(),
+    /** Map of values by their [ReferenceId]s. */
+    val values: MutableMap<ReferenceId, DataValue<T>> = mutableMapOf()
+  ) : CrdtData
+
+  /** A particular datum within a [CrdtSet]. */
+  data class DataValue<T : Referencable>(
+    /** The 'time' when the item was added. */
+    val versionMap: VersionMap,
+    /** The actual value of the datum. */
+    val value: T
+  )
+
+  /** Operations which can be performed on a [CrdtSet]. */
+  sealed class Operation<T : Referencable> : CrdtOperation {
+    /** Performs the operation on the specified [Data] instance. */
+    internal abstract fun applyTo(data: Data<T>): Boolean
+
+    /**
+     * Represents an addition of a new item into a [CrdtSet] and returns whether or not the
+     * operation could be applied.
+     */
+    data class Add<T : Referencable>(
+      val clock: VersionMap,
+      val actor: Actor,
+      val added: T
+    ) : Operation<T>() {
+      override fun applyTo(data: Data<T>): Boolean {
+        // Only accept an add if it is immediately consecutive to the clock for that actor.
+        if (clock[actor] != data.versionMap[actor] + 1) return false
+
+        data.versionMap[actor] = clock[actor]
+        val previousVersion = data.values[added.id]?.versionMap ?: VersionMap()
+        data.values[added.id] = DataValue(clock mergeWith previousVersion, added)
+        return true
+      }
+    }
+
+    /** Represents the removal of an item from a [CrdtSet]. */
+    data class Remove<T : Referencable>(
+      val clock: VersionMap,
+      val actor: Actor,
+      val removed: T
+    ) : Operation<T>() {
+      override fun applyTo(data: Data<T>): Boolean {
+        // Can't remove an item that doesn't exist.
+        val existingDatum = data.values[removed.id] ?: return false
+
+        // Ensure the remove op doesn't change the clock value.
+        if (clock[actor] != data.versionMap[actor]) return false
+
+        // Can't remove the item unless the clock value dominates that of the item already in the
+        // set.
+        if (clock isDominatedBy existingDatum.versionMap) return false
+
+        data.versionMap[actor] = clock[actor]
+        data.values.remove(removed.id)
+        return true
+      }
+    }
+
+    /** Represents a batch operation to catch one [CrdtSet] up with another. */
+    data class FastForward<T : Referencable>(
+      val oldClock: VersionMap,
+      val newClock: VersionMap,
+      val added: MutableList<DataValue<T>> = mutableListOf(),
+      val removed: MutableList<T> = mutableListOf()
+    ) : Operation<T>() {
+      override fun applyTo(data: Data<T>): Boolean {
+        // Can't fast-forward when current data's clock is behind oldClock.
+        if (data.versionMap isDominatedBy oldClock) return false
+
+        // If the current data already knows about everything in the fast-forward op, we don't have
+        // to do anything.
+        if (data.versionMap dominates newClock) return true
+
+        added.forEach { (addedClock: VersionMap, addedValue: T) ->
+          val existingValue = data.values[addedValue.id]
+          if (existingValue != null) {
+            data.values[addedValue.id] =
+              DataValue(addedClock mergeWith existingValue.versionMap, existingValue.value)
+          } else if (data.versionMap isDominatedBy addedClock) {
+            data.values[addedValue.id] = DataValue(addedClock, addedValue)
+          }
+        }
+
+        removed.forEach { removedValue: T ->
+          val existingValue = data.values[removedValue.id]
+          if (existingValue != null && newClock dominates existingValue.versionMap) {
+            data.values.remove(removedValue.id)
+          }
+        }
+
+        data.versionMap = data.versionMap mergeWith newClock
+        return true
+      }
+
+      /**
+       * Simplifies a [FastForward] operation, if possible.
+       *
+       * Converts a simple fast-forward operation into a sequence of regular ops.
+       *
+       * **Note:** Currently only supports converting add ops made by a single actor. Returns a list
+       * containing this [FastForward] op if it could not simplify.
+       */
+      fun simplify(): List<Operation<T>> {
+        // Remove ops can't be replayed in order.
+        if (removed.isNotEmpty()) return listOf(this)
+
+        // This is just a version bump, since there are no additions and no removals.
+        if (added.isEmpty()) return listOf(this)
+
+        // Can only return a simplified list of ops if all additions come from a single actor.
+        val versionDiff = newClock - oldClock
+        if (versionDiff.size != 1) return listOf(this)
+        val actor = versionDiff.actors.first()
+
+        val sortedAdds = added.sortedBy { it.versionMap[actor] }
+        var expectedVersion = oldClock[actor]
+        sortedAdds.forEach { (itemVersion: VersionMap, _) ->
+          // The add op's version for the actor wasn't just an increment-by-one from the previous
+          // version.
+          if (++expectedVersion != itemVersion[actor]) return listOf(this)
+        }
+
+        val expectedClock = VersionMap(oldClock).also { it[actor] = expectedVersion }
+
+        // If the final clock does not match an increment-by-one approach for each addition for the
+        // actor, we can't simplify.
+        if (expectedClock != newClock) return listOf(this)
+
+        return added.map { Add(it.versionMap, actor, it.value) }
+      }
+    }
+  }
+}

--- a/src_kt/java/arcs/crdt/internal/internal.kt
+++ b/src_kt/java/arcs/crdt/internal/internal.kt
@@ -14,8 +14,11 @@ package arcs.crdt.internal
 /** Denotes an individual actor responsible for modifications to a Crdt. */
 typealias Actor = String
 
+/** An identifier for a [Referencable]. */
+typealias ReferenceId = String
+
 /** Represents a referencable object, ie. one which can be referenced by a unique [id]. */
 interface Referencable {
   /** Unique identifier of the Referencable object. */
-  val id: String
+  val id: ReferenceId
 }

--- a/src_kt/javatests/arcs/crdt/CrdtSetTest.kt
+++ b/src_kt/javatests/arcs/crdt/CrdtSetTest.kt
@@ -1,0 +1,510 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.crdt
+
+import arcs.crdt.internal.*
+import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.Truth.assertWithMessage
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+private data class Reference(override val id: ReferenceId) : Referencable
+
+/** Tests for [CrdtSet]. */
+@RunWith(JUnit4::class)
+class CrdtSetTest {
+  private lateinit var alice: CrdtSet<Reference>
+  private lateinit var bob: CrdtSet<Reference>
+
+  @Before
+  fun setUp() {
+    alice = CrdtSet()
+    bob = CrdtSet()
+  }
+
+  @Test
+  fun startsEmpty() {
+    assertThat(alice.consumerView).isEmpty()
+  }
+
+  @Test
+  fun supportsAddingTwoDifferentItems_fromSameActor() {
+    alice.add("alice", VersionMap("alice" to 1), "one")
+    assertThat(
+      alice.applyOperation(
+        Add("alice", VersionMap("alice" to 2), "two")
+      )
+    ).isTrue()
+    assertThat(alice.consumerView).containsExactly(Reference("one"), Reference("two"))
+  }
+
+  @Test
+  fun supportsAddingSameValue_fromDifferentActors() {
+    alice.add("alice", VersionMap("alice" to 1), "one")
+    alice.add("bob", VersionMap("bob" to 1), "one")
+
+    assertThat(alice.consumerView).containsExactly(Reference("one"))
+  }
+
+  @Test
+  fun rejectsAdds_notInSequence() {
+    alice.add("alice", VersionMap("alice" to 1), "one")
+
+    assertThat(
+      alice.applyOperation(
+        Add("alice", VersionMap("alice" to 0), "two")
+      )
+    ).isFalse()
+    assertThat(
+      alice.applyOperation(
+        Add("alice", VersionMap("alice" to 1), "two")
+      )
+    ).isFalse()
+    assertThat(
+      alice.applyOperation(
+        Add("alice", VersionMap("alice" to 3), "two")
+      )
+    ).isFalse()
+  }
+
+  @Test
+  fun remove_removesAnItem() {
+    alice.add("alice", VersionMap("alice" to 1), "one")
+
+    assertThat(
+      alice.applyOperation(
+        Remove("alice", VersionMap("alice" to 1), "one")
+      )
+    ).isTrue()
+    assertThat(alice.consumerView).isEmpty()
+  }
+
+  @Test
+  fun removeIsRejected_ifVersionMismatch() {
+    alice.add("alice", VersionMap("alice" to 1), "one")
+
+    assertThat(
+      alice.applyOperation(
+        Remove("alice", VersionMap("alice" to 2), "one")
+      )
+    ).isFalse()
+    assertThat(
+      alice.applyOperation(
+        Remove("alice", VersionMap("alice" to 0), "one")
+      )
+    ).isFalse()
+  }
+
+  @Test
+  fun removeIsRejected_ifItemNotInSet() {
+    alice.add("alice", VersionMap("alice" to 1), "one")
+
+    assertThat(
+      alice.applyOperation(
+        Remove("alice", VersionMap("alice" to 1), "two")
+      )
+    ).isFalse()
+  }
+
+  @Test
+  fun removeIsRejected_ifVersionIsTooOld() {
+    alice.add("alice", VersionMap("alice" to 1), "one")
+    alice.add("bob", VersionMap("bob" to 1), "two")
+
+    assertThat(
+      alice.applyOperation(
+        Remove("charlie", VersionMap("alice" to 1), "one")
+      )
+    ).isTrue()
+    assertThat(
+      alice.applyOperation(
+        Remove("charlie", VersionMap("alice" to 1), "two")
+      )
+    ).isFalse()
+  }
+
+  @Test
+  fun merge_canMergeTwoModels() {
+    listOf(
+      Add("charlie", VersionMap("charlie" to 1), "kept by both"),
+      Add("charlie", VersionMap("charlie" to 2), "removed by alice"),
+      Add("charlie", VersionMap("charlie" to 3), "removed by bob"),
+      Add("charlie", VersionMap("charlie" to 4), "removed by alice added by bob"),
+      Add("charlie", VersionMap("charlie" to 5), "removed by bob added by alice")
+    ).forEach {
+      assertThat(alice.applyOperation(it)).isTrue()
+      assertThat(bob.applyOperation(it)).isTrue()
+    }
+
+    listOf(
+      Remove("alice", VersionMap("alice" to 0, "charlie" to 5), "removed by alice"),
+      Add("alice", VersionMap("alice" to 1, "charlie" to 5), "added by alice"),
+      Add("alice", VersionMap("alice" to 2, "charlie" to 5), "added by both"),
+      Add("alice", VersionMap("alice" to 3, "charlie" to 5), "removed by bob added by alice"),
+      Remove(
+        "alice", VersionMap("alice" to 3, "charlie" to 5), "removed by alice added by bob"
+      )
+    ).forEach { assertWithMessage("Alice: $it").that(alice.applyOperation(it)).isTrue() }
+
+    listOf(
+      Add("bob", VersionMap("bob" to 1, "charlie" to 5), "added by both"),
+      Add("bob", VersionMap("bob" to 2, "charlie" to 5), "added by bob"),
+      Remove("bob", VersionMap("bob" to 2, "charlie" to 5), "removed by bob"),
+      Remove("bob", VersionMap("bob" to 2, "charlie" to 5), "removed by bob added by alice"),
+      Add("bob", VersionMap("bob" to 3, "charlie" to 5), "removed by alice added by bob")
+    ).forEach { assertWithMessage("Bob: $it").that(bob.applyOperation(it)).isTrue() }
+
+    val changes = alice.merge(bob.data)
+    val expectedVersion = VersionMap(
+      "alice" to 3,
+      "bob" to 3,
+      "charlie" to 5
+    )
+
+    val modelChange =
+      requireNotNull(
+        changes.modelChange
+          as? CrdtChange.Data<CrdtSet.Data<Reference>, CrdtSet.Operation<Reference>>
+      )
+    val otherChange =
+      requireNotNull(
+        changes.otherChange
+          as? CrdtChange.Operations<CrdtSet.Data<Reference>, CrdtSet.Operation<Reference>>
+      )
+
+    assertThat(modelChange.data.versionMap).isEqualTo(expectedVersion)
+    assertThat(modelChange.data.values)
+      .containsExactlyEntriesIn(
+        mapOf(
+          "kept by both" to
+            CrdtSet.DataValue(VersionMap("charlie" to 1), Reference("kept by both")),
+          "removed by alice added by bob" to
+            CrdtSet.DataValue(
+              VersionMap("bob" to 3, "charlie" to 5), Reference("removed by alice added by bob")
+            ),
+          "removed by bob added by alice" to
+            CrdtSet.DataValue(
+              VersionMap("alice" to 3, "charlie" to 5),
+              Reference("removed by bob added by alice")
+            ),
+          "added by alice" to
+            CrdtSet.DataValue(
+              VersionMap("alice" to 1, "charlie" to 5), Reference("added by alice")
+            ),
+          "added by bob" to
+            CrdtSet.DataValue(VersionMap("bob" to 2, "charlie" to 5), Reference("added by bob")),
+          "added by both" to
+            CrdtSet.DataValue(
+              VersionMap("alice" to 2, "bob" to 1, "charlie" to 5), Reference("added by both")
+            )
+        )
+      )
+
+    assertThat(otherChange.size).isEqualTo(1)
+    val fastForward = requireNotNull(otherChange[0] as? CrdtSet.Operation.FastForward<Reference>)
+    assertThat(fastForward.added)
+      .containsExactly(
+        CrdtSet.DataValue(
+          VersionMap("alice" to 2, "bob" to 1, "charlie" to 5), Reference("added by both")
+        ),
+        CrdtSet.DataValue(
+          VersionMap("alice" to 3, "charlie" to 5), Reference("removed by bob added by alice")
+        ),
+        CrdtSet.DataValue(
+          VersionMap("alice" to 1, "charlie" to 5), Reference("added by alice")
+        )
+      )
+    assertThat(fastForward.removed)
+      .containsExactly(Reference("removed by alice"))
+    assertThat(fastForward.oldClock).isEqualTo(VersionMap("bob" to 3, "charlie" to 5))
+    assertThat(fastForward.newClock).isEqualTo(expectedVersion)
+
+    assertThat(bob.applyOperation(fastForward)).isTrue()
+
+    assertThat(alice.data.versionMap).isEqualTo(bob.data.versionMap)
+    assertThat(alice.data.values).containsExactlyEntriesIn(bob.data.values)
+  }
+
+  @Test
+  fun fastForward_canSimplifySingleActorAddOps() {
+    listOf(
+      Add("alice", VersionMap("alice" to 1), "zero"),
+      Add("bob", VersionMap("bob" to 1), "one")
+    ).forEach {
+      assertThat(alice.applyOperation(it)).isTrue()
+      assertThat(bob.applyOperation(it)).isTrue()
+    }
+
+    val expectedAdds = listOf(
+      Add("bob", VersionMap("alice" to 1, "bob" to 2), "two"),
+      Add("bob", VersionMap("alice" to 1, "bob" to 3), "three"),
+      Add("bob", VersionMap("alice" to 1, "bob" to 4), "four"),
+      Add("bob", VersionMap("alice" to 1, "bob" to 5), "five")
+    ).onEach { assertThat(bob.applyOperation(it)).isTrue() }
+
+    val (_, otherChange) = bob.merge(alice.data)
+
+    val operations = requireNotNull(
+      otherChange as? CrdtChange.Operations<CrdtSet.Data<Reference>, CrdtSet.Operation<Reference>>
+    )
+
+    assertThat(operations.ops).containsExactlyElementsIn(expectedAdds)
+  }
+
+  @Test
+  fun fastForwardRejected_whenItBeginsInTheFuture() {
+    assertThat(
+      alice.applyOperation(
+        CrdtSet.Operation.FastForward(
+          oldClock = VersionMap("alice" to 5),
+          newClock = VersionMap("alice" to 10)
+        )
+      )
+    ).isFalse()
+  }
+
+  @Test
+  fun fastForwardNoOps_whenItEndsInThePast() {
+    listOf(
+      Add("alice", VersionMap("alice" to 1), "one"),
+      Add("alice", VersionMap("alice" to 2), "two"),
+      Add("alice", VersionMap("alice" to 3), "three")
+    ).forEach { assertThat(alice.applyOperation(it)).isTrue() }
+
+    assertThat(
+      alice.applyOperation(
+        CrdtSet.Operation.FastForward(
+          oldClock = VersionMap("alice" to 1),
+          newClock = VersionMap("bob" to 2),
+          added = mutableListOf(
+            CrdtSet.DataValue(VersionMap("alice" to 2), Reference("four"))
+          )
+        )
+      )
+    ).isTrue()
+    assertThat(alice.data.values).doesNotContainKey("four")
+  }
+
+  @Test
+  fun fastForward_advancesTheClock() {
+    listOf(
+      Add("alice", VersionMap("alice" to 1), "one"),
+      Add("alice", VersionMap("alice" to 2), "two"),
+      Add("bob", VersionMap("bob" to 1), "three"),
+      Add("charlie", VersionMap("charlie" to 1), "four")
+    ).forEach { assertThat(alice.applyOperation(it)).isTrue() }
+
+    assertThat(alice.data.versionMap)
+      .isEqualTo(VersionMap("alice" to 2, "bob" to 1, "charlie" to 1))
+
+    assertThat(
+      alice.applyOperation(
+        CrdtSet.Operation.FastForward(
+          oldClock = VersionMap("alice" to 2, "bob" to 1),
+          newClock = VersionMap("alice" to 27, "bob" to 45)
+        )
+      )
+    ).isTrue()
+
+    assertThat(alice.data.versionMap)
+      .isEqualTo(VersionMap("alice" to 27, "bob" to 45, "charlie" to 1))
+  }
+
+  @Test
+  fun fastForward_canAddElements() {
+    listOf(
+      Add("alice", VersionMap("alice" to 1), "one"),
+      Add("bob", VersionMap("bob" to 1), "two")
+    ).forEach { assertThat(alice.applyOperation(it)).isTrue() }
+
+    // Do some fast-forwarding.
+    assertThat(
+      alice.applyOperation(
+        CrdtSet.Operation.FastForward(
+          oldClock = VersionMap("alice" to 1, "bob" to 1),
+          newClock = VersionMap("alice" to 1, "bob" to 9),
+          added = mutableListOf(
+            CrdtSet.DataValue(VersionMap("alice" to 1, "bob" to 7), Reference("one")),
+            CrdtSet.DataValue(VersionMap("alice" to 1, "bob" to 9), Reference("four"))
+          )
+        )
+      )
+    ).isTrue()
+
+    // Now a couple of additional operations after the fast-forward.
+    listOf(
+      Remove("alice", VersionMap("alice" to 1, "bob" to 1), "two"),
+      Add("alice", VersionMap("alice" to 2, "bob" to 1), "three")
+    ).forEach { assertThat(alice.applyOperation(it)).isTrue() }
+
+    // One should be merged with the new version, two was removed and shouldn't be added back again,
+    // three was existing and shouldn't be deleted, and four is new.
+    assertThat(alice.data.versionMap).isEqualTo(VersionMap("alice" to 2, "bob" to 9))
+    assertThat(alice.data.values)
+      .containsExactlyEntriesIn(
+        mapOf(
+          // Merged
+          "one" to CrdtSet.DataValue(VersionMap("alice" to 1, "bob" to 7), Reference("one")),
+          // Existing
+          "three" to CrdtSet.DataValue(VersionMap("alice" to 2, "bob" to 1), Reference("three")),
+          // Added
+          "four" to CrdtSet.DataValue(VersionMap("alice" to 1, "bob" to 9), Reference("four"))
+        )
+      )
+  }
+
+  @Test
+  fun fastForward_canRemoveElements() {
+    listOf(
+      Add("alice", VersionMap("alice" to 1), "one"),
+      Add("alice", VersionMap("alice" to 2), "two"),
+      Add("bob", VersionMap("bob" to 1), "three")
+    ).forEach { assertThat(alice.applyOperation(it)).isTrue() }
+
+    assertThat(
+      alice.applyOperation(
+        CrdtSet.Operation.FastForward(
+          oldClock = VersionMap("alice" to 1, "bob" to 1),
+          newClock = VersionMap("alice" to 1, "bob" to 5),
+          removed = mutableListOf(
+            Reference("one"),
+            Reference("two")
+          )
+        )
+      )
+    ).isTrue()
+
+    assertThat(alice.data.values).containsKey("two")
+    assertThat(alice.data.values).containsKey("three")
+    assertThat(alice.data.versionMap).isEqualTo(VersionMap("alice" to 2, "bob" to 5))
+  }
+
+  @Test
+  fun fastForward_simplifiesSingleAddOp_fromASingleActor() {
+    val simplified = CrdtSet.Operation.FastForward(
+      oldClock = VersionMap("alice" to 1, "bob" to 1),
+      newClock = VersionMap("alice" to 2, "bob" to 1),
+      added = mutableListOf(
+        CrdtSet.DataValue(VersionMap("alice" to 2, "bob" to 1), Reference("one"))
+      )
+    ).simplify()
+
+    assertThat(simplified)
+      .containsExactly(Add("alice", VersionMap("alice" to 2, "bob" to 1), "one"))
+  }
+
+  @Test
+  fun fastForward_simplifiesMultipleAddOps_fromASingleActor() {
+    val simplified = CrdtSet.Operation.FastForward(
+      oldClock = VersionMap("alice" to 1, "bob" to 1),
+      newClock = VersionMap("alice" to 3, "bob" to 1),
+      added = mutableListOf(
+        CrdtSet.DataValue(VersionMap("alice" to 3, "bob" to 1), Reference("two")),
+        CrdtSet.DataValue(VersionMap("alice" to 2, "bob" to 1), Reference("one"))
+      )
+    ).simplify()
+
+    assertThat(simplified)
+      .containsExactly(
+        Add("alice", VersionMap("alice" to 2, "bob" to 1), "one"),
+        Add("alice", VersionMap("alice" to 3, "bob" to 1), "two")
+      )
+  }
+
+  @Test
+  fun fastForward_doesntSimplify_removeOps() {
+    val ff = CrdtSet.Operation.FastForward(
+      oldClock = VersionMap("alice" to 1),
+      newClock = VersionMap("alice" to 1),
+      removed = mutableListOf(
+        Reference("one")
+      )
+    )
+
+    assertThat(ff.simplify()).isEqualTo(listOf(ff))
+  }
+
+  @Test
+  fun fastForward_doesntSimplify_pureVersionBumps() {
+    val ff = CrdtSet.Operation.FastForward<Reference>(
+      oldClock = VersionMap("alice" to 1),
+      newClock = VersionMap("alice" to 5)
+    )
+
+    assertThat(ff.simplify()).isEqualTo(listOf(ff))
+  }
+
+  @Test
+  fun fastForward_doesntSimplify_addOpsFromSingleActor_withVersionJumps() {
+    val ff = CrdtSet.Operation.FastForward(
+      oldClock = VersionMap("alice" to 0),
+      newClock = VersionMap("alice" to 4),
+      added = mutableListOf(
+        CrdtSet.DataValue(VersionMap("alice" to 1), Reference("one")),
+        CrdtSet.DataValue(VersionMap("alice" to 2), Reference("two")),
+        CrdtSet.DataValue(VersionMap("alice" to 4), Reference("four"))
+      )
+    )
+
+    assertThat(ff.simplify()).isEqualTo(listOf(ff))
+  }
+
+  @Test
+  fun fastForward_doesntSimplify_addOpsFromMultipleActors() {
+    val ff = CrdtSet.Operation.FastForward(
+      oldClock = VersionMap("alice" to 1, "bob" to 1),
+      newClock = VersionMap("alice" to 2, "bob" to 2),
+      added = mutableListOf(
+        CrdtSet.DataValue(VersionMap("alice" to 2), Reference("one")),
+        CrdtSet.DataValue(VersionMap("bob" to 2), Reference("two"))
+      )
+    )
+
+    assertThat(ff.simplify()).isEqualTo(listOf(ff))
+  }
+
+  @Test
+  fun fastForward_doesntSimplify_addOps_whenNewClockIsAJump() {
+    val ff = CrdtSet.Operation.FastForward(
+      oldClock = VersionMap("alice" to 1),
+      newClock = VersionMap("alice" to 3),
+      added = mutableListOf(
+        CrdtSet.DataValue(VersionMap("alice" to 2), Reference("one"))
+      )
+    )
+
+    assertThat(ff.simplify()).isEqualTo(listOf(ff))
+  }
+}
+
+/** Pseudo-constructor for [CrdtSet.Operation.Add]. */
+private fun Add(actor: Actor, versions: VersionMap, id: ReferenceId) =
+  CrdtSet.Operation.Add(versions, actor, Reference(id))
+
+/** Pseudo-constructor for [CrdtSet.Operation.Remove]. */
+private fun Remove(actor: Actor, versions: VersionMap, id: ReferenceId) =
+  CrdtSet.Operation.Remove(versions, actor, Reference(id))
+
+private fun CrdtSet<Reference>.add(
+  actor: Actor,
+  versions: VersionMap,
+  id: ReferenceId
+) = Add(actor, versions, id).also { applyOperation(it) }
+
+private fun CrdtSet<Reference>.remove(
+  actor: Actor,
+  versions: VersionMap,
+  id: ReferenceId
+) = Remove(actor, versions, id).also { applyOperation(it) }
+

--- a/src_kt/javatests/arcs/crdt/internal/VersionMapTest.kt
+++ b/src_kt/javatests/arcs/crdt/internal/VersionMapTest.kt
@@ -94,7 +94,7 @@ class VersionMapTest {
 
     a = VersionMap()
     b = VersionMap(a)
-    assertThat(a isDominatedBy  b).isFalse()
+    assertThat(a isDominatedBy b).isFalse()
   }
 
   @Test

--- a/src_kt/javatests/arcs/crdt/internal/VersionMapTest.kt
+++ b/src_kt/javatests/arcs/crdt/internal/VersionMapTest.kt
@@ -85,6 +85,45 @@ class VersionMapTest {
   }
 
   @Test
+  fun isDominatedByReturnsFalse_whenVersionMapsAreEqual() {
+    var a = VersionMap()
+    a["alice"]++
+    a["bob"] = 42
+    var b = VersionMap(a)
+    assertThat(a isDominatedBy b).isFalse()
+
+    a = VersionMap()
+    b = VersionMap(a)
+    assertThat(a isDominatedBy  b).isFalse()
+  }
+
+  @Test
+  fun isDominatedByReturnsTrue_whenVersionMapIsDominatedByAnother() {
+    val a = VersionMap()
+    val b = VersionMap()
+
+    a["alice"]++
+    assertThat(b isDominatedBy a).isTrue()
+
+    a["bob"] = 2
+    b["bob"] = 2
+    assertThat(b isDominatedBy a).isTrue()
+  }
+
+  @Test
+  fun isDominatedByReturnsFalse_whenVersionMapDominatesAnother() {
+    val a = VersionMap()
+    val b = VersionMap()
+
+    b["alice"]++
+    assertThat(b isDominatedBy a).isFalse()
+
+    a["bob"] = 2
+    b["bob"] = 2
+    assertThat(b isDominatedBy a).isFalse()
+  }
+
+  @Test
   fun mergeWith_mergesTwoEmptyMaps() {
     val a = VersionMap()
     val b = VersionMap()
@@ -116,7 +155,7 @@ class VersionMapTest {
     a["alice"]++
     b["bob"]++
 
-    val merged = a mergeWith b
+    @Suppress("UNUSED_VARIABLE") val merged = a mergeWith b
     assertThat("bob" !in a).isTrue()
     assertThat(a["bob"]).isEqualTo(0)
     assertThat("alice" !in b).isTrue()
@@ -153,5 +192,53 @@ class VersionMapTest {
     a["bob"] = 2
 
     assertThat(a != b).isTrue()
+  }
+
+  @Test
+  fun minus_returnsEmptyMap_whenBothAreEqual() {
+    val a = VersionMap()
+    val b = VersionMap()
+
+    assertThat((b - a).isEmpty())
+      .isTrue()
+    assertThat((a - b).isEmpty())
+      .isTrue()
+
+    a["alice"] = 42
+    b["alice"] = 42
+    assertThat((b - a).isEmpty())
+      .isTrue()
+    assertThat((a - b).isEmpty())
+      .isTrue()
+  }
+
+  @Test
+  fun minus_returnsEmptyMap_ifLhsDoesNotDominateRhs() {
+    val a = VersionMap()
+    val b = VersionMap()
+
+    b["alice"] = 42
+    assertThat((a - b).isEmpty()).isTrue()
+  }
+
+  @Test
+  fun minus_returnsNonEmptyMap_ifLhsDominatesRhs() {
+    val a = VersionMap()
+    val b = VersionMap()
+
+    a["alice"]++
+    var difference = a - b
+    assertThat(difference["alice"]).isEqualTo(1)
+
+    a["alice"]++
+    difference = a - b
+    assertThat(difference["alice"]).isEqualTo(2)
+
+    b["alice"] = 2
+    a["bob"] = 1337
+    difference = a - b
+    assertThat(difference.size).isEqualTo(1)
+    assertThat(difference["bob"]).isEqualTo(1337)
+    assertThat(difference["alice"]).isEqualTo(0)
   }
 }


### PR DESCRIPTION
Implements CRDTCollection from Typescript as CrdtSet in Kotlin. This name change keeps the api contract as expected when dealing with Sets in Java/Kotlin.