### PR TITLE
Rename wasm classes to include "Impl" suffix.

### DIFF
--- a/java/arcs/sdk/wasm/WasmCollectionImpl.kt
+++ b/java/arcs/sdk/wasm/WasmCollectionImpl.kt
@@ -14,8 +14,8 @@ package arcs.sdk.wasm
 import arcs.sdk.ReadWriteCollection
 
 /** [ReadWriteCollection] implementation for WASM. */
-class WasmCollection<T : WasmEntity>(
-    particle: WasmParticle,
+class WasmCollectionImpl<T : WasmEntity>(
+    particle: WasmParticleImpl,
     name: String,
     private val entitySpec: WasmEntitySpec<T>
 ) : WasmHandle<T>(name, particle), ReadWriteCollection<T> {

--- a/java/arcs/sdk/wasm/WasmHandle.kt
+++ b/java/arcs/sdk/wasm/WasmHandle.kt
@@ -16,7 +16,7 @@ import arcs.sdk.Handle
 /** Base [Handle] implementation for WASM. */
 abstract class WasmHandle<T : WasmEntity>(
     override val name: String,
-    val particle: WasmParticle
+    val particle: WasmParticleImpl
 ) : Handle {
     init {
         particle.registerHandle(this)

--- a/java/arcs/sdk/wasm/WasmJsInterop.kt
+++ b/java/arcs/sdk/wasm/WasmJsInterop.kt
@@ -120,7 +120,7 @@ fun connectHandle(
     canWrite: Boolean
 ): WasmAddress {
     return particlePtr
-        .toObject<WasmParticle>()
+        .toObject<WasmParticleImpl>()
         ?.connectHandle(handleName.toKString(), canRead, canWrite)
         ?.toAddress() ?: 0
 }
@@ -128,7 +128,7 @@ fun connectHandle(
 @Retain
 @ExportForCppRuntime("_init")
 fun init(particlePtr: WasmAddress) {
-    particlePtr.toObject<WasmParticle>()?.init()
+    particlePtr.toObject<WasmParticleImpl>()?.init()
 }
 
 @Retain
@@ -137,7 +137,7 @@ fun syncHandle(particlePtr: WasmAddress, handlePtr: WasmAddress, encoded: WasmNu
     val handle = handlePtr.toObject<WasmHandle<*>>()
     handle?.let {
         it.sync(encoded.toByteArray())
-        particlePtr.toObject<WasmParticle>()?.sync(it)
+        particlePtr.toObject<WasmParticleImpl>()?.sync(it)
     }
 }
 
@@ -152,7 +152,7 @@ fun updateHandle(
     val handle = handlePtr.toObject<WasmHandle<*>>()
     handle?.let {
         it.update(encoded1Ptr.toByteArray(), encoded2Ptr.toByteArray())
-        particlePtr.toObject<WasmParticle>()?.onHandleUpdate(it)
+        particlePtr.toObject<WasmParticleImpl>()?.onHandleUpdate(it)
     }
 }
 
@@ -165,7 +165,7 @@ fun renderSlot(
     sendModel: Boolean
 ) {
     @Suppress("DEPRECATION")
-    particlePtr.toObject<WasmParticle>()?.renderSlot(
+    particlePtr.toObject<WasmParticleImpl>()?.renderSlot(
         slotNamePtr.toKString(),
         sendTemplate,
         sendModel
@@ -180,7 +180,7 @@ fun fireEvent(
     handlerNamePtr: WasmString,
     eventData: WasmString
 ) {
-    particlePtr.toObject<WasmParticle>()?.fireEvent(
+    particlePtr.toObject<WasmParticleImpl>()?.fireEvent(
         slotNamePtr.toKString(),
         handlerNamePtr.toKString(),
         StringDecoder.decodeDictionary(eventData.toByteArray())
@@ -196,7 +196,7 @@ fun serviceResponse(
     tagPtr: WasmString
 ) {
     val dict = StringDecoder.decodeDictionary(responsePtr.toByteArray())
-    particlePtr.toObject<WasmParticle>()?.serviceResponse(
+    particlePtr.toObject<WasmParticleImpl>()?.serviceResponse(
         callPtr.toKString(),
         dict,
         tagPtr.toKString()
@@ -206,7 +206,7 @@ fun serviceResponse(
 @Retain
 @ExportForCppRuntime("_renderOutput")
 fun renderOutput(particlePtr: WasmAddress) {
-    particlePtr.toObject<WasmParticle>()
+    particlePtr.toObject<WasmParticleImpl>()
         ?.renderOutput()
 }
 

--- a/java/arcs/sdk/wasm/WasmParticleImpl.kt
+++ b/java/arcs/sdk/wasm/WasmParticleImpl.kt
@@ -17,7 +17,7 @@ import arcs.sdk.Particle
 /**
  * Base class for all wasm particles.
  */
-abstract class WasmParticle : Particle {
+abstract class WasmParticleImpl : Particle {
     private val handles: MutableMap<String, Handle> = mutableMapOf()
     private val toSync: MutableSet<Handle> = mutableSetOf()
     private val eventHandlers: MutableMap<String, (Map<String, String>) -> Unit> = mutableMapOf()

--- a/java/arcs/sdk/wasm/WasmRuntimeClient.kt
+++ b/java/arcs/sdk/wasm/WasmRuntimeClient.kt
@@ -12,12 +12,12 @@
 package arcs.sdk.wasm
 
 object WasmRuntimeClient {
-    fun <T : WasmEntity> singletonClear(particle: WasmParticle, singleton: WasmSingleton<T>) =
+    fun <T : WasmEntity> singletonClear(particle: WasmParticleImpl, singleton: WasmSingletonImpl<T>) =
         singletonClear(particle.toAddress(), singleton.toAddress())
 
     fun <T : WasmEntity> singletonSet(
-        particle: WasmParticle,
-        singleton: WasmSingleton<T>,
+        particle: WasmParticleImpl,
+        singleton: WasmSingletonImpl<T>,
         encoded: NullTermByteArray
     ) = singletonSet(
         particle.toAddress(),
@@ -26,8 +26,8 @@ object WasmRuntimeClient {
     )
 
     fun <T : WasmEntity> collectionRemove(
-        particle: WasmParticle,
-        collection: WasmCollection<T>,
+        particle: WasmParticleImpl,
+        collection: WasmCollectionImpl<T>,
         encoded: NullTermByteArray
     ) = collectionRemove(
         particle.toAddress(),
@@ -35,12 +35,12 @@ object WasmRuntimeClient {
         encoded.bytes.toWasmAddress()
     )
 
-    fun <T : WasmEntity> collectionClear(particle: WasmParticle, collection: WasmCollection<T>) =
+    fun <T : WasmEntity> collectionClear(particle: WasmParticleImpl, collection: WasmCollectionImpl<T>) =
         collectionClear(particle.toAddress(), collection.toAddress())
 
     fun <T : WasmEntity> collectionStore(
-        particle: WasmParticle,
-        collection: WasmCollection<T>,
+        particle: WasmParticleImpl,
+        collection: WasmCollectionImpl<T>,
         encoded: NullTermByteArray
     ): String? {
         val wasmId = collectionStore(
@@ -53,7 +53,7 @@ object WasmRuntimeClient {
 
     fun log(msg: String) = arcs.sdk.wasm.log(msg)
 
-    fun onRenderOutput(particle: WasmParticle, template: String?, model: NullTermByteArray?) =
+    fun onRenderOutput(particle: WasmParticleImpl, template: String?, model: NullTermByteArray?) =
         onRenderOutput(
             particle.toAddress(),
             template.toWasmNullableString(),
@@ -61,7 +61,7 @@ object WasmRuntimeClient {
         )
 
     fun serviceRequest(
-        particle: WasmParticle,
+        particle: WasmParticleImpl,
         call: String,
         encoded: NullTermByteArray,
         tag: String

--- a/java/arcs/sdk/wasm/WasmSingletonImpl.kt
+++ b/java/arcs/sdk/wasm/WasmSingletonImpl.kt
@@ -14,8 +14,8 @@ package arcs.sdk.wasm
 import arcs.sdk.ReadWriteSingleton
 
 /** [ReadWriteSingleton] implementation for WASM. */
-open class WasmSingleton<T : WasmEntity>(
-    particle: WasmParticle,
+class WasmSingletonImpl<T : WasmEntity>(
+    particle: WasmParticleImpl,
     name: String,
     private val entitySpec: WasmEntitySpec<T>
 ) : WasmHandle<T>(name, particle), ReadWriteSingleton<T> {

--- a/javatests/arcs/sdk/wasm/EntityClassApiTest.kt
+++ b/javatests/arcs/sdk/wasm/EntityClassApiTest.kt
@@ -15,8 +15,8 @@ class EntityClassApiTest : TestBase<EntityClassApiTest_Errors>(
     ::EntityClassApiTest_Errors,
     EntityClassApiTest_Errors_Spec()
 ) {
-    private val unused1 = WasmSingleton(this, "data", EntityClassApiTest_Data_Spec())
-    private val unused2 = WasmSingleton(this, "empty", EntityClassApiTest_Empty_Spec())
+    private val unused1 = WasmSingletonImpl(this, "data", EntityClassApiTest_Data_Spec())
+    private val unused2 = WasmSingletonImpl(this, "empty", EntityClassApiTest_Empty_Spec())
 
     /** Run tests on particle initialization */
     override fun init() {

--- a/javatests/arcs/sdk/wasm/HandleSyncUpdateTest.kt
+++ b/javatests/arcs/sdk/wasm/HandleSyncUpdateTest.kt
@@ -22,10 +22,10 @@ class HandleSyncUpdateTest : AbstractHandleSyncUpdateTest() {
         val out = HandleSyncUpdateTest_Res()
         out.txt = "update:${handle.name}"
         if (handle.name == "sng") {
-            val data = (handle as WasmSingleton<*>).get() as HandleSyncUpdateTest_Sng
+            val data = (handle as WasmSingletonImpl<*>).get() as HandleSyncUpdateTest_Sng
             out.num = data.num
         } else if (handle.name == "col") {
-            val data = (handle as WasmCollection<*>).iterator().next() as HandleSyncUpdateTest_Col
+            val data = (handle as WasmCollectionImpl<*>).iterator().next() as HandleSyncUpdateTest_Col
             out.num = data.num
         } else {
             out.txt = "unexpected handle name: ${handle.name}"

--- a/javatests/arcs/sdk/wasm/SpecialSchemaFieldsTest.kt
+++ b/javatests/arcs/sdk/wasm/SpecialSchemaFieldsTest.kt
@@ -15,7 +15,7 @@ class SpecialSchemaFieldsTest : TestBase<SpecialSchemaFieldsTest_Errors>(
     ::SpecialSchemaFieldsTest_Errors,
     SpecialSchemaFieldsTest_Errors_Spec()
 ) {
-    private val unused = WasmSingleton(
+    private val unused = WasmSingletonImpl(
         this, "fields", SpecialSchemaFieldsTest_Fields_Spec()
     )
 

--- a/javatests/arcs/sdk/wasm/TestBase.kt
+++ b/javatests/arcs/sdk/wasm/TestBase.kt
@@ -17,11 +17,11 @@ import kotlin.test.Asserter
 open class TestBase<T : WasmEntity>(
     val ctor: (txt: String) -> T,
     spec: WasmEntitySpec<T>
-) : WasmParticle(), Asserter {
-    private val errors = WasmCollection(this, "errors", spec)
+) : WasmParticleImpl(), Asserter {
+    private val errors = WasmCollectionImpl(this, "errors", spec)
 
     private fun <T : WasmEntity> assertContainerEqual(
-        container: WasmCollection<T>,
+        container: WasmCollectionImpl<T>,
         converter: (T) -> String,
         expected: List<String>,
         isOrdered: Boolean = true

--- a/javatests/arcs/sdk/wasm/UnicodeTest.kt
+++ b/javatests/arcs/sdk/wasm/UnicodeTest.kt
@@ -18,9 +18,9 @@ class UnicodeTest : AbstractUnicodeTest() {
         val out = UnicodeTest_Res(pass = "", src = "")
         out.src = "åŗċş 🌈"
         out.pass = if (handle.name == "sng") {
-            ((handle as WasmSingleton<*>).get() as UnicodeTest_Sng).pass
+            ((handle as WasmSingletonImpl<*>).get() as UnicodeTest_Sng).pass
         } else {
-            ((handle as WasmCollection<*>).iterator().next() as UnicodeTest_Col).pass
+            ((handle as WasmCollectionImpl<*>).iterator().next() as UnicodeTest_Col).pass
         }
         res.store(out)
     }

--- a/src/tools/schema2kotlin.ts
+++ b/src/tools/schema2kotlin.ts
@@ -52,21 +52,8 @@ package ${this.scope}
 //
 // Current implementation doesn't support references or optional field detection
 
-import arcs.sdk.wasm.NullTermByteArray
-import arcs.sdk.ReadableCollection
-import arcs.sdk.ReadableSingleton
-import arcs.sdk.ReadWriteCollection
-import arcs.sdk.ReadWriteSingleton
-import arcs.sdk.wasm.StringDecoder
-import arcs.sdk.wasm.StringEncoder
-import arcs.sdk.WritableCollection
-import arcs.sdk.WritableSingleton
-import arcs.sdk.wasm.WasmCollection
-import arcs.sdk.wasm.WasmEntity
-import arcs.sdk.wasm.WasmEntitySpec
-import arcs.sdk.wasm.WasmParticle
-import arcs.sdk.wasm.WasmSingleton
-import arcs.sdk.wasm.toUtf8String
+import arcs.sdk.*
+import arcs.sdk.wasm.*
 `;
   }
 
@@ -95,11 +82,11 @@ import arcs.sdk.wasm.toUtf8String
         default:
           throw new Error(`Unsupported handle direction: ${connection.direction}`);
       }
-      handleConcreteType = `Wasm${handleConcreteType}`;
+      handleConcreteType = `Wasm${handleConcreteType}Impl`;
       handleDecls.push(`protected val ${handleName}: ${handleInterfaceType} = ${handleConcreteType}(this, "${handleName}", ${entityType}_Spec())`);
     }
     return `
-abstract class Abstract${particleName} : WasmParticle() {
+abstract class Abstract${particleName} : WasmParticleImpl() {
     ${handleDecls.join('\n    ')}
 }
 `;

--- a/src/tools/tests/goldens/generated-schemas.kt
+++ b/src/tools/tests/goldens/generated-schemas.kt
@@ -8,21 +8,8 @@ package arcs.sdk
 //
 // Current implementation doesn't support references or optional field detection
 
-import arcs.sdk.wasm.NullTermByteArray
-import arcs.sdk.ReadableCollection
-import arcs.sdk.ReadableSingleton
-import arcs.sdk.ReadWriteCollection
-import arcs.sdk.ReadWriteSingleton
-import arcs.sdk.wasm.StringDecoder
-import arcs.sdk.wasm.StringEncoder
-import arcs.sdk.WritableCollection
-import arcs.sdk.WritableSingleton
-import arcs.sdk.wasm.WasmCollection
-import arcs.sdk.wasm.WasmEntity
-import arcs.sdk.wasm.WasmEntitySpec
-import arcs.sdk.wasm.WasmParticle
-import arcs.sdk.wasm.WasmSingleton
-import arcs.sdk.wasm.toUtf8String
+import arcs.sdk.*
+import arcs.sdk.wasm.*
 
 class GoldInternal1() : WasmEntity {
 
@@ -239,7 +226,7 @@ class Gold_Data_Spec() : WasmEntitySpec<Gold_Data> {
 }
 
 
-abstract class AbstractGold : WasmParticle() {
-    protected val data: ReadableSingleton<Gold_Data> = WasmSingleton(this, "data", Gold_Data_Spec())
-    protected val alias: WritableSingleton<Gold_Alias> = WasmSingleton(this, "alias", Gold_Alias_Spec())
+abstract class AbstractGold : WasmParticleImpl() {
+    protected val data: ReadableSingleton<Gold_Data> = WasmSingletonImpl(this, "data", Gold_Data_Spec())
+    protected val alias: WritableSingleton<Gold_Alias> = WasmSingletonImpl(this, "alias", Gold_Alias_Spec())
 }


### PR DESCRIPTION
This is for parity with the JVM ones, e.g. SingletonImpl.

The convention is that shared interfaces have a normal name
(`Particle`), the JVM implementations will have a Impl name
(`ParticleImpl`) and the wasm implementations will have a Wasm prefix
too (`WasmParticleImpl`).

Disambiguating these classes by using different names is necessary
instead of using expect/actual keywords, because the signatures are
different. e.g. WasmSingleton requires a WasmEntitySpec instead of just
an EntitySpec, since it needs the decode method.