### PR TITLE
better type-structure for ui-particle

### DIFF
--- a/src/runtime/ui-particle.ts
+++ b/src/runtime/ui-particle.ts
@@ -11,24 +11,37 @@
 import {XenStateMixin} from '../../modalities/dom/components/xen/xen-state.js';
 import {UiParticleBase} from './ui-particle-base.js';
 import {Handle} from './handle.js';
-import {Runnable} from './hot.js';
+import {Runnable, Dictionary} from './hot.js';
+
+// tslint:disable-next-line: no-any
+type AnyModel = Dictionary<any>;
 
 export interface UiStatefulParticle extends UiParticleBase {
   // add type info for XenState members here
   _invalidate(): void;
+  _setState(state: AnyModel): boolean | undefined;
+  _setProps(props: AnyModel): boolean | undefined;
+  _setProperty(name: string, model: AnyModel);
+  _debounce(key, idleThenFunc, delay);
+  _state: AnyModel;
+  _props: AnyModel;
 }
 
+// create actual class via mixin
+// tslint:disable-next-line: variable-name
+const UiStatefulParticle: typeof UiParticleBase = XenStateMixin(UiParticleBase);
+
 // binds implementation below to interface above
-export interface UiParticle extends UiStatefulParticle {
-}
+// TODO(sjmiles): how and why does this work?
+export interface UiParticle extends UiStatefulParticle {}
 
 /**
  * Particle that interoperates with DOM and uses a simple state system
  * to handle updates.
  */
-// TODO(sjmiles): seems like this is really `UiStatefulParticle` but it's
-// used so often, I went with the simpler name
-export class UiParticle extends XenStateMixin(UiParticleBase) {
+// TODO(sjmiles): this is really `UiStatefulParticle` but it's
+// used so often, we went with the simpler name
+export class UiParticle extends UiStatefulParticle { //XenStateMixin(UiParticleBase) {
   /**
    * Override if necessary, to do things when props change.
    * Avoid if possible, use `update` instead.
@@ -161,6 +174,6 @@ export class UiParticle extends XenStateMixin(UiParticleBase) {
       state[subkey] = null;
     };
     // TODO(sjmiles): rewrite Xen debounce so caller has idle control
-    super._debounce(key, idleThenFunc, delay);
+    this._debounce(key, idleThenFunc, delay);
   }
 }


### PR DESCRIPTION
Previously, TypeScript didn't consider UiParticle a derivative of Particle, which was a problem downstream and also looked weird in the typedocs.

This is fixed, in addition to some more type-coverage.

Note: there is still some black-magic I don't understand with respect to annotating the mixin as indicated in comments.