### PR TITLE
Adds `external` keyword to particle defn syntax

### DIFF
--- a/particles/PipeApps/AndroidAutofill.arcs
+++ b/particles/PipeApps/AndroidAutofill.arcs
@@ -5,7 +5,7 @@ schema AutofillRequest
   Text hint
 
 // An Android particle which powers the Android AutofillService.
-particle AutofillParticle
+external particle AutofillParticle
   // TODO: Use a Singleton instead, when that is supported in Java.
   out [AutofillRequest] request
   consume root
@@ -31,7 +31,7 @@ recipe AndroidAutofill
     request <- request
     consume fillSlot as fillSlot
 
-particle CapturePerson
+external particle CapturePerson
   inout [Person] people
 
 recipe IngestPeople

--- a/particles/PipeApps/Ingestion.arcs
+++ b/particles/PipeApps/Ingestion.arcs
@@ -8,7 +8,7 @@ schema Place
 schema Message
   Text message
 
-particle CaptureEntity in './source/CaptureEntity.java'
+external particle CaptureEntity
   out [IncomingEntity] entities
 
 particle CopyEntities in './source/CopyEntities.js'
@@ -17,9 +17,8 @@ particle CopyEntities in './source/CopyEntities.js'
   out [Person] people
   out [Message] messages
 
-particle ToastParticle in './source/ToastParticle.java'
+external particle ToastParticle
   in [Message] alert
-
 
 recipe Ingestion
   create #incomingEntities as incomingEntities

