### PR TITLE
Uncaught error when fetching the default manifest

### DIFF
--- a/shells/pipes-shell/web/config.js
+++ b/shells/pipes-shell/web/config.js
@@ -10,7 +10,7 @@
 
 const params = (new URL(document.location)).searchParams;
 
-export const manifest = (params.has('solo')) ? `import '${params.get('solo')}'` : null;
+export const manifest = (params.has('solo')) ? `import '${params.get('solo')}'` : undefined;
 export const test = params.has('test');
 
 export {paths} from './paths.js';


### PR DESCRIPTION
Uncaught (in promise) TypeError: Cannot read property 'charAt' of null
The error is raised when connecting device to remote pipes-shell via
the url: http://localhost:8786/shells/pipes-shell/web/deploy/dist/?

null is an object so the default value of function parameter would
always take the null instead of the content of defaultManifest string
template.