### PR TITLE
Add wasm_kt_binary to kotlin.bzl

### DIFF
--- a/third_party/bazel_rules/rules_kotlin/kotlin/native/wasm.bzl
+++ b/third_party/bazel_rules/rules_kotlin/kotlin/native/wasm.bzl
@@ -1,3 +1,3 @@
 # Alias wasm split transition rule unless G3 Kotlin Native synced with GH rules
 def wasm_kt_binary(name, kt_target):
-    native.alias(name = name, actual = kt_target)
+    native.alias(name = name, actual = kt_target, visibility = ["//visibility:public"])

--- a/third_party/bazel_rules/rules_kotlin/kotlin/native/wasm.bzl
+++ b/third_party/bazel_rules/rules_kotlin/kotlin/native/wasm.bzl
@@ -1,0 +1,3 @@
+# Alias wasm split transition rule unless G3 Kotlin Native synced with GH rules
+def wasm_kt_binary(name, kt_target):
+    native.alias(name = name, actual = kt_target)

--- a/third_party/java/arcs/build_defs/internal/kotlin.bzl
+++ b/third_party/java/arcs/build_defs/internal/kotlin.bzl
@@ -6,6 +6,7 @@ Rules are re-exported in build_defs.bzl -- use those instead.
 load("//third_party/bazel_rules/rules_kotlin/kotlin/native:native_rules.bzl", "kt_native_binary", "kt_native_library")
 load("//third_party/bazel_rules/rules_kotlin/kotlin/js:js_library.bzl", "kt_js_library", kt_js_import = "kt_js_import_fixed")
 load("//tools/build_defs/kotlin:rules.bzl", "kt_jvm_library")
+load("//third_party/bazel_rules/rules_kotlin/kotlin/native:wasm.bzl", "wasm_kt_binary")
 
 _ARCS_KOTLIN_LIBS = ["//third_party/java/arcs/sdk/kotlin"]
 
@@ -25,22 +26,29 @@ def arcs_kt_binary(name, srcs = [], deps = [], visibility = None):
 
     if srcs:
         libname = name + "_lib"
+
         # Declare a library because g3 kt_native_binary doesn't take srcs
         kt_native_library(
             name = libname,
             srcs = srcs,
             deps = _ARCS_KOTLIN_LIBS + deps,
-            visibility = visibility
+            visibility = visibility,
         )
 
         deps = [":" + libname]
 
+    bin_name = name + "_bin"
     kt_native_binary(
-        name = name,
+        name = bin_name,
         entry_point = "arcs.main",
         deps = _ARCS_KOTLIN_LIBS + deps,
         tags = ["wasm"],
         visibility = visibility,
+    )
+
+    wasm_kt_binary(
+        name = name,
+        kt_target = ":" + bin_name,
     )
 
 def kt_jvm_and_js_library(

--- a/third_party/java/arcs/build_defs/internal/kotlin.bzl
+++ b/third_party/java/arcs/build_defs/internal/kotlin.bzl
@@ -37,9 +37,8 @@ def arcs_kt_binary(name, srcs = [], deps = [], visibility = None):
 
         deps = [":" + libname]
 
-    bin_name = name + "_bin"
     kt_native_binary(
-        name = bin_name,
+        name = name,
         entry_point = "arcs.main",
         deps = _ARCS_KOTLIN_LIBS + deps,
         tags = ["wasm"],
@@ -47,8 +46,8 @@ def arcs_kt_binary(name, srcs = [], deps = [], visibility = None):
     )
 
     wasm_kt_binary(
-        name = name,
-        kt_target = ":" + bin_name,
+        name = name + "_wasm",
+        kt_target = ":" + name,
     )
 
 def kt_jvm_and_js_library(


### PR DESCRIPTION
For now, this just aliases. When kt_native_binary is synced between G3 and GH, we can use
the real implementation. Right now, kt_native_binary in GH already implies WASM.
