### PR TITLE
Fix bug in //:all_srcs glob

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -3,8 +3,11 @@ licenses(["notice"])
 package(default_visibility = ["//visibility:public"])
 
 filegroup(
-  name = "tsconfig",
-  srcs = ["tsconfig.json", "config/tsconfig.base.json"]
+    name = "tsconfig",
+    srcs = [
+        "config/tsconfig.base.json",
+        "tsconfig.json",
+    ],
 )
 
 filegroup(
@@ -12,27 +15,32 @@ filegroup(
     srcs = glob(
         include = ["node_modules/**/*"],
         exclude = [
-          # Files under test & docs may contain file names that
-          # are not legal Bazel labels (e.g.,
-          # node_modules/ecstatic/test/public/äæ/ææ.html)
-          "node_modules/test/**",
-          "node_modules/docs/**",
-          # Files with spaces are not allowed in Bazel runfiles
-          # See https://github.com/bazelbuild/bazel/issues/4327
-          "node_modules/**/* */**",
-          "node_modules/**/* *",
+            # Files under test & docs may contain file names that
+            # are not legal Bazel labels (e.g.,
+            # node_modules/ecstatic/test/public/äæ/ææ.html)
+            "node_modules/test/**",
+            "node_modules/docs/**",
+            # Files with spaces are not allowed in Bazel runfiles
+            # See https://github.com/bazelbuild/bazel/issues/4327
+            "node_modules/**/* */**",
+            "node_modules/**/* *",
         ],
     ),
 )
 
 filegroup(
     name = "all_srcs",
+    # NOTE: This glob doesn't include files in directories which have their own
+    # BUILD files. You must add separate filegroups for those files.
     srcs = glob([
         "src/**",
         "tools/**",
         "devtools/shared/**",
         "shells/**/*.js",
         "modalities/**/*",
-    ]),
+    ]) + [
+        "//src/tools:all_srcs",
+        "//tools:tools_srcs",
+    ],
     visibility = ["//visibility:public"],
 )

--- a/src/tools/BUILD
+++ b/src/tools/BUILD
@@ -5,3 +5,9 @@ filegroup(
     ]),
     visibility = ["//visibility:public"],
 )
+
+filegroup(
+    name = "all_srcs",
+    srcs = glob(["**"]),
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
Globs can only reach into subdirectories when those subdirectories do
not contain a BUILD file of their own.

The :all_srcs filegroup was designed to copy over all of the important
src files into bazel runfiles so that things like `sigh build` can work.
However, there are some folder (notably the tools folders) that include
BUILD files, so those sources weren't being copied.

I've added deps for //src/tools and //tools so those now get included.

There are other folders that have BUILD files (e.g. //src/wasm) which
are still not being included, but I don't think that's an issue (for
now).

This isn't an ideal situation; I think we're going to continue to be
bitten by this as we continue to add more BUILD files. Having a proper
bazel-driven compilation for our TypeScript code would solve a lot of
problems...