### PR TITLE
Fix for broken master: Types & updates untyped (and out of date) direction unioning

### DIFF
--- a/src/planning/strategies/convert-constraints-to-connections.ts
+++ b/src/planning/strategies/convert-constraints-to-connections.ts
@@ -135,15 +135,16 @@ export class ConvertConstraintsToConnections extends Strategy {
             });
           }
 
-          const unionDirections = (a, b) => {
-            if (a === '=') {
-              return '=';
+          const unionDirections = (a: Direction, b: Direction): Direction => {
+            // TODO(jopra): Move to be with other handle direction + type resolution code.
+            if (a === 'any') {
+              return 'any';
             }
-            if (b === '=') {
-              return '=';
+            if (b === 'any') {
+              return 'any';
             }
             if (a !== b) {
-              return '=';
+              return 'any';
             }
             return a;
           };


### PR DESCRIPTION
I recently broke master because I didn't update some untyped code as it was not being tested well and, without types, I didn't realize that it was effected.

This should fix the breakage and ensure that it is updated in future.