### PR TITLE
Align GH deps with G3 deps

### DIFF
--- a/javaharness/java/arcs/android/BUILD
+++ b/javaharness/java/arcs/android/BUILD
@@ -26,6 +26,5 @@ android_library(
         "//third_party/java/dagger",
         "//third_party/java/flogger",
         "//third_party/java/jsr330_inject",
-        "@maven//:com_google_flogger_flogger_system_backend",
     ],
 )

--- a/javaharness/java/arcs/android/BUILD
+++ b/javaharness/java/arcs/android/BUILD
@@ -19,15 +19,13 @@ android_library(
     idl_srcs = glob(["*.aidl"]),
     javacopts = ["-Xep:AndroidJdkLibsChecker:OFF"],
     manifest = "AndroidManifest.xml",
-    plugins = [
-        "//javaharness:dagger_compiler",
-    ],
     resource_files = glob(["res/**"]),
     deps = [
-        "//javaharness:autovalue",
+        "//third_party/java/auto:auto_value",
         "//javaharness/java/arcs/api:api-android",
-        "@maven//:com_google_dagger_dagger",
+        "//third_party/java/dagger",
+        "//third_party/java/flogger",
+        "//third_party/java/jsr330_inject",
         "@maven//:com_google_flogger_flogger_system_backend",
-        "@maven//:javax_inject_javax_inject",
     ],
 )

--- a/javaharness/java/arcs/android/demo/BUILD
+++ b/javaharness/java/arcs/android/demo/BUILD
@@ -19,6 +19,5 @@ android_binary(
         "//third_party/java/dagger",
         "//third_party/java/flogger",
         "//third_party/java/jsr330_inject",
-        "@maven//:com_google_flogger_flogger_system_backend",
     ],
 )

--- a/javaharness/java/arcs/android/demo/BUILD
+++ b/javaharness/java/arcs/android/demo/BUILD
@@ -12,15 +12,13 @@ android_binary(
     javacopts = ["-Xep:AndroidJdkLibsChecker:OFF"],
     licenses = ["notice"],
     manifest = "AndroidManifest.xml",
-    plugins = [
-        "//javaharness:dagger_compiler",
-    ],
     resource_files = glob(["res/**"]),
     deps = [
         "//javaharness/java/arcs/android",
         "//javaharness/java/arcs/api:api-android",
-        "@maven//:com_google_dagger_dagger",
+        "//third_party/java/dagger",
+        "//third_party/java/flogger",
+        "//third_party/java/jsr330_inject",
         "@maven//:com_google_flogger_flogger_system_backend",
-        "@maven//:javax_inject_javax_inject",
     ],
 )

--- a/javaharness/java/arcs/api/BUILD
+++ b/javaharness/java/arcs/api/BUILD
@@ -15,8 +15,7 @@ android_library(
     javacopts = ["-Xep:AndroidJdkLibsChecker:OFF"],
     deps = [
         "//javaharness/java/arcs/crdt:crdt-android",
-        "@maven//:com_google_dagger_dagger",
-        "@maven//:javax_inject_javax_inject",
-        "@maven//:org_json_json",
+        "//third_party/java/dagger",
+        "//third_party/java/jsr330_inject",
     ],
 )

--- a/javaharness/java/arcs/crdt/BUILD
+++ b/javaharness/java/arcs/crdt/BUILD
@@ -14,7 +14,7 @@ android_library(
     ]),
     javacopts = ["-Xep:AndroidJdkLibsChecker:OFF"],
     deps = [
-        "@maven//:com_google_dagger_dagger",
-        "@maven//:javax_inject_javax_inject",
+      "//third_party/java/dagger",
+      "//third_party/java/jsr330_inject",
     ],
 )

--- a/javaharness/javatests/arcs/android/BUILD
+++ b/javaharness/javatests/arcs/android/BUILD
@@ -8,6 +8,6 @@ java_test(
     deps = [
         "//javaharness/java/arcs/android",
         "//javaharness/java/arcs/api:api-android",
-        "@maven//:junit_junit",
+        "//third_party/java/junit",
     ],
 )

--- a/javaharness/javatests/arcs/api/BUILD
+++ b/javaharness/javatests/arcs/api/BUILD
@@ -6,7 +6,7 @@ java_test(
     srcs = glob(["*.java"]),
     test_class = "arcs.api.AllTests",
     deps = [
+        "//third_party/java/junit",
         "//javaharness/java/arcs/api:api-android",
-        "@maven//:junit_junit",
     ],
 )

--- a/javaharness/javatests/arcs/crdt/BUILD
+++ b/javaharness/javatests/arcs/crdt/BUILD
@@ -6,8 +6,8 @@ java_test(
     srcs = glob(["*.java"]),
     test_class = "arcs.crdt.AllTests",
     deps = [
+        "//third_party/java/junit",
         "//javaharness/java/arcs/api:api-android",
         "//javaharness/java/arcs/crdt:crdt-android",
-        "@maven//:junit_junit",
     ],
 )

--- a/third_party/java/auto/BUILD
+++ b/third_party/java/auto/BUILD
@@ -1,4 +1,5 @@
 package(default_visibility = ["//visibility:public"])