--- a/src/devtools-connector/tests/devtools-arc-inspector-test.ts
+++ b/src/devtools-connector/tests/devtools-arc-inspector-test.ts
@@ -66,6 +66,7 @@ describe('DevtoolsArcInspector', () => {
       spec: {
         name: 'P',
         description: {},
+        external: false,
         implFile: 'p.js',
         modality: ['dom'],
         slotConnections: [],

--- a/src/runtime/api-channel.ts
+++ b/src/runtime/api-channel.ts
@@ -262,7 +262,7 @@ export class APIPort {
     const count = this.messageCount++;
     if (this.inspector) {
       this.inspector.pecMessage('on' + e.data.messageType, e.data.messageBody, count,
-          this.supportsJavaParticle() ? /* android */ 'a' : /* web */ 'w',
+          this.supportsExternalParticle() ? /* android */ 'a' : /* web */ 'w',
           this._port['pecId'],
           e.data.stack);
     }
@@ -274,14 +274,14 @@ export class APIPort {
     const count = this.messageCount++;
     if (this.inspector) {
       this.inspector.pecMessage(name, args, count,
-          this.supportsJavaParticle() ? /* android */ 'a' : /* web */ 'w',
+          this.supportsExternalParticle() ? /* android */ 'a' : /* web */ 'w',
           this._port['pecId'] || '',
           new Error().stack || '');
     }
     await this._port.postMessage(call);
   }
 
-  supportsJavaParticle(): boolean {
+  supportsExternalParticle(): boolean {
     // TODO: improve heuristics.
     return Object.getPrototypeOf(this._port.constructor).name === 'MessagePort';
   }

--- a/src/runtime/arc.ts
+++ b/src/runtime/arc.ts
@@ -477,7 +477,7 @@ ${this.activeRecipe.toString()}`;
     this.loadedParticleInfo.set(recipeParticle.id.toString(), info);
 
     // if supported, provide particle caching via a BlobUrl representing spec.implFile
-    if (!recipeParticle.isJavaParticle()) {
+    if (!recipeParticle.isExternalParticle()) {
       await this._provisionSpecUrl(recipeParticle.spec);
     }
 

--- a/src/runtime/manifest-ast-nodes.ts
+++ b/src/runtime/manifest-ast-nodes.ts
@@ -181,6 +181,7 @@ export type MetaItem = MetaStorageKey | MetaName;
 export interface Particle extends BaseNode {
   kind: 'particle';
   name: string;
+  external?: boolean;         // not used in RecipeParticle
   implFile?: string;          // not used in RecipeParticle
   verbs?: VerbList;           // not used in RecipeParticle
   args?: ParticleHandleConnection[];  // not used in RecipeParticle

--- a/src/runtime/manifest-parser.peg
+++ b/src/runtime/manifest-parser.peg
@@ -1575,6 +1575,7 @@ ReservedWord
   / 'schema'
   / 'require'
   / 'handle'
+  / 'external'
   ) ([^a-zA-Z0-9_] / !.)  // '!.' matches end-of-input
 {
   expected(`identifier`);

--- a/src/runtime/manifest-parser.peg
+++ b/src/runtime/manifest-parser.peg
@@ -352,7 +352,7 @@ MetaStorageKey = 'storageKey' whiteSpace? ':' whiteSpace? key:id eolWhiteSpace
 };
 
 Particle
-  = 'particle' whiteSpace name:upperIdent verbs:(whiteSpace VerbList)? implFile:(whiteSpace 'in' whiteSpace id)? eolWhiteSpace items:(Indent (SameIndent ParticleItem)*)? eolWhiteSpace?
+  = external:('external' whiteSpace)? 'particle' whiteSpace name:upperIdent verbs:(whiteSpace VerbList)? implFile:(whiteSpace 'in' whiteSpace id)? eolWhiteSpace items:(Indent (SameIndent ParticleItem)*)? eolWhiteSpace?
   {
     const args: AstNode.ParticleHandleConnection[] = [];
     const modality: string[] = [];
@@ -362,6 +362,11 @@ Particle
     let description: AstNode.Description | null = null;
     let hasParticleHandleConnection = false;
     verbs = optional(verbs, parsedOutput => parsedOutput[1], []);
+    external = !!external;
+    implFile = optional(implFile, implFile => implFile[3], null);
+    if (external && implFile) {
+      error('Particles marked external cannot have an implementation file.');
+    }
     items = optional(items, extractIndented, []);
     items.forEach(item => {
       if (item.kind === 'particle-interface') {
@@ -394,12 +399,13 @@ Particle
     if (modality.length === 0) {
       // Add default modality
       modality.push('dom');
-    }
+    }    
 
     return  toAstNode<AstNode.Particle>({
       kind: 'particle',
       name,
-      implFile: optional(implFile, implFile => implFile[3], null),
+      external,
+      implFile,
       verbs,
       args,
       modality,

--- a/src/runtime/particle-execution-host.ts
+++ b/src/runtime/particle-execution-host.ts
@@ -70,7 +70,7 @@ export class ParticleExecutionHost {
 
   private choosePortForParticle(particle: Particle): PECOuterPort {
     assert(!this._portByParticle.has(particle), `port already found for particle '${particle.spec.name}'`);
-    const port = this._apiPorts.find(port => particle.isJavaParticle() === port.supportsJavaParticle());
+    const port = this._apiPorts.find(port => particle.isExternalParticle() === port.supportsExternalParticle());
     assert(!!port, `No port found for '${particle.spec.name}'`);
     this._portByParticle.set(particle, port);
     return this.getPort(particle);

--- a/src/runtime/particle-spec.ts
+++ b/src/runtime/particle-spec.ts
@@ -202,6 +202,7 @@ export interface SerializedParticleSpec extends Literal {
   verbs: string[];
   args: SerializedHandleConnectionSpec[];
   description: {pattern?: string};
+  external: boolean;
   implFile: string;
   implBlobUrl: string | null;
   modality: string[];
@@ -216,6 +217,7 @@ export class ParticleSpec {
   verbs: string[];
   handleConnectionMap: Map<string, HandleConnectionSpec>;
   pattern: string;
+  external: boolean;
   implFile: string;
   implBlobUrl: string | null;
   modality: Modality;
@@ -239,6 +241,7 @@ export class ParticleSpec {
       connectionSpec.pattern = model.description[name];
     });
 
+    this.external = model.external;
     this.implFile = model.implFile;
     this.implBlobUrl = model.implBlobUrl;
     this.modality = model.modality ? Modality.create(model.modality) : Modality.all;
@@ -332,19 +335,19 @@ export class ParticleSpec {
   }
 
   toLiteral(): SerializedParticleSpec {
-    const {args, name, verbs, description, implFile, implBlobUrl, modality, slotConnections, trustClaims, trustChecks} = this.model;
+    const {args, name, verbs, description, external, implFile, implBlobUrl, modality, slotConnections, trustClaims, trustChecks} = this.model;
     const connectionToLiteral : (input: SerializedHandleConnectionSpec) => SerializedHandleConnectionSpec =
       ({type, direction, name, isOptional, dependentConnections}) => ({type: asTypeLiteral(type), direction, name, isOptional, dependentConnections: dependentConnections.map(connectionToLiteral)});
     const argsLiteral = args.map(a => connectionToLiteral(a));
-    return {args: argsLiteral, name, verbs, description, implFile, implBlobUrl, modality, slotConnections, trustClaims, trustChecks};
+    return {args: argsLiteral, name, verbs, description, external, implFile, implBlobUrl, modality, slotConnections, trustClaims, trustChecks};
   }
 
   static fromLiteral(literal: SerializedParticleSpec): ParticleSpec {
-    let {args, name, verbs, description, implFile, implBlobUrl, modality, slotConnections, trustClaims, trustChecks} = literal;
+    let {args, name, verbs, description, external, implFile, implBlobUrl, modality, slotConnections, trustClaims, trustChecks} = literal;
     const connectionFromLiteral = ({type, direction, name, isOptional, dependentConnections}) =>
       ({type: asType(type), direction, name, isOptional, dependentConnections: dependentConnections ? dependentConnections.map(connectionFromLiteral) : []});
     args = args.map(connectionFromLiteral);
-    return new ParticleSpec({args, name, verbs: verbs || [], description, implFile, implBlobUrl, modality, slotConnections, trustClaims, trustChecks});
+    return new ParticleSpec({args, name, verbs: verbs || [], description, external, implFile, implBlobUrl, modality, slotConnections, trustClaims, trustChecks});
   }
 
   // Note: this method shouldn't be called directly.
@@ -385,7 +388,15 @@ export class ParticleSpec {
     if (this.verbs.length > 0) {
       verbs = ' ' + this.verbs.map(verb => `&${verb}`).join(' ');
     }
-    results.push(`particle ${this.name}${verbs} in '${this.implFile}'`.trim());
+    let line = '';
+    if (this.external) {
+      line += 'external ';
+    }
+    line += `particle ${this.name}${verbs}`;
+    if (this.implFile) {
+      line += ` in '${this.implFile}'`;
+    }
+    results.push(line);
     const indent = '  ';
     const writeConnection = (connection, indent) => {
       const tags = connection.tags.map((tag) => ` #${tag}`).join('');

--- a/src/runtime/recipe/particle.ts
+++ b/src/runtime/recipe/particle.ts
@@ -382,8 +382,8 @@ export class Particle implements Comparable<Particle> {
     this.recipe.removeParticle(this);
   }
 
-  isJavaParticle(): boolean {
-    return this.spec && (this.spec.implFile || '').endsWith('java');
+  isExternalParticle(): boolean {
+    return this.spec && this.spec.external;
   }
 
   toString(options: ToStringOptions = {}, nameMap?: Map<RecipeComponent, string>): string {

--- a/src/runtime/tests/manifest-test.ts
+++ b/src/runtime/tests/manifest-test.ts
@@ -1947,7 +1947,7 @@ resource SomeName
     verifyPrimitiveType(innerSchema.fields.far, 'Text');
 
     assert.strictEqual(manifest.particles[0].toString(),
-`particle P in 'null'
+`particle P
   bar: reads Bar {Reference<Foo {Text far}> foo}
   modality dom`);
   }));
@@ -1971,7 +1971,7 @@ resource SomeName
     verifyPrimitiveType(innerSchema.fields.far, 'Text');
 
     assert.strictEqual(manifest.particles[0].toString(),
-`particle P in 'null'
+`particle P
   in Bar {Reference<Foo {Text far}> foo} bar
   modality dom`);
   }));
@@ -1994,7 +1994,7 @@ resource SomeName
     verifyPrimitiveType(innerSchema.fields.far, 'Text');
 
     assert.strictEqual(manifest.particles[0].toString(),
-`particle P in 'null'
+`particle P
   bar: reads Bar {Reference<Foo {Text far}> foo}
   modality dom`);
   }));
@@ -2017,7 +2017,7 @@ resource SomeName
     verifyPrimitiveType(innerSchema.fields.far, 'Text');
 
     assert.strictEqual(manifest.particles[0].toString(),
-`particle P in 'null'
+`particle P
   in Bar {Reference<Foo {Text far}> foo} bar
   modality dom`);
   }));
@@ -2041,7 +2041,7 @@ resource SomeName
     verifyPrimitiveType(innerSchema.fields.far, 'Text');
 
     assert.strictEqual(manifest.particles[0].toString(),
-`particle P in 'null'
+`particle P
   bar: reads Bar {[Reference<Foo {Text far}>] foo}
   modality dom`);
   }));
@@ -2065,7 +2065,7 @@ resource SomeName
     verifyPrimitiveType(innerSchema.fields.far, 'Text');
 
     assert.strictEqual(manifest.particles[0].toString(),
-`particle P in 'null'
+`particle P
   in Bar {[Reference<Foo {Text far}>] foo} bar
   modality dom`);
   }));
