### PR TITLE
Implement 'No any' syntax change for unification syntax

### DIFF
--- a/particles/Arcs/Login.arcs
+++ b/particles/Arcs/Login.arcs
@@ -9,6 +9,6 @@ recipe Login &login
   create as key
   slot 'rootslotid-root' as root
   Login
-    key: any key
+    key: key
     root: consumes root
   description `user sign in`

--- a/particles/Demo/ProductsDemo.arcs
+++ b/particles/Demo/ProductsDemo.arcs
@@ -20,19 +20,19 @@ recipe Products
     root: consumes
       annotation: provides annotationSlot
       action: provides actionSlot
-    list: any shoplist
-    selected: any selected
+    list: shoplist
+    selected: selected
   ItemMultiplexer
-    list: any shoplist
-    hostedParticle: any ProductItem
+    list: shoplist
+    hostedParticle: ProductItem
   //
   // &shopForOccasion
   person: map #claire
   GiftList
-    person: any person
+    person: person
   SimpleAnnotationMultiplexer
-    list: any shoplist
-    hostedParticle: any Arrivinator
+    list: shoplist
+    hostedParticle: Arrivinator
     annotation: consumes annotationSlot
   //
   // &addFromWishlist
@@ -41,27 +41,27 @@ recipe Products
   // annotates shoplist
   ChoicesMultiplexer
     choice: consumes annotationSlot
-    list: any shoplist
-    choices: any wishlist
-    hostedParticle: any AlsoOn
+    list: shoplist
+    choices: wishlist
+    hostedParticle: AlsoOn
   // recommend products from wishlist
   Recommend
-    population: any wishlist
-    known: any shoplist
-    recommendations: any recommendations
+    population: wishlist
+    known: shoplist
+    recommendations: recommendations
   // present recommendations for adding to shoplist
   Chooser
     action: consumes actionSlot
-    person: any person
-    choices: any recommendations
-    resultList: any shoplist
+    person: person
+    choices: recommendations
+    resultList: shoplist
   //
   // &manufacturerInfo
   SimpleAnnotationMultiplexer
-    list: any shoplist
-    hostedParticle: any ManufacturerInfo
+    list: shoplist
+    hostedParticle: ManufacturerInfo
   //
   // &productInterests
   Interests
-    list: any shoplist
-    person: any person
+    list: shoplist
+    person: person

--- a/particles/Layout/Detail.arcs
+++ b/particles/Layout/Detail.arcs
@@ -6,4 +6,4 @@ particle DetailSlider in 'source/DetailSlider.js'
 recipe DetailSlider
   selected: use #selected
   DetailSlider
-    selected: any selected
+    selected: selected

--- a/particles/Layout/SLANDLESDetail.arcs
+++ b/particles/Layout/SLANDLESDetail.arcs
@@ -6,4 +6,4 @@ particle SlandleDetailSlider in 'source/DetailSlider.js'
 recipe SlandleDetailSlider
   selected: use #selected
   SlandleDetailSlider
-    selected: any selected
+    selected: selected

--- a/particles/List/Annotations.arcs
+++ b/particles/List/Annotations.arcs
@@ -41,5 +41,5 @@ particle CombinedAnnotationMultiplexer in 'source/Multiplexer.js'
 //  list: use #items
 //  annotation: use #annotation
 //  AnnotationMultiplexer
-//    list: any list
-//    annotation: any annotation
+//    list: list
+//    annotation: annotation

--- a/particles/List/Items.arcs
+++ b/particles/List/Items.arcs
@@ -42,7 +42,7 @@ particle SelectableItems in 'source/Items.js'
   // TODO(sjmiles): without `#items` this recipe doesn't coalese, why?
 //  list: use #items
 //  ItemMultiplexer
-//    list: any list
+//    list: list
 
 // TODO(sjmiles): nearly duplicate recipes here because we want to support `use` and `copy` but not `create`,
 // maybe there should be a fate for this, or require `create` to be explicit
@@ -51,16 +51,16 @@ particle SelectableItems in 'source/Items.js'
 //  items: copy #items
 //  selected: create #selected
 //  SelectableItems
-//    items: any items
-//    selected: any selected
+//    items: items
+//    selected: selected
 //  ItemMultiplexer
-//    list: any items
+//    list: items
 
 //recipe SelectableUseItemsRecipe
 //  items: use #items
 //  selected: create #selected
 //  SelectableItems
-//    items: any items
-//    selected: any selected
+//    items: items
+//    selected: selected
 //  ItemMultiplexer
-//    list: any items
+//    list: items

--- a/particles/List/SLANDLESAnnotations.arcs
+++ b/particles/List/SLANDLESAnnotations.arcs
@@ -41,5 +41,5 @@ particle SlandleCombinedAnnotationMultiplexer in 'source/Multiplexer.js'
 //  list: use #items
 //  annotation: use #annotation
 //  SlandleAnnotationMultiplexer
-//    list: any list
-//    annotation: any annotation
+//    list: list
+//    annotation: annotation

--- a/particles/List/Tiles.arcs
+++ b/particles/List/Tiles.arcs
@@ -22,20 +22,20 @@ particle SelectableTiles in 'source/Tiles.js'
 //recipe TileMultiplexer
 //  list: use #tile
 //  TileMultiplexer
-//    list: any list
+//    list: list
 
 //recipe SelectableCopyTilesRecipe
 //  items: copy #items
 //  selected: create #selected
 //  SelectableTiles
-//    items: any items
-//    selected: any selected
+//    items: items
+//    selected: selected
 //  description `show ${SelectableTiles.items}`
 
 //recipe SelectableUseTilesRecipe
 //  use #items as items
 //  create #selected as selected
 //  SelectableTiles
-//    items: any items
-//    selected: any selected
+//    items: items
+//    selected: selected
 //  description `show ${SelectableTiles.items}`

--- a/particles/Music/Playlist.arcs
+++ b/particles/Music/Playlist.arcs
@@ -20,8 +20,8 @@ recipe PlaylistView
   items: map #items
   selected: create #selected
   ItemMultiplexer
-    list: any items
-    hostedParticle: any PlaylistItem
+    list: items
+    hostedParticle: PlaylistItem
   SelectableItems
-    list: any items
-    selected: any selected
+    list: items
+    selected: selected

--- a/particles/Products/Gifts.arcs
+++ b/particles/Products/Gifts.arcs
@@ -32,14 +32,14 @@ particle AlternateShipping in 'source/AlternateShipping.js'
 //  shoplist: use #shoplist
 //  person: copy *
 //  GiftList
-//    person: any person
+//    person: person
 //  Multiplexer
-//    list: any shoplist
-//    hostedParticle: any Arrivinator
+//    list: shoplist
+//    hostedParticle: Arrivinator
 //    annotation: consumes annotationSlot
 //  Multiplexer
-//    list: any shoplist
-//    hostedParticle: any AlternateShipping
+//    list: shoplist
+//    hostedParticle: AlternateShipping
 //    annotation: consumes annotationSlot
 //  description `check shipping for ${GiftList.person}'s ${GiftList.person.occasion} on ${GiftList.person.date}`
 

--- a/particles/Products/Interests.arcs
+++ b/particles/Products/Interests.arcs
@@ -20,12 +20,12 @@ particle Interests in 'source/Interests.js'
 //  wishlist: map #wishlist
 //  person: use *
 //  Interests
-//    list: any wishlist
-//    person: any person
+//    list: wishlist
+//    person: person
 
 recipe ProductInterests
   list: use *
   person: use *
   Interests
-    list: any list
-    person: any person
+    list: list
+    person: person

