### PR TITLE
Fix for global not being defined on the web

### DIFF
--- a/src/runtime/manifest-parser.peg
+++ b/src/runtime/manifest-parser.peg
@@ -100,7 +100,7 @@ Manifest
     });
     checkNormal(result);
     if (preSlandlesSyntaxLocations.length > 0 && !Flags.defaultToPreSlandlesSyntax) {
-      if (!global['testFlags'].quiet) {
+      if (typeof global !== 'undefined' && !global['testFlags'].quiet) {
         console.warn('WARNING: Pre-Slandles Syntax is deprecated. Contact jopra@google.com for more information.');
         console.warn(`WARNING: Used in \n  ${
           preSlandlesSyntaxLocations.map(loc => `line ${loc.start.line} column ${loc.start.column}`).join("\n  ")


### PR DESCRIPTION
Global doesn't exist on the web. This causes parse failure if preslandles syntax is used with preslandles syntax turned off (set of false in src/runtime/flags.ts).