### PR TITLE
Remove unneeded manual tag from wasm bin target.

### DIFF
--- a/third_party/java/arcs/build_defs/internal/kotlin.bzl
+++ b/third_party/java/arcs/build_defs/internal/kotlin.bzl
@@ -62,7 +62,6 @@ def arcs_kt_binary(name, srcs = [], deps = [], visibility = None):
         name = bin_name,
         entry_point = "arcs.main",
         deps = [_to_wasm_dep(dep) for dep in _ARCS_KOTLIN_LIBS + deps],
-        tags = ["manual"],
         visibility = visibility,
     )
 


### PR DESCRIPTION
It wasn't doing anything, since it is a dependency of another target
which is not manual (and isn't supposed to be).