### PR TITLE
Adds a UnionFind datastructure to utils.

### DIFF
--- a/java/arcs/core/util/UnionFind.kt
+++ b/java/arcs/core/util/UnionFind.kt
@@ -12,28 +12,25 @@
 package arcs.core.util
 
 /**
- * A union-find datastructure for computing equivalence classes
- * consisting of `Element` instances.
+ * A union-find datastructure for computing equivalence classes consisting of [E] instances.
+ * This datastructure is not thread safe.
  */
-class UnionFind<Element> {
+class UnionFind<E> {
     /**
      * A node in the union find datastructure.
      */
-    private inner class Node(e: Element, p: Node?) {
-        val element: Element = e
-        var parent: Node? = p
-    }
+    private data class Node<E>(val element: E, var parent: Node<E>? = null)
 
-    private val nodes = HashMap<Element, Node>()
+    private val nodes = mutableMapOf<E, Node<E>>()
 
     /**
      * Unifies the equivalence classes of elements [e1] and [e2]. If either
      * element is not present in any set, it is added.
      */
-    fun union(e1: Element, e2: Element) {
+    fun union(e1: E, e2: E) {
         val e1Root = findRoot(e1)
         val e2Root = findRoot(e2)
-        if (e1Root != e2Root) {
+        if (e1Root !== e2Root) {
             e1Root.parent = e2Root
         }
     }
@@ -42,35 +39,27 @@ class UnionFind<Element> {
      * Find the equivalence class for the element [e]. If the element
      * is not already present in any set, a new singleton set is created.
      */
-    fun find(e: Element): Element {
-        return findRoot(e).element
-    }
+    fun find(e: E): E = findRoot(e).element
 
     /**
      * If [e] is not already in any set, create a set with a single element.
      */
-    fun makeSet(e: Element) {
+    fun makeSet(e: E) {
         getOrCreateNode(e)
     }
 
     /**
      * Get or create a union-find node for the element [e].
      */
-    private fun getOrCreateNode(e: Element): Node {
-        var result = nodes[e]
-        if (result == null) {
-            result = Node(e, null)
-            nodes[e] = result
-        }
-        return result
-    }
+    private fun getOrCreateNode(e: E): Node<E> =
+        nodes[e] ?: Node(e, null).also { nodes[e] = it }
 
     /**
      * Returns the root node for element [e].
      */
-    private fun findRoot(e: Element): Node {
-        var node: Node = getOrCreateNode(e)
-        var parent: Node? = node.parent
+    private fun findRoot(e: E): Node<E> {
+        var node = getOrCreateNode(e)
+        var parent = node.parent
         while (parent != null) {
             node = parent
             parent = node.parent

--- a/java/arcs/core/util/UnionFind.kt
+++ b/java/arcs/core/util/UnionFind.kt
@@ -17,13 +17,6 @@ package arcs.core.util
  */
 class UnionFind<E> {
     /**
-     * A node in the union find datastructure.
-     */
-    private data class Node<E>(val element: E, var parent: Node<E>? = null)
-
-    private val nodes = mutableMapOf<E, Node<E>>()
-
-    /**
      * Unifies the equivalence classes of elements [e1] and [e2]. If either
      * element is not present in any set, it is added.
      */
@@ -66,4 +59,11 @@ class UnionFind<E> {
         }
         return node
     }
+
+    private val nodes = mutableMapOf<E, Node<E>>()
+
+    /**
+     * A node in the union find datastructure.
+     */
+    private data class Node<E>(val element: E, var parent: Node<E>? = null)
 }

--- a/java/arcs/core/util/UnionFind.kt
+++ b/java/arcs/core/util/UnionFind.kt
@@ -16,65 +16,65 @@ package arcs.core.util
  * consisting of `Element` instances.
  */
 class UnionFind<Element> {
-  /**
-   * A node in the union find datastructure.
-   */
-  private inner class Node(e: Element, p: Node?) {
-    val element: Element = e
-    var parent: Node? = p
-  }
-
-  private val nodes = HashMap<Element, Node>()
-
-  /**
-   * Unifies the equivalence classes of elements [e1] and [e2]. If either
-   * element is not present in any set, it is added.
-   */
-  fun union(e1: Element, e2: Element) {
-    val e1Root = findRoot(e1)
-    val e2Root = findRoot(e2)
-    if (e1Root != e2Root) {
-      e1Root.parent = e2Root
+    /**
+     * A node in the union find datastructure.
+     */
+    private inner class Node(e: Element, p: Node?) {
+        val element: Element = e
+        var parent: Node? = p
     }
-  }
 
-  /**
-   * Find the equivalence class for the element [e]. If the element
-   * is not already present in any set, a new singleton set is created.
-   */
-  fun find(e: Element): Element {
-    return findRoot(e).element
-  }
+    private val nodes = HashMap<Element, Node>()
 
-  /**
-   * If [e] is not already in any set, create a set with a single element.
-   */
-  fun makeSet(e: Element) {
-    getOrCreateNode(e)
-  }
-
-  /**
-   * Get or create a union-find node for the element [e].
-   */
-  private fun getOrCreateNode(e: Element): Node {
-    var result = nodes[e]
-    if (result == null) {
-      result = Node(e, null)
-      nodes[e] = result
+    /**
+     * Unifies the equivalence classes of elements [e1] and [e2]. If either
+     * element is not present in any set, it is added.
+     */
+    fun union(e1: Element, e2: Element) {
+        val e1Root = findRoot(e1)
+        val e2Root = findRoot(e2)
+        if (e1Root != e2Root) {
+            e1Root.parent = e2Root
+        }
     }
-    return result
-  }
 
-  /**
-   * Returns the root node for element [e].
-   */
-  private fun findRoot(e: Element): Node {
-    var node: Node = getOrCreateNode(e)
-    var parent: Node? = node.parent
-    while (parent != null) {
-      node = parent
-      parent = node.parent
+    /**
+     * Find the equivalence class for the element [e]. If the element
+     * is not already present in any set, a new singleton set is created.
+     */
+    fun find(e: Element): Element {
+        return findRoot(e).element
     }
-    return node
-  }
+
+    /**
+     * If [e] is not already in any set, create a set with a single element.
+     */
+    fun makeSet(e: Element) {
+        getOrCreateNode(e)
+    }
+
+    /**
+     * Get or create a union-find node for the element [e].
+     */
+    private fun getOrCreateNode(e: Element): Node {
+        var result = nodes[e]
+        if (result == null) {
+            result = Node(e, null)
+            nodes[e] = result
+        }
+        return result
+    }
+
+    /**
+     * Returns the root node for element [e].
+     */
+    private fun findRoot(e: Element): Node {
+        var node: Node = getOrCreateNode(e)
+        var parent: Node? = node.parent
+        while (parent != null) {
+            node = parent
+            parent = node.parent
+        }
+        return node
+    }
 }

--- a/java/arcs/core/util/UnionFind.kt
+++ b/java/arcs/core/util/UnionFind.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC.
+ * Copyright 2020 Google LLC.
  *
  * This code may only be used under the BSD style license found at
  * http://polymer.github.io/LICENSE.txt
@@ -11,10 +11,14 @@
 
 package arcs.core.util
 
-/// A union-find datastructure for computing equivalence classes
-/// consisting of `Element` instances.
+/**
+ * A union-find datastructure for computing equivalence classes
+ * consisting of `Element` instances.
+ */
 class UnionFind<Element> {
-  // A node in the union find datastructure.
+  /**
+   * A node in the union find datastructure.
+   */
   private inner class Node(e: Element, p: Node?) {
     val element: Element = e
     var parent: Node? = p
@@ -22,8 +26,10 @@ class UnionFind<Element> {
 
   private val nodes = HashMap<Element, Node>()
 
-  // Unifies the equivalence classes of elements `e1` and `e2`. If an
-  // element is not present in any set, it is added.
+  /**
+   * Unifies the equivalence classes of elements [e1] and [e2]. If either
+   * element is not present in any set, it is added.
+   */
   fun union(e1: Element, e2: Element) {
     val e1Root = findRoot(e1)
     val e2Root = findRoot(e2)
@@ -32,17 +38,24 @@ class UnionFind<Element> {
     }
   }
 
-  // Find the equivalence class for the given element. If the element
-  // is not already present in any set, a new singleton set is created.
+  /**
+   * Find the equivalence class for the element [e]. If the element
+   * is not already present in any set, a new singleton set is created.
+   */
   fun find(e: Element): Element {
     return findRoot(e).element
   }
 
-  // If it is not already in the set, create a set with a single element.
+  /**
+   * If [e] is not already in any set, create a set with a single element.
+   */
   fun makeSet(e: Element) {
     getOrCreateNode(e)
   }
 
+  /**
+   * Get or create a union-find node for the element [e].
+   */
   private fun getOrCreateNode(e: Element): Node {
     var result = nodes[e]
     if (result == null) {
@@ -52,6 +65,9 @@ class UnionFind<Element> {
     return result
   }
 
+  /**
+   * Returns the root node for element [e].
+   */
   private fun findRoot(e: Element): Node {
     var node: Node = getOrCreateNode(e)
     var parent: Node? = node.parent

--- a/java/arcs/core/util/UnionFind.kt
+++ b/java/arcs/core/util/UnionFind.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.core.util
+
+/// A union-find datastructure for computing equivalence classes
+/// consisting of `Element` instances.
+class UnionFind<Element> {
+  // A node in the union find datastructure.
+  private inner class Node(e: Element, p: Node?) {
+    val element: Element = e
+    var parent: Node? = p
+  }
+
+  private val nodes = HashMap<Element, Node>()
+
+  // Unifies the equivalence classes of elements `e1` and `e2`. If an
+  // element is not present in any set, it is added.
+  fun union(e1: Element, e2: Element) {
+    val e1Root = findRoot(e1)
+    val e2Root = findRoot(e2)
+    if (e1Root != e2Root) {
+      e1Root.parent = e2Root
+    }
+  }
+
+  // Find the equivalence class for the given element. If the element
+  // is not already present in any set, a new singleton set is created.
+  fun find(e: Element): Element {
+    return findRoot(e).element
+  }
+
+  // If it is not already in the set, create a set with a single element.
+  fun makeSet(e: Element) {
+    getOrCreateNode(e)
+  }
+
+  private fun getOrCreateNode(e: Element): Node {
+    var result = nodes[e]
+    if (result == null) {
+      result = Node(e, null)
+      nodes[e] = result
+    }
+    return result
+  }
+
+  private fun findRoot(e: Element): Node {
+    var node: Node = getOrCreateNode(e)
+    var parent: Node? = node.parent
+    while (parent != null) {
+      node = parent
+      parent = node.parent
+    }
+    return node
+  }
+}

--- a/java/arcs/core/util/UnionFind.kt
+++ b/java/arcs/core/util/UnionFind.kt
@@ -28,8 +28,8 @@ class UnionFind<E> {
      * element is not present in any set, it is added.
      */
     fun union(e1: E, e2: E) {
-        val e1Root = findRoot(e1)
-        val e2Root = findRoot(e2)
+        val e1Root = e1.findRoot()
+        val e2Root = e2.findRoot()
         if (e1Root !== e2Root) {
             e1Root.parent = e2Root
         }
@@ -39,7 +39,7 @@ class UnionFind<E> {
      * Find the equivalence class for the element [e]. If the element
      * is not already present in any set, a new singleton set is created.
      */
-    fun find(e: E): E = findRoot(e).element
+    fun find(e: E): E = e.findRoot().element
 
     /**
      * If [e] is not already in any set, create a set with a single element.
@@ -57,8 +57,8 @@ class UnionFind<E> {
     /**
      * Returns the root node for element [e].
      */
-    private fun findRoot(e: E): Node<E> {
-        var node = getOrCreateNode(e)
+    private fun E.findRoot(): Node<E> {
+        var node = getOrCreateNode(this)
         var parent = node.parent
         while (parent != null) {
             node = parent

--- a/javatests/arcs/core/util/UnionFindTest.kt
+++ b/javatests/arcs/core/util/UnionFindTest.kt
@@ -1,0 +1,45 @@
+package arcs.core.util
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Assert.fail
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+
+@RunWith(JUnit4::class)
+class UnionFindTest {
+
+  @Test
+  fun makeSetCreatesDisjointSets() {
+    var uf = UnionFind<Int>()
+    uf.makeSet(10)
+    uf.makeSet(20)
+    assertThat(uf.find(10)).isEqualTo(10)
+    assertThat(uf.find(20)).isEqualTo(20)
+    assertThat(uf.find(10)).isNotEqualTo(uf.find(20))
+    assertThat(uf.find(20)).isNotEqualTo(uf.find(10))
+  }
+
+  @Test
+  fun unionMergesClasses() {
+    var uf = UnionFind<Int>()
+    uf.makeSet(10)
+    uf.makeSet(20)
+    uf.makeSet(30)
+    uf.makeSet(40)
+    uf.union(20, 30)
+    uf.union(30, 40)
+    // 10 is its own equivalence class.
+    assertThat(uf.find(10)).isEqualTo(10)
+    // 20, 30, 40 are in the same equivalence class.
+    assertThat(uf.find(20)).isEqualTo(uf.find(30))
+    assertThat(uf.find(20)).isEqualTo(uf.find(40))
+    assertThat(uf.find(30)).isEqualTo(uf.find(40))
+    // 10 is in a different equivalent class than {20, 30, 40}
+    assertThat(uf.find(10)).isNotEqualTo(uf.find(20))
+    assertThat(uf.find(10)).isNotEqualTo(uf.find(30))
+    assertThat(uf.find(10)).isNotEqualTo(uf.find(40))
+  }
+}

--- a/javatests/arcs/core/util/UnionFindTest.kt
+++ b/javatests/arcs/core/util/UnionFindTest.kt
@@ -1,3 +1,13 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
 package arcs.core.util
 
 import com.google.common.truth.Truth.assertThat
@@ -10,7 +20,6 @@ import org.junit.runners.JUnit4
 
 @RunWith(JUnit4::class)
 class UnionFindTest {
-
   @Test
   fun makeSetCreatesDisjointSets() {
     var uf = UnionFind<Int>()

--- a/javatests/arcs/core/util/UnionFindTest.kt
+++ b/javatests/arcs/core/util/UnionFindTest.kt
@@ -17,7 +17,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
-
 @RunWith(JUnit4::class)
 class UnionFindTest {
     @Test

--- a/javatests/arcs/core/util/UnionFindTest.kt
+++ b/javatests/arcs/core/util/UnionFindTest.kt
@@ -20,35 +20,35 @@ import org.junit.runners.JUnit4
 
 @RunWith(JUnit4::class)
 class UnionFindTest {
-  @Test
-  fun makeSetCreatesDisjointSets() {
-    var uf = UnionFind<Int>()
-    uf.makeSet(10)
-    uf.makeSet(20)
-    assertThat(uf.find(10)).isEqualTo(10)
-    assertThat(uf.find(20)).isEqualTo(20)
-    assertThat(uf.find(10)).isNotEqualTo(uf.find(20))
-    assertThat(uf.find(20)).isNotEqualTo(uf.find(10))
-  }
+    @Test
+    fun makeSetCreatesDisjointSets() {
+        var uf = UnionFind<Int>()
+        uf.makeSet(10)
+        uf.makeSet(20)
+        assertThat(uf.find(10)).isEqualTo(10)
+        assertThat(uf.find(20)).isEqualTo(20)
+        assertThat(uf.find(10)).isNotEqualTo(uf.find(20))
+        assertThat(uf.find(20)).isNotEqualTo(uf.find(10))
+    }
 
-  @Test
-  fun unionMergesClasses() {
-    var uf = UnionFind<Int>()
-    uf.makeSet(10)
-    uf.makeSet(20)
-    uf.makeSet(30)
-    uf.makeSet(40)
-    uf.union(20, 30)
-    uf.union(30, 40)
-    // 10 is its own equivalence class.
-    assertThat(uf.find(10)).isEqualTo(10)
-    // 20, 30, 40 are in the same equivalence class.
-    assertThat(uf.find(20)).isEqualTo(uf.find(30))
-    assertThat(uf.find(20)).isEqualTo(uf.find(40))
-    assertThat(uf.find(30)).isEqualTo(uf.find(40))
-    // 10 is in a different equivalent class than {20, 30, 40}
-    assertThat(uf.find(10)).isNotEqualTo(uf.find(20))
-    assertThat(uf.find(10)).isNotEqualTo(uf.find(30))
-    assertThat(uf.find(10)).isNotEqualTo(uf.find(40))
-  }
+    @Test
+    fun unionMergesClasses() {
+        var uf = UnionFind<Int>()
+        uf.makeSet(10)
+        uf.makeSet(20)
+        uf.makeSet(30)
+        uf.makeSet(40)
+        uf.union(20, 30)
+        uf.union(30, 40)
+        // 10 is its own equivalence class.
+        assertThat(uf.find(10)).isEqualTo(10)
+        // 20, 30, 40 are in the same equivalence class.
+        assertThat(uf.find(20)).isEqualTo(uf.find(30))
+        assertThat(uf.find(20)).isEqualTo(uf.find(40))
+        assertThat(uf.find(30)).isEqualTo(uf.find(40))
+        // 10 is in a different equivalent class than {20, 30, 40}
+        assertThat(uf.find(10)).isNotEqualTo(uf.find(20))
+        assertThat(uf.find(10)).isNotEqualTo(uf.find(30))
+        assertThat(uf.find(10)).isNotEqualTo(uf.find(40))
+    }
 }


### PR DESCRIPTION
This PR has a very simple implementation of [union-find](https://en.wikipedia.org/wiki/Disjoint-set_data_structure) without path compression or any of the other optimizations. Optimizations will be added in subsequent PRs. 

The union find data structure is needed to implement the type checker in Kotlin.
