### PR TITLE
Rename mutex guardWith checker to guardedBy.

### DIFF
--- a/java/arcs/android/common/resurrection/ResurrectorService.kt
+++ b/java/arcs/android/common/resurrection/ResurrectorService.kt
@@ -17,7 +17,7 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.annotation.VisibleForTesting
 import arcs.core.storage.StorageKey
-import arcs.core.util.guardWith
+import arcs.core.util.guardedBy
 import java.io.PrintWriter
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
@@ -44,9 +44,9 @@ abstract class ResurrectorService : Service() {
 
     private val mutex = Mutex()
     private var registeredRequests: Set<ResurrectionRequest>
-        by guardWith(mutex, setOf())
+        by guardedBy(mutex, setOf())
     private var registeredRequestsByNotifiers: Map<StorageKey?, Set<ResurrectionRequest>>
-        by guardWith(mutex, mapOf())
+        by guardedBy(mutex, mapOf())
     @VisibleForTesting var loadJob: Job? = null
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {

--- a/java/arcs/android/storage/database/AndroidSqliteDatabaseFactory.kt
+++ b/java/arcs/android/storage/database/AndroidSqliteDatabaseFactory.kt
@@ -14,7 +14,7 @@ package arcs.android.storage.database
 import android.content.Context
 import arcs.core.storage.database.Database
 import arcs.core.storage.database.DatabaseFactory
-import arcs.core.util.guardWith
+import arcs.core.util.guardedBy
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
@@ -25,7 +25,7 @@ import kotlinx.coroutines.sync.withLock
 class AndroidSqliteDatabaseFactory(context: Context) : DatabaseFactory {
     private val context = context.applicationContext
     private val mutex = Mutex()
-    private val dbCache by guardWith(mutex, mutableMapOf<Pair<String, Boolean>, Database>())
+    private val dbCache by guardedBy(mutex, mutableMapOf<Pair<String, Boolean>, Database>())
 
     override suspend fun getDatabase(name: String, persistent: Boolean): Database = mutex.withLock {
         dbCache[name to persistent]

--- a/java/arcs/android/storage/database/DatabaseImpl.kt
+++ b/java/arcs/android/storage/database/DatabaseImpl.kt
@@ -35,7 +35,7 @@ import arcs.core.storage.StorageKeyParser
 import arcs.core.storage.database.Database
 import arcs.core.storage.database.DatabaseClient
 import arcs.core.storage.database.DatabaseData
-import arcs.core.util.guardWith
+import arcs.core.util.guardedBy
 import kotlin.reflect.KClass
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -75,7 +75,7 @@ class DatabaseImpl(
     private val mutex = Mutex()
 
     /** Maps from schema hash to type ID (local copy of the 'types' table). */
-    private val schemaTypeMap by guardWith(mutex, ::loadTypes)
+    private val schemaTypeMap by guardedBy(mutex, ::loadTypes)
 
     override fun onCreate(db: SQLiteDatabase) = db.transaction {
         CREATE.forEach(db::execSQL)

--- a/java/arcs/core/storage/StorageProxy.kt
+++ b/java/arcs/core/storage/StorageProxy.kt
@@ -16,7 +16,7 @@ import arcs.core.crdt.CrdtModel
 import arcs.core.crdt.CrdtOperation
 import arcs.core.crdt.VersionMap
 import arcs.core.util.TaggedLog
-import arcs.core.util.guardWith
+import arcs.core.util.guardedBy
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
@@ -41,15 +41,15 @@ class StorageProxy<Data : CrdtData, Op : CrdtOperation, T>(
 
     private val handlesMutex = Mutex()
     private val readHandles
-        by guardWith<MutableSet<Handle<Data, Op, T>>>(handlesMutex, mutableSetOf())
+        by guardedBy<MutableSet<Handle<Data, Op, T>>>(handlesMutex, mutableSetOf())
 
     private val syncMutex = Mutex()
     private val crdt
-        by guardWith(syncMutex, initialCrdt)
+        by guardedBy(syncMutex, initialCrdt)
     private val waitingSyncs
-        by guardWith(syncMutex, mutableListOf<CompletableDeferred<ValueAndVersion<T>>>())
+        by guardedBy(syncMutex, mutableListOf<CompletableDeferred<ValueAndVersion<T>>>())
     private var synchronized
-        by guardWith(syncMutex, false)
+        by guardedBy(syncMutex, false)
 
     private val store = storeEndpointProvider.getStorageEndpoint()
 

--- a/java/arcs/core/storage/api/ArcsSet.kt
+++ b/java/arcs/core/storage/api/ArcsSet.kt
@@ -26,7 +26,7 @@ import arcs.core.storage.StoreOptions
 import arcs.core.storage.referencemode.RefModeStoreData
 import arcs.core.storage.referencemode.RefModeStoreOp
 import arcs.core.storage.referencemode.ReferenceModeStorageKey
-import arcs.core.util.guardWith
+import arcs.core.util.guardedBy
 import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CompletableJob
@@ -143,9 +143,9 @@ class ArcsSet<T, StoreData, StoreOp>(
     val actor: Actor by lazy { "ArcsSet@${hashCode()}" }
 
     private val crdtMutex = Mutex()
-    private val crdtSet by guardWith(crdtMutex, CrdtSet<T>())
-    private var cachedVersion by guardWith(crdtMutex, VersionMap())
-    private var cachedConsumerData by guardWith(crdtMutex, emptySet<T>())
+    private val crdtSet by guardedBy(crdtMutex, CrdtSet<T>())
+    private var cachedVersion by guardedBy(crdtMutex, VersionMap())
+    private var cachedConsumerData by guardedBy(crdtMutex, emptySet<T>())
     private val scope = CoroutineScope(coroutineContext)
     private val initialized: CompletableJob = Job(scope.coroutineContext[Job.Key])
     private var syncJob: CompletableJob? = null

--- a/java/arcs/core/storage/api/ArcsSingleton.kt
+++ b/java/arcs/core/storage/api/ArcsSingleton.kt
@@ -25,7 +25,7 @@ import arcs.core.storage.referencemode.RefModeStoreData
 import arcs.core.storage.referencemode.RefModeStoreOp
 import arcs.core.storage.referencemode.ReferenceModeStorageKey
 import arcs.core.util.TaggedLog
-import arcs.core.util.guardWith
+import arcs.core.util.guardedBy
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.coroutineContext
 import kotlinx.coroutines.CompletableDeferred
@@ -152,13 +152,13 @@ class ArcsSingleton<T, StoreData, StoreOp>(
 
     private val scope = CoroutineScope(coroutineContext)
     private val crdtMutex = Mutex()
-    private val crdtSingleton by guardWith(crdtMutex, CrdtSingleton<T>())
-    private var cachedVersion by guardWith(crdtMutex, VersionMap())
+    private val crdtSingleton by guardedBy(crdtMutex, CrdtSingleton<T>())
+    private var cachedVersion by guardedBy(crdtMutex, VersionMap())
     @Suppress("RemoveExplicitTypeArguments")
-    private var cachedConsumerData: T? by guardWith<T?>(crdtMutex, null)
+    private var cachedConsumerData: T? by guardedBy<T?>(crdtMutex, null)
     private val initialized: CompletableJob = Job(scope.coroutineContext[Job])
     @Suppress("RemoveExplicitTypeArguments")
-    private var syncJob: CompletableJob? by guardWith<CompletableJob?>(crdtMutex, null)
+    private var syncJob: CompletableJob? by guardedBy<CompletableJob?>(crdtMutex, null)
     private var callbackId: Int = -1
     private val activated =
         CompletableDeferred<ActiveStore<StoreData, StoreOp, T>>(initialized)

--- a/java/arcs/core/storage/driver/Database.kt
+++ b/java/arcs/core/storage/driver/Database.kt
@@ -34,7 +34,7 @@ import arcs.core.storage.referencemode.toReferenceSet
 import arcs.core.storage.referencemode.toReferenceSingleton
 import arcs.core.util.Random
 import arcs.core.util.TaggedLog
-import arcs.core.util.guardWith
+import arcs.core.util.guardedBy
 import kotlin.reflect.KClass
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -177,8 +177,8 @@ class DatabaseDriver<Data : Any>(
     /* internal */ var receiver: (suspend (data: Data, version: Int) -> Unit)? = null
     /* internal */ val clientId: Int = database.addClient(this)
     private val localDataMutex = Mutex()
-    private var localData: Data? by guardWith<Data?>(localDataMutex, null)
-    private var localVersion: Int? by guardWith<Int?>(localDataMutex, null)
+    private var localData: Data? by guardedBy<Data?>(localDataMutex, null)
+    private var localVersion: Int? by guardedBy<Int?>(localDataMutex, null)
     private val schema: Schema
         get() = checkNotNull(schemaLookup(storageKey.entitySchemaHash)) {
             "Schema not found for hash: ${storageKey.entitySchemaHash}"

--- a/java/arcs/core/util/Guard.kt
+++ b/java/arcs/core/util/Guard.kt
@@ -17,7 +17,7 @@ import kotlinx.coroutines.sync.Mutex
  * ```kotlin
  * class MyClass {
  *     val mutex = Mutex()
- *     var myProtectedString: String by guardWith(mutex) { "Hello world." }
+ *     var myProtectedString: String by guardedBy(mutex) { "Hello world." }
  *
  *     suspend fun succeed() {
  *         val randomNum = Random.nextInt()
@@ -31,7 +31,7 @@ import kotlinx.coroutines.sync.Mutex
  * }
  * ```
  */
-fun <T> guardWith(mutex: Mutex, initialValue: () -> T) = Guard(mutex, initialValue)
+fun <T> guardedBy(mutex: Mutex, initialValue: () -> T) = Guard(mutex, initialValue)
 
 /**
  * Builds a [Guard] property delegate where all access/mutation to the delegated property must be
@@ -44,7 +44,7 @@ fun <T> guardWith(mutex: Mutex, initialValue: () -> T) = Guard(mutex, initialVal
  * ```kotlin
  * class MyClass {
  *     val mutex = Mutex()
- *     var myProtectedString: String by guardWith(mutex, "Hello world.")
+ *     var myProtectedString: String by guardedBy(mutex, "Hello world.")
  *
  *     suspend fun succeed() {
  *         val randomNum = Random.nextInt()
@@ -58,7 +58,7 @@ fun <T> guardWith(mutex: Mutex, initialValue: () -> T) = Guard(mutex, initialVal
  * }
  * ```
  */
-fun <T> guardWith(mutex: Mutex, initialValue: T) = Guard(mutex) { initialValue }
+fun <T> guardedBy(mutex: Mutex, initialValue: T) = Guard(mutex) { initialValue }
 
 /** Provider of the [GuardDelegate] property delegate. */
 class Guard<T>(private val mutex: Mutex, private val initialValue: () -> T) {

--- a/java/arcs/core/util/performance/PerformanceStatistics.kt
+++ b/java/arcs/core/util/performance/PerformanceStatistics.kt
@@ -12,7 +12,7 @@
 package arcs.core.util.performance
 
 import arcs.core.util.RunningStatistics
-import arcs.core.util.guardWith
+import arcs.core.util.guardedBy
 import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
@@ -33,8 +33,8 @@ class PerformanceStatistics private constructor(
     initialStats: Snapshot = Snapshot(counterNames)
 ) {
     private val mutex = Mutex()
-    private val runtimeStats by guardWith(mutex, RunningStatistics(initialStats.runtimeStatistics))
-    private val counters by guardWith(mutex, CounterStatistics(initialStats.countStatistics))
+    private val runtimeStats by guardedBy(mutex, RunningStatistics(initialStats.runtimeStatistics))
+    private val counters by guardedBy(mutex, CounterStatistics(initialStats.countStatistics))
 
     /**
      * Creates a [PerformanceStatistics] object.

--- a/java/arcs/jvm/storage/database/testutil/MockDatabaseFactory.kt
+++ b/java/arcs/jvm/storage/database/testutil/MockDatabaseFactory.kt
@@ -18,7 +18,7 @@ import arcs.core.storage.database.Database
 import arcs.core.storage.database.DatabaseClient
 import arcs.core.storage.database.DatabaseData
 import arcs.core.storage.database.DatabaseFactory
-import arcs.core.util.guardWith
+import arcs.core.util.guardedBy
 import kotlin.coroutines.coroutineContext
 import kotlin.reflect.KClass
 import kotlinx.coroutines.CoroutineScope
@@ -35,7 +35,7 @@ import kotlinx.coroutines.sync.withLock
 class MockDatabaseFactory : DatabaseFactory {
     private val mutex = Mutex()
     private val cache: MutableMap<Pair<String, Boolean>, Database>
-        by guardWith(mutex, mutableMapOf())
+        by guardedBy(mutex, mutableMapOf())
 
     override suspend fun getDatabase(name: String, persistent: Boolean): Database = mutex.withLock {
         cache[name to persistent]

--- a/javatests/arcs/android/host/ArcHostHelperTest.kt
+++ b/javatests/arcs/android/host/ArcHostHelperTest.kt
@@ -36,7 +36,7 @@ import arcs.core.data.SchemaName
 import arcs.core.host.ArcHost
 import arcs.core.host.ParticleIdentifier
 import arcs.core.storage.driver.VolatileStorageKey
-import arcs.core.util.guardWith
+import arcs.core.util.guardedBy
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
@@ -59,9 +59,9 @@ class ArcHostHelperTest {
 
     class TestArcHost : ArcHost {
         private val hostMutex = Mutex()
-        var startArcCalls: MutableList<PlanPartition> by guardWith(hostMutex, mutableListOf())
-        var stopArcCalls: MutableList<PlanPartition> by guardWith(hostMutex, mutableListOf())
-        var registeredParticles: MutableList<ParticleIdentifier> by guardWith(
+        var startArcCalls: MutableList<PlanPartition> by guardedBy(hostMutex, mutableListOf())
+        var stopArcCalls: MutableList<PlanPartition> by guardedBy(hostMutex, mutableListOf())
+        var registeredParticles: MutableList<ParticleIdentifier> by guardedBy(
             hostMutex, mutableListOf()
         )
 

--- a/javatests/arcs/core/util/GuardTest.kt
+++ b/javatests/arcs/core/util/GuardTest.kt
@@ -10,18 +10,18 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
-/** Tests for the [guardWith]-generated property delegate: [GuardDelegate]. */
+/** Tests for the [guardedBy]-generated property delegate: [GuardDelegate]. */
 @ExperimentalCoroutinesApi
 @RunWith(JUnit4::class)
 class GuardTest {
     class RequiresLocking(initialValue: Int = 0) {
         val mutex = Mutex()
-        var value by guardWith(mutex) { initialValue }
+        var value by guardedBy(mutex) { initialValue }
     }
 
     class LazyTestClass(initialValue: () -> Int) {
         val mutex = Mutex()
-        var value: Int by guardWith(mutex, initialValue)
+        var value: Int by guardedBy(mutex, initialValue)
     }
 
     @Test
@@ -69,7 +69,7 @@ class GuardTest {
         var initializerCalled = false
         class NullableValue {
             val mutex = Mutex()
-            var value: Int? by guardWith(mutex) {
+            var value: Int? by guardedBy(mutex) {
                 initializerCalled = true
                 1
             }


### PR DESCRIPTION
This clarifies that the delegate only checks mutex state, not actually
acquiring the mutex itself. This feedback came from internal readability
review.