### PR TITLE
Storage Service - The Beginning

### DIFF
--- a/.bazelproject
+++ b/.bazelproject
@@ -1,24 +1,35 @@
 directories:
-  src_kt/java/arcs
-  src_kt/javatests/arcs
-  src_kt/project
+  src_kt/java
+  src_kt/javatests
   build_defs
   tools
   third_party
   particles
   src
+  shells/android/java
+  shells/android/javatests
+  javaharness/java
+  javaharness/javatests
 
 targets:
   //src_kt/java/...
   //src_kt/javatests/...
+  //shells/android/java/...
+  //shells/android/javatests/...
+  //javaharness/java/...
+  //javaharness/javatests/...
 
 test_sources:
   src_kt/javatests/
+  shells/android/javatests/
+  javaharness/javatests/
 
 additional_languages:
   kotlin
 
 workspace_type: java
+
+android_sdk_platform: android-29
 
 build_flags:
   --incompatible_depset_is_not_iterable=false

--- a/.bazelproject
+++ b/.bazelproject
@@ -27,7 +27,7 @@ test_sources:
 additional_languages:
   kotlin
 
-workspace_type: java
+java_language_level: 8
 
 android_sdk_platform: android-29
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -73,6 +73,17 @@ kotlin_repositories(compiler_release = KOTLINC_RELEASE)
 
 register_toolchains("//third_party/java/arcs/build_defs/internal:kotlin_toolchain")
 
+# Robolectric
+
+http_archive(
+    name = "robolectric",
+    urls = ["https://github.com/robolectric/robolectric-bazel/archive/4.1.tar.gz"],
+    sha256 = "2ee850ca521288db72b0dedb9ecbda55b64d11c470435a882f8daf615091253d",
+    strip_prefix = "robolectric-bazel-4.1",
+)
+load("@robolectric//bazel:robolectric.bzl", "robolectric_repositories")
+robolectric_repositories()
+
 # Java deps from Maven.
 
 RULES_JVM_EXTERNAL_TAG = "2.10"
