### PR TITLE
More buildifier fixes

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -13,7 +13,7 @@ filegroup(
 filegroup(
     name = "node_modules",
     srcs = glob(
-        include = ["node_modules/**/*"],
+        ["node_modules/**/*"],
         exclude = [
             # Files under test & docs may contain file names that
             # are not legal Bazel labels (e.g.,

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -83,6 +83,18 @@ load("@robolectric//bazel:robolectric.bzl", "robolectric_repositories")
 
 robolectric_repositories()
 
+# Python
+
+http_archive(
+    name = "rules_python",
+    url = "https://github.com/bazelbuild/rules_python/releases/download/0.0.1/rules_python-0.0.1.tar.gz",
+    sha256 = "aa96a691d3a8177f3215b14b0edc9641787abaaa30363a080165d06ab65e1161",
+)
+
+load("@rules_python//python:repositories.bzl", "py_repositories")
+
+py_repositories()
+
 # Java deps from Maven.
 
 RULES_JVM_EXTERNAL_TAG = "2.10"

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -45,10 +45,11 @@ http_archive(
 # Kotlin
 
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+
 git_repository(
     name = "io_bazel_rules_kotlin",
-    remote = "https://github.com/cromwellian/rules_kotlin.git",
     commit = "e1a4f61521b9bba4b0584ef55f5cb621093d705d",
+    remote = "https://github.com/cromwellian/rules_kotlin.git",
     shallow_since = "1574206775 -0800",
 )
 
@@ -73,11 +74,13 @@ register_toolchains("//third_party/java/arcs/build_defs/internal:kotlin_toolchai
 
 http_archive(
     name = "robolectric",
-    urls = ["https://github.com/robolectric/robolectric-bazel/archive/4.1.tar.gz"],
     sha256 = "2ee850ca521288db72b0dedb9ecbda55b64d11c470435a882f8daf615091253d",
     strip_prefix = "robolectric-bazel-4.1",
+    urls = ["https://github.com/robolectric/robolectric-bazel/archive/4.1.tar.gz"],
 )
+
 load("@robolectric//bazel:robolectric.bzl", "robolectric_repositories")
+
 robolectric_repositories()
 
 # Java deps from Maven.

--- a/javaharness/BUILD
+++ b/javaharness/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library", "java_plugin")
+
 package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])

--- a/javaharness/javatests/arcs/android/BUILD
+++ b/javaharness/javatests/arcs/android/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 licenses(["notice"])
 
 java_test(

--- a/javaharness/javatests/arcs/api/BUILD
+++ b/javaharness/javatests/arcs/api/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 licenses(["notice"])
 
 java_test(

--- a/javaharness/javatests/arcs/crdt/BUILD
+++ b/javaharness/javatests/arcs/crdt/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 licenses(["notice"])
 
 java_test(

--- a/particles/Native/Wasm/BUILD
+++ b/particles/Native/Wasm/BUILD
@@ -6,7 +6,6 @@ load(
     "arcs_kt_schema",
     "arcs_manifest",
     "arcs_manifest_bundle",
-    "arcs_ts_test",
 )
 
 licenses(["notice"])

--- a/shells/android/java/arcs/storage/service/BUILD
+++ b/shells/android/java/arcs/storage/service/BUILD
@@ -1,4 +1,4 @@
-load("@rules_android//android:rules.bzl", "android_library")
+load("@build_bazel_rules_android//android:rules.bzl", "android_library")
 
 licenses(["notice"])
 

--- a/shells/android/java/arcs/storage/service/BUILD
+++ b/shells/android/java/arcs/storage/service/BUILD
@@ -1,3 +1,5 @@
+load("@rules_android//android:rules.bzl", "android_library")
+
 licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])

--- a/src/wasm/cpp/tests/BUILD
+++ b/src/wasm/cpp/tests/BUILD
@@ -1,4 +1,4 @@
-load("//third_party/java/arcs/build_defs:build_defs.bzl", "arcs_cc_schema", "arcs_ts_test")
+load("//third_party/java/arcs/build_defs:build_defs.bzl", "arcs_cc_schema")
 load("//third_party/java/arcs/build_defs/emscripten:build_defs.bzl", "cc_wasm_binary")
 
 filegroup(

--- a/src_kt/javatests/arcs/common/BUILD
+++ b/src_kt/javatests/arcs/common/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])

--- a/src_kt/javatests/arcs/crdt/BUILD
+++ b/src_kt/javatests/arcs/crdt/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])

--- a/src_kt/javatests/arcs/crdt/internal/BUILD
+++ b/src_kt/javatests/arcs/crdt/internal/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])

--- a/src_kt/javatests/arcs/storage/BUILD
+++ b/src_kt/javatests/arcs/storage/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])

--- a/src_kt/javatests/arcs/storage/api/BUILD
+++ b/src_kt/javatests/arcs/storage/api/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])

--- a/src_kt/javatests/arcs/storage/driver/BUILD
+++ b/src_kt/javatests/arcs/storage/driver/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])

--- a/src_kt/javatests/arcs/storage/referencemode/BUILD
+++ b/src_kt/javatests/arcs/storage/referencemode/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])

--- a/src_kt/javatests/arcs/storage/util/BUILD
+++ b/src_kt/javatests/arcs/storage/util/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])

--- a/src_kt/javatests/arcs/stringEncoder/BUILD
+++ b/src_kt/javatests/arcs/stringEncoder/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])

