### PR TITLE
Don't fail linking files in case of racing builds

### DIFF
--- a/tools/sigh.ts
+++ b/tools/sigh.ts
@@ -417,9 +417,9 @@ function makeLink(src: string, dest: string): boolean {
   } catch (lerr) {
     // In case of racing builds.
     if (lerr.message.startsWith('EEXIST:')) {
-      console.warn(`Warn linking ${src} to ${dest} ${lerr.message}`);
+      console.warn(`Warning when linking ${src} to ${dest}: ${lerr.message}`);
     } else {
-      console.error(`Error linking ${src} to ${dest} ${lerr.message}`);
+      console.error(`Error when linking ${src} to ${dest}: ${lerr.message}`);
       return false;
     }
   }

--- a/tools/sigh.ts
+++ b/tools/sigh.ts
@@ -415,8 +415,11 @@ function makeLink(src: string, dest: string): boolean {
     }
     fs.linkSync(src, dest);
   } catch (lerr) {
-    console.error(`Error linking ${src} to ${dest} ${lerr.message}`);
-    return false;
+    // In case of racing builds.
+    if (!lerr.message.startsWith('EEXIST:')) {
+      console.error(`Error linking ${src} to ${dest} ${lerr.message}`);
+      return false;
+    }
   }
   return true;
 }

--- a/tools/sigh.ts
+++ b/tools/sigh.ts
@@ -416,7 +416,9 @@ function makeLink(src: string, dest: string): boolean {
     fs.linkSync(src, dest);
   } catch (lerr) {
     // In case of racing builds.
-    if (!lerr.message.startsWith('EEXIST:')) {
+    if (lerr.message.startsWith('EEXIST:')) {
+      console.warn(`Warn linking ${src} to ${dest} ${lerr.message}`);
+    } else {
       console.error(`Error linking ${src} to ${dest} ${lerr.message}`);
       return false;
     }


### PR DESCRIPTION
Seems this happens more frequently than I thought (multiple/lots of times a day...)
i.e. the recent failure
https://travis-ci.org/PolymerLabs/arcs/jobs/638042883

Create the PR to save work time, otherwise devs need to restart their Travis build/test upon link errors.

Fixed #4465 