### PR TITLE
Set up remote cache for bazel.

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -26,9 +26,11 @@ steps:
 - id: 'local-presubmit'
   name: 'gcr.io/cloud-builders/docker'
   args: [
-    'run', '--rm', 'arcs-base',
+    'run',
+    '--network=cloudbuild',
+    '--rm', 'arcs-base',
     'tools/local-presubmit',
-    '--bazelrc=tools/travis.bazelrc',
+    '--bazelrc=tools/gcb.bazelrc',
   ]
   waitFor: ['build-image']
 

--- a/tools/gcb.bazelrc
+++ b/tools/gcb.bazelrc
@@ -1,0 +1,3 @@
+build --remote_cache=https://storage.googleapis.com/arcs-github-gcb-bazel-cache --google_default_credentials
+build --verbose_failures --spawn_strategy=sandboxed --jobs=32 --ram_utilization_factor=33
+test --spawn_strategy=sandboxed --nocache_test_results --test_output=errors --jobs=32 --ram_utilization_factor=33


### PR DESCRIPTION
This shaves off ~5 minutes from the `local-presubmit` step.