### PR TITLE
Fix for test broken via incorrect and partial usage of slandles

### DIFF
--- a/src/runtime/tests/artifacts/Common/Multiplexer.manifest
+++ b/src/runtime/tests/artifacts/Common/Multiplexer.manifest
@@ -8,7 +8,7 @@
 
 interface HostedAnnotationParticleInterface
   reads ~a
-  annotation: consumes? Slot
+  annotation: consumes Slot
 
 // TODO: This particle should use generic slot name.
 particle Multiplexer in 'source/Multiplexer.js'
@@ -21,11 +21,11 @@ particle Multiplexer in 'source/Multiplexer.js'
 interface HostedParticleInterface2
   reads ~a
   reads [~a]
-  consumes? Slot
+  consumes Slot
 
 particle Multiplexer2 in 'source/Multiplexer.js'
   hostedParticle: hosts HostedParticleInterface2
   list: reads [~a]
   others: reads [~a]
-  annotation: consumes? [Slot]
+  annotation: consumes [Slot]
   description `${hostedParticle} for ${list}`

--- a/src/runtime/tests/artifacts/Common/SLANDLESMultiplexer.arcs
+++ b/src/runtime/tests/artifacts/Common/SLANDLESMultiplexer.arcs
@@ -8,24 +8,24 @@
 
 interface SlandleHostedAnnotationParticleInterface
   reads ~a
-  annotation: consumes? Slot
+  annotation: `consumes Slot
 
 // TODO: This particle should use generic slot name.
 particle SlandleMultiplexer in 'source/SlandleMultiplexer.js'
   hostedParticle: hosts SlandleHostedAnnotationParticleInterface
   list: reads [~a]
-  annotation: consumes? [Slot]
+  annotation: `consumes? [Slot]
   description `${hostedParticle} for ${list}`
 
 // Same as SlandleMultiplexer above, but with an additional connection.
 interface SlandleHostedParticleInterface2
   reads ~a
   reads [~a]
-  consumes? Slot
+  `consumes? Slot
 
 particle SlandleMultiplexer2 in 'source/SlandleMultiplexer.js'
   hostedParticle: hosts SlandleHostedParticleInterface2
   list: reads [~a]
   others: reads [~a]
-  annotation: consumes? [Slot]
+  annotation: `consumes? [Slot]
   description `${hostedParticle} for ${list}`

--- a/src/runtime/tests/artifacts/Common/SLANDLESMultiplexer.arcs
+++ b/src/runtime/tests/artifacts/Common/SLANDLESMultiplexer.arcs
@@ -21,7 +21,7 @@ particle SlandleMultiplexer in 'source/SlandleMultiplexer.js'
 interface SlandleHostedParticleInterface2
   reads ~a
   reads [~a]
-  `consumes? Slot
+  `consumes Slot
 
 particle SlandleMultiplexer2 in 'source/SlandleMultiplexer.js'
   hostedParticle: hosts SlandleHostedParticleInterface2