--- a/particles/Products/Manufacturer.arcs
+++ b/particles/Products/Manufacturer.arcs
@@ -17,6 +17,6 @@ particle ManufacturerInfo in 'source/ManufacturerInfo.js'
 recipe ProductManufacturerInfo
   shoplist: use *
   SimpleAnnotationMultiplexer
-    list: any shoplist
-    hostedParticle: any ManufacturerInfo
+    list: shoplist
+    hostedParticle: ManufacturerInfo
   description `check manufacturer information`

--- a/particles/Products/Products.arcs
+++ b/particles/Products/Products.arcs
@@ -12,20 +12,20 @@ import 'Interests.arcs'
 recipe Products
   products: use *
   Items
-    list: any products
+    list: products
   ItemMultiplexer
-    list: any products
-    hostedParticle: any ProductItem
+    list: products
+    hostedParticle: ProductItem
 
 // Entry point for Products Demo: create a shopping list from context data
 
 recipe CreateShoppingList
   products: copy *
   Items
-    list: any products
+    list: products
   ItemMultiplexer
-    list: any products
-    hostedParticle: any ProductItem
+    list: products
+    hostedParticle: ProductItem
   description `create shopping list from ${Items.list}`
 
 // Convert simple shopping list to a shopping list for an occasion, like a birthday
@@ -35,10 +35,10 @@ recipe ShopForOccasion
   shoplist: use *
   person: map
   GiftList
-    person: any person
+    person: person
   SimpleAnnotationMultiplexer
-    list: any shoplist
-    hostedParticle: any Arrivinator
+    list: shoplist
+    hostedParticle: Arrivinator
     annotation: consumes annotationSlot
   // description derives from GiftList particle
 
@@ -55,19 +55,19 @@ recipe UseWishlist
     // This is probably wrong, but it works now (instead of annotationSlot)
     // choice: consumes annotationSlot
     choice: consumes actionSlot
-    list: any shoplist
-    choices: any wishlist
-    hostedParticle: any AlsoOn
+    list: shoplist
+    choices: wishlist
+    hostedParticle: AlsoOn
   // recommend products from wishlist
   Recommend
-    population: any wishlist
-    known: any shoplist
-    recommendations: any recommendations
+    population: wishlist
+    known: shoplist
+    recommendations: recommendations
   // present recommendations for adding to shoplist
   Chooser
     action: consumes actionSlot
-    person: any person
-    choices: any recommendations
-    resultList: any shoplist
+    person: person
+    choices: recommendations
+    resultList: shoplist
 
 

--- a/particles/Profile/BasicProfile.arcs
+++ b/particles/Profile/BasicProfile.arcs
@@ -26,11 +26,11 @@ recipe BasicProfile
   avatars: map 'BOXED_avatar'
   userNames: map 'BOXED_userName'
   BasicProfile
-    avatar: any avatar
+    avatar: avatar
   UserNameForm
-    userName: any userName
+    userName: userName
   FriendsPicker
-    friends: any friends
-    avatars: any avatars
-    userNames: any userNames
+    friends: friends
+    avatars: avatars
+    userNames: userNames
   description `edit user profile (name, avatar, and friends)`

--- a/particles/Profile/FavoriteFood.arcs
+++ b/particles/Profile/FavoriteFood.arcs
@@ -15,5 +15,5 @@ particle FavoriteFoodPicker in 'source/FavoriteFoodPicker.js'
 recipe FavoriteFood
   foods: create #favoriteFoods
   FavoriteFoodPicker
-    foods: any foods
+    foods: foods
 

--- a/particles/Profile/Geolocate.arcs
+++ b/particles/Profile/Geolocate.arcs
@@ -9,4 +9,4 @@ particle Geolocate in './source/Geolocate.js'
 recipe Geolocate
   location: create *
   Geolocate
-    location: any location
+    location: location

--- a/particles/Restaurants/FavoriteFoodAnnotation.arcs
+++ b/particles/Restaurants/FavoriteFoodAnnotation.arcs
@@ -35,12 +35,12 @@ recipe FavoriteFoodAnnotation
   names: map 'BOXED_userName'
   descriptions: create *
   SharesFrom
-    shares: any foods
-    names: any names
-    descriptions: any descriptions
+    shares: foods
+    names: names
+    descriptions: descriptions
   AnnotationMultiplexerThree
-    list: any restaurants
-    choices: any foods
-    names: any names
-    hostedParticle: any FavoriteFoodAnnotation
+    list: restaurants
+    choices: foods
+    names: names
+    hostedParticle: FavoriteFoodAnnotation
   description `check restaurants for ${SharesFrom}'s favorite foods`

--- a/particles/Restaurants/Reservations.arcs
+++ b/particles/Restaurants/Reservations.arcs
@@ -53,27 +53,27 @@ recipe MakeReservations
   annotationDescriptions: create #volatile
   toproot: slot 'rootslotid-toproot'
   Calendar
-    event: any event
-    descriptions: any calendarDescriptions
+    event: event
+    descriptions: calendarDescriptions
     action: consumes toproot
   // top-of-frame event editor
   ReservationForm
-    restaurant: any restaurant
-    event: any event
+    restaurant: restaurant
+    event: event
     action: consumes toproot
   // per-restaurant tile scheduler
   AnnotationMultiplexer
-    list: any restaurants
-    annotation: any event
-    hostedParticle: any ReservationMultiAnnotation
+    list: restaurants
+    annotation: event
+    hostedParticle: ReservationMultiAnnotation
   // event editor (+scheduler) on restaurant detail
   DetailReservationForm
-    restaurant: any restaurant
-    event: any event
+    restaurant: restaurant
+    event: event
     detailAction: consumes
       annotation: provides detailAnnotation
   ReservationAnnotation
-    restaurant: any restaurant
-    event: any event
-    descriptions: any annotationDescriptions
+    restaurant: restaurant
+    event: event
+    descriptions: annotationDescriptions
     annotation: consumes detailAnnotation

--- a/particles/Restaurants/RestaurantFind.arcs
+++ b/particles/Restaurants/RestaurantFind.arcs
@@ -16,6 +16,6 @@ particle RestaurantFind in 'source/RestaurantFind.js'
 //recipe RestaurantFind
 //  restaurants: create #tiles
 //  RestaurantFind
-//    restaurants: any restaurants
+//    restaurants: restaurants
 //  description `find restaurants near ${RestaurantFind.location}`
 

--- a/particles/Restaurants/Restaurants.arcs
+++ b/particles/Restaurants/Restaurants.arcs
@@ -15,22 +15,22 @@ recipe Restaurants
   modalSlot: slot 'rootslotid-modal'
   Geolocate
     root: consumes rootSlot
-    location: any location
+    location: location
   RestaurantFind
-    location: any location
-    restaurants: any restaurants
+    location: location
+    restaurants: restaurants
   SelectableTiles
-    list: any restaurants
-    selected: any selected
+    list: restaurants
+    selected: selected
     root: consumes rootSlot
       tile: provides tileSlot
   TileMultiplexer
-    list: any restaurants
-    hostedParticle: any RestaurantTile
+    list: restaurants
+    hostedParticle: RestaurantTile
     tile: consumes tileSlot
   DetailSlider
-    selected: any selected
+    selected: selected
     modal: consumes modalSlot
   RestaurantDetail
-    restaurant: any selected
+    restaurant: selected
   description `find restaurants near ${RestaurantFind.location}`

