### PR TITLE
Wasm C++: for set/store, pass entity by non-const ref not pointer

### DIFF
--- a/particles/Native/Wasm/source/example.cc
+++ b/particles/Native/Wasm/source/example.cc
@@ -29,11 +29,9 @@ public:
   void fireEvent(const std::string& slot_name, const std::string& handler) override {
     if (handler == "clicky") {
       arcs::BasicParticle_Foo copy = arcs::clone_entity(foo_.get());  // does not copy internal entity id
-      // TODO(alxr): Myk, please advise
-      arcs::BasicParticle_Bar copy1;
-      copy1.set_name(copy.name());
-      copy1.set_sku(copy.sku());
-      bar_.store(&copy1);  // pass as pointer; 'copy' will be updated with a new internal id
+      copy.set_name(copy.name());
+      copy.set_sku(copy.sku());
+      bar_.store(copy);    // 'copy' will be updated with a new internal id
 
       // Basic printf-style logging; note the c_str() for std::string variables
       console("Product copied; new id is %s\n", arcs::entity_to_str(copy).c_str());

--- a/particles/Native/Wasm/source/example.cc
+++ b/particles/Native/Wasm/source/example.cc
@@ -29,8 +29,6 @@ public:
   void fireEvent(const std::string& slot_name, const std::string& handler) override {
     if (handler == "clicky") {
       arcs::BasicParticle_Foo copy = arcs::clone_entity(foo_.get());  // does not copy internal entity id
-      copy.set_name(copy.name());
-      copy.set_sku(copy.sku());
       bar_.store(copy);    // 'copy' will be updated with a new internal id
 
       // Basic printf-style logging; note the c_str() for std::string variables

--- a/src/wasm/cpp/arcs.h
+++ b/src/wasm/cpp/arcs.h
@@ -289,17 +289,17 @@ public:
 
   // For new entities created by a particle, this method will generate a new internal ID and update
   // the given entity with it. The data fields will not be modified.
-  void set(T* entity) {
+  void set(T& entity) {
     failForDirection(In);
-    std::string encoded = internal::Accessor::encode_entity(*entity);
+    std::string encoded = internal::Accessor::encode_entity(entity);
     const char* id = internal::singletonSet(particle_, this, encoded.c_str());
     if (id != nullptr) {
-      entity->_internal_id_ = id;
+      entity._internal_id_ = id;
       free((void*)id);
     }
     // Write-only handles do not keep entity data locally.
     if (dir_ == InOut) {
-      entity_ = *entity;
+      entity_ = entity;
     }
   }
 
@@ -380,17 +380,17 @@ public:
 
   // For new entities created by a particle, this method will generate a new internal ID and update
   // the given entity with it. The data fields will not be modified.
-  void store(T* entity) {
+  void store(T& entity) {
     failForDirection(In);
-    std::string encoded = internal::Accessor::encode_entity(*entity);
+    std::string encoded = internal::Accessor::encode_entity(entity);
     const char* id = internal::collectionStore(particle_, this, encoded.c_str());
     if (id != nullptr) {
-      entity->_internal_id_ = id;
+      entity._internal_id_ = id;
       free((void*)id);
     }
     // Write-only handles do not keep entity data locally.
     if (dir_ == InOut) {
-      entities_.emplace(entity->_internal_id_, new T(*entity));
+      entities_.emplace(entity._internal_id_, new T(entity));
     }
   }
 

--- a/src/wasm/cpp/tests/particle-api-test.cc
+++ b/src/wasm/cpp/tests/particle-api-test.cc
@@ -12,7 +12,7 @@ public:
   void onHandleSync(const std::string& name, bool all_synced) override {
     arcs::Test_Data out;
     out.set_txt("sync:" + name + (all_synced ? ":true" : ":false"));
-    res_.store(&out);
+    res_.store(out);
   }
 
   void onHandleUpdate(const std::string& name) override {
@@ -25,7 +25,7 @@ public:
     } else {
       out.set_txt("unexpected handle name: " + name);
     }
-    res_.store(&out);
+    res_.store(out);
   }
 
   arcs::Singleton<arcs::Test_Data> sng_;
@@ -88,7 +88,7 @@ public:
   void fireEvent(const std::string& slot_name, const std::string& handler) override {
     arcs::Test_Data out;
     out.set_txt("event:" + slot_name + ":" + handler);
-    output_.set(&out);
+    output_.set(out);
   }
 
   arcs::Singleton<arcs::Test_Data> output_;
@@ -108,7 +108,7 @@ public:
     arcs::Test_ServiceResponse out;
     out.set_call("resolveUrl");
     out.set_payload(url);
-    output_.store(&out);
+    output_.store(out);
 
     serviceRequest("random.next", {}, "first");
     serviceRequest("random.next", {}, "second");
@@ -126,7 +126,7 @@ public:
     out.set_call(call);
     out.set_tag(tag);
     out.set_payload(payload);
-    output_.store(&out);
+    output_.store(out);
   }
 
   arcs::Collection<arcs::Test_ServiceResponse> output_;

--- a/src/wasm/cpp/tests/storage-api-test.cc
+++ b/src/wasm/cpp/tests/storage-api-test.cc
@@ -18,11 +18,11 @@ public:
     } else if (handler == "case2") {
       arcs::Test_Data d = arcs::clone_entity(in_.get());
       d.set_num(d.num() * 2);
-      out_.set(&d);
+      out_.set(d);
     } else if (handler == "case3") {
       arcs::Test_Data d = arcs::clone_entity(io_.get());
       d.set_num(d.num() * 3);
-      io_.set(&d);
+      io_.set(d);
     }
   }
 
@@ -49,7 +49,7 @@ public:
     } else if (handler == "case2") {
       stored_.set_flg(in_.empty());
       stored_.set_num(in_.size());
-      out_.store(&stored_);
+      out_.store(stored_);
     } else if (handler == "case3") {
       // We can't read from out_ so use a previously stored entity to test remove().
       out_.remove(stored_);
@@ -61,29 +61,29 @@ public:
       d1.set_txt(arcs::entity_to_str(*i1));  // op*
       d1.set_num(i1->num() * 2);             // op->
       d1.set_flg(i1 != in_.end());           // op!=
-      out_.store(&d1);
+      out_.store(d1);
 
       auto i2 = in_.begin();
       d2.set_txt((i2 == i1) ? "eq" : "ne");  // op==
       d2.set_flg(i1++ == in_.end());         // postfix op++
-      out_.store(&d2);
+      out_.store(d2);
 
       d3.set_txt((i2 != i1) ? "ne" : "eq");
       d3.set_flg(++i2 == in_.end());         // prefix op++
-      out_.store(&d3);
+      out_.store(d3);
     } else if (handler == "case5") {
       arcs::Test_Data extra, d1, d2, d3;
 
       // Store and remove an entity.
       extra.set_txt("abc");
-      io_.store(&extra);
+      io_.store(extra);
       d1.set_num(io_.size());
       d1.set_flg(io_.empty());
-      out_.store(&d1);
+      out_.store(d1);
 
       io_.remove(extra);
       d2.set_num(io_.size());
-      out_.store(&d2);
+      out_.store(d2);
 
       // Ranged iteration; order is not guaranteed so use 'num' to assign sorted array slots.
       std::string res[3];
@@ -93,13 +93,13 @@ public:
       for (size_t i = 0; i < io_.size(); i++) {
         arcs::Test_Data d;
         d.set_txt(res[i]);
-        out_.store(&d);
+        out_.store(d);
       }
 
       io_.clear();
       d3.set_num(io_.size());
       d3.set_flg(io_.empty());
-      out_.store(&d3);
+      out_.store(d3);
     }
   }
 
