### PR TITLE
Schema-aware database driver

### DIFF
--- a/java/arcs/core/storage/driver/BUILD
+++ b/java/arcs/core/storage/driver/BUILD
@@ -12,6 +12,7 @@ kt_jvm_and_js_library(
     srcs = glob(["*.kt"]),
     deps = [
         "//java/arcs/core/common",
+        "//java/arcs/core/data",
         "//java/arcs/core/storage",
         "//java/arcs/core/storage:proxy",
         "//java/arcs/core/storage:storage_key",

--- a/java/arcs/core/storage/driver/Database.kt
+++ b/java/arcs/core/storage/driver/Database.kt
@@ -59,10 +59,10 @@ data class DatabaseStorageKey(
         private val ENTITY_SCHEMA_HASH_PATTERN = "[a-fA-F0-9]+".toRegex()
         private const val VARIANT_PERSISTENT = "persistent"
         private const val VARIANT_IN_MEMORY = "in-memory"
-        // ktlint-disable max-line-length
+        /* ktlint-disable max-line-length */
         private val DB_STORAGE_KEY_PATTERN =
             "^($ENTITY_SCHEMA_HASH_PATTERN)@($DATABASE_NAME_PATTERN):($VARIANT_PERSISTENT|$VARIANT_IN_MEMORY)/(.+)\$".toRegex()
-        // ktlint-enable max-line-length
+        /* ktlint-enable max-line-length */
 
         init {
             // When DatabaseStorageKey is imported, this will register its parser with the storage

--- a/javatests/arcs/core/storage/driver/BUILD
+++ b/javatests/arcs/core/storage/driver/BUILD
@@ -12,6 +12,7 @@ arcs_kt_jvm_test_suite(
     package = "arcs.core.storage.driver",
     deps = [
         "//java/arcs/core/common",
+        "//java/arcs/core/data",
         "//java/arcs/core/storage",
         "//java/arcs/core/storage/driver",
         "//java/arcs/core/testutil",

--- a/tools/ktlint
+++ b/tools/ktlint
@@ -2,13 +2,23 @@
 
 source $(dirname $0)/logging.sh
 
+gnuxargs=$(xargs --version 2>&1 |grep -s GNU >/dev/null && echo true || echo false)
+
+function portable_xargs_r() {
+  if $gnuxargs ; then
+    cat - | xargs -r """$@"""
+  else
+    cat - | xargs """$@"""
+  fi
+}
+
 cd $ROOT
 
 # TODO(wkorman): Consider moving ktlint to a sigh or blaze task.
 status "Running ktlint on any Kotlin files modified w.r.t. upstream/master..."
 BASE=$(git merge-base HEAD upstream/master)
 if [[ $BASE ]]; then
-  git diff --name-only --relative $BASE | grep '\.kt[s\"]\?$' | xargs -r ktlint --android --relative --verbose
+  git diff --name-only --relative $BASE | grep '\.kt[s\"]\?$' | portable_xargs_r ktlint --android --relative --verbose
 else
   fail "Could not determine the common ancestor for HEAD and upstream/master"
 fi


### PR DESCRIPTION
* Adds entity schema hash to `DatabaseStorageKey`
* Requires the Allocator/ArcHost/Whatever to provide the `DatabaseDriverProvider` with a lambda capable of returning `Schema` values when given a hash.
* Fixes `tools/ktlint` to work properly on mac.