### PR TITLE
Support unicode (UTF8) in the wasm ABI.

### DIFF
--- a/javatests/arcs/core/stringEncoder/StringDecoderTest.kt
+++ b/javatests/arcs/core/stringEncoder/StringDecoderTest.kt
@@ -1,6 +1,7 @@
 package arcs.core.stringEncoder
 
 import arcs.StringDecoder
+import arcs.stringToUtf8
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -14,8 +15,8 @@ class StringDecoderTest {
     @Test
     fun encodeDictionary() {
         val Dict = mapOf("name" to "Jill", "age" to "70.0")
-        val encdoedDict = "2:4:name4:Jill3:age4:70.0"
-        val decodedDict = StringDecoder.decodeDictionary(encdoedDict)
+        val encodedDict = "2:4:name4:Jill3:age4:70.0"
+        val decodedDict = StringDecoder.decodeDictionary(encodedDict.stringToUtf8())
         assertThat(decodedDict).isEqualTo(Dict)
     }
 }

--- a/javatests/arcs/core/stringEncoder/StringEncoderTest.kt
+++ b/javatests/arcs/core/stringEncoder/StringEncoderTest.kt
@@ -1,6 +1,8 @@
 package arcs.core.stringEncoder
 
 import arcs.StringEncoder
+import arcs.utf8ToString
+
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -10,74 +12,78 @@ import org.junit.runners.JUnit4
 @Suppress("UNCHECKED_CAST", "UNUSED_VARIABLE")
 @RunWith(JUnit4::class)
 class StringEncoderTest {
-
     @Test
     fun encodeTrueBoolean() {
-        val b = true
-        val encodedString = StringEncoder.encodeValue(b)
-        val expectedString = "B1"
-        assertThat(encodedString).isEqualTo(expectedString)
+        val se = StringEncoder()
+        se.encodeValue(true)
+        val encodedString = se.toByteArray().utf8ToString()
+        assertThat(encodedString).isEqualTo("B1")
     }
 
     @Test
     fun encodeFalseBoolean() {
-        val b = false
-        val encodedString = StringEncoder.encodeValue(b)
-        val expectedString = "B0"
-        assertThat(encodedString).isEqualTo(expectedString)
+        val se = StringEncoder()
+        se.encodeValue(false)
+        val encodedString = se.toByteArray().utf8ToString()
+        assertThat(encodedString).isEqualTo("B0")
     }
 
     @Test
     fun encodeNumber() {
-        val n = 127.89
-        val encodedString = StringEncoder.encodeValue(n)
-        val expectedString = "N127.89:"
-        assertThat(encodedString).isEqualTo(expectedString)
+        val se = StringEncoder()
+        se.encodeValue(127.89)
+        val encodedString = se.toByteArray().utf8ToString()
+        assertThat(encodedString).isEqualTo("N127.89:")
     }
 
     @Test
     fun encodeText() {
-        val txt = "Kangaroo"
-        val encodedString = StringEncoder.encodeValue(txt)
-        val expectedString = "T8:Kangaroo"
-        assertThat(encodedString).isEqualTo(expectedString)
+        val se = StringEncoder()
+        se.encodeValue("Kangaroo")
+        val encodedString = se.toByteArray().utf8ToString()
+        assertThat(encodedString).isEqualTo("T8:Kangaroo")
     }
 
     @Test
     fun encodeDictionary() {
-        val Dict = mapOf("name" to "Jill", "age" to 70.0)
-        val encodedString = StringEncoder.encodeDictionary(Dict)
-        val expectedString = "2:4:nameT4:Jill3:ageN70.0:"
-        assertThat(encodedString).isEqualTo(expectedString)
+        val se = StringEncoder()
+        val dict = mapOf("name" to "Jill", "age" to 70.0)
+        se.encodeDictionary(dict)
+        val encodedString = se.toByteArray().utf8ToString()
+        assertThat(encodedString).isEqualTo("2:4:nameT4:Jill3:ageN70.0:")
     }
 
     @Test
     fun encodeList() {
+        val se = StringEncoder()
         val list = listOf(
             mapOf("name" to "Jill", "age" to 70.0),
             mapOf("name" to "Jack", "age" to 2.0),
             mapOf("name" to "Jen", "age" to 150.0)
         )
-        val encodedString = StringEncoder.encodeList(list)
+        se.encodeList(list)
+        val encodedString = se.toByteArray().utf8ToString()
         /* ktlint-disable max-line-length */
-        val expectedString =
+        assertThat(encodedString).isEqualTo(
             "3:D26:2:4:nameT4:Jill3:ageN70.0:D25:2:4:nameT4:Jack3:ageN2.0:D26:2:4:nameT3:Jen3:ageN150.0:"
+        )
         /* ktlint-enable max-line-length */
-        assertThat(encodedString).isEqualTo(expectedString)
     }
 
     @Test
-    fun encodeEntity() {
+    fun encodeListAsValue() {
+        val se = StringEncoder()
         val list = listOf(
             mapOf("name" to "Jill", "age" to "70.0"),
             mapOf("name" to "Jack", "age" to "25.0"),
             mapOf("name" to "Jen", "age" to "50.0")
         )
-        val encodedString = StringEncoder.encodeValue(list)
+        se.encodeValue(list)
+        val encodedString = se.toByteArray().utf8ToString()
         /* ktlint-disable max-line-length */
-        val expectedString =
+        assertThat(encodedString).isEqualTo(
             "A94:3:D27:2:4:nameT4:Jill3:ageT4:70.0D27:2:4:nameT4:Jack3:ageT4:25.0D26:2:4:nameT3:Jen3:ageT4:50.0"
+        )
         /* ktlint-enable max-line-length */
-        assertThat(encodedString).isEqualTo(expectedString)
     }
 }

--- a/src/platform/text-encoder-node.ts
+++ b/src/platform/text-encoder-node.ts
@@ -1,0 +1,12 @@
+/**
+ * @license
+ * Copyright (c) 2019 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {TextEncoder, TextDecoder} from 'util';
+export {TextEncoder, TextDecoder};

--- a/src/platform/text-encoder-web.ts
+++ b/src/platform/text-encoder-web.ts
@@ -1,0 +1,14 @@
+/**
+ * @license
+ * Copyright (c) 2019 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+// You can't export a global symbol, so we need to bind them locally first.
+const localTextEncoder = TextEncoder;
+const localTextDecoder = TextDecoder;
+export {localTextEncoder as TextEncoder, localTextDecoder as TextDecoder};

--- a/src/runtime/tests/wasm-test.ts
+++ b/src/runtime/tests/wasm-test.ts
@@ -8,11 +8,12 @@
  * http://polymer.github.io/PATENTS.txt
  */
 import {assert} from '../../platform/chai-web.js';
+import {TextEncoder, TextDecoder} from '../../platform/text-encoder-web.js';
 import {Manifest} from '../manifest.js';
 import {EntityType, ReferenceType} from '../type.js';
 import {Entity} from '../entity.js';
 import {Reference} from '../reference.js';
-import {StringEncoder, StringDecoder} from '../wasm.js';
+import {StringEncoder, StringDecoder, DynamicBuffer} from '../wasm.js';
 import {BiMap} from '../bimap.js';
 
 async function setup() {
@@ -43,7 +44,7 @@ describe('wasm', () => {
     const encoded = encoder.encodeSingleton(foo);
     assert.deepStrictEqual([...typeMap.entries()], [[1, barType]]);
 
-    const foo2 = decoder.decodeSingleton(encoded);
+    const foo2 = decoder.decodeSingleton(encoded.view());
     assert.deepStrictEqual(foo, foo2);
   });
 
@@ -53,7 +54,7 @@ describe('wasm', () => {
     Entity.identify(foo, '!test:foo:bar|');
 
     const encoded = encoder.encodeSingleton(foo);
-    const foo2 = decoder.decodeSingleton(encoded);
+    const foo2 = decoder.decodeSingleton(encoded.view());
     assert.deepStrictEqual(foo, foo2);
   });
 
@@ -63,7 +64,7 @@ describe('wasm', () => {
     Entity.identify(foo, 'te|st');
 
     const encoded = encoder.encodeSingleton(foo);
-    const foo2 = decoder.decodeSingleton(encoded);
+    const foo2 = decoder.decodeSingleton(encoded.view());
     assert.deepStrictEqual(foo, foo2);
   });
 
@@ -73,7 +74,7 @@ describe('wasm', () => {
     Entity.identify(foo, 'te st');
 
     const encoded = encoder.encodeSingleton(foo);
-    const foo2 = decoder.decodeSingleton(encoded);
+    const foo2 = decoder.decodeSingleton(encoded.view());
     assert.deepStrictEqual(foo, foo2);
   });
 
@@ -92,7 +93,7 @@ describe('wasm', () => {
     const encoded = encoder.encodeCollection([f1, f2, f3]);
 
     // Decoding of collections hasn't been implemented (yet?).
-    assert.strictEqual(encoded,
+    assert.strictEqual(new TextDecoder().decode(encoded.view()),
       '3:' +
       '71:3:id1|txt:T3:abc|lnk:U10:http://def|num:N9.2:|flg:B1|ref:R2:r1|2:k1|1:|' +
       '10:7:id2|two|' +
@@ -122,31 +123,31 @@ describe('wasm', () => {
   });
 
   it('decodes string values in dictionary', () => {
-    const enc = '1:3:foo3:bar';
-    const dic = StringDecoder.decodeDictionary(enc);
+    const str = '1:3:foo3:bar';
+    const dic = StringDecoder.decodeDictionary(new TextEncoder().encode(str));
     assert.deepStrictEqual(dic, {foo: 'bar'});
   });
 
   it('decodes type-coded values in dictionary', () => {
-    const enc = '1:3:fooT3:bar';
-    const dic = StringDecoder.decodeDictionary(enc);
+    const str = '1:3:fooT3:bar';
+    const dic = StringDecoder.decodeDictionary(new TextEncoder().encode(str));
     assert.deepStrictEqual(dic, {foo: 'bar'});
   });
 
   it('decodes nested dictionaries', () => {
     const base = '1:3:fooT3:bar';
-    const nestedEnc = `1:3:fooD${base.length}:${base}`;
-    const enc = `1:3:fooD${nestedEnc.length}:${nestedEnc}`;
-    const dic = StringDecoder.decodeDictionary(enc);
+    const nested = `1:3:fooD${base.length}:${base}`;
+    const str = `1:3:fooD${nested.length}:${nested}`;
+    const dic = StringDecoder.decodeDictionary(new TextEncoder().encode(str));
     assert.deepStrictEqual<{}>(dic, {foo: {foo: {foo: 'bar'}}});
   });
 
   it('decodes complex dictionary', () => {
     const data = '2:okB13:numN42:3:fooT3:bar';
     const base = `3:${data}`;
-    const nestedEnc = `4:${data}3:bazD${base.length}:${base}`;
-    const enc = `2:3:zotT3:zoo3:fooD${nestedEnc.length}:${nestedEnc}`;
-    const dic = StringDecoder.decodeDictionary(enc);
+    const nested = `4:${data}3:bazD${base.length}:${base}`;
+    const str = `2:3:zotT3:zoo3:fooD${nested.length}:${nested}`;
+    const dic = StringDecoder.decodeDictionary(new TextEncoder().encode(str));
     assert.deepStrictEqual<{}>(dic, {
       zot: 'zoo',
       foo: {
@@ -157,11 +158,44 @@ describe('wasm', () => {
 
   it('decodes array', () => {
     const str = '3:D27:2:4:nameT4:Jill3:ageT4:70.0D27:2:4:nameT4:Jack3:ageT4:25.0D26:2:4:nameT3:Jen3:ageT4:50.0';
-    const list = StringDecoder.decodeArray(str);
+    const list = StringDecoder.decodeArray(new TextEncoder().encode(str));
     assert.deepStrictEqual<{}>(list, [
         {name: 'Jill', age: '70.0'},
         {name: 'Jack', age: '25.0'},
         {name: 'Jen', age: '50.0'}
     ]);
+  });
+
+  it('DynamicBuffer supports ascii, unicode and other DynamicBuffers', () => {
+    const decoder = new TextDecoder();
+
+    const b1 = new DynamicBuffer(1);
+    b1.addAscii('abc', '!!');
+    assert.strictEqual(decoder.decode(b1.view()), 'abc!!');
+
+    const b2 = new DynamicBuffer(1);
+    b2.addUnicode('-⛲-');
+    assert.strictEqual(decoder.decode(b2.view()), '5:-⛲-');
+
+    b1.addBytes(b2);
+    assert.strictEqual(decoder.decode(b1.view()), 'abc!!7:5:-⛲-');
+  });
+
+  it('DynamicBuffer resizes for large inputs', () => {
+    const decoder = new TextDecoder();
+    const str = 'abcdefghijklmnopqrstuvwxyz_ABCDEFGHIJKLMNOPQRSTUVWXYZ_0123456789';
+    const input = str + str + str;
+
+    const b1 = new DynamicBuffer(2);
+    b1.addAscii(input);
+    assert.strictEqual(decoder.decode(b1.view()), input);
+
+    const b2 = new DynamicBuffer(3);
+    b2.addUnicode(input);
+    assert.strictEqual(decoder.decode(b2.view()), `192:${input}`);
+
+    const b3 = new DynamicBuffer(5);
+    b3.addBytes(b2);
+    assert.strictEqual(decoder.decode(b3.view()), `196:192:${input}`);
   });
 });

--- a/src/tools/schema2kotlin.ts
+++ b/src/tools/schema2kotlin.ts
@@ -51,10 +51,12 @@ package ${this.scope}
 //
 // Current implementation doesn't support references or optional field detection
 
-${withCustomPackage(`import arcs.Particle;
+${withCustomPackage(`import arcs.Particle
+import arcs.NullTermByteArray
 import arcs.Entity
 import arcs.StringEncoder
 import arcs.StringDecoder
+import arcs.utf8ToString
 `)}`;
   }
 
@@ -103,7 +105,7 @@ class KotlinGenerator implements ClassGenerator {
 
 ${withFields('data ')}class ${name}(${ withFields(`\n  ${this.fields.join(',\n  ')}\n`) }) : Entity<${name}>() {
 
-  override fun decodeEntity(encoded: String): ${name}? {
+  override fun decodeEntity(encoded: ByteArray): ${name}? {
     if (encoded.isEmpty()) return null
 
     val decoder = StringDecoder(encoded)
@@ -111,7 +113,7 @@ ${withFields('data ')}class ${name}(${ withFields(`\n  ${this.fields.join(',\n  
     decoder.validate("|")
     ${withFields(`  for (_i in 0 until ${fieldCount}) {
          if (decoder.done()) break
-         val name = decoder.upTo(":")
+         val name = utf8ToString(decoder.upTo(':'))
          when (name) {
            ${this.decode.join('\n           ')}
          }
@@ -122,11 +124,11 @@ ${withFields('data ')}class ${name}(${ withFields(`\n  ${this.fields.join(',\n  
     return this
   }
 
-  override fun encodeEntity(): String {
+  override fun encodeEntity(): NullTermByteArray {
     val encoder = StringEncoder()
     encoder.encode("", internalId)
     ${this.encode.join('\n    ')}
-    return encoder.result()
+    return encoder.toNullTermByteArray()
   }
   ${withoutFields(`
   override fun toString(): String {

--- a/src/tools/schema2kotlin.ts
+++ b/src/tools/schema2kotlin.ts
@@ -113,7 +113,7 @@ ${withFields('data ')}class ${name}(${ withFields(`\n  ${this.fields.join(',\n  
     decoder.validate("|")
     ${withFields(`  for (_i in 0 until ${fieldCount}) {
          if (decoder.done()) break
-         val name = utf8ToString(decoder.upTo(':'))
+         val name = decoder.upTo(':').utf8ToString()
          when (name) {
            ${this.decode.join('\n           ')}
          }

--- a/src/wasm/cpp/tests/particle-api-test.cc
+++ b/src/wasm/cpp/tests/particle-api-test.cc
@@ -115,3 +115,24 @@ public:
 };
 
 DEFINE_PARTICLE(ServicesTest)
+
+
+class UnicodeTest : public arcs::Particle {
+public:
+  void onHandleUpdate(const std::string& name) override {
+    arcs::UnicodeTest_Res out;
+    out.set_src("åŗċş 🌈");
+    if (name == "sng") {
+      out.set_pass(sng_.get().pass());
+    } else {
+      out.set_pass(col_.begin()->pass());
+    }
+    res_.store(out);
+  }
+
+  arcs::Singleton<arcs::UnicodeTest_Sng> sng_{"sng", this};
+  arcs::Collection<arcs::UnicodeTest_Col> col_{"col", this};
+  arcs::Collection<arcs::UnicodeTest_Res> res_{"res", this};
+};
+
+DEFINE_PARTICLE(UnicodeTest)

--- a/src/wasm/kotlin/java/arcs/BUILD
+++ b/src/wasm/kotlin/java/arcs/BUILD
@@ -28,6 +28,6 @@ kt_native_library(
             "**/wasm/*.kt",
         ],
     ),
-    kotlincopts = KOTLINC_OPTS,
+    kotlincopts = KOTLINC_OPTS + ["-Xinline-classes"],
     visibility = ["//visibility:public"],
 )

--- a/src/wasm/kotlin/java/arcs/Entity.kt
+++ b/src/wasm/kotlin/java/arcs/Entity.kt
@@ -36,7 +36,7 @@ class StringDecoder(private var bytes: ByteArray) {
         return chunk
     }
 
-    fun getInt(sep: Char): Int = utf8ToString(upTo(sep)).toInt()
+    fun getInt(sep: Char): Int = upTo(sep).utf8ToString().toInt()
 
     fun chomp(len: Int): ByteArray {
         // TODO: detect overrun
@@ -46,16 +46,16 @@ class StringDecoder(private var bytes: ByteArray) {
     }
 
     fun validate(token: String) {
-        if (utf8ToString(chomp(token.length)) != token) {
+        if (chomp(token.length).utf8ToString() != token) {
             throw IllegalArgumentException("Packaged entity decoding failed in validate()")
         }
     }
 
-    fun decodeText(): String = utf8ToString(chomp(getInt(':')))
+    fun decodeText(): String = chomp(getInt(':')).utf8ToString()
 
-    fun decodeNum(): Double = utf8ToString(upTo(':')).toDouble()
+    fun decodeNum(): Double = upTo(':').utf8ToString().toDouble()
 
-    fun decodeBool(): Boolean = utf8ToString(chomp(1)) == "1"
+    fun decodeBool(): Boolean = chomp(1).utf8ToString() == "1"
 
     companion object {
         fun decodeDictionary(bytes: ByteArray): Map<String, String> {
@@ -65,10 +65,10 @@ class StringDecoder(private var bytes: ByteArray) {
             var num = decoder.getInt(':')
             while (num-- > 0) {
                 val klen = decoder.getInt(':')
-                val key = utf8ToString(decoder.chomp(klen))
+                val key = decoder.chomp(klen).utf8ToString()
 
                 val vlen = decoder.getInt(':')
-                val value = utf8ToString(decoder.chomp(vlen))
+                val value = decoder.chomp(vlen).utf8ToString()
 
                 dict[key] = value
             }
@@ -85,7 +85,7 @@ class StringEncoder(
     fun encodeDictionary(dict: Map<String, Any?>): StringEncoder {
         addStr("${dict.size}:")
         for ((key, value) in dict) {
-            addBytes("", stringtoUtf8(key))
+            addBytes("", key.stringToUtf8())
             encodeValue(value)
         }
         return this
@@ -97,9 +97,9 @@ class StringEncoder(
         return this
     }
 
-    private fun encodeValue(value: Any?) {
+    fun encodeValue(value: Any?) {
         when (value) {
-            is String -> addBytes("T", stringtoUtf8(value))
+            is String -> addBytes("T", value.stringToUtf8())
             is Boolean -> addStr("B${if (value) 1 else 0}")
             is Double -> addStr("N$value:")
             is Map<*, *> -> {
@@ -117,7 +117,7 @@ class StringEncoder(
     }
 
     fun encode(prefix: String, str: String) {
-        addBytes(prefix, stringtoUtf8(str))
+        addBytes(prefix, str.stringToUtf8())
         addStr("|")
     }
 
@@ -130,7 +130,7 @@ class StringEncoder(
     }
 
     private fun addStr(str: String) {
-        stringtoUtf8(str).also {
+        str.stringToUtf8().also {
             buffers.add(it)
             size += it.size
         }

--- a/src/wasm/kotlin/java/arcs/Entity.kt
+++ b/src/wasm/kotlin/java/arcs/Entity.kt
@@ -13,27 +13,62 @@ package arcs
 
 typealias URL = String
 
+/** Wraps a ByteArray whose final byte is set to 0. */
+inline class NullTermByteArray(val bytes: ByteArray)
+
 abstract class Entity<T> {
     var internalId = ""
-    abstract fun decodeEntity(encoded: String): T?
-    abstract fun encodeEntity(): String
+    abstract fun decodeEntity(encoded: ByteArray): T?
+    abstract fun encodeEntity(): NullTermByteArray
 }
 
-class StringDecoder(private var str: String) {
+class StringDecoder(private var bytes: ByteArray) {
+
+    fun done(): Boolean = bytes.isEmpty() || bytes[0] == 0.toByte()
+
+    fun upTo(sep: Char): ByteArray {
+        val ind = bytes.indexOf(sep.toByte())
+        if (ind == -1) {
+            error("Packaged entity decoding failed in upTo()\n")
+        }
+        val chunk = bytes.sliceArray(0..(ind - 1))
+        bytes = bytes.sliceArray((ind + 1)..(bytes.size - 1))
+        return chunk
+    }
+
+    fun getInt(sep: Char): Int = utf8ToString(upTo(sep)).toInt()
+
+    fun chomp(len: Int): ByteArray {
+        // TODO: detect overrun
+        val chunk = bytes.sliceArray(0..(len - 1))
+        bytes = bytes.sliceArray(len..(bytes.size - 1))
+        return chunk
+    }
+
+    fun validate(token: String) {
+        if (utf8ToString(chomp(token.length)) != token) {
+            throw IllegalArgumentException("Packaged entity decoding failed in validate()")
+        }
+    }
+
+    fun decodeText(): String = utf8ToString(chomp(getInt(':')))
+
+    fun decodeNum(): Double = utf8ToString(upTo(':')).toDouble()
+
+    fun decodeBool(): Boolean = utf8ToString(chomp(1)) == "1"
 
     companion object {
-
-        fun decodeDictionary(str: String): Map<String, String> {
-            val decoder = StringDecoder(str)
+        fun decodeDictionary(bytes: ByteArray): Map<String, String> {
+            val decoder = StringDecoder(bytes)
             val dict = mutableMapOf<String, String>()
 
-            var num = decoder.getInt(":")
+            var num = decoder.getInt(':')
             while (num-- > 0) {
-                val klen = decoder.getInt(":")
-                val key = decoder.chomp(klen)
+                val klen = decoder.getInt(':')
+                val key = utf8ToString(decoder.chomp(klen))
 
-                val vlen = decoder.getInt(":")
-                val value = decoder.chomp(vlen)
+                val vlen = decoder.getInt(':')
+                val value = utf8ToString(decoder.chomp(vlen))
 
                 dict[key] = value
             }
@@ -41,103 +76,91 @@ class StringDecoder(private var str: String) {
             return dict
         }
     }
-
-    fun done(): Boolean {
-        return str.isEmpty()
-    }
-
-    fun upTo(sep: String): String {
-        val ind = str.indexOf(sep)
-        if (ind == -1) {
-            error("Packaged entity decoding failed in upTo()\n")
-        }
-        val token = str.substring(0, ind)
-        str = str.substring(ind + 1)
-        return token
-    }
-
-    fun getInt(sep: String): Int {
-        val token = upTo(sep)
-        return token.toInt()
-    }
-
-    fun chomp(len: Int): String {
-        // TODO: detect overrun
-        val token = str.substring(0, len)
-        str = str.substring(len)
-        return token
-    }
-
-    fun validate(token: String) {
-        if (chomp(token.length) != token) {
-            throw Exception("Packaged entity decoding failed in validate()\n")
-        }
-    }
-
-    fun decodeText(): String {
-        val len = getInt(":")
-        return chomp(len)
-    }
-
-    fun decodeNum(): Double {
-        val token = upTo(":")
-        return token.toDouble()
-    }
-
-    fun decodeBool(): Boolean {
-        return (chomp(1)[0] == '1')
-    }
 }
 
-class StringEncoder(private val sb: StringBuilder = StringBuilder()) {
-
-    companion object {
-        fun encodeDictionary(dict: Map<String, Any?>): String {
-            val sb = StringBuilder()
-            sb.append(dict.size).append(":")
-
-            for ((key, value) in dict) {
-                sb.append(key.length).append(":").append(key)
-                sb.append(encodeValue(value))
-            }
-            return sb.toString()
+class StringEncoder(
+    private val buffers: MutableList<ByteArray> = mutableListOf(),
+    private var size: Int = 0
+) {
+    fun encodeDictionary(dict: Map<String, Any?>): StringEncoder {
+        addStr("${dict.size}:")
+        for ((key, value) in dict) {
+            addBytes("", stringtoUtf8(key))
+            encodeValue(value)
         }
+        return this
+    }
 
-        fun encodeList(list: List<Any>): String {
-            return list.joinToString(separator = "", prefix = "${list.size}:") { encodeValue(it) }
-        }
+    fun encodeList(list: List<Any>): StringEncoder {
+        addStr("${list.size}:")
+        list.forEach { encodeValue(it) }
+        return this
+    }
 
-        fun encodeValue(value: Any?): String {
-            return when (value) {
-                is String -> "T${value.length}:$value"
-                is Boolean -> "B${if (value) 1 else 0}"
-                is Double -> "N$value:"
-                is Map<*, *> -> {
-                    @Suppress("UNCHECKED_CAST")
-                    val dictString = encodeDictionary(value as Map<String, Any?>)
-                    "D${dictString.length}:$dictString"
-                }
-                is List<*> -> {
-                    @Suppress("UNCHECKED_CAST")
-                    val listString = encodeList(value as List<Any>)
-                    "A${listString.length}:$listString"
-                }
-                else -> throw IllegalArgumentException("Unknown expression.")
+    private fun encodeValue(value: Any?) {
+        when (value) {
+            is String -> addBytes("T", stringtoUtf8(value))
+            is Boolean -> addStr("B${if (value) 1 else 0}")
+            is Double -> addStr("N$value:")
+            is Map<*, *> -> {
+                @Suppress("UNCHECKED_CAST")
+                val se = StringEncoder().encodeDictionary(value as Map<String, Any?>)
+                addBytes("D", se.toByteArray())
             }
+            is List<*> -> {
+                @Suppress("UNCHECKED_CAST")
+                val se = StringEncoder().encodeList(value as List<Any>)
+                addBytes("A", se.toByteArray())
+            }
+            else -> throw IllegalArgumentException("Unknown expression.")
         }
     }
 
-    fun result(): String = sb.toString()
-
     fun encode(prefix: String, str: String) {
-        sb.append("$prefix${str.length}:$str|")
+        addBytes(prefix, stringtoUtf8(str))
+        addStr("|")
     }
 
     fun encode(prefix: String, num: Double) {
-        sb.append("$prefix$num:|")
+        addStr("$prefix$num:|")
     }
 
     fun encode(prefix: String, flag: Boolean) {
-        sb.append("$prefix${if (flag) "1" else "0"}|")
+        addStr("$prefix${if (flag) "1" else "0"}|")
+    }
+
+    private fun addStr(str: String) {
+        stringtoUtf8(str).also {
+            buffers.add(it)
+            size += it.size
+        }
+    }
+
+    private fun addBytes(prefix: String, bytes: ByteArray) {
+        addStr("$prefix${bytes.size}:")
+        buffers.add(bytes)
+        size += bytes.size
+    }
+
+    fun toByteArray(): ByteArray {
+        val res = ByteArray(size)
+        populate(res)
+        return res
+    }
+
+    fun toNullTermByteArray(): NullTermByteArray {
+        val res = ByteArray(size + 1)
+        var pos = populate(res)
+        res[pos] = 0.toByte()
+        return NullTermByteArray(res)
+    }
+
+    private fun populate(res: ByteArray): Int {
+        var pos = 0
+        buffers.forEach {
+            it.copyInto(res, pos)
+            pos += it.size
+        }
+        return pos
     }
 }

--- a/src/wasm/kotlin/java/arcs/RuntimeClient.kt
+++ b/src/wasm/kotlin/java/arcs/RuntimeClient.kt
@@ -11,8 +11,11 @@
 
 package arcs
 
-expect fun utf8ToString(bytes: ByteArray): String
-expect fun stringtoUtf8(str: String): ByteArray
+expect fun utf8ToStringImpl(bytes: ByteArray): String
+expect fun stringToUtf8Impl(str: String): ByteArray
+
+fun ByteArray.utf8ToString(): String = utf8ToStringImpl(this)
+fun String.stringToUtf8(): ByteArray = stringToUtf8Impl(this)
 
 /**
  * Delegate core runtime operations to the appropriate platform.

--- a/src/wasm/kotlin/java/arcs/RuntimeClient.kt
+++ b/src/wasm/kotlin/java/arcs/RuntimeClient.kt
@@ -11,6 +11,9 @@
 
 package arcs
 
+expect fun utf8ToString(bytes: ByteArray): String
+expect fun stringtoUtf8(str: String): ByteArray
+
 /**
  * Delegate core runtime operations to the appropriate platform.
  */
@@ -30,7 +33,7 @@ expect object RuntimeClient {
      * @param singleton target to be cleared
      * @param encoded serialized representation of an entity
      */
-    fun <T : Entity<T>> singletonSet(particle: Particle, singleton: Singleton<T>, encoded: String)
+    fun <T : Entity<T>> singletonSet(particle: Particle, singleton: Singleton<T>, encoded: NullTermByteArray)
 
     /**
      * Removes all entities to produce an empty collection.
@@ -47,7 +50,7 @@ expect object RuntimeClient {
      * @param collection target to be mutated
      * @param encoded serialized representation of an entity
      */
-    fun <T : Entity<T>> collectionRemove(particle: Particle, collection: Collection<T>, encoded: String)
+    fun <T : Entity<T>> collectionRemove(particle: Particle, collection: Collection<T>, encoded: NullTermByteArray)
 
     /**
      * Add a single entity to a collection
@@ -60,7 +63,7 @@ expect object RuntimeClient {
     fun <T : Entity<T>> collectionStore(
         particle: Particle,
         collection: Collection<T>,
-        encoded: String
+        encoded: NullTermByteArray
     ): String?
 
     /** @param msg message to write to a logging system. */
@@ -73,7 +76,7 @@ expect object RuntimeClient {
      * @param template string encoding of UI template
      * @param model data model to be interpolated in the template
      */
-    fun onRenderOutput(particle: Particle, template: String?, model: String?)
+    fun onRenderOutput(particle: Particle, template: String?, model: NullTermByteArray?)
 
     /**
      * Request an action to be performed by a Service
@@ -83,7 +86,7 @@ expect object RuntimeClient {
      * @param encoded serialized key-value data to be passed to the service
      * @param tag name the request to the service
      */
-    fun serviceRequest(particle: Particle, call: String, encoded: String, tag: String)
+    fun serviceRequest(particle: Particle, call: String, encoded: NullTermByteArray, tag: String)
 
     /** @param url translate to absolute location */
     fun resolveUrl(url: String): String

--- a/src/wasm/kotlin/java/arcs/jvm/JvmRuntimeClient.kt
+++ b/src/wasm/kotlin/java/arcs/jvm/JvmRuntimeClient.kt
@@ -11,8 +11,8 @@
 
 package arcs
 
-actual fun utf8ToString(bytes: ByteArray): String = throw NotImplementedError()
-actual fun stringtoUtf8(str: String): ByteArray = throw NotImplementedError()
+actual fun utf8ToStringImpl(bytes: ByteArray): String = bytes.toString(Charsets.UTF_8)
+actual fun stringToUtf8Impl(str: String): ByteArray = str.toByteArray(Charsets.UTF_8)
 
 // TODO(alxr): Implement Jvm Runtime
 actual object RuntimeClient {

--- a/src/wasm/kotlin/java/arcs/jvm/JvmRuntimeClient.kt
+++ b/src/wasm/kotlin/java/arcs/jvm/JvmRuntimeClient.kt
@@ -11,16 +11,23 @@
 
 package arcs
 
+actual fun utf8ToString(bytes: ByteArray): String = throw NotImplementedError()
+actual fun stringtoUtf8(str: String): ByteArray = throw NotImplementedError()
+
 // TODO(alxr): Implement Jvm Runtime
 actual object RuntimeClient {
     actual fun <T : Entity<T>> singletonClear(particle: Particle, singleton: Singleton<T>): Unit =
         throw NotImplementedError()
 
-    actual fun <T : Entity<T>> singletonSet(particle: Particle, singleton: Singleton<T>, encoded: String): Unit =
-        throw NotImplementedError()
+    actual fun <T : Entity<T>> singletonSet(particle: Particle,
+        singleton: Singleton<T>,
+        encoded: NullTermByteArray
+    ): Unit = throw NotImplementedError()
 
-    actual fun <T : Entity<T>> collectionRemove(particle: Particle, collection: Collection<T>, encoded: String): Unit =
-        throw NotImplementedError()
+    actual fun <T : Entity<T>> collectionRemove(particle: Particle,
+        collection: Collection<T>,
+        encoded: NullTermByteArray
+    ): Unit = throw NotImplementedError()
 
     actual fun <T : Entity<T>> collectionClear(particle: Particle, collection: Collection<T>): Unit =
         throw NotImplementedError()
@@ -28,14 +35,15 @@ actual object RuntimeClient {
     actual fun <T : Entity<T>> collectionStore(
         particle: Particle,
         collection: Collection<T>,
-        encoded: String): String? = throw NotImplementedError()
+        encoded: NullTermByteArray
+    ): String? = throw NotImplementedError()
 
     actual fun log(msg: String): Unit = throw NotImplementedError()
 
-    actual fun onRenderOutput(particle: Particle, template: String?, model: String?): Unit =
+    actual fun onRenderOutput(particle: Particle, template: String?, model: NullTermByteArray?): Unit =
         throw NotImplementedError()
 
-    actual fun serviceRequest(particle: Particle, call: String, encoded: String, tag: String): Unit =
+    actual fun serviceRequest(particle: Particle, call: String, encoded: NullTermByteArray, tag: String): Unit =
         throw NotImplementedError()
 
     actual fun resolveUrl(url: String): String = throw NotImplementedError()
@@ -44,4 +52,3 @@ actual object RuntimeClient {
 
     actual fun assert(message: String, cond: Boolean): Unit = throw NotImplementedError()
 }
-

--- a/src/wasm/kotlin/java/arcs/wasm/WasmRuntimeClient.kt
+++ b/src/wasm/kotlin/java/arcs/wasm/WasmRuntimeClient.kt
@@ -29,8 +29,8 @@ import arcs.wasm.toWasmString
 import arcs.wasm.toWasmAddress
 import arcs.wasm.WasmString
 
-actual fun utf8ToString(bytes: ByteArray): String = bytes.decodeToString()
-actual fun stringtoUtf8(str: String): ByteArray = str.encodeToByteArray()
+actual fun utf8ToStringImpl(bytes: ByteArray): String = bytes.decodeToString()
+actual fun stringToUtf8Impl(str: String): ByteArray = str.encodeToByteArray()
 
 actual object RuntimeClient {
     actual fun <T : Entity<T>> singletonClear(particle: Particle, singleton: Singleton<T>) =

--- a/src/wasm/kotlin/java/arcs/wasm/WasmRuntimeClient.kt
+++ b/src/wasm/kotlin/java/arcs/wasm/WasmRuntimeClient.kt
@@ -12,6 +12,7 @@
 package arcs
 
 import arcs.addressable.toAddress
+import arcs.NullTermByteArray
 import arcs.wasm._free
 import arcs.wasm.collectionClear
 import arcs.wasm.collectionRemove
@@ -25,25 +26,35 @@ import arcs.wasm.toKString
 import arcs.wasm.toNullableKString
 import arcs.wasm.toWasmNullableString
 import arcs.wasm.toWasmString
+import arcs.wasm.toWasmAddress
 import arcs.wasm.WasmString
+
+actual fun utf8ToString(bytes: ByteArray): String = bytes.decodeToString()
+actual fun stringtoUtf8(str: String): ByteArray = str.encodeToByteArray()
 
 actual object RuntimeClient {
     actual fun <T : Entity<T>> singletonClear(particle: Particle, singleton: Singleton<T>) =
         singletonClear(particle.toAddress(), singleton.toAddress())
 
-    actual fun <T : Entity<T>> singletonSet(particle: Particle, singleton: Singleton<T>, encoded: String) =
-        singletonSet(
-            particle.toAddress(),
-            singleton.toAddress(),
-            encoded.toWasmString()
-        )
+    actual fun <T : Entity<T>> singletonSet(
+        particle: Particle,
+        singleton: Singleton<T>,
+        encoded: NullTermByteArray
+    ) = singletonSet(
+        particle.toAddress(),
+        singleton.toAddress(),
+        encoded.bytes.toWasmAddress()
+    )
 
-    actual fun <T : Entity<T>> collectionRemove(particle: Particle, collection: Collection<T>, encoded: String) =
-        collectionRemove(
-            particle.toAddress(),
-            collection.toAddress(),
-            encoded.toWasmString()
-        )
+    actual fun <T : Entity<T>> collectionRemove(
+        particle: Particle,
+        collection: Collection<T>,
+        encoded: NullTermByteArray
+    ) = collectionRemove(
+        particle.toAddress(),
+        collection.toAddress(),
+        encoded.bytes.toWasmAddress()
+    )
 
     actual fun <T : Entity<T>> collectionClear(particle: Particle, collection: Collection<T>) =
         collectionClear(particle.toAddress(), collection.toAddress())
@@ -51,30 +62,30 @@ actual object RuntimeClient {
     actual fun <T : Entity<T>> collectionStore(
         particle: Particle,
         collection: Collection<T>,
-        encoded: String
+        encoded: NullTermByteArray
     ): String? {
         val wasmId = collectionStore(
             particle.toAddress(),
             collection.toAddress(),
-            encoded.toWasmString()
+            encoded.bytes.toWasmAddress()
         )
         return wasmId.toNullableKString()?.let { _free(wasmId); it }
     }
 
-    actual fun log(msg: String) = arcs.wasm.log(msg);
+    actual fun log(msg: String) = arcs.wasm.log(msg)
 
-    actual fun onRenderOutput(particle: Particle, template: String?, model: String?) =
+    actual fun onRenderOutput(particle: Particle, template: String?, model: NullTermByteArray?) =
         onRenderOutput(
             particle.toAddress(),
             template.toWasmNullableString(),
-            model.toWasmNullableString()
+            model?.bytes?.toWasmAddress() ?: 0
         )
 
-    actual fun serviceRequest(particle: Particle, call: String, encoded: String, tag: String) =
+    actual fun serviceRequest(particle: Particle, call: String, encoded: NullTermByteArray, tag: String) =
         serviceRequest(
             particle.toAddress(),
             call.toWasmString(),
-            encoded.toWasmString(),
+            encoded.bytes.toWasmAddress(),
             tag.toWasmString()
         )
 
@@ -85,7 +96,7 @@ actual object RuntimeClient {
         return resolved
     }
 
-    actual fun abort() = arcs.wasm.abort();
+    actual fun abort() = arcs.wasm.abort()
 
     actual fun assert(message: String, cond: Boolean) {
         if (cond) return

--- a/src/wasm/kotlin/javatests/arcs/EntityClassApiTest.kt
+++ b/src/wasm/kotlin/javatests/arcs/EntityClassApiTest.kt
@@ -68,13 +68,13 @@ class EntityClassApiTest(ctor: (String) -> EntityClassApiTest_Errors) :
             lnk = "",
             flg = false
         )
-        val emptyStr = empty.encodeEntity()
+        val encodedEmpty = empty.encodeEntity()
         val decodedEmpty = EntityClassApiTest_Data(
             num = 10.0,
             txt = "20",
             lnk = "https://thirty.net",
             flg = true
-        ).decodeEntity(emptyStr)
+        ).decodeEntity(encodedEmpty.bytes)
         assertEquals(
             "Encoding and Decoding an empty entity results in the same entity",
             empty,
@@ -87,14 +87,13 @@ class EntityClassApiTest(ctor: (String) -> EntityClassApiTest_Errors) :
             lnk = "https://thirty.net",
             flg = true
         )
-        val fullStr = full.encodeEntity()
-        println("fullStr $fullStr")
+        val encodedFull = full.encodeEntity()
         val decodedFull = EntityClassApiTest_Data(
             num = 10.0,
             txt = "20",
             lnk = "https://thirty.net",
             flg = true
-        ).decodeEntity(fullStr)
+        ).decodeEntity(encodedFull.bytes)
         assertEquals(
             "Encoding and Decoding an full entity results in the same entity",
             full,

--- a/src/wasm/kotlin/javatests/arcs/SpecialSchemaFieldsTest.kt
+++ b/src/wasm/kotlin/javatests/arcs/SpecialSchemaFieldsTest.kt
@@ -53,7 +53,7 @@ class SpecialSchemaFieldsTest(
             internal_id = 0.0,
             internalId_ = 0.0
         )
-        val encoding = utf8ToString(s.encodeEntity().bytes)
+        val encoding = s.encodeEntity().bytes.utf8ToString()
         assertTrue("The encoding uses the language keyword", encoding.contains("|for:"))
     }
 
@@ -84,7 +84,7 @@ class SpecialSchemaFieldsTest(
             internal_id = 0.0,
             internalId_ = 10.0
         )
-        val encoding = utf8ToString(s.encodeEntity().bytes)
+        val encoding = s.encodeEntity().bytes.utf8ToString()
         assertTrue("The encoding uses the keyword 'internalId'", encoding.contains("|internalId:"))
     }
 }

--- a/src/wasm/kotlin/javatests/arcs/SpecialSchemaFieldsTest.kt
+++ b/src/wasm/kotlin/javatests/arcs/SpecialSchemaFieldsTest.kt
@@ -12,6 +12,7 @@
 package sdk.kotlin.javatests.arcs
 
 import arcs.Singleton
+import arcs.utf8ToString
 import arcs.addressable.toAddress
 import kotlin.native.Retain
 import kotlin.native.internal.ExportForCppRuntime
@@ -52,8 +53,8 @@ class SpecialSchemaFieldsTest(
             internal_id = 0.0,
             internalId_ = 0.0
         )
-        val encoding: String = s.encodeEntity()
-        assertTrue("The encoding uses the language keyword", encoding.contains("for"))
+        val encoding = utf8ToString(s.encodeEntity().bytes)
+        assertTrue("The encoding uses the language keyword", encoding.contains("|for:"))
     }
 
     @Test
@@ -83,8 +84,8 @@ class SpecialSchemaFieldsTest(
             internal_id = 0.0,
             internalId_ = 10.0
         )
-        val encoding: String = s.encodeEntity()
-        assertTrue("The encoding uses the keyword 'internalId'", encoding.contains("internalId"))
+        val encoding = utf8ToString(s.encodeEntity().bytes)
+        assertTrue("The encoding uses the keyword 'internalId'", encoding.contains("|internalId:"))
     }
 }
 

--- a/src/wasm/kotlin/javatests/arcs/UnicodeTest.kt
+++ b/src/wasm/kotlin/javatests/arcs/UnicodeTest.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package sdk.kotlin.javatests.arcs
+
+import arcs.addressable.toAddress
+import arcs.Collection
+import arcs.Handle
+import arcs.Particle
+import arcs.Singleton
+import kotlin.native.internal.ExportForCppRuntime
+import kotlin.native.Retain
+
+class UnicodeTest : Particle() {
+    private val sng = Singleton(this, "sng") { UnicodeTest_Sng(
+        pass = "",
+        src = ""
+    ) }
+    private val col = Collection(this, "col") { UnicodeTest_Col(
+        pass = "",
+        src = ""
+    ) }
+    private val res = Collection(this, "res") { UnicodeTest_Res(
+        pass = "",
+        src = ""
+    ) }
+
+    override fun onHandleUpdate(handle: Handle) {
+        val out = UnicodeTest_Res(pass = "", src = "")
+        out.src = "åŗċş 🌈"
+        out.pass = if (handle.name == "sng") {
+            ((handle as Singleton<*>).get() as UnicodeTest_Sng).pass
+        } else {
+            ((handle as Collection<*>).iterator().next() as UnicodeTest_Col).pass
+        }
+        res.store(out)
+    }
+}
+
+@Retain
+@ExportForCppRuntime("_newUnicodeTest")
+fun constructUnicodeTest() = UnicodeTest().toAddress()

--- a/src/wasm/tests/manifest.arcs
+++ b/src/wasm/tests/manifest.arcs
@@ -153,3 +153,16 @@ recipe SchemaReferenceFieldsTest
     input: reads h1
     output: writes h2
     res: writes h3
+
+// -----------------------------------------------------------------------------------------------
+
+particle UnicodeTest in '$module.wasm'
+  sng: reads * {pass: Text, src: Text}
+  col: reads [* {pass: Text, src: Text}]
+  res: writes [* {pass: Text, src: Text}]
+
+recipe UnicodeTest
+  UnicodeTest
+    sng: reads h1
+    col: reads h2
+    res: writes h3


### PR DESCRIPTION
Kotlin is unicode aware, so should be able to use unicode freely.
C++ still uses plain char strings, but is able to preserve unicode data in entity fields.