### PR TITLE
 Simplify Handle callback management

### DIFF
--- a/java/arcs/core/host/EntityHandleManager.kt
+++ b/java/arcs/core/host/EntityHandleManager.kt
@@ -1,13 +1,9 @@
 package arcs.core.host
 
 import arcs.core.common.Id
-import arcs.core.crdt.CrdtData
-import arcs.core.crdt.CrdtOperationAtTime
 import arcs.core.data.HandleMode
 import arcs.core.data.RawEntity
 import arcs.core.data.Schema
-import arcs.core.storage.Callbacks
-import arcs.core.storage.Handle as StorageHandle
 import arcs.core.storage.StorageKey
 import arcs.core.storage.api.Entity
 import arcs.core.storage.api.EntitySpec
@@ -20,20 +16,8 @@ import arcs.core.storage.api.WriteCollectionHandle
 import arcs.core.storage.api.WriteSingletonHandle
 import arcs.core.storage.handle.CollectionImpl
 import arcs.core.storage.handle.HandleManager
-import arcs.core.storage.handle.SetData
 import arcs.core.storage.handle.SetHandle
-import arcs.core.storage.handle.SetOp
-import arcs.core.storage.handle.SingletonData
 import arcs.core.storage.handle.SingletonHandle
-import arcs.core.storage.handle.SingletonOp
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.launch
-
-typealias Sender = (block: suspend () -> Unit) -> Unit
-typealias SingletonSenderCallbackAdapter<E> =
-    SenderCallbackAdapter<SingletonData<RawEntity>, SingletonOp<RawEntity>, RawEntity?, E?>
-typealias CollectionSenderCallbackAdapter<E> =
-    SenderCallbackAdapter<SetData<RawEntity>, SetOp<RawEntity>, Set<RawEntity>, E>
 
 /**
  * Wraps a [HandleManager] and creates [Entity] handles based on [HandleMode], such as
@@ -52,7 +36,6 @@ class EntityHandleManager(private val handleManager: HandleManager) {
      * @property storageKey a [StorageKey]
      * @property schema the [Schema] for this [StorageKey]
      * @property handleMode whether a handle is Read,Write, or ReadWrite (default)
-     * @property sender block used to execute callback lambdas
      * @property idGenerator used to generate unique IDs for newly stored entities.
      */
     suspend fun <T : Entity> createSingletonHandle(
@@ -61,10 +44,9 @@ class EntityHandleManager(private val handleManager: HandleManager) {
         storageKey: StorageKey,
         schema: Schema,
         handleMode: HandleMode = HandleMode.ReadWrite,
-        idGenerator: Id.Generator = Id.Generator.newSession(),
-        sender: Sender = ::defaultSender
+        idGenerator: Id.Generator = Id.Generator.newSession()
     ): Handle {
-        val storageHandle = handleManager.singletonHandle(
+        val storageHandle = handleManager.rawEntitySingletonHandle(
             storageKey,
             schema,
             canRead = handleMode != HandleMode.Write
@@ -74,14 +56,12 @@ class EntityHandleManager(private val handleManager: HandleManager) {
                 entitySpec,
                 handleName,
                 storageHandle,
-                idGenerator,
-                sender
+                idGenerator
             )
             HandleMode.Read -> ReadSingletonHandleImpl(
                 entitySpec,
                 handleName,
-                storageHandle,
-                sender
+                storageHandle
             )
             HandleMode.Write -> WriteSingletonHandleImpl<T>(
                 handleName,
@@ -98,7 +78,6 @@ class EntityHandleManager(private val handleManager: HandleManager) {
      * @property storageKey a [StorageKey]
      * @property schema the [Schema] for this [StorageKey]
      * @property handleMode whether a handle is Read,Write, or ReadWrite (default)
-     * @property sender block used to execute callback lambdas
      * @property idGenerator used to generate unique IDs for newly stored entities.
      */
     suspend fun <T : Entity> createSetHandle(
@@ -107,10 +86,9 @@ class EntityHandleManager(private val handleManager: HandleManager) {
         storageKey: StorageKey,
         schema: Schema,
         handleMode: HandleMode = HandleMode.ReadWrite,
-        idGenerator: Id.Generator = Id.Generator.newSession(),
-        sender: Sender = ::defaultSender
+        idGenerator: Id.Generator = Id.Generator.newSession()
     ): Handle {
-        val storageHandle = handleManager.setHandle(
+        val storageHandle = handleManager.rawEntitySetHandle(
             storageKey,
             schema,
             canRead = handleMode != HandleMode.Write
@@ -120,14 +98,12 @@ class EntityHandleManager(private val handleManager: HandleManager) {
                 entitySpec,
                 handleName,
                 storageHandle,
-                idGenerator,
-                sender
+                idGenerator
             )
             HandleMode.Read -> ReadCollectionHandleImpl(
                 entitySpec,
                 handleName,
-                storageHandle,
-                sender
+                storageHandle
             )
             HandleMode.Write -> WriteCollectionHandleImpl<T>(
                 handleName,
@@ -136,70 +112,33 @@ class EntityHandleManager(private val handleManager: HandleManager) {
             )
         }
     }
-
-    /**
-     * Same-thread non-blocking dispatch. Note that this may lead to concurrency problems on
-     * some platforms. On platforms with real preemptive threads, use an implementation that
-     * provides concurrency aware dispatch.
-     */
-    private fun defaultSender(block: suspend () -> Unit) {
-        GlobalScope.launch {
-            block()
-        }
-    }
-}
-
-internal open class HandleEventBase<T, H : Handle> {
-    protected val onUpdateActions: MutableList<(T) -> Unit> = mutableListOf()
-    protected val onSyncActions: MutableList<(H) -> Unit> = mutableListOf()
-    protected val onDesyncActions: MutableList<(H) -> Unit> = mutableListOf()
-
-    suspend fun onUpdate(action: (T) -> Unit) {
-        onUpdateActions.add(action)
-    }
-
-    suspend fun onSync(action: (H) -> Unit) {
-        onSyncActions.add(action)
-    }
-
-    suspend fun onDesync(action: (H) -> Unit) {
-        onDesyncActions.add(action)
-    }
-
-    protected suspend fun fireUpdate(value: T) {
-        onUpdateActions.forEach { action -> action(value) }
-    }
-
-    protected suspend fun fireSync() {
-        onSyncActions.forEach { action -> action(this as H) }
-    }
-
-    protected suspend fun fireDesync() {
-        onDesyncActions.forEach { action -> action(this as H) }
-    }
 }
 
 internal open class ReadSingletonHandleImpl<T : Entity>(
     val entitySpec: EntitySpec<T>,
     val handleName: String,
-    val storageHandle: SingletonHandle<RawEntity>,
-    sender: Sender
-) : HandleEventBase<T?, ReadSingletonHandle<T>>(), ReadSingletonHandle<T> {
-    init {
-        storageHandle.callback = SingletonSenderCallbackAdapter(
-            this::fetch,
-            this::fireUpdate,
-            this::fireSync,
-            this::fireDesync,
-            sender
-        )
-    }
-
+    val storageHandle: SingletonHandle<RawEntity>
+) : ReadSingletonHandle<T> {
     override val name: String
         get() = handleName
 
-    override suspend fun fetch(): T? = storageHandle.fetch()?.let {
-        rawEntity -> entitySpec.deserialize(rawEntity)
+    private fun adaptValue(raw: RawEntity?) =
+        raw?.let { entitySpec.deserialize(it) }
+
+    override suspend fun fetch(): T? = adaptValue(storageHandle.fetch())
+
+    override suspend fun onUpdate(action: (T?) -> Unit) {
+        storageHandle.addOnUpdate { rawValue ->
+            action(adaptValue(rawValue))
+        }
+    }
+
+    override suspend fun onSync(action: (ReadSingletonHandle<T>) -> Unit) {
+        storageHandle.addOnSync { action(this) }
+    }
+
+    override suspend fun onDesync(action: (ReadSingletonHandle<T>) -> Unit) {
+        storageHandle.addOnDesync { action(this) }
     }
 }
 
@@ -227,14 +166,13 @@ internal class ReadWriteSingletonHandleImpl<T : Entity>(
     handleName: String,
     storageHandle: SingletonHandle<RawEntity>,
     idGenerator: Id.Generator,
-    sender: Sender,
     private val writableSingleton: WriteSingletonHandleImpl<T> = WriteSingletonHandleImpl(
         handleName,
         storageHandle,
         idGenerator
     )
 ) : ReadWriteSingletonHandle<T>,
-    ReadSingletonHandleImpl<T>(entitySpec, handleName, storageHandle, sender),
+    ReadSingletonHandleImpl<T>(entitySpec, handleName, storageHandle),
     WriteSingletonHandle<T> by writableSingleton {
     override val name: String
         get() = writableSingleton.name
@@ -243,19 +181,8 @@ internal class ReadWriteSingletonHandleImpl<T : Entity>(
 internal open class ReadCollectionHandleImpl<T : Entity>(
     private val entitySpec: EntitySpec<T>,
     val handleName: String,
-    private val storageHandle: SetHandle<RawEntity>,
-    sender: Sender
-) : HandleEventBase<Set<T>, ReadCollectionHandle<T>>(), ReadCollectionHandle<T> {
-    init {
-        storageHandle.callback = CollectionSenderCallbackAdapter(
-            this::fetchAll,
-            this::fireUpdate,
-            this::fireSync,
-            this::fireDesync,
-            sender
-        )
-    }
-
+    private val storageHandle: SetHandle<RawEntity>
+) : ReadCollectionHandle<T> {
     override val name: String
         get() = handleName
 
@@ -263,9 +190,22 @@ internal open class ReadCollectionHandleImpl<T : Entity>(
 
     override suspend fun isEmpty() = fetchAll().isEmpty()
 
-    override suspend fun fetchAll(): Set<T> = storageHandle.fetchAll().map {
-        entitySpec.deserialize(it)
-    }.toSet()
+    private fun adaptValues(raw: Set<RawEntity>) =
+        raw.map { entitySpec.deserialize(it) }.toSet()
+
+    override suspend fun fetchAll(): Set<T> = adaptValues(storageHandle.fetchAll())
+
+    override suspend fun onUpdate(action: (Set<T>) -> Unit) {
+        storageHandle.addOnUpdate { rawValues ->
+            action(adaptValues(rawValues))
+        }
+    }
+
+    override suspend fun onSync(action: () -> Unit) {
+        storageHandle.addOnSync(action)
+    }
+
+    override suspend fun onDesync(action: () -> Unit) { }
 }
 
 internal class WriteCollectionHandleImpl<T : Entity>(
@@ -296,49 +236,16 @@ internal class ReadWriteCollectionHandleImpl<T : Entity>(
     handleName: String,
     storageHandle: CollectionImpl<RawEntity>,
     idGenerator: Id.Generator,
-    sender: Sender,
     private val writableCollection: WriteCollectionHandleImpl<T> = WriteCollectionHandleImpl(
         handleName,
         storageHandle,
         idGenerator
     )
 ) : ReadWriteCollectionHandle<T>,
-    ReadCollectionHandleImpl<T>(entitySpec, handleName, storageHandle, sender),
+    ReadCollectionHandleImpl<T>(entitySpec, handleName, storageHandle),
     WriteCollectionHandle<T> by writableCollection {
     override val name: String
         get() = writableCollection.name
-}
-
-/**
- * Adapts [StorageHandle] [Callbacks] events into SDK callbacks. All events are dispatched
- * via a [Sender], which can enforce appropriate levels of concurrency.
- */
-class SenderCallbackAdapter<Data : CrdtData, Op : CrdtOperationAtTime, T, E>(
-    private val fetchFunc: suspend () -> E,
-    private val updateCallback: (suspend (E) -> Unit),
-    private val syncCallback: (suspend () -> Unit),
-    private val desyncCallback: (suspend () -> Unit),
-    private val sender: Sender
-) : Callbacks<Data, Op, T> {
-
-    /**
-     * Used to ensure serialized invocations of [Handle] events. This can be per-[Handle],
-     * per-[Particle], per-[Arc], depending on the [Sender] used. Typically, it will be
-     * per-[Particle] when handles are hosted inside of a [Particle]
-     */
-    private fun invokeWithSender(block: suspend () -> Unit) = sender(block)
-
-    override fun onUpdate(handle: StorageHandle<Data, Op, T>, op: Op) = invokeWithSender {
-        updateCallback.invoke(fetchFunc())
-    }
-
-    override fun onSync(handle: StorageHandle<Data, Op, T>) = invokeWithSender {
-        syncCallback.invoke()
-    }
-
-    override fun onDesync(handle: StorageHandle<Data, Op, T>) = invokeWithSender {
-        desyncCallback.invoke()
-    }
 }
 
 private fun <T : Entity> T.ensureIdentified(idGenerator: Id.Generator, handleName: String): T {

--- a/java/arcs/core/host/EntityHandleManager.kt
+++ b/java/arcs/core/host/EntityHandleManager.kt
@@ -140,6 +140,10 @@ internal open class ReadSingletonHandleImpl<T : Entity>(
     override suspend fun onDesync(action: (ReadSingletonHandle<T>) -> Unit) {
         storageHandle.addOnDesync { action(this) }
     }
+
+    override suspend fun removeAllCallbacks() {
+        storageHandle.removeAllCallbacks()
+    }
 }
 
 internal class WriteSingletonHandleImpl<T : Entity>(
@@ -206,6 +210,10 @@ internal open class ReadCollectionHandleImpl<T : Entity>(
     }
 
     override suspend fun onDesync(action: () -> Unit) { }
+
+    override suspend fun removeAllCallbacks() {
+        storageHandle.removeAllCallbacks()
+    }
 }
 
 internal class WriteCollectionHandleImpl<T : Entity>(

--- a/java/arcs/core/storage/Handle.kt
+++ b/java/arcs/core/storage/Handle.kt
@@ -75,13 +75,23 @@ open class Handle<Data : CrdtData, Op : CrdtOperationAtTime, T>(
     protected val log = TaggedLog { "Handle($name)" }
 
     /** Add an action to be performed whenever the contents of the [Handle]'s data changes*/
-    suspend fun addOnUpdate(action: (value: T) -> Unit) { storageProxy.addOnUpdate(action) }
+    suspend fun addOnUpdate(action: (value: T) -> Unit) {
+        storageProxy.addOnUpdate(name, action)
+    }
 
     /** Add an action to be performed whenever the [Handle] becomes synchronized */
-    suspend fun addOnSync(action: () -> Unit) { storageProxy.addOnSync(action) }
+    suspend fun addOnSync(action: () -> Unit) { storageProxy.addOnSync(name, action) }
 
     /** Add an action to be performed whenever the [Handle] becomes de-synchronized */
-    suspend fun addOnDesync(action: () -> Unit) { storageProxy.addOnDesync(action) }
+    suspend fun addOnDesync(action: () -> Unit) { storageProxy.addOnDesync(name, action) }
+
+    /**
+     * Remove any `onUpdate` `onSync`, or `onDesync` callbacks that this [Handle] has registered
+     * with its [StorageProxy].
+     */
+    suspend fun removeAllCallbacks() {
+        storageProxy.removeCallbacksForName(name)
+    }
 
     /** Creates a [Reference] for a given [Referencable] and backing [StorageKey]. */
     fun createReference(referencable: Referencable, backingKey: StorageKey): Reference {

--- a/java/arcs/core/storage/Handle.kt
+++ b/java/arcs/core/storage/Handle.kt
@@ -74,15 +74,15 @@ open class Handle<Data : CrdtData, Op : CrdtOperationAtTime, T>(
 ) {
     protected val log = TaggedLog { "Handle($name)" }
 
-    /** Add an action to be performed whenever the contents of the [Handle]'s data changes*/
+    /** Add an action to be performed whenever the contents of the [Handle]'s data changes. */
     suspend fun addOnUpdate(action: (value: T) -> Unit) {
         storageProxy.addOnUpdate(name, action)
     }
 
-    /** Add an action to be performed whenever the [Handle] becomes synchronized */
+    /** Add an action to be performed whenever the [Handle] becomes synchronized. */
     suspend fun addOnSync(action: () -> Unit) { storageProxy.addOnSync(name, action) }
 
-    /** Add an action to be performed whenever the [Handle] becomes de-synchronized */
+    /** Add an action to be performed whenever the [Handle] becomes de-synchronized. */
     suspend fun addOnDesync(action: () -> Unit) { storageProxy.addOnDesync(name, action) }
 
     /**

--- a/java/arcs/core/storage/Handle.kt
+++ b/java/arcs/core/storage/Handle.kt
@@ -22,30 +22,6 @@ import arcs.core.util.TaggedLog
 import arcs.core.util.Time
 
 /**
- * The [Callbacks] interface is a simple stand-in for the callbacks that a [Handle] might want to
- * use to signal information back to a subscriber (like a handle).
- */
-interface Callbacks<Data : CrdtData, Op : CrdtOperationAtTime, T> {
-    /**
-     * [onUpdate] is called when a diff is received from storage, or from a handle. Handles can
-     * be notified for their own writes.
-     * This method is not called for every change! A model sync will call [onSync] instead.
-     * Do not depend on seeing every update via this callback.
-     */
-    fun onUpdate(handle: Handle<Data, Op, T>, op: Op) = Unit
-
-    /**
-     * [onSync] is called when the proxy is synced from its backing [Store].
-     */
-    fun onSync(handle: Handle<Data, Op, T>) = Unit
-
-    /**
-     * [onDesync] is called when the proxy realizes it is out of sync with its backing [Store].
-     */
-    fun onDesync(handle: Handle<Data, Op, T>) = Unit
-}
-
-/**
  * Base implementation of Arcs handles on the runtime.
  *
  * A handle is in charge of translating SDK data operations into the appropriate CRDT operation,
@@ -71,9 +47,6 @@ open class Handle<Data : CrdtData, Op : CrdtOperationAtTime, T>(
     /** [name] is the unique name for this handle, used to track state in the [VersionMap]. */
     val name: String,
     val storageProxy: StorageProxy<Data, Op, T>,
-
-    /** [callback] contains optional Handle-owner provided callbacks to add behavior. */
-    var callback: Callbacks<Data, Op, T>? = null,
 
     /** [ttl] applied to the data in the [Handle]. */
     val ttl: Ttl,
@@ -101,6 +74,15 @@ open class Handle<Data : CrdtData, Op : CrdtOperationAtTime, T>(
 ) {
     protected val log = TaggedLog { "Handle($name)" }
 
+    /** Add an action to be performed whenever the contents of the [Handle]'s data changes*/
+    suspend fun addOnUpdate(action: (value: T) -> Unit) { storageProxy.addOnUpdate(action) }
+
+    /** Add an action to be performed whenever the [Handle] becomes synchronized */
+    suspend fun addOnSync(action: () -> Unit) { storageProxy.addOnSync(action) }
+
+    /** Add an action to be performed whenever the [Handle] becomes de-synchronized */
+    suspend fun addOnDesync(action: () -> Unit) { storageProxy.addOnDesync(action) }
+
     /** Creates a [Reference] for a given [Referencable] and backing [StorageKey]. */
     fun createReference(referencable: Referencable, backingKey: StorageKey): Reference {
         return Reference(referencable.id, backingKey, null).also {
@@ -121,30 +103,6 @@ open class Handle<Data : CrdtData, Op : CrdtOperationAtTime, T>(
     protected fun VersionMap.increment(): VersionMap {
         this[name]++
         return this
-    }
-
-    /**
-     * This should be called by the [StorageProxy] this [Handle] has been registered with,
-     * after a model update has been cleanly applied to the [StorageProxy]'s local copy.
-     */
-    internal fun onUpdate(op: Op) {
-        callback?.onUpdate(this, op)
-    }
-
-    /**
-     * This should be called by the [StorageProxy] this [Handle] has been registered with,
-     * after a full sync has occurred.
-     */
-    internal fun onSync() {
-        callback?.onSync(this)
-    }
-
-    /**
-     * This should be called by the [StorageProxy] this [Handle] has been registered with,
-     * when the [StorageProxy] has detected that its local model is out of sync.
-     */
-    internal fun onDesync() {
-        callback?.onDesync(this)
     }
 
     /**

--- a/java/arcs/core/storage/StorageProxy.kt
+++ b/java/arcs/core/storage/StorageProxy.kt
@@ -37,10 +37,13 @@ class StorageProxy<Data : CrdtData, Op : CrdtOperationAtTime, T>(
 ) {
     private val log = TaggedLog { "StorageProxy" }
 
-    private val handlesMutex = Mutex()
-
-    private val readHandles: MutableSet<Handle<Data, Op, T>>
-        by guardedBy(handlesMutex, mutableSetOf())
+    private val callbackMutex = Mutex()
+    private val onUpdateActions: MutableList<(T) -> Unit>
+        by guardedBy(callbackMutex, mutableListOf())
+    private val onSyncActions: MutableList<() -> Unit>
+        by guardedBy(callbackMutex, mutableListOf())
+    private val onDesyncActions: MutableList<() -> Unit>
+        by guardedBy(callbackMutex, mutableListOf())
 
     private val syncMutex = Mutex()
     private val crdt: CrdtModel<Data, Op, T>
@@ -56,32 +59,22 @@ class StorageProxy<Data : CrdtData, Op : CrdtOperationAtTime, T>(
         store.setCallback(ProxyCallback(::onMessage))
     }
 
-    /**
-     * Connects a [Handle]. If the handle is readable, it will receive the configured callbacks.
-     */
-    suspend fun registerHandle(handle: Handle<Data, Op, T>) {
-        // non-readers don't get callbacks, return early
-        if (!handle.canRead) return
-
-        log.debug { "Registering handle: $handle" }
-
-        val firstReader = handlesMutex.withLock {
-            readHandles.add(handle)
-            readHandles.size == 1
+    suspend fun addOnUpdate(action: (value: T) -> Unit) {
+        callbackMutex.withLock {
+            onUpdateActions.add(action)
         }
-
-        val hasSynced = syncMutex.withLock { isSynchronized }
-
-        if (firstReader) requestSynchronization()
-        else if (hasSynced) coroutineScope { launch { handle.onSync() } }
     }
 
-    /**
-     * Disconnects a handle so it no longer receives callbacks.
-     */
-    suspend fun deregisterHandle(handle: Handle<Data, Op, T>) {
-        log.debug { "Unregistering handle: $handle" }
-        handlesMutex.withLock { readHandles.remove(handle) }
+    suspend fun addOnSync(action: () -> Unit) {
+        callbackMutex.withLock {
+            onSyncActions.add(action)
+        }
+    }
+
+    suspend fun addOnDesync(action: () -> Unit) {
+        callbackMutex.withLock {
+            onDesyncActions.add(action)
+        }
     }
 
     /**
@@ -90,7 +83,9 @@ class StorageProxy<Data : CrdtData, Op : CrdtOperationAtTime, T>(
      */
     suspend fun applyOp(op: Op): Boolean {
         log.debug { "Applying operation: $op" }
-        val localSuccess = syncMutex.withLock { crdt.applyOperation(op) }
+        val (localSuccess, value) = syncMutex.withLock {
+            crdt.applyOperation(op) to crdt.consumerView
+        }
         if (!localSuccess) return false
 
         val msg = ProxyMessage.Operations<Data, Op, T>(listOf(op), null)
@@ -102,7 +97,7 @@ class StorageProxy<Data : CrdtData, Op : CrdtOperationAtTime, T>(
             requestSynchronization()
         }
 
-        notifyUpdate(listOf(op))
+        notifyUpdate(value)
 
         return true
     }
@@ -178,7 +173,7 @@ class StorageProxy<Data : CrdtData, Op : CrdtOperationAtTime, T>(
 
                 // all ops from storage applied cleanly so resolve waiting syncs
                 futuresToResolve.forEach { it.complete(value) }
-                notifyUpdate(message.operations)
+                notifyUpdate(value)
             }
             is ProxyMessage.SyncRequest -> {
                 // storage wants our latest state
@@ -191,28 +186,17 @@ class StorageProxy<Data : CrdtData, Op : CrdtOperationAtTime, T>(
         return true
     }
 
-    private suspend fun notifyUpdate(ops: List<Op>) = forEachHandle { handle ->
-        ops.forEach {
-            handle.onUpdate(it)
-        }
-    }
+    private suspend fun notifyUpdate(data: T) = callbackMutex.withLock {
+        onUpdateActions.toSet()
+    }.forEach { coroutineScope { launch { it(data) } } }
 
-    private suspend fun notifySync() = forEachHandle {
-        it.onSync()
-    }
+    private suspend fun notifySync() = callbackMutex.withLock {
+        onSyncActions.toSet()
+    }.forEach { coroutineScope { launch { it() } } }
 
-    private suspend fun notifyDesync() = forEachHandle { it.onDesync() }
-
-    private suspend inline fun forEachHandle(crossinline block: (Handle<Data, Op, T>) -> Unit) {
-        val handlesToNotify = handlesMutex.withLock { readHandles.toSet() }
-
-        // suspends until all handles have completed (in parallel)
-        coroutineScope {
-            handlesToNotify.forEach { handle ->
-                launch { block(handle) }
-            }
-        }
-    }
+    private suspend fun notifyDesync() = callbackMutex.withLock {
+        onDesyncActions.toSet()
+    }.forEach { coroutineScope { launch { it() } } }
 
     private suspend fun requestSynchronization(): Boolean {
         val msg = ProxyMessage.SyncRequest<Data, Op, T>(null)

--- a/java/arcs/core/storage/api/Handle.kt
+++ b/java/arcs/core/storage/api/Handle.kt
@@ -9,6 +9,8 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
+@file:Suppress("EXPERIMENTAL_FEATURE_WARNING")
+
 package arcs.core.storage.api
 
 /** Base interface for all handle classes. */
@@ -54,10 +56,10 @@ interface ReadCollectionHandle<T : Entity> : Handle {
     suspend fun onUpdate(action: (Set<T>) -> Unit)
 
     /** Assign a callback when the collection handle is synced. */
-    suspend fun onSync(action: (ReadCollectionHandle<T>) -> Unit)
+    suspend fun onSync(action: () -> Unit)
 
     /** Assign a callback when the collection handle is desynced. */
-    suspend fun onDesync(action: (ReadCollectionHandle<T>) -> Unit)
+    suspend fun onDesync(action: () -> Unit)
 
     /** Returns a set with all the entities in the collection. */
     suspend fun fetchAll(): Set<T>

--- a/java/arcs/core/storage/api/Handle.kt
+++ b/java/arcs/core/storage/api/Handle.kt
@@ -30,6 +30,9 @@ interface ReadSingletonHandle<T : Entity> : Handle {
 
     /** Assign a callback when the handle is sdeynced. */
     suspend fun onDesync(action: (ReadSingletonHandle<T>) -> Unit)
+
+    /** Remove any attached callbacks for this [Handle] */
+    suspend fun removeAllCallbacks()
 }
 
 /** A singleton handle with write access. */
@@ -63,6 +66,9 @@ interface ReadCollectionHandle<T : Entity> : Handle {
 
     /** Returns a set with all the entities in the collection. */
     suspend fun fetchAll(): Set<T>
+
+    /** Remove any attached callbacks for this [Handle] */
+    suspend fun removeAllCallbacks()
 }
 
 /** A collection handle with read access. */

--- a/java/arcs/core/storage/api/Handle.kt
+++ b/java/arcs/core/storage/api/Handle.kt
@@ -28,10 +28,10 @@ interface ReadSingletonHandle<T : Entity> : Handle {
     /** Assign a callback when the handle is synced. */
     suspend fun onSync(action: (ReadSingletonHandle<T>) -> Unit)
 
-    /** Assign a callback when the handle is sdeynced. */
+    /** Assign a callback when the handle is desynced. */
     suspend fun onDesync(action: (ReadSingletonHandle<T>) -> Unit)
 
-    /** Remove any attached callbacks for this [Handle] */
+    /** Remove any attached callbacks for this [Handle]. */
     suspend fun removeAllCallbacks()
 }
 
@@ -67,7 +67,7 @@ interface ReadCollectionHandle<T : Entity> : Handle {
     /** Returns a set with all the entities in the collection. */
     suspend fun fetchAll(): Set<T>
 
-    /** Remove any attached callbacks for this [Handle] */
+    /** Remove any attached callbacks for this [Handle]. */
     suspend fun removeAllCallbacks()
 }
 

--- a/java/arcs/core/storage/handle/CollectionImpl.kt
+++ b/java/arcs/core/storage/handle/CollectionImpl.kt
@@ -17,7 +17,6 @@ import arcs.core.data.RawEntity
 import arcs.core.data.Schema
 import arcs.core.data.Ttl
 import arcs.core.storage.ActivationFactory
-import arcs.core.storage.Callbacks
 import arcs.core.storage.Dereferencer
 import arcs.core.storage.Handle
 import arcs.core.storage.StorageProxy
@@ -32,7 +31,6 @@ typealias SetHandle<T> = CollectionImpl<T>
 typealias SetActivationFactory<T> = ActivationFactory<SetData<T>, SetOp<T>, Set<T>>
 typealias SetProxy<T> = StorageProxy<CrdtSet.Data<T>, CrdtSet.IOperation<T>, Set<T>>
 typealias SetBase<T> = Handle<CrdtSet.Data<T>, CrdtSet.IOperation<T>, Set<T>>
-typealias SetCallbacks<T> = Callbacks<SetData<T>, SetOp<T>, Set<T>>
 
 /**
  * Collection Handle implementation for the runtime.
@@ -43,7 +41,6 @@ typealias SetCallbacks<T> = Callbacks<SetData<T>, SetOp<T>, Set<T>>
 class CollectionImpl<T : Referencable>(
     name: String,
     storageProxy: SetProxy<T>,
-    callbacks: SetCallbacks<T>? = null,
     ttl: Ttl = Ttl.Infinite,
     time: Time,
     canRead: Boolean = true,
@@ -52,7 +49,6 @@ class CollectionImpl<T : Referencable>(
 ) : SetBase<T>(
     name,
     storageProxy,
-    callbacks,
     ttl,
     time,
     canRead,

--- a/java/arcs/core/storage/handle/HandleManager.kt
+++ b/java/arcs/core/storage/handle/HandleManager.kt
@@ -79,7 +79,6 @@ class HandleManager(
     suspend fun rawEntitySingletonHandle(
         storageKey: StorageKey,
         schema: Schema,
-        callbacks: SingletonCallbacks<RawEntity>? = null,
         name: String = storageKey.toKeyString(),
         ttl: Ttl = Ttl.Infinite,
         canRead: Boolean = true
@@ -102,39 +101,13 @@ class HandleManager(
         return SingletonHandle(
             name,
             storageProxy,
-            callbacks,
             ttl,
             time,
             canRead,
             dereferencer = RawEntityDereferencer(schema, aff?.dereferenceFactory()),
             schema = schema
-        ).also { storageProxy.registerHandle(it) }
+        )
     }
-
-    /**
-     * @deprecated use [rawEntitySingletonHandle] instead.
-     */
-    /* ktlint-disable max-line-length */
-    @Deprecated(
-        "Use rawEntitySingletonHandle instead",
-        replaceWith = ReplaceWith("this.rawEntitySingletonHandle(storageKey, schema, callbacks, name, ttl, canRead)")
-    )
-    /* ktlint-enable max-line-length */
-    suspend fun singletonHandle(
-        storageKey: StorageKey,
-        schema: Schema,
-        callbacks: SingletonCallbacks<RawEntity>? = null,
-        name: String = storageKey.toKeyString(),
-        ttl: Ttl = Ttl.Infinite,
-        canRead: Boolean = true
-    ): SingletonHandle<RawEntity> = rawEntitySingletonHandle(
-        storageKey,
-        schema,
-        callbacks,
-        name,
-        ttl,
-        canRead
-    )
 
     /**
      * Creates a new [SingletonHandle] which manages a singleton of type: [Reference], where the
@@ -143,7 +116,6 @@ class HandleManager(
     suspend fun referenceSingletonHandle(
         storageKey: StorageKey,
         schema: Schema,
-        callbacks: SingletonCallbacks<Reference>? = null,
         name: String = storageKey.toKeyString(),
         ttl: Ttl = Ttl.Infinite,
         canRead: Boolean = true
@@ -166,13 +138,12 @@ class HandleManager(
         return SingletonHandle(
             name,
             storageProxy,
-            callbacks,
             ttl,
             time,
             canRead,
             dereferencer = RawEntityDereferencer(schema, aff?.dereferenceFactory()),
             schema = schema
-        ).also { storageProxy.registerHandle(it) }
+        )
     }
 
     /**
@@ -183,7 +154,6 @@ class HandleManager(
     suspend fun rawEntitySetHandle(
         storageKey: StorageKey,
         schema: Schema,
-        callbacks: SetCallbacks<RawEntity>? = null,
         name: String = storageKey.toKeyString(),
         ttl: Ttl = Ttl.Infinite,
         canRead: Boolean = true
@@ -203,13 +173,12 @@ class HandleManager(
         return SetHandle(
             name,
             storageProxy,
-            callbacks,
             ttl,
             time,
             canRead,
             dereferencer = RawEntityDereferencer(schema, aff?.dereferenceFactory()),
             schema = schema
-        ).also { storageProxy.registerHandle(it) }
+        )
     }
 
     /**
@@ -218,20 +187,18 @@ class HandleManager(
     /* ktlint-disable max-line-length */
     @Deprecated(
         "Use rawEntitySetHandle instead",
-        replaceWith = ReplaceWith("this.rawEntitySetHandle(storageKey, schema, callbacks, name, ttl, canRead)")
+        replaceWith = ReplaceWith("this.rawEntitySetHandle(storageKey, schema, name, ttl, canRead)")
     )
     /* ktlint-enable max-line-length */
     suspend fun setHandle(
         storageKey: StorageKey,
         schema: Schema,
-        callbacks: SetCallbacks<RawEntity>? = null,
         name: String = storageKey.toKeyString(),
         ttl: Ttl = Ttl.Infinite,
         canRead: Boolean = true
     ): SetHandle<RawEntity> = rawEntitySetHandle(
         storageKey,
         schema,
-        callbacks,
         name,
         ttl,
         canRead
@@ -244,7 +211,6 @@ class HandleManager(
     suspend fun referenceSetHandle(
         storageKey: StorageKey,
         schema: Schema,
-        callbacks: SetCallbacks<Reference>? = null,
         name: String = storageKey.toKeyString(),
         ttl: Ttl = Ttl.Infinite,
         canRead: Boolean = true
@@ -267,12 +233,11 @@ class HandleManager(
         return SetHandle(
             name = name,
             storageProxy = storageProxy,
-            callbacks = callbacks,
             ttl = ttl,
             time = time,
             canRead = canRead,
             dereferencer = RawEntityDereferencer(schema, aff?.dereferenceFactory()),
             schema = schema
-        ).also { storageProxy.registerHandle(it) }
+        )
     }
 }

--- a/java/arcs/core/storage/handle/SingletonImpl.kt
+++ b/java/arcs/core/storage/handle/SingletonImpl.kt
@@ -17,7 +17,6 @@ import arcs.core.data.RawEntity
 import arcs.core.data.Schema
 import arcs.core.data.Ttl
 import arcs.core.storage.ActivationFactory
-import arcs.core.storage.Callbacks
 import arcs.core.storage.Dereferencer
 import arcs.core.storage.Handle
 import arcs.core.storage.StorageProxy
@@ -32,7 +31,6 @@ typealias SingletonOp<T> = CrdtSingleton.IOperation<T>
 typealias SingletonStoreOptions<T> = StoreOptions<SingletonData<T>, SingletonOp<T>, T?>
 typealias SingletonHandle<T> = SingletonImpl<T>
 typealias SingletonActivationFactory<T> = ActivationFactory<SingletonData<T>, SingletonOp<T>, T?>
-typealias SingletonCallbacks<T> = Callbacks<SingletonData<T>, SingletonOp<T>, T?>
 
 /**
  * Singleton [Handle] implementation for the runtime.
@@ -43,7 +41,6 @@ typealias SingletonCallbacks<T> = Callbacks<SingletonData<T>, SingletonOp<T>, T?
 class SingletonImpl<T : Referencable>(
     name: String,
     storageProxy: SingletonProxy<T>,
-    callbacks: SingletonCallbacks<T>? = null,
     ttl: Ttl = Ttl.Infinite,
     time: Time,
     canRead: Boolean = true,
@@ -52,7 +49,6 @@ class SingletonImpl<T : Referencable>(
 ) : SingletonBase<T>(
     name,
     storageProxy,
-    callbacks,
     ttl,
     time,
     canRead,

--- a/javatests/arcs/android/storage/handle/AndroidHandleManagerTest.kt
+++ b/javatests/arcs/android/storage/handle/AndroidHandleManagerTest.kt
@@ -275,7 +275,7 @@ class AndroidHandleManagerTest : LifecycleOwner {
         // `removeAllCallbacks` works, and only removes the callbacks for the specified handle.
         firstHandle.removeAllCallbacks()
         secondHandle.store(entity2)
-        //verify(testOnUpdate1).invoke(setOf(entity2))
+        verifyNoMoreInteractions(testOnUpdate1)
         verify(testOnUpdate2).invoke(setOf(entity2))
     }
 

--- a/javatests/arcs/android/storage/handle/AndroidHandleManagerTest.kt
+++ b/javatests/arcs/android/storage/handle/AndroidHandleManagerTest.kt
@@ -8,8 +8,6 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.work.testing.WorkManagerTestInitHelper
 import arcs.core.crdt.CrdtEntity
-import arcs.core.crdt.CrdtSet
-import arcs.core.crdt.CrdtSingleton
 import arcs.core.crdt.VersionMap
 import arcs.core.data.FieldType
 import arcs.core.data.RawEntity
@@ -23,8 +21,6 @@ import arcs.core.storage.driver.RamDisk
 import arcs.core.storage.driver.RamDiskStorageKey
 import arcs.core.storage.driver.VolatileEntry
 import arcs.core.storage.handle.HandleManager
-import arcs.core.storage.handle.SetCallbacks
-import arcs.core.storage.handle.SingletonCallbacks
 import arcs.core.storage.referencemode.ReferenceModeStorageKey
 import arcs.sdk.android.storage.service.testutil.TestConnectionFactory
 import com.google.common.truth.Truth.assertThat
@@ -128,6 +124,7 @@ class AndroidHandleManagerTest : LifecycleOwner {
         val singleton2Handle = handleManager.rawEntitySingletonHandle(
             storageKey = storageKey1, schema = schema
         )
+
         val storageKey2 = ReferenceModeStorageKey(backingKey, RamDiskStorageKey("entity2"))
         val singleton2Handle2 = handleManager.rawEntitySingletonHandle(
             storageKey = storageKey2, schema = schema
@@ -167,7 +164,7 @@ class AndroidHandleManagerTest : LifecycleOwner {
     }
 
     @Test
-    fun testCreateReferenceSingletonHandle() = runBlocking {
+    fun singleton_createReferenceHandle() = runBlocking {
         val singletonHandle = handleManager.referenceSingletonHandle(singletonRefKey, schema)
         val entity1Ref = singletonHandle.createReference(entity1, backingKey)
         singletonHandle.store(entity1Ref)
@@ -199,7 +196,7 @@ class AndroidHandleManagerTest : LifecycleOwner {
     }
 
     @Test
-    fun testCreateReferenceSetHandle() = runBlocking {
+    fun set_createReferenceHandle() = runBlocking {
         val setHandle = handleManager.referenceSetHandle(singletonRefKey, schema)
         val entity1Ref = setHandle.createReference(entity1, backingKey)
         val entity2Ref = setHandle.createReference(entity2, backingKey)
@@ -252,83 +249,79 @@ class AndroidHandleManagerTest : LifecycleOwner {
 
     private fun testMapForKey(key: StorageKey) = VersionMap(key.toKeyString() to 1)
 
+    // Mocking Function1<T, Unit> causes [ClassCastException
+    // These interface defintions prevent the problem.
+    interface OnUpdate<T> : Function1<T, Unit>
+    interface OnSync : Function0<Unit>
     @Test
     fun set_onHandleUpdate() = runBlocking<Unit> {
-        val testCallback1 = mock<SetCallbacks<RawEntity>>()
-        val testCallback2 = mock<SetCallbacks<RawEntity>>()
-        val firstHandle = handleManager.rawEntitySetHandle(setKey, schema, testCallback1)
-        val secondHandle = handleManager.rawEntitySetHandle(setKey, schema, testCallback2)
+        val firstHandle = handleManager.rawEntitySetHandle(setKey, schema)
+        val testOnUpdate1 = mock<OnUpdate<Set<RawEntity>>>().also { firstHandle.addOnUpdate(it::invoke) }
+        val secondHandle = handleManager.rawEntitySetHandle(setKey, schema)
+        val testOnUpdate2 = mock<OnUpdate<Set<RawEntity>>>().also { secondHandle.addOnUpdate(it::invoke) }
 
-        val expectedAdd = CrdtSet.Operation.Add(
-            setKey.toKeyString(),
-            testMapForKey(setKey),
-            entity1
-        )
         secondHandle.store(entity1)
-        verify(testCallback1).onUpdate(firstHandle, expectedAdd)
-        verify(testCallback2).onUpdate(secondHandle, expectedAdd)
+        verify(testOnUpdate1).invoke(setOf(entity1))
+        verify(testOnUpdate2).invoke(setOf(entity1))
 
         firstHandle.remove(entity1)
-        val expectedRemove = CrdtSet.Operation.Remove(
-            setKey.toKeyString(),
-            testMapForKey(setKey),
-            entity1
-        )
-        verify(testCallback1).onUpdate(firstHandle, expectedRemove)
-        verify(testCallback2).onUpdate(secondHandle, expectedRemove)
+
+        verify(testOnUpdate1).invoke(emptySet<RawEntity>())
+        verify(testOnUpdate2).invoke(emptySet<RawEntity>())
     }
 
     @Test
     fun singleton_OnHandleUpdate() = runBlocking<Unit> {
-        val testCallback1 = mock<SingletonCallbacks<RawEntity>>()
-        val testCallback2 = mock<SingletonCallbacks<RawEntity>>()
         val firstHandle = handleManager.rawEntitySingletonHandle(
             storageKey = singletonKey,
-            schema = schema,
-            callbacks = testCallback1
+            schema = schema
         )
+        val testOnUpdate1 = mock<OnUpdate<RawEntity?>>().also { firstHandle.addOnUpdate(it::invoke) }
         val secondHandle = handleManager.rawEntitySingletonHandle(
             storageKey = singletonKey,
-            schema = schema,
-            callbacks = testCallback2
+            schema = schema
         )
+        val testOnUpdate2 = mock<OnUpdate<RawEntity?>>().also { firstHandle.addOnUpdate(it::invoke) }
+
         secondHandle.store(entity1)
-        val expectedAdd = CrdtSingleton.Operation.Update(
-            singletonKey.toKeyString(),
-            testMapForKey(singletonKey),
-            entity1
-        )
-        verify(testCallback1).onUpdate(firstHandle, expectedAdd)
-        verify(testCallback2).onUpdate(secondHandle, expectedAdd)
+        verify(testOnUpdate1).invoke(entity1)
+        verify(testOnUpdate2).invoke(entity1)
         firstHandle.clear()
 
-        val expectedRemove = CrdtSingleton.Operation.Clear<RawEntity>(
-            singletonKey.toKeyString(),
-            testMapForKey(singletonKey)
-        )
-        verify(testCallback1).onUpdate(firstHandle, expectedRemove)
-        verify(testCallback2).onUpdate(secondHandle, expectedRemove)
+        verify(testOnUpdate1).invoke(null)
+        verify(testOnUpdate2).invoke(null)
     }
 
     @Test
     fun set_syncOnRegister() = runBlocking<Unit> {
-        val testCallback = mock<SetCallbacks<RawEntity>>()
-        val firstHandle = handleManager.rawEntitySetHandle(setKey, schema, testCallback)
-        verify(testCallback).onSync(firstHandle)
+        val firstHandle = handleManager.rawEntitySetHandle(setKey, schema)
+        val testOnSync = mock<OnSync>().also { firstHandle.addOnSync(it::invoke) }
         firstHandle.fetchAll()
-        verify(testCallback).onSync(firstHandle)
+        verify(testOnSync).invoke()
     }
 
     @Test
     fun singleton_syncOnRegister() = runBlocking<Unit> {
-        val testCallback = mock<SingletonCallbacks<RawEntity>>()
         val firstHandle = handleManager.rawEntitySingletonHandle(
             storageKey = setKey,
-            schema = schema,
-            callbacks = testCallback
+            schema = schema
         )
-        verify(testCallback).onSync(firstHandle)
+        val testOnSync = mock<OnSync>().also { firstHandle.addOnSync(it::invoke) }
         firstHandle.fetch()
-        verify(testCallback).onSync(firstHandle)
+        verify(testOnSync).invoke()
+    }
+
+
+    @Test
+    fun set_laterHandleWrite() = runBlocking<Unit> {
+        val firstHandle = handleManager.rawEntitySetHandle(setKey, schema)
+        firstHandle.store(entity1)
+        val testOnUpdate1 = mock<OnUpdate<Set<RawEntity>>>().also { firstHandle.addOnUpdate(it::invoke) }
+
+        // Create a second handle and make sure that writes succeed from the start
+        val secondHandle = handleManager.rawEntitySetHandle(setKey, schema)
+        secondHandle.store(entity2)
+
+        verify(testOnUpdate1).invoke(setOf(entity1, entity2))
     }
 }

--- a/javatests/arcs/core/storage/StorageProxyTest.kt
+++ b/javatests/arcs/core/storage/StorageProxyTest.kt
@@ -88,7 +88,7 @@ class StorageProxyTest {
         assertThat(fakeStoreEndpoint.getProxyMessages()).containsExactly(modelUpdate)
     }
 
-    /** Test that when store application of an op fails, synchronization is triggered */
+    /** Test that when store application of an op fails, synchronization is triggered. */
     @Test
     fun failedApplyOpTriggersSync() = runBlockingTest {
         val storageProxy = StorageProxy(mockStorageEndpointProvider, mockCrdtModel)
@@ -98,7 +98,7 @@ class StorageProxyTest {
         mockCrdtModel.appliesOpAs(mockCrdtOperation, true)
 
         // Store op will fail
-        fakeStoreEndpoint.proxyMessageReturn = false
+        fakeStoreEndpoint.onProxyMessageReturn = false
         assertThat(storageProxy.applyOp(mockCrdtOperation)).isTrue()
         val syncReq = ProxyMessage.SyncRequest<CrdtData, CrdtOperation, String>(null)
         val opReq = ProxyMessage.Operations<CrdtData, CrdtOperation, String> (

--- a/javatests/arcs/core/storage/StorageProxyTest.kt
+++ b/javatests/arcs/core/storage/StorageProxyTest.kt
@@ -28,6 +28,7 @@ import org.junit.runners.JUnit4
 import org.mockito.Mock
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
+import org.mockito.Mockito.any
 import org.mockito.MockitoAnnotations
 
 @Suppress("UNCHECKED_CAST", "UNUSED_VARIABLE")
@@ -55,25 +56,25 @@ class StorageProxyTest {
     @Test
     fun propagatesStorageOpToReaders() = runBlockingTest {
         val storageProxy = StorageProxy(mockStorageEndpointProvider, mockCrdtModel)
-        val (readHandle, readCallback) = newHandle("testReader", storageProxy, true)
+        val readHandle = newHandle("testReader", storageProxy, true)
+        val readCallback = mock<(String)->Unit>().also { readHandle.addOnUpdate(it) }
         mockCrdtModel.appliesOpAs(mockCrdtOperation, true)
 
-        storageProxy.registerHandle(readHandle)
         storageProxy.onMessage(ProxyMessage.Operations(listOf(mockCrdtOperation), null))
 
-        verify(readCallback).onUpdate(readHandle, mockCrdtOperation)
+        verify(readCallback).invoke(mockCrdtModel.consumerView)
     }
 
     @Test
     fun propagatesStorageFullModelToReaders() = runBlockingTest {
         val storageProxy = StorageProxy(mockStorageEndpointProvider, mockCrdtModel)
-        val (readHandle, readCallback) = newHandle("testReader", storageProxy, true)
+        val readHandle = newHandle("testReader", storageProxy, true)
+        val syncCallback = mock<()->Unit>().also { readHandle.addOnSync(it) }
         mockCrdtModel.appliesOpAs(mockCrdtOperation, true)
 
-        storageProxy.registerHandle(readHandle)
         storageProxy.onMessage(ProxyMessage.ModelUpdate(mockCrdtData, null))
 
-        verify(readCallback).onSync(readHandle)
+        verify(syncCallback).invoke()
     }
 
     @Test
@@ -87,42 +88,33 @@ class StorageProxyTest {
         assertThat(fakeStoreEndpoint.getProxyMessages()).containsExactly(modelUpdate)
     }
 
-    @Test
-    fun propagatesUpdatesToReadersAndNotToWriters() = runBlockingTest {
-        val storageProxy = StorageProxy(mockStorageEndpointProvider, mockCrdtModel)
-        val (readHandle, readCallback) = newHandle("testReader", storageProxy, true)
-        val (writeHandle ,writeCallback) = newHandle("testWriter", storageProxy, false)
-        mockCrdtModel.appliesOpAs(mockCrdtOperation, true)
-
-        storageProxy.registerHandle(readHandle)
-        storageProxy.registerHandle(writeHandle)
-        assertThat(storageProxy.applyOp(mockCrdtOperation)).isTrue()
-
-        verify(readCallback).onUpdate(readHandle, mockCrdtOperation)
-        verifyNoMoreInteractions(writeCallback)
-    }
-
+    /** Test that when store application of an op fails, synchronization is triggered */
     @Test
     fun failedApplyOpTriggersSync() = runBlockingTest {
         val storageProxy = StorageProxy(mockStorageEndpointProvider, mockCrdtModel)
-        val (readHandle, _) = newHandle("testReader", storageProxy, true)
-        mockCrdtModel.appliesOpAs(mockCrdtOperation, false)
+        val readHandle = newHandle("testReader", storageProxy, true)
 
-        storageProxy.registerHandle(readHandle)
-        assertThat(storageProxy.applyOp(mockCrdtOperation)).isFalse()
+        // Local op will succeed
+        mockCrdtModel.appliesOpAs(mockCrdtOperation, true)
 
+        // Store op will fail
+        fakeStoreEndpoint.proxyMessageReturn = false
+        assertThat(storageProxy.applyOp(mockCrdtOperation)).isTrue()
         val syncReq = ProxyMessage.SyncRequest<CrdtData, CrdtOperation, String>(null)
-        assertThat(fakeStoreEndpoint.getProxyMessages()).containsExactly(syncReq)
+        val opReq = ProxyMessage.Operations<CrdtData, CrdtOperation, String> (
+            listOf(mockCrdtOperation),
+            null
+        )
+        assertThat(fakeStoreEndpoint.getProxyMessages()).containsExactly(opReq, syncReq)
     }
 
     @Test
     fun getParticleViewReturnsSyncedState() = runBlockingTest {
         val storageProxy = StorageProxy(mockStorageEndpointProvider, mockCrdtModel)
         whenever(mockCrdtModel.consumerView).thenReturn("someData")
-        val (readHandle, _) = newHandle("testReader", storageProxy, true)
+        val readHandle = newHandle("testReader", storageProxy, true)
         mockCrdtModel.appliesOpAs(mockCrdtOperation, true)
 
-        storageProxy.registerHandle(readHandle)
         assertThat(storageProxy.onMessage(ProxyMessage.Operations(listOf(mockCrdtOperation), null)))
             .isTrue()
         val view = storageProxy.getParticleView()
@@ -134,9 +126,8 @@ class StorageProxyTest {
     fun getParticleViewWhenUnsyncedQueues() = runBlockingTest {
         val storageProxy = StorageProxy(mockStorageEndpointProvider, mockCrdtModel)
         whenever(mockCrdtModel.consumerView).thenReturn("someData")
-        val (readHandle, _) = newHandle("testReader", storageProxy, true)
+        val readHandle = newHandle("testReader", storageProxy, true)
         mockCrdtModel.appliesOpAs(mockCrdtOperation, true)
-        storageProxy.registerHandle(readHandle)
 
         // get view when not synced
         val future = storageProxy.getParticleViewAsync()
@@ -159,17 +150,6 @@ class StorageProxyTest {
         whenever(mockCrdtModel.consumerView).thenReturn("someData")
 
         val ops = listOf(
-            suspend {
-                // registerHandle
-                val (handle, _) = newHandle("testReader", storageProxy, true)
-                storageProxy.registerHandle(handle)
-            },
-            suspend {
-                // deregisterHandle
-                val (handle, _) = newHandle("testReader-${Random.nextInt()}", storageProxy, true)
-                storageProxy.registerHandle(handle)
-                storageProxy.deregisterHandle(handle)
-            },
             suspend {
                 // store sends sync req
                 val syncReq = ProxyMessage.SyncRequest<CrdtData, CrdtOperationAtTime, String>(null)
@@ -220,18 +200,11 @@ class StorageProxyTest {
         }
     }
 
-    private data class HandleWithCallback<Data : CrdtData, Op : CrdtOperationAtTime, T>(
-        val handle: Handle<Data, Op, T>,
-        val callback: Callbacks<Data, Op, T>
-    )
-
     private fun newHandle(
         name: String,
         storageProxy: StorageProxy<CrdtData, CrdtOperationAtTime, String>,
         reader: Boolean
-    ) = mock<Callbacks<CrdtData, CrdtOperationAtTime, String>>().let {
-        HandleWithCallback(Handle(name, storageProxy, it, Ttl.Infinite, TimeImpl(), reader, true), it)
-    }
+    ) = Handle(name, storageProxy, Ttl.Infinite, TimeImpl(), reader, true)
 
     fun CrdtModel<CrdtData, CrdtOperationAtTime, String>.appliesOpAs(op: CrdtOperationAtTime, result: Boolean) {
         whenever(this.applyOperation(op)).thenReturn(result)

--- a/javatests/arcs/core/storage/StoreEndpointFake.kt
+++ b/javatests/arcs/core/storage/StoreEndpointFake.kt
@@ -15,7 +15,8 @@ class StoreEndpointFake<Data : CrdtData, Op : CrdtOperation, T>:
     private var callbacks = mutableListOf<ProxyCallback<Data, Op, T>>()
     private var proxyMessages = mutableListOf<ProxyMessage<Data, Op, T>>()
 
-    var proxyMessageReturn = true
+    // Tests can change this field to alter the value returned by `onProxyMessage`.
+    var onProxyMessageReturn = true
 
     override fun setCallback(callback: ProxyCallback<Data, Op, T>) {
         // must be blocking since the storage impl is. Unlikely to be heavily contended.
@@ -30,7 +31,7 @@ class StoreEndpointFake<Data : CrdtData, Op : CrdtOperation, T>:
 
     override suspend fun onProxyMessage(message: ProxyMessage<Data, Op, T>): Boolean {
         mutex.withLock { proxyMessages.add(message) }
-        return proxyMessageReturn
+        return onProxyMessageReturn
     }
 
     suspend fun getProxyMessages() : List<ProxyMessage<Data, Op, T>> {

--- a/javatests/arcs/core/storage/StoreEndpointFake.kt
+++ b/javatests/arcs/core/storage/StoreEndpointFake.kt
@@ -15,6 +15,8 @@ class StoreEndpointFake<Data : CrdtData, Op : CrdtOperation, T>:
     private var callbacks = mutableListOf<ProxyCallback<Data, Op, T>>()
     private var proxyMessages = mutableListOf<ProxyMessage<Data, Op, T>>()
 
+    var proxyMessageReturn = true
+
     override fun setCallback(callback: ProxyCallback<Data, Op, T>) {
         // must be blocking since the storage impl is. Unlikely to be heavily contended.
         runBlocking {
@@ -28,7 +30,7 @@ class StoreEndpointFake<Data : CrdtData, Op : CrdtOperation, T>:
 
     override suspend fun onProxyMessage(message: ProxyMessage<Data, Op, T>): Boolean {
         mutex.withLock { proxyMessages.add(message) }
-        return true
+        return proxyMessageReturn
     }
 
     suspend fun getProxyMessages() : List<ProxyMessage<Data, Op, T>> {

--- a/javatests/arcs/core/storage/handle/CollectionIntegrationTest.kt
+++ b/javatests/arcs/core/storage/handle/CollectionIntegrationTest.kt
@@ -70,10 +70,8 @@ class CollectionIntegrationTest {
         testStore = Store(STORE_OPTIONS)
         storageProxy = StorageProxy(testStore.activate(), CrdtSet<RawEntity>())
 
-        collectionA = CollectionImpl("collectionA", storageProxy, null, Ttl.Infinite, TimeImpl(), schema = SCHEMA_A)
-        storageProxy.registerHandle(collectionA)
-        collectionB = CollectionImpl("collectionB", storageProxy, null, Ttl.Infinite, TimeImpl(), schema = SCHEMA_B)
-        storageProxy.registerHandle(collectionB)
+        collectionA = CollectionImpl("collectionA", storageProxy, Ttl.Infinite, TimeImpl(), schema = SCHEMA_A)
+        collectionB = CollectionImpl("collectionB", storageProxy,  Ttl.Infinite, TimeImpl(), schema = SCHEMA_B)
         Unit
     }
 
@@ -189,15 +187,13 @@ class CollectionIntegrationTest {
         assertThat(collectionA.fetchAll().first().expirationTimestamp)
             .isEqualTo(RawEntity.UNINITIALIZED_TIMESTAMP)
 
-        val collectionC = CollectionImpl("collectionC", storageProxy, null, Ttl.Days(2), TimeImpl(), schema = SCHEMA_A)
-        storageProxy.registerHandle(collectionC)
+        val collectionC = CollectionImpl("collectionC", storageProxy, Ttl.Days(2), TimeImpl(), schema = SCHEMA_A)
         assertThat(collectionC.store(person.toRawEntity())).isTrue()
         val entityC = collectionC.fetchAll().first()
         assertThat(entityC.creationTimestamp).isGreaterThan(creationTimestampA)
         assertThat(entityC.expirationTimestamp).isGreaterThan(RawEntity.UNINITIALIZED_TIMESTAMP)
 
-        val collectionD = CollectionImpl("collectionD", storageProxy, null, Ttl.Minutes(1), TimeImpl(), schema = SCHEMA_B)
-        storageProxy.registerHandle(collectionD)
+        val collectionD = CollectionImpl("collectionD", storageProxy, Ttl.Minutes(1), TimeImpl(), schema = SCHEMA_B)
         assertThat(collectionD.store(person.toRawEntity())).isTrue()
         val entityD = collectionD.fetchAll().first()
         assertThat(entityD.creationTimestamp).isGreaterThan(creationTimestampA)

--- a/javatests/arcs/core/storage/handle/SingletonIntegrationTest.kt
+++ b/javatests/arcs/core/storage/handle/SingletonIntegrationTest.kt
@@ -66,10 +66,8 @@ class SingletonIntegrationTest {
         store = Store(STORE_OPTIONS)
         storageProxy = StorageProxy(store.activate(), CrdtSingleton<RawEntity>())
 
-        singletonA = SingletonImpl("singletonA", storageProxy, null, Ttl.Infinite, TimeImpl(), schema = SCHEMA)
-        storageProxy.registerHandle(singletonA)
-        singletonB = SingletonImpl("singletonB", storageProxy, null, Ttl.Infinite, TimeImpl(), schema = SCHEMA)
-        storageProxy.registerHandle(singletonB)
+        singletonA = SingletonImpl("singletonA", storageProxy,Ttl.Infinite, TimeImpl(), schema = SCHEMA)
+        singletonB = SingletonImpl("singletonB", storageProxy, Ttl.Infinite, TimeImpl(), schema = SCHEMA)
         Unit
     }
 
@@ -143,15 +141,13 @@ class SingletonIntegrationTest {
         assertThat(requireNotNull(singletonA.fetch()).expirationTimestamp)
             .isEqualTo(RawEntity.UNINITIALIZED_TIMESTAMP)
 
-        val singletonC = SingletonImpl("singletonC", storageProxy, null, Ttl.Days(2), TimeImpl(), schema = SCHEMA)
-        storageProxy.registerHandle(singletonC)
+        val singletonC = SingletonImpl("singletonC", storageProxy, Ttl.Days(2), TimeImpl(), schema = SCHEMA)
         assertThat(singletonC.store(person.toRawEntity())).isTrue()
         val entityC = requireNotNull(singletonC.fetch())
         assertThat(entityC.creationTimestamp).isGreaterThan(creationTimestampA)
         assertThat(entityC.expirationTimestamp).isGreaterThan(RawEntity.UNINITIALIZED_TIMESTAMP)
 
-        val singletonD = SingletonImpl("singletonD", storageProxy, null, Ttl.Minutes(1), TimeImpl(), schema = SCHEMA)
-        storageProxy.registerHandle(singletonD)
+        val singletonD = SingletonImpl("singletonD", storageProxy, Ttl.Minutes(1), TimeImpl(), schema = SCHEMA)
         assertThat(singletonD.store(person.toRawEntity())).isTrue()
         val entityD = requireNotNull(singletonD.fetch())
         assertThat(entityD.creationTimestamp).isGreaterThan(creationTimestampA)


### PR DESCRIPTION
* Remove the `core` `Callbacks` interface type, in favor of
 finer-grained action functions
* Move ownerships of data activity callbacks into `StorageProxy`
* Remove some deprecated functions
* Remove the `registerHandle` and `deregisterHandle` methods on
  StorageProxy

What started as adding `start`/`stop` functionality to handles turned
into a re-imagining of the callbacks pattern.

Observations:
* `registerHandle` (which was to be called via a `start` method on the
handle) is only setting up callbacks to the handle.
* The only action a handle takes when receiving `storageProxy` callback
calls is to trigger any developer-supplied callbacks.
* Adapting between the single-interface-with-all-3-callbacks and
callbacks-as-individual-methods approach seemed to cause some
complicated interface adaption needs.