### PR TITLE
Dump process global binder stats

### DIFF
--- a/java/arcs/android/util/AndroidBinderStats.kt
+++ b/java/arcs/android/util/AndroidBinderStats.kt
@@ -29,14 +29,11 @@ import java.io.File
 object AndroidBinderStats {
     private const val STATS_FILE_NODE = "/sys/kernel/debug/binder/stats"
     private const val PROCESS_TAG = "proc "
-    private val log = TaggedLog {"AndroidBinderStats"}
+    private val log = TaggedLog { "AndroidBinderStats" }
 
     /** Query the stats of the given binder process record [tags]. */
     fun query(vararg tags: String): List<String> =
         with(parse()) {
-            for ((k, v) in this) {
-                log.info {"${k}: ${v}"}
-            }
             tags.map { this[it] ?: "" }
         }
 
@@ -68,10 +65,10 @@ object AndroidBinderStats {
                     it.trim() to ""
                 }
             }
-        } catch(e: Exception) {
+        } catch (e: Exception) {
             // The possible reasons could be Linux debugfs is not mounted on some Android
             // devices and builds, denial of permission, etc.
-            log.info {"${e.message}"}
+            log.info { "${e.message}" }
             return emptyMap()
         }
     }

--- a/java/arcs/android/util/AndroidBinderStats.kt
+++ b/java/arcs/android/util/AndroidBinderStats.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.android.util
+
+import android.os.Process
+import arcs.core.util.TaggedLog
+import java.io.File
+
+/**
+ * An utility singleton queries binder stats directly from the kernel binder driver.
+ *
+ * Note:
+ * If a permission denial shows up at i.e. a privileged application, try to execute the command
+ * to configure secure Linux to permissive mode:
+ * $> adb shell setenforce 0
+ *
+ * By default, a privileged application is disallowed to access any debugfs file attributes.
+ * neverallow priv_app debugfs:file read;
+ */
+object AndroidBinderStats {
+    private const val STATS_FILE_NODE = "/sys/kernel/debug/binder/stats"
+    private const val PROCESS_TAG = "proc "
+    private val log = TaggedLog {"AndroidBinderStats"}
+
+    /** Query the stats of the given binder process record [tags]. */
+    fun query(vararg tags: String): List<String> =
+        with(parse()) {
+            for ((k, v) in this) {
+                log.info {"${k}: ${v}"}
+            }
+            tags.map { this[it] ?: "" }
+        }
+
+    private fun parse(): Map<String, String> {
+        try {
+            File(STATS_FILE_NODE).useLines { lines ->
+                val delimiter = PROCESS_TAG + Process.myPid()
+                var partitionFlip = false
+                return lines.partition {
+                    if (it.startsWith(PROCESS_TAG)) {
+                        partitionFlip = it == delimiter
+                    }
+                    partitionFlip
+                }.first.associate {
+                    // General case where a binder process record is delimited by a colon.
+                    var index = it.lastIndexOf(":")
+                    if (index != -1) {
+                        return@associate it.substring(0, index).trim() to
+                            it.substring(index + 1).trim()
+                    }
+
+                    // Special case e.g. "ready threads N", "free async space M"
+                    index = it.lastIndexOf(" ")
+                    if (index != -1) {
+                        return@associate it.substring(0, index).trim() to
+                            it.substring(index + 1).trim()
+                    }
+
+                    it.trim() to ""
+                }
+            }
+        } catch(e: Exception) {
+            // The possible reasons could be Linux debugfs is not mounted on some Android
+            // devices and builds, denial of permission, etc.
+            log.info {"${e.message}"}
+            return emptyMap()
+        }
+    }
+}

