### PR TITLE
Update StorageProxy deadlock test

### DIFF
--- a/java/arcs/core/storage/StorageProxy.kt
+++ b/java/arcs/core/storage/StorageProxy.kt
@@ -73,7 +73,8 @@ class StorageProxy<Data : CrdtData, Op : CrdtOperation, T>(
             readHandles.size == 1
         }
 
-        val (hasSynced, versionMap) = syncMutex.withLock { isSynchronized to crdt.versionMap.copy() }
+        val (hasSynced, versionMap) =
+            syncMutex.withLock { isSynchronized to crdt.versionMap.copy() }
 
         if (firstReader) requestSynchronization()
         else if (hasSynced) coroutineScope { launch { handle.callback?.onSync() } }

--- a/javatests/arcs/core/storage/BUILD
+++ b/javatests/arcs/core/storage/BUILD
@@ -47,6 +47,6 @@ arcs_kt_jvm_library(
     deps = [
         "//java/arcs/core/crdt",
         "//java/arcs/core/storage",
-        "//third_party/kotlin/kotlinx_atomicfu",
+        "//third_party/kotlin/kotlinx_coroutines",
     ],
 )

--- a/javatests/arcs/core/storage/StorageProxyTest.kt
+++ b/javatests/arcs/core/storage/StorageProxyTest.kt
@@ -198,8 +198,7 @@ class StorageProxyTest {
 
         val workers = 20
         val jobs = 10
-        Executors.newFixedThreadPool(workers).asCoroutineDispatcher().use {
-            val inPool = it
+        Executors.newFixedThreadPool(workers).asCoroutineDispatcher().use {inPool ->
             repeat(10) {
                 runBlocking {
                     withTimeout(5000) {

--- a/javatests/arcs/core/storage/StorageProxyTest.kt
+++ b/javatests/arcs/core/storage/StorageProxyTest.kt
@@ -7,6 +7,8 @@ import arcs.core.crdt.VersionMap
 import com.google.common.truth.Truth.assertThat
 import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
 import com.nhaarman.mockitokotlin2.whenever
+import java.util.concurrent.Executors
+import kotlin.random.Random
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.delay
@@ -23,8 +25,6 @@ import org.mockito.Mock
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
 import org.mockito.MockitoAnnotations
-import java.util.concurrent.Executors
-import kotlin.random.Random
 
 @Suppress("UNCHECKED_CAST", "UNUSED_VARIABLE")
 @ExperimentalCoroutinesApi
@@ -216,9 +216,10 @@ class StorageProxyTest {
         }
     }
 
-    private fun newHandle(name: String,
-                          storageProxy: StorageProxy<CrdtData, CrdtOperation, String>,
-                          reader: Boolean
+    private fun newHandle(
+        name: String,
+        storageProxy: StorageProxy<CrdtData, CrdtOperation, String>,
+        reader: Boolean
     ) = Handle(name, storageProxy, reader).apply {
         this.callback = mock(Callbacks::class.java) as Callbacks<CrdtOperation>
     }

--- a/javatests/arcs/core/storage/StoreEndpointFake.kt
+++ b/javatests/arcs/core/storage/StoreEndpointFake.kt
@@ -9,7 +9,8 @@ import kotlinx.coroutines.sync.withLock
 /** [StoreEndpointFake] exists to capture calls made to [Store] for unit tests. This is needed
  * because Google3's Mockito is incompatible with suspend functions.
  */
-class StoreEndpointFake<Data : CrdtData, Op : CrdtOperation, T> : StorageCommunicationEndpoint<Data, Op, T> {
+class StoreEndpointFake<Data : CrdtData, Op : CrdtOperation, T>:
+ StorageCommunicationEndpoint<Data, Op, T> {
     private val mutex = Mutex()
     private var callbacks = mutableListOf<ProxyCallback<Data, Op, T>>()
     private var proxyMessages = mutableListOf<ProxyMessage<Data, Op, T>>()

--- a/javatests/arcs/core/storage/StoreEndpointFake.kt
+++ b/javatests/arcs/core/storage/StoreEndpointFake.kt
@@ -2,14 +2,14 @@ package arcs.core.storage
 
 import arcs.core.crdt.CrdtData
 import arcs.core.crdt.CrdtOperation
-import kotlinx.atomicfu.locks.ReentrantLock
-import kotlinx.atomicfu.locks.withLock
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 
 /** [StoreEndpointFake] exists to capture calls made to [Store] for unit tests. This is needed
  * because Google3's Mockito is incompatible with suspend functions.
  */
 class StoreEndpointFake<Data : CrdtData, Op : CrdtOperation, T> : StorageCommunicationEndpoint<Data, Op, T> {
-    private val mutex = ReentrantLock()
+    private val mutex = Mutex()
     private var callbacks = mutableListOf<ProxyCallback<Data, Op, T>>()
     private var proxyMessages = mutableListOf<ProxyMessage<Data, Op, T>>()
 


### PR DESCRIPTION
Remove use of blocking reentrant mutex in the storage fake.
Update deadlock test:
- The previous op we were sending to StorageProxy was not guaranteed to
unblock any waiting readers.
- Clarify the context we launch async operations in.