### PR TITLE
Ensure VersionMap is actually copied.

### DIFF
--- a/java/arcs/core/crdt/VersionMap.kt
+++ b/java/arcs/core/crdt/VersionMap.kt
@@ -42,7 +42,8 @@ class VersionMap(initialData: Map<Actor, Version> = emptyMap()) {
     fun isNotEmpty(): Boolean = !isEmpty()
 
     /** Creates a deep copy of this [VersionMap]. */
-    fun copy(): VersionMap = VersionMap(this)
+    // toMutableMap is documented to copy the data.
+    fun copy(): VersionMap = VersionMap(this.backingMap.toMutableMap())
 
     /**
      * Gets a the current [Version] for a given [Actor], or [DEFAULT_VERSION] if no value has been

--- a/javatests/arcs/core/crdt/VersionMapTest.kt
+++ b/javatests/arcs/core/crdt/VersionMapTest.kt
@@ -241,4 +241,16 @@ class VersionMapTest {
         assertThat(difference["bob"]).isEqualTo(1337)
         assertThat(difference["alice"]).isEqualTo(0)
     }
+
+    @Test
+    fun versionMapCopyIsActuallyCopied() {
+        val a = VersionMap()
+        a["alice"]++
+
+        val b = a.copy()
+        a["alice"]++
+
+        var difference = a - b
+        assertThat(difference["alice"]).isEqualTo(1)
+    }
 }


### PR DESCRIPTION
The previous implementation was not guaranteed to do so,
this version is documented to be making a copy of the underlying data.