### PR TITLE
Fix dead loop when client and ArcsService are in the same DI scope.

### DIFF
--- a/javaharness/java/arcs/android/ArcsAndroidClient.java
+++ b/javaharness/java/arcs/android/ArcsAndroidClient.java
@@ -8,6 +8,7 @@ import android.os.IBinder;
 import android.os.RemoteException;
 import android.util.Log;
 
+import arcs.api.HandleFactory;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.List;
@@ -17,7 +18,6 @@ import java.util.function.Consumer;
 import javax.inject.Inject;
 
 import arcs.api.ArcData;
-import arcs.api.ArcsMessageSender;
 import arcs.api.Particle;
 import arcs.api.PecInnerPort;
 import arcs.api.PecPortManager;
@@ -37,16 +37,14 @@ public class ArcsAndroidClient {
   private IArcsService arcsService;
   private Queue<Consumer<IArcsService>> pendingCalls = new ArrayDeque<>();
 
+
   @Inject
   ArcsAndroidClient(
-      PecPortManager pecPortManager,
       PortableJsonParser jsonParser,
-      ArcsMessageSender arcsMessageSender) {
-    this.pecPortManager = pecPortManager;
+      HandleFactory handleFactory) {
     this.jsonParser = jsonParser;
+    this.pecPortManager = new PecPortManager(this::sendMessageToArcs, jsonParser, handleFactory);
     this.serviceConnection = new HelperServiceConnection();
-
-    arcsMessageSender.attachProxy(this::sendMessageToArcs);
   }
 
   public void connect(Context context) {

--- a/javaharness/java/arcs/api/ArcsMessageSender.java
+++ b/javaharness/java/arcs/api/ArcsMessageSender.java
@@ -1,27 +1,5 @@
 package arcs.api;
 
-import javax.inject.Inject;
-import javax.inject.Singleton;
-
-@Singleton
-public class ArcsMessageSender {
-
-  public interface Proxy {
-    void sendMessage(String message);
-  }
-
-  Proxy proxy;
-
-  @Inject
-  ArcsMessageSender() {}
-
-  public void sendMessageToArcs(String message) {
-    if (proxy != null) {
-      proxy.sendMessage(message);
-    }
-  }
-
-  public void attachProxy(Proxy proxy) {
-    this.proxy = proxy;
-  }
+public interface ArcsMessageSender {
+  void sendMessageToArcs(String message);
 }

--- a/javaharness/java/arcs/api/HandleFactory.java
+++ b/javaharness/java/arcs/api/HandleFactory.java
@@ -2,6 +2,7 @@ package arcs.api;
 
 import javax.inject.Inject;
 
+@javax.inject.Singleton
 public class HandleFactory {
 
   @Inject

--- a/javaharness/java/arcs/api/PecInnerPort.java
+++ b/javaharness/java/arcs/api/PecInnerPort.java
@@ -95,9 +95,9 @@ public class PecInnerPort {
         if (mapper.hasThingForIdentifier(particleId)) {
           // Non-factory instantiation of a Particle.
           Particle particle = mapper.thingForIdentifier(particleId).getParticle();
-          initializeParticle(particle, spec, proxies, idGenerator);
           // TODO: implement proper capabilities.
           particle.setOutput((content) -> output(particle, content));
+          initializeParticle(particle, spec, proxies, idGenerator);
         } else {
           throw new AssertionError(
               "Unexpected instantiate/reinstantiate call for " + particleId);

--- a/javaharness/java/arcs/api/PecPortManager.java
+++ b/javaharness/java/arcs/api/PecPortManager.java
@@ -2,10 +2,7 @@ package arcs.api;
 
 import java.util.HashMap;
 import java.util.Map;
-import javax.inject.Inject;
-import javax.inject.Singleton;
 
-@Singleton
 public class PecPortManager {
 
   private final ArcsMessageSender arcsMessageSender;
@@ -15,8 +12,7 @@ public class PecPortManager {
   private final Map<String, PecInnerPort> pecPortMap = new HashMap<>();
   private final Map<String, PecInnerPortProxy> pecInnerPortProxyMap = new HashMap<>();
 
-  @Inject
-  PecPortManager(
+  public PecPortManager(
       ArcsMessageSender arcsMessageSender,
       PortableJsonParser jsonParser,
       HandleFactory handleFactory) {

--- a/javaharness/java/arcs/api/UiBroker.java
+++ b/javaharness/java/arcs/api/UiBroker.java
@@ -3,10 +3,7 @@ package arcs.api;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Logger;
-import javax.inject.Inject;
-import javax.inject.Singleton;
 
-@Singleton
 public final class UiBroker {
 
   private static final Logger logger = Logger.getLogger(UiBroker.class.getName());
@@ -15,8 +12,7 @@ public final class UiBroker {
 
   private final Map<String, UiRenderer> renderers = new HashMap<>();
 
-  @Inject
-  UiBroker() {}
+  public UiBroker() {}
 
   public void registerRenderer(String modality, UiRenderer renderer) {
     renderers.put(modality, renderer);


### PR DESCRIPTION
When they are in the same DI scope, ArcsMessageSender could ended up sending message to itself, causing a deadloop. Since we have two DI systems, I decided it's best manually creating these classes as otherwise a lot of manual code replacement needs to be done when importing.