--- a/java/arcs/android/util/AndroidBinderStats.kt
+++ b/java/arcs/android/util/AndroidBinderStats.kt
@@ -32,17 +32,16 @@ object AndroidBinderStats {
     private val log = TaggedLog { "AndroidBinderStats" }
 
     /** Query the stats of the given binder process record [tags]. */
-    fun query(vararg tags: String): List<String> =
-        with(parse()) {
-            tags.map { this[it] ?: "" }
-        }
+    fun query(vararg tags: String): List<String> = with(parse()) {
+        tags.map { this[it] ?: "" }
+    }
 
     private fun parse(): Map<String, String> {
-        try {
+        return try {
             File(STATS_FILE_NODE).useLines { lines ->
                 val delimiter = PROCESS_TAG + Process.myPid()
                 var partitionFlip = false
-                return lines.partition {
+                lines.partition {
                     if (it.startsWith(PROCESS_TAG)) {
                         partitionFlip = it == delimiter
                     }
@@ -68,8 +67,8 @@ object AndroidBinderStats {
         } catch (e: Exception) {
             // The possible reasons could be Linux debugfs is not mounted on some Android
             // devices and builds, denial of permission, etc.
-            log.info { "${e.message}" }
-            return emptyMap()
+            log.info { e.message ?: "Unknown exception on accessing $STATS_FILE_NODE" }
+            emptyMap()
         }
     }
 }

--- a/java/arcs/sdk/android/storage/service/BUILD
+++ b/java/arcs/sdk/android/storage/service/BUILD
@@ -15,6 +15,7 @@ kt_android_library(
         "//java/arcs/android/storage/service",
         "//java/arcs/android/storage/service:aidl",
         "//java/arcs/android/storage/ttl",
+        "//java/arcs/android/util",
         "//java/arcs/core/storage",
         "//java/arcs/core/storage/database",
         "//java/arcs/core/storage/driver",

--- a/java/arcs/sdk/android/storage/service/StorageService.kt
+++ b/java/arcs/sdk/android/storage/service/StorageService.kt
@@ -136,8 +136,7 @@ class StorageService : ResurrectorService() {
             AndroidBinderStats.query(*values.toTypedArray()).iterator().let { stats ->
                 mapValues { stats.next() }
             }
-        }.run { if (any { (_, v) -> v.isNotEmpty() }) this else null
-        }?.run {
+        }.takeIf { it.any { (_, v) -> v.isNotEmpty() } }?.run {
             writer.println(
                 """
                     |Current Process Binder Stats:

--- a/java/arcs/sdk/android/storage/service/StorageService.kt
+++ b/java/arcs/sdk/android/storage/service/StorageService.kt
@@ -136,13 +136,13 @@ class StorageService : ResurrectorService() {
             AndroidBinderStats.query(*values.toTypedArray()).iterator().let { stats ->
                 mapValues { stats.next() }
             }.let { stats ->
-                if (stats.any {(_, v) -> v.isNotEmpty()}) stats else null
+                if (stats.any { (_, v) -> v.isNotEmpty() }) stats else null
             }
         }?.run {
             writer.println(
                 """
                     |Current Process Binder Stats:
-                    |  - ${map {(k, v) -> "${k}: ${v}"}.joinToString("\n|  - ")}
+                    |  - ${map {(k, v) -> "$k: $v"}.joinToString("\n|  - ")}
                 """.trimMargin("|")
             )
         }

--- a/java/arcs/sdk/android/storage/service/StorageService.kt
+++ b/java/arcs/sdk/android/storage/service/StorageService.kt
@@ -135,9 +135,8 @@ class StorageService : ResurrectorService() {
         ).run {
             AndroidBinderStats.query(*values.toTypedArray()).iterator().let { stats ->
                 mapValues { stats.next() }
-            }.let { stats ->
-                if (stats.any { (_, v) -> v.isNotEmpty() }) stats else null
             }
+        }.run { if (any { (_, v) -> v.isNotEmpty() }) this else null
         }?.run {
             writer.println(
                 """

--- a/java/arcs/sdk/android/storage/service/StorageService.kt
+++ b/java/arcs/sdk/android/storage/service/StorageService.kt
@@ -24,6 +24,7 @@ import arcs.android.storage.ParcelableStoreOptions
 import arcs.android.storage.service.BindingContext
 import arcs.android.storage.service.BindingContextStatsImpl
 import arcs.android.storage.ttl.PeriodicCleanupTask
+import arcs.android.util.AndroidBinderStats
 import arcs.core.storage.ProxyMessage
 import arcs.core.storage.Store
 import arcs.core.storage.StoreOptions
@@ -122,6 +123,29 @@ class StorageService : ResurrectorService() {
                 |  - Peak: ${stats.transactions.peak}
             """.trimMargin("|")
         )
+
+        // Dump current process global binder stats to understand contention in the thread pool,
+        // peak usage of shared binder memory, the number of pending transactions, etc.
+        // Hide the dump when failing to fetch the stats from the kernel binder driver.
+        mapOf(
+            "Memory high watermark (pages)" to "pages high watermark",
+            "Pending transactions" to "pending transactions",
+            "Requested threads" to "requested threads",
+            "Ready threads" to "ready threads"
+        ).run {
+            AndroidBinderStats.query(*values.toTypedArray()).iterator().let { stats ->
+                mapValues { stats.next() }
+            }.let { stats ->
+                if (stats.any {(_, v) -> v.isNotEmpty()}) stats else null
+            }
+        }?.run {
+            writer.println(
+                """
+                    |Current Process Binder Stats:
+                    |  - ${map {(k, v) -> "${k}: ${v}"}.joinToString("\n|  - ")}
+                """.trimMargin("|")
+            )
+        }
 
         writer.println()
 


### PR DESCRIPTION
This is not like the dump of STS concurrency level we created before.
Instead, it retrieves per-process binder stats from kernel binder driver directly to help understand:
a) contention of binder thread pool (multiple services creating their own AIDLs racing the same binder pool)
b) peak usage of shared <1MB binder memory
c) pending binder transactions across all services/activities in current process

Since sepolicy disallows privileged application for accessing to debugfs, showing the stats dump by typing: ```adb shell setenforce 0``` before executing dumpsys command. Without issuing the command, the dump will be automatically skipped.