### PR TITLE
Enable Arcs Cache Manager on DevEx

### DIFF
--- a/javaharness/README.md
+++ b/javaharness/README.md
@@ -113,6 +113,6 @@ Android properties are used to change and tweak Arcs settings at run-time.
 | debug.arcs.runtime.log | Change logging level of the JS Arcs runtime | 2 (the most verbose) |
 | debug.arcs.runtime.enable_arcs_explorer | Connect to the Arcs Explorer frontend via ALDS proxy while starting the JS Arcs runtime | false |
 | debug.arcs.runtime.dev_server_port | The port to use for communication with ALDS | 8786 |
-| debug.arcs.runtime.shell_url | Specify which shell to use | https://appassets.androidplatform.net/assets/arcs/index.html? (on-device pipes-shell with the Arcs Cache Manager) |
+| debug.arcs.runtime.shell_url | Specify which shell to use | https://appassets.androidplatform.net/<br/>assets/arcs/index.html? (on-device pipes-shell with the Arcs Cache Manager) |
 | debug.arcs.runtime.load_workstation_assets | Whether to load recipes and particles from the workstation | false (assets from the APK) |
 | debug.arcs.runtime.use_cache_mgr | Whether to use the Arcs Cache Manager | true

--- a/javaharness/README.md
+++ b/javaharness/README.md
@@ -93,7 +93,7 @@ The Arcs Cache Manager compiles javascript and webassembly sources eagerly and c
 Enabling the Arcs Cache Manager:
 1. Terminate the existing demo application.
 1. Activate the Arcs Cache Manager then launch demo application to reflect new settings.
- ```bash
+* ```bash
   adb shell "setprop debug.arcs.runtime.use_cache_mgr true"
   adb shell "setprop debug.arcs.runtime.shell_url 'https://appassets.androidplatform.net/assets/arcs/index.html?'"
   ```
@@ -102,7 +102,7 @@ Disabling the Arcs Cache Manager:
 1. Deactivate the Arcs Cache Manager then launch demo application to reflect new settings.
 * ```bash
   adb shell "setprop debug.arcs.runtime.use_cache_mgr false"
-  adb shell "setprop debug.arcs.runtime.shell_url ''"
+  adb shell "setprop debug.arcs.runtime.shell_url 'file:///android_asset/arcs/index.html?'"
   ```
 
 ## Properties
@@ -113,6 +113,6 @@ Android properties are used to change and tweak Arcs settings at run-time.
 | debug.arcs.runtime.log | Change logging level of the JS Arcs runtime | 2 (the most verbose) |
 | debug.arcs.runtime.enable_arcs_explorer | Connect to the Arcs Explorer frontend via ALDS proxy while starting the JS Arcs runtime | false |
 | debug.arcs.runtime.dev_server_port | The port to use for communication with ALDS | 8786 |
-| debug.arcs.runtime.shell_url | Specify which shell to use | file:///android_asset/index.html? (on-device pipes-shell) |
+| debug.arcs.runtime.shell_url | Specify which shell to use | https://appassets.androidplatform.net/assets/arcs/index.html? (on-device pipes-shell with the Arcs Cache Manager) |
 | debug.arcs.runtime.load_workstation_assets | Whether to load recipes and particles from the workstation | false (assets from the APK) |
-| debug.arcs.runtime.use_cache_mgr | Whether to use the Arcs Cache Manager | false
+| debug.arcs.runtime.use_cache_mgr | Whether to use the Arcs Cache Manager | true

--- a/javaharness/java/arcs/android/AndroidRuntimeSettings.java
+++ b/javaharness/java/arcs/android/AndroidRuntimeSettings.java
@@ -32,13 +32,18 @@ public final class AndroidRuntimeSettings implements RuntimeSettings {
   // Does *not* connect Arcs Explorer
   private static final boolean DEFAULT_ENABLE_ARCS_EXPLORER = false;
   // Loads the on-device pipes-shell
-  private static final String DEFAULT_SHELL_URL = "file:///android_asset/arcs/index.html?";
+  // Multiple protocols are supported, i.e.
+  // file:///android_asset/arcs/index.html?
+  // https://appassets.androidplatform.net/assets/arcs/index.html?
+  // The Arcs Cache Manager only works at https secure origin.
+  private static final String DEFAULT_SHELL_URL =
+      "https://appassets.androidplatform.net/assets/arcs/index.html?";
   // Load the on-device assets
   private static final boolean DEFAULT_ASSETS_FROM_WORKSTATION = false;
   // Uses the standard 8786 port
   private static final int DEFAULT_DEV_SERVER_PORT = 8786;
-  // Deactivates the Arcs Cache Manager.
-  private static final boolean DEFAULT_USE_CACHE_MANAGER = false;
+  // Activates the Arcs Cache Manager.
+  private static final boolean DEFAULT_USE_CACHE_MANAGER = true;
 
   private static final Logger logger = Logger.getLogger(
       AndroidRuntimeSettings.class.getName());

--- a/shells/pipes-shell/web/cache-mgr-sw.js
+++ b/shells/pipes-shell/web/cache-mgr-sw.js
@@ -69,8 +69,8 @@ self.addEventListener('fetch', event => {
       event.request.cache === 'only-if-cached') {
     return;
   }
-  // Bypass non-sw-scope resource caching i.e. reflecting changes on workstation
-  // assets on the fly when enabling debug.arcs.runtime.load_workstation_assets
+  // Bypass non-sw-scope resource caching i.e. reflecting in-place editing on
+  // workstation assets when enabling debug.arcs.runtime.load_workstation_assets
   if (event.request.url.indexOf(self.location.host) === -1) {
     return;
   }

--- a/shells/pipes-shell/web/cache-mgr-sw.js
+++ b/shells/pipes-shell/web/cache-mgr-sw.js
@@ -69,5 +69,10 @@ self.addEventListener('fetch', event => {
       event.request.cache === 'only-if-cached') {
     return;
   }
+  // Bypass non-sw-scope resource caching i.e. reflecting changes on workstation
+  // assets on the fly when enabling debug.arcs.runtime.load_workstation_assets
+  if (event.request.url.indexOf(self.location.host) === -1) {
+    return;
+  }
   event.respondWith(cachedFetch(event));
 });


### PR DESCRIPTION
Check go/arcs-cache-manager for optimization results.
After the ServiceWorker officially supports dedicated workers (soon), the latency will be improved
significantly (10-50+ ms) for particles' execution of each PEC spawned at a new dedicated worker context at run-time. 

Turn on for the time being and follow up bugs if any.