### PR TITLE
Break cycle between Runtime and Arc.

### DIFF
--- a/src/planning/plan/tests/plan-producer-test.ts
+++ b/src/planning/plan/tests/plan-producer-test.ts
@@ -16,6 +16,7 @@ import {Runtime} from '../../../runtime/runtime.js';
 import {SingletonStorageProvider} from '../../../runtime/storage/storage-provider-base.js';
 import {storageKeyPrefixForTest} from '../../../runtime/testing/handle-for-test.js';
 import {FakeSlotComposer} from '../../../runtime/testing/fake-slot-composer.js';
+import {TestStoreRegistry} from '../../../runtime/testing/test-store-registry.js';
 import {TestVolatileMemoryProvider} from '../../../runtime/testing/test-volatile-memory-provider.js';
 import {StubLoader} from '../../../runtime/testing/stub-loader.js';
 import {PlanProducer} from '../../plan/plan-producer.js';
@@ -172,13 +173,15 @@ describe('plan producer - search', () => {
 
   async function init(): Promise<TestSearchPlanProducer> {
     const loader = new Loader();
+    const storeRegistry = new TestStoreRegistry();
     const memoryProvider = new TestVolatileMemoryProvider();
     const manifest = await Manifest.parse(`
       schema Bar
         value: Text
     `, {memoryProvider});
-    const arc = new Arc({slotComposer: new FakeSlotComposer(), loader, context: manifest, id: ArcId.newForTest('test'),
-                         storageKey: 'volatile://test^^123'});
+    const arc = new Arc({slotComposer: new FakeSlotComposer(), loader,
+        storeRegistry, context: manifest, id: ArcId.newForTest('test'),
+        storageKey: 'volatile://test^^123'});
     const searchStore = await Planificator['_initSearchStore'](arc);
 
     const producer = new TestSearchPlanProducer(arc, searchStore);

--- a/src/planning/plan/tests/planificator-test.ts
+++ b/src/planning/plan/tests/planificator-test.ts
@@ -15,6 +15,7 @@ import {Loader} from '../../../platform/loader.js';
 import {RamDiskStorageDriverProvider} from '../../../runtime/storageNG/drivers/ramdisk.js';
 import {FakeSlotComposer} from '../../../runtime/testing/fake-slot-composer.js';
 import {StubLoader} from '../../../runtime/testing/stub-loader.js';
+import {TestStoreRegistry} from '../../../runtime/testing/test-store-registry.js';
 import {TestVolatileMemoryProvider} from '../../../runtime/testing/test-volatile-memory-provider.js';
 import {Planificator} from '../../plan/planificator.js';
 import {PlanningResult} from '../../plan/planning-result.js';
@@ -93,6 +94,7 @@ describe('remote planificator', () => {
     const deserializedArc = await Arc.deserialize({serialization,
       slotComposer: new FakeSlotComposer(),
       loader: new Loader(),
+      storeRegistry: new TestStoreRegistry(),
       fileName: '',
       pecFactories: undefined,
       context: consumePlanificator.arc.context});

--- a/src/planning/plan/tests/replan-queue-test.ts
+++ b/src/planning/plan/tests/replan-queue-test.ts
@@ -12,6 +12,7 @@ import {Arc} from '../../../runtime/arc.js';
 import {Loader} from '../../../platform/loader.js';
 import {Manifest} from '../../../runtime/manifest.js';
 import {FakeSlotComposer} from '../../../runtime/testing/fake-slot-composer.js';
+import {TestStoreRegistry} from '../../../runtime/testing/test-store-registry.js';
 import {PlanProducer} from '../../plan/plan-producer.js';
 import {PlanningResult} from '../../plan/planning-result.js';
 import {ReplanQueue} from '../../plan/replan-queue.js';
@@ -40,7 +41,9 @@ async function init(options?) {
     schema Bar
       value: Text
   `);
-  const arc = new Arc({slotComposer: new FakeSlotComposer(), loader, context: manifest, id: ArcId.newForTest('test')});
+  const arc = new Arc({slotComposer: new FakeSlotComposer(), loader,
+      storeRegistry: new TestStoreRegistry(),
+      context: manifest, id: ArcId.newForTest('test')});
 
   const producer = new TestPlanProducer(arc);
   const queue = new ReplanQueue(producer, options);

--- a/src/planning/recipe-index.ts
+++ b/src/planning/recipe-index.ts
@@ -23,6 +23,7 @@ import {Recipe} from '../runtime/recipe/recipe.js';
 import {SlotUtils} from '../runtime/recipe/slot-utils.js';
 import {Slot} from '../runtime/recipe/slot.js';
 import {Descendant} from '../runtime/recipe/walker.js';
+import {Runtime} from '../runtime/runtime.js';
 import {SlotComposer} from '../runtime/slot-composer.js';
 import {Tracing} from '../tracelib/trace.js';
 
@@ -109,7 +110,8 @@ export class RecipeIndex {
         modalityHandler: PlanningModalityHandler.createHeadlessHandler(),
         noRoot: true
       }),
-      stub: true
+      stub: true,
+      storeRegistry: Runtime.getRuntime().getStoreRegistry()
     });
     const strategizer = new Strategizer(
       [

--- a/src/planning/strategies/tests/convert-constraints-to-connections-test.ts
+++ b/src/planning/strategies/tests/convert-constraints-to-connections-test.ts
@@ -13,6 +13,7 @@ import {Loader} from '../../../platform/loader.js';
 import {Manifest} from '../../../runtime/manifest.js';
 import {Modality} from '../../../runtime/modality.js';
 import {FakeSlotComposer} from '../../../runtime/testing/fake-slot-composer.js';
+import {TestStoreRegistry} from '../../../runtime/testing/test-store-registry.js';
 import {ConvertConstraintsToConnections} from '../../strategies/convert-constraints-to-connections.js';
 import {InstanceEndPoint} from '../../../runtime/recipe/connection-constraint.js';
 import {ArcId} from '../../../runtime/id.js';
@@ -25,7 +26,8 @@ describe('ConvertConstraintsToConnections', () => {
       id: ArcId.newForTest('test-plan-arc'),
       slotComposer: new FakeSlotComposer(),
       context: manifest,
-      loader: new Loader()
+      loader: new Loader(),
+      storeRegistry: new TestStoreRegistry()
     });
   };
 
@@ -304,7 +306,8 @@ describe('ConvertConstraintsToConnections', () => {
       id: ArcId.newForTest('test-plan-arc'),
       slotComposer: new FakeSlotComposer({modalityName: Modality.Name.Vr}),
       context: manifest,
-      loader: new Loader()
+      loader: new Loader(),
+      storeRegistry: new TestStoreRegistry()
     }));
     const results = await cctc.generateFrom(generated);
     assert.lengthOf(results, 1);

--- a/src/planning/strategies/tests/find-hosted-particle-test.ts
+++ b/src/planning/strategies/tests/find-hosted-particle-test.ts
@@ -19,6 +19,7 @@ import {FindHostedParticle} from '../../strategies/find-hosted-particle.js';
 import {StrategyTestHelper} from '../../testing/strategy-test-helper.js';
 import {ArcId} from '../../../runtime/id.js';
 import {singletonHandleForTest} from '../../../runtime/testing/handle-for-test.js';
+import {TestStoreRegistry} from '../../../runtime/testing/test-store-registry.js';
 import {Flags} from '../../../runtime/flags.js';
 
 async function runStrategy(manifestStr) {
@@ -147,6 +148,7 @@ describe('FindHostedParticle', () => {
   });
   it(`produces recipes that can be instantiated with particle spec`, async () => {
     const loader = new Loader();
+    const storeRegistry = new TestStoreRegistry();
     const manifest = await Manifest.parse(`
       import 'src/runtime/tests/artifacts/test-particles.manifest'
 
@@ -158,7 +160,8 @@ describe('FindHostedParticle', () => {
           output: h0
     `, {loader, fileName: process.cwd() + '/input.manifest'});
 
-    const arc = new Arc({id: ArcId.newForTest('test'), context: manifest, loader});
+    const arc = new Arc({id: ArcId.newForTest('test'), context: manifest,
+        loader, storeRegistry});
     const strategy = new FindHostedParticle(arc);
 
     const inRecipe = manifest.recipes[0];

--- a/src/planning/strategies/tests/init-population-test.ts
+++ b/src/planning/strategies/tests/init-population-test.ts
@@ -13,6 +13,7 @@ import {assert} from '../../../platform/chai-web.js';
 import {Arc} from '../../../runtime/arc.js';
 import {Manifest} from '../../../runtime/manifest.js';
 import {StubLoader} from '../../../runtime/testing/stub-loader.js';
+import {TestStoreRegistry} from '../../../runtime/testing/test-store-registry.js';
 import {InitPopulation} from '../../strategies/init-population.js';
 
 import {StrategyTestHelper} from '../../testing/strategy-test-helper.js';
@@ -37,7 +38,9 @@ describe('InitPopulation', () => {
     });
     const recipe = manifest.recipes[0];
     assert(recipe.normalize());
-    const arc = new Arc({id: ArcId.newForTest('test-plan-arc'), context: manifest, loader});
+    const storeRegistry = new TestStoreRegistry();
+    const arc = new Arc({id: ArcId.newForTest('test-plan-arc'),
+        context: manifest, loader, storeRegistry});
 
     async function scoreOfInitPopulationOutput() {
       const results = await new InitPopulation(arc, StrategyTestHelper.createTestStrategyArgs(
@@ -63,10 +66,11 @@ describe('InitPopulation', () => {
     const loader = new StubLoader({
       'A.js': 'defineParticle(({Particle}) => class extends Particle {})'
     });
+    const storeRegistry = new TestStoreRegistry();
     const arc = new Arc({
       id: ArcId.newForTest('test-plan-arc'),
       context: new Manifest({id: ArcId.newForTest('test')}),
-      loader
+      loader, storeRegistry
     });
 
     const results = await new InitPopulation(arc, {contextual: false,

--- a/src/planning/strategies/tests/map-slots-test.ts
+++ b/src/planning/strategies/tests/map-slots-test.ts
@@ -14,6 +14,7 @@ import {Arc} from '../../../runtime/arc.js';
 import {Loader} from '../../../platform/loader.js';
 import {Manifest} from '../../../runtime/manifest.js';
 import {FakeSlotComposer} from '../../../runtime/testing/fake-slot-composer.js';
+import {TestStoreRegistry} from '../../../runtime/testing/test-store-registry.js';
 import {MapSlots} from '../../strategies/map-slots.js';
 import {ResolveRecipe} from '../../strategies/resolve-recipe.js';
 
@@ -159,6 +160,7 @@ ${recipeManifest}
     const arc = new Arc({
       id: ArcId.newForTest('test-plan-arc'),
       loader: new Loader(),
+      storeRegistry: new TestStoreRegistry(),
       context: new Manifest({id: ArcId.newForTest('test')}),
       slotComposer: new FakeSlotComposer({containers: {root: {}, action: {}}})
     });

--- a/src/planning/testing/strategy-test-helper.ts
+++ b/src/planning/testing/strategy-test-helper.ts
@@ -14,17 +14,21 @@ import {Arc} from '../../runtime/arc.js';
 import {Loader} from '../../platform/loader.js';
 import {Manifest} from '../../runtime/manifest.js';
 import {Modality} from '../../runtime/modality.js';
+import {StoreRegistry} from '../../runtime/storageNG/unified-store.js';
 import {FakeSlotComposer} from '../../runtime/testing/fake-slot-composer.js';
+import {TestStoreRegistry} from '../../runtime/testing/test-store-registry.js';
 import {RecipeIndex} from '../recipe-index.js';
 import {Id, ArcId} from '../../runtime/id.js';
 import {Planner} from '../planner.js';
 import {Suggestion} from '../plan/suggestion.js';
 
 export class StrategyTestHelper {
-  static createTestArc(context: Manifest, options: {arcId?: Id, modalityName?: string, loader?: Loader} = {}) {
+  static createTestArc(context: Manifest, options: {
+      arcId?: Id, modalityName?: string, loader?: Loader, storeRegistry?: StoreRegistry} = {}) {
     return new Arc({
       id: options.arcId || ArcId.newForTest('test-arc'),
       loader: options.loader || new Loader(),
+      storeRegistry: options.storeRegistry || new TestStoreRegistry(),
       context,
       slotComposer: new FakeSlotComposer(options)
     });

--- a/src/planning/tests/planner-test.ts
+++ b/src/planning/tests/planner-test.ts
@@ -14,6 +14,7 @@ import {Particle} from '../../runtime/particle.js';
 import {Loader} from '../../platform/loader.js';
 import {Manifest} from '../../runtime/manifest.js';
 import {StubLoader} from '../../runtime/testing/stub-loader.js';
+import {TestStoreRegistry} from '../../runtime/testing/test-store-registry.js';
 import {Planner} from '../planner.js';
 import {Speculator} from '../speculator.js';
 
@@ -99,7 +100,9 @@ const loadTestArcAndRunSpeculation = async (manifest, manifestLoadedCallback) =>
   const loadedManifest = await Manifest.load('manifest', loader, {registry, memoryProvider});
   manifestLoadedCallback(loadedManifest);
 
-  const arc = new Arc({id: ArcId.newForTest('test-plan-arc'), context: loadedManifest, loader});
+  const storeRegistry = new TestStoreRegistry();
+  const arc = new Arc({id: ArcId.newForTest('test-plan-arc'),
+      context: loadedManifest, loader, storeRegistry});
   const planner = new Planner();
   const options = {strategyArgs: StrategyTestHelper.createTestStrategyArgs(arc), speculator: new Speculator()};
   planner.init(arc, options);

--- a/src/planning/tests/recipe-index-test.ts
+++ b/src/planning/tests/recipe-index-test.ts
@@ -13,6 +13,7 @@ import {Arc} from '../../runtime/arc.js';
 import {Loader} from '../../platform/loader.js';
 import {Manifest} from '../../runtime/manifest.js';
 import {MockSlotComposer} from '../../runtime/testing/mock-slot-composer.js';
+import {TestStoreRegistry} from '../../runtime/testing/test-store-registry.js';
 import {checkDefined} from '../../runtime/testing/preconditions.js';
 import {RecipeIndex} from '../recipe-index.js';
 import {Id, ArcId} from '../../runtime/id.js';
@@ -25,10 +26,12 @@ describe('RecipeIndex', () => {
       assert(recipe.normalize());
     }
     const loader = new Loader();
+    const storeRegistry = new TestStoreRegistry();
     const arc = new Arc({
       id: ArcId.newForTest('test-plan-arc'),
       context: manifest,
       loader,
+      storeRegistry,
       slotComposer: new MockSlotComposer()
     });
     const recipeIndex = RecipeIndex.create(arc);

--- a/src/planning/tests/simple-planner-test.ts
+++ b/src/planning/tests/simple-planner-test.ts
@@ -15,6 +15,7 @@ import {Loader} from '../../platform/loader.js';
 import {Manifest} from '../../runtime/manifest.js';
 import {Match, SimplePlanner} from '../simple-planner.js';
 import {FakeSlotComposer} from '../../runtime/testing/fake-slot-composer.js';
+import {TestStoreRegistry} from '../../runtime/testing/test-store-registry.js';
 import {Id, ArcId} from '../../runtime/id.js';
 import {RecipeResolver} from '../../runtime/recipe/recipe-resolver.js';
 
@@ -108,7 +109,11 @@ describe('trigger parsing', () => {
 });
 
 describe('simple planner', () => {
-  const createArc = (manifest) => new Arc({id: ArcId.newForTest('test'), slotComposer: new FakeSlotComposer(), loader: new Loader(), context: manifest});
+  const createArc = (manifest) => new Arc({id: ArcId.newForTest('test'),
+      slotComposer: new FakeSlotComposer(),
+      loader: new Loader(),
+      storeRegistry: new TestStoreRegistry(),
+      context: manifest});
 
   it('If no triggers are present, the table is empty', async () => {
     const manifest = await Manifest.parse(`

--- a/src/planning/tests/speculator-test.ts
+++ b/src/planning/tests/speculator-test.ts
@@ -12,13 +12,18 @@ import {assert} from '../../platform/chai-web.js';
 import {Arc} from '../../runtime/arc.js';
 import {Loader} from '../../platform/loader.js';
 import {Manifest} from '../../runtime/manifest.js';
+import {TestStoreRegistry} from '../../runtime/testing/test-store-registry.js';
 import {Speculator} from '../speculator.js';
 import {Id, ArcId} from '../../runtime/id.js';
 
 describe('speculator', () => {
   it('can speculatively produce a relevance', async () => {
     const loader = new Loader();
-    const arc = new Arc({id: ArcId.newForTest('test'), loader, context: new Manifest({id: ArcId.newForTest('test')})});
+    const storeRegistry = new TestStoreRegistry();
+    const arc = new Arc({id: ArcId.newForTest('test'),
+        loader,
+        storeRegistry,
+        context: new Manifest({id: ArcId.newForTest('test')})});
     const manifest = await Manifest.load('./src/runtime/tests/artifacts/test.manifest', loader);
     const recipe = manifest.recipes[0];
     assert(recipe.normalize());

--- a/src/runtime/manual_tests/firebase-test.ts
+++ b/src/runtime/manual_tests/firebase-test.ts
@@ -18,8 +18,10 @@ import {Runtime} from '../runtime.js';
 import {EntityType, ReferenceType} from '../type.js';
 import {resetStorageForTesting} from '../storage/firebase/firebase-storage.js';
 import {BigCollectionStorageProvider, CollectionStorageProvider, SingletonStorageProvider} from '../storage/storage-provider-base.js';
+import {StoreRegistry} from '../storageNG/unified-store.js';
 import {StorageProviderFactory} from '../storage/storage-provider-factory.js';
 import {FakeSlotComposer} from '../testing/fake-slot-composer.js';
+import {TestStoreRegistry} from '../testing/test-store-registry.js';
 import {StubLoader} from '../testing/stub-loader.js';
 
 // Console is https://firebase.corp.google.com/project/arcs-storage-test/database/arcs-storage-test/data/firebase-storage-test
@@ -64,13 +66,21 @@ describe('firebase', function() {
     storageInstances = [];
   });
 
+  const newArc = (context, loader?: Loader, storeRegistry?: StoreRegistry) => {
+    return new Arc({
+        id: ArcId.newForTest('test'),
+        loader: loader || new Loader(),
+        storeRegistry: storeRegistry || new TestStoreRegistry(),
+        context});
+  };
+
   describe('variable', () => {
     it('supports basic construct and mutate', async () => {
       const manifest = await Manifest.parse(`
         schema Bar
           value: Text
       `);
-      const arc = new Arc({id: ArcId.newForTest('test'), loader: new Loader(), context: manifest});
+      const arc = newArc(manifest);
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const value = 'Hi there' + Math.random();
@@ -92,7 +102,7 @@ describe('firebase', function() {
         schema Bar
           value: Text
       `);
-      const arc = new Arc({id: ArcId.newForTest('test'), loader: new Loader(), context: manifest});
+      const arc = newArc(manifest);
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const key = newStoreKey('variable');
@@ -110,7 +120,7 @@ describe('firebase', function() {
         schema Bar
           value: Text
       `);
-      const arc = new Arc({id: ArcId.newForTest('test'), loader: new Loader(), context: manifest});
+      const arc = newArc(manifest);
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const key1 = newStoreKey('varPtr');
@@ -132,8 +142,7 @@ describe('firebase', function() {
         schema Bar
           value: Text
       `);
-      const arc = new Arc({id: ArcId.newForTest('test'), loader: new Loader(), context: manifest});
-
+      const arc = newArc(manifest);
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const key1 = newStoreKey('varPtr');
@@ -156,7 +165,7 @@ describe('firebase', function() {
           data: Text
       `);
       const barType = new EntityType(manifest.schemas.Bar1);
-      const arc = new Arc({id: ArcId.newForTest('test'), loader: new Loader(), context: manifest});
+      const arc = newArc(manifest);
       const storage = createStorage(arc.id);
 
       const var1 = await storage.construct('test1', barType, newStoreKey('variable')) as SingletonStorageProvider;
@@ -191,7 +200,7 @@ describe('firebase', function() {
         schema Bar
           value: Text
       `);
-      const arc = new Arc({id: ArcId.newForTest('test'), loader: new Loader(), context: manifest});
+      const arc = newArc(manifest);
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const value1 = 'Hi there' + Math.random();
@@ -217,7 +226,7 @@ describe('firebase', function() {
         schema Bar
           value: Text
       `);
-      const arc = new Arc({id: ArcId.newForTest('test'), loader: new Loader(), context: manifest});
+      const arc = newArc(manifest);
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const key = newStoreKey('collection');
@@ -234,7 +243,7 @@ describe('firebase', function() {
         schema Bar
           value: Text
       `);
-      const arc = new Arc({id: ArcId.newForTest('test'), loader: new Loader(), context: manifest});
+      const arc = newArc(manifest);
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const key = newStoreKey('collection');
@@ -254,7 +263,7 @@ describe('firebase', function() {
         schema Bar
           value: Text
       `);
-      const arc = new Arc({id: ArcId.newForTest('test'), loader: new Loader(), context: manifest});
+      const arc = newArc(manifest);
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const key = newStoreKey('collection');
@@ -273,7 +282,7 @@ describe('firebase', function() {
           value: Text
       `);
 
-      const arc = new Arc({id: ArcId.newForTest('test'), loader: new Loader(), context: manifest});
+      const arc = newArc(manifest);
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const key1 = newStoreKey('colPtr');
@@ -301,7 +310,7 @@ describe('firebase', function() {
           value: Text
       `);
 
-      const arc = new Arc({id: ArcId.newForTest('test'), loader: new Loader(), context: manifest});
+      const arc = newArc(manifest);
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const key1 = newStoreKey('colPtr');
@@ -324,7 +333,7 @@ describe('firebase', function() {
         schema Bar
           value: Text
       `);
-      const arc = new Arc({id: ArcId.newForTest('test'), loader: new Loader(), context: manifest});
+      const arc = newArc(manifest);
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const key = newStoreKey('collection');
@@ -343,7 +352,7 @@ describe('firebase', function() {
           data: Text
       `);
       const barType = new EntityType(manifest.schemas.Bar2);
-      const arc = new Arc({id: ArcId.newForTest('test'), loader: new Loader(), context: manifest});
+      const arc = newArc(manifest);
       const storage = createStorage(arc.id);
 
       const col1 = await storage.construct('test1', barType.collectionOf(), newStoreKey('collection')) as CollectionStorageProvider;
@@ -406,7 +415,7 @@ describe('firebase', function() {
         schema Bar
           data: Text
       `);
-      const arc = new Arc({id: ArcId.newForTest('test'), loader: new Loader(), context: manifest});
+      const arc = newArc(manifest);
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const key = newStoreKey('bigcollection');
@@ -482,7 +491,7 @@ describe('firebase', function() {
         schema Bar
           data: Text
       `);
-      const arc = new Arc({id: ArcId.newForTest('test'), loader: new Loader(), context: manifest});
+      const arc = newArc(manifest);
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const col = await storage.construct('test0', barType.bigCollectionOf(), newStoreKey('bigcollection')) as BigCollectionStorageProvider;
@@ -559,7 +568,7 @@ describe('firebase', function() {
         schema Bar
           data: Text
       `);
-      const arc = new Arc({id: ArcId.newForTest('test'), loader: new Loader(), context: manifest});
+      const arc = newArc(manifest);
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const col = await storage.construct('test0', barType.bigCollectionOf(), newStoreKey('bigcollection')) as BigCollectionStorageProvider;
@@ -725,7 +734,8 @@ describe('firebase', function() {
         `
       });
       const manifest = await Manifest.load('manifest', loader);
-      const arc = new Arc({id: ArcId.newForTest('test'), loader, context: manifest});
+      const storeRegistry = new TestStoreRegistry();
+      const arc = newArc(manifest, loader, storeRegistry);
       const storage = createStorage(arc.id);
       const dataType = new EntityType(manifest.schemas.Data);
 
@@ -758,7 +768,9 @@ describe('firebase', function() {
       await colStore.store({id: 'i5', rawData: {value: 'v5'}}, ['k5']);
       await bigStore.store({id: 'i6', rawData: {value: 'v6'}}, ['k6']);
 
-      const arc2 = await Arc.deserialize({serialization, loader, fileName: '', pecFactories: undefined, slotComposer: undefined, context: manifest});
+      const arc2 = await Arc.deserialize({serialization, loader,
+          storeRegistry, fileName: '', pecFactories: undefined,
+          slotComposer: undefined, context: manifest});
       const varStore2 = arc2.findStoreById(varStore.id) as SingletonStorageProvider;
       const colStore2 = arc2.findStoreById(colStore.id) as CollectionStorageProvider;
       const bigStore2 = arc2.findStoreById(bigStore.id) as BigCollectionStorageProvider;
@@ -789,7 +801,7 @@ describe('firebase', function() {
           data: Text
       `);
       const barType = new EntityType(manifest.schemas.Bar3);
-      const arc = new Arc({id: ArcId.newForTest('test'), loader: new Loader(), context: manifest});
+      const arc = newArc(manifest);
       const storage = createStorage(arc.id);
       const col = await storage.construct('test1', barType.collectionOf(), newStoreKey('collection')) as CollectionStorageProvider;
       const backing = await col.ensureBackingStore();

--- a/src/runtime/storageNG/unified-store.ts
+++ b/src/runtime/storageNG/unified-store.ts
@@ -182,3 +182,8 @@ export type StoreInfo = {
    */
   readonly includeKey?: string;
 };
+
+export interface StoreRegistry {
+  registerStore(store: UnifiedStore, tags: string[]): void;
+  unregisterStore(storeId: string, tags: string[]);
+}

--- a/src/runtime/testing/manifest-integration-test-setup.ts
+++ b/src/runtime/testing/manifest-integration-test-setup.ts
@@ -13,13 +13,16 @@ import {Arc} from '../arc.js';
 import {Loader} from '../../platform/loader.js';
 import {Manifest} from '../manifest.js';
 import {Id, ArcId} from '../id.js';
+import {TestStoreRegistry} from './test-store-registry.js';
 
 export async function manifestTestSetup() {
   const registry = {};
   const loader = new Loader();
   const manifest = await Manifest.load('./src/runtime/tests/artifacts/test.manifest', loader, registry);
   assert(manifest);
-  const arc = new Arc({id: ArcId.newForTest('test'), context: manifest, loader});
+  const storeRegistry = new TestStoreRegistry();
+  const arc = new Arc({id: ArcId.newForTest('test'), context: manifest,
+      loader, storeRegistry});
   const recipe = manifest.recipes[0];
   assert(recipe.normalize());
   assert(recipe.isResolved());

--- a/src/runtime/testing/test-store-registry.ts
+++ b/src/runtime/testing/test-store-registry.ts
@@ -1,0 +1,24 @@
+/**
+ * @license
+ * Copyright 2019 Google LLC.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {StoreRegistry, UnifiedStore} from '../storageNG/unified-store.js';
+
+/**
+ * A trivial registry implementation for testing purposes. Note that it
+ * does exactly nothing for now, though someday we might want to actually
+ * store, unregister, and allow inspection.
+ */
+export class TestStoreRegistry implements StoreRegistry {
+    registerStore(store: UnifiedStore, tags: string[]): void {
+    }
+
+    unregisterStore(storeId: string, tags: string[]) {
+    }
+}

--- a/src/runtime/tests/data-layer-test.ts
+++ b/src/runtime/tests/data-layer-test.ts
@@ -12,6 +12,7 @@ import {assert} from '../../platform/chai-web.js';
 import {Arc} from '../arc.js';
 import {Loader} from '../../platform/loader.js';
 import {FakeSlotComposer} from '../testing/fake-slot-composer.js';
+import {TestStoreRegistry} from '../testing/test-store-registry.js';
 import {Schema} from '../schema.js';
 import {EntityType} from '../type.js';
 import {Entity} from '../entity.js';
@@ -22,7 +23,7 @@ describe('entity', () => {
   it('can be created, stored, and restored', async () => {
     const schema = new Schema(['TestSchema'], {value: 'Text'});
 
-    const arc = new Arc({slotComposer: new FakeSlotComposer(), id: ArcId.newForTest('test'), context: null, loader: new Loader()});
+    const arc = new Arc({slotComposer: new FakeSlotComposer(), id: ArcId.newForTest('test'), context: null, loader: new Loader(), storeRegistry: new TestStoreRegistry()});
     const entity = new (Entity.createEntityClass(schema, null))({value: 'hello world'});
     assert.isDefined(entity);
 

--- a/src/runtime/tests/description-test.ts
+++ b/src/runtime/tests/description-test.ts
@@ -18,6 +18,7 @@ import {Recipe} from '../recipe/recipe.js';
 import {Relevance} from '../relevance.js';
 import {SingletonStorageProvider, BigCollectionStorageProvider} from '../storage/storage-provider-base.js';
 import {FakeSlotComposer} from '../testing/fake-slot-composer.js';
+import {TestStoreRegistry} from '../testing/test-store-registry.js';
 import {EntityType} from '../type.js';
 import {Entity} from '../entity.js';
 import {ArcId} from '../id.js';
@@ -26,7 +27,8 @@ import {ConCap} from '../../testing/test-util.js';
 
 function createTestArc(recipe: Recipe, manifest: Manifest) {
   const slotComposer = new FakeSlotComposer();
-  const arc = new Arc({slotComposer, id: ArcId.newForTest('test'), context: manifest, loader: new Loader()});
+  const storeRegistry = new TestStoreRegistry();
+  const arc = new Arc({slotComposer, id: ArcId.newForTest('test'), context: manifest, loader: new Loader(), storeRegistry});
   // TODO(lindner) stop messing with arc internal state, or provide a way to supply in constructor..
   arc['_activeRecipe'] = recipe;
   arc['_recipeDeltas'].push({particles: recipe.particles, handles: recipe.handles, slots: recipe.slots, patterns: recipe.patterns});

--- a/src/runtime/tests/handle-test.ts
+++ b/src/runtime/tests/handle-test.ts
@@ -17,6 +17,7 @@ import {EntityType, InterfaceType} from '../type.js';
 import {Entity} from '../entity.js';
 import {ArcId, IdGenerator} from '../id.js';
 import {NoOpStorageProxy} from '../storage-proxy.js';
+import {TestStoreRegistry} from '../testing/test-store-registry.js';
 // database providers are optional, these tests use these provider(s)
 import '../storage/pouchdb/pouch-db-provider.js';
 
@@ -24,13 +25,15 @@ describe('Handle', () => {
 
   let loader;
   let manifest;
+  let storeRegistry;
   before(async () => {
     loader = new Loader();
+    storeRegistry = new TestStoreRegistry();
     manifest = await Manifest.load('./src/runtime/tests/artifacts/test-particles.manifest', loader);
   });
 
   it('clear singleton store', async () => {
-    const arc = new Arc({id: ArcId.newForTest('test'), context: manifest, loader});
+    const arc = new Arc({id: ArcId.newForTest('test'), context: manifest, loader, storeRegistry});
     const barStore = await arc.createStore(new EntityType(manifest.schemas.Bar)) as SingletonStorageProvider;
     await barStore.set({id: 'an id', value: 'a Bar'});
     await barStore.clear();
@@ -41,7 +44,7 @@ describe('Handle', () => {
     // NOTE: Until entity mutation is distinct from collection modification,
     // referenceMode stores *can't* ignore duplicate stores of the same
     // entity value.
-    const arc = new Arc({id: ArcId.newForTest('test'), context: manifest, loader});
+    const arc = new Arc({id: ArcId.newForTest('test'), context: manifest, loader, storeRegistry});
     const store = await arc.createStore(new EntityType(manifest.schemas.Bar)) as SingletonStorageProvider;
     let version = 0;
     store.legacyOn(() => version++);
@@ -57,7 +60,7 @@ describe('Handle', () => {
   });
 
   it('ignores duplicate stores of the same entity value (collection)', async () => {
-    const arc = new Arc({id: ArcId.newForTest('test'), context: manifest, loader});
+    const arc = new Arc({id: ArcId.newForTest('test'), context: manifest, loader, storeRegistry});
     const barStore = await arc.createStore(new EntityType(manifest.schemas.Bar).collectionOf()) as CollectionStorageProvider;
     let version = 0;
     barStore.legacyOn(({add: [{effective}]}) => {if (effective) version++;});
@@ -74,7 +77,7 @@ describe('Handle', () => {
   });
 
   it('dedupes common user-provided ids', async () => {
-    const arc = new Arc({id: ArcId.newForTest('test'), context: manifest, loader});
+    const arc = new Arc({id: ArcId.newForTest('test'), context: manifest, loader, storeRegistry});
 
     // tslint:disable-next-line: variable-name
     const Foo = Entity.createEntityClass(manifest.schemas.Foo, null);
@@ -87,7 +90,7 @@ describe('Handle', () => {
   });
 
   it('allows updates with same user-provided ids but different value (collection)', async () => {
-    const arc = new Arc({id: ArcId.newForTest('test'), context: manifest, loader});
+    const arc = new Arc({id: ArcId.newForTest('test'), context: manifest, loader, storeRegistry});
 
     // tslint:disable-next-line: variable-name
     const Foo = Entity.createEntityClass(manifest.schemas.Foo, null);
@@ -100,7 +103,7 @@ describe('Handle', () => {
   });
 
   it('allows updates with same user-provided ids but different value (singleton)', async () => {
-    const arc = new Arc({id: ArcId.newForTest('test'), context: manifest, loader});
+    const arc = new Arc({id: ArcId.newForTest('test'), context: manifest, loader, storeRegistry});
 
     // tslint:disable-next-line: variable-name
     const Foo = Entity.createEntityClass(manifest.schemas.Foo, null);
@@ -113,7 +116,7 @@ describe('Handle', () => {
   });
 
   it('disable handle sets storage into a noOp storage', async () => {
-    const arc = new Arc({id: ArcId.newForTest('test'), context: manifest, loader});
+    const arc = new Arc({id: ArcId.newForTest('test'), context: manifest, loader, storeRegistry});
 
     // tslint:disable-next-line: variable-name
     const Foo = Entity.createEntityClass(manifest.schemas.Foo, null);
@@ -126,7 +129,7 @@ describe('Handle', () => {
   });
 
   it('remove entry from store', async () => {
-    const arc = new Arc({id: ArcId.newForTest('test'), context: manifest, loader});
+    const arc = new Arc({id: ArcId.newForTest('test'), context: manifest, loader, storeRegistry});
     const barStore = await arc.createStore(new EntityType(manifest.schemas.Bar).collectionOf()) as CollectionStorageProvider;
     const bar = {id: 'an id', value: 'a Bar'};
     await barStore.store(bar, ['key1']);
@@ -135,7 +138,7 @@ describe('Handle', () => {
   });
 
   it('can store a particle in an interface store', async () => {
-    const arc = new Arc({id: ArcId.newForTest('test'), context: manifest, loader});
+    const arc = new Arc({id: ArcId.newForTest('test'), context: manifest, loader, storeRegistry});
 
     const iface = InterfaceType.make('Test', [
       {type: new EntityType(manifest.schemas.Foo), direction: 'any'},
@@ -149,7 +152,7 @@ describe('Handle', () => {
   });
 
   it('createHandle only allows valid tags & types in stores', async () => {
-    const arc = new Arc({id: ArcId.newForTest('test'), context: manifest, loader});
+    const arc = new Arc({id: ArcId.newForTest('test'), context: manifest, loader, storeRegistry});
 
     await arc.createStore(new EntityType(manifest.schemas.Bar), 'name', 'id1', ['#sufficient']);
     await arc.createStore(new EntityType(manifest.schemas.Bar), 'name', 'id2', ['#valid']);
@@ -161,7 +164,7 @@ describe('Handle', () => {
 
   it('uses default storage keys', async () => {
     const arc = new Arc({id: ArcId.newForTest('test'), storageKey: 'pouchdb://memory/yyy/test',
-                         context: manifest, loader});
+                         context: manifest, loader, storeRegistry});
     const singleton = await arc.createStore(new EntityType(manifest.schemas.Bar), 'foo', 'test1') as SingletonStorageProvider;
     assert.strictEqual(singleton.storageKey, 'pouchdb://memory/yyy/test/handles/test1');
   });

--- a/src/runtime/tests/multiplexer-test.ts
+++ b/src/runtime/tests/multiplexer-test.ts
@@ -15,6 +15,7 @@ import {Loader} from '../../platform/loader.js';
 import {Manifest} from '../manifest.js';
 import {checkDefined} from '../testing/preconditions.js';
 import {FakeSlotComposer} from '../testing/fake-slot-composer.js';
+import {TestStoreRegistry} from '../testing/test-store-registry.js';
 import {collectionHandleForTest} from '../testing/handle-for-test.js';
 import {Flags} from '../flags.js';
 
@@ -48,7 +49,7 @@ describe('Multiplexer', () => {
       return slotComposerCreateHostedSlot.apply(slotComposer, args);
     };
 
-    const arc = new Arc({id: ArcId.newForTest('test'), context: manifest, slotComposer, loader: new Loader()});
+    const arc = new Arc({id: ArcId.newForTest('test'), context: manifest, slotComposer, loader: new Loader(), storeRegistry: new TestStoreRegistry()});
     const barStore = await arc.createStore(barType.collectionOf(), null, 'test:1');
     const barHandle = await collectionHandleForTest(arc, barStore);
     recipe.handles[0].mapToStorage(barStore);
@@ -96,7 +97,7 @@ describe('Multiplexer', () => {
       return slotComposerCreateHostedSlot.apply(slotComposer, args);
     };
 
-    const arc = new Arc({id: ArcId.newForTest('test'), context: manifest, slotComposer, loader: new Loader()});
+    const arc = new Arc({id: ArcId.newForTest('test'), context: manifest, slotComposer, loader: new Loader(), storeRegistry: new TestStoreRegistry()});
     const barStore = await arc.createStore(barType.collectionOf(), null, 'test:1');
     const barHandle = await collectionHandleForTest(arc, barStore);
     recipe.handles[0].mapToStorage(barStore);

--- a/src/runtime/tests/particle-api-test.ts
+++ b/src/runtime/tests/particle-api-test.ts
@@ -11,6 +11,7 @@
 import {assert} from '../../platform/chai-web.js';
 import {FakeSlotComposer} from '../testing/fake-slot-composer.js';
 import {MockSlotComposer} from '../testing/mock-slot-composer.js';
+import {TestStoreRegistry} from '../testing/test-store-registry.js';
 import {StubLoader} from '../testing/stub-loader.js';
 import {Arc} from '../arc.js';
 import {Description} from '../description.js';
@@ -946,7 +947,8 @@ describe('particle-api', () => {
     });
 
     const id = IdGenerator.createWithSessionIdForTesting('session').newArcId('test');
-    const arc = new Arc({id, loader, context: null});
+    const storeRegistry = new TestStoreRegistry();
+    const arc = new Arc({id, loader, storeRegistry, context: null});
     const manifest = await Manifest.load('manifest', loader);
     const recipe = manifest.recipes[0];
 
@@ -998,7 +1000,8 @@ describe('particle-api', () => {
     });
 
     const id = IdGenerator.createWithSessionIdForTesting('session').newArcId('test');
-    const arc = new Arc({id, loader, context: null});
+    const storeRegistry = new TestStoreRegistry();
+    const arc = new Arc({id, loader, storeRegistry, context: null});
     const manifest = await Manifest.load('manifest', loader);
     const recipe = manifest.recipes[0];
 
@@ -1050,7 +1053,8 @@ describe('particle-api', () => {
     });
 
     const id = IdGenerator.createWithSessionIdForTesting('session').newArcId('test');
-    const arc = new Arc({id, loader, context: null});
+    const storeRegistry = new TestStoreRegistry();
+    const arc = new Arc({id, loader, storeRegistry, context: null});
     const manifest = await Manifest.load('manifest', loader);
     const recipe = manifest.recipes[0];
 
@@ -1101,18 +1105,19 @@ describe('particle-api', () => {
       `
     });
 
-     const id = IdGenerator.createWithSessionIdForTesting('session').newArcId('test');
-    const arc = new Arc({id, loader, context: null});
+    const id = IdGenerator.createWithSessionIdForTesting('session').newArcId('test');
+    const storeRegistry = new TestStoreRegistry();
+    const arc = new Arc({id, loader, storeRegistry, context: null});
     const manifest = await Manifest.load('manifest', loader);
     const recipe = manifest.recipes[0];
 
-     const inStore = await arc.createStore(new EntityType(new Schema([], {})), 'h0', 'test:0');
+    const inStore = await arc.createStore(new EntityType(new Schema([], {})), 'h0', 'test:0');
     const outStore = await arc.createStore(new EntityType(new Schema([], {result: 'Text'})), 'h1', 'test:1');
     recipe.handles[0].mapToStorage(inStore);
     recipe.handles[1].mapToStorage(outStore);
     recipe.normalize();
 
-     const {speculativeArc, relevance} = await (new Speculator()).speculate(arc, recipe, 'recipe-hash');
+    const {speculativeArc, relevance} = await (new Speculator()).speculate(arc, recipe, 'recipe-hash');
     const description = await Description.create(speculativeArc, relevance);
     assert.strictEqual(description.getRecipeSuggestion(), 'Out is hi!');
   });
@@ -1163,13 +1168,14 @@ describe('particle-api', () => {
       `
     });
 
-     const id = IdGenerator.createWithSessionIdForTesting('session').newArcId('test');
-    const arc = new Arc({id, loader, context: null});
+    const id = IdGenerator.createWithSessionIdForTesting('session').newArcId('test');
+    const storeRegistry = new TestStoreRegistry();
+    const arc = new Arc({id, loader, storeRegistry, context: null});
     const manifest = await Manifest.load('manifest', loader);
     const recipe = manifest.recipes[0];
     assert.isTrue(recipe.normalize());
 
-     const {speculativeArc, relevance} = await (new Speculator()).speculate(arc, recipe, 'recipe-hash');
+    const {speculativeArc, relevance} = await (new Speculator()).speculate(arc, recipe, 'recipe-hash');
     const description = await Description.create(speculativeArc, relevance);
     assert.strictEqual(description.getRecipeSuggestion(), 'Out is hi!');
   });
@@ -1222,8 +1228,14 @@ describe('particle-api', () => {
     });
     // TODO(lindner): add strict rendering
     const slotComposer = new MockSlotComposer({strict: false}).newExpectations('debug');
-    const arc = new Arc({id: IdGenerator.newSession().newArcId('demo'),
-        storageKey: 'key', loader, slotComposer, context});
+    const storeRegistry = new TestStoreRegistry();
+    const arc = new Arc({
+        id: IdGenerator.newSession().newArcId('demo'),
+        storageKey: 'key',
+        loader,
+        storeRegistry,
+        slotComposer,
+        context});
     const [recipe] = arc.context.recipes;
     recipe.normalize();
 
@@ -1296,8 +1308,14 @@ describe('particle-api', () => {
     });
     // TODO(lindner): add strict rendering
     const slotComposer = new MockSlotComposer({strict: false}).newExpectations('debug');
-    const arc = new Arc({id: IdGenerator.newSession().newArcId('demo'),
-        storageKey: 'key', loader, slotComposer, context});
+    const storeRegistry = new TestStoreRegistry();
+    const arc = new Arc({
+        id: IdGenerator.newSession().newArcId('demo'),
+        storageKey: 'key',
+        loader,
+        storeRegistry,
+        slotComposer,
+        context});
     const [recipe] = arc.context.recipes;
     recipe.normalize();
 

--- a/src/runtime/tests/particle-execution-context-test.ts
+++ b/src/runtime/tests/particle-execution-context-test.ts
@@ -15,6 +15,7 @@ import {HeadlessSlotDomConsumer} from '../headless-slot-dom-consumer.js';
 import {Manifest} from '../manifest.js';
 import {MockSlotComposer} from '../testing/mock-slot-composer.js';
 import {StubLoader} from '../testing/stub-loader.js';
+import {TestStoreRegistry} from '../testing/test-store-registry.js';
 
 describe('Particle Execution Context', () => {
   it('substitutes slot names for model references', async () => {
@@ -36,7 +37,8 @@ describe('Particle Execution Context', () => {
       });`
     });
     const slotComposer = new MockSlotComposer({strict: false}).newExpectations('debug');
-    const arc = new Arc({id: ArcId.newForTest('demo'), storageKey: 'volatile://', slotComposer, loader, context});
+    const storeRegistry = new TestStoreRegistry();
+    const arc = new Arc({id: ArcId.newForTest('demo'), storageKey: 'volatile://', slotComposer, loader, storeRegistry, context});
     const [recipe] = arc.context.recipes;
     recipe.normalize();
     await arc.instantiate(recipe);

--- a/src/runtime/tests/particle-interface-loading-test.ts
+++ b/src/runtime/tests/particle-interface-loading-test.ts
@@ -19,6 +19,7 @@ import {ParticleSpec} from '../particle-spec.js';
 import {ArcId} from '../id.js';
 import {SingletonStorageProvider} from '../storage/storage-provider-base.js';
 import {singletonHandleForTest} from '../testing/handle-for-test.js';
+import {TestStoreRegistry} from '../testing/test-store-registry.js';
 
 describe('particle interface loading', () => {
 
@@ -61,7 +62,8 @@ describe('particle interface loading', () => {
           });`});
 
     const manifest = await Manifest.load('./src/runtime/tests/artifacts/test-particles.manifest', loader);
-    const arc = new Arc({id: ArcId.newForTest('test'), loader, context: manifest});
+    const storeRegistry = new TestStoreRegistry();
+    const arc = new Arc({id: ArcId.newForTest('test'), loader, storeRegistry, context: manifest});
 
     const fooType = new EntityType(manifest.schemas.Foo);
     const barType = new EntityType(manifest.schemas.Bar);
@@ -132,7 +134,8 @@ describe('particle interface loading', () => {
           input: reads h1
       `, {loader, fileName: './test.manifest'});
 
-    const arc = new Arc({id: ArcId.newForTest('test'), context: manifest, loader});
+    const storeRegistry = new TestStoreRegistry();
+    const arc = new Arc({id: ArcId.newForTest('test'), context: manifest, loader, storeRegistry});
 
     const fooType = manifest.findTypeByName('Foo');
     const barType = manifest.findTypeByName('Bar');
@@ -215,7 +218,8 @@ describe('particle interface loading', () => {
         });
       `
     });
-    const arc = new Arc({id: ArcId.newForTest('test'), context: manifest, loader});
+    const storeRegistry = new TestStoreRegistry();
+    const arc = new Arc({id: ArcId.newForTest('test'), context: manifest, loader, storeRegistry});
     const fooType = manifest.findTypeByName('Foo');
     const fooStore = await arc.createStore(fooType);
     recipe.handles[0].mapToStorage(fooStore);

--- a/src/runtime/tests/particle-interface-loading-with-slots-test.ts
+++ b/src/runtime/tests/particle-interface-loading-with-slots-test.ts
@@ -18,6 +18,7 @@ import {HostedSlotContext, ProvidedSlotContext} from '../slot-context.js';
 import {MockSlotComposer} from '../testing/mock-slot-composer.js';
 import {Recipe} from '../recipe/recipe.js';
 import {collectionHandleForTest} from '../testing/handle-for-test.js';
+import {TestStoreRegistry} from '../testing/test-store-registry.js';
 import {CollectionHandle} from '../storageNG/handle.js';
 import {Entity} from '../entity.js';
 
@@ -41,7 +42,8 @@ describe('particle interface loading with slots', () => {
       `, {loader, fileName: ''});
     const recipe = manifest.recipes[0];
 
-    const arc = new Arc({id: ArcId.newForTest('test'), slotComposer, context: manifest, loader});
+    const storeRegistry = new TestStoreRegistry();
+    const arc = new Arc({id: ArcId.newForTest('test'), slotComposer, context: manifest, loader, storeRegistry});
 
     assert(recipe.normalize(), `can't normalize recipe`);
     assert(recipe.isResolved(), `recipe isn't resolved`);

--- a/src/runtime/tests/recipe-resolver-test.ts
+++ b/src/runtime/tests/recipe-resolver-test.ts
@@ -14,6 +14,7 @@ import {Loader} from '../../platform/loader.js';
 import {Manifest} from '../manifest.js';
 import {RecipeResolver} from '../recipe/recipe-resolver.js';
 import {FakeSlotComposer} from '../testing/fake-slot-composer.js';
+import {TestStoreRegistry} from '../testing/test-store-registry.js';
 import {StubLoader} from '../testing/stub-loader.js';
 import {Id, ArcId} from '../id.js';
 
@@ -24,7 +25,12 @@ describe('RecipeResolver', () => {
     return await Manifest.load('manifest', loader, {registry});
   };
 
-  const createArc = (manifest) => new Arc({id: ArcId.newForTest('test'), slotComposer: new FakeSlotComposer(), loader: new Loader(), context: manifest});
+  const createArc = (manifest) => new Arc({
+      id: ArcId.newForTest('test'),
+      slotComposer: new FakeSlotComposer(),
+      loader: new Loader(),
+      storeRegistry: new TestStoreRegistry(),
+      context: manifest});
 
   it('resolves a recipe', async () => {
     const manifest = await buildManifest({

--- a/src/runtime/tests/reference-test.ts
+++ b/src/runtime/tests/reference-test.ts
@@ -17,9 +17,15 @@ import {StubLoader} from '../testing/stub-loader.js';
 import {EntityType, ReferenceType, CollectionType} from '../type.js';
 import {Id} from '../id.js';
 import {collectionHandleForTest, singletonHandleForTest} from '../testing/handle-for-test.js';
+import {TestStoreRegistry} from '../testing/test-store-registry.js';
 import {Entity} from '../entity.js';
 
 describe('references', () => {
+  let storeRegistry;
+  beforeEach(() => {
+    storeRegistry = new TestStoreRegistry();
+  });
+
   it('can parse & validate a recipe containing references', async () => {
     const manifest = await Manifest.parse(`
         schema Result
@@ -89,7 +95,7 @@ describe('references', () => {
     });
 
     const manifest = await Manifest.load('manifest', loader);
-    const arc = new Arc({id: Id.fromString('test:0'), loader, context: manifest});
+    const arc = new Arc({id: Id.fromString('test:0'), loader, storeRegistry, context: manifest});
     const recipe = manifest.recipes[0];
     assert.isTrue(recipe.normalize());
     assert.isTrue(recipe.isResolved());
@@ -148,7 +154,7 @@ describe('references', () => {
     });
 
     const manifest = await Manifest.load('manifest', loader);
-    const arc = new Arc({id: Id.fromString('test:0'), loader, context: manifest});
+    const arc = new Arc({id: Id.fromString('test:0'), loader, storeRegistry, context: manifest});
     const recipe = manifest.recipes[0];
     assert.isTrue(recipe.normalize());
     assert.isTrue(recipe.isResolved());
@@ -212,7 +218,7 @@ describe('references', () => {
     });
 
     const manifest = await Manifest.load('manifest', loader);
-    const arc = new Arc({id: Id.fromString('test:0'), loader, context: manifest});
+    const arc = new Arc({id: Id.fromString('test:0'), loader, storeRegistry, context: manifest});
 
     const recipe = manifest.recipes[0];
     assert.isTrue(recipe.normalize());
@@ -269,7 +275,7 @@ describe('references', () => {
     });
 
     const manifest = await Manifest.load('manifest', loader);
-    const arc = new Arc({id: Id.fromString('test:0'), loader, context: manifest});
+    const arc = new Arc({id: Id.fromString('test:0'), loader, storeRegistry, context: manifest});
     const recipe = manifest.recipes[0];
     assert.isTrue(recipe.normalize());
     assert.isTrue(recipe.isResolved());
@@ -369,7 +375,7 @@ describe('references', () => {
     });
 
     const manifest = await Manifest.load('manifest', loader);
-    const arc = new Arc({id: Id.fromString('test:0'), loader, context: manifest});
+    const arc = new Arc({id: Id.fromString('test:0'), loader, storeRegistry, context: manifest});
     const recipe = manifest.recipes[0];
     assert.isTrue(recipe.normalize());
     assert.isTrue(recipe.isResolved());
@@ -443,7 +449,7 @@ describe('references', () => {
     });
 
     const manifest = await Manifest.load('manifest', loader);
-    const arc = new Arc({id: Id.fromString('test:0'), loader, context: manifest});
+    const arc = new Arc({id: Id.fromString('test:0'), loader, storeRegistry, context: manifest});
     const recipe = manifest.recipes[0];
     assert.isTrue(recipe.normalize());
     assert.isTrue(recipe.isResolved());
@@ -523,7 +529,7 @@ describe('references', () => {
     });
 
     const manifest = await Manifest.load('manifest', loader);
-    const arc = new Arc({id: Id.fromString('test:0'), loader, context: manifest});
+    const arc = new Arc({id: Id.fromString('test:0'), loader, storeRegistry, context: manifest});
     const recipe = manifest.recipes[0];
     assert.isTrue(recipe.normalize());
     assert.isTrue(recipe.isResolved());

--- a/src/runtime/tests/runtime-test.ts
+++ b/src/runtime/tests/runtime-test.ts
@@ -15,6 +15,7 @@ import {Loader} from '../../platform/loader.js';
 import {Manifest} from '../manifest.js';
 import {Runtime} from '../runtime.js';
 import {FakeSlotComposer} from '../testing/fake-slot-composer.js';
+import {TestStoreRegistry} from '../testing/test-store-registry.js';
 import {ArcId} from '../id.js';
 import {StubLoader} from '../testing/stub-loader.js';
 import {TestVolatileMemoryProvider} from '../testing/test-volatile-memory-provider.js';
@@ -33,8 +34,13 @@ function assertManifestsEqual(actual: Manifest, expected: Manifest) {
 
 describe('Runtime', () => {
   it('gets an arc description for an arc', async () => {
-    const arc = new Arc({slotComposer: new FakeSlotComposer(), id: ArcId.newForTest('test'), loader: new Loader(),
-                         context: new Manifest({id: ArcId.newForTest('test')})});
+    const arc = new Arc({
+        slotComposer: new FakeSlotComposer(),
+        id: ArcId.newForTest('test'),
+        loader: new Loader(),
+        storeRegistry: new TestStoreRegistry(),
+        context: new Manifest({id: ArcId.newForTest('test')})
+      });
     const description = await Description.create(arc);
     const expected = await description.getArcDescription();
     const actual = await Runtime.getArcDescription(arc);

--- a/src/runtime/tests/storage/pouchdb/pouch-db-test.ts
+++ b/src/runtime/tests/storage/pouchdb/pouch-db-test.ts
@@ -18,6 +18,7 @@ import {PouchDbStorage} from '../../../storage/pouchdb/pouch-db-storage.js';
 import {PouchDbSingleton} from '../../../storage/pouchdb/pouch-db-singleton.js';
 import {StorageProviderFactory} from '../../../storage/storage-provider-factory.js';
 import {CallbackTracker} from '../../../testing/callback-tracker.js';
+import {TestStoreRegistry} from '../../../testing/test-store-registry.js';
 import {EntityType, ReferenceType} from '../../../type.js';
 import {Id, ArcId} from '../../../id.js';
 
@@ -60,13 +61,25 @@ describe('pouchdb for ' + testUrl, () => {
     storageInstances.clear();
   });
 
+  const newArc = async () => {
+    const context = await Manifest.parse(`
+      schema Bar
+        value: Text
+    `);
+    return {
+        manifest: context,
+        arc: new Arc({
+            id: ArcId.newForTest('test'),
+            context,
+            loader: new Loader(),
+            storeRegistry: new TestStoreRegistry()
+        })
+    };
+  };
+
   describe('variable', () => {
     it('supports basic construct and mutate', async () => {
-      const manifest = await Manifest.parse(`
-        schema Bar
-          value: Text
-      `);
-      const arc = new Arc({id: ArcId.newForTest('test'), context: manifest, loader: new Loader()});
+      const {manifest, arc} = await newArc();
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const value = 'Hi there' + Math.random();
@@ -80,11 +93,7 @@ describe('pouchdb for ' + testUrl, () => {
     });
 
     it('resolves concurrent set', async () => {
-      const manifest = await Manifest.parse(`
-        schema Bar
-          value: Text
-      `);
-      const arc = new Arc({id: ArcId.newForTest('test'), context: manifest, loader: new Loader()});
+      const {manifest, arc} = await newArc();
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const key = newStoreKey('variable');
@@ -111,12 +120,7 @@ describe('pouchdb for ' + testUrl, () => {
     });
 
     it('enables referenceMode by default', async () => {
-      const manifest = await Manifest.parse(`
-        schema Bar
-          value: Text
-      `);
-
-      const arc = new Arc({id: ArcId.newForTest('test'), context: manifest, loader: new Loader()});
+      const {manifest, arc} = await newArc();
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const key1 = newStoreKey('varPtr');
@@ -134,12 +138,7 @@ describe('pouchdb for ' + testUrl, () => {
     });
 
     it('supports references', async () => {
-      const manifest = await Manifest.parse(`
-        schema Bar
-          value: Text
-      `);
-
-      const arc = new Arc({id: ArcId.newForTest('test'),  context: manifest, loader: new Loader()});
+      const {manifest, arc} = await newArc();
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const key1 = newStoreKey('varPtr');
@@ -157,11 +156,7 @@ describe('pouchdb for ' + testUrl, () => {
 
   describe('collection', () => {
     it('supports basic construct and mutate', async () => {
-      const manifest = await Manifest.parse(`
-        schema Bar
-          value: Text
-      `);
-      const arc = new Arc({id: ArcId.newForTest('test'), context: manifest, loader: new Loader()});
+      const {manifest, arc} = await newArc();
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const value1 = 'Hi there' + Math.random();
@@ -176,11 +171,7 @@ describe('pouchdb for ' + testUrl, () => {
       assert.deepEqual(result, [{id: 'id0', value: value1}, {id: 'id1', value: value2}]);
     });
     it('resolves concurrent add of same id', async () => {
-      const manifest = await Manifest.parse(`
-        schema Bar
-          value: Text
-      `);
-      const arc = new Arc({id: ArcId.newForTest('test'), context: manifest, loader: new Loader()});
+      const {manifest, arc} = await newArc();
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const key = newStoreKey('collection');
@@ -197,11 +188,7 @@ describe('pouchdb for ' + testUrl, () => {
     });
 
     it('resolves concurrent add/remove of same id', async () => {
-      const manifest = await Manifest.parse(`
-        schema Bar
-          value: Text
-      `);
-      const arc = new Arc({id: ArcId.newForTest('test'), context: manifest, loader: new Loader()});
+      const {manifest, arc} = await newArc();
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const key = newStoreKey('collection');
@@ -217,11 +204,7 @@ describe('pouchdb for ' + testUrl, () => {
       assert.isEmpty(await collection2.toList());
     });
     it('resolves concurrent add of different id', async () => {
-      const manifest = await Manifest.parse(`
-        schema Bar
-          value: Text
-      `);
-      const arc = new Arc({id: ArcId.newForTest('test'), context: manifest, loader: new Loader()});
+      const {manifest, arc} = await newArc();
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const key = newStoreKey('collection');
@@ -238,12 +221,7 @@ describe('pouchdb for ' + testUrl, () => {
     });
 
     it('enables referenceMode by default', async () => {
-      const manifest = await Manifest.parse(`
-        schema Bar
-          value: Text
-      `);
-
-      const arc = new Arc({id: ArcId.newForTest('test'), context: manifest, loader: new Loader()});
+      const {manifest, arc} = await newArc();
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const key1 = newStoreKey('colPtr');
@@ -266,11 +244,7 @@ describe('pouchdb for ' + testUrl, () => {
     });
 
     it('supports removeMultiple', async () => {
-      const manifest = await Manifest.parse(`
-        schema Bar
-          value: Text
-      `);
-      const arc = new Arc({id: ArcId.newForTest('test'), context: manifest, loader: new Loader()});
+      const {manifest, arc} = await newArc();
       const storage = new StorageProviderFactory(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const key = newStoreKey('collectionRemoveMultiple');
@@ -286,12 +260,7 @@ describe('pouchdb for ' + testUrl, () => {
     });
 
     it('supports references', async () => {
-      const manifest = await Manifest.parse(`
-        schema Bar
-          value: Text
-      `);
-
-      const arc = new Arc({id: ArcId.newForTest('test'), context: manifest, loader: new Loader()});
+      const {manifest, arc} = await newArc();
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const key1 = newStoreKey('colPtr');
@@ -312,11 +281,7 @@ describe('pouchdb for ' + testUrl, () => {
       callbackTracker.verify();
     });
     it('supports removeMultiple', async () => {
-      const manifest = await Manifest.parse(`
-        schema Bar
-          value: Text
-      `);
-      const arc = new Arc({id: ArcId.newForTest('test'), context: manifest, loader: new Loader()});
+      const {manifest, arc} = await newArc();
       const storage = createStorage(arc.id);
       const barType = new EntityType(manifest.schemas.Bar);
       const key = newStoreKey('collection');

--- a/src/tests/hotreload-integration-test.ts
+++ b/src/tests/hotreload-integration-test.ts
@@ -19,6 +19,7 @@ import {FakePecFactory} from '../runtime/fake-pec-factory.js';
 import {HeadlessSlotDomConsumer} from '../runtime/headless-slot-dom-consumer.js';
 import {singletonHandleForTest} from '../runtime/testing/handle-for-test.js';
 import {RuntimeCacheService} from '../runtime/runtime-cache.js';
+import {TestStoreRegistry} from '../runtime/testing/test-store-registry.js';
 import {VolatileStorage} from '../runtime/storage/volatile-storage.js';
 
 class StubWasmLoader extends Loader {
@@ -67,7 +68,8 @@ describe('Hot Code Reload for JS Particle', async () => {
     const id = ArcId.newForTest('HotReload');
     const pecFactories = [FakePecFactory(loader).bind(null)];
     const slotComposer = new FakeSlotComposer();
-    const arc = new Arc({id, pecFactories, slotComposer, loader, context});
+    const storeRegistry = new TestStoreRegistry();
+    const arc = new Arc({id, pecFactories, slotComposer, loader, context, storeRegistry});
 
     const [recipe] = arc.context.recipes;
     assert.isTrue(recipe.normalize() && recipe.isResolved());
@@ -131,7 +133,8 @@ describe('Hot Code Reload for JS Particle', async () => {
       });`
     });
 
-    const arc = new Arc({id: ArcId.newForTest('test'), context, loader});
+    const storeRegistry = new TestStoreRegistry();
+    const arc = new Arc({id: ArcId.newForTest('test'), context, loader, storeRegistry});
     const personType = context.findTypeByName('Person');
 
     const personStoreIn = await arc.createStore(personType);
@@ -198,7 +201,8 @@ describe('Hot Code Reload for WASM Particle', async () => {
     const id = ArcId.newForTest('HotReload');
     const pecFactories = [FakePecFactory(loader).bind(null)];
     const slotComposer = new FakeSlotComposer();
-    const arc = new Arc({id, pecFactories, slotComposer, loader, context});
+    const storeRegistry = new TestStoreRegistry();
+    const arc = new Arc({id, pecFactories, slotComposer, loader, storeRegistry, context});
 
     const [recipe] = arc.context.recipes;
     assert.isTrue(recipe.normalize() && recipe.isResolved());
@@ -233,7 +237,8 @@ describe('Hot Code Reload for WASM Particle', async () => {
           personIn: reads personIn
           personOut: writes personOut`, {loader, fileName: './input.arcs'});
 
-    const arc = new Arc({id: ArcId.newForTest('test'), context, loader});
+    const storeRegistry = new TestStoreRegistry();
+    const arc = new Arc({id: ArcId.newForTest('test'), context, loader, storeRegistry});
     const personType = context.findTypeByName('Person');
 
     const personStoreIn = await arc.createStore(personType);

--- a/src/tests/particles/TicTacToe/moveapplier-test.ts
+++ b/src/tests/particles/TicTacToe/moveapplier-test.ts
@@ -13,6 +13,7 @@ import {Manifest} from '../../../runtime/manifest.js';
 import {Loader} from '../../../platform/loader.js';
 import {Arc} from '../../../runtime/arc.js';
 import {FakeSlotComposer} from '../../../runtime/testing/fake-slot-composer.js';
+import {TestStoreRegistry} from '../../../runtime/testing/test-store-registry.js';
 import {ArcId} from '../../../runtime/id.js';
 import {singletonHandleForTest} from '../../../runtime/testing/handle-for-test.js';
 
@@ -36,8 +37,14 @@ describe('TicTacToe MoveApplier tests', () => {
     const recipe = manifest.recipes[0];
     assert.isTrue(recipe.normalize());
     assert.isTrue(recipe.isResolved(), recipe.toString({showUnresolved: true}));
-    const arc = new Arc({slotComposer: new FakeSlotComposer(), loader, context: manifest, id: ArcId.newForTest('test'),
-                         storageKey: 'volatile://test^^123'});
+    const storeRegistry = new TestStoreRegistry();
+    const arc = new Arc({
+        slotComposer: new FakeSlotComposer(),
+        loader,
+        storeRegistry,
+        context: manifest,
+        id: ArcId.newForTest('test'),
+        storageKey: 'volatile://test^^123'});
     await arc.instantiate(recipe);
     const {nextMoveStore, stateStore, boardResultStore, messageResultStore, boardStore} = await createTestHandles(arc);
 
@@ -61,8 +68,14 @@ describe('TicTacToe MoveApplier tests', () => {
     const recipe = manifest.recipes[0];
     assert.isTrue(recipe.normalize());
     assert.isTrue(recipe.isResolved(), recipe.toString({showUnresolved: true}));
-    const arc = new Arc({slotComposer: new FakeSlotComposer(), loader, context: manifest, id: ArcId.newForTest('test'),
-                         storageKey: 'volatile://test^^123'});
+    const storeRegistry = new TestStoreRegistry();
+    const arc = new Arc({
+        slotComposer: new FakeSlotComposer(),
+        loader,
+        storeRegistry,
+        context: manifest,
+        id: ArcId.newForTest('test'),
+        storageKey: 'volatile://test^^123'});
     await arc.instantiate(recipe);
     const {nextMoveStore, stateStore, boardResultStore, messageResultStore, boardStore} = await createTestHandles(arc);
 

--- a/src/tests/particles/products-test.ts
+++ b/src/tests/particles/products-test.ts
@@ -16,6 +16,7 @@ import {Manifest} from '../../runtime/manifest.js';
 import {Runtime} from '../../runtime/runtime.js';
 import {MockSlotComposer} from '../../runtime/testing/mock-slot-composer.js';
 import {FakeSlotComposer} from '../../runtime/testing/fake-slot-composer.js';
+import {TestStoreRegistry} from '../../runtime/testing/test-store-registry.js';
 import {StorageProviderBase} from '../../runtime/storage/storage-provider-base.js';
 import {TestVolatileMemoryProvider} from '../../runtime/testing/test-volatile-memory-provider.js';
 
@@ -49,10 +50,12 @@ describe('products test', () => {
     const memoryProvider = new TestVolatileMemoryProvider();
     const slotComposer = new MockSlotComposer({strict: false});
     const id = IdGenerator.newSession().newArcId('demo');
+    const storeRegistry = new TestStoreRegistry();
     const arc = new Arc({
       id,
       storageKey: `volatile://${id.toString()}`,
       loader,
+      storeRegistry,
       slotComposer,
       context: await Manifest.load(manifestFilename, loader, {memoryProvider})
     });

--- a/src/tests/slot-composer-test.ts
+++ b/src/tests/slot-composer-test.ts
@@ -16,6 +16,7 @@ import {Loader} from '../platform/loader.js';
 import {HostedSlotContext, ProvidedSlotContext} from '../runtime/slot-context.js';
 import {MockSlotComposer} from '../runtime/testing/mock-slot-composer.js';
 import {StubLoader} from '../runtime/testing/stub-loader.js';
+import {TestStoreRegistry} from '../runtime/testing/test-store-registry.js';
 import {StrategyTestHelper} from '../planning/testing/strategy-test-helper.js';
 import {Id, ArcId} from '../runtime/id.js';
 import {Manifest} from '../runtime/manifest.js';
@@ -28,11 +29,13 @@ async function initSlotComposer(recipeStr) {
   const loader = new StubLoader({
     '*': `defineParticle(({Particle}) => { return class P extends Particle {} });`
   });
+  const storeRegistry = new TestStoreRegistry();
   const arc = new Arc({
     id: ArcId.newForTest('test-plan-arc'),
     context: manifest,
     slotComposer,
-    loader
+    loader,
+    storeRegistry
   });
   const startRenderParticles: string[] = [];
   arc.pec.startRender = ({particle}) => { startRenderParticles.push(particle.name); };

--- a/tools/sigh.ts
+++ b/tools/sigh.ts
@@ -542,7 +542,7 @@ async function cycles(args: string[]): Promise<boolean> {
   // This should only go down!
   // Please adjust this number down when you remove cycles.
   // https://github.com/PolymerLabs/arcs/issues/1878
-  const CURRENT_NUMBER_OF_CYCLES = 12;
+  const CURRENT_NUMBER_OF_CYCLES = 11;
 
   if (res.length > CURRENT_NUMBER_OF_CYCLES)  {
     sighLog('You seem to have added a dependency cycle, please refactor your code.');


### PR DESCRIPTION
Moves cycle count from 12 to 11.

Introduces a StoreRegistry interface for arcs to use when registering
and unregistering their stores.

Part of https://github.com/PolymerLabs/arcs/issues/1878