### PR TITLE
Create guardWith property delegate.

### DIFF
--- a/src_kt/java/arcs/util/BUILD
+++ b/src_kt/java/arcs/util/BUILD
@@ -7,5 +7,6 @@ kt_jvm_and_js_library(
     srcs = glob(["*.kt"]),
     deps = [
         "//third_party/kotlin/kotlinx/kotlinx_atomicfu",
+        "//third_party/kotlin/kotlinx/kotlinx_coroutines",
     ],
 )

--- a/src_kt/java/arcs/util/Guard.kt
+++ b/src_kt/java/arcs/util/Guard.kt
@@ -1,0 +1,85 @@
+package arcs.arcs.util
+
+import kotlinx.coroutines.sync.Mutex
+import kotlin.properties.ReadWriteProperty
+import kotlin.reflect.KProperty
+
+/**
+ * Builds a [Guard] property delegate where all access/mutation to the delegated property must be
+ * done within a lock on the provided [mutex].
+ *
+ * [initialValue] is a function which returns the starting value of the property.
+ *
+ * Example:
+ *
+ * ```kotlin
+ * class MyClass {
+ *     val mutex = Mutex()
+ *     var myProtectedString: String by guardWith(mutex) { "Hello world." }
+ *
+ *     suspend fun succeed() {
+ *         val randomNum = Random.nextInt()
+ *         mutex.withLock { myProtectedString = "Random: $randomNum" }
+ *     }
+ *
+ *     suspend fun crash() {
+ *         val randomNum = Random.nextInt()
+ *         myProtectedString = "Random: $randomNum"
+ *     }
+ * }
+ * ```
+ */
+fun <T> guardWith(mutex: Mutex, initialValue: () -> T) = Guard(mutex, initialValue())
+
+/**
+ * Builds a [Guard] property delegate where all access/mutation to the delegated property must be
+ * done within a lock on the provided [mutex].
+ *
+ * [initialValue] is the starting value of the property.
+ *
+ * Example:
+ *
+ * ```kotlin
+ * class MyClass {
+ *     val mutex = Mutex()
+ *     var myProtectedString: String by guardWith(mutex, "Hello world.")
+ *
+ *     suspend fun succeed() {
+ *         val randomNum = Random.nextInt()
+ *         mutex.withLock { myProtectedString = "Random: $randomNum" }
+ *     }
+ *
+ *     suspend fun crash() {
+ *         val randomNum = Random.nextInt()
+ *         myProtectedString = "Random: $randomNum"
+ *     }
+ * }
+ * ```
+ */
+fun <T> guardWith(mutex: Mutex, initialValue: T) = Guard(mutex, initialValue)
+
+/** Provider of the [GuardDelegate] property delegate. */
+class Guard<T>(private val mutex: Mutex, private val initialValue: T) {
+    operator fun provideDelegate(thisRef: Any, prop: KProperty<*>): ReadWriteProperty<Any, T> =
+        GuardDelegate(mutex, initialValue)
+}
+
+/**
+ * Implementation of a [ReadWriteProperty] delegate which checks that the given [mutex] is locked
+ * before allowing access/modification to the [value].
+ */
+private class GuardDelegate<T>(
+    private val mutex: Mutex,
+    private var value: T
+) : ReadWriteProperty<Any, T> {
+    override fun getValue(thisRef: Any, property: KProperty<*>): T {
+        check(mutex.isLocked) { "Access to ${property.name} must be done within a mutex lock." }
+        return value
+    }
+
+    override fun setValue(thisRef: Any, property: KProperty<*>, value: T) {
+        check(mutex.isLocked) { "Changes to ${property.name} must be done within a mutex lock." }
+        this.value = value
+    }
+}
+

--- a/src_kt/javatests/arcs/util/BUILD
+++ b/src_kt/javatests/arcs/util/BUILD
@@ -10,10 +10,12 @@ load("//tools/build_defs/kotlin:rules.bzl", "kt_jvm_test")
         test_class = "arcs.util.%s" % src_file[:-3],
         deps = [
             "//src_kt/java/arcs/util",
+            "//src_kt/java/arcs/testutil",
             "//third_party/java/junit",
             "//third_party/java/truth",
-            "//third_party/kotlin/kotlinx/kotlinx_coroutines",
             "//third_party/kotlin/kotlinx/kotlinx_atomicfu",
+            "//third_party/kotlin/kotlinx/kotlinx_coroutines",
+            "//third_party/kotlin/kotlinx/kotlinx_coroutines:kotlinx_coroutines_test",
         ],
     )
     for src_file in glob(

--- a/src_kt/javatests/arcs/util/GuardTest.kt
+++ b/src_kt/javatests/arcs/util/GuardTest.kt
@@ -1,0 +1,55 @@
+package arcs.util
+
+import arcs.arcs.util.guardWith
+import arcs.testutil.assertThrows
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+/** Tests for the [guardWith]-generated property delegate: [GuardDelegate]. */
+@ExperimentalCoroutinesApi
+@RunWith(JUnit4::class)
+class GuardTest {
+    class RequiresLocking(initialValue: Int = 0) {
+        val mutex = Mutex()
+        var value by guardWith(mutex) { initialValue }
+    }
+
+    @Test
+    fun accessingGuardedValue_outsideOfLock_throws() {
+        val obj = RequiresLocking()
+
+        assertThrows(IllegalStateException::class) { println(obj.value) }
+    }
+
+    @Test
+    fun accessingGuardedValue_insideLock_succeeds() = runBlockingTest {
+        val obj = RequiresLocking(100)
+
+        obj.mutex.withLock {
+            assertThat(obj.value).isEqualTo(100)
+        }
+    }
+
+    @Test
+    fun mutatingGuardedValue_outsideOfLock_throws() {
+        val obj = RequiresLocking()
+
+        assertThrows(IllegalStateException::class) { obj.value = 25 }
+    }
+
+    @Test
+    fun mutatingGuardedValue_insideLock_succeeds() = runBlockingTest {
+        val obj = RequiresLocking()
+
+        obj.mutex.withLock {
+            obj.value = 25
+            assertThat(obj.value).isEqualTo(25)
+        }
+    }
+}


### PR DESCRIPTION
It's turning out that we need to do a lot of mutual exclusion in various parts of the store, this new property delegate enforces a lock being held on a mutex before allowing accesses/mutations to a class's field.