### PR TITLE
Break cycle between Manifest and Synthetic Storage.

### DIFF
--- a/src/cli/spotify-importer.ts
+++ b/src/cli/spotify-importer.ts
@@ -11,7 +11,7 @@
 
 import fs from 'fs';
 import {Id} from '../runtime/id.js';
-import {Manifest} from '../runtime/manifest.js';
+import {Manifest, ManifestHandleRetriever} from '../runtime/manifest.js';
 import {EntityType} from '../runtime/type.js';
 import {StorageProviderFactory} from '../runtime/storage/storage-provider-factory.js';
 import {resetStorageForTesting} from '../runtime/storage/firebase/firebase-storage.js';
@@ -105,7 +105,7 @@ void (async () => {
     const playlistType = new EntityType(manifest.schemas.Playlist);
 
     const id = Id.fromString('import');
-    const storage = new StorageProviderFactory(id);
+    const storage = new StorageProviderFactory(id, new ManifestHandleRetriever());
     const construct = () => storage.construct('import', playlistType.bigCollectionOf(), key);
     const connect = () => storage.connect('import', playlistType.bigCollectionOf(), key);
 

--- a/src/runtime/arc.ts
+++ b/src/runtime/arc.ts
@@ -15,7 +15,7 @@ import {FakePecFactory} from './fake-pec-factory.js';
 import {Id, IdGenerator, ArcId} from './id.js';
 import {Loader} from '../platform/loader.js';
 import {Runnable} from './hot.js';
-import {Manifest} from './manifest.js';
+import {Manifest, ManifestHandleRetriever} from './manifest.js';
 import {MessagePort} from './message-channel.js';
 import {Modality} from './modality.js';
 import {ParticleExecutionHost} from './particle-execution-host.js';
@@ -141,7 +141,8 @@ export class Arc implements ArcInterface {
     this.storageKey = storageKey;
     const ports = this.pecFactories.map(f => f(this.generateID(), this.idGenerator));
     this.pec = new ParticleExecutionHost(slotComposer, this, ports);
-    this.storageProviderFactory = storageProviderFactory || new StorageProviderFactory(this.id);
+    this.storageProviderFactory = storageProviderFactory ||
+        new StorageProviderFactory(this.id, new ManifestHandleRetriever());
 
     this.volatileStorageDriverProvider = new VolatileStorageDriverProvider(this);
     DriverFactory.register(this.volatileStorageDriverProvider);

--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -31,6 +31,7 @@ import {Recipe, RequireSection} from './recipe/recipe.js';
 import {Search} from './recipe/search.js';
 import {TypeChecker} from './recipe/type-checker.js';
 import {StorageProviderFactory} from './storage/storage-provider-factory.js';
+import {HandleRetriever} from './storage/handle-retriever.js';
 import {Schema} from './schema.js';
 import {BigCollectionType, CollectionType, EntityType, InterfaceInfo, InterfaceType,
         ReferenceType, SlotType, Type, TypeVariable, SingletonType} from './type.js';
@@ -129,6 +130,16 @@ interface ManifestLoadOptions {
   memoryProvider?: VolatileMemoryProvider;
 }
 
+export class ManifestHandleRetriever implements HandleRetriever {
+  async getHandlesFromManifest(content: string) : Promise<Handle[]> {
+    const manifest = await Manifest.parse(content, {});
+    if (!manifest.activeRecipe) {
+      return null;
+    }
+    return manifest.activeRecipe.handles || [];
+  }
+}
+
 export class Manifest {
   private _recipes: Recipe[] = [];
   private _imports: Manifest[] = [];
@@ -174,7 +185,7 @@ export class Manifest {
       throw new Error('Not present in the new storage stack.');
     }
     if (this._storageProviderFactory == undefined) {
-      this._storageProviderFactory = new StorageProviderFactory(this.id);
+      this._storageProviderFactory = new StorageProviderFactory(this.id, new ManifestHandleRetriever());
     }
     return this._storageProviderFactory;
   }

--- a/src/runtime/manual_tests/firebase-test.ts
+++ b/src/runtime/manual_tests/firebase-test.ts
@@ -13,7 +13,7 @@ import {assert} from '../../platform/chai-web.js';
 import {Arc} from '../arc.js';
 import {Id, ArcId} from '../id.js';
 import {Loader} from '../../platform/loader.js';
-import {Manifest} from '../manifest.js';
+import {Manifest, ManifestHandleRetriever} from '../manifest.js';
 import {Runtime} from '../runtime.js';
 import {EntityType, ReferenceType} from '../type.js';
 import {resetStorageForTesting} from '../storage/firebase/firebase-storage.js';
@@ -54,7 +54,7 @@ describe('firebase', function() {
   let storageInstances: StorageProviderFactory[] = [];
 
   function createStorage(id: Id): StorageProviderFactory {
-    const storage = new StorageProviderFactory(id);
+    const storage = new StorageProviderFactory(id, new ManifestHandleRetriever());
     storageInstances.push(storage);
     return storage;
   }

--- a/src/runtime/storage/handle-retriever.ts
+++ b/src/runtime/storage/handle-retriever.ts
@@ -1,0 +1,19 @@
+/**
+ * @license
+ * Copyright (c) 2020 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {Handle} from '../recipe/handle.js';
+
+export interface HandleRetriever {
+  // Given an Arcs manifest as string, the implementation should return
+  // an array of any Handles in the resulting parsed Manifest object or
+  // the empty list if none were present. On parse error the promise
+  // should reject with error detail.
+  getHandlesFromManifest(content: string) : Promise<Handle[]>;
+}

--- a/src/runtime/storage/storage-provider-factory.ts
+++ b/src/runtime/storage/storage-provider-factory.ts
@@ -11,6 +11,7 @@
 import {StorageBase, StorageProviderBase} from './storage-provider-base.js';
 import {VolatileStorage} from './volatile-storage.js';
 import {SyntheticStorage} from './synthetic-storage.js';
+import {HandleRetriever} from './handle-retriever.js';
 import {Id} from '../id.js';
 import {Type} from '../type.js';
 import {KeyBase} from './key-base.js';
@@ -34,13 +35,19 @@ export class StorageProviderFactory {
   private _storageInstances: Dictionary<{storage: StorageBase, isPersistent: boolean}>;
 
   private readonly mutexMap: Map<string, Mutex> = new Map<string, Mutex>();
+  private readonly handleRetriever: HandleRetriever;
 
-  constructor(private readonly arcId: Id) {
+  constructor(private readonly arcId: Id, handleRetriever: HandleRetriever) {
+    this.handleRetriever = handleRetriever;
     this._storageInstances = {};
     Object.keys(providers).forEach(name => {
       const {storage, isPersistent} = providers[name];
       this._storageInstances[name] = {storage: new storage(arcId, this), isPersistent};
     });
+  }
+
+  getHandleRetriever(): HandleRetriever {
+    return this.handleRetriever;
   }
 
   private getInstance(key: string) {

--- a/src/runtime/tests/storage/pouchdb/pouch-db-test.ts
+++ b/src/runtime/tests/storage/pouchdb/pouch-db-test.ts
@@ -12,7 +12,7 @@ import '../../../storage/pouchdb/pouch-db-provider.js';
 import {assert} from '../../../../platform/chai-web.js';
 import {Arc} from '../../../arc.js';
 import {Loader} from '../../../../platform/loader.js';
-import {Manifest} from '../../../manifest.js';
+import {Manifest, ManifestHandleRetriever} from '../../../manifest.js';
 import {PouchDbCollection} from '../../../storage/pouchdb/pouch-db-collection.js';
 import {PouchDbStorage} from '../../../storage/pouchdb/pouch-db-storage.js';
 import {PouchDbSingleton} from '../../../storage/pouchdb/pouch-db-singleton.js';
@@ -46,7 +46,7 @@ describe('pouchdb for ' + testUrl, () => {
   function createStorage(id: Id) {
     let storage = storageInstances.get(id);
     if (!storage) {
-      storage = new StorageProviderFactory(id);
+      storage = new StorageProviderFactory(id, new ManifestHandleRetriever());
       storageInstances.set(id, storage);
     }
 
@@ -271,7 +271,7 @@ describe('pouchdb for ' + testUrl, () => {
           value: Text
       `);
       const arc = new Arc({id: ArcId.newForTest('test'), context: manifest, loader: new Loader()});
-      const storage = new StorageProviderFactory(arc.id);
+      const storage = new StorageProviderFactory(arc.id, new ManifestHandleRetriever());
       const barType = new EntityType(manifest.schemas.Bar);
       const key = newStoreKey('collectionRemoveMultiple');
       const collection = await storage.construct('test1', barType.collectionOf(), key) as PouchDbCollection;

--- a/src/runtime/tests/synthetic-storage-test.ts
+++ b/src/runtime/tests/synthetic-storage-test.ts
@@ -10,6 +10,7 @@
 
 import {assert} from '../../platform/chai-web.js';
 import {Id, ArcId} from '../id.js';
+import {ManifestHandleRetriever} from '../manifest.js';
 import {ChangeEvent, CollectionStorageProvider, SingletonStorageProvider} from '../storage/storage-provider-base.js';
 import {StorageProviderFactory} from '../storage/storage-provider-factory.js';
 import {resetVolatileStorageForTesting} from '../storage/volatile-storage.js';
@@ -24,7 +25,7 @@ describe('synthetic storage ', () => {
 
   async function setup(serialization): Promise<{id: Id, targetStore: SingletonStorageProvider, synth: CollectionStorageProvider}> {
     const id = ArcId.newForTest('test');
-    const storage = new StorageProviderFactory(id);
+    const storage = new StorageProviderFactory(id, new ManifestHandleRetriever());
     const type = new ArcType();
     const key = storage.parseStringAsKey(`volatile://${id}`).childKeyForArcInfo().toString();
     const targetStore = await storage.construct('id0', type, key) as SingletonStorageProvider;
@@ -39,7 +40,7 @@ describe('synthetic storage ', () => {
   }
 
   it('invalid synthetic keys', async () => {
-    const storage = new StorageProviderFactory(ArcId.newForTest('test'));
+    const storage = new StorageProviderFactory(ArcId.newForTest('test'), new ManifestHandleRetriever());
     const check = (key, msg) => assertThrowsAsync(() => storage.connect('id1', null, key), msg);
 
     await Promise.all([
@@ -53,7 +54,7 @@ describe('synthetic storage ', () => {
   });
 
   it('non-existent target key', async () => {
-    const storage = new StorageProviderFactory(ArcId.newForTest('test'));
+    const storage = new StorageProviderFactory(ArcId.newForTest('test'), new ManifestHandleRetriever());
     const synth = await storage.connect('id1', null, `synthetic://arc/handles/volatile://nope`);
     assert.isNull(synth);
   });

--- a/tools/sigh.ts
+++ b/tools/sigh.ts
@@ -542,7 +542,7 @@ async function cycles(args: string[]): Promise<boolean> {
   // This should only go down!
   // Please adjust this number down when you remove cycles.
   // https://github.com/PolymerLabs/arcs/issues/1878
-  const CURRENT_NUMBER_OF_CYCLES = 8;
+  const CURRENT_NUMBER_OF_CYCLES = 7;
 
   if (res.length > CURRENT_NUMBER_OF_CYCLES)  {
     sighLog('You seem to have added a dependency cycle, please refactor your code.');


### PR DESCRIPTION
Moves cycles from 8 to 7.

Introduces a `HandleRetriever` class used only for synthetic storage so
as to break the direct link to `Manifest`. This in turn requires passing
a retriever in to the (old storage stack) `StorageProviderFactory`. We
could then pass it along to the individual storage drivers even though
not all of them need it, but given the stack migration underway, I
decided to just add an accessor to the factory.

Only synthetic storage even has the need to retrieve the handles from
a manifest, so there may be a better factoring, but this seems
reasonably well contained and a small change.

Part of #1878.