### PR TITLE
Plumb CRDT KClass through storage to drivers.

### DIFF
--- a/java/arcs/android/storage/database/BUILD
+++ b/java/arcs/android/storage/database/BUILD
@@ -12,6 +12,7 @@ kt_android_library(
         "//java/arcs/android/common",  # unuseddeps: keep
         "//java/arcs/core/data",
         "//java/arcs/core/storage",
+        "//java/arcs/core/storage:storage_key",
         "//java/arcs/core/storage/database",
         "//java/arcs/core/util",
         "//third_party/java/androidx/annotation",

--- a/java/arcs/core/crdt/CrdtModel.kt
+++ b/java/arcs/core/crdt/CrdtModel.kt
@@ -14,6 +14,7 @@ package arcs.core.crdt
 import arcs.core.crdt.CrdtChange.Data
 import arcs.core.crdt.internal.VersionMap
 import arcs.core.type.Type
+import kotlin.reflect.KClass
 
 /**
  * A [CrdtModel] can:
@@ -141,6 +142,9 @@ sealed class CrdtChange<Data : CrdtData, Op : CrdtOperation> {
 
 /** Defines a [Type] that's capable of generating a [CrdtModel]. */
 interface CrdtModelType<Data : CrdtData, Op : CrdtOperation, ConsumerData> : Type {
+    /** The [KClass] of the [Data] this type works with. */
+    val crdtModelDataClass: KClass<*>
+
     /** Creates a new instance of a [CrdtModel]. */
     fun createCrdtModel(): CrdtModel<Data, Op, ConsumerData>
 }

--- a/java/arcs/core/data/CollectionType.kt
+++ b/java/arcs/core/data/CollectionType.kt
@@ -21,6 +21,7 @@ import arcs.core.type.Tag
 import arcs.core.type.Type
 import arcs.core.type.TypeFactory
 import arcs.core.type.TypeLiteral
+import kotlin.reflect.KClass
 
 /** Extension function to wrap any type in a collection type. */
 fun <T : Type> T?.collectionOf(): CollectionType<T>? =
@@ -49,6 +50,8 @@ data class CollectionType<T : Type>(
                 collectionResolvedType.collectionOf()
             } else this
         }
+
+    override val crdtModelDataClass: KClass<*> = CrdtSet.DataImpl::class
 
     override fun maybeEnsureResolved(): Boolean = collectionType.maybeEnsureResolved()
 

--- a/java/arcs/core/data/CountType.kt
+++ b/java/arcs/core/data/CountType.kt
@@ -17,11 +17,14 @@ import arcs.core.type.Tag
 import arcs.core.type.Type
 import arcs.core.type.TypeFactory
 import arcs.core.type.TypeLiteral