--- a/particles/Restaurants/SLANDLESReservations.arcs
+++ b/particles/Restaurants/SLANDLESReservations.arcs
@@ -46,26 +46,26 @@ recipe SlandleMakeReservations
   annotationDescriptions: create #volatile
   toproot: `slot 'rootslotid-toproot'
   SlandleCalendar
-    event: any event
-    descriptions: any calendarDescriptions
+    event: event
+    descriptions: calendarDescriptions
   // top-of-frame event editor
   SlandleReservationForm
-    restaurant: any restaurant
-    event: any event
+    restaurant: restaurant
+    event: event
     action `consume toproot
   // per-restaurant tile scheduler
   SlandleAnnotationMultiplexer
-    list: any restaurants
-    annotation: any event
-    hostedParticle: any SlandleReservationMultiAnnotation
+    list: restaurants
+    annotation: event
+    hostedParticle: SlandleReservationMultiAnnotation
   // event editor (+scheduler) on restaurant detail
   SlandleDetailReservationForm
-     restaurant: any restaurant
-     event: any event
+     restaurant: restaurant
+     event: event
      detailAction `consume
        annotation `provide detailAnnotation
   SlandleReservationAnnotation
-    restaurant: any restaurant
-    event: any event
-    descriptions: any annotationDescriptions
+    restaurant: restaurant
+    event: event
+    descriptions: annotationDescriptions
     annotation `consume detailAnnotation

--- a/particles/Restaurants/SLANDLESRestaurants.arcs
+++ b/particles/Restaurants/SLANDLESRestaurants.arcs
@@ -17,18 +17,18 @@ recipe SlandleRestaurants
   restaurants: create *
   selected: create #volatile #selected
   SlandleGeolocate
-    location: any location
+    location: location
   SlandleRestaurantFind
-    location: any location
-    restaurants: any restaurants
+    location: location
+    restaurants: restaurants
   SlandleSelectableTiles
-    list: any restaurants
-    selected: any selected
+    list: restaurants
+    selected: selected
   SlandleTileMultiplexer
-    list: any restaurants
-    hostedParticle: any SlandleRestaurantTile
+    list: restaurants
+    hostedParticle: SlandleRestaurantTile
   SlandleDetailSlider
-    selected: any selected
+    selected: selected
   SlandleRestaurantDetail
-    restaurant: any selected
+    restaurant: selected
   description `find restaurants near ${RestaurantFind.location} using SLANDLES`

--- a/particles/Stardate/Stardate.arcs
+++ b/particles/Stardate/Stardate.arcs
@@ -14,11 +14,11 @@ recipe StardateTOS
     randomData: writes randomTime
 
   StardateTOS
-    stardate: any stardate
-    destination: any destination
+    stardate: stardate
+    destination: destination
     randomTime: reads randomTime
     randomPlanet: reads randomPlanet
 
   StardateDisplay
-    stardate: any stardate
-    destination: any destination
+    stardate: stardate
+    destination: destination

--- a/particles/TMDB/recipes/TMDBSearchPanel.arcs
+++ b/particles/TMDB/recipes/TMDBSearchPanel.arcs
@@ -8,8 +8,8 @@ recipe TMDBSearch
   query: use *
   results: create *
   TMDBSearch
-    query: any query
-    results: any results
+    query: query
+    results: results
   description `search TMDB(tm)`
 
 recipe TMDBShowTiles
@@ -22,10 +22,10 @@ recipe TMDBShowTiles
   SelectableTiles
     consume root as container
       provide tile as tile
-    list: any results
-    selected: any selected
+    list: results
+    selected: selected
   TileMultiplexer
-    hostedParticle: any TMDBTile
+    hostedParticle: TMDBTile
     consume tile as tile
-    list: any results
+    list: results
   description `show ${SelectableTiles.list}`

--- a/particles/TVMaze/TVMazeApp.arcs
+++ b/particles/TVMaze/TVMazeApp.arcs
@@ -38,16 +38,16 @@ recipe TVMazeApp
   descriptions: create #volatile
   //
   TVMazeAppShell
-    user: any user
-    boxedShows: any boxedShows
-    selected: any selected
-    recentShows: any pipedShows
-    foundShows: any foundshows
-    boxedUserNames: any boxedUserNames
-    friends: any friends
-    watchers: any watchers
-    watcherText: any alsoWatch
-    descriptions: any descriptions
+    user: user
+    boxedShows: boxedShows
+    selected: selected
+    recentShows: pipedShows
+    foundShows: foundshows
+    boxedUserNames: boxedUserNames
+    friends: friends
+    watchers: watchers
+    watcherText: alsoWatch
+    descriptions: descriptions
     root: consumes root
       recommended: provides recommended
       shows: provides shows
@@ -57,70 +57,70 @@ recipe TVMazeApp
   // slot `shows` holds my primary show list
   uniqueProfileShows: create #volatile #uniqueProfile
   TVMazeDeduplicate
-    shows: any profileShows
-    uniqueShows: any uniqueProfileShows
+    shows: profileShows
+    uniqueShows: uniqueProfileShows
   SelectableTiles
     root: consumes shows
       tile: provides tile1
       annotation: provides action1
-    list: any uniqueProfileShows
-    selected: any selected
+    list: uniqueProfileShows
+    selected: selected
   TileMultiplexer
-    list: any uniqueProfileShows
-    hostedParticle: any TVMazeShowTile
+    list: uniqueProfileShows
+    hostedParticle: TVMazeShowTile
     tile: consumes tile1
   //
   // slot `recommended` holds recommendations
   // which are pulled from `allPipedShows`
   uniquePipedShows: create #volatile #uniquePiped
   TVMazeDeduplicate
-    shows: any allPipedShows
-    uniqueShows: any uniquePipedShows
+    shows: allPipedShows
+    uniqueShows: uniquePipedShows
   SelectableTiles
     root: consumes recommended
       tile: provides tile2
       annotation: provides action2
-    list: any uniquePipedShows
-    selected: any selected
+    list: uniquePipedShows
+    selected: selected
   TileMultiplexer
     tile: consumes tile2
-    list: any uniquePipedShows
-    hostedParticle: any TVMazeShowTile
+    list: uniquePipedShows
+    hostedParticle: TVMazeShowTile
   ActionMultiplexer
     action: consumes action2
-    list: any uniquePipedShows
-    shows: any myshows
-    hostedParticle: any TVMazeShowActions
+    list: uniquePipedShows
+    shows: myshows
+    hostedParticle: TVMazeShowActions
   //
   // slot `search` contains search ui
   query: create #volatile #query
   TVMazeSearchBar
     toproot: consumes searchbar
-    query: any query
+    query: query
   TVMazeSearchShows
-    query: any query
-    shows: any foundshows
+    query: query
+    shows: foundshows
   SelectableTiles
     root: consumes search
       tile: provides tile3
       annotation: provides action3
-    list: any foundshows
-    selected: any selected
+    list: foundshows
+    selected: selected
   TileMultiplexer
     tile: consumes tile3
-    hostedParticle: any TVMazeShowTile
-    list: any foundshows
+    hostedParticle: TVMazeShowTile
+    list: foundshows
   ActionMultiplexer
     action: consumes action3
-    hostedParticle: any TVMazeShowActions
-    list: any foundshows
-    shows: any myshows
+    hostedParticle: TVMazeShowActions
+    list: foundshows
+    shows: myshows
   //
   // standard slot 'modal' holds detail view
   DetailSlider
-    selected: any selected
+    selected: selected
   TVMazeShowPanel
-    show: any selected
-    alsoWatch: any alsoWatch
+    show: selected
+    alsoWatch: alsoWatch
   //
   description `${TVMazeAppShell}`

--- a/particles/TVMaze/TVMazeSearchPanel.arcs
+++ b/particles/TVMaze/TVMazeSearchPanel.arcs
@@ -10,14 +10,14 @@ import '../Layout/Layout.arcs'
 recipe TVMazeSearchBar
   query: create #volatile
   TVMazeSearchBar
-    query: any query
+    query: query
 
 recipe TVMazeSearchShows
   query: use
   shows: create #tiles #shows
   TVMazeSearchShows
-    query: any query
-    shows: any shows
+    query: query
+    shows: shows
   description `use TVMaze(tm) to search for TV shows`
 
 recipe TVMazeShowTiles
@@ -27,18 +27,18 @@ recipe TVMazeShowTiles
     root: consumes
       tile: provides
       annotation: provides action
-    list: any shows
-    selected: any selected
+    list: shows
+    selected: selected
   TileMultiplexer
-    hostedParticle: any TVMazeShowTile
+    hostedParticle: TVMazeShowTile
     tile: consumes
-    list: any shows
+    list: shows
   description `show information about ${SelectableTiles.list}`
 
 recipe TVMazeShowPanel
   show: use
   descriptions: create #volatile
   TVMazeShowPanel
-    show: any show
-    descriptions: any descriptions
+    show: show
+    descriptions: descriptions
 

--- a/particles/Words/SLANDLESWords.arcs
+++ b/particles/Words/SLANDLESWords.arcs
@@ -19,11 +19,11 @@ recipe SlandleWords
   //posts: create #posts
   //post: create
   SlandleGamePane
-    move: any move
-    board: any board
-    stats: any stats
-    //posts: any posts
-    //post: any post
-    //person: any person
-    //renderParticle: any ShowSingleStats
-    //shellTheme: any shellTheme
+    move: move
+    board: board
+    stats: stats
+    //posts: posts
+    //post: post
+    //person: person
+    //renderParticle: ShowSingleStats
+    //shellTheme: shellTheme

--- a/particles/Words/Words.arcs
+++ b/particles/Words/Words.arcs
@@ -19,11 +19,11 @@ recipe Words
   //posts: create #posts
   //post: create
   GamePane
-    move: any move
-    board: any board
-    stats: any stats
-    //posts: any posts
-    //post: any post
-    //person: any person
-    //renderParticle: any ShowSingleStats
-    //shellTheme: any shellTheme
+    move: move
+    board: board
+    stats: stats
+    //posts: posts
+    //post: post
+    //person: person
+    //renderParticle: ShowSingleStats
+    //shellTheme: shellTheme

--- a/src/planning/strategies/tests/convert-constraints-to-connections-test.ts
+++ b/src/planning/strategies/tests/convert-constraints-to-connections-test.ts
@@ -147,7 +147,7 @@ describe('ConvertConstraintsToConnections', () => {
       assert.lengthOf(results, 1, `Failed to resolve ${constraint1} & ${constraint2}`);
     };
     // Test for all possible combination of connection constraints with 3 particles.
-    const constraints = [['A.b: any C.d', 'C.d: any A.b'], ['A.b: writes E.f', 'E.f: reads A.b'], ['C.d: writes E.f', 'E.f: reads C.d']];
+    const constraints = [['A.b: C.d', 'C.d: A.b'], ['A.b: writes E.f', 'E.f: reads A.b'], ['C.d: writes E.f', 'E.f: reads C.d']];
     for (let i = 0; i < constraints.length; ++i) {
       for (let j = 0; j < constraints.length; ++j) {
         if (i === j) continue;
@@ -420,7 +420,7 @@ describe('ConvertConstraintsToConnections', () => {
         handle1: use
         C
         A
-          b: any handle1`);
+          b: handle1`);
     const generated = [{result: manifest.recipes[0], score: 1, derivation: [], hash: '0', valid: true}];
     const cctc = new ConvertConstraintsToConnections(newArc(manifest));
     const results = await cctc.generateFrom(generated);

--- a/src/planning/strategies/tests/strategy-sequence-test.ts
+++ b/src/planning/strategies/tests/strategy-sequence-test.ts
@@ -308,7 +308,7 @@ describe('A Strategy Sequence', () => {
           population: reads wishlist
         &showList
         Multiplexer2
-          hostedParticle: any AlsoOn
+          hostedParticle: AlsoOn
     `);
 
     let recipe = manifest.recipes[1];
