### PR TITLE
Wasm: Singletons should return pointers to entities to allow for nullability

### DIFF
--- a/java/arcs/sdk/wasm/WasmSingletonImpl.kt
+++ b/java/arcs/sdk/wasm/WasmSingletonImpl.kt
@@ -23,7 +23,7 @@ class WasmSingletonImpl<T : WasmEntity>(
     private var entity: T? = null
 
     override fun sync(encoded: ByteArray) {
-        entity = entitySpec.decode(encoded)
+        entity = if (encoded.size > 0) entitySpec.decode(encoded) else null
     }
 
     override fun update(added: ByteArray, removed: ByteArray) = sync(added)
@@ -42,7 +42,7 @@ class WasmSingletonImpl<T : WasmEntity>(
     }
 
     override fun clear() {
-        entity = entitySpec.create()
+        entity = null
         WasmRuntimeClient.singletonClear(particle, this)
     }
 }

--- a/javatests/arcs/sdk/wasm/HandleSyncUpdateTest.kt
+++ b/javatests/arcs/sdk/wasm/HandleSyncUpdateTest.kt
@@ -16,17 +16,20 @@ import arcs.sdk.Handle
 class HandleSyncUpdateTest : AbstractHandleSyncUpdateTest() {
     override fun onHandleSync(handle: Handle, allSynced: Boolean) {
         res.store(HandleSyncUpdateTest_Res(txt = "sync:${handle.name}:$allSynced", num = 0.0))
+        if (allSynced) {
+            val ptr = HandleSyncUpdateTest_Res()
+            ptr.txt = if (sng.get() != null) "sng:populated" else "sng:null"
+            res.store(ptr)
+        }
     }
 
     override fun onHandleUpdate(handle: Handle) {
         val out = HandleSyncUpdateTest_Res()
         out.txt = "update:${handle.name}"
         if (handle.name == "sng") {
-            val data = (handle as WasmSingletonImpl<*>).get() as HandleSyncUpdateTest_Sng
-            out.num = data.num
+            out.num = sng.get()?.num ?: -1.0
         } else if (handle.name == "col") {
-            val data = (handle as WasmCollectionImpl<*>).iterator().next() as HandleSyncUpdateTest_Col
-            out.num = data.num
+            out.num = if (col.size > 0) col.iterator().next().num else -1.0
         } else {
             out.txt = "unexpected handle name: ${handle.name}"
         }

--- a/javatests/arcs/sdk/wasm/SingletonApiTest.kt
+++ b/javatests/arcs/sdk/wasm/SingletonApiTest.kt
@@ -15,8 +15,18 @@ class SingletonApiTest : AbstractSingletonApiTest() {
     override fun fireEvent(slotName: String, eventName: String, eventData: Map<String, String>) {
         when (eventName) {
             "case1" -> {
+                if (ioHandle.get() == null) {
+                    errors.store(
+                        SingletonApiTest_Errors(msg = "case1: populated handle should not be null")
+                    )
+                }
                 outHandle.clear()
                 ioHandle.clear()
+                if (ioHandle.get() != null) {
+                    errors.store(
+                        SingletonApiTest_Errors(msg = "case1: cleared handle should be null")
+                    )
+                }
             }
             "case2" -> {
                 val input = inHandle.get()
@@ -35,6 +45,20 @@ class SingletonApiTest : AbstractSingletonApiTest() {
                 )
                 d.num = d.num.times(3)
                 ioHandle.set(d)
+            }
+            "case4" -> {
+                if (ioHandle.get() != null) {
+                    errors.store(
+                        SingletonApiTest_Errors(msg = "case4: cleared handle should be null")
+                    )
+                }
+                outHandle.set(SingletonApiTest_OutHandle(txt = "out", num = 0.0))
+                ioHandle.set(SingletonApiTest_IoHandle(txt = "io", num = 0.0))
+                if (ioHandle.get() == null) {
+                    errors.store(
+                        SingletonApiTest_Errors(msg = "case4: populated handle should not be null")
+                    )
+                }
             }
         }
     }

--- a/javatests/arcs/sdk/wasm/manifest.arcs
+++ b/javatests/arcs/sdk/wasm/manifest.arcs
@@ -103,6 +103,7 @@ particle SingletonApiTest in '$module.wasm'
   inHandle: reads {num: Number, txt: Text}
   outHandle: writes {num: Number, txt: Text}
   ioHandle: reads writes {num: Number, txt: Text}
+  errors: writes [{msg: Text}]
 
 recipe SingletonApiTest
   s1: slot 'rootslotid-root'
@@ -111,6 +112,7 @@ recipe SingletonApiTest
     inHandle: reads h1
     outHandle: writes h2
     ioHandle: reads writes h3
+    errors: writes h4
 
 // -----------------------------------------------------------------------------------------------
 

--- a/particles/Native/Wasm/source/example.cc
+++ b/particles/Native/Wasm/source/example.cc
@@ -26,24 +26,27 @@ public:
   }
 
   void populateModel(const std::string& slot_name, arcs::Dictionary* model) override {
-    const arcs::BasicParticle_Foo& product = foo_.get();
-    model->emplace("name", product.name());
-    model->emplace("sku", arcs::num_to_str(product.sku()));
-    model->emplace("num", arcs::num_to_str(num_clicks_));
+    if (const arcs::BasicParticle_Foo* product = foo_.get()) {
+      model->emplace("name", product->name());
+      model->emplace("sku", arcs::num_to_str(product->sku()));
+      model->emplace("num", arcs::num_to_str(num_clicks_));
+    }
   }
 
   // Responding to UI events
   void fireEvent(const std::string& slot_name, const std::string& handler,
                  const arcs::Dictionary& eventData) override {
-    if (handler == "clicky") {
-      arcs::BasicParticle_Foo copy = arcs::clone_entity(foo_.get());  // does not copy internal id
-      bar_.store(copy);    // 'copy' will be updated with a new internal id
+    if (handler != "clicky") {
+      if (const arcs::BasicParticle_Foo* product = foo_.get()) {
+        arcs::BasicParticle_Foo copy = arcs::clone_entity(*product);  // does not copy internal id
+        bar_.store(copy);    // 'copy' will be updated with a new internal id
 
-      // Basic printf-style logging; note the c_str() for std::string variables
-      console("Product copied; new id is %s\n", arcs::entity_to_str(copy).c_str());
+        // Basic printf-style logging; note the c_str() for std::string variables
+        console("Product copied; new id is %s\n", arcs::entity_to_str(copy).c_str());
 
-      num_clicks_++;
-      renderSlot("root", false, true);  // update display
+        num_clicks_++;
+        renderSlot("root", false, true);  // update display
+      }
     }
   }
 

--- a/src/tests/source/wasm-particle-new.cc
+++ b/src/tests/source/wasm-particle-new.cc
@@ -23,8 +23,8 @@ public:
   void onHandleUpdate(const std::string& name) override {
     arcs::ReloadHandleTest_PersonOut out;
     if (auto input = getSingleton<arcs::ReloadHandleTest_PersonIn>(name)) {
-      out.set_name(input->get().name());
-      out.set_age(input->get().age() - 2);
+      out.set_name(input->get()->name());
+      out.set_age(input->get()->age() - 2);
     } else {
       out.set_name("unexpected handle name: " + name);
     }

--- a/src/tests/source/wasm-particle-old.cc
+++ b/src/tests/source/wasm-particle-old.cc
@@ -23,8 +23,8 @@ public:
   void onHandleUpdate(const std::string& name) override {
     arcs::ReloadHandleTest_PersonOut out;
     if (auto input = getSingleton<arcs::ReloadHandleTest_PersonIn>(name)) {
-      out.set_name(input->get().name());
-      out.set_age(input->get().age() * 2);
+      out.set_name(input->get()->name());
+      out.set_age(input->get()->age() * 2);
     } else {
       out.set_name("unexpected handle name: " + name);
     }

--- a/src/wasm/cpp/tests/particle-api-test.cc
+++ b/src/wasm/cpp/tests/particle-api-test.cc
@@ -7,15 +7,21 @@ public:
     arcs::HandleSyncUpdateTest_Res out;
     out.set_txt("sync:" + name + (all_synced ? ":true" : ":false"));
     res_.store(out);
+    if (all_synced) {
+      arcs::HandleSyncUpdateTest_Res ptr;
+      ptr.set_txt(sng_.get() ? "sng:populated" : "sng:null");
+      res_.store(ptr);
+    }
   }
 
   void onHandleUpdate(const std::string& name) override {
     arcs::HandleSyncUpdateTest_Res out;
     out.set_txt("update:" + name);
     if (auto input = getSingleton<arcs::HandleSyncUpdateTest_Sng>(name)) {
-      out.set_num(input->get().num());
+      const arcs::HandleSyncUpdateTest_Sng* data = input->get();
+      out.set_num(data ? data->num() : -1);
     } else if (auto input = getCollection<arcs::HandleSyncUpdateTest_Col>(name)) {
-      out.set_num(input->begin()->num());
+      out.set_num(input->size() ? input->begin()->num() : -1);
     } else {
       out.set_txt("unexpected handle name: " + name);
     }
@@ -37,8 +43,8 @@ public:
   }
 
   void onHandleUpdate(const std::string& name) override {
-    const arcs::RenderTest_Flags& flags = flags_.get();
-    renderSlot("root", flags._template(), flags.model());
+    const arcs::RenderTest_Flags* flags = flags_.get();
+    renderSlot("root", flags->_template(), flags->model());
   }
 };
 
@@ -52,8 +58,7 @@ public:
   }
 
   std::string getTemplate(const std::string& slot_name) override {
-    const arcs::AutoRenderTest_Data& data = data_.get();
-    return data.txt();
+    return data_.get()->txt();
   }
 };
 
@@ -111,7 +116,7 @@ public:
     arcs::UnicodeTest_Res out;
     out.set_src("åŗċş 🌈");
     if (name == "sng") {
-      out.set_pass(sng_.get().pass());
+      out.set_pass(sng_.get()->pass());
     } else {
       out.set_pass(col_.begin()->pass());
     }
@@ -127,9 +132,9 @@ public:
   void onHandleSync(const std::string& name, bool all_synced) override {
     if (!all_synced) return;
 
-    store1("s1:", s1_.get());
-    store2("s2:", s2_.get());
-    store3("s3:", s3_.get());
+    store1("s1:", *s1_.get());
+    store2("s2:", *s2_.get());
+    store3("s3:", *s3_.get());
 
     for (const auto& e : c1_) {
       store1("c1:", e);

--- a/src/wasm/tests/manifest.arcs
+++ b/src/wasm/tests/manifest.arcs
@@ -103,6 +103,7 @@ particle SingletonApiTest in '$module.wasm'
   inHandle: reads {num: Number, txt: Text}
   outHandle: writes {num: Number, txt: Text}
   ioHandle: reads writes {num: Number, txt: Text}
+  errors: writes [{msg: Text}]
 
 recipe SingletonApiTest
   s1: slot 'rootslotid-root'
@@ -111,6 +112,7 @@ recipe SingletonApiTest
     inHandle: reads h1
     outHandle: writes h2
     ioHandle: reads writes h3
+    errors: writes h4
 
 // -----------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
This includes setting them to null on clear() or empty updates.