### PR TITLE
Adds a 'wasm' tag to kt_native_binary target

### DIFF
--- a/third_party/java/arcs/build_defs/internal/kotlin.bzl
+++ b/third_party/java/arcs/build_defs/internal/kotlin.bzl
@@ -24,6 +24,7 @@ def arcs_kt_binary(name, srcs = [], deps = []):
         srcs = srcs,
         entry_point = "arcs.main",
         deps = _ARCS_KOTLIN_LIBS + deps,
+        tags = ["wasm"],
     )
 
 def kt_jvm_and_js_library(


### PR DESCRIPTION
This is in order to be able to filter out wasm targets, as they require different bazel config.