### PR TITLE
Freeze devtools modules and sync cross-env version with top level.

### DIFF
--- a/devtools/package.json
+++ b/devtools/package.json
@@ -3,24 +3,24 @@
   "name": "arcs-devtools",
   "version": "0.0.0",
   "dependencies": {
-    "@polymer/iron-a11y-keys-behavior": "^3.0.1",
-    "@polymer/iron-autogrow-textarea": "^3.0.1",
-    "@polymer/iron-dropdown": "^3.0.1",
-    "@polymer/iron-icons": "^3.0.1",
-    "@polymer/iron-list": "^3.0.2",
-    "@polymer/polymer": "^3.2.0",
-    "@vaadin/vaadin-split-layout": "^4.1.0",
-    "@webcomponents/webcomponentsjs": "^2.2.10",
-    "diff": "^4.0.1",
-    "golden-layout": "^1.5.9",
-    "jquery": "^3.4.1",
-    "vis": "^4.21.0",
-    "web-animations-js": "^2.3.1"
+    "@polymer/iron-a11y-keys-behavior": "3.0.1",
+    "@polymer/iron-autogrow-textarea": "3.0.1",
+    "@polymer/iron-dropdown": "3.0.1",
+    "@polymer/iron-icons": "3.0.1",
+    "@polymer/iron-list": "3.1.0",
+    "@polymer/polymer": "3.3.1",
+    "@vaadin/vaadin-split-layout": "4.1.1",
+    "@webcomponents/webcomponentsjs": "2.4.0",
+    "diff": "4.0.1",
+    "golden-layout": "1.5.9",
+    "jquery": "3.4.1",
+    "vis": "4.21.0-EOL",
+    "web-animations-js": "2.3.2"
   },
   "devDependencies": {
     "@shaper42/compassion": "1.0.0",
-    "cross-env": "^5.1.3",
-    "js-green-licenses": "^1.1.0"
+    "cross-env": "5.2.1",
+    "js-green-licenses": "1.1.0"
   },
   "scripts": {
     "postinstall": "cross-env empathy install -a deps && cross-env tools/css-module-wrap ./node_modules/vis/dist/vis-timeline-graph2d.min.css ./node_modules/golden-layout/src/css/goldenlayout-base.css ./node_modules/golden-layout/src/css/goldenlayout-light-theme.css",


### PR DESCRIPTION
Moves cross-env from ^5.1.3 to 5.2.1.

Other versions updated to reflect latest installed as of 20191127.

Note visjs is EOL and recommends using https://github.com/visjs instead.