### PR TITLE
Update SchemaFields to include field types.

### DIFF
--- a/java/arcs/core/data/Schema.kt
+++ b/java/arcs/core/data/Schema.kt
@@ -30,8 +30,8 @@ data class Schema(
 
     private val emptyRawEntity: RawEntity
         get() = RawEntity(
-            singletonFields = fields.singletons,
-            collectionFields = fields.collections
+            singletonFields = fields.singletons.keys,
+            collectionFields = fields.collections.keys
         )
 
     fun toLiteral(): Literal = Literal(names, fields, description, hash)

--- a/java/arcs/core/data/SchemaFields.kt
+++ b/java/arcs/core/data/SchemaFields.kt
@@ -11,8 +11,40 @@
 
 package arcs.core.data
 
+/** The possible types for a field in a [Schema]. */
+sealed class FieldType(
+    val tag: Tag
+) {
+    /** An Arcs primitive type. */
+    data class Primitive(val primitiveType: PrimitiveType): FieldType(Tag.Primitive)
+
+    /** A reference to an entity. */
+    data class EntityRef(val schemaHash: String) : FieldType(Tag.EntityRef)
+
+    // TODO: Collections of References in fields are not supported in Kotlin at all yet.
+
+    enum class Tag {
+        Primitive,
+        EntityRef
+    }
+
+    // Convenient aliases for all of the primitive field types.
+    companion object {
+        val Boolean = Primitive(PrimitiveType.Boolean)
+        val Number = Primitive(PrimitiveType.Number)
+        val Text = Primitive(PrimitiveType.Text)
+    }
+}
+
+/** Arcs primitive types. */
+enum class PrimitiveType {
+    Boolean,
+    Number,
+    Text,
+}
+
 /** TODO: This is super minimal for now. */
 data class SchemaFields(
-    val singletons: Set<FieldName>,
-    val collections: Set<FieldName>
+    val singletons: Map<FieldName, FieldType>,
+    val collections: Map<FieldName, FieldType>
 )

--- a/java/arcs/core/data/SchemaFields.kt
+++ b/java/arcs/core/data/SchemaFields.kt
@@ -21,8 +21,6 @@ sealed class FieldType(
     /** A reference to an entity. */
     data class EntityRef(val schemaHash: String) : FieldType(Tag.EntityRef)
 
-    // TODO: Collections of References in fields are not supported in Kotlin at all yet.
-
     enum class Tag {
         Primitive,
         EntityRef

--- a/javatests/arcs/android/type/ParcelableSchemaFieldsTest.kt
+++ b/javatests/arcs/android/type/ParcelableSchemaFieldsTest.kt
@@ -13,6 +13,7 @@ package arcs.android.type
 
 import android.os.Parcel
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import arcs.core.data.FieldType
 import arcs.core.data.SchemaFields
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
@@ -24,8 +25,11 @@ class ParcelableSchemaFieldsTest {
     @Test
     fun parcelableRoundtrip_works() {
         val fields = SchemaFields(
-            singletons = setOf("foo", "bar"),
-            collections = setOf("fooCollection", "barCollection")
+            singletons = mapOf("foo" to FieldType.Text, "bar" to FieldType.Number),
+            collections = mapOf(
+                "fooCollection" to FieldType.Text,
+                "barCollection" to FieldType.Number
+            )
         )
 
         val marshalled = with(Parcel.obtain()) {
@@ -45,8 +49,8 @@ class ParcelableSchemaFieldsTest {
     @Test
     fun parcelableRoundtrip_works_emptySets() {
         val fields = SchemaFields(
-            singletons = emptySet(),
-            collections = emptySet()
+            singletons = emptyMap(),
+            collections = emptyMap()
         )
 
         val marshalled = with(Parcel.obtain()) {

--- a/javatests/arcs/android/type/ParcelableSchemaTest.kt
+++ b/javatests/arcs/android/type/ParcelableSchemaTest.kt
@@ -13,6 +13,7 @@ package arcs.android.type
 
 import android.os.Parcel
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import arcs.core.data.FieldType
 import arcs.core.data.Schema
 import arcs.core.data.SchemaDescription
 import arcs.core.data.SchemaFields
@@ -29,8 +30,8 @@ class ParcelableSchemaTest {
         val schema = Schema(
             names = listOf(SchemaName("MySchema"), SchemaName("AlsoMySchema")),
             fields = SchemaFields(
-                singletons = setOf("name", "age"),
-                collections = setOf("friends")
+                singletons = mapOf("name" to FieldType.Text, "age" to FieldType.Number),
+                collections = mapOf("friends" to FieldType.EntityRef("hash"))
             ),
             description = SchemaDescription("MySchemaPattern"),
             hash = "hash"
@@ -54,7 +55,7 @@ class ParcelableSchemaTest {
     fun parcelableRoundtrip_works_empty() {
         val schema = Schema(
             names = emptyList(),
-            fields = SchemaFields(singletons = emptySet(), collections = emptySet()),
+            fields = SchemaFields(singletons = emptyMap(), collections = emptyMap()),
             description = SchemaDescription(),
             hash = "hash"
         )

--- a/javatests/arcs/android/type/ParcelableTypeTest.kt
+++ b/javatests/arcs/android/type/ParcelableTypeTest.kt
@@ -16,6 +16,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import arcs.core.data.CollectionType
 import arcs.core.data.CountType
 import arcs.core.data.EntityType
+import arcs.core.data.FieldType
 import arcs.core.data.ReferenceType
 import arcs.core.data.Schema
 import arcs.core.data.SchemaDescription
@@ -122,8 +123,8 @@ class ParcelableTypeTest {
     private val entitySchema = Schema(
         names = listOf(SchemaName("Person")),
         fields = SchemaFields(
-            singletons = setOf("name", "age"),
-            collections = setOf("friends")
+            singletons = mapOf("name" to FieldType.Text, "age" to FieldType.Number),
+            collections = mapOf("friends" to FieldType.EntityRef("hash"))
         ),
         description = SchemaDescription(),
         hash = "hash"

--- a/javatests/arcs/core/host/AllocatorTest.kt
+++ b/javatests/arcs/core/host/AllocatorTest.kt
@@ -1,6 +1,7 @@
 package arcs.core.host
 
 import arcs.core.common.Id
+import arcs.core.data.FieldType
 import arcs.core.data.Schema
 import arcs.core.data.SchemaDescription
 import arcs.core.data.SchemaFields
@@ -47,7 +48,7 @@ class AllocatorTest {
      */
     private val personSchema = Schema(
         listOf(SchemaName("Person")),
-        SchemaFields(setOf("name"), emptySet()),
+        SchemaFields(mapOf("name" to FieldType.Text), emptyMap()),
         SchemaDescription(),
         "hash"
     )

--- a/javatests/arcs/core/storage/ReferenceModeStoreTest.kt
+++ b/javatests/arcs/core/storage/ReferenceModeStoreTest.kt
@@ -22,6 +22,7 @@ import arcs.core.crdt.internal.VersionMap
 import arcs.core.data.CollectionType
 import arcs.core.data.CountType
 import arcs.core.data.EntityType
+import arcs.core.data.FieldType
 import arcs.core.data.RawEntity
 import arcs.core.data.Schema
 import arcs.core.data.SchemaDescription
@@ -67,7 +68,10 @@ class ReferenceModeStoreTest {
         baseStore = Store(StoreOptions(testKey, ExistenceCriteria.ShouldCreate, CountType()))
         schema = Schema(
             listOf(SchemaName("person")),
-            SchemaFields(setOf("age", "name"), emptySet()),
+            SchemaFields(
+                singletons = mapOf("name" to FieldType.Text, "age" to FieldType.Number),
+                collections = emptyMap()
+            ),
             SchemaDescription(),
             "hash"
         )

--- a/javatests/arcs/core/storage/api/ArcsSetTest.kt
+++ b/javatests/arcs/core/storage/api/ArcsSetTest.kt
@@ -1,5 +1,6 @@
 package arcs.core.storage.api
 
+import arcs.core.data.FieldType
 import arcs.core.data.RawEntity
 import arcs.core.data.Schema
 import arcs.core.data.SchemaDescription
@@ -35,7 +36,7 @@ class ArcsSetTest {
         ReferenceModeStorageKey(backingStorageKey, directStorageKey)
     private val personSchema = Schema(
         listOf(SchemaName("person")),
-        SchemaFields(setOf("name", "age"), emptySet()),
+        SchemaFields(mapOf("name" to FieldType.Text, "age" to FieldType.Number), emptyMap()),
         SchemaDescription(),
         "hash"
     )

--- a/javatests/arcs/core/storage/api/ArcsSingletonTest.kt
+++ b/javatests/arcs/core/storage/api/ArcsSingletonTest.kt
@@ -1,5 +1,6 @@
 package arcs.core.storage.api
 
+import arcs.core.data.FieldType
 import arcs.core.data.RawEntity
 import arcs.core.data.Schema
 import arcs.core.data.SchemaDescription
@@ -30,7 +31,10 @@ class ArcsSingletonTest {
     private val personSchema =
         Schema(
             listOf(SchemaName("person")),
-            SchemaFields(setOf("name", "age"), emptySet()),
+            SchemaFields(
+                singletons = mapOf("name" to FieldType.Text, "age" to FieldType.Number),
+                collections = emptyMap()
+            ),
             SchemaDescription(),
             "hash"
         )


### PR DESCRIPTION
Field types are needed so that we can map entities via their schemas into the normalised database structure.