### PR TITLE
Convert connections in [ParticleSpec] to a map.

### DIFF
--- a/java/arcs/core/data/ParticleSpec.kt
+++ b/java/arcs/core/data/ParticleSpec.kt
@@ -11,6 +11,13 @@
 
 package arcs.core.data
 
+/**
+ * This class contains metadata about a [Particle] in a [Recipe].
+ *
+ * @property name the name of the particle.
+ * @property connections all the handle connections of the particle indexed by the connection name.
+ * @property location the location of the implementation.
+ */
 data class ParticleSpec(
     val name: String,
     val connections: Map<String, HandleConnectionSpec>,

--- a/java/arcs/core/data/ParticleSpec.kt
+++ b/java/arcs/core/data/ParticleSpec.kt
@@ -13,6 +13,6 @@ package arcs.core.data
 
 data class ParticleSpec(
     val name: String,
-    val connections: List<HandleConnectionSpec>,
+    val connections: Map<String, HandleConnectionSpec>,
     val location: String
 )

--- a/java/arcs/core/data/proto/BUILD
+++ b/java/arcs/core/data/proto/BUILD
@@ -22,6 +22,7 @@ arcs_kt_library(
         ":recipe_java_proto_lite",
         "//java/arcs/core/data",
         "//java/arcs/core/type",
+        "//java/arcs/core/util",
     ],
 )
 

--- a/java/arcs/core/data/proto/BUILD
+++ b/java/arcs/core/data/proto/BUILD
@@ -38,6 +38,7 @@ arcs_kt_library(
         ":recipe_java_proto",
         "//java/arcs/core/data",
         "//java/arcs/core/type",
+        "//java/arcs/core/util",
     ],
 )
 

--- a/java/arcs/core/data/proto/ParticleSpecProtoDecoder.kt
+++ b/java/arcs/core/data/proto/ParticleSpecProtoDecoder.kt
@@ -14,6 +14,8 @@ package arcs.core.data.proto
 import arcs.core.data.HandleConnectionSpec
 import arcs.core.data.HandleConnectionSpec.Direction
 import arcs.core.data.ParticleSpec
+import arcs.core.util.Result
+import arcs.core.util.resultOf
 
 typealias DirectionProto = HandleConnectionSpecProto.Direction
 
@@ -35,8 +37,7 @@ fun HandleConnectionSpecProto.decode() = HandleConnectionSpec(
 )
 
 /** Converts a [ParticleSpecProto] to the corresponding [ParticleSpec] instance. */
-fun ParticleSpecProto.decode() = ParticleSpec(
-    name = getName(),
-    connections = getConnectionsList().map { it.getName() to it.decode() }.toMap(),
-    location = getLocation()
-)
+fun ParticleSpecProto.decode(): Result<ParticleSpec> = resultOf {
+    val connections = getConnectionsList().map { it.getName() to it.decode() }.toMap()
+    ParticleSpec(name = getName(), connections = connections, location = getLocation())
+}

