### PR TITLE
schema2kotlin: Generation of Empty entities + added imports

### DIFF
--- a/src/tools/schema2kotlin.ts
+++ b/src/tools/schema2kotlin.ts
@@ -80,8 +80,8 @@ class KotlinGenerator implements ClassGenerator {
     this.fields.push(`var ${fixed}: ${type} = ${defaultVal}`);
 
     this.decode.push(`"${field}" -> {`,
-                     `    decoder.validate("${typeChar}")`,
-                     `    this.${fixed} = decoder.${decodeFn}`,
+                     `  decoder.validate("${typeChar}")`,
+                     `  this.${fixed} = decoder.${decodeFn}`,
                      `}`);
 
     this.encode.push(`encoder.encode("${field}:${typeChar}", ${fixed})`);
@@ -100,37 +100,37 @@ class KotlinGenerator implements ClassGenerator {
 
     return `\
 
-${withFields('data ')}class ${name}(${ withFields(`\n    ${this.fields.join(',\n    ')}\n`) }) : Entity<${name}>() {
+${withFields('data ')}class ${name}(${ withFields(`\n  ${this.fields.join(',\n  ')}\n`) }) : Entity<${name}>() {
 
-    override fun decodeEntity(encoded: String): ${name}? {
-        if (encoded.isEmpty()) {
-            return null
-        }
-        val decoder = StringDecoder(encoded)
-        this.internalId = decoder.decodeText()
-        decoder.validate("|")
-        ${withFields(`var i = 0
-        while (!decoder.done() && i < ${fieldCount}) {
-            val name = decoder.upTo(":")
-            when (name) {
-                ${this.decode.join('\n                ')}
-            }
-            decoder.validate("|")
-            i++
-        }`)}
-        return this
+  override fun decodeEntity(encoded: String): ${name}? {
+    if (encoded.isEmpty()) {
+      return null
     }
-
-    override fun encodeEntity(): String {
-        val encoder = StringEncoder()
-        encoder.encode("", internalId)
-        ${this.encode.join('\n        ')}
-        return encoder.result()
-    }
-    ${withoutFields(`
-    override fun toString(): String {
-        return "${name}()"
+    val decoder = StringDecoder(encoded)
+    this.internalId = decoder.decodeText()
+    decoder.validate("|")
+    ${withFields(`var i = 0
+    while (!decoder.done() && i < ${fieldCount}) {
+      val name = decoder.upTo(":")
+      when (name) {
+        ${this.decode.join('\n        ')}
+      }
+      decoder.validate("|")
+      i++
     }`)}
+    return this
+  }
+
+  override fun encodeEntity(): String {
+    val encoder = StringEncoder()
+    encoder.encode("", internalId)
+    ${this.encode.join('\n    ')}
+    return encoder.result()
+  }
+  ${withoutFields(`
+  override fun toString(): String {
+    return "${name}()"
+  }`)}
 }
 ${typeDecls}
 `;

--- a/src/tools/schema2kotlin.ts
+++ b/src/tools/schema2kotlin.ts
@@ -50,9 +50,9 @@ package ${this.scope}
 // Current implementation doesn't support references or optional field detection
 
 ${withCustomPackage(`import arcs.Particle;
-import arcs.Entity; 
-import arcs.StringDecoder;
-import arcs.StringEncoder; 
+import arcs.Entity
+import arcs.StringEncoder
+import arcs.StringDecoder
 `)}`;
   }
 

