### PR TITLE
Temporarily restore firebase at top level to fix Wasm tests.

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "assert": "1.5.0",
     "circular-dependency-plugin": "5.2.0",
     "esm": "3.2.25",
+    "firebase": "6.0.4",
     "idb": "2.1.3",
     "jsrsasign": "8.0.12",
     "jsrsasign-util": "1.0.0",


### PR DESCRIPTION
Partially undoes the overall goal of #4277 but it's less
impactful than a full revert.

Part of #4287 but refraining from calling it a fix as we need
to investigate and remove firebase again once we figure out how
to fix the tests without it present at top level.