### PR TITLE
Improve Kotlin Native Wasm targets for g3

### DIFF
--- a/third_party/java/arcs/build_defs/internal/kotlin.bzl
+++ b/third_party/java/arcs/build_defs/internal/kotlin.bzl
@@ -57,17 +57,18 @@ def arcs_kt_binary(name, srcs = [], deps = [], visibility = None):
 
         deps = [":" + libname]
 
+    bin_name = name + "_bin"
     kt_native_binary(
-        name = name,
+        name = bin_name,
         entry_point = "arcs.main",
         deps = [_to_wasm_dep(dep) for dep in _ARCS_KOTLIN_LIBS + deps],
-        tags = ["wasm"],
+        tags = ["manual", "notap"],
         visibility = visibility,
     )
 
     wasm_kt_binary(
-        name = name + "_wasm",
-        kt_target = ":" + name,
+        name = name,
+        kt_target = ":" + bin_name,
     )
 
 def kt_jvm_and_wasm_library(


### PR DESCRIPTION
Already done in #4255 and then reverted in #4259 

Improves the naming and puts the tags that exclude unbuildable rules from /... and automated integration tools.

