### PR TITLE
Macros for manifest2proto

### DIFF
--- a/java/arcs/core/data/testdata/BUILD
+++ b/java/arcs/core/data/testdata/BUILD
@@ -1,7 +1,18 @@
+load(
+    "//third_party/java/arcs/build_defs:build_defs.bzl",
+    "arcs_manifest_proto",
+)
+
 licenses(["notice"])
 
 filegroup(
     name = "encoded_manifest",
     srcs = ["example.pb.bin"],
+    visibility = ["//visibility:public"],
+)
+
+arcs_manifest_proto(
+    name = "example",
+    src = "Example.arcs",
     visibility = ["//visibility:public"],
 )

--- a/src/tools/manifest2proto-cli.ts
+++ b/src/tools/manifest2proto-cli.ts
@@ -1,0 +1,64 @@
+import minimist from 'minimist';
+import fs from 'fs';
+import path from 'path';
+import {Runtime} from "../runtime/runtime.js";
+import {serialize2proto} from "./manifest2proto.js";
+
+const opts = minimist(process.argv.slice(2), {
+  string: ['outdir', 'outfile'],
+  alias: {d: 'outdir', f: 'outfile'},
+  default: {outdir: '.'}
+});
+
+if (opts.help || opts._.length === 0) {
+  console.log(`
+Usage
+  $ tools/sigh manifest2proto [options] path/to/manifest.arcs
+
+Description
+  Serializes manifests to a protobuf file. 
+
+Options
+  --outfile, -f output filename; required
+  --outdir, -d  output directory; defaults to '.'
+  --help        usage info
+`);
+  process.exit(0);
+}
+
+if (!opts.outfile) {
+  console.error(`Parameter --outfile is required.`);
+  process.exit(1);
+}
+
+// TODO(alxr): Support proto generation from multiple manifests
+if (opts._.length > 1) {
+  console.error(`Only a single manifest is allowed`);
+  process.exit(1);
+}
+
+if (opts._.some((file) => !file.endsWith('.arcs'))) {
+  console.error(`Only Arcs manifests ('*.arcs') are allowed.`);
+  process.exit(1);
+}
+
+async function main() {
+  try {
+    Runtime.init('../..');
+    fs.mkdirSync(opts.outdir, {recursive: true});
+
+    const buffer = await serialize2proto(opts._[0]);
+
+    const outPath = path.join(opts.outdir, opts.outfile);
+    console.log(outPath);
+
+    const outFile = fs.openSync(outPath, 'w');
+    fs.writeSync(outFile, Buffer.from(buffer));
+    fs.closeSync(outFile);
+  } catch (e) {
+    console.error(e);
+    process.exit(1);
+  }
+}
+
+void main();

