### PR TITLE
Parcelable StoreOptions

### DIFF
--- a/shells/android/java/arcs/crdt/parcelables/CrdtParcelables.kt
+++ b/shells/android/java/arcs/crdt/parcelables/CrdtParcelables.kt
@@ -11,10 +11,15 @@
 
 package arcs.crdt.parcelables
 
+import android.os.Parcel
 import android.os.Parcelable
+import arcs.crdt.CrdtCount
 import arcs.crdt.CrdtData
+import arcs.crdt.CrdtEntity
 import arcs.crdt.CrdtOperation
 import arcs.crdt.CrdtOperationAtTime
+import arcs.crdt.CrdtSet
+import arcs.crdt.CrdtSingleton
 
 /** Base interface for [Parcelable] implementations of [CrdtData] classes. */
 interface ParcelableCrdtData<T : CrdtData> : CrdtData, Parcelable {
@@ -29,3 +34,25 @@ interface ParcelableCrdtOperation<T : CrdtOperation> : CrdtOperation, Parcelable
 /** Base interface for [Parcelable] implementations of [CrdtOperationAtTime] classes. */
 interface ParcelableCrdtOperationAtTime<T : CrdtOperationAtTime> :
     ParcelableCrdtOperation<T>, CrdtOperationAtTime
+
+/** Writes [CrdtData] to the [Parcel]. */
+fun Parcel.writeModelData(model: CrdtData?, flags: Int) {
+    when (model) {
+        is CrdtCount.Data ->
+            writeTypedObject((model as? CrdtCount.Data)?.toParcelable(), flags)
+        is CrdtSet.Data<*> ->
+            TODO("Implement me when ParcelableSet is ready")
+        is CrdtSingleton.Data<*> ->
+            TODO("Implement me when ParcelableSingleton is ready")
+        is CrdtEntity.Data ->
+            TODO("Implement me when ParcelableEntity is ready")
+    }
+}
+
+/** Reads [CrdtData] from the [Parcel], using the [expectedType] as a hint. */
+fun Parcel.readModelData(expectedType: ParcelableCrdtType): CrdtData? =
+    readTypedObject(
+        requireNotNull(expectedType.crdtDataCreator) {
+            "No crdtDataCreator for type $expectedType"
+        }
+    )?.actual

--- a/shells/android/java/arcs/storage/parcelables/BUILD
+++ b/shells/android/java/arcs/storage/parcelables/BUILD
@@ -11,9 +11,11 @@ kt_android_library(
     idl_parcelables = glob(["*.aidl"]),
     deps = [
         "//shells/android/java/arcs/crdt/parcelables",
+        "//shells/android/java/arcs/type/parcelables",
         "//src_kt/java/arcs/common",
         "//src_kt/java/arcs/crdt",
         "//src_kt/java/arcs/crdt/internal",
-        "//src_kt/java/arcs/storage"
+        "//src_kt/java/arcs/storage",
+        "//src_kt/java/arcs/type"
     ],
 )

--- a/shells/android/java/arcs/storage/parcelables/ParcelableStoreOptions.kt
+++ b/shells/android/java/arcs/storage/parcelables/ParcelableStoreOptions.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.storage.parcelables
+
+import android.os.Parcel
+import android.os.Parcelable
+import arcs.crdt.CrdtData
+import arcs.crdt.CrdtOperation
+import arcs.crdt.parcelables.ParcelableCrdtType
+import arcs.crdt.parcelables.readModelData
+import arcs.crdt.parcelables.writeModelData
+import arcs.storage.ExistenceCriteria
+import arcs.storage.StorageKeyParser
+import arcs.storage.StorageMode
+import arcs.storage.StoreOptions
+import arcs.type.parcelables.readType
+import arcs.type.parcelables.writeType
+
+/** [Parcelable] variant for [StoreOptions]. */
+data class ParcelableStoreOptions(
+    val actual: StoreOptions<out CrdtData, out CrdtOperation, Any?>,
+    val crdtType: ParcelableCrdtType
+) : Parcelable {
+    override fun writeToParcel(parcel: Parcel, flags: Int) {
+        parcel.writeInt(crdtType.ordinal)
+        parcel.writeString(actual.storageKey.toString())
+        parcel.writeInt(actual.existenceCriteria.ordinal)
+        parcel.writeType(actual.type, flags)
+        parcel.writeInt(actual.mode.ordinal)
+        // Skip StoreOptions.baseStore.
+        parcel.writeString(actual.versionToken)
+        parcel.writeModelData(actual.model, flags)
+    }
+
+    override fun describeContents(): Int = 0
+
+    companion object CREATOR : Parcelable.Creator<ParcelableStoreOptions> {
+        override fun createFromParcel(parcel: Parcel): ParcelableStoreOptions {
+            val crdtType = ParcelableCrdtType.values()[parcel.readInt()]
+            val storageKey = StorageKeyParser.parse(requireNotNull(parcel.readString()))
+            val existenceCriteria = ExistenceCriteria.values()[parcel.readInt()]
+            val type = requireNotNull(parcel.readType()) { "Could not extract Type from Parcel" }
+            val mode = StorageMode.values()[parcel.readInt()]
+            val versionToken = parcel.readString()
+            val modelData = parcel.readModelData(crdtType)
+
+            return ParcelableStoreOptions(
+                StoreOptions(
+                    storageKey = storageKey,
+                    existenceCriteria = existenceCriteria,
+                    type = type,
+                    mode = mode,
+                    baseStore = null, // Skip baseStore.
+                    versionToken = versionToken,
+                    model = modelData
+                ),
+                crdtType
+            )
+        }
+
+        override fun newArray(size: Int): Array<ParcelableStoreOptions?> = arrayOfNulls(size)
+    }
+}
+

--- a/shells/android/java/arcs/storage/parcelables/ParcelableStoreOptions.kt
+++ b/shells/android/java/arcs/storage/parcelables/ParcelableStoreOptions.kt
@@ -27,7 +27,7 @@ import arcs.type.parcelables.writeType
 
 /** [Parcelable] variant for [StoreOptions]. */
 data class ParcelableStoreOptions(
-    val actual: StoreOptions<out CrdtData, out CrdtOperation, Any?>,
+    val actual: StoreOptions<out CrdtData, out CrdtOperation, out Any?>,
     val crdtType: ParcelableCrdtType
 ) : Parcelable {
     override fun writeToParcel(parcel: Parcel, flags: Int) {
@@ -71,3 +71,20 @@ data class ParcelableStoreOptions(
     }
 }
 
+/**
+ * Wraps the [StoreOptions] in a [ParcelableStoreOptions], using the [ParcelableCrdtType] as a hint.
+ */
+fun StoreOptions<out CrdtData, out CrdtOperation, out Any?>.toParcelable(
+    crdtType: ParcelableCrdtType
+): ParcelableStoreOptions = ParcelableStoreOptions(this, crdtType)
+
+/** Writes [StoreOptions] to the [Parcel]. */
+fun Parcel.writeStoreOptions(
+    storeOptions: StoreOptions<out CrdtData, out CrdtOperation, out Any?>,
+    representingCrdtType: ParcelableCrdtType,
+    flags: Int
+) = writeTypedObject(storeOptions.toParcelable(representingCrdtType), flags)
+
+/** Reads [StoreOptions] from the [Parcel]. */
+fun Parcel.readStoreOptions(): StoreOptions<out CrdtData, out CrdtOperation, out Any?>? =
+    readTypedObject(ParcelableStoreOptions.CREATOR)?.actual

--- a/shells/android/java/arcs/type/parcelables/BUILD
+++ b/shells/android/java/arcs/type/parcelables/BUILD
@@ -1,0 +1,17 @@
+licenses(["notice"])
+
+package(default_visibility = ["//visibility:public"])
+
+load("//tools/build_defs/kotlin:rules.bzl", "kt_android_library")
+
+kt_android_library(
+    name = "parcelables",
+    srcs = glob(["*.kt"]),
+    idl_parcelables = glob(["*.aidl"]),
+    manifest = "//shells/android/java/arcs/common:AndroidManifest.xml",
+    deps = [
+        "//src_kt/java/arcs/common",
+        "//src_kt/java/arcs/data",
+        "//src_kt/java/arcs/type",
+    ],
+)

--- a/shells/android/java/arcs/type/parcelables/ParcelableSchema.kt
+++ b/shells/android/java/arcs/type/parcelables/ParcelableSchema.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.type.parcelables
+
+import android.os.Parcel
+import android.os.Parcelable
+import arcs.data.Schema
+import arcs.data.SchemaName
+
+/** [Parcelable] variant of [Schema]. */
+data class ParcelableSchema(val actual: Schema) : Parcelable {
+    override fun writeToParcel(parcel: Parcel, flags: Int) {
+        parcel.writeStringList(
+            actual.names.mapTo(mutableListOf()) {it.name}
+        )
+        parcel.writeSchemaFields(actual.fields, flags)
+        parcel.writeSchemaDescription(actual.description, flags)
+    }
+
+    override fun describeContents(): Int = 0
+
+    companion object CREATOR : Parcelable.Creator<ParcelableSchema> {
+        override fun createFromParcel(parcel: Parcel): ParcelableSchema {
+            val names = mutableListOf<String>()
+                .also { parcel.readStringList(it) }
+                .map { SchemaName(it) }
+
+            val fields = requireNotNull(parcel.readSchemaFields()) {
+                "No SchemaFields found in Parcel"
+            }
+
+            val description = requireNotNull(parcel.readSchemaDescription()) {
+                "No SchemaDescription found in Parcel"
+            }
+
+            return ParcelableSchema(Schema(names, fields, description))
+        }
+
+        override fun newArray(size: Int): Array<ParcelableSchema?> = arrayOfNulls(size)
+    }
+}
+
+/** Wraps a [Schema] as a [ParcelableSchema]. */
+fun Schema.toParcelable(): ParcelableSchema = ParcelableSchema(this)
+
+/** Writes a [Schema] to a [Parcel]. */
+fun Parcel.writeSchema(schema: Schema, flags: Int) = writeTypedObject(schema.toParcelable(), flags)
+
+/** Reads a [Schema] from a [Parcel]. */
+fun Parcel.readSchema(): Schema? = readTypedObject(ParcelableSchema.CREATOR)?.actual

--- a/shells/android/java/arcs/type/parcelables/ParcelableSchema.kt
+++ b/shells/android/java/arcs/type/parcelables/ParcelableSchema.kt
@@ -20,7 +20,7 @@ import arcs.data.SchemaName
 data class ParcelableSchema(val actual: Schema) : Parcelable {
     override fun writeToParcel(parcel: Parcel, flags: Int) {
         parcel.writeStringList(
-            actual.names.mapTo(mutableListOf()) {it.name}
+            actual.names.mapTo(mutableListOf()) { it.name }
         )
         parcel.writeSchemaFields(actual.fields, flags)
         parcel.writeSchemaDescription(actual.description, flags)

--- a/shells/android/java/arcs/type/parcelables/ParcelableSchemaDescription.kt
+++ b/shells/android/java/arcs/type/parcelables/ParcelableSchemaDescription.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.type.parcelables
+
+import android.os.Parcel
+import android.os.Parcelable
+import arcs.data.SchemaDescription
+
+/** [Parcelable] variant of [SchemaDescription]. */
+data class ParcelableSchemaDescription(val actual: SchemaDescription) : Parcelable {
+    override fun writeToParcel(parcel: Parcel, flags: Int) {
+        parcel.writeString(actual.pattern)
+        parcel.writeString(actual.plural)
+    }
+
+    override fun describeContents(): Int = 0
+
+    companion object CREATOR : Parcelable.Creator<ParcelableSchemaDescription> {
+        override fun createFromParcel(parcel: Parcel): ParcelableSchemaDescription =
+            ParcelableSchemaDescription(SchemaDescription(parcel.readString(), parcel.readString()))
+
+        override fun newArray(size: Int): Array<ParcelableSchemaDescription?> = arrayOfNulls(size)
+    }
+}
+
+/** Wraps a [SchemaDescription] as a [ParcelableSchemaDescription]. */
+fun SchemaDescription.toParcelable(): ParcelableSchemaDescription =
+    ParcelableSchemaDescription(this)
+
+/** Writes a [SchemaDescription] to a [Parcel]. */
+fun Parcel.writeSchemaDescription(schemaDescription: SchemaDescription, flags: Int) =
+    writeTypedObject(schemaDescription.toParcelable(), flags)
+
+/** Reads a [SchemaDescription] from a [Parcel]. */
+fun Parcel.readSchemaDescription(): SchemaDescription? =
+    readTypedObject(ParcelableSchemaDescription.CREATOR)?.actual

--- a/shells/android/java/arcs/type/parcelables/ParcelableSchemaFields.kt
+++ b/shells/android/java/arcs/type/parcelables/ParcelableSchemaFields.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.type.parcelables
+
+import android.os.Parcel
+import android.os.Parcelable
+import arcs.data.FieldName
+import arcs.data.SchemaFields
+
+data class ParcelableSchemaFields(val actual: SchemaFields) : Parcelable {
+    override fun writeToParcel(parcel: Parcel, flags: Int) {
+        parcel.writeStringList(actual.singletons.toMutableList())
+        parcel.writeStringList(actual.collections.toMutableList())
+    }
+
+    override fun describeContents(): Int = 0
+
+    companion object CREATOR : Parcelable.Creator<ParcelableSchemaFields> {
+        override fun createFromParcel(parcel: Parcel): ParcelableSchemaFields {
+            val singletons = mutableListOf<FieldName>()
+                .also { parcel.readStringList(it) }
+                .toSet()
+            val collections = mutableListOf<FieldName>()
+                .also { parcel.readStringList(it) }
+                .toSet()
+            return ParcelableSchemaFields(SchemaFields(singletons, collections))
+        }
+
+        override fun newArray(size: Int): Array<ParcelableSchemaFields?> = arrayOfNulls(size)
+    }
+}
+
+/** Wraps a [SchemaFields] object in a [ParcelableSchemaFields] instance. */
+fun SchemaFields.toParcelable(): ParcelableSchemaFields = ParcelableSchemaFields(this)
+
+/** Writes a [SchemaFields] object to a [Parcel]. */
+fun Parcel.writeSchemaFields(schemaFields: SchemaFields, flags: Int) =
+    writeTypedObject(schemaFields.toParcelable(), flags)
+
+/** Reads a [SchemaFields] object from a [Parcel]. */
+fun Parcel.readSchemaFields(): SchemaFields? =
+    readTypedObject(ParcelableSchemaFields.CREATOR)?.actual

--- a/shells/android/java/arcs/type/parcelables/ParcelableType.kt
+++ b/shells/android/java/arcs/type/parcelables/ParcelableType.kt
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.type.parcelables
+
+import android.os.Parcel
+import android.os.Parcelable
+import arcs.data.CollectionType
+import arcs.data.CountType
+import arcs.data.EntityType
+import arcs.data.ReferenceType
+import arcs.data.SingletonType
+import arcs.type.Tag
+import arcs.type.Type
+
+/** Wrappers for [Type] classes which implements [Parcelable]. */
+sealed class ParcelableType(open val actual: Type) : Parcelable {
+    override fun writeToParcel(parcel: Parcel, flags: Int) {
+        parcel.writeInt(actual.tag.ordinal)
+        // Subclasses will write the remainder.
+    }
+
+    override fun describeContents(): Int = 0
+
+    /** [Parcelable] variant of [arcs.data.CollectionType]. */
+    data class CollectionType(
+        override val actual: arcs.data.CollectionType<*>
+    ) : ParcelableType(actual) {
+        override fun writeToParcel(parcel: Parcel, flags: Int) =
+            parcel.writeType(actual.collectionType, flags)
+
+        companion object CREATOR : Parcelable.Creator<CollectionType> {
+            override fun createFromParcel(parcel: Parcel): CollectionType =
+                CollectionType(actual = CollectionType(requireNotNull(parcel.readType())))
+
+            override fun newArray(size: Int): Array<CollectionType?> = arrayOfNulls(size)
+        }
+    }
+
+    /** [Parcelable] variant of [arcs.data.CollectionType]. */
+    data class CountType(
+        override val actual: arcs.data.CountType = arcs.data.CountType()
+    ) : ParcelableType(actual) {
+        override fun writeToParcel(parcel: Parcel, flags: Int) = Unit // Nothing else needed.
+
+        companion object CREATOR : Parcelable.Creator<CountType> {
+            override fun createFromParcel(parcel: Parcel): CountType = CountType()
+            override fun newArray(size: Int): Array<CountType?> = arrayOfNulls(size)
+        }
+    }
+
+    /** [Parcelable] variant of [arcs.data.EntityType]. */
+    data class EntityType(
+        override val actual: arcs.data.EntityType
+    ) : ParcelableType(actual) {
+        override fun writeToParcel(parcel: Parcel, flags: Int) =
+            parcel.writeSchema(actual.entitySchema, flags)
+
+        companion object CREATOR : Parcelable.Creator<EntityType> {
+            override fun createFromParcel(parcel: Parcel): EntityType =
+                EntityType(actual = EntityType(requireNotNull(parcel.readSchema())))
+
+            override fun newArray(size: Int): Array<EntityType?> = arrayOfNulls(size)
+        }
+    }
+
+    /** [Parcelable] variant of [arcs.data.ReferenceType]. */
+    class ReferenceType(
+        override val actual: arcs.data.ReferenceType<*>
+    ) : ParcelableType(actual) {
+        override fun writeToParcel(parcel: Parcel, flags: Int) =
+            parcel.writeType(actual.containedType, flags)
+
+        companion object CREATOR : Parcelable.Creator<ReferenceType> {
+            override fun createFromParcel(parcel: Parcel): ReferenceType =
+                ReferenceType(actual = ReferenceType(requireNotNull(parcel.readType())))
+
+            override fun newArray(size: Int): Array<ReferenceType?> = arrayOfNulls(size)
+        }
+    }
+
+    /** [Parcelable] variant of [arcs.data.SingletonType]. */
+    data class SingletonType(
+        override val actual: arcs.data.SingletonType<*>
+    ) : ParcelableType(actual) {
+        override fun writeToParcel(parcel: Parcel, flags: Int) =
+            parcel.writeType(actual.containedType, flags)
+
+        companion object CREATOR : Parcelable.Creator<SingletonType> {
+            override fun createFromParcel(parcel: Parcel): SingletonType =
+                SingletonType(
+                    actual = SingletonType(requireNotNull(parcel.readType()))
+                )
+
+            override fun newArray(size: Int): Array<SingletonType?> = arrayOfNulls(size)
+        }
+    }
+
+    companion object CREATOR : Parcelable.Creator<ParcelableType> {
+        override fun createFromParcel(parcel: Parcel): ParcelableType =
+            when(Tag.values()[parcel.readInt()]) {
+                Tag.Collection -> CollectionType.createFromParcel(parcel)
+                Tag.Count -> CountType.createFromParcel(parcel)
+                Tag.Entity -> EntityType.createFromParcel(parcel)
+                Tag.Reference -> ReferenceType.createFromParcel(parcel)
+                Tag.Singleton -> SingletonType.createFromParcel(parcel)
+            }
+
+        override fun newArray(size: Int): Array<ParcelableType?> = arrayOfNulls(size)
+    }
+}
+
+/** Converts a raw [Type] to its [ParcelableType] variant. */
+fun Type.toParcelable(): ParcelableType = when (tag) {
+    Tag.Collection -> ParcelableType.CollectionType(this as CollectionType<*>)
+    Tag.Count -> ParcelableType.CountType(this as CountType)
+    Tag.Entity -> ParcelableType.EntityType(this as EntityType)
+    Tag.Reference -> ParcelableType.ReferenceType(this as ReferenceType<*>)
+    Tag.Singleton -> ParcelableType.SingletonType(this as SingletonType<*>)
+}
+
+/** Writes a [Type] to the [Parcel]. */
+fun Parcel.writeType(type: Type, flags: Int) = writeTypedObject(type.toParcelable(), flags)
+
+/** Reads a [Type] from the [Parcel]. */
+fun Parcel.readType(): Type? = readTypedObject(ParcelableType.CREATOR)?.actual

--- a/shells/android/java/arcs/type/parcelables/ParcelableType.kt
+++ b/shells/android/java/arcs/type/parcelables/ParcelableType.kt
@@ -34,8 +34,10 @@ sealed class ParcelableType(open val actual: Type) : Parcelable {
     data class CollectionType(
         override val actual: arcs.data.CollectionType<*>
     ) : ParcelableType(actual) {
-        override fun writeToParcel(parcel: Parcel, flags: Int) =
+        override fun writeToParcel(parcel: Parcel, flags: Int) {
+            super.writeToParcel(parcel, flags)
             parcel.writeType(actual.collectionType, flags)
+        }
 
         companion object CREATOR : Parcelable.Creator<CollectionType> {
             override fun createFromParcel(parcel: Parcel): CollectionType =
@@ -49,7 +51,7 @@ sealed class ParcelableType(open val actual: Type) : Parcelable {
     data class CountType(
         override val actual: arcs.data.CountType = arcs.data.CountType()
     ) : ParcelableType(actual) {
-        override fun writeToParcel(parcel: Parcel, flags: Int) = Unit // Nothing else needed.
+        // No need to override writeToParcel.
 
         companion object CREATOR : Parcelable.Creator<CountType> {
             override fun createFromParcel(parcel: Parcel): CountType = CountType()
@@ -61,8 +63,10 @@ sealed class ParcelableType(open val actual: Type) : Parcelable {
     data class EntityType(
         override val actual: arcs.data.EntityType
     ) : ParcelableType(actual) {
-        override fun writeToParcel(parcel: Parcel, flags: Int) =
+        override fun writeToParcel(parcel: Parcel, flags: Int) {
+            super.writeToParcel(parcel, flags)
             parcel.writeSchema(actual.entitySchema, flags)
+        }
 
         companion object CREATOR : Parcelable.Creator<EntityType> {
             override fun createFromParcel(parcel: Parcel): EntityType =
@@ -76,8 +80,10 @@ sealed class ParcelableType(open val actual: Type) : Parcelable {
     class ReferenceType(
         override val actual: arcs.data.ReferenceType<*>
     ) : ParcelableType(actual) {
-        override fun writeToParcel(parcel: Parcel, flags: Int) =
+        override fun writeToParcel(parcel: Parcel, flags: Int) {
+            super.writeToParcel(parcel, flags)
             parcel.writeType(actual.containedType, flags)
+        }
 
         companion object CREATOR : Parcelable.Creator<ReferenceType> {
             override fun createFromParcel(parcel: Parcel): ReferenceType =
@@ -91,8 +97,10 @@ sealed class ParcelableType(open val actual: Type) : Parcelable {
     data class SingletonType(
         override val actual: arcs.data.SingletonType<*>
     ) : ParcelableType(actual) {
-        override fun writeToParcel(parcel: Parcel, flags: Int) =
+        override fun writeToParcel(parcel: Parcel, flags: Int) {
+            super.writeToParcel(parcel, flags)
             parcel.writeType(actual.containedType, flags)
+        }
 
         companion object CREATOR : Parcelable.Creator<SingletonType> {
             override fun createFromParcel(parcel: Parcel): SingletonType =
@@ -106,7 +114,7 @@ sealed class ParcelableType(open val actual: Type) : Parcelable {
 
     companion object CREATOR : Parcelable.Creator<ParcelableType> {
         override fun createFromParcel(parcel: Parcel): ParcelableType =
-            when(Tag.values()[parcel.readInt()]) {
+            when (Tag.values()[parcel.readInt()]) {
                 Tag.Collection -> CollectionType.createFromParcel(parcel)
                 Tag.Count -> CountType.createFromParcel(parcel)
                 Tag.Entity -> EntityType.createFromParcel(parcel)

--- a/shells/android/javatests/arcs/storage/parcelables/BUILD
+++ b/shells/android/javatests/arcs/storage/parcelables/BUILD
@@ -10,12 +10,12 @@ load("//tools/build_defs/kotlin:rules.bzl", "kt_android_library")
         android_local_test(
             name = src_file[:-3],
             size = "small",
-            test_class = "arcs.storage.parcelables.%s" % src_file[:-3],
             manifest = "//shells/android/java/arcs/common:AndroidManifest.xml",
+            test_class = "arcs.storage.parcelables.%s" % src_file[:-3],
             deps = [
                 ":%sLib" % src_file[:-3],
                 "@robolectric//bazel:android-all",
-            ]
+            ],
         ),
         kt_android_library(
             name = src_file[:-3] + "Lib",
@@ -26,6 +26,7 @@ load("//tools/build_defs/kotlin:rules.bzl", "kt_android_library")
                 "//shells/android/java/arcs/storage/parcelables",
                 "//src_kt/java/arcs/crdt",
                 "//src_kt/java/arcs/storage",
+                "//src_kt/java/arcs/storage/driver",
                 "//third_party/android/androidx_test/core",
                 "//third_party/android/androidx_test/ext/junit",
                 "//third_party/java/junit",
@@ -33,7 +34,7 @@ load("//tools/build_defs/kotlin:rules.bzl", "kt_android_library")
                 "//third_party/java/robolectric",
                 "//third_party/java/truth",
             ],
-        )
+        ),
     ]
     for src_file in glob(["*.kt"])
 ]

--- a/shells/android/javatests/arcs/storage/parcelables/ParcelableStoreOptionsTest.kt
+++ b/shells/android/javatests/arcs/storage/parcelables/ParcelableStoreOptionsTest.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.storage.parcelables
+
+import android.os.Parcel
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import arcs.crdt.CrdtCount
+import arcs.crdt.parcelables.ParcelableCrdtType
+import arcs.data.CountType
+import arcs.storage.ExistenceCriteria
+import arcs.storage.StorageMode
+import arcs.storage.StoreOptions
+import arcs.storage.driver.RamDiskStorageKey
+import arcs.storage.referencemode.ReferenceModeStorageKey
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/** Tests for [ParcelableStoreOptions]. */
+@RunWith(AndroidJUnit4::class)
+class ParcelableStoreOptionsTest {
+    @Test
+    fun parcelableRoundtrip_works() {
+        val storeOptions = StoreOptions<CrdtCount.Data, CrdtCount.Operation, Int>(
+            RamDiskStorageKey("test"),
+            ExistenceCriteria.MayExist,
+            CountType(),
+            StorageMode.Direct,
+            versionToken = "Foo",
+            model = CrdtCount.Data()
+        )
+
+        val marshalled = with(Parcel.obtain()) {
+            writeStoreOptions(storeOptions, ParcelableCrdtType.Count, 0)
+            marshall()
+        }
+
+        val unmarshalled = with(Parcel.obtain()) {
+            unmarshall(marshalled, 0, marshalled.size)
+            readStoreOptions()
+        }
+
+        assertThat(unmarshalled).isEqualTo(storeOptions)
+    }
+
+    @Test
+    fun parcelableRoundtrip_works_withAllowableNullDefaults() {
+        val storeOptions = StoreOptions<CrdtCount.Data, CrdtCount.Operation, Int>(
+            ReferenceModeStorageKey(
+                RamDiskStorageKey("backing"),
+                RamDiskStorageKey("collection")
+            ),
+            ExistenceCriteria.ShouldExist,
+            CountType(),
+            StorageMode.ReferenceMode
+        )
+
+        val marshalled = with(Parcel.obtain()) {
+            writeStoreOptions(storeOptions, ParcelableCrdtType.Count, 0)
+            marshall()
+        }
+
+        val unmarshalled = with(Parcel.obtain()) {
+            unmarshall(marshalled, 0, marshalled.size)
+            readStoreOptions()
+        }
+
+        assertThat(unmarshalled).isEqualTo(storeOptions)
+    }
+}

--- a/shells/android/javatests/arcs/type/parcelables/ParcelableSchemaDescriptionTest.kt
+++ b/shells/android/javatests/arcs/type/parcelables/ParcelableSchemaDescriptionTest.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.type.parcelables
+
+import android.os.Parcel
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import arcs.data.SchemaDescription
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/** Tests for [ParcelableSchemaDescription]. */
+@RunWith(AndroidJUnit4::class)
+class ParcelableSchemaDescriptionTest {
+    @Test
+    fun parcelableRoundtrip_works() {
+        val description = SchemaDescription(pattern = "blah", plural = "blahs")
+
+        val marshalled = with(Parcel.obtain()) {
+            writeSchemaDescription(description, 0)
+            marshall()
+        }
+
+        val unmarshalled = with(Parcel.obtain()) {
+            unmarshall(marshalled, 0, marshalled.size)
+            readSchemaDescription()
+        }
+
+        assertThat(unmarshalled).isEqualTo(description)
+    }
+
+    @Test
+    fun parcelableRoundtrip_works_nullValues() {
+        val description = SchemaDescription(pattern = null, plural = null)
+
+        val marshalled = with(Parcel.obtain()) {
+            writeSchemaDescription(description, 0)
+            marshall()
+        }
+
+        val unmarshalled = with(Parcel.obtain()) {
+            unmarshall(marshalled, 0, marshalled.size)
+            readSchemaDescription()
+        }
+
+        assertThat(unmarshalled).isEqualTo(description)
+    }
+}

--- a/shells/android/javatests/arcs/type/parcelables/ParcelableSchemaFieldsTest.kt
+++ b/shells/android/javatests/arcs/type/parcelables/ParcelableSchemaFieldsTest.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.type.parcelables
+
+import android.os.Parcel
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import arcs.data.SchemaFields
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/** Tests for [ParcelableSchemaFields]. */
+@RunWith(AndroidJUnit4::class)
+class ParcelableSchemaFieldsTest {
+    @Test
+    fun parcelableRoundtrip_works() {
+        val fields = SchemaFields(
+            singletons = setOf("foo", "bar"),
+            collections = setOf("fooCollection", "barCollection")
+        )
+
+        val marshalled = with(Parcel.obtain()) {
+            writeSchemaFields(fields, 0)
+            marshall()
+        }
+
+        val unmarshalled = with(Parcel.obtain()) {
+            unmarshall(marshalled, 0, marshalled.size)
+            readSchemaFields()
+        }
+
+        assertThat(unmarshalled).isEqualTo(fields)
+    }
+
+    @Test
+    fun parcelableRoundtrip_works_emptySets() {
+        val fields = SchemaFields(
+            singletons = emptySet(),
+            collections = emptySet()
+        )
+
+        val marshalled = with(Parcel.obtain()) {
+            writeSchemaFields(fields, 0)
+            marshall()
+        }
+
+        val unmarshalled = with(Parcel.obtain()) {
+            unmarshall(marshalled, 0, marshalled.size)
+            readSchemaFields()
+        }
+
+        assertThat(unmarshalled).isEqualTo(fields)
+    }
+}

--- a/shells/android/javatests/arcs/type/parcelables/ParcelableSchemaTest.kt
+++ b/shells/android/javatests/arcs/type/parcelables/ParcelableSchemaTest.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.type.parcelables
+
+import android.os.Parcel
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import arcs.data.Schema
+import arcs.data.SchemaDescription
+import arcs.data.SchemaFields
+import arcs.data.SchemaName
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/** Tests for [ParcelableSchema]. */
+@RunWith(AndroidJUnit4::class)
+class ParcelableSchemaTest {
+    @Test
+    fun parcelableRoundtrip_works() {
+        val schema = Schema(
+            names = listOf(SchemaName("MySchema"), SchemaName("AlsoMySchema")),
+            fields = SchemaFields(
+                singletons = setOf("name", "age"),
+                collections = setOf("friends")
+            ),
+            description = SchemaDescription("MySchemaPattern")
+        )
+
+        val marshalled = with(Parcel.obtain()) {
+            writeSchema(schema, 0)
+            marshall()
+        }
+
+        val unmarshalled = with(Parcel.obtain()) {
+            unmarshall(marshalled, 0, marshalled.size)
+            readSchema()
+        }
+
+        assertThat(unmarshalled).isEqualTo(schema)
+    }
+
+    @Test
+    fun parcelableRoundtrip_works_empty() {
+        val schema = Schema(
+            names = emptyList(),
+            fields = SchemaFields(singletons = emptySet(), collections = emptySet()),
+            description = SchemaDescription()
+        )
+
+        val marshalled = with(Parcel.obtain()) {
+            writeSchema(schema, 0)
+            marshall()
+        }
+
+        val unmarshalled = with(Parcel.obtain()) {
+            unmarshall(marshalled, 0, marshalled.size)
+            readSchema()
+        }
+
+        assertThat(unmarshalled).isEqualTo(schema)
+    }
+}

--- a/shells/android/javatests/arcs/type/parcelables/ParcelableTypeTest.kt
+++ b/shells/android/javatests/arcs/type/parcelables/ParcelableTypeTest.kt
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.type.parcelables
+
+import android.os.Parcel
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import arcs.data.CollectionType
+import arcs.data.CountType
+import arcs.data.EntityType
+import arcs.data.ReferenceType
+import arcs.data.Schema
+import arcs.data.SchemaDescription
+import arcs.data.SchemaFields
+import arcs.data.SchemaName
+import arcs.data.SingletonType
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/** Tests for [ParcelableType]. */
+@RunWith(AndroidJUnit4::class)
+class ParcelableTypeTest {
+    @Test
+    fun parcelableRoundtrip_works_forCollectionType() {
+        val collectionType = CollectionType(EntityType(entitySchema))
+
+        val marshalled = with(Parcel.obtain()) {
+            writeType(collectionType, 0)
+            marshall()
+        }
+
+        val unmarshalled = with(Parcel.obtain()) {
+            unmarshall(marshalled, 0, marshalled.size)
+            readType()
+        }
+
+        assertThat(unmarshalled).isEqualTo(collectionType)
+    }
+
+    @Test
+    fun parcelableRoundtrip_works_forCountType() {
+        val countType = CountType()
+
+        val marshalled = with(Parcel.obtain()) {
+            writeType(countType, 0)
+            marshall()
+        }
+
+        val unmarshalled = with(Parcel.obtain()) {
+            unmarshall(marshalled, 0, marshalled.size)
+            readType()
+        }
+
+        assertThat(unmarshalled).isEqualTo(countType)
+    }
+
+    @Test
+    fun parcelableRoundtrip_works_forEntityType() {
+        val entityType = EntityType(entitySchema)
+
+        val marshalled = with(Parcel.obtain()) {
+            writeType(entityType, 0)
+            marshall()
+        }
+
+        val unmarshalled = with(Parcel.obtain()) {
+            unmarshall(marshalled, 0, marshalled.size)
+            readType()
+        }
+
+        assertThat(unmarshalled).isEqualTo(entityType)
+    }
+
+    @Test
+    fun parcelableRoundtrip_works_forReferenceType() {
+        val referenceType = ReferenceType(EntityType(entitySchema))
+
+        val marshalled = with(Parcel.obtain()) {
+            writeType(referenceType, 0)
+            marshall()
+        }
+
+        val unmarshalled = with(Parcel.obtain()) {
+            unmarshall(marshalled, 0, marshalled.size)
+            readType()
+        }
+
+        assertThat(unmarshalled).isEqualTo(referenceType)
+    }
+
+    @Test
+    fun parcelableRoundtrip_works_forSingletonType() {
+        val singletonType = SingletonType(EntityType(entitySchema))
+
+        val marshalled = with(Parcel.obtain()) {
+            writeType(singletonType, 0)
+            marshall()
+        }
+
+        val unmarshalled = with(Parcel.obtain()) {
+            unmarshall(marshalled, 0, marshalled.size)
+            readType()
+        }
+
+        assertThat(unmarshalled).isEqualTo(singletonType)
+    }
+
+    private val entitySchema = Schema(
+        names = listOf(SchemaName("Person")),
+        fields = SchemaFields(
+            singletons = setOf("name", "age"),
+            collections = setOf("friends")
+        ),
+        description = SchemaDescription()
+    )
+}

--- a/src_kt/java/arcs/data/CollectionType.kt
+++ b/src_kt/java/arcs/data/CollectionType.kt
@@ -27,7 +27,7 @@ fun <T : Type> T?.collectionOf(): CollectionType<T>? =
     if (this == null) null else CollectionType(this)
 
 /** [Type] representation of a collection. */
-open class CollectionType<T : Type>(
+data class CollectionType<T : Type>(
     val collectionType: T
 ) : Type,
     Type.TypeContainer<T>,

--- a/src_kt/java/arcs/data/CountType.kt
+++ b/src_kt/java/arcs/data/CountType.kt
@@ -19,9 +19,9 @@ import arcs.type.TypeFactory
 import arcs.type.TypeLiteral
 
 /** [Type] representation for a counter. */
-class CountType : Type, CrdtModelType<CrdtCount.Data, CrdtCount.Operation, Int> {
-    override val tag = Tag.Count
-
+data class CountType(
+    override val tag: Tag = Tag.Count
+) : Type, CrdtModelType<CrdtCount.Data, CrdtCount.Operation, Int> {
     override fun toLiteral() = Literal(tag)
 
     override fun createCrdtModel() = CrdtCount()

--- a/src_kt/java/arcs/data/EntityType.kt
+++ b/src_kt/java/arcs/data/EntityType.kt
@@ -20,7 +20,7 @@ import arcs.type.TypeFactory
 import arcs.type.TypeLiteral
 
 /** [Type] representation of an entity. */
-class EntityType(override val entitySchema: Schema) :
+data class EntityType(override val entitySchema: Schema) :
     Type,
     EntitySchemaProviderType,
     CrdtModelType<CrdtEntity.Data, CrdtEntity.Operation, RawEntity> {

--- a/src_kt/java/arcs/data/ReferenceType.kt
+++ b/src_kt/java/arcs/data/ReferenceType.kt
@@ -17,7 +17,7 @@ import arcs.type.TypeFactory
 import arcs.type.TypeLiteral
 
 /** [Type] representation of a reference. */
-class ReferenceType<T : Type>(referredType: T) :
+data class ReferenceType<T : Type>(private val referredType: T) :
     Type, Type.TypeContainer<T>, EntitySchemaProviderType {
     override val tag = Tag.Reference
     override val containedType: T = referredType

--- a/src_kt/java/arcs/data/Schema.kt
+++ b/src_kt/java/arcs/data/Schema.kt
@@ -15,7 +15,7 @@ import arcs.crdt.CrdtEntity
 import arcs.crdt.internal.VersionMap
 import arcs.type.Type
 
-class Schema(
+data class Schema(
     val names: List<SchemaName>,
     val fields: SchemaFields,
     val description: SchemaDescription

--- a/src_kt/java/arcs/data/Schema.kt
+++ b/src_kt/java/arcs/data/Schema.kt
@@ -23,7 +23,7 @@ class Schema(
     val name: SchemaName?
         get() = names.firstOrNull()
 
-    val emptyRawEntity: RawEntity
+    private val emptyRawEntity: RawEntity
         get() = RawEntity(
             singletonFields = fields.singletons,
             collectionFields = fields.collections

--- a/src_kt/java/arcs/data/SchemaFields.kt
+++ b/src_kt/java/arcs/data/SchemaFields.kt
@@ -12,7 +12,7 @@
 package arcs.data
 
 /** TODO: This is super minimal for now. */
-class SchemaFields(
+data class SchemaFields(
     val singletons: Set<FieldName>,
     val collections: Set<FieldName>
 )

--- a/src_kt/java/arcs/data/SingletonType.kt
+++ b/src_kt/java/arcs/data/SingletonType.kt
@@ -20,7 +20,7 @@ import arcs.type.TypeFactory
 import arcs.type.TypeLiteral
 
 /** [Type] representation for a singleton. */
-class SingletonType<T : Type>(override val containedType: T) :
+data class SingletonType<T : Type>(override val containedType: T) :
     Type,
     Type.TypeContainer<T>,
     CrdtModelType<


### PR DESCRIPTION
Note: none of the tests in shells/android are currently being run by Travis (a tracking bug for this exists in buganizer). I have verified that all tests pass locally using:

`bazel test //shells/android/javatests/...`

```
INFO: Elapsed time: 37.865s, Critical Path: 35.44s
INFO: 70 processes: 55 darwin-sandbox, 15 worker.
INFO: Build completed successfully, 89 total actions
//shells/android/javatests/arcs/crdt/parcelables:ParcelableCrdtCountTest PASSED in 25.2s
//shells/android/javatests/arcs/crdt/parcelables:ParcelableCrdtExceptionTest PASSED in 25.9s
//shells/android/javatests/arcs/crdt/parcelables:ParcelableVersionMapTest PASSED in 25.2s
//shells/android/javatests/arcs/storage/parcelables:ParcelableModelUpdateTest PASSED in 27.3s
//shells/android/javatests/arcs/storage/parcelables:ParcelableOperationsTest PASSED in 28.0s
//shells/android/javatests/arcs/storage/parcelables:ParcelableStoreOptionsTest PASSED in 27.5s
//shells/android/javatests/arcs/storage/parcelables:ParcelableSyncRequestTest PASSED in 26.8s
//shells/android/javatests/arcs/type/parcelables:ParcelableSchemaDescriptionTest PASSED in 25.8s
//shells/android/javatests/arcs/type/parcelables:ParcelableSchemaFieldsTest PASSED in 27.5s
//shells/android/javatests/arcs/type/parcelables:ParcelableSchemaTest    PASSED in 27.0s
//shells/android/javatests/arcs/type/parcelables:ParcelableTypeTest      PASSED in 27.2s

INFO: Build completed successfully, 89 total actions
```