### PR TITLE
Create `storage` package and the VolatileDriver.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -103,6 +103,9 @@ maven_install(
         "com.google.auto.value:auto-value-annotations:" + AUTO_VALUE_VERSION,
         "com.google.truth:truth:1.0",
         "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.2",
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core-js:1.3.2",
+        "org.jetbrains.kotlinx:atomicfu:0.13.1",
+        "org.jetbrains.kotlinx:atomicfu-js:0.13.1",
     ],
     repositories = [
         "https://jcenter.bintray.com/",

--- a/build_defs/internal/kotlin.bzl
+++ b/build_defs/internal/kotlin.bzl
@@ -39,11 +39,12 @@ def kt_jvm_and_js_library(
         deps = [_to_jvm_dep(dep) for dep in deps],
     )
 
-    kt_js_library(
-        name = "%s-js" % name,
-        srcs = srcs,
-        deps = [_to_js_dep(dep) for dep in deps],
-    )
+    # Disabled while https://github.com/bazelbuild/rules_kotlin/issues/219 is unfixed.
+    # kt_js_library(
+    #    name = "%s-js" % name,
+    #    srcs = srcs,
+    #    deps = [_to_js_dep(dep) for dep in deps],
+    #)
 
 def _to_jvm_dep(dep):
     return dep
@@ -76,7 +77,7 @@ def _kt_js_import_for_thirdparty(thirdparty_dep):
     kt_js_import(
         name = name,
         jars = [maven_name],
-        srcjar = "%s-%s-sources.jar" % (version, name)
+        srcjar = "%s-%s-sources.jar" % (name, version)
     )
 
     return ":%s" % name

--- a/build_defs/internal/kotlin.bzl
+++ b/build_defs/internal/kotlin.bzl
@@ -4,7 +4,7 @@ Rules are re-exported in build_defs.bzl -- use those instead.
 """
 
 load("//build_defs/kotlin_native:build_defs.bzl", "kt_wasm_binary", "kt_wasm_library")
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_android_library", "kt_js_library", "kt_jvm_library")
+load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_android_library", "kt_js_library", "kt_jvm_library", "kt_js_import")
 
 _ARCS_KOTLIN_LIBS = ["//src/wasm/kotlin:arcs_wasm"]
 
@@ -36,7 +36,7 @@ def kt_jvm_and_js_library(
     kt_jvm_library(
         name = name,
         srcs = srcs,
-        deps = deps,
+        deps = [_to_jvm_dep(dep) for dep in deps],
     )
 
     kt_js_library(
@@ -45,11 +45,39 @@ def kt_jvm_and_js_library(
         deps = [_to_js_dep(dep) for dep in deps],
     )
 
+def _to_jvm_dep(dep):
+    return dep
+
 def _to_js_dep(dep):
     last_part = dep.split("/")[-1]
+
+    if (dep.find("@maven") == 0):
+        return _kt_js_import_for_thirdparty(dep)
 
     index_of_colon = dep.find(":")
     if (index_of_colon == -1):
         return dep + (":%s-js" % last_part)
     else:
         return dep + "-js"
+
+def _kt_js_import_for_thirdparty(thirdparty_dep):
+    name = "unknown"
+    version = ""
+    maven_name = "unknown"
+    if (thirdparty_dep == "@maven//:org_jetbrains_kotlinx_kotlinx_coroutines_core"):
+        name = "kotlinx-coroutines-core-js"
+        version = "1.3.2"
+        maven_name = "@maven//:org_jetbrains_kotlinx_kotlinx_coroutines_core_js"
+    if (thirdparty_dep == "@maven//:org_jetbrains_kotlinx_atomicfu"):
+        name = "atomicfu-js"
+        version = "0.13.1"
+        maven_name = "@maven//:org_jetbrains_kotlinx_atomicfu_js"
+
+    kt_js_import(
+        name = name,
+        jars = [maven_name],
+        srcjar = "%s-%s-sources.jar" % (version, name)
+    )
+
+    return ":%s" % name
+

--- a/src_kt/.bazelproject
+++ b/src_kt/.bazelproject
@@ -2,6 +2,7 @@ directories:
   src_kt/java/arcs
   src_kt/javatests/arcs
   src_kt/project
+  build_defs
 
 targets:
   //src_kt/java/...

--- a/src_kt/java/arcs/Arc.kt
+++ b/src_kt/java/arcs/Arc.kt
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs
+
+class Arc {
+  // TODO: everything(?)
+}

--- a/src_kt/java/arcs/common/Id.kt
+++ b/src_kt/java/arcs/common/Id.kt
@@ -89,9 +89,11 @@ interface Id {
         IdImpl("", bits)
       }
     }
-
   }
 }
+
+/** Convenience to parse a [String] into an [ArcId]. */
+fun String.toArcId(): ArcId = toId().let { ArcId(it.root, it.idTree) }
 
 /** [Id] for an Arc. */
 data class ArcId internal constructor(
@@ -110,6 +112,7 @@ data class ArcId internal constructor(
      *   this.
      */
     fun newForTest(name: String): ArcId = Id.Generator.newSession().newArcId(name)
+
   }
 }
 

--- a/src_kt/java/arcs/storage/BUILD
+++ b/src_kt/java/arcs/storage/BUILD
@@ -3,7 +3,11 @@ package(default_visibility = ["//visibility:public"])
 load("//build_defs:build_defs.bzl", "kt_jvm_and_js_library")
 
 kt_jvm_and_js_library(
-    name = "util",
+    name = "storage",
     srcs = glob(["*.kt"]),
+    deps = [
+        "@maven//:org_jetbrains_kotlinx_kotlinx_coroutines_core",
+        "@maven//:org_jetbrains_kotlinx_atomicfu"
+    ]
 )
 

--- a/src_kt/java/arcs/storage/Driver.kt
+++ b/src_kt/java/arcs/storage/Driver.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.storage
+
+/**
+ * Interface that all drivers must support.
+ *
+ * Note the threading of a version number here; each model provided by the [Driver] to the [Store]
+ * (using a receiver registered with [registerReceiver]) is paired with a version, as is each model
+ * sent from the [Store] to the driver (using [send]).
+ *
+ * This threading is used to track whether driver state has changed while the [Store] is processing
+ * a particular model. [send] should always fail if the version isn't exactly `1` greater than the
+ * current internal version.
+ */
+interface Driver<Data : Any> {
+  /** Key identifying the [Driver]. */
+  val storageKey: StorageKey
+
+  /** Requirement for the existence of the [Driver]. */
+  val existenceCriteria: ExistenceCriteria
+
+  /** Registers a listener for [Data]. */
+  fun registerReceiver(receiver: (data: Data, version: Int) -> Unit)
+
+  /** Sends data to the [Driver] for storage. */
+  suspend fun send(data: Data, version: Int): Boolean
+
+  enum class ExistenceCriteria {
+    ShouldExist,
+    ShouldCreate,
+    MayExist
+  }
+}

--- a/src_kt/java/arcs/storage/Driver.kt
+++ b/src_kt/java/arcs/storage/Driver.kt
@@ -29,8 +29,17 @@ interface Driver<Data : Any> {
   /** Requirement for the existence of the [Driver]. */
   val existenceCriteria: ExistenceCriteria
 
+  /**
+   * Returns a token that represents the current state of the data.
+   *
+   * This can be provided to [registerReceiver], and will impact what data is delivered on
+   * initialization (only "new" data should be delivered, though note that this can be satisfied by
+   * sending a model for merging rather than by remembering a set of ops).
+   */
+  val token: String?
+
   /** Registers a listener for [Data]. */
-  fun registerReceiver(receiver: (data: Data, version: Int) -> Unit)
+  fun registerReceiver(token: String? = null, receiver: (data: Data, version: Int) -> Unit)
 
   /** Sends data to the [Driver] for storage. */
   suspend fun send(data: Data, version: Int): Boolean

--- a/src_kt/java/arcs/storage/DriverFactory.kt
+++ b/src_kt/java/arcs/storage/DriverFactory.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.storage
+
+import arcs.storage.Driver.ExistenceCriteria
+import kotlinx.atomicfu.atomic
+import kotlinx.atomicfu.update
+
+/** Factory with which to register and retrieve [Driver]s. */
+object DriverFactory {
+  private var providers = atomic(setOf<DriverProvider>())
+
+  /**
+   * Determines if a [DriverProvdier] has been registered which will support data at a given
+   * [storageKey].
+   */
+  fun willSupport(storageKey: StorageKey): Boolean =
+    providers.value.any { it.willSupport(storageKey) }
+
+  /**
+   * Fetches a [Driver] of type [Data] given its [storageKey] with specified [existenceCriteria].
+   */
+  suspend fun <Data : Any> getDriver(
+    storageKey: StorageKey,
+    existenceCriteria: ExistenceCriteria
+  ): Driver<Data>? {
+    return providers.value
+      .find { it.willSupport(storageKey) }
+      ?.getDriver(storageKey, existenceCriteria)
+  }
+
+  /** Registers a new [DriverProvider]. */
+  fun register(driverProvider: DriverProvider) = providers.update { it + setOf(driverProvider) }
+
+  /** Unregisters a [DriverProvider]. */
+  fun unregister(driverProvider: DriverProvider) = providers.update { it - setOf(driverProvider) }
+
+  /** Reset the driver registration to an empty set. For use in tests only. */
+  fun clearRegistrationsForTesting() = providers.lazySet(setOf())
+}
+
+/** Provider of information on the [Driver] and characteristics of the storage behind it. */
+interface DriverProvider {
+  /** Returns whether or not the driver will support data keyed by the [storageKey]. */
+  fun willSupport(storageKey: StorageKey): Boolean
+
+  /** Gets a [Driver] for the given [storageKey] with the specified [existenceCriteria]. */
+  suspend fun <Data : Any> getDriver(
+    storageKey: StorageKey,
+    existenceCriteria: ExistenceCriteria
+  ): Driver<Data>
+}

--- a/src_kt/java/arcs/storage/StorageKey.kt
+++ b/src_kt/java/arcs/storage/StorageKey.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.storage
+
+/** Locator for a specific piece of data within the storage layer. */
+abstract class StorageKey(val protocol: String) {
+  val childKeyForArcInfo: StorageKey
+    get() = childKeyWithComponent("arc-info")
+
+  abstract fun toKeyString(): String
+
+  abstract fun childKeyWithComponent(component: String): StorageKey
+
+  fun childKeyForHandle(handleId: String): StorageKey =
+    childKeyWithComponent("handle/$handleId")
+
+  override fun toString(): String = "$protocol://${toKeyString()}"
+}

--- a/src_kt/java/arcs/storage/StorageKeyParser.kt
+++ b/src_kt/java/arcs/storage/StorageKeyParser.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.storage
+
+/**
+ * Parses storage key string representations back into real StorageKey
+ * instances.
+ *
+ * If you modify the default set of storage keys in a test (using [addParser]), remember to call
+ * [reset] in the tear-down method.
+ */
+object StorageKeyParser {
+  private var parsers = DEFAULT_PARSERS.toMutableMap()
+
+  /** Parses a raw [key] into a [StorageKey]. */
+  fun parse(key: String): StorageKey {
+    val match = requireNotNull(VALID_KEY_PATTERN.matchEntire(key)) { "Illegal key: \"$key\"" }
+
+    val protocol = match.groupValues[1]
+    val contents = match.groupValues[2]
+    val parser = requireNotNull(parsers[protocol]) { "Unknown protocol \"$protocol\" in \"$key\"" }
+
+    return parser(contents)
+  }
+
+  /** Registers a new [StorageKey] parser for the given [protocol]. */
+  fun addParser(protocol: String, parser: (contents: String) -> StorageKey) {
+    parsers[protocol] = parser
+  }
+
+  /** Resets the registered parsers to the defaults. */
+  fun reset() {
+    parsers = DEFAULT_PARSERS.toMutableMap()
+  }
+}
+
+private val VALID_KEY_PATTERN = "^(\\w+)://(.*)$".toRegex()
+private val DEFAULT_PARSERS = mapOf<String, (contents: String) -> StorageKey>()

--- a/src_kt/java/arcs/storage/Store.kt
+++ b/src_kt/java/arcs/storage/Store.kt
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.storage
+
+interface Store {
+  // TODO: Everything.
+}

--- a/src_kt/java/arcs/storage/driver/BUILD
+++ b/src_kt/java/arcs/storage/driver/BUILD
@@ -6,6 +6,9 @@ kt_jvm_and_js_library(
     name = "driver",
     srcs = glob(["*.kt"]),
     deps = [
-        "//src_kt/java/arcs/storage"
+        "//src_kt/java/arcs/common",
+        "//src_kt/java/arcs/storage",
+        "//src_kt/java/arcs/util",
+        "@maven//:org_jetbrains_kotlinx_atomicfu",
     ]
 )

--- a/src_kt/java/arcs/storage/driver/BUILD
+++ b/src_kt/java/arcs/storage/driver/BUILD
@@ -3,7 +3,9 @@ package(default_visibility = ["//visibility:public"])
 load("//build_defs:build_defs.bzl", "kt_jvm_and_js_library")
 
 kt_jvm_and_js_library(
-    name = "util",
+    name = "driver",
     srcs = glob(["*.kt"]),
+    deps = [
+        "//src_kt/java/arcs/storage"
+    ]
 )
-

--- a/src_kt/java/arcs/storage/driver/Volatile.kt
+++ b/src_kt/java/arcs/storage/driver/Volatile.kt
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.storage.driver
+
+// TODO: create Volatile stuff.

--- a/src_kt/javatests/arcs/storage/BUILD
+++ b/src_kt/javatests/arcs/storage/BUILD
@@ -1,0 +1,18 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_test")
+
+[
+    kt_jvm_test(
+        name = src_file[:-3],
+        size = "small",
+        srcs = [src_file],
+        test_class = "arcs.storage.%s" % src_file[:-3],
+        deps = [
+            "//src_kt/java/arcs/storage",
+            "@maven//:com_google_truth_truth",
+            "@maven//:junit_junit",
+        ],
+    )
+    for src_file in glob(["*.kt"])
+]

--- a/src_kt/javatests/arcs/storage/StorageKeyParserTest.kt
+++ b/src_kt/javatests/arcs/storage/StorageKeyParserTest.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.storage
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.After
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import java.lang.Exception
+
+/** Tests for [StorageKeyParser]. */
+@RunWith(JUnit4::class)
+class StorageKeyParserTest {
+  @After
+  fun teardown() {
+    StorageKeyParser.reset()
+  }
+
+  @Test
+  fun addParser_registersParser() {
+    StorageKeyParser.addParser("myParser") {
+      MyStorageKey(it.split("/")) // dummy.
+    }
+
+    val parsed = StorageKeyParser.parse("myParser://foo/bar")
+    assertThat(parsed).isInstanceOf(MyStorageKey::class.java)
+    assertThat((parsed as MyStorageKey).components).containsExactly("foo", "bar")
+  }
+
+  @Test
+  fun reset_resetsToDefaults() {
+    StorageKeyParser.addParser("myParser") {
+      MyStorageKey(it.split("/")) // dummy.
+    }
+    StorageKeyParser.reset()
+
+    var thrownError: Exception? = null
+    try {
+      StorageKeyParser.parse("myParser://foo")
+    } catch (e: Exception) {
+      thrownError = e
+    }
+
+    assertThat(thrownError).isInstanceOf(IllegalArgumentException::class.java)
+  }
+
+  data class MyStorageKey(val components: List<String>) : StorageKey("myParser") {
+    override fun toKeyString(): String = components.joinToString("/")
+
+    override fun childKeyWithComponent(component: String): StorageKey =
+      MyStorageKey(components + listOf(component))
+  }
+}

--- a/src_kt/javatests/arcs/storage/driver/BUILD
+++ b/src_kt/javatests/arcs/storage/driver/BUILD
@@ -1,0 +1,22 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_test")
+
+[
+    kt_jvm_test(
+        name = src_file[:-3],
+        size = "small",
+        srcs = [src_file],
+        test_class = "arcs.storage.driver.%s" % src_file[:-3],
+        deps = [
+            "//src_kt/java/arcs/common",
+            "//src_kt/java/arcs/storage",
+            "//src_kt/java/arcs/storage/driver",
+            "//src_kt/java/arcs/util",
+            "@maven//:com_google_truth_truth",
+            "@maven//:junit_junit",
+            "@maven//:org_jetbrains_kotlinx_kotlinx_coroutines_core",
+        ],
+    )
+    for src_file in glob(["*.kt"])
+]

--- a/src_kt/javatests/arcs/storage/driver/VolatileDriverProviderTest.kt
+++ b/src_kt/javatests/arcs/storage/driver/VolatileDriverProviderTest.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.storage.driver
+
+import arcs.common.ArcId
+import arcs.storage.Driver
+import arcs.storage.DriverFactory
+import arcs.storage.StorageKey
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+/** Tests for [VolatileDriverProvider]. */
+@RunWith(JUnit4::class)
+class VolatileDriverProviderTest {
+  private lateinit var arcIdFoo: ArcId
+  private lateinit var arcIdBar: ArcId
+  private lateinit var fooProvider: VolatileDriverProvider
+  private lateinit var barProvider: VolatileDriverProvider
+
+  @Before
+  fun setup() {
+    arcIdFoo = ArcId.newForTest("foo")
+    arcIdBar = ArcId.newForTest("bar")
+    fooProvider = VolatileDriverProvider(arcIdFoo)
+    barProvider = VolatileDriverProvider(arcIdBar)
+  }
+
+  @After
+  fun tearDown() {
+    DriverFactory.clearRegistrationsForTesting()
+  }
+
+  @Test
+  fun constructor_registersSelfWithDriverFactory() {
+    // These also cover testing the happy-path of willSupport on VolatileDriverProvider itself.
+    assertThat(DriverFactory.willSupport(VolatileStorageKey(arcIdFoo, "myfoo"))).isTrue()
+    assertThat(DriverFactory.willSupport(VolatileStorageKey(arcIdBar, "mybar"))).isTrue()
+
+    // Make sure it's not returning true for just anything.
+    assertThat(
+      DriverFactory.willSupport(VolatileStorageKey(ArcId.newForTest("baz"), "myBaz"))
+    ).isFalse()
+  }
+
+  @Test
+  fun willSupport_requiresVolatileStorageKey() {
+    class NonVolatileKey : StorageKey("nonvolatile") {
+      override fun toKeyString() = "blah"
+      override fun childKeyWithComponent(component: String) = NonVolatileKey()
+    }
+
+    assertThat(fooProvider.willSupport(NonVolatileKey())).isFalse()
+  }
+
+  @Test
+  fun willSupport_requiresArcIdMatch() {
+    assertThat(fooProvider.willSupport(VolatileStorageKey(arcIdBar, "mybar"))).isFalse()
+  }
+
+  @Test
+  fun getDriver_getsDriverForExistenceCriteria() = runBlocking {
+    val driver =
+      fooProvider.getDriver<Int>(
+        VolatileStorageKey(arcIdFoo, "myfoo"),
+        Driver.ExistenceCriteria.ShouldCreate
+      )
+
+    assertThat(driver).isNotNull()
+    assertThat(driver.storageKey).isEqualTo(VolatileStorageKey(arcIdFoo, "myfoo"))
+    assertThat(driver.existenceCriteria).isEqualTo(Driver.ExistenceCriteria.ShouldCreate)
+  }
+}

--- a/src_kt/javatests/arcs/storage/driver/VolatileDriverTest.kt
+++ b/src_kt/javatests/arcs/storage/driver/VolatileDriverTest.kt
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.storage.driver
+
+import arcs.common.ArcId
+import arcs.storage.Driver.ExistenceCriteria
+import arcs.storage.StorageKey
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.fail
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+/** Tests for [VolatileDriver]. */
+@RunWith(JUnit4::class)
+class VolatileDriverTest {
+  private lateinit var key: VolatileStorageKey
+  private lateinit var arcId: ArcId
+  private lateinit var memory: VolatileMemory
+
+  @Before
+  fun setup() {
+    arcId = ArcId.newForTest("test")
+    memory = VolatileMemory()
+    key = VolatileStorageKey(arcId, "foo")
+  }
+
+  @Test
+  fun constructor_addsEntryToMemory() {
+    val driver = VolatileDriver<Int>(key, ExistenceCriteria.ShouldCreate, memory)
+
+    val expected = VolatileEntry(null, 0, driver)
+    val actual: VolatileEntry<Int>? = memory[key]
+    assertThat(expected).isEqualTo(actual)
+  }
+
+  @Test
+  fun constructor_addsEntryToMemory_andAppendsItselfToEntryDrivers() {
+    val driver1 = VolatileDriver<Int>(key, ExistenceCriteria.ShouldCreate, memory)
+    val driver2 = VolatileDriver<Int>(key, ExistenceCriteria.MayExist, memory)
+
+    val expected = VolatileEntry(null, 0, driver1, driver2)
+    val actual: VolatileEntry<Int>? = memory[key]
+    assertThat(expected).isEqualTo(actual)
+  }
+
+  @Test(expected = IllegalArgumentException::class)
+  fun constructorThrows_whenStorageKey_isNotVolatileStorageKey() {
+    class NotVolatileKey : StorageKey("notRight") {
+      override fun toKeyString(): String = "M'eh"
+      override fun childKeyWithComponent(component: String): StorageKey = NotVolatileKey()
+    }
+
+    VolatileDriver<Int>(NotVolatileKey(), ExistenceCriteria.ShouldExist, memory)
+  }
+
+  @Test(expected = IllegalArgumentException::class)
+  fun constructorThrows_whenShouldCreate_butAlreadyCreated() {
+    memory[key] = VolatileEntry(42)
+
+    VolatileDriver<Int>(key, ExistenceCriteria.ShouldCreate, memory)
+  }
+
+  @Test(expected = IllegalArgumentException::class)
+  fun constructorThrows_whenShouldExist_butDoesntExist() {
+    VolatileDriver<Int>(key, ExistenceCriteria.ShouldExist, memory)
+  }
+
+  @Test
+  fun firstRegisterReceiver_whenShouldExist_receivesExistingValue() {
+    memory[key] = VolatileEntry(42, version = 1337)
+
+    val driver = VolatileDriver<Int>(key, ExistenceCriteria.ShouldExist, memory)
+
+    var calledWithData: Int? = null
+    var calledWithVersion: Int? = null
+    fun receiver(data: Int, version: Int) {
+      calledWithData = data
+      calledWithVersion = version
+    }
+
+    driver.registerReceiver(receiver = ::receiver)
+
+    assertThat(calledWithData).isEqualTo(42)
+    assertThat(calledWithVersion).isEqualTo(1337)
+  }
+
+  @Test
+  fun firstRegisterReceiver_whenShouldExist_doesNotReceiveExistingValue_whenTokenMatches() {
+    memory[key] = VolatileEntry(42, version = 1337)
+
+    val driver = VolatileDriver<Int>(key, ExistenceCriteria.ShouldExist, memory)
+
+    @Suppress("UNUSED_PARAMETER")
+    fun receiver(data: Int, version: Int) {
+      fail("Should not be called.")
+    }
+
+    driver.registerReceiver(token = driver.token, receiver = ::receiver)
+  }
+
+  @Test
+  fun firstRegisterReceiver_whenMayExist_receivesExistingValue() {
+    memory[key] = VolatileEntry(42, version = 1337)
+
+    val driver = VolatileDriver<Int>(key, ExistenceCriteria.MayExist, memory)
+
+    var calledWithData: Int? = null
+    var calledWithVersion: Int? = null
+    fun receiver(data: Int, version: Int) {
+      calledWithData = data
+      calledWithVersion = version
+    }
+
+    driver.registerReceiver(receiver = ::receiver)
+
+    assertThat(calledWithData).isEqualTo(42)
+    assertThat(calledWithVersion).isEqualTo(1337)
+  }
+
+  @Test
+  fun firstRegisterReceiver_whenMayExist_doesNotReceiveValue_whenDoesntExist() {
+    val driver = VolatileDriver<Int>(key, ExistenceCriteria.MayExist, memory)
+
+    @Suppress("UNUSED_PARAMETER")
+    fun receiver(data: Int, version: Int) {
+      fail("Should not be called.")
+    }
+
+    driver.registerReceiver(receiver = ::receiver)
+  }
+
+  @Test
+  fun send_updatesMemory_whenVersion_isCorrect() = runBlocking {
+    val driver = VolatileDriver<Int>(key, ExistenceCriteria.ShouldCreate, memory)
+
+    assertThat(driver.send(data = 1, version = 1)).isTrue()
+
+    var expected = VolatileEntry(1, 1, driver)
+    var actual: VolatileEntry<Int>? = memory[key]
+    assertThat(expected).isEqualTo(actual)
+
+    assertThat(driver.send(data = 2, version = 2)).isTrue()
+
+    expected = VolatileEntry(2, 2, driver)
+    actual = memory[key]
+    assertThat(expected).isEqualTo(actual)
+  }
+
+  @Test
+  fun send_doesNotUpdateMemory_whenVersion_isIncorrect() = runBlocking {
+    val driver = VolatileDriver<Int>(key, ExistenceCriteria.ShouldCreate, memory)
+
+    assertThat(driver.send(data = 1, version = 0)).isFalse()
+
+    var expected = VolatileEntry(null, 0, driver)
+    var actual: VolatileEntry<Int>? = memory[key]
+    assertThat(expected).isEqualTo(actual)
+
+    assertThat(driver.send(data = 1, version = 2)).isFalse()
+
+    expected = VolatileEntry(null, 0, driver)
+    actual = memory[key]
+    assertThat(expected).isEqualTo(actual)
+  }
+
+  @Test
+  fun send_canSendToOtherDriverReceiver() = runBlocking {
+    val driver1 = VolatileDriver<Int>(key, ExistenceCriteria.ShouldCreate, memory)
+    val driver2 = VolatileDriver<Int>(key, ExistenceCriteria.ShouldExist, memory)
+
+    var receivedDataAt1: Int? = null
+    var receivedVersionAt1: Int? = null
+    driver1.registerReceiver(driver1.token) { data, version ->
+      receivedDataAt1 = data
+      receivedVersionAt1 = version
+    }
+
+    var receivedDataAt2: Int? = null
+    var receivedVersionAt2: Int? = null
+    driver2.registerReceiver(driver2.token) { data, version ->
+      receivedDataAt2 = data
+      receivedVersionAt2 = version
+    }
+
+    assertThat(driver1.send(1, 1)).isTrue()
+    assertThat(receivedDataAt1).isNull()
+    assertThat(receivedVersionAt1).isNull()
+    assertThat(receivedDataAt2).isEqualTo(1)
+    assertThat(receivedVersionAt2).isEqualTo(1)
+
+    assertThat(driver2.send(2, 2)).isTrue()
+    assertThat(receivedDataAt2).isEqualTo(1)
+    assertThat(receivedVersionAt2).isEqualTo(1)
+    assertThat(receivedDataAt1).isEqualTo(2)
+    assertThat(receivedVersionAt1).isEqualTo(2)
+  }
+}

--- a/src_kt/javatests/arcs/storage/driver/VolatileMemoryTest.kt
+++ b/src_kt/javatests/arcs/storage/driver/VolatileMemoryTest.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.storage.driver
+
+import arcs.common.ArcId
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+/** Tests for [VolatileMemory]. */
+@RunWith(JUnit4::class)
+class VolatileMemoryTest {
+  private val bar = VolatileStorageKey(ArcId.newForTest("foo"), "bar")
+  private val baz = bar.childKeyWithComponent("baz")
+
+  @Test
+  fun tokenChanges_withEachPutData() {
+    val memory = VolatileMemory()
+    val originalToken = memory.token
+
+    memory[bar] = VolatileEntry<Int>()
+
+    val afterBar = memory.token
+    assertThat(afterBar).isNotEqualTo(originalToken)
+
+    memory[baz] = VolatileEntry<Int>()
+    assertThat(memory.token).isNotEqualTo(originalToken)
+    assertThat(memory.token).isNotEqualTo(afterBar)
+  }
+
+  @Test
+  fun get_returnsNullIfNoEntryForKey() {
+    val memory = VolatileMemory()
+    memory[bar] = VolatileEntry<Int>()
+
+    val value: VolatileEntry<Int>? = memory[baz]
+    assertThat(value).isNull()
+  }
+
+  @Test
+  fun get_returnsValueIfEntryExistsForKey() {
+    val memory = VolatileMemory()
+    val expectedValue = VolatileEntry(data = 42)
+    memory[bar] = expectedValue
+
+    val value: VolatileEntry<Int>? = memory[bar]
+    assertThat(value).isEqualTo(expectedValue)
+  }
+}


### PR DESCRIPTION
Getting the ball rolling on actually implementing parts of the Storage apis.

* Adds:
  * `Driver`, `DriverProvider` interfaces
  * `DriverFactory` implementation.
  * `StorageKey` abstract class.
  * `StorageKeyParser` singleton (with tests)
  * `VolatileDriver` and associated other Volatile-related stuff. 
  * A bunch of stubs.
* Introduces some extra logic to translate the JVM maven dependencies to JS maven dependencies.
* Had to disable js-simultaneous builds for now (due to a bug in bazel's kotlin rules)