### PR TITLE
Initial Allocator implementation

### DIFF
--- a/java/arcs/core/host/AbstractArcHost.kt
+++ b/java/arcs/core/host/AbstractArcHost.kt
@@ -30,4 +30,13 @@ abstract class AbstractArcHost : ArcHost {
 
     override val registeredParticles: List<KClass<out Particle>>
         get() = particles
+
+    override fun startArc(partition: PlanPartition) {
+
+        // TODO(cromwellian): implement
+    }
+
+    override fun stopArc(partition: PlanPartition) {
+        // TODO(cromwellian): implement
+    }
 }

--- a/java/arcs/core/host/AbstractArcHost.kt
+++ b/java/arcs/core/host/AbstractArcHost.kt
@@ -23,7 +23,7 @@ import kotlinx.coroutines.sync.withLock
 abstract class AbstractArcHost : ArcHost {
     private val hostMutex = Mutex()
     private var particles: MutableList<KClass<out Particle>> by
-    guardWith(hostMutex, mutableListOf())
+        guardWith(hostMutex, mutableListOf())
 
     override suspend fun registerParticle(particle: KClass<out Particle>) {
         hostMutex.withLock { particles.add(particle) }

--- a/java/arcs/core/host/Allocator.kt
+++ b/java/arcs/core/host/Allocator.kt
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+package arcs.core.host
+
+import arcs.core.common.ArcId
+import arcs.core.common.Id
+import arcs.core.sdk.Particle
+import arcs.core.storage.StorageKey
+import arcs.core.storage.driver.RamDiskStorageKey
+import arcs.core.storage.driver.VolatileStorageKey
+
+// TODO(cromwellian): This should be based off some configuration
+typealias DefaultHost = ProdHost
+
+/**
+ * An [Allocator] is responsible for starting and stopping arcs via a distributed
+ * set of [ArcHost] implementations. It accomplishes this by being given a [Plan]
+ * which it partitions into a set of [PlanPartition] objects, one per participating
+ * [ArcHost] according to [HostRegistry] entries.
+ *
+ * Each [PlanPartition] lists a set of [HandleSpec] objects with [arcs.core.storage.StorageKey] and
+ * [arcs.core.data.Schema], a set of [Particle]s to instantiate, and connections between each
+ * [HandleSpec] and [Particle].
+ */
+class Allocator(val hostRegistry: HostRegistry) {
+
+    /** [ArcHost] used for unannotated Particles */
+    private val defaultHost =
+        hostRegistry.availableArcHosts.find { it.javaClass == DefaultHost::class.java }!!
+
+    /** Currently active Arcs and their associated [PlanPartition]s. */
+    private val partitionMap: MutableMap<ArcId, List<PlanPartition>> = mutableMapOf()
+
+    /**
+     * Start a new Arc given a [Plan] and return the generated [ArcId].
+     */
+    fun startArcForPlan(arcName: String, plan: Plan): ArcId {
+        val idGenerator = Id.Generator.newSession()
+        val arcId = idGenerator.newArcId(arcName)
+        // Any unresolved handles ('create' fate) need storage keys
+        createStorageKeysIfNecessary(arcId, idGenerator, plan)
+        val partitions = computePartitions(arcId, plan)
+        // Store computed partitions for later
+        writePartitionMap(arcId, partitions)
+        startPlanPartitionsOnHosts(partitions)
+        return arcId
+    }
+
+    // VisibleForTesting
+    fun getPartitionsFor(arcId: ArcId): List<PlanPartition>? {
+        return partitionMap[arcId]
+    }
+
+    /**
+     * Asks each [ArcHost] to start an Arc given a [PlanPartition].
+     */
+    private fun startPlanPartitionsOnHosts(partitions: List<PlanPartition>) =
+        partitions.forEach { partition -> partition.arcHost.startArc(partition) }
+
+    /**
+     * Persists [ArcId] and associoated [PlatPartition]s.
+     */
+    private fun writePartitionMap(arcId: ArcId, partitions: List<PlanPartition>) {
+        partitionMap[arcId] = partitions
+        // TODO(cromwellian): implement actual persistence that survives reboot?
+    }
+
+    /**
+     * Finds [HandleSpec] instances which were unresolved at build time (null [StorageKey]) and
+     * attaches generated keys.
+     */
+    private fun createStorageKeysIfNecessary(arcId: ArcId, idGenerator: Id.Generator, plan: Plan) =
+        plan.handleSpecs
+            .filter { spec -> spec.storageKey == null }
+            .forEach { spec ->
+                spec.storageKey = createStorageKey(arcId, spec, idGenerator)
+            }
+
+    /**
+     * Creates new [StorageKey] instances based on [HandleSpec] tags.
+     * Incomplete implementation for now, only Ram or Volatile can be created.
+     */
+    private fun createStorageKey(
+        arcId: ArcId,
+        spec: HandleSpec,
+        idGenerator: Id.Generator
+    ): StorageKey = when {
+        !isVolatileHandle(spec.tags) -> RamDiskStorageKey(
+            idGenerator.newChildId(arcId, "").toString()
+        )
+        else -> VolatileStorageKey(
+            arcId,
+            idGenerator.newChildId(arcId, "").toString()
+        )
+    }
+
+    private fun isVolatileHandle(tags: Set<String>) = tags.contains("volatile")
+
+    /**
+     * Slice plan into pieces grouped by [ArcHost], each group consisting of a [PlanPartition]
+     * that lists [HandleSpec], [ParticleSpec], and [HandleConnectionSpec] needed for that host.
+     */
+    private fun computePartitions(arcId: ArcId, plan: Plan): List<PlanPartition> =
+        plan.particleSpecs
+            .map {
+                    spec -> findArcHostBySpec(spec) to spec }
+            .groupBy({ it.first }, { it.second })
+            // map ArcHost -> List<ParticleSpec> into List<PlanPartition>
+            .map {
+                // find all HandleConnectionSpecs for the given List<ParticleSpec>
+                val handleConnectionSpecs =
+                    plan.handleConnectionSpecs.filter { spec ->
+                        it.value.contains(spec.usingParticle)
+                    }
+                PlanPartition(
+                    arcId.toString(),
+                    it.key /* ArcHost */,
+                    handleConnectionSpecs.map { it.usedHandle },
+                    it.value /* List<ParticleSpec> */,
+                    handleConnectionSpecs
+                )
+            }
+
+    /**
+     * Find [ArcHosts] by looking up known registered particles in every [ArcHost],
+     * mapping them to fully qualified Java classnames, and comparing them with the
+     * [ParticleSpec.location].
+     */
+    private fun findArcHostBySpec(spec: ParticleSpec): ArcHost =
+        hostRegistry.availableArcHosts
+            .filter { host ->
+                host.registeredParticles.map { clazz -> clazz.java.getCanonicalName() }
+                    .contains(spec.location)
+            }.firstOrNull() ?: defaultHost
+}

--- a/java/arcs/core/host/Allocator.kt
+++ b/java/arcs/core/host/Allocator.kt
@@ -17,9 +17,6 @@ import arcs.core.storage.StorageKey
 import arcs.core.storage.driver.RamDiskStorageKey
 import arcs.core.storage.driver.VolatileStorageKey
 
-// TODO(cromwellian): This should be based off some configuration
-typealias DefaultHost = ProdHost
-
 /**
  * An [Allocator] is responsible for starting and stopping arcs via a distributed
  * set of [ArcHost] implementations. It accomplishes this by being given a [Plan]
@@ -31,10 +28,6 @@ typealias DefaultHost = ProdHost
  * [HandleSpec] and [Particle].
  */
 class Allocator(val hostRegistry: HostRegistry) {
-
-    /** [ArcHost] used for unannotated Particles */
-    private val defaultHost =
-        hostRegistry.availableArcHosts.find { it.javaClass == DefaultHost::class.java }!!
 
     /** Currently active Arcs and their associated [PlanPartition]s. */
     private val partitionMap: MutableMap<ArcId, List<PlanPartition>> = mutableMapOf()
@@ -69,7 +62,7 @@ class Allocator(val hostRegistry: HostRegistry) {
     fun lookupArcHost(arcHost: String) =
         hostRegistry.availableArcHosts.filter { it ->
             it::class.java.canonicalName == arcHost
-        }.firstOrNull() ?: defaultHost
+        }.firstOrNull() ?: throw ArcHostNotFoundException(arcHost)
 
 
     /**
@@ -144,5 +137,5 @@ class Allocator(val hostRegistry: HostRegistry) {
             .filter { host ->
                 host.registeredParticles.map { clazz -> clazz.java.getCanonicalName() }
                     .contains(spec.location)
-            }.firstOrNull() ?: defaultHost
+            }.firstOrNull() ?: throw ParticleNotFoundException(spec)
 }

--- a/java/arcs/core/host/Allocator.kt
+++ b/java/arcs/core/host/Allocator.kt
@@ -123,8 +123,6 @@ class Allocator(val hostRegistry: HostRegistry) {
                 PlanPartition(
                     arcId.toString(),
                     it.key /* ArcHost */,
-                    handleConnectionSpecs.map { it.handleSpec },
-                    it.value /* List<ParticleSpec> */,
                     handleConnectionSpecs
                 )
             }

--- a/java/arcs/core/host/Allocator.kt
+++ b/java/arcs/core/host/Allocator.kt
@@ -63,7 +63,14 @@ class Allocator(val hostRegistry: HostRegistry) {
      * Asks each [ArcHost] to start an Arc given a [PlanPartition].
      */
     private fun startPlanPartitionsOnHosts(partitions: List<PlanPartition>) =
-        partitions.forEach { partition -> partition.arcHost.startArc(partition) }
+        partitions.forEach { partition -> lookupArcHost(partition.arcHost).startArc(partition) }
+
+    // VisibleForTesting
+    fun lookupArcHost(arcHost: String) =
+        hostRegistry.availableArcHosts.filter { it ->
+            it::class.java.canonicalName == arcHost
+        }.firstOrNull() ?: defaultHost
+
 
     /**
      * Persists [ArcId] and associoated [PlatPartition]s.
@@ -122,7 +129,7 @@ class Allocator(val hostRegistry: HostRegistry) {
                     }
                 PlanPartition(
                     arcId.toString(),
-                    it.key /* ArcHost */,
+                    it.key::class.java.canonicalName!! /* ArcHost */,
                     handleConnectionSpecs
                 )
             }

