### PR TITLE
Dynamic configuration for pipes-shell

### DIFF
--- a/shells/broker-shell/index.js
+++ b/shells/broker-shell/index.js
@@ -10,9 +10,29 @@
 
 import {connectToPlatform, waitForRenderSurface, addToast} from './lib/platform.js';
 
+const config = {
+  rootPath: '.',
+  urlMap: {
+    'https://$arcs/': `../../../`,
+    'https://$particles/': `../../../particles/`,
+    'https://$build/': `../../lib/build/`
+  },
+  storage: 'volatile://',
+  manifest: `
+import 'https://$particles/Pipes/Pipes.arcs'
+import 'https://$particles/Restaurants/Restaurants.arcs'
+import 'https://$particles/Notification/Notification.arcs'
+  `
+};
+
 const Application = {
   ready() {
+    // message channel is ready, time to configure
+    this.send({message: 'configure', config});
+  },
+  context() {
     // testing ingestion
+    this.send({message: 'enableIngestion'});
     this.send({message: 'ingest', entity: {type: 'person', jsonData: `{"name": "John Hancock"}`}});
     setTimeout(() => {
       this.ingestTid = this.send({message: 'spawn', recipe: 'PersonAutofill'});

--- a/shells/broker-shell/lib/platform.js
+++ b/shells/broker-shell/lib/platform.js
@@ -20,19 +20,25 @@ export const connectToPlatform = async Application => {
     receive(json) {
       const packet = JSON.parse(json);
       console.log('RECEIVED: ', packet);
-      const delegate = dispatcher[packet.message] || Application.receive.bind(Application);
-      delegate(packet);
+      //const delegate = dispatcher[packet.message] || Application.receive.bind(Application);
+      const delegate = dispatcher[packet.message];
+      if (delegate) {
+        delegate(packet);
+      } else {
+        const delegate = Application[packet.message];
+        if (delegate) {
+          delegate.call(Application, packet);
+        }
+      }
     }
   };
   // bus packet handlers
   const dispatcher = {
     ready(packet) {
-      if (packet.message === 'ready') {
-        // create function which sends to Arcs runtime
-        Application.send = msg => arcsProcess.ShellApi.receive(msg);
-        // forward signal
-        Application.ready(packet);
-      }
+      // create function which sends to Arcs runtime
+      Application.send = msg => arcsProcess.ShellApi.receive(msg);
+      // forward signal
+      Application.ready(packet);
     },
     // hand all slot rendering requests to a uiBroker (we could differentiate
     // by modality here, or let uiBroker do it; these decisions can be composed)

--- a/shells/pipes-shell/node/node.js
+++ b/shells/pipes-shell/node/node.js
@@ -10,16 +10,18 @@
 
  // configure
 import '../../lib/platform/loglevel-node.js';
-import {version, paths, storage, test} from './config.js';
+import {version, test, paths, storage, manifest} from './config.js';
 
 // optional
 //import '../../lib/pouchdb-support.js';
 //import '../../lib/firebase-support.js';
 //import {DevtoolsSupport} from '../../lib/devtools-support.js';
 
-// dependencies
-import {initPipe, initArcs} from '../pipe.js';
-import {smokeTest} from '../smoke.js';
+// main dependencies
+import {Bus} from '../source/bus.js';
+import {busReady} from '../source/pipe.js';
+import {smokeTest} from '../source/smoke.js';
+import {dispatcher} from '../source/dispatcher.js';
 
 console.log(`${version} -- ${storage}`);
 
@@ -28,15 +30,14 @@ const client = global.DeviceClient || {};
 (async () => {
   // if remote DevTools are requested, wait for connect
   //await DevtoolsSupport();
-  // configure pipes and get a bus
-  const bus = await initPipe(client, paths, storage);
+  // create a bus
+  const bus = new Bus(dispatcher, client);
   // export bus
   global.ShellApi = bus;
-  // post startup shell initializations.
-  await initArcs(storage, bus);
+  busReady(bus);
   // run smokeTest if requested
   if (test) {
-    smokeTest(bus);
+    smokeTest(paths, storage, manifest, bus);
   }
 })();
 

--- a/shells/pipes-shell/source/smoke.js
+++ b/shells/pipes-shell/source/smoke.js
@@ -8,8 +8,23 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-export const smokeTest = async bus => {
+const defaultManifest = `
+// UIBroker/demo particles below here
+import 'https://$particles/Pipes/Pipes.arcs'
+//import 'https://$particles/Restaurants/Restaurants.arcs'
+import 'https://$particles/Notification/Notification.arcs'
+`;
+
+export const smokeTest = async (paths, storage, manifest, bus) => {
   const send = envelope => bus.receive(envelope);
+  // configure for smoke test
+  send({message: 'configure', config: {
+    rootPath: paths.root,
+    urlMap: paths.map,
+    storage,
+    manifest: defaultManifest
+  }});
+  //
   const enqueue = (tests, delay) => {
     if (tests.length) {
       console.warn(`busish: starting new task...(${tests.length} remaining)`);
@@ -44,6 +59,9 @@ export const smokeTest = async bus => {
   };
   //
   enqueue([
+    // waste 500ms so configuration can complete
+    // TODO(sjmiles): instead, wait for ready message
+    () => {},
     ingestionTest,
     autofillTest,
     notificationTest,

--- a/shells/pipes-shell/source/verbs/run-arc.js
+++ b/shells/pipes-shell/source/verbs/run-arc.js
@@ -17,7 +17,7 @@ import {portIndustry} from '../pec-port.js';
 const {log, warn} = logsFactory('pipe');
 
 // The implementation was forked from verbs/spawn.js
-export const runArc = async (msg, bus, runtime, env) => {
+export const runArc = async (msg, bus, runtime) => {
   const {recipe, arcId, storageKeyPrefix, pecId, particles} = msg;
   const action = runtime.context.allRecipes.find(r => r.name === recipe);
   if (!arcId) {
@@ -30,7 +30,7 @@ export const runArc = async (msg, bus, runtime, env) => {
   }
   const arc = runtime.runArc(arcId, storageKeyPrefix || 'volatile://', {
       fileName: './serialized.manifest',
-      pecFactories: [].concat([env.pecFactory], [portIndustry(bus, pecId)]),
+      pecFactories: [].concat([runtime.pecFactory], [portIndustry(bus, pecId)]),
       loader: runtime.loader,
       inspectorFactory: devtoolsArcInspectorFactory,
   });

--- a/shells/pipes-shell/web/config.js
+++ b/shells/pipes-shell/web/config.js
@@ -10,7 +10,8 @@
 
 const params = (new URL(document.location)).searchParams;
 
-export const manifest = (params.has('solo')) ? `import '${params.get('solo')}'` : null;
+export const manifest = (params.has('solo')) ? `import '${params.get('solo')}'` : '';
+
 export const test = params.has('test');
 
 export {paths} from './paths.js';

--- a/shells/pipes-shell/web/web.js
+++ b/shells/pipes-shell/web/web.js
@@ -10,17 +10,19 @@
 
 // configure
 import '../../lib/platform/loglevel-web.js';
-import {manifest, version, paths, storage, test} from './config.js';
+import {version, test, paths, storage, manifest} from './config.js';
 
 // optional
 //import '../../lib/pouchdb-support.js';
 //import '../../lib/firebase-support.js';
-//import '../../configuration/whitelisted.js';
 import {DevtoolsSupport} from '../../lib/devtools-support.js';
+//import '../../configuration/whitelisted.js';
 
 // main dependencies
-import {initPipe, initArcs} from '../source/pipe.js';
+import {Bus} from '../source/bus.js';
+import {busReady} from '../source/pipe.js';
 import {smokeTest} from '../source/smoke.js';
+import {dispatcher} from '../source/dispatcher.js';
 
 console.log(`${version} -- ${storage}`);
 
@@ -29,15 +31,14 @@ const client = window.DeviceClient || {};
 (async () => {
   // if remote DevTools are requested, wait for connect
   await DevtoolsSupport();
-  // configure pipes and get a bus
-  const bus = await initPipe(client, paths, storage, manifest);
+  // create a bus
+  const bus = new Bus(dispatcher, client);
   // export bus
   window.ShellApi = bus;
-  // post startup shell initializations.
-  await initArcs(storage, bus, manifest);
+  busReady(bus, {manifest});
   // run smokeTest if requested
   if (test) {
-    smokeTest(bus);
+    smokeTest(paths, storage, manifest, bus);
     // world's dumbest ui
     window.onclick = () => {
       bus.receive({message: 'ingest', entity: {type: 'notion', jsonData: 'Dogs are awesome'}});


### PR DESCRIPTION
See #3915

1. first message sent by `pipes-shell` is still `ready`, but now it's just a bare message to indicate pipe-shell has initialized (the _bus_ is ready).
2. `pipes-shell` listens for `configure` message, structured like this example:
```
{message: 'configure', config: {
  // path from pipes-shell CWD to Arcs root
  rootPath: '.', 
  // path-prefix macros
  urlMap: {
    'https://$internal/': 'file:///android_asset/',
    'https://$external/': {
      root: 'http://192.168.0.1:8080/',
      buildDir: 'bazel-bin/',
      buildOutputRegex: '\.wasm$',
    }
  },
  // default storage key
  storage: 'volatile://',
  // default context manifest
  manifest: `
import 'https://$particles/Pipes/Pipes.arcs'
import 'https://$particles/Restaurants/Restaurants.arcs'
import 'https://$particles/Notification/Notification.arcs'
  `
}});
```
3. `pipes-shell` is now configured with all verbs (`runArc`, etc.)
4. `pipes-shell` responds with `context` message that contains list of recipes and triggers in the Context (formerly sent by `ready`)
