### PR TITLE
[WIP] Cleanup and reorg of handle callback code

### DIFF
--- a/java/arcs/core/storage/Handle.kt
+++ b/java/arcs/core/storage/Handle.kt
@@ -22,30 +22,6 @@ import arcs.core.util.TaggedLog
 import arcs.core.util.Time
 
 /**
- * The [Callbacks] interface is a simple stand-in for the callbacks that a [Handle] might want to
- * use to signal information back to a subscriber (like a handle).
- */
-interface Callbacks<Data : CrdtData, Op : CrdtOperationAtTime, T> {
-    /**
-     * [onUpdate] is called when a diff is received from storage, or from a handle. Handles can
-     * be notified for their own writes.
-     * This method is not called for every change! A model sync will call [onSync] instead.
-     * Do not depend on seeing every update via this callback.
-     */
-    fun onUpdate(handle: Handle<Data, Op, T>, op: Op) = Unit
-
-    /**
-     * [onSync] is called when the proxy is synced from its backing [Store].
-     */
-    fun onSync(handle: Handle<Data, Op, T>) = Unit
-
-    /**
-     * [onDesync] is called when the proxy realizes it is out of sync with its backing [Store].
-     */
-    fun onDesync(handle: Handle<Data, Op, T>) = Unit
-}
-
-/**
  * Base implementation of Arcs handles on the runtime.
  *
  * A handle is in charge of translating SDK data operations into the appropriate CRDT operation,
@@ -71,9 +47,6 @@ open class Handle<Data : CrdtData, Op : CrdtOperationAtTime, T>(
     /** [name] is the unique name for this handle, used to track state in the [VersionMap]. */
     val name: String,
     val storageProxy: StorageProxy<Data, Op, T>,
-
-    /** [callback] contains optional Handle-owner provided callbacks to add behavior. */
-    var callback: Callbacks<Data, Op, T>? = null,
 
     /** [ttl] applied to the data in the [Handle]. */
     val ttl: Ttl,
