### PR TITLE
[WIP] Handle impl in kt

### DIFF
--- a/java/arcs/core/storage/Handle.kt
+++ b/java/arcs/core/storage/Handle.kt
@@ -1,0 +1,187 @@
+package arcs.core.storage
+
+import arcs.core.common.Referencable
+import arcs.core.crdt.CrdtData
+import arcs.core.crdt.CrdtOperation
+import arcs.core.crdt.CrdtSet
+import arcs.core.crdt.CrdtSingleton
+import arcs.core.crdt.CrdtSingleton.Data
+import arcs.core.crdt.CrdtSingleton.Operation.Clear
+import arcs.core.crdt.CrdtSingleton.Operation.Update
+import arcs.core.crdt.internal.VersionMap
+
+// Todo: Reconcile differences with Particle
+interface Particle {
+    fun onHandleSync(handle: Handle<*,*,*>)
+    fun onHandleDesync(handle: Handle<*,*,*>)
+    fun onHandleUpdate(handle: Handle<*,*,*>)
+}
+
+// Return type for StorageProxy.getParticleView
+data class ValueAndVersion<T>(val value: T, val versionMap: VersionMap)
+
+// TODO - actually implement storage proxy
+interface StorageProxy<StorageType : CrdtData, Operation : CrdtOperation, ConsumerType> {
+    fun getParticleView(): ValueAndVersion<ConsumerType>
+    fun applyOp(op: Operation): Boolean
+}
+
+/**
+ * Base class for handles.
+ *
+ * OPEN QUESTIONS:
+ * * Entity creation
+ * * Serialization (and if so, across what boundaries?)
+ * * Update messages to particle... Messaging to particle in general
+ */
+abstract class Handle<StorageType : CrdtData, Operation : CrdtOperation, ConsumerType>(
+    val key: String,
+    val storageProxy: StorageProxy<StorageType, Operation, ConsumerType>,
+    val particle: Particle,
+    var direction: Direction,
+    val name: String="")
+{
+
+    class HandleNotReadableException : IllegalStateException("handle not readable")
+    class HandleNotWriteableException : IllegalStateException("handle not writable")
+
+    enum class Direction(val canRead: Boolean, val canWrite: Boolean) {
+        Unconnected(false, false),
+        In(true, false),
+        Out(false, true),
+        InOut(true, true)
+    }
+
+    var clock: VersionMap=VersionMap()
+        protected set
+
+    fun incrementClock() {
+        this.clock[this.key] += 1
+    }
+
+    abstract fun onSync()
+    abstract fun onDesync()
+    abstract fun onUpdate(op: Operation, version: VersionMap)
+
+    fun mustBeReadable() { this.direction.canRead || throw HandleNotReadableException() }
+    fun mustBeWritable() { this.direction.canWrite || throw HandleNotWriteableException() }
+}
+
+/**
+ * Implementation of a handle containing a single value that can be set and get
+ */
+class Singleton<T : Referencable>(
+    key: String,
+    storageProxy: StorageProxy<Data<T>, CrdtSingleton.IOperation<T>, T?>,
+    particle: Particle,
+    direction: Direction,
+    name: String=""
+) : Handle<Data<T>, CrdtSingleton.IOperation<T>, T?>(key, storageProxy, particle, direction, name) {
+
+    //region getters/setters
+    fun get(): T? {
+        mustBeReadable()
+        val (value, versionMap) = storageProxy.getParticleView();
+        this.clock = versionMap
+        return value
+    }
+
+    fun set(value: T): Boolean {
+        mustBeWritable()
+        incrementClock()
+        return storageProxy.applyOp(Update(key, clock, value))
+    }
+
+    fun clear(): Boolean {
+        mustBeWritable()
+        return this.storageProxy.applyOp(Clear(key, clock))
+    }
+    //endregion
+
+    //region event handlers
+    override fun onUpdate(op: CrdtSingleton.IOperation<T>, version: VersionMap) {
+        mustBeReadable()
+        this.clock = version
+        // TODO - pass update message with data changes?
+        // Pass change to particle
+        particle.onHandleUpdate(this)
+    }
+
+    override fun onSync() {
+        mustBeReadable()
+        particle.onHandleSync(this)
+    }
+
+    override fun onDesync() {
+        mustBeReadable()
+        particle.onHandleDesync(this)
+    }
+    //endregion
+}
+
+class Collection<T : Referencable>(
+    key: String,
+    storageProxy: StorageProxy<CrdtSet.Data<T>, CrdtSet.IOperation<T>, Set<T>>,
+    particle: Particle,
+    direction: Direction,
+    name: String=""
+) : Handle<CrdtSet.Data<T>, CrdtSet.IOperation<T>, Set<T>>(key, storageProxy, particle, direction, name) {
+
+    //region getters/setters
+    fun add(entity: T) {
+        mustBeWritable()
+        incrementClock()
+        storageProxy.applyOp(CrdtSet.Operation.Add(clock, key, entity))
+    }
+
+    fun add(vararg entities: T) = add(entities.toSet())
+
+    fun add(entities: Iterable<T>) {
+        mustBeWritable()
+        entities.map(::add)
+    }
+
+    fun remove(entity: T) {
+        mustBeWritable()
+        storageProxy.applyOp(CrdtSet.Operation.Remove(clock, key, entity))
+    }
+
+    fun clear() {
+        mustBeWritable()
+        storageProxy.getParticleView().value?.map(::remove)
+    }
+
+    fun get(id: String): T? {
+        mustBeReadable()
+        val (value, versionMap) = storageProxy.getParticleView();
+        this.clock = versionMap
+        return value?.find { it.id == id }
+    }
+
+    fun toSet(): Set<T>?  {
+        mustBeReadable()
+        return storageProxy.getParticleView().value
+    }
+    //endregion
+
+
+    //region event handlers
+    override fun onUpdate(op: CrdtSet.IOperation<T>, version: VersionMap) {
+        mustBeReadable()
+        this.clock = version
+        // Pass change to particle
+        // TODO - pass update message with data changes?
+        particle.onHandleUpdate(this)
+    }
+
+    override fun onSync() {
+        mustBeReadable()
+        particle.onHandleSync(this)
+    }
+
+    override fun onDesync() {
+        mustBeReadable()
+        particle.onHandleDesync(this)
+    }
+    //endregion
+}

