### PR TITLE
Adds new Kotlin test_suite macros

### DIFF
--- a/shells/android/javatests/arcs/crdt/parcelables/BUILD
+++ b/shells/android/javatests/arcs/crdt/parcelables/BUILD
@@ -1,38 +1,25 @@
+load(
+    "//third_party/java/arcs/build_defs:build_defs.bzl",
+    "arcs_kt_android_test_suite",
+)
+
 licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])
 
-load("//tools/build_defs/android:rules.bzl", "android_local_test")
-load("//tools/build_defs/kotlin:rules.bzl", "kt_android_library")
-
-[
-    [
-        android_local_test(
-            name = src_file[:-3],
-            size = "small",
-            manifest = "//shells/android/java/arcs/common:AndroidManifest.xml",
-            test_class = "arcs.crdt.parcelables.%s" % src_file[:-3],
-            deps = [
-                ":%sLib" % src_file[:-3],
-                "@robolectric//bazel:android-all",
-            ],
-        ),
-        kt_android_library(
-            name = src_file[:-3] + "Lib",
-            srcs = [src_file],
-            manifest = "//shells/android/java/arcs/common:AndroidManifest.xml",
-            deps = [
-                "//shells/android/java/arcs/crdt/parcelables",
-                "//src_kt/java/arcs/crdt",
-                "//src_kt/java/arcs/crdt/internal",
-                "//third_party/android/androidx_test/core",
-                "//third_party/android/androidx_test/ext/junit",
-                "//third_party/java/junit",
-                "//third_party/java/mockito",
-                "//third_party/java/robolectric",
-                "//third_party/java/truth",
-            ],
-        ),
-    ]
-    for src_file in glob(["*.kt"])
-]
+arcs_kt_android_test_suite(
+    name = "parcelables",
+    manifest = "//shells/android/java/arcs/common:AndroidManifest.xml",
+    package = "arcs.crdt.parcelables",
+    deps = [
+        "//shells/android/java/arcs/crdt/parcelables",
+        "//src_kt/java/arcs/crdt",
+        "//src_kt/java/arcs/crdt/internal",
+        "//third_party/android/androidx_test/core",
+        "//third_party/android/androidx_test/ext/junit",
+        "//third_party/java/junit",
+        "//third_party/java/mockito",
+        "//third_party/java/robolectric",
+        "//third_party/java/truth",
+    ],
+)

--- a/shells/android/javatests/arcs/storage/parcelables/BUILD
+++ b/shells/android/javatests/arcs/storage/parcelables/BUILD
@@ -1,40 +1,27 @@
+load(
+    "//third_party/java/arcs/build_defs:build_defs.bzl",
+    "arcs_kt_android_test_suite",
+)
+
 licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])
 
-load("//tools/build_defs/android:rules.bzl", "android_local_test")
-load("//tools/build_defs/kotlin:rules.bzl", "kt_android_library")
-
-[
-    [
-        android_local_test(
-            name = src_file[:-3],
-            size = "small",
-            manifest = "//shells/android/java/arcs/common:AndroidManifest.xml",
-            test_class = "arcs.storage.parcelables.%s" % src_file[:-3],
-            deps = [
-                ":%sLib" % src_file[:-3],
-                "@robolectric//bazel:android-all",
-            ],
-        ),
-        kt_android_library(
-            name = src_file[:-3] + "Lib",
-            srcs = [src_file],
-            manifest = "//shells/android/java/arcs/common:AndroidManifest.xml",
-            deps = [
-                "//shells/android/java/arcs/crdt/parcelables",
-                "//shells/android/java/arcs/storage/parcelables",
-                "//src_kt/java/arcs/crdt",
-                "//src_kt/java/arcs/storage",
-                "//src_kt/java/arcs/storage/driver",
-                "//third_party/android/androidx_test/core",
-                "//third_party/android/androidx_test/ext/junit",
-                "//third_party/java/junit",
-                "//third_party/java/mockito",
-                "//third_party/java/robolectric",
-                "//third_party/java/truth",
-            ],
-        ),
-    ]
-    for src_file in glob(["*.kt"])
-]
+arcs_kt_android_test_suite(
+    name = "parcelables",
+    manifest = "//shells/android/java/arcs/common:AndroidManifest.xml",
+    package = "arcs.storage.parcelables",
+    deps = [
+        "//shells/android/java/arcs/crdt/parcelables",
+        "//shells/android/java/arcs/storage/parcelables",
+        "//src_kt/java/arcs/crdt",
+        "//src_kt/java/arcs/storage",
+        "//src_kt/java/arcs/storage/driver",
+        "//third_party/android/androidx_test/core",
+        "//third_party/android/androidx_test/ext/junit",
+        "//third_party/java/junit",
+        "//third_party/java/mockito",
+        "//third_party/java/robolectric",
+        "//third_party/java/truth",
+    ],
+)

