### PR TITLE
Bump to Bazel version 1.2.0 with check

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,3 +1,7 @@
+load("//build_defs:bazel_version_check.bzl", "bazel_version_check")
+
+bazel_version_check()
+
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 # NodeJS
@@ -87,8 +91,8 @@ robolectric_repositories()
 
 http_archive(
     name = "rules_python",
-    url = "https://github.com/bazelbuild/rules_python/releases/download/0.0.1/rules_python-0.0.1.tar.gz",
     sha256 = "aa96a691d3a8177f3215b14b0edc9641787abaaa30363a080165d06ab65e1161",
+    url = "https://github.com/bazelbuild/rules_python/releases/download/0.0.1/rules_python-0.0.1.tar.gz",
 )
 
 load("@rules_python//python:repositories.bzl", "py_repositories")

--- a/build_defs/bazel_version_check.bzl
+++ b/build_defs/bazel_version_check.bzl
@@ -1,0 +1,27 @@
+"""Checks that the correct version of bazel is installed."""
+
+# The minimum required version of bazel.
+# KEEP UP TO DATE WITH tools/install_bazel.sh
+_MIN_BAZEL_VERSION = "1.2.0"
+
+def _parse_version(version):
+    # Bazel version should be of form x.y.z
+    parts = version.split(".")
+    if len(parts) != 3:
+        fail(("Unable to parse bazel version \"%s\". Expected format of form " +
+              "\"x.y.z\".") % version)
+    return tuple([int(n) for n in parts])
+
+def bazel_version_check():
+    """Checks that the correct version of bazel is installed.
+
+    Fails if it isn't. Returns silently if it is. Call from WORKSPACE file.
+    """
+    installed_version_tuple = _parse_version(native.bazel_version)
+    min_version_tuple = _parse_version(_MIN_BAZEL_VERSION)
+    if min_version_tuple > installed_version_tuple:
+        fail(("ERROR: Minimum required bazel version is \"{min}\". You have " +
+              "\"{installed}\".").format(
+            min = _MIN_BAZEL_VERSION,
+            installed = native.bazel_version,
+        ))

--- a/tools/Dockerfile.CI
+++ b/tools/Dockerfile.CI
@@ -34,6 +34,7 @@ WORKDIR $WORKSPACE
 # Install Bazel
 COPY tools/install_bazel.sh $WORKSPACE/tools/install_bazel.sh
 RUN ./tools/install_bazel.sh
+ENV PATH="/root/bin:${PATH}"
 
 # Install ktlint
 RUN (cd /usr/bin/ && curl -L -s -O https://github.com/pinterest/ktlint/releases/download/0.35.0/ktlint && cd -)

--- a/tools/Dockerfile.CI
+++ b/tools/Dockerfile.CI
@@ -16,13 +16,6 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y \
       unzip \
       xz-utils
 
-
-# Install Bazel
-#  Reference: https://docs.bazel.build/versions/master/install-ubuntu.html
-RUN echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list
-RUN curl https://bazel.build/bazel-release.pub.gpg | apt-key add -
-RUN apt-get update && apt-get install bazel -y
-
 # Install Chrome for Selenium
 #  Reference: https://tecadmin.net/setup-selenium-chromedriver-on-ubuntu/
 RUN curl -sS -o - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add
@@ -33,15 +26,18 @@ RUN curl https://chromedriver.storage.googleapis.com/2.41/chromedriver_linux64.z
 RUN unzip /usr/bin/chromedriver_linux64.zip -d /usr/bin/chromedriver
 RUN chmod +x /usr/bin/chromedriver
 
-# Install ktlint
-RUN (cd /usr/bin/ && curl -L -s -O https://github.com/pinterest/ktlint/releases/download/0.35.0/ktlint && cd -)
-RUN chmod +x /usr/bin/ktlint
-
-
 # Set up workspace
 ENV WORKSPACE /usr/src/app
 RUN mkdir -p $WORKSPACE
 WORKDIR $WORKSPACE
+
+# Install Bazel
+COPY tools/install_bazel.sh $WORKSPACE/tools/install_bazel.sh
+RUN ./tools/install_bazel.sh
+
+# Install ktlint
+RUN (cd /usr/bin/ && curl -L -s -O https://github.com/pinterest/ktlint/releases/download/0.35.0/ktlint && cd -)
+RUN chmod +x /usr/bin/ktlint
 
 # Install Nodejs & npm
 RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -

--- a/tools/install_bazel.sh
+++ b/tools/install_bazel.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Script to install bazel. Should be usable in Dockerfile.CI, by the
+# tools/setup script, and locally.
+set -e
+
+# KEEP UP TO DATE WITH build_defs/bazel_version_check.bzl
+BAZEL_VERSION="1.2.0"
+
+# Detect Platform
+case $(uname | tr '[:upper:]' '[:lower:]') in
+  linux*)
+    BAZEL_DEP="https://github.com/bazelbuild/bazel/releases/download/$BAZEL_VERSION/bazel-$BAZEL_VERSION-installer-linux-x86_64.sh"
+    ;;
+  darwin*)
+    BAZEL_DEP="https://github.com/bazelbuild/bazel/releases/download/$BAZEL_VERSION/bazel-$BAZEL_VERSION-installer-darwin-x86_64.sh"
+    ;;
+  msys*)
+    BAZEL_DEP="https://github.com/bazelbuild/bazel/releases/download/$BAZEL_VERSION/bazel-$BAZEL_VERSION-windows-x86_64.exe"
+    # TODO(alxr) investigate windows compatability
+    >2& echo "Windows is currently unsupported. Please follow install instructions in the README."
+    exit 1
+    ;;
+  *)
+    >2& echo "Can't detect host OS"
+    exit 1
+    ;;
+esac
+
+BAZEL_SCRIPT_NAME=$(basename "$BAZEL_DEP")
+
+# Show what commands are being run.
+set -x
+
+curl -L -s -O "$BAZEL_DEP" --output "$BAZEL_SCRIPT_NAME"
+chmod +x "$BAZEL_SCRIPT_NAME"
+"./$BAZEL_SCRIPT_NAME" --user
+rm "$BAZEL_SCRIPT_NAME"

