### PR TITLE
Use consistent argument order for CRDT operation ctors

### DIFF
--- a/java/arcs/android/crdt/ParcelableCrdtSet.kt
+++ b/java/arcs/android/crdt/ParcelableCrdtSet.kt
@@ -120,7 +120,7 @@ object ParcelableCrdtSet {
                         }
                     val actor = requireNotNull(parcel.readString())
                     val added = requireNotNull(parcel.readReferencable())
-                    return Add(CrdtSet.Operation.Add(clock, actor, added))
+                    return Add(CrdtSet.Operation.Add(actor, clock, added))
                 }
 
                 override fun newArray(size: Int): Array<Add?> = arrayOfNulls(size)
@@ -149,7 +149,7 @@ object ParcelableCrdtSet {
                         }
                     val actor = requireNotNull(parcel.readString())
                     val removed = requireNotNull(parcel.readReferencable())
-                    return Remove(CrdtSet.Operation.Remove(clock, actor, removed))
+                    return Remove(CrdtSet.Operation.Remove(actor, clock, removed))
                 }
 
                 override fun newArray(size: Int): Array<Remove?> = arrayOfNulls(size)

--- a/java/arcs/core/crdt/CrdtEntity.kt
+++ b/java/arcs/core/crdt/CrdtEntity.kt
@@ -323,7 +323,7 @@ class CrdtEntity(
             /**
              * Converts the [CrdtEntity.Operation] into its corresponding [CrdtSet.Operation].
              */
-            fun toSetOp(): SetOp.Add<Reference> = CrdtSet.Operation.Add(clock, actor, added)
+            fun toSetOp(): SetOp.Add<Reference> = CrdtSet.Operation.Add(actor, clock, added)
         }
 
         /**
@@ -339,7 +339,7 @@ class CrdtEntity(
             /**
              * Converts the [CrdtEntity.Operation] into its corresponding [CrdtSet.Operation].
              */
-            fun toSetOp(): SetOp.Remove<Reference> = CrdtSet.Operation.Remove(clock, actor, removed)
+            fun toSetOp(): SetOp.Remove<Reference> = CrdtSet.Operation.Remove(actor, clock, removed)
         }
     }
 }

