### PR TITLE
Fix wasm reference tests for storageNG.

### DIFF
--- a/src/runtime/reference.ts
+++ b/src/runtime/reference.ts
@@ -79,10 +79,10 @@ export class Reference implements Storable {
   }
 
   // Called by WasmParticle to retrieve the entity for a reference held in a wasm module.
-  static async retrieve(pec: ChannelConstructor, id: string, storageKey: string, entityType: EntityType) {
+  static async retrieve(pec: ChannelConstructor, id: string, storageKey: string, entityType: EntityType, particleId: string) {
     const proxy = await pec.getStorageProxy(storageKey, entityType);
     // tslint:disable-next-line: no-any
-    const handle = unifiedHandleFor({proxy, idGenerator: pec.idGenerator}) as CollectionHandle<any>;
+    const handle = unifiedHandleFor({proxy, idGenerator: pec.idGenerator, particleId}) as CollectionHandle<any>;
     return await handle.get(id);
   }
 }

--- a/src/runtime/wasm.ts
+++ b/src/runtime/wasm.ts
@@ -937,7 +937,7 @@ export class WasmParticle extends Particle {
     }
 
     const encoder = this.getEncoder(entityType);
-    const entity = await Reference.retrieve(this.container.pec, id, storageKey, entityType);
+    const entity = await Reference.retrieve(this.container.pec, id, storageKey, entityType, this.id);
 
     const p = this.container.storeBytes(await encoder.encodeSingleton(entity));
     this.exports._dereferenceResponse(this.innerParticle, continuationId, p);

--- a/src/wasm/tests/wasm-api-test.ts
+++ b/src/wasm/tests/wasm-api-test.ts
@@ -16,9 +16,15 @@ import {SlotTestObserver} from '../../runtime/testing/slot-test-observer.js';
 import {RuntimeCacheService} from '../../runtime/runtime-cache.js';
 import {VolatileCollection, VolatileSingleton, VolatileStorage} from '../../runtime/storage/volatile-storage.js';
 //import {assertThrowsAsync} from '../../testing/test-util.js';
-import {ReferenceType} from '../../runtime/type.js';
+import {ReferenceType, SingletonType, Type} from '../../runtime/type.js';
 import {Entity} from '../../runtime/entity.js';
 import {TestVolatileMemoryProvider} from '../../runtime/testing/test-volatile-memory-provider.js';
+import {Flags} from '../../runtime/flags.js';
+import {VolatileStorageKey} from '../../runtime/storageNG/drivers/volatile.js';
+import {Store} from '../../runtime/storageNG/store.js';
+import {Exists} from '../../runtime/storageNG/drivers/driver.js';
+import {Reference} from '../../runtime/reference.js';
+import {Arc} from '../../runtime/arc.js';
 
 // Import some service definition files for their side-effects (the services get
 // registered automatically).
@@ -49,8 +55,27 @@ const testMap = {
   'Kotlin': '../../javatests/arcs/sdk/wasm',
 };
 
