### PR TITLE
C++ wasm: improved API for handle declaration

### DIFF
--- a/particles/Native/Wasm/source/example.cc
+++ b/particles/Native/Wasm/source/example.cc
@@ -4,8 +4,6 @@
 class BasicParticle : public arcs::Particle {
 public:
   BasicParticle() {
-    registerHandle("foo", foo_);  // required for each handle declared in the manifest
-    registerHandle("bar", bar_);
     autoRender();  // automatically render once handles are ready, and then when updated
   }
 
@@ -26,9 +24,10 @@ public:
   }
 
   // Responding to UI events
-  void fireEvent(const std::string& slot_name, const std::string& handler, const arcs::Dictionary& eventData) override {
+  void fireEvent(const std::string& slot_name, const std::string& handler,
+                 const arcs::Dictionary& eventData) override {
     if (handler == "clicky") {
-      arcs::BasicParticle_Foo copy = arcs::clone_entity(foo_.get());  // does not copy internal entity id
+      arcs::BasicParticle_Foo copy = arcs::clone_entity(foo_.get());  // does not copy internal id
       bar_.store(copy);    // 'copy' will be updated with a new internal id
 
       // Basic printf-style logging; note the c_str() for std::string variables
@@ -40,8 +39,9 @@ public:
   }
 
 private:
-  arcs::Singleton<arcs::BasicParticle_Foo> foo_;
-  arcs::Collection<arcs::BasicParticle_Bar> bar_;
+  // name arg must match the manifest, particle arg must be 'this'; note the {} brace style
+  arcs::Singleton<arcs::BasicParticle_Foo> foo_{"foo", this};
+  arcs::Collection<arcs::BasicParticle_Bar> bar_{"bar", this};
   int num_clicks_ = 0;
 };
 
@@ -49,7 +49,6 @@ private:
 class Watcher : public arcs::Particle {
 public:
   Watcher() {
-    registerHandle("bar", bar_);
     autoRender();
   }
 
@@ -62,7 +61,7 @@ public:
   }
 
 private:
-  arcs::Collection<arcs::Watcher_Bar> bar_;
+  arcs::Collection<arcs::Watcher_Bar> bar_{"bar", this};
 };
 
 

