### PR TITLE
Make time() test non-flaky.

### DIFF
--- a/javatests/arcs/core/util/performance/PerformanceStatisticsTest.kt
+++ b/javatests/arcs/core/util/performance/PerformanceStatisticsTest.kt
@@ -16,7 +16,6 @@ import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runBlockingTest
-import kotlinx.coroutines.yield
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
@@ -75,7 +74,7 @@ class PerformanceStatisticsTest {
     }
 
     @Test
-    fun time() = runBlockingTest {
+    fun time() = runBlocking {
         val stats = PerformanceStatistics(timer, "foo")
 
         stats.time {


### PR DESCRIPTION
Used `--runs_per_test=100` and it now passes without failure.