@@ -2087,7 +2087,7 @@ resource SomeName
     verifyPrimitiveType(innerSchema.fields.far, 'Text');
 
     assert.strictEqual(manifest.particles[0].toString(),
-`particle P in 'null'
+`particle P
   bar: reads Bar {[Reference<Foo {Text far}>] foo}
   modality dom`);
   }));
@@ -2109,7 +2109,7 @@ resource SomeName
     verifyPrimitiveType(innerSchema.fields.far, 'Text');
 
     assert.strictEqual(manifest.particles[0].toString(),
-`particle P in 'null'
+`particle P
   in Bar {[Reference<Foo {Text far}>] foo} bar
   modality dom`);
   }));
@@ -3224,6 +3224,32 @@ particle A
     assert.lengthOf(manifest.errors, 1);
     assert.equal(manifest.errors[0].key, 'externalSchemas');
   });
+
+  it('SLANDLES SYNTAX can round-trip external particles', Flags.withPostSlandlesSyntax(async () => {
+    const manifestString = `external particle TestParticle
+  input: reads [Product {}]
+  modality dom`;
+
+    const manifest = await Manifest.parse(manifestString);
+    assert.lengthOf(manifest.particles, 1);
+    const particle = manifest.particles[0];
+    assert.isTrue(particle.external);
+    assert.isNull(particle.implFile);
+    assert.strictEqual(manifestString, particle.toString());
+  }));
+
+  it('can round-trip external particles', Flags.withPreSlandlesSyntax(async () => {
+    const manifestString = `external particle TestParticle
+  in [Product {}] input
+  modality dom`;
+
+    const manifest = await Manifest.parse(manifestString);
+    assert.lengthOf(manifest.particles, 1);
+    const particle = manifest.particles[0];
+    assert.isTrue(particle.external);
+    assert.isNull(particle.implFile);
+    assert.strictEqual(manifestString, particle.toString());
+  }));
 });
 
 describe('Manifest storage migration', () => {

--- a/src/runtime/tests/particle-interface-loading-test.ts
+++ b/src/runtime/tests/particle-interface-loading-test.ts
@@ -73,6 +73,7 @@ describe('particle interface loading', () => {
     const outerParticleSpec = new ParticleSpec({
       name: 'outerParticle',
       description: {},
+      external: false,
       implBlobUrl: '',
       modality: ['dom'],
       slotConnections: [],

--- a/src/tools/manifest-checker.ts
+++ b/src/tools/manifest-checker.ts
@@ -38,14 +38,12 @@ async function checkManifest(src: string) {
 
   // Check particle impls can be loaded.
   for (const particle of manifest.particles) {
-    if (particle.external) {
-      // External particles don't specify their implementation files, so just
-      // skip this.
-      continue;
-    } else if (!particle.implFile) {
-      throw new Error(`Particle ${particle.name} does not have an implementation file and is not marked external.`);
-    } else {
-      await loader.loadResource(particle.implFile);
+    if (!particle.external) {
+      if (particle.implFile) {
+        await loader.loadResource(particle.implFile);
+      } else {
+        throw new Error(`Particle ${particle.name} does not have an implementation file and is not marked external.`);
+      }
     }
   }
 }

--- a/src/tools/manifest-checker.ts
+++ b/src/tools/manifest-checker.ts
@@ -37,11 +37,15 @@ async function checkManifest(src: string) {
   }
 
   // Check particle impls can be loaded.
-  for (const {implFile} of manifest.particles) {
-    // Particle may not have an implementation. Might be an Android particle,
-    // so this is possibly fine. Just skip it.
-    if (implFile) {
-      await loader.loadResource(implFile);
+  for (const particle of manifest.particles) {
+    if (particle.external) {
+      // External particles don't specify their implementation files, so just
+      // skip this.
+      continue;
+    } else if (!particle.implFile) {
+      throw new Error(`Particle ${particle.name} does not have an implementation file and is not marked external.`);
+    } else {
+      await loader.loadResource(particle.implFile);
     }
   }
 }


### PR DESCRIPTION
This indicates that the particle is not instantiable, and does not have an impl file. Used for Android particles.

Formerly we would say:
```
particle Foo in 'path/to/nowhere.java'
```
and it would magically work because it ends with .java (the file doesn't even have to exist).

Now we can say:
```
external particle Foo
```