### PR TITLE
Ignore unexpected fields when decoding entities on the wasm side.

### DIFF
--- a/javatests/arcs/sdk/wasm/EntitySlicingTest.kt
+++ b/javatests/arcs/sdk/wasm/EntitySlicingTest.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.sdk.wasm
+
+import arcs.sdk.Handle
+
+typealias Res = EntitySlicingTest_Res
+
+class EntitySlicingTest : AbstractEntitySlicingTest() {
+    override fun onHandleSync(handle: Handle, allSynced: Boolean) {
+        if (!allSynced) return;
+
+        s1.get()?.let { res.store(Res("s1:${it.num.toInt()}")) }
+        s2.get()?.let { res.store(Res("s2:${it.num.toInt()},${it.txt}")) }
+        s3.get()?.let { res.store(Res("s3:${it.num.toInt()},${it.txt},${it.flg}")) }
+
+        for (e in c1) {
+            res.store(Res("c1:${e.num.toInt()}"))
+        }
+        for (e in c2) {
+            res.store(Res("c2:${e.num.toInt()},${e.txt}"))
+        }
+        for (e in c3) {
+            res.store(Res("c3:${e.num.toInt()},${e.txt},${e.flg}"))
+        }
+    }
+}

--- a/javatests/arcs/sdk/wasm/manifest.arcs
+++ b/javatests/arcs/sdk/wasm/manifest.arcs
@@ -166,3 +166,32 @@ recipe UnicodeTest
     sng: reads h1
     col: reads h2
     res: writes h3
+
+// -----------------------------------------------------------------------------------------------
+
+schema Slice
+  num: Number
+  flg: Boolean
+  txt: Text
+
+particle EntitySlicingTest in '$module.wasm'
+  s1: reads Slice {num}
+  s2: reads Slice {txt, num}
+  s3: reads Slice {num, flg, txt}
+  c1: reads [Slice {num}]
+  c2: reads [Slice {num, txt}]
+  c3: reads [Slice {flg, txt, num}]
+  res: writes [{val: Text}]
+
+recipe EntitySlicingTest
+  sngHandle: use *
+  colHandle: use *
+  resHandle: use *
+  EntitySlicingTest
+    s1: reads sngHandle
+    s2: reads sngHandle
+    s3: reads sngHandle
+    c1: reads colHandle
+    c2: reads colHandle
+    c3: reads colHandle
+    res: writes resHandle

--- a/src/tools/schema2cpp.ts
+++ b/src/tools/schema2cpp.ts
@@ -291,6 +291,20 @@ inline void internal::Accessor::decode_entity(${name}* entity, const char* str) 
     std::string name = decoder.upTo(':');
     if (0) {
     ${this.decode.join('\n    ')}
+    } else {
+      // Ignore unknown fields until type slicing is fully implemented.
+      std::string typeChar = decoder.chomp(1);
+      if (typeChar == "T" || typeChar == "U") {
+        std::string s;
+        decoder.decode(s);
+      } else if (typeChar == "N") {
+        double d;
+        decoder.decode(d);
+      } else if (typeChar == "B") {
+        bool b;
+        decoder.decode(b);
+      }
+      i--;
     }
     decoder.validate("|");
   }

--- a/src/tools/tests/goldens/generated-schemas.h
+++ b/src/tools/tests/goldens/generated-schemas.h
@@ -110,6 +110,20 @@ inline void internal::Accessor::decode_entity(GoldInternal1* entity, const char*
       decoder.validate("T");
       decoder.decode(entity->val_);
       entity->val_valid_ = true;
+    } else {
+      // Ignore unknown fields until type slicing is fully implemented.
+      std::string typeChar = decoder.chomp(1);
+      if (typeChar == "T" || typeChar == "U") {
+        std::string s;
+        decoder.decode(s);
+      } else if (typeChar == "N") {
+        double d;
+        decoder.decode(d);
+      } else if (typeChar == "B") {
+        bool b;
+        decoder.decode(b);
+      }
+      i--;
     }
     decoder.validate("|");
   }
@@ -313,6 +327,20 @@ inline void internal::Accessor::decode_entity(Gold_Data* entity, const char* str
       decoder.validate("R");
       decoder.decode(entity->ref_);
       entity->ref_valid_ = true;
+    } else {
+      // Ignore unknown fields until type slicing is fully implemented.
+      std::string typeChar = decoder.chomp(1);
+      if (typeChar == "T" || typeChar == "U") {
+        std::string s;
+        decoder.decode(s);
+      } else if (typeChar == "N") {
+        double d;
+        decoder.decode(d);
+      } else if (typeChar == "B") {
+        bool b;
+        decoder.decode(b);
+      }
+      i--;
     }
     decoder.validate("|");
   }

