### PR TITLE
Add optional '*' for recipe handle syntax

### DIFF
--- a/src/runtime/manifest-parser.peg
+++ b/src/runtime/manifest-parser.peg
@@ -1370,6 +1370,13 @@ HandleRef
       tags: tags || [],
     });
   }
+  / '*' tags:SpaceTagList?
+  {
+    return toAstNode<AstNode.HandleRef>({
+      kind: 'handle-ref',
+      tags: tags || [],
+    });
+  }
   / tags:TagList
   {
     return toAstNode<AstNode.HandleRef>({

--- a/src/runtime/manual_tests/firebase-test.ts
+++ b/src/runtime/manual_tests/firebase-test.ts
@@ -713,9 +713,9 @@ describe('firebase', function() {
             big: reads writes BigCollection<Data>
 
           recipe
-            handle0: use
-            handle1: use
-            handle2: use
+            handle0: use *
+            handle1: use *
+            handle2: use *
             P
               var: reads handle0
               col: writes handle1

--- a/src/runtime/tests/manifest-test.ts
+++ b/src/runtime/tests/manifest-test.ts
@@ -376,15 +376,15 @@ ${particleStr1}
         x: writes S
 
       recipe
-        handle1: use
-        handle2: use
+        handle1: use *
+        handle2: use *
         P1
           x: writes handle1
         P1
           x: writes handle2
       recipe
-        handle1: use
-        handle2: use
+        handle1: use *
+        handle2: use *
         P1
           x: writes handle2
         P1


### PR DESCRIPTION
This supports the 'use *' star syntax that was discussed in recipe committee, an oversight from previous unification syntax changes.

It's allowed, but not required so that `use #tag` and `create #tag` round trip neatly without more complex rules for when it should be used. Later we should revisit 'target' syntax but that's part of syntax v2 work.