### PR TITLE
Unified types syntax (using TS + kotlin style)

### DIFF
--- a/src/dataflow/analysis/tests/analysis-test.ts
+++ b/src/dataflow/analysis/tests/analysis-test.ts
@@ -1392,7 +1392,7 @@ describe('FlowGraph validation', () => {
   it('SLANDLES SYNTAX supports datastore tag claims', Flags.withPostSlandlesSyntax(async () => {
     const graph = await buildFlowGraph(`
       schema MyEntity
-        Text text
+        text: Text
       resource MyResource
         start
         [{"text": "asdf"}]
@@ -1901,7 +1901,7 @@ describe('FlowGraph validation', () => {
     it('SLANDLES SYNTAX succeeds when the data store identified by name is present', Flags.withPostSlandlesSyntax(async () => {
       const graph = await buildFlowGraph(`
         schema MyEntity
-          Text text
+          text: Text
         resource MyResource
           start
           [{"text": "asdf"}]
@@ -1938,7 +1938,7 @@ describe('FlowGraph validation', () => {
     it('SLANDLES SYNTAX succeeds when the data store identified by ID is present', Flags.withPostSlandlesSyntax(async () => {
       const graph = await buildFlowGraph(`
         schema MyEntity
-          Text text
+          text: Text
         resource MyResource
           start
           [{"text": "asdf"}]
@@ -1976,7 +1976,7 @@ describe('FlowGraph validation', () => {
     it('SLANDLES SYNTAX succeeds for a negated store check when the store is different', Flags.withPostSlandlesSyntax(async () => {
       const graph = await buildFlowGraph(`
         schema MyEntity
-          Text text
+          text: Text
         resource MyResource
           start
           [{"text": "asdf"}]
@@ -2016,7 +2016,7 @@ describe('FlowGraph validation', () => {
     it('SLANDLES SYNTAX fails for a negated store check when the store is the same', Flags.withPostSlandlesSyntax(async () => {
       const graph = await buildFlowGraph(`
         schema MyEntity
-          Text text
+          text: Text
         resource MyResource
           start
           [{"text": "asdf"}]
@@ -2098,7 +2098,7 @@ describe('FlowGraph validation', () => {
     it('SLANDLES SYNTAX fails when the data store is not connected', Flags.withPostSlandlesSyntax(async () => {
       assertThrowsAsync(async () => await buildFlowGraph(`
         schema MyEntity
-          Text text
+          text: Text
         resource MyResource
           start
           [{"text": "asdf"}]
@@ -2136,7 +2136,7 @@ describe('FlowGraph validation', () => {
     it('SLANDLES SYNTAX fails when the wrong data store is present', Flags.withPostSlandlesSyntax(async () => {
       const graph = await buildFlowGraph(`
         schema MyEntity
-          Text text
+          text: Text
         resource MyResource
           start
           [{"text": "asdf"}]

--- a/src/planning/tests/planner-test.ts
+++ b/src/planning/tests/planner-test.ts
@@ -842,14 +842,14 @@ describe('Automatic resolution', () => {
   it('SLANDLES SYNTAX coalesces recipes to resolve connections', Flags.withPostSlandlesSyntax(async () => {
     const result = await verifyResolvedPlan(`
       schema Thing
-        Text id
+        id: Text
       schema Product extends Thing
-        Text name
+        name: Text
       schema Other
-        Number count
+        count: Number
       schema Location
-        Number lat
-        Number lng
+        lat: Number
+        lng: Number
 
       particle A
         product: writes Product
@@ -857,7 +857,7 @@ describe('Automatic resolution', () => {
         thing: reads Thing
         other: writes Other
       particle C
-        something: reads * {Number count}
+        something: reads * {count: Number}
         location: reads Location
       particle D
         location: reads writes Location
@@ -881,7 +881,7 @@ describe('Automatic resolution', () => {
     assert.strictEqual(`recipe
   handle0: create // ~
   handle1: create // ~
-  handle2: create // Location {Number lat, Number lng}
+  handle2: create // Location {lat: Number, lng: Number}
   A as particle0
     product: writes handle0
   B as particle1

--- a/src/runtime/manifest-parser.peg
+++ b/src/runtime/manifest-parser.peg
@@ -1413,12 +1413,23 @@ SchemaInline
   }
 
 SchemaInlineField
-  = type:(SchemaType whiteSpace)? name:fieldName
+  = preSlandlesType:(SchemaType whiteSpace)? name:fieldName //type:(':' whiteSpace? SchemaType)?
   {
+    let type = null;
+    if (type && preSlandlesType) {
+      error('cannot provide a type using both preslandles syntax and unification syntax for SchemaInlineField.');
+    }
+    if (preSlandlesType) {
+      requireUsePreSlandleSyntax();
+      type = optional(preSlandlesType, ty => ty[0], null);
+    } else if (type) {
+      requireUsePostSlandleSyntax();
+      type = optional(type, ty => ty[2], null);
+    }
     return toAstNode<AstNode.SchemaInlineField>({
       kind: 'schema-inline-field',
       name,
-      type: optional(type, type => type[0], null),
+      type
     });
   }
 
@@ -1463,6 +1474,7 @@ SchemaItem
   = SchemaField
   / Description
 
+  // = field:SchemaInlineField eolWhiteSpace
 SchemaField
   = type:SchemaType whiteSpace name:fieldName eolWhiteSpace
   {

--- a/src/runtime/manifest-parser.peg
+++ b/src/runtime/manifest-parser.peg
@@ -1592,7 +1592,7 @@ lowerIdent "a lowercase identifier (e.g. foo)"
 unsafeLowerIdent "a lowercase identifier or keyword"
   = [a-z][a-z0-9_]i* &([^a-zA-Z0-9_] / !.)  // '!.' matches end-of-input
   { return text(); }
-fieldName "a field name (e.g. foo9)" // Current handle and formFactor.
+fieldName "a field name (e.g. foo9)" // Current handle, formFactor or any entity field.
   = [a-z][a-z0-9_]i* { return text(); }
 dottedName "a name conforming to the rules of an android app name, per https://developer.android.com/guide/topics/manifest/manifest-element.html#package"
   = $ (simpleName ("." simpleName)*) // Note that a single simpleName matches too

--- a/src/runtime/manifest-parser.peg
+++ b/src/runtime/manifest-parser.peg
@@ -1413,9 +1413,8 @@ SchemaInline
   }
 
 SchemaInlineField
-  = preSlandlesType:(SchemaType whiteSpace)? name:fieldName //type:(':' whiteSpace? SchemaType)?
+  = preSlandlesType:(SchemaType whiteSpace)? name:fieldName type:(':' whiteSpace? SchemaType)?
   {
-    let type = null;
     if (type && preSlandlesType) {
       error('cannot provide a type using both preslandles syntax and unification syntax for SchemaInlineField.');
     }
@@ -1474,15 +1473,14 @@ SchemaItem
   = SchemaField
   / Description
 
-  // = field:SchemaInlineField eolWhiteSpace
 SchemaField
-  = type:SchemaType whiteSpace name:fieldName eolWhiteSpace
+  = field:SchemaInlineField eolWhiteSpace
   {
-    return toAstNode<AstNode.SchemaField>({
-      kind: 'schema-field',
-      type,
-      name,
-    });
+    if (!field.type) {
+      expected('a type (required for schema fields)');
+    }
+    field.kind = 'schema-field';
+    return toAstNode<AstNode.SchemaField>(field);
   }
 
 SchemaType

--- a/src/runtime/tests/artifacts/SLANDLEStest-particles.arcs
+++ b/src/runtime/tests/artifacts/SLANDLEStest-particles.arcs
@@ -6,9 +6,9 @@
 // http://polymer.github.io/PATENTS.txt
 
 schema Foo
-  Text value
+  value: Text
 schema Bar
-  Text value
+  value: Text
 schema Far
 
 particle SlandleTestParticle in 'test-particle.js'

--- a/src/runtime/tests/interface-info-test.ts
+++ b/src/runtime/tests/interface-info-test.ts
@@ -20,7 +20,7 @@ describe('interface', () => {
   it('SLANDLES SYNTAX round trips interface info', Flags.withPostSlandlesSyntax(async () => {
     const interfStr = `interface HostedInterface
   reads ~a
-  name: writes Text {Text name}
+  name: writes Text {name: Text}
   root: consumes? Slot
   other: provides [Slot]`;
     const manifest = await Manifest.parse(interfStr);

--- a/src/runtime/tests/manifest-test.ts
+++ b/src/runtime/tests/manifest-test.ts
@@ -35,7 +35,58 @@ function verifyPrimitiveType(field, type) {
 }
 
 describe('manifest', () => {
-  it('can parse a manifest containing a recipe', async () => {
+  it('SLANDLES SYNTAX can parse a manifest containing a recipe', Flags.withPostSlandlesSyntax(async () => {
+    const manifest = await Manifest.parse(`
+      schema S
+        t: Text
+
+        description \`one-s\`
+          plural \`many-ses\`
+          value \`s:\${t}\`
+      particle SomeParticle &work in 'some-particle.js'
+        someParam: writes S
+
+      recipe SomeRecipe &someVerb1 &someVerb2
+        map #someHandle
+        handle0: create #newHandle
+        SomeParticle
+          someParam: writes #tag
+        description \`hello world\`
+          handle0 \`best handle\``);
+    const verify = (manifest: Manifest) => {
+      const particle = manifest.particles[0];
+      assert.strictEqual('SomeParticle', particle.name);
+      assert.deepEqual(['work'], particle.verbs);
+      const recipe = manifest.recipes[0];
+      assert(recipe);
+      assert.strictEqual('SomeRecipe', recipe.name);
+      assert.deepEqual(['someVerb1', 'someVerb2'], recipe.verbs);
+      assert.sameMembers(manifest.findRecipesByVerb('someVerb1'), [recipe]);
+      assert.sameMembers(manifest.findRecipesByVerb('someVerb2'), [recipe]);
+      assert.lengthOf(recipe.particles, 1);
+      assert.lengthOf(recipe.handles, 2);
+      assert.strictEqual(recipe.handles[0].fate, 'map');
+      assert.strictEqual(recipe.handles[1].fate, 'create');
+      assert.lengthOf(recipe.handleConnections, 1);
+      assert.sameMembers(recipe.handleConnections[0].tags, ['tag']);
+      assert.lengthOf(recipe.patterns, 1);
+      assert.strictEqual(recipe.patterns[0], 'hello world');
+      assert.strictEqual(recipe.handles[1].pattern, 'best handle');
+      const type = recipe.handleConnections[0]['_resolvedType'];
+      assert.lengthOf(Object.keys(manifest.schemas), 1);
+      const schema = Object.values(manifest.schemas)[0] as Schema;
+      assert.lengthOf(Object.keys(schema.description), 3);
+      assert.deepEqual(Object.keys(schema.description), ['pattern', 'plural', 'value']);
+    };
+    verify(manifest);
+    // TODO(dstockwell): The connection between particles and schemas does
+    //                   not roundtrip the same way.
+    const type = manifest.recipes[0].handleConnections[0].type;
+    assert.strictEqual('one-s', type.toPrettyString());
+    assert.strictEqual('many-ses', type.collectionOf().toPrettyString());
+    verify(await Manifest.parse(manifest.toString(), {}));
+  }));
+  it('can parse a manifest containing a recipe', Flags.withPreSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
       schema S
         Text t
@@ -84,7 +135,7 @@ describe('manifest', () => {
     assert.strictEqual('one-s', type.toPrettyString());
     assert.strictEqual('many-ses', type.collectionOf().toPrettyString());
     verify(await Manifest.parse(manifest.toString(), {}));
-  });
+  }));
   it('SLANDLES SYNTAX can parse a manifest containing a particle specification', Flags.withPostSlandlesSyntax(async () => {
     const schemaStr = `
 schema Product

--- a/src/runtime/tests/type-test.ts
+++ b/src/runtime/tests/type-test.ts
@@ -303,7 +303,7 @@ describe('types', () => {
       const iface = InterfaceType.make('i', [{type: entity, name: 'foo'}, {type: variable}], [{name: 'x', direction: 'consume'}]);
       assert.strictEqual(iface.interfaceInfo.toString(),
 `interface i
-  foo: any Foo {Text value}
+  foo: any Foo {value: Text}
   any ~a
   x: consumes? Slot`);
     }));

--- a/src/runtime/type.ts
+++ b/src/runtime/type.ts
@@ -153,8 +153,8 @@ export class Schema {
   }
 
   equals(otherSchema: Schema): boolean {
+    // TODO(cypher1): Check equality without calling contains.
     return this === otherSchema || (this.name === otherSchema.name
-       // TODO(cypher1): Check equality without calling contains.
        && this.isMoreSpecificThan(otherSchema)
        && otherSchema.isMoreSpecificThan(this));
   }
@@ -209,16 +209,26 @@ export class Schema {
     };
   }
 
+  // TODO(jopra): Enforce that 'type' of a field is a Type.
+  // tslint:disable-next-line: no-any
+  static fieldToString([name, type]: [string, any]) {
+    const typeStr = Schema._typeString(type);
+    if (Flags.defaultToPreSlandlesSyntax) {
+      return `${typeStr} ${name}`;
+    }
+    return `${name}: ${typeStr}`;
+  }
+
   toInlineSchemaString(options?: {hideFields?: boolean}): string {
     const names = this.names.join(' ') || '*';
-    const fields = Object.entries(this.fields).map(([name, type]) => `${Schema._typeString(type)} ${name}`).join(', ');
+    const fields = Object.entries(this.fields).map(Schema.fieldToString).join(', ');
     return `${names} {${fields.length > 0 && options && options.hideFields ? '...' : fields}}`;
   }
 
   toManifestString(): string {
     const results:string[] = [];
     results.push(`schema ${this.names.join(' ')}`);
-    results.push(...Object.entries(this.fields).map(([name, type]) => `  ${Schema._typeString(type)} ${name}`));
+    results.push(...Object.entries(this.fields).map(f => `  ${Schema.fieldToString(f)}`));
     if (Object.keys(this.description).length > 0) {
       results.push(`  description \`${this.description.pattern}\``);
       for (const name of Object.keys(this.description)) {

--- a/src/runtime/type.ts
+++ b/src/runtime/type.ts
@@ -24,7 +24,7 @@ import {CRDTEntity, SingletonEntityModel, CollectionEntityModel} from './crdt/cr
 import {CollectionHandle, SingletonHandle, Handle} from './storageNG/handle.js';
 import {ParticleExecutionContext} from './particle-execution-context.js';
 import {Referenceable} from './crdt/crdt-collection.js';
-
+import {Flags} from './flags.js';
 
 export class Schema {
   readonly names: string[];


### PR DESCRIPTION
Updates the post slandles syntax to use typescript style type annotations:

Schemas now look like:
`
schema Foo
  field: Type
  bar: Ref<* {name: Text}>
`
and Inline schemas like:
`
Foo {field: Type, bar: Ref<* {name: Text}>}
`