### PR TITLE
Pass all kotlin files in BUILD rule to kotlinc when building a wasm library.

### DIFF
--- a/third_party/java/arcs/build_defs/internal/kotlin.bzl
+++ b/third_party/java/arcs/build_defs/internal/kotlin.bzl
@@ -164,7 +164,7 @@ def arcs_kt_particles(
         wasm_deps = [_to_wasm_dep(dep) for dep in deps]
 
         # Create a wasm library for each particle.
-        wasm_particle_libs = []
+        wasm_srcs = []
         for src in srcs:
             if not src.endswith(".kt"):
                 fail("%s is not a Kotlin file (must end in .kt)" % src)
@@ -178,22 +178,20 @@ def arcs_kt_particles(
                 package = package,
                 out = wasm_annotations_file,
             )
-            arcs_kt_native_library(
-                name = wasm_lib,
-                srcs = [
-                    src,
-                    wasm_annotations_file,
-                ],
-                deps = wasm_deps,
-            )
-            wasm_particle_libs.append(wasm_lib)
+            wasm_srcs.extend([src, wasm_annotations_file])
 
-        # Create a kt_native_binary that groups everything together.
+        wasm_particle_lib = name + "-lib" + _WASM_SUFFIX
+        arcs_kt_native_library(
+	    name = wasm_particle_lib,
+	    srcs = wasm_srcs,
+	    deps = wasm_deps,
+	 )
+         # Create a kt_native_binary that groups everything together.
         native_binary_name = name + _WASM_SUFFIX
         kt_native_binary(
             name = native_binary_name,
             entry_point = "arcs.sdk.main",
-            deps = wasm_particle_libs,
+            deps = [wasm_particle_lib],
             # Don't build this manually. Build the wasm_kt_binary rule below
             # instead; otherwise this rule will build a non-wasm binary.
             tags = ["manual", "notap"],

--- a/third_party/java/arcs/build_defs/internal/kotlin.bzl
+++ b/third_party/java/arcs/build_defs/internal/kotlin.bzl
@@ -163,7 +163,7 @@ def arcs_kt_particles(
     if wasm:
         wasm_deps = [_to_wasm_dep(dep) for dep in deps]
 
-        # Create a wasm library for each particle.
+        # Collect all the sources and annotation files in `wasm_srcs`.
         wasm_srcs = []
         for src in srcs:
             if not src.endswith(".kt"):
@@ -180,13 +180,15 @@ def arcs_kt_particles(
             )
             wasm_srcs.extend([src, wasm_annotations_file])
 
+        # Create a wasm library containing code for all the particles.
         wasm_particle_lib = name + "-lib" + _WASM_SUFFIX
         arcs_kt_native_library(
-	    name = wasm_particle_lib,
-	    srcs = wasm_srcs,
-	    deps = wasm_deps,
-	 )
-         # Create a kt_native_binary that groups everything together.
+            name = wasm_particle_lib,
+            srcs = wasm_srcs,
+            deps = wasm_deps,
+        )
+
+        # Create a kt_native_binary that groups everything together.
         native_binary_name = name + _WASM_SUFFIX
         kt_native_binary(
             name = native_binary_name,


### PR DESCRIPTION
This will allow classes to be refactored out into utilities that can be shared across particles. 

e.g., 

```
// Util.kt
package arcs.is.awesome

class Util {...}

// Particle.kt 
package arcs.is.awesome

class Particle {
  var x:Util = ...
}

// BUILD
arcs_kt_particles(
  name = my_particle,
  srcs = ["Particle.kt", "Util.kt"]
  package = "arcs.is.awesome"
)
```
