### PR TITLE
Associate additional information with the equivalence class in unionfind.

### DIFF
--- a/java/arcs/core/util/UnionFind.kt
+++ b/java/arcs/core/util/UnionFind.kt
@@ -19,17 +19,16 @@ package arcs.core.util
  */
 class UnionFind<E, I> {
     /**
-     * Unifies the equivalence classes of elements [e1] and [e2]. If either element is not present
-     * in any set, it is added. The [combine] function determines how the information associated
-     * with the two equivalence classes are merged. The default [combine] method returns the
-     * information associated with the new root.
+     * Unifies the equivalence classes of elements [e1] and [e2].
+     *
+     * If either element is not present in any set, it is added. The [combine] function determines
+     * how the information associated with the two equivalence classes are merged. The default
+     * [combine] method returns the information associated with the new root.
      */
     fun union(
         e1: E,
         e2: E,
-        combine: (destInfo: I?, srcInfo: I?) -> I? = {
-            destInfo: I?, _: I? -> destInfo
-        }
+        combine: (destInfo: I?, srcInfo: I?) -> I? = { destInfo, _ -> destInfo }
     ) {
         val e1Root = e1.findRoot()
         val e2Root = e2.findRoot()
@@ -41,15 +40,18 @@ class UnionFind<E, I> {
     }
 
     /**
-     * Find the equivalence class for the element [e]. If the element
-     * is not already present in any set, a new singleton set is created.
+     * Finds the equivalence class for the element [e].
+     *
+     * If the element is not already present in any set, a new singleton set is created.
      */
     fun find(e: E): E = e.findRoot().element
 
     /**
-     * Update the information for the equivalence class for [e] with [info].
+     * Updates the information for the equivalence class for [e] with [info].
      */
-    fun setInfo(e: E, info: I) { e.findRoot().info = info }
+    fun setInfo(e: E, info: I) {
+        e.findRoot().info = info
+    }
 
     /**
      * Returns the information associated with the equivalence class for [e].
@@ -57,17 +59,19 @@ class UnionFind<E, I> {
     fun getInfo(e: E): I? = e.findRoot().info
 
     /**
-     * If [e] is not already in any set, create a set with a single element.
-     * Optionally, associate [info] with the newly created set.
+     * If [e] is not already in any set, creates a set with a single element.
+     * Optionally, also associates [info] with the newly created set.
      */
-    fun makeSet(e: E, info: I? = null) { getOrCreateNode(e, info) }
+    fun makeSet(e: E, info: I? = null) {
+        getOrCreateNode(e, info)
+    }
 
     /**
-     * Get or create a union-find node for the element [e].
+     * Gets or creates a union-find node for the element [e].
      * Optionally, associate [info] with the newly created set.
      */
     private fun getOrCreateNode(e: E, info: I? = null): Node<E, I> =
-        nodes[e] ?: Node(e, null, info).also { nodes[e] = it }
+        nodes[e] ?: Node(e, info = info).also { nodes[e] = it }
 
     /**
      * Returns the root node for element [e].

--- a/java/arcs/core/util/UnionFind.kt
+++ b/java/arcs/core/util/UnionFind.kt
@@ -90,5 +90,6 @@ class UnionFind<E, I> {
     private data class Node<E, I>(
         val element: E,
         var parent: Node<E, I>? = null,
-        var info: I? = null)
+        var info: I? = null
+    )
 }

--- a/javatests/arcs/core/util/UnionFindTest.kt
+++ b/javatests/arcs/core/util/UnionFindTest.kt
@@ -21,7 +21,7 @@ import org.junit.runners.JUnit4
 class UnionFindTest {
     @Test
     fun makeSetCreatesDisjointSets() {
-        var uf = UnionFind<Int>()
+        var uf = UnionFind<Int, Unit>()
         uf.makeSet(10)
         uf.makeSet(20)
         assertThat(uf.find(10)).isEqualTo(10)
@@ -32,7 +32,7 @@ class UnionFindTest {
 
     @Test
     fun unionMergesClasses() {
-        var uf = UnionFind<Int>()
+        var uf = UnionFind<Int, Unit>()
         uf.makeSet(10)
         uf.makeSet(20)
         uf.makeSet(30)
@@ -49,5 +49,54 @@ class UnionFindTest {
         assertThat(uf.find(10)).isNotEqualTo(uf.find(20))
         assertThat(uf.find(10)).isNotEqualTo(uf.find(30))
         assertThat(uf.find(10)).isNotEqualTo(uf.find(40))
+    }
+
+    @Test
+    fun makeSetWithInfo() {
+        var uf = UnionFind<Int, Int>()
+        uf.makeSet(10, 10)
+        uf.makeSet(20, 20)
+        assertThat(uf.getInfo(10)).isEqualTo(10)
+        assertThat(uf.getInfo(20)).isEqualTo(20)
+    }
+
+    @Test
+    fun setInfoUpdatesEquivalenceClassInfo() {
+        var uf = UnionFind<Int, Int>()
+        uf.makeSet(10, 10)
+        uf.makeSet(20, 20)
+        uf.makeSet(30, 30)
+        uf.makeSet(40, 40)
+        assertThat(uf.getInfo(10)).isEqualTo(10)
+        assertThat(uf.getInfo(20)).isEqualTo(20)
+        assertThat(uf.getInfo(30)).isEqualTo(30)
+        assertThat(uf.getInfo(40)).isEqualTo(40)
+        uf.union(20, 30)
+        uf.setInfo(20, 25)
+        assertThat(uf.getInfo(30)).isEqualTo(25)
+    }
+
+    @Test
+    fun unionCombinesInfo() {
+        // Info keeps track of the size of equivalence classes.
+        val intSum: (Int?, Int?) -> Int? = fun(x: Int?, y: Int?): Int? {
+            return if (x == null || y == null) null else x + y
+        }
+        var uf = UnionFind<Int, Int>()
+        uf.makeSet(10, 1)
+        uf.makeSet(20, 1)
+        uf.makeSet(30, 1)
+        uf.makeSet(40, 1)
+        uf.makeSet(50, 1)
+        uf.makeSet(60, 1)
+        uf.union(20, 30, intSum)
+        uf.union(30, 40, intSum)
+        uf.union(50, 60, intSum)
+        assertThat(uf.getInfo(10)).isEqualTo(1)
+        assertThat(uf.getInfo(20)).isEqualTo(3)
+        assertThat(uf.getInfo(30)).isEqualTo(3)
+        assertThat(uf.getInfo(40)).isEqualTo(3)
+        assertThat(uf.getInfo(50)).isEqualTo(2)
+        assertThat(uf.getInfo(60)).isEqualTo(2)
     }
 }


### PR DESCRIPTION
This PR adds support to associate auxiliary information to an equivalence class. This would be useful to assign types/dataflow facts to the equivalence classes, for example.