### PR TITLE
pipes-shell: force runArc commands to be executed serially

### DIFF
--- a/shells/pipes-shell/source/pipe.js
+++ b/shells/pipes-shell/source/pipe.js
@@ -21,6 +21,7 @@ import {instantiateRecipeByName} from './lib/utils.js';
 import {requireContext} from './context.js';
 import {dispatcher} from './dispatcher.js';
 import {requireIngestionArc} from './ingestion-arc.js';
+import {serializeVerb} from './serialize-verb.js';
 
 const {log} = logsFactory('pipe');
 
@@ -61,7 +62,8 @@ const populateDispatcher = (dispatcher, storage, context) => {
     // TODO: consolidate runArc and uiEvent with spawn and event, as well as
     // use of runtime object and composerFactory, brokerFactory below.
     runArc: async (msg, tid, bus) => {
-      return await runArc(msg, bus, runtime, storage);
+      const task = async () => await runArc(msg, bus, runtime, storage);
+      return await serializeVerb('runArc', task);
     },
     uiEvent: async (msg, tid, bus) => {
       return await uiEvent(msg, runtime);

--- a/shells/pipes-shell/source/serialize-verb.js
+++ b/shells/pipes-shell/source/serialize-verb.js
@@ -23,7 +23,7 @@ let index = 0;
 
 export const serializeVerb = async (verb, asyncTask) => {
   // only for logging
-  let id = ++index;
+  const id = ++index;
   // capture previous work-promise
   const busy = work[verb];
   // construct new work-promise

--- a/shells/pipes-shell/source/serialize-verb.js
+++ b/shells/pipes-shell/source/serialize-verb.js
@@ -12,8 +12,8 @@ import {logsFactory} from '../../../build/platform/logs-factory.js';
 
 const {log} = logsFactory('SerializeVerb');
 
-// TODO(sjmiles): serialize requests to runArc to reduce synchronization
-// burden on apps. Revisit at some point.
+// TODO(sjmiles): allow serializing verbs to reduce synchronization
+// burden on apps. Not strictly part of runtime api: revisit at some point.
 
 // have separate queues per verb
 const work = {};

--- a/shells/pipes-shell/source/serialize-verb.js
+++ b/shells/pipes-shell/source/serialize-verb.js
@@ -1,0 +1,44 @@
+/**
+ * @license
+ * Copyright 2019 Google LLC.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {logsFactory} from '../../../build/platform/logs-factory.js';
+
+const {log} = logsFactory('SerializeVerb');
+
+// TODO(sjmiles): serialize requests to runArc to reduce synchronization
+// burden on apps. Revisit at some point.
+
+// have separate queues per verb
+const work = {};
+
+// only for logging
+let index = 0;
+
+export const serializeVerb = async (verb, asyncTask) => {
+  // only for logging
+  let id = ++index;
+  // capture previous work-promise
+  const busy = work[verb];
+  // construct new work-promise
+  let resolve;
+  work[verb] = new Promise(_resolve => resolve = _resolve);
+  // wait for previous work (yields at await)
+  log(`awaiting [${verb}][${id-1}]`);
+  await busy;
+  // begin new work (yields at await)
+  log(`invoking [${verb}][${id}]`);
+  await (async () => {
+    const result = await asyncTask();
+    log(`completed [${verb}][${id}]`);
+    resolve(result);
+  })();
+  // return new work-promise
+  return work[verb];
+};

--- a/shells/pipes-shell/source/testDevice.js
+++ b/shells/pipes-shell/source/testDevice.js
@@ -105,6 +105,13 @@ const smokeTest = async (bus) => {
     send({message: 'spawn', modality: 'dom', recipe: 'HelloWorldRecipe'});
   };
   //
+  const runArcSerialTest = () => {
+    // async `runArc` commands are performed serially
+    send({message: 'runArc', arcId: 'pipe-notification-test1', modality: 'dom', recipe: 'Notification'});
+    send({message: 'runArc', arcId: 'pipe-notification-test2', modality: 'dom', recipe: 'Notification'});
+    send({message: 'runArc', arcId: 'pipe-notification-test3', modality: 'dom', recipe: 'Notification'});
+  };
+  //
   // perform tests
   enqueue([
     enableIngestion,
@@ -112,6 +119,7 @@ const smokeTest = async (bus) => {
     autofillTest,
     notificationTest,
     wasmTest,
-    parseTest
+    parseTest,
+    runArcSerialTest
   ], 500);
 };

--- a/shells/pipes-shell/source/verbs/run-arc.js
+++ b/shells/pipes-shell/source/verbs/run-arc.js
@@ -16,36 +16,6 @@ import {portIndustry} from '../pec-port.js';
 
 const {log, warn} = logsFactory('runArc');
 
-/*
-// TODO(sjmiles): serialize requests to runArc to reduce synchronization
-// burden on apps. Revisit at some point.
-
-const runQueue = [];
-
-export const runArc = async (...args) => {
-  if (runArc.busy) {
-    runQueue.push(args);
-    warn('queue.push: length is ', runQueue.length);
-  } else {
-    await _runArc(...args);
-    warn('queue.shift: length is ', runQueue.length);
-    const nextArgs = runQueue.shift();
-    if (nextArgs) {
-      await runArc(...nextArgs);
-    }
-  }
-};
-
-const _runArc = async(...args) => {
-  runArc.busy = true;
-  try {
-    await __runArc(...args);
-  } finally {
-    runArc.busy = false;
-  }
-};
-*/
-
 // This implementation was forked from verbs/spawn.js
 
 export const runArc = async (msg, bus, runtime, defaultStorageKeyPrefix) => {

--- a/shells/pipes-shell/source/verbs/run-arc.js
+++ b/shells/pipes-shell/source/verbs/run-arc.js
@@ -16,10 +16,11 @@ import {portIndustry} from '../pec-port.js';
 
 const {log, warn} = logsFactory('runArc');
 
-const runQueue = [];
-
+/*
 // TODO(sjmiles): serialize requests to runArc to reduce synchronization
 // burden on apps. Revisit at some point.
+
+const runQueue = [];
 
 export const runArc = async (...args) => {
   if (runArc.busy) {
@@ -43,10 +44,11 @@ const _runArc = async(...args) => {
     runArc.busy = false;
   }
 };
+*/
 
 // This implementation was forked from verbs/spawn.js
 
-export const __runArc = async (msg, bus, runtime, defaultStorageKeyPrefix) => {
+export const runArc = async (msg, bus, runtime, defaultStorageKeyPrefix) => {
   const {recipe, arcId, storageKeyPrefix, pecId, particles} = msg;
   const action = runtime.context.allRecipes.find(r => r.name === recipe);
   if (!arcId) {


### PR DESCRIPTION
Possible implementation by request of @piotrswigon to resolve errors with upstream users executing serial dependent runArc commands.