### PR TITLE
Do not cache cache-mgr itself

### DIFF
--- a/shells/pipes-shell/web/cache-mgr-sw.js
+++ b/shells/pipes-shell/web/cache-mgr-sw.js
@@ -24,6 +24,11 @@ const PREBUILT_CACHES = [
   './shell.js',
 ];
 
+// The files/resources are never served/cached by the Arcs Cache Manager.
+const BLACKLIST = [
+  'cache-mgr.js',
+];
+
 self.addEventListener('install', event => {
   async function buildCache() {
     console.log('building Arcs caches');
@@ -73,6 +78,12 @@ self.addEventListener('fetch', event => {
   // workstation assets when enabling debug.arcs.runtime.load_workstation_assets
   if (event.request.url.indexOf(self.location.host) === -1) {
     return;
+  }
+  // Bypass the resources and files in the blacklist
+  for (const res of BLACKLIST) {
+    if (event.request.url.endsWith(res)) {
+      return;
+    }
   }
   event.respondWith(cachedFetch(event));
 });


### PR DESCRIPTION
This is a follow-up to #4186 to bypass caching for cache-mgr.js
It is required so the registrant (cache-mgr.js) can actually register the updated Arcs Cache Manger (cache-mgr-sw.js). 