### PR TITLE
Add ActivationFactory parameter to ArcsSingleton

### DIFF
--- a/java/arcs/core/storage/Store.kt
+++ b/java/arcs/core/storage/Store.kt
@@ -26,7 +26,7 @@ import arcs.core.type.Type
  * of an inactive [Store].
  */
 interface ActivationFactory<Data : CrdtData, Op : CrdtOperation, T> {
-    suspend fun create(options: StoreOptions<Data, Op, T>): ActiveStore<Data, Op, T>
+    suspend operator fun invoke(options: StoreOptions<Data, Op, T>): ActiveStore<Data, Op, T>
 }
 
 /**
@@ -79,7 +79,7 @@ class Store<Data : CrdtData, Op : CrdtOperation, ConsumerData>(
             model = model
         )
         // If we were given a specific factory to use, use it; otherwise use the default factory.
-        val  activeStore = (activationFactory ?: getDefaultFactory<Data, Op, ConsumerData>()).create(options)
+        val  activeStore = (activationFactory ?: getDefaultFactory()).invoke(options)
 
         existenceCriteria = ExistenceCriteria.ShouldExist
         this.activeStore = activeStore
@@ -103,7 +103,7 @@ class Store<Data : CrdtData, Op : CrdtOperation, ConsumerData>(
         }
 
         private val defaultFactory = object : ActivationFactory<CrdtData, CrdtOperation, Any> {
-            override suspend fun create(
+            override suspend fun invoke(
                 options: StoreOptions<CrdtData, CrdtOperation, Any>
             ): ActiveStore<CrdtData, CrdtOperation, Any> {
                 val constructor = CrdtException.requireNotNull(DEFAULT_CONSTRUCTORS[options.mode]) {

--- a/java/arcs/core/storage/Store.kt
+++ b/java/arcs/core/storage/Store.kt
@@ -63,9 +63,7 @@ class Store<Data : CrdtData, Op : CrdtOperation, ConsumerData>(
      * Supply a custom [activationFactory] to override the default behavior.
      */
     suspend fun activate(
-        /* ktlint-disable max-line-length */
         activationFactory: ActivationFactory<Data, Op, ConsumerData>? = null
-        /* ktlint-enable max-line-length */
     ): ActiveStore<Data, Op, ConsumerData> {
         activeStore?.let { return it }
 
@@ -79,7 +77,7 @@ class Store<Data : CrdtData, Op : CrdtOperation, ConsumerData>(
             model = model
         )
         // If we were given a specific factory to use, use it; otherwise use the default factory.
-        val  activeStore = (activationFactory ?: getDefaultFactory()).invoke(options)
+        val activeStore = (activationFactory ?: getDefaultFactory()).invoke(options)
 
         existenceCriteria = ExistenceCriteria.ShouldExist
         this.activeStore = activeStore
@@ -98,9 +96,8 @@ class Store<Data : CrdtData, Op : CrdtOperation, ConsumerData>(
          * the [defaultFactory] instance.
          */
         @Suppress("UNCHECKED_CAST")
-        private fun <Data : CrdtData, Op : CrdtOperation, T>getDefaultFactory(): ActivationFactory<Data, Op, T> {
-            return defaultFactory as ActivationFactory<Data, Op, T>
-        }
+        private fun <Data : CrdtData, Op : CrdtOperation, T> getDefaultFactory() =
+            defaultFactory as ActivationFactory<Data, Op, T>
 
         private val defaultFactory = object : ActivationFactory<CrdtData, CrdtOperation, Any> {
             override suspend fun invoke(
@@ -117,7 +114,9 @@ class Store<Data : CrdtData, Op : CrdtOperation, ConsumerData>(
 
                 return CrdtException.requireNotNull(
                     constructor(options, dataClass) as? ActiveStore<CrdtData, CrdtOperation, Any>
-                ) { "Could not cast constructed store to ActiveStore${constructor.typeParamString}" }
+                ) {
+                    "Could not cast constructed store to ActiveStore${constructor.typeParamString}"
+                }
             }
         }
     }

--- a/java/arcs/core/storage/api/ArcsSingleton.kt
+++ b/java/arcs/core/storage/api/ArcsSingleton.kt
@@ -54,7 +54,9 @@ fun ArcsSingleton(
     schema: Schema,
     existenceCriteria: ExistenceCriteria = ExistenceCriteria.MayExist,
     coroutineContext: CoroutineContext = Dispatchers.Default,
+    /* ktlint-disable max-line-length */
     activationFactory: ActivationFactory<RefModeStoreData.Singleton, RefModeStoreOp.Singleton, RawEntity>? = null
+    /* ktlint-enable max-line-length */
 ): ArcsSingleton<RawEntity, RefModeStoreData.Singleton, RefModeStoreOp.Singleton> {
     val storeOpts = StoreOptions<RefModeStoreData.Singleton, RefModeStoreOp.Singleton, RawEntity>(
         storageKey = storageKey,
@@ -90,7 +92,9 @@ inline fun <reified T> ArcsSingleton(
     storageKey: StorageKey,
     existenceCriteria: ExistenceCriteria = ExistenceCriteria.MayExist,
     coroutineContext: CoroutineContext = Dispatchers.Default,
+    /* ktlint-disable max-line-length */
     activationFactory: ActivationFactory<CrdtSingleton.Data<ReferencablePrimitive<T>>, CrdtSingleton.IOperation<ReferencablePrimitive<T>>, ReferencablePrimitive<T>>? = null
+    /* ktlint-enable max-line-length */
 ): ArcsSingleton<ReferencablePrimitive<T>,
     CrdtSingleton.Data<ReferencablePrimitive<T>>,
     CrdtSingleton.IOperation<ReferencablePrimitive<T>>> {

--- a/java/arcs/core/storage/api/ArcsSingleton.kt
+++ b/java/arcs/core/storage/api/ArcsSingleton.kt
@@ -12,6 +12,7 @@ import arcs.core.data.RawEntity
 import arcs.core.data.Schema
 import arcs.core.data.SingletonType
 import arcs.core.data.util.ReferencablePrimitive
+import arcs.core.storage.ActivationFactory
 import arcs.core.storage.ActiveStore
 import arcs.core.storage.ExistenceCriteria
 import arcs.core.storage.ProxyCallback
@@ -52,7 +53,8 @@ fun ArcsSingleton(
     storageKey: ReferenceModeStorageKey,
     schema: Schema,
     existenceCriteria: ExistenceCriteria = ExistenceCriteria.MayExist,
-    coroutineContext: CoroutineContext = Dispatchers.Default
+    coroutineContext: CoroutineContext = Dispatchers.Default,
+    activationFactory: ActivationFactory<RefModeStoreData.Singleton, RefModeStoreOp.Singleton, RawEntity>? = null
 ): ArcsSingleton<RawEntity, RefModeStoreData.Singleton, RefModeStoreOp.Singleton> {
     val storeOpts = StoreOptions<RefModeStoreData.Singleton, RefModeStoreOp.Singleton, RawEntity>(
         storageKey = storageKey,
@@ -70,7 +72,8 @@ fun ArcsSingleton(
                 else -> throw IllegalArgumentException("Invalid operation type: $it")
             }
         },
-        coroutineContext = coroutineContext
+        coroutineContext = coroutineContext,
+        activationFactory = activationFactory
     )
 }
 
@@ -86,7 +89,8 @@ fun ArcsSingleton(
 inline fun <reified T> ArcsSingleton(
     storageKey: StorageKey,
     existenceCriteria: ExistenceCriteria = ExistenceCriteria.MayExist,
-    coroutineContext: CoroutineContext = Dispatchers.Default
+    coroutineContext: CoroutineContext = Dispatchers.Default,
+    activationFactory: ActivationFactory<CrdtSingleton.Data<ReferencablePrimitive<T>>, CrdtSingleton.IOperation<ReferencablePrimitive<T>>, ReferencablePrimitive<T>>? = null
 ): ArcsSingleton<ReferencablePrimitive<T>,
     CrdtSingleton.Data<ReferencablePrimitive<T>>,
     CrdtSingleton.IOperation<ReferencablePrimitive<T>>> {
@@ -109,7 +113,8 @@ inline fun <reified T> ArcsSingleton(
         store = Store(storeOps),
         toStoreData = { it },
         toStoreOp = { it },
-        coroutineContext = coroutineContext
+        coroutineContext = coroutineContext,
+        activationFactory = activationFactory
     )
 }
 
@@ -127,7 +132,8 @@ class ArcsSingleton<T, StoreData, StoreOp>(
     private val store: Store<StoreData, StoreOp, T>,
     private val toStoreData: (CrdtSingleton.Data<T>) -> StoreData,
     private val toStoreOp: (CrdtSingleton.IOperation<T>) -> StoreOp,
-    coroutineContext: CoroutineContext
+    coroutineContext: CoroutineContext,
+    activationFactory: ActivationFactory<StoreData, StoreOp, T>? = null
 ) : Referencable
     where T : Referencable,
           StoreData : CrdtSingleton.Data<T>,
@@ -160,7 +166,7 @@ class ArcsSingleton<T, StoreData, StoreOp>(
         // Launch a coroutine to activate the backing store, register ourselves as a ProxyCallback,
         // and perform an initial sync.
         scope.launch {
-            activeStore = store.activate().also { activeStore ->
+            activeStore = store.activate(activationFactory).also { activeStore ->
                 initialized.complete()
                 ProxyCallback<StoreData, StoreOp, T> { handleStoreCallback(it) }
                     .also {

--- a/java/arcs/sdk/android/storage/ServiceStore.kt
+++ b/java/arcs/sdk/android/storage/ServiceStore.kt
@@ -25,6 +25,7 @@ import arcs.android.storage.toParcelable
 import arcs.core.crdt.CrdtData
 import arcs.core.crdt.CrdtException
 import arcs.core.crdt.CrdtOperation
+import arcs.core.storage.ActivationFactory
 import arcs.core.storage.ActiveStore
 import arcs.core.storage.ProxyCallback
 import arcs.core.storage.ProxyMessage
@@ -62,8 +63,8 @@ class ServiceStoreFactory<Data : CrdtData, Op : CrdtOperation, ConsumerData>(
     private val crdtType: ParcelableCrdtType,
     private val coroutineContext: CoroutineContext = Dispatchers.IO,
     private val connectionFactory: ConnectionFactory? = null
-) {
-    suspend operator fun invoke(
+) : ActivationFactory<Data, Op, ConsumerData> {
+    override suspend operator fun invoke(
         options: StoreOptions<Data, Op, ConsumerData>
     ): ServiceStore<Data, Op, ConsumerData> {
         val storeContext = coroutineContext + CoroutineName("ServiceStore(${options.storageKey})")


### PR DESCRIPTION
This is just so that we can temporarily use ArcsSingleton to test
ServiceStore instantiation before Handles/StorageProxy are ready.