### PR TITLE
Adds missing memoryProvider in Runtime.parseFile.

### DIFF
--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -270,7 +270,7 @@ export class Runtime {
 
   async parseFile(path: string, options?): Promise<Manifest> {
     const content = await this.loader.loadResource(path);
-    const opts = {id: path, fileName: path, loader: this.loader, ...options};
+    const opts = {id: path, fileName: path, loader: this.loader, memoryProvider: this.memoryProvider, ...options};
     return this.parse(content, opts);
   }
 


### PR DESCRIPTION
Fixes a parse error when storageNG is enabled. This was causing a bug in the schema2kotlin code generator:

```
ERROR: /usr/local/google/home/csilvestrini/code/arcs/javatests/arcs/sdk/wasm/BUILD:26:1: Couldn't build file javatests/arcs/sdk/wasm/manifest_GeneratedSchemas.jvm.kt: error executing shell command: '/bin/bash -c bazel-out/k8-fastbuild/bin/javatests/arcs/sdk/wasm/manifest_genrule_jvm.sh' failed (Exit 1)
{ Error: Creating ram disk stores requires having a memory provider.
    at Function._processStore (file:///usr/local/google/home/csilvestrini/code/arcs/build/runtime/manifest.js:1145:27)
    at item (file:///usr/local/google/home/csilvestrini/code/arcs/build/runtime/manifest.js:450:58)
    at processItems (file:///usr/local/google/home/csilvestrini/code/arcs/build/runtime/manifest.js:436:31)
    at Function.parse (file:///usr/local/google/home/csilvestrini/code/arcs/build/runtime/manifest.js:450:19)
  severity: 'error',
  location:
   { start: { offset: 837, line: 29, column: 1 },
     end: { offset: 885, line: 31, column: 1 } } }
😱 FAILURE
bazel-out/k8-fastbuild/bin/javatests/arcs/sdk/wasm/manifest_GeneratedSchemas.jvm.kt
```