--- a/java/arcs/core/crdt/CrdtSet.kt
+++ b/java/arcs/core/crdt/CrdtSet.kt
@@ -160,8 +160,8 @@ class CrdtSet<T : Referencable>(
          * operation could be applied.
          */
         open class Add<T : Referencable>(
-            override val clock: VersionMap,
             val actor: Actor,
+            override val clock: VersionMap,
             val added: T
         ) : Operation<T>() {
             override fun applyTo(data: Data<T>, isDryRun: Boolean): Boolean {
@@ -190,8 +190,8 @@ class CrdtSet<T : Referencable>(
 
         /** Represents the removal of an item from a [CrdtSet]. */
         open class Remove<T : Referencable>(
-            override val clock: VersionMap,
             val actor: Actor,
+            override val clock: VersionMap,
             val removed: T
         ) : Operation<T>() {
             override fun applyTo(data: Data<T>, isDryRun: Boolean): Boolean {
@@ -302,7 +302,7 @@ class CrdtSet<T : Referencable>(
                 // for the actor, we can't simplify.
                 if (expectedClock != newClock) return listOf(this)
 
-                return added.map { Add(it.versionMap, actor, it.value) }
+                return added.map { Add(actor, it.versionMap, it.value) }
             }
         }
     }

--- a/java/arcs/core/crdt/CrdtSingleton.kt
+++ b/java/arcs/core/crdt/CrdtSingleton.kt
@@ -133,7 +133,7 @@ class CrdtSingleton<T : Referencable>(
                 if (!Clear<T>(actor, removeClock).applyTo(set)) return false
 
                 // After removal of all existing values, we simply need to add the new value.
-                return set.applyOperation(Add(clock, actor, value))
+                return set.applyOperation(Add(actor, clock, value))
             }
 
             override fun equals(other: Any?): Boolean =
@@ -156,7 +156,7 @@ class CrdtSingleton<T : Referencable>(
                 // Clear all existing values if our clock allows it.
 
                 val removeOps = set.data.values
-                    .map { (_, value) -> Remove(clock, actor, value.value) }
+                    .map { (_, value) -> Remove(actor, clock, value.value) }
 
                 removeOps.forEach { set.applyOperation(it) }
                 return true

--- a/java/arcs/core/storage/api/ArcsSet.kt
+++ b/java/arcs/core/storage/api/ArcsSet.kt
@@ -325,7 +325,7 @@ class ArcsSet<T, StoreData, StoreOp>(
      */
     private fun makeAddOp(element: T): Add<T> {
         cachedVersion[actor]++
-        return Add(cachedVersion.copy(), actor, element)
+        return Add(actor, cachedVersion.copy(), element)
     }
 
     /**
@@ -334,7 +334,7 @@ class ArcsSet<T, StoreData, StoreOp>(
      * **Note:** Must be called from within a lock of [crdtMutex].
      */
     private fun makeRemoveOp(element: T): Remove<T> {
-        return Remove(cachedVersion.copy(), actor, element)
+        return Remove(actor, cachedVersion.copy(), element)
     }
 
     private suspend fun applyOperationToStore(op: CrdtSet.Operation<T>): Boolean =

--- a/java/arcs/core/storage/referencemode/BridgingOperation.kt
+++ b/java/arcs/core/storage/referencemode/BridgingOperation.kt
@@ -123,11 +123,11 @@ fun RefModeStoreOp.toBridgingOp(storageKey: StorageKey): BridgingOperation = whe
     }
     is RefModeStoreOp.SetAdd -> {
         val reference = added.toReference(storageKey, clock)
-        AddToSet(added, reference, CrdtSet.Operation.Add(clock, actor, reference), this)
+        AddToSet(added, reference, CrdtSet.Operation.Add(actor, clock, reference), this)
     }
     is RefModeStoreOp.SetRemove -> {
         val reference = removed.toReference(storageKey, clock)
-        RemoveFromSet(removed, reference, CrdtSet.Operation.Remove(clock, actor, reference), this)
+        RemoveFromSet(removed, reference, CrdtSet.Operation.Remove(actor, clock, reference), this)
     }
     else -> throw CrdtException("Unsupported operation: $this")
 }

--- a/java/arcs/core/storage/referencemode/Message.kt
+++ b/java/arcs/core/storage/referencemode/Message.kt
@@ -132,9 +132,9 @@ private fun List<CrdtOperation>.toReferenceModeMessageOps(): List<CrdtOperationA
             is CrdtSingleton.Operation.Clear<*> ->
                 CrdtSingleton.Operation.Clear<Referencable>(op.actor, op.clock)
             is CrdtSet.Operation.Add<*> ->
-                CrdtSet.Operation.Add(op.clock, op.actor, op.added)
+                CrdtSet.Operation.Add(op.actor, op.clock, op.added)
             is CrdtSet.Operation.Remove<*> ->
-                CrdtSet.Operation.Add(op.clock, op.actor, op.removed)
+                CrdtSet.Operation.Add(op.actor, op.clock, op.removed)
             else -> throw CrdtException("Unsupported operation for ReferenceModeStore: $this")
         }
     }

--- a/java/arcs/core/storage/referencemode/RefModeCrdtTypes.kt
+++ b/java/arcs/core/storage/referencemode/RefModeCrdtTypes.kt
@@ -96,14 +96,14 @@ interface RefModeStoreOp : CrdtOperationAtTime {
     class SetAdd(actor: Actor, clock: VersionMap, added: RawEntity) :
         Set,
         RefModeSet,
-        CrdtSet.Operation.Add<RawEntity>(clock, actor, added) {
+        CrdtSet.Operation.Add<RawEntity>(actor, clock, added) {
         constructor(setOp: Add<RawEntity>) : this(setOp.actor, setOp.clock, setOp.added)
     }
 
     class SetRemove(actor: Actor, clock: VersionMap, removed: RawEntity) :
         Set,
         RefModeSet,
-        CrdtSet.Operation.Remove<RawEntity>(clock, actor, removed) {
+        CrdtSet.Operation.Remove<RawEntity>(actor, clock, removed) {
         constructor(setOp: Remove<RawEntity>) : this(setOp.actor, setOp.clock, setOp.removed)
     }
 }

--- a/java/arcs/sdk/android/dev/api/CollectionProxy.java
+++ b/java/arcs/sdk/android/dev/api/CollectionProxy.java
@@ -174,8 +174,8 @@ class CollectionProxy extends StorageProxy implements CollectionStore {
       ModelEntry entry = vv.getValue();
       if (model.applyOperation(
           new CrdtSet.Operation.Remove<>(
-            item.getObject("keys").getString(0),
-            vv.getVersionMap(),
+              item.getObject("keys").getString(0),
+              vv.getVersionMap(),
               entry))) {
         removedItems.put(
             removedItems.getLength(), item.put("rawData", entry.value.value.getObject("rawData")));

--- a/java/arcs/sdk/android/dev/api/CollectionProxy.java
+++ b/java/arcs/sdk/android/dev/api/CollectionProxy.java
@@ -81,7 +81,7 @@ class CollectionProxy extends StorageProxy implements CollectionStore {
         boolean effective = remove.getBool("effective");
         if ((apply
                 && model.applyOperation(
-                    new CrdtSet.Operation.Remove<>(vv.getVersionMap(), actor, entry)))
+                    new CrdtSet.Operation.Remove<>(actor, vv.getVersionMap(), entry)))
             || (!apply && effective)) {
           removed.put(removed.getLength(), entry.value.value);
         }
@@ -174,8 +174,8 @@ class CollectionProxy extends StorageProxy implements CollectionStore {
       ModelEntry entry = vv.getValue();
       if (model.applyOperation(
           new CrdtSet.Operation.Remove<>(
-              vv.getVersionMap(),
-              item.getObject("keys").getString(0),
+            item.getObject("keys").getString(0),
+            vv.getVersionMap(),
               entry))) {
         removedItems.put(
             removedItems.getLength(), item.put("rawData", entry.value.value.getObject("rawData")));
@@ -216,7 +216,7 @@ class CollectionProxy extends StorageProxy implements CollectionStore {
     port.handleRemove(this, (unused) -> {}, data, particleId);
 
     if (!model.applyOperation(
-        new CrdtSet.Operation.Remove<>(vv.getVersionMap(), /* actor= */"", entry))) {
+        new CrdtSet.Operation.Remove<>(/* actor = */ "", vv.getVersionMap(), entry))) {
       return;
     }
     PortableJson update =
@@ -244,8 +244,8 @@ class CollectionProxy extends StorageProxy implements CollectionStore {
     int itemVersion = modelVersion.get(keys.get(0)) + 1;
     //noinspection unchecked
     return new CrdtSet.Operation.Add<>(
-        new VersionMap(keys.get(0), itemVersion),
         keys.get(0),
+        new VersionMap(keys.get(0), itemVersion),
         new ModelEntry(value.getString("id"), value, keys));
   }
 

--- a/javatests/arcs/android/crdt/ParcelableCrdtSetTest.kt
+++ b/javatests/arcs/android/crdt/ParcelableCrdtSetTest.kt
@@ -66,7 +66,7 @@ class ParcelableCrdtSetTest {
 
     @Test
     fun operationAdd_parcelableRoundTrip_works() {
-        val op = CrdtSet.Operation.Add(versionMap, "alice", entity1)
+        val op = CrdtSet.Operation.Add("alice", versionMap, entity1)
 
         val marshalled = with(Parcel.obtain()) {
             writeTypedObject(op.toParcelable(), 0)
@@ -83,7 +83,7 @@ class ParcelableCrdtSetTest {
 
     @Test
     fun operationRemove_parcelableRoundTrip_works() {
-        val op = CrdtSet.Operation.Remove(versionMap, "alice", entity1)
+        val op = CrdtSet.Operation.Remove("alice", versionMap, entity1)
 
         val marshalled = with(Parcel.obtain()) {
             writeTypedObject(op.toParcelable(), 0)

--- a/javatests/arcs/core/crdt/CrdtSetTest.kt
+++ b/javatests/arcs/core/crdt/CrdtSetTest.kt
@@ -531,11 +531,11 @@ class CrdtSetTest {
 
     /** Pseudo-constructor for [CrdtSet.Operation.Add]. */
     private fun Add(actor: Actor, versions: VersionMap, id: ReferenceId) =
-        CrdtSet.Operation.Add(versions, actor, Reference(id))
+        CrdtSet.Operation.Add(actor, versions, Reference(id))
 
     /** Pseudo-constructor for [CrdtSet.Operation.Remove]. */
     private fun Remove(actor: Actor, versions: VersionMap, id: ReferenceId) =
-        CrdtSet.Operation.Remove(versions, actor, Reference(id))
+        CrdtSet.Operation.Remove(actor, versions, Reference(id))
 
     private fun CrdtSet<Reference>.add(
         actor: Actor,

--- a/javatests/arcs/core/storage/ReferenceModeStoreTest.kt
+++ b/javatests/arcs/core/storage/ReferenceModeStoreTest.kt
@@ -117,7 +117,7 @@ class ReferenceModeStoreTest {
         val collection = CrdtSet<RawEntity>()
         val entity = createPersonEntity("an-id", "bob", 42)
         collection.applyOperation(
-            CrdtSet.Operation.Add(VersionMap("me" to 1), "me", entity)
+            CrdtSet.Operation.Add("me", VersionMap("me" to 1), entity)
         )
 
         assertThat(
@@ -166,7 +166,7 @@ class ReferenceModeStoreTest {
         val collection = CrdtSet<RawEntity>()
         val entity = createPersonEntity("an-id", "bob", 42)
         collection.applyOperation(
-            CrdtSet.Operation.Add(VersionMap("me" to 1), "me", entity)
+            CrdtSet.Operation.Add("me", VersionMap("me" to 1), entity)
         )
         activeStore.onProxyMessage(
             ProxyMessage.ModelUpdate(RefModeStoreData.Set(collection.data), 1)
@@ -189,7 +189,7 @@ class ReferenceModeStoreTest {
 
         val personCollection = CrdtSet<RawEntity>()
         val bob = createPersonEntity("an-id", "bob", 42)
-        val operation = CrdtSet.Operation.Add(VersionMap("me" to 1), "me", bob)
+        val operation = CrdtSet.Operation.Add("me", VersionMap("me" to 1), bob)
 
         val referenceCollection = CrdtSet<Reference>()
         val bobRef = Reference(
@@ -197,7 +197,7 @@ class ReferenceModeStoreTest {
             activeStore.backingStore.storageKey,
             VersionMap(actor to 1)
         )
-        val refOperation = CrdtSet.Operation.Add(VersionMap(actor to 1), actor, bobRef)
+        val refOperation = CrdtSet.Operation.Add(actor, VersionMap(actor to 1), bobRef)
 
         val bobEntity = createPersonEntityCrdt()
 
@@ -260,7 +260,7 @@ class ReferenceModeStoreTest {
 
         val entityCollection = CrdtSet<RawEntity>()
         val bob = createPersonEntity("an-id", "bob", 42)
-        entityCollection.applyOperation(CrdtSet.Operation.Add(VersionMap("me" to 1), "me", bob))
+        entityCollection.applyOperation(CrdtSet.Operation.Add("me", VersionMap("me" to 1), bob))
 
         var sentSyncRequest = false
         val job = Job(coroutineContext[Job.Key])
@@ -327,12 +327,12 @@ class ReferenceModeStoreTest {
 
         val bobCollection = CrdtSet<RawEntity>()
         val bob = createPersonEntity("an-id", "bob", 42)
-        bobCollection.applyOperation(CrdtSet.Operation.Add(VersionMap("me" to 1), "me", bob))
+        bobCollection.applyOperation(CrdtSet.Operation.Add("me", VersionMap("me" to 1), bob))
 
         val referenceCollection = CrdtSet<Reference>()
         val bobRef = bob.toReference(activeStore.backingStore.storageKey, VersionMap("me" to 1))
         referenceCollection.applyOperation(
-            CrdtSet.Operation.Add(VersionMap("me" to 1), "me", bobRef)
+            CrdtSet.Operation.Add("me", VersionMap("me" to 1), bobRef)
         )
 
         val bobCrdt = createPersonEntityCrdt()
@@ -384,7 +384,7 @@ class ReferenceModeStoreTest {
         val referenceCollection = CrdtSet<Reference>()
         val reference = Reference("an-id", MockHierarchicalStorageKey(), VersionMap("me" to 1))
         referenceCollection.applyOperation(
-            CrdtSet.Operation.Add(VersionMap("me" to 1), "me", reference)
+            CrdtSet.Operation.Add("me", VersionMap("me" to 1), reference)
         )
 
         val driver = activeStore.containerStore.driver as MockDriver<CrdtSet.Data<Reference>>
@@ -403,14 +403,14 @@ class ReferenceModeStoreTest {
         // local model from proxy.
         val bobCollection = CrdtSet<RawEntity>()
         val bob = createPersonEntity("an-id", "bob", 42)
-        bobCollection.applyOperation(CrdtSet.Operation.Add(VersionMap("me" to 1), "me", bob))
+        bobCollection.applyOperation( CrdtSet.Operation.Add("me", VersionMap("me" to 1), bob))
 
         // conflicting remote count from store
         val remoteCollection = CrdtSet<Reference>()
         val reference =
             Reference("another-id", MockHierarchicalStorageKey(), VersionMap("them" to 1))
         remoteCollection.applyOperation(
-            CrdtSet.Operation.Add(VersionMap("them" to 1), "them", reference)
+            CrdtSet.Operation.Add("them", VersionMap("them" to 1), reference)
         )
 
         // Ensure remote entity is stored in backing store.
@@ -436,7 +436,7 @@ class ReferenceModeStoreTest {
 
         val actor = activeStore.crdtKey
         val ref2 = Reference("an-id", MockHierarchicalStorageKey(), VersionMap(actor to 1))
-        remoteCollection.applyOperation(CrdtSet.Operation.Add(VersionMap("me" to 1), "me", ref2))
+        remoteCollection.applyOperation(CrdtSet.Operation.Add("me", VersionMap("me" to 1), ref2))
         assertThat(driver.sentData.last()).isEqualTo(remoteCollection.data)
     }
 
@@ -521,7 +521,7 @@ class ReferenceModeStoreTest {
 
         val referenceCollection = CrdtSet<Reference>()
         val ref = Reference("an-id", MockHierarchicalStorageKey(), VersionMap(actor to 1))
-        referenceCollection.applyOperation(CrdtSet.Operation.Add(VersionMap("me" to 1), "me", ref))
+        referenceCollection.applyOperation(CrdtSet.Operation.Add("me", VersionMap("me" to 1), ref))
 
         val job = Job(coroutineContext[Job.Key])
         var backingStoreSent = false


### PR DESCRIPTION
Most were (actor, clock, [, T]), but set was (clock, actor, [, T]). This
PR swaps the order of the constructor arguments for CrdtSet operations
so that they match the others. (Having actor first feels reasonable to
me)