### PR TITLE
Fix warning in generated kotlin files

### DIFF
--- a/src/tools/schema2kotlin.ts
+++ b/src/tools/schema2kotlin.ts
@@ -81,7 +81,7 @@ class KotlinGenerator implements ClassGenerator {
                      `  this.${fixed} = decoder.${decodeFn}`,
                      `}`);
 
-    this.encode.push(`${fixed}?.let { encoder.encode("${field}:${typeChar}", it) }`);
+    this.encode.push(`${fixed}.let { encoder.encode("${field}:${typeChar}", it) }`);
   }
 
   addReference(field: string, refName: string) {


### PR DESCRIPTION
```
warning: unnecessary safe call on a non-null receiver of type String
    value?.let { encoder.encode("value:T", it) }
```