--- a/src/tools/manifest2proto-cli.ts
+++ b/src/tools/manifest2proto-cli.ts
@@ -1,8 +1,17 @@
+/**
+ * @license
+ * Copyright (c) 2020 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
 import minimist from 'minimist';
 import fs from 'fs';
 import path from 'path';
-import {Runtime} from "../runtime/runtime.js";
-import {serialize2proto} from "./manifest2proto.js";
+import {Runtime} from '../runtime/runtime.js';
+import {serialize2proto} from './manifest2proto.js';
 
 const opts = minimist(process.argv.slice(2), {
   string: ['outdir', 'outfile'],

--- a/src/tools/manifest2proto.ts
+++ b/src/tools/manifest2proto.ts
@@ -7,9 +7,6 @@
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
-import minimist from 'minimist';
-import fs from 'fs';
-import path from 'path';
 import {Runtime} from '../runtime/runtime.js';
 import protobuf from 'protobufjs';
 
@@ -35,62 +32,3 @@ export async function serialize2proto(path: string): Promise<Uint8Array> {
 
   return manifestProto.encode(message).finish();
 }
-
-const opts = minimist(process.argv.slice(2), {
-  string: ['outdir', 'outfile'],
-  alias: {d: 'outdir', f: 'outfile'},
-  default: {outdir: '.'}
-});
-
-if (opts.help || opts._.length === 0) {
-  console.log(`
-Usage
-  $ tools/sigh manifest2proto [options] path/to/manifest.arcs
-
-Description
-  Serializes manifests to a protobuf file. 
-
-Options
-  --outfile, -f output filename; required
-  --outdir, -d  output directory; defaults to '.'
-  --help        usage info
-`);
-  process.exit(0);
-}
-
-if (!opts.outfile) {
-  console.error(`Parameter --outfile is required.`);
-  process.exit(1);
-}
-
-// TODO(alxr): Support proto generation from multiple manifests
-if (opts._.length > 1) {
-  console.error(`Only a single manifest is allowed`);
-  process.exit(1);
-}
-
-if (opts._.some((file) => !file.endsWith('.arcs'))) {
-  console.error(`Only Arcs manifests ('*.arcs') are allowed.`);
-  process.exit(1);
-}
-
-async function main() {
-  try {
-    Runtime.init('../..');
-    fs.mkdirSync(opts.outdir, {recursive: true});
-
-    const buffer = await serialize2proto(opts._[0]);
-
-    const outPath = path.join(opts.outdir, opts.outfile);
-    console.log(outPath);
-
-    const outFile = fs.openSync(outPath, 'w');
-    fs.writeSync(outFile, Buffer.from(buffer));
-    fs.closeSync(outFile);
-  } catch (e) {
-    console.error(e);
-    process.exit(1);
-  }
-}
-
-void main();

--- a/src/tools/manifest2proto.ts
+++ b/src/tools/manifest2proto.ts
@@ -7,6 +7,9 @@
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
+import minimist from 'minimist';
+import fs from 'fs';
+import path from 'path';
 import {Runtime} from '../runtime/runtime.js';
 import protobuf from 'protobufjs';
 
@@ -32,3 +35,62 @@ export async function serialize2proto(path: string): Promise<Uint8Array> {
 
   return manifestProto.encode(message).finish();
 }
+
+const opts = minimist(process.argv.slice(2), {
+  string: ['outdir', 'outfile'],
+  alias: {d: 'outdir', f: 'outfile'},
+  default: {outdir: '.'}
+});
+
+if (opts.help || opts._.length === 0) {
+  console.log(`
+Usage
+  $ tools/sigh manifest2proto [options] path/to/manifest.arcs
+
+Description
+  Serializes manifests to a protobuf file. 
+
+Options
+  --outfile, -f output filename; required
+  --outdir, -d  output directory; defaults to '.'
+  --help        usage info
+`);
+  process.exit(0);
+}
+
+if (!opts.outfile) {
+  console.error(`Parameter --outfile is required.`);
+  process.exit(1);
+}
+
+// TODO(alxr): Support proto generation from multiple manifests
+if (opts._.length > 1) {
+  console.error(`Only a single manifest is allowed`);
+  process.exit(1);
+}
+
+if (opts._.some((file) => !file.endsWith('.arcs'))) {
+  console.error(`Only Arcs manifests ('*.arcs') are allowed.`);
+  process.exit(1);
+}
+
+async function main() {
+  try {
+    Runtime.init('../..');
+    fs.mkdirSync(opts.outdir, {recursive: true});
+
+    const buffer = await serialize2proto(opts._[0]);
+
+    const outPath = path.join(opts.outdir, opts.outfile);
+    console.log(outPath);
+
+    const outFile = fs.openSync(outPath, 'w');
+    fs.writeSync(outFile, Buffer.from(buffer));
+    fs.closeSync(outFile)
+  } catch (e) {
+    console.error(e);
+    process.exit(1);
+  }
+}
+
+void main();

--- a/src/tools/manifest2proto.ts
+++ b/src/tools/manifest2proto.ts
@@ -86,7 +86,7 @@ async function main() {
 
     const outFile = fs.openSync(outPath, 'w');
     fs.writeSync(outFile, Buffer.from(buffer));
-    fs.closeSync(outFile)
+    fs.closeSync(outFile);
   } catch (e) {
     console.error(e);
     process.exit(1);

--- a/third_party/java/arcs/build_defs/build_defs.bzl
+++ b/third_party/java/arcs/build_defs/build_defs.bzl
@@ -18,6 +18,7 @@ load(
     _arcs_manifest = "arcs_manifest",
     _arcs_manifest_bundle = "arcs_manifest_bundle",
     _arcs_manifest_json = "arcs_manifest_json",
+    _arcs_manifest_proto = "arcs_manifest_proto",
 )
 load(
     "//third_party/java/arcs/build_defs/internal:schemas.bzl",
@@ -49,6 +50,8 @@ arcs_manifest = _arcs_manifest
 arcs_manifest_bundle = _arcs_manifest_bundle
 
 arcs_manifest_json = _arcs_manifest_json
+
+arcs_manifest_proto = _arcs_manifest_proto
 
 kt_js_library = _kt_js_library
 

--- a/third_party/java/arcs/build_defs/internal/manifest.bzl
+++ b/third_party/java/arcs/build_defs/internal/manifest.bzl
@@ -68,7 +68,7 @@ def arcs_manifest_proto(name, src, deps = [], out = None, visibility = None):
 
     Args:
       name: the name of the target to create
-      srcs: an Arcs manifest files to serialize
+      src: an Arcs manifest files to serialize
       deps: list of dependencies (other manifests)
       out: the name of the output artifact (a proto file).
       visibility: list of visibilities

--- a/third_party/java/arcs/build_defs/internal/manifest.bzl
+++ b/third_party/java/arcs/build_defs/internal/manifest.bzl
@@ -61,6 +61,29 @@ def arcs_manifest_json(name, srcs = [], deps = [], out = None, visibility = None
         sigh_cmd = "manifest2json --outdir $(dirname {OUT}) --outfile $(basename {OUT}) {SRC}",
     )
 
+def arcs_manifest_proto(name, src, deps = [], out = None, visibility = None):
+    """Serialize a manifest file.
+
+    This converts a '.arcs' file into a protobuf representation, using manifest2proto.
+
+    Args:
+      name: the name of the target to create
+      srcs: an Arcs manifest files to serialize
+      deps: list of dependencies (other manifests)
+      out: the name of the output artifact (a proto file).
+      visibility: list of visibilities
+    """
+    outs = [out] if out != None else [output_name(name, ".pb.bin")]
+
+    sigh_command(
+        name = name,
+        srcs = [src],
+        outs = outs,
+        deps = deps,
+        progress_message = "Serializing manifest",
+        sigh_cmd = "manifest2proto --outdir $(dirname {OUT}) --outfile $(basename {OUT}) {SRC}",
+    )
+
 def _generate_root_manifest_content(label, input_files):
     """Generates the contents for a root manifest for a manifest bundle.
 

--- a/tools/sigh.ts
+++ b/tools/sigh.ts
@@ -84,6 +84,7 @@ const steps: {[index: string]: ((args?: string[]) => boolean|Promise<boolean>)[]
   bundle: runNodeScriptSteps('bundle'),
   schema2wasm: runNodeScriptSteps('schema2wasm'),
   manifest2json: runNodeScriptSteps('manifest2json'),
+  manifest2proto: runNodeScriptSteps('manifest2proto'),
   flowcheck: runNodeScriptSteps('flowcheck'),
   devServer: [peg, build, webpack, devServer],
   languageServer: [peg, build, buildLS, webpackLS],
@@ -114,6 +115,9 @@ const scripts: {[index: string]: string} = {
 
   /** Serializes manifests to JSON. */
   manifest2json: 'build/tools/manifest2json.js',
+
+  /** Serializes a manifest to protobufs. */
+  manifest2proto: 'build/tools/manifest2proto.js',
 };
 
 const eslintCache = '.eslint_sigh_cache';

--- a/tools/sigh.ts
+++ b/tools/sigh.ts
@@ -117,7 +117,7 @@ const scripts: {[index: string]: string} = {
   manifest2json: 'build/tools/manifest2json.js',
 
   /** Serializes a manifest to protobufs. */
-  manifest2proto: 'build/tools/manifest2proto.js',
+  manifest2proto: 'build/tools/manifest2proto-cli.js',
 };
 
 const eslintCache = '.eslint_sigh_cache';


### PR DESCRIPTION
Extended @piotrswigon's manifest2proto script into a CLI tool. Added bazel macro wrapper (plus an example BUILD rule). 