### PR TITLE
Update sequence and multiplexing tests for post slandles syntax

### DIFF
--- a/particles/List/source/SlandleSyntaxMultiplexer.js
+++ b/particles/List/source/SlandleSyntaxMultiplexer.js
@@ -10,17 +10,17 @@
 'use strict';
 
 defineParticle(({Particle, MultiplexerDomParticle}) => {
-  return class SlandleMultiplexer extends MultiplexerDomParticle {
+  return class SlandleSyntaxMultiplexer extends MultiplexerDomParticle {
     constructInnerRecipe(hostedParticle, item, itemHandle, slot, other) {
       return Particle.buildManifest`
 ${hostedParticle}
 recipe
   handle1: use '${itemHandle._id}'
   ${other.handles.join('\n')}
-  handle2: \`slot '${slot.id}'
+  handle2: slot '${slot.id}'
   ${hostedParticle.name}
     ${hostedParticle.handleConnections[0].name}: reads handle1
-    ${hostedParticle.handleConnections[1].name}: \`consumes handle2
+    ${hostedParticle.handleConnections[1].name}: consumes handle2
     ${other.connections.join('\n')}
   `;
     }

--- a/src/planning/strategies/convert-constraints-to-connections.ts
+++ b/src/planning/strategies/convert-constraints-to-connections.ts
@@ -144,6 +144,7 @@ export class ConvertConstraintsToConnections extends Strategy {
               return 'any';
             }
             if (a !== b) {
+              // TODO(jopra): Double check this, should require both directions.
               return 'any';
             }
             return a;


### PR DESCRIPTION
This fixes potential test failures that would have started when preSlandlesSyntax is disabled (not currently set).

It also adds a comment on a potentially wrong direction unification.