### PR TITLE
Fix script exec permission on Docker

### DIFF
--- a/tools/Dockerfile.CI
+++ b/tools/Dockerfile.CI
@@ -50,10 +50,14 @@ RUN mkdir -p $ANDROID_HOME/licenses/ && \
 ADD ./tools/android-sdk-packages.txt /sdk
 RUN mkdir -p /root/.android && \
   touch /root/.android/repositories.cfg && \
-  ${ANDROID_HOME}/tools/bin/sdkmanager --update 
+  ${ANDROID_HOME}/tools/bin/sdkmanager --update
 RUN while read -r package; do PACKAGES="${PACKAGES}${package} "; done < /sdk/android-sdk-packages.txt && \
     ${ANDROID_HOME}/tools/bin/sdkmanager ${PACKAGES}
 RUN yes | ${ANDROID_HOME}/tools/bin/sdkmanager --licenses
+
+# Allows running script with privileged permission
+# i.e. scripts {...} at package.json
+RUN npm set unsafe-perm true
 
 # Install Project
 COPY package.json $WORKSPACE/package.json

--- a/tools/npm-install-all
+++ b/tools/npm-install-all
@@ -6,7 +6,9 @@
 
 # Use find to look for all package.json files. Exclude node_modules and deps
 # folders.
+# Use --unsafe-perm to allow running scripts with privileged permission
+# during executing "scripts {...}" at package.json.
 for f in $(find \( -name deps -o -name node_modules \) -prune \
            -o -type f -name package.json -print); do
-  (cd $(dirname "$f") && npm install)
+  (cd $(dirname "$f") && npm install --unsafe-perm)
 done


### PR DESCRIPTION
To resolve the issue shown at Travis log:
"npm WARN lifecycle arcs@0.0.0~prepare: cannot run in wd arcs@0.0.0 cross-env tools/sigh check && cd devtools && npm i && cd ../concrete-storage && npm i (wd=/usr/src/app)
"

