### PR TITLE
allow registering empty capabilities

### DIFF
--- a/src/devtools-connector/tests/arc-stores-fetcher-test.ts
+++ b/src/devtools-connector/tests/arc-stores-fetcher-test.ts
@@ -72,7 +72,7 @@ describe('ArcStoresFetcher', () => {
                   type: 'Text'
                 }
               },
-              hashStr: null,
+              hashStr: '1c9b8f8d51ff6e11235ac13bf0c5ca74c88537e0',
               names: ['Foo'],
               refinement: null,
             },

--- a/src/runtime/capabilities.ts
+++ b/src/runtime/capabilities.ts
@@ -42,6 +42,7 @@ export class Capabilities {
     return [...this.capabilities].sort().join(' ');
   }
 
+  static readonly empty = new Capabilities([]);
   static readonly tiedToArc = new Capabilities(['tied-to-arc']);
   static readonly tiedToRuntime = new Capabilities(['tied-to-runtime']);
   static readonly persistent = new Capabilities(['persistent']);

--- a/src/runtime/capabilities.ts
+++ b/src/runtime/capabilities.ts
@@ -35,6 +35,9 @@ export class Capabilities {
   }
 
   contains(other: Capabilities): boolean {
+    if (other.isEmpty()) {
+      return this.isEmpty();
+    }
     return [...other.capabilities].every(c => this.capabilities.has(c));
   }
 

