### PR TITLE
Include handle instance as callback argument

### DIFF
--- a/java/arcs/core/storage/handle/CollectionImpl.kt
+++ b/java/arcs/core/storage/handle/CollectionImpl.kt
@@ -13,14 +13,21 @@ package arcs.core.storage.handle
 
 import arcs.core.common.Referencable
 import arcs.core.crdt.CrdtSet
+import arcs.core.storage.ActivationFactory
 import arcs.core.storage.Callbacks
 import arcs.core.storage.Handle
 import arcs.core.storage.StorageProxy
+import arcs.core.storage.StoreOptions
 
 /** These typealiases are defined to clean up the class declaration below. */
+typealias SetData<T> = CrdtSet.Data<T>
+typealias SetOp<T> = CrdtSet.IOperation<T>
+typealias SetStoreOptions<T> = StoreOptions<SetData<T>, SetOp<T>, Set<T>>
+typealias SetHandle<T> = CollectionImpl<T>
+typealias SetActivationFactory<T> = ActivationFactory<SetData<T>, SetOp<T>, Set<T>>
 typealias SetProxy<T> = StorageProxy<CrdtSet.Data<T>, CrdtSet.IOperation<T>, Set<T>>
 typealias SetBase<T> = Handle<CrdtSet.Data<T>, CrdtSet.IOperation<T>, Set<T>>
-typealias SetCallbacks<T> = Callbacks<CrdtSet.IOperation<T>>
+typealias SetCallbacks<T> = Callbacks<SetData<T>, SetOp<T>, Set<T>>
 
 /**
  * Collection Handle implementation for the runtime.

--- a/java/arcs/core/storage/handle/HandleManager.kt
+++ b/java/arcs/core/storage/handle/HandleManager.kt
@@ -7,29 +7,14 @@ import arcs.core.data.EntityType
 import arcs.core.data.RawEntity
 import arcs.core.data.Schema
 import arcs.core.data.SingletonType
-import arcs.core.storage.ActivationFactory
-import arcs.core.storage.Callbacks
 import arcs.core.storage.ExistenceCriteria
 import arcs.core.storage.StorageKey
 import arcs.core.storage.StorageMode
 import arcs.core.storage.StorageProxy
 import arcs.core.storage.Store
-import arcs.core.storage.StoreOptions
 import arcs.core.util.guardedBy
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-
-typealias SingletonData<T> = CrdtSingleton.Data<T>
-typealias SingletonOp<T> = CrdtSingleton.IOperation<T>
-typealias SingletonStoreOptions<T> = StoreOptions<SingletonData<T>, SingletonOp<T>, T?>
-typealias SingletonHandle<T> = SingletonImpl<T>
-typealias SingletonActivationFactory<T> = ActivationFactory<SingletonData<T>, SingletonOp<T>, T?>
-
-typealias SetData<T> = CrdtSet.Data<T>
-typealias SetOp<T> = CrdtSet.IOperation<T>
-typealias SetStoreOptions<T> = StoreOptions<SetData<T>, SetOp<T>, Set<T>>
-typealias SetHandle<T> = CollectionImpl<T>
-typealias SetActivationFactory<T> = ActivationFactory<SetData<T>, SetOp<T>, Set<T>>
 
 /**
  * This interface is a convenience for creating the two common types of activation factories
@@ -75,7 +60,7 @@ class HandleManager(private val aff: ActivationFactoryFactory? = null) {
     suspend fun singletonHandle(
         storageKey: StorageKey,
         schema: Schema,
-        callbacks: Callbacks<SingletonOp<RawEntity>>? = null
+        callbacks: SingletonCallbacks<RawEntity>? = null
     ): SingletonHandle<RawEntity> {
         val storeOptions = SingletonStoreOptions<RawEntity>(
             storageKey = storageKey,
@@ -106,7 +91,7 @@ class HandleManager(private val aff: ActivationFactoryFactory? = null) {
     suspend fun setHandle(
         storageKey: StorageKey,
         schema: Schema,
-        callbacks: Callbacks<SetOp<RawEntity>>? = null
+        callbacks: SetCallbacks<RawEntity>? = null
     ): SetHandle<RawEntity> {
         val storeOptions = SetStoreOptions<RawEntity>(
             storageKey = storageKey,

--- a/java/arcs/core/storage/handle/SingletonImpl.kt
+++ b/java/arcs/core/storage/handle/SingletonImpl.kt
@@ -13,16 +13,21 @@ package arcs.core.storage.handle
 
 import arcs.core.common.Referencable
 import arcs.core.crdt.CrdtSingleton
+import arcs.core.storage.ActivationFactory
 import arcs.core.storage.Callbacks
 import arcs.core.storage.Handle
 import arcs.core.storage.StorageProxy
+import arcs.core.storage.StoreOptions
 
 /** These typealiases are defined to clean up the class declaration below. */
