### PR TITLE
Add '--test_output=errors' to bazel test.

### DIFF
--- a/tools/local-presubmit
+++ b/tools/local-presubmit
@@ -18,7 +18,7 @@ status "Testing all of the things."
 set -x
 
 ./tools/sigh webpack
-./tools/bazelisk ${BAZELRC_OPTS} test //java/... //javatests/... //src/... //particles/...
+./tools/bazelisk ${BAZELRC_OPTS} test --test_output=errors //java/... //javatests/... //src/... //particles/...
 ./tools/sigh testShells
 ./tools/sigh lint
 ./tools/sigh test --all


### PR DESCRIPTION
The cloud build log should have more information on failures. 