### PR TITLE
Making concrete-storage node_modules visible at blaze/bazel sigh_command.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -28,6 +28,20 @@ filegroup(
     ),
 )
 
+# concrete-storage/node_modules
+filegroup(
+    name = "concrete_storage_node_modules",
+    srcs = glob(
+        ["concrete-storage/node_modules/**/*"],
+        exclude = [
+            "concrete-storage/node_modules/test/**",
+            "concrete-storage/node_modules/docs/**",
+            "concrete-storage/node_modules/**/* */**",
+            "concrete-storage/node_modules/**/* *",
+        ],
+    ),
+)
+
 filegroup(
     name = "all_srcs",
     # NOTE: This glob doesn't include files in directories which have their own

--- a/third_party/java/arcs/build_defs/sigh.bzl
+++ b/third_party/java/arcs/build_defs/sigh.bzl
@@ -55,6 +55,7 @@ def sigh_command(
         tags = EXECUTION_REQUIREMENTS_TAGS,
         deps = [
             "//:all_srcs",
+            "//:concrete_storage_node_modules",
             "//:node_modules",
             "//tools:sigh_bin",
             "//tools:tools_srcs",


### PR DESCRIPTION
Travis tests are broken with the error: module firebase/{app, storage, database} not found.
The same tests can pass with plain ./tools/sigh test xxx
ex.,
[PASSED] ./tools/sigh test --file src/wasm/tests/wasm-api-test.ts
[FAILED] bazel test //src/wasm/tests:all

The bazel variant actually run the same command as the passed one via sigh_command skylark rule.
The root cause is: the firebase package is removed at #4277 from root package.json/node_modules and added to a secondary package.json/node_modules at concrete-storage ends up during execution of sigh_command via bazel/blaze, all concrete-storage/node_modules/**/* is invisible to the sigh_command.

Add a new dep to concrete-storage/node_modules/**/* for sigh_command to ensure all node_modules at root and sub-directories are visible during executing sigh_command.

All newly-added sub node_modules need to add their dependencies to the sigh_command rule in the future if any.