### PR TITLE
Increase size of DatabaseImplTest to medium

### DIFF
--- a/javatests/arcs/android/storage/database/BUILD
+++ b/javatests/arcs/android/storage/database/BUILD
@@ -9,6 +9,7 @@ package(default_visibility = ["//visibility:public"])
 
 arcs_kt_android_test_suite(
     name = "database",
+    size = "medium",
     manifest = "//java/arcs/android/common:AndroidManifest.xml",
     package = "arcs.android.storage.database",
     deps = [

--- a/tools/local-presubmit
+++ b/tools/local-presubmit
@@ -23,3 +23,5 @@ set -x
 ./tools/sigh lint
 ./tools/sigh test --all
 
+# Temporary to check flakiness of test.
+./tools/bazelisk ${BAZELRC_OPTS} test //javatests/arcs/android/storage/database:DatabaseImplTest --runs_per_test=200

--- a/tools/local-presubmit
+++ b/tools/local-presubmit
@@ -23,5 +23,3 @@ set -x
 ./tools/sigh lint
 ./tools/sigh test --all
 
-# Temporary to check flakiness of test.
-./tools/bazelisk ${BAZELRC_OPTS} test //javatests/arcs/android/storage/database:DatabaseImplTest --runs_per_test=200


### PR DESCRIPTION
Was a bit flaky.

Addresses one of the flaky tests from https://github.com/PolymerLabs/arcs/issues/4781