### PR TITLE
Create CrdtEntityDescriptor, FieldValueInterpreter, etc.

### DIFF
--- a/src_kt/java/arcs/crdt/CrdtEntity.kt
+++ b/src_kt/java/arcs/crdt/CrdtEntity.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.crdt
+
+import arcs.crdt.internal.Referencable
+
+/**
+ * A [CrdtModel] capable of managing a complex entity consisting of named [CrdtSingleton]s and named
+ * [CrdtSet]s, each of which can manage various types of [Referencable] data.
+ *
+ * ```kotlin
+ * enum class Party {
+ *   Democratic, Republican, Independent
+ * }
+ * data class PersonReference(val id: String)
+ *
+ * CrdtEntity.addFieldValueInterpreters(
+ *   object : FieldValueInterpreter<String> {
+ *     override fun getReferenceId(value: String) = value
+ *     override fun serialize(value: String) = "$value".toByteArray()
+ *     override fun deserialize(rawData: ByteArray) = rawData.toString()
+ *   },
+ *   object : FieldValueInterpreter<Int> {
+ *     override fun getReferenceId(value: Int) = "$value"
+ *     override fun serialize(value: Int) = "$value".toByteArray()
+ *     override fun deserialize(rawData: ByteArray) = rawData.toString().toInt()
+ *   },
+ *   object : FieldValueInterpreter<Party> {
+ *     override fun getReferenceId(value: Party) = "${value.ordinal}"
+ *     override fun serialize(value: Party) = "$value".toByteArray()
+ *     override fun deserialize(rawData: ByteArray) = Party.valueOf(rawData.toString())
+ *   },
+ *   object : FieldValueInterpreter<PersonReference> {
+ *     override fun getReferenceId(value: PersonReference) = value.id
+ *     override fun serialize(value: PersonReference) = "${value.id}".toByteArray()
+ *     override fun deserialize(rawData: ByteArray) = PersonReference(id = rawData.toString())
+ *   }
+ * )
+ *
+ * val jason = CrdtEntity(
+ *   "name" to String::class,
+ *   "age" to Int::class,
+ *   "politicalParty" to Party::class,
+ *   // Only collection supported is MutableSet, at least until we have a CrdtModel for
+ *   "friends" to MutableSet<PersonReference>::class
+ * ).initialize(
+ *   "Jason Feinstein",
+ *   34,
+ *   Party.Independent,
+ *   mutableSetOf(
+ *     PersonReference("BJ Esmailbegui"),
+ *     PersonReference("Yusuf Simonson"),
+ *     PersonReference("Michael Whidby"),
+ *     PersonReference("Jason Kwon")
+ *   )
+ * )
+ * ```
+ */
+class CrdtEntity {
+
+}

