### PR TITLE
Warn about circular dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
   "dependencies": {
     "@tensorflow/tfjs": "^1.2.9",
     "assert": "^1.4.1",
+    "circular-dependency-plugin": "^5.2.0",
     "esm": "^3.0.84",
     "firebase": "^6.0.4",
     "idb": "^2.1.3",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,8 +9,13 @@
  */
 const path = require('path');
 const webpack = require('webpack');
+const CircularDependencyPlugin = require('circular-dependency-plugin')
 
 const lib = './shells/lib';
+
+// Decrease MAX_CYCLES every time you eliminate circular dependencies from the codebase.
+const MAX_CYCLES = 11;
+let numCyclesDetected = 0;
 
 module.exports = {
   mode: 'none',
@@ -37,6 +42,27 @@ module.exports = {
        // build/worker.js needs the stub version of this file
        /devtools-channel-web.js/,
        resource =>  resource.request = resource.request.replace(/web/, `stub`)
-    )
+    ),
+    new CircularDependencyPlugin({
+      exclude: /node_modules/,
+      onStart() {
+        numCyclesDetected = 0;
+      },
+      onDetected({module, paths, compilation}) {
+        numCyclesDetected++;
+        compilation.warnings.push(new Error(paths.join(' -> ')))
+      },
+      onEnd({compilation}) {
+        if (numCyclesDetected > MAX_CYCLES) {
+          compilation.errors.push(new Error(
+            `Detected ${numCyclesDetected} cycles which exceeds configured limit of ${MAX_CYCLES}`
+          ));
+        }
+      },
+      allowAsyncCycles: false,
+      // failOnError should replace the onStart(), onDetected() and onEnd() methods
+      // once we we eliminate circular dependencies.
+      // failOnError: true,
+    })
   ]
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,12 +9,12 @@
  */
 const path = require('path');
 const webpack = require('webpack');
-const CircularDependencyPlugin = require('circular-dependency-plugin')
+const CircularDependencyPlugin = require('circular-dependency-plugin');
 
 const lib = './shells/lib';
 
 // Decrease MAX_CYCLES every time you eliminate circular dependencies from the codebase.
-const MAX_CYCLES = 11;
+const MAX_CYCLES = 15;
 let numCyclesDetected = 0;
 
 module.exports = {
@@ -50,7 +50,7 @@ module.exports = {
       },
       onDetected({module, paths, compilation}) {
         numCyclesDetected++;
-        compilation.warnings.push(new Error(paths.join(' -> ')))
+        compilation.warnings.push(new Error(paths.join(' -> ')));
       },
       onEnd({compilation}) {
         if (numCyclesDetected > MAX_CYCLES) {


### PR DESCRIPTION
Currently allows the 15 that are present.