### PR TITLE
Simplify service test pattern

### DIFF
--- a/javatests/arcs/android/host/BUILD
+++ b/javatests/arcs/android/host/BUILD
@@ -9,6 +9,16 @@ licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])
 
+kt_android_library(
+    name = "test_app",
+    testonly = 1,
+    srcs = ["TestActivity.kt"],
+    manifest = ":AndroidManifest.xml",
+    deps = [
+        "//third_party/java/androidx/appcompat",
+    ],
+)
+
 arcs_kt_android_test_suite(
     name = "host",
     srcs = glob(["*Test.kt"]),
@@ -17,6 +27,7 @@ arcs_kt_android_test_suite(
     deps = [
         ":schemas",
         ":services",
+        ":test_app",
         "//java/arcs/android/crdt",
         "//java/arcs/android/host",
         "//java/arcs/android/sdk/host",
@@ -42,7 +53,6 @@ arcs_kt_android_test_suite(
         "//java/arcs/sdk/android/storage",
         "//java/arcs/sdk/android/storage/service",
         "//java/arcs/sdk/android/storage/service/testutil",
-        "//javatests/arcs/android/storage/handle:test_app",
         "//javatests/arcs/core/allocator:allocator-test-util",
         "//third_party/android/androidx_test/core",
         "//third_party/android/androidx_test/ext/junit",

--- a/javatests/arcs/android/storage/handle/AndroidManifest.xml
+++ b/javatests/arcs/android/storage/handle/AndroidManifest.xml
@@ -16,12 +16,6 @@
 
     <application>
         <service android:name="arcs.sdk.android.service.StorageService" android:exported="false"/>
-        <activity android:name="arcs.android.storage.handle.TestActivity" >
-        <intent-filter>
-          <action android:name="android.intent.action.MAIN"/>
-          <category android:name="android.intent.category.LAUNCHER"/>
-        </intent-filter>
-      </activity>
     </application>
 
 </manifest>

--- a/javatests/arcs/android/storage/handle/BUILD
+++ b/javatests/arcs/android/storage/handle/BUILD
@@ -2,21 +2,10 @@ load(
     "//third_party/java/arcs/build_defs:build_defs.bzl",
     "arcs_kt_android_test_suite",
 )
-load("//tools/build_defs/kotlin:rules.bzl", "kt_android_library")
 
 licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])
-
-kt_android_library(
-    name = "test_app",
-    testonly = 1,
-    srcs = ["TestActivity.kt"],
-    manifest = ":AndroidManifest.xml",
-    deps = [
-        "//third_party/java/androidx/appcompat",
-    ],
-)
 
 arcs_kt_android_test_suite(
     name = "handle",
@@ -25,7 +14,6 @@ arcs_kt_android_test_suite(
     manifest = "AndroidManifest.xml",
     package = "arcs.android.storage.handle",
     deps = [
-        ":test_app",
         "//java/arcs/android/crdt",
         "//java/arcs/android/storage",
         "//java/arcs/android/storage/handle",
@@ -45,14 +33,12 @@ arcs_kt_android_test_suite(
         "//java/arcs/sdk/android/storage/service/testutil",
         "//third_party/android/androidx_test/core",
         "//third_party/android/androidx_test/ext/junit",
-        "//third_party/java/androidx/appcompat",
         "//third_party/java/androidx/work:testing",
         "//third_party/java/junit:junit-android",
         "//third_party/java/mockito:mockito-android",
         "//third_party/java/robolectric",
         "//third_party/java/truth:truth-android",
         "//third_party/kotlin/kotlinx_coroutines",
-        "//third_party/kotlin/kotlinx_coroutines:kotlinx_coroutines_test",
         "//third_party/kotlin/mockito_kotlin:mockito_kotlin-android",
     ],
 )

--- a/javatests/arcs/android/storage/handle/TestActivity.kt
+++ b/javatests/arcs/android/storage/handle/TestActivity.kt
@@ -1,5 +1,0 @@
-package arcs.android.storage.handle
-
-import androidx.appcompat.app.AppCompatActivity
-
-class TestActivity : AppCompatActivity()


### PR DESCRIPTION
* Make a simple test lifecycle registry, instead of creating empty
testactivity

* Remove use of `runBlockingTest`: according to
https://github.com/Kotlin/kotlinx.coroutines/issues/1222, if the test
results in coroutines being finished on other threads, it's possible to
receive "This job has not yet completed" exceptions, even though the
jobs were properly terminated. Since we don't need the delay-skipping
properties of `runBlockingTest`, I think it's OK to simply using
`runBlocking`, instead.