### PR TITLE
Moves bundled manifest files under the "arcs" subdirectory by default

### DIFF
--- a/third_party/java/arcs/build_defs/internal/manifest.bzl
+++ b/third_party/java/arcs/build_defs/internal/manifest.bzl
@@ -47,9 +47,14 @@ def _generate_root_manifest_content(label, input_files):
 def _arcs_manifest_bundle(ctx):
     name = ctx.label.name
     input_files = ctx.files.deps
+    folder = ctx.attr.folder
+
+    # Make sure folder ends with a slash
+    if folder:
+        folder += "/"
 
     # Generate root manifest.
-    root_manifest_filename = name + ".arcs"
+    root_manifest_filename = folder + name + ".arcs"
     root_manifest_file = ctx.actions.declare_file(root_manifest_filename)
     ctx.actions.write(
         output = root_manifest_file,
@@ -65,7 +70,7 @@ def _arcs_manifest_bundle(ctx):
     # manifest bundle is included in an Android assets folder, all the relative
     # paths will be preserved inside the assets folder (i.e. assets/d/e/f).
     for input_file in input_files:
-        output_relative_path = input_file.short_path
+        output_relative_path = folder + input_file.short_path
         output_file = ctx.actions.declare_file(output_relative_path)
         ctx.actions.run_shell(
             outputs = [output_file],
@@ -86,6 +91,11 @@ arcs_manifest_bundle = rule(
     implementation = _arcs_manifest_bundle,
     attrs = {
         "deps": attr.label_list(allow_files = True),
+        "folder": attr.string(
+            default = "arcs",
+            doc = """Optional folder/path under which to nest the bundled
+            manifest files. Can be empty""",
+        ),
     },
     doc = """Bundles up a number of arcs_manifest rules into a single filegroup.
 


### PR DESCRIPTION
This mimics the behaviour introduced in #3891, for #3819.

(Previously it was taking `//particles/foo/bar.arcs` and putting it inside assets.zip with the path `assets.zip/particles/foo/bar.arcs`. Now it's putting it at `assets.zip/arcs/particles/foo/bar.arcs`)