### PR TITLE
Remove a bunch of internal keywords

### DIFF
--- a/src_kt/java/arcs/common/Id.kt
+++ b/src_kt/java/arcs/common/Id.kt
@@ -97,7 +97,7 @@ interface Id {
 fun String.toArcId(): ArcId = toId().let { ArcId(it.root, it.idTree) }
 
 /** [Id] for an Arc. */
-data class ArcId internal constructor(
+data class ArcId /* internal */ constructor(
     override val root: String,
     override val idTree: List<String>
 ) : Id {

--- a/src_kt/java/arcs/common/Id.kt
+++ b/src_kt/java/arcs/common/Id.kt
@@ -116,7 +116,7 @@ data class ArcId internal constructor(
     }
 }
 
-internal data class IdImpl(
+/* internal */ data class IdImpl(
     override val root: String,
     override val idTree: List<String> = emptyList()
 ) : Id {

--- a/src_kt/java/arcs/crdt/CrdtEntity.kt
+++ b/src_kt/java/arcs/crdt/CrdtEntity.kt
@@ -236,7 +236,7 @@ class CrdtEntity(
         /** Makes a deep copy of this [CrdtEntity.Data] object. */
         // We can't rely on the Data Class's .copy(param=val,..) because it doesn't deep-copy the
         // inners, unfortunately.
-        internal fun copy(): Data = Data(
+        /* internal */ fun copy(): Data = Data(
             versionMap.copy(),
             HashMap(singletons.mapValues { it.value.copy() }),
             HashMap(collections.mapValues { it.value.copy() })

--- a/src_kt/java/arcs/crdt/CrdtSet.kt
+++ b/src_kt/java/arcs/crdt/CrdtSet.kt
@@ -23,7 +23,7 @@ import arcs.crdt.internal.VersionMap
 /** A [CrdtModel] capable of managing a set of items [T]. */
 class CrdtSet<T : Referencable>(
     /** Initial data. */
-    internal var _data: Data<T> = DataImpl(),
+    /* internal */ var _data: Data<T> = DataImpl(),
     /** Function to construct a new, empty [Data] object with a given [VersionMap]. */
     private val dataBuilder: (VersionMap) -> Data<T> = { DataImpl(it) }
 ) : CrdtModel<Data<T>, CrdtSet.IOperation<T>, Set<T>> {
@@ -109,7 +109,7 @@ class CrdtSet<T : Referencable>(
     }
 
     /** Makes a deep copy of this [CrdtSet]. */
-    internal fun copy(): CrdtSet<T> = CrdtSet(
+    /* internal */ fun copy(): CrdtSet<T> = CrdtSet(
         DataImpl(_data.versionMap.copy(), HashMap(_data.values)),
         dataBuilder
     )

--- a/src_kt/java/arcs/crdt/CrdtSingleton.kt
+++ b/src_kt/java/arcs/crdt/CrdtSingleton.kt
@@ -87,7 +87,7 @@ class CrdtSingleton<T : Referencable>(
     override fun updateData(newData: Data<T>) = set.updateData(newData)
 
     /** Makes a deep copy of this [CrdtSingleton]. */
-    internal fun copy(): CrdtSingleton<T> = CrdtSingleton(singletonToCopy = this)
+    /* internal */ fun copy(): CrdtSingleton<T> = CrdtSingleton(singletonToCopy = this)
 
     override fun toString(): String = "CrdtSingleton(data=${set.data})"
 

--- a/src_kt/java/arcs/data/Schema.kt
+++ b/src_kt/java/arcs/data/Schema.kt
@@ -45,7 +45,7 @@ data class Schema(
     }
 
     companion object {
-        fun fromLiteral(literal: arcs.common.Literal): Schema {
+        fun fromLiteral(@Suppress("UNUSED_PARAMETER") literal: arcs.common.Literal): Schema {
             TODO("Implement me.")
         }
     }

--- a/src_kt/java/arcs/storage/BackingStore.kt
+++ b/src_kt/java/arcs/storage/BackingStore.kt
@@ -87,7 +87,7 @@ class BackingStore(
     }
 
     @Suppress("UNCHECKED_CAST") // TODO: See if we can clean up this generics situation.
-    internal suspend fun setupStore(muxId: String): StoreRecord {
+    /* internal */ suspend fun setupStore(muxId: String): StoreRecord {
         val store = DirectStore.CONSTRUCTOR(
             // Copy of our options, but with a child storage key using the muxId.
             options.copy(options.storageKey.childKeyWithComponent(muxId))

--- a/src_kt/java/arcs/storage/BackingStore.kt
+++ b/src_kt/java/arcs/storage/BackingStore.kt
@@ -34,7 +34,7 @@ class BackingStore(
     private val options: StoreOptions<CrdtData, CrdtOperation, Any?>
 ) : ActiveStore<CrdtData, CrdtOperation, Any?>(options) {
     private val storeMutex = Mutex()
-    internal val stores = mutableMapOf<String, StoreRecord>()
+    /* internal */ val stores = mutableMapOf<String, StoreRecord>()
     private val callbacks = ProxyCallbackManager<CrdtData, CrdtOperation, Any?>()
 
     @Deprecated(

--- a/src_kt/java/arcs/storage/DirectStore.kt
+++ b/src_kt/java/arcs/storage/DirectStore.kt
@@ -35,7 +35,7 @@ import kotlinx.coroutines.Job
  * This is what *directly* manages a [CrdtSingleton], [CrdtSet], or [CrdtCount].
  */
 // TODO: generics here are sub-optimal, can we make this class generic itself?
-class DirectStore internal constructor(
+class DirectStore /* internal */ constructor(
     options: StoreOptions<CrdtData, CrdtOperation, Any?>,
     /* internal */ val localModel: CrdtModel<CrdtData, CrdtOperation, Any?>,
     /* internal */ val driver: Driver<CrdtData>
@@ -151,7 +151,7 @@ class DirectStore internal constructor(
         )
     }
 
-    internal suspend fun onReceive(data: CrdtData, version: Int) {
+    /* internal */ suspend fun onReceive(data: CrdtData, version: Int) {
         log.debug { "onReceive($data, $version)" }
 
         if (state.value.shouldApplyPendingDriverModelsOnReceive(data, version)) {

--- a/src_kt/java/arcs/storage/DirectStore.kt
+++ b/src_kt/java/arcs/storage/DirectStore.kt
@@ -37,8 +37,8 @@ import kotlinx.coroutines.Job
 // TODO: generics here are sub-optimal, can we make this class generic itself?
 class DirectStore internal constructor(
     options: StoreOptions<CrdtData, CrdtOperation, Any?>,
-    internal val localModel: CrdtModel<CrdtData, CrdtOperation, Any?>,
-    internal val driver: Driver<CrdtData>
+    /* internal */ val localModel: CrdtModel<CrdtData, CrdtOperation, Any?>,
+    /* internal */ val driver: Driver<CrdtData>
 ) : ActiveStore<CrdtData, CrdtOperation, Any?>(options) {
     override val versionToken: String?
         get() = driver.token

--- a/src_kt/java/arcs/storage/ReferenceModeStore.kt
+++ b/src_kt/java/arcs/storage/ReferenceModeStore.kt
@@ -73,8 +73,8 @@ import kotlinx.coroutines.Job
  */
 class ReferenceModeStore private constructor(
     options: StoreOptions<RefModeStoreData, RefModeStoreOp, RefModeStoreOutput>,
-    internal val backingStore: BackingStore,
-    internal val containerStore: DirectStore
+    /* internal */ val backingStore: BackingStore,
+    /* internal */ val containerStore: DirectStore
 ) : ActiveStore<RefModeStoreData, RefModeStoreOp, RefModeStoreOutput>(options) {
     /**
      * A queue of incoming updates from the backing store, container store, and connected proxies.
@@ -108,7 +108,7 @@ class ReferenceModeStore private constructor(
      * needs to synthesize updates. This key is used as the unique write key and
      * [arcs.crdt.internal.Actor] for those updates.
      */
-    internal val crdtKey = Random.nextSafeRandomLong().toString()
+    /* internal */ val crdtKey = Random.nextSafeRandomLong().toString()
     /**
      * The [versions] map transitively tracks the maximum write version for each contained entity's
      * fields, to ensure synthesized updates can be correctly applied downstream.

--- a/src_kt/java/arcs/storage/StoreInterface.kt
+++ b/src_kt/java/arcs/storage/StoreInterface.kt
@@ -37,7 +37,7 @@ data class StoreConstructor(
     val typeParamString: String
         get() = "<$dataClass, $opClass, $consumerDataClass>"
 
-    internal suspend operator fun <Data : CrdtData, Op : CrdtOperation, ConsumerData> invoke(
+    /* internal */ suspend operator fun <Data : CrdtData, Op : CrdtOperation, ConsumerData> invoke(
         options: StoreOptions<Data, Op, ConsumerData>
     ) = constructor(options)
 }

--- a/src_kt/java/arcs/storage/StoreInterface.kt
+++ b/src_kt/java/arcs/storage/StoreInterface.kt
@@ -29,9 +29,9 @@ interface IStore<Data : CrdtData, Op : CrdtOperation, ConsumerData> {
  * well as provide ample information to support looking the constructor up by expected types.
  */
 data class StoreConstructor(
-    internal val dataClass: KClass<out CrdtData>,
-    internal val opClass: KClass<out CrdtOperation>,
-    internal val consumerDataClass: KClass<*>,
+    /* internal */ val dataClass: KClass<out CrdtData>,
+    /* internal */ val opClass: KClass<out CrdtOperation>,
+    /* internal */ val consumerDataClass: KClass<*>,
     private val constructor: suspend (StoreOptions<*, *, *>) -> ActiveStore<*, *, *>
 ) {
     val typeParamString: String

--- a/src_kt/java/arcs/storage/api/ArcsSet.kt
+++ b/src_kt/java/arcs/storage/api/ArcsSet.kt
@@ -411,7 +411,7 @@ class ArcsSet<T, StoreData, StoreOp>(
      * The [removeAsync] function allows for concurrent removal of the iterator's current item from
      * the [ArcsSet].
      */
-    class SuspendingIterator<T, StoreData, StoreOp> internal constructor(
+    class SuspendingIterator<T, StoreData, StoreOp> /* internal */ constructor(
         private val parent: ArcsSet<T, StoreData, StoreOp>,
         private var backingIterator: Iterator<T>
     ) : Iterator<T> where T : Referencable,
@@ -435,7 +435,7 @@ class ArcsSet<T, StoreData, StoreOp>(
             return parent.removeAsync(current, coroutineContext)
         }
 
-        internal suspend fun sync(
+        /* internal */ suspend fun sync(
             coroutineContext: CoroutineContext = parent.scope.coroutineContext
         ) {
             check(current == null) { "Syncs may only be performed before iteration has begun" }

--- a/src_kt/java/arcs/storage/driver/RamDisk.kt
+++ b/src_kt/java/arcs/storage/driver/RamDisk.kt
@@ -87,7 +87,7 @@ class RamDiskDriverProvider : DriverProvider {
 
 /** Singleton, for maintaining a single [VolatileMemory] reference to be shared across all arcs. */
 object RamDisk {
-    internal val memory = VolatileMemory()
+    /* internal */ val memory = VolatileMemory()
 
     /** Clears every piece of data from the [RamDisk] memory. */
     fun clear() = memory.clear()

--- a/src_kt/java/arcs/storage/driver/Volatile.kt
+++ b/src_kt/java/arcs/storage/driver/Volatile.kt
@@ -83,7 +83,7 @@ data class VolatileDriverProvider(private val arcId: ArcId) : DriverProvider {
 }
 
 /** [Driver] implementation for an in-memory store of data. */
-internal class VolatileDriver<Data : Any>(
+/* internal */ class VolatileDriver<Data : Any>(
     override val storageKey: StorageKey,
     override val existenceCriteria: ExistenceCriteria,
     private val memory: VolatileMemory
@@ -92,7 +92,7 @@ internal class VolatileDriver<Data : Any>(
     // The identifier is simply used to help differentiate between VolatileDrivers for the same
     // storage key.
     private val identifier = nextIdentifier.incrementAndGet()
-    internal var receiver: (suspend (data: Data, version: Int) -> Unit)? = null
+    /* internal */ var receiver: (suspend (data: Data, version: Int) -> Unit)? = null
     private var pendingModel: Data? = null
     private var pendingVersion: Int = 0
 
@@ -174,7 +174,7 @@ internal class VolatileDriver<Data : Any>(
 }
 
 /** A single entry in a [VolatileDriver]. */
-internal data class VolatileEntry<Data : Any>(
+/* internal */ data class VolatileEntry<Data : Any>(
     val data: Data? = null,
     val version: Int = 0,
     val drivers: Set<VolatileDriver<Data>> = emptySet()
@@ -186,7 +186,7 @@ internal data class VolatileEntry<Data : Any>(
 /**
  * Lookup map of storage keys to entries, with a [token] that gets updated when data has changed.
  */
-internal class VolatileMemory {
+/* internal */ class VolatileMemory {
     private val lock = Any()
     private val entries = mutableMapOf<StorageKey, VolatileEntry<*>>()
 

--- a/src_kt/java/arcs/storage/referencemode/BridgingOperation.kt
+++ b/src_kt/java/arcs/storage/referencemode/BridgingOperation.kt
@@ -42,7 +42,7 @@ sealed class BridgingOperation : CrdtOperationAtTime {
     abstract val refModeOp: RefModeStoreOp
 
     /** Denotes an update to the [CrdtSingleton] managed by the store. */
-    data class UpdateSingleton internal constructor(
+    data class UpdateSingleton /* internal */ constructor(
         override val entityValue: RawEntity?,
         override val referenceValue: Reference?,
         override val containerOp: CrdtSingleton.Operation.Update<Reference>,
@@ -52,7 +52,7 @@ sealed class BridgingOperation : CrdtOperationAtTime {
     }
 
     /** Denotes a clearing of the [CrdtSingleton] managed by the store. */
-    data class ClearSingleton internal constructor(
+    data class ClearSingleton /* internal */ constructor(
         override val containerOp: CrdtSingleton.Operation.Clear<Reference>,
         override val refModeOp: RefModeStoreOp.SingletonClear
     ) : BridgingOperation() {
@@ -62,7 +62,7 @@ sealed class BridgingOperation : CrdtOperationAtTime {
     }
 
     /** Denotes an addition to the [CrdtSet] managed by the store. */
-    class AddToSet internal constructor(
+    class AddToSet /* internal */ constructor(
         override val entityValue: RawEntity?,
         override val referenceValue: Reference?,
         override val containerOp: CrdtSet.Operation.Add<Reference>,
@@ -72,7 +72,7 @@ sealed class BridgingOperation : CrdtOperationAtTime {
     }
 
     /** Denotes a removal from the [CrdtSet] managed by the store. */
-    class RemoveFromSet internal constructor(
+    class RemoveFromSet /* internal */ constructor(
         override val entityValue: RawEntity?,
         override val referenceValue: Reference?,
         override val containerOp: CrdtSet.Operation.Remove<Reference>,

--- a/src_kt/java/arcs/storage/referencemode/ReferenceModeStorageKey.kt
+++ b/src_kt/java/arcs/storage/referencemode/ReferenceModeStorageKey.kt
@@ -75,8 +75,8 @@ data class ReferenceModeStorageKey(
     }
 }
 
-internal fun String.unEmbed(): StorageKey =
+/* internal */ fun String.unEmbed(): StorageKey =
     StorageKeyParser.parse(replace("\\{\\{".toRegex(), "{").replace("}}".toRegex(), "}"))
 
-internal fun StorageKey.embed() =
+/* internal */ fun StorageKey.embed() =
     toString().replace("\\{".toRegex(), "{{").replace("}".toRegex(), "}}")

--- a/src_kt/java/arcs/storage/util/HoldQueue.kt
+++ b/src_kt/java/arcs/storage/util/HoldQueue.kt
@@ -26,7 +26,7 @@ import kotlinx.coroutines.sync.withLock
  */
 class HoldQueue {
     private val mutex = Mutex()
-    internal val queue = mutableMapOf<ReferenceId, MutableList<Record>>()
+    /* internal */ val queue = mutableMapOf<ReferenceId, MutableList<Record>>()
 
     /**
      * Enqueues a collection of [Entities] into the [HoldQueue]. When they are ready, [onRelease]
@@ -78,7 +78,7 @@ class HoldQueue {
     data class Entity(val id: ReferenceId, val version: VersionMap)
 
     // Internal for testing.
-    internal data class Record(
+    /* internal */ data class Record(
         val ids: MutableMap<ReferenceId, VersionMap>,
         val onRelease: suspend () -> Unit
     )

--- a/src_kt/java/arcs/storage/util/ProxyCallbackManager.kt
+++ b/src_kt/java/arcs/storage/util/ProxyCallbackManager.kt
@@ -23,7 +23,7 @@ import kotlinx.coroutines.sync.withLock
 class ProxyCallbackManager<Data : CrdtData, Op : CrdtOperation, ConsumerData> {
     private val mutex = Mutex()
     val nextCallbackToken = atomic(1)
-    internal val callbacks = mutableMapOf<Int, ProxyCallback<Data, Op, ConsumerData>>()
+    /* internal */ val callbacks = mutableMapOf<Int, ProxyCallback<Data, Op, ConsumerData>>()
 
     /** Adds a [ProxyCallback] to the collection, and returns its token. */
     fun register(proxyCallback: ProxyCallback<Data, Op, ConsumerData>): Int {

--- a/src_kt/java/arcs/storage/util/SendQueue.kt
+++ b/src_kt/java/arcs/storage/util/SendQueue.kt
@@ -93,7 +93,7 @@ class SendQueue(
         holdQueue.processReferenceId(id, version)
 
     /** Utility to get the queued runnables from tests. */
-    internal suspend fun getQueueRunnables(): List<suspend () -> Unit> =
+    /* internal */ suspend fun getQueueRunnables(): List<suspend () -> Unit> =
         mutex.withLock { queue.map { it.fn } }
 
     /** Wrapper for a suspending function which is used as an item in a [SendQueue]. */

--- a/src_kt/java/arcs/type/TypeFactory.kt
+++ b/src_kt/java/arcs/type/TypeFactory.kt
@@ -58,5 +58,5 @@ object TypeFactory {
     }
 
     /** For use in `teardown()` methods in test cases. Clears any registered type builders. */
-    internal fun clearRegistrationsForTesting() = synchronized(lock) { builders.clear() }
+    /* internal */ fun clearRegistrationsForTesting() = synchronized(lock) { builders.clear() }
 }

--- a/src_kt/java/arcs/util/Log.kt
+++ b/src_kt/java/arcs/util/Log.kt
@@ -10,7 +10,7 @@ import kotlinx.atomicfu.atomic
  * Allows for pluggable log-output sinks (see [writer]) and message [formatter]s.
  */
 object Log {
-    internal val logIndex = atomic(0)
+    /* internal */ val logIndex = atomic(0)
 
     /** The current log level. See [Level]. */
     var level = DEFAULT_LEVEL


### PR DESCRIPTION
These internal functions are called in unit tests, but that is not supported yet in google internally. I've marked them with `/* internal */` so that we can revert them later.

Using `@VisibleForTesting` would be a good compromise too, but there's a few hoops to jump through to get that working, so let's just wait until `internal` works.