### PR TITLE
Add a separate gcs bucket for logging in cloud build.

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -36,7 +36,7 @@ images:
 - 'gcr.io/$PROJECT_ID/${_IMAGE_NAME}'
 
 timeout: 3600s # 60 mins, just in case.
-
+logsBucket: 'gs://arcs-github-gcb-logs'
 options:
   machineType: 'N1_HIGHCPU_32'
 


### PR DESCRIPTION
This sets up a separate storage bucket for the build logs so that we can manage permissions appropriately. 