### PR TITLE
Rework Runtime ctor to take an options type.

### DIFF
--- a/src/devtools-connector/tests/arc-stores-fetcher-test.ts
+++ b/src/devtools-connector/tests/arc-stores-fetcher-test.ts
@@ -29,7 +29,11 @@ describe('ArcStoresFetcher', () => {
     const context = await Manifest.parse(`
       schema Foo
         value: Text`);
-    const runtime = new Runtime(new StubLoader({}), FakeSlotComposer, context);
+    const runtime = new Runtime({
+        loader: new StubLoader({}),
+        composerClass: FakeSlotComposer,
+        context
+      });
     const arc = runtime.newArc('demo', storageKeyPrefixForTest(), {inspectorFactory: devtoolsArcInspectorFactory});
 
     const foo = Entity.createEntityClass(arc.context.findSchemaByName('Foo'), null);
@@ -111,7 +115,11 @@ describe('ArcStoresFetcher', () => {
         foo: create *
         P
           foo: foo`);
-    const runtime = new Runtime(loader, FakeSlotComposer, context);
+    const runtime = new Runtime({
+        loader,
+        composerClass: FakeSlotComposer,
+        context
+      });
     const arc = runtime.newArc('demo', storageKeyPrefixForTest(), {inspectorFactory: devtoolsArcInspectorFactory});
 
     const recipe = arc.context.recipes[0];

--- a/src/devtools-connector/tests/devtools-arc-inspector-test.ts
+++ b/src/devtools-connector/tests/devtools-arc-inspector-test.ts
@@ -40,7 +40,8 @@ describe('DevtoolsArcInspector', () => {
         foo: use *
         P
           foo: foo`);
-    const runtime = new Runtime(loader, MockSlotComposer, context);
+    const runtime = new Runtime({
+      loader, composerClass: MockSlotComposer, context});
     const arc = runtime.newArc('demo', storageKeyPrefixForTest(), {inspectorFactory: devtoolsArcInspectorFactory});
 
     const foo = Entity.createEntityClass(arc.context.findSchemaByName('Foo'), null);

--- a/src/planning/plan/tests/plan-consumer-test.ts
+++ b/src/planning/plan/tests/plan-consumer-test.ts
@@ -70,7 +70,8 @@ async function storeResults(consumer, suggestions) {
             other: consumes other
           description \`Test Recipe\`
       `, {loader, fileName: '', memoryProvider});
-      const runtime = new Runtime(loader, FakeSlotComposer, context, null, memoryProvider);
+      const runtime = new Runtime({
+          loader, composerClass: FakeSlotComposer, context, memoryProvider});
       const arc = runtime.newArc('demo', storageKeyPrefixForTest());
       let suggestions = await StrategyTestHelper.planForArc(arc);
 
@@ -166,7 +167,8 @@ ${addRecipe(['ParticleTouch', 'ParticleBoth'])}
           });
         }
       }
-      const runtime = new Runtime(loader, ModalitySlotComposer, context, null, memoryProvider);
+      const runtime = new Runtime({
+          loader, composerClass: ModalitySlotComposer, context, memoryProvider});
       const arc = runtime.newArc('demo', storageKeyPrefixForTest());
       assert.lengthOf(arc.context.allRecipes, 4);
       const consumer = await createPlanConsumer('volatile', arc);

