### PR TITLE
disable kt_js when not bazel, move to third_party deps for kotlinx

### DIFF
--- a/src_kt/java/arcs/BUILD
+++ b/src_kt/java/arcs/BUILD
@@ -6,4 +6,3 @@ kt_jvm_and_js_library(
     name = "util",
     srcs = glob(["*.kt"]),
 )
-

--- a/src_kt/java/arcs/common/BUILD
+++ b/src_kt/java/arcs/common/BUILD
@@ -6,6 +6,6 @@ kt_jvm_and_js_library(
     name = "common",
     srcs = glob(["*.kt"]),
     deps = [
-        "//src_kt/java/arcs/util"
-    ]
+        "//src_kt/java/arcs/util",
+    ],
 )

--- a/src_kt/java/arcs/storage/BUILD
+++ b/src_kt/java/arcs/storage/BUILD
@@ -6,8 +6,7 @@ kt_jvm_and_js_library(
     name = "storage",
     srcs = glob(["*.kt"]),
     deps = [
-        "@maven//:org_jetbrains_kotlinx_kotlinx_coroutines_core",
-        "@maven//:org_jetbrains_kotlinx_atomicfu"
-    ]
+        "//third_party/kotlin/kotlinx/kotlinx_atomicfu",
+        "//third_party/kotlin/kotlinx/kotlinx_coroutines",
+    ],
 )
-

--- a/src_kt/java/arcs/storage/driver/BUILD
+++ b/src_kt/java/arcs/storage/driver/BUILD
@@ -9,6 +9,6 @@ kt_jvm_and_js_library(
         "//src_kt/java/arcs/common",
         "//src_kt/java/arcs/storage",
         "//src_kt/java/arcs/util",
-        "@maven//:org_jetbrains_kotlinx_atomicfu",
-    ]
+        "//third_party/kotlin/kotlinx/kotlinx_atomicfu",
+    ],
 )

--- a/src_kt/javatests/arcs/BUILD
+++ b/src_kt/javatests/arcs/BUILD
@@ -1,2 +1,1 @@
 package(default_visibility = ["//visibility:public"])
-

--- a/src_kt/javatests/arcs/common/BUILD
+++ b/src_kt/javatests/arcs/common/BUILD
@@ -10,8 +10,8 @@ load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_test")
         test_class = "arcs.common.%s" % src_file[:-3],
         deps = [
             "//src_kt/java/arcs/common",
-            "@maven//:com_google_truth_truth",
-            "@maven//:junit_junit",
+            "//third_party/java/truth",
+            "//third_party/java/junit",
         ],
     )
     for src_file in glob(["*.kt"])

--- a/src_kt/javatests/arcs/common/BUILD
+++ b/src_kt/javatests/arcs/common/BUILD
@@ -10,8 +10,8 @@ load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_test")
         test_class = "arcs.common.%s" % src_file[:-3],
         deps = [
             "//src_kt/java/arcs/common",
-            "//third_party/java/truth",
             "//third_party/java/junit",
+            "//third_party/java/truth",
         ],
     )
     for src_file in glob(["*.kt"])

--- a/src_kt/javatests/arcs/crdt/BUILD
+++ b/src_kt/javatests/arcs/crdt/BUILD
@@ -12,8 +12,8 @@ load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_test")
             "//src_kt/java/arcs/common",
             "//src_kt/java/arcs/crdt",
             "//src_kt/java/arcs/crdt/internal",
-            "//third_party/java/truth",
             "//third_party/java/junit",
+            "//third_party/java/truth",
         ],
     )
     for src_file in glob(["*.kt"])

--- a/src_kt/javatests/arcs/crdt/BUILD
+++ b/src_kt/javatests/arcs/crdt/BUILD
@@ -12,8 +12,8 @@ load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_test")
             "//src_kt/java/arcs/common",
             "//src_kt/java/arcs/crdt",
             "//src_kt/java/arcs/crdt/internal",
-            "@maven//:com_google_truth_truth",
-            "@maven//:junit_junit",
+            "//third_party/java/truth",
+            "//third_party/java/junit",
         ],
     )
     for src_file in glob(["*.kt"])

--- a/src_kt/javatests/arcs/crdt/entity/BUILD
+++ b/src_kt/javatests/arcs/crdt/entity/BUILD
@@ -10,8 +10,8 @@ load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_test")
         deps = [
             "//src_kt/java/arcs/crdt/entity",
             "//src_kt/java/arcs/crdt/internal",
-            "//third_party/java/truth",
             "//third_party/java/junit",
+            "//third_party/java/truth",
         ],
     )
     for src_file in glob(["*.kt"])

