### PR TITLE
Implement ServiceStore

### DIFF
--- a/shells/android/java/arcs/storage/BUILD
+++ b/shells/android/java/arcs/storage/BUILD
@@ -1,3 +1,21 @@
 licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])
+
+load("//tools/build_defs/kotlin:rules.bzl", "kt_android_library")
+
+kt_android_library(
+    name = "storage",
+    srcs = glob(["*.kt"]),
+    manifest = "//shells/android/java/arcs/common:AndroidManifest.xml",
+    deps = [
+        "//shells/android/java/arcs/crdt/parcelables",
+        "//shells/android/java/arcs/storage/parcelables",
+        "//shells/android/java/arcs/storage/service",
+        "//src_kt/java/arcs/common",
+        "//src_kt/java/arcs/crdt",
+        "//src_kt/java/arcs/crdt/internal",
+        "//src_kt/java/arcs/storage",
+        "//third_party/java/androidx/lifecycle"
+    ],
+)

--- a/shells/android/java/arcs/storage/BUILD
+++ b/shells/android/java/arcs/storage/BUILD
@@ -1,8 +1,8 @@
+load("//tools/build_defs/kotlin:rules.bzl", "kt_android_library")
+
 licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])
-
-load("//tools/build_defs/kotlin:rules.bzl", "kt_android_library")
 
 kt_android_library(
     name = "storage",

--- a/shells/android/java/arcs/storage/BUILD
+++ b/shells/android/java/arcs/storage/BUILD
@@ -16,6 +16,6 @@ kt_android_library(
         "//src_kt/java/arcs/crdt",
         "//src_kt/java/arcs/crdt/internal",
         "//src_kt/java/arcs/storage",
-        "//third_party/java/androidx/lifecycle"
+        "//third_party/java/androidx/lifecycle",
     ],
 )

--- a/shells/android/java/arcs/storage/ServiceStore.kt
+++ b/shells/android/java/arcs/storage/ServiceStore.kt
@@ -49,7 +49,7 @@ import kotlinx.coroutines.withContext
 
 /**
  * Factory which can be supplied to [Store.activate] to force store creation to use the
- * ServiceStore.
+ * [ServiceStore].
  */
 @ExperimentalCoroutinesApi
 @UseExperimental(FlowPreview::class)

