### PR TITLE
Restore tests that filter Particles by modality

### DIFF
--- a/src/planning/plan/tests/plan-consumer-test.ts
+++ b/src/planning/plan/tests/plan-consumer-test.ts
@@ -122,7 +122,7 @@ describe('plan consumer', () => {
   });
 
   it('filters suggestions by modality', async () => {
-    const initConsumer = async (modalityName) => {
+    const initConsumer = async (modality) => {
       const addRecipe = (particles) => {
         return `
   recipe
@@ -152,7 +152,7 @@ ${addRecipe(['ParticleDom', 'ParticleBoth'])}
 ${addRecipe(['ParticleTouch', 'ParticleBoth'])}
         `, {loader, fileName: '', memoryProvider});
       const runtime = new Runtime({loader, context, memoryProvider});
-      const arc = runtime.newArc('demo', storageKeyPrefixForTest());
+      const arc = runtime.newArc('demo', storageKeyPrefixForTest(), {modality});
       assert.lengthOf(arc.context.allRecipes, 4);
       const consumer = await createPlanConsumer(arc);
       assert.isNotNull(consumer);
@@ -167,28 +167,22 @@ ${addRecipe(['ParticleTouch', 'ParticleBoth'])}
       return consumer;
     };
 
-    const consumerDom = await initConsumer(Modality.Name.Dom);
-    // TODO(sjmiles): modality detection has changed, this will be restored in a follow-up PR
-    //const domSuggestions = consumerDom.getCurrentSuggestions();
-    //assert.lengthOf(domSuggestions, 2);
-    //assert.deepEqual(domSuggestions.map(s => s.plan.particles.map(p => p.name)),
-    //    [['ParticleDom'], ['ParticleDom', 'ParticleBoth']]);
-
+    const consumerDom = await initConsumer(Modality.dom);
+    const domSuggestions = consumerDom.getCurrentSuggestions();
+    assert.lengthOf(domSuggestions, 2);
+    assert.deepEqual(domSuggestions.map(s => s.plan.particles.map(p => p.name)),
+        [['ParticleDom'], ['ParticleDom', 'ParticleBoth']]);
     DriverFactory.clearRegistrationsForTesting();
 
-    // TODO(sjmiles): modality detection has changed, this will be restored in a follow-up PR
-    //const consumerVr = await initConsumer(Modality.Name.Vr);
-    //assert.isEmpty(consumerVr.getCurrentSuggestions());
-
+    const consumerVr = await initConsumer(Modality.vr);
+    assert.isEmpty(consumerVr.getCurrentSuggestions());
     DriverFactory.clearRegistrationsForTesting();
 
-    // TODO(sjmiles): modality detection has changed, this will be restored in a follow-up PR
-    //const consumerTouch = await initConsumer(Modality.Name.DomTouch);
-    //const touchSuggestions = consumerTouch.getCurrentSuggestions();
-    //assert.lengthOf(touchSuggestions, 2);
-    //assert.deepEqual(touchSuggestions.map(s => s.plan.particles.map(p => p.name)),
-    //    [['ParticleTouch'], ['ParticleTouch', 'ParticleBoth']]);
-
+    const consumerTouch = await initConsumer(Modality.domTouch);
+    const touchSuggestions = consumerTouch.getCurrentSuggestions();
+    assert.lengthOf(touchSuggestions, 2);
+    assert.deepEqual(touchSuggestions.map(s => s.plan.particles.map(p => p.name)),
+       [['ParticleTouch'], ['ParticleTouch', 'ParticleBoth']]);
     DriverFactory.clearRegistrationsForTesting();
   });
 });

