### PR TITLE
Update most of the wasm API tests to use a better storage pattern

### DIFF
--- a/javatests/arcs/sdk/wasm/CollectionApiTest.kt
+++ b/javatests/arcs/sdk/wasm/CollectionApiTest.kt
@@ -33,7 +33,7 @@ class CollectionApiTest : AbstractCollectionApiTest() {
                 val iter = inHandle.iterator()
                 d1.flg = iter.hasNext()
                 val i1 = iter.next()
-                d1.txt = "{${i1.internalId}}, num: ${i1.num.toInt()}"
+                d1.txt = "num: ${i1.num.toInt()}"
                 d1.num = i1.num.let { it * 2 }
                 outHandle.store(d1)
 
@@ -67,14 +67,11 @@ class CollectionApiTest : AbstractCollectionApiTest() {
                 outHandle.store(d2)
 
                 // Ranged iteration; order is not guaranteed so use 'num' to assign sorted array slots.
-                val sorted = arrayOfNulls<CollectionApiTest_IoHandle>(3)
-                for (data in ioHandle) {
-                    sorted[data.num.toInt()] = data
-                }
-                sorted.iterator().forEach {
+                val sorted = ioHandle.sortedBy { it.num.toInt() }
+                sorted.forEach {
                     outHandle.store(CollectionApiTest_OutHandle(
-                        num = it!!.num,
-                        txt = it.internalId,
+                        num = it.num,
+                        txt = it.txt,
                         flg = false
                     ))
                 }

--- a/javatests/arcs/sdk/wasm/manifest.arcs
+++ b/javatests/arcs/sdk/wasm/manifest.arcs
@@ -1,7 +1,7 @@
 particle HandleSyncUpdateTest in '$module.wasm'
-  sng: reads * {num: Number, txt: Text, lnk: URL, flg: Boolean, ref: &Foo {val: Text}}
-  col: reads [* {num: Number, txt: Text, lnk: URL, flg: Boolean, ref: &Foo {val: Text}}]
-  res: writes [* {txt: Text, num: Number}]
+  sng: reads {num: Number, txt: Text, lnk: URL, flg: Boolean, ref: &Foo {val: Text}}
+  col: reads [{num: Number, txt: Text, lnk: URL, flg: Boolean, ref: &Foo {val: Text}}]
+  res: writes [{txt: Text, num: Number}]
 
 recipe HandleSyncUpdateTest
   HandleSyncUpdateTest
@@ -13,7 +13,7 @@ recipe HandleSyncUpdateTest
 
 particle RenderTest in '$module.wasm'
   root: consumes Slot
-  flags: reads * {template: Boolean, model: Boolean}
+  flags: reads {template: Boolean, model: Boolean}
 
 recipe RenderTest
   s1: slot 'rootslotid-root'
@@ -26,11 +26,11 @@ recipe RenderTest
 resource DataResource
   start
   [{"txt": "initial"}]
-store DataStore of * {txt: Text} in DataResource
+store DataStore of {txt: Text} in DataResource
 
 particle AutoRenderTest in '$module.wasm'
   root: consumes Slot
-  data: reads * {txt: Text}
+  data: reads {txt: Text}
 
 recipe AutoRenderTest
   h1: copy DataStore
@@ -43,7 +43,7 @@ recipe AutoRenderTest
 
 particle EventsTest in '$module.wasm'
   root: consumes Slot
-  output: writes * {txt: Text}
+  output: writes {txt: Text}
 
 recipe EventsTest
   s1: slot 'rootslotid-root'
@@ -54,7 +54,7 @@ recipe EventsTest
 // -----------------------------------------------------------------------------------------------
 
 particle ServicesTest in '$module.wasm'
-  output: writes [* {call: Text, tag: Text, payload: Text}]
+  output: writes [{call: Text, tag: Text, payload: Text}]
 
 recipe ServicesTest
   ServicesTest
@@ -63,9 +63,9 @@ recipe ServicesTest
 // -----------------------------------------------------------------------------------------------
 
 particle EntityClassApiTest in '$module.wasm'
-  data: reads * {num: Number, txt: Text, lnk: URL, flg: Boolean, ref: &Foo {val: Text}}
-  empty: reads * {}
-  errors: writes [* {msg: Text}]
+  data: reads {num: Number, txt: Text, lnk: URL, flg: Boolean, ref: &Foo {val: Text}}
+  empty: reads {}
+  errors: writes [{msg: Text}]
 
 recipe EntityClassApiTest
   EntityClassApiTest
@@ -77,8 +77,8 @@ recipe EntityClassApiTest
 
 particle SpecialSchemaFieldsTest in '$module.wasm'
   // 'internal_id' is for C++; 'internalId' is for Kotlin
-  fields: reads * {for: Text, internal_id: Number, internalId: Number}
-  errors: writes [* {msg: Text}]
+  fields: reads {for: Text, internal_id: Number, internalId: Number}
+  errors: writes [{msg: Text}]
 
 recipe SpecialSchemaFieldsTest
   SpecialSchemaFieldsTest
@@ -88,8 +88,8 @@ recipe SpecialSchemaFieldsTest
 // -----------------------------------------------------------------------------------------------
 
 particle ReferenceClassApiTest in '$module.wasm'
-  data: reads * {num: Number, txt: Text}
-  errors: writes [* {msg: Text}]
+  data: reads {num: Number, txt: Text}
+  errors: writes [{msg: Text}]
 
 recipe ReferenceClassApiTest
   ReferenceClassApiTest
@@ -100,9 +100,9 @@ recipe ReferenceClassApiTest
 
 particle SingletonApiTest in '$module.wasm'
   root: consumes Slot
-  inHandle: reads * {num: Number, txt: Text}
-  outHandle: writes * {num: Number, txt: Text}
-  ioHandle: reads writes * {num: Number, txt: Text}
+  inHandle: reads {num: Number, txt: Text}
+  outHandle: writes {num: Number, txt: Text}
+  ioHandle: reads writes {num: Number, txt: Text}
 
 recipe SingletonApiTest
   s1: slot 'rootslotid-root'
@@ -116,9 +116,9 @@ recipe SingletonApiTest
 
 particle CollectionApiTest in '$module.wasm'
   root: consumes Slot
-  inHandle: reads [* {num: Number}]
-  outHandle: writes [* {num: Number, txt: Text, flg: Boolean}]
-  ioHandle: reads writes [* {num: Number, txt: Text, flg: Boolean}]
+  inHandle: reads [{num: Number}]
+  outHandle: writes [{num: Number, txt: Text, flg: Boolean}]
+  ioHandle: reads writes [{num: Number, txt: Text, flg: Boolean}]
 
 recipe CollectionApiTest
   s1: slot 'rootslotid-root'
@@ -131,9 +131,9 @@ recipe CollectionApiTest
 // -----------------------------------------------------------------------------------------------
 
 particle ReferenceHandlesTest in '$module.wasm'
-  sng: reads writes &* {num: Number, txt: Text}
-  col: reads writes [&* {num: Number, txt: Text}]
-  res: writes [* {txt: Text}]
+  sng: reads writes &{num: Number, txt: Text}
+  col: reads writes [&{num: Number, txt: Text}]
+  res: writes [{txt: Text}]
 
 recipe ReferenceHandlesTest
   ReferenceHandlesTest
@@ -144,9 +144,9 @@ recipe ReferenceHandlesTest
 // -----------------------------------------------------------------------------------------------
 
 particle SchemaReferenceFieldsTest in '$module.wasm'
-  input: reads * {num: Number, txt: Text, ref: &* {val: Text}}
-  output: writes * {num: Number, txt: Text, ref: &* {val: Text}}
-  res: writes [* {txt: Text}]
+  input: reads {num: Number, txt: Text, ref: &{val: Text}}
+  output: writes {num: Number, txt: Text, ref: &{val: Text}}
+  res: writes [{txt: Text}]
 
 recipe SchemaReferenceFieldsTest
   SchemaReferenceFieldsTest
@@ -157,9 +157,9 @@ recipe SchemaReferenceFieldsTest
 // -----------------------------------------------------------------------------------------------
 
 particle UnicodeTest in '$module.wasm'
-  sng: reads * {pass: Text, src: Text}
-  col: reads [* {pass: Text, src: Text}]
-  res: writes [* {pass: Text, src: Text}]
+  sng: reads {pass: Text, src: Text}
+  col: reads [{pass: Text, src: Text}]
+  res: writes [{pass: Text, src: Text}]
 
 recipe UnicodeTest
   UnicodeTest

--- a/src/runtime/storage/volatile-storage.ts
+++ b/src/runtime/storage/volatile-storage.ts
@@ -366,6 +366,10 @@ export class VolatileCollection extends VolatileStorageProvider implements Colle
     }
   }
 
+  async clear() {
+    this._model = new CrdtCollectionModel();
+  }
+
   clearItemsForTesting() {
     this._model = new CrdtCollectionModel();
   }

--- a/src/tools/schema2cpp.ts
+++ b/src/tools/schema2cpp.ts
@@ -274,9 +274,11 @@ inline bool ${name}::operator==(const ${name}& other) const {
 }
 
 template<>
-inline std::string internal::Accessor::entity_to_str(const ${name}& entity, const char* join) {
+inline std::string internal::Accessor::entity_to_str(const ${name}& entity, const char* join, bool with_id) {
   internal::StringPrinter printer;
-  printer.addId(entity._internal_id_);
+  if (with_id) {
+    printer.addId(entity._internal_id_);
+  }
   ${this.stringify.join('\n  ')}
   return printer.result(join);
 }

--- a/src/tools/tests/goldens/generated-schemas.h
+++ b/src/tools/tests/goldens/generated-schemas.h
@@ -90,9 +90,11 @@ inline bool GoldInternal1::operator==(const GoldInternal1& other) const {
 }
 
 template<>
-inline std::string internal::Accessor::entity_to_str(const GoldInternal1& entity, const char* join) {
+inline std::string internal::Accessor::entity_to_str(const GoldInternal1& entity, const char* join, bool with_id) {
   internal::StringPrinter printer;
-  printer.addId(entity._internal_id_);
+  if (with_id) {
+    printer.addId(entity._internal_id_);
+  }
   if (entity.val_valid_) printer.add("val: ", entity.val_);
   return printer.result(join);
 }
@@ -287,9 +289,11 @@ inline bool Gold_Data::operator==(const Gold_Data& other) const {
 }
 
 template<>
-inline std::string internal::Accessor::entity_to_str(const Gold_Data& entity, const char* join) {
+inline std::string internal::Accessor::entity_to_str(const Gold_Data& entity, const char* join, bool with_id) {
   internal::StringPrinter printer;
-  printer.addId(entity._internal_id_);
+  if (with_id) {
+    printer.addId(entity._internal_id_);
+  }
   if (entity.num_valid_) printer.add("num: ", entity.num_);
   if (entity.txt_valid_) printer.add("txt: ", entity.txt_);
   if (entity.lnk_valid_) printer.add("lnk: ", entity.lnk_);

--- a/src/wasm/cpp/arcs.h
+++ b/src/wasm/cpp/arcs.h
@@ -153,7 +153,7 @@ public:
   }
 
   template<typename T>
-  static std::string entity_to_str(const T& entity, const char* join) {
+  static std::string entity_to_str(const T& entity, const char* join, bool with_id) {
     static_assert(sizeof(T) == 0, "Only schema-specific implementations of entity_to_str can be used");
     return "";
   }
@@ -174,7 +174,7 @@ public:
   // Ref-based versions of the above; implemented below the Ref class definition.
   // clone_entity and fields_equal are not available for references.
   template<typename T> static size_t hash_entity(const Ref<T>& ref);
-  template<typename T> static std::string entity_to_str(const Ref<T>& ref, const char* join);
+  template<typename T> static std::string entity_to_str(const Ref<T>& ref, const char* join, bool with_id);
   template<typename T> static void decode_entity(Ref<T>* ref, const char* str);
   template<typename T> static std::string encode_entity(const Ref<T>& ref);
 
@@ -241,8 +241,8 @@ bool fields_equal(const T& a, const T& b) {
 
 // Converts an entity to a string. Unset fields are omitted.
 template<typename T>
-std::string entity_to_str(const T& entity, const char* join = ", ") {
-  return internal::Accessor::entity_to_str(entity, join);
+std::string entity_to_str(const T& entity, const char* join = ", ", bool with_id = true) {
+  return internal::Accessor::entity_to_str(entity, join, with_id);
 }
 
 // Strips trailing zeros, and the decimal point for integer values.
@@ -571,7 +571,7 @@ inline size_t Accessor::hash_entity(const Ref<T>& ref) {
 }
 
 template<typename T>
-inline std::string Accessor::entity_to_str(const Ref<T>& ref, const char* unused) {
+inline std::string Accessor::entity_to_str(const Ref<T>& ref, const char* unused, bool with_id) {
   StringPrinter printer;
   printer.add("REF<");
   printer.add("", ref._internal_id_);
@@ -579,7 +579,7 @@ inline std::string Accessor::entity_to_str(const Ref<T>& ref, const char* unused
     printer.add("|", ref.storage_key_);
   }
   if (ref.is_dereferenced()) {
-    printer.add("|[", entity_to_str(ref.entity(), ", "));
+    printer.add("|[", entity_to_str(ref.entity(), ", ", with_id));
     printer.add("]");
   }
   printer.add(">");

--- a/src/wasm/cpp/tests/storage-api-test.cc
+++ b/src/wasm/cpp/tests/storage-api-test.cc
@@ -42,18 +42,18 @@ public:
 
       // Test begin()/end() and WrappedIter operators
       auto i1 = inHandle_.begin();
-      d1.set_txt(arcs::entity_to_str(*i1));  // op*
-      d1.set_num(i1->num() * 2);             // op->
-      d1.set_flg(i1 != inHandle_.end());           // op!=
+      d1.set_txt(arcs::entity_to_str(*i1, "", false));  // op*
+      d1.set_num(i1->num() * 2);                        // op->
+      d1.set_flg(i1 != inHandle_.end());                // op!=
       outHandle_.store(d1);
 
       auto i2 = inHandle_.begin();
-      d2.set_txt((i2 == i1) ? "eq" : "ne");  // op==
-      d2.set_flg(i1++ == inHandle_.end());         // postfix op++
+      d2.set_txt((i2 == i1) ? "eq" : "ne");             // op==
+      d2.set_flg(i1++ == inHandle_.end());              // postfix op++
       outHandle_.store(d2);
 
       d3.set_txt((i2 != i1) ? "ne" : "eq");
-      d3.set_flg(++i2 == inHandle_.end());         // prefix op++
+      d3.set_flg(++i2 == inHandle_.end());              // prefix op++
       outHandle_.store(d3);
     } else if (handler == "case5") {
       arcs::CollectionApiTest_OutHandle d1, d2, d3;
@@ -78,7 +78,7 @@ public:
       for (size_t i = 0; i < 3; i++) {
         arcs::CollectionApiTest_OutHandle d;
         d.set_num(i);
-        d.set_txt(Accessor::get_id(*sorted[i]));
+        d.set_txt(sorted[i]->txt());
         outHandle_.store(d);
       }
 

--- a/src/wasm/tests/manifest.arcs
+++ b/src/wasm/tests/manifest.arcs
@@ -1,7 +1,7 @@
 particle HandleSyncUpdateTest in '$module.wasm'
-  sng: reads * {num: Number, txt: Text, lnk: URL, flg: Boolean, ref: &Foo {val: Text}}
-  col: reads [* {num: Number, txt: Text, lnk: URL, flg: Boolean, ref: &Foo {val: Text}}]
-  res: writes [* {txt: Text, num: Number}]
+  sng: reads {num: Number, txt: Text, lnk: URL, flg: Boolean, ref: &Foo {val: Text}}
+  col: reads [{num: Number, txt: Text, lnk: URL, flg: Boolean, ref: &Foo {val: Text}}]
+  res: writes [{txt: Text, num: Number}]
 
 recipe HandleSyncUpdateTest
   HandleSyncUpdateTest
@@ -13,7 +13,7 @@ recipe HandleSyncUpdateTest
 
 particle RenderTest in '$module.wasm'
   root: consumes Slot
-  flags: reads * {template: Boolean, model: Boolean}
+  flags: reads {template: Boolean, model: Boolean}
 
 recipe RenderTest
   s1: slot 'rootslotid-root'
@@ -26,11 +26,11 @@ recipe RenderTest
 resource DataResource
   start
   [{"txt": "initial"}]
-store DataStore of * {txt: Text} in DataResource
+store DataStore of {txt: Text} in DataResource
 
 particle AutoRenderTest in '$module.wasm'
   root: consumes Slot
-  data: reads * {txt: Text}
+  data: reads {txt: Text}
 
 recipe AutoRenderTest
   h1: copy DataStore
@@ -43,7 +43,7 @@ recipe AutoRenderTest
 
 particle EventsTest in '$module.wasm'
   root: consumes Slot
-  output: writes * {txt: Text}
+  output: writes {txt: Text}
 
 recipe EventsTest
   s1: slot 'rootslotid-root'
@@ -54,7 +54,7 @@ recipe EventsTest
 // -----------------------------------------------------------------------------------------------
 
 particle ServicesTest in '$module.wasm'
-  output: writes [* {call: Text, tag: Text, payload: Text}]
+  output: writes [{call: Text, tag: Text, payload: Text}]
 
 recipe ServicesTest
   ServicesTest
@@ -63,9 +63,9 @@ recipe ServicesTest
 // -----------------------------------------------------------------------------------------------
 
 particle EntityClassApiTest in '$module.wasm'
-  data: reads * {num: Number, txt: Text, lnk: URL, flg: Boolean, ref: &Foo {val: Text}}
-  empty: reads * {}
-  errors: writes [* {msg: Text}]
+  data: reads {num: Number, txt: Text, lnk: URL, flg: Boolean, ref: &Foo {val: Text}}
+  empty: reads {}
+  errors: writes [{msg: Text}]
 
 recipe EntityClassApiTest
   EntityClassApiTest
@@ -77,8 +77,8 @@ recipe EntityClassApiTest
 
 particle SpecialSchemaFieldsTest in '$module.wasm'
   // 'internal_id' is for C++; 'internalId' is for Kotlin
-  fields: reads * {for: Text, internal_id: Number, internalId: Number}
-  errors: writes [* {msg: Text}]
+  fields: reads {for: Text, internal_id: Number, internalId: Number}
+  errors: writes [{msg: Text}]
 
 recipe SpecialSchemaFieldsTest
   SpecialSchemaFieldsTest
@@ -88,8 +88,8 @@ recipe SpecialSchemaFieldsTest
 // -----------------------------------------------------------------------------------------------
 
 particle ReferenceClassApiTest in '$module.wasm'
-  data: reads * {num: Number, txt: Text}
-  errors: writes [* {msg: Text}]
+  data: reads {num: Number, txt: Text}
+  errors: writes [{msg: Text}]
 
 recipe ReferenceClassApiTest
   ReferenceClassApiTest
@@ -100,9 +100,9 @@ recipe ReferenceClassApiTest
 
 particle SingletonApiTest in '$module.wasm'
   root: consumes Slot
-  inHandle: reads * {num: Number, txt: Text}
-  outHandle: writes * {num: Number, txt: Text}
-  ioHandle: reads writes * {num: Number, txt: Text}
+  inHandle: reads {num: Number, txt: Text}
+  outHandle: writes {num: Number, txt: Text}
+  ioHandle: reads writes {num: Number, txt: Text}
 
 recipe SingletonApiTest
   s1: slot 'rootslotid-root'
@@ -116,9 +116,9 @@ recipe SingletonApiTest
 
 particle CollectionApiTest in '$module.wasm'
   root: consumes Slot
-  inHandle: reads [* {num: Number}]
-  outHandle: writes [* {num: Number, txt: Text, flg: Boolean}]
-  ioHandle: reads writes [* {num: Number, txt: Text, flg: Boolean}]
+  inHandle: reads [{num: Number}]
+  outHandle: writes [{num: Number, txt: Text, flg: Boolean}]
+  ioHandle: reads writes [{num: Number, txt: Text, flg: Boolean}]
 
 recipe CollectionApiTest
   s1: slot 'rootslotid-root'
@@ -131,9 +131,9 @@ recipe CollectionApiTest
 // -----------------------------------------------------------------------------------------------
 
 particle ReferenceHandlesTest in '$module.wasm'
-  sng: reads writes &* {num: Number, txt: Text}
-  col: reads writes [&* {num: Number, txt: Text}]
-  res: writes [* {txt: Text}]
+  sng: reads writes &{num: Number, txt: Text}
+  col: reads writes [&{num: Number, txt: Text}]
+  res: writes [{txt: Text}]
 
 recipe ReferenceHandlesTest
   ReferenceHandlesTest
@@ -144,9 +144,9 @@ recipe ReferenceHandlesTest
 // -----------------------------------------------------------------------------------------------
 
 particle SchemaReferenceFieldsTest in '$module.wasm'
-  input: reads * {num: Number, txt: Text, ref: &* {val: Text}}
-  output: writes * {num: Number, txt: Text, ref: &* {val: Text}}
-  res: writes [* {txt: Text}]
+  input: reads {num: Number, txt: Text, ref: &{val: Text}}
+  output: writes {num: Number, txt: Text, ref: &{val: Text}}
+  res: writes [{txt: Text}]
 
 recipe SchemaReferenceFieldsTest
   SchemaReferenceFieldsTest
@@ -157,9 +157,9 @@ recipe SchemaReferenceFieldsTest
 // -----------------------------------------------------------------------------------------------
 
 particle UnicodeTest in '$module.wasm'
-  sng: reads * {pass: Text, src: Text}
-  col: reads [* {pass: Text, src: Text}]
-  res: writes [* {pass: Text, src: Text}]
+  sng: reads {pass: Text, src: Text}
+  col: reads [{pass: Text, src: Text}]
+  res: writes [{pass: Text, src: Text}]
 
 recipe UnicodeTest
   UnicodeTest


### PR DESCRIPTION
That is, use *HandleForTest around stores and create entities with handle.entityClass. The reference tests still use the old style; wasn't sure how to wrap the backing stores correctly.