### PR TITLE
Move StringEncoder and StringDecoder into the wasm package

### DIFF
--- a/java/arcs/sdk/BUILD
+++ b/java/arcs/sdk/BUILD
@@ -35,5 +35,5 @@ arcs_kt_jvm_library(
         "jvm/JvmUtils.kt",
     ],
     kotlincopts = KOTLINC_OPTS + ["-Xallow-kotlin-package"],
-    visibility = ["//javatests/arcs/sdk/wasm:__pkg__"],
+    visibility = ["//visibility:public"],
 )

--- a/java/arcs/sdk/BUILD
+++ b/java/arcs/sdk/BUILD
@@ -25,3 +25,15 @@ kt_native_library(
     kotlincopts = KOTLINC_OPTS + ["-Xinline-classes"],
     visibility = ["//visibility:public"],
 )
+
+# Special package containing wasm srcs for unit testing (on the JVM).
+arcs_kt_jvm_library(
+    name = "arcs-wasm-testing",
+    testonly = 1,
+    srcs = glob(["*.kt"]) + [
+        "wasm/Encoding.kt",
+        "jvm/JvmUtils.kt",
+    ],
+    kotlincopts = KOTLINC_OPTS + ["-Xallow-kotlin-package"],
+    visibility = ["//javatests/arcs/sdk/wasm:__pkg__"],
+)

--- a/java/arcs/sdk/wasm/Encoding.kt
+++ b/java/arcs/sdk/wasm/Encoding.kt
@@ -9,11 +9,9 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-package arcs.sdk
+package arcs.sdk.wasm
 
-// These classes are wasm-only, but need JVM implementations of toUtf8String/toUtf8ByteArray in
-// order for their tests to run on the JVM.
-// TODO: move as much code as possible into the wasm package.
+import arcs.sdk.Utils
 
 /** Converts a [ByteArray] into a [String]. */
 fun ByteArray.toUtf8String(): String = Utils.toUtf8String(this)

--- a/java/arcs/sdk/wasm/WasmCollection.kt
+++ b/java/arcs/sdk/wasm/WasmCollection.kt
@@ -12,7 +12,6 @@
 package arcs.sdk.wasm
 
 import arcs.sdk.ReadWriteCollection
