### PR TITLE
Break cycle between Runtime and SlotDomConsumer.

### DIFF
--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -26,6 +26,7 @@ import {VolatileStorage} from './storage/volatile-storage.js';
 import {StorageKey} from './storageNG/storage-key.js';
 import {Recipe} from './recipe/recipe.js';
 import {RecipeResolver} from './recipe/recipe-resolver.js';
+import {SlotDomConsumer} from './slot-dom-consumer.js';
 import {Loader} from '../platform/loader.js';
 import {pecIndustry} from '../platform/pec-industry.js';
 import {logsFactory} from '../platform/logs-factory.js';
@@ -152,6 +153,9 @@ export class Runtime {
     // a Runtime instance and forge ahead. This is only temporary until we move
     // to the new storage stack.
     VolatileStorage.setStorageCache(this.cacheService);
+    // TODO(wkorman): UI Broker refactor is underway and will change the
+    // Slot related infrastructure, so the below is only temporary.
+    SlotDomConsumer.setCacheService(this.cacheService);
     this.loader = loader;
     this.pecFactory = pecFactory;
     this.composerClass = composerClass;

--- a/src/runtime/slot-dom-consumer.ts
+++ b/src/runtime/slot-dom-consumer.ts
@@ -16,18 +16,20 @@ import {Arc} from './arc.js';
 import {SlotConnection} from './recipe/slot-connection.js';
 import {SlotConsumer, Content, Rendering} from './slot-consumer.js';
 import {ProvidedSlotContext} from './slot-context.js';
-import {Runtime} from './runtime.js';
+import {RuntimeCacheService} from './runtime-cache.js';
 
 export interface DomRendering extends Rendering {
   liveDom?: Template;
 }
 
-const templateByName = () => Runtime.getRuntime().getCacheService().getOrCreateCache<string, HTMLElement>('templateByName');
-
 // this style sheet is installed in every particle shadow-root
 let commonStyleTemplate;
 
+const templateByName = () => SlotDomConsumer.templateByName();
+
 export class SlotDomConsumer extends SlotConsumer {
+  private static cacheService: RuntimeCacheService;
+
   private readonly _observer: MutationObserver;
 
   constructor(arc: Arc, consumeConn?: SlotConnection, containerKind?: string) {
@@ -43,6 +45,15 @@ export class SlotDomConsumer extends SlotConsumer {
       request.push('template');
     }
     return request;
+  }
+
+  static setCacheService(cacheService: RuntimeCacheService) {
+    SlotDomConsumer.cacheService = cacheService;
+  }
+
+  static templateByName() {
+    assert(SlotDomConsumer.cacheService, `SlotDomConsumer requires provisioning with a cache service before use.`);
+    return SlotDomConsumer.cacheService.getOrCreateCache<string, HTMLElement>('templateByName');
   }
 
   static hasTemplate(templatePrefix: string): string {

--- a/src/tests/hotreload-integration-test.ts
+++ b/src/tests/hotreload-integration-test.ts
@@ -40,7 +40,9 @@ class StubWasmLoader extends Loader {
 
 describe('Hot Code Reload for JS Particle', async () => {
   beforeEach(() => {
-    VolatileStorage.setStorageCache(new RuntimeCacheService());
+    const cacheService = new RuntimeCacheService();
+    HeadlessSlotDomConsumer.setCacheService(cacheService);
+    VolatileStorage.setStorageCache(cacheService);
   });
 
   it('updates model and template', async () =>{

--- a/tools/sigh.ts
+++ b/tools/sigh.ts
@@ -542,7 +542,7 @@ async function cycles(args: string[]): Promise<boolean> {
   // This should only go down!
   // Please adjust this number down when you remove cycles.
   // https://github.com/PolymerLabs/arcs/issues/1878
-  const CURRENT_NUMBER_OF_CYCLES = 7;
+  const CURRENT_NUMBER_OF_CYCLES = 6;
 
   if (res.length > CURRENT_NUMBER_OF_CYCLES)  {
     sighLog('You seem to have added a dependency cycle, please refactor your code.');


### PR DESCRIPTION
Moves cycles from 7 to 6.

Achieved via statically setting a cache service in `SlotDomConsumer` as
part of `Runtime` ctor. The UI Broker rework underway currently is
likely to change this further or perhaps obviate it entirely.

Part of #1878.