### PR TITLE
Upgrade some eslint whitespace warnings to errors

### DIFF
--- a/config/eslintrc.json
+++ b/config/eslintrc.json
@@ -35,8 +35,8 @@
       ]
     ],
 
-    "no-trailing-spaces": 1,
-    "eol-last": 1,
+    "no-trailing-spaces": "error",
+    "eol-last": "error",
 
     // Things we do, but probably shouldn't.
     "no-console": "off",
@@ -70,7 +70,6 @@
     "linebreak-style": "off",
     "no-multi-spaces": "off",
     "keyword-spacing": [1, {"before": true, "after": true}],
-    "no-constant-condition": "off",
 
     // Always require .js extension for imported files, but not for node packages.
     "import/extensions": [1, "always", {"ignorePackages": true}]


### PR DESCRIPTION
Otherwise people get random changes in their PRs when they run `tools/sigh lint --fix`.

Also removed a duplicate rule from the config.