### PR TITLE
Introduces Arcs Cache Manager (service worker)

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -96,6 +96,7 @@ KOTLINX_COROUTINES_VERSION = "1.3.2"
 
 maven_install(
     artifacts = [
+        "androidx.webkit:webkit:1.1.0-rc01",
         "com.google.flogger:flogger:0.4",
         "com.google.flogger:flogger-system-backend:0.4",
         "com.google.dagger:dagger:2.23.1",

--- a/javaharness/README.md
+++ b/javaharness/README.md
@@ -87,6 +87,23 @@ Particles and recipes are by default loaded from the APK, but you can configure 
   adb shell setprop debug.arcs.runtime.load_workstation_assets true
 ```
 
+## The Arcs Cache Manager
+The Arcs Service Manager compiles javascript and webassembly sources eagerly and caches the compiled binaries at local storage to serve subsequent requests. Page loading time and compilation overhead are optimized when enabled.
+
+Enabling the Arcs Cache Manager:
+1. Terminate the existing demo application.
+1. Activate the Arcs Cache Manager then launch demo application to reflect new settings.
+ ```bash
+  adb shell "setprop debug.arcs.runtime.use_cache_mgr true"
+  adb shell "setprop debug.arcs.runtime.shell_url 'https://appassets.androidplatform.net/assets/arcs/index.html?'"
+  ```
+Disabling the Arcs Cache Manager:
+1. Terminate the existing demo application.
+1. Deactivate the Arcs Cache Manager then launch demo application to reflect new settings.
+* ```bash
+  adb shell "setprop debug.arcs.runtime.use_cache_mgr false"
+  adb shell "setprop debug.arcs.runtime.shell_url ''"
+  ```
 
 ## Properties
 Android properties are used to change and tweak Arcs settings at run-time.
@@ -98,3 +115,4 @@ Android properties are used to change and tweak Arcs settings at run-time.
 | debug.arcs.runtime.dev_server_port | The port to use for communication with ALDS | 8786 |
 | debug.arcs.runtime.shell_url | Specify which shell to use | file:///android_asset/index.html? (on-device pipes-shell) |
 | debug.arcs.runtime.load_workstation_assets | Whether to load recipes and particles from the workstation | false (assets from the APK) |
+| debug.arcs.runtime.use_cache_mgr | Whether to use the Arcs Cache Manager | false

--- a/javaharness/README.md
+++ b/javaharness/README.md
@@ -88,7 +88,7 @@ Particles and recipes are by default loaded from the APK, but you can configure 
 ```
 
 ## The Arcs Cache Manager
-The Arcs Service Manager compiles javascript and webassembly sources eagerly and caches the compiled binaries at local storage to serve subsequent requests. Page loading time and compilation overhead are optimized when enabled.
+The Arcs Cache Manager compiles javascript and webassembly sources eagerly and caches the compiled binaries at local storage to serve subsequent requests. Page loading time and compilation overhead are optimized when enabled.
 
 Enabling the Arcs Cache Manager:
 1. Terminate the existing demo application.

--- a/javaharness/java/arcs/android/AndroidArcsEnvironment.java
+++ b/javaharness/java/arcs/android/AndroidArcsEnvironment.java
@@ -1,8 +1,11 @@
 package arcs.android;
 
 import android.content.Context;
+import android.graphics.Bitmap;
 import android.os.Handler;
 import android.os.Looper;
+import android.os.Trace;
+import android.text.TextUtils;
 import android.util.Log;
 import android.view.View;
 import android.webkit.JavascriptInterface;
@@ -125,6 +128,16 @@ final class AndroidArcsEnvironment {
       public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
         // For the renderer main thread to intercept the urls.
         return assetLoader.shouldInterceptRequest(request.getUrl());
+      }
+
+      @Override
+      public void onPageStarted(WebView view, String url, Bitmap favicon) {
+        Trace.beginAsyncSection("AndroidArcsEnvironment::init::loadUrl", 0);
+      }
+
+      @Override
+      public void onPageFinished(WebView view, String url) {
+        Trace.endAsyncSection("AndroidArcsEnvironment::init::loadUrl", 0);
       }
     });
 

