### PR TITLE
Tidy up javaharness WORKSPACE rules

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,4 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+# NodeJS
+
 http_archive(
     name = "build_bazel_rules_nodejs",
     sha256 = "0942d188f4d0de6ddb743b9f6642a26ce1ad89f09c0035a9a5ca5ba9615c96aa",
@@ -8,159 +11,29 @@ http_archive(
 load("@build_bazel_rules_nodejs//:index.bzl", "node_repositories")
 
 node_repositories(
-    package_json = ["//:package.json"],
     node_version = "10.16.0",
+    package_json = ["//:package.json"],
     yarn_version = "1.13.0",
 )
 
-load("//build_defs/emscripten:repo.bzl", "emsdk_repo")
-load("//build_defs/kotlin_native:repo.bzl", "kotlin_native_repo")
-
 # Install Emscripten via the emsdk.
+
+load("//build_defs/emscripten:repo.bzl", "emsdk_repo")
+
 emsdk_repo()
 
 # Install the Kotlin-Native compiler
+
+load("//build_defs/kotlin_native:repo.bzl", "kotlin_native_repo")
+
 kotlin_native_repo()
 
-maven_jar(
-    name = "org_json_local",
-    artifact = "org.json:json:20141113",
-)
-
-maven_jar(
-    name = "flogger",
-    artifact = "com.google.flogger:flogger:0.4",
-)
-
-maven_jar(
-    name = "flogger_system_backend",
-    artifact = "com.google.flogger:flogger-system-backend:0.4",
-)
-
-#git_repository(
-#    name = "android_sdk_downloader",
-#    remote = "https://github.com/quittle/bazel_android_sdk_downloader",
-#    commit = "a08905c5571dc9a74027ec57c90ffad53d7f7efe",
-#)
-
-#load("@android_sdk_downloader//:rules.bzl", "android_sdk_repository")
-
-#android_sdk_repository(
-#    name = "androidsdk",
-#    workspace_name = "arcs_javaharness",
-#  api_level = 27,
-#    build_tools_version = "27.0.3",
-#)
+# Android SDK
 
 android_sdk_repository(
     name = "androidsdk",
     api_level = 29,
 )
-
-# Needed for some reason now
-http_archive(
-    name = "rules_java",
-    sha256 = "bc81f1ba47ef5cc68ad32225c3d0e70b8c6f6077663835438da8d5733f917598",
-    strip_prefix = "rules_java-7cf3cefd652008d0a64a419c34c13bdca6c8f178",
-    urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_java/archive/7cf3cefd652008d0a64a419c34c13bdca6c8f178.zip",
-        "https://github.com/bazelbuild/rules_java/archive/7cf3cefd652008d0a64a419c34c13bdca6c8f178.zip",
-    ],
-)
-
-http_archive(
-    name = "rules_proto",
-    sha256 = "602e7161d9195e50246177e7c55b2f39950a9cf7366f74ed5f22fd45750cd208",
-    strip_prefix = "rules_proto-97d8af4dc474595af3900dd85cb3a29ad28cc313",
-    urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_proto/archive/97d8af4dc474595af3900dd85cb3a29ad28cc313.tar.gz",
-        "https://github.com/bazelbuild/rules_proto/archive/97d8af4dc474595af3900dd85cb3a29ad28cc313.tar.gz",
-    ],
-)
-
-
-
-rules_kotlin_version = "legacy-modded-1_0_0-01"
-rules_kotlin_sha = "b7984b28e0a1e010e225a3ecdf0f49588b7b9365640af783bd01256585cbb3ae"
-
-http_archive(
-    name = "io_bazel_rules_kotlin",
-    sha256 = rules_kotlin_sha,
-    strip_prefix = "rules_kotlin-%s" % rules_kotlin_version,
-    type = "zip",
-    urls = ["https://github.com/cgruber/rules_kotlin/archive/%s.zip" % rules_kotlin_version],
-)
-
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kotlin_repositories", "kt_register_toolchains")
-
-kotlin_repositories()  # if you want the default. Otherwise see custom kotlinc distribution below
-
-kt_register_toolchains()  # to use the default toolchain, otherwise see toolchains below
-
-# Load j2cl repository
-http_archive(
-    name = "com_google_j2cl",
-    strip_prefix = "j2cl-master",
-    url = "https://github.com/google/j2cl/archive/master.zip",
-)
-
-#http_archive(
-#    name = "google_bazel_common",
-#    strip_prefix = "bazel-common-1c225e62390566a9e88916471948ddd56e5f111c",
-#    urls = ["https://github.com/google/bazel-common/archive/1c225e62390566a9e88916471948ddd56e5f111c.zip"],
-#)
-
-load("@com_google_j2cl//build_defs:repository.bzl", "load_j2cl_repo_deps")
-
-load_j2cl_repo_deps()
-
-load("@com_google_j2cl//build_defs:rules.bzl", "setup_j2cl_workspace")
-
-setup_j2cl_workspace()
-
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-
-_JSINTEROP_BASE_VERSION = "master"
-
-http_archive(
-    name = "com_google_jsinterop_base",
-    strip_prefix = "jsinterop-base-%s" % _JSINTEROP_BASE_VERSION,
-    url = "https://github.com/google/jsinterop-base/archive/%s.zip" % _JSINTEROP_BASE_VERSION,
-)
-
-http_archive(
-    name = "com_google_dagger",
-    urls = ["https://github.com/google/dagger/archive/dagger-2.23.1.zip"],
-)
-
-maven_jar(
-    name = "com_google_dagger_runtime",
-    artifact = "com.google.dagger:dagger:jar:sources:2.23.1",
-)
-
-maven_jar(
-    name = "javax_inject_source",
-    artifact = "javax.inject:javax.inject:jar:sources:1",
-)
-
-maven_jar(
-    name = "junit",
-    artifact = "junit:junit:4.11",
-)
-
-http_archive(
-    name = "com_google_elemental2",
-    strip_prefix = "elemental2-master",
-    url = "https://github.com/google/elemental2/archive/master.zip",
-)
-
-load("@com_google_elemental2//build_defs:repository.bzl", "load_elemental2_repo_deps")
-
-load_elemental2_repo_deps()
-
-load("@com_google_elemental2//build_defs:workspace.bzl", "setup_elemental2_workspace")
-
-setup_elemental2_workspace()
 
 http_archive(
     name = "build_bazel_rules_android",
@@ -169,16 +42,57 @@ http_archive(
     urls = ["https://github.com/bazelbuild/rules_android/archive/v0.1.1.zip"],
 )
 
-AUTO_VALUE_VERSION = "1.7"
+# Kotlin
 
-maven_jar(
-    name = "autovalue",
-    artifact = "com.google.auto.value:auto-value:" + AUTO_VALUE_VERSION,
-    sha1 = "fe8387764ed19460eda4f106849c664f51c07121",
+rules_kotlin_version = "7543a917cda483c5856ec79b590343c9669eacd6"
+
+rules_kotlin_sha = "d335be363937ed62b5758cfdb33910ee52429835685345ef6b9f009c2bff9a9d"
+
+http_archive(
+    name = "io_bazel_rules_kotlin",
+    sha256 = rules_kotlin_sha,
+    strip_prefix = "rules_kotlin-%s" % rules_kotlin_version,
+    urls = ["https://github.com/bazelbuild/rules_kotlin/archive/%s.tar.gz" % rules_kotlin_version],
 )
 
-maven_jar(
-    name = "autovalue_annotations",
-    artifact = "com.google.auto.value:auto-value-annotations:" + AUTO_VALUE_VERSION,
-    sha1 = "5be124948ebdc7807df68207f35a0f23ce427f29",
+load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kotlin_repositories", "kt_register_toolchains")
+
+kotlin_repositories()
+
+kt_register_toolchains()
+
+# Java deps from Maven.
+
+RULES_JVM_EXTERNAL_TAG = "2.8"
+
+RULES_JVM_EXTERNAL_SHA = "79c9850690d7614ecdb72d68394f994fef7534b292c4867ce5e7dec0aa7bdfad"
+
+http_archive(
+    name = "rules_jvm_external",
+    sha256 = RULES_JVM_EXTERNAL_SHA,
+    strip_prefix = "rules_jvm_external-%s" % RULES_JVM_EXTERNAL_TAG,
+    url = "https://github.com/bazelbuild/rules_jvm_external/archive/%s.zip" % RULES_JVM_EXTERNAL_TAG,
+)
+
+load("@rules_jvm_external//:defs.bzl", "maven_install")
+
+AUTO_VALUE_VERSION = "1.7"
+
+maven_install(
+    artifacts = [
+        "org.json:json:20141113",
+        "com.google.flogger:flogger:0.4",
+        "com.google.flogger:flogger-system-backend:0.4",
+        "com.google.dagger:dagger:2.23.1",
+        "com.google.dagger:dagger-compiler:2.23.1",
+        "javax.inject:javax.inject:1",
+        "junit:junit:4.11",
+        "com.google.auto.value:auto-value:" + AUTO_VALUE_VERSION,
+        "com.google.auto.value:auto-value-annotations:" + AUTO_VALUE_VERSION,
+    ],
+    repositories = [
+        "https://jcenter.bintray.com/",
+        "https://maven.google.com",
+        "https://repo1.maven.org/maven2",
+    ],
 )

--- a/javaharness/BUILD
+++ b/javaharness/BUILD
@@ -4,12 +4,21 @@ package(default_visibility = ["//visibility:public"])
 java_plugin(
     name = "autovalue_plugin",
     processor_class = "com.google.auto.value.processor.AutoValueProcessor",
-    deps = ["@autovalue//jar"],
+    deps = ["@maven//:com_google_auto_value_auto_value"],
 )
 
 java_library(
     name = "autovalue",
     exported_plugins = [":autovalue_plugin"],
     neverlink = 1,  # Only used at compilation rather than at run-time.
-    exports = ["@autovalue_annotations//jar"],
+    exports = ["@maven//:com_google_auto_value_auto_value_annotations"],
+)
+
+java_plugin(
+    name = "dagger_compiler",
+    generates_api = 1,
+    processor_class = "dagger.internal.codegen.ComponentProcessor",
+    deps = [
+        "@maven//:com_google_dagger_dagger_compiler",
+    ],
 )

--- a/javaharness/java/arcs/android/BUILD
+++ b/javaharness/java/arcs/android/BUILD
@@ -10,22 +10,24 @@ load("@build_bazel_rules_android//android:rules.bzl", "android_library")
 android_library(
     name = "android",
     srcs = glob(["*.java"]),
-    javacopts = ["-Xep:AndroidJdkLibsChecker:OFF"],
-    idl_srcs = glob(["*.aidl"]),
-    idl_import_root = ".",
-    manifest = "AndroidManifest.xml",
     assets = [
         "//shells/pipes-shell:pipes_shell_web",
     ],
-    exports_manifest = 1,
     assets_dir = "pipes_shell_web_dist",
+    exports_manifest = 1,
+    idl_import_root = ".",
+    idl_srcs = glob(["*.aidl"]),
+    javacopts = ["-Xep:AndroidJdkLibsChecker:OFF"],
+    manifest = "AndroidManifest.xml",
+    plugins = [
+        "//javaharness:dagger_compiler",
+    ],
     resource_files = glob(["res/**"]),
     deps = [
         "//javaharness:autovalue",
         "//javaharness/java/arcs/api:api-android",
-        "@com_google_dagger",
-        "@flogger//jar",
-        "@flogger_system_backend//jar",
-        "@javax_inject_source//jar",
+        "@maven//:com_google_dagger_dagger",
+        "@maven//:com_google_flogger_flogger_system_backend",
+        "@maven//:javax_inject_javax_inject",
     ],
 )

--- a/javaharness/java/arcs/android/demo/BUILD
+++ b/javaharness/java/arcs/android/demo/BUILD
@@ -5,20 +5,22 @@ load("@build_bazel_rules_android//android:rules.bzl", "android_binary")
 android_binary(
     name = "demo",
     srcs = glob(["*.java"]),
-    manifest = "AndroidManifest.xml",
-    resource_files = glob(["res/**"]),
-    javacopts = ["-Xep:AndroidJdkLibsChecker:OFF"],
     dexopts = [
         "--min-sdk-version=29",
         "--target-sdk-version=29",
     ],
+    javacopts = ["-Xep:AndroidJdkLibsChecker:OFF"],
     licenses = ["notice"],
+    manifest = "AndroidManifest.xml",
+    plugins = [
+        "//javaharness:dagger_compiler",
+    ],
+    resource_files = glob(["res/**"]),
     deps = [
         "//javaharness/java/arcs/android",
         "//javaharness/java/arcs/api:api-android",
-        "@com_google_dagger",
-        "@flogger//jar",
-        "@flogger_system_backend//jar",
-        "@javax_inject_source//jar",
+        "@maven//:com_google_dagger_dagger",
+        "@maven//:com_google_flogger_flogger_system_backend",
+        "@maven//:javax_inject_javax_inject",
     ],
 )

--- a/javaharness/java/arcs/api/BUILD
+++ b/javaharness/java/arcs/api/BUILD
@@ -15,8 +15,8 @@ android_library(
     javacopts = ["-Xep:AndroidJdkLibsChecker:OFF"],
     deps = [
         "//javaharness/java/arcs/crdt:crdt-android",
-        "@com_google_dagger",
-        "@javax_inject_source//jar",
-        "@org_json//jar",
+        "@maven//:com_google_dagger_dagger",
+        "@maven//:javax_inject_javax_inject",
+        "@maven//:org_json_json",
     ],
 )

--- a/javaharness/java/arcs/crdt/BUILD
+++ b/javaharness/java/arcs/crdt/BUILD
@@ -14,7 +14,7 @@ android_library(
     ]),
     javacopts = ["-Xep:AndroidJdkLibsChecker:OFF"],
     deps = [
-      "@com_google_dagger",
-      "@javax_inject_source//jar",
+        "@maven//:com_google_dagger_dagger",
+        "@maven//:javax_inject_javax_inject",
     ],
 )

--- a/javaharness/javatests/arcs/android/BUILD
+++ b/javaharness/javatests/arcs/android/BUILD
@@ -8,6 +8,6 @@ java_test(
     deps = [
         "//javaharness/java/arcs/android",
         "//javaharness/java/arcs/api:api-android",
-        "@junit//jar",
+        "@maven//:junit_junit",
     ],
 )

--- a/javaharness/javatests/arcs/api/BUILD
+++ b/javaharness/javatests/arcs/api/BUILD
@@ -1,14 +1,12 @@
-
 licenses(["notice"])
 
 java_test(
     name = "AllTests",
-    srcs = glob(["*.java"]),
     size = "small",
+    srcs = glob(["*.java"]),
     test_class = "arcs.api.AllTests",
     deps = [
-        "@junit//jar",
         "//javaharness/java/arcs/api:api-android",
+        "@maven//:junit_junit",
     ],
 )
-

--- a/javaharness/javatests/arcs/crdt/BUILD
+++ b/javaharness/javatests/arcs/crdt/BUILD
@@ -1,14 +1,13 @@
-
 licenses(["notice"])
 
 java_test(
     name = "AllTests",
-    srcs = glob(["*.java"]),
     size = "small",
+    srcs = glob(["*.java"]),
     test_class = "arcs.crdt.AllTests",
     deps = [
-        "@junit//jar",
         "//javaharness/java/arcs/api:api-android",
         "//javaharness/java/arcs/crdt:crdt-android",
+        "@maven//:junit_junit",
     ],
 )


### PR DESCRIPTION
Migrated from maven_jar to maven_install, and removed some unused j2cl
deps.

In a follow-up PR I'll combine the src_kt/WORKSAPCE file with the main
WORKSPACE file to make things even simpler.