--- a/src_kt/javatests/arcs/common/BUILD
+++ b/src_kt/javatests/arcs/common/BUILD
@@ -1,29 +1,18 @@
-load("@rules_java//java:defs.bzl", "java_test")
+load(
+    "//third_party/java/arcs/build_defs:build_defs.bzl",
+    "arcs_kt_jvm_test_suite",
+)
 
 licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])
 
-load("//tools/build_defs/kotlin:rules.bzl", "kt_jvm_library")
-
-[
-    [
-        java_test(
-            name = src_file[:-3],
-            size = "small",
-            test_class = "arcs.common.%s" % src_file[:-3],
-            runtime_deps = [":%sLib" % src_file[:-3]],
-        ),
-        kt_jvm_library(
-            name = "%sLib" % src_file[:-3],
-            testonly = True,
-            srcs = [src_file],
-            deps = [
-                "//src_kt/java/arcs/common",
-                "//third_party/java/junit",
-                "//third_party/java/truth",
-            ],
-        ),
-    ]
-    for src_file in glob(["*.kt"])
-]
+arcs_kt_jvm_test_suite(
+    name = "common",
+    package = "arcs.common",
+    deps = [
+        "//src_kt/java/arcs/common",
+        "//third_party/java/junit",
+        "//third_party/java/truth",
+    ],
+)

--- a/src_kt/javatests/arcs/crdt/BUILD
+++ b/src_kt/javatests/arcs/crdt/BUILD
@@ -1,33 +1,22 @@
-load("@rules_java//java:defs.bzl", "java_test")
+load(
+    "//third_party/java/arcs/build_defs:build_defs.bzl",
+    "arcs_kt_jvm_test_suite",
+)
 
 licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])
 
-load("//tools/build_defs/kotlin:rules.bzl", "kt_jvm_library")
-
-[
-    [
-        java_test(
-            name = src_file[:-3],
-            size = "small",
-            test_class = "arcs.crdt.%s" % src_file[:-3],
-            runtime_deps = [":%sLib" % src_file[:-3]],
-        ),
-        kt_jvm_library(
-            name = "%sLib" % src_file[:-3],
-            testonly = True,
-            srcs = [src_file],
-            deps = [
-                "//src_kt/java/arcs/common",
-                "//src_kt/java/arcs/crdt",
-                "//src_kt/java/arcs/crdt/internal",
-                "//src_kt/java/arcs/data",
-                "//src_kt/java/arcs/testutil",
-                "//third_party/java/junit",
-                "//third_party/java/truth",
-            ],
-        ),
-    ]
-    for src_file in glob(["*.kt"])
-]
+arcs_kt_jvm_test_suite(
+    name = "crdt",
+    package = "arcs.crdt",
+    deps = [
+        "//src_kt/java/arcs/common",
+        "//src_kt/java/arcs/crdt",
+        "//src_kt/java/arcs/crdt/internal",
+        "//src_kt/java/arcs/data",
+        "//src_kt/java/arcs/testutil",
+        "//third_party/java/junit",
+        "//third_party/java/truth",
+    ],
+)

--- a/src_kt/javatests/arcs/crdt/internal/BUILD
+++ b/src_kt/javatests/arcs/crdt/internal/BUILD
@@ -1,30 +1,19 @@
-load("@rules_java//java:defs.bzl", "java_test")
+load(
+    "//third_party/java/arcs/build_defs:build_defs.bzl",
+    "arcs_kt_jvm_test_suite",
+)
 
 licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])
 
-load("//tools/build_defs/kotlin:rules.bzl", "kt_jvm_library")
-
-[
-    [
-        java_test(
-            name = src_file[:-3],
-            size = "small",
-            test_class = "arcs.crdt.internal.%s" % src_file[:-3],
-            runtime_deps = [":%sLib" % src_file[:-3]],
-        ),
-        kt_jvm_library(
-            name = "%sLib" % src_file[:-3],
-            testonly = True,
-            srcs = [src_file],
-            deps = [
-                "//src_kt/java/arcs/crdt",
-                "//src_kt/java/arcs/crdt/internal",
-                "//third_party/java/junit",
-                "//third_party/java/truth",
-            ],
-        ),
-    ]
-    for src_file in glob(["*.kt"])
-]
+arcs_kt_jvm_test_suite(
+    name = "common",
+    package = "arcs.crdt.internal",
+    deps = [
+        "//src_kt/java/arcs/crdt",
+        "//src_kt/java/arcs/crdt/internal",
+        "//third_party/java/junit",
+        "//third_party/java/truth",
+    ],
+)

