### PR TITLE
Simplify Handle callback management (take 2)

### DIFF
--- a/java/arcs/core/host/EntityHandleManager.kt
+++ b/java/arcs/core/host/EntityHandleManager.kt
@@ -11,13 +11,9 @@
 package arcs.core.host
 
 import arcs.core.common.Id
-import arcs.core.crdt.CrdtData
-import arcs.core.crdt.CrdtOperationAtTime
 import arcs.core.data.HandleMode
 import arcs.core.data.RawEntity
 import arcs.core.data.Schema
-import arcs.core.storage.Callbacks
-import arcs.core.storage.Handle as StorageHandle
 import arcs.core.storage.StorageKey
 import arcs.core.storage.api.Entity
 import arcs.core.storage.api.EntitySpec
@@ -28,21 +24,9 @@ import arcs.core.storage.api.ReadWriteCollectionHandle
 import arcs.core.storage.api.ReadWriteSingletonHandle
 import arcs.core.storage.api.WriteCollectionHandle
 import arcs.core.storage.api.WriteSingletonHandle
-import arcs.core.storage.handle.CollectionData
 import arcs.core.storage.handle.CollectionHandle
-import arcs.core.storage.handle.CollectionOp
 import arcs.core.storage.handle.HandleManager
-import arcs.core.storage.handle.SingletonData
 import arcs.core.storage.handle.SingletonHandle