--- a/src/tests/source/wasm-particle-new.cc
+++ b/src/tests/source/wasm-particle-new.cc
@@ -15,29 +15,24 @@ class HotReloadTest : public arcs::Particle {
 DEFINE_PARTICLE(HotReloadTest)
 
 class ReloadHandleTest : public arcs::Particle {
-  public:
-    ReloadHandleTest() {
-      registerHandle("personIn", personIn);
-      registerHandle("personOut", personOut);
+public:
+  void onHandleSync(const std::string& name, bool all_synced) override {
+    onHandleUpdate(name);
+  }
+
+  void onHandleUpdate(const std::string& name) override {
+    arcs::Test_Person out;
+    if (auto input = getSingleton<arcs::Test_Person>(name)) {
+      out.set_name(input->get().name());
+      out.set_age(input->get().age() - 2);
+    } else {
+      out.set_name("unexpected handle name: " + name);
     }
-    void onHandleSync(const std::string& name, bool all_synced) override {
-      update(name);
-    }
-    void onHandleUpdate(const std::string& name) override {
-      update(name);
-    }
-    void update(const std::string& name) {
-      arcs::Test_Person out;
-      if (auto input = getSingleton<arcs::Test_Person>(name)) {
-        out.set_name(input->get().name());
-        out.set_age(input->get().age() - 2);
-      } else {
-        out.set_name("unexpected handle name: " + name);
-      }
-      personOut.set(out);
-    }
-    arcs::Singleton<arcs::Test_Person> personIn;
-    arcs::Singleton<arcs::Test_Person> personOut;
+    personOut.set(out);
+  }
+
+  arcs::Singleton<arcs::Test_Person> personIn{"personIn", this};
+  arcs::Singleton<arcs::Test_Person> personOut{"personOut", this};
 };
 
 DEFINE_PARTICLE(ReloadHandleTest);

--- a/src/tests/source/wasm-particle-old.cc
+++ b/src/tests/source/wasm-particle-old.cc
@@ -15,29 +15,24 @@ class HotReloadTest : public arcs::Particle {
 DEFINE_PARTICLE(HotReloadTest)
 
 class ReloadHandleTest : public arcs::Particle {
-  public:
-    ReloadHandleTest() {
-      registerHandle("personIn", personIn);
-      registerHandle("personOut", personOut);
+public:
+  void onHandleSync(const std::string& name, bool all_synced) override {
+    onHandleUpdate(name);
+  }
+
+  void onHandleUpdate(const std::string& name) override {
+    arcs::Test_Person out;
+    if (auto input = getSingleton<arcs::Test_Person>(name)) {
+      out.set_name(input->get().name());
+      out.set_age(input->get().age() * 2);
+    } else {
+      out.set_name("unexpected handle name: " + name);
     }
-    void onHandleSync(const std::string& name, bool all_synced) override {
-      update(name);
-    }
-    void onHandleUpdate(const std::string& name) override {
-      update(name);
-    }
-    void update(const std::string& name) {
-      arcs::Test_Person out;
-      if (auto input = getSingleton<arcs::Test_Person>(name)) {
-        out.set_name(input->get().name());
-        out.set_age(input->get().age() * 2);
-      } else {
-        out.set_name("unexpected handle name: " + name);
-      }
-      personOut.set(out);
-    }
-    arcs::Singleton<arcs::Test_Person> personIn;
-    arcs::Singleton<arcs::Test_Person> personOut;
+    personOut.set(out);
+  }
+
+  arcs::Singleton<arcs::Test_Person> personIn{"personIn", this};
+  arcs::Singleton<arcs::Test_Person> personOut{"personOut", this};
 };
 
 DEFINE_PARTICLE(ReloadHandleTest);

--- a/src/wasm/cpp/arcs.cc
+++ b/src/wasm/cpp/arcs.cc
@@ -305,6 +305,10 @@ std::string num_to_str(double num) {
 // --- Storage classes ---
 
 // Handle
+Handle::Handle(const char* name, Particle* particle) : name_(name), particle_(particle) {
+  particle_->registerHandle(this);
+}
+
 bool Handle::failForDirection(Direction bad_dir) const {
   if (dir_ == bad_dir) {
     std::string action = (bad_dir == In) ? "write to" : "read from";
@@ -317,10 +321,8 @@ bool Handle::failForDirection(Direction bad_dir) const {
 }
 
 // Particle
-void Particle::registerHandle(const std::string& name, Handle& handle) {
-  handle.name_ = name;
-  handle.particle_ = this;
-  handles_[handle.name_] = &handle;
+void Particle::registerHandle(Handle* handle) {
+  handles_[handle->name()] = handle;
 }
 
 void Particle::autoRender(const std::string& slot_name) {

--- a/src/wasm/cpp/tests/entity-class-test.cc
+++ b/src/wasm/cpp/tests/entity-class-test.cc
@@ -17,14 +17,10 @@ static auto converter() {
 
 class EntityClassApiTest : public TestBase<arcs::EntityClassApiTest_Errors> {
 public:
-  EntityClassApiTest() {
-    // These handles are required so we can specify the desired inline schemas in the particle spec
-    // to get the generated classes for testing, but we don't actually use the handles themselves.
-    registerHandle("data", unused1_);
-    registerHandle("empty", unused2_);
-  }
-  arcs::Singleton<arcs::EntityClassApiTest_Data> unused1_;
-  arcs::Singleton<arcs::EntityClassApiTest_Empty> unused2_;
+  // These handles are required so we can specify the desired inline schemas in the particle spec
+  // to get the generated classes for testing, but we don't actually use the handles themselves.
+  arcs::Singleton<arcs::EntityClassApiTest_Data> unused1_{"data", this};
+  arcs::Singleton<arcs::EntityClassApiTest_Empty> unused2_{"empty", this};
 
   void init() override {
     RUN(test_field_methods);
@@ -586,12 +582,9 @@ DEFINE_PARTICLE(EntityClassApiTest)
 
 class SpecialSchemaFieldsTest : public TestBase<arcs::SpecialSchemaFieldsTest_Errors> {
 public:
-  SpecialSchemaFieldsTest() {
-    // This handle is required so we can specify the desired inline schema in the particle spec
-    // to get the generated class for testing, but we don't actually use the handle itself.
-    registerHandle("fields", unused_);
-  }
-  arcs::Singleton<arcs::SpecialSchemaFieldsTest_Fields> unused_;
+  // This handle is required so we can specify the desired inline schema in the particle spec
+  // to get the generated class for testing, but we don't actually use the handle itself.
+  arcs::Singleton<arcs::SpecialSchemaFieldsTest_Fields> unused_{"fields", this};
 
   void init() override {
     RUN(test_language_keyword_field);

--- a/src/wasm/cpp/tests/particle-api-test.cc
+++ b/src/wasm/cpp/tests/particle-api-test.cc
@@ -3,12 +3,6 @@
 
 class HandleSyncUpdateTest : public arcs::Particle {
 public:
-  HandleSyncUpdateTest() {
-    registerHandle("sng", sng_);
-    registerHandle("col", col_);
-    registerHandle("res", res_);
-  }
-
   void onHandleSync(const std::string& name, bool all_synced) override {
     arcs::HandleSyncUpdateTest_Res out;
     out.set_txt("sync:" + name + (all_synced ? ":true" : ":false"));
@@ -28,9 +22,9 @@ public:
     res_.store(out);
   }
 
-  arcs::Singleton<arcs::HandleSyncUpdateTest_Sng> sng_;
-  arcs::Collection<arcs::HandleSyncUpdateTest_Col> col_;
-  arcs::Collection<arcs::HandleSyncUpdateTest_Res> res_;
+  arcs::Singleton<arcs::HandleSyncUpdateTest_Sng> sng_{"sng", this};
+  arcs::Collection<arcs::HandleSyncUpdateTest_Col> col_{"col", this};
+  arcs::Collection<arcs::HandleSyncUpdateTest_Res> res_{"res", this};
 };
 
 DEFINE_PARTICLE(HandleSyncUpdateTest)
@@ -38,10 +32,6 @@ DEFINE_PARTICLE(HandleSyncUpdateTest)
 
 class RenderTest : public arcs::Particle {
 public:
-  RenderTest() {
-    registerHandle("flags", flags_);
-  }
-
   std::string getTemplate(const std::string& slot_name) override {
     return "abc";
   }
@@ -55,7 +45,7 @@ public:
     renderSlot("root", flags._template(), flags.model());
   }
 
-  arcs::Singleton<arcs::RenderTest_Flags> flags_;
+  arcs::Singleton<arcs::RenderTest_Flags> flags_{"flags", this};
 };
 
 DEFINE_PARTICLE(RenderTest)
@@ -64,7 +54,6 @@ DEFINE_PARTICLE(RenderTest)
 class AutoRenderTest : public arcs::Particle {
 public:
   AutoRenderTest() {
-    registerHandle("data", data_);
     autoRender();
   }
 
@@ -73,7 +62,7 @@ public:
     return data.has_txt() ? data.txt() : "empty";
   }
 
-  arcs::Singleton<arcs::AutoRenderTest_Data> data_;
+  arcs::Singleton<arcs::AutoRenderTest_Data> data_{"data", this};
 };
 
 DEFINE_PARTICLE(AutoRenderTest)
@@ -81,10 +70,6 @@ DEFINE_PARTICLE(AutoRenderTest)
 
 class EventsTest : public arcs::Particle {
 public:
-  EventsTest() {
-    registerHandle("output", output_);
-  }
-
   void fireEvent(const std::string& slot_name, const std::string& handler,
                  const arcs::Dictionary& eventData) override {
     arcs::EventsTest_Output out;
@@ -92,7 +77,7 @@ public:
     output_.set(out);
   }
 
-  arcs::Singleton<arcs::EventsTest_Output> output_;
+  arcs::Singleton<arcs::EventsTest_Output> output_{"output", this};
 };
 
 DEFINE_PARTICLE(EventsTest)
@@ -100,10 +85,6 @@ DEFINE_PARTICLE(EventsTest)
 
 class ServicesTest : public arcs::Particle {
 public:
-  ServicesTest() {
-    registerHandle("output", output_);
-  }
-
   void init() override {
     std::string url = resolveUrl("$resolve-me");
     arcs::ServicesTest_Output out;
@@ -130,7 +111,7 @@ public:
     output_.store(out);
   }
 
-  arcs::Collection<arcs::ServicesTest_Output> output_;
+  arcs::Collection<arcs::ServicesTest_Output> output_{"output", this};
 };
 
 DEFINE_PARTICLE(ServicesTest)

--- a/src/wasm/cpp/tests/reference-class-test.cc
+++ b/src/wasm/cpp/tests/reference-class-test.cc
@@ -12,12 +12,9 @@ static auto converter() {
 
 class ReferenceClassApiTest : public TestBase<arcs::ReferenceClassApiTest_Errors> {
 public:
-  ReferenceClassApiTest() {
-    // This handle is required so we can specify the desired inline schema in the particle spec
-    // to get the generated class for testing, but we don't actually use the handle itself.
-    registerHandle("data", unused_);
-  }
-  arcs::Singleton<arcs::ReferenceClassApiTest_Data> unused_;
+  // This handle is required so we can specify the desired inline schema in the particle spec
+  // to get the generated class for testing, but we don't actually use the handle itself.
+  arcs::Singleton<arcs::ReferenceClassApiTest_Data> unused_{"data", this};
 
   // Used to inject values into a dereference call.
   arcs::ReferenceClassApiTest_Data data_;

--- a/src/wasm/cpp/tests/storage-api-test.cc
+++ b/src/wasm/cpp/tests/storage-api-test.cc
@@ -5,12 +5,6 @@ using arcs::internal::Accessor;
 
 class SingletonApiTest : public arcs::Particle {
 public:
-  SingletonApiTest() {
-    registerHandle("inHandle", in_);
-    registerHandle("outHandle", out_);
-    registerHandle("ioHandle", io_);
-  }
-
   void fireEvent(const std::string& slot_name, const std::string& handler, const arcs::Dictionary& eventData) override {
     if (handler == "case1") {
       out_.clear();
@@ -26,9 +20,9 @@ public:
     }
   }
 
-  arcs::Singleton<arcs::SingletonApiTest_InHandle> in_;
-  arcs::Singleton<arcs::SingletonApiTest_OutHandle> out_;
-  arcs::Singleton<arcs::SingletonApiTest_IoHandle> io_;
+  arcs::Singleton<arcs::SingletonApiTest_InHandle> in_{"inHandle", this};
+  arcs::Singleton<arcs::SingletonApiTest_OutHandle> out_{"outHandle", this};
+  arcs::Singleton<arcs::SingletonApiTest_IoHandle> io_{"ioHandle", this};
 };
 
 DEFINE_PARTICLE(SingletonApiTest)
@@ -36,12 +30,6 @@ DEFINE_PARTICLE(SingletonApiTest)
 
 class CollectionApiTest : public arcs::Particle {
 public:
-  CollectionApiTest() {
-    registerHandle("inHandle", in_);
-    registerHandle("outHandle", out_);
-    registerHandle("ioHandle", io_);
-  }
-
   void fireEvent(const std::string& slot_name, const std::string& handler, const arcs::Dictionary& eventData) override {
     if (handler == "case1") {
       out_.clear();
@@ -104,9 +92,9 @@ public:
     }
   }
 
-  arcs::Collection<arcs::CollectionApiTest_InHandle> in_;
-  arcs::Collection<arcs::CollectionApiTest_OutHandle> out_;
-  arcs::Collection<arcs::CollectionApiTest_IoHandle> io_;
+  arcs::Collection<arcs::CollectionApiTest_InHandle> in_{"inHandle", this};
+  arcs::Collection<arcs::CollectionApiTest_OutHandle> out_{"outHandle", this};
+  arcs::Collection<arcs::CollectionApiTest_IoHandle> io_{"ioHandle", this};
   arcs::CollectionApiTest_OutHandle stored_;
 };
 
@@ -115,12 +103,6 @@ DEFINE_PARTICLE(CollectionApiTest)
 
 class ReferenceHandlesTest : public arcs::Particle {
 public:
-  ReferenceHandlesTest() {
-    registerHandle("sng", sng_);
-    registerHandle("col", col_);
-    registerHandle("res", res_);
-  }
-
   void onHandleSync(const std::string& name, bool all_synced) override {
     if (!all_synced) return;
 
@@ -151,9 +133,9 @@ public:
     res_.store(d);
   }
 
-  arcs::Singleton<arcs::Ref<arcs::ReferenceHandlesTest_Sng>> sng_;
-  arcs::Collection<arcs::Ref<arcs::ReferenceHandlesTest_Col>> col_;
-  arcs::Collection<arcs::ReferenceHandlesTest_Res> res_;
+  arcs::Singleton<arcs::Ref<arcs::ReferenceHandlesTest_Sng>> sng_{"sng", this};
+  arcs::Collection<arcs::Ref<arcs::ReferenceHandlesTest_Col>> col_{"col", this};
+  arcs::Collection<arcs::ReferenceHandlesTest_Res> res_{"res", this};
 };
 
 DEFINE_PARTICLE(ReferenceHandlesTest)
@@ -161,12 +143,6 @@ DEFINE_PARTICLE(ReferenceHandlesTest)
 
 class SchemaReferenceFieldsTest : public arcs::Particle {
 public:
-  SchemaReferenceFieldsTest() {
-    registerHandle("input", input_);
-    registerHandle("output", output_);
-    registerHandle("res", res_);
-  }
-
   void onHandleSync(const std::string& name, bool all_synced) override {
     if (!all_synced) return;
 
@@ -201,9 +177,9 @@ public:
     res_.store(d);
   }
 
-  arcs::Singleton<arcs::SchemaReferenceFieldsTest_Input> input_;
-  arcs::Singleton<arcs::SchemaReferenceFieldsTest_Output> output_;
-  arcs::Collection<arcs::SchemaReferenceFieldsTest_Res> res_;
+  arcs::Singleton<arcs::SchemaReferenceFieldsTest_Input> input_{"input", this};
+  arcs::Singleton<arcs::SchemaReferenceFieldsTest_Output> output_{"output", this};
+  arcs::Collection<arcs::SchemaReferenceFieldsTest_Res> res_{"res", this};
 };
 
 DEFINE_PARTICLE(SchemaReferenceFieldsTest)

--- a/src/wasm/cpp/tests/test-base.h
+++ b/src/wasm/cpp/tests/test-base.h
@@ -8,10 +8,6 @@
 template<typename T>
 class TestBase : public arcs::Particle {
 public:
-  TestBase() {
-    registerHandle("errors", errors_);
-  }
-
   virtual void before_each() {}
 
   bool check(bool ok, const std::string& condition, std::string file, int line) {
@@ -75,7 +71,7 @@ public:
   }
 
   std::string test_name_;
-  arcs::Collection<T> errors_;
+  arcs::Collection<T> errors_{"errors", this};
   char marker_;
 };
 


### PR DESCRIPTION
Change `registerHandle` to be an internal function and require Singleton/Collection members to be declared with their name and the particle pointer instead. That means `this` appears in each declaration, but that's still less cumbersome than having to call `registerHandle` for every handle field in the constructor.