--- a/src_kt/javatests/arcs/storage/BUILD
+++ b/src_kt/javatests/arcs/storage/BUILD
@@ -1,39 +1,28 @@
-load("@rules_java//java:defs.bzl", "java_test")
+load(
+    "//third_party/java/arcs/build_defs:build_defs.bzl",
+    "arcs_kt_jvm_test_suite",
+)
 
 licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])
 
-load("//tools/build_defs/kotlin:rules.bzl", "kt_jvm_library")
-
-[
-    [
-        java_test(
-            name = src_file[:-3],
-            size = "small",
-            test_class = "arcs.storage.%s" % src_file[:-3],
-            runtime_deps = [":%sLib" % src_file[:-3]],
-        ),
-        kt_jvm_library(
-            name = "%sLib" % src_file[:-3],
-            testonly = True,
-            srcs = [src_file],
-            deps = [
-                "//src_kt/java/arcs/crdt",
-                "//src_kt/java/arcs/data",
-                "//src_kt/java/arcs/data/util",
-                "//src_kt/java/arcs/storage",
-                "//src_kt/java/arcs/storage/driver",
-                "//src_kt/java/arcs/storage/referencemode",
-                "//src_kt/java/arcs/testutil",
-                "//third_party/java/junit",
-                "//third_party/java/mockito",
-                "//third_party/java/truth",
-                "//third_party/kotlin/kotlinx/kotlinx_coroutines",
-                "//third_party/kotlin/kotlinx/kotlinx_coroutines:kotlinx_coroutines_test",
-                "//third_party/kotlin/mockito_kotlin",
-            ],
-        ),
-    ]
-    for src_file in glob(["*.kt"])
-]
+arcs_kt_jvm_test_suite(
+    name = "storage",
+    package = "arcs.storage",
+    deps = [
+        "//src_kt/java/arcs/crdt",
+        "//src_kt/java/arcs/data",
+        "//src_kt/java/arcs/data/util",
+        "//src_kt/java/arcs/storage",
+        "//src_kt/java/arcs/storage/driver",
+        "//src_kt/java/arcs/storage/referencemode",
+        "//src_kt/java/arcs/testutil",
+        "//third_party/java/junit",
+        "//third_party/java/mockito",
+        "//third_party/java/truth",
+        "//third_party/kotlin/kotlinx/kotlinx_coroutines",
+        "//third_party/kotlin/kotlinx/kotlinx_coroutines:kotlinx_coroutines_test",
+        "//third_party/kotlin/mockito_kotlin",
+    ],
+)

--- a/src_kt/javatests/arcs/storage/api/BUILD
+++ b/src_kt/javatests/arcs/storage/api/BUILD
@@ -1,38 +1,27 @@
-load("@rules_java//java:defs.bzl", "java_test")
+load(
+    "//third_party/java/arcs/build_defs:build_defs.bzl",
+    "arcs_kt_jvm_test_suite",
+)
 
 licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])
 
-load("//tools/build_defs/kotlin:rules.bzl", "kt_jvm_library")
-
-[
-    [
-        java_test(
-            name = src_file[:-3],
-            size = "small",
-            test_class = "arcs.storage.api.%s" % src_file[:-3],
-            runtime_deps = [":%sLib" % src_file[:-3]],
-        ),
-        kt_jvm_library(
-            name = "%sLib" % src_file[:-3],
-            testonly = True,
-            srcs = [src_file],
-            deps = [
-                "//src_kt/java/arcs/common",
-                "//src_kt/java/arcs/data",
-                "//src_kt/java/arcs/data/util",
-                "//src_kt/java/arcs/storage",
-                "//src_kt/java/arcs/storage/api",
-                "//src_kt/java/arcs/storage/driver",
-                "//src_kt/java/arcs/util",
-                "//src_kt/java/arcs/util/testutil",
-                "//third_party/java/junit",
-                "//third_party/java/truth",
-                "//third_party/kotlin/kotlinx/kotlinx_coroutines",
-                "//third_party/kotlin/kotlinx/kotlinx_coroutines:kotlinx_coroutines_test",
-            ],
-        ),
-    ]
-    for src_file in glob(["*.kt"])
-]
+arcs_kt_jvm_test_suite(
+    name = "api",
+    package = "arcs.storage.api",
+    deps = [
+        "//src_kt/java/arcs/common",
+        "//src_kt/java/arcs/data",
+        "//src_kt/java/arcs/data/util",
+        "//src_kt/java/arcs/storage",
+        "//src_kt/java/arcs/storage/api",
+        "//src_kt/java/arcs/storage/driver",
+        "//src_kt/java/arcs/util",
+        "//src_kt/java/arcs/util/testutil",
+        "//third_party/java/junit",
+        "//third_party/java/truth",
+        "//third_party/kotlin/kotlinx/kotlinx_coroutines",
+        "//third_party/kotlin/kotlinx/kotlinx_coroutines:kotlinx_coroutines_test",
+    ],
+)

