### PR TITLE
Move some tools scripts to bash from sh.

### DIFF
--- a/tools/clean
+++ b/tools/clean
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # A basic script to clean all of the build artifacts and installed
 # modules.  Order matters, and it's easy to overlook something. In the

--- a/tools/ktlint
+++ b/tools/ktlint
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 source $(dirname $0)/logging.sh
 

--- a/tools/local-presubmit
+++ b/tools/local-presubmit
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # A basic script to locally semi-simulate the build and test
 # operations performed by our continuous integration service. Note

--- a/tools/logging.sh
+++ b/tools/logging.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+# Utility routines and constants for use by Arcs shell tools.
 
 ROOT=$(dirname $0)/..
 

--- a/tools/setup
+++ b/tools/setup
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 source $(dirname $0)/logging.sh
 


### PR DESCRIPTION
`source` is a `bash` thing, we could switch to `.` which seems more POSIX compliant, or we could just shift these to `bash`. One of many reasons to move to a real scripting language or put it properly into a build tool, this was fine on my workstation but on my Pixelbook `/bin/sh` complained.