### PR TITLE
Performance stats

### DIFF
--- a/java/arcs/core/util/performance/PerformanceStatistics.kt
+++ b/java/arcs/core/util/performance/PerformanceStatistics.kt
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.core.util.performance
+
+import arcs.core.util.RunningStatistics
+import arcs.core.util.guardWith
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Utility for tracking running performance/runtime statistics of arbitrary operations.
+ *
+ * Example usage:
+ *
+ * ```kotlin
+ * object FibonacciCalculator {
+ *     private val fiboSlowStats =
+ *         PerformanceStatistics(PlatformTimer, "additions", "recursiveCalls")
+ *     private val fiboFastStats =
+ *         PerformanceStatistics(PlatformTimer, "additions", "loops")
+ *
+ *     fun fiboSlow(n: Int): Int = fiboSlowStats.time { counters ->
+ *         fun inner(n: Int): Int {
+ *             if (n == 0 || n == 1) return 1
+ *
+ *             counters.increment("recursiveCalls")
+ *             val nMinus2 = inner(n - 2)
+ *             counters.increment("recursiveCalls")
+ *             val nMinus1 = inner(n - 1)
+ *
+ *             counters.increment("additions")
+ *             return nMinus2 + nMinus1
+ *         }
+ *
+ *         return@time inner(n)
+ *     }
+ *
+ *     fun fiboFast(n: Int): Int = fiboFastStats.time { counters ->
+ *         var nMinus2 = 0
+ *         var nMinus1 = 1
+ *
+ *         repeat(n) {
+ *             counters.increment("loops")
+ *             counters.increment("additions")
+ *             val sum = nMinus1 + nMinus2
+ *             nMinus2 = nMinus1
+ *             nMinus1 = sum
+ *         }
+ *
+ *         return@time nMinus1
+ *     }
+ *
+ *     suspend fun printStats() {
+ *         val fiboSlowSnapshot = fiboSlowStats.snapshot()
+ *         println("Slow stats:")
+ *         println(fiboSlowSnapshot)
+ *
+ *         val fiboFastSnapshot = fiboFastStats.snapshot()
+ *         println("Fast stats:")
+ *         println(fiboFastSnapshot)
+ *     }
+ * }
+ * ```
+ */
+class PerformanceStatistics private constructor(
+    private val timer: Timer,
+    private val counterNames: Set<String>,
+    initialStats: Snapshot = Snapshot(counterNames)
+) {
+    private val mutex = Mutex()
+    private val runtimeStats by guardWith(mutex, RunningStatistics(initialStats.runtimeStatistics))
+    private val counters by guardWith(mutex, CounterStatistics(initialStats.countStatistics))
+
+    /**
+     * Creates a [PerformanceStatistics] object.
+     *
+     * @param requiredCounterNames required counters for the new [PerformanceStatistics].
+     */
+    constructor(
+        timer: Timer,
+        vararg requiredCounterNames: String
+    ) : this(
+        timer,
+        requiredCounterNames.toSet(),
+        Snapshot(
+            RunningStatistics.Snapshot(),
+            CounterStatistics.Snapshot(requiredCounterNames.toSet())
+        )
+    )
+
+    /**
+     * Creates a [PerformanceStatistics] object.
+     *
+     * @param initialStats statistics from previous usage as a starting point for the created
+     *     object.
+     * @param requiredCounterNames required counters for the new [PerformanceStatistics]. Counter
+     *     names from the previous snapshots not found in [requiredCounterNames] will be dropped,
+     *     new names will be initialized with new/empty statistics.
+     */
+    constructor(
+        timer: Timer,
+        initialStats: Snapshot,
+        vararg requiredCounterNames: String
+    ) : this(
+        timer,
+        requiredCounterNames.toSet(),
+        initialStats
+    )
+
+    /** Takes a [Snapshot] of the current performance statistics. */
+    suspend fun snapshot(): Snapshot = mutex.withLock {
+        Snapshot(runtimeStats.snapshot(), counters.snapshot())
+    }
+
+    /** Asynchronously takes a [Snapshot] of the current performance statistics. */
+    fun snapshotAsync(
+        coroutineContext: CoroutineContext = Dispatchers.Default
+    ): Deferred<Snapshot> = CoroutineScope(coroutineContext).async { snapshot() }
+
+    /**
+     * Records the execution duration of the given [block].
+     *
+     * The [block] can use the provided [Counters] to track individual named-operations,
+     * accumulating statistics for the numbers of those invocations.
+     */
+    fun <Calculated> time(block: (Counters) -> Calculated): Calculated {
+        val (timedResult, elapsed) = timer.time {
+            val counts = Counters(counterNames)
+            block(counts) to counts
+        }
+        val (result, counts) = timedResult
+
+        CoroutineScope(Dispatchers.Default).launch {
+            mutex.withLock {
+                runtimeStats.logStat(elapsed.toDouble())
+                counters.append(counts)
+            }
+        }
+
+        return result
+    }
+
+    /**
+     * Records the execution duration of the given suspending [block].
+     *
+     * The [block] can use the provided [Counters] to track individual named-operations,
+     * accumulating statistics for the numbers of those invocations.
+     */
+    suspend fun <Calculated> timeSuspending(block: suspend (Counters) -> Calculated): Calculated {
+        val (timedResult, elapsed) = timer.timeSuspending {
+            val counts = Counters(counterNames)
+            block(counts) to counts
+        }
+        val (result, counts) = timedResult
+
+        mutex.withLock {
+            runtimeStats.logStat(elapsed.toDouble())
+            counters.append(counts)
+        }
+
+        return result
+    }
+
+    /** Frozen snapshot of [PerformanceStatistics]. */
+    data class Snapshot(
+        val runtimeStatistics: RunningStatistics.Snapshot,
+        val countStatistics: CounterStatistics.Snapshot
+    ) {
+        /**
+         * Creates an empty [Snapshot] with a [CounterStatistics.Snapshot] value for the given
+         * [counterNames].
+         */
+        constructor(counterNames: Set<String>) :
+            this(RunningStatistics.Snapshot(), CounterStatistics.Snapshot(counterNames))
+    }
+}