--- a/src/planning/plan/tests/plan-producer-test.ts
+++ b/src/planning/plan/tests/plan-producer-test.ts
@@ -90,7 +90,8 @@ class TestPlanProducer extends PlanProducer {
       const loader = new StubLoader({});
       const memoryProvider = new TestVolatileMemoryProvider();
       const context = await Manifest.load('./src/runtime/tests/artifacts/Products/Products.recipes', loader, {memoryProvider});
-      const runtime = new Runtime(loader, FakeSlotComposer, context, null, memoryProvider);
+      const runtime = new Runtime({
+          loader, composerClass: FakeSlotComposer, context, memoryProvider});
       const arc = runtime.newArc('demo', storageKeyPrefixForTest());
       const suggestions = await StrategyTestHelper.planForArc(
           runtime.newArc('demo', storageKeyPrefixForTest())

--- a/src/planning/plan/tests/planificator-test.ts
+++ b/src/planning/plan/tests/planificator-test.ts
@@ -25,7 +25,8 @@ import '../../../runtime/storage/pouchdb/pouch-db-provider.js';
 
 describe('planificator', () => {
   it('constructs suggestion and search storage keys for fb arc', async () => {
-    const runtime = new Runtime(new StubLoader({}), FakeSlotComposer);
+    const runtime = new Runtime({
+        loader: new StubLoader({}), composerClass: FakeSlotComposer});
     const arc = runtime.newArc(
         'demo',
         'firebase://arcs-storage.firebaseio.com/AIzaSyBme42moeI-2k8WgXh-6YK_wYyjEXo4Oz8/0_6_0/demo'
@@ -65,7 +66,8 @@ describe('remote planificator', () => {
     const context = manifestString
         ? await Manifest.parse(manifestString, {loader, fileName: '', memoryProvider})
         : await Manifest.load(manifestFilename, loader, {memoryProvider});
-    const runtime = new Runtime(loader, FakeSlotComposer, context, null, memoryProvider);
+    const runtime = new Runtime({
+        loader, composerClass: FakeSlotComposer, context, memoryProvider});
     return runtime.newArc('demo', storageKey);
   }
   async function createConsumePlanificator(plannerStorageKeyBase, manifestFilename) {

--- a/src/planning/plan/tests/planning-result-test.ts
+++ b/src/planning/plan/tests/planning-result-test.ts
@@ -32,7 +32,8 @@ describe('planning result', () => {
   async function testResultSerialization(manifestFilename) {
     const loader = new StubLoader({});
     const context = await Manifest.load(manifestFilename, loader, {memoryProvider});
-    const runtime = new Runtime(loader, FakeSlotComposer, context, null, memoryProvider);
+    const runtime = new Runtime({
+        loader, composerClass: FakeSlotComposer, context, memoryProvider});
     const arc = runtime.newArc('demo', storageKeyPrefixForTest());
     const suggestions = await StrategyTestHelper.planForArc(arc);
 
@@ -54,7 +55,8 @@ describe('planning result', () => {
   it('appends search suggestions', async () => {
     const loader = new StubLoader({});
     const context = await Manifest.load('./src/runtime/tests/artifacts/Products/Products.recipes', loader, {memoryProvider});
-    const runtime = new Runtime(loader, FakeSlotComposer, context, null, memoryProvider);
+    const runtime = new Runtime({
+        loader, composerClass: FakeSlotComposer, context, memoryProvider});
     const arc = runtime.newArc('demo', storageKeyPrefixForTest());
     const suggestions = await StrategyTestHelper.planForArc(arc);
 
@@ -125,7 +127,7 @@ recipe R3
         `;
   async function prepareMerge(manifestStr1, manifestStr2) {
     const loader = new StubLoader({});
-    const runtime = new Runtime(loader, FakeSlotComposer);
+    const runtime = new Runtime({loader, composerClass: FakeSlotComposer});
     const arc = runtime.newArc('demo', storageKeyPrefixForTest());
 
     const planToSuggestion = async (plan: Recipe): Promise<Suggestion> => {

--- a/src/planning/tests/suggestion-composer-test.ts
+++ b/src/planning/tests/suggestion-composer-test.ts
@@ -45,7 +45,8 @@ describe('suggestion composer', () => {
     const loader = new StubLoader({});
     const memoryProvider = new TestVolatileMemoryProvider();
     const context = await Manifest.load('./src/runtime/tests/artifacts/suggestions/Cake.recipes', loader, {memoryProvider});
-    const runtime = new Runtime(loader, TestSlotComposer, context, null, memoryProvider);
+    const runtime = new Runtime({
+        loader, composerClass: TestSlotComposer, context, memoryProvider});
     const arc = runtime.newArc('demo', storageKeyPrefixForTest());
     const slotComposer = arc.pec.slotComposer as MockSlotComposer;
     slotComposer.newExpectations('debug');
@@ -89,7 +90,8 @@ describe('suggestion composer', () => {
     const loader = new StubLoader({});
     const memoryProvider = new TestVolatileMemoryProvider();
     const context = await Manifest.load('./src/runtime/tests/artifacts/suggestions/Cakes.recipes', loader, {memoryProvider});
-    const runtime = new Runtime(loader, TestSlotComposer, context, null, memoryProvider);
+    const runtime = new Runtime({
+        loader, composerClass: TestSlotComposer, context, memoryProvider});
     const arc = runtime.newArc('demo', storageKeyPrefixForTest());
     const slotComposer = arc.pec.slotComposer as MockSlotComposer;
     slotComposer.newExpectations('debug');

--- a/src/runtime/manual_tests/firebase-test.ts
+++ b/src/runtime/manual_tests/firebase-test.ts
@@ -684,7 +684,7 @@ describe('firebase', function() {
       };
       const loader = new StubLoader(fileMap);
       const manifest = await Manifest.parse(fileMap.manifest);
-      const runtime = new Runtime(loader, FakeSlotComposer, manifest);
+      const runtime = new Runtime({loader, composerClass: FakeSlotComposer, context: manifest});
       const arc = runtime.newArc('demo', 'volatile://');
       const storage = createStorage(arc.id);
       const dataType = new EntityType(manifest.schemas.Data);

--- a/src/runtime/tests/arc-test.ts
+++ b/src/runtime/tests/arc-test.ts
@@ -55,7 +55,8 @@ async function setup(storageKeyPrefix: string | ((arcId: ArcId) => StorageKey)) 
         foo: reads handle0
         bar: writes handle1
   `, {loader, memoryProvider, fileName: process.cwd() + '/input.manifest'});
-  const runtime = new Runtime(loader, FakeSlotComposer, manifest, null, memoryProvider);
+  const runtime = new Runtime({
+      loader, composerClass: FakeSlotComposer, context: manifest, memoryProvider});
   const arc = runtime.newArc('test', storageKeyPrefix);
 
   return {
@@ -323,7 +324,8 @@ describe('Arc ' + storageKeyPrefix, () => {
         defineParticle(({Particle}) => class Noop extends Particle {});
       `
     });
-    const runtime = new Runtime(loader, FakeSlotComposer, manifest, null, memoryProvider);
+    const runtime = new Runtime({
+        loader, composerClass: FakeSlotComposer, context: manifest, memoryProvider});
 
     // Successfully instantiates a recipe with 'copy' handle for store in a context.
     await runtime.newArc('test0', storageKeyPrefix).instantiate(manifest.recipes[0]);

--- a/src/runtime/tests/particle-api-more-test.ts
+++ b/src/runtime/tests/particle-api-more-test.ts
@@ -39,7 +39,7 @@ const getCollectionData = async (arc: Arc, index: number) => {
 };
 
 const spawnTestArc = async (loader) => {
-  const runtime = new Runtime(loader, FakeSlotComposer);
+  const runtime = new Runtime({loader, composerClass: FakeSlotComposer});
   const arc = runtime.runArc('test-arc', storageKeyPrefixForTest());
   const manifest = await Manifest.load('manifest', loader);
   const [recipe] = manifest.recipes;

--- a/src/runtime/tests/particle-api-test.ts
+++ b/src/runtime/tests/particle-api-test.ts
@@ -99,7 +99,8 @@ class ResultInspector {
 
 async function loadFilesIntoNewArc(fileMap: {[index:string]: string, manifest: string}): Promise<Arc> {
   const manifest = await Manifest.parse(fileMap.manifest);
-  const runtime = new Runtime(new StubLoader(fileMap), FakeSlotComposer, manifest);
+  const runtime = new Runtime({
+      loader: new StubLoader(fileMap), composerClass: FakeSlotComposer, context: manifest});
   return runtime.newArc('demo', Flags.useNewStorageStack ? null : 'volatile://');
 }
 

--- a/src/runtime/tests/runtime-test.ts
+++ b/src/runtime/tests/runtime-test.ts
@@ -95,7 +95,7 @@ describe('Runtime', () => {
       `,
       '*': 'defineParticle(({Particle}) => class extends Particle {});',
     });
-    const runtime = new Runtime(loader, FakeSlotComposer, context, null, memoryProvider);
+    const runtime = new Runtime({loader, composerClass: FakeSlotComposer, context, memoryProvider});
     const arc = runtime.runArc('test-arc', 'volatile://');
     const manifest = await Manifest.load('manifest', loader, {memoryProvider});
     manifest.recipes[0].normalize();

--- a/src/tests/arc-integration-test.ts
+++ b/src/tests/arc-integration-test.ts
@@ -42,7 +42,8 @@ describe('Arc integration', () => {
         ]
       store ThingStore of Thing 'mything' #best in ThingResource
     `, {memoryProvider});
-    const runtime = new Runtime(loader, FakeSlotComposer, manifest, null, memoryProvider);
+    const runtime = new Runtime({
+        loader, composerClass: FakeSlotComposer, context: manifest, memoryProvider});
     RamDiskStorageDriverProvider.register(memoryProvider);
 
     const arc = runtime.newArc('demo', 'volatile://');

--- a/src/tests/multiplexer-integration-test.ts
+++ b/src/tests/multiplexer-integration-test.ts
@@ -61,7 +61,8 @@ describe('Multiplexer', () => {
     });
     postsStub['referenceMode'] = false;
     // version could be set here, but doesn't matter for tests.
-    const runtime = new Runtime(loader, MockSlotComposer, context, null, memoryProvider);
+    const runtime = new Runtime({
+        loader, composerClass: MockSlotComposer, context, memoryProvider});
     const arc = runtime.newArc('demo', storageKeyPrefixForTest());
     const slotComposer = arc.pec.slotComposer as MockSlotComposer;
     const suggestions = await StrategyTestHelper.planForArc(arc);

--- a/src/tests/particles/common-test.ts
+++ b/src/tests/particles/common-test.ts
@@ -75,7 +75,8 @@ describe('common particles test', () => {
     const loader = new StubLoader({});
     const memoryProvider = new TestVolatileMemoryProvider();
     const context =  await Manifest.load('./src/tests/particles/artifacts/copy-collection-test.recipes', loader, {memoryProvider});
-    const runtime = new Runtime(loader, FakeSlotComposer, context, null, memoryProvider);
+    const runtime = new Runtime({
+        loader, composerClass: FakeSlotComposer, context, memoryProvider});
     const arc = runtime.newArc('demo', 'volatile://');
 
     const suggestions = await StrategyTestHelper.planForArc(arc);

--- a/src/tests/particles/multi-slot-test.ts
+++ b/src/tests/particles/multi-slot-test.ts
@@ -26,7 +26,8 @@ describe('multi-slot test', () => {
     const memoryProvider = new TestVolatileMemoryProvider();
     const context = await Manifest.load(
         './src/tests/particles/artifacts/multi-slot-test.manifest', loader, {memoryProvider});
-    const runtime = new Runtime(loader, MockSlotComposer, context, null, memoryProvider);
+    const runtime = new Runtime({
+        loader, composerClass: MockSlotComposer, context, memoryProvider});
     const arc = runtime.newArc('demo', storageKeyPrefixForTest());
     const slotComposer = arc.pec.slotComposer as MockSlotComposer;
     const suggestions = await StrategyTestHelper.planForArc(arc);

--- a/src/tests/particles/products-test.ts
+++ b/src/tests/particles/products-test.ts
@@ -33,9 +33,12 @@ describe('products test', () => {
   it('filters', async () => {
     const loader = new Loader();
     const memoryProvider = new TestVolatileMemoryProvider();
-    const runtime = new Runtime(loader, FakeSlotComposer,
-        await Manifest.load(manifestFilename, loader, {memoryProvider}),
-        null, memoryProvider);
+    const runtime = new Runtime({
+        loader,
+        composerClass: FakeSlotComposer,
+        context: await Manifest.load(manifestFilename, loader, {memoryProvider}),
+        memoryProvider
+      });
     const arc = runtime.newArc('demo', 'volatile://');
     const recipe = arc.context.recipes.find(r => r.name === 'FilterBooks');
     assert.isTrue(recipe.normalize() && recipe.isResolved());

--- a/src/tests/particles/transformation-slots-test.ts
+++ b/src/tests/particles/transformation-slots-test.ts
@@ -23,7 +23,8 @@ describe('transformation slots', () => {
     const memoryProvider = new TestVolatileMemoryProvider();
     const context = await Manifest.load(
         './src/tests/particles/artifacts/provide-hosted-particle-slots.manifest', loader, {memoryProvider});
-    const runtime = new Runtime(loader, MockSlotComposer, context, null, memoryProvider);
+    const runtime = new Runtime({
+        loader, composerClass: MockSlotComposer, context, memoryProvider});
     const arc = runtime.newArc('demo', storageKeyPrefixForTest());
     const slotComposer = arc.pec.slotComposer as MockSlotComposer;
 

--- a/src/tests/recipe-descriptions-test.ts
+++ b/src/tests/recipe-descriptions-test.ts
@@ -96,7 +96,7 @@ store BoxesStore of [Box] 'allboxes' in AllBoxes` : ''}
     const context =  await Manifest.parse(
         options.manifestString || createManifestString(options),
         {loader, memoryProvider, fileName: 'foo.js'});
-    const runtime = new Runtime(loader, FakeSlotComposer, context, null, memoryProvider);
+    const runtime = new Runtime({loader, composerClass: FakeSlotComposer, context, memoryProvider});
     const arc = runtime.newArc('demo', 'volatile://');
     arc.pec.slotComposer.modalityHandler.descriptionFormatter = options.formatter;
 
@@ -257,7 +257,7 @@ store BoxesStore of [Box] 'allboxes' in AllBoxes` : ''}
             foo: writes fooHandle
           description \`cannot show duplicate \${ShowFoo.foo}\`
       `, {loader, fileName: '', memoryProvider});
-    const runtime = new Runtime(loader, FakeSlotComposer, context);
+    const runtime = new Runtime({loader, composerClass: FakeSlotComposer, context, memoryProvider});
     const arc = runtime.newArc('demo', 'volatile://');
 
     await StrategyTestHelper.planForArc(arc).then(() => assert('expected exception for duplicate particles'))
@@ -309,7 +309,7 @@ store BoxesStore of [Box] 'allboxes' in AllBoxes` : ''}
         Dummy
         description \`show \${ShowFoo.foo} with dummy\`
     `, {loader, fileName: '', memoryProvider});
-    const runtime = new Runtime(loader, FakeSlotComposer, context);
+    const runtime = new Runtime({loader, composerClass: FakeSlotComposer, context, memoryProvider});
     const arc = runtime.newArc('demo', 'volatile://');
     // Plan for arc
     const suggestions0 = await StrategyTestHelper.planForArc(arc);
@@ -341,7 +341,7 @@ store BoxesStore of [Box] 'allboxes' in AllBoxes` : ''}
         C
         description \`do C\`
     `, {loader, fileName: '', memoryProvider});
-    const runtime = new Runtime(loader, FakeSlotComposer, context);
+    const runtime = new Runtime({loader, composerClass: FakeSlotComposer, context, memoryProvider});
     const arc = runtime.newArc('demo', 'volatile://');
 
     const suggestions = await StrategyTestHelper.planForArc(arc);

--- a/src/tests/slot-composer-test.ts
+++ b/src/tests/slot-composer-test.ts
@@ -121,7 +121,7 @@ recipe
     const loader = new StubLoader({});
     const context = await Manifest.load(
         './src/tests/particles/artifacts/products-test.recipes', loader);
-    const runtime = new Runtime(loader, MockSlotComposer, context);
+    const runtime = new Runtime({loader, composerClass: MockSlotComposer, context});
     const arc = runtime.newArc('demo', storageKeyPrefixForTest());
     const slotComposer = arc.pec.slotComposer as MockSlotComposer;
 
@@ -297,7 +297,7 @@ recipe
         slot0: slot 'rootslotid-root'
         TransformationParticle
           root: consumes slot0`, {loader, fileName: ''});
-    const runtime = new Runtime(loader, MockSlotComposer, context);
+    const runtime = new Runtime({loader, composerClass: MockSlotComposer, context});
     const arc = runtime.newArc('demo', storageKeyPrefixForTest());
     const slotComposer = arc.pec.slotComposer as MockSlotComposer;
     slotComposer.newExpectations()

--- a/src/wasm/tests/wasm-api-test.ts
+++ b/src/wasm/tests/wasm-api-test.ts
@@ -62,7 +62,7 @@ class TestLoader extends Loader {
     });
 
     async function setup(recipeName) {
-      const runtime = new Runtime(loader, RozSlotComposer, await manifestPromise);
+      const runtime = new Runtime({loader, composerClass: RozSlotComposer, context: await manifestPromise});
       const arc = runtime.newArc('wasm-test', 'volatile://');
 
       const recipe = arc.context.allRecipes.find(r => r.name === recipeName);


### PR DESCRIPTION
General cleanup particularly warranted following recent cycle
reduction which has added more params (memory provider, store
registry) to Runtime ctor which was already cluttered with a sequence
of often optional parameters, e.g., pecFactory.

Addresses TODO added in https://github.com/PolymerLabs/arcs/pull/4344 and furthered in https://github.com/PolymerLabs/arcs/pull/4346.