--- a/src_kt/javatests/arcs/storage/driver/BUILD
+++ b/src_kt/javatests/arcs/storage/driver/BUILD
@@ -1,34 +1,23 @@
-load("@rules_java//java:defs.bzl", "java_test")
+load(
+    "//third_party/java/arcs/build_defs:build_defs.bzl",
+    "arcs_kt_jvm_test_suite",
+)
 
 licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])
 
-load("//tools/build_defs/kotlin:rules.bzl", "kt_jvm_library")
-
-[
-    [
-        java_test(
-            name = src_file[:-3],
-            size = "small",
-            test_class = "arcs.storage.driver.%s" % src_file[:-3],
-            runtime_deps = [":%sLib" % src_file[:-3]],
-        ),
-        kt_jvm_library(
-            name = "%sLib" % src_file[:-3],
-            testonly = True,
-            srcs = [src_file],
-            deps = [
-                "//src_kt/java/arcs/common",
-                "//src_kt/java/arcs/storage",
-                "//src_kt/java/arcs/storage/driver",
-                "//src_kt/java/arcs/util",
-                "//third_party/java/junit",
-                "//third_party/java/truth",
-                "//third_party/kotlin/kotlinx/kotlinx_coroutines",
-                "//third_party/kotlin/kotlinx/kotlinx_coroutines:kotlinx_coroutines_test",
-            ],
-        ),
-    ]
-    for src_file in glob(["*.kt"])
-]
+arcs_kt_jvm_test_suite(
+    name = "driver",
+    package = "arcs.storage.driver",
+    deps = [
+        "//src_kt/java/arcs/common",
+        "//src_kt/java/arcs/storage",
+        "//src_kt/java/arcs/storage/driver",
+        "//src_kt/java/arcs/util",
+        "//third_party/java/junit",
+        "//third_party/java/truth",
+        "//third_party/kotlin/kotlinx/kotlinx_coroutines",
+        "//third_party/kotlin/kotlinx/kotlinx_coroutines:kotlinx_coroutines_test",
+    ],
+)

--- a/src_kt/javatests/arcs/storage/referencemode/BUILD
+++ b/src_kt/javatests/arcs/storage/referencemode/BUILD
@@ -1,36 +1,25 @@
-load("@rules_java//java:defs.bzl", "java_test")
+load(
+    "//third_party/java/arcs/build_defs:build_defs.bzl",
+    "arcs_kt_jvm_test_suite",
+)
 
 licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])
 
-load("//tools/build_defs/kotlin:rules.bzl", "kt_jvm_library")
-
-[
-    [
-        java_test(
-            name = src_file[:-3],
-            size = "small",
-            test_class = "arcs.storage.referencemode.%s" % src_file[:-3],
-            runtime_deps = [":%sLib" % src_file[:-3]],
-        ),
-        kt_jvm_library(
-            name = "%sLib" % src_file[:-3],
-            testonly = True,
-            srcs = [src_file],
-            deps = [
-                "//src_kt/java/arcs/common",
-                "//src_kt/java/arcs/crdt",
-                "//src_kt/java/arcs/storage",
-                "//src_kt/java/arcs/storage/driver",
-                "//src_kt/java/arcs/storage/referencemode",
-                "//third_party/java/junit",
-                "//third_party/java/truth",
-                "//third_party/kotlin/kotlinx/kotlinx_coroutines",
-                "//third_party/kotlin/kotlinx/kotlinx_coroutines:kotlinx_coroutines_test",
-                "//third_party/kotlin/mockito_kotlin",
-            ],
-        ),
-    ]
-    for src_file in glob(["*.kt"])
-]
+arcs_kt_jvm_test_suite(
+    name = "referencemode",
+    package = "arcs.storage.referencemode",
+    deps = [
+        "//src_kt/java/arcs/common",
+        "//src_kt/java/arcs/crdt",
+        "//src_kt/java/arcs/storage",
+        "//src_kt/java/arcs/storage/driver",
+        "//src_kt/java/arcs/storage/referencemode",
+        "//third_party/java/junit",
+        "//third_party/java/truth",
+        "//third_party/kotlin/kotlinx/kotlinx_coroutines",
+        "//third_party/kotlin/kotlinx/kotlinx_coroutines:kotlinx_coroutines_test",
+        "//third_party/kotlin/mockito_kotlin",
+    ],
+)

