### PR TITLE
Show process memory stats at STS dumpsys

### DIFF
--- a/java/arcs/sdk/android/storage/service/StorageService.kt
+++ b/java/arcs/sdk/android/storage/service/StorageService.kt
@@ -33,6 +33,7 @@ import arcs.core.storage.database.persistent
 import arcs.core.storage.driver.DatabaseDriverProvider
 import arcs.core.storage.driver.RamDiskDriverProvider
 import arcs.core.util.TaggedLog
+import arcs.core.util.performance.MemoryStats
 import arcs.core.util.performance.PerformanceStatistics
 import java.io.FileDescriptor
 import java.io.PrintWriter
@@ -141,6 +142,15 @@ class StorageService : ResurrectorService() {
                 """
                     |Current Process Binder Stats:
                     |  - ${map {(k, v) -> "$k: $v"}.joinToString("\n|  - ")}
+                """.trimMargin("|")
+            )
+        }
+
+        MemoryStats.snapshot().run {
+            writer.println(
+                """
+                    |Process Memory Stats (KB):
+                    |  - ${map {(k, v) -> "${k.name}: $v"}.joinToString("\n|  - ")}
                 """.trimMargin("|")
             )
         }

--- a/java/arcs/sdk/android/storage/service/StorageService.kt
+++ b/java/arcs/sdk/android/storage/service/StorageService.kt
@@ -141,7 +141,7 @@ class StorageService : ResurrectorService() {
             writer.println(
                 """
                     |Current Process Binder Stats:
-                    |  - ${map {(k, v) -> "$k: $v"}.joinToString("\n|  - ")}
+                    |  - ${map { (k, v) -> "$k: $v" }.joinToString("\n|  - ")}
                 """.trimMargin("|")
             )
         }
@@ -150,7 +150,7 @@ class StorageService : ResurrectorService() {
             writer.println(
                 """
                     |Process Memory Stats (KB):
-                    |  - ${map {(k, v) -> "${k.name}: $v"}.joinToString("\n|  - ")}
+                    |  - ${map { (k, v) -> "${k.name}: $v" }.joinToString("\n|  - ")}
                 """.trimMargin("|")
             )
         }


### PR DESCRIPTION
This is the final patch for tracking memory usage over time/dump.
Memory usage is categorized per types, take a dumpsys example:
```
    Process Memory Stats (KB):
      - TOTAL: 74938
      - JAVA_HEAP: 24104
      - NATIVE_HEAP: 8296
      - CODE_STATIC: 144
      - STACK: 52
      - GRAPHICS: 0
      - SYSTEM: 35130
      - OTHER: 7212
```

Both HEAPS are main spots we should pay the most attention to.
