### PR TITLE
Deduplicate test and build scripts

### DIFF
--- a/tools/hooks/pre-commit
+++ b/tools/hooks/pre-commit
@@ -1,5 +1,3 @@
 #!/bin/bash
-./tools/sigh lint
-./tools/sigh check
-git diff --name-only --cached --relative | grep '\.kt[s"]\?$' | xargs ktlint --android --relative --verbose .
+./tools/local-presubmit
 if [ $? -ne 0 ]; then exit 1; fi


### PR DESCRIPTION
This removes a stale script in tools that used to run bazel test (but since the directory move does not work and the equivalent tests can just be run from tools/local-presubmit).

It also updates tools/hooks/pre-commit so that it runs tools/local-presubmit, this makes sense that git hook configuration doesn't need to be changed, but git will now be able to run all of the presubmit checks (instead of just sigh lint and sigh test).