--- a/src_kt/javatests/arcs/storage/util/BUILD
+++ b/src_kt/javatests/arcs/storage/util/BUILD
@@ -1,34 +1,23 @@
-load("@rules_java//java:defs.bzl", "java_test")
+load(
+    "//third_party/java/arcs/build_defs:build_defs.bzl",
+    "arcs_kt_jvm_test_suite",
+)
 
 licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])
 
-load("//tools/build_defs/kotlin:rules.bzl", "kt_jvm_library")
-
-[
-    [
-        java_test(
-            name = src_file[:-3],
-            size = "small",
-            test_class = "arcs.storage.util.%s" % src_file[:-3],
-            runtime_deps = [":%sLib" % src_file[:-3]],
-        ),
-        kt_jvm_library(
-            name = "%sLib" % src_file[:-3],
-            testonly = True,
-            srcs = [src_file],
-            deps = [
-                "//src_kt/java/arcs/crdt/internal",
-                "//src_kt/java/arcs/storage:proxy",
-                "//src_kt/java/arcs/storage/driver",
-                "//src_kt/java/arcs/storage/referencemode",
-                "//src_kt/java/arcs/storage/util",
-                "//third_party/java/truth",
-                "//third_party/kotlin/kotlinx/kotlinx_coroutines",
-                "//third_party/kotlin/kotlinx/kotlinx_coroutines:kotlinx_coroutines_test",
-            ],
-        ),
-    ]
-    for src_file in glob(["*.kt"])
-]
+arcs_kt_jvm_test_suite(
+    name = "util",
+    package = "arcs.storage.util",
+    deps = [
+        "//src_kt/java/arcs/crdt/internal",
+        "//src_kt/java/arcs/storage:proxy",
+        "//src_kt/java/arcs/storage/driver",
+        "//src_kt/java/arcs/storage/referencemode",
+        "//src_kt/java/arcs/storage/util",
+        "//third_party/java/truth",
+        "//third_party/kotlin/kotlinx/kotlinx_coroutines",
+        "//third_party/kotlin/kotlinx/kotlinx_coroutines:kotlinx_coroutines_test",
+    ],
+)

--- a/src_kt/javatests/arcs/stringEncoder/BUILD
+++ b/src_kt/javatests/arcs/stringEncoder/BUILD
@@ -1,31 +1,20 @@
-load("@rules_java//java:defs.bzl", "java_test")
+load(
+    "//third_party/java/arcs/build_defs:build_defs.bzl",
+    "arcs_kt_jvm_test_suite",
+)
 
 licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])
 
-load("//tools/build_defs/kotlin:rules.bzl", "kt_jvm_library")
-
-[
-    [
-        java_test(
-            name = src_file[:-3],
-            size = "small",
-            test_class = "arcs.stringEncoder.%s" % src_file[:-3],
-            runtime_deps = [":%sLib" % src_file[:-3]],
-        ),
-        kt_jvm_library(
-            name = "%sLib" % src_file[:-3],
-            testonly = True,
-            srcs = [src_file],
-            deps = [
-                "//src/wasm/kotlin:arcs",
-                "//third_party/java/junit",
-                "//third_party/java/truth",
-                "//third_party/kotlin/kotlinx/kotlinx_coroutines",
-                "//third_party/kotlin/kotlinx/kotlinx_coroutines:kotlinx_coroutines_test",
-            ],
-        ),
-    ]
-    for src_file in glob(["*.kt"])
-]
+arcs_kt_jvm_test_suite(
+    name = "stringEncoder",
+    package = "arcs.stringEncoder",
+    deps = [
+        "//src/wasm/kotlin:arcs",
+        "//third_party/java/junit",
+        "//third_party/java/truth",
+        "//third_party/kotlin/kotlinx/kotlinx_coroutines",
+        "//third_party/kotlin/kotlinx/kotlinx_coroutines:kotlinx_coroutines_test",
+    ],
+)

