### PR TITLE
Destroy Webview instead of loading an empty page to release resource

### DIFF
--- a/javaharness/java/arcs/android/AndroidArcsEnvironment.java
+++ b/javaharness/java/arcs/android/AndroidArcsEnvironment.java
@@ -128,8 +128,7 @@ final class AndroidArcsEnvironment {
 
   void destroy() {
     if (webView != null) {
-      // Clean up content/context thus the host devServer can be aware of the disconnection.
-      webView.loadUrl("about:blank");
+      webView.destroy();
     }
   }
 


### PR DESCRIPTION
correctly.