### PR TITLE
Configure travis to send email when cron fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,16 @@ sudo: required
 addons:
   chrome: stable
 
+# We want email to the whole team when the cron build fails. But regular PR
+# builds don't trigger email at all (per https://docs.travis-ci.com/user/notifications/#configuring-email-notifications),
+# so configuring email notifications should send them only from cron builds.
+notifications:
+  email:
+    recipients:
+      - arcs-team+cron@google.com
+    on_success: never # default: change
+    on_failure: always # default: always
+
 script:
   # Run ktlint against every kotlin file in the diff between the branch and master's head.
   - git diff --name-only --relative $TRAVIS_COMMIT_RANGE | grep '\.kt[s"]\?$' | xargs ktlint --android --relative --verbose .


### PR DESCRIPTION
The [travis docs say](https://docs.travis-ci.com/user/notifications/#configuring-email-notifications) that no email will be sent for normal push builds, so this
shouldn't cause any irrelevant spam, but let's see what actually happens.