### PR TITLE
Add .npmrc to disable package-lock for sub-projects.

### DIFF
--- a/devtools/.npmrc
+++ b/devtools/.npmrc
@@ -1,0 +1,1 @@
+package-lock = false

--- a/server/.npmrc
+++ b/server/.npmrc
@@ -1,0 +1,1 @@
+package-lock = false

--- a/src/tools/vscode-language-client/.npmrc
+++ b/src/tools/vscode-language-client/.npmrc
@@ -1,0 +1,1 @@
+package-lock = false


### PR DESCRIPTION
Oversight that should have been done as part of #3993.