--- a/src/runtime/tests/artifacts/Common/source/Multiplexer.js
+++ b/src/runtime/tests/artifacts/Common/source/Multiplexer.js
@@ -15,13 +15,13 @@ defineParticle(({Particle, MultiplexerDomParticle}) => {
       const recipe = Particle.buildManifest`
 ${hostedParticle}
 recipe
-  use '${itemHandle._id}' as handle1
+  handle1: use '${itemHandle._id}'
   ${other.handles.join('\n')}
-  slot '${slot.id}' as slot1
+  slot1: slot '${slot.id}'
   ${hostedParticle.name}
-    ${hostedParticle.handleConnections[0].name} <- handle1
+    ${hostedParticle.handleConnections[0].name}: reads handle1
     ${other.connections.join('\n')}
-    consume ${slot.name} as slot1
+    ${slot.name}: consumes slot1
   `;
       return recipe;
     }

--- a/src/runtime/tests/artifacts/Products/Gifts.recipes
+++ b/src/runtime/tests/artifacts/Products/Gifts.recipes
@@ -18,7 +18,7 @@ particle GiftList in 'source/GiftList.js'
 
 particle Arrivinator in 'source/Arrivinator.js'
   product: reads Product
-  annotation: consumes? Slot
+  annotation: consumes Slot
   description `estimate arrival date`
   // TODO: add support for patterns:
   //description `estimate ${product} arrival date`
@@ -26,7 +26,7 @@ particle Arrivinator in 'source/Arrivinator.js'
 
 particle AlternateShipping in 'source/AlternateShipping.js'
   product: reads Product
-  annotation: consumes? Slot
+  annotation: consumes Slot
   description `find alternate shipping for products which won't make it on time`
 
 // Buying for [person]'s [occasion] in [timeframe]? Product [X] arrives too late.

--- a/src/runtime/tests/artifacts/Products/Manufacturer.recipes
+++ b/src/runtime/tests/artifacts/Products/Manufacturer.recipes
@@ -12,7 +12,7 @@ import 'Product.schema'
 
 particle ManufacturerInfo in 'source/ManufacturerInfo.js'
   in Product product
-  consume annotation
+  must consume annotation
   description `check manufacturer information`
 
 // Check manufacturer information for products.

--- a/src/runtime/tests/artifacts/Products/Recommend.recipes
+++ b/src/runtime/tests/artifacts/Products/Recommend.recipes
@@ -31,7 +31,7 @@ particle Chooser in 'source/Chooser.js'
 particle AlsoOn in 'source/AlsoOn.js'
   in Thing product
   in [Thing] choices
-  consume annotation
+  must consume annotation
 
 recipe &addFromWishlist
   use as shoplist

--- a/src/runtime/tests/artifacts/SLANDLEStest-particles.arcs
+++ b/src/runtime/tests/artifacts/SLANDLEStest-particles.arcs
@@ -27,4 +27,4 @@ particle SlandleOuterParticle in 'SLANDLESSYNTAXouter-particle.js'
 
 particle SlandleConsumerParticle in 'consumer-particle.js'
   input: reads Bar
-  annotation: consumes? Slot
+  annotation: `consumes Slot

--- a/src/runtime/tests/artifacts/test-particles.manifest
+++ b/src/runtime/tests/artifacts/test-particles.manifest
@@ -6,25 +6,25 @@
 // http://polymer.github.io/PATENTS.txt
 
 schema Foo
-  Text value
+  value: Text
 schema Bar
-  Text value
+  value: Text
 schema Far
 
 particle TestParticle in 'test-particle.js'
-  in Foo foo
-  out Bar bar
+  foo: reads Foo
+  bar: writes Bar
   description `test particle`
 
 interface TestInterface
-  in Foo foo
-  out Bar bar
+  foo: reads Foo
+  bar: writes Bar
 
 particle OuterParticle in 'outer-particle.js'
-  host TestInterface particle0
-  in Foo input
-  out Bar output
+  particle0: hosts TestInterface
+  input: reads Foo
+  output: writes Bar
 
 particle ConsumerParticle in 'consumer-particle.js'
-  in Bar input
-  consume annotation
+  input: reads Bar
+  annotation: consumes Slot

--- a/src/runtime/tests/multiplexer-test.ts
+++ b/src/runtime/tests/multiplexer-test.ts
@@ -68,7 +68,7 @@ describe('Multiplexer', () => {
     assert.strictEqual(slotsCreated, 3);
   });
 
-  it('SLANDLES SYNTAX Processes multiple inputs', Flags.withPostSlandlesSyntax(async () => {
+  it('SLANDLES Processes multiple inputs', Flags.withPostSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
       import 'src/runtime/tests/artifacts/Common/SLANDLESMultiplexer.arcs'
       import 'src/runtime/tests/artifacts/SLANDLEStest-particles.arcs'
@@ -78,7 +78,7 @@ describe('Multiplexer', () => {
         handle0: use 'test:1'
         SlandleMultiplexer
           hostedParticle: SlandleConsumerParticle
-          annotation: consumes slot0
+          annotation: \`consumes slot0
           list: reads handle0
     `, {loader: new Loader(), fileName: ''});
     const recipe = manifest.recipes[0];

--- a/src/runtime/tests/multiplexer-test.ts
+++ b/src/runtime/tests/multiplexer-test.ts
@@ -68,17 +68,17 @@ describe('Multiplexer', () => {
     assert.strictEqual(slotsCreated, 3);
   });
 
-  it('SLANDLES Processes multiple inputs', Flags.withPostSlandlesSyntax(async () => {
+  it('SLANDLES SYNTAX Processes multiple inputs', Flags.withPostSlandlesSyntax(async () => {
     const manifest = await Manifest.parse(`
-      import 'src/runtime/tests/artifacts/Common/SLANDLESMultiplexer.arcs'
-      import 'src/runtime/tests/artifacts/SLANDLEStest-particles.arcs'
+      import 'src/runtime/tests/artifacts/Common/Multiplexer.manifest'
+      import 'src/runtime/tests/artifacts/test-particles.manifest'
 
       recipe
         slot0: slot 'rootslotid-slotid'
         handle0: use 'test:1'
-        SlandleMultiplexer
-          hostedParticle: SlandleConsumerParticle
-          annotation: \`consumes slot0
+        Multiplexer
+          hostedParticle: ConsumerParticle
+          annotation: consumes slot0
           list: reads handle0
     `, {loader: new Loader(), fileName: ''});
     const recipe = manifest.recipes[0];


### PR DESCRIPTION
The affected test both used slandles and nonslandles (which currently do not reliably resolve against one another) and had an incorrect optionality annotation.

This change fixes these errors, converting the test to only use unified syntax, without slandles.