### PR TITLE
Break cycle between Manifest and Runtime for RamDisk.

### DIFF
--- a/src/runtime/ram-disk-memory-provider.ts
+++ b/src/runtime/ram-disk-memory-provider.ts
@@ -1,0 +1,15 @@
+/**
+ * @license
+ * Copyright (c) 2019 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {VolatileMemory} from './storageNG/drivers/volatile.js';
+
+export interface RamDiskMemoryProvider {
+  getRamDiskMemory(): VolatileMemory;
+}

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -16,6 +16,7 @@ import {UnifiedStore} from './storageNG/unified-store.js';
 import {RuntimeCacheService} from './runtime-cache.js';
 import {IdGenerator, ArcId} from './id.js';
 import {PecFactory} from './particle-execution-context.js';
+import {RamDiskMemoryProvider} from './ram-disk-memory-provider.js';
 import {SlotComposer} from './slot-composer.js';
 import {UiSlotComposer} from './ui-slot-composer.js';
 import {StorageProviderFactory} from './storage/storage-provider-factory.js';
@@ -56,7 +57,7 @@ let runtime: Runtime | null = null;
 // To start with, this class will simply hide the runtime classes that are
 // currently imported by ArcsLib.js. Once that refactoring is done, we can
 // think about what the api should actually look like.
-export class Runtime {
+export class Runtime implements RamDiskMemoryProvider {
   public context: Manifest;
   public readonly pecFactory: PecFactory;
   private cacheService: RuntimeCacheService;

--- a/src/runtime/storageNG/drivers/ramdisk.ts
+++ b/src/runtime/storageNG/drivers/ramdisk.ts
@@ -58,6 +58,8 @@ export class RamDiskStorageDriverProvider implements StorageDriverProvider {
     }
 
     // Use a VolatileDriver backed by the Runtime's RamDisk memory instance.
+    // TODO(wkorman): Pass in the RamDiskMemoryProvider rather than grabbing
+    // from Runtime directly.
     const memory = Runtime.getRuntime().getRamDiskMemory();
     return new VolatileDriver<Data>(storageKey as RamDiskStorageKey, exists, memory);
   }

--- a/src/runtime/tests/manifest-test.ts
+++ b/src/runtime/tests/manifest-test.ts
@@ -30,6 +30,16 @@ import {RamDiskStorageKey, RamDiskStorageDriverProvider} from '../storageNG/driv
 import {digest} from '../../platform/digest-web.js';
 import {DriverFactory} from '../storageNG/drivers/driver-factory.js';
 import {RefinementExpression, BinaryExpressionNode} from '../manifest-ast-nodes.js';
+import {RamDiskMemoryProvider} from '../ram-disk-memory-provider.js';
+import {VolatileMemory} from '../storageNG/drivers/volatile.js';
+
+class RamDiskMemoryImpl implements RamDiskMemoryProvider {
+  private readonly ramDiskMemory: VolatileMemory = new VolatileMemory();
+
+  getRamDiskMemory(): VolatileMemory {
+    return this.ramDiskMemory;
+  }
+}
 
 function verifyPrimitiveType(field, type) {
   const copy = {...field};
@@ -3133,7 +3143,7 @@ resource NobIdJson
     },
     "locations": {}
   }
-`);
+`, {ramDiskMemoryProvider: new RamDiskMemoryImpl()});
     assert.lengthOf(manifest.stores, 1);
     const store = manifest.stores[0];
 


### PR DESCRIPTION
We still see the same number of cycles, but they've changed
to be more granular rather than "manifest > runtime".

I believe we'll need to jockey actual Runtime instance, or
sub-instances (ex. cache providers) to various other portions of the
code base in order to fully resolve cycles.

Part of https://github.com/PolymerLabs/arcs/issues/1878

And see https://github.com/PolymerLabs/arcs/pull/4310 for an early preview of further work which actually reduces the cycle count (needs more work particularly on jockeying cache service into storageNG).