### PR TITLE
Update tests to work under StorageNG with new memory provisioning.

### DIFF
--- a/src/dataflow/analysis/testing/flow-graph-testing.ts
+++ b/src/dataflow/analysis/testing/flow-graph-testing.ts
@@ -13,10 +13,12 @@ import {Manifest} from '../../../runtime/manifest.js';
 import {FlowGraph} from '../flow-graph.js';
 import {CheckCondition} from '../../../runtime/particle-check.js';
 import {Edge, Node, FlowModifier} from '../graph-internals.js';
+import {TestVolatileMemoryProvider} from '../../../runtime/testing/test-volatile-memory-provider.js';
 
 /** Constructs a FlowGraph from the recipe in the given manifest. */
 export async function buildFlowGraph(manifestContent: string): Promise<FlowGraph> {
-  const manifest = await Manifest.parse(manifestContent);
+  const memoryProvider = new TestVolatileMemoryProvider();
+  const manifest = await Manifest.parse(manifestContent, {memoryProvider});
   assert.lengthOf(manifest.recipes, 1);
   const recipe = manifest.recipes[0];
   assert(recipe.normalize(), 'Failed to normalize recipe.');

--- a/src/planning/plan/tests/plan-consumer-test.ts
+++ b/src/planning/plan/tests/plan-consumer-test.ts
@@ -23,6 +23,8 @@ import {Suggestion} from '../../plan/suggestion.js';
 import {SuggestFilter} from '../../plan/suggest-filter.js';
 import {PlanningModalityHandler} from '../../planning-modality-handler.js';
 import {StrategyTestHelper} from '../../testing/strategy-test-helper.js';
+import {RamDiskStorageDriverProvider} from '../../../runtime/storageNG/drivers/ramdisk.js';
+import {TestVolatileMemoryProvider} from '../../../runtime/testing/test-volatile-memory-provider.js';
 // database providers are optional, these tests use these provider(s)
 import '../../../runtime/storage/firebase/firebase-provider.js';
 import '../../../runtime/storage/pouchdb/pouch-db-provider.js';
@@ -46,6 +48,8 @@ async function storeResults(consumer, suggestions) {
   describe('plan consumer for ' + storageKeyBase, () => {
     it('consumes', async () => {
       const loader = new StubLoader({});
+      const memoryProvider = new TestVolatileMemoryProvider();
+      RamDiskStorageDriverProvider.register(memoryProvider);
       const context =  await Manifest.parse(`
         import './src/runtime/tests/artifacts/Products/Products.recipes'
 
@@ -65,8 +69,8 @@ async function storeResults(consumer, suggestions) {
           Test2
             other: consumes other
           description \`Test Recipe\`
-      `, {loader, fileName: ''});
-      const runtime = new Runtime(loader, FakeSlotComposer, context);
+      `, {loader, fileName: '', memoryProvider});
+      const runtime = new Runtime(loader, FakeSlotComposer, context, null, memoryProvider);
       const arc = runtime.newArc('demo', storageKeyPrefixForTest());
       let suggestions = await StrategyTestHelper.planForArc(arc);
 
@@ -136,6 +140,8 @@ describe('plan consumer', () => {
         `;
       };
       const loader = new StubLoader({});
+      const memoryProvider = new TestVolatileMemoryProvider();
+      RamDiskStorageDriverProvider.register(memoryProvider);
       const context =  await Manifest.parse(`
 particle ParticleDom in './src/runtime/tests/artifacts/consumer-particle.js'
   root: consumes Slot
@@ -150,7 +156,7 @@ ${addRecipe(['ParticleDom'])}
 ${addRecipe(['ParticleTouch'])}
 ${addRecipe(['ParticleDom', 'ParticleBoth'])}
 ${addRecipe(['ParticleTouch', 'ParticleBoth'])}
-        `, {loader, fileName: ''});
+        `, {loader, fileName: '', memoryProvider});
       class ModalitySlotComposer extends FakeSlotComposer {
         prototype: {};
         constructor(options?: SlotComposerOptions) {
@@ -160,7 +166,7 @@ ${addRecipe(['ParticleTouch', 'ParticleBoth'])}
           });
         }
       }
-      const runtime = new Runtime(loader, ModalitySlotComposer, context);
+      const runtime = new Runtime(loader, ModalitySlotComposer, context, null, memoryProvider);
       const arc = runtime.newArc('demo', storageKeyPrefixForTest());
       assert.lengthOf(arc.context.allRecipes, 4);
       const consumer = await createPlanConsumer('volatile', arc);

--- a/src/planning/plan/tests/plan-producer-test.ts
+++ b/src/planning/plan/tests/plan-producer-test.ts
@@ -16,6 +16,7 @@ import {Runtime} from '../../../runtime/runtime.js';
 import {SingletonStorageProvider} from '../../../runtime/storage/storage-provider-base.js';
 import {storageKeyPrefixForTest} from '../../../runtime/testing/handle-for-test.js';
 import {FakeSlotComposer} from '../../../runtime/testing/fake-slot-composer.js';
+import {TestVolatileMemoryProvider} from '../../../runtime/testing/test-volatile-memory-provider.js';
 import {StubLoader} from '../../../runtime/testing/stub-loader.js';
 import {PlanProducer} from '../../plan/plan-producer.js';
 import {Planificator} from '../../plan/planificator.js';
@@ -87,8 +88,9 @@ class TestPlanProducer extends PlanProducer {
   describe('plan producer for ' + storageKeyBase, () => {
     async function createProducer(manifestFilename) {
       const loader = new StubLoader({});
-      const context = await Manifest.load('./src/runtime/tests/artifacts/Products/Products.recipes', loader);
-      const runtime = new Runtime(loader, FakeSlotComposer, context);
+      const memoryProvider = new TestVolatileMemoryProvider();
+      const context = await Manifest.load('./src/runtime/tests/artifacts/Products/Products.recipes', loader, {memoryProvider});
+      const runtime = new Runtime(loader, FakeSlotComposer, context, null, memoryProvider);
       const arc = runtime.newArc('demo', storageKeyPrefixForTest());
       const suggestions = await StrategyTestHelper.planForArc(
           runtime.newArc('demo', storageKeyPrefixForTest())
@@ -170,10 +172,11 @@ describe('plan producer - search', () => {
 
   async function init(): Promise<TestSearchPlanProducer> {
     const loader = new Loader();
+    const memoryProvider = new TestVolatileMemoryProvider();
     const manifest = await Manifest.parse(`
       schema Bar
         value: Text
-    `);
+    `, {memoryProvider});
     const arc = new Arc({slotComposer: new FakeSlotComposer(), loader, context: manifest, id: ArcId.newForTest('test'),
                          storageKey: 'volatile://test^^123'});
     const searchStore = await Planificator['_initSearchStore'](arc);
@@ -230,4 +233,3 @@ describe('plan producer - search', () => {
   });
   }); // end describe
 }); // end forEach
