### PR TITLE
Adds a small test for inline schema usage

### DIFF
--- a/src/runtime/tests/manifest-test.ts
+++ b/src/runtime/tests/manifest-test.ts
@@ -245,6 +245,16 @@ ${particleStr1}
     verify(manifest);
     verify(await Manifest.parse(manifest.toString(), {}));
   });
+  it('can parse a manifest containing an inline schema', async () => {
+    const manifest = await Manifest.parse(`
+      schema Foo
+        value: Text
+      particle Fooer
+        foo: reads Foo {value}`);
+    const verify = (manifest: Manifest) => verifyPrimitiveType(manifest.schemas.Foo.fields.value, 'Text');
+    verify(manifest);
+    verify(await Manifest.parse(manifest.toString(), {}));
+  });
   it('two manifests with stores with the same filename, store name and data have the same ids', async () => {
     const manifestA = await Manifest.parse(`
         store NobId of NobIdStore {nobId: Text} in NobIdJson

--- a/src/runtime/tests/wasm-test.ts
+++ b/src/runtime/tests/wasm-test.ts
@@ -154,7 +154,7 @@ describe('wasm', () => {
       }
     });
   });
-  
+
   it('decodes array', () => {
     const str = '3:D27:2:4:nameT4:Jill3:ageT4:70.0D27:2:4:nameT4:Jack3:ageT4:25.0D26:2:4:nameT3:Jen3:ageT4:50.0';
     const list = StringDecoder.decodeArray(str);


### PR DESCRIPTION
This ensures that the new syntax's inline schema fields work as expected.

Also fixes a lint issue that was blocking.