### PR TITLE
Round trip syntax tests

### DIFF
--- a/src/runtime/flags.ts
+++ b/src/runtime/flags.ts
@@ -26,24 +26,28 @@ export class Flags extends FlagDefaults {
     Object.assign(Flags, FlagDefaults);
   }
 
-  static withPreSlandlesSyntax<T>(f: () => Promise<T>): () => Promise<T> {
+  // tslint:disable-next-line: no-any
+  static withPreSlandlesSyntax<T, Args extends any[]>(f: (...args: Args) => Promise<T>): (...args: Args) => Promise<T> {
     return Flags.withFlags({parseBothSyntaxes: false, defaultToPreSlandlesSyntax: true}, f);
   }
-  static withPostSlandlesSyntax<T>(f: () => Promise<T>): () => Promise<T> {
+  // tslint:disable-next-line: no-any
+  static withPostSlandlesSyntax<T, Args extends any[]>(f: (...args: Args) => Promise<T>): (...args: Args) => Promise<T> {
     return Flags.withFlags({parseBothSyntaxes: false, defaultToPreSlandlesSyntax: false}, f);
   }
 
-  static withNewStorageStack<T>(f: () => Promise<T>): () => Promise<T> {
+  // tslint:disable-next-line: no-any
+  static withNewStorageStack<T, Args extends any[]>(f: (...args: Args) => Promise<T>): (...args: Args) => Promise<T> {
     return Flags.withFlags({useNewStorageStack: true}, f);
   }
 
   // For testing with a different set of flags to the default.
-  static withFlags<T>(args: Partial<typeof FlagDefaults>, f: () => Promise<T>): () => Promise<T> {
-    return async () => {
-      Object.assign(Flags, args);
+  // tslint:disable-next-line: no-any
+  static withFlags<T, Args extends any[]>(flagsSettings: Partial<typeof FlagDefaults>, f: (...args: Args) => Promise<T>): (...args: Args) => Promise<T> {
+    return async (...args) => {
+      Object.assign(Flags, flagsSettings);
       let res;
       try {
-        res = await f();
+        res = await f(...args);
       } finally {
         Flags.reset();
       }

--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -519,12 +519,12 @@ ${e.message}
       // when constructing manifest stores.
       await processItems('meta', meta => manifest.applyMeta(meta.items));
       // similarly, resources may be referenced from other parts of the manifest.
-      await processItems('resource', item => this._processResource(manifest, item));
-      await processItems('schema', item => this._processSchema(manifest, item));
-      await processItems('interface', item => this._processInterface(manifest, item));
-      await processItems('particle', item => this._processParticle(manifest, item, loader));
-      await processItems('store', item => this._processStore(manifest, item, loader));
-      await processItems('recipe', item => this._processRecipe(manifest, item));
+      await processItems('resource', item => Manifest._processResource(manifest, item));
+      await processItems('schema', item => Manifest._processSchema(manifest, item));
+      await processItems('interface', item => Manifest._processInterface(manifest, item));
+      await processItems('particle', item => Manifest._processParticle(manifest, item, loader));
+      await processItems('store', item => Manifest._processStore(manifest, item, loader));
+      await processItems('recipe', item => Manifest._processRecipe(manifest, item));
     } catch (e) {
       dumpErrors(manifest);
       throw processError(e, false);
@@ -782,7 +782,7 @@ ${e.message}
     if (recipeItem.verbs) {
       recipe.verbs = recipeItem.verbs;
     }
-    this._buildRecipe(manifest, recipe, recipeItem.items);
+    Manifest._buildRecipe(manifest, recipe, recipeItem.items);
   }
 
   private static _buildRecipe(manifest: Manifest, recipe: Recipe, recipeItems: AstNode.RecipeItem[]) {
@@ -1154,7 +1154,7 @@ ${e.message}
     if (items.require) {
       for (const item of items.require) {
         const requireSection = recipe.newRequireSection();
-        this._buildRecipe(manifest, requireSection, item.items);
+        Manifest._buildRecipe(manifest, requireSection, item.items);
       }
     }
   }

--- a/src/runtime/tests/arcfmt-test.ts
+++ b/src/runtime/tests/arcfmt-test.ts
@@ -1,0 +1,73 @@
+/**
+ * @license
+ * Copyright (c) 2019 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {Flags} from '../flags.js';
+import {Manifest} from '../manifest.js';
+import {assert} from '../../platform/chai-web.js';
+
+
+describe('Parser', () => {
+  describe('Stability over flags', () => {
+    const oldManifestStr =
+`schema S
+  Text t
+  description \`one-s\`
+    plural \`many-ses\`
+    value \`s:\${t}\`
+particle SomeParticle &work in 'some-particle.js'
+  out S {Text t} someParam
+  modality dom
+recipe SomeRecipe &someVerb1 &someVerb2
+  map #someHandle as handle1
+  create #newHandle as handle0
+  SomeParticle as particle0
+    someParam -> #tag
+  description \`hello world\`
+    handle0 \`best handle\``;
+    const newManifestStr =
+`schema S
+  t: Text
+  description \`one-s\`
+    plural \`many-ses\`
+    value \`s:\${t}\`
+particle SomeParticle &work in 'some-particle.js'
+  someParam: writes S {t: Text}
+  modality dom
+recipe SomeRecipe &someVerb1 &someVerb2
+  handle1: map #someHandle
+  handle0: create #newHandle
+  SomeParticle as particle0
+    someParam: writes #tag
+  description \`hello world\`
+    handle0 \`best handle\``;
+    it('can revert to an old syntax', async () => {
+      const newManifest = await Flags.withPostSlandlesSyntax(Manifest.parse)(newManifestStr);
+      await Flags.withPreSlandlesSyntax(async () => {
+        assert.strictEqual(newManifest.toString(), oldManifestStr, 'old syntax should convert to new syntax');
+      })();
+    });
+    it('can update from an old syntax', async () => {
+      const oldManifest = await Flags.withPreSlandlesSyntax(Manifest.parse)(oldManifestStr);
+      await Flags.withPostSlandlesSyntax(async () => {
+        assert.strictEqual(oldManifest.toString(), newManifestStr, 'new syntax should convert to old syntax');
+      })();
+    });
+    it('parser can read two different syntaxes', async () => {
+      const oldManifest = await Flags.withPreSlandlesSyntax(Manifest.parse)(oldManifestStr);
+      const newManifest = await Flags.withPostSlandlesSyntax(Manifest.parse)(newManifestStr);
+      await Flags.withPreSlandlesSyntax(async () => {
+        assert.strictEqual(oldManifest.toString(), newManifest.toString(), 'new syntax should convert to old syntax');
+      })();
+      await Flags.withPostSlandlesSyntax(async () => {
+        assert.strictEqual(newManifest.toString(), oldManifest.toString(), 'old syntax should convert to new syntax');
+      })();
+    });
+  });
+});


### PR DESCRIPTION
Tests that the parser and run time can (using flags) convert between new and old version of our syntaxes.

This may be useful for ensuring that we can automate some of the upcoming conversion work.

Waiting on https://github.com/PolymerLabs/arcs/pull/3936 before landing