--- a/java/arcs/core/util/performance/PerformanceStatistics.kt
+++ b/java/arcs/core/util/performance/PerformanceStatistics.kt
@@ -25,57 +25,7 @@ import kotlinx.coroutines.sync.withLock
 /**
  * Utility for tracking running performance/runtime statistics of arbitrary operations.
  *
- * Example usage:
- *
- * ```kotlin
- * object FibonacciCalculator {
- *     private val fiboSlowStats =
- *         PerformanceStatistics(PlatformTimer, "additions", "recursiveCalls")
- *     private val fiboFastStats =
- *         PerformanceStatistics(PlatformTimer, "additions", "loops")
- *
- *     fun fiboSlow(n: Int): Int = fiboSlowStats.time { counters ->
- *         fun inner(n: Int): Int {
- *             if (n == 0 || n == 1) return 1
- *
- *             counters.increment("recursiveCalls")
- *             val nMinus2 = inner(n - 2)
- *             counters.increment("recursiveCalls")
- *             val nMinus1 = inner(n - 1)
- *
- *             counters.increment("additions")
- *             return nMinus2 + nMinus1
- *         }
- *
- *         return@time inner(n)
- *     }
- *
- *     fun fiboFast(n: Int): Int = fiboFastStats.time { counters ->
- *         var nMinus2 = 0
- *         var nMinus1 = 1
- *
- *         repeat(n) {
- *             counters.increment("loops")
- *             counters.increment("additions")
- *             val sum = nMinus1 + nMinus2
- *             nMinus2 = nMinus1
- *             nMinus1 = sum
- *         }
- *
- *         return@time nMinus1
- *     }
- *
- *     suspend fun printStats() {
- *         val fiboSlowSnapshot = fiboSlowStats.snapshot()
- *         println("Slow stats:")
- *         println(fiboSlowSnapshot)
- *
- *         val fiboFastSnapshot = fiboFastStats.snapshot()
- *         println("Fast stats:")
- *         println(fiboFastSnapshot)
- *     }
- * }
- * ```
+ * For an example use-case, see [FiboPerformanceStatisticsTest].
  */
 class PerformanceStatistics private constructor(
     private val timer: Timer,

--- a/java/arcs/core/util/performance/PerformanceStatistics.kt
+++ b/java/arcs/core/util/performance/PerformanceStatistics.kt
@@ -13,6 +13,7 @@ package arcs.core.util.performance
 
 import arcs.core.util.RunningStatistics
 import arcs.core.util.guardWith
+import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
@@ -20,7 +21,6 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import kotlin.coroutines.CoroutineContext
 
 /**
  * Utility for tracking running performance/runtime statistics of arbitrary operations.

--- a/javatests/arcs/core/util/performance/FiboPerformanceStatisticsTest.kt
+++ b/javatests/arcs/core/util/performance/FiboPerformanceStatisticsTest.kt
@@ -12,16 +12,15 @@
 package arcs.core.util.performance
 
 import com.google.common.truth.Truth.assertThat
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.runBlocking
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
-@Suppress("EXPERIMENTAL_API_USAGE")
 @RunWith(JUnit4::class)
 class FiboPerformanceStatisticsTest {
     @Test
-    fun compareStats() = runBlockingTest {
+    fun compareStats() = runBlocking {
         val calculator = FibonacciCalculator()
         assertThat(calculator.fiboSlow(0)).isEqualTo(1)
         assertThat(calculator.fiboSlow(1)).isEqualTo(1)
@@ -81,7 +80,7 @@ class FiboPerformanceStatisticsTest {
         val fiboSlowStats = PerformanceStatistics(PlatformTimer, "additions", "recursiveCalls")
         val fiboFastStats = PerformanceStatistics(PlatformTimer, "additions", "loops")
 
-        fun fiboSlow(n: Int): Int = fiboSlowStats.time { counters ->
+        suspend fun fiboSlow(n: Int): Int = fiboSlowStats.timeSuspending { counters ->
             fun inner(n: Int): Int {
                 if (n == 0 || n == 1) return 1
 
@@ -94,10 +93,10 @@ class FiboPerformanceStatisticsTest {
                 return nMinus2 + nMinus1
             }
 
-            return@time inner(n)
+            return@timeSuspending inner(n)
         }
 
-        fun fiboFast(n: Int): Int = fiboFastStats.time { counters ->
+        suspend fun fiboFast(n: Int): Int = fiboFastStats.timeSuspending { counters ->
             var nMinus2 = 0
             var nMinus1 = 1
 
@@ -109,7 +108,7 @@ class FiboPerformanceStatisticsTest {
                 nMinus1 = sum
             }
 
-            return@time nMinus1
+            return@timeSuspending nMinus1
         }
     }
 

--- a/javatests/arcs/core/util/performance/FiboPerformanceStatisticsTest.kt
+++ b/javatests/arcs/core/util/performance/FiboPerformanceStatisticsTest.kt
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.core.util.performance
+
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@Suppress("EXPERIMENTAL_API_USAGE")
+@RunWith(JUnit4::class)
+class FiboPerformanceStatisticsTest {
+    @Test
+    fun compareStats() = runBlockingTest {
+        val calculator = FibonacciCalculator()
+        assertThat(calculator.fiboSlow(0)).isEqualTo(1)
+        assertThat(calculator.fiboSlow(1)).isEqualTo(1)
+        assertThat(calculator.fiboSlow(2)).isEqualTo(2)
+        assertThat(calculator.fiboSlow(3)).isEqualTo(3)
+        assertThat(calculator.fiboSlow(4)).isEqualTo(5)
+        assertThat(calculator.fiboSlow(5)).isEqualTo(8)
+        assertThat(calculator.fiboSlow(20)).isEqualTo(10946)
+
+        assertThat(calculator.fiboFast(0)).isEqualTo(1)
+        assertThat(calculator.fiboFast(1)).isEqualTo(1)
+        assertThat(calculator.fiboFast(2)).isEqualTo(2)
+        assertThat(calculator.fiboFast(3)).isEqualTo(3)
+        assertThat(calculator.fiboFast(4)).isEqualTo(5)
+        assertThat(calculator.fiboFast(5)).isEqualTo(8)
+        assertThat(calculator.fiboFast(20)).isEqualTo(10946)
+
+        val slowStats = calculator.fiboSlowStats.snapshot()
+        val fastStats = calculator.fiboFastStats.snapshot()
+
+        println()
+        println("Fibonacci Number Algorithm Performance")
+        println()
+        println("Slow Runtime (nanos):")
+        println("  ${slowStats.runtimeStatistics}")
+        println("Fast Runtime (nanos):")
+        println("  ${fastStats.runtimeStatistics}")
+        println()
+        println("Slow Counts:")
+        println("  additions:")
+        println("    ${slowStats.countStatistics["additions"]}")
+        println("  recursive calls:")
+        println("    ${slowStats.countStatistics["recursiveCalls"]}")
+        println("Fast Counts:")
+        println("  additions:")
+        println("    ${fastStats.countStatistics["additions"]}")
+        println("  loops:")
+        println("    ${fastStats.countStatistics["loops"]}")
+
+        assertThat(slowStats.runtimeStatistics.measurements)
+            .isEqualTo(fastStats.runtimeStatistics.measurements)
+        assertThat(slowStats.runtimeStatistics.mean)
+            .isGreaterThan(fastStats.runtimeStatistics.mean)
+        assertThat(slowStats.runtimeStatistics.max)
+            .isGreaterThan(fastStats.runtimeStatistics.max)
+
+        assertThat(slowStats.countStatistics["additions"].measurements)
+            .isEqualTo(fastStats.countStatistics["additions"].measurements)
+        assertThat(slowStats.countStatistics["additions"].mean)
+            .isGreaterThan(fastStats.countStatistics["additions"].mean)
+        assertThat(slowStats.countStatistics["additions"].max)
+            .isGreaterThan(fastStats.countStatistics["additions"].max)
+    }
+
+    /** Implementation of the example from the KDoc on [PerformanceStatistics]. */
+    private class FibonacciCalculator {
+        val fiboSlowStats = PerformanceStatistics(PlatformTimer, "additions", "recursiveCalls")
+        val fiboFastStats = PerformanceStatistics(PlatformTimer, "additions", "loops")
+
+        fun fiboSlow(n: Int): Int = fiboSlowStats.time { counters ->
+            fun inner(n: Int): Int {
+                if (n == 0 || n == 1) return 1
+
+                counters.increment("recursiveCalls")
+                val nMinus2 = inner(n - 2)
+                counters.increment("recursiveCalls")
+                val nMinus1 = inner(n - 1)
+
+                counters.increment("additions")
+                return nMinus2 + nMinus1
+            }
+
+            return@time inner(n)
+        }
+
+        fun fiboFast(n: Int): Int = fiboFastStats.time { counters ->
+            var nMinus2 = 0
+            var nMinus1 = 1
+
+            repeat(n) {
+                counters.increment("loops")
+                counters.increment("additions")
+                val sum = nMinus1 + nMinus2
+                nMinus2 = nMinus1
+                nMinus1 = sum
+            }
+
+            return@time nMinus1
+        }
+    }
+
+    private object PlatformTimer : Timer() {
+        override val currentTimeNanos: Long
+            get() = System.nanoTime()
+    }
+}

