### PR TITLE
Arcs never gets ready

### DIFF
--- a/javaharness/java/arcs/android/ArcsShellApi.java
+++ b/javaharness/java/arcs/android/ArcsShellApi.java
@@ -44,6 +44,7 @@ class ArcsShellApi {
 
   void init(Context context) {
     arcsReady = false;
+    environment.init(context);
     environment.addReadyListener(recipes -> arcsReady = true);
     environment.addReadyListener(recipes -> {
       recipes.forEach(recipe -> {
@@ -53,7 +54,6 @@ class ArcsShellApi {
         }
       });
     });
-    environment.init(context);
   }
 
   void destroy() {


### PR DESCRIPTION
The ready listeners registered at ArcsShellApi.init() are removed
when the AndroidArcsEnvironment initializes.