### PR TITLE
Remove iterator from collection in favour of fetchAll

### DIFF
--- a/java/arcs/sdk/Handle.kt
+++ b/java/arcs/sdk/Handle.kt
@@ -37,7 +37,10 @@ interface WritableSingleton<T : Entity> : Handle {
 interface ReadWriteSingleton<T : Entity> : ReadableSingleton<T>, WritableSingleton<T>
 
 /** A collection handle with read access. */
-interface ReadableCollection<T : Entity> : Handle, Iterable<T> {
+interface ReadableCollection<T : Entity> : Handle {
+    /** Returns the values of all entities in the collection. */
+    fun fetchAll(): Iterable<T>
+
     /** The number of elements in the collection. */
     val size: Int
 

--- a/java/arcs/sdk/jvm/CollectionImpl.kt
+++ b/java/arcs/sdk/jvm/CollectionImpl.kt
@@ -26,7 +26,7 @@ class CollectionImpl<T : Entity>(
 
     override fun isEmpty(): Boolean = entities.isEmpty()
 
-    override fun iterator(): Iterator<T> = entities.iterator()
+    override fun fetchAll(): Iterable<T> = entities
 
     override fun store(entity: T) {
         entities.add(entity)

--- a/java/arcs/sdk/wasm/WasmCollectionImpl.kt
+++ b/java/arcs/sdk/wasm/WasmCollectionImpl.kt
@@ -25,7 +25,7 @@ class WasmCollectionImpl<T : WasmEntity>(
     override val size: Int
         get() = entities.size
 
-    override fun iterator() = entities.values.iterator()
+    override fun fetchAll() = entities.values
 
     override fun sync(encoded: ByteArray) {
         entities.clear()

--- a/javatests/arcs/sdk/jvm/CollectionImplTest.kt
+++ b/javatests/arcs/sdk/jvm/CollectionImplTest.kt
@@ -43,7 +43,7 @@ class CollectionImplTest {
         assertThat(collection.name).isEqualTo(HANDLE_NAME)
         assertThat(collection.size).isEqualTo(0)
         assertThat(collection.isEmpty()).isTrue()
-        assertThat(collection.toList()).isEmpty()
+        assertThat(collection.fetchAll()).isEmpty()
     }
 
     @Test
@@ -52,7 +52,7 @@ class CollectionImplTest {
 
         assertThat(collection.size).isEqualTo(1)
         assertThat(collection.isEmpty()).isFalse()
-        assertThat(collection.toList()).containsExactly(DUMMY_VALUE1)
+        assertThat(collection.fetchAll()).containsExactly(DUMMY_VALUE1)
     }
 
     @Test
@@ -62,7 +62,7 @@ class CollectionImplTest {
 
         assertThat(collection.size).isEqualTo(2)
         assertThat(collection.isEmpty()).isFalse()
-        assertThat(collection.toList()).containsExactly(DUMMY_VALUE1, DUMMY_VALUE2)
+        assertThat(collection.fetchAll()).containsExactly(DUMMY_VALUE1, DUMMY_VALUE2)
     }
 
     @Test
@@ -80,7 +80,7 @@ class CollectionImplTest {
 
         assertThat(collection.size).isEqualTo(1)
         assertThat(collection.isEmpty()).isFalse()
-        assertThat(collection.toList()).containsExactly(DUMMY_VALUE1)
+        assertThat(collection.fetchAll()).containsExactly(DUMMY_VALUE1)
     }
 
     @Test
@@ -98,7 +98,7 @@ class CollectionImplTest {
 
         assertThat(collection.size).isEqualTo(0)
         assertThat(collection.isEmpty()).isTrue()
-        assertThat(collection.toList()).isEmpty()
+        assertThat(collection.fetchAll()).isEmpty()
     }
 
     @Test

--- a/javatests/arcs/sdk/wasm/CollectionApiTest.kt
+++ b/javatests/arcs/sdk/wasm/CollectionApiTest.kt
@@ -32,7 +32,7 @@ class CollectionApiTest : AbstractCollectionApiTest() {
             }
             "case4" -> {
                 val d1 = CollectionApiTest_OutHandle()
-                val iter = handles.inHandle.iterator()
+                val iter = handles.inHandle.fetchAll().iterator()
                 val flg = iter.hasNext()
                 val i1 = iter.next()
                 handles.outHandle.store(d1.copy(
@@ -70,7 +70,7 @@ class CollectionApiTest : AbstractCollectionApiTest() {
                 handles.outHandle.store(d2)
 
                 // Ranged iteration; order is not guaranteed so use 'num' to assign sorted array slots.
-                val sorted = handles.ioHandle.sortedBy { it.num.toInt() }
+                val sorted = handles.ioHandle.fetchAll().sortedBy { it.num.toInt() }
                 sorted.forEach {
                     handles.outHandle.store(CollectionApiTest_OutHandle(
                         num = it.num,

--- a/javatests/arcs/sdk/wasm/EntitySlicingTest.kt
+++ b/javatests/arcs/sdk/wasm/EntitySlicingTest.kt
@@ -23,13 +23,13 @@ class EntitySlicingTest : AbstractEntitySlicingTest() {
         handles.s2.fetch()?.let { handles.res.store(Res("s2:${it.num.toInt()},${it.txt}")) }
         handles.s3.fetch()?.let { handles.res.store(Res("s3:${it.num.toInt()},${it.txt},${it.flg}")) }
 
-        for (e in handles.c1) {
+        for (e in handles.c1.fetchAll()) {
             handles.res.store(Res("c1:${e.num.toInt()}"))
         }
-        for (e in handles.c2) {
+        for (e in handles.c2.fetchAll()) {
             handles.res.store(Res("c2:${e.num.toInt()},${e.txt}"))
         }
-        for (e in handles.c3) {
+        for (e in handles.c3.fetchAll()) {
             handles.res.store(Res("c3:${e.num.toInt()},${e.txt},${e.flg}"))
         }
     }

--- a/javatests/arcs/sdk/wasm/HandleSyncUpdateTest.kt
+++ b/javatests/arcs/sdk/wasm/HandleSyncUpdateTest.kt
@@ -28,7 +28,8 @@ class HandleSyncUpdateTest : AbstractHandleSyncUpdateTest() {
         if (handle.name == "sng") {
             num = handles.sng.fetch()?.num ?: -1.0
         } else if (handle.name == "col") {
-            num = if (handles.col.size > 0) handles.col.iterator().next().num else -1.0
+            // TODO(cypher1): This is unsafe, there is no guarantee of ordering.
+            num = if (handles.col.size > 0) handles.col.fetchAll().iterator().next().num else -1.0
         } else {
             txt = "unexpected handle name: ${handle.name}"
         }

--- a/javatests/arcs/sdk/wasm/TestBase.kt
+++ b/javatests/arcs/sdk/wasm/TestBase.kt
@@ -30,7 +30,7 @@ open class TestBase<T : WasmEntity>(
             fail("expected container to have ${expected.size} items; actual size ${container.size}")
 
         // Convert result values to strings and sort them when checking an unordered container.
-        val converted = container.map(converter)
+        val converted = container.fetchAll().map(converter)
         val res = if (isOrdered) converted else converted.sorted()
 
         val comparison = expected zip res

--- a/javatests/arcs/sdk/wasm/UnicodeTest.kt
+++ b/javatests/arcs/sdk/wasm/UnicodeTest.kt
@@ -19,7 +19,8 @@ class UnicodeTest : AbstractUnicodeTest() {
         val pass = if (handle.name == "sng") {
             ((handle as WasmSingletonImpl<*>).fetch() as UnicodeTest_Sng).pass
         } else {
-            ((handle as WasmCollectionImpl<*>).iterator().next() as UnicodeTest_Col).pass
+            // TODO(cypher1): This is unsafe, there is no guarantee of ordering.
+            ((handle as WasmCollectionImpl<*>).fetchAll().iterator().next() as UnicodeTest_Col).pass
         }
         handles.res.store(out.copy(pass = pass))
     }

--- a/particles/Blackjack/Dealer.kt
+++ b/particles/Blackjack/Dealer.kt
@@ -23,7 +23,9 @@ class Dealer : AbstractDealer() {
         """.trimIndent()
 
     override fun populateModel(slotName: String, model: Map<String, Any>): Map<String, Any> {
-        val desc = handles.hand.joinToString(separator = ":") { Card.cardDesc(it.value.toInt()) }
+        val desc = handles.hand.fetchAll().joinToString(separator = ":") {
+            Card.cardDesc(it.value.toInt())
+        }
         return model + mapOf("hand" to desc)
     }
 

--- a/particles/Blackjack/Player.kt
+++ b/particles/Blackjack/Player.kt
@@ -23,7 +23,7 @@ class Player : AbstractPlayer() {
          """.trimIndent()
 
     override fun populateModel(slotName: String, model: Map<String, Any>): Map<String, Any> {
-        val desc = handles.hand.joinToString(separator = ":") { card ->
+        val desc = handles.hand.fetchAll().joinToString(separator = ":") { card ->
             Card.cardDesc(card.value.toInt())
         }
         return model + mapOf("hand" to desc)

--- a/particles/Native/Wasm/source/TestParticle.kt
+++ b/particles/Native/Wasm/source/TestParticle.kt
@@ -38,7 +38,7 @@ class TestParticle : AbstractTestParticle() {
         var infoStr = "Size: ${handles.info.size}\n"
         if (!handles.info.isEmpty()) {
             var i = 0
-            handles.info.forEach { info ->
+            handles.info.fetchAll().forEach { info ->
                 infoStr += "${(++i)}. $info | \n"
             }
         } else {
@@ -132,7 +132,7 @@ class TestParticle : AbstractTestParticle() {
         }
 
         eventHandler("remove") {
-            val iterator = handles.info.iterator()
+            val iterator = handles.info.fetchAll().iterator()
             if (iterator.hasNext()) {
                 handles.info.remove(iterator.next())
             }

--- a/particles/Tutorial/Kotlin/5_Collections/Collections.kt
+++ b/particles/Tutorial/Kotlin/5_Collections/Collections.kt
@@ -17,7 +17,7 @@ package arcs.tutorials
 class Collections : AbstractCollections() {
     override fun populateModel(slotName: String, model: Map<String, Any>): Map<String, Any> {
         val peopleList = mutableListOf<Map<String, Comparable<*>?>>()
-        handles.inputData.forEach { people ->
+        handles.inputData.fetchAll().forEach { people ->
             peopleList.add(mapOf("name" to people.name, "age" to people.age))
         }
 

--- a/particles/Tutorial/Kotlin/Demo/src/pt2/TTTHumanPlayer.kt
+++ b/particles/Tutorial/Kotlin/Demo/src/pt2/TTTHumanPlayer.kt
@@ -18,7 +18,7 @@ class TTTHumanPlayer : AbstractTTTHumanPlayer() {
         if (handles.events.size <= 0) return
 
         // Get the element with the largest time as this will be the most recent.
-        val event = handles.events.sortedBy { it.time }.last()
+        val event = handles.events.fetchAll().sortedBy { it.time }.last()
         // Set the move
         if (event.type == "move" && event.time > -1.0) {
             handles.myMove.set(TTTHumanPlayer_MyMove(event.move))

--- a/particles/Tutorial/Kotlin/Demo/src/pt3/TTTHumanPlayer.kt
+++ b/particles/Tutorial/Kotlin/Demo/src/pt3/TTTHumanPlayer.kt
@@ -19,7 +19,7 @@ class TTTHumanPlayer : AbstractTTTHumanPlayer() {
           || handles.gameState.fetch()?.currentPlayer != handles.player.fetch()?.id) return
 
         // Get the element with the largest time as this will be the most recent.
-        val event = handles.events.sortedBy { it.time }.last()
+        val event = handles.events.fetchAll().sortedBy { it.time }.last()
         // Set the move
         if (event.type == "move") {
             handles.myMove.set(TTTHumanPlayer_MyMove(event.move))

--- a/particles/Tutorial/Kotlin/Demo/src/pt4/TTTGame.kt
+++ b/particles/Tutorial/Kotlin/Demo/src/pt4/TTTGame.kt
@@ -141,7 +141,7 @@ class TTTGame : AbstractTTTGame() {
         ))
     }
 
-    private fun hasReset() = handles.events.any { it.type == "reset" }
+    private fun hasReset() = handles.events.fetchAll().any { it.type == "reset" }
 
     private fun Int.isValidMove(boardList: List<String>) = this in 0..9 && boardList[this] == ""
 }

--- a/particles/Tutorial/Kotlin/Demo/src/pt4/TTTHumanPlayer.kt
+++ b/particles/Tutorial/Kotlin/Demo/src/pt4/TTTHumanPlayer.kt
@@ -19,7 +19,7 @@ class TTTHumanPlayer : AbstractTTTHumanPlayer() {
           || handles.gameState.fetch()?.currentPlayer != handles.player.fetch()?.id) return
 
         // Get the element with the largest time as this will be the most recent.
-        val event = handles.events.sortedBy { it.time }.last()
+        val event = handles.events.fetchAll().sortedBy { it.time }.last()
         // Set the move
         if (event.type == "move") {
             handles.myMove.set(TTTHumanPlayer_MyMove(event.move))

--- a/particles/Tutorial/Kotlin/Demo/src/total/TTTGame.kt
+++ b/particles/Tutorial/Kotlin/Demo/src/total/TTTGame.kt
@@ -141,7 +141,7 @@ class TTTGame : AbstractTTTGame() {
         ))
     }
 
-    private fun hasReset() = handles.events.any { it.type == "reset" }
+    private fun hasReset() = handles.events.fetchAll().any { it.type == "reset" }
 
     private fun Int.isValidMove(boardList: List<String>) = this in 0..9 && boardList[this] == ""
 }

--- a/particles/Tutorial/Kotlin/Demo/src/total/TTTHumanPlayer.kt
+++ b/particles/Tutorial/Kotlin/Demo/src/total/TTTHumanPlayer.kt
@@ -19,7 +19,7 @@ class TTTHumanPlayer : AbstractTTTHumanPlayer() {
                 || handles.gameState.fetch()?.currentPlayer != handles.player.fetch()?.id) return
 
         // Get the element with the largest time as this will be the most recent.
-        val event = handles.events.sortedBy { it.time }.last()
+        val event = handles.events.fetchAll().sortedBy { it.time }.last()
         // Set the move
         if (event.type == "move") {
             handles.myMove.set(TTTHumanPlayer_MyMove(event.move))


### PR DESCRIPTION
This is a step towards moving from `arcs.sdk.jvm.CollectionImpl` to `arcs.core.storage.handle.CollectionImpl` and  `arcs.sdk.jvm.SingletonImpl` to `arcs.core.storage.handle.SingletonImpl`.