### PR TITLE
Added native.oss.bzl file

### DIFF
--- a/javaharness/BUILD
+++ b/javaharness/BUILD
@@ -1,5 +1,5 @@
 load(
-    "//third_party/arcs/build_defs/native.oss.bzl",
+    "//third_party/java/arcs/build_defs:native.oss.bzl",
     "java_library",
     "java_plugin",
 )

--- a/javaharness/BUILD
+++ b/javaharness/BUILD
@@ -1,4 +1,8 @@
-load("@rules_java//java:defs.bzl", "java_library", "java_plugin")
+load(
+    "//third_party/arcs/build_defs/native.oss.bzl",
+    "java_library",
+    "java_plugin",
+)
 
 package(default_visibility = ["//visibility:public"])
 

--- a/javaharness/javatests/arcs/android/BUILD
+++ b/javaharness/javatests/arcs/android/BUILD
@@ -1,4 +1,4 @@
-load("@rules_java//java:defs.bzl", "java_test")
+load("//third_party/arcs/build_defs/native.oss.bzl", "java_test")
 
 licenses(["notice"])
 

--- a/javaharness/javatests/arcs/android/BUILD
+++ b/javaharness/javatests/arcs/android/BUILD
@@ -1,4 +1,4 @@
-load("//third_party/arcs/build_defs/native.oss.bzl", "java_test")
+load("//third_party/java/arcs/build_defs:native.oss.bzl", "java_test")
 
 licenses(["notice"])
 

--- a/javaharness/javatests/arcs/api/BUILD
+++ b/javaharness/javatests/arcs/api/BUILD
@@ -1,4 +1,4 @@
-load("@rules_java//java:defs.bzl", "java_test")
+load("//third_party/arcs/build_defs/native.oss.bzl", "java_test")
 
 licenses(["notice"])
 

--- a/javaharness/javatests/arcs/api/BUILD
+++ b/javaharness/javatests/arcs/api/BUILD
@@ -1,4 +1,4 @@
-load("//third_party/arcs/build_defs/native.oss.bzl", "java_test")
+load("//third_party/java/arcs/build_defs:native.oss.bzl", "java_test")
 
 licenses(["notice"])
 

--- a/javaharness/javatests/arcs/crdt/BUILD
+++ b/javaharness/javatests/arcs/crdt/BUILD
@@ -1,4 +1,4 @@
-load("@rules_java//java:defs.bzl", "java_test")
+load("//third_party/arcs/build_defs/native.oss.bzl", "java_test")
 
 licenses(["notice"])
 

--- a/javaharness/javatests/arcs/crdt/BUILD
+++ b/javaharness/javatests/arcs/crdt/BUILD
@@ -1,4 +1,4 @@
-load("//third_party/arcs/build_defs/native.oss.bzl", "java_test")
+load("//third_party/java/arcs/build_defs:native.oss.bzl", "java_test")
 
 licenses(["notice"])
 

--- a/third_party/java/arcs/build_defs/native.oss.bzl
+++ b/third_party/java/arcs/build_defs/native.oss.bzl
@@ -1,0 +1,17 @@
+"""Re-exports some "native" build rules.
+
+Use these in Arcs instead of loading them from the external repos directly.
+"""
+
+load(
+    "@rules_java//java:defs.bzl",
+    _java_library = "java_library",
+    _java_plugin = "java_plugin",
+    _java_test = "java_test",
+)
+
+java_library = _java_library
+
+java_plugin = _java_plugin
+
+java_test = _java_test


### PR DESCRIPTION
This file just re-exports "native" build rules, e.g. java_library. Instead of loading these from @java_rules, we now load them from this native.oss.bzl file.

This will help with importing into google, where referencing those external repos (@java_rules) is not needed.