### PR TITLE
Defines new arcs_kt_particles build rule

### DIFF
--- a/particles/Native/Wasm/BUILD
+++ b/particles/Native/Wasm/BUILD
@@ -1,12 +1,15 @@
 load(
     "//third_party/java/arcs/build_defs:build_defs.bzl",
     "arcs_cc_schema",
-    "arcs_kt_binary",
+    "arcs_kt_particles",
     "arcs_kt_schema",
     "arcs_manifest",
     "arcs_manifest_bundle",
 )
-load("//third_party/java/arcs/build_defs/emscripten:build_defs.bzl", "cc_wasm_binary")
+load(
+    "//third_party/java/arcs/build_defs/emscripten:build_defs.bzl",
+    "cc_wasm_binary",
+)
 
 licenses(["notice"])
 
@@ -28,12 +31,12 @@ arcs_kt_schema(
     srcs = ["Harness.arcs"],
 )
 
-arcs_kt_binary(
+arcs_kt_particles(
     name = "service_particle",
     srcs = ["source/ServiceParticle.kt"],
 )
 
-arcs_kt_binary(
+arcs_kt_particles(
     name = "test_particle",
     srcs = ["source/TestParticle.kt"],
     deps = [":wasm_schemas"],

--- a/particles/Tutorial/Kotlin/1_HelloWorld/BUILD
+++ b/particles/Tutorial/Kotlin/1_HelloWorld/BUILD
@@ -1,6 +1,8 @@
-load("//third_party/java/arcs/build_defs:build_defs.bzl", "arcs_kt_binary")
+load("//third_party/java/arcs/build_defs:build_defs.bzl", "arcs_kt_particles")
 
-arcs_kt_binary(
+licenses(["notice"])
+
+arcs_kt_particles(
     name = "HelloWorld",
     srcs = ["HelloWorld.kt"],
 )

--- a/particles/Tutorial/Kotlin/2_BasicTemplates/BUILD
+++ b/particles/Tutorial/Kotlin/2_BasicTemplates/BUILD
@@ -1,6 +1,8 @@
-load("//third_party/java/arcs/build_defs:build_defs.bzl", "arcs_kt_binary")
+load("//third_party/java/arcs/build_defs:build_defs.bzl", "arcs_kt_particles")
 
-arcs_kt_binary(
+licenses(["notice"])
+
+arcs_kt_particles(
     name = "BasicTemplate",
     srcs = ["BasicTemplate.kt"],
 )

--- a/particles/Tutorial/Kotlin/3_RenderSlots/BUILD
+++ b/particles/Tutorial/Kotlin/3_RenderSlots/BUILD
@@ -1,11 +1,8 @@
-load("//third_party/java/arcs/build_defs:build_defs.bzl", "arcs_kt_binary")
+load("//third_party/java/arcs/build_defs:build_defs.bzl", "arcs_kt_particles")
 
-arcs_kt_binary(
-    name = "ParentParticle",
-    srcs = ["ParentParticle.kt"],
-)
+licenses(["notice"])
 
-arcs_kt_binary(
-    name = "ChildParticle",
-    srcs = ["ChildParticle.kt"],
+arcs_kt_particles(
+    name = "RenderSlots",
+    srcs = glob(["*.kt"]),
 )

--- a/particles/Tutorial/Kotlin/3_RenderSlots/RenderSlots.arcs
+++ b/particles/Tutorial/Kotlin/3_RenderSlots/RenderSlots.arcs
@@ -2,7 +2,7 @@
 // Creates two particles, and renders one inside the other using render slots.
 
 // The "parent" particle. It provides a slot for another particle to be rendered inside it.
-particle ParentParticle in 'ParentParticle.wasm'
+particle ParentParticle in 'RenderSlots.wasm'
   // This particle renders to the root slot ("consumes" it), and provides a slot inside it called "mySlot" in which another particle can render
   // itself. The child particle will be rendered inside a special div with the identifier "mySlot", which this particle will need to provide in
   // its HTML.
@@ -10,7 +10,7 @@ particle ParentParticle in 'ParentParticle.wasm'
     mySlot: provides
 
 // The "child" particle. Instead of consuming "root" it consumes "mySlot", which connects it to the slot provided by ParentParticle.
-particle ChildParticle in 'ChildParticle.wasm'
+particle ChildParticle in 'RenderSlots.wasm'
   render: consumes
 
 recipe RenderSlotsRecipe

--- a/particles/Tutorial/Kotlin/4_Handles/BUILD
+++ b/particles/Tutorial/Kotlin/4_Handles/BUILD
@@ -1,4 +1,10 @@
-load("//third_party/java/arcs/build_defs:build_defs.bzl", "arcs_kt_binary", "arcs_kt_schema")
+load(
+    "//third_party/java/arcs/build_defs:build_defs.bzl",
+    "arcs_kt_particles",
+    "arcs_kt_schema",
+)
+
+licenses(["notice"])
 
 arcs_kt_schema(
     name = "handles_schemas",
@@ -6,14 +12,8 @@ arcs_kt_schema(
     package = "arcs.tutorials",
 )
 
-arcs_kt_binary(
-    name = "GetPerson",
-    srcs = ["GetPerson.kt"],
-    deps = [":handles_schemas"],
-)
-
-arcs_kt_binary(
-    name = "DisplayGreeting",
-    srcs = ["DisplayGreeting.kt"],
+arcs_kt_particles(
+    name = "Handles",
+    srcs = glob(["*.kt"]),
     deps = [":handles_schemas"],
 )

--- a/particles/Tutorial/Kotlin/4_Handles/Handles.arcs
+++ b/particles/Tutorial/Kotlin/4_Handles/Handles.arcs
@@ -1,25 +1,25 @@
-// Define a schema that allows us to store a person's name 
+// Define a schema that allows us to store a person's name
 schema Person
   name: Text
 
 // The GetPerson particle allows the user to input their name, then writes
 // the input to the Person handle.
 // This particle also provides a slot to display a greeting to the person.
-particle GetPerson in 'GetPerson.wasm'
+particle GetPerson in 'Handles.wasm'
   person: writes Person
   root: consumes
     greetingSlot: provides
 
 // The DisplayGreeting particle, takes the name passed through the Person
 // handle, and displays a greeting.
-particle DisplayGreeting in 'DisplayGreeting.wasm'
+particle DisplayGreeting in 'Handles.wasm'
   person: reads Person
   greetingSlot: consumes
 
 recipe HandleRecipe
   GetPerson
     // Pass the output person to the handle recipePerson.
-    person: writes recipePerson 
+    person: writes recipePerson
     root: consumes
       greetingSlot: provides greeting
   DisplayGreeting

--- a/particles/Tutorial/Kotlin/5_Collections/BUILD
+++ b/particles/Tutorial/Kotlin/5_Collections/BUILD
@@ -1,11 +1,17 @@
-load("//third_party/java/arcs/build_defs:build_defs.bzl", "arcs_kt_binary", "arcs_kt_schema")
+load(
+    "//third_party/java/arcs/build_defs:build_defs.bzl",
+    "arcs_kt_particles",
+    "arcs_kt_schema",
+)
+
+licenses(["notice"])
 
 arcs_kt_schema(
     name = "collections_schemas",
     srcs = ["Collections.arcs"],
 )
 
-arcs_kt_binary(
+arcs_kt_particles(
     name = "Collections",
     srcs = ["Collections.kt"],
     deps = [":collections_schemas"],

--- a/particles/Tutorial/Kotlin/6_JsonStore/BUILD
+++ b/particles/Tutorial/Kotlin/6_JsonStore/BUILD
@@ -1,4 +1,10 @@
-load("//third_party/java/arcs/build_defs:build_defs.bzl", "arcs_kt_binary", "arcs_kt_schema")
+load(
+    "//third_party/java/arcs/build_defs:build_defs.bzl",
+    "arcs_kt_particles",
+    "arcs_kt_schema",
+)
+
+licenses(["notice"])
 
 arcs_kt_schema(
     name = "store_schemas",
@@ -6,7 +12,7 @@ arcs_kt_schema(
     package = "arcs.tutorials",
 )
 
-arcs_kt_binary(
+arcs_kt_particles(
     name = "JsonStore",
     srcs = ["JsonStore.kt"],
     deps = [":store_schemas"],

--- a/particles/Tutorial/Kotlin/Demo/README.md
+++ b/particles/Tutorial/Kotlin/Demo/README.md
@@ -316,22 +316,20 @@ fun constructTTTBoard() = TTTBoard().toAddress()
 
 And finally, to build it all we need the BUILD file:
 ```BUILD
-load("//third_party/java/arcs/build_defs:build_defs.bzl", "arcs_kt_binary", "arcs_kt_schema")
+load(
+    "//third_party/java/arcs/build_defs:build_defs.bzl",
+    "arcs_kt_particles",
+    "arcs_kt_schema",
+)
 
 arcs_kt_schema(
     name = "game_schemas",
     srcs = ["TTTGame.arcs"],
 )
 
-arcs_kt_binary(
-    name = "TTTBoard",
-    srcs = ["TTTBoard.kt"],
-    deps = [":game_schemas"],
-)
-
-arcs_kt_binary(
-    name = "TTTGame",
-    srcs = ["TTTGame.kt"],
+arcs_kt_particles(
+    name = "particles",
+    srcs = glob("*.kt"),
     deps = [":game_schemas"],
 )
 ```
@@ -382,25 +380,25 @@ game!
 
 Currently you should have a tic-tac-toe board that does nothing.
 Sure, you can click it and see the Events populate, but that is
-still rather boring. Let's make it more fun by adding a human 
+still rather boring. Let's make it more fun by adding a human
 player. By now, that original design we made in the first section
 is probably not in the forefront of your mind, so we'll start by
 looking at our design diagram.
 
-![Tic Tac Toe Design](diagrams/TTT.jpg)  
+![Tic Tac Toe Design](diagrams/TTT.jpg)
 
 From this, we can see that the Human Player needs a Player and
 Move handle, and these handles connect the Game and Human Player.
 We also need to populate the information about the player, so
-we create a store. This updates our Arcs Manifest File to 
+we create a store. This updates our Arcs Manifest File to
 the one [here](https://github.com/PolymerLabs/arcs/blob/master/particles/Tutorial/Kotlin/Demo/src/pt2/TTTGame.arcs).
 
 Next, we create the human player to take the events stream and
-convert it to a move. This can be viewed in TTTHumanPlayer.kt 
+convert it to a move. This can be viewed in TTTHumanPlayer.kt
 [here](https://github.com/PolymerLabs/arcs/blob/master/particles/Tutorial/Kotlin/Demo/src/pt2/TTTHumanPlayer.kt).
 
 Next, we need to update the game particle to update the board
-based on the move. This gives us the updated TTTGame file 
+based on the move. This gives us the updated TTTGame file
 [here](https://github.com/PolymerLabs/arcs/blob/master/particles/Tutorial/Kotlin/Demo/src/pt2/TTTGame.kt).
 
 And finally, as always, we need to add the HumanPlayer to the

--- a/particles/Tutorial/Kotlin/Demo/src/pt1/BUILD
+++ b/particles/Tutorial/Kotlin/Demo/src/pt1/BUILD
@@ -1,18 +1,18 @@
-load("//third_party/java/arcs/build_defs:build_defs.bzl", "arcs_kt_binary", "arcs_kt_schema")
+load(
+    "//third_party/java/arcs/build_defs:build_defs.bzl",
+    "arcs_kt_particles",
+    "arcs_kt_schema",
+)
+
+licenses(["notice"])
 
 arcs_kt_schema(
     name = "game_schemas",
     srcs = ["TTTGame.arcs"],
 )
 
-arcs_kt_binary(
-    name = "TTTBoard",
-    srcs = ["TTTBoard.kt"],
-    deps = [":game_schemas"],
-)
-
-arcs_kt_binary(
-    name = "TTTGame",
-    srcs = ["TTTGame.kt"],
+arcs_kt_particles(
+    name = "particles",
+    srcs = glob(["*.kt"]),
     deps = [":game_schemas"],
 )

--- a/particles/Tutorial/Kotlin/Demo/src/pt1/TTTGame.arcs
+++ b/particles/Tutorial/Kotlin/Demo/src/pt1/TTTGame.arcs
@@ -11,12 +11,12 @@ schema Event
   time: Number
 
 
-particle TTTBoard in 'TTTBoard.wasm'
+particle TTTBoard in 'particles.wasm'
   events: writes [Event]
   gameState: reads GameState
   boardSlot: consumes
 
-particle TTTGame in 'TTTGame.wasm'
+particle TTTGame in 'particles.wasm'
   gameState: reads writes GameState
   events: reads writes [Event]
   root: consumes

--- a/particles/Tutorial/Kotlin/Demo/src/pt2/BUILD
+++ b/particles/Tutorial/Kotlin/Demo/src/pt2/BUILD
@@ -1,24 +1,18 @@
-load("//third_party/java/arcs/build_defs:build_defs.bzl", "arcs_kt_binary", "arcs_kt_schema")
+load(
+    "//third_party/java/arcs/build_defs:build_defs.bzl",
+    "arcs_kt_particles",
+    "arcs_kt_schema",
+)
+
+licenses(["notice"])
 
 arcs_kt_schema(
     name = "game_schemas",
     srcs = ["TTTGame.arcs"],
 )
 
-arcs_kt_binary(
-    name = "TTTBoard",
-    srcs = ["TTTBoard.kt"],
-    deps = [":game_schemas"],
-)
-
-arcs_kt_binary(
-    name = "TTTGame",
-    srcs = ["TTTGame.kt"],
-    deps = [":game_schemas"],
-)
-
-arcs_kt_binary(
-    name = "TTTHumanPlayer",
-    srcs = ["TTTHumanPlayer.kt"],
+arcs_kt_particles(
+    name = "particles",
+    srcs = glob(["*.kt"]),
     deps = [":game_schemas"],
 )

--- a/particles/Tutorial/Kotlin/Demo/src/pt2/TTTGame.arcs
+++ b/particles/Tutorial/Kotlin/Demo/src/pt2/TTTGame.arcs
@@ -24,12 +24,12 @@ resource HumanDefault
 
 store HumanStore of Person in HumanDefault
 
-particle TTTBoard in 'TTTBoard.wasm'
+particle TTTBoard in 'particles.wasm'
   events: writes [Event]
   gameState: reads GameState
   boardSlot: consumes
 
-particle TTTGame in 'TTTGame.wasm'
+particle TTTGame in 'particles.wasm'
   gameState: reads writes GameState
   playerOne: reads writes Person
   playerOneMove: reads writes Move
@@ -37,7 +37,7 @@ particle TTTGame in 'TTTGame.wasm'
   root: consumes
     boardSlot: provides
 
-particle TTTHumanPlayer in 'TTTHumanPlayer.wasm'
+particle TTTHumanPlayer in 'particles.wasm'
   gameState: reads GameState
   events: reads [Event]
   player: reads Person

--- a/particles/Tutorial/Kotlin/Demo/src/pt3/BUILD
+++ b/particles/Tutorial/Kotlin/Demo/src/pt3/BUILD
@@ -1,30 +1,17 @@
-load("//third_party/java/arcs/build_defs:build_defs.bzl", "arcs_kt_binary", "arcs_kt_schema")
+load(
+    "//third_party/java/arcs/build_defs:build_defs.bzl",
+    "arcs_kt_particles",
+    "arcs_kt_schema",
+)
 
 arcs_kt_schema(
     name = "game_schemas",
     srcs = ["TTTGame.arcs"],
 )
 
-arcs_kt_binary(
-    name = "TTTBoard",
-    srcs = ["TTTBoard.kt"],
+arcs_kt_particles(
+    name = "particles",
+    srcs = glob(["*.kt"]),
     deps = [":game_schemas"],
 )
 
-arcs_kt_binary(
-    name = "TTTGame",
-    srcs = ["TTTGame.kt"],
-    deps = [":game_schemas"],
-)
-
-arcs_kt_binary(
-    name = "TTTHumanPlayer",
-    srcs = ["TTTHumanPlayer.kt"],
-    deps = [":game_schemas"],
-)
-
-arcs_kt_binary(
-    name = "TTTRandomComputer",
-    srcs = ["TTTRandomComputer.kt"],
-    deps = [":game_schemas"],
-)

--- a/particles/Tutorial/Kotlin/Demo/src/pt3/BUILD
+++ b/particles/Tutorial/Kotlin/Demo/src/pt3/BUILD
@@ -14,4 +14,3 @@ arcs_kt_particles(
     srcs = glob(["*.kt"]),
     deps = [":game_schemas"],
 )
-

--- a/particles/Tutorial/Kotlin/Demo/src/pt3/TTTGame.arcs
+++ b/particles/Tutorial/Kotlin/Demo/src/pt3/TTTGame.arcs
@@ -33,12 +33,12 @@ resource HumanDefault
 store ComputerStore of Person in ComputerDefault
 store HumanStore of Person in HumanDefault
 
-particle TTTBoard in 'TTTBoard.wasm'
+particle TTTBoard in 'particles.wasm'
   events: writes [Event]
   gameState: reads GameState
   boardSlot: consumes
 
-particle TTTGame in 'TTTGame.wasm'
+particle TTTGame in 'particles.wasm'
   gameState: reads writes GameState
   playerOne: reads writes Person
   playerOneMove: reads writes Move
@@ -48,13 +48,13 @@ particle TTTGame in 'TTTGame.wasm'
   root: consumes
     boardSlot: provides
 
-particle TTTHumanPlayer in 'TTTHumanPlayer.wasm'
+particle TTTHumanPlayer in 'particles.wasm'
   gameState: reads GameState
   events: reads [Event]
   player: reads Person
   myMove: writes Move
 
-particle TTTRandomComputer in 'TTTRandomComputer.wasm'
+particle TTTRandomComputer in 'particles.wasm'
   gameState: reads GameState
   player: reads Person
   myMove: writes Move

--- a/particles/Tutorial/Kotlin/Demo/src/total/BUILD
+++ b/particles/Tutorial/Kotlin/Demo/src/total/BUILD
@@ -1,30 +1,18 @@
-load("//third_party/java/arcs/build_defs:build_defs.bzl", "arcs_kt_binary", "arcs_kt_schema")
+load(
+    "//third_party/java/arcs/build_defs:build_defs.bzl",
+    "arcs_kt_particles",
+    "arcs_kt_schema",
+)
+
+licenses(["notice"])
 
 arcs_kt_schema(
     name = "game_schemas",
     srcs = ["TTTGame.arcs"],
 )
 
-arcs_kt_binary(
-    name = "TTTBoard",
-    srcs = ["TTTBoard.kt"],
-    deps = [":game_schemas"],
-)
-
-arcs_kt_binary(
-    name = "TTTGame",
-    srcs = ["TTTGame.kt"],
-    deps = [":game_schemas"],
-)
-
-arcs_kt_binary(
-    name = "TTTHumanPlayer",
-    srcs = ["TTTHumanPlayer.kt"],
-    deps = [":game_schemas"],
-)
-
-arcs_kt_binary(
-    name = "TTTRandomComputer",
-    srcs = ["TTTRandomComputer.kt"],
+arcs_kt_particles(
+    name = "particles",
+    srcs = glob(["*.kt"]),
     deps = [":game_schemas"],
 )

--- a/particles/Tutorial/Kotlin/Demo/src/total/TTTGame.arcs
+++ b/particles/Tutorial/Kotlin/Demo/src/total/TTTGame.arcs
@@ -65,12 +65,12 @@ store HumanStore of Person in HumanDefault
 store HumanOneStore of Person in FirstHuman
 store HumanTwoStore of Person in SecondHuman
 
-particle TTTBoard in 'TTTBoard.wasm'
+particle TTTBoard in 'particles.wasm'
   events: writes [Event]
   gameState: reads GameState
   boardSlot: consumes
 
-particle TTTGame in 'TTTGame.wasm'
+particle TTTGame in 'particles.wasm'
   gameState: reads writes GameState
   playerOne: reads writes Person
   playerOneMove: reads writes Move
@@ -80,13 +80,13 @@ particle TTTGame in 'TTTGame.wasm'
   root: consumes
     boardSlot: provides
 
-particle TTTHumanPlayer in 'TTTHumanPlayer.wasm'
+particle TTTHumanPlayer in 'particles.wasm'
   gameState: reads GameState
   events: reads [Event]
   player: reads Person
   myMove: writes Move
 
-particle TTTRandomComputer in 'TTTRandomComputer.wasm'
+particle TTTRandomComputer in 'particles.wasm'
   gameState: reads GameState
   player: reads Person
   myMove: writes Move

--- a/particles/Tutorial/Kotlin/README.md
+++ b/particles/Tutorial/Kotlin/README.md
@@ -62,10 +62,10 @@ Finally, we need a 'BUILD' file. Arcs particles can be built using Bazel rules. 
 
 ```BUILD
 // Required imports
-load("//build_defs:build_defs.bzl", "arcs_kt_binary")
+load("//build_defs:build_defs.bzl", "arcs_kt_particles")
 
 // Arcs Kotlin particle build rule
-arcs_kt_binary(
+arcs_kt_particles(
     name = "HelloWorld",
     srcs = ["HelloWorld.kt"],
 )
@@ -127,9 +127,9 @@ fun constructBasicTemplateParticle() = BasicTemplateParticle().toAddress()
 
 Finally, the Bazel BUILD file, which looks nearly identical to the one we used in the hello world program.
 ```
-load("//build_defs:build_defs.bzl", "arcs_kt_binary")
+load("//build_defs:build_defs.bzl", "arcs_kt_particles")
 
-arcs_kt_binary(
+arcs_kt_particles(
     name = "BasicTemplate",
     srcs = ["BasicTemplate.kt"],
 )
@@ -150,7 +150,7 @@ This all is a bit theoretical, so let's get to an example. To show how particles
 As usual, we start with the Arcs manifest file:
 ```
 // The "parent" particle. It provides a slot for another particle to be rendered inside it.
-particle ParentParticle in 'ParentParticle.wasm'
+particle ParentParticle in 'particles.wasm'
   // This particle renders to the root slot ("consumes" it), and provides a slot inside it called
   // "mySlot" in which another particle can render itself. The child particle will be rendered inside
   // a special div with the identifier "mySlot", which this particle will need to provide in its HTML.
@@ -159,7 +159,7 @@ particle ParentParticle in 'ParentParticle.wasm'
 
 // The "child" particle. Instead of consuming "root" it consumes "mySlot", which connects it to the
 // slot provided by ParentParticle.
-particle ChildParticle in 'ChildParticle.wasm'
+particle ChildParticle in 'particles.wasm'
   render: consumes
 
 recipe RenderSlotsRecipe
@@ -212,18 +212,15 @@ fun _newChildParticle() = ChildParticle().toAddress()
 
 And finally the BUILD file, which is the same as in the previous tutorials, but has a second rule.
 ```
-load("//third_party/java/arcs/build_defs:build_defs.bzl", "arcs_kt_binary")
+load("//third_party/java/arcs/build_defs:build_defs.bzl", "arcs_kt_particles")
 
-arcs_kt_binary(
-    name = "ParentParticle",
-    srcs = ["ParentParticle.kt"],
+arcs_kt_particles(
+    name = "particles",
+    srcs = [
+        "ParentParticle.kt",
+        "ChildParticle.kt",
+    ],
 )
-
-arcs_kt_binary(
-    name = "ChildParticle",
-    srcs = ["ChildParticle.kt"],
-)
-
 ```
 
 And there you have it! The mystery of root solved, and a basic understanding of slots. Slots are a large part of the power of Arcs to hide user data, so we'll be using them a lot going forward. So don't worry if you don't fully understand them yet, there will plenty more examples to come!
@@ -255,14 +252,14 @@ schema Person
 // The GetPerson particle allows the user to input their name, then writes
 // the input to the Person handle.
 // This particle also provides a slot to display a greeting to the person.
-particle GetPerson in 'GetPerson.wasm'
+particle GetPerson in 'particles.wasm'
   person: writes Person
   root: consumes
     greetingSlot: provides
 
 // The DisplayGreeting particle, takes the name passed through the Person
 // handle, and displays a greeting.
-particle DisplayGreeting in 'DisplayGreeting.wasm'
+particle DisplayGreeting in 'particles.wasm'
   person: reads Person
   greetingSlot: consumes
 
@@ -362,7 +359,7 @@ And finally, the BUILD file. Note the `arcs_kt_schema` rule which will generate 
 '$ParticleName_EntityName'. This is why `DisplayGreeting.kt` referenced `GetPerson_Person()` while `DisplayGreeting.kt`
 referenced `DisplayGreeting_Person()`.
 ```build
-load("//third_party/java/arcs/build_defs:build_defs.bzl", "arcs_kt_binary", "arcs_kt_schema")
+load("//third_party/java/arcs/build_defs:build_defs.bzl", "arcs_kt_particles", "arcs_kt_schema")
 
 arcs_kt_schema(
     name = "handles_schemas",
@@ -370,15 +367,12 @@ arcs_kt_schema(
     package = "arcs.tutorials",
 )
 
-arcs_kt_binary(
-    name = "GetPerson",
-    srcs = ["GetPerson.kt"],
-    deps = [":handles_schemas"],
-)
-
-arcs_kt_binary(
-    name = "DisplayGreeting",
-    srcs = ["DisplayGreeting.kt"],
+arcs_kt_particles(
+    name = "particles",
+    srcs = [
+        "GetPerson.kt",
+        "DisplayGreeting.kt",
+    ],
     deps = [":handles_schemas"],
 )
 ```
@@ -494,14 +488,14 @@ fun constructCollectionsParticle(): Address = CollectionsParticle().toAddress()
 
 And the BUILD file:
 ```build
-load("//third_party/java/arcs/build_defs:build_defs.bzl", "arcs_kt_binary", "arcs_kt_schema")
+load("//third_party/java/arcs/build_defs:build_defs.bzl", "arcs_kt_particles", "arcs_kt_schema")
 
 arcs_kt_schema(
     name = "collections_schemas",
     srcs = ["Collections.arcs"],
 )
 
-arcs_kt_binary(
+arcs_kt_particles(
     name = "Collections",
     srcs = ["Collections.kt"],
     deps = [":collections_schemas"],

--- a/src/wasm/kotlin/README.md
+++ b/src/wasm/kotlin/README.md
@@ -1,8 +1,8 @@
 # Kotlin --> Wasm particles
 
-## Setup 
+## Setup
 
-Our code is built by Bazel. It uses Kotlin Mutliplatform to target JVM and Wasm 
+Our code is built by Bazel. It uses Kotlin Mutliplatform to target JVM and Wasm
 runtimes. Bazel must be installed to build and run the code and tests, which
 reside in `src/wasm/`.
 
@@ -13,7 +13,7 @@ reside in `src/wasm/`.
 See [here](../../../particles/Native/Wasm) or [here](../../../particles/Tutorial/Kotlin) for working examples.
 
 - Add a `BUILD` file in the relevant directory
-- Generate Kotlin Data Classes from your particle spec using the 
+- Generate Kotlin Data Classes from your particle spec using the
   `arcs_kt_schema` build rule:
   ```
   arcs_kt_schema(
@@ -26,27 +26,28 @@ See [here](../../../particles/Native/Wasm) or [here](../../../particles/Tutorial
   )
   ```
 - Write your Kotlin particle(s): See [the Kotlin tutorial](../../../particles/Tutorial/Kotlin) for greater detail.
-- To target both Wasm and the JVM, add `arcs_kt_library` and `arcs_kt_binary` to the `BUILD` file.
+- To target both Wasm and the JVM, add `arcs_kt_particles` to the `BUILD` file.
   ```
+  # This library is optional, you might not need one if you only have particle files.
   arcs_kt_library(
       # Name of the BUILD rule (tell Bazel to build this particle using this name).
-      name = "example_particle-lib",
+      name = "example_lib",
       # Input Kotlin particle source files to compile.
-      srcs = ["Example.kt"],
-      # Specify the Bazel rule visibility 
+      srcs = ["MyLib.kt"],
+      # Specify the Bazel rule visibility
       visibility = ["//visibility:public"],
       # Other Kotlin dependencies this library depends on (for example, the generated schemas).
       deps = [":example_schema"],
   )
-  
-  arcs_kt_binary(
-      name = "example_particle", 
-      # Specify other sources to compile (optional)
-      srcs = [], 
-      # Specify the Bazel rule visibility 
+
+  arcs_kt_particles(
+      name = "example_particles",
+      # Specify Kotlin particle srcs.
+      srcs = ["MyParticle.kt"],
+      # Specify the Bazel rule visibility
       visibility = ["//visibility:public"],
       # Other Kotlin dependencies this binary depends on (for example, the compiled library).
-      deps = [":example_particle-lib"],
+      deps = [":example_lib"],
   )
   ```
 - Build your particle using Bazel: `bazel build //particles/path/to/BUILD/file:example_particle`.

--- a/src/wasm/kotlin/javatests/arcs/BUILD
+++ b/src/wasm/kotlin/javatests/arcs/BUILD
@@ -14,7 +14,19 @@ arcs_kt_schema(
 
 arcs_kt_particles(
     name = "test-module",
-    srcs = glob(["*.kt"]),
+    srcs = glob(
+        ["*.kt"],
+        exclude = ["TestBase.kt"],
+    ),
     visibility = ["//visibility:public"],
+    deps = [
+        ":TestBase-lib",
+        ":schemas",
+    ],
+)
+
+arcs_kt_particles(
+    name = "TestBase",
+    srcs = ["TestBase.kt"],
     deps = [":schemas"],
 )

--- a/src/wasm/kotlin/javatests/arcs/BUILD
+++ b/src/wasm/kotlin/javatests/arcs/BUILD
@@ -1,4 +1,8 @@
-load("//third_party/java/arcs/build_defs:build_defs.bzl", "arcs_kt_binary", "arcs_kt_schema")
+load(
+    "//third_party/java/arcs/build_defs:build_defs.bzl",
+    "arcs_kt_particles",
+    "arcs_kt_schema",
+)
 
 licenses(["notice"])
 
@@ -8,7 +12,7 @@ arcs_kt_schema(
     package = "sdk.kotlin.javatests.arcs",
 )
 
-arcs_kt_binary(
+arcs_kt_particles(
     name = "test-module",
     srcs = glob(["*.kt"]),
     visibility = ["//visibility:public"],

--- a/third_party/bazel_rules/rules_kotlin/kotlin/native/wasm.bzl
+++ b/third_party/bazel_rules/rules_kotlin/kotlin/native/wasm.bzl
@@ -1,10 +1,10 @@
 # Alias wasm split transition rule unless G3 Kotlin Native synced with GH rules
-def wasm_kt_binary(name, kt_target):
+def wasm_kt_binary(name, kt_target, visibility = None):
     native.genrule(
         name = name,
         srcs = [kt_target + ".wasm", kt_target + ".wasm.js"],
         cmd = "cp $(location %s.wasm) $(@D)/%s.wasm; cp $(location %s.wasm.js) $(@D)/%s.wasm.js" % (kt_target, name, kt_target, name),
         outs = ["%s.wasm" % name, "%s.wasm.js" % name],
         tools = [kt_target],
-        visibility = ["//visibility:public"],
+        visibility = visibility,
     )

--- a/third_party/java/arcs/build_defs/build_defs.bzl
+++ b/third_party/java/arcs/build_defs/build_defs.bzl
@@ -3,10 +3,10 @@
 load(
     "//third_party/java/arcs/build_defs/internal:kotlin.bzl",
     _arcs_kt_android_test_suite = "arcs_kt_android_test_suite",
-    _arcs_kt_binary = "arcs_kt_binary",
     _arcs_kt_jvm_library = "arcs_kt_jvm_library",
     _arcs_kt_jvm_test_suite = "arcs_kt_jvm_test_suite",
     _arcs_kt_library = "arcs_kt_library",
+    _arcs_kt_particles = "arcs_kt_particles",
     _kt_jvm_and_js_library = "kt_jvm_and_js_library",
 )
 load(
@@ -33,7 +33,7 @@ arcs_kt_schema = _arcs_kt_schema
 
 arcs_kt_library = _arcs_kt_library
 
-arcs_kt_binary = _arcs_kt_binary
+arcs_kt_particles = _arcs_kt_particles
 
 arcs_manifest = _arcs_manifest
 

--- a/third_party/java/arcs/build_defs/internal/kotlin.bzl
+++ b/third_party/java/arcs/build_defs/internal/kotlin.bzl
@@ -54,7 +54,7 @@ def arcs_kt_particles(name, srcs = [], deps = [], visibility = None):
         if not src.endswith(".kt"):
             fail("%s is not a Kotlin file (must end in .kt)" % src)
         particle = src[:-3]
-        wasm_lib = particle + _WASM_SUFFIX + "-lib"
+        wasm_lib = particle + "-lib" + _WASM_SUFFIX
         kt_native_library(
             name = wasm_lib,
             srcs = [src],


### PR DESCRIPTION
This replaces arcs_kt_binary.

There are two main advantages for using this rule instead of
arcs_kt_binary:
1. You can bundles lots of particles together into the one wasm binary
   (technically you could do this before using arcs_kt_binary, but we
   weren't)
2. It will let us do interesting things when compiling particles (e.g.
   generate wasm bindings, etc.)