-typealias SingletonProxy<T> =
-    StorageProxy<CrdtSingleton.Data<T>, CrdtSingleton.IOperation<T>, T?>
-typealias SingletonBase<T> =
-    Handle<CrdtSingleton.Data<T>, CrdtSingleton.IOperation<T>, T?>
-typealias SingletonCallbacks<T> = Callbacks<CrdtSingleton.IOperation<T>>
+typealias SingletonProxy<T> = StorageProxy<SingletonData<T>, SingletonOp<T>, T?>
+typealias SingletonBase<T> = Handle<SingletonData<T>, SingletonOp<T>, T?>
+typealias SingletonData<T> = CrdtSingleton.Data<T>
+typealias SingletonOp<T> = CrdtSingleton.IOperation<T>
+typealias SingletonStoreOptions<T> = StoreOptions<SingletonData<T>, SingletonOp<T>, T?>
+typealias SingletonHandle<T> = SingletonImpl<T>
+typealias SingletonActivationFactory<T> = ActivationFactory<SingletonData<T>, SingletonOp<T>, T?>
+typealias SingletonCallbacks<T> = Callbacks<SingletonData<T>, SingletonOp<T>, T?>
 
 /**
  * Singleton [Handle] implementation for the runtime.

--- a/javatests/arcs/core/storage/StorageProxyTest.kt
+++ b/javatests/arcs/core/storage/StorageProxyTest.kt
@@ -59,7 +59,7 @@ class StorageProxyTest {
         storageProxy.registerHandle(readHandle)
         storageProxy.onMessage(ProxyMessage.Operations(listOf(mockCrdtOperation), null))
 
-        verify(readCallback).onUpdate(mockCrdtOperation)
+        verify(readCallback).onUpdate(readHandle, mockCrdtOperation)
     }
 
     @Test
@@ -71,7 +71,7 @@ class StorageProxyTest {
         storageProxy.registerHandle(readHandle)
         storageProxy.onMessage(ProxyMessage.ModelUpdate(mockCrdtData, null))
 
-        verify(readCallback).onSync()
+        verify(readCallback).onSync(readHandle)
     }
 
     @Test
@@ -96,7 +96,7 @@ class StorageProxyTest {
         storageProxy.registerHandle(writeHandle)
         assertThat(storageProxy.applyOp(mockCrdtOperation)).isTrue()
 
-        verify(readCallback).onUpdate(mockCrdtOperation)
+        verify(readCallback).onUpdate(readHandle, mockCrdtOperation)
         verifyNoMoreInteractions(writeCallback)
     }
 
@@ -222,14 +222,14 @@ class StorageProxyTest {
 
     private data class HandleWithCallback<Data : CrdtData, Op : CrdtOperationAtTime, T>(
         val handle: Handle<Data, Op, T>,
-        val callback: Callbacks<Op>
+        val callback: Callbacks<Data, Op, T>
     )
 
     private fun newHandle(
         name: String,
         storageProxy: StorageProxy<CrdtData, CrdtOperationAtTime, String>,
         reader: Boolean
-    ) = mock<Callbacks<CrdtOperationAtTime>>().let {
+    ) = mock<Callbacks<CrdtData, CrdtOperationAtTime, String>>().let {
         HandleWithCallback(Handle(name, storageProxy, it, reader, true), it)
     }
 


### PR DESCRIPTION
This more closely matches the structure of the TS handles, and makes it
easier for the callback implementations to interact with the `Handle`
that triggered them.