### PR TITLE
Add --incompatible_depset_is_not_iterable=false flag to javaharness .…

### DIFF
--- a/javaharness/.bazelproject
+++ b/javaharness/.bazelproject
@@ -10,3 +10,6 @@ additional_languages:
   # kotlin
 
 android_sdk_platform: android-29
+
+build_flags:
+  --incompatible_depset_is_not_iterable=false


### PR DESCRIPTION
…bazelproject file

This fixes an error when you try to sync in Android Studio.

```
in @intellij_aspect//:intellij_info_bundled.bzl%intellij_info_aspect aspect on android_binary rule //javaharness/java/arcs/android/demo:demo:
Traceback (most recent call last):
	File "/Users/csilvestrini/dev/arcs/javaharness/java/arcs/android/demo/BUILD", line 9
		@intellij_aspect//:intellij_info_bundled.bzl%intellij_info_aspect(...)
	File "/private/var/tmp/_bazel_csilvestrini/7ad377ede00394dd6a9261e364bb67f4/external/intellij_aspect/intellij_info_bundled.bzl", line 54, in _aspect_impl
		intellij_info_aspect_impl(<3 more arguments>)
	File "/private/var/tmp/_bazel_csilvestrini/7ad377ede00394dd6a9261e364bb67f4/external/intellij_aspect/intellij_info_impl.bzl", line 895, in intellij_info_aspect_impl
		collect_android_info(target, <5 more arguments>)
	File "/private/var/tmp/_bazel_csilvestrini/7ad377ede00394dd6a9261e364bb67f4/external/intellij_aspect/intellij_info_impl.bzl", line 706, in collect_android_info
		get_res_artifacts(<2 more arguments>)
	File "/private/var/tmp/_bazel_csilvestrini/7ad377ede00394dd6a9261e364bb67f4/external/intellij_aspect/intellij_info_impl.bzl", line 118, in get_res_artifacts
		for file in resource.files: ...
type 'depset' is not iterable. Use the `to_list()` method to get a list. Use --incompatible_depset_is_not_iterable=false to temporarily disable this check.
```