### PR TITLE
Register `$arcs` prefix in pipes-shell

### DIFF
--- a/shells/pipes-shell/node/paths.js
+++ b/shells/pipes-shell/node/paths.js
@@ -10,8 +10,9 @@
 export const paths = {
   root: '.',
   map: {
-    'https://$build/': `../../lib/build/`,
-    'https://$particles/': `../../../particles/`
+    'https://$arcs/': `../../../`,
+    'https://$particles/': `../../../particles/`,
+    'https://$build/': `../../lib/build/`
   }
 };
 

--- a/shells/pipes-shell/source/context.js
+++ b/shells/pipes-shell/source/context.js
@@ -23,10 +23,8 @@ export const requireContext = async manifest => {
 // longer important.
 
 export const mirrorStore = async (sourceStore, contextStore) => {
-  const change = change => {
-    cloneStoreChange(contextStore, change);
-  };
   cloneStore(sourceStore, contextStore);
+  const change = change => cloneStoreChange(contextStore, change);
   sourceStore.on(change);
 };
 
@@ -41,7 +39,9 @@ const cloneStore = async (sourceStore, contextStore) => {
 
 const cloneStoreChange = async (store, change) => {
   console.log('mirroring store change', change);
-  if (store && change.add) {
-    await Promise.all(change.add.map(async add => store.store(add.value, [Math.random()])));
+  if (store && change && change.add) {
+    await Promise.all(change.add.map(
+      async add => store.store(add.value, [Math.random()]))
+    );
   }
 };

--- a/shells/pipes-shell/web/paths.js
+++ b/shells/pipes-shell/web/paths.js
@@ -10,8 +10,9 @@
 export const paths = {
   root: '.',
   map: {
-    'https://$build/': `../../lib/build/`,
-    'https://$particles/': `../../../particles/`
+    'https://$arcs/': `../../../`,
+    'https://$particles/': `../../../particles/`,
+    'https://$build/': `../../lib/build/`
   }
 };
 


### PR DESCRIPTION
I tested `pipes-shell` against Tutorial/Kotlin (wasm) particles. There was a problem because the `wasm`  is built into a special folder which is referenced thus:
```
https://$arcs/bazel-bin/particles/Tutorial/Kotlin/hello_world.wasm
```
`pipes-shell` didn't have a registered `$arcs` prefix, so the resulting path was incorrect, now it does.

Note this doesn't necessarily explain @yuangu-google 's problem, since his error output showed no `https` in the path at all. It would be useful to know what Particle is causing the trouble, it may be an issue with the Particle declaration.

PR also includes a tweak to make `context.js` safe against null `change` records.