### PR TITLE
Add basic Handle implementations for JVM

### DIFF
--- a/java/arcs/sdk/Particle.kt
+++ b/java/arcs/sdk/Particle.kt
@@ -16,8 +16,7 @@ interface Particle {
     /**
      * React to handle updates.
      *
-     * Called for handles when change events are received from the backing store. Default action is to trigger
-     * rendering.
+     * Called for handles when change events are received from the backing store.
      *
      * @param handle Singleton or Collection handle
      */
@@ -28,7 +27,6 @@ interface Particle {
      *
      * Called for handles that are marked for synchronization at connection, when they are updated with the full model
      * of their data. This will occur once after setHandles() and any time thereafter if the handle is resynchronized.
-     * Default action is to trigger rendering.
      *
      * @param handle Singleton or Collection handle
      * @param allSynced flag indicating if all handles are synchronized

--- a/java/arcs/sdk/Particle.kt
+++ b/java/arcs/sdk/Particle.kt
@@ -13,5 +13,57 @@ package arcs.sdk
 
 /** Base interface for all particles. */
 interface Particle {
-    // TODO: Add methods common to wasm and jvm Particles here.
+    /**
+     * React to handle updates.
+     *
+     * Called for handles when change events are received from the backing store. Default action is to trigger
+     * rendering.
+     *
+     * @param handle Singleton or Collection handle
+     */
+    fun onHandleUpdate(handle: Handle) = Unit
+
+    /**
+     * React to handle synchronization.
+     *
+     * Called for handles that are marked for synchronization at connection, when they are updated with the full model
+     * of their data. This will occur once after setHandles() and any time thereafter if the handle is resynchronized.
+     * Default action is to trigger rendering.
+     *
+     * @param handle Singleton or Collection handle
+     * @param allSynced flag indicating if all handles are synchronized
+     */
+    fun onHandleSync(handle: Handle, allSynced: Boolean) = Unit
+
+    /**
+     * Rendering through UiBroker.
+     *
+     * Only implemented for wasm, no-op on JVM.
+     */
+    fun renderOutput() = Unit
+
+    /**
+     * Define template for rendering (optional).
+     *
+     * Only implemented for wasm, no-op on JVM.
+     *
+     * @param slotName name of slot where template is rendered.
+     * @see [renderOutput]
+     */
+    fun getTemplate(slotName: String): String? = null
+
+    /**
+     * Populate model for rendering (UiBroker model).
+     *
+     * Only implemented for wasm, no-op on JVM.
+     *
+     * @param slotName name of slot where model data is populated
+     * @param model Starting model state; Default: empty map
+     * @return new model state
+     * @see [renderOutput]
+     */
+    fun populateModel(
+        slotName: String,
+        model: Map<String, Any> = mapOf()
+    ): Map<String, Any>? = model
 }

--- a/java/arcs/sdk/jvm/CollectionImpl.kt
+++ b/java/arcs/sdk/jvm/CollectionImpl.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.sdk
+
+/** [ReadWriteCollection] implementation for WASM. */
+@Suppress("UNUSED_PARAMETER")
+// TODO: Connect to storage.
+class CollectionImpl<T : Entity>(
+    val particle: Particle,
+    override val name: String,
+    entitySpec: EntitySpec<T>
+) : ReadWriteCollection<T> {
+    private val entities = mutableListOf<T>()
+
+    override val size: Int
+        get() = entities.size
+
+    override fun isEmpty(): Boolean = entities.isEmpty()
+
+    override fun iterator(): Iterator<T> = entities.iterator()
+
+    override fun store(entity: T) {
+        entities.add(entity)
+        particle.onHandleUpdate(this)
+    }
+
+    override fun clear() {
+        entities.clear()
+        particle.onHandleUpdate(this)
+    }
+
+    override fun remove(entity: T) {
+        entities.remove(entity)
+        particle.onHandleUpdate(this)
+    }
+}

--- a/java/arcs/sdk/jvm/CollectionImpl.kt
+++ b/java/arcs/sdk/jvm/CollectionImpl.kt
@@ -11,7 +11,7 @@
 
 package arcs.sdk
 
-/** [ReadWriteCollection] implementation for WASM. */
+/** [ReadWriteCollection] implementation for the JVM. */
 @Suppress("UNUSED_PARAMETER")
 // TODO: Connect to storage.
 class CollectionImpl<T : Entity>(

--- a/java/arcs/sdk/jvm/SingletonImpl.kt
+++ b/java/arcs/sdk/jvm/SingletonImpl.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.sdk
+
+/** [ReadWriteSingleton] implementation for WASM. */
+@Suppress("UNUSED_PARAMETER")
+// TODO: Connect to storage.
+class SingletonImpl<T : Entity>(
+    private val particle: Particle,
+    override val name: String,
+    entitySpec: EntitySpec<T>
+) : ReadWriteSingleton<T> {
+    private var entity: T? = null
+
+    override fun get(): T? = entity
+
+    override fun set(entity: T) {
+        this.entity = entity
+        particle.onHandleUpdate(this)
+    }
+
+    override fun clear() {
+        this.entity = null
+        particle.onHandleUpdate(this)
+    }
+}

--- a/java/arcs/sdk/jvm/SingletonImpl.kt
+++ b/java/arcs/sdk/jvm/SingletonImpl.kt
@@ -11,7 +11,7 @@
 
 package arcs.sdk
 
-/** [ReadWriteSingleton] implementation for WASM. */
+/** [ReadWriteSingleton] implementation for the JVM. */
 @Suppress("UNUSED_PARAMETER")
 // TODO: Connect to storage.
 class SingletonImpl<T : Entity>(

--- a/java/arcs/sdk/wasm/WasmParticle.kt
+++ b/java/arcs/sdk/wasm/WasmParticle.kt
@@ -94,30 +94,8 @@ abstract class WasmParticle : Particle {
         onHandleSync(handle, toSync.isEmpty())
     }
 
-    /**
-     * React to handle updates.
-     *
-     * Called for handles when change events are received from the backing store. Default action is to trigger
-     * rendering.
-     *
-     * @param handle Singleton or Collection handle
-     */
-    open fun onHandleUpdate(handle: Handle) = Unit
-
-    /**
-     * React to handle synchronization.
-     *
-     * Called for handles that are marked for synchronization at connection, when they are updated with the full model
-     * of their data. This will occur once after setHandles() and any time thereafter if the handle is resynchronized.
-     * Default action is to trigger rendering.
-     *
-     * @param handle Singleton or Collection handle
-     * @param allSynced flag indicating if all handles are synchronized
-     */
-    open fun onHandleSync(handle: Handle, allSynced: Boolean) = Unit
-
     /** Rendering through UiBroker */
-    fun renderOutput() {
+    override fun renderOutput() {
         val slotName = ""
         val template = getTemplate(slotName)
         val model = populateModel(slotName)?.let {
@@ -125,27 +103,6 @@ abstract class WasmParticle : Particle {
         }
         WasmRuntimeClient.onRenderOutput(this, template, model)
     }
-
-    /**
-     * Define template for rendering (optional)
-     *
-     * @param slotName name of slot where template is rendered.
-     * @see [renderOutput]
-     */
-    open fun getTemplate(slotName: String): String? = null
-
-    /**
-     * Populate model for rendering (UiBroker model)
-     *
-     * @param slotName name of slot where model data is populated
-     * @param model Starting model state; Default: empty map
-     * @return new model state
-     * @see [renderOutput]
-     */
-    open fun populateModel(
-        slotName: String,
-        model: Map<String, Any> = mapOf()
-    ): Map<String, Any>? = model
 
     /** @deprecated for contexts using UiBroker (e.g Kotlin) */
     @Deprecated("Rendering refactored to use UiBroker.", ReplaceWith("renderOutput()"))

--- a/javatests/arcs/sdk/jvm/BUILD
+++ b/javatests/arcs/sdk/jvm/BUILD
@@ -1,0 +1,33 @@
+load(
+    "//third_party/java/arcs/build_defs:build_defs.bzl",
+    "arcs_kt_jvm_library",
+    "arcs_kt_jvm_test_suite",
+)
+
+licenses(["notice"])
+
+TEST_SRCS = glob(["*Test.kt"])
+
+arcs_kt_jvm_test_suite(
+    name = "jvm",
+    srcs = TEST_SRCS,
+    package = "arcs.sdk.jvm",
+    deps = [
+        ":fakes",
+        "//java/arcs/sdk:arcs",
+        "//third_party/java/junit:junit-android",
+        "//third_party/java/mockito:mockito-android",
+        "//third_party/java/truth:truth-android",
+    ],
+)
+
+arcs_kt_jvm_library(
+    name = "fakes",
+    srcs = glob(
+        ["*.kt"],
+        exclude = TEST_SRCS,
+    ),
+    deps = [
+        "//java/arcs/sdk:arcs",
+    ],
+)

--- a/javatests/arcs/sdk/jvm/BUILD
+++ b/javatests/arcs/sdk/jvm/BUILD
@@ -15,9 +15,9 @@ arcs_kt_jvm_test_suite(
     deps = [
         ":fakes",
         "//java/arcs/sdk:arcs",
-        "//third_party/java/junit:junit-android",
-        "//third_party/java/mockito:mockito-android",
-        "//third_party/java/truth:truth-android",
+        "//third_party/java/junit",
+        "//third_party/java/mockito",
+        "//third_party/java/truth",
     ],
 )
 

--- a/javatests/arcs/sdk/jvm/CollectionImplTest.kt
+++ b/javatests/arcs/sdk/jvm/CollectionImplTest.kt
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.sdk.jvm
+
+import arcs.sdk.Particle
+import arcs.sdk.CollectionImpl
+import com.google.common.truth.Truth.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.mockito.Mock
+import org.mockito.Mockito.verify
+import org.mockito.MockitoAnnotations
+
+@RunWith(JUnit4::class)
+class CollectionImplTest {
+
+    private lateinit var collection: CollectionImpl<DummyEntity>
+    @Mock private lateinit var particle: Particle
+
+    private val HANDLE_NAME = "HANDLE_NAME"
+    private val DUMMY_VALUE1 = DummyEntity("111")
+    private val DUMMY_VALUE2 = DummyEntity("222")
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.initMocks(this)
+        collection = CollectionImpl(particle, HANDLE_NAME, DummyEntity.Spec())
+    }
+
+    @Test
+    fun initialState() {
+        assertThat(collection.name).isEqualTo(HANDLE_NAME)
+        assertThat(collection.size).isEqualTo(0)
+        assertThat(collection.isEmpty()).isTrue()
+        assertThat(collection.toList()).isEmpty()
+    }
+
+    @Test
+    fun store_addsElement() {
+        collection.store(DUMMY_VALUE1)
+
+        assertThat(collection.size).isEqualTo(1)
+        assertThat(collection.isEmpty()).isFalse()
+        assertThat(collection.toList()).containsExactly(DUMMY_VALUE1)
+    }
+
+    @Test
+    fun store_canAddMultipleValues() {
+        collection.store(DUMMY_VALUE1)
+        collection.store(DUMMY_VALUE2)
+
+        assertThat(collection.size).isEqualTo(2)
+        assertThat(collection.isEmpty()).isFalse()
+        assertThat(collection.toList()).containsExactly(DUMMY_VALUE1, DUMMY_VALUE2)
+    }
+
+    @Test
+    fun store_updatesParticle() {
+        collection.store(DUMMY_VALUE1)
+        verify(particle).onHandleUpdate(collection)
+    }
+
+    @Test
+    fun remove_removesSingleValue() {
+        collection.store(DUMMY_VALUE1)
+        collection.store(DUMMY_VALUE2)
+
+        collection.remove(DUMMY_VALUE2)
+
+        assertThat(collection.size).isEqualTo(1)
+        assertThat(collection.isEmpty()).isFalse()
+        assertThat(collection.toList()).containsExactly(DUMMY_VALUE1)
+    }
+
+    @Test
+    fun remove_updatesParticle() {
+        collection.remove(DUMMY_VALUE2)
+        verify(particle).onHandleUpdate(collection)
+    }
+
+    @Test
+    fun clear_removesMultipleValues() {
+        collection.store(DUMMY_VALUE1)
+        collection.store(DUMMY_VALUE2)
+
+        collection.clear()
+
+        assertThat(collection.size).isEqualTo(0)
+        assertThat(collection.isEmpty()).isTrue()
+        assertThat(collection.toList()).isEmpty()
+    }
+
+    @Test
+    fun clear_updatesParticle() {
+        collection.clear()
+        verify(particle).onHandleUpdate(collection)
+    }
+}

--- a/javatests/arcs/sdk/jvm/DummyEntity.kt
+++ b/javatests/arcs/sdk/jvm/DummyEntity.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.sdk.jvm
+
+import arcs.sdk.Entity
+import arcs.sdk.EntitySpec
+
+/** Fake [Entity] implementation. */
+data class DummyEntity(val text: String) : Entity {
+    override var internalId = "abc"
+
+    override fun schemaHash() = "def"
+
+    override fun isSet() = true
+
+    override fun getFieldsNotSet(): List<String> = emptyList()
+
+    /** Fake [EntitySpec] implementation for [DummyEntity]. */
+    class Spec : EntitySpec<DummyEntity> {
+        override fun create() = DummyEntity("default")
+    }
+}

--- a/javatests/arcs/sdk/jvm/SingletonImplTest.kt
+++ b/javatests/arcs/sdk/jvm/SingletonImplTest.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.sdk.jvm
+
+import arcs.sdk.Particle
+import arcs.sdk.SingletonImpl
+import com.google.common.truth.Truth.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.mockito.Mock
+import org.mockito.Mockito.verify
+import org.mockito.MockitoAnnotations
+
+@RunWith(JUnit4::class)
+class SingletonImplTest {
+
+    private lateinit var singleton: SingletonImpl<DummyEntity>
+    @Mock private lateinit var particle: Particle
+
+    private val HANDLE_NAME = "HANDLE_NAME"
+    private val DUMMY_VALUE = DummyEntity("123")
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.initMocks(this)
+        singleton = SingletonImpl(particle, HANDLE_NAME, DummyEntity.Spec())
+    }
+
+    @Test
+    fun initialState() {
+        assertThat(singleton.name).isEqualTo(HANDLE_NAME)
+        assertThat(singleton.get()).isNull()
+    }
+
+    @Test
+    fun set_changesValue() {
+        singleton.set(DUMMY_VALUE)
+        assertThat(singleton.get()).isEqualTo(DUMMY_VALUE)
+    }
+
+    @Test
+    fun set_updatesParticle() {
+        singleton.set(DUMMY_VALUE)
+        verify(particle).onHandleUpdate(singleton)
+    }
+
+    @Test
+    fun clear_changesValue() {
+        singleton.set(DUMMY_VALUE)
+        singleton.clear()
+        assertThat(singleton.get()).isNull()
+    }
+
+    @Test
+    fun clear_updatesParticle() {
+        singleton.clear()
+        verify(particle).onHandleUpdate(singleton)
+    }
+}

--- a/third_party/java/arcs/build_defs/internal/kotlin.bzl
+++ b/third_party/java/arcs/build_defs/internal/kotlin.bzl
@@ -53,12 +53,13 @@ def arcs_kt_jvm_library(**kwargs):
       **kwargs: Set of arguments
     """
     disable_lint_checks = kwargs.pop("disable_lint_checks", [])
+    constraints = kwargs.pop("constraints", ["android"])
     if not IS_BAZEL:
         kwargs["disable_lint_checks"] = [
             "PackageName",
             "TopLevelName",
         ] + disable_lint_checks
-        kwargs["constraints"] = ["android"]
+        kwargs["constraints"] = constraints
 
     kt_jvm_library(**kwargs)
 
@@ -317,6 +318,8 @@ def arcs_kt_jvm_test_suite(name, package, srcs = None, tags = [], deps = []):
     arcs_kt_jvm_library(
         name = name,
         srcs = srcs,
+        # We don't need this to be Android compatible.
+        constraints = [],
         testonly = True,
         deps = deps,
     )


### PR DESCRIPTION
These classes just have dummy implementations for now, they will be
hooked up to actual storage later on (by @jblebrun). Just getting
something checked in so that I can work towards getting particles
to compile on the JVM again.

Also moved some methods from WasmParticle into the base Particle
interface.