--- a/javatests/arcs/core/util/performance/PerformanceStatisticsTest.kt
+++ b/javatests/arcs/core/util/performance/PerformanceStatisticsTest.kt
@@ -69,7 +69,7 @@ class PerformanceStatisticsTest {
         )
         val stats = PerformanceStatistics(timer, initialSnapshot, "foo", "bar")
 
-        val deferred = stats.snapshotAsync()
+        val deferred = stats.snapshotAsync(coroutineContext)
 
         assertThat(deferred.await()).isEqualTo(initialSnapshot)
     }
@@ -83,7 +83,7 @@ class PerformanceStatisticsTest {
             it.increment("foo")
         }
 
-        yield() // let the mutex in the time function run.
+        delay(100) // let the mutex in the time function run.
 
         val snapshot = stats.snapshot()
         assertThat(snapshot.runtimeStatistics.measurements).isEqualTo(1)

--- a/javatests/arcs/core/util/performance/PerformanceStatisticsTest.kt
+++ b/javatests/arcs/core/util/performance/PerformanceStatisticsTest.kt
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.core.util.performance
+
+import arcs.core.util.RunningStatistics
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.yield
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@Suppress("EXPERIMENTAL_API_USAGE")
+@RunWith(JUnit4::class)
+class PerformanceStatisticsTest {
+    private val timer = TimerImpl()
+
+    @Test
+    fun constructor_noInitialStats() = runBlockingTest {
+        val stats = PerformanceStatistics(timer, "foo", "bar")
+
+        val snapshot = stats.snapshot()
+        assertThat(snapshot).isEqualTo(
+            PerformanceStatistics.Snapshot(
+                RunningStatistics.Snapshot(),
+                CounterStatistics.Snapshot(setOf("foo", "bar"))
+            )
+        )
+    }
+
+    @Test
+    fun constructor_initialStats() = runBlockingTest {
+        val initialSnapshot = PerformanceStatistics.Snapshot(
+            RunningStatistics.Snapshot(1, min = 0.0, max = 0.0),
+            CounterStatistics.Snapshot(
+                mapOf(
+                    "foo" to RunningStatistics.Snapshot(1, min = 10.0, max = 10.0),
+                    "bar" to RunningStatistics.Snapshot(1, min = 5.0, max = 5.0)
+                )
+            )
+        )
+        val stats = PerformanceStatistics(timer, initialSnapshot, "foo", "bar")
+
+        val snapshot = stats.snapshot()
+        assertThat(snapshot).isEqualTo(initialSnapshot)
+    }
+
+    @Test
+    fun snapshotAsync() = runBlockingTest {
+        val initialSnapshot = PerformanceStatistics.Snapshot(
+            RunningStatistics.Snapshot(1, min = 0.0, max = 0.0),
+            CounterStatistics.Snapshot(
+                mapOf(
+                    "foo" to RunningStatistics.Snapshot(1, min = 10.0, max = 10.0),
+                    "bar" to RunningStatistics.Snapshot(1, min = 5.0, max = 5.0)
+                )
+            )
+        )
+        val stats = PerformanceStatistics(timer, initialSnapshot, "foo", "bar")
+
+        val deferred = stats.snapshotAsync()
+
+        assertThat(deferred.await()).isEqualTo(initialSnapshot)
+    }
+
+    @Test
+    fun time() = runBlockingTest {
+        val stats = PerformanceStatistics(timer, "foo")
+
+        stats.time {
+            Thread.sleep(500)
+            it.increment("foo")
+        }
+
+        yield() // let the mutex in the time function run.
+
+        val snapshot = stats.snapshot()
+        assertThat(snapshot.runtimeStatistics.measurements).isEqualTo(1)
+        assertThat(snapshot.runtimeStatistics.mean).isAtLeast(500 * 1000 * 1000)
+        assertThat(snapshot.runtimeStatistics.min).isAtLeast(500 * 1000 * 1000)
+        assertThat(snapshot.runtimeStatistics.max).isAtLeast(500 * 1000 * 1000)
+        assertThat(snapshot.countStatistics["foo"].measurements).isEqualTo(1)
+        assertThat(snapshot.countStatistics["foo"].mean).isEqualTo(1)
+        assertThat(snapshot.countStatistics["foo"].min).isEqualTo(1)
+        assertThat(snapshot.countStatistics["foo"].max).isEqualTo(1)
+    }
+
+    @Test
+    fun timeSuspending() = runBlocking {
+        val stats = PerformanceStatistics(timer, "foo")
+
+        stats.timeSuspending {
+            delay(500)
+            it.increment("foo")
+        }
+
+        val snapshot = stats.snapshot()
+        assertThat(snapshot.runtimeStatistics.measurements).isEqualTo(1)
+        assertThat(snapshot.runtimeStatistics.mean).isAtLeast(500 * 1000 * 1000)
+        assertThat(snapshot.runtimeStatistics.min).isAtLeast(500 * 1000 * 1000)
+        assertThat(snapshot.runtimeStatistics.max).isAtLeast(500 * 1000 * 1000)
+        assertThat(snapshot.countStatistics["foo"].measurements).isEqualTo(1)
+        assertThat(snapshot.countStatistics["foo"].mean).isEqualTo(1)
+        assertThat(snapshot.countStatistics["foo"].min).isEqualTo(1)
+        assertThat(snapshot.countStatistics["foo"].max).isEqualTo(1)
+    }
+
+    private class TimerImpl : Timer() {
+        override val currentTimeNanos: Long
+            get() = System.nanoTime()
+    }
+}


