### PR TITLE
Set up StorageNG volatile memory and ramdisk in dev shell.

### DIFF
--- a/shells/dev-shell/index.js
+++ b/shells/dev-shell/index.js
@@ -13,6 +13,8 @@ import '../configuration/whitelisted.js';
 import '../lib/platform/loglevel-web.js';
 
 import {Runtime} from '../../build/runtime/runtime.js';
+import {RamDiskStorageDriverProvider} from '../../build/runtime/storageNG/drivers/ramdisk.js';
+import {SimpleVolatileMemoryProvider} from '../../build/runtime/storageNG/drivers/volatile.js';
 import {Loader} from '../../build/platform/loader.js';
 import {Arc} from '../../build/runtime/arc.js';
 import {IdGenerator} from '../../build/runtime/id.js';
@@ -42,10 +44,13 @@ const {
   helpButton
 } = window;
 
+let memoryProvider;
 init();
 
 function init() {
   VolatileStorage.setStorageCache(new RuntimeCacheService());
+  const memoryProvider = new SimpleVolatileMemoryProvider();
+  RamDiskStorageDriverProvider.register(memoryProvider);
   filePane.init(execute, toggleFilesButton, exportFilesButton);
   executeButton.addEventListener('click', execute);
   helpButton.addEventListener('click', showHelp);
@@ -114,7 +119,7 @@ async function wrappedExecute() {
 
   let manifest;
   try {
-    const options = {loader, fileName: './manifest', throwImportErrors: true};
+    const options = {loader, fileName: './manifest', throwImportErrors: true, memoryProvider};
     manifest = await Runtime.parseManifest(filePane.getManifest(), options);
   } catch (e) {
     outputPane.showError('Error in Manifest.parse', e);


### PR DESCRIPTION
I don't like adding `memoryProvider` as a top level global but it's just a dev shell. We could rework things so that `init` is a method on an object and that'd give us a place to store the instance.