--- a/tools/setup
+++ b/tools/setup
@@ -2,7 +2,6 @@
 
 ROOT=$(dirname $0)/..
 NVM_VERSION="v0.34.0"
-BAZEL_VERSION="1.0.0"
 
 YLW="\033[33m"
 RED="\033[91m"
@@ -37,15 +36,12 @@ append_once() {
 case $(uname | tr '[:upper:]' '[:lower:]') in
   linux*)
     OS_NAME=linux
-    BAZEL_DEP="https://github.com/bazelbuild/bazel/releases/download/$BAZEL_VERSION/bazel-$BAZEL_VERSION-installer-linux-x86_64.sh"
     ;;
   darwin*)
     OS_NAME=osx
-    BAZEL_DEP="https://github.com/bazelbuild/bazel/releases/download/$BAZEL_VERSION/bazel-$BAZEL_VERSION-installer-darwin-x86_64.sh"
     ;;
   msys*)
     OS_NAME=windows
-    BAZEL_DEP="https://github.com/bazelbuild/bazel/releases/download/$BAZEL_VERSION/bazel-$BAZEL_VERSION-windows-x86_64.exe"
     # TODO(alxr) investigate windows compatability
     fail "Windows is currently unsupported. Please follow install instructions in the README."
     ;;
@@ -54,8 +50,6 @@ case $(uname | tr '[:upper:]' '[:lower:]') in
     fail "Can't detect host OS"
     ;;
 esac
-
-BAZEL_SCRIPT_NAME=$(basename "$BAZEL_DEP")
 
 status "0. Pre-requisites"
 if [ "$OS_NAME" = "linux" ]; then
@@ -93,10 +87,7 @@ status "4.1. Install useful optional dependencies"
 status "5. Install Bazel"
 
 status "5.1. Downloading and running install script"
-curl -L -s -O "$BAZEL_DEP" --output "$BAZEL_SCRIPT_NAME"
-chmod +x "$BAZEL_SCRIPT_NAME"
-"./$BAZEL_SCRIPT_NAME" --user || fail "Failed to install Bazel"
-rm "$BAZEL_SCRIPT_NAME"
+(cd $ROOT && ./tools/install_bazel.sh)
 
 status "5.2. Updating PATH"
 append_once 'export PATH="$PATH:$HOME/bin"' ~/.profile


### PR DESCRIPTION
* Bump bazel version to 1.2.0
* Add check to bazel so it will crash early if you have the wrong
  version
* Update setup script and Dockerfile.CI to use the same (new)
  bazel_install.sh script to keep them both aligned.

Already pushed new Dockerfile.CI to Docker Hub