--- a/shells/android/java/arcs/storage/ServiceStore.kt
+++ b/shells/android/java/arcs/storage/ServiceStore.kt
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.storage
+
+import android.content.Context
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleObserver
+import androidx.lifecycle.OnLifecycleEvent
+import arcs.crdt.CrdtData
+import arcs.crdt.CrdtException
+import arcs.crdt.CrdtOperation
+import arcs.crdt.parcelables.ParcelableCrdtType
+import arcs.storage.parcelables.toParcelable
+import arcs.storage.service.ConnectionFactory
+import arcs.storage.service.DefaultConnectionFactory
+import arcs.storage.service.DeferredResult
+import arcs.storage.service.IStorageService
+import arcs.storage.service.ParcelableProxyMessageChannel
+import arcs.storage.service.ParcelableProxyMessageChannel.MessageAndResult
+import arcs.storage.service.StorageServiceConnection
+import arcs.storage.util.ProxyCallbackManager
+import arcs.storage.util.SendQueue
+import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.withContext
+
+/**
+ * Factory which can be supplied to [Store.activate] to force store creation to use the
+ * ServiceStore.
+ */
+@ExperimentalCoroutinesApi
+@UseExperimental(FlowPreview::class)
+class ServiceStoreFactory<Data : CrdtData, Op : CrdtOperation, ConsumerData>(
+    private val context: Context,
+    private val lifecycle: Lifecycle,
+    private val crdtType: ParcelableCrdtType,
+    private val coroutineContext: CoroutineContext = Dispatchers.IO
+) {
+    suspend operator fun invoke(
+        options: StoreOptions<Data, Op, ConsumerData>
+    ): ServiceStore<Data, Op, ConsumerData> {
+        val storeContext = coroutineContext + CoroutineName("ServiceStore(${options.storageKey})")
+        return ServiceStore(options, crdtType, context, lifecycle, storeContext).initialize()
+    }
+}
+
+/** Implementation of [ActiveStore] which pipes [ProxyMessage]s to and from the [StorageService]. */
+@UseExperimental(FlowPreview::class)
+@ExperimentalCoroutinesApi
+class ServiceStore<Data : CrdtData, Op : CrdtOperation, ConsumerData> internal constructor(
+    private val options: StoreOptions<Data, Op, ConsumerData>,
+    private val crdtType: ParcelableCrdtType,
+    context: Context,
+    lifecycle: Lifecycle,
+    private val coroutineContext: CoroutineContext,
+    private val connectionFactory: ConnectionFactory =
+        DefaultConnectionFactory(context, coroutineContext)
+) : ActiveStore<Data, Op, ConsumerData>(options), LifecycleObserver {
+    private val scope = CoroutineScope(coroutineContext)
+    private var storageService: IStorageService? = null
+    private var serviceConnection: StorageServiceConnection? = null
+    private val proxyCallbacks = ProxyCallbackManager<Data, Op, ConsumerData>()
+    private var serviceCallbackToken: Int = -1
+    private val sendQueue = SendQueue()
+
+    init {
+        lifecycle.addObserver(this)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    override suspend fun getLocalData(): Data {
+        val service = checkNotNull(storageService)
+        val channel = ParcelableProxyMessageChannel(coroutineContext)
+        service.getLocalData(channel)
+        val flow = channel.asFlow()
+        val modelUpdate =
+            flow.flowOn(coroutineContext)
+                .onEach { it.result.complete(true) }
+                .mapNotNull {
+                    it.message.actual as? ProxyMessage.ModelUpdate<Data, Op, ConsumerData>
+                }
+                .first()
+        channel.cancel()
+        return modelUpdate.model
+    }
+
+    override fun on(callback: ProxyCallback<Data, Op, ConsumerData>): Int =
+        proxyCallbacks.register(callback)
+
+    override fun off(callbackToken: Int) = proxyCallbacks.unregister(callbackToken)
+
+    override suspend fun onProxyMessage(message: ProxyMessage<Data, Op, ConsumerData>): Boolean {
+        val service = checkNotNull(storageService)
+        val result = DeferredResult(coroutineContext)
+        sendQueue.enqueue {
+            service.sendProxyMessage(message.toParcelable(crdtType), result)
+        }
+        return result.await()
+    }
+
+    internal suspend fun initialize() = apply {
+        check(serviceConnection == null ||
+            storageService == null ||
+            storageService?.asBinder()?.isBinderAlive != true) {
+            "Connection to StorageService is already alive."
+        }
+        val connection = connectionFactory(options, crdtType)
+        val service = connection.connectAsync().await()
+
+        val messageChannel = ParcelableProxyMessageChannel(coroutineContext)
+        serviceCallbackToken = withContext(coroutineContext) {
+            service.registerCallback(messageChannel)
+        }
+
+        messageChannel.asFlow()
+            .flowOn(coroutineContext)
+            .onEach(this::handleMessageAndResultFromService)
+
+        this.serviceConnection = connection
+        this.storageService = service
+    }
+
+    @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+    private fun onLifecycleDestroyed() {
+        serviceConnection?.disconnect()
+        storageService?.unregisterCallback(serviceCallbackToken)
+        storageService = null
+        scope.cancel()
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private suspend fun handleMessageAndResultFromService(messageAndResult: MessageAndResult) {
+        try {
+            val actualMessage = CrdtException.requireNotNull(
+                messageAndResult.message.actual as? ProxyMessage<Data, Op, ConsumerData>
+            ) { "Could not cast ProxyMessage to required type." }
+
+            sendQueue.enqueue {
+                messageAndResult.result.complete(proxyCallbacks.send(actualMessage))
+            }
+        } catch (e: Exception) {
+            messageAndResult.result.completeExceptionally(e)
+        }
+    }
+}

--- a/shells/android/java/arcs/storage/ServiceStore.kt
+++ b/shells/android/java/arcs/storage/ServiceStore.kt
@@ -53,20 +53,28 @@ class ServiceStoreFactory<Data : CrdtData, Op : CrdtOperation, ConsumerData>(
     private val context: Context,
     private val lifecycle: Lifecycle,
     private val crdtType: ParcelableCrdtType,
-    private val coroutineContext: CoroutineContext = Dispatchers.IO
+    private val coroutineContext: CoroutineContext = Dispatchers.IO,
+    private val connectionFactory: ConnectionFactory? = null
 ) {
     suspend operator fun invoke(
         options: StoreOptions<Data, Op, ConsumerData>
     ): ServiceStore<Data, Op, ConsumerData> {
         val storeContext = coroutineContext + CoroutineName("ServiceStore(${options.storageKey})")
-        return ServiceStore(options, crdtType, context, lifecycle, storeContext).initialize()
+        return ServiceStore(
+            options = options,
+            crdtType = crdtType,
+            context = context,
+            lifecycle = lifecycle,
+            coroutineContext = storeContext,
+            connectionFactory = connectionFactory ?: DefaultConnectionFactory(context, storeContext)
+        ).initialize()
     }
 }
 
 /** Implementation of [ActiveStore] which pipes [ProxyMessage]s to and from the [StorageService]. */
 @UseExperimental(FlowPreview::class)
 @ExperimentalCoroutinesApi
-class ServiceStore<Data : CrdtData, Op : CrdtOperation, ConsumerData> internal constructor(
+class ServiceStore<Data : CrdtData, Op : CrdtOperation, ConsumerData>(
     private val options: StoreOptions<Data, Op, ConsumerData>,
     private val crdtType: ParcelableCrdtType,
     context: Context,

--- a/shells/android/java/arcs/storage/service/StorageServiceConnection.kt
+++ b/shells/android/java/arcs/storage/service/StorageServiceConnection.kt
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.storage.service
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.ServiceConnection
+import android.os.IBinder
+import androidx.annotation.VisibleForTesting
+import arcs.crdt.parcelables.ParcelableCrdtType
+import arcs.storage.StoreOptions
+import arcs.storage.parcelables.ParcelableStoreOptions
+import arcs.storage.parcelables.toParcelable
+import kotlin.coroutines.CoroutineContext
+import kotlinx.atomicfu.atomic
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+
+/** A [ConnectionFactory] is capable of creating a [StorageServiceConnection]. */
+typealias ConnectionFactory =
+    (StoreOptions<*, *, *>, ParcelableCrdtType) -> StorageServiceConnection
+
+/**
+ * Returns a default [ConnectionFactory] implementation which uses the provided [context] to bind to
+ * the [StorageService] and the provided [coroutineContext] as the parent for
+ * [StorageServiceConnection.connectAsync]'s [Deferred] return value.
+ */
+@Suppress("FunctionName")
+@ExperimentalCoroutinesApi
+fun DefaultConnectionFactory(
+    context: Context,
+    coroutineContext: CoroutineContext = Dispatchers.Default
+): ConnectionFactory = { options, crdtType ->
+    StorageServiceConnectionImpl(context, options.toParcelable(crdtType), coroutineContext)
+}
+
+/**
+ * Interface for implementations capable of connecting-to and disconnecting-from the
+ * [StorageService].
+ */
+interface StorageServiceConnection {
+    /** Whether or not the connection is active/alive. */
+    val isConnected: Boolean
+
+    /**
+     * Initiates a connection with the [StorageService], returns a [Deferred] which will be resolved
+     * with the [IStorageService] binder.
+     */
+    fun connectAsync(): Deferred<IStorageService>
+
+    /** Disconnects from the [StorageService]. */
+    fun disconnect()
+}
+
+/** Default implementation of the [StorageServiceConnection]. */
+@ExperimentalCoroutinesApi
+@VisibleForTesting(otherwise = VisibleForTesting.PACKAGE_PRIVATE)
+class StorageServiceConnectionImpl(
+    /** Android [Context] to use when connecting to the [StorageService]. */
+    private val context: Context,
+    /** Parcelable [StoreOptions] to pass to the [StorageService] when connecting. */
+    private val storeOptions: ParcelableStoreOptions,
+    /** Parent [CoroutineContext] for the [Deferred] returned by [connectAsync]. */
+    private val coroutineContext: CoroutineContext = Dispatchers.Default
+) : StorageServiceConnection, ServiceConnection {
+    private var needsDisconnect = false
+    private var service = atomic(CompletableDeferred<IStorageService>(coroutineContext[Job.Key]))
+
+    override val isConnected: Boolean
+        get() = needsDisconnect &&
+            service.value.let { it.isCompleted && it.getCompleted().asBinder().isBinderAlive }
+
+    override fun connectAsync(): Deferred<IStorageService> {
+        if (isConnected) return service.value
+
+        val deferred = CompletableDeferred<IStorageService>(coroutineContext[Job.Key])
+        service.value = deferred
+        needsDisconnect = context.bindService(
+            StorageService.createBindIntent(context, storeOptions),
+            /* conn = */ this,
+            /* flags = */ 0
+        )
+        return deferred
+    }
+
+    override fun disconnect() {
+        if (needsDisconnect) context.unbindService(this)
+    }
+
+    override fun onServiceConnected(name: ComponentName?, service: IBinder) {
+        this.service.value.complete(service as IStorageService)
+    }
+
+    override fun onServiceDisconnected(name: ComponentName?) {
+        // Reset the needsDisconnect flag, since we no longer need to disconnect - and to make
+        // isConnected return false.
+        needsDisconnect = false
+    }
+}

--- a/shells/android/javatests/arcs/storage/BUILD
+++ b/shells/android/javatests/arcs/storage/BUILD
@@ -8,11 +8,12 @@ licenses(["notice"])
 package(default_visibility = ["//visibility:public"])
 
 arcs_kt_android_test_suite(
-    name = "service",
+    name = "store",
     manifest = "//shells/android/java/arcs/common:AndroidManifest.xml",
-    package = "arcs.storage.service",
+    package = "arcs.storage",
     deps = [
         "//shells/android/java/arcs/crdt/parcelables",
+        "//shells/android/java/arcs/storage",
         "//shells/android/java/arcs/storage/parcelables",
         "//shells/android/java/arcs/storage/service",
         "//src_kt/java/arcs/crdt",
@@ -26,8 +27,8 @@ arcs_kt_android_test_suite(
         "//third_party/java/mockito",
         "//third_party/java/robolectric",
         "//third_party/java/truth",
-        "//third_party/kotlin/mockito_kotlin",
         "//third_party/kotlin/kotlinx/kotlinx_coroutines",
         "//third_party/kotlin/kotlinx/kotlinx_coroutines:kotlinx_coroutines_test",
+        "//third_party/kotlin/mockito_kotlin",
     ],
 )

--- a/shells/android/javatests/arcs/storage/ServiceStoreTest.kt
+++ b/shells/android/javatests/arcs/storage/ServiceStoreTest.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.storage
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import arcs.crdt.parcelables.ParcelableCrdtType
+import arcs.storage.driver.RamDisk
+import arcs.storage.driver.RamDiskDriverProvider
+import arcs.storage.parcelables.ParcelableStoreOptions
+import arcs.storage.service.BindingContext
+import arcs.storage.service.StorageServiceBindingDelegate
+import com.nhaarman.mockitokotlin2.mock
+import kotlin.coroutines.coroutineContext
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/** Tests for the [ServiceStore]. */
+@RunWith(AndroidJUnit4::class)
+@UseExperimental(ExperimentalCoroutinesApi::class)
+class ServiceStoreTest {
+    private lateinit var bindingDelegate: StorageServiceBindingDelegate
+    private lateinit var lifecycle: Lifecycle
+
+    @Before
+    fun setup() {
+        RamDisk.clear()
+        RamDiskDriverProvider()
+        bindingDelegate = mock()
+        lifecycle = mock()
+    }
+
+    @Test
+    fun getLocalData_getsLocalDataFromService() = runBlockingTest {
+    }
+
+    private suspend fun buildService(storeOpts: ParcelableStoreOptions): BindingContext {
+        val store = Store(storeOpts.actual)
+        return BindingContext(store, ParcelableCrdtType.Count, coroutineContext)
+    }
+}

--- a/shells/android/javatests/arcs/storage/ServiceStoreTest.kt
+++ b/shells/android/javatests/arcs/storage/ServiceStoreTest.kt
@@ -11,17 +11,29 @@
 
 package arcs.storage
 
+import android.content.ComponentName
+import android.content.ServiceConnection
+import androidx.lifecycle.Lifecycle
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import arcs.crdt.CrdtCount
 import arcs.crdt.parcelables.ParcelableCrdtType
+import arcs.data.CountType
 import arcs.storage.driver.RamDisk
 import arcs.storage.driver.RamDiskDriverProvider
+import arcs.storage.driver.RamDiskStorageKey
 import arcs.storage.parcelables.ParcelableStoreOptions
+import arcs.storage.parcelables.toParcelable
 import arcs.storage.service.BindingContext
+import arcs.storage.service.ConnectionFactory
+import arcs.storage.service.DeferredResult
 import arcs.storage.service.StorageServiceBindingDelegate
+import arcs.storage.service.StorageServiceConnection
+import com.google.common.truth.Truth.assertThat
 import com.nhaarman.mockitokotlin2.mock
 import kotlin.coroutines.coroutineContext
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.yield
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -30,19 +42,108 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 @UseExperimental(ExperimentalCoroutinesApi::class)
 class ServiceStoreTest {
-    private lateinit var bindingDelegate: StorageServiceBindingDelegate
     private lateinit var lifecycle: Lifecycle
+    private val storeOptions = StoreOptions<CrdtCount.Data, CrdtCount.Operation, Int>(
+        RamDiskStorageKey("myData"),
+        ExistenceCriteria.ShouldCreate,
+        CountType()
+    )
 
     @Before
     fun setup() {
         RamDisk.clear()
         RamDiskDriverProvider()
-        bindingDelegate = mock()
         lifecycle = mock()
     }
 
     @Test
-    fun getLocalData_getsLocalDataFromService() = runBlockingTest {
+    fun getLocalData_getsLocalDataFromService() = runBlocking {
+        val service = buildService(storeOptions.toParcelable(ParcelableCrdtType.Count))
+        val bindingDelegate = buildBindingDelegate(service)
+        val connectionFactory = buildConnectionFactory(bindingDelegate)
+
+        val store = ServiceStore(
+            storeOptions,
+            ParcelableCrdtType.Count,
+            lifecycle,
+            connectionFactory,
+            coroutineContext
+        ).initialize()
+
+        val data = store.getLocalData()
+
+        assertThat(data.values).isEmpty()
+
+        // Increment at the binding context directly.
+        val deferredResult = DeferredResult(coroutineContext)
+        service.sendProxyMessage(
+            ProxyMessage.Operations<CrdtCount.Data, CrdtCount.Operation, Int>(
+                listOf(CrdtCount.Operation.Increment("alice", 0 to 1)),
+                null
+            ).toParcelable(ParcelableCrdtType.Count),
+            deferredResult
+        )
+
+        deferredResult.await()
+
+        val dataAfter = store.getLocalData()
+
+        assertThat(dataAfter.values).containsExactly("alice", 1).inOrder()
+
+        store.onLifecycleDestroyed()
+    }
+
+    @Test
+    fun onProxyMessage_sendsProxyMessageToService() = runBlocking {
+        val service = buildService(storeOptions.toParcelable(ParcelableCrdtType.Count))
+        val bindingDelegate = buildBindingDelegate(service)
+        val connectionFactory = buildConnectionFactory(bindingDelegate)
+
+        val store = ServiceStore(
+            storeOptions,
+            ParcelableCrdtType.Count,
+            lifecycle,
+            connectionFactory,
+            coroutineContext
+        ).initialize()
+
+        store.onProxyMessage(
+            ProxyMessage.Operations(
+                listOf(CrdtCount.Operation.Increment("alice", 0 to 1)),
+                null
+            )
+        )
+
+        yield()
+
+        val data = store.getLocalData()
+        assertThat(data.values).containsExactly("alice", 1).inOrder()
+
+        store.onLifecycleDestroyed()
+    }
+
+    private fun buildBindingDelegate(
+        service: BindingContext
+    ): StorageServiceBindingDelegate = object : StorageServiceBindingDelegate {
+        override fun bindStorageService(
+            conn: ServiceConnection,
+            flags: Int,
+            options: ParcelableStoreOptions
+        ): Boolean {
+            conn.onServiceConnected(ComponentName("asdf", "asdf"), service)
+            return true
+        }
+
+        override fun unbindStorageService(conn: ServiceConnection) = Unit
+    }
+
+    private suspend fun buildConnectionFactory(
+        bindingDelegate: StorageServiceBindingDelegate
+    ): ConnectionFactory {
+        val context = coroutineContext
+        return { opts, type ->
+            StorageServiceConnection(bindingDelegate, opts.toParcelable(type), context)
+        }
     }
 
     private suspend fun buildService(storeOpts: ParcelableStoreOptions): BindingContext {

--- a/shells/android/javatests/arcs/storage/ServiceStoreTest.kt
+++ b/shells/android/javatests/arcs/storage/ServiceStoreTest.kt
@@ -50,7 +50,7 @@ class ServiceStoreTest {
     )
 
     @Before
-    fun setup() {
+    fun setUp() {
         RamDisk.clear()
         RamDiskDriverProvider()
         lifecycle = mock()

--- a/shells/android/javatests/arcs/storage/service/BUILD
+++ b/shells/android/javatests/arcs/storage/service/BUILD
@@ -26,8 +26,8 @@ arcs_kt_android_test_suite(
         "//third_party/java/mockito",
         "//third_party/java/robolectric",
         "//third_party/java/truth",
-        "//third_party/kotlin/mockito_kotlin",
         "//third_party/kotlin/kotlinx/kotlinx_coroutines",
         "//third_party/kotlin/kotlinx/kotlinx_coroutines:kotlinx_coroutines_test",
+        "//third_party/kotlin/mockito_kotlin",
     ],
 )

--- a/shells/android/javatests/arcs/storage/service/StorageServiceConnectionTest.kt
+++ b/shells/android/javatests/arcs/storage/service/StorageServiceConnectionTest.kt
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.storage.service
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import arcs.crdt.CrdtCount
+import arcs.crdt.parcelables.ParcelableCrdtType
+import arcs.data.CountType
+import arcs.storage.ExistenceCriteria
+import arcs.storage.StoreOptions
+import arcs.storage.driver.RamDiskStorageKey
+import arcs.storage.parcelables.ParcelableProxyMessage
+import arcs.storage.parcelables.toParcelable
+import arcs.testutil.assertSuspendingThrows
+import com.google.common.truth.Truth.assertThat
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/** Tests for [StorageServiceConnection]. */
+@RunWith(AndroidJUnit4::class)
+@UseExperimental(ExperimentalCoroutinesApi::class)
+class StorageServiceConnectionTest {
+    private lateinit var delegateMock: StorageServiceBindingDelegate
+    private lateinit var serviceMock: IStorageService
+
+    @Before
+    fun setup() {
+        delegateMock = mock {
+            on { bindStorageService(any(), any(), any()) }.doReturn(true)
+        }
+        serviceMock = object : IStorageService.Stub() {
+            override fun registerCallback(callback: IStorageServiceCallback?): Int = 1
+
+            override fun sendProxyMessage(
+                message: ParcelableProxyMessage?,
+                resultCallback: IResultCallback?
+            ) = Unit
+
+            override fun getLocalData(callback: IStorageServiceCallback?) = Unit
+
+            override fun unregisterCallback(token: Int) = Unit
+        }
+    }
+
+    @Test
+    fun isConnected_returnsFalse_whenNeedsDisconnectIsFalse() = runBlockingTest {
+        val connection = StorageServiceConnection(delegateMock, OPTIONS, coroutineContext)
+
+        assertThat(connection.isConnected).isFalse()
+    }
+
+    @Test
+    fun isConnected_returnsFalse_whileServiceIsUnresolved() = runBlockingTest {
+        val connection = StorageServiceConnection(delegateMock, OPTIONS, coroutineContext)
+
+        // DelegateMock never calls onServiceConnected, so the service will still be unresolved.
+        val deferred = connection.connectAsync()
+
+        assertThat(connection.isConnected).isFalse()
+
+        // Resolve the deferred, so we don't have a dangling job.
+        (deferred as CompletableDeferred).complete(serviceMock)
+    }
+
+    @Test
+    fun connectAsync_returnsDeferredWhichIsResolved_afterOnServiceConnected() = runBlockingTest {
+        val connection = StorageServiceConnection(delegateMock, OPTIONS, coroutineContext)
+
+        val deferred = connection.connectAsync()
+
+        connection.onServiceConnected(null, serviceMock.asBinder())
+
+        verify(delegateMock).bindStorageService(eq(connection), any(), eq(OPTIONS))
+
+        assertThat(deferred.isCompleted).isTrue()
+        assertThat(connection.isConnected).isTrue()
+
+        assertThat(deferred.await()).isEqualTo(serviceMock)
+    }
+
+    @Test
+    fun connectAsync_returnsDeferredWhichThrows_afterDelegateFailsToBind() = runBlockingTest {
+        val connection = StorageServiceConnection(delegateMock, OPTIONS, coroutineContext)
+
+        whenever(delegateMock.bindStorageService(any(), any(), any())).thenReturn(false)
+
+        val deferred = connection.connectAsync()
+        assertSuspendingThrows(IllegalStateException::class) {
+            deferred.await()
+        }
+    }
+
+    @Test
+    fun disconnect_callsDelegate_unbindStorageService_whenConnected() = runBlockingTest {
+        val connection = StorageServiceConnection(delegateMock, OPTIONS, coroutineContext)
+
+        val deferred = connection.connectAsync()
+
+        // Complete the connection (and thus: the deferred)
+        connection.onServiceConnected(null, serviceMock.asBinder())
+        deferred.await()
+
+        connection.disconnect()
+
+        verify(delegateMock).unbindStorageService(eq(connection))
+    }
+
+    @Test
+    fun disconnect_beforeConnect_completesDeferredWithException() = runBlockingTest {
+        val connection = StorageServiceConnection(delegateMock, OPTIONS, coroutineContext)
+
+        val deferred = connection.connectAsync()
+        connection.disconnect()
+
+        assertSuspendingThrows(IllegalStateException::class) {
+            deferred.await()
+        }
+    }
+
+    companion object {
+        private val OPTIONS = StoreOptions<CrdtCount.Data, CrdtCount.Operation, Int>(
+            RamDiskStorageKey("myData"),
+            ExistenceCriteria.ShouldCreate,
+            CountType()
+        ).toParcelable(ParcelableCrdtType.Count)
+    }
+}

--- a/shells/android/javatests/arcs/storage/service/StorageServiceConnectionTest.kt
+++ b/shells/android/javatests/arcs/storage/service/StorageServiceConnectionTest.kt
@@ -43,7 +43,7 @@ class StorageServiceConnectionTest {
     private lateinit var serviceMock: IStorageService
 
     @Before
-    fun setup() {
+    fun setUp() {
         delegateMock = mock {
             on { bindStorageService(any(), any(), any()) }.doReturn(true)
         }

--- a/src_kt/java/arcs/storage/DirectStore.kt
+++ b/src_kt/java/arcs/storage/DirectStore.kt
@@ -37,8 +37,10 @@ import kotlinx.coroutines.Job
 // TODO: generics here are sub-optimal, can we make this class generic itself?
 class DirectStore /* internal */ constructor(
     options: StoreOptions<CrdtData, CrdtOperation, Any?>,
-    /* internal */ val localModel: CrdtModel<CrdtData, CrdtOperation, Any?>,
-    /* internal */ val driver: Driver<CrdtData>
+    /* internal */
+    val localModel: CrdtModel<CrdtData, CrdtOperation, Any?>,
+    /* internal */
+    val driver: Driver<CrdtData>
 ) : ActiveStore<CrdtData, CrdtOperation, Any?>(options) {
     override val versionToken: String?
         get() = driver.token
@@ -223,13 +225,13 @@ class DirectStore /* internal */ constructor(
         when {
             thisChange is CrdtChange.Operations && thisChange.ops.isNotEmpty() -> {
                 callbacks.value.filter { messageFromDriver || channel != it.key }
-                    .map { (id, callback) ->
+                    .forEach { (id, callback) ->
                         callback(ProxyMessage.Operations(thisChange.ops, id))
                     }
             }
             thisChange is CrdtChange.Data -> {
                 callbacks.value.filter { messageFromDriver || channel != it.key }
-                    .map { (id, callback) ->
+                    .forEach { (id, callback) ->
                         callback(ProxyMessage.ModelUpdate(thisChange.data, id))
                     }
             }

--- a/src_kt/java/arcs/storage/StoreInterface.kt
+++ b/src_kt/java/arcs/storage/StoreInterface.kt
@@ -13,6 +13,7 @@ package arcs.storage
 
 import arcs.crdt.CrdtData
 import arcs.crdt.CrdtOperation
+import arcs.storage.referencemode.ReferenceModeStorageKey
 import arcs.type.Type
 import kotlin.reflect.KClass
 
@@ -67,7 +68,9 @@ data class StoreOptions<Data : CrdtData, Op : CrdtOperation, ConsumerData>(
     val storageKey: StorageKey,
     val existenceCriteria: ExistenceCriteria,
     val type: Type,
-    val mode: StorageMode = StorageMode.Direct,
+    val mode: StorageMode =
+        if (storageKey is ReferenceModeStorageKey) StorageMode.ReferenceMode
+        else StorageMode.Direct,
     val baseStore: IStore<Data, Op, ConsumerData>? = null,
     val versionToken: String? = null,
     val model: Data? = null


### PR DESCRIPTION
Also includes changes to support making it possible to override the default store activation flow, which will allow clients not running on the same process as the storage service to always prefer activating to a ServiceStore.

Still needed, but will be in a different PR (or PRs):
* Full integration tests.
* Sample/test app