@@ -511,7 +511,7 @@ describe('A Strategy Sequence', () => {
         i: reads S {}
         o: writes T {}
       recipe
-        A: any B
+        A: B
     `);
 
     let recipe = manifest.recipes[0];

--- a/src/planning/tests/planner-test.ts
+++ b/src/planning/tests/planner-test.ts
@@ -167,7 +167,7 @@ describe('Planner', () => {
     assert.lengthOf(results, 1);
   }));
 
-  it('SLANDLES resolves particles with multiple consumed slots with the any direction', Flags.withPostSlandlesSyntax(async () => {
+  it('SLANDLES resolves particles with multiple consumed slots with the implicit any direction', Flags.withPostSlandlesSyntax(async () => {
     const results = await planFromManifest(`
       particle P1 in './some-particle.js'
         one: \`consumes Slot
@@ -175,12 +175,12 @@ describe('Planner', () => {
       recipe
         s0: \`slot 'slot-id0'
         P1
-          one: any s0
+          one: s0
     `);
     assert.lengthOf(results, 1);
   }));
 
-  it('SLANDLES resolves particles with multiple consumed set with the any direction', Flags.withPostSlandlesSyntax(async () => {
+  it('SLANDLES resolves particles with multiple consumed set with the implicit any direction', Flags.withPostSlandlesSyntax(async () => {
     const results = await planFromManifest(`
       particle P1 in './some-particle.js'
         one: \`consumes [Slot]
@@ -188,7 +188,7 @@ describe('Planner', () => {
       recipe
         s0: \`slot 'slot-id0'
         P1
-          one: any s0
+          one: s0
     `);
     assert.lengthOf(results, 1);
   }));
@@ -204,10 +204,10 @@ describe('Planner', () => {
         s0: \`slot 'slot-id0'
         s1: \`slot 'slot-id1'
         P1
-          inSlot: any s0
-          outSlot: any s1
+          inSlot: s0
+          outSlot: s1
         P2
-          inSlot: any s1
+          inSlot: s1
     `);
     assert.lengthOf(results, 1);
   }));
@@ -223,10 +223,10 @@ describe('Planner', () => {
         s0: \`slot 'slot-id0'
         s1: \`slot 'slot-id1'
         P1
-          inSlot: any s0
-          outSlot: any s1
+          inSlot: s0
+          outSlot: s1
         P2
-          inSlot: any s1
+          inSlot: s1
     `);
     assert.lengthOf(results, 1);
   }));
@@ -242,10 +242,10 @@ describe('Planner', () => {
         s0: \`slot 'slot-id0'
         s1: \`slot 'slot-id1'
         P1
-          inSlot: any s0
-          outSlot: any s1
+          inSlot: s0
+          outSlot: s1
         P2
-          inSlot: any s1
+          inSlot: s1
     `);
     assert.lengthOf(results, 0);
   }));
@@ -312,7 +312,7 @@ describe('Planner', () => {
       recipe
         s0: \`slot 'slot-id0'
         P1
-          one: any s0
+          one: s0
     `);
     assert.lengthOf(results, 1);
   }));

