### PR TITLE
Make context a required parameter for Arc ctor.

### DIFF
--- a/src/runtime/arc.ts
+++ b/src/runtime/arc.ts
@@ -112,9 +112,8 @@ export class Arc implements ArcInterface {
   readonly volatileMemory = new VolatileMemory();
   private readonly volatileStorageDriverProvider: VolatileStorageDriverProvider;
 
-constructor({id, context, pecFactories, slotComposer, loader, storageKey, storageProviderFactory, speculative, innerArc, stub, inspectorFactory} : ArcOptions) {
-    // TODO: context should not be optional.
-    this._context = context || new Manifest({id});
+  constructor({id, context, pecFactories, slotComposer, loader, storageKey, storageProviderFactory, speculative, innerArc, stub, inspectorFactory} : ArcOptions) {
+    this._context = context;
     // TODO: pecFactories should not be optional. update all callers and fix here.
     this.pecFactories = pecFactories && pecFactories.length > 0 ? pecFactories.slice() : [FakePecFactory(loader).bind(null)];
 

--- a/src/runtime/tests/arc-test.ts
+++ b/src/runtime/tests/arc-test.ts
@@ -60,6 +60,7 @@ async function setup(storageKeyPrefix: string | ((arcId: ArcId) => StorageKey)) 
 
   return {
     arc,
+    context: manifest,
     recipe: manifest.recipes[0],
     Foo: Entity.createEntityClass(manifest.findSchemaByName('Foo'), null),
     Bar: Entity.createEntityClass(manifest.findSchemaByName('Bar'), null),
@@ -719,10 +720,11 @@ describe('Arc ' + storageKeyPrefix, () => {
     const loader = new Loader();
     const id = Id.fromString('test');
     const storageKey = storageKeyPrefix + id.toString();
-    const arc = new Arc({slotComposer, loader, id, storageKey, context: undefined});
+    const context = new Manifest({id});
+    const arc = new Arc({slotComposer, loader, id, storageKey, context});
 
     const serialization = await arc.serialize();
-    const newArc = await Arc.deserialize({serialization, loader, slotComposer, context: undefined, fileName: 'foo.manifest'});
+    const newArc = await Arc.deserialize({serialization, loader, slotComposer, context, fileName: 'foo.manifest'});
     assert.strictEqual(newArc._stores.length, 0);
     assert.strictEqual(newArc.activeRecipe.toString(), arc.activeRecipe.toString());
     assert.strictEqual(newArc.id.idTreeAsString(), 'test');
@@ -734,7 +736,7 @@ describe('Arc ' + storageKeyPrefix, () => {
       this.skip();
     }
 
-    const {arc, recipe, Foo, Bar, loader} = await setup(storageKeyPrefix);
+    const {arc, context, recipe, Foo, Bar, loader} = await setup(storageKeyPrefix);
     let fooStore = await arc.createStore(Foo.type, undefined, 'test:1');
     const fooHandle = await singletonHandleForTest(arc, fooStore);
     const fooStoreCallbacks = await CallbackTracker.create(fooStore, 1);
@@ -756,7 +758,7 @@ describe('Arc ' + storageKeyPrefix, () => {
     const serialization = await arc.serialize();
     arc.dispose();
 
-    const newArc = await Arc.deserialize({serialization, loader, fileName: '', slotComposer: new FakeSlotComposer(), context: undefined});
+    const newArc = await Arc.deserialize({serialization, loader, fileName: '', slotComposer: new FakeSlotComposer(), context});
     fooStore = newArc.findStoreById(fooStore.id);
     barStore = newArc.findStoreById(barStore.id);
     assert.strictEqual(fooStore.versionToken, '1');
@@ -1123,7 +1125,7 @@ describe('Arc ' + storageKeyPrefix, () => {
 
     const slotComposer = new FakeSlotComposer();
 
-    const newArc = await Arc.deserialize({serialization, loader, slotComposer, context: undefined, fileName: 'foo.manifest'});
+    const newArc = await Arc.deserialize({serialization, loader, slotComposer, context: manifest, fileName: 'foo.manifest'});
     assert.strictEqual(newArc._stores.length, 1);
     assert.strictEqual(newArc.activeRecipe.toString(), arc.activeRecipe.toString());
     assert.strictEqual(newArc.id.idTreeAsString(), 'test');

--- a/src/runtime/tests/particle-api-test.ts
+++ b/src/runtime/tests/particle-api-test.ts
@@ -946,7 +946,8 @@ describe('particle-api', () => {
     });
 
     const id = IdGenerator.createWithSessionIdForTesting('session').newArcId('test');
-    const arc = new Arc({id, loader, context: null});
+    const context = new Manifest({id});
+    const arc = new Arc({id, loader, context});
     const manifest = await Manifest.load('manifest', loader);
     const recipe = manifest.recipes[0];
 
@@ -998,7 +999,8 @@ describe('particle-api', () => {
     });
 
     const id = IdGenerator.createWithSessionIdForTesting('session').newArcId('test');
-    const arc = new Arc({id, loader, context: null});
+    const context = new Manifest({id});
+    const arc = new Arc({id, loader, context});
     const manifest = await Manifest.load('manifest', loader);
     const recipe = manifest.recipes[0];
 
@@ -1050,7 +1052,8 @@ describe('particle-api', () => {
     });
 
     const id = IdGenerator.createWithSessionIdForTesting('session').newArcId('test');
-    const arc = new Arc({id, loader, context: null});
+    const context = new Manifest({id});
+    const arc = new Arc({id, loader, context});
     const manifest = await Manifest.load('manifest', loader);
     const recipe = manifest.recipes[0];
 
@@ -1101,8 +1104,9 @@ describe('particle-api', () => {
       `
     });
 
-     const id = IdGenerator.createWithSessionIdForTesting('session').newArcId('test');
-    const arc = new Arc({id, loader, context: null});
+    const id = IdGenerator.createWithSessionIdForTesting('session').newArcId('test');
+    const context = new Manifest({id});
+    const arc = new Arc({id, loader, context});
     const manifest = await Manifest.load('manifest', loader);
     const recipe = manifest.recipes[0];
 
@@ -1163,8 +1167,9 @@ describe('particle-api', () => {
       `
     });
 
-     const id = IdGenerator.createWithSessionIdForTesting('session').newArcId('test');
-    const arc = new Arc({id, loader, context: null});
+    const id = IdGenerator.createWithSessionIdForTesting('session').newArcId('test');
+    const context = new Manifest({id});
+    const arc = new Arc({id, loader, context});
     const manifest = await Manifest.load('manifest', loader);
     const recipe = manifest.recipes[0];
     assert.isTrue(recipe.normalize());


### PR DESCRIPTION
Addresses a prior TODO in Arc ctor.

The options type already specified this correctly, but some tests were
passing null/undefined.