### PR TITLE
Export UrlMap type, use it in runtime.ts

### DIFF
--- a/src/platform/loader-base.ts
+++ b/src/platform/loader-base.ts
@@ -23,10 +23,9 @@ import {html} from '../runtime/html.js';
 import {logsFactory} from '../platform/logs-factory.js';
 import {Dictionary} from '../runtime/hot.js';
 
-type Ctor = typeof Object;
 type ParticleCtor = typeof Particle;
 
-type UrlMap = Dictionary<string | {
+export type UrlMap = Dictionary<string | {
   root: string
   path?: string
   buildDir: string

--- a/src/platform/loader.ts
+++ b/src/platform/loader.ts
@@ -7,4 +7,5 @@
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
+export {UrlMap} from './loader-base.js';
 export * from './loader-web.js';

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -23,7 +23,7 @@ import {ArcInspectorFactory} from './arc-inspector.js';
 import {FakeSlotComposer} from './testing/fake-slot-composer.js';
 import {VolatileMemory} from './storageNG/drivers/volatile.js';
 import {StorageKey} from './storageNG/storage-key.js';
-import {Loader} from '../platform/loader.js';
+import {UrlMap, Loader} from '../platform/loader.js';
 import {pecIndustry} from '../platform/pec-industry.js';
 
 export type RuntimeArcOptions = Readonly<{
@@ -77,7 +77,7 @@ export class Runtime {
    */
   static init(root?: string, urls?: {}): Runtime {
     const map = {...Runtime.mapFromRootPath(root), ...urls};
-    const loader = new Loader(map);
+    const loader = new Loader(map as UrlMap);
     const pecFactory = pecIndustry(loader);
     return new Runtime(loader, SlotComposer, null, pecFactory);
   }
@@ -94,7 +94,7 @@ export class Runtime {
         root,
         path: '/particles/',
         buildDir: '/bazel-bin',
-        buildOutputRegex: /\.wasm$/
+        buildOutputRegex: /\.wasm$/.source
       }
     };
   }


### PR DESCRIPTION
Otherwise, `runtime.ts` is using `{}` which causes tslint failure.