### PR TITLE
Fix Travis failure on c++ wasm

### DIFF
--- a/src/tests/source/wasm-particle-new.cc
+++ b/src/tests/source/wasm-particle-new.cc
@@ -34,7 +34,7 @@ class ReloadHandleTest : public arcs::Particle {
       } else {
         out.set_name("unexpected handle name: " + name);
       }
-      personOut.set(&out);
+      personOut.set(out);
     }
     arcs::Singleton<arcs::Test_Person> personIn;
     arcs::Singleton<arcs::Test_Person> personOut;

--- a/src/tests/source/wasm-particle-old.cc
+++ b/src/tests/source/wasm-particle-old.cc
@@ -34,7 +34,7 @@ class ReloadHandleTest : public arcs::Particle {
       } else {
         out.set_name("unexpected handle name: " + name);
       }
-      personOut.set(&out);
+      personOut.set(out);
     }
     arcs::Singleton<arcs::Test_Person> personIn;
     arcs::Singleton<arcs::Test_Person> personOut;


### PR DESCRIPTION
API signature was changed from pointer to lvalue reference.