### PR TITLE
Break cycle between Runtime and Arc (option 2).

### DIFF
--- a/src/runtime/arc.ts
+++ b/src/runtime/arc.ts
@@ -34,7 +34,6 @@ import {ArcType, CollectionType, EntityType, InterfaceInfo, InterfaceType,
 import {PecFactory} from './particle-execution-context.js';
 import {Mutex} from './mutex.js';
 import {Dictionary} from './hot.js';
-import {Runtime} from './runtime.js';
 import {VolatileMemory, VolatileStorageDriverProvider, VolatileStorageKey} from './storageNG/drivers/volatile.js';
 import {DriverFactory, Exists} from './storageNG/drivers/driver-factory.js';
 import {StorageKey} from './storageNG/storage-key.js';
@@ -179,7 +178,7 @@ export class Arc implements ArcInterface {
     DriverFactory.unregister(this.volatileStorageDriverProvider);
 
     for (const store of this._stores) {
-      Runtime.getRuntime().unregisterStore(store.id, [...this.findStoreTags(store)]);
+      this.context.unregisterStore(store.id, [...this.findStoreTags(store)]);
     }
   }
 
@@ -626,7 +625,7 @@ export class Arc implements ArcInterface {
     const activeStore = await store.activate();
     activeStore.on(async () => this._onDataChange());
 
-    Runtime.getRuntime().registerStore(store, tags);
+    this.context.registerStore(store, tags);
   }
 
   _tagStore(store: UnifiedStore, tags: Set<string>): void {

--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -1362,6 +1362,27 @@ ${e.message}
     return recipe;
   }
 
+  // TODO: This is a temporary method to allow sharing stores with other Arcs.
+  registerStore(store: UnifiedStore, tags: string[]): void {
+    if (!this.findStoreById(store.id) && tags.includes('shared')) {
+      this._addStore(store, tags);
+    }
+  }
+
+  // Temporary method to allow sharing stores with other Arcs.
+  unregisterStore(storeId: string, tags: string[]) {
+    // #shared tag indicates that a store was made available to all arcs.
+    if (!tags.includes('shared')) {
+      return;
+    }
+    const index = this.stores.findIndex(store => store.id === storeId);
+    if (index >= 0) {
+      const store = this.stores[index];
+      this.storeTags.delete(store);
+      this.stores.splice(index, 1);
+    }
+  }
+
   toString(options: {recursive?: boolean, showUnresolved?: boolean, hideFields?: boolean} = {}): string {
     // TODO: sort?
     const results: string[] = [];

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -12,7 +12,6 @@ import {assert} from '../platform/assert-web.js';
 import {Description} from './description.js';
 import {Manifest} from './manifest.js';
 import {Arc} from './arc.js';
-import {UnifiedStore} from './storageNG/unified-store.js';
 import {RuntimeCacheService} from './runtime-cache.js';
 import {IdGenerator, ArcId} from './id.js';
 import {PecFactory} from './particle-execution-context.js';
@@ -220,27 +219,6 @@ export class Runtime {
 
   findArcByParticleId(particleId: string): Arc {
     return [...this.arcById.values()].find(arc => !!arc.activeRecipe.findParticle(particleId));
-  }
-
-  // TODO: This is a temporary method to allow sharing stores with other Arcs.
-  registerStore(store: UnifiedStore, tags: string[]): void {
-    if (!this.context.findStoreById(store.id) && tags.includes('shared')) {
-      this.context['_addStore'](store, tags);
-    }
-  }
-
-  // Temporary method to allow sharing stores with other Arcs.
-  unregisterStore(storeId: string, tags: string[]) {
-    // #shared tag indicates that a store was made available to all arcs.
-    if (!tags.includes('shared')) {
-      return;
-    }
-    const index = this.context.stores.findIndex(store => store.id === storeId);
-    if (index >= 0) {
-      const store = this.context.stores[index];
-      this.context.storeTags.delete(store);
-      this.context.stores.splice(index, 1);
-    }
   }
 
   /**

--- a/src/runtime/tests/data-layer-test.ts
+++ b/src/runtime/tests/data-layer-test.ts
@@ -11,6 +11,7 @@
 import {assert} from '../../platform/chai-web.js';
 import {Arc} from '../arc.js';
 import {Loader} from '../../platform/loader.js';
+import {Manifest} from '../manifest.js';
 import {FakeSlotComposer} from '../testing/fake-slot-composer.js';
 import {Schema} from '../schema.js';
 import {EntityType} from '../type.js';
@@ -22,7 +23,9 @@ describe('entity', () => {
   it('can be created, stored, and restored', async () => {
     const schema = new Schema(['TestSchema'], {value: 'Text'});
 
-    const arc = new Arc({slotComposer: new FakeSlotComposer(), id: ArcId.newForTest('test'), context: null, loader: new Loader()});
+    const id = ArcId.newForTest('test');
+    const context = new Manifest({id});
+    const arc = new Arc({slotComposer: new FakeSlotComposer(), id, context, loader: new Loader()});
     const entity = new (Entity.createEntityClass(schema, null))({value: 'hello world'});
     assert.isDefined(entity);
 

--- a/tools/sigh.ts
+++ b/tools/sigh.ts
@@ -542,7 +542,7 @@ async function cycles(args: string[]): Promise<boolean> {
   // This should only go down!
   // Please adjust this number down when you remove cycles.
   // https://github.com/PolymerLabs/arcs/issues/1878
-  const CURRENT_NUMBER_OF_CYCLES = 12;
+  const CURRENT_NUMBER_OF_CYCLES = 11;
 
   if (res.length > CURRENT_NUMBER_OF_CYCLES)  {
     sighLog('You seem to have added a dependency cycle, please refactor your code.');


### PR DESCRIPTION
Moves cycle count from 12 to 11.

Move registering and unregistering stores into the Manifest itself.

Avoids the complexity of adding a StoreRegistry interface and having
to pass it along to the Arc ctor as in #4346.

Potential down sides:
- Requires that the Manifest (`context`) that the Arc has, and is
  given in its ctor, is assured to be the right one to
  register/unregister the Arc's stores.
- There is future evolution foreseen around Context that may
  mean there is benefit to the separation of concerns afforded
  by a more minimal StoreRegistry interface vs interacting
  with a heavyweight Manifest object.

Part of #1878.