### PR TITLE
buildOutputRegex must be a `string`

### DIFF
--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -94,7 +94,7 @@ export class Runtime {
         root,
         path: '/particles/',
         buildDir: '/bazel-bin',
-        buildOutputRegex: /\.wasm$/
+        buildOutputRegex: /\.wasm$/.source
       }
     };
   }


### PR DESCRIPTION
Fixing type-error borking the build, as two PRs crossed in the night (day).

Supercedes #3958.