### PR TITLE
Switch post slandles (unification) syntax on

### DIFF
--- a/src/runtime/flags.ts
+++ b/src/runtime/flags.ts
@@ -14,7 +14,7 @@ class FlagDefaults {
   static useNewStorageStack = false;
   // Enables the parsing of both pre and post slandles (unified) syntaxes.
   // Preslandles syntax is to be deprecated.
-  static parseBothSyntaxes = false;
+  static parseBothSyntaxes = true;
   // Use pre slandles syntax for parsing and toString by default.
   // If parseBothSyntaxes is off, this will set which syntax is enabled.
   static defaultToPreSlandlesSyntax = true;


### PR DESCRIPTION
Turns on post slandles / unification syntax on which makes it available as an alternative syntax, but does not change the default (i.e. toString will give old syntax).

This should allow us to convert tests and manifest artifacts.