### PR TITLE
Fix presubmit wdio error

### DIFF
--- a/tools/local-presubmit
+++ b/tools/local-presubmit
@@ -13,8 +13,6 @@ status "Testing all of the things."
 
 ./tools/sigh webpack
 ./bazelisk test //java/... //javatests/... //src/... //particles/...
-echo generate changes
-echo $@
 ./tools/sigh testShells
 ./tools/ktlint
 ./tools/sigh lint

--- a/tools/local-presubmit
+++ b/tools/local-presubmit
@@ -13,6 +13,8 @@ status "Testing all of the things."
 
 ./tools/sigh webpack
 ./bazelisk test //java/... //javatests/... //src/... //particles/...
+echo generate changes
+echo $@
 ./tools/sigh testShells
 ./tools/ktlint
 ./tools/sigh lint

--- a/tools/sigh.ts
+++ b/tools/sigh.ts
@@ -1031,7 +1031,8 @@ function testWdioShells(args: string[]) : boolean {
       // windows machine (`e:/path/` becomes `e:/e:/path/`)
       //fixPathForWindows(path.resolve('shells/tests/wdio.conf.js'))*/,
       path.resolve('shells/tests/wdio.conf.js'),
-      ...args
+      ...args,
+      '< /dev/null',
   ]);
 }
 

--- a/tools/sigh.ts
+++ b/tools/sigh.ts
@@ -1032,6 +1032,10 @@ function testWdioShells(args: string[]) : boolean {
       //fixPathForWindows(path.resolve('shells/tests/wdio.conf.js'))*/,
       path.resolve('shells/tests/wdio.conf.js'),
       ...args,
+      // WebdriverIO reads the spec data from stdin which pipes in the changed
+      // git object within a git hook. Redirects stdin to the null device to
+      // avoid reading from stdin but from the wdio.conf.js directly.
+      // Also see {@link https://github.com/webdriverio/webdriverio/issues/4957}
       '< /dev/null',
   ]);
 }


### PR DESCRIPTION
git-push triggers pre-submit build/test now.
I got the error at the console:
```
2020-01-21T11:59:13.364Z WARN @wdio/config:ConfigParser: pattern refs/heads/fix_presubmit_wdio 3f8632c1a927bbf73feca6bd081afaf0783ad58d refs/heads/fix_presubmit_wdio 0000000000000000000000000000000000000000 did not match any file
2020-01-21T11:59:13.364Z ERROR @wdio/cli:launcher: No specs found to run, exiting with failure
```

The root cause can be referenced at https://github.com/webdriverio/webdriverio/issues/4957.
