### PR TITLE
Align wasm output directory with G3

### DIFF
--- a/third_party/bazel_rules/rules_kotlin/kotlin/native/wasm.bzl
+++ b/third_party/bazel_rules/rules_kotlin/kotlin/native/wasm.bzl
@@ -1,3 +1,10 @@
 # Alias wasm split transition rule unless G3 Kotlin Native synced with GH rules
 def wasm_kt_binary(name, kt_target):
-    native.alias(name = name, actual = kt_target, visibility = ["//visibility:public"])
+    native.genrule(
+        name = name,
+        srcs = [kt_target + ".wasm", kt_target + ".wasm.js"],
+        cmd = "cp $(location %s.wasm) $(@D)/%s.wasm; cp $(location %s.wasm.js) $(@D)/%s.wasm.js" % (kt_target, name, kt_target, name),
+        outs = ["%s.wasm" % name, "%s.wasm.js" % name],
+        tools = [kt_target],
+        visibility = ["//visibility:public"],
+    )


### PR DESCRIPTION
G3 auto wasm rule creates another directory target, where as previous we used an alias, this means you'd end up with the wasm files under two different blaze-bin directory locations. This PR makes wasm_kt_binary act more like the internal one in terms of output location.
