### PR TITLE
Some storage testing fixes

### DIFF
--- a/java/arcs/core/data/Entity.kt
+++ b/java/arcs/core/data/Entity.kt
@@ -18,8 +18,7 @@ data class Entity(
     val schema: Schema,
     val data: MutableMap<FieldName, Any?>
 ) {
-    @Suppress("UNCHECKED_CAST")
-    val entries: MutableSet<MutableMap.MutableEntry<FieldName, Any?>>
+    val entries: Set<Map.Entry<FieldName, Any?>>
         get() = data.entries
 
     fun put(key: FieldName, value: Any?): Any? {

--- a/java/arcs/core/data/Entity.kt
+++ b/java/arcs/core/data/Entity.kt
@@ -17,12 +17,12 @@ data class Entity(
     val id: String,
     val schema: Schema,
     val data: MutableMap<FieldName, Any?>
-) : AbstractMutableMap<FieldName, Any?>() {
+) {
     @Suppress("UNCHECKED_CAST")
-    override val entries: MutableSet<MutableMap.MutableEntry<FieldName, Any?>>
+    val entries: MutableSet<MutableMap.MutableEntry<FieldName, Any?>>
         get() = data.entries
 
-    override fun put(key: FieldName, value: Any?): Any? {
+    fun put(key: FieldName, value: Any?): Any? {
         require(key in schema.fields.collections || key in schema.fields.singletons) {
             "Illegal field $key, not part of ${schema.name}'s schema."
         }

--- a/java/arcs/core/storage/testutil/BUILD
+++ b/java/arcs/core/storage/testutil/BUILD
@@ -1,0 +1,14 @@
+load("//third_party/java/arcs/build_defs/internal:kotlin.bzl", "arcs_kt_jvm_library")
+
+licenses(["notice"])
+
+package(default_visibility = ["//visibility:public"])
+
+arcs_kt_jvm_library(
+    name = "testutil",
+    testonly = True,
+    srcs = glob(["*.kt"]),
+    deps = [
+        "//java/arcs/core/storage:storage_key",
+    ],
+)

--- a/java/arcs/core/storage/testutil/DummyStorageKey.kt
+++ b/java/arcs/core/storage/testutil/DummyStorageKey.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.core.storage.testutil
+
+import arcs.core.storage.StorageKey
+import arcs.core.storage.StorageKeyParser
+
+/** Fake [StorageKey] implementation for use in unit tests. */
+class DummyStorageKey(val key: String) : StorageKey(protocol) {
+    override fun toKeyString(): String = key
+
+    override fun childKeyWithComponent(component: String): StorageKey = this
+
+    companion object {
+        const val protocol = "dummy"
+
+        fun parse(rawKeyString: String): DummyStorageKey = DummyStorageKey(rawKeyString)
+
+        fun registerParser() {
+            StorageKeyParser.addParser(protocol, ::parse)
+        }
+    }
+}

--- a/javatests/arcs/android/storage/database/BUILD
+++ b/javatests/arcs/android/storage/database/BUILD
@@ -17,6 +17,7 @@ arcs_kt_android_test_suite(
         "//java/arcs/core/data",
         "//java/arcs/core/storage:storage_key",
         "//java/arcs/core/storage/database",
+        "//java/arcs/core/storage/testutil",
         "//java/arcs/core/testutil",
         "//third_party/android/androidx_test/core",
         "//third_party/android/androidx_test/ext/junit",

--- a/javatests/arcs/core/storage/BUILD
+++ b/javatests/arcs/core/storage/BUILD
@@ -21,6 +21,7 @@ arcs_kt_android_test_suite(
         "//java/arcs/core/storage/database",
         "//java/arcs/core/storage/driver",
         "//java/arcs/core/storage/referencemode",
+        "//java/arcs/core/storage/testutil",
         "//java/arcs/core/testutil",
         "//java/arcs/core/type",
         "//java/arcs/core/util/testutil",

--- a/javatests/arcs/core/storage/ReferenceModeStoreDatabaseIntegrationTest.kt
+++ b/javatests/arcs/core/storage/ReferenceModeStoreDatabaseIntegrationTest.kt
@@ -133,7 +133,7 @@ class ReferenceModeStoreDatabaseIntegrationTest {
             database.get(bobKey, DatabaseData.Entity::class, schema) as? DatabaseData.Entity
         )
 
-        assertThat(capturedBob.entity).containsExactly(
+        assertThat(capturedBob.entity.data).containsExactly(
             "name", "bob",
             "age", 42.0
         )

--- a/javatests/arcs/core/storage/StoreTest.kt
+++ b/javatests/arcs/core/storage/StoreTest.kt
@@ -18,6 +18,7 @@ import arcs.core.crdt.CrdtException
 import arcs.core.crdt.CrdtOperation
 import arcs.core.crdt.internal.VersionMap
 import arcs.core.data.CountType
+import arcs.core.storage.testutil.DummyStorageKey
 import com.google.common.truth.Truth.assertThat
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.anyOrNull
@@ -42,7 +43,7 @@ import org.junit.runners.JUnit4
 @ExperimentalCoroutinesApi
 @RunWith(JUnit4::class)
 class StoreTest {
-    val testKey: StorageKey = DummyKey()
+    val testKey: StorageKey = DummyStorageKey("key")
 
     @Before
     fun setup() {
@@ -348,9 +349,4 @@ class StoreTest {
 
     private fun createStore(): Store<CrdtData, CrdtOperation, Any?> =
         Store(StoreOptions(testKey, ExistenceCriteria.ShouldCreate, CountType()))
-
-    class DummyKey : StorageKey("dummy") {
-        override fun toKeyString(): String = "dummy"
-        override fun childKeyWithComponent(component: String): StorageKey = this
-    }
 }


### PR DESCRIPTION
Moved the `DummyStorageKey` class into a `testutil` package, and reused it in another test file.

Made `Entity` not extend `AbstractMutableMap` anymore. This was messing up the data class equality check in an unexpected way: two entities would be considered equal if their field data matched (but IDs could be different).