### PR TITLE
Hide linking warning if there were no already linked files

### DIFF
--- a/tools/sigh.ts
+++ b/tools/sigh.ts
@@ -455,7 +455,7 @@ function link(srcFiles: Iterable<string>): boolean {
       }
     }
   }
-  if (linkOptions.existing !== []) {
+  if (linkOptions.existing.length > 0) {
     console.warn(`Warning when linking ${linkOptions.existing.length} file(s) already existed.`);
   }
   return success;


### PR DESCRIPTION
Accidentally used a strict equality here. Switched to be very clear about the requirement for logging