### PR TITLE
Fix for run_in_repo on Windows

### DIFF
--- a/build_defs/run_in_repo.bzl
+++ b/build_defs/run_in_repo.bzl
@@ -43,10 +43,14 @@ def _write_shell_script(ctx, run_script):
 
     # Optionally run the shell script.
     if run_script:
-        ctx.actions.run(
-            executable = script_file,
+        # Running scripts via ctx.actions.run is not supported on Windows, so
+        # we need to use ctx.actions.run_shell instead, with the script path as
+        # our only command.
+        ctx.actions.run_shell(
+            command = script_file.path,
             inputs = depset(input_files + ctx.files.deps),
             outputs = output_files,
+            tools = [script_file],
             progress_message = ctx.attr.progress_message,
             use_default_shell_env = True,
             execution_requirements = EXECUTION_REQUIREMENTS_DICT,


### PR DESCRIPTION
Replaced call to ctx.actions.run with ctx.actions.run_shell.

Windows was trying to execute the script as a win32 binary, which was
failing with the following error:

```
Action failed to execute: java.io.IOException: ERROR: src/main/native/windows/process.cc(199): CreateProcessW("C:\temp\7qgjmpto\execroot\__main__\bazel-out\x64_windows-fastbuild\bin\particles\Tutorial\Kotlin\3_JsonStore\JsonStore_genrule.sh"): %1 is not a valid Win32 application.
```

Advice from https://github.com/bazelbuild/bazel/issues/3589 is to use
ctx.actions.run_shell instead.