### PR TITLE
Fixes bug fetching storage key ids

### DIFF
--- a/javatests/arcs/android/storage/database/DatabaseImplTest.kt
+++ b/javatests/arcs/android/storage/database/DatabaseImplTest.kt
@@ -167,9 +167,13 @@ class DatabaseImplTest {
     }
 
     @Test
-    fun getStorageKeyId_existingKey() = runBlockingTest {
-        assertThat(database.getEntityStorageKeyId(DummyStorageKey("key"), 123L, db)).isEqualTo(1L)
-        assertThat(database.getEntityStorageKeyId(DummyStorageKey("key"), 123L, db)).isEqualTo(1L)
+    fun getStorageKeyId_existingKeys() = runBlockingTest {
+        // Create new keys.
+        assertThat(database.getEntityStorageKeyId(DummyStorageKey("key1"), 123L, db)).isEqualTo(1L)
+        assertThat(database.getEntityStorageKeyId(DummyStorageKey("key2"), 123L, db)).isEqualTo(2L)
+        // Check existing keys.
+        assertThat(database.getEntityStorageKeyId(DummyStorageKey("key1"), 123L, db)).isEqualTo(1L)
+        assertThat(database.getEntityStorageKeyId(DummyStorageKey("key2"), 123L, db)).isEqualTo(2L)
     }
 
     @Test


### PR DESCRIPTION
Existing IDs were not being returned correctly. I misunderstood how
insertWithOnConflict worked: if the row already exists, it doesn't return
the ID of the matching row like I expected, it instead returns the number
of rows (for some reason...)

Now we do two separate queries: SELECT first, then optionally INSERT.