### PR TITLE
Break cycles between Runtime and StorageNG Firebase driver.

### DIFF
--- a/src/runtime/storageNG/drivers/tests/firebase-test.ts
+++ b/src/runtime/storageNG/drivers/tests/firebase-test.ts
@@ -8,65 +8,67 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {Runtime} from '../../../runtime.js';
+import {StorageKey} from '../../storage-key.js';
 import {assert} from '../../../../platform/chai-web.js';
 import {Exists} from '../driver-factory.js';
+import {RuntimeCacheService} from '../../../runtime-cache.js';
 import {MockFirebaseStorageDriverProvider, MockFirebaseStorageKey} from '../../testing/mock-firebase.js';
 import {assertThrowsAsync} from '../../../../testing/test-util.js';
 
 describe('Firebase Driver', async () => {
-
+  let cacheService;
   beforeEach(() => {
-    Runtime.clearRuntimeForTesting();
+    cacheService = new RuntimeCacheService();
   });
 
-  after(() => {
-    Runtime.clearRuntimeForTesting();
-  });
+  const newDriver = async <Data>(storageKey: StorageKey, exists: Exists) => {
+    return MockFirebaseStorageDriverProvider.newDriverForTesting<Data>(
+        cacheService, storageKey, exists);
+  };
 
   it('can be multiply instantiated against the same storage location', async () => {
     const firebaseKey = new MockFirebaseStorageKey('test-location');
 
-    const firebase1 = await MockFirebaseStorageDriverProvider.newDriverForTesting(firebaseKey, Exists.ShouldCreate);
-    const firebase2 = await MockFirebaseStorageDriverProvider.newDriverForTesting(firebaseKey, Exists.ShouldExist);
+    const firebase1 = await newDriver(firebaseKey, Exists.ShouldCreate);
+    const firebase2 = await newDriver(firebaseKey, Exists.ShouldExist);
   });
 
   it('treats keys constructed separately as the same if the details are the same', async () => {
     const key1 = new MockFirebaseStorageKey('test-location');
     const key2 = new MockFirebaseStorageKey('test-location');
 
-    const firebase1 = await MockFirebaseStorageDriverProvider.newDriverForTesting(key1, Exists.ShouldCreate);
-    const firebase2 = await MockFirebaseStorageDriverProvider.newDriverForTesting(key2, Exists.ShouldExist);
+    const firebase1 = await newDriver(key1, Exists.ShouldCreate);
+    const firebase2 = await newDriver(key2, Exists.ShouldExist);
   });
 
   it(`can't be instantiated as ShouldExist if the storage location doesn't yet exist`, async () => {
     const firebaseKey = new MockFirebaseStorageKey('test-location');
     await assertThrowsAsync(
-      () => MockFirebaseStorageDriverProvider.newDriverForTesting(firebaseKey, Exists.ShouldExist), `location doesn't exist`);
+      () => newDriver(firebaseKey, Exists.ShouldExist), `location doesn't exist`);
   });
 
   it(`can't be instantiated as ShouldCreate if the storage location already exists`, async () => {
     const firebaseKey = new MockFirebaseStorageKey('test-location');
-    const firebase1 = await MockFirebaseStorageDriverProvider.newDriverForTesting(firebaseKey, Exists.ShouldCreate);
+    const firebase1 = await newDriver(firebaseKey, Exists.ShouldCreate);
 
     await assertThrowsAsync(
-      () => MockFirebaseStorageDriverProvider.newDriverForTesting(firebaseKey, Exists.ShouldCreate), `location already exists`);
+      () => newDriver(firebaseKey, Exists.ShouldCreate), `location already exists`);
   });
 
   it('can be instantiated either as a creation or as a connection using MayExist', async () => {
     const firebaseKey = new MockFirebaseStorageKey('test-location');
-    const firebase1 =  await MockFirebaseStorageDriverProvider.newDriverForTesting(firebaseKey, Exists.MayExist);
-    const firebase2 =  await MockFirebaseStorageDriverProvider.newDriverForTesting(firebaseKey, Exists.MayExist);
+    const firebase1 =  await newDriver(firebaseKey, Exists.MayExist);
+    const firebase2 =  await newDriver(firebaseKey, Exists.MayExist);
   });
 
   it('transmits a write to a connected driver', async () => {
     const firebaseKey = new MockFirebaseStorageKey('test-location');
-    const firebase1 = await MockFirebaseStorageDriverProvider.newDriverForTesting<number>(firebaseKey, Exists.ShouldCreate);
+    const firebase1 = await newDriver<number>(firebaseKey, Exists.ShouldCreate);
     const recvQueue1: {model: number, version: number}[] = [];
     firebase1.registerReceiver((model: number, version: number) => recvQueue1.push({model, version}));
     await firebase1.send(3, 1);
 
-    const firebase2 = await MockFirebaseStorageDriverProvider.newDriverForTesting<number>(firebaseKey, Exists.ShouldExist);
+    const firebase2 = await newDriver<number>(firebaseKey, Exists.ShouldExist);
     const recvQueue2: {model: number, version: number}[] = [];
     firebase2.registerReceiver((model: number, version: number) => recvQueue2.push({model, version}));
 
@@ -76,7 +78,7 @@ describe('Firebase Driver', async () => {
 
   it(`won't accept out-of-date writes`, async () => {
     const firebaseKey = new MockFirebaseStorageKey('test-location');
-    const firebase1 = await MockFirebaseStorageDriverProvider.newDriverForTesting<number>(firebaseKey, Exists.ShouldCreate);
+    const firebase1 = await newDriver<number>(firebaseKey, Exists.ShouldCreate);
 
     assert.isTrue(await firebase1.send(3, 1));
     assert.isFalse(await firebase1.send(4, 0));
@@ -87,10 +89,10 @@ describe('Firebase Driver', async () => {
 
   it('will only accept a given version from one connected driver', async () => {
     const firebaseKey = new MockFirebaseStorageKey('test-location');
-    const firebase1 = await MockFirebaseStorageDriverProvider.newDriverForTesting<number>(firebaseKey, Exists.ShouldCreate);
+    const firebase1 = await newDriver<number>(firebaseKey, Exists.ShouldCreate);
     const recvQueue1: {model: number, version: number}[] = [];
     firebase1.registerReceiver((model: number, version: number) => recvQueue1.push({model, version}));
-    const firebase2 = await MockFirebaseStorageDriverProvider.newDriverForTesting<number>(firebaseKey, Exists.ShouldExist);
+    const firebase2 = await newDriver<number>(firebaseKey, Exists.ShouldExist);
     const recvQueue2: {model: number, version: number}[] = [];
     firebase2.registerReceiver((model: number, version: number) => recvQueue2.push({model, version}));
 

--- a/src/runtime/storageNG/tests/store-sequence-test.ts
+++ b/src/runtime/storageNG/tests/store-sequence-test.ts
@@ -231,7 +231,7 @@ describe('Store Sequence', async () => {
     sequenceTest.setTestConstructor(async () => {
       const runtime = new Runtime();
       DriverFactory.clearRegistrationsForTesting();
-      MockFirebaseStorageDriverProvider.register();
+      MockFirebaseStorageDriverProvider.register(runtime.getCacheService());
       const storageKey = new FirebaseStorageKey('test', 'test.domain', 'testKey', 'foo');
       const store1 = createStore(storageKey, Exists.ShouldCreate);
       const activeStore1 = await store1.activate();

--- a/tools/sigh.ts
+++ b/tools/sigh.ts
@@ -542,7 +542,7 @@ async function cycles(args: string[]): Promise<boolean> {
   // This should only go down!
   // Please adjust this number down when you remove cycles.
   // https://github.com/PolymerLabs/arcs/issues/1878
-  const CURRENT_NUMBER_OF_CYCLES = 11;
+  const CURRENT_NUMBER_OF_CYCLES = 8;
 
   if (res.length > CURRENT_NUMBER_OF_CYCLES)  {
     sighLog('You seem to have added a dependency cycle, please refactor your code.');


### PR DESCRIPTION
Moves cycle count from 11 to 8.

Applies similar pattern to that used in prior work focused on volatile
storage use of the `RuntimeCacheService` in #4310.

Part of #1878.