### PR TITLE
Add some AndroidHandleManagerTests

### DIFF
--- a/java/arcs/core/storage/handle/CollectionImpl.kt
+++ b/java/arcs/core/storage/handle/CollectionImpl.kt
@@ -13,12 +13,14 @@ package arcs.core.storage.handle
 
 import arcs.core.common.Referencable
 import arcs.core.crdt.CrdtSet
+import arcs.core.storage.Callbacks
 import arcs.core.storage.Handle
 import arcs.core.storage.StorageProxy
 
 /** These typealiases are defined to clean up the class declaration below. */
 typealias SetProxy<T> = StorageProxy<CrdtSet.Data<T>, CrdtSet.IOperation<T>, Set<T>>
 typealias SetBase<T> = Handle<CrdtSet.Data<T>, CrdtSet.IOperation<T>, Set<T>>
+typealias SetCallbacks<T> = Callbacks<CrdtSet.IOperation<T>>
 
 /**
  * Collection Handle implementation for the runtime.
@@ -28,8 +30,9 @@ typealias SetBase<T> = Handle<CrdtSet.Data<T>, CrdtSet.IOperation<T>, Set<T>>
  */
 class CollectionImpl<T : Referencable>(
     name: String,
-    storageProxy: SetProxy<T>
-) : SetBase<T>(name, storageProxy) {
+    storageProxy: SetProxy<T>,
+    callbacks: SetCallbacks<T>? = null
+) : SetBase<T>(name, storageProxy, callbacks) {
     /** Return the number of items in the storage proxy view of the collection. */
     suspend fun size(): Int = value().size
 

--- a/java/arcs/core/storage/handle/HandleManager.kt
+++ b/java/arcs/core/storage/handle/HandleManager.kt
@@ -93,9 +93,8 @@ class HandleManager(private val aff: ActivationFactoryFactory? = null) {
             }
         }
 
-        return SingletonHandle(storageKey.toKeyString(), storageProxy).also {
+        return SingletonHandle(storageKey.toKeyString(), storageProxy, callbacks).also {
             storageProxy.registerHandle(it)
-            it.callback = callbacks
         }
     }
 
@@ -122,9 +121,8 @@ class HandleManager(private val aff: ActivationFactoryFactory? = null) {
             }
         }
 
-        return SetHandle(storageKey.toKeyString(), storageProxy).also {
+        return SetHandle(storageKey.toKeyString(), storageProxy, callbacks).also {
             storageProxy.registerHandle(it)
-            it.callback = callbacks
         }
     }
 }

--- a/java/arcs/core/storage/handle/SingletonImpl.kt
+++ b/java/arcs/core/storage/handle/SingletonImpl.kt
@@ -13,6 +13,7 @@ package arcs.core.storage.handle
 
 import arcs.core.common.Referencable
 import arcs.core.crdt.CrdtSingleton
+import arcs.core.storage.Callbacks
 import arcs.core.storage.Handle
 import arcs.core.storage.StorageProxy
 
@@ -21,6 +22,7 @@ typealias SingletonProxy<T> =
     StorageProxy<CrdtSingleton.Data<T>, CrdtSingleton.IOperation<T>, T?>
 typealias SingletonBase<T> =
     Handle<CrdtSingleton.Data<T>, CrdtSingleton.IOperation<T>, T?>
