### PR TITLE
Aus recipe particle connection

### DIFF
--- a/src/planning/strategies/convert-constraints-to-connections.ts
+++ b/src/planning/strategies/convert-constraints-to-connections.ts
@@ -13,13 +13,13 @@ import {RecipeUtil, HandleRepr} from '../../runtime/recipe/recipe-util.js';
 import {Recipe} from '../../runtime/recipe/recipe.js';
 import {StrategizerWalker, Strategy, StrategyParams} from '../strategizer.js';
 import {ParticleSpec} from '../../runtime/particle-spec.js';
-import {reverseArrow} from '../../runtime/recipe/recipe-util.js';
-import {DirectionArrow} from '../../runtime/manifest-ast-nodes.js';
+import {reverseDirection} from '../../runtime/recipe/recipe-util.js';
+import {Direction} from '../../runtime/manifest-ast-nodes.js';
 import {Descendant} from '../../runtime/recipe/walker.js';
 import {Handle} from '../../runtime/recipe/handle.js';
 import {Dictionary} from '../../runtime/hot.js';
 
-type Obligation = {from: EndPoint, to: EndPoint, direction: DirectionArrow};
+type Obligation = {from: EndPoint, to: EndPoint, direction: Direction};
 
 export class ConvertConstraintsToConnections extends Strategy {
   async generate(inputParams: StrategyParams): Promise<Descendant<Recipe>[]> {
@@ -92,7 +92,7 @@ export class ConvertConstraintsToConnections extends Strategy {
             }
           }
           if (from instanceof HandleEndPoint) {
-            handle = {handle: nameForHandle(from.handle, handleNames), direction: reverseArrow(constraint.direction), localName: from.handle.localName};
+            handle = {handle: nameForHandle(from.handle, handleNames), direction: reverseDirection(constraint.direction), localName: from.handle.localName};
             handles.add(handle.handle);
           }
           if (to instanceof ParticleEndPoint) {
@@ -163,7 +163,7 @@ export class ConvertConstraintsToConnections extends Strategy {
             }
           }
 
-          direction = reverseArrow(constraint.direction);
+          direction = reverseDirection(constraint.direction);
           if (to instanceof ParticleEndPoint) {
             const connection = to.connection;
             if (connection) {

--- a/src/planning/strategies/tests/convert-constraints-to-connections-test.ts
+++ b/src/planning/strategies/tests/convert-constraints-to-connections-test.ts
@@ -17,7 +17,7 @@ import {ConvertConstraintsToConnections} from '../../strategies/convert-constrai
 import {InstanceEndPoint} from '../../../runtime/recipe/connection-constraint.js';
 import {ArcId} from '../../../runtime/id.js';
 
-import {withPreSlandlesSyntax} from '../../../runtime/manifest-ast-nodes.js';
+import {Flags} from '../../../runtime/flags.js';
 
 describe('ConvertConstraintsToConnections', () => {
   const newArc = (manifest: Manifest) => {
@@ -54,7 +54,7 @@ describe('ConvertConstraintsToConnections', () => {
 
   // TODO(jopra): Remove once slandles unification syntax is implemented.
   it('fills out an empty constraint', async () => {
-    withPreSlandlesSyntax(async () => {
+    Flags.withPreSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
       particle A
         inout S {} b
@@ -96,7 +96,7 @@ describe('ConvertConstraintsToConnections', () => {
 
   // TODO(jopra): Remove once slandles unification syntax is implemented.
   it('does not cause an input only handle to be created', async () => {
-    withPreSlandlesSyntax(async () => {
+    Flags.withPreSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
       schema S
       particle A
@@ -166,7 +166,7 @@ describe('ConvertConstraintsToConnections', () => {
 
   // TODO(jopra): Remove once slandles unification syntax is implemented.
   it('can create handle for input and output handle', async () => {
-    withPreSlandlesSyntax(async () => {
+    Flags.withPreSlandlesSyntax(async () => {
     const parseManifest = async (constraint1, constraint2) => await Manifest.parse(`
       schema S
       particle A
@@ -228,7 +228,7 @@ describe('ConvertConstraintsToConnections', () => {
 
   // TODO(jopra): Remove once slandles unification syntax is implemented.
   it('fills out a constraint, reusing a single particle', async () => {
-    withPreSlandlesSyntax(async () => {
+    Flags.withPreSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
       schema S
       particle A
@@ -281,7 +281,7 @@ describe('ConvertConstraintsToConnections', () => {
 
   // TODO(jopra): Remove once slandles unification syntax is implemented.
   it('fills out a constraint, reusing a single particle (2)', async () => {
-    withPreSlandlesSyntax(async () => {
+    Flags.withPreSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
       schema S
       particle A
@@ -335,7 +335,7 @@ describe('ConvertConstraintsToConnections', () => {
 
   // TODO(jopra): Remove once slandles unification syntax is implemented.
   it('fills out a constraint, reusing two particles', async () => {
-    withPreSlandlesSyntax(async () => {
+    Flags.withPreSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
       schema S
       particle A
@@ -392,7 +392,7 @@ describe('ConvertConstraintsToConnections', () => {
 
   // TODO(jopra): Remove once slandles unification syntax is implemented.
   it('fills out a constraint, reusing two particles and a handle', async () => {
-    withPreSlandlesSyntax(async () => {
+    Flags.withPreSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
       schema S
       particle A
@@ -451,7 +451,7 @@ describe('ConvertConstraintsToConnections', () => {
 
   // TODO(jopra): Remove once slandles unification syntax is implemented.
   it('fills out a constraint, reusing two particles and a handle (2)', async () => {
-    withPreSlandlesSyntax(async () => {
+    Flags.withPreSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
       schema S
       particle A
@@ -510,7 +510,7 @@ describe('ConvertConstraintsToConnections', () => {
 
   // TODO(jopra): Remove once slandles unification syntax is implemented.
   it('removes an already fulfilled constraint', async () => {
-    withPreSlandlesSyntax(async () => {
+    Flags.withPreSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
       schema S
       particle A
@@ -573,7 +573,7 @@ describe('ConvertConstraintsToConnections', () => {
 
   // TODO(jopra): Remove once slandles unification syntax is implemented.
   it('verifies modality', async () => {
-    withPreSlandlesSyntax(async () => {
+    Flags.withPreSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
       schema S
       particle A in 'A.js'
@@ -631,7 +631,7 @@ describe('ConvertConstraintsToConnections', () => {
 
   // TODO(jopra): Remove once slandles unification syntax is implemented.
   it('connects to handles', async () => {
-    withPreSlandlesSyntax(async () => {
+    Flags.withPreSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
       particle A
         out S {} o
@@ -682,7 +682,7 @@ describe('ConvertConstraintsToConnections', () => {
 
   // TODO(jopra): Remove once slandles unification syntax is implemented.
   it('connects existing particles to handles', async () => {
-    withPreSlandlesSyntax(async () => {
+    Flags.withPreSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
       particle A
         out S {} o
@@ -736,7 +736,7 @@ describe('ConvertConstraintsToConnections', () => {
 
   // TODO(jopra): Remove once slandles unification syntax is implemented.
   it(`doesn't attempt to duplicate existing handles to particles`, async () => {
-    withPreSlandlesSyntax(async () => {
+    Flags.withPreSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
       particle A
         out S {} o
@@ -795,7 +795,7 @@ describe('ConvertConstraintsToConnections', () => {
 
   // TODO(jopra): Remove once slandles unification syntax is implemented.
   it(`duplicates particles to get handle connections right`, async () => {
-    withPreSlandlesSyntax(async () => {
+    Flags.withPreSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
       particle A
         out S {} o
@@ -852,7 +852,7 @@ describe('ConvertConstraintsToConnections', () => {
 
   // TODO(jopra): Remove once slandles unification syntax is implemented.
   it('connects to tags', async () => {
-    withPreSlandlesSyntax(async () => {
+    Flags.withPreSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
     particle A
       out S {} o
@@ -905,7 +905,7 @@ describe('ConvertConstraintsToConnections', () => {
 
   // TODO(jopra): Remove once slandles unification syntax is implemented.
   it('connects existing particles to tags', async () => {
-    withPreSlandlesSyntax(async () => {
+    Flags.withPreSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
     particle A
       out S {} o
@@ -961,7 +961,7 @@ describe('ConvertConstraintsToConnections', () => {
 
   // TODO(jopra): Remove once slandles unification syntax is implemented.
   it(`doesn't attempt to duplicate existing connections to tags`, async () => {
-    withPreSlandlesSyntax(async () => {
+    Flags.withPreSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
     particle A
       out S {} o
@@ -1011,7 +1011,7 @@ describe('ConvertConstraintsToConnections', () => {
 
   // TODO(jopra): Remove once slandles unification syntax is implemented.
   it(`connects particles together when there's only one possible connection`, async () => {
-    withPreSlandlesSyntax(async () => {
+    Flags.withPreSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
     particle A
       out S {} o
@@ -1056,7 +1056,7 @@ describe('ConvertConstraintsToConnections', () => {
 
   // TODO(jopra): Remove once slandles unification syntax is implemented.
   it(`connects particles together when there's extra things that can't connect`, async () => {
-    withPreSlandlesSyntax(async () => {
+    Flags.withPreSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
     particle A
       out S {} o
@@ -1103,7 +1103,7 @@ describe('ConvertConstraintsToConnections', () => {
 
   // TODO(jopra): Remove once slandles unification syntax is implemented.
   it(`connects particles together with multiple connections`, async () => {
-    withPreSlandlesSyntax(async () => {
+    Flags.withPreSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
     particle A
       out S {} o

--- a/src/planning/strategies/tests/convert-constraints-to-connections-test.ts
+++ b/src/planning/strategies/tests/convert-constraints-to-connections-test.ts
@@ -29,7 +29,7 @@ describe('ConvertConstraintsToConnections', () => {
     });
   };
 
-  it('SLANDLES SYNTAX fills out an empty constraint', async () => {
+  it('SLANDLES SYNTAX fills out an empty constraint', Flags.withPostSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
       particle A
         inout S {} b
@@ -50,11 +50,10 @@ describe('ConvertConstraintsToConnections', () => {
     b: inout handle0
   C as particle1
     d: inout handle0`);
-  });
+  }));
 
   // TODO(jopra): Remove once slandles unification syntax is implemented.
-  it('fills out an empty constraint', async () => {
-    Flags.withPreSlandlesSyntax(async () => {
+  it('fills out an empty constraint', Flags.withPreSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
       particle A
         inout S {} b
@@ -75,10 +74,9 @@ describe('ConvertConstraintsToConnections', () => {
     b <-> handle0
   C as particle1
     d <-> handle0`);
-    });
-  });
+  }));
 
-  it('SLANDLES SYNTAX does not cause an input only handle to be created', async () => {
+  it('SLANDLES SYNTAX does not cause an input only handle to be created', Flags.withPostSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
       schema S
       particle A
@@ -92,11 +90,10 @@ describe('ConvertConstraintsToConnections', () => {
     const cctc = new ConvertConstraintsToConnections(newArc(manifest));
     const results = await cctc.generateFrom(generated);
     assert.isEmpty(results);
-  });
+  }));
 
   // TODO(jopra): Remove once slandles unification syntax is implemented.
-  it('does not cause an input only handle to be created', async () => {
-    Flags.withPreSlandlesSyntax(async () => {
+  it('does not cause an input only handle to be created', Flags.withPreSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
       schema S
       particle A
@@ -110,8 +107,7 @@ describe('ConvertConstraintsToConnections', () => {
     const cctc = new ConvertConstraintsToConnections(newArc(manifest));
     const results = await cctc.generateFrom(generated);
     assert.isEmpty(results);
-    });
-  });
+  }));
 
   it('can resolve input only handle connection with a mapped handle', async () => {
     const manifest = await Manifest.parse(`
@@ -130,7 +126,7 @@ describe('ConvertConstraintsToConnections', () => {
     assert.lengthOf(results, 1);
   });
 
-  it('SLANDLES SYNTAX can create handle for input and output handle', async () => {
+  it('SLANDLES SYNTAX can create handle for input and output handle', Flags.withPostSlandlesSyntax(async () => {
     const parseManifest = async (constraint1, constraint2) => await Manifest.parse(`
       schema S
       particle A
@@ -162,11 +158,10 @@ describe('ConvertConstraintsToConnections', () => {
         }
       }
     }
-  });
+  }));
 
   // TODO(jopra): Remove once slandles unification syntax is implemented.
-  it('can create handle for input and output handle', async () => {
-    Flags.withPreSlandlesSyntax(async () => {
+  it('can create handle for input and output handle', Flags.withPreSlandlesSyntax(async () => {
     const parseManifest = async (constraint1, constraint2) => await Manifest.parse(`
       schema S
       particle A
@@ -198,10 +193,9 @@ describe('ConvertConstraintsToConnections', () => {
         }
       }
     }
-    });
-  });
+  }));
 
-  it('SLANDLES SYNTAX fills out a constraint, reusing a single particle', async () => {
+  it('SLANDLES SYNTAX fills out a constraint, reusing a single particle', Flags.withPostSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
       schema S
       particle A
@@ -224,11 +218,10 @@ describe('ConvertConstraintsToConnections', () => {
     b: inout handle0
   C as particle1
     d: inout handle0`);
-  });
+  }));
 
   // TODO(jopra): Remove once slandles unification syntax is implemented.
-  it('fills out a constraint, reusing a single particle', async () => {
-    Flags.withPreSlandlesSyntax(async () => {
+  it('fills out a constraint, reusing a single particle', Flags.withPreSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
       schema S
       particle A
@@ -251,10 +244,9 @@ describe('ConvertConstraintsToConnections', () => {
     b <-> handle0
   C as particle1
     d <-> handle0`);
-    });
-  });
+  }));
 
-  it('SLANDLES SYNTAX fills out a constraint, reusing a single particle (2)', async () => {
+  it('SLANDLES SYNTAX fills out a constraint, reusing a single particle (2)', Flags.withPostSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
       schema S
       particle A
@@ -277,11 +269,10 @@ describe('ConvertConstraintsToConnections', () => {
     b: inout handle0
   C as particle1
     d: inout handle0`);
-  });
+  }));
 
   // TODO(jopra): Remove once slandles unification syntax is implemented.
-  it('fills out a constraint, reusing a single particle (2)', async () => {
-    Flags.withPreSlandlesSyntax(async () => {
+  it('fills out a constraint, reusing a single particle (2)', Flags.withPreSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
       schema S
       particle A
@@ -304,10 +295,9 @@ describe('ConvertConstraintsToConnections', () => {
     b <-> handle0
   C as particle1
     d <-> handle0`);
-    });
-  });
+  }));
 
-  it('SLANDLES SYNTAX fills out a constraint, reusing two particles', async () => {
+  it('SLANDLES SYNTAX fills out a constraint, reusing two particles', Flags.withPostSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
       schema S
       particle A
@@ -331,11 +321,10 @@ describe('ConvertConstraintsToConnections', () => {
     b: inout handle0
   C as particle1
     d: inout handle0`);
-  });
+  }));
 
   // TODO(jopra): Remove once slandles unification syntax is implemented.
-  it('fills out a constraint, reusing two particles', async () => {
-    Flags.withPreSlandlesSyntax(async () => {
+  it('fills out a constraint, reusing two particles', Flags.withPreSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
       schema S
       particle A
@@ -359,10 +348,9 @@ describe('ConvertConstraintsToConnections', () => {
     b <-> handle0
   C as particle1
     d <-> handle0`);
-    });
-  });
+  }));
 
-  it('SLANDLES SYNTAX fills out a constraint, reusing two particles and a handle', async () => {
+  it('SLANDLES SYNTAX fills out a constraint, reusing two particles and a handle', Flags.withPostSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
       schema S
       particle A
@@ -388,11 +376,10 @@ describe('ConvertConstraintsToConnections', () => {
     b: inout handle0
   C as particle1
     d: inout handle0`);
-  });
+  }));
 
   // TODO(jopra): Remove once slandles unification syntax is implemented.
-  it('fills out a constraint, reusing two particles and a handle', async () => {
-    Flags.withPreSlandlesSyntax(async () => {
+  it('fills out a constraint, reusing two particles and a handle', Flags.withPreSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
       schema S
       particle A
@@ -418,10 +405,9 @@ describe('ConvertConstraintsToConnections', () => {
     b <-> handle0
   C as particle1
     d <-> handle0`);
-    });
-  });
+  }));
 
-  it('SLANDLES SYNTAX fills out a constraint, reusing two particles and a handle (2)', async () => {
+  it('SLANDLES SYNTAX fills out a constraint, reusing two particles and a handle (2)', Flags.withPostSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
       schema S
       particle A
@@ -447,11 +433,10 @@ describe('ConvertConstraintsToConnections', () => {
     b: inout handle0
   C as particle1
     d: inout handle0`);
-  });
+  }));
 
   // TODO(jopra): Remove once slandles unification syntax is implemented.
-  it('fills out a constraint, reusing two particles and a handle (2)', async () => {
-    Flags.withPreSlandlesSyntax(async () => {
+  it('fills out a constraint, reusing two particles and a handle (2)', Flags.withPreSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
       schema S
       particle A
@@ -477,10 +462,9 @@ describe('ConvertConstraintsToConnections', () => {
     b <-> handle0
   C as particle1
     d <-> handle0`);
-    });
-  });
+  }));
 
-  it('SLANDLES SYNTAX removes an already fulfilled constraint', async () => {
+  it('SLANDLES SYNTAX removes an already fulfilled constraint', Flags.withPostSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
       schema S
       particle A
@@ -506,11 +490,10 @@ describe('ConvertConstraintsToConnections', () => {
     b: inout handle0
   C as particle1
     d: inout handle0`);
-  });
+  }));
 
   // TODO(jopra): Remove once slandles unification syntax is implemented.
-  it('removes an already fulfilled constraint', async () => {
-    Flags.withPreSlandlesSyntax(async () => {
+  it('removes an already fulfilled constraint', Flags.withPreSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
       schema S
       particle A
@@ -536,10 +519,9 @@ describe('ConvertConstraintsToConnections', () => {
     b <-> handle0
   C as particle1
     d <-> handle0`);
-    });
-  });
+  }));
 
-  it('SLANDLES SYNTAX verifies modality', async () => {
+  it('SLANDLES SYNTAX verifies modality', Flags.withPostSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
       schema S
       particle A in 'A.js'
@@ -569,11 +551,10 @@ describe('ConvertConstraintsToConnections', () => {
     const results = await cctc.generateFrom(generated);
     assert.lengthOf(results, 1);
     assert.deepEqual(results[0].result.particles.map(p => p.name), ['A', 'C']);
-  });
+  }));
 
   // TODO(jopra): Remove once slandles unification syntax is implemented.
-  it('verifies modality', async () => {
-    Flags.withPreSlandlesSyntax(async () => {
+  it('verifies modality', Flags.withPreSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
       schema S
       particle A in 'A.js'
@@ -603,10 +584,9 @@ describe('ConvertConstraintsToConnections', () => {
     const results = await cctc.generateFrom(generated);
     assert.lengthOf(results, 1);
     assert.deepEqual(results[0].result.particles.map(p => p.name), ['A', 'C']);
-    });
-  });
+  }));
 
-  it('SLANDLES SYNTAX connects to handles', async () => {
+  it('SLANDLES SYNTAX connects to handles', Flags.withPostSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
       particle A
         out S {} o
@@ -627,11 +607,10 @@ describe('ConvertConstraintsToConnections', () => {
     o: out handle0
   B as particle1
     i: in handle0`);
-  });
+  }));
 
   // TODO(jopra): Remove once slandles unification syntax is implemented.
-  it('connects to handles', async () => {
-    Flags.withPreSlandlesSyntax(async () => {
+  it('connects to handles', Flags.withPreSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
       particle A
         out S {} o
@@ -652,10 +631,9 @@ describe('ConvertConstraintsToConnections', () => {
     o -> handle0
   B as particle1
     i <- handle0`);
-    });
-  });
+  }));
 
-  it('SLANDLES SYNTAX connects existing particles to handles', async () => {
+  it('SLANDLES SYNTAX connects existing particles to handles', Flags.withPostSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
       particle A
         out S {} o
@@ -678,11 +656,10 @@ describe('ConvertConstraintsToConnections', () => {
     o: out handle0
   B as particle1
     i: in handle0`);
-  });
+  }));
 
   // TODO(jopra): Remove once slandles unification syntax is implemented.
-  it('connects existing particles to handles', async () => {
-    Flags.withPreSlandlesSyntax(async () => {
+  it('connects existing particles to handles', Flags.withPreSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
       particle A
         out S {} o
@@ -705,10 +682,9 @@ describe('ConvertConstraintsToConnections', () => {
     o -> handle0
   B as particle1
     i <- handle0`);
-    });
-  });
+  }));
 
-  it(`SLANDLES SYNTAX doesn't attempt to duplicate existing handles to particles`, async () => {
+  it(`SLANDLES SYNTAX doesn't attempt to duplicate existing handles to particles`, Flags.withPostSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
       particle A
         out S {} o
@@ -732,11 +708,10 @@ describe('ConvertConstraintsToConnections', () => {
     o: out handle0
   B as particle1
     i: in handle0`);
-  });
+  }));
 
   // TODO(jopra): Remove once slandles unification syntax is implemented.
-  it(`doesn't attempt to duplicate existing handles to particles`, async () => {
-    Flags.withPreSlandlesSyntax(async () => {
+  it(`doesn't attempt to duplicate existing handles to particles`, Flags.withPreSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
       particle A
         out S {} o
@@ -760,10 +735,9 @@ describe('ConvertConstraintsToConnections', () => {
     o -> handle0
   B as particle1
     i <- handle0`);
-    });
-  });
+  }));
 
-  it(`SLANDLES SYNTAX duplicates particles to get handle connections right`, async () => {
+  it(`SLANDLES SYNTAX duplicates particles to get handle connections right`, Flags.withPostSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
       particle A
         out S {} o
@@ -791,11 +765,10 @@ describe('ConvertConstraintsToConnections', () => {
     o: out handle1
   B as particle2
     i: in handle1`);
-  });
+  }));
 
   // TODO(jopra): Remove once slandles unification syntax is implemented.
-  it(`duplicates particles to get handle connections right`, async () => {
-    Flags.withPreSlandlesSyntax(async () => {
+  it(`duplicates particles to get handle connections right`, Flags.withPreSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
       particle A
         out S {} o
@@ -823,10 +796,9 @@ describe('ConvertConstraintsToConnections', () => {
     o -> handle1
   B as particle2
     i <- handle1`);
-    });
-  });
+  }));
 
-  it('SLANDLES SYNTAX connects to tags', async () => {
+  it('SLANDLES SYNTAX connects to tags', Flags.withPostSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
     particle A
       out S {} o
@@ -848,11 +820,10 @@ describe('ConvertConstraintsToConnections', () => {
     o: out handle0
   B as particle1
     i: out handle1`);
-  });
+  }));
 
   // TODO(jopra): Remove once slandles unification syntax is implemented.
-  it('connects to tags', async () => {
-    Flags.withPreSlandlesSyntax(async () => {
+  it('connects to tags', Flags.withPreSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
     particle A
       out S {} o
@@ -874,10 +845,9 @@ describe('ConvertConstraintsToConnections', () => {
     o -> handle0
   B as particle1
     i -> handle1`);
-    });
-  });
+  }));
 
-  it('SLANDLE SYNTAX connects existing particles to tags', async () => {
+  it('SLANDLE SYNTAX connects existing particles to tags', Flags.withPostSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
     particle A
       out S {} o
@@ -901,11 +871,10 @@ describe('ConvertConstraintsToConnections', () => {
     o: out handle0
   B as particle1
     i: out handle1`);
-  });
+  }));
 
   // TODO(jopra): Remove once slandles unification syntax is implemented.
-  it('connects existing particles to tags', async () => {
-    Flags.withPreSlandlesSyntax(async () => {
+  it('connects existing particles to tags', Flags.withPreSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
     particle A
       out S {} o
@@ -929,10 +898,9 @@ describe('ConvertConstraintsToConnections', () => {
     o -> handle0
   B as particle1
     i -> handle1`);
-    });
-  });
+  }));
 
-  it(`SLANDLES SYNTAX doesn't attempt to duplicate existing connections to tags`, async () => {
+  it(`SLANDLES SYNTAX doesn't attempt to duplicate existing connections to tags`, Flags.withPostSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
     particle A
       out S {} o
@@ -957,11 +925,10 @@ describe('ConvertConstraintsToConnections', () => {
     o: out handle0
   B as particle1
     i: out handle0`);
-  });
+  }));
 
   // TODO(jopra): Remove once slandles unification syntax is implemented.
-  it(`doesn't attempt to duplicate existing connections to tags`, async () => {
-    Flags.withPreSlandlesSyntax(async () => {
+  it(`doesn't attempt to duplicate existing connections to tags`, Flags.withPreSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
     particle A
       out S {} o
@@ -986,10 +953,9 @@ describe('ConvertConstraintsToConnections', () => {
     o -> handle0
   B as particle1
     i -> handle0`);
-    });
-  });
+  }));
 
-  it(`SLANDLES SYNTAX connects particles together when there's only one possible connection`, async () => {
+  it(`SLANDLES SYNTAX connects particles together when there's only one possible connection`, Flags.withPostSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
     particle A
       out S {} o
@@ -1007,11 +973,10 @@ describe('ConvertConstraintsToConnections', () => {
     assert.lengthOf(recipe.obligations, 1);
     assert.strictEqual((recipe.obligations[0].from as InstanceEndPoint).instance, recipe.particles[0]);
     assert.strictEqual((recipe.obligations[0].to as InstanceEndPoint).instance, recipe.particles[1]);
-  });
+  }));
 
   // TODO(jopra): Remove once slandles unification syntax is implemented.
-  it(`connects particles together when there's only one possible connection`, async () => {
-    Flags.withPreSlandlesSyntax(async () => {
+  it(`connects particles together when there's only one possible connection`, Flags.withPreSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
     particle A
       out S {} o
@@ -1029,10 +994,9 @@ describe('ConvertConstraintsToConnections', () => {
     assert.lengthOf(recipe.obligations, 1);
     assert.strictEqual((recipe.obligations[0].from as InstanceEndPoint).instance, recipe.particles[0]);
     assert.strictEqual((recipe.obligations[0].to as InstanceEndPoint).instance, recipe.particles[1]);
-    });
-  });
+  }));
 
-  it(`SLANDLES SYNTAX connects particles together when there's extra things that can't connect`, async () => {
+  it(`SLANDLES SYNTAX connects particles together when there's extra things that can't connect`, Flags.withPostSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
     particle A
       out S {} o
@@ -1052,11 +1016,10 @@ describe('ConvertConstraintsToConnections', () => {
     assert.lengthOf(recipe.obligations, 1);
     assert.strictEqual((recipe.obligations[0].from as InstanceEndPoint).instance, recipe.particles[0]);
     assert.strictEqual((recipe.obligations[0].to as InstanceEndPoint).instance, recipe.particles[1]);
-  });
+  }));
 
   // TODO(jopra): Remove once slandles unification syntax is implemented.
-  it(`connects particles together when there's extra things that can't connect`, async () => {
-    Flags.withPreSlandlesSyntax(async () => {
+  it(`connects particles together when there's extra things that can't connect`, Flags.withPreSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
     particle A
       out S {} o
@@ -1076,10 +1039,9 @@ describe('ConvertConstraintsToConnections', () => {
     assert.lengthOf(recipe.obligations, 1);
     assert.strictEqual((recipe.obligations[0].from as InstanceEndPoint).instance, recipe.particles[0]);
     assert.strictEqual((recipe.obligations[0].to as InstanceEndPoint).instance, recipe.particles[1]);
-    });
-  });
+  }));
 
-  it(`SLANDLES SYNTAX connects particles together with multiple connections`, async () => {
+  it(`SLANDLES SYNTAX connects particles together with multiple connections`, Flags.withPostSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
     particle A
       out S {} o
@@ -1099,11 +1061,10 @@ describe('ConvertConstraintsToConnections', () => {
     assert.lengthOf(recipe.obligations, 1);
     assert.strictEqual((recipe.obligations[0].from as InstanceEndPoint).instance, recipe.particles[0]);
     assert.strictEqual((recipe.obligations[0].to as InstanceEndPoint).instance, recipe.particles[1]);
-  });
+  }));
 
   // TODO(jopra): Remove once slandles unification syntax is implemented.
-  it(`connects particles together with multiple connections`, async () => {
-    Flags.withPreSlandlesSyntax(async () => {
+  it(`connects particles together with multiple connections`, Flags.withPreSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
     particle A
       out S {} o
@@ -1123,6 +1084,5 @@ describe('ConvertConstraintsToConnections', () => {
     assert.lengthOf(recipe.obligations, 1);
     assert.strictEqual((recipe.obligations[0].from as InstanceEndPoint).instance, recipe.particles[0]);
     assert.strictEqual((recipe.obligations[0].to as InstanceEndPoint).instance, recipe.particles[1]);
-    });
-  });
+  }));
 });

--- a/src/planning/strategies/tests/match-recipe-by-verb-test.ts
+++ b/src/planning/strategies/tests/match-recipe-by-verb-test.ts
@@ -15,8 +15,41 @@ import {MatchRecipeByVerb} from '../../strategies/match-recipe-by-verb.js';
 
 import {StrategyTestHelper} from '../../testing/strategy-test-helper.js';
 
+import {withPreSlandlesSyntax} from '../../../runtime/manifest-ast-nodes.js';
+
 describe('MatchRecipeByVerb', () => {
+  it('SLANDLES SYNTAX removes a particle and adds a recipe', async () => {
+    const manifest = await Manifest.parse(`
+      recipe
+        &jump
+
+      schema Feet
+      schema Energy
+
+      particle JumpingBoots in 'A.js'
+        in Feet f
+        in Energy e
+      particle FootFactory in 'B.js'
+        out Feet f
+      particle NuclearReactor in 'C.js'
+        out Energy e
+
+      recipe &jump
+        JumpingBoots.f: in FootFactory.f
+        JumpingBoots.e: in NuclearReactor.e
+    `);
+    const arc = StrategyTestHelper.createTestArc(manifest);
+    const generated = [{result: manifest.recipes[0], score: 1}];
+    const mrv = new MatchRecipeByVerb(arc);
+    const results = await mrv.generateFrom(generated);
+    assert.lengthOf(results, 1);
+    assert.isEmpty(results[0].result.particles);
+    assert.deepEqual(results[0].result.toString(), 'recipe &jump\n  JumpingBoots.e: in NuclearReactor.e\n  JumpingBoots.f: in FootFactory.f');
+  });
+
+  // TODO(jopra): Remove once slandles unification syntax is implemented.
   it('removes a particle and adds a recipe', async () => {
+    withPreSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
       recipe
         &jump
@@ -44,8 +77,45 @@ describe('MatchRecipeByVerb', () => {
     assert.lengthOf(results, 1);
     assert.isEmpty(results[0].result.particles);
     assert.deepEqual(results[0].result.toString(), 'recipe &jump\n  JumpingBoots.e <- NuclearReactor.e\n  JumpingBoots.f <- FootFactory.f');
+    });
   });
+
+  it('SLANDLES SYNTAX plays nicely with constraints', async () => {
+    const manifest = await Manifest.parse(`
+      schema S
+      particle P in 'A.js'
+        out S p
+      particle Q in 'B.js'
+        in S q
+
+      recipe
+        P.p: out Q.q
+        &a
+
+      recipe &a
+        P
+    `);
+
+    const arc = StrategyTestHelper.createTestArc(manifest);
+    const generated = [{result: manifest.recipes[0], score: 1}];
+    const mrv = new MatchRecipeByVerb(arc);
+    let results = await mrv.generateFrom(generated);
+    assert.lengthOf(results, 1);
+    const cctc = new ConvertConstraintsToConnections(arc);
+    results = await cctc.generateFrom(results);
+    assert.lengthOf(results, 1);
+    assert.deepEqual(results[0].result.toString(),
+`recipe &a
+  create as handle0 // S {}
+  P as particle0
+    p: out handle0
+  Q as particle1
+    q: in handle0`);
+  });
+
+  // TODO(jopra): Remove once slandles unification syntax is implemented.
   it('plays nicely with constraints', async () => {
+    withPreSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
       schema S
       particle P in 'A.js'
@@ -76,6 +146,7 @@ describe('MatchRecipeByVerb', () => {
     p -> handle0
   Q as particle1
     q <- handle0`);
+    });
   });
 
   const basicHandlesContraintsManifest = `
@@ -113,12 +184,25 @@ ${recipesManifest}`);
 
   it('listens to handle constraints - all recipes', async () => {
     const results = await generatePlans(`
-      recipe 
+      recipe
         &verb`);
     assert.lengthOf(results, 4);
   });
 
+  it('SLANDLES SYNTAX listens to handle constraints - out connection', async () => {
+    const results = await generatePlans(`
+      recipe
+        &verb
+          a: out`);
+    assert.lengthOf(results, 2);
+    assert.lengthOf(results[0].result.particles, 1);
+    assert.strictEqual(results[0].result.particles[0].name, 'P');
+    assert.lengthOf(results[1].result.particles, 2);
+  });
+
+  // TODO(jopra): Remove once slandles unification syntax is implemented.
   it('listens to handle constraints - out connection', async () => {
+    withPreSlandlesSyntax(async () => {
     const results = await generatePlans(`
       recipe
         &verb
@@ -127,20 +211,50 @@ ${recipesManifest}`);
     assert.lengthOf(results[0].result.particles, 1);
     assert.strictEqual(results[0].result.particles[0].name, 'P');
     assert.lengthOf(results[1].result.particles, 2);
+    });
   });
 
-  it('listens to handle constraints - in connection', async () => {
+  it('SLANDLES SYNTAX listens to handle constraints - in connection', async () => {
     const results = await generatePlans(`
-      recipe 
+      recipe
         &verb
-          a <-`);
+          a: in`);
     assert.lengthOf(results, 2);
     assert.lengthOf(results[1].result.particles, 1);
     assert.strictEqual(results[1].result.particles[0].name, 'Q');
     assert.lengthOf(results[0].result.particles, 2);
   });
 
+  // TODO(jopra): Remove once slandles unification syntax is implemented.
+  it('listens to handle constraints - in connection', async () => {
+    withPreSlandlesSyntax(async () => {
+    const results = await generatePlans(`
+      recipe
+        &verb
+          a <-`);
+    assert.lengthOf(results, 2);
+    assert.lengthOf(results[1].result.particles, 1);
+    assert.strictEqual(results[1].result.particles[0].name, 'Q');
+    assert.lengthOf(results[0].result.particles, 2);
+    });
+  });
+
+  it('SLANDLES SYNTAX listens to handle constraints - both connection', async () => {
+    const results = await generatePlans(`
+      recipe
+        &verb
+          a: in
+          b: out
+      `);
+    assert.lengthOf(results, 2);
+    assert.lengthOf(results[1].result.particles, 1);
+    assert.strictEqual(results[1].result.particles[0].name, 'Q');
+    assert.lengthOf(results[0].result.particles, 2);
+  });
+
+  // TODO(jopra): Remove once slandles unification syntax is implemented.
   it('listens to handle constraints - both connection', async () => {
+    withPreSlandlesSyntax(async () => {
     const results = await generatePlans(`
       recipe
         &verb
@@ -151,8 +265,22 @@ ${recipesManifest}`);
     assert.lengthOf(results[1].result.particles, 1);
     assert.strictEqual(results[1].result.particles[0].name, 'Q');
     assert.lengthOf(results[0].result.particles, 2);
+    });
   });
+
+  it('SLANDLES SYNTAX listens to handle constraints - handle', async () => {
+    const results = await generatePlans(`
+      recipe
+        create as handle0
+        &verb
+          *: out handle0
+      `);
+    assert.lengthOf(results, 3);
+    assert.deepEqual([['P'], ['P', 'Q'], ['Q']], results.map(r => r.result.particles.map(p => p.name)));
+  });
+  // TODO(jopra): Remove once slandles unification syntax is implemented.
   it('listens to handle constraints - handle', async () => {
+    withPreSlandlesSyntax(async () => {
     const results = await generatePlans(`
       recipe
         create as handle0
@@ -161,13 +289,14 @@ ${recipesManifest}`);
       `);
     assert.lengthOf(results, 3);
     assert.deepEqual([['P'], ['P', 'Q'], ['Q']], results.map(r => r.result.particles.map(p => p.name)));
+    });
   });
   it('listens to slot constraints', async () => {
     const manifest = await Manifest.parse(`
       particle P in 'A.js'
         consume foo
           provide bar
-    
+
       particle Q in 'B.js'
         consume boo
           provide far
@@ -215,12 +344,44 @@ ${recipesManifest}`);
     assert.strictEqual(results[0].result.particles[0].name, 'P');
     assert.lengthOf(results[1].result.particles, 2);
   });
-  it('carries handle assignments across verb substitution', async () => {
+  it('SLANDLES SYNTAX carries handle assignments across verb substitution', async () => {
     const manifest = await Manifest.parse(`
-    
+
       particle P in 'A.js'
         in S {} a
-      
+
+      particle Q in 'B.js'
+        out S {} b
+
+      recipe &verb
+        P
+
+      recipe
+        create as handle0
+        &verb
+          a: in handle0
+        Q
+          b: out handle0
+    `);
+
+    const arc = StrategyTestHelper.createTestArc(manifest);
+    const generated = [{result: manifest.recipes[1], score: 1}];
+    const mrv = new MatchRecipeByVerb(arc);
+    const results = await mrv.generateFrom(generated);
+    assert.lengthOf(results, 1);
+    const recipe = results[0].result;
+    assert.strictEqual(recipe.particles[0].connections.a.handle, recipe.particles[1].connections.b.handle);
+    assert.strictEqual(recipe.particles[0].connections.a.handle.connections[0].particle, recipe.particles[0]);
+    assert.strictEqual(recipe.particles[1].connections.b.handle.connections[1].particle, recipe.particles[1]);
+  });
+  // TODO(jopra): Remove once slandles unification syntax is implemented.
+  it('carries handle assignments across verb substitution', async () => {
+    withPreSlandlesSyntax(async () => {
+    const manifest = await Manifest.parse(`
+
+      particle P in 'A.js'
+        in S {} a
+
       particle Q in 'B.js'
         out S {} b
 
@@ -244,13 +405,46 @@ ${recipesManifest}`);
     assert.strictEqual(recipe.particles[0].connections.a.handle, recipe.particles[1].connections.b.handle);
     assert.strictEqual(recipe.particles[0].connections.a.handle.connections[0].particle, recipe.particles[0]);
     assert.strictEqual(recipe.particles[1].connections.b.handle.connections[1].particle, recipe.particles[1]);
+    });
   });
-  it('carries handle assignments across verb substitution with generic binding', async () => {
+  it('SLANDLES SYNTAX carries handle assignments across verb substitution with generic binding', async () => {
     const manifest = await Manifest.parse(`
-    
+
       particle P in 'A.js'
         in S {} a
-      
+
+      particle Q in 'B.js'
+        out S {} b
+
+      recipe &verb
+        P
+
+      recipe
+        create as handle0
+        &verb
+          *: in handle0
+        Q
+          b: out handle0
+    `);
+
+    const arc = StrategyTestHelper.createTestArc(manifest);
+    const generated = [{result: manifest.recipes[1], score: 1}];
+    const mrv = new MatchRecipeByVerb(arc);
+    const results = await mrv.generateFrom(generated);
+    assert.lengthOf(results, 1);
+    const recipe = results[0].result;
+    assert.strictEqual(recipe.particles[0].connections.a.handle, recipe.particles[1].connections.b.handle);
+    assert.strictEqual(recipe.particles[0].connections.a.handle.connections[0].particle, recipe.particles[0]);
+    assert.strictEqual(recipe.particles[1].connections.b.handle.connections[1].particle, recipe.particles[1]);
+  });
+  // TODO(jopra): Remove once slandles unification syntax is implemented.
+  it('carries handle assignments across verb substitution with generic binding', async () => {
+    withPreSlandlesSyntax(async () => {
+    const manifest = await Manifest.parse(`
+
+      particle P in 'A.js'
+        in S {} a
+
       particle Q in 'B.js'
         out S {} b
 
@@ -274,10 +468,12 @@ ${recipesManifest}`);
     assert.strictEqual(recipe.particles[0].connections.a.handle, recipe.particles[1].connections.b.handle);
     assert.strictEqual(recipe.particles[0].connections.a.handle.connections[0].particle, recipe.particles[0]);
     assert.strictEqual(recipe.particles[1].connections.b.handle.connections[1].particle, recipe.particles[1]);
+    });
   });
-  it('selects the appropriate generic binding when handle assignments carry type information', async () => {
+
+  it('SLANDLES SYNTAX selects the appropriate generic binding when handle assignments carry type information', async () => {
     const manifest = await Manifest.parse(`
-    
+
       particle O in 'Z.js'
         in R {} x
         out S {} y
@@ -286,7 +482,49 @@ ${recipesManifest}`);
         in R {} x
         out S {} y
         in S {} a
-      
+
+      particle Q in 'B.js'
+        out S {} b
+
+      recipe &verb
+        O
+        P
+
+      recipe
+        create as handle0
+        &verb
+          *: in handle0
+        Q
+          b: out handle0
+    `);
+
+    const arc = StrategyTestHelper.createTestArc(manifest);
+    const generated = [{result: manifest.recipes[1], score: 1}];
+    const mrv = new MatchRecipeByVerb(arc);
+    const results = await mrv.generateFrom(generated);
+    assert.lengthOf(results, 1);
+    const recipe = results[0].result;
+    const particleP = recipe.particles.find(p => p.name === 'P');
+    const particleQ = recipe.particles.find(p => p.name === 'Q');
+    assert.strictEqual(particleP.connections.a.handle, particleQ.connections.b.handle);
+    assert.strictEqual(particleP.connections.a.handle.connections[0].particle, particleP);
+    assert.strictEqual(particleQ.connections.b.handle.connections[1].particle, particleQ);
+  });
+
+  // TODO(jopra): Remove once slandles unification syntax is implemented.
+  it('selects the appropriate generic binding when handle assignments carry type information', async () => {
+    withPreSlandlesSyntax(async () => {
+    const manifest = await Manifest.parse(`
+
+      particle O in 'Z.js'
+        in R {} x
+        out S {} y
+
+      particle P in 'A.js'
+        in R {} x
+        out S {} y
+        in S {} a
+
       particle Q in 'B.js'
         out S {} b
 
@@ -313,12 +551,13 @@ ${recipesManifest}`);
     assert.strictEqual(particleP.connections.a.handle, particleQ.connections.b.handle);
     assert.strictEqual(particleP.connections.a.handle.connections[0].particle, particleP);
     assert.strictEqual(particleQ.connections.b.handle.connections[1].particle, particleQ);
+    });
   });
   it('carries slot assignments across verb substitution', async () => {
     const manifest = await Manifest.parse(`
       particle P in 'A.js'
         consume foo
-          provide bar  
+          provide bar
 
       particle S in 'B.js'
         consume bar
@@ -326,7 +565,7 @@ ${recipesManifest}`);
 
       recipe &verb
         P
-    
+
       recipe
         &verb
           consume foo
@@ -365,7 +604,7 @@ ${recipesManifest}`);
     const manifest = await Manifest.parse(`
     particle P in 'A.js'
       consume foo
-        provide bar  
+        provide bar
 
     particle S in 'B.js'
       consume bar
@@ -377,7 +616,7 @@ ${recipesManifest}`);
 
     recipe &verb
       P
-  
+
     recipe
       &verb
         consume foo

--- a/src/planning/strategies/tests/match-recipe-by-verb-test.ts
+++ b/src/planning/strategies/tests/match-recipe-by-verb-test.ts
@@ -18,7 +18,7 @@ import {StrategyTestHelper} from '../../testing/strategy-test-helper.js';
 import {Flags} from '../../../runtime/flags.js';
 
 describe('MatchRecipeByVerb', () => {
-  it('SLANDLES SYNTAX removes a particle and adds a recipe', async () => {
+  it('SLANDLES SYNTAX removes a particle and adds a recipe', Flags.withPostSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
       recipe
         &jump
@@ -45,11 +45,10 @@ describe('MatchRecipeByVerb', () => {
     assert.lengthOf(results, 1);
     assert.isEmpty(results[0].result.particles);
     assert.deepEqual(results[0].result.toString(), 'recipe &jump\n  JumpingBoots.e: in NuclearReactor.e\n  JumpingBoots.f: in FootFactory.f');
-  });
+  }));
 
   // TODO(jopra): Remove once slandles unification syntax is implemented.
-  it('removes a particle and adds a recipe', async () => {
-    Flags.withPreSlandlesSyntax(async () => {
+  it('removes a particle and adds a recipe', Flags.withPreSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
       recipe
         &jump
@@ -77,10 +76,9 @@ describe('MatchRecipeByVerb', () => {
     assert.lengthOf(results, 1);
     assert.isEmpty(results[0].result.particles);
     assert.deepEqual(results[0].result.toString(), 'recipe &jump\n  JumpingBoots.e <- NuclearReactor.e\n  JumpingBoots.f <- FootFactory.f');
-    });
-  });
+  }));
 
-  it('SLANDLES SYNTAX plays nicely with constraints', async () => {
+  it('SLANDLES SYNTAX plays nicely with constraints', Flags.withPostSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
       schema S
       particle P in 'A.js'
@@ -111,11 +109,10 @@ describe('MatchRecipeByVerb', () => {
     p: out handle0
   Q as particle1
     q: in handle0`);
-  });
+  }));
 
   // TODO(jopra): Remove once slandles unification syntax is implemented.
-  it('plays nicely with constraints', async () => {
-    Flags.withPreSlandlesSyntax(async () => {
+  it('plays nicely with constraints', Flags.withPreSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
       schema S
       particle P in 'A.js'
@@ -146,8 +143,7 @@ describe('MatchRecipeByVerb', () => {
     p -> handle0
   Q as particle1
     q <- handle0`);
-    });
-  });
+  }));
 
   const basicHandlesContraintsManifest = `
       particle P in 'A.js'
@@ -189,7 +185,7 @@ ${recipesManifest}`);
     assert.lengthOf(results, 4);
   });
 
-  it('SLANDLES SYNTAX listens to handle constraints - out connection', async () => {
+  it('SLANDLES SYNTAX listens to handle constraints - out connection', Flags.withPostSlandlesSyntax(async () => {
     const results = await generatePlans(`
       recipe
         &verb
@@ -198,11 +194,10 @@ ${recipesManifest}`);
     assert.lengthOf(results[0].result.particles, 1);
     assert.strictEqual(results[0].result.particles[0].name, 'P');
     assert.lengthOf(results[1].result.particles, 2);
-  });
+  }));
 
   // TODO(jopra): Remove once slandles unification syntax is implemented.
-  it('listens to handle constraints - out connection', async () => {
-    Flags.withPreSlandlesSyntax(async () => {
+  it('listens to handle constraints - out connection', Flags.withPreSlandlesSyntax(async () => {
     const results = await generatePlans(`
       recipe
         &verb
@@ -211,10 +206,9 @@ ${recipesManifest}`);
     assert.lengthOf(results[0].result.particles, 1);
     assert.strictEqual(results[0].result.particles[0].name, 'P');
     assert.lengthOf(results[1].result.particles, 2);
-    });
-  });
+  }));
 
-  it('SLANDLES SYNTAX listens to handle constraints - in connection', async () => {
+  it('SLANDLES SYNTAX listens to handle constraints - in connection', Flags.withPostSlandlesSyntax(async () => {
     const results = await generatePlans(`
       recipe
         &verb
@@ -223,11 +217,10 @@ ${recipesManifest}`);
     assert.lengthOf(results[1].result.particles, 1);
     assert.strictEqual(results[1].result.particles[0].name, 'Q');
     assert.lengthOf(results[0].result.particles, 2);
-  });
+  }));
 
   // TODO(jopra): Remove once slandles unification syntax is implemented.
-  it('listens to handle constraints - in connection', async () => {
-    Flags.withPreSlandlesSyntax(async () => {
+  it('listens to handle constraints - in connection', Flags.withPreSlandlesSyntax(async () => {
     const results = await generatePlans(`
       recipe
         &verb
@@ -236,10 +229,9 @@ ${recipesManifest}`);
     assert.lengthOf(results[1].result.particles, 1);
     assert.strictEqual(results[1].result.particles[0].name, 'Q');
     assert.lengthOf(results[0].result.particles, 2);
-    });
-  });
+  }));
 
-  it('SLANDLES SYNTAX listens to handle constraints - both connection', async () => {
+  it('SLANDLES SYNTAX listens to handle constraints - both connection', Flags.withPostSlandlesSyntax(async () => {
     const results = await generatePlans(`
       recipe
         &verb
@@ -250,11 +242,10 @@ ${recipesManifest}`);
     assert.lengthOf(results[1].result.particles, 1);
     assert.strictEqual(results[1].result.particles[0].name, 'Q');
     assert.lengthOf(results[0].result.particles, 2);
-  });
+  }));
 
   // TODO(jopra): Remove once slandles unification syntax is implemented.
-  it('listens to handle constraints - both connection', async () => {
-    Flags.withPreSlandlesSyntax(async () => {
+  it('listens to handle constraints - both connection', Flags.withPreSlandlesSyntax(async () => {
     const results = await generatePlans(`
       recipe
         &verb
@@ -265,10 +256,9 @@ ${recipesManifest}`);
     assert.lengthOf(results[1].result.particles, 1);
     assert.strictEqual(results[1].result.particles[0].name, 'Q');
     assert.lengthOf(results[0].result.particles, 2);
-    });
-  });
+  }));
 
-  it('SLANDLES SYNTAX listens to handle constraints - handle', async () => {
+  it('SLANDLES SYNTAX listens to handle constraints - handle', Flags.withPostSlandlesSyntax(async () => {
     const results = await generatePlans(`
       recipe
         create as handle0
@@ -277,10 +267,9 @@ ${recipesManifest}`);
       `);
     assert.lengthOf(results, 3);
     assert.deepEqual([['P'], ['P', 'Q'], ['Q']], results.map(r => r.result.particles.map(p => p.name)));
-  });
+  }));
   // TODO(jopra): Remove once slandles unification syntax is implemented.
-  it('listens to handle constraints - handle', async () => {
-    Flags.withPreSlandlesSyntax(async () => {
+  it('listens to handle constraints - handle', Flags.withPreSlandlesSyntax(async () => {
     const results = await generatePlans(`
       recipe
         create as handle0
@@ -289,8 +278,7 @@ ${recipesManifest}`);
       `);
     assert.lengthOf(results, 3);
     assert.deepEqual([['P'], ['P', 'Q'], ['Q']], results.map(r => r.result.particles.map(p => p.name)));
-    });
-  });
+  }));
   it('listens to slot constraints', async () => {
     const manifest = await Manifest.parse(`
       particle P in 'A.js'
@@ -344,7 +332,7 @@ ${recipesManifest}`);
     assert.strictEqual(results[0].result.particles[0].name, 'P');
     assert.lengthOf(results[1].result.particles, 2);
   });
-  it('SLANDLES SYNTAX carries handle assignments across verb substitution', async () => {
+  it('SLANDLES SYNTAX carries handle assignments across verb substitution', Flags.withPostSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
 
       particle P in 'A.js'
@@ -373,10 +361,9 @@ ${recipesManifest}`);
     assert.strictEqual(recipe.particles[0].connections.a.handle, recipe.particles[1].connections.b.handle);
     assert.strictEqual(recipe.particles[0].connections.a.handle.connections[0].particle, recipe.particles[0]);
     assert.strictEqual(recipe.particles[1].connections.b.handle.connections[1].particle, recipe.particles[1]);
-  });
+  }));
   // TODO(jopra): Remove once slandles unification syntax is implemented.
-  it('carries handle assignments across verb substitution', async () => {
-    Flags.withPreSlandlesSyntax(async () => {
+  it('carries handle assignments across verb substitution', Flags.withPreSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
 
       particle P in 'A.js'
@@ -405,9 +392,8 @@ ${recipesManifest}`);
     assert.strictEqual(recipe.particles[0].connections.a.handle, recipe.particles[1].connections.b.handle);
     assert.strictEqual(recipe.particles[0].connections.a.handle.connections[0].particle, recipe.particles[0]);
     assert.strictEqual(recipe.particles[1].connections.b.handle.connections[1].particle, recipe.particles[1]);
-    });
-  });
-  it('SLANDLES SYNTAX carries handle assignments across verb substitution with generic binding', async () => {
+  }));
+  it('SLANDLES SYNTAX carries handle assignments across verb substitution with generic binding', Flags.withPostSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
 
       particle P in 'A.js'
@@ -436,10 +422,9 @@ ${recipesManifest}`);
     assert.strictEqual(recipe.particles[0].connections.a.handle, recipe.particles[1].connections.b.handle);
     assert.strictEqual(recipe.particles[0].connections.a.handle.connections[0].particle, recipe.particles[0]);
     assert.strictEqual(recipe.particles[1].connections.b.handle.connections[1].particle, recipe.particles[1]);
-  });
+  }));
   // TODO(jopra): Remove once slandles unification syntax is implemented.
-  it('carries handle assignments across verb substitution with generic binding', async () => {
-    Flags.withPreSlandlesSyntax(async () => {
+  it('carries handle assignments across verb substitution with generic binding', Flags.withPreSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
 
       particle P in 'A.js'
@@ -468,10 +453,9 @@ ${recipesManifest}`);
     assert.strictEqual(recipe.particles[0].connections.a.handle, recipe.particles[1].connections.b.handle);
     assert.strictEqual(recipe.particles[0].connections.a.handle.connections[0].particle, recipe.particles[0]);
     assert.strictEqual(recipe.particles[1].connections.b.handle.connections[1].particle, recipe.particles[1]);
-    });
-  });
+  }));
 
-  it('SLANDLES SYNTAX selects the appropriate generic binding when handle assignments carry type information', async () => {
+  it('SLANDLES SYNTAX selects the appropriate generic binding when handle assignments carry type information', Flags.withPostSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
 
       particle O in 'Z.js'
@@ -509,11 +493,10 @@ ${recipesManifest}`);
     assert.strictEqual(particleP.connections.a.handle, particleQ.connections.b.handle);
     assert.strictEqual(particleP.connections.a.handle.connections[0].particle, particleP);
     assert.strictEqual(particleQ.connections.b.handle.connections[1].particle, particleQ);
-  });
+  }));
 
   // TODO(jopra): Remove once slandles unification syntax is implemented.
-  it('selects the appropriate generic binding when handle assignments carry type information', async () => {
-    Flags.withPreSlandlesSyntax(async () => {
+  it('selects the appropriate generic binding when handle assignments carry type information', Flags.withPreSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
 
       particle O in 'Z.js'
@@ -551,8 +534,7 @@ ${recipesManifest}`);
     assert.strictEqual(particleP.connections.a.handle, particleQ.connections.b.handle);
     assert.strictEqual(particleP.connections.a.handle.connections[0].particle, particleP);
     assert.strictEqual(particleQ.connections.b.handle.connections[1].particle, particleQ);
-    });
-  });
+  }));
   it('carries slot assignments across verb substitution', async () => {
     const manifest = await Manifest.parse(`
       particle P in 'A.js'

--- a/src/planning/strategies/tests/match-recipe-by-verb-test.ts
+++ b/src/planning/strategies/tests/match-recipe-by-verb-test.ts
@@ -15,7 +15,7 @@ import {MatchRecipeByVerb} from '../../strategies/match-recipe-by-verb.js';
 
 import {StrategyTestHelper} from '../../testing/strategy-test-helper.js';
 
-import {withPreSlandlesSyntax} from '../../../runtime/manifest-ast-nodes.js';
+import {Flags} from '../../../runtime/flags.js';
 
 describe('MatchRecipeByVerb', () => {
   it('SLANDLES SYNTAX removes a particle and adds a recipe', async () => {
@@ -49,7 +49,7 @@ describe('MatchRecipeByVerb', () => {
 
   // TODO(jopra): Remove once slandles unification syntax is implemented.
   it('removes a particle and adds a recipe', async () => {
-    withPreSlandlesSyntax(async () => {
+    Flags.withPreSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
       recipe
         &jump
@@ -115,7 +115,7 @@ describe('MatchRecipeByVerb', () => {
 
   // TODO(jopra): Remove once slandles unification syntax is implemented.
   it('plays nicely with constraints', async () => {
-    withPreSlandlesSyntax(async () => {
+    Flags.withPreSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
       schema S
       particle P in 'A.js'
@@ -202,7 +202,7 @@ ${recipesManifest}`);
 
   // TODO(jopra): Remove once slandles unification syntax is implemented.
   it('listens to handle constraints - out connection', async () => {
-    withPreSlandlesSyntax(async () => {
+    Flags.withPreSlandlesSyntax(async () => {
     const results = await generatePlans(`
       recipe
         &verb
@@ -227,7 +227,7 @@ ${recipesManifest}`);
 
   // TODO(jopra): Remove once slandles unification syntax is implemented.
   it('listens to handle constraints - in connection', async () => {
-    withPreSlandlesSyntax(async () => {
+    Flags.withPreSlandlesSyntax(async () => {
     const results = await generatePlans(`
       recipe
         &verb
@@ -254,7 +254,7 @@ ${recipesManifest}`);
 
   // TODO(jopra): Remove once slandles unification syntax is implemented.
   it('listens to handle constraints - both connection', async () => {
-    withPreSlandlesSyntax(async () => {
+    Flags.withPreSlandlesSyntax(async () => {
     const results = await generatePlans(`
       recipe
         &verb
@@ -280,7 +280,7 @@ ${recipesManifest}`);
   });
   // TODO(jopra): Remove once slandles unification syntax is implemented.
   it('listens to handle constraints - handle', async () => {
-    withPreSlandlesSyntax(async () => {
+    Flags.withPreSlandlesSyntax(async () => {
     const results = await generatePlans(`
       recipe
         create as handle0
@@ -376,7 +376,7 @@ ${recipesManifest}`);
   });
   // TODO(jopra): Remove once slandles unification syntax is implemented.
   it('carries handle assignments across verb substitution', async () => {
-    withPreSlandlesSyntax(async () => {
+    Flags.withPreSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
 
       particle P in 'A.js'
@@ -439,7 +439,7 @@ ${recipesManifest}`);
   });
   // TODO(jopra): Remove once slandles unification syntax is implemented.
   it('carries handle assignments across verb substitution with generic binding', async () => {
-    withPreSlandlesSyntax(async () => {
+    Flags.withPreSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
 
       particle P in 'A.js'
@@ -513,7 +513,7 @@ ${recipesManifest}`);
 
   // TODO(jopra): Remove once slandles unification syntax is implemented.
   it('selects the appropriate generic binding when handle assignments carry type information', async () => {
-    withPreSlandlesSyntax(async () => {
+    Flags.withPreSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
 
       particle O in 'Z.js'

--- a/src/planning/tests/planner-test.ts
+++ b/src/planning/tests/planner-test.ts
@@ -839,7 +839,7 @@ describe('Automatic resolution', () => {
         B`);
   });
 
-  it('SLANDLES SYNTAX coalesces recipes to resolve connections', async () => {
+  it('SLANDLES SYNTAX coalesces recipes to resolve connections', Flags.withPostSlandlesSyntax(async () => {
     const result = await verifyResolvedPlan(`
       schema Thing
         Text id
@@ -892,11 +892,10 @@ describe('Automatic resolution', () => {
     something: in handle1
   D as particle3
     location: inout handle2`, result.toString({hideFields: false}));
-  });
+  }));
 
   // TODO(jopra): Remove once slandles unification syntax is implemented.
-  it('coalesces recipes to resolve connections', async () => {
-    Flags.withPreSlandlesSyntax(async () => {
+  it('coalesces recipes to resolve connections', Flags.withPreSlandlesSyntax(async () => {
     const result = await verifyResolvedPlan(`
       schema Thing
         Text id
@@ -949,8 +948,7 @@ describe('Automatic resolution', () => {
     something <- handle1
   D as particle3
     location <-> handle2`, result.toString({hideFields: false}));
-    });
-  });
+  }));
 
   it('uses existing handle from the arc', async () => {
     // An existing handle from the arc can be used as input to a recipe
@@ -974,7 +972,7 @@ describe('Automatic resolution', () => {
     assert.strictEqual('test:1', handle.id);
   });
 
-  it('SLANDLES SYNTAX composes recipe rendering a list of items from a recipe', async () => {
+  it('SLANDLES SYNTAX composes recipe rendering a list of items from a recipe', Flags.withPostSlandlesSyntax(async () => {
     let arc = null;
     const recipes = await verifyResolvedPlans(`
       import './src/runtime/tests/artifacts/Common/List.recipes'
@@ -1016,10 +1014,9 @@ describe('Automatic resolution', () => {
     things: out handle0`;
     assert.strictEqual(composedRecipes[0].toString(), recipeString);
     assert.strictEqual(composedRecipes[0].toString({showUnresolved: true}), recipeString);
-  });
+  }));
   // TODO(jopra): Remove once slandles unification syntax is implemented.
-  it('composes recipe rendering a list of items from a recipe', async () => {
-    Flags.withPreSlandlesSyntax(async () => {
+  it('composes recipe rendering a list of items from a recipe', Flags.withPreSlandlesSyntax(async () => {
     let arc = null;
     const recipes = await verifyResolvedPlans(`
       import './src/runtime/tests/artifacts/Common/List.recipes'
@@ -1061,9 +1058,8 @@ describe('Automatic resolution', () => {
     things -> handle0`;
     assert.strictEqual(composedRecipes[0].toString(), recipeString);
     assert.strictEqual(composedRecipes[0].toString({showUnresolved: true}), recipeString);
-    });
-  });
-  it('SLANDLES SYNTAX composes recipe rendering a list of items from the current arc', async () => {
+  }));
+  it('SLANDLES SYNTAX composes recipe rendering a list of items from the current arc', Flags.withPostSlandlesSyntax(async () => {
     let arc = null;
     const recipes = await verifyResolvedPlans(`
         import './src/runtime/tests/artifacts/Common/List.recipes'
@@ -1096,11 +1092,10 @@ describe('Automatic resolution', () => {
       provide item as slot0
       provide postamble as slot4
       provide preamble as slot5`);
-  });
+  }));
 
   // TODO(jopra): Remove once slandles unification syntax is implemented.
-  it('composes recipe rendering a list of items from the current arc', async () => {
-    Flags.withPreSlandlesSyntax(async () => {
+  it('composes recipe rendering a list of items from the current arc', Flags.withPreSlandlesSyntax(async () => {
     let arc = null;
     const recipes = await verifyResolvedPlans(`
         import './src/runtime/tests/artifacts/Common/List.recipes'
@@ -1133,8 +1128,7 @@ describe('Automatic resolution', () => {
       provide item as slot0
       provide postamble as slot4
       provide preamble as slot5`);
-    });
-  });
+  }));
   it('coalesces resolved recipe with no UI', async () => {
     const recipes = await verifyResolvedPlans(`
       schema Thing

--- a/src/planning/tests/planner-test.ts
+++ b/src/planning/tests/planner-test.ts
@@ -22,7 +22,7 @@ import {assertThrowsAsync} from '../../runtime/testing/test-util.js';
 import {StrategyTestHelper} from '../testing/strategy-test-helper.js';
 import {Id, ArcId} from '../../runtime/id.js';
 
-import {withPreSlandlesSyntax} from '../../runtime/manifest-ast-nodes.js';
+import {Flags} from '../../runtime/flags.js';
 
 async function planFromManifest(manifest, {arcFactory, testSteps}: {arcFactory?, testSteps?} = {}) {
   const loader = new Loader();
@@ -896,7 +896,7 @@ describe('Automatic resolution', () => {
 
   // TODO(jopra): Remove once slandles unification syntax is implemented.
   it('coalesces recipes to resolve connections', async () => {
-    withPreSlandlesSyntax(async () => {
+    Flags.withPreSlandlesSyntax(async () => {
     const result = await verifyResolvedPlan(`
       schema Thing
         Text id
@@ -1019,7 +1019,7 @@ describe('Automatic resolution', () => {
   });
   // TODO(jopra): Remove once slandles unification syntax is implemented.
   it('composes recipe rendering a list of items from a recipe', async () => {
-    withPreSlandlesSyntax(async () => {
+    Flags.withPreSlandlesSyntax(async () => {
     let arc = null;
     const recipes = await verifyResolvedPlans(`
       import './src/runtime/tests/artifacts/Common/List.recipes'
@@ -1100,7 +1100,7 @@ describe('Automatic resolution', () => {
 
   // TODO(jopra): Remove once slandles unification syntax is implemented.
   it('composes recipe rendering a list of items from the current arc', async () => {
-    withPreSlandlesSyntax(async () => {
+    Flags.withPreSlandlesSyntax(async () => {
     let arc = null;
     const recipes = await verifyResolvedPlans(`
         import './src/runtime/tests/artifacts/Common/List.recipes'

--- a/src/planning/tests/recipe-index-test.ts
+++ b/src/planning/tests/recipe-index-test.ts
@@ -40,7 +40,7 @@ describe('RecipeIndex', () => {
     return (await createIndex(manifestContent)).recipes.map(r => r.toString());
   }
 
-  it('SLANDLES SYNTAX adds use handles', async () => {
+  it('SLANDLES SYNTAX adds use handles', Flags.withPostSlandlesSyntax(async () => {
     assert.sameMembers(await extractIndexRecipeStrings(`
       schema Person
       schema Lumberjack
@@ -59,11 +59,10 @@ describe('RecipeIndex', () => {
     lumberjack: out handle0
     person: in handle1`
     ]);
-  });
+  }));
 
   // TODO(jopra): Remove once slandles unification syntax is implemented.
-  it('adds use handles', async () => {
-    Flags.withPreSlandlesSyntax(async () => {
+  it('adds use handles', Flags.withPreSlandlesSyntax(async () => {
     assert.sameMembers(await extractIndexRecipeStrings(`
       schema Person
       schema Lumberjack
@@ -82,10 +81,9 @@ describe('RecipeIndex', () => {
     lumberjack -> handle0
     person <- handle1`
     ]);
-    });
-  });
+  }));
 
-  it('SLANDLES SYNTAX matches free handles to connections', async () => {
+  it('SLANDLES SYNTAX matches free handles to connections', Flags.withPostSlandlesSyntax(async () => {
     assert.sameMembers(await extractIndexRecipeStrings(`
       schema Person
 
@@ -101,11 +99,10 @@ describe('RecipeIndex', () => {
   A as particle0
     person: inout handle0`
     ]);
-  });
+  }));
 
   // TODO(jopra): Remove once slandles unification syntax is implemented.
-  it('matches free handles to connections', async () => {
-    Flags.withPreSlandlesSyntax(async () => {
+  it('matches free handles to connections', Flags.withPreSlandlesSyntax(async () => {
     assert.sameMembers(await extractIndexRecipeStrings(`
       schema Person
 
@@ -121,8 +118,7 @@ describe('RecipeIndex', () => {
   A as particle0
     person <-> handle0`
     ]);
-    });
-  });
+  }));
 
   it('resolves local slots, but not a root slot', async () => {
     assert.sameMembers(await extractIndexRecipeStrings(`
@@ -146,7 +142,7 @@ describe('RecipeIndex', () => {
     ]);
   });
 
-  it('SLANDLES SYNTAX resolves constraints', async () => {
+  it('SLANDLES SYNTAX resolves constraints', Flags.withPostSlandlesSyntax(async () => {
     assert.sameMembers(await extractIndexRecipeStrings(`
       schema A
       schema B
@@ -173,11 +169,10 @@ describe('RecipeIndex', () => {
     b: in handle1
     c: out handle2`
     ]);
-  });
+  }));
 
   // TODO(jopra): Remove once slandles unification syntax is implemented.
-  it('resolves constraints', async () => {
-    Flags.withPreSlandlesSyntax(async () => {
+  it('resolves constraints', Flags.withPreSlandlesSyntax(async () => {
     assert.sameMembers(await extractIndexRecipeStrings(`
       schema A
       schema B
@@ -204,8 +199,7 @@ describe('RecipeIndex', () => {
     b <- handle1
     c -> handle2`
     ]);
-    });
-  });
+  }));
 
   it('does not resolve verbs', async () => {
     assert.sameMembers(await extractIndexRecipeStrings(`
@@ -240,7 +234,7 @@ describe('RecipeIndex', () => {
     ]);
   });
 
-  it('SLANDLES SYNTAX finds matching handles by fate', async () => {
+  it('SLANDLES SYNTAX finds matching handles by fate', Flags.withPostSlandlesSyntax(async () => {
     const index = await createIndex(`
       schema Thing
 
@@ -272,7 +266,7 @@ describe('RecipeIndex', () => {
 
     assert.deepEqual(['A'], index.findHandleMatch(handle, ['map']).map(h => h.recipe.name));
     assert.deepEqual(['B'], index.findHandleMatch(handle, ['create']).map(h => h.recipe.name));
-  });
+  }));
 
   // TODO(jopra): Remove once slandles unification syntax is implemented.
   it('finds matching handles by fate', async () => {

--- a/src/planning/tests/recipe-index-test.ts
+++ b/src/planning/tests/recipe-index-test.ts
@@ -16,7 +16,7 @@ import {MockSlotComposer} from '../../runtime/testing/mock-slot-composer.js';
 import {checkDefined} from '../../runtime/testing/preconditions.js';
 import {RecipeIndex} from '../recipe-index.js';
 import {Id, ArcId} from '../../runtime/id.js';
-import {withPreSlandlesSyntax} from '../../runtime/manifest-ast-nodes.js';
+import {Flags} from '../../runtime/flags.js';
 
 describe('RecipeIndex', () => {
   async function createIndex(manifestContent) {
@@ -63,7 +63,7 @@ describe('RecipeIndex', () => {
 
   // TODO(jopra): Remove once slandles unification syntax is implemented.
   it('adds use handles', async () => {
-    withPreSlandlesSyntax(async () => {
+    Flags.withPreSlandlesSyntax(async () => {
     assert.sameMembers(await extractIndexRecipeStrings(`
       schema Person
       schema Lumberjack
@@ -105,7 +105,7 @@ describe('RecipeIndex', () => {
 
   // TODO(jopra): Remove once slandles unification syntax is implemented.
   it('matches free handles to connections', async () => {
-    withPreSlandlesSyntax(async () => {
+    Flags.withPreSlandlesSyntax(async () => {
     assert.sameMembers(await extractIndexRecipeStrings(`
       schema Person
 
@@ -177,7 +177,7 @@ describe('RecipeIndex', () => {
 
   // TODO(jopra): Remove once slandles unification syntax is implemented.
   it('resolves constraints', async () => {
-    withPreSlandlesSyntax(async () => {
+    Flags.withPreSlandlesSyntax(async () => {
     assert.sameMembers(await extractIndexRecipeStrings(`
       schema A
       schema B

--- a/src/planning/tests/recipe-index-test.ts
+++ b/src/planning/tests/recipe-index-test.ts
@@ -16,6 +16,7 @@ import {MockSlotComposer} from '../../runtime/testing/mock-slot-composer.js';
 import {checkDefined} from '../../runtime/testing/preconditions.js';
 import {RecipeIndex} from '../recipe-index.js';
 import {Id, ArcId} from '../../runtime/id.js';
+import {withPreSlandlesSyntax} from '../../runtime/manifest-ast-nodes.js';
 
 describe('RecipeIndex', () => {
   async function createIndex(manifestContent) {
@@ -39,7 +40,30 @@ describe('RecipeIndex', () => {
     return (await createIndex(manifestContent)).recipes.map(r => r.toString());
   }
 
+  it('SLANDLES SYNTAX adds use handles', async () => {
+    assert.sameMembers(await extractIndexRecipeStrings(`
+      schema Person
+      schema Lumberjack
+
+      particle Transform
+        in Person person
+        out Lumberjack lumberjack
+
+      recipe
+        Transform
+    `), [
+`recipe
+  ? as handle0 // ~
+  ? as handle1 // ~
+  Transform as particle0
+    lumberjack: out handle0
+    person: in handle1`
+    ]);
+  });
+
+  // TODO(jopra): Remove once slandles unification syntax is implemented.
   it('adds use handles', async () => {
+    withPreSlandlesSyntax(async () => {
     assert.sameMembers(await extractIndexRecipeStrings(`
       schema Person
       schema Lumberjack
@@ -58,9 +82,30 @@ describe('RecipeIndex', () => {
     lumberjack -> handle0
     person <- handle1`
     ]);
+    });
   });
 
+  it('SLANDLES SYNTAX matches free handles to connections', async () => {
+    assert.sameMembers(await extractIndexRecipeStrings(`
+      schema Person
+
+      particle A
+        inout Person person
+
+      recipe
+        create as person
+        A
+    `), [
+`recipe
+  create as handle0 // Person {}
+  A as particle0
+    person: inout handle0`
+    ]);
+  });
+
+  // TODO(jopra): Remove once slandles unification syntax is implemented.
   it('matches free handles to connections', async () => {
+    withPreSlandlesSyntax(async () => {
     assert.sameMembers(await extractIndexRecipeStrings(`
       schema Person
 
@@ -76,6 +121,7 @@ describe('RecipeIndex', () => {
   A as particle0
     person <-> handle0`
     ]);
+    });
   });
 
   it('resolves local slots, but not a root slot', async () => {
@@ -100,7 +146,38 @@ describe('RecipeIndex', () => {
     ]);
   });
 
+  it('SLANDLES SYNTAX resolves constraints', async () => {
+    assert.sameMembers(await extractIndexRecipeStrings(`
+      schema A
+      schema B
+      schema C
+
+      particle Transform
+        in A a
+        out B b
+      particle TransformAgain
+        in B b
+        out C c
+
+      recipe
+        Transform.b: out TransformAgain.b
+    `), [
+`recipe
+  ? as handle0 // ~
+  create as handle1 // B {}
+  ? as handle2 // ~
+  Transform as particle0
+    a: in handle0
+    b: out handle1
+  TransformAgain as particle1
+    b: in handle1
+    c: out handle2`
+    ]);
+  });
+
+  // TODO(jopra): Remove once slandles unification syntax is implemented.
   it('resolves constraints', async () => {
+    withPreSlandlesSyntax(async () => {
     assert.sameMembers(await extractIndexRecipeStrings(`
       schema A
       schema B
@@ -127,6 +204,7 @@ describe('RecipeIndex', () => {
     b <- handle1
     c -> handle2`
     ]);
+    });
   });
 
   it('does not resolve verbs', async () => {
@@ -162,6 +240,41 @@ describe('RecipeIndex', () => {
     ]);
   });
 
+  it('SLANDLES SYNTAX finds matching handles by fate', async () => {
+    const index = await createIndex(`
+      schema Thing
+
+      particle A
+        in Thing thing
+      recipe A
+        map as thing
+        A
+          thing: any thing
+
+      particle B
+        out Thing thing
+      recipe B
+        create as thing
+        B
+          thing: any thing
+
+      particle C
+        in Thing thing
+      recipe C
+        use as thing
+        C
+          thing: any thing
+    `);
+
+    const recipe = checkDefined(index.recipes.find(r => r.name === 'C'), 'missing recipe C');
+
+    const handle = recipe.handles[0];
+
+    assert.deepEqual(['A'], index.findHandleMatch(handle, ['map']).map(h => h.recipe.name));
+    assert.deepEqual(['B'], index.findHandleMatch(handle, ['create']).map(h => h.recipe.name));
+  });
+
+  // TODO(jopra): Remove once slandles unification syntax is implemented.
   it('finds matching handles by fate', async () => {
     const index = await createIndex(`
       schema Thing

--- a/src/runtime/flags.ts
+++ b/src/runtime/flags.ts
@@ -11,10 +11,23 @@
 /** Arcs runtime flags. */
 export class Flags {
   static useNewStorageStack: boolean;
+  static usePreSlandlesSyntax: boolean;
 
   /** Resets flags. To be called in test teardown methods. */
   static reset() {
     Flags.useNewStorageStack = false;
+    Flags.usePreSlandlesSyntax = false;
+  }
+
+  static async withPreSlandlesSyntax(f) {
+    Flags.usePreSlandlesSyntax = true;
+    let res;
+    try {
+      res = await f();
+    } finally {
+      Flags.reset();
+    }
+    return res;
   }
 }
 

--- a/src/runtime/flags.ts
+++ b/src/runtime/flags.ts
@@ -16,18 +16,34 @@ export class Flags {
   /** Resets flags. To be called in test teardown methods. */
   static reset() {
     Flags.useNewStorageStack = false;
-    Flags.usePreSlandlesSyntax = false;
+    Flags.usePreSlandlesSyntax = true;
   }
 
-  static async withPreSlandlesSyntax(f) {
-    Flags.usePreSlandlesSyntax = true;
-    let res;
-    try {
-      res = await f();
-    } finally {
-      Flags.reset();
-    }
-    return res;
+  // For testing new syntax.
+  static withPostSlandlesSyntax(f) {
+    return async () => {
+      Flags.usePreSlandlesSyntax = false;
+      let res;
+      try {
+        res = await f();
+      } finally {
+        Flags.reset();
+      }
+      return res;
+    };
+  }
+  // For testing old syntax.
+  static withPreSlandlesSyntax(f) {
+    return async () => {
+      Flags.usePreSlandlesSyntax = true;
+      let res;
+      try {
+        res = await f();
+      } finally {
+        Flags.reset();
+      }
+      return res;
+    };
   }
 }
 

--- a/src/runtime/manifest-ast-nodes.ts
+++ b/src/runtime/manifest-ast-nodes.ts
@@ -364,7 +364,7 @@ export type RecipeItem = RecipeParticle | RecipeHandle | RequireHandleSection | 
 export interface RecipeParticleConnection extends BaseNode {
   kind: 'handle-connection';
   param: string;
-  dir: DirectionArrow;
+  dir: Direction;
   target: ParticleConnectionTargetComponents;
   dependentConnections: RecipeParticleConnection[];
 }
@@ -404,7 +404,7 @@ export interface RecipeSlotConnectionRef extends BaseNode {
 
 export interface RecipeConnection extends BaseNode {
   kind: 'connection';
-  direction: DirectionArrow;
+  direction: Direction;
   from: ConnectionTarget;
   to: ConnectionTarget;
 }
@@ -631,7 +631,6 @@ export type eol = string;
 // String-based enums.
 // TODO: convert to actual enums so that they can be iterated over.
 export type Direction = 'in' | 'out' | 'inout' | 'host' | '`consume' | '`provide' | 'any';
-export type DirectionArrow = '<-' | '->' | '<->' | 'consume' | 'provide' | '=';
 
 export type SlotDirection = 'provide' | 'consume';
 export type Fate = 'use' | 'create' | 'map' | 'copy' | '?' | '`slot';

--- a/src/runtime/manifest-ast-nodes.ts
+++ b/src/runtime/manifest-ast-nodes.ts
@@ -679,31 +679,6 @@ export function directionToArrow(dir: Direction): string {
   }
 }
 
-let usePreSlandlesSyntax = false;
-export function withPreSlandlesSyntaxSync(f) {
-  usePreSlandlesSyntax = true;
-  let res;
-  try {
-    res = f();
-  } finally {
-    usePreSlandlesSyntax = false;
-  }
-  return res;
-}
-export async function withPreSlandlesSyntax(f) {
-  usePreSlandlesSyntax = true;
-  let res;
-  try {
-    res = await f();
-  } finally {
-    usePreSlandlesSyntax = false;
-  }
-  return res;
-}
-export function usingPreSlandlesSyntax() {
-  return usePreSlandlesSyntax;
-}
-
 export type SlotDirection = 'provide' | 'consume';
 export type Fate = 'use' | 'create' | 'map' | 'copy' | '?' | '`slot';
 

--- a/src/runtime/manifest-ast-nodes.ts
+++ b/src/runtime/manifest-ast-nodes.ts
@@ -632,6 +632,78 @@ export type eol = string;
 // TODO: convert to actual enums so that they can be iterated over.
 export type Direction = 'in' | 'out' | 'inout' | 'host' | '`consume' | '`provide' | 'any';
 
+// Temporary move of DirectionArrow type definition and conversions so allow
+// DirectionArrow to be removed from the runtime.
+// TODO(jopra): Remove after syntax unification.
+export type DirectionArrow = '<-' | '->' | '<->' | 'consume' | 'provide' | '=';
+
+export function arrowToDirection(arrow: DirectionArrow): Direction {
+  // TODO(jopra): Remove after syntax unification.
+  // Use switch for totality checking.
+  switch (arrow) {
+    case '->':
+      return 'out';
+    case '<-':
+      return 'in';
+    case '<->':
+      return 'inout';
+    case 'consume':
+      return '`consume';
+    case 'provide':
+      return '`provide';
+    case '=':
+      return 'any';
+    default:
+      // Catch nulls and unsafe values from javascript.
+      throw new Error(`Bad arrow ${arrow}`);
+  }
+}
+
+export function directionToArrow(dir: Direction): string {
+  // TODO(jopra): Remove after syntax unification.
+  switch (dir) {
+    case 'in':
+      return '<-';
+    case 'out':
+      return '->';
+    case 'inout':
+      return '<->';
+    case 'host':
+      return '=';
+    case '`consume':
+      return '`consume';
+    case '`provide':
+      return '`provide';
+    case 'any':
+      return '=';
+  }
+}
+
+let usePreSlandlesSyntax = false;
+export function withPreSlandlesSyntaxSync(f) {
+  usePreSlandlesSyntax = true;
+  let res;
+  try {
+    res = f();
+  } finally {
+    usePreSlandlesSyntax = false;
+  }
+  return res;
+}
+export async function withPreSlandlesSyntax(f) {
+  usePreSlandlesSyntax = true;
+  let res;
+  try {
+    res = await f();
+  } finally {
+    usePreSlandlesSyntax = false;
+  }
+  return res;
+}
+export function usingPreSlandlesSyntax() {
+  return usePreSlandlesSyntax;
+}
+
 export type SlotDirection = 'provide' | 'consume';
 export type Fate = 'use' | 'create' | 'map' | 'copy' | '?' | '`slot';
 

--- a/src/runtime/manifest-ast-nodes.ts
+++ b/src/runtime/manifest-ast-nodes.ts
@@ -671,11 +671,13 @@ export function directionToArrow(dir: Direction): string {
     case 'host':
       return '=';
     case '`consume':
-      return '`consume';
+      return 'consume';
     case '`provide':
-      return '`provide';
+      return 'provide';
     case 'any':
       return '=';
+    default:
+      throw new Error(`Unexpected direction ${dir}`);
   }
 }
 

--- a/src/runtime/manifest-parser.peg
+++ b/src/runtime/manifest-parser.peg
@@ -70,32 +70,6 @@
     return {...data, location: location()} as T;
   }
 
-
-  // Temporary move of DirectionArrow type definition and conversions so allow
-  // DirectionArrow to be removed from the runtime.
-  type DirectionArrow = '<-' | '->' | '<->' | 'consume' | 'provide' | '=';
-
-  function arrowToDirection(arrow: DirectionArrow): AstNode.Direction {
-    // Use switch for totality checking.
-    switch (arrow) {
-      case '->':
-        return 'out';
-      case '<-':
-        return 'in';
-      case '<->':
-        return 'inout';
-      case 'consume':
-        return '`consume';
-      case 'provide':
-        return '`provide';
-      case '=':
-        return 'any';
-      default:
-        // Catch nulls and unsafe values from javascript.
-        throw new Error(`Bad arrow ${arrow}`);
-    }
-  }
-
 }
 
 Manifest
@@ -542,7 +516,7 @@ Direction "a direction (e.g. inout, in, out, host, `consume, `provide, any)"
 // TODO(jopra): Remove when syntax is updated to not use arrows.
 DirectionArrow "a direction arrow (e.g. <-, ->, <->, =, consume, provide)"
   = '<->' / '<-' / '->' / '=' / 'consume' / 'provide' {
-    const dir = text() as DirectionArrow;
+    const dir = text() as AstNode.DirectionArrow;
     if(dir === null) {
       expected('a direction arrow');
     }
@@ -846,7 +820,7 @@ RecipeParticleConnectionPreSlandle
     return toAstNode<AstNode.RecipeParticleConnection>({
       kind: 'handle-connection',
       param,
-      dir: arrowToDirection(dir),
+      dir: AstNode.arrowToDirection(dir),
       target: optional(target, target => target[1], null),
       dependentConnections: optional(dependentConnections, extractIndented, []),
     });
@@ -919,7 +893,7 @@ RecipeConnectionPreSlandle
   {
     return toAstNode<AstNode.RecipeConnection>({
       kind: 'connection',
-      direction: arrowToDirection(direction),
+      direction: AstNode.arrowToDirection(direction),
       from,
       to,
     });

--- a/src/runtime/manifest-parser.peg
+++ b/src/runtime/manifest-parser.peg
@@ -69,6 +69,33 @@
   function toAstNode<T extends {location: IFileRange} & Omit<T, 'location'>>(data: Omit<T, 'location'>): T {
     return {...data, location: location()} as T;
   }
+
+
+  // Temporary move of DirectionArrow type definition and conversions so allow
+  // DirectionArrow to be removed from the runtime.
+  type DirectionArrow = '<-' | '->' | '<->' | 'consume' | 'provide' | '=';
+
+  function arrowToDirection(arrow: DirectionArrow): AstNode.Direction {
+    // Use switch for totality checking.
+    switch (arrow) {
+      case '->':
+        return 'out';
+      case '<-':
+        return 'in';
+      case '<->':
+        return 'inout';
+      case 'consume':
+        return '`consume';
+      case 'provide':
+        return '`provide';
+      case '=':
+        return 'any';
+      default:
+        // Catch nulls and unsafe values from javascript.
+        throw new Error(`Bad arrow ${arrow}`);
+    }
+  }
+
 }
 
 Manifest
@@ -512,9 +539,10 @@ Direction "a direction (e.g. inout, in, out, host, `consume, `provide, any)"
     return dir;
   }
 
+// TODO(jopra): Remove when syntax is updated to not use arrows.
 DirectionArrow "a direction arrow (e.g. <-, ->, <->, =, consume, provide)"
   = '<->' / '<-' / '->' / '=' / 'consume' / 'provide' {
-    const dir = text() as AstNode.DirectionArrow;
+    const dir = text() as DirectionArrow;
     if(dir === null) {
       expected('a direction arrow');
     }
@@ -797,12 +825,28 @@ RecipeParticle
 RecipeParticleItem = RecipeParticleSlotConnection / RecipeParticleConnection
 
 RecipeParticleConnection
-  = param:(lowerIdent / '*') whiteSpace dir:DirectionArrow target:(whiteSpace ParticleConnectionTargetComponents)? eolWhiteSpace dependentConnections:(Indent (SameIndent RecipeParticleConnection)*)?
+  = RecipeParticleConnectionPreSlandle / RecipeParticleConnectionUnified
+
+RecipeParticleConnectionUnified
+  = param:(lowerIdent / '*') ':' whiteSpace dir:Direction target:(whiteSpace ParticleConnectionTargetComponents)? eolWhiteSpace dependentConnections:(Indent (SameIndent RecipeParticleConnection)*)?
   {
     return toAstNode<AstNode.RecipeParticleConnection>({
       kind: 'handle-connection',
       param,
       dir,
+      target: optional(target, target => target[1], null),
+      dependentConnections: optional(dependentConnections, extractIndented, []),
+    });
+  }
+
+// TODO(jopra): Remove after unification
+RecipeParticleConnectionPreSlandle
+  = param:(lowerIdent / '*') whiteSpace dir:DirectionArrow target:(whiteSpace ParticleConnectionTargetComponents)? eolWhiteSpace dependentConnections:(Indent (SameIndent RecipeParticleConnection)*)?
+  {
+    return toAstNode<AstNode.RecipeParticleConnection>({
+      kind: 'handle-connection',
+      param,
+      dir: arrowToDirection(dir),
       target: optional(target, target => target[1], null),
       dependentConnections: optional(dependentConnections, extractIndented, []),
     });
@@ -857,11 +901,25 @@ SlotDirection
   = 'provide' / 'consume'
 
 RecipeConnection
-  = from:ConnectionTarget whiteSpace direction:DirectionArrow whiteSpace to:ConnectionTarget eolWhiteSpace
+  = RecipeConnectionUnified / RecipeConnectionPreSlandle
+
+RecipeConnectionUnified
+  = from:ConnectionTarget ':' whiteSpace direction:Direction whiteSpace to:ConnectionTarget eolWhiteSpace
   {
     return toAstNode<AstNode.RecipeConnection>({
       kind: 'connection',
       direction,
+      from,
+      to,
+    });
+  }
+
+RecipeConnectionPreSlandle
+  = from:ConnectionTarget whiteSpace direction:DirectionArrow whiteSpace to:ConnectionTarget eolWhiteSpace
+  {
+    return toAstNode<AstNode.RecipeConnection>({
+      kind: 'connection',
+      direction: arrowToDirection(direction),
       from,
       to,
     });
@@ -1240,6 +1298,7 @@ SameOrMoreIndent "same or more indentation" = &(i:" "* &{
 ReservedWord
   = keyword:(DirectionArrow
   / Direction
+  / SlotDirection
   / RecipeHandleFate
   / 'particle'
   / 'recipe'

--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -27,7 +27,7 @@ import {Handle} from './recipe/handle.js';
 import {Particle} from './recipe/particle.js';
 import {Slot} from './recipe/slot.js';
 import {HandleConnection} from './recipe/handle-connection.js';
-import {RecipeUtil, arrowToDirection, connectionMatchesHandleDirection} from './recipe/recipe-util.js';
+import {RecipeUtil, connectionMatchesHandleDirection} from './recipe/recipe-util.js';
 import {Recipe, RequireSection} from './recipe/recipe.js';
 import {Search} from './recipe/search.js';
 import {TypeChecker} from './recipe/type-checker.js';
@@ -1005,7 +1005,7 @@ ${e.message}
           // TODO: else, merge tags? merge directions?
         }
         connection.tags = connectionItem.target ? connectionItem.target.tags : [];
-        const direction = arrowToDirection(connectionItem.dir);
+        const direction = connectionItem.dir;
         if (!connectionMatchesHandleDirection(direction, connection.direction)) {
           throw new ManifestError(
               connectionItem.location,

--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -1009,7 +1009,7 @@ ${e.message}
         if (!connectionMatchesHandleDirection(direction, connection.direction)) {
           throw new ManifestError(
               connectionItem.location,
-              `'${connectionItem.dir}' (${direction}) not compatible with '${connection.direction}' param of '${particle.name}'`);
+              `'${direction}' not compatible with '${connection.direction}' param of '${particle.name}'`);
         } else if (connection.direction === 'any') {
           if (connectionItem.param !== '*' && particle.spec !== undefined) {
             throw new ManifestError(

--- a/src/runtime/recipe/connection-constraint.ts
+++ b/src/runtime/recipe/connection-constraint.ts
@@ -11,7 +11,7 @@
 import {assert} from '../../platform/assert-web.js';
 import {ParticleSpec} from '../particle-spec.js';
 
-import {Direction, DirectionArrow} from '../manifest-ast-nodes.js';
+import {Direction} from '../manifest-ast-nodes.js';
 import {Handle} from './handle.js';
 import {Comparable, compareArrays, compareComparables, compareStrings} from './comparable.js';
 import {Recipe, RecipeComponent, CloneMap, ToStringOptions} from './recipe.js';
@@ -134,10 +134,10 @@ export class TagEndPoint extends EndPoint {
 export class ConnectionConstraint implements Comparable<ConnectionConstraint> {
   from: EndPoint;
   to: EndPoint;
-  direction: DirectionArrow;
+  direction: Direction;
   type: 'constraint' | 'obligation';
 
-  constructor(fromConnection: EndPoint, toConnection: EndPoint, direction: DirectionArrow, type: 'constraint' | 'obligation') {
+  constructor(fromConnection: EndPoint, toConnection: EndPoint, direction: Direction, type: 'constraint' | 'obligation') {
     assert(direction);
     assert(type);
     this.from = fromConnection;
@@ -173,6 +173,6 @@ export class ConnectionConstraint implements Comparable<ConnectionConstraint> {
     if (options && options.showUnresolved === true && this.type === 'obligation') {
       unresolved = ' // unresolved obligation';
     }
-    return `${this.from.toString(nameMap)} ${this.direction} ${this.to.toString(nameMap)}${unresolved}`;
+    return `${this.from.toString(nameMap)}: ${this.direction} ${this.to.toString(nameMap)}${unresolved}`;
   }
 }

--- a/src/runtime/recipe/connection-constraint.ts
+++ b/src/runtime/recipe/connection-constraint.ts
@@ -11,11 +11,12 @@
 import {assert} from '../../platform/assert-web.js';
 import {ParticleSpec} from '../particle-spec.js';
 
-import {usingPreSlandlesSyntax, Direction, directionToArrow} from '../manifest-ast-nodes.js';
+import {Direction, directionToArrow} from '../manifest-ast-nodes.js';
 import {Handle} from './handle.js';
 import {Comparable, compareArrays, compareComparables, compareStrings} from './comparable.js';
 import {Recipe, RecipeComponent, CloneMap, ToStringOptions} from './recipe.js';
 import {Particle} from './particle.js';
+import {Flags} from '../flags.js';
 
 export abstract class EndPoint implements Comparable<EndPoint> {
   abstract _compareTo(other: EndPoint): number;
@@ -173,7 +174,7 @@ export class ConnectionConstraint implements Comparable<ConnectionConstraint> {
     if (options && options.showUnresolved === true && this.type === 'obligation') {
       unresolved = ' // unresolved obligation';
     }
-    if (usingPreSlandlesSyntax()) {
+    if (Flags.usePreSlandlesSyntax) {
       return `${this.from.toString(nameMap)} ${directionToArrow(this.direction)} ${this.to.toString(nameMap)}${unresolved}`;
     }
     return `${this.from.toString(nameMap)}: ${this.direction} ${this.to.toString(nameMap)}${unresolved}`;

--- a/src/runtime/recipe/connection-constraint.ts
+++ b/src/runtime/recipe/connection-constraint.ts
@@ -11,7 +11,7 @@
 import {assert} from '../../platform/assert-web.js';
 import {ParticleSpec} from '../particle-spec.js';
 
-import {Direction} from '../manifest-ast-nodes.js';
+import {usingPreSlandlesSyntax, Direction, directionToArrow} from '../manifest-ast-nodes.js';
 import {Handle} from './handle.js';
 import {Comparable, compareArrays, compareComparables, compareStrings} from './comparable.js';
 import {Recipe, RecipeComponent, CloneMap, ToStringOptions} from './recipe.js';
@@ -172,6 +172,9 @@ export class ConnectionConstraint implements Comparable<ConnectionConstraint> {
     let unresolved = '';
     if (options && options.showUnresolved === true && this.type === 'obligation') {
       unresolved = ' // unresolved obligation';
+    }
+    if (usingPreSlandlesSyntax()) {
+      return `${this.from.toString(nameMap)} ${directionToArrow(this.direction)} ${this.to.toString(nameMap)}${unresolved}`;
     }
     return `${this.from.toString(nameMap)}: ${this.direction} ${this.to.toString(nameMap)}${unresolved}`;
   }

--- a/src/runtime/recipe/handle-connection.ts
+++ b/src/runtime/recipe/handle-connection.ts
@@ -20,7 +20,7 @@ import {acceptedDirections} from './recipe-util.js';
 import {TypeChecker} from './type-checker.js';
 import {compareArrays, compareComparables, compareStrings, Comparable} from './comparable.js';
 
-import {Direction} from '../manifest-ast-nodes.js';
+import {usingPreSlandlesSyntax, Direction, directionToArrow} from '../manifest-ast-nodes.js';
 
 export class HandleConnection implements Comparable<HandleConnection> {
   private readonly _recipe: Recipe;
@@ -274,8 +274,13 @@ export class HandleConnection implements Comparable<HandleConnection> {
 
   toString(nameMap: Map<RecipeComponent, string>, options: ToStringOptions): string {
     const result: string[] = [];
-    result.push(`${this.name || '*'}:`);
-    result.push(this.direction);
+    if (usingPreSlandlesSyntax()) {
+      result.push(`${this.name || '*'}`); // TODO: Remove post slandles syntax
+      result.push(directionToArrow(this.direction));
+    } else {
+      result.push(`${this.name || '*'}:`);
+      result.push(this.direction);
+    }
     if (this.handle) {
       if (this.handle.immediateValue) {
         result.push(this.handle.immediateValue.name);

--- a/src/runtime/recipe/handle-connection.ts
+++ b/src/runtime/recipe/handle-connection.ts
@@ -20,7 +20,8 @@ import {acceptedDirections} from './recipe-util.js';
 import {TypeChecker} from './type-checker.js';
 import {compareArrays, compareComparables, compareStrings, Comparable} from './comparable.js';
 
-import {usingPreSlandlesSyntax, Direction, directionToArrow} from '../manifest-ast-nodes.js';
+import {Direction, directionToArrow} from '../manifest-ast-nodes.js';
+import {Flags} from '../flags.js';
 
 export class HandleConnection implements Comparable<HandleConnection> {
   private readonly _recipe: Recipe;
@@ -274,7 +275,7 @@ export class HandleConnection implements Comparable<HandleConnection> {
 
   toString(nameMap: Map<RecipeComponent, string>, options: ToStringOptions): string {
     const result: string[] = [];
-    if (usingPreSlandlesSyntax()) {
+    if (Flags.usePreSlandlesSyntax) {
       result.push(`${this.name || '*'}`); // TODO: Remove post slandles syntax
       result.push(directionToArrow(this.direction));
     } else {

--- a/src/runtime/recipe/handle-connection.ts
+++ b/src/runtime/recipe/handle-connection.ts
@@ -16,7 +16,7 @@ import {Handle} from './handle.js';
 import {SlotConnection} from './slot-connection.js';
 import {Particle} from './particle.js';
 import {CloneMap, IsValidOptions, Recipe, RecipeComponent, ToStringOptions, VariableMap} from './recipe.js';
-import {directionToArrow, acceptedDirections} from './recipe-util.js';
+import {acceptedDirections} from './recipe-util.js';
 import {TypeChecker} from './type-checker.js';
 import {compareArrays, compareComparables, compareStrings, Comparable} from './comparable.js';
 
@@ -274,8 +274,8 @@ export class HandleConnection implements Comparable<HandleConnection> {
 
   toString(nameMap: Map<RecipeComponent, string>, options: ToStringOptions): string {
     const result: string[] = [];
-    result.push(this.name || '*');
-    result.push(directionToArrow(this.direction));
+    result.push(`${this.name || '*'}:`);
+    result.push(this.direction);
     if (this.handle) {
       if (this.handle.immediateValue) {
         result.push(this.handle.immediateValue.name);

--- a/src/runtime/recipe/recipe-util.ts
+++ b/src/runtime/recipe/recipe-util.ts
@@ -13,73 +13,30 @@ import {ParticleSpec, HandleConnectionSpec} from '../particle-spec.js';
 import {InterfaceType} from '../type.js';
 
 import {HandleConnection} from './handle-connection.js';
-import {Direction, DirectionArrow} from '../manifest-ast-nodes.js';
+import {Direction} from '../manifest-ast-nodes.js';
 import {Handle} from './handle.js';
 import {Particle} from './particle.js';
 import {Recipe, RecipeComponent} from './recipe.js';
 import {Id} from '../id.js';
 import {Dictionary} from '../hot.js';
 
-export function directionToArrow(direction: Direction): DirectionArrow {
-  // Use switch for totality checking.
+export function reverseDirection(direction: Direction): Direction {
   switch (direction) {
-    case 'out':
-      return '->';
     case 'in':
-      return '<-';
-    case 'inout':
-      return '<->';
-    case '`consume':
-      return 'consume';
-    case '`provide':
-      return 'provide';
-    case 'host':
-      return '='; // TODO(cypher1): Check this
-    case 'any':
-      return '=';
-    default:
-      throw new Error(`Bad direction ${direction}`);
-  }
-}
-
-export function arrowToDirection(arrow: DirectionArrow): Direction {
-  // Use switch for totality checking.
-  switch (arrow) {
-    case '->':
       return 'out';
-    case '<-':
+    case 'out':
       return 'in';
-    case '<->':
+    case 'inout':
       return 'inout';
-    case 'consume':
-      return '`consume';
-    case 'provide':
+    case '`consume':
       return '`provide';
-    case '=':
+    case '`provide':
+      return '`consume';
+    case 'any':
       return 'any';
     default:
       // Catch nulls and unsafe values from javascript.
-      throw new Error(`Bad arrow ${arrow}`);
-  }
-}
-
-export function reverseArrow(arrow: DirectionArrow): DirectionArrow {
-  switch (arrow) {
-    case '->':
-      return '<-';
-    case '<-':
-      return '->';
-    case '<->':
-      return '<->';
-    case 'consume':
-      return 'provide';
-    case 'provide':
-      return 'consume';
-    case '=':
-      return '=';
-    default:
-      // Catch nulls and unsafe values from javascript.
-      throw new Error(`Bad arrow ${arrow}`);
+      throw new Error(`Bad direction ${direction}`);
   }
 }
 
@@ -137,7 +94,7 @@ class Shape {
 }
 type DirectionCounts = {[K in Direction]: number};
 
-export type HandleRepr = {localName?: string, handle: string, tags?: string[], direction?: DirectionArrow};
+export type HandleRepr = {localName?: string, handle: string, tags?: string[], direction?: Direction};
 
 type RecipeUtilComponent = RecipeComponent | HandleConnectionSpec;
 
@@ -160,8 +117,8 @@ export class RecipeUtil {
         }
 
         const connection = pMap[key].addConnectionName(name);
-        // NOTE: for now, 'any' on the connection and '=' on the shape means 'accept anything'.
-        connection.direction = arrowToDirection(handle.direction || '=');
+        // NOTE: for now, 'any' on the connection and shape means 'accept anything'.
+        connection.direction = handle.direction || 'any';
 
         hMap.get(handle.handle).tags = tags;
         connection.connectToHandle(hMap.get(handle.handle));

--- a/src/runtime/recipe/recipe.ts
+++ b/src/runtime/recipe/recipe.ts
@@ -15,7 +15,7 @@ import {HandleConnectionSpec} from '../particle-spec.js';
 import {InterfaceType, Type} from '../type.js';
 
 import {ConnectionConstraint, EndPoint} from './connection-constraint.js';
-import {DirectionArrow} from '../manifest-ast-nodes.js';
+import {Direction} from '../manifest-ast-nodes.js';
 import {HandleConnection} from './handle-connection.js';
 import {Handle} from './handle.js';
 import {Particle} from './particle.js';
@@ -72,13 +72,13 @@ export class Recipe implements Cloneable<Recipe> {
     this._name = name;
   }
 
-  newConnectionConstraint(from: EndPoint, to: EndPoint, direction: DirectionArrow): ConnectionConstraint {
+  newConnectionConstraint(from: EndPoint, to: EndPoint, direction: Direction): ConnectionConstraint {
     const result = new ConnectionConstraint(from, to, direction, 'constraint');
     this._connectionConstraints.push(result);
     return result;
   }
 
-  newObligation(from: EndPoint, to: EndPoint, direction: DirectionArrow): ConnectionConstraint {
+  newObligation(from: EndPoint, to: EndPoint, direction: Direction): ConnectionConstraint {
     const result = new ConnectionConstraint(from, to, direction, 'obligation');
     this._obligations.push(result);
     return result;

--- a/src/runtime/tests/manifest-test.ts
+++ b/src/runtime/tests/manifest-test.ts
@@ -1474,7 +1474,7 @@ Expected a verb (e.g. &Verb) or an uppercase identifier (e.g. Foo) but "?" found
       assert.fail();
     } catch (e) {
       console.error(e.message);
-      assert.match(e.message, /'->' \(out\) not compatible with 'in' param of 'TestParticle'/);
+      assert.match(e.message, /'out' not compatible with 'in' param of 'TestParticle'/);
     }
   });
 

--- a/src/runtime/tests/recipe-test.ts
+++ b/src/runtime/tests/recipe-test.ts
@@ -14,6 +14,8 @@ import {Manifest} from '../manifest.js';
 import {Modality} from '../modality.js';
 import {Type} from '../type.js';
 
+import {withPreSlandlesSyntax} from '../manifest-ast-nodes.js';
+
 describe('recipe', () => {
   it('normalize errors', async () => {
     const manifest = await Manifest.parse(`
@@ -390,7 +392,118 @@ describe('recipe', () => {
     assert(recipe.normalize());
     assert.isFalse(recipe.isResolved());
   });
+  it('SLANDLES SYNTAX considers type resolution as recipe update', async () => {
+    const manifest = await Manifest.parse(`
+      schema Thing
+      particle Generic
+        in ~a anyA
+      particle Specific
+        in Thing thing
+      recipe
+        map as thingHandle
+        Generic
+          anyA: in thingHandle
+        Specific
+          thing: in thingHandle
+      store MyThings of Thing 'my-things' in ThingsJson
+      resource ThingsJson
+        start
+        [{}]
+    `);
+    assert.lengthOf(manifest.recipes, 1);
+    const recipe = manifest.recipes[0];
+    recipe.handles[0].id = 'my-things';
+    recipe.normalize();
+    assert.isFalse(recipe.isResolved());
+    assert.strictEqual(`recipe
+  map 'my-things' as handle0 // ~
+  Generic as particle0
+    anyA: in handle0
+  Specific as particle1
+    thing: in handle0`, recipe.toString());
+    assert.strictEqual(`recipe
+  map 'my-things' as handle0 // ~ // Thing {}  // unresolved handle: unresolved type
+  Generic as particle0
+    anyA: in handle0
+  Specific as particle1
+    thing: in handle0`, recipe.toString({showUnresolved: true}));
+    const hash = await recipe.digest();
+
+    const recipeClone = recipe.clone();
+    const hashClone = await recipeClone.digest();
+    assert.strictEqual(hash, hashClone);
+
+    const store = manifest.findStoreByName('MyThings');
+    recipeClone.handles[0].mapToStorage(store);
+    recipeClone.normalize();
+    assert.isTrue(recipeClone.isResolved());
+    const hashResolvedClone = await recipeClone.digest();
+    assert.strictEqual(`recipe
+  map 'my-things' as handle0 // Thing {}
+  Generic as particle0
+    anyA: in handle0
+  Specific as particle1
+    thing: in handle0`, recipeClone.toString());
+    assert.strictEqual(recipeClone.toString(), recipeClone.toString({showUnresolved: true}));
+    assert.notStrictEqual(hash, hashResolvedClone);
+  });
+  it('SLANDLES SYNTAX considers type resolution as recipe update', async () => {
+    const manifest = await Manifest.parse(`
+      schema Thing
+      particle Generic
+        in ~a anyA
+      particle Specific
+        in Thing thing
+      recipe
+        map as thingHandle
+        Generic
+          anyA: in thingHandle
+        Specific
+          thing: in thingHandle
+      store MyThings of Thing 'my-things' in ThingsJson
+      resource ThingsJson
+        start
+        [{}]
+    `);
+    assert.lengthOf(manifest.recipes, 1);
+    const recipe = manifest.recipes[0];
+    recipe.handles[0].id = 'my-things';
+    recipe.normalize();
+    assert.isFalse(recipe.isResolved());
+    assert.strictEqual(`recipe
+  map 'my-things' as handle0 // ~
+  Generic as particle0
+    anyA: in handle0
+  Specific as particle1
+    thing: in handle0`, recipe.toString());
+    assert.strictEqual(`recipe
+  map 'my-things' as handle0 // ~ // Thing {}  // unresolved handle: unresolved type
+  Generic as particle0
+    anyA: in handle0
+  Specific as particle1
+    thing: in handle0`, recipe.toString({showUnresolved: true}));
+    const hash = await recipe.digest();
+
+    const recipeClone = recipe.clone();
+    const hashClone = await recipeClone.digest();
+    assert.strictEqual(hash, hashClone);
+
+    const store = manifest.findStoreByName('MyThings');
+    recipeClone.handles[0].mapToStorage(store);
+    recipeClone.normalize();
+    assert.isTrue(recipeClone.isResolved());
+    const hashResolvedClone = await recipeClone.digest();
+    assert.strictEqual(`recipe
+  map 'my-things' as handle0 // Thing {}
+  Generic as particle0
+    anyA: in handle0
+  Specific as particle1
+    thing: in handle0`, recipeClone.toString());
+    assert.strictEqual(recipeClone.toString(), recipeClone.toString({showUnresolved: true}));
+    assert.notStrictEqual(hash, hashResolvedClone);
+  });
   it('considers type resolution as recipe update', async () => {
+    withPreSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
       schema Thing
       particle Generic
@@ -444,6 +557,7 @@ describe('recipe', () => {
     thing <- handle0`, recipeClone.toString());
     assert.strictEqual(recipeClone.toString(), recipeClone.toString({showUnresolved: true}));
     assert.notStrictEqual(hash, hashResolvedClone);
+  });
   });
   const isResolved = (recipe) => {
     const recipeClone = recipe.clone();

--- a/src/runtime/tests/recipe-test.ts
+++ b/src/runtime/tests/recipe-test.ts
@@ -392,7 +392,7 @@ describe('recipe', () => {
     assert(recipe.normalize());
     assert.isFalse(recipe.isResolved());
   });
-  it('SLANDLES SYNTAX considers type resolution as recipe update', async () => {
+  it('SLANDLES SYNTAX considers type resolution as recipe update', Flags.withPostSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
       schema Thing
       particle Generic
@@ -446,8 +446,8 @@ describe('recipe', () => {
     thing: in handle0`, recipeClone.toString());
     assert.strictEqual(recipeClone.toString(), recipeClone.toString({showUnresolved: true}));
     assert.notStrictEqual(hash, hashResolvedClone);
-  });
-  it('SLANDLES SYNTAX considers type resolution as recipe update', async () => {
+  }));
+  it('SLANDLES SYNTAX considers type resolution as recipe update', Flags.withPostSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
       schema Thing
       particle Generic
@@ -501,9 +501,8 @@ describe('recipe', () => {
     thing: in handle0`, recipeClone.toString());
     assert.strictEqual(recipeClone.toString(), recipeClone.toString({showUnresolved: true}));
     assert.notStrictEqual(hash, hashResolvedClone);
-  });
-  it('considers type resolution as recipe update', async () => {
-    Flags.withPreSlandlesSyntax(async () => {
+  }));
+  it('considers type resolution as recipe update', Flags.withPreSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
       schema Thing
       particle Generic
@@ -557,8 +556,7 @@ describe('recipe', () => {
     thing <- handle0`, recipeClone.toString());
     assert.strictEqual(recipeClone.toString(), recipeClone.toString({showUnresolved: true}));
     assert.notStrictEqual(hash, hashResolvedClone);
-    });
-  });
+  }));
   const isResolved = (recipe) => {
     const recipeClone = recipe.clone();
     assert.isTrue(recipeClone.normalize());

--- a/src/runtime/tests/recipe-test.ts
+++ b/src/runtime/tests/recipe-test.ts
@@ -14,7 +14,7 @@ import {Manifest} from '../manifest.js';
 import {Modality} from '../modality.js';
 import {Type} from '../type.js';
 
-import {withPreSlandlesSyntax} from '../manifest-ast-nodes.js';
+import {Flags} from '../flags.js';
 
 describe('recipe', () => {
   it('normalize errors', async () => {
@@ -503,7 +503,7 @@ describe('recipe', () => {
     assert.notStrictEqual(hash, hashResolvedClone);
   });
   it('considers type resolution as recipe update', async () => {
-    withPreSlandlesSyntax(async () => {
+    Flags.withPreSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
       schema Thing
       particle Generic
@@ -557,7 +557,7 @@ describe('recipe', () => {
     thing <- handle0`, recipeClone.toString());
     assert.strictEqual(recipeClone.toString(), recipeClone.toString({showUnresolved: true}));
     assert.notStrictEqual(hash, hashResolvedClone);
-  });
+    });
   });
   const isResolved = (recipe) => {
     const recipeClone = recipe.clone();


### PR DESCRIPTION
First step towards new slandles unification syntax. This uses in, out and inout still, reads/writes/reads writes to come later.

This should allow us to introduce a warning on usage of the old syntax once unification syntax is complete.

Might be worth checking the commits out individually (the first few are actual syntax changes and change conversion between arrows and directions, the later changes are working on testing and backwards compatibility).