+
 licenses(["notice"])
 
 java_plugin(

--- a/third_party/java/auto/BUILD
+++ b/third_party/java/auto/BUILD
@@ -1,8 +1,6 @@
 package(default_visibility = ["//visibility:public"])
-
 licenses(["notice"])
 
-# Standalone deps of Java libraries and plugins
 java_plugin(
     name = "autovalue_plugin",
     processor_class = "com.google.auto.value.processor.AutoValueProcessor",
@@ -10,17 +8,8 @@ java_plugin(
 )
 
 java_library(
-    name = "autovalue",
+    name = "auto_value",
     exported_plugins = [":autovalue_plugin"],
     neverlink = 1,  # Only used at compilation rather than at run-time.
     exports = ["@maven//:com_google_auto_value_auto_value_annotations"],
-)
-
-java_plugin(
-    name = "dagger_compiler",
-    generates_api = 1,
-    processor_class = "dagger.internal.codegen.ComponentProcessor",
-    deps = [
-        "@maven//:com_google_dagger_dagger_compiler",
-    ],
 )

--- a/third_party/java/dagger/BUILD
+++ b/third_party/java/dagger/BUILD
@@ -1,0 +1,19 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+java_library(
+  name = "dagger",
+  exports = ["@maven//:com_google_dagger_dagger"],
+  exported_plugins = [":dagger_compiler"],
+)
+
+java_plugin(
+    name = "dagger_compiler",
+    generates_api = 1,
+    processor_class = "dagger.internal.codegen.ComponentProcessor",
+    deps = [
+        "@maven//:com_google_dagger_dagger_compiler",
+    ],
+)
+

--- a/third_party/java/flogger/BUILD
+++ b/third_party/java/flogger/BUILD
@@ -1,0 +1,9 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+alias(
+  name = "flogger",
+  actual = "@maven//:com_google_flogger_flogger",
+)
+

--- a/third_party/java/flogger/BUILD
+++ b/third_party/java/flogger/BUILD
@@ -2,8 +2,8 @@ package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])
 
-alias(
-  name = "flogger",
-  actual = "@maven//:com_google_flogger_flogger",
+java_library(
+    name = "flogger",
+    exports = ["@maven//:com_google_flogger_flogger"],
+    runtime_deps = ["@maven//:com_google_flogger_flogger_system_backend"],
 )
-

--- a/third_party/java/jsr330_inject/BUILD
+++ b/third_party/java/jsr330_inject/BUILD
@@ -1,0 +1,8 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+alias(
+  name = "jsr330_inject",
+  actual = "@maven//:javax_inject_javax_inject",
+)

--- a/third_party/java/junit/BUILD
+++ b/third_party/java/junit/BUILD
@@ -3,6 +3,6 @@ package(default_visibility = ["//visibility:public"])
 licenses(["notice"])
 
 alias(
-  name = "junit",
-  actual = "@maven//:junit_junit",
+    name = "junit",
+    actual = "@maven//:junit_junit",
 )

--- a/third_party/java/junit/BUILD
+++ b/third_party/java/junit/BUILD
@@ -1,0 +1,8 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+alias(
+  name = "junit",
+  actual = "@maven//:junit_junit",
+)

--- a/third_party/java/truth/BUILD
+++ b/third_party/java/truth/BUILD
@@ -1,0 +1,8 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+alias(
+  name = "truth",
+  actual = "@maven//:com_google_truth_truth",
+)

--- a/third_party/java/truth/BUILD
+++ b/third_party/java/truth/BUILD
@@ -3,6 +3,6 @@ package(default_visibility = ["//visibility:public"])
 licenses(["notice"])
 
 alias(
-  name = "truth",
-  actual = "@maven//:com_google_truth_truth",
+    name = "truth",
+    actual = "@maven//:com_google_truth_truth",
 )

--- a/third_party/kotlin/kotlinx/kotlinx_coroutines/BUILD
+++ b/third_party/kotlin/kotlinx/kotlinx_coroutines/BUILD
@@ -3,6 +3,6 @@ package(default_visibility = ["//visibility:public"])
 licenses(["notice"])
 
 alias(
-  name = "kotlinx_coroutines",
-  actual = "@maven//:org_jetbrains_kotlinx_kotlinx_coroutines_core",
+    name = "kotlinx_coroutines",
+    actual = "@maven//:org_jetbrains_kotlinx_kotlinx_coroutines_core",
 )

--- a/third_party/kotlin/kotlinx/kotlinx_coroutines/BUILD
+++ b/third_party/kotlin/kotlinx/kotlinx_coroutines/BUILD
@@ -1,0 +1,8 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+alias(
+  name = "kotlinx_coroutines",
+  actual = "@maven//:org_jetbrains_kotlinx_kotlinx_coroutines_core",
+)


### PR DESCRIPTION
Simplify copybara maintainence by aligning the dependency paths with G3.

It may be possible later to automatic the creation of these BUILD files
via a bazel rule using a dictionary in WORKSPACE, but for now, if you
need to add a new @maven dep, create a third_party alias for it.