### PR TITLE
Switch onUpdateActions in singletons to val

### DIFF
--- a/java/arcs/sdk/jvm/SingletonImpl.kt
+++ b/java/arcs/sdk/jvm/SingletonImpl.kt
@@ -20,7 +20,7 @@ class SingletonImpl<T : Entity>(
     entitySpec: EntitySpec<T>
 ) : ReadWriteSingleton<T> {
     private var entity: T? = null
-    private var onUpdateActions: MutableList<(T?) -> Unit> = mutableListOf()
+    private val onUpdateActions: MutableList<(T?) -> Unit> = mutableListOf()
 
     override fun fetch(): T? = entity
 

--- a/java/arcs/sdk/wasm/WasmSingletonImpl.kt
+++ b/java/arcs/sdk/wasm/WasmSingletonImpl.kt
@@ -21,7 +21,7 @@ class WasmSingletonImpl<T : WasmEntity>(
 ) : WasmHandle<T>(name, particle), ReadWriteSingleton<T> {
 
     private var entity: T? = null
-    private var onUpdateActions: MutableList<(T?) -> Unit> = mutableListOf()
+    private val onUpdateActions: MutableList<(T?) -> Unit> = mutableListOf()
 
     override fun sync(encoded: ByteArray) {
         entity = if (encoded.size > 0) entitySpec.decode(encoded) else null


### PR DESCRIPTION
In implementing the onUpdate method for collections, I realized this should be a val not a var.