### PR TITLE
Bump emsdk commit number

### DIFF
--- a/build_defs/emscripten/repo.bzl
+++ b/build_defs/emscripten/repo.bzl
@@ -7,7 +7,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
 ## The directory structure might change between versions without warning, so
 # the emsdk.BUILD file might need updating too (also, the bundled version of
 # node might change too).
-_emsdk_commit_hash = "efc64876db1473312587a3f346be000a733bc16d"
+_emsdk_commit_hash = "a5082b232617c762cb65832429f896c838df2483"
 _emscripten_version = "1.38.43"
 
 def emsdk_repo():


### PR DESCRIPTION
As mentioned in #3968, it looks like emsdk have changed their storage host, so the old AWS URLs no longer work. Bumping the commit number we're pinned to so that we can point at the new correct URLs. Note that I haven't changed the actual emscripten version we're using, so the compiler should still be exactly the same.