### PR TITLE
Refactor handles field, add EntitySpec.deserialize for PA

### DIFF
--- a/java/arcs/sdk/BUILD
+++ b/java/arcs/sdk/BUILD
@@ -18,6 +18,7 @@ arcs_kt_jvm_library(
     visibility = ["//visibility:public"],
     exports = [
         "//java/arcs/core/data:rawentity",
+        "//java/arcs/core/data/util:data-util",
     ],
     deps = [
         "//java/arcs/core/data",

--- a/java/arcs/sdk/Entity.kt
+++ b/java/arcs/sdk/Entity.kt
@@ -11,6 +11,8 @@
 
 package arcs.sdk
 
+import arcs.core.data.RawEntity
+
 interface Entity {
     var internalId: String
     fun schemaHash(): String
@@ -29,7 +31,6 @@ interface EntitySpec<T : Entity> {
      * Takes a [Map] representing a serialized representation of a [RawEntity] from the
      * storage layer, and converts it to a concrete entity class.
      * TODO: replace this with kotlinx.serialization
-     * TODO: this could just accept a RawEntity, but it would be tighter-coupling of SDK<->Core
      */
-    fun deserialize(data: Map<String, Any?>): T
+    fun deserialize(data: RawEntity): T
 }

--- a/java/arcs/sdk/Entity.kt
+++ b/java/arcs/sdk/Entity.kt
@@ -24,4 +24,12 @@ interface Entity {
 interface EntitySpec<T : Entity> {
     /** Returns an empty new instance of [T]. */
     fun create(): T
+
+    /**
+     * Takes a [Map] representing a serialized representation of a [RawEntity] from the
+     * storage layer, and converts it to a concrete entity class.
+     * TODO: replace this with kotlinx.serialization
+     * TODO: this could just accept a RawEntity, but it would be tighter-coupling of SDK<->Core
+     */
+    fun deserialize(data: Map<String, Any?>): T
 }

--- a/java/arcs/sdk/Entity.kt
+++ b/java/arcs/sdk/Entity.kt
@@ -11,8 +11,6 @@
 
 package arcs.sdk
 
-import arcs.core.data.RawEntity
-
 interface Entity {
     var internalId: String
     fun schemaHash(): String
@@ -26,11 +24,4 @@ interface Entity {
 interface EntitySpec<T : Entity> {
     /** Returns an empty new instance of [T]. */
     fun create(): T
-
-    /**
-     * Takes a [Map] representing a serialized representation of a [RawEntity] from the
-     * storage layer, and converts it to a concrete entity class.
-     * TODO: replace this with kotlinx.serialization
-     */
-    fun deserialize(data: RawEntity): T
 }

--- a/java/arcs/sdk/Particle.kt
+++ b/java/arcs/sdk/Particle.kt
@@ -36,12 +36,6 @@ abstract class HandleHolderBase(
 interface Particle {
 
     /**
-     * This field contains a reference to all of the [Particle]'s handles that were declared in
-     * the manifest.
-     */
-    val handles: HandleHolder
-
-    /**
      * React to handle updates.
      *
      * Called for handles when change events are received from the backing store.

--- a/java/arcs/sdk/Particle.kt
+++ b/java/arcs/sdk/Particle.kt
@@ -11,8 +11,33 @@
 
 package arcs.sdk
 
+/**
+ * Interface used by [ArcHost]s to interact dynamically with code-generated [Handle] fields
+ * used by [Particle]s.
+ */
+interface HandleHolder {
+    val map: MutableMap<String, Handle>
+    val entitySpecs: MutableMap<String, EntitySpec<out Entity>>
+}
+
+/**
+ * Base class used by `schema2kotlin` code-generator tool to generate a class containing all
+ * declared handles.
+ */
+abstract class HandleHolderBase(
+    override val map: MutableMap<String, Handle> = mutableMapOf(),
+    override val entitySpecs: MutableMap<String, EntitySpec<out Entity>> = mutableMapOf()
+) : HandleHolder
+
 /** Base interface for all particles. */
 interface Particle {
+
+    /**
+     * This field is provided in an abstract base class by the `schema2kotlin` code generator
+     * and contains all declared handles in the manifest.
+     */
+    val handles: HandleHolder
+
     /**
      * React to handle updates.
      *

--- a/java/arcs/sdk/Particle.kt
+++ b/java/arcs/sdk/Particle.kt
@@ -14,10 +14,13 @@ package arcs.sdk
 /**
  * Interface used by [ArcHost]s to interact dynamically with code-generated [Handle] fields
  * used by [Particle]s.
+ *
+ * @property map Key is a handle name, value is the corresponding [Handle].
+ * @property entitySpecs Key is a handle name, value is the corresponding [EntitySpec].
  */
 interface HandleHolder {
-    val map: MutableMap<String, Handle>
-    val entitySpecs: MutableMap<String, EntitySpec<out Entity>>
+    val map: Map<String, Handle>
+    val entitySpecs: Map<String, EntitySpec<out Entity>>
 }
 
 /**
@@ -25,16 +28,16 @@ interface HandleHolder {
  * declared handles.
  */
 abstract class HandleHolderBase(
-    override val map: MutableMap<String, Handle> = mutableMapOf(),
-    override val entitySpecs: MutableMap<String, EntitySpec<out Entity>> = mutableMapOf()
+    override val map: Map<String, Handle>,
+    override val entitySpecs: Map<String, EntitySpec<out Entity>>
 ) : HandleHolder
 
 /** Base interface for all particles. */
 interface Particle {
 
     /**
-     * This field is provided in an abstract base class by the `schema2kotlin` code generator
-     * and contains all declared handles in the manifest.
+     * This field contains a reference to all of the [Particle]'s handles that were declared in
+     * the manifest.
      */
     val handles: HandleHolder
 

--- a/java/arcs/sdk/jvm/BaseParticle.kt
+++ b/java/arcs/sdk/jvm/BaseParticle.kt
@@ -12,4 +12,10 @@
 package arcs.sdk
 
 /** Implementation of [Particle] for the JVM. */
-abstract class BaseParticle : Particle
+abstract class BaseParticle : Particle {
+    /**
+     * This field contains a reference to all of the [Particle]'s handles that were declared in
+     * the manifest.
+     */
+    abstract val handles: HandleHolder
+}

--- a/java/arcs/sdk/jvm/JvmEntity.kt
+++ b/java/arcs/sdk/jvm/JvmEntity.kt
@@ -19,4 +19,11 @@ interface JvmEntity : Entity {
     fun serialize(): RawEntity
 }
 
-interface JvmEntitySpec<T : Entity> : EntitySpec<T>
+interface JvmEntitySpec<T : Entity> : EntitySpec<T> {
+    /**
+     * Takes a [Map] representing a serialized representation of a [RawEntity] from the
+     * storage layer, and converts it to a concrete entity class.
+     * TODO: replace this with kotlinx.serialization
+     */
+    fun deserialize(data: RawEntity): T
+}

--- a/src/tools/schema2kotlin.ts
+++ b/src/tools/schema2kotlin.ts
@@ -54,7 +54,7 @@ package ${this.scope}
 // Current implementation doesn't support references or optional field detection
 
 import arcs.sdk.*
-${this.opts.wasm ? 'import arcs.sdk.wasm.*' : 'import arcs.core.data.RawEntity\nimport arcs.core.data.util.toReferencable'}
+${this.opts.wasm ? 'import arcs.sdk.wasm.*' : 'import arcs.core.data.RawEntity\nimport arcs.core.data.util.toReferencable\nimport arcs.core.data.util.ReferencablePrimitive'}
 `;
   }
 
@@ -89,23 +89,38 @@ ${this.opts.wasm ? 'import arcs.sdk.wasm.*' : 'import arcs.core.data.RawEntity\n
             throw new Error(`Unsupported handle direction: ${connection.direction}`);
         }
       }
-      handleDecls.push(`val ${handleName}: ${handleInterfaceType} by map`);
-      specDecls.push(`entitySpecs["${handleName}"] = ${entityType}_Spec()`);
+      if (this.opts.wasm) {
+        handleDecls.push(`val ${handleName}: ${handleInterfaceType} = ${this.getType(handleConcreteType) + 'Impl'}(particle, "${handleName}", ${entityType}_Spec())`);
+      } else {
+        specDecls.push(`"${handleName}" to ${entityType}_Spec()`);
+        handleDecls.push(`val ${handleName}: ${handleInterfaceType} by map`);
+      }
 
-      // handleDecls.push(`val ${handleName}: ${handleInterfaceType} = ${this.getType(handleConcreteType) + 'Impl'}(particle, "${handleName}", ${entityType}_Spec())`);
     }
     return `
-class ${particleName}Handles(particle : ${this.opts.wasm ? 'WasmParticleImpl' : 'BaseParticle'}) : HandleHolderBase() {
-    ${handleDecls.join('\n    ')}
-    init {
-      ${specDecls.join('\n      ')}
-    }
+class ${particleName}Handles(
+    particle : ${this.getBaseParticle()}
+) ${this.getExtendsClause(specDecls)} {
+    ${handleDecls.join('\n    ')} 
 }
 
 abstract class Abstract${particleName} : ${this.opts.wasm ? 'WasmParticleImpl' : 'BaseParticle'}() {
-    override val handles: ${particleName}Handles = ${particleName}Handles(this)
+    ${this.opts.wasm ? '' : 'override '}val handles: ${particleName}Handles = ${particleName}Handles(this)
 }
 `;
+  }
+
+  private getExtendsClause(entitySpecs): string {
+    return this.opts.wasm ? '' : `: HandleHolderBase(
+        mutableMapOf(), 
+        mapOf(
+            ${entitySpecs.join(',\n            ')}
+        )
+    )`;
+  }
+
+  private getBaseParticle(): string {
+    return this.opts.wasm ? 'WasmParticleImpl' : 'BaseParticle';
   }
 
   private getType(type: string): string {
@@ -162,7 +177,7 @@ class KotlinGenerator implements ClassGenerator {
     this.encode.push(`${fixed}.let { encoder.encode("${field}:${typeChar}", ${fixed}) }`);
 
     this.fieldSerializes.push(`"${field}" to ${fixed}.toReferencable()`);
-    this.fieldDeserializes.push(`${fixed} = (data["${fixed}"] as? ${type}) ?: ${defaultVal}`);
+    this.fieldDeserializes.push(`${fixed} = (data.singletons["${fixed}"] as? ReferencablePrimitive<${type}>?)?.value ?: ${defaultVal}`);
     this.fieldsForToString.push(`${fixed} = $${fixed}`);
   }
 
@@ -224,13 +239,13 @@ ${this.opts.wasm ? `
 class ${name}_Spec() : ${this.getType('EntitySpec')}<${name}> {
 
     override fun create() = ${name}()
-    
-    override fun deserialize(data: Map<String, Any?>): ${name} {
+    ${!this.opts.wasm ? `
+    override fun deserialize(data: RawEntity): ${name} {
       // TODO: only handles singletons for now
       return create().copy(
         ${withFields(`${this.fieldDeserializes.join(', \n        ')}`)}
       )
-    }
+    }` : ''}
 ${this.opts.wasm ? `
     override fun decode(encoded: ByteArray): ${name}? {
         if (encoded.isEmpty()) return null

--- a/src/tools/tests/goldens/generated-schemas.jvm.kt
+++ b/src/tools/tests/goldens/generated-schemas.jvm.kt
@@ -46,13 +46,18 @@ class GoldInternal1() : JvmEntity {
             "val" to val_.toReferencable()
         )
     )
-
-    override fun toString() = "GoldInternal1(val_ = $val_)"
 }
 
 class GoldInternal1_Spec() : JvmEntitySpec<GoldInternal1> {
 
     override fun create() = GoldInternal1()
+
+    override fun deserialize(data: Map<String, Any?>): GoldInternal1 {
+      // TODO: only handles singletons for now
+      return create().copy(
+        val_ = (data["val_"] as? String) ?: ""
+      )
+    }
 
 }
 
@@ -128,22 +133,34 @@ class Gold_Data() : JvmEntity {
             "flg" to flg.toReferencable()
         )
     )
-
-    override fun toString() = "Gold_Data(num = $num, txt = $txt, lnk = $lnk, flg = $flg)"
 }
 
 class Gold_Data_Spec() : JvmEntitySpec<Gold_Data> {
 
     override fun create() = Gold_Data()
 
+    override fun deserialize(data: Map<String, Any?>): Gold_Data {
+      // TODO: only handles singletons for now
+      return create().copy(
+        num = (data["num"] as? Double) ?: 0.0,
+        txt = (data["txt"] as? String) ?: "",
+        lnk = (data["lnk"] as? String) ?: "",
+        flg = (data["flg"] as? Boolean) ?: false
+      )
+    }
+
 }
 
 
-class GoldHandles(particle : BaseParticle) {
-    val data: ReadableSingleton<Gold_Data> = SingletonImpl(particle, "data", Gold_Data_Spec())
-    val alias: WritableSingleton<Gold_Alias> = SingletonImpl(particle, "alias", Gold_Alias_Spec())
+class GoldHandles(particle : BaseParticle) : HandleHolderBase() {
+    val data: ReadableSingleton<Gold_Data> by map
+    val alias: WritableSingleton<Gold_Alias> by map
+    init {
+      entitySpecs["data"] = Gold_Data_Spec()
+      entitySpecs["alias"] = Gold_Alias_Spec()
+    }
 }
 
 abstract class AbstractGold : BaseParticle() {
-    protected val handles: GoldHandles = GoldHandles(this)
+    override val handles: GoldHandles = GoldHandles(this)
 }

--- a/src/tools/tests/goldens/generated-schemas.jvm.kt
+++ b/src/tools/tests/goldens/generated-schemas.jvm.kt
@@ -11,6 +11,7 @@ package arcs.sdk
 import arcs.sdk.*
 import arcs.core.data.RawEntity
 import arcs.core.data.util.toReferencable
+import arcs.core.data.util.ReferencablePrimitive
 
 class GoldInternal1() : JvmEntity {
 
@@ -46,16 +47,18 @@ class GoldInternal1() : JvmEntity {
             "val" to val_.toReferencable()
         )
     )
+
+    override fun toString() = "GoldInternal1(val_ = $val_)"
 }
 
 class GoldInternal1_Spec() : JvmEntitySpec<GoldInternal1> {
 
     override fun create() = GoldInternal1()
 
-    override fun deserialize(data: Map<String, Any?>): GoldInternal1 {
+    override fun deserialize(data: RawEntity): GoldInternal1 {
       // TODO: only handles singletons for now
       return create().copy(
-        val_ = (data["val_"] as? String) ?: ""
+        val_ = (data.singletons["val_"] as? ReferencablePrimitive<String>?)?.value ?: ""
       )
     }
 
@@ -133,32 +136,38 @@ class Gold_Data() : JvmEntity {
             "flg" to flg.toReferencable()
         )
     )
+
+    override fun toString() = "Gold_Data(num = $num, txt = $txt, lnk = $lnk, flg = $flg)"
 }
 
 class Gold_Data_Spec() : JvmEntitySpec<Gold_Data> {
 
     override fun create() = Gold_Data()
 
-    override fun deserialize(data: Map<String, Any?>): Gold_Data {
+    override fun deserialize(data: RawEntity): Gold_Data {
       // TODO: only handles singletons for now
       return create().copy(
-        num = (data["num"] as? Double) ?: 0.0,
-        txt = (data["txt"] as? String) ?: "",
-        lnk = (data["lnk"] as? String) ?: "",
-        flg = (data["flg"] as? Boolean) ?: false
+        num = (data.singletons["num"] as? ReferencablePrimitive<Double>?)?.value ?: 0.0,
+        txt = (data.singletons["txt"] as? ReferencablePrimitive<String>?)?.value ?: "",
+        lnk = (data.singletons["lnk"] as? ReferencablePrimitive<String>?)?.value ?: "",
+        flg = (data.singletons["flg"] as? ReferencablePrimitive<Boolean>?)?.value ?: false
       )
     }
 
 }
 
 
-class GoldHandles(particle : BaseParticle) : HandleHolderBase() {
+class GoldHandles(
+    particle : BaseParticle
+) : HandleHolderBase(
+        mutableMapOf(),
+        mapOf(
+            "data" to Gold_Data_Spec(),
+            "alias" to Gold_Alias_Spec()
+        )
+    ) {
     val data: ReadableSingleton<Gold_Data> by map
     val alias: WritableSingleton<Gold_Alias> by map
-    init {
-      entitySpecs["data"] = Gold_Data_Spec()
-      entitySpecs["alias"] = Gold_Alias_Spec()
-    }
 }
 
 abstract class AbstractGold : BaseParticle() {

--- a/src/tools/tests/goldens/generated-schemas.wasm.kt
+++ b/src/tools/tests/goldens/generated-schemas.wasm.kt
@@ -53,6 +53,7 @@ class GoldInternal1_Spec() : WasmEntitySpec<GoldInternal1> {
 
     override fun create() = GoldInternal1()
 
+
     override fun decode(encoded: ByteArray): GoldInternal1? {
         if (encoded.isEmpty()) return null
 
@@ -170,6 +171,7 @@ class Gold_Data_Spec() : WasmEntitySpec<Gold_Data> {
 
     override fun create() = Gold_Data()
 
+
     override fun decode(encoded: ByteArray): Gold_Data? {
         if (encoded.isEmpty()) return null
 
@@ -226,11 +228,13 @@ class Gold_Data_Spec() : WasmEntitySpec<Gold_Data> {
 }
 
 
-class GoldHandles(particle : WasmParticleImpl) {
+class GoldHandles(
+    particle : WasmParticleImpl
+)  {
     val data: WasmSingletonImpl<Gold_Data> = WasmSingletonImpl(particle, "data", Gold_Data_Spec())
     val alias: WasmSingletonImpl<Gold_Alias> = WasmSingletonImpl(particle, "alias", Gold_Alias_Spec())
 }
 
 abstract class AbstractGold : WasmParticleImpl() {
-    protected val handles: GoldHandles = GoldHandles(this)
+    val handles: GoldHandles = GoldHandles(this)
 }


### PR DESCRIPTION
Adds EntitySpec.deserialize(map)
Adds HandleHolder interface which requires 'map' and 'entitySpec' fields
Adds handles field to Particle (HandleHolder)
HandleHolder delegates each handle field by map
Allows ArcHost to dynamically lookup and supply handles and specs


