### PR TITLE
Parcelable impls for RawEntity, CrdtSet, Referencable

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -128,6 +128,7 @@ maven_install(
         "androidx.test:runner:1.1.0",
         "androidx.test:rules:1.1.0",
         "com.google.flogger:flogger:0.4",
+        "com.google.code.findbugs:jsr305:3.0.2",
         "com.google.flogger:flogger-system-backend:0.4",
         "com.google.dagger:dagger:2.23.1",
         "com.google.dagger:dagger-compiler:2.23.1",

--- a/shells/android/java/arcs/crdt/parcelables/BUILD
+++ b/shells/android/java/arcs/crdt/parcelables/BUILD
@@ -13,5 +13,6 @@ kt_android_library(
         "//src_kt/java/arcs/common",
         "//src_kt/java/arcs/crdt",
         "//src_kt/java/arcs/crdt/internal",
+        "//third_party/java/jsr305_annotations",
     ],
 )

--- a/shells/android/java/arcs/crdt/parcelables/CrdtParcelables.kt
+++ b/shells/android/java/arcs/crdt/parcelables/CrdtParcelables.kt
@@ -63,12 +63,13 @@ fun Parcel.readModelData(expectedType: ParcelableCrdtType): CrdtData? =
 
 /** Writes a [CrdtOperation] to the [Parcel]. */
 fun Parcel.writeOperation(operation: CrdtOperation?, flags: Int) {
+    @Suppress("UNCHECKED_CAST")
     when (operation) {
         null -> writeTypedObject(null, flags)
         is CrdtCount.Operation ->
-            writeTypedObject(operation.toParcelable(), flags)
+            writeTypedObject((operation as? CrdtCount.Operation)?.toParcelable(), flags)
         is CrdtSet.Operation<*> ->
-            writeTypedObject(operation.toParcelable(), flags)
+            writeTypedObject((operation as? CrdtSet.Operation<Referencable>)?.toParcelable(), flags)
         is CrdtSingleton.Operation<*> ->
             TODO("Implement me when ParcelableSingleton is ready")
         is CrdtEntity.Operation ->

--- a/shells/android/java/arcs/crdt/parcelables/CrdtParcelables.kt
+++ b/shells/android/java/arcs/crdt/parcelables/CrdtParcelables.kt
@@ -13,6 +13,7 @@ package arcs.crdt.parcelables
 
 import android.os.Parcel
 import android.os.Parcelable
+import arcs.common.Referencable
 import arcs.crdt.CrdtCount
 import arcs.crdt.CrdtData
 import arcs.crdt.CrdtEntity
@@ -36,13 +37,14 @@ interface ParcelableCrdtOperationAtTime<T : CrdtOperationAtTime> :
     ParcelableCrdtOperation<T>, CrdtOperationAtTime
 
 /** Writes [CrdtData] to the [Parcel]. */
+@Suppress("UNCHECKED_CAST")
 fun Parcel.writeModelData(model: CrdtData?, flags: Int) {
     when (model) {
         null -> writeTypedObject(null, flags)
         is CrdtCount.Data ->
             writeTypedObject((model as? CrdtCount.Data)?.toParcelable(), flags)
         is CrdtSet.Data<*> ->
-            TODO("Implement me when ParcelableSet is ready")
+            writeTypedObject((model as CrdtSet.Data<Referencable>).toParcelable(), flags)
         is CrdtSingleton.Data<*> ->
             TODO("Implement me when ParcelableSingleton is ready")
         is CrdtEntity.Data ->
@@ -64,9 +66,9 @@ fun Parcel.writeOperation(operation: CrdtOperation?, flags: Int) {
     when (operation) {
         null -> writeTypedObject(null, flags)
         is CrdtCount.Operation ->
-            writeTypedObject((operation as? CrdtCount.Operation)?.toParcelable(), flags)
+            writeTypedObject(operation.toParcelable(), flags)
         is CrdtSet.Operation<*> ->
-            TODO("Implement me when ParcelableSet is ready")
+            writeTypedObject(operation.toParcelable(), flags)
         is CrdtSingleton.Operation<*> ->
             TODO("Implement me when ParcelableSingleton is ready")
         is CrdtEntity.Operation ->

--- a/shells/android/java/arcs/crdt/parcelables/CrdtParcelables.kt
+++ b/shells/android/java/arcs/crdt/parcelables/CrdtParcelables.kt
@@ -44,7 +44,7 @@ fun Parcel.writeModelData(model: CrdtData?, flags: Int) {
         is CrdtCount.Data ->
             writeTypedObject((model as? CrdtCount.Data)?.toParcelable(), flags)
         is CrdtSet.Data<*> ->
-            writeTypedObject((model as CrdtSet.Data<Referencable>).toParcelable(), flags)
+            writeTypedObject((model as? CrdtSet.Data<Referencable>)?.toParcelable(), flags)
         is CrdtSingleton.Data<*> ->
             TODO("Implement me when ParcelableSingleton is ready")
         is CrdtEntity.Data ->
@@ -62,8 +62,8 @@ fun Parcel.readModelData(expectedType: ParcelableCrdtType): CrdtData? =
     )?.actual
 
 /** Writes a [CrdtOperation] to the [Parcel]. */
+@Suppress("UNCHECKED_CAST")
 fun Parcel.writeOperation(operation: CrdtOperation?, flags: Int) {
-    @Suppress("UNCHECKED_CAST")
     when (operation) {
         null -> writeTypedObject(null, flags)
         is CrdtCount.Operation ->

--- a/shells/android/java/arcs/crdt/parcelables/ParcelableCrdtSet.kt
+++ b/shells/android/java/arcs/crdt/parcelables/ParcelableCrdtSet.kt
@@ -53,14 +53,14 @@ object ParcelableCrdtSet {
             override fun createFromParcel(parcel: Parcel): Data {
                 val versionMap = requireNotNull(
                     parcel.readTypedObject(ParcelableVersionMap.CREATOR)
-                ) { "No VersionMap found in parcel when reading ParcelableCrdtCountData" }
+                ) { "No VersionMap found in parcel when reading ParcelableCrdtSet.Data" }
 
                 val values = mutableMapOf<ReferenceId, CrdtSet.DataValue<Referencable>>()
                 val items = parcel.readInt()
                 repeat(items) {
                     values[requireNotNull(parcel.readString())] =
                         requireNotNull(parcel.readTypedObject(DataValue.CREATOR)) {
-                            "No DataValue found in parcel"
+                            "No DataValue found in parcel when reading ParcelableCrdtSet.Data"
                         }.actual
                 }
 
@@ -103,7 +103,10 @@ object ParcelableCrdtSet {
             companion object CREATOR : Parcelable.Creator<Add> {
                 override fun createFromParcel(parcel: Parcel): Add {
                     val clock =
-                        requireNotNull(parcel.readTypedObject(ParcelableVersionMap.CREATOR)).actual
+                        requireNotNull(parcel.readTypedObject(ParcelableVersionMap.CREATOR)) {
+                            "VersionMap not found in parcel when reading " +
+                                "ParcelableCrdtSet.Operation.Add"
+                        }.actual
                     val actor = requireNotNull(parcel.readString())
                     val added = requireNotNull(parcel.readReferencable())
                     return Add(CrdtSet.Operation.Add(clock, actor, added))
@@ -129,7 +132,10 @@ object ParcelableCrdtSet {
             companion object CREATOR : Parcelable.Creator<Remove> {
                 override fun createFromParcel(parcel: Parcel): Remove {
                     val clock =
-                        requireNotNull(parcel.readTypedObject(ParcelableVersionMap.CREATOR)).actual
+                        requireNotNull(parcel.readTypedObject(ParcelableVersionMap.CREATOR)) {
+                            "VersionMap not found in parcel when reading " +
+                                "ParcelableCrdtSet.Operation.Remove"
+                        }.actual
                     val actor = requireNotNull(parcel.readString())
                     val removed = requireNotNull(parcel.readReferencable())
                     return Remove(CrdtSet.Operation.Remove(clock, actor, removed))
@@ -164,7 +170,10 @@ object ParcelableCrdtSet {
             companion object CREATOR : Parcelable.Creator<FastForward> {
                 override fun createFromParcel(parcel: Parcel): FastForward {
                     val oldClock =
-                        requireNotNull(parcel.readTypedObject(ParcelableVersionMap.CREATOR)).actual
+                        requireNotNull(parcel.readTypedObject(ParcelableVersionMap.CREATOR)) {
+                            "VersionMap not found in parcel when reading " +
+                                "ParcelableCrdtSet.Operation.FastForward"
+                        }.actual
                     val newClock =
                         requireNotNull(parcel.readTypedObject(ParcelableVersionMap.CREATOR)).actual
 

--- a/shells/android/java/arcs/crdt/parcelables/ParcelableCrdtSet.kt
+++ b/shells/android/java/arcs/crdt/parcelables/ParcelableCrdtSet.kt
@@ -1,0 +1,195 @@
+package arcs.crdt.parcelables
+
+import android.os.Parcel
+import android.os.Parcelable
+import arcs.common.Referencable
+import arcs.common.ReferenceId
+import arcs.crdt.CrdtSet
+
+object ParcelableCrdtSet {
+    data class DataValue(
+        val actual: CrdtSet.DataValue<Referencable>
+    ) : Parcelable {
+        override fun describeContents(): Int = 0
+
+        override fun writeToParcel(parcel: Parcel, flags: Int) {
+            parcel.writeTypedObject(ParcelableVersionMap(actual.versionMap), flags)
+            parcel.writeTypedObject(ParcelableReferencable(actual.value), flags)
+        }
+
+        companion object CREATOR : Parcelable.Creator<DataValue> {
+            override fun createFromParcel(parcel: Parcel): DataValue {
+                val versionMap = parcel.readTypedObject(ParcelableVersionMap.CREATOR)!!.actual
+                val value = requireNotNull(parcel.readReferencable())
+                return DataValue(CrdtSet.DataValue(versionMap, value))
+            }
+
+            override fun newArray(size: Int): Array<DataValue?> = arrayOfNulls(size)
+        }
+    }
+
+    data class Data(
+        override val actual: CrdtSet.Data<Referencable>
+    ) : ParcelableCrdtData<CrdtSet.Data<Referencable>> {
+        override var versionMap = actual.versionMap
+
+        override fun writeToParcel(parcel: Parcel, flags: Int) {
+            parcel.writeTypedObject(ParcelableVersionMap(actual.versionMap), flags)
+            parcel.writeInt(actual.values.size)
+            actual.values.forEach { (actor, value) ->
+                parcel.writeString(actor)
+                parcel.writeTypedObject(DataValue(value), flags)
+            }
+        }
+
+        override fun describeContents(): Int = 0
+
+        companion object CREATOR : Parcelable.Creator<Data> {
+            override fun createFromParcel(parcel: Parcel): Data {
+                val versionMap = requireNotNull(
+                    parcel.readTypedObject(ParcelableVersionMap.CREATOR)
+                ) { "No VersionMap found in parcel when reading ParcelableCrdtCountData" }
+
+                val values = mutableMapOf<ReferenceId, CrdtSet.DataValue<Referencable>>()
+                val items = parcel.readInt()
+                repeat(items) {
+                    values[requireNotNull(parcel.readString())] =
+                        parcel.readTypedObject(DataValue.CREATOR)!!.actual
+                }
+
+                return Data(CrdtSet.DataImpl(versionMap.actual, values))
+            }
+
+            override fun newArray(size: Int): Array<Data?> = arrayOfNulls(size)
+        }
+    }
+
+    sealed class Operation(
+        private val opType: OpType
+    ) : ParcelableCrdtOperation<CrdtSet.Operation<Referencable>> {
+
+        override fun writeToParcel(parcel: Parcel, flags: Int) {
+            // Write the opType so we can multiplex during createFromParcel.
+            parcel.writeInt(opType.ordinal)
+        }
+
+        data class Add(
+            override val actual: CrdtSet.Operation.Add<Referencable>
+        ) : Operation(OpType.Add) {
+            override fun describeContents(): Int = 0
+
+            override fun writeToParcel(parcel: Parcel, flags: Int) {
+                super.writeToParcel(parcel, flags)
+                parcel.writeTypedObject(ParcelableVersionMap(actual.clock), flags)
+                parcel.writeString(actual.actor)
+                parcel.writeTypedObject(ParcelableReferencable(actual.added), flags)
+            }
+
+            companion object CREATOR : Parcelable.Creator<Add> {
+                override fun createFromParcel(parcel: Parcel): Add {
+                    val clock = parcel.readTypedObject(ParcelableVersionMap.CREATOR)!!.actual
+                    val actor = requireNotNull(parcel.readString())
+                    val added = requireNotNull(parcel.readReferencable())
+                    return Add(CrdtSet.Operation.Add(clock, actor, added))
+                }
+
+                override fun newArray(size: Int): Array<Add?> = arrayOfNulls(size)
+            }
+        }
+
+        data class Remove(
+            override val actual: CrdtSet.Operation.Remove<Referencable>
+        ) : Operation(OpType.Remove) {
+            override fun describeContents(): Int = 0
+
+            override fun writeToParcel(parcel: Parcel, flags: Int) {
+                super.writeToParcel(parcel, flags)
+                parcel.writeTypedObject(ParcelableVersionMap(actual.clock), flags)
+                parcel.writeString(actual.actor)
+                parcel.writeTypedObject(ParcelableReferencable(actual.removed), flags)
+            }
+
+            companion object CREATOR : Parcelable.Creator<Remove> {
+                override fun createFromParcel(parcel: Parcel): Remove {
+                    val clock = parcel.readTypedObject(ParcelableVersionMap.CREATOR)!!.actual
+                    val actor = requireNotNull(parcel.readString())
+                    val removed = requireNotNull(parcel.readReferencable())
+                    return Remove(CrdtSet.Operation.Remove(clock, actor, removed))
+                }
+
+                override fun newArray(size: Int): Array<Remove?> = arrayOfNulls(size)
+            }
+        }
+
+        data class FastForward(
+            override val actual: CrdtSet.Operation.FastForward<Referencable>
+        ) : Operation(OpType.FastForward) {
+            override fun describeContents(): Int = 0
+
+            override fun writeToParcel(parcel: Parcel, flags: Int) {
+                super.writeToParcel(parcel, flags)
+                parcel.writeTypedObject(ParcelableVersionMap(actual.oldClock), flags)
+                parcel.writeTypedObject(ParcelableVersionMap(actual.newClock), flags)
+
+                parcel.writeInt(actual.added.size)
+                actual.added.forEach {
+                    parcel.writeTypedObject(DataValue(it), flags)
+                }
+
+                parcel.writeInt(actual.removed.size)
+                actual.removed.forEach {
+                    parcel.writeTypedObject(ParcelableReferencable(it), flags)
+                }
+            }
+
+            companion object CREATOR : Parcelable.Creator<FastForward> {
+                override fun createFromParcel(parcel: Parcel): FastForward {
+                    val oldClock = parcel.readTypedObject(ParcelableVersionMap.CREATOR)!!.actual
+                    val newClock = parcel.readTypedObject(ParcelableVersionMap.CREATOR)!!.actual
+
+                    val added = mutableListOf<CrdtSet.DataValue<Referencable>>()
+                    val numAdded = parcel.readInt()
+                    repeat(numAdded) {
+                        added.add(parcel.readTypedObject(DataValue.CREATOR)!!.actual)
+                    }
+
+                    val removed = mutableListOf<Referencable>()
+                    val numRemoved = parcel.readInt()
+                    repeat(numRemoved) {
+                        removed.add(requireNotNull(parcel.readReferencable()))
+                    }
+                    return FastForward(CrdtSet.Operation.FastForward(oldClock, newClock, added, removed))
+                }
+
+                override fun newArray(size: Int): Array<FastForward?> = arrayOfNulls(size)
+            }
+        }
+
+        companion object CREATOR : Parcelable.Creator<Operation> {
+            override fun createFromParcel(parcel: Parcel): Operation =
+                when (OpType.values()[parcel.readInt()]) {
+                    OpType.Add -> Add.createFromParcel(parcel)
+                    OpType.Remove -> Remove.createFromParcel(parcel)
+                    OpType.FastForward -> FastForward.createFromParcel(parcel)
+                }
+
+            override fun newArray(size: Int): Array<Operation?> = arrayOfNulls(size)
+        }
+    }
+
+    internal enum class OpType {
+        Add,
+        Remove,
+        FastForward,
+    }
+}
+
+fun CrdtSet.Data<Referencable>.toParcelable(): ParcelableCrdtSet.Data =
+    ParcelableCrdtSet.Data(this)
+
+fun CrdtSet.Operation<Referencable>.toParcelable(): ParcelableCrdtOperation<CrdtSet.Operation<Referencable>> =
+    when (this) {
+        is CrdtSet.Operation.Add -> ParcelableCrdtSet.Operation.Add(this)
+        is CrdtSet.Operation.Remove -> ParcelableCrdtSet.Operation.Remove(this)
+        is CrdtSet.Operation.FastForward -> ParcelableCrdtSet.Operation.FastForward(this)
+    }

--- a/shells/android/java/arcs/crdt/parcelables/ParcelableCrdtSet.kt
+++ b/shells/android/java/arcs/crdt/parcelables/ParcelableCrdtSet.kt
@@ -6,7 +6,9 @@ import arcs.common.Referencable
 import arcs.common.ReferenceId
 import arcs.crdt.CrdtSet
 
+/** Container of [Parcelable] implementations for the data and ops classes of [CrdtSet]. */
 object ParcelableCrdtSet {
+    /** Parcelable variant of [CrdtSet.DataValue]. */
     data class DataValue(
         val actual: CrdtSet.DataValue<Referencable>
     ) : Parcelable {
@@ -28,6 +30,7 @@ object ParcelableCrdtSet {
         }
     }
 
+    /** Parcelable variant of [CrdtSet.Data]. */
     data class Data(
         override val actual: CrdtSet.Data<Referencable>
     ) : ParcelableCrdtData<CrdtSet.Data<Referencable>> {
@@ -64,6 +67,13 @@ object ParcelableCrdtSet {
         }
     }
 
+    /**
+     * Parcelable variants of [CrdtSet.Operation].
+     *
+     * This class is implemented such that it serves as a multiplexed parcelable for its subclasses.
+     * We write the ordinal value of [OpType] first, before parceling the contents of the subclass.
+     * The [OpType] is used to figure out the correct subtype when deserialising.
+     */
     sealed class Operation(
         private val opType: OpType
     ) : ParcelableCrdtOperation<CrdtSet.Operation<Referencable>> {
@@ -73,6 +83,7 @@ object ParcelableCrdtSet {
             parcel.writeInt(opType.ordinal)
         }
 
+        /** Parcelable variant of [CrdtSet.Operation.Add]. */
         data class Add(
             override val actual: CrdtSet.Operation.Add<Referencable>
         ) : Operation(OpType.Add) {
@@ -97,6 +108,7 @@ object ParcelableCrdtSet {
             }
         }
 
+        /** Parcelable variant of [CrdtSet.Operation.Remove]. */
         data class Remove(
             override val actual: CrdtSet.Operation.Remove<Referencable>
         ) : Operation(OpType.Remove) {
@@ -121,6 +133,7 @@ object ParcelableCrdtSet {
             }
         }
 
+        /** Parcelable variant of [CrdtSet.Operation.FastForward]. */
         data class FastForward(
             override val actual: CrdtSet.Operation.FastForward<Referencable>
         ) : Operation(OpType.FastForward) {
@@ -177,6 +190,7 @@ object ParcelableCrdtSet {
         }
     }
 
+    /** Identifiers for the subtypes of [Operation]. */
     internal enum class OpType {
         Add,
         Remove,
@@ -184,10 +198,13 @@ object ParcelableCrdtSet {
     }
 }
 
+/** Returns a [Parcelable] variant of the [CrdtSet.Data] object. */
 fun CrdtSet.Data<Referencable>.toParcelable(): ParcelableCrdtSet.Data =
     ParcelableCrdtSet.Data(this)
 
-fun CrdtSet.Operation<Referencable>.toParcelable(): ParcelableCrdtOperation<CrdtSet.Operation<Referencable>> =
+/** Returns a [Parcelable] variant of the [CrdtSet.Operation] object. */
+fun CrdtSet.Operation<Referencable>.toParcelable():
+    ParcelableCrdtOperation<CrdtSet.Operation<Referencable>> =
     when (this) {
         is CrdtSet.Operation.Add -> ParcelableCrdtSet.Operation.Add(this)
         is CrdtSet.Operation.Remove -> ParcelableCrdtSet.Operation.Remove(this)

--- a/shells/android/java/arcs/crdt/parcelables/ParcelableCrdtSet.kt
+++ b/shells/android/java/arcs/crdt/parcelables/ParcelableCrdtSet.kt
@@ -15,13 +15,15 @@ object ParcelableCrdtSet {
         override fun describeContents(): Int = 0
 
         override fun writeToParcel(parcel: Parcel, flags: Int) {
-            parcel.writeTypedObject(ParcelableVersionMap(actual.versionMap), flags)
-            parcel.writeTypedObject(ParcelableReferencable(actual.value), flags)
+            parcel.writeTypedObject(actual.versionMap.toParcelable(), flags)
+            parcel.writeTypedObject(actual.value.toParcelable(), flags)
         }
 
         companion object CREATOR : Parcelable.Creator<DataValue> {
             override fun createFromParcel(parcel: Parcel): DataValue {
-                val versionMap = parcel.readTypedObject(ParcelableVersionMap.CREATOR)!!.actual
+                val versionMap = requireNotNull(parcel.readTypedObject(ParcelableVersionMap.CREATOR)) {
+                    "VersionMap not found in parcel when reading ParcelableCrdtSet.DataValue"
+                }.actual
                 val value = requireNotNull(parcel.readReferencable())
                 return DataValue(CrdtSet.DataValue(versionMap, value))
             }
@@ -37,7 +39,7 @@ object ParcelableCrdtSet {
         override var versionMap = actual.versionMap
 
         override fun writeToParcel(parcel: Parcel, flags: Int) {
-            parcel.writeTypedObject(ParcelableVersionMap(actual.versionMap), flags)
+            parcel.writeTypedObject(actual.versionMap.toParcelable(), flags)
             parcel.writeInt(actual.values.size)
             actual.values.forEach { (actor, value) ->
                 parcel.writeString(actor)
@@ -57,7 +59,9 @@ object ParcelableCrdtSet {
                 val items = parcel.readInt()
                 repeat(items) {
                     values[requireNotNull(parcel.readString())] =
-                        parcel.readTypedObject(DataValue.CREATOR)!!.actual
+                        requireNotNull(parcel.readTypedObject(DataValue.CREATOR)) {
+                            "No DataValue found in parcel"
+                        }.actual
                 }
 
                 return Data(CrdtSet.DataImpl(versionMap.actual, values))
@@ -91,14 +95,15 @@ object ParcelableCrdtSet {
 
             override fun writeToParcel(parcel: Parcel, flags: Int) {
                 super.writeToParcel(parcel, flags)
-                parcel.writeTypedObject(ParcelableVersionMap(actual.clock), flags)
+                parcel.writeTypedObject(actual.clock.toParcelable(), flags)
                 parcel.writeString(actual.actor)
                 parcel.writeTypedObject(ParcelableReferencable(actual.added), flags)
             }
 
             companion object CREATOR : Parcelable.Creator<Add> {
                 override fun createFromParcel(parcel: Parcel): Add {
-                    val clock = parcel.readTypedObject(ParcelableVersionMap.CREATOR)!!.actual
+                    val clock =
+                        requireNotNull(parcel.readTypedObject(ParcelableVersionMap.CREATOR)).actual
                     val actor = requireNotNull(parcel.readString())
                     val added = requireNotNull(parcel.readReferencable())
                     return Add(CrdtSet.Operation.Add(clock, actor, added))
@@ -116,14 +121,15 @@ object ParcelableCrdtSet {
 
             override fun writeToParcel(parcel: Parcel, flags: Int) {
                 super.writeToParcel(parcel, flags)
-                parcel.writeTypedObject(ParcelableVersionMap(actual.clock), flags)
+                parcel.writeTypedObject(actual.clock.toParcelable(), flags)
                 parcel.writeString(actual.actor)
                 parcel.writeTypedObject(ParcelableReferencable(actual.removed), flags)
             }
 
             companion object CREATOR : Parcelable.Creator<Remove> {
                 override fun createFromParcel(parcel: Parcel): Remove {
-                    val clock = parcel.readTypedObject(ParcelableVersionMap.CREATOR)!!.actual
+                    val clock =
+                        requireNotNull(parcel.readTypedObject(ParcelableVersionMap.CREATOR)).actual
                     val actor = requireNotNull(parcel.readString())
                     val removed = requireNotNull(parcel.readReferencable())
                     return Remove(CrdtSet.Operation.Remove(clock, actor, removed))
@@ -141,8 +147,8 @@ object ParcelableCrdtSet {
 
             override fun writeToParcel(parcel: Parcel, flags: Int) {
                 super.writeToParcel(parcel, flags)
-                parcel.writeTypedObject(ParcelableVersionMap(actual.oldClock), flags)
-                parcel.writeTypedObject(ParcelableVersionMap(actual.newClock), flags)
+                parcel.writeTypedObject(actual.oldClock.toParcelable(), flags)
+                parcel.writeTypedObject(actual.newClock.toParcelable(), flags)
 
                 parcel.writeInt(actual.added.size)
                 actual.added.forEach {
@@ -157,13 +163,15 @@ object ParcelableCrdtSet {
 
             companion object CREATOR : Parcelable.Creator<FastForward> {
                 override fun createFromParcel(parcel: Parcel): FastForward {
-                    val oldClock = parcel.readTypedObject(ParcelableVersionMap.CREATOR)!!.actual
-                    val newClock = parcel.readTypedObject(ParcelableVersionMap.CREATOR)!!.actual
+                    val oldClock =
+                        requireNotNull(parcel.readTypedObject(ParcelableVersionMap.CREATOR)).actual
+                    val newClock =
+                        requireNotNull(parcel.readTypedObject(ParcelableVersionMap.CREATOR)).actual
 
                     val added = mutableListOf<CrdtSet.DataValue<Referencable>>()
                     val numAdded = parcel.readInt()
                     repeat(numAdded) {
-                        added.add(parcel.readTypedObject(DataValue.CREATOR)!!.actual)
+                        added.add(requireNotNull(parcel.readTypedObject(DataValue.CREATOR)).actual)
                     }
 
                     val removed = mutableListOf<Referencable>()
@@ -171,7 +179,8 @@ object ParcelableCrdtSet {
                     repeat(numRemoved) {
                         removed.add(requireNotNull(parcel.readReferencable()))
                     }
-                    return FastForward(CrdtSet.Operation.FastForward(oldClock, newClock, added, removed))
+                    return FastForward(
+                        CrdtSet.Operation.FastForward(oldClock, newClock, added, removed))
                 }
 
                 override fun newArray(size: Int): Array<FastForward?> = arrayOfNulls(size)

--- a/shells/android/java/arcs/crdt/parcelables/ParcelableCrdtType.kt
+++ b/shells/android/java/arcs/crdt/parcelables/ParcelableCrdtType.kt
@@ -26,7 +26,7 @@ enum class ParcelableCrdtType(
 ) {
     // TODO: provide creators for each CRDT data structure and remove the default values.
     Count(ParcelableCrdtCount.Data.CREATOR, ParcelableCrdtCount.Operation.CREATOR),
-    Set,
+    Set(ParcelableCrdtSet.Data.CREATOR, ParcelableCrdtSet.Operation.CREATOR),
     Singleton,
     Entity,
 }

--- a/shells/android/java/arcs/crdt/parcelables/ParcelableRawEntity.kt
+++ b/shells/android/java/arcs/crdt/parcelables/ParcelableRawEntity.kt
@@ -6,6 +6,7 @@ import arcs.common.Referencable
 import arcs.data.FieldName
 import arcs.data.RawEntity
 
+/** Parcelable variant of [RawEntity]. */
 data class ParcelableRawEntity(
     override val actual: RawEntity
 ) : ParcelableReferencable {

--- a/shells/android/java/arcs/crdt/parcelables/ParcelableRawEntity.kt
+++ b/shells/android/java/arcs/crdt/parcelables/ParcelableRawEntity.kt
@@ -1,0 +1,62 @@
+package arcs.crdt.parcelables
+
+import android.os.Parcel
+import android.os.Parcelable
+import arcs.common.Referencable
+import arcs.data.FieldName
+import arcs.data.RawEntity
+
+data class ParcelableRawEntity(
+    override val actual: RawEntity
+) : ParcelableReferencable {
+    override fun writeToParcel(parcel: Parcel, flags: Int) {
+        super.writeToParcel(parcel, flags)
+        parcel.writeString(actual.id)
+
+        parcel.writeInt(actual.singletons.size)
+        actual.singletons.forEach { (key, value) ->
+            parcel.writeString(key)
+            parcel.writeTypedObject(value?.let { ParcelableReferencable(it) }, flags)
+        }
+
+        parcel.writeInt(actual.collections.size)
+        actual.collections.forEach { (key, set) ->
+            parcel.writeString(key)
+            parcel.writeInt(set.size)
+            set.forEach {
+                parcel.writeTypedObject(ParcelableReferencable(it), flags)
+            }
+        }
+    }
+
+    override fun describeContents(): Int = 0
+
+    companion object CREATOR : Parcelable.Creator<ParcelableRawEntity> {
+        override fun createFromParcel(parcel: Parcel): ParcelableRawEntity {
+            val id = requireNotNull(parcel.readString())
+
+            val singletons = mutableMapOf<FieldName, Referencable?>()
+            val numSingletons = parcel.readInt()
+            repeat(numSingletons) {
+                singletons[requireNotNull(parcel.readString())] = parcel.readReferencable()
+            }
+
+            val collections = mutableMapOf<FieldName, Set<Referencable>>()
+            val numCollections = parcel.readInt()
+            repeat(numCollections) {
+                val key = requireNotNull(parcel.readString())
+                val numElements = parcel.readInt()
+                val set = mutableSetOf<Referencable>()
+                repeat(numElements) {
+                    set.add(requireNotNull(parcel.readReferencable()))
+                }
+                collections[key] = set
+            }
+
+            val rawEntity = RawEntity(id, singletons, collections)
+            return ParcelableRawEntity(rawEntity)
+        }
+
+        override fun newArray(size: Int): Array<ParcelableRawEntity?> = arrayOfNulls(size)
+    }
+}

--- a/shells/android/java/arcs/crdt/parcelables/ParcelableRawEntity.kt
+++ b/shells/android/java/arcs/crdt/parcelables/ParcelableRawEntity.kt
@@ -32,7 +32,8 @@ data class ParcelableRawEntity(
 
     override fun describeContents(): Int = 0
 
-    companion object CREATOR : Parcelable.Creator<ParcelableRawEntity> {
+    /** Don't use this directly; use the [ParcelableReferencable] base class instead. */
+    internal companion object CREATOR : Parcelable.Creator<ParcelableRawEntity> {
         override fun createFromParcel(parcel: Parcel): ParcelableRawEntity {
             val id = requireNotNull(parcel.readString())
 

--- a/shells/android/java/arcs/crdt/parcelables/ParcelableReferencable.kt
+++ b/shells/android/java/arcs/crdt/parcelables/ParcelableReferencable.kt
@@ -72,4 +72,4 @@ interface ParcelableReferencable : Parcelable {
 
 /** Reads a [Referencable] from the [Parcel]. */
 fun Parcel.readReferencable(): Referencable? =
-    readTypedObject(ParcelableReferencable.Companion.CREATOR)!!.actual
+    readTypedObject(ParcelableReferencable.Companion.CREATOR)?.actual

--- a/shells/android/java/arcs/crdt/parcelables/ParcelableReferencable.kt
+++ b/shells/android/java/arcs/crdt/parcelables/ParcelableReferencable.kt
@@ -70,6 +70,9 @@ interface ParcelableReferencable : Parcelable {
     }
 }
 
+/** Converts a [Referencable] into a [ParcelableReferencable]. */
+fun Referencable.toParcelable(): ParcelableReferencable = ParcelableReferencable(this)
+
 /** Reads a [Referencable] from the [Parcel]. */
 fun Parcel.readReferencable(): Referencable? =
     readTypedObject(ParcelableReferencable.Companion.CREATOR)?.actual

--- a/shells/android/java/arcs/crdt/parcelables/ParcelableReferencable.kt
+++ b/shells/android/java/arcs/crdt/parcelables/ParcelableReferencable.kt
@@ -8,9 +8,16 @@ import java.lang.IllegalArgumentException
 import javax.annotation.OverridingMethodsMustInvokeSuper
 import kotlin.reflect.KClass
 
+/**
+ * Parcelable variant of the [Referencable] interface.
+ *
+ * All subclasses of [Referencable] need to have their own [Parcelable] implementation. [Type] is
+ * used to identify which subclass is being parceled.
+ */
 interface ParcelableReferencable : Parcelable {
     val actual: Referencable
 
+    /** Indicates which subclass of [ParcelableReferencable] is being parceled. */
     enum class Type(
         val creator: Parcelable.Creator<out ParcelableReferencable>
     ) : Parcelable {
@@ -63,5 +70,6 @@ interface ParcelableReferencable : Parcelable {
     }
 }
 
+/** Reads a [Referencable] from the [Parcel]. */
 fun Parcel.readReferencable(): Referencable? =
     readTypedObject(ParcelableReferencable.Companion.CREATOR)!!.actual

--- a/shells/android/java/arcs/crdt/parcelables/ParcelableReferencable.kt
+++ b/shells/android/java/arcs/crdt/parcelables/ParcelableReferencable.kt
@@ -1,0 +1,67 @@
+package arcs.crdt.parcelables
+
+import android.os.Parcel
+import android.os.Parcelable
+import arcs.common.Referencable
+import arcs.data.RawEntity
+import java.lang.IllegalArgumentException
+import javax.annotation.OverridingMethodsMustInvokeSuper
+import kotlin.reflect.KClass
+
+interface ParcelableReferencable : Parcelable {
+    val actual: Referencable
+
+    enum class Type(
+        val creator: Parcelable.Creator<out ParcelableReferencable>
+    ) : Parcelable {
+        // TODO: Add other ParcelableReferencable subclasses.
+        RawEntity(ParcelableRawEntity.CREATOR);
+
+        override fun writeToParcel(parcel: Parcel, flags: Int) {
+            parcel.writeInt(ordinal)
+        }
+
+        override fun describeContents(): Int = 0
+
+        companion object CREATOR : Parcelable.Creator<Type> {
+            override fun createFromParcel(parcel: Parcel): Type = values()[parcel.readInt()]
+
+            override fun newArray(size: Int): Array<Type?> = arrayOfNulls(size)
+        }
+    }
+
+    @OverridingMethodsMustInvokeSuper
+    override fun writeToParcel(parcel: Parcel, flags: Int) {
+        parcel.writeTypedObject(
+            when (this) {
+                // TODO: Add other ParcelableReferencable subclasses.
+                is ParcelableRawEntity -> Type.RawEntity
+                else -> throw IllegalArgumentException("Unsupported")
+            },
+            flags)
+    }
+
+    override fun describeContents(): Int {
+        return 0
+    }
+
+    companion object {
+        operator fun invoke(actual: Referencable): ParcelableReferencable = when (actual) {
+            // TODO: Add other ParcelableReferencable subclasses.
+            is RawEntity -> ParcelableRawEntity(actual)
+            else -> throw IllegalArgumentException("Unsupported Referencable type: ${actual.javaClass}")
+        }
+
+        object CREATOR : Parcelable.Creator<ParcelableReferencable> {
+            override fun createFromParcel(parcel: Parcel): ParcelableReferencable {
+                val type = requireNotNull(parcel.readTypedObject(Type.CREATOR))
+                return type.creator.createFromParcel(parcel)
+            }
+
+            override fun newArray(size: Int): Array<ParcelableReferencable?> = arrayOfNulls(size)
+        }
+    }
+}
+
+fun Parcel.readReferencable(): Referencable? =
+    readTypedObject(ParcelableReferencable.Companion.CREATOR)!!.actual

--- a/shells/android/javatests/arcs/crdt/parcelables/ParcelableCrdtSetTest.kt
+++ b/shells/android/javatests/arcs/crdt/parcelables/ParcelableCrdtSetTest.kt
@@ -1,0 +1,108 @@
+package arcs.crdt.parcelables
+
+import android.os.Parcel
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import arcs.common.Referencable
+import arcs.crdt.CrdtSet
+import arcs.crdt.internal.VersionMap
+import arcs.data.RawEntity
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ParcelableCrdtSetTest {
+    private val versionMap: VersionMap = VersionMap("alice" to 1, "bob" to 2)
+    private val entity1: Referencable = RawEntity("ref-id-1", setOf("a"), setOf())
+    private val entity2: Referencable = RawEntity("ref-id-2", setOf(), setOf("b"))
+
+    @Test
+    fun dataValue_parcelableRoundTrip_works() {
+        val dataValue = CrdtSet.DataValue(versionMap, entity1)
+
+        val marshalled = with(Parcel.obtain()) {
+            writeTypedObject(ParcelableCrdtSet.DataValue(dataValue), 0)
+            marshall()
+        }
+        val unmarshalled = with(Parcel.obtain()) {
+            unmarshall(marshalled, 0, marshalled.size)
+            readTypedObject(requireNotNull(ParcelableCrdtSet.DataValue.CREATOR))
+        }
+
+        assertThat(unmarshalled?.actual).isEqualTo(dataValue)
+    }
+
+    @Test
+    fun data_parcelableRoundTrip_works() {
+        val data = CrdtSet.DataImpl(versionMap, mutableMapOf(
+            entity1.id to CrdtSet.DataValue(VersionMap("alice" to 1), entity1),
+            entity2.id to CrdtSet.DataValue(VersionMap("alice" to 1), entity2)
+        ))
+
+        val marshalled = with(Parcel.obtain()) {
+            writeTypedObject(ParcelableCrdtSet.Data(data), 0)
+            marshall()
+        }
+        val unmarshalled = with(Parcel.obtain()) {
+            unmarshall(marshalled, 0, marshalled.size)
+            readTypedObject(requireNotNull(ParcelableCrdtType.Set.crdtDataCreator))
+        }
+
+        assertThat(unmarshalled?.actual).isEqualTo(data)
+    }
+
+    @Test
+    fun operationAdd_parcelableRoundTrip_works() {
+        val op = CrdtSet.Operation.Add(versionMap, "alice", entity1)
+
+        val marshalled = with(Parcel.obtain()) {
+            writeTypedObject(op.toParcelable(), 0)
+            marshall()
+        }
+        val unmarshalled = with(Parcel.obtain()) {
+            unmarshall(marshalled, 0, marshalled.size)
+            readTypedObject(requireNotNull(ParcelableCrdtType.Set.crdtOperationCreator))
+        }
+
+        assertThat(unmarshalled?.actual).isEqualTo(op)
+    }
+
+    @Test
+    fun operationRemove_parcelableRoundTrip_works() {
+        val op = CrdtSet.Operation.Remove(versionMap, "alice", entity1)
+
+        val marshalled = with(Parcel.obtain()) {
+            writeTypedObject(op.toParcelable(), 0)
+            marshall()
+        }
+        val unmarshalled = with(Parcel.obtain()) {
+            unmarshall(marshalled, 0, marshalled.size)
+            readTypedObject(requireNotNull(ParcelableCrdtType.Set.crdtOperationCreator))
+        }
+
+        assertThat(unmarshalled?.actual).isEqualTo(op)
+    }
+
+    @Test
+    fun operationFastForward_parcelableRoundTrip_works() {
+        val oldClock = VersionMap("alice" to 1)
+        val newClock = VersionMap("alice" to 1, "bob" to 1)
+        val op = CrdtSet.Operation.FastForward(
+            oldClock,
+            newClock,
+            added = mutableListOf(CrdtSet.DataValue(newClock, entity1)),
+            removed = mutableListOf(entity2)
+        )
+
+        val marshalled = with(Parcel.obtain()) {
+            writeTypedObject(op.toParcelable(), 0)
+            marshall()
+        }
+        val unmarshalled = with(Parcel.obtain()) {
+            unmarshall(marshalled, 0, marshalled.size)
+            readTypedObject(requireNotNull(ParcelableCrdtType.Set.crdtOperationCreator))
+        }
+
+        assertThat(unmarshalled?.actual).isEqualTo(op)
+    }
+}

--- a/shells/android/javatests/arcs/crdt/parcelables/ParcelableRawEntityTest.kt
+++ b/shells/android/javatests/arcs/crdt/parcelables/ParcelableRawEntityTest.kt
@@ -28,4 +28,27 @@ class ParcelableRawEntityTest {
 
         assertThat(unmarshalled?.actual).isEqualTo(entity)
     }
+
+    @Test
+    fun parcelableRoundTrip_withNestedRawEntities_works() {
+        val entity1 = RawEntity("entity1", setOf(), setOf())
+        val entity2 = RawEntity("entity2", setOf(), setOf())
+        val entity3 = RawEntity("entity3", setOf(), setOf())
+        val uberEntity = RawEntity(
+            id = "uberEntity",
+            singletons = mapOf("a" to entity1),
+            collections = mapOf("b" to setOf(entity2, entity3))
+        )
+
+        val marshalled = with(Parcel.obtain()) {
+            writeTypedObject(ParcelableRawEntity(uberEntity), 0)
+            marshall()
+        }
+        val unmarshalled = with(Parcel.obtain()) {
+            unmarshall(marshalled, 0, marshalled.size)
+            readTypedObject(ParcelableReferencable.Companion.CREATOR)
+        }
+
+        assertThat(unmarshalled?.actual).isEqualTo(uberEntity)
+    }
 }

--- a/shells/android/javatests/arcs/crdt/parcelables/ParcelableRawEntityTest.kt
+++ b/shells/android/javatests/arcs/crdt/parcelables/ParcelableRawEntityTest.kt
@@ -1,0 +1,31 @@
+package arcs.crdt.parcelables
+
+import android.os.Parcel
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import arcs.data.RawEntity
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ParcelableRawEntityTest {
+    @Test
+    fun parcelableRoundTrip_works() {
+        val entity = RawEntity(
+            id = "reference-id",
+            singletonFields = setOf("a"),
+            collectionFields = setOf("b", "c")
+        )
+
+        val marshalled = with(Parcel.obtain()) {
+            writeTypedObject(ParcelableRawEntity(entity), 0)
+            marshall()
+        }
+        val unmarshalled = with(Parcel.obtain()) {
+            unmarshall(marshalled, 0, marshalled.size)
+            readTypedObject(ParcelableReferencable.Companion.CREATOR)
+        }
+
+        assertThat(unmarshalled?.actual).isEqualTo(entity)
+    }
+}

--- a/src_kt/java/arcs/crdt/CrdtSingleton.kt
+++ b/src_kt/java/arcs/crdt/CrdtSingleton.kt
@@ -26,7 +26,7 @@ class CrdtSingleton<T : Referencable>(
     initialVersion: VersionMap = VersionMap(),
     initialData: T? = null,
     singletonToCopy: CrdtSingleton<T>? = null
-) : CrdtModel<CrdtSingleton.Data<T>, CrdtSingleton.IOperation<T>, T?> {
+) : CrdtModel<Data<T>, CrdtSingleton.IOperation<T>, T?> {
     override val versionMap: VersionMap
         get() = set._data.versionMap.copy()
     private var set: CrdtSet<T>

--- a/third_party/java/jsr305_annotations/BUILD
+++ b/third_party/java/jsr305_annotations/BUILD
@@ -1,0 +1,8 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+alias(
+    name = "jsr305_annotations",
+    actual = "@maven//:com_google_code_findbugs_jsr305",
+)


### PR DESCRIPTION
Added Parcelable implementation of CrdtSet.

Also implemented the skeleton of ParcelableReferencable, plus the impl of a single Referencable subclass: RawEntity. Shouldn't be hard to add extra ones for the other subclasses.