### PR TITLE
Fix: rm Bazel Cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,6 @@ script:
 
 cache:
   npm: true
-  directories:
-    - /home/travis/.cache/bazel/
 
 # Thinking about adding install steps? Why not modify the tools/setup script instead?
 # The list command dumps the top-level packages with their versions, in case we need that for debugging.


### PR DESCRIPTION
The Bazel cache is making the build run north of 15hrs. Let's revert the change to speed up the build. 