### PR TITLE
Add type parameters to DirectStore and BackingStore

### DIFF
--- a/java/arcs/core/storage/ReferenceModeStore.kt
+++ b/java/arcs/core/storage/ReferenceModeStore.kt
@@ -74,9 +74,9 @@ import kotlinx.coroutines.Job
 class ReferenceModeStore private constructor(
     options: StoreOptions<RefModeStoreData, RefModeStoreOp, RefModeStoreOutput>,
     /* internal */
-    val backingStore: BackingStore,
+    val backingStore: BackingStore<CrdtData, CrdtOperation, Any?>,
     /* internal */
-    val containerStore: DirectStore
+    val containerStore: DirectStore<CrdtData, CrdtOperation, Any?>
 ) : ActiveStore<RefModeStoreData, RefModeStoreOp, RefModeStoreOutput>(options) {
     /**
      * A queue of incoming updates from the backing store, container store, and connected proxies.
@@ -605,7 +605,7 @@ class ReferenceModeStore private constructor(
                     mode = StorageMode.Backing,
                     baseStore = options.baseStore
                 )
-            ) as BackingStore
+            ) as BackingStore<CrdtData, CrdtOperation, Any?>
             val containerStore = DirectStore.CONSTRUCTOR(
                 StoreOptions(
                     storageKey = storageKey.storageKey,
@@ -614,7 +614,7 @@ class ReferenceModeStore private constructor(
                     baseStore = options.baseStore,
                     versionToken = options.versionToken
                 )
-            ) as DirectStore
+            ) as DirectStore<CrdtData, CrdtOperation, Any?>
 
             ReferenceModeStore(refableOptions, backingStore, containerStore).apply {
                 registerStoreCallbacks()

--- a/javatests/arcs/core/storage/RamDiskBackingStoreIntegrationTest.kt
+++ b/javatests/arcs/core/storage/RamDiskBackingStoreIntegrationTest.kt
@@ -60,7 +60,7 @@ class RamDiskBackingStoreIntegrationTest {
                 storageKey, ExistenceCriteria.ShouldCreate, CountType(), StorageMode.Backing
             )
         )
-        val store = baseStore.activate() as BackingStore
+        val store = baseStore.activate() as BackingStore<CrdtData, CrdtOperation, Any?>
 
         val count1 = CrdtCount()
         count1.applyOperation(Increment("me", version = 0 to 1))

--- a/javatests/arcs/core/storage/RamDiskStoreIntegrationTest.kt
+++ b/javatests/arcs/core/storage/RamDiskStoreIntegrationTest.kt
@@ -14,6 +14,8 @@ package arcs.core.storage
 import arcs.core.crdt.CrdtCount
 import arcs.core.crdt.CrdtCount.Operation.Increment
 import arcs.core.crdt.CrdtCount.Operation.MultiIncrement
+import arcs.core.crdt.CrdtData
+import arcs.core.crdt.CrdtOperation
 import arcs.core.data.CountType
 import arcs.core.storage.ProxyMessage.ModelUpdate
 import arcs.core.storage.ProxyMessage.Operations
@@ -58,7 +60,7 @@ class RamDiskStoreIntegrationTest {
     fun stores_sequenceOfModelAndOperationUpdates_asModels() = runBlockingTest {
         val storageKey = RamDiskStorageKey("unique")
         val store = createStore(storageKey, ExistenceCriteria.ShouldCreate)
-        val activeStore = store.activate() as DirectStore
+        val activeStore = store.activate()
 
         val count = CrdtCount()
         count.applyOperation(MultiIncrement(actor = "me", version = 0 to 27, delta = 42))
@@ -97,9 +99,9 @@ class RamDiskStoreIntegrationTest {
     fun stores_operationUpdates_fromMultipleSources() = runBlockingTest {
         val storageKey = RamDiskStorageKey("unique")
         val store1 = createStore(storageKey, ExistenceCriteria.ShouldCreate)
-        val activeStore1 = store1.activate() as DirectStore
+        val activeStore1 = store1.activate()
         val store2 = createStore(storageKey, ExistenceCriteria.ShouldExist)
-        val activeStore2 = store2.activate() as DirectStore
+        val activeStore2 = store2.activate()
 
         val count1 = CrdtCount()
         count1.applyOperation(MultiIncrement("me", version = 0 to 27, delta = 42))
@@ -170,12 +172,13 @@ class RamDiskStoreIntegrationTest {
     }
 
     @Test
+    @Suppress("UNCHECKED_CAST")
     fun store_operationUpdates_fromMultipleSources_withTimingDelays() = runBlockingTest {
         val storageKey = RamDiskStorageKey("unique")
         val store1 = createStore(storageKey, ExistenceCriteria.ShouldCreate)
-        val activeStore1 = store1.activate() as DirectStore
+        val activeStore1 = store1.activate() as DirectStore<CrdtData, CrdtOperation, Any>
         val store2 = createStore(storageKey, ExistenceCriteria.ShouldExist)
-        val activeStore2 = store2.activate() as DirectStore
+        val activeStore2 = store2.activate() as DirectStore<CrdtData, CrdtOperation, Any>
 
         assertThat(
             activeStore1.onProxyMessage(Operations(listOf(Increment("me", 0 to 1)), 1))

--- a/javatests/arcs/core/storage/ReferenceModeStoreTest.kt
+++ b/javatests/arcs/core/storage/ReferenceModeStoreTest.kt
@@ -13,8 +13,10 @@ package arcs.core.storage
 
 import arcs.core.common.ReferenceId
 import arcs.core.crdt.CrdtCount
+import arcs.core.crdt.CrdtData
 import arcs.core.crdt.CrdtEntity
 import arcs.core.crdt.CrdtException
+import arcs.core.crdt.CrdtOperation
 import arcs.core.crdt.CrdtSet
 import arcs.core.crdt.internal.VersionMap
 import arcs.core.data.CollectionType
@@ -580,7 +582,7 @@ class ReferenceModeStoreTest {
 
     // region Helpers
 
-    private fun BackingStore.getEntityDriver(id: ReferenceId): MockDriver<CrdtEntity.Data> =
+    private fun BackingStore<CrdtData, CrdtOperation, Any?>.getEntityDriver(id: ReferenceId): MockDriver<CrdtEntity.Data> =
         requireNotNull(stores[id]).store.driver as MockDriver<CrdtEntity.Data>
 
     private suspend fun createReferenceModeStore(): ReferenceModeStore {

--- a/javatests/arcs/core/storage/StoreTest.kt
+++ b/javatests/arcs/core/storage/StoreTest.kt
@@ -74,7 +74,7 @@ class StoreTest {
         val (driver, _) = setupMocks()
 
         val store = createStore()
-        val activeStore = store.activate() as DirectStore
+        val activeStore = store.activate() as DirectStore<CrdtData, CrdtOperation, Any?>
 
         val modelCaptor = argumentCaptor<CrdtCount.Data>()
         whenever(driver.send(modelCaptor.capture(), any())).thenReturn(true)
@@ -93,7 +93,7 @@ class StoreTest {
         val (driver, _) = setupMocks()
 
         val store = createStore()
-        val activeStore = store.activate() as DirectStore
+        val activeStore = store.activate() as DirectStore<CrdtData, CrdtOperation, Any?>
 
         val modelCaptor = argumentCaptor<CrdtCount.Data>()
         whenever(driver.send(modelCaptor.capture(), any())).thenReturn(true)
@@ -113,7 +113,7 @@ class StoreTest {
         val (driver, _) = setupMocks()
 
         val store = createStore()
-        val activeStore = store.activate() as DirectStore
+        val activeStore = store.activate() as DirectStore<CrdtData, CrdtOperation, Any?>
 
         whenever(driver.send(any(), any())).thenReturn(true)
 
@@ -302,7 +302,7 @@ class StoreTest {
         whenever(driver.registerReceiver(anyOrNull(), receiverCaptor.capture())).thenReturn(Unit)
         whenever(driver.send(driverModelCaptor.capture(), any())).thenReturn(true)
 
-        val activeStore = createStore().activate() as DirectStore
+        val activeStore = createStore().activate() as DirectStore<CrdtData, CrdtOperation, Any?>
 
         activeStore.onProxyMessage(ProxyMessage.Operations(listOf(Increment("me", 0 to 1)), id = 1))
         activeStore.onProxyMessage(ProxyMessage.Operations(listOf(Increment("me", 1 to 2)), id = 1))


### PR DESCRIPTION
Two core changes:
* Add type parameters to DirectStore
* Add type parameters to BackingStore

The rest of the changes are just adapting to these types requiring
parameters now.

Practically, this is not increasing the type safety yet. But it's a step
down that path. Whether or not it's worth continuing down this path is
up for debate.

Areas specifically avoided for now:
* adding ReferenceModeStore type parameters
* type safe construction patterns