### PR TITLE
update devtools-connector tests to be compatible with new storage stack

### DIFF
--- a/src/devtools-connector/tests/arc-stores-fetcher-test.ts
+++ b/src/devtools-connector/tests/arc-stores-fetcher-test.ts
@@ -15,20 +15,9 @@ import {FakeSlotComposer} from '../../runtime/testing/fake-slot-composer.js';
 import {StubLoader} from '../../runtime/testing/stub-loader.js';
 import {Manifest} from '../../runtime/manifest.js';
 import {Runtime} from '../../runtime/runtime.js';
-import {VolatileSingleton} from '../../runtime/storage/volatile-storage.js';
-import {VolatileStorageKey} from '../../runtime/storageNG/drivers/volatile.js';
 import {SingletonType} from '../../runtime/type.js';
-import {singletonHandleForTest} from '../../runtime/testing/handle-for-test.js';
-import {StorageKey} from '../../runtime/storageNG/storage-key.js';
+import {singletonHandleForTest, storageKeyPrefixForTest} from '../../runtime/testing/handle-for-test.js';
 import {Flags} from '../../runtime/flags.js';
-import {ArcId} from '../../runtime/id.js';
-
-function getStorageKeyPrefix(): string|((arcId: ArcId) => StorageKey) {
-  if (Flags.useNewStorageStack) {
-    return arcId => new VolatileStorageKey(arcId, '');
-  }
-  return 'volatile://';
-}
 
 describe('ArcStoresFetcher', () => {
   before(() => DevtoolsForTests.ensureStub());
@@ -39,7 +28,7 @@ describe('ArcStoresFetcher', () => {
       schema Foo
         Text value`);
     const runtime = new Runtime(new StubLoader({}), FakeSlotComposer, context);
-    const arc = runtime.newArc('demo', getStorageKeyPrefix(), {inspectorFactory: devtoolsArcInspectorFactory});
+    const arc = runtime.newArc('demo', storageKeyPrefixForTest(), {inspectorFactory: devtoolsArcInspectorFactory});
 
     const foo = arc.context.findSchemaByName('Foo').entityClass();
     const fooStore = await arc.createStore(new SingletonType(foo.type), 'fooStoreName', 'fooStoreId', ['awesome', 'arcs']);
@@ -118,7 +107,7 @@ describe('ArcStoresFetcher', () => {
         P
           foo = foo`);
     const runtime = new Runtime(loader, FakeSlotComposer, context);
-    const arc = runtime.newArc('demo', getStorageKeyPrefix(), {inspectorFactory: devtoolsArcInspectorFactory});
+    const arc = runtime.newArc('demo', storageKeyPrefixForTest(), {inspectorFactory: devtoolsArcInspectorFactory});
 
     const recipe = arc.context.recipes[0];
     recipe.normalize();

--- a/src/devtools-connector/tests/devtools-arc-inspector-test.ts
+++ b/src/devtools-connector/tests/devtools-arc-inspector-test.ts
@@ -15,6 +15,18 @@ import {MockSlotComposer} from '../../runtime/testing/mock-slot-composer.js';
 import {StubLoader} from '../../runtime/testing/stub-loader.js';
 import {Manifest} from '../../runtime/manifest.js';
 import {Runtime} from '../../runtime/runtime.js';
+import {VolatileStorageKey} from '../../runtime/storageNG/drivers/volatile.js';
+import {SingletonType} from '../../runtime/type.js';
+import {StorageKey} from '../../runtime/storageNG/storage-key.js';
+import {Flags} from '../../runtime/flags.js';
+import {ArcId} from '../../runtime/id.js';
+
+function getStorageKeyPrefix(): string|((arcId: ArcId) => StorageKey) {
+  if (Flags.useNewStorageStack) {
+    return arcId => new VolatileStorageKey(arcId, '');
+  }
+  return 'volatile://';
+}
 
 describe('DevtoolsArcInspector', () => {
   before(() => DevtoolsForTests.ensureStub());
@@ -38,7 +50,7 @@ describe('DevtoolsArcInspector', () => {
         P
           foo = foo`);
     const runtime = new Runtime(loader, MockSlotComposer, context);
-    const arc = runtime.newArc('demo', 'volatile://', {inspectorFactory: devtoolsArcInspectorFactory});
+    const arc = runtime.newArc('demo', getStorageKeyPrefix(), {inspectorFactory: devtoolsArcInspectorFactory});
 
     const foo = arc.context.findSchemaByName('Foo').entityClass();
     const fooStore = await arc.createStore(foo.type, undefined, 'fooStore');

--- a/src/devtools-connector/tests/devtools-arc-inspector-test.ts
+++ b/src/devtools-connector/tests/devtools-arc-inspector-test.ts
@@ -15,18 +15,7 @@ import {MockSlotComposer} from '../../runtime/testing/mock-slot-composer.js';
 import {StubLoader} from '../../runtime/testing/stub-loader.js';
 import {Manifest} from '../../runtime/manifest.js';
 import {Runtime} from '../../runtime/runtime.js';
-import {VolatileStorageKey} from '../../runtime/storageNG/drivers/volatile.js';
-import {SingletonType} from '../../runtime/type.js';
-import {StorageKey} from '../../runtime/storageNG/storage-key.js';
-import {Flags} from '../../runtime/flags.js';
-import {ArcId} from '../../runtime/id.js';
-
-function getStorageKeyPrefix(): string|((arcId: ArcId) => StorageKey) {
-  if (Flags.useNewStorageStack) {
-    return arcId => new VolatileStorageKey(arcId, '');
-  }
-  return 'volatile://';
-}
+import {storageKeyPrefixForTest} from '../../runtime/testing/handle-for-test.js';
 
 describe('DevtoolsArcInspector', () => {
   before(() => DevtoolsForTests.ensureStub());
@@ -50,7 +39,7 @@ describe('DevtoolsArcInspector', () => {
         P
           foo = foo`);
     const runtime = new Runtime(loader, MockSlotComposer, context);
-    const arc = runtime.newArc('demo', getStorageKeyPrefix(), {inspectorFactory: devtoolsArcInspectorFactory});
+    const arc = runtime.newArc('demo', storageKeyPrefixForTest(), {inspectorFactory: devtoolsArcInspectorFactory});
 
     const foo = arc.context.findSchemaByName('Foo').entityClass();
     const fooStore = await arc.createStore(foo.type, undefined, 'fooStore');

--- a/src/runtime/arc.ts
+++ b/src/runtime/arc.ts
@@ -29,7 +29,7 @@ import {compareComparables} from './recipe/comparable.js';
 import {SlotComposer} from './slot-composer.js';
 import {StorageProviderBase, SingletonStorageProvider} from './storage/storage-provider-base.js';
 import {StorageProviderFactory} from './storage/storage-provider-factory.js';
-import {ArcType, CollectionType, EntityType, InterfaceType, RelationType, Type, TypeVariable, SingletonType, ReferenceType} from './type.js';
+import {ArcType, CollectionType, EntityType, InterfaceType, RelationType, ReferenceType, SingletonType, Type, TypeVariable} from './type.js';
 import {PecFactory} from './particle-execution-context.js';
 import {InterfaceInfo} from './interface-info.js';
 import {Mutex} from './mutex.js';
@@ -568,6 +568,11 @@ constructor({id, context, pecFactories, slotComposer, loader, storageKey, storag
     if (Flags.useNewStorageStack) {
       if (typeof storageKey === 'string') {
         throw new Error(`Can't use string storage keys with the new storage stack.`);
+      }
+      // Wrap entity types in a singleton.
+      if (type.isEntity) {
+        // TODO: Once recipes can handle singleton types this conversion can be removed.
+        type = new SingletonType(type);
       }
       store = new Store({storageKey, exists: Exists.MayExist, type, id, name});
     } else {

--- a/src/runtime/storageNG/unified-store.ts
+++ b/src/runtime/storageNG/unified-store.ts
@@ -52,6 +52,7 @@ export abstract class UnifiedStore implements Comparable<UnifiedStore>, OldStore
 
   // Series of StoreInfo getters to make migration easier.
   get id() { return this.storeInfo.id; }
+  get apiChannelMappingId() { return this.id; }
   get name() { return this.storeInfo.name; }
   get type() { return this.storeInfo.type; }
   get originalId() { return this.storeInfo.originalId; }

--- a/src/runtime/testing/handle-for-test.ts
+++ b/src/runtime/testing/handle-for-test.ts
@@ -20,6 +20,10 @@ import {CRDTSingletonTypeRecord} from '../crdt/crdt-singleton.js';
 import {Manifest} from '../manifest.js';
 import {SerializedEntity} from '../storage-proxy.js';
 import {Entity} from '../entity.js';
+import {VolatileStorageKey} from '../../runtime/storageNG/drivers/volatile.js';
+import {StorageKey} from '../../runtime/storageNG/storage-key.js';
+import {ArcId} from '../../runtime/id.js';
+
 
 /**
  * Creates a singleton handle for a store for testing purposes. Returns an
@@ -72,6 +76,17 @@ export async function collectionHandleForTest(arcOrManifest: Arc | Manifest, sto
       throw new Error('Expected Collection.');
     }
   }
+}
+
+/**
+ * Creates a storage key prefix for a store for testing purposes. Returns an
+ * appropriate string or NG storage key type depending on the storage migration flag.
+ */
+export function storageKeyPrefixForTest(): string|((arcId: ArcId) => StorageKey) {
+  if (Flags.useNewStorageStack) {
+    return arcId => new VolatileStorageKey(arcId, '');
+  }
+  return 'volatile://';
 }
 
 async function createStorageProxyForTest<T extends CRDTTypeRecord>(

--- a/src/runtime/type.ts
+++ b/src/runtime/type.ts
@@ -179,6 +179,9 @@ export abstract class Type {
     return false;
   }
 
+  get isEntity(): boolean {
+    return false;
+  }
 
   collectionOf() {
     return new CollectionType(this);
@@ -313,6 +316,10 @@ export class SingletonType<T extends Type> extends Type {
 
   get isSingleton(): boolean {
     return true;
+  }
+
+  getEntitySchema(): Schema {
+    return this.innerType.getEntitySchema();
   }
 
   toString(options = undefined): string {


### PR DESCRIPTION
This required changing arc.createStore to wrap entities in singleton (for new storage stack only).