### PR TITLE
Add canWrite flag on core handle for TS parity.

### DIFF
--- a/java/arcs/core/storage/Handle.kt
+++ b/java/arcs/core/storage/Handle.kt
@@ -73,9 +73,15 @@ open class Handle<Data : CrdtData, Op : CrdtOperationAtTime, T>(
 
     /**
      * [canRead] is whether this handle reads data so proxy can decide whether to keep its crdt
-     * up to date
+     * up to date.
      */
-    val canRead: Boolean = true
+    val canRead: Boolean = true,
+
+    /**
+     * [canWrite] is whether this handle is writable. This can be used to enforce additional runtime
+     * checks.
+     */
+    val canWrite: Boolean = true
 ) {
     protected val log = TaggedLog { "Handle($name)" }
 

--- a/javatests/arcs/core/storage/StorageProxyTest.kt
+++ b/javatests/arcs/core/storage/StorageProxyTest.kt
@@ -230,7 +230,7 @@ class StorageProxyTest {
         storageProxy: StorageProxy<CrdtData, CrdtOperationAtTime, String>,
         reader: Boolean
     ) = mock<Callbacks<CrdtOperationAtTime>>().let {
-        HandleWithCallback(Handle(name, storageProxy, it, reader), it)
+        HandleWithCallback(Handle(name, storageProxy, it, reader, true), it)
     }
 
     fun CrdtModel<CrdtData, CrdtOperationAtTime, String>.appliesOpAs(op: CrdtOperationAtTime, result: Boolean) {


### PR DESCRIPTION
This can be used as an additional runtime check that a Handle op can
check before accepting a write operation.