--- a/src_kt/javatests/arcs/crdt/entity/BUILD
+++ b/src_kt/javatests/arcs/crdt/entity/BUILD
@@ -10,8 +10,8 @@ load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_test")
         deps = [
             "//src_kt/java/arcs/crdt/entity",
             "//src_kt/java/arcs/crdt/internal",
-            "@maven//:com_google_truth_truth",
-            "@maven//:junit_junit",
+            "//third_party/java/truth",
+            "//third_party/java/junit",
         ],
     )
     for src_file in glob(["*.kt"])

--- a/src_kt/javatests/arcs/crdt/internal/BUILD
+++ b/src_kt/javatests/arcs/crdt/internal/BUILD
@@ -11,8 +11,8 @@ load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_test")
         deps = [
             "//src_kt/java/arcs/crdt",
             "//src_kt/java/arcs/crdt/internal",
-            "@maven//:com_google_truth_truth",
-            "@maven//:junit_junit",
+            "//third_party/java/truth",
+            "//third_party/java/junit",
         ],
     )
     for src_file in glob(["*.kt"])

--- a/src_kt/javatests/arcs/crdt/internal/BUILD
+++ b/src_kt/javatests/arcs/crdt/internal/BUILD
@@ -11,8 +11,8 @@ load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_test")
         deps = [
             "//src_kt/java/arcs/crdt",
             "//src_kt/java/arcs/crdt/internal",
-            "//third_party/java/truth",
             "//third_party/java/junit",
+            "//third_party/java/truth",
         ],
     )
     for src_file in glob(["*.kt"])

--- a/src_kt/javatests/arcs/storage/BUILD
+++ b/src_kt/javatests/arcs/storage/BUILD
@@ -10,8 +10,8 @@ load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_test")
         test_class = "arcs.storage.%s" % src_file[:-3],
         deps = [
             "//src_kt/java/arcs/storage",
-            "@maven//:com_google_truth_truth",
-            "@maven//:junit_junit",
+            "//third_party/java/truth",
+            "//third_party/java/junit",
         ],
     )
     for src_file in glob(["*.kt"])

--- a/src_kt/javatests/arcs/storage/BUILD
+++ b/src_kt/javatests/arcs/storage/BUILD
@@ -10,8 +10,8 @@ load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_test")
         test_class = "arcs.storage.%s" % src_file[:-3],
         deps = [
             "//src_kt/java/arcs/storage",
-            "//third_party/java/truth",
             "//third_party/java/junit",
+            "//third_party/java/truth",
         ],
     )
     for src_file in glob(["*.kt"])

--- a/src_kt/javatests/arcs/storage/driver/BUILD
+++ b/src_kt/javatests/arcs/storage/driver/BUILD
@@ -13,9 +13,9 @@ load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_test")
             "//src_kt/java/arcs/storage",
             "//src_kt/java/arcs/storage/driver",
             "//src_kt/java/arcs/util",
-            "@maven//:com_google_truth_truth",
-            "@maven//:junit_junit",
-            "@maven//:org_jetbrains_kotlinx_kotlinx_coroutines_core",
+            "//third_party/java/truth",
+            "//third_party/java/junit",
+            "//third_party/kotlin/kotlinx/kotlinx_coroutines",
         ],
     )
     for src_file in glob(["*.kt"])

--- a/src_kt/javatests/arcs/storage/driver/BUILD
+++ b/src_kt/javatests/arcs/storage/driver/BUILD
@@ -13,8 +13,8 @@ load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_test")
             "//src_kt/java/arcs/storage",
             "//src_kt/java/arcs/storage/driver",
             "//src_kt/java/arcs/util",
-            "//third_party/java/truth",
             "//third_party/java/junit",
+            "//third_party/java/truth",
             "//third_party/kotlin/kotlinx/kotlinx_coroutines",
         ],
     )

--- a/src_kt/javatests/arcs/util/BUILD
+++ b/src_kt/javatests/arcs/util/BUILD
@@ -10,9 +10,9 @@ load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_test")
         test_class = "arcs.util.%s" % src_file[:-3],
         deps = [
             "//src_kt/java/arcs/util",
-            "@maven//:com_google_truth_truth",
-            "@maven//:junit_junit",
-            "@maven//:org_jetbrains_kotlinx_kotlinx_coroutines_core",
+            "//third_party/java/truth",
+            "//third_party/java/junit",
+            "//third_party/kotlin/kotlinx/kotlinx_coroutines",
         ],
     )
     for src_file in glob(
@@ -28,8 +28,8 @@ kt_jvm_test(
     test_class = "arcs.util.Base64PerformanceTest",
     deps = [
         "//src_kt/java/arcs/util",
-        "@maven//:com_google_truth_truth",
-        "@maven//:junit_junit",
-        "@maven//:org_jetbrains_kotlinx_kotlinx_coroutines_core",
+        "//third_party/java/truth",
+        "//third_party/java/junit",
+        "//third_party/kotlin/kotlinx/kotlinx_coroutines",
     ],
 )

--- a/src_kt/javatests/arcs/util/BUILD
+++ b/src_kt/javatests/arcs/util/BUILD
@@ -10,8 +10,8 @@ load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_test")
         test_class = "arcs.util.%s" % src_file[:-3],
         deps = [
             "//src_kt/java/arcs/util",
-            "//third_party/java/truth",
             "//third_party/java/junit",
+            "//third_party/java/truth",
             "//third_party/kotlin/kotlinx/kotlinx_coroutines",
         ],
     )