--- a/src_kt/java/arcs/crdt/CrdtEntity.kt
+++ b/src_kt/java/arcs/crdt/CrdtEntity.kt
@@ -66,5 +66,7 @@ import arcs.crdt.internal.Referencable
  * ```
  */
 class CrdtEntity {
-
+  init {
+    TODO("Not implemented yet.")
+  }
 }

--- a/src_kt/java/arcs/crdt/entity/BUILD
+++ b/src_kt/java/arcs/crdt/entity/BUILD
@@ -6,6 +6,7 @@ kt_arcs_library(
     name = "entity",
     srcs = glob(["*.kt"]),
     deps = [
-        "//java/arcs/crdt/internal"
-    ]
+        "//java/arcs/crdt/internal",
+        "//java/arcs/util",
+    ],
 )

--- a/src_kt/java/arcs/crdt/entity/BUILD
+++ b/src_kt/java/arcs/crdt/entity/BUILD
@@ -1,0 +1,11 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//build_defs:build_defs.bzl", "kt_arcs_library")
+
+kt_arcs_library(
+    name = "entity",
+    srcs = glob(["*.kt"]),
+    deps = [
+        "//java/arcs/crdt/internal"
+    ]
+)

--- a/src_kt/java/arcs/crdt/entity/CrdtEntityDescriptor.kt
+++ b/src_kt/java/arcs/crdt/entity/CrdtEntityDescriptor.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.crdt.entity
+
+import kotlin.reflect.KClass
+
+/**
+ * Defines the fields capable of being managed by a Crdt-based Entity.
+ *
+ * TODO: determine how to support `Set<T : [Primitive | Referencable]>` field types as well.
+ */
+data class CrdtEntityDescriptor(
+  /** Mapping from [EntityFieldName] to the expected type of the field. */
+  private val descriptions: Map<EntityFieldName, KClass<*>>
+) : Map<EntityFieldName, KClass<*>> by descriptions {
+  /**
+   * Constructor allowing for creation of a [CrdtEntityDescriptor] using [Pair] notation.
+   *
+   * For example:
+   *
+   * ```kotlin
+   * val descriptor = CrdtEntityDescriptor(
+   *   "name" to Text::class,
+   *   "age" to Number::class
+   * )
+   * ```
+   */
+  constructor(vararg descriptions: Pair<EntityFieldName, KClass<*>>) :  this(mapOf(*descriptions))
+
+  init {
+    val unsupportedTypes = entries.filter { !it.value.isArcsSupportedFieldType }
+
+    if (unsupportedTypes.isNotEmpty()) {
+      throw IllegalArgumentException(
+        "The following fields are of types which have no registered FieldValueInterpreters: " +
+          unsupportedTypes.joinToString { "${it.key}(${it.value})" }
+      )
+    }
+  }
+}
+
+private val KClass<*>.isArcsSupportedFieldType: Boolean
+  get() = FieldValueInterpreter.containsInterpreterFor(this)
+
+

--- a/src_kt/java/arcs/crdt/entity/FieldValue.kt
+++ b/src_kt/java/arcs/crdt/entity/FieldValue.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.crdt.entity
+
+import arcs.crdt.internal.Referencable
+import arcs.crdt.internal.ReferenceId
+
+/**
+ * Referencable wrapper of an actual value for an entity's field.
+ *
+ * **Note:** A [FieldValueInterpreter] must have been registered for [T] before instantiation.
+ */
+data class FieldValue<T : Any>(
+  /** [ReferenceId] for the value. */
+  override val id: ReferenceId,
+  /** Raw string-representation of the value. */
+  val serializedValue: String,
+  /** @deprecated */
+  @Deprecated(
+    "Use getValue() instead.",
+    ReplaceWith("getValue()"),
+    DeprecationLevel.WARNING
+  )
+  var actualValue: T? = null
+) : Referencable {
+  /** Parsed value for the field. */
+  @Suppress("DEPRECATION")
+  inline fun <reified Out : T> getValue(): T =
+    actualValue ?: FieldValueInterpreter.deserialize<Out>(serializedValue).also { actualValue = it }
+}
+
+/**
+ * Pseudo-constructor for building a [FieldValue] from a given value of type [T].
+ *
+ * **Note:** A [FieldValueInterpreter] must have been registered for [T] before instantiation.
+ */
+inline fun <reified T : Any> FieldValue(value: T): FieldValue<T> =
+  FieldValue(
+    FieldValueInterpreter.getReferenceId(value),
+    FieldValueInterpreter.serialize(value),
+    value
+  )
+
+/**
+ * Convert a [T] to a [FieldValue] (referencable).
+ *
+ * **Note:** A [FieldValueInterpreter] must have been registered for [T].
+ */
+inline fun <reified T : Any> T.toFieldValue(): FieldValue<T> = FieldValue(this)
+
+/**
+ * Convert a serialized [T] to a [FieldValue] with the given [ReferenceId].
+ *
+ * **Note:** A [FieldValueInterpreter] must have been registered for [T].
+ */
+inline fun <reified T : Any> String.toFieldValue(id: ReferenceId): FieldValue<T> =
+  FieldValue(id, this)

--- a/src_kt/java/arcs/crdt/entity/FieldValueInterpreter.kt
+++ b/src_kt/java/arcs/crdt/entity/FieldValueInterpreter.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.crdt.entity
+
+import arcs.crdt.internal.ReferenceId
+import kotlin.reflect.KClass
+
+/**
+ * Defines an interpreter capable of serializing, deserializing, and identifying the value for an
+ * entity's field.
+ */
+interface FieldValueInterpreter<T> {
+  /** Identifies the [value]. */
+  fun getReferenceId(value: T): ReferenceId
+
+  /** Serializes the [value] to a [String]. */
+  fun serialize(value: T): String
+
+  /** Deserializes the [rawValue] to an instance of [T]. */
+  fun deserialize(rawValue: String): T
+
+  companion object {
+    private val registeredInterpreters = mutableMapOf<KClass<*>, FieldValueInterpreter<*>>()
+
+    /** Registers one or more [FieldValueInterpreter]s for later use. */
+    fun register(vararg interpreters: Pair<KClass<*>, FieldValueInterpreter<*>>) {
+      interpreters.forEach { (kClass, interpreter) ->
+        registeredInterpreters[kClass] = interpreter
+      }
+    }
+
+    /**
+     * Returns whether or not a [FieldValueInterpreter] has been registered for the given [KClass].
+     */
+    fun containsInterpreterFor(kClass: KClass<*>): Boolean = kClass in registeredInterpreters
+
+    /**
+     * Gets the [FieldValueInterpreter] associated with the given [KClass].
+     *
+     * @throws IllegalArgumentException if no [FieldValueInterpreter] has been registered for
+     *   [kClass].
+     */
+    @Suppress("UNCHECKED_CAST")
+    fun <T> requireInterpreter(kClass: KClass<*>): FieldValueInterpreter<T> =
+      requireNotNull(registeredInterpreters[kClass] as? FieldValueInterpreter<T>) {
+        "No FieldValueInterpreter registered for $kClass"
+      }
+
+    /**
+     * Gets a [ReferenceId] for the given value.
+     *
+     * @throws IllegalArgumentException if no [FieldValueInterpreter] has been registered for [T].
+     */
+    inline fun <reified T> getReferenceId(value: T): ReferenceId =
+      requireInterpreter<T>(T::class).getReferenceId(value)
+
+    /**
+     * Serializes the given [value] to a [String].
+     *
+     * @throws IllegalArgumentException if no [FieldValueInterpreter] has been registered for [T].
+     */
+    inline fun <reified T> serialize(value: T): String =
+      requireInterpreter<T>(T::class).serialize(value)
+
+    /**
+     * Deserializes a [T] instance from the given [rawValue].
+     *
+     * @throws IllegalArgumentException if no [FieldValueInterpreter] has been registered for [T].
+     */
+    inline fun <reified T> deserialize(rawValue: String): T =
+      requireInterpreter<T>(T::class).deserialize(rawValue)
+  }
+}

--- a/src_kt/java/arcs/crdt/entity/PrimitiveInterpreters.kt
+++ b/src_kt/java/arcs/crdt/entity/PrimitiveInterpreters.kt
@@ -12,6 +12,8 @@
 package arcs.crdt.entity
 
 import arcs.crdt.internal.ReferenceId
+import arcs.util.toBase64Bytes
+import arcs.util.toBase64String
 import kotlin.reflect.KClass
 import arcs.crdt.entity.Url as ArcsUrl
 
@@ -59,16 +61,18 @@ object PrimitiveInterpreters {
       arcs.crdt.entity.Bytes::class,
       "Bytes",
       { toBase64String() },
-      { toBase64Bytes() }
+      { toBase64Bytes() },
+      { contentHashCode() }
     )
 
   private fun <T : Any> buildInterpreter(
     kClass: KClass<T>,
     idPrefix: String = kClass.toString(),
     toString: T.() -> String,
-    fromString: String.() -> T
+    fromString: String.() -> T,
+    getHashCode: T.() -> Int = { hashCode() }
   ): Pair<KClass<T>, FieldValueInterpreter<T>> = kClass to object : FieldValueInterpreter<T> {
-    override fun getReferenceId(value: T): ReferenceId = "$idPrefix::${value.hashCode()}"
+    override fun getReferenceId(value: T): ReferenceId = "$idPrefix::${value.getHashCode()}"
     override fun serialize(value: T): String = toString(value)
     override fun deserialize(rawValue: String): T = rawValue.fromString()
   }

--- a/src_kt/java/arcs/crdt/entity/PrimitiveInterpreters.kt
+++ b/src_kt/java/arcs/crdt/entity/PrimitiveInterpreters.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.crdt.entity
+
+import arcs.crdt.internal.ReferenceId
+import kotlin.reflect.KClass
+import arcs.crdt.entity.Url as ArcsUrl
+
+/**
+ * Creates [FieldValueInterpreter]s for a number of arcs-supported primitives.
+ *
+ * * Boolean
+ * * Number (see the note below)
+ * * Text
+ * * Url
+ *
+ * **Note:** In order to use a number, the type used must be of type [Number] (not [Int], [Double],
+ * etc). TODO: Try to figure out a better solution for this.
+ */
+object PrimitiveInterpreters {
+  internal val Boolean: Pair<KClass<Boolean>, FieldValueInterpreter<Boolean>> =
+    buildInterpreter(kotlin.Boolean::class, "Boolean", kotlin.Boolean::toString, String::toBoolean)
+  internal val Number: Pair<KClass<Number>, FieldValueInterpreter<Number>> =
+    buildInterpreter(
+      kotlin.Number::class,
+      "Number",
+      // Regardless of which subclass of kotlin.Number, serialize as if it were a Double.
+      { toDouble().toString() },
+      { toDouble() }
+    )
+  internal val Text: Pair<KClass<Text>, FieldValueInterpreter<Text>> =
+    buildInterpreter(arcs.crdt.entity.Text::class, "Text", String::toJson, String::fromJson)
+  internal val Url: Pair<KClass<ArcsUrl>, FieldValueInterpreter<ArcsUrl>> =
+    buildInterpreter(
+      ArcsUrl::class,
+      "URL",
+      // Use the string value of the URL.
+      { string.toJson() },
+      { ArcsUrl(this.fromJson()) }
+    )
+  internal val Instant: Pair<KClass<Instant>, FieldValueInterpreter<Instant>> =
+    buildInterpreter(
+      arcs.crdt.entity.Instant::class,
+      "Instant",
+      arcs.crdt.entity.Instant::toString,
+      { toInstant() }
+    )
+  internal val Bytes: Pair<KClass<Bytes>, FieldValueInterpreter<Bytes>> =
+    buildInterpreter(
+      arcs.crdt.entity.Bytes::class,
+      "Bytes",
+      { toBase64String() },
+      { toBase64Bytes() }
+    )
+
+  private fun <T : Any> buildInterpreter(
+    kClass: KClass<T>,
+    idPrefix: String = kClass.toString(),
+    toString: T.() -> String,
+    fromString: String.() -> T
+  ): Pair<KClass<T>, FieldValueInterpreter<T>> = kClass to object : FieldValueInterpreter<T> {
+    override fun getReferenceId(value: T): ReferenceId = "$idPrefix::${value.hashCode()}"
+    override fun serialize(value: T): String = toString(value)
+    override fun deserialize(rawValue: String): T = rawValue.fromString()
+  }
+}
+
+/** Registers [FieldValueInterpreter]s for the supported primitive types. */
+fun FieldValueInterpreter.Companion.registerPrimitives() = register(
+  PrimitiveInterpreters.Boolean,
+  PrimitiveInterpreters.Number,
+  PrimitiveInterpreters.Text,
+  PrimitiveInterpreters.Url,
+  PrimitiveInterpreters.Instant,
+  PrimitiveInterpreters.Bytes
+)

--- a/src_kt/java/arcs/crdt/entity/entity.kt
+++ b/src_kt/java/arcs/crdt/entity/entity.kt
@@ -20,14 +20,6 @@ typealias Text = String
 /** Arcs-entity-friendly name for [ByteArray]. */
 typealias Bytes = ByteArray
 
-fun String.toBase64Bytes(): Bytes {
-  TODO("Implement once Base64 Utils have landed.")
-}
-
-fun ByteArray.toBase64String(): String {
-  TODO("Implement once Base64 Utils have landed.")
-}
-
 /** Point in time. Represents milliseconds from the epoch. */
 typealias Instant = Long
 

--- a/src_kt/java/arcs/crdt/entity/entity.kt
+++ b/src_kt/java/arcs/crdt/entity/entity.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.crdt.entity
+
+/** The name of a field within an entity. */
+typealias EntityFieldName = String
+
+/** Arcs-entity-friendly name for [String]. */
+typealias Text = String
+
+/** Arcs-entity-friendly name for [ByteArray]. */
+typealias Bytes = ByteArray
+
+fun String.toBase64Bytes(): Bytes {
+  TODO("Implement once Base64 Utils have landed.")
+}
+
+fun ByteArray.toBase64String(): String {
+  TODO("Implement once Base64 Utils have landed.")
+}
+
+/** Point in time. Represents milliseconds from the epoch. */
+typealias Instant = Long
+
+/** Converts a [String] to an [Instant]. */
+fun String.toInstant(): Instant = toLong()
+
+/**
+ * Represents a URL.
+ *
+ * **Note:** URL is not available as part of the kotlin runtime without the JVM, this class is meant
+ * to still support "URL" primitives in schemas.
+ *
+ * TODO: consider supporting common URL-related methods (encoding/decoding), getting the scheme,
+ *   etc.
+ */
+data class Url(val string: String) : CharSequence by string
+
+fun String.toJson(): String = "\"$this\""
+fun String.fromJson(): String = substring(1, length - 1)

--- a/src_kt/java/arcs/util/Base64.kt
+++ b/src_kt/java/arcs/util/Base64.kt
@@ -11,6 +11,11 @@
 
 package arcs.util
 
+/** Extension function to decode a base64 string into a [ByteArray]. */
+fun String.toBase64Bytes(): ByteArray = Base64.decode(this)
+
+fun ByteArray.toBase64String(): String = Base64.encode(this)
+
 /** Implementations of Base-64 encoding/decoding. */
 object Base64 {
   private const val CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"

--- a/src_kt/javatests/arcs/crdt/entity/BUILD
+++ b/src_kt/javatests/arcs/crdt/entity/BUILD
@@ -1,0 +1,17 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_test")
+
+[
+    kt_jvm_test(
+        name = src_file[:-3],
+        srcs = [src_file],
+        test_class = "arcs.crdt.entity.%s" % src_file[:-3],
+        deps = [
+            "@maven//:junit_junit",
+            "@maven//:com_google_truth_truth",
+            "//java/arcs/crdt/entity",
+            "//java/arcs/crdt/internal",
+        ]
+    ) for src_file in glob(["*.kt"])
+]

--- a/src_kt/javatests/arcs/crdt/entity/CrdtEntityDescriptorTest.kt
+++ b/src_kt/javatests/arcs/crdt/entity/CrdtEntityDescriptorTest.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.crdt.entity
+
+import org.junit.BeforeClass
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+/** Tests for [CrdtEntityDescriptor]. */
+@RunWith(JUnit4::class)
+class CrdtEntityDescriptorTest {
+  @Test(expected = IllegalArgumentException::class)
+  fun unsupportedType_triggersIllegalArgumentException() {
+    CrdtEntityDescriptor("dummy" to MyDummyType::class)
+  }
+
+  @Test
+  fun supportedTypes_areSupported() {
+    CrdtEntityDescriptor(
+      "name" to Text::class,
+      "age" to Number::class,
+      "website" to Url::class,
+      "knowsKotlin" to Boolean::class
+    )
+
+    // Shouldn't throw.
+  }
+
+  class MyDummyType
+
+  companion object {
+    @BeforeClass
+    @JvmStatic
+    fun beforeClass() {
+      FieldValueInterpreter.registerPrimitives()
+    }
+  }
+}

--- a/src_kt/javatests/arcs/crdt/entity/FieldValueInterpreterTest.kt
+++ b/src_kt/javatests/arcs/crdt/entity/FieldValueInterpreterTest.kt
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.crdt.entity
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.BeforeClass
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+/** Tests for [FieldValue], [FieldValueInterpreter], and [PrimitiveInterpreters]. */
+@RunWith(JUnit4::class)
+class FieldValueInterpreterTest {
+  @Test
+  fun numbersAreSupported() {
+    with((42.0 as Number).toFieldValue()) {
+      assertThat(id).isEqualTo("Number::${42.0.hashCode()}")
+      assertThat(serializedValue).isEqualTo("42.0")
+    }
+    with("42.0".toFieldValue<Number>("blah")) {
+      assertThat(getValue<Number>()).isEqualTo(42)
+    }
+  }
+
+  @Test
+  fun numbersAreSupported_intsSerializeToDoubles() {
+    with((1337 as Number).toFieldValue()) {
+      assertThat(serializedValue).isEqualTo("1337.0")
+    }
+  }
+
+  @Test
+  fun booleansAreSupported_true() {
+    with(true.toFieldValue()) {
+      assertThat(id).isEqualTo("Boolean::${true.hashCode()}")
+      assertThat(serializedValue).isEqualTo("true")
+    }
+    with("true".toFieldValue<Boolean>("blah")) {
+      assertThat(getValue<Boolean>()).isTrue()
+    }
+  }
+
+  @Test
+  fun booleansAreSupported_false() {
+    with(false.toFieldValue()) {
+      assertThat(id).isEqualTo("Boolean::${false.hashCode()}")
+      assertThat(serializedValue).isEqualTo("false")
+    }
+    with("false".toFieldValue<Boolean>("blah")) {
+      assertThat(getValue<Boolean>()).isFalse()
+    }
+  }
+
+  @Test
+  fun textIsSupported() {
+    with("this is a test".toFieldValue()) {
+      assertThat(id).isEqualTo("Text::${"this is a test".hashCode()}")
+      assertThat(serializedValue).isEqualTo("\"this is a test\"")
+    }
+    with("\"this is a test\"".toFieldValue<Text>("blah")) {
+      assertThat(getValue<Text>()).isEqualTo("this is a test")
+    }
+  }
+
+  @Test
+  fun textIsSupported_emptyString() {
+    with("".toFieldValue()) {
+      assertThat(id).isEqualTo("Text::${"".hashCode()}")
+      assertThat(serializedValue).isEqualTo("\"\"")
+    }
+    with("\"\"".toFieldValue<Text>("blah")) {
+      assertThat(getValue<Text>()).isEqualTo("")
+    }
+  }
+
+  @Test
+  fun urlIsSupported() {
+    with(Url("http://google.com").toFieldValue()) {
+      assertThat(id).isEqualTo("URL::${Url("http://google.com").hashCode()}")
+      assertThat(serializedValue).isEqualTo("\"http://google.com\"")
+    }
+    with("\"http://google.com\"".toFieldValue<Url>("blah")) {
+      assertThat(getValue<Url>()).isEqualTo(Url("http://google.com"))
+    }
+  }
+
+  @Test
+  fun instantIsSupported() {
+    with(System.currentTimeMillis().toFieldValue()) {
+      assertThat(id).isEqualTo("Instant::${getValue<Instant>().hashCode()}")
+      assertThat(serializedValue).isEqualTo("${getValue<Instant>()}")
+    }
+    val time = System.currentTimeMillis()
+    with(time.toString().toFieldValue<Instant>("blah")) {
+      assertThat(getValue<Instant>()).isEqualTo(time)
+    }
+  }
+
+  // TODO: enable this test when Base64 support is implemented.
+  //@Test
+  fun byteArrayIsSupported() {
+    val myData = "this is not a test"
+    val bytes = myData.toByteArray()
+
+    with(bytes.toFieldValue()) {
+      assertThat(id).isEqualTo("Bytes::${bytes.toBase64String().hashCode()}")
+      assertThat(serializedValue).isEqualTo(bytes.toBase64String())
+    }
+    with(bytes.toBase64String().toFieldValue<Bytes>("blah")) {
+      assertThat(getValue<Bytes>().asList()).containsExactlyElementsIn(bytes.asList())
+    }
+  }
+
+  companion object {
+    @BeforeClass
+    @JvmStatic
+    fun registerInterpreters() {
+      FieldValueInterpreter.registerPrimitives()
+    }
+  }
+}

--- a/src_kt/javatests/arcs/crdt/entity/FieldValueInterpreterTest.kt
+++ b/src_kt/javatests/arcs/crdt/entity/FieldValueInterpreterTest.kt
@@ -11,8 +11,10 @@
 
 package arcs.crdt.entity
 
+import arcs.util.toBase64String
 import com.google.common.truth.Truth.assertThat
 import org.junit.BeforeClass
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
@@ -105,14 +107,13 @@ class FieldValueInterpreterTest {
     }
   }
 
-  // TODO: enable this test when Base64 support is implemented.
-  //@Test
+  @Test
   fun byteArrayIsSupported() {
     val myData = "this is not a test"
     val bytes = myData.toByteArray()
 
     with(bytes.toFieldValue()) {
-      assertThat(id).isEqualTo("Bytes::${bytes.toBase64String().hashCode()}")
+      assertThat(id).isEqualTo("Bytes::${bytes.contentHashCode()}")
       assertThat(serializedValue).isEqualTo(bytes.toBase64String())
     }
     with(bytes.toBase64String().toFieldValue<Bytes>("blah")) {


### PR DESCRIPTION
These classes will be used by `CrdtEntity` (still a stub) to support entity definitions.

A rough sketch for how to use the field value interpreters with `CrdtEntity` is in the kdoc for it. Be warned: the sketch is very rough.