--- a/src_kt/javatests/arcs/type/BUILD
+++ b/src_kt/javatests/arcs/type/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])

--- a/src_kt/javatests/arcs/util/BUILD
+++ b/src_kt/javatests/arcs/util/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])

--- a/third_party/bazel_rules/rules_kotlin/kotlin/js/BUILD
+++ b/third_party/bazel_rules/rules_kotlin/kotlin/js/BUILD
@@ -1,3 +1,5 @@
+load("@rules_python//python:defs.bzl", "py_binary")
+
 py_binary(
     name = "importer",
     srcs = ["importer.py"],

--- a/third_party/bazel_rules/rules_kotlin/kotlin/js/impl.bzl
+++ b/third_party/bazel_rules/rules_kotlin/kotlin/js/impl.bzl
@@ -1,4 +1,5 @@
 """Implementation of Kotlin JS rules."""
+
 load("@io_bazel_rules_kotlin//kotlin/internal:defs.bzl", "KtJsInfo")
 
 def kt_js_import_impl(ctx):

--- a/third_party/bazel_rules/rules_kotlin/kotlin/js/js_library.bzl
+++ b/third_party/bazel_rules/rules_kotlin/kotlin/js/js_library.bzl
@@ -1,4 +1,5 @@
 """Kotlin JS Rules"""
+
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", _kt_js_import = "kt_js_import", _kt_js_library = "kt_js_library")
 load("@io_bazel_rules_kotlin//kotlin/internal:defs.bzl", "KtJsInfo")
 load("//third_party/bazel_rules/rules_kotlin/kotlin/js:impl.bzl", "kt_js_import_impl")

--- a/third_party/java/arcs/build_defs/internal/kotlin.bzl
+++ b/third_party/java/arcs/build_defs/internal/kotlin.bzl
@@ -3,8 +3,9 @@
 Rules are re-exported in build_defs.bzl -- use those instead.
 """
 
+load("@rules_java//java:defs.bzl", "java_library")
 load("//third_party/bazel_rules/rules_kotlin/kotlin/native:native_rules.bzl", "kt_native_binary", "kt_native_library")
-load("//third_party/bazel_rules/rules_kotlin/kotlin/js:js_library.bzl", "kt_js_library", kt_js_import = "kt_js_import_fixed")
+load("//third_party/bazel_rules/rules_kotlin/kotlin/js:js_library.bzl", "kt_js_library")
 load("//tools/build_defs/kotlin:rules.bzl", "kt_jvm_library")
 load("//third_party/bazel_rules/rules_kotlin/kotlin/native:wasm.bzl", "wasm_kt_binary")
 
@@ -73,7 +74,7 @@ def kt_jvm_and_js_library(
         # will wrap it in a java_library rule and export everything that is
         # needed from there.
         kt_name = name + "-kt"
-        native.java_library(
+        java_library(
             name = name,
             exports = exports + [kt_name],
             visibility = visibility,

--- a/third_party/java/arcs/build_defs/internal/schemas.bzl
+++ b/third_party/java/arcs/build_defs/internal/schemas.bzl
@@ -31,11 +31,11 @@ def _run_schema2wasm(name, src, out, language_name, language_flag, package):
                    language_flag + " " +
                    "--outdir $(dirname {OUT}) " +
                    "--outfile $(basename {OUT}) " +
-                   "--package " + package  + " " +
+                   "--package " + package + " " +
                    "{SRC}",
     )
 
-def arcs_cc_schema(name, src, out = None, package = 'arcs'):
+def arcs_cc_schema(name, src, out = None, package = "arcs"):
     """Generates a C++ header file for the given .arcs schema file."""
     out = out or _output_name(src, ".h")
     _run_schema2wasm(
@@ -44,10 +44,10 @@ def arcs_cc_schema(name, src, out = None, package = 'arcs'):
         out = out,
         language_flag = "--cpp",
         language_name = "C++",
-        package = package
+        package = package,
     )
 
-def arcs_kt_schema(name, srcs, package = 'arcs'):
+def arcs_kt_schema(name, srcs, package = "arcs"):
     """Generates a Kotlin file for the given .arcs schema file."""
     outs = []
     for src in srcs:

--- a/third_party/java/arcs/build_defs/run_in_repo.bzl
+++ b/third_party/java/arcs/build_defs/run_in_repo.bzl
@@ -73,7 +73,7 @@ _RUN_RULE_ATTRS = {
     "cmd": attr.string(
         doc = """
 Command to run in the repo root. You can use standard python format placeholders
-of the form \{SRCS\}, which will be substituted when the command is run.
+of the form \\{SRCS\\}, which will be substituted when the command is run.
 Placeholders are:
  * SRCS: list of input source files (relative to repo root).
  * OUTS: list of output files (absolute filesystem paths).

--- a/third_party/java/auto/BUILD
+++ b/third_party/java/auto/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library", "java_plugin")
+
 package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])

--- a/third_party/java/dagger/BUILD
+++ b/third_party/java/dagger/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library", "java_plugin")
+
 package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])

--- a/third_party/java/flogger/BUILD
+++ b/third_party/java/flogger/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])


### PR DESCRIPTION
This time ran buildifier with `--lint=fix`. Not all of the lint warnings were automatically fixable.

Will update `sigh lint` to use the stricter argument in a follow-up PR, after all the issues are fixed.