### PR TITLE
Remove duplicate port close

### DIFF
--- a/src/runtime/particle-execution-host.ts
+++ b/src/runtime/particle-execution-host.ts
@@ -62,7 +62,6 @@ export class ParticleExecutionHost {
 
   constructor(slotComposer: SlotComposer, arc: Arc, ports: MessagePort[]) {
     this.close = () => {
-      ports.forEach(port => port.close());
       this._apiPorts.forEach(apiPort => apiPort.close());
     };
 


### PR DESCRIPTION
The ports were passed to
this._apiPorts = ports.map(port => new PECOuterPortImpl(port, arc));
where the close() method at the PECOuterPortImpl's root class APIPort has already handled the port close.