### PR TITLE
Wire up DatabasePerformanceStatistics

### DIFF
--- a/java/arcs/android/storage/database/AndroidSqliteDatabaseManager.kt
+++ b/java/arcs/android/storage/database/AndroidSqliteDatabaseManager.kt
@@ -13,16 +13,18 @@ package arcs.android.storage.database
 
 import android.content.Context
 import arcs.core.storage.database.Database
-import arcs.core.storage.database.DatabaseFactory
+import arcs.core.storage.database.DatabaseIdentifier
+import arcs.core.storage.database.DatabaseManager
+import arcs.core.storage.database.DatabasePerformanceStatistics
 import arcs.core.util.guardedBy
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
 /**
- * [DatabaseFactory] implementation which constructs [DatabaseImpl] instances for use on Android
+ * [DatabaseManager] implementation which constructs [DatabaseImpl] instances for use on Android
  * with SQLite.
  */
-class AndroidSqliteDatabaseFactory(context: Context) : DatabaseFactory {
+class AndroidSqliteDatabaseManager(context: Context) : DatabaseManager {
     private val context = context.applicationContext
     private val mutex = Mutex()
     private val dbCache by guardedBy(mutex, mutableMapOf<Pair<String, Boolean>, Database>())
@@ -30,5 +32,9 @@ class AndroidSqliteDatabaseFactory(context: Context) : DatabaseFactory {
     override suspend fun getDatabase(name: String, persistent: Boolean): Database = mutex.withLock {
         dbCache[name to persistent]
             ?: DatabaseImpl(context, name, persistent).also { dbCache[name to persistent] = it }
+    }
+
+    override suspend fun snapshotStatistics(): Map<DatabaseIdentifier, DatabasePerformanceStatistics.Snapshot> {
+        TODO("not implemented")
     }
 }

--- a/java/arcs/android/storage/database/AndroidSqliteDatabaseManager.kt
+++ b/java/arcs/android/storage/database/AndroidSqliteDatabaseManager.kt
@@ -15,7 +15,7 @@ import android.content.Context
 import arcs.core.storage.database.Database
 import arcs.core.storage.database.DatabaseIdentifier
 import arcs.core.storage.database.DatabaseManager
-import arcs.core.storage.database.DatabasePerformanceStatistics
+import arcs.core.storage.database.DatabasePerformanceStatistics.Snapshot
 import arcs.core.util.guardedBy
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -27,14 +27,13 @@ import kotlinx.coroutines.sync.withLock
 class AndroidSqliteDatabaseManager(context: Context) : DatabaseManager {
     private val context = context.applicationContext
     private val mutex = Mutex()
-    private val dbCache by guardedBy(mutex, mutableMapOf<Pair<String, Boolean>, Database>())
+    private val dbCache by guardedBy(mutex, mutableMapOf<DatabaseIdentifier, Database>())
 
     override suspend fun getDatabase(name: String, persistent: Boolean): Database = mutex.withLock {
         dbCache[name to persistent]
             ?: DatabaseImpl(context, name, persistent).also { dbCache[name to persistent] = it }
     }
 
-    override suspend fun snapshotStatistics(): Map<DatabaseIdentifier, DatabasePerformanceStatistics.Snapshot> {
-        TODO("not implemented")
-    }
+    override suspend fun snapshotStatistics(): Map<DatabaseIdentifier, Snapshot> =
+        mutex.withLock { dbCache.mapValues { it.value.snapshotStatistics() } }
 }

--- a/java/arcs/android/storage/database/BUILD
+++ b/java/arcs/android/storage/database/BUILD
@@ -16,6 +16,7 @@ kt_android_library(
         "//java/arcs/core/storage:storage_key",
         "//java/arcs/core/storage/database",
         "//java/arcs/core/util",
+        "//java/arcs/jvm/util/performance",
         "//third_party/java/androidx/annotation",
         "//third_party/kotlin/kotlinx_coroutines",
     ],

--- a/java/arcs/android/storage/database/BUILD
+++ b/java/arcs/android/storage/database/BUILD
@@ -16,6 +16,7 @@ kt_android_library(
         "//java/arcs/core/storage:storage_key",
         "//java/arcs/core/storage/database",
         "//java/arcs/core/util",
+        "//java/arcs/core/util/performance",
         "//java/arcs/jvm/util/performance",
         "//third_party/java/androidx/annotation",
         "//third_party/kotlin/kotlinx_coroutines",

--- a/java/arcs/android/storage/database/DatabaseCounters.kt
+++ b/java/arcs/android/storage/database/DatabaseCounters.kt
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.android.storage.database
+
+/** Collection of constants for use with [DatabasePerformanceStatistics] for [DatabaseImpl]. */
+object DatabaseCounters {
+    /* Entity-related Counters */
+    const val INSERTUPDATE_ENTITY = "insertUpdate_entity"
+    const val GET_ENTITY = "get_entity"
+    const val GET_ENTITY_STORAGEKEY_ID = "get_entity_storageKey_id"
+    const val GET_ENTITY_FIELDS = "get_entity_fields"
+    const val GET_ENTITY_REFERENCE = "get_entity_reference"
+    const val GET_ENTITY_TYPE_BY_STORAGEKEY = "get_entity_type_by_storageKey"
+    const val GET_ENTITY_FIELD_VALUES = "get_entity_field_values"
+    const val GET_ENTITY_FIELD_VALUE_PRIMITIVE = "get_entity_field_value_primitive"
+    const val ENTITY_SCHEMA_CACHE_HIT = "entity_schema_cache_hit"
+    const val ENTITY_SCHEMA_CACHE_MISS = "entity_schema_cache_miss"
+    const val INSERT_ENTITY_TYPE_ID = "insert_entity_type_id"
+    const val INSERT_ENTITY_FIELD = "insert_entity_field"
+    const val INSERT_ENTITY_REFERENCE = "insert_entity_reference"
+    const val INSERT_ENTITY_STORAGEKEY = "insert_entity_storageKey"
+    const val INSERT_ENTITY_RECORD = "insert_entity_record"
+    const val UPDATE_ENTITY_FIELD_VALUE = "update_entity_field_value"
+
+    /* Collection-related Counters */
+    const val INSERTUPDATE_COLLECTION = "insertUpdate_collection"
+    const val GET_COLLECTION = "get_collection"
+    const val GET_COLLECTION_ID = "get_collection_id"
+    const val GET_COLLECTION_ENTRIES = "get_collection_entries"
+    const val INSERT_COLLECTION_RECORD = "insert_collection_record"
+    const val INSERT_COLLECTION_STORAGEKEY = "insert_collection_storageKey"
+    const val DELETE_COLLECTION_ENTRIES = "delete_collection_entries"
+    const val INSERT_COLLECTION_ENTRY = "insert_collection_entry"
+
+    /* Singleton-related Counters */
+    const val INSERTUPDATE_SINGLETON = "insertUpdate_singleton"
+    const val GET_SINGLETON = "get_singleton"
+    const val GET_SINGLETON_ID = "get_singleton_id"
+    const val GET_SINGLETON_ENTRIES = "get_singleton_entries"
+    const val INSERT_SINGLETON_RECORD = "insert_singleton_record"
+    const val INSERT_SINGLETON_STORAGEKEY = "insert_singleton_storageKey"
+    const val DELETE_SINGLETON_ENTRY = "delete_singleton_entries"
+    const val INSERT_SINGLETON_ENTRY = "insert_singleton_entry"
+
+    /* Primitive Counters */
+    const val GET_BOOLEAN_VALUE_ID = "get_boolean_value_id"
+    const val GET_TEXT_VALUE_ID = "get_text_value_id"
+    const val GET_NUMBER_VALUE_ID = "get_number_value_id"
+    const val INSERT_TEXT_VALUE = "insert_text_value"
+    const val INSERT_NUMBER_VALUE = "insert_number_value"
+    const val GET_PRIMITIVE_VALUE_BOOLEAN = "get_primitive_value_boolean"
+    const val GET_PRIMITIVE_VALUE_TEXT = "get_primitive_value_text"
+    const val GET_PRIMITIVE_VALUE_NUMBER = "get_primitive_value_number"
+
+    /** [Array] of counter names for [DatabaseImpl.insertOrUpdate]. */
+    val INSERT_UPDATE_COUNTERS = arrayOf(
+        INSERTUPDATE_ENTITY,
+        INSERTUPDATE_COLLECTION,
+        INSERTUPDATE_SINGLETON,
+        ENTITY_SCHEMA_CACHE_HIT,
+        ENTITY_SCHEMA_CACHE_MISS,
+        INSERT_ENTITY_TYPE_ID,
+        INSERT_ENTITY_FIELD,
+        GET_ENTITY_STORAGEKEY_ID,
+        INSERT_ENTITY_STORAGEKEY,
+        INSERT_ENTITY_RECORD,
+        GET_ENTITY_FIELDS,
+        UPDATE_ENTITY_FIELD_VALUE,
+        GET_BOOLEAN_VALUE_ID,
+        GET_TEXT_VALUE_ID,
+        GET_NUMBER_VALUE_ID,
+        INSERT_TEXT_VALUE,
+        INSERT_NUMBER_VALUE,
+        GET_COLLECTION_ID,
+        GET_SINGLETON_ID,
+        GET_ENTITY_REFERENCE,
+        INSERT_ENTITY_REFERENCE,
+        INSERT_COLLECTION_RECORD,
+        INSERT_COLLECTION_STORAGEKEY,
+        DELETE_COLLECTION_ENTRIES,
+        INSERT_COLLECTION_ENTRY,
+        INSERT_SINGLETON_RECORD,
+        INSERT_SINGLETON_STORAGEKEY,
+        DELETE_SINGLETON_ENTRY,
+        INSERT_SINGLETON_ENTRY
+    )
+
+    /** [Array] of counter names for [DatabaseImpl.get]. */
+    val GET_COUNTERS = arrayOf(
+        GET_ENTITY,
+        GET_COLLECTION,
+        GET_SINGLETON,
+        GET_ENTITY_TYPE_BY_STORAGEKEY,
+        GET_ENTITY_FIELDS,
+        GET_ENTITY_FIELD_VALUES,
+        GET_ENTITY_FIELD_VALUE_PRIMITIVE,
+        GET_PRIMITIVE_VALUE_BOOLEAN,
+        GET_PRIMITIVE_VALUE_TEXT,
+        GET_PRIMITIVE_VALUE_NUMBER,
+        GET_COLLECTION_ID,
+        GET_COLLECTION_ENTRIES,
+        GET_SINGLETON_ID,
+        GET_SINGLETON_ENTRIES
+    )
+
+    /** [Array] of counter names for [DatabaseImpl.delete]. */
+    // TODO(csilvestrini): Flesh this out.
+    val DELETE_COUNTERS = arrayOf<String>()
+}

--- a/java/arcs/android/storage/database/DatabaseImpl.kt
+++ b/java/arcs/android/storage/database/DatabaseImpl.kt
@@ -40,9 +40,9 @@ import arcs.core.util.guardedBy
 import arcs.core.util.performance.Counters
 import arcs.core.util.performance.PerformanceStatistics
 import arcs.jvm.util.performance.JvmTimer
+import kotlin.reflect.KClass
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import kotlin.reflect.KClass
 
 /** The Type ID that gets stored in the database. */
 typealias TypeId = Long

--- a/java/arcs/core/storage/Store.kt
+++ b/java/arcs/core/storage/Store.kt
@@ -112,6 +112,7 @@ class Store<Data : CrdtData, Op : CrdtOperation, ConsumerData>(
                     else -> throw CrdtException("Unsupported type for storage: $type")
                 }
 
+                @Suppress("UNCHECKED_CAST")
                 return CrdtException.requireNotNull(
                     constructor(options, dataClass) as? ActiveStore<CrdtData, CrdtOperation, Any>
                 ) {

--- a/java/arcs/core/storage/database/BUILD
+++ b/java/arcs/core/storage/database/BUILD
@@ -15,5 +15,6 @@ arcs_kt_library(
         "//java/arcs/core/data",
         "//java/arcs/core/storage:reference",
         "//java/arcs/core/storage:storage_key",
+        "//java/arcs/core/util/performance",
     ],
 )

--- a/java/arcs/core/storage/database/Database.kt
+++ b/java/arcs/core/storage/database/Database.kt
@@ -45,6 +45,9 @@ interface Database {
     /** Removes everything associated with the given [storageKey] from the database. */
     suspend fun delete(storageKey: StorageKey, originatingClientId: Int? = null)
 
+    /** Takes a snapshot of the current [DatabasePerformanceStatistics] for the database. */
+    suspend fun snapshotStatistics(): DatabasePerformanceStatistics.Snapshot
+
     /**
      * Registers a [client] which will be called when the data at its specified
      * [DatabaseClient.storageKey] is created, updated, or deleted. Returns a unique identifier for

--- a/java/arcs/core/storage/database/DatabaseManager.kt
+++ b/java/arcs/core/storage/database/DatabaseManager.kt
@@ -33,7 +33,7 @@ interface DatabaseManager {
      * aware of.
      */
     suspend fun snapshotStatistics():
-        Map<DatabaseIdentifier,  DatabasePerformanceStatistics.Snapshot>
+        Map<DatabaseIdentifier, DatabasePerformanceStatistics.Snapshot>
 }
 
 /** Identifier for an individual [Database] instance. */

--- a/java/arcs/core/storage/database/DatabaseManager.kt
+++ b/java/arcs/core/storage/database/DatabaseManager.kt
@@ -17,10 +17,32 @@ package arcs.core.storage.database
 // TODO: In the future it may be important for there to be an additional parameter on getDatabase
 //  which hints the factory as to where the database should be found (e.g. a remote server, a local
 //  service like postgres, android sqlite database, non-android sqlite database, WebDatabase, etc..)
-interface DatabaseFactory {
+interface DatabaseManager {
     /**
      * Gets a [Database] for the given [name].  If [persistent] is `false`, the [Database] should
      * only exist in-memory (if possible for the current platform).
      */
     suspend fun getDatabase(name: String, persistent: Boolean): Database
+
+    /** Gets a [Database] for the given [DatabaseIdentifier]. */
+    suspend fun getDatabase(databaseIdentifier: DatabaseIdentifier): Database =
+        getDatabase(databaseIdentifier.name, databaseIdentifier.persistent)
+
+    /**
+     * Gets [DatabasePerformanceStatistics.Snapshot]s for all databases the [DatabaseManager] is
+     * aware of.
+     */
+    suspend fun snapshotStatistics():
+        Map<DatabaseIdentifier,  DatabasePerformanceStatistics.Snapshot>
 }
+
+/** Identifier for an individual [Database] instance. */
+typealias DatabaseIdentifier = Pair<String, Boolean>
+
+/** Name of the [Database]. */
+val DatabaseIdentifier.name: String
+    get() = first
+
+/** Whether or not the [Database] should be persisted to disk. */
+val DatabaseIdentifier.persistent: Boolean
+    get() = second

--- a/java/arcs/core/storage/database/DatabasePerformanceStatistics.kt
+++ b/java/arcs/core/storage/database/DatabasePerformanceStatistics.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.core.storage.database
+
+import arcs.core.util.performance.PerformanceStatistics
+
+/** Wrapper for [PerformanceStatistics] by operation type on [Database] instances. */
+class DatabasePerformanceStatistics(
+    /** [PerformanceStatistics] around insertions/updates to data in the database. */
+    val insertUpdate: PerformanceStatistics,
+    /** [PerformanceStatistics] around gets of data from the database. */
+    val get: PerformanceStatistics,
+    /** [PerformanceStatistics] around deletions of data from the database. */
+    val delete: PerformanceStatistics
+) {
+    suspend fun snapshot(): Snapshot =
+        Snapshot(insertUpdate.snapshot(), get.snapshot(), delete.snapshot())
+
+    /** Snapshot in time of [PerformanceStatistics] by operation type on [Database] instances. */
+    data class Snapshot(
+        val insertUpdate: PerformanceStatistics.Snapshot,
+        val get: PerformanceStatistics.Snapshot,
+        val delete: PerformanceStatistics.Snapshot
+    )
+}

--- a/java/arcs/core/storage/driver/Database.kt
+++ b/java/arcs/core/storage/driver/Database.kt
@@ -108,8 +108,17 @@ data class DatabaseStorageKey(
 
 /** [DriverProvider] which provides a [DatabaseDriver]. */
 object DatabaseDriverProvider : DriverProvider {
+    /**
+     * Whether or not the [DatabaseDriverProvider] has been configured with a [DatabaseManager] and
+     * a schema lookup function.
+     */
+    val isConfigured: Boolean
+        get() = _manager != null
+
     private var _manager: DatabaseManager? = null
-    private val manager: DatabaseManager
+
+    /** The configured [DatabaseManager]. */
+    val manager: DatabaseManager
         get() = requireNotNull(_manager) { ERROR_MESSAGE_CONFIGURE_NOT_CALLED }
 
     /**

--- a/java/arcs/core/storage/driver/Database.kt
+++ b/java/arcs/core/storage/driver/Database.kt
@@ -37,9 +37,9 @@ import arcs.core.storage.referencemode.toReferenceSingleton
 import arcs.core.util.Random
 import arcs.core.util.TaggedLog
 import arcs.core.util.guardedBy
+import kotlin.reflect.KClass
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import kotlin.reflect.KClass
 
 /** Protocol to be used with the database driver. */
 const val DATABASE_DRIVER_PROTOCOL = "db"

--- a/java/arcs/core/util/performance/PerformanceStatistics.kt
+++ b/java/arcs/core/util/performance/PerformanceStatistics.kt
@@ -13,6 +13,7 @@ package arcs.core.util.performance
 
 import arcs.core.util.RunningStatistics
 import arcs.core.util.guardedBy
+import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
@@ -20,7 +21,6 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import kotlin.coroutines.CoroutineContext
 
 /**
  * Utility for tracking running performance/runtime statistics of arbitrary operations.

--- a/java/arcs/core/util/performance/PerformanceStatistics.kt
+++ b/java/arcs/core/util/performance/PerformanceStatistics.kt
@@ -13,7 +13,6 @@ package arcs.core.util.performance
 
 import arcs.core.util.RunningStatistics
 import arcs.core.util.guardedBy
-import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
@@ -21,6 +20,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlin.coroutines.CoroutineContext
 
 /**
  * Utility for tracking running performance/runtime statistics of arbitrary operations.

--- a/java/arcs/jvm/storage/database/testutil/BUILD
+++ b/java/arcs/jvm/storage/database/testutil/BUILD
@@ -14,6 +14,8 @@ arcs_kt_jvm_library(
         "//java/arcs/core/storage:storage_key",
         "//java/arcs/core/storage/database",
         "//java/arcs/core/util",
+        "//java/arcs/core/util/performance",
+        "//java/arcs/jvm/util/performance",
         "//third_party/kotlin/kotlinx_coroutines",
     ],
 )

--- a/java/arcs/jvm/storage/database/testutil/MockDatabaseManager.kt
+++ b/java/arcs/jvm/storage/database/testutil/MockDatabaseManager.kt
@@ -17,10 +17,12 @@ import arcs.core.storage.StorageKey
 import arcs.core.storage.database.Database
 import arcs.core.storage.database.DatabaseClient
 import arcs.core.storage.database.DatabaseData
-import arcs.core.storage.database.DatabaseFactory
+import arcs.core.storage.database.DatabaseIdentifier
+import arcs.core.storage.database.DatabaseManager
+import arcs.core.storage.database.DatabasePerformanceStatistics
 import arcs.core.util.guardedBy
-import kotlin.coroutines.coroutineContext
-import kotlin.reflect.KClass
+import arcs.core.util.performance.PerformanceStatistics
+import arcs.jvm.util.performance.JvmTimer
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filter
@@ -30,21 +32,33 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlin.coroutines.coroutineContext
+import kotlin.reflect.KClass
 
-/** [DatabaseFactory] which generates mockito mocks of [Database] objects. */
-class MockDatabaseFactory : DatabaseFactory {
+/** [DatabaseManager] which generates mockito mocks of [Database] objects. */
+class MockDatabaseManager : DatabaseManager {
     private val mutex = Mutex()
-    private val cache: MutableMap<Pair<String, Boolean>, Database>
+    private val cache: MutableMap<DatabaseIdentifier, Database>
         by guardedBy(mutex, mutableMapOf())
 
     override suspend fun getDatabase(name: String, persistent: Boolean): Database = mutex.withLock {
         cache[name to persistent]
             ?: MockDatabase().also { cache[name to persistent] = it }
     }
+
+    override suspend fun snapshotStatistics():
+        Map<DatabaseIdentifier, DatabasePerformanceStatistics.Snapshot> =
+        mutex.withLock { cache.mapValues { it.value.snapshotStatistics() } }
 }
 
 @Suppress("EXPERIMENTAL_API_USAGE")
 open class MockDatabase : Database {
+    private val stats = DatabasePerformanceStatistics(
+        insertUpdate = PerformanceStatistics(JvmTimer),
+        get = PerformanceStatistics(JvmTimer),
+        delete = PerformanceStatistics(JvmTimer)
+    )
+
     private val clientMutex = Mutex()
     private var nextClientId = 1
     open val clients = mutableMapOf<Int, Pair<StorageKey, DatabaseClient>>()
@@ -59,7 +73,7 @@ open class MockDatabase : Database {
         storageKey: StorageKey,
         data: DatabaseData,
         originatingClientId: Int?
-    ): Int {
+    ): Int = stats.insertUpdate.timeSuspending {
         val (version, isNew) = dataMutex.withLock {
             val oldData = this.data[storageKey]
             if (oldData?.databaseVersion != data.databaseVersion) {
@@ -76,7 +90,7 @@ open class MockDatabase : Database {
                 .launchIn(CoroutineScope(coroutineContext))
         }
 
-        return version
+        return@timeSuspending version
     }
 
     @Suppress("UNCHECKED_CAST")
@@ -84,12 +98,12 @@ open class MockDatabase : Database {
         storageKey: StorageKey,
         dataType: KClass<out DatabaseData>,
         schema: Schema
-    ): DatabaseData? {
+    ): DatabaseData? = stats.get.timeSuspending {
         val dataVal = dataMutex.withLock { data[storageKey] }
 
-        if (dataVal != null) return dataVal
+        if (dataVal != null) return@timeSuspending dataVal
 
-        return when (dataType) {
+        return@timeSuspending when (dataType) {
             DatabaseData.Singleton::class ->
                 DatabaseData.Singleton(null, schema, -1, VersionMap())
             DatabaseData.Collection::class ->
@@ -99,11 +113,15 @@ open class MockDatabase : Database {
         }
     }
 
-    override suspend fun delete(storageKey: StorageKey, originatingClientId: Int?) {
-        dataMutex.withLock { data.remove(storageKey) }
-        clientFlow.onEach { it.onDatabaseDelete(originatingClientId) }
-            .launchIn(CoroutineScope(coroutineContext))
-    }
+    override suspend fun delete(storageKey: StorageKey, originatingClientId: Int?) =
+        stats.delete.timeSuspending {
+            dataMutex.withLock { data.remove(storageKey) }
+            clientFlow.onEach { it.onDatabaseDelete(originatingClientId) }
+                .launchIn(CoroutineScope(coroutineContext))
+            Unit
+        }
+
+    override suspend fun snapshotStatistics() = stats.snapshot()
 
     override fun addClient(client: DatabaseClient): Int = runBlocking {
         clientMutex.withLock {

--- a/java/arcs/jvm/storage/database/testutil/MockDatabaseManager.kt
+++ b/java/arcs/jvm/storage/database/testutil/MockDatabaseManager.kt
@@ -23,6 +23,8 @@ import arcs.core.storage.database.DatabasePerformanceStatistics
 import arcs.core.util.guardedBy
 import arcs.core.util.performance.PerformanceStatistics
 import arcs.jvm.util.performance.JvmTimer
+import kotlin.coroutines.coroutineContext
+import kotlin.reflect.KClass
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filter
@@ -32,8 +34,6 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import kotlin.coroutines.coroutineContext
-import kotlin.reflect.KClass
 
 /** [DatabaseManager] which generates mockito mocks of [Database] objects. */
 class MockDatabaseManager : DatabaseManager {

--- a/java/arcs/sdk/android/storage/service/BUILD
+++ b/java/arcs/sdk/android/storage/service/BUILD
@@ -18,6 +18,7 @@ kt_android_library(
         "//java/arcs/core/storage",
         "//java/arcs/core/storage/driver",
         "//java/arcs/core/util",
+        "//java/arcs/core/util/performance",
         "//third_party/java/androidx/annotation",
         "//third_party/java/androidx/work",
         "//third_party/kotlin/kotlinx_atomicfu",

--- a/java/arcs/sdk/android/storage/service/BUILD
+++ b/java/arcs/sdk/android/storage/service/BUILD
@@ -16,6 +16,7 @@ kt_android_library(
         "//java/arcs/android/storage/service:aidl",
         "//java/arcs/android/storage/ttl",
         "//java/arcs/core/storage",
+        "//java/arcs/core/storage/database",
         "//java/arcs/core/storage/driver",
         "//java/arcs/core/util",
         "//java/arcs/core/util/performance",

--- a/java/arcs/sdk/android/storage/service/StorageService.kt
+++ b/java/arcs/sdk/android/storage/service/StorageService.kt
@@ -164,10 +164,10 @@ class StorageService : ResurrectorService() {
             """
                 |$pad$title (%d measurements):
                 |$pad  Runtime (ms):
-                |$pad  Average: %.3f 
-                |$pad  StdDev: %.3f 
-                |$pad  Min: %.3f
-                |$pad  Max: %.3f 
+                |$pad    Average: %.3f 
+                |$pad    StdDev: %.3f 
+                |$pad    Min: %.3f
+                |$pad    Max: %.3f 
                 |        
                 |${pad}Counts per measurement (name: average, standard deviation, min, max):
             """.trimMargin()

--- a/java/arcs/sdk/android/storage/service/StorageService.kt
+++ b/java/arcs/sdk/android/storage/service/StorageService.kt
@@ -33,15 +33,15 @@ import arcs.core.storage.driver.DatabaseDriverProvider
 import arcs.core.storage.driver.RamDiskDriverProvider
 import arcs.core.util.TaggedLog
 import arcs.core.util.performance.PerformanceStatistics
+import java.io.FileDescriptor
+import java.io.PrintWriter
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.runBlocking
-import java.io.FileDescriptor
-import java.io.PrintWriter
-import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.TimeUnit
 
 /**
  * Implementation of a [Service] which manages [Store]s and exposes the ability to access them via
@@ -148,7 +148,6 @@ class StorageService : ResurrectorService() {
                 writer.println()
             }
         }
-
 
         dumpRegistrations(writer)
     }

--- a/javatests/arcs/android/storage/database/AndroidSqliteDatabaseManagerTest.kt
+++ b/javatests/arcs/android/storage/database/AndroidSqliteDatabaseManagerTest.kt
@@ -13,7 +13,7 @@ package arcs.android.storage.database
 
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import arcs.core.storage.database.DatabaseFactory
+import arcs.core.storage.database.DatabaseManager
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
@@ -26,33 +26,33 @@ import java.util.Random
 
 @ExperimentalCoroutinesApi
 @RunWith(AndroidJUnit4::class)
-class AndroidSqliteDatabaseFactoryTest {
-    private lateinit var factory: DatabaseFactory
+class AndroidSqliteDatabaseManagerTest {
+    private lateinit var manager: DatabaseManager
     private lateinit var random: Random
 
     @Before
     fun setUp() {
-        factory = AndroidSqliteDatabaseFactory(ApplicationProvider.getApplicationContext())
+        manager = AndroidSqliteDatabaseManager(ApplicationProvider.getApplicationContext())
         random = Random(System.currentTimeMillis())
     }
 
     @Test
     fun getDatabase() = runBlockingTest {
-        val database = factory.getDatabase("foo", true)
+        val database = manager.getDatabase("foo", true)
         assertThat(database).isInstanceOf(DatabaseImpl::class.java)
     }
 
     @Test
     fun getDatabases() = runBlockingTest {
-        val databaseFoo = factory.getDatabase("foo", true)
+        val databaseFoo = manager.getDatabase("foo", true)
         assertThat(databaseFoo).isInstanceOf(DatabaseImpl::class.java)
 
-        val databaseBar = factory.getDatabase("bar", true)
+        val databaseBar = manager.getDatabase("bar", true)
         assertThat(databaseBar).isInstanceOf(DatabaseImpl::class.java)
         assertThat(databaseFoo).isNotEqualTo(databaseBar)
         assertThat(databaseFoo).isNotSameInstanceAs(databaseBar)
 
-        val databaseFooMemory = factory.getDatabase("foo", false)
+        val databaseFooMemory = manager.getDatabase("foo", false)
         assertThat(databaseFooMemory).isInstanceOf(DatabaseImpl::class.java)
         assertThat(databaseFoo).isNotEqualTo(databaseBar)
         assertThat(databaseFoo).isNotSameInstanceAs(databaseBar)
@@ -60,8 +60,8 @@ class AndroidSqliteDatabaseFactoryTest {
 
     @Test
     fun getSameDatabase_returnsSameObject() = runBlockingTest {
-        val firstFoo = factory.getDatabase("foo", true)
-        val secondFoo = factory.getDatabase("foo", true)
+        val firstFoo = manager.getDatabase("foo", true)
+        val secondFoo = manager.getDatabase("foo", true)
 
         assertThat(firstFoo).isInstanceOf(DatabaseImpl::class.java)
         assertThat(secondFoo).isInstanceOf(DatabaseImpl::class.java)
@@ -72,11 +72,11 @@ class AndroidSqliteDatabaseFactoryTest {
     fun getSameDatabase_concurrently_returnsSameObject() = runBlockingTest {
         val firstFoo = async {
             delay(random.nextInt(1000).toLong())
-            factory.getDatabase("foo", true)
+            manager.getDatabase("foo", true)
         }
         val secondFoo = async {
             delay(random.nextInt(1000).toLong())
-            factory.getDatabase("foo", true)
+            manager.getDatabase("foo", true)
         }
 
         assertThat(firstFoo.await()).isSameInstanceAs(secondFoo.await())

--- a/javatests/arcs/core/storage/CapabilitiesResolverTest.kt
+++ b/javatests/arcs/core/storage/CapabilitiesResolverTest.kt
@@ -16,14 +16,13 @@ import arcs.core.data.Capabilities
 import arcs.core.data.Schema
 import arcs.core.storage.driver.*
 import arcs.core.testutil.assertThrows
-import arcs.jvm.storage.database.testutil.MockDatabaseFactory
+import arcs.jvm.storage.database.testutil.MockDatabaseManager
 import com.google.common.truth.Truth.assertThat
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
-import java.lang.Error
 
 /** Tests for [CapabilitiesResolver]. */
 @RunWith(JUnit4::class)
@@ -82,7 +81,7 @@ class CapabilitiesResolverTest {
     @Test
     fun capabilitiesResolver_createsStorageKeys() {
         RamDisk.clear()
-        DatabaseDriverProvider.configure(MockDatabaseFactory(), mapOf<String, Schema>()::get)
+        DatabaseDriverProvider.configure(MockDatabaseManager(), mapOf<String, Schema>()::get)
         val options = CapabilitiesResolver.StorageKeyOptions(ArcId.newForTest("test"))
         val resolver1 = CapabilitiesResolver(options)
         assertThat(resolver1.findStorageKeyProtocols(Capabilities.TiedToArc))

--- a/javatests/arcs/core/storage/ReferenceModeStoreDatabaseIntegrationTest.kt
+++ b/javatests/arcs/core/storage/ReferenceModeStoreDatabaseIntegrationTest.kt
@@ -33,7 +33,7 @@ import arcs.core.storage.referencemode.RefModeStoreOp
 import arcs.core.storage.referencemode.RefModeStoreOutput
 import arcs.core.storage.referencemode.ReferenceModeStorageKey
 import arcs.core.util.testutil.LogRule
-import arcs.jvm.storage.database.testutil.MockDatabaseFactory
+import arcs.jvm.storage.database.testutil.MockDatabaseManager
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
@@ -56,7 +56,7 @@ class ReferenceModeStoreDatabaseIntegrationTest {
 
     private lateinit var hash: String
     private lateinit var testKey: ReferenceModeStorageKey
-    private lateinit var databaseFactory: MockDatabaseFactory
+    private lateinit var databaseFactory: MockDatabaseManager
     private lateinit var schema: Schema
 
     @Before
@@ -79,7 +79,7 @@ class ReferenceModeStoreDatabaseIntegrationTest {
         )
 
         DriverFactory.clearRegistrationsForTesting()
-        databaseFactory = MockDatabaseFactory()
+        databaseFactory = MockDatabaseManager()
         DatabaseDriverProvider.configure(databaseFactory) { schema }
     }
 

--- a/javatests/arcs/core/storage/driver/DatabaseDriverProviderTest.kt
+++ b/javatests/arcs/core/storage/driver/DatabaseDriverProviderTest.kt
@@ -24,11 +24,10 @@ import arcs.core.storage.CapabilitiesResolver
 import arcs.core.storage.DriverFactory
 import arcs.core.storage.ExistenceCriteria
 import arcs.core.storage.StorageKey
-import arcs.core.storage.database.DatabaseFactory
+import arcs.core.storage.database.DatabaseManager
 import arcs.core.testutil.assertSuspendingThrows
-import arcs.jvm.storage.database.testutil.MockDatabaseFactory
+import arcs.jvm.storage.database.testutil.MockDatabaseManager
 import com.google.common.truth.Truth.assertThat
-import kotlin.coroutines.coroutineContext
 import kotlinx.coroutines.test.runBlockingTest
 import org.junit.After
 import org.junit.Test
@@ -39,12 +38,12 @@ import org.junit.runners.JUnit4
 @Suppress("EXPERIMENTAL_API_USAGE")
 @RunWith(JUnit4::class)
 class DatabaseDriverProviderTest {
-    private var databaseFactory: DatabaseFactory? = null
+    private var databaseManager: DatabaseManager? = null
     private val schemaHashLookup = mutableMapOf<String, Schema>()
 
     @After
     fun tearDown() {
-        databaseFactory = null
+        databaseManager = null
         DriverFactory.clearRegistrationsForTesting()
         schemaHashLookup.clear()
         CapabilitiesResolver.reset()
@@ -154,8 +153,8 @@ class DatabaseDriverProviderTest {
         assertThat(singletonDriver.storageKey).isEqualTo(key)
     }
 
-    private fun databaseFactory(): DatabaseFactory =
-        databaseFactory ?: MockDatabaseFactory().also { databaseFactory = it}
+    private fun databaseFactory(): DatabaseManager =
+        databaseManager ?: MockDatabaseManager().also { databaseManager = it}
 
     companion object {
         private val DUMMY_SCHEMA = Schema(


### PR DESCRIPTION
First pass at adding database performance stats to the android SQLite Database Impl, also provides the ability to fetch all known databases' statistics via the DatabaseManager (renamed from DatabaseFactory), and renders those statistics in StorageService's `dumpsys` output.