--- a/javaharness/java/arcs/android/AndroidArcsEnvironment.java
+++ b/javaharness/java/arcs/android/AndroidArcsEnvironment.java
@@ -51,7 +51,8 @@ final class AndroidArcsEnvironment {
     Logger.getLogger(AndroidArcsEnvironment.class.getName());
 
   private static final String ASSETS_PREFIX = "https://$assets/";
-  private static final String APK_ASSETS_URL_PREFIX = "file:////android_asset/arcs/";
+  // Uses relative path to support multiple protocols i.e. file, https and etc.
+  private static final String APK_ASSETS_URL_PREFIX = "./";
   private static final String ROOT_MANIFEST_FILENAME = "Root.arcs";
 
   private static final String FIELD_MESSAGE = "message";

--- a/javaharness/java/arcs/android/AndroidArcsEnvironment.java
+++ b/javaharness/java/arcs/android/AndroidArcsEnvironment.java
@@ -110,11 +110,6 @@ final class AndroidArcsEnvironment {
     // needed to allow WebWorkers to work in FileURLs.
     arcsSettings.setAllowUniversalAccessFromFileURLs(true);
 
-    dynamicManifest = manifests
-        .stream()
-        .map(s -> String.format("import \'%s%s\'", ASSETS_PREFIX, s))
-        .collect(Collectors.joining("\n"));
-
     // As trampolines to map https protocol to file protocol.
     // E.g. https://appassets.androidplatform.net/assets/foo is mapped to
     // file:///android_asset/foo

--- a/javaharness/java/arcs/android/AndroidArcsEnvironment.java
+++ b/javaharness/java/arcs/android/AndroidArcsEnvironment.java
@@ -136,8 +136,8 @@ final class AndroidArcsEnvironment {
       }
     });
 
