### PR TITLE
Delete oldData field from onHandleUpdate

### DIFF
--- a/src/runtime/handle.ts
+++ b/src/runtime/handle.ts
@@ -309,8 +309,7 @@ export class Singleton extends HandleOld {
         return;
       case 'update': {
         const data = this._restore(details.data);
-        const oldData = this._restore(details.oldData);
-        await particle.callOnHandleUpdate(this, {data, oldData}, e => this.reportUserExceptionInHost(e, particle, 'onHandleUpdate'));
+        await particle.callOnHandleUpdate(this, {data}, e => this.reportUserExceptionInHost(e, particle, 'onHandleUpdate'));
         return;
       }
       case 'desync':

--- a/src/runtime/particle.ts
+++ b/src/runtime/particle.ts
@@ -138,7 +138,7 @@ export class Particle {
   }
 
   // tslint:disable-next-line: no-any
-  async callOnHandleUpdate(handle: Handle, update: {data?: any, oldData?: any, added?: any, removed?: any, originator?: any}, onException: Consumer<Error>) {
+  async callOnHandleUpdate(handle: Handle, update: {data?: any, added?: any, removed?: any, originator?: any}, onException: Consumer<Error>) {
     await this.invokeSafely(async p => p.onHandleUpdate(handle, update), onException);
   }
 
@@ -151,13 +151,12 @@ export class Particle {
    * @param handle The Handle instance that was updated.
    * @param update An object containing one of the following fields:
    *  - data: The full Entity for a Singleton-backed Handle.
-   *  - oldData: The previous value of a Singleton before it was updated.
    *  - added: An Array of Entities added to a Collection-backed Handle.
    *  - removed: An Array of Entities removed from a Collection-backed Handle.
    *  - originator: whether the update originated from this particle.
    */
   // tslint:disable-next-line: no-any
-  protected async onHandleUpdate(handle: Handle, update: {data?: any, oldData?: any, added?: any, removed?: any, originator?: boolean}): Promise<void> {
+  protected async onHandleUpdate(handle: Handle, update: {data?: any, added?: any, removed?: any, originator?: boolean}): Promise<void> {
   }
 
   async callOnHandleDesync(handle: Handle, onException: Consumer<Error>) {

--- a/src/runtime/storage-proxy.ts
+++ b/src/runtime/storage-proxy.ts
@@ -455,9 +455,8 @@ export class SingletonProxy extends StorageProxy implements SingletonStore {
       }
       return null;
     }
-    const oldData = this.model;
     this.model = update.data;
-    return {...update, oldData};
+    return {...update};
   }
 
   // Read ops: if we're synchronized we can just return the local copy of the data.
@@ -488,12 +487,11 @@ export class SingletonProxy extends StorageProxy implements SingletonStore {
     } else {
       barrier = null;
     }
-    const oldData = this.model;
     // TODO: is this already a clone?
     this.model = JSON.parse(JSON.stringify(entity));
     this.barrier = barrier;
     this.port.HandleSet(this, entity, particleId, barrier);
-    const update = {originatorId: particleId, data: entity, oldData};
+    const update = {originatorId: particleId, data: entity};
     this._notify('update', update, options => options.notifyUpdate);
     return Promise.resolve();
   }
@@ -503,11 +501,10 @@ export class SingletonProxy extends StorageProxy implements SingletonStore {
       return Promise.resolve();
     }
     const barrier = this.generateBarrier();
-    const oldData = this.model;
     this.model = null;
     this.barrier = barrier;
     this.port.HandleClear(this, particleId, barrier);
-    const update = {originatorId: particleId, data: null, oldData};
+    const update = {originatorId: particleId, data: null};
     this._notify('update', update, options => options.notifyUpdate);
     return Promise.resolve();
   }

--- a/src/runtime/storageNG/handle.ts
+++ b/src/runtime/storageNG/handle.ts
@@ -101,7 +101,7 @@ export abstract class Handle<StorageType extends CRDTTypeRecord> {
     this.storageProxy.reportExceptionInHost(new UserException(exception, method, this.key, particle.spec.name));
   }
 
-  abstract onUpdate(update: StorageType['operation'], oldData: StorageType['consumerType'], version: VersionMap): void;
+  abstract onUpdate(update: StorageType['operation'], version: VersionMap): void;
   abstract onSync(): void;
 
   async onDesync(): Promise<void> {
@@ -224,7 +224,7 @@ export class CollectionHandle<T extends Entity> extends PreEntityMutationHandle<
     return [...set];
   }
 
-  async onUpdate(op: CollectionOperation<SerializedEntity>, oldData: Set<SerializedEntity>, version: VersionMap): Promise<void> {
+  async onUpdate(op: CollectionOperation<SerializedEntity>, version: VersionMap): Promise<void> {
     this.clock = version;
     // FastForward cannot be expressed in terms of ordered added/removed, so pass a full model to
     // the particle.
@@ -289,10 +289,10 @@ export class SingletonHandle<T extends Entity> extends PreEntityMutationHandle<C
     return value == null ? null : this.deserialize(value) as T;
   }
 
-  async onUpdate(op: SingletonOperation<SerializedEntity>, oldData: SerializedEntity, version: VersionMap): Promise<void> {
+  async onUpdate(op: SingletonOperation<SerializedEntity>, version: VersionMap): Promise<void> {
      this.clock = version;
     // Pass the change up to the particle.
-    const update: {data?: Entity, oldData: SerializedEntity, originator: boolean} = {oldData, originator: (this.key === op.actor)};
+    const update: {data?: Entity, originator: boolean} = {originator: (this.key === op.actor)};
     if (op.type === SingletonOpTypes.Set) {
       update.data = this.deserialize(op.value);
     }

--- a/src/runtime/storageNG/testing/test-storage.ts
+++ b/src/runtime/storageNG/testing/test-storage.ts
@@ -122,8 +122,8 @@ export class MockHandle<T extends CRDTTypeRecord> extends Handle<T> {
   onSync() {
     this.onSyncCalled = true;
   }
-  onUpdate(op: CRDTOperation, oldData: CRDTConsumerType, version: VersionMap) {
-    this.lastUpdate = [op, oldData, version];
+  onUpdate(op: CRDTOperation, version: VersionMap) {
+    this.lastUpdate = [op, version];
   }
 }
 

--- a/src/runtime/storageNG/tests/handle-test.ts
+++ b/src/runtime/storageNG/tests/handle-test.ts
@@ -160,7 +160,7 @@ describe('CollectionHandle', async () => {
       actor: 'actor',
       clock: {'actor': 1}
     };
-    await handle.onUpdate(op, new Set(), {'actor': 1, 'other': 2});
+    await handle.onUpdate(op, {'actor': 1, 'other': 2});
     assert.equal(Entity.id(particle.lastUpdate.removed), 'id');
     assert.isFalse(particle.lastUpdate.originator);
   });
@@ -175,7 +175,7 @@ describe('CollectionHandle', async () => {
       oldClock: {'actor': 1},
       newClock: {'actor': 1}
     };
-    await handle.onUpdate(op, new Set(), {'actor': 1, 'other': 2});
+    await handle.onUpdate(op, {'actor': 1, 'other': 2});
     assert.isTrue(particle.onSyncCalled);
   });
 
@@ -254,10 +254,8 @@ describe('SingletonHandle', async () => {
       actor: 'actor',
       clock: {'actor': 1}
     };
-    await handle.onUpdate(op, {id: 'old', rawData: {}}, {'actor': 1, 'other': 2});
-    assert.deepEqual(
-        particle.lastUpdate,
-        {data: {}, oldData: {id: 'old', rawData: {}}, originator: false});
+    await handle.onUpdate(op, {'actor': 1, 'other': 2});
+    assert.deepEqual(particle.lastUpdate, {data: {}, originator: false});
     assert.equal(Entity.id(particle.lastUpdate.data), 'id');
   });
 

--- a/src/runtime/storageNG/tests/storage-proxy-test.ts
+++ b/src/runtime/storageNG/tests/storage-proxy-test.ts
@@ -50,7 +50,7 @@ describe('StorageProxy', async () => {
       id: 1
     });
     await storageProxy.idle();
-    assert.sameDeepMembers(handle.lastUpdate, [op, null, {A: 1}]);
+    assert.sameDeepMembers(handle.lastUpdate, [op, {A: 1}]);
   });
 
   it('will sync if desynced before returning the particle view', async () => {

--- a/src/runtime/tests/particle-api-test.ts
+++ b/src/runtime/tests/particle-api-test.ts
@@ -100,17 +100,17 @@ describe('particle-api', () => {
     await fooHandle.set(new fooHandle.entityClass({value: 'v2'}));
     fooStore['_fire'] = fireFn;
     await fooHandle.set(new fooHandle.entityClass({value: 'v3'}));
-    await inspector.verify('update:{"data":{"value":"v1"},"oldData":null}',
+    await inspector.verify('update:{"data":{"value":"v1"}}',
                            'desync',
                            'sync:{"value":"v3"}');
 
     // Check it includes the previous value (v3) in updates.
     await fooHandle.set(new fooHandle.entityClass({value: 'v4'}));
-    await inspector.verify('update:{"data":{"value":"v4"},"oldData":{"value":"v3"}}');
+    await inspector.verify('update:{"data":{"value":"v4"}}');
 
     // Check clearing the store.
     await fooHandle.clear();
-    await inspector.verify('update:{"data":null,"oldData":{"value":"v4"}}');
+    await inspector.verify('update:{"data":null}');
   });
 
   it('can sync/update and store/remove with collections', async () => {

--- a/src/runtime/tests/storage-proxy-test.ts
+++ b/src/runtime/tests/storage-proxy-test.ts
@@ -155,9 +155,6 @@ class TestParticle {
     if ('data' in update) {
       details += this._toString(update.data);
     }
-    if ('oldData' in update && update.oldData !== null) {
-      details += `:(was:${this._toString(update.oldData)})`;
-    }
     if ('added' in update) {
       details += '+' + this._toString(update.added);
     }
@@ -342,7 +339,7 @@ describe('storage-proxy', () => {
 
     fooStore.clear();
     barStore.remove('i1');
-    await engine.verify('onHandleUpdate:P1:foo:(null):(was:oh)', 'onHandleUpdate:P1:bar:-[hai]');
+    await engine.verify('onHandleUpdate:P1:foo:(null)', 'onHandleUpdate:P1:bar:-[hai]');
   });
 
   it('notifies for updates to initially populated handles', async () => {
@@ -369,11 +366,11 @@ describe('storage-proxy', () => {
 
     fooStore.set(engine.newEntity('gday'));
     barStore.store('i3', engine.newEntity('mate'));
-    await engine.verify('onHandleUpdate:P1:foo:gday:(was:well)', 'onHandleUpdate:P1:bar:+[mate]');
+    await engine.verify('onHandleUpdate:P1:foo:gday', 'onHandleUpdate:P1:bar:+[mate]');
 
     fooStore.clear();
     barStore.remove('i2');
-    await engine.verify('onHandleUpdate:P1:foo:(null):(was:gday)', 'onHandleUpdate:P1:bar:-[there]');
+    await engine.verify('onHandleUpdate:P1:foo:(null)', 'onHandleUpdate:P1:bar:-[there]');
   });
 
   it('handles dropped updates on a Singleton with immediate resync', async () => {
@@ -661,7 +658,7 @@ describe('storage-proxy', () => {
     // Write to handle modifies the model directly, dispatches update and store write.
     const changed = engine.newEntity('changed');
     await fooHandle.set(changed);
-    await engine.verifySubsequence('onHandleUpdate:P1:foo:changed:(was:start)');
+    await engine.verifySubsequence('onHandleUpdate:P1:foo:changed');
     await engine.verify('HandleSet:foo:changed');
 
     // Read the handle again; the read should still be able to complete locally.
@@ -679,7 +676,7 @@ describe('storage-proxy', () => {
 
     // Subsequent updates should be visible in the handle.
     fooStore.set(engine.newEntity('subsequent'));
-    await engine.verify('onHandleUpdate:P1:foo:subsequent:(was:changed)');
+    await engine.verify('onHandleUpdate:P1:foo:subsequent');
   });
 
   it('multiple particles observing one proxy', async () => {
@@ -737,7 +734,7 @@ describe('storage-proxy', () => {
                         'onHandleSync:P1:foo:Huey', 'onHandleSync:P2:foo:Huey');
 
     fooStore.set(engine.newEntity('Dewey'));
-    await engine.verify('onHandleUpdate:P1:foo:Dewey:(was:Huey)', 'onHandleUpdate:P2:foo:Dewey:(was:Huey)');
+    await engine.verify('onHandleUpdate:P1:foo:Dewey', 'onHandleUpdate:P2:foo:Dewey');
 
     const particle3 = engine.newParticle();
     const fooHandle3 = engine.newHandle(fooStore, fooProxy, particle3, CAN_READ, CAN_WRITE);
@@ -745,8 +742,8 @@ describe('storage-proxy', () => {
     await engine.verify('onHandleSync:P3:foo:Dewey');
 
     fooStore.set(engine.newEntity('Louie'));
-    await engine.verify('onHandleUpdate:P1:foo:Louie:(was:Dewey)', 'onHandleUpdate:P2:foo:Louie:(was:Dewey)',
-                        'onHandleUpdate:P3:foo:Louie:(was:Dewey)');
+    await engine.verify('onHandleUpdate:P1:foo:Louie', 'onHandleUpdate:P2:foo:Louie',
+                        'onHandleUpdate:P3:foo:Louie');
   });
 
   it('multiple particles with different handle configurations', async () => {

--- a/src/runtime/wasm.ts
+++ b/src/runtime/wasm.ts
@@ -640,7 +640,7 @@ export class WasmParticle extends Particle {
   }
 
   // tslint:disable-next-line: no-any
-  async onHandleUpdate(handle: Handle, update: {data?: any, oldData?: any, added?: any, removed?: any, originator?: any}) {
+  async onHandleUpdate(handle: Handle, update: {data?: any, added?: any, removed?: any, originator?: any}) {
     if (update.originator) {
       return;
     }


### PR DESCRIPTION
This was unused, and is incompatible with the new storage proxy
structure.