### PR TITLE
Plumb local CRDT application state back to handles.

### DIFF
--- a/java/arcs/core/storage/StorageProxy.kt
+++ b/java/arcs/core/storage/StorageProxy.kt
@@ -102,10 +102,11 @@ class StorageProxy<Data : CrdtData, Op : CrdtOperation, T>(
         val msg = ProxyMessage.Operations<Data, Op, T>(listOf(op), null)
         val storeSuccess = store.onProxyMessage(msg)
 
-        // TODO(jwf/jibbl): We need to think-through the ramifications of returning false if
-        //  the store fails to apply the update. Maybe we should delete our local copy and ask for
-        //  a re-sync in this situation?
-        if (!storeSuccess) return false
+        if (!storeSuccess) {
+            // we're not up to date so request latest model from store. This will get merged with
+            // already applied local changes.
+            requestSynchronization()
+        }
 
         notifyUpdate(listOf(op))
 

--- a/java/arcs/core/storage/handle/SingletonImpl.kt
+++ b/java/arcs/core/storage/handle/SingletonImpl.kt
@@ -35,17 +35,23 @@ class SingletonImpl<T : Referencable>(
     /** Get the current value from the backing [StorageProxy]. */
     suspend fun fetch() = value()
 
-    /** Send a new value to the backing [StorageProxy]. */
-    suspend fun set(entity: T) {
+    /**
+     * Send a new value to the backing [StorageProxy]. If this returns false, your operation failed
+     * and should be retried.
+     * */
+    suspend fun set(entity: T): Boolean {
         versionMap.increment()
-        storageProxy.applyOp(CrdtSingleton.Operation.Update(name, versionMap, entity))
+        return storageProxy.applyOp(CrdtSingleton.Operation.Update(name, versionMap, entity))
     }
 
-    /** Clear the value from the backing [StorageProxy]. */
-    suspend fun clear() {
+    /**
+     * Clears the value in the backing [StorageProxy]. If this returns false, your operation failed
+     * and should be retried.
+     * */
+    suspend fun clear(): Boolean {
         // Sync before clearing in order to get an updated versionMap. This ensures we can clear
         // values set by other actors.
         fetch()
-        storageProxy.applyOp(CrdtSingleton.Operation.Clear(name, versionMap))
+        return storageProxy.applyOp(CrdtSingleton.Operation.Clear(name, versionMap))
     }
 }

--- a/java/arcs/core/storage/handle/SingletonImpl.kt
+++ b/java/arcs/core/storage/handle/SingletonImpl.kt
@@ -36,8 +36,8 @@ class SingletonImpl<T : Referencable>(
     suspend fun fetch() = value()
 
     /**
-     * Send a new value to the backing [StorageProxy]. If this returns false, your operation failed
-     * and should be retried.
+     * Sends a new value to the backing [StorageProxy]. If this returns `false`, your operation
+     * did not apply fully. Fetch the latest value and retry.
      * */
     suspend fun set(entity: T): Boolean {
         versionMap.increment()
@@ -45,8 +45,8 @@ class SingletonImpl<T : Referencable>(
     }
 
     /**
-     * Clears the value in the backing [StorageProxy]. If this returns false, your operation failed
-     * and should be retried.
+     * Clears the value in the backing [StorageProxy]. If this returns `false`, your operation
+     * did not apply fully. Fetch the latest value and retry.
      * */
     suspend fun clear(): Boolean {
         // Sync before clearing in order to get an updated versionMap. This ensures we can clear

--- a/javatests/arcs/core/storage/handle/CollectionIntegrationTest.kt
+++ b/javatests/arcs/core/storage/handle/CollectionIntegrationTest.kt
@@ -87,7 +87,7 @@ class CollectionIntegrationTest {
     fun addingElementToA_showsUpInB() = runBlockingTest {
         val person = Person("Miles", 55, true)
 
-        collectionA.store(person.toRawEntity())
+        assertThat(collectionA.store(person.toRawEntity())).isTrue()
         assertThat(collectionA.fetchAll()).containsExactly(person.toRawEntity())
         assertThat(collectionB.fetchAll()).containsExactly(person.toRawEntity())
     }
@@ -103,7 +103,9 @@ class CollectionIntegrationTest {
         assertThat(collectionA.fetchAll()).containsExactly(miles.toRawEntity(), jason.toRawEntity())
         assertThat(collectionB.fetchAll()).containsExactly(miles.toRawEntity(), jason.toRawEntity())
 
-        collectionA.remove(jason.toRawEntity())
+        assertThat(collectionA.remove(jason.toRawEntity())).isTrue()
+        // duplicate remove fails
+        assertThat(collectionA.remove(jason.toRawEntity())).isFalse()
         assertThat(collectionA.fetchAll()).containsExactly(miles.toRawEntity())
         assertThat(collectionB.fetchAll()).containsExactly(miles.toRawEntity())
     }

--- a/javatests/arcs/core/storage/handle/SingletonIntegrationTest.kt
+++ b/javatests/arcs/core/storage/handle/SingletonIntegrationTest.kt
@@ -87,7 +87,7 @@ class SingletonIntegrationTest {
     fun settingOnA_showsUpInB() = runBlockingTest {
         val person = Person("Lou", 95, true)
 
-        singletonA.set(person.toRawEntity())
+        assertThat(singletonA.set(person.toRawEntity())).isTrue()
         assertThat(singletonA.fetch()).isEqualTo(person.toRawEntity())
         assertThat(singletonB.fetch()).isEqualTo(person.toRawEntity())
     }


### PR DESCRIPTION
If an operation fails to apply /locally/, the developer needs to
retrieve the latest version map (by reading the handle), and then retry
the operation. Alternatively, they were doing something invalid, like
removing an entity from a collection more than once. This also needs to
be plumbed through to the developer facing handles, but those are
currently in flux so I've held off until Ray's PR lands.

Note: if the update applies locally but NOT at the store, this is still
success from the developer point of view. The storageProxy will trigger
a sync with storage, and the resulting model will be merged, preserving
the locally generated change.