@@ -101,6 +74,10 @@ open class Handle<Data : CrdtData, Op : CrdtOperationAtTime, T>(
 ) {
     protected val log = TaggedLog { "Handle($name)" }
 
+    suspend fun addOnUpdate(action: (value: T) -> Unit) { storageProxy.addOnUpdate(action) }
+    suspend fun addOnSync(action: () -> Unit) { storageProxy.addOnSync(action) }
+    suspend fun addOnDesync(action: () -> Unit) { storageProxy.addOnDesync(action) }
+
     /** Creates a [Reference] for a given [Referencable] and backing [StorageKey]. */
     fun createReference(referencable: Referencable, backingKey: StorageKey): Reference {
         return Reference(referencable.id, backingKey, null).also {
@@ -121,30 +98,6 @@ open class Handle<Data : CrdtData, Op : CrdtOperationAtTime, T>(
     protected fun VersionMap.increment(): VersionMap {
         this[name]++
         return this
-    }
-
-    /**
-     * This should be called by the [StorageProxy] this [Handle] has been registered with,
-     * after a model update has been cleanly applied to the [StorageProxy]'s local copy.
-     */
-    internal fun onUpdate(op: Op) {
-        callback?.onUpdate(this, op)
-    }
-
-    /**
-     * This should be called by the [StorageProxy] this [Handle] has been registered with,
-     * after a full sync has occurred.
-     */
-    internal fun onSync() {
-        callback?.onSync(this)
-    }
-
-    /**
-     * This should be called by the [StorageProxy] this [Handle] has been registered with,
-     * when the [StorageProxy] has detected that its local model is out of sync.
-     */
-    internal fun onDesync() {
-        callback?.onDesync(this)
     }
 
     /**

--- a/java/arcs/core/storage/StorageProxy.kt
+++ b/java/arcs/core/storage/StorageProxy.kt
@@ -19,8 +19,6 @@ import arcs.core.util.TaggedLog
 import arcs.core.util.guardedBy
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Deferred
-import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
@@ -37,10 +35,14 @@ class StorageProxy<Data : CrdtData, Op : CrdtOperationAtTime, T>(
 ) {
     private val log = TaggedLog { "StorageProxy" }
 
-    private val handlesMutex = Mutex()
-
-    private val readHandles: MutableSet<Handle<Data, Op, T>>
-        by guardedBy(handlesMutex, mutableSetOf())
+    // TODO - do we need to store these by handle ID for cleanup?
+    private val callbackMutex = Mutex()
+    private val onUpdateActions: MutableList<(T) -> Unit>
+        by guardedBy(callbackMutex, mutableListOf())
+    private val onSyncActions: MutableList<() -> Unit>
+        by guardedBy(callbackMutex, mutableListOf())
+    private val onDesyncActions: MutableList<() -> Unit>
+        by guardedBy(callbackMutex, mutableListOf())
 
     private val syncMutex = Mutex()
     private val crdt: CrdtModel<Data, Op, T>
@@ -52,36 +54,28 @@ class StorageProxy<Data : CrdtData, Op : CrdtOperationAtTime, T>(
 
     private val store = storeEndpointProvider.getStorageEndpoint()
 
+    // TODO - should we trigger sync?
     init {
         store.setCallback(ProxyCallback(::onMessage))
     }
 
-    /**
-     * Connects a [Handle]. If the handle is readable, it will receive the configured callbacks.
-     */
-    suspend fun registerHandle(handle: Handle<Data, Op, T>) {
-        // non-readers don't get callbacks, return early
-        if (!handle.canRead) return
-
-        log.debug { "Registering handle: $handle" }
-
-        val firstReader = handlesMutex.withLock {
-            readHandles.add(handle)
-            readHandles.size == 1
+    suspend fun addOnUpdate(action: (value: T) -> Unit) {
+        callbackMutex.withLock {
+            onUpdateActions.add(action)
         }
-
-        val hasSynced = syncMutex.withLock { isSynchronized }
-
-        if (firstReader) requestSynchronization()
-        else if (hasSynced) coroutineScope { launch { handle.onSync() } }
     }
 
-    /**
-     * Disconnects a handle so it no longer receives callbacks.
-     */
-    suspend fun deregisterHandle(handle: Handle<Data, Op, T>) {
-        log.debug { "Unregistering handle: $handle" }
-        handlesMutex.withLock { readHandles.remove(handle) }
+    // TODO -- should we trigger sync?
+    suspend fun addOnSync(action: () -> Unit) {
+        callbackMutex.withLock {
+            onSyncActions.add(action)
+        }
+    }
+
+    suspend fun addOnDesync(action: () -> Unit) {
+        callbackMutex.withLock {
+            onDesyncActions.add(action)
+        }
     }
 
     /**
@@ -90,7 +84,9 @@ class StorageProxy<Data : CrdtData, Op : CrdtOperationAtTime, T>(
      */
     suspend fun applyOp(op: Op): Boolean {
         log.debug { "Applying operation: $op" }
-        val localSuccess = syncMutex.withLock { crdt.applyOperation(op) }
+        val (localSuccess, value) = syncMutex.withLock {
+            crdt.applyOperation(op) to crdt.consumerView
+        }
         if (!localSuccess) return false
 
         val msg = ProxyMessage.Operations<Data, Op, T>(listOf(op), null)
@@ -102,7 +98,7 @@ class StorageProxy<Data : CrdtData, Op : CrdtOperationAtTime, T>(
             requestSynchronization()
         }
 
-        notifyUpdate(listOf(op))
+        notifyUpdate(value)
 
         return true
     }
@@ -178,7 +174,7 @@ class StorageProxy<Data : CrdtData, Op : CrdtOperationAtTime, T>(
 
                 // all ops from storage applied cleanly so resolve waiting syncs
                 futuresToResolve.forEach { it.complete(value) }
-                notifyUpdate(message.operations)
+                notifyUpdate(value)
             }
             is ProxyMessage.SyncRequest -> {
                 // storage wants our latest state
@@ -191,28 +187,17 @@ class StorageProxy<Data : CrdtData, Op : CrdtOperationAtTime, T>(
         return true
     }
 
-    private suspend fun notifyUpdate(ops: List<Op>) = forEachHandle { handle ->
-        ops.forEach {
-            handle.onUpdate(it)
-        }
-    }
+    private suspend fun notifyUpdate(data: T) = callbackMutex.withLock {
+        onUpdateActions.toSet()
+    }.forEach { it(data) }
 
-    private suspend fun notifySync() = forEachHandle {
-        it.onSync()
-    }
+    private suspend fun notifySync() = callbackMutex.withLock {
+        onSyncActions.toSet()
+    }.forEach { it() }
 
-    private suspend fun notifyDesync() = forEachHandle { it.onDesync() }
-
-    private suspend inline fun forEachHandle(crossinline block: (Handle<Data, Op, T>) -> Unit) {
-        val handlesToNotify = handlesMutex.withLock { readHandles.toSet() }
-
-        // suspends until all handles have completed (in parallel)
-        coroutineScope {
-            handlesToNotify.forEach { handle ->
-                launch { block(handle) }
-            }
-        }
-    }
+    private suspend fun notifyDesync() = callbackMutex.withLock {
+        onDesyncActions.toSet()
+    }.forEach { it() }
 
     private suspend fun requestSynchronization(): Boolean {
         val msg = ProxyMessage.SyncRequest<Data, Op, T>(null)

--- a/java/arcs/core/storage/api/Handle.kt
+++ b/java/arcs/core/storage/api/Handle.kt
@@ -54,10 +54,10 @@ interface ReadCollectionHandle<T : Entity> : Handle {
     suspend fun onUpdate(action: (Set<T>) -> Unit)
 
     /** Assign a callback when the collection handle is synced. */
-    suspend fun onSync(action: (ReadCollectionHandle<T>) -> Unit)
+    suspend fun onSync(action: () -> Unit)
 
     /** Assign a callback when the collection handle is desynced. */
-    suspend fun onDesync(action: (ReadCollectionHandle<T>) -> Unit)
+    suspend fun onDesync(action: () -> Unit)
 
     /** Returns a set with all the entities in the collection. */
     suspend fun fetchAll(): Set<T>

--- a/java/arcs/core/storage/handle/CollectionImpl.kt
+++ b/java/arcs/core/storage/handle/CollectionImpl.kt
@@ -17,7 +17,6 @@ import arcs.core.data.RawEntity
 import arcs.core.data.Schema
 import arcs.core.data.Ttl
 import arcs.core.storage.ActivationFactory
-import arcs.core.storage.Callbacks
 import arcs.core.storage.Dereferencer
 import arcs.core.storage.Handle
 import arcs.core.storage.StorageProxy
@@ -32,7 +31,6 @@ typealias SetHandle<T> = CollectionImpl<T>
 typealias SetActivationFactory<T> = ActivationFactory<SetData<T>, SetOp<T>, Set<T>>
 typealias SetProxy<T> = StorageProxy<CrdtSet.Data<T>, CrdtSet.IOperation<T>, Set<T>>
 typealias SetBase<T> = Handle<CrdtSet.Data<T>, CrdtSet.IOperation<T>, Set<T>>
-typealias SetCallbacks<T> = Callbacks<SetData<T>, SetOp<T>, Set<T>>
 
 /**
  * Collection Handle implementation for the runtime.
@@ -43,7 +41,6 @@ typealias SetCallbacks<T> = Callbacks<SetData<T>, SetOp<T>, Set<T>>
 class CollectionImpl<T : Referencable>(
     name: String,
     storageProxy: SetProxy<T>,
-    callbacks: SetCallbacks<T>? = null,
     ttl: Ttl = Ttl.Infinite,
     time: Time,
     canRead: Boolean = true,
@@ -52,7 +49,6 @@ class CollectionImpl<T : Referencable>(
 ) : SetBase<T>(
     name,
     storageProxy,
-    callbacks,
     ttl,
     time,
     canRead,

--- a/java/arcs/core/storage/handle/HandleManager.kt
+++ b/java/arcs/core/storage/handle/HandleManager.kt
@@ -79,7 +79,6 @@ class HandleManager(
     suspend fun rawEntitySingletonHandle(
         storageKey: StorageKey,
         schema: Schema,
-        callbacks: SingletonCallbacks<RawEntity>? = null,
         name: String = storageKey.toKeyString(),
         ttl: Ttl = Ttl.Infinite,
         canRead: Boolean = true
@@ -102,39 +101,13 @@ class HandleManager(
         return SingletonHandle(
             name,
             storageProxy,
-            callbacks,
             ttl,
             time,
             canRead,
             dereferencer = RawEntityDereferencer(schema, aff?.dereferenceFactory()),
             schema = schema
-        ).also { storageProxy.registerHandle(it) }
+        )
     }
-
-    /**
-     * @deprecated use [rawEntitySingletonHandle] instead.
-     */
-    /* ktlint-disable max-line-length */
-    @Deprecated(
-        "Use rawEntitySingletonHandle instead",
-        replaceWith = ReplaceWith("this.rawEntitySingletonHandle(storageKey, schema, callbacks, name, ttl, canRead)")
-    )
-    /* ktlint-enable max-line-length */
-    suspend fun singletonHandle(
-        storageKey: StorageKey,
-        schema: Schema,
-        callbacks: SingletonCallbacks<RawEntity>? = null,
-        name: String = storageKey.toKeyString(),
-        ttl: Ttl = Ttl.Infinite,
-        canRead: Boolean = true
-    ): SingletonHandle<RawEntity> = rawEntitySingletonHandle(
-        storageKey,
-        schema,
-        callbacks,
-        name,
-        ttl,
-        canRead
-    )
 
     /**
      * Creates a new [SingletonHandle] which manages a singleton of type: [Reference], where the
@@ -143,7 +116,6 @@ class HandleManager(
     suspend fun referenceSingletonHandle(
         storageKey: StorageKey,
         schema: Schema,
-        callbacks: SingletonCallbacks<Reference>? = null,
         name: String = storageKey.toKeyString(),
         ttl: Ttl = Ttl.Infinite,
         canRead: Boolean = true
@@ -166,13 +138,12 @@ class HandleManager(
         return SingletonHandle(
             name,
             storageProxy,
-            callbacks,
             ttl,
             time,
             canRead,
             dereferencer = RawEntityDereferencer(schema, aff?.dereferenceFactory()),
             schema = schema
-        ).also { storageProxy.registerHandle(it) }
+        )
     }
 
     /**
@@ -183,7 +154,6 @@ class HandleManager(
     suspend fun rawEntitySetHandle(
         storageKey: StorageKey,
         schema: Schema,
-        callbacks: SetCallbacks<RawEntity>? = null,
         name: String = storageKey.toKeyString(),
         ttl: Ttl = Ttl.Infinite,
         canRead: Boolean = true
@@ -203,13 +173,12 @@ class HandleManager(
         return SetHandle(
             name,
             storageProxy,
-            callbacks,
             ttl,
             time,
             canRead,
             dereferencer = RawEntityDereferencer(schema, aff?.dereferenceFactory()),
             schema = schema
-        ).also { storageProxy.registerHandle(it) }
+        )
     }
 
     /**
@@ -218,20 +187,18 @@ class HandleManager(
     /* ktlint-disable max-line-length */
     @Deprecated(
         "Use rawEntitySetHandle instead",
-        replaceWith = ReplaceWith("this.rawEntitySetHandle(storageKey, schema, callbacks, name, ttl, canRead)")
+        replaceWith = ReplaceWith("this.rawEntitySetHandle(storageKey, schema, name, ttl, canRead)")
     )
     /* ktlint-enable max-line-length */
     suspend fun setHandle(
         storageKey: StorageKey,
         schema: Schema,
-        callbacks: SetCallbacks<RawEntity>? = null,
         name: String = storageKey.toKeyString(),
         ttl: Ttl = Ttl.Infinite,
         canRead: Boolean = true
     ): SetHandle<RawEntity> = rawEntitySetHandle(
         storageKey,
         schema,
-        callbacks,
         name,
         ttl,
         canRead
@@ -244,7 +211,6 @@ class HandleManager(
     suspend fun referenceSetHandle(
         storageKey: StorageKey,
         schema: Schema,
-        callbacks: SetCallbacks<Reference>? = null,
         name: String = storageKey.toKeyString(),
         ttl: Ttl = Ttl.Infinite,
         canRead: Boolean = true
@@ -267,12 +233,11 @@ class HandleManager(
         return SetHandle(
             name = name,
             storageProxy = storageProxy,
-            callbacks = callbacks,
             ttl = ttl,
             time = time,
             canRead = canRead,
             dereferencer = RawEntityDereferencer(schema, aff?.dereferenceFactory()),
             schema = schema
-        ).also { storageProxy.registerHandle(it) }
+        )
     }
 }

--- a/java/arcs/core/storage/handle/SingletonImpl.kt
+++ b/java/arcs/core/storage/handle/SingletonImpl.kt
@@ -17,7 +17,6 @@ import arcs.core.data.RawEntity
 import arcs.core.data.Schema
 import arcs.core.data.Ttl
 import arcs.core.storage.ActivationFactory
-import arcs.core.storage.Callbacks
 import arcs.core.storage.Dereferencer
 import arcs.core.storage.Handle
 import arcs.core.storage.StorageProxy
@@ -32,7 +31,6 @@ typealias SingletonOp<T> = CrdtSingleton.IOperation<T>
 typealias SingletonStoreOptions<T> = StoreOptions<SingletonData<T>, SingletonOp<T>, T?>
 typealias SingletonHandle<T> = SingletonImpl<T>
 typealias SingletonActivationFactory<T> = ActivationFactory<SingletonData<T>, SingletonOp<T>, T?>
-typealias SingletonCallbacks<T> = Callbacks<SingletonData<T>, SingletonOp<T>, T?>
 
 /**
  * Singleton [Handle] implementation for the runtime.
@@ -43,7 +41,6 @@ typealias SingletonCallbacks<T> = Callbacks<SingletonData<T>, SingletonOp<T>, T?
 class SingletonImpl<T : Referencable>(
     name: String,
     storageProxy: SingletonProxy<T>,
-    callbacks: SingletonCallbacks<T>? = null,
     ttl: Ttl = Ttl.Infinite,
     time: Time,
     canRead: Boolean = true,
@@ -52,7 +49,6 @@ class SingletonImpl<T : Referencable>(
 ) : SingletonBase<T>(
     name,
     storageProxy,
-    callbacks,
     ttl,
     time,
     canRead,

--- a/javatests/arcs/android/storage/handle/AndroidHandleManagerTest.kt
+++ b/javatests/arcs/android/storage/handle/AndroidHandleManagerTest.kt
@@ -8,8 +8,6 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.work.testing.WorkManagerTestInitHelper
 import arcs.core.crdt.CrdtEntity
-import arcs.core.crdt.CrdtSet
-import arcs.core.crdt.CrdtSingleton
 import arcs.core.crdt.VersionMap
 import arcs.core.data.FieldType
 import arcs.core.data.RawEntity
@@ -23,8 +21,6 @@ import arcs.core.storage.driver.RamDisk
 import arcs.core.storage.driver.RamDiskStorageKey
 import arcs.core.storage.driver.VolatileEntry
 import arcs.core.storage.handle.HandleManager
-import arcs.core.storage.handle.SetCallbacks
-import arcs.core.storage.handle.SingletonCallbacks
 import arcs.core.storage.referencemode.ReferenceModeStorageKey
 import arcs.sdk.android.storage.service.testutil.TestConnectionFactory
 import com.google.common.truth.Truth.assertThat
@@ -128,6 +124,7 @@ class AndroidHandleManagerTest : LifecycleOwner {
         val singleton2Handle = handleManager.rawEntitySingletonHandle(
             storageKey = storageKey1, schema = schema
         )
+
         val storageKey2 = ReferenceModeStorageKey(backingKey, RamDiskStorageKey("entity2"))
         val singleton2Handle2 = handleManager.rawEntitySingletonHandle(
             storageKey = storageKey2, schema = schema
@@ -252,83 +249,65 @@ class AndroidHandleManagerTest : LifecycleOwner {
 
     private fun testMapForKey(key: StorageKey) = VersionMap(key.toKeyString() to 1)
 
+    // Mocking Function1<T, Unit> causes [ClassCastException
+    // These interface defintions prevent the problem.
+    interface OnUpdate<T> : Function1<T, Unit>
+    interface OnSync : Function0<Unit>
     @Test
     fun set_onHandleUpdate() = runBlocking<Unit> {
-        val testCallback1 = mock<SetCallbacks<RawEntity>>()
-        val testCallback2 = mock<SetCallbacks<RawEntity>>()
-        val firstHandle = handleManager.rawEntitySetHandle(setKey, schema, testCallback1)
-        val secondHandle = handleManager.rawEntitySetHandle(setKey, schema, testCallback2)
+        val firstHandle = handleManager.rawEntitySetHandle(setKey, schema)
+        val testOnUpdate1 = mock<OnUpdate<Set<RawEntity>>>().also { firstHandle.addOnUpdate(it::invoke) }
+        val secondHandle = handleManager.rawEntitySetHandle(setKey, schema)
+        val testOnUpdate2 = mock<OnUpdate<Set<RawEntity>>>().also { secondHandle.addOnUpdate(it::invoke) }
 
-        val expectedAdd = CrdtSet.Operation.Add(
-            setKey.toKeyString(),
-            testMapForKey(setKey),
-            entity1
-        )
         secondHandle.store(entity1)
-        verify(testCallback1).onUpdate(firstHandle, expectedAdd)
-        verify(testCallback2).onUpdate(secondHandle, expectedAdd)
+        verify(testOnUpdate1).invoke(setOf(entity1))
+        verify(testOnUpdate2).invoke(setOf(entity1))
 
         firstHandle.remove(entity1)
-        val expectedRemove = CrdtSet.Operation.Remove(
-            setKey.toKeyString(),
-            testMapForKey(setKey),
-            entity1
-        )
-        verify(testCallback1).onUpdate(firstHandle, expectedRemove)
-        verify(testCallback2).onUpdate(secondHandle, expectedRemove)
+
+        verify(testOnUpdate1).invoke(emptySet<RawEntity>())
+        verify(testOnUpdate2).invoke(emptySet<RawEntity>())
     }
 
     @Test
     fun singleton_OnHandleUpdate() = runBlocking<Unit> {
-        val testCallback1 = mock<SingletonCallbacks<RawEntity>>()
-        val testCallback2 = mock<SingletonCallbacks<RawEntity>>()
         val firstHandle = handleManager.rawEntitySingletonHandle(
             storageKey = singletonKey,
-            schema = schema,
-            callbacks = testCallback1
+            schema = schema
         )
+        val testOnUpdate1 = mock<OnUpdate<RawEntity?>>().also { firstHandle.addOnUpdate(it::invoke) }
         val secondHandle = handleManager.rawEntitySingletonHandle(
             storageKey = singletonKey,
-            schema = schema,
-            callbacks = testCallback2
+            schema = schema
         )
+        val testOnUpdate2 = mock<OnUpdate<RawEntity?>>().also { firstHandle.addOnUpdate(it::invoke) }
+
         secondHandle.store(entity1)
-        val expectedAdd = CrdtSingleton.Operation.Update(
-            singletonKey.toKeyString(),
-            testMapForKey(singletonKey),
-            entity1
-        )
-        verify(testCallback1).onUpdate(firstHandle, expectedAdd)
-        verify(testCallback2).onUpdate(secondHandle, expectedAdd)
+        verify(testOnUpdate1).invoke(entity1)
+        verify(testOnUpdate2).invoke(entity1)
         firstHandle.clear()
 
-        val expectedRemove = CrdtSingleton.Operation.Clear<RawEntity>(
-            singletonKey.toKeyString(),
-            testMapForKey(singletonKey)
-        )
-        verify(testCallback1).onUpdate(firstHandle, expectedRemove)
-        verify(testCallback2).onUpdate(secondHandle, expectedRemove)
+        verify(testOnUpdate1).invoke(null)
+        verify(testOnUpdate2).invoke(null)
     }
 
     @Test
     fun set_syncOnRegister() = runBlocking<Unit> {
-        val testCallback = mock<SetCallbacks<RawEntity>>()
-        val firstHandle = handleManager.rawEntitySetHandle(setKey, schema, testCallback)
-        verify(testCallback).onSync(firstHandle)
+        val firstHandle = handleManager.rawEntitySetHandle(setKey, schema)
+        val testOnSync = mock<OnSync>().also { firstHandle.addOnSync(it::invoke) }
         firstHandle.fetchAll()
-        verify(testCallback).onSync(firstHandle)
+        verify(testOnSync).invoke()
     }
 
     @Test
     fun singleton_syncOnRegister() = runBlocking<Unit> {
-        val testCallback = mock<SingletonCallbacks<RawEntity>>()
         val firstHandle = handleManager.rawEntitySingletonHandle(
             storageKey = setKey,
-            schema = schema,
-            callbacks = testCallback
+            schema = schema
         )
-        verify(testCallback).onSync(firstHandle)
+        val testOnSync = mock<OnSync>().also { firstHandle.addOnSync(it::invoke) }
         firstHandle.fetch()
-        verify(testCallback).onSync(firstHandle)
+        verify(testOnSync).invoke()
     }
 }

--- a/javatests/arcs/core/storage/StorageProxyTest.kt
+++ b/javatests/arcs/core/storage/StorageProxyTest.kt
@@ -28,6 +28,7 @@ import org.junit.runners.JUnit4
 import org.mockito.Mock
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
+import org.mockito.Mockito.any
 import org.mockito.MockitoAnnotations
 
 @Suppress("UNCHECKED_CAST", "UNUSED_VARIABLE")
@@ -55,25 +56,25 @@ class StorageProxyTest {
     @Test
     fun propagatesStorageOpToReaders() = runBlockingTest {
         val storageProxy = StorageProxy(mockStorageEndpointProvider, mockCrdtModel)
-        val (readHandle, readCallback) = newHandle("testReader", storageProxy, true)
+        val readHandle = newHandle("testReader", storageProxy, true)
+        val readCallback = mock<(String)->Unit>().also { readHandle.addOnUpdate(it) }
         mockCrdtModel.appliesOpAs(mockCrdtOperation, true)
 
-        storageProxy.registerHandle(readHandle)
         storageProxy.onMessage(ProxyMessage.Operations(listOf(mockCrdtOperation), null))
 
-        verify(readCallback).onUpdate(readHandle, mockCrdtOperation)
+        verify(readCallback).invoke(mockCrdtModel.consumerView)
     }
 
     @Test
     fun propagatesStorageFullModelToReaders() = runBlockingTest {
         val storageProxy = StorageProxy(mockStorageEndpointProvider, mockCrdtModel)
-        val (readHandle, readCallback) = newHandle("testReader", storageProxy, true)
+        val readHandle = newHandle("testReader", storageProxy, true)
+        val syncCallback = mock<()->Unit>().also { readHandle.addOnSync(it) }
         mockCrdtModel.appliesOpAs(mockCrdtOperation, true)
 
-        storageProxy.registerHandle(readHandle)
         storageProxy.onMessage(ProxyMessage.ModelUpdate(mockCrdtData, null))
 
-        verify(readCallback).onSync(readHandle)
+        verify(syncCallback).invoke()
     }
 
     @Test
@@ -88,41 +89,19 @@ class StorageProxyTest {
     }
 
     @Test
-    fun propagatesUpdatesToReadersAndNotToWriters() = runBlockingTest {
-        val storageProxy = StorageProxy(mockStorageEndpointProvider, mockCrdtModel)
-        val (readHandle, readCallback) = newHandle("testReader", storageProxy, true)
-        val (writeHandle ,writeCallback) = newHandle("testWriter", storageProxy, false)
-        mockCrdtModel.appliesOpAs(mockCrdtOperation, true)
-
-        storageProxy.registerHandle(readHandle)
-        storageProxy.registerHandle(writeHandle)
-        assertThat(storageProxy.applyOp(mockCrdtOperation)).isTrue()
-
-        verify(readCallback).onUpdate(readHandle, mockCrdtOperation)
-        verifyNoMoreInteractions(writeCallback)
-    }
-
-    @Test
     fun failedApplyOpTriggersSync() = runBlockingTest {
         val storageProxy = StorageProxy(mockStorageEndpointProvider, mockCrdtModel)
-        val (readHandle, _) = newHandle("testReader", storageProxy, true)
-        mockCrdtModel.appliesOpAs(mockCrdtOperation, false)
-
-        storageProxy.registerHandle(readHandle)
-        assertThat(storageProxy.applyOp(mockCrdtOperation)).isFalse()
-
-        val syncReq = ProxyMessage.SyncRequest<CrdtData, CrdtOperation, String>(null)
-        assertThat(fakeStoreEndpoint.getProxyMessages()).containsExactly(syncReq)
+        val readHandle = newHandle("testReader", storageProxy, true)
+        // TODO - test that local application but store failure results in sync
     }
 
     @Test
     fun getParticleViewReturnsSyncedState() = runBlockingTest {
         val storageProxy = StorageProxy(mockStorageEndpointProvider, mockCrdtModel)
         whenever(mockCrdtModel.consumerView).thenReturn("someData")
-        val (readHandle, _) = newHandle("testReader", storageProxy, true)
+        val readHandle = newHandle("testReader", storageProxy, true)
         mockCrdtModel.appliesOpAs(mockCrdtOperation, true)
 
-        storageProxy.registerHandle(readHandle)
         assertThat(storageProxy.onMessage(ProxyMessage.Operations(listOf(mockCrdtOperation), null)))
             .isTrue()
         val view = storageProxy.getParticleView()
@@ -134,9 +113,8 @@ class StorageProxyTest {
     fun getParticleViewWhenUnsyncedQueues() = runBlockingTest {
         val storageProxy = StorageProxy(mockStorageEndpointProvider, mockCrdtModel)
         whenever(mockCrdtModel.consumerView).thenReturn("someData")
-        val (readHandle, _) = newHandle("testReader", storageProxy, true)
+        val readHandle = newHandle("testReader", storageProxy, true)
         mockCrdtModel.appliesOpAs(mockCrdtOperation, true)
-        storageProxy.registerHandle(readHandle)
 
         // get view when not synced
         val future = storageProxy.getParticleViewAsync()
@@ -159,17 +137,6 @@ class StorageProxyTest {
         whenever(mockCrdtModel.consumerView).thenReturn("someData")
 
         val ops = listOf(
-            suspend {
-                // registerHandle
-                val (handle, _) = newHandle("testReader", storageProxy, true)
-                storageProxy.registerHandle(handle)
-            },
-            suspend {
-                // deregisterHandle
-                val (handle, _) = newHandle("testReader-${Random.nextInt()}", storageProxy, true)
-                storageProxy.registerHandle(handle)
-                storageProxy.deregisterHandle(handle)
-            },
             suspend {
                 // store sends sync req
                 val syncReq = ProxyMessage.SyncRequest<CrdtData, CrdtOperationAtTime, String>(null)
@@ -220,18 +187,11 @@ class StorageProxyTest {
         }
     }
 
-    private data class HandleWithCallback<Data : CrdtData, Op : CrdtOperationAtTime, T>(
-        val handle: Handle<Data, Op, T>,
-        val callback: Callbacks<Data, Op, T>
-    )
-
     private fun newHandle(
         name: String,
         storageProxy: StorageProxy<CrdtData, CrdtOperationAtTime, String>,
         reader: Boolean
-    ) = mock<Callbacks<CrdtData, CrdtOperationAtTime, String>>().let {
-        HandleWithCallback(Handle(name, storageProxy, it, Ttl.Infinite, TimeImpl(), reader, true), it)
-    }
+    ) = Handle(name, storageProxy, Ttl.Infinite, TimeImpl(), reader, true)
 
     fun CrdtModel<CrdtData, CrdtOperationAtTime, String>.appliesOpAs(op: CrdtOperationAtTime, result: Boolean) {
         whenever(this.applyOperation(op)).thenReturn(result)

--- a/javatests/arcs/core/storage/handle/CollectionIntegrationTest.kt
+++ b/javatests/arcs/core/storage/handle/CollectionIntegrationTest.kt
@@ -70,10 +70,8 @@ class CollectionIntegrationTest {
         testStore = Store(STORE_OPTIONS)
         storageProxy = StorageProxy(testStore.activate(), CrdtSet<RawEntity>())
 
-        collectionA = CollectionImpl("collectionA", storageProxy, null, Ttl.Infinite, TimeImpl(), schema = SCHEMA_A)
-        storageProxy.registerHandle(collectionA)
-        collectionB = CollectionImpl("collectionB", storageProxy, null, Ttl.Infinite, TimeImpl(), schema = SCHEMA_B)
-        storageProxy.registerHandle(collectionB)
+        collectionA = CollectionImpl("collectionA", storageProxy, Ttl.Infinite, TimeImpl(), schema = SCHEMA_A)
+        collectionB = CollectionImpl("collectionB", storageProxy,  Ttl.Infinite, TimeImpl(), schema = SCHEMA_B)
         Unit
     }
 
@@ -189,15 +187,13 @@ class CollectionIntegrationTest {
         assertThat(collectionA.fetchAll().first().expirationTimestamp)
             .isEqualTo(RawEntity.UNINITIALIZED_TIMESTAMP)
 
-        val collectionC = CollectionImpl("collectionC", storageProxy, null, Ttl.Days(2), TimeImpl(), schema = SCHEMA_A)
-        storageProxy.registerHandle(collectionC)
+        val collectionC = CollectionImpl("collectionC", storageProxy, Ttl.Days(2), TimeImpl(), schema = SCHEMA_A)
         assertThat(collectionC.store(person.toRawEntity())).isTrue()
         val entityC = collectionC.fetchAll().first()
         assertThat(entityC.creationTimestamp).isGreaterThan(creationTimestampA)
         assertThat(entityC.expirationTimestamp).isGreaterThan(RawEntity.UNINITIALIZED_TIMESTAMP)
 
-        val collectionD = CollectionImpl("collectionD", storageProxy, null, Ttl.Minutes(1), TimeImpl(), schema = SCHEMA_B)
-        storageProxy.registerHandle(collectionD)
+        val collectionD = CollectionImpl("collectionD", storageProxy, Ttl.Minutes(1), TimeImpl(), schema = SCHEMA_B)
         assertThat(collectionD.store(person.toRawEntity())).isTrue()
         val entityD = collectionD.fetchAll().first()
         assertThat(entityD.creationTimestamp).isGreaterThan(creationTimestampA)

--- a/javatests/arcs/core/storage/handle/SingletonIntegrationTest.kt
+++ b/javatests/arcs/core/storage/handle/SingletonIntegrationTest.kt
@@ -66,10 +66,8 @@ class SingletonIntegrationTest {
         store = Store(STORE_OPTIONS)
         storageProxy = StorageProxy(store.activate(), CrdtSingleton<RawEntity>())
 
-        singletonA = SingletonImpl("singletonA", storageProxy, null, Ttl.Infinite, TimeImpl(), schema = SCHEMA)
-        storageProxy.registerHandle(singletonA)
-        singletonB = SingletonImpl("singletonB", storageProxy, null, Ttl.Infinite, TimeImpl(), schema = SCHEMA)
-        storageProxy.registerHandle(singletonB)
+        singletonA = SingletonImpl("singletonA", storageProxy,Ttl.Infinite, TimeImpl(), schema = SCHEMA)
+        singletonB = SingletonImpl("singletonB", storageProxy, Ttl.Infinite, TimeImpl(), schema = SCHEMA)
         Unit
     }
 
@@ -143,15 +141,13 @@ class SingletonIntegrationTest {
         assertThat(requireNotNull(singletonA.fetch()).expirationTimestamp)
             .isEqualTo(RawEntity.UNINITIALIZED_TIMESTAMP)
 
-        val singletonC = SingletonImpl("singletonC", storageProxy, null, Ttl.Days(2), TimeImpl(), schema = SCHEMA)
-        storageProxy.registerHandle(singletonC)
+        val singletonC = SingletonImpl("singletonC", storageProxy, Ttl.Days(2), TimeImpl(), schema = SCHEMA)
         assertThat(singletonC.store(person.toRawEntity())).isTrue()
         val entityC = requireNotNull(singletonC.fetch())
         assertThat(entityC.creationTimestamp).isGreaterThan(creationTimestampA)
         assertThat(entityC.expirationTimestamp).isGreaterThan(RawEntity.UNINITIALIZED_TIMESTAMP)
 
-        val singletonD = SingletonImpl("singletonD", storageProxy, null, Ttl.Minutes(1), TimeImpl(), schema = SCHEMA)
-        storageProxy.registerHandle(singletonD)
+        val singletonD = SingletonImpl("singletonD", storageProxy, Ttl.Minutes(1), TimeImpl(), schema = SCHEMA)
         assertThat(singletonD.store(person.toRawEntity())).isTrue()
         val entityD = requireNotNull(singletonD.fetch())
         assertThat(entityD.creationTimestamp).isGreaterThan(creationTimestampA)


### PR DESCRIPTION
NOTE: Still thinking through these changes and the ramifications, I have
a PR up to see if copybara has any issues. Feel free to weigh in with
thoughts, if you're bored and want to review this early.

What started as adding `start`/`stop` functionality to handles turned
into a re-imagining of the callbacks pattern.

Observations:
* `registerHandle` (which was to be called via a `start` method on the
handle) is only setting up callbacks to the handle.
* The only action a handle takes when receiving `storageProxy` callback
calls is to trigger any developer-supplied callbacks.
* Adapting between the single-interface-with-all-3-callbacks and
callbacks-as-individual-methods approach seemed to cause some
complicated interface adaption needs.

PENDING TOODs:
* Decide on when to request synchronization of the Handle
* Figure out a callback removal strategy (per handle, per particle?)
* Consider dispatch model for callbacks
* Fix up a few tests