--- a/src/planning/tests/recipe-index-test.ts
+++ b/src/planning/tests/recipe-index-test.ts
@@ -265,21 +265,21 @@ describe('RecipeIndex', () => {
       recipe A
         thing: map
         A
-          thing: any thing
+          thing: thing
 
       particle B
         thing: writes Thing
       recipe B
         thing: create
         B
-          thing: any thing
+          thing: thing
 
       particle C
         thing: reads Thing
       recipe C
         thing: use
         C
-          thing: any thing
+          thing: thing
     `);
 
     const recipe = checkDefined(index.recipes.find(r => r.name === 'C'), 'missing recipe C');

--- a/src/runtime/interface-info.ts
+++ b/src/runtime/interface-info.ts
@@ -196,9 +196,15 @@ export class InterfaceInfo {
         if (Flags.defaultToPreSlandlesSyntax) {
           return `  ${h.direction || 'any'} ${h.type.toString()} ${h.name ? h.name : '*'}`;
         } else {
-          const nameStr = h.name ? `${h.name}: ` : '';
-          const direction = AstNode.preSlandlesDirectionToDirection(h.direction || 'any');
-          return `  ${nameStr}${direction} ${h.type.toString()}`;
+          const parts = [];
+          if (h.name) {
+            parts.push(`${h.name}:`);
+          }
+          if (h.direction !== undefined && h.direction !== 'any') {
+            parts.push(AstNode.preSlandlesDirectionToDirection(h.direction));
+          }
+          parts.push(h.type.toString());
+          return `  ${parts.join(' ')}`;
         }
       }).join('\n');
   }

--- a/src/runtime/manifest-ast-nodes.ts
+++ b/src/runtime/manifest-ast-nodes.ts
@@ -560,7 +560,7 @@ export type InterfaceItem = Interface | InterfaceArgument | InterfaceSlot;
 export interface InterfaceArgument extends BaseNode {
   kind: 'interface-argument';
   direction: Direction;
-  type: string;
+  type: ParticleHandleConnectionType;
   name: string;
 }
 

--- a/src/runtime/manifest-parser.peg
+++ b/src/runtime/manifest-parser.peg
@@ -608,14 +608,14 @@ NameWithColon
   }
 
 ParticleHandleConnectionBodyUnified
-  = name:NameWithColon? direction:DirectionUnified isOptional:'?'? whiteSpace type:ParticleHandleConnectionType maybeTags:SpaceTagList?
+  = name:NameWithColon? direction:(DirectionUnified '?'?)? whiteSpace type:ParticleHandleConnectionType maybeTags:SpaceTagList?
   {
     requireUsePostSlandleSyntax(6);
     return toAstNode<AstNode.ParticleHandleConnection>({
       kind: 'particle-argument',
-      direction,
-      type: type,
-      isOptional: !!isOptional,
+      direction: optional(direction, d => d[0], 'any'),
+      type,
+      isOptional: optional(direction, d => !!d[1], false),
       dependentConnections: [],
       name: name || (maybeTags && maybeTags[0]) || expected(`either a name or tags to be supplied ${name} ${maybeTags}`),
       tags: maybeTags || []
@@ -630,7 +630,7 @@ DirectionPreSlandles "a direction (e.g. inout, in, out, host, `consume, `provide
   }
 
 DirectionUnified "a direction (e.g. reads writes, reads, writes, hosts, `consumes, `provides, any')"
-  = (('reads' ('?'?) ' writes') / 'reads' / 'writes' / 'hosts' / '`consumes' / '`provides' / 'any') &([^a-zA-Z0-9] / !.)
+  = (('reads' ('?'?) ' writes') / 'reads' / 'writes' / 'hosts' / '`consumes' / '`provides') &([^a-zA-Z0-9] / !.)
   {
     // TODO(jopra): Parse optionality properly.
     requireUsePostSlandleSyntax(8);
@@ -1039,13 +1039,13 @@ RecipeParticleConnection
   / RecipeParticleConnectionPreSlandle
 
 RecipeParticleConnectionUnified
-  = param:NameWithColon? dir:DirectionUnified target:(whiteSpace ParticleConnectionTargetComponents)? eolWhiteSpace dependentConnections:(Indent (SameIndent RecipeParticleConnection)*)?
+  = param:NameWithColon? dir:DirectionUnified? target:(whiteSpace ParticleConnectionTargetComponents)? eolWhiteSpace dependentConnections:(Indent (SameIndent RecipeParticleConnection)*)?
   {
     requireUsePostSlandleSyntax(13);
     return toAstNode<AstNode.RecipeParticleConnection>({
       kind: 'handle-connection',
       param: param || '*',
-      dir,
+      dir: dir || 'any',
       target: optional(target, target => target[1], null),
       dependentConnections: optional(dependentConnections, extractIndented, []),
     });

--- a/src/runtime/manifest-parser.peg
+++ b/src/runtime/manifest-parser.peg
@@ -86,6 +86,19 @@
       error(`using post slandles syntax (disabled by flag) #${tag}`);
     }
   }
+
+  function buildInterfaceArgument(name: string, direction: AstNode.Direction, type: AstNode.ParticleHandleConnectionType) {
+    requireUsePostSlandleSyntax(2);
+    if (direction === 'host') {
+      error(`Interface cannot have arguments with a 'host' direction.`);
+    }
+    return toAstNode<AstNode.InterfaceArgument>({
+      kind: 'interface-argument',
+      direction,
+      type,
+      name
+    });
+  }
 }
 
 Manifest
@@ -283,20 +296,12 @@ InterfaceArgumentPreSlandlesSyntax
   }
 
 InterfaceArgumentUnified
-  = name:NameWithColon? direction:DirectionUnified type:(whiteSpace ParticleHandleConnectionType)? eolWhiteSpace
-  {
-    requireUsePostSlandleSyntax(2);
-    name = name || '*';
-    if (direction === 'host') {
-      error(`Interface cannot have arguments with a 'host' direction.`);
-    }
-    return toAstNode<AstNode.InterfaceArgument>({
-      kind: 'interface-argument',
-      direction,
-      type: optional(type, ty => ty[1], null),
-      name,
-    });
-  }
+  = name:NameWithColon direction:DirectionUnified? type:(whiteSpace? ParticleHandleConnectionType)? eolWhiteSpace
+  { return buildInterfaceArgument(name, direction || 'any', optional(type, t => t[1], null)); }
+  / direction:DirectionUnified type:(whiteSpace? ParticleHandleConnectionType)? eolWhiteSpace
+  { return buildInterfaceArgument('*', direction || 'any', optional(type, t => t[1], null)); }
+  / type:(whiteSpace? ParticleHandleConnectionType) eolWhiteSpace
+  { return buildInterfaceArgument('*', 'any', type); }
 
 InterfaceSlot
   = InterfaceSlotPreSlandles
@@ -1039,14 +1044,25 @@ RecipeParticleConnection
   / RecipeParticleConnectionPreSlandle
 
 RecipeParticleConnectionUnified
-  = param:NameWithColon? dir:DirectionUnified? target:(whiteSpace ParticleConnectionTargetComponents)? eolWhiteSpace dependentConnections:(Indent (SameIndent RecipeParticleConnection)*)?
+  = param:NameWithColon? dir:DirectionUnified target:(whiteSpace ParticleConnectionTargetComponents)? eolWhiteSpace dependentConnections:(Indent (SameIndent RecipeParticleConnection)*)?
   {
     requireUsePostSlandleSyntax(13);
     return toAstNode<AstNode.RecipeParticleConnection>({
       kind: 'handle-connection',
       param: param || '*',
-      dir: dir || 'any',
-      target: optional(target, target => target[1], null),
+      dir,
+      target: optional(target, t => t[1], null),
+      dependentConnections: optional(dependentConnections, extractIndented, []),
+    });
+  }
+  / param:NameWithColon? target:ParticleConnectionTargetComponents eolWhiteSpace dependentConnections:(Indent (SameIndent RecipeParticleConnection)*)?
+  {
+    requireUsePostSlandleSyntax(13);
+    return toAstNode<AstNode.RecipeParticleConnection>({
+      kind: 'handle-connection',
+      param: param || '*',
+      dir: 'any',
+      target,
       dependentConnections: optional(dependentConnections, extractIndented, []),
     });
   }
