### PR TITLE
Adds "namespace" to Arcs Manifest and uses it for code generation.

### DIFF
--- a/java/arcs/core/data/testdata/BUILD
+++ b/java/arcs/core/data/testdata/BUILD
@@ -24,6 +24,5 @@ arcs_manifest_proto(
 arcs_kt_plan(
     name = "example_plan",
     src = "WriterReaderExample.arcs",
-    package = "arcs.core.data.testdata",
     visibility = ["//visibility:public"],
 )

--- a/java/arcs/core/data/testdata/WriterReaderExample.arcs
+++ b/java/arcs/core/data/testdata/WriterReaderExample.arcs
@@ -1,3 +1,6 @@
+meta
+  namespace: arcs.core.data.testdata
+
 particle Reader
   data: reads Thing {name: Text}
 

--- a/java/arcs/core/host/ArcHostContext.arcs
+++ b/java/arcs/core/host/ArcHostContext.arcs
@@ -1,3 +1,5 @@
+meta
+  namespace: arcs.core.host
 // These schema definitions are used to store a de-normalized version of ArcHostContext via ArcHostContextParticle
 
 // Represents a de-normalized Map<String, Plan.HandleConnection>

--- a/java/arcs/core/host/BUILD
+++ b/java/arcs/core/host/BUILD
@@ -9,7 +9,6 @@ arcs_kt_schema(
     srcs = [
         "ArcHostContext.arcs",
     ],
-    package = "arcs.core.host",
 )
 
 arcs_kt_library(

--- a/java/arcs/sdk/README.md
+++ b/java/arcs/sdk/README.md
@@ -24,8 +24,6 @@ See [this](../../../particles/Native/Wasm) or [this](../../../particles/Tutorial
       name = "example_schema",
       # Input source.
       src = "example.arcs",
-      # Optionally, specify package where entities will reside.
-      package = "arcs.example",
   )
   ```
 - Write your Kotlin particle(s): See [this Kotlin tutorial](../../../particles/Tutorial/Kotlin) for greater detail.

--- a/javatests/arcs/android/host/BUILD
+++ b/javatests/arcs/android/host/BUILD
@@ -54,7 +54,6 @@ arcs_kt_schema(
     srcs = [
         "test.arcs",
     ],
-    package = "arcs.android.host",
 )
 
 kt_android_library(

--- a/javatests/arcs/android/host/test.arcs
+++ b/javatests/arcs/android/host/test.arcs
@@ -1,3 +1,5 @@
+meta
+  namespace: arcs.android.host
 
 schema Person
   name: Text

--- a/javatests/arcs/core/host/BUILD
+++ b/javatests/arcs/core/host/BUILD
@@ -30,7 +30,6 @@ arcs_kt_schema(
         "person.arcs",
         "test.arcs",
     ],
-    package = "arcs.core.host",
 )
 
 arcs_kt_jvm_library(

--- a/javatests/arcs/core/host/person.arcs
+++ b/javatests/arcs/core/host/person.arcs
@@ -1,3 +1,6 @@
+meta
+  namespace: arcs.core.host
+
 schema Person
   name: Text
 

--- a/javatests/arcs/core/host/test.arcs
+++ b/javatests/arcs/core/host/test.arcs
@@ -1,3 +1,6 @@
+meta
+  namespace: arcs.core.host
+
 particle TestProdParticle in 'arcs.core.host.TestProdParticle'
 
 particle TestHostParticle in 'arcs.core.host.TestHostParticle'

--- a/javatests/arcs/sdk/wasm/BUILD
+++ b/javatests/arcs/sdk/wasm/BUILD
@@ -26,7 +26,6 @@ PARTICLE_TEST_SRCS = glob(
 arcs_kt_schema(
     name = "schemas",
     srcs = ["manifest.arcs"],
-    package = "arcs.sdk.wasm",
 )
 
 arcs_kt_particles(

--- a/javatests/arcs/sdk/wasm/manifest.arcs
+++ b/javatests/arcs/sdk/wasm/manifest.arcs
@@ -1,3 +1,6 @@
+meta
+  namespace: arcs.sdk.wasm
+
 particle HandleSyncUpdateTest in '$module.wasm'
   sng: reads {num: Number, txt: Text, lnk: URL, flg: Boolean, ref: &Foo {val: Text}}
   col: reads [{num: Number, txt: Text, lnk: URL, flg: Boolean, ref: &Foo {val: Text}}]

--- a/particles/Blackjack/BUILD
+++ b/particles/Blackjack/BUILD
@@ -9,7 +9,6 @@ licenses(["notice"])
 arcs_kt_schema(
     name = "blackjack_schemas",
     srcs = ["Blackjack.arcs"],
-    package = "arcs.tutorials.blackjack",
 )
 
 arcs_kt_particles(

--- a/particles/Blackjack/Blackjack.arcs
+++ b/particles/Blackjack/Blackjack.arcs
@@ -1,3 +1,6 @@
+meta
+  namespace: arcs.tutorials.blackjack
+
 // Encodes a card from 0 to 51. -1 indicates an invalid (or joker).
 schema Card
   value: Number

--- a/particles/Native/Wasm/BUILD
+++ b/particles/Native/Wasm/BUILD
@@ -32,13 +32,12 @@ arcs_kt_schema(
         "Harness.arcs",
         "Services.arcs",
     ],
-    package = "arcs.test",
 )
 
 arcs_kt_particles(
     name = "service_particle",
     srcs = ["source/ServiceParticle.kt"],
-    package = "arcs.test",
+    package = "arcs",
     platforms = ["wasm"],
     deps = [":wasm_schemas"],
 )
@@ -46,7 +45,7 @@ arcs_kt_particles(
 arcs_kt_particles(
     name = "test_particle",
     srcs = ["source/TestParticle.kt"],
-    package = "arcs.test",
+    package = "arcs",
     platforms = ["wasm"],
     deps = [":wasm_schemas"],
 )

--- a/particles/Native/Wasm/Harness.arcs
+++ b/particles/Native/Wasm/Harness.arcs
@@ -5,6 +5,8 @@
 // Code distributed by Google as part of this project is also
 // subject to an additional IP rights grant found at
 // http://polymer.github.io/PATENTS.txt
+meta
+  namespace: arcs
 
 schema Data
   num: Number

--- a/particles/Native/Wasm/Services.arcs
+++ b/particles/Native/Wasm/Services.arcs
@@ -5,6 +5,8 @@
 // Code distributed by Google as part of this project is also
 // subject to an additional IP rights grant found at
 // http://polymer.github.io/PATENTS.txt
+meta
+  namespace: arcs
 
 particle ServiceParticle in 'service_particle.wasm'
   root: consumes

--- a/particles/Native/Wasm/example.arcs
+++ b/particles/Native/Wasm/example.arcs
@@ -5,6 +5,8 @@
 // Code distributed by Google as part of this project is also
 // subject to an additional IP rights grant found at
 // http://polymer.github.io/PATENTS.txt
+meta
+  namespace: arcs
 
 schema Product
   name: Text

--- a/particles/Native/Wasm/source/ServiceParticle.kt
+++ b/particles/Native/Wasm/source/ServiceParticle.kt
@@ -9,7 +9,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-package arcs.test
+package arcs
 
 import arcs.sdk.Utils.log
 

--- a/particles/Native/Wasm/source/TestParticle.kt
+++ b/particles/Native/Wasm/source/TestParticle.kt
@@ -7,7 +7,7 @@
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
-package arcs.test
+package arcs
 
 import arcs.sdk.wasm.WasmHandle
 import arcs.sdk.Utils.abort

--- a/particles/Tutorial/Kotlin/1_HelloWorld/BUILD
+++ b/particles/Tutorial/Kotlin/1_HelloWorld/BUILD
@@ -9,7 +9,6 @@ licenses(["notice"])
 arcs_kt_schema(
     name = "schemas",
     srcs = ["HelloWorld.arcs"],
-    package = "arcs.tutorials",
 )
 
 arcs_kt_particles(

--- a/particles/Tutorial/Kotlin/1_HelloWorld/HelloWorld.arcs
+++ b/particles/Tutorial/Kotlin/1_HelloWorld/HelloWorld.arcs
@@ -1,5 +1,7 @@
 // Tutorial: Hello World
 // Defines a really simple particle that just prints out "Hello, world!"
+meta
+  namespace: arcs.tutorials
 
 // Defines the Hello World particle, and links it to the Kotlin source code in file hello-world.js.
 particle HelloWorld in 'HelloWorld.wasm'

--- a/particles/Tutorial/Kotlin/2_BasicTemplates/BUILD
+++ b/particles/Tutorial/Kotlin/2_BasicTemplates/BUILD
@@ -9,7 +9,6 @@ licenses(["notice"])
 arcs_kt_schema(
     name = "schemas",
     srcs = ["BasicTemplates.arcs"],
-    package = "arcs.tutorials",
 )
 
 arcs_kt_particles(

--- a/particles/Tutorial/Kotlin/2_BasicTemplates/BasicTemplates.arcs
+++ b/particles/Tutorial/Kotlin/2_BasicTemplates/BasicTemplates.arcs
@@ -1,5 +1,7 @@
 // Tutorial: Basic Templates
 // Shows how to use templates to render data. This recipe has the exact same structure as the Hello World tutorial, only the JS is different.
+meta
+  namespace: arcs.tutorials
 
 particle BasicTemplate in 'BasicTemplate.wasm'
   root: consumes

--- a/particles/Tutorial/Kotlin/3_RenderSlots/BUILD
+++ b/particles/Tutorial/Kotlin/3_RenderSlots/BUILD
@@ -9,7 +9,6 @@ licenses(["notice"])
 arcs_kt_schema(
     name = "schemas",
     srcs = ["RenderSlots.arcs"],
-    package = "arcs.tutorials",
 )
 
 arcs_kt_particles(

--- a/particles/Tutorial/Kotlin/3_RenderSlots/RenderSlots.arcs
+++ b/particles/Tutorial/Kotlin/3_RenderSlots/RenderSlots.arcs
@@ -1,5 +1,7 @@
 // Tutorial: Render Slots
 // Creates two particles, and renders one inside the other using render slots.
+meta
+  namespace: arcs.tutorials
 
 // The "parent" particle. It provides a slot for another particle to be rendered inside it.
 particle ParentParticle in 'RenderSlots.wasm'

--- a/particles/Tutorial/Kotlin/4_Handles/BUILD
+++ b/particles/Tutorial/Kotlin/4_Handles/BUILD
@@ -15,7 +15,6 @@ arcs_manifest(
 arcs_kt_schema(
     name = "handles_schemas",
     srcs = ["Handles.arcs"],
-    package = "arcs.tutorials",
     deps = [":shared_people_schemas"],
 )
 

--- a/particles/Tutorial/Kotlin/4_Handles/Handles.arcs
+++ b/particles/Tutorial/Kotlin/4_Handles/Handles.arcs
@@ -1,3 +1,6 @@
+meta
+  namespace: arcs.tutorials
+
 // Imports contents of another manifest via a relative path from this manifest.
 import 'PeopleSchemas.arcs'
 

--- a/particles/Tutorial/Kotlin/5_Collections/BUILD
+++ b/particles/Tutorial/Kotlin/5_Collections/BUILD
@@ -15,7 +15,6 @@ arcs_manifest(
 arcs_kt_schema(
     name = "collections_schemas",
     srcs = ["Collections.arcs"],
-    package = "arcs.tutorials",
     deps = [":shared_people_schemas"],
 )
 

--- a/particles/Tutorial/Kotlin/5_Collections/Collections.arcs
+++ b/particles/Tutorial/Kotlin/5_Collections/Collections.arcs
@@ -1,6 +1,7 @@
 // Tutorial: Collections
 // Shows how to use an input list, and store data in a manifest file.
-
+meta
+  namespace: arcs.tutorials
 
 // Imports contents of another manifest via a relative path from this manifest.
 import 'PeopleSchemas.arcs'

--- a/particles/Tutorial/Kotlin/6_JsonStore/BUILD
+++ b/particles/Tutorial/Kotlin/6_JsonStore/BUILD
@@ -15,7 +15,6 @@ arcs_manifest(
 arcs_kt_schema(
     name = "store_schemas",
     srcs = ["JsonStore.arcs"],
-    package = "arcs.tutorials",
     deps = [":shared_people_schemas"],
 )
 

--- a/particles/Tutorial/Kotlin/6_JsonStore/JsonStore.arcs
+++ b/particles/Tutorial/Kotlin/6_JsonStore/JsonStore.arcs
@@ -1,5 +1,7 @@
 // Tutorial: JSON Store
 // Loads data stored in a JSON file.
+meta
+  namespace: arcs.tutorials
 
 // Imports contents of another manifest via a relative path from this manifest.
 import 'PeopleSchemas.arcs'

--- a/particles/Tutorial/Kotlin/7_Functional/BUILD
+++ b/particles/Tutorial/Kotlin/7_Functional/BUILD
@@ -15,7 +15,6 @@ arcs_manifest(
 arcs_kt_schema(
     name = "functional_schemas",
     srcs = ["Functional.arcs"],
-    package = "arcs.tutorials",
     deps = [":shared_people_schemas"],
 )
 

--- a/particles/Tutorial/Kotlin/7_Functional/Functional.arcs
+++ b/particles/Tutorial/Kotlin/7_Functional/Functional.arcs
@@ -1,6 +1,8 @@
+meta
+  namespace: arcs.tutorials
+
 // Imports contents of another manifest via a relative path from this manifest.
 import 'PeopleSchemas.arcs'
-
 
 // The GetPerson particle allows the user to input their name, then writes
 // the input to the Person handle.

--- a/particles/Tutorial/Kotlin/Demo/src/BUILD
+++ b/particles/Tutorial/Kotlin/Demo/src/BUILD
@@ -9,7 +9,6 @@ licenses(["notice"])
 arcs_kt_schema(
     name = "game_schemas",
     srcs = ["TTTGame.arcs"],
-    package = "arcs.tutorials.tictactoe",
 )
 
 arcs_kt_particles(

--- a/particles/Tutorial/Kotlin/Demo/src/TTTGame.arcs
+++ b/particles/Tutorial/Kotlin/Demo/src/TTTGame.arcs
@@ -1,6 +1,7 @@
 // Tutorial Demo
 // Shows how to use Arcs features to create a tic-tac-toe game.
-
+meta
+  namespace: arcs.tutorials.tictactoe
 
 schema Person
   name: Text

--- a/particles/Tutorial/Kotlin/README.md
+++ b/particles/Tutorial/Kotlin/README.md
@@ -319,7 +319,6 @@ arcs_manifest(
 arcs_kt_schema(
     name = "handles_schemas",
     srcs = ["Handles.arcs"],
-    package = "arcs.tutorials",
     deps = [":shared_people_schemas"],
 )
 

--- a/src/runtime/manifest-ast-nodes.ts
+++ b/src/runtime/manifest-ast-nodes.ts
@@ -188,6 +188,12 @@ export interface MetaStorageKey extends BaseNode {
   kind: 'storageKey';
 }
 
+export interface MetaNamespace extends BaseNode {
+  key: 'namespace';
+  value: string;
+  kind: 'namespace';
+}
+
 export type MetaItem = MetaStorageKey | MetaName;
 
 export interface Particle extends BaseNode {
@@ -772,7 +778,7 @@ export type ParticleHandleConnectionType = TypeVariable|CollectionType|
     BigCollectionType|ReferenceType|SlotType|SchemaInline|TypeName;
 
 // Note that ManifestStorage* are not here, as they do not have 'kind'
-export type All = Import|Meta|MetaName|MetaStorageKey|Particle|ParticleHandleConnection|
+export type All = Import|Meta|MetaName|MetaStorageKey|MetaNamespace|Particle|ParticleHandleConnection|
     ParticleInterface|RecipeHandle|Resource|Interface|InterfaceArgument|InterfaceInterface|
     InterfaceSlot;
 

--- a/src/runtime/manifest-meta.ts
+++ b/src/runtime/manifest-meta.ts
@@ -12,6 +12,7 @@
 export class ManifestMeta {
   storageKey: string|null;
   name: string|null;
+  namespace: string|null;
 
   constructor() {
     this.storageKey = null;

--- a/src/runtime/manifest-parser.pegjs
+++ b/src/runtime/manifest-parser.pegjs
@@ -299,7 +299,7 @@ Meta
   return toAstNode<AstNode.Meta>({kind: 'meta', items: items});
 }
 
-MetaItem = MetaStorageKey / MetaName
+MetaItem = MetaStorageKey / MetaName / MetaNamespace
 
 MetaName = 'name' whiteSpace? ':' whiteSpace? name:id eolWhiteSpace
 {
@@ -309,6 +309,11 @@ MetaName = 'name' whiteSpace? ':' whiteSpace? name:id eolWhiteSpace
 MetaStorageKey = 'storageKey' whiteSpace? ':' whiteSpace? key:id eolWhiteSpace
 {
   return toAstNode<AstNode.MetaStorageKey>({key: 'storageKey', value: key, kind: 'storageKey' });
+};
+
+MetaNamespace = 'namespace' whiteSpace? ':' whiteSpace? namespace:dottedName eolWhiteSpace
+{
+  return toAstNode<AstNode.MetaNamespace>({key: 'namespace', value: namespace, kind: 'namespace' });
 };
 
 Particle

--- a/src/runtime/tests/manifest-test.ts
+++ b/src/runtime/tests/manifest-test.ts
@@ -606,6 +606,16 @@ ${particleStr1}
     verify(manifest);
     verify(await parseManifest(manifest.toString()));
   });
+  it('parses meta namespace section', async () => {
+    const manifest = await parseManifest(`
+      meta
+        name: 'Awesome Arc'
+        namespace: com.some.namespace  
+      particle P
+        data: writes * {name: Text, age: Number}
+    `);
+    assert.equal(manifest.meta.namespace, 'com.some.namespace');
+  });
   describe('refinement types', async () => {
     it('can construct manifest containing schema with refinement types', Flags.withFieldRefinementsAllowed(async () => {
       const manifest = await parseManifest(`

--- a/src/tests/source/schemas.arcs
+++ b/src/tests/source/schemas.arcs
@@ -1,3 +1,6 @@
+meta
+  namespace: arcs
+  
 schema Person
   name: Text
   age: Number

--- a/src/tools/plan-generator.ts
+++ b/src/tools/plan-generator.ts
@@ -29,7 +29,7 @@ export class PlanGeneratorError extends Error {
 export class PlanGenerator {
   private specRegistry: Dictionary<string> = {};
 
-  constructor(private resolvedRecipes: Recipe[], private scope: string) {
+  constructor(private resolvedRecipes: Recipe[], private namespace: string) {
   }
 
   /** Generates a Kotlin file with plan classes derived from resolved recipes. */
@@ -150,14 +150,14 @@ export class PlanGenerator {
 /* ktlint-disable */
 @file:Suppress("PackageName", "TopLevelName")
 
-package ${this.scope}
+package ${this.namespace}
 
 //
 // GENERATED CODE -- DO NOT EDIT
 //
 
-${tryImport('arcs.core.data.*', this.scope)}
-${tryImport('arcs.core.storage.*', this.scope)}
+${tryImport('arcs.core.data.*', this.namespace)}
+${tryImport('arcs.core.storage.*', this.namespace)}
 `;
   }
 

--- a/src/tools/recipe2plan-cli.ts
+++ b/src/tools/recipe2plan-cli.ts
@@ -15,8 +15,8 @@ import {recipe2plan} from './recipe2plan.js';
 import {Flags} from '../runtime/flags.js';
 
 const opts = minimist(process.argv.slice(2), {
-  string: ['outdir', 'outfile', 'package'],
-  alias: {d: 'outdir', f: 'outfile', p: 'package'},
+  string: ['outdir', 'outfile'],
+  alias: {d: 'outdir', f: 'outfile'},
   default: {outdir: '.'}
 });
 
@@ -31,7 +31,6 @@ Description
 Options
   --outfile, -f output filename; required
   --outdir, -d  output directory; defaults to '.'
-  --package, -p kotlin package.
   --help        usage info
 `);
   process.exit(0);
@@ -42,11 +41,6 @@ if (!opts.outfile) {
   process.exit(1);
 }
 
-
-if (!opts.package) {
-  console.error(`Parameter --package is required.`);
-  process.exit(1);
-}
 
 // TODO(alxr): Support generation from multiple manifests
 if (opts._.length > 1) {
@@ -64,7 +58,7 @@ async function main() {
     Runtime.init('../..');
     fs.mkdirSync(opts.outdir, {recursive: true});
 
-    const plans: string = await recipe2plan(opts._[0], opts.package);
+    const plans: string = await recipe2plan(opts._[0]);
 
     const outPath = path.join(opts.outdir, opts.outfile);
     console.log(outPath);

--- a/src/tools/recipe2plan.ts
+++ b/src/tools/recipe2plan.ts
@@ -11,6 +11,7 @@ import {Runtime} from '../runtime/runtime.js';
 import {StorageKeyRecipeResolver} from './storage-key-recipe-resolver.js';
 import {PlanGenerator} from './plan-generator.js';
 import {Flags} from '../runtime/flags.js';
+import {assert} from '../platform/assert-node.js';
 
 
 /**
@@ -20,13 +21,14 @@ import {Flags} from '../runtime/flags.js';
  * @param scope kotlin package name
  * @return Generated Kotlin code.
  */
-export async function recipe2plan(path: string, scope: string): Promise<string> {
+export async function recipe2plan(path: string): Promise<string> {
   return await Flags.withDefaultReferenceMode(async () => {
     const manifest = await Runtime.parseFile(path);
 
+    assert(manifest.meta.namespace, `Namespace is required in '${path}' for code generation.`);
     const recipes = await (new StorageKeyRecipeResolver(manifest)).resolve();
 
-    const generator = new PlanGenerator(recipes, scope);
+    const generator = new PlanGenerator(recipes, manifest.meta.namespace);
 
     return generator.generate();
   })();

--- a/src/tools/schema2base.ts
+++ b/src/tools/schema2base.ts
@@ -31,11 +31,10 @@ export interface ClassGenerator {
 }
 
 export abstract class Schema2Base {
-  scope: string;
+  namespace: string;
 
   constructor(readonly opts: minimist.ParsedArgs) {
     Runtime.init('../..');
-    this.scope = this.opts.package || 'arcs.sdk';
   }
 
   async call() {
@@ -60,6 +59,12 @@ export abstract class Schema2Base {
     if (manifest.errors.some(e => e.severity !== 'warning')) {
       return;
     }
+
+    this.namespace = manifest.meta.namespace;
+    if (!this.namespace) {
+      throw new Error(`Namespace is required in '${src}' for code generation.`);
+    }
+
     const classes = await this.processManifest(manifest);
     if (classes.length === 0) {
       console.warn(`Could not find any particle connections with schemas in '${src}'`);

--- a/src/tools/schema2cpp.ts
+++ b/src/tools/schema2cpp.ts
@@ -75,7 +75,7 @@ export class Schema2Cpp extends Schema2Base {
   }
 
   getClassGenerator(node: SchemaNode): ClassGenerator {
-    return new CppGenerator(node, this.scope.replace(/\./g, '::'));
+    return new CppGenerator(node, this.namespace.replace(/\./g, '::'));
   }
 
   generateParticleClass(particle: ParticleSpec): string {

--- a/src/tools/schema2kotlin.ts
+++ b/src/tools/schema2kotlin.ts
@@ -67,7 +67,7 @@ export class Schema2Kotlin extends Schema2Base {
 /* ktlint-disable */
 @file:Suppress("PackageName", "TopLevelName")
 
-package ${this.scope}
+package ${this.namespace}
 
 //
 // GENERATED CODE -- DO NOT EDIT

--- a/src/tools/schema2wasm.ts
+++ b/src/tools/schema2wasm.ts
@@ -12,10 +12,10 @@ import {Schema2Cpp} from './schema2cpp.js';
 import {Schema2Kotlin} from './schema2kotlin.js';
 
 const opts = minimist(process.argv.slice(2), {
-  string: ['outdir', 'outfile', 'package'],
+  string: ['outdir', 'outfile'],
   boolean: ['cpp', 'kotlin', 'update', 'wasm', 'help'],
-  alias: {c: 'cpp', k: 'kotlin', d: 'outdir', f: 'outfile', u: 'update', p: 'package'},
-  default: {outdir: '.', package: 'arcs'}
+  alias: {c: 'cpp', k: 'kotlin', d: 'outdir', f: 'outfile', u: 'update'},
+  default: {outdir: '.'}
 });
 
 if (opts.help || opts._.length === 0) {
@@ -32,7 +32,6 @@ Options
   --wasm         whether to output wasm-specific code (applies to Kotlin only)
   --outdir, -d   output directory; defaults to '.'
   --outfile, -f  output filename; if omitted, generated from the manifest name
-  --package, -p  scope generated code to the specified package or namespace
   --update, -u   only generate if the source file is newer than the destination
   --help         usage info
 `);

--- a/src/tools/storage-key-recipe-resolver.ts
+++ b/src/tools/storage-key-recipe-resolver.ts
@@ -42,7 +42,7 @@ export class StorageKeyRecipeResolver {
    */
   async resolve(): Promise<Recipe[]> {
     const recipes = [];
-    for (const recipe of this.runtime.context.allRecipes) {
+    for (const recipe of this.runtime.context.recipes) {
       this.validateHandles(recipe);
       const arcId = this.findLongRunningArcId(recipe);
       const arc = this.runtime.newArc(

--- a/src/tools/tests/golden.arcs
+++ b/src/tools/tests/golden.arcs
@@ -1,5 +1,7 @@
 // Example manifest file, serving as a test for the schema2kotlin and schema2cpp
 // code generators.
+meta
+  namespace: arcs.golden
 
 particle Gold
   data: reads {num: Number, txt: Text, lnk: URL, flg: Boolean, ref: &{val: Text}}

--- a/src/tools/tests/goldens/generated-schemas.h
+++ b/src/tools/tests/goldens/generated-schemas.h
@@ -6,7 +6,7 @@
 #error arcs.h must be included before entity class headers
 #endif
 
-namespace arcs {
+namespace arcs::golden {
 
 // Aliased as Gold_Data_Ref, Gold_Alias
 class GoldInternal1 {
@@ -139,7 +139,7 @@ inline std::string internal::Accessor::encode_entity(const GoldInternal1& entity
   return encoder.result();
 }
 
-}  // namespace arcs
+}  // namespace arcs::golden
 
 // For STL unordered associative containers. Entities will need to be std::move()-inserted.
 template<>
@@ -149,7 +149,7 @@ struct std::hash<arcs::GoldInternal1> {
   }
 };
 
-namespace arcs {
+namespace arcs::golden {
 
 class Gold_QCollection {
 public:
@@ -404,7 +404,7 @@ inline std::string internal::Accessor::encode_entity(const Gold_QCollection& ent
   return encoder.result();
 }
 
-}  // namespace arcs
+}  // namespace arcs::golden
 
 // For STL unordered associative containers. Entities will need to be std::move()-inserted.
 template<>
@@ -414,7 +414,7 @@ struct std::hash<arcs::Gold_QCollection> {
   }
 };
 
-namespace arcs {
+namespace arcs::golden {
 
 class Gold_Data {
 public:
@@ -627,7 +627,7 @@ inline std::string internal::Accessor::encode_entity(const Gold_Data& entity) {
   return encoder.result();
 }
 
-}  // namespace arcs
+}  // namespace arcs::golden
 
 // For STL unordered associative containers. Entities will need to be std::move()-inserted.
 template<>

--- a/src/tools/tests/goldens/generated-schemas.jvm.kt
+++ b/src/tools/tests/goldens/generated-schemas.jvm.kt
@@ -1,7 +1,7 @@
 /* ktlint-disable */
 @file:Suppress("PackageName", "TopLevelName")
 
-package arcs.sdk
+package arcs.golden
 
 //
 // GENERATED CODE -- DO NOT EDIT

--- a/src/tools/tests/goldens/generated-schemas.wasm.kt
+++ b/src/tools/tests/goldens/generated-schemas.wasm.kt
@@ -1,7 +1,7 @@
 /* ktlint-disable */
 @file:Suppress("PackageName", "TopLevelName")
 
-package arcs.sdk
+package arcs.golden
 
 //
 // GENERATED CODE -- DO NOT EDIT

--- a/src/tools/tests/recipe2plan-test.ts
+++ b/src/tools/tests/recipe2plan-test.ts
@@ -15,7 +15,7 @@ import {Flags} from '../../runtime/flags.js';
 describe('recipe2plan', () => {
   it('generates plans from recipes in a manifest', Flags.withDefaultReferenceMode(async () => {
     assert.deepStrictEqual(
-      await recipe2plan('java/arcs/core/data/testdata/WriterReaderExample.arcs', 'arcs.core.data.testdata'),
+      await recipe2plan('java/arcs/core/data/testdata/WriterReaderExample.arcs'),
       fs.readFileSync('src/tools/tests/goldens/WriterReaderExample.kt', 'utf8')
     );
   }));

--- a/src/wasm/tests/manifest.arcs
+++ b/src/wasm/tests/manifest.arcs
@@ -1,3 +1,6 @@
+meta
+  namespace: arcs
+  
 particle HandleSyncUpdateTest in '$module.wasm'
   sng: reads {num: Number, txt: Text, lnk: URL, flg: Boolean, ref: &Foo {val: Text}}
   col: reads [{num: Number, txt: Text, lnk: URL, flg: Boolean, ref: &Foo {val: Text}}]

--- a/third_party/java/arcs/build_defs/internal/kotlin.bzl
+++ b/third_party/java/arcs/build_defs/internal/kotlin.bzl
@@ -246,6 +246,8 @@ def arcs_kt_particles(
             kotlin_wasm_annotations(
                 name = particle + "-wasm-annotations",
                 particle = particle,
+                # TODO: Package name should be parsed from the
+                # Arcs manifest, instead of being passed explicitly.
                 package = package,
                 out = wasm_annotations_file,
             )
@@ -322,13 +324,12 @@ def arcs_kt_android_test_suite(name, manifest, package, srcs = None, tags = [], 
             data = data,
         )
 
-def arcs_kt_plan(name, src, package, deps = [], out = None, visibility = None):
+def arcs_kt_plan(name, src, deps = [], out = None, visibility = None):
     """Converts recipes in manifests into Kotlin Plans.
 
     Args:
       name: the name of the target to create
       src: an Arcs manifest file
-      package: name of kotlin package for generated file
       deps: list of dependencies (other manifests)
       out: the name of the output artifact (a Kotlin file).
       visibility: list of visibilities
@@ -341,7 +342,7 @@ def arcs_kt_plan(name, src, package, deps = [], out = None, visibility = None):
         outs = outs,
         deps = deps,
         progress_message = "Generating Plans",
-        sigh_cmd = "recipe2plan --outdir $(dirname {OUT}) --outfile $(basename {OUT}) --package " + package + " {SRC}",
+        sigh_cmd = "recipe2plan --outdir $(dirname {OUT}) --outfile $(basename {OUT}) {SRC}",
     )
 
 def arcs_kt_jvm_test_suite(name, package, srcs = None, tags = [], deps = [], data = []):

--- a/third_party/java/arcs/build_defs/internal/schemas.bzl
+++ b/third_party/java/arcs/build_defs/internal/schemas.bzl
@@ -14,7 +14,6 @@ def _run_schema2wasm(
         out,
         language_name,
         language_flag,
-        package,
         wasm):
     """Generates source code for the given .arcs schema file.
 
@@ -41,12 +40,10 @@ def _run_schema2wasm(
                    ("--wasm " if wasm else "") +
                    "--outdir $(dirname {OUT}) " +
                    "--outfile $(basename {OUT}) " +
-                   "--package " + package + " " +
                    "{SRC}",
     )
 
-# TODO: Specify the appropriate c++ package name, given the new repo structure
-def arcs_cc_schema(name, src, deps = [], out = None, package = "arcs"):
+def arcs_cc_schema(name, src, deps = [], out = None):
     """Generates a C++ header file for the given .arcs schema file."""
     _run_schema2wasm(
         name = name + "_genrule",
@@ -56,17 +53,15 @@ def arcs_cc_schema(name, src, deps = [], out = None, package = "arcs"):
         language_flag = "--cpp",
         language_name = "C++",
         wasm = False,
-        package = package,
     )
 
-def arcs_kt_schema(name, srcs, deps = [], package = "arcs.sdk"):
+def arcs_kt_schema(name, srcs, deps = []):
     """Generates a Kotlin file for the given .arcs schema file.
 
     Args:
       name: name of the target to create
       srcs: list of Arcs manifest files to include
       deps: list of imported manifests
-      package: package name to use for the generated source code
     """
     outs = []
     for src in srcs:
@@ -83,7 +78,6 @@ def arcs_kt_schema(name, srcs, deps = [], package = "arcs.sdk"):
                 wasm = wasm,
                 language_flag = "--kotlin",
                 language_name = "Kotlin",
-                package = package,
             )
 
     arcs_kt_library(


### PR DESCRIPTION
Now the Kotlin and C++ code generated via out tools (`schema2base`, `recipe2plan`) will use the namespace from the `meta` tag of the manifest file. I've also removed various defaults (arcs or arcs.sdk, depending on a tool) that I feel were not helping.

This solves the problem of recipe2plan not knowing what are the package names of the code generated with schema2kotlin (in a different bazel rule, in potentially different package).

We still need to specify the package name for `arcs_kt_particles` rule generation wasm modules, as it uses the `kotlin_wasm_annotations_template.tmpl` for the codegen of _newParticle method. At this stage package name is not parsed from the manifest, so we still need to pass it explicitly for WASM.