### PR TITLE
Use SingletonHandle impl for Entities in new storage stack.

### DIFF
--- a/src/planning/strategies/tests/init-population-test.ts
+++ b/src/planning/strategies/tests/init-population-test.ts
@@ -16,7 +16,7 @@ import {StubLoader} from '../../../runtime/testing/stub-loader.js';
 import {InitPopulation} from '../../strategies/init-population.js';
 
 import {StrategyTestHelper} from '../../testing/strategy-test-helper.js';
-import {Id, ArcId} from '../../../runtime/id.js';
+import {ArcId} from '../../../runtime/id.js';
 
 describe('InitPopulation', () => {
   it('penalizes resolution of particles that already exist in the arc', async () => {

--- a/src/runtime/api-channel.ts
+++ b/src/runtime/api-channel.ts
@@ -27,7 +27,7 @@ import {floatingPromiseToAudit} from './util.js';
 import {MessagePort} from './message-channel.js';
 import {StorageProxy as StorageProxyNG} from './storageNG/storage-proxy.js';
 import {CRDTTypeRecord} from './crdt/crdt.js';
-import {ActiveStore, ProxyCallback, ProxyMessage} from './storageNG/store.js';
+import {ActiveStore, ProxyCallback, ProxyMessage, Store} from './storageNG/store.js';
 import {StorageProviderBase} from './storage/storage-provider-base.js';
 
 enum MappingType {Mapped, LocalMapped, RemoteMapped, Direct, ObjectMap, List, ByLiteral}
@@ -514,8 +514,8 @@ export abstract class PECOuterPort extends APIPort {
   abstract onStreamCursorNext(handle: StorageProviderBase, callback: number, cursorId: number);
   abstract onStreamCursorClose(handle: StorageProviderBase, cursorId: number);
 
-  abstract onRegister(handle: ActiveStore<CRDTTypeRecord>, messagesCallback: number, idCallback: number);
-  abstract onProxyMessage(handle: ActiveStore<CRDTTypeRecord>, message: ProxyMessage<CRDTTypeRecord>, callback: number);
+  abstract onRegister(handle: Store<CRDTTypeRecord>, messagesCallback: number, idCallback: number);
+  abstract onProxyMessage(handle: Store<CRDTTypeRecord>, message: ProxyMessage<CRDTTypeRecord>, callback: number);
 
   abstract onIdle(version: number, relevance: Map<recipeParticle.Particle, number[]>);
 

--- a/src/runtime/type.ts
+++ b/src/runtime/type.ts
@@ -369,6 +369,12 @@ export class EntityType extends Type {
   crdtInstanceConstructor() {
     return this.entitySchema.crdtConstructor();
   }
+
+  handleConstructor<T>() {
+    // Currently using SingletonHandle as the implementation for Entity handles.
+    // TODO: Make an EntityHandle class that uses the proper Entity CRDT.
+    return SingletonHandle;
+  }
 }
 
 


### PR DESCRIPTION
This fixes a test that fails when the new storage flag is enabled. We
don't have an EntityHandle class yet, so we'll use SingletonHandle
instead.