### PR TITLE
Convert RecipeHandle definitions to unified syntax

### DIFF
--- a/src/dataflow/analysis/tests/analysis-test.ts
+++ b/src/dataflow/analysis/tests/analysis-test.ts
@@ -1402,7 +1402,7 @@ describe('FlowGraph validation', () => {
         input: in MyEntity
         check input is trusted
       recipe R
-        use MyStore as s
+        s: use MyStore
         P
           input: in s
     `);
@@ -1910,7 +1910,7 @@ describe('FlowGraph validation', () => {
           input: in MyEntity
           check input is from store MyStore
         recipe R
-          use MyStore as s
+          s: use MyStore
           P
             input: in s
       `);
@@ -1947,7 +1947,7 @@ describe('FlowGraph validation', () => {
           input: in MyEntity
           check input is from store 'my-store-id'
         recipe R
-          use MyStore as s
+          s: use MyStore
           P
             input: in s
       `);
@@ -1985,7 +1985,7 @@ describe('FlowGraph validation', () => {
           input: in MyEntity
           check input is not from store 'my-store-id'
         recipe R
-          use MyStore as s
+          s: use MyStore
           P
             input: in h
       `);
@@ -2025,7 +2025,7 @@ describe('FlowGraph validation', () => {
           input: in MyEntity
           check input is not from store 'my-store-id'
         recipe R
-          use MyStore as s
+          s: use MyStore
           P
             input: in s
       `);
@@ -2108,7 +2108,7 @@ describe('FlowGraph validation', () => {
           input: in MyEntity
           check input is from store 'my-store-id'
         recipe R
-          use SomeOtherStore as s
+          s: use SomeOtherStore
           P
             input: in s
       `), 'Store with id my-store-id is not connected by a handle.');
@@ -2147,8 +2147,8 @@ describe('FlowGraph validation', () => {
           input2: in MyEntity
           check input1 is from store MyStore
         recipe R
-          use SomeOtherStore as s1
-          use MyStore as s2
+          s1: use SomeOtherStore
+          s2: use MyStore
           P
             input1: in s1
             input2: in s2

--- a/src/planning/strategies/tests/convert-constraints-to-connections-test.ts
+++ b/src/planning/strategies/tests/convert-constraints-to-connections-test.ts
@@ -45,7 +45,7 @@ describe('ConvertConstraintsToConnections', () => {
     const {result, score} = results[0];
     assert.deepEqual(result.toString(),
 `recipe
-  create as handle0 // S {}
+  handle0: create // S {}
   A as particle0
     b: inout handle0
   C as particle1
@@ -213,7 +213,7 @@ describe('ConvertConstraintsToConnections', () => {
     const {result, score} = results[0];
     assert.deepEqual(result.toString(),
 `recipe
-  create as handle0 // S {}
+  handle0: create // S {}
   A as particle0
     b: inout handle0
   C as particle1
@@ -264,7 +264,7 @@ describe('ConvertConstraintsToConnections', () => {
     const {result, score} = results[0];
     assert.deepEqual(result.toString(),
 `recipe
-  create as handle0 // S {}
+  handle0: create // S {}
   A as particle0
     b: inout handle0
   C as particle1
@@ -316,7 +316,7 @@ describe('ConvertConstraintsToConnections', () => {
     const {result, score} = results[0];
     assert.deepEqual(result.toString(),
 `recipe
-  create as handle0 // S {}
+  handle0: create // S {}
   A as particle0
     b: inout handle0
   C as particle1
@@ -360,7 +360,7 @@ describe('ConvertConstraintsToConnections', () => {
 
       recipe
         A.b: out C.d
-        use as handle1
+        handle1: use
         C
           d: inout handle1
         A`);
@@ -371,7 +371,7 @@ describe('ConvertConstraintsToConnections', () => {
     const {result, score} = results[0];
     assert.deepEqual(result.toString(),
 `recipe
-  use as handle0 // S {}
+  handle0: use // S {}
   A as particle0
     b: inout handle0
   C as particle1
@@ -417,7 +417,7 @@ describe('ConvertConstraintsToConnections', () => {
 
       recipe
         A.b: out C.d
-        use as handle1
+        handle1: use
         C
         A
           b: any handle1`);
@@ -428,7 +428,7 @@ describe('ConvertConstraintsToConnections', () => {
     const {result, score} = results[0];
     assert.deepEqual(result.toString(),
 `recipe
-  use as handle0 // S {}
+  handle0: use // S {}
   A as particle0
     b: inout handle0
   C as particle1
@@ -474,7 +474,7 @@ describe('ConvertConstraintsToConnections', () => {
 
       recipe
         A.b: out C.d
-        use as handle1
+        handle1: use
         C
           d: inout handle1
         A
@@ -485,7 +485,7 @@ describe('ConvertConstraintsToConnections', () => {
     assert.lengthOf(results, 1);
     const {result, score} = results[0];
     assert.deepEqual(result.toString(), `recipe
-  use as handle0 // S {}
+  handle0: use // S {}
   A as particle0
     b: inout handle0
   C as particle1
@@ -593,7 +593,7 @@ describe('ConvertConstraintsToConnections', () => {
       particle B
         i: in S {}
       recipe
-        ? as h
+        h: ?
         A.o: out h
         h: out B.i
     `);
@@ -602,7 +602,7 @@ describe('ConvertConstraintsToConnections', () => {
     const results = await cctc.generateFrom(generated);
     assert.lengthOf(results, 1);
     assert.deepEqual(results[0].result.toString(), `recipe
-  ? as handle0 // S {}
+  handle0: ? // S {}
   A as particle0
     o: out handle0
   B as particle1
@@ -640,7 +640,7 @@ describe('ConvertConstraintsToConnections', () => {
       particle B
         i: in S {}
       recipe
-        ? as h
+        h: ?
         A.o: out h
         h: out B.i
         A
@@ -651,7 +651,7 @@ describe('ConvertConstraintsToConnections', () => {
     const results = await cctc.generateFrom(generated);
     assert.lengthOf(results, 1);
     assert.deepEqual(results[0].result.toString(), `recipe
-  ? as handle0 // S {}
+  handle0: ? // S {}
   A as particle0
     o: out handle0
   B as particle1
@@ -691,7 +691,7 @@ describe('ConvertConstraintsToConnections', () => {
       particle B
         i: in S {}
       recipe
-        ? as h
+        h: ?
         A.o: out h
         h: out B.i
         A
@@ -703,7 +703,7 @@ describe('ConvertConstraintsToConnections', () => {
     const results = await cctc.generateFrom(generated);
     assert.lengthOf(results, 1);
     assert.deepEqual(results[0].result.toString(), `recipe
-  ? as handle0 // S {}
+  handle0: ? // S {}
   A as particle0
     o: out handle0
   B as particle1
@@ -744,8 +744,8 @@ describe('ConvertConstraintsToConnections', () => {
       particle B
         i: in S {}
       recipe
-        ? as h
-        ? as j
+        h: ?
+        j: ?
         A.o: out h
         h: out B.i
         A
@@ -757,8 +757,8 @@ describe('ConvertConstraintsToConnections', () => {
     const results = await cctc.generateFrom(generated);
     assert.lengthOf(results, 1);
     assert.deepEqual(results[0].result.toString(), `recipe
-  ? as handle0 // ~
-  ? as handle1 // S {}
+  handle0: ? // ~
+  handle1: ? // S {}
   A as particle0
     o: out handle0
   A as particle1
@@ -805,7 +805,7 @@ describe('ConvertConstraintsToConnections', () => {
     particle B
       i: out S {}
     recipe
-      ? #hashtag
+      *: ? #hashtag
       A.o: out #hashtag
       #trashbag: in B.i
     `);
@@ -814,8 +814,8 @@ describe('ConvertConstraintsToConnections', () => {
     const results = await cctc.generateFrom(generated);
     assert.lengthOf(results, 1);
     assert.deepEqual(results[0].result.toString(), `recipe
-  ? #hashtag as handle0 // ~
-  create #trashbag as handle1 // ~
+  handle0: ? #hashtag // ~
+  handle1: create #trashbag // ~
   A as particle0
     o: out handle0
   B as particle1
@@ -854,7 +854,7 @@ describe('ConvertConstraintsToConnections', () => {
     particle B
       i: out S {}
     recipe
-      ? #hashtag
+      *: ? #hashtag
       A.o: out #hashtag
       #trashbag: in B.i
       A
@@ -865,8 +865,8 @@ describe('ConvertConstraintsToConnections', () => {
     const results = await cctc.generateFrom(generated);
     assert.lengthOf(results, 1);
     assert.deepEqual(results[0].result.toString(), `recipe
-  ? #hashtag as handle0 // ~
-  create #trashbag as handle1 // ~
+  handle0: ? #hashtag // ~
+  handle1: create #trashbag // ~
   A as particle0
     o: out handle0
   B as particle1
@@ -907,7 +907,7 @@ describe('ConvertConstraintsToConnections', () => {
     particle B
       i: out S {}
     recipe
-      ? #hashtag as handle0
+      handle0: ? #hashtag
       A.o: out #hashtag
       #trashbag: in B.i
       A
@@ -920,7 +920,7 @@ describe('ConvertConstraintsToConnections', () => {
     const results = await cctc.generateFrom(generated);
     assert.lengthOf(results, 1);
     assert.deepEqual(results[0].result.toString(), `recipe
-  ? #hashtag as handle0 // ~
+  handle0: ? #hashtag // ~
   A as particle0
     o: out handle0
   B as particle1

--- a/src/planning/strategies/tests/match-recipe-by-verb-test.ts
+++ b/src/planning/strategies/tests/match-recipe-by-verb-test.ts
@@ -104,7 +104,7 @@ describe('MatchRecipeByVerb', () => {
     assert.lengthOf(results, 1);
     assert.deepEqual(results[0].result.toString(),
 `recipe &a
-  create as handle0 // S {}
+  handle0: create // S {}
   P as particle0
     p: out handle0
   Q as particle1
@@ -294,7 +294,7 @@ ${recipesManifest}`);
   it('SLANDLES SYNTAX listens to handle constraints - handle', Flags.withPostSlandlesSyntax(async () => {
     const results = await slandlesSyntaxGeneratePlans(`
       recipe
-        create as handle0
+        handle0: create
         &verb
           *: out handle0
       `);
@@ -378,7 +378,7 @@ ${recipesManifest}`);
         P
 
       recipe
-        create as handle0
+        handle0: create
         &verb
           a: in handle0
         Q
@@ -439,7 +439,7 @@ ${recipesManifest}`);
         P
 
       recipe
-        create as handle0
+        handle0: create
         &verb
           *: in handle0
         Q
@@ -508,7 +508,7 @@ ${recipesManifest}`);
         P
 
       recipe
-        create as handle0
+        handle0: create
         &verb
           *: in handle0
         Q

--- a/src/planning/tests/planner-test.ts
+++ b/src/planning/tests/planner-test.ts
@@ -147,7 +147,7 @@ describe('Planner', () => {
         one: \`consume Slot
         two: \`consume Slot
       recipe
-        \`slot 'slot-id0' as s0
+        s0: \`slot 'slot-id0'
         P1
           one: \`consume s0
     `);
@@ -160,7 +160,7 @@ describe('Planner', () => {
         one: \`consume [Slot]
         two: \`consume [Slot]
       recipe
-        \`slot 'slot-id0' as s0
+        s0: \`slot 'slot-id0'
         P1
           one: \`consume s0
     `);
@@ -173,7 +173,7 @@ describe('Planner', () => {
         one: \`consume Slot
         two: \`consume Slot
       recipe
-        \`slot 'slot-id0' as s0
+        s0: \`slot 'slot-id0'
         P1
           one: any s0
     `);
@@ -186,7 +186,7 @@ describe('Planner', () => {
         one: \`consume [Slot]
         two: \`consume [Slot]
       recipe
-        \`slot 'slot-id0' as s0
+        s0: \`slot 'slot-id0'
         P1
           one: any s0
     `);
@@ -201,8 +201,8 @@ describe('Planner', () => {
       particle P2 in './render.js'
         inSlot: \`consume Slot
       recipe
-        \`slot 'slot-id0' as s0
-        \`slot 'slot-id1' as s1
+        s0: \`slot 'slot-id0'
+        s1: \`slot 'slot-id1'
         P1
           inSlot: any s0
           outSlot: any s1
@@ -220,8 +220,8 @@ describe('Planner', () => {
       particle P2 in './render.js'
         inSlot: \`consume [Slot]
       recipe
-        \`slot 'slot-id0' as s0
-        \`slot 'slot-id1' as s1
+        s0: \`slot 'slot-id0'
+        s1: \`slot 'slot-id1'
         P1
           inSlot: any s0
           outSlot: any s1
@@ -239,8 +239,8 @@ describe('Planner', () => {
       particle P2 in './render.js'
         inSlot: \`consume [Slot]
       recipe
-        \`slot 'slot-id0' as s0
-        \`slot 'slot-id1' as s1
+        s0: \`slot 'slot-id0'
+        s1: \`slot 'slot-id1'
         P1
           inSlot: any s0
           outSlot: any s1
@@ -257,7 +257,7 @@ describe('Planner', () => {
           one: \`consume Slot
           two: \`consume Slot
         recipe
-          \`slot 'slot-id0' as s0
+          s0: \`slot 'slot-id0'
           P1
             one: \`provide s0
       `);
@@ -271,7 +271,7 @@ describe('Planner', () => {
           one: \`consume [Slot]
           two: \`consume [Slot]
         recipe
-          \`slot 'slot-id0' as s0
+          s0: \`slot 'slot-id0'
           P1
             one: \`provide s0
       `);
@@ -284,7 +284,7 @@ describe('Planner', () => {
         one: \`consume Slot
         two: \`consume Slot
       recipe
-        \`slot 'slot-id0' as s0
+        s0: \`slot 'slot-id0'
         P1
           one: \`consume s0
     `);
@@ -297,25 +297,25 @@ describe('Planner', () => {
         one: \`consume [Slot]
         two: \`consume [Slot]
       recipe
-        \`slot 'slot-id0' as s0
+        s0: \`slot 'slot-id0'
         P1
           one: \`consume s0
     `);
     assert.lengthOf(results, 1);
   }));
 
-  it('resolves particles with multiple consumed set SLANDLES with arrows', async () => {
+  it('SLANDLES resolves particles with multiple consumed set slots with any', Flags.withPostSlandlesSyntax(async () => {
     const results = await planFromManifest(`
       particle P1 in './some-particle.js'
-        \`consume [Slot] one
-        \`consume [Slot] two
+        one: \`consume [Slot]
+        two: \`consume [Slot]
       recipe
-        \`slot 'slot-id0' as s0
+        s0: \`slot 'slot-id0'
         P1
-          one <- s0
+          one: any s0
     `);
     assert.lengthOf(results, 1);
-  });
+  }));
 
   it('can speculate in parallel', async () => {
     const manifest = `
@@ -863,25 +863,25 @@ describe('Automatic resolution', () => {
         location: inout Location
 
       recipe
-        ? as product
+        product: ?
         A
           product: out product
       recipe
-        ? as other
+        other: ?
         B
           other: out other
       recipe
         C
       recipe
-        ? as location
+        location: ?
         D
           location: inout location
 `);
 
     assert.strictEqual(`recipe
-  create as handle0 // ~
-  create as handle1 // ~
-  create as handle2 // Location {Number lat, Number lng}
+  handle0: create // ~
+  handle1: create // ~
+  handle2: create // Location {Number lat, Number lng}
   A as particle0
     product: out handle0
   B as particle1
@@ -986,7 +986,7 @@ describe('Automatic resolution', () => {
         item: consume? Slot
 
       recipe ProducingRecipe
-        create #items as things
+        things: create #items
         ThingProducer`, arcRef => arc = arcRef);
 
     assert.lengthOf(recipes, 2);
@@ -994,8 +994,8 @@ describe('Automatic resolution', () => {
     assert.lengthOf(composedRecipes, 1);
 
     const recipeString = `recipe
-  create #items as handle0 // [Thing {}]
-  create #selected as handle1 // Thing {}
+  handle0: create #items // [Thing {}]
+  handle1: create #selected // Thing {}
   slot1: slot 'rootslotid-root' #root
   ItemMultiplexer as particle0
     hostedParticle: host ThingRenderer
@@ -1076,8 +1076,8 @@ describe('Automatic resolution', () => {
 
     assert.lengthOf(recipes, 1);
     assert.strictEqual(recipes[0].toString(), `recipe SelectableUseListRecipe
-  use 'test-store' #items as handle0 // [Thing {}]
-  create #selected as handle1 // Thing {}
+  handle0: use 'test-store' #items // [Thing {}]
+  handle1: create #selected // Thing {}
   slot1: slot 'rootslotid-root' #root
   ItemMultiplexer as particle0
     hostedParticle: host ThingRenderer

--- a/src/planning/tests/recipe-index-test.ts
+++ b/src/planning/tests/recipe-index-test.ts
@@ -53,8 +53,8 @@ describe('RecipeIndex', () => {
         Transform
     `), [
 `recipe
-  ? as handle0 // ~
-  ? as handle1 // ~
+  handle0: ? // ~
+  handle1: ? // ~
   Transform as particle0
     lumberjack: out handle0
     person: in handle1`
@@ -91,11 +91,11 @@ describe('RecipeIndex', () => {
         person: inout Person
 
       recipe
-        create as person
+        person: create
         A
     `), [
 `recipe
-  create as handle0 // Person {}
+  handle0: create // Person {}
   A as particle0
     person: inout handle0`
     ]);
@@ -181,9 +181,9 @@ describe('RecipeIndex', () => {
         Transform.b: out TransformAgain.b
     `), [
 `recipe
-  ? as handle0 // ~
-  create as handle1 // B {}
-  ? as handle2 // ~
+  handle0: ? // ~
+  handle1: create // B {}
+  handle2: ? // ~
   Transform as particle0
     a: in handle0
     b: out handle1
@@ -263,21 +263,21 @@ describe('RecipeIndex', () => {
       particle A
         thing: in Thing
       recipe A
-        map as thing
+        thing: map
         A
           thing: any thing
 
       particle B
         thing: out Thing
       recipe B
-        create as thing
+        thing: create
         B
           thing: any thing
 
       particle C
         thing: in Thing
       recipe C
-        use as thing
+        thing: use
         C
           thing: any thing
     `);

--- a/src/runtime/manifest-parser.peg
+++ b/src/runtime/manifest-parser.peg
@@ -524,7 +524,7 @@ ParticleHandleConnectionBodyPreSlandle
 NameWithColon
   = &((unsafeLowerIdent / '*') whiteSpace? ':') name:(lowerIdent / '*') whiteSpace? ':' whiteSpace?
   {
-    // TODO(jopra): Remove ability to use "*: <def>" syntax and instead use anonymouse "<def>".
+    // TODO(jopra): Remove ability to use "*: <def>" syntax and instead use anonymous "<def>".
     if (name === '*') {
       return null;
     }

--- a/src/runtime/manifest-parser.peg
+++ b/src/runtime/manifest-parser.peg
@@ -73,9 +73,9 @@
   }
 
   function requireUsePreSlandleSyntax() {
-    /*if (!Flags.usePreSlandlesSyntax) {
+    if (!Flags.usePreSlandlesSyntax) {
       error('using pre slandles syntax (disabled by flag)');
-    }*/
+    }
   }
 
   function requireUsePostSlandleSyntax() {

--- a/src/runtime/manifest-parser.peg
+++ b/src/runtime/manifest-parser.peg
@@ -73,9 +73,9 @@
   }
 
   function requireUsePreSlandleSyntax() {
-    if (!Flags.usePreSlandlesSyntax) {
+    /*if (!Flags.usePreSlandlesSyntax) {
       error('using pre slandles syntax (disabled by flag)');
-    }
+    }*/
   }
 
   function requireUsePostSlandleSyntax() {

--- a/src/runtime/manifest-parser.peg
+++ b/src/runtime/manifest-parser.peg
@@ -522,8 +522,12 @@ ParticleHandleConnectionBodyPreSlandle
   }
 
 NameWithColon
-  = &(unsafeLowerIdent whiteSpace? ':') name:lowerIdent whiteSpace? ':' whiteSpace?
+  = &((unsafeLowerIdent / '*') whiteSpace? ':') name:(lowerIdent / '*') whiteSpace? ':' whiteSpace?
   {
+    // TODO(jopra): Remove ability to use "*: <def>" syntax and instead use anonymouse "<def>".
+    if (name === '*') {
+      return null;
+    }
     return name;
   }
 
@@ -1109,8 +1113,25 @@ RecipeHandleFate
   / '`slot'
 
 RecipeHandle
+  = RecipeHandlePreSlandle
+  / RecipeHandleUnified
+
+RecipeHandleUnified
+  = name:NameWithColon? fate:RecipeHandleFate ref:(whiteSpace HandleRef)? eolWhiteSpace
+  {
+    requireUsePostSlandleSyntax();
+    return toAstNode<AstNode.RecipeHandle>({
+      kind: 'handle',
+      name,
+      ref: optional(ref, ref => ref[1], emptyRef()) as AstNode.HandleRef,
+      fate
+    });
+  }
+
+RecipeHandlePreSlandle
   = type:RecipeHandleFate ref:(whiteSpace HandleRef)? name:(whiteSpace LocalName)? eolWhiteSpace
   {
+    requireUsePreSlandleSyntax();
     return toAstNode<AstNode.RecipeHandle>({
       kind: 'handle',
       name: optional(name, name => name[1], null),

--- a/src/runtime/recipe/handle.ts
+++ b/src/runtime/recipe/handle.ts
@@ -23,6 +23,7 @@ import {compareArrays, compareComparables, compareStrings, Comparable} from './c
 import {Fate, Direction} from '../manifest-ast-nodes.js';
 import {ClaimIsTag, Claim} from '../particle-claim.js';
 import {StorageKey} from '../storageNG/storage-key.js';
+import {Flags} from '../flags.js';
 
 export class Handle implements Comparable<Handle> {
   private readonly _recipe: Recipe;
@@ -316,15 +317,28 @@ export class Handle implements Comparable<Handle> {
     }
     // TODO: type? maybe output in a comment
     const result: string[] = [];
-    result.push(this.fate);
-    if (this.id) {
-      result.push(`'${this.id}'`);
-    }
-    result.push(...this.tags.map(a => `#${a}`));
     const name = (nameMap && nameMap.get(this)) || this.localName;
-    if (name) {
-      result.push(`as ${name}`);
+    if (Flags.usePreSlandlesSyntax) {
+      result.push(this.fate);
+      if (this.id) {
+        result.push(`'${this.id}'`);
+      }
+      result.push(...this.tags.map(a => `#${a}`));
+      if (name) {
+        result.push(`as ${name}`);
+      }
+    } else {
+      if (name) {
+        result.push(`${name}:`);
+      }
+      result.push(this.fate);
+      if (this.id) {
+        result.push(`'${this.id}'`);
+      }
+      result.push(...this.tags.map(a => `#${a}`));
     }
+
+    // Debug information etc.
     if (this.type) {
       result.push('//');
       if (this.type.isResolved()) {

--- a/src/runtime/tests/artifacts/Common/SLANDLESListRecipes.arcs
+++ b/src/runtime/tests/artifacts/Common/SLANDLESListRecipes.arcs
@@ -13,8 +13,8 @@ import 'SLANDLESList.arcs'
 //----------------------------------
 
 recipe SelectableUseListRecipe
-  use #items as items
-  create #selected as selected
+  items: use #items
+  selected: create #selected
   SelectableList
     items: any items
     selected: any selected
@@ -22,8 +22,8 @@ recipe SelectableUseListRecipe
     list: any items
 
 recipe SelectableCopyListRecipe
-  copy #items as items
-  create #selected as selected
+  items: copy #items
+  selected: create #selected
   SelectableList
     items: any items
     selected: any selected
@@ -35,8 +35,8 @@ recipe SelectableCopyListRecipe
 //----------------------------------------
 
 recipe SelectableCopyTilesRecipe
-  copy #tiles as items
-  create #selected as selected
+  items: copy #tiles
+  selected: create #selected
   SelectableTileList
     items: any items
     selected: any selected
@@ -45,8 +45,8 @@ recipe SelectableCopyTilesRecipe
   description `show ${SelectableTileList.items}`
 
 recipe SelectableUseTilesRecipe
-  use #tiles as items
-  create #selected as selected
+  items: use #tiles
+  selected: create #selected
   SelectableTileList
     items: any items
     selected: any selected

--- a/src/runtime/tests/artifacts/Common/source/SlandleMultiplexer.js
+++ b/src/runtime/tests/artifacts/Common/source/SlandleMultiplexer.js
@@ -15,9 +15,9 @@ defineParticle(({Particle, MultiplexerDomParticle}) => {
       const recipe = Particle.buildManifest`
 ${hostedParticle}
 recipe
-  use '${itemHandle._id}' as handle1
+  handle1: use '${itemHandle._id}'
   ${other.handles.join('\n')}
-  \`slot '${slot.id}' as handle2
+  handle2: \`slot '${slot.id}'
   ${hostedParticle.name}
     ${hostedParticle.handleConnections[0].name}: in handle1
     ${hostedParticle.handleConnections[1].name}: \`consume handle2

--- a/src/runtime/tests/manifest-test.ts
+++ b/src/runtime/tests/manifest-test.ts
@@ -631,7 +631,7 @@ ${particleStr1}
         oneMoreSlot: consume Slot
 
       recipe SomeRecipe
-        ? #someHandle1 as myHandle
+        myHandle: ? #someHandle1
         slot0: slot 'slotIDs:A' #someSlot
         SomeParticle
           someParam: in myHandle
@@ -678,8 +678,8 @@ ${particleStr1}
         oneMoreSlot: \`consume Slot
 
       recipe SomeRecipe
-        ? #someHandle1 as myHandle
-        \`slot 'slotIDs:A' #someSlot as slot0
+        myHandle: ? #someHandle1
+        slot0: \`slot 'slotIDs:A' #someSlot
         SomeParticle
           someParam: in myHandle
           mySlot: \`consume slot0
@@ -836,7 +836,7 @@ ${particleStr1}
           slotB: \`consume${arg.isRequiredSlotB ? '' : '?'} Slot
 
         recipe
-          \`slot 'slota-0' as s0
+          s0: \`slot 'slota-0'
           SomeParticle
             slotA: \`consume s0
       `)).recipes[0];
@@ -857,7 +857,7 @@ ${particleStr1}
           slotB: \`consume${arg.isRequiredSlotB ? '' : '?'} [Slot]
 
         recipe
-          \`slot 'slota-0' as s0
+          s0: \`slot 'slota-0'
           SomeParticle
             slotA: \`consume s0
       `)).recipes[0];
@@ -959,7 +959,7 @@ ${particleStr1}
         slotA: \`consume Slot #aaa
           slotB: \`provide Slot #bbb
       recipe
-        \`slot 'slot-id0' #aa #aaa as s0
+        s0: \`slot 'slot-id0' #aa #aaa
         SomeParticle
           slotA: \`consume s0 #aa #hello
           slotB: \`provide
@@ -1016,7 +1016,7 @@ ${particleStr1}
         slotB1: \`consume Slot
           slotB2: \`provide Slot
       recipe
-        \`slot 'slot-id0' as s0
+        s0: \`slot 'slot-id0'
         ParticleA
           slotA: \`consume mySlot
         ParticleB
@@ -1043,7 +1043,7 @@ ${particleStr1}
         slotB1: \`consume Slot
           slotB2: \`provide Slot
       recipe
-        \`slot 'slot-id0' as s0
+        s0: \`slot 'slot-id0'
         ParticleA
           slotA: \`consume mySlot
         ParticleB
@@ -1067,7 +1067,7 @@ ${particleStr1}
         slotB1: \`consume Slot
           slotB2: \`provide [Slot]
       recipe
-        \`slot 'slot-id0' as s0
+        s0: \`slot 'slot-id0'
         ParticleA
           slotA: \`consume mySlot
         ParticleB
@@ -1094,7 +1094,7 @@ ${particleStr1}
         slotB1: \`consume [Slot]
           slotB2: \`provide [Slot]
       recipe
-        \`slot 'slot-id0' as s0
+        s0: \`slot 'slot-id0'
         ParticleA
           slotA: \`consume mySlot
         ParticleB
@@ -1121,7 +1121,7 @@ ${particleStr1}
         slotB1: \`consume Slot
           slotB2: \`provide Slot
       recipe
-        \`slot 'slot-id0' as s0
+        s0: \`slot 'slot-id0'
         ParticleA
           slotA: \`consume mySlot
         ParticleB
@@ -1145,7 +1145,7 @@ ${particleStr1}
         slotB1: \`consume Slot
           slotB2: \`provide [Slot]
       recipe
-        \`slot 'slot-id0' as s0
+        s0: \`slot 'slot-id0'
         ParticleA
           slotA: \`consume mySlot
         ParticleB
@@ -1172,7 +1172,7 @@ ${particleStr1}
         slotB1: \`consume [Slot]
           slotB2: \`provide [Slot]
       recipe
-        \`slot 'slot-id0' as s0
+        s0: \`slot 'slot-id0'
         ParticleA
           slotA: \`consume mySlot
         ParticleB
@@ -1387,8 +1387,8 @@ ${particleStr1}
       particle P2 in 'some-particle.js'
         slotB: \`consume Slot
       recipe
-        \`slot 'rootslot-0' as slot0
-        \`slot 'local-slot-0' as slot1
+        slot0: \`slot 'rootslot-0'
+        slot1: \`slot 'local-slot-0'
         P1
           slotA: \`consume slot0
           slotB: \`provide slot1
@@ -1926,7 +1926,7 @@ resource SomeName
       particle P
         bar: in Bar {Reference<Foo> foo}
       recipe
-        create as h0
+        h0: create
         P
           bar: any h0
     `);
@@ -1973,7 +1973,7 @@ resource SomeName
       particle P
         bar: in Bar {Reference<Foo {Text far}> foo}
       recipe
-        create as h0
+        h0: create
         P
           bar: any h0
     `);
@@ -2020,7 +2020,7 @@ resource SomeName
       particle P
         bar: in Bar {[Reference<Foo>] foo}
       recipe
-        create as h0
+        h0: create
         P
           bar: any h0
     `);
@@ -2066,7 +2066,7 @@ resource SomeName
       particle P
         bar: in Bar {[Reference<Foo {Text far}>] foo}
       recipe
-        create as h0
+        h0: create
         P
           bar: any h0
     `);
@@ -2341,7 +2341,7 @@ resource SomeName
   it('SLANDLES can parse a recipe with slot constraints on verbs', Flags.withPostSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
       recipe
-        \`slot as provideSlot
+        provideSlot: \`slot
         &verb
           foo: \`consume provideSlot
     `);

--- a/src/runtime/tests/manifest-test.ts
+++ b/src/runtime/tests/manifest-test.ts
@@ -1532,7 +1532,22 @@ Error parsing JSON from 'EntityList' (Unexpected token h in JSON at position 1)'
       }
     ]);
   });
-  it('resolves store names to ids', async () => {
+  it('SLANDLES SYNTAX resolves store names to ids', Flags.withPostSlandlesSyntax(async () => {
+    const manifestSource = `
+        schema Thing
+        store Store0 of [Thing] in 'entities.json'
+        recipe
+          map Store0 as myStore`;
+    const entitySource = JSON.stringify([]);
+    const loader = new StubLoader({
+      'the.manifest': manifestSource,
+      'entities.json': entitySource,
+    });
+    const manifest = await Manifest.load('the.manifest', loader);
+    const recipe = manifest.recipes[0];
+    assert.deepEqual(recipe.toString(), 'recipe\n  myStore: map \'!manifest:the.manifest:store0:97d170e1550eee4afc0af065b78cda302a97674c\'');
+  }));
+  it('resolves store names to ids', Flags.withPreSlandlesSyntax(async () => {
     const manifestSource = `
         schema Thing
         store Store0 of [Thing] in 'entities.json'
@@ -1546,7 +1561,7 @@ Error parsing JSON from 'EntityList' (Unexpected token h in JSON at position 1)'
     const manifest = await Manifest.load('the.manifest', loader);
     const recipe = manifest.recipes[0];
     assert.deepEqual(recipe.toString(), 'recipe\n  map \'!manifest:the.manifest:store0:97d170e1550eee4afc0af065b78cda302a97674c\' as myStore');
-  });
+  }));
   it('has prettyish syntax errors', async () => {
     try {
       await Manifest.parse('recipe ?', {fileName: 'bad-file'});

--- a/src/runtime/tests/multiplexer-test.ts
+++ b/src/runtime/tests/multiplexer-test.ts
@@ -74,8 +74,8 @@ describe('Multiplexer', () => {
       import 'src/runtime/tests/artifacts/SLANDLEStest-particles.arcs'
 
       recipe
-        use 'test:1' as handle0
-        \`slot 'rootslotid-slotid' as slot0
+        handle0: use 'test:1'
+        slot0: \`slot 'rootslotid-slotid'
         SlandleMultiplexer
           hostedParticle: host SlandleConsumerParticle
           annotation: \`consume slot0

--- a/src/runtime/tests/recipe-test.ts
+++ b/src/runtime/tests/recipe-test.ts
@@ -400,7 +400,7 @@ describe('recipe', () => {
       particle Specific
         thing: in Thing
       recipe
-        map as thingHandle
+        thingHandle: map
         Generic
           anyA: in thingHandle
         Specific
@@ -416,13 +416,13 @@ describe('recipe', () => {
     recipe.normalize();
     assert.isFalse(recipe.isResolved());
     assert.strictEqual(`recipe
-  map 'my-things' as handle0 // ~
+  handle0: map 'my-things' // ~
   Generic as particle0
     anyA: in handle0
   Specific as particle1
     thing: in handle0`, recipe.toString());
     assert.strictEqual(`recipe
-  map 'my-things' as handle0 // ~ // Thing {}  // unresolved handle: unresolved type
+  handle0: map 'my-things' // ~ // Thing {}  // unresolved handle: unresolved type
   Generic as particle0
     anyA: in handle0
   Specific as particle1
@@ -439,7 +439,7 @@ describe('recipe', () => {
     assert.isTrue(recipeClone.isResolved());
     const hashResolvedClone = await recipeClone.digest();
     assert.strictEqual(`recipe
-  map 'my-things' as handle0 // Thing {}
+  handle0: map 'my-things' // Thing {}
   Generic as particle0
     anyA: in handle0
   Specific as particle1
@@ -455,7 +455,7 @@ describe('recipe', () => {
       particle Specific
         thing: in Thing
       recipe
-        map as thingHandle
+        thingHandle: map
         Generic
           anyA: in thingHandle
         Specific
@@ -471,13 +471,13 @@ describe('recipe', () => {
     recipe.normalize();
     assert.isFalse(recipe.isResolved());
     assert.strictEqual(`recipe
-  map 'my-things' as handle0 // ~
+  handle0: map 'my-things' // ~
   Generic as particle0
     anyA: in handle0
   Specific as particle1
     thing: in handle0`, recipe.toString());
     assert.strictEqual(`recipe
-  map 'my-things' as handle0 // ~ // Thing {}  // unresolved handle: unresolved type
+  handle0: map 'my-things' // ~ // Thing {}  // unresolved handle: unresolved type
   Generic as particle0
     anyA: in handle0
   Specific as particle1
@@ -494,7 +494,7 @@ describe('recipe', () => {
     assert.isTrue(recipeClone.isResolved());
     const hashResolvedClone = await recipeClone.digest();
     assert.strictEqual(`recipe
-  map 'my-things' as handle0 // Thing {}
+  handle0: map 'my-things' // Thing {}
   Generic as particle0
     anyA: in handle0
   Specific as particle1


### PR DESCRIPTION
Same as https://github.com/PolymerLabs/arcs/pull/3854 but for handles.
To avoid accidental usage of old parser a star should be used instead of the optional name, for now. This means that the parser can always know which syntax is in use, but will require a clean up when we change the default.