### PR TITLE
Change generated Kotlin schema filename

### DIFF
--- a/build_defs/build_defs.bzl
+++ b/build_defs/build_defs.bzl
@@ -74,7 +74,7 @@ def _android_and_wasm_library(name, srcs, deps):
 
 def arcs_kt_schema(name, src, out = None, deps = [], wasm_deps = []):
     """Generates a Kotlin file for the given .arcs schema file."""
-    out = out or _output_name(src, ".kt")
+    out = out or _output_name(src, "_GeneratedSchemas.kt")
     _run_schema2pkg(
         name = name + "_genrule",
         src = src,


### PR DESCRIPTION
For a file Foo.arcs, the generated code used to be output to Foo.kt. However, this could easily cause conflicts with an existing source file Foo.kt. Now, we instead call it Foo_GeneratedSchemas.kt, which no self-respecting developer would ever use. This should avoid conflicts.

Developers won't actually see this; they will still consume the generated code via the build rule's name, e.g. ":foo_schema".