### PR TITLE
Fix manifest checker

### DIFF
--- a/src/tools/manifest-checker.ts
+++ b/src/tools/manifest-checker.ts
@@ -40,7 +40,7 @@ async function checkManifest(src: string) {
   for (const particle of manifest.particles) {
     const implFile = particle.implFile;
     if (implFile.endsWith('.wasm')) {
-      await loader.loadWasmBinary(implFile);
+      await loader.loadWasmBinary(particle);
     } else {
       await loader.loadResource(implFile);
     }


### PR DESCRIPTION
Followup: Someone should fix loader.loadWasmBinary to declare the argument as a particlespec