@@ -28,8 +28,8 @@ kt_jvm_test(
     test_class = "arcs.util.Base64PerformanceTest",
     deps = [
         "//src_kt/java/arcs/util",
-        "//third_party/java/truth",
         "//third_party/java/junit",
+        "//third_party/java/truth",
         "//third_party/kotlin/kotlinx/kotlinx_coroutines",
     ],
 )

--- a/third_party/java/arcs/build_defs/internal/kotlin.bzl
+++ b/third_party/java/arcs/build_defs/internal/kotlin.bzl
@@ -4,10 +4,12 @@ Rules are re-exported in build_defs.bzl -- use those instead.
 """
 
 load("//tools/build_defs/kotlin/release/rules/native:native_rules.bzl", "kt_native_binary", "kt_native_library")
-load("//tools/build_defs/kotlin/release/rules/js:js_library.bzl", "kt_js_import", "kt_js_library")
+load("//tools/build_defs/kotlin/release/rules/js:js_library.bzl", "kt_js_library")
 load("//tools/build_defs/kotlin:rules.bzl", "kt_android_library", "kt_jvm_library")
 
 _ARCS_KOTLIN_LIBS = ["//src/wasm/kotlin:arcs_wasm"]
+
+IS_BAZEL = not (hasattr(native, "genmpm"))
 
 def arcs_kt_library(name, srcs = [], deps = []):
     """Declares kotlin library targets for Kotlin particle sources."""
@@ -41,12 +43,18 @@ def kt_jvm_and_js_library(
         deps = [_to_jvm_dep(dep) for dep in deps],
     )
 
-    # Disabled while https://github.com/bazelbuild/rules_kotlin/issues/219 is unfixed.
-    # kt_js_library(
-    #    name = "%s-js" % name,
-    #    srcs = srcs,
-    #    deps = [_to_js_dep(dep) for dep in deps],
-    #)
+    # if IS_BAZEL:
+    #   Disabled while https://github.com/bazelbuild/rules_kotlin/issues/219 is unfixed.
+    #   kt_js_library(
+    #      name = "%s-js" % name,
+    #      srcs = srcs,
+    #      deps = [_to_js_dep(dep) for dep in deps],
+    #  )
+
+
+# Currently unsupported in G3
+def kt_js_import(**kwargs):
+  pass
 
 def _to_jvm_dep(dep):
     return dep
@@ -67,11 +75,11 @@ def _kt_js_import_for_thirdparty(thirdparty_dep):
     name = "unknown"
     version = ""
     maven_name = "unknown"
-    if (thirdparty_dep == "@maven//:org_jetbrains_kotlinx_kotlinx_coroutines_core"):
+    if (thirdparty_dep == "//third_party/kotlin/kotlinx/kotlinx_coroutines"):
         name = "kotlinx-coroutines-core-js"
         version = "1.3.2"
         maven_name = "@maven//:org_jetbrains_kotlinx_kotlinx_coroutines_core_js"
-    if (thirdparty_dep == "@maven//:org_jetbrains_kotlinx_atomicfu"):
+    if (thirdparty_dep == "//third_party/kotlin/kotlinx/kotlinx_atomicfu"):
         name = "atomicfu-js"
         version = "0.13.1"
         maven_name = "@maven//:org_jetbrains_kotlinx_atomicfu_js"

--- a/third_party/kotlin/kotlinx/kotlinx_atomicfu/BUILD
+++ b/third_party/kotlin/kotlinx/kotlinx_atomicfu/BUILD
@@ -1,0 +1,9 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+alias(
+    name = "kotlinx_atomicfu",
+    actual = "@maven//:org_jetbrains_kotlinx_atomicfu",
+)
+


### PR DESCRIPTION
Put kt_js stuff behind IS_BAZEL flag (not G3 supported right now)

move from using maven deps to third_party deps
