### PR TITLE
ConCap: test tutility to capture or silence console logging.

### DIFF
--- a/src/planning/tests/suggestion-composer-test.ts
+++ b/src/planning/tests/suggestion-composer-test.ts
@@ -16,6 +16,7 @@ import {PlanningTestHelper} from '../testing/planning-test-helper.js';
 import {HeadlessSuggestDomConsumer} from '../headless-suggest-dom-consumer.js';
 import {PlanningModalityHandler} from '../planning-modality-handler.js';
 import {SuggestionComposer} from '../suggestion-composer.js';
+import {ConCap} from '../../testing/test-util.js';
 
 class TestSuggestionComposer extends SuggestionComposer {
   get suggestConsumers() {
@@ -33,7 +34,7 @@ describe('suggestion composer', () => {
       manifestFilename: './src/runtime/tests/artifacts/suggestions/Cake.recipes',
       slotComposer
     });
-    const suggestionComposer = new TestSuggestionComposer(helper.arc, slotComposer);
+    const suggestionComposer = ConCap.silence(() => new TestSuggestionComposer(helper.arc, slotComposer));
     await suggestionComposer.setSuggestions(helper.suggestions);
     assert.lengthOf(helper.suggestions, 1);
     assert.isEmpty(suggestionComposer.suggestConsumers);
@@ -73,7 +74,7 @@ describe('suggestion composer', () => {
       manifestFilename: './src/runtime/tests/artifacts/suggestions/Cakes.recipes',
       slotComposer
     });
-    const suggestionComposer = new TestSuggestionComposer(helper.arc, slotComposer);
+    const suggestionComposer = ConCap.silence(() => new TestSuggestionComposer(helper.arc, slotComposer));
     await suggestionComposer.setSuggestions(helper.suggestions);
     assert.lengthOf(helper.suggestions, 1);
     assert.isEmpty(suggestionComposer.suggestConsumers);

--- a/src/runtime/slot-composer.ts
+++ b/src/runtime/slot-composer.ts
@@ -93,8 +93,9 @@ export class SlotComposer {
       console.warn(`No containers for '${name}'`);
     } else if (contexts.length === 1) {
       return contexts[0].container;
+    } else {
+      console.warn(`Ambiguous containers for '${name}'`);
     }
-    console.warn(`Ambiguous containers for '${name}'`);
     return undefined;
   }
 

--- a/src/runtime/storage/pouchdb/pouch-db-singleton.ts
+++ b/src/runtime/storage/pouchdb/pouch-db-singleton.ts
@@ -186,7 +186,7 @@ export class PouchDbSingleton extends PouchDbStorageProvider implements Singleto
       const doc = await this.upsert(async doc => doc);
       let value = doc.value;
       if (value == null) {
-        console.warn('value is null and refmode=' + this.referenceMode);
+        //console.warn('value is null and refmode=' + this.referenceMode);
       }
       if (this.referenceMode && value) {
         const backingStore = await this.ensureBackingStore();

--- a/src/runtime/tests/manifest-test.ts
+++ b/src/runtime/tests/manifest-test.ts
@@ -16,7 +16,7 @@ import {Manifest, ErrorSeverity} from '../manifest.js';
 import {checkDefined, checkNotNull} from '../testing/preconditions.js';
 import {StubLoader} from '../testing/stub-loader.js';
 import {Dictionary} from '../hot.js';
-import {assertThrowsAsync} from '../../testing/test-util.js';
+import {assertThrowsAsync, ConCap} from '../../testing/test-util.js';
 import {ClaimType, ClaimIsTag, ClaimDerivesFrom} from '../particle-claim.js';
 import {CheckHasTag, CheckBooleanExpression, CheckCondition, CheckIsFromStore} from '../particle-check.js';
 import {ProvideSlotConnectionSpec} from '../particle-spec.js';
@@ -423,7 +423,10 @@ ${particleStr1}
       'a': `import 'b'`,
       'b': `lol what is this`,
     });
-    await Manifest.load('a', loader);
+    const cc = await ConCap.capture(() => Manifest.load('a', loader));
+    assert.lengthOf(cc.warn, 2);
+    assert.match(cc.warn[0], /Parse error in 'b' line 1/);
+    assert.match(cc.warn[1], /Error importing 'b'/);
   });
   it('throws an error when a particle has invalid description', async () => {
     try {
@@ -1479,7 +1482,6 @@ Expected a verb (e.g. &Verb) or an uppercase identifier (e.g. Foo) but "?" found
       await Manifest.parse(manifest);
       assert.fail();
     } catch (e) {
-      console.error(e.message);
       assert.match(e.message, /'out' not compatible with 'in' param of 'TestParticle'/);
     }
   });
@@ -1498,7 +1500,6 @@ Expected a verb (e.g. &Verb) or an uppercase identifier (e.g. Foo) but "?" found
       await Manifest.parse(manifest);
       assert.fail();
     } catch (e) {
-      console.error(e.message);
       assert.match(e.message, /param 'b' is not defined by 'TestParticle'/);
     }
   });

