### PR TITLE
Adds SQLite get() support for basic entities

### DIFF
--- a/java/arcs/android/storage/database/BUILD
+++ b/java/arcs/android/storage/database/BUILD
@@ -10,6 +10,7 @@ kt_android_library(
     manifest = "//java/arcs/android/common:AndroidManifest.xml",
     deps = [
         "//java/arcs/android/common",  # unuseddeps: keep
+        "//java/arcs/core/crdt/internal",
         "//java/arcs/core/data",
         "//java/arcs/core/storage",
         "//java/arcs/core/storage:storage_key",

--- a/java/arcs/android/storage/database/DatabaseImpl.kt
+++ b/java/arcs/android/storage/database/DatabaseImpl.kt
@@ -48,6 +48,7 @@ typealias FieldValueId = Long
 
 /** Implementation of [Database] for Android using SQLite. */
 @VisibleForTesting(otherwise = VisibleForTesting.PACKAGE_PRIVATE)
+@Suppress("Recycle") // Our helper extension methods close Cursors correctly.
 class DatabaseImpl(
     context: Context,
     databaseName: String,

--- a/java/arcs/core/storage/database/Database.kt
+++ b/java/arcs/core/storage/database/Database.kt
@@ -12,6 +12,7 @@
 package arcs.core.storage.database
 
 import arcs.core.crdt.internal.VersionMap
+import arcs.core.data.Schema
 import arcs.core.storage.Reference
 import arcs.core.storage.StorageKey
 import kotlin.reflect.KClass
@@ -35,7 +36,11 @@ interface Database {
     ): Int
 
     /** Fetches the data at [storageKey] from the database. */
-    suspend fun get(storageKey: StorageKey, dataType: KClass<out DatabaseData>): DatabaseData?
+    suspend fun get(
+        storageKey: StorageKey,
+        dataType: KClass<out DatabaseData>,
+        schema: Schema
+    ): DatabaseData?
 
     /** Removes everything associated with the given [storageKey] from the database. */
     suspend fun delete(storageKey: StorageKey, originatingClientId: Int? = null)

--- a/java/arcs/core/storage/driver/Database.kt
+++ b/java/arcs/core/storage/driver/Database.kt
@@ -220,7 +220,8 @@ class DatabaseDriver<Data : Any>(
                         CrdtSingleton.DataImpl::class -> DatabaseData.Singleton::class
                         CrdtSet.DataImpl::class -> DatabaseData.Collection::class
                         else -> throw IllegalStateException("Illegal dataClass: $dataClass")
-                    }
+                    },
+                    schema
                 )?.also {
                     dataAndVersion = when (it) {
                         is DatabaseData.Entity ->

--- a/java/arcs/jvm/storage/database/testutil/BUILD
+++ b/java/arcs/jvm/storage/database/testutil/BUILD
@@ -10,6 +10,7 @@ arcs_kt_jvm_library(
     srcs = glob(["*.kt"]),
     deps = [
         "//java/arcs/core/crdt/internal",
+        "//java/arcs/core/data:data-kt",
         "//java/arcs/core/storage:storage_key",
         "//java/arcs/core/storage/database",
         "//java/arcs/core/util",

--- a/java/arcs/jvm/storage/database/testutil/MockDatabaseFactory.kt
+++ b/java/arcs/jvm/storage/database/testutil/MockDatabaseFactory.kt
@@ -12,6 +12,7 @@
 package arcs.jvm.storage.database.testutil
 
 import arcs.core.crdt.internal.VersionMap
+import arcs.core.data.Schema
 import arcs.core.storage.StorageKey
 import arcs.core.storage.database.Database
 import arcs.core.storage.database.DatabaseClient
@@ -81,7 +82,8 @@ open class MockDatabase : Database {
     @Suppress("UNCHECKED_CAST")
     override suspend fun get(
         storageKey: StorageKey,
-        dataType: KClass<out DatabaseData>
+        dataType: KClass<out DatabaseData>,
+        schema: Schema
     ): DatabaseData? {
         val dataVal = dataMutex.withLock { data[storageKey] }
 

--- a/javatests/arcs/android/storage/database/DatabaseImplTest.kt
+++ b/javatests/arcs/android/storage/database/DatabaseImplTest.kt
@@ -322,7 +322,6 @@ class DatabaseImplTest {
         private val TEXT_TYPE_ID = PrimitiveType.Text.ordinal.toLong()
         private val BOOLEAN_TYPE_ID = PrimitiveType.Boolean.ordinal.toLong()
         private val NUMBER_TYPE_ID = PrimitiveType.Number.ordinal.toLong()
-
     }
 }
 

--- a/javatests/arcs/core/storage/ReferenceModeStoreDatabaseIntegrationTest.kt
+++ b/javatests/arcs/core/storage/ReferenceModeStoreDatabaseIntegrationTest.kt
@@ -120,7 +120,7 @@ class ReferenceModeStoreDatabaseIntegrationTest {
         val database = databaseFactory.getDatabase(containerKey.dbName, containerKey.persistent)
 
         val capturedCollection = requireNotNull(
-            database.get(containerKey, DatabaseData.Collection::class)
+            database.get(containerKey, DatabaseData.Collection::class, schema)
         ) as DatabaseData.Collection
 
         assertThat(capturedCollection.values)
@@ -130,7 +130,7 @@ class ReferenceModeStoreDatabaseIntegrationTest {
 
         val bobKey = activeStore.backingStore.storageKey.childKeyWithComponent("an-id")
         val capturedBob = requireNotNull(
-            database.get(bobKey, DatabaseData.Entity::class) as? DatabaseData.Entity
+            database.get(bobKey, DatabaseData.Entity::class, schema) as? DatabaseData.Entity
         )
 
         assertThat(capturedBob.entity).containsExactly(
@@ -219,7 +219,11 @@ class ReferenceModeStoreDatabaseIntegrationTest {
         val containerKey = activeStore.containerStore.storageKey as DatabaseStorageKey
         val capturedPeople =
             databaseFactory.getDatabase(containerKey.dbName, containerKey.persistent)
-                .get(containerKey, DatabaseData.Collection::class) as DatabaseData.Collection
+                .get(
+                    containerKey,
+                    DatabaseData.Collection::class,
+                    schema
+                ) as DatabaseData.Collection
 
         assertThat(capturedPeople.values).isEqualTo(referenceCollection.consumerView)
         val storedBob = activeStore.backingStore.getLocalData("an-id") as CrdtEntity.Data


### PR DESCRIPTION
Only supports singleton primitive fields.
Updated the `insert` tests to include fetching the inserted entity from the database again.