--- a/src/tools/tests/goldens/generated-schemas.kt
+++ b/src/tools/tests/goldens/generated-schemas.kt
@@ -59,16 +59,26 @@ class GoldInternal1_Spec() : EntitySpec<GoldInternal1> {
         return create().apply {
             internalId = decoder.decodeText()
             decoder.validate("|")
-            for (_i in 0 until 1) {
-                if (decoder.done()) break
+            var i = 0
+            while (i < 1 && !decoder.done()) {
                 val name = decoder.upTo(':').utf8ToString()
                 when (name) {
                     "val" -> {
                         decoder.validate("T")
                         this.val_ = decoder.decodeText()
                     }
+                    else -> {
+                        // Ignore unknown fields until type slicing is fully implemented.
+                        when (decoder.chomp(1).utf8ToString()) {
+                            "T", "U" -> decoder.decodeText()
+                            "N" -> decoder.decodeNum()
+                            "B" -> decoder.decodeBool()
+                        }
+                        i--
+                    }
                 }
                 decoder.validate("|")
+                i++
             }
         }
     }
@@ -170,8 +180,8 @@ class Gold_Data_Spec() : EntitySpec<Gold_Data> {
         return create().apply {
             internalId = decoder.decodeText()
             decoder.validate("|")
-            for (_i in 0 until 5) {
-                if (decoder.done()) break
+            var i = 0
+            while (i < 5 && !decoder.done()) {
                 val name = decoder.upTo(':').utf8ToString()
                 when (name) {
                     "num" -> {
@@ -190,8 +200,18 @@ class Gold_Data_Spec() : EntitySpec<Gold_Data> {
                         decoder.validate("B")
                         this.flg = decoder.decodeBool()
                     }
+                    else -> {
+                        // Ignore unknown fields until type slicing is fully implemented.
+                        when (decoder.chomp(1).utf8ToString()) {
+                            "T", "U" -> decoder.decodeText()
+                            "N" -> decoder.decodeNum()
+                            "B" -> decoder.decodeBool()
+                        }
+                        i--
+                    }
                 }
                 decoder.validate("|")
+                i++
             }
         }
     }

--- a/src/wasm/cpp/tests/particle-api-test.cc
+++ b/src/wasm/cpp/tests/particle-api-test.cc
@@ -120,3 +120,48 @@ public:
 };
 
 DEFINE_PARTICLE(UnicodeTest)
+
+
+class EntitySlicingTest : public AbstractEntitySlicingTest {
+public:
+  void onHandleSync(const std::string& name, bool all_synced) override {
+    if (!all_synced) return;
+
+    store1("s1:", s1_.get());
+    store2("s2:", s2_.get());
+    store3("s3:", s3_.get());
+
+    for (const auto& e : c1_) {
+      store1("c1:", e);
+    }
+    for (const auto& e : c2_) {
+      store2("c2:", e);
+    }
+    for (const auto& e : c3_) {
+      store3("c3:", e);
+    }
+  }
+
+  template<typename T>
+  void store1(const std::string& s, const T& e) {
+    arcs::EntitySlicingTest_Res out;
+    out.set_val(s + arcs::num_to_str(e.num()));
+    res_.store(out);
+  }
+
+  template<typename T>
+  void store2(const std::string& s, const T& e) {
+    arcs::EntitySlicingTest_Res out;
+    out.set_val(s + arcs::num_to_str(e.num()) + "," + e.txt());
+    res_.store(out);
+  }
+
+  template<typename T>
+  void store3(const std::string& s, const T& e) {
+    arcs::EntitySlicingTest_Res out;
+    out.set_val(s + arcs::num_to_str(e.num()) + "," + e.txt() + "," + (e.flg() ? "true" : "false"));
+    res_.store(out);
+  }
+};
+
+DEFINE_PARTICLE(EntitySlicingTest)

--- a/src/wasm/tests/manifest.arcs
+++ b/src/wasm/tests/manifest.arcs
@@ -166,3 +166,32 @@ recipe UnicodeTest
     sng: reads h1
     col: reads h2
     res: writes h3
+
+// -----------------------------------------------------------------------------------------------
+
+schema Slice
+  num: Number
+  flg: Boolean
+  txt: Text
+
+particle EntitySlicingTest in '$module.wasm'
+  s1: reads Slice {num}
+  s2: reads Slice {txt, num}
+  s3: reads Slice {num, flg, txt}
+  c1: reads [Slice {num}]
+  c2: reads [Slice {num, txt}]
+  c3: reads [Slice {flg, txt, num}]
+  res: writes [{val: Text}]
+
+recipe EntitySlicingTest
+  sngHandle: use *
+  colHandle: use *
+  resHandle: use *
+  EntitySlicingTest
+    s1: reads sngHandle
+    s2: reads sngHandle
+    s3: reads sngHandle
+    c1: reads colHandle
+    c2: reads colHandle
+    c3: reads colHandle
+    res: writes resHandle


### PR DESCRIPTION
This allows type slicing from schema aliases to work in wasm particles.