-    ServiceWorkerController swController = ServiceWorkerController.getInstance();
-    swController.setServiceWorkerClient(new ServiceWorkerClient() {
+    ServiceWorkerController.getInstance()
+        .setServiceWorkerClient(new ServiceWorkerClient() {
       @Override
       public WebResourceResponse shouldInterceptRequest(WebResourceRequest request) {
         // For the service worker thread to intercept the urls.

--- a/javaharness/java/arcs/android/AndroidArcsEnvironment.java
+++ b/javaharness/java/arcs/android/AndroidArcsEnvironment.java
@@ -150,8 +150,9 @@ final class AndroidArcsEnvironment {
     if (settings.enableArcsExplorer()) {
       url += "&explore-proxy=" + settings.devServerPort();
     }
-
-    // TODO: add a runtime setting for ?use-cache
+    if (settings.useCacheManager()) {
+      url += "&use-cache";
+    }
 
     Log.i("Arcs", "runtime url: " + url);
     webView.loadUrl(url);

--- a/javaharness/java/arcs/android/AndroidArcsEnvironment.java
+++ b/javaharness/java/arcs/android/AndroidArcsEnvironment.java
@@ -5,7 +5,6 @@ import android.graphics.Bitmap;
 import android.os.Handler;
 import android.os.Looper;
 import android.os.Trace;
-import android.text.TextUtils;
 import android.util.Log;
 import android.view.View;
 import android.webkit.JavascriptInterface;

--- a/javaharness/java/arcs/android/AndroidRuntimeSettings.java
+++ b/javaharness/java/arcs/android/AndroidRuntimeSettings.java
@@ -112,6 +112,7 @@ public final class AndroidRuntimeSettings implements RuntimeSettings {
   @Override
   public int devServerPort() {
     return settings.devServerPort();
+  }
 
   @Override
   public boolean useCacheManager() {

--- a/javaharness/java/arcs/android/AndroidRuntimeSettings.java
+++ b/javaharness/java/arcs/android/AndroidRuntimeSettings.java
@@ -22,6 +22,8 @@ public final class AndroidRuntimeSettings implements RuntimeSettings {
       "debug.arcs.runtime.load_workstation_assets";
   // Port to be used for the communication with the dev server.
   private static final String DEV_SERVER_PORT_PROPERTY = "debug.arcs.runtime.dev_server_port";
+  // Equivalent to &use-cache parameter
+  private static final String USE_CACHE_MANAGER_PROPERTY = "debug.arcs.runtime.use_cache_mgr";
 
   // Default settings:
   // Logs the most information
@@ -34,6 +36,8 @@ public final class AndroidRuntimeSettings implements RuntimeSettings {
   private static final boolean DEFAULT_ASSETS_FROM_WORKSTATION = false;
   // Uses the standard 8786 port
   private static final int DEFAULT_DEV_SERVER_PORT = 8786;
+  private static final boolean DEFAULT_USE_DEV_SERVER = false;
+  private static final boolean DEFAULT_USE_CACHE_MANAGER = false;
 
   private static final Logger logger = Logger.getLogger(
       AndroidRuntimeSettings.class.getName());
@@ -45,6 +49,7 @@ public final class AndroidRuntimeSettings implements RuntimeSettings {
     abstract String shellUrl();
     abstract boolean loadAssetsFromWorkstation();
     abstract int devServerPort();
+    abstract boolean useCacheManager();
 
     static Builder builder() {
       return new AutoValue_AndroidRuntimeSettings_Settings.Builder();
@@ -57,6 +62,7 @@ public final class AndroidRuntimeSettings implements RuntimeSettings {
       abstract Builder setShellUrl(String shellUrl);
       abstract Builder setLoadAssetsFromWorkstation(boolean loadAssetsFromWorkstation);
       abstract Builder setDevServerPort(int devServerPort);
+      abstract Builder setUseCacheManager(boolean useCacheManager);
       abstract Settings build();
     }
   }
@@ -78,6 +84,8 @@ public final class AndroidRuntimeSettings implements RuntimeSettings {
                 DEFAULT_ASSETS_FROM_WORKSTATION))
         .setDevServerPort(
             getProperty(DEV_SERVER_PORT_PROPERTY, Integer::valueOf, DEFAULT_DEV_SERVER_PORT))
+        .setUseCacheManager(
+            getProperty(USE_CACHE_MANAGER_PROPERTY, Boolean::valueOf, DEFAULT_USE_CACHE_MANAGER))
         .build();
   }
 
@@ -104,6 +112,10 @@ public final class AndroidRuntimeSettings implements RuntimeSettings {
   @Override
   public int devServerPort() {
     return settings.devServerPort();
+
+  @Override
+  public boolean useCacheManager() {
+    return settings.useCacheManager();
   }
 
   /**

--- a/javaharness/java/arcs/android/AndroidRuntimeSettings.java
+++ b/javaharness/java/arcs/android/AndroidRuntimeSettings.java
@@ -14,7 +14,8 @@ public final class AndroidRuntimeSettings implements RuntimeSettings {
   // Equivalent to &log parameter
   private static final String LOG_LEVEL_PROPERTY = "debug.arcs.runtime.log";
   // Equivalent to &explore-proxy parameter
-  private static final String ENABLE_ARCS_EXPLORER_PROPERTY = "debug.arcs.runtime.enable_arcs_explorer";
+  private static final String ENABLE_ARCS_EXPLORER_PROPERTY =
+      "debug.arcs.runtime.enable_arcs_explorer";
   // The target shell to be loaded (on-device) or be connected (on-host)
   private static final String SHELL_URL_PROPERTY = "debug.arcs.runtime.shell_url";
   // Whether to load particles and recipes from the workstation
@@ -36,7 +37,7 @@ public final class AndroidRuntimeSettings implements RuntimeSettings {
   private static final boolean DEFAULT_ASSETS_FROM_WORKSTATION = false;
   // Uses the standard 8786 port
   private static final int DEFAULT_DEV_SERVER_PORT = 8786;
-  private static final boolean DEFAULT_USE_DEV_SERVER = false;
+  // Deactivates the Arcs Cache Manager.
   private static final boolean DEFAULT_USE_CACHE_MANAGER = false;
 
   private static final Logger logger = Logger.getLogger(
@@ -76,7 +77,10 @@ public final class AndroidRuntimeSettings implements RuntimeSettings {
         .setLogLevel(
             getProperty(LOG_LEVEL_PROPERTY, Integer::valueOf, DEFAULT_LOG_LEVEL))
         .setEnableArcsExplorer(
-            getProperty(ENABLE_ARCS_EXPLORER_PROPERTY, Boolean::valueOf, DEFAULT_ENABLE_ARCS_EXPLORER))
+            getProperty(
+                ENABLE_ARCS_EXPLORER_PROPERTY,
+                Boolean::valueOf,
+                DEFAULT_ENABLE_ARCS_EXPLORER))
         .setShellUrl(
             getProperty(SHELL_URL_PROPERTY, String::valueOf, DEFAULT_SHELL_URL))
         .setLoadAssetsFromWorkstation(

--- a/javaharness/java/arcs/android/BUILD
+++ b/javaharness/java/arcs/android/BUILD
@@ -22,6 +22,7 @@ android_library(
     resource_files = glob(["res/**"]),
     deps = [
         "//javaharness/java/arcs/api:api-android",
+        "//third_party/java/androidx/webkit",
         "//third_party/java/auto:auto_value",
         "//third_party/java/dagger",
         "//third_party/java/flogger:android",

--- a/javaharness/java/arcs/api/RuntimeSettings.java
+++ b/javaharness/java/arcs/api/RuntimeSettings.java
@@ -20,4 +20,15 @@ public interface RuntimeSettings {
   // Used only by Javascript-based Arcs runtime to specify which shell
   // either on-device or on-host to connect with.
   String shellUrl();
+
+  // Used only by Javascript-based Arcs runtime to create the dedicated
+  // service worker thread (the Arcs Cache Manager) to match url requests to
+  // the generated responses at the cache_storage. The generated responses on
+  // js/wasm requests would trigger eager compilation rather than default lazy
+  // compilation.
+  //
+  // Note:
+  // This option only works when the runtime url is specified in "https"
+  // protocol complying with the security origin policy.
+  boolean useCacheManager();
 }

--- a/shells/pipes-shell/web/cache-mgr-sw.js
+++ b/shells/pipes-shell/web/cache-mgr-sw.js
@@ -24,7 +24,7 @@ const PREBUILT_CACHES = [
   './shell.js',
 ];
 
-self.addEventListener('install', (event) => {
+self.addEventListener('install', event => {
   async function buildCache() {
     console.log('building Arcs caches');
     const cache = await caches.open(SW_CACHES_FILE);
@@ -53,7 +53,7 @@ self.addEventListener('activate', event => {
   );
 });
 
-self.addEventListener('fetch', (event) => {
+self.addEventListener('fetch', event => {
   async function cachedFetch(event) {
     const cache = await caches.open(SW_CACHES_FILE);
     let response = await cache.match(event.request);
@@ -64,7 +64,7 @@ self.addEventListener('fetch', (event) => {
     cache.put(event.request, response.clone());
     return response;
   }
-  // Quite: 'only-if-cached' can be set only with 'same-origin' mode
+  // Suppress warning: 'only-if-cached' can be set only with 'same-origin' mode
   if (event.request.mode !== 'same-origin' &&
       event.request.cache === 'only-if-cached') {
     return;

--- a/shells/pipes-shell/web/cache-mgr-sw.js
+++ b/shells/pipes-shell/web/cache-mgr-sw.js
@@ -8,9 +8,10 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-// __ARCS_MD5__ will be replaced in place to reflect md5 checksum of dist/**
-// This is required prior to Chrome 78 since service worker can invalidate and
-// rebuild caches only when its source script is changed.
+// __ARCS_MD5__ will be replaced in place to reflect md5 checksum of the bazel
+// output directory. This is required prior to M78 since service worker can
+// invalidate and rebuild caches only when the content of its source script
+// changes.
 const SW_CACHES_VERSION='__ARCS_MD5__';
 
 // The storage of caches

--- a/shells/pipes-shell/web/cache-mgr-sw.js
+++ b/shells/pipes-shell/web/cache-mgr-sw.js
@@ -1,0 +1,72 @@
+/**
+ * @license
+ * Copyright 2019 Google LLC.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+// __ARCS_MD5__ will be replaced in place to reflect md5 checksum of dist/**
+// This is required prior to Chrome 78 since service worker can invalidate and
+// rebuild caches only when its source script is changed.
+const SW_CACHES_VERSION='__ARCS_MD5__';
+
+// The storage of caches
+const SW_CACHES_FILE = `arcs_${SW_CACHES_VERSION}`;
+
+// Pre-builds caches for the listed files and resources ahead of time.
+// Other file caches will be generated then cached at run-time upon accesses.
+const PREBUILT_CACHES = [
+  './worker.js',
+  './shell.js',
+];
+
+self.addEventListener('install', (event) => {
+  async function buildCache() {
+    console.log('building Arcs caches');
+    const cache = await caches.open(SW_CACHES_FILE);
+    return cache.addAll(PREBUILT_CACHES);
+  }
+  // Terminates the existing service worker at the same scope to
+  // serve upcoming requests with the up-to-date caches.
+  event.waitUntil(buildCache().then(() => self.skipWaiting()));
+});
+
+self.addEventListener('activate', event => {
+  // Cleans up the caches at the stale stores.
+  event.waitUntil(
+    caches.keys().then(keys => Promise.all(
+      keys.map(key => {
+        if (key !== SW_CACHES_FILE) {
+          return caches.delete(key);
+        }
+      })
+    )).then(() => {
+      // Serves the current page immediately instead of waiting until
+      // next page load/refresh.
+      clients.claim();
+      console.log(`${SW_CACHES_FILE} started serving Arcs caches`);
+    })
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  async function cachedFetch(event) {
+    const cache = await caches.open(SW_CACHES_FILE);
+    let response = await cache.match(event.request);
+    if (response) {
+      return response;
+    }
+    response = await fetch(event.request);
+    cache.put(event.request, response.clone());
+    return response;
+  }
+  // Quite: 'only-if-cached' can be set only with 'same-origin' mode
+  if (event.request.mode !== 'same-origin' &&
+      event.request.cache === 'only-if-cached') {
+    return;
+  }
+  event.respondWith(cachedFetch(event));
+});

--- a/shells/pipes-shell/web/cache-mgr.js
+++ b/shells/pipes-shell/web/cache-mgr.js
@@ -13,9 +13,14 @@ const ARCS_CACHE_MANAGER = './cache-mgr-sw.js';
 // Arcs Cache Manager
 (async function _arcsCacheManager() {
   if ('serviceWorker' in navigator) {
-    // Only registers the cache manager service worker when requested with
-    // ?use-cache url parameter, otherwise unregisters all service workers
-    // at this scope.
+    // Service Worker supports ONLY https:// and http://localhost.
+    // Only https:// is accepted at this moment since local socket test
+    // servers are not supported on devices.
+    if (location.protocol !== 'https:') return;
+
+    // Only registering the new cache manager service worker instance when
+    // requested in 'https' protocol and with ?use-cache url parameter,
+    // otherwise unregistering the existing service workers at this scope.
     const params = new URLSearchParams(window.location.search);
     if (!params.has('use-cache')) {
       navigator.serviceWorker.getRegistrations().then(function(regs) {

--- a/shells/pipes-shell/web/cache-mgr.js
+++ b/shells/pipes-shell/web/cache-mgr.js
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright 2019 Google LLC.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+const ARCS_CACHE_MANAGER = './cache-mgr-sw.js';
+
+// Arcs Cache Manager
+(async function _arcsCacheManager() {
+  if ('serviceWorker' in navigator) {
+    // Only registers the cache manager service worker when requested with
+    // ?use-cache url parameter, otherwise unregisters all service workers
+    // at this scope.
+    const params = new URLSearchParams(window.location.search);
+    if (!params.has('use-cache')) {
+      navigator.serviceWorker.getRegistrations().then(function(regs) {
+        for (const reg of regs) {
+          console.log('unregistering Arcs Cache Manager: ' + reg.scope);
+          reg.unregister();
+        }
+      }).catch(function(err) {
+        console.log('Arcs Cache Manager unregistration failed: ' + err);
+      });
+      return;
+    }
+
+    navigator.serviceWorker.register(ARCS_CACHE_MANAGER)
+      .then(reg => {
+        console.log(`Arcs Cache Manager registered, scope: ${reg.scope}`);
+      })
+      .catch(err => {
+        console.log(
+          `Arcs Cache Manager registration failed: ${err.message}`);
+      });
+  }
+})();

--- a/shells/pipes-shell/web/cache-mgr.js
+++ b/shells/pipes-shell/web/cache-mgr.js
@@ -12,35 +12,38 @@ const ARCS_CACHE_MANAGER = './cache-mgr-sw.js';
 
 // Arcs Cache Manager
 (async function _arcsCacheManager() {
-  if ('serviceWorker' in navigator) {
-    // Service Worker supports ONLY https:// and http://localhost.
-    // Only https:// is accepted at this moment since local socket test
-    // servers are not supported on devices.
-    if (location.protocol !== 'https:') return;
-
-    // Only registering the new cache manager service worker instance when
-    // requested in 'https' protocol and with ?use-cache url parameter,
-    // otherwise unregistering the existing service workers at this scope.
-    const params = new URLSearchParams(window.location.search);
-    if (!params.has('use-cache')) {
-      navigator.serviceWorker.getRegistrations().then(function(regs) {
-        for (const reg of regs) {
-          console.log('unregistering Arcs Cache Manager: ' + reg.scope);
-          reg.unregister();
-        }
-      }).catch(function(err) {
-        console.log('Arcs Cache Manager unregistration failed: ' + err);
-      });
-      return;
-    }
-
-    navigator.serviceWorker.register(ARCS_CACHE_MANAGER)
-      .then(reg => {
-        console.log(`Arcs Cache Manager registered, scope: ${reg.scope}`);
-      })
-      .catch(err => {
-        console.log(
-          `Arcs Cache Manager registration failed: ${err.message}`);
-      });
+  const serviceWorker = navigator.serviceWorker;
+  if (!serviceWorker) {
+    return;
   }
+
+  // Service Worker supports ONLY https:// and http://localhost.
+  // Only https:// is accepted at this moment since local socket test
+  // servers are not supported on devices.
+  if (location.protocol !== 'https:') return;
+
+  // Only registering the new cache manager service worker instance when
+  // requested in 'https' protocol and with ?use-cache url parameter,
+  // otherwise unregistering the existing service workers at this scope.
+  const params = new URLSearchParams(window.location.search);
+  if (!params.has('use-cache')) {
+    serviceWorker.getRegistrations().then(function(regs) {
+      for (const reg of regs) {
+        console.log('unregistering Arcs Cache Manager: ' + reg.scope);
+        reg.unregister();
+      }
+    }).catch(function(err) {
+      console.log('Arcs Cache Manager unregistration failed: ' + err);
+    });
+    return;
+  }
+
+  navigator.serviceWorker.register(ARCS_CACHE_MANAGER)
+    .then(reg => {
+      console.log(`Arcs Cache Manager registered, scope: ${reg.scope}`);
+    })
+    .catch(err => {
+      console.log(
+        `Arcs Cache Manager registration failed: ${err.message}`);
+    });
 })();

--- a/shells/pipes-shell/web/deploy/android_deploy.sh
+++ b/shells/pipes-shell/web/deploy/android_deploy.sh
@@ -18,4 +18,5 @@ cp source/index.html "$OUT_DIR/index.html"
 # Arcs cache manager and versioning
 # Must be done at the last step to ensure the correct $OUT_DIR/** checksum
 cp -fR ../cache-mgr*.js $OUT_DIR/
-sed -i "s/__ARCS_MD5__/$(tar -cf - dist | md5sum | cut -d' ' -f1)/g" $OUT_DIR/cache-mgr-sw.js
+sed -i "s/__ARCS_MD5__/$(tar -cf - $OUT_DIR | md5sum | cut -d' ' -f1)/g" \
+$OUT_DIR/cache-mgr-sw.js

--- a/shells/pipes-shell/web/deploy/android_deploy.sh
+++ b/shells/pipes-shell/web/deploy/android_deploy.sh
@@ -19,4 +19,4 @@ cp source/index.html "$OUT_DIR/index.html"
 # Must be done at the last step to ensure the correct $OUT_DIR/** checksum
 cp -fR ../cache-mgr*.js $OUT_DIR/
 sed -i "s/__ARCS_MD5__/$(tar -cf - $OUT_DIR | md5sum | cut -d' ' -f1)/g" \
-$OUT_DIR/cache-mgr-sw.js
+  $OUT_DIR/cache-mgr-sw.js

--- a/shells/pipes-shell/web/deploy/android_deploy.sh
+++ b/shells/pipes-shell/web/deploy/android_deploy.sh
@@ -14,3 +14,8 @@ cp ../../../lib/build/worker.js "$OUT_DIR/worker.js"
 
 # Copy over shell html.
 cp source/index.html "$OUT_DIR/index.html"
+
+# Arcs cache manager and versioning
+# Must be done at the last step to ensure the correct $OUT_DIR/** checksum
+cp -fR ../cache-mgr*.js $OUT_DIR/
+sed -i "s/__ARCS_MD5__/$(tar -cf - dist | md5sum | cut -d' ' -f1)/g" $OUT_DIR/cache-mgr-sw.js

--- a/shells/pipes-shell/web/deploy/deploy.sh
+++ b/shells/pipes-shell/web/deploy/deploy.sh
@@ -11,3 +11,7 @@ ln -s $PWD/../../../../particles $PWD/dist/particles
 cp -fR ../../../lib/build/worker.js dist/
 # collate sources
 npx webpack --display=errors-only
+# Arcs cache manager and versioning
+# Must be done at the last step to ensure the correct dist/** checksum
+cp -fR ../cache-mgr*.js dist/
+sed -i "s/__ARCS_MD5__/$(tar -cf - dist | md5sum | cut -d' ' -f1)/g" dist/cache-mgr-sw.js

--- a/shells/pipes-shell/web/deploy/deploy.sh
+++ b/shells/pipes-shell/web/deploy/deploy.sh
@@ -15,4 +15,4 @@ npx webpack --display=errors-only
 # Must be done at the last step to ensure the correct dist/** checksum
 cp -fR ../cache-mgr*.js dist/
 sed -i "s/__ARCS_MD5__/$(tar -cf - dist | md5sum | cut -d' ' -f1)/g" \
-dist/cache-mgr-sw.js
+  dist/cache-mgr-sw.js

--- a/shells/pipes-shell/web/deploy/deploy.sh
+++ b/shells/pipes-shell/web/deploy/deploy.sh
@@ -14,4 +14,5 @@ npx webpack --display=errors-only
 # Arcs cache manager and versioning
 # Must be done at the last step to ensure the correct dist/** checksum
 cp -fR ../cache-mgr*.js dist/
-sed -i "s/__ARCS_MD5__/$(tar -cf - dist | md5sum | cut -d' ' -f1)/g" dist/cache-mgr-sw.js
+sed -i "s/__ARCS_MD5__/$(tar -cf - dist | md5sum | cut -d' ' -f1)/g" \
+dist/cache-mgr-sw.js

--- a/shells/pipes-shell/web/deploy/source/index.html
+++ b/shells/pipes-shell/web/deploy/source/index.html
@@ -15,6 +15,8 @@ http://polymer.github.io/PATENTS.txt
 
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+  <!-- No complains about missing favicon.ico from https requests. -->
+  <link rel="icon" href="data:,">
 
   <script>
     window.fetch = function fetchLocal(url) {
@@ -32,6 +34,7 @@ http://polymer.github.io/PATENTS.txt
     };
   </script>
 
+  <script type="text/javascript" src="./cache-mgr.js"></script>
   <script type="text/javascript" src="./shell.js"></script>
 
   <style>

--- a/src/platform/pec-industry-web.ts
+++ b/src/platform/pec-industry-web.ts
@@ -18,12 +18,16 @@ export const pecIndustry = (loader): PecFactory => {
   const remap = expandUrls(loader.urlMap);
   // get real path from meta path
   const workerUrl = loader.resolve(WORKER_PATH);
+  // use service worker cache instead of generating blobs
+  const useCache = new URLSearchParams(window.location.search).has('use-cache');
   // provision (cached) Blob url (async, same workerBlobUrl is captured in both closures)
   let workerBlobUrl;
-  loader.provisionObjectUrl(workerUrl).then((url: string) => workerBlobUrl = url);
+  if (!useCache) {
+    loader.provisionObjectUrl(workerUrl).then((url: string) => workerBlobUrl = url);
+  }
   // return a pecfactory
   const factory = (id: Id, idGenerator?: IdGenerator) => {
-    if (!workerBlobUrl) {
+    if (!workerBlobUrl && !useCache) {
       console.warn('workerBlob not available, falling back to network URL');
     }
     const worker = new Worker(workerBlobUrl || workerUrl);
@@ -55,8 +59,8 @@ const expandUrls = urlMap => {
   Object.keys(urlMap).forEach(k => {
     const config = urlMap[k];
     remap[k] = typeof config === 'string'
-        ? transform(config)
-        : {...config, root: transform(config.root)};
+      ? transform(config)
+      : {...config, root: transform(config.root)};
   });
   return remap;
 };

--- a/src/platform/pec-industry-web.ts
+++ b/src/platform/pec-industry-web.ts
@@ -19,7 +19,9 @@ export const pecIndustry = (loader): PecFactory => {
   // get real path from meta path
   const workerUrl = loader.resolve(WORKER_PATH);
   // use service worker cache instead of generating blobs
-  const useCache = new URLSearchParams(window.location.search).has('use-cache');
+  const useCache =
+    location.protocol === 'https:' &&
+    (new URLSearchParams(window.location.search)).has('use-cache');
   // provision (cached) Blob url (async, same workerBlobUrl is captured in both closures)
   let workerBlobUrl;
   if (!useCache) {

--- a/src/platform/pec-industry-web.ts
+++ b/src/platform/pec-industry-web.ts
@@ -61,8 +61,8 @@ const expandUrls = urlMap => {
   Object.keys(urlMap).forEach(k => {
     const config = urlMap[k];
     remap[k] = typeof config === 'string'
-      ? transform(config)
-      : {...config, root: transform(config.root)};
+        ? transform(config)
+        : {...config, root: transform(config.root)};
   });
   return remap;
 };

--- a/src/tools/dev_server/dev-server.ts
+++ b/src/tools/dev_server/dev-server.ts
@@ -41,6 +41,13 @@ async function launch() {
   await hotReloadServer.init();
 
   const app = express();
+  app.all('*', (req, res, next) => {
+    // Allows COR as the pipes-shell can be loaded in https protocol
+    // which requests Arcs manifests/recipes/particles at remote workstation
+    // via adb-reverse socket connecting to http://localhost:port.
+    res.header("Access-Control-Allow-Origin", "*");
+    next();
+  });
   if (options['verbose']) {
     app.use(morgan(':method :url :status - :response-time ms, :res[content-length] bytes'));
   }

--- a/src/tools/dev_server/dev-server.ts
+++ b/src/tools/dev_server/dev-server.ts
@@ -45,7 +45,7 @@ async function launch() {
     // Allows COR as the pipes-shell can be loaded in https protocol
     // which requests Arcs manifests/recipes/particles at remote workstation
     // via adb-reverse socket connecting to http://localhost:port.
-    res.header("Access-Control-Allow-Origin", "*");
+    res.header('Access-Control-Allow-Origin', '*');
     next();
   });
   if (options['verbose']) {

--- a/third_party/java/androidx/webkit/BUILD
+++ b/third_party/java/androidx/webkit/BUILD
@@ -1,0 +1,9 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+alias(
+    name = "webkit",
+    actual = "@maven//:androidx_webkit_webkit",
+)
+


### PR DESCRIPTION
By initial measurement (reloading the pipes-shell at DevTools which triggers
re-initializing the Arcs runtime, re-setting up the pipes and bus, re-instantiating Ingestion Arcs and etc):
The 'load' time improves 26.2% and 'Finish' time improves 14.4% in average.
There is no obvious difference at memory footprint, both consume around ~83 MB after each reloading.