### PR TITLE
recipe2plan: New means of generating `Create` handle `StorageKey`s.

### DIFF
--- a/src/tools/plan-generator.ts
+++ b/src/tools/plan-generator.ts
@@ -12,8 +12,8 @@ import {Type} from '../runtime/type.js';
 import {Particle} from '../runtime/recipe/particle.js';
 import {KotlinGenerationUtils, quote, tryImport} from './kotlin-generation-utils.js';
 import {HandleConnection} from '../runtime/recipe/handle-connection.js';
-import {StorageKey} from '../runtime/storageNG/storage-key.js';
 import {Direction} from '../runtime/manifest-ast-nodes.js';
+import {Handle} from '../runtime/recipe/handle.js';
 
 const ktUtils = new KotlinGenerationUtils();
 
@@ -69,7 +69,7 @@ export class PlanGenerator {
 
   /** Generates a Kotlin `Plan.HandleConnection` from a HandleConnection. */
   createHandleConnection(connection: HandleConnection): string {
-    const storageKey = this.createStorageKey(connection.handle.storageKey);
+    const storageKey = this.createStorageKey(connection.handle);
     const mode = this.createDirection(connection.direction);
     const type = this.createType(connection.type);
     const ttl = 'null';
@@ -88,9 +88,12 @@ export class PlanGenerator {
     }
   }
 
-  /** Generates a Kotlin `StorageKey` from a StorageKey. */
-  createStorageKey(storageKey: StorageKey | undefined): string {
-    return `StorageKeyParser.parse("${(storageKey || '').toString()}")`;
+  /** Generates a Kotlin `StorageKey` from a recipe Handle. */
+  createStorageKey(handle: Handle): string {
+    switch (handle.fate) {
+      case 'create': return ktUtils.applyFun('CreateableStorageKey', [quote(handle.id)]);
+      default: return `StorageKeyParser.parse("${(handle.storageKey || '').toString()}")`;
+    }
   }
 
   /** Generates a Kotlin `core.arc.type.Type` from a Type. */

--- a/src/tools/plan-generator.ts
+++ b/src/tools/plan-generator.ts
@@ -111,10 +111,11 @@ export class PlanGenerator {
 
   /** Generates a Kotlin `StorageKey` from a recipe Handle. */
   createStorageKey(handle: Handle): string {
-    switch (handle.fate) {
-      case 'create': return ktUtils.applyFun('CreateableStorageKey', [quote(handle.id)]);
-      default: return `StorageKeyParser.parse("${(handle.storageKey || '').toString()}")`;
+    const storageKey = handle.storageKey;
+    if (!storageKey && handle.fate === 'create') {
+      return ktUtils.applyFun('CreateableStorageKey', [quote(handle.id)]);
     }
+    return ktUtils.applyFun('StorageKeyParser.parse', [(storageKey || '').toString()]);
   }
 
   /** Generates a Kotlin `core.arc.type.Type` from a Type. */

--- a/src/tools/plan-generator.ts
+++ b/src/tools/plan-generator.ts
@@ -111,11 +111,13 @@ export class PlanGenerator {
 
   /** Generates a Kotlin `StorageKey` from a recipe Handle. */
   createStorageKey(handle: Handle): string {
-    const storageKey = handle.storageKey;
-    if (!storageKey && handle.fate === 'create') {
+    if (handle.storageKey) {
+      return ktUtils.applyFun('StorageKeyParser.parse', [quote(handle.storageKey.toString())]);
+    }
+    if (handle.fate === 'create') {
       return ktUtils.applyFun('CreateableStorageKey', [quote(handle.id)]);
     }
-    return ktUtils.applyFun('StorageKeyParser.parse', [quote((storageKey || '').toString())]);
+    throw new PlanGeneratorError(`Problematic handle '${handle.id}': Only 'create' Handles can have null 'StorageKey's.`);
   }
 
   /** Generates a Kotlin `core.arc.type.Type` from a Type. */

--- a/src/tools/plan-generator.ts
+++ b/src/tools/plan-generator.ts
@@ -115,7 +115,7 @@ export class PlanGenerator {
     if (!storageKey && handle.fate === 'create') {
       return ktUtils.applyFun('CreateableStorageKey', [quote(handle.id)]);
     }
-    return ktUtils.applyFun('StorageKeyParser.parse', [(storageKey || '').toString()]);
+    return ktUtils.applyFun('StorageKeyParser.parse', [quote((storageKey || '').toString())]);
   }
 
   /** Generates a Kotlin `core.arc.type.Type` from a Type. */

--- a/src/tools/tests/goldens/WriterReaderExample.kt
+++ b/src/tools/tests/goldens/WriterReaderExample.kt
@@ -16,7 +16,12 @@ object IngestionPlan : Plan(
             "Writer",
             "",
             mapOf(
-                "data" to HandleConnection(StorageKeyParser.parse(""), HandleMode.Write, null, null)
+                "data" to HandleConnection(
+                    CreateableStorageKey("my-handle-id"),
+                    HandleMode.Write,
+                    null,
+                    null
+                )
             )
         )
     )
@@ -28,7 +33,7 @@ object ConsumptionPlan : Plan(
             "",
             mapOf(
                 "data" to HandleConnection(
-                    StorageKeyParser.parse("reference-mode://{ramdisk://Thing}{ramdisk:///handle/my-handle-id}"),
+                    StorageKeyParser.parse("db://25e71af4e9fc8b6958fc46a8f4b7cdf6b5f31516@arcs/!228758327805841:writingArcId/handle/my-handle-id"),
                     HandleMode.Read,
                     null,
                     null

--- a/src/tools/tests/goldens/WriterReaderExample.kt
+++ b/src/tools/tests/goldens/WriterReaderExample.kt
@@ -33,7 +33,9 @@ object ConsumptionPlan : Plan(
             "",
             mapOf(
                 "data" to HandleConnection(
-                    StorageKeyParser.parse("reference-mode://{db://25e71af4e9fc8b6958fc46a8f4b7cdf6b5f31516@arcs/Thing}{db://25e71af4e9fc8b6958fc46a8f4b7cdf6b5f31516@arcs/!:writingArcId/handle/my-handle-id}"),
+                    StorageKeyParser.parse(
+                        "reference-mode://{db://25e71af4e9fc8b6958fc46a8f4b7cdf6b5f31516@arcs/Thing}{db://25e71af4e9fc8b6958fc46a8f4b7cdf6b5f31516@arcs/!:writingArcId/handle/my-handle-id}"
+                    ),
                     HandleMode.Read,
                     EntityType(Reader_Data_Spec.SCHEMA),
                     null

--- a/src/tools/tests/goldens/WriterReaderExample.kt
+++ b/src/tools/tests/goldens/WriterReaderExample.kt
@@ -17,7 +17,7 @@ object IngestionPlan : Plan(
             "",
             mapOf(
                 "data" to HandleConnection(
-                    StorageKeyParser.parse(""),
+                    CreateableStorageKey("my-handle-id"),
                     HandleMode.Write,
                     EntityType(Writer_Data_Spec.SCHEMA),
                     null


### PR DESCRIPTION
Updating storage key generation: Now, if a handle has a `create` fate and a key has not been assigned in recipe resolution, we will generate a `CreateableStorageKey` from the handle id. 