### PR TITLE
Small fix for type error: typescript's regex type is not a string

### DIFF
--- a/src/platform/loader-base.ts
+++ b/src/platform/loader-base.ts
@@ -30,7 +30,7 @@ type UrlMap = Dictionary<string | {
   root: string
   path?: string
   buildDir: string
-  buildOutputRegex: string
+  buildOutputRegex: string | RegExp
   compiledRegex?: RegExp
 }>;
 
@@ -284,7 +284,11 @@ export abstract class LoaderBase {
   private compileRegExp(urlMap: UrlMap) {
     for (const config of Object.values(urlMap)) {
       if (typeof config === 'string') continue;
-      config.compiledRegex = RegExp(config.buildOutputRegex);
+      if (typeof config.buildOutputRegex === 'string') {
+        config.compiledRegex = RegExp(config.buildOutputRegex);
+      } else {
+        config.compiledRegex = config.buildOutputRegex;
+      }
     }
   }
 }


### PR DESCRIPTION
Fixes type error introduced in #3945 by adding handling for both strings and regexes in LoaderBase and to the UrlMap type.