### PR TITLE
Fix: arcs-live whitelist 

### DIFF
--- a/tools/deployment/.gitignore
+++ b/tools/deployment/.gitignore
@@ -6,7 +6,7 @@
 !devtools/
 !dist/
 !extension/
-!modalities/dom/
+!modalities/
 !particles/
 !shells/
 
@@ -18,3 +18,6 @@
 !index.html
 !README.md
 
+# Include Wasm artifacts
+!**.wasm.js
+!**.wasm

--- a/tools/deployment/.gitignore
+++ b/tools/deployment/.gitignore
@@ -6,7 +6,7 @@
 !devtools/
 !dist/
 !extension/
-!modalities/dom
+!modalities/dom/
 !particles/
 !shells/
 


### PR DESCRIPTION
Problem: The modalities isn't being transferred
Potential fix: Removed subfolder, ensure we have a trailing `/`. 

In addition: added rule to include `.wasm` and `.wasm.js` files. 