### PR TITLE
Make Arcs Service load stuff from the workstation

### DIFF
--- a/javaharness/README.md
+++ b/javaharness/README.md
@@ -19,7 +19,7 @@ TODO: This code is undergoing refactoring, add packages descriptions, when compl
    * Project view: from project view file: `javaharness/.bazelproject`
 1. Add a new run configuration of type Bazel Command, with command
    `mobile-install` and target expression:
-   `//javaharness/java/arcs/android/demo/app:app`
+   `//javaharness/java/arcs/android/demo:demo`
 
 Before this will actually work, you will need to build pipes-shell
 
@@ -60,9 +60,9 @@ Follow the steps to inspect and debug Arcs:
   adb wait-for-device root
   adb reverse tcp:8786 tcp:8786
   ```
-4. Instructing the on-device Arcs runtime to use ALDS proxy before starting it:
+4. Instructing the on-device Arcs runtime to connect to the Arcs Explorer tool:
 * ```bash
-  adb shell setprop debug.arcs.runtime.use_alds true
+  adb shell setprop debug.arcs.runtime.enable_arcs_explorer true
   ```
 5. Launching the demo activity i.e. Autofill by pressing the Autofill button at the demo application.
 * > The button pressing starts the on-device Arcs runtime, connecting to the host ALDS then launching the demo activity.
@@ -78,11 +78,23 @@ Follow the steps to inspect and debug Arcs:
 
 > Re-visiting all steps if the device reboots.
 
+## Loading particles and recipes from the workstation
+Particles and recipes are by default loaded from the APK, but you can configure the device to load them from you workstation instead:
+
+1. Ensure you have ALDS running and can connect to it by following steps 2 and 3 from the Debugging and Inspection section.
+1. Ask for the assets to be loaded from the workstation:
+```bash
+  adb shell setprop debug.arcs.runtime.load_workstation_assets true
+```
+
+
 ## Properties
 Android properties are used to change and tweak Arcs settings at run-time.
 
 | Property | Description | Default |
 | -------- | ----------- | ------- |
 | debug.arcs.runtime.log | Change logging level of the JS Arcs runtime | 2 (the most verbose) |
-| debug.arcs.runtime.use_alds | Connect to the host ALDS while starting the JS Arcs runtime | false |
+| debug.arcs.runtime.enable_arcs_explorer | Connect to the Arcs Explorer frontend via ALDS proxy while starting the JS Arcs runtime | false |
+| debug.arcs.runtime.dev_server_port | The port to use for communication with ALDS | 8786 |
 | debug.arcs.runtime.shell_url | Specify which shell to use | file:///android_asset/index.html? (on-device pipes-shell) |
+| debug.arcs.runtime.load_workstation_assets | Whether to load recipes and particles from the workstation | false (assets from the APK) |

--- a/javaharness/java/arcs/android/AndroidRuntimeSettings.java
+++ b/javaharness/java/arcs/android/AndroidRuntimeSettings.java
@@ -14,17 +14,26 @@ public final class AndroidRuntimeSettings implements RuntimeSettings {
   // Equivalent to &log parameter
   private static final String LOG_LEVEL_PROPERTY = "debug.arcs.runtime.log";
   // Equivalent to &explore-proxy parameter
-  private static final String USE_DEV_SERVER_PROXY_PROPERTY = "debug.arcs.runtime.use_alds";
+  private static final String ENABLE_ARCS_EXPLORER_PROPERTY = "debug.arcs.runtime.enable_arcs_explorer";
   // The target shell to be loaded (on-device) or be connected (on-host)
   private static final String SHELL_URL_PROPERTY = "debug.arcs.runtime.shell_url";
+  // Whether to load particles and recipes from the workstation
+  private static final String LOAD_ASSETS_FROM_WORKSTATION_PROPERTY =
+      "debug.arcs.runtime.load_workstation_assets";
+  // Port to be used for the communication with the dev server.
+  private static final String DEV_SERVER_PORT_PROPERTY = "debug.arcs.runtime.dev_server_port";
 
   // Default settings:
-  // Logs the most information, loads the on-device pipes-shell
-  // and not uses ALDS proxy.
+  // Logs the most information
   private static final int DEFAULT_LOG_LEVEL = 2;
-  private static final boolean DEFAULT_USE_DEV_SERVER = false;
-  private static final String DEFAULT_SHELL_URL = "file:///android_asset/arcs/index.html?solo=dynamic.manifest&";
-  private static final String LOCALHOST_SHELL_URL = "http://localhost:8786/shells/pipes-shell/web/deploy/dist/?";
+  // Does *not* connect Arcs Explorer
+  private static final boolean DEFAULT_ENABLE_ARCS_EXPLORER = false;
+  // Loads the on-device pipes-shell
+  private static final String DEFAULT_SHELL_URL = "file:///android_asset/arcs/index.html?";
+  // Load the on-device assets
+  private static final boolean DEFAULT_ASSETS_FROM_WORKSTATION = false;
+  // Uses the standard 8786 port
+  private static final int DEFAULT_DEV_SERVER_PORT = 8786;
 
   private static final Logger logger = Logger.getLogger(
       AndroidRuntimeSettings.class.getName());
@@ -32,8 +41,10 @@ public final class AndroidRuntimeSettings implements RuntimeSettings {
   @AutoValue
   abstract static class Settings {
     abstract int logLevel();
-    abstract boolean useDevServerProxy();
+    abstract boolean enableArcsExplorer();
     abstract String shellUrl();
+    abstract boolean loadAssetsFromWorkstation();
+    abstract int devServerPort();
 
     static Builder builder() {
       return new AutoValue_AndroidRuntimeSettings_Settings.Builder();
@@ -42,8 +53,10 @@ public final class AndroidRuntimeSettings implements RuntimeSettings {
     @AutoValue.Builder
     abstract static class Builder {
       abstract Builder setLogLevel(int level);
-      abstract Builder setUseDevServerProxy(boolean useDevServerProxy);
+      abstract Builder setEnableArcsExplorer(boolean useDevServerProxy);
       abstract Builder setShellUrl(String shellUrl);
+      abstract Builder setLoadAssetsFromWorkstation(boolean loadAssetsFromWorkstation);
+      abstract Builder setDevServerPort(int devServerPort);
       abstract Settings build();
     }
   }
@@ -56,10 +69,15 @@ public final class AndroidRuntimeSettings implements RuntimeSettings {
     settings = Settings.builder()
         .setLogLevel(
             getProperty(LOG_LEVEL_PROPERTY, Integer::valueOf, DEFAULT_LOG_LEVEL))
-        .setUseDevServerProxy(
-            getProperty(USE_DEV_SERVER_PROXY_PROPERTY, Boolean::valueOf, DEFAULT_USE_DEV_SERVER))
+        .setEnableArcsExplorer(
+            getProperty(ENABLE_ARCS_EXPLORER_PROPERTY, Boolean::valueOf, DEFAULT_ENABLE_ARCS_EXPLORER))
         .setShellUrl(
             getProperty(SHELL_URL_PROPERTY, String::valueOf, DEFAULT_SHELL_URL))
+        .setLoadAssetsFromWorkstation(
+            getProperty(LOAD_ASSETS_FROM_WORKSTATION_PROPERTY, Boolean::valueOf,
+                DEFAULT_ASSETS_FROM_WORKSTATION))
+        .setDevServerPort(
+            getProperty(DEV_SERVER_PORT_PROPERTY, Integer::valueOf, DEFAULT_DEV_SERVER_PORT))
         .build();
   }
 
@@ -69,13 +87,23 @@ public final class AndroidRuntimeSettings implements RuntimeSettings {
   }
 
   @Override
-  public boolean useDevServerProxy() {
-    return settings.useDevServerProxy();
+  public boolean enableArcsExplorer() {
+    return settings.enableArcsExplorer();
   }
 
   @Override
   public String shellUrl() {
     return settings.shellUrl();
+  }
+
+  @Override
+  public boolean loadAssetsFromWorkstation() {
+    return settings.loadAssetsFromWorkstation();
+  }
+
+  @Override
+  public int devServerPort() {
+    return settings.devServerPort();
   }
 
   /**

--- a/javaharness/java/arcs/api/RuntimeSettings.java
+++ b/javaharness/java/arcs/api/RuntimeSettings.java
@@ -4,20 +4,20 @@ package arcs.api;
 public interface RuntimeSettings {
   // Used by Javascript-based and/or other types of Arcs runtime(s).
   // Equivalent to the &log=<level> parameter at JS Arcs runtime.
-  default int logLevel() {
-    return 0;
-  }
+  int logLevel();
 
-  // Used mainly by Javascript-based Arcs runtime to establish WebSocket
-  // connection to the host from the device during runtime initialization.
+  // Controls whether JS Arcs Runtime should wait on the connection to the Arcs Explorer tool.
   // Equivalent to the &explore-proxy parameter at JS Arcs runtime.
-  default boolean useDevServerProxy() {
-    return false;
-  }
+  boolean enableArcsExplorer();
+
+  // Controls whether to override loading of the particles and recipes to the Development Server,
+  // which loads them from the developer's workstation.
+  boolean loadAssetsFromWorkstation();
+
+  // Value of the port to be used for connecting to the developer server.
+  int devServerPort();
 
   // Used only by Javascript-based Arcs runtime to specify which shell
   // either on-device or on-host to connect with.
-  default String shellUrl() {
-    return "";
-  }
+  String shellUrl();
 }


### PR DESCRIPTION
Fixes #3821.

Introduces a major new property:

* `load_workstation_assets` - whether to load from the workstation.

Also for good hygiene:

* `dev_server_port` - If 8786 is not your thing.
* `enable_arcs_explorer` - is more technically correct than `use_alds`

Still not solved: How is the root manifest name configured exactly? I'm not sure the current API is the best way, but I've left it in place.