### PR TITLE
Support Tuples in the Manifest Parser

### DIFF
--- a/src/runtime/manifest-ast-nodes.ts
+++ b/src/runtime/manifest-ast-nodes.ts
@@ -73,6 +73,11 @@ export interface ReferenceType extends BaseNode {
   type: ParticleHandleConnectionType;
 }
 
+export interface TupleType extends BaseNode {
+  kind: 'tuple-type';
+  types: ParticleHandleConnectionType[];
+}
+
 export interface TypeVariable extends BaseNode {
   kind: 'variable-type';
   name: string;

--- a/src/runtime/manifest-parser.pegjs
+++ b/src/runtime/manifest-parser.pegjs
@@ -570,6 +570,7 @@ ParticleHandleConnectionType
   / BigCollectionType
   / ReferenceType
   / SlotType
+  / TupleType
   / type: SchemaInline whiteSpace? refinement:Refinement? 
   {
     type.refinement = refinement;
@@ -617,6 +618,15 @@ ReferenceType
     return toAstNode<AstNode.ReferenceType>({
       kind: 'reference-type',
       type,
+    });
+  }
+
+TupleType  "a tuple of types (e.g. (A, &B, [C]))"
+  = '(' eolPlusWhiteSpace? first:ParticleHandleConnectionType rest:(eolPlusWhiteSpace? ',' eolPlusWhiteSpace? ParticleHandleConnectionType)* eolPlusWhiteSpace? ',' ? eolPlusWhiteSpace? ')'
+  {
+    return toAstNode<AstNode.TupleType>({
+      kind: 'tuple-type',
+      types: [first].concat(rest.map(t => t[3])),
     });
   }
 
@@ -670,7 +680,7 @@ TypeName
   }
 
 TypeVariableList
-  = head:TypeVariable tail:(',' whiteSpace TypeVariable)*
+  = head:TypeVariable tail:(',' eolPlusWhiteSpace? TypeVariable)*
   {
     return [head, ...tail.map(a => a[2])];
   }
@@ -1558,5 +1568,7 @@ eolWhiteSpace "a group of new lines (and optionally comments)"
   = spaceChar* !.
   / spaceChar* '//' [^\n]* eolWhiteSpace
   / spaceChar* eol eolWhiteSpace?
+eolPlusWhiteSpace "eol plus trailing whitespace"
+  = eolWhiteSpace? whiteSpace?
 eol "a new line"
   = "\r"? "\n" "\r"?

--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -34,7 +34,7 @@ import {TypeChecker} from './recipe/type-checker.js';
 import {Ttl} from './recipe/ttl.js';
 import {Schema} from './schema.js';
 import {BigCollectionType, CollectionType, EntityType, InterfaceInfo, InterfaceType,
-        ReferenceType, SlotType, Type, TypeVariable, SingletonType} from './type.js';
+        ReferenceType, SlotType, Type, TypeVariable, SingletonType, TupleType} from './type.js';
 import {Dictionary} from './hot.js';
 import {ClaimIsTag} from './particle-claim.js';
 import {UnifiedStore} from './storageNG/unified-store.js';
@@ -610,6 +610,12 @@ ${e.message}
             return;
           case 'singleton-type':
             node.model = new SingletonType(node.type.model);
+            return;
+          case 'tuple-type':
+            if (node.types.some(t => t.kind !== 'reference-type')) {
+              throw new ManifestError(node.location, 'Only tuples of references are supported.');
+            }
+            node.model = new TupleType(node.types.map(t => t.model));
             return;
           default:
             return;

--- a/src/runtime/tests/manifest-parser-test.ts
+++ b/src/runtime/tests/manifest-parser-test.ts
@@ -391,6 +391,53 @@ describe('manifest parser', () => {
         outRef: writes &Bar
     `);
   });
+  it('fails to parse an empty tuple', () => {
+    assert.throws(() => {
+      parse(`
+        particle Foo
+          data: reads ()
+      `);
+    });
+  });
+  it('parses tuple with one type', () => {
+    parse(`
+      particle Foo
+        data: reads (Foo)
+    `);
+  });
+  it('parses tuple with two types', () => {
+    parse(`
+      particle Foo
+        data: writes ([Foo], &Bar {name: Text})
+    `);
+  });
+  it('fails to parse a tuple without separator between elements', () => {
+    assert.throws(() => {
+      parse(`
+        particle Foo
+          data: reads (Foo{}Bar{})
+      `);
+    });
+  });
+  it('parses tuple with indented types and comments', () => {
+    parse(`
+      particle Foo
+        data: reads (
+          Foo, // First type
+          &Bar {name: Text}, // Second type
+          [Baz {photo: URL}] // Third type
+        )
+    `);
+  });
+  it('parses tuple with indented types and trailing comma', () => {
+    parse(`
+      particle Foo
+        data: reads (
+          &Foo,
+          &Bar,
+        )
+    `);
+  });
   it('parses refinement types in a schema', Flags.withFieldRefinementsAllowed(async () => {
       parse(`
         schema Foo

--- a/src/runtime/type.ts
+++ b/src/runtime/type.ts
@@ -9,7 +9,6 @@
  */
 
 import {assert} from '../platform/assert-web.js';
-import {Id} from './id.js';
 import {SlotInfo} from './slot-info.js';
 import {Predicate, Literal} from './hot.js';
 import {CRDTTypeRecord, CRDTModel} from './crdt/crdt.js';
@@ -683,7 +682,7 @@ export class BigCollectionType<T extends Type> extends Type {
 }
 
 export class TupleType extends Type {
-  private readonly tupleTypes: Type[];
+  readonly tupleTypes: Type[];
 
   constructor(tuple: Type[]) {
     super('Tuple');


### PR DESCRIPTION
This is just the parser part.

I would like feedback on the `eolPlusWhiteSpace` Frankenstein.
Also, I made an empty tuple invalid - we can debate whether we want it.

Next part will be type inference working for tuples.