### PR TITLE
Break cycle between handle.ts and reference.ts

### DIFF
--- a/src/platform/loader-base.ts
+++ b/src/platform/loader-base.ts
@@ -30,6 +30,7 @@ import '../runtime/handle-constructors.js';
 import '../runtime/noop-proxy.js';
 import '../runtime/storageNG/store-constructors.js';
 import '../runtime/entity-utils.js';
+import '../runtime/reference.js';
 
 type ParticleCtor = typeof Particle;
 

--- a/src/runtime/reference.ts
+++ b/src/runtime/reference.ts
@@ -9,7 +9,7 @@
  */
 
 import {assert} from '../platform/assert-web.js';
-import {Collection, Storable, unifiedHandleFor} from './handle.js';
+import {HandleOld, Collection, Storable, unifiedHandleFor} from './handle.js';
 import {ParticleExecutionContext} from './particle-execution-context.js';
 import {ReferenceType, EntityType} from './type.js';
 import {Entity, SerializedEntity} from './entity.js';
@@ -125,3 +125,9 @@ export abstract class ClientReference extends Reference {
     };
   }
 }
+
+function makeReference(data: {id: string, storageKey: string | null}, type: ReferenceType, context: ParticleExecutionContext): Reference {
+ return new Reference(data, type, context);
+}
+
+HandleOld.makeReference = makeReference;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,7 +14,7 @@ const CircularDependencyPlugin = require('circular-dependency-plugin');
 const lib = './shells/lib';
 
 // Decrease MAX_CYCLES every time you eliminate circular dependencies from the codebase.
-const MAX_CYCLES = 6;
+const MAX_CYCLES = 4;
 let numCyclesDetected = 0;
 
 module.exports = {


### PR DESCRIPTION
This drop the cycle count to 4, of which only two are real due to duplicates. The remaining two are hard, but the end is in sight.