--- a/src_kt/javatests/arcs/type/BUILD
+++ b/src_kt/javatests/arcs/type/BUILD
@@ -1,29 +1,18 @@
-load("@rules_java//java:defs.bzl", "java_test")
+load(
+    "//third_party/java/arcs/build_defs:build_defs.bzl",
+    "arcs_kt_jvm_test_suite",
+)
 
 licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])
 
-load("//tools/build_defs/kotlin:rules.bzl", "kt_jvm_library")
-
-[
-    [
-        java_test(
-            name = src_file[:-3],
-            size = "small",
-            test_class = "arcs.type.%s" % src_file[:-3],
-            runtime_deps = [":%sLib" % src_file[:-3]],
-        ),
-        kt_jvm_library(
-            name = "%sLib" % src_file[:-3],
-            testonly = True,
-            srcs = [src_file],
-            deps = [
-                "//src_kt/java/arcs/type",
-                "//third_party/java/junit",
-                "//third_party/java/truth",
-            ],
-        ),
-    ]
-    for src_file in glob(["*.kt"])
-]
+arcs_kt_jvm_test_suite(
+    name = "type",
+    package = "arcs.type",
+    deps = [
+        "//src_kt/java/arcs/type",
+        "//third_party/java/junit",
+        "//third_party/java/truth",
+    ],
+)

--- a/src_kt/javatests/arcs/util/BUILD
+++ b/src_kt/javatests/arcs/util/BUILD
@@ -1,51 +1,38 @@
-load("@rules_java//java:defs.bzl", "java_test")
+load(
+    "//third_party/java/arcs/build_defs:build_defs.bzl",
+    "arcs_kt_jvm_test_suite",
+)
 
 licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])
 
