### PR TITLE
Create a `common` package.

### DIFF
--- a/src_kt/java/arcs/common/BUILD
+++ b/src_kt/java/arcs/common/BUILD
@@ -1,11 +1,11 @@
 package(default_visibility = ["//visibility:public"])
 
-load("//build_defs:build_defs.bzl", "kt_arcs_library")
+load("//build_defs:build_defs.bzl", "kt_jvm_and_js_library")
 
-kt_arcs_library(
+kt_jvm_and_js_library(
     name = "common",
     srcs = glob(["*.kt"]),
     deps = [
-        "//java/arcs/util"
+        "//src_kt/java/arcs/util"
     ]
 )

--- a/src_kt/java/arcs/common/BUILD
+++ b/src_kt/java/arcs/common/BUILD
@@ -5,4 +5,7 @@ load("//build_defs:build_defs.bzl", "kt_arcs_library")
 kt_arcs_library(
     name = "common",
     srcs = glob(["*.kt"]),
+    deps = [
+        "//java/arcs/util"
+    ]
 )

--- a/src_kt/java/arcs/common/BUILD
+++ b/src_kt/java/arcs/common/BUILD
@@ -1,0 +1,8 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//build_defs:build_defs.bzl", "kt_arcs_library")
+
+kt_arcs_library(
+    name = "common",
+    srcs = glob(["*.kt"]),
+)

--- a/src_kt/java/arcs/common/Id.kt
+++ b/src_kt/java/arcs/common/Id.kt
@@ -11,5 +11,114 @@
 
 package arcs.common
 
-class Id {
+import arcs.util.Random
+import arcs.util.nextSafeRandomLong
+
+/** Convenience extension to convert a string to an [Id]. */
+fun String.toId(): Id = Id.fromString(this)
+
+/** An immutable identifier for a resource in Arcs. */
+interface Id {
+  /**
+   * The session id from the particular session in which the [Id] was constructed.
+   *
+   * See [Id.Generator].
+   */
+  val root: String
+
+  /**
+   * A list of sub-components, forming a hierarchy of ids.
+   *
+   * Child [Id]s are created with the concatenation of their parent's [idTree] and their
+   * sub-component's name.
+   */
+  val idTree: List<String>
+
+  /** String representation of the [idTree]. */
+  val idTreeString: String
+    get() = idTree.joinToString(":")
+
+  /**
+   * Generates new [Id]s which are rooted in the current session.
+   *
+   * Only one [Generator] should be instantiated for each running Arc, and all of the [Id]s created
+   * should be created using that same [Generator] instance.
+   */
+  class Generator private constructor(
+    /** Unique identifier for the session associated with this [Generator]. */
+    val currentSessionId: String,
+    private var nextComponentId: Int = 0
+  ) {
+
+    /** Creates a new [ArcId] as a child of the current session. */
+    fun newArcId(name: String): ArcId = ArcId(currentSessionId, listOf(name))
+
+    /**
+     * Creates a new [Id], as a child of the given [parentId].
+     *
+     * The given [subComponent] will be appended to the component hierarchy of the given [parentId],
+     * but the generator's random session id ([currentSessionId]) will be used as the ID's root.
+     */
+    fun newChildId(parentId: Id, subComponent: String = ""): Id =
+      IdImpl(currentSessionId, parentId.idTree + listOf("$subComponent${nextComponentId++}"))
+
+    companion object {
+      /** Creates a new random session id and returns a [Generator] using it. */
+      fun newSession(): Generator = Generator(Random.nextSafeRandomLong().toString())
+
+      /**
+       * Creates a new [Generator] for use in testing.
+       *
+       * TODO: See if we can use android's @VisibleForTesting on the constructor instead of
+       *   providing this.
+       */
+      fun newForTest(sessionId: String) = Generator(sessionId)
+    }
+  }
+
+  companion object {
+    /** Parses an [Id] from a [String], see [Id.toString]. */
+    fun fromString(stringId: String): Id {
+      require(stringId.isNotBlank()) { "Id string cannot be empty" }
+
+      val bits = stringId.split(":")
+
+      return if (bits[0].startsWith("!")) {
+        IdImpl(bits[0].substring(1), bits.drop(1).filter { it.isNotBlank() })
+      } else {
+        IdImpl("", bits)
+      }
+    }
+
+  }
 }
+
+/** [Id] for an Arc. */
+data class ArcId internal constructor(
+  override val root: String,
+  override val idTree: List<String>
+) : Id {
+  override fun toString() = idToString(this)
+
+  companion object {
+    /**
+     * Creates a new [ArcId] with the given [name].
+     *
+     * For convenience in unit testing only; otherwise use [Id.Generator] to create new IDs.
+     *
+     * TODO: See if we can use android's @VisibleForTesting on the constructor instead of providing
+     *   this.
+     */
+    fun newForTest(name: String): ArcId = Id.Generator.newSession().newArcId(name)
+  }
+}
+
+internal data class IdImpl(
+  override val root: String,
+  override val idTree: List<String> = emptyList()
+): Id {
+  /** Returns the full ID string. */
+  override fun toString() = idToString(this)
+}
+
+private fun idToString(id: Id): String = "!${id.root}:${id.idTreeString}"

--- a/src_kt/java/arcs/common/Id.kt
+++ b/src_kt/java/arcs/common/Id.kt
@@ -9,8 +9,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-package arcs.crdt.internal
+package arcs.common
 
-/** Denotes an individual actor responsible for modifications to a Crdt. */
-typealias Actor = String
-
+class Id {
+}

--- a/src_kt/java/arcs/common/Literal.kt
+++ b/src_kt/java/arcs/common/Literal.kt
@@ -9,8 +9,9 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-package arcs.crdt.internal
+package arcs.common
 
-/** Denotes an individual actor responsible for modifications to a Crdt. */
-typealias Actor = String
+interface Literal
 
+/** A list of [Literal]s that is itself a [Literal]. */
+class LiteralList<T : Literal>(private val items: List<T>) : List<T> by items, Literal

--- a/src_kt/java/arcs/common/Literal.kt
+++ b/src_kt/java/arcs/common/Literal.kt
@@ -11,6 +11,10 @@
 
 package arcs.common
 
+/**
+ * An interface which denotes a particular (and immutable) class as being a serializable/copyable
+ * instance of a more complicated class.
+ */
 interface Literal
 
 /** A list of [Literal]s that is itself a [Literal]. */

--- a/src_kt/java/arcs/common/Referencable.kt
+++ b/src_kt/java/arcs/common/Referencable.kt
@@ -9,8 +9,13 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-package arcs.crdt.internal
+package arcs.common
 
-/** Denotes an individual actor responsible for modifications to a Crdt. */
-typealias Actor = String
+/** An identifier for a [Referencable]. */
+typealias ReferenceId = String
 
+/** Represents a referencable object, ie. one which can be referenced by a unique [id]. */
+interface Referencable {
+  /** Unique identifier of the Referencable object. */
+  val id: ReferenceId
+}

--- a/src_kt/java/arcs/crdt/BUILD
+++ b/src_kt/java/arcs/crdt/BUILD
@@ -6,6 +6,7 @@ kt_jvm_and_js_library(
     name = "crdt",
     srcs = glob(["*.kt"]),
     deps = [
+        "//src_kt/java/arcs/common",
         "//src_kt/java/arcs/crdt/internal",
     ],
 )

--- a/src_kt/java/arcs/crdt/CrdtEntity.kt
+++ b/src_kt/java/arcs/crdt/CrdtEntity.kt
@@ -11,7 +11,7 @@
 
 package arcs.crdt
 
-import arcs.crdt.internal.Referencable
+import arcs.common.Referencable
 
 /**
  * A [CrdtModel] capable of managing a complex entity consisting of named [CrdtSingleton]s and named

--- a/src_kt/java/arcs/crdt/CrdtSet.kt
+++ b/src_kt/java/arcs/crdt/CrdtSet.kt
@@ -12,8 +12,8 @@
 package arcs.crdt
 
 import arcs.crdt.internal.Actor
-import arcs.crdt.internal.Referencable
-import arcs.crdt.internal.ReferenceId
+import arcs.common.Referencable
+import arcs.common.ReferenceId
 import arcs.crdt.internal.VersionMap
 
 /** A [CrdtModel] capable of managing a set of items [T]. */

--- a/src_kt/java/arcs/crdt/CrdtSingleton.kt
+++ b/src_kt/java/arcs/crdt/CrdtSingleton.kt
@@ -14,8 +14,8 @@ package arcs.crdt
 import arcs.crdt.CrdtSet.Operation.Add
 import arcs.crdt.CrdtSet.Operation.Remove
 import arcs.crdt.internal.Actor
-import arcs.crdt.internal.Referencable
-import arcs.crdt.internal.ReferenceId
+import arcs.common.Referencable
+import arcs.common.ReferenceId
 import arcs.crdt.internal.VersionMap
 
 /** A [CrdtModel] capable of managing a mutable reference. */

--- a/src_kt/java/arcs/crdt/entity/BUILD
+++ b/src_kt/java/arcs/crdt/entity/BUILD
@@ -6,6 +6,7 @@ kt_jvm_and_js_library(
     name = "entity",
     srcs = glob(["*.kt"]),
     deps = [
+        "//src_kt/java/arcs/common",
         "//src_kt/java/arcs/crdt/internal",
         "//src_kt/java/arcs/util",
     ],

--- a/src_kt/java/arcs/crdt/entity/FieldValue.kt
+++ b/src_kt/java/arcs/crdt/entity/FieldValue.kt
@@ -11,8 +11,8 @@
 
 package arcs.crdt.entity
 
-import arcs.crdt.internal.Referencable
-import arcs.crdt.internal.ReferenceId
+import arcs.common.Referencable
+import arcs.common.ReferenceId
 
 /**
  * Referencable wrapper of an actual value for an entity's field.

--- a/src_kt/java/arcs/crdt/entity/FieldValueInterpreter.kt
+++ b/src_kt/java/arcs/crdt/entity/FieldValueInterpreter.kt
@@ -11,7 +11,7 @@
 
 package arcs.crdt.entity
 
-import arcs.crdt.internal.ReferenceId
+import arcs.common.ReferenceId
 import kotlin.reflect.KClass
 
 /**

--- a/src_kt/java/arcs/crdt/entity/PrimitiveInterpreters.kt
+++ b/src_kt/java/arcs/crdt/entity/PrimitiveInterpreters.kt
@@ -11,7 +11,7 @@
 
 package arcs.crdt.entity
 
-import arcs.crdt.internal.ReferenceId
+import arcs.common.ReferenceId
 import arcs.util.toBase64Bytes
 import arcs.util.toBase64String
 import kotlin.reflect.KClass

--- a/src_kt/java/arcs/util/random.kt
+++ b/src_kt/java/arcs/util/random.kt
@@ -1,0 +1,43 @@
+package arcs.util
+
+import kotlin.math.pow
+import kotlin.random.Random as KotlinRandom
+
+/**
+ * Instance of [kotlin.random.Random] to use arcs-wide.
+ *
+ * TODO: Consider seeding the random object ourselves. Unfortunately kotlin.system.getTimeMillis
+ *   isn't in the common kotlin library. This will mean we need to make this an `expect` and
+ *   implement it for JVM, JS, and WASM targets. Bonus points for using SecureRandom when running in
+ *   JVM.
+ */
+val Random: KotlinRandom
+  get() = RandomBuilder(null)
+
+/**
+ * Generator of a kotlin random class instance.
+ *
+ * This variable is configurable so as to make it possible for tests to make predictable 'random'
+ * behavior possible.
+ */
+var RandomBuilder: (seed: Long?) -> KotlinRandom = fn@{ seed ->
+  val globalRandom = globalRandomInstance
+
+  @Suppress("IfThenToElvis") // Because it's more readable like this.
+  if (globalRandom != null) {
+    // If we've already initialized the global random instance, use it.
+    return@fn globalRandom
+  } else {
+    // Looks like we need to initialize it still, so - depending on whether or not we have a seed,
+    // either return a seeded KotlinRandom, or the default.
+    return@fn (seed?.let { KotlinRandom(seed) } ?: KotlinRandom.Default)
+      // Stash it as the global instance.
+      .also { globalRandomInstance = it }
+  }
+}
+
+/** Gets the next Arcs-safe random long value. */
+fun KotlinRandom.nextSafeRandomLong(): Long = Random.nextLong(MAX_SAFE_LONG)
+
+private val MAX_SAFE_LONG = 2.0.pow(50).toLong()
+private var globalRandomInstance: KotlinRandom? = null

--- a/src_kt/javatests/arcs/common/BUILD
+++ b/src_kt/javatests/arcs/common/BUILD
@@ -9,7 +9,7 @@ load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_test")
         srcs = [src_file],
         test_class = "arcs.common.%s" % src_file[:-3],
         deps = [
-            "//java/arcs/common",
+            "//src_kt/java/arcs/common",
             "@maven//:com_google_truth_truth",
             "@maven//:junit_junit",
         ],

--- a/src_kt/javatests/arcs/common/BUILD
+++ b/src_kt/javatests/arcs/common/BUILD
@@ -1,0 +1,18 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_test")
+
+[
+    kt_jvm_test(
+        name = src_file[:-3],
+        size = "small",
+        srcs = [src_file],
+        test_class = "arcs.common.%s" % src_file[:-3],
+        deps = [
+            "//java/arcs/common",
+            "@maven//:com_google_truth_truth",
+            "@maven//:junit_junit",
+        ],
+    )
+    for src_file in glob(["*.kt"])
+]

--- a/src_kt/javatests/arcs/common/IdTest.kt
+++ b/src_kt/javatests/arcs/common/IdTest.kt
@@ -1,3 +1,14 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
 package arcs.common
 
 import arcs.util.RandomBuilder

--- a/src_kt/javatests/arcs/common/IdTest.kt
+++ b/src_kt/javatests/arcs/common/IdTest.kt
@@ -1,0 +1,91 @@
+package arcs.common
+
+import arcs.util.RandomBuilder
+import arcs.util.nextSafeRandomLong
+import com.google.common.truth.Truth.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+/** Tests for [Id]. */
+@RunWith(JUnit4::class)
+class IdTest {
+  private val testSessionid = "sessionId"
+  private lateinit var testGenerator: Id.Generator
+
+  @Before
+  fun setup() {
+    testGenerator = Id.Generator.newForTest(testSessionid)
+  }
+
+  @Test
+  fun parses_withExclamationMarks() {
+    assertThat(Id.fromString("!root")).isEqualTo(IdImpl("root"))
+    assertThat(Id.fromString("!root:")).isEqualTo(IdImpl("root"))
+    assertThat(Id.fromString("!root:x:y")).isEqualTo(IdImpl("root", listOf("x", "y")))
+  }
+
+  @Test
+  fun parses_withoutExclamationMarks() {
+    assertThat(Id.fromString("x")).isEqualTo(IdImpl("", listOf("x")))
+    assertThat(Id.fromString("x:y")).isEqualTo(IdImpl("", listOf("x", "y")))
+  }
+
+  @Test
+  fun encodesToAString() {
+    assertThat(IdImpl("root").toString()).isEqualTo("!root:")
+    assertThat(IdImpl("root", listOf("x", "y")).toString()).isEqualTo("!root:x:y")
+  }
+
+  @Test
+  fun encodesIdTree() {
+    assertThat(IdImpl("root").idTreeString).isEqualTo("")
+    assertThat(IdImpl("root", listOf("x", "y")).idTreeString).isEqualTo("x:y")
+  }
+
+  @Test
+  fun idGenerator_newSession_generatesRandomSessionId() {
+    val seed = 0
+    val knownRandom = { kotlin.random.Random(seed) }
+
+    // Set the global random builder.
+    val oldRandomBuilder = RandomBuilder
+    RandomBuilder = { knownRandom() }
+
+    val expectedRandomValue = knownRandom().nextSafeRandomLong()
+    val idGenerator = Id.Generator.newSession()
+
+    assertThat(idGenerator.currentSessionId).isEqualTo(expectedRandomValue.toString())
+    RandomBuilder = oldRandomBuilder
+  }
+
+  @Test
+  fun idGenerator_newChildId_createsChildIds_usingItsSessionId() {
+    val parentId = IdImpl("root")
+    val childId = testGenerator.newChildId(parentId, "z")
+    assertThat(childId.root).isEqualTo(testSessionid)
+  }
+
+  @Test
+  fun idGenerator_newChildId_appendsSubComponents() {
+    val parentId = IdImpl("root", listOf("x", "y"))
+    val childId = testGenerator.newChildId(parentId, "z")
+    assertThat(childId.idTree).containsExactly("x", "y", "z0")
+  }
+
+  @Test
+  fun idGenerator_newChildId_incrementsItsCounter() {
+    val parentId = IdImpl("root", listOf("x", "y"))
+    assertThat(testGenerator.newChildId(parentId, "z").idTree).containsExactly("x", "y", "z0")
+    assertThat(testGenerator.newChildId(parentId, "z").idTree).containsExactly("x", "y", "z1")
+    assertThat(testGenerator.newChildId(parentId, "z").idTree).containsExactly("x", "y", "z2")
+  }
+
+  @Test
+  fun idGenerator_newArcId_createsAValidArcId() {
+    val arcId = testGenerator.newArcId("foo")
+    assertThat(arcId).isInstanceOf(ArcId::class.java)
+    assertThat(arcId.toString()).isEqualTo("!sessionId:foo")
+  }
+}

--- a/src_kt/javatests/arcs/crdt/BUILD
+++ b/src_kt/javatests/arcs/crdt/BUILD
@@ -9,6 +9,7 @@ load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_test")
         srcs = [src_file],
         test_class = "arcs.crdt.%s" % src_file[:-3],
         deps = [
+            "//src_kt/java/arcs/common",
             "//src_kt/java/arcs/crdt",
             "//src_kt/java/arcs/crdt/internal",
             "@maven//:com_google_truth_truth",

--- a/src_kt/javatests/arcs/crdt/CrdtSetTest.kt
+++ b/src_kt/javatests/arcs/crdt/CrdtSetTest.kt
@@ -12,8 +12,8 @@
 package arcs.crdt
 
 import arcs.crdt.internal.Actor
-import arcs.crdt.internal.Referencable
-import arcs.crdt.internal.ReferenceId
+import arcs.common.Referencable
+import arcs.common.ReferenceId
 import arcs.crdt.internal.VersionMap
 import com.google.common.truth.Truth.assertThat
 import com.google.common.truth.Truth.assertWithMessage

--- a/src_kt/javatests/arcs/crdt/CrdtSingletonTest.kt
+++ b/src_kt/javatests/arcs/crdt/CrdtSingletonTest.kt
@@ -13,8 +13,8 @@ package arcs.crdt
 
 import arcs.crdt.CrdtSingleton.Operation.Clear
 import arcs.crdt.CrdtSingleton.Operation.Update
-import arcs.crdt.internal.Referencable
-import arcs.crdt.internal.ReferenceId
+import arcs.common.Referencable
+import arcs.common.ReferenceId
 import arcs.crdt.internal.VersionMap
 import com.google.common.truth.Truth.assertThat
 import org.junit.Before


### PR DESCRIPTION
This is the first of what's likely to be many PRs which will flesh out what's needed to support `CrdtEntity` implementation efforts.

In this PR:

* Created `arcs.common` package.
* Implemented `Id`, `IdGenerator`, `ArcsId`, as well as tests for them.
* Implemented the `Literal` interface and the `LiteralList` data class. (will be used heavily with `Type`, coming soon)
* Moved `Referencable` and `ReferenceId` to `arcs.common`.
* Created `arcs/util/random.kt` - an abstraction from Kotlin's `Random` which includes support for making random number generation not-random in tests.

I'd like to move the utils to be a subpackage of `common`, but will save that for another PR.