### PR TITLE
Add fake android target for g3 android targets

### DIFF
--- a/javaharness/java/arcs/android/BUILD
+++ b/javaharness/java/arcs/android/BUILD
@@ -24,7 +24,7 @@ android_library(
         "//third_party/java/auto:auto_value",
         "//javaharness/java/arcs/api:api-android",
         "//third_party/java/dagger",
-        "//third_party/java/flogger",
+        "//third_party/java/flogger:android",
         "//third_party/java/jsr330_inject",
     ],
 )

--- a/javaharness/java/arcs/android/demo/BUILD
+++ b/javaharness/java/arcs/android/demo/BUILD
@@ -17,7 +17,7 @@ android_binary(
         "//javaharness/java/arcs/android",
         "//javaharness/java/arcs/api:api-android",
         "//third_party/java/dagger",
-        "//third_party/java/flogger",
+        "//third_party/java/flogger:android",
         "//third_party/java/jsr330_inject",
     ],
 )

--- a/third_party/java/flogger/BUILD
+++ b/third_party/java/flogger/BUILD
@@ -7,3 +7,11 @@ java_library(
     exports = ["@maven//:com_google_flogger_flogger"],
     runtime_deps = ["@maven//:com_google_flogger_flogger_system_backend"],
 )
+
+
+java_library(
+    name = "android",
+    exports = ["@maven//:com_google_flogger_flogger"],
+    runtime_deps = ["@maven//:com_google_flogger_flogger_system_backend"],
+)
+

--- a/third_party/java/flogger/BUILD
+++ b/third_party/java/flogger/BUILD
@@ -8,10 +8,7 @@ java_library(
     runtime_deps = ["@maven//:com_google_flogger_flogger_system_backend"],
 )
 
-
-java_library(
+alias(
     name = "android",
-    exports = ["@maven//:com_google_flogger_flogger"],
-    runtime_deps = ["@maven//:com_google_flogger_flogger_system_backend"],
+    actual = ":flogger",
 )
-


### PR DESCRIPTION
third_party/java/flogger doesn't have constraints=android and so breaks g3 android_library constraint checcking, but third_party/java/flogger:android does. However, android flogger doesn't exist in OSS, so we just alias them for now. 
