### PR TITLE
Introduce a 'refinements' and querying in the CollectionImpl

### DIFF
--- a/java/arcs/core/common/Refinement.kt
+++ b/java/arcs/core/common/Refinement.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.core.common
+
+/**
+ * Representation of a refinement type for filtering data from a collection at runtime.
+ *
+ * Supports filtering and data validation via a predicate (optional runtime arguments).
+ * e.g. when querying a collection by id, a refinement predicate such as
+ * ```
+ *  { value: Person, args: String -> value.id == args }
+ * ```
+ * could be used to filter the dataset to only retrive relevant data.
+ * This allows particles to write `people.query('personid')` in their implementation code.
+ */
+class Refinement<EntityType>(
+    val predicate: (value: EntityType, args: Any) -> Boolean
+) {
+    // TODO(cypher1): val toSql: (args: Any) -> String
+
+    /** A helper method for filtering the values of a collection by the associated refinement. */
+    fun filterBy(values: Set<EntityType>, args: Any): Set<EntityType> {
+        return values.filter { value -> predicate(value, args) }.toSet()
+    }
+}

--- a/java/arcs/core/storage/handle/HandleManager.kt
+++ b/java/arcs/core/storage/handle/HandleManager.kt
@@ -110,6 +110,8 @@ class HandleManager(private val aff: ActivationFactoryFactory? = null) {
             }
         }
 
-        return SetHandle(name, storageProxy, callbacks, refinement).also { storageProxy.registerHandle(it) }
+        return SetHandle(name, storageProxy, callbacks, refinement).also {
+            storageProxy.registerHandle(it)
+        }
     }
 }

--- a/java/arcs/core/storage/handle/HandleManager.kt
+++ b/java/arcs/core/storage/handle/HandleManager.kt
@@ -1,5 +1,6 @@
 package arcs.core.storage.handle
 
+import arcs.core.common.Refinement
 import arcs.core.crdt.CrdtSet
 import arcs.core.crdt.CrdtSingleton
 import arcs.core.data.CollectionType
@@ -93,7 +94,8 @@ class HandleManager(private val aff: ActivationFactoryFactory? = null) {
         storageKey: StorageKey,
         schema: Schema,
         callbacks: SetCallbacks<RawEntity>? = null,
-        name: String = storageKey.toKeyString()
+        name: String = storageKey.toKeyString(),
+        refinement: Refinement<RawEntity>? = null
     ): SetHandle<RawEntity> {
         val storeOptions = SetStoreOptions<RawEntity>(
             storageKey = storageKey,
@@ -108,6 +110,6 @@ class HandleManager(private val aff: ActivationFactoryFactory? = null) {
             }
         }
 
-        return SetHandle(name, storageProxy, callbacks).also { storageProxy.registerHandle(it) }
+        return SetHandle(name, storageProxy, callbacks, refinement).also { storageProxy.registerHandle(it) }
     }
 }

--- a/javatests/arcs/core/storage/handle/BUILD
+++ b/javatests/arcs/core/storage/handle/BUILD
@@ -15,6 +15,7 @@ arcs_kt_android_test_suite(
     manifest = "//java/arcs/android/common:AndroidManifest.xml",
     package = "arcs.core.storage.handle",
     deps = [
+        "//java/arcs/core/common",
         "//java/arcs/core/crdt",
         "//java/arcs/core/data",
         "//java/arcs/core/data:rawentity",
@@ -22,6 +23,7 @@ arcs_kt_android_test_suite(
         "//java/arcs/core/storage/driver",
         "//java/arcs/core/storage/handle",
         "//java/arcs/core/storage/referencemode",
+        "//java/arcs/core/testutil",
         "//java/arcs/core/util",
         "//java/arcs/core/util/testutil",
         "//javatests/arcs/core/storage",  # buildcleaner: keep


### PR DESCRIPTION
This adds a type argument to CollectionImpl which is intended to represent the type of the arguments available for querying.

When we support multiple queries and multi-argument queries we should introduce an interface or class to hold these query args.

Note: This is filtering on the full data in the handle and will not be efficient.