### PR TITLE
Make type names optional

### DIFF
--- a/src/runtime/manifest-parser.peg
+++ b/src/runtime/manifest-parser.peg
@@ -1205,11 +1205,11 @@ RecipeSlot
   }
 
 SchemaInline
-  = names:((upperIdent / '*') whiteSpace)+ '{' whiteSpace? fields:(SchemaInlineField (',' whiteSpace? SchemaInlineField)*)? whiteSpace? '}'
+  = names:((upperIdent / '*') whiteSpace)* '{' whiteSpace? fields:(SchemaInlineField (',' whiteSpace? SchemaInlineField)*)? whiteSpace? '}'
   {
     return toAstNode<AstNode.SchemaInline>({
       kind: 'schema-inline',
-      names: optional(names, names => names.map(name => name[0]).filter(name => name !== '*'), []),
+      names: optional(names, names => names.map(name => name[0]).filter(name => name !== '*'), ['*']),
       fields: optional(fields, fields => [fields[0], ...fields[1].map(tail => tail[2])], []),
     });
   }

--- a/src/runtime/tests/manifest-parser-test.ts
+++ b/src/runtime/tests/manifest-parser-test.ts
@@ -233,6 +233,34 @@ describe('manifest parser', () => {
         optionalType: reads * {value}
     `);
   });
+  it('parses inline schemas with any name', () => {
+    parse(`
+      particle Foo
+        anonSchema: reads [* {value: Text, num: Number}]
+    `);
+    parse(`
+      particle Foo
+        union: reads * {value: (Text or Number)}
+    `);
+    parse(`
+      particle Foo
+        optionalType: reads * {value}
+    `);
+  });
+  it('parses inline schemas with no name', () => {
+    parse(`
+      particle Foo
+        anonSchema: reads [{value: Text, num: Number}]
+    `);
+    parse(`
+      particle Foo
+        union: reads {value: (Text or Number)}
+    `);
+    parse(`
+      particle Foo
+        optionalType: reads {value}
+    `);
+  });
   it('parses a schema with a bytes field', () => {
     parse(`
       schema Avatar


### PR DESCRIPTION
This removes the need for entity type's to have a name (which has lead to widespread use of '*' as an entity name).

Removing this requirement should make the type system easier to use.