### PR TITLE
Clean up legacy Arc id type logic.

### DIFF
--- a/src/runtime/arc.ts
+++ b/src/runtime/arc.ts
@@ -123,15 +123,7 @@ export class Arc implements ArcInterface {
       slotComposer['arc'] = this;
     }
 
-    if (typeof id === 'string') {
-      // TODO(csilvestrini): Replace this warning with an exception.
-      console.error(
-          `Arc created with string ID ${id}!!! This should be an object of type Id instead. This warning will turn into an ` +
-          `exception soon (end of April 2019).`);
-      this.id = ArcId.fromString(id);
-    } else {
-      this.id = id;
-    }
+    this.id = id;
     this.isSpeculative = !!speculative; // undefined => false
     this.isInnerArc = !!innerArc; // undefined => false
     this.isStub = !!stub;


### PR DESCRIPTION
This looks quite stale, AFAICT it shouldn't even be possible to call the ctor without an appropriate type any more (unless one wrangled things in the transpiled JS, but I also don't see any of our JS code doing that).

FYI @csilvestrini 