### PR TITLE
fix immediate value handle storage key in arc instantiate method

### DIFF
--- a/src/runtime/arc.ts
+++ b/src/runtime/arc.ts
@@ -484,11 +484,12 @@ export class Arc implements ArcInterface {
         type = type.resolvedType();
         assert(type.isResolved(), `Can't create handle for unresolved type ${type}`);
 
+        const storeId = this.generateID().toString();
         const volatileKey = recipeHandle.immediateValue ? (
-          Flags.useNewStorageStack ? new VolatileStorageKey(this.id, '') : 'volatile'
+          Flags.useNewStorageStack ? new VolatileStorageKey(this.id, '').childKeyForHandle(storeId) : 'volatile'
         ) : undefined;
 
-        const newStore = await this.createStoreInternal(type, /* name= */ null, this.generateID().toString(),
+        const newStore = await this.createStoreInternal(type, /* name= */ null, storeId,
             recipeHandle.tags, volatileKey);
         if (recipeHandle.immediateValue) {
           const particleSpec = recipeHandle.immediateValue;


### PR DESCRIPTION
this fixes test `'initialize recipe and render hosted slots'` in slot-composer-test with storageNG.
there are 2 transformation particles in the recipe, and without this change both immediate-value stores created during recipe instantiation are assigned the same storage key.

note: the test is still flaky, but that is in the slots rendering area and i'll hand it back to Scott after this change is merged.