### PR TITLE
SingletonHandle.clear() now syncs before clearing

### DIFF
--- a/java/arcs/core/storage/handle/SingletonImpl.kt
+++ b/java/arcs/core/storage/handle/SingletonImpl.kt
@@ -43,6 +43,8 @@ class SingletonImpl<T : Referencable>(
 
     /** Clear the value from the backing [StorageProxy]. */
     suspend fun clear() {
+        // Sync before clearing (for a similar behaviour to collections).
+        fetch()
         storageProxy.applyOp(CrdtSingleton.Operation.Clear(name, versionMap))
     }
 }

--- a/java/arcs/core/storage/handle/SingletonImpl.kt
+++ b/java/arcs/core/storage/handle/SingletonImpl.kt
@@ -43,7 +43,8 @@ class SingletonImpl<T : Referencable>(
 
     /** Clear the value from the backing [StorageProxy]. */
     suspend fun clear() {
-        // Sync before clearing (for a similar behaviour to collections).
+        // Sync before clearing in order to get an updated versionMap. This ensures we can clear
+        // values set by other actors.
         fetch()
         storageProxy.applyOp(CrdtSingleton.Operation.Clear(name, versionMap))
     }

--- a/javatests/arcs/core/storage/handle/SingletonIntegrationTest.kt
+++ b/javatests/arcs/core/storage/handle/SingletonIntegrationTest.kt
@@ -120,6 +120,19 @@ class SingletonIntegrationTest {
         assertThat(singletonB.fetch()).isNull()
     }
 
+    @Test
+    fun syncsBeforeClearing() = runBlockingTest {
+        val lou = Person("Lou", 95, true)
+        val jan = Person("Jan", 28, true, emptySet())
+        singletonA.set(lou.toRawEntity())
+        singletonB.fetch()
+        singletonB.set(jan.toRawEntity())
+
+        singletonA.clear()
+
+        assertThat(singletonA.fetch()).isNull()
+    }
+
     private data class Person(
         val name: String,
         val age: Int,

--- a/javatests/arcs/core/storage/handle/SingletonIntegrationTest.kt
+++ b/javatests/arcs/core/storage/handle/SingletonIntegrationTest.kt
@@ -121,7 +121,7 @@ class SingletonIntegrationTest {
     }
 
     @Test
-    fun syncsBeforeClearing() = runBlockingTest {
+    fun clearingOnA_clearsValueSetByB() = runBlockingTest {
         val lou = Person("Lou", 95, true)
         val jan = Person("Jan", 28, true, emptySet())
         singletonA.set(lou.toRawEntity())

--- a/src/runtime/storageNG/handle.ts
+++ b/src/runtime/storageNG/handle.ts
@@ -415,6 +415,10 @@ export class SingletonHandle<T> extends Handle<CRDTSingletonTypeRecord<Reference
     if (!this.canWrite) {
       throw new Error('Handle not writeable');
     }
+    // Sync before clearing (for a similar behaviour to collections).
+    const [_, versionMap] = await this.storageProxy.getParticleView();
+    this.clock = versionMap;
+    // Issue clear op.
     const op: CRDTOperation = {
       type: SingletonOpTypes.Clear,
       actor: this.key,

--- a/src/runtime/storageNG/handle.ts
+++ b/src/runtime/storageNG/handle.ts
@@ -415,7 +415,8 @@ export class SingletonHandle<T> extends Handle<CRDTSingletonTypeRecord<Reference
     if (!this.canWrite) {
       throw new Error('Handle not writeable');
     }
-    // Sync before clearing (for a similar behaviour to collections).
+    // Sync before clearing in order to get an updated versionMap. This ensures
+    // we can clear values set by other actors.
     const [_, versionMap] = await this.storageProxy.getParticleView();
     this.clock = versionMap;
     // Issue clear op.

--- a/src/runtime/storageNG/tests/handle-test.ts
+++ b/src/runtime/storageNG/tests/handle-test.ts
@@ -278,7 +278,7 @@ describe('SingletonHandle', async () => {
     assert.isTrue(particle.onSyncCalled);
   });
 
-  it('syncs before clearing', async () => {
+  it('can clear value set by other actor', async () => {
     const handle = await getSingletonHandle(barType);
     await handle.set(newEntity('A'));
     // Simulate another writer overwriting the value.


### PR DESCRIPTION
This makes the behaviour more similar to how CollectionHandle.clear() works.