### PR TITLE
Introduce a 'quiet' flag to testFlags

### DIFF
--- a/src/runtime/manifest-parser.peg
+++ b/src/runtime/manifest-parser.peg
@@ -100,10 +100,12 @@ Manifest
     });
     checkNormal(result);
     if (preSlandlesSyntaxLocations.length > 0 && !Flags.defaultToPreSlandlesSyntax) {
-      console.warn('WARNING: Pre-Slandles Syntax is deprecated. Contact jopra@google.com for more information.');
-      console.warn(`WARNING: Used in \n  ${
-        preSlandlesSyntaxLocations.map(loc => `line ${loc.start.line} column ${loc.start.column}`).join("\n  ")
-      }`);
+      if (!global['testFlags'].quiet) {
+        console.warn('WARNING: Pre-Slandles Syntax is deprecated. Contact jopra@google.com for more information.');
+        console.warn(`WARNING: Used in \n  ${
+          preSlandlesSyntaxLocations.map(loc => `line ${loc.start.line} column ${loc.start.column}`).join("\n  ")
+        }`);
+      }
     }
     return result;
   }

--- a/tools/sigh.ts
+++ b/tools/sigh.ts
@@ -125,6 +125,8 @@ const isTravisDaily = (process.env.TRAVIS_EVENT_TYPE === 'cron');
 const testFlags = {
   /** If true, runs tests flagged as bazel tests. */
   bazel: false,
+  /** If true, runs tests with some warning messages suppressed. */
+  quiet: false,
 };
 
 /** Logs to console.log, unless suppressed by the global --quiet flag. */
@@ -639,6 +641,7 @@ function runTests(args: string[]): boolean {
     // invokes sigh directly.
     testFlags.bazel = true;
   }
+  testFlags.quiet = globalOptions.quiet;
 
   const testsInDir = dir => findProjectFiles(dir, buildExclude, fullPath => {
     // TODO(wkorman): Integrate shell testing more deeply into sigh testing. For


### PR DESCRIPTION
This simply copies globalFlags.quiet into testFlags so that tests can suppress warnings.

It also checks the quite flag in the parser so that sigh test --quiet isn't filled with junk while we convert the syntax over.