-import arcs.sdk.StringDecoder
 
 /** [ReadWriteCollection] implementation for WASM. */
 class WasmCollection<T : WasmEntity>(

--- a/java/arcs/sdk/wasm/WasmEntity.kt
+++ b/java/arcs/sdk/wasm/WasmEntity.kt
@@ -13,7 +13,6 @@ package arcs.sdk.wasm
 
 import arcs.sdk.Entity
 import arcs.sdk.EntitySpec
-import arcs.sdk.NullTermByteArray
 
 /** Wasm-specific extensions to the base [Entity] interface. */
 interface WasmEntity : Entity {

--- a/java/arcs/sdk/wasm/WasmJsInterop.kt
+++ b/java/arcs/sdk/wasm/WasmJsInterop.kt
@@ -11,7 +11,6 @@
 
 package arcs.sdk.wasm
 
-import arcs.sdk.StringDecoder
 import kotlin.native.Retain
 import kotlin.native.internal.ExportForCppRuntime
 import kotlinx.cinterop.ByteVar

--- a/java/arcs/sdk/wasm/WasmParticle.kt
+++ b/java/arcs/sdk/wasm/WasmParticle.kt
@@ -13,7 +13,6 @@ package arcs.sdk.wasm
 
 import arcs.sdk.Handle
 import arcs.sdk.Particle
-import arcs.sdk.StringEncoder
 
 /**
  * Base class for all wasm particles.

--- a/java/arcs/sdk/wasm/WasmRuntimeClient.kt
+++ b/java/arcs/sdk/wasm/WasmRuntimeClient.kt
@@ -11,8 +11,6 @@
 
 package arcs.sdk.wasm
 
-import arcs.sdk.NullTermByteArray
-
 object WasmRuntimeClient {
     fun <T : WasmEntity> singletonClear(particle: WasmParticle, singleton: WasmSingleton<T>) =
         singletonClear(particle.toAddress(), singleton.toAddress())

--- a/javatests/arcs/sdk/wasm/BUILD
+++ b/javatests/arcs/sdk/wasm/BUILD
@@ -1,11 +1,27 @@
 load(
     "//third_party/java/arcs/build_defs:build_defs.bzl",
+    "arcs_kt_jvm_test_suite",
     "arcs_kt_library",
     "arcs_kt_particles",
     "arcs_kt_schema",
 )
 
 licenses(["notice"])
+
+WASM_UNIT_TEST_SRCS = [
+    "StringDecoderTest.kt",
+    "StringEncoderTest.kt",
+]
+
+PARTICLE_TEST_BASE_SRCS = [
+    "Test.kt",
+    "TestBase.kt",
+]
+
+PARTICLE_TEST_SRCS = glob(
+    ["*.kt"],
+    exclude = PARTICLE_TEST_BASE_SRCS + WASM_UNIT_TEST_SRCS,
+)
 
 arcs_kt_schema(
     name = "schemas",
@@ -15,13 +31,7 @@ arcs_kt_schema(
 
 arcs_kt_particles(
     name = "test-module",
-    srcs = glob(
-        ["*.kt"],
-        exclude = [
-            "TestBase.kt",
-            "Test.kt",
-        ],
-    ),
+    srcs = PARTICLE_TEST_SRCS,
     jvm = False,
     package = "arcs.sdk.wasm",
     visibility = ["//visibility:public"],
@@ -33,13 +43,21 @@ arcs_kt_particles(
 
 arcs_kt_library(
     name = "TestBase",
-    srcs = [
-        "Test.kt",
-        "TestBase.kt",
-    ],
+    srcs = PARTICLE_TEST_BASE_SRCS,
     jvm = False,
     deps = [
         ":schemas",
         "//java/arcs/sdk:arcs",
+    ],
+)
+
+arcs_kt_jvm_test_suite(
+    name = "WasmUnitTests",
+    srcs = WASM_UNIT_TEST_SRCS,
+    package = "arcs.sdk.wasm",
+    deps = [
+        "//java/arcs/sdk:arcs-wasm-testing",
+        "//third_party/java/junit:junit-android",
+        "//third_party/java/truth:truth-android",
     ],
 )

--- a/javatests/arcs/sdk/wasm/SpecialSchemaFieldsTest.kt
+++ b/javatests/arcs/sdk/wasm/SpecialSchemaFieldsTest.kt
@@ -11,8 +11,6 @@
 
 package arcs.sdk.wasm
 
-import arcs.sdk.toUtf8String
-
 class SpecialSchemaFieldsTest : TestBase<SpecialSchemaFieldsTest_Errors>(
     ::SpecialSchemaFieldsTest_Errors,
     SpecialSchemaFieldsTest_Errors_Spec()

--- a/javatests/arcs/sdk/wasm/StringDecoderTest.kt
+++ b/javatests/arcs/sdk/wasm/StringDecoderTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC.
+ * Copyright 2020 Google LLC.
  *
  * This code may only be used under the BSD style license found at
  * http://polymer.github.io/LICENSE.txt
@@ -9,7 +9,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-package arcs.sdk
+package arcs.sdk.wasm
 
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test

--- a/javatests/arcs/sdk/wasm/StringEncoderTest.kt
+++ b/javatests/arcs/sdk/wasm/StringEncoderTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC.
+ * Copyright 2020 Google LLC.
  *
  * This code may only be used under the BSD style license found at
  * http://polymer.github.io/LICENSE.txt
@@ -9,7 +9,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-package arcs.sdk
+package arcs.sdk.wasm
 
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test

--- a/src/tools/schema2kotlin.ts
+++ b/src/tools/schema2kotlin.ts
@@ -52,21 +52,21 @@ package ${this.scope}
 //
 // Current implementation doesn't support references or optional field detection
 
-import arcs.sdk.NullTermByteArray
+import arcs.sdk.wasm.NullTermByteArray
 import arcs.sdk.ReadableCollection
 import arcs.sdk.ReadableSingleton
 import arcs.sdk.ReadWriteCollection
 import arcs.sdk.ReadWriteSingleton
-import arcs.sdk.StringDecoder
-import arcs.sdk.StringEncoder
+import arcs.sdk.wasm.StringDecoder
+import arcs.sdk.wasm.StringEncoder
 import arcs.sdk.WritableCollection
 import arcs.sdk.WritableSingleton
-import arcs.sdk.toUtf8String
 import arcs.sdk.wasm.WasmCollection
 import arcs.sdk.wasm.WasmEntity
 import arcs.sdk.wasm.WasmEntitySpec
 import arcs.sdk.wasm.WasmParticle
 import arcs.sdk.wasm.WasmSingleton
+import arcs.sdk.wasm.toUtf8String
 `;
   }
 

--- a/src/tools/tests/goldens/generated-schemas.kt
+++ b/src/tools/tests/goldens/generated-schemas.kt
@@ -17,12 +17,12 @@ import arcs.sdk.StringDecoder
 import arcs.sdk.StringEncoder
 import arcs.sdk.WritableCollection
 import arcs.sdk.WritableSingleton
-import arcs.sdk.toUtf8String
 import arcs.sdk.wasm.WasmCollection
 import arcs.sdk.wasm.WasmEntity
 import arcs.sdk.wasm.WasmEntitySpec
 import arcs.sdk.wasm.WasmParticle
 import arcs.sdk.wasm.WasmSingleton
+import arcs.sdk.wasm.toUtf8String
 
 class GoldInternal1() : WasmEntity {
 

--- a/src/tools/tests/goldens/generated-schemas.kt
+++ b/src/tools/tests/goldens/generated-schemas.kt
@@ -8,13 +8,13 @@ package arcs.sdk
 //
 // Current implementation doesn't support references or optional field detection
 
-import arcs.sdk.NullTermByteArray
+import arcs.sdk.wasm.NullTermByteArray
 import arcs.sdk.ReadableCollection
 import arcs.sdk.ReadableSingleton
 import arcs.sdk.ReadWriteCollection
 import arcs.sdk.ReadWriteSingleton
-import arcs.sdk.StringDecoder
-import arcs.sdk.StringEncoder
+import arcs.sdk.wasm.StringDecoder
+import arcs.sdk.wasm.StringEncoder
 import arcs.sdk.WritableCollection
 import arcs.sdk.WritableSingleton
 import arcs.sdk.wasm.WasmCollection


### PR DESCRIPTION
They aren't needed on jvm.

Made a special testonly package containing the required jvm deps needed
to be able to unit test those wasm classes