@@ -144,7 +144,7 @@ public:
     const std::string& id = Accessor::get_id(ref);
     const std::string& bang = ref.is_dereferenced() ? "" : "!";
     d.set_txt(label + " <" + id + "> " + bang + arcs::entity_to_str(ref.entity()));
-    res_.store(&d);
+    res_.store(d);
   }
 
   arcs::Singleton<arcs::Ref<arcs::Test_Data>> sng_;
@@ -184,7 +184,7 @@ public:
       data.set_txt("xyz");
       data.bind_ref(foo);
 
-      output_.set(&data);
+      output_.set(data);
     });
   }
 
@@ -193,7 +193,7 @@ public:
     const std::string& id = Accessor::get_id(ref);
     const std::string& bang = ref.is_dereferenced() ? "" : "!";
     d.set_txt(label + " <" + id + "> " + bang + arcs::entity_to_str(ref.entity()));
-    res_.store(&d);
+    res_.store(d);
   }
 
   arcs::Singleton<arcs::Test_Data> input_;

--- a/src/wasm/cpp/tests/test-base.h
+++ b/src/wasm/cpp/tests/test-base.h
@@ -21,7 +21,7 @@ public:
       }
       err.set_txt("[" + test_name_ + "] " + file + ":" + std::to_string(line) +
                   ": " + condition);
-      errors_.store(&err);
+      errors_.store(err);
       marker_ = 'X';
     }
     return ok;


### PR DESCRIPTION
These operations need to update entities that don't yet have an arcs id, so need to modify the input, which would otherwise be const. I originally made them pass-by-pointer to highlight this, but since the
arcs id is an internal details, pass-by-ref seems more natural (and protects against nulls).