### PR TITLE
Consolidate store serialisation code.

### DIFF
--- a/src/runtime/arc.ts
+++ b/src/runtime/arc.ts
@@ -252,7 +252,7 @@ constructor({id, context, pecFactories, slotComposer, loader, storageKey, storag
       key = store.storageKey;
     }
     const tags: Set<string> = this.storeTags.get(store) || new Set();
-    const handleTags = [...tags].map(a => `#${a}`);
+    const handleTags = [...tags];
 
     const actualHandle = this.activeRecipe.findHandle(store.id);
     const originalId = actualHandle ? actualHandle.originalId : null;

--- a/src/runtime/arc.ts
+++ b/src/runtime/arc.ts
@@ -240,7 +240,7 @@ constructor({id, context, pecFactories, slotComposer, loader, storageKey, storag
     return innerArc;
   }
 
-  private async _serializeStore(store: UnifiedStore, context: SerializeContext, id: string): Promise<void> {
+  private async _serializeStore(store: UnifiedStore, context: SerializeContext, name: string): Promise<void> {
     const type = store.type.getContainedType() || store.type;
     if (type instanceof InterfaceType) {
       context.interfaces += type.interfaceInfo.toString() + '\n';
@@ -252,7 +252,7 @@ constructor({id, context, pecFactories, slotComposer, loader, storageKey, storag
       key = store.storageKey;
     }
     const tags: Set<string> = this.storeTags.get(store) || new Set();
-    const handleTags = [...tags].map(a => `#${a}`).join(' ');
+    const handleTags = [...tags].map(a => `#${a}`);
 
     const actualHandle = this.activeRecipe.findHandle(store.id);
     const originalId = actualHandle ? actualHandle.originalId : null;
@@ -264,7 +264,7 @@ constructor({id, context, pecFactories, slotComposer, loader, storageKey, storag
     switch (key.protocol) {
       case 'firebase':
       case 'pouchdb':
-        context.handles += `store ${id} of ${store.type.toString()} ${combinedId} @${store.version === null ? 0 : store.version} ${handleTags} at '${store.storageKey}'\n`;
+        context.handles += context.handles += store.toManifestString({handleTags, overrides: {name}}) + '\n';
         break;
       case 'volatile': {
         // TODO(sjmiles): emit empty data for stores marked `volatile`: shell will supply data
@@ -299,7 +299,7 @@ constructor({id, context, pecFactories, slotComposer, loader, storageKey, storag
         if (store.referenceMode && serializedData.length > 0) {
           const storageKey = serializedData[0].storageKey;
           if (!context.dataResources.has(storageKey)) {
-            const storeId = `${id}_Data`;
+            const storeId = `${name}_Data`;
             context.dataResources.set(storageKey, storeId);
             // TODO: can't just reach into the store for the backing Store like this, should be an
             // accessor that loads-on-demand in the storage objects.
@@ -314,13 +314,14 @@ constructor({id, context, pecFactories, slotComposer, loader, storageKey, storag
 
         const indent = '  ';
         const data = JSON.stringify(serializedData);
+        const resourceName = `${name}Resource`;
 
-        context.resources += `resource ${id}Resource\n`
+        context.resources += `resource ${resourceName}\n`
           + indent + 'start\n'
           + data.split('\n').map(line => indent + line).join('\n')
           + '\n';
 
-        context.handles += `store ${id} of ${store.type.toString()} ${combinedId} @${store.version || 0} ${handleTags} in ${id}Resource\n`;
+        context.handles += store.toManifestString({handleTags, overrides: {name, source: resourceName, origin: 'resource'}}) + '\n';
         break;
       }
       default:
@@ -870,7 +871,7 @@ ${this.activeRecipe.toString()}`;
     const results: string[] = [];
     const stores = [...this.storesById.values()].sort(compareComparables);
     stores.forEach(store => {
-      results.push(store.toManifestString([...this.storeTags.get(store)]));
+      results.push(store.toManifestString({handleTags: [...this.storeTags.get(store)]}));
     });
 
     // TODO: include stores entities

--- a/src/runtime/manifest-ast-nodes.ts
+++ b/src/runtime/manifest-ast-nodes.ts
@@ -123,7 +123,7 @@ export interface ManifestStorage extends BaseNode {
   version: number;
   tags: TagList;
   source: string;
-  origin: string;
+  origin: 'file' | 'resource' | 'storage';
   description: string|null;
   claim: ManifestStorageClaim;
 }

--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -247,6 +247,7 @@ export class Manifest {
       description?: string,
       version?: number,
       source?: string,
+      origin?: 'file' | 'resource' | 'storage',
       referenceMode?: boolean,
       model?: {}[],
   }) {
@@ -276,6 +277,7 @@ export class Manifest {
           opts.description,
           opts.version,
           opts.source,
+          opts.origin,
           opts.referenceMode,
           opts.model);
     }
@@ -1206,6 +1208,7 @@ ${e.message}
         claims,
         description: item.description,
         version: item.version,
+        origin: item.origin,
       });
     }
 
@@ -1310,6 +1313,7 @@ ${e.message}
         description: item.description,
         version,
         source: item.source,
+        origin: item.origin,
         referenceMode,
         model,
     });
@@ -1349,7 +1353,7 @@ ${e.message}
 
     const stores = [...this.stores].sort(compareComparables);
     stores.forEach(store => {
-      results.push(store.toManifestString(this.storeTags.get(store).map(a => `#${a}`)));
+      results.push(store.toManifestString({handleTags: this.storeTags.get(store).map(a => `#${a}`)}));
     });
 
     return results.join('\n');

--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -1353,7 +1353,7 @@ ${e.message}
 
     const stores = [...this.stores].sort(compareComparables);
     stores.forEach(store => {
-      results.push(store.toManifestString({handleTags: this.storeTags.get(store).map(a => `#${a}`)}));
+      results.push(store.toManifestString({handleTags: this.storeTags.get(store)}));
     });
 
     return results.join('\n');

--- a/src/runtime/storage-stub.ts
+++ b/src/runtime/storage-stub.ts
@@ -31,9 +31,10 @@ export class StorageStub extends UnifiedStore {
               description: string,
               public readonly version?: number,
               source?: string,
+              origin?: 'file' | 'resource' | 'storage',
               public referenceMode: boolean = false,
               public readonly model?: {}[]) {
-    super({type, id, name, originalId, claims, description, source});
+    super({type, id, name, originalId, claims, description, source, origin});
   }
 
   // No-op implementations for `on` and `off`.

--- a/src/runtime/storageNG/unified-store.ts
+++ b/src/runtime/storageNG/unified-store.ts
@@ -107,7 +107,7 @@ export abstract class UnifiedStore implements Comparable<UnifiedStore>, OldStore
     if (info.originalId) {
       handleStr.push(`!!${info.originalId}`);
     }
-    if (this.version !== undefined) {
+    if (this.version != null) {
       handleStr.push(`@${this.version}`);
     }
     if (opts.handleTags && opts.handleTags.length) {

--- a/src/runtime/storageNG/unified-store.ts
+++ b/src/runtime/storageNG/unified-store.ts
@@ -91,43 +91,48 @@ export abstract class UnifiedStore implements Comparable<UnifiedStore>, OldStore
   }
 
   // TODO: Make these tags live inside StoreInfo.
-  toManifestString(handleTags: string[]): string {
+  toManifestString(opts?: {handleTags?: string[], overrides?: Partial<StoreInfo>}): string {
+    opts = opts || {};
+    const info = {...this.storeInfo, ...opts.overrides};
     const results: string[] = [];
     const handleStr: string[] = [];
     handleStr.push(`store`);
-    if (this.name) {
-      handleStr.push(`${this.name}`);
+    if (info.name) {
+      handleStr.push(`${info.name}`);
     }
-    handleStr.push(`of ${this.type.toString()}`);
-    if (this.id) {
-      handleStr.push(`'${this.id}'`);
+    handleStr.push(`of ${info.type.toString()}`);
+    if (info.id) {
+      handleStr.push(`'${info.id}'`);
     }
-    if (this.originalId) {
-      handleStr.push(`!!${this.originalId}`);
+    if (info.originalId) {
+      handleStr.push(`!!${info.originalId}`);
     }
     if (this.version !== undefined) {
       handleStr.push(`@${this.version}`);
     }
-    if (handleTags && handleTags.length) {
-      handleStr.push(`${handleTags.join(' ')}`);
+    if (opts.handleTags && opts.handleTags.length) {
+      handleStr.push(`${opts.handleTags.join(' ')}`);
     }
-    if (this.source) {
-      handleStr.push(`in '${this.source}'`);
+    if (info.source) {
+      if (info.origin === 'file') {
+        handleStr.push(`in '${info.source}'`);
+      } else {
+        handleStr.push(`in ${info.source}`);
+      }
     } else if (this.storageKey) {
       handleStr.push(`at '${this.storageKey}'`);
     }
     // TODO(shans): there's a 'this.source' in StorageProviderBase which is sometimes
     // serialized here too - could it ever be part of StorageStub?
     results.push(handleStr.join(' '));
-    if (this.claims.length > 0) {
-      results.push(`  claim is ${this.claims.map(claim => claim.tag).join(' and is ')}`);
+    if (info.claims && info.claims.length > 0) {
+      results.push(`  claim is ${info.claims.map(claim => claim.tag).join(' and is ')}`);
     }
-    if (this.description) {
-      results.push(`  description \`${this.description}\``);
+    if (info.description) {
+      results.push(`  description \`${info.description}\``);
     }
     return results.join('\n');
   }
-
 }
 
 export interface UnifiedActiveStore {
@@ -156,6 +161,7 @@ export type StoreInfo = {
   readonly type: Type;
   readonly originalId?: string;
   readonly source?: string;
+  readonly origin?: 'file' | 'resource' | 'storage';
   readonly description?: string;
 
   /** Trust tags claimed by this data store. */

--- a/src/runtime/storageNG/unified-store.ts
+++ b/src/runtime/storageNG/unified-store.ts
@@ -111,7 +111,7 @@ export abstract class UnifiedStore implements Comparable<UnifiedStore>, OldStore
       handleStr.push(`@${this.version}`);
     }
     if (opts.handleTags && opts.handleTags.length) {
-      handleStr.push(`${opts.handleTags.join(' ')}`);
+      handleStr.push(`${opts.handleTags.map(tag => `#${tag}`).join(' ')}`);
     }
     if (info.source) {
       if (info.origin === 'file') {

--- a/src/runtime/tests/manifest-test.ts
+++ b/src/runtime/tests/manifest-test.ts
@@ -1682,8 +1682,8 @@ Expected a verb (e.g. &Verb) or an uppercase identifier (e.g. Foo) but "?" found
       assert.deepEqual(['wishlist'], manifest.storeTags.get(manifest.stores[0]));
     };
     verify(manifest);
-    assert.strictEqual(manifest.stores[0].toManifestString([]),
-                 (await Manifest.parse(manifest.stores[0].toManifestString([]), {loader})).toString());
+    assert.strictEqual(manifest.stores[0].toManifestString(),
+                 (await Manifest.parse(manifest.stores[0].toManifestString(), {loader})).toString());
     verify(await Manifest.parse(manifest.toString(), {loader}));
   });
   it('can parse a manifest containing resources', async () => {
@@ -2030,8 +2030,8 @@ resource SomeName
     const [validRecipe] = manifest.recipes;
     assert.isTrue(validRecipe.normalize());
     assert.isTrue(validRecipe.isResolved());
-    assert.strictEqual(manifest.stores[0].toManifestString([]),
-                 (await Manifest.parse(manifest.stores[0].toManifestString([]))).toString());
+    assert.strictEqual(manifest.stores[0].toManifestString(),
+                 (await Manifest.parse(manifest.stores[0].toManifestString())).toString());
   });
 
   it('can process a schema alias', async () => {


### PR DESCRIPTION
Now all serialisation of Stores goes through the
UnifiedStore.toManifestString function, rather than being so hodge-podge.