### PR TITLE
Fix missing runtime context

### DIFF
--- a/shells/pipes-shell/source/pipe.js
+++ b/shells/pipes-shell/source/pipe.js
@@ -36,8 +36,9 @@ export const busReady = async (bus, {manifest}) => {
 const configureRuntime = async ({rootPath, urlMap, storage, manifest}, bus) => {
   // configure arcs runtime environment
   Runtime.init(rootPath, urlMap);
-  // marshal context
+  // marshal and bind context
   const context = await requireContext(manifest || config.manifest);
+  Runtime.getRuntime().bindContext(context);
   // attach verb-handlers to dispatcher
   populateDispatcher(dispatcher, storage, context);
   // send pipe identifiers to client

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -57,7 +57,7 @@ let runtime: Runtime | null = null;
 // currently imported by ArcsLib.js. Once that refactoring is done, we can
 // think about what the api should actually look like.
 export class Runtime {
-  public readonly context: Manifest;
+  public context: Manifest;
   public readonly pecFactory: PecFactory;
   private cacheService: RuntimeCacheService;
   private loader: Loader | null;
@@ -144,6 +144,11 @@ export class Runtime {
   }
 
   destroy() {
+  }
+
+  // Allow dynamic context binding to this runtime.
+  bindContext(context: Manifest) {
+    this.context = context;
   }
 
   /**


### PR DESCRIPTION
pipes-shell at demo app doesn't work after #3980 due to the warning
"found no recipes matching [recipe name]"

The cause is:
Runtime.init() instantiates a new runtime with a null context at the very first place.
Later on requireContext() parses the manifest and generates the context required
by the spawned runtime but the context is never bound to the runtime ends up the not-found issue.
