### PR TITLE
pipes-shell: implement `parse` verb

### DIFF
--- a/shells/lib/utils.js
+++ b/shells/lib/utils.js
@@ -46,7 +46,21 @@ const parse = async (content, options) => {
     fileName: `./${id}`,
     loader: env.loader
   };
-  if (options) {
+  return _parse(content, localOptions, options);
+};
+
+const parseFile = async (path, options) => {
+  const localOptions = {
+    id: path,
+    fileName: path,
+    loader: env.loader
+  };
+  const content = await env.loader.loadResource(path);
+  return _parse(content, localOptions, options);
+};
+
+const _parse = async (content, localOptions, options) => {
+  if (localOptions && options) {
     Object.assign(localOptions, options);
   }
   return Manifest.parse(content, localOptions);
@@ -109,6 +123,7 @@ export const Utils = {
   init,
   env,
   parse,
+  parseFile,
   resolve,
   spawn
 };

--- a/shells/pipes-shell/source/pipe.js
+++ b/shells/pipes-shell/source/pipe.js
@@ -22,6 +22,7 @@ import {runArc, stopArc, uiEvent} from './verbs/run-arc.js';
 import {event} from './verbs/event.js';
 import {spawn} from './verbs/spawn.js';
 import {ingest} from './verbs/ingest.js';
+import {parse} from './verbs/parse.js';
 
 const {log} = logsFactory('pipe');
 
@@ -97,6 +98,9 @@ const populateDispatcher = (dispatcher, storage, context, env) => {
     },
     event: async (msg, tid, bus) => {
       return await event(msg, tid, bus);
+    },
+    parse: async (msg, tid, bus) => {
+      return await parse(msg, tid, bus);
     }
   });
   return dispatcher;

--- a/shells/pipes-shell/source/smoke.js
+++ b/shells/pipes-shell/source/smoke.js
@@ -36,9 +36,17 @@ export const smokeTest = async bus => {
     send({message: 'spawn', modality: 'dom', recipe: 'Notification'});
   };
   //
+  const parseTest = () => {
+    // parse manifest content
+    send({message: 'parse', content: `import 'https://$particles/canonical.arcs'`});
+    // parse manifest file
+    send({message: 'parse', path: `https://$particles/canonical.arcs`});
+  };
+  //
   enqueue([
     ingestionTest,
     autofillTest,
-    notificationTest
+    notificationTest,
+    parseTest
   ], 500);
 };

--- a/shells/pipes-shell/source/verbs/parse.js
+++ b/shells/pipes-shell/source/verbs/parse.js
@@ -1,0 +1,34 @@
+/**
+ * @license
+ * Copyright 2019 Google LLC.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {Utils} from '../../../lib/utils.js';
+import {logsFactory} from '../../../../build/runtime/log-factory.js';
+
+const {log} = logsFactory('pipe::parse');
+
+// can provide either a path or literal content for a manifest
+export const parse = async ({path, content}, tid, bus) => {
+  // TODO(sjmiles): catch exceptions and relay over bus?
+  let manifest;
+  if (path) {
+    log(`loading [${path}]`);
+    manifest = await Utils.parseFile(path);;
+  }
+  if (content) {
+    log(`parsing [${content.length}] bytes`);
+    manifest = await Utils.parse(content);
+  }
+  let recipes = [];
+  if (manifest) {
+    recipes = manifest.allRecipes.map(r => ({name: r.name, triggers: r.triggers}));
+  }
+  log(`sending [${JSON.stringify(recipes)}]`);
+  bus.send({tid, messageType: 'manifest', recipes});
+};

--- a/shells/pipes-shell/source/verbs/parse.js
+++ b/shells/pipes-shell/source/verbs/parse.js
@@ -19,7 +19,7 @@ export const parse = async ({path, content}, tid, bus) => {
   let manifest;
   if (path) {
     log(`loading [${path}]`);
-    manifest = await Utils.parseFile(path);;
+    manifest = await Utils.parseFile(path);
   }
   if (content) {
     log(`parsing [${content.length}] bytes`);

--- a/shells/pipes-shell/source/verbs/parse.js
+++ b/shells/pipes-shell/source/verbs/parse.js
@@ -20,8 +20,7 @@ export const parse = async ({path, content}, tid, bus) => {
   if (path) {
     log(`loading [${path}]`);
     manifest = await Utils.parseFile(path);
-  }
-  if (content) {
+  } else if (content) {
     log(`parsing [${content.length}] bytes`);
     manifest = await Utils.parse(content);
   }


### PR DESCRIPTION
Adds `parse` verb to pipes-shell. This verb parses a manifest provided either in literal text or as a url/path. Current it returns only the list of recipe names and triggers found in the manifest, but we can modify the code to send any needed manifest data.
```
// literal manifest content 
const tid = `send({message: 'parse', content: `import 'https://$particles/canonical.arcs'`});`
```
or 
```
// path to manifest content
const tid = send({message: 'parse', path: `https://$particles/canonical.arcs`});
```
Either one produces a result message like:
```
{"tid":4,"messageType":"manifest","recipes":[{"name":"VisualizerRecipe","triggers":[]},
{"name":"TicTacToeShowBoard","triggers":[]}, ... }
```