### PR TITLE
Stop throwing exceptions when DatabaseImpl encounters an old version

### DIFF
--- a/java/arcs/android/storage/database/DatabaseImpl.kt
+++ b/java/arcs/android/storage/database/DatabaseImpl.kt
@@ -562,7 +562,9 @@ class DatabaseImpl(
         } else {
             // Collection already exists; delete all existing entries.
             val collectionId = metadata.collectionId
-            if (data.databaseVersion <= metadata.versionNumber) return@useTransaction false
+            if (data.databaseVersion != metadata.versionNumber + 1) {
+                return@useTransaction false
+            }
 
             // TODO: Don't blindly delete everything and re-insert: only insert/remove the diff.
             when (dataType) {
@@ -809,7 +811,7 @@ class DatabaseImpl(
                     "$storedEntityId."
             }
             val storedVersion = it.getInt(2)
-            if (databaseVersion <= storedVersion) {
+            if (databaseVersion != storedVersion + 1) {
                 return@transaction null
             }
 

--- a/java/arcs/core/storage/database/Database.kt
+++ b/java/arcs/core/storage/database/Database.kt
@@ -34,7 +34,7 @@ interface Database {
         storageKey: StorageKey,
         data: DatabaseData,
         originatingClientId: Int? = null
-    ): Int
+    ): Boolean
 
     /** Fetches the data at [storageKey] from the database. */
     suspend fun get(

--- a/java/arcs/core/storage/driver/Database.kt
+++ b/java/arcs/core/storage/driver/Database.kt
@@ -346,7 +346,7 @@ class DatabaseDriver<Data : Any>(
         }
 
         // Store the prepped data.
-        return (database.insertOrUpdate(storageKey, databaseData, clientId) == version).also {
+        return database.insertOrUpdate(storageKey, databaseData, clientId).also {
             // If the update was successful, update our local data/version.
             if (it) localDataMutex.withLock {
                 localData = data

--- a/java/arcs/jvm/storage/database/testutil/MockDatabaseManager.kt
+++ b/java/arcs/jvm/storage/database/testutil/MockDatabaseManager.kt
@@ -11,7 +11,6 @@
 
 package arcs.jvm.storage.database.testutil
 
-import arcs.core.crdt.VersionMap
 import arcs.core.data.Schema
 import arcs.core.storage.StorageKey
 import arcs.core.storage.database.Database

--- a/java/arcs/jvm/storage/database/testutil/MockDatabaseManager.kt
+++ b/java/arcs/jvm/storage/database/testutil/MockDatabaseManager.kt
@@ -73,10 +73,11 @@ open class MockDatabase : Database {
         storageKey: StorageKey,
         data: DatabaseData,
         originatingClientId: Int?
-    ): Int = stats.insertUpdate.timeSuspending {
+    ): Boolean = stats.insertUpdate.timeSuspending {
         val (version, isNew) = dataMutex.withLock {
             val oldData = this.data[storageKey]
-            if (oldData?.databaseVersion != data.databaseVersion) {
+            // Must be exactly old version + 1, or have no previous version.
+            if (oldData == null || data.databaseVersion == oldData.databaseVersion + 1) {
                 this.data[storageKey] = data
                 data.databaseVersion to true
             } else {
@@ -90,7 +91,7 @@ open class MockDatabase : Database {
                 .launchIn(CoroutineScope(coroutineContext))
         }
 
-        return@timeSuspending version
+        isNew
     }
 
     @Suppress("UNCHECKED_CAST")
@@ -99,18 +100,7 @@ open class MockDatabase : Database {
         dataType: KClass<out DatabaseData>,
         schema: Schema
     ): DatabaseData? = stats.get.timeSuspending {
-        val dataVal = dataMutex.withLock { data[storageKey] }
-
-        if (dataVal != null) return@timeSuspending dataVal
-
-        return@timeSuspending when (dataType) {
-            DatabaseData.Singleton::class ->
-                DatabaseData.Singleton(null, schema, -1, VersionMap())
-            DatabaseData.Collection::class ->
-                DatabaseData.Collection(emptySet(), schema, -1, VersionMap())
-            DatabaseData.Entity::class -> null
-            else -> throw IllegalArgumentException("Illegal type.")
-        }
+        dataMutex.withLock { data[storageKey] }
     }
 
     override suspend fun delete(storageKey: StorageKey, originatingClientId: Int?) =

--- a/javatests/arcs/android/storage/ReferenceModeStoreDatabaseImplIntegrationTest.kt
+++ b/javatests/arcs/android/storage/ReferenceModeStoreDatabaseImplIntegrationTest.kt
@@ -447,7 +447,7 @@ class ReferenceModeStoreDatabaseImplIntegrationTest {
                     "t1" to t1Ref
                 )
             ),
-            1
+            3
         )
         driver.receiver!!(
             CrdtSet.DataImpl(
@@ -458,7 +458,7 @@ class ReferenceModeStoreDatabaseImplIntegrationTest {
                     "t2" to t2Ref
                 )
             ),
-            2
+            4
         )
 
         activeStore.idle()

--- a/javatests/arcs/android/storage/database/DatabaseImplTest.kt
+++ b/javatests/arcs/android/storage/database/DatabaseImplTest.kt
@@ -307,7 +307,7 @@ class DatabaseImplTest {
     }
 
     @Test
-    fun createEntityStorageKeyId_versionNumberMustBeLarger() = runBlockingTest {
+    fun createEntityStorageKeyId_versionNumberMustBeOneLarger() = runBlockingTest {
         val key = DummyStorageKey("key")
         val entityId = "entity-id"
         val typeId = 123L
@@ -351,7 +351,21 @@ class DatabaseImplTest {
             )
         ).isNull()
 
-        // Increasing version number is ok.
+        // Increasing version number by more than 1 is rejected.
+        assertThat(
+            database.createEntityStorageKeyId(
+                key,
+                entityId,
+                CREATION_TIMESTAMP,
+                EXPIRATION_TIMESTAMP,
+                typeId,
+                VERSION_MAP,
+                12,
+                db
+            )
+        ).isNull()
+
+        // Increasing version number by 1 is ok.
         val newStorageKeyId = database.createEntityStorageKeyId(
             key,
             entityId,
@@ -363,6 +377,8 @@ class DatabaseImplTest {
             db
         )
         assertThat(newStorageKeyId).isNotNull()
+        // TODO: If the storage key is the same, there's no need to delete the old one and create a
+        // new one.
         assertThat(newStorageKeyId).isNotEqualTo(originalStorageKeyId)
     }
 

--- a/javatests/arcs/core/storage/ReferenceModeStoreDatabaseIntegrationTest.kt
+++ b/javatests/arcs/core/storage/ReferenceModeStoreDatabaseIntegrationTest.kt
@@ -432,7 +432,7 @@ class ReferenceModeStoreDatabaseIntegrationTest {
                     "t1" to t1Ref
                 )
             ),
-            1
+            3
         )
         driver.receiver!!(
             CrdtSet.DataImpl(
@@ -443,7 +443,7 @@ class ReferenceModeStoreDatabaseIntegrationTest {
                     "t2" to t2Ref
                 )
             ),
-            2
+            4
         )
 
         activeStore.idle()


### PR DESCRIPTION
insertOrUpdate now returns a Boolean instead of a version number Int, which indicates whether the operation was applied or not. Previously we would throw an exception if the version number given in the request was the same or older than the one stored in the database. Now, getting an old version number is a no-op, and will return false.