@@ -1066,7 +1082,7 @@ RecipeParticleConnectionPreSlandle
   }
 
 ParticleConnectionTargetComponents
-  = param:(upperIdent / lowerIdent)? whiteSpace? tags:(TagList)?
+  = param:(upperIdent / lowerIdent) tags:(whiteSpace TagList)?
   {
     param = optional(param, param => param, null);
     let name: string|null = null;
@@ -1083,7 +1099,17 @@ ParticleConnectionTargetComponents
       kind: 'handle-connection-components',
       name,
       particle,
-      tags: optional(tags, tags => tags, []),
+      tags: optional(tags, t => t[1], []),
+    });
+  }
+  / tags:TagList
+  {
+    let particle = null;
+    return toAstNode<AstNode.ParticleConnectionTargetComponents>({
+      kind: 'handle-connection-components',
+      name: null,
+      particle,
+      tags
     });
   }
 
@@ -1138,7 +1164,7 @@ RecipeConnection
   = RecipeConnectionUnified / RecipeConnectionPreSlandle
 
 RecipeConnectionUnified
-  = from:ConnectionTargetWithColon? direction:DirectionUnified whiteSpace to:ConnectionTarget eolWhiteSpace
+  = from:ConnectionTargetWithColon? direction:(DirectionUnified whiteSpace)? to:ConnectionTarget eolWhiteSpace
   {
     const anyTarget = toAstNode<AstNode.NameConnectionTarget>({
       kind: 'connection-target',
@@ -1150,14 +1176,14 @@ RecipeConnectionUnified
     requireUsePostSlandleSyntax(17);
     return toAstNode<AstNode.RecipeConnection>({
       kind: 'connection',
-      direction,
+      direction: optional(direction, d => d[0], 'any'),
       from: from || anyTarget,
       to,
     });
   }
 
 ConnectionTargetWithColon
-  = target: ConnectionTarget ':' whiteSpace?
+  = target:ConnectionTarget ':' whiteSpace?
   {
     return target;
   }

--- a/src/runtime/manifest-parser.peg
+++ b/src/runtime/manifest-parser.peg
@@ -1104,11 +1104,10 @@ ParticleConnectionTargetComponents
   }
   / tags:TagList
   {
-    let particle = null;
     return toAstNode<AstNode.ParticleConnectionTargetComponents>({
       kind: 'handle-connection-components',
       name: null,
-      particle,
+      particle: null,
       tags
     });
   }

--- a/src/runtime/manifest.md
+++ b/src/runtime/manifest.md
@@ -176,16 +176,16 @@ recipe
   handle1: map                   // maps a store external to the arc; changes in the
                                  // external store will be reflected locally, but the
                                  // local handle is read-only.
-  handle2: use                   // uses some handle already in the Arc
-  handle3: create                // creates a new empty handle
+  handle2: use *                 // uses some handle already in the Arc
+  handle3: create *              // creates a new empty handle
   handle4: copy ImportedHandle   // creates a handle on a new store populated with entries
                                  // from a store defined in or imported by the manifest
                                  
   SomeParticle
-    param1: reads handle1   // bind's SomeParticle's input param1 connection to handle1
-    param2: writes handle2  // binds output connection
-    param3: any handle3     // binds input and output connection
-    param4: reads handle4   // binds the copied handle.
+    param1: reads handle1        // bind's SomeParticle's input param1 connection to handle1
+    param2: writes handle2       // binds output connection
+    param3: reads writes handle3 // binds input and output connection
+    param4: reads handle4        // binds the copied handle.
 ```
 
 Can include how particles are connected to slots:

--- a/src/runtime/manual_tests/firebase-test.ts
+++ b/src/runtime/manual_tests/firebase-test.ts
@@ -719,7 +719,7 @@ describe('firebase', function() {
             P
               var: reads handle0
               col: writes handle1
-              big: any handle2
+              big: handle2
         `,
         'a.js': `
           defineParticle(({Particle}) => class Noop extends Particle {});

--- a/src/runtime/particle-spec.ts
+++ b/src/runtime/particle-spec.ts
@@ -404,7 +404,8 @@ export class ParticleSpec {
         // TODO: Remove post slandles syntax
         results.push(`${indent}${connection.direction}${connection.isOptional ? '?' : ''} ${connection.type.toString()} ${connection.name}${tags}`);
       } else {
-        results.push(`${indent}${connection.name}: ${AstNode.preSlandlesDirectionToDirection(connection.direction, connection.isOptional)} ${connection.type.toString()}${tags}`);
+        const dir = connection.direction === 'any' ? '' : `${AstNode.preSlandlesDirectionToDirection(connection.direction, connection.isOptional)} `;
+        results.push(`${indent}${connection.name}: ${dir}${connection.type.toString()}${tags}`);
       }
       for (const dependent of connection.dependentConnections) {
         writeConnection(dependent, indent + '  ');

--- a/src/runtime/tests/artifacts/Common/Detail.manifest
+++ b/src/runtime/tests/artifacts/Common/Detail.manifest
@@ -15,4 +15,4 @@ particle DetailSlider in 'source/DetailSlider.js'
 recipe DetailSlider
   selected: use #selected
   DetailSlider
-    selected: any selected
+    selected: selected

--- a/src/runtime/tests/artifacts/Common/List.recipes
+++ b/src/runtime/tests/artifacts/Common/List.recipes
@@ -16,19 +16,19 @@ recipe SelectableUseListRecipe
   items: use #items
   selected: create #selected
   SelectableList
-    items: any items
-    selected: any selected
+    items: items
+    selected: selected
   ItemMultiplexer
-    list: any items
+    list: items
 
 recipe SelectableCopyListRecipe
   items: copy #items
   selected: create #selected
   SelectableList
-    items: any items
-    selected: any selected
+    items: items
+    selected: selected
   ItemMultiplexer
-    list: any items
+    list: items
 
 //----------------------------------------
 // Recipe: Generic Tiled List (Selectable)
@@ -38,18 +38,18 @@ recipe SelectableCopyTilesRecipe
   items: copy #tiles
   selected: create #selected
   SelectableTileList
-    items: any items
-    selected: any selected
+    items: items
+    selected: selected
   TileMultiplexer
-    list: any items
+    list: items
   description `show ${SelectableTileList.items}`
 
 recipe SelectableUseTilesRecipe
   items: use #tiles
   selected: create #selected
   SelectableTileList
-    items: any items
-    selected: any selected
+    items: items
+    selected: selected
   TileMultiplexer
-    list: any items
+    list: items
   description `show ${SelectableTileList.items}`

--- a/src/runtime/tests/artifacts/Common/SLANDLESListRecipes.arcs
+++ b/src/runtime/tests/artifacts/Common/SLANDLESListRecipes.arcs
@@ -16,19 +16,19 @@ recipe SelectableUseListRecipe
   items: use #items
   selected: create #selected
   SelectableList
-    items: any items
-    selected: any selected
+    items: items
+    selected: selected
   ItemMultiplexer
-    list: any items
+    list: items
 
 recipe SelectableCopyListRecipe
   items: copy #items
   selected: create #selected
   SelectableList
-    items: any items
-    selected: any selected
+    items: items
+    selected: selected
   ItemMultiplexer
-    list: any items
+    list: items
 
 //----------------------------------------
 // Recipe: Generic Tiled List (Selectable)
@@ -38,18 +38,18 @@ recipe SelectableCopyTilesRecipe
   items: copy #tiles
   selected: create #selected
   SelectableTileList
-    items: any items
-    selected: any selected
+    items: items
+    selected: selected
   TileMultiplexer
-    list: any items
+    list: items
   description `show ${SelectableTileList.items}`
 
 recipe SelectableUseTilesRecipe
   items: use #tiles
   selected: create #selected
   SelectableTileList
-    items: any items
-    selected: any selected
+    items: items
+    selected: selected
   TileMultiplexer
-    list: any items
+    list: items
   description `show ${SelectableTileList.items}`

--- a/src/runtime/tests/artifacts/Places/Places.recipes
+++ b/src/runtime/tests/artifacts/Places/Places.recipes
@@ -10,7 +10,7 @@ import 'AddressForm.manifest'
 recipe
   address: create #address
   AddressForm
-    address: any address
+    address: address
 
 import 'ExtractLocation.manifest'
 import 'GoogleMap.manifest'

--- a/src/runtime/tests/artifacts/Products/Gifts.recipes
+++ b/src/runtime/tests/artifacts/Products/Gifts.recipes
@@ -34,14 +34,14 @@ recipe MakeIntoGiftList
   shoplist: use #shoplist
   person: copy *
   GiftList
-    person: any person
+    person: person
   Multiplexer
-    list: any shoplist
-    hostedParticle: any Arrivinator
+    list: shoplist
+    hostedParticle: Arrivinator
     annotation: consumes annotationSlot
   Multiplexer
-    list: any shoplist
-    hostedParticle: any AlternateShipping
+    list: shoplist
+    hostedParticle: AlternateShipping
     annotation: consumes annotationSlot
   description `check shipping for ${GiftList.person}'s ${GiftList.person.occasion} on ${GiftList.person.date}`
 

--- a/src/runtime/tests/artifacts/Profile/Profile.recipes
+++ b/src/runtime/tests/artifacts/Profile/Profile.recipes
@@ -17,12 +17,12 @@ recipe BasicUserProfile
   people: use #identities
   avatars: map #BOXED_avatar
   AvatarPicker
-    avatar: any avatar
+    avatar: avatar
     person: reads person
   FriendsPicker
     person: reads person
-    friends: any friends
+    friends: friends
     avatars: reads avatars
     people: reads people
   AddressForm
-    address: any address
+    address: address

--- a/src/runtime/tests/artifacts/Restaurants/Restaurants.recipes
+++ b/src/runtime/tests/artifacts/Restaurants/Restaurants.recipes
@@ -27,7 +27,7 @@ recipe
 recipe &nearbyRestaurants
   restaurants: create #restaurants #volatile
   FindRestaurants
-    restaurants: any restaurants
+    restaurants: restaurants
 
 import '../Events/Event.schema'
 import '../Events/PartySize.manifest'
@@ -38,12 +38,12 @@ recipe &makeReservation
   event: create #event
   list: use #restaurants
   ReservationForm
-    event: any event
+    event: event
   ReservationAnnotation
-    event: any event
-    list: any list
+    event: event
+    list: list
   PartySize
-    event: any event
+    event: event
 
 import '../Events/Events.recipes'
 

--- a/src/runtime/tests/artifacts/Restaurants/SLANDLESRestaurants.recipes
+++ b/src/runtime/tests/artifacts/Restaurants/SLANDLESRestaurants.recipes
@@ -27,7 +27,7 @@ recipe
 recipe &nearbyRestaurants
   restaurants: create #restaurants #volatile
   SlandleFindRestaurants
-    restaurants: any restaurants
+    restaurants: restaurants
 
 import '../Events/Event.schema'
 import '../Events/SLANDLESPartySize.manifest'
@@ -38,12 +38,12 @@ recipe &makeReservation
   event: create #event
   list: use #restaurants
   SlandleReservationForm
-    event: any event
+    event: event
   SlandleReservationAnnotation
-    event: any event
-    list: any list
+    event: event
+    list: list
   SlandlePartySize
-    event: any event
+    event: event
 
 import '../Events/SLANDLESEvents.recipes'
 

--- a/src/runtime/tests/artifacts/Social/Social.recipes
+++ b/src/runtime/tests/artifacts/Social/Social.recipes
@@ -25,22 +25,22 @@ recipe
   shellTheme: use #shelltheme
 
   WritePosts
-    posts: any posts
-    post: any post
+    posts: posts
+    post: post
   EditPost
-    posts: any posts
-    post: any post
+    posts: posts
+    post: post
     user: reads user
-    renderParticle: any ShowSinglePost
+    renderParticle: ShowSinglePost
     shellTheme: reads shellTheme
   ShowPosts
-    posts: any posts
-    metadata: any metadata
+    posts: posts
+    metadata: metadata
     user: reads user
     avatars: reads avatars
     people: reads people
   DetailSlider
-    selected: any post
+    selected: post
 
 // Non-muxed post feed. Deprecated and to be removed once the muxed feeds below
 // are fully operational.
@@ -63,12 +63,12 @@ recipe
   posts: map #BOXED_posts
   rankedPosts: create *
   PostTimeRanker
-    input: any posts
-    output: any rankedPosts
+    input: posts
+    output: rankedPosts
   PostList
-    items: any rankedPosts
+    items: rankedPosts
   PostMuxer
-    list: any rankedPosts
+    list: rankedPosts
 
 // Words game leaderboard feed.
 recipe
@@ -77,10 +77,10 @@ recipe
   rankedPosts: create *
   LeaderboardStatsTheme
   WordsScoreRanker
-    input: any posts
-    stats: any stats
-    output: any rankedPosts
+    input: posts
+    stats: stats
+    output: rankedPosts
   PostList
-    items: any rankedPosts
+    items: rankedPosts
   PostMuxer
-    list: any rankedPosts
+    list: rankedPosts

--- a/src/runtime/tests/artifacts/Words/Words.recipes
+++ b/src/runtime/tests/artifacts/Words/Words.recipes
@@ -19,11 +19,11 @@ recipe
   posts: create #posts
   post: create
   GamePane
-    move: any move
-    board: any board
-    stats: any stats
-    posts: any posts
-    post: any post
+    move: move
+    board: board
+    stats: stats
+    posts: posts
+    post: post
     person: reads person
-    renderParticle: any ShowSingleStats
+    renderParticle: ShowSingleStats
     shellTheme: reads shellTheme

--- a/src/runtime/tests/artifacts/suggestions/Cakes.recipes
+++ b/src/runtime/tests/artifacts/suggestions/Cakes.recipes
@@ -30,10 +30,10 @@ particle CakeMuxer in '../Common/source/Multiplexer.js'
 recipe &makeCakes
   cakesHandle: map #cakes
   List
-    items: any cakesHandle
+    items: cakesHandle
   CakeMuxer
-    list: any cakesHandle
-    hostedParticle: any MakeCake
+    list: cakesHandle
+    hostedParticle: MakeCake
   description `show ${List.items}`
 
 interface LightCandleInterface
@@ -51,8 +51,8 @@ particle CandleMuxer in '../Common/source/Multiplexer.js'
 //   map #cakes as cakesHandle
 //   slot #special as candlesSlot
 //   CandleMuxer
-//     list: any cakesHandle
-//     hostedParticle: any LightCandles
+//     list: cakesHandle
+//     hostedParticle: LightCandles
 //     consumes candles as candlesSlot
 //   description `light candles for ${CandleMuxer.list}`
 

--- a/src/runtime/tests/manifest-parser-test.ts
+++ b/src/runtime/tests/manifest-parser-test.ts
@@ -40,7 +40,7 @@ describe('manifest parser', () => {
         SomeParticle
           a: writes #something
           b: reads #somethingElse
-          any #someOtherParticle`);
+          #someOtherParticle`);
   });
   it('parses trivial particles', () => {
     parse(`
@@ -70,8 +70,8 @@ describe('manifest parser', () => {
         X: writes Y
         X.a: writes Y.a
         &foo.bar: writes &far.#bash #fash
-        a: any b
-        a.a: any b.b
+        a: b
+        a.a: b.b
         X.a #tag: reads a.y`);
   });
   it('parses manifests with stores', () => {

--- a/src/runtime/tests/manifest-test.ts
+++ b/src/runtime/tests/manifest-test.ts
@@ -1713,7 +1713,7 @@ resource SomeName
       interface NoHandleType
         foo: reads writes
       interface NoHandleDirection
-        foo: any Foo
+        foo: Foo
       interface OnlyHandleDirection
         writes
       interface ManyHandles
@@ -1831,7 +1831,7 @@ resource SomeName
       recipe
         h0: create
         P
-          bar: any h0
+          bar: h0
     `);
 
     const [recipe] = manifest.recipes;
@@ -1854,7 +1854,7 @@ resource SomeName
       recipe
         h0: create
         P
-          bar: any h0
+          bar: h0
     `);
 
     const [recipe] = manifest.recipes;
@@ -1878,7 +1878,7 @@ resource SomeName
       recipe
         h0: create
         P
-          bar: any h0
+          bar: h0
     `);
 
     const [recipe] = manifest.recipes;
@@ -1900,7 +1900,7 @@ resource SomeName
       recipe
         h0: create
         P
-          bar: any h0
+          bar: h0
     `);
 
     const [recipe] = manifest.recipes;
@@ -1949,23 +1949,23 @@ resource SomeName
       recipe
         h0: create
         P
-          foo: any h0
+          foo: h0
         P2
-          foo: any h0
+          foo: h0
 
       recipe
         h0: create
         P2
-          foo: any h0
+          foo: h0
         P3
-          foo: any h0
+          foo: h0
 
       recipe
         h0: create
         P2
-          foo: any h0
+          foo: h0
         P4
-          foo: any h0
+          foo: h0
     `);
     const [validRecipe, suspiciouslyValidRecipe, invalidRecipe] = manifest.recipes;
     assert(validRecipe.normalize());
@@ -1995,9 +1995,9 @@ resource SomeName
       recipe
         h0: create
         P
-          foo: any h0
+          foo: h0
         P2
-          foo: any h0
+          foo: h0
     `);
     const [validRecipe] = manifest.recipes;
     assert(validRecipe.normalize());

