### PR TITLE
Adds ability to insert new entities into the database

### DIFF
--- a/java/arcs/android/storage/database/DatabaseImpl.kt
+++ b/java/arcs/android/storage/database/DatabaseImpl.kt
@@ -19,6 +19,7 @@ import androidx.annotation.VisibleForTesting
 import arcs.android.common.forEach
 import arcs.android.common.transaction
 import arcs.android.common.useTransaction
+import arcs.core.data.Entity
 import arcs.core.data.FieldName
 import arcs.core.data.FieldType
 import arcs.core.data.PrimitiveType
@@ -102,9 +103,16 @@ class DatabaseImpl(
         data: DatabaseData,
         originatingClientId: Int?
     ): Int {
-        TODO("not implemented")
+        when (data) {
+            is DatabaseData.Entity -> insertOrUpdate(storageKey, data.entity)
+            else -> TODO("Support Singletons and Collections")
+        }
+        // TODO: Return a proper database version number.
+        return 1
     }
-    override suspend fun insertOrUpdate(storageKey: StorageKey, entity: Entity) {
+
+    @VisibleForTesting
+    suspend fun insertOrUpdate(storageKey: StorageKey, entity: Entity) {
         writableDatabase.useTransaction {
             val schemaTypeId = getSchemaTypeId(entity.schema)
             val storageKeyId = getStorageKeyId(storageKey)

--- a/javatests/arcs/android/storage/database/DatabaseImplTest.kt
+++ b/javatests/arcs/android/storage/database/DatabaseImplTest.kt
@@ -222,7 +222,7 @@ class DatabaseImplTest {
 
     @Test
     fun insertOrUpdate_newEmptyEntity() = runBlockingTest {
-        val entity = Entity(newSchema("hash"), mutableMapOf())
+        val entity = Entity("entity", newSchema("hash"), mutableMapOf())
         database.insertOrUpdate(DummyKey("key"), entity)
 
         // TODO: Get entity back out of DB and check it's equivalent.
@@ -231,6 +231,7 @@ class DatabaseImplTest {
     @Test
     fun insertOrUpdate_newEntityWithFields() = runBlockingTest {
         val entity = Entity(
+            "entity",
             newSchema("hash", SchemaFields(
                 singletons = mapOf(
                     "text" to FieldType.Text,

--- a/javatests/arcs/android/storage/database/DatabaseImplTest.kt
+++ b/javatests/arcs/android/storage/database/DatabaseImplTest.kt
@@ -15,6 +15,7 @@ import android.database.Cursor
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import arcs.android.common.map
+import arcs.core.data.Entity
 import arcs.core.data.FieldType
 import arcs.core.data.PrimitiveType
 import arcs.core.data.Schema
@@ -22,6 +23,7 @@ import arcs.core.data.SchemaDescription
 import arcs.core.data.SchemaFields
 import arcs.core.storage.StorageKey
 import arcs.core.testutil.assertSuspendingThrows
+import arcs.core.testutil.assertThrows
 import com.google.common.truth.Truth.assertThat
 import java.lang.IllegalArgumentException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -39,6 +41,10 @@ class DatabaseImplTest {
     /** The first free Type ID after all primitive types have been assigned. */
     private val FIRST_ENTITY_TYPE_ID = 3
 
+    private val TEXT_TYPE_ID = PrimitiveType.Text.ordinal.toLong()
+    private val BOOLEAN_TYPE_ID = PrimitiveType.Boolean.ordinal.toLong()
+    private val NUMBER_TYPE_ID = PrimitiveType.Number.ordinal.toLong()
+
     @Before
     fun setUp() {
         database = DatabaseImpl(ApplicationProvider.getApplicationContext(), "test.sqlite3")
@@ -47,6 +53,7 @@ class DatabaseImplTest {
     @After
     fun tearDown() {
         database.reset()
+        database.close()
     }
 
     @Test
@@ -106,14 +113,14 @@ class DatabaseImplTest {
 
         assertThat(typeId).isEqualTo(FIRST_ENTITY_TYPE_ID)
         assertThat(readFieldsTable()).containsExactly(
-            FieldRow(1, PrimitiveType.Text.ordinal.toLong(), typeId, "text"),
-            FieldRow(2, PrimitiveType.Boolean.ordinal.toLong(), typeId, "bool"),
-            FieldRow(3, PrimitiveType.Number.ordinal.toLong(), typeId, "num")
+            FieldRow(1, TEXT_TYPE_ID, typeId, "text"),
+            FieldRow(2, BOOLEAN_TYPE_ID, typeId, "bool"),
+            FieldRow(3, NUMBER_TYPE_ID, typeId, "num")
         )
     }
 
     @Test
-    fun getSchemaFieldIds() = runBlockingTest {
+    fun getSchemaFields() = runBlockingTest {
         val schema1 = newSchema("abc", SchemaFields(
             singletons = mapOf("text" to FieldType.Text, "bool" to FieldType.Boolean),
             collections = mapOf("num" to FieldType.Number)
@@ -121,24 +128,24 @@ class DatabaseImplTest {
         val schemaTypeId1 = database.getSchemaTypeId(schema1)
 
         // Creates new IDs for each field.
-        val fieldIds1 = database.getSchemaFieldIds(schemaTypeId1)
-        assertThat(fieldIds1).containsExactly(
-            "text", 1L,
-            "bool", 2L,
-            "num", 3L
+        val fields1 = database.getSchemaFields(schemaTypeId1)
+        assertThat(fields1).containsExactly(
+            "text", DatabaseImpl.SchemaField("text", 1L, TEXT_TYPE_ID),
+            "bool", DatabaseImpl.SchemaField("bool", 2L, BOOLEAN_TYPE_ID),
+            "num", DatabaseImpl.SchemaField("num", 3L, NUMBER_TYPE_ID)
         )
 
         // Re-running with the same schema doesn't create new field IDs
-        assertThat(database.getSchemaFieldIds(schemaTypeId1)).isEqualTo(fieldIds1)
+        assertThat(database.getSchemaFields(schemaTypeId1)).isEqualTo(fields1)
 
         // Running on a different schema creates new field IDs.
         val schema2 = schema1.copy(hash = "xyz")
         val schemaTypeId2 = database.getSchemaTypeId(schema2)
-        val fieldIds2 = database.getSchemaFieldIds(schemaTypeId2)
-        assertThat(fieldIds2).containsExactly(
-            "text", 4L,
-            "bool", 5L,
-            "num", 6L
+        val fields2 = database.getSchemaFields(schemaTypeId2)
+        assertThat(fields2).containsExactly(
+            "text", DatabaseImpl.SchemaField("text", 4L, TEXT_TYPE_ID),
+            "bool", DatabaseImpl.SchemaField("bool", 5L, BOOLEAN_TYPE_ID),
+            "num", DatabaseImpl.SchemaField("num", 6L, NUMBER_TYPE_ID)
         )
     }
 
@@ -146,12 +153,12 @@ class DatabaseImplTest {
     fun getSchemaFieldIds_emptySchema() = runBlockingTest {
         val schema = newSchema("abc")
         val schemaTypeId = database.getSchemaTypeId(schema)
-        assertThat(database.getSchemaFieldIds(schemaTypeId)).isEmpty()
+        assertThat(database.getSchemaFields(schemaTypeId)).isEmpty()
     }
 
     @Test
     fun getSchemaFieldIds_unknownSchemaId() = runBlockingTest {
-        val fieldIds = database.getSchemaFieldIds(987654L)
+        val fieldIds = database.getSchemaFields(987654L)
         assertThat(fieldIds).isEmpty()
     }
 
@@ -166,6 +173,81 @@ class DatabaseImplTest {
     fun getStorageKeyId_existingKey() = runBlockingTest {
         assertThat(database.getStorageKeyId(DummyKey("key"))).isEqualTo(1L)
         assertThat(database.getStorageKeyId(DummyKey("key"))).isEqualTo(1L)
+    }
+
+    @Test
+    fun getPrimitiveValueId_boolean() = runBlockingTest {
+        assertThat(database.getPrimitiveValueId(true, BOOLEAN_TYPE_ID)).isEqualTo(1)
+        assertThat(database.getPrimitiveValueId(false, BOOLEAN_TYPE_ID)).isEqualTo(0)
+
+        val exception = assertThrows(IllegalArgumentException::class) {
+            database.getPrimitiveValueId("not a bool", BOOLEAN_TYPE_ID)
+        }
+        assertThat(exception).hasMessageThat().isEqualTo("Expected value to be a Boolean.")
+    }
+
+    @Test
+    fun getPrimitiveValueId_text() = runBlockingTest {
+        assertThat(database.getPrimitiveValueId("aaa", TEXT_TYPE_ID)).isEqualTo(1)
+        assertThat(database.getPrimitiveValueId("bbb", TEXT_TYPE_ID)).isEqualTo(2)
+        assertThat(database.getPrimitiveValueId("ccc", TEXT_TYPE_ID)).isEqualTo(3)
+        assertThat(database.getPrimitiveValueId("aaa", TEXT_TYPE_ID)).isEqualTo(1)
+
+        val exception = assertThrows(IllegalArgumentException::class) {
+            database.getPrimitiveValueId(123.0, TEXT_TYPE_ID)
+        }
+        assertThat(exception).hasMessageThat().isEqualTo("Expected value to be a String.")
+    }
+
+    @Test
+    fun getPrimitiveValueId_number() = runBlockingTest {
+        assertThat(database.getPrimitiveValueId(111.0, NUMBER_TYPE_ID)).isEqualTo(1)
+        assertThat(database.getPrimitiveValueId(222.0, NUMBER_TYPE_ID)).isEqualTo(2)
+        assertThat(database.getPrimitiveValueId(333.0, NUMBER_TYPE_ID)).isEqualTo(3)
+        assertThat(database.getPrimitiveValueId(111.0, NUMBER_TYPE_ID)).isEqualTo(1)
+
+        val exception = assertThrows(IllegalArgumentException::class) {
+            database.getPrimitiveValueId("not a number", NUMBER_TYPE_ID)
+        }
+        assertThat(exception).hasMessageThat().isEqualTo("Expected value to be a Double.")
+    }
+
+    @Test
+    fun getPrimitiveValueId_unknownTypeId() = runBlockingTest {
+        val exception = assertThrows(IllegalArgumentException::class) {
+            database.getPrimitiveValueId("aaa", 987654L)
+        }
+        assertThat(exception).hasMessageThat().isEqualTo("Not a primitive type ID: 987654")
+    }
+
+    @Test
+    fun insertOrUpdate_newEmptyEntity() = runBlockingTest {
+        val entity = Entity(newSchema("hash"), mutableMapOf())
+        database.insertOrUpdate(DummyKey("key"), entity)
+
+        // TODO: Get entity back out of DB and check it's equivalent.
+    }
+
+    @Test
+    fun insertOrUpdate_newEntityWithFields() = runBlockingTest {
+        val entity = Entity(
+            newSchema("hash", SchemaFields(
+                singletons = mapOf(
+                    "text" to FieldType.Text,
+                    "bool" to FieldType.Boolean,
+                    "num" to FieldType.Number
+                ),
+                collections = emptyMap()
+            )),
+            mutableMapOf(
+                "text" to "abc",
+                "bool" to true,
+                "num" to 123.0
+            )
+        )
+        database.insertOrUpdate(DummyKey("key"), entity)
+
+        // TODO: Get entity back out of DB and check it's equivalent.
     }
 
     private fun newSchema(


### PR DESCRIPTION
Only a small subset of initial functionality so far. Entities can only
have singleton primitive fields.

Tests are currently very barebones, because we don't have the ability to
retrieve entities from the database yet.