### PR TITLE
Deprecate #shared tag, use not #volatile and volatile storage key instead to register shareable stores.

### DIFF
--- a/javaharness/java/arcs/android/AndroidArcsEnvironment.java
+++ b/javaharness/java/arcs/android/AndroidArcsEnvironment.java
@@ -260,7 +260,7 @@ final class AndroidArcsEnvironment {
         .put(Constants.MESSAGE_FIELD, Constants.CONFIGURE_MESSAGE)
         .put("config", jsonParser.emptyObject()
             .put("rootPath", ".")
-            .put("storage", "volatile://")
+            .put("storage", "ramdisk://")
             .put("manifest", "import '" + ASSETS_PREFIX + ROOT_MANIFEST_FILENAME + "'")
             .put("urlMap", urlMap))));
   }

--- a/particles/PipeApps/AndroidAutofill.arcs
+++ b/particles/PipeApps/AndroidAutofill.arcs
@@ -35,6 +35,6 @@ external particle CapturePerson
   people: reads writes [Person]
 
 recipe IngestPeople
-  people: create #recentPeople #shared
+  people: create #recentPeople
   CapturePerson
     people: reads writes people

--- a/src/runtime/arc-serializer.ts
+++ b/src/runtime/arc-serializer.ts
@@ -195,7 +195,6 @@ ${this.arc.activeRecipe.toString()}`;
     let id = 0;
     const importSet: Set<string> = new Set();
     const handlesToSerialize: Set<string> = new Set();
-    const contextSet = new Set(this.arc.context.stores.map(store => store.id));
     const handlesToSkip: Set<string> = new Set();
 
     for (const handle of this.arc.activeRecipe.handles) {
@@ -217,7 +216,7 @@ ${this.arc.activeRecipe.toString()}`;
 
     for (const store of this.arc._stores) {
 
-      if (Flags.useNewStorageStack || (handlesToSerialize.has(store.id) && !contextSet.has(store.id))) {
+      if (Flags.useNewStorageStack || (handlesToSerialize.has(store.id))) {
         if (handlesToSkip.has(store.id)) {
           continue;
         }

--- a/src/runtime/arc.ts
+++ b/src/runtime/arc.ts
@@ -173,10 +173,6 @@ export class Arc implements ArcInterface {
     }
 
     DriverFactory.unregister(this.volatileStorageDriverProvider);
-
-    for (const store of this._stores) {
-      this.context.unregisterStore(store.id, [...this.findStoreTags(store)]);
-    }
   }
 
   // Returns a promise that spins sending a single `AwaitIdle` message until it

--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -1374,22 +1374,12 @@ ${e.message}
 
   // TODO: This is a temporary method to allow sharing stores with other Arcs.
   registerStore(store: UnifiedStore, tags: string[]): void {
-    if (!this.findStoreById(store.id) && tags.includes('shared')) {
+    // Only register stores that have non-volatile storage key and don't have a
+    // #volatile tag.
+    if (!this.findStoreById(store.id) &&
+        !store.storageKey.toString().startsWith('volatile')
+        && !tags.includes('volatile')) {
       this._addStore(store, tags);
-    }
-  }
-
-  // Temporary method to allow sharing stores with other Arcs.
-  unregisterStore(storeId: string, tags: string[]) {
-    // #shared tag indicates that a store was made available to all arcs.
-    if (!tags.includes('shared')) {
-      return;
-    }
-    const index = this.stores.findIndex(store => store.id === storeId);
-    if (index >= 0) {
-      const store = this.stores[index];
-      this.storeTags.delete(store);
-      this.stores.splice(index, 1);
     }
   }
 

--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -1377,7 +1377,9 @@ ${e.message}
     // Only register stores that have non-volatile storage key and don't have a
     // #volatile tag.
     if (!this.findStoreById(store.id) &&
-        !store.storageKey.toString().startsWith('volatile')
+        (Flags.useNewStorageStack
+            ? (store.storageKey as StorageKey).protocol !== 'volatile'
+            : !store.storageKey.toString().startsWith('volatile'))
         && !tags.includes('volatile')) {
       this._addStore(store, tags);
     }

--- a/src/runtime/storage/storage-provider-factory.ts
+++ b/src/runtime/storage/storage-provider-factory.ts
@@ -51,7 +51,13 @@ export class StorageProviderFactory {
   }
 
   private getInstance(key: string) {
-    const instance = this._storageInstances[key.split(':')[0]];
+    let name = key.split(':')[0];
+    // HACKALERT: this is the easiest option to support ramdisk storage before
+    // storageNG migration is complete.
+    if (name === 'ramdisk') {
+      name = 'volatile';
+    }
+    const instance = this._storageInstances[name];
     if (!instance) {
       throw new Error(`unknown storage protocol: ${key}`);
     }

--- a/src/runtime/storage/volatile-storage.ts
+++ b/src/runtime/storage/volatile-storage.ts
@@ -31,19 +31,20 @@ class VolatileKey extends KeyBase {
     super();
     let parts = key.split('://');
     this.protocol = parts[0];
-    assert(this.protocol === 'volatile', `can't construct volatile key for protocol ${this.protocol} (input key ${key})`);
+    assert(this.protocol === 'volatile' || this.protocol === 'ramdisk',
+           `can't construct volatile key for protocol ${this.protocol} (input key ${key})`);
     parts = parts[1] ? parts.slice(1).join('://').split('^^') : [];
     this.arcId = parts[0];
     this.location = parts[1];
     assert(this.toString() === key, `Expected ${key}, but got ${this.toString()} volatile key base.`);
   }
 
-  base(): string { return 'volatile'; }
+  base(): string { return this.protocol; }
   get arcId(): string { return this._arcId; }
   set arcId(arcId: string) { this._arcId = arcId; }
 
   childKeyForHandle(id): VolatileKey {
-    return new VolatileKey('volatile');
+    return new VolatileKey(this.protocol);
   }
 
   childKeyForArcInfo(): VolatileKey {

--- a/src/runtime/testing/handle-for-test.ts
+++ b/src/runtime/testing/handle-for-test.ts
@@ -19,6 +19,7 @@ import {CRDTTypeRecord} from '../crdt/crdt.js';
 import {CRDTSingletonTypeRecord} from '../crdt/crdt-singleton.js';
 import {Manifest} from '../manifest.js';
 import {Entity, SerializedEntity} from '../entity.js';
+import {RamDiskStorageKey} from '../storageNG/drivers/ramdisk.js';
 import {VolatileStorageKey} from '../../runtime/storageNG/drivers/volatile.js';
 import {StorageKey} from '../../runtime/storageNG/storage-key.js';
 import {ArcId} from '../../runtime/id.js';
@@ -86,6 +87,15 @@ export function storageKeyPrefixForTest(): string|((arcId: ArcId) => StorageKey)
     return arcId => new VolatileStorageKey(arcId, '');
   }
   return 'volatile://';
+}
+export function volatileStorageKeyPrefixForTest(): string|((arcId: ArcId) => StorageKey) {
+  return storageKeyPrefixForTest();
+}
+export function ramDiskStorageKeyPrefixForTest(): string|((arcId: ArcId) => StorageKey) {
+  if (Flags.useNewStorageStack) {
+    return arcId => new RamDiskStorageKey('');
+  }
+  return 'ramdisk://';
 }
 
 export function storageKeyForTest(arcId: ArcId): string|StorageKey {

--- a/src/runtime/tests/runtime-test.ts
+++ b/src/runtime/tests/runtime-test.ts
@@ -16,6 +16,7 @@ import {Manifest} from '../manifest.js';
 import {Runtime} from '../runtime.js';
 import {FakeSlotComposer} from '../testing/fake-slot-composer.js';
 import {ArcId} from '../id.js';
+import {RamDiskStorageDriverProvider} from '../storageNG/drivers/ramdisk.js';
 import {StubLoader} from '../testing/stub-loader.js';
 import {TestVolatileMemoryProvider} from '../testing/test-volatile-memory-provider.js';
 import {ramDiskStorageKeyPrefixForTest, volatileStorageKeyPrefixForTest} from '../testing/handle-for-test.js';
@@ -77,6 +78,7 @@ describe('Runtime', () => {
   });
   it('registers and unregisters stores', async () => {
     const memoryProvider = new TestVolatileMemoryProvider();
+    RamDiskStorageDriverProvider.register(memoryProvider);
     const context = await Manifest.parse(``, {memoryProvider});
     const loader = new StubLoader({
       manifest: `

--- a/src/runtime/tests/runtime-test.ts
+++ b/src/runtime/tests/runtime-test.ts
@@ -124,7 +124,9 @@ describe('Runtime', () => {
     const recipe1 = await runtime.resolveRecipe(volatileArc1, manifest.recipes[1]);
     assert.isTrue(recipe1 && recipe1.isResolved());
     await volatileArc1.instantiate(recipe1);
+    assert.lengthOf(runtime.context.stores, 2);
     volatileArc1.dispose();
+    assert.lengthOf(runtime.context.stores, 2);
 
     volatileArc.dispose();
     assert.lengthOf(runtime.context.stores, 2);
@@ -132,10 +134,12 @@ describe('Runtime', () => {
     ramdiskArc.dispose();
     assert.lengthOf(runtime.context.stores, 2);
 
-    const volatileArc2 = runtime.runArc('test-arc-v1', volatileStorageKeyPrefixForTest());
+    const volatileArc2 = runtime.runArc('test-arc-v2', volatileStorageKeyPrefixForTest());
     const recipe2 = await runtime.resolveRecipe(volatileArc2, manifest.recipes[1]);
     assert.isTrue(recipe2 && recipe2.isResolved());
     await volatileArc2.instantiate(recipe2);
-
+    assert.lengthOf(runtime.context.stores, 2);
+    assert.isTrue(runtime.context.stores.map(s => s.storageKey).includes(
+        volatileArc2.activeRecipe.handles[0].storageKey));
   });
 });

--- a/src/runtime/tests/runtime-test.ts
+++ b/src/runtime/tests/runtime-test.ts
@@ -18,11 +18,7 @@ import {FakeSlotComposer} from '../testing/fake-slot-composer.js';
 import {ArcId} from '../id.js';
 import {StubLoader} from '../testing/stub-loader.js';
 import {TestVolatileMemoryProvider} from '../testing/test-volatile-memory-provider.js';
-<<<<<<< HEAD
-import {storageKeyPrefixForTest} from '../testing/handle-for-test.js';
-=======
 import {ramDiskStorageKeyPrefixForTest, volatileStorageKeyPrefixForTest} from '../testing/handle-for-test.js';
->>>>>>> Distinguish between 'ramdisk' and 'volatile' in runtime.ts and java code.
 
 // tslint:disable-next-line: no-any
 function unsafe<T>(value: T): any { return value; }

--- a/src/runtime/tests/runtime-test.ts
+++ b/src/runtime/tests/runtime-test.ts
@@ -97,6 +97,12 @@ describe('Runtime', () => {
             t1: writes t1
             t2: writes t2
             t3: writes t3
+        particle MyOtherParticle in './my-other-particle.js'
+          t4: reads [Thing]
+        recipe
+          t4: map #things
+          MyOtherParticle
+            t4: reads t4
       `,
       '*': 'defineParticle(({Particle}) => class extends Particle {});',
     });
@@ -114,10 +120,22 @@ describe('Runtime', () => {
     await ramdiskArc.instantiate(manifest.recipes[0]);
     assert.lengthOf(runtime.context.stores, 2);
 
+    const volatileArc1 = runtime.runArc('test-arc-v1', volatileStorageKeyPrefixForTest());
+    const recipe1 = await runtime.resolveRecipe(volatileArc1, manifest.recipes[1]);
+    assert.isTrue(recipe1 && recipe1.isResolved());
+    await volatileArc1.instantiate(recipe1);
+    volatileArc1.dispose();
+
     volatileArc.dispose();
     assert.lengthOf(runtime.context.stores, 2);
 
     ramdiskArc.dispose();
-    assert.lengthOf(runtime.context.stores, 0);
+    assert.lengthOf(runtime.context.stores, 2);
+
+    const volatileArc2 = runtime.runArc('test-arc-v1', volatileStorageKeyPrefixForTest());
+    const recipe2 = await runtime.resolveRecipe(volatileArc2, manifest.recipes[1]);
+    assert.isTrue(recipe2 && recipe2.isResolved());
+    await volatileArc2.instantiate(recipe2);
+
   });
 });

--- a/src/runtime/tests/runtime-test.ts
+++ b/src/runtime/tests/runtime-test.ts
@@ -67,12 +67,12 @@ describe('Runtime', () => {
   it('runs arcs', async () => {
     const runtime = Runtime.getRuntime();
     assert.equal(runtime.arcById.size, 0);
-    const arc = runtime.runArc('test-arc', storageKeyPrefixForTest());
+    const arc = runtime.runArc('test-arc', volatileStorageKeyPrefixForTest());
     assert.isNotNull(arc);
     assert.hasAllKeys(runtime.arcById, ['test-arc']);
-    runtime.runArc('test-arc', storageKeyPrefixForTest());
+    runtime.runArc('test-arc', volatileStorageKeyPrefixForTest());
     assert.hasAllKeys(runtime.arcById, ['test-arc']);
-    runtime.runArc('other-test-arc', storageKeyPrefixForTest());
+    runtime.runArc('other-test-arc', volatileStorageKeyPrefixForTest());
     assert.hasAllKeys(runtime.arcById, ['test-arc', 'other-test-arc']);
   });
   it('registers and unregisters stores', async () => {


### PR DESCRIPTION
and distinguish between 'ramdisk' and 'volatile' in runtime.ts and java code