--- a/src/tools/schema2kotlin.ts
+++ b/src/tools/schema2kotlin.ts
@@ -83,8 +83,8 @@ class KotlinGenerator implements ClassGenerator {
     this.fields.push(`var ${fixed}: ${type} = ${defaultVal}`);
 
     this.decode.push(`"${field}" -> {`,
-                     `  decoder.validate("${typeChar}")`,
-                     `  this.${fixed} = decoder.${decodeFn}`,
+                     `    decoder.validate("${typeChar}")`,
+                     `    this.${fixed} = decoder.${decodeFn}`,
                      `}`);
 
     this.encode.push(`encoder.encode("${field}:${typeChar}", ${fixed})`);
@@ -103,37 +103,37 @@ class KotlinGenerator implements ClassGenerator {
 
     return `\
 
-${withFields('data ')}class ${name}(${ withFields(`\n  ${this.fields.join(',\n  ')}\n`) }) : Entity<${name}>() {
+${withFields('data ')}class ${name}(${ withFields(`\n    ${this.fields.join(',\n    ')}\n`) }) : Entity<${name}>() {
 
-  override fun decodeEntity(encoded: String): ${name}? {
-    if (encoded.isEmpty()) {
-      return null
+    override fun decodeEntity(encoded: String): ${name}? {
+        if (encoded.isEmpty()) {
+            return null
+        }
+        val decoder = StringDecoder(encoded)
+        this.internalId = decoder.decodeText()
+        decoder.validate("|")
+        ${withFields(`var i = 0
+        while (!decoder.done() && i < ${fieldCount}) {
+            val name = decoder.upTo(":")
+            when (name) {
+                ${this.decode.join('\n                ')}
+            }
+            decoder.validate("|")
+            i++
+        }`)}
+        return this
     }
-    val decoder = StringDecoder(encoded)
-    this.internalId = decoder.decodeText()
-    decoder.validate("|")
-    ${withFields(`var i = 0
-    while (!decoder.done() && i < ${fieldCount}) {
-      val name = decoder.upTo(":")
-      when (name) {
-        ${this.decode.join('\n        ')}
-      }
-      decoder.validate("|")
-      i++
-    }`)}
-    return this
-  }
 
-  override fun encodeEntity(): String {
-    val encoder = StringEncoder()
-    encoder.encode("", internalId)
-    ${this.encode.join('\n    ')}
-    return encoder.result()
-  }
-  ${withoutFields(`
-  override fun toString(): String {
-    return "${name}()"
-  }`)}
+    override fun encodeEntity(): String {
+        val encoder = StringEncoder()
+        encoder.encode("", internalId)
+        ${this.encode.join('\n        ')}
+        return encoder.result()
+    }
+    ${withoutFields(`
+    override fun toString(): String {
+        return "${name}()"
+    }`)}
 }
 ${typeDecls}
 `;

--- a/src/tools/schema2kotlin.ts
+++ b/src/tools/schema2kotlin.ts
@@ -50,9 +50,6 @@ package ${this.scope}
 // Current implementation doesn't support references or optional field detection
 
 ${withCustomPackage(`import arcs.Particle;
-import arcs.Handle;
-import arcs.Singleton;
-import arcs.Collection;
 import arcs.Entity; 
 import arcs.StringDecoder;
 import arcs.StringEncoder; 

--- a/src/tools/schema2kotlin.ts
+++ b/src/tools/schema2kotlin.ts
@@ -103,21 +103,19 @@ class KotlinGenerator implements ClassGenerator {
 ${withFields('data ')}class ${name}(${ withFields(`\n  ${this.fields.join(',\n  ')}\n`) }) : Entity<${name}>() {
 
   override fun decodeEntity(encoded: String): ${name}? {
-    if (encoded.isEmpty()) {
-      return null
-    }
+    if (encoded.isEmpty()) return null
+    
     val decoder = StringDecoder(encoded)
-    this.internalId = decoder.decodeText()
+    internalId = decoder.decodeText()
     decoder.validate("|")
-    ${withFields(`var i = 0
-    while (!decoder.done() && i < ${fieldCount}) {
+    ${withFields(`0.until(${fieldCount}).takeWhile { !decoder.done() }
+     .forEach {
       val name = decoder.upTo(":")
       when (name) {
         ${this.decode.join('\n        ')}
       }
       decoder.validate("|")
-      i++
-    }`)}
+     }`)}
     return this
   }
 


### PR DESCRIPTION
- Fixed compilation error: Data classes must have fields (solution: generating standard classes)
- Prevented future issues: If we aren't in the `arcs` package, import required classes. 