### PR TITLE
Even more porting from the old syntax to the new

### DIFF
--- a/shells/dev-shell/index.js
+++ b/shells/dev-shell/index.js
@@ -60,8 +60,8 @@ function init() {
 import 'https://$particles/Tutorial/Javascript/1_HelloWorld/HelloWorld.arcs'
 
 schema Data
-  Number num
-  Text txt
+  num: Number
+  txt: Text
 
 resource DataResource
   start
@@ -70,13 +70,13 @@ resource DataResource
 store DataStore of Data in DataResource
 
 particle P in 'a.js'
-  consume root
-  in Data data
+  root: consumes Slot
+  data: reads Data
 
 recipe
-  map DataStore as h0
+  h0: map DataStore
   P
-    data <- h0`;
+    data: reads h0`;
 
     const exampleParticle = `
 defineParticle(({SimpleParticle, html, log}) => {

--- a/src/planning/strategies/tests/match-recipe-by-verb-test.ts
+++ b/src/planning/strategies/tests/match-recipe-by-verb-test.ts
@@ -18,7 +18,7 @@ import {StrategyTestHelper} from '../../testing/strategy-test-helper.js';
 import {Flags} from '../../../runtime/flags.js';
 
 describe('MatchRecipeByVerb', () => {
-  it('SLANDLES SYNTAX removes a particle and adds a recipe', Flags.withPostSlandlesSyntax(async () => {
+  it('removes a particle and adds a recipe', async () => {
     const manifest = await Manifest.parse(`
       recipe
         &jump
@@ -45,40 +45,9 @@ describe('MatchRecipeByVerb', () => {
     assert.lengthOf(results, 1);
     assert.isEmpty(results[0].result.particles);
     assert.deepEqual(results[0].result.toString(), 'recipe &jump\n  JumpingBoots.e: reads NuclearReactor.e\n  JumpingBoots.f: reads FootFactory.f');
-  }));
+  });
 
-  // TODO(jopra): Remove once slandles unification syntax is implemented.
-  it('removes a particle and adds a recipe', Flags.withPreSlandlesSyntax(async () => {
-    const manifest = await Manifest.parse(`
-      recipe
-        &jump
-
-      schema Feet
-      schema Energy
-
-      particle JumpingBoots in 'A.js'
-        in Feet f
-        in Energy e
-      particle FootFactory in 'B.js'
-        out Feet f
-      particle NuclearReactor in 'C.js'
-        out Energy e
-
-      recipe &jump
-        JumpingBoots.f <- FootFactory.f
-        JumpingBoots.e <- NuclearReactor.e
-    `);
-
-    const arc = StrategyTestHelper.createTestArc(manifest);
-    const generated = [{result: manifest.recipes[0], score: 1}];
-    const mrv = new MatchRecipeByVerb(arc);
-    const results = await mrv.generateFrom(generated);
-    assert.lengthOf(results, 1);
-    assert.isEmpty(results[0].result.particles);
-    assert.deepEqual(results[0].result.toString(), 'recipe &jump\n  JumpingBoots.e <- NuclearReactor.e\n  JumpingBoots.f <- FootFactory.f');
-  }));
-
-  it('SLANDLES SYNTAX plays nicely with constraints', Flags.withPostSlandlesSyntax(async () => {
+  it('plays nicely with constraints', async () => {
     const manifest = await Manifest.parse(`
       schema S
       particle P in 'A.js'
@@ -109,52 +78,18 @@ describe('MatchRecipeByVerb', () => {
     p: writes handle0
   Q as particle1
     q: reads handle0`);
-  }));
-
-  // TODO(jopra): Remove once slandles unification syntax is implemented.
-  it('plays nicely with constraints', Flags.withPreSlandlesSyntax(async () => {
-    const manifest = await Manifest.parse(`
-      schema S
-      particle P in 'A.js'
-        out S p
-      particle Q in 'B.js'
-        in S q
-
-      recipe
-        P.p -> Q.q
-        &a
-
-      recipe &a
-        P
-    `);
-
-    const arc = StrategyTestHelper.createTestArc(manifest);
-    const generated = [{result: manifest.recipes[0], score: 1}];
-    const mrv = new MatchRecipeByVerb(arc);
-    let results = await mrv.generateFrom(generated);
-    assert.lengthOf(results, 1);
-    const cctc = new ConvertConstraintsToConnections(arc);
-    results = await cctc.generateFrom(results);
-    assert.lengthOf(results, 1);
-    assert.deepEqual(results[0].result.toString(),
-`recipe &a
-  create as handle0 // S {}
-  P as particle0
-    p -> handle0
-  Q as particle1
-    q <- handle0`);
-  }));
+  });
 
   const basicHandlesContraintsManifest = `
       particle P in 'A.js'
-        out S {} a
+        a: writes S {}
 
       particle Q in 'B.js'
-        in S {} a
-        out S {} b
+        a: reads S {}
+        b: writes S {}
 
       particle R in 'C.js'
-        in S {} c
+        c: reads S {}
 
       recipe &verb
         P
@@ -218,7 +153,7 @@ ${recipesManifest}`);
     assert.lengthOf(results, 4);
   });
 
