### PR TITLE
Makes it possible to decode a proto from the text format

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -193,6 +193,7 @@ maven_install(
         "com.google.auto.value:auto-value-annotations:" + AUTO_VALUE_VERSION,
         "com.google.auto.service:auto-service:" + AUTO_SERVICE_VERSION,
         "com.google.auto.service:auto-service-annotations:" + AUTO_SERVICE_VERSION,
+        "com.google.protobuf:protobuf-java:3.11.4",
         "com.google.truth:truth:1.0",
         "com.github.ajalt:clikt:" + CLIKT_VERSION,
         "com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0",

--- a/java/arcs/core/data/BUILD
+++ b/java/arcs/core/data/BUILD
@@ -4,7 +4,7 @@ load(
 )
 load(
     "//third_party/java/arcs/build_defs:native.oss.bzl",
-    "android_proto_library",
+    "java_proto_library",
     "proto_library",
 )
 
@@ -48,7 +48,7 @@ proto_library(
     srcs = ["recipe.proto"],
 )
 
-android_proto_library(
-    name = "recipe_android_proto",
+java_proto_library(
+    name = "recipe_java_proto",
     deps = [":recipe_proto"],
 )

--- a/java/arcs/core/data/recipe.proto
+++ b/java/arcs/core/data/recipe.proto
@@ -46,7 +46,7 @@ message HandleConnectionProto {
   // Refers to envelope.particle_specs.connections.name
   string name = 1;
   // Refers to envelope.plan.handles.name
-  string handle_name = 2;
+  string handle = 2;
 }
 
 // Defines a particle contract and links it with implementation.
@@ -68,7 +68,7 @@ message HandleConnectionSpecProto {
   }
   // Identifies a connection in a particle spec.
   string name = 1;
-  Direction directions = 2;
+  Direction direction = 2;
   TypeProto type = 3;
 }
 

--- a/java/arcs/core/data/testdata/BUILD
+++ b/java/arcs/core/data/testdata/BUILD
@@ -6,8 +6,11 @@ load(
 licenses(["notice"])
 
 filegroup(
-    name = "encoded_manifest",
-    srcs = ["example.pb.bin"],
+    name = "examples",
+    srcs = glob(
+        ["*"],
+        exclude = ["BUILD"],
+    ),
     visibility = ["//visibility:public"],
 )
 

--- a/java/arcs/core/data/testdata/example.textproto
+++ b/java/arcs/core/data/testdata/example.textproto
@@ -1,0 +1,79 @@
+# A proto encoding of the following recipe: 
+# """
+# external particle Writer
+#   data: writes Thing {name: Text}
+# 
+# external particle Reader
+#   data: reads Thing {name: Text}
+# 
+# recipe PassThrough
+#   thing: create
+#   Writer
+#     data: writes thing
+#   Reader
+#     data: reads thing
+# """
+
+recipe {
+  name: "PassThrough"
+  handles {
+    name: "thing"
+    fate: CREATE
+  }
+  particles {
+    spec_name: "Reader"
+    connections {
+      name: "data"
+      handle: "thing"
+    }
+  }
+  particles {
+    spec_name: "Writer"
+    connections {
+      name: "data"
+      handle: "thing"
+    }
+  }
+}
+
+particle_specs {
+  name: "Reader"
+  connections {
+    name: "data"
+    direction: READS
+    type {
+      entity {
+        schema {
+          names: "Thing"
+          fields {
+            key: "name"
+            value: {
+              primitive: TEXT
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+particle_specs {
+  name: "Writer"
+  connections {
+    name: "data"
+    direction: WRITES
+    type {
+      entity {
+        schema {
+          names: "Thing"
+          fields {
+            key: "name"
+            value: {
+              primitive: TEXT
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/javatests/arcs/core/data/BUILD
+++ b/javatests/arcs/core/data/BUILD
@@ -9,13 +9,14 @@ package(default_visibility = ["//visibility:public"])
 
 arcs_kt_jvm_test_suite(
     name = "data",
-    data = ["//java/arcs/core/data/testdata:encoded_manifest"],
+    data = ["//java/arcs/core/data/testdata:examples"],
     package = "arcs.core.data",
     deps = [
         "//java/arcs/core/data",
-        "//java/arcs/core/data:recipe_android_proto",
+        "//java/arcs/core/data:recipe_java_proto",
         "//java/arcs/core/storage:storage_key",
         "//java/arcs/repoutils",
+        "//third_party/java/arcs/deps:protobuf_java",
         "//third_party/java/junit:junit-android",
         "//third_party/java/truth:truth-android",
     ],

--- a/javatests/arcs/core/data/DecodeManifestProtoTest.kt
+++ b/javatests/arcs/core/data/DecodeManifestProtoTest.kt
@@ -2,6 +2,7 @@ package arcs.core.data
 
 import arcs.repoutils.runfilesDir
 import com.google.common.truth.Truth.assertThat
+import com.google.protobuf.TextFormat
 import java.io.File
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -10,15 +11,23 @@ import org.junit.runners.JUnit4
 @RunWith(JUnit4::class)
 class DecodeManifestProtoTest {
 
-    /**
-     * Validate that decoding of the proto encoded in JS works.
-     */
     @Test
-    fun decodesEncodedManifest() {
+    fun decodesManifestEncodedInTypeScript() {
         val path = runfilesDir() + "java/arcs/core/data/testdata/example.pb.bin"
         val recipe = RecipeEnvelopeProto.parseFrom(File(path).readBytes()).recipe
         assertThat(recipe.name).isEqualTo("PassThrough")
-        assertThat(recipe.particlesList.map {it.specName}).containsExactly("Reader", "Writer")
-        assertThat(recipe.handlesList.map {it.name}).containsExactly("thing")
+        assertThat(recipe.particlesList.map { it.specName }).containsExactly("Reader", "Writer")
+        assertThat(recipe.handlesList.map { it.name }).containsExactly("thing")
+    }
+
+    @Test
+    fun decodesManifestEncodedInTextFormat() {
+        val path = runfilesDir() + "java/arcs/core/data/testdata/example.textproto"
+        val builder = RecipeEnvelopeProto.newBuilder()
+        TextFormat.getParser().merge(File(path).readText(), builder)
+        val recipe = builder.build().recipe
+        assertThat(recipe.name).isEqualTo("PassThrough")
+        assertThat(recipe.particlesList.map { it.specName }).containsExactly("Reader", "Writer")
+        assertThat(recipe.handlesList.map { it.name }).containsExactly("thing")
     }
 }

--- a/third_party/java/arcs/build_defs/native.oss.bzl
+++ b/third_party/java/arcs/build_defs/native.oss.bzl
@@ -7,6 +7,7 @@ load(
     "@rules_java//java:defs.bzl",
     _java_library = "java_library",
     _java_plugin = "java_plugin",
+    _java_proto_library = "java_proto_library",
     _java_test = "java_test",
 )
 load("@rules_proto//proto:defs.bzl", _proto_library = "proto_library")
@@ -22,5 +23,7 @@ java_plugin = _java_plugin
 java_test = _java_test
 
 proto_library = _proto_library
+
+java_proto_library = _java_proto_library
 
 android_proto_library = _android_proto_library

--- a/third_party/java/arcs/deps/BUILD.bazel
+++ b/third_party/java/arcs/deps/BUILD.bazel
@@ -9,3 +9,8 @@ alias(
     name = "protobuf_javalite",
     actual = "@com_google_protobuf//:protobuf_javalite",
 )
+
+alias(
+    name = "protobuf_java",
+    actual = "@com_google_protobuf//:protobuf_java",
+)


### PR DESCRIPTION
This unlocks checking-in human readable representation of protos into the codebase as test input/outputs or examples for folks to follow. E.g. I need to create an example of a proto representing a recipe with a join syntax - currently I could only check in a binary format, or code writing the proto, both options are suboptimal.

Some non-obvious pieces:

* Had to move arcs/code/data from android protos to java protos. It makes sense for these protos to not be "android" as they are in core, but what's really happening is java_protos are `Message`'s, not `MessageLite`, which unlocks TextFormat to work.
* Protobuf `TextFormat` is _not_ under third_party in google repo, yet it is open sourced. I decided to do a reverse of the `third_party` directory, namely `google_repo`. It will contain open sourced libraries that live in the main google repo tree and the structure of the directory mirrors the google repo.

Also I sneaked in 2 tiny changes to the proto representation. (@bgogul FYI, I hope you don't mind)