### PR TITLE
Remove pre slandles directions

### DIFF
--- a/devtools/src/arcs-overview.js
+++ b/devtools/src/arcs-overview.js
@@ -291,7 +291,7 @@ class ArcsOverview extends MessengerMixin(PolymerElement) {
                 let color;
                 let arrows;
                 switch (connSpec.direction) {
-                  case '`consume':
+                  case '`consumes':
                     arrows = {
                       from: {
                         enabled: true,
@@ -300,11 +300,11 @@ class ArcsOverview extends MessengerMixin(PolymerElement) {
                     };
                     color = this._cssVar('--green');
                     break;
-                  case 'in':
+                  case 'reads':
                     arrows = 'from';
                     color = this._cssVar('--dark-green');
                     break;
-                  case '`provide':
+                  case '`provides':
                     arrows = {
                       to: {
                         enabled: true,
@@ -313,15 +313,15 @@ class ArcsOverview extends MessengerMixin(PolymerElement) {
                     };
                     color = this._cssVar('--red');
                     break;
-                  case 'out':
+                  case 'writes':
                     arrows = 'to';
                     color = this._cssVar('--dark-red');
                     break;
-                  case 'inout':
+                  case 'reads writes':
                     arrows = 'to, from';
                     color = this._cssVar('--highlight-blue');
                     break;
-                  case 'host':
+                  case 'hosts':
                     arrows = {
                       from: {
                         enabled: true,

--- a/src/dataflow/analysis/flow-graph.ts
+++ b/src/dataflow/analysis/flow-graph.ts
@@ -69,12 +69,14 @@ export class FlowGraph {
         this.edgeMap.set(edgeId, edge);
       };
 
-      if (connection.direction === 'inout') {
+      if (connection.direction === 'reads writes') {
         // An inout handle connection is represented by two edges.
         addEdgeWithDirection('in');
         addEdgeWithDirection('out');
-      } else if (connection.direction === 'in' || connection.direction === 'out') {
-        addEdgeWithDirection(connection.direction);
+      } else if (connection.direction === 'reads') {
+        addEdgeWithDirection('in');
+      } else if (connection.direction === 'writes') {
+        addEdgeWithDirection('out');
       } else {
         throw new Error(`Unsupported handle connection direction: ${connection.direction}`);
       }

--- a/src/dataflow/analysis/particle-node.ts
+++ b/src/dataflow/analysis/particle-node.ts
@@ -189,7 +189,7 @@ export function createParticleNodes(particles: Particle[]) {
 function isTypeCompatibleWithReference(type: Type, target: ReferenceType, canBeReference: boolean) {
   switch (type.tag) {
     case 'Entity':
-      if (TypeChecker.compareTypes({type, direction: 'in'}, {type: target.getContainedType(), direction: 'out'})) {
+      if (TypeChecker.compareTypes({type, direction: 'reads'}, {type: target.getContainedType(), direction: 'writes'})) {
         return true;
       }
       if (canBeReference) {

--- a/src/devtools-connector/tests/devtools-arc-inspector-test.ts
+++ b/src/devtools-connector/tests/devtools-arc-inspector-test.ts
@@ -78,7 +78,7 @@ describe('DevtoolsArcInspector', () => {
         trustChecks: [],
         args: [{
           dependentConnections: [],
-          direction: 'inout',
+          direction: 'reads writes',
           isOptional: false,
           name: 'foo'
         }]

--- a/src/planning/plan/tests/planificator-test.ts
+++ b/src/planning/plan/tests/planificator-test.ts
@@ -207,8 +207,8 @@ import './src/runtime/tests/artifacts/People/Person.schema'
 store User of Person 'User' in './src/runtime/tests/artifacts/Things/empty.json'
 import './src/runtime/tests/artifacts/Products/Product.schema'
 particle ShowProduct in 'show-product.js'
-  in Product product
-  consume item
+  product: reads Product
+  item: consumes Slot
   `;
     const restaurantsPlanificator = new Planificator(
         await createArc({manifestString: restaurantsManifestString}, storageKey),

--- a/src/planning/planner.ts
+++ b/src/planning/planner.ts
@@ -276,7 +276,7 @@ export class Planner implements InspectablePlanner {
         const particle = plan.particles.find(p => p.name === tokens[0]);
         assert(particle);
         const handleConn = particle.getConnectionByName(tokens[1]);
-        if (handleConn && handleConn.handle && RecipeUtil.directionCounts(handleConn.handle).out > 0) {
+        if (handleConn && handleConn.handle && RecipeUtil.directionCounts(handleConn.handle).writes > 0) {
           return true;
         }
       }
@@ -286,7 +286,7 @@ export class Planner implements InspectablePlanner {
       const allTokens = Description.getAllTokens(particle.spec.pattern);
       for (const tokens of allTokens) {
         const handleConn = particle.getConnectionByName(tokens[0]);
-        if (handleConn && handleConn.handle && RecipeUtil.directionCounts(handleConn.handle).out > 0) {
+        if (handleConn && handleConn.handle && RecipeUtil.directionCounts(handleConn.handle).writes > 0) {
           return true;
         }
       }

--- a/src/planning/recipe-index.ts
+++ b/src/planning/recipe-index.ts
@@ -210,7 +210,7 @@ export class RecipeIndex {
       const counts = RecipeUtil.directionCounts(handle);
       const otherCounts = RecipeUtil.directionCounts(otherHandle);
       // Someone has to read and someone has to write.
-      if (otherCounts.in + counts.in === 0 || otherCounts.out + counts.out === 0) {
+      if (otherCounts.reads + counts.reads === 0 || otherCounts.writes + counts.writes === 0) {
         return false;
       }
     }
@@ -295,7 +295,7 @@ export class RecipeIndex {
       if (!providedHandleConn) continue;
 
       const matchingConns = Object.values(particle.connections).filter(handleConn => {
-        return handleConn.direction !== 'host'
+        return handleConn.direction !== 'hosts'
           && (!handleConn.handle || !handleConn.handle.id || handleConn.handle.id === providedHandleConn.handle.id)
           && Handle.effectiveType(providedHandleConn.handle.mappedType, [handleConn]);
       });

--- a/src/planning/strategies/coalesce-recipes.ts
+++ b/src/planning/strategies/coalesce-recipes.ts
@@ -217,7 +217,7 @@ export class CoalesceRecipes extends Strategy {
           if (recipe.particles.length + otherHandle.recipe.particles.length > 10) continue;
 
           // This is a poor man's proxy for the other handle being an output of a recipe.
-          if (otherHandle.findConnectionByDirection('in')) continue;
+          if (otherHandle.findConnectionByDirection('reads')) continue;
 
           // We ignore type variables not constrained for reading, otherwise
           // generic recipes would apply - which we currently don't want here.

--- a/src/planning/strategies/convert-constraints-to-connections.ts
+++ b/src/planning/strategies/convert-constraints-to-connections.ts
@@ -14,12 +14,12 @@ import {Recipe} from '../../runtime/recipe/recipe.js';
 import {StrategizerWalker, Strategy, StrategyParams} from '../strategizer.js';
 import {ParticleSpec} from '../../runtime/particle-spec.js';
 import {reverseDirection} from '../../runtime/recipe/recipe-util.js';
-import {DirectionPreSlandles} from '../../runtime/manifest-ast-nodes.js';
+import {Direction} from '../../runtime/manifest-ast-nodes.js';
 import {Descendant} from '../../runtime/recipe/walker.js';
 import {Handle} from '../../runtime/recipe/handle.js';
 import {Dictionary} from '../../runtime/hot.js';
 
-type Obligation = {from: EndPoint, to: EndPoint, direction: DirectionPreSlandles};
+type Obligation = {from: EndPoint, to: EndPoint, direction: Direction};
 
 export class ConvertConstraintsToConnections extends Strategy {
   async generate(inputParams: StrategyParams): Promise<Descendant<Recipe>[]> {
@@ -135,7 +135,7 @@ export class ConvertConstraintsToConnections extends Strategy {
             });
           }
 
-          const unionDirections = (a: DirectionPreSlandles, b: DirectionPreSlandles): DirectionPreSlandles => {
+          const unionDirections = (a: Direction, b: Direction): Direction => {
             // TODO(jopra): Move to be with other handle direction + type resolution code.
             if (a === 'any') {
               return 'any';

--- a/src/planning/strategies/find-hosted-particle.ts
+++ b/src/planning/strategies/find-hosted-particle.ts
@@ -45,7 +45,7 @@ export class FindHostedParticle extends Strategy {
         if (!connectionSpec) {
           return undefined;
         }
-        if (connectionSpec.direction !== 'host') {
+        if (connectionSpec.direction !== 'hosts') {
           return undefined;
         }
         assert(connectionType instanceof InterfaceType);

--- a/src/planning/strategies/match-recipe-by-verb.ts
+++ b/src/planning/strategies/match-recipe-by-verb.ts
@@ -16,7 +16,7 @@ import {Particle} from '../../runtime/recipe/particle.js';
 import {Recipe} from '../../runtime/recipe/recipe.js';
 import {StrategizerWalker, Strategy} from '../strategizer.js';
 import {GenerateParams, Descendant} from '../../runtime/recipe/walker.js';
-import {DirectionPreSlandles} from '../../runtime/manifest-ast-nodes.js';
+import {Direction} from '../../runtime/manifest-ast-nodes.js';
 import {Type} from '../../runtime/type.js';
 import {HandleConnection} from '../../runtime/recipe/handle-connection.js';
 import {Dictionary} from '../../runtime/hot.js';
@@ -32,7 +32,7 @@ import {Dictionary} from '../../runtime/hot.js';
 // Note that the recipe may have the slot pattern multiple times over, but
 // this strategy currently only connects the first instance of the pattern up
 // if there are multiple instances.
-type HandleConstraint = {handle: Handle, direction: DirectionPreSlandles};
+type HandleConstraint = {handle: Handle, direction: Direction};
 type SlotConstraint = {targetSlot: Slot, providedSlots: Dictionary<Slot>};
 
 export class MatchRecipeByVerb extends Strategy {
@@ -240,14 +240,14 @@ export class MatchRecipeByVerb extends Strategy {
     }
     return true;
   }
-  static connectionMatchesConstraint(connection: {direction: DirectionPreSlandles}, handleConstraint: HandleConstraint): boolean {
+  static connectionMatchesConstraint(connection: {direction: Direction}, handleConstraint: HandleConstraint): boolean {
     if (connection.direction !== handleConstraint.direction) {
       return false;
     }
     if (!handleConstraint.handle) {
       return true;
     }
-    const connections: {type?: Type, direction?: DirectionPreSlandles}[] = [...handleConstraint.handle.connections, connection];
+    const connections: {type?: Type, direction?: Direction}[] = [...handleConstraint.handle.connections, connection];
     return Boolean(Handle.effectiveType(handleConstraint.handle.mappedType, connections));
   }
 

--- a/src/planning/strategies/search-tokens-to-handles.ts
+++ b/src/planning/strategies/search-tokens-to-handles.ts
@@ -24,8 +24,8 @@ export class SearchTokensToHandles extends Strategy {
       stores = arc.findStoresByType(handle.type, {tags: [`${token}`]});
       let fate = 'use';
       if (stores.length === 0) {
-        stores = arc.context.findStoresByType(handle.type, {tags: [`${token}`], subtype: counts.out === 0});
-        fate = counts.out === 0 ? 'map' : 'copy';
+        stores = arc.context.findStoresByType(handle.type, {tags: [`${token}`], subtype: counts.writes === 0});
+        fate = counts.writes === 0 ? 'map' : 'copy';
       }
       stores = stores.filter(store => !handle.recipe.handles.find(handle => handle.id === store.id));
       return stores.map(store => ({store, fate, token}));

--- a/src/planning/strategies/tests/coalesce-recipes-test.ts
+++ b/src/planning/strategies/tests/coalesce-recipes-test.ts
@@ -170,7 +170,7 @@ describe('CoalesceRecipes', () => {
     `);
   });
 
-  it('evaluates fates of handles of required slot in coalesced recipes', async () => {
+  describe('evaluates fates of handles of required slot in coalesced recipes', async () => {
     const parseManifest = async (options) => {
       return `
         schema Thing
@@ -200,32 +200,46 @@ describe('CoalesceRecipes', () => {
       `;
     };
 
-    await doCoalesceRecipes(await parseManifest({fateA: 'map'}));
-    await doCoalesceRecipes(await parseManifest({fateA: 'map', fateB: 'map'}));
-    await doCoalesceRecipes(await parseManifest({fateA: 'map', fateB: 'use'}));
-    await doCoalesceRecipes(await parseManifest({fateA: 'map', fateB: '?'}));
-    await doNotCoalesceRecipes(await parseManifest({fateA: 'map', fateB: 'use', outThingB: true}));
-    await doNotCoalesceRecipes(await parseManifest({fateA: 'map', fateB: 'copy'}));
-    await doCoalesceRecipes(await parseManifest({fateA: 'copy'}));
-    await doCoalesceRecipes(await parseManifest({fateA: 'copy', fateB: 'map'}));
-    await doCoalesceRecipes(await parseManifest({fateA: 'copy', fateB: 'copy'}));
-    await doNotCoalesceRecipes(await parseManifest({fateA: 'copy', fateB: 'create'}));
+    const expectSuccessData = [
+      {fateA: 'map'},
+      {fateA: 'map', fateB: 'map'},
+      {fateA: 'map', fateB: 'use'},
+      {fateA: 'map', fateB: '?'},
+      {fateA: 'copy'},
+      {fateA: 'copy', fateB: 'map'},
+      {fateA: 'copy', fateB: 'copy'},
+      {fateA: 'use', fateB: 'use'},
+      {fateA: 'use', fateB: 'use', outThingB: true},
+      {fateA: 'use', fateB: '?'},
+      {fateA: 'use', fateB: '?', outThingB: true},
+      {fateA: 'create'},
+      {fateA: 'create', fateB: '?'},
+      {fateA: 'create', fateB: 'use'},
+      {fateA: 'create', fateB: 'use', outThingB: true}
+    ];
 
-    await doCoalesceRecipes(await parseManifest({fateA: 'use', fateB: 'use'}));
-    await doCoalesceRecipes(await parseManifest({fateA: 'use', fateB: 'use', outThingB: true}));
-    await doCoalesceRecipes(await parseManifest({fateA: 'use', fateB: '?'}));
-    await doCoalesceRecipes(await parseManifest({fateA: 'use', fateB: '?', outThingB: true}));
-    await doNotCoalesceRecipes(await parseManifest({fateA: 'use', fateB: 'create'}));
-    await doNotCoalesceRecipes(await parseManifest({fateA: 'use', fateB: 'map'}));
-    await doNotCoalesceRecipes(await parseManifest({fateA: 'use', fateB: 'copy'}));
+    for (const setup of expectSuccessData) {
+      it(`parse with options: ${JSON.stringify(setup)}`, async () => {
+        await doCoalesceRecipes(await parseManifest(setup));
+      });
+    }
 
-    await doCoalesceRecipes(await parseManifest({fateA: 'create'}));
-    await doCoalesceRecipes(await parseManifest({fateA: 'create', fateB: '?'}));
-    await doCoalesceRecipes(await parseManifest({fateA: 'create', fateB: 'use'}));
-    await doCoalesceRecipes(await parseManifest({fateA: 'create', fateB: 'use', outThingB: true}));
-    await doNotCoalesceRecipes(await parseManifest({fateA: 'create', fateB: 'create'}));
-    await doNotCoalesceRecipes(await parseManifest({fateA: 'create', fateB: 'map'}));
-    await doNotCoalesceRecipes(await parseManifest({fateA: 'create', fateB: 'copy'}));
+    const expectFailureData = [
+      {fateA: 'map', fateB: 'use', outThingB: true},
+      {fateA: 'map', fateB: 'copy'},
+      {fateA: 'copy', fateB: 'create'},
+      {fateA: 'use', fateB: 'create'},
+      {fateA: 'use', fateB: 'map'},
+      {fateA: 'use', fateB: 'copy'},
+      {fateA: 'create', fateB: 'create'},
+      {fateA: 'create', fateB: 'map'},
+      {fateA: 'create', fateB: 'copy'}
+    ];
+    for (const setup of expectFailureData) {
+      it(`parse with options: ${JSON.stringify(setup)}`, async () => {
+        await doNotCoalesceRecipes(await parseManifest(setup));
+      });
+    }
   });
 
   it('coalesces multiple handles', async () => {

--- a/src/planning/tests/planner-test.ts
+++ b/src/planning/tests/planner-test.ts
@@ -266,7 +266,7 @@ describe('Planner', () => {
           P1
             one: \`provides s0
       `);
-    }, 'not compatible with \'`consume\'');
+    }, 'not compatible with \'`consumes\'');
   });
 
   it('SLANDLES cannot resolve multiple consumed set slots with incorrect directions', async () => {
@@ -280,7 +280,7 @@ describe('Planner', () => {
           P1
             one: \`provides s0
       `);
-    }, 'not compatible with \'`consume\'');
+    }, 'not compatible with \'`consumes\'');
   });
 
   it('SLANDLES resolves particles with multiple consumed slots', async () => {

--- a/src/runtime/arc.ts
+++ b/src/runtime/arc.ts
@@ -35,7 +35,7 @@ import {PecFactory} from './particle-execution-context.js';
 import {Mutex} from './mutex.js';
 import {Dictionary} from './hot.js';
 import {Runtime} from './runtime.js';
-import {VolatileMemory, VolatileStorageDriverProvider, VolatileStorageKey, VolatileDriver} from './storageNG/drivers/volatile.js';
+import {VolatileMemory, VolatileStorageDriverProvider, VolatileStorageKey} from './storageNG/drivers/volatile.js';
 import {DriverFactory, Exists} from './storageNG/drivers/driver-factory.js';
 import {StorageKey} from './storageNG/storage-key.js';
 import {Store} from './storageNG/store.js';
@@ -696,7 +696,7 @@ constructor({id, context, pecFactories, slotComposer, loader, storageKey, storag
     // Rewrite of this method tracked by https://github.com/PolymerLabs/arcs/issues/1636.
     return stores.filter(s => {
       const storeType = s.type.isSingleton ? s.type.getContainedType() : s.type;
-      return !!Handle.effectiveType(type, [{type: storeType, direction: (storeType instanceof InterfaceType) ? 'host' : 'inout'}]);
+      return !!Handle.effectiveType(type, [{type: storeType, direction: (storeType instanceof InterfaceType) ? 'hosts' : 'reads writes'}]);
     });
   }
 

--- a/src/runtime/handle.ts
+++ b/src/runtime/handle.ts
@@ -220,7 +220,7 @@ export class Collection extends HandleOld {
   /**
    * Returns the Entity specified by id contained by the handle, or null if this id is not
    * contained by the handle.
-   * @throws {Error} if this handle is not configured as a readable handle (i.e. 'in' or 'inout')
+   * @throws {Error} if this handle is not configured as a readable handle (i.e. 'reads' or 'reads writes')
    * in the particle's manifest.
    */
   async get(id: string) {
@@ -232,7 +232,7 @@ export class Collection extends HandleOld {
 
   /**
    * @returns a list of the Entities contained by the handle.
-   * @throws {Error} if this handle is not configured as a readable handle (i.e. 'in' or 'inout')
+   * @throws {Error} if this handle is not configured as a readable handle (i.e. 'reads' or 'reads writes')
    * in the particle's manifest.
    */
   async toList() {
@@ -258,7 +258,7 @@ export class Collection extends HandleOld {
 
   /**
    * Stores a new entity into the Handle.
-   * @throws {Error} if this handle is not configured as a writeable handle (i.e. 'out' or 'inout')
+   * @throws {Error} if this handle is not configured as a writeable handle (i.e. 'writes' or 'reads writes')
    * in the particle's manifest.
    */
   async store(entity: Storable) {
@@ -272,7 +272,7 @@ export class Collection extends HandleOld {
 
   /**
    * Removes all known entities from the Handle.
-   * @throws {Error} if this handle is not configured as a writeable handle (i.e. 'out' or 'inout')
+   * @throws {Error} if this handle is not configured as a writeable handle (i.e. 'writes' or 'reads writes')
    * in the particle's manifest.
    */
   async clear() {
@@ -288,7 +288,7 @@ export class Collection extends HandleOld {
 
   /**
    * Removes an entity from the Handle.
-   * @throws {Error} if this handle is not configured as a writeable handle (i.e. 'out' or 'inout')
+   * @throws {Error} if this handle is not configured as a writeable handle (i.e. 'writes' or 'reads writes')
    * in the particle's manifest.
    */
   async remove(entity: Storable) {
@@ -335,7 +335,7 @@ export class Singleton extends HandleOld {
 
   /**
    * @returns the Entity contained by the Singleton, or undefined if the Singleton is cleared.
-   * @throws {Error} if this Singleton is not configured as a readable handle (i.e. 'in' or 'inout')
+   * @throws {Error} if this Singleton is not configured as a readable handle (i.e. 'reads' or 'reads writes')
    * in the particle's manifest.
    */
   async get() {
@@ -364,7 +364,7 @@ export class Singleton extends HandleOld {
 
   /**
    * Stores a new entity into the Singleton, replacing any existing entity.
-   * @throws {Error} if this Singleton is not configured as a writeable handle (i.e. 'out' or 'inout')
+   * @throws {Error} if this Singleton is not configured as a writeable handle (i.e. 'writes' or 'reads writes')
    * in the particle's manifest.
    */
   async set(entity: Storable) {
@@ -382,7 +382,7 @@ export class Singleton extends HandleOld {
 
   /**
    * Clears any entity currently in the Singleton.
-   * @throws {Error} if this Singleton is not configured as a writeable handle (i.e. 'out' or 'inout')
+   * @throws {Error} if this Singleton is not configured as a writeable handle (i.e. 'writes' or 'reads writes')
    * in the particle's manifest.
    */
   async clear() {
@@ -454,7 +454,7 @@ export class BigCollection extends HandleOld {
 
   /**
    * Stores a new entity into the Handle.
-   * @throws {Error} if this handle is not configured as a writeable handle (i.e. 'out' or 'inout')
+   * @throws {Error} if this handle is not configured as a writeable handle (i.e. 'writes' or 'reads writes')
    * in the particle's manifest.
    */
   async store(entity: Storable) {
@@ -468,7 +468,7 @@ export class BigCollection extends HandleOld {
 
   /**
    * Removes an entity from the Handle.
-   * @throws {Error} if this handle is not configured as a writeable handle (i.e. 'out' or 'inout')
+   * @throws {Error} if this handle is not configured as a writeable handle (i.e. 'writes' or 'reads writes')
    * in the particle's manifest.
    */
   async remove(entity: Entity) {
@@ -488,7 +488,7 @@ export class BigCollection extends HandleOld {
    * caveat that items removed during a streamed read may be returned at the end). Set `forward`
    * to false to return items in reverse insertion order.
    *
-   * @throws {Error} if this Singleton is not configured as a readable handle (i.e. 'in' or 'inout')
+   * @throws {Error} if this Singleton is not configured as a readable handle (i.e. 'reads' or 'reads writes')
    * in the particle's manifest.
    */
   async stream({pageSize, forward = true}: {pageSize: number, forward: boolean}) {

--- a/src/runtime/interface-info-impl.ts
+++ b/src/runtime/interface-info-impl.ts
@@ -147,7 +147,7 @@ class InterfaceInfoImpl extends InterfaceInfo {
           parts.push(`${h.name}:`);
         }
         if (h.direction !== undefined && h.direction !== 'any') {
-          parts.push(AstNode.preSlandlesDirectionToDirection(h.direction));
+          parts.push(h.direction);
         }
         parts.push(h.type.toString());
         return `  ${parts.join(' ')}`;
@@ -159,7 +159,7 @@ class InterfaceInfoImpl extends InterfaceInfo {
     return this.slots
       .map(slot => {
         const nameStr = slot.name ? `${slot.name}: ` : '';
-        return `  ${nameStr}${slot.direction}s${slot.isRequired ? '' : '?'} ${slot.isSet ? '[Slot]' : 'Slot'}`;
+        return `  ${nameStr}${slot.direction}${slot.isRequired ? '' : '?'} ${slot.isSet ? '[Slot]' : 'Slot'}`;
       })
       .join('\n');
   }
@@ -374,9 +374,9 @@ ${this._slotsToManifestString()}`;
 
     const particleSlots: Slot[] = [];
     particleSpec.slotConnections.forEach(consumedSlot => {
-      particleSlots.push({name: consumedSlot.name, direction: 'consume', isRequired: consumedSlot.isRequired, isSet: consumedSlot.isSet});
+      particleSlots.push({name: consumedSlot.name, direction: 'consumes', isRequired: consumedSlot.isRequired, isSet: consumedSlot.isSet});
       consumedSlot.provideSlotConnections.forEach(providedSlot => {
-        particleSlots.push({name: providedSlot.name, direction: 'provide', isRequired: false, isSet: providedSlot.isSet});
+        particleSlots.push({name: providedSlot.name, direction: 'provides', isRequired: false, isSet: providedSlot.isSet});
       });
     });
     const slotsThatMatch = this.slots.map(slot => particleSlots.filter(particleSlot => InterfaceInfo.slotsMatch(slot, particleSlot)));

--- a/src/runtime/manifest-ast-nodes.ts
+++ b/src/runtime/manifest-ast-nodes.ts
@@ -292,7 +292,7 @@ export interface ParticleModality extends BaseNode {
 
 export interface ParticleHandleConnection extends BaseNode {
   kind: 'particle-argument';
-  direction: DirectionPreSlandles;
+  direction: Direction;
   type: ParticleHandleConnectionType;
   isOptional: boolean;
   dependentConnections: ParticleHandleConnection[];
@@ -373,7 +373,7 @@ export type RecipeItem = RecipeParticle | RecipeHandle | RequireHandleSection | 
 export interface RecipeParticleConnection extends BaseNode {
   kind: 'handle-connection';
   param: string;
-  dir: DirectionPreSlandles;
+  dir: Direction;
   target: ParticleConnectionTargetComponents;
   dependentConnections: RecipeParticleConnection[];
 }
@@ -413,7 +413,7 @@ export interface RecipeSlotConnectionRef extends BaseNode {
 
 export interface RecipeConnection extends BaseNode {
   kind: 'connection';
-  direction: DirectionPreSlandles;
+  direction: Direction;
   from: ConnectionTarget;
   to: ConnectionTarget;
 }
@@ -559,7 +559,7 @@ export type InterfaceItem = Interface | InterfaceArgument | InterfaceSlot;
 
 export interface InterfaceArgument extends BaseNode {
   kind: 'interface-argument';
-  direction: DirectionPreSlandles;
+  direction: Direction;
   type: ParticleHandleConnectionType;
   name: string;
 }
@@ -574,7 +574,7 @@ export interface InterfaceSlot extends BaseNode {
   kind: 'interface-slot';
   name: string|null;
   isRequired: boolean;
-  direction: DirectionPreSlandles;
+  direction: Direction;
   isSet: boolean;
 }
 
@@ -639,25 +639,24 @@ export type eol = string;
 
 // String-based enums.
 // TODO: convert to actual enums so that they can be iterated over.
-export type DirectionPreSlandles = 'in' | 'out' | 'inout' | 'host' | '`consume' | '`provide' | 'any';
 export type Direction = 'reads' | 'writes' | 'reads writes' | 'hosts' | '`consumes' | '`provides' | 'any';
 
-export function preSlandlesDirectionToDirection(direction: DirectionPreSlandles, isOptional: boolean = false): string {
+export function preSlandlesDirectionToDirection(direction: Direction, isOptional: boolean = false): string {
   // TODO(jopra): Remove after syntax unification.
   // Use switch for totality checking.
   const opt: string = isOptional ? '?' : '';
   switch (direction) {
-    case 'in':
+    case 'reads':
       return `reads${opt}`;
-    case 'out':
+    case 'writes':
       return `writes${opt}`;
-    case 'inout':
+    case 'reads writes':
       return `reads${opt} writes${opt}`;
-    case '`consume':
+    case '`consumes':
       return `\`consumes${opt}`;
-    case '`provide':
+    case '`provides':
       return `\`provides${opt}`;
-    case 'host':
+    case 'hosts':
       return `hosts${opt}`;
     case 'any':
       return `any${opt}`;
@@ -667,31 +666,7 @@ export function preSlandlesDirectionToDirection(direction: DirectionPreSlandles,
   }
 }
 
-export function directionToPreSlandlesDirection(direction: Direction): DirectionPreSlandles {
-  // TODO(jopra): Remove after syntax unification.
-  // Use switch for totality checking.
-  switch (direction) {
-    case 'reads':
-      return 'in';
-    case 'writes':
-      return 'out';
-    case 'reads writes':
-      return 'inout';
-    case '`consumes':
-      return '`consume';
-    case '`provides':
-      return '`provide';
-    case 'hosts':
-      return 'host';
-    case 'any':
-      return 'any';
-    default:
-      // Catch nulls and unsafe values from javascript.
-      throw new Error(`Bad direction ${direction}`);
-  }
-}
-
-export type SlotDirection = 'provide' | 'consume';
+export type SlotDirection = 'provides' | 'consumes';
 export type Fate = 'use' | 'create' | 'map' | 'copy' | '?' | '`slot';
 
 export type ParticleHandleConnectionType = TypeVariable|CollectionType|

--- a/src/runtime/manifest-parser.peg
+++ b/src/runtime/manifest-parser.peg
@@ -72,9 +72,9 @@
     return {...data, location: location()} as T;
   }
 
-  function buildInterfaceArgument(name: string, direction: AstNode.DirectionPreSlandles, type: AstNode.ParticleHandleConnectionType) {
-    if (direction === 'host') {
-      error(`Interface cannot have arguments with a 'host' direction.`);
+  function buildInterfaceArgument(name: string, direction: AstNode.Direction, type: AstNode.ParticleHandleConnectionType) {
+    if (direction === 'hosts') {
+      error(`Interface cannot have arguments with a 'hosts' direction.`);
     }
     return toAstNode<AstNode.InterfaceArgument>({
       kind: 'interface-argument',
@@ -269,12 +269,6 @@ InterfaceSlot
       type.fields.forEach(({name, value}) => {
         error(`interface slots do not currently support fields`);
       });
-    }
-    if (direction === 'consumes') {
-      direction = 'consume';
-    }
-    if (direction === 'provides') {
-      direction = 'provide';
     }
     return toAstNode<AstNode.InterfaceSlot>({
       kind: 'interface-slot',
@@ -553,7 +547,7 @@ Direction "a direction (e.g. reads writes, reads, writes, hosts, `consumes, `pro
       // Fix for faking proper capability set support with optionality.
       dir = 'reads writes';
     }
-    return AstNode.directionToPreSlandlesDirection(dir as AstNode.Direction);
+    return dir as AstNode.Direction;
   }
 
 ParticleHandleConnectionType
@@ -957,8 +951,7 @@ RecipeSlotConnectionRef
   }
 
 SlotDirection
-  = 'provides' { return 'provide'; }
-  / 'consumes' { return 'consume'; }
+  = 'provides' / 'consumes'
 
 RecipeConnection
   = from:ConnectionTargetWithColon? direction:(Direction whiteSpace)? to:ConnectionTarget eolWhiteSpace

--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -366,7 +366,7 @@ export class Manifest {
     // Quick check that a new handle can fulfill the type contract.
     // Rewrite of this method tracked by https://github.com/PolymerLabs/arcs/issues/1636.
     return stores.filter(s => !!Handle.effectiveType(
-      type, [{type: s.type, direction: (s.type instanceof InterfaceType) ? 'host' : 'inout'}]));
+      type, [{type: s.type, direction: (s.type instanceof InterfaceType) ? 'hosts' : 'reads writes'}]));
   }
   findInterfaceByName(name: string) {
     return this._find(manifest => manifest._interfaces.find(iface => iface.name === name));
@@ -920,7 +920,7 @@ ${e.message}
       items.byParticle.set(particle, item);
 
       for (const slotConnectionItem of item.slotConnections) {
-        if (slotConnectionItem.direction === 'provide') {
+        if (slotConnectionItem.direction === 'provides') {
           throw new ManifestError(item.location, `invalid slot connection: provide slot must be dependent`);
         }
         let slotConn = particle.getSlotConnectionByName(slotConnectionItem.param);
@@ -947,7 +947,7 @@ ${e.message}
         }
         slotConn.tags = slotConnectionItem.tags || [];
         slotConnectionItem.dependentSlotConnections.forEach(ps => {
-          if (ps.direction === 'consume') {
+          if (ps.direction === 'consumes') {
             throw new ManifestError(item.location, `invalid slot connection: consume slot must not be dependent`);
           }
           if (ps.dependentSlotConnections.length !== 0) {
@@ -1038,7 +1038,7 @@ ${e.message}
             const handle = recipe.newHandle();
             handle.tags = [];
             handle.localName = connectionItem.target.name;
-            if (connection.direction === '`consume' || connection.direction === '`provide') {
+            if (connection.direction === '`consumes' || connection.direction === '`provides') {
               // TODO(jopra): This is something of a hack to catch users who have not forward-declared their slandles.
               handle.fate = '`slot';
             } else {

--- a/src/runtime/particle-check.ts
+++ b/src/runtime/particle-check.ts
@@ -9,7 +9,7 @@
  */
 
 import * as AstNode from './manifest-ast-nodes.js';
-import {DirectionPreSlandles} from './manifest-ast-nodes.js';
+import {Direction} from './manifest-ast-nodes.js';
 import {Claim} from './particle-claim.js';
 import {Type} from './type.js';
 import {assert} from '../platform/assert-web.js';
@@ -26,7 +26,7 @@ export type CheckTarget = HandleConnectionSpecInterface | ProvideSlotConnectionS
 
 export interface HandleConnectionSpecInterface {
   discriminator: 'HCS';
-  direction: DirectionPreSlandles;
+  direction: Direction;
   name: string;
   type: Type;
   isOptional: boolean;

--- a/src/runtime/recipe/connection-constraint.ts
+++ b/src/runtime/recipe/connection-constraint.ts
@@ -11,12 +11,11 @@
 import {assert} from '../../platform/assert-web.js';
 import {ParticleSpec} from '../particle-spec.js';
 
-import {DirectionPreSlandles, preSlandlesDirectionToDirection} from '../manifest-ast-nodes.js';
+import {Direction} from '../manifest-ast-nodes.js';
 import {Handle} from './handle.js';
 import {Comparable, compareArrays, compareComparables, compareStrings} from './comparable.js';
 import {Recipe, RecipeComponent, CloneMap, ToStringOptions} from './recipe.js';
 import {Particle} from './particle.js';
-import {Flags} from '../flags.js';
 
 export abstract class EndPoint implements Comparable<EndPoint> {
   abstract _compareTo(other: EndPoint): number;
@@ -135,10 +134,10 @@ export class TagEndPoint extends EndPoint {
 export class ConnectionConstraint implements Comparable<ConnectionConstraint> {
   from: EndPoint;
   to: EndPoint;
-  direction: DirectionPreSlandles;
+  direction: Direction;
   type: 'constraint' | 'obligation';
 
-  constructor(fromConnection: EndPoint, toConnection: EndPoint, direction: DirectionPreSlandles, type: 'constraint' | 'obligation') {
+  constructor(fromConnection: EndPoint, toConnection: EndPoint, direction: Direction, type: 'constraint' | 'obligation') {
     assert(direction);
     assert(type);
     this.from = fromConnection;
@@ -174,6 +173,6 @@ export class ConnectionConstraint implements Comparable<ConnectionConstraint> {
     if (options && options.showUnresolved === true && this.type === 'obligation') {
       unresolved = ' // unresolved obligation';
     }
-    return `${this.from.toString(nameMap)}: ${preSlandlesDirectionToDirection(this.direction)} ${this.to.toString(nameMap)}${unresolved}`;
+    return `${this.from.toString(nameMap)}: ${this.direction} ${this.to.toString(nameMap)}${unresolved}`;
   }
 }

--- a/src/runtime/recipe/handle-connection.ts
+++ b/src/runtime/recipe/handle-connection.ts
@@ -20,15 +20,14 @@ import {acceptedDirections} from './recipe-util.js';
 import {TypeChecker} from './type-checker.js';
 import {compareArrays, compareComparables, compareStrings, Comparable} from './comparable.js';
 
-import {DirectionPreSlandles, preSlandlesDirectionToDirection} from '../manifest-ast-nodes.js';
-import {Flags} from '../flags.js';
+import {Direction} from '../manifest-ast-nodes.js';
 
 export class HandleConnection implements Comparable<HandleConnection> {
   private readonly _recipe: Recipe;
   private _name: string;
   private _tags: string[] = [];
   private resolvedType?: Type = undefined;
-  private _direction: DirectionPreSlandles = 'any';
+  private _direction: Direction = 'any';
   private _particle: Particle;
   _handle?: Handle = undefined;
 
@@ -100,7 +99,7 @@ export class HandleConnection implements Comparable<HandleConnection> {
     return spec ? spec.type : undefined;
   }
 
-  get direction(): DirectionPreSlandles {
+  get direction(): Direction {
     // TODO: Should take the most strict of the direction and the spec direction.
     if (this._direction !== 'any') {
       return this._direction;
@@ -110,10 +109,10 @@ export class HandleConnection implements Comparable<HandleConnection> {
   }
 
   get isInput(): boolean {
-    return this.direction === 'in' || this.direction === 'inout';
+    return this.direction === 'reads' || this.direction === 'reads writes';
   }
   get isOutput(): boolean {
-    return this.direction === 'out' || this.direction === 'inout';
+    return this.direction === 'writes' || this.direction === 'reads writes';
   }
   get handle(): Handle|undefined { return this._handle; } // Handle?
   get particle() { return this._particle; } // never null
@@ -124,7 +123,7 @@ export class HandleConnection implements Comparable<HandleConnection> {
     this._resetHandleType();
   }
 
-  set direction(direction: DirectionPreSlandles) {
+  set direction(direction: Direction) {
     if (direction === null) {
       throw new Error(`Invalid direction '${direction}' for handle connection '${this.getQualifiedName()}'`);
     }
@@ -276,7 +275,7 @@ export class HandleConnection implements Comparable<HandleConnection> {
   toString(nameMap: Map<RecipeComponent, string>, options: ToStringOptions): string {
     const result: string[] = [];
     result.push(`${this.name || '*'}:`);
-    result.push(preSlandlesDirectionToDirection(this.direction)); // TODO(jopra): support optionality.
+    result.push(this.direction); // TODO(jopra): support optionality.
     if (this.handle) {
       if (this.handle.immediateValue) {
         result.push(this.handle.immediateValue.name);

--- a/src/runtime/recipe/handle.ts
+++ b/src/runtime/recipe/handle.ts
@@ -18,7 +18,7 @@ import {SlotConnection} from './slot-connection.js';
 import {Recipe, CloneMap, RecipeComponent, IsResolvedOptions, IsValidOptions, ToStringOptions, VariableMap} from './recipe.js';
 import {TypeChecker} from './type-checker.js';
 import {compareArrays, compareComparables, compareStrings, Comparable} from './comparable.js';
-import {Fate, DirectionPreSlandles} from '../manifest-ast-nodes.js';
+import {Fate, Direction} from '../manifest-ast-nodes.js';
 import {ClaimIsTag, Claim} from '../particle-claim.js';
 import {StorageKey} from '../storageNG/storage-key.js';
 
@@ -210,7 +210,7 @@ export class Handle implements Comparable<Handle> {
   get immediateValue() { return this._immediateValue; }
   set immediateValue(value: ParticleSpec) { this._immediateValue = value; }
 
-  static effectiveType(handleType: Type, connections: {type?: Type, direction?: DirectionPreSlandles}[]) {
+  static effectiveType(handleType: Type, connections: {type?: Type, direction?: Direction}[]) {
     const variableMap = new Map<TypeVariableInfo|Schema, TypeVariableInfo|Schema>();
     // It's OK to use _cloneWithResolutions here as for the purpose of this test, the handle set + handleType
     // contain the full set of type variable information that needs to be maintained across the clone.
@@ -227,7 +227,7 @@ export class Handle implements Comparable<Handle> {
     const tags = new Set<string>();
     for (const connection of this._connections) {
       // A remote handle cannot be connected to an output param.
-      if (this.fate === 'map' && ['out', 'inout'].includes(connection.direction)) {
+      if (this.fate === 'map' && ['writes', 'reads writes'].includes(connection.direction)) {
         if (options && options.errors) {
           options.errors.set(this, `Invalid fate '${this.fate}' for handle '${this}'; it is used for '${connection.direction}' ${connection.getQualifiedName()} connection`);
         }
@@ -354,7 +354,7 @@ export class Handle implements Comparable<Handle> {
     return result.join(' ');
   }
 
-  findConnectionByDirection(dir: string): HandleConnection|undefined {
+  findConnectionByDirection(dir: Direction): HandleConnection|undefined {
     return this._connections.find(conn => conn.direction === dir);
   }
 }

--- a/src/runtime/recipe/particle.ts
+++ b/src/runtime/recipe/particle.ts
@@ -279,7 +279,7 @@ export class Particle implements Comparable<Particle> {
 
   getSlandleConnections(): SlotConnection[] {
     // TODO(jopra): Revisit when slots are removed.
-    return [...Object.values(this._consumedSlotConnections), ...this.allConnections().map(conn => conn.direction === '`consume' && conn.toSlotConnection()).filter(conn => conn)];
+    return [...Object.values(this._consumedSlotConnections), ...this.allConnections().map(conn => conn.direction === '`consumes' && conn.toSlotConnection()).filter(conn => conn)];
   }
 
   getSlotConnections(): SlotConnection[] {
@@ -327,7 +327,7 @@ export class Particle implements Comparable<Particle> {
     const connectionSpec = this.spec.getConnectionByName(name);
     connection.type = connectionSpec.type;
     if (connection.direction !== connectionSpec.direction) {
-      assert(connection.direction === 'inout',
+      assert(connection.direction === 'reads writes',
              `Unnamed connection cannot adjust direction ${connection.direction} to ${name}'s direction ${connectionSpec.direction}`);
       connection.direction = connectionSpec.direction;
     }

--- a/src/runtime/recipe/recipe-util.ts
+++ b/src/runtime/recipe/recipe-util.ts
@@ -13,25 +13,25 @@ import {ParticleSpec, HandleConnectionSpec} from '../particle-spec.js';
 import {InterfaceType} from '../type.js';
 
 import {HandleConnection} from './handle-connection.js';
-import {DirectionPreSlandles} from '../manifest-ast-nodes.js';
+import {Direction} from '../manifest-ast-nodes.js';
 import {Handle} from './handle.js';
 import {Particle} from './particle.js';
 import {Recipe, RecipeComponent} from './recipe.js';
 import {Id} from '../id.js';
 import {Dictionary} from '../hot.js';
 
-export function reverseDirection(direction: DirectionPreSlandles): DirectionPreSlandles {
+export function reverseDirection(direction: Direction): Direction {
   switch (direction) {
-    case 'in':
-      return 'out';
-    case 'out':
-      return 'in';
-    case 'inout':
-      return 'inout';
-    case '`consume':
-      return '`provide';
-    case '`provide':
-      return '`consume';
+    case 'reads':
+      return 'writes';
+    case 'writes':
+      return 'reads';
+    case 'reads writes':
+      return 'reads writes';
+    case '`consumes':
+      return '`provides';
+    case '`provides':
+      return '`consumes';
     case 'any':
       return 'any';
     default:
@@ -40,30 +40,30 @@ export function reverseDirection(direction: DirectionPreSlandles): DirectionPreS
   }
 }
 
-export function connectionMatchesHandleDirection(connectionDirection: DirectionPreSlandles, handleDirection: DirectionPreSlandles): boolean {
+export function connectionMatchesHandleDirection(connectionDirection: Direction, handleDirection: Direction): boolean {
   return acceptedDirections(connectionDirection).includes(handleDirection);
 }
 
-export function acceptedDirections(direction: DirectionPreSlandles): DirectionPreSlandles[] {
+export function acceptedDirections(direction: Direction): Direction[] {
   // @param direction: the direction of a handleconnection.
   // @return acceptedDirections: the list of directions a handle can have that
   // are allowed with this handle connection.
   //
   switch (direction) {
     case 'any':
-      return ['any', 'in', 'out', 'inout', 'host', '`consume', '`provide'];
-    case 'in':
-      return ['any', 'in', 'inout', 'host', '`consume'];
-    case 'out':
-      return ['any', 'out', 'inout', '`provide'];
-    case 'inout':
-      return ['any', 'inout'];
-    case 'host':
-      return ['any', 'host'];
-    case '`consume':
-      return ['any', '`consume'];
-    case '`provide':
-      return ['any', '`provide'];
+      return ['any', 'reads', 'writes', 'reads writes', 'hosts', '`consumes', '`provides'];
+    case 'reads':
+      return ['any', 'reads', 'reads writes', 'hosts', '`consumes'];
+    case 'writes':
+      return ['any', 'writes', 'reads writes', '`provides'];
+    case 'reads writes':
+      return ['any', 'reads writes'];
+    case 'hosts':
+      return ['any', 'hosts'];
+    case '`consumes':
+      return ['any', '`consumes'];
+    case '`provides':
+      return ['any', '`provides'];
     default:
       // Catch nulls and unsafe values from javascript.
       throw new Error(`Bad direction ${direction}`);
@@ -92,9 +92,9 @@ class Shape {
     }
   }
 }
-type DirectionCounts = {[K in DirectionPreSlandles]: number};
+export type DirectionCounts = {[K in Direction]: number};
 
-export type HandleRepr = {localName?: string, handle: string, tags?: string[], direction?: DirectionPreSlandles};
+export type HandleRepr = {localName?: string, handle: string, tags?: string[], direction?: Direction};
 
 type RecipeUtilComponent = RecipeComponent | HandleConnectionSpec;
 
@@ -440,12 +440,12 @@ export class RecipeUtil {
   }
 
   static directionCounts(handle: Handle): DirectionCounts {
-    const counts: DirectionCounts = {'in': 0, 'out': 0, 'inout': 0, 'host': 0, '`consume': 0, '`provide': 0, 'any': 0};
+    const counts: DirectionCounts = {'reads': 0, 'writes': 0, 'reads writes': 0, 'hosts': 0, '`consumes': 0, '`provides': 0, 'any': 0};
     for (const connection of handle.connections) {
       counts[connection.direction]++;
     }
-    counts.in += counts.inout;
-    counts.out += counts.inout;
+    counts.reads += counts['reads writes'];
+    counts.writes += counts['reads writes'];
     return counts;
   }
 

--- a/src/runtime/recipe/recipe.ts
+++ b/src/runtime/recipe/recipe.ts
@@ -16,7 +16,7 @@ import {Schema} from '../schema.js';
 import {InterfaceType, Type, TypeVariableInfo} from '../type.js';
 
 import {ConnectionConstraint, EndPoint} from './connection-constraint.js';
-import {DirectionPreSlandles} from '../manifest-ast-nodes.js';
+import {Direction} from '../manifest-ast-nodes.js';
 import {HandleConnection} from './handle-connection.js';
 import {Handle} from './handle.js';
 import {Particle} from './particle.js';
@@ -71,13 +71,13 @@ export class Recipe implements Cloneable<Recipe> {
     this._name = name;
   }
 
-  newConnectionConstraint(from: EndPoint, to: EndPoint, direction: DirectionPreSlandles): ConnectionConstraint {
+  newConnectionConstraint(from: EndPoint, to: EndPoint, direction: Direction): ConnectionConstraint {
     const result = new ConnectionConstraint(from, to, direction, 'constraint');
     this._connectionConstraints.push(result);
     return result;
   }
 
-  newObligation(from: EndPoint, to: EndPoint, direction: DirectionPreSlandles): ConnectionConstraint {
+  newObligation(from: EndPoint, to: EndPoint, direction: Direction): ConnectionConstraint {
     const result = new ConnectionConstraint(from, to, direction, 'obligation');
     this._obligations.push(result);
     return result;
@@ -669,7 +669,7 @@ export class Recipe implements Cloneable<Recipe> {
     return this.allSpecifiedConnections.filter(
         ({particle, connSpec}) => !connSpec.isOptional &&
                                   connSpec.name !== 'descriptions' &&
-                                  connSpec.direction !== 'host' &&
+                                  connSpec.direction !== 'hosts' &&
                                   !particle.connections[connSpec.name] &&
                                   (!type || TypeChecker.compareTypes({type}, {type: connSpec.type})));
   }

--- a/src/runtime/recipe/type-checker.ts
+++ b/src/runtime/recipe/type-checker.ts
@@ -9,12 +9,12 @@
  */
 
 import {BigCollectionType, CollectionType, EntityType, InterfaceType, ReferenceType, SlotType, Type, TypeVariable} from '../type.js';
-import {DirectionPreSlandles} from '../manifest-ast-nodes.js';
+import {Direction} from '../manifest-ast-nodes.js';
 
 export interface TypeListInfo {
   type: Type;
-  direction?: DirectionPreSlandles;
-  connection?: {direction: DirectionPreSlandles};
+  direction?: Direction;
+  connection?: {direction: Direction};
 }
 
 export class TypeChecker {
@@ -162,7 +162,7 @@ export class TypeChecker {
         }
       }
 
-      if (direction === 'out' || direction === 'inout' || direction === '`provide') {
+      if (direction === 'writes' || direction === 'reads writes' || direction === '`provides') {
         // the canReadSubset of the handle represents the maximal type that can be read from the
         // handle, so we need to intersect out any type that is more specific than the maximal type
         // that could be written.
@@ -170,7 +170,7 @@ export class TypeChecker {
           return false;
         }
       }
-      if (direction === 'in' || direction === 'inout' || direction === '`consume') {
+      if (direction === 'reads' || direction === 'reads writes' || direction === '`consumes') {
         // the canWriteSuperset of the handle represents the maximum lower-bound type that is read from the handle,
         // so we need to union it with the type that wants to be read here.
         if (!primitiveHandleType.variable.maybeMergeCanWriteSuperset(primitiveConnectionType.canReadSubset)) {
@@ -182,12 +182,12 @@ export class TypeChecker {
         return false;
       }
 
-      if (direction === 'out' || direction === 'inout') {
+      if (direction === 'writes' || direction === 'reads writes') {
         if (!TypeChecker._writeConstraintsApply(primitiveHandleType, primitiveConnectionType)) {
           return false;
         }
       }
-      if (direction === 'in' || direction === 'inout') {
+      if (direction === 'reads' || direction === 'reads writes') {
         if (!TypeChecker._readConstraintsApply(primitiveHandleType, primitiveConnectionType)) {
           return false;
         }
@@ -289,16 +289,16 @@ export class TypeChecker {
     }
     const [superclass, subclass] = leftIsSuper ? [left, right] : [right, left];
 
-    // treat handle types as if they were 'inout' connections. Note that this
+    // treat handle types as if they were 'reads writes' connections. Note that this
     // guarantees that the handle's type will be preserved, and that the fact
     // that the type comes from a handle rather than a connection will also
     // be preserved.
-    const superDirection = superclass.direction || (superclass.connection ? superclass.connection.direction : 'inout');
-    const subDirection = subclass.direction || (subclass.connection ? subclass.connection.direction : 'inout');
-    if (superDirection === 'in') {
+    const superDirection = superclass.direction || (superclass.connection ? superclass.connection.direction : 'reads writes');
+    const subDirection = subclass.direction || (subclass.connection ? subclass.connection.direction : 'reads writes');
+    if (superDirection === 'reads') {
       return true;
     }
-    if (subDirection === 'out') {
+    if (subDirection === 'writes') {
       return true;
     }
     return false;

--- a/src/runtime/tests/artifacts/suggestions/Cake.manifest
+++ b/src/runtime/tests/artifacts/suggestions/Cake.manifest
@@ -20,7 +20,7 @@ particle MakeCake in 'source/MakeCake.js'
 
 particle LightCandles in 'source/LightCandles.js'
   // Note: birthday cake should is an input connection.
-  // It is only made 'inout' to force speculative execution.
+  // It is only made 'reads writes' to force speculative execution.
   birthdayCake: reads writes Cake
   candles: consumes Slot #special
   description `Light candles on ${birthdayCake} cake`

--- a/src/runtime/tests/interface-info-test.ts
+++ b/src/runtime/tests/interface-info-test.ts
@@ -37,7 +37,7 @@ describe('interface', () => {
 
   it('finds type variable references in slots', () => {
     const iface = InterfaceInfo.make('Test', [], [
-      {name: TypeVariable.make('a'), direction: 'consume', isRequired: false, isSet: false}]);
+      {name: TypeVariable.make('a'), direction: 'consumes', isRequired: false, isSet: false}]);
     assert.lengthOf(iface.typeVars, 1);
     assert.strictEqual(iface.typeVars[0].field, 'name');
     assert.strictEqual(iface.typeVars[0].object[iface.typeVars[0].field].variable.name, 'a');
@@ -94,7 +94,7 @@ describe('interface', () => {
           foo: writes NotTest
       `);
     const type = new EntityType(manifest.schemas.Test);
-    const iface = InterfaceInfo.make('Test', [{name: 'foo', type: TypeVariable.make('a')}, {direction: 'in', type: TypeVariable.make('b')}, {type}], []);
+    const iface = InterfaceInfo.make('Test', [{name: 'foo', type: TypeVariable.make('a')}, {direction: 'reads', type: TypeVariable.make('b')}, {type}], []);
     assert(!iface.particleMatches(manifest.particles[0]));
     assert(iface.particleMatches(manifest.particles[1]));
     assert(iface.particleMatches(manifest.particles[2]));
@@ -125,9 +125,9 @@ describe('interface', () => {
       `);
     const type = new EntityType(manifest.schemas.Test);
     const iface = InterfaceInfo.make('Test', [
-      {direction: 'in', type}], [
+      {direction: 'reads', type}], [
         {name: 'one'},
-        {direction: 'provide', isSet: true}]);
+        {direction: 'provides', isSet: true}]);
 
     assert(!iface.particleMatches(manifest.particles[0]));
     assert(!iface.particleMatches(manifest.particles[1]));
@@ -142,17 +142,17 @@ describe('interface', () => {
 
   it('Can ensure resolved a schema type', () => {
     const type = EntityType.make(['Thing'], {});
-    const iface = InterfaceInfo.make('Test', [{type, name: 'foo'}, {type, direction: 'in'}, {type}], []);
+    const iface = InterfaceInfo.make('Test', [{type, name: 'foo'}, {type, direction: 'reads'}, {type}], []);
     assert.isTrue(iface.canEnsureResolved());
     assert.isTrue(iface.maybeEnsureResolved());
   });
 
   it('Maybe ensure resolved does not mutate on failure', () => {
     const constrainedType1 = TypeChecker.processTypeList(
-      TypeVariable.make('a'), [{type: EntityType.make(['Thing'], {}), direction: 'in'}]
+      TypeVariable.make('a'), [{type: EntityType.make(['Thing'], {}), direction: 'reads'}]
     );
     const constrainedType2 = TypeChecker.processTypeList(
-      TypeVariable.make('b'), [{type: EntityType.make(['Thing'], {}), direction: 'out'}]
+      TypeVariable.make('b'), [{type: EntityType.make(['Thing'], {}), direction: 'writes'}]
     );
     const unconstrainedType = TypeVariable.make('c');
     const allTypes = [constrainedType1, constrainedType2, unconstrainedType];
@@ -282,7 +282,7 @@ describe('interface', () => {
     const hostParticle = recipe.particles.find(p => p.name === 'Host');
     const hostedInterface = (hostParticle.spec.getConnectionByName('hosted').type as InterfaceType).interfaceInfo;
 
-    const check = name => hostedInterface.particleMatches(manifest.findParticleByName(name));
+    const check = (name: string) => hostedInterface.particleMatches(manifest.findParticleByName(name));
 
     // reads writes Thing is not be compatible with in Instrument input
     // reads writes LesPaul is not be compatible with out Gibson output

--- a/src/runtime/tests/manifest-test.ts
+++ b/src/runtime/tests/manifest-test.ts
@@ -1287,8 +1287,8 @@ ${particleStr1}
 
     const directions = slotB.connections.map(c => c.direction);
     assert.lengthOf(directions, 2);
-    assert.include(directions, '`provide');
-    assert.include(directions, '`consume');
+    assert.include(directions, '`provides');
+    assert.include(directions, '`consumes');
   });
   it('parses local slots with IDs', async () => {
     const recipe = (await Manifest.parse(`
@@ -1563,7 +1563,7 @@ Expected a verb (e.g. &Verb) or an uppercase identifier (e.g. Foo) but "?" found
       await Manifest.parse(manifest);
       assert.fail();
     } catch (e) {
-      assert.match(e.message, /'out' not compatible with 'in' param of 'TestParticle'/);
+      assert.match(e.message, /'writes' not compatible with 'reads' param of 'TestParticle'/);
     }
   });
 
@@ -2245,7 +2245,7 @@ resource SomeName
     assert.isUndefined(recipe.particles[0].spec);
     const slotConnection = recipe.particles[0].connections.foo;
     // TODO(jopra): Internalize new direction names
-    assert.strictEqual(slotConnection.direction, '`consume');
+    assert.strictEqual(slotConnection.direction, '`consumes');
 
     assert.lengthOf(recipe.handles, 1);
     assert.lengthOf(recipe.handles[0].connections, 1);
@@ -2749,7 +2749,7 @@ resource SomeName
         particle A
           foo: writes T {}
           check foo is trusted
-      `), `Can't make a check on handle foo with direction out (not an input handle)`);
+      `), `Can't make a check on handle foo with direction writes (not an input handle)`);
     });
 
     it(`doesn't allow multiple different claims for the same output`, async () => {

--- a/src/runtime/tests/particle-interface-loading-test.ts
+++ b/src/runtime/tests/particle-interface-loading-test.ts
@@ -78,9 +78,9 @@ describe('particle interface loading', () => {
       verbs: [],
       implFile: 'outer-particle.js',
       args: [
-        {direction: 'host', type: ifaceType, name: 'particle0', dependentConnections: [], isOptional: false},
-        {direction: 'in', type: fooType, name: 'input', dependentConnections: [], isOptional: false},
-        {direction: 'out', type: barType, name: 'output', dependentConnections: [], isOptional: false}
+        {direction: 'hosts', type: ifaceType, name: 'particle0', dependentConnections: [], isOptional: false},
+        {direction: 'reads', type: fooType, name: 'input', dependentConnections: [], isOptional: false},
+        {direction: 'writes', type: barType, name: 'output', dependentConnections: [], isOptional: false}
       ],
     });
 

--- a/src/runtime/tests/reference-test.ts
+++ b/src/runtime/tests/reference-test.ts
@@ -292,7 +292,7 @@ describe('references', () => {
   it('can construct references in schemas', async () => {
     // This test looks at different scenarios for creating references
     // inside schemas. It:
-    // * reads a single value from the inout connection 'out'
+    // * reads a single value from the reads writes connection 'out'
     // * reads the single 'inFoo'
     // * reads a collction of Results from 'inResult'.
     // * puts a Result into each of the Foos retrieved from 'out' and 'inFoo'

--- a/src/runtime/tests/type-checker-test.ts
+++ b/src/runtime/tests/type-checker-test.ts
@@ -19,7 +19,7 @@ describe('TypeChecker', () => {
     const a = TypeVariable.make('a').collectionOf();
     const b = TypeVariable.make('b').collectionOf();
     const c = EntityType.make(['Product'], {}).collectionOf();
-    const result = TypeChecker.processTypeList(undefined, [{type: a, direction: 'in'}, {type: b, direction: 'out'}, {type: c, direction: 'in'}]);
+    const result = TypeChecker.processTypeList(undefined, [{type: a, direction: 'reads'}, {type: b, direction: 'writes'}, {type: c, direction: 'reads'}]);
     const canWriteSuperset = a.resolvedType().collectionType.canWriteSuperset as EntityType;
 
     assert.instanceOf(canWriteSuperset, EntityType);
@@ -36,7 +36,7 @@ describe('TypeChecker', () => {
   it(`doesn't resolve a pair of inout [~a], inout ~a`, async () => {
     const variable = TypeVariable.make('a');
     const collection = variable.collectionOf();
-    const result = TypeChecker.processTypeList(undefined, [{type: variable, direction: 'inout'}, {type: collection, direction: 'inout'}]);
+    const result = TypeChecker.processTypeList(undefined, [{type: variable, direction: 'reads writes'}, {type: collection, direction: 'reads writes'}]);
     assert.isNull(result);
   });
 
@@ -44,7 +44,7 @@ describe('TypeChecker', () => {
     const a = TypeVariable.make('a').bigCollectionOf();
     const b = TypeVariable.make('b').bigCollectionOf();
     const c = EntityType.make(['Product'], {}).bigCollectionOf();
-    const result = TypeChecker.processTypeList(undefined, [{type: a, direction: 'in'}, {type: b, direction: 'out'}, {type: c, direction: 'in'}]);
+    const result = TypeChecker.processTypeList(undefined, [{type: a, direction: 'reads'}, {type: b, direction: 'writes'}, {type: c, direction: 'reads'}]);
 
     let canWriteSuperset = a.resolvedType().bigCollectionType.canWriteSuperset as EntityType;
     assert.instanceOf(canWriteSuperset, EntityType);
@@ -65,7 +65,7 @@ describe('TypeChecker', () => {
     const a = EntityType.make(['Thing'], {}).collectionOf();
     const b = EntityType.make(['Thing'], {}).collectionOf();
     const c = EntityType.make(['Product', 'Thing'], {}).collectionOf();
-    const result = TypeChecker.processTypeList(undefined, [{type: a, direction: 'in'}, {type: b, direction: 'in'}, {type: c, direction: 'out'}]);
+    const result = TypeChecker.processTypeList(undefined, [{type: a, direction: 'reads'}, {type: b, direction: 'reads'}, {type: c, direction: 'writes'}]);
     if (result.isCollectionType() && result.collectionType.canReadSubset instanceof EntityType && result.collectionType.canWriteSuperset instanceof EntityType) {
       assert.strictEqual(result.collectionType.canReadSubset.entitySchema.name, 'Product');
       assert.strictEqual(result.collectionType.canWriteSuperset.entitySchema.name, 'Thing');
@@ -78,7 +78,7 @@ describe('TypeChecker', () => {
     const a = EntityType.make(['Thing'], {}).bigCollectionOf();
     const b = EntityType.make(['Thing'], {}).bigCollectionOf();
     const c = EntityType.make(['Product', 'Thing'], {}).bigCollectionOf();
-    const result = TypeChecker.processTypeList(undefined, [{type: a, direction: 'in'}, {type: b, direction: 'in'}, {type: c, direction: 'out'}]);
+    const result = TypeChecker.processTypeList(undefined, [{type: a, direction: 'reads'}, {type: b, direction: 'reads'}, {type: c, direction: 'writes'}]);
     if (result.isBigCollectionType() && result.bigCollectionType.canReadSubset instanceof EntityType && result.bigCollectionType.canWriteSuperset instanceof EntityType) {
       assert.strictEqual(result.bigCollectionType.canReadSubset.entitySchema.name, 'Product');
       assert.strictEqual(result.bigCollectionType.canWriteSuperset.entitySchema.name, 'Thing');
@@ -91,7 +91,7 @@ describe('TypeChecker', () => {
     const a = EntityType.make(['Thing'], {}).collectionOf();
     const b = EntityType.make(['Thing'], {}).collectionOf();
     const c = EntityType.make(['Product', 'Thing'], {}).collectionOf();
-    const result = TypeChecker.processTypeList(undefined, [{type: c, direction: 'out'}, {type: a, direction: 'in'}, {type: b, direction: 'in'}]);
+    const result = TypeChecker.processTypeList(undefined, [{type: c, direction: 'writes'}, {type: a, direction: 'reads'}, {type: b, direction: 'reads'}]);
     if (result.isCollectionType() && result.collectionType.canReadSubset instanceof EntityType && result.collectionType.canWriteSuperset instanceof EntityType) {
       assert.strictEqual(result.collectionType.canReadSubset.entitySchema.name, 'Product');
       assert.strictEqual(result.collectionType.canWriteSuperset.entitySchema.name, 'Thing');
@@ -104,7 +104,7 @@ describe('TypeChecker', () => {
     const a = EntityType.make(['Thing'], {}).bigCollectionOf();
     const b = EntityType.make(['Thing'], {}).bigCollectionOf();
     const c = EntityType.make(['Product', 'Thing'], {}).bigCollectionOf();
-    const result = TypeChecker.processTypeList(undefined, [{type: c, direction: 'out'}, {type: a, direction: 'in'}, {type: b, direction: 'in'}]);
+    const result = TypeChecker.processTypeList(undefined, [{type: c, direction: 'writes'}, {type: a, direction: 'reads'}, {type: b, direction: 'reads'}]);
     if (result.isBigCollectionType() && result.bigCollectionType.canReadSubset instanceof EntityType && result.bigCollectionType.canWriteSuperset instanceof EntityType) {
       assert.strictEqual(result.bigCollectionType.canReadSubset.entitySchema.name, 'Product');
       assert.strictEqual(result.bigCollectionType.canWriteSuperset.entitySchema.name, 'Thing');
@@ -120,7 +120,7 @@ describe('TypeChecker', () => {
     a.collectionType.variable.resolution = resolution;
     b.collectionType.variable.resolution = resolution;
     const c = EntityType.make(['Product', 'Thing'], {}).collectionOf();
-    const result = TypeChecker.processTypeList(undefined, [{type: a, direction: 'in'}, {type: b, direction: 'in'}, {type: c, direction: 'out'}]);
+    const result = TypeChecker.processTypeList(undefined, [{type: a, direction: 'reads'}, {type: b, direction: 'reads'}, {type: c, direction: 'writes'}]);
     if (result.isCollectionType() && result.collectionType.canReadSubset instanceof EntityType && result.collectionType.canWriteSuperset instanceof EntityType) {
       assert.strictEqual(result.collectionType.canReadSubset.entitySchema.name, 'Product');
       assert.strictEqual(result.collectionType.canWriteSuperset.entitySchema.name, 'Thing');
@@ -136,7 +136,7 @@ describe('TypeChecker', () => {
     a.bigCollectionType.variable.resolution = resolution;
     b.bigCollectionType.variable.resolution = resolution;
     const c = EntityType.make(['Product', 'Thing'], {}).bigCollectionOf();
-    const result = TypeChecker.processTypeList(undefined, [{type: a, direction: 'in'}, {type: b, direction: 'in'}, {type: c, direction: 'out'}]);
+    const result = TypeChecker.processTypeList(undefined, [{type: a, direction: 'reads'}, {type: b, direction: 'reads'}, {type: c, direction: 'writes'}]);
     if (result.isBigCollectionType() && result.bigCollectionType.canReadSubset instanceof EntityType && result.bigCollectionType.canWriteSuperset instanceof EntityType) {
       assert.strictEqual(result.bigCollectionType.canReadSubset.entitySchema.name, 'Product');
       assert.strictEqual(result.bigCollectionType.canWriteSuperset.entitySchema.name, 'Thing');
@@ -149,7 +149,7 @@ describe('TypeChecker', () => {
     const a = TypeVariable.make('a').collectionOf();
     a.collectionType.variable.resolution = EntityType.make(['Thing'], {});
     const c = EntityType.make(['Product', 'Thing'], {}).collectionOf();
-    const result = TypeChecker.processTypeList(undefined, [{type: a, direction: 'in'}, {type: c, direction: 'out'}]);
+    const result = TypeChecker.processTypeList(undefined, [{type: a, direction: 'reads'}, {type: c, direction: 'writes'}]);
     if (result.isCollectionType() && result.collectionType.canReadSubset instanceof EntityType && result.collectionType.canWriteSuperset instanceof EntityType) {
       assert.strictEqual(result.collectionType.canReadSubset.entitySchema.name, 'Product');
       assert.include(result.collectionType.canReadSubset.entitySchema.names, 'Thing');
@@ -163,7 +163,7 @@ describe('TypeChecker', () => {
     const a = TypeVariable.make('a').bigCollectionOf();
     a.bigCollectionType.variable.resolution = EntityType.make(['Thing'], {});
     const c = EntityType.make(['Product', 'Thing'], {}).bigCollectionOf();
-    const result = TypeChecker.processTypeList(undefined, [{type: a, direction: 'in'}, {type: c, direction: 'out'}]);
+    const result = TypeChecker.processTypeList(undefined, [{type: a, direction: 'reads'}, {type: c, direction: 'writes'}]);
     if (result.isBigCollectionType() && result.bigCollectionType.canReadSubset instanceof EntityType && result.bigCollectionType.canWriteSuperset instanceof EntityType) {
       assert.strictEqual(result.bigCollectionType.canReadSubset.entitySchema.name, 'Product');
       assert.include(result.bigCollectionType.canReadSubset.entitySchema.names, 'Thing');
@@ -177,7 +177,7 @@ describe('TypeChecker', () => {
     const a = TypeVariable.make('a').collectionOf();
     a.collectionType.variable.resolution = EntityType.make(['Thing'], {});
     const c = EntityType.make(['Product', 'Thing'], {}).collectionOf();
-    const result = TypeChecker.processTypeList(undefined, [{type: a, direction: 'out'}, {type: c, direction: 'in'}]);
+    const result = TypeChecker.processTypeList(undefined, [{type: a, direction: 'writes'}, {type: c, direction: 'reads'}]);
     assert.isNull(result);
   });
 
@@ -185,7 +185,7 @@ describe('TypeChecker', () => {
     const a = TypeVariable.make('a').bigCollectionOf();
     a.bigCollectionType.variable.resolution = EntityType.make(['Thing'], {});
     const c = EntityType.make(['Product', 'Thing'], {}).bigCollectionOf();
-    const result = TypeChecker.processTypeList(undefined, [{type: a, direction: 'out'}, {type: c, direction: 'in'}]);
+    const result = TypeChecker.processTypeList(undefined, [{type: a, direction: 'writes'}, {type: c, direction: 'reads'}]);
     assert.isNull(result);
   });
 
@@ -193,7 +193,7 @@ describe('TypeChecker', () => {
     const a = TypeVariable.make('a').collectionOf();
     a.collectionType.variable.resolution = EntityType.make(['Thing'], {});
     const c = EntityType.make(['Product', 'Thing'], {}).collectionOf();
-    const result = TypeChecker.processTypeList(undefined, [{type: a, direction: 'out'}, {type: c, direction: 'inout'}]);
+    const result = TypeChecker.processTypeList(undefined, [{type: a, direction: 'writes'}, {type: c, direction: 'reads writes'}]);
     assert.isNull(result);
   });
 
@@ -201,7 +201,7 @@ describe('TypeChecker', () => {
     const a = TypeVariable.make('a').bigCollectionOf();
     a.bigCollectionType.variable.resolution = EntityType.make(['Thing'], {});
     const c = EntityType.make(['Product', 'Thing'], {}).bigCollectionOf();
-    const result = TypeChecker.processTypeList(undefined, [{type: a, direction: 'out'}, {type: c, direction: 'inout'}]);
+    const result = TypeChecker.processTypeList(undefined, [{type: a, direction: 'writes'}, {type: c, direction: 'reads writes'}]);
     assert.isNull(result);
   });
 
@@ -216,7 +216,7 @@ describe('TypeChecker', () => {
     const e = TypeVariable.make('d').collectionOf();
     resolution = EntityType.make(['Product', 'Thing'], {});
     e.collectionType.variable.resolution = resolution;
-    const result = TypeChecker.processTypeList(undefined, [{type: a, direction: 'inout'}, {type: b, direction: 'in'}, {type: c, direction: 'in'}, {type: d, direction: 'in'}, {type: e, direction: 'in'}]);
+    const result = TypeChecker.processTypeList(undefined, [{type: a, direction: 'reads writes'}, {type: b, direction: 'reads'}, {type: c, direction: 'reads'}, {type: d, direction: 'reads'}, {type: e, direction: 'reads'}]);
     assert.isNull(result);
   });
 
@@ -231,7 +231,7 @@ describe('TypeChecker', () => {
     const e = TypeVariable.make('d').bigCollectionOf();
     resolution = EntityType.make(['Product', 'Thing'], {});
     e.bigCollectionType.variable.resolution = resolution;
-    const result = TypeChecker.processTypeList(undefined, [{type: a, direction: 'inout'}, {type: b, direction: 'in'}, {type: c, direction: 'in'}, {type: d, direction: 'in'}, {type: e, direction: 'in'}]);
+    const result = TypeChecker.processTypeList(undefined, [{type: a, direction: 'reads writes'}, {type: b, direction: 'reads'}, {type: c, direction: 'reads'}, {type: d, direction: 'reads'}, {type: e, direction: 'reads'}]);
     assert.isNull(result);
   });
 
@@ -239,7 +239,7 @@ describe('TypeChecker', () => {
     let a = TypeVariable.make('a');
     const b = EntityType.make(['Product', 'Thing'], {});
     const c = EntityType.make(['Thing'], {});
-    let result = TypeChecker.processTypeList(undefined, [{type: a, direction: 'in'}, {type: b, direction: 'out'}, {type: c, direction: 'in'}]);
+    let result = TypeChecker.processTypeList(undefined, [{type: a, direction: 'reads'}, {type: b, direction: 'writes'}, {type: c, direction: 'reads'}]);
     if (a.variable.canReadSubset instanceof EntityType && a.variable.canWriteSuperset instanceof EntityType) {
       assert.strictEqual(a.variable.canReadSubset.entitySchema.name, 'Product');
       assert.strictEqual(a.variable.canWriteSuperset.entitySchema.name, 'Thing');
@@ -248,7 +248,7 @@ describe('TypeChecker', () => {
     }
 
     a = TypeVariable.make('a');
-    result = TypeChecker.processTypeList(undefined, [{type: a, direction: 'in'}, {type: c, direction: 'in'}, {type: b, direction: 'out'}]);
+    result = TypeChecker.processTypeList(undefined, [{type: a, direction: 'reads'}, {type: c, direction: 'reads'}, {type: b, direction: 'writes'}]);
     if (a.variable.canReadSubset instanceof EntityType && a.variable.canWriteSuperset instanceof EntityType) {
       assert.strictEqual(a.variable.canReadSubset.entitySchema.name, 'Product');
       assert.strictEqual(a.variable.canWriteSuperset.entitySchema.name, 'Thing');
@@ -291,11 +291,11 @@ describe('TypeChecker', () => {
   it(`doesn't resolve Entity and Collection`, async () => {
     const entity: TypeListInfo = {
       type: EntityType.make(['Product', 'Thing'], {}),
-      direction: 'inout'
+      direction: 'reads writes'
     };
     const collection: TypeListInfo = {
       type: EntityType.make(['Product', 'Thing'], {}).collectionOf(),
-      direction: 'inout'
+      direction: 'reads writes'
     };
 
     assert.isNull(TypeChecker.processTypeList(entity.type, [collection]));
@@ -307,11 +307,11 @@ describe('TypeChecker', () => {
   it(`doesn't resolve Entity and BigCollection`, async () => {
     const entity: TypeListInfo = {
       type: EntityType.make(['Product', 'Thing'], {}),
-      direction: 'inout'
+      direction: 'reads writes'
     };
     const bigCollection: TypeListInfo = {
       type: EntityType.make(['Product', 'Thing'], {}).bigCollectionOf(),
-      direction: 'inout'
+      direction: 'reads writes'
     };
 
     assert.isNull(TypeChecker.processTypeList(entity.type, [bigCollection]));
@@ -323,11 +323,11 @@ describe('TypeChecker', () => {
   it(`doesn't resolve Collection and BigCollection`, async () => {
     const collection: TypeListInfo = {
       type: EntityType.make(['Product', 'Thing'], {}).collectionOf(),
-      direction: 'inout'
+      direction: 'reads writes'
     };
     const bigCollection: TypeListInfo = {
       type: EntityType.make(['Product', 'Thing'], {}).bigCollectionOf(),
-      direction: 'inout'
+      direction: 'reads writes'
     };
 
     assert.isNull(TypeChecker.processTypeList(collection.type, [bigCollection]));
@@ -339,25 +339,25 @@ describe('TypeChecker', () => {
   it(`doesn't resolve Entity and Collection of type variable`, () => {
     const a = EntityType.make(['Thing'], {});
     const b = TypeVariable.make('a').collectionOf();
-    assert.isNull(TypeChecker.processTypeList(a, [{type: b, direction: 'inout'}]));
+    assert.isNull(TypeChecker.processTypeList(a, [{type: b, direction: 'reads writes'}]));
   });
 
   it(`doesn't resolve Entity and BigCollection of type variable`, () => {
     const a = EntityType.make(['Thing'], {});
     const b = TypeVariable.make('a').bigCollectionOf();
-    assert.isNull(TypeChecker.processTypeList(a, [{type: b, direction: 'inout'}]));
+    assert.isNull(TypeChecker.processTypeList(a, [{type: b, direction: 'reads writes'}]));
   });
 
   it(`doesn't resolve Collection and BigCollection of type variable`, () => {
     const a = EntityType.make(['Thing'], {}).collectionOf();
     const b = TypeVariable.make('a').bigCollectionOf();
-    assert.isNull(TypeChecker.processTypeList(a, [{type: b, direction: 'inout'}]));
+    assert.isNull(TypeChecker.processTypeList(a, [{type: b, direction: 'reads writes'}]));
   });
 
   it(`doesn't modify an input baseType if invoked through Handle.effectiveType`, async () => {
     const baseType = TypeVariable.make('a');
     const newType = Handle.effectiveType(baseType, [
-      {type: EntityType.make(['Thing'], {}), direction: 'inout'}]);
+      {type: EntityType.make(['Thing'], {}), direction: 'reads writes'}]);
     assert.notStrictEqual(baseType, newType);
     assert.isNull(baseType.variable.resolution);
     assert.isNotNull(newType instanceof TypeVariable && newType.variable.resolution);
@@ -396,13 +396,13 @@ describe('TypeChecker', () => {
   it(`doesn't mutate types provided to effectiveType calls`, () => {
     const a = TypeVariable.make('a');
     assert.isNull(a.variable._resolution);
-    Handle.effectiveType(undefined, [{type: a, direction: 'inout'}]);
+    Handle.effectiveType(undefined, [{type: a, direction: 'reads writes'}]);
     assert.isNull(a.variable._resolution);
   });
 
   it('resolves a single Slot type', () => {
     const a = SlotType.make('f', 'h');
-    const result = TypeChecker.processTypeList(null, [{type: a, direction: '`consume'}]);
+    const result = TypeChecker.processTypeList(null, [{type: a, direction: '`consumes'}]);
     assert(result.canEnsureResolved());
     result.maybeEnsureResolved();
     assert(result.isResolved());

--- a/src/runtime/tests/type-test.ts
+++ b/src/runtime/tests/type-test.ts
@@ -298,7 +298,7 @@ describe('types', () => {
     it('serializes interfaces', async () => {
       const entity = EntityType.make(['Foo'], {value: 'Text'});
       const variable = TypeVariable.make('a', null, null);
-      const iface = InterfaceType.make('i', [{type: entity, name: 'foo'}, {type: variable}], [{name: 'x', direction: 'consume'}]);
+      const iface = InterfaceType.make('i', [{type: entity, name: 'foo'}, {type: variable}], [{name: 'x', direction: 'consumes'}]);
       assert.strictEqual(iface.interfaceInfo.toString(),
 `interface i
   foo: Foo {value: Text}

--- a/src/runtime/type.ts
+++ b/src/runtime/type.ts
@@ -687,7 +687,7 @@ export class RelationType extends Type {
 export interface HandleConnection {
   type: Type;
   name?: string|TypeVariable;
-  direction?: AstNode.DirectionPreSlandles; // TODO make required
+  direction?: AstNode.Direction; // TODO make required
 }
 
 // TODO(lindner) only tests use optional props
@@ -1175,7 +1175,7 @@ export class TypeVariableInfo {
 export interface HandleConnectionLiteral {
   type?: TypeLiteral;
   name?: string|TypeLiteral;
-  direction?: AstNode.DirectionPreSlandles;
+  direction?: AstNode.Direction;
 }
 
 export interface SlotLiteral {
@@ -1196,7 +1196,7 @@ export interface InterfaceInfoLiteral {
   slots: SlotLiteral[];
 }
 
-export type MatchResult = {var: TypeVariable, value: Type, direction: AstNode.DirectionPreSlandles};
+export type MatchResult = {var: TypeVariable, value: Type, direction: AstNode.Direction};
 
 type Maker = (name: string, handleConnections: HandleConnection[], slots: Slot[]) => InterfaceInfo;
 type HandleConnectionMatcher = (interfaceHandleConnection: HandleConnection, particleHandleConnection: HandleConnection) => boolean|MatchResult[];

--- a/src/tools/vscode-language-client/snippets/arcs.json
+++ b/src/tools/vscode-language-client/snippets/arcs.json
@@ -13,11 +13,11 @@
         ],
         "description": "Insert particle definition"
     },
-    "consume": {
-        "prefix": "consume",
+    "consumes": {
+        "prefix": "consumes",
         "body": [
-            "consume ${1:slot}$0"
+            "consumes Slot"
         ],
-        "description": "Insert consume slot"
+        "description": "Insert consumes slot"
     }
 }

--- a/src/wasm/tests/wasm-api-test.ts
+++ b/src/wasm/tests/wasm-api-test.ts
@@ -224,8 +224,8 @@ class TestLoader extends Loader {
       };
 
       // clear() on out/io with pre-populated stores
-      await outStore.set({id: 'i1', rawData: {txt: 'out'}});
-      await ioStore.set({id: 'i2', rawData: {txt: 'inout'}});
+      await outStore.set({id: 'i1', rawData: {txt: 'writes'}});
+      await ioStore.set({id: 'i2', rawData: {txt: 'reads writes'}});
       await sendEvent('case1');
       assert.isNull(await outStore.get());
       assert.isNull(await ioStore.get());


### PR DESCRIPTION
This moves the internals of the runtime to use the new direction keywords (i.e. 'reads' 'writes' over 'in' 'out').