### PR TITLE
There can only be one!

### DIFF
--- a/src/dataflow/analysis/particle-node.ts
+++ b/src/dataflow/analysis/particle-node.ts
@@ -143,7 +143,7 @@ export class ParticleOutput implements Edge {
       assert(false, 'Must be a Reference.');
     }
     const particleNode = this.start;
-    const outRef = this.type as ReferenceType;
+    const outRef = this.type as ReferenceType<Type>;
 
     const result: Edge[] = [];
 
@@ -186,7 +186,7 @@ export function createParticleNodes(particles: Particle[]) {
  * @param canBeReference controls whether a reference type is allowed to be the
  *     source of the output reference
  */
-function isTypeCompatibleWithReference(type: Type, target: ReferenceType, canBeReference: boolean) {
+function isTypeCompatibleWithReference(type: Type, target: ReferenceType<Type>, canBeReference: boolean) {
   switch (type.tag) {
     case 'Entity':
       if (TypeChecker.compareTypes({type, direction: 'reads'}, {type: target.getContainedType(), direction: 'writes'})) {
@@ -223,7 +223,7 @@ function isTypeCompatibleWithReference(type: Type, target: ReferenceType, canBeR
  * sub-entities).
  */
 // tslint:disable-next-line: no-any
-function isSchemaFieldCompatibleWithReference(field: any, target: ReferenceType) {
+function isSchemaFieldCompatibleWithReference(field: any, target: ReferenceType<Type>) {
   switch (field.kind) {
     case 'schema-reference': {
       const referencedType = field.schema.model as Type;

--- a/src/devtools-connector/arc-stores-fetcher.ts
+++ b/src/devtools-connector/arc-stores-fetcher.ts
@@ -14,7 +14,7 @@ import {Manifest} from '../runtime/manifest.js';
 import {Type} from '../runtime/type.js';
 import {StorageKey} from '../runtime/storageNG/storage-key.js';
 import {Store} from '../runtime/storageNG/store.js';
-import {UnifiedStore} from '../runtime/storageNG/unified-store.js';
+import {AbstractStore} from '../runtime/storageNG/abstract-store.js';
 
 type Result = {
   name: string,
@@ -61,7 +61,7 @@ export class ArcStoresFetcher {
   }
 
   private async listStores() {
-    const find = (manifest: Manifest): [UnifiedStore, string[]][] => {
+    const find = (manifest: Manifest): [AbstractStore, string[]][] => {
       let tags = [...manifest.storeTags];
       if (manifest.imports) {
         manifest.imports.forEach(imp => tags = tags.concat(find(imp)));
@@ -74,7 +74,7 @@ export class ArcStoresFetcher {
     };
   }
 
-  private async digestStores(stores: [UnifiedStore, string[] | Set<string>][]) {
+  private async digestStores(stores: [AbstractStore, string[] | Set<string>][]) {
     const result: Result[] = [];
     for (const [store, tags] of stores) {
       result.push({
@@ -91,7 +91,7 @@ export class ArcStoresFetcher {
   }
 
   // tslint:disable-next-line: no-any
-  private async dereference(store: UnifiedStore): Promise<any> {
+  private async dereference(store: AbstractStore): Promise<any> {
     // TODO(shanestephens): Replace this with handle-based reading
     if (store instanceof Store) {
       // tslint:disable-next-line: no-any

--- a/src/devtools-connector/tests/devtools-arc-inspector-test.ts
+++ b/src/devtools-connector/tests/devtools-arc-inspector-test.ts
@@ -18,6 +18,7 @@ import {storageKeyPrefixForTest} from '../../runtime/testing/handle-for-test.js'
 
 import {Entity} from '../../runtime/entity.js';
 import {Flags} from '../../runtime/flags.js';
+import {SingletonType} from '../../runtime/type.js';
 
 describe('DevtoolsArcInspector', () => {
   before(() => DevtoolsForTests.ensureStub());
@@ -44,7 +45,7 @@ describe('DevtoolsArcInspector', () => {
     const arc = runtime.newArc('demo', storageKeyPrefixForTest(), {inspectorFactory: devtoolsArcInspectorFactory});
 
     const foo = Entity.createEntityClass(arc.context.findSchemaByName('Foo'), null);
-    const fooStore = await arc.createStore(foo.type, undefined, 'fooStore');
+    const fooStore = await arc.createStore(new SingletonType(foo.type), undefined, 'fooStore');
 
     const recipe = arc.context.recipes[0];
     recipe.handles[0].mapToStorage(fooStore);

--- a/src/planning/plan/plan-producer.ts
+++ b/src/planning/plan/plan-producer.ts
@@ -20,7 +20,7 @@ import {StrategyDerived} from '../strategizer.js';
 import {PlanningResult} from './planning-result.js';
 import {Suggestion} from './suggestion.js';
 import {PlannerInspector} from '../planner-inspector.js';
-import {singletonHandle, ActiveSingletonEntityStore, SingletonEntityHandle} from '../../runtime/storageNG/storage-ng.js';
+import {ActiveSingletonEntityStore, SingletonEntityHandle, handleForActiveStore} from '../../runtime/storageNG/storage-ng.js';
 
 const defaultTimeoutMs = 5000;
 
@@ -65,7 +65,7 @@ export class PlanProducer {
     this.searchStore = searchStore;
     this.inspector = inspector;
     if (this.searchStore) {
-      this.handle = singletonHandle(this.searchStore, this.arc);
+      this.handle = handleForActiveStore(this.searchStore, this.arc);
       this.searchStoreCallbackId = this.searchStore.on(() => this.onSearchChanged());
     }
     this.debug = debug;

--- a/src/planning/plan/planificator.ts
+++ b/src/planning/plan/planificator.ts
@@ -13,7 +13,7 @@ import {Runnable} from '../../runtime/hot.js';
 import {Exists} from '../../runtime/storageNG/drivers/driver.js';
 import {StorageKey} from '../../runtime/storageNG/storage-key.js';
 import {Store} from '../../runtime/storageNG/store.js';
-import {UnifiedStore} from '../../runtime/storageNG/unified-store.js';
+import {AbstractStore} from '../../runtime/storageNG/abstract-store.js';
 import {checkDefined} from '../../runtime/testing/preconditions.js';
 import {EntityType, SingletonType, Type} from '../../runtime/type.js';
 import {PlannerInspector, PlannerInspectorFactory} from '../planner-inspector.js';
@@ -21,7 +21,7 @@ import {PlanConsumer} from './plan-consumer.js';
 import {PlanProducer, Trigger} from './plan-producer.js';
 import {PlanningResult} from './planning-result.js';
 import {ReplanQueue} from './replan-queue.js';
-import {ActiveSingletonEntityStore, CRDTEntitySingleton, singletonHandle, SingletonEntityHandle} from '../../runtime/storageNG/storage-ng.js';
+import {ActiveSingletonEntityStore, CRDTEntitySingleton, SingletonEntityHandle, handleForActiveStore} from '../../runtime/storageNG/storage-ng.js';
 
 const planificatorId = 'plans';
 
@@ -64,7 +64,7 @@ export class Planificator {
   producer?: PlanProducer;
   replanQueue?: ReplanQueue;
   dataChangeCallback: Runnable;
-  storeCallbackIds: Map<UnifiedStore, number>;
+  storeCallbackIds: Map<AbstractStore, number>;
   search: string|null = null;
   searchStore: ActiveSingletonEntityStore;
   inspector: PlannerInspector|undefined;
@@ -187,11 +187,11 @@ export class Planificator {
   }
 
   private static async _initStore(arc: Arc, id: string, type: Type, storageKey: StorageKey): Promise<ActiveSingletonEntityStore> {
-    return new Store<CRDTEntitySingleton>({storageKey, exists: Exists.MayExist, type: new SingletonType(type), id}).activate();
+    return new Store<CRDTEntitySingleton>(new SingletonType(type), {storageKey, exists: Exists.MayExist, id}).activate();
   }
 
   async _storeSearch(): Promise<void> {
-    const handleNG: SingletonEntityHandle = singletonHandle(this.searchStore, this.arc);
+    const handleNG = handleForActiveStore(this.searchStore, this.arc);
     const handleValue = await handleNG.fetch();
     const values = handleValue ? JSON.parse(handleValue.current) : [];
 

--- a/src/planning/plan/planning-result.ts
+++ b/src/planning/plan/planning-result.ts
@@ -14,9 +14,8 @@ import {Arc} from '../../runtime/arc.js';
 import {Runnable} from '../../runtime/hot.js';
 import {RecipeUtil} from '../../runtime/recipe/recipe-util.js';
 import {EnvOptions, Suggestion} from './suggestion.js';
-import {UnifiedActiveStore} from '../../runtime/storageNG/unified-store.js';
 import {EntityType} from '../../runtime/type.js';
-import {singletonHandle, ActiveSingletonEntityStore, SingletonEntityHandle} from '../../runtime/storageNG/storage-ng.js';
+import {ActiveSingletonEntityStore, SingletonEntityHandle, handleForActiveStore} from '../../runtime/storageNG/storage-ng.js';
 
 const {error} = logsFactory('PlanningResult', '#ff0090');
 
@@ -40,7 +39,7 @@ export class PlanningResult {
   lastUpdated: Date = new Date();
   generations: SerializableGeneration[] = [];
   contextual = true;
-  store?: UnifiedActiveStore;
+  store?: ActiveSingletonEntityStore;
   handle?: SingletonEntityHandle;
   private storeCallbackId: number;
   private changeCallbacks: Runnable[] = [];
@@ -52,7 +51,7 @@ export class PlanningResult {
     assert(envOptions.loader, `loader cannot be null`);
     this.store = store;
     if (this.store) {
-      this.handle = singletonHandle(store, envOptions.context);
+      this.handle = handleForActiveStore(store, envOptions.context);
       this.storeCallbackId = this.store.on(() => this.load());
     }
   }

--- a/src/planning/plan/tests/plan-producer-test.ts
+++ b/src/planning/plan/tests/plan-producer-test.ts
@@ -22,7 +22,7 @@ import {PlanningResult} from '../../plan/planning-result.js';
 import {Suggestion} from '../../plan/suggestion.js';
 import {StrategyTestHelper} from '../../testing/strategy-test-helper.js';
 import {RamDiskStorageDriverProvider} from '../../../runtime/storageNG/drivers/ramdisk.js';
-import {singletonHandle, ActiveSingletonEntityStore} from '../../../runtime/storageNG/storage-ng.js';
+import {ActiveSingletonEntityStore, handleForActiveStore} from '../../../runtime/storageNG/storage-ng.js';
 
 class TestPlanProducer extends PlanProducer {
   options;
@@ -161,7 +161,7 @@ describe('plan producer - search', () => {
     }
 
     async setNextSearch(search: string) {
-      const handle = singletonHandle(this.searchStore, this.arc);
+      const handle = handleForActiveStore(this.searchStore, this.arc);
       await handle.setFromData({current: JSON.stringify([{arc: this.arc.id.idTreeAsString(), search}])});
       return this.onSearchChanged();
     }

--- a/src/planning/strategies/assign-handles.ts
+++ b/src/planning/strategies/assign-handles.ts
@@ -11,7 +11,7 @@
 import {assert} from '../../platform/assert-web.js';
 import {RecipeUtil, DirectionCounts} from '../../runtime/recipe/recipe-util.js';
 import {StrategizerWalker, Strategy} from '../strategizer.js';
-import {UnifiedStore} from '../../runtime/storageNG/unified-store.js';
+import {AbstractStore} from '../../runtime/storageNG/abstract-store.js';
 
 export class AssignHandles extends Strategy {
   async generate(inputParams) {
@@ -94,8 +94,8 @@ export class AssignHandles extends Strategy {
     }(StrategizerWalker.Permuted), this);
   }
 
-  getMappableStores(fate, type, tags: string[], counts: DirectionCounts): Map<UnifiedStore, string> {
-    const stores: Map<UnifiedStore, string> = new Map();
+  getMappableStores(fate, type, tags: string[], counts: DirectionCounts): Map<AbstractStore, string> {
+    const stores: Map<AbstractStore, string> = new Map();
 
     if (fate === 'use' || fate === '?') {
       this.arc.findStoresByType(type, {tags}).forEach(store => stores.set(store, 'use'));

--- a/src/planning/strategies/search-tokens-to-handles.ts
+++ b/src/planning/strategies/search-tokens-to-handles.ts
@@ -10,7 +10,7 @@
 
 import {RecipeUtil} from '../../runtime/recipe/recipe-util.js';
 import {StrategizerWalker, Strategy} from '../strategizer.js';
-import {UnifiedStore} from '../../runtime/storageNG/unified-store.js';
+import {AbstractStore} from '../../runtime/storageNG/abstract-store.js';
 
 export class SearchTokensToHandles extends Strategy {
 
@@ -20,7 +20,7 @@ export class SearchTokensToHandles extends Strategy {
     // which are not already mapped into the provided handle's recipe
     const findMatchingStores = (token, handle) => {
       const counts = RecipeUtil.directionCounts(handle);
-      let stores: UnifiedStore[];
+      let stores: AbstractStore[];
       stores = arc.findStoresByType(handle.type, {tags: [`${token}`]});
       let fate = 'use';
       if (stores.length === 0) {

--- a/src/planning/strategies/tests/find-hosted-particle-test.ts
+++ b/src/planning/strategies/tests/find-hosted-particle-test.ts
@@ -17,8 +17,8 @@ import {InterfaceType} from '../../../runtime/type.js';
 import {FindHostedParticle} from '../../strategies/find-hosted-particle.js';
 import {StrategyTestHelper} from '../../testing/strategy-test-helper.js';
 import {ArcId} from '../../../runtime/id.js';
-import {singletonHandle, SingletonInterfaceHandle} from '../../../runtime/storageNG/storage-ng.js';
-import {isSingletonInterfaceStore} from '../../../runtime/storageNG/unified-store.js';
+import {SingletonInterfaceHandle, handleForStore} from '../../../runtime/storageNG/storage-ng.js';
+import {isSingletonInterfaceStore} from '../../../runtime/storageNG/abstract-store.js';
 
 async function runStrategy(manifestStr) {
   const manifest = await Manifest.parse(manifestStr);
@@ -174,7 +174,7 @@ describe('FindHostedParticle', () => {
     assert.isEmpty(arc._stores);
     await arc.instantiate(outRecipe);
     const particleSpecStore = arc._stores.find(isSingletonInterfaceStore);
-    const handle: SingletonInterfaceHandle = singletonHandle(await particleSpecStore.activate(), arc);
+    const handle = await handleForStore(particleSpecStore, arc);
     const particleSpec = await handle.fetch();
     // TODO(shans): fix this by putting an id field on particleSpec, or by having a ParticleSpec subclass
     // for storing.

--- a/src/planning/strategies/tests/init-population-test.ts
+++ b/src/planning/strategies/tests/init-population-test.ts
@@ -19,6 +19,7 @@ import {StrategyTestHelper} from '../../testing/strategy-test-helper.js';
 import {ArcId} from '../../../runtime/id.js';
 
 import {Entity} from '../../../runtime/entity.js';
+import {SingletonType} from '../../../runtime/type.js';
 
 describe('InitPopulation', () => {
   it('penalizes resolution of particles that already exist in the arc', async () => {
@@ -131,7 +132,7 @@ describe('InitPopulation', () => {
     async function openRestaurantWith(foodType) {
       const restaurant = manifest.recipes.find(recipe => recipe.name === `${foodType}Restaurant`);
       const foodEntity = Entity.createEntityClass(manifest.findSchemaByName(foodType), null);
-      const store = await arc.createStore(foodEntity.type, undefined, `test:${foodType}`);
+      const store = await arc.createStore(new SingletonType(foodEntity.type), undefined, `test:${foodType}`);
       restaurant.handles[0].mapToStorage(store);
       restaurant.normalize();
       restaurant.mergeInto(arc.activeRecipe);

--- a/src/planning/strategies/tests/resolve-recipe-test.ts
+++ b/src/planning/strategies/tests/resolve-recipe-test.ts
@@ -15,6 +15,7 @@ import {StrategyTestHelper} from '../../testing/strategy-test-helper.js';
 import {TestVolatileMemoryProvider} from '../../../runtime/testing/test-volatile-memory-provider.js';
 import {RamDiskStorageDriverProvider} from '../../../runtime/storageNG/drivers/ramdisk.js';
 import {Entity} from '../../../runtime/entity.js';
+import {SingletonType} from '../../../runtime/type.js';
 
 const {createTestArc, onlyResult, theResults, noResult} = StrategyTestHelper;
 
@@ -232,7 +233,7 @@ describe('resolve recipe', () => {
     const arc = createTestArc(manifest);
 
     const car = Entity.createEntityClass(manifest.findSchemaByName('Car'), null);
-    await arc.createStore(car.type, /* name= */ null, 'batmobile');
+    await arc.createStore(new SingletonType(car.type), /* name= */ null, 'batmobile');
 
     const recipe = manifest.recipes[0];
 

--- a/src/planning/tests/planner-test.ts
+++ b/src/planning/tests/planner-test.ts
@@ -22,7 +22,7 @@ import {ArcId} from '../../runtime/id.js';
 
 import {RamDiskStorageDriverProvider, RamDiskStorageKey} from '../../runtime/storageNG/drivers/ramdisk.js';
 import {TestVolatileMemoryProvider} from '../../runtime/testing/test-volatile-memory-provider.js';
-import {EntityType} from '../../runtime/type.js';
+import {EntityType, SingletonType} from '../../runtime/type.js';
 import {Entity} from '../../runtime/entity.js';
 import {DriverFactory} from '../../runtime/storageNG/drivers/driver-factory.js';
 
@@ -932,7 +932,7 @@ describe('Automatic resolution', () => {
       `,
       async (arc, manifest) => {
         const thing = Entity.createEntityClass(manifest.findSchemaByName('Thing'), null);
-        await arc.createStore(thing.type, undefined, 'test:1');
+        await arc.createStore(new SingletonType(thing.type), undefined, 'test:1');
       }
     );
 

--- a/src/runtime/api-channel.ts
+++ b/src/runtime/api-channel.ts
@@ -10,7 +10,7 @@
 
 import {assert} from '../platform/assert-web.js';
 import {Arc} from './arc.js';
-import {UnifiedStore} from './storageNG/unified-store.js';
+import {AbstractStore} from './storageNG/abstract-store.js';
 import {ArcInspector} from './arc-inspector.js';
 import {ParticleSpec} from './particle-spec.js';
 import {Particle} from './particle.js';
@@ -529,9 +529,9 @@ export abstract class PECOuterPort extends APIPort {
   }
 
   @NoArgs Stop() {}
-  DefineHandle(@RedundantInitializer store: UnifiedStore, @ByLiteral(Type) type: Type, @Direct name: string, @Direct storageKey: string, @ByLiteral(Ttl) ttl: Ttl) {}
-  InstantiateParticle(@Initializer particle: recipeParticle.Particle, @Identifier @Direct id: string, @ByLiteral(ParticleSpec) spec: ParticleSpec, @ObjectMap(MappingType.Direct, MappingType.Mapped) stores: Map<string, UnifiedStore>, @Direct reinstantiate: boolean) {}
-  ReinstantiateParticle(@Identifier @Direct id: string, @ByLiteral(ParticleSpec) spec: ParticleSpec, @ObjectMap(MappingType.Direct, MappingType.Mapped) stores: Map<string, UnifiedStore>) {}
+  DefineHandle(@RedundantInitializer store: AbstractStore, @ByLiteral(Type) type: Type, @Direct name: string, @Direct storageKey: string, @ByLiteral(Ttl) ttl: Ttl) {}
+  InstantiateParticle(@Initializer particle: recipeParticle.Particle, @Identifier @Direct id: string, @ByLiteral(ParticleSpec) spec: ParticleSpec, @ObjectMap(MappingType.Direct, MappingType.Mapped) stores: Map<string, AbstractStore>, @Direct reinstantiate: boolean) {}
+  ReinstantiateParticle(@Identifier @Direct id: string, @ByLiteral(ParticleSpec) spec: ParticleSpec, @ObjectMap(MappingType.Direct, MappingType.Mapped) stores: Map<string, AbstractStore>) {}
   ReloadParticles(@OverridingInitializer particles: recipeParticle.Particle[], @List(MappingType.Direct) ids: string[]) {}
 
   UIEvent(@Mapped particle: recipeParticle.Particle, @Direct slotName: string, @Direct event: {}) {}
@@ -545,13 +545,13 @@ export abstract class PECOuterPort extends APIPort {
   abstract onIdle(version: number, relevance: Map<recipeParticle.Particle, number[]>);
 
   abstract onGetBackingStore(callback: number, storageKey: string, type: Type);
-  GetBackingStoreCallback(@Initializer store: UnifiedStore, @RemoteMapped callback: number, @ByLiteral(Type) type: Type, @Direct name: string, @Identifier @Direct id: string, @Direct storageKey: string) {}
+  GetBackingStoreCallback(@Initializer store: AbstractStore, @RemoteMapped callback: number, @ByLiteral(Type) type: Type, @Direct name: string, @Identifier @Direct id: string, @Direct storageKey: string) {}
 
   abstract onConstructInnerArc(callback: number, particle: recipeParticle.Particle);
   ConstructArcCallback(@RemoteMapped callback: number, @LocalMapped arc: {}) {}
 
   abstract onArcCreateHandle(callback: number, arc: {}, type: Type, name: string);
-  CreateHandleCallback(@Initializer handle: UnifiedStore, @RemoteMapped callback: number, @ByLiteral(Type) type: Type, @Direct name: string, @Identifier @Direct id: string) {}
+  CreateHandleCallback(@Initializer handle: AbstractStore, @RemoteMapped callback: number, @ByLiteral(Type) type: Type, @Direct name: string, @Identifier @Direct id: string) {}
   abstract onArcMapHandle(callback: number, arc: Arc, handle: recipeHandle.Handle);
   MapHandleCallback(@RemoteIgnore @Initializer newHandle: {}, @RemoteMapped callback: number, @Direct id: string) {}
 

--- a/src/runtime/arc-serializer.ts
+++ b/src/runtime/arc-serializer.ts
@@ -8,7 +8,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {UnifiedStore} from './storageNG/unified-store.js';
+import {AbstractStore} from './storageNG/abstract-store.js';
 import {InterfaceType} from './type.js';
 import {StorageKey} from './storageNG/storage-key.js';
 import {ParticleSpec} from './particle-spec.js';
@@ -30,9 +30,9 @@ import {VolatileMemory, VolatileStorageKey} from './storageNG/drivers/volatile.j
 export interface ArcInterface {
   activeRecipe: Recipe;
   id: Id;
-  storeTags: Map<UnifiedStore, Set<string>>;
+  storeTags: Map<AbstractStore, Set<string>>;
   context: Manifest;
-  _stores: UnifiedStore[];
+  _stores: AbstractStore[];
   storageKey?: string | StorageKey;
   volatileMemory: VolatileMemory;
 }
@@ -85,7 +85,7 @@ ${this.arc.activeRecipe.toString()}`;
     return serialization;
   }
 
-  private async _serializeStore(store: UnifiedStore, name: string): Promise<void> {
+  private async _serializeStore(store: AbstractStore, name: string): Promise<void> {
     const type = store.type.getContainedType() || store.type;
     if (type instanceof InterfaceType) {
       this.interfaces += type.interfaceInfo.toString() + '\n';

--- a/src/runtime/crdt/crdt-collection.ts
+++ b/src/runtime/crdt/crdt-collection.ts
@@ -11,7 +11,6 @@
 import {ChangeType, CRDTChange, CRDTError, CRDTModel, CRDTTypeRecord, VersionMap, createEmptyChange} from './crdt.js';
 import {Dictionary} from '../hot.js';
 import {assert} from '../../platform/assert-web.js';
-import {Entity} from '../entity.js';
 
 type RawCollection<T> = Set<T>;
 

--- a/src/runtime/entity.ts
+++ b/src/runtime/entity.ts
@@ -46,7 +46,7 @@ export type MutableEntityData = Dictionary<any>;
  * @see https://stackoverflow.com/a/13955591
  */
 export interface EntityStaticInterface {
-  readonly type: Type;
+  readonly type: EntityType;
   readonly key: {tag: string, schema: Schema};
   readonly schema: Schema;
 }
@@ -327,7 +327,7 @@ export abstract class Entity implements Storable {
         });
       }
 
-      static get type(): Type {
+      static get type(): EntityType {
         // TODO: should the entity's key just be its type?
         // Should it just be called type in that case?
         return new EntityType(schema);

--- a/src/runtime/particle-execution-context.ts
+++ b/src/runtime/particle-execution-context.ts
@@ -29,7 +29,7 @@ import {SystemTrace} from '../tracelib/systrace.js';
 import {delegateSystemTraceApis} from '../tracelib/systrace-helpers.js';
 import {ChannelConstructor} from './channel-constructor.js';
 import {Ttl} from './recipe/ttl.js';
-import {Handle, handleNGFor} from './storageNG/handle.js';
+import {Handle} from './storageNG/handle.js';
 
 export type PecFactory = (pecId: Id, idGenerator: IdGenerator) => MessagePort;
 
@@ -39,6 +39,22 @@ export type InnerArcHandle = {
   createSlot(transformationParticle: Particle, transformationSlotName: string, handleId: string): Promise<string>;
   loadRecipe(recipe: string): Promise<{error?: string}>;
 };
+
+function handleNGFor<T extends CRDTTypeRecord>(key: string,
+  storageProxy: StorageProxy<T>,
+  idGenerator: IdGenerator,
+  particle: Particle,
+  canRead: boolean,
+  canWrite: boolean,
+  name?: string): Handle<T> {
+return new (storageProxy.type.handleConstructor<T>())(key,
+      storageProxy,
+      idGenerator,
+      particle,
+      canRead,
+      canWrite,
+      name);
+}
 
 @SystemTrace
 export class ParticleExecutionContext implements StorageCommunicationEndpointProvider<CRDTTypeRecord> {

--- a/src/runtime/storageNG/storage-ng.ts
+++ b/src/runtime/storageNG/storage-ng.ts
@@ -9,17 +9,21 @@
  */
 
 import {StorageProxy} from './storage-proxy.js';
-import {Type} from '../type.js';
+import {Type, CollectionType, EntityType, ReferenceType, SingletonType, InterfaceType} from '../type.js';
 import {Ttl} from '../recipe/ttl.js';
-import {SingletonHandle, CollectionHandle} from './handle.js';
+import {SingletonHandle, CollectionHandle, Handle} from './handle.js';
 import {Particle} from '../particle.js';
 import {CRDTSingletonTypeRecord} from '../crdt/crdt-singleton.js';
 import {ActiveStore, Store} from './store.js';
 import {Entity, SerializedEntity} from '../entity.js';
 import {Id, IdGenerator} from '../id.js';
 import {ParticleSpec, StorableSerializedParticleSpec} from '../particle-spec.js';
-import {Referenceable, CRDTCollectionTypeRecord} from '../crdt/crdt-collection.js';
+import {CRDTCollectionTypeRecord} from '../crdt/crdt-collection.js';
 import {SerializedReference, Reference} from '../reference.js';
+import {StoreInfo} from './abstract-store.js';
+import {StorageKey} from './storage-key.js';
+import {Exists} from './drivers/driver.js';
+import {CRDTTypeRecord} from '../crdt/crdt.js';
 
 type HandleOptions = {
   type?: Type;
@@ -35,56 +39,101 @@ type ArcLike = {
   idGenerator: IdGenerator;
 };
 
-export type CRDTReferenceableSingleton = CRDTSingletonTypeRecord<Referenceable>;
-export type CRDTReferenceableCollection = CRDTCollectionTypeRecord<Referenceable>;
-
+export type SingletonEntityType = SingletonType<EntityType>;
 export type CRDTEntitySingleton = CRDTSingletonTypeRecord<SerializedEntity>;
 export type SingletonEntityStore = Store<CRDTEntitySingleton>;
 export type ActiveSingletonEntityStore = ActiveStore<CRDTEntitySingleton>;
 export type SingletonEntityHandle = SingletonHandle<Entity>;
 
+export type CollectionEntityType = CollectionType<EntityType>;
 export type CRDTEntityCollection = CRDTCollectionTypeRecord<SerializedEntity>;
 export type CollectionEntityStore = Store<CRDTEntityCollection>;
 export type ActiveCollectionEntityStore = ActiveStore<CRDTEntityCollection>;
 export type CollectionEntityHandle = CollectionHandle<Entity>;
 
+export type SingletonReferenceType = SingletonType<ReferenceType<EntityType>>;
 export type CRDTReferenceSingleton = CRDTSingletonTypeRecord<SerializedReference>;
 export type SingletonReferenceStore = Store<CRDTReferenceSingleton>;
 export type ActiveSingletonReferenceStore = ActiveStore<CRDTReferenceSingleton>;
 export type SingletonReferenceHandle = SingletonHandle<Reference>;
 
+export type CollectionReferenceType = CollectionType<ReferenceType<EntityType>>;
 export type CRDTReferenceCollection = CRDTCollectionTypeRecord<SerializedReference>;
 export type CollectionReferenceStore = Store<CRDTReferenceCollection>;
 export type ActiveCollectionReferenceStore = ActiveStore<CRDTReferenceCollection>;
 export type CollectionReferenceHandle = CollectionHandle<Reference>;
 
+export type SingletonInterfaceType = SingletonType<InterfaceType>;
 export type CRDTInterfaceSingleton = CRDTSingletonTypeRecord<StorableSerializedParticleSpec>;
 export type SingletonInterfaceStore = Store<CRDTInterfaceSingleton>;
 export type ActiveSingletonInterfaceStore = ActiveStore<CRDTInterfaceSingleton>;
 export type SingletonInterfaceHandle = SingletonHandle<ParticleSpec>;
 
-export function singletonHandle<T extends CRDTReferenceableSingleton, U>(
-  store: ActiveStore<T>,
-  arc: ArcLike,
-  options?: HandleOptions
-): SingletonHandle<U> {
-  const type = options && options.type ? options.type : store.baseStore.type;
-  const storageKey = store.baseStore.storageKey.toString();
-  const ttl = options && options.ttl ? options.ttl : undefined;
-  const proxy = new StorageProxy<T>(store.baseStore.id, store, type, storageKey, ttl);
-  const idGenerator = arc.idGenerator;
-  const particle = options && options.particle ? options.particle : null;
-  const canRead = options && options.canRead ? options.canRead : true;
-  const canWrite = options && options.canWrite ? options.canWrite : true;
-  const name = options && options.name ? options.name : null;
-  return new SingletonHandle(arc.generateID().toString(), proxy, idGenerator, particle, canRead, canWrite, name);
+
+export type ToStore<T extends Type>
+  = T extends CollectionEntityType ? CollectionEntityStore :
+   (T extends CollectionReferenceType ? CollectionReferenceStore :
+   (T extends SingletonEntityType ? SingletonEntityStore :
+   (T extends SingletonReferenceType ? SingletonReferenceStore :
+   (T extends SingletonInterfaceType ? SingletonInterfaceStore :
+    Store<CRDTTypeRecord>))));
+
+export type ToActive<T extends Store<CRDTTypeRecord>>
+  = T extends CollectionEntityStore ? ActiveCollectionEntityStore :
+   (T extends CollectionReferenceStore ? ActiveCollectionReferenceStore :
+   (T extends SingletonEntityStore ? ActiveSingletonEntityStore :
+   (T extends SingletonReferenceStore ? ActiveSingletonReferenceStore :
+   (T extends SingletonInterfaceStore ? ActiveSingletonInterfaceStore :
+    ActiveStore<CRDTTypeRecord>))));
+
+export type ToType<T extends Store<CRDTTypeRecord>>
+  = T extends CollectionEntityStore ? CollectionEntityType :
+   (T extends CollectionReferenceStore ? CollectionReferenceType :
+   (T extends SingletonEntityStore ? SingletonEntityType :
+   (T extends SingletonReferenceStore ? SingletonReferenceType :
+   (T extends SingletonInterfaceStore ? SingletonInterfaceType :
+    Type))));
+
+export type HandleToType<T extends Handle<CRDTTypeRecord>>
+  = T extends CollectionEntityHandle ? CollectionEntityType :
+  (T extends CollectionReferenceHandle ? CollectionReferenceType :
+  (T extends SingletonEntityHandle ? SingletonEntityType :
+  (T extends SingletonReferenceHandle ? SingletonReferenceType :
+  (T extends SingletonInterfaceHandle ? SingletonInterfaceType :
+   Type))));
+
+export type ToHandle<T extends ActiveStore<CRDTTypeRecord>>
+  = T extends ActiveCollectionEntityStore ? CollectionEntityHandle :
+   (T extends ActiveCollectionReferenceStore ? CollectionReferenceHandle :
+   (T extends ActiveSingletonEntityStore ? SingletonEntityHandle :
+   (T extends ActiveSingletonReferenceStore ? SingletonReferenceHandle :
+   (T extends ActiveSingletonInterfaceStore ? SingletonInterfaceHandle :
+    never))));
+
+export function newStore<T extends Type>(type: T, opts: StoreInfo & {storageKey: StorageKey, exists: Exists}): ToStore<T> {
+  return new Store(type, opts) as ToStore<T>;
 }
 
-export function collectionHandle<T extends CRDTReferenceableCollection, U>(
+export function storeType<T extends Store<CRDTTypeRecord>>(store: T) {
+  return store.type as ToType<T>;
+}
+
+export function handleType<T extends Handle<CRDTTypeRecord>>(handle: T) {
+  return handle.type as HandleToType<T>;
+}
+
+export async function newHandle<T extends Type>(type: T, storageKey: StorageKey, arc: ArcLike, options: StoreInfo & HandleOptions): Promise<ToHandle<ToActive<ToStore<T>>>> {
+  options['storageKey'] = storageKey;
+  options['exists'] = Exists.MayExist;
+  const store = newStore(type, options as StoreInfo & {storageKey: StorageKey, exists: Exists});
+  return handleForStore(store, arc, options);
+}
+
+export function handleForActiveStore<T extends CRDTTypeRecord>(
   store: ActiveStore<T>,
   arc: ArcLike,
   options?: HandleOptions
-): CollectionHandle<U> {
+): ToHandle<ActiveStore<T>> {
   const type = options && options.type ? options.type : store.baseStore.type;
   const storageKey = store.baseStore.storageKey.toString();
   const ttl = options && options.ttl ? options.ttl : undefined;
@@ -94,5 +143,16 @@ export function collectionHandle<T extends CRDTReferenceableCollection, U>(
   const canRead = options && options.canRead ? options.canRead : true;
   const canWrite = options && options.canWrite ? options.canWrite : true;
   const name = options && options.name ? options.name : null;
-  return new CollectionHandle(arc.generateID().toString(), proxy, idGenerator, particle, canRead, canWrite, name);
+  const generateID = arc.generateID ? () => arc.generateID().toString() : () => '';
+  if (type instanceof SingletonType) {
+    // tslint:disable-next-line: no-any
+    return new SingletonHandle(generateID(), proxy as any, idGenerator, particle, canRead, canWrite, name) as ToHandle<ActiveStore<T>>;
+  } else {
+    // tslint:disable-next-line: no-any
+    return new CollectionHandle(generateID(), proxy as any, idGenerator, particle, canRead, canWrite, name) as ToHandle<ActiveStore<T>>;
+  }
+}
+
+export async function handleForStore<T extends CRDTTypeRecord>(store: Store<T>, arc: ArcLike, options?: HandleOptions): Promise<ToHandle<ActiveStore<T>>> {
+  return handleForActiveStore(await store.activate(), arc, options);
 }

--- a/src/runtime/storageNG/store-interface.ts
+++ b/src/runtime/storageNG/store-interface.ts
@@ -15,7 +15,6 @@ import {Type} from '../type.js';
 import {Exists} from './drivers/driver.js';
 import {StorageKey} from './storage-key.js';
 import {StorageProxy} from './storage-proxy.js';
-import {UnifiedActiveStore} from './unified-store.js';
 import {Store} from './store.js';
 import {Producer} from '../hot.js';
 import {ChannelConstructor} from '../channel-constructor.js';
@@ -71,7 +70,7 @@ export interface StorageCommunicationEndpointProvider<T extends CRDTTypeRecord> 
 // A representation of an active store. Subclasses of this class provide specific
 // behaviour as controlled by the provided StorageMode.
 export abstract class ActiveStore<T extends CRDTTypeRecord>
-    implements StoreInterface<T>, StorageCommunicationEndpointProvider<T>, UnifiedActiveStore {
+    implements StoreInterface<T>, StorageCommunicationEndpointProvider<T> {
   readonly storageKey: StorageKey;
   exists: Exists;
   readonly type: Type;
@@ -95,7 +94,7 @@ export abstract class ActiveStore<T extends CRDTTypeRecord>
   // tslint:disable-next-line no-any
   abstract async serializeContents(): Promise<T['data']>;
 
-  async cloneFrom(store: UnifiedActiveStore): Promise<void> {
+  async cloneFrom(store: ActiveStore<T>): Promise<void> {
     // TODO(shans): work out what ID to use for messages that aren't from an established
     // channel, like these.
     assert(store instanceof ActiveStore);

--- a/src/runtime/storageNG/store.ts
+++ b/src/runtime/storageNG/store.ts
@@ -12,8 +12,9 @@ import {CRDTModel, CRDTTypeRecord} from '../crdt/crdt.js';
 import {Exists} from './drivers/driver.js';
 import {StorageKey} from './storage-key.js';
 import {StoreInterface, StorageMode, ActiveStore, ProxyMessageType, ProxyMessage, ProxyCallback, StorageCommunicationEndpoint, StorageCommunicationEndpointProvider, StoreConstructor} from './store-interface.js';
-import {UnifiedStore, StoreInfo} from './unified-store.js';
+import {AbstractStore, StoreInfo} from './abstract-store.js';
 import {ReferenceModeStorageKey} from './reference-mode-storage-key.js';
+import {Type} from '../type.js';
 
 export {
   ActiveStore,
@@ -30,12 +31,13 @@ export {
 // StorageProxy objects, and no data will be read or written.
 //
 // Calling 'activate()' will generate an interactive store and return it.
-export class Store<T extends CRDTTypeRecord> extends UnifiedStore implements StoreInterface<T> {
+export class Store<T extends CRDTTypeRecord> extends AbstractStore implements StoreInterface<T> {
   protected unifiedStoreType: 'Store' = 'Store';
 
   readonly storageKey: StorageKey;
   exists: Exists;
   readonly mode: StorageMode;
+  type: Type;
 
   // The last known version of this store that was stored in the serialized
   // representation.
@@ -52,8 +54,9 @@ export class Store<T extends CRDTTypeRecord> extends UnifiedStore implements Sto
   // instead of being defined here.
   static constructors : Map<StorageMode, StoreConstructor> = null;
 
-  constructor(opts: StoreInfo & {storageKey: StorageKey, exists: Exists}) {
+  constructor(type: Type, opts: StoreInfo & {storageKey: StorageKey, exists: Exists}) {
     super(opts);
+    this.type = type;
     this.storageKey = opts.storageKey;
     this.exists = opts.exists;
     this.mode = opts.storageKey instanceof ReferenceModeStorageKey ? StorageMode.ReferenceMode : StorageMode.Direct;

--- a/src/runtime/storageNG/tests/firebase-store-integration-test.ts
+++ b/src/runtime/storageNG/tests/firebase-store-integration-test.ts
@@ -19,7 +19,7 @@ import {CountType} from '../../type.js';
 import {StorageKey} from '../storage-key.js';
 
 function createStore(storageKey: StorageKey, exists: Exists): Store<CRDTCountTypeRecord> {
-  return new Store({storageKey, exists, type: new CountType(), id: 'an-id'});
+  return new Store(new CountType(), {storageKey, exists, id: 'an-id'});
 }
 
 describe('chicken Firebase + Store Integration', async () => {

--- a/src/runtime/storageNG/tests/handle-test.ts
+++ b/src/runtime/storageNG/tests/handle-test.ts
@@ -16,19 +16,21 @@ import {CRDTSingletonTypeRecord, SingletonOperation, SingletonOpTypes} from '../
 import {IdGenerator} from '../../id.js';
 import {Particle} from '../../particle.js';
 import {CollectionType, EntityType, SingletonType, Type} from '../../type.js';
-import {CollectionHandle, SingletonHandle, handleNGFor} from '../handle.js';
+import {CollectionHandle, SingletonHandle} from '../handle.js';
 import {StorageProxy} from '../storage-proxy.js';
 import {ProxyMessageType} from '../store.js';
 import {MockParticle, MockStore} from '../testing/test-storage.js';
 import {Manifest} from '../../manifest.js';
 import {EntityClass, Entity, SerializedEntity} from '../../entity.js';
 import {SYMBOL_INTERNALS} from '../../symbols.js';
+import {CRDTEntityCollection, CollectionEntityStore} from '../storage-ng.js';
 
 
 async function getCollectionHandle(primitiveType: Type, particle?: MockParticle, canRead=true, canWrite=true):
     Promise<CollectionHandle<Entity>> {
   const fakeParticle: Particle = (particle || new MockParticle()) as unknown as Particle;
-  const handle = handleNGFor(
+  const store = new MockStore<CRDTEntityCollection>() as unknown as CollectionEntityStore;
+  const handle = new CollectionHandle(
       'me',
       new StorageProxy(
           'id',
@@ -51,7 +53,7 @@ async function getCollectionHandle(primitiveType: Type, particle?: MockParticle,
 async function getSingletonHandle(primitiveType: Type, particle?: MockParticle, canRead=true, canWrite=true):
     Promise<SingletonHandle<Entity>> {
   const fakeParticle: Particle = (particle || new MockParticle()) as unknown as Particle;
-  const handle = handleNGFor(
+  const handle = new SingletonHandle(
       'me',
       new StorageProxy(
           'id',

--- a/src/runtime/storageNG/tests/ramdisk-backing-store-integration-test.ts
+++ b/src/runtime/storageNG/tests/ramdisk-backing-store-integration-test.ts
@@ -35,7 +35,7 @@ describe('RamDisk + Backing Store Integration', async () => {
     const runtime = new Runtime();
     RamDiskStorageDriverProvider.register(runtime.getMemoryProvider());
     const storageKey = new RamDiskStorageKey('unique');
-    const baseStore = new Store<CRDTCountTypeRecord>({storageKey, exists: Exists.ShouldCreate, type: new CountType(), id: 'base-store-id'});
+    const baseStore = new Store<CRDTCountTypeRecord>(new CountType(), {storageKey, exists: Exists.ShouldCreate, id: 'base-store-id'});
     const store = await BackingStore.construct<CRDTCountTypeRecord>({
       storageKey,
       exists: Exists.ShouldCreate,

--- a/src/runtime/storageNG/tests/ramdisk-store-integration-test.ts
+++ b/src/runtime/storageNG/tests/ramdisk-store-integration-test.ts
@@ -19,7 +19,7 @@ import {CountType} from '../../type.js';
 import {StorageKey} from '../storage-key.js';
 
 function createStore(storageKey: StorageKey, exists: Exists): Store<CRDTCountTypeRecord> {
-  return new Store({storageKey, exists, type: new CountType(), id: 'an-id'});
+  return new Store(new CountType(), {storageKey, exists, id: 'an-id'});
 }
 
 describe('RamDisk + Store Integration', async () => {

--- a/src/runtime/storageNG/tests/reference-mode-store-test.ts
+++ b/src/runtime/storageNG/tests/reference-mode-store-test.ts
@@ -68,7 +68,7 @@ describe('Reference Mode Store', async () => {
 
   beforeEach(() => {
     testKey = new ReferenceModeStorageKey(new MockHierarchicalStorageKey(), new MockHierarchicalStorageKey());
-    baseStore = new Store({storageKey: testKey, exists: Exists.ShouldCreate, type: new SingletonType(new CountType()), id: 'base-store-id'});
+    baseStore = new Store(new SingletonType(new CountType()), {storageKey: testKey, exists: Exists.ShouldCreate, id: 'base-store-id'});
     DriverFactory.clearRegistrationsForTesting();
   });
 
@@ -77,7 +77,7 @@ describe('Reference Mode Store', async () => {
   });
 
   it(`will throw an exception if an appropriate driver can't be found`, async () => {
-    const store = new Store({storageKey: testKey, exists: Exists.ShouldCreate, type: new SingletonType(new CountType()), id: 'an-id'});
+    const store = new Store(new SingletonType(new CountType()), {storageKey: testKey, exists: Exists.ShouldCreate, id: 'an-id'});
     try {
       await store.activate();
       assert.fail('store.activate() should not have succeeded');
@@ -89,7 +89,7 @@ describe('Reference Mode Store', async () => {
   it('will construct ReferenceMode stores when required', async () => {
     DriverFactory.register(new MockStorageDriverProvider());
 
-    const store = new Store({storageKey: testKey, exists: Exists.ShouldCreate, type: new SingletonType(new CountType()), id: 'an-id'});
+    const store = new Store(new SingletonType(new CountType()), {storageKey: testKey, exists: Exists.ShouldCreate, id: 'an-id'});
     const activeStore = await store.activate();
 
     assert.equal(activeStore.constructor, ReferenceModeStore);

--- a/src/runtime/storageNG/tests/store-sequence-test.ts
+++ b/src/runtime/storageNG/tests/store-sequence-test.ts
@@ -26,7 +26,7 @@ import {CountType} from '../../type.js';
 let testKey: StorageKey;
 
 function createStore(storageKey: StorageKey, exists: Exists): Store<CRDTCountTypeRecord> {
-  return new Store({storageKey, exists, type: new CountType(), id: 'an-id'});
+  return new Store(new CountType(), {storageKey, exists, id: 'an-id'});
 }
 
 const incOp = (actor: string, from: number): ProxyMessage<CRDTCountTypeRecord> => (

--- a/src/runtime/storageNG/tests/store-test.ts
+++ b/src/runtime/storageNG/tests/store-test.ts
@@ -22,7 +22,7 @@ import {CRDTTypeRecord} from '../../crdt/crdt.js';
 let testKey: StorageKey;
 
 function createStore(): Store<CRDTTypeRecord> {
-  return new Store({storageKey: testKey, exists: Exists.ShouldCreate, type: new CountType(), id: 'an-id'});
+  return new Store(new CountType(), {storageKey: testKey, exists: Exists.ShouldCreate, id: 'an-id'});
 }
 
 describe('Store', async () => {

--- a/src/runtime/testing/callback-tracker.ts
+++ b/src/runtime/testing/callback-tracker.ts
@@ -10,7 +10,7 @@
 
 import {assert} from '../../platform/chai-web.js';
 import {Dictionary} from '../hot.js';
-import {UnifiedStore} from '../storageNG/unified-store.js';
+import {AbstractStore} from '../storageNG/abstract-store.js';
 
 /**
  * Simple class to verify callbacks used in the Arcs storage APIs.
@@ -29,7 +29,7 @@ export class CallbackTracker {
 
   private constructor(public expectedEvents: number) {}
 
-  static async create(store: UnifiedStore, expectedEvents = 0): Promise<CallbackTracker> {
+  static async create(store: AbstractStore, expectedEvents = 0): Promise<CallbackTracker> {
     const tracker = new CallbackTracker(expectedEvents);
     const activeStore = await store.activate();
     activeStore.on(async val => tracker.changeEvent(val));

--- a/src/runtime/testing/handle-for-test.ts
+++ b/src/runtime/testing/handle-for-test.ts
@@ -7,55 +7,10 @@
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
-import {UnifiedStore} from '../storageNG/unified-store.js';
-import {Arc} from '../arc.js';
-import {SingletonHandle, CollectionHandle} from '../storageNG/handle.js';
-import {ActiveStore} from '../storageNG/store.js';
-import {StorageProxy} from '../storageNG/storage-proxy.js';
-import {CRDTCollectionTypeRecord} from '../crdt/crdt-collection.js';
-import {CRDTTypeRecord} from '../crdt/crdt.js';
-import {CRDTSingletonTypeRecord} from '../crdt/crdt-singleton.js';
-import {Manifest} from '../manifest.js';
-import {SerializedEntity} from '../entity.js';
 import {RamDiskStorageKey} from '../storageNG/drivers/ramdisk.js';
 import {VolatileStorageKey} from '../../runtime/storageNG/drivers/volatile.js';
 import {StorageKey} from '../../runtime/storageNG/storage-key.js';
 import {ArcId} from '../../runtime/id.js';
-
-
-/**
- * Creates a singleton handle for a store for testing purposes. Returns an
- * appropriate OldHandle/HandleNG type depending on the storage migration flag.
- */
-// TODO: Can we correctly type the result here?
-// tslint:disable-next-line: no-any
-export async function singletonHandleForTest(arcOrManifest: Arc | Manifest, store: UnifiedStore): Promise<SingletonHandle<any>> {
-  return new SingletonHandle(
-    arcOrManifest.generateID('test-handle').toString(),
-    await createStorageProxyForTest<CRDTSingletonTypeRecord<SerializedEntity>>(arcOrManifest, store),
-    arcOrManifest.idGenerator,
-    /* particle= */ null, // TODO: We don't have a particle here.
-    /* canRead= */ true,
-    /* canWrite= */ true,
-    /* name?= */ null);
-}
-
-/**
- * Creates a collection handle for a store for testing purposes. Returns an
- * appropriate OldHandle/HandleNG type depending on the storage migration flag.
- */
-// TODO: Can we correctly type the result here?
-// tslint:disable-next-line: no-any
-export async function collectionHandleForTest(arcOrManifest: Arc | Manifest, store: UnifiedStore): Promise<CollectionHandle<any>> {
-  return new CollectionHandle(
-    arcOrManifest.generateID('test-handle').toString(),
-    await createStorageProxyForTest<CRDTCollectionTypeRecord<SerializedEntity>>(arcOrManifest, store),
-    arcOrManifest.idGenerator,
-    /* particle= */ null, // TODO: We don't have a particle here.
-    /* canRead= */ true,
-    /* canWrite= */ true,
-    /* name?= */ null);
-}
 
 /**
  * Creates a storage key prefix for a store for testing purposes. Returns an
@@ -73,13 +28,4 @@ export function ramDiskStorageKeyPrefixForTest(): (arcId: ArcId) => StorageKey {
 
 export function storageKeyForTest(arcId: ArcId): StorageKey {
   return storageKeyPrefixForTest()(arcId);
-}
-
-async function createStorageProxyForTest<T extends CRDTTypeRecord>(
-    arcOrManifest: Arc | Manifest, store: UnifiedStore): Promise<StorageProxy<T>> {
-  const activeStore = await store.activate();
-  if (!(activeStore instanceof ActiveStore)) {
-    throw new Error('Expected an ActiveStore.');
-  }
-  return new StorageProxy(arcOrManifest.generateID('test-proxy').toString(), activeStore, store.type, store.storageKey.toString());
 }

--- a/src/runtime/tests/data-layer-test.ts
+++ b/src/runtime/tests/data-layer-test.ts
@@ -17,7 +17,8 @@ import {Schema} from '../schema.js';
 import {EntityType} from '../type.js';
 import {Entity} from '../entity.js';
 import {ArcId} from '../id.js';
-import {collectionHandleForTest} from '../testing/handle-for-test.js';
+import {handleForStore} from '../storageNG/storage-ng.js';
+import {isCollectionEntityStore, entityHasName} from '../storageNG/abstract-store.js';
 
 describe('entity', () => {
   it('can be created, stored, and restored', async () => {
@@ -32,14 +33,15 @@ describe('entity', () => {
     const collectionType = new EntityType(schema).collectionOf();
 
     const storage = await arc.createStore(collectionType);
-    const handle = await collectionHandleForTest(arc, storage);
+    const handle = await handleForStore(storage, arc);
     await handle.add(entity);
 
-    const collection = await collectionHandleForTest(arc, arc.findStoresByType(collectionType)[0]);
+    const store = arc._stores.filter(isCollectionEntityStore).find(entityHasName('TestSchema'));
+    const collection = await handleForStore(store, arc);
     const list = await collection.toList();
     const clone = list[0];
     assert.isDefined(clone);
-    assert.deepEqual(clone, {value: 'hello world'});
+    assert.deepEqual(clone as {}, {value: 'hello world'});
 
     // TODO(https://github.com/PolymerLabs/arcs/pull/2916#discussion_r277793505)
     // Test that clone/entity are not deeply equal.  Revisit once we

--- a/src/runtime/tests/manifest-test.ts
+++ b/src/runtime/tests/manifest-test.ts
@@ -22,7 +22,6 @@ import {CheckHasTag, CheckBooleanExpression, CheckCondition, CheckIsFromStore} f
 import {ProvideSlotConnectionSpec} from '../particle-spec.js';
 import {Schema} from '../schema.js';
 import {Store} from '../storageNG/store.js';
-import {collectionHandleForTest} from '../testing/handle-for-test.js';
 import {Entity} from '../entity.js';
 import {RamDiskStorageDriverProvider, RamDiskStorageKey} from '../storageNG/drivers/ramdisk.js';
 import {digest} from '../../platform/digest-web.js';
@@ -33,7 +32,8 @@ import {Runtime} from '../runtime.js';
 import {BinaryExpression, FieldNamePrimitive, NumberPrimitive} from '../refiner.js';
 import {mockFirebaseStorageKeyOptions} from '../storageNG/testing/mock-firebase.js';
 import {Flags} from '../flags.js';
-import {TupleType, CollectionType, ReferenceType} from '../type.js';
+import {TupleType, CollectionType} from '../type.js';
+import {ActiveCollectionEntityStore, handleForActiveStore} from '../storageNG/storage-ng.js';
 
 function verifyPrimitiveType(field, type) {
   const copy = {...field};
@@ -1774,9 +1774,9 @@ recipe SomeRecipe
     const manifest = await Manifest.load('./the.manifest', loader, {memoryProvider});
     const storageStub = manifest.findStoreByName('Store0');
     assert(storageStub);
-    const store = await storageStub.activate();
+    const store = await storageStub.activate() as ActiveCollectionEntityStore;
     assert(store);
-    const handle = await collectionHandleForTest(manifest, store.baseStore);
+    const handle = handleForActiveStore(store, manifest);
 
     assert.deepEqual((await handle.toList()).map(Entity.serialize), [
       {
@@ -1828,9 +1828,9 @@ Error parsing JSON from 'EntityList' (Unexpected token h in JSON at position 1)'
 
       store Store0 of [Thing] in EntityList
     `, {fileName: 'the.manifest', memoryProvider});
-    const store = (await manifest.findStoreByName('Store0').activate());
+    const store = (await manifest.findStoreByName('Store0').activate()) as ActiveCollectionEntityStore;
     assert(store);
-    const handle = await collectionHandleForTest(manifest, store.baseStore);
+    const handle = handleForActiveStore(store, manifest);
 
     // TODO(shans): address as part of storage refactor
     assert.deepEqual((await handle.toList()).map(Entity.serialize), [

--- a/src/runtime/tests/multiplexer-test.ts
+++ b/src/runtime/tests/multiplexer-test.ts
@@ -15,7 +15,8 @@ import {Loader} from '../../platform/loader.js';
 import {Manifest} from '../manifest.js';
 import {checkDefined} from '../testing/preconditions.js';
 import {SlotComposer} from '../slot-composer.js';
-import {collectionHandleForTest} from '../testing/handle-for-test.js';
+import {handleForStore} from '../storageNG/storage-ng.js';
+import {EntityType} from '../type.js';
 
 describe('Multiplexer', () => {
   it('processes multiple inputs', async () => {
@@ -33,12 +34,12 @@ describe('Multiplexer', () => {
     `, {loader: new Loader(), fileName: ''});
 
     const recipe = manifest.recipes[0];
-    const barType = checkDefined(manifest.findTypeByName('Bar'));
+    const barType = checkDefined(manifest.findTypeByName('Bar')) as EntityType;
     const slotComposer = new SlotComposer();
 
     const arc = new Arc({id: ArcId.newForTest('test'), context: manifest, slotComposer, loader: new Loader()});
     const barStore = await arc.createStore(barType.collectionOf(), null, 'test:1');
-    const barHandle = await collectionHandleForTest(arc, barStore);
+    const barHandle = await handleForStore(barStore, arc);
     recipe.handles[0].mapToStorage(barStore);
     assert(recipe.normalize(), 'normalize');
     assert(recipe.isResolved());

--- a/src/runtime/tests/particle-api-more-test.ts
+++ b/src/runtime/tests/particle-api-more-test.ts
@@ -9,30 +9,30 @@
  */
 
 import {assert} from '../../platform/chai-web.js';
-import {SlotComposer} from '../slot-composer.js';
 import {Loader} from '../../platform/loader.js';
 import {Manifest} from '../manifest.js';
 import {Runtime} from '../runtime.js';
 import {Arc} from '../arc.js';
-import {singletonHandleForTest, collectionHandleForTest, storageKeyPrefixForTest} from '../testing/handle-for-test.js';
+import {storageKeyPrefixForTest} from '../testing/handle-for-test.js';
+import {SingletonEntityStore, CollectionEntityStore, SingletonEntityHandle, CollectionEntityHandle, handleForStore} from '../storageNG/storage-ng.js';
 
 //
 // TODO(sjmiles): deref'ing stores by index is brittle, but `id` provided to create syntax
 // doesn't end up on the store, and searching by type or tags is hard (?)
 //
 const getSingletonData = async (arc: Arc, index: number) => {
-  const store = arc._stores[index];
+  const store = arc._stores[index] as SingletonEntityStore;
   assert.ok(store, `failed to find store[${index}]`);
-  const handle = await singletonHandleForTest(arc, store);
+  const handle: SingletonEntityHandle = await handleForStore(store, arc);
   const data = await handle.fetch();
   assert.ok(data, `store[${index}] was empty`);
   return data;
 };
 
 const getCollectionData = async (arc: Arc, index: number) => {
-  const store = arc._stores[index];
+  const store = arc._stores[index] as CollectionEntityStore;
   assert.ok(store, `failed to find store[${index}]`);
-  const handle = await collectionHandleForTest(arc, store);
+  const handle: CollectionEntityHandle = await handleForStore(store, arc);
   const data = await handle.toList();
   assert.ok(data, `store[${index}] was empty`);
   return data;

--- a/src/runtime/tests/particle-interface-loading-with-slots-test.ts
+++ b/src/runtime/tests/particle-interface-loading-with-slots-test.ts
@@ -16,9 +16,8 @@ import {Manifest} from '../manifest.js';
 import {SlotComposer} from '../slot-composer.js';
 import {SlotTestObserver} from '../testing/slot-test-observer.js';
 import {Recipe} from '../recipe/recipe.js';
-import {collectionHandleForTest} from '../testing/handle-for-test.js';
-import {CollectionHandle} from '../storageNG/handle.js';
 import {Entity} from '../entity.js';
+import {CollectionEntityStore, handleForStore, CollectionEntityHandle} from '../storageNG/storage-ng.js';
 
 describe('particle interface loading with slots', () => {
   async function initializeManifestAndArc(contextContainer?):
@@ -49,12 +48,12 @@ describe('particle interface loading with slots', () => {
   }
 
   // tslint:disable-next-line: no-any
-  async function instantiateRecipeAndStore(arc: Arc, recipe: Recipe, manifest: Manifest): Promise<CollectionHandle<any>> {
+  async function instantiateRecipeAndStore(arc: Arc, recipe: Recipe, manifest: Manifest): Promise<CollectionEntityHandle> {
     await arc.instantiate(recipe);
-    const inStore = arc.findStoresByType(manifest.findTypeByName('Foo').collectionOf())[0];
-    const inHandle = await collectionHandleForTest(arc, inStore);
-    await inHandle.add(Entity.identify(new inHandle.entityClass({value: 'foo1'}), 'subid-1', null, null));
-    await inHandle.add(Entity.identify(new inHandle.entityClass({value: 'foo2'}), 'subid-2', null, null));
+    const inStore = arc.findStoresByType(manifest.findTypeByName('Foo').collectionOf())[0] as CollectionEntityStore;
+    const inHandle = await handleForStore(inStore, arc);
+    await inHandle.add(Entity.identify(new inHandle.entityClass({value: 'foo1'}), 'subid-1', null));
+    await inHandle.add(Entity.identify(new inHandle.entityClass({value: 'foo2'}), 'subid-2', null));
     return inHandle;
   }
 

--- a/src/runtime/tests/runtime-manifest-integration-test.ts
+++ b/src/runtime/tests/runtime-manifest-integration-test.ts
@@ -10,7 +10,7 @@
 
 import {assert} from '../../platform/chai-web.js';
 import {manifestTestSetup} from '../testing/manifest-integration-test-setup.js';
-import {singletonHandleForTest} from '../testing/handle-for-test.js';
+import {SingletonEntityStore, handleForStore} from '../storageNG/storage-ng.js';
 
 describe('runtime manifest integration', () => {
   it('can produce a recipe that can be instantiated in an arc', async () => {
@@ -18,9 +18,9 @@ describe('runtime manifest integration', () => {
     await arc.instantiate(recipe);
     await arc.idle;
     const type = recipe.handles[0].type;
-    const [store] = arc.findStoresByType(type);
+    const [store] = arc.findStoresByType(type) as SingletonEntityStore[];
 
-    const handle = await singletonHandleForTest(arc, store);
+    const handle = await handleForStore(store, arc);
     // TODO: This should not be necessary.
     type.maybeEnsureResolved();
     const result = await handle.fetch();

--- a/src/runtime/type.ts
+++ b/src/runtime/type.ts
@@ -122,7 +122,7 @@ export abstract class Type {
     return this instanceof BigCollectionType;
   }
 
-  isReferenceType(): this is ReferenceType {
+  isReferenceType(): this is ReferenceType<Type> {
     return this instanceof ReferenceType;
   }
 
@@ -933,10 +933,10 @@ export class SlotType extends Type {
 }
 
 
-export class ReferenceType extends Type {
-  readonly referredType: Type;
+export class ReferenceType<T extends Type> extends Type {
+  readonly referredType: T;
 
-  constructor(reference: Type) {
+  constructor(reference: T) {
     super('Reference');
     if (reference == null) {
       throw new Error('invalid type! Reference types must include a referenced type declaration');
@@ -948,7 +948,7 @@ export class ReferenceType extends Type {
     return true;
   }
 
-  getContainedType(): Type {
+  getContainedType(): T {
     return this.referredType;
   }
 
@@ -984,8 +984,8 @@ export class ReferenceType extends Type {
     return Type.fromLiteral({tag: this.tag, data});
   }
 
-  _cloneWithResolutions(variableMap: Map<TypeVariableInfo|Schema, TypeVariableInfo|Schema>): ReferenceType {
-    return new ReferenceType(this.referredType._cloneWithResolutions(variableMap));
+  _cloneWithResolutions(variableMap: Map<TypeVariableInfo|Schema, TypeVariableInfo|Schema>): ReferenceType<T> {
+    return new ReferenceType<T>(this.referredType._cloneWithResolutions(variableMap) as T);
   }
 
   toLiteral(): TypeLiteral {

--- a/src/tests/hotreload-integration-test.ts
+++ b/src/tests/hotreload-integration-test.ts
@@ -15,8 +15,8 @@ import {ArcId} from '../runtime/id.js';
 import {Loader} from '../platform/loader.js';
 import {SlotComposer} from '../runtime/slot-composer.js';
 import {FakePecFactory} from '../runtime/fake-pec-factory.js';
-import {singletonHandleForTest} from '../runtime/testing/handle-for-test.js';
-import {RuntimeCacheService} from '../runtime/runtime-cache.js';
+import {handleForStore} from '../runtime/storageNG/storage-ng.js';
+import {SingletonType, EntityType} from '../runtime/type.js';
 
 const manifestFile = 'src/tests/source/schemas.arcs';
 
@@ -126,13 +126,13 @@ describe('Hot Code Reload for JS Particle', async () => {
     });
 
     const arc = new Arc({id: ArcId.newForTest('test'), context, loader});
-    const personType = context.findTypeByName('Person');
+    const personType = context.findTypeByName('Person') as EntityType;
 
-    const personStoreIn = await arc.createStore(personType);
-    const personStoreOut = await arc.createStore(personType);
-    const personHandleIn = await singletonHandleForTest(arc, personStoreIn);
-    const personHandleOut = await singletonHandleForTest(arc, personStoreOut);
-    await personHandleIn.set(new personHandleIn.entityClass({name: 'Jack', age: 15}));
+    const personStoreIn = await arc.createStore(new SingletonType(personType));
+    const personStoreOut = await arc.createStore(new SingletonType(personType));
+    const personHandleIn = await handleForStore(personStoreIn, arc);
+    const personHandleOut = await handleForStore(personStoreOut, arc);
+    await personHandleIn.setFromData({name: 'Jack', age: 15});
 
     const recipe = context.recipes[0];
     recipe.handles[0].mapToStorage(personStoreIn);
@@ -141,7 +141,7 @@ describe('Hot Code Reload for JS Particle', async () => {
 
     await arc.instantiate(recipe);
     await arc.idle;
-    assert.deepStrictEqual(await personHandleOut.fetch(), {name: 'Jack', age: 30});
+    assert.deepStrictEqual(await personHandleOut.fetch() as {}, {name: 'Jack', age: 30});
 
     loader.staticMap['A.js'] = `defineParticle(({Particle}) => {
       return class extends Particle {
@@ -161,9 +161,9 @@ describe('Hot Code Reload for JS Particle', async () => {
     });`;
     arc.peh.reload(arc.peh.particles);
     await arc.idle;
-    await personHandleIn.set(new personHandleIn.entityClass({name: 'Jane', age: 20}));
+    await personHandleIn.setFromData({name: 'Jane', age: 20});
     await arc.idle;
-    assert.deepStrictEqual(await personHandleOut.fetch(), {name: 'Jane', age: 18});
+    assert.deepStrictEqual(await personHandleOut.fetch() as {}, {name: 'Jane', age: 18});
   });
 });
 
@@ -209,13 +209,13 @@ describe('Hot Code Reload for WASM Particle', async () => {
     const context = await Manifest.load(manifestFile, loader);
 
     const arc = new Arc({id: ArcId.newForTest('test'), context, loader});
-    const personType = context.findTypeByName('Person');
+    const personType = context.findTypeByName('Person') as EntityType;
 
-    const personStoreIn = await arc.createStore(personType);
-    const personStoreOut = await arc.createStore(personType);
-    const personHandleIn = await singletonHandleForTest(arc, personStoreIn);
-    const personHandleOut = await singletonHandleForTest(arc, personStoreOut);
-    await personHandleIn.set(new personHandleIn.entityClass({name: 'Jack', age: 15}));
+    const personStoreIn = await arc.createStore(new SingletonType(personType));
+    const personStoreOut = await arc.createStore(new SingletonType(personType));
+    const personHandleIn = await handleForStore(personStoreIn, arc);
+    const personHandleOut = await handleForStore(personStoreOut, arc);
+    await personHandleIn.setFromData({name: 'Jack', age: 15});
 
     const recipe = context.recipes.filter(r => r.name === 'ReloadHandleRecipe')[0];
     recipe.handles[0].mapToStorage(personStoreIn);
@@ -224,13 +224,13 @@ describe('Hot Code Reload for WASM Particle', async () => {
 
     await arc.instantiate(recipe);
     await arc.idle;
-    assert.deepStrictEqual(await personHandleOut.fetch(), {name: 'Jack', age: 30});
+    assert.deepStrictEqual(await personHandleOut.fetch() as {}, {name: 'Jack', age: 30});
 
     loader.reloaded = true;
     arc.peh.reload(arc.peh.particles);
     await arc.idle;
     await personHandleIn.set(new personHandleIn.entityClass({name: 'Jane', age: 20}));
     await arc.idle;
-    assert.deepStrictEqual(await personHandleOut.fetch(), {name: 'Jane', age: 18});
+    assert.deepStrictEqual(await personHandleOut.fetch() as {}, {name: 'Jane', age: 18});
   });
 });

--- a/src/tests/particles/common-test.ts
+++ b/src/tests/particles/common-test.ts
@@ -16,7 +16,7 @@ import {Loader} from '../../platform/loader.js';
 import {StrategyTestHelper} from '../../planning/testing/strategy-test-helper.js';
 import {RamDiskStorageDriverProvider} from '../../runtime/storageNG/drivers/ramdisk.js';
 import {storageKeyPrefixForTest} from '../../runtime/testing/handle-for-test.js';
-import {collectionHandle, ActiveCollectionEntityStore} from '../../runtime/storageNG/storage-ng.js';
+import {ActiveCollectionEntityStore, handleForActiveStore} from '../../runtime/storageNG/storage-ng.js';
 
 describe('common particles test', () => {
   it('resolves after cloning', async () => {
@@ -90,7 +90,7 @@ describe('common particles test', () => {
     await arc.idle;
 
     const endpointProvider = await arc._stores[2].activate() as ActiveCollectionEntityStore;
-    const handle = collectionHandle(endpointProvider, arc);
+    const handle = handleForActiveStore(endpointProvider, arc);
     assert.strictEqual((await handle.toList()).length, 5);
   });
 });

--- a/src/tests/particles/products-test.ts
+++ b/src/tests/particles/products-test.ts
@@ -18,8 +18,9 @@ import {SlotComposer} from '../../runtime/slot-composer.js';
 import {SlotTestObserver} from '../../runtime/testing/slot-test-observer.js';
 import {DriverFactory} from '../../runtime/storageNG/drivers/driver-factory.js';
 import {RamDiskStorageDriverProvider} from '../../runtime/storageNG/drivers/ramdisk.js';
-import {collectionHandleForTest, storageKeyForTest, storageKeyPrefixForTest} from '../../runtime/testing/handle-for-test.js';
+import {storageKeyForTest, storageKeyPrefixForTest} from '../../runtime/testing/handle-for-test.js';
 import {TestVolatileMemoryProvider} from '../../runtime/testing/test-volatile-memory-provider.js';
+import {CollectionEntityStore, CollectionEntityHandle, handleForStore} from '../../runtime/storageNG/storage-ng.js';
 
 describe('products test', () => {
 
@@ -31,8 +32,8 @@ describe('products test', () => {
 
   const verifyFilteredBook = async (arc: Arc) => {
     const booksHandle = arc.activeRecipe.handleConnections.find(hc => hc.isOutput).handle;
-    const store = arc.findStoreById(booksHandle.id);
-    const handle = await collectionHandleForTest(arc, store);
+    const store = arc.findStoreById(booksHandle.id) as CollectionEntityStore;
+    const handle: CollectionEntityHandle = await handleForStore(store, arc);
     const list = await handle.toList();
     assert.lengthOf(list, 1);
     assert.strictEqual('Harry Potter', list[0].name);

--- a/src/tools/storage-key-recipe-resolver.ts
+++ b/src/tools/storage-key-recipe-resolver.ts
@@ -112,7 +112,7 @@ export class StorageKeyRecipeResolver {
       }
       const storageKey = await resolver.createStorageKey(
           createHandle.capabilities, createHandle.type.getEntitySchema(), createHandle.id);
-      const store = new Store({storageKey, exists: Exists.MayExist, type: createHandle.type, id: createHandle.id});
+      const store = new Store(createHandle.type, {storageKey, exists: Exists.MayExist, id: createHandle.id});
       arc.context.registerStore(store, createHandle.tags);
     }
   }


### PR DESCRIPTION
.. set of methods for creating stores and handles.

This PR replaces all the varying ways we create handles (new StorageProxy/handleNGFor, singletonHandleForTest, collectionHandleForTest, etc.) with a single set of implementations, found in storage-ng.ts.

Some type trickery also allows us to derive a fully functional handle type from the provided Type, which is neat. This has been extended throughout the various places that vend stores (e.g. arc.createStore or arc.findStoresByType).

Finally, a sketch of some predicates for searching through arc._stores in a type-aware manner has been provided. I'll probably extend this later.