### PR TITLE
Make the pipe-shell deploy script quieter

### DIFF
--- a/shells/pipes-shell/web/deploy/deploy.sh
+++ b/shells/pipes-shell/web/deploy/deploy.sh
@@ -1,4 +1,4 @@
-#!/bin/sh 
+#!/bin/sh
 # target
 rm -rf dist
 mkdir dist
@@ -10,6 +10,4 @@ ln -s $PWD/../../../../particles $PWD/dist/particles
 # worker build
 cp -fR ../../../lib/build/worker.js dist/
 # collate sources
-echo packing...
-npx webpack
-echo done.
+npx webpack --display=errors-only


### PR DESCRIPTION
Should now only output on errors. Useful for keeping noise out of our
bazel builds.