### PR TITLE
Defines arcs_manifest build rule

### DIFF
--- a/build_defs/build_defs.bzl
+++ b/build_defs/build_defs.bzl
@@ -1,14 +1,16 @@
 """Arcs BUILD rules."""
 
 load(":run_in_repo.bzl", "EXECUTION_REQUIREMENTS_TAGS", "run_in_repo_test")
+load("//build_defs/internal:kotlin.bzl", _arcs_kt_binary = "arcs_kt_binary", _arcs_kt_library = "arcs_kt_library")
+load("//build_defs/internal:manifest.bzl", _arcs_manifest = "arcs_manifest")
 load("//build_defs/internal:schemas.bzl", _arcs_cc_schema = "arcs_cc_schema", _arcs_kt_schema = "arcs_kt_schema")
-load("//build_defs/internal:kotlin.bzl", _arcs_kt_library = "arcs_kt_library", _arcs_kt_binary = "arcs_kt_binary")
 
 # Re-export rules from various other files.
 arcs_cc_schema = _arcs_cc_schema
 arcs_kt_schema = _arcs_kt_schema
 arcs_kt_library = _arcs_kt_library
 arcs_kt_binary = _arcs_kt_binary
+arcs_manifest = _arcs_manifest
 
 def arcs_ts_test(name, src, deps):
     """Runs a TypeScript test file using `sigh test`."""

--- a/build_defs/internal/manifest.bzl
+++ b/build_defs/internal/manifest.bzl
@@ -1,0 +1,21 @@
+"""Arcs manifest bundling rules."""
+
+def arcs_manifest(name, srcs, deps = []):
+    """Bundles .arcs manifest files with their particle implementations.
+
+    Generates a filegroup that can be included in e.g. an Android assets folder.
+
+    TODO: Check that all the files referenced in the manifest files are included
+    (i.e. .wasm and .js particle implementations, and json data files).
+    """
+    for src in srcs:
+        if not src.endswith(".arcs"):
+            fail("srcs can only contain .arcs manifest files.")
+
+    native.filegroup(
+        name = name,
+        srcs = srcs + deps,
+    )
+
+    # TODO: Add a test to check that all required data files are included in
+    # deps.

--- a/particles/Native/Wasm/BUILD
+++ b/particles/Native/Wasm/BUILD
@@ -1,6 +1,6 @@
 load("//build_defs/kotlin_native:build_defs.bzl", "kt_wasm_binary", "kt_wasm_library")
 load("//build_defs/emscripten:build_defs.bzl", "cc_wasm_binary")
-load("//build_defs:build_defs.bzl", "arcs_kt_binary", "arcs_kt_schema", "arcs_cc_schema", "arcs_ts_test")
+load("//build_defs:build_defs.bzl", "arcs_kt_binary", "arcs_kt_schema", "arcs_cc_schema", "arcs_ts_test", "arcs_manifest")
 
 licenses(["notice"])
 
@@ -15,6 +15,12 @@ cc_wasm_binary(
     srcs = ["source/example.cc"],
     hdrs = ["example.h"],
     deps = ["//src/wasm/cpp:arcs"],
+)
+
+arcs_manifest(
+    name = "example_manifest",
+    srcs = ["example.arcs"],
+    deps = [":example_particle"],
 )
 
 arcs_kt_schema(

--- a/particles/Native/Wasm/example.arcs
+++ b/particles/Native/Wasm/example.arcs
@@ -8,13 +8,12 @@ resource ProductResource
 store ProductStore of Product in ProductResource
 
 // Particle name must match the C++ class name
-// Wasm module name must match one specified in wasm.json
-particle BasicParticle in 'module.wasm'
+particle BasicParticle in 'example_particle.wasm'
   consume root
   in Product foo
   out [Product] bar
 
-particle Watcher in 'https://$arcs/bazel-bin/particles/Native/Wasm/module.wasm'
+particle Watcher in 'example_particle.wasm'
   consume root
   in [Product] bar
 


### PR DESCRIPTION
Bundles .arcs manifest files and particle impls together into a
filegroup. This will let us include them easily in android assets.

In an upcoming PR: add a test to check that all dependencies are
included.