### PR TITLE
Support loading out-of-context recipes via `runArc` in `pipes-shell`

### DIFF
--- a/shells/pipes-shell/source/smoke.js
+++ b/shells/pipes-shell/source/smoke.js
@@ -43,10 +43,18 @@ export const smokeTest = async bus => {
     send({message: 'parse', path: `https://$particles/canonical.arcs`});
   };
   //
+  const runArcTest = () => {
+    // create an arc and instantiate a recipe from the context
+    send({message: 'runArc', arcId: 'smoke-test-run-arc', recipe: `Notification`});
+    // create an arc and instantiate a recipe from a full path
+    send({message: 'runArc', arcId: 'smoke-test-run-arc-path', recipe: `https://$particles/Notification/Notification.arcs|Notification`});
+  };
+  //
   enqueue([
     ingestionTest,
     autofillTest,
     notificationTest,
-    parseTest
+    parseTest,
+    runArcTest
   ], 500);
 };

--- a/shells/pipes-shell/source/verbs/spawn.js
+++ b/shells/pipes-shell/source/verbs/spawn.js
@@ -30,8 +30,6 @@ export const spawn = async ({modality, recipe}, tid, bus, composerFactory, stora
       composer: composerFactory(modality, bus, tid),
       portFactories: [portIndustry(bus)]
     });
-    // TODO(sjmiles): why is this here?
-    //arc.tid = tid;
     if (contextRecipe) {
       // instantiate optional recipe
       await instantiateRecipe(arc, contextRecipe);


### PR DESCRIPTION
Modifies `runArc` to accept a `recipe` of the form `<path-to-manifest>|<name-of-recipe>` (in addition to original `<name-of-recipe>` format.

Example (from `smoke.js`):
```
send({message: 'runArc', arcId: 'smoke-test-run-arc-path', 
  recipe: `https://$particles/Notification/Notification.arcs|Notification`});
```
@mmandlis if you aren't comfortable with this PR, that's ok, we can just use this for discussion. I just wanted to concretize my assertions that this behavior is supportable.

