### PR TITLE
Fix checksum on linux and mac hosts

### DIFF
--- a/shells/pipes-shell/web/deploy/android_deploy.sh
+++ b/shells/pipes-shell/web/deploy/android_deploy.sh
@@ -18,5 +18,5 @@ cp source/index.html "$OUT_DIR/index.html"
 # Arcs cache manager and versioning
 # Must be done at the last step to ensure the correct $OUT_DIR/** checksum
 cp -fR ../cache-mgr*.js $OUT_DIR/
-sed -i "s/__ARCS_MD5__/$(tar -cf - $OUT_DIR | md5sum | cut -d' ' -f1)/g" \
+sed -i "s/__ARCS_MD5__/$(tar -cf - $OUT_DIR | shasum | cut -d' ' -f1)/g" \
   $OUT_DIR/cache-mgr-sw.js

--- a/shells/pipes-shell/web/deploy/deploy.sh
+++ b/shells/pipes-shell/web/deploy/deploy.sh
@@ -14,5 +14,5 @@ npx webpack --display=errors-only
 # Arcs cache manager and versioning
 # Must be done at the last step to ensure the correct dist/** checksum
 cp -fR ../cache-mgr*.js dist/
-sed -i "s/__ARCS_MD5__/$(tar -cf - dist | md5sum | cut -d' ' -f1)/g" \
+sed -i "s/__ARCS_MD5__/$(tar -cf - dist | shasum | cut -d' ' -f1)/g" \
   dist/cache-mgr-sw.js


### PR DESCRIPTION
md5sum doesn't work on mac hosts while md5@mac has different output format.
shasum is common on both hosts.