### PR TITLE
Introduce tools/build_defs aliasing to align load() statements with g3

### DIFF
--- a/javaharness/java/BUILD
+++ b/javaharness/java/BUILD
@@ -1,2 +1,1 @@
 package(default_visibility = ["//visibility:public"])
-

--- a/javaharness/java/arcs/android/BUILD
+++ b/javaharness/java/arcs/android/BUILD
@@ -5,7 +5,7 @@ package(default_visibility = [
 
 licenses(["notice"])
 
-load("@build_bazel_rules_android//android:rules.bzl", "android_library")
+load("//tools/build_defs/android:rules.bzl", "android_library")
 
 android_library(
     name = "android",
@@ -21,8 +21,8 @@ android_library(
     manifest = "AndroidManifest.xml",
     resource_files = glob(["res/**"]),
     deps = [
-        "//third_party/java/auto:auto_value",
         "//javaharness/java/arcs/api:api-android",
+        "//third_party/java/auto:auto_value",
         "//third_party/java/dagger",
         "//third_party/java/flogger",
         "//third_party/java/jsr330_inject",

--- a/javaharness/java/arcs/android/demo/BUILD
+++ b/javaharness/java/arcs/android/demo/BUILD
@@ -1,6 +1,6 @@
 licenses(["notice"])
 
-load("@build_bazel_rules_android//android:rules.bzl", "android_binary")
+load("//tools/build_defs/android:rules.bzl", "android_binary")
 
 android_binary(
     name = "demo",

--- a/javaharness/java/arcs/api/BUILD
+++ b/javaharness/java/arcs/api/BUILD
@@ -5,7 +5,7 @@ package(default_visibility = [
     "//javaharness/javatests/arcs:__subpackages__",
 ])
 
-load("@build_bazel_rules_android//android:rules.bzl", "android_library")
+load("//tools/build_defs/android:rules.bzl", "android_library")
 
 android_library(
     name = "api-android",

--- a/javaharness/java/arcs/crdt/BUILD
+++ b/javaharness/java/arcs/crdt/BUILD
@@ -5,7 +5,7 @@ package(default_visibility = [
     "//javaharness/javatests/arcs:__subpackages__",
 ])
 
-load("@build_bazel_rules_android//android:rules.bzl", "android_library")
+load("//tools/build_defs/android:rules.bzl", "android_library")
 
 android_library(
     name = "crdt-android",
@@ -14,7 +14,7 @@ android_library(
     ]),
     javacopts = ["-Xep:AndroidJdkLibsChecker:OFF"],
     deps = [
-      "//third_party/java/dagger",
-      "//third_party/java/jsr330_inject",
+        "//third_party/java/dagger",
+        "//third_party/java/jsr330_inject",
     ],
 )

--- a/javaharness/javatests/BUILD
+++ b/javaharness/javatests/BUILD
@@ -1,2 +1,1 @@
 package(default_visibility = ["//visibility:public"])
-

--- a/javaharness/javatests/arcs/BUILD
+++ b/javaharness/javatests/arcs/BUILD
@@ -1,2 +1,1 @@
 package(default_visibility = ["//visibility:public"])
-

--- a/javaharness/javatests/arcs/api/BUILD
+++ b/javaharness/javatests/arcs/api/BUILD
@@ -6,7 +6,7 @@ java_test(
     srcs = glob(["*.java"]),
     test_class = "arcs.api.AllTests",
     deps = [
-        "//third_party/java/junit",
         "//javaharness/java/arcs/api:api-android",
+        "//third_party/java/junit",
     ],
 )

--- a/javaharness/javatests/arcs/crdt/BUILD
+++ b/javaharness/javatests/arcs/crdt/BUILD
@@ -6,8 +6,8 @@ java_test(
     srcs = glob(["*.java"]),
     test_class = "arcs.crdt.AllTests",
     deps = [
-        "//third_party/java/junit",
         "//javaharness/java/arcs/api:api-android",
         "//javaharness/java/arcs/crdt:crdt-android",
+        "//third_party/java/junit",
     ],
 )


### PR DESCRIPTION
Similar to third_party, all of our load() statements which reference @ workspace repos, can use standard g3 paths to tools/build_defs. 

This means after aligning the naming conventions of kotlin_rules and rules_kotlin, copybara will only need to move the harness directory, and patch the app framework.
