### PR TITLE
Remove support for the old syntax

### DIFF
--- a/src/runtime/flags.ts
+++ b/src/runtime/flags.ts
@@ -14,7 +14,7 @@ class FlagDefaults {
   static useNewStorageStack = false;
   // Enables the parsing of both pre and post slandles (unified) syntaxes.
   // Preslandles syntax is to be deprecated.
-  static parseBothSyntaxes = true;
+  static parseBothSyntaxes = false;
   // Use pre slandles syntax for parsing and toString by default.
   // If parseBothSyntaxes is off, this will set which syntax is enabled.
   static defaultToPreSlandlesSyntax = false;


### PR DESCRIPTION
Note: This should not be landed until we're sure that internal usage of Arcs has been switched to the new syntax.

Otherwise, this should allow clean up of the syntax flags and the old syntax code, along with dealing with some tech debt around capabilities/direction handling as well as internalizing the new direction names (currently we convert into the old syntax before usage in the type checker and runtime). 