### PR TITLE
Temporarily disable deadlock test while we rework it.

### DIFF
--- a/java/arcs/core/storage/BUILD
+++ b/java/arcs/core/storage/BUILD
@@ -40,10 +40,10 @@ arcs_kt_library(
         # TODO: should we move VersionMap to the top-level crdt package if it's being used here?
         "//java/arcs/core/crdt/internal",
         "//java/arcs/core/data",
-        "//java/arcs/core/data:rawentity",
-        "//java/arcs/core/type",
+        "//java/arcs/core/data:rawentity",  # unuseddeps: keep
         "//java/arcs/core/storage/referencemode",
         "//java/arcs/core/storage/util",
+        "//java/arcs/core/type",
         "//java/arcs/core/util",
         "//third_party/kotlin/kotlinx_atomicfu",
         "//third_party/kotlin/kotlinx_coroutines",

--- a/java/arcs/core/storage/handle/BUILD
+++ b/java/arcs/core/storage/handle/BUILD
@@ -13,7 +13,7 @@ arcs_kt_library(
     deps = [
         "//java/arcs/core/common",
         "//java/arcs/core/crdt",
-        "//java/arcs/core/crdt/internal",
+        "//java/arcs/core/crdt/internal",  # unuseddeps: keep
         "//java/arcs/core/storage",
         "//java/arcs/core/util",
     ],

--- a/javatests/arcs/core/storage/StorageProxyTest.kt
+++ b/javatests/arcs/core/storage/StorageProxyTest.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runBlockingTest
 import kotlinx.coroutines.withTimeout
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
@@ -149,6 +150,7 @@ class StorageProxyTest {
     }
 
     @Test
+    @Ignore("We've detected flakes with this approach, reworking in follow up PR")
     fun deadlockDetectionTest() = runBlocking {
         val storageProxy = StorageProxy(mockStorageEndpointProvider, mockCrdtModel)
         whenever(mockCrdtModel.consumerView).thenReturn("someData")
@@ -196,8 +198,9 @@ class StorageProxyTest {
         val workers = 20
         val jobs = 10
         Executors.newFixedThreadPool(workers).asCoroutineDispatcher().use {
+            val newScope = it // does it@ work for this?
             repeat(10) {
-                runBlocking {
+                runBlocking(newScope) {
                     withTimeout(2000) {
                         repeat(workers) {
                             launch {

--- a/javatests/arcs/core/storage/handle/BUILD
+++ b/javatests/arcs/core/storage/handle/BUILD
@@ -25,7 +25,7 @@ arcs_kt_android_test_suite(
         "//java/arcs/core/storage/handle",
         "//java/arcs/core/storage/referencemode",
         "//java/arcs/core/util/testutil",
-        "//javatests/arcs/core/storage",
+        "//javatests/arcs/core/storage",  # unuseddeps: keep
         "//third_party/java/junit:junit-android",
         "//third_party/java/mockito:mockito-android",
         "//third_party/java/truth:truth-android",


### PR DESCRIPTION
Also remove an unused dep.