### PR TITLE
Tweak sigh lint output

### DIFF
--- a/src/runtime/wasm.ts
+++ b/src/runtime/wasm.ts
@@ -677,6 +677,7 @@ export class WasmContainer {
       _collectionClear: (p, h) => this.getParticle(p).collectionClear(h),
       _onRenderOutput: (p, template, model) => this.getParticle(p).onRenderOutput(template, model),
       _dereference: (p, id, key, hash, cid) => this.getParticle(p).dereference(id, key, hash, cid),
+      // tslint:disable-next-line: deprecation
       _render: (p, slot, template, model) => this.getParticle(p).renderImpl(slot, template, model),
       _serviceRequest: (p, call, args, tag) => this.getParticle(p).serviceRequest(call, args, tag),
       _resolveUrl: (url) => this.resolve(url),

--- a/tools/sigh.ts
+++ b/tools/sigh.ts
@@ -487,7 +487,10 @@ function lint(args: string[]): boolean {
   });
   const report = cli.executeOnFiles(jsSources);
   const formatter = cli.getFormatter(options.format || 'stylish');
-  sighLog(formatter(report.results));
+  const output = formatter(report.results);
+  if (output) {
+    sighLog(formatter(report.results));
+  }
 
   if (options.fix) {
     CLIEngine.outputFixes(report);

--- a/tools/sigh.ts
+++ b/tools/sigh.ts
@@ -489,7 +489,7 @@ function lint(args: string[]): boolean {
   const formatter = cli.getFormatter(options.format || 'stylish');
   const output = formatter(report.results);
   if (output) {
-    sighLog(formatter(report.results));
+    sighLog(output);
   }
 
   if (options.fix) {


### PR DESCRIPTION
No blank lint for `lint` and no pointless deprecation warning in wasm.ts