### PR TITLE
Stop using the `exports` property of kt_jvm_library

### DIFF
--- a/third_party/java/arcs/build_defs/internal/kotlin.bzl
+++ b/third_party/java/arcs/build_defs/internal/kotlin.bzl
@@ -51,19 +51,36 @@ def arcs_kt_binary(name, srcs = [], deps = [], visibility = None):
     )
 
 def kt_jvm_and_js_library(
-        name = None,
+        name,
         srcs = [],
         deps = [],
         visibility = None,
+        exports = [],
         **kwargs):
     """Simultaneously defines JVM and JS kotlin libraries.
     name: String; Name of the library
     srcs: List; List of sources
     deps: List; List of dependencies
+    exports: List; List of exported dependencies
     visibility: List; List of visibilities
     """
+
+    kt_name = name
+    js_name = name + "-js"
+
+    if exports:
+        # kt_jvm_library doesn't support the "exports" property. Instead, we
+        # will wrap it in a java_library rule and export everything that is
+        # needed from there.
+        kt_name = name + "-kt"
+        native.java_library(
+            name = name,
+            exports = exports + [kt_name],
+            visibility = visibility,
+        )
+
     kt_jvm_library(
-        name = name,
+        name = kt_name,
         srcs = srcs,
         deps = [_to_jvm_dep(dep) for dep in deps],
         visibility = visibility,
@@ -75,7 +92,7 @@ def kt_jvm_and_js_library(
         if "exports" in js_kwargs:
             js_kwargs.pop("exports")
         kt_js_library(
-            name = "%s-js" % name,
+            name = js_name,
             srcs = srcs,
             deps = [_to_js_dep(dep) for dep in deps],
             **js_kwargs


### PR DESCRIPTION
This isn't properly supported. Instead, we will generate a java_library
wrapper around the kotlin rule, and use that to export the libraries.
Kotlin libaries can happily depend on this java_library rule, they won't
notice it.

The js rule is unaffected.

Should fix copybara.