### PR TITLE
Updated troubleshooting doc for Unresolved References

### DIFF
--- a/docs/IDE-Setup.md
+++ b/docs/IDE-Setup.md
@@ -92,6 +92,12 @@ Consider using the [IDE file chooser](https://intellij-support.jetbrains.com/hc/
 #### IDE shows `Unresolved Reference` for generated entities
 
 - Ensure that your Kotlin plugin is at version 1.3.61 or higher: Preferences > Plugins > Installed > Kotlin 
+- Ensure that your IDE is at an recent enough version
+| IDE            | Version |
+| -------------- | ------- |
+| Android Studio | 3.6+    |
+| IntelliJ       | TBD     | 
+- Ensure that Bazel is version 1.2 (2.0 will cause problems)
 - Try Invalidating Caches: File > Invalidate Caches > Invalidate and Restart
 - Try [this workaround](https://github.com/bazelbuild/intellij/issues/490#issuecomment-454030118) (1 should be sufficient).
 

--- a/docs/IDE-Setup.md
+++ b/docs/IDE-Setup.md
@@ -91,9 +91,9 @@ Consider using the [IDE file chooser](https://intellij-support.jetbrains.com/hc/
 
 #### IDE shows `Unresolved Reference` for generated entities
 
+- Ensure that your Kotlin plugin is at version 1.3.61 or higher: Preferences > Plugins > Installed > Kotlin 
 - Try Invalidating Caches: File > Invalidate Caches > Invalidate and Restart
 - Try [this workaround](https://github.com/bazelbuild/intellij/issues/490#issuecomment-454030118) (1 should be sufficient).
-- Ensure that your Kotlin plugin is at version 1.3.61 or higher: Preferences > Plugins > Installed > Kotlin 
 
 ## References
 

--- a/docs/IDE-Setup.md
+++ b/docs/IDE-Setup.md
@@ -93,6 +93,7 @@ Consider using the [IDE file chooser](https://intellij-support.jetbrains.com/hc/
 
 - Try Invalidating Caches: File > Invalidate Caches > Invalidate and Restart
 - Try [this workaround](https://github.com/bazelbuild/intellij/issues/490#issuecomment-454030118) (1 should be sufficient).
+- Ensure that your Kotlin plugin is at version 1.3.61 or higher: Preferences > Plugins > Installed > Kotlin 
 
 ## References
 


### PR DESCRIPTION
## Summary
- Reproduced Unresolved Reference issue on my machine. 
- Upgraded the JetBrains Kotlin plugin to the version documented here
- Unresolved Reference issue was addressed, and was able to jump to definition of generated code (decompiled bytecode). 