+import kotlin.reflect.KClass
 
 /** [Type] representation for a counter. */
 data class CountType(
     override val tag: Tag = Tag.Count
 ) : Type, CrdtModelType<CrdtCount.Data, CrdtCount.Operation, Int> {
+    override val crdtModelDataClass: KClass<*> = CrdtCount.Data::class
+
     override fun toLiteral() = Literal(tag)
 
     override fun createCrdtModel() = CrdtCount()

--- a/java/arcs/core/data/EntityType.kt
+++ b/java/arcs/core/data/EntityType.kt
@@ -18,6 +18,7 @@ import arcs.core.type.Tag
 import arcs.core.type.Type
 import arcs.core.type.TypeFactory
 import arcs.core.type.TypeLiteral
+import kotlin.reflect.KClass
 
 /** [Type] representation of an entity. */
 data class EntityType(override val entitySchema: Schema) :
@@ -26,6 +27,8 @@ data class EntityType(override val entitySchema: Schema) :
     CrdtModelType<CrdtEntity.Data, CrdtEntity.Operation, RawEntity> {
 
     override val tag = Tag.Entity
+
+    override val crdtModelDataClass: KClass<*> = CrdtEntity.Data::class
 
     override fun copyWithResolutions(variableMap: MutableMap<Any, Any>): Type =
         variableMap[entitySchema] as? Type

--- a/java/arcs/core/data/SingletonType.kt
+++ b/java/arcs/core/data/SingletonType.kt
@@ -18,6 +18,7 @@ import arcs.core.type.Tag
 import arcs.core.type.Type
 import arcs.core.type.TypeFactory
 import arcs.core.type.TypeLiteral
+import kotlin.reflect.KClass
 
 /** [Type] representation for a singleton. */
 data class SingletonType<T : Type>(override val containedType: T) :
@@ -28,6 +29,8 @@ data class SingletonType<T : Type>(override val containedType: T) :
         CrdtSingleton.IOperation<Referencable>,
         Referencable?> {
     override val tag = Tag.Singleton
+
+    override val crdtModelDataClass: KClass<*> = CrdtSingleton.DataImpl::class
 
     override fun toLiteral() = Literal(tag, containedType.toLiteral())
 

--- a/java/arcs/core/storage/BackingStore.kt
+++ b/java/arcs/core/storage/BackingStore.kt
@@ -98,10 +98,10 @@ class BackingStore<Data : CrdtData, Op : CrdtOperation, T>(
                 is ReferenceType<*> -> when (val contained = type.containedType) {
                     is CrdtModelType<*, *, *> -> contained.crdtModelDataClass
                     else -> throw UnsupportedOperationException(
-                        "Unsupported contained type: ${options.type}"
+                        "Unsupported contained type: $contained"
                     )
                 }
-                else -> throw UnsupportedOperationException("Unsupported type: ${options.type}")
+                else -> throw UnsupportedOperationException("Unsupported type: $type")
             }
         ) as DirectStore<Data, Op, T>
 

--- a/java/arcs/core/storage/BackingStore.kt
+++ b/java/arcs/core/storage/BackingStore.kt
@@ -12,7 +12,9 @@
 package arcs.core.storage
 
 import arcs.core.crdt.CrdtData
+import arcs.core.crdt.CrdtModelType
 import arcs.core.crdt.CrdtOperation
+import arcs.core.data.ReferenceType
 import arcs.core.storage.ProxyMessage.ModelUpdate
 import arcs.core.storage.ProxyMessage.Operations
 import arcs.core.storage.ProxyMessage.SyncRequest
@@ -90,7 +92,17 @@ class BackingStore<Data : CrdtData, Op : CrdtOperation, T>(
     /* internal */ suspend fun setupStore(muxId: String): StoreRecord<Data, Op, T> {
         val store = DirectStore.CONSTRUCTOR(
             // Copy of our options, but with a child storage key using the muxId.
-            options.copy(options.storageKey.childKeyWithComponent(muxId))
+            options.copy(options.storageKey.childKeyWithComponent(muxId)),
+            dataClass = when (val type = options.type) {
+                is CrdtModelType<*, *, *> -> type.crdtModelDataClass
+                is ReferenceType<*> -> when (val contained = type.containedType) {
+                    is CrdtModelType<*, *, *> -> contained.crdtModelDataClass
+                    else -> throw UnsupportedOperationException(
+                        "Unsupported contained type: ${options.type}"
+                    )
+                }
+                else -> throw UnsupportedOperationException("Unsupported type: ${options.type}")
+            }
         ) as DirectStore<Data, Op, T>
 
         val id = store.on(ProxyCallback { processStoreCallback(muxId, it) })
@@ -112,8 +124,8 @@ class BackingStore<Data : CrdtData, Op : CrdtOperation, T>(
 
     companion object {
         @Suppress("UNCHECKED_CAST")
-        val CONSTRUCTOR = StoreConstructor<CrdtData, CrdtOperation, Any?> {
-            BackingStore(it as StoreOptions<CrdtData, CrdtOperation, Any?>)
+        val CONSTRUCTOR = StoreConstructor<CrdtData, CrdtOperation, Any?> { options, dataClass ->
+            BackingStore(options as StoreOptions<CrdtData, CrdtOperation, Any?>)
         }
     }
 }

--- a/java/arcs/core/storage/DirectStore.kt
+++ b/java/arcs/core/storage/DirectStore.kt
@@ -22,6 +22,7 @@ import arcs.core.storage.DirectStore.State.Name.AwaitingResponse
 import arcs.core.storage.DirectStore.State.Name.Idle
 import arcs.core.util.TaggedLog
 import kotlin.coroutines.coroutineContext
+import kotlin.reflect.KClass
 import kotlinx.atomicfu.AtomicRef
 import kotlinx.atomicfu.atomic
 import kotlinx.atomicfu.getAndUpdate
@@ -414,7 +415,7 @@ class DirectStore<Data : CrdtData, Op : CrdtOperation, T> /* internal */ constru
          */
         private const val MAX_UPDATE_SPINS = 1000
 
-        suspend fun <Data : CrdtData, Op : CrdtOperation, T> create(
+        suspend inline fun <reified Data : CrdtData, Op : CrdtOperation, T> create(
             options: StoreOptions<Data, Op, T>,
             type: CrdtModelType<Data, Op, T>
         ): DirectStore<Data, Op, T> {
@@ -427,7 +428,7 @@ class DirectStore<Data : CrdtData, Op : CrdtOperation, T> /* internal */ constru
 
         @Suppress("UNCHECKED_CAST")
         // TODO: generics here are sub-optimal, can we make this constructor generic itself?
-        val CONSTRUCTOR = StoreConstructor<CrdtData, CrdtOperation, Any?> { options ->
+        val CONSTRUCTOR = StoreConstructor<CrdtData, CrdtOperation, Any?> { options, dataClass ->
             val localModel =
                 requireNotNull(options.type as? CrdtModelType<CrdtData, CrdtOperation, Any?>) {
                     "Specified type ${options.type} does not implement CrdtModelType"
@@ -437,13 +438,17 @@ class DirectStore<Data : CrdtData, Op : CrdtOperation, T> /* internal */ constru
 
             val driver =
                 CrdtException.requireNotNull(
-                    DriverFactory.getDriver<CrdtData>(options.storageKey, options.existenceCriteria)
+                    DriverFactory.getDriver(
+                        options.storageKey,
+                        options.existenceCriteria,
+                        dataClass as KClass<out CrdtData>
+                    )
                 ) { "No driver exists to support storage key ${options.storageKey}" }
 
             return@StoreConstructor DirectStore(
                 options as StoreOptions<CrdtData, CrdtOperation, Any?>,
                 localModel = localModel,
-                driver = driver
+                driver = driver as Driver<CrdtData>
             ).also { store ->
                 driver.registerReceiver(options.versionToken) { data, version ->
                     store.onReceive(data, version)

--- a/java/arcs/core/storage/DriverFactory.kt
+++ b/java/arcs/core/storage/DriverFactory.kt
@@ -11,6 +11,7 @@
 
 package arcs.core.storage
 
+import kotlin.reflect.KClass
 import kotlinx.atomicfu.atomic
 import kotlinx.atomicfu.update
 
@@ -28,13 +29,23 @@ object DriverFactory {
     /**
      * Fetches a [Driver] of type [Data] given its [storageKey] with specified [existenceCriteria].
      */
-    suspend fun <Data : Any> getDriver(
+    suspend inline fun <reified Data : Any> getDriver(
         storageKey: StorageKey,
         existenceCriteria: ExistenceCriteria
+    ): Driver<Data>? = getDriver(storageKey, existenceCriteria, Data::class)
+
+    /**
+     * Fetches a [Driver] of type [Data] (declared by [dataClass]) given its [storageKey] with
+     * specified [existenceCriteria].
+     */
+    suspend fun <Data : Any> getDriver(
+        storageKey: StorageKey,
+        existenceCriteria: ExistenceCriteria,
+        dataClass: KClass<Data>
     ): Driver<Data>? {
         return providers.value
             .find { it.willSupport(storageKey) }
-            ?.getDriver(storageKey, existenceCriteria)
+            ?.getDriver(storageKey, existenceCriteria, dataClass)
     }
 
     /** Registers a new [DriverProvider]. */
@@ -55,6 +66,7 @@ interface DriverProvider {
     /** Gets a [Driver] for the given [storageKey] with the specified [existenceCriteria]. */
     suspend fun <Data : Any> getDriver(
         storageKey: StorageKey,
-        existenceCriteria: ExistenceCriteria
+        existenceCriteria: ExistenceCriteria,
+        dataClass: KClass<Data>
     ): Driver<Data>
 }

--- a/java/arcs/core/storage/ReferenceModeStore.kt
+++ b/java/arcs/core/storage/ReferenceModeStore.kt
@@ -108,7 +108,7 @@ class ReferenceModeStore private constructor(
      * When entity updates are received by instances of [ReferenceModeStore], they're non-CRDT blobs
      * of data. The [ReferenceModeStore] needs to convert them to tracked CRDTs, which means it
      * needs to synthesize updates. This key is used as the unique write key and
-     * [arcs.crdt.internal.Actor] for those updates.
+     * [arcs.core.crdt.internal.Actor] for those updates.
      */
     /* internal */ val crdtKey = Random.nextSafeRandomLong().toString()
     /**
@@ -572,53 +572,66 @@ class ReferenceModeStore private constructor(
             maxVersion = maxOf(maxVersion, fieldVersion)
         }
 
-        return CrdtEntity.Data(entity, VersionMap(crdtKey to maxVersion), fieldVersionProvider) {
-            CrdtEntity.ReferenceImpl(it.id)
-        }
+        return CrdtEntity.Data(
+            entity,
+            VersionMap(crdtKey to maxVersion),
+            fieldVersionProvider
+        ) { CrdtEntity.ReferenceImpl(it.id) }
     }
 
     companion object {
         @Suppress("UNCHECKED_CAST")
-        val CONSTRUCTOR = StoreConstructor<CrdtData, CrdtOperationAtTime, Referencable> { options ->
-            val refableOptions =
-                requireNotNull(
-                    options as? StoreOptions<RefModeStoreData, RefModeStoreOp, RefModeStoreOutput>
-                ) { "ReferenceMode stores only manage singletons/collections of Entities." }
+        val CONSTRUCTOR =
+            StoreConstructor<CrdtData, CrdtOperationAtTime, Referencable> { options, dataClass ->
+                val refableOptions =
+                    requireNotNull(
+                        /* ktlint-disable max-line-length */
+                        options as? StoreOptions<RefModeStoreData, RefModeStoreOp, RefModeStoreOutput>
+                        /* ktlint-enable max-line-length */
+                    ) { "ReferenceMode stores only manage singletons/collections of Entities." }
 
-            val type = requireNotNull(options.type as? Type.TypeContainer<*>) {
-                "Type ${options.type} does not implement TypeContainer"
-            }
-            val storageKey = requireNotNull(options.storageKey as? ReferenceModeStorageKey) {
-                "StorageKey ${options.storageKey} is not a ReferenceModeStorageKey"
-            }
-            val refType = if (options.type is CollectionType<*>) {
-                CollectionType(ReferenceType(type.containedType))
-            } else {
-                SingletonType(ReferenceType(type.containedType))
-            }
+                val (type, containedTypeClass) = requireNotNull(
+                    options.type as? Type.TypeContainer<*>
+                ) { "Type ${options.type} does not implement TypeContainer" }.let {
+                    /* ktlint-disable max-line-length */
+                    it to requireNotNull(it.containedType as? CrdtModelType<*, *, *>).crdtModelDataClass
+                    /* ktlint-enable max-line-length */
+                }
+                val storageKey = requireNotNull(options.storageKey as? ReferenceModeStorageKey) {
+                    "StorageKey ${options.storageKey} is not a ReferenceModeStorageKey"
+                }
+                val (refType, refTypeDataClass) = if (options.type is CollectionType<*>) {
+                    CollectionType(ReferenceType(type.containedType)) to
+                        CrdtSet.DataImpl::class
+                } else {
+                    SingletonType(ReferenceType(type.containedType)) to
+                        CrdtSingleton.DataImpl::class
+                }
 
-            val backingStore = BackingStore.CONSTRUCTOR(
-                StoreOptions(
-                    storageKey = storageKey.backingKey,
-                    existenceCriteria = options.existenceCriteria,
-                    type = type.containedType,
-                    mode = StorageMode.Backing,
-                    baseStore = options.baseStore
-                )
-            ) as BackingStore<CrdtData, CrdtOperation, Any?>
-            val containerStore = DirectStore.CONSTRUCTOR(
-                StoreOptions(
-                    storageKey = storageKey.storageKey,
-                    existenceCriteria = options.existenceCriteria,
-                    type = refType,
-                    baseStore = options.baseStore,
-                    versionToken = options.versionToken
-                )
-            ) as DirectStore<CrdtData, CrdtOperation, Any?>
+                val backingStore = BackingStore.CONSTRUCTOR(
+                    StoreOptions(
+                        storageKey = storageKey.backingKey,
+                        existenceCriteria = options.existenceCriteria,
+                        type = type.containedType,
+                        mode = StorageMode.Backing,
+                        baseStore = options.baseStore
+                    ),
+                    containedTypeClass
+                ) as BackingStore<CrdtData, CrdtOperation, Any?>
+                val containerStore = DirectStore.CONSTRUCTOR(
+                    StoreOptions(
+                        storageKey = storageKey.storageKey,
+                        existenceCriteria = options.existenceCriteria,
+                        type = refType,
+                        baseStore = options.baseStore,
+                        versionToken = options.versionToken
+                    ),
+                    refTypeDataClass
+                ) as DirectStore<CrdtData, CrdtOperation, Any?>
 
-            ReferenceModeStore(refableOptions, backingStore, containerStore).apply {
-                registerStoreCallbacks()
+                ReferenceModeStore(refableOptions, backingStore, containerStore).apply {
+                    registerStoreCallbacks()
+                }
             }
-        }
     }
 }

--- a/java/arcs/core/storage/Store.kt
+++ b/java/arcs/core/storage/Store.kt
@@ -13,6 +13,7 @@ package arcs.core.storage
 
 import arcs.core.crdt.CrdtData
 import arcs.core.crdt.CrdtException
+import arcs.core.crdt.CrdtModelType
 import arcs.core.crdt.CrdtOperation
 import arcs.core.storage.Store.Companion.defaultFactory
 import arcs.core.type.Type
@@ -90,8 +91,13 @@ class Store<Data : CrdtData, Op : CrdtOperation, ConsumerData>(
                 "No constructor registered for mode ${options.mode}"
             }
 
+            val dataClass = when (val type = options.type) {
+                is CrdtModelType<*, *, *> -> type.crdtModelDataClass
+                else -> throw CrdtException("Unsupported type for storage: $type")
+            }
+
             return CrdtException.requireNotNull(
-                constructor(options) as? ActiveStore<Data, Op, ConsumerData>
+                constructor(options, dataClass) as? ActiveStore<Data, Op, ConsumerData>
             ) { "Could not cast constructed store to ActiveStore${constructor.typeParamString}" }
         }
     }

--- a/java/arcs/core/storage/StoreInterface.kt
+++ b/java/arcs/core/storage/StoreInterface.kt
@@ -36,14 +36,15 @@ data class StoreConstructor(
     val opClass: KClass<out CrdtOperation>,
     /* internal */
     val consumerDataClass: KClass<*>,
-    private val constructor: suspend (StoreOptions<*, *, *>) -> ActiveStore<*, *, *>
+    private val constructor: suspend (StoreOptions<*, *, *>, KClass<*>) -> ActiveStore<*, *, *>
 ) {
     val typeParamString: String
         get() = "<$dataClass, $opClass, $consumerDataClass>"
 
     /* internal */ suspend operator fun <Data : CrdtData, Op : CrdtOperation, ConsumerData> invoke(
-        options: StoreOptions<Data, Op, ConsumerData>
-    ) = constructor(options)
+        options: StoreOptions<Data, Op, ConsumerData>,
+        dataClass: KClass<*>
+    ) = constructor(options, dataClass)
 }
 
 /**
@@ -51,7 +52,7 @@ data class StoreConstructor(
  * [ActiveStore] instance as a [StoreConstructor].
  */
 inline fun <reified Data, reified Op, reified ConsumerData> StoreConstructor(
-    noinline constructor: suspend (StoreOptions<*, *, *>) -> ActiveStore<*, *, *>
+    noinline constructor: suspend (StoreOptions<*, *, *>, KClass<*>) -> ActiveStore<*, *, *>
 ): StoreConstructor where Data : CrdtData, Op : CrdtOperation =
     StoreConstructor(Data::class, Op::class, ConsumerData::class, constructor)
 

--- a/java/arcs/core/storage/driver/BUILD
+++ b/java/arcs/core/storage/driver/BUILD
@@ -12,6 +12,7 @@ kt_jvm_and_js_library(
     srcs = glob(["*.kt"]),
     deps = [
         "//java/arcs/core/common",
+        "//java/arcs/core/crdt",
         "//java/arcs/core/data",
         "//java/arcs/core/storage",
         "//java/arcs/core/storage:proxy",

--- a/java/arcs/core/storage/driver/RamDisk.kt
+++ b/java/arcs/core/storage/driver/RamDisk.kt
@@ -17,6 +17,7 @@ import arcs.core.storage.DriverProvider
 import arcs.core.storage.ExistenceCriteria
 import arcs.core.storage.StorageKey
 import arcs.core.storage.StorageKeyParser
+import kotlin.reflect.KClass
 
 /** Protocol to be used with the ramdisk driver. */
 const val RAMDISK_DRIVER_PROTOCOL = "ramdisk"
@@ -72,7 +73,8 @@ class RamDiskDriverProvider : DriverProvider {
 
     override suspend fun <Data : Any> getDriver(
         storageKey: StorageKey,
-        existenceCriteria: ExistenceCriteria
+        existenceCriteria: ExistenceCriteria,
+        dataClass: KClass<Data>
     ): Driver<Data> {
         require(willSupport(storageKey)) {
             "This provider does not support StorageKey: $storageKey"

--- a/java/arcs/core/storage/driver/Volatile.kt
+++ b/java/arcs/core/storage/driver/Volatile.kt
@@ -21,6 +21,7 @@ import arcs.core.storage.StorageKey
 import arcs.core.storage.StorageKeyParser
 import arcs.core.util.Random
 import arcs.core.util.TaggedLog
+import kotlin.reflect.KClass
 import kotlinx.atomicfu.atomic
 
 /** Protocol to be used with the volatile driver. */
@@ -77,7 +78,8 @@ data class VolatileDriverProvider(private val arcId: ArcId) : DriverProvider {
 
     override suspend fun <Data : Any> getDriver(
         storageKey: StorageKey,
-        existenceCriteria: ExistenceCriteria
+        existenceCriteria: ExistenceCriteria,
+        dataClass: KClass<Data>
     ): Driver<Data> {
         require(
             willSupport(storageKey)

--- a/javatests/arcs/android/storage/database/BUILD
+++ b/javatests/arcs/android/storage/database/BUILD
@@ -13,9 +13,9 @@ arcs_kt_android_test_suite(
     package = "arcs.android.storage.database",
     deps = [
         "//java/arcs/android/common",  # unuseddeps: keep
-        "//java/arcs/core/storage:storage_key",
         "//java/arcs/android/storage/database",
         "//java/arcs/core/data",
+        "//java/arcs/core/storage:storage_key",
         "//java/arcs/core/testutil",
         "//third_party/android/androidx_test/core",
         "//third_party/android/androidx_test/ext/junit",

--- a/javatests/arcs/android/storage/database/BUILD
+++ b/javatests/arcs/android/storage/database/BUILD
@@ -13,6 +13,7 @@ arcs_kt_android_test_suite(
     package = "arcs.android.storage.database",
     deps = [
         "//java/arcs/android/common",  # unuseddeps: keep
+        "//java/arcs/core/storage:storage_key",
         "//java/arcs/android/storage/database",
         "//java/arcs/core/data",
         "//java/arcs/core/testutil",

--- a/javatests/arcs/android/storage/database/DatabaseImplTest.kt
+++ b/javatests/arcs/android/storage/database/DatabaseImplTest.kt
@@ -21,15 +21,14 @@ import arcs.core.data.Schema
 import arcs.core.data.SchemaDescription
 import arcs.core.data.SchemaFields
 import arcs.core.testutil.assertSuspendingThrows
-import arcs.core.testutil.assertThrows
 import com.google.common.truth.Truth.assertThat
+import java.lang.IllegalArgumentException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runBlockingTest
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import java.lang.IllegalArgumentException
 
 @ExperimentalCoroutinesApi
 @RunWith(AndroidJUnit4::class)

--- a/javatests/arcs/core/storage/ReferenceModeStoreTest.kt
+++ b/javatests/arcs/core/storage/ReferenceModeStoreTest.kt
@@ -38,6 +38,7 @@ import arcs.core.storage.referencemode.ReferenceModeStorageKey
 import arcs.core.storage.referencemode.toReference
 import arcs.core.testutil.assertSuspendingThrows
 import com.google.common.truth.Truth.assertThat
+import kotlin.reflect.KClass
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
@@ -410,7 +411,7 @@ class ReferenceModeStoreTest {
         // local model from proxy.
         val bobCollection = CrdtSet<RawEntity>()
         val bob = createPersonEntity("an-id", "bob", 42)
-        bobCollection.applyOperation( CrdtSet.Operation.Add("me", VersionMap("me" to 1), bob))
+        bobCollection.applyOperation(CrdtSet.Operation.Add("me", VersionMap("me" to 1), bob))
 
         // conflicting remote count from store
         val remoteCollection = CrdtSet<Reference>()
@@ -587,7 +588,9 @@ class ReferenceModeStoreTest {
 
     // region Helpers
 
-    private fun BackingStore<CrdtData, CrdtOperation, Any?>.getEntityDriver(id: ReferenceId): MockDriver<CrdtEntity.Data> =
+    private fun BackingStore<CrdtData, CrdtOperation, Any?>.getEntityDriver(
+        id: ReferenceId
+    ): MockDriver<CrdtEntity.Data> =
         requireNotNull(stores[id]).store.driver as MockDriver<CrdtEntity.Data>
 
     private suspend fun createReferenceModeStore(): ReferenceModeStore {
@@ -597,7 +600,8 @@ class ReferenceModeStoreTest {
                 ExistenceCriteria.ShouldCreate,
                 CollectionType(EntityType(schema)),
                 StorageMode.ReferenceMode
-            )
+            ),
+            CrdtSet.Data::class
         ) as ReferenceModeStore
     }
 
@@ -661,8 +665,9 @@ class ReferenceModeStoreTest {
 
         override suspend fun <Data : Any> getDriver(
             storageKey: StorageKey,
-            existenceCriteria: ExistenceCriteria
-        ): Driver<Data> = MockDriver<Data>(storageKey, existenceCriteria)
+            existenceCriteria: ExistenceCriteria,
+            dataClass: KClass<Data>
+        ): Driver<Data> = MockDriver(storageKey, existenceCriteria)
     }
 
     private class MockDriver<T : Any>(

--- a/javatests/arcs/core/storage/StoreTest.kt
+++ b/javatests/arcs/core/storage/StoreTest.kt
@@ -22,6 +22,7 @@ import com.google.common.truth.Truth.assertThat
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.anyOrNull
 import com.nhaarman.mockitokotlin2.argumentCaptor
+import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import kotlinx.atomicfu.atomic
@@ -338,7 +339,7 @@ class StoreTest {
         val provider = mock<DriverProvider> {
             on { willSupport(testKey) }.thenReturn(true)
         }
-        whenever(provider.getDriver<CrdtCount.Data>(any(), any())).thenReturn(driver)
+        whenever(provider.getDriver(any(), any(), eq(CrdtCount.Data::class))).thenReturn(driver)
 
         DriverFactory.register(provider)
 

--- a/javatests/arcs/core/storage/driver/DatabaseDriverProviderTest.kt
+++ b/javatests/arcs/core/storage/driver/DatabaseDriverProviderTest.kt
@@ -87,7 +87,7 @@ class DatabaseDriverProviderTest {
         val volatile = VolatileStorageKey(ArcId.newForTest("myarc"), "foo")
 
         assertSuspendingThrows(IllegalArgumentException::class) {
-            provider.getDriver<Int>(volatile, ExistenceCriteria.ShouldCreate)
+            provider.getDriver(volatile, ExistenceCriteria.ShouldCreate, Int::class)
         }
         Unit
     }
@@ -98,7 +98,7 @@ class DatabaseDriverProviderTest {
         val key = DatabaseStorageKey("foo", "1234a")
 
         assertSuspendingThrows(IllegalArgumentException::class) {
-            provider.getDriver<Int>(key, ExistenceCriteria.ShouldCreate)
+            provider.getDriver(key, ExistenceCriteria.ShouldCreate, Int::class)
         }
         Unit
     }

--- a/javatests/arcs/core/storage/driver/RamDiskDriverProviderTest.kt
+++ b/javatests/arcs/core/storage/driver/RamDiskDriverProviderTest.kt
@@ -69,7 +69,7 @@ class RamDiskDriverProviderTest {
         val provider = RamDiskDriverProvider()
         val volatile = VolatileStorageKey(ArcId.newForTest("myarc"), "foo")
 
-        provider.getDriver<Int>(volatile, ExistenceCriteria.ShouldCreate)
+        provider.getDriver(volatile, ExistenceCriteria.ShouldCreate, Int::class)
         Unit
     }
 
@@ -80,9 +80,9 @@ class RamDiskDriverProviderTest {
 
         val key = RamDiskStorageKey("foo")
 
-        val driver1 = provider1.getDriver<Int>(key, ExistenceCriteria.MayExist)
-        val driver2 = provider1.getDriver<Int>(key, ExistenceCriteria.MayExist)
-        val driver3 = provider2.getDriver<Int>(key, ExistenceCriteria.MayExist)
+        val driver1 = provider1.getDriver(key, ExistenceCriteria.MayExist, Int::class)
+        val driver2 = provider1.getDriver(key, ExistenceCriteria.MayExist, Int::class)
+        val driver3 = provider2.getDriver(key, ExistenceCriteria.MayExist, Int::class)
 
         var driver2Value: Int? = null
         var driver2Version: Int? = null

--- a/javatests/arcs/core/storage/driver/VolatileDriverProviderTest.kt
+++ b/javatests/arcs/core/storage/driver/VolatileDriverProviderTest.kt
@@ -74,9 +74,10 @@ class VolatileDriverProviderTest {
     @Test
     fun getDriver_getsDriverForExistenceCriteria() = runBlocking {
         val driver =
-            fooProvider.getDriver<Int>(
+            fooProvider.getDriver(
                 VolatileStorageKey(arcIdFoo, "myfoo"),
-                ExistenceCriteria.ShouldCreate
+                ExistenceCriteria.ShouldCreate,
+                Int::class
             )
 
         assertThat(driver).isNotNull()


### PR DESCRIPTION
Add dataClass to the Store constructors, and pass it to the driver provider so drivers can be aware of the type of data they're tasked with storing.