-

--- a/src/planning/strategies/tests/search-tokens-to-handles-test.ts
+++ b/src/planning/strategies/tests/search-tokens-to-handles-test.ts
@@ -11,10 +11,17 @@
 import {assert} from '../../../platform/chai-web.js';
 import {Loader} from '../../../platform/loader.js';
 import {Manifest} from '../../../runtime/manifest.js';
+import {RamDiskStorageDriverProvider} from '../../../runtime/storageNG/drivers/ramdisk.js';
+import {TestVolatileMemoryProvider} from '../../../runtime/testing/test-volatile-memory-provider.js';
 import {SearchTokensToHandles} from '../../strategies/search-tokens-to-handles.js';
 import {StrategyTestHelper} from '../../testing/strategy-test-helper.js';
 
 describe('SearchTokensToHandles', () => {
+  let memoryProvider;
+  beforeEach(() => {
+    memoryProvider = new TestVolatileMemoryProvider();
+    RamDiskStorageDriverProvider.register(memoryProvider);
+  });
   it('finds local handle by tags', async () => {
     const manifest = (await Manifest.parse(`
       schema Thing
@@ -30,7 +37,7 @@ describe('SearchTokensToHandles', () => {
       resource ThingsJson
         start
         [{}]
-    `));
+    `, {memoryProvider}));
 
     const arc = StrategyTestHelper.createTestArc(manifest);
     await arc._registerStore(arc.context.stores[0], ['mything']);
@@ -58,7 +65,7 @@ store Things of [Foo] #manythings in ThingsJson
   resource ThingsJson
     start
     [{}]
-    `, {loader, fileName: ''}));
+    `, {loader, fileName: '', memoryProvider}));
     const manifest = (await Manifest.parse(`
 import 'src/runtime/tests/artifacts/test-particles.manifest'
 particle ChooseFoo &choose in 'A.js'
@@ -72,7 +79,7 @@ recipe
   ChooseFoo
     inFoos: reads h0
     outFoo: writes h1
-    `, {loader, fileName: ''}));
+    `, {loader, fileName: '', memoryProvider}));
     const arc = StrategyTestHelper.createTestArc(manifest);
     arc.context.imports.push(storeManifest);
     const recipe = manifest.recipes[0];