-  it('SLANDLES SYNTAX listens to handle constraints - out connection', Flags.withPostSlandlesSyntax(async () => {
+  it('listens to handle constraints - out connection', async () => {
     const results = await slandlesSyntaxGeneratePlans(`
       recipe
         &verb
@@ -227,21 +162,9 @@ ${recipesManifest}`);
     assert.lengthOf(results[0].result.particles, 1);
     assert.strictEqual(results[0].result.particles[0].name, 'P');
     assert.lengthOf(results[1].result.particles, 2);
-  }));
+  });
 
-  // TODO(jopra): Remove once slandles unification syntax is implemented.
-  it('listens to handle constraints - out connection', Flags.withPreSlandlesSyntax(async () => {
-    const results = await generatePlans(`
-      recipe
-        &verb
-          a ->`);
-    assert.lengthOf(results, 2);
-    assert.lengthOf(results[0].result.particles, 1);
-    assert.strictEqual(results[0].result.particles[0].name, 'P');
-    assert.lengthOf(results[1].result.particles, 2);
-  }));
-
-  it('SLANDLES SYNTAX listens to handle constraints - in connection', Flags.withPostSlandlesSyntax(async () => {
+  it('listens to handle constraints - in connection', async () => {
     const results = await slandlesSyntaxGeneratePlans(`
       recipe
         &verb
@@ -250,21 +173,9 @@ ${recipesManifest}`);
     assert.lengthOf(results[1].result.particles, 1);
     assert.strictEqual(results[1].result.particles[0].name, 'Q');
     assert.lengthOf(results[0].result.particles, 2);
-  }));
+  });
 
-  // TODO(jopra): Remove once slandles unification syntax is implemented.
-  it('listens to handle constraints - in connection', Flags.withPreSlandlesSyntax(async () => {
-    const results = await generatePlans(`
-      recipe
-        &verb
-          a <-`);
-    assert.lengthOf(results, 2);
-    assert.lengthOf(results[1].result.particles, 1);
-    assert.strictEqual(results[1].result.particles[0].name, 'Q');
-    assert.lengthOf(results[0].result.particles, 2);
-  }));
-
-  it('SLANDLES SYNTAX listens to handle constraints - both connection', Flags.withPostSlandlesSyntax(async () => {
+  it('listens to handle constraints - both connection', async () => {
     const results = await slandlesSyntaxGeneratePlans(`
       recipe
         &verb
@@ -275,23 +186,9 @@ ${recipesManifest}`);
     assert.lengthOf(results[1].result.particles, 1);
     assert.strictEqual(results[1].result.particles[0].name, 'Q');
     assert.lengthOf(results[0].result.particles, 2);
-  }));
+  });
 
