### PR TITLE
strip trailing slashes from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,7 @@ enclave/sdk
 enclave/toolchains
 enclave/host/storage/db.img
 enclave/host/storage/key
-build/
+build
 src/gen
 coverage
 .vscode
@@ -34,10 +34,10 @@ server/log.txt
 pack-stats.json
 default.profraw
 # pouch local database
-user-test/
+user-test
 test-output
-node_modules/.cache/
-server/node_modules/.cache/
+node_modules/.cache
+server/node_modules/.cache
 bazel-*
 .bazelrc
 .ijwb


### PR DESCRIPTION
`travis.yml` uses regex to alter .gitignore before deploying to arcs-live.

E.g.
`- cd ${TRAVIS_BUILD_DIR} && sed -i.sedbackup -e '/^build$/d' .gitignore`

This regex was not matching the rule in .gitignore which had become `build/`.

Many paths in .gitignore do not have trailing slashes, so in this PR I standardize that file by removing all the slashes, which should allow the travis regex to match the correct line.