--- a/src/runtime/tests/multiplexer-test.ts
+++ b/src/runtime/tests/multiplexer-test.ts
@@ -77,7 +77,7 @@ describe('Multiplexer', () => {
         slot0: slot 'rootslotid-slotid'
         handle0: use 'test:1'
         SlandleMultiplexer
-          hostedParticle: any SlandleConsumerParticle
+          hostedParticle: SlandleConsumerParticle
           annotation: consumes slot0
           list: reads handle0
     `, {loader: new Loader(), fileName: ''});

--- a/src/runtime/tests/type-test.ts
+++ b/src/runtime/tests/type-test.ts
@@ -297,46 +297,25 @@ describe('types', () => {
   });
 
   describe('serialization', () => {
-    it('SLANDLES SYNTAX serializes interfaces', Flags.withPostSlandlesSyntax(async () => {
+    it('serializes interfaces', Flags.withFlags({defaultToPreSlandlesSyntax: false}, async () => {
       const entity = EntityType.make(['Foo'], {value: 'Text'});
       const variable = TypeVariable.make('a', null, null);
       const iface = InterfaceType.make('i', [{type: entity, name: 'foo'}, {type: variable}], [{name: 'x', direction: 'consume'}]);
       assert.strictEqual(iface.interfaceInfo.toString(),
 `interface i
   foo: Foo {value: Text}
-  any ~a
+  ~a
   x: consumes? Slot`);
     }));
 
-    it('serializes interfaces', Flags.withPreSlandlesSyntax(async () => {
-      const entity = EntityType.make(['Foo'], {value: 'Text'});
-      const variable = TypeVariable.make('a', null, null);
-      const iface = InterfaceType.make('i', [{type: entity, name: 'foo'}, {type: variable}], [{name: 'x', direction: 'consume'}]);
-      assert.strictEqual(iface.interfaceInfo.toString(),
-`interface i
-  any Foo {Text value} foo
-  any ~a *
-  consume x`);
-    }));
-
     // Regression test for https://github.com/PolymerLabs/arcs/issues/2575
-    it('SLANDLES SYNTAX disregards type variable resolutions in interfaces', Flags.withPostSlandlesSyntax(async () => {
+    it('disregards type variable resolutions in interfaces', Flags.withFlags({defaultToPreSlandlesSyntax: false}, async () => {
       const variable = TypeVariable.make('a', null, null);
       variable.variable.resolution = EntityType.make(['Foo'], {value: 'Text'});
       const iface = InterfaceType.make('i', [{type: variable}], []);
       assert.strictEqual(iface.interfaceInfo.toString(),
 `interface i
-  any ~a
-`);
-    }));
-    // Regression test for https://github.com/PolymerLabs/arcs/issues/2575
-    it('disregards type variable resolutions in interfaces', Flags.withPreSlandlesSyntax(async () => {
-      const variable = TypeVariable.make('a', null, null);
-      variable.variable.resolution = EntityType.make(['Foo'], {value: 'Text'});
-      const iface = InterfaceType.make('i', [{type: variable}], []);
-      assert.strictEqual(iface.interfaceInfo.toString(),
-`interface i
-  any ~a *
+  ~a
 `);
     }));
   });

--- a/src/runtime/tests/type-test.ts
+++ b/src/runtime/tests/type-test.ts
@@ -303,7 +303,7 @@ describe('types', () => {
       const iface = InterfaceType.make('i', [{type: entity, name: 'foo'}, {type: variable}], [{name: 'x', direction: 'consume'}]);
       assert.strictEqual(iface.interfaceInfo.toString(),
 `interface i
-  foo: any Foo {value: Text}
+  foo: Foo {value: Text}
   any ~a
   x: consumes? Slot`);
     }));

--- a/src/tests/particles/artifacts/products-test.recipes
+++ b/src/tests/particles/artifacts/products-test.recipes
@@ -22,14 +22,14 @@ recipe FilterAndDisplayBooks
   rootSlot: slot 'rootslotid-root'
   ProductFilter
     products: reads mylist
-    hostedParticle: any ProductIsBook
+    hostedParticle: ProductIsBook
     results: writes books
   List
-    items: any books
+    items: books
     root: consumes rootSlot
       item: provides itemSlot
   ItemMultiplexer
-    list: any books
+    list: books
     hostedParticle: hosts ShowProduct
     item: consumes itemSlot
 
@@ -39,7 +39,7 @@ recipe FilterBooks
   books: create *
   ProductFilter
     products: reads mylist
-    hostedParticle: any ProductIsBook
+    hostedParticle: ProductIsBook
     results: writes books
 
 resource ProductList


### PR DESCRIPTION
This removes the 'any' keyword, instead treating an unspecified capability as 'any'.

This fits with our type syntax (where not writing in a type allows any) and names.