### PR TITLE
Align bazel version

### DIFF
--- a/javaharness/install_dependencies.sh
+++ b/javaharness/install_dependencies.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
 
-npm install -g @bazel/bazel@0.26.0
+# Aligns the bazel version among the downloaded binary and installed npm one.
+BAZEL_VERSION=$(awk -F'[="]' '{if($1 == "BAZEL_VERSION") print $3;}' ../tools/setup)
+
+npm install -g @bazel/bazel@${BAZEL_VERSION}
 npm install -g @bazel/ibazel

--- a/tools/setup
+++ b/tools/setup
@@ -97,6 +97,8 @@ rm "$BAZEL_SCRIPT_NAME"
 
 status "5.2. Updating PATH"
 append_once 'export PATH="$PATH:$HOME/bin"' ~/.profile
+# Makes the updates visiable at this subshell i.e. bazel
+source ~/.profile
 
 status "5.3. Set up the .bazelrc file"
 (cd $ROOT && ./tools/add_repo_root.sh)
@@ -115,3 +117,5 @@ echo "- Run tests:"
 echo "  - $CMD\`./tools/sigh test\`$END"
 echo "  - $CMD\`./tools/test\`$END"
 
+echo "\nPlease source the updated environment variables:"
+echo "  - $CMD\`source ~/.profile\`$END"


### PR DESCRIPTION
Align bazel version among tools/setup and javaharness deps installation.
Source the updated env variables at the subshell to reflect the changes,
otherwise the error "bazel: command not found" would appear in the
environment where bazel is not installed yet.