### PR TITLE
Create new deploy script for pipes-shell on Android

### DIFF
--- a/javaharness/.bazelproject
+++ b/javaharness/.bazelproject
@@ -5,9 +5,6 @@ directories:
 targets:
   //javaharness/java/...
   //javaharness/javatests/...
-  # This symlinked directory contains BUILD files which aren't relevant and
-  # which won't resolve correctly:
-  -javaharness/java/arcs/pipes-shell/...
 
 additional_languages:
   # kotlin

--- a/javaharness/java/arcs/android/BUILD
+++ b/javaharness/java/arcs/android/BUILD
@@ -11,9 +11,7 @@ android_library(
     name = "android",
     srcs = glob(["*.java"]),
     assets = [
-        # And example manifest bundle.
-        # TODO: Include the actual particles needed by the javaharness app.
-        "//particles/Native/Wasm:bundle",
+        "//third_party/javascript/arcs:pipes-shell-assets",
     ],
     assets_dir = "",
     exports_manifest = 1,
@@ -23,21 +21,10 @@ android_library(
     manifest = "AndroidManifest.xml",
     resource_files = glob(["res/**"]),
     deps = [
-        ":pipe-shell-assets",
         "//javaharness/java/arcs/api:api-android",
         "//third_party/java/auto:auto_value",
         "//third_party/java/dagger",
         "//third_party/java/flogger:android",
         "//third_party/java/jsr330_inject",
     ],
-)
-
-# Combines all of the pipes-shell compiled source into an Android assets folder.
-android_library(
-    name = "pipe-shell-assets",
-    assets = [
-        "//third_party/javascript/arcs:pipes-shell-assets",
-    ],
-    assets_dir = "",
-    manifest = "AndroidManifest.xml",
 )

--- a/javaharness/java/arcs/android/demo/BUILD
+++ b/javaharness/java/arcs/android/demo/BUILD
@@ -2,6 +2,7 @@ licenses(["notice"])
 
 load("//tools/build_defs/android:rules.bzl", "android_binary")
 
+# TODO: Add manifest_bundle assets for all the particles needed in the demo app.
 android_binary(
     name = "demo",
     srcs = glob(["*.java"]),

--- a/shells/pipes-shell/BUILD
+++ b/shells/pipes-shell/BUILD
@@ -1,20 +1,17 @@
 load("//third_party/java/arcs/build_defs:run_in_repo.bzl", "run_in_repo")
 
-# Webpacks the pipes-shell code for web, by running the deploy.sh script. The
-# result gets copied into a pipes_shell_web_dist folder in bazel-bin.
+# Webpacks the pipes-shell code for Android, by running android_deploy.sh. Puts
+# it under an arcs/ subfolder.
 run_in_repo(
-    name = "pipes_shell_web",
+    name = "pipes_shell_android",
     srcs = glob(["**"]),
     outs = ["arcs"],
-    cmd = "set OLDPWD=$PWD && cd $PWD/$(dirname $(location //shells/pipes-shell:web_deploy_bin)) && " +
-          "./deploy.sh && " +
-          "cp -r dist $OLDPWD/{OUT}",
+    cmd = "$(location :android_deploy_bin) $(location :arcs)",
     progress_message = "Webpacking pipes-shell",
     visibility = ["//visibility:public"],
     deps = [
-        ":web_deploy_bin",
+        ":android_deploy_bin",
         ":web_deploy_srcs",
-        "//tools:sigh_webpack",
     ],
 )
 
@@ -22,11 +19,11 @@ filegroup(
     name = "web_deploy_srcs",
     srcs = glob(
         ["web/deploy/**"],
-        exclude = ["web/deploy/deploy.sh"],
+        exclude = ["web/deploy/android_deploy.sh"],
     ),
 )
 
 filegroup(
-    name = "web_deploy_bin",
-    srcs = ["web/deploy/deploy.sh"],
+    name = "android_deploy_bin",
+    srcs = ["web/deploy/android_deploy.sh"],
 )

--- a/shells/pipes-shell/web/deploy/android_deploy.sh
+++ b/shells/pipes-shell/web/deploy/android_deploy.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+# Deploy script for Android. Webpacks the pipes-shell code and copied only the
+# essential files into the given folder (command line arg is relative path).
+OUT_DIR="$PWD/$1"
+
+# cd to directory containing this script.
+cd "${0%/*}"
+
+# Webpack shell code.
+npx webpack --display=errors-only --output="$OUT_DIR/shell.js"
+
+# Copy over webpacked Arcs runtime.
+cp ../../../lib/build/worker.js "$OUT_DIR/worker.js"
+
+# Copy over shell html.
+cp source/index.html "$OUT_DIR/index.html"

--- a/third_party/javascript/arcs/BUILD
+++ b/third_party/javascript/arcs/BUILD
@@ -4,5 +4,5 @@ licenses(["notice"])
 
 alias(
     name = "pipes-shell-assets",
-    actual = "//shells/pipes-shell:pipes_shell_web",
+    actual = "//shells/pipes-shell:pipes_shell_android",
 )


### PR DESCRIPTION
This new script includes only the stuff that is strictly needed for
running the pipes-shell (i.e. webpacked shell code, webpacked arcs
runtime code, shell index.html), and notably does not include the entire
particles/ directory. It is up to the client to include the manifest
files it actually needs (via arcs_manifest/arcs_manifest_bundle rules).

For #3819