### PR TITLE
Add test for arcs_manifest rule

### DIFF
--- a/build_defs/build_defs.bzl
+++ b/build_defs/build_defs.bzl
@@ -1,6 +1,5 @@
 """Arcs BUILD rules."""
 
-load(":run_in_repo.bzl", "EXECUTION_REQUIREMENTS_TAGS", "run_in_repo_test")
 load(":sigh.bzl", "sigh_command")
 load(
     "//build_defs/internal:kotlin.bzl",

--- a/build_defs/internal/manifest.bzl
+++ b/build_defs/internal/manifest.bzl
@@ -1,21 +1,31 @@
 """Arcs manifest bundling rules."""
 
+load("//build_defs:sigh.bzl", "sigh_command")
+
 def arcs_manifest(name, srcs, deps = []):
     """Bundles .arcs manifest files with their particle implementations.
 
     Generates a filegroup that can be included in e.g. an Android assets folder.
-
-    TODO: Check that all the files referenced in the manifest files are included
-    (i.e. .wasm and .js particle implementations, and json data files).
     """
     for src in srcs:
         if not src.endswith(".arcs"):
-            fail("srcs can only contain .arcs manifest files.")
+            fail("src must be an .arcs manifest file, found %s" % src)
+
+    # All the files that need to go in the filegroup.
+    all_files = srcs + deps
 
     native.filegroup(
         name = name,
-        srcs = srcs + deps,
+        srcs = all_files,
     )
 
-    # TODO: Add a test to check that all required data files are included in
-    # deps.
+    test_args = " ".join(["--src $(location %s)" % src for src in srcs])
+
+    sigh_command(
+        name = name + "_test",
+        srcs = all_files,
+        sigh_cmd = "run manifestChecker " + test_args,
+        deps = [name],
+        progress_message = "Checking Arcs manifest",
+        execute = False,
+    )

--- a/src/tools/manifest-checker.ts
+++ b/src/tools/manifest-checker.ts
@@ -40,9 +40,9 @@ async function checkManifest(src: string) {
   for (const particle of manifest.particles) {
     const implFile = particle.implFile;
     if (implFile.endsWith('.wasm')) {
-      await loader.loadResource(implFile);
-    } else {
       await loader.loadWasmBinary(implFile);
+    } else {
+      await loader.loadResource(implFile);
     }
   }
 }

--- a/src/tools/manifest-checker.ts
+++ b/src/tools/manifest-checker.ts
@@ -1,0 +1,74 @@
+/**
+ * @license
+ * Copyright (c) 2019 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import minimist from 'minimist';
+import {Manifest, ManifestWarning} from '../runtime/manifest.js';
+import {PlatformLoader} from '../platform/loader-web.js';
+
+// Script to check that a bundle of Arcs manifest files, particle
+// implementations and JSON data files is complete (i.e. no explicitly mentioned
+// dependencies are missing).
+//
+// To be run with the arcs_manifest BUILD rule.
+
+/**
+ * Loads the given .arcs manifest file and checks it for errors. Errors are
+ * thrown as an exception.
+ */
+async function checkManifest(src: string) {
+  const loader = new PlatformLoader({});
+  const manifest = await Manifest.load(src, loader);
+
+  // Look for errors from parsing the manifest (ignore warnings). This covers
+  // missing .arcs imports.
+  const manifestErrors = manifest.errors
+      .filter(error => !(error instanceof ManifestWarning))
+      .map(error => error.toString());
+
+  if (manifestErrors.length) {
+    throw manifestErrors.join('\n');
+  }
+
+  // Check particle impls can be loaded.
+  for (const particle of manifest.particles) {
+    const implFile = particle.implFile;
+    if (implFile.endsWith('.wasm')) {
+      await loader.loadResource(implFile);
+    } else {
+      await loader.loadWasmBinary(implFile);
+    }
+  }
+}
+
+async function main() {
+  const opts = minimist(process.argv.slice(2), {
+    string: ['src'],
+  });
+  const srcs: string[] = typeof opts.src === 'string' ? [opts.src] : opts.src;
+
+  let foundError = false;
+
+  for (const src of srcs) {
+    try {
+      await checkManifest(src);
+    } catch (e) {
+      // Catch exceptions and report them as errors.
+      console.error(`Errors encountered when parsing manifest '${src}':`);
+      console.error(e);
+      foundError = true;
+    }
+  }
+
+  if (foundError) {
+    process.exit(1);
+  }
+}
+
+void main();

--- a/tools/sigh.ts
+++ b/tools/sigh.ts
@@ -94,6 +94,8 @@ const scripts: {[index: string]: string} = {
   flowcheck: 'build/dataflow/cli/flowcheck.js',
 
   schema2pkg: 'build/tools/schema2packager.js',
+
+  manifestChecker: 'build/tools/manifest-checker.js',
 };
 
 const eslintCache = '.eslint_sigh_cache';


### PR DESCRIPTION
Test checks that all the important files are included in the filegroup.
i.e. other imported .arcs files, particle implementations in .wasm/.js
files, .json data files.