### PR TITLE
Code generation for schema refinements and queries

### DIFF
--- a/java/arcs/core/data/Schema.kt
+++ b/java/arcs/core/data/Schema.kt
@@ -19,7 +19,7 @@ import arcs.core.type.Type
 typealias Refinement = (data: RawEntity) -> Boolean
 
 /** Returns true if the RawEntity data matches the query predicate (given a query argument)*/
-typealias Query = (data: RawEntity, queryArg: Any) -> Boolean
+typealias Query = (data: RawEntity, queryArgs: Any) -> Boolean
 
 data class Schema(
     val names: List<SchemaName>,

--- a/src/runtime/refiner.ts
+++ b/src/runtime/refiner.ts
@@ -33,6 +33,7 @@ const KOTLIN_QUERY_ARGUMENT_NAME = 'queryArgument';
 interface CodeGenerator {
   escapeIdentifier(name: string): string;
   typeFor(name: string): string;
+  defaultValFor(name: string): string;
 }
 
 
@@ -1305,7 +1306,7 @@ export class KTExtracter {
     const genFieldAsLocal = (fieldName: string) => {
       const type = schema.fields[fieldName].type;
       const fixed = codeGenerator.escapeIdentifier(fieldName);
-      return `val ${fixed} = data.singletons["${fieldName}"] as ${codeGenerator.typeFor(type)}`;
+      return `val ${fixed} = data.singletons["${fieldName}"].toPrimitiveValue(${codeGenerator.typeFor(type)}::class, ${codeGenerator.defaultValFor(type)})`;
     };
 
     const genQueryArgAsLocal = ([_, type]: [string, string]) => {

--- a/src/runtime/refiner.ts
+++ b/src/runtime/refiner.ts
@@ -1305,11 +1305,11 @@ export class KTExtracter {
     const genFieldAsLocal = (fieldName: string) => {
       const type = schema.fields[fieldName].type;
       const fixed = codeGenerator.escapeIdentifier(fieldName);
-      return `val ${fixed} = data.${fixed} as ${codeGenerator.typeFor(type)}`;
+      return `val ${fixed} = data.singletons["${fieldName}"] as ${codeGenerator.typeFor(type)}`;
     };
 
     const genQueryArgAsLocal = ([_, type]: [string, string]) => {
-        return `val ${KOTLIN_QUERY_ARGUMENT_NAME} = queryArg as ${codeGenerator.typeFor(type)}`;
+        return `val ${KOTLIN_QUERY_ARGUMENT_NAME} = queryArgs as ${codeGenerator.typeFor(type)}`;
     };
 
     const fieldNames = new Set<string>();
@@ -1332,7 +1332,7 @@ export class KTExtracter {
     }
     const expr = filterTerms.length > 0 ? `${filterTerms.join(' && ')}` : 'true';
 
-    return `${locals.map(x => `${x}\n`).join('')}return ${expr}`;
+    return `${locals.map(x => `${x}\n`).join('')}${expr}`;
   }
 }
 

--- a/src/runtime/tests/refiner-test.ts
+++ b/src/runtime/tests/refiner-test.ts
@@ -583,7 +583,10 @@ describe('KTExtracter', () => {
       const schema = manifest.particles[0].handleConnectionMap.get('input').type.getEntitySchema();
       const query: string = KTExtracter.fromSchema(schema, escaper);
       assert.strictEqual(query,
-        'val a = data.singletons["a"] as Double\nval b = data.singletons["b"] as Double\n((b + (a * 3)) > 300) && ((a > 3) && (!(a == 100))) && ((b > 20) && (b < 100))');
+        `\
+val a = data.singletons["a"] as Double
+val b = data.singletons["b"] as Double
+((b + (a * 3)) > 300) && ((a > 3) && (!(a == 100))) && ((b > 20) && (b < 100))`);
   }));
   it('tests can create queries from refinement expressions involving boolean expressions', Flags.withFieldRefinementsAllowed(async () => {
     const manifest = await Manifest.parse(`
@@ -594,7 +597,10 @@ describe('KTExtracter', () => {
     const query = KTExtracter.fromSchema(schema, escaper);
     //TODO(cypher1): Implement some simple boolean simplifications.
     //This should simplify to, '(!a) && b'
-    assert.strictEqual(query, 'val a = data.singletons["a"] as Boolean\nval b = data.singletons["b"] as Boolean\n(b || a) && (!a) && b');
+    assert.strictEqual(query, `\
+val a = data.singletons["a"] as Boolean
+val b = data.singletons["b"] as Boolean
+(b || a) && (!a) && b`);
   }));
   it('tests can create queries where field refinement is null', async () => {
     const manifest = await Manifest.parse(`
@@ -603,7 +609,10 @@ describe('KTExtracter', () => {
     `);
     const schema = manifest.particles[0].handleConnectionMap.get('input').type.getEntitySchema();
     const query = KTExtracter.fromSchema(schema, escaper);
-    assert.strictEqual(query, 'val a = data.singletons["a"] as Boolean\nval b = data.singletons["b"] as Boolean\n(b && a)');
+    assert.strictEqual(query, `\
+val a = data.singletons["a"] as Boolean
+val b = data.singletons["b"] as Boolean
+(b && a)`);
   });
   it('tests can create queries where schema refinement is null', Flags.withFieldRefinementsAllowed(async () => {
     const manifest = await Manifest.parse(`
@@ -612,7 +621,10 @@ describe('KTExtracter', () => {
     `);
     const schema = manifest.particles[0].handleConnectionMap.get('input').type.getEntitySchema();
     const query = KTExtracter.fromSchema(schema, escaper);
-    assert.strictEqual(query, 'val a = data.singletons["a"] as Boolean\nval b = data.singletons["b"] as Boolean\n(!a) && b');
+    assert.strictEqual(query, `\
+val a = data.singletons["a"] as Boolean
+val b = data.singletons["b"] as Boolean
+(!a) && b`);
   }));
   it('tests can create queries where there is no refinement', async () => {
     const manifest = await Manifest.parse(`

--- a/src/runtime/tests/refiner-test.ts
+++ b/src/runtime/tests/refiner-test.ts
@@ -583,7 +583,7 @@ describe('KTExtracter', () => {
       const schema = manifest.particles[0].handleConnectionMap.get('input').type.getEntitySchema();
       const query: string = KTExtracter.fromSchema(schema, escaper);
       assert.strictEqual(query,
-        'val a = data.a as Double\nval b = data.b as Double\nreturn ((b + (a * 3)) > 300) && ((a > 3) && (!(a == 100))) && ((b > 20) && (b < 100))');
+        'val a = data.singletons["a"] as Double\nval b = data.singletons["b"] as Double\n((b + (a * 3)) > 300) && ((a > 3) && (!(a == 100))) && ((b > 20) && (b < 100))');
   }));
   it('tests can create queries from refinement expressions involving boolean expressions', Flags.withFieldRefinementsAllowed(async () => {
     const manifest = await Manifest.parse(`
@@ -593,8 +593,8 @@ describe('KTExtracter', () => {
     const schema = manifest.particles[0].handleConnectionMap.get('input').type.getEntitySchema();
     const query = KTExtracter.fromSchema(schema, escaper);
     //TODO(cypher1): Implement some simple boolean simplifications.
-    //This should simplify to, 'return (!a) && b'
-    assert.strictEqual(query, 'val a = data.a as Boolean\nval b = data.b as Boolean\nreturn (b || a) && (!a) && b');
+    //This should simplify to, '(!a) && b'
+    assert.strictEqual(query, 'val a = data.singletons["a"] as Boolean\nval b = data.singletons["b"] as Boolean\n(b || a) && (!a) && b');
   }));
   it('tests can create queries where field refinement is null', async () => {
     const manifest = await Manifest.parse(`
@@ -603,7 +603,7 @@ describe('KTExtracter', () => {
     `);
     const schema = manifest.particles[0].handleConnectionMap.get('input').type.getEntitySchema();
     const query = KTExtracter.fromSchema(schema, escaper);
-    assert.strictEqual(query, 'val a = data.a as Boolean\nval b = data.b as Boolean\nreturn (b && a)');
+    assert.strictEqual(query, 'val a = data.singletons["a"] as Boolean\nval b = data.singletons["b"] as Boolean\n(b && a)');
   });
   it('tests can create queries where schema refinement is null', Flags.withFieldRefinementsAllowed(async () => {
     const manifest = await Manifest.parse(`
@@ -612,7 +612,7 @@ describe('KTExtracter', () => {
     `);
     const schema = manifest.particles[0].handleConnectionMap.get('input').type.getEntitySchema();
     const query = KTExtracter.fromSchema(schema, escaper);
-    assert.strictEqual(query, 'val a = data.a as Boolean\nval b = data.b as Boolean\nreturn (!a) && b');
+    assert.strictEqual(query, 'val a = data.singletons["a"] as Boolean\nval b = data.singletons["b"] as Boolean\n(!a) && b');
   }));
   it('tests can create queries where there is no refinement', async () => {
     const manifest = await Manifest.parse(`
@@ -621,7 +621,7 @@ describe('KTExtracter', () => {
     `);
     const schema = manifest.particles[0].handleConnectionMap.get('input').type.getEntitySchema();
     const query = KTExtracter.fromSchema(schema, escaper);
-    assert.strictEqual(query, 'return true');
+    assert.strictEqual(query, 'true');
   });
 });
 

--- a/src/runtime/tests/refiner-test.ts
+++ b/src/runtime/tests/refiner-test.ts
@@ -521,7 +521,8 @@ describe('Range', () => {
 describe('SQLExtracter', () => {
   const escaper = {
     escapeIdentifier: (name: string) => name,
-    typeFor: (type: string) => type
+    typeFor: (type: string) => null,
+    defaultValFor: (_type: string) => null
   };
   it('tests can create queries from refinement expressions involving math expressions', Flags.withFieldRefinementsAllowed(async () => {
       const manifest = await Manifest.parse(`
@@ -573,7 +574,8 @@ describe('SQLExtracter', () => {
 describe('KTExtracter', () => {
   const escaper = {
     escapeIdentifier: (name: string) => name,
-    typeFor: (type: string) => type === 'Number' ? 'Double' : type
+    typeFor: (type: string) => type === 'Number' ? 'Double' : type,
+    defaultValFor: (type: string) => ({'Number': '0.0', 'Boolean': 'false', 'Text': '""'}[type])
   };
   it('tests can create queries from refinement expressions involving math expressions', Flags.withFieldRefinementsAllowed(async () => {
       const manifest = await Manifest.parse(`

--- a/src/runtime/tests/refiner-test.ts
+++ b/src/runtime/tests/refiner-test.ts
@@ -586,8 +586,8 @@ describe('KTExtracter', () => {
       const query: string = KTExtracter.fromSchema(schema, escaper);
       assert.strictEqual(query,
         `\
-val a = data.singletons["a"] as Double
-val b = data.singletons["b"] as Double
+val a = data.singletons["a"].toPrimitiveValue(Double::class, 0.0)
+val b = data.singletons["b"].toPrimitiveValue(Double::class, 0.0)
 ((b + (a * 3)) > 300) && ((a > 3) && (!(a == 100))) && ((b > 20) && (b < 100))`);
   }));
   it('tests can create queries from refinement expressions involving boolean expressions', Flags.withFieldRefinementsAllowed(async () => {
@@ -600,8 +600,8 @@ val b = data.singletons["b"] as Double
     //TODO(cypher1): Implement some simple boolean simplifications.
     //This should simplify to, '(!a) && b'
     assert.strictEqual(query, `\
-val a = data.singletons["a"] as Boolean
-val b = data.singletons["b"] as Boolean
+val a = data.singletons["a"].toPrimitiveValue(Boolean::class, false)
+val b = data.singletons["b"].toPrimitiveValue(Boolean::class, false)
 (b || a) && (!a) && b`);
   }));
   it('tests can create queries where field refinement is null', async () => {
@@ -612,8 +612,8 @@ val b = data.singletons["b"] as Boolean
     const schema = manifest.particles[0].handleConnectionMap.get('input').type.getEntitySchema();
     const query = KTExtracter.fromSchema(schema, escaper);
     assert.strictEqual(query, `\
-val a = data.singletons["a"] as Boolean
-val b = data.singletons["b"] as Boolean
+val a = data.singletons["a"].toPrimitiveValue(Boolean::class, false)
+val b = data.singletons["b"].toPrimitiveValue(Boolean::class, false)
 (b && a)`);
   });
   it('tests can create queries where schema refinement is null', Flags.withFieldRefinementsAllowed(async () => {
@@ -624,8 +624,8 @@ val b = data.singletons["b"] as Boolean
     const schema = manifest.particles[0].handleConnectionMap.get('input').type.getEntitySchema();
     const query = KTExtracter.fromSchema(schema, escaper);
     assert.strictEqual(query, `\
-val a = data.singletons["a"] as Boolean
-val b = data.singletons["b"] as Boolean
+val a = data.singletons["a"].toPrimitiveValue(Boolean::class, false)
+val b = data.singletons["b"].toPrimitiveValue(Boolean::class, false)
 (!a) && b`);
   }));
   it('tests can create queries where there is no refinement', async () => {

--- a/src/tools/kotlin-generation-utils.ts
+++ b/src/tools/kotlin-generation-utils.ts
@@ -67,15 +67,15 @@ export class KotlinGenerationUtils {
    * @param items strings to join
    * @param extraIndent (optional) add other indentation when calculating line limits.
    */
-  joinWithIndents(items: string[], extraIndent: number = 0): string {
+  joinWithIndents(items: string[], extraIndent: number = 0, numberOfIndents: number = 1): string {
     const candidate = items.join(', ');
     if (extraIndent + candidate.length <= this.pref.lineLength) return candidate;
-    return `\n${this.indent(items.join(',\n'))}\n`;
+    return `\n${this.indent(items.join(',\n'), numberOfIndents)}\n${this.indent('', numberOfIndents-1)}`;
   }
 
   /** Indent a codeblock with the preferred indentation. */
-  indent(block: string): string  {
-    return leftPad(block, this.pref.indent);
+  indent(block: string, numberOfIndents: number = 1): string  {
+    return leftPad(block, this.pref.indent * numberOfIndents);
   }
 }
 

--- a/src/tools/schema2base.ts
+++ b/src/tools/schema2base.ts
@@ -12,13 +12,12 @@ import path from 'path';
 import minimist from 'minimist';
 import {Manifest} from '../runtime/manifest.js';
 import {Runtime} from '../runtime/runtime.js';
-import {Refinement} from '../runtime/refiner.js';
 import {SchemaGraph, SchemaNode} from './schema2graph.js';
 import {ParticleSpec} from '../runtime/particle-spec.js';
 
 export type AddFieldOptions = Readonly<{
   field: string;
-  typeChar: string;
+  typeName: string;
   isOptional?: boolean;
   refClassName?: string;
   isCollection?: boolean;
@@ -89,12 +88,12 @@ export abstract class Schema2Base {
         for (const [field, descriptor] of fields) {
           if (descriptor.kind === 'schema-primitive') {
             if (['Text', 'URL', 'Number', 'Boolean'].includes(descriptor.type)) {
-              generator.addField({field, typeChar: descriptor.type[0]});
+              generator.addField({field, typeName: descriptor.type});
             } else {
               throw new Error(`Schema type '${descriptor.type}' for field '${field}' is not supported`);
             }
           } else if (descriptor.kind === 'schema-reference') {
-            generator.addField({field, typeChar: 'R', refClassName: node.refs.get(field).name});
+            generator.addField({field, typeName: 'Reference', refClassName: node.refs.get(field).name});
           } else if (descriptor.kind === 'schema-collection' && descriptor.schema.kind === 'schema-reference') {
             // TODO: support collections of references
           } else if (descriptor.kind === 'schema-collection') {
@@ -102,7 +101,7 @@ export abstract class Schema2Base {
             if (!['Text', 'URL', 'Number', 'Boolean'].includes(schema.type)) {
               throw new Error(`Schema type '${schema.type}' for field '${field}' is not supported`);
             }
-            generator.addField({field, typeChar: schema.type[0], isCollection: true});
+            generator.addField({field, typeName: schema.type, isCollection: true});
           } else {
             throw new Error(`Schema kind '${descriptor.kind}' for field '${field}' is not supported`);
           }

--- a/src/tools/schema2base.ts
+++ b/src/tools/schema2base.ts
@@ -12,6 +12,7 @@ import path from 'path';
 import minimist from 'minimist';
 import {Manifest} from '../runtime/manifest.js';
 import {Runtime} from '../runtime/runtime.js';
+import {Refinement} from '../runtime/refiner.js';
 import {SchemaGraph, SchemaNode} from './schema2graph.js';
 import {ParticleSpec} from '../runtime/particle-spec.js';
 
@@ -25,6 +26,8 @@ export type AddFieldOptions = Readonly<{
 
 export interface ClassGenerator {
   addField(opts: AddFieldOptions): void;
+  escapeIdentifier(ident: string): string;
+  generatePredicates(): void;
   generate(schemaHash: string, fieldCount: number): string;
 }
 
@@ -103,6 +106,9 @@ export abstract class Schema2Base {
           } else {
             throw new Error(`Schema kind '${descriptor.kind}' for field '${field}' is not supported`);
           }
+        }
+        if (node.schema.refinement) {
+          generator.generatePredicates();
         }
         classes.push(generator.generate(await node.schema.hash(), fields.length));
       }

--- a/src/tools/schema2cpp.ts
+++ b/src/tools/schema2cpp.ts
@@ -36,11 +36,11 @@ export interface CppTypeInfo {
 }
 
 const typeMap: Dictionary<CppTypeInfo> = {
-  'Text':      {type: 'std::string',  defaultVal: ' = ""',    isString: true},
-  'URL':       {type: 'URL',          defaultVal: ' = ""',    isString: true},
-  'Number':    {type: 'double',       defaultVal: ' = 0',     isString: false},
-  'Boolean':   {type: 'bool',         defaultVal: ' = false', isString: false},
-  'Reference': {type: '',             defaultVal: ' = {}',    isString: false},
+'Text': {type: 'std::string', defaultVal: ' = ""',    isString: true},
+'URL': {type: 'URL',          defaultVal: ' = ""',    isString: true},
+'Number': {type: 'double',    defaultVal: ' = 0',     isString: false},
+'Boolean': {type: 'bool',     defaultVal: ' = false', isString: false},
+'Reference': {type: '',       defaultVal: ' = {}',    isString: false},
 };
 
 function getTypeInfo(name: string): CppTypeInfo {

--- a/src/tools/schema2cpp.ts
+++ b/src/tools/schema2cpp.ts
@@ -181,6 +181,8 @@ class CppGenerator implements ClassGenerator {
   }
 
   generatePredicates() {
+    // TODO(cypher1): Generate refinements and predicates for cpp
+    // https://github.com/PolymerLabs/arcs/issues/4884
   }
 
   generate(schemaHash: string, fieldCount: number): string {

--- a/src/tools/schema2kotlin.ts
+++ b/src/tools/schema2kotlin.ts
@@ -345,7 +345,7 @@ class ${name}_Spec() : ${this.prefixTypeForRuntime('EntitySpec')}<${name}> {
     ${!this.opts.wasm ? `
     override fun deserialize(data: RawEntity): ${name} {
         // TODO: only handles singletons for now
-        val rtn = create().copy(${withFields(`${ktUtils.joinWithIndents(this.fieldDeserializes, 32, 2)}`)})
+        val rtn = create().copy(${withFields(`${ktUtils.joinWithIndents(this.fieldDeserializes, 32, 3)}`)})
         rtn.internalId = data.id
         return rtn
     }` : ''}

--- a/src/tools/schema2kotlin.ts
+++ b/src/tools/schema2kotlin.ts
@@ -177,11 +177,9 @@ abstract class Abstract${particleName} : ${this.opts.wasm ? 'WasmParticleImpl' :
 export class KotlinGenerator implements ClassGenerator {
   fields: string[] = [];
   fieldVals: string[] = [];
-  setFields: string[] = [];
   encode: string[] = [];
   decode: string[] = [];
   fieldsReset: string[] = [];
-  getUnsetFields: string[] = [];
   fieldsForCopyDecl: string[] = [];
   fieldsForCopy: string[] = [];
   setFieldsToDefaults: string[] = [];
@@ -212,13 +210,12 @@ export class KotlinGenerator implements ClassGenerator {
 
     this.fields.push(`${fixed}: ${type} = ${defaultVal}`);
     this.fieldVals.push(
-      `var ${fixed} = ${defaultVal}\n` +
+      `var ${fixed} = ${fixed}\n` +
       `        get() = field\n` +
       `        private set(_value) {\n` +
       `            field = _value\n` +
       `        }`
     );
-    this.setFields.push(`this.${fixed} = ${fixed}`);
     this.fieldsReset.push(
       `${fixed} = ${defaultVal}`,
     );
@@ -289,17 +286,13 @@ Schema(
 
     return `\
 
-class ${name}() : ${this.getType('Entity')} {
+class ${name}(${withFields(`
+        ${this.fields.join(',\n        ')}
+    `)}) : ${this.getType('Entity')} {
 
     override var internalId = ""
 
     ${withFields(`${this.fieldVals.join('\n    ')}`)}
-
-    ${withFields(`constructor(
-        ${this.fields.join(',\n        ')}
-    ) : this() {
-        ${this.setFields.join('\n        ')}
-    }`)}
 
     fun copy(
         ${this.fieldsForCopyDecl.join(',\n        ')}

--- a/src/tools/schema2kotlin.ts
+++ b/src/tools/schema2kotlin.ts
@@ -305,22 +305,22 @@ class ${name}(${withFields(`
     }
 
     override fun equals(other: Any?): Boolean {
-      if (this === other) {
-        return true
-      }
-      
-      if (other is ${name}) {
-        if (internalId != "") {
-          return internalId == other.internalId
+        if (this === other) {
+            return true
         }
-        return toString() == other.toString()
-      }  
-      return false;
+
+        if (other is ${name}) {
+            if (internalId != "") {
+                return internalId == other.internalId
+            }
+            return toString() == other.toString()
+        }
+        return false;
     }
-    
+
     override fun hashCode(): Int =
       if (internalId != "") internalId.hashCode() else toString().hashCode()
-        
+
     override fun schemaHash() = "${schemaHash}"
 ${this.opts.wasm ? `
     override fun encodeEntity(): NullTermByteArray {

--- a/src/tools/schema2kotlin.ts
+++ b/src/tools/schema2kotlin.ts
@@ -273,11 +273,11 @@ Schema(
     const lines = leftPad(expression, 8);
     if (queryType) {
       this.query = `{ data, queryArgs ->
-        ${lines}
+${lines}
     }`;
     } else {
       this.refinement = `{ data ->
-        ${lines}
+${lines}
     }`;
     }
   }

--- a/src/tools/tests/golden.arcs
+++ b/src/tools/tests/golden.arcs
@@ -3,4 +3,5 @@
 
 particle Gold
   data: reads {num: Number, txt: Text, lnk: URL, flg: Boolean, ref: &{val: Text}}
+  qCollection: reads [People {name: Text, age: Number, lastCall: Number}[lastCall < 3*24*60*60 and name == ?]]
   alias: writes {val: Text}

--- a/src/tools/tests/golden.arcs
+++ b/src/tools/tests/golden.arcs
@@ -3,5 +3,7 @@
 
 particle Gold
   data: reads {num: Number, txt: Text, lnk: URL, flg: Boolean, ref: &{val: Text}}
+  // These are People that have a lastCall value less than three (24 hour) days ago
+  // lastCall represents the time since last phone call to/from this contact (in seconds)
   qCollection: reads [People {name: Text, age: Number, lastCall: Number}[lastCall < 3*24*60*60 and name == ?]]
   alias: writes {val: Text}

--- a/src/tools/tests/golden.arcs
+++ b/src/tools/tests/golden.arcs
@@ -5,5 +5,5 @@ particle Gold
   data: reads {num: Number, txt: Text, lnk: URL, flg: Boolean, ref: &{val: Text}}
   // These are People that have a lastCall value less than three (24 hour) days ago
   // lastCall represents the time since last phone call to/from this contact (in seconds)
-  qCollection: reads [People {name: Text, age: Number, lastCall: Number}[lastCall < 3*24*60*60 and name == ?]]
+  qCollection: reads [People {name: Text, age: Number, lastCall: Number, address: Text, favoriteColor: Text, birthDayMonth: Number, birthDayDOM: Number}[lastCall < 3*24*60*60 and name == ?]]
   alias: writes {val: Text}

--- a/src/tools/tests/goldens/generated-schemas.h
+++ b/src/tools/tests/goldens/generated-schemas.h
@@ -151,6 +151,187 @@ struct std::hash<arcs::GoldInternal1> {
 
 namespace arcs {
 
+class Gold_QCollection {
+public:
+  // Entities must be copied with arcs::clone_entity(), which will exclude the internal id.
+  // Move operations are ok (and will include the internal id).
+  Gold_QCollection() = default;
+  Gold_QCollection(Gold_QCollection&&) = default;
+  Gold_QCollection& operator=(Gold_QCollection&&) = default;
+
+  template<typename T>
+  Gold_QCollection(const T& other) :
+    name_(other.name()), name_valid_(other.has_name()),
+    age_(other.age()), age_valid_(other.has_age()),
+    lastCall_(other.lastCall()), lastCall_valid_(other.has_lastCall())
+  {}
+
+  const std::string& name() const { return name_; }
+  void set_name(const std::string& value) { name_ = value; name_valid_ = true; }
+
+  double age() const { return age_; }
+  void set_age(double value) { age_ = value; age_valid_ = true; }
+
+  double lastCall() const { return lastCall_; }
+  void set_lastCall(double value) { lastCall_ = value; lastCall_valid_ = true; }
+
+  // Equality ops compare internal ids and all data fields.
+  // Use arcs::fields_equal() to compare only the data fields.
+  bool operator==(const Gold_QCollection& other) const;
+  bool operator!=(const Gold_QCollection& other) const { return !(*this == other); }
+
+  // For STL containers.
+  friend bool operator<(const Gold_QCollection& a, const Gold_QCollection& b) {
+    if (int cmp = a._internal_id_.compare(b._internal_id_)) {
+      return cmp < 0;
+    }
+    if (0) {
+    } else if (int cmp = a.name_.compare(b.name_)) {
+      return cmp < 0;
+    }
+    if (0) {
+    } else if (a.age_ != b.age_) {
+      return a.age_ < b.age_;
+    }
+    if (0) {
+    } else if (a.lastCall_ != b.lastCall_) {
+      return a.lastCall_ < b.lastCall_;
+    }
+    return false;
+  }
+
+protected:
+  // Allow private copying for use in Handles.
+  Gold_QCollection(const Gold_QCollection&) = default;
+  Gold_QCollection& operator=(const Gold_QCollection&) = default;
+
+  static const char* _schema_hash() { return "f72d6bee9c5b13d2133e2af89a5ed591d670ee74"; }
+  static const int _field_count = 3;
+
+  std::string name_ = "";
+  bool name_valid_ = false;
+
+  double age_ = 0;
+  bool age_valid_ = false;
+
+  double lastCall_ = 0;
+  bool lastCall_valid_ = false;
+
+  std::string _internal_id_;
+
+  friend class Singleton<Gold_QCollection>;
+  friend class Collection<Gold_QCollection>;
+  friend class Ref<Gold_QCollection>;
+  friend class internal::Accessor;
+};
+
+template<>
+inline Gold_QCollection internal::Accessor::clone_entity(const Gold_QCollection& entity) {
+  Gold_QCollection clone;
+  clone.name_ = entity.name_;
+  clone.name_valid_ = entity.name_valid_;
+  clone.age_ = entity.age_;
+  clone.age_valid_ = entity.age_valid_;
+  clone.lastCall_ = entity.lastCall_;
+  clone.lastCall_valid_ = entity.lastCall_valid_;
+  return clone;
+}
+
+template<>
+inline size_t internal::Accessor::hash_entity(const Gold_QCollection& entity) {
+  size_t h = 0;
+  internal::hash_combine(h, entity._internal_id_);
+  internal::hash_combine(h, entity.name_);
+  internal::hash_combine(h, entity.age_);
+  internal::hash_combine(h, entity.lastCall_);
+  return h;
+}
+
+template<>
+inline bool internal::Accessor::fields_equal(const Gold_QCollection& a, const Gold_QCollection& b) {
+  return (a.name_ == b.name_) &&
+         (a.age_ == b.age_) &&
+         (a.lastCall_ == b.lastCall_);
+}
+
+inline bool Gold_QCollection::operator==(const Gold_QCollection& other) const {
+  return _internal_id_ == other._internal_id_ && fields_equal(*this, other);
+}
+
+template<>
+inline std::string internal::Accessor::entity_to_str(const Gold_QCollection& entity, const char* join, bool with_id) {
+  internal::StringPrinter printer;
+  if (with_id) {
+    printer.addId(entity._internal_id_);
+  }
+  if (entity.name_valid_) printer.add("name: ", entity.name_);
+  if (entity.age_valid_) printer.add("age: ", entity.age_);
+  if (entity.lastCall_valid_) printer.add("lastCall: ", entity.lastCall_);
+  return printer.result(join);
+}
+
+template<>
+inline void internal::Accessor::decode_entity(Gold_QCollection* entity, const char* str) {
+  if (str == nullptr) return;
+  internal::StringDecoder decoder(str);
+  decoder.decode(entity->_internal_id_);
+  decoder.validate("|");
+  for (int i = 0; !decoder.done() && i < Gold_QCollection::_field_count; i++) {
+    std::string name = decoder.upTo(':');
+    if (0) {
+    } else if (name == "name") {
+      decoder.validate("T");
+      decoder.decode(entity->name_);
+      entity->name_valid_ = true;
+    } else if (name == "age") {
+      decoder.validate("N");
+      decoder.decode(entity->age_);
+      entity->age_valid_ = true;
+    } else if (name == "lastCall") {
+      decoder.validate("N");
+      decoder.decode(entity->lastCall_);
+      entity->lastCall_valid_ = true;
+    } else {
+      // Ignore unknown fields until type slicing is fully implemented.
+      std::string typeChar = decoder.chomp(1);
+      if (typeChar == "T" || typeChar == "U") {
+        std::string s;
+        decoder.decode(s);
+      } else if (typeChar == "N") {
+        double d;
+        decoder.decode(d);
+      } else if (typeChar == "B") {
+        bool b;
+        decoder.decode(b);
+      }
+      i--;
+    }
+    decoder.validate("|");
+  }
+}
+
+template<>
+inline std::string internal::Accessor::encode_entity(const Gold_QCollection& entity) {
+  internal::StringEncoder encoder;
+  encoder.encode("", entity._internal_id_);
+  encoder.encode("name:T", entity.name_);
+  encoder.encode("age:N", entity.age_);
+  encoder.encode("lastCall:N", entity.lastCall_);
+  return encoder.result();
+}
+
+}  // namespace arcs
+
+// For STL unordered associative containers. Entities will need to be std::move()-inserted.
+template<>
+struct std::hash<arcs::Gold_QCollection> {
+  size_t operator()(const arcs::Gold_QCollection& entity) const {
+    return arcs::hash_entity(entity);
+  }
+};
+
+namespace arcs {
+
 class Gold_Data {
 public:
   // Entities must be copied with arcs::clone_entity(), which will exclude the internal id.
@@ -375,6 +556,7 @@ struct std::hash<arcs::Gold_Data> {
 class AbstractGold : public arcs::Particle {
 protected:
   arcs::Singleton<arcs::Gold_Data> data_{this, "data"};
+  arcs::Collection<arcs::Gold_QCollection> qCollection_{this, "qCollection"};
   arcs::Singleton<arcs::Gold_Alias> alias_{this, "alias"};
 };
 

--- a/src/tools/tests/goldens/generated-schemas.h
+++ b/src/tools/tests/goldens/generated-schemas.h
@@ -163,7 +163,11 @@ public:
   Gold_QCollection(const T& other) :
     name_(other.name()), name_valid_(other.has_name()),
     age_(other.age()), age_valid_(other.has_age()),
-    lastCall_(other.lastCall()), lastCall_valid_(other.has_lastCall())
+    lastCall_(other.lastCall()), lastCall_valid_(other.has_lastCall()),
+    address_(other.address()), address_valid_(other.has_address()),
+    favoriteColor_(other.favoriteColor()), favoriteColor_valid_(other.has_favoriteColor()),
+    birthDayMonth_(other.birthDayMonth()), birthDayMonth_valid_(other.has_birthDayMonth()),
+    birthDayDOM_(other.birthDayDOM()), birthDayDOM_valid_(other.has_birthDayDOM())
   {}
 
   const std::string& name() const { return name_; }
@@ -174,6 +178,18 @@ public:
 
   double lastCall() const { return lastCall_; }
   void set_lastCall(double value) { lastCall_ = value; lastCall_valid_ = true; }
+
+  const std::string& address() const { return address_; }
+  void set_address(const std::string& value) { address_ = value; address_valid_ = true; }
+
+  const std::string& favoriteColor() const { return favoriteColor_; }
+  void set_favoriteColor(const std::string& value) { favoriteColor_ = value; favoriteColor_valid_ = true; }
+
+  double birthDayMonth() const { return birthDayMonth_; }
+  void set_birthDayMonth(double value) { birthDayMonth_ = value; birthDayMonth_valid_ = true; }
+
+  double birthDayDOM() const { return birthDayDOM_; }
+  void set_birthDayDOM(double value) { birthDayDOM_ = value; birthDayDOM_valid_ = true; }
 
   // Equality ops compare internal ids and all data fields.
   // Use arcs::fields_equal() to compare only the data fields.
@@ -197,6 +213,22 @@ public:
     } else if (a.lastCall_ != b.lastCall_) {
       return a.lastCall_ < b.lastCall_;
     }
+    if (0) {
+    } else if (int cmp = a.address_.compare(b.address_)) {
+      return cmp < 0;
+    }
+    if (0) {
+    } else if (int cmp = a.favoriteColor_.compare(b.favoriteColor_)) {
+      return cmp < 0;
+    }
+    if (0) {
+    } else if (a.birthDayMonth_ != b.birthDayMonth_) {
+      return a.birthDayMonth_ < b.birthDayMonth_;
+    }
+    if (0) {
+    } else if (a.birthDayDOM_ != b.birthDayDOM_) {
+      return a.birthDayDOM_ < b.birthDayDOM_;
+    }
     return false;
   }
 
@@ -205,8 +237,8 @@ protected:
   Gold_QCollection(const Gold_QCollection&) = default;
   Gold_QCollection& operator=(const Gold_QCollection&) = default;
 
-  static const char* _schema_hash() { return "f72d6bee9c5b13d2133e2af89a5ed591d670ee74"; }
-  static const int _field_count = 3;
+  static const char* _schema_hash() { return "ccd14452cc01e1b00b94cdb25bfe34a5a632daaa"; }
+  static const int _field_count = 7;
 
   std::string name_ = "";
   bool name_valid_ = false;
@@ -216,6 +248,18 @@ protected:
 
   double lastCall_ = 0;
   bool lastCall_valid_ = false;
+
+  std::string address_ = "";
+  bool address_valid_ = false;
+
+  std::string favoriteColor_ = "";
+  bool favoriteColor_valid_ = false;
+
+  double birthDayMonth_ = 0;
+  bool birthDayMonth_valid_ = false;
+
+  double birthDayDOM_ = 0;
+  bool birthDayDOM_valid_ = false;
 
   std::string _internal_id_;
 
@@ -234,6 +278,14 @@ inline Gold_QCollection internal::Accessor::clone_entity(const Gold_QCollection&
   clone.age_valid_ = entity.age_valid_;
   clone.lastCall_ = entity.lastCall_;
   clone.lastCall_valid_ = entity.lastCall_valid_;
+  clone.address_ = entity.address_;
+  clone.address_valid_ = entity.address_valid_;
+  clone.favoriteColor_ = entity.favoriteColor_;
+  clone.favoriteColor_valid_ = entity.favoriteColor_valid_;
+  clone.birthDayMonth_ = entity.birthDayMonth_;
+  clone.birthDayMonth_valid_ = entity.birthDayMonth_valid_;
+  clone.birthDayDOM_ = entity.birthDayDOM_;
+  clone.birthDayDOM_valid_ = entity.birthDayDOM_valid_;
   return clone;
 }
 
@@ -244,6 +296,10 @@ inline size_t internal::Accessor::hash_entity(const Gold_QCollection& entity) {
   internal::hash_combine(h, entity.name_);
   internal::hash_combine(h, entity.age_);
   internal::hash_combine(h, entity.lastCall_);
+  internal::hash_combine(h, entity.address_);
+  internal::hash_combine(h, entity.favoriteColor_);
+  internal::hash_combine(h, entity.birthDayMonth_);
+  internal::hash_combine(h, entity.birthDayDOM_);
   return h;
 }
 
@@ -251,7 +307,11 @@ template<>
 inline bool internal::Accessor::fields_equal(const Gold_QCollection& a, const Gold_QCollection& b) {
   return (a.name_ == b.name_) &&
          (a.age_ == b.age_) &&
-         (a.lastCall_ == b.lastCall_);
+         (a.lastCall_ == b.lastCall_) &&
+         (a.address_ == b.address_) &&
+         (a.favoriteColor_ == b.favoriteColor_) &&
+         (a.birthDayMonth_ == b.birthDayMonth_) &&
+         (a.birthDayDOM_ == b.birthDayDOM_);
 }
 
 inline bool Gold_QCollection::operator==(const Gold_QCollection& other) const {
@@ -267,6 +327,10 @@ inline std::string internal::Accessor::entity_to_str(const Gold_QCollection& ent
   if (entity.name_valid_) printer.add("name: ", entity.name_);
   if (entity.age_valid_) printer.add("age: ", entity.age_);
   if (entity.lastCall_valid_) printer.add("lastCall: ", entity.lastCall_);
+  if (entity.address_valid_) printer.add("address: ", entity.address_);
+  if (entity.favoriteColor_valid_) printer.add("favoriteColor: ", entity.favoriteColor_);
+  if (entity.birthDayMonth_valid_) printer.add("birthDayMonth: ", entity.birthDayMonth_);
+  if (entity.birthDayDOM_valid_) printer.add("birthDayDOM: ", entity.birthDayDOM_);
   return printer.result(join);
 }
 
@@ -291,6 +355,22 @@ inline void internal::Accessor::decode_entity(Gold_QCollection* entity, const ch
       decoder.validate("N");
       decoder.decode(entity->lastCall_);
       entity->lastCall_valid_ = true;
+    } else if (name == "address") {
+      decoder.validate("T");
+      decoder.decode(entity->address_);
+      entity->address_valid_ = true;
+    } else if (name == "favoriteColor") {
+      decoder.validate("T");
+      decoder.decode(entity->favoriteColor_);
+      entity->favoriteColor_valid_ = true;
+    } else if (name == "birthDayMonth") {
+      decoder.validate("N");
+      decoder.decode(entity->birthDayMonth_);
+      entity->birthDayMonth_valid_ = true;
+    } else if (name == "birthDayDOM") {
+      decoder.validate("N");
+      decoder.decode(entity->birthDayDOM_);
+      entity->birthDayDOM_valid_ = true;
     } else {
       // Ignore unknown fields until type slicing is fully implemented.
       std::string typeChar = decoder.chomp(1);
@@ -317,6 +397,10 @@ inline std::string internal::Accessor::encode_entity(const Gold_QCollection& ent
   encoder.encode("name:T", entity.name_);
   encoder.encode("age:N", entity.age_);
   encoder.encode("lastCall:N", entity.lastCall_);
+  encoder.encode("address:T", entity.address_);
+  encoder.encode("favoriteColor:T", entity.favoriteColor_);
+  encoder.encode("birthDayMonth:N", entity.birthDayMonth_);
+  encoder.encode("birthDayDOM:N", entity.birthDayDOM_);
   return encoder.result();
 }
 

--- a/src/tools/tests/goldens/generated-schemas.jvm.kt
+++ b/src/tools/tests/goldens/generated-schemas.jvm.kt
@@ -79,8 +79,12 @@ class GoldInternal1_Spec() : EntitySpec<GoldInternal1> {
                 singletons = mapOf("val" to FieldType.Text),
                 collections = emptyMap()
             ),
-            "485712110d89359a3e539dac987329cd2649d889"
-        )
+            "485712110d89359a3e539dac987329cd2649d889",
+            refinement = { _ ->
+                true
+            },
+            query = null
+          )
 
         init {
             SchemaRegistry.register(schema)
@@ -106,6 +110,131 @@ typealias Gold_Data_Ref = GoldInternal1
 typealias Gold_Data_Ref_Spec = GoldInternal1_Spec
 typealias Gold_Alias = GoldInternal1
 typealias Gold_Alias_Spec = GoldInternal1_Spec
+
+class Gold_QCollection() : Entity {
+
+    override var internalId = ""
+
+    var name = ""
+        get() = field
+        private set(_value) {
+            field = _value
+        }
+    var age = 0.0
+        get() = field
+        private set(_value) {
+            field = _value
+        }
+    var lastCall = 0.0
+        get() = field
+        private set(_value) {
+            field = _value
+        }
+
+    constructor(
+        name: String = "",
+        age: Double = 0.0,
+        lastCall: Double = 0.0
+    ) : this() {
+        this.name = name
+        this.age = age
+        this.lastCall = lastCall
+    }
+
+    fun copy(
+        name: String = this.name,
+        age: Double = this.age,
+        lastCall: Double = this.lastCall
+    ) = Gold_QCollection(
+        name = name,
+        age = age,
+        lastCall = lastCall
+    )
+
+    fun reset() {
+        name = ""
+        age = 0.0
+        lastCall = 0.0
+    }
+
+    override fun equals(other: Any?): Boolean {
+      if (this === other) {
+        return true
+      }
+
+      if (other is Gold_QCollection) {
+        if (internalId != "") {
+          return internalId == other.internalId
+        }
+        return toString() == other.toString()
+      }
+      return false;
+    }
+
+    override fun hashCode(): Int =
+      if (internalId != "") internalId.hashCode() else toString().hashCode()
+
+    override fun schemaHash() = "f72d6bee9c5b13d2133e2af89a5ed591d670ee74"
+
+    override fun serialize() = RawEntity(
+        internalId,
+        mapOf(
+            "name" to name.toReferencable(),
+            "age" to age.toReferencable(),
+            "lastCall" to lastCall.toReferencable()
+        )
+    )
+
+    override fun toString() = "Gold_QCollection(name = $name, age = $age, lastCall = $lastCall)"
+}
+
+class Gold_QCollection_Spec() : EntitySpec<Gold_QCollection> {
+
+    companion object {
+        val schema = Schema(
+            listOf(SchemaName("People")),
+            SchemaFields(
+                singletons = mapOf(
+                    "name" to FieldType.Text,
+                    "age" to FieldType.Number,
+                    "lastCall" to FieldType.Number
+                ),
+                collections = emptyMap()
+            ),
+            "f72d6bee9c5b13d2133e2af89a5ed591d670ee74",
+            refinement = { _ ->
+                true
+            },
+            query = { data, queryArgs ->
+                val lastCall = data.singletons["lastCall"] as Double
+                val name = data.singletons["name"] as String
+                val queryArgument = queryArgs as String
+                ((lastCall < 259200) && (name == queryArgument))
+            }
+          )
+
+        init {
+            SchemaRegistry.register(schema)
+        }
+    }
+
+    override fun schema() = schema
+
+    override fun create() = Gold_QCollection()
+
+    override fun deserialize(data: RawEntity): Gold_QCollection {
+      // TODO: only handles singletons for now
+      val rtn = create().copy(
+        name = data.singletons["name"].toPrimitiveValue(String::class, ""),
+        age = data.singletons["age"].toPrimitiveValue(Double::class, 0.0),
+        lastCall = data.singletons["lastCall"].toPrimitiveValue(Double::class, 0.0)
+      )
+      rtn.internalId = data.id
+      return rtn
+    }
+
+}
+
 
 class Gold_Data() : Entity {
 
@@ -209,8 +338,12 @@ class Gold_Data_Spec() : EntitySpec<Gold_Data> {
                 ),
                 collections = emptyMap()
             ),
-            "d8058d336e472da47b289eafb39733f77eadb111"
-        )
+            "d8058d336e472da47b289eafb39733f77eadb111",
+            refinement = { _ ->
+                true
+            },
+            query = null
+          )
 
         init {
             SchemaRegistry.register(schema)
@@ -240,10 +373,12 @@ class GoldHandles : HandleHolderBase(
     "Gold",
     mapOf(
         "data" to Gold_Data_Spec(),
+        "qCollection" to Gold_QCollection_Spec(),
         "alias" to Gold_Alias_Spec()
     )
 ) {
     val data: ReadSingletonHandle<Gold_Data> by handles
+    val qCollection: ReadQueryCollectionHandle<Gold_QCollection, String> by handles
     val alias: WriteSingletonHandle<Gold_Alias> by handles
 }
 

--- a/src/tools/tests/goldens/generated-schemas.jvm.kt
+++ b/src/tools/tests/goldens/generated-schemas.jvm.kt
@@ -214,14 +214,14 @@ class Gold_QCollection_Spec() : EntitySpec<Gold_QCollection> {
     override fun deserialize(data: RawEntity): Gold_QCollection {
         // TODO: only handles singletons for now
         val rtn = create().copy(
-        name = data.singletons["name"].toPrimitiveValue(String::class, ""),
-        age = data.singletons["age"].toPrimitiveValue(Double::class, 0.0),
-        lastCall = data.singletons["lastCall"].toPrimitiveValue(Double::class, 0.0),
-        address = data.singletons["address"].toPrimitiveValue(String::class, ""),
-        favoriteColor = data.singletons["favoriteColor"].toPrimitiveValue(String::class, ""),
-        birthDayMonth = data.singletons["birthDayMonth"].toPrimitiveValue(Double::class, 0.0),
-        birthDayDOM = data.singletons["birthDayDOM"].toPrimitiveValue(Double::class, 0.0)
-    )
+            name = data.singletons["name"].toPrimitiveValue(String::class, ""),
+            age = data.singletons["age"].toPrimitiveValue(Double::class, 0.0),
+            lastCall = data.singletons["lastCall"].toPrimitiveValue(Double::class, 0.0),
+            address = data.singletons["address"].toPrimitiveValue(String::class, ""),
+            favoriteColor = data.singletons["favoriteColor"].toPrimitiveValue(String::class, ""),
+            birthDayMonth = data.singletons["birthDayMonth"].toPrimitiveValue(Double::class, 0.0),
+            birthDayDOM = data.singletons["birthDayDOM"].toPrimitiveValue(Double::class, 0.0)
+        )
         rtn.internalId = data.id
         return rtn
     }
@@ -344,11 +344,11 @@ class Gold_Data_Spec() : EntitySpec<Gold_Data> {
     override fun deserialize(data: RawEntity): Gold_Data {
         // TODO: only handles singletons for now
         val rtn = create().copy(
-        num = data.singletons["num"].toPrimitiveValue(Double::class, 0.0),
-        txt = data.singletons["txt"].toPrimitiveValue(String::class, ""),
-        lnk = data.singletons["lnk"].toPrimitiveValue(String::class, ""),
-        flg = data.singletons["flg"].toPrimitiveValue(Boolean::class, false)
-    )
+            num = data.singletons["num"].toPrimitiveValue(Double::class, 0.0),
+            txt = data.singletons["txt"].toPrimitiveValue(String::class, ""),
+            lnk = data.singletons["lnk"].toPrimitiveValue(String::class, ""),
+            flg = data.singletons["flg"].toPrimitiveValue(Boolean::class, false)
+        )
         rtn.internalId = data.id
         return rtn
     }

--- a/src/tools/tests/goldens/generated-schemas.jvm.kt
+++ b/src/tools/tests/goldens/generated-schemas.jvm.kt
@@ -15,9 +15,7 @@ import arcs.core.data.util.toReferencable
 import arcs.core.data.util.ReferencablePrimitive
 import arcs.core.storage.api.toPrimitiveValue
 
-class GoldInternal1(
-        val_: String = ""
-    ) : Entity {
+class GoldInternal1(val_: String = "") : Entity {
 
     override var internalId = ""
 
@@ -27,11 +25,7 @@ class GoldInternal1(
             field = _value
         }
 
-    fun copy(
-        val_: String = this.val_
-    ) = GoldInternal1(
-        val_ = val_
-    )
+    fun copy(val_: String = this.val_) = GoldInternal1(val_ = val_)
 
     fun reset() {
         val_ = ""
@@ -43,63 +37,57 @@ class GoldInternal1(
         }
 
         if (other is GoldInternal1) {
-            if (internalId != "") {
+            if (internalId.isNotEmpty()) {
                 return internalId == other.internalId
             }
             return toString() == other.toString()
-        }
+       }
         return false;
     }
 
     override fun hashCode(): Int =
-      if (internalId != "") internalId.hashCode() else toString().hashCode()
+        if (internalId.isNotEmpty()) internalId.hashCode() else toString().hashCode()
 
     override fun schemaHash() = "485712110d89359a3e539dac987329cd2649d889"
 
     override fun serialize() = RawEntity(
         internalId,
-        mapOf(
-            "val" to val_.toReferencable()
-        )
+        mapOf("val" to val_.toReferencable())
     )
 
-    override fun toString() = "GoldInternal1(val_ = $val_)"
+    override fun toString() =
+      "GoldInternal1(val_ = $val_)"
 }
 
 class GoldInternal1_Spec() : EntitySpec<GoldInternal1> {
 
+    override fun create() = GoldInternal1()
+
+    override fun deserialize(data: RawEntity): GoldInternal1 {
+        // TODO: only handles singletons for now
+        val rtn = create().copy(val_ = data.singletons["val_"].toPrimitiveValue(String::class, ""))
+        rtn.internalId = data.id
+        return rtn
+    }
+
+    override fun schema() = SCHEMA
+
     companion object {
-        val schema = Schema(
+        val SCHEMA = Schema(
             listOf(),
             SchemaFields(
                 singletons = mapOf("val" to FieldType.Text),
                 collections = emptyMap()
             ),
             "485712110d89359a3e539dac987329cd2649d889",
-            refinement = { _ ->
-                true
-            },
+            refinement = { _ -> true },
             query = null
           )
 
         init {
-            SchemaRegistry.register(schema)
+            SchemaRegistry.register(SCHEMA)
         }
     }
-
-    override fun schema() = schema
-
-    override fun create() = GoldInternal1()
-
-    override fun deserialize(data: RawEntity): GoldInternal1 {
-      // TODO: only handles singletons for now
-      val rtn = create().copy(
-        val_ = data.singletons["val_"].toPrimitiveValue(String::class, "")
-      )
-      rtn.internalId = data.id
-      return rtn
-    }
-
 }
 
 typealias Gold_Data_Ref = GoldInternal1
@@ -108,10 +96,14 @@ typealias Gold_Alias = GoldInternal1
 typealias Gold_Alias_Spec = GoldInternal1_Spec
 
 class Gold_QCollection(
-        name: String = "",
-        age: Double = 0.0,
-        lastCall: Double = 0.0
-    ) : Entity {
+    name: String = "",
+    age: Double = 0.0,
+    lastCall: Double = 0.0,
+    address: String = "",
+    favoriteColor: String = "",
+    birthDayMonth: Double = 0.0,
+    birthDayDOM: Double = 0.0
+) : Entity {
 
     override var internalId = ""
 
@@ -130,21 +122,53 @@ class Gold_QCollection(
         private set(_value) {
             field = _value
         }
+    var address = address
+        get() = field
+        private set(_value) {
+            field = _value
+        }
+    var favoriteColor = favoriteColor
+        get() = field
+        private set(_value) {
+            field = _value
+        }
+    var birthDayMonth = birthDayMonth
+        get() = field
+        private set(_value) {
+            field = _value
+        }
+    var birthDayDOM = birthDayDOM
+        get() = field
+        private set(_value) {
+            field = _value
+        }
 
     fun copy(
         name: String = this.name,
         age: Double = this.age,
-        lastCall: Double = this.lastCall
+        lastCall: Double = this.lastCall,
+        address: String = this.address,
+        favoriteColor: String = this.favoriteColor,
+        birthDayMonth: Double = this.birthDayMonth,
+        birthDayDOM: Double = this.birthDayDOM
     ) = Gold_QCollection(
         name = name,
         age = age,
-        lastCall = lastCall
+        lastCall = lastCall,
+        address = address,
+        favoriteColor = favoriteColor,
+        birthDayMonth = birthDayMonth,
+        birthDayDOM = birthDayDOM
     )
 
     fun reset() {
         name = ""
         age = 0.0
         lastCall = 0.0
+        address = ""
+        favoriteColor = ""
+        birthDayMonth = 0.0
+        birthDayDOM = 0.0
     }
 
     override fun equals(other: Any?): Boolean {
@@ -153,50 +177,76 @@ class Gold_QCollection(
         }
 
         if (other is Gold_QCollection) {
-            if (internalId != "") {
+            if (internalId.isNotEmpty()) {
                 return internalId == other.internalId
             }
             return toString() == other.toString()
-        }
+       }
         return false;
     }
 
     override fun hashCode(): Int =
-      if (internalId != "") internalId.hashCode() else toString().hashCode()
+        if (internalId.isNotEmpty()) internalId.hashCode() else toString().hashCode()
 
-    override fun schemaHash() = "f72d6bee9c5b13d2133e2af89a5ed591d670ee74"
+    override fun schemaHash() = "ccd14452cc01e1b00b94cdb25bfe34a5a632daaa"
 
     override fun serialize() = RawEntity(
         internalId,
         mapOf(
             "name" to name.toReferencable(),
             "age" to age.toReferencable(),
-            "lastCall" to lastCall.toReferencable()
+            "lastCall" to lastCall.toReferencable(),
+            "address" to address.toReferencable(),
+            "favoriteColor" to favoriteColor.toReferencable(),
+            "birthDayMonth" to birthDayMonth.toReferencable(),
+            "birthDayDOM" to birthDayDOM.toReferencable()
         )
     )
 
-    override fun toString() = "Gold_QCollection(name = $name, age = $age, lastCall = $lastCall)"
+    override fun toString() =
+      "Gold_QCollection(name = $name, age = $age, lastCall = $lastCall, address = $address, favoriteColor = $favoriteColor, birthDayMonth = $birthDayMonth, birthDayDOM = $birthDayDOM)"
 }
 
 class Gold_QCollection_Spec() : EntitySpec<Gold_QCollection> {
 
+    override fun create() = Gold_QCollection()
+
+    override fun deserialize(data: RawEntity): Gold_QCollection {
+        // TODO: only handles singletons for now
+        val rtn = create().copy(
+        name = data.singletons["name"].toPrimitiveValue(String::class, ""),
+        age = data.singletons["age"].toPrimitiveValue(Double::class, 0.0),
+        lastCall = data.singletons["lastCall"].toPrimitiveValue(Double::class, 0.0),
+        address = data.singletons["address"].toPrimitiveValue(String::class, ""),
+        favoriteColor = data.singletons["favoriteColor"].toPrimitiveValue(String::class, ""),
+        birthDayMonth = data.singletons["birthDayMonth"].toPrimitiveValue(Double::class, 0.0),
+        birthDayDOM = data.singletons["birthDayDOM"].toPrimitiveValue(Double::class, 0.0)
+    )
+        rtn.internalId = data.id
+        return rtn
+    }
+
+    override fun schema() = SCHEMA
+
     companion object {
-        val schema = Schema(
+        val SCHEMA = Schema(
             listOf(SchemaName("People")),
             SchemaFields(
                 singletons = mapOf(
                     "name" to FieldType.Text,
                     "age" to FieldType.Number,
-                    "lastCall" to FieldType.Number
+                    "lastCall" to FieldType.Number,
+                    "address" to FieldType.Text,
+                    "favoriteColor" to FieldType.Text,
+                    "birthDayMonth" to FieldType.Number,
+                    "birthDayDOM" to FieldType.Number
                 ),
                 collections = emptyMap()
             ),
-            "f72d6bee9c5b13d2133e2af89a5ed591d670ee74",
-            refinement = { _ ->
-                true
-            },
+            "ccd14452cc01e1b00b94cdb25bfe34a5a632daaa",
+            refinement = { _ -> true },
             query = { data, queryArgs ->
-                val lastCall = data.singletons["lastCall"] as Double
+                        val lastCall = data.singletons["lastCall"] as Double
                 val name = data.singletons["name"] as String
                 val queryArgument = queryArgs as String
                 ((lastCall < 259200) && (name == queryArgument))
@@ -204,34 +254,18 @@ class Gold_QCollection_Spec() : EntitySpec<Gold_QCollection> {
           )
 
         init {
-            SchemaRegistry.register(schema)
+            SchemaRegistry.register(SCHEMA)
         }
     }
-
-    override fun schema() = schema
-
-    override fun create() = Gold_QCollection()
-
-    override fun deserialize(data: RawEntity): Gold_QCollection {
-      // TODO: only handles singletons for now
-      val rtn = create().copy(
-        name = data.singletons["name"].toPrimitiveValue(String::class, ""),
-        age = data.singletons["age"].toPrimitiveValue(Double::class, 0.0),
-        lastCall = data.singletons["lastCall"].toPrimitiveValue(Double::class, 0.0)
-      )
-      rtn.internalId = data.id
-      return rtn
-    }
-
 }
 
 
 class Gold_Data(
-        num: Double = 0.0,
-        txt: String = "",
-        lnk: String = "",
-        flg: Boolean = false
-    ) : Entity {
+    num: Double = 0.0,
+    txt: String = "",
+    lnk: String = "",
+    flg: Boolean = false
+) : Entity {
 
     override var internalId = ""
 
@@ -261,12 +295,7 @@ class Gold_Data(
         txt: String = this.txt,
         lnk: String = this.lnk,
         flg: Boolean = this.flg
-    ) = Gold_Data(
-        num = num,
-        txt = txt,
-        lnk = lnk,
-        flg = flg
-    )
+    ) = Gold_Data(num = num, txt = txt, lnk = lnk, flg = flg)
 
     fun reset() {
         num = 0.0
@@ -281,16 +310,16 @@ class Gold_Data(
         }
 
         if (other is Gold_Data) {
-            if (internalId != "") {
+            if (internalId.isNotEmpty()) {
                 return internalId == other.internalId
             }
             return toString() == other.toString()
-        }
+       }
         return false;
     }
 
     override fun hashCode(): Int =
-      if (internalId != "") internalId.hashCode() else toString().hashCode()
+        if (internalId.isNotEmpty()) internalId.hashCode() else toString().hashCode()
 
     override fun schemaHash() = "d8058d336e472da47b289eafb39733f77eadb111"
 
@@ -304,13 +333,30 @@ class Gold_Data(
         )
     )
 
-    override fun toString() = "Gold_Data(num = $num, txt = $txt, lnk = $lnk, flg = $flg)"
+    override fun toString() =
+      "Gold_Data(num = $num, txt = $txt, lnk = $lnk, flg = $flg)"
 }
 
 class Gold_Data_Spec() : EntitySpec<Gold_Data> {
 
+    override fun create() = Gold_Data()
+
+    override fun deserialize(data: RawEntity): Gold_Data {
+        // TODO: only handles singletons for now
+        val rtn = create().copy(
+        num = data.singletons["num"].toPrimitiveValue(Double::class, 0.0),
+        txt = data.singletons["txt"].toPrimitiveValue(String::class, ""),
+        lnk = data.singletons["lnk"].toPrimitiveValue(String::class, ""),
+        flg = data.singletons["flg"].toPrimitiveValue(Boolean::class, false)
+    )
+        rtn.internalId = data.id
+        return rtn
+    }
+
+    override fun schema() = SCHEMA
+
     companion object {
-        val schema = Schema(
+        val SCHEMA = Schema(
             listOf(),
             SchemaFields(
                 singletons = mapOf(
@@ -322,33 +368,14 @@ class Gold_Data_Spec() : EntitySpec<Gold_Data> {
                 collections = emptyMap()
             ),
             "d8058d336e472da47b289eafb39733f77eadb111",
-            refinement = { _ ->
-                true
-            },
+            refinement = { _ -> true },
             query = null
           )
 
         init {
-            SchemaRegistry.register(schema)
+            SchemaRegistry.register(SCHEMA)
         }
     }
-
-    override fun schema() = schema
-
-    override fun create() = Gold_Data()
-
-    override fun deserialize(data: RawEntity): Gold_Data {
-      // TODO: only handles singletons for now
-      val rtn = create().copy(
-        num = data.singletons["num"].toPrimitiveValue(Double::class, 0.0),
-        txt = data.singletons["txt"].toPrimitiveValue(String::class, ""),
-        lnk = data.singletons["lnk"].toPrimitiveValue(String::class, ""),
-        flg = data.singletons["flg"].toPrimitiveValue(Boolean::class, false)
-      )
-      rtn.internalId = data.id
-      return rtn
-    }
-
 }
 
 

--- a/src/tools/tests/goldens/generated-schemas.jvm.kt
+++ b/src/tools/tests/goldens/generated-schemas.jvm.kt
@@ -246,8 +246,8 @@ class Gold_QCollection_Spec() : EntitySpec<Gold_QCollection> {
             "ccd14452cc01e1b00b94cdb25bfe34a5a632daaa",
             refinement = { _ -> true },
             query = { data, queryArgs ->
-                        val lastCall = data.singletons["lastCall"] as Double
-                val name = data.singletons["name"] as String
+                val lastCall = data.singletons["lastCall"].toPrimitiveValue(Double::class, 0.0)
+                val name = data.singletons["name"].toPrimitiveValue(String::class, "")
                 val queryArgument = queryArgs as String
                 ((lastCall < 259200) && (name == queryArgument))
             }

--- a/src/tools/tests/goldens/generated-schemas.jvm.kt
+++ b/src/tools/tests/goldens/generated-schemas.jvm.kt
@@ -15,21 +15,17 @@ import arcs.core.data.util.toReferencable
 import arcs.core.data.util.ReferencablePrimitive
 import arcs.core.storage.api.toPrimitiveValue
 
-class GoldInternal1() : Entity {
+class GoldInternal1(
+        val_: String = ""
+    ) : Entity {
 
     override var internalId = ""
 
-    var val_ = ""
+    var val_ = val_
         get() = field
         private set(_value) {
             field = _value
         }
-
-    constructor(
-        val_: String = ""
-    ) : this() {
-        this.val_ = val_
-    }
 
     fun copy(
         val_: String = this.val_
@@ -42,17 +38,17 @@ class GoldInternal1() : Entity {
     }
 
     override fun equals(other: Any?): Boolean {
-      if (this === other) {
-        return true
-      }
-
-      if (other is GoldInternal1) {
-        if (internalId != "") {
-          return internalId == other.internalId
+        if (this === other) {
+            return true
         }
-        return toString() == other.toString()
-      }
-      return false;
+
+        if (other is GoldInternal1) {
+            if (internalId != "") {
+                return internalId == other.internalId
+            }
+            return toString() == other.toString()
+        }
+        return false;
     }
 
     override fun hashCode(): Int =
@@ -111,35 +107,29 @@ typealias Gold_Data_Ref_Spec = GoldInternal1_Spec
 typealias Gold_Alias = GoldInternal1
 typealias Gold_Alias_Spec = GoldInternal1_Spec
 
-class Gold_QCollection() : Entity {
-
-    override var internalId = ""
-
-    var name = ""
-        get() = field
-        private set(_value) {
-            field = _value
-        }
-    var age = 0.0
-        get() = field
-        private set(_value) {
-            field = _value
-        }
-    var lastCall = 0.0
-        get() = field
-        private set(_value) {
-            field = _value
-        }
-
-    constructor(
+class Gold_QCollection(
         name: String = "",
         age: Double = 0.0,
         lastCall: Double = 0.0
-    ) : this() {
-        this.name = name
-        this.age = age
-        this.lastCall = lastCall
-    }
+    ) : Entity {
+
+    override var internalId = ""
+
+    var name = name
+        get() = field
+        private set(_value) {
+            field = _value
+        }
+    var age = age
+        get() = field
+        private set(_value) {
+            field = _value
+        }
+    var lastCall = lastCall
+        get() = field
+        private set(_value) {
+            field = _value
+        }
 
     fun copy(
         name: String = this.name,
@@ -158,17 +148,17 @@ class Gold_QCollection() : Entity {
     }
 
     override fun equals(other: Any?): Boolean {
-      if (this === other) {
-        return true
-      }
-
-      if (other is Gold_QCollection) {
-        if (internalId != "") {
-          return internalId == other.internalId
+        if (this === other) {
+            return true
         }
-        return toString() == other.toString()
-      }
-      return false;
+
+        if (other is Gold_QCollection) {
+            if (internalId != "") {
+                return internalId == other.internalId
+            }
+            return toString() == other.toString()
+        }
+        return false;
     }
 
     override fun hashCode(): Int =
@@ -236,42 +226,35 @@ class Gold_QCollection_Spec() : EntitySpec<Gold_QCollection> {
 }
 
 
-class Gold_Data() : Entity {
-
-    override var internalId = ""
-
-    var num = 0.0
-        get() = field
-        private set(_value) {
-            field = _value
-        }
-    var txt = ""
-        get() = field
-        private set(_value) {
-            field = _value
-        }
-    var lnk = ""
-        get() = field
-        private set(_value) {
-            field = _value
-        }
-    var flg = false
-        get() = field
-        private set(_value) {
-            field = _value
-        }
-
-    constructor(
+class Gold_Data(
         num: Double = 0.0,
         txt: String = "",
         lnk: String = "",
         flg: Boolean = false
-    ) : this() {
-        this.num = num
-        this.txt = txt
-        this.lnk = lnk
-        this.flg = flg
-    }
+    ) : Entity {
+
+    override var internalId = ""
+
+    var num = num
+        get() = field
+        private set(_value) {
+            field = _value
+        }
+    var txt = txt
+        get() = field
+        private set(_value) {
+            field = _value
+        }
+    var lnk = lnk
+        get() = field
+        private set(_value) {
+            field = _value
+        }
+    var flg = flg
+        get() = field
+        private set(_value) {
+            field = _value
+        }
 
     fun copy(
         num: Double = this.num,
@@ -293,17 +276,17 @@ class Gold_Data() : Entity {
     }
 
     override fun equals(other: Any?): Boolean {
-      if (this === other) {
-        return true
-      }
-
-      if (other is Gold_Data) {
-        if (internalId != "") {
-          return internalId == other.internalId
+        if (this === other) {
+            return true
         }
-        return toString() == other.toString()
-      }
-      return false;
+
+        if (other is Gold_Data) {
+            if (internalId != "") {
+                return internalId == other.internalId
+            }
+            return toString() == other.toString()
+        }
+        return false;
     }
 
     override fun hashCode(): Int =

--- a/src/tools/tests/goldens/generated-schemas.wasm.kt
+++ b/src/tools/tests/goldens/generated-schemas.wasm.kt
@@ -11,9 +11,7 @@ package arcs.sdk
 import arcs.sdk.*
 import arcs.sdk.wasm.*
 
-class GoldInternal1(
-        val_: String = ""
-    ) : WasmEntity {
+class GoldInternal1(val_: String = "") : WasmEntity {
 
     override var internalId = ""
 
@@ -23,11 +21,7 @@ class GoldInternal1(
             field = _value
         }
 
-    fun copy(
-        val_: String = this.val_
-    ) = GoldInternal1(
-        val_ = val_
-    )
+    fun copy(val_: String = this.val_) = GoldInternal1(val_ = val_)
 
     fun reset() {
         val_ = ""
@@ -39,16 +33,16 @@ class GoldInternal1(
         }
 
         if (other is GoldInternal1) {
-            if (internalId != "") {
+            if (internalId.isNotEmpty()) {
                 return internalId == other.internalId
             }
             return toString() == other.toString()
-        }
+       }
         return false;
     }
 
     override fun hashCode(): Int =
-      if (internalId != "") internalId.hashCode() else toString().hashCode()
+        if (internalId.isNotEmpty()) internalId.hashCode() else toString().hashCode()
 
     override fun schemaHash() = "485712110d89359a3e539dac987329cd2649d889"
 
@@ -59,7 +53,8 @@ class GoldInternal1(
         return encoder.toNullTermByteArray()
     }
 
-    override fun toString() = "GoldInternal1(val_ = $val_)"
+    override fun toString() =
+      "GoldInternal1(val_ = $val_)"
 }
 
 class GoldInternal1_Spec() : WasmEntitySpec<GoldInternal1> {
@@ -110,10 +105,14 @@ typealias Gold_Alias = GoldInternal1
 typealias Gold_Alias_Spec = GoldInternal1_Spec
 
 class Gold_QCollection(
-        name: String = "",
-        age: Double = 0.0,
-        lastCall: Double = 0.0
-    ) : WasmEntity {
+    name: String = "",
+    age: Double = 0.0,
+    lastCall: Double = 0.0,
+    address: String = "",
+    favoriteColor: String = "",
+    birthDayMonth: Double = 0.0,
+    birthDayDOM: Double = 0.0
+) : WasmEntity {
 
     override var internalId = ""
 
@@ -132,21 +131,53 @@ class Gold_QCollection(
         private set(_value) {
             field = _value
         }
+    var address = address
+        get() = field
+        private set(_value) {
+            field = _value
+        }
+    var favoriteColor = favoriteColor
+        get() = field
+        private set(_value) {
+            field = _value
+        }
+    var birthDayMonth = birthDayMonth
+        get() = field
+        private set(_value) {
+            field = _value
+        }
+    var birthDayDOM = birthDayDOM
+        get() = field
+        private set(_value) {
+            field = _value
+        }
 
     fun copy(
         name: String = this.name,
         age: Double = this.age,
-        lastCall: Double = this.lastCall
+        lastCall: Double = this.lastCall,
+        address: String = this.address,
+        favoriteColor: String = this.favoriteColor,
+        birthDayMonth: Double = this.birthDayMonth,
+        birthDayDOM: Double = this.birthDayDOM
     ) = Gold_QCollection(
         name = name,
         age = age,
-        lastCall = lastCall
+        lastCall = lastCall,
+        address = address,
+        favoriteColor = favoriteColor,
+        birthDayMonth = birthDayMonth,
+        birthDayDOM = birthDayDOM
     )
 
     fun reset() {
         name = ""
         age = 0.0
         lastCall = 0.0
+        address = ""
+        favoriteColor = ""
+        birthDayMonth = 0.0
+        birthDayDOM = 0.0
     }
 
     override fun equals(other: Any?): Boolean {
@@ -155,18 +186,18 @@ class Gold_QCollection(
         }
 
         if (other is Gold_QCollection) {
-            if (internalId != "") {
+            if (internalId.isNotEmpty()) {
                 return internalId == other.internalId
             }
             return toString() == other.toString()
-        }
+       }
         return false;
     }
 
     override fun hashCode(): Int =
-      if (internalId != "") internalId.hashCode() else toString().hashCode()
+        if (internalId.isNotEmpty()) internalId.hashCode() else toString().hashCode()
 
-    override fun schemaHash() = "f72d6bee9c5b13d2133e2af89a5ed591d670ee74"
+    override fun schemaHash() = "ccd14452cc01e1b00b94cdb25bfe34a5a632daaa"
 
     override fun encodeEntity(): NullTermByteArray {
         val encoder = StringEncoder()
@@ -174,10 +205,15 @@ class Gold_QCollection(
         name.let { encoder.encode("name:T", name) }
         age.let { encoder.encode("age:N", age) }
         lastCall.let { encoder.encode("lastCall:N", lastCall) }
+        address.let { encoder.encode("address:T", address) }
+        favoriteColor.let { encoder.encode("favoriteColor:T", favoriteColor) }
+        birthDayMonth.let { encoder.encode("birthDayMonth:N", birthDayMonth) }
+        birthDayDOM.let { encoder.encode("birthDayDOM:N", birthDayDOM) }
         return encoder.toNullTermByteArray()
     }
 
-    override fun toString() = "Gold_QCollection(name = $name, age = $age, lastCall = $lastCall)"
+    override fun toString() =
+      "Gold_QCollection(name = $name, age = $age, lastCall = $lastCall, address = $address, favoriteColor = $favoriteColor, birthDayMonth = $birthDayMonth, birthDayDOM = $birthDayDOM)"
 }
 
 class Gold_QCollection_Spec() : WasmEntitySpec<Gold_QCollection> {
@@ -195,8 +231,12 @@ class Gold_QCollection_Spec() : WasmEntitySpec<Gold_QCollection> {
         var name = ""
         var age = 0.0
         var lastCall = 0.0
+        var address = ""
+        var favoriteColor = ""
+        var birthDayMonth = 0.0
+        var birthDayDOM = 0.0
         var i = 0
-        while (i < 3 && !decoder.done()) {
+        while (i < 7 && !decoder.done()) {
             val _name = decoder.upTo(':').toUtf8String()
             when (_name) {
                 "name" -> {
@@ -210,6 +250,22 @@ class Gold_QCollection_Spec() : WasmEntitySpec<Gold_QCollection> {
                 "lastCall" -> {
                     decoder.validate("N")
                     lastCall = decoder.decodeNum()
+                }
+                "address" -> {
+                    decoder.validate("T")
+                    address = decoder.decodeText()
+                }
+                "favoriteColor" -> {
+                    decoder.validate("T")
+                    favoriteColor = decoder.decodeText()
+                }
+                "birthDayMonth" -> {
+                    decoder.validate("N")
+                    birthDayMonth = decoder.decodeNum()
+                }
+                "birthDayDOM" -> {
+                    decoder.validate("N")
+                    birthDayDOM = decoder.decodeNum()
                 }
                 else -> {
                     // Ignore unknown fields until type slicing is fully implemented.
@@ -225,9 +281,15 @@ class Gold_QCollection_Spec() : WasmEntitySpec<Gold_QCollection> {
             i++
         }
         val _rtn = create().copy(
+
             name = name,
             age = age,
-            lastCall = lastCall
+            lastCall = lastCall,
+            address = address,
+            favoriteColor = favoriteColor,
+            birthDayMonth = birthDayMonth,
+            birthDayDOM = birthDayDOM
+
         )
         _rtn.internalId = internalId
         return _rtn
@@ -236,11 +298,11 @@ class Gold_QCollection_Spec() : WasmEntitySpec<Gold_QCollection> {
 
 
 class Gold_Data(
-        num: Double = 0.0,
-        txt: String = "",
-        lnk: String = "",
-        flg: Boolean = false
-    ) : WasmEntity {
+    num: Double = 0.0,
+    txt: String = "",
+    lnk: String = "",
+    flg: Boolean = false
+) : WasmEntity {
 
     override var internalId = ""
 
@@ -270,12 +332,7 @@ class Gold_Data(
         txt: String = this.txt,
         lnk: String = this.lnk,
         flg: Boolean = this.flg
-    ) = Gold_Data(
-        num = num,
-        txt = txt,
-        lnk = lnk,
-        flg = flg
-    )
+    ) = Gold_Data(num = num, txt = txt, lnk = lnk, flg = flg)
 
     fun reset() {
         num = 0.0
@@ -290,16 +347,16 @@ class Gold_Data(
         }
 
         if (other is Gold_Data) {
-            if (internalId != "") {
+            if (internalId.isNotEmpty()) {
                 return internalId == other.internalId
             }
             return toString() == other.toString()
-        }
+       }
         return false;
     }
 
     override fun hashCode(): Int =
-      if (internalId != "") internalId.hashCode() else toString().hashCode()
+        if (internalId.isNotEmpty()) internalId.hashCode() else toString().hashCode()
 
     override fun schemaHash() = "d8058d336e472da47b289eafb39733f77eadb111"
 
@@ -313,7 +370,8 @@ class Gold_Data(
         return encoder.toNullTermByteArray()
     }
 
-    override fun toString() = "Gold_Data(num = $num, txt = $txt, lnk = $lnk, flg = $flg)"
+    override fun toString() =
+      "Gold_Data(num = $num, txt = $txt, lnk = $lnk, flg = $flg)"
 }
 
 class Gold_Data_Spec() : WasmEntitySpec<Gold_Data> {
@@ -366,10 +424,7 @@ class Gold_Data_Spec() : WasmEntitySpec<Gold_Data> {
             i++
         }
         val _rtn = create().copy(
-            num = num,
-            txt = txt,
-            lnk = lnk,
-            flg = flg
+            num = num, txt = txt, lnk = lnk, flg = flg
         )
         _rtn.internalId = internalId
         return _rtn

--- a/src/tools/tests/goldens/generated-schemas.wasm.kt
+++ b/src/tools/tests/goldens/generated-schemas.wasm.kt
@@ -11,21 +11,17 @@ package arcs.sdk
 import arcs.sdk.*
 import arcs.sdk.wasm.*
 
-class GoldInternal1() : WasmEntity {
+class GoldInternal1(
+        val_: String = ""
+    ) : WasmEntity {
 
     override var internalId = ""
 
-    var val_ = ""
+    var val_ = val_
         get() = field
         private set(_value) {
             field = _value
         }
-
-    constructor(
-        val_: String = ""
-    ) : this() {
-        this.val_ = val_
-    }
 
     fun copy(
         val_: String = this.val_
@@ -38,17 +34,17 @@ class GoldInternal1() : WasmEntity {
     }
 
     override fun equals(other: Any?): Boolean {
-      if (this === other) {
-        return true
-      }
-
-      if (other is GoldInternal1) {
-        if (internalId != "") {
-          return internalId == other.internalId
+        if (this === other) {
+            return true
         }
-        return toString() == other.toString()
-      }
-      return false;
+
+        if (other is GoldInternal1) {
+            if (internalId != "") {
+                return internalId == other.internalId
+            }
+            return toString() == other.toString()
+        }
+        return false;
     }
 
     override fun hashCode(): Int =
@@ -113,35 +109,29 @@ typealias Gold_Data_Ref_Spec = GoldInternal1_Spec
 typealias Gold_Alias = GoldInternal1
 typealias Gold_Alias_Spec = GoldInternal1_Spec
 
-class Gold_QCollection() : WasmEntity {
-
-    override var internalId = ""
-
-    var name = ""
-        get() = field
-        private set(_value) {
-            field = _value
-        }
-    var age = 0.0
-        get() = field
-        private set(_value) {
-            field = _value
-        }
-    var lastCall = 0.0
-        get() = field
-        private set(_value) {
-            field = _value
-        }
-
-    constructor(
+class Gold_QCollection(
         name: String = "",
         age: Double = 0.0,
         lastCall: Double = 0.0
-    ) : this() {
-        this.name = name
-        this.age = age
-        this.lastCall = lastCall
-    }
+    ) : WasmEntity {
+
+    override var internalId = ""
+
+    var name = name
+        get() = field
+        private set(_value) {
+            field = _value
+        }
+    var age = age
+        get() = field
+        private set(_value) {
+            field = _value
+        }
+    var lastCall = lastCall
+        get() = field
+        private set(_value) {
+            field = _value
+        }
 
     fun copy(
         name: String = this.name,
@@ -160,17 +150,17 @@ class Gold_QCollection() : WasmEntity {
     }
 
     override fun equals(other: Any?): Boolean {
-      if (this === other) {
-        return true
-      }
-
-      if (other is Gold_QCollection) {
-        if (internalId != "") {
-          return internalId == other.internalId
+        if (this === other) {
+            return true
         }
-        return toString() == other.toString()
-      }
-      return false;
+
+        if (other is Gold_QCollection) {
+            if (internalId != "") {
+                return internalId == other.internalId
+            }
+            return toString() == other.toString()
+        }
+        return false;
     }
 
     override fun hashCode(): Int =
@@ -245,42 +235,35 @@ class Gold_QCollection_Spec() : WasmEntitySpec<Gold_QCollection> {
 }
 
 
-class Gold_Data() : WasmEntity {
-
-    override var internalId = ""
-
-    var num = 0.0
-        get() = field
-        private set(_value) {
-            field = _value
-        }
-    var txt = ""
-        get() = field
-        private set(_value) {
-            field = _value
-        }
-    var lnk = ""
-        get() = field
-        private set(_value) {
-            field = _value
-        }
-    var flg = false
-        get() = field
-        private set(_value) {
-            field = _value
-        }
-
-    constructor(
+class Gold_Data(
         num: Double = 0.0,
         txt: String = "",
         lnk: String = "",
         flg: Boolean = false
-    ) : this() {
-        this.num = num
-        this.txt = txt
-        this.lnk = lnk
-        this.flg = flg
-    }
+    ) : WasmEntity {
+
+    override var internalId = ""
+
+    var num = num
+        get() = field
+        private set(_value) {
+            field = _value
+        }
+    var txt = txt
+        get() = field
+        private set(_value) {
+            field = _value
+        }
+    var lnk = lnk
+        get() = field
+        private set(_value) {
+            field = _value
+        }
+    var flg = flg
+        get() = field
+        private set(_value) {
+            field = _value
+        }
 
     fun copy(
         num: Double = this.num,
@@ -302,17 +285,17 @@ class Gold_Data() : WasmEntity {
     }
 
     override fun equals(other: Any?): Boolean {
-      if (this === other) {
-        return true
-      }
-
-      if (other is Gold_Data) {
-        if (internalId != "") {
-          return internalId == other.internalId
+        if (this === other) {
+            return true
         }
-        return toString() == other.toString()
-      }
-      return false;
+
+        if (other is Gold_Data) {
+            if (internalId != "") {
+                return internalId == other.internalId
+            }
+            return toString() == other.toString()
+        }
+        return false;
     }
 
     override fun hashCode(): Int =

--- a/src/tools/tests/goldens/generated-schemas.wasm.kt
+++ b/src/tools/tests/goldens/generated-schemas.wasm.kt
@@ -113,6 +113,138 @@ typealias Gold_Data_Ref_Spec = GoldInternal1_Spec
 typealias Gold_Alias = GoldInternal1
 typealias Gold_Alias_Spec = GoldInternal1_Spec
 
+class Gold_QCollection() : WasmEntity {
+
+    override var internalId = ""
+
+    var name = ""
+        get() = field
+        private set(_value) {
+            field = _value
+        }
+    var age = 0.0
+        get() = field
+        private set(_value) {
+            field = _value
+        }
+    var lastCall = 0.0
+        get() = field
+        private set(_value) {
+            field = _value
+        }
+
+    constructor(
+        name: String = "",
+        age: Double = 0.0,
+        lastCall: Double = 0.0
+    ) : this() {
+        this.name = name
+        this.age = age
+        this.lastCall = lastCall
+    }
+
+    fun copy(
+        name: String = this.name,
+        age: Double = this.age,
+        lastCall: Double = this.lastCall
+    ) = Gold_QCollection(
+        name = name,
+        age = age,
+        lastCall = lastCall
+    )
+
+    fun reset() {
+        name = ""
+        age = 0.0
+        lastCall = 0.0
+    }
+
+    override fun equals(other: Any?): Boolean {
+      if (this === other) {
+        return true
+      }
+
+      if (other is Gold_QCollection) {
+        if (internalId != "") {
+          return internalId == other.internalId
+        }
+        return toString() == other.toString()
+      }
+      return false;
+    }
+
+    override fun hashCode(): Int =
+      if (internalId != "") internalId.hashCode() else toString().hashCode()
+
+    override fun schemaHash() = "f72d6bee9c5b13d2133e2af89a5ed591d670ee74"
+
+    override fun encodeEntity(): NullTermByteArray {
+        val encoder = StringEncoder()
+        encoder.encode("", internalId)
+        name.let { encoder.encode("name:T", name) }
+        age.let { encoder.encode("age:N", age) }
+        lastCall.let { encoder.encode("lastCall:N", lastCall) }
+        return encoder.toNullTermByteArray()
+    }
+
+    override fun toString() = "Gold_QCollection(name = $name, age = $age, lastCall = $lastCall)"
+}
+
+class Gold_QCollection_Spec() : WasmEntitySpec<Gold_QCollection> {
+
+    override fun create() = Gold_QCollection()
+
+
+    override fun decode(encoded: ByteArray): Gold_QCollection? {
+        if (encoded.isEmpty()) return null
+
+        val decoder = StringDecoder(encoded)
+        val internalId = decoder.decodeText()
+        decoder.validate("|")
+
+        var name = ""
+        var age = 0.0
+        var lastCall = 0.0
+        var i = 0
+        while (i < 3 && !decoder.done()) {
+            val _name = decoder.upTo(':').toUtf8String()
+            when (_name) {
+                "name" -> {
+                    decoder.validate("T")
+                    name = decoder.decodeText()
+                }
+                "age" -> {
+                    decoder.validate("N")
+                    age = decoder.decodeNum()
+                }
+                "lastCall" -> {
+                    decoder.validate("N")
+                    lastCall = decoder.decodeNum()
+                }
+                else -> {
+                    // Ignore unknown fields until type slicing is fully implemented.
+                    when (decoder.chomp(1).toUtf8String()) {
+                        "T", "U" -> decoder.decodeText()
+                        "N" -> decoder.decodeNum()
+                        "B" -> decoder.decodeBool()
+                    }
+                    i--
+                }
+            }
+            decoder.validate("|")
+            i++
+        }
+        val _rtn = create().copy(
+            name = name,
+            age = age,
+            lastCall = lastCall
+        )
+        _rtn.internalId = internalId
+        return _rtn
+    }
+}
+
+
 class Gold_Data() : WasmEntity {
 
     override var internalId = ""
@@ -266,6 +398,7 @@ class GoldHandles(
     particle: WasmParticleImpl
 ) {
     val data: WasmSingletonImpl<Gold_Data> = WasmSingletonImpl(particle, "data", Gold_Data_Spec())
+    val qCollection: WasmCollectionImpl<Gold_QCollection> = WasmCollectionImpl(particle, "qCollection", Gold_QCollection_Spec())
     val alias: WasmSingletonImpl<Gold_Alias> = WasmSingletonImpl(particle, "alias", Gold_Alias_Spec())
 }
 

--- a/src/tools/tests/schema2wasm-test.ts
+++ b/src/tools/tests/schema2wasm-test.ts
@@ -35,9 +35,9 @@ class Schema2Mock extends Schema2Base {
         return name;
       },
 
-      addField({field, typeChar, isOptional, refClassName}: AddFieldOptions) {
+      addField({field, typeName, isOptional, refClassName}: AddFieldOptions) {
         const refInfo = refClassName ? `<${refClassName}>` : '';
-        collector.adds.push(field + ':' + typeChar + refInfo + (isOptional ? '?' : ''));
+        collector.adds.push(field + ':' + typeName[0] + refInfo + (isOptional ? '?' : ''));
       },
 
       generatePredicates() {

--- a/src/tools/tests/schema2wasm-test.ts
+++ b/src/tools/tests/schema2wasm-test.ts
@@ -31,9 +31,16 @@ class Schema2Mock extends Schema2Base {
     const collector = {count: 0, adds: []};
     this.res[node.name] = collector;
     return {
+      escapeIdentifier(name: string): string {
+        return name;
+      },
+
       addField({field, typeChar, isOptional, refClassName}: AddFieldOptions) {
         const refInfo = refClassName ? `<${refClassName}>` : '';
         collector.adds.push(field + ':' + typeChar + refInfo + (isOptional ? '?' : ''));
+      },
+
+      generatePredicates() {
       },
 
       generate(schemaHash: string, fieldCount: number): string {


### PR DESCRIPTION
This PR contains the glue code which lets our kotlin generator build handles that can query and refine types using the type information contained in the associated `Schema`.

This PR contains fixes for the Refinement Kotlin generator to match Kotlin style and also changes for use of `RawEntity`s. It also updates golden tests to make use of the query generation.