--- a/src/runtime/tests/synthetic-storage-test.ts
+++ b/src/runtime/tests/synthetic-storage-test.ts
@@ -13,7 +13,7 @@ import {Id, ArcId} from '../id.js';
 import {ChangeEvent, CollectionStorageProvider, SingletonStorageProvider} from '../storage/storage-provider-base.js';
 import {StorageProviderFactory} from '../storage/storage-provider-factory.js';
 import {resetVolatileStorageForTesting} from '../storage/volatile-storage.js';
-import {assertThrowsAsync} from '../../testing/test-util.js';
+import {assertThrowsAsync, ConCap} from '../../testing/test-util.js';
 import {ArcType} from '../type.js';
 
 describe('synthetic storage ', () => {
@@ -59,8 +59,9 @@ describe('synthetic storage ', () => {
   });
 
   it('invalid manifest', async () => {
-    const {synth} = await setup('bad manifest, no cookie for you');
-    assert.isEmpty(await synth.toList());
+    const cc = await ConCap.capture(() => setup('bad manifest, no cookie for you'));
+    assert.isEmpty(await cc.result.synth.toList());
+    assert.match(cc.warn[0], /Error parsing manifest/);
   });
 
   it('manifest with no active recipe', async () => {

--- a/src/testing/test-util.ts
+++ b/src/testing/test-util.ts
@@ -21,3 +21,89 @@ export async function assertThrowsAsync(fn: Function, ...args): Promise<void> {
     assert.throws(() => {throw e;}, ...args);
   }
 }
+
+/**
+ * Capture or disable console logging.
+ *
+ * To capture expected console output and verify that specific phrases were logged:
+ *
+ *   const cc = ConCap.capture(() => testAnErrorCase('parse failure'));
+ *   assert.equals(cc.result, 'this holds whatever testAnErrorCase returned');
+ *   assert.match(cc.log[0], /Error parsing/);
+ *
+ * To simply discard all console logging:
+ *
+ *   const testObject = ConCap.silence(() => new NoisyTestObject(...));
+ *
+ * Both sync and async functions can be wrapped; in the latter case you just need to
+ * await the capture/silence call.
+ */
+export class ConCap {
+  // tslint:disable: no-any
+  result: any;
+  log: any[][] = [];
+  warn: any[][] = [];
+  error: any[][] = [];
+  dir: any[][] = [];
+  private save: (() => void)[];
+  private restore: () => void;
+  // tslint:enable: no-any
+
+  private constructor() {
+    this.save = [console.log, console.warn, console.error, console.dir];
+    this.restore = () => [console.log, console.warn, console.error, console.dir] = this.save;
+  }
+
+  /**
+   * Captures the arguments for any calls to console.log and its friends while fn is being executed.
+   * If fn is synchronous, returns a ConCap with `result` holding fn's return value.
+   * If fn is asynchronous, returns a Promise with a ConCap whose `result` holds the awaited fn return.
+   * In both cases, the log/warn/etc fields hold whatever `fn` wrote to the corresponding console function.
+   */
+  // tslint:disable-next-line: no-any
+  static capture(fn: () => any): any {
+    const cc = new ConCap();
+    console.log   = (...args) => cc.log.push([...args]);
+    console.warn  = (...args) => cc.warn.push([...args]);
+    console.error = (...args) => cc.error.push([...args]);
+    console.dir   = (...args) => cc.dir.push([...args]);
+
+    const result = fn();
+    if (result && typeof result.then === 'function') {
+      let resolve;
+      const wrap = new Promise(r => resolve = r);
+      result.then(value => {
+        cc.result = value;
+        cc.restore();
+        resolve(cc);
+      });
+      return wrap;
+    } else {
+      cc.result = result;
+      cc.restore();
+      return cc;
+    }
+  }
+
+  /** Discards all calls to console.log and its friends. Returns the result of fn. */
+  static silence<T>(fn: () => T): T {
+    const cc = new ConCap();
+    console.log = console.warn = console.error = console.dir = () => {};
+
+    const result = fn();
+    cc.restore();
+    return result;
+  }
+
+  /** Returns a function that will invoke `fn` and capture anything logged to the console. */
+  // tslint:disable-next-line: no-any
+  static wrapCaptured<T, Args extends any[]>(fn: (...args: Args) => any): (...args: Args) => any {
+    return (...args: Args) => ConCap.capture(() => fn(...args));
+  }
+
+  /** Returns a function that will invoke `fn` without logging anything to the console. */
+  // tslint:disable-next-line: no-any
+  static wrapSilent<T, Args extends any[]>(fn: (...args: Args) => any): (...args: Args) => any {
+    return (...args: Args) => ConCap.silence(() => fn(...args));
+  }
+}


### PR DESCRIPTION
Some tests result in console output as a normal result of the test case
(usually due to error logging). This tends to obfuscate the output of
the test execution, and sometimes hides genuine problems because we end
up ignoring them amidst the noise. The ConCap class provides a simple
mechanism for disabling console output completely, or capturing it to
verify that specific messages were logged.