### PR TITLE
Remove default entity instances from Kotlin particles and use the normal

### DIFF
--- a/particles/Native/Wasm/source/TestParticle.kt
+++ b/particles/Native/Wasm/source/TestParticle.kt
@@ -104,12 +104,9 @@ class TestParticle : Particle() {
                  </table>""".trimIndent()
     }
 
-    private val defaultData = TestParticle_Data()
-    private val defaultRes = TestParticle_Res()
-    private val defaultInfo = TestParticle_Info()
-    private val data = Singleton(this, "data") { defaultData }
-    private val res = Singleton(this, "res") { defaultRes }
-    private val info = Collection(this, "info") { defaultInfo }
+    private val data = Singleton(this, "data") { TestParticle_Data() }
+    private val res = Singleton(this, "res") { TestParticle_Res() }
+    private val info = Collection(this, "info") { TestParticle_Info() }
     private var updated = 0
     private var storeCount = 0
 

--- a/particles/Tutorial/Kotlin/Demo/README.md
+++ b/particles/Tutorial/Kotlin/Demo/README.md
@@ -186,7 +186,7 @@ import arcs.TTTGame_GameState
 class TTTGame : Particle() {
     private val defaultGame = TTTGame_GameState(board = ",,,,,,,,")
 
-    private val gameState = Singleton(this, "gameState") { defaultGame }
+    private val gameState = Singleton(this, "gameState") { TTTGame_GameState() }
     private val events = Collection(this, "events") { TTTGame_Events(
         type = "",
         move = -1.0,
@@ -229,8 +229,8 @@ class TTTBoard : Particle() {
         time = -1.0
     )
 
-    private val gameState = Singleton(this, "gameState") { defaultGameState }
-    private val events = Collection(this, "events") { defaultEvent }
+    private val gameState = Singleton(this, "gameState") { TTTBoard_GameState() }
+    private val events = Collection(this, "events") { TTTBoard_Events() }
     private var clicks = 0.0
     private val emptyBoard = listOf("", "", "", "", "", "", "", "", "")
 

--- a/particles/Tutorial/Kotlin/Demo/src/pt3/TTTGame.kt
+++ b/particles/Tutorial/Kotlin/Demo/src/pt3/TTTGame.kt
@@ -28,7 +28,7 @@ class TTTGame : Particle() {
         currentPlayer = (0..1).random().toDouble()
     )
 
-    private val gameState = Singleton(this, "gameState") { defaultGame }
+    private val gameState = Singleton(this, "gameState") { TTTGame_GameState() }
     private val playerOne = Singleton(this, "playerOne") { TTTGame_PlayerOne() }
     private val playerOneMove = Singleton(this, "playerOneMove") { TTTGame_PlayerOneMove() }
     private val playerTwo = Singleton(this, "playerTwo") { TTTGame_PlayerTwo() }

--- a/particles/Tutorial/Kotlin/Demo/src/pt4/TTTGame.kt
+++ b/particles/Tutorial/Kotlin/Demo/src/pt4/TTTGame.kt
@@ -30,7 +30,7 @@ class TTTGame : Particle() {
         winnerAvatar = ""
     )
 
-    private val gameState = Singleton(this, "gameState") { defaultGame }
+    private val gameState = Singleton(this, "gameState") { TTTGame_GameState() }
     private val playerOne = Singleton(this, "playerOne") { TTTGame_PlayerOne() }
     private val playerOneMove = Singleton(this, "playerOneMove") { TTTGame_PlayerOneMove() }
     private val playerTwo = Singleton(this, "playerTwo") { TTTGame_PlayerTwo() }

--- a/particles/Tutorial/Kotlin/Demo/src/total/TTTGame.kt
+++ b/particles/Tutorial/Kotlin/Demo/src/total/TTTGame.kt
@@ -30,7 +30,7 @@ class TTTGame : Particle() {
         winnerAvatar = ""
     )
 
-    private val gameState = Singleton(this, "gameState") { defaultGame }
+    private val gameState = Singleton(this, "gameState") { TTTGame_GameState() }
     private val playerOne = Singleton(this, "playerOne") { TTTGame_PlayerOne() }
     private val playerOneMove = Singleton(this, "playerOneMove") { TTTGame_PlayerOneMove() }
     private val playerTwo = Singleton(this, "playerTwo") { TTTGame_PlayerTwo() }


### PR DESCRIPTION
Remove default entity instances from Kotlin particles and use the normal entity constructor.

This code will soon be autogenerated, and won't support default
instances anymore.