### PR TITLE
Refine service worker registration process and versioning

### DIFF
--- a/shells/pipes-shell/web/cache-mgr-sw.js
+++ b/shells/pipes-shell/web/cache-mgr-sw.js
@@ -12,7 +12,7 @@
 // output directory. This is required prior to M78 since service worker can
 // invalidate and rebuild caches only when the content of its source script
 // changes.
-const SW_CACHES_VERSION='__ARCS_MD5__';
+const SW_CACHES_VERSION = '__ARCS_MD5__';
 
 // The storage of caches
 const SW_CACHES_FILE = `arcs_${SW_CACHES_VERSION}`;

--- a/shells/pipes-shell/web/cache-mgr.js
+++ b/shells/pipes-shell/web/cache-mgr.js
@@ -38,7 +38,18 @@ const ARCS_CACHE_MANAGER = './cache-mgr-sw.js';
     return;
   }
 
-  navigator.serviceWorker.register(ARCS_CACHE_MANAGER)
+  // crbug/971571: reverts "Stop resurrecting uninstalled workers"
+  // After the revert, the stale-but-still-alive service worker will resurrect
+  // to serve all requests at its responsible scope. The problem behind is even
+  // if we modify source codes, re-deploy, re-build/install application but
+  // the resurrected service worker still serves resources and compiled binaries
+  // with the stale caches.
+  // The Arcs Manager version is appended as one url parameter will trigger the
+  // service worker registration process instantiates a new service worker when
+  // there is a version change detected. The new service worker instance then
+  // checks whether to update caches and/or migrate cache database at the script
+  // ${ARCS_CACHE_MANAGER}.
+  serviceWorker.register(ARCS_CACHE_MANAGER + '?version=__ARCS_MD5__')
     .then(reg => {
       console.log(`Arcs Cache Manager registered, scope: ${reg.scope}`);
     })

--- a/shells/pipes-shell/web/deploy/android_deploy.sh
+++ b/shells/pipes-shell/web/deploy/android_deploy.sh
@@ -18,9 +18,12 @@ cp source/index.html "$OUT_DIR/index.html"
 # Arcs cache manager and versioning
 # Must be done at the last step to ensure the correct $OUT_DIR/** checksum
 # OSX needs explicit backup extension for sed command while Linux does not.
-# For compatibility, explicitly specify backup file as cache-mgr-sw.js.tmp
-# that gets deleted after patching cache-mgr-sw.js.
+# For compatibility, explicitly specify backup file as cache-mgr*.js.tmp
+# that gets deleted after patching cache-mgr*.js.
 cp -fR ../cache-mgr*.js $OUT_DIR/
-sed -i'.tmp' "s/__ARCS_MD5__/$(tar -cf - $OUT_DIR | shasum | cut -d' ' -f1)/g" \
+CACHE_MGR_VERSION=$(tar cfP - $OUT_DIR | shasum | cut -d' ' -f1)
+sed -i'.tmp' "s/__ARCS_MD5__/${CACHE_MGR_VERSION}/g" \
+  $OUT_DIR/cache-mgr.js
+sed -i'.tmp' "s/__ARCS_MD5__/${CACHE_MGR_VERSION}/g" \
   $OUT_DIR/cache-mgr-sw.js
-rm -f $OUT_DIR/cache-mgr-sw.js.tmp
+rm -f $OUT_DIR/cache-mgr*.js.tmp

--- a/shells/pipes-shell/web/deploy/deploy.sh
+++ b/shells/pipes-shell/web/deploy/deploy.sh
@@ -14,9 +14,12 @@ npx webpack --display=errors-only
 # Arcs cache manager and versioning
 # Must be done at the last step to ensure the correct dist/** checksum
 # OSX needs explicit backup extension for sed command while Linux does not.
-# For compatibility, explicitly specify backup file as cache-mgr-sw.js.tmp
-# that gets deleted after patching cache-mgr-sw.js.
+# For compatibility, explicitly specify backup file as cache-mgr*.js.tmp
+# that gets deleted after patching cache-mgr*.js.
 cp -fR ../cache-mgr*.js dist/
-sed -i'.tmp' "s/__ARCS_MD5__/$(tar -cf - dist | shasum | cut -d' ' -f1)/g" \
+CACHE_MGR_VERSION=$(tar cf - dist | shasum | cut -d' ' -f1)
+sed -i'.tmp' "s/__ARCS_MD5__/${CACHE_MGR_VERSION}/g" \
+  dist/cache-mgr.js
+sed -i'.tmp' "s/__ARCS_MD5__/${CACHE_MGR_VERSION}/g" \
   dist/cache-mgr-sw.js
-rm -f dist/cache-mgr-sw.js.tmp
+rm -f dist/cache-mgr*.js.tmp


### PR DESCRIPTION
The PR adapts to the chromium change crbug/971571 where the stale-but-still-alive service workers
will be resurrected to serve new requests with the stale caches such that any changes on source
codes and resources will not be detected as expected!

commit dc2ea1fc29f3a6b93bfdf12b0500f93f4a2baaba
Author: Yannic Bonenberger <yannic.bonenberger@gmail.com>
Date: Tue Oct 15 02:13:27 2019

Revert "[ServiceWorker] Stop resurrecting uninstalled workers"

This reverts commit 6216be03fea4d16279b92b1afe650f49a92482cb.
