### PR TITLE
Allows specifying builtOutputRegex with a string

### DIFF
--- a/shells/lib/utils.js
+++ b/shells/lib/utils.js
@@ -28,7 +28,7 @@ const createPathMap = root => ({
     root,
     path: '/particles/',
     buildDir: '/bazel-bin',
-    buildOutputRegex: /\.wasm$/,
+    buildOutputRegex: '\\.wasm$',
   }
 });
 

--- a/src/platform/tests/loader-test.ts
+++ b/src/platform/tests/loader-test.ts
@@ -28,7 +28,7 @@ describe('PlatformLoader', () => {
       'https://$macro/': {
         root: 'http://host/',
         buildDir: 'bazel-bin/',
-        buildOutputRegex: /\.wasm$/,
+        buildOutputRegex: '\\.wasm$',
       }
     });
 
@@ -43,7 +43,7 @@ describe('PlatformLoader', () => {
         root: '../../',
         path: 'over/here/',
         buildDir: 'bazel-bin/',
-        buildOutputRegex: /\.wasm$/,
+        buildOutputRegex: '\\.wasm$',
       }
     });
 


### PR DESCRIPTION
This is handy when configuring the pipes shell with the API, as regexes are not json serializable.