### PR TITLE
Arcs worker pool runtime settings

### DIFF
--- a/java/arcs/sdk/android/dev/api/RuntimeSettings.java
+++ b/java/arcs/sdk/android/dev/api/RuntimeSettings.java
@@ -39,4 +39,26 @@ public interface RuntimeSettings {
   // Options not listed above would be skipped, namely trace messages are
   // neither generated nor bridged.
   String systemTraceChannel();
+
+  // Used only by Javascript-based Arcs runtime to create a worker pool which
+  // spins up workers ahead of time and also supports to suspend workers then
+  // resumes later (aka resurrecting workers) to prevent spin-up overhead.
+  boolean useWorkerPool();
+
+  // Used together with the setting {@link #useWorkerPool()} to supply additional
+  // worker pool configurations. Options are separated by commas.
+  // Available options:
+  //   'nosuspend': only create new workers ahead of time (no resurrecting workers)
+  String workerPoolOptions();
+
+  // Used only by Javascript-based Arcs runtime to determine and adjust size of
+  // worker pool dynamically. The option is effective when {@link #useWorkerPool()}
+  // is enabled.
+  // Available policies:
+  //   'conservative': keep as small-and-constant pool size as possible
+  //   'aggressive': maintain bigger spare room, eager to fulfill worker demands
+  //                 anytime if possible
+  //   'predictive': foresee worker demands in accordance of current demand and
+  //                 historical stats
+  String sizingPolicy();
 }

--- a/java/arcs/sdk/android/dev/api/RuntimeSettings.java
+++ b/java/arcs/sdk/android/dev/api/RuntimeSettings.java
@@ -60,5 +60,6 @@ public interface RuntimeSettings {
   //                 anytime if possible
   //   'predictive': foresee worker demands in accordance of current demand and
   //                 historical stats
+  // Default: conservative
   String sizingPolicy();
 }

--- a/java/arcs/sdk/android/dev/api/RuntimeSettings.java
+++ b/java/arcs/sdk/android/dev/api/RuntimeSettings.java
@@ -60,6 +60,8 @@ public interface RuntimeSettings {
   //                 anytime if possible
   //   'predictive': foresee worker demands in accordance of current demand and
   //                 historical stats
-  // Default: conservative
+  //   'default': the default policy auto-selected by Arcs runtime which is
+  //              'conservative'.
+  // If none or an unknown policy is specified, go with 'default'.
   String sizingPolicy();
 }

--- a/java/arcs/sdk/android/dev/service/AndroidArcsEnvironment.java
+++ b/java/arcs/sdk/android/dev/service/AndroidArcsEnvironment.java
@@ -163,6 +163,10 @@ final class AndroidArcsEnvironment {
       url += "&use-cache";
     }
     url += "&systrace=" + settings.systemTraceChannel();
+    if (settings.useWorkerPool()) {
+      url += "&use-worker-pool=" + settings.workerPoolOptions();
+      url += "&sizing-policy=" + settings.sizingPolicy();
+    }
 
     Log.i("Arcs", "runtime url: " + url);
     webView.loadUrl(url);

