### PR TITLE
Unify all Kotlin platform targets (incl. JS) in arcs_kt_library

### DIFF
--- a/java/arcs/core/BUILD
+++ b/java/arcs/core/BUILD
@@ -1,13 +1,13 @@
 load(
     "//third_party/java/arcs/build_defs:build_defs.bzl",
-    "kt_jvm_and_js_library",
+    "arcs_kt_library",
 )
 
 licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])
 
-kt_jvm_and_js_library(
+arcs_kt_library(
     name = "arcs",
     srcs = glob(["*.kt"]),
 )

--- a/java/arcs/core/common/BUILD
+++ b/java/arcs/core/common/BUILD
@@ -1,13 +1,13 @@
 load(
     "//third_party/java/arcs/build_defs:build_defs.bzl",
-    "kt_jvm_and_js_library",
+    "arcs_kt_library",
 )
 
 licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])
 
-kt_jvm_and_js_library(
+arcs_kt_library(
     name = "common",
     srcs = glob(["*.kt"]),
     deps = [

--- a/java/arcs/core/crdt/BUILD
+++ b/java/arcs/core/crdt/BUILD
@@ -1,13 +1,13 @@
 load(
     "//third_party/java/arcs/build_defs:build_defs.bzl",
-    "kt_jvm_and_js_library",
+    "arcs_kt_library",
 )
 
 licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])
 
-kt_jvm_and_js_library(
+arcs_kt_library(
     name = "crdt",
     srcs = glob(["*.kt"]),
     deps = [

--- a/java/arcs/core/crdt/internal/BUILD
+++ b/java/arcs/core/crdt/internal/BUILD
@@ -1,13 +1,13 @@
 load(
     "//third_party/java/arcs/build_defs:build_defs.bzl",
-    "kt_jvm_and_js_library",
+    "arcs_kt_library",
 )
 
 licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])
 
-kt_jvm_and_js_library(
+arcs_kt_library(
     name = "internal",
     srcs = glob(["*.kt"]),
 )

--- a/java/arcs/core/data/BUILD
+++ b/java/arcs/core/data/BUILD
@@ -1,6 +1,6 @@
 load(
     "//third_party/java/arcs/build_defs:build_defs.bzl",
-    "kt_jvm_and_js_library",
+    "arcs_kt_library",
 )
 
 licenses(["notice"])
@@ -12,7 +12,7 @@ ENTITY_SRCS = [
     "RawEntity.kt",
 ]
 
-kt_jvm_and_js_library(
+arcs_kt_library(
     name = "data",
     srcs = glob(
         ["*.kt"],
@@ -30,7 +30,7 @@ kt_jvm_and_js_library(
     ],
 )
 
-kt_jvm_and_js_library(
+arcs_kt_library(
     name = "rawentity",
     srcs = ENTITY_SRCS,
     deps = [

--- a/java/arcs/core/data/util/BUILD
+++ b/java/arcs/core/data/util/BUILD
@@ -1,13 +1,13 @@
 load(
     "//third_party/java/arcs/build_defs:build_defs.bzl",
-    "kt_jvm_and_js_library",
+    "arcs_kt_library",
 )
 
 licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])
 
-kt_jvm_and_js_library(
+arcs_kt_library(
     name = "util",
     srcs = glob(["*.kt"]),
     deps = [

--- a/java/arcs/core/storage/BUILD
+++ b/java/arcs/core/storage/BUILD
@@ -1,6 +1,6 @@
 load(
     "//third_party/java/arcs/build_defs:build_defs.bzl",
-    "kt_jvm_and_js_library",
+    "arcs_kt_library",
 )
 
 licenses(["notice"])
@@ -20,7 +20,7 @@ REFERENCE_SRCS = [
     "Reference.kt",
 ]
 
-kt_jvm_and_js_library(
+arcs_kt_library(
     name = "storage",
     srcs = glob(
         ["*.kt"],
@@ -50,12 +50,12 @@ kt_jvm_and_js_library(
     ],
 )
 
-kt_jvm_and_js_library(
+arcs_kt_library(
     name = "storage_key",
     srcs = STORAGE_KEY_SRCS,
 )
 
-kt_jvm_and_js_library(
+arcs_kt_library(
     name = "reference",
     srcs = REFERENCE_SRCS,
     deps = [
@@ -65,7 +65,7 @@ kt_jvm_and_js_library(
     ],
 )
 
-kt_jvm_and_js_library(
+arcs_kt_library(
     name = "proxy",
     srcs = PROXY_SRCS,
     deps = [

--- a/java/arcs/core/storage/api/BUILD
+++ b/java/arcs/core/storage/api/BUILD
@@ -1,13 +1,13 @@
 load(
     "//third_party/java/arcs/build_defs:build_defs.bzl",
-    "kt_jvm_and_js_library",
+    "arcs_kt_library",
 )
 
 licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])
 
-kt_jvm_and_js_library(
+arcs_kt_library(
     name = "api",
     srcs = glob(["*.kt"]),
     deps = [

--- a/java/arcs/core/storage/database/BUILD
+++ b/java/arcs/core/storage/database/BUILD
@@ -1,13 +1,13 @@
 load(
     "//third_party/java/arcs/build_defs:build_defs.bzl",
-    "kt_jvm_and_js_library",
+    "arcs_kt_library",
 )
 
 licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])
 
-kt_jvm_and_js_library(
+arcs_kt_library(
     name = "database",
     srcs = glob(["*.kt"]),
     deps = [

--- a/java/arcs/core/storage/driver/BUILD
+++ b/java/arcs/core/storage/driver/BUILD
@@ -1,13 +1,13 @@
 load(
     "//third_party/java/arcs/build_defs:build_defs.bzl",
-    "kt_jvm_and_js_library",
+    "arcs_kt_library",
 )
 
 licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])
 
-kt_jvm_and_js_library(
+arcs_kt_library(
     name = "driver",
     srcs = glob(["*.kt"]),
     deps = [

--- a/java/arcs/core/storage/handle/BUILD
+++ b/java/arcs/core/storage/handle/BUILD
@@ -1,13 +1,13 @@
 load(
     "//third_party/java/arcs/build_defs:build_defs.bzl",
-    "kt_jvm_and_js_library",
+    "arcs_kt_library",
 )
 
 licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])
 
-kt_jvm_and_js_library(
+arcs_kt_library(
     name = "handle",
     srcs = glob(["*.kt"]),
     deps = [

--- a/java/arcs/core/storage/referencemode/BUILD
+++ b/java/arcs/core/storage/referencemode/BUILD
@@ -1,13 +1,13 @@
 load(
     "//third_party/java/arcs/build_defs:build_defs.bzl",
-    "kt_jvm_and_js_library",
+    "arcs_kt_library",
 )
 
 licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])
 
-kt_jvm_and_js_library(
+arcs_kt_library(
     name = "referencemode",
     srcs = glob(["*.kt"]),
     deps = [

--- a/java/arcs/core/storage/util/BUILD
+++ b/java/arcs/core/storage/util/BUILD
@@ -1,13 +1,13 @@
 load(
     "//third_party/java/arcs/build_defs:build_defs.bzl",
-    "kt_jvm_and_js_library",
+    "arcs_kt_library",
 )
 
 licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])
 
-kt_jvm_and_js_library(
+arcs_kt_library(
     name = "util",
     srcs = glob(["*.kt"]),
     deps = [

--- a/java/arcs/core/type/BUILD
+++ b/java/arcs/core/type/BUILD
@@ -1,13 +1,13 @@
 load(
     "//third_party/java/arcs/build_defs:build_defs.bzl",
-    "kt_jvm_and_js_library",
+    "arcs_kt_library",
 )
 
 licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])
 
-kt_jvm_and_js_library(
+arcs_kt_library(
     name = "type",
     srcs = glob(["*.kt"]),
     deps = [

--- a/java/arcs/core/util/BUILD
+++ b/java/arcs/core/util/BUILD
@@ -1,13 +1,13 @@
 load(
     "//third_party/java/arcs/build_defs:build_defs.bzl",
-    "kt_jvm_and_js_library",
+    "arcs_kt_library",
 )
 
 licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])
 
-kt_jvm_and_js_library(
+arcs_kt_library(
     name = "util",
     srcs = glob(["*.kt"]),
     deps = [

--- a/javatests/arcs/sdk/wasm/BUILD
+++ b/javatests/arcs/sdk/wasm/BUILD
@@ -32,8 +32,8 @@ arcs_kt_schema(
 arcs_kt_particles(
     name = "test-module",
     srcs = PARTICLE_TEST_SRCS,
-    jvm = False,
     package = "arcs.sdk.wasm",
+    platforms = ["wasm"],
     visibility = ["//visibility:public"],
     deps = [
         ":TestBase",
@@ -44,7 +44,7 @@ arcs_kt_particles(
 arcs_kt_library(
     name = "TestBase",
     srcs = PARTICLE_TEST_BASE_SRCS,
-    jvm = False,
+    platforms = ["wasm"],
     deps = [
         ":schemas",
         "//java/arcs/sdk",

--- a/particles/Blackjack/BUILD
+++ b/particles/Blackjack/BUILD
@@ -21,7 +21,7 @@ arcs_kt_particles(
         "DealingShoe.kt",
         "Player.kt",
     ],
-    jvm = False,
     package = "arcs.tutorials.blackjack",
+    platforms = ["wasm"],
     deps = [":blackjack_schemas"],
 )

--- a/particles/Native/Wasm/BUILD
+++ b/particles/Native/Wasm/BUILD
@@ -38,16 +38,16 @@ arcs_kt_schema(
 arcs_kt_particles(
     name = "service_particle",
     srcs = ["source/ServiceParticle.kt"],
-    jvm = False,
     package = "arcs.test",
+    platforms = ["wasm"],
     deps = [":wasm_schemas"],
 )
 
 arcs_kt_particles(
     name = "test_particle",
     srcs = ["source/TestParticle.kt"],
-    jvm = False,
     package = "arcs.test",
+    platforms = ["wasm"],
     deps = [":wasm_schemas"],
 )
 

--- a/particles/Tutorial/Kotlin/4_Handles/BUILD
+++ b/particles/Tutorial/Kotlin/4_Handles/BUILD
@@ -22,7 +22,7 @@ arcs_kt_schema(
 arcs_kt_particles(
     name = "Handles",
     srcs = glob(["*.kt"]),
-    jvm = False,
     package = "arcs.tutorials",
+    platforms = ["wasm"],
     deps = [":handles_schemas"],
 )

--- a/particles/Tutorial/Kotlin/Demo/src/pt1/BUILD
+++ b/particles/Tutorial/Kotlin/Demo/src/pt1/BUILD
@@ -15,7 +15,7 @@ arcs_kt_schema(
 arcs_kt_particles(
     name = "particles",
     srcs = glob(["*.kt"]),
-    jvm = False,
     package = "arcs.tutorials.tictactoe",
+    platforms = ["wasm"],
     deps = [":game_schemas"],
 )

--- a/particles/Tutorial/Kotlin/Demo/src/pt2/BUILD
+++ b/particles/Tutorial/Kotlin/Demo/src/pt2/BUILD
@@ -15,7 +15,7 @@ arcs_kt_schema(
 arcs_kt_particles(
     name = "particles",
     srcs = glob(["*.kt"]),
-    jvm = False,
     package = "arcs.tutorials.tictactoe",
+    platforms = ["wasm"],
     deps = [":game_schemas"],
 )

--- a/particles/Tutorial/Kotlin/Demo/src/pt3/BUILD
+++ b/particles/Tutorial/Kotlin/Demo/src/pt3/BUILD
@@ -15,7 +15,7 @@ arcs_kt_schema(
 arcs_kt_particles(
     name = "particles",
     srcs = glob(["*.kt"]),
-    jvm = False,
     package = "arcs.tutorials.tictactoe",
+    platforms = ["wasm"],
     deps = [":game_schemas"],
 )

--- a/particles/Tutorial/Kotlin/Demo/src/pt4/BUILD
+++ b/particles/Tutorial/Kotlin/Demo/src/pt4/BUILD
@@ -13,7 +13,7 @@ arcs_kt_schema(
 arcs_kt_particles(
     name = "particles",
     srcs = glob(["*.kt"]),
-    jvm = False,
     package = "arcs.tutorials.tictactoe",
+    platforms = ["wasm"],
     deps = [":game_schemas"],
 )

--- a/particles/Tutorial/Kotlin/Demo/src/total/BUILD
+++ b/particles/Tutorial/Kotlin/Demo/src/total/BUILD
@@ -15,7 +15,7 @@ arcs_kt_schema(
 arcs_kt_particles(
     name = "particles",
     srcs = glob(["*.kt"]),
-    jvm = False,
     package = "arcs.tutorials.tictactoe",
+    platforms = ["wasm"],
     deps = [":game_schemas"],
 )

--- a/third_party/java/arcs/build_defs/build_defs.bzl
+++ b/third_party/java/arcs/build_defs/build_defs.bzl
@@ -12,7 +12,6 @@ load(
     _arcs_kt_library = "arcs_kt_library",
     _arcs_kt_native_library = "arcs_kt_native_library",
     _arcs_kt_particles = "arcs_kt_particles",
-    _kt_jvm_and_js_library = "kt_jvm_and_js_library",
 )
 load(
     "//third_party/java/arcs/build_defs/internal:manifest.bzl",
@@ -32,9 +31,9 @@ arcs_cc_schema = _arcs_cc_schema
 
 arcs_kt_android_test_suite = _arcs_kt_android_test_suite
 
-arcs_kt_jvm_test_suite = _arcs_kt_jvm_test_suite
+arcs_kt_jvm_library = _arcs_kt_jvm_library
 
-arcs_kt_schema = _arcs_kt_schema
+arcs_kt_jvm_test_suite = _arcs_kt_jvm_test_suite
 
 arcs_kt_library = _arcs_kt_library
 
@@ -42,15 +41,13 @@ arcs_kt_native_library = _arcs_kt_native_library
 
 arcs_kt_particles = _arcs_kt_particles
 
+arcs_kt_schema = _arcs_kt_schema
+
 arcs_manifest = _arcs_manifest
 
 arcs_manifest_bundle = _arcs_manifest_bundle
 
-kt_jvm_and_js_library = _kt_jvm_and_js_library
-
 kt_js_library = _kt_js_library
-
-arcs_kt_jvm_library = _arcs_kt_jvm_library
 
 def arcs_ts_test(name, src, deps):
     """Runs a TypeScript test file using `sigh test`."""

--- a/third_party/java/arcs/build_defs/internal/kotlin.bzl
+++ b/third_party/java/arcs/build_defs/internal/kotlin.bzl
@@ -69,13 +69,14 @@ def arcs_kt_jvm_library(**kwargs):
     """
     constraints = kwargs.pop("constraints", ["android"])
     disable_lint_checks = kwargs.pop("disable_lint_checks", [])
+    exports = kwargs.pop("exports", [])
     kotlincopts = kwargs.pop("kotlincopts", [])
     kwargs["kotlincopts"] = _merge_lists(kotlincopts, KOTLINC_OPTS)
     if not IS_BAZEL:
         kwargs["constraints"] = constraints
         kwargs["disable_lint_checks"] = _merge_lists(disable_lint_checks, DISABLED_LINT_CHECKS)
 
-    if kwargs.get("exports"):
+    if exports:
         # kt_jvm_library doesn't support the "exports" property. Instead, we
         # will wrap it in a java_library rule and export everything that is
         # needed from there.
@@ -83,7 +84,7 @@ def arcs_kt_jvm_library(**kwargs):
         kt_name = name + _KT_SUFFIX
         kwargs["name"] = kt_name
 
-        exports = kwargs.pop("exports") + [kt_name]
+        exports += [kt_name]
 
         if not IS_BAZEL:
             java_kwargs = {"constraints": constraints}

--- a/third_party/java/arcs/build_defs/internal/kotlin.bzl
+++ b/third_party/java/arcs/build_defs/internal/kotlin.bzl
@@ -84,7 +84,7 @@ def arcs_kt_jvm_library(**kwargs):
         kt_name = name + _KT_SUFFIX
         kwargs["name"] = kt_name
 
-        exports += [kt_name]
+        exports.append(kt_name)
 
         if not IS_BAZEL:
             java_kwargs = {"constraints": constraints}

--- a/third_party/java/arcs/build_defs/internal/kotlin.bzl
+++ b/third_party/java/arcs/build_defs/internal/kotlin.bzl
@@ -52,12 +52,14 @@ DISABLED_LINT_CHECKS = [
     "TopLevelName",
 ]
 
-def _merge_lists(*lists):
-    result = {}
-    for x in lists:
-        for elem in x:
-            result[elem] = 1
-    return result.keys()
+# All supported Kotlin platforms.
+ALL_PLATFORMS = ["jvm", "js", "wasm"]
+
+# Default set of platforms for Kotlin libraries.
+DEFAULT_LIBRARY_PLATFORMS = ["jvm", "js"]
+
+# Default set of platforms for Kotlin particles.
+DEFAULT_PARTICLE_PLATFORMS = ["jvm", "wasm"]
 
 def arcs_kt_jvm_library(**kwargs):
     """Wrapper around kt_jvm_library for Arcs.
@@ -73,6 +75,28 @@ def arcs_kt_jvm_library(**kwargs):
         kwargs["constraints"] = constraints
         kwargs["disable_lint_checks"] = _merge_lists(disable_lint_checks, DISABLED_LINT_CHECKS)
 
+    if kwargs.get("exports"):
+        # kt_jvm_library doesn't support the "exports" property. Instead, we
+        # will wrap it in a java_library rule and export everything that is
+        # needed from there.
+        name = kwargs["name"]
+        kt_name = name + _KT_SUFFIX
+        kwargs["name"] = kt_name
+
+        exports = kwargs.pop("exports") + [kt_name]
+
+        if not IS_BAZEL:
+            java_kwargs = {"constraints": constraints}
+        else:
+            java_kwargs = {}
+
+        java_library(
+            name = name,
+            exports = exports,
+            visibility = kwargs["visibility"],
+            **java_kwargs
+        )
+
     kt_jvm_library(**kwargs)
 
 def arcs_kt_native_library(**kwargs):
@@ -85,38 +109,63 @@ def arcs_kt_native_library(**kwargs):
     kwargs["kotlincopts"] = _merge_lists(kotlincopts, KOTLINC_OPTS)
     kt_native_library(**kwargs)
 
+def arcs_kt_js_library(**kwargs):
+    """Wrapper around kt_js_library for Arcs.
+
+    Args:
+      **kwargs: Set of args to forward to kt_js_library
+    """
+
+    # Don't produce JS libs for blaze.
+    if not IS_BAZEL:
+        return
+
+    kotlincopts = kwargs.pop("kotlincopts", [])
+    kwargs["kotlincopts"] = _merge_lists(kotlincopts, KOTLINC_OPTS)
+    kt_js_library(**kwargs)
+
 def arcs_kt_library(
         name,
         srcs = [],
         deps = [],
-        visibility = None,
-        wasm = True,
-        jvm = True):
-    """Declares kotlin library targets for Kotlin particle sources.
-
-    Defines both jvm and wasm Kotlin libraries.
+        platforms = DEFAULT_LIBRARY_PLATFORMS,
+        exports = None,
+        visibility = None):
+    """Declares Kotlin library targets for multiple platforms.
 
     Args:
       name: String; Name of the library
       srcs: List; List of sources
       deps: List; List of dependencies
+      platforms: List; List of platforms for which to compile. Valid options
+          are: "jvm", "js", "wasm". Defaults to "jvm" and "js".
       visibility: List; List of visibilities
       wasm: whether to build a wasm library
       jvm: whether to build a jvm library
     """
-    if not jvm and not wasm:
-        fail("At least one of wasm or jvm must be built.")
+    _check_platforms(platforms)
 
-    if jvm:
+    if "jvm" in platforms:
         arcs_kt_jvm_library(
             name = name,
             # Exclude any wasm-specific srcs.
             srcs = [src for src in srcs if not src.endswith(".wasm.kt")],
             deps = [_to_jvm_dep(dep) for dep in deps],
+            exports = exports,
             visibility = visibility,
         )
 
-    if wasm:
+    if "js" in platforms:
+        arcs_kt_js_library(
+            name = name + _JS_SUFFIX,
+            # Exclude any wasm-specific srcs.
+            # TODO: jvm srcs will be included here. That is not what we want.
+            srcs = [src for src in srcs if not src.endswith(".wasm.kt")],
+            deps = [_to_js_dep(dep) for dep in deps],
+            visibility = visibility,
+        )
+
+    if "wasm" in platforms:
         arcs_kt_native_library(
             name = name + _WASM_SUFFIX,
             # Exclude any jvm-specific srcs.
@@ -130,9 +179,8 @@ def arcs_kt_particles(
         package,
         srcs = [],
         deps = [],
-        visibility = None,
-        wasm = True,
-        jvm = True):
+        platforms = DEFAULT_PARTICLE_PLATFORMS,
+        visibility = None):
     """Performs final compilation of wasm and bundling if necessary.
 
     Args:
@@ -142,17 +190,15 @@ def arcs_kt_particles(
         class of the same name, which must match the name of a particle defined
         in a .arcs file.
       deps: list of dependencies
+      platforms: List of platforms for which to compile. Valid options
+          are: "jvm", "js", "wasm". Defaults to "jvm" and "js".
       visibility: list of visibilities
-      wasm: whether to build wasm libraries
-      jvm: whether to build a jvm library
     """
-    if not jvm and not wasm:
-        fail("At least one of wasm or jvm must be built.")
+    _check_platforms(platforms)
 
     deps = ARCS_SDK_DEPS + deps
 
-    if jvm:
-        # Create a jvm library just as a build test.
+    if "jvm" in platforms:
         arcs_kt_jvm_library(
             name = name + "-jvm",
             srcs = srcs,
@@ -160,7 +206,15 @@ def arcs_kt_particles(
             visibility = visibility,
         )
 
-    if wasm:
+    if "js" in platforms:
+        arcs_kt_js_library(
+            name = name + _JS_SUFFIX,
+            srcs = srcs,
+            deps = [_to_js_dep(dep) for dep in deps],
+            visibility = visibility,
+        )
+
+    if "wasm" in platforms:
         wasm_deps = [_to_wasm_dep(dep) for dep in deps]
 
         # Collect all the sources and annotation files in `wasm_srcs`.
@@ -205,76 +259,6 @@ def arcs_kt_particles(
             kt_target = ":" + native_binary_name,
             visibility = visibility,
         )
-
-def kt_jvm_and_js_library(
-        name,
-        srcs = [],
-        deps = [],
-        visibility = None,
-        exports = [],
-        **kwargs):
-    """Simultaneously defines JVM and JS kotlin libraries.
-
-    Args:
-      name: String; Name of the library
-      srcs: List; List of sources
-      deps: List; List of dependencies
-      exports: List; List of exported dependencies
-      visibility: List; List of visibilities
-      **kwargs: other arguments to forward to the kt_jvm_library and
-        kt_js_library rules
-    """
-
-    kt_name = name
-    js_name = "%s%s" % (name, _JS_SUFFIX)
-
-    if exports:
-        # kt_jvm_library doesn't support the "exports" property. Instead, we
-        # will wrap it in a java_library rule and export everything that is
-        # needed from there.
-        #
-        # Also, 'constraints' doesn't exist for java_library in Bazel, so we have to fork based on
-        # that as well.
-        kt_name = name + _KT_SUFFIX
-        if IS_BAZEL:
-            java_library(
-                name = name,
-                exports = exports + [kt_name],
-                visibility = visibility,
-            )
-        else:
-            java_library(
-                name = name,
-                exports = exports + [kt_name],
-                visibility = visibility,
-                constraints = ["android"],
-            )
-
-    arcs_kt_jvm_library(
-        name = kt_name,
-        srcs = srcs,
-        deps = [_to_jvm_dep(dep) for dep in deps],
-        visibility = visibility,
-        **kwargs
-    )
-
-    if IS_BAZEL:
-        js_kwargs = dict(**kwargs)
-        kt_js_library(
-            name = js_name,
-            srcs = srcs,
-            deps = [_to_js_dep(dep) for dep in deps],
-            **js_kwargs
-        )
-
-def _to_wasm_dep(dep):
-    last_part = dep.split("/")[-1]
-
-    index_of_colon = dep.find(":")
-    if (index_of_colon == -1):
-        return dep + (":%s%s" % (last_part, _WASM_SUFFIX))
-    else:
-        return dep + _WASM_SUFFIX
 
 def arcs_kt_android_test_suite(name, manifest, package, srcs = None, tags = [], deps = []):
     """Defines Kotlin Android test targets for a directory.
@@ -355,14 +339,40 @@ def arcs_kt_jvm_test_suite(name, package, srcs = None, tags = [], deps = []):
             tags = tags,
         )
 
+def _check_platforms(platforms):
+    if len(platforms) == 0:
+        fail("You must specify at least one platform from: %s" %
+             ", ".join(ALL_PLATFORMS))
+
+    for platform in platforms:
+        if platform not in ALL_PLATFORMS:
+            fail(
+                "Unknown platform %s. Expected one of: %s.",
+                platform,
+                ", ".join(ALL_PLATFORMS),
+            )
+
+def _merge_lists(*lists):
+    result = {}
+    for x in lists:
+        for elem in x:
+            result[elem] = 1
+    return result.keys()
+
 def _to_jvm_dep(dep):
     return dep
 
 def _to_js_dep(dep):
+    return _to_dep_with_suffix(dep, _JS_SUFFIX)
+
+def _to_wasm_dep(dep):
+    return _to_dep_with_suffix(dep, _WASM_SUFFIX)
+
+def _to_dep_with_suffix(dep, suffix):
     last_part = dep.split("/")[-1]
 
     index_of_colon = dep.find(":")
     if (index_of_colon == -1):
-        return dep + (":%s%s" % (last_part, _JS_SUFFIX))
+        return dep + (":%s%s" % (last_part, suffix))
     else:
-        return dep + _JS_SUFFIX
+        return dep + suffix

--- a/third_party/java/arcs/build_defs/internal/kotlin.bzl
+++ b/third_party/java/arcs/build_defs/internal/kotlin.bzl
@@ -139,9 +139,8 @@ def arcs_kt_library(
       deps: List; List of dependencies
       platforms: List; List of platforms for which to compile. Valid options
           are: "jvm", "js", "wasm". Defaults to "jvm" and "js".
+      exports: List; Optional list of deps to export from this build rule.
       visibility: List; List of visibilities
-      wasm: whether to build a wasm library
-      jvm: whether to build a jvm library
     """
     _check_platforms(platforms)
 

--- a/third_party/java/arcs/build_defs/internal/schemas.bzl
+++ b/third_party/java/arcs/build_defs/internal/schemas.bzl
@@ -4,7 +4,12 @@ Rules are re-exported in build_defs.bzl -- use those instead.
 """
 
 load("//third_party/java/arcs/build_defs:sigh.bzl", "sigh_command")
-load(":kotlin.bzl", "ARCS_SDK_DEPS", "arcs_kt_library")
+load(
+    ":kotlin.bzl",
+    "ARCS_SDK_DEPS",
+    "DEFAULT_PARTICLE_PLATFORMS",
+    "arcs_kt_library",
+)
 
 def _output_name(src, suffix = ""):
     """Cleans up the given file name, and replaces the .arcs extension."""
@@ -97,5 +102,6 @@ def arcs_kt_schema(name, srcs, deps = [], package = "arcs.sdk"):
     arcs_kt_library(
         name = name,
         srcs = outs,
+        platforms = DEFAULT_PARTICLE_PLATFORMS,
         deps = ARCS_SDK_DEPS,
     )


### PR DESCRIPTION
This is the new rule-to-rule-them-all. Use it any time you want to
compile to more than one platform.

Single platform rules still exist, and can be used if you only want a
single platform for your library.

There are a different default sets of platforms for particles and for core libraries. The former targets wasm and jvm (the old default), and the latter targets jvm and js (replicating the old kt_jvm_and_js_library rule)