### PR TITLE
Fix G3 presubmit issues

### DIFF
--- a/src/runtime/keymgmt/base64.ts
+++ b/src/runtime/keymgmt/base64.ts
@@ -1,20 +1,23 @@
 /* eslint-disable header/header */
 
-// ISC License (ISC)
-//
-// Copyright 2017 Rhett Robinson
-//
-// Permission to use, copy, modify, and/or distribute this software for any purpose
-// with or without fee is hereby granted, provided that the above copyright notice
-// and this permission notice appear in all copies.
-//
-//     THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
-// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
-// FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
-//     INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
-// OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
-// TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
-// THIS SOFTWARE.
+/**
+ * @license
+ * ISC License (ISC)
+ *
+ * Copyright 2017 Rhett Robinson
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any purpose
+ * with or without fee is hereby granted, provided that the above copyright notice
+ * and this permission notice appear in all copies.
+ *
+ *     THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+ * REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+ *     INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+ * OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+ * TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+ * THIS SOFTWARE.
+ */
 
 // Originally forked from https://github.com/rrhett/typescript-base64-arraybuffer/blob/master/src/base64.ts
 // For the base64 encoding pieces.

--- a/src/wasm/kotlin/tests/arcs/BUILD
+++ b/src/wasm/kotlin/tests/arcs/BUILD
@@ -1,5 +1,7 @@
 load("//third_party/java/arcs/build_defs:build_defs.bzl", "arcs_kt_schema")
-load("//third_party/bazel_rules/rules_kotlin/kotlin/native:native_rules.bzl", "kt_native_binary")
+load("//third_party/bazel_rules/rules_kotlin/kotlin/native:native_rules.bzl", "kt_native_library", "kt_native_binary")
+
+licenses(["notice"])
 
 filegroup(
   name = "schemas_srcs",
@@ -13,9 +15,16 @@ arcs_kt_schema(
     srcs = ["schemas.arcs"],
 )
 
+kt_native_library(
+    name = "test-module_lib",
+    srcs = glob(["*.kt"]),
+    visibility = ["//visibility:public"],
+    deps = [":test_schemas"],
+)
+
 kt_native_binary(
     name = "test-module",
-    srcs = glob(["*.kt"]),
-    deps = [":test_schemas"],
     visibility = ["//visibility:public"],
+    deps = [":test-module_lib"],
 )
+

--- a/third_party/java/arcs/build_defs/internal/kotlin.bzl
+++ b/third_party/java/arcs/build_defs/internal/kotlin.bzl
@@ -5,7 +5,7 @@ Rules are re-exported in build_defs.bzl -- use those instead.
 
 load("//third_party/bazel_rules/rules_kotlin/kotlin/native:native_rules.bzl", "kt_native_binary", "kt_native_library")
 load("//third_party/bazel_rules/rules_kotlin/kotlin/js:js_library.bzl", "kt_js_library", kt_js_import = "kt_js_import_fixed")
-load("//tools/build_defs/kotlin:rules.bzl", "kt_android_library", "kt_jvm_library")
+load("//tools/build_defs/kotlin:rules.bzl", "kt_jvm_library")
 
 _ARCS_KOTLIN_LIBS = ["//third_party/java/arcs/sdk/kotlin"]
 


### PR DESCRIPTION
Needed so future imports won't break.

kt_native_binary in G3 doesn't accept a 'srcs' parameter 
