### PR TITLE
Adds missing android_library rule

### DIFF
--- a/tools/build_defs/android/rules.bzl
+++ b/tools/build_defs/android/rules.bzl
@@ -1,0 +1,9 @@
+load(
+    "@build_bazel_rules_android//android:rules.bzl",
+    _android_binary = "android_binary",
+    _android_library = "android_library",
+)
+
+android_binary = _android_binary
+
+android_library = _android_library


### PR DESCRIPTION
Fixes javaharness build, broken in #3871. BUILD files import
android_library and android_binary from //tools/build_defs/android, but
there are no files there in our git repo.

Now just re-exports them from @build_bazel_rules_android