-  // TODO(jopra): Remove once slandles unification syntax is implemented.
-  it('listens to handle constraints - both connection', Flags.withPreSlandlesSyntax(async () => {
-    const results = await generatePlans(`
-      recipe
-        &verb
-          a <-
-          b ->
-      `);
-    assert.lengthOf(results, 2);
-    assert.lengthOf(results[1].result.particles, 1);
-    assert.strictEqual(results[1].result.particles[0].name, 'Q');
-    assert.lengthOf(results[0].result.particles, 2);
-  }));
-
-  it('SLANDLES SYNTAX listens to handle constraints - handle', Flags.withPostSlandlesSyntax(async () => {
+  it('listens to handle constraints - handle', async () => {
     const results = await slandlesSyntaxGeneratePlans(`
       recipe
         handle0: create
@@ -300,18 +197,8 @@ ${recipesManifest}`);
       `);
     assert.lengthOf(results, 3);
     assert.deepEqual([['P'], ['P', 'Q'], ['Q']], results.map(r => r.result.particles.map(p => p.name)));
-  }));
-  // TODO(jopra): Remove once slandles unification syntax is implemented.
-  it('listens to handle constraints - handle', Flags.withPreSlandlesSyntax(async () => {
-    const results = await generatePlans(`
-      recipe
-        create as handle0
-        &verb
-          * -> handle0
-      `);
-    assert.lengthOf(results, 3);
-    assert.deepEqual([['P'], ['P', 'Q'], ['Q']], results.map(r => r.result.particles.map(p => p.name)));
-  }));
+  });
+
   it('listens to slot constraints', async () => {
     const manifest = await Manifest.parse(`
       particle P in 'A.js'
@@ -365,7 +252,8 @@ ${recipesManifest}`);
     assert.strictEqual(results[0].result.particles[0].name, 'P');
     assert.lengthOf(results[1].result.particles, 2);
   });
-  it('SLANDLES SYNTAX carries handle assignments across verb substitution', Flags.withPostSlandlesSyntax(async () => {
+
+  it('carries handle assignments across verb substitution', async () => {
     const manifest = await Manifest.parse(`
 
       particle P in 'A.js'
@@ -394,39 +282,9 @@ ${recipesManifest}`);
     assert.strictEqual(recipe.particles[0].connections.a.handle, recipe.particles[1].connections.b.handle);
     assert.strictEqual(recipe.particles[0].connections.a.handle.connections[0].particle, recipe.particles[0]);
     assert.strictEqual(recipe.particles[1].connections.b.handle.connections[1].particle, recipe.particles[1]);
-  }));
-  // TODO(jopra): Remove once slandles unification syntax is implemented.
-  it('carries handle assignments across verb substitution', Flags.withPreSlandlesSyntax(async () => {
-    const manifest = await Manifest.parse(`
+  });
 
-      particle P in 'A.js'
-        in S {} a
-
-      particle Q in 'B.js'
-        out S {} b
-
-      recipe &verb
-        P
-
-      recipe
-        create as handle0
-        &verb
-          a <- handle0
-        Q
-          b -> handle0
-    `);
-
-    const arc = StrategyTestHelper.createTestArc(manifest);
-    const generated = [{result: manifest.recipes[1], score: 1}];
-    const mrv = new MatchRecipeByVerb(arc);
-    const results = await mrv.generateFrom(generated);
-    assert.lengthOf(results, 1);
-    const recipe = results[0].result;
-    assert.strictEqual(recipe.particles[0].connections.a.handle, recipe.particles[1].connections.b.handle);
-    assert.strictEqual(recipe.particles[0].connections.a.handle.connections[0].particle, recipe.particles[0]);
-    assert.strictEqual(recipe.particles[1].connections.b.handle.connections[1].particle, recipe.particles[1]);
-  }));
-  it('SLANDLES SYNTAX carries handle assignments across verb substitution with generic binding', Flags.withPostSlandlesSyntax(async () => {
+  it('carries handle assignments across verb substitution with generic binding', async () => {
     const manifest = await Manifest.parse(`
 
       particle P in 'A.js'
@@ -455,40 +313,9 @@ ${recipesManifest}`);
     assert.strictEqual(recipe.particles[0].connections.a.handle, recipe.particles[1].connections.b.handle);
     assert.strictEqual(recipe.particles[0].connections.a.handle.connections[0].particle, recipe.particles[0]);
     assert.strictEqual(recipe.particles[1].connections.b.handle.connections[1].particle, recipe.particles[1]);
-  }));
-  // TODO(jopra): Remove once slandles unification syntax is implemented.
-  it('carries handle assignments across verb substitution with generic binding', Flags.withPreSlandlesSyntax(async () => {
-    const manifest = await Manifest.parse(`
+  });
 
-      particle P in 'A.js'
-        in S {} a
-
-      particle Q in 'B.js'
-        out S {} b
-
-      recipe &verb
-        P
-
-      recipe
-        create as handle0
-        &verb
-          * <- handle0
-        Q
-          b -> handle0
-    `);
-
-    const arc = StrategyTestHelper.createTestArc(manifest);
-    const generated = [{result: manifest.recipes[1], score: 1}];
-    const mrv = new MatchRecipeByVerb(arc);
-    const results = await mrv.generateFrom(generated);
-    assert.lengthOf(results, 1);
-    const recipe = results[0].result;
-    assert.strictEqual(recipe.particles[0].connections.a.handle, recipe.particles[1].connections.b.handle);
-    assert.strictEqual(recipe.particles[0].connections.a.handle.connections[0].particle, recipe.particles[0]);
-    assert.strictEqual(recipe.particles[1].connections.b.handle.connections[1].particle, recipe.particles[1]);
-  }));
-
-  it('SLANDLES SYNTAX selects the appropriate generic binding when handle assignments carry type information', Flags.withPostSlandlesSyntax(async () => {
+  it('selects the appropriate generic binding when handle assignments carry type information', async () => {
     const manifest = await Manifest.parse(`
 
       particle O in 'Z.js'
@@ -526,7 +353,7 @@ ${recipesManifest}`);
     assert.strictEqual(particleP.connections.a.handle, particleQ.connections.b.handle);
     assert.strictEqual(particleP.connections.a.handle.connections[0].particle, particleP);
     assert.strictEqual(particleQ.connections.b.handle.connections[1].particle, particleQ);
-  }));
+  });
 
   it('carries slot assignments across verb substitution', async () => {
     const manifest = await Manifest.parse(`

--- a/src/runtime/manual_tests/firebase-test.ts
+++ b/src/runtime/manual_tests/firebase-test.ts
@@ -154,7 +154,7 @@ describe('firebase', function() {
       // related to FirebaseBackingStore.
       const manifest = await Manifest.parse(`
         schema Bar1
-          Text data
+          data: Text
       `);
       const barType = new EntityType(manifest.schemas.Bar1);
       const arc = new Arc({id: ArcId.newForTest('test'), loader: new Loader(), context: manifest});
@@ -341,7 +341,7 @@ describe('firebase', function() {
       // related to FirebaseBackingStore.
       const manifest = await Manifest.parse(`
         schema Bar2
-          Text data
+          data: Text
       `);
       const barType = new EntityType(manifest.schemas.Bar2);
       const arc = new Arc({id: ArcId.newForTest('test'), loader: new Loader(), context: manifest});
@@ -405,7 +405,7 @@ describe('firebase', function() {
     it('supports get, store and remove (including concurrently)', async () => {
       const manifest = await Manifest.parse(`
         schema Bar
-          Text data
+          data: Text
       `);
       const arc = new Arc({id: ArcId.newForTest('test'), loader: new Loader(), context: manifest});
       const storage = createStorage(arc.id);
@@ -481,7 +481,7 @@ describe('firebase', function() {
     it('supports version-stable streamed reads forwards', async () => {
       const manifest = await Manifest.parse(`
         schema Bar
-          Text data
+          data: Text
       `);
       const arc = new Arc({id: ArcId.newForTest('test'), loader: new Loader(), context: manifest});
       const storage = createStorage(arc.id);
@@ -558,7 +558,7 @@ describe('firebase', function() {
     it('supports version-stable streamed reads backwards', async () => {
       const manifest = await Manifest.parse(`
         schema Bar
-          Text data
+          data: Text
       `);
       const arc = new Arc({id: ArcId.newForTest('test'), loader: new Loader(), context: manifest});
       const storage = createStorage(arc.id);

--- a/src/runtime/tests/artifacts/Products/test/ProductFilter.manifest
+++ b/src/runtime/tests/artifacts/Products/test/ProductFilter.manifest
@@ -9,13 +9,13 @@
 import '../Product.schema'
 
 interface HostedParticleInterface
-  in Product *
-  out Product *
+  reads Product
+  writes Product
 
 // TODO: This particle should use generic handle type and slot name.
 particle ProductFilter in 'source/ProductFilter.js'
-  host HostedParticleInterface hostedParticle
-  in [Product] products
-  out [Product] results
+  hostedParticle: hosts HostedParticleInterface
+  products: reads [Product]
+  results: writes [Product]
   description `show filtered products`
     results `filtered list of products`

--- a/src/runtime/tests/artifacts/Products/test/ProductIsBook.manifest
+++ b/src/runtime/tests/artifacts/Products/test/ProductIsBook.manifest
@@ -9,7 +9,7 @@
 import '../Product.schema'
 
 particle ProductIsBook in 'source/ProductIsBook.js'
-  in Product product
-  out Product book
+  product: reads Product
+  book: writes Product
   description `filter books`
     book `book`

--- a/src/runtime/tests/artifacts/Products/test/source/ProductFilter.js
+++ b/src/runtime/tests/artifacts/Products/test/source/ProductFilter.js
@@ -42,11 +42,11 @@ defineParticle(({Particle}) => {
         const recipe = Particle.buildManifest`
           ${this._hostedParticle}
           recipe
-            use '${productHandle._id}' as handle1
-            use '${resultHandle._id}' as handle2
+            handle1: use '${productHandle._id}'
+            handle2: use '${resultHandle._id}'
             ${this._hostedParticle.name}
-              ${this._hostedParticle.handleConnections[0].name} <- handle1
-              ${this._hostedParticle.handleConnections[1].name} -> handle2
+              ${this._hostedParticle.handleConnections[0].name}: reads handle1
+              ${this._hostedParticle.handleConnections[1].name}: writes handle2
           `;
 
         await this._arc.loadRecipe(recipe, this);

--- a/src/runtime/tests/artifacts/transformations/test-multiplex-slots-particle.js
+++ b/src/runtime/tests/artifacts/transformations/test-multiplex-slots-particle.js
@@ -47,18 +47,18 @@ defineParticle(({TransformationDomParticle}) => {
         const slotId = await arc.createSlot(this, slotName);
         const recipe = `
           schema Foo
-            Text value
+            value: Text
 
           particle ${hostedParticle.name} in '${hostedParticle.implFile}'
-            in Foo foo
-            consume ${hostedSlotName}
+            foo: reads Foo
+            ${hostedSlotName}: consumes Slot
 
           recipe
-            use '${fooHandle._id}' as handle1
-            slot '${slotId}' as slot1
+            handle1: use '${fooHandle._id}'
+            slot1: slot '${slotId}'
             ${hostedParticle.name}
-              foo <- handle1
-              consume ${hostedSlotName} as slot1
+              foo: reads handle1
+              ${hostedSlotName}: consumes slot1
         `;
 
         try {

--- a/src/runtime/tests/particle-execution-context-test.ts
+++ b/src/runtime/tests/particle-execution-context-test.ts
@@ -20,14 +20,14 @@ describe('Particle Execution Context', () => {
   it('substitutes slot names for model references', async () => {
     const context = await Manifest.parse(`
       particle A in 'A.js'
-        consume root
-          provide detail
-          provide annotation
+        root: consumes Slot
+          detail: provides? Slot
+          annotation: provides? Slot
 
       recipe
-        slot 'rootslotid-root' as slot0
+        slot0: slot 'rootslotid-root'
         A
-          consume root as slot0`);
+          root: consumes slot0`);
     const loader = new StubLoader({
       'A.js': `defineParticle(({DomParticle}) => {
         return class extends DomParticle {

--- a/src/runtime/tests/particle-interface-loading-test.ts
+++ b/src/runtime/tests/particle-interface-loading-test.ts
@@ -45,11 +45,11 @@ describe('particle interface loading', () => {
                     \${model}
 
                     recipe
-                      use \${this.inHandle} as handle1
-                      use \${this.outHandle} as handle2
+                      handle1: use \${this.inHandle}
+                      handle2: use \${this.outHandle}
                       \${model.name}
-                        foo <- handle1
-                        bar -> handle2
+                        foo: reads handle1
+                        bar: writes handle2
                   \`);
                 }
               }
@@ -125,12 +125,12 @@ describe('particle interface loading', () => {
       import './src/runtime/tests/artifacts/test-particles.manifest'
 
       recipe
-        create as h0
-        create as h1
+        h0: create *
+        h1: create *
         OuterParticle
-          particle0 <- TestParticle
-          output -> h0
-          input <- h1
+          particle0: reads TestParticle
+          output: writes h0
+          input: reads h1
       `, {loader, fileName: './test.manifest'});
 
     const arc = new Arc({id: ArcId.newForTest('test'), context: manifest, loader});
@@ -159,19 +159,19 @@ describe('particle interface loading', () => {
   it('updates transformation particle on inner handle', async () => {
     const manifest = await Manifest.parse(`
       schema Foo
-        Text value
+        value: Text
       particle UpdatingParticle in 'updating-particle.js'
-        out Foo innerFoo
+        innerFoo: writes Foo
       interface TestInterface
-        out Foo *
+        writes Foo
       particle MonitoringParticle in 'monitoring-particle.js'
-        host TestInterface hostedParticle
-        out Foo foo
+        hostedParticle: hosts TestInterface
+        foo: writes Foo
       recipe
-        use as h0
+        h0: use *
         MonitoringParticle
-          foo = h0
-          hostedParticle = UpdatingParticle
+          foo: h0
+          hostedParticle: UpdatingParticle
     `);
     assert.lengthOf(manifest.recipes, 1);
     const recipe = manifest.recipes[0];
@@ -190,9 +190,9 @@ describe('particle interface loading', () => {
                 await this.arc.loadRecipe(Particle.buildManifest\`
                   \${model}
                   recipe
-                    use \${this.innerFooHandle} as h0
+                    h0: use \${this.innerFooHandle}
                     \${model.name}
-                      innerFoo = h0
+                      innerFoo: h0
                 \`);
               }
             }

--- a/src/runtime/tests/particle-interface-loading-with-slots-test.ts
+++ b/src/runtime/tests/particle-interface-loading-with-slots-test.ts
@@ -32,12 +32,12 @@ describe('particle interface loading with slots', () => {
       import './src/runtime/tests/artifacts/transformations/test-slots-particles.manifest'
 
       recipe
-        create as handle0
-        slot 'rootslotid-set-slotid-0' as slot0
+        handle0: create *
+        slot0: slot 'rootslotid-set-slotid-0'
         MultiplexSlotsParticle
-          particle0 = SingleSlotParticle
-          foos <- handle0
-          consume annotationsSet as slot0
+          particle0: SingleSlotParticle
+          foos: reads handle0
+          annotationsSet: consumes slot0
       `, {loader, fileName: ''});
     const recipe = manifest.recipes[0];
 

--- a/src/runtime/tests/recipe-resolver-test.ts
+++ b/src/runtime/tests/recipe-resolver-test.ts
@@ -30,7 +30,7 @@ describe('RecipeResolver', () => {
     const manifest = await buildManifest({
       manifest: `
       particle P in 'A.js'
-        consume root
+        root: consumes Slot
         modality dom
 
       recipe
@@ -57,8 +57,8 @@ describe('RecipeResolver', () => {
     const manifest = await buildManifest({
       manifest: `
       particle P in 'A.js'
-        out * {Text value} text
-        consume root
+        text: writes * {value: Text}
+        root: consumes Slot
         modality dom
 
       recipe

--- a/src/runtime/tests/recipe/particle-test.ts
+++ b/src/runtime/tests/recipe/particle-test.ts
@@ -17,16 +17,16 @@ describe('Recipe Particle', () => {
   it('cloning maints type variable mapping', async () => {
     const manifest = await Manifest.parse(`
       interface HostedInterface
-        in ~a *
+        reads ~a
 
       particle Multiplexer
-        host HostedInterface hostedParticle
-        in [~a] list
+        hostedParticle: hosts HostedInterface
+        list: reads [~a]
 
       recipe
-        create as items
+        items: create *
         Multiplexer
-          list = items
+          list: items
     `);
 
     let recipe = manifest.recipes[0];
@@ -59,9 +59,9 @@ describe('Recipe Particle', () => {
     const particleManifest = `
       schema Thing
       particle P
-        out? Thing thing0
-          out Thing thing1
-            out Thing thing2
+        thing0: writes? Thing
+          thing1: writes Thing
+            thing2: writes Thing
     `;
     const verifyRecipe = async (recipeManifest, expectedResolved) => {
       const manifest = await Manifest.parse(`${particleManifest}${recipeManifest}`);
@@ -75,17 +75,17 @@ describe('Recipe Particle', () => {
     `, true);
     await verifyRecipe(`
       recipe
-        create as handle0
+        handle0: create *
         P
-          thing0 = handle0
+          thing0: handle0
     `, false);
     await verifyRecipe(`
       recipe
-        create as handle0
-        create as handle1
+        handle0: create *
+        handle1: create *
         P
-          thing0 = handle0
-          thing1 = handle1
+          thing0: handle0
+          thing1: handle1
     `, false);
   });
 });

--- a/src/runtime/tests/reference-test.ts
+++ b/src/runtime/tests/reference-test.ts
@@ -26,17 +26,17 @@ describe('references', () => {
           value: Text
 
         particle Referencer in 'referencer.js'
-          in Result inResult
-          out Reference<Result> outResult
+          inResult: reads Result
+          outResult: writes Reference<Result>
 
         particle Dereferencer in 'dereferencer.js'
-          in Reference<Result> inResult
-          out Result outResult
+          inResult: reads Reference<Result>
+          outResult: writes Result
 
         recipe
-          create 'input:1' as handle0
-          create 'reference:1' as handle1
-          create 'output:1' as handle2
+          handle0: create 'input:1'
+          handle1: create 'reference:1'
+          handle2: create 'output:1'
           Referencer
             inResult: reads handle0
             outResult: writes handle1
@@ -60,12 +60,12 @@ describe('references', () => {
           value: Text
 
         particle Dereferencer in 'dereferencer.js'
-          in Reference<Result> inResult
-          out Result outResult
+          inResult: reads Reference<Result>
+          outResult: writes Result
 
         recipe
-          create 'input:1' as handle0
-          create 'output:1' as handle1
+          handle0: create 'input:1'
+          handle1: create 'output:1'
           Dereferencer
             inResult: reads handle0
             outResult: writes handle1
@@ -117,12 +117,12 @@ describe('references', () => {
           value: Text
 
         particle Dereferencer in 'dereferencer.js'
-          in [Reference<Result>] inResult
-          out [Result] outResult
+          inResult: reads [Reference<Result>]
+          outResult: writes [Result]
 
         recipe
-          create 'input:1' as handle0
-          create 'output:1' as handle1
+          handle0: create 'input:1'
+          handle1: create 'output:1'
           Dereferencer
             inResult: reads handle0
             outResult: writes handle1
@@ -181,12 +181,12 @@ describe('references', () => {
           value: Text
 
         particle Referencer in 'referencer.js'
-          in Result inResult
-          out Reference<Result> outResult
+          inResult: reads Result
+          outResult: writes Reference<Result>
 
         recipe
-          create 'input:1' as handle0
-          create 'output:1' as handle1
+          handle0: create 'input:1'
+          handle1: create 'output:1'
           Referencer
             inResult: reads handle0
             outResult: writes handle1
@@ -236,12 +236,12 @@ describe('references', () => {
           value: Text
 
         particle ExtractReference in 'extractReference.js'
-          in Foo {Reference<Result> result} referenceIn
-          out Result rawOut
+          referenceIn: reads Foo {result: Reference<Result>}
+          rawOut: writes Result
 
         recipe
-          create 'input:1' as handle0
-          create 'output:1' as handle1
+          handle0: create 'input:1'
+          handle1: create 'output:1'
           ExtractReference
             referenceIn: reads handle0
             rawOut: writes handle1
@@ -303,18 +303,18 @@ describe('references', () => {
           value: Text
 
         particle Referencer in 'referencer.js'
-          in [Result] inResult
-          in Foo {Reference<Result> result, Text shortForm} inFoo
-          inout [Foo {Reference<Result> result, Text shortForm}] outResult
+          inResult: reads [Result]
+          inFoo: reads Foo {result: Reference<Result>, shortForm: Text}
+          outResult: reads writes [Foo {result: Reference<Result>, shortForm: Text}]
 
         recipe
-          create 'input:1' as handle0
-          create 'input:2' as handle1
-          create 'output:1' as handle2
+          handle0: create 'input:1'
+          handle1: create 'input:2'
+          handle2: create 'output:1'
           Referencer
             inResult: reads handle0
             inFoo: reads handle1
-            outResult = handle2
+            outResult: handle2
       `,
       'referencer.js': `
         defineParticle(({Particle, Reference}) => {
@@ -409,12 +409,12 @@ describe('references', () => {
           value: Text
 
         particle ExtractReferences in 'extractReferences.js'
-          in Foo {[Reference<Result>] result} referenceIn
-          out [Result] rawOut
+          referenceIn: reads Foo {result: [Reference<Result>]}
+          rawOut: writes [Result]
 
         recipe
-          create 'input:1' as handle0
-          create 'output:1' as handle1
+          handle0: create 'input:1'
+          handle1: create 'output:1'
           ExtractReferences
             referenceIn: reads handle0
             rawOut: writes handle1
@@ -475,12 +475,12 @@ describe('references', () => {
           value: Text
 
         particle ConstructReferenceCollection in 'constructReferenceCollection.js'
-          out Foo {[Reference<Result>] result} referenceOut
-          in [Result] rawIn
+          referenceOut: writes Foo {result: [Reference<Result>]}
+          rawIn: reads [Result]
 
         recipe
-          create 'input:1' as handle0
-          create 'output:1' as handle1
+          handle0: create 'input:1'
+          handle1: create 'output:1'
           ConstructReferenceCollection
             referenceOut: writes handle0
             rawIn: reads handle1

--- a/src/runtime/tests/schema-test.ts
+++ b/src/runtime/tests/schema-test.ts
@@ -37,22 +37,22 @@ describe('schema', () => {
       'Product.schema': `
           import './src/runtime/tests/artifacts/Things/Thing.schema'
           schema Product extends Thing
-            Text category
-            Text seller
-            Text price
-            Number shipDays
-            Boolean isReal
+            category: Text
+            seller: Text
+            price: Text
+            shipDays: Number
+            isReal: Boolean
 
           schema Animal extends Thing
-            Boolean isReal
+            isReal: Boolean
 
           schema Person
-            Text name
-            Text surname
-            Number price
+            name: Text
+            surname: Text
+            price: Number
 
           schema AlienLife
-            Boolean isBasedOnDna
+            isBasedOnDna: Boolean
           `
     });
   });
@@ -194,8 +194,8 @@ describe('schema', () => {
   it('enforces rules when storing union types', async () => {
     const manifest = await Manifest.parse(`
       schema Unions
-        (Text or Number) u1
-        (URL or Number or Boolean) u2`);
+        u1: (Text or Number)
+        u2: (URL or Number or Boolean)`);
     const Unions = manifest.findSchemaByName('Unions').entityClass();
     const unions = new Unions({u1: 'foo', u2: true});
     assert.strictEqual(unions.u1, 'foo');
@@ -232,8 +232,8 @@ describe('schema', () => {
       schema ReferencedTwo
         bar: Number
       schema References
-        Reference<ReferencedOne> one
-        Reference<ReferencedTwo> two`);
+        one: Reference<ReferencedOne>
+        two: Reference<ReferencedTwo>`);
 
     const References = manifest.findSchemaByName('References').entityClass();
 
@@ -259,7 +259,7 @@ describe('schema', () => {
   it('enforces rules when storing collection types', async () => {
     const manifest = await Manifest.parse(`
       schema Collections
-        [Reference<Foo {Text value}>] collection
+        collection: [Reference<Foo {value: Text}>]
     `);
 
     const Collections = manifest.findSchemaByName('Collections').entityClass();
@@ -411,7 +411,7 @@ describe('schema', () => {
   it('handles Bytes fields', async () => {
     const manifest = await Manifest.parse(`
       schema Buffer
-        Bytes data`);
+        data: Bytes`);
     const Buffer = manifest.findSchemaByName('Buffer').entityClass();
     const b1 = new Buffer({data: Uint8Array.from([12, 34, 56])});
     assert.deepEqual(b1.data, Uint8Array.from([12, 34, 56]));
@@ -422,16 +422,16 @@ describe('schema', () => {
   it('handles Schema Catalogue syntax', async () => {
     const manifest = await Manifest.parse(`
       alias schema * as Base
-        Text name
-        Text phoneNumber
-        URL website
+        name: Text
+        phoneNumber: Text
+        website: URL
         
       schema Person extends Base
-        Text jobTitle
-        Number age
+        jobTitle: Text
+        age: Number
       
       particle P
-        in Person {name, age, Bytes custom} person`);
+        person: reads Person {name, age, custom: Bytes}`);
 
     const particle = manifest.particles[0];
     const connection = particle.handleConnections[0];
@@ -447,10 +447,10 @@ describe('schema', () => {
   it('handles multi named aliased schemas with extensions', async () => {
     const manifest = await Manifest.parse(`
       alias schema Event Occurrence as EventAlias
-        Text name
+        name: Text
         
       schema Accident extends EventAlias
-        Number financialCost
+        financialCost: Number
       
       schema Crisis extends Accident`);
 
@@ -478,7 +478,7 @@ describe('schema', () => {
   it('parses anonymous inline schemas', async () => {
     const manifest = await Manifest.parse(`
       particle P
-        in * {} thing`);
+        thing: reads * {}`);
 
     const particle = manifest.particles[0];
     const connection = particle.handleConnections[0];

--- a/src/tools/tests/schema2graph-test.ts
+++ b/src/tools/tests/schema2graph-test.ts
@@ -38,8 +38,8 @@ describe('schema2graph', () => {
   it('empty graph', async () => {
     const manifest = await Manifest.parse(`
       particle E
-        consume root
-          provide tile
+        root: consumes Slot
+          tile: provides Slot
     `);
     const graph = new SchemaGraph(manifest.particles[0]);
     assert.isEmpty([...graph.walk()]);
@@ -110,11 +110,11 @@ describe('schema2graph', () => {
         p2: reads * {a: Text, c: Text}              //  3   4
         p3: reads * {a: Text, b: Text, d: Text}
         p4: reads * {a: Text, c: Text, e: Text}
-        v5: reads * {URL a}                         //  5   6
-        v6: reads * {URL c}                         //   7 8
-        v7: reads * {URL a, URL b}                  //    9
-        v8: reads * {URL c, URL d}
-        v9: reads * {URL a, URL b, URL c, URL d}
+        v5: reads * {a: URL}                        //  5   6
+        v6: reads * {c: URL}                        //   7 8
+        v7: reads * {a: URL, b: URL}                //    9
+        v8: reads * {c: URL, d: URL}
+        v9: reads * {a: URL, b: URL, c: URL, d: URL}
     `);
     const res = convert(new SchemaGraph(manifest.particles[0]));
 

--- a/src/tools/tests/schema2wasm-test.ts
+++ b/src/tools/tests/schema2wasm-test.ts
@@ -50,9 +50,9 @@ describe('schema2wasm', () => {
   it('generates one class per unique schema', async () => {
     const manifest = await Manifest.parse(`\
       particle Foo
-        in * {Text txt} input1
-        out Reference<* {Text txt, Number num}> input2
-        inout [Site {URL url, Reference<* {Text txt}> ref}] input3
+        input1: reads * {txt: Text}
+        input2: writes Reference<* {txt: Text, num: Number}>
+        input3: reads writes [Site {url: URL, ref: Reference<* {txt: Text}>}]
     `);
     const mock = new Schema2Mock(manifest);
     assert.deepStrictEqual(mock.res, {
@@ -65,7 +65,7 @@ describe('schema2wasm', () => {
   it('supports all primitive types', async () => {
     const manifest = await Manifest.parse(`\
       particle Foo
-        in * {Text txt, URL url, Number num, Boolean flg} input
+        input: reads * {txt: Text, url: URL, num: Number, flg: Boolean}
     `);
     const mock = new Schema2Mock(manifest);
     assert.deepStrictEqual(mock.res, {
@@ -76,8 +76,8 @@ describe('schema2wasm', () => {
   it('supports nested references with schema aliasing', async () => {
     const manifest = await Manifest.parse(`\
       particle Foo
-        in * {Text a, Reference<* {Text b}> r} h1
-        in * {Reference<* {Boolean f, Reference<* {Number x}> t}> s} h2
+        h1: reads * {a: Text, r: Reference<* {b: Text}>}
+        h2: reads * {s: Reference<* {f: Boolean, t: Reference<* {x: Number}>}>}
     `);
     const mock = new Schema2Mock(manifest);
     assert.deepStrictEqual(mock.res, {

--- a/src/tools/tests/test-data/invalid/__bundle_entry.arcs
+++ b/src/tools/tests/test-data/invalid/__bundle_entry.arcs
@@ -1,2 +1,2 @@
 schema Thing
-  Text name
+  name: Text


### PR DESCRIPTION
Restructured these changes into this PR as well as https://github.com/PolymerLabs/arcs/pull/4140 and https://github.com/PolymerLabs/arcs/pull/4141.

They should be independent but should allow us to flip the `parseBothSyntaxes` flag which will make the old syntax fully deprecated. There may be a few clean up PRs after this but I believe this to be the last of all the manifests that we actually test, there are unused manifests that will need to be cleaned up separately.