### PR TITLE
Remove devtools dependency from runtime.ts

### DIFF
--- a/shells/lib/components/arc-host.js
+++ b/shells/lib/components/arc-host.js
@@ -12,6 +12,7 @@ import {ArcType} from '../../../build/runtime/type.js';
 import {logsFactory} from '../../../build/platform/logs-factory.js';
 import {Runtime} from '../../../build/runtime/runtime.js';
 import {SyntheticStores} from '../synthetic-stores.js';
+import {devtoolsArcInspectorFactory} from '../../../build/devtools-connector/devtools-arc-inspector.js';
 
 const {log, warn, error} = logsFactory('ArcHost', '#cade57');
 
@@ -71,7 +72,15 @@ export class ArcHost {
     return serialization;
   }
   async _spawn(context, composer, storage, id, serialization, portFactories) {
-    return await Runtime.spawnArc({id, context, composer, serialization, storage: `${storage}/${id}`, portFactories});
+    return await Runtime.spawnArc({
+      id,
+      context,
+      composer,
+      serialization,
+      storage: `${storage}/${id}`,
+      portFactories,
+      inspectorFactory: devtoolsArcInspectorFactory,
+    });
   }
   async instantiateDefaultRecipe(arc, manifest) {
     log('instantiateDefaultRecipe');

--- a/shells/pipes-shell/source/verbs/spawn.js
+++ b/shells/pipes-shell/source/verbs/spawn.js
@@ -13,6 +13,7 @@ import {Runtime} from '../../../../build/runtime/runtime.js';
 import {recipeByName, instantiateRecipe} from '../lib/utils.js';
 import {portIndustry} from '../pec-port.js';
 import {logsFactory} from '../../../../build/platform/logs-factory.js';
+import {devtoolsArcInspectorFactory} from '../../../../build/devtools-connector/devtools-arc-inspector.js';
 
 const {warn} = logsFactory('pipe');
 
@@ -28,7 +29,8 @@ export const spawn = async ({modality, recipe}, tid, bus, composerFactory, stora
       //storage,
       id: generateId(),
       composer: composerFactory(modality, bus, tid),
-      portFactories: [portIndustry(bus)]
+      portFactories: [portIndustry(bus)],
+      inspectorFactory: devtoolsArcInspectorFactory,
     });
     if (contextRecipe) {
       // instantiate optional recipe
@@ -37,4 +39,3 @@ export const spawn = async ({modality, recipe}, tid, bus, composerFactory, stora
     return arc;
   }
 };
-

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -28,7 +28,6 @@ import {RecipeResolver} from './recipe/recipe-resolver.js';
 import {Loader} from '../platform/loader.js';
 import {pecIndustry} from '../platform/pec-industry.js';
 import {logsFactory} from '../platform/logs-factory.js';
-import {devtoolsArcInspectorFactory} from '../devtools-connector/devtools-arc-inspector.js';
 
 const {warn} = logsFactory('Runtime', 'orange');
 
@@ -48,7 +47,8 @@ type SpawnArgs = {
   context: Manifest,
   composer: SlotComposer,
   storage: string,
-  portFactories: []
+  portFactories: [],
+  inspectorFactory?: ArcInspectorFactory
 };
 
 let runtime: Runtime | null = null;
@@ -300,7 +300,7 @@ export class Runtime {
 
   // TODO(sjmiles): redundant vs. newArc, but has some impedance mismatch
   // strategy is to merge first, unify second
-  async spawnArc({id, serialization, context, composer, storage, portFactories}: SpawnArgs): Promise<Arc> {
+  async spawnArc({id, serialization, context, composer, storage, portFactories, inspectorFactory}: SpawnArgs): Promise<Arc> {
     const params = {
       id: IdGenerator.newSession().newArcId(id),
       fileName: './serialized.manifest',
@@ -310,9 +310,7 @@ export class Runtime {
       slotComposer: composer,
       pecFactories: [this.pecFactory, ...(portFactories || [])],
       loader: this.loader,
-      // TODO(sjmiles): maybe doesn't belong here, but empirically it's
-      // wanted in (almost?) all Arc instantiations
-      inspectorFactory: devtoolsArcInspectorFactory
+      inspectorFactory,
     };
     return serialization ? Arc.deserialize(params) : new Arc(params);
   }


### PR DESCRIPTION
Having issues importing devtools into Google at the moment, so I'm
removing this direct dependency for now. The shell code now injects the
devtools inspector into Runtime.spawnArc() call.