### PR TITLE
Add info when an exception is neither a user or system exception.

### DIFF
--- a/src/runtime/arc-exceptions.ts
+++ b/src/runtime/arc-exceptions.ts
@@ -51,7 +51,8 @@ export class PropagatedException extends Error {
         exception = new UserException(cause, literal.method, literal.particleId, literal.particleName);
         break;
       default:
-        throw new Error(`Unknown exception type: ${literal.exceptionType}`);
+        exception = new PropagatedException(cause, literal.method, literal.particleId, literal.particleName);
+        break;
     }
     exception.stack = literal.stack;
     return exception;

--- a/src/runtime/particle-execution-host.ts
+++ b/src/runtime/particle-execution-host.ts
@@ -425,7 +425,10 @@ class PECOuterPortImpl extends PECOuterPort {
 
   onReportExceptionInHost(exception: PropagatedException) {
     if (!exception.particleName) {
-      exception.particleName = this.arc.loadedParticleInfo.get(exception.particleId).spec.name;
+      particleInfo = this.arc.loadedParticleInfo.get(exception.particleId);
+      if (particleInfo) {
+        exception.particleName = spec.name;
+      }
     }
     reportSystemException(exception);
   }


### PR DESCRIPTION
This should help with debugging an issue whenever an unknown exception is thrown. Here is a sample output:

> arc-exceptions.ts:24 Uncaught (in promise) Error
    at Object.onError (../../shells/lib/build/worker.js:1114:67)
    at Object._processMessage (../../shells/lib/build/worker.js:819:18)
Caused by: Error: HTTP 404: Not Found for http://localhost:9786/bazel-bin/particles/Tutorial/Kotlin/3_RenderSlots/RenderSlots.wasm
    at Loader.fetchBuffer (../../shells/lib/build/worker.js:9861:31)
    at async Object.loadWasmParticle (../../shells/lib/build/worker.js:506:28)
    at async Object.createParticleFromSpec (../../shells/lib/build/worker.js:491:24)
    at async Object.instantiateParticle (../../shells/lib/build/worker.js:399:26)
    at async ThingMapper.establishThingMapping (../../shells/lib/build/worker.js:765:50)
    at async Object.before (../../shells/lib/build/worker.js:999:25)
    at async Object._processMessage (../../shells/lib/build/worker.js:816:13)
