### PR TITLE
Bundles missing demo particles

### DIFF
--- a/javaharness/java/arcs/android/demo/BUILD
+++ b/javaharness/java/arcs/android/demo/BUILD
@@ -1,11 +1,16 @@
 licenses(["notice"])
 
 load("//tools/build_defs/android:rules.bzl", "android_binary")
+load(
+    "//third_party/java/arcs/build_defs:build_defs.bzl",
+    "arcs_manifest_bundle",
+)
 
-# TODO: Add manifest_bundle assets for all the particles needed in the demo app.
 android_binary(
     name = "demo",
     srcs = glob(["*.java"]),
+    assets = [":demo_manifest_bundle"],
+    assets_dir = "",
     dexopts = [
         "--min-sdk-version=29",
         "--target-sdk-version=29",
@@ -20,5 +25,13 @@ android_binary(
         "//third_party/java/dagger",
         "//third_party/java/flogger:android",
         "//third_party/java/jsr330_inject",
+    ],
+)
+
+arcs_manifest_bundle(
+    name = "demo_manifest_bundle",
+    deps = [
+        "//particles/PipeApps:AndroidAutofill",
+        "//particles/PipeApps:RenderNotification",
     ],
 )

--- a/particles/PipeApps/AndroidAutofill.arcs
+++ b/particles/PipeApps/AndroidAutofill.arcs
@@ -5,7 +5,7 @@ schema AutofillRequest
   Text hint
 
 // An Android particle which powers the Android AutofillService.
-particle AutofillParticle in './source/AutofillParticle.java'
+particle AutofillParticle
   // TODO: Use a Singleton instead, when that is supported in Java.
   out [AutofillRequest] request
   consume root
@@ -31,7 +31,7 @@ recipe AndroidAutofill
     request <- request
     consume fillSlot as fillSlot
 
-particle CapturePerson in './source/CapturePerson.java'
+particle CapturePerson
   inout [Person] people
 
 recipe IngestPeople

--- a/particles/PipeApps/BUILD
+++ b/particles/PipeApps/BUILD
@@ -1,0 +1,29 @@
+load("//third_party/java/arcs/build_defs:build_defs.bzl", "arcs_manifest")
+
+package(default_visibility = ["//visibility:public"])
+
+arcs_manifest(
+    name = "IncomingEntity",
+    srcs = ["schemas/IncomingEntity.arcs"],
+)
+
+arcs_manifest(
+    name = "Person",
+    srcs = ["schemas/Person.arcs"],
+)
+
+arcs_manifest(
+    name = "AndroidAutofill",
+    srcs = ["AndroidAutofill.arcs"],
+    deps = [
+        ":IncomingEntity",
+        ":Person",
+        ":source/DummyAutofillResponder.js",
+    ],
+)
+
+arcs_manifest(
+    name = "RenderNotification",
+    srcs = ["RenderNotification.arcs"],
+    deps = [":source/RenderNotification.js"],
+)

--- a/src/tests/particles/particles-test.ts
+++ b/src/tests/particles/particles-test.ts
@@ -27,7 +27,11 @@ describe('Particle definitions', () => {
       it(`parses successfully: ${filename}`, async () => {
         const manifest = await Manifest.load(filename, loader);
         for (const particle of manifest.particles) {
-          assert.isNotNull(particle.implFile, `particle ${particle.name} specified with implementation found in ${particle.implFile}.`);
+          if (particle.implFile == null) {
+            // It's ok for some particles to not have implementation files (e.g.
+            // Android particles).
+            continue;
+          }
           if (particle.implFile.endsWith('.js')) {
             assert.isTrue(fs.existsSync(particle.implFile), `${particle.implFile} not found`);
           }

--- a/src/tools/manifest-checker.ts
+++ b/src/tools/manifest-checker.ts
@@ -39,7 +39,11 @@ async function checkManifest(src: string) {
   // Check particle impls can be loaded.
   for (const particle of manifest.particles) {
     const implFile = particle.implFile;
-    if (implFile.endsWith('.wasm')) {
+    if (!implFile) {
+      // Particle does not have an implementation. Might be an Android particle,
+      // so this is possibly fine. Just skip it.
+      continue;
+    } else if (implFile.endsWith('.wasm')) {
       await loader.loadWasmBinary(particle);
     } else {
       await loader.loadResource(implFile);


### PR DESCRIPTION
Fixes #3819

Bundles RenderNotification and AndroidAutofill particle definitions into
the Android demo app. As far as I know, these are the only particles
that are actually used.

(App is currently broken so it's hard to know...)

Bundled assets in the apk now looks like this:

```
$ unzip -l bazel-bin/javaharness/java/arcs/android/demo/demo.apk
Archive:  bazel-bin/javaharness/java/arcs/android/demo/demo.apk
  Length      Date    Time    Name
---------  ---------- -----   ----
[...]
      297  2010-01-01 00:00   assets/arcs/demo_manifest_bundle.arcs
     1342  2010-01-01 00:00   assets/arcs/index.html
     1030  2010-01-01 00:00   assets/arcs/particles/PipeApps/AndroidAutofill.arcs
      150  2010-01-01 00:00   assets/arcs/particles/PipeApps/RenderNotification.arcs
       64  2010-01-01 00:00   assets/arcs/particles/PipeApps/schemas/IncomingEntity.arcs
       97  2010-01-01 00:00   assets/arcs/particles/PipeApps/schemas/Person.arcs
     1655  2010-01-01 00:00   assets/arcs/particles/PipeApps/source/DummyAutofillResponder.js
     1399  2010-01-01 00:00   assets/arcs/particles/PipeApps/source/RenderNotification.js
  1813402  2010-01-01 00:00   assets/arcs/shell.js
   516152  2010-01-01 00:00   assets/arcs/worker.js
[...]
---------                     -------
  2676237                     28 files
```

You should be able to load the root manifest at
`file://android_assets/arcs/demo_manifest_bundle.arcs`