### PR TITLE
Better exceptions

### DIFF
--- a/src/planning/plan/tests/test-environment-test.ts
+++ b/src/planning/plan/tests/test-environment-test.ts
@@ -13,7 +13,7 @@ let exceptions: Error[] = [];
 
 before(() => {
   removeSystemExceptionHandler(defaultSystemExceptionHandler);
-  registerSystemExceptionHandler((exception) => exceptions.push(exception));
+  registerSystemExceptionHandler(exception => exceptions.push(exception));
 });
 
 afterEach(function() {

--- a/src/planning/plan/tests/test-environment-test.ts
+++ b/src/planning/plan/tests/test-environment-test.ts
@@ -7,17 +7,20 @@
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
-import {registerSystemExceptionHandler} from '../../../runtime/arc-exceptions.js';
+import {registerSystemExceptionHandler, removeSystemExceptionHandler, defaultSystemExceptionHandler} from '../../../runtime/arc-exceptions.js';
 
 let exceptions = [];
 
-beforeEach(() => registerSystemExceptionHandler((exception) => exceptions.push(exception)));
+before(() => {
+  removeSystemExceptionHandler(defaultSystemExceptionHandler);
+  registerSystemExceptionHandler((exception) => exceptions.push(exception));
+});
 
 afterEach(function() {
   if (exceptions.length > 0) {
-    for (const exception of exceptions) {
-      this.test.ctx.currentTest.err = exception;
-    }
+    const exception = exceptions[0];
     exceptions = [];
+    // Error function not yet included in mocha typescript declarations...
+    this.test['error'](exception);
   }
 });

--- a/src/planning/plan/tests/test-environment-test.ts
+++ b/src/planning/plan/tests/test-environment-test.ts
@@ -9,7 +9,7 @@
  */
 import {registerSystemExceptionHandler, removeSystemExceptionHandler, defaultSystemExceptionHandler} from '../../../runtime/arc-exceptions.js';
 
-let exceptions = [];
+let exceptions: Error[] = [];
 
 before(() => {
   removeSystemExceptionHandler(defaultSystemExceptionHandler);

--- a/src/runtime/arc-exceptions.ts
+++ b/src/runtime/arc-exceptions.ts
@@ -76,12 +76,17 @@ export class UserException extends PropagatedException {
   }
 }
 
-type ExceptionHandler = Consumer<PropagatedException>;
+type ExceptionHandler = Consumer<Error>;
 
 const systemHandlers = <ExceptionHandler[]>[];
 
 export function reportSystemException(exception: PropagatedException) {
-  console.log('reportSystemException');
+  for (const handler of systemHandlers) {
+    handler(exception);
+  }
+}
+
+export function reportGlobalException(exception: Error) {
   for (const handler of systemHandlers) {
     handler(exception);
   }

--- a/src/runtime/arc-exceptions.ts
+++ b/src/runtime/arc-exceptions.ts
@@ -81,6 +81,7 @@ type ExceptionHandler = Consumer<PropagatedException>;
 const systemHandlers = <ExceptionHandler[]>[];
 
 export function reportSystemException(exception: PropagatedException) {
+  console.log('reportSystemException');
   for (const handler of systemHandlers) {
     handler(exception);
   }
@@ -99,7 +100,9 @@ export function removeSystemExceptionHandler(handler: ExceptionHandler) {
   }
 }
 
-registerSystemExceptionHandler((exception) => {
+export const defaultSystemExceptionHandler = (exception) => {
   console.log(exception.method, exception.particleName);
   throw exception;
-});
+};
+
+registerSystemExceptionHandler(defaultSystemExceptionHandler);

--- a/src/runtime/flags.ts
+++ b/src/runtime/flags.ts
@@ -11,7 +11,7 @@
 /** Arcs runtime flags. */
 
 class FlagDefaults {
-  static useNewStorageStack = true;
+  static useNewStorageStack = false;
 }
 
 export class Flags extends FlagDefaults {

--- a/src/runtime/flags.ts
+++ b/src/runtime/flags.ts
@@ -11,7 +11,7 @@
 /** Arcs runtime flags. */
 
 class FlagDefaults {
-  static useNewStorageStack = false;
+  static useNewStorageStack = true;
 }
 
 export class Flags extends FlagDefaults {

--- a/src/runtime/particle.ts
+++ b/src/runtime/particle.ts
@@ -46,6 +46,7 @@ export class Particle {
 
   protected slotProxiesByName: Map<string, SlotProxy> = new Map();
   private capabilities: Capabilities;
+  protected onError: Consumer<Error>;
 
   constructor() {
     // Typescript only sees this.constructor as a Function type.
@@ -90,6 +91,7 @@ export class Particle {
     this.handles = handles;
     await this.invokeSafely(async p => p.setHandles(handles), onException);
     this._handlesToSync = this._countInputHandles(handles);
+    this.onError = onException;
     if (!this._handlesToSync) {
       // onHandleSync is called IFF there are input handles, otherwise we are ready now
       this.ready();

--- a/src/runtime/tests/particle-api-more-test.ts
+++ b/src/runtime/tests/particle-api-more-test.ts
@@ -49,7 +49,7 @@ const spawnTestArc = async (loader) => {
   return arc;
 };
 
-describe.only('ui-particle-api', () => {
+describe('ui-particle-api', () => {
 
   describe('high-level handle operations', () => {
 
@@ -198,9 +198,9 @@ describe.only('ui-particle-api', () => {
           }
         });`
       });
-      //
+
       const arc = await spawnTestArc(loader);
-      //
+
       const thingData = await getCollectionData(arc, 1);
       const list = JSON.stringify(thingData.map(thing => thing.value).sort());
       const expected = `["FooBarE0","FooBarE1","FooBarEntity"]`;

--- a/src/runtime/tests/particle-api-more-test.ts
+++ b/src/runtime/tests/particle-api-more-test.ts
@@ -49,7 +49,7 @@ const spawnTestArc = async (loader) => {
   return arc;
 };
 
-describe('ui-particle-api', () => {
+describe.only('ui-particle-api', () => {
 
   describe('high-level handle operations', () => {
 
@@ -207,6 +207,7 @@ describe('ui-particle-api', () => {
       assert.equal(list, expected, 'Collection incorrect after adds');
       const resultData = await getSingletonData(arc, 0);
       assert.ok(resultData.ok, 'failed to throw on adding a value to a Singleton');
+      await arc.idle;
     });
 
     it('can `remove` things', async () => {

--- a/src/runtime/tests/test-environment-test.ts
+++ b/src/runtime/tests/test-environment-test.ts
@@ -9,7 +9,7 @@
  */
 import {registerSystemExceptionHandler, PropagatedException, removeSystemExceptionHandler, defaultSystemExceptionHandler} from '../arc-exceptions.js';
 
-let exceptions: PropagatedException[] = [];
+let exceptions: Error[] = [];
 
 before(() => {
   removeSystemExceptionHandler(defaultSystemExceptionHandler);

--- a/src/runtime/tests/test-environment-test.ts
+++ b/src/runtime/tests/test-environment-test.ts
@@ -13,7 +13,7 @@ let exceptions: Error[] = [];
 
 before(() => {
   removeSystemExceptionHandler(defaultSystemExceptionHandler);
-  registerSystemExceptionHandler((exception) => exceptions.push(exception));
+  registerSystemExceptionHandler(exception => exceptions.push(exception));
 });
 
 afterEach(function() {

--- a/src/runtime/tests/test-environment-test.ts
+++ b/src/runtime/tests/test-environment-test.ts
@@ -7,17 +7,20 @@
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
-import {registerSystemExceptionHandler, PropagatedException} from '../arc-exceptions.js';
+import {registerSystemExceptionHandler, PropagatedException, removeSystemExceptionHandler, defaultSystemExceptionHandler} from '../arc-exceptions.js';
 
 let exceptions: PropagatedException[] = [];
 
-beforeEach(() => registerSystemExceptionHandler((exception) => exceptions.push(exception)));
+before(() => {
+  removeSystemExceptionHandler(defaultSystemExceptionHandler);
+  registerSystemExceptionHandler((exception) => exceptions.push(exception));
+});
 
 afterEach(function() {
   if (exceptions.length > 0) {
-    for (const exception of exceptions) {
-      this.test.ctx.currentTest.err = exception;
-    }
+    const exception = exceptions[0];
     exceptions = [];
+    // Error function not yet included in mocha typescript declarations...
+    this.test['error'](exception);
   }
 });

--- a/src/runtime/ui-particle-base.ts
+++ b/src/runtime/ui-particle-base.ts
@@ -12,6 +12,7 @@ import {Entity, EntityClass} from './entity.js';
 import {Handle, Collection, Singleton} from './handle.js';
 import {Particle} from './particle.js';
 import {CollectionHandle, SingletonHandle} from './storageNG/handle.js';
+import {Consumer} from './hot.js';
 
 export interface UiParticleConfig {
   handleNames: string[];
@@ -98,7 +99,7 @@ export class UiParticleBase extends Particle {
    */
   // tslint:disable-next-line: no-any
   async await(task: (p: this) => Promise<any>) {
-    return await this.invokeSafely(task, err => { throw err; });
+    return await this.invokeSafely(task, this.onError);
   }
 
   /**

--- a/src/tests/particles/test-environment-test.ts
+++ b/src/tests/particles/test-environment-test.ts
@@ -13,7 +13,7 @@ let exceptions: Error[] = [];
 
 before(() => {
   removeSystemExceptionHandler(defaultSystemExceptionHandler);
-  registerSystemExceptionHandler((exception) => exceptions.push(exception));
+  registerSystemExceptionHandler(exception => exceptions.push(exception));
 });
 
 afterEach(function() {

--- a/src/tests/particles/test-environment-test.ts
+++ b/src/tests/particles/test-environment-test.ts
@@ -9,7 +9,7 @@
  */
 import {registerSystemExceptionHandler, removeSystemExceptionHandler, defaultSystemExceptionHandler} from '../../runtime/arc-exceptions.js';
 
-let exceptions = [];
+let exceptions: Error[] = [];
 
 before(() => {
   removeSystemExceptionHandler(defaultSystemExceptionHandler);

--- a/src/tests/particles/test-environment-test.ts
+++ b/src/tests/particles/test-environment-test.ts
@@ -7,17 +7,20 @@
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
-import {registerSystemExceptionHandler} from '../../runtime/arc-exceptions.js';
+import {registerSystemExceptionHandler, removeSystemExceptionHandler, defaultSystemExceptionHandler} from '../../runtime/arc-exceptions.js';
 
 let exceptions = [];
 
-beforeEach(() => registerSystemExceptionHandler((exception) => exceptions.push(exception)));
+before(() => {
+  removeSystemExceptionHandler(defaultSystemExceptionHandler);
+  registerSystemExceptionHandler((exception) => exceptions.push(exception));
+});
 
 afterEach(function() {
   if (exceptions.length > 0) {
-    for (const exception of exceptions) {
-      this.test.ctx.currentTest.err = exception;
-    }
+    const exception = exceptions[0];
     exceptions = [];
+    // Error function not yet included in mocha typescript declarations...
+    this.test['error'](exception);
   }
 });

--- a/tools/sigh.ts
+++ b/tools/sigh.ts
@@ -777,6 +777,8 @@ function runTests(args: string[]): boolean {
               });
             });
         process.on('unhandledRejection', (reason, promise) => {
+          console.error('Uncaught Exception');
+          console.error(reason);
           runner.abort();
           throw reason;
         });


### PR DESCRIPTION
This significantly improves exception plumbing, so that tests tend to report their own errors rather than their siblings, and so that the full test suite tends to complete even on failure.

I'll write up some notes about exceptions in our codebase to accompany this patch, too.