--- a/java/arcs/core/host/ArcHost.kt
+++ b/java/arcs/core/host/ArcHost.kt
@@ -24,29 +24,29 @@ interface ArcHost {
     /**
      * Registers a [Particle] class with this host.
      */
-    fun registerParticle(particle: KClass<out Particle>)
+    suspend fun registerParticle(particle: KClass<out Particle>): Unit
 
     /**
      * Unregisters a [Particle] class.
      */
-    fun unregisterParticle(particle: KClass<out Particle>)
+    suspend fun unregisterParticle(particle: KClass<out Particle>): Unit
 
     /**
      * Returns a list of Particles registered to run in this host.
      */
-    val registeredParticles: List<KClass<out Particle>>
+    suspend fun registeredParticles(): List<KClass<out Particle>>
 
     /**
      * Requests this arc host to start or restart an Arc associated with this [PlanPartition]. This
      * may include creating handles and storage proxies, registering for updates from the storage
      * system, instantiating particles, and registering for resurrection.
      */
-    fun startArc(partition: PlanPartition)
+    suspend fun startArc(partition: PlanPartition)
 
     /**
      * Shuts down an existing arc. This may include unregistering for updates from storage,
      * resurrection, and notifying particles they are at the end of their lifecycle.
      */
-    fun stopArc(partition: PlanPartition)
+    suspend fun stopArc(partition: PlanPartition)
     // TODO: HandleMessage
 }

