### PR TITLE
Added buildifier to sigh lint

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "webpack-cli": "3.3.10"
   },
   "dependencies": {
+    "@bazel/buildifier": "0.29.0",
     "@tensorflow/tfjs": "1.3.1",
     "assert": "1.5.0",
     "circular-dependency-plugin": "5.2.0",

--- a/particles/Tutorial/Kotlin/Demo/BUILD
+++ b/particles/Tutorial/Kotlin/Demo/BUILD
@@ -18,9 +18,9 @@ arcs_kt_binary(
 )
 
 arcs_kt_binary(
-     name = "TTTHumanPlayer",
-     srcs = ["TTTHumanPlayer.kt"],
-     deps = [":game_schemas"],
+    name = "TTTHumanPlayer",
+    srcs = ["TTTHumanPlayer.kt"],
+    deps = [":game_schemas"],
 )
 
 arcs_kt_binary(

--- a/src_kt/javatests/arcs/crdt/internal/BUILD
+++ b/src_kt/javatests/arcs/crdt/internal/BUILD
@@ -16,8 +16,8 @@ load("//tools/build_defs/kotlin:rules.bzl", "kt_jvm_library")
         ),
         kt_jvm_library(
             name = "%sLib" % src_file[:-3],
-            srcs = [src_file],
             testonly = True,
+            srcs = [src_file],
             deps = [
                 "//src_kt/java/arcs/crdt",
                 "//src_kt/java/arcs/crdt/internal",

--- a/src_kt/javatests/arcs/util/BUILD
+++ b/src_kt/javatests/arcs/util/BUILD
@@ -44,8 +44,8 @@ java_test(
 
 kt_jvm_library(
     name = "Base64PerformanceTestLib",
-    srcs = ["Base64PerformanceTest.kt"],
     testonly = True,
+    srcs = ["Base64PerformanceTest.kt"],
     deps = [
         "//src_kt/java/arcs/util",
         "//third_party/java/junit",

--- a/tools/sigh.ts
+++ b/tools/sigh.ts
@@ -72,7 +72,7 @@ const steps: {[index: string]: ((args?: string[]) => boolean)[]} = {
   webpackTools: [peg, build, webpackTools],
   build: [peg, build],
   watch: [watch],
-  lint: [peg, build, lint, tslint],
+  lint: [peg, build, lint, tslint, buildifier],
   tslint: [peg, build, tslint],
   check: [check],
   clean: [clean],
@@ -535,6 +535,20 @@ function lint(args: string[]): boolean {
   }
 
   return report.errorCount === 0;
+}
+
+/** Runs buildifier on all BUILD files. */
+function buildifier(args: string[]): boolean {
+  const options = minimist(args, {
+    boolean: ['fix'],
+  });
+
+  const mode = options.fix ? '--mode=fix' : '--mode=check';
+  return saneSpawnSync('find', [
+    '.',
+    '-name', 'BUILD', '-o', '-name', 'BUILD.bazel', '-o', '-name', 'WORKSPACE',
+    '-exec', 'node_modules/@bazel/buildifier/buildifier.js', mode, '{}', '\\;'
+  ]);
 }
 
 function licenses(): boolean {

--- a/tools/sigh.ts
+++ b/tools/sigh.ts
@@ -14,7 +14,6 @@ const path = require('path');
 const minimist = require('minimist');
 const semver = require('semver');
 import {ChildProcess} from 'child_process';
-import {triggerAsyncId} from 'async_hooks';
 
 // Use saneSpawn[Sync] or saneSpawnSyncWithOutput instead, as the arguments to
 // child_process.spawn[Sync] calls must be massaged to be cross-platform.

--- a/tools/sigh.ts
+++ b/tools/sigh.ts
@@ -543,11 +543,12 @@ function buildifier(args: string[]): boolean {
     boolean: ['fix'],
   });
 
-  const mode = options.fix ? '--mode=fix' : '--mode=check';
+  const modeOpts = options.fix ? ['--lint=fix', '--mode=fix'] : ['--lint=warn', '--mode=check'];
+
   return saneSpawnSync('find', [
     '.',
-    '-name', 'BUILD', '-o', '-name', 'BUILD.bazel', '-o', '-name', 'WORKSPACE',
-    '-exec', 'node_modules/@bazel/buildifier/buildifier.js', mode, '{}', '\\;'
+    '-name', 'BUILD', '-o', '-name', 'BUILD.bazel', '-o', '-name', 'WORKSPACE', '-o', '-name', '*.bzl',
+    '-exec', 'node_modules/@bazel/buildifier/buildifier.js', ...modeOpts, '--warnings=-module-docstring,-bzl-visibility', '{}', '\\;'
   ]);
 }
 


### PR DESCRIPTION
This now lints all BUILD and WORKSPACE files with buildifier. Run `./tools/sigh lint --fix` to fix them automatically.

Also fixed WORKSPACE file, which had lint errors.

This is important for importing into google.