### PR TITLE
Rework schema2packager with a type lattice for type inheritance/slicing

### DIFF
--- a/particles/Native/Wasm/source/TestParticle.kt
+++ b/particles/Native/Wasm/source/TestParticle.kt
@@ -78,9 +78,9 @@ class TestParticle : Particle() {
              </table>""".trimIndent()
       }
 
-    private val data = Singleton { TestParticle_data() }
-    private val res = Singleton { TestParticle_res() }
-    private val info = Collection { TestParticle_info() }
+    private val data = Singleton { TestParticle_Data() }
+    private val res = Singleton { TestParticle_Res() }
+    private val info = Collection { TestParticle_Info() }
     private var updated = 0
     private var storeCount = 0
 
@@ -101,7 +101,7 @@ class TestParticle : Particle() {
         }
 
         eventHandler("store") {
-          val info = TestParticle_info()
+          val info = TestParticle_Info()
           info.internalId = "wasm" + (++storeCount)
           info.val_ = (this.info.size + storeCount).toDouble()
           this.info.store(info)

--- a/particles/Native/Wasm/source/example.cc
+++ b/particles/Native/Wasm/source/example.cc
@@ -19,7 +19,7 @@ public:
   }
 
   void populateModel(const std::string& slot_name, arcs::Dictionary* model) override {
-    const arcs::BasicParticle_foo& product = foo_.get();
+    const arcs::BasicParticle_Foo& product = foo_.get();
     model->emplace("name", product.name());
     model->emplace("sku", arcs::num_to_str(product.sku()));
     model->emplace("num", arcs::num_to_str(num_clicks_));
@@ -28,9 +28,9 @@ public:
   // Responding to UI events
   void fireEvent(const std::string& slot_name, const std::string& handler) override {
     if (handler == "clicky") {
-      arcs::BasicParticle_foo copy = arcs::clone_entity(foo_.get());  // does not copy internal entity id
+      arcs::BasicParticle_Foo copy = arcs::clone_entity(foo_.get());  // does not copy internal entity id
       // TODO(alxr): Myk, please advise
-      arcs::BasicParticle_bar copy1;
+      arcs::BasicParticle_Bar copy1;
       copy1.set_name(copy.name());
       copy1.set_sku(copy.sku());
       bar_.store(&copy1);  // pass as pointer; 'copy' will be updated with a new internal id
@@ -44,8 +44,8 @@ public:
   }
 
 private:
-  arcs::Singleton<arcs::BasicParticle_foo> foo_;
-  arcs::Collection<arcs::BasicParticle_bar> bar_;
+  arcs::Singleton<arcs::BasicParticle_Foo> foo_;
+  arcs::Collection<arcs::BasicParticle_Bar> bar_;
   int num_clicks_ = 0;
 };
 
@@ -66,7 +66,7 @@ public:
   }
 
 private:
-  arcs::Collection<arcs::Watcher_bar> bar_;
+  arcs::Collection<arcs::Watcher_Bar> bar_;
 };
 
 

--- a/particles/Tutorial/Kotlin/3_JsonStore/JsonStore.kt
+++ b/particles/Tutorial/Kotlin/3_JsonStore/JsonStore.kt
@@ -3,7 +3,7 @@ package arcs.tutorials
 import arcs.Particle
 import arcs.WasmAddress
 import arcs.Singleton
-import arcs.JsonStoreParticle_inputData
+import arcs.JsonStoreParticle_InputData
 import kotlin.native.internal.ExportForCppRuntime
 
 /**
@@ -11,18 +11,18 @@ import kotlin.native.internal.ExportForCppRuntime
  */
 class JsonStoreParticle : Particle() {
 
-    private val res = Singleton { JsonStoreParticle_inputData() }
+    private val res = Singleton { JsonStoreParticle_InputData() }
     init {
         registerHandle("inputData", res)
     }
 
     override fun populateModel(slotName: String, model: Map<String, String>): Map<String, String> {
-        val person = res.get() ?: JsonStoreParticle_inputData("", 0.0);
+        val person = res.get() ?: JsonStoreParticle_InputData("", 0.0);
 
         return model + mapOf(
             "name" to person.name,
             "age" to person.age.toString()
-        )   
+        )
     }
 
     override fun getTemplate(slotName: String): String {

--- a/src/tests/source/wasm-particle-new.cc
+++ b/src/tests/source/wasm-particle-new.cc
@@ -27,8 +27,8 @@ class ReloadHandleTest : public arcs::Particle {
       update(name);
     }
     void update(const std::string& name) {
-      arcs::Test_person out;
-      if (auto input = getSingleton<arcs::Test_person>(name)) {
+      arcs::Test_Person out;
+      if (auto input = getSingleton<arcs::Test_Person>(name)) {
         out.set_name(input->get().name());
         out.set_age(input->get().age() - 2);
       } else {
@@ -36,8 +36,8 @@ class ReloadHandleTest : public arcs::Particle {
       }
       personOut.set(&out);
     }
-    arcs::Singleton<arcs::Test_person> personIn;
-    arcs::Singleton<arcs::Test_person> personOut;
+    arcs::Singleton<arcs::Test_Person> personIn;
+    arcs::Singleton<arcs::Test_Person> personOut;
 };
 
 DEFINE_PARTICLE(ReloadHandleTest);

--- a/src/tests/source/wasm-particle-old.cc
+++ b/src/tests/source/wasm-particle-old.cc
@@ -27,8 +27,8 @@ class ReloadHandleTest : public arcs::Particle {
       update(name);
     }
     void update(const std::string& name) {
-      arcs::Test_person out;
-      if (auto input = getSingleton<arcs::Test_person>(name)) {
+      arcs::Test_Person out;
+      if (auto input = getSingleton<arcs::Test_Person>(name)) {
         out.set_name(input->get().name());
         out.set_age(input->get().age() * 2);
       } else {
@@ -36,8 +36,8 @@ class ReloadHandleTest : public arcs::Particle {
       }
       personOut.set(&out);
     }
-    arcs::Singleton<arcs::Test_person> personIn;
-    arcs::Singleton<arcs::Test_person> personOut;
+    arcs::Singleton<arcs::Test_Person> personIn;
+    arcs::Singleton<arcs::Test_Person> personOut;
 };
 
 DEFINE_PARTICLE(ReloadHandleTest);

--- a/src/tools/schema2base.ts
+++ b/src/tools/schema2base.ts
@@ -10,19 +10,21 @@
 import fs from 'fs';
 import path from 'path';
 import minimist from 'minimist';
-import {Schema} from '../runtime/schema.js';
-import {Dictionary} from '../runtime/hot.js';
 import {Utils} from '../../shells/lib/utils.js';
 import {Manifest} from '../runtime/manifest.js';
+import {SchemaGraph, SchemaNode} from './schema2graph.js';
 
-export type Aliases = Dictionary<Set<string>>;
+export interface ClassGenerator {
+  processField(field: string, typeChar: string, inherited: boolean, refName: string);
+  generate(fieldCount: number): string;
+}
 
 export abstract class Schema2Base {
-  private readonly scope: string;
+  scope: string;
 
   constructor(readonly opts: minimist.ParsedArgs) {
     Utils.init('../..');
-    this.scope = opts.package;
+    this.scope = this.opts.package || 'arcs';
   }
 
   async call() {
@@ -36,73 +38,6 @@ export abstract class Schema2Base {
     }
   }
 
-
-  /** Collect schemas from particle connections and build map of aliases. */
-  public processManifest(manifest: Manifest): [Aliases, Dictionary<Schema>, Dictionary<Schema>] {
-    const aliases: Aliases = {};
-
-    const updateAliases = (rhs: string, alias: string) => {
-      if (aliases[rhs] !== undefined) {
-        aliases[rhs].add(alias);
-      } else {
-        aliases[rhs] = new Set([alias]);
-      }
-    };
-
-    const schemas: Dictionary<Schema> = {};
-    const refSchemas: Dictionary<Schema> = {};
-
-    // Try to get one of the following keys from the manifest metadata
-    this.addScope(this.scope);
-
-    for (const particle of manifest.allParticles) {
-      const namespaceByParticle = (other: string) => `${particle.name}_${other}`;
-      for (const connection of particle.connections) {
-        const schema = connection.type.getEntitySchema();
-        if (!schema) {
-          continue;
-        }
-
-        // Include primary schemas from particle and connection name
-        // Given non-inline schemas: Create particle-namespaced schemas and alias connections to them.
-        const name = namespaceByParticle(connection.name);
-
-        if (aliases[name] === undefined) {
-          aliases[name] = new Set<string>([]);
-        }
-
-        schemas[name] = schema;
-
-        schema.names.forEach(n => {
-          const mangledName = namespaceByParticle(n);
-          if (Object.values(aliases).some(lst => lst.has(mangledName))) {
-            Object.values(aliases).forEach(lst => lst.delete(mangledName));
-          } else {
-            aliases[name].add(mangledName);
-          }
-        });
-
-        // Collect reference schema fields. These will be output first so they're defined
-        // prior to use in their containing entity classes.
-        for (const [field, descriptor] of Object.entries(schema.fields)) {
-          if (descriptor.kind === 'schema-reference') {
-            const refSchemaName = this.inlineSchemaName(field, descriptor);
-            const refSchema = descriptor.schema.model.getEntitySchema();
-            if (!(refSchemaName in refSchemas)) {
-              refSchemas[refSchemaName] = refSchema;
-            }
-
-            // TODO(alxr) Test the corner cases
-            refSchema.names.filter(n => n !== refSchemaName).forEach(n => updateAliases(refSchemaName, n));
-          }
-        }
-      }
-    }
-
-
-    return [aliases, refSchemas, schemas];
-  }
-
   private async processFile(src: string) {
     const outName = this.opts.outfile || this.outputName(path.basename(src));
     const outPath = path.join(this.opts.outdir, outName);
@@ -112,60 +47,66 @@ export abstract class Schema2Base {
     }
 
     const manifest = await Utils.parse(`import '${src}'`);
-
-    const [aliases, ...schemas] = this.processManifest(manifest);
-
-
-    if (Object.values(schemas).map(s => Object.keys(s).length).reduce((acc, x) => acc + x, 0) === 0) {
-      console.warn(`No schemas found in '${src}'`);
+    const classes = this.processManifest(manifest);
+    if (classes.length === 0) {
+      console.warn(`Could not find any particle connections with schemas in '${src}'`);
       return;
     }
 
     const outFile = fs.openSync(outPath, 'w');
     fs.writeSync(outFile, this.fileHeader(outName));
-    for (const dict of schemas) {
-      for (const [name, schema] of Object.entries(dict)) {
-        fs.writeSync(outFile, this.entityClass(name, schema).replace(/ +\n/g, '\n'));
-      }
+    for (const text of classes) {
+      fs.writeSync(outFile, text.replace(/ +\n/g, '\n'));
     }
-    fs.writeSync(outFile, `\n${this.addAliases(aliases)}\n`);
     fs.writeSync(outFile, this.fileFooter());
     fs.closeSync(outFile);
   }
 
-  protected processSchema(schema: Schema,
-                          processField: (field: string, typeChar: string, refName: string) => void): number {
-    let fieldCount = 0;
-    for (const [field, descriptor] of Object.entries(schema.fields)) {
-      fieldCount++;
-      switch (this.typeSummary(descriptor)) {
-        case 'schema-primitive:Text':
-          processField(field, 'T', null);
-          break;
+  processManifest(manifest: Manifest): string[] {
+    // TODO: consider an option to generate one file per particle
+    const classes: string[] = [];
+    for (const particle of manifest.allParticles) {
+      const graph = new SchemaGraph(particle);
 
-        case 'schema-primitive:URL':
-          processField(field, 'U', null);
-          break;
+      // Generate one class definition per node in the graph.
+      for (const node of graph.walk()) {
+        const generator = this.getClassGenerator(node);
+        const fields = Object.entries(node.schema.fields);
 
-        case 'schema-primitive:Number':
-          processField(field, 'N', null);
-          break;
+        for (const [field, descriptor] of fields) {
+          const inherited = !node.extras.includes(field);
+          switch (this.typeSummary(descriptor)) {
+            case 'schema-primitive:Text':
+              generator.processField(field, 'T', inherited, null);
+              break;
 
-        case 'schema-primitive:Boolean':
-          processField(field, 'B', null);
-          break;
+            case 'schema-primitive:URL':
+              generator.processField(field, 'U', inherited, null);
+              break;
 
-        case 'schema-reference':
-          processField(field, 'R', this.inlineSchemaName(field, descriptor));
-          break;
+            case 'schema-primitive:Number':
+              generator.processField(field, 'N', inherited, null);
+              break;
 
-        default:
-          console.log(`Schema type for field '${field}' is not yet supported:`);
-          console.dir(descriptor, {depth: null});
-          process.exit(1);
+            case 'schema-primitive:Boolean':
+              generator.processField(field, 'B', inherited, null);
+              break;
+
+            case 'schema-reference':
+              // TODO: this will be changed to its own method in a follow-up CL
+              generator.processField(field, 'R', inherited, node.refs[field].name);
+              break;
+
+            default:
+              console.log(`Schema type for field '${field}' is not yet supported:`);
+              console.dir(descriptor, {depth: null});
+              process.exit(1);
+          }
+        }
+        classes.push(generator.generate(fields.length));
       }
     }
-    return fieldCount;
+    return classes;
   }
 
   private typeSummary(descriptor) {
@@ -181,27 +122,11 @@ export abstract class Schema2Base {
     }
   }
 
-  private inlineSchemaName(field, descriptor) {
-    let name = descriptor.schema.name;
-    if (!name && descriptor.schema.names && descriptor.schema.names.length > 0) {
-      name = descriptor.schema.names[0];
-    }
-    if (!name) {
-      console.log(`Unnamed inline schemas (field '${field}') are not yet supported`);
-      process.exit(1);
-    }
-    return name;
-  }
+  outputName(baseName: string): string { return ''; }
 
-  abstract outputName(baseName: string): string;
+  fileHeader(outName: string): string { return ''; }
 
-  abstract fileHeader(outName: string): string;
+  fileFooter(): string { return ''; }
 
-  abstract fileFooter(): string;
-
-  abstract entityClass(name: string, schema: Schema): string;
-
-  abstract addAliases(aliases: Aliases): string;
-
-  abstract addScope(namespace: string);
+  abstract getClassGenerator(node: SchemaNode): ClassGenerator;
 }

--- a/src/tools/schema2graph.ts
+++ b/src/tools/schema2graph.ts
@@ -1,0 +1,196 @@
+/**
+ * @license
+ * Copyright (c) 2019 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+import {Schema} from '../runtime/schema.js';
+import {ParticleSpec} from '../runtime/particle-spec.js';
+import {Dictionary} from '../runtime/hot.js';
+
+export class SchemaNode {
+  schema: Schema;
+
+  // If this schema is only found once, name is of the form 'Particle_Handle' and aliases
+  // is empty. Otherwise, name is of the form 'ParticleInternal#' and aliases lists the
+  // 'Particle_Handle' names that need to be type aliased to it.
+  name: string;
+  aliases: string[] = [];
+
+  // All schemas that can be sliced to this one.
+  descendants = new Set<SchemaNode>();
+
+  // Immediate descendants and ancestors. Initially null as state indicators during the two
+  // build phases, but will be set to empty arrays if no parents or children are present.
+  parents: SchemaNode[] = null;
+  children: SchemaNode[] = null;
+
+  // True if any other schema has the same parent as this one. Used to set up virtual
+  // inheritance for C++ classes.
+  sharesParent = false;
+
+  // The list of field names that this schema has *in addition to* all of its ancestors.
+  extras: string[];
+
+  // Maps reference fields to the schema name and node that they contain. This is also used
+  // to ensure that nested schemas are generated before the references that rely on them.
+  refs: Dictionary<{name: string, node: SchemaNode}> = {};
+
+  constructor(schema: Schema, name: string) {
+    this.schema = schema;
+    this.aliases.push(name);
+    this.extras = Object.keys(schema.fields);
+  }
+}
+
+// Builds a directed type lattice graph from the set of schemas defined in a particle's connections,
+// including schemas nested in references, with one node per unique schema found. The graph's edges
+// indicate "slicability", such that a child node's schema can be sliced to any of its parents.
+// For example, the schema '* {Text t, URL u}' is slicable to both '* {Text t}' and '* {URL u}'.
+//
+// The graph has a second set of edges via the refs field, which connects nodes whose schemas have
+// references to other nodes which hold those references' nested schemas. These connections are used
+// to ensure that classes are generated in the order needed to satisfy both their reference fields'
+// type definitions and their inheritance heirarchies.
+export class SchemaGraph {
+  nodes: SchemaNode[] = [];
+  startNodes: SchemaNode[];
+  internalClassIndex = 0;
+
+  constructor(readonly particleSpec: ParticleSpec) {
+    // First pass to establish a node for each unique schema, with the descendants field populated.
+    for (const connection of this.particleSpec.connections) {
+      const schema = connection.type.getEntitySchema();
+      if (schema) {
+        this.createNodes(schema, connection.name);
+      }
+    }
+
+    // Both the second pass and the walk() method need to start from nodes with no parents.
+    this.startNodes = this.nodes.filter(n => !n.parents);
+
+    // Second pass to set up the class names, aliases and the parents, children and extras lists.
+    for (const node of this.startNodes) {
+      node.parents = [];
+      this.process(node);
+    }
+  }
+
+  private createNodes(schema: Schema, name: string) {
+    // We can only have one node in the graph per schema. Collect duplicates as aliases.
+    const previous = this.nodes.find(n => schema.equals(n.schema));
+    if (previous) {
+      previous.aliases.push(name);
+      return previous;
+    }
+
+    // This is a new schema. Check for slicability against all previous schemas
+    // (in both directions) to establish the descendancy mappings.
+    const node = new SchemaNode(schema, name);
+    for (const previous of this.nodes) {
+      for (const [a, b] of [[node, previous], [previous, node]]) {
+        if (b.schema.isMoreSpecificThan(a.schema)) {
+          a.descendants.add(b);  // b can be sliced to a
+          b.parents = [];        // non-null to indicate this has parents; will be filled later
+        }
+      }
+    }
+    this.nodes.push(node);
+
+    // Recurse on any nested schemas in reference-typed fields.
+    for (const [field, descriptor] of Object.entries(schema.fields)) {
+      let nestedSchema;
+      if (descriptor.kind === 'schema-reference') {
+        nestedSchema = descriptor.schema.model.entitySchema;
+      } else if (descriptor.kind === 'schema-collection' && descriptor.schema.kind === 'schema-reference') {
+        nestedSchema = descriptor.schema.schema.model.entitySchema;
+      }
+      if (nestedSchema) {
+        // We have a reference field. Generate a node for its nested schema and connect it into the
+        // refs map to indicate that this node requires nestedNode's class to be generated first.
+        const nestedName = name + '_' + this.upperFirst(field);
+        const nestedNode = this.createNodes(nestedSchema, nestedName);
+        node.refs[field] = {name: this.typeName(nestedName), node: nestedNode};
+      }
+    }
+    return node;
+  }
+
+  private process(node: SchemaNode) {
+    if (node.children) return;  // already visited
+
+    // If this node only has one alias, use that for the class name.
+    // Otherwise generate an internal name and create aliases for it.
+    if (node.aliases.length === 1) {
+      node.name = this.typeName(node.aliases.pop());
+    } else {
+      node.name = `${this.particleSpec.name}Internal${++this.internalClassIndex}`;
+      node.aliases = node.aliases.map(a => this.typeName(a));
+    }
+
+    // Set up children links: collect descendants of descendants.
+    const transitiveDescendants = new Set<SchemaNode>();
+    for (const d of node.descendants) {
+      for (const td of d.descendants) {
+        transitiveDescendants.add(td);
+      }
+    }
+
+    // children = (all descendants) - (descendants of descendants)
+    node.children = [...node.descendants].filter(x => !transitiveDescendants.has(x));
+
+    // Set up parent links on child nodes. If this node has multiple children, mark each
+    // of them as sharing a parent. This is used to set up virtual inheritance in C++.
+    // TODO: detect shared descendants across children for more accurate virtual inheritance
+    const sharesParent = node.children.length > 1;
+    const parentFields = Object.keys(node.schema.fields);
+    for (const child of node.children) {
+      child.parents.push(node);
+      child.sharesParent = child.sharesParent || sharesParent;  // don't wipe previous true value
+
+      // Remove all of this node's field names (derived from the schema) from each child's extras
+      // list. This means that extras will end up naming only those fields that a schema has in
+      // addition to its entire ancestry tree.
+      child.extras = child.extras.filter(f => !parentFields.includes(f));
+
+      this.process(child);
+    }
+  }
+
+  private typeName(postfix: string): string {
+    return `${this.particleSpec.name}_${this.upperFirst(postfix)}`;
+  }
+
+  private upperFirst(s: string): string {
+    return s[0].toUpperCase() + s.slice(1);
+  }
+
+  // Traverses the graph to yield schemas in the order in which they should be generated.
+  // The traversal is primarily breadth-first, but some nodes may be pushed back due to
+  // unsatisfied constraints.
+  * walk(): IterableIterator<SchemaNode> {
+    const queue: SchemaNode[] = [...this.startNodes];
+    const seen = new Set<SchemaNode>();
+    while (queue.length > 0) {
+      const node = queue.shift();
+      if (seen.has(node)) {
+        continue;
+      }
+
+      // We can only process this node if all its parents and reference fields have
+      // themselves been processed. If not, push it to the back of the queue.
+      if (node.parents.some(p => !seen.has(p)) ||
+          Object.values(node.refs).some(r => !seen.has(r.node))) {
+        queue.push(node);
+        continue;
+      }
+
+      queue.push(...node.children);
+      seen.add(node);
+      yield node;
+    }
+  }
+}

--- a/src/tools/schema2packager.ts
+++ b/src/tools/schema2packager.ts
@@ -11,10 +11,6 @@ import minimist from 'minimist';
 import {Schema2Cpp} from './schema2cpp.js';
 import {Schema2Kotlin} from './schema2kotlin.js';
 
-// TODO: schemas with multiple names and schemas with parents
-// TODO: schemas with no fields
-// TODO: schemas with no names?  i.e. inline '* {Text s}'
-
 const opts = minimist(process.argv.slice(2), {
   string: ['outdir', 'outfile', 'package'],
   boolean: ['cpp', 'kotlin', 'update', 'help'],

--- a/src/tools/tests/schema2cpp-test.ts
+++ b/src/tools/tests/schema2cpp-test.ts
@@ -7,157 +7,16 @@
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
-
 import {assert} from '../../platform/chai-web.js';
-import {Schema2Cpp} from '../schema2cpp.js';
 import {Manifest} from '../../runtime/manifest.js';
+import {Schema2Cpp} from '../schema2cpp.js';
 
 describe('schema2cpp', () => {
-  it('creates unique aliases for schemas with multiple names', async () => {
-    const manifest = await Manifest.parse(`\
-  particle Foo
-    in Product Element Thing {Text value} alpha
-    in Thing {Number n} beta
-    `);
-
-    const mock = new Schema2Cpp({'_': []});
-    const [aliases, ..._] = mock.processManifest(manifest);
-    const generated = mock.addAliases(aliases);
-
-    assert.sameMembers(generated.split(/\n+/g), [
-      'namespace arcs {',
-      'using Foo_Product = Foo_alpha;',
-      'using Foo_Element = Foo_alpha;',
-      '}  // namespace arcs',
-    ]);
+  it('converts manifest file names to appropriate header file names', () => {
+    const cpp = new Schema2Cpp({'_': []});
+    assert.strictEqual(cpp.outputName('simple.arcs'), 'simple.h');
+    assert.strictEqual(cpp.outputName('test-CPP.file_Name.arcs'), 'test-cpp-file-name.h');
   });
 
-  it('creates scoped aliases for global schemas', async () => {
-    const manifest = await Manifest.parse(`\
-schema Product
-  Text name
-  Number sku
-
-resource ProductResource
-  start
-  [{"name": "Vegemite", "sku": 249126}]
-store ProductStore of Product in ProductResource
-
-// Particle name must match the C++ class name
-// Wasm module name must match one specified in wasm.json
-particle BasicParticle in 'module.wasm'
-  consume root
-  in Product foo
-  out [Product] bar
-
-particle Watcher in 'https://$arcs/bazel-bin/particles/Native/Wasm/module.wasm'
-  consume root
-  in [Product] bar`);
-
-    const mock = new Schema2Cpp({'_': []});
-    const [aliases, ..._] = mock.processManifest(manifest);
-    const generated = mock.addAliases(aliases);
-
-    assert.sameMembers(generated.split(/\n+/g), [
-      'namespace arcs {',
-      'using Watcher_Product = Watcher_bar;',
-      '}  // namespace arcs'
-    ]);
-  });
-
-  it('sets the nested namespace for entities', async () => {
-    const manifest = await Manifest.parse(`\
-schema Product
-  Text name
-  Number sku
-  
-particle BasicParticle in 'module.wasm'
-  consume root
-  in Product foo
-  out [Product] bar`);
-
-    const mock = new Schema2Cpp({'_': [], 'package': 'grandma.mom.daughter'});
-    const [_, __, schemas] = mock.processManifest(manifest);
-
-    const entities: string[] = Object.entries(schemas).map(([name, schema]) => mock.entityClass(name, schema));
-
-    for (const entity of entities) {
-      assert.include(entity,
-`namespace grandma {
-namespace mom {
-namespace daughter {`);
-
-      assert.include(entity,
-`}  // namespace daughter
-}  // namespace mom
-}  // namespace grandma`);
-    }
-  });
-
-  it('sets the nested namespace for aliases', async () => {
-    const manifest = await Manifest.parse(`\
-schema Product
-  Text name
-  Number sku
-  
-particle BasicParticle in 'module.wasm'
-  consume root
-  in Product foo
-  out [Product] bar`);
-
-    const mock = new Schema2Cpp({'_': [], 'package': 'grandma.mom.daughter'});
-    const [aliases, ..._] = mock.processManifest(manifest);
-    const generated = mock.addAliases(aliases);
-
-    assert.sameMembers(generated.split(/\n+/g), [
-      'namespace grandma {',
-      'namespace mom {',
-      'namespace daughter {',
-      '}  // namespace daughter',
-      '}  // namespace mom',
-      '}  // namespace grandma',
-    ]);
-  });
-  it('sets the default namespace for entities', async () => {
-    const manifest = await Manifest.parse(`\
-schema Product
-  Text name
-  Number sku
-  
-particle BasicParticle in 'module.wasm'
-  consume root
-  in Product foo
-  out [Product] bar`);
-
-    const mock = new Schema2Cpp({'_': []});
-    const [_, __, schemas] = mock.processManifest(manifest);
-
-    const entities: string[] = Object.entries(schemas).map(([name, schema]) => mock.entityClass(name, schema));
-
-    for (const entity of entities) {
-      assert.include(entity, `namespace arcs {`);
-      assert.include(entity, `}  // namespace arcs`);
-    }
-  });
-
-  it('sets the default namespace for aliases', async () => {
-    const manifest = await Manifest.parse(`\
-schema Product
-  Text name
-  Number sku
-  
-particle BasicParticle in 'module.wasm'
-  consume root
-  in Product foo
-  out [Product] bar`);
-
-    const mock = new Schema2Cpp({'_': []});
-    const [aliases, ..._] = mock.processManifest(manifest);
-    const generated = mock.addAliases(aliases);
-
-    assert.sameMembers(generated.split(/\n+/g), [
-      'namespace arcs {',
-      '}  // namespace arcs',
-    ]);
-  });
+  // TODO: more tests
 });

--- a/src/tools/tests/schema2graph-test.ts
+++ b/src/tools/tests/schema2graph-test.ts
@@ -1,0 +1,474 @@
+/**
+ * @license
+ * Copyright (c) 2017 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+import {assert} from '../../platform/chai-web.js';
+import {Manifest} from '../../runtime/manifest.js';
+import {Dictionary} from '../../runtime/hot.js';
+import {SchemaGraph} from '../schema2graph.js';
+
+interface NodeInfo {
+  name: string;     // generated class name
+  parents: string;  // list of parent class names, sorted and stringified
+  extras: string;   // fields this schema has in addition to its ancestors, sorted and stringified
+  shares: boolean;  // indicates this schema shares a parent class with another schema
+}
+
+function convert(graph: SchemaGraph) {
+  const nodes: NodeInfo[] = [];
+  const aliases: Dictionary<string[]> = {};
+  for (const node of graph.walk()) {
+    nodes.push({
+      name: node.name,
+      parents: node.parents.map(p => p.name).sort().join(', '),
+      extras: [...node.extras].sort().join(''),
+      shares: node.sharesParent,
+    });
+    if (node.aliases.length) {
+      aliases[node.name] = [...node.aliases].sort();
+    }
+  }
+  return {nodes, aliases};
+}
+
+describe('schema2graph', () => {
+  it('empty graph', async () => {
+    const manifest = await Manifest.parse(`
+      particle E
+        consume root
+          provide tile
+    `);
+    const graph = new SchemaGraph(manifest.particles[0]);
+    assert.isEmpty([...graph.walk()]);
+  });
+
+  it('linear graph', async () => {
+    const manifest = await Manifest.parse(`
+      particle L
+        in * {Text a} h1                     // 1 -> 2 -> 3
+        in * {Text a, Text b} h2
+        in * {Text a, Text b, Text c} h3
+    `);
+    const res = convert(new SchemaGraph(manifest.particles[0]));
+    assert.deepStrictEqual(res.nodes, [
+      {name: 'L_H1', parents: '',     extras: 'a', shares: false},
+      {name: 'L_H2', parents: 'L_H1', extras: 'b', shares: false},
+      {name: 'L_H3', parents: 'L_H2', extras: 'c', shares: false},
+    ]);
+    assert.isEmpty(res.aliases);
+  });
+
+  it('diamond graph', async () => {
+    const manifest = await Manifest.parse(`
+      particle D
+        in * {Text a} h1                      //   1
+        in * {Text a, Text b} h2              //  2 3
+        in * {Text a, Text c} h3              //   4
+        in * {Text a, Text b, Text c} h4
+    `);
+    const res = convert(new SchemaGraph(manifest.particles[0]));
+    assert.deepStrictEqual(res.nodes, [
+      {name: 'D_H1', parents: '',           extras: 'a', shares: false},
+      {name: 'D_H2', parents: 'D_H1',       extras: 'b', shares: true},
+      {name: 'D_H3', parents: 'D_H1',       extras: 'c', shares: true},
+      {name: 'D_H4', parents: 'D_H2, D_H3', extras: '',  shares: false},
+    ]);
+    assert.isEmpty(res.aliases);
+  });
+
+  it('aliased schemas', async () => {
+    const manifest = await Manifest.parse(`
+      particle A
+        in * {Text a} h1                      //   1
+        in * {Text a, Text b} h2              //  2 3
+        in * {Text a, Text c} h3              //   4
+        in * {Text a, Text b, Text c} h4
+        in * {Text a, Text b} d2
+        in * {Text a, Text b, Text c} d4
+    `);
+    const res = convert(new SchemaGraph(manifest.particles[0]));
+    assert.deepStrictEqual(res.nodes, [
+      {name: 'A_H1',       parents: '',                 extras: 'a', shares: false},
+      {name: 'AInternal1', parents: 'A_H1',             extras: 'b', shares: true},
+      {name: 'A_H3',       parents: 'A_H1',             extras: 'c', shares: true},
+      {name: 'AInternal2', parents: 'AInternal1, A_H3', extras: '',  shares: false},
+    ]);
+    assert.deepStrictEqual(res.aliases, {
+      'AInternal1': ['A_D2', 'A_H2'],
+      'AInternal2': ['A_D4', 'A_H4'],
+    });
+  });
+
+  it('pyramid and vee as separate graphs', async () => {
+    const manifest = await Manifest.parse(`
+      particle S
+        in * {Text a} p0                      //    0
+        in * {Text a, Text b} p1              //   1 2
+        in * {Text a, Text c} p2              //  3   4
+        in * {Text a, Text b, Text d} p3
+        in * {Text a, Text c, Text e} p4
+        in * {URL a} v5                       //  5   6
+        in * {URL c} v6                       //   7 8
+        in * {URL a, URL b} v7                //    9
+        in * {URL c, URL d} v8
+        in * {URL a, URL b, URL c, URL d} v9
+    `);
+    const res = convert(new SchemaGraph(manifest.particles[0]));
+
+    // Traversal is breadth-first; nodes within a row are in the same order as in the manifest.
+    assert.deepStrictEqual(res.nodes, [
+      {name: 'S_P0', parents: '',           extras: 'a', shares: false},
+      {name: 'S_V5', parents: '',           extras: 'a', shares: false},
+      {name: 'S_V6', parents: '',           extras: 'c', shares: false},
+      {name: 'S_P1', parents: 'S_P0',       extras: 'b', shares: true},
+      {name: 'S_P2', parents: 'S_P0',       extras: 'c', shares: true},
+      {name: 'S_V7', parents: 'S_V5',       extras: 'b', shares: false},
+      {name: 'S_V8', parents: 'S_V6',       extras: 'd', shares: false},
+      {name: 'S_P3', parents: 'S_P1',       extras: 'd', shares: false},
+      {name: 'S_P4', parents: 'S_P2',       extras: 'e', shares: false},
+      {name: 'S_V9', parents: 'S_V7, S_V8', extras: '',  shares: false},
+    ]);
+    assert.isEmpty(res.aliases);
+  });
+
+  it('mesh graph', async () => {
+    //    1:a  2:b
+    //    |  \/  |
+    //    |  /\  |
+    //  3:abc  4:abd
+    //      \  /
+    //    5:abcde
+    const manifest = await Manifest.parse(`
+      particle M
+        in * {Text a} h1
+        in * {Text b} h2
+        in * {Text a, Text b, Text c} h3
+        in * {Text a, Text b, Text d} h4
+        in * {Text a, Text b, Text c, Text d, Text e} h5
+    `);
+    const res = convert(new SchemaGraph(manifest.particles[0]));
+    assert.deepStrictEqual(res.nodes, [
+      {name: 'M_H1', parents: '',           extras: 'a', shares: false},
+      {name: 'M_H2', parents: '',           extras: 'b', shares: false},
+      {name: 'M_H3', parents: 'M_H1, M_H2', extras: 'c', shares: true},
+      {name: 'M_H4', parents: 'M_H1, M_H2', extras: 'd', shares: true},
+      {name: 'M_H5', parents: 'M_H3, M_H4', extras: 'e', shares: false},
+    ]);
+    assert.isEmpty(res.aliases);
+  });
+
+  it('jump graph', async () => {
+    // Check that a descendant connection that jumps past multiple levels of the
+    // graph doesn't cause incorrect ordering.
+    //
+    //  1:a   2:x
+    //   |     |
+    //  3:ab   |
+    //   |     |
+    //  4:abc  |
+    //     \   |
+    //     5:abcx
+    const manifest = await Manifest.parse(`
+      particle J
+        in * {Text a} h1
+        in * {Text x} h2
+        in * {Text a, Text b} h3
+        in * {Text a, Text b, Text c} h4
+        in * {Text a, Text b, Text c, Text x} h5
+    `);
+    const res = convert(new SchemaGraph(manifest.particles[0]));
+    assert.deepStrictEqual(res.nodes, [
+      {name: 'J_H1', parents: '',           extras: 'a', shares: false},
+      {name: 'J_H2', parents: '',           extras: 'x', shares: false},
+      {name: 'J_H3', parents: 'J_H1',       extras: 'b', shares: false},
+      {name: 'J_H4', parents: 'J_H3',       extras: 'c', shares: false},
+      {name: 'J_H5', parents: 'J_H2, J_H4', extras: '',  shares: false},
+    ]);
+    assert.isEmpty(res.aliases);
+  });
+
+  it('unconnected graph with aliased schema', async () => {
+    // Use more realistic field names and connection types, and check that schema names are
+    // ignored outside of the more-specific-than comparison.
+    const manifest = await Manifest.parse(`
+      particle Test
+        in Widget {Text t} name
+        out Data {Number n} age
+        in [Thing Product {Text z}] moniker
+        inout [Data {Number n}] oldness
+        out Reference<* {URL u}> mainAddress
+    `);
+    const res = convert(new SchemaGraph(manifest.particles[0]));
+    assert.deepStrictEqual(res.nodes, [
+      {name: 'Test_Name',        parents: '', extras: 't', shares: false},
+      {name: 'TestInternal1',    parents: '', extras: 'n', shares: false},
+      {name: 'Test_Moniker',     parents: '', extras: 'z', shares: false},
+      {name: 'Test_MainAddress', parents: '', extras: 'u', shares: false},
+    ]);
+    assert.deepStrictEqual(res.aliases, {
+      'TestInternal1': ['Test_Age', 'Test_Oldness']
+    });
+  });
+
+  it('collections and handle-level references do not affect the graph', async () => {
+    const manifest = await Manifest.parse(`
+      particle W
+        in Reference<* {Text a}> h1
+        in [* {Text a, Text b}] h2
+        in [Reference<* {Text a, Text b, Text c}>] h3
+        in * {Text a, Text b, [Reference<* {Text d}>] r} h4
+    `);
+    const res = convert(new SchemaGraph(manifest.particles[0]));
+    assert.deepStrictEqual(res.nodes, [
+      {name: 'W_H1',   parents: '',     extras: 'a', shares: false},
+      {name: 'W_H4_R', parents: '',     extras: 'd', shares: false},
+      {name: 'W_H2',   parents: 'W_H1', extras: 'b', shares: false},
+      {name: 'W_H3',   parents: 'W_H2', extras: 'c', shares: true},
+      {name: 'W_H4',   parents: 'W_H2', extras: 'r', shares: true},
+    ]);
+    assert.isEmpty(res.aliases);
+  });
+
+  it('complex graph', async () => {
+    // Handles are declared in a different order from their graph "position" but
+    // named using their numeric order in which their classes are generated.
+    //
+    //          1:a
+    //           |
+    //          3:ab      2:d
+    //         /    \     / \
+    //       6:abc   5:abd   4:dx
+    //       /   \    /
+    //  8:abcy   7:abcd
+    //              |
+    //           9:abcde
+    const manifest = await Manifest.parse(`
+      particle X
+        in * {Text d, Text x} h4
+        in * {Text a, Text b, Text c, Text y} h8
+        in * {Text a} h1
+        in * {Text a, Text b, Text c} h6
+        in * {Text a, Text b, Text c, Text d, Text e} h9
+        in * {Text d} h2
+        in * {Text a, Text b, Text c, Text d} h7
+        in * {Text a, Text b, Text d} h5
+        in * {Text a, Text b} h3
+    `);
+    const res = convert(new SchemaGraph(manifest.particles[0]));
+    assert.deepStrictEqual(res.nodes, [
+      {name: 'X_H1', parents: '',           extras: 'a', shares: false},
+      {name: 'X_H2', parents: '',           extras: 'd', shares: false},
+      {name: 'X_H3', parents: 'X_H1',       extras: 'b', shares: false},
+      {name: 'X_H4', parents: 'X_H2',       extras: 'x', shares: true},
+      {name: 'X_H5', parents: 'X_H2, X_H3', extras: '',  shares: true},
+      {name: 'X_H6', parents: 'X_H3',       extras: 'c', shares: true},
+      {name: 'X_H7', parents: 'X_H5, X_H6', extras: '',  shares: true},
+      {name: 'X_H8', parents: 'X_H6',       extras: 'y', shares: true},
+      {name: 'X_H9', parents: 'X_H7',       extras: 'e', shares: false},
+    ]);
+    assert.isEmpty(res.aliases);
+  });
+
+  it('field slicing', async () => {
+    // Check that more complicated sequences of field combinations work.
+    //
+    //  3:d    1:a   2:bc    4:be   5:f   11:qr
+    //    \    / \    |        |     |      |
+    //    6:ade   7:abcgh   8:beghi  |    12:qrs
+    //                 \     /       |
+    //                9:abceghi      |
+    //                        \      |
+    //                       10:abcefghij
+    const manifest = await Manifest.parse(`
+      particle F
+        in * {Text a} h1
+        in * {Text b, Text c} h2
+        in * {Text d} h3
+        in * {Text b, Text e} h4
+        in * {Text f} h5
+        in * {Text a, Text d, Text e} h6
+        in * {Text a, Text b, Text c, Text g, Text h} h7
+        in * {Text b, Text e, Text g, Text h, Text i} h8
+        in * {Text a, Text b, Text c, Text e, Text g, Text h, Text i} h9
+        in * {Text a, Text b, Text c, Text e, Text f, Text g, Text h, Text i, Text j} h10
+        in * {Text q, Text r} h11
+        in * {Text q, Text r, Text s} h12
+    `);
+    const res = convert(new SchemaGraph(manifest.particles[0]));
+    assert.deepStrictEqual(res.nodes, [
+       {name: 'F_H1',  parents: '',           extras: 'a',   shares: false},
+       {name: 'F_H2',  parents: '',           extras: 'bc',  shares: false},
+       {name: 'F_H3',  parents: '',           extras: 'd',   shares: false},
+       {name: 'F_H4',  parents: '',           extras: 'be',  shares: false},
+       {name: 'F_H5',  parents: '',           extras: 'f',   shares: false},
+       {name: 'F_H11', parents: '',           extras: 'qr',  shares: false},
+       {name: 'F_H6',  parents: 'F_H1, F_H3', extras: 'e',   shares: true},
+       {name: 'F_H7',  parents: 'F_H1, F_H2', extras: 'gh',  shares: true},
+       {name: 'F_H8',  parents: 'F_H4',       extras: 'ghi', shares: false},
+       {name: 'F_H12', parents: 'F_H11',      extras: 's',   shares: false},
+       {name: 'F_H9',  parents: 'F_H7, F_H8', extras: '',    shares: false},
+       {name: 'F_H10', parents: 'F_H5, F_H9', extras: 'j',   shares: false},
+    ]);
+    assert.isEmpty(res.aliases);
+  });
+
+  it('nested schemas use camel-cased path names', async () => {
+    const manifest = await Manifest.parse(`
+      particle Names
+        in * {Reference<* {Text t, Reference<* {URL u}> inner}> outer} data
+        in * {Text t, Reference<* {URL u}> inner} dupe
+    `);
+    const graph = new SchemaGraph(manifest.particles[0]);
+    const res = convert(graph);
+    assert.deepStrictEqual(res.nodes.map(x => x.name), [
+      'Names_Data_Outer_Inner',
+      'NamesInternal1',
+      'Names_Data',
+    ]);
+    assert.deepStrictEqual(res.aliases, {
+      'NamesInternal1': ['Names_Data_Outer', 'Names_Dupe']
+    });
+  });
+
+  it('aliased nested schemas', async () => {
+    // The handle schemas form a linear chain (h1 -> h2 -> h3) and the reference schemas
+    // create a separate, single class with two aliases.
+    const manifest = await Manifest.parse(`
+      particle N
+        in * {Text a} h1
+        in * {Text a, Reference<* {Text b}> r} h2
+        in * {Text a, Reference<* {Text b}> r, Text c} h3
+    `);
+    const res = convert(new SchemaGraph(manifest.particles[0]));
+    assert.deepStrictEqual(res.nodes, [
+      {name: 'N_H1',       parents: '',     extras: 'a', shares: false},
+      {name: 'NInternal1', parents: '',     extras: 'b', shares: false},
+      {name: 'N_H2',       parents: 'N_H1', extras: 'r', shares: false},
+      {name: 'N_H3',       parents: 'N_H2', extras: 'c', shares: false},
+    ]);
+    assert.deepStrictEqual(res.aliases, {
+      'NInternal1': ['N_H2_R', 'N_H3_R']
+    });
+  });
+
+  it('diamond graph using nested schemas', async () => {
+    //       1:a      3:rs
+    //      /   \
+    //  3R:ab   3S:ac
+    //      \   /
+    //      2:abc
+    const manifest = await Manifest.parse(`
+      particle I
+        in * {Text a} h1
+        in * {Text a, Text b, Text c} h2
+        in * {Reference<* {Text a, Text b}> r, Reference<* {Text a, Text c}> s} h3
+    `);
+    const res = convert(new SchemaGraph(manifest.particles[0]));
+    assert.deepStrictEqual(res.nodes, [
+      {name: 'I_H1',   parents: '',               extras: 'a',  shares: false},
+      {name: 'I_H3_R', parents: 'I_H1',           extras: 'b',  shares: true},
+      {name: 'I_H3_S', parents: 'I_H1',           extras: 'c',  shares: true},
+      {name: 'I_H3',   parents: '',               extras: 'rs', shares: false},
+      {name: 'I_H2',   parents: 'I_H3_R, I_H3_S', extras: '',   shares: false},
+    ]);
+    assert.isEmpty(res.aliases);
+  });
+
+  it('deeply nested schemas', async () => {
+    const manifest = await Manifest.parse(`
+      particle Y
+        in * {Reference<* {Text a}> r} h1
+        in * {Text a, Reference<* {Text a}> s} h2
+        in * {Reference<* {Text b, Reference<* {Text b, Text c, Reference<* {Text d}> v}> u}> t} h3
+        in * {Text a, Text d, Text e} h4
+        in * {Text b, Text c, Reference<* {Text d}> v} h5
+    `);
+    const res = convert(new SchemaGraph(manifest.particles[0]));
+    assert.deepStrictEqual(res.nodes, [
+      {name: 'YInternal1', parents: '',                       extras: 'a',   shares: false},
+      {name: 'Y_H3_T_U_V', parents: '',                       extras: 'd',   shares: false},
+      {name: 'Y_H1',       parents: '',                       extras: 'r',   shares: false},
+      {name: 'Y_H2',       parents: 'YInternal1',             extras: 's',   shares: true},
+      {name: 'Y_H4',       parents: 'YInternal1, Y_H3_T_U_V', extras: 'e',   shares: true},
+      {name: 'YInternal2', parents: '',                       extras: 'bcv', shares: false},
+      {name: 'Y_H3_T',     parents: '',                       extras: 'bu',  shares: false},
+      {name: 'Y_H3',       parents: '',                       extras: 't',   shares: false},
+    ]);
+    assert.deepStrictEqual(res.aliases, {
+      'YInternal1': ['Y_H1_R', 'Y_H2_S'],
+      'YInternal2': ['Y_H3_T_U', 'Y_H5'],
+    });
+  });
+
+  it('nested schema matching one further down the graph outputs in correct order', async () => {
+    //      1:a
+    //     /   \
+    //  3:ab   2:ar
+    //    |
+    //  4:abc == 2R:abc
+    const manifest = await Manifest.parse(`
+      particle V
+        in * {Text a} h1
+        in * {Text a, Reference<* {Text a, Text b, Text c}> r} h2
+        in * {Text a, Text b} h3
+        in * {Text a, Text b, Text c} h4
+    `);
+    const res = convert(new SchemaGraph(manifest.particles[0]));
+    assert.deepStrictEqual(res.nodes, [
+      {name: 'V_H1',       parents: '',     extras: 'a', shares: false},
+      {name: 'V_H3',       parents: 'V_H1', extras: 'b', shares: true},
+      {name: 'VInternal1', parents: 'V_H3', extras: 'c', shares: false},
+      {name: 'V_H2',       parents: 'V_H1', extras: 'r', shares: true},
+    ]);
+    assert.deepStrictEqual(res.aliases, {
+      'VInternal1': ['V_H2_R', 'V_H4']
+    });
+  });
+
+  it('nested schemas with various descendant patterns', async () => {
+    const manifest = await Manifest.parse(`
+      particle R
+        // Starting node with a reference
+        in * {Reference<* {Text a}> r} h1
+
+        // Starting node with a reference descending from h1
+        in * {Reference<* {Text a, Text b}> s} h2
+
+        // Separate starting node
+        in * {Reference<* {Number n}> i} k1
+
+        // Descendant node with multiple independent references
+        in * {Reference<* {Text a}> r, Reference<* {Text c}> t, Reference<* {Text d}> u} h3
+
+        // Descendant node with co-descendant reference
+        in * {Reference<* {Text a}> r, Reference<* {Text a, Text e}> v} h4
+
+        // Separate starting node with co-descendant reference
+        in * {Reference<* {Number n, Number o}> j} k2
+    `);
+    const res = convert(new SchemaGraph(manifest.particles[0]));
+    assert.deepStrictEqual(res.nodes, [
+      {name: 'RInternal1', parents: '',           extras: 'a',  shares: false},
+      {name: 'R_K1_I',     parents: '',           extras: 'n',  shares: false},
+      {name: 'R_H3_T',     parents: '',           extras: 'c',  shares: false},
+      {name: 'R_H3_U',     parents: '',           extras: 'd',  shares: false},
+      {name: 'R_H1',       parents: '',           extras: 'r',  shares: false},
+      {name: 'R_H2_S',     parents: 'RInternal1', extras: 'b',  shares: true},
+      {name: 'R_H4_V',     parents: 'RInternal1', extras: 'e',  shares: true},
+      {name: 'R_H2',       parents: '',           extras: 's',  shares: false},
+      {name: 'R_K1',       parents: '',           extras: 'i',  shares: false},
+      {name: 'R_K2_J',     parents: 'R_K1_I',     extras: 'o',  shares: false},
+      {name: 'R_K2',       parents: '',           extras: 'j',  shares: false},
+      {name: 'R_H3',       parents: 'R_H1',       extras: 'tu', shares: true},
+      {name: 'R_H4',       parents: 'R_H1',       extras: 'v',  shares: true},
+    ]);
+    assert.deepStrictEqual(res.aliases, {
+      'RInternal1': ['R_H1_R', 'R_H3_R', 'R_H4_R']
+    });
+  });
+});

--- a/src/tools/tests/schema2kotlin-test.ts
+++ b/src/tools/tests/schema2kotlin-test.ts
@@ -7,121 +7,16 @@
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
-
 import {assert} from '../../platform/chai-web.js';
-import {Schema2Kotlin} from '../schema2kotlin.js';
 import {Manifest} from '../../runtime/manifest.js';
+import {Schema2Kotlin} from '../schema2kotlin.js';
 
 describe('schema2kotlin', () => {
-  it('creates unique aliases for schemas with multiple names', async () => {
-    const manifest = await Manifest.parse(`\
-  particle Foo
-    in Product Element Thing {Text value} alpha
-    in Thing {Number n} beta
-    `);
-
-    const mock = new Schema2Kotlin({'_': []});
-    const [aliases, ..._] = mock.processManifest(manifest);
-    const generated = mock.addAliases(aliases);
-
-    assert.notInclude(generated, ';');
-    assert.sameMembers(generated.split(/\n+/g), [
-      'typealias Foo_Product = Foo_alpha',
-      'typealias Foo_Element = Foo_alpha',
-    ]);
+  it('converts manifest file names to appropriate source file names', () => {
+    const kotlin = new Schema2Kotlin({'_': []});
+    assert.strictEqual(kotlin.outputName('simple.arcs'), 'Simple.kt');
+    assert.strictEqual(kotlin.outputName('test-KOTLIN.file_Name.arcs'), 'TestKotlinFileName.kt');
   });
 
-  it('creates aliases while eliminating ambiguous identifiers', async () => {
-    const manifest = await Manifest.parse(`\
-particle Reader
-  in * {Text value} object
-  in Product Element Thing {Text value} myThing
-  in Thing {Number n} otherThing`);
-
-    const mock = new Schema2Kotlin({'_': []});
-    const [aliases, ..._] = mock.processManifest(manifest);
-    const generated = mock.addAliases(aliases);
-
-    assert.notInclude(generated, ';');
-    assert.sameMembers(generated.split(/\n+/g), [
-      'typealias Reader_Product = Reader_myThing',
-      'typealias Reader_Element = Reader_myThing',
-    ]);
-  });
-
-  it('creates aliases while eliminating ambiguous identifies, including in the first connection', async () => {
-    const manifest = await Manifest.parse(`\
-particle Foo
-  in Product Element Thing {Text value} myThing
-  in Thing {Number n} otherThing
-  out Product {Text name, Number age} anotherThing`);
-
-    const mock = new Schema2Kotlin({'_': []});
-    const [aliases, ..._] = mock.processManifest(manifest);
-    const generated = mock.addAliases(aliases);
-
-    assert.notInclude(generated, ';');
-    assert.equal(generated, 'typealias Foo_Element = Foo_myThing');
-  });
-
-  it('creates scoped aliases for global schemas', async () => {
-    const manifest = await Manifest.parse(`\
-schema Product
-  Text name
-  Number sku
-
-resource ProductResource
-  start
-  [{"name": "Vegemite", "sku": 249126}]
-store ProductStore of Product in ProductResource
-
-// Particle name must match the C++ class name
-// Wasm module name must match one specified in wasm.json
-particle BasicParticle in 'module.wasm'
-  consume root
-  in Product foo
-  out [Product] bar
-
-particle Watcher in 'https://$arcs/bazel-bin/particles/Native/Wasm/module.wasm'
-  consume root
-  in [Product] bar`);
-
-    const mock = new Schema2Kotlin({'_': []});
-    const [aliases, ..._] = mock.processManifest(manifest);
-    const generated = mock.addAliases(aliases);
-
-    assert.notInclude(generated, ';');
-    assert.sameMembers(generated.split(/\n+/g), [
-      // 'typealias BasicParticle_foo = BasicParticle_Product',
-      // 'typealias BasicParticle_bar = BasicParticle_Product',
-      'typealias Watcher_Product = Watcher_bar',
-    ]);
-  });
-
-  it('creates nested package name for entities', async () => {
-    const manifest = await Manifest.parse(`\
-    particle Reader
-      in * {Text value} object
-      out Id {Number hash} output`);
-
-    const mock = new Schema2Kotlin({'_': [], 'package': 'grandma.mom.daughter'});
-    const _ = mock.processManifest(manifest);
-    const header = mock.fileHeader('');
-
-    assert.equal(header.split(/\n+/g)[0], `package grandma.mom.daughter`);
-  });
-
-  it('creates a default package name when needed', async () => {
-
-    const manifest = await Manifest.parse(`\
-    particle Foo
-      in * {Text name} input
-      out Id {Number hash} output`);
-
-    const mock = new Schema2Kotlin({'_': []});
-    const _ = mock.processManifest(manifest);
-    const header = mock.fileHeader('');
-
-    assert.equal(header.split(/\n+/g)[0], `package arcs`);
-  });
+  // TODO: more tests
 });

--- a/src/wasm/cpp/tests/entity-class-test.cc
+++ b/src/wasm/cpp/tests/entity-class-test.cc
@@ -10,12 +10,12 @@ static size_t hash(const T& d) {
   return std::hash<T>()(d);
 }
 
-static arcs::Ref<arcs::Foo> make_ref(const std::string& id, const std::string& key) {
-  return Accessor::make_ref<arcs::Foo>(id, key);
+static arcs::Ref<arcs::Test_Data_Ref> make_ref(const std::string& id, const std::string& key) {
+  return Accessor::make_ref<arcs::Test_Data_Ref>(id, key);
 }
 
 static auto converter() {
-  return [](const arcs::Test_data& d) { return arcs::entity_to_str(d); };
+  return [](const arcs::Test_Data& d) { return arcs::entity_to_str(d); };
 }
 
 
@@ -39,7 +39,7 @@ public:
   }
 
   void test_field_methods() {
-    arcs::Test_data d;
+    arcs::Test_Data d;
 
     IS_FALSE(d.has_num());
     EQUAL(d.num(), 0);
@@ -85,8 +85,8 @@ public:
     IS_TRUE(d.has_flg());
     IS_FALSE(d.flg());
 
-    arcs::Ref<arcs::Foo> empty;
-    arcs::Ref<arcs::Foo> populated = make_ref("id", "key");
+    arcs::Ref<arcs::Test_Data_Ref> empty;
+    arcs::Ref<arcs::Test_Data_Ref> populated = make_ref("id", "key");
     IS_FALSE(d.has_ref());
     EQUAL(d.ref(), empty);
     d.set_ref(populated);
@@ -100,7 +100,7 @@ public:
   }
 
   void test_id_equality() {
-    arcs::Test_data d1, d2;
+    arcs::Test_Data d1, d2;
     EQUAL(Accessor::get_id(d1), "");
 
     // unset vs value
@@ -123,7 +123,7 @@ public:
   }
 
   void test_number_field_equality() {
-    arcs::Test_data d1, d2;
+    arcs::Test_Data d1, d2;
 
     // unset vs default value
     d2.set_num(0);
@@ -165,7 +165,7 @@ public:
   }
 
   void test_text_field_equality() {
-    arcs::Test_data d1, d2;
+    arcs::Test_Data d1, d2;
 
     // unset vs default value
     d2.set_txt("");
@@ -207,7 +207,7 @@ public:
   }
 
   void test_url_field_equality() {
-    arcs::Test_data d1, d2;
+    arcs::Test_Data d1, d2;
 
     // unset vs default value
     d2.set_lnk("");
@@ -249,7 +249,7 @@ public:
   }
 
   void test_boolean_field_equality() {
-    arcs::Test_data d1, d2;
+    arcs::Test_Data d1, d2;
 
     // unset vs default value
     d2.set_flg(false);
@@ -285,8 +285,8 @@ public:
   }
 
   void test_reference_field_equality() {
-    arcs::Test_data d1, d2;
-    arcs::Ref<arcs::Foo> empty;
+    arcs::Test_Data d1, d2;
+    arcs::Ref<arcs::Test_Data_Ref> empty;
 
     // unset vs default value
     d2.set_ref({});
@@ -326,7 +326,7 @@ public:
   }
 
   void test_entity_equality() {
-    arcs::Test_data d1, d2;
+    arcs::Test_Data d1, d2;
 
     // Empty entities are equal
     EQUAL(d1, d2);
@@ -336,7 +336,7 @@ public:
     EQUAL(hash(d1), hash(d2));
 
     // Entities with the same fields are equal
-    for (arcs::Test_data* d : std::vector{&d1, &d2}) {
+    for (arcs::Test_Data* d : std::vector{&d1, &d2}) {
       d->set_num(3);
       d->set_txt("abc");
       d->set_lnk("");
@@ -406,8 +406,8 @@ public:
   }
 
   void test_clone_entity() {
-    arcs::Test_data src;
-    arcs::Test_data d1 = arcs::clone_entity(src);
+    arcs::Test_Data src;
+    arcs::Test_Data d1 = arcs::clone_entity(src);
     EQUAL(d1, src);
     IS_TRUE(arcs::fields_equal(d1, src));
     EQUAL(hash(d1), hash(src));
@@ -415,7 +415,7 @@ public:
     src.set_num(8);
     src.set_txt("def");
     src.set_flg(false);
-    arcs::Test_data d2 = arcs::clone_entity(src);
+    arcs::Test_Data d2 = arcs::clone_entity(src);
     EQUAL(d2, src);
     IS_TRUE(arcs::fields_equal(d2, src));
     EQUAL(hash(d2), hash(src));
@@ -425,7 +425,7 @@ public:
 
     // Cloning doesn't include the internal id.
     Accessor::set_id(&src, "id");
-    arcs::Test_data d3 = arcs::clone_entity(src);
+    arcs::Test_Data d3 = arcs::clone_entity(src);
     EQUAL(Accessor::get_id(d3), "");
     NOT_EQUAL(d3, src);
     IS_TRUE(arcs::fields_equal(d3, src));
@@ -433,7 +433,7 @@ public:
   }
 
   void test_entity_to_str() {
-    arcs::Test_data d;
+    arcs::Test_Data d;
     EQUAL(arcs::entity_to_str(d), "{}");
 
     d.set_num(6);
@@ -449,12 +449,12 @@ public:
   }
 
   void test_stl_vector() {
-    arcs::Test_data d1, d2, d3;
+    arcs::Test_Data d1, d2, d3;
     d1.set_num(12);
     d2.set_num(12);
     Accessor::set_id(&d3, "id");
 
-    std::vector<arcs::Test_data> v;
+    std::vector<arcs::Test_Data> v;
     v.push_back(std::move(d1));
     v.push_back(std::move(d2));
     v.push_back(std::move(d3));
@@ -468,31 +468,31 @@ public:
   }
 
   void test_stl_set() {
-    arcs::Test_data d1;
+    arcs::Test_Data d1;
     d1.set_num(45);
     d1.set_txt("woop");
 
     // duplicate
-    arcs::Test_data d2;
+    arcs::Test_Data d2;
     d2.set_num(45);
     d2.set_txt("woop");
 
     // duplicate fields but with an id
-    arcs::Test_data d3;
+    arcs::Test_Data d3;
     Accessor::set_id(&d3, "id");
     d3.set_num(45);
     d3.set_txt("woop");
 
     // same id, different fields
-    arcs::Test_data d4;
+    arcs::Test_Data d4;
     Accessor::set_id(&d4, "id");
     d4.set_flg(false);
 
     // duplicate
-    arcs::Test_data d5 = arcs::clone_entity(d4);
+    arcs::Test_Data d5 = arcs::clone_entity(d4);
     Accessor::set_id(&d5, "id");
 
-    std::set<arcs::Test_data> s;
+    std::set<arcs::Test_Data> s;
     s.insert(std::move(d1));
     s.insert(std::move(d2));
     s.insert(std::move(d3));
@@ -508,31 +508,31 @@ public:
   }
 
   void test_stl_unordered_set() {
-    arcs::Test_data d1;
+    arcs::Test_Data d1;
     d1.set_num(45);
     d1.set_txt("woop");
 
     // duplicate
-    arcs::Test_data d2;
+    arcs::Test_Data d2;
     d2.set_num(45);
     d2.set_txt("woop");
 
     // duplicate fields but with an id
-    arcs::Test_data d3;
+    arcs::Test_Data d3;
     Accessor::set_id(&d3, "id");
     d3.set_num(45);
     d3.set_txt("woop");
 
     // same id, different fields
-    arcs::Test_data d4;
+    arcs::Test_Data d4;
     Accessor::set_id(&d4, "id");
     d4.set_flg(false);
 
     // duplicate
-    arcs::Test_data d5 = arcs::clone_entity(d4);
+    arcs::Test_Data d5 = arcs::clone_entity(d4);
     Accessor::set_id(&d5, "id");
 
-    std::unordered_set<arcs::Test_data> s;
+    std::unordered_set<arcs::Test_Data> s;
     s.insert(std::move(d1));
     s.insert(std::move(d2));
     s.insert(std::move(d3));
@@ -548,7 +548,7 @@ public:
   }
 
   void test_empty_schema() {
-    arcs::Test_empty e1, e2;
+    arcs::Test_Empty e1, e2;
 
     EQUAL(Accessor::get_id(e1), "");
     EQUAL(e1, e2);
@@ -574,21 +574,21 @@ public:
     IS_TRUE(arcs::fields_equal(e1, e2));
     EQUAL(hash(e1), hash(e2));
 
-    arcs::Test_empty e3 = arcs::clone_entity(e1);
+    arcs::Test_Empty e3 = arcs::clone_entity(e1);
     EQUAL(arcs::entity_to_str(e3), "{}");
 
-    auto converter = [](const arcs::Test_empty& e) {
+    auto converter = [](const arcs::Test_Empty& e) {
       return arcs::entity_to_str(e);
     };
     std::vector<std::string> expected = {"{id}", "{}"};
 
-    std::set<arcs::Test_empty> s1;
+    std::set<arcs::Test_Empty> s1;
     s1.insert(std::move(e1));
     s1.insert(std::move(e3));
     CHECK_UNORDERED(s1, converter, expected);
 
-    std::unordered_set<arcs::Test_empty> s2;
-    arcs::Test_empty e4;
+    std::unordered_set<arcs::Test_Empty> s2;
+    arcs::Test_Empty e4;
     s2.insert(std::move(e2));
     s2.insert(std::move(e4));
     CHECK_UNORDERED(s2, converter, expected);
@@ -608,7 +608,7 @@ public:
 
   // Test that language keywords can be field names.
   void test_language_keyword_field() {
-    arcs::Test_specialFields s;
+    arcs::Test_SpecialFields s;
 
     IS_FALSE(s.has_for());
     EQUAL(s._for(), "");
@@ -624,7 +624,7 @@ public:
 
   // Test that a field called 'internal_id' doesn't conflict with the Arcs internal id.
   void test_internal_id_field() {
-    arcs::Test_specialFields s;
+    arcs::Test_SpecialFields s;
     Accessor::set_id(&s, "real");
 
     IS_FALSE(s.has_internal_id());
@@ -642,7 +642,7 @@ public:
   }
 
   void test_general_usage() {
-    arcs::Test_specialFields s1;
+    arcs::Test_SpecialFields s1;
     Accessor::set_id(&s1, "id");
     s1.set_for("abc");
     s1.set_internal_id(15);
@@ -650,7 +650,7 @@ public:
     EQUAL(arcs::entity_to_str(s1), "{id}, for: abc, internal_id: 15");
 
     // same fields, different ids
-    arcs::Test_specialFields s2 = arcs::clone_entity(s1);
+    arcs::Test_SpecialFields s2 = arcs::clone_entity(s1);
     NOT_EQUAL(s1, s2);
     NOT_LESS(s1, s2);
     LESS(s2, s1);

--- a/src/wasm/cpp/tests/particle-api-test.cc
+++ b/src/wasm/cpp/tests/particle-api-test.cc
@@ -10,15 +10,15 @@ public:
   }
 
   void onHandleSync(const std::string& name, bool all_synced) override {
-    arcs::Test_data out;
+    arcs::Test_Data out;
     out.set_txt("sync:" + name);
     out.set_flg(all_synced);
     output_.store(&out);
   }
 
   void onHandleUpdate(const std::string& name) override {
-    arcs::Test_data out;
-    if (auto input = getSingleton<arcs::Test_data>(name)) {
+    arcs::Test_Data out;
+    if (auto input = getSingleton<arcs::Test_Data>(name)) {
       out.set_txt("update:" + name);
       out.set_num(input->get().num());
     } else {
@@ -27,9 +27,9 @@ public:
     output_.store(&out);
   }
 
-  arcs::Singleton<arcs::Test_data> input1_;
-  arcs::Singleton<arcs::Test_data> input2_;
-  arcs::Collection<arcs::Test_data> output_;
+  arcs::Singleton<arcs::Test_Data> input1_;
+  arcs::Singleton<arcs::Test_Data> input2_;
+  arcs::Collection<arcs::Test_Data> output_;
 };
 
 DEFINE_PARTICLE(HandleSyncUpdateTest)
@@ -50,11 +50,11 @@ public:
   }
 
   void onHandleUpdate(const std::string& name) override {
-    const arcs::Test_renderFlags& flags = flags_.get();
+    const arcs::Test_RenderFlags& flags = flags_.get();
     renderSlot("root", flags._template(), flags.model());
   }
 
-  arcs::Singleton<arcs::Test_renderFlags> flags_;
+  arcs::Singleton<arcs::Test_RenderFlags> flags_;
 };
 
 DEFINE_PARTICLE(RenderTest)
@@ -68,11 +68,11 @@ public:
   }
 
   std::string getTemplate(const std::string& slot_name) override {
-    const arcs::Test_data& data = data_.get();
+    const arcs::Test_Data& data = data_.get();
     return data.has_txt() ? data.txt() : "empty";
   }
 
-  arcs::Singleton<arcs::Test_data> data_;
+  arcs::Singleton<arcs::Test_Data> data_;
 };
 
 DEFINE_PARTICLE(AutoRenderTest)
@@ -85,12 +85,12 @@ public:
   }
 
   void fireEvent(const std::string& slot_name, const std::string& handler) override {
-    arcs::Test_data out;
+    arcs::Test_Data out;
     out.set_txt("event:" + slot_name + ":" + handler);
     output_.set(&out);
   }
 
-  arcs::Singleton<arcs::Test_data> output_;
+  arcs::Singleton<arcs::Test_Data> output_;
 };
 
 DEFINE_PARTICLE(EventsTest)
@@ -104,7 +104,7 @@ public:
 
   void init() override {
     std::string url = resolveUrl("$resolve-me");
-    arcs::Test_serviceResponse out;
+    arcs::Test_ServiceResponse out;
     out.set_call("resolveUrl");
     out.set_payload(url);
     output_.store(&out);
@@ -121,14 +121,14 @@ public:
       payload += pair.first + ":" + pair.second + ";";
     }
 
-    arcs::Test_serviceResponse out;
+    arcs::Test_ServiceResponse out;
     out.set_call(call);
     out.set_tag(tag);
     out.set_payload(payload);
     output_.store(&out);
   }
 
-  arcs::Collection<arcs::Test_serviceResponse> output_;
+  arcs::Collection<arcs::Test_ServiceResponse> output_;
 };
 
 DEFINE_PARTICLE(ServicesTest)
@@ -147,11 +147,11 @@ public:
   }
 
   void fireEvent(const std::string& slot_name, const std::string& handler) override {
-    arcs::Test_data data;
+    arcs::Test_Data data;
     data_.set(&data);
   }
 
-  arcs::Singleton<arcs::Test_data> data_;
+  arcs::Singleton<arcs::Test_Data> data_;
 };
 
 DEFINE_PARTICLE(UnconnectedHandlesTest)

--- a/src/wasm/cpp/tests/reference-class-test.cc
+++ b/src/wasm/cpp/tests/reference-class-test.cc
@@ -6,7 +6,7 @@
 using arcs::internal::Accessor;
 
 static auto converter() {
-  return [](const arcs::Ref<arcs::Test_data>& r) { return arcs::entity_to_str(r); };
+  return [](const arcs::Ref<arcs::Test_Data>& r) { return arcs::entity_to_str(r); };
 }
 
 
@@ -20,7 +20,7 @@ public:
     fn(Accessor::encode_entity(data).c_str());
   }
 
-  arcs::Test_data data;
+  arcs::Test_Data data;
 };
 
 
@@ -37,7 +37,7 @@ public:
   }
 
   void test_accessor_methods() {
-    arcs::Ref<arcs::Test_data> r1;
+    arcs::Ref<arcs::Test_Data> r1;
 
     Accessor::decode_entity(&r1, "5:id789|6:key123|");
     EQUAL(arcs::entity_to_str(r1), "REF<id789|key123>");
@@ -51,13 +51,13 @@ public:
     EQUAL(Accessor::get_id(r1), "id55");
     NOT_EQUAL(arcs::hash_entity(r1), h1);
 
-    arcs::Ref<arcs::Test_data> r2 = arcs::clone_entity(r1);
+    arcs::Ref<arcs::Test_Data> r2 = arcs::clone_entity(r1);
     IS_TRUE(arcs::fields_equal(r1, r2));
     EQUAL(arcs::hash_entity(r1), arcs::hash_entity(r2));
     EQUAL(arcs::entity_to_str(r1), arcs::entity_to_str(r2));
 
     // References are copyable.
-    arcs::Ref<arcs::Test_data> r3 = r1;
+    arcs::Ref<arcs::Test_Data> r3 = r1;
     IS_TRUE(arcs::fields_equal(r1, r3));
 
     // Different ids, same storage keys.
@@ -74,15 +74,15 @@ public:
   }
 
   void test_empty_references() {
-    arcs::Ref<arcs::Test_data> r1;
+    arcs::Ref<arcs::Test_Data> r1;
 
-    EQUAL(r1.entity(), arcs::Test_data());
+    EQUAL(r1.entity(), arcs::Test_Data());
     IS_FALSE(r1.is_dereferenced());
     EQUAL(arcs::entity_to_str(r1), "REF<>");
     EQUAL(Accessor::encode_entity(r1), "0:|0:|");
     EQUAL(Accessor::get_id(r1), "");
 
-    arcs::Ref<arcs::Test_data> r2 = arcs::clone_entity(r1);
+    arcs::Ref<arcs::Test_Data> r2 = arcs::clone_entity(r1);
     IS_TRUE(arcs::fields_equal(r1, r2));
     EQUAL(arcs::hash_entity(r1), arcs::hash_entity(r2));
     EQUAL(arcs::entity_to_str(r1), arcs::entity_to_str(r2));
@@ -93,13 +93,13 @@ public:
     handle.data.set_txt("ltuae");
     handle.data.set_num(42);
 
-    arcs::Ref<arcs::Test_data> r1(&handle);
+    arcs::Ref<arcs::Test_Data> r1(&handle);
     Accessor::decode_entity(&r1, "5:id789|6:key123|");
     EQUAL(arcs::entity_to_str(r1), "REF<id789|key123>");
     EQUAL(arcs::entity_to_str(r1.entity()), "{}");
 
     // Make a copy prior to dereferencing.
-    arcs::Ref<arcs::Test_data> r2 = r1;
+    arcs::Ref<arcs::Test_Data> r2 = r1;
     IS_FALSE(r1.is_dereferenced());
     IS_FALSE(r2.is_dereferenced());
 
@@ -127,7 +127,7 @@ public:
     EQUAL(arcs::entity_to_str(r1.entity()), arcs::entity_to_str(r2.entity()));
 
     // TODO: use the mutation API
-    arcs::Test_data* d1 = const_cast<arcs::Test_data*>(&r1.entity());
+    arcs::Test_Data* d1 = const_cast<arcs::Test_Data*>(&r1.entity());
     d1->set_lnk("zelda");
     EQUAL(r2.entity().lnk(), "zelda");
     EQUAL(arcs::entity_to_str(r1.entity()), arcs::entity_to_str(r2.entity()));
@@ -135,8 +135,8 @@ public:
 
   void test_operators() {
     TestHandle handle;
-    arcs::Ref<arcs::Test_data> r1(&handle);
-    arcs::Ref<arcs::Test_data> r2(&handle);
+    arcs::Ref<arcs::Test_Data> r1(&handle);
+    arcs::Ref<arcs::Test_Data> r2(&handle);
 
     Accessor::decode_entity(&r1, "3:idA|4:keyA|");
     Accessor::decode_entity(&r2, "3:idB|4:keyA|");
@@ -167,22 +167,22 @@ public:
     handle.data.set_num(99);
 
     // empty
-    arcs::Ref<arcs::Test_data> r1;
+    arcs::Ref<arcs::Test_Data> r1;
 
     // populated and dereferenced
-    arcs::Ref<arcs::Test_data> r2(&handle);
+    arcs::Ref<arcs::Test_Data> r2(&handle);
     Accessor::decode_entity(&r2, "3:idA|4:keyA|");
     r2.dereference([] {});
 
     // populated but not dereferenced
-    arcs::Ref<arcs::Test_data> r3;
+    arcs::Ref<arcs::Test_Data> r3;
     Accessor::decode_entity(&r3, "3:idB|4:keyB|");
 
     // same reference as r2, but not a copy
-    arcs::Ref<arcs::Test_data> r4;
+    arcs::Ref<arcs::Test_Data> r4;
     Accessor::decode_entity(&r4, "3:idA|4:keyA|");
 
-    std::vector<arcs::Ref<arcs::Test_data>> v = {r1, r2, r3, r4};
+    std::vector<arcs::Ref<arcs::Test_Data>> v = {r1, r2, r3, r4};
     std::vector<std::string> expected = {
       "REF<>",
       "REF<idA|keyA|{idA}, num: 99>",
@@ -197,22 +197,22 @@ public:
     handle.data.set_txt("zz");
 
     // empty
-    arcs::Ref<arcs::Test_data> r1;
+    arcs::Ref<arcs::Test_Data> r1;
 
     // dereferenced
-    arcs::Ref<arcs::Test_data> r2(&handle);
+    arcs::Ref<arcs::Test_Data> r2(&handle);
     Accessor::decode_entity(&r2, "3:idA|4:keyA|");
     r2.dereference([] {});
 
     // populated but not dereferenced
-    arcs::Ref<arcs::Test_data> r3;
+    arcs::Ref<arcs::Test_Data> r3;
     Accessor::decode_entity(&r3, "3:idB|4:keyB|");
 
     // same reference as r2, but not a copy
-    arcs::Ref<arcs::Test_data> r4;
+    arcs::Ref<arcs::Test_Data> r4;
     Accessor::decode_entity(&r4, "3:idA|4:keyA|");
 
-    std::set<arcs::Ref<arcs::Test_data>> s = {r1, r2, r3, r4};
+    std::set<arcs::Ref<arcs::Test_Data>> s = {r1, r2, r3, r4};
     std::vector<std::string> expected = {
       "REF<>",
       "REF<idA|keyA|{idA}, txt: zz>",
@@ -226,22 +226,22 @@ public:
     handle.data.set_lnk("knl");
 
     // empty
-    arcs::Ref<arcs::Test_data> r1;
+    arcs::Ref<arcs::Test_Data> r1;
 
     // dereferenced
-    arcs::Ref<arcs::Test_data> r2(&handle);
+    arcs::Ref<arcs::Test_Data> r2(&handle);
     Accessor::decode_entity(&r2, "3:idA|4:keyA|");
     r2.dereference([] {});
 
     // populated but not dereferenced
-    arcs::Ref<arcs::Test_data> r3;
+    arcs::Ref<arcs::Test_Data> r3;
     Accessor::decode_entity(&r3, "3:idB|4:keyB|");
 
     // same reference as r2, but not a copy
-    arcs::Ref<arcs::Test_data> r4;
+    arcs::Ref<arcs::Test_Data> r4;
     Accessor::decode_entity(&r4, "3:idA|4:keyA|");
 
-    std::unordered_set<arcs::Ref<arcs::Test_data>> s = {r1, r2, r3, r4};
+    std::unordered_set<arcs::Ref<arcs::Test_Data>> s = {r1, r2, r3, r4};
     std::vector<std::string> expected = {
       "REF<>",
       "REF<idA|keyA|{idA}, lnk: knl>",

--- a/src/wasm/cpp/tests/schemas.arcs
+++ b/src/wasm/cpp/tests/schemas.arcs
@@ -1,11 +1,9 @@
-schema Foo
-
 schema Data
   Number num
   Text txt
   URL lnk
   Boolean flg
-  Reference<Foo> ref
+  Reference<Foo {}> ref
 
 schema Empty
 
@@ -23,7 +21,6 @@ schema SpecialFields
   Number internal_id
 
 particle Test
-  in Foo foo
   in Data data
   in Empty empty
   in RenderFlags renderFlags

--- a/src/wasm/cpp/tests/storage-api-test.cc
+++ b/src/wasm/cpp/tests/storage-api-test.cc
@@ -14,19 +14,19 @@ public:
       out_.clear();
       io_.clear();
     } else if (handler == "case2") {
-      arcs::Test_data d = arcs::clone_entity(in_.get());
+      arcs::Test_Data d = arcs::clone_entity(in_.get());
       d.set_num(d.num() * 2);
       out_.set(&d);
     } else if (handler == "case3") {
-      arcs::Test_data d = arcs::clone_entity(io_.get());
+      arcs::Test_Data d = arcs::clone_entity(io_.get());
       d.set_num(d.num() * 3);
       io_.set(&d);
     }
   }
 
-  arcs::Singleton<arcs::Test_data> in_;
-  arcs::Singleton<arcs::Test_data> out_;
-  arcs::Singleton<arcs::Test_data> io_;
+  arcs::Singleton<arcs::Test_Data> in_;
+  arcs::Singleton<arcs::Test_Data> out_;
+  arcs::Singleton<arcs::Test_Data> io_;
 };
 
 DEFINE_PARTICLE(SingletonApiTest)
@@ -52,7 +52,7 @@ public:
       // We can't read from out_ so use a previously stored entity to test remove().
       out_.remove(stored_);
     } else if (handler == "case4") {
-      arcs::Test_data d1, d2, d3;
+      arcs::Test_Data d1, d2, d3;
 
       // Test begin()/end() and WrappedIter operators
       auto i1 = in_.begin();
@@ -70,7 +70,7 @@ public:
       d3.set_flg(++i2 == in_.end());         // prefix op++
       out_.store(&d3);
     } else if (handler == "case5") {
-      arcs::Test_data extra, d1, d2, d3;
+      arcs::Test_Data extra, d1, d2, d3;
 
       // Store and remove an entity.
       extra.set_txt("abc");
@@ -85,11 +85,11 @@ public:
 
       // Ranged iteration; order is not guaranteed so use 'num' to assign sorted array slots.
       std::string res[3];
-      for (const arcs::Test_data& data : io_) {
+      for (const arcs::Test_Data& data : io_) {
         res[static_cast<int>(data.num())] = arcs::entity_to_str(data);
       }
       for (size_t i = 0; i < io_.size(); i++) {
-        arcs::Test_data d;
+        arcs::Test_Data d;
         d.set_txt(res[i]);
         out_.store(&d);
       }
@@ -101,10 +101,10 @@ public:
     }
   }
 
-  arcs::Collection<arcs::Test_data> in_;
-  arcs::Collection<arcs::Test_data> out_;
-  arcs::Collection<arcs::Test_data> io_;
-  arcs::Test_data stored_;
+  arcs::Collection<arcs::Test_Data> in_;
+  arcs::Collection<arcs::Test_Data> out_;
+  arcs::Collection<arcs::Test_Data> io_;
+  arcs::Test_Data stored_;
 };
 
 DEFINE_PARTICLE(CollectionApiTest)
@@ -137,16 +137,16 @@ public:
     }
   }
 
-  void report(const std::string& label, const arcs::Ref<arcs::Test_data>& ref) {
-    arcs::Test_data d;
+  void report(const std::string& label, const arcs::Ref<arcs::Test_Data>& ref) {
+    arcs::Test_Data d;
     const std::string& id = arcs::internal::Accessor::get_id(ref);
     d.set_txt(label + " <" + id + "> " + arcs::entity_to_str(ref.entity()));
     res_.store(&d);
   }
 
-  arcs::Singleton<arcs::Ref<arcs::Test_data>> sng_;
-  arcs::Collection<arcs::Ref<arcs::Test_data>> col_;
-  arcs::Collection<arcs::Test_data> res_;
+  arcs::Singleton<arcs::Ref<arcs::Test_Data>> sng_;
+  arcs::Collection<arcs::Ref<arcs::Test_Data>> col_;
+  arcs::Collection<arcs::Test_Data> res_;
 };
 
 DEFINE_PARTICLE(InputReferenceHandlesTest)
@@ -160,18 +160,18 @@ public:
   }
 
   void init() override {
-    arcs::Ref<arcs::Test_data> r1;
+    arcs::Ref<arcs::Test_Data> r1;
     arcs::internal::Accessor::decode_entity(&r1, "3:idX|4:keyX|");
     sng_.set(&r1);
 
-    arcs::Ref<arcs::Test_data> r2;
+    arcs::Ref<arcs::Test_Data> r2;
     arcs::internal::Accessor::decode_entity(&r2, "3:idY|4:keyY|");
     col_.store(&r1);
     col_.store(&r2);
   }
 
-  arcs::Singleton<arcs::Ref<arcs::Test_data>> sng_;
-  arcs::Collection<arcs::Ref<arcs::Test_data>> col_;
+  arcs::Singleton<arcs::Ref<arcs::Test_Data>> sng_;
+  arcs::Collection<arcs::Ref<arcs::Test_Data>> col_;
 };
 
 DEFINE_PARTICLE(OutputReferenceHandlesTest)

--- a/src/wasm/cpp/tests/test-base.h
+++ b/src/wasm/cpp/tests/test-base.h
@@ -13,7 +13,7 @@ public:
 
   bool check(bool ok, const std::string& condition, std::string file, int line) {
     if (!ok) {
-      arcs::Test_data err;
+      arcs::Test_Data err;
       if (auto pos = file.find_last_of("\\/"); pos != std::string::npos) {
         file = file.substr(pos + 1);
       }
@@ -72,7 +72,7 @@ public:
   }
 
   std::string test_name_;
-  arcs::Collection<arcs::Test_data> errors_;
+  arcs::Collection<arcs::Test_Data> errors_;
   char marker_;
 };
 


### PR DESCRIPTION
This builds a type lattice and then uses that to arrange entity class inheritance hierarchies in C++, such that type slicing between compatible entities will just work. The equivalent interface structure in Kotlin still needs to be done. I also want to add a bunch more tests for the actual generated code (in another CL).

This also restructures how the Schema2Base/Cpp/Kotlin classes interact in preparation for future changes to reference handling.

Sorry for the large PR. The actual logic changes are confined to the files under src/tools; everything else is just name changes like `Particle_data` -> `Particle_Data`; you can just skim those.