### PR TITLE
Use dynamic manifest in Android Arcs.

### DIFF
--- a/javaharness/java/arcs/android/AndroidRuntimeSettings.java
+++ b/javaharness/java/arcs/android/AndroidRuntimeSettings.java
@@ -23,7 +23,7 @@ public final class AndroidRuntimeSettings implements RuntimeSettings {
   // and not uses ALDS proxy.
   private static final int DEFAULT_LOG_LEVEL = 2;
   private static final boolean DEFAULT_USE_DEV_SERVER = false;
-  private static final String DEFAULT_SHELL_URL = "file:///android_asset/arcs/index.html?";
+  private static final String DEFAULT_SHELL_URL = "file:///android_asset/arcs/index.html?solo=dynamic.manifest&";
   private static final String LOCALHOST_SHELL_URL = "http://localhost:8786/shells/pipes-shell/web/deploy/dist/?";
 
   private static final Logger logger = Logger.getLogger(

--- a/javaharness/java/arcs/android/ArcsAndroidClient.java
+++ b/javaharness/java/arcs/android/ArcsAndroidClient.java
@@ -189,6 +189,16 @@ public class ArcsAndroidClient {
     });
   }
 
+  public void addManifests(List<String> manifests) {
+    executeArcsServiceCall(iArcsService -> {
+      try {
+        iArcsService.addManifests(manifests);
+      } catch (RemoteException e) {
+        e.printStackTrace();
+      }
+    });
+  }
+
   /**
    * If the service is not connected, adds the Consumer callback to a queue to be executed later
    * when the service (re)connects. Otherwise, invokes the provided callback immediately with an

--- a/javaharness/java/arcs/android/ArcsAndroidClient.java
+++ b/javaharness/java/arcs/android/ArcsAndroidClient.java
@@ -189,10 +189,11 @@ public class ArcsAndroidClient {
     });
   }
 
-  public void addManifests(List<String> manifests) {
+  public void addManifests(List<String> manifests, Consumer<Boolean> callback) {
     executeArcsServiceCall(iArcsService -> {
       try {
-        iArcsService.addManifests(manifests);
+        boolean success = iArcsService.addManifests(manifests);
+        callback.accept(success);
       } catch (RemoteException e) {
         e.printStackTrace();
       }

--- a/javaharness/java/arcs/android/ArcsService.java
+++ b/javaharness/java/arcs/android/ArcsService.java
@@ -81,6 +81,11 @@ public class ArcsService extends Service {
       public void registerRenderer(String modality, IRemoteOutputCallback callback) {
         arcsShellApi.registerRemoteRenderer(modality, callback);
       }
+
+      @Override
+      public boolean addManifests(List<String> manifests) {
+        return arcsShellApi.addManifests(manifests);
+      }
     };
   }
 }

--- a/javaharness/java/arcs/android/ArcsShellApi.java
+++ b/javaharness/java/arcs/android/ArcsShellApi.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.os.RemoteException;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import javax.inject.Inject;
@@ -37,14 +38,16 @@ class ArcsShellApi {
   @Inject
   UiBroker uiBroker;
 
+  private Context context;
   private boolean arcsReady;
+  private boolean manifestsAdded;
 
   @Inject
   ArcsShellApi() {}
 
   void init(Context context) {
+    this.context = context;
     arcsReady = false;
-    environment.init(context);
     environment.addReadyListener(recipes -> arcsReady = true);
     environment.addReadyListener(recipes -> {
       recipes.forEach(recipe -> {
@@ -113,6 +116,16 @@ class ArcsShellApi {
 
   void sendMessageToArcs(String message) {
     runWhenReady(() -> arcsMessageSender.sendMessageToArcs(message));
+  }
+
+  boolean addManifests(List<String> manifests) {
+    if (manifestsAdded) {
+      return false;
+    } else {
+      manifestsAdded = true;
+      environment.init(context, manifests);
+      return true;
+    }
   }
 
   private String constructRunArcRequest(ArcData arcData) {

--- a/javaharness/java/arcs/android/IArcsService.aidl
+++ b/javaharness/java/arcs/android/IArcsService.aidl
@@ -26,7 +26,6 @@ interface IArcsService {
   void stopArc(String arcId, String pecId);
 
   // TODO: add unregisterRenderer method.
-  // TODO: add UI events passing / handling method.
   void registerRenderer(String modality, IRemoteOutputCallback callback);
 
   // Adds manifests to Arcs.

--- a/javaharness/java/arcs/android/IArcsService.aidl
+++ b/javaharness/java/arcs/android/IArcsService.aidl
@@ -25,8 +25,12 @@ interface IArcsService {
 
   void stopArc(String arcId, String pecId);
 
-  void registerRenderer(String modality, IRemoteOutputCallback callback);
   // TODO: add unregisterRenderer method.
   // TODO: add UI events passing / handling method.
+  void registerRenderer(String modality, IRemoteOutputCallback callback);
+
+  // Adds manifests to Arcs.
+  // Returns true if manifests are successfully added. Otherwise false.
+  boolean addManifests(in List<String> manifests);
 }
 

--- a/javaharness/java/arcs/android/demo/ArcsAutofillService.java
+++ b/javaharness/java/arcs/android/demo/ArcsAutofillService.java
@@ -12,7 +12,6 @@ import android.service.autofill.SaveRequest;
 import android.widget.RemoteViews;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 

--- a/javaharness/java/arcs/android/demo/ArcsAutofillService.java
+++ b/javaharness/java/arcs/android/demo/ArcsAutofillService.java
@@ -12,6 +12,7 @@ import android.service.autofill.SaveRequest;
 import android.widget.RemoteViews;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 

--- a/javaharness/java/arcs/android/demo/AutofillDemoActivity.java
+++ b/javaharness/java/arcs/android/demo/AutofillDemoActivity.java
@@ -10,6 +10,7 @@ import android.view.autofill.AutofillManager;
 import android.widget.Button;
 import android.widget.TextView;
 
+import java.util.Arrays;
 import javax.inject.Inject;
 
 import arcs.android.ArcsAndroidClient;
@@ -45,6 +46,8 @@ public class AutofillDemoActivity extends Activity {
     capturePersonButton.setOnClickListener(v -> capturePerson());
 
     arcsAndroidClient.connect(this);
+    arcsAndroidClient.addManifests(
+        Arrays.asList("https://$particles/PipeApps/AndroidAutofill.arcs"));
   }
 
   @Override

--- a/javaharness/java/arcs/android/demo/AutofillDemoActivity.java
+++ b/javaharness/java/arcs/android/demo/AutofillDemoActivity.java
@@ -9,8 +9,11 @@ import android.view.View;
 import android.view.autofill.AutofillManager;
 import android.widget.Button;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import java.util.Arrays;
+import java.util.function.Consumer;
+
 import javax.inject.Inject;
 
 import arcs.android.ArcsAndroidClient;
@@ -47,7 +50,12 @@ public class AutofillDemoActivity extends Activity {
 
     arcsAndroidClient.connect(this);
     arcsAndroidClient.addManifests(
-        Arrays.asList("https://$particles/PipeApps/AndroidAutofill.arcs"));
+        Arrays.asList("https://$particles/PipeApps/AndroidAutofill.arcs"),
+        success ->  {
+          if (!success) {
+            throw new IllegalStateException("Failed to add manfiest");
+          }
+        });
   }
 
   @Override

--- a/javaharness/java/arcs/android/demo/NotificationDemoActivity.java
+++ b/javaharness/java/arcs/android/demo/NotificationDemoActivity.java
@@ -3,6 +3,7 @@ package arcs.android.demo;
 import android.app.Activity;
 import android.os.Bundle;
 
+import java.util.Arrays;
 import javax.inject.Inject;
 
 import arcs.android.ArcsAndroidClient;
@@ -23,6 +24,8 @@ public class NotificationDemoActivity extends Activity {
     ((ArcsDemoApplication) getApplication()).getComponent().inject(this);
 
     arcsAndroidClient.connect(this);
+    arcsAndroidClient.addManifests(
+        Arrays.asList("https://$particles/PipeApps/RenderNotification.arcs"));
     arcsAndroidClient.registerRenderer("notification", notificationRenderer);
 
     setContentView(R.layout.notification_demo);

--- a/javaharness/java/arcs/android/demo/NotificationDemoActivity.java
+++ b/javaharness/java/arcs/android/demo/NotificationDemoActivity.java
@@ -25,7 +25,12 @@ public class NotificationDemoActivity extends Activity {
 
     arcsAndroidClient.connect(this);
     arcsAndroidClient.addManifests(
-        Arrays.asList("https://$particles/PipeApps/RenderNotification.arcs"));
+        Arrays.asList("https://$particles/PipeApps/RenderNotification.arcs"),
+        success ->  {
+          if (!success) {
+            throw new IllegalStateException("Failed to add manfiest");
+          }
+        });
     arcsAndroidClient.registerRenderer("notification", notificationRenderer);
 
     setContentView(R.layout.notification_demo);

--- a/shells/pipes-shell/source/pipe.js
+++ b/shells/pipes-shell/source/pipe.js
@@ -26,7 +26,7 @@ import {parse} from './verbs/parse.js';
 
 const {log} = logsFactory('pipe');
 
-const manifest = `
+const defaultManifest = `
 import 'https://$particles/PipeApps/RenderNotification.arcs'
 import 'https://$particles/PipeApps/AndroidAutofill.arcs'
 // UIBroker/demo particles below here
@@ -35,7 +35,7 @@ import 'https://$particles/Restaurants/Restaurants.arcs'
 import 'https://$particles/Notification/Notification.arcs'
 `;
 
-export const initPipe = async (client, paths, storage) => {
+export const initPipe = async (client, paths, storage, manifest = defaultManifest) => {
   // configure arcs environment
   const env = Utils.init(paths.root, paths.map);
   // marshal context
@@ -49,7 +49,7 @@ export const initPipe = async (client, paths, storage) => {
 };
 
 // TODO(sjmiles): must be called only after `window.ShellApi` is initialized
-export const initArcs = async (storage, bus) => {
+export const initArcs = async (storage, bus, manifest = defaultManifest) => {
   // marshal ingestion arc
   // TODO(sjmiles): "live context" tool (for demos)
   await requireIngestionArc(storage, bus);

--- a/shells/pipes-shell/web/web.js
+++ b/shells/pipes-shell/web/web.js
@@ -10,7 +10,7 @@
 
 // configure
 import '../../lib/platform/loglevel-web.js';
-import {version, paths, storage, test} from './config.js';
+import {manifest, version, paths, storage, test} from './config.js';
 
 // optional
 //import '../../lib/pouchdb-support.js';
@@ -30,11 +30,11 @@ const client = window.DeviceClient || {};
   // if remote DevTools are requested, wait for connect
   await DevtoolsSupport();
   // configure pipes and get a bus
-  const bus = await initPipe(client, paths, storage);
+  const bus = await initPipe(client, paths, storage, manifest);
   // export bus
   window.ShellApi = bus;
   // post startup shell initializations.
-  await initArcs(storage, bus);
+  await initArcs(storage, bus, manifest);
   // run smokeTest if requested
   if (test) {
     smokeTest(bus);


### PR DESCRIPTION
Note this doesn't mean each client needs to add their manifests before calling. The demos each run ArcsService in their own activities so it's find for them to provide the manifests. If we have multiple clients using Arcs, a loader service (same service which registers necessary renderers like NotificaitonRenderer) will find and provided all the recipes.