### PR TITLE
Support using &T instead of Reference<T> for references

### DIFF
--- a/java/arcs/core/data/ReferenceType.kt
+++ b/java/arcs/core/data/ReferenceType.kt
@@ -45,10 +45,10 @@ data class ReferenceType<T : Type>(private val referredType: T) :
 
     override fun toLiteral() = Literal(tag, containedType.toLiteral())
 
-    override fun toString() = "Reference<$containedType>"
+    override fun toString() = "&$containedType"
 
     override fun toString(options: Type.ToStringOptions): String =
-        "Reference<${containedType.toString(options)}>"
+        "&${containedType.toString(options)}"
 
     data class Literal(override val tag: Tag, override val data: TypeLiteral) : TypeLiteral
 

--- a/src/runtime/manifest-parser.peg
+++ b/src/runtime/manifest-parser.peg
@@ -595,6 +595,13 @@ ReferenceType
       type,
     });
   }
+  / '&' type:ParticleHandleConnectionType
+  {
+    return toAstNode<AstNode.ReferenceType>({
+      kind: 'reference-type',
+      type,
+    });
+  }
 
 TypeVariable "a type variable (e.g. ~foo)"
   = '~' name:lowerIdent constraint:(whiteSpace 'with' whiteSpace type:ParticleHandleConnectionType)?
@@ -1283,7 +1290,7 @@ SchemaType
       return type;
   }
 
-SchemaCollectionType = '[' whiteSpace* schema:SchemaReferenceType whiteSpace* ']'
+SchemaCollectionType = '[' whiteSpace? schema:SchemaReferenceType whiteSpace? ']'
   {
     return toAstNode<AstNode.SchemaCollectionType>({
       kind: 'schema-collection',
@@ -1292,7 +1299,14 @@ SchemaCollectionType = '[' whiteSpace* schema:SchemaReferenceType whiteSpace* ']
     });
   }
 
