### PR TITLE
Prevent the user of non-space white space characters

### DIFF
--- a/src/runtime/manifest-parser.peg
+++ b/src/runtime/manifest-parser.peg
@@ -1401,10 +1401,12 @@ dottedName "a name conforming to the rules of an android app name, per https://d
 simpleName "a name starting with a letter and containing letters, digits and underscores"
   = [a-zA-Z][a-zA-Z0-9_]* {return text();}
 whiteSpace "one or more whitespace characters"
-  = " "+
+  = spaceChar+
+spaceChar "a 'plain' space (use whiteSpace instead)"
+  = ' ' / ("\u00A0" / "\t" / "\f" / "\r" / "\v") {expected('space');}
 eolWhiteSpace "a group of new lines (and optionally comments)"
-  = [ ]* !.
-  / [ ]* '//' [^\n]* eolWhiteSpace
-  / [ ]* eol eolWhiteSpace?
+  = spaceChar* !.
+  / spaceChar* '//' [^\n]* eolWhiteSpace
+  / spaceChar* eol eolWhiteSpace?
 eol "a new line"
   = "\r"? "\n" "\r"?

--- a/src/runtime/tests/manifest-parser-test.ts
+++ b/src/runtime/tests/manifest-parser-test.ts
@@ -23,6 +23,27 @@ describe('manifest parser', () => {
     parse(`
       recipe Recipe`);
   });
+  it('fails to parse non-standard indentation (horizontal tab)', () => {
+    // Note: This is to protect against confusing whitespace issues caused by
+    // mixed tabs and spaces.
+    assert.throws(() => {
+    parse('\trecipe Recipe');
+    }, 'Expected space but "\\t" found.');
+  });
+  it('fails to parse non-standard indentation (vertical tab)', () => {
+    // Note: This is to protect against confusing whitespace issues caused by
+    // mixed tabs and spaces.
+    assert.throws(() => {
+    parse('\vrecipe Recipe');
+    }, 'Expected space but "\\x0B" found.');
+  });
+  it('fails to parse non-standard indentation (non-breaking space)', () => {
+    // Note: This is to protect against confusing whitespace issues caused by
+    // mixed tabs and spaces.
+    assert.throws(() => {
+    parse('\xA0recipe Recipe');
+    }, 'Expected space but "\xA0" found.');
+  });
   it('parses recipes that map handles', () => {
     parse(`
       recipe Thing


### PR DESCRIPTION
This prevents confusion by failing parses when using tabs, vertical tables, a few types of uncommon feed symbols and non-breaking space (which could easily be accidentally introduced when copying from html). 