### PR TITLE
Remove unnecessary dot qualifier on bazel_binary.

### DIFF
--- a/.bazelproject
+++ b/.bazelproject
@@ -16,7 +16,7 @@ targets:
 test_sources:
   javatests/
 
-bazel_binary: ./tools/bazelisk
+bazel_binary: tools/bazelisk
 
 additional_languages:
   kotlin


### PR DESCRIPTION
Things worked but the path in Bazel console was unsightly as it read `.../arcs/./tools/bazelisk`.