### PR TITLE
Alias third_party/javascript/arcs

### DIFF
--- a/javaharness/java/arcs/android/BUILD
+++ b/javaharness/java/arcs/android/BUILD
@@ -11,7 +11,7 @@ android_library(
     name = "android",
     srcs = glob(["*.java"]),
     assets = [
-        "//shells/pipes-shell:pipes_shell_web",
+        "//third_party/javascript/arcs:pipes-shell-assets",
     ],
     assets_dir = "pipes_shell_web_dist",
     exports_manifest = 1,

--- a/third_party/javascript/arcs/BUILD
+++ b/third_party/javascript/arcs/BUILD
@@ -1,0 +1,8 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+alias(
+    name = "pipes-shell-assets",
+    actual = "//shells/pipes-shell:pipes_shell_web",
+)


### PR DESCRIPTION
Similarly, add a third_party alias for the JS assets in g3
