### PR TITLE
Fix the logic that removes "-wasm" suffix in wasm_kt_particle rule

### DIFF
--- a/third_party/bazel_rules/rules_kotlin/kotlin/native/wasm.bzl
+++ b/third_party/bazel_rules/rules_kotlin/kotlin/native/wasm.bzl
@@ -1,6 +1,8 @@
 # Alias wasm split transition rule unless G3 Kotlin Native synced with GH rules
 def wasm_kt_binary(name, kt_target, visibility = None):
-    outname = name.rstrip("-wasm")
+    # Remove the `-wasm` suffix from the name.
+    suffix = "-wasm"
+    outname = name if not name.endswith(suffix) else name[:-len(suffix)]
     native.genrule(
         name = name,
         srcs = [kt_target + ".wasm", kt_target + ".wasm.js"],


### PR DESCRIPTION
Right now, it strips characters `-wasm` from the end, which means that `RenderSlots-wasm` becomes `RenderSlot`. 