### PR TITLE
default capabilities in recipe handles

### DIFF
--- a/src/runtime/arc.ts
+++ b/src/runtime/arc.ts
@@ -460,7 +460,8 @@ export class Arc implements ArcInterface {
 
         const newStore = await this.createStoreInternal(
             type, /* name= */ null, storeId, recipeHandle.tags, volatileKey,
-            recipeHandle.getCapabilitiesWithDefault(), recipeHandle.ttl);
+            recipeHandle.getCapabilitiesWithDefault(),
+            recipeHandle.ttl);
         if (recipeHandle.immediateValue) {
           const particleSpec = recipeHandle.immediateValue;
           const type = recipeHandle.type;
@@ -535,8 +536,8 @@ export class Arc implements ArcInterface {
     handle._type = handle.mappedType;
   }
 
-  async createStore(type: Type, name?: string, id?: string, tags?: string[], storageKey?: StorageKey): Promise<UnifiedStore> {
-    const store = await this.createStoreInternal(type, name, id, tags, storageKey);
+  async createStore(type: Type, name?: string, id?: string, tags?: string[], storageKey?: StorageKey, capabilities?: Capabilities, ttl?: Ttl): Promise<UnifiedStore> {
+    const store = await this.createStoreInternal(type, name, id, tags, storageKey, capabilities, ttl);
     this.addStoreToRecipe(store);
     return store;
   }
@@ -582,8 +583,8 @@ export class Arc implements ArcInterface {
     if (storageKey instanceof ReferenceModeStorageKey) {
       const refContainedType = new ReferenceType(type.getContainedType());
       const refType = type.isSingleton ? new SingletonType(refContainedType) : new CollectionType(refContainedType);
-      await this.createStore(refType, name ? name + '_referenceContainer' : null, null, [], storageKey.storageKey);
-      await this.createStore(new CollectionType(type.getContainedType()), name ? name + '_backingStore' : null, null, [], storageKey.backingKey);
+      await this.createStore(refType, name ? name + '_referenceContainer' : null, null, [], storageKey.storageKey, capabilities, ttl);
+      await this.createStore(new CollectionType(type.getContainedType()), name ? name + '_backingStore' : null, null, [], storageKey.backingKey, capabilities, ttl);
     }
     return store;
   }

--- a/src/runtime/arc.ts
+++ b/src/runtime/arc.ts
@@ -458,8 +458,9 @@ export class Arc implements ArcInterface {
           ? new VolatileStorageKey(this.id, '').childKeyForHandle(storeId)
           : undefined;
 
-        const newStore = await this.createStoreInternal(type, /* name= */ null, storeId,
-            recipeHandle.tags, volatileKey, recipeHandle.capabilities, recipeHandle.ttl);
+        const newStore = await this.createStoreInternal(
+            type, /* name= */ null, storeId, recipeHandle.tags, volatileKey,
+            recipeHandle.getCapabilitiesWithDefault(), recipeHandle.ttl);
         if (recipeHandle.immediateValue) {
           const particleSpec = recipeHandle.immediateValue;
           const type = recipeHandle.type;
@@ -555,7 +556,8 @@ export class Arc implements ArcInterface {
     }
 
     if (storageKey == undefined) {
-      if (capabilities && !capabilities.isEmpty()) {
+      if (capabilities) {
+        assert(!capabilities.isEmpty());
         storageKey = await this.capabilitiesResolver.createStorageKey(
             capabilities, type.getEntitySchema(), id);
       } else if (this.storageKey) {

--- a/src/runtime/flags.ts
+++ b/src/runtime/flags.ts
@@ -24,6 +24,7 @@ class FlagDefaults {
   static enforceRefinements = false;
   static useSlandles = false;
   static fieldRefinementsAllowed = false;
+  static defaultReferenceMode = false;
 }
 
 export class Flags extends FlagDefaults {
@@ -50,6 +51,11 @@ export class Flags extends FlagDefaults {
   // tslint:disable-next-line: no-any
   static withFieldRefinementsAllowed<T, Args extends any[]>(f: (...args: Args) => Promise<T>): (...args: Args) => Promise<T> {
     return Flags.withFlags({fieldRefinementsAllowed: true}, f);
+  }
+
+  // tslint:disable-next-line: no-any
+  static withDefaultReferenceMode<T, Args extends any[]>(f: (...args: Args) => Promise<T>): (...args: Args) => Promise<T> {
+    return Flags.withFlags({defaultReferenceMode: true}, f);
   }
 
   // For testing with a different set of flags to the default.

--- a/src/runtime/recipe/handle.ts
+++ b/src/runtime/recipe/handle.ts
@@ -147,6 +147,18 @@ export class Handle implements Comparable<Handle> {
     }
   }
 
+  getCapabilitiesWithDefault(): Capabilities {
+    if (this.capabilities && !this.capabilities.isEmpty()) {
+      return this.capabilities;
+    }
+    return this.defaultCapabilities();
+  }
+
+  defaultCapabilities(): Capabilities {
+    return this.recipe.isLongRunning
+        ? Capabilities.tiedToRuntime : Capabilities.tiedToArc;
+  }
+
   _finishNormalize() {
     for (const connection of this._connections) {
       assert(Object.isFrozen(connection), `Handle connection '${connection.name}' is not frozen.`);

--- a/src/runtime/recipe/recipe.ts
+++ b/src/runtime/recipe/recipe.ts
@@ -540,7 +540,7 @@ export class Recipe implements Cloneable<Recipe> {
 
     recipe._name = this.name;
     recipe._verbs = recipe._verbs.concat(...this._verbs);
-
+    recipe.triggers = recipe.triggers.concat(this.triggers);
     // Clone regular handles first, then synthetic ones, as synthetic can depend on regular.
     this._handles.filter(h => !h.isSynthetic).forEach(cloneTheThing);
     this._handles.filter(h => h.isSynthetic).forEach(cloneTheThing);

--- a/src/runtime/storageNG/drivers/ramdisk.ts
+++ b/src/runtime/storageNG/drivers/ramdisk.ts
@@ -77,6 +77,6 @@ export class RamDiskStorageDriverProvider implements StorageDriverProvider {
     CapabilitiesResolver.registerKeyCreator(
         RamDiskStorageKey.protocol,
         Capabilities.tiedToRuntime,
-        (options: StorageKeyOptions) => new RamDiskStorageKey(options.unique()));
+        (options: StorageKeyOptions) => new RamDiskStorageKey(options.location()));
     }
 }

--- a/src/runtime/tests/capabilities-resolver-test.ts
+++ b/src/runtime/tests/capabilities-resolver-test.ts
@@ -22,6 +22,7 @@ import {DriverFactory} from '../storageNG/drivers/driver-factory.js';
 import {Runtime} from '../runtime.js';
 import {MockFirebaseStorageDriverProvider} from '../storageNG/testing/mock-firebase.js';
 import {assertThrowsAsync} from '../../testing/test-util.js';
+import {Flags} from '../flags.js';
 
 describe('Capabilities Resolver', () => {
   type StorageKeyType = typeof VolatileStorageKey|typeof RamDiskStorageKey|typeof DatabaseStorageKey;
@@ -34,7 +35,7 @@ describe('Capabilities Resolver', () => {
   const schema = new Schema(['Thing'], {result: 'Text'});
   const handleId = 'h0';
 
-  it('creates storage keys', async () => {
+  it('creates storage keys', Flags.withDefaultReferenceMode(async () => {
     const resolver1 = new CapabilitiesResolver({arcId: ArcId.newForTest('test')});
     const key = await resolver1.createStorageKey(Capabilities.tiedToArc, schema, handleId);
     verifyStorageKey(key, VolatileStorageKey);
@@ -73,9 +74,9 @@ describe('Capabilities Resolver', () => {
         Capabilities.tiedToArc, schema, handleId), VolatileStorageKey);
     await assertThrowsAsync(async () => await resolver5.createStorageKey(
         Capabilities.tiedToRuntime, schema, handleId));
-});
+  }));
 
-  it('registers and creates database key', async () => {
+  it('registers and creates database key', Flags.withDefaultReferenceMode(async () => {
     const resolver1 = new CapabilitiesResolver({arcId: ArcId.newForTest('test')});
     await assertThrowsAsync(async () => await resolver1.createStorageKey(
         Capabilities.persistent, schema, handleId));
@@ -84,16 +85,16 @@ describe('Capabilities Resolver', () => {
     const resolver2 = new CapabilitiesResolver({arcId: ArcId.newForTest('test')});
     const key = await resolver2.createStorageKey(Capabilities.persistent, schema, handleId);
     verifyStorageKey(key, PersistentDatabaseStorageKey);
-  });
+  }));
 
-  it('fails for unsupported capabilities', async () => {
+  it('fails for unsupported capabilities', Flags.withDefaultReferenceMode(async () => {
     const capabilitiesResolver = new CapabilitiesResolver({arcId: ArcId.newForTest('test')});
     await assertThrowsAsync(async () => await capabilitiesResolver.createStorageKey(
         Capabilities.tiedToRuntime, schema, handleId));
 
     await assertThrowsAsync(async () => await capabilitiesResolver.createStorageKey(
         new Capabilities(['persistent', 'tied-to-arc']), schema, handleId));
-  });
+  }));
 
   it('verifies static creators', () => {
     assert.equal(CapabilitiesResolver.getDefaultCreators().size, 1);

--- a/src/runtime/tests/runtime-test.ts
+++ b/src/runtime/tests/runtime-test.ts
@@ -118,7 +118,10 @@ describe('Runtime', () => {
     await volatileArc.instantiate(manifest.recipes[0]);
     assert.lengthOf(runtime.context.stores, 0);
 
-    await ramdiskArc.instantiate(manifest.recipes[0]);
+    const longRunningRecipe = manifest.recipes[0].clone();
+    longRunningRecipe.triggers.push([['launch', 'startup'], ['arcId', 'myLongRunningArc']]);
+    assert(longRunningRecipe.normalize() && longRunningRecipe.isResolved());
+    await ramdiskArc.instantiate(longRunningRecipe);
     assert.lengthOf(runtime.context.stores, 2);
 
     const volatileArc1 = runtime.runArc('test-arc-v1', volatileStorageKeyPrefixForTest());


### PR DESCRIPTION
i'd like to distinguish between `volatile` and `ramdisk`, but without exposing this in the manifest.
i think it can be done by providing reasonable default, where long running recipe maps to ramdisk and ephemeral to volatile.

we should definitely revisit and make this more robust, but it should suffice for the short term, and hopefully not too terrible of a hack. WDYT?