### PR TITLE
Fix Auto Wasm in G3

### DIFF
--- a/third_party/java/arcs/build_defs/internal/kotlin.bzl
+++ b/third_party/java/arcs/build_defs/internal/kotlin.bzl
@@ -57,9 +57,9 @@ def arcs_kt_binary(name, srcs = [], deps = [], visibility = None):
 
         deps = [":" + libname]
 
-    binname = name + "_bin"
+    bin_name = name + "_bin"
     kt_native_binary(
-        name = binname,
+        name = bin_name,
         entry_point = "arcs.main",
         deps = [_to_wasm_dep(dep) for dep in _ARCS_KOTLIN_LIBS + deps],
         tags = ["manual"],
@@ -68,7 +68,7 @@ def arcs_kt_binary(name, srcs = [], deps = [], visibility = None):
 
     wasm_kt_binary(
         name = name,
-        kt_target = ":" + binname,
+        kt_target = ":" + bin_name,
     )
 
 def kt_jvm_and_wasm_library(

--- a/third_party/java/arcs/build_defs/internal/kotlin.bzl
+++ b/third_party/java/arcs/build_defs/internal/kotlin.bzl
@@ -49,7 +49,7 @@ def arcs_kt_binary(name, srcs = [], deps = [], visibility = None):
 
         # Declare a library because g3 kt_native_binary doesn't take srcs
         kt_native_library(
-            name = libname + _WASM_SUFFIX,
+            name = libname,
             srcs = srcs,
             deps = [_to_wasm_dep(dep) for dep in _ARCS_KOTLIN_LIBS + deps],
             visibility = visibility,
@@ -57,17 +57,18 @@ def arcs_kt_binary(name, srcs = [], deps = [], visibility = None):
 
         deps = [":" + libname]
 
+    binname = name + "_bin"
     kt_native_binary(
-        name = name,
+        name = binname,
         entry_point = "arcs.main",
         deps = [_to_wasm_dep(dep) for dep in _ARCS_KOTLIN_LIBS + deps],
-        tags = ["wasm"],
+        tags = ["manual"],
         visibility = visibility,
     )
 
     wasm_kt_binary(
-        name = name + "_wasm",
-        kt_target = ":" + name,
+        name = name,
+        kt_target = ":" + binname,
     )
 
 def kt_jvm_and_wasm_library(

--- a/third_party/java/arcs/build_defs/internal/kotlin.bzl
+++ b/third_party/java/arcs/build_defs/internal/kotlin.bzl
@@ -49,7 +49,7 @@ def arcs_kt_binary(name, srcs = [], deps = [], visibility = None):
 
         # Declare a library because g3 kt_native_binary doesn't take srcs
         kt_native_library(
-            name = libname,
+            name = libname + _WASM_SUFFIX,
             srcs = srcs,
             deps = [_to_wasm_dep(dep) for dep in _ARCS_KOTLIN_LIBS + deps],
             visibility = visibility,


### PR DESCRIPTION
Addresses b/143951991

Summary of Changes: 
- the wasm_kt_binary should be the target name
- the intermediary is mangled to be a `_bin`
- the intermediary is tagged as "manual" to be ignored in "..." or "all" builds