### PR TITLE
Pins tsc and express versions to fix build, and restores tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,15 +13,15 @@ addons:
 script:
   # Bazel build & test everything. Can't use `bazel build ...` yet, because
   # javaharness doesn't build on Travis (needs working Android SDK).
-  #
-  # TODO(csilvestrini): Restore //particles/... and //src/... to blaze
-  # build/test below when they're operational on Travis again.
-  # https://github.com/PolymerLabs/arcs/issues/4018
   - >
     bazel build --noshow_progress --noshow_loading_progress
+    //particles/...
+    //src/...
     //src_kt/...
   - >
     bazel test --noshow_progress --noshow_loading_progress --test_output=errors
+    //particles/...
+    //src/...
     //src_kt/...
   - npm run test-with-start
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@types/chai": "^4.1.7",
-    "@types/express": "^4.17.0",
+    "@types/express": "4.17.1",
     "@types/jszip": "^3.1.6",
     "@types/minimist": "^1.2.0",
     "@types/mocha": "^5.2.7",
@@ -61,7 +61,7 @@
     "eslint-config-google": "^0.14.0",
     "eslint-plugin-header": "^3.0.0",
     "eslint-plugin-import": "^2.18.2",
-    "express": "^4.17.1",
+    "express": "4.17.1",
     "glob": "^7.1.4",
     "grammkit": "0.7.0",
     "js-green-licenses": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "pouchdb-debug": "^7.1.1",
     "source-map-support": "^0.5.12",
     "sourcemapped-stacktrace": "^1.1.9",
-    "typescript": "^3.5.3",
+    "typescript": "3.7.2",
     "ws": "~6.0.0"
   },
   "repository": {

--- a/server/package.json
+++ b/server/package.json
@@ -51,7 +51,7 @@
     "@types/cors": "^2.8.5",
     "@types/debug": "4.1.4",
     "@types/expect": "^1.20.4",
-    "@types/express": "^4.17.0",
+    "@types/express": "4.17.1",
     "@types/mocha": "^5.2.7",
     "@types/morgan": "^1.7.35",
     "@types/node": "^10.12.24",

--- a/server/package.json
+++ b/server/package.json
@@ -72,7 +72,7 @@
     "ts-node-dev": "^1.0.0-pre.39",
     "tslint": "^5.18.0",
     "typedoc": "^0.14.2",
-    "typescript": "^3.5.1"
+    "typescript": "3.7.2"
   },
   "repository": {
     "type": "git",

--- a/shells/tests/specs/webshell-test.js
+++ b/shells/tests/specs/webshell-test.js
@@ -31,10 +31,7 @@ describe('wait for server', () => {
 
 const persona = `${marshalPersona('volatile')}`;
 describe(`WASM (${persona})`, () => {
-  // TODO(csilvestrini): Re-enable this test once Wasm particle
-  // blaze builds are operational again.
-  // https://github.com/PolymerLabs/arcs/issues/4018
-  it.skip('loads Kotlin Tutorial 1', async function() {
+  it('loads Kotlin Tutorial 1', async function() {
     console.log(`running "${this.test.fullTitle()}"`);
     await openArc(persona);
     await searchFor('Kotlin');

--- a/src/tools/vscode-language-client/package.json
+++ b/src/tools/vscode-language-client/package.json
@@ -58,7 +58,7 @@
     "devDependencies": {
         "mocha": "^6.1.4",
         "tslint": "^5.14.0",
-        "typescript": "^3.0.0",
+        "typescript": "3.7.2",
         "vsce": "^1.63.0",
         "vscode": "^1.1.36"
     },


### PR DESCRIPTION
- Pins tsc to version 3.7.2
- Pins express to version 4.17.1
- Restores webshell test (reverts #4022)
- Restores bazel tests on Travis (reverts #4019)

Remaining work is to restore personal cloud build/test on Travis (i.e. revert #4024)

This PR addresses most of #4018