+typealias SingletonCallbacks<T> = Callbacks<CrdtSingleton.IOperation<T>>
 
 /**
  * Singleton [Handle] implementation for the runtime.
@@ -30,8 +32,9 @@ typealias SingletonBase<T> =
  */
 class SingletonImpl<T : Referencable>(
     name: String,
-    storageProxy: SingletonProxy<T>
-) : SingletonBase<T>(name, storageProxy) {
+    storageProxy: SingletonProxy<T>,
+    callbacks: SingletonCallbacks<T>? = null
+) : SingletonBase<T>(name, storageProxy, callbacks) {
     /** Get the current value from the backing [StorageProxy]. */
     suspend fun fetch() = value()
 

--- a/javatests/arcs/android/storage/handle/AndroidHandleManagerTest.kt
+++ b/javatests/arcs/android/storage/handle/AndroidHandleManagerTest.kt
@@ -6,25 +6,32 @@ import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.work.testing.WorkManagerTestInitHelper
-import arcs.android.storage.service.IStorageService
+import arcs.core.crdt.CrdtSet
+import arcs.core.crdt.CrdtSingleton
+import arcs.core.crdt.VersionMap
 import arcs.core.data.FieldType
 import arcs.core.data.RawEntity
 import arcs.core.data.Schema
 import arcs.core.data.SchemaFields
 import arcs.core.data.SchemaName
 import arcs.core.data.util.toReferencable
+import arcs.core.storage.Callbacks
+import arcs.core.storage.StorageKey
+import arcs.core.storage.driver.RamDisk
 import arcs.core.storage.driver.RamDiskStorageKey
 import arcs.core.storage.handle.HandleManager
 import arcs.core.storage.referencemode.ReferenceModeStorageKey
 import arcs.sdk.android.storage.service.DefaultConnectionFactory
 import arcs.sdk.android.storage.service.testutil.TestBindingDelegate
 import com.google.common.truth.Truth.assertThat
+import com.nhaarman.mockitokotlin2.mock
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.Robolectric
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
 
 
 @Suppress("EXPERIMENTAL_API_USAGE")
@@ -77,6 +84,7 @@ class AndroidHandleManagerTest {
 
     @Before
     fun setUp() {
+        RamDisk.clear()
         app = ApplicationProvider.getApplicationContext()
         app.setTheme(R.style.Theme_AppCompat);
 
@@ -124,9 +132,87 @@ class AndroidHandleManagerTest {
             setHandle.store(entity2)
 
             // Now read back from a different handle
-            val readbackHandle = hm.setHandle(setKey, schema)
-            val readBack = readbackHandle.fetchAll()
+            val secondHandle = hm.setHandle(setKey, schema)
+            val readBack = secondHandle.fetchAll()
             assertThat(readBack).containsExactly(entity1, entity2)
+        }
+    }
+
+    private fun testMapForKey(key: StorageKey) = VersionMap(key.toKeyString() to 1)
+
+    @Test
+    fun testSetHandleOnUpdate()  = runBlockingTest {
+        handleManagerTest { hm ->
+            val testCallback1 = mock<Callbacks<CrdtSet.IOperation<RawEntity>>>()
+            val testCallback2 = mock<Callbacks<CrdtSet.IOperation<RawEntity>>>()
+            val firstHandle = hm.setHandle(setKey, schema, testCallback1)
+            val secondHandle = hm.setHandle(setKey, schema, testCallback2)
+
+            val expectedAdd = CrdtSet.Operation.Add(
+                setKey.toKeyString(),
+                testMapForKey(setKey),
+                entity1
+            )
+            secondHandle.store(entity1)
+            verify(testCallback1, times(1)).onUpdate(expectedAdd)
+            verify(testCallback2, times(1)).onUpdate(expectedAdd)
+
+            firstHandle.remove(entity1)
+            val expectedRemove = CrdtSet.Operation.Remove(
+                setKey.toKeyString(),
+                testMapForKey(setKey),
+                entity1
+            )
+            verify(testCallback1, times(1)).onUpdate(expectedRemove)
+            verify(testCallback2, times(1)).onUpdate(expectedRemove)
+        }
+    }
+
+    @Test
+    fun testSingletonHandleOnUpdate() = runBlockingTest {
+        handleManagerTest { hm ->
+            val testCallback1 = mock<Callbacks<CrdtSingleton.IOperation<RawEntity>>>()
+            val testCallback2 = mock<Callbacks<CrdtSingleton.IOperation<RawEntity>>>()
+            val firstHandle = hm.singletonHandle(singletonKey, schema, testCallback1)
+            val secondHandle = hm.singletonHandle(singletonKey, schema, testCallback2)
+            secondHandle.set(entity1)
+            val expectedAdd = CrdtSingleton.Operation.Update(
+                singletonKey.toKeyString(),
+                testMapForKey(singletonKey),
+                entity1
+            )
+            verify(testCallback1, times(1)).onUpdate(expectedAdd)
+            verify(testCallback2, times(1)).onUpdate(expectedAdd)
+            firstHandle.clear()
+
+            val expectedRemove = CrdtSingleton.Operation.Clear<RawEntity>(
+                singletonKey.toKeyString(),
+                testMapForKey(singletonKey)
+            )
+            verify(testCallback1, times(1)).onUpdate(expectedRemove)
+            verify(testCallback2, times(1)).onUpdate(expectedRemove)
+        }
+    }
+
+    @Test
+    fun testSetSyncOnRegister() = runBlockingTest {
+        handleManagerTest { hm ->
+            val testCallback = mock<Callbacks<CrdtSet.IOperation<RawEntity>>>()
+            val firstHandle = hm.setHandle(setKey, schema, testCallback)
+            verify(testCallback, times(1)).onSync()
+            firstHandle.fetchAll()
+            verify(testCallback, times(1)).onSync()
+        }
+    }
+
+    @Test
+    fun testSingletonSyncOnRegister() = runBlockingTest {
+        handleManagerTest { hm ->
+            val testCallback = mock<Callbacks<CrdtSingleton.IOperation<RawEntity>>>()
+            val firstHandle = hm.singletonHandle(setKey, schema, testCallback)
+            verify(testCallback, times(1)).onSync()
+            firstHandle.fetch()
+            verify(testCallback, times(1)).onSync()
         }
     }
 }


### PR DESCRIPTION
Add some AndroidHandleManagerTests

Tests added:
* Verify that `onSync` fires on handle registration
* Verify that `onUpdate` fires when other handles change data

Issues fixed:
* Improved pattern for setting callbacks on `Handle` to fix `onSync` problem.
* Ensure `Handle` `VersionMap` is updated when `StorageProxy` receives a change that triggers `onSync` or `onUpdate`.
* Change type bound of `Op` type for `Handle` and `StorageProxy` to be `CrdtOperationAtTime`, ensuring that ops include a `VersionMap`.