### PR DESCRIPTION
Last in a series of PRs  to add robust performance statistics-tracking capabilities to Arcs.

Diffbase #4632 

Fun:
Here's the STDOUT from the FiboPerformanceStatisticsTest:

```
Fibonacci Number Algorithm Performance

Slow Runtime (nanos):
  Snapshot(measurements=7, mean=1125829.1428571427, variance=2.743477474897265E12, standardDeviation=1656344.612360986, min=18946.0, max=4880704.0)
Fast Runtime (nanos):
  Snapshot(measurements=7, mean=17170.285714285714, variance=1.1077758820408164E8, standardDeviation=10525.09326343865, min=9151.0, max=41944.0)

Slow Counts:
  additions:
    Snapshot(measurements=7, mean=1565.5714285714284, variance=1.4662285387755102E7, standardDeviation=3829.13637622834, min=0.0, max=10945.0)
  recursive calls:
    Snapshot(measurements=7, mean=3131.142857142857, variance=5.8649141551020406E7, standardDeviation=7658.27275245668, min=0.0, max=21890.0)
Fast Counts:
  additions:
    Snapshot(measurements=7, mean=5.0, variance=40.0, standardDeviation=6.324555320336759, min=0.0, max=20.0)
  loops:
    Snapshot(measurements=7, mean=5.0, variance=40.0, standardDeviation=6.324555320336759, min=0.0, max=20.0)
```