### PR TITLE
Generalize Flags.with methods

### DIFF
--- a/src/runtime/flags.ts
+++ b/src/runtime/flags.ts
@@ -11,8 +11,8 @@
 /** Arcs runtime flags. */
 
 class FlagDefaults {
-  static useNewStorageStack: boolean = false;
-  static usePreSlandlesSyntax: boolean = true;
+  static useNewStorageStack = false;
+  static usePreSlandlesSyntax = true;
 }
 
 export class Flags extends FlagDefaults {

--- a/src/runtime/flags.ts
+++ b/src/runtime/flags.ts
@@ -9,33 +9,28 @@
  */
 
 /** Arcs runtime flags. */
-export class Flags {
-  static useNewStorageStack: boolean;
-  static usePreSlandlesSyntax: boolean;
 
+class FlagDefaults {
+  static useNewStorageStack: boolean = false;
+  static usePreSlandlesSyntax: boolean = true;
+}
+
+export class Flags extends FlagDefaults {
   /** Resets flags. To be called in test teardown methods. */
   static reset() {
-    Flags.useNewStorageStack = false;
-    Flags.usePreSlandlesSyntax = true;
+    Object.assign(Flags, FlagDefaults);
   }
 
-  // For testing new syntax.
-  static withPostSlandlesSyntax(f) {
-    return async () => {
-      Flags.usePreSlandlesSyntax = false;
-      let res;
-      try {
-        res = await f();
-      } finally {
-        Flags.reset();
-      }
-      return res;
-    };
+  static withPreSlandlesSyntax<T>(f: () => Promise<T>): () => Promise<T> {
+    return Flags.withFlags({usePreSlandlesSyntax: true}, f);
   }
-  // For testing old syntax.
-  static withPreSlandlesSyntax(f) {
+  static withPostSlandlesSyntax<T>(f: () => Promise<T>): () => Promise<T> {
+    return Flags.withFlags({usePreSlandlesSyntax: false}, f);
+  }
+  // For testing with a different set of flags to the default.
+  static withFlags<T>(args: Partial<typeof FlagDefaults>, f: () => Promise<T>): () => Promise<T> {
     return async () => {
-      Flags.usePreSlandlesSyntax = true;
+      Object.assign(Flags, args);
       let res;
       try {
         res = await f();


### PR DESCRIPTION
This ensures that flags can be used in a type safe way and also reset easily inside tests.

I hope this will help ensure that bugs aren't introduced in making helpers for testing or breaking test-ability by tests modify global state.