--- a/src/runtime/flags.ts
+++ b/src/runtime/flags.ts
@@ -24,6 +24,7 @@ class FlagDefaults {
   static enforceRefinements = false;
   static useSlandles = false;
   static fieldRefinementsAllowed = false;
+  static defaultReferenceMode = false;
 }
 
 export class Flags extends FlagDefaults {
@@ -50,6 +51,11 @@ export class Flags extends FlagDefaults {
   // tslint:disable-next-line: no-any
   static withFieldRefinementsAllowed<T, Args extends any[]>(f: (...args: Args) => Promise<T>): (...args: Args) => Promise<T> {
     return Flags.withFlags({fieldRefinementsAllowed: true}, f);
+  }
+
+  // tslint:disable-next-line: no-any
+  static withDefaultReferenceMode<T, Args extends any[]>(f: (...args: Args) => Promise<T>): (...args: Args) => Promise<T> {
+    return Flags.withFlags({defaultReferenceMode: true}, f);
   }
 
   // For testing with a different set of flags to the default.

--- a/src/runtime/flags.ts
+++ b/src/runtime/flags.ts
@@ -24,6 +24,7 @@ class FlagDefaults {
   static enforceRefinements = false;
   static useSlandles = false;
   static fieldRefinementsAllowed = false;
+  // TODO(#4843): temporary avoid using reference-mode-store in tests.
   static defaultReferenceMode = false;
 }
 

--- a/src/runtime/recipe/handle.ts
+++ b/src/runtime/recipe/handle.ts
@@ -39,7 +39,7 @@ export class Handle implements Comparable<Handle> {
   private _associatedHandles: Handle[] = [];
   private _mappedType: Type | undefined = undefined;
   private _storageKey: StorageKey | undefined = undefined;
-  capabilities: Capabilities;
+  capabilities: Capabilities = Capabilities.empty;
   private _pattern: string | undefined = undefined;
   // Value assigned in the immediate mode, E.g. hostedParticle = ShowProduct
   // Currently only supports ParticleSpec.
@@ -97,7 +97,7 @@ export class Handle implements Comparable<Handle> {
       handle._mappedType = this._mappedType;
       handle._storageKey = this._storageKey;
       handle._immediateValue = this._immediateValue;
-      handle.capabilities = this.capabilities ? this.capabilities.clone() : undefined;
+      handle.capabilities = this.capabilities.clone();
       handle._ttl = this._ttl;
       // the connections are re-established when Particles clone their
       // attached HandleConnection objects.
@@ -347,7 +347,7 @@ export class Handle implements Comparable<Handle> {
     if (this.associatedHandles.length) {
       result.push(`(${this.associatedHandles.map(h => getName(h)).join(', ')})`);
     }
-    if (this.capabilities && !this.capabilities.isEmpty()) {
+    if (!this.capabilities.isEmpty()) {
       result.push(this.capabilities.toString());
     }
     if (this.id) {

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -12,7 +12,7 @@ import {assert} from '../platform/assert-web.js';
 import {Description} from './description.js';
 import {Manifest} from './manifest.js';
 import {Arc} from './arc.js';
-import {CapabilitiesResolver, StorageKeyCreatorsMap} from './capabilities-resolver.js';
+import {CapabilitiesResolver, StorageKeyCreatorInfo} from './capabilities-resolver.js';
 import {RuntimeCacheService} from './runtime-cache.js';
 import {IdGenerator, ArcId} from './id.js';
 import {PecFactory} from './particle-execution-context.js';
@@ -46,7 +46,7 @@ export type RuntimeArcOptions = Readonly<{
   stub?: boolean;
   listenerClasses?: ArcInspectorFactory[];
   inspectorFactory?: ArcInspectorFactory;
-  storageKeyCreators?: StorageKeyCreatorsMap;
+  storageKeyCreators?: StorageKeyCreatorInfo[];
 }>;
 
 type SpawnArgs = {

--- a/src/runtime/storageNG/drivers/volatile.ts
+++ b/src/runtime/storageNG/drivers/volatile.ts
@@ -260,3 +260,7 @@ CapabilitiesResolver.registerDefaultKeyCreator(
     VolatileStorageKey.protocol,
     Capabilities.tiedToArc,
     (options: StorageKeyOptions) => new VolatileStorageKey(options.arcId, options.unique(), ''));
+CapabilitiesResolver.registerDefaultKeyCreator(
+    VolatileStorageKey.protocol,
+    Capabilities.empty,
+    (options: StorageKeyOptions) => new VolatileStorageKey(options.arcId, options.unique(), ''));

--- a/src/runtime/tests/arc-test.ts
+++ b/src/runtime/tests/arc-test.ts
@@ -10,6 +10,7 @@
 
 import {assert} from '../../platform/chai-web.js';
 import {Arc} from '../arc.js';
+import {Flags} from '../flags.js';
 import {Id, ArcId, IdGenerator} from '../id.js';
 import {Loader} from '../../platform/loader.js';
 import {Manifest} from '../manifest.js';
@@ -162,7 +163,7 @@ describe('Arc new storage', () => {
     assert.deepEqual(refVarData, d4);
   });
 
-  it('supports capabilities - storage protocol', async () => {
+  it('supports capabilities - storage protocol', Flags.withDefaultReferenceMode(async () => {
     DriverFactory.clearRegistrationsForTesting();
     const loader = new Loader(null, {
       '*': `
@@ -196,7 +197,7 @@ describe('Arc new storage', () => {
     assert.instanceOf(refKey.backingKey, VolatileStorageKey);
     assert.instanceOf(refKey.storageKey, VolatileStorageKey);
     assert.isTrue(key.toString().includes(arc.id.toString()));
-  });
+  }));
 });
 
 const doSetup = async () => setup(arcId => new VolatileStorageKey(arcId, ''));

--- a/src/runtime/tests/capabilities-resolver-test.ts
+++ b/src/runtime/tests/capabilities-resolver-test.ts
@@ -40,6 +40,8 @@ describe('Capabilities Resolver', () => {
     const key = await resolver1.createStorageKey(Capabilities.tiedToArc, schema, handleId);
     verifyStorageKey(key, VolatileStorageKey);
     await assertThrowsAsync(async () => await resolver1.createStorageKey(
+        Capabilities.empty, schema, handleId));
+    await assertThrowsAsync(async () => await resolver1.createStorageKey(
         Capabilities.tiedToRuntime, schema, handleId));
     await assertThrowsAsync(async () => await resolver1.createStorageKey(
         Capabilities.persistent, schema, handleId));
@@ -67,11 +69,19 @@ describe('Capabilities Resolver', () => {
     verifyStorageKey(await resolver4.createStorageKey(
         Capabilities.persistent, schema, handleId), DatabaseStorageKey);
 
+    const resolver5 = new CapabilitiesResolver({arcId: ArcId.newForTest('test')}, [{
+        protocol: VolatileStorageKey.protocol,
+        capabilities: Capabilities.empty,
+        create: (options: StorageKeyOptions) => new VolatileStorageKey(options.arcId, options.unique(), options.unique())
+    }]);
+    verifyStorageKey(await resolver4.createStorageKey(
+        Capabilities.empty, schema, handleId), VolatileStorageKey);
+
     CapabilitiesResolver.reset();
-    const resolver5 = new CapabilitiesResolver({arcId: ArcId.newForTest('test')});
-    verifyStorageKey(await resolver5.createStorageKey(
+    const resolver6 = new CapabilitiesResolver({arcId: ArcId.newForTest('test')});
+    verifyStorageKey(await resolver6.createStorageKey(
         Capabilities.tiedToArc, schema, handleId), VolatileStorageKey);
-    await assertThrowsAsync(async () => await resolver5.createStorageKey(
+    await assertThrowsAsync(async () => await resolver6.createStorageKey(
         Capabilities.tiedToRuntime, schema, handleId));
   }));
 

--- a/src/runtime/tests/capabilities-resolver-test.ts
+++ b/src/runtime/tests/capabilities-resolver-test.ts
@@ -9,6 +9,7 @@
  */
 import {assert} from '../../platform/chai-web.js';
 import {ArcId} from '../id.js';
+import {Flags} from '../flags.js';
 import {CapabilitiesResolver, StorageKeyOptions} from '../capabilities-resolver.js';
 import {Capabilities} from '../capabilities.js';
 import {Schema} from '../schema.js';
@@ -34,7 +35,7 @@ describe('Capabilities Resolver', () => {
   const schema = new Schema(['Thing'], {result: 'Text'});
   const handleId = 'h0';
 
-  it('creates storage keys', async () => {
+  it('creates storage keys', Flags.withDefaultReferenceMode(async () => {
     const resolver1 = new CapabilitiesResolver({arcId: ArcId.newForTest('test')});
     const key = await resolver1.createStorageKey(Capabilities.tiedToArc, schema, handleId);
     verifyStorageKey(key, VolatileStorageKey);
@@ -43,12 +44,11 @@ describe('Capabilities Resolver', () => {
     await assertThrowsAsync(async () => await resolver1.createStorageKey(
         Capabilities.persistent, schema, handleId));
 
-    const resolver2 = new CapabilitiesResolver({arcId: ArcId.newForTest('test')},
-        new Map([
-            [RamDiskStorageKey.protocol, {
-                capabilities: Capabilities.tiedToRuntime,
-                create: (options: StorageKeyOptions) => new RamDiskStorageKey(options.unique())
-    }]]));
+    const resolver2 = new CapabilitiesResolver({arcId: ArcId.newForTest('test')}, [{
+        protocol: RamDiskStorageKey.protocol,
+        capabilities: Capabilities.tiedToRuntime,
+        create: (options: StorageKeyOptions) => new RamDiskStorageKey(options.unique())
+    }]);
     await assertThrowsAsync(async () => await resolver2.createStorageKey(
         Capabilities.tiedToArc, schema, handleId));
     verifyStorageKey(await resolver2.createStorageKey(
@@ -73,9 +73,9 @@ describe('Capabilities Resolver', () => {
         Capabilities.tiedToArc, schema, handleId), VolatileStorageKey);
     await assertThrowsAsync(async () => await resolver5.createStorageKey(
         Capabilities.tiedToRuntime, schema, handleId));
-});
+  }));
 
-  it('registers and creates database key', async () => {
+  it('registers and creates database key', Flags.withDefaultReferenceMode(async () => {
     const resolver1 = new CapabilitiesResolver({arcId: ArcId.newForTest('test')});
     await assertThrowsAsync(async () => await resolver1.createStorageKey(
         Capabilities.persistent, schema, handleId));
@@ -84,21 +84,21 @@ describe('Capabilities Resolver', () => {
     const resolver2 = new CapabilitiesResolver({arcId: ArcId.newForTest('test')});
     const key = await resolver2.createStorageKey(Capabilities.persistent, schema, handleId);
     verifyStorageKey(key, PersistentDatabaseStorageKey);
-  });
+  }));
 
-  it('fails for unsupported capabilities', async () => {
+  it('fails for unsupported capabilities', Flags.withDefaultReferenceMode(async () => {
     const capabilitiesResolver = new CapabilitiesResolver({arcId: ArcId.newForTest('test')});
     await assertThrowsAsync(async () => await capabilitiesResolver.createStorageKey(
         Capabilities.tiedToRuntime, schema, handleId));
 
     await assertThrowsAsync(async () => await capabilitiesResolver.createStorageKey(
         new Capabilities(['persistent', 'tied-to-arc']), schema, handleId));
-  });
+  }));
 
   it('verifies static creators', () => {
-    assert.equal(CapabilitiesResolver.getDefaultCreators().size, 1);
-    assert.isTrue(
-        CapabilitiesResolver.getDefaultCreators().has(VolatileStorageKey.protocol));
+    assert.equal(CapabilitiesResolver.getDefaultCreators().length, 2);
+    assert.isTrue(CapabilitiesResolver.getDefaultCreators().every(
+        ({protocol}) => protocol === VolatileStorageKey.protocol));
   });
 
   it('finds storage key protocols for capabilities', () => {

--- a/src/runtime/tests/capabilities-test.ts
+++ b/src/runtime/tests/capabilities-test.ts
@@ -12,6 +12,7 @@ import {Capabilities} from '../capabilities.js';
 
 describe('Capabilities', () => {
   it('verifies same capabilities', () => {
+    assert.isTrue(Capabilities.empty.isSame(Capabilities.empty));
     assert.isTrue(Capabilities.persistent.isSame(Capabilities.persistent));
     assert.isTrue(Capabilities.queryable.isSame(Capabilities.queryable));
     assert.isTrue(Capabilities.persistentQueryable.isSame(
@@ -19,12 +20,13 @@ describe('Capabilities', () => {
     assert.isTrue(Capabilities.tiedToRuntime.isSame(Capabilities.tiedToRuntime));
     assert.isTrue(Capabilities.tiedToArc.isSame(Capabilities.tiedToArc));
 
+    assert.isFalse(Capabilities.empty.isSame(Capabilities.persistent));
     assert.isFalse(Capabilities.persistent.isSame(Capabilities.tiedToRuntime));
     assert.isFalse(Capabilities.tiedToRuntime.isSame(Capabilities.tiedToArc));
     assert.isFalse(Capabilities.tiedToArc.isSame(Capabilities.persistent));
     assert.isFalse(Capabilities.queryable.isSame(Capabilities.persistentQueryable));
 
-
+    assert.isTrue(new Capabilities([]).isSame(new Capabilities([])));
     assert.isTrue(new Capabilities(['persistent', 'tied-to-arc']).isSame(
         new Capabilities(['persistent', 'tied-to-arc'])));
     assert.isTrue(new Capabilities(['persistent', 'queryable']).isSame(
@@ -35,6 +37,7 @@ describe('Capabilities', () => {
   });
 
   it('verifies contained capabilities', () => {
+    assert.isTrue(Capabilities.empty.contains(Capabilities.empty));
     assert.isTrue(Capabilities.persistent.contains(Capabilities.persistent));
     assert.isTrue(Capabilities.queryable.contains(Capabilities.queryable));
     assert.isTrue(Capabilities.persistentQueryable.contains(Capabilities.persistentQueryable));
@@ -43,6 +46,8 @@ describe('Capabilities', () => {
     assert.isTrue(Capabilities.tiedToRuntime.contains(Capabilities.tiedToRuntime));
     assert.isTrue(Capabilities.tiedToArc.contains(Capabilities.tiedToArc));
 
+    assert.isFalse(Capabilities.empty.contains(Capabilities.persistent));
+    assert.isFalse(Capabilities.persistent.contains(Capabilities.empty));
     assert.isFalse(Capabilities.persistent.contains(Capabilities.tiedToRuntime));
     assert.isFalse(Capabilities.tiedToRuntime.contains(Capabilities.tiedToArc));
     assert.isFalse(Capabilities.tiedToArc.contains(Capabilities.persistent));

--- a/src/runtime/tests/runtime-test.ts
+++ b/src/runtime/tests/runtime-test.ts
@@ -92,8 +92,8 @@ describe('Runtime', () => {
           t3: writes [Thing]
         recipe
           t1: create
-          t2: create * #volatile
-          t3: create #things
+          t2: create *
+          t3: create tied-to-runtime #things
           MyParticle
             t1: writes t1
             t2: writes t2
@@ -116,7 +116,7 @@ describe('Runtime', () => {
     assert.equal(runtime.context, volatileArc.context);
 
     await volatileArc.instantiate(manifest.recipes[0]);
-    assert.lengthOf(runtime.context.stores, 0);
+    assert.lengthOf(runtime.context.stores, 1);
 
     await ramdiskArc.instantiate(manifest.recipes[0]);
     assert.lengthOf(runtime.context.stores, 2);


### PR DESCRIPTION
- Registering Volatile key as corresponding to an empty capability.
- I'm temporarily putting use of reference more stores behind a flag, so that i can first push this, and fix every other failing test in a follow up PR.