### PR TITLE
Tidy up the BUILD rules in the sdk package

### DIFF
--- a/java/arcs/sdk/BUILD
+++ b/java/arcs/sdk/BUILD
@@ -1,6 +1,8 @@
-load("//third_party/bazel_rules/rules_kotlin/kotlin/native:native_rules.bzl", "kt_native_library")
-load("//third_party/java/arcs/build_defs:build_defs.bzl", "arcs_kt_jvm_library")
-load("//third_party/java/arcs/build_defs/internal:kotlin.bzl", "KOTLINC_OPTS")
+load(
+    "//third_party/java/arcs/build_defs:build_defs.bzl",
+    "arcs_kt_jvm_library",
+    "arcs_kt_native_library",
+)
 
 licenses(["notice"])
 
@@ -12,18 +14,14 @@ arcs_kt_jvm_library(
         "*.kt",
         "jvm/*.kt",
     ]),
-    kotlincopts = KOTLINC_OPTS + ["-Xallow-kotlin-package"],
-    visibility = ["//visibility:public"],
 )
 
-kt_native_library(
+arcs_kt_native_library(
     name = "arcs-wasm",
     srcs = glob([
         "*.kt",
         "wasm/*.kt",
     ]),
-    kotlincopts = KOTLINC_OPTS + ["-Xinline-classes"],
-    visibility = ["//visibility:public"],
 )
 
 # Special package containing wasm srcs for unit testing (on the JVM).
@@ -34,6 +32,4 @@ arcs_kt_jvm_library(
         "wasm/Encoding.kt",
         "jvm/JvmUtils.kt",
     ],
-    kotlincopts = KOTLINC_OPTS + ["-Xallow-kotlin-package"],
-    visibility = ["//visibility:public"],
 )

--- a/third_party/java/arcs/build_defs/build_defs.bzl
+++ b/third_party/java/arcs/build_defs/build_defs.bzl
@@ -6,6 +6,7 @@ load(
     _arcs_kt_jvm_library = "arcs_kt_jvm_library",
     _arcs_kt_jvm_test_suite = "arcs_kt_jvm_test_suite",
     _arcs_kt_library = "arcs_kt_library",
+    _arcs_kt_native_library = "arcs_kt_native_library",
     _arcs_kt_particles = "arcs_kt_particles",
     _kt_jvm_and_js_library = "kt_jvm_and_js_library",
 )
@@ -32,6 +33,8 @@ arcs_kt_jvm_test_suite = _arcs_kt_jvm_test_suite
 arcs_kt_schema = _arcs_kt_schema
 
 arcs_kt_library = _arcs_kt_library
+
+arcs_kt_native_library = _arcs_kt_native_library
 
 arcs_kt_particles = _arcs_kt_particles
 

--- a/third_party/java/arcs/build_defs/internal/kotlin.bzl
+++ b/third_party/java/arcs/build_defs/internal/kotlin.bzl
@@ -54,8 +54,8 @@ DISABLED_LINT_CHECKS = [
 
 def _merge_lists(*lists):
     result = {}
-    for l in lists:
-        for elem in l:
+    for x in lists:
+        for elem in x:
             result[elem] = 1
     return result.keys()
 

--- a/third_party/java/arcs/build_defs/internal/kotlin.bzl
+++ b/third_party/java/arcs/build_defs/internal/kotlin.bzl
@@ -62,8 +62,6 @@ def _merge_lists(*lists):
 def arcs_kt_jvm_library(**kwargs):
     """Wrapper around kt_jvm_library for Arcs.
 
-    Provides a bunch of default arguments.
-
     Args:
       **kwargs: Set of args to forward to kt_jvm_library
     """
@@ -79,8 +77,6 @@ def arcs_kt_jvm_library(**kwargs):
 
 def arcs_kt_native_library(**kwargs):
     """Wrapper around kt_native_library for Arcs.
-
-    Provides a bunch of default arguments.
 
     Args:
       **kwargs: Set of args to forward to kt_native_library


### PR DESCRIPTION
by moving all the kotlincopts into the standard bzl file