### PR TITLE
Refine sed command to work on osx and linux

### DIFF
--- a/shells/pipes-shell/web/deploy/android_deploy.sh
+++ b/shells/pipes-shell/web/deploy/android_deploy.sh
@@ -17,6 +17,10 @@ cp source/index.html "$OUT_DIR/index.html"
 
 # Arcs cache manager and versioning
 # Must be done at the last step to ensure the correct $OUT_DIR/** checksum
+# OSX needs explicit backup extension for sed command while Linux does not.
+# For compatibility, explicitly specify backup file as cache-mgr-sw.js.tmp
+# that gets deleted after patching cache-mgr-sw.js.
 cp -fR ../cache-mgr*.js $OUT_DIR/
-sed -i "s/__ARCS_MD5__/$(tar -cf - $OUT_DIR | shasum | cut -d' ' -f1)/g" \
+sed -i'.tmp' "s/__ARCS_MD5__/$(tar -cf - $OUT_DIR | shasum | cut -d' ' -f1)/g" \
   $OUT_DIR/cache-mgr-sw.js
+rm -f $OUT_DIR/cache-mgr-sw.js.tmp

--- a/shells/pipes-shell/web/deploy/deploy.sh
+++ b/shells/pipes-shell/web/deploy/deploy.sh
@@ -13,6 +13,10 @@ cp -fR ../../../lib/build/worker.js dist/
 npx webpack --display=errors-only
 # Arcs cache manager and versioning
 # Must be done at the last step to ensure the correct dist/** checksum
+# OSX needs explicit backup extension for sed command while Linux does not.
+# For compatibility, explicitly specify backup file as cache-mgr-sw.js.tmp
+# that gets deleted after patching cache-mgr-sw.js.
 cp -fR ../cache-mgr*.js dist/
-sed -i "s/__ARCS_MD5__/$(tar -cf - dist | shasum | cut -d' ' -f1)/g" \
+sed -i'.tmp' "s/__ARCS_MD5__/$(tar -cf - dist | shasum | cut -d' ' -f1)/g" \
   dist/cache-mgr-sw.js
+rm -f dist/cache-mgr-sw.js.tmp


### PR DESCRIPTION
osx need sed -i 'backup_file_extension' while linux doesn't need.
The way-out here is always to create a backup file then delete it after patching cache-mgr-sw.js  