### PR TITLE
No shopt available on travis for mv .* files.

### DIFF
--- a/tools/deploy
+++ b/tools/deploy
@@ -5,4 +5,4 @@ npm run build:typedoc
 # Track Version
 git log -n 1 > VERSION
 # Move deployment artifacts to project root
-(shopt -s dotglob; mv tools/deployment/* .)
+mv tools/deployment/* tools/deployment/.* .


### PR DESCRIPTION
Part of https://github.com/PolymerLabs/arcs/pull/4106. Fix following failure of https://github.com/PolymerLabs/arcs/pull/4124 due to Travis not having shopt available for whatever reason not yet further investigated.