### PR TITLE
Remove references to "npm start" in code and doc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,7 @@ $ git config core.hooksPath tools/hooks
 
 ## Starting Arcs
 
-After the full build (`npm install && tools/sigh`) run: (note that `npm
-start` will block, so you'll have to run the second command in a new shell):
+After the full build (`npm install && tools/sigh`) run:
 
 ```
 $ tools/sigh devServer

--- a/tools/setup
+++ b/tools/setup
@@ -109,7 +109,7 @@ echo "ktlint --version"
 ktlint --version
 echo "\nNext, try the following:\n"
 echo "- Setup git hooks: $CMD\`git config core.hooksPath tools/hooks\`$END"
-echo "- Serve the project: $CMD\`npm start\`$END"
+echo "- Serve the project: $CMD\`./tools/sigh devServer\`$END"
 echo "- Run tests:"
 echo "  - $CMD\`./tools/sigh test\`$END"
 echo "  - $CMD\`./tools/test\`$END"


### PR DESCRIPTION
It looks like `npm start` is no longer supported and `./tools/sigh devServer` is the right way to serve.