### PR TITLE
Hide sigh warnings about linking existing files

### DIFF
--- a/tools/sigh.ts
+++ b/tools/sigh.ts
@@ -406,7 +406,7 @@ function tsc(path: string): boolean {
   return result.success;
 }
 
-function makeLink(src: string, dest: string, options: {existing: [string, string, string][]}): boolean {
+function makeLink(src: string, dest: string, options: {existing: {src: string, dest: string, message: string}[]}): boolean {
   try {
     // First we have to ensure the entire path is there.
     const dir = path.dirname(dest);
@@ -417,7 +417,7 @@ function makeLink(src: string, dest: string, options: {existing: [string, string
   } catch (lerr) {
     // In case of racing builds.
     if (lerr.message.startsWith('EEXIST:')) {
-      options.existing.push([src, dest, lerr.message]);
+      options.existing.push({src, dest, message: lerr.message});
     } else {
       console.error(`Error when linking ${src} to ${dest}: ${lerr.message}`);
       return false;

--- a/tools/sigh.ts
+++ b/tools/sigh.ts
@@ -428,7 +428,7 @@ function makeLink(src: string, dest: string, options: {existing: {src: string, d
 
 function link(srcFiles: Iterable<string>): boolean {
   let success = true;
-  let linkOptions = {existing: []};
+  const linkOptions = {existing: []};
   for (const src of srcFiles) {
     const srcStats = fs.statSync(src);
     const dest = src.replace('src', 'build');

--- a/tools/sigh.ts
+++ b/tools/sigh.ts
@@ -406,7 +406,7 @@ function tsc(path: string): boolean {
   return result.success;
 }
 
-function makeLink(src: string, dest: string): boolean {
+function makeLink(src: string, dest: string, options: {existing: [string, string, string][]}): boolean {
   try {
     // First we have to ensure the entire path is there.
     const dir = path.dirname(dest);
@@ -417,7 +417,7 @@ function makeLink(src: string, dest: string): boolean {
   } catch (lerr) {
     // In case of racing builds.
     if (lerr.message.startsWith('EEXIST:')) {
-      console.warn(`Warning when linking ${src} to ${dest}: ${lerr.message}`);
+      options.existing.push([src, dest, lerr.message]);
     } else {
       console.error(`Error when linking ${src} to ${dest}: ${lerr.message}`);
       return false;
@@ -428,6 +428,7 @@ function makeLink(src: string, dest: string): boolean {
 
 function link(srcFiles: Iterable<string>): boolean {
   let success = true;
+  let linkOptions = {existing: []};
   for (const src of srcFiles) {
     const srcStats = fs.statSync(src);
     const dest = src.replace('src', 'build');
@@ -438,14 +439,14 @@ function link(srcFiles: Iterable<string>): boolean {
         // They aren't the same. This is likely due to switching branches.
         // Just remove the destination and make the link.
         fs.unlinkSync(dest);
-        if (!makeLink(src, dest)) {
+        if (!makeLink(src, dest, linkOptions)) {
           success = false;
         }
       }
     } catch (err) {
       // If the error was that the dest does not exist, we make the link.
       if (err.code === 'ENOENT') {
-        if (!makeLink(src, dest)) {
+        if (!makeLink(src, dest, linkOptions)) {
           success = false;
         }
       } else {
@@ -453,6 +454,9 @@ function link(srcFiles: Iterable<string>): boolean {
         success = false;
       }
     }
+  }
+  if (linkOptions.existing !== []) {
+    console.warn(`Warning when linking ${linkOptions.existing.length} file(s) already existed.`);
   }
   return success;
 }


### PR DESCRIPTION
Should shorten travis logs polluted with warnings about the cached files not being (re) linked