### PR TITLE
Disable bazel tests on Travis while we fix sandbox breakage.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,15 +13,15 @@ addons:
 script:
   # Bazel build & test everything. Can't use `bazel build ...` yet, because
   # javaharness doesn't build on Travis (needs working Android SDK).
+  #
+  # TODO(csilvestrini): Restore //particles/... and //src/... to blaze
+  # build/test below when they're operational on Travis again.
+  # https://github.com/PolymerLabs/arcs/issues/4018
   - >
     bazel build --noshow_progress --noshow_loading_progress
-    //particles/...
-    //src/...
     //src_kt/...
   - >
     bazel test --noshow_progress --noshow_loading_progress --test_output=errors
-    //particles/...
-    //src/...
     //src_kt/...
   - npm run test-with-start
   - npm run build:rollup


### PR DESCRIPTION
Follow-up tracked in https://github.com/PolymerLabs/arcs/issues/4018