--- a/javatests/arcs/core/storage/HandleTest.kt
+++ b/javatests/arcs/core/storage/HandleTest.kt
@@ -1,0 +1,289 @@
+package arcs.core.storage
+
+import arcs.core.common.Referencable
+import arcs.core.common.ReferenceId
+import arcs.core.crdt.*
+import arcs.core.crdt.CrdtSingleton.Operation.Update
+import arcs.core.crdt.internal.VersionMap
+import arcs.core.storage.Handle.Direction.*
+import arcs.core.storage.Handle.HandleNotReadableException
+import arcs.core.storage.Handle.HandleNotWriteableException
+import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.Truth.assert_
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Suite
+
+
+class Mocks {
+
+    data class Value(override val id: ReferenceId, val data: String = "") : Referencable
+
+    companion object {
+        fun values(vararg ids: String): Set<Value> {
+            return ids.map { Value(it) }.toSet()
+        }
+    }
+
+    class StorageProxy<Data : CrdtData, Operation : CrdtOperation, T>(val crdt: CrdtModel<Data, Operation, T>) : arcs.core.storage.StorageProxy<Data, Operation, T> {
+        val versionMap = VersionMap()
+        override fun getParticleView(): ValueAndVersion<T> = ValueAndVersion(crdt.consumerView, versionMap)
+
+        override fun applyOp(op: Operation): Boolean {
+            crdt.applyOperation(op)
+            return true
+        }
+    }
+
+    class Particle : arcs.core.storage.Particle {
+        var onSyncCalled = false
+        var onDesyncCalled = false
+        var onHandleUpdateCalled = false
+        override fun onHandleSync(handle: Handle<*, *, *>) {
+            onSyncCalled = true
+        }
+
+        override fun onHandleDesync(handle: Handle<*, *, *>) {
+            onDesyncCalled = true
+        }
+
+        override fun onHandleUpdate(handle: Handle<*, *, *>) {
+            onHandleUpdateCalled = true
+        }
+    }
+}
+class CollectionHandleTest {
+
+    fun <T : Referencable> newCollectionHandle(direction: Handle.Direction, particle: Particle = Mocks.Particle()): Collection<T> {
+        val model = CrdtSet<T>()
+        val sp = Mocks.StorageProxy(model)
+        return Collection<T>(
+            "test",
+            sp,
+            particle,
+            direction,
+            "noname"
+        )
+    }
+
+    @Test
+    fun testAddAndRemoveElements() {
+        val handle = newCollectionHandle<Mocks.Value>(InOut)
+        handle.add(Mocks.Value("a"))
+        assertThat(handle.toSet()).containsExactlyElementsIn(Mocks.values("a"))
+        handle.add(Mocks.Value("b"))
+        assertThat(handle.toSet()).containsExactlyElementsIn(Mocks.values("a", "b"))
+        handle.remove(Mocks.Value("a"))
+        assertThat(handle.toSet()).containsExactlyElementsIn(Mocks.values("b"))
+    }
+
+    @Test
+    fun respectsCanWrite() {
+        val handle = newCollectionHandle<Mocks.Value>(In)
+        try {
+            handle.add(Mocks.Value("a"))
+            assert_().withMessage("non-writable handle should not allow add").fail()
+        } catch (e: HandleNotWriteableException) {
+            //success
+        }
+        try {
+            handle.remove(Mocks.Value("a"))
+            assert_().withMessage("non-writable handle should not allow remove").fail()
+        } catch (e: HandleNotWriteableException) {
+            //success
+        }
+        try {
+            handle.clear()
+            assert_().withMessage("non-writable handle should not allow clear").fail()
+        } catch (e: HandleNotWriteableException) {
+            //success
+        }
+    }
+
+    @Test
+    fun respectsCanRead() {
+        val handle = newCollectionHandle<Mocks.Value>(Out)
+        try {
+            handle.get("a")
+            assert_().withMessage("non-readable handle should not allow get").fail()
+        } catch (e: HandleNotReadableException) {
+            // success
+        }
+
+        try {
+            handle.toSet()
+            assert_().withMessage("non-readable handle should not allow toSet").fail()
+        } catch (e: HandleNotReadableException) {
+            // success
+        }
+    }
+
+    @Test
+    fun getElementByID() {
+        val handle = newCollectionHandle<Mocks.Value>(InOut)
+        val entityA = Mocks.Value("a", "something")
+        val entityB = Mocks.Value("b", "somethingelse")
+        handle.add(entityA)
+        handle.add(entityB)
+        assertThat(handle.get("a")).isEqualTo(entityA)
+        assertThat(handle.get("b")).isEqualTo(entityB)
+    }
+
+    @Test // support this at all?
+    fun assignIDWhenMissing() {
+    }
+
+    @Test
+    fun clearElements() {
+        val handle = newCollectionHandle<Mocks.Value>(InOut)
+        handle.add(Mocks.Value("a"))
+        handle.add(Mocks.Value("b"))
+        handle.clear()
+        assertThat(handle.toSet()).isEmpty()
+    }
+
+    @Test
+    fun addMultipleEntities() {
+        val handle = newCollectionHandle<Mocks.Value>(InOut)
+        handle.add(Mocks.Value("a"), Mocks.Value("b"))
+        assertThat(handle.toSet()).containsExactlyElementsIn(Mocks.values("a", "b"))
+        handle.add(listOf(Mocks.Value("c"), Mocks.Value("d"), Mocks.Value("e")))
+        assertThat(handle.toSet()).containsExactlyElementsIn(Mocks.values("a", "b", "c", "d", "e"))
+    }
+
+    @Test
+    fun notifySync() {
+        val particle = Mocks.Particle()
+        val handle = newCollectionHandle<Mocks.Value>(InOut, particle)
+        handle.onSync()
+        assertThat(particle.onSyncCalled).isTrue()
+    }
+
+    @Test
+    fun notifyDesync() {
+        val particle = Mocks.Particle()
+        val handle = newCollectionHandle<Mocks.Value>(InOut, particle)
+        handle.onDesync()
+        assertThat(particle.onDesyncCalled).isTrue()
+    }
+
+    @Test
+    fun notifyUpdate() {
+       // TODO
+    }
+
+    @Test
+    fun notifyFastForwardUpdate() {
+        // TODO
+    }
+
+    @Test
+    fun storesNewVersionMap() {
+       // TODO
+    }
+
+    @Test
+    fun overrideDefaultOptions() {
+        // TODO
+    }
+}
+
+class SingletonHandleTest {
+
+    fun <T : Referencable> newSingletonHandle(direction: Handle.Direction, particle: Particle = Mocks.Particle()): Singleton<T> {
+        val model: CrdtModel<CrdtSingleton.Data<T>, CrdtSingleton.IOperation<T>,T?> = CrdtSingleton()
+        val sp = Mocks.StorageProxy(model)
+
+        return Singleton(
+            "test",
+            sp,
+            particle,
+            direction,
+            "noname"
+        )
+    }
+
+    @Test
+    fun setAndClearElements() {
+        val handle = newSingletonHandle<Mocks.Value>(InOut)
+        assertThat(handle.get()).isEqualTo(null);
+        handle.set(Mocks.Value("A"))
+        assertThat(handle.get()).isEqualTo(Mocks.Value("A"))
+        handle.set(Mocks.Value("B"))
+        assertThat(handle.get()).isEqualTo(Mocks.Value("B"))
+        handle.clear()
+        assertThat(handle.get()).isEqualTo(null)
+    }
+
+    @Test
+    fun notifyParticleOnSync() {
+        val particle = Mocks.Particle()
+        val handle = newSingletonHandle<Mocks.Value>(InOut, particle)
+        handle.onSync()
+        assertThat(particle.onSyncCalled).isTrue()
+    }
+
+    @Test
+    fun notifyParticleOnDesync() {
+        val particle = Mocks.Particle()
+        val handle = newSingletonHandle<Mocks.Value>(InOut, particle)
+        handle.onDesync()
+        assertThat(particle.onDesyncCalled).isTrue()
+    }
+
+    @Test
+    // TODO
+    fun notifyParticleOfUpdates() {
+        val particle = Mocks.Particle()
+        val handle = newSingletonHandle<Mocks.Value>(InOut, particle)
+        val version = VersionMap()
+        val value = Mocks.Value("foo")
+        handle.onUpdate(Update("actor", version, value), version)
+        // TODO
+        // assertThat(particle.lastUpdate).isEqualTo(updateToExpect)
+        // assertThat(particle.lastUpdate.data).isEqualToo("foo")
+    }
+
+    @Test
+    // TODO
+    fun storeNewVersionMap() {
+        // TODO - have mock storage proxy return above version map
+        // Call get to pull in pre-specified version map
+        // Mock apply op to check that the update clock is passed in the next operation
+        // assert captured clock is equal to original clock after non-update operation(clear)
+    }
+
+    @Test
+    fun respectCanWrite() {
+        val handle = newSingletonHandle<Mocks.Value>(In)
+        try {
+            handle.set(Mocks.Value("dontdoit"))
+            assert_().withMessage("should not have set").fail()
+        } catch (e: HandleNotWriteableException) {
+            // success
+        }
+
+        try {
+            handle.clear()
+            assert_().withMessage("should not have cleared").fail()
+        } catch (e: HandleNotWriteableException) {
+            // success
+        }
+    }
+
+    @Test
+    fun respectCanRead() {
+        val handle = newSingletonHandle<Mocks.Value>(Out)
+        try {
+            handle.get()
+            assert_().withMessage("should not have gotten").fail()
+        } catch (e: HandleNotReadableException) {
+            // success
+        }
+    }
+}
+
+@RunWith(Suite::class)
+@Suite.SuiteClasses(SingletonHandleTest::class, CollectionHandleTest::class)
+class HandleTest
+


### PR DESCRIPTION
Here's the work I've done so porting the handle typescript code over to Kotlin. This is currently a work in progress; opening this PR primarily as a vehicle for my own enlightenment.


For the most part, the work thus far is only the superficial aspects of the Handle functionality:
* Respecting read/write settings for the handle
* Setters/getters for the underlying data (update/clear/get for Singleton, add/remove/clear/get/toSet for Collection)
* Delegating the correct operation to a storageproxy (mocked for now) for given operations
* Trivial forwarding of sync, desync, and update events to the associated particle. 


Open Questions:
* The typescript implementation sends a structure to particles in onUpdate indicating some details about the data update that occurred. The current Particle.kt implementation omits this, so I've left it out for now.

* There's no support for any sort of serialization right now, will there be boundaries over which we need to do some sort of serialization (or other transformation)?

* There's no automatic ID generation 

* All invocations are synchronous and direct, seems possible that might need to change?

* Options are not implemented yet. I notice that the configuration struct exists in the storageNG handle on the typescript side, but the values there don't seem to be respected, so I wanted to verify the expections around those settings before implementing them.