### PR TITLE
Moves test code into test blocks

### DIFF
--- a/src/dataflow/analysis/tests/analysis-test.ts
+++ b/src/dataflow/analysis/tests/analysis-test.ts
@@ -394,10 +394,12 @@ describe('Solver', () => {
   });
 });
 
-const entityString = Flags.useNewStorageStack ?
-  '{"root": {"values": {"ida": {"value": {"id": "ida", "text": "asdf"}, "version": {"u": 1}}}, "version":{"u": 1}}, "locations": {}}'
-  :
-  '[{"text": "asdf"}]';
+function entityString() {
+  if (Flags.useNewStorageStack) {
+    return '{"root": {"values": {"ida": {"value": {"id": "ida", "text": "asdf"}, "version": {"u": 1}}}, "version":{"u": 1}}, "locations": {}}';
+  }
+  return '[{"text": "asdf"}]';
+}
 
 describe('FlowGraph validation', () => {
   it('succeeds when there are no checks', async () => {
@@ -904,7 +906,7 @@ describe('FlowGraph validation', () => {
         text: Text
       resource MyResource
         start
-        ${entityString}
+        ${entityString()}
       store MyStore of MyEntity in MyResource
         claim is trusted
       particle P
@@ -1161,7 +1163,7 @@ describe('FlowGraph validation', () => {
           text: Text
         resource MyResource
           start
-          ${entityString}
+          ${entityString()}
         store MyStore of MyEntity in MyResource
         particle P
           input: reads MyEntity
@@ -1180,7 +1182,7 @@ describe('FlowGraph validation', () => {
           text: Text
         resource MyResource
           start
-          ${entityString}
+          ${entityString()}
         store MyStore of MyEntity 'my-store-id' in MyResource
         particle P
           input: reads MyEntity
@@ -1199,7 +1201,7 @@ describe('FlowGraph validation', () => {
           text: Text
         resource MyResource
           start
-          ${entityString}
+          ${entityString()}
         store MyStore of MyEntity 'my-store-id' in MyResource
         particle P
           input: reads MyEntity
@@ -1219,7 +1221,7 @@ describe('FlowGraph validation', () => {
           text: Text
         resource MyResource
           start
-          ${entityString}
+          ${entityString()}
         store MyStore of MyEntity 'my-store-id' in MyResource
         particle P
           input: reads MyEntity
@@ -1260,7 +1262,7 @@ describe('FlowGraph validation', () => {
           text: Text
         resource MyResource
           start
-          ${entityString}
+          ${entityString()}
         store MyStore of MyEntity 'my-store-id' in MyResource
         store SomeOtherStore of MyEntity in MyResource
         particle P
@@ -1279,7 +1281,7 @@ describe('FlowGraph validation', () => {
           text: Text
         resource MyResource
           start
-          ${entityString}
+          ${entityString()}
         store MyStore of MyEntity in MyResource
         store SomeOtherStore of MyEntity in MyResource
         particle P

--- a/src/planning/plan/tests/planificator-test.ts
+++ b/src/planning/plan/tests/planificator-test.ts
@@ -62,10 +62,11 @@ describe('planificator', () => {
 
 describe('remote planificator', () => {
   // TODO: support arc storage key be in PouchDB as well.
-  const arcStorageKey = storageKeyPrefixForTest();
+  let arcStorageKey;
 
   let memoryProvider;
   beforeEach(() => {
+    arcStorageKey = storageKeyPrefixForTest();
     memoryProvider = new TestVolatileMemoryProvider();
     RamDiskStorageDriverProvider.register(memoryProvider);
   });

--- a/src/planning/plan/tests/planificator-test.ts
+++ b/src/planning/plan/tests/planificator-test.ts
@@ -66,7 +66,6 @@ describe('remote planificator', () => {
 
   let memoryProvider;
   beforeEach(() => {
-    Flags.reset();
     arcStorageKey = storageKeyPrefixForTest();
     memoryProvider = new TestVolatileMemoryProvider();
     RamDiskStorageDriverProvider.register(memoryProvider);

--- a/src/planning/plan/tests/planificator-test.ts
+++ b/src/planning/plan/tests/planificator-test.ts
@@ -66,6 +66,7 @@ describe('remote planificator', () => {
 
   let memoryProvider;
   beforeEach(() => {
+    Flags.reset();
     arcStorageKey = storageKeyPrefixForTest();
     memoryProvider = new TestVolatileMemoryProvider();
     RamDiskStorageDriverProvider.register(memoryProvider);

--- a/src/tests/particles/products-test.ts
+++ b/src/tests/particles/products-test.ts
@@ -24,13 +24,17 @@ import {TestVolatileMemoryProvider} from '../../runtime/testing/test-volatile-me
 
 describe('products test', () => {
 
+  beforeEach(() => {
+    manifestFilename = Flags.useNewStorageStack ?
+      './src/tests/particles/artifacts/ProductsTestNg.arcs' :
+      './src/tests/particles/artifacts/products-test.recipes';
+  });
+
   afterEach(() => {
     DriverFactory.clearRegistrationsForTesting();
   });
 
-  const manifestFilename = Flags.useNewStorageStack ?
-      './src/tests/particles/artifacts/ProductsTestNg.arcs' :
-      './src/tests/particles/artifacts/products-test.recipes';
+  let manifestFilename: string;
 
   const verifyFilteredBook = async (arc: Arc) => {
     const booksHandle = arc.activeRecipe.handleConnections.find(hc => hc.isOutput).handle;


### PR DESCRIPTION
This should improve some unreliable behavior when using flags (as test code was executing before the flags were set).

I think we still need to find a place to inject a `Flags.reset()` that will always run before