### PR TITLE
Add missing `ws` peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,10 @@
     "webpack": "4.41.2",
     "webpack-cli": "3.3.10"
   },
+  "optionalDependencies": {
+    "bufferutil": "4.0.1",
+    "utf-8-validate": "5.0.2"
+  },
   "dependencies": {
     "@bazel/buildifier": "0.29.0",
     "@tensorflow/tfjs": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@wdio/mocha-framework": "5.16.0",
     "@wdio/spec-reporter": "5.15.2",
     "@wdio/sync": "5.16.0",
+    "bufferutil": "4.0.1",
     "c8": "4.1.5",
     "chai": "4.2.0",
     "chromedriver": "78.0.0",
@@ -74,14 +75,11 @@
     "tslint": "5.20.1",
     "type-coverage": "2.3.0",
     "typedoc": "0.15.0",
+    "utf-8-validate": "5.0.2",
     "wdio-chromedriver-service": "5.0.2",
     "webdriverio": "5.16.0",
     "webpack": "4.41.2",
     "webpack-cli": "3.3.10"
-  },
-  "optionalDependencies": {
-    "bufferutil": "4.0.1",
-    "utf-8-validate": "5.0.2"
   },
   "dependencies": {
     "@bazel/buildifier": "0.29.0",


### PR DESCRIPTION
Appveyor was complaining about these:

```
npm ERR! peer dep missing: bufferutil@^4.0.1, required by ws@7.2.1
npm ERR! peer dep missing: utf-8-validate@^5.0.2, required by ws@7.2.1
```

https://ci.appveyor.com/project/arcs/arcs-3i77k/builds/29555525

Added as dev dependencies. Instructions say to use optional deps, but we don't particularly like them. https://www.npmjs.com/package/ws/v/6.0.0#installing