### PR TITLE
Add 'handles' field to the particle base class

### DIFF
--- a/javatests/arcs/sdk/wasm/AutoRenderTest.kt
+++ b/javatests/arcs/sdk/wasm/AutoRenderTest.kt
@@ -17,5 +17,5 @@ class AutoRenderTest : AbstractAutoRenderTest() {
     override fun init() = renderOutput()
     override fun onHandleUpdate(handle: Handle) = renderOutput()
     override fun onHandleSync(handle: Handle, allSynced: Boolean) = renderOutput()
-    override fun getTemplate(slotName: String): String = data.fetch()?.txt ?: ""
+    override fun getTemplate(slotName: String): String = handles.data.fetch()?.txt ?: ""
 }

--- a/javatests/arcs/sdk/wasm/CollectionApiTest.kt
+++ b/javatests/arcs/sdk/wasm/CollectionApiTest.kt
@@ -17,36 +17,36 @@ class CollectionApiTest : AbstractCollectionApiTest() {
     override fun fireEvent(slotName: String, eventName: String, eventData: Map<String, String>) {
         when (eventName) {
             "case1" -> {
-                outHandle.clear()
-                ioHandle.clear()
+                handles.outHandle.clear()
+                handles.ioHandle.clear()
             }
             "case2" -> {
                 stored = stored.copy(
-                    flg = inHandle.isEmpty(),
-                    num = inHandle.size.toDouble()
+                    flg = handles.inHandle.isEmpty(),
+                    num = handles.inHandle.size.toDouble()
                 )
-                outHandle.store(stored)
+                handles.outHandle.store(stored)
             }
             "case3" -> {
-                outHandle.remove(stored)
+                handles.outHandle.remove(stored)
             }
             "case4" -> {
                 val d1 = CollectionApiTest_OutHandle()
-                val iter = inHandle.iterator()
+                val iter = handles.inHandle.iterator()
                 val flg = iter.hasNext()
                 val i1 = iter.next()
-                outHandle.store(d1.copy(
+                handles.outHandle.store(d1.copy(
                     txt = "num: ${i1.num.toInt()}",
                     num = i1.num.let { it * 2 },
                     flg = flg
                 ))
 
-                outHandle.store(d1.copy(
+                handles.outHandle.store(d1.copy(
                     txt = "eq",
                     flg = iter.hasNext()
                 ))
 
-                outHandle.store(d1.copy(
+                handles.outHandle.store(d1.copy(
                     txt = "ne",
                     flg = !iter.hasNext()
                 ))
@@ -55,38 +55,38 @@ class CollectionApiTest : AbstractCollectionApiTest() {
                 val extra = CollectionApiTest_IoHandle().copy(txt = "abc")
 
 
-                ioHandle.store(extra)
+                handles.ioHandle.store(extra)
                 val d1 = CollectionApiTest_OutHandle(
-                    num = ioHandle.size.toDouble(),
+                    num = handles.ioHandle.size.toDouble(),
                     txt = "",
-                    flg = ioHandle.isEmpty())
-                outHandle.store(d1)
+                    flg = handles.ioHandle.isEmpty())
+                handles.outHandle.store(d1)
 
-                ioHandle.remove(extra)
+                handles.ioHandle.remove(extra)
                 val d2 = CollectionApiTest_OutHandle(
-                    num = ioHandle.size.toDouble(),
+                    num = handles.ioHandle.size.toDouble(),
                     txt = "",
                     flg = false
                 )
-                outHandle.store(d2)
+                handles.outHandle.store(d2)
 
                 // Ranged iteration; order is not guaranteed so use 'num' to assign sorted array slots.
-                val sorted = ioHandle.sortedBy { it.num.toInt() }
+                val sorted = handles.ioHandle.sortedBy { it.num.toInt() }
                 sorted.forEach {
-                    outHandle.store(CollectionApiTest_OutHandle(
+                    handles.outHandle.store(CollectionApiTest_OutHandle(
                         num = it.num,
                         txt = it.txt,
                         flg = false
                     ))
                 }
 
-                ioHandle.clear()
+                handles.ioHandle.clear()
                 val d3 = CollectionApiTest_OutHandle(
-                    num = ioHandle.size.toDouble(),
+                    num = handles.ioHandle.size.toDouble(),
                     txt = "",
-                    flg = ioHandle.isEmpty()
+                    flg = handles.ioHandle.isEmpty()
                 )
-                outHandle.store(d3)
+                handles.outHandle.store(d3)
             }
         }
     }

--- a/javatests/arcs/sdk/wasm/EntitySlicingTest.kt
+++ b/javatests/arcs/sdk/wasm/EntitySlicingTest.kt
@@ -19,18 +19,18 @@ class EntitySlicingTest : AbstractEntitySlicingTest() {
     override fun onHandleSync(handle: Handle, allSynced: Boolean) {
         if (!allSynced) return;
 
-        s1.fetch()?.let { res.store(Res("s1:${it.num.toInt()}")) }
-        s2.fetch()?.let { res.store(Res("s2:${it.num.toInt()},${it.txt}")) }
-        s3.fetch()?.let { res.store(Res("s3:${it.num.toInt()},${it.txt},${it.flg}")) }
+        handles.s1.fetch()?.let { handles.res.store(Res("s1:${it.num.toInt()}")) }
+        handles.s2.fetch()?.let { handles.res.store(Res("s2:${it.num.toInt()},${it.txt}")) }
+        handles.s3.fetch()?.let { handles.res.store(Res("s3:${it.num.toInt()},${it.txt},${it.flg}")) }
 
-        for (e in c1) {
-            res.store(Res("c1:${e.num.toInt()}"))
+        for (e in handles.c1) {
+            handles.res.store(Res("c1:${e.num.toInt()}"))
         }
-        for (e in c2) {
-            res.store(Res("c2:${e.num.toInt()},${e.txt}"))
+        for (e in handles.c2) {
+            handles.res.store(Res("c2:${e.num.toInt()},${e.txt}"))
         }
-        for (e in c3) {
-            res.store(Res("c3:${e.num.toInt()},${e.txt},${e.flg}"))
+        for (e in handles.c3) {
+            handles.res.store(Res("c3:${e.num.toInt()},${e.txt},${e.flg}"))
         }
     }
 }

--- a/javatests/arcs/sdk/wasm/EventsTest.kt
+++ b/javatests/arcs/sdk/wasm/EventsTest.kt
@@ -13,6 +13,8 @@ package arcs.sdk.wasm
 
 class EventsTest : AbstractEventsTest() {
     override fun fireEvent(slotName: String, eventName: String, eventData: Map<String, String>) {
-        output.set(EventsTest_Output(txt = "event:$slotName:$eventName:${eventData["info"]}"))
+        handles.output.set(
+                EventsTest_Output(txt = "event:$slotName:$eventName:${eventData["info"]}")
+        )
     }
 }

--- a/javatests/arcs/sdk/wasm/HandleSyncUpdateTest.kt
+++ b/javatests/arcs/sdk/wasm/HandleSyncUpdateTest.kt
@@ -15,10 +15,10 @@ import arcs.sdk.Handle
 
 class HandleSyncUpdateTest : AbstractHandleSyncUpdateTest() {
     override fun onHandleSync(handle: Handle, allSynced: Boolean) {
-        res.store(HandleSyncUpdateTest_Res(txt = "sync:${handle.name}:$allSynced", num = 0.0))
+        handles.res.store(HandleSyncUpdateTest_Res(txt = "sync:${handle.name}:$allSynced", num = 0.0))
         if (allSynced) {
             var ptr = HandleSyncUpdateTest_Res()
-            res.store(ptr.copy(txt = if (sng.fetch() != null) "sng:populated" else "sng:null"))
+            handles.res.store(ptr.copy(txt = if (handles.sng.fetch() != null) "sng:populated" else "sng:null"))
         }
     }
 
@@ -27,13 +27,13 @@ class HandleSyncUpdateTest : AbstractHandleSyncUpdateTest() {
         var txt = "update:${handle.name}"
         var num = out.num
         if (handle.name == "sng") {
-            num = sng.fetch()?.num ?: -1.0
+            num = handles.sng.fetch()?.num ?: -1.0
         } else if (handle.name == "col") {
-            num = if (col.size > 0) col.iterator().next().num else -1.0
+            num = if (handles.col.size > 0) handles.col.iterator().next().num else -1.0
         } else {
             txt = "unexpected handle name: ${handle.name}"
         }
-        res.store(out.copy(
+        handles.res.store(out.copy(
             txt = txt,
             num = num
         ))

--- a/javatests/arcs/sdk/wasm/RenderTest.kt
+++ b/javatests/arcs/sdk/wasm/RenderTest.kt
@@ -27,7 +27,7 @@ class RenderTest : AbstractRenderTest() {
         if (shouldPopulate) mapOf("foo" to "bar") else null
 
     override fun onHandleUpdate(handle: Handle) {
-        flags.fetch()?.let {
+        handles.flags.fetch()?.let {
             shouldTemplate = it.template
             shouldPopulate = it.model
         }

--- a/javatests/arcs/sdk/wasm/ServicesTest.kt
+++ b/javatests/arcs/sdk/wasm/ServicesTest.kt
@@ -14,7 +14,7 @@ package arcs.sdk.wasm
 class ServicesTest : AbstractServicesTest() {
     override fun init() {
         val url: String = resolveUrl("\$resolve-me")
-        output.store(ServicesTest_Output("resolveUrl", tag = "", payload = url))
+        handles.output.store(ServicesTest_Output("resolveUrl", tag = "", payload = url))
 
         serviceRequest("random.next", mapOf(), "first")
         serviceRequest("random.next", mapOf(), "second")
@@ -28,6 +28,6 @@ class ServicesTest : AbstractServicesTest() {
             .forEach { str -> builder.append(str) }
         val payload = builder.toString()
 
-        output.store(ServicesTest_Output(call, tag, payload))
+        handles.output.store(ServicesTest_Output(call, tag, payload))
     }
 }

--- a/javatests/arcs/sdk/wasm/SingletonApiTest.kt
+++ b/javatests/arcs/sdk/wasm/SingletonApiTest.kt
@@ -14,7 +14,7 @@ package arcs.sdk.wasm
 class SingletonApiTest : AbstractSingletonApiTest() {
     var x = 0;
     init{
-        inHandle.onUpdate{
+        handles.inHandle.onUpdate{
             x = 1;
         }
     }
@@ -22,20 +22,20 @@ class SingletonApiTest : AbstractSingletonApiTest() {
     override fun fireEvent(slotName: String, eventName: String, eventData: Map<String, String>) {
         when (eventName) {
             "case1" -> {
-                if (ioHandle.fetch() == null) {
-                    errors.store(
+                if (handles.ioHandle.fetch() == null) {
+                    handles.errors.store(
                         SingletonApiTest_Errors(msg = "case1: populated handle should not be null")
                     )
                 }
                 if(x == 1) {
-                    errors.store(
+                    handles.errors.store(
                       SingletonApiTest_Errors(msg = "case1: handle.onUpdate should not have been called yet.")
                     )
                 }
-                outHandle.clear()
-                ioHandle.clear()
-                if (ioHandle.fetch() != null) {
-                    errors.store(
+                handles.outHandle.clear()
+                handles.ioHandle.clear()
+                if (handles.ioHandle.fetch() != null) {
+                    handles.errors.store(
                         SingletonApiTest_Errors(msg = "case1: cleared handle should be null")
                     )
                 }
@@ -43,35 +43,35 @@ class SingletonApiTest : AbstractSingletonApiTest() {
             }
             "case2" -> {
                 if(x == 0) {
-                    errors.store(
+                    handles.errors.store(
                       SingletonApiTest_Errors(msg = "case1: handle.onUpdate should have been called.")
                     )
                 }
-                val input = inHandle.fetch()
+                val input = handles.inHandle.fetch()
                 val d = SingletonApiTest_OutHandle(
                     num = input?.num ?: 0.0,
                     txt = input?.txt ?: ""
                 )
-                outHandle.set(d.copy(num = d.num.times(2)))
+                handles.outHandle.set(d.copy(num = d.num.times(2)))
             }
             "case3" -> {
-                val input = inHandle.fetch()
+                val input = handles.inHandle.fetch()
                 val d = SingletonApiTest_IoHandle(
                     num = input?.num ?: 0.0,
                     txt = input?.txt ?: ""
                 )
-                ioHandle.set(d.copy(d.num.times(3)))
+                handles.ioHandle.set(d.copy(d.num.times(3)))
             }
             "case4" -> {
-                if (ioHandle.fetch() != null) {
-                    errors.store(
+                if (handles.ioHandle.fetch() != null) {
+                    handles.errors.store(
                         SingletonApiTest_Errors(msg = "case4: cleared handle should be null")
                     )
                 }
-                outHandle.set(SingletonApiTest_OutHandle(txt = "out", num = 0.0))
-                ioHandle.set(SingletonApiTest_IoHandle(txt = "io", num = 0.0))
-                if (ioHandle.fetch() == null) {
-                    errors.store(
+                handles.outHandle.set(SingletonApiTest_OutHandle(txt = "out", num = 0.0))
+                handles.ioHandle.set(SingletonApiTest_IoHandle(txt = "io", num = 0.0))
+                if (handles.ioHandle.fetch() == null) {
+                    handles.errors.store(
                         SingletonApiTest_Errors(msg = "case4: populated handle should not be null")
                     )
                 }

--- a/javatests/arcs/sdk/wasm/UnicodeTest.kt
+++ b/javatests/arcs/sdk/wasm/UnicodeTest.kt
@@ -21,6 +21,6 @@ class UnicodeTest : AbstractUnicodeTest() {
         } else {
             ((handle as WasmCollectionImpl<*>).iterator().next() as UnicodeTest_Col).pass
         }
-        res.store(out.copy(pass = pass))
+        handles.res.store(out.copy(pass = pass))
     }
 }

--- a/particles/Blackjack/Dealer.kt
+++ b/particles/Blackjack/Dealer.kt
@@ -8,7 +8,7 @@ class Dealer : AbstractDealer() {
 
     init {
         eventHandler("onHit") {
-            cardRequest.set(Dealer_CardRequest(player = name))
+            handles.cardRequest.set(Dealer_CardRequest(player = name))
             log("Hit.")
         }
         eventHandler("onStand") {
@@ -23,15 +23,15 @@ class Dealer : AbstractDealer() {
         """.trimIndent()
 
     override fun populateModel(slotName: String, model: Map<String, Any>): Map<String, Any> {
-        val desc = hand.joinToString(separator = ":") { Card.cardDesc(it.value.toInt()) }
+        val desc = handles.hand.joinToString(separator = ":") { Card.cardDesc(it.value.toInt()) }
         return model + mapOf("hand" to desc)
     }
 
     override fun onHandleUpdate(handle: Handle) {
         // We only respond to changes to nextCard.
         if (handle.name != "nextCard") return
-        val nc = nextCard.fetch()?.takeIf { it.player == name } ?: return
-        hand.store(Dealer_Hand(value = nc.card))
+        val nc = handles.nextCard.fetch()?.takeIf { it.player == name } ?: return
+        handles.hand.store(Dealer_Hand(value = nc.card))
         renderOutput()
     }
 }

--- a/particles/Blackjack/DealingShoe.kt
+++ b/particles/Blackjack/DealingShoe.kt
@@ -13,13 +13,13 @@ class DealingShoe : AbstractDealingShoe() {
     override fun getTemplate(slotName: String) = "Card is <span>{{nextCard}}</span>"
 
     override fun populateModel(slotName: String, model: Map<String, Any>) =
-        model + mapOf("nextCard" to nextCard.toString())
+        model + mapOf("nextCard" to handles.nextCard.toString())
 
     override fun onHandleUpdate(handle: Handle) {
         if (handle.name != "cardRequest") return
-        val request = cardRequest.fetch() ?: return
+        val request = handles.cardRequest.fetch() ?: return
         val card = pickACard() ?: return
-        nextCard.set(
+        handles.nextCard.set(
             DealingShoe_NextCard(
                 player = request.player,
                 card = card.value.toDouble()
@@ -38,7 +38,7 @@ class DealingShoe : AbstractDealingShoe() {
     }
 
     fun pickACard(): Card? {
-        val localDecks = decks.fetch() ?: initializedDecks()
+        val localDecks = handles.decks.fetch() ?: initializedDecks()
         var choice = Random.nextInt(totalCards)
         val cards = localDecks.cards.takeIf { it != emptyDeck } ?: return null
         // This could be done more efficiently, but should suffice for now.
@@ -47,7 +47,7 @@ class DealingShoe : AbstractDealingShoe() {
             choice = (choice + 1) % totalCards
             ++readCards
         }
-        decks.set(localDecks.copy(
+        handles.decks.set(localDecks.copy(
             cards = cards.replaceRange(choice, choice + 1, cardAbsent)
         ))
         return Card(choice % 52)

--- a/particles/Blackjack/Player.kt
+++ b/particles/Blackjack/Player.kt
@@ -8,7 +8,7 @@ class Player : AbstractPlayer() {
 
     init {
         eventHandler("onHit") {
-            cardRequest.set(Player_CardRequest(player = name))
+            handles.cardRequest.set(Player_CardRequest(player = name))
             log("Hit.")
         }
         eventHandler("onStand") {
@@ -23,7 +23,7 @@ class Player : AbstractPlayer() {
          """.trimIndent()
 
     override fun populateModel(slotName: String, model: Map<String, Any>): Map<String, Any> {
-        val desc = hand.joinToString(separator = ":") { card ->
+        val desc = handles.hand.joinToString(separator = ":") { card ->
             Card.cardDesc(card.value.toInt())
         }
         return model + mapOf("hand" to desc)
@@ -32,8 +32,8 @@ class Player : AbstractPlayer() {
     override fun onHandleUpdate(handle: Handle) {
         // We only respond to changes to nextCard.
         if (handle.name != "nextCard") return
-        val nc = nextCard.fetch()?.takeIf { it.player == name } ?: return
-        hand.store(Player_Hand(value = nc.card))
+        val nc = handles.nextCard.fetch()?.takeIf { it.player == name } ?: return
+        handles.hand.store(Player_Hand(value = nc.card))
         this.renderOutput()
     }
 }

--- a/particles/Native/Wasm/source/TestParticle.kt
+++ b/particles/Native/Wasm/source/TestParticle.kt
@@ -32,13 +32,13 @@ class TestParticle : AbstractTestParticle() {
 
     override fun populateModel(slotName: String, model: Map<String, Any>): Map<String, Any> {
         val dataCol = if (updated == 1) "color: blue;" else ""
-        val dataStr = "${data.fetch()}\n"
+        val dataStr = "${handles.data.fetch()}\n"
 
         val infoCol = if (updated == 2) "color: blue;" else ""
-        var infoStr = "Size: ${info.size}\n"
-        if (!info.isEmpty()) {
+        var infoStr = "Size: ${handles.info.size}\n"
+        if (!handles.info.isEmpty()) {
             var i = 0
-            info.forEach { info ->
+            handles.info.forEach { info ->
                 infoStr += "${(++i)}. $info | \n"
             }
         } else {
@@ -103,21 +103,21 @@ class TestParticle : AbstractTestParticle() {
 
     init {
         eventHandler("add") {
-            val newData = data.fetch() ?: TestParticle_Data(
+            val newData = handles.data.fetch() ?: TestParticle_Data(
                 num = 0.0,
                 txt = "",
                 lnk = "",
                 flg = false
             )
             
-            this.data.set(newData.copy(
+            handles.data.set(newData.copy(
                 num = newData.num.let { it + 2 },
                 txt = "${newData.txt}!!!!!!"
             ))
         }
 
         eventHandler("dataclear") {
-            data.clear()
+            handles.data.clear()
         }
 
         eventHandler("store") {
@@ -126,19 +126,19 @@ class TestParticle : AbstractTestParticle() {
                 val_ = 0.0
             )
             info.internalId = "wasm" + (++storeCount)
-            this.info.store(info.copy(
-                val_ = (this.info.size + storeCount).toDouble()
+            handles.info.store(info.copy(
+                val_ = (handles.info.size + storeCount).toDouble()
             ))
         }
 
         eventHandler("remove") {
-            val iterator = info.iterator()
+            val iterator = handles.info.iterator()
             if (iterator.hasNext()) {
-                info.remove(iterator.next())
+                handles.info.remove(iterator.next())
             }
         }
         eventHandler("infoclear") {
-            info.clear()
+            handles.info.clear()
         }
         eventHandler("throw") {
             throw Exception("this message doesn't get passed (yet?)")

--- a/particles/Tutorial/Kotlin/4_Handles/DisplayGreeting.kt
+++ b/particles/Tutorial/Kotlin/4_Handles/DisplayGreeting.kt
@@ -25,7 +25,7 @@ class DisplayGreeting : AbstractDisplayGreeting() {
 
     override fun populateModel(slotName: String, model: Map<String, Any>): Map<String, Any> {
         return model + mapOf(
-            "name" to (person.fetch()?.name ?: "Human")
+            "name" to (handles.person.fetch()?.name ?: "Human")
         )
     }
 }

--- a/particles/Tutorial/Kotlin/4_Handles/GetPerson.kt
+++ b/particles/Tutorial/Kotlin/4_Handles/GetPerson.kt
@@ -21,7 +21,7 @@ class GetPerson : AbstractGetPerson() {
 
     init {
         eventHandler("onNameInputChange") { eventData ->
-            person.set(GetPerson_Person(name = eventData["value"] ?: "Human"))
+            handles.person.set(GetPerson_Person(name = eventData["value"] ?: "Human"))
         }
     }
 }

--- a/particles/Tutorial/Kotlin/5_Collections/Collections.kt
+++ b/particles/Tutorial/Kotlin/5_Collections/Collections.kt
@@ -17,7 +17,7 @@ package arcs.tutorials
 class Collections : AbstractCollections() {
     override fun populateModel(slotName: String, model: Map<String, Any>): Map<String, Any> {
         val peopleList = mutableListOf<Map<String, Comparable<*>?>>()
-        inputData.forEach { people ->
+        handles.inputData.forEach { people ->
             peopleList.add(mapOf("name" to people.name, "age" to people.age))
         }
 

--- a/particles/Tutorial/Kotlin/6_JsonStore/JsonStore.kt
+++ b/particles/Tutorial/Kotlin/6_JsonStore/JsonStore.kt
@@ -16,7 +16,7 @@ package arcs.tutorials
  */
 class JsonStore : AbstractJsonStore() {
     override fun populateModel(slotName: String, model: Map<String, Any>): Map<String, Any> {
-        val person = inputData.fetch() ?: JsonStore_InputData()
+        val person = handles.inputData.fetch() ?: JsonStore_InputData()
 
         return model + mapOf(
             "name" to person.name,

--- a/particles/Tutorial/Kotlin/Demo/README.md
+++ b/particles/Tutorial/Kotlin/Demo/README.md
@@ -182,8 +182,8 @@ class TTTGame : AbstractTTTGame() {
     private val defaultGame = TTTGame_GameState(board = ",,,,,,,,")
 
     override fun onHandleSync(handle: Handle, allSynced: Boolean) {
-        if (gameState.fetch() == null) {
-            gameState.set(defaultGame)
+        if (handles.gameState.fetch() == null) {
+            handles.gameState.set(defaultGame)
         }
     }
 
@@ -217,7 +217,7 @@ class TTTBoard : AbstractTTTBoard() {
 
     init {
         eventHandler("onClick") { eventData ->
-            events.store(TTTBoard_Events(
+            handles.events.store(TTTBoard_Events(
                     type = "move",
                     move = eventData["value"]?.toDouble() ?: -1.0,
                     time = clicks
@@ -226,7 +226,7 @@ class TTTBoard : AbstractTTTBoard() {
         }
 
         eventHandler("reset") {
-            events.store(TTTBoard_Events(type = "reset", time = clicks, move = -1.0))
+            handles.events.store(TTTBoard_Events(type = "reset", time = clicks, move = -1.0))
             clicks++
         }
     }
@@ -234,7 +234,7 @@ class TTTBoard : AbstractTTTBoard() {
     override fun onHandleUpdate(handle: Handle) = renderOutput()
 
     override fun populateModel(slotName: String, model: Map<String, Any>): Map<String, Any> {
-        val gs = gameState.fetch() ?: defaultGameState
+        val gs = handles.gameState.fetch() ?: defaultGameState
         val boardList = gs.board.split(",")
         val boardModel = mutableListOf<Map<String, String?>>()
         boardList.forEachIndexed { index, cell ->

--- a/particles/Tutorial/Kotlin/Demo/src/pt1/TTTBoard.kt
+++ b/particles/Tutorial/Kotlin/Demo/src/pt1/TTTBoard.kt
@@ -18,7 +18,7 @@ class TTTBoard : AbstractTTTBoard() {
 
     init {
         eventHandler("onClick") { eventData ->
-            events.store(TTTBoard_Events(
+            handles.events.store(TTTBoard_Events(
                     type = "move",
                     move = eventData["value"]?.toDouble() ?: -1.0,
                     time = clicks
@@ -27,7 +27,7 @@ class TTTBoard : AbstractTTTBoard() {
         }
 
         eventHandler("reset") {
-            events.store(TTTBoard_Events(type = "reset", time = clicks, move = -1.0))
+            handles.events.store(TTTBoard_Events(type = "reset", time = clicks, move = -1.0))
             clicks++
         }
     }
@@ -35,7 +35,7 @@ class TTTBoard : AbstractTTTBoard() {
     override fun onHandleUpdate(handle: Handle) = renderOutput()
 
     override fun populateModel(slotName: String, model: Map<String, Any>): Map<String, Any> {
-        val gs = gameState.fetch() ?: TTTBoard_GameState()
+        val gs = handles.gameState.fetch() ?: TTTBoard_GameState()
         val boardList = gs.board.split(",")
         val boardModel = mutableListOf<Map<String, String?>>()
         boardList.forEachIndexed { index, cell ->

--- a/particles/Tutorial/Kotlin/Demo/src/pt1/TTTGame.kt
+++ b/particles/Tutorial/Kotlin/Demo/src/pt1/TTTGame.kt
@@ -17,8 +17,8 @@ class TTTGame : AbstractTTTGame() {
     private val defaultGame = TTTGame_GameState(board = ",,,,,,,,")
 
     override fun onHandleSync(handle: Handle, allSynced: Boolean) {
-        if (gameState.fetch() == null) {
-            gameState.set(defaultGame)
+        if (handles.gameState.fetch() == null) {
+            handles.gameState.set(defaultGame)
         }
     }
 

--- a/particles/Tutorial/Kotlin/Demo/src/pt2/TTTBoard.kt
+++ b/particles/Tutorial/Kotlin/Demo/src/pt2/TTTBoard.kt
@@ -18,7 +18,7 @@ class TTTBoard : AbstractTTTBoard() {
 
     init {
         eventHandler("onClick") { eventData ->
-            events.store(TTTBoard_Events(
+            handles.events.store(TTTBoard_Events(
                 type = "move",
                 move = eventData["value"]?.toDouble() ?: -1.0,
                 time = clicks
@@ -27,7 +27,7 @@ class TTTBoard : AbstractTTTBoard() {
         }
 
         eventHandler("reset") {
-            events.store(TTTBoard_Events(type = "reset", time = clicks, move = -1.0))
+            handles.events.store(TTTBoard_Events(type = "reset", time = clicks, move = -1.0))
             clicks++
         }
     }
@@ -35,7 +35,7 @@ class TTTBoard : AbstractTTTBoard() {
     override fun onHandleUpdate(handle: Handle) = renderOutput()
 
     override fun populateModel(slotName: String, model: Map<String, Any>): Map<String, Any> {
-        val gs = gameState.fetch() ?: TTTBoard_GameState()
+        val gs = handles.gameState.fetch() ?: TTTBoard_GameState()
         val boardList = gs.board.split(",")
         val boardModel = mutableListOf<Map<String, String?>>()
         boardList.forEachIndexed { index, cell ->

--- a/particles/Tutorial/Kotlin/Demo/src/pt2/TTTGame.kt
+++ b/particles/Tutorial/Kotlin/Demo/src/pt2/TTTGame.kt
@@ -17,15 +17,15 @@ class TTTGame : AbstractTTTGame() {
     private val defaultGame = TTTGame_GameState(board = ",,,,,,,,")
 
     override fun onHandleSync(handle: Handle, allSynced: Boolean) {
-        if (gameState.fetch() == null) {
-            gameState.set(defaultGame)
+        if (handles.gameState.fetch() == null) {
+            handles.gameState.set(defaultGame)
         }
     }
 
     override fun onHandleUpdate(handle: Handle) {
-        val gs = gameState.fetch() ?: defaultGame
-        val p1 = playerOne.fetch() ?: TTTGame_PlayerOne()
-        val mv = playerOneMove.fetch() ?: TTTGame_PlayerOneMove()
+        val gs = handles.gameState.fetch() ?: defaultGame
+        val p1 = handles.playerOne.fetch() ?: TTTGame_PlayerOne()
+        val mv = handles.playerOneMove.fetch() ?: TTTGame_PlayerOneMove()
         val boardList = gs.board.split(",").toMutableList()
         // Check the handle updated matches the current player
         if (handle.name == "playerOneMove") {
@@ -50,6 +50,6 @@ class TTTGame : AbstractTTTGame() {
         gs: TTTGame_GameState
     ) {
         boardList[mv] = avatar
-        gameState.set(gs.copy(board = boardList.joinToString(",")))
+        handles.gameState.set(gs.copy(board = boardList.joinToString(",")))
     }
 }

--- a/particles/Tutorial/Kotlin/Demo/src/pt2/TTTHumanPlayer.kt
+++ b/particles/Tutorial/Kotlin/Demo/src/pt2/TTTHumanPlayer.kt
@@ -15,13 +15,13 @@ import arcs.sdk.Handle
 
 class TTTHumanPlayer : AbstractTTTHumanPlayer() {
     override fun onHandleUpdate(handle: Handle) {
-        if (events.size <= 0) return
+        if (handles.events.size <= 0) return
 
         // Get the element with the largest time as this will be the most recent.
-        val event = events.sortedBy { it.time }.last()
+        val event = handles.events.sortedBy { it.time }.last()
         // Set the move
         if (event.type == "move" && event.time > -1.0) {
-            myMove.set(TTTHumanPlayer_MyMove(event.move))
+            handles.myMove.set(TTTHumanPlayer_MyMove(event.move))
         }
     }
 }

--- a/particles/Tutorial/Kotlin/Demo/src/pt3/TTTBoard.kt
+++ b/particles/Tutorial/Kotlin/Demo/src/pt3/TTTBoard.kt
@@ -18,7 +18,7 @@ class TTTBoard : AbstractTTTBoard() {
 
     init {
         eventHandler("onClick") { eventData ->
-            events.store(TTTBoard_Events(
+            handles.events.store(TTTBoard_Events(
                 type = "move",
                 move = eventData["value"]?.toDouble() ?: -1.0,
                 time = clicks
@@ -27,7 +27,7 @@ class TTTBoard : AbstractTTTBoard() {
         }
 
         eventHandler("reset") {
-            events.store(TTTBoard_Events(type = "reset", time = clicks, move = -1.0))
+            handles.events.store(TTTBoard_Events(type = "reset", time = clicks, move = -1.0))
             clicks++
         }
     }
@@ -35,7 +35,7 @@ class TTTBoard : AbstractTTTBoard() {
     override fun onHandleUpdate(handle: Handle) = renderOutput()
 
     override fun populateModel(slotName: String, model: Map<String, Any>): Map<String, Any> {
-        val gs = gameState.fetch() ?: TTTBoard_GameState()
+        val gs = handles.gameState.fetch() ?: TTTBoard_GameState()
         val boardList = gs.board.split(",")
         val boardModel = mutableListOf<Map<String, String?>>()
         boardList.forEachIndexed { index, cell ->

--- a/particles/Tutorial/Kotlin/Demo/src/pt3/TTTGame.kt
+++ b/particles/Tutorial/Kotlin/Demo/src/pt3/TTTGame.kt
@@ -20,25 +20,25 @@ class TTTGame : AbstractTTTGame() {
     )
 
     override fun onHandleSync(handle: Handle, allSynced: Boolean) {
-        if (gameState.fetch()?.board == null) {
-            gameState.set(defaultGame)
+        if (handles.gameState.fetch()?.board == null) {
+            handles.gameState.set(defaultGame)
         }
-        if (handle.name == "playerOne" && playerOne.fetch()?.id != 0.0) {
-            val p1 = playerOne.fetch() ?: TTTGame_PlayerOne()
-            playerOne.set(p1.copy(id = 0.0))
+        if (handle.name == "handles.playerOne" && handles.playerOne.fetch()?.id != 0.0) {
+            val p1 = handles.playerOne.fetch() ?: TTTGame_PlayerOne()
+            handles.playerOne.set(p1.copy(id = 0.0))
         }
-        if (handle.name == "playerTwo" && playerTwo.fetch()?.id != 1.0) {
-            val p2 = playerTwo.fetch() ?: TTTGame_PlayerTwo()
-            playerTwo.set(p2.copy(id = 1.0))
+        if (handle.name == "playerTwo" && handles.playerTwo.fetch()?.id != 1.0) {
+            val p2 = handles.playerTwo.fetch() ?: TTTGame_PlayerTwo()
+            handles.playerTwo.set(p2.copy(id = 1.0))
         }
     }
 
     override fun onHandleUpdate(handle: Handle) {
-        val gs = gameState.fetch() ?: defaultGame
-        val p1 = playerOne.fetch() ?: TTTGame_PlayerOne()
-        val p2 = playerTwo.fetch() ?: TTTGame_PlayerTwo()
-        val mv1 = playerOneMove.fetch() ?: TTTGame_PlayerOneMove()
-        val mv2 = playerTwoMove.fetch() ?: TTTGame_PlayerTwoMove()
+        val gs = handles.gameState.fetch() ?: defaultGame
+        val p1 = handles.playerOne.fetch() ?: TTTGame_PlayerOne()
+        val p2 = handles.playerTwo.fetch() ?: TTTGame_PlayerTwo()
+        val mv1 = handles.playerOneMove.fetch() ?: TTTGame_PlayerOneMove()
+        val mv2 = handles.playerTwoMove.fetch() ?: TTTGame_PlayerTwoMove()
 
         // Apply the moves
         val boardList = gs.board.split(",").toMutableList()
@@ -74,7 +74,7 @@ class TTTGame : AbstractTTTGame() {
         if (!mv.isValidMove(boardList)) return
         boardList[mv] = avatar
 
-        gameState.set(gs.copy(
+        handles.gameState.set(gs.copy(
             board = boardList.joinToString(","),
             currentPlayer = (gs.currentPlayer + 1) % 2
         ))

--- a/particles/Tutorial/Kotlin/Demo/src/pt3/TTTHumanPlayer.kt
+++ b/particles/Tutorial/Kotlin/Demo/src/pt3/TTTHumanPlayer.kt
@@ -15,13 +15,14 @@ import arcs.sdk.Handle
 
 class TTTHumanPlayer : AbstractTTTHumanPlayer() {
     override fun onHandleUpdate(handle: Handle) {
-        if (events.size <= 0 || gameState.fetch()?.currentPlayer != player.fetch()?.id) return
+        if (handles.events.size <= 0
+          || handles.gameState.fetch()?.currentPlayer != handles.player.fetch()?.id) return
 
         // Get the element with the largest time as this will be the most recent.
-        val event = events.sortedBy { it.time }.last()
+        val event = handles.events.sortedBy { it.time }.last()
         // Set the move
         if (event.type == "move") {
-            myMove.set(TTTHumanPlayer_MyMove(event.move))
+            handles.myMove.set(TTTHumanPlayer_MyMove(event.move))
         }
     }
 }

--- a/particles/Tutorial/Kotlin/Demo/src/pt3/TTTRandomComputer.kt
+++ b/particles/Tutorial/Kotlin/Demo/src/pt3/TTTRandomComputer.kt
@@ -14,12 +14,12 @@ package arcs.tutorials.tictactoe
 import arcs.sdk.Handle
 
 class TTTRandomComputer : AbstractTTTRandomComputer() {
-    override fun onHandleSync(handle: Handle, allSynced: Boolean) = onHandleUpdate(gameState)
+    override fun onHandleSync(handle: Handle, allSynced: Boolean) = onHandleUpdate(handles.gameState)
 
     override fun onHandleUpdate(handle: Handle) {
-        if (gameState.fetch()?.currentPlayer != player.fetch()?.id) return
+        if (handles.gameState.fetch()?.currentPlayer != handles.player.fetch()?.id) return
 
-        val gs = gameState.fetch() ?: TTTRandomComputer_GameState()
+        val gs = handles.gameState.fetch() ?: TTTRandomComputer_GameState()
 
         val boardArr = gs.board.split(",")
         val emptyCells = mutableListOf<Double>()
@@ -32,7 +32,7 @@ class TTTRandomComputer : AbstractTTTRandomComputer() {
         // Choose a random cell as the move
         if (emptyCells.isNotEmpty()) {
             val mv = emptyCells.shuffled().first()
-            myMove.set(TTTRandomComputer_MyMove(move = mv))
+            handles.myMove.set(TTTRandomComputer_MyMove(move = mv))
         }
     }
 }

--- a/particles/Tutorial/Kotlin/Demo/src/pt4/TTTBoard.kt
+++ b/particles/Tutorial/Kotlin/Demo/src/pt4/TTTBoard.kt
@@ -18,7 +18,7 @@ class TTTBoard : AbstractTTTBoard() {
 
     init {
         eventHandler("onClick") { eventData ->
-            events.store(TTTBoard_Events(
+            handles.events.store(TTTBoard_Events(
                 type = "move",
                 move = eventData["value"]?.toDouble() ?: -1.0,
                 time = clicks
@@ -27,7 +27,7 @@ class TTTBoard : AbstractTTTBoard() {
         }
 
         eventHandler("reset") {
-            events.store(TTTBoard_Events(type = "reset", time = clicks, move = -1.0))
+            handles.events.store(TTTBoard_Events(type = "reset", time = clicks, move = -1.0))
             clicks++
         }
     }
@@ -35,7 +35,7 @@ class TTTBoard : AbstractTTTBoard() {
     override fun onHandleUpdate(handle: Handle) = renderOutput()
 
     override fun populateModel(slotName: String, model: Map<String, Any>): Map<String, Any> {
-        val gs = gameState.fetch() ?: TTTBoard_GameState()
+        val gs = handles.gameState.fetch() ?: TTTBoard_GameState()
         val boardList = gs.board.split(",")
         val boardModel = mutableListOf<Map<String, String?>>()
         boardList.forEachIndexed { index, cell ->

--- a/particles/Tutorial/Kotlin/Demo/src/pt4/TTTGame.kt
+++ b/particles/Tutorial/Kotlin/Demo/src/pt4/TTTGame.kt
@@ -33,23 +33,23 @@ class TTTGame : AbstractTTTGame() {
     )
 
     override fun onHandleSync(handle: Handle, allSynced: Boolean) {
-        if (gameState.fetch()?.board == null) {
-            gameState.set(defaultGame)
+        if (handles.gameState.fetch()?.board == null) {
+            handles.gameState.set(defaultGame)
         }
-        if (handle.name == "playerOne" && playerOne.fetch()?.id != 0.0) {
-            val p1 = playerOne.fetch() ?: TTTGame_PlayerOne()
-            playerOne.set(p1.copy(id = 0.0))
+        if (handle.name == "playerOne" && handles.playerOne.fetch()?.id != 0.0) {
+            val p1 = handles.playerOne.fetch() ?: TTTGame_PlayerOne()
+            handles.playerOne.set(p1.copy(id = 0.0))
         }
-        if (handle.name == "playerTwo" && playerTwo.fetch()?.id != 1.0) {
-            val p2 = playerTwo.fetch() ?: TTTGame_PlayerTwo()
-            playerTwo.set(p2.copy(id = 1.0))
+        if (handle.name == "playerTwo" && handles.playerTwo.fetch()?.id != 1.0) {
+            val p2 = handles.playerTwo.fetch() ?: TTTGame_PlayerTwo()
+            handles.playerTwo.set(p2.copy(id = 1.0))
         }
     }
 
     override fun populateModel(slotName: String, model: Map<String, Any>): Map<String, Any> {
-        val gs = gameState.fetch() ?: TTTGame_GameState()
-        val p1 = playerOne.fetch() ?: TTTGame_PlayerOne()
-        val p2 = playerTwo.fetch() ?: TTTGame_PlayerTwo()
+        val gs = handles.gameState.fetch() ?: TTTGame_GameState()
+        val p1 = handles.playerOne.fetch() ?: TTTGame_PlayerOne()
+        val p2 = handles.playerTwo.fetch() ?: TTTGame_PlayerTwo()
 
         val cpName = if (gs.currentPlayer == p1.id) p1.name else p2.name
         val cpAvatar = if (gs.currentPlayer == p1.id) p1.avatar else p2.avatar
@@ -68,11 +68,11 @@ class TTTGame : AbstractTTTGame() {
     }
 
     override fun onHandleUpdate(handle: Handle) {
-        val gs = gameState.fetch() ?: defaultGame
-        val p1 = playerOne.fetch() ?: TTTGame_PlayerOne()
-        val p2 = playerTwo.fetch() ?: TTTGame_PlayerTwo()
-        val mv1 = playerOneMove.fetch() ?: TTTGame_PlayerOneMove()
-        val mv2 = playerTwoMove.fetch() ?: TTTGame_PlayerTwoMove()
+        val gs = handles.gameState.fetch() ?: defaultGame
+        val p1 = handles.playerOne.fetch() ?: TTTGame_PlayerOne()
+        val p2 = handles.playerTwo.fetch() ?: TTTGame_PlayerTwo()
+        val mv1 = handles.playerOneMove.fetch() ?: TTTGame_PlayerOneMove()
+        val mv2 = handles.playerTwoMove.fetch() ?: TTTGame_PlayerTwoMove()
         // Apply the moves
         if (gs.gameOver != true) {
             val boardList = gs.board.split(",").toMutableList()
@@ -94,15 +94,15 @@ class TTTGame : AbstractTTTGame() {
             }
         }
         if (hasReset()) {
-            gameState.set(TTTGame_GameState(
+            handles.gameState.set(TTTGame_GameState(
                 board = ",,,,,,,,",
                 currentPlayer = (0..1).random().toDouble(),
                 gameOver = false,
                 winnerAvatar = ""
             ))
-            playerOneMove.set(mv1.copy(move = -1.0))
-            playerTwoMove.set(mv2.copy(move = -1.0))
-            events.clear()
+            handles.playerOneMove.set(mv1.copy(move = -1.0))
+            handles.playerTwoMove.set(mv2.copy(move = -1.0))
+            handles.events.clear()
         }
         renderOutput()
     }
@@ -133,7 +133,7 @@ class TTTGame : AbstractTTTGame() {
             }
         }
 
-        gameState.set(gs.copy(
+        handles.gameState.set(gs.copy(
             board = boardList.joinToString(","),
             currentPlayer = (gs.currentPlayer + 1) % 2,
             gameOver = gameOver,
@@ -141,7 +141,7 @@ class TTTGame : AbstractTTTGame() {
         ))
     }
 
-    private fun hasReset() = events.any { it.type == "reset" }
+    private fun hasReset() = handles.events.any { it.type == "reset" }
 
     private fun Int.isValidMove(boardList: List<String>) = this in 0..9 && boardList[this] == ""
 }

--- a/particles/Tutorial/Kotlin/Demo/src/pt4/TTTHumanPlayer.kt
+++ b/particles/Tutorial/Kotlin/Demo/src/pt4/TTTHumanPlayer.kt
@@ -15,13 +15,14 @@ import arcs.sdk.Handle
 
 class TTTHumanPlayer : AbstractTTTHumanPlayer() {
     override fun onHandleUpdate(handle: Handle) {
-        if (events.size <= 0 || gameState.fetch()?.currentPlayer != player.fetch()?.id) return
+        if (handles.events.size <= 0
+          || handles.gameState.fetch()?.currentPlayer != handles.player.fetch()?.id) return
 
         // Get the element with the largest time as this will be the most recent.
-        val event = events.sortedBy { it.time }.last()
+        val event = handles.events.sortedBy { it.time }.last()
         // Set the move
         if (event.type == "move") {
-            myMove.set(TTTHumanPlayer_MyMove(event.move))
+            handles.myMove.set(TTTHumanPlayer_MyMove(event.move))
         }
     }
 }

--- a/particles/Tutorial/Kotlin/Demo/src/pt4/TTTRandomComputer.kt
+++ b/particles/Tutorial/Kotlin/Demo/src/pt4/TTTRandomComputer.kt
@@ -14,12 +14,12 @@ package arcs.tutorials.tictactoe
 import arcs.sdk.Handle
 
 class TTTRandomComputer : AbstractTTTRandomComputer() {
-    override fun onHandleSync(handle: Handle, allSynced: Boolean) = onHandleUpdate(gameState)
+    override fun onHandleSync(handle: Handle, allSynced: Boolean) = onHandleUpdate(handles.gameState)
 
     override fun onHandleUpdate(handle: Handle) {
-        if (gameState.fetch()?.currentPlayer != player.fetch()?.id) return
+        if (handles.gameState.fetch()?.currentPlayer != handles.player.fetch()?.id) return
 
-        val gs = gameState.fetch() ?: TTTRandomComputer_GameState()
+        val gs = handles.gameState.fetch() ?: TTTRandomComputer_GameState()
 
         val boardArr = gs.board.split(",")
         val emptyCells = mutableListOf<Double>()
@@ -32,7 +32,7 @@ class TTTRandomComputer : AbstractTTTRandomComputer() {
         // Choose a random cell as the move
         if (emptyCells.isNotEmpty()) {
             val mv = emptyCells.shuffled().first()
-            myMove.set(TTTRandomComputer_MyMove(move = mv))
+            handles.myMove.set(TTTRandomComputer_MyMove(move = mv))
         }
     }
 }

--- a/particles/Tutorial/Kotlin/Demo/src/total/TTTBoard.kt
+++ b/particles/Tutorial/Kotlin/Demo/src/total/TTTBoard.kt
@@ -18,7 +18,7 @@ class TTTBoard : AbstractTTTBoard() {
 
     init {
         eventHandler("onClick") { eventData ->
-            events.store(TTTBoard_Events(
+            handles.events.store(TTTBoard_Events(
                 type = "move",
                 move = eventData["value"]?.toDouble() ?: -1.0,
                 time = clicks
@@ -27,7 +27,7 @@ class TTTBoard : AbstractTTTBoard() {
         }
 
         eventHandler("reset") {
-            events.store(TTTBoard_Events(type = "reset", time = clicks, move = -1.0))
+            handles.events.store(TTTBoard_Events(type = "reset", time = clicks, move = -1.0))
             clicks++
         }
     }
@@ -35,7 +35,7 @@ class TTTBoard : AbstractTTTBoard() {
     override fun onHandleUpdate(handle: Handle) = renderOutput()
 
     override fun populateModel(slotName: String, model: Map<String, Any>): Map<String, Any> {
-        val gs = gameState.fetch() ?: TTTBoard_GameState()
+        val gs = handles.gameState.fetch() ?: TTTBoard_GameState()
         val boardList = gs.board.split(",")
         val boardModel = mutableListOf<Map<String, String?>>()
         boardList.forEachIndexed { index, cell ->

--- a/particles/Tutorial/Kotlin/Demo/src/total/TTTGame.kt
+++ b/particles/Tutorial/Kotlin/Demo/src/total/TTTGame.kt
@@ -33,23 +33,23 @@ class TTTGame : AbstractTTTGame() {
     )
 
     override fun onHandleSync(handle: Handle, allSynced: Boolean) {
-        if (gameState.fetch()?.board == null) {
-            gameState.set(defaultGame)
+        if (handles.gameState.fetch()?.board == null) {
+            handles.gameState.set(defaultGame)
         }
-        if (handle.name == "playerOne" && playerOne.fetch()?.id != 0.0) {
-            val p1 = playerOne.fetch() ?: TTTGame_PlayerOne()
-            playerOne.set(p1.copy(id = 0.0))
+        if (handle.name == "playerOne" && handles.playerOne.fetch()?.id != 0.0) {
+            val p1 = handles.playerOne.fetch() ?: TTTGame_PlayerOne()
+            handles.playerOne.set(p1.copy(id = 0.0))
         }
-        if (handle.name == "playerTwo" && playerTwo.fetch()?.id != 1.0) {
-            val p2 = playerTwo.fetch() ?: TTTGame_PlayerTwo()
-            playerTwo.set(p2.copy(id = 1.0))
+        if (handle.name == "playerTwo" && handles.playerTwo.fetch()?.id != 1.0) {
+            val p2 = handles.playerTwo.fetch() ?: TTTGame_PlayerTwo()
+            handles.playerTwo.set(p2.copy(id = 1.0))
         }
     }
 
     override fun populateModel(slotName: String, model: Map<String, Any>): Map<String, Any> {
-        val gs = gameState.fetch() ?: TTTGame_GameState()
-        val p1 = playerOne.fetch() ?: TTTGame_PlayerOne()
-        val p2 = playerTwo.fetch() ?: TTTGame_PlayerTwo()
+        val gs = handles.gameState.fetch() ?: TTTGame_GameState()
+        val p1 = handles.playerOne.fetch() ?: TTTGame_PlayerOne()
+        val p2 = handles.playerTwo.fetch() ?: TTTGame_PlayerTwo()
 
         val cpName = if (gs.currentPlayer == p1.id) p1.name else p2.name
         val cpAvatar = if (gs.currentPlayer == p1.id) p1.avatar else p2.avatar
@@ -68,11 +68,11 @@ class TTTGame : AbstractTTTGame() {
     }
 
     override fun onHandleUpdate(handle: Handle) {
-        val gs = gameState.fetch() ?: TTTGame_GameState()
-        val p1 = playerOne.fetch() ?: TTTGame_PlayerOne()
-        val p2 = playerTwo.fetch() ?: TTTGame_PlayerTwo()
-        val mv1 = playerOneMove.fetch() ?: TTTGame_PlayerOneMove()
-        val mv2 = playerTwoMove.fetch() ?: TTTGame_PlayerTwoMove()
+        val gs = handles.gameState.fetch() ?: TTTGame_GameState()
+        val p1 = handles.playerOne.fetch() ?: TTTGame_PlayerOne()
+        val p2 = handles.playerTwo.fetch() ?: TTTGame_PlayerTwo()
+        val mv1 = handles.playerOneMove.fetch() ?: TTTGame_PlayerOneMove()
+        val mv2 = handles.playerTwoMove.fetch() ?: TTTGame_PlayerTwoMove()
         // Apply the moves
         if (gs.gameOver != true) {
             val boardList = gs.board.split(",").toMutableList()
@@ -94,15 +94,15 @@ class TTTGame : AbstractTTTGame() {
             }
         }
         if (hasReset()) {
-            gameState.set(TTTGame_GameState(
+            handles.gameState.set(TTTGame_GameState(
                 board = ",,,,,,,,",
                 currentPlayer = (0..1).random().toDouble(),
                 gameOver = false,
                 winnerAvatar = ""
             ))
-            playerOneMove.set(mv1.copy(move = -1.0))
-            playerTwoMove.set(mv2.copy(move = -1.0))
-            events.clear()
+            handles.playerOneMove.set(mv1.copy(move = -1.0))
+            handles.playerTwoMove.set(mv2.copy(move = -1.0))
+            handles.events.clear()
         }
         renderOutput()
     }
@@ -133,7 +133,7 @@ class TTTGame : AbstractTTTGame() {
             }
         }
 
-        gameState.set(gs.copy(
+        handles.gameState.set(gs.copy(
             board = boardList.joinToString(","),
             currentPlayer = (gs.currentPlayer + 1) % 2,
             gameOver = gameOver,
@@ -141,7 +141,7 @@ class TTTGame : AbstractTTTGame() {
         ))
     }
 
-    private fun hasReset() = events.any { it.type == "reset" }
+    private fun hasReset() = handles.events.any { it.type == "reset" }
 
     private fun Int.isValidMove(boardList: List<String>) = this in 0..9 && boardList[this] == ""
 }

--- a/particles/Tutorial/Kotlin/Demo/src/total/TTTHumanPlayer.kt
+++ b/particles/Tutorial/Kotlin/Demo/src/total/TTTHumanPlayer.kt
@@ -15,13 +15,14 @@ import arcs.sdk.Handle
 
 class TTTHumanPlayer : AbstractTTTHumanPlayer() {
     override fun onHandleUpdate(handle: Handle) {
-        if (events.size <= 0 || gameState.fetch()?.currentPlayer != player.fetch()?.id) return
+        if (handles.events.size <= 0
+                || handles.gameState.fetch()?.currentPlayer != handles.player.fetch()?.id) return
 
         // Get the element with the largest time as this will be the most recent.
-        val event = events.sortedBy { it.time }.last()
+        val event = handles.events.sortedBy { it.time }.last()
         // Set the move
         if (event.type == "move") {
-            myMove.set(TTTHumanPlayer_MyMove(event.move))
+            handles.myMove.set(TTTHumanPlayer_MyMove(event.move))
         }
     }
 }

--- a/particles/Tutorial/Kotlin/Demo/src/total/TTTRandomComputer.kt
+++ b/particles/Tutorial/Kotlin/Demo/src/total/TTTRandomComputer.kt
@@ -14,12 +14,12 @@ package arcs.tutorials.tictactoe
 import arcs.sdk.Handle
 
 class TTTRandomComputer : AbstractTTTRandomComputer() {
-    override fun onHandleSync(handle: Handle, allSynced: Boolean) = onHandleUpdate(gameState)
+    override fun onHandleSync(handle: Handle, allSynced: Boolean) = onHandleUpdate(handles.gameState)
 
     override fun onHandleUpdate(handle: Handle) {
-        if (gameState.fetch()?.currentPlayer != player.fetch()?.id) return
+        if (handles.gameState.fetch()?.currentPlayer != handles.player.fetch()?.id) return
 
-        val gs = gameState.fetch() ?: TTTRandomComputer_GameState()
+        val gs = handles.gameState.fetch() ?: TTTRandomComputer_GameState()
 
         val boardArr = gs.board.split(",")
         val emptyCells = mutableListOf<Double>()
@@ -32,7 +32,7 @@ class TTTRandomComputer : AbstractTTTRandomComputer() {
         // Choose a random cell as the move
         if (emptyCells.isNotEmpty()) {
             val mv = emptyCells.shuffled().first()
-            myMove.set(TTTRandomComputer_MyMove(move = mv))
+            handles.myMove.set(TTTRandomComputer_MyMove(move = mv))
         }
     }
 }

--- a/particles/Tutorial/Kotlin/README.md
+++ b/particles/Tutorial/Kotlin/README.md
@@ -266,7 +266,7 @@ class GetPersonParticle : AbstractGetPersonParticle() {
         // on the element.
         eventHandler("onNameInputChange") { eventData ->
             // Update the handle based on the eventData.
-            person.set(GetPerson_Person(name = eventData["value"] ?: "Human"))
+            handles.person.set(GetPerson_Person(name = eventData["value"] ?: "Human"))
         }
     }
 }
@@ -287,7 +287,7 @@ class DisplayGreetingParticle : AbstractDisplayGreetingParticle() {
 
     override fun populateModel(slotName: String, model: Map<String, Any>): Map<String, Any> {
         return model + mapOf(
-            "name" to (person.fetch()?.name ?: "Human")
+            "name" to (handles.person.fetch()?.name ?: "Human")
         )
     }
 }
@@ -406,7 +406,7 @@ class CollectionsParticle : AbstractCollectionsParticle() {
         // We begin by generating the list of models that should fill the template. Our template
         // has name ang age so we will use these names.
         val peopleList = mutableListOf<Map<String, Comparable<*>?>>()
-        people.forEach { people ->
+        handles.people.forEach { people ->
             peopleList.add(mapOf("name" to people.name, "age" to people.age))
         }
 
@@ -419,7 +419,7 @@ class CollectionsParticle : AbstractCollectionsParticle() {
                 "\$template" to "person",
                 // Each model in this list will get passed into the person template. The template
                 // can access the properties in this model (name and age) via placeholders.
-                "models" to peopleList
+                "models" to handles.peopleList
             )
         )
     }
@@ -519,7 +519,7 @@ package arcs.tutorials
  */
 class JsonStoreParticle : AbstractJsonStoreParticle() {
     override fun populateModel(slotName: String, model: Map<String, Any>): Map<String, Any> {
-        val person = res.fetch() ?: JsonStoreParticle_InputData()
+        val person = handles.res.fetch() ?: JsonStoreParticle_InputData()
 
         return model + mapOf(
             "name" to person.name,

--- a/src/tools/schema2kotlin.ts
+++ b/src/tools/schema2kotlin.ts
@@ -83,11 +83,15 @@ ${this.opts.wasm ? 'import arcs.sdk.wasm.*' : ''}
         default:
           throw new Error(`Unsupported handle direction: ${connection.direction}`);
       }
-      handleDecls.push(`protected val ${handleName}: ${handleInterfaceType} = ${this.getType(handleConcreteType) + 'Impl'}(this, "${handleName}", ${entityType}_Spec())`);
+      handleDecls.push(`val ${handleName}: ${handleInterfaceType} = ${this.getType(handleConcreteType) + 'Impl'}(particle, "${handleName}", ${entityType}_Spec())`);
     }
     return `
-abstract class Abstract${particleName} : ${this.opts.wasm ? 'WasmParticleImpl' : 'BaseParticle'}() {
+class ${particleName}Handles(particle : ${this.opts.wasm ? 'WasmParticleImpl' : 'BaseParticle'}) {
     ${handleDecls.join('\n    ')}
+}
+
+abstract class Abstract${particleName} : ${this.opts.wasm ? 'WasmParticleImpl' : 'BaseParticle'}() {
+    protected val handles: ${particleName}Handles = ${particleName}Handles(this)
 }
 `;
   }

--- a/src/tools/tests/goldens/generated-schemas.jvm.kt
+++ b/src/tools/tests/goldens/generated-schemas.jvm.kt
@@ -123,7 +123,11 @@ class Gold_Data_Spec() : EntitySpec<Gold_Data> {
 }
 
 
+class GoldHandles(particle : BaseParticle) {
+    val data: ReadableSingleton<Gold_Data> = SingletonImpl(particle, "data", Gold_Data_Spec())
+    val alias: WritableSingleton<Gold_Alias> = SingletonImpl(particle, "alias", Gold_Alias_Spec())
+}
+
 abstract class AbstractGold : BaseParticle() {
-    protected val data: ReadableSingleton<Gold_Data> = SingletonImpl(this, "data", Gold_Data_Spec())
-    protected val alias: WritableSingleton<Gold_Alias> = SingletonImpl(this, "alias", Gold_Alias_Spec())
+    protected val handles: GoldHandles = GoldHandles(this)
 }

--- a/src/tools/tests/goldens/generated-schemas.wasm.kt
+++ b/src/tools/tests/goldens/generated-schemas.wasm.kt
@@ -226,7 +226,11 @@ class Gold_Data_Spec() : WasmEntitySpec<Gold_Data> {
 }
 
 
+class GoldHandles(particle : WasmParticleImpl) {
+    val data: ReadableSingleton<Gold_Data> = WasmSingletonImpl(particle, "data", Gold_Data_Spec())
+    val alias: WritableSingleton<Gold_Alias> = WasmSingletonImpl(particle, "alias", Gold_Alias_Spec())
+}
+
 abstract class AbstractGold : WasmParticleImpl() {
-    protected val data: ReadableSingleton<Gold_Data> = WasmSingletonImpl(this, "data", Gold_Data_Spec())
-    protected val alias: WritableSingleton<Gold_Alias> = WasmSingletonImpl(this, "alias", Gold_Alias_Spec())
+    protected val handles: GoldHandles = GoldHandles(this)
 }


### PR DESCRIPTION
* For access to storage without using particles it’s convenient to have an object that holds all the handles as described by the particles in the manifest (what I call “virtual particles”), but without using the actual particle class.
* For the API inside the particle we discussed for a long time having handles.connectionName being more explicit than just connectionName and nicer than connectionNameHandle.