--- a/src/planning/tests/suggestion-composer-test.ts
+++ b/src/planning/tests/suggestion-composer-test.ts
@@ -16,6 +16,7 @@ import {SlotComposerOptions} from '../../runtime/ui-slot-composer.js';
 import {MockSlotComposer} from '../../runtime/testing/mock-slot-composer.js';
 import {storageKeyPrefixForTest} from '../../runtime/testing/handle-for-test.js';
 import {StubLoader} from '../../runtime/testing/stub-loader.js';
+import {TestVolatileMemoryProvider} from '../../runtime/testing/test-volatile-memory-provider.js';
 import {HeadlessSuggestDomConsumer} from '../headless-suggest-dom-consumer.js';
 import {PlanningModalityHandler} from '../planning-modality-handler.js';
 import {Planner} from '../planner.js';
@@ -42,8 +43,9 @@ class TestSlotComposer extends MockSlotComposer {
 describe('suggestion composer', () => {
   it('singleton suggestion slots', async () => {
     const loader = new StubLoader({});
-    const context = await Manifest.load('./src/runtime/tests/artifacts/suggestions/Cake.recipes', loader);
-    const runtime = new Runtime(loader, TestSlotComposer, context);
+    const memoryProvider = new TestVolatileMemoryProvider();
+    const context = await Manifest.load('./src/runtime/tests/artifacts/suggestions/Cake.recipes', loader, {memoryProvider});
+    const runtime = new Runtime(loader, TestSlotComposer, context, null, memoryProvider);
     const arc = runtime.newArc('demo', storageKeyPrefixForTest());
     const slotComposer = arc.pec.slotComposer as MockSlotComposer;
     slotComposer.newExpectations('debug');
@@ -85,8 +87,9 @@ describe('suggestion composer', () => {
 
   it('suggestion set-slots', async () => {
     const loader = new StubLoader({});
-    const context = await Manifest.load('./src/runtime/tests/artifacts/suggestions/Cakes.recipes', loader);
-    const runtime = new Runtime(loader, TestSlotComposer, context);
+    const memoryProvider = new TestVolatileMemoryProvider();
+    const context = await Manifest.load('./src/runtime/tests/artifacts/suggestions/Cakes.recipes', loader, {memoryProvider});
+    const runtime = new Runtime(loader, TestSlotComposer, context, null, memoryProvider);
     const arc = runtime.newArc('demo', storageKeyPrefixForTest());
     const slotComposer = arc.pec.slotComposer as MockSlotComposer;
     slotComposer.newExpectations('debug');

--- a/src/runtime/storageNG/drivers/volatile.ts
+++ b/src/runtime/storageNG/drivers/volatile.ts
@@ -84,6 +84,14 @@ export interface VolatileMemoryProvider {
   getVolatileMemory(): VolatileMemory;
 }
 
+export class SimpleVolatileMemoryProvider implements VolatileMemoryProvider {
+  private readonly memory: VolatileMemory = new VolatileMemory();
+
+  getVolatileMemory(): VolatileMemory {
+    return this.memory;
+  }
+}
+
 let id = 0;
 
 export class VolatileDriver<Data> extends Driver<Data> {

--- a/src/runtime/storageNG/tests/ramdisk-backing-store-integration-test.ts
+++ b/src/runtime/storageNG/tests/ramdisk-backing-store-integration-test.ts
@@ -32,7 +32,7 @@ describe('RamDisk + Backing Store Integration', async () => {
 
   it('will allow storage of a number of objects', async () => {
     const runtime = new Runtime();
-    RamDiskStorageDriverProvider.register(runtime);
+    RamDiskStorageDriverProvider.register(runtime.getMemoryProvider());
     const storageKey = new RamDiskStorageKey('unique');
     const baseStore = new Store<CRDTCountTypeRecord>({storageKey, exists: Exists.ShouldCreate, type: new CountType(), id: 'base-store-id'});
     const store = await BackingStore.construct<CRDTCountTypeRecord>({

--- a/src/runtime/storageNG/tests/ramdisk-store-integration-test.ts
+++ b/src/runtime/storageNG/tests/ramdisk-store-integration-test.ts
@@ -29,7 +29,7 @@ describe('RamDisk + Store Integration', async () => {
 
   it('will store a sequence of model and operation updates as models', async () => {
     const runtime = new Runtime();
-    RamDiskStorageDriverProvider.register(runtime);
+    RamDiskStorageDriverProvider.register(runtime.getMemoryProvider());
     const storageKey = new RamDiskStorageKey('unique');
     const store = createStore(storageKey, Exists.ShouldCreate);
     const activeStore = await store.activate();
@@ -45,14 +45,14 @@ describe('RamDisk + Store Integration', async () => {
       {type: CountOpTypes.Increment, actor: 'them', version: {from: 0, to: 1}}
     ], id: 1});
 
-    const volatileEntry = runtime.getVolatileMemory().entries.get(storageKey.unique);
+    const volatileEntry = runtime.getMemoryProvider().getVolatileMemory().entries.get(storageKey.unique);
     assert.deepEqual(volatileEntry.root.data, activeStore['localModel'].getData());
     assert.strictEqual(volatileEntry.root.version, 3);
   });
 
   it('will store operation updates from multiple sources', async () => {
     const runtime = new Runtime();
-    RamDiskStorageDriverProvider.register(runtime);
+    RamDiskStorageDriverProvider.register(runtime.getMemoryProvider());
     const storageKey = new RamDiskStorageKey('unique');
     const store1 = createStore(storageKey, Exists.ShouldCreate);
     const activeStore1 = await store1.activate();
@@ -86,7 +86,7 @@ describe('RamDisk + Store Integration', async () => {
     await activeStore1.idle();
     await activeStore2.idle();
 
-    const volatileEntry = runtime.getVolatileMemory().entries.get(storageKey.unique);
+    const volatileEntry = runtime.getMemoryProvider().getVolatileMemory().entries.get(storageKey.unique);
     assert.deepEqual(volatileEntry.root.data, activeStore1['localModel'].getData());
     assert.strictEqual(volatileEntry.root.version, 3);
   });
@@ -94,7 +94,7 @@ describe('RamDisk + Store Integration', async () => {
   it('will store operation updates from multiple sources with some timing delays', async () => {
     // store1.onProxyMessage, DELAY, DELAY, DELAY, store1.onProxyMessage, store2.onProxyMessage, DELAY, DELAY, DELAY, store2.onProxyMessage, DELAY, DELAY, DELAY, DELAY, DELAY
     const runtime = new Runtime();
-    RamDiskStorageDriverProvider.register(runtime);
+    RamDiskStorageDriverProvider.register(runtime.getMemoryProvider());
     const storageKey = new RamDiskStorageKey('unique');
     const store1 = createStore(storageKey, Exists.ShouldCreate);
     const activeStore1 = await store1.activate();
@@ -132,7 +132,7 @@ describe('RamDisk + Store Integration', async () => {
     await activeStore1.idle();
     await activeStore2.idle();
 
-    const volatileEntry = runtime.getVolatileMemory().entries.get(storageKey.unique);
+    const volatileEntry = runtime.getMemoryProvider().getVolatileMemory().entries.get(storageKey.unique);
     assert.deepEqual(volatileEntry.root.data, activeStore1['localModel'].getData());
     assert.strictEqual(volatileEntry.root.version, 4);
   });

--- a/src/runtime/tests/recipe-test.ts
+++ b/src/runtime/tests/recipe-test.ts
@@ -17,7 +17,16 @@ import {Type} from '../type.js';
 import {Flags} from '../flags.js';
 import {Entity} from '../entity.js';
 
+import {TestVolatileMemoryProvider} from '../testing/test-volatile-memory-provider.js';
+import {RamDiskStorageDriverProvider} from '../storageNG/drivers/ramdisk.js';
+
 describe('recipe', () => {
+  let memoryProvider;
+  beforeEach(() => {
+      memoryProvider = new TestVolatileMemoryProvider();
+      RamDiskStorageDriverProvider.register(memoryProvider);
+  });
+
   it('normalize errors', async () => {
     const manifest = await Manifest.parse(`
         schema S1
@@ -226,7 +235,7 @@ describe('recipe', () => {
   const getFirstRecipeHash = async manifestContent => {
     const loader = new Loader();
     const manifest = await Manifest.parse(manifestContent,
-        {loader, fileName: './manifest.manifest'});
+        {loader, fileName: './manifest.manifest', memoryProvider});
     const [recipe] = manifest.recipes;
     assert.isTrue(recipe.normalize());
     return recipe.digest();
@@ -410,7 +419,7 @@ describe('recipe', () => {
       resource ThingsJson
         start
         [{}]
-    `);
+    `, {memoryProvider});
     assert.lengthOf(manifest.recipes, 1);
     const recipe = manifest.recipes[0];
     recipe.handles[0].id = 'my-things';
@@ -745,7 +754,7 @@ describe('recipe', () => {
         P
           inThing: handle0
           outThing: handle1
-    `)).recipes[0];
+    `, {memoryProvider})).recipes[0];
     const verifyRecipe = (recipe, errorPrefix) => {
       const errors: string[] = [];
       const resolvedType = recipe.handleConnections[0].type.resolvedType();

--- a/src/runtime/tests/runtime-test.ts
+++ b/src/runtime/tests/runtime-test.ts
@@ -17,6 +17,7 @@ import {Runtime} from '../runtime.js';
 import {FakeSlotComposer} from '../testing/fake-slot-composer.js';
 import {ArcId} from '../id.js';
 import {StubLoader} from '../testing/stub-loader.js';
+import {TestVolatileMemoryProvider} from '../testing/test-volatile-memory-provider.js';
 
 // tslint:disable-next-line: no-any
 function unsafe<T>(value: T): any { return value; }
@@ -74,7 +75,8 @@ describe('Runtime', () => {
     assert.hasAllKeys(runtime.arcById, ['test-arc', 'other-test-arc']);
   });
   it('registers and unregisters stores', async () => {
-    const context = await Manifest.parse(``);
+    const memoryProvider = new TestVolatileMemoryProvider();
+    const context = await Manifest.parse(``, {memoryProvider});
     const loader = new StubLoader({
       manifest: `
         schema Thing
@@ -93,9 +95,9 @@ describe('Runtime', () => {
       `,
       '*': 'defineParticle(({Particle}) => class extends Particle {});',
     });
-    const runtime = new Runtime(loader, FakeSlotComposer, context);
+    const runtime = new Runtime(loader, FakeSlotComposer, context, null, memoryProvider);
     const arc = runtime.runArc('test-arc', 'volatile://');
-    const manifest = await Manifest.load('manifest', loader);
+    const manifest = await Manifest.load('manifest', loader, {memoryProvider});
     manifest.recipes[0].normalize();
     await arc.instantiate(manifest.recipes[0]);
     assert.lengthOf(arc.context.stores, 2);

--- a/src/tests/arc-integration-test.ts
+++ b/src/tests/arc-integration-test.ts
@@ -12,8 +12,10 @@ import {assert} from '../platform/chai-web.js';
 import {Arc} from '../runtime/arc.js';
 import {Manifest} from '../runtime/manifest.js';
 import {Runtime} from '../runtime/runtime.js';
+import {RamDiskStorageDriverProvider} from '../runtime/storageNG/drivers/ramdisk.js';
 import {StubLoader} from '../runtime/testing/stub-loader.js';
 import {FakeSlotComposer} from '../runtime/testing/fake-slot-composer.js';
+import {TestVolatileMemoryProvider} from '../runtime/testing/test-volatile-memory-provider.js';
 
 describe('Arc integration', () => {
   it('copies store tags', async () => {
@@ -23,6 +25,7 @@ describe('Arc integration', () => {
         }
       });`
     });
+    const memoryProvider = new TestVolatileMemoryProvider();
     const manifest = await Manifest.parse(`
       schema Thing
         name: Text
@@ -38,9 +41,10 @@ describe('Arc integration', () => {
           {"name": "mything"}
         ]
       store ThingStore of Thing 'mything' #best in ThingResource
-    `);
+    `, {memoryProvider});
+    const runtime = new Runtime(loader, FakeSlotComposer, manifest, null, memoryProvider);
+    RamDiskStorageDriverProvider.register(memoryProvider);
 
-    const runtime = new Runtime(loader, FakeSlotComposer, manifest);
     const arc = runtime.newArc('demo', 'volatile://');
     assert.lengthOf(arc._stores, 0);
     assert.isEmpty(arc.storeTags);

--- a/src/tests/multiplexer-integration-test.ts
+++ b/src/tests/multiplexer-integration-test.ts
@@ -17,14 +17,16 @@ import {Runtime} from '../runtime/runtime.js';
 import {MockSlotComposer} from '../runtime/testing/mock-slot-composer.js';
 import {checkDefined} from '../runtime/testing/preconditions.js';
 import {StubLoader} from '../runtime/testing/stub-loader.js';
+import {TestVolatileMemoryProvider} from '../runtime/testing/test-volatile-memory-provider.js';
 import {collectionHandleForTest, storageKeyPrefixForTest} from '../runtime/testing/handle-for-test.js';
 import {StrategyTestHelper} from '../planning/testing/strategy-test-helper.js';
 
 describe('Multiplexer', () => {
   it('renders polymorphic multiplexed slots', async () => {
     const loader = new StubLoader({});
+    const memoryProvider = new TestVolatileMemoryProvider();
     const context = await Manifest.load(
-        './src/tests/particles/artifacts/polymorphic-muxing.recipes', loader);
+        './src/tests/particles/artifacts/polymorphic-muxing.recipes', loader, {memoryProvider});
 
     const showOneParticle = context.particles.find(p => p.name === 'ShowOne');
     const showTwoParticle = context.particles.find(p => p.name === 'ShowTwo');
@@ -59,7 +61,7 @@ describe('Multiplexer', () => {
     });
     postsStub['referenceMode'] = false;
     // version could be set here, but doesn't matter for tests.
-    const runtime = new Runtime(loader, MockSlotComposer, context);
+    const runtime = new Runtime(loader, MockSlotComposer, context, null, memoryProvider);
     const arc = runtime.newArc('demo', storageKeyPrefixForTest());
     const slotComposer = arc.pec.slotComposer as MockSlotComposer;
     const suggestions = await StrategyTestHelper.planForArc(arc);

--- a/src/tests/particles/common-test.ts
+++ b/src/tests/particles/common-test.ts
@@ -14,11 +14,13 @@ import {Manifest} from '../../runtime/manifest.js';
 import {Runtime} from '../../runtime/runtime.js';
 import {VolatileCollection} from '../../runtime/storage/volatile-storage.js';
 import {FakeSlotComposer} from '../../runtime/testing/fake-slot-composer.js';
+import {TestVolatileMemoryProvider} from '../../runtime/testing/test-volatile-memory-provider.js';
 import {StubLoader} from '../../runtime/testing/stub-loader.js';
 import {StrategyTestHelper} from '../../planning/testing/strategy-test-helper.js';
 
 describe('common particles test', () => {
   it('resolves after cloning', async () => {
+    const memoryProvider = new TestVolatileMemoryProvider();
     const manifest = await Manifest.parse(`
   schema Thing
     name: Text
@@ -58,7 +60,7 @@ describe('common particles test', () => {
       {"name": "ball"}
     ]
   store Store1 of [Thing] 'smallthings' in SmallThings
-    `);
+    `, {memoryProvider});
 
     const recipe = manifest.recipes[0];
     const newRecipe = recipe.clone();
@@ -71,8 +73,9 @@ describe('common particles test', () => {
 
   it('copy handle test', async () => {
     const loader = new StubLoader({});
-    const context =  await Manifest.load('./src/tests/particles/artifacts/copy-collection-test.recipes', loader);
-    const runtime = new Runtime(loader, FakeSlotComposer, context);
+    const memoryProvider = new TestVolatileMemoryProvider();
+    const context =  await Manifest.load('./src/tests/particles/artifacts/copy-collection-test.recipes', loader, {memoryProvider});
+    const runtime = new Runtime(loader, FakeSlotComposer, context, null, memoryProvider);
     const arc = runtime.newArc('demo', 'volatile://');
 
     const suggestions = await StrategyTestHelper.planForArc(arc);

--- a/src/tests/particles/dataflow-test.ts
+++ b/src/tests/particles/dataflow-test.ts
@@ -12,6 +12,8 @@ import {Loader} from '../../platform/loader.js';
 import {Manifest} from '../../runtime/manifest.js';
 import {analyseDataflow} from '../../dataflow/analysis/analysis.js';
 import {assert} from '../../platform/chai-web.js';
+import {RamDiskStorageDriverProvider} from '../../runtime/storageNG/drivers/ramdisk.js';
+import {TestVolatileMemoryProvider} from '../../runtime/testing/test-volatile-memory-provider.js';
 
 // Checks that all of the Dataflow example recipes successfully pass dataflow
 // analysis.
@@ -21,7 +23,9 @@ describe('Dataflow example recipes', () => {
 
   for (const filename of filenames) {
     it(`passes dataflow analysis: ${filename}`, async () => {
-      const manifest = await Manifest.load(filename, loader);
+      const memoryProvider = new TestVolatileMemoryProvider();
+      RamDiskStorageDriverProvider.register(memoryProvider);
+      const manifest = await Manifest.load(filename, loader, {memoryProvider});
       for (const recipe of manifest.recipes) {
         recipe.normalize();
         const [_graph, result] = analyseDataflow(recipe, manifest);

--- a/src/tests/particles/multi-slot-test.ts
+++ b/src/tests/particles/multi-slot-test.ts
@@ -16,15 +16,17 @@ import {Manifest} from '../../runtime/manifest.js';
 import {Runtime} from '../../runtime/runtime.js';
 import {storageKeyPrefixForTest} from '../../runtime/testing/handle-for-test.js';
 import {MockSlotComposer} from '../../runtime/testing/mock-slot-composer.js';
+import {TestVolatileMemoryProvider} from '../../runtime/testing/test-volatile-memory-provider.js';
 import {checkNotNull} from '../../runtime/testing/preconditions.js';
 import {StubLoader} from '../../runtime/testing/stub-loader.js';
 
 describe('multi-slot test', () => {
   async function init() {
     const loader = new StubLoader({});
+    const memoryProvider = new TestVolatileMemoryProvider();
     const context = await Manifest.load(
-        './src/tests/particles/artifacts/multi-slot-test.manifest', loader);
-    const runtime = new Runtime(loader, MockSlotComposer, context);
+        './src/tests/particles/artifacts/multi-slot-test.manifest', loader, {memoryProvider});
+    const runtime = new Runtime(loader, MockSlotComposer, context, null, memoryProvider);
     const arc = runtime.newArc('demo', storageKeyPrefixForTest());
     const slotComposer = arc.pec.slotComposer as MockSlotComposer;
     const suggestions = await StrategyTestHelper.planForArc(arc);

--- a/src/tests/particles/particles-test.ts
+++ b/src/tests/particles/particles-test.ts
@@ -12,11 +12,19 @@ import {Manifest} from '../../runtime/manifest.js';
 import glob from 'glob';
 import {Loader} from '../../platform/loader.js';
 import {assert} from '../../platform/chai-web.js';
+import {RamDiskStorageDriverProvider} from '../../runtime/storageNG/drivers/ramdisk.js';
+import {TestVolatileMemoryProvider} from '../../runtime/testing/test-volatile-memory-provider.js';
 
 /** Tests that all .schema, .recipe(s) and .manifest files in the particles folder compile successfully. */
 describe('Particle definitions', () => {
   const loader = new Loader();
   const filenames = glob.sync('particles/**/*.arcs');
+
+  let memoryProvider;
+  beforeEach(() => {
+    memoryProvider = new TestVolatileMemoryProvider();
+    RamDiskStorageDriverProvider.register(memoryProvider);
+  });
 
   filenames
     .forEach(filename => {
@@ -25,7 +33,7 @@ describe('Particle definitions', () => {
         return;
       }
       it(`parses successfully: ${filename}`, async () => {
-        const manifest = await Manifest.load(filename, loader);
+        const manifest = await Manifest.load(filename, loader, {memoryProvider});
         for (const particle of manifest.particles) {
           if (particle.implFile == null) {
             // It's ok for some particles to not have implementation files (e.g.

--- a/src/tests/particles/products-test.ts
+++ b/src/tests/particles/products-test.ts
@@ -17,6 +17,7 @@ import {Runtime} from '../../runtime/runtime.js';
 import {MockSlotComposer} from '../../runtime/testing/mock-slot-composer.js';
 import {FakeSlotComposer} from '../../runtime/testing/fake-slot-composer.js';
 import {StorageProviderBase} from '../../runtime/storage/storage-provider-base.js';
+import {TestVolatileMemoryProvider} from '../../runtime/testing/test-volatile-memory-provider.js';
 
 describe('products test', () => {
   const manifestFilename = './src/tests/particles/artifacts/products-test.recipes';
@@ -31,7 +32,10 @@ describe('products test', () => {
 
   it('filters', async () => {
     const loader = new Loader();
-    const runtime = new Runtime(loader, FakeSlotComposer, await Manifest.load(manifestFilename, loader));
+    const memoryProvider = new TestVolatileMemoryProvider();
+    const runtime = new Runtime(loader, FakeSlotComposer,
+        await Manifest.load(manifestFilename, loader, {memoryProvider}),
+        null, memoryProvider);
     const arc = runtime.newArc('demo', 'volatile://');
     const recipe = arc.context.recipes.find(r => r.name === 'FilterBooks');
     assert.isTrue(recipe.normalize() && recipe.isResolved());
@@ -42,6 +46,7 @@ describe('products test', () => {
 
   it('filters and displays', async () => {
     const loader = new Loader();
+    const memoryProvider = new TestVolatileMemoryProvider();
     const slotComposer = new MockSlotComposer({strict: false});
     const id = IdGenerator.newSession().newArcId('demo');
     const arc = new Arc({
@@ -49,7 +54,7 @@ describe('products test', () => {
       storageKey: `volatile://${id.toString()}`,
       loader,
       slotComposer,
-      context: await Manifest.load(manifestFilename, loader)
+      context: await Manifest.load(manifestFilename, loader, {memoryProvider})
     });
     const recipe = arc.context.recipes.find(r => r.name === 'FilterAndDisplayBooks');
     assert.isTrue(recipe.normalize() && recipe.isResolved());

--- a/src/tests/particles/transformation-slots-test.ts
+++ b/src/tests/particles/transformation-slots-test.ts
@@ -14,14 +14,16 @@ import {Runtime} from '../../runtime/runtime.js';
 import {storageKeyPrefixForTest} from '../../runtime/testing/handle-for-test.js';
 import {MockSlotComposer} from '../../runtime/testing/mock-slot-composer.js';
 import {StubLoader} from '../../runtime/testing/stub-loader.js';
+import {TestVolatileMemoryProvider} from '../../runtime/testing/test-volatile-memory-provider.js';
 import {StrategyTestHelper} from '../../planning/testing/strategy-test-helper.js';
 
 describe('transformation slots', () => {
   it('combines hosted particles provided singleton slots into transformation provided set slot', async () => {
     const loader = new StubLoader({});
+    const memoryProvider = new TestVolatileMemoryProvider();
     const context = await Manifest.load(
-        './src/tests/particles/artifacts/provide-hosted-particle-slots.manifest', loader);
-    const runtime = new Runtime(loader, MockSlotComposer, context);
+        './src/tests/particles/artifacts/provide-hosted-particle-slots.manifest', loader, {memoryProvider});
+    const runtime = new Runtime(loader, MockSlotComposer, context, null, memoryProvider);
     const arc = runtime.newArc('demo', storageKeyPrefixForTest());
     const slotComposer = arc.pec.slotComposer as MockSlotComposer;
 

--- a/src/tools/bundle.ts
+++ b/src/tools/bundle.ts
@@ -14,6 +14,7 @@ import JSZip from 'jszip';
 
 import {Loader} from '../platform/loader.js';
 import {Manifest} from '../runtime/manifest.js';
+import {SimpleVolatileMemoryProvider} from '../runtime/storageNG/drivers/volatile.js';
 
 export type BundleEntry = {
   filePath: string,
@@ -71,7 +72,8 @@ export async function bundleListing(...entryPoints: string[]): Promise<BundleEnt
       : path.resolve(process.cwd(), ep).split(path.sep).join('/'));
 
   const loader = new Loader();
-  const entryManifests = await Promise.all(entryPoints.map(ep => Manifest.load(ep, loader)));
+  const memoryProvider = new SimpleVolatileMemoryProvider();
+  const entryManifests = await Promise.all(entryPoints.map(ep => Manifest.load(ep, loader, {memoryProvider})));
 
   const filePathsSet = new Set<string>();
   entryManifests.forEach(m => collectDependencies(m, filePathsSet));


### PR DESCRIPTION
Follow-up to #4310 wherein I didn't think to test with StorageNG enabled.

A few follow-ups:
- Added TODO to consider refactoring `Runtime` ctor to take an options object.
- Having a separate init/ctor for `Runtime` feels messy, warrants a review given how it's grown organically.
- It might be handy to have a base class or a testing util or some easier way for tests to apply `beforeEach` boilerplate to set up a `Loader` (or `StubLoader`, both are common), a `VolatileMemoryProvider`, and register it with `RamDiskStorageDriverProvider`. However, it's also nice in a way for tests to have to set up explicitly what they need since sometimes they need one but not the others.