### PR TITLE
Remove `shells/lib/utils.js` dependency from `schema2base.ts`

### DIFF
--- a/src/platform/pec-industry-web.ts
+++ b/src/platform/pec-industry-web.ts
@@ -8,9 +8,12 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
+import {PecFactory} from '../runtime/particle-execution-context.js';
+import {Id, IdGenerator} from '../runtime/id.js';
+
 const WORKER_PATH = `https://$build/worker.js`;
 
-export const pecIndustry = loader => {
+export const pecIndustry = (loader): PecFactory => {
   // worker paths are relative to worker location, remap urls from there to here
   const remap = expandUrls(loader.urlMap);
   // get real path from meta path
@@ -19,7 +22,7 @@ export const pecIndustry = loader => {
   let workerBlobUrl;
   loader.provisionObjectUrl(workerUrl).then((url: string) => workerBlobUrl = url);
   // return a pecfactory
-  return id => {
+  const factory = (id: Id, idGenerator?: IdGenerator) => {
     if (!workerBlobUrl) {
       console.warn('workerBlob not available, falling back to network URL');
     }
@@ -28,6 +31,9 @@ export const pecIndustry = loader => {
     worker.postMessage({id: `${id}:inner`, base: remap, logLevel: window['logLevel']}, [channel.port1]);
     return channel.port2;
   };
+  // TODO(sjmiles): PecFactory type is defined against custom `MessageChannel` and `MessagePort` objects, not the
+  // browser-standard objects used here. We need to clean this up, it's only working de facto.
+  return factory as unknown as PecFactory;
 };
 
 const expandUrls = urlMap => {

--- a/src/platform/pec-industry.ts
+++ b/src/platform/pec-industry.ts
@@ -1,0 +1,10 @@
+/**
+ * @license
+ * Copyright 2019 Google LLC.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+export * from './pec-industry-web.js';

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -70,9 +70,10 @@ export class Runtime {
 
   /**
    * `Runtime.getRuntime()` returns the most recently constructed Runtime object (or creates one),
-   * so one can call `init` to initialize a default environment without capturing the return value.
-   * Systems can use `Runtime.getRuntime()` to access the default environment instead of plumbing a
-   * `runtime` argument through numerous functions.
+   * so calling `init` establishes a default environment (capturing the return value is optional).
+   * Systems can use `Runtime.getRuntime()` to access this environment instead of plumbing `runtime`
+   * arguments through numerous functions.
+   * Some static methods on this class automatically use the default environment.
    */
   static init(root?: string, urls?: {}): Runtime {
     const map = {...Runtime.mapFromRootPath(root), ...urls};
@@ -82,6 +83,8 @@ export class Runtime {
   }
 
   static mapFromRootPath(root: string) {
+    // TODO(sjmiles): this is a commonly-used map, but it's not generic enough to live here.
+    // Shells that use this default should be provide it to `init` themselves.
     return {
       // important: path to `worker.js`
       'https://$build/': `${root}/shells/lib/build/`,
@@ -213,7 +216,11 @@ export class Runtime {
 
   async parse(content: string, options?): Promise<Manifest> {
     const {loader} = this;
+    // TODO(sjmiles): this method of generating a manifest id is ad-hoc,
+    // maybe should be using one of the id generators, or even better
+    // we could eliminate it if the Manifest object takes care of this.
     const id = `in-memory-${Math.floor((Math.random()+1)*1e6)}.manifest`;
+    // TODO(sjmiles): this is a virtual manifest, the fileName is invented
     const localOptions = {id, fileName: `./${id}`, loader};
     return Manifest.parse(content, {...localOptions, ...options});
   }

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -199,6 +199,28 @@ export class Runtime {
 
   // stuff the strategizer needs
 
+  // stuff from Shells/Utils
+
+  static async parseContent(content: string, options?): Promise<Manifest> {
+    const {loader} = this.getRuntime();
+    const id = `in-memory-${Math.floor((Math.random()+1)*1e6)}.manifest`;
+    const localOptions = {id, fileName: `./${id}`, loader};
+    return this._parse(content, localOptions, options);
+  }
+
+  static async parseFile(path, options) {
+    const {loader} = this.getRuntime();
+    const localOptions = {id: path, fileName: path, loader};
+    const content = await loader.loadResource(path);
+    return this._parse(content, localOptions, options);
+  }
+
+  static async _parse(content: string, localOptions?, options?) {
+    if (localOptions && options) {
+      localOptions = {...localOptions, ...options};
+    }
+    return Manifest.parse(content, localOptions);
+  }
 }
 
 let runtime: Runtime = null;

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -189,7 +189,7 @@ export class Runtime {
   }
 
   /**
-   * Load and parse a manifest from a resource (not stritcly a file) and return
+   * Load and parse a manifest from a resource (not strictly a file) and return
    * a Manifest object. The loader determines the semantics of the fileName. See
    * the Manifest class for details.
    */

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -68,10 +68,12 @@ export class Runtime {
     return new Runtime(new Loader(), FakeSlotComposer, context);
   }
 
-  // Note: `Runtime.getRuntime()` returns the most recently constructed Runtime object (or creates one),
-  // so one can call `init` to initialize the default environment without capturing the return value.
-  // Systems can use `Runtime.getRuntime()` to access the default environment instead of plumbing `runtime`
-  // arguments through all functions.
+  /**
+   * `Runtime.getRuntime()` returns the most recently constructed Runtime object (or creates one),
+   * so one can call `init` to initialize a default environment without capturing the return value.
+   * Systems can use `Runtime.getRuntime()` to access the default environment instead of plumbing a
+   * `runtime` argument through numerous functions.
+   */
   static init(root?: string, urls?: {}): Runtime {
     const map = {...Runtime.mapFromRootPath(root), ...urls};
     const loader = new Loader(map);
@@ -207,13 +209,17 @@ export class Runtime {
   // stuff from shells/lib/utils
 
   // TODO(sjmiles): there is redundancy vs `parse/loadManifest` above, but this is
-  // temporary until we polish this integration.
+  // temporary until we polish the Utils integration.
 
-  static async parse(content: string, options?): Promise<Manifest> {
-    const {loader} = this.getRuntime();
+  async parse(content: string, options?): Promise<Manifest> {
+    const {loader} = this;
     const id = `in-memory-${Math.floor((Math.random()+1)*1e6)}.manifest`;
     const localOptions = {id, fileName: `./${id}`, loader};
     return Manifest.parse(content, {...localOptions, ...options});
+  }
+
+  static async parse(content: string, options?): Promise<Manifest> {
+    return this.getRuntime().parse(content, options);
   }
 
 }

--- a/src/runtime/slot-composer.ts
+++ b/src/runtime/slot-composer.ts
@@ -43,7 +43,7 @@ export class SlotComposer {
    * and may contain:
    * - containerKind: the type of container wrapping each slot-context's container  (for example, div).
    */
-  constructor(options: SlotComposerOptions) {
+  constructor(options?: SlotComposerOptions) {
 //    assert(options.modalityHandler && options.modalityHandler.constructor === ModalityHandler,
 //           `Missing or invalid modality handler: ${options.modalityHandler}`);
     assert(options.modalityHandler,

--- a/src/runtime/ui-slot-composer.ts
+++ b/src/runtime/ui-slot-composer.ts
@@ -45,7 +45,7 @@ export class UiSlotComposer {
    * and may contain:
    * - containerKind: the type of container wrapping each slot-context's container  (for example, div).
    */
-  constructor(options: SlotComposerOptions) {
+  constructor(options?: SlotComposerOptions) {
     const opts = {
       containers: {'root': 'root-context'},
       modalityHandler: ModalityHandler.basicHandler,

--- a/src/tools/schema2base.ts
+++ b/src/tools/schema2base.ts
@@ -10,8 +10,8 @@
 import fs from 'fs';
 import path from 'path';
 import minimist from 'minimist';
-import {Utils} from '../../shells/lib/utils.js';
 import {Manifest} from '../runtime/manifest.js';
+import {Runtime} from '../runtime/runtime.js';
 import {SchemaGraph, SchemaNode} from './schema2graph.js';
 
 export interface ClassGenerator {
@@ -23,7 +23,7 @@ export abstract class Schema2Base {
   scope: string;
 
   constructor(readonly opts: minimist.ParsedArgs) {
-    Utils.init('../..');
+    Runtime.init('../..');
     this.scope = this.opts.package || 'arcs';
   }
 
@@ -46,7 +46,7 @@ export abstract class Schema2Base {
       return;
     }
 
-    const manifest = await Utils.parse(`import '${src}'`);
+    const manifest = await Runtime.parse(`import '${src}'`);
     if (manifest.errors.length) {
       return;
     }


### PR DESCRIPTION
Accomplished by moving some skills from shells/lib/utils to runtime/runtime, and using the latter for schema2base.ts.

This is a fix-it PR, but has synergy with a larger effort to subsume utils into runtime.