-load("//tools/build_defs/kotlin:rules.bzl", "kt_jvm_library")
-
-[
-    [
-        java_test(
-            name = src_file[:-3],
-            size = "small",
-            test_class = "arcs.util.%s" % src_file[:-3],
-            runtime_deps = [":%sLib" % src_file[:-3]],
-        ),
-        kt_jvm_library(
-            name = "%sLib" % src_file[:-3],
-            testonly = True,
-            srcs = [src_file],
-            deps = [
-                "//src_kt/java/arcs/testutil",
-                "//src_kt/java/arcs/util",
-                "//third_party/java/junit",
-                "//third_party/java/truth",
-                "//third_party/kotlin/kotlinx/kotlinx_atomicfu",
-                "//third_party/kotlin/kotlinx/kotlinx_coroutines",
-                "//third_party/kotlin/kotlinx/kotlinx_coroutines:kotlinx_coroutines_test",
-            ],
-        ),
-    ]
-    for src_file in glob(
-        ["*.kt"],
-        exclude = ["Base64PerformanceTest.kt"],
-    )
+PERFORMANCE_SRCS = [
+    "Base64PerformanceTest.kt",
 ]
 
-java_test(
-    name = "Base64PerformanceTest",
-    size = "small",
-    test_class = "arcs.util.Base64PerformanceTest",
-    runtime_deps = [":Base64PerformanceTestLib"],
+arcs_kt_jvm_test_suite(
+    name = "util",
+    package = "arcs.util",
+    srcs = glob(
+        ["*.kt"],
+        exclude = PERFORMANCE_SRCS,
+    ),
+    deps = [
+        "//src_kt/java/arcs/testutil",
+        "//src_kt/java/arcs/util",
+        "//third_party/java/junit",
+        "//third_party/java/truth",
+        "//third_party/kotlin/kotlinx/kotlinx_atomicfu",
+        "//third_party/kotlin/kotlinx/kotlinx_coroutines",
+        "//third_party/kotlin/kotlinx/kotlinx_coroutines:kotlinx_coroutines_test",
+    ],
 )
 
-kt_jvm_library(
-    name = "Base64PerformanceTestLib",
-    testonly = True,
-    srcs = ["Base64PerformanceTest.kt"],
+arcs_kt_jvm_test_suite(
+    name = "util_performance",
+    package = "arcs.util",
+    srcs = PERFORMANCE_SRCS,
     deps = [
         "//src_kt/java/arcs/util",
         "//third_party/java/junit",

--- a/src_kt/javatests/arcs/util/BUILD
+++ b/src_kt/javatests/arcs/util/BUILD
@@ -13,11 +13,11 @@ PERFORMANCE_SRCS = [
 
 arcs_kt_jvm_test_suite(
     name = "util",
-    package = "arcs.util",
     srcs = glob(
         ["*.kt"],
         exclude = PERFORMANCE_SRCS,
     ),
+    package = "arcs.util",
     deps = [
         "//src_kt/java/arcs/testutil",
         "//src_kt/java/arcs/util",
@@ -31,8 +31,8 @@ arcs_kt_jvm_test_suite(
 
 arcs_kt_jvm_test_suite(
     name = "util_performance",
-    package = "arcs.util",
     srcs = PERFORMANCE_SRCS,
+    package = "arcs.util",
     deps = [
         "//src_kt/java/arcs/util",
         "//third_party/java/junit",

--- a/third_party/java/arcs/build_defs/build_defs.bzl
+++ b/third_party/java/arcs/build_defs/build_defs.bzl
@@ -4,8 +4,8 @@ load(":sigh.bzl", "sigh_command")
 load(
     "//third_party/java/arcs/build_defs/internal:kotlin.bzl",
     _arcs_kt_android_test_suite = "arcs_kt_android_test_suite",
-    _arcs_kt_jvm_test_suite = "arcs_kt_jvm_test_suite",
     _arcs_kt_binary = "arcs_kt_binary",
+    _arcs_kt_jvm_test_suite = "arcs_kt_jvm_test_suite",
     _arcs_kt_library = "arcs_kt_library",
     _kt_jvm_and_js_library = "kt_jvm_and_js_library",
 )

--- a/third_party/java/arcs/build_defs/build_defs.bzl
+++ b/third_party/java/arcs/build_defs/build_defs.bzl
@@ -3,6 +3,8 @@
 load(":sigh.bzl", "sigh_command")
 load(
     "//third_party/java/arcs/build_defs/internal:kotlin.bzl",
+    _arcs_kt_android_test_suite = "arcs_kt_android_test_suite",
+    _arcs_kt_jvm_test_suite = "arcs_kt_jvm_test_suite",
     _arcs_kt_binary = "arcs_kt_binary",
     _arcs_kt_library = "arcs_kt_library",
     _kt_jvm_and_js_library = "kt_jvm_and_js_library",
@@ -21,6 +23,10 @@ load(
 # Re-export rules from various other files.
 
 arcs_cc_schema = _arcs_cc_schema
+
+arcs_kt_android_test_suite = _arcs_kt_android_test_suite
+
+arcs_kt_jvm_test_suite = _arcs_kt_jvm_test_suite
 
 arcs_kt_schema = _arcs_kt_schema
 

--- a/third_party/java/arcs/build_defs/internal/kotlin.bzl
+++ b/third_party/java/arcs/build_defs/internal/kotlin.bzl
@@ -180,10 +180,7 @@ def arcs_kt_jvm_test_suite(name, package, srcs = None, deps = []):
             name = class_name,
             size = "small",
             test_class = "%s.%s" % (package, class_name),
-            runtime_deps = [
-                ":%s" % name,
-                "@robolectric//bazel:android-all",
-            ],
+            runtime_deps = [":%s" % name],
         )
 
 def _to_jvm_dep(dep):

--- a/third_party/java/arcs/build_defs/internal/kotlin.bzl
+++ b/third_party/java/arcs/build_defs/internal/kotlin.bzl
@@ -8,7 +8,7 @@ load("//third_party/bazel_rules/rules_kotlin/kotlin/js:js_library.bzl", "kt_js_l
 load("//third_party/bazel_rules/rules_kotlin/kotlin/native:native_rules.bzl", "kt_native_binary", "kt_native_library")
 load("//third_party/bazel_rules/rules_kotlin/kotlin/native:wasm.bzl", "wasm_kt_binary")
 load("//tools/build_defs/android:rules.bzl", "android_local_test")
-load("//tools/build_defs/kotlin:rules.bzl", "kt_jvm_library", "kt_android_library")
+load("//tools/build_defs/kotlin:rules.bzl", "kt_android_library", "kt_jvm_library")
 
 _ARCS_KOTLIN_LIBS = ["//third_party/java/arcs/sdk/kotlin"]
 
@@ -113,7 +113,7 @@ def kt_jvm_and_js_library(
 
 def arcs_kt_android_test_suite(name, manifest, package, srcs = None, deps = []):
     """Defines Kotlin Android test targets for a directory.
-    
+
     Defines a Kotlin Android library (kt_android_library) for all of the sources
     in the current directory, and then defines an Android test target
     (android_local_test) for each individual test file.
@@ -152,7 +152,7 @@ def arcs_kt_android_test_suite(name, manifest, package, srcs = None, deps = []):
 
 def arcs_kt_jvm_test_suite(name, package, srcs = None, deps = []):
     """Defines Kotlin JVM test targets for a directory.
-    
+
     Defines a Kotlin JVM library (kt_jvm_library) for all of the sources
     in the current directory, and then defines an JVM test target (java_test)
     for each individual test file.

--- a/third_party/java/arcs/build_defs/internal/kotlin.bzl
+++ b/third_party/java/arcs/build_defs/internal/kotlin.bzl
@@ -3,11 +3,12 @@
 Rules are re-exported in build_defs.bzl -- use those instead.
 """
 
-load("@rules_java//java:defs.bzl", "java_library")
-load("//third_party/bazel_rules/rules_kotlin/kotlin/native:native_rules.bzl", "kt_native_binary", "kt_native_library")
+load("@rules_java//java:defs.bzl", "java_library", "java_test")
 load("//third_party/bazel_rules/rules_kotlin/kotlin/js:js_library.bzl", "kt_js_library")
-load("//tools/build_defs/kotlin:rules.bzl", "kt_jvm_library")
+load("//third_party/bazel_rules/rules_kotlin/kotlin/native:native_rules.bzl", "kt_native_binary", "kt_native_library")
 load("//third_party/bazel_rules/rules_kotlin/kotlin/native:wasm.bzl", "wasm_kt_binary")
+load("//tools/build_defs/android:rules.bzl", "android_local_test")
+load("//tools/build_defs/kotlin:rules.bzl", "kt_jvm_library", "kt_android_library")
 
 _ARCS_KOTLIN_LIBS = ["//third_party/java/arcs/sdk/kotlin"]
 
@@ -108,6 +109,81 @@ def kt_jvm_and_js_library(
             srcs = srcs,
             deps = [_to_js_dep(dep) for dep in deps],
             **js_kwargs
+        )
+
+def arcs_kt_android_test_suite(name, manifest, package, srcs = None, deps = []):
+    """Defines Kotlin Android test targets for a directory.
+    
+    Defines a Kotlin Android library (kt_android_library) for all of the sources
+    in the current directory, and then defines an Android test target
+    (android_local_test) for each individual test file.
+
+    Args:
+      name: name to use for the kt_android_library target
+      manifest: label of the Android manifest file to use
+      package: package the test classes are in
+      srcs: Optional list of source files. If not supplied, a glob of all *.kt
+        files will be used.
+      deps: list of dependencies for the kt_android_library
+    """
+    if not srcs:
+        srcs = native.glob(["*.kt"])
+
+    kt_android_library(
+        name = name,
+        srcs = native.glob(["*.kt"]),
+        manifest = manifest,
+        testonly = True,
+        deps = deps,
+    )
+
+    for src in native.glob(["*.kt"]):
+        class_name = src[:-3]
+        android_local_test(
+            name = class_name,
+            size = "small",
+            manifest = manifest,
+            test_class = "%s.%s" % (package, class_name),
+            deps = [
+                ":%s" % name,
+                "@robolectric//bazel:android-all",
+            ],
+        )
+
+def arcs_kt_jvm_test_suite(name, package, srcs = None, deps = []):
+    """Defines Kotlin JVM test targets for a directory.
+    
+    Defines a Kotlin JVM library (kt_jvm_library) for all of the sources
+    in the current directory, and then defines an JVM test target (java_test)
+    for each individual test file.
+
+    Args:
+      name: name to use for the kt_jvm_library target
+      package: package the test classes are in
+      srcs: Optional list of source files. If not supplied, a glob of all *.kt
+        files will be used.
+      deps: list of dependencies for the kt_jvm_library
+    """
+    if not srcs:
+        srcs = native.glob(["*.kt"])
+
+    kt_jvm_library(
+        name = name,
+        srcs = srcs,
+        testonly = True,
+        deps = deps,
+    )
+
+    for src in srcs:
+        class_name = src[:-3]
+        java_test(
+            name = class_name,
+            size = "small",
+            test_class = "%s.%s" % (package, class_name),
+            runtime_deps = [
+                ":%s" % name,
+                "@robolectric//bazel:android-all",
+            ],
         )
 
 def _to_jvm_dep(dep):


### PR DESCRIPTION
These macros consolidate the logic for writing suites of unit tests all in one place.

They're also going to be helpful for importing this code inside google, since there is some build rule wrangling that needs to be done, and that can now be done in one place.
