### PR TITLE
Fixes personal cloud build and restores test on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ script:
     //src/...
     //src_kt/...
   - npm run test-with-start
+  - npm run build:rollup
+  - npm --prefix=server test
 
 cache:
   npm: true

--- a/server/package.json
+++ b/server/package.json
@@ -72,7 +72,7 @@
     "ts-node-dev": "^1.0.0-pre.39",
     "tslint": "^5.18.0",
     "typedoc": "^0.14.2",
-    "typescript": "3.7.2"
+    "typescript": "3.6.4"
   },
   "repository": {
     "type": "git",

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -49,9 +49,11 @@ function onError(error: NodeJS.ErrnoException): void {
     case 'EACCES':
       console.error(`${bind} requires elevated privileges`);
       process.exit(1);
+      break;
     case 'EADDRINUSE':
       console.error(`${bind} is already in use`);
       process.exit(1);
+      break;
     default:
       throw error;
   }

--- a/src/tools/dev_server/status-handler.ts
+++ b/src/tools/dev_server/status-handler.ts
@@ -17,10 +17,7 @@ import {ExplorerProxy} from './explorer-proxy.js';
  * Very simple at the moment, will likely grow as we add features.
  */
 export function status(proxy: ExplorerProxy) {
-  // The following any is the return type defined in express-serve-static-core/index.d.ts.
-  // It is needed here to resolve the type for tsc, which otherwise throws error TS2742.
-  // tslint:disable-next-line no-any
-  return (req: Request, res: Response, next: NextFunction): any => {
+  return (req: Request, res: Response, next: NextFunction) => {
     if (req.path !== '/status') {
       return next();
     }


### PR DESCRIPTION
- Revert tsc version to 3.6.4 for server (we haven't the server code to work with 3.7.2 yet)
- Reverts #4014 (caused error TS7027: Unreachable code detected).
- Restores personal cloud test on Travis (reverts #4024).

Build should be back to normal!

Fixes #4018.