### PR TITLE
Dynamic queries syntax

### DIFF
--- a/src/runtime/manifest-ast-nodes.ts
+++ b/src/runtime/manifest-ast-nodes.ts
@@ -537,7 +537,7 @@ export interface RefinementNode extends BaseNode {
   expression: RefinementExpressionNode;
 }
 
-export type RefinementExpressionNode = BinaryExpressionNode | UnaryExpressionNode | FieldNode | NumberNode | BooleanNode | TextNode;
+export type RefinementExpressionNode = BinaryExpressionNode | UnaryExpressionNode | FieldNode | QueryNode | NumberNode | BooleanNode | TextNode;
 
 export interface ExpressionNode extends BaseNode {
   operator: string;
@@ -556,6 +556,11 @@ export interface UnaryExpressionNode extends ExpressionNode {
 
 export interface FieldNode extends BaseNode {
   kind: 'field-name-node';
+  value: string;
+}
+
+export interface QueryNode extends BaseNode {
+  kind: 'query-argument-node';
   value: string;
 }
 

--- a/src/runtime/manifest-parser.peg
+++ b/src/runtime/manifest-parser.peg
@@ -1438,6 +1438,11 @@ PrimaryExpression
   {
     return toAstNode<AstNode.FieldNode>({kind: 'field-name-node', value: fn});
   }
+  / fn: '?'
+  {
+    // TODO(cypher1): Add support for named query arguments
+    return toAstNode<AstNode.QueryNode>({kind: 'query-argument-node', value: fn});
+  }
   / "'" txt:[^'\n]* "'"
   {
     return toAstNode<AstNode.TextNode>({kind: 'text-node', value: txt.join('')});

--- a/src/runtime/refiner.ts
+++ b/src/runtime/refiner.ts
@@ -213,6 +213,9 @@ abstract class RefinementExpression {
       case 'NumberPrimitiveNode': return NumberPrimitive.fromLiteral(expr);
       case 'BooleanPrimitiveNode': return BooleanPrimitive.fromLiteral(expr);
       case 'TextPrimitiveNode': return TextPrimitive.fromLiteral(expr);
+      default:
+        // Should never happen; all known kinds are handled above, but the linter wants a default.
+        throw new Error(`RefinementExpression.fromLiteral: Unknown node type ${expr['kind']}`);
     }
   }
 

--- a/src/runtime/refiner.ts
+++ b/src/runtime/refiner.ts
@@ -174,7 +174,7 @@ export class Refinement {
   validateData(data: Dictionary<ExpressionPrimitives>): boolean {
     const res = this.expression.applyOperator(data);
     if (typeof res !== 'boolean') {
-      throw new Error('Refinement expression evaluated to a non-boolean type.');
+      throw new Error(`Refinement expression ${this.expression} evaluated to a non-boolean type.`);
     }
     return res;
   }
@@ -1122,12 +1122,12 @@ export class RefinementOperator {
         return;
       }
       if (operandTypes[0].evalType !== operandTypes[1].evalType) {
-        throw new Error(`Expected ${operandTypes[0].evalType} and ${operandTypes[1].evalType} to be the same.`);
+        throw new Error(`Expected refinement expression ${operandTypes[0]} and ${operandTypes[1]} to have the same type. But found types ${operandTypes[0].evalType} and ${operandTypes[1].evalType}.`);
       }
     } else {
       for (const type of operandTypes) {
         if (type.evalType !== this.opInfo.argType) {
-          throw new Error(`Got type ${type.evalType}. Expected ${this.opInfo.argType}.`);
+          throw new Error(`Refinement expression ${type} has type ${type.evalType}. Expected ${this.opInfo.argType}.`);
         }
       }
     }

--- a/src/runtime/refiner.ts
+++ b/src/runtime/refiner.ts
@@ -8,7 +8,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {RefinementNode, RefinementExpressionNode, BinaryExpressionNode, UnaryExpressionNode, FieldNode, NumberNode, BooleanNode, TextNode} from './manifest-ast-nodes.js';
+import {RefinementNode, RefinementExpressionNode, BinaryExpressionNode, UnaryExpressionNode, FieldNode, QueryNode, NumberNode, BooleanNode, TextNode} from './manifest-ast-nodes.js';
 import {Dictionary} from './hot.js';
 import {Schema} from './schema.js';
 import {Entity} from './entity.js';
@@ -180,10 +180,12 @@ export class Refinement {
   }
 }
 
+type RefinementExpressionNodeType = 'BinaryExpressionNode' | 'UnaryExpressionNode' | 'FieldNamePrimitiveNode' | 'QueryArgumentPrimitiveNode' | 'NumberPrimitiveNode' | 'BooleanPrimitiveNode' | 'TextPrimitiveNode';
+
 abstract class RefinementExpression {
   evalType: Primitive.BOOLEAN | Primitive.NUMBER | Primitive.TEXT;
 
-  constructor(readonly kind: 'BinaryExpressionNode' | 'UnaryExpressionNode' | 'FieldNamePrimitiveNode' | 'NumberPrimitiveNode' | 'BooleanPrimitiveNode' | 'TextPrimitiveNode') {}
+  constructor(readonly kind: RefinementExpressionNodeType) {}
   static fromAst(expr: RefinementExpressionNode, typeData: Dictionary<ExpressionPrimitives>): RefinementExpression {
     if (!expr) {
       return null;
@@ -192,6 +194,7 @@ abstract class RefinementExpression {
       case 'binary-expression-node': return BinaryExpression.fromAst(expr, typeData);
       case 'unary-expression-node': return UnaryExpression.fromAst(expr, typeData);
       case 'field-name-node': return FieldNamePrimitive.fromAst(expr, typeData);
+      case 'query-argument-node': return QueryArgumentPrimitive.fromAst(expr, typeData);
       case 'number-node': return NumberPrimitive.fromAst(expr);
       case 'boolean-node': return BooleanPrimitive.fromAst(expr);
       case 'text-node': return TextPrimitive.fromAst(expr);
@@ -201,16 +204,15 @@ abstract class RefinementExpression {
     }
   }
 
-  static fromLiteral(expr): RefinementExpression {
+  static fromLiteral(expr: {kind: RefinementExpressionNodeType}): RefinementExpression {
     switch (expr.kind) {
       case 'BinaryExpressionNode': return BinaryExpression.fromLiteral(expr);
       case 'UnaryExpressionNode': return UnaryExpression.fromLiteral(expr);
       case 'FieldNamePrimitiveNode': return FieldNamePrimitive.fromLiteral(expr);
+      case 'QueryArgumentPrimitiveNode': return QueryArgumentPrimitive.fromLiteral(expr);
       case 'NumberPrimitiveNode': return NumberPrimitive.fromLiteral(expr);
       case 'BooleanPrimitiveNode': return BooleanPrimitive.fromLiteral(expr);
-      default:
-        // Should never happen; all known kinds are handled above, but the linter wants a default.
-        throw new Error(`RefinementExpression.fromLiteral: Unknown node type ${expr['kind']}`);
+      case 'TextPrimitiveNode': return TextPrimitive.fromLiteral(expr);
     }
   }
 
@@ -248,7 +250,7 @@ export class BinaryExpression extends RefinementExpression {
     this.leftExpr = leftExpr;
     this.rightExpr = rightExpr;
     this.operator = op;
-    this.operator.validateOperandCompatibility([this.leftExpr.evalType, this.rightExpr.evalType]);
+    this.operator.validateOperandCompatibility([this.leftExpr, this.rightExpr]);
     this.evalType = this.operator.evalType();
   }
 
@@ -407,7 +409,7 @@ export class UnaryExpression extends RefinementExpression {
     super('UnaryExpressionNode');
     this.expr = expr;
     this.operator = op;
-    this.operator.validateOperandCompatibility([this.expr.evalType]);
+    this.operator.validateOperandCompatibility([this.expr]);
     this.evalType = this.operator.evalType();
   }
 
@@ -514,6 +516,49 @@ export class FieldNamePrimitive extends RefinementExpression {
       return data[this.value];
     }
     throw new Error(`Unresolved field name '${this.value}' in the refinement expression.`);
+  }
+
+  getFieldNames(): Set<string> {
+    return new Set<string>([this.value]);
+  }
+
+  getTextPrimitives(): Set<string> {
+    return new Set<string>();
+  }
+}
+
+export class QueryArgumentPrimitive extends RefinementExpression {
+  value: string;
+  evalType: Primitive;
+
+  constructor(value: string, evalType?: Primitive.NUMBER | Primitive.BOOLEAN | Primitive.TEXT) {
+    super('QueryArgumentPrimitiveNode');
+    this.value = value;
+    this.evalType = evalType;
+  }
+
+  static fromAst(expression: QueryNode, typeData: Dictionary<ExpressionPrimitives>): RefinementExpression {
+    return new QueryArgumentPrimitive(expression.value, typeData[expression.value]);
+  }
+
+  static fromLiteral(expr): RefinementExpression {
+    return new QueryArgumentPrimitive(expr.value);
+  }
+
+  toString(): string {
+    return this.value.toString();
+  }
+
+  toSQLExpression(): string {
+    return this.value.toString();
+  }
+
+  applyOperator(data: Dictionary<ExpressionPrimitives> = {}): ExpressionPrimitives {
+    if (data[this.value] != undefined) {
+      return data[this.value];
+    }
+    // This is an 'explicit' unknown value which should not restrict data.
+    return null;
   }
 
   getFieldNames(): Set<string> {
@@ -1062,18 +1107,27 @@ export class RefinementOperator {
     return this.opInfo.evalType;
   }
 
-  validateOperandCompatibility(operandTypes: string[]): void {
+  validateOperandCompatibility(operandTypes: {evalType: String}[]): void {
     if (operandTypes.length !== this.opInfo.nArgs) {
       throw new Error(`Expected ${this.opInfo.nArgs} operands. Got ${operandTypes.length}.`);
     }
     if (this.opInfo.argType === 'same') {
-      if (operandTypes[0] !== operandTypes[1]) {
-        throw new Error(`Expected ${operandTypes[0]} and ${operandTypes[1]} to be the same.`);
+      // If there is a type variable, apply the restriction.
+      if (operandTypes[0].evalType === undefined) {
+        operandTypes[0].evalType = operandTypes[1].evalType;
+        return;
+      }
+      if (operandTypes[1].evalType === undefined) {
+        operandTypes[1].evalType = operandTypes[0].evalType;
+        return;
+      }
+      if (operandTypes[0].evalType !== operandTypes[1].evalType) {
+        throw new Error(`Expected ${operandTypes[0].evalType} and ${operandTypes[1].evalType} to be the same.`);
       }
     } else {
       for (const type of operandTypes) {
-        if (type !== this.opInfo.argType) {
-          throw new Error(`Got type ${type}. Expected ${this.opInfo.argType}.`);
+        if (type.evalType !== this.opInfo.argType) {
+          throw new Error(`Got type ${type.evalType}. Expected ${this.opInfo.argType}.`);
         }
       }
     }

--- a/src/runtime/refiner.ts
+++ b/src/runtime/refiner.ts
@@ -1107,25 +1107,25 @@ export class RefinementOperator {
     return this.opInfo.evalType;
   }
 
-  validateOperandCompatibility(operandTypes: {evalType: string}[]): void {
-    if (operandTypes.length !== this.opInfo.nArgs) {
-      throw new Error(`Expected ${this.opInfo.nArgs} operands. Got ${operandTypes.length}.`);
+  validateOperandCompatibility(operands: RefinementExpression[]): void {
+    if (operands.length !== this.opInfo.nArgs) {
+      throw new Error(`Expected ${this.opInfo.nArgs} operands. Got ${operands.length}.`);
     }
     if (this.opInfo.argType === 'same') {
       // If there is a type variable, apply the restriction.
-      if (operandTypes[0].evalType === undefined) {
-        operandTypes[0].evalType = operandTypes[1].evalType;
+      if (operands[0].evalType === undefined) {
+        operands[0].evalType = operands[1].evalType;
         return;
       }
-      if (operandTypes[1].evalType === undefined) {
-        operandTypes[1].evalType = operandTypes[0].evalType;
+      if (operands[1].evalType === undefined) {
+        operands[1].evalType = operands[0].evalType;
         return;
       }
-      if (operandTypes[0].evalType !== operandTypes[1].evalType) {
-        throw new Error(`Expected refinement expression ${operandTypes[0]} and ${operandTypes[1]} to have the same type. But found types ${operandTypes[0].evalType} and ${operandTypes[1].evalType}.`);
+      if (operands[0].evalType !== operands[1].evalType) {
+        throw new Error(`Expected refinement expression ${operands[0]} and ${operands[1]} to have the same type. But found types ${operands[0].evalType} and ${operands[1].evalType}.`);
       }
     } else {
-      for (const type of operandTypes) {
+      for (const type of operands) {
         if (type.evalType !== this.opInfo.argType) {
           throw new Error(`Refinement expression ${type} has type ${type.evalType}. Expected ${this.opInfo.argType}.`);
         }

--- a/src/runtime/refiner.ts
+++ b/src/runtime/refiner.ts
@@ -1107,7 +1107,7 @@ export class RefinementOperator {
     return this.opInfo.evalType;
   }
 
-  validateOperandCompatibility(operandTypes: {evalType: String}[]): void {
+  validateOperandCompatibility(operandTypes: {evalType: string}[]): void {
     if (operandTypes.length !== this.opInfo.nArgs) {
       throw new Error(`Expected ${this.opInfo.nArgs} operands. Got ${operandTypes.length}.`);
     }

--- a/src/runtime/tests/refiner-test.ts
+++ b/src/runtime/tests/refiner-test.ts
@@ -128,8 +128,7 @@ describe('refiner', () => {
   });
 });
 
-
-describe('refiner', () => {
+describe('refiner enforcement', () => {
     let schema: Schema;
     let entityClass: EntityClass;
     before(async () => {
@@ -150,6 +149,22 @@ describe('refiner', () => {
     it('data does conform to the refinement', Flags.whileEnforcingRefinements(async () => {
         assert.doesNotThrow(() => { const e = new entityClass({txt: 'abc', num: 8}); });
       }));
+});
+
+describe('dynamic refinements', () => {
+    it('Parses a particle with dynamic refinements.', () => {
+        const manifestAst = parse(`
+            particle AddressBook
+                contacts: reads [Contact {name: Text [ name == ? ] }]
+        `);
+        const typeData = {'name': 'Text'};
+        const ref = Refinement.fromAst(manifestAst[0].args[0].type.fields[0].type.refinement, typeData);
+        const data = {
+            num: 'Ghost Busters'
+        };
+        const res = ref.validateData(data);
+        assert.strictEqual(res, data.name === '' || data.name === 'Ghost Busters');
+    });
 });
 
 describe('normalisation', () => {

--- a/src/runtime/tests/refiner-test.ts
+++ b/src/runtime/tests/refiner-test.ts
@@ -40,7 +40,7 @@ describe('refiner', () => {
             const data = {
                 num: 6,
             };
-            const _ = ref.validateData(data);
+            ref.validateData(data);
         }, `Unresolved field name 'num2' in the refinement expression.`);
     });
     it('Throws error when expression does not produce boolean result.', () => {
@@ -54,8 +54,8 @@ describe('refiner', () => {
             const data = {
                 num: 6,
             };
-            const _ = ref.validateData(data);
-        }, `Refinement expression evaluated to a non-boolean type.`);
+            ref.validateData(data);
+        }, `Refinement expression (num + 5) evaluated to a non-boolean type.`);
     });
     it('Throws error when operators and operands are incompatible.', () => {
         assert.throws(() => {
@@ -68,8 +68,8 @@ describe('refiner', () => {
             const data = {
                 num: 6,
             };
-            const _ = ref.validateData(data);
-        }, `Got type Boolean. Expected Number.`);
+            ref.validateData(data);
+        }, `Refinement expression (num < 5) has type Boolean. Expected Number.`);
         assert.throws(() => {
             const manifestAst = parse(`
                 particle Foo
@@ -80,7 +80,7 @@ describe('refiner', () => {
             const data = {
                 num: 6,
             };
-            const _ = ref.validateData(data);
+            ref.validateData(data);
         }, `Got type Number. Expected Boolean.`);
         assert.throws(() => {
           const manifestAst = parse(`
@@ -92,8 +92,8 @@ describe('refiner', () => {
           const data = {
               name: 'Josh',
           };
-          const _ = ref.validateData(data);
-      }, `Got type Text. Expected Number.`);
+            ref.validateData(data);
+        }, `Refinement expression num has type Number. Expected Boolean.`);
     });
     it('tests expression to range conversion.', () => {
         let manifestAst = parse(`

--- a/src/runtime/tests/refiner-test.ts
+++ b/src/runtime/tests/refiner-test.ts
@@ -81,7 +81,7 @@ describe('refiner', () => {
                 num: 6,
             };
             ref.validateData(data);
-        }, `Got type Number. Expected Boolean.`);
+        }, `Refinement expression num has type Number. Expected Boolean.`);
         assert.throws(() => {
           const manifestAst = parse(`
               particle Foo
@@ -93,7 +93,7 @@ describe('refiner', () => {
               name: 'Josh',
           };
             ref.validateData(data);
-        }, `Refinement expression num has type Number. Expected Boolean.`);
+        }, `Refinement expression name has type Text. Expected Number.`);
     });
     it('tests expression to range conversion.', () => {
         let manifestAst = parse(`


### PR DESCRIPTION
Introduces the '?' query argument into the refinement syntax.

Also adds a test that the refinement system's type checking system properly assigns a type (when known) to the query argument expression (to be later used in fast query generation and the Kotlin API code gen).

I've also restricted some types a little further (e.g. replacing some `string` types with `Op`s which is a more specific subtype) and added some more information to error messages (mostly by passing expressions to the typechecking, rather than just the expression's type).