+async function createBackingEntity(arc: Arc, referenceType: ReferenceType, id: string, entityData: {}): Promise<[string, Reference|{}]> {
+  assert(Flags.useNewStorageStack, 'createBackingEntity requires the new storage stack');
+  const backingStorageKey = new VolatileStorageKey(arc.id, '', id);
+  const baseType = referenceType.getContainedType();
+  const backingStore = new Store({
+    id: 'backing1',
+    storageKey: backingStorageKey,
+    type: new SingletonType(baseType),
+    exists: Exists.MayExist,
+  });
+  const backingHandle1 = await singletonHandleForTest(arc, backingStore);
+  const entity = await backingHandle1.setFromData(entityData);
+  const entityId = Entity.id(entity);
+  const reference = new Reference({id: entityId, entityStorageKey: backingStorageKey.toString()}, referenceType, null);
+  return [entityId, reference];
+}
+
+[false, true].forEach(useNewStorageStack => {
+
 Object.entries(testMap).forEach(([testLabel, testDir]) => {
-  describe(`wasm tests (${testLabel})`, () => {
+  describe(`wasm tests (${testLabel}) (useNewStorageStack = ${useNewStorageStack})`, () => {
     const isKotlin = testLabel === 'Kotlin';
     const isCpp = testLabel === 'C++';
 
@@ -60,6 +85,7 @@ Object.entries(testMap).forEach(([testLabel, testDir]) => {
       if (!global['testFlags'].bazel) {
         this.skip();
       } else {
+        Flags.useNewStorageStack = useNewStorageStack;
         loader = new TestLoader(testDir);
         VolatileStorage.setStorageCache(new RuntimeCacheService());
         manifestPromise = Manifest.parse(`import 'src/wasm/tests/manifest.arcs'`, {
@@ -68,6 +94,10 @@ Object.entries(testMap).forEach(([testLabel, testDir]) => {
           memoryProvider: new TestVolatileMemoryProvider()
         });
       }
+    });
+
+    after(() => {
+      Flags.reset();
     });
 
     async function setup(recipeName) {
@@ -244,7 +274,12 @@ Object.entries(testMap).forEach(([testLabel, testDir]) => {
     });
 
     // TODO - check that writing to read-only handles throws and vice versa
-    it('singleton storage API', async () => {
+    it('singleton storage API', async function() {
+      if (Flags.useNewStorageStack) {
+        // TODO(csilvestrini): Fix this test for storageNG.
+        this.skip();
+      }
+
       const {arc, stores} = await setup('SingletonApiTest');
       const inHandle = await singletonHandleForTest(arc, stores.get('inHandle'));
       const outHandle = await singletonHandleForTest(arc, stores.get('outHandle'));
@@ -339,11 +374,70 @@ Object.entries(testMap).forEach(([testLabel, testDir]) => {
     });
 
     // TODO: writing to reference-typed handles
-    // TODO: convert to the new storage access pattern (ie. using *HandleForTest and handle.entityClass)
-    it('reference-typed handles', async () => {
+    it('reference-typed handles - storageNG', async function() {
+      if (!Flags.useNewStorageStack) {
+        this.skip();
+      }
       // TODO(alxr): Remove when tests are ready
       if (isKotlin) {
         return;
+      }
+      const {arc, stores} = await setup('ReferenceHandlesTest');
+      const sng = await singletonHandleForTest(arc, stores.get('sng'));
+      const col = await collectionHandleForTest(arc, stores.get('col'));
+      const res = await collectionHandleForTest(arc, stores.get('res'));
+
+      assert.instanceOf(sng.type, SingletonType);
+      assert.instanceOf(sng.type.getContainedType(), ReferenceType);
+      assert.instanceOf(col.type.getContainedType(), ReferenceType);
+
+      // onHandleSync tests uninitialised reference handles.
+      assert.sameMembers((await res.toList()).map(e => e.txt), [
+        's::null',  // handle should just be null
+      ]);
+      await res.clear();
+
+      // onHandleUpdate tests populated references handles.
+      const referenceType = sng.type.getContainedType() as ReferenceType;
+      const [entityId1, reference1] = await createBackingEntity(arc, referenceType, 'id1', {num: 6, txt: 'ok'});
+      const [entityId2, reference2] = await createBackingEntity(arc, referenceType, 'id2', {num: 7, txt: 'ko'});
+
+      // Singleton
+      await sng.set(reference1);
+      await arc.idle;
+      assert.sameMembers((await res.toList()).map(e => e.txt), [
+        `s::before <${entityId1}> !{}`,                      // before dereferencing: contained entity is empty
+        `s::after <${entityId1}> {${entityId1}}, num: 6, txt: ok`     // after: entity is populated, ids should match
+      ]);
+      await res.clear();
+
+      // Collection
+      await col.add(reference1);
+      await arc.idle;
+      assert.sameMembers((await res.toList()).map(e => e.txt), [
+        `c::before <${entityId1}> !{}`,                      // ref to same entity as singleton; still empty in this handle
+        `c::after <${entityId1}> {${entityId1}}, num: 6, txt: ok`
+      ]);
+      await res.clear();
+
+      await col.add(reference2);
+      await arc.idle;
+      assert.sameMembers((await res.toList()).map(e => e.txt), [
+        `c::before <${entityId1}> {${entityId1}}, num: 6, txt: ok`,   // already populated by the previous deref
+        `c::after <${entityId1}> {${entityId1}}, num: 6, txt: ok`,
+        `c::before <${entityId2}> !{}`,
+        `c::after <${entityId2}> {${entityId2}}, num: 7, txt: ko`
+      ]);
+    });
+
+    // TODO: delete once storageNG is in.
+    it('reference-typed handles - storageOG', async function() {
+      if (Flags.useNewStorageStack) {
+        this.skip();
+      }
+      // TODO(alxr): Remove when tests are ready
+      if (isKotlin) {
+        this.skip();
       }
       const {arc, stores} = await setup('ReferenceHandlesTest');
       const sng = stores.get('sng') as VolatileSingleton;
@@ -394,8 +488,57 @@ Object.entries(testMap).forEach(([testLabel, testDir]) => {
     });
 
     // TODO: nested references
-    // TODO: convert to the new storage access pattern (ie. using *HandleForTest and handle.entityClass)
-    it('reference-typed schema fields', async () => {
+    it('reference-typed schema fields - storageNG', async function() {
+      if (!Flags.useNewStorageStack) {
+        this.skip();
+      }
+      // TODO(alxr): Remove when tests are ready
+      if (isKotlin) {
+        this.skip();
+      }
+      const {arc, stores} = await setup('SchemaReferenceFieldsTest');
+      const input = await singletonHandleForTest(arc, stores.get('input'));
+      const output = await singletonHandleForTest(arc, stores.get('output'));
+      const res = await collectionHandleForTest(arc, stores.get('res'));
+
+      // Uninitialised reference fields.
+      await input.set(new input.entityClass({num: 5}));
+      await arc.idle;
+
+      assert.sameMembers((await res.toList()).map(e => e.txt), [
+        'before <> !{}',  // no id or entity data; dereference is a no-op (no 'after' output)
+      ]);
+      await res.clear();
+
+      // Populated reference fields.
+      const entityType = input.type.getEntitySchema().fields.ref.schema.model;  // yikes
+      const refType = new ReferenceType(entityType);
+      const [childEntityId, childRef] = await createBackingEntity(arc, refType, 'id1', {val: 'v1'});
+
+      const parentEntity = new input.entityClass({num: 12, ref: childRef});
+      await input.set(parentEntity);
+      await arc.idle;
+
+      assert.sameMembers((await res.toList()).map(e => e.txt), [
+        `before <${childEntityId}> !{}`,            // before dereferencing: contained entity is empty
+        `after <${childEntityId}> {${childEntityId}}, val: v1`,  // after dereferencing: entity is populated, ids should match
+      ]);
+
+      // The particle clones 'input', binds to a new entity and writes that to 'output'.
+      // The ref field should have a storage key, but since this isn't deterministic we need to
+      // check for its presence then discard it.
+      const data = JSON.parse(JSON.stringify((await output.get())));
+      assert.isNotEmpty(data.ref.entityStorageKey);
+      assert.strictEqual(data.num, 12);
+      assert.strictEqual(data.txt, 'xyz');
+      assert.strictEqual(data.ref.id, 'foo1');
+    });
+
+    // TODO: delete once storageNG is in.
+    it('reference-typed schema fields - storageOG', async function() {
+      if (Flags.useNewStorageStack) {
+        this.skip();
+      }
       // TODO(alxr): Remove when tests are ready
       if (isKotlin) {
         return;
@@ -504,3 +647,5 @@ Object.entries(testMap).forEach(([testLabel, testDir]) => {
     });
   });
 });
+
+});  // forEach(useNewStorageStack)


### PR DESCRIPTION
I had to fork the test cases because so much of the code was different
between the old and new stacks.

Now running the tests with the flag both on and off, to prevent
regressions.

Down to only one failing test!! (skipped for now)