### PR TITLE
Add third_party/java/arcs/sdk directory

### DIFF
--- a/particles/Native/Wasm/BUILD
+++ b/particles/Native/Wasm/BUILD
@@ -21,7 +21,7 @@ cc_wasm_binary(
     name = "example_particle",
     srcs = ["source/example.cc"],
     hdrs = ["example.h"],
-    deps = ["//src/wasm/cpp:arcs"],
+    deps = ["//third_party/java/arcs/sdk/cpp"],
 )
 
 arcs_kt_schema(

--- a/src/tests/source/BUILD
+++ b/src/tests/source/BUILD
@@ -18,12 +18,12 @@ cc_wasm_binary(
     name = "wasm-particle-old",
     srcs = ["wasm-particle-old.cc"],
     hdrs = ["entities.h"],
-    deps = ["//src/wasm/cpp:arcs"],
+    deps = ["//third_party/java/arcs/sdk/cpp"],
 )
 
 cc_wasm_binary(
     name = "wasm-particle-new",
     srcs = ["wasm-particle-new.cc"],
     hdrs = ["entities.h"],
-    deps = ["//src/wasm/cpp:arcs"],
+    deps = ["//third_party/java/arcs/sdk/cpp"],
 )

--- a/third_party/java/arcs/build_defs/internal/kotlin.bzl
+++ b/third_party/java/arcs/build_defs/internal/kotlin.bzl
@@ -7,7 +7,7 @@ load("//third_party/bazel_rules/rules_kotlin/kotlin/native:native_rules.bzl", "k
 load("//third_party/bazel_rules/rules_kotlin/kotlin/js:js_library.bzl", "kt_js_library", kt_js_import = "kt_js_import_fixed")
 load("//tools/build_defs/kotlin:rules.bzl", "kt_android_library", "kt_jvm_library")
 
-_ARCS_KOTLIN_LIBS = ["//third_party/java/arcs/kotlin:arcs_wasm"]
+_ARCS_KOTLIN_LIBS = ["//third_party/java/arcs/sdk/kotlin"]
 
 IS_BAZEL = not (hasattr(native, "genmpm"))
 

--- a/third_party/java/arcs/sdk/cpp/BUILD
+++ b/third_party/java/arcs/sdk/cpp/BUILD
@@ -3,6 +3,6 @@ package(default_visibility = ["//visibility:public"])
 licenses(["notice"])
 
 alias(
-    name = "arcs_wasm",
-    actual = "//src/wasm/kotlin:arcs_wasm",
+    name = "cpp",
+    actual = "//src/wasm/cpp:arcs",
 )

--- a/third_party/java/arcs/sdk/kotlin/BUILD
+++ b/third_party/java/arcs/sdk/kotlin/BUILD
@@ -1,0 +1,8 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+alias(
+    name = "kotlin",
+    actual = "//src/wasm/kotlin:arcs_wasm",
+)


### PR DESCRIPTION
Aligns G3 and GH paths, so that arcs.h and Particle.kt live under a well known shared alias.