@@ -97,6 +108,10 @@ KOTLINX_COROUTINES_VERSION = "1.3.2"
 maven_install(
     artifacts = [
         "androidx.webkit:webkit:1.1.0-rc01",
+        "androidx.test:core:1.0.0",
+        "androidx.test.ext:junit:1.0.0",
+        "androidx.test:runner:1.1.0",
+        "androidx.test:rules:1.1.0",
         "com.google.flogger:flogger:0.4",
         "com.google.flogger:flogger-system-backend:0.4",
         "com.google.dagger:dagger:2.23.1",
@@ -114,6 +129,7 @@ maven_install(
         "org.jetbrains.kotlinx:atomicfu-js:" + KOTLINX_ATOMICFU_VERSION,
         "org.json:json:20141113",
         "org.mockito:mockito-core:2.23.0",
+        "org.robolectric:robolectric:4.1",
     ],
     fetch_sources = True,
     repositories = [

--- a/javaharness/java/arcs/android/BUILD
+++ b/javaharness/java/arcs/android/BUILD
@@ -15,7 +15,6 @@ android_library(
     ],
     assets_dir = "",
     exports_manifest = 1,
-    idl_import_root = ".",
     idl_srcs = glob(["*.aidl"]),
     javacopts = ["-Xep:AndroidJdkLibsChecker:OFF"],
     manifest = "AndroidManifest.xml",

--- a/shells/android/java/arcs/BUILD
+++ b/shells/android/java/arcs/BUILD
@@ -1,0 +1,3 @@
+licenses(["notice"])
+
+package(default_visibility = ["//visibility:public"])

--- a/shells/android/java/arcs/common/AndroidManifest.xml
+++ b/shells/android/java/arcs/common/AndroidManifest.xml
@@ -1,0 +1,16 @@
+<!--
+  ~ Copyright 2019 Google LLC.
+  ~
+  ~ This code may only be used under the BSD style license found at
+  ~ http://polymer.github.io/LICENSE.txt
+  ~
+  ~ Code distributed by Google as part of this project is also subject to an additional IP rights
+  ~ grant found at
+  ~ http://polymer.github.io/PATENTS.txt
+  -->
+
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="arcs.android">
+    <uses-sdk
+            android:minSdkVersion="28"
+            android:targetSdkVersion="28"/>
+</manifest>

--- a/shells/android/java/arcs/common/BUILD
+++ b/shells/android/java/arcs/common/BUILD
@@ -1,0 +1,5 @@
+licenses(["notice"])
+
+package(default_visibility = ["//visibility:public"])
+
+exports_files(["AndroidManifest.xml"])

--- a/shells/android/java/arcs/crdt/parcelables/BUILD
+++ b/shells/android/java/arcs/crdt/parcelables/BUILD
@@ -1,0 +1,17 @@
+licenses(["notice"])
+
+package(default_visibility = ["//visibility:public"])
+
+load("//tools/build_defs/kotlin:rules.bzl", "kt_android_library")
+
+kt_android_library(
+    name = "parcelables",
+    srcs = glob(["*.kt"]),
+    manifest = "//shells/android/java/arcs/common:AndroidManifest.xml",
+    idl_parcelables = glob(["*.aidl"]),
+    deps = [
+        "//src_kt/java/arcs/common",
+        "//src_kt/java/arcs/crdt",
+        "//src_kt/java/arcs/crdt/internal",
+    ],
+)

--- a/shells/android/java/arcs/crdt/parcelables/CrdtParcelables.kt
+++ b/shells/android/java/arcs/crdt/parcelables/CrdtParcelables.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.crdt.parcelables
+
+import android.os.Parcelable
+import arcs.crdt.CrdtData
+import arcs.crdt.CrdtOperation
+import arcs.crdt.CrdtOperationAtTime
+
+/** Base interface for [Parcelable] implementations of [CrdtData] classes. */
+interface ParcelableCrdtData<T : CrdtData> : CrdtData, Parcelable {
+    val actual: T
+}
+
+/** Base interface for [Parcelable] implementations of [CrdtOperation] classes. */
+interface ParcelableCrdtOperation<T : CrdtOperation> : CrdtOperation, Parcelable {
+    val actual: T
+}
+
+/** Base interface for [Parcelable] implementations of [CrdtOperationAtTime] classes. */
+interface ParcelableCrdtOperationAtTime<T : CrdtOperationAtTime> :
+    ParcelableCrdtOperation<T>, CrdtOperationAtTime

--- a/shells/android/java/arcs/crdt/parcelables/ParcelableCrdtCount.kt
+++ b/shells/android/java/arcs/crdt/parcelables/ParcelableCrdtCount.kt
@@ -67,7 +67,6 @@ object ParcelableCrdtCount {
         }
     }
 
-
     /**
      * Parcelable variants of [CrdtCount.Operation].
      *
@@ -172,12 +171,12 @@ object ParcelableCrdtCount {
 fun CrdtCount.Data.toParcelable(): ParcelableCrdtData<CrdtCount.Data> =
     ParcelableCrdtCount.Data(this)
 
+/** Converts a [CrdtCount.Operation] to a [Parcelable] variant. */
+fun CrdtCount.Operation.toParcelable(): ParcelableCrdtOperation<CrdtCount.Operation> = when (this) {
+    is CrdtCount.Operation.Increment -> ParcelableCrdtCount.Operation.Increment(this)
+    is CrdtCount.Operation.MultiIncrement -> ParcelableCrdtCount.Operation.MultiIncrement(this)
+}
+
 /** Returns a list of [ParcelableCrdtOperation]s based on the list of [CrdtCount.Operation]s. */
 fun List<CrdtCount.Operation>.toParcelables(): List<ParcelableCrdtOperation<CrdtCount.Operation>> =
-    map {
-        when(it) {
-            is CrdtCount.Operation.Increment -> ParcelableCrdtCount.Operation.Increment(it)
-            is CrdtCount.Operation.MultiIncrement ->
-                ParcelableCrdtCount.Operation.MultiIncrement(it)
-        }
-    }
+    map { it.toParcelable() }

--- a/shells/android/java/arcs/crdt/parcelables/ParcelableCrdtCount.kt
+++ b/shells/android/java/arcs/crdt/parcelables/ParcelableCrdtCount.kt
@@ -23,7 +23,7 @@ object ParcelableCrdtCount {
      * Parcelable variant of [CrdtCount.Data].
      *
      * **Note:** There is no AIDL parcelable definition provided for this, because it is always
-     * passed as a member of another class to an AIDL interface, so none is needed.
+     * passed as a member of another class to an AIDL interface, not directly.
      */
     data class Data(
         override val actual: CrdtCount.Data
@@ -66,4 +66,118 @@ object ParcelableCrdtCount {
             override fun newArray(size: Int): Array<Data?> = arrayOfNulls(size)
         }
     }
+
+
+    /**
+     * Parcelable variants of [CrdtCount.Operation].
+     *
+     * This class is implemented such that it serves as a multiplexed parcelable for its subclasses:
+     *
+     * During [writeToParcel], we write the ordinal value of the [OpType] before the subclasses
+     * write their bodies.
+     *
+     * During [createFromParcel], we read the ordinal value of the [OpType] again, use that to find
+     * the corresponding enum value, and multiplex down to the appropriate [createFromParcel] method
+     * within the subclasses' [CREATOR]s.
+     *
+     * **Note:** There are no AIDL parcelable definition provided for these, because they are always
+     * passed as members of another class to an AIDL interface, not directly.
+     */
+    sealed class Operation(
+        private val opType: OpType
+    ) : ParcelableCrdtOperation<CrdtCount.Operation> {
+
+        override fun writeToParcel(parcel: Parcel, flags: Int) {
+            // Write the opType so we can multiplex during createFromParcel.
+            parcel.writeInt(opType.ordinal)
+        }
+
+        /** Parcelable variant of [CrdtCount.Operation.Increment]. */
+        data class Increment(
+            override val actual: CrdtCount.Operation.Increment
+        ) : Operation(OpType.Increment) {
+
+            override fun writeToParcel(parcel: Parcel, flags: Int) {
+                super.writeToParcel(parcel, flags)
+                parcel.writeString(actual.actor)
+                parcel.writeInt(actual.version.first)
+                parcel.writeInt(actual.version.second)
+            }
+
+            override fun describeContents(): Int = 0
+
+            companion object CREATOR : Parcelable.Creator<Increment> {
+                override fun createFromParcel(parcel: Parcel): Increment {
+                    val actor = requireNotNull(parcel.readString())
+                    val from = parcel.readInt()
+                    val to = parcel.readInt()
+                    return Increment(CrdtCount.Operation.Increment(actor, from to to))
+                }
+
+                override fun newArray(size: Int): Array<Increment?> = arrayOfNulls(size)
+            }
+        }
+
+        /** Parcelable variant of [CrdtCount.Operation.MultiIncrement]. */
+        data class MultiIncrement(
+            override val actual: CrdtCount.Operation.MultiIncrement
+        ) : Operation(OpType.MultiIncrement) {
+            override fun writeToParcel(parcel: Parcel, flags: Int) {
+                super.writeToParcel(parcel, flags)
+                parcel.writeString(actual.actor)
+                parcel.writeInt(actual.version.first)
+                parcel.writeInt(actual.version.second)
+                parcel.writeInt(actual.delta)
+            }
+
+            override fun describeContents(): Int = 0
+
+            companion object CREATOR : Parcelable.Creator<MultiIncrement> {
+                override fun createFromParcel(parcel: Parcel): MultiIncrement {
+                    val actor = requireNotNull(parcel.readString())
+                    val from = parcel.readInt()
+                    val to = parcel.readInt()
+                    val delta = parcel.readInt()
+                    return MultiIncrement(
+                        CrdtCount.Operation.MultiIncrement(actor, from to to, delta)
+                    )
+                }
+
+                override fun newArray(size: Int): Array<MultiIncrement?> = arrayOfNulls(size)
+            }
+        }
+
+        companion object CREATOR : Parcelable.Creator<Operation> {
+            override fun createFromParcel(parcel: Parcel): Operation =
+                when (OpType.values()[parcel.readInt()]) {
+                    OpType.Increment -> Increment.createFromParcel(parcel)
+                    OpType.MultiIncrement -> MultiIncrement.createFromParcel(parcel)
+                }
+
+            override fun newArray(size: Int): Array<Operation?> = arrayOfNulls(size)
+        }
+    }
+
+    /**
+     * Identifiers for when [Operation] is reading from a parcelable, so it can multiplex out to the
+     * correct subclass.
+     */
+    internal enum class OpType {
+        Increment,
+        MultiIncrement,
+    }
 }
+
+/** Returns a [Parcelable] variant of the [CrdtCount.Data] object. */
+fun CrdtCount.Data.toParcelable(): ParcelableCrdtData<CrdtCount.Data> =
+    ParcelableCrdtCount.Data(this)
+
+/** Returns a list of [ParcelableCrdtOperation]s based on the list of [CrdtCount.Operation]s. */
+fun List<CrdtCount.Operation>.toParcelables(): List<ParcelableCrdtOperation<CrdtCount.Operation>> =
+    map {
+        when(it) {
+            is CrdtCount.Operation.Increment -> ParcelableCrdtCount.Operation.Increment(it)
+            is CrdtCount.Operation.MultiIncrement ->
+                ParcelableCrdtCount.Operation.MultiIncrement(it)
+        }
+    }

--- a/shells/android/java/arcs/crdt/parcelables/ParcelableCrdtCount.kt
+++ b/shells/android/java/arcs/crdt/parcelables/ParcelableCrdtCount.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.crdt.parcelables
+
+import android.os.Parcel
+import android.os.Parcelable
+import arcs.crdt.CrdtCount
+import arcs.crdt.internal.Actor
+import arcs.crdt.internal.VersionMap
+
+/** Container of [Parcelable] implementations for [CrdtCount]'s data and ops classes. */
+object ParcelableCrdtCount {
+    /**
+     * Parcelable variant of [CrdtCount.Data].
+     *
+     * **Note:** There is no AIDL parcelable definition provided for this, because it is always
+     * passed as a member of another class to an AIDL interface, so none is needed.
+     */
+    data class Data(
+        override val actual: CrdtCount.Data
+    ) : ParcelableCrdtData<CrdtCount.Data> {
+        override var versionMap: VersionMap = actual.versionMap
+
+        override fun writeToParcel(parcel: Parcel, flags: Int) {
+            // Write the version map.
+            parcel.writeTypedObject(ParcelableVersionMap(actual.versionMap), flags)
+
+            // Write the number of values as a hint of what to expect.
+            parcel.writeInt(actual.values.size)
+            // Write the actual values.
+            actual.values.forEach { (actor, value) ->
+                parcel.writeString(actor)
+                parcel.writeInt(value)
+            }
+        }
+
+        override fun describeContents(): Int = 0
+
+        companion object CREATOR : Parcelable.Creator<Data> {
+            override fun createFromParcel(parcel: Parcel): Data {
+                // Read the version map.
+                val versionMap = requireNotNull(
+                    parcel.readTypedObject(ParcelableVersionMap.CREATOR)
+                ) { "No VersionMap found in parcel when reading ParcelableCrdtCountData" }
+                val values = mutableMapOf<Actor, Int>()
+
+                // Read the item count hint.
+                val items = parcel.readInt()
+                // Use the item count hint to read the values into the map.
+                repeat(items) {
+                    values[requireNotNull(parcel.readString())] = parcel.readInt()
+                }
+
+                return Data(CrdtCount.Data(values, versionMap.actual))
+            }
+
+            override fun newArray(size: Int): Array<Data?> = arrayOfNulls(size)
+        }
+    }
+}

--- a/shells/android/java/arcs/crdt/parcelables/ParcelableCrdtException.aidl
+++ b/shells/android/java/arcs/crdt/parcelables/ParcelableCrdtException.aidl
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.crdt.parcelables;
+
+parcelable ParcelableCrdtException;

--- a/shells/android/java/arcs/crdt/parcelables/ParcelableCrdtException.kt
+++ b/shells/android/java/arcs/crdt/parcelables/ParcelableCrdtException.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.crdt.parcelables
+
+import android.os.Parcel
+import android.os.Parcelable
+import arcs.crdt.CrdtException
+
+/** [Parcelable] wrapper for a [CrdtException]. */
+class ParcelableCrdtException(
+    val message: String? = null,
+    val stackTrace: Array<String> = emptyArray()
+) : Parcelable {
+    constructor(e: CrdtException) : this(e.message, e.stackTrace.toStrings())
+
+    override fun writeToParcel(parcel: Parcel, flags: Int) {
+        parcel.writeValue(message)
+        parcel.writeInt(stackTrace.size)
+        parcel.writeStringArray(stackTrace)
+    }
+
+    override fun describeContents(): Int = 0
+
+    companion object CREATOR : Parcelable.Creator<ParcelableCrdtException> {
+        override fun createFromParcel(parcel: Parcel): ParcelableCrdtException {
+            val message = parcel.readValue(String::class.java.classLoader) as? String
+            val stackTraceSize = parcel.readInt()
+            val stackTrace = Array(stackTraceSize) { "" }.also { parcel.readStringArray(it) }
+            return ParcelableCrdtException(message, stackTrace)
+        }
+
+        override fun newArray(size: Int): Array<ParcelableCrdtException?> = arrayOfNulls(size)
+    }
+}
+
+private fun Array<StackTraceElement>.toStrings(): Array<String> =
+    Array(this.size) { index -> this[index].toString() }

--- a/shells/android/java/arcs/crdt/parcelables/ParcelableCrdtException.kt
+++ b/shells/android/java/arcs/crdt/parcelables/ParcelableCrdtException.kt
@@ -42,5 +42,8 @@ class ParcelableCrdtException(
     }
 }
 
-private fun Array<StackTraceElement>.toStrings(): Array<String> =
+/** Converts a [CrdtException] into a [ParcelableCrdtException]. */
+fun CrdtException.toParcelable(): ParcelableCrdtException = ParcelableCrdtException(this)
+
+internal fun Array<StackTraceElement>.toStrings(): Array<String> =
     Array(this.size) { index -> this[index].toString() }

--- a/shells/android/java/arcs/crdt/parcelables/ParcelableCrdtType.kt
+++ b/shells/android/java/arcs/crdt/parcelables/ParcelableCrdtType.kt
@@ -13,6 +13,7 @@ package arcs.crdt.parcelables
 
 import android.os.Parcelable
 import arcs.crdt.CrdtData
+import arcs.crdt.CrdtModel
 import arcs.crdt.CrdtOperation
 
 /** Enumeration of the parcelable [CrdtModel] types. */
@@ -24,7 +25,7 @@ enum class ParcelableCrdtType(
         null
 ) {
     // TODO: provide creators for each CRDT data structure and remove the default values.
-    Count(ParcelableCrdtCount.Data.CREATOR),
+    Count(ParcelableCrdtCount.Data.CREATOR, ParcelableCrdtCount.Operation.CREATOR),
     Set,
     Singleton,
     Entity,

--- a/shells/android/java/arcs/crdt/parcelables/ParcelableCrdtType.kt
+++ b/shells/android/java/arcs/crdt/parcelables/ParcelableCrdtType.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.crdt.parcelables
+
+import android.os.Parcelable
+import arcs.crdt.CrdtData
+import arcs.crdt.CrdtOperation
+
+/** Enumeration of the parcelable [CrdtModel] types. */
+enum class ParcelableCrdtType(
+    /** [Parcelable.Creator] for the type's [ParcelableCrdtData] class. */
+    val crdtDataCreator: Parcelable.Creator<out ParcelableCrdtData<out CrdtData>>? = null,
+    /** [Parcelable.Creator] for the type's [ParcelableCrdtOperation] classes. */
+    val crdtOperationCreator: Parcelable.Creator<out ParcelableCrdtOperation<out CrdtOperation>>? =
+        null
+) {
+    // TODO: provide creators for each CRDT data structure and remove the default values.
+    Count(ParcelableCrdtCount.Data.CREATOR),
+    Set,
+    Singleton,
+    Entity,
+}

--- a/shells/android/java/arcs/crdt/parcelables/ParcelableVersionMap.kt
+++ b/shells/android/java/arcs/crdt/parcelables/ParcelableVersionMap.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.crdt.parcelables
+
+import android.os.Parcel
+import android.os.Parcelable
+import arcs.crdt.internal.VersionMap
+
+/** [Parcelable] wrapper for [VersionMap]. */
+data class ParcelableVersionMap(
+    val actual: VersionMap
+) : Parcelable {
+    override fun writeToParcel(parcel: Parcel, flags: Int) {
+        val actors = actual.actors.toList()
+        parcel.writeInt(actors.size)
+        actors.forEach {
+            parcel.writeString(it)
+            parcel.writeInt(actual[it])
+        }
+    }
+
+    override fun describeContents(): Int = 0
+
+    companion object CREATOR : Parcelable.Creator<ParcelableVersionMap> {
+        override fun createFromParcel(parcel: Parcel): ParcelableVersionMap {
+            val actual = VersionMap()
+            val entries = parcel.readInt()
+            repeat(entries) {
+                actual[requireNotNull(parcel.readString())] = requireNotNull(parcel.readInt())
+            }
+            return ParcelableVersionMap(actual)
+        }
+
+        override fun newArray(size: Int): Array<ParcelableVersionMap?> = arrayOfNulls(size)
+    }
+}

--- a/shells/android/java/arcs/crdt/parcelables/ParcelableVersionMap.kt
+++ b/shells/android/java/arcs/crdt/parcelables/ParcelableVersionMap.kt
@@ -43,3 +43,6 @@ data class ParcelableVersionMap(
         override fun newArray(size: Int): Array<ParcelableVersionMap?> = arrayOfNulls(size)
     }
 }
+
+/** Converts a [VersionMap] into a [ParcelableVersionMap]. */
+fun VersionMap.toParcelable(): ParcelableVersionMap = ParcelableVersionMap(this)

--- a/shells/android/java/arcs/storage/BUILD
+++ b/shells/android/java/arcs/storage/BUILD
@@ -1,0 +1,3 @@
+licenses(["notice"])
+
+package(default_visibility = ["//visibility:public"])

--- a/shells/android/java/arcs/storage/parcelables/BUILD
+++ b/shells/android/java/arcs/storage/parcelables/BUILD
@@ -1,0 +1,19 @@
+licenses(["notice"])
+
+package(default_visibility = ["//visibility:public"])
+
+load("//tools/build_defs/kotlin:rules.bzl", "kt_android_library")
+
+kt_android_library(
+    name = "parcelables",
+    srcs = glob(["*.kt"]),
+    manifest = "//shells/android/java/arcs/common:AndroidManifest.xml",
+    idl_parcelables = glob(["*.aidl"]),
+    deps = [
+        "//shells/android/java/arcs/crdt/parcelables",
+        "//src_kt/java/arcs/common",
+        "//src_kt/java/arcs/crdt",
+        "//src_kt/java/arcs/crdt/internal",
+        "//src_kt/java/arcs/storage"
+    ],
+)

--- a/shells/android/java/arcs/storage/parcelables/ParcelableModelUpdate.aidl
+++ b/shells/android/java/arcs/storage/parcelables/ParcelableModelUpdate.aidl
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.storage.parcelables;
+
+parcelable ParcelableModelUpdate;

--- a/shells/android/java/arcs/storage/parcelables/ParcelableModelUpdate.kt
+++ b/shells/android/java/arcs/storage/parcelables/ParcelableModelUpdate.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.storage.parcelables
+
+import android.annotation.TargetApi
+import android.os.Build
+import android.os.Parcel
+import android.os.Parcelable
+import arcs.crdt.CrdtData
+import arcs.crdt.CrdtOperation
+import arcs.crdt.parcelables.ParcelableCrdtData
+import arcs.crdt.parcelables.ParcelableCrdtType
+import arcs.storage.ProxyMessage
+
+/** Parcelable variant of [ProxyMessage.ModelUpdate]. */
+@TargetApi(Build.VERSION_CODES.M)
+data class ParcelableModelUpdate(
+    val model: ParcelableCrdtData<*>,
+    override val id: Int?,
+    override val crdtType: ParcelableCrdtType,
+    override val type: ProxyMessage.Type = ProxyMessage.Type.ModelUpdate
+) : ParcelableProxyMessage(id, crdtType, type) {
+    @Suppress("UNCHECKED_CAST")
+    override fun <Data, Op, ConsumerData> actualize(): ProxyMessage<Data, Op, ConsumerData>
+        where Data : CrdtData, Op : CrdtOperation =
+        ProxyMessage.ModelUpdate(model.actual as Data, id)
+
+    override fun writeToParcel(parcel: Parcel, flags: Int) {
+        parcel.writeInt(id ?: NO_ID)
+        parcel.writeInt(crdtType.ordinal)
+        parcel.writeInt(type.ordinal)
+        // We write the model last, so when createFromParcel is called, we can refer to the crdtType
+        // to rehydrate the model.
+        parcel.writeTypedObject(model, 0)
+    }
+
+    override fun describeContents(): Int = 0
+
+    companion object CREATOR :
+        Parcelable.Creator<ParcelableModelUpdate> {
+        override fun createFromParcel(parcel: Parcel): ParcelableModelUpdate {
+            val id = parcel.readInt().takeIf { it != NO_ID }
+            val crdtType = ParcelableCrdtType.values()[parcel.readInt()]
+            val type = ProxyMessage.Type.values()[parcel.readInt()]
+            val model = requireNotNull(
+                parcel.readTypedObject(
+                    requireNotNull(crdtType.crdtDataCreator) {
+                        "No ParcelableCrdtData creator for $crdtType"
+                    }
+                )
+            ) { "ParcelableCrdtData not found in parcel for ModelUpdate proxy message" }
+            return ParcelableModelUpdate(model, id, crdtType, type)
+        }
+
+        override fun newArray(size: Int): Array<ParcelableModelUpdate?> = arrayOfNulls(size)
+    }
+}

--- a/shells/android/java/arcs/storage/parcelables/ParcelableOperations.aidl
+++ b/shells/android/java/arcs/storage/parcelables/ParcelableOperations.aidl
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.storage.parcelables;
+
+parcelable ParcelableOperations;

--- a/shells/android/java/arcs/storage/parcelables/ParcelableOperations.kt
+++ b/shells/android/java/arcs/storage/parcelables/ParcelableOperations.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.storage.parcelables
+
+import android.os.Parcel
+import android.os.Parcelable
+import arcs.crdt.CrdtData
+import arcs.crdt.CrdtOperation
+import arcs.crdt.parcelables.ParcelableCrdtOperation
+import arcs.crdt.parcelables.ParcelableCrdtType
+import arcs.storage.ProxyMessage
+
+/** Parcelable variant of [ProxyMessage.Operations]. */
+data class ParcelableOperations(
+    val operations: List<ParcelableCrdtOperation<*>>,
+    override val id: Int?,
+    override val crdtType: ParcelableCrdtType,
+    override val type: ProxyMessage.Type = ProxyMessage.Type.Operations
+) : ParcelableProxyMessage(id, crdtType, type) {
+    @Suppress("UNCHECKED_CAST")
+    override fun <Data, Op, ConsumerData> actualize(): ProxyMessage<Data, Op, ConsumerData>
+        where Data : CrdtData, Op : CrdtOperation =
+        ProxyMessage.Operations(operations.map { it.actual as Op }, id)
+
+    override fun writeToParcel(parcel: Parcel, flags: Int) {
+        parcel.writeInt(id ?: NO_ID)
+        parcel.writeInt(crdtType.ordinal)
+        parcel.writeInt(type.ordinal)
+        // We write the operations last, so when createFromParcel is called, we can refer to the
+        // crdtType to rehydrate the operations.
+        parcel.writeTypedList(operations)
+    }
+
+    override fun describeContents(): Int = 0
+
+    companion object CREATOR :
+        Parcelable.Creator<ParcelableOperations> {
+        override fun createFromParcel(parcel: Parcel): ParcelableOperations {
+            val id = parcel.readInt().takeIf { it != NO_ID }
+            val crdtType = ParcelableCrdtType.values()[parcel.readInt()]
+            val type = ProxyMessage.Type.values()[parcel.readInt()]
+            val ops = requireNotNull(
+                parcel.createTypedArrayList(
+                    requireNotNull(crdtType.crdtOperationCreator) {
+                        "No ParcelableCrdtOperation creator for $crdtType"
+                    }
+                )
+            ) { "ParcelableCrdtOperations not found in parcel for Operations proxy message" }
+
+            return ParcelableOperations(ops, id, crdtType, type)
+        }
+
+        override fun newArray(size: Int): Array<ParcelableOperations?> = arrayOfNulls(size)
+    }
+}

--- a/shells/android/java/arcs/storage/parcelables/ParcelableProxyMessage.kt
+++ b/shells/android/java/arcs/storage/parcelables/ParcelableProxyMessage.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.storage.parcelables
+
+import android.os.Parcelable
+import arcs.crdt.CrdtData
+import arcs.crdt.CrdtOperation
+import arcs.crdt.parcelables.ParcelableCrdtType
+import arcs.storage.ProxyMessage
+
+/** Defines parcelable variants of the [ProxyMessage]s. */
+abstract class ParcelableProxyMessage(
+    /** Identifier for the [ProxyMessage]. */
+    open val id: Int?,
+    /** Type of CRDT this message is intended for. */
+    open val crdtType: ParcelableCrdtType,
+    /** [Type] of the message. */
+    internal open val type: ProxyMessage.Type
+) : Parcelable {
+    /** Converts the [Parcelable] [ProxyMessage] back into an actual [ProxyMessage] variant. */
+    abstract fun <Data, Op, ConsumerData> actualize(): ProxyMessage<Data, Op, ConsumerData>
+        where Data : CrdtData, Op : CrdtOperation
+
+    companion object {
+        /** Represents the absence of an [id] in a [ParcelableProxyMessage]. */
+        const val NO_ID = -1
+    }
+}

--- a/shells/android/java/arcs/storage/parcelables/ParcelableSyncRequest.aidl
+++ b/shells/android/java/arcs/storage/parcelables/ParcelableSyncRequest.aidl
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.storage.parcelables;
+
+parcelable ParcelableSyncRequest;

--- a/shells/android/java/arcs/storage/parcelables/ParcelableSyncRequest.kt
+++ b/shells/android/java/arcs/storage/parcelables/ParcelableSyncRequest.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.storage.parcelables
+
+import android.os.Parcel
+import android.os.Parcelable
+import arcs.crdt.CrdtData
+import arcs.crdt.CrdtOperation
+import arcs.crdt.parcelables.ParcelableCrdtType
+import arcs.storage.ProxyMessage
+
+/** Parcelable variant of [ProxyMessage.SyncRequest]. */
+data class ParcelableSyncRequest(
+    override val id: Int?,
+    override val crdtType: ParcelableCrdtType,
+    override val type: ProxyMessage.Type = ProxyMessage.Type.SyncRequest
+) : ParcelableProxyMessage(id, crdtType, type) {
+    override fun <Data, Op, ConsumerData> actualize(): ProxyMessage<Data, Op, ConsumerData>
+        where Data : CrdtData, Op : CrdtOperation = ProxyMessage.SyncRequest(id)
+
+    override fun writeToParcel(parcel: Parcel, flags: Int) {
+        parcel.writeInt(id ?: NO_ID)
+        parcel.writeInt(crdtType.ordinal)
+        parcel.writeInt(type.ordinal)
+    }
+
+    override fun describeContents(): Int = 0
+
+    companion object CREATOR : Parcelable.Creator<ParcelableSyncRequest> {
+        override fun createFromParcel(parcel: Parcel): ParcelableSyncRequest {
+            val id = parcel.readInt().takeIf { it != NO_ID }
+            val crdtType = ParcelableCrdtType.values()[parcel.readInt()]
+            val type = ProxyMessage.Type.values()[parcel.readInt()]
+            return ParcelableSyncRequest(id, crdtType, type)
+        }
+
+        override fun newArray(size: Int): Array<ParcelableSyncRequest?> = arrayOfNulls(size)
+    }
+}

--- a/shells/android/java/arcs/storage/service/BUILD
+++ b/shells/android/java/arcs/storage/service/BUILD
@@ -1,0 +1,31 @@
+licenses(["notice"])
+
+package(default_visibility = ["//visibility:public"])
+
+load("//tools/build_defs/kotlin:rules.bzl", "kt_android_library")
+
+kt_android_library(
+    name = "service",
+    srcs = glob(["*.kt"]),
+    manifest = "//shells/android/java/arcs/common:AndroidManifest.xml",
+    deps = [
+        ":aidl",
+        "//shells/android/java/arcs/storage/parcelables",
+        "//src_kt/java/arcs/common",
+        "//src_kt/java/arcs/crdt",
+        "//src_kt/java/arcs/crdt/internal",
+        "//src_kt/java/arcs/storage"
+    ],
+)
+
+android_library(
+    name = "aidl",
+    manifest = "//shells/android/java/arcs/common:AndroidManifest.xml",
+    idl_srcs = glob(["*.aidl"]),
+    idl_import_root = ".",
+    deps = [
+        "//shells/android/java/arcs/crdt/parcelables",
+        "//shells/android/java/arcs/storage/parcelables",
+    ],
+)
+

--- a/shells/android/java/arcs/storage/service/IResultCallback.aidl
+++ b/shells/android/java/arcs/storage/service/IResultCallback.aidl
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.storage.service;
+
+import arcs.crdt.parcelables.ParcelableCrdtException;
+
+/** Mechanism allowing an asynchronous response from the StorageService. */
+interface IResultCallback {
+    /**
+     * Handles success/failure of an async op.<br><br>
+     *
+     * {@param exception} is nullable.
+     */
+    void onResult(boolean success, in ParcelableCrdtException exception);
+}

--- a/shells/android/java/arcs/storage/service/IStorageService.aidl
+++ b/shells/android/java/arcs/storage/service/IStorageService.aidl
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.storage.service;
+
+import arcs.storage.parcelables.ParcelableModelUpdate;
+import arcs.storage.parcelables.ParcelableOperations;
+import arcs.storage.parcelables.ParcelableSyncRequest;
+import arcs.storage.service.IResultCallback;
+import arcs.storage.service.IStorageServiceCallback;
+
+/** Exposed API for the StorageService. */
+interface IStorageService {
+    /**
+     * Registers an {@link IStorageServiceCallback} with the StorageService and returns its callback
+     * token.
+     */
+    int registerCallback(IStorageServiceCallback callback);
+
+    /** Unregisters the callback associated with the given {@param token}. */
+    void unregisterCallback(int token);
+
+    /** Sends the StorageService a SyncRequest ParcelableProxyMessage. */
+    void sendSyncRequest(in ParcelableSyncRequest req, IResultCallback resultCallback);
+
+    /** Sends the StorageService a ModelUpdate ParcelableProxyMessage. */
+    void sendModelUpdate(in ParcelableModelUpdate update, IResultCallback resultCallback);
+
+    /** Sends the StorageService an Operations ParcelableProxyMessage. */
+    void sendOperations(in ParcelableOperations operations, IResultCallback resultCallback);
+}

--- a/shells/android/java/arcs/storage/service/IStorageService.aidl
+++ b/shells/android/java/arcs/storage/service/IStorageService.aidl
@@ -17,7 +17,11 @@ import arcs.storage.parcelables.ParcelableSyncRequest;
 import arcs.storage.service.IResultCallback;
 import arcs.storage.service.IStorageServiceCallback;
 
-/** Exposed API for the StorageService. */
+/**
+ * Exposed API for the StorageService.
+ *
+ * TODO: subject to change.
+ */
 interface IStorageService {
     /**
      * Registers an {@link IStorageServiceCallback} with the StorageService and returns its callback

--- a/shells/android/java/arcs/storage/service/IStorageServiceCallback.aidl
+++ b/shells/android/java/arcs/storage/service/IStorageServiceCallback.aidl
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.storage.service;
+
+import arcs.storage.parcelables.ParcelableModelUpdate;
+import arcs.storage.parcelables.ParcelableOperations;
+import arcs.storage.parcelables.ParcelableSyncRequest;
+import arcs.storage.service.IResultCallback;
+
+/** Variant of ProxyCallback intended for StorageService communications. */
+interface IStorageServiceCallback {
+    /** Handles an incoming SyncRequest. */
+    void onSyncRequest(in ParcelableSyncRequest req, IResultCallback resultCallback);
+
+    /** Handles an incoming ModelUpdate. */
+    void onModelUpdate(in ParcelableModelUpdate update, IResultCallback resultCallback);
+
+    /** Handles an incoming Operations. */
+    void onOperations(in ParcelableOperations operations, IResultCallback resultCallback);
+}

--- a/shells/android/java/arcs/storage/service/StorageService.kt
+++ b/shells/android/java/arcs/storage/service/StorageService.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.storage.service
+
+import android.app.Service
+import android.content.Intent
+import android.os.IBinder
+import arcs.storage.parcelables.ParcelableModelUpdate
+import arcs.storage.parcelables.ParcelableOperations
+import arcs.storage.parcelables.ParcelableSyncRequest
+
+class StorageService : Service() {
+    override fun onBind(p0: Intent?): IBinder? = BindingContext()
+
+    class BindingContext : IStorageService.Stub() {
+        override fun registerCallback(callback: IStorageServiceCallback): Int {
+            TODO("implement me")
+        }
+
+        override fun sendSyncRequest(
+            req: ParcelableSyncRequest,
+            resultCallback: IResultCallback
+        ) {
+            TODO("implement me")
+        }
+
+        override fun sendOperations(
+            operations: ParcelableOperations,
+            resultCallback: IResultCallback
+        ) {
+            TODO("implement me")
+        }
+
+        override fun sendModelUpdate(
+            update: ParcelableModelUpdate,
+            resultCallback: IResultCallback
+        ) {
+            TODO("implement me")
+        }
+
+        override fun unregisterCallback(token: Int) {
+            TODO("implement me")
+        }
+    }
+}

--- a/shells/android/javatests/arcs/BUILD
+++ b/shells/android/javatests/arcs/BUILD
@@ -1,0 +1,3 @@
+licenses(["notice"])
+
+package(default_visibility = ["//visibility:public"])

--- a/shells/android/javatests/arcs/crdt/parcelables/BUILD
+++ b/shells/android/javatests/arcs/crdt/parcelables/BUILD
@@ -1,0 +1,38 @@
+licenses(["notice"])
+
+package(default_visibility = ["//visibility:public"])
+
+load("//tools/build_defs/android:rules.bzl", "android_local_test")
+load("//tools/build_defs/kotlin:rules.bzl", "kt_android_library")
+
+[
+    [
+        android_local_test(
+            name = src_file[:-3],
+            size = "small",
+            manifest = "//shells/android/java/arcs/common:AndroidManifest.xml",
+            test_class = "arcs.crdt.parcelables.%s" % src_file[:-3],
+            deps = [
+                ":%sLib" % src_file[:-3],
+                "@robolectric//bazel:android-all",
+            ],
+        ),
+        kt_android_library(
+            name = src_file[:-3] + "Lib",
+            srcs = [src_file],
+            manifest = "//shells/android/java/arcs/common:AndroidManifest.xml",
+            deps = [
+                "//shells/android/java/arcs/crdt/parcelables",
+                "//src_kt/java/arcs/crdt",
+                "//src_kt/java/arcs/crdt/internal",
+                "//third_party/android/androidx_test/core",
+                "//third_party/android/androidx_test/ext/junit",
+                "//third_party/java/junit",
+                "//third_party/java/mockito",
+                "//third_party/java/robolectric",
+                "//third_party/java/truth",
+            ],
+        ),
+    ]
+    for src_file in glob(["*.kt"])
+]

--- a/shells/android/javatests/arcs/crdt/parcelables/ParcelableCrdtCountTest.kt
+++ b/shells/android/javatests/arcs/crdt/parcelables/ParcelableCrdtCountTest.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.crdt.parcelables
+
+import android.os.Parcel
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import arcs.crdt.CrdtCount
+import arcs.crdt.internal.VersionMap
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/** Tests for [ParcelableCrdtCount]'s classes. */
+@RunWith(AndroidJUnit4::class)
+class ParcelableCrdtCountTest {
+    @Test
+    fun data_parcelableRoundTrip_works() {
+        val data = CrdtCount.Data(
+            mutableMapOf(
+                "alice" to 1,
+                "bob" to 2
+            ),
+            VersionMap("alice" to 1, "bob" to 2)
+        )
+
+        val marshalled = with(Parcel.obtain()) {
+            writeTypedObject(data.toParcelable(), 0)
+            marshall()
+        }
+
+        val unmarshalled = with(Parcel.obtain()) {
+            unmarshall(marshalled, 0, marshalled.size)
+            readTypedObject(requireNotNull(ParcelableCrdtType.Count.crdtDataCreator))
+        }
+
+        assertThat(unmarshalled?.actual).isEqualTo(data)
+    }
+
+    @Test
+    fun incrementOperation_parcelableRoundTrip_works() {
+        val op = CrdtCount.Operation.Increment("alice", 0 to 1)
+
+        val marshalled = with(Parcel.obtain()) {
+            writeTypedObject(op.toParcelable(), 0)
+            marshall()
+        }
+
+        val unmarshalled = with(Parcel.obtain()) {
+            unmarshall(marshalled, 0, marshalled.size)
+            readTypedObject(requireNotNull(ParcelableCrdtType.Count.crdtOperationCreator))
+        }
+
+        assertThat(unmarshalled?.actual).isEqualTo(op)
+    }
+
+    @Test
+    fun multiIncrementOperation_parcelableRoundTrip_works() {
+        val op = CrdtCount.Operation.MultiIncrement("alice", 0 to 1000, delta = 1000)
+
+        val marshalled = with(Parcel.obtain()) {
+            writeTypedObject(op.toParcelable(), 0)
+            marshall()
+        }
+
+        val unmarshalled = with(Parcel.obtain()) {
+            unmarshall(marshalled, 0, marshalled.size)
+            readTypedObject(requireNotNull(ParcelableCrdtType.Count.crdtOperationCreator))
+        }
+
+        assertThat(unmarshalled?.actual).isEqualTo(op)
+    }
+}

--- a/shells/android/javatests/arcs/crdt/parcelables/ParcelableCrdtExceptionTest.kt
+++ b/shells/android/javatests/arcs/crdt/parcelables/ParcelableCrdtExceptionTest.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.crdt.parcelables
+
+import android.os.Parcel
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import arcs.crdt.CrdtException
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/** Tests for [ParcelableCrdtException]. */
+@RunWith(AndroidJUnit4::class)
+class ParcelableCrdtExceptionTest {
+    @Test
+    fun parcelableRoundTrip_works() {
+        val exception: CrdtException
+        try {
+            throw CrdtException("Uh oh")
+        } catch (e: CrdtException) {
+            exception = e
+        }
+
+        val marshalled = with(Parcel.obtain()) {
+            writeParcelable(exception.toParcelable(), 0)
+            marshall()
+        }
+
+        val unmarshalled = with(Parcel.obtain()) {
+            unmarshall(marshalled, 0, marshalled.size)
+            readParcelable<ParcelableCrdtException>(ParcelableCrdtException::class.java.classLoader)
+        }
+
+        assertThat(unmarshalled?.message).isEqualTo("Uh oh")
+        assertThat(unmarshalled?.stackTrace).isEqualTo(exception.stackTrace.toStrings())
+    }
+}

--- a/shells/android/javatests/arcs/crdt/parcelables/ParcelableVersionMapTest.kt
+++ b/shells/android/javatests/arcs/crdt/parcelables/ParcelableVersionMapTest.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.crdt.parcelables
+
+import android.os.Parcel
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import arcs.crdt.internal.VersionMap
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/** Tests for [ParcelableVersionMap]. */
+@RunWith(AndroidJUnit4::class)
+class ParcelableVersionMapTest {
+    @Test
+    fun parcelableRoundTrip_works() {
+        val emptyMap = VersionMap()
+        val singleItem = VersionMap(mapOf("foo" to 10))
+        val lotsOfItems = VersionMap(
+            mapOf(
+                "alice" to 1,
+                "bob" to 2,
+                "charlie" to 3,
+                "delores" to 4,
+                "evan" to 5,
+                "felicia" to 6
+            )
+        )
+
+        val marshalled = with(Parcel.obtain()) {
+            writeParcelable(emptyMap.toParcelable(), 0)
+            writeParcelable(singleItem.toParcelable(), 0)
+            writeParcelable(lotsOfItems.toParcelable(), 0)
+            marshall()
+        }
+
+        val unmarshalled = Parcel.obtain().apply { unmarshall(marshalled, 0, marshalled.size) }
+
+        assertThat(
+            unmarshalled.readParcelable<ParcelableVersionMap>(
+                ParcelableVersionMap::class.java.classLoader
+            )?.actual
+        ).isEqualTo(emptyMap)
+        assertThat(
+            unmarshalled.readParcelable<ParcelableVersionMap>(
+                ParcelableVersionMap::class.java.classLoader
+            )?.actual
+        ).isEqualTo(singleItem)
+        assertThat(
+            unmarshalled.readParcelable<ParcelableVersionMap>(
+                ParcelableVersionMap::class.java.classLoader
+            )?.actual
+        ).isEqualTo(lotsOfItems)
+    }
+}

--- a/shells/android/javatests/arcs/storage/parcelables/BUILD
+++ b/shells/android/javatests/arcs/storage/parcelables/BUILD
@@ -1,0 +1,39 @@
+licenses(["notice"])
+
+package(default_visibility = ["//visibility:public"])
+
+load("//tools/build_defs/android:rules.bzl", "android_local_test")
+load("//tools/build_defs/kotlin:rules.bzl", "kt_android_library")
+
+[
+    [
+        android_local_test(
+            name = src_file[:-3],
+            size = "small",
+            test_class = "arcs.storage.parcelables.%s" % src_file[:-3],
+            manifest = "//shells/android/java/arcs/common:AndroidManifest.xml",
+            deps = [
+                ":%sLib" % src_file[:-3],
+                "@robolectric//bazel:android-all",
+            ]
+        ),
+        kt_android_library(
+            name = src_file[:-3] + "Lib",
+            srcs = [src_file],
+            manifest = "//shells/android/java/arcs/common:AndroidManifest.xml",
+            deps = [
+                "//shells/android/java/arcs/crdt/parcelables",
+                "//shells/android/java/arcs/storage/parcelables",
+                "//src_kt/java/arcs/crdt",
+                "//src_kt/java/arcs/storage",
+                "//third_party/android/androidx_test/core",
+                "//third_party/android/androidx_test/ext/junit",
+                "//third_party/java/junit",
+                "//third_party/java/mockito",
+                "//third_party/java/robolectric",
+                "//third_party/java/truth",
+            ],
+        )
+    ]
+    for src_file in glob(["*.kt"])
+]

--- a/shells/android/javatests/arcs/storage/parcelables/ParcelableModelUpdateTest.kt
+++ b/shells/android/javatests/arcs/storage/parcelables/ParcelableModelUpdateTest.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.storage.parcelables
+
+import android.os.Bundle
+import arcs.crdt.CrdtCount
+import arcs.crdt.internal.VersionMap
+import arcs.crdt.parcelables.ParcelableCrdtCount
+import arcs.crdt.parcelables.ParcelableCrdtType
+import arcs.storage.ProxyMessage
+import com.google.common.truth.Truth.assertThat
+import org.junit.Assert.fail
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/** Tests for [ParcelableSyncRequest]. */
+@RunWith(RobolectricTestRunner::class)
+class ParcelableModelUpdateTest {
+    @Test
+    fun parcelableRoundtrip_works() {
+        val bundle = Bundle()
+        val data = CrdtCount.Data(
+            mutableMapOf("Foo" to 1, "Bar" to 2),
+            VersionMap("Foo" to 1, "Bar" to 1)
+        )
+        bundle.putParcelable(
+            "myCountModelUpdate",
+            ParcelableModelUpdate(ParcelableCrdtCount.Data(data), 1, ParcelableCrdtType.Count)
+        )
+
+        // Now get them back out.
+        val deparcalized = bundle.getParcelable<ParcelableModelUpdate>("myCountModelUpdate")
+        assertThat(deparcalized)
+            .isEqualTo(
+                ParcelableModelUpdate(ParcelableCrdtCount.Data(data), 1, ParcelableCrdtType.Count)
+            )
+        val actualized = requireNotNull(
+            deparcalized?.actualize<CrdtCount.Data, CrdtCount.Operation, Int>()
+        )
+        when (actualized) {
+            is ProxyMessage.ModelUpdate ->
+                assertThat(actualized.model).isEqualTo(data)
+            else ->
+                fail("Illegal type.")
+        }
+    }
+}

--- a/shells/android/javatests/arcs/storage/parcelables/ParcelableModelUpdateTest.kt
+++ b/shells/android/javatests/arcs/storage/parcelables/ParcelableModelUpdateTest.kt
@@ -34,7 +34,6 @@ class ParcelableModelUpdateTest {
             VersionMap("Foo" to 1, "Bar" to 1)
         )
 
-
         // Create a parcel and populate it with a ParcelableOperations object.
         val marshalled = with(Parcel.obtain()) {
             writeParcelable(

--- a/shells/android/javatests/arcs/storage/parcelables/ParcelableOperationsTest.kt
+++ b/shells/android/javatests/arcs/storage/parcelables/ParcelableOperationsTest.kt
@@ -21,7 +21,6 @@ import com.google.common.truth.Truth.assertThat
 import org.junit.Assert.fail
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
 /** Tests for [ParcelableOperations]. */
 @RunWith(AndroidJUnit4::class)

--- a/shells/android/javatests/arcs/storage/parcelables/ParcelableSyncRequestTest.kt
+++ b/shells/android/javatests/arcs/storage/parcelables/ParcelableSyncRequestTest.kt
@@ -11,44 +11,36 @@
 
 package arcs.storage.parcelables
 
-import android.os.Bundle
+import android.os.Parcel
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import arcs.crdt.parcelables.ParcelableCrdtType
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
 /** Tests for [ParcelableSyncRequest]. */
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class ParcelableSyncRequestTest {
     @Test
     fun parcelableRoundtrip_works() {
-        val bundle = Bundle()
-        bundle.putParcelable(
-            "myCountSyncRequest",
-            ParcelableSyncRequest(1, ParcelableCrdtType.Count)
+        val expected = listOf(
+            ParcelableSyncRequest(1, ParcelableCrdtType.Count),
+            ParcelableSyncRequest(null, ParcelableCrdtType.Set),
+            ParcelableSyncRequest(25, ParcelableCrdtType.Singleton),
+            ParcelableSyncRequest(null, ParcelableCrdtType.Entity)
         )
-        bundle.putParcelable(
-            "mySetSyncRequest",
-            ParcelableSyncRequest(null, ParcelableCrdtType.Set)
-        )
-        bundle.putParcelable(
-            "mySingletonSyncRequest",
-            ParcelableSyncRequest(1, ParcelableCrdtType.Singleton)
-        )
-        bundle.putParcelable(
-            "myEntitySyncRequest",
-            ParcelableSyncRequest(1, ParcelableCrdtType.Entity)
-        )
+        val marshalled = with(Parcel.obtain()) {
+            expected.forEach { writeParcelable(it, 0) }
+            marshall()
+        }
 
-        // Now get them back out.
-        assertThat(bundle.getParcelable<ParcelableSyncRequest>("myCountSyncRequest"))
-            .isEqualTo(ParcelableSyncRequest(1, ParcelableCrdtType.Count))
-        assertThat(bundle.getParcelable<ParcelableSyncRequest>("mySetSyncRequest"))
-            .isEqualTo(ParcelableSyncRequest(null, ParcelableCrdtType.Set))
-        assertThat(bundle.getParcelable<ParcelableSyncRequest>("mySingletonSyncRequest"))
-            .isEqualTo(ParcelableSyncRequest(1, ParcelableCrdtType.Singleton))
-        assertThat(bundle.getParcelable<ParcelableSyncRequest>("myEntitySyncRequest"))
-            .isEqualTo(ParcelableSyncRequest(1, ParcelableCrdtType.Entity))
+        val unmarshalled = with(Parcel.obtain()) {
+            unmarshall(marshalled, 0, marshalled.size)
+            0.until(4).map {
+                readParcelable<ParcelableSyncRequest>(ParcelableSyncRequest::class.java.classLoader)
+            }
+        }
+
+        assertThat(unmarshalled).containsExactlyElementsIn(expected)
     }
 }

--- a/shells/android/javatests/arcs/storage/parcelables/ParcelableSyncRequestTest.kt
+++ b/shells/android/javatests/arcs/storage/parcelables/ParcelableSyncRequestTest.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.storage.parcelables
+
+import android.os.Bundle
+import arcs.crdt.parcelables.ParcelableCrdtType
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/** Tests for [ParcelableSyncRequest]. */
+@RunWith(RobolectricTestRunner::class)
+class ParcelableSyncRequestTest {
+    @Test
+    fun parcelableRoundtrip_works() {
+        val bundle = Bundle()
+        bundle.putParcelable(
+            "myCountSyncRequest",
+            ParcelableSyncRequest(1, ParcelableCrdtType.Count)
+        )
+        bundle.putParcelable(
+            "mySetSyncRequest",
+            ParcelableSyncRequest(null, ParcelableCrdtType.Set)
+        )
+        bundle.putParcelable(
+            "mySingletonSyncRequest",
+            ParcelableSyncRequest(1, ParcelableCrdtType.Singleton)
+        )
+        bundle.putParcelable(
+            "myEntitySyncRequest",
+            ParcelableSyncRequest(1, ParcelableCrdtType.Entity)
+        )
+
+        // Now get them back out.
+        assertThat(bundle.getParcelable<ParcelableSyncRequest>("myCountSyncRequest"))
+            .isEqualTo(ParcelableSyncRequest(1, ParcelableCrdtType.Count))
+        assertThat(bundle.getParcelable<ParcelableSyncRequest>("mySetSyncRequest"))
+            .isEqualTo(ParcelableSyncRequest(null, ParcelableCrdtType.Set))
+        assertThat(bundle.getParcelable<ParcelableSyncRequest>("mySingletonSyncRequest"))
+            .isEqualTo(ParcelableSyncRequest(1, ParcelableCrdtType.Singleton))
+        assertThat(bundle.getParcelable<ParcelableSyncRequest>("myEntitySyncRequest"))
+            .isEqualTo(ParcelableSyncRequest(1, ParcelableCrdtType.Entity))
+    }
+}

--- a/third_party/android/androidx_test/core/BUILD
+++ b/third_party/android/androidx_test/core/BUILD
@@ -1,0 +1,8 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+alias(
+    name = "core",
+    actual = "@maven//:androidx_test_core",
+)

--- a/third_party/android/androidx_test/ext/junit/BUILD
+++ b/third_party/android/androidx_test/ext/junit/BUILD
@@ -1,0 +1,8 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+alias(
+    name = "junit",
+    actual = "@maven//:androidx_test_ext_junit",
+)

--- a/third_party/android/androidx_test/rules/BUILD
+++ b/third_party/android/androidx_test/rules/BUILD
@@ -1,0 +1,9 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+alias(
+    name = "rules",
+    actual = "@maven//:androidx_test_rules",
+)
+

--- a/third_party/android/androidx_test/runner/BUILD
+++ b/third_party/android/androidx_test/runner/BUILD
@@ -1,0 +1,8 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+alias(
+    name = "runner",
+    actual = "@maven//:androidx_test_runner",
+)

--- a/third_party/java/robolectric/BUILD
+++ b/third_party/java/robolectric/BUILD
@@ -1,0 +1,8 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+alias(
+    name = "robolectric",
+    actual = "@maven//:org_robolectric_robolectric",
+)

--- a/tools/build_defs/android/rules.bzl
+++ b/tools/build_defs/android/rules.bzl
@@ -2,8 +2,11 @@ load(
     "@build_bazel_rules_android//android:rules.bzl",
     _android_binary = "android_binary",
     _android_library = "android_library",
+    _android_local_test = "android_local_test",
 )
 
 android_binary = _android_binary
 
 android_library = _android_library
+
+android_local_test = _android_local_test


### PR DESCRIPTION
This PR lays out some of the directory structure for the Android StorageService and creates a number of `Parcelable` classes:

* ParcelableSyncRequest
* ParcelableModelUpdate
* ParcelableOperations
* ParcelableCrdtCount.Data
* ParcelableCrdtCount.Operation.Increment
* ParcelableCrdtCount.Operation.MultiIncrement
* ParcelableVersionMap

Support was added for running Robolectric/AndroidJUnit tests (and several tests were created, for the above classes).

Additionally, this PR adjusts and expands the root `.bazelproject` to include `javaharness`, `src_kt`, and `shells/android` as well as making the root `.bazelproject` an android project, rather than a java project.