--- a/src/planning/strategies/tests/convert-constraints-to-connections-test.ts
+++ b/src/planning/strategies/tests/convert-constraints-to-connections-test.ts
@@ -301,15 +301,14 @@ describe('ConvertConstraintsToConnections', () => {
     const generated = [{result: manifest.recipes[0], score: 1, derivation: [], hash: '0', valid: true}, {result: manifest.recipes[1], score: 1, derivation: [], hash: '0', valid: true}];
     const cctc = new ConvertConstraintsToConnections(new Arc({
       id: ArcId.newForTest('test-plan-arc'),
-      slotComposer: new SlotComposer(/*{modalityName: Modality.Name.Vr}*/),
       context: manifest,
-      loader: new Loader()
+      loader: new Loader(),
+      modality: Modality.vr
     }));
 
     const results = await cctc.generateFrom(generated);
-    // TODO(sjmiles): modality detection has changed, this will be restored in a follow-up PR
-    //assert.lengthOf(results, 1);
-    //assert.deepEqual(results[0].result.particles.map(p => p.name), ['A', 'C']);
+    assert.lengthOf(results, 1);
+    assert.deepEqual(results[0].result.particles.map(p => p.name), ['A', 'C']);
   });
 
   it('connects to handles', async () => {

--- a/src/planning/strategies/tests/match-particle-by-verb-test.ts
+++ b/src/planning/strategies/tests/match-particle-by-verb-test.ts
@@ -54,16 +54,16 @@ describe('MatchParticleByVerb', () => {
 
   it('particles by verb strategy', async () => {
     const manifest = (await Manifest.parse(manifestStr));
-    const arc = StrategyTestHelper.createTestArc(manifest, {modalityName: Modality.Name.Dom});
+    const arc = StrategyTestHelper.createTestArc(manifest, {modality: Modality.dom});
     // Apply MatchParticleByVerb strategy.
     const inputParams = {generated: [{result: manifest.recipes[0], score: 1}]};
     const mpv = new MatchParticleByVerb(arc, StrategyTestHelper.createTestStrategyArgs(arc));
 
     const results = await mpv.generate(inputParams);
-    // TODO(sjmiles): modality detection has changed, this will be restored in a follow-up PR
-    //assert.lengthOf(results, 3);
+    assert.lengthOf(results, 3);
     // Note: handle connections are not resolved yet.
-    //assert.deepEqual(['GalaxyJumper', 'SimpleJumper', 'StarJumper'], results.map(r => r.result.particles[0].name).sort());
+    assert.deepEqual(['GalaxyJumper', 'SimpleJumper', 'StarJumper'],
+        results.map(r => r.result.particles[0].name).sort());
   });
 
   it('particles by verb recipe fully resolved', async () => {
@@ -72,16 +72,15 @@ describe('MatchParticleByVerb', () => {
     recipe.handles[0].mapToStorage({id: 'test1', type: Entity.createEntityClass(manifest.findSchemaByName('Height'), null).type});
     recipe.handles[1].mapToStorage({id: 'test2', type: Entity.createEntityClass(manifest.findSchemaByName('Energy'), null).type});
 
-    const arc = StrategyTestHelper.createTestArc(manifest, {modalityName: Modality.Name.Dom});
+    const arc = StrategyTestHelper.createTestArc(manifest, {modality: Modality.dom});
 
     // Apply all strategies to resolve recipe where particles are referenced by verbs.
     const planner = new Planner();
     planner.init(arc, {strategyArgs: StrategyTestHelper.createTestStrategyArgs(arc)});
     const plans = await planner.plan(1000);
 
-    // TODO(sjmiles): modality detection has changed, this will be restored in a follow-up PR
-    //assert.lengthOf(plans, 2);
-    //assert.deepEqual(plans.map(plan => plan.particles.map(particle => particle.name)),
-    //  [['SimpleJumper'], ['StarJumper']]);
+    assert.lengthOf(plans, 2);
+    assert.deepEqual(plans.map(plan => plan.particles.map(particle => particle.name)),
+        [['SimpleJumper'], ['StarJumper']]);
   });
 });

--- a/src/planning/testing/strategy-test-helper.ts
+++ b/src/planning/testing/strategy-test-helper.ts
@@ -18,14 +18,16 @@ import {RecipeIndex} from '../recipe-index.js';
 import {Id, ArcId} from '../../runtime/id.js';
 import {Planner} from '../planner.js';
 import {Suggestion} from '../plan/suggestion.js';
+import {Modality} from '../../runtime/modality.js';
 
 export class StrategyTestHelper {
-  static createTestArc(context: Manifest, options: {arcId?: Id, modalityName?: string, loader?: Loader} = {}) {
+  static createTestArc(context: Manifest, options: {arcId?: Id, modality?: Modality, loader?: Loader} = {}) {
     return new Arc({
       id: options.arcId || ArcId.newForTest('test-arc'),
       loader: options.loader || new Loader(),
-      context,
-      slotComposer: new SlotComposer()
+      slotComposer: new SlotComposer(),
+      modality: options.modality,
+      context
     });
   }
   static createTestStrategyArgs(arc: Arc, args?) {

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -28,6 +28,7 @@ import {pecIndustry} from '../platform/pec-industry.js';
 import {logsFactory} from '../platform/logs-factory.js';
 import {SystemTrace} from '../tracelib/systrace.js';
 import {workerPool} from './worker-pool.js';
+import {Modality} from './modality.js';
 
 const {warn} = logsFactory('Runtime', 'orange');
 
@@ -47,6 +48,7 @@ export type RuntimeArcOptions = Readonly<{
   listenerClasses?: ArcInspectorFactory[];
   inspectorFactory?: ArcInspectorFactory;
   storageKeyCreators?: StorageKeyCreatorInfo[];
+  modality?: Modality;
 }>;
 
 type SpawnArgs = {
@@ -111,9 +113,6 @@ export class Runtime {
     const loader = new Loader(map);
     const pecFactory = pecIndustry(loader);
     const memoryProvider = new SimpleVolatileMemoryProvider();
-    // TODO(sjmiles): SlotComposer type shenanigans are temporary pending complete replacement
-    // of SlotComposer by SlotComposer. Also it's weird that `new Runtime(..., SlotComposer, ...)`
-    // doesn't bother tslint at all when done in other modules.
     const runtime = new Runtime({
       loader,
       composerClass: SlotComposer,


### PR DESCRIPTION
- adds `modality: Modality` property to `Arc` class (note that a Modality object can represent multiple modalities)