--- a/java/arcs/sdk/android/dev/service/AndroidRuntimeSettings.java
+++ b/java/arcs/sdk/android/dev/service/AndroidRuntimeSettings.java
@@ -27,6 +27,16 @@ public final class AndroidRuntimeSettings implements RuntimeSettings {
   private static final String USE_CACHE_MANAGER_PROPERTY = "debug.arcs.runtime.use_cache_mgr";
   // Equivalent to &systrace parameter
   private static final String SYSTEM_TRACE_CHANNEL_PROPERTY = "debug.arcs.runtime.systrace";
+  // Whether to use worker pool to expedite Arcs execution.
+  private static final String USE_WORKER_POOL_PROPERTY = "debug.arcs.runtime.use_worker_pool";
+  // Supplies additional worker pool configurations.
+  // Sees {@link RuntimeSettings#workerPoolOptions()} for all available options.
+  private static final String WORKER_POOL_OPTIONS_PROPERTY =
+      "debug.arcs.runtime.worker_pool_options";
+  // Guides how to shrink or grow worker pool dynamically.
+  // Sees {@link RuntimeSettings#sizingPolicy()} for all available policies and
+  // the default policy.
+  private static final String SIZING_POLICY_PROPERTY = "debug.arcs.runtime.sizing_policy";
 
   // Default settings:
   // Logs the most information
@@ -48,6 +58,12 @@ public final class AndroidRuntimeSettings implements RuntimeSettings {
   private static final boolean DEFAULT_USE_CACHE_MANAGER = true;
   // Disables system trace
   private static final String DEFAULT_SYSTEM_TRACE_CHANNEL = "";
+  // Disables worker pool
+  private static final boolean DEFAULT_USE_WORKER_POOL = false;
+  // Uses the default configuration
+  private static final String DEFAULT_WORKER_POOL_OPTIONS = "";
+  // Uses the default sizing policy
+  private static final String DEFAULT_SIZING_POLICY = "";
 
   private static final Logger logger = Logger.getLogger(
       AndroidRuntimeSettings.class.getName());
@@ -61,6 +77,9 @@ public final class AndroidRuntimeSettings implements RuntimeSettings {
     abstract int devServerPort();
     abstract boolean useCacheManager();
     abstract String systemTraceChannel();
+    abstract boolean useWorkerPool();
+    abstract String workerPoolOptions();
+    abstract String sizingPolicy();
 
     static Builder builder() {
       return new AutoValue_AndroidRuntimeSettings_Settings.Builder();
@@ -75,6 +94,9 @@ public final class AndroidRuntimeSettings implements RuntimeSettings {
       abstract Builder setDevServerPort(int devServerPort);
       abstract Builder setUseCacheManager(boolean useCacheManager);
       abstract Builder setSystemTraceChannel(String systemTraceChannel);
+      abstract Builder setUseWorkerPool(boolean useWorkerPool);
+      abstract Builder setWorkerPoolOptions(String workerPoolOptions);
+      abstract Builder setSizingPolicy(String sizingPolicy);
       abstract Settings build();
     }
   }
@@ -106,6 +128,15 @@ public final class AndroidRuntimeSettings implements RuntimeSettings {
                 SYSTEM_TRACE_CHANNEL_PROPERTY,
                 String::valueOf,
                 DEFAULT_SYSTEM_TRACE_CHANNEL))
+        .setUseWorkerPool(
+            getProperty(USE_WORKER_POOL_PROPERTY, Boolean::valueOf, DEFAULT_USE_WORKER_POOL))
+        .setWorkerPoolOptions(
+            getProperty(
+                WORKER_POOL_OPTIONS_PROPERTY,
+                String::valueOf,
+                DEFAULT_WORKER_POOL_OPTIONS))
+        .setSizingPolicy(
+            getProperty(SIZING_POLICY_PROPERTY, String::valueOf, DEFAULT_SIZING_POLICY))
         .build();
   }
 
@@ -146,17 +177,17 @@ public final class AndroidRuntimeSettings implements RuntimeSettings {
 
   @Override
   public boolean useWorkerPool() {
-    return false;
+    return settings.useWorkerPool();
   }
 
   @Override
   public String workerPoolOptions() {
-    return "";
+    return settings.workerPoolOptions();
   }
 
   @Override
   public String sizingPolicy() {
-    return "";
+    return settings.sizingPolicy();
   }
 
   /**

--- a/java/arcs/sdk/android/dev/service/AndroidRuntimeSettings.java
+++ b/java/arcs/sdk/android/dev/service/AndroidRuntimeSettings.java
@@ -60,10 +60,10 @@ public final class AndroidRuntimeSettings implements RuntimeSettings {
   private static final String DEFAULT_SYSTEM_TRACE_CHANNEL = "";
   // Disables worker pool
   private static final boolean DEFAULT_USE_WORKER_POOL = false;
-  // Uses the default configuration
+  // Uses the default settings (no additional configurations)
   private static final String DEFAULT_WORKER_POOL_OPTIONS = "";
-  // Uses the default sizing policy
-  private static final String DEFAULT_SIZING_POLICY = "";
+  // Uses the default sizing policy auto-selected by Arcs runtime
+  private static final String DEFAULT_SIZING_POLICY = "default";
 
   private static final Logger logger = Logger.getLogger(
       AndroidRuntimeSettings.class.getName());

--- a/java/arcs/sdk/android/dev/service/AndroidRuntimeSettings.java
+++ b/java/arcs/sdk/android/dev/service/AndroidRuntimeSettings.java
@@ -144,6 +144,21 @@ public final class AndroidRuntimeSettings implements RuntimeSettings {
     return settings.systemTraceChannel();
   }
 
+  @Override
+  public boolean useWorkerPool() {
+    return false;
+  }
+
+  @Override
+  public String workerPoolOptions() {
+    return "";
+  }
+
+  @Override
+  public String sizingPolicy() {
+    return "";
+  }
+
   /**
    * This API reads the specified <var>property</var>, converts the content to
    * the type of <var>T</var> via the <var>converter</var>, then returns the

--- a/java/arcs/sdk/android/dev/service/README.md
+++ b/java/arcs/sdk/android/dev/service/README.md
@@ -117,3 +117,6 @@ Android properties are used to change and tweak Arcs settings at run-time.
 | debug.arcs.runtime.load_workstation_assets | Whether to load recipes and particles from the workstation | false (assets from the APK) |
 | debug.arcs.runtime.use_cache_mgr | Whether to use the Arcs Cache Manager | true
 | debug.arcs.runtime.systrace | Specify system tracing channel (options: [android,console]) | n/a (trace off)
+| debug.arcs.runtime.use_worker_pool | Whether to use the Arcs Worker Pool | false
+| debug.arcs.runtime.worker_pool_options| Provide additional worker pool configurations | ""
+| debug.arcs.runtime.sizing_policy | Select worker pool dynamic sizing (shrink/grow) policy | conservative

--- a/java/arcs/sdk/android/dev/service/README.md
+++ b/java/arcs/sdk/android/dev/service/README.md
@@ -119,4 +119,4 @@ Android properties are used to change and tweak Arcs settings at run-time.
 | debug.arcs.runtime.systrace | Specify system tracing channel (options: [android,console]) | n/a (trace off)
 | debug.arcs.runtime.use_worker_pool | Whether to use the Arcs Worker Pool | false
 | debug.arcs.runtime.worker_pool_options| Provide additional worker pool configurations | ""
-| debug.arcs.runtime.sizing_policy | Select worker pool dynamic sizing (shrink/grow) policy | conservative
+| debug.arcs.runtime.sizing_policy | Select worker pool dynamic sizing (shrink/grow) policy | default


### PR DESCRIPTION
This is the last PR prior to enable Arcs worker pool.

Next PR will turn on Arcs worker pool with the 'nosuspend' configuration enabled.
The option 'nosuspend' guides the pool management not to reuse (suspend/resume) workers; instead, just spawn new workers ahead of time so that each PEC can execute at a clean (non-shared, no side-channel) environment.