--- a/java/arcs/core/host/ArcHost.kt
+++ b/java/arcs/core/host/ArcHost.kt
@@ -36,5 +36,17 @@ interface ArcHost {
      */
     val registeredParticles: List<KClass<out Particle>>
 
-    // TODO: Implement startArc/stopArc/handleMessage
+    /**
+     * Requests this arc host to start or restart an Arc associated with this [PlanPartition]. This
+     * may include creating handles and storage proxies, registering for updates from the storage
+     * system, instantiating particles, and registering for resurrection.
+     */
+    fun startArc(partition: PlanPartition)
+
+    /**
+     * Shuts down an existing arc. This may include unregistering for updates from storage,
+     * resurrection, and notifying particles they are at the end of their lifecycle.
+     */
+    fun stopArc(partition: PlanPartition)
+    // TODO: HandleMessage
 }

--- a/java/arcs/core/host/ArcHostNotFoundException.kt
+++ b/java/arcs/core/host/ArcHostNotFoundException.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.core.host
+
+import arcs.core.sdk.Particle
+import kotlin.reflect.KClass
+
+/**
+ * An [ArcHostNotFoundException] is thrown if a [Particle] has an annotation with
+ * [TargetHost] that requests an [ArcHost] that is not registered with a [HostRegistry].
+ */
+class ArcHostNotFoundException(msg: String) : Exception(msg)
+

--- a/java/arcs/core/host/BUILD
+++ b/java/arcs/core/host/BUILD
@@ -9,6 +9,8 @@ arcs_kt_jvm_library(
     srcs = glob(["*.kt"]),
     deps = [
         "//java/arcs/core/sdk",
+        "//java/arcs/core/storage",
+        "//java/arcs/core/storage/driver",
         "//third_party/java/auto:auto_service",
     ],
 )

--- a/java/arcs/core/host/BUILD
+++ b/java/arcs/core/host/BUILD
@@ -12,5 +12,8 @@ arcs_kt_jvm_library(
         "//java/arcs/core/storage",
         "//java/arcs/core/storage/driver",
         "//third_party/java/auto:auto_service",
+        "//third_party/kotlin/kotlinx_atomicfu",
+        "//third_party/kotlin/kotlinx_coroutines",
+        "//third_party/kotlin/kotlinx_coroutines:kotlinx_coroutines_test",
     ],
 )

