### PR TITLE
Add cloud function to publish cloud build status.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Cloud Build Status](https://storage.googleapis.com/arcs-github-gcb-badges/builds/arcs/branches/master.svg)](https://console.cloud.google.com/cloud-build/builds?project=arcs-265404&pageState=(%22builds%22:(%22f%22:%22%255B%257B_22k_22_3A_22Trigger%2520Name_22_2C_22t_22_3A10_2C_22v_22_3A_22_5C_22Arcs-Master-Trigger_5C_22_22_2C_22s_22_3Atrue_2C_22i_22_3A_22triggerName_22%257D%255D%22)))
+[![Cloud Build Status](https://storage.googleapis.com/arcs-github-gcb-badges/builds/arcs/branches/master.svg)](https://console.cloud.google.com/cloud-build/builds?query=trigger_id%3D%22bdf768b5-8901-43e5-814c-f3adffff2eab%22&project=arcs-265404)
 [![Build Status](https://travis-ci.org/PolymerLabs/arcs.svg?branch=master)](https://travis-ci.org/PolymerLabs/arcs)
 [![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/rswlpkq2vtp9cns0/branch/master?svg=true)](https://ci.appveyor.com/project/arcs/arcs-3i77k/branch/master)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
+[![Cloud Build Status](https://storage.googleapis.com/arcs-github-gcb-badges/builds/arcs/branches/master.svg)](https://console.cloud.google.com/cloud-build/builds?project=arcs-265404&pageState=(%22builds%22:(%22f%22:%22%255B%257B_22k_22_3A_22Trigger%2520Name_22_2C_22t_22_3A10_2C_22v_22_3A_22_5C_22Arcs-Master-Trigger_5C_22_22_2C_22s_22_3Atrue_2C_22i_22_3A_22triggerName_22%257D%255D%22)))
 [![Build Status](https://travis-ci.org/PolymerLabs/arcs.svg?branch=master)](https://travis-ci.org/PolymerLabs/arcs)
 [![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/rswlpkq2vtp9cns0/branch/master?svg=true)](https://ci.appveyor.com/project/arcs/arcs-3i77k/branch/master)
-
 
 # Arcs
 

--- a/tools/gcb_badge/deploy.sh
+++ b/tools/gcb_badge/deploy.sh
@@ -5,6 +5,6 @@ gcloud functions deploy cloud-build-badge \
     --source . \
     --runtime python37 \
     --entry-point build_badge \
-    --service-account cloud-build-badge@${GCP_PROJECT}.iam.gserviceaccount.com \
+    --service-account gcb-badge@${GCP_PROJECT}.iam.gserviceaccount.com \
     --trigger-topic=cloud-builds \
     --set-env-vars BADGES_BUCKET=arcs-github-gcb-badges,TEMPLATE_PATH='builds/${repo}/branches/${branch}.svg'

--- a/tools/gcb_badge/deploy.sh
+++ b/tools/gcb_badge/deploy.sh
@@ -1,0 +1,10 @@
+#!bin/bash
+
+GCP_PROJECT=arcs-265404
+gcloud functions deploy cloud-build-badge \
+    --source . \
+    --runtime python37 \
+    --entry-point build_badge \
+    --service-account cloud-build-badge@${GCP_PROJECT}.iam.gserviceaccount.com \
+    --trigger-topic=cloud-builds \
+    --set-env-vars BADGES_BUCKET=arcs-github-gcb-badges,TEMPLATE_PATH='builds/${repo}/branches/${branch}.svg'

--- a/tools/gcb_badge/main.py
+++ b/tools/gcb_badge/main.py
@@ -15,7 +15,6 @@ from google.cloud import storage, exceptions
 import base64
 import json
 import os
-import re
 from string import Template
 
 

--- a/tools/gcb_badge/main.py
+++ b/tools/gcb_badge/main.py
@@ -1,0 +1,63 @@
+# Adapted from https://github.com/leg100/cloud-build-badge
+#
+# To deploy or update gcloud function, use the following command:
+#
+# gcloud functions deploy cloud-build-badge \
+#    --source . \
+#    --runtime python37 \
+#    --entry-point build_badge \
+#    --service-account cloud-build-badge@arcs-265404.iam.gserviceaccount.com \
+#    --trigger-topic=cloud-builds \
+#    --set-env-vars BADGES_BUCKET=arcs-github-gcb-badges,TEMPLATE_PATH='builds/${repo}/branches/${branch}.svg'
+#
+from google.cloud import storage, exceptions
+
+import base64
+import json
+import os
+import re
+from string import Template
+
+
+def copy_badge(bucket_name, obj, new_obj):
+    client = storage.Client()
+
+    try:
+        bucket = client.get_bucket(bucket_name)
+    except exceptions.NotFound:
+        raise RuntimeError(f"Could not find bucket {bucket_name}")
+    else:
+        blob = bucket.get_blob(obj)
+        if blob is None:
+            raise RuntimeError(f"Could not find object {obj} in bucket {bucket_name}")
+        else:
+            bucket.copy_blob(blob, bucket, new_name=new_obj)
+
+
+def build_badge(event, context):
+    """
+    Background Cloud Function to be triggered by Pub/Sub.
+
+    Updates repository build badge. Triggered by incoming
+    pubsub messages from Google Cloud Build.
+    """
+
+    decoded = base64.b64decode(event['data']).decode('utf-8')
+    data = json.loads(decoded)
+
+    bucket = os.environ['BADGES_BUCKET']
+    try:
+        # GitHub app sets these values. 
+        repo = data['substitutions']['REPO_NAME']
+        branch = data['substitutions']['BRANCH_NAME']
+        tmpl = os.environ.get('TEMPLATE_PATH',
+                'builds/${repo}/branches/${branch}.svg')
+
+        src = 'badges/{}.svg'.format(data['status'].lower())
+        dest = Template(tmpl).substitute(repo=repo, branch=branch)
+
+        copy_badge(bucket, src, dest)
+    except KeyError:
+        # Don't do anything on error.
+        pass
+    return 

--- a/tools/gcb_badge/requirements.txt
+++ b/tools/gcb_badge/requirements.txt
@@ -1,0 +1,1 @@
+google-cloud-storage


### PR DESCRIPTION
This is based on using  [google cloud function](https://cloud.google.com/functions/docs/calling/pubsub) to subscribe to the notifications from [google cloud build](https://cloud.google.com/cloud-build/docs/send-build-notifications). The pub/sub trigger topic for builds is `cloud-builds`.

See [Badge](https://github.com/PolymerLabs/arcs/blob/6e662372d73910e7f7039b205bb6a6050e0dd69a/README.md) in action.