### PR TITLE
Cleaning up Kt-Multiplatform addressable. 

### DIFF
--- a/particles/Native/Wasm/source/ServiceParticle.kt
+++ b/particles/Native/Wasm/source/ServiceParticle.kt
@@ -11,10 +11,10 @@
 
 package arcs.test
 
+import arcs.addressable.toAddress
 import arcs.Address
 import arcs.Particle
 import arcs.log
-import arcs.wasm.toAddress
 import kotlin.native.internal.ExportForCppRuntime
 
 class ServiceParticle : Particle() {

--- a/particles/Native/Wasm/source/ServiceParticle.kt
+++ b/particles/Native/Wasm/source/ServiceParticle.kt
@@ -11,8 +11,8 @@
 
 package arcs.test
 
+import arcs.addressable.Address
 import arcs.addressable.toAddress
-import arcs.Address
 import arcs.Particle
 import arcs.log
 import kotlin.native.internal.ExportForCppRuntime

--- a/particles/Native/Wasm/source/TestParticle.kt
+++ b/particles/Native/Wasm/source/TestParticle.kt
@@ -9,6 +9,7 @@
  */
 package arcs.test
 
+import arcs.addressable.toAddress
 import arcs.Collection
 import arcs.Handle
 import arcs.Particle
@@ -18,7 +19,6 @@ import arcs.TestParticle_Info
 import arcs.TestParticle_Res
 import arcs.abort
 import arcs.log
-import arcs.wasm.toAddress
 import kotlin.Exception
 import kotlin.native.internal.ExportForCppRuntime
 

--- a/particles/Tutorial/Kotlin/1_HelloWorld/HelloWorld.kt
+++ b/particles/Tutorial/Kotlin/1_HelloWorld/HelloWorld.kt
@@ -1,7 +1,7 @@
 package arcs.tutorials
 
+import arcs.addressable.toAddress
 import arcs.Particle
-import arcs.wasm.toAddress
 import kotlin.native.internal.ExportForCppRuntime
 
 /**

--- a/particles/Tutorial/Kotlin/2_BasicTemplates/BasicTemplate.kt
+++ b/particles/Tutorial/Kotlin/2_BasicTemplates/BasicTemplate.kt
@@ -1,7 +1,7 @@
 package arcs.tutorials
 
+import arcs.addressable.toAddress
 import arcs.Particle
-import arcs.wasm.toAddress
 import kotlin.native.internal.ExportForCppRuntime
 
 /**

--- a/particles/Tutorial/Kotlin/3_RenderSlots/ChildParticle.kt
+++ b/particles/Tutorial/Kotlin/3_RenderSlots/ChildParticle.kt
@@ -11,8 +11,8 @@
 
 package arcs.tutorials
 
+import arcs.addressable.toAddress
 import arcs.Particle
-import arcs.wasm.toAddress
 import kotlin.native.internal.ExportForCppRuntime
 
 /**

--- a/particles/Tutorial/Kotlin/3_RenderSlots/ParentParticle.kt
+++ b/particles/Tutorial/Kotlin/3_RenderSlots/ParentParticle.kt
@@ -11,8 +11,8 @@
 
 package arcs.tutorials
 
+import arcs.addressable.toAddress
 import arcs.Particle
-import arcs.wasm.toAddress
 import kotlin.native.internal.ExportForCppRuntime
 
 /**

--- a/particles/Tutorial/Kotlin/4_Handles/DisplayGreeting.kt
+++ b/particles/Tutorial/Kotlin/4_Handles/DisplayGreeting.kt
@@ -11,10 +11,10 @@
 
 package arcs.tutorials
 
+import arcs.addressable.toAddress
 import arcs.Handle
 import arcs.Particle
 import arcs.Singleton
-import arcs.wasm.toAddress
 import kotlin.native.internal.ExportForCppRuntime
 
 /**

--- a/particles/Tutorial/Kotlin/4_Handles/GetPerson.kt
+++ b/particles/Tutorial/Kotlin/4_Handles/GetPerson.kt
@@ -11,9 +11,9 @@
 
 package arcs.tutorials
 
+import arcs.addressable.toAddress
 import arcs.Particle
 import arcs.Singleton
-import arcs.wasm.toAddress
 import kotlin.native.internal.ExportForCppRuntime
 
 /**

--- a/particles/Tutorial/Kotlin/5_Collections/Collections.kt
+++ b/particles/Tutorial/Kotlin/5_Collections/Collections.kt
@@ -11,10 +11,10 @@
 
 package arcs.tutorials
 
+import arcs.addressable.toAddress
 import arcs.Collection
 import arcs.CollectionsParticle_InputData
 import arcs.Particle
-import arcs.wasm.toAddress
 import kotlin.native.internal.ExportForCppRuntime
 
 /**

--- a/particles/Tutorial/Kotlin/6_JsonStore/JsonStore.kt
+++ b/particles/Tutorial/Kotlin/6_JsonStore/JsonStore.kt
@@ -11,9 +11,9 @@
 
 package arcs.tutorials
 
+import arcs.addressable.toAddress
 import arcs.Particle
 import arcs.Singleton
-import arcs.wasm.toAddress
 import kotlin.native.internal.ExportForCppRuntime
 
 /**

--- a/particles/Tutorial/Kotlin/Demo/TTTBoard.kt
+++ b/particles/Tutorial/Kotlin/Demo/TTTBoard.kt
@@ -11,13 +11,13 @@
 
 package arcs.tutorials.tictactoe
 
+import arcs.addressable.toAddress
 import arcs.Collection
 import arcs.Handle
 import arcs.Particle
 import arcs.Singleton
 import arcs.TTTBoard_Events
 import arcs.TTTBoard_GameState
-import arcs.wasm.toAddress
 import kotlin.native.internal.ExportForCppRuntime
 
 class TTTBoard : Particle() {

--- a/particles/Tutorial/Kotlin/Demo/TTTGame.kt
+++ b/particles/Tutorial/Kotlin/Demo/TTTGame.kt
@@ -11,6 +11,7 @@
 
 package arcs.tutorials
 
+import arcs.addressable.toAddress
 import arcs.Collection
 import arcs.Handle
 import arcs.Particle
@@ -21,7 +22,6 @@ import arcs.TTTGame_PlayerOne
 import arcs.TTTGame_PlayerOneMove
 import arcs.TTTGame_PlayerTwo
 import arcs.TTTGame_PlayerTwoMove
-import arcs.wasm.toAddress
 import kotlin.native.internal.ExportForCppRuntime
 
 class TTTGame : Particle() {

--- a/particles/Tutorial/Kotlin/Demo/TTTHumanPlayer.kt
+++ b/particles/Tutorial/Kotlin/Demo/TTTHumanPlayer.kt
@@ -11,6 +11,7 @@
 
 package arcs.tutorials.tictactoe
 
+import arcs.addressable.toAddress
 import arcs.Collection
 import arcs.Handle
 import arcs.Particle
@@ -19,7 +20,6 @@ import arcs.TTTHumanPlayer_Events
 import arcs.TTTHumanPlayer_GameState
 import arcs.TTTHumanPlayer_MyMove
 import arcs.TTTHumanPlayer_Player
-import arcs.wasm.toAddress
 import kotlin.native.internal.ExportForCppRuntime
 
 class TTTHumanPlayer : Particle() {

--- a/particles/Tutorial/Kotlin/Demo/TTTRandomComputer.kt
+++ b/particles/Tutorial/Kotlin/Demo/TTTRandomComputer.kt
@@ -11,13 +11,13 @@
 
 package arcs.tutorials.tictactoe
 
+import arcs.addressable.toAddress
 import arcs.Handle
 import arcs.Particle
 import arcs.Singleton
 import arcs.TTTRandomComputer_GameState
 import arcs.TTTRandomComputer_MyMove
 import arcs.TTTRandomComputer_Player
-import arcs.wasm.toAddress
 import kotlin.native.internal.ExportForCppRuntime
 
 class TTTRandomComputer : Particle() {

--- a/src/wasm/kotlin/java/arcs/Addressable.kt
+++ b/src/wasm/kotlin/java/arcs/Addressable.kt
@@ -11,16 +11,6 @@
 
 package arcs
 
-import arcs.AddressableMap.address2Addressable
-import arcs.AddressableMap.addressable2Address
-import arcs.AddressableMap.nextAddress
-
-/**
- * Any object implementing this interface can be converted into a stable identifier. This
- * could a platform specific pointer, identity hashcode, or id as long as it is guaranteed unique.
- */
-interface Addressable
-
 typealias Address = Int
 
 internal object AddressableMap {
@@ -28,30 +18,4 @@ internal object AddressableMap {
     internal val addressable2Address = mutableMapOf<Any, Address>()
     internal var nextAddress = 1;
 }
-
-/**
- * Convert an [Addressable] object into an [Address]. Null references
- * are converted to the 0 Address.
- */
-fun Addressable?.toAddress(): Address {
-    // Null pointer maps to 0
-    if (this == null) return 0
-
-    val existingAddress = addressable2Address[this]
-    if (existingAddress != null) return existingAddress
-
-    val address = nextAddress++
-    address2Addressable[address] = this
-    addressable2Address[this] = address
-    return address
-}
-
-/**
- *  Convert an Address back into a Kotlin Object reference. The
- *  zero Address is converted to null, however any other address
- *  that fails to map to an Addressable throws an exception.
- **/
-@Suppress("UNCHECKED_CAST")
-fun  <T : Addressable> Address.toObject(): T? =
-    if (this == 0) null else address2Addressable[this] as T?
 

--- a/src/wasm/kotlin/java/arcs/Addressable.kt
+++ b/src/wasm/kotlin/java/arcs/Addressable.kt
@@ -9,7 +9,11 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-package arcs
+package arcs.addressable
+
+import arcs.addressable.AddressableMap.address2Addressable
+import arcs.addressable.AddressableMap.addressable2Address
+import arcs.addressable.AddressableMap.nextAddress
 
 typealias Address = Int
 
@@ -18,4 +22,28 @@ internal object AddressableMap {
     internal val addressable2Address = mutableMapOf<Any, Address>()
     internal var nextAddress = 1;
 }
+
+/**
+ * Converts [Any] into an [Address]. Null references
+ * are converted to the 0 Address.
+ */
+fun Any?.toAddress(): Address {
+    // Null pointer maps to 0
+    if (this == null) return 0
+
+    val existingAddress = addressable2Address[this]
+    if (existingAddress != null) return existingAddress
+
+    val address = nextAddress++
+    address2Addressable[address] = this
+    addressable2Address[this] = address
+    return address
+}
+
+/**
+ *  Convert an Address back into a Kotlin Object reference. The
+ *  zero Address is converted to null, however any other address
+ *  that fails to map to an Addressable throws an exception.
+ **/
+fun <T> Address?.toObject(): T? = if (this == 0) null else address2Addressable[this] as T
 

--- a/src/wasm/kotlin/java/arcs/wasm/WasmJsInterop.kt
+++ b/src/wasm/kotlin/java/arcs/wasm/WasmJsInterop.kt
@@ -11,13 +11,12 @@
 
 package arcs.wasm
 
-import arcs.Address
+import arcs.addressable.Address
+import arcs.addressable.toAddress
+import arcs.addressable.toObject
 import arcs.Handle
 import arcs.Particle
 import arcs.StringDecoder
-import arcs.AddressableMap.address2Addressable
-import arcs.AddressableMap.addressable2Address
-import arcs.AddressableMap.nextAddress
 import kotlin.native.internal.ExportForCppRuntime
 import kotlin.native.Retain
 import kotlin.native.toUtf8
@@ -38,22 +37,6 @@ typealias WasmAddress = Address
 typealias WasmString = Int
 
 typealias WasmNullableString = Int
-
-fun Any?.toAddress(): Address {
-    // Null pointer maps to 0
-    if (this == null) return 0
-
-    val existingAddress = addressable2Address[this]
-    if (existingAddress != null) return existingAddress
-
-    val address = nextAddress++
-    address2Addressable[address] = this
-    addressable2Address[this] = address
-
-    return address
-}
-
-fun <T> Address?.toObject(): T? = if (this == 0) null else address2Addressable[this] as T
 
 // Extension method to convert an Int into a Kotlin heap ptr
 fun WasmAddress.toPtr(): NativePtr {

--- a/src/wasm/kotlin/java/arcs/wasm/WasmRuntimeClient.kt
+++ b/src/wasm/kotlin/java/arcs/wasm/WasmRuntimeClient.kt
@@ -11,6 +11,7 @@
 
 package arcs
 
+import arcs.addressable.toAddress
 import arcs.wasm._free
 import arcs.wasm.collectionClear
 import arcs.wasm.collectionRemove
@@ -20,7 +21,6 @@ import arcs.wasm.resolveUrl
 import arcs.wasm.singletonClear
 import arcs.wasm.singletonSet
 import arcs.wasm.serviceRequest
-import arcs.wasm.toAddress
 import arcs.wasm.toKString
 import arcs.wasm.toNullableKString
 import arcs.wasm.toWasmNullableString

--- a/src/wasm/kotlin/javatests/arcs/AutoRenderTest.kt
+++ b/src/wasm/kotlin/javatests/arcs/AutoRenderTest.kt
@@ -11,10 +11,10 @@
 
 package wasm.kotlin.javatests.arcs
 
+import arcs.addressable.toAddress
 import arcs.Particle
 import arcs.Handle
 import arcs.Singleton
-import arcs.addressable.toAddress
 import kotlin.native.internal.ExportForCppRuntime
 import kotlin.native.Retain
 

--- a/src/wasm/kotlin/javatests/arcs/AutoRenderTest.kt
+++ b/src/wasm/kotlin/javatests/arcs/AutoRenderTest.kt
@@ -14,7 +14,7 @@ package wasm.kotlin.javatests.arcs
 import arcs.Particle
 import arcs.Handle
 import arcs.Singleton
-import arcs.wasm.toAddress
+import arcs.addressable.toAddress
 import kotlin.native.internal.ExportForCppRuntime
 import kotlin.native.Retain
 

--- a/src/wasm/kotlin/javatests/arcs/CollectionApiTest.kt
+++ b/src/wasm/kotlin/javatests/arcs/CollectionApiTest.kt
@@ -11,9 +11,9 @@
 
 package wasm.kotlin.javatests.arcs
 
+import arcs.addressable.toAddress
 import arcs.Collection
 import arcs.Particle
-import arcs.wasm.toAddress
 import kotlin.native.internal.ExportForCppRuntime
 import kotlin.native.Retain
 

--- a/src/wasm/kotlin/javatests/arcs/EntityClassApiTest.kt
+++ b/src/wasm/kotlin/javatests/arcs/EntityClassApiTest.kt
@@ -11,8 +11,8 @@
 
 package wasm.kotlin.javatests.arcs
 
+import arcs.addressable.toAddress
 import arcs.Singleton
-import arcs.wasm.toAddress
 import kotlin.native.internal.ExportForCppRuntime
 import kotlin.native.Retain
 

--- a/src/wasm/kotlin/javatests/arcs/EventsTest.kt
+++ b/src/wasm/kotlin/javatests/arcs/EventsTest.kt
@@ -11,9 +11,9 @@
 
 package wasm.kotlin.javatests.arcs
 
+import arcs.addressable.toAddress
 import arcs.Particle
 import arcs.Singleton
-import arcs.wasm.toAddress
 import kotlin.native.internal.ExportForCppRuntime
 import kotlin.native.Retain
 

--- a/src/wasm/kotlin/javatests/arcs/HandleSyncUpdateTest.kt
+++ b/src/wasm/kotlin/javatests/arcs/HandleSyncUpdateTest.kt
@@ -11,11 +11,11 @@
 
 package wasm.kotlin.javatests.arcs
 
+import arcs.addressable.toAddress
 import arcs.Collection
 import arcs.Handle
 import arcs.Particle
 import arcs.Singleton
-import arcs.wasm.toAddress
 import kotlin.native.internal.ExportForCppRuntime
 import kotlin.native.Retain
 

--- a/src/wasm/kotlin/javatests/arcs/MissingRegisterHandleTest.kt
+++ b/src/wasm/kotlin/javatests/arcs/MissingRegisterHandleTest.kt
@@ -11,8 +11,8 @@
 
 package wasm.kotlin.javatests.arcs
 
+import arcs.addressable.toAddress
 import arcs.Particle
-import arcs.wasm.toAddress
 import kotlin.native.internal.ExportForCppRuntime
 import kotlin.native.Retain
 

--- a/src/wasm/kotlin/javatests/arcs/RenderTest.kt
+++ b/src/wasm/kotlin/javatests/arcs/RenderTest.kt
@@ -11,10 +11,10 @@
 
 package wasm.kotlin.javatests.arcs
 
+import arcs.addressable.toAddress
 import arcs.Handle
 import arcs.Particle
 import arcs.Singleton
-import arcs.wasm.toAddress
 import kotlin.native.internal.ExportForCppRuntime
 import kotlin.native.Retain
 

--- a/src/wasm/kotlin/javatests/arcs/ServicesTest.kt
+++ b/src/wasm/kotlin/javatests/arcs/ServicesTest.kt
@@ -11,9 +11,9 @@
 
 package wasm.kotlin.javatests.arcs
 
+import arcs.addressable.toAddress
 import arcs.Collection
 import arcs.Particle
-import arcs.wasm.toAddress
 import kotlin.native.internal.ExportForCppRuntime
 import kotlin.native.Retain
 

--- a/src/wasm/kotlin/javatests/arcs/SingletonApiTest.kt
+++ b/src/wasm/kotlin/javatests/arcs/SingletonApiTest.kt
@@ -11,9 +11,9 @@
 
 package wasm.kotlin.javatests.arcs
 
+import arcs.addressable.toAddress
 import arcs.Particle
 import arcs.Singleton
-import arcs.wasm.toAddress
 import kotlin.native.internal.ExportForCppRuntime
 import kotlin.native.Retain
 

--- a/src/wasm/kotlin/javatests/arcs/SpecialSchemaFieldsTest.kt
+++ b/src/wasm/kotlin/javatests/arcs/SpecialSchemaFieldsTest.kt
@@ -11,8 +11,8 @@
 
 package wasm.kotlin.javatests.arcs
 
+import arcs.addressable.toAddress
 import arcs.Singleton
-import arcs.wasm.toAddress
 import kotlin.native.internal.ExportForCppRuntime
 import kotlin.native.Retain
 


### PR DESCRIPTION
- De-duplicating toAddress / toObject
- Associating addressable functionality with `arcs.addressable` package.