### PR TITLE
Fix non-hermetic emsdk_wrapper

### DIFF
--- a/build_defs/emscripten/emsdk_wrapper.sh
+++ b/build_defs/emscripten/emsdk_wrapper.sh
@@ -12,16 +12,18 @@ print(os.path.abspath(sys.argv[1]))' "$repo_rel")
 
 # Set up the required environment variables. This is equivalent to running:
 #   source "$repo/emsdk_env.sh"
-export PATH="$PATH:$repo"
-export PATH="$PATH:$repo/fastcomp/emscripten"
-export PATH="$PATH:$repo/node/12.9.1_64bit/bin"
+export EM_PATH="$repo"
+export EM_PATH="$EM_PATH:$repo/fastcomp/emscripten"
+export EM_PATH="$EM_PATH:$repo/node/12.9.1_64bit/bin"
+# Note: Our path must come before $PATH to ensure we pick up the local emsdk
+export PATH="$EM_PATH:$PATH"
 export EMSDK="$repo"
 export EM_CONFIG="$repo/.emscripten"
 export EMSDK_NODE="$repo/node/12.9.1_64bit/bin/node"
 
 # Use a different location for emscripten's cache folder. The default one, which
 # is inside the emsdk folder, is read-only.
-export EM_CACHE="/tmp/bazel_emscripten"
+export EM_CACHE="$PWD/bazel_emscripten"
 
 # Run the command line args that were passed to this script.
 exec "$@"


### PR DESCRIPTION
Because emsdk_wrapper puts the $PATH first over its own repo, any system installed versions of emscripten outside bazel will be picked up. This broke my local OSX build because I had the very latest version of emscripten installed globally via brew, and it has a different ABI that the one Arcs requires.

Also, I moved the emscripten cache back to the execution root, so that in the future, when build caching is turned, the emscripten cache may be preserved between continuous integration builds as well.
