### PR TITLE
Move recipe.proto to java/arcs/core/data/proto/

### DIFF
--- a/java/arcs/core/data/BUILD
+++ b/java/arcs/core/data/BUILD
@@ -2,11 +2,6 @@ load(
     "//third_party/java/arcs/build_defs:build_defs.bzl",
     "arcs_kt_library",
 )
-load(
-    "//third_party/java/arcs/build_defs:native.oss.bzl",
-    "java_proto_library",
-    "proto_library",
-)
 
 licenses(["notice"])
 

--- a/java/arcs/core/data/BUILD
+++ b/java/arcs/core/data/BUILD
@@ -43,13 +43,3 @@ arcs_kt_library(
         "//java/arcs/core/common",
     ],
 )
-
-proto_library(
-    name = "recipe_proto",
-    srcs = ["recipe.proto"],
-)
-
-java_proto_library(
-    name = "recipe_java_proto",
-    deps = [":recipe_proto"],
-)

--- a/java/arcs/core/data/proto/BUILD
+++ b/java/arcs/core/data/proto/BUILD
@@ -1,8 +1,4 @@
 load(
-    "//third_party/java/arcs/build_defs:build_defs.bzl",
-    "arcs_kt_library",
-)
-load(
     "//third_party/java/arcs/build_defs:native.oss.bzl",
     "java_proto_library",
     "proto_library",

--- a/java/arcs/core/data/proto/BUILD
+++ b/java/arcs/core/data/proto/BUILD
@@ -1,0 +1,23 @@
+load(
+    "//third_party/java/arcs/build_defs:build_defs.bzl",
+    "arcs_kt_library",
+)
+load(
+    "//third_party/java/arcs/build_defs:native.oss.bzl",
+    "java_proto_library",
+    "proto_library",
+)
+
+licenses(["notice"])
+
+package(default_visibility = ["//visibility:public"])
+
+proto_library(
+    name = "recipe_proto",
+    srcs = ["recipe.proto"],
+)
+
+java_proto_library(
+    name = "recipe_java_proto",
+    deps = [":recipe_proto"],
+)

--- a/java/arcs/core/data/proto/recipe.proto
+++ b/java/arcs/core/data/proto/recipe.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package arcs;
 
-option java_package = "arcs.core.data";
+option java_package = "arcs.core.data.proto";
 option java_multiple_files = true;
 
 // Holds a single plan and particle specs used by it.

--- a/javatests/arcs/core/data/BUILD
+++ b/javatests/arcs/core/data/BUILD
@@ -13,6 +13,7 @@ arcs_kt_jvm_test_suite(
     package = "arcs.core.data",
     deps = [
         "//java/arcs/core/data",
+        "//java/arcs/core/storage:storage_key",
         "//java/arcs/core/util",
         "//java/arcs/jvm/util/testutil",
         "//java/arcs/repoutils",

--- a/javatests/arcs/core/data/proto/BUILD
+++ b/javatests/arcs/core/data/proto/BUILD
@@ -14,6 +14,7 @@ arcs_kt_jvm_test_suite(
     deps = [
         "//java/arcs/core/data/proto:recipe_java_proto",
         "//java/arcs/repoutils",
+        "//third_party/java/arcs/deps:protobuf_java",
         "//third_party/java/junit:junit-android",
         "//third_party/java/truth:truth-android",
     ],

--- a/javatests/arcs/core/data/proto/BUILD
+++ b/javatests/arcs/core/data/proto/BUILD
@@ -8,15 +8,12 @@ licenses(["notice"])
 package(default_visibility = ["//visibility:public"])
 
 arcs_kt_jvm_test_suite(
-    name = "data",
+    name = "proto",
     data = ["//java/arcs/core/data/testdata:examples"],
-    package = "arcs.core.data",
+    package = "arcs.core.data.proto",
     deps = [
-        "//java/arcs/core/data",
-        "//java/arcs/core/util",
-        "//java/arcs/jvm/util/testutil",
+        "//java/arcs/core/data/proto:recipe_java_proto",
         "//java/arcs/repoutils",
-        "//third_party/java/arcs/deps:protobuf_java",
         "//third_party/java/junit:junit-android",
         "//third_party/java/truth:truth-android",
     ],

--- a/javatests/arcs/core/data/proto/ParseManifestProtoTest.kt
+++ b/javatests/arcs/core/data/proto/ParseManifestProtoTest.kt
@@ -1,4 +1,4 @@
-package arcs.core.data
+package arcs.core.data.proto
 
 import arcs.repoutils.runfilesDir
 import com.google.common.truth.Truth.assertThat

--- a/src/tools/manifest2proto.ts
+++ b/src/tools/manifest2proto.ts
@@ -10,7 +10,7 @@
 import {Runtime} from '../runtime/runtime.js';
 import protobuf from 'protobufjs';
 
-const rootNamespace = protobuf.loadSync('./java/arcs/core/data/recipe.proto');
+const rootNamespace = protobuf.loadSync('./java/arcs/core/data/proto/recipe.proto');
 const envelope = rootNamespace.lookupType('arcs.RecipeEnvelopeProto');
 
 export async function serialize2proto(path: string): Promise<Uint8Array> {


### PR DESCRIPTION
This would make it easier to organize utilities around the proto. See https://github.com/bgogul/arcs/commit/55be8df119eb3aad9e928d11aba67293644db0af for example.