### PR TITLE
Disable npm cache on Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ jobs:
 # This connects to the docker container via a volume mount (`-v /home/travis/disk-cache:/disk-cache/`).
 # Bazel will store artifacts here due to the `--disk_cache=/disk-cache/` argument.
 cache:
-  npm: true
+  npm: false
 
 # Pulling container from https://hub.docker.com/repository/docker/arcproject/travis-build
 before_install:


### PR DESCRIPTION
It's not 100% clear what this will do w.r.t. our setup -- our Travis config is using a Bazel disk cache via docker per #4008, and there's a comment that the npm cache was tied to that, but it's confusing because Bazel caching seems like it should be separate from npm caching, and Travis docs just talk about the simpler non-docker not-Bazel-related caching.

Will our docker image/instance/disk still have npm modules cached from prior builds even after this change, for some reason? I cannot say.