### PR TITLE
Tweak buildifier configuration

### DIFF
--- a/src_kt/project/WORKSPACE
+++ b/src_kt/project/WORKSPACE
@@ -1,1 +1,0 @@
-../../WORKSPACE

--- a/tools/sigh.ts
+++ b/tools/sigh.ts
@@ -72,6 +72,7 @@ const steps: {[index: string]: ((args?: string[]) => boolean)[]} = {
   webpackTools: [peg, build, webpackTools],
   build: [peg, build],
   watch: [watch],
+  buildifier: [buildifier],
   lint: [peg, build, lint, tslint, buildifier],
   tslint: [peg, build, tslint],
   check: [check],
@@ -550,7 +551,7 @@ function buildifier(args: string[]): boolean {
     buildifierOptions.push('--lint=warn', '--mode=check');
   }
 
-  const exclude = /\bnode_modules\b/;
+  const exclude = /node_modules|dist/;
   const include = /(WORKSPACE|BUILD|BUILD\.bazel|\.bzl)$/;
   let allSucceeded = true;
   for (const file of findProjectFiles(process.cwd(), exclude, include)) {


### PR DESCRIPTION
- Exclude `dist` from target search (sigh.ts)
- Add `buildifier` sigh command
- Remove redundant `WORKSPACE` file