### PR TITLE
Make added and removed props lists in onUpdate.

### DIFF
--- a/src/runtime/storageNG/handle.ts
+++ b/src/runtime/storageNG/handle.ts
@@ -359,12 +359,12 @@ export class CollectionHandle<T> extends Handle<CRDTCollectionTypeRecord<Referen
       return this.onSync(set);
     }
     // Pass the change up to the particle.
-    const update: {added?: Entity, removed?: Entity, originator: boolean} = {originator: ('actor' in op && this.key === op.actor)};
+    const update: {added?: Entity[], removed?: Entity[], originator: boolean} = {originator: ('actor' in op && this.key === op.actor)};
     if (op.type === CollectionOpTypes.Add) {
-      update.added = this.serializer.deserialize(op.added, this.storageProxy.storageKey);
+      update.added = [this.serializer.deserialize(op.added, this.storageProxy.storageKey)];
     }
     if (op.type === CollectionOpTypes.Remove) {
-      update.removed = this.serializer.deserialize(op.removed, this.storageProxy.storageKey);
+      update.removed = [this.serializer.deserialize(op.removed, this.storageProxy.storageKey)];
     }
     if (this.particle) {
       await this.particle.callOnHandleUpdate(

--- a/src/runtime/storageNG/tests/handle-test.ts
+++ b/src/runtime/storageNG/tests/handle-test.ts
@@ -200,7 +200,7 @@ describe('CollectionHandle', async () => {
       clock: {'actor': 1}
     };
     await handle.onUpdate(op, {'actor': 1, 'other': 2});
-    assert.equal(Entity.id(particle.lastUpdate.removed), 'id');
+    assert.equal(Entity.id(particle.lastUpdate.removed[0]), 'id');
     assert.isFalse(particle.lastUpdate.originator);
   });
 

--- a/src/runtime/tests/reference-test.ts
+++ b/src/runtime/tests/reference-test.ts
@@ -153,14 +153,9 @@ describe('references', () => {
 
             async onHandleUpdate(handle, update) {
               if (handle.name == 'inResult') {
-                if (update.added.length) {
-                  for (const ref of update.added) {
-                    await ref.dereference();
-                    this.output.store(ref.entity);
-                  }
-                } else {
-                  await update.added.dereference();
-                  this.output.add(update.added.entity);
+                for (const ref of update.added) {
+                  await ref.dereference();
+                  this.output.add(ref.entity);
                 }
               }
             }


### PR DESCRIPTION
The old storage stack always delivers update.added and update.removed as
lists. StorageNG was delivering single entities. Updated to always
deliver a list to be consistent, and to fix a bug in wasm.