--- a/java/arcs/core/data/proto/ParticleSpecProtoDecoder.kt
+++ b/java/arcs/core/data/proto/ParticleSpecProtoDecoder.kt
@@ -39,12 +39,10 @@ fun HandleConnectionSpecProto.decode() = HandleConnectionSpec(
 /** Converts a [ParticleSpecProto] to the corresponding [ParticleSpec] instance. */
 fun ParticleSpecProto.decode(): Result<ParticleSpec> = resultOf {
     val connections = mutableMapOf<String, HandleConnectionSpec>()
-    for (connection in getConnectionsList()) {
-        val oldValue = connections.put(connection.name, connection.decode())
-        if (oldValue != null) {
-            throw IllegalArgumentException(
-                "Duplicate connection '${connection.name}' when " +
-                "decoding ParticleSpecProto '${name}'")
+    connectionsList.forEach {
+        val oldValue = connections.put(it.name, it.decode())
+        require (oldValue == null) {
+            "Duplicate connection '${it.name}' when decoding ParticleSpecProto '${name}'"
         }
     }
     ParticleSpec(name, connections, location)

--- a/java/arcs/core/data/proto/ParticleSpecProtoDecoder.kt
+++ b/java/arcs/core/data/proto/ParticleSpecProtoDecoder.kt
@@ -41,8 +41,8 @@ fun ParticleSpecProto.decode(): Result<ParticleSpec> = resultOf {
     val connections = mutableMapOf<String, HandleConnectionSpec>()
     connectionsList.forEach {
         val oldValue = connections.put(it.name, it.decode())
-        require (oldValue == null) {
-            "Duplicate connection '${it.name}' when decoding ParticleSpecProto '${name}'"
+        require(oldValue == null) {
+            "Duplicate connection '${it.name}' when decoding ParticleSpecProto '$name'"
         }
     }
     ParticleSpec(name, connections, location)

--- a/java/arcs/core/data/proto/ParticleSpecProtoDecoder.kt
+++ b/java/arcs/core/data/proto/ParticleSpecProtoDecoder.kt
@@ -38,6 +38,14 @@ fun HandleConnectionSpecProto.decode() = HandleConnectionSpec(
 
 /** Converts a [ParticleSpecProto] to the corresponding [ParticleSpec] instance. */
 fun ParticleSpecProto.decode(): Result<ParticleSpec> = resultOf {
-    val connections = getConnectionsList().map { it.getName() to it.decode() }.toMap()
-    ParticleSpec(name = getName(), connections = connections, location = getLocation())
+    val connections = mutableMapOf<String, HandleConnectionSpec>()
+    for (connection in getConnectionsList()) {
+        val oldValue = connections.put(connection.name, connection.decode())
+        if (oldValue != null) {
+            throw IllegalArgumentException(
+                "Duplicate connection '${connection.name}' when " +
+                "decoding ParticleSpecProto '${name}'")
+        }
+    }
+    ParticleSpec(name, connections, location)
 }

--- a/java/arcs/core/data/proto/ParticleSpecProtoDecoder.kt
+++ b/java/arcs/core/data/proto/ParticleSpecProtoDecoder.kt
@@ -37,6 +37,6 @@ fun HandleConnectionSpecProto.decode() = HandleConnectionSpec(
 /** Converts a [ParticleSpecProto] to the corresponding [ParticleSpec] instance. */
 fun ParticleSpecProto.decode() = ParticleSpec(
     name = getName(),
-    connections = getConnectionsList().map { it.decode() },
+    connections = getConnectionsList().map { it.getName() to it.decode() }.toMap(),
     location = getLocation()
 )

--- a/javatests/arcs/core/data/proto/BUILD
+++ b/javatests/arcs/core/data/proto/BUILD
@@ -16,6 +16,7 @@ arcs_kt_jvm_test_suite(
         "//java/arcs/core/data/proto:proto_for_test",
         "//java/arcs/core/data/proto:recipe_java_proto",
         "//java/arcs/core/testutil",
+        "//java/arcs/core/util",
         "//java/arcs/repoutils",
         "//third_party/java/arcs/deps:protobuf_java",
         "//third_party/java/junit:junit-android",

--- a/javatests/arcs/core/data/proto/ParticleSpecProtoDecoderTest.kt
+++ b/javatests/arcs/core/data/proto/ParticleSpecProtoDecoderTest.kt
@@ -92,7 +92,7 @@ class ParticleSpecProtoDecoderTest {
         val readConnectionSpec = decodeHandleConnectionSpecProto(readConnectionSpecProto)
         assertThat(readerSpec.name).isEqualTo("Reader")
         assertThat(readerSpec.location).isEqualTo("Everywhere")
-        assertThat(readerSpec.connections).isEqualTo(listOf(readConnectionSpec))
+        assertThat(readerSpec.connections).isEqualTo(mapOf("read" to readConnectionSpec))
 
         val readerWriterSpecProto = """
           name: "ReaderWriter"
@@ -105,6 +105,6 @@ class ParticleSpecProtoDecoderTest {
         assertThat(readerWriterSpec.name).isEqualTo("ReaderWriter")
         assertThat(readerWriterSpec.location).isEqualTo("Nowhere")
         assertThat(readerWriterSpec.connections).isEqualTo(
-            listOf(readConnectionSpec, writeConnectionSpec))
+            mapOf("read" to readConnectionSpec, "write" to writeConnectionSpec))
     }
 }

--- a/javatests/arcs/core/data/proto/ParticleSpecProtoDecoderTest.kt
+++ b/javatests/arcs/core/data/proto/ParticleSpecProtoDecoderTest.kt
@@ -112,4 +112,19 @@ class ParticleSpecProtoDecoderTest {
         assertThat(readerWriterSpec.connections).isEqualTo(
             mapOf("read" to readConnectionSpec, "write" to writeConnectionSpec))
     }
+
+    @Test
+    fun detectsDuplicateConnections() {
+        val readConnectionSpecProto = getHandleConnectionSpecProto("read", "READS", "Thing")
+        val readerSpecProto = """
+          name: "Reader"
+          connections { ${readConnectionSpecProto} }
+          connections { ${readConnectionSpecProto} }
+          location: "Everywhere"
+        """.trimIndent()
+        val exception = assertThrows(IllegalArgumentException::class) {
+            decodeParticleSpecProto(readerSpecProto)
+        }
+        assertThat(exception).hasMessageThat().contains("Duplicate connection 'read'")
+    }
 }

--- a/javatests/arcs/core/data/proto/ParticleSpecProtoDecoderTest.kt
+++ b/javatests/arcs/core/data/proto/ParticleSpecProtoDecoderTest.kt
@@ -3,6 +3,7 @@ package arcs.core.data.proto
 import arcs.core.data.*
 import arcs.core.testutil.assertThrows
 import arcs.core.testutil.fail
+import arcs.core.util.Result
 import arcs.repoutils.runfilesDir
 import com.google.common.truth.Truth.assertThat
 import com.google.protobuf.Message.Builder
@@ -28,7 +29,11 @@ fun decodeHandleConnectionSpecProto(protoText: String): HandleConnectionSpec {
 fun decodeParticleSpecProto(protoText: String): ParticleSpec {
     val builder = ParticleSpecProto.newBuilder()
     TextFormat.getParser().merge(protoText, builder)
-    return builder.build().decode()
+    val result = builder.build().decode()
+    return when (result) {
+        is Result.Ok -> result.value
+        is Result.Err -> throw result.thrown
+    }
 }
 
 @RunWith(JUnit4::class)


### PR DESCRIPTION
This will be useful when decoding `HandleConnectionProto` because we will need to lookup a `HandleConnectionSpec` by name. 

This PR also adds some logic to detect duplicate connection names when decoding.