--- a/java/arcs/core/host/BUILD
+++ b/java/arcs/core/host/BUILD
@@ -8,9 +8,12 @@ arcs_kt_jvm_library(
     name = "host",
     srcs = glob(["*.kt"]),
     deps = [
+        "//java/arcs/core/common",
+        "//java/arcs/core/data",
         "//java/arcs/core/sdk",
         "//java/arcs/core/storage",
         "//java/arcs/core/storage/driver",
+        "//java/arcs/core/util",
         "//third_party/java/auto:auto_service",
         "//third_party/kotlin/kotlinx_atomicfu",
         "//third_party/kotlin/kotlinx_coroutines",

--- a/java/arcs/core/host/ExplicitHostRegistry.kt
+++ b/java/arcs/core/host/ExplicitHostRegistry.kt
@@ -23,8 +23,8 @@ object ExplicitHostRegistry : AnnotationBasedHostRegistry() {
     /**
      * Explicitly register all particles used.
      */
-    fun registerParticles(allParticles: List<KClass<out Particle>>) {
-        availableArcHosts.forEach { host ->
+    suspend fun registerParticles(allParticles: List<KClass<out Particle>>) {
+        availableArcHosts().forEach { host ->
             registerParticles(findParticlesForHost(allParticles, host), host)
         }
     }

--- a/java/arcs/core/host/ExternalHost.kt
+++ b/java/arcs/core/host/ExternalHost.kt
@@ -1,0 +1,3 @@
+package arcs.core.host
+
+class ExternalHost : AbstractArcHost()

--- a/java/arcs/core/host/ExternalHost.kt
+++ b/java/arcs/core/host/ExternalHost.kt
@@ -1,3 +1,9 @@
 package arcs.core.host
 
+/**
+ * [ExternalHost] is the base class for all Android-specific non-isolated hosts.
+ * Just a place holder for now, but serves as a marker for the [Allocator]
+ * in the future, and likely to house Android specific state, like application
+ * context.
+ */
 class ExternalHost : AbstractArcHost()

--- a/java/arcs/core/host/HandleConnectionSpec.kt
+++ b/java/arcs/core/host/HandleConnectionSpec.kt
@@ -1,0 +1,10 @@
+package arcs.core.host
+
+/**
+ * Represents a use of a [Handle] by a [Particle].
+ */
+data class HandleConnectionSpec(
+    val connectionName: String,
+    val usedHandle: HandleSpec,
+    val usingParticle: ParticleSpec
+)

--- a/java/arcs/core/host/HandleConnectionSpec.kt
+++ b/java/arcs/core/host/HandleConnectionSpec.kt
@@ -5,6 +5,6 @@ package arcs.core.host
  */
 data class HandleConnectionSpec(
     val connectionName: String,
-    val usedHandle: HandleSpec,
-    val usingParticle: ParticleSpec
+    val handleSpec: HandleSpec,
+    val particleSpec: ParticleSpec
 )

--- a/java/arcs/core/host/HandleSpec.kt
+++ b/java/arcs/core/host/HandleSpec.kt
@@ -1,0 +1,19 @@
+package arcs.core.host
+
+import arcs.core.data.Schema
+import arcs.core.storage.StorageKey
+
+/**
+ * A [HandleSpec] represents a handle in a recipe that has either been resolved (contains a
+ * [StorageKey]), or requires the allocator to construct a new [StorageKey].
+ * [schema] is the [Schema] definition that this [StorageKey] uses, typically retrieved from
+ * the Entity class generated at build time.
+ */
+class HandleSpec(
+    // unused for now
+    var id: String?,
+    var name: String?,
+    var storageKey: StorageKey?,
+    val tags: Set<String> = mutableSetOf(),
+    val schema: Schema
+)

--- a/java/arcs/core/host/HandleSpec.kt
+++ b/java/arcs/core/host/HandleSpec.kt
@@ -6,8 +6,11 @@ import arcs.core.storage.StorageKey
 /**
  * A [HandleSpec] represents a handle in a recipe that has either been resolved (contains a
  * [StorageKey]), or requires the allocator to construct a new [StorageKey].
- * [schema] is the [Schema] definition that this [StorageKey] uses, typically retrieved from
- * the Entity class generated at build time.
+ * @property id handle id from the manifest
+ * @property name the name of the handle
+ * @property storageKey the [StorageKey] backing this handle.
+ * @property tags specified on the handle in the manifest.
+ * @property schema is the [Schema] definition used for this [StorageKey]
  */
 class HandleSpec(
     // unused for now

--- a/java/arcs/core/host/HostRegistry.kt
+++ b/java/arcs/core/host/HostRegistry.kt
@@ -17,15 +17,15 @@ interface HostRegistry {
     /**
      * Returns a list of all current [ArcHost] implementations in the system.
      */
-    val availableArcHosts: List<ArcHost>
+    suspend fun availableArcHosts(): List<ArcHost>
 
     /**
      * Register a new [ArcHost].
      */
-    fun registerHost(host: ArcHost): Unit
+    suspend fun registerHost(host: ArcHost): Unit
 
     /**
      * Remove an [ArcHost] from the list of those available.
      */
-    fun unregisterHost(host: ArcHost): Unit
+    suspend fun unregisterHost(host: ArcHost): Unit
 }

--- a/java/arcs/core/host/ParticleNotFoundException.kt
+++ b/java/arcs/core/host/ParticleNotFoundException.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.core.host
+
+import arcs.core.sdk.Particle
+import kotlin.reflect.KClass
+
+/**
+ * An [ParticleNotFoundException] is thrown if a [Particle] cannot be located in
+ * any [ArcHost]s available on the [HostRegistry].
+ */
+class ParticleNotFoundException(spec: ParticleSpec) :
+    Exception("""${spec.particleName} with location ${spec.location} cannot be found.""")
+

--- a/java/arcs/core/host/ParticleSpec.kt
+++ b/java/arcs/core/host/ParticleSpec.kt
@@ -1,0 +1,9 @@
+package arcs.core.host
+
+/**
+ * A [ParticleSpec] consists of the information neccessary to instantiate a particle
+ * when starting an arc.
+ * [manifestName] is human readable of the Particle in the recipe.
+ * [location] is either a fully qualified Java class name, or a filesystem path.
+ */
+data class ParticleSpec(val manifestName: String, val location: String)

--- a/java/arcs/core/host/ParticleSpec.kt
+++ b/java/arcs/core/host/ParticleSpec.kt
@@ -3,7 +3,7 @@ package arcs.core.host
 /**
  * A [ParticleSpec] consists of the information neccessary to instantiate a particle
  * when starting an arc.
- * [particleName] is human readable of the Particle in the recipe.
+ * [particleName] is human readable name of the Particle in the recipe.
  * [location] is either a fully qualified Java class name, or a filesystem path.
  */
 data class ParticleSpec(val particleName: String, val location: String)

--- a/java/arcs/core/host/ParticleSpec.kt
+++ b/java/arcs/core/host/ParticleSpec.kt
@@ -3,7 +3,7 @@ package arcs.core.host
 /**
  * A [ParticleSpec] consists of the information neccessary to instantiate a particle
  * when starting an arc.
- * [manifestName] is human readable of the Particle in the recipe.
+ * [particleName] is human readable of the Particle in the recipe.
  * [location] is either a fully qualified Java class name, or a filesystem path.
  */
-data class ParticleSpec(val manifestName: String, val location: String)
+data class ParticleSpec(val particleName: String, val location: String)

--- a/java/arcs/core/host/ParticleSpec.kt
+++ b/java/arcs/core/host/ParticleSpec.kt
@@ -3,7 +3,7 @@ package arcs.core.host
 /**
  * A [ParticleSpec] consists of the information neccessary to instantiate a particle
  * when starting an arc.
- * [particleName] is human readable name of the Particle in the recipe.
- * [location] is either a fully qualified Java class name, or a filesystem path.
+ * @property particleName is human readable name of the Particle in the recipe.
+ * @property location is either a fully qualified Java class name, or a filesystem path.
  */
 data class ParticleSpec(val particleName: String, val location: String)

--- a/java/arcs/core/host/Plan.kt
+++ b/java/arcs/core/host/Plan.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+package arcs.core.host
+
+/**
+ * A [Plan] is usually produced by running the build time Particle Accelerator tool, it consists
+ * of a set of specs for handles, particles used in a recipe, and mappings between them.
+ */
+open class Plan(
+    val handleSpecs: List<HandleSpec>,
+    val particleSpecs: List<ParticleSpec>,
+    val handleConnectionSpecs: List<HandleConnectionSpec>
+)

--- a/java/arcs/core/host/Plan.kt
+++ b/java/arcs/core/host/Plan.kt
@@ -15,7 +15,5 @@ package arcs.core.host
  * of a set of specs for handles, particles used in a recipe, and mappings between them.
  */
 open class Plan(
-    val handleSpecs: List<HandleSpec>,
-    val particleSpecs: List<ParticleSpec>,
     val handleConnectionSpecs: List<HandleConnectionSpec>
 )

--- a/java/arcs/core/host/Plan.kt
+++ b/java/arcs/core/host/Plan.kt
@@ -15,5 +15,6 @@ package arcs.core.host
  * of a set of specs for handles, particles used in a recipe, and mappings between them.
  */
 open class Plan(
+    // TODO(cromwellian): add more fields as needed (e.g. RecipeName, etc for debugging)
     val handleConnectionSpecs: List<HandleConnectionSpec>
 )

--- a/java/arcs/core/host/PlanPartition.kt
+++ b/java/arcs/core/host/PlanPartition.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+package arcs.core.host
+
+/**
+ * A [PlanPartition] is a part of a [Plan] that runs on an [ArcHost]. Since [Plan]s may span
+ * multiple [ArcHost]s, an [Allocator] must partition a plan by [ArcHost].
+ */
+data class PlanPartition(
+    val arcId: String,
+    val arcHost: ArcHost,
+    val handleSpecs: List<HandleSpec>,
+    val particleSpecs: List<ParticleSpec>,
+    val handleConnectionSpecs: List<HandleConnectionSpec>
+)

--- a/java/arcs/core/host/PlanPartition.kt
+++ b/java/arcs/core/host/PlanPartition.kt
@@ -17,7 +17,5 @@ package arcs.core.host
 data class PlanPartition(
     val arcId: String,
     val arcHost: ArcHost,
-    val handleSpecs: List<HandleSpec>,
-    val particleSpecs: List<ParticleSpec>,
     val handleConnectionSpecs: List<HandleConnectionSpec>
 )

--- a/java/arcs/core/host/PlanPartition.kt
+++ b/java/arcs/core/host/PlanPartition.kt
@@ -16,6 +16,6 @@ package arcs.core.host
  */
 data class PlanPartition(
     val arcId: String,
-    val arcHost: ArcHost,
+    val arcHost: String,
     val handleConnectionSpecs: List<HandleConnectionSpec>
 )

--- a/java/arcs/jvm/host/BUILD
+++ b/java/arcs/jvm/host/BUILD
@@ -11,6 +11,6 @@ arcs_kt_jvm_library(
     deps = [
         "//java/arcs/core/host",
         "//java/arcs/core/sdk",
-        "//third_party/kotlin/kotlinx_coroutines:kotlinx_coroutines",
+        "//third_party/kotlin/kotlinx_coroutines",
     ],
 )

--- a/java/arcs/jvm/host/BUILD
+++ b/java/arcs/jvm/host/BUILD
@@ -11,5 +11,6 @@ arcs_kt_jvm_library(
     deps = [
         "//java/arcs/core/host",
         "//java/arcs/core/sdk",
+        "//third_party/kotlin/kotlinx_coroutines:kotlinx_coroutines",
     ],
 )

--- a/javatests/arcs/core/host/AllocatorTest.kt
+++ b/javatests/arcs/core/host/AllocatorTest.kt
@@ -1,0 +1,201 @@
+package arcs.core.host
+
+import arcs.core.common.Id
+import arcs.core.data.Schema
+import arcs.core.data.SchemaDescription
+import arcs.core.data.SchemaFields
+import arcs.core.data.SchemaName
+import arcs.core.sdk.Particle
+import arcs.core.storage.driver.VolatileStorageKey
+import arcs.jvm.host.ServiceLoaderHostRegistry
+import com.google.auto.service.AutoService
+import com.google.common.truth.Truth.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class AllocatorTest {
+    /**
+     * A test recipe, two particles
+     * [WritePerson] writes a Person to a handle
+     * [ReadPerson] reads a Person from a handle
+     * [WritePerson] runs in [WritingHost]
+     * [ReadPerson] runs in [ReadingHost]
+     *
+     * Hand translated 'compilation' roughly equivalent to:
+     *
+     * schema Person { name: Text }
+     * particle ReadPerson in 'arcs.core.host.AllocatorTest.ReadPerson'
+     *   person: reads Person
+     *
+     * particle WritePerson in 'arcs.core.host.AllocatorTest.WritePerson'
+     *   person: writes Person
+     *
+     * recipe WriteAndReadPerson
+     *   recipePerson: create
+     *   WritePerson
+     *     person: writes recipePerson
+     *   ReadPerson
+     *     person: reads recipePerson
+     */
+    private val personSchema = Schema(
+        listOf(SchemaName("Person")),
+        SchemaFields(setOf("name"), emptySet()),
+        SchemaDescription()
+    )
+
+    @Target(AnnotationTarget.CLASS)
+    @Retention(AnnotationRetention.RUNTIME)
+    @TargetHost(WritingHost::class)
+    annotation class RunInWritingHost
+
+    @Target(AnnotationTarget.CLASS)
+    @Retention(AnnotationRetention.RUNTIME)
+    @TargetHost(ReadingHost::class)
+    annotation class RunInReadingHost
+
+    @AutoService(Particle::class)
+    @RunInWritingHost
+    class WritePerson : Particle
+
+    @AutoService(Particle::class)
+    @RunInReadingHost
+    class ReadPerson : Particle
+
+    open class TestingHost : AbstractArcHost() {
+        var started = mutableListOf<PlanPartition>()
+
+        override fun startArc(partition: PlanPartition) {
+            super.startArc(partition)
+            started.add(partition)
+        }
+
+        fun setup() {
+            started.clear()
+        }
+    }
+
+    @AutoService(ArcHost::class)
+    class WritingHost : TestingHost()
+
+    @AutoService(ArcHost::class)
+    class ReadingHost : TestingHost()
+
+    private lateinit var personHandleSpec: HandleSpec
+    private lateinit var readPersonHandleConnectionSpec: HandleConnectionSpec
+    private lateinit var writePersonHandleConnectionSpec: HandleConnectionSpec
+    private lateinit var writePersonParticleSpec: ParticleSpec
+    private lateinit var readPersonParticleSpec: ParticleSpec
+    private lateinit var writeAndReadPersonPlan: Plan
+
+    @Before
+    fun setUp() {
+        personHandleSpec =
+            HandleSpec(
+                null, "recipePerson", null, mutableSetOf("volatile"),
+                personSchema
+            )
+
+        writePersonParticleSpec =
+            ParticleSpec("WritePerson", WritePerson::class.java.getCanonicalName()!!)
+        writePersonHandleConnectionSpec =
+            HandleConnectionSpec("person", personHandleSpec, writePersonParticleSpec)
+
+        readPersonParticleSpec =
+            ParticleSpec("ReadPerson", ReadPerson::class.java.getCanonicalName()!!)
+        readPersonHandleConnectionSpec =
+            HandleConnectionSpec("person", personHandleSpec, readPersonParticleSpec)
+
+        writeAndReadPersonPlan = Plan(
+            listOf(personHandleSpec), listOf(writePersonParticleSpec, readPersonParticleSpec),
+            listOf(writePersonHandleConnectionSpec, readPersonHandleConnectionSpec)
+        )
+
+        ServiceLoaderHostRegistry.availableArcHosts.forEach {
+            when (it) {
+                is TestingHost -> it.setup()
+                else -> {}
+            }
+        }
+    }
+
+    /**
+     * Tests that the Recipe is properly partitioned so that [ReadingHost] contains only
+     * [ReadPerson] with associated handles and connections, and [WritingHost] contains only
+     * [WritePerson] with associated handles and connections.
+     */
+    @Test
+    fun allocator_computePartitions() {
+        val allocator = Allocator(ServiceLoaderHostRegistry)
+        val arcId = allocator.startArcForPlan("readWritePerson", writeAndReadPersonPlan)
+        val planPartitions = allocator.getPartitionsFor(arcId)!!
+        assertThat(planPartitions.size).isEqualTo(2)
+        planPartitions.forEach {
+            assertThat(it.arcId).isEqualTo(arcId.toString())
+            when (it.arcHost) {
+                is ReadingHost -> {
+                    assertThat(it.handleSpecs).containsExactly(personHandleSpec)
+                    assertThat(it.handleConnectionSpecs).containsExactly(
+                        readPersonHandleConnectionSpec
+                    )
+                    assertThat(it.particleSpecs).containsExactly(readPersonParticleSpec)
+                }
+                is WritingHost -> {
+                    assertThat(it.handleSpecs).containsExactly(personHandleSpec)
+                    assertThat(it.handleConnectionSpecs).containsExactly(
+                        writePersonHandleConnectionSpec
+                    )
+                    assertThat(it.particleSpecs).containsExactly(writePersonParticleSpec)
+                }
+                else -> {
+                    assert(false)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun allocator_verifyStorageKeysCreated() {
+        writeAndReadPersonPlan.handleSpecs.forEach { it ->
+            assertThat(it.storageKey).isNull()
+        }
+        val allocator = Allocator(ServiceLoaderHostRegistry)
+        val arcId = allocator.startArcForPlan("readWritePerson", writeAndReadPersonPlan)
+        val planPartitions = allocator.getPartitionsFor(arcId)!!
+        planPartitions.flatMap { it -> it.handleSpecs }
+            .forEach { assertThat(it.storageKey).isNotNull() }
+    }
+
+    @Test
+    fun allocator_verifyStorageKeysNotOverwritten() {
+        val idGenerator = Id.Generator.newSession()
+        val testArcId = idGenerator.newArcId("Test")
+        val testKey = VolatileStorageKey(testArcId, "test")
+
+        writeAndReadPersonPlan.handleSpecs.forEach { it ->
+            it.storageKey = testKey
+        }
+
+        val allocator = Allocator(ServiceLoaderHostRegistry)
+        val arcId = allocator.startArcForPlan("readWritePerson", writeAndReadPersonPlan)
+        val planPartitions = allocator.getPartitionsFor(arcId)!!
+        planPartitions.flatMap { it -> it.handleSpecs }
+            .forEach { assertThat(it.storageKey).isEqualTo(testKey) }
+    }
+
+    @Test
+    fun allocator_verifyArcHostStartCalled() {
+        val allocator = Allocator(ServiceLoaderHostRegistry)
+        val arcId = allocator.startArcForPlan("readWritePerson", writeAndReadPersonPlan)
+        val planPartitions = allocator.getPartitionsFor(arcId)!!
+        planPartitions.forEach {
+            when (it.arcHost) {
+                is TestingHost ->
+                    assertThat((it.arcHost as TestingHost).started).containsExactly(it)
+                else -> {}
+            }
+        }
+    }
+}

--- a/javatests/arcs/core/host/AllocatorTest.kt
+++ b/javatests/arcs/core/host/AllocatorTest.kt
@@ -119,10 +119,8 @@ class AllocatorTest {
             )
 
             ServiceLoaderHostRegistry.availableArcHosts().forEach {
-                when (it) {
-                    is TestingHost -> it.setup()
-                    else -> {
-                    }
+                if (it is TestingHost) {
+                    it.setup()
                 }
             }
         }
@@ -138,25 +136,18 @@ class AllocatorTest {
         val allocator = Allocator(ServiceLoaderHostRegistry)
         val arcId = allocator.startArcForPlan("readWritePerson", writeAndReadPersonPlan)
         val planPartitions = allocator.getPartitionsFor(arcId)!!
-        assertThat(planPartitions.size).isEqualTo(2)
-        planPartitions.forEach {
-            assertThat(it.arcId).isEqualTo(arcId.toString())
-            when (it.arcHost) {
-                ReadingHost::class.java.canonicalName -> {
-                    assertThat(it.handleConnectionSpecs).containsExactly(
-                        readPersonHandleConnectionSpec
-                    )
-                }
-                WritingHost::class.java.canonicalName -> {
-                    assertThat(it.handleConnectionSpecs).containsExactly(
-                        writePersonHandleConnectionSpec
-                    )
-                }
-                else -> {
-                    assert(false)
-                }
-            }
-        }
+        assertThat(planPartitions).containsExactly(
+            PlanPartition(
+                arcId.toString(),
+                ReadingHost::class.java.canonicalName,
+                listOf(readPersonHandleConnectionSpec)
+            ),
+            PlanPartition(
+                arcId.toString(),
+                WritingHost::class.java.canonicalName,
+                listOf(writePersonHandleConnectionSpec)
+            )
+        )
     }
 
     @Test

--- a/javatests/arcs/core/host/AllocatorTest.kt
+++ b/javatests/arcs/core/host/AllocatorTest.kt
@@ -199,4 +199,15 @@ class AllocatorTest {
             }
         }
     }
+
+    @Test(expected = ParticleNotFoundException::class)
+    fun allocator_verifyUnknownParticleThrows() {
+        val allocator = Allocator(ServiceLoaderHostRegistry)
+        val handleConnectionSpec = HandleConnectionSpec(
+            "unknown", personHandleSpec,
+            ParticleSpec("UnknownParticle", "Unknown")
+        )
+        val plan = Plan(listOf(handleConnectionSpec))
+        allocator.startArcForPlan("unknown", plan)
+    }
 }

--- a/javatests/arcs/core/host/AllocatorTest.kt
+++ b/javatests/arcs/core/host/AllocatorTest.kt
@@ -136,18 +136,14 @@ class AllocatorTest {
             assertThat(it.arcId).isEqualTo(arcId.toString())
             when (it.arcHost) {
                 is ReadingHost -> {
-                    assertThat(it.handleSpecs).containsExactly(personHandleSpec)
                     assertThat(it.handleConnectionSpecs).containsExactly(
                         readPersonHandleConnectionSpec
                     )
-                    assertThat(it.particleSpecs).containsExactly(readPersonParticleSpec)
                 }
                 is WritingHost -> {
-                    assertThat(it.handleSpecs).containsExactly(personHandleSpec)
                     assertThat(it.handleConnectionSpecs).containsExactly(
                         writePersonHandleConnectionSpec
                     )
-                    assertThat(it.particleSpecs).containsExactly(writePersonParticleSpec)
                 }
                 else -> {
                     assert(false)
@@ -164,8 +160,8 @@ class AllocatorTest {
         val allocator = Allocator(ServiceLoaderHostRegistry)
         val arcId = allocator.startArcForPlan("readWritePerson", writeAndReadPersonPlan)
         val planPartitions = allocator.getPartitionsFor(arcId)!!
-        planPartitions.flatMap { it -> it.handleSpecs }
-            .forEach { assertThat(it.storageKey).isNotNull() }
+        planPartitions.flatMap { it -> it.handleConnectionSpecs }
+            .forEach { assertThat(it.handleSpec.storageKey).isNotNull() }
     }
 
     @Test
@@ -181,8 +177,8 @@ class AllocatorTest {
         val allocator = Allocator(ServiceLoaderHostRegistry)
         val arcId = allocator.startArcForPlan("readWritePerson", writeAndReadPersonPlan)
         val planPartitions = allocator.getPartitionsFor(arcId)!!
-        planPartitions.flatMap { it -> it.handleSpecs }
-            .forEach { assertThat(it.storageKey).isEqualTo(testKey) }
+        planPartitions.flatMap { it -> it.handleConnectionSpecs }
+            .forEach { assertThat(it.handleSpec.storageKey).isEqualTo(testKey) }
     }
 
     @Test

--- a/javatests/arcs/core/host/AllocatorTest.kt
+++ b/javatests/arcs/core/host/AllocatorTest.kt
@@ -135,12 +135,12 @@ class AllocatorTest {
         planPartitions.forEach {
             assertThat(it.arcId).isEqualTo(arcId.toString())
             when (it.arcHost) {
-                is ReadingHost -> {
+                ReadingHost::class.java.canonicalName -> {
                     assertThat(it.handleConnectionSpecs).containsExactly(
                         readPersonHandleConnectionSpec
                     )
                 }
-                is WritingHost -> {
+                WritingHost::class.java.canonicalName -> {
                     assertThat(it.handleConnectionSpecs).containsExactly(
                         writePersonHandleConnectionSpec
                     )
@@ -187,10 +187,14 @@ class AllocatorTest {
         val arcId = allocator.startArcForPlan("readWritePerson", writeAndReadPersonPlan)
         val planPartitions = allocator.getPartitionsFor(arcId)!!
         planPartitions.forEach {
-            when (it.arcHost) {
+            val host = allocator.lookupArcHost(it.arcHost)
+            when (host) {
                 is TestingHost ->
-                    assertThat((it.arcHost as TestingHost).started).containsExactly(it)
+                    assertThat(
+                        (allocator.lookupArcHost(it.arcHost) as TestingHost).started
+                    ).containsExactly(it)
                 else -> {
+                    assert(false)
                 }
             }
         }

--- a/javatests/arcs/core/host/AllocatorTest.kt
+++ b/javatests/arcs/core/host/AllocatorTest.kt
@@ -109,14 +109,14 @@ class AllocatorTest {
             HandleConnectionSpec("person", personHandleSpec, readPersonParticleSpec)
 
         writeAndReadPersonPlan = Plan(
-            listOf(personHandleSpec), listOf(writePersonParticleSpec, readPersonParticleSpec),
             listOf(writePersonHandleConnectionSpec, readPersonHandleConnectionSpec)
         )
 
         ServiceLoaderHostRegistry.availableArcHosts.forEach {
             when (it) {
                 is TestingHost -> it.setup()
-                else -> {}
+                else -> {
+                }
             }
         }
     }
@@ -158,8 +158,8 @@ class AllocatorTest {
 
     @Test
     fun allocator_verifyStorageKeysCreated() {
-        writeAndReadPersonPlan.handleSpecs.forEach { it ->
-            assertThat(it.storageKey).isNull()
+        writeAndReadPersonPlan.handleConnectionSpecs.forEach { it ->
+            assertThat(it.handleSpec.storageKey).isNull()
         }
         val allocator = Allocator(ServiceLoaderHostRegistry)
         val arcId = allocator.startArcForPlan("readWritePerson", writeAndReadPersonPlan)
@@ -174,8 +174,8 @@ class AllocatorTest {
         val testArcId = idGenerator.newArcId("Test")
         val testKey = VolatileStorageKey(testArcId, "test")
 
-        writeAndReadPersonPlan.handleSpecs.forEach { it ->
-            it.storageKey = testKey
+        writeAndReadPersonPlan.handleConnectionSpecs.forEach { it ->
+            it.handleSpec.storageKey = testKey
         }
 
         val allocator = Allocator(ServiceLoaderHostRegistry)
@@ -194,7 +194,8 @@ class AllocatorTest {
             when (it.arcHost) {
                 is TestingHost ->
                     assertThat((it.arcHost as TestingHost).started).containsExactly(it)
-                else -> {}
+                else -> {
+                }
             }
         }
     }

--- a/javatests/arcs/core/host/BUILD
+++ b/javatests/arcs/core/host/BUILD
@@ -14,13 +14,12 @@ arcs_kt_jvm_test_suite(
     package = "arcs.core.host",
     deps = [
         ":particle",
-
         "//java/arcs/core/common",
         "//java/arcs/core/data",
         "//java/arcs/core/host",
         "//java/arcs/core/sdk",
-        "//java/arcs/core/storage/driver",
         "//java/arcs/core/storage:storage_key",
+        "//java/arcs/core/storage/driver",
         "//java/arcs/core/testutil",
         "//java/arcs/jvm/host",
         "//third_party/java/auto:auto_service",

--- a/javatests/arcs/core/host/BUILD
+++ b/javatests/arcs/core/host/BUILD
@@ -16,10 +16,14 @@ arcs_kt_jvm_test_suite(
         ":particle",
         "//java/arcs/core/host",
         "//java/arcs/core/sdk",
+        "//java/arcs/core/testutil",
         "//java/arcs/jvm/host",
         "//third_party/java/auto:auto_service",
         "//third_party/java/junit:junit-android",
         "//third_party/java/truth:truth-android",
+        "//third_party/kotlin/kotlinx_atomicfu",
+        "//third_party/kotlin/kotlinx_coroutines",
+        "//third_party/kotlin/kotlinx_coroutines:kotlinx_coroutines_test",
     ],
 )
 

--- a/javatests/arcs/core/host/BUILD
+++ b/javatests/arcs/core/host/BUILD
@@ -14,8 +14,13 @@ arcs_kt_jvm_test_suite(
     package = "arcs.core.host",
     deps = [
         ":particle",
+
+        "//java/arcs/core/common",
+        "//java/arcs/core/data",
         "//java/arcs/core/host",
         "//java/arcs/core/sdk",
+        "//java/arcs/core/storage/driver",
+        "//java/arcs/core/storage:storage_key",
         "//java/arcs/core/testutil",
         "//java/arcs/jvm/host",
         "//third_party/java/auto:auto_service",

--- a/javatests/arcs/core/host/ParticleRegistrationTest.kt
+++ b/javatests/arcs/core/host/ParticleRegistrationTest.kt
@@ -3,25 +3,29 @@ package arcs.core.host
 import arcs.core.sdk.Particle
 import arcs.jvm.host.ServiceLoaderHostRegistry
 import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 @RunWith(JUnit4::class)
+@UseExperimental(ExperimentalCoroutinesApi::class)
 class ParticleRegistrationTest {
     @Test
-    fun serviceLoader_allParticlesAreRegistered() {
+    fun serviceLoader_allParticlesAreRegistered() = runBlockingTest {
         var foundProdHost = false
         var foundTestHost = false
 
-        ServiceLoaderHostRegistry.availableArcHosts.forEach { host: ArcHost ->
+        ServiceLoaderHostRegistry.availableArcHosts().forEach { host: ArcHost ->
             when (host) {
                 is ProdHost -> {
-                    assertThat(host.registeredParticles).contains(TestProdParticle::class)
+                    assertThat(host.registeredParticles()).contains(TestProdParticle::class)
                     foundProdHost = true
                 }
                 is TestHost -> {
-                    assertThat(host.registeredParticles).contains(TestHostParticle::class)
+                    assertThat(host.registeredParticles()).contains(TestHostParticle::class)
                     foundTestHost = true
                 }
             }
@@ -33,27 +37,27 @@ class ParticleRegistrationTest {
     class DummyParticle : Particle
     class DummyHost : AbstractArcHost() {
         init {
-            registerParticle(DummyParticle::class)
+            runBlocking { registerParticle(DummyParticle::class) }
         }
     }
 
     @Test
-    fun serviceLoader_registerHostDynamically() {
+    fun serviceLoader_registerHostDynamically() = runBlockingTest {
         val hostRegistry = ServiceLoaderHostRegistry
         val dummyhost = DummyHost()
         hostRegistry.registerHost(dummyhost)
-        assertThat(hostRegistry.availableArcHosts).contains(dummyhost)
-        assertThat(dummyhost.registeredParticles).contains(DummyParticle::class)
+        assertThat(hostRegistry.availableArcHosts()).contains(dummyhost)
+        assertThat(dummyhost.registeredParticles()).contains(DummyParticle::class)
 
         dummyhost.unregisterParticle(DummyParticle::class)
-        assertThat(dummyhost.registeredParticles).doesNotContain(DummyParticle::class)
+        assertThat(dummyhost.registeredParticles()).doesNotContain(DummyParticle::class)
 
         hostRegistry.unregisterHost(dummyhost)
-        assertThat(hostRegistry.availableArcHosts).doesNotContain(dummyhost)
+        assertThat(hostRegistry.availableArcHosts()).doesNotContain(dummyhost)
     }
 
     @Test
-    fun explicit_allParticlesAreRegistered() {
+    fun explicit_allParticlesAreRegistered() = runBlockingTest {
         var foundProdHost = false
         var foundTestHost = false
 
@@ -62,14 +66,14 @@ class ParticleRegistrationTest {
         ExplicitHostRegistry.registerParticles(
             listOf(TestProdParticle::class, TestHostParticle::class)
         )
-        ExplicitHostRegistry.availableArcHosts.forEach { host: ArcHost ->
+        ExplicitHostRegistry.availableArcHosts().forEach { host: ArcHost ->
             when (host) {
                 is ProdHost -> {
-                    assertThat(host.registeredParticles).contains(TestProdParticle::class)
+                    assertThat(host.registeredParticles()).contains(TestProdParticle::class)
                     foundProdHost = true
                 }
                 is TestHost -> {
-                    assertThat(host.registeredParticles).contains(TestHostParticle::class)
+                    assertThat(host.registeredParticles()).contains(TestHostParticle::class)
                     foundTestHost = true
                 }
             }


### PR DESCRIPTION
* Initial classes for Plan, HandleSpec, ParticleSpec, HandleConnectionSpec, etc. These may be insufficient and need to evolve. 
* Allocator class capable of taking a HostRegistry and Plan, partitioning plan by ArcHost, creating missing storage keys, and invoking ArcHost lifecycle method

Follow-ons:
* ArcHost implementation that can instantiate Handles/StorageProxies, Particles, and drive Particle lifecycle.
* Refactor of APIs to utilize coroutines
* Android HostRegistry facade that communicates via Intents + Parcelable adapters for PlanPartition/*Spec classes/etc