-SchemaReferenceType = 'Reference<' whiteSpace* schema:(SchemaInline / TypeName) whiteSpace* '>'
+SchemaReferenceType = 'Reference<' whiteSpace? schema:(SchemaInline / TypeName) whiteSpace? '>'
+  {
+    return toAstNode<AstNode.SchemaReferenceType>({
+      kind: 'schema-reference',
+      schema
+    });
+  }
+  / '&' whiteSpace? schema:(SchemaInline / TypeName) whiteSpace?
   {
     return toAstNode<AstNode.SchemaReferenceType>({
       kind: 'schema-reference',

--- a/src/runtime/schema.ts
+++ b/src/runtime/schema.ts
@@ -84,7 +84,7 @@ export class Schema {
       case 'schema-tuple':
         return `(${type.types.map(t => t.type).join(', ')})`;
       case 'schema-reference':
-        return `Reference<${Schema._typeString(type.schema)}>`;
+        return `&${Schema._typeString(type.schema)}`;
       case 'type-name':
       case 'schema-inline':
         return type.model.entitySchema.toInlineSchemaString();

--- a/src/runtime/tests/manifest-parser-test.ts
+++ b/src/runtime/tests/manifest-parser-test.ts
@@ -10,7 +10,6 @@
 
 import {parse} from '../../gen/runtime/manifest-parser.js';
 import {assert} from '../../platform/chai-web.js';
-import {Flags} from '../flags.js';
 
 describe('manifest parser', () => {
   it('parses an empy manifest', () => {
@@ -247,10 +246,22 @@ describe('manifest parser', () => {
         review: Reference<Review>
     `);
   });
+  it('parses a schema with a reference field (with sugar)', () => {
+    parse(`
+      schema Product
+        review: &Review
+    `);
+  });
   it('parses a schema with a referenced inline schema', () => {
     parse(`
       schema Product
         review: Reference<Review {reviewText: Text}>
+    `);
+  });
+  it('parses a schema with a referenced inline schema (with sugar)', () => {
+    parse(`
+      schema Product
+        review: &Review {reviewText: Text}
     `);
   });
   it('parses an inline schema with a reference to a schema', () => {
@@ -259,10 +270,22 @@ describe('manifest parser', () => {
         inReview: reads Product {review: Reference<Review>}
     `);
   });
+  it('parses an inline schema with a reference to a schema (with sugar)', () => {
+    parse(`
+      particle Foo
+        inReview: reads Product {review: &Review}
+    `);
+  });
   it('parses an inline schema with a collection of references to schemas', () => {
     parse(`
       particle Foo
         inResult: reads Product {review: [Reference<Review>]}
+    `);
+  });
+  it('parses an inline schema with a collection of references to schemas (with sugar)', () => {
+    parse(`
+      particle Foo
+        inResult: reads Product {review: [&Review]}
     `);
   });
   it('parses an inline schema with a referenced inline schema', () => {
@@ -271,10 +294,22 @@ describe('manifest parser', () => {
       inReview: reads Product {review: Reference<Review {reviewText: Text}> }
     `);
   });
+  it('parses an inline schema with a referenced inline schema (with sugar)', () => {
+    parse(`
+    particle Foo
+      inReview: reads Product {review: &Review {reviewText: Text} }
+    `);
+  });
   it('parses an inline schema with a collection of references to inline schemas', () => {
     parse(`
       particle Foo
         productReviews: reads Product {review: [Reference<Review {reviewText: Text}>]}
+    `);
+  });
+  it('parses an inline schema with a collection of references to inline schemas (with sugar)', () => {
+    parse(`
+      particle Foo
+        productReviews: reads Product {review: [&Review {reviewText: Text}]}
     `);
   });
   it('parses reference types', () => {
@@ -282,6 +317,13 @@ describe('manifest parser', () => {
       particle Foo
         inRef: reads Reference<Foo>
         outRef: writes Reference<Bar>
+    `);
+  });
+  it('parses reference types (with sugar)', () => {
+    parse(`
+      particle Foo
+        inRef: reads &Reference<Foo>
+        outRef: writes &Reference<Bar>
     `);
   });
   it('parses refinement types in a schema', () => {

--- a/src/runtime/tests/manifest-test.ts
+++ b/src/runtime/tests/manifest-test.ts
@@ -1909,7 +1909,7 @@ resource SomeName
       schema Foo
         far: Text
       particle P
-        bar: reads Bar {foo: Reference<Foo>}
+        bar: reads Bar {foo: &Foo}
       recipe
         h0: create
         P
@@ -1925,14 +1925,14 @@ resource SomeName
 
     assert.strictEqual(manifest.particles[0].toString(),
 `particle P
-  bar: reads Bar {foo: Reference<Foo {far: Text}>}
+  bar: reads Bar {foo: &Foo {far: Text}}
   modality dom`);
   });
   it('can resolve a particle with an inline schema reference', async () => {
     const manifest = await Manifest.parse(`
       schema Foo
       particle P
-        bar: reads Bar {foo: Reference<Foo {far: Text}>}
+        bar: reads Bar {foo: &Foo {far: Text}}
       recipe
         h0: create
         P
@@ -1948,7 +1948,7 @@ resource SomeName
 
     assert.strictEqual(manifest.particles[0].toString(),
 `particle P
-  bar: reads Bar {foo: Reference<Foo {far: Text}>}
+  bar: reads Bar {foo: &Foo {far: Text}}
   modality dom`);
   });
   it('can resolve a particle with a collection of schema references', async () => {
@@ -1956,7 +1956,7 @@ resource SomeName
       schema Foo
         far: Text
       particle P
-        bar: reads Bar {foo: [Reference<Foo>]}
+        bar: reads Bar {foo: [&Foo]}
       recipe
         h0: create
         P
@@ -1972,13 +1972,13 @@ resource SomeName
 
     assert.strictEqual(manifest.particles[0].toString(),
 `particle P
-  bar: reads Bar {foo: [Reference<Foo {far: Text}>]}
+  bar: reads Bar {foo: [&Foo {far: Text}]}
   modality dom`);
   });
   it('can resolve a particle with a collection of inline schema references', async () => {
     const manifest = await Manifest.parse(`
       particle P
-        bar: reads Bar {foo: [Reference<Foo {far: Text}>]}
+        bar: reads Bar {foo: [&Foo {far: Text}]}
       recipe
         h0: create
         P
@@ -1994,7 +1994,7 @@ resource SomeName
 
     assert.strictEqual(manifest.particles[0].toString(),
 `particle P
-  bar: reads Bar {foo: [Reference<Foo {far: Text}>]}
+  bar: reads Bar {foo: [&Foo {far: Text}]}
   modality dom`);
   });
   it('can resolve inline schemas against out of line schemas', async () => {

--- a/src/runtime/type.ts
+++ b/src/runtime/type.ts
@@ -895,7 +895,7 @@ export class ReferenceType extends Type {
   }
 
   toString(options = undefined): string {
-    return 'Reference<' + this.referredType.toString() + '>';
+    return '&' + this.referredType.toString();
   }
 
   toPrettyString(): string {


### PR DESCRIPTION
This would give an alternative syntax for reference types which is a bit more familiar to C++ and Rust users and removes some nesting to reduce the burden on readers.

Reference<T> is kept as an alternative syntax so that this change is backwards compatible but should be updated at some point when we have a consistent, readable syntax for parameterized types.