### PR TITLE
Enable worker pool with nosuspend

### DIFF
--- a/java/arcs/sdk/android/dev/api/RuntimeSettings.java
+++ b/java/arcs/sdk/android/dev/api/RuntimeSettings.java
@@ -48,7 +48,13 @@ public interface RuntimeSettings {
   // Used together with the setting {@link #useWorkerPool()} to supply additional
   // worker pool configurations. Options are separated by commas.
   // Available options:
-  //   'nosuspend': only create new workers ahead of time (no resurrecting workers)
+  //   'nosuspend': only create new workers ahead of time (no resurrecting workers).
+  //                A resurrected or resumed worker exposes the same global context
+  //                to all Arcs that were and is running on it. Which implies new
+  //                Arcs can potentially eavesdrop older Arcs' information as a
+  //                side-channel attack if old Arcs forgot to clean what they stored
+  //                at the worker's global context.
+  //
   String workerPoolOptions();
 
   // Used only by Javascript-based Arcs runtime to determine and adjust size of

--- a/java/arcs/sdk/android/dev/service/AndroidRuntimeSettings.java
+++ b/java/arcs/sdk/android/dev/service/AndroidRuntimeSettings.java
@@ -61,7 +61,8 @@ public final class AndroidRuntimeSettings implements RuntimeSettings {
   // Activates worker pool
   private static final boolean DEFAULT_USE_WORKER_POOL = true;
   // "nosuspend" prepares or replenishes new workers ahead of time but never
-  // re-uses (suspend-then-resume) them.
+  // re-uses (suspend-then-resume) them. More details, please see:
+  // {@link RuntimeSettings#workerPoolOptions()}
   private static final String DEFAULT_WORKER_POOL_OPTIONS = "nosuspend";
   // Uses the default sizing policy auto-selected by Arcs runtime
   private static final String DEFAULT_SIZING_POLICY = "default";

--- a/java/arcs/sdk/android/dev/service/AndroidRuntimeSettings.java
+++ b/java/arcs/sdk/android/dev/service/AndroidRuntimeSettings.java
@@ -58,10 +58,11 @@ public final class AndroidRuntimeSettings implements RuntimeSettings {
   private static final boolean DEFAULT_USE_CACHE_MANAGER = true;
   // Disables system trace
   private static final String DEFAULT_SYSTEM_TRACE_CHANNEL = "";
-  // Disables worker pool
-  private static final boolean DEFAULT_USE_WORKER_POOL = false;
-  // Uses the default settings (no additional configurations)
-  private static final String DEFAULT_WORKER_POOL_OPTIONS = "";
+  // Activates worker pool
+  private static final boolean DEFAULT_USE_WORKER_POOL = true;
+  // "nosuspend" prepares or replenishes new workers ahead of time but never
+  // re-uses (suspend-then-resume) them.
+  private static final String DEFAULT_WORKER_POOL_OPTIONS = "nosuspend";
   // Uses the default sizing policy auto-selected by Arcs runtime
   private static final String DEFAULT_SIZING_POLICY = "default";
 

--- a/java/arcs/sdk/android/dev/service/README.md
+++ b/java/arcs/sdk/android/dev/service/README.md
@@ -117,6 +117,6 @@ Android properties are used to change and tweak Arcs settings at run-time.
 | debug.arcs.runtime.load_workstation_assets | Whether to load recipes and particles from the workstation | false (assets from the APK) |
 | debug.arcs.runtime.use_cache_mgr | Whether to use the Arcs Cache Manager | true
 | debug.arcs.runtime.systrace | Specify system tracing channel (options: [android,console]) | n/a (trace off)
-| debug.arcs.runtime.use_worker_pool | Whether to use the Arcs Worker Pool | false
-| debug.arcs.runtime.worker_pool_options| Provide additional worker pool configurations | ""
+| debug.arcs.runtime.use_worker_pool | Whether to use the Arcs Worker Pool | true
+| debug.arcs.runtime.worker_pool_options| Provide additional worker pool configurations | "nosuspend"
 | debug.arcs.runtime.sizing_policy | Select worker pool dynamic sizing (shrink/grow) policy | default


### PR DESCRIPTION
This is the final PR for worker pool.
Using nosuspend option to only spin up new workers ahead of time but never
re-use them by suspend/resume functions.
This keeps the worker global scope/context clean from potential side channels and else.

The pipe-shell url for a performant DevHost should look like:
https://appassets.androidplatform.net/assets/arcs/index.html?log=2&use-cache&use-worker-pool=nosuspend