### PR TITLE
Setting flags via command line flags

### DIFF
--- a/src/runtime/flags.ts
+++ b/src/runtime/flags.ts
@@ -19,7 +19,10 @@ class FlagDefaults {
 export class Flags extends FlagDefaults {
   /** Resets flags. To be called in test teardown methods. */
   static reset() {
+    // Use the defaults
     Object.assign(Flags, FlagDefaults);
+    // Overwrite the defaults with the testFlags.
+    Object.assign(Flags, global['testFlags']);
   }
 
   // tslint:disable-next-line: no-any
@@ -37,7 +40,7 @@ export class Flags extends FlagDefaults {
   static withFlags<T, Args extends any[]>(flagsSettings: Partial<typeof FlagDefaults>, f: (...args: Args) => Promise<T>): (...args: Args) => Promise<T> {
     return async (...args) => {
       Object.assign(Flags, flagsSettings);
-      let res;
+      let res: T;
       try {
         res = await f(...args);
       } finally {

--- a/src/runtime/flags.ts
+++ b/src/runtime/flags.ts
@@ -8,8 +8,17 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-/** Arcs runtime flags. */
-
+/* Arcs runtime flags.
+ * These can be set via command line arguments and are generally for introducing
+ * incrementally introducing potentially breaking changes (e.g. adding/removing
+ * features).
+ *
+ * Example:
+ * To run all test, but use the new storage stack, use the following command:
+ * sigh test --useNewStorageStack=true
+ *
+ * Note: This does not override flag values set explicitly for a test.
+ */
 class FlagDefaults {
   static useNewStorageStack = false;
   static enforceRefinements = false;

--- a/src/runtime/flags.ts
+++ b/src/runtime/flags.ts
@@ -31,7 +31,9 @@ export class Flags extends FlagDefaults {
     // Use the defaults
     Object.assign(Flags, FlagDefaults);
     // Overwrite the defaults with the testFlags.
-    Object.assign(Flags, global['testFlags']);
+    if (typeof global !== 'undefined') {
+      Object.assign(Flags, global['testFlags']);
+    }
   }
 
   // tslint:disable-next-line: no-any

--- a/src/runtime/flags.ts
+++ b/src/runtime/flags.ts
@@ -9,7 +9,7 @@
  */
 
 /* Arcs runtime flags.
- * These can be set via command line arguments and are generally for introducing
+ * These can be set via command line arguments and are generally for
  * incrementally introducing potentially breaking changes (e.g. adding/removing
  * features).
  *

--- a/tools/sigh.ts
+++ b/tools/sigh.ts
@@ -1074,11 +1074,14 @@ async function runSteps(command: string, args: string[]): Promise<boolean> {
     boolean: ['install'],
   })};
   for (const key in globalOptions) {
-    const value = globalOptions[key];
-    if (value === 'true') {
-      globalOptions[key] = true;
-    } else if (value === 'false') {
-      globalOptions[key] = false;
+    if (globalOptions.hasOwnProperty(key)) {
+      let value = globalOptions[key];
+      if (value === 'true') {
+        value = true;
+      } else if (value === 'false') {
+        value = false;
+      }
+      globalOptions[key] = value;
     }
   }
 

--- a/tools/sigh.ts
+++ b/tools/sigh.ts
@@ -1074,6 +1074,8 @@ async function runSteps(command: string, args: string[]): Promise<boolean> {
     boolean: ['install'],
   })};
   for (const key in globalOptions) {
+    // This converts command line arguments that should be interpreted as booleans.
+    // This is to avoid accidentally interpreting 'false' as a truthy value.
     if (globalOptions.hasOwnProperty(key)) {
       let value = globalOptions[key];
       if (value === 'true') {

--- a/tools/sigh.ts
+++ b/tools/sigh.ts
@@ -68,7 +68,7 @@ const webpackLS = webpackPkg('webpack-languageserver');
 const steps: {[index: string]: ((args?: string[]) => boolean|Promise<boolean>)[]} = {
   peg: [peg, railroad],
   test: [peg, build, runTestsOrHealthOnCron],
-  testShells: [peg, build, webpack, devServerAsync, testWdioShells],
+  testShells: [peg, build, webpack, webpackStorage, devServerAsync, testWdioShells],
   testWdioShells: [testWdioShells],
   webpack: [peg, build, webpack],
   webpackStorage: [webpackStorage],

--- a/tools/sigh.ts
+++ b/tools/sigh.ts
@@ -25,9 +25,13 @@ const _DO_NOT_USE_spawn = require('child_process').spawn;
 const projectRoot = path.resolve(__dirname, '..');
 process.chdir(projectRoot);
 
+// Flags for sigh and unit tests; use `global['testFlags'].foo` to access them.
 let globalOptions = {
   install: false,
+  /** If true, runs tests with some warning messages suppressed. */
   quiet: false,
+  /** If true, runs tests flagged as bazel tests. */
+  bazel: false,
 };
 
 const sources = {
@@ -128,14 +132,6 @@ const nodeFlags = [
 
 // The 'cron' env type indicates the daily build in Travis.
 const isTravisDaily = (process.env.TRAVIS_EVENT_TYPE === 'cron');
-
-// Flags for unit tests; use `global['testFlags'].foo` to access them.
-const testFlags = {
-  /** If true, runs tests flagged as bazel tests. */
-  bazel: false,
-  /** If true, runs tests with some warning messages suppressed. */
-  quiet: false,
-};
 
 /** Logs to console.log, unless suppressed by the global --quiet flag. */
 function sighLog(message, ...optionalParams) {
@@ -668,9 +664,8 @@ function runTests(args: string[]): boolean {
     // Enables unit tests that are marked as requiring bazel. These tests are
     // usually skipped; they should generally only be supplied by bazel when it
     // invokes sigh directly.
-    testFlags.bazel = true;
+    globalOptions.bazel = true;
   }
-  testFlags.quiet = globalOptions.quiet;
 
   const testsInDir = dir => findProjectFiles(dir, buildExclude, fullPath => {
     // TODO(wkorman): Integrate shell testing more deeply into sigh testing. For
@@ -753,7 +748,7 @@ function runTests(args: string[]): boolean {
       (async () => {
         ${options.explore ? 'await DevtoolsConnection.onceConnected;' : ''}
         // Mocha doesn't have any way to pass custom flags into tests.
-        global.testFlags = ${JSON.stringify(testFlags)};
+        global.testFlags = ${JSON.stringify(globalOptions)};
         let runner = mocha
             .grep(${JSON.stringify(options.grep || '')})
             .run(function(failures) {
@@ -1078,6 +1073,14 @@ async function runSteps(command: string, args: string[]): Promise<boolean> {
   globalOptions = {...globalOptions, ...minimist(args, {
     boolean: ['install'],
   })};
+  for (const key in globalOptions) {
+    const value = globalOptions[key];
+    if (value === 'true') {
+      globalOptions[key] = true;
+    } else if (value === 'false') {
+      globalOptions[key] = false;
+    }
+  }
 
   sighLog(`😌 ${command}`);
   let result = false;


### PR DESCRIPTION
This makes it possible to quickly set the Flags object via the sigh command line flags.

It also merges the testFlags and sigh's globalOptions (to reduce the complexity of having three different flag systems). 