-import arcs.core.storage.handle.SingletonOp
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.launch
-
-typealias Sender = (block: suspend () -> Unit) -> Unit
-typealias SingletonSenderCallbackAdapter<E> =
-    SenderCallbackAdapter<SingletonData<RawEntity>, SingletonOp<RawEntity>, RawEntity?, E?>
-typealias CollectionSenderCallbackAdapter<E> =
-    SenderCallbackAdapter<CollectionData<RawEntity>, CollectionOp<RawEntity>, Set<RawEntity>, E>
 
 /**
  * Wraps a [HandleManager] and creates [Entity] handles based on [HandleMode], such as
@@ -61,7 +45,6 @@ class EntityHandleManager(private val handleManager: HandleManager) {
      * @property storageKey a [StorageKey]
      * @property schema the [Schema] for this [StorageKey]
      * @property handleMode whether a handle is Read,Write, or ReadWrite (default)
-     * @property sender block used to execute callback lambdas
      * @property idGenerator used to generate unique IDs for newly stored entities.
      */
     suspend fun <T : Entity> createSingletonHandle(
@@ -70,10 +53,9 @@ class EntityHandleManager(private val handleManager: HandleManager) {
         storageKey: StorageKey,
         schema: Schema,
         handleMode: HandleMode = HandleMode.ReadWrite,
-        idGenerator: Id.Generator = Id.Generator.newSession(),
-        sender: Sender = ::defaultSender
+        idGenerator: Id.Generator = Id.Generator.newSession()
     ): Handle {
-        val storageHandle = handleManager.singletonHandle(
+        val storageHandle = handleManager.rawEntitySingletonHandle(
             storageKey,
             schema,
             canRead = handleMode != HandleMode.Write
@@ -83,14 +65,12 @@ class EntityHandleManager(private val handleManager: HandleManager) {
                 entitySpec,
                 handleName,
                 storageHandle,
-                idGenerator,
-                sender
+                idGenerator
             )
             HandleMode.Read -> ReadSingletonHandleImpl(
                 entitySpec,
                 handleName,
-                storageHandle,
-                sender
+                storageHandle
             )
             HandleMode.Write -> WriteSingletonHandleImpl<T>(
                 handleName,
@@ -107,7 +87,6 @@ class EntityHandleManager(private val handleManager: HandleManager) {
      * @property storageKey a [StorageKey]
      * @property schema the [Schema] for this [StorageKey]
      * @property handleMode whether a handle is Read,Write, or ReadWrite (default)
-     * @property sender block used to execute callback lambdas
      * @property idGenerator used to generate unique IDs for newly stored entities.
      */
     suspend fun <T : Entity> createCollectionHandle(
@@ -116,10 +95,9 @@ class EntityHandleManager(private val handleManager: HandleManager) {
         storageKey: StorageKey,
         schema: Schema,
         handleMode: HandleMode = HandleMode.ReadWrite,
-        idGenerator: Id.Generator = Id.Generator.newSession(),
-        sender: Sender = ::defaultSender
+        idGenerator: Id.Generator = Id.Generator.newSession()
     ): Handle {
-        val storageHandle = handleManager.collectionHandle(
+        val storageHandle = handleManager.rawEntityCollectionHandle(
             storageKey,
             schema,
             canRead = handleMode != HandleMode.Write
@@ -129,14 +107,12 @@ class EntityHandleManager(private val handleManager: HandleManager) {
                 entitySpec,
                 handleName,
                 storageHandle,
-                idGenerator,
-                sender
+                idGenerator
             )
             HandleMode.Read -> ReadCollectionHandleImpl(
                 entitySpec,
                 handleName,
-                storageHandle,
-                sender
+                storageHandle
             )
             HandleMode.Write -> WriteCollectionHandleImpl<T>(
                 handleName,
@@ -145,70 +121,37 @@ class EntityHandleManager(private val handleManager: HandleManager) {
             )
         }
     }
-
-    /**
-     * Same-thread non-blocking dispatch. Note that this may lead to concurrency problems on
-     * some platforms. On platforms with real preemptive threads, use an implementation that
-     * provides concurrency aware dispatch.
-     */
-    private fun defaultSender(block: suspend () -> Unit) {
-        GlobalScope.launch {
-            block()
-        }
-    }
-}
-
-internal open class HandleEventBase<T, H : Handle> {
-    protected val onUpdateActions: MutableList<(T) -> Unit> = mutableListOf()
-    protected val onSyncActions: MutableList<(H) -> Unit> = mutableListOf()
-    protected val onDesyncActions: MutableList<(H) -> Unit> = mutableListOf()
-
-    suspend fun onUpdate(action: (T) -> Unit) {
-        onUpdateActions.add(action)
-    }
-
-    suspend fun onSync(action: (H) -> Unit) {
-        onSyncActions.add(action)
-    }
-
-    suspend fun onDesync(action: (H) -> Unit) {
-        onDesyncActions.add(action)
-    }
-
-    protected suspend fun fireUpdate(value: T) {
-        onUpdateActions.forEach { action -> action(value) }
-    }
-
-    protected suspend fun fireSync() {
-        onSyncActions.forEach { action -> action(this as H) }
-    }
-
-    protected suspend fun fireDesync() {
-        onDesyncActions.forEach { action -> action(this as H) }
-    }
 }
 
 internal open class ReadSingletonHandleImpl<T : Entity>(
     val entitySpec: EntitySpec<T>,
     val handleName: String,
-    val storageHandle: SingletonHandle<RawEntity>,
-    sender: Sender
-) : HandleEventBase<T?, ReadSingletonHandle<T>>(), ReadSingletonHandle<T> {
-    init {
-        storageHandle.callback = SingletonSenderCallbackAdapter(
-            this::fetch,
-            this::fireUpdate,
-            this::fireSync,
-            this::fireDesync,
-            sender
-        )
-    }
-
+    val storageHandle: SingletonHandle<RawEntity>
+) : ReadSingletonHandle<T> {
     override val name: String
         get() = handleName
 
-    override suspend fun fetch(): T? = storageHandle.fetch()?.let {
-        rawEntity -> entitySpec.deserialize(rawEntity)
+    private fun adaptValue(raw: RawEntity?) =
+        raw?.let { entitySpec.deserialize(it) }
+
+    override suspend fun fetch(): T? = adaptValue(storageHandle.fetch())
+
+    override suspend fun onUpdate(action: (T?) -> Unit) {
+        storageHandle.addOnUpdate { rawValue ->
+            action(adaptValue(rawValue))
+        }
+    }
+
+    override suspend fun onSync(action: (ReadSingletonHandle<T>) -> Unit) {
+        storageHandle.addOnSync { action(this) }
+    }
+
+    override suspend fun onDesync(action: (ReadSingletonHandle<T>) -> Unit) {
+        storageHandle.addOnDesync { action(this) }
+    }
+
+    override suspend fun removeAllCallbacks() {
+        storageHandle.removeAllCallbacks()
     }
 }
 
@@ -236,14 +179,13 @@ internal class ReadWriteSingletonHandleImpl<T : Entity>(
     handleName: String,
     storageHandle: SingletonHandle<RawEntity>,
     idGenerator: Id.Generator,
-    sender: Sender,
     private val writableSingleton: WriteSingletonHandleImpl<T> = WriteSingletonHandleImpl(
         handleName,
         storageHandle,
         idGenerator
     )
 ) : ReadWriteSingletonHandle<T>,
-    ReadSingletonHandleImpl<T>(entitySpec, handleName, storageHandle, sender),
+    ReadSingletonHandleImpl<T>(entitySpec, handleName, storageHandle),
     WriteSingletonHandle<T> by writableSingleton {
     override val name: String
         get() = writableSingleton.name
@@ -252,19 +194,8 @@ internal class ReadWriteSingletonHandleImpl<T : Entity>(
 internal open class ReadCollectionHandleImpl<T : Entity>(
     private val entitySpec: EntitySpec<T>,
     val handleName: String,
-    private val storageHandle: CollectionHandle<RawEntity>,
-    sender: Sender
-) : HandleEventBase<Set<T>, ReadCollectionHandle<T>>(), ReadCollectionHandle<T> {
-    init {
-        storageHandle.callback = CollectionSenderCallbackAdapter(
-            this::fetchAll,
-            this::fireUpdate,
-            this::fireSync,
-            this::fireDesync,
-            sender
-        )
-    }
-
+    private val storageHandle: CollectionHandle<RawEntity>
+) : ReadCollectionHandle<T> {
     override val name: String
         get() = handleName
 
@@ -272,9 +203,26 @@ internal open class ReadCollectionHandleImpl<T : Entity>(
 
     override suspend fun isEmpty() = fetchAll().isEmpty()
 
-    override suspend fun fetchAll(): Set<T> = storageHandle.fetchAll().map {
-        entitySpec.deserialize(it)
-    }.toSet()
+    private fun adaptValues(raw: Set<RawEntity>) =
+        raw.map { entitySpec.deserialize(it) }.toSet()
+
+    override suspend fun fetchAll(): Set<T> = adaptValues(storageHandle.fetchAll())
+
+    override suspend fun onUpdate(action: (Set<T>) -> Unit) {
+        storageHandle.addOnUpdate { rawValues ->
+            action(adaptValues(rawValues))
+        }
+    }
+
+    override suspend fun onSync(action: () -> Unit) {
+        storageHandle.addOnSync(action)
+    }
+
+    override suspend fun onDesync(action: () -> Unit) { }
+
+    override suspend fun removeAllCallbacks() {
+        storageHandle.removeAllCallbacks()
+    }
 }
 
 internal class WriteCollectionHandleImpl<T : Entity>(
@@ -305,49 +253,16 @@ internal class ReadWriteCollectionHandleImpl<T : Entity>(
     handleName: String,
     storageHandle: CollectionHandle<RawEntity>,
     idGenerator: Id.Generator,
-    sender: Sender,
     private val writableCollection: WriteCollectionHandleImpl<T> = WriteCollectionHandleImpl(
         handleName,
         storageHandle,
         idGenerator
     )
 ) : ReadWriteCollectionHandle<T>,
-    ReadCollectionHandleImpl<T>(entitySpec, handleName, storageHandle, sender),
+    ReadCollectionHandleImpl<T>(entitySpec, handleName, storageHandle),
     WriteCollectionHandle<T> by writableCollection {
     override val name: String
         get() = writableCollection.name
-}
-
-/**
- * Adapts [StorageHandle] [Callbacks] events into SDK callbacks. All events are dispatched
- * via a [Sender], which can enforce appropriate levels of concurrency.
- */
-class SenderCallbackAdapter<Data : CrdtData, Op : CrdtOperationAtTime, T, E>(
-    private val fetchFunc: suspend () -> E,
-    private val updateCallback: (suspend (E) -> Unit),
-    private val syncCallback: (suspend () -> Unit),
-    private val desyncCallback: (suspend () -> Unit),
-    private val sender: Sender
-) : Callbacks<Data, Op, T> {
-
-    /**
-     * Used to ensure serialized invocations of [Handle] events. This can be per-[Handle],
-     * per-[Particle], per-[Arc], depending on the [Sender] used. Typically, it will be
-     * per-[Particle] when handles are hosted inside of a [Particle]
-     */
-    private fun invokeWithSender(block: suspend () -> Unit) = sender(block)
-
-    override fun onUpdate(handle: StorageHandle<Data, Op, T>, op: Op) = invokeWithSender {
-        updateCallback.invoke(fetchFunc())
-    }
-
-    override fun onSync(handle: StorageHandle<Data, Op, T>) = invokeWithSender {
-        syncCallback.invoke()
-    }
-
-    override fun onDesync(handle: StorageHandle<Data, Op, T>) = invokeWithSender {
-        desyncCallback.invoke()
-    }
 }
 
 private fun <T : Entity> T.ensureIdentified(idGenerator: Id.Generator, handleName: String): T {

--- a/java/arcs/core/storage/Handle.kt
+++ b/java/arcs/core/storage/Handle.kt
@@ -22,30 +22,6 @@ import arcs.core.util.TaggedLog
 import arcs.core.util.Time
 
 /**
- * The [Callbacks] interface is a simple stand-in for the callbacks that a [Handle] might want to
- * use to signal information back to a subscriber (like a handle).
- */
-interface Callbacks<Data : CrdtData, Op : CrdtOperationAtTime, T> {
-    /**
-     * [onUpdate] is called when a diff is received from storage, or from a handle. Handles can
-     * be notified for their own writes.
-     * This method is not called for every change! A model sync will call [onSync] instead.
-     * Do not depend on seeing every update via this callback.
-     */
-    fun onUpdate(handle: Handle<Data, Op, T>, op: Op) = Unit
-
-    /**
-     * [onSync] is called when the proxy is synced from its backing [Store].
-     */
-    fun onSync(handle: Handle<Data, Op, T>) = Unit
-
-    /**
-     * [onDesync] is called when the proxy realizes it is out of sync with its backing [Store].
-     */
-    fun onDesync(handle: Handle<Data, Op, T>) = Unit
-}
-
-/**
  * Base implementation of Arcs handles on the runtime.
  *
  * A handle is in charge of translating SDK data operations into the appropriate CRDT operation,
@@ -71,9 +47,6 @@ open class Handle<Data : CrdtData, Op : CrdtOperationAtTime, T>(
     /** [name] is the unique name for this handle, used to track state in the [VersionMap]. */
     val name: String,
     val storageProxy: StorageProxy<Data, Op, T>,
-
-    /** [callback] contains optional Handle-owner provided callbacks to add behavior. */
-    var callback: Callbacks<Data, Op, T>? = null,
 
     /** [ttl] applied to the data in the [Handle]. */
     val ttl: Ttl,
@@ -101,6 +74,25 @@ open class Handle<Data : CrdtData, Op : CrdtOperationAtTime, T>(
 ) {
     protected val log = TaggedLog { "Handle($name)" }
 
+    /** Add an action to be performed whenever the contents of the [Handle]'s data changes. */
+    suspend fun addOnUpdate(action: (value: T) -> Unit) {
+        storageProxy.addOnUpdate(name, action)
+    }
+
+    /** Add an action to be performed whenever the [Handle] becomes synchronized. */
+    suspend fun addOnSync(action: () -> Unit) { storageProxy.addOnSync(name, action) }
+
+    /** Add an action to be performed whenever the [Handle] becomes de-synchronized. */
+    suspend fun addOnDesync(action: () -> Unit) { storageProxy.addOnDesync(name, action) }
+
+    /**
+     * Remove any `onUpdate`, `onSync`, or `onDesync` callbacks that this [Handle] has registered
+     * with its [StorageProxy].
+     */
+    suspend fun removeAllCallbacks() {
+        storageProxy.removeCallbacksForName(name)
+    }
+
     /** Creates a [Reference] for a given [Referencable] and backing [StorageKey]. */
     fun createReference(referencable: Referencable, backingKey: StorageKey): Reference {
         return Reference(referencable.id, backingKey, null).also {
@@ -121,30 +113,6 @@ open class Handle<Data : CrdtData, Op : CrdtOperationAtTime, T>(
     protected fun VersionMap.increment(): VersionMap {
         this[name]++
         return this
-    }
-
-    /**
-     * This should be called by the [StorageProxy] this [Handle] has been registered with,
-     * after a model update has been cleanly applied to the [StorageProxy]'s local copy.
-     */
-    internal fun onUpdate(op: Op) {
-        callback?.onUpdate(this, op)
-    }
-
-    /**
-     * This should be called by the [StorageProxy] this [Handle] has been registered with,
-     * after a full sync has occurred.
-     */
-    internal fun onSync() {
-        callback?.onSync(this)
-    }
-
-    /**
-     * This should be called by the [StorageProxy] this [Handle] has been registered with,
-     * when the [StorageProxy] has detected that its local model is out of sync.
-     */
-    internal fun onDesync() {
-        callback?.onDesync(this)
     }
 
     /**

--- a/java/arcs/core/storage/api/Handle.kt
+++ b/java/arcs/core/storage/api/Handle.kt
@@ -9,6 +9,8 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
+@file:Suppress("EXPERIMENTAL_FEATURE_WARNING")
+
 package arcs.core.storage.api
 
 /** Base interface for all handle classes. */
@@ -26,8 +28,11 @@ interface ReadSingletonHandle<T : Entity> : Handle {
     /** Assign a callback when the handle is synced. */
     suspend fun onSync(action: (ReadSingletonHandle<T>) -> Unit)
 
-    /** Assign a callback when the handle is sdeynced. */
+    /** Assign a callback when the handle is desynced. */
     suspend fun onDesync(action: (ReadSingletonHandle<T>) -> Unit)
+
+    /** Remove any attached callbacks for this [Handle]. */
+    suspend fun removeAllCallbacks()
 }
 
 /** A singleton handle with write access. */
@@ -54,13 +59,16 @@ interface ReadCollectionHandle<T : Entity> : Handle {
     suspend fun onUpdate(action: (Set<T>) -> Unit)
 
     /** Assign a callback when the collection handle is synced. */
-    suspend fun onSync(action: (ReadCollectionHandle<T>) -> Unit)
+    suspend fun onSync(action: () -> Unit)
 
     /** Assign a callback when the collection handle is desynced. */
-    suspend fun onDesync(action: (ReadCollectionHandle<T>) -> Unit)
+    suspend fun onDesync(action: () -> Unit)
 
     /** Returns a set with all the entities in the collection. */
     suspend fun fetchAll(): Set<T>
+
+    /** Remove any attached callbacks for this [Handle]. */
+    suspend fun removeAllCallbacks()
 }
 
 /** A collection handle with read access. */

--- a/java/arcs/core/storage/handle/CollectionHandle.kt
+++ b/java/arcs/core/storage/handle/CollectionHandle.kt
@@ -17,7 +17,6 @@ import arcs.core.data.RawEntity
 import arcs.core.data.Schema
 import arcs.core.data.Ttl
 import arcs.core.storage.ActivationFactory
-import arcs.core.storage.Callbacks
 import arcs.core.storage.Dereferencer
 import arcs.core.storage.Handle
 import arcs.core.storage.StorageProxy
@@ -32,7 +31,6 @@ typealias CollectionActivationFactory<T> =
     ActivationFactory<CollectionData<T>, CollectionOp<T>, Set<T>>
 typealias CollectionProxy<T> = StorageProxy<CrdtSet.Data<T>, CrdtSet.IOperation<T>, Set<T>>
 typealias CollectionBase<T> = Handle<CrdtSet.Data<T>, CrdtSet.IOperation<T>, Set<T>>
-typealias CollectionCallbacks<T> = Callbacks<CollectionData<T>, CollectionOp<T>, Set<T>>
 
 /**
  * Collection Handle implementation for the runtime.
@@ -43,7 +41,6 @@ typealias CollectionCallbacks<T> = Callbacks<CollectionData<T>, CollectionOp<T>,
 class CollectionHandle<T : Referencable>(
     name: String,
     storageProxy: CollectionProxy<T>,
-    callbacks: CollectionCallbacks<T>? = null,
     ttl: Ttl = Ttl.Infinite,
     time: Time,
     canRead: Boolean = true,
@@ -52,7 +49,6 @@ class CollectionHandle<T : Referencable>(
 ) : CollectionBase<T>(
     name,
     storageProxy,
-    callbacks,
     ttl,
     time,
     canRead,

--- a/java/arcs/core/storage/handle/HandleManager.kt
+++ b/java/arcs/core/storage/handle/HandleManager.kt
@@ -89,7 +89,6 @@ class HandleManager(
     suspend fun rawEntitySingletonHandle(
         storageKey: StorageKey,
         schema: Schema,
-        callbacks: SingletonCallbacks<RawEntity>? = null,
         name: String = storageKey.toKeyString(),
         ttl: Ttl = Ttl.Infinite,
         canRead: Boolean = true
@@ -112,39 +111,13 @@ class HandleManager(
         return SingletonHandle(
             name,
             storageProxy,
-            callbacks,
             ttl,
             time,
             canRead,
             dereferencer = RawEntityDereferencer(schema, aff?.dereferenceFactory()),
             schema = schema
-        ).also { storageProxy.registerHandle(it) }
+        )
     }
-
-    /**
-     * @deprecated use [rawEntitySingletonHandle] instead.
-     */
-    /* ktlint-disable max-line-length */
-    @Deprecated(
-        "Use rawEntitySingletonHandle instead",
-        replaceWith = ReplaceWith("this.rawEntitySingletonHandle(storageKey, schema, callbacks, name, ttl, canRead)")
-    )
-    /* ktlint-enable max-line-length */
-    suspend fun singletonHandle(
-        storageKey: StorageKey,
-        schema: Schema,
-        callbacks: SingletonCallbacks<RawEntity>? = null,
-        name: String = storageKey.toKeyString(),
-        ttl: Ttl = Ttl.Infinite,
-        canRead: Boolean = true
-    ): SingletonHandle<RawEntity> = rawEntitySingletonHandle(
-        storageKey,
-        schema,
-        callbacks,
-        name,
-        ttl,
-        canRead
-    )
 
     /**
      * Creates a new [SingletonHandle] which manages a singleton of type: [Reference], where the
@@ -153,7 +126,6 @@ class HandleManager(
     suspend fun referenceSingletonHandle(
         storageKey: StorageKey,
         schema: Schema,
-        callbacks: SingletonCallbacks<Reference>? = null,
         name: String = storageKey.toKeyString(),
         ttl: Ttl = Ttl.Infinite,
         canRead: Boolean = true
@@ -176,13 +148,12 @@ class HandleManager(
         return SingletonHandle(
             name,
             storageProxy,
-            callbacks,
             ttl,
             time,
             canRead,
             dereferencer = RawEntityDereferencer(schema, aff?.dereferenceFactory()),
             schema = schema
-        ).also { storageProxy.registerHandle(it) }
+        )
     }
 
     /**
@@ -193,7 +164,6 @@ class HandleManager(
     suspend fun rawEntityCollectionHandle(
         storageKey: StorageKey,
         schema: Schema,
-        callbacks: CollectionCallbacks<RawEntity>? = null,
         name: String = storageKey.toKeyString(),
         ttl: Ttl = Ttl.Infinite,
         canRead: Boolean = true
@@ -213,39 +183,13 @@ class HandleManager(
         return CollectionHandle(
             name,
             storageProxy,
-            callbacks,
             ttl,
             time,
             canRead,
             dereferencer = RawEntityDereferencer(schema, aff?.dereferenceFactory()),
             schema = schema
-        ).also { storageProxy.registerHandle(it) }
+        )
     }
-
-    /**
-     * @deprecated Use [rawEntityCollectionHandle] instead.
-     */
-    /* ktlint-disable max-line-length */
-    @Deprecated(
-        "Use rawEntityCollectionHandle instead",
-        replaceWith = ReplaceWith("this.rawEntityCollectionHandle(storageKey, schema, callbacks, name, ttl, canRead)")
-    )
-    /* ktlint-enable max-line-length */
-    suspend fun collectionHandle(
-        storageKey: StorageKey,
-        schema: Schema,
-        callbacks: CollectionCallbacks<RawEntity>? = null,
-        name: String = storageKey.toKeyString(),
-        ttl: Ttl = Ttl.Infinite,
-        canRead: Boolean = true
-    ): CollectionHandle<RawEntity> = rawEntityCollectionHandle(
-        storageKey,
-        schema,
-        callbacks,
-        name,
-        ttl,
-        canRead
-    )
 
     /**
      * Creates a new [CollectionHandle] which manages a singleton of type: [Reference], where the
@@ -254,7 +198,6 @@ class HandleManager(
     suspend fun referenceCollectionHandle(
         storageKey: StorageKey,
         schema: Schema,
-        callbacks: CollectionCallbacks<Reference>? = null,
         name: String = storageKey.toKeyString(),
         ttl: Ttl = Ttl.Infinite,
         canRead: Boolean = true
@@ -277,12 +220,11 @@ class HandleManager(
         return CollectionHandle(
             name = name,
             storageProxy = storageProxy,
-            callbacks = callbacks,
             ttl = ttl,
             time = time,
             canRead = canRead,
             dereferencer = RawEntityDereferencer(schema, aff?.dereferenceFactory()),
             schema = schema
-        ).also { storageProxy.registerHandle(it) }
+        )
     }
 }

--- a/java/arcs/core/storage/handle/SingletonHandle.kt
+++ b/java/arcs/core/storage/handle/SingletonHandle.kt
@@ -17,7 +17,6 @@ import arcs.core.data.RawEntity
 import arcs.core.data.Schema
 import arcs.core.data.Ttl
 import arcs.core.storage.ActivationFactory
-import arcs.core.storage.Callbacks
 import arcs.core.storage.Dereferencer
 import arcs.core.storage.Handle
 import arcs.core.storage.StorageProxy
@@ -31,7 +30,6 @@ typealias SingletonData<T> = CrdtSingleton.Data<T>
 typealias SingletonOp<T> = CrdtSingleton.IOperation<T>
 typealias SingletonStoreOptions<T> = StoreOptions<SingletonData<T>, SingletonOp<T>, T?>
 typealias SingletonActivationFactory<T> = ActivationFactory<SingletonData<T>, SingletonOp<T>, T?>
-typealias SingletonCallbacks<T> = Callbacks<SingletonData<T>, SingletonOp<T>, T?>
 
 /**
  * Singleton [Handle] implementation for the runtime.
@@ -42,7 +40,6 @@ typealias SingletonCallbacks<T> = Callbacks<SingletonData<T>, SingletonOp<T>, T?
 class SingletonHandle<T : Referencable>(
     name: String,
     storageProxy: SingletonProxy<T>,
-    callbacks: SingletonCallbacks<T>? = null,
     ttl: Ttl = Ttl.Infinite,
     time: Time,
     canRead: Boolean = true,
@@ -51,7 +48,6 @@ class SingletonHandle<T : Referencable>(
 ) : SingletonBase<T>(
     name,
     storageProxy,
-    callbacks,
     ttl,
     time,
     canRead,

--- a/javatests/arcs/core/storage/StoreEndpointFake.kt
+++ b/javatests/arcs/core/storage/StoreEndpointFake.kt
@@ -15,7 +15,10 @@ class StoreEndpointFake<Data : CrdtData, Op : CrdtOperation, T> :
     private var callbacks = mutableListOf<ProxyCallback<Data, Op, T>>()
     private var proxyMessages = mutableListOf<ProxyMessage<Data, Op, T>>()
 
-    override fun setCallback(callback: ProxyCallback<Data, Op, T>): Int {
+    // Tests can change this field to alter the value returned by `onProxyMessage`.
+    var onProxyMessageReturn = true
+
+override fun setCallback(callback: ProxyCallback<Data, Op, T>): Int {
         // must be blocking since the storage impl is. Unlikely to be heavily contended.
         return runBlocking {
             mutex.withLock {
@@ -31,7 +34,7 @@ class StoreEndpointFake<Data : CrdtData, Op : CrdtOperation, T> :
 
     override suspend fun onProxyMessage(message: ProxyMessage<Data, Op, T>): Boolean {
         mutex.withLock { proxyMessages.add(message) }
-        return true
+        return onProxyMessageReturn
     }
 
     suspend fun getProxyMessages() : List<ProxyMessage<Data, Op, T>> {

--- a/javatests/arcs/core/storage/handle/CollectionIntegrationTest.kt
+++ b/javatests/arcs/core/storage/handle/CollectionIntegrationTest.kt
@@ -67,10 +67,8 @@ class CollectionIntegrationTest {
         testStore = Store(STORE_OPTIONS)
         storageProxy = StorageProxy(testStore.activate(), CrdtSet<RawEntity>())
 
-        collectionA = CollectionHandle("collectionA", storageProxy, null, Ttl.Infinite, TimeImpl(), schema = SCHEMA_A)
-        storageProxy.registerHandle(collectionA)
-        collectionB = CollectionHandle("collectionB", storageProxy, null, Ttl.Infinite, TimeImpl(), schema = SCHEMA_B)
-        storageProxy.registerHandle(collectionB)
+        collectionA = CollectionHandle("collectionA", storageProxy, Ttl.Infinite, TimeImpl(), schema = SCHEMA_A)
+        collectionB = CollectionHandle("collectionB", storageProxy, Ttl.Infinite, TimeImpl(), schema = SCHEMA_B)
         Unit
     }
 
@@ -186,15 +184,13 @@ class CollectionIntegrationTest {
         assertThat(collectionA.fetchAll().first().expirationTimestamp)
             .isEqualTo(RawEntity.UNINITIALIZED_TIMESTAMP)
 
-        val collectionC = CollectionHandle("collectionC", storageProxy, null, Ttl.Days(2), TimeImpl(), schema = SCHEMA_A)
-        storageProxy.registerHandle(collectionC)
+        val collectionC = CollectionHandle("collectionC", storageProxy, Ttl.Days(2), TimeImpl(), schema = SCHEMA_A)
         assertThat(collectionC.store(person.toRawEntity())).isTrue()
         val entityC = collectionC.fetchAll().first()
         assertThat(entityC.creationTimestamp).isGreaterThan(creationTimestampA)
         assertThat(entityC.expirationTimestamp).isGreaterThan(RawEntity.UNINITIALIZED_TIMESTAMP)
 
-        val collectionD = CollectionHandle("collectionD", storageProxy, null, Ttl.Minutes(1), TimeImpl(), schema = SCHEMA_B)
-        storageProxy.registerHandle(collectionD)
+        val collectionD = CollectionHandle("collectionD", storageProxy, Ttl.Minutes(1), TimeImpl(), schema = SCHEMA_B)
         assertThat(collectionD.store(person.toRawEntity())).isTrue()
         val entityD = collectionD.fetchAll().first()
         assertThat(entityD.creationTimestamp).isGreaterThan(creationTimestampA)

--- a/javatests/arcs/core/storage/handle/SingletonIntegrationTest.kt
+++ b/javatests/arcs/core/storage/handle/SingletonIntegrationTest.kt
@@ -65,10 +65,8 @@ class SingletonIntegrationTest {
         store = Store(STORE_OPTIONS)
         storageProxy = StorageProxy(store.activate(), CrdtSingleton<RawEntity>())
 
-        singletonA = SingletonHandle("singletonA", storageProxy, null, Ttl.Infinite, TimeImpl(), schema = SCHEMA)
-        storageProxy.registerHandle(singletonA)
-        singletonB = SingletonHandle("singletonB", storageProxy, null, Ttl.Infinite, TimeImpl(), schema = SCHEMA)
-        storageProxy.registerHandle(singletonB)
+        singletonA = SingletonHandle("singletonA", storageProxy, Ttl.Infinite, TimeImpl(), schema = SCHEMA)
+        singletonB = SingletonHandle("singletonB", storageProxy, Ttl.Infinite, TimeImpl(), schema = SCHEMA)
         Unit
     }
 
@@ -142,15 +140,13 @@ class SingletonIntegrationTest {
         assertThat(requireNotNull(singletonA.fetch()).expirationTimestamp)
             .isEqualTo(RawEntity.UNINITIALIZED_TIMESTAMP)
 
-        val singletonC = SingletonHandle("singletonC", storageProxy, null, Ttl.Days(2), TimeImpl(), schema = SCHEMA)
-        storageProxy.registerHandle(singletonC)
+        val singletonC = SingletonHandle("singletonC", storageProxy, Ttl.Days(2), TimeImpl(), schema = SCHEMA)
         assertThat(singletonC.store(person.toRawEntity())).isTrue()
         val entityC = requireNotNull(singletonC.fetch())
         assertThat(entityC.creationTimestamp).isGreaterThan(creationTimestampA)
         assertThat(entityC.expirationTimestamp).isGreaterThan(RawEntity.UNINITIALIZED_TIMESTAMP)
 
-        val singletonD = SingletonHandle("singletonD", storageProxy, null, Ttl.Minutes(1), TimeImpl(), schema = SCHEMA)
-        storageProxy.registerHandle(singletonD)
+        val singletonD = SingletonHandle("singletonD", storageProxy, Ttl.Minutes(1), TimeImpl(), schema = SCHEMA)
         assertThat(singletonD.store(person.toRawEntity())).isTrue()
         val entityD = requireNotNull(singletonD.fetch())
         assertThat(entityD.creationTimestamp).isGreaterThan(creationTimestampA)

--- a/javatests/arcs/core/storage/ttl/RemovalManagerTest.kt
+++ b/javatests/arcs/core/storage/ttl/RemovalManagerTest.kt
@@ -83,7 +83,6 @@ class RemovalManagerTest {
         singletonHandle = hm.rawEntitySingletonHandle(
             singletonKey,
             schema,
-            null,
             "name1",
             Ttl.Minutes(5)
         )
@@ -91,7 +90,6 @@ class RemovalManagerTest {
         collectionHandle = hm.rawEntityCollectionHandle(
             setKey,
             schema,
-            null,
             "name2",
             Ttl.Hours(2)
         )


### PR DESCRIPTION
* Remove the `core` `Callbacks` interface type, in favor of
  finer-grained action functions
* Move ownerships of data activity callbacks into `StorageProxy`
* Remove some deprecated functions
* Remove the `registerHandle` and `deregisterHandle` methods on
  `StorageProxy`
* Fix the `failedApplyOpTriggersSync` test in `StorageProxy` that wasn't
  quite right.

What started as adding `start`/`stop` functionality to handles turned
into a re-imagining of the callbacks pattern.

Observations:
* `registerHandle` (which was to be called via a `start` method on the
handle) is only setting up callbacks to the handle.
* The only action a handle takes when receiving `storageProxy` callback
calls is to trigger any developer-supplied callbacks.
* Adapting between the single-interface-with-all-3-callbacks and
callbacks-as-individual-methods approach seemed to cause some
complicated interface adaption needs.