### PR TITLE
Fix arcs-live deploy: Incorrect npm version

### DIFF
--- a/tools/deploy
+++ b/tools/deploy
@@ -2,6 +2,8 @@
 
 # Track Version
 git log -n 1 > VERSION
+# Ensure we have the correct npm version
+npm install -g "npm@$(jq -r '.engines.npm' package.json)"
 # Produce build artifacts
 npm install
 tools/sigh webpack

--- a/tools/deploy
+++ b/tools/deploy
@@ -2,8 +2,10 @@
 
 # Track Version
 git log -n 1 > VERSION
-# Ensure we have the correct npm version
-npm install -g "npm@$(jq -r '.engines.npm' package.json)"
+# Ensure we have the correct node & npm versions
+nvm install
+nvm use
+nvm install-latest-npm
 # Produce build artifacts
 npm install
 tools/sigh webpack

--- a/tools/deploy
+++ b/tools/deploy
@@ -5,7 +5,7 @@ git log -n 1 > VERSION
 # Ensure we have the correct node & npm versions
 nvm install
 nvm use
-nvm install-latest-npm
+npm install -g "npm@$(jq -r '.engines.npm' package.json)"
 # Produce build artifacts
 npm install
 tools/sigh webpack


### PR DESCRIPTION
Fixing this error with the deploy script in the travis environment: 
```
Error: at least npm >= 6.9.0 is required, you have 6.4.1
    at check (/home/travis/build/PolymerLabs/arcs/build/sigh.js:203:15)
    at runSteps (/home/travis/build/PolymerLabs/arcs/build/sigh.js:924:18)
    at Object.<anonymous> (/home/travis/build/PolymerLabs/arcs/build/sigh.js:951:16)
    at Module._compile (internal/modules/cjs/loader.js:701:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:712:10)
    at Module.load (internal/modules/cjs/loader.js:600:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:539:12)
    at Function.Module._load (internal/modules/cjs/loader.js:531:3)
    at Function.Module.runMain (internal/modules/cjs/loader.js:754:12)
    at startup (internal/bootstrap/node.js:283:19)
😱 FAILURE
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! arcs@0.0.0 prepare: `cross-env tools/sigh check && cd devtools && npm install`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the arcs@0.0.0 prepare script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
npm ERR! A complete log of this run can be found in:
npm ERR!     /home/travis/.npm/_logs/2019-11-25T20_29_26_976Z-debug.log
```

