### PR TITLE
Tidy up the EntitySpec class

### DIFF
--- a/java/arcs/core/host/ArcHostContextParticle.kt
+++ b/java/arcs/core/host/ArcHostContextParticle.kt
@@ -230,19 +230,19 @@ class ArcHostContextParticle : AbstractArcHostParticle() {
         // Because we don't have references/collections support yet, we use 3 handles/schemas
         val arcStateKey = resolver.createStorageKey(
             capability,
-            ArcHostParticle_ArcHostContext_Spec.SCHEMA,
+            ArcHostParticle_ArcHostContext.SCHEMA,
             "${hostId}_arcState"
         )
 
         val particlesStateKey = resolver.createStorageKey(
             capability,
-            ArcHostParticle_Particles_Spec.SCHEMA,
+            ArcHostParticle_Particles.SCHEMA,
             "${hostId}_arcState_particles"
         )
 
         val handleConnectionsKey = resolver.createStorageKey(
             capability,
-            ArcHostParticle_HandleConnections_Spec.SCHEMA,
+            ArcHostParticle_HandleConnections.SCHEMA,
             "${hostId}_arcState_handleConnections"
         )
 
@@ -258,21 +258,21 @@ class ArcHostContextParticle : AbstractArcHostParticle() {
                             arcStateKey!!,
                             HandleMode.ReadWrite,
                             SingletonType(
-                                EntityType(ArcHostParticle_ArcHostContext_Spec.SCHEMA)
+                                EntityType(ArcHostParticle_ArcHostContext.SCHEMA)
                             )
                         ),
                         "particles" to HandleConnection(
                             particlesStateKey!!,
                             HandleMode.ReadWrite,
                             CollectionType(
-                                EntityType(ArcHostParticle_Particles_Spec.SCHEMA)
+                                EntityType(ArcHostParticle_Particles.SCHEMA)
                             )
                         ),
                         "handleConnections" to HandleConnection(
                             handleConnectionsKey!!,
                             HandleMode.ReadWrite,
                             CollectionType(
-                                EntityType(ArcHostParticle_HandleConnections_Spec.SCHEMA)
+                                EntityType(ArcHostParticle_HandleConnections.SCHEMA)
                             )
                         )
                     )

--- a/java/arcs/core/host/ArcHostContextParticle.kt
+++ b/java/arcs/core/host/ArcHostContextParticle.kt
@@ -195,7 +195,7 @@ class ArcHostContextParticle : AbstractArcHostParticle() {
      */
     fun fromTag(arcId: String, particle: Particle, tag: String, handleName: String): Type {
         try {
-            val schema = particle.handles.getEntitySpec(handleName).schema()
+            val schema = particle.handles.getEntitySpec(handleName).SCHEMA
             return when (Tag.valueOf(tag)) {
                 Tag.Singleton -> SingletonType(EntityType(schema))
                 Tag.Collection -> CollectionType(EntityType(schema))

--- a/java/arcs/core/storage/api/Entity.kt
+++ b/java/arcs/core/storage/api/Entity.kt
@@ -20,7 +20,6 @@ import kotlin.reflect.KClass
 
 interface Entity {
     var internalId: String
-    fun schemaHash(): String
     fun serialize(): RawEntity
 }
 
@@ -40,8 +39,8 @@ interface EntitySpec<T : Entity> {
      */
     fun deserialize(data: RawEntity): T
 
-    /** Returns the corresponding [Schema] for the specified [Entity]. */
-    fun schema(): Schema
+    /** The corresponding [Schema] for the specified [Entity]. */
+    val SCHEMA: Schema
 }
 
 /**

--- a/java/arcs/sdk/wasm/WasmEntity.kt
+++ b/java/arcs/sdk/wasm/WasmEntity.kt
@@ -14,7 +14,6 @@ package arcs.sdk.wasm
 /** Wasm-specific extensions to the base [Entity] interface. */
 interface WasmEntity {
     var internalId: String
-    fun schemaHash(): String
     fun encodeEntity(): NullTermByteArray
 }
 

--- a/javatests/arcs/core/allocator/AllocatorTestBase.kt
+++ b/javatests/arcs/core/allocator/AllocatorTestBase.kt
@@ -12,7 +12,7 @@ import arcs.core.host.HostRegistry
 import arcs.core.host.ParticleNotFoundException
 import arcs.core.host.ParticleState
 import arcs.core.host.ReadPerson
-import arcs.core.host.ReadPerson_Person_Spec
+import arcs.core.host.ReadPerson_Person
 import arcs.core.host.WritePerson
 import arcs.core.host.toRegistration
 import arcs.core.storage.CapabilitiesResolver
@@ -52,7 +52,7 @@ open class AllocatorTestBase {
     private lateinit var readPersonParticle: Plan.Particle
     private lateinit var writeAndReadPersonPlan: Plan
 
-    protected val personSchema = ReadPerson_Person_Spec.SCHEMA
+    protected val personSchema = ReadPerson_Person.SCHEMA
     private var personEntityType: Type = SingletonType(EntityType(personSchema))
 
     private lateinit var readingExternalHost: TestingHost

--- a/javatests/arcs/sdk/wasm/EntityClassApiTest.kt
+++ b/javatests/arcs/sdk/wasm/EntityClassApiTest.kt
@@ -13,16 +13,16 @@ package arcs.sdk.wasm
 
 class EntityClassApiTest : TestBase<EntityClassApiTest_Errors>(
     ::EntityClassApiTest_Errors,
-    EntityClassApiTest_Errors_Spec()
+    EntityClassApiTest_Errors
 ) {
-    private val unused1 = WasmSingletonImpl(this, "data", EntityClassApiTest_Data_Spec())
-    private val unused2 = WasmSingletonImpl(this, "empty", EntityClassApiTest_Empty_Spec())
+    private val unused1 = WasmSingletonImpl(this, "data", EntityClassApiTest_Data)
+    private val unused2 = WasmSingletonImpl(this, "empty", EntityClassApiTest_Empty)
 
     @Test
     fun testEncodingDecoding() {
         val empty = EntityClassApiTest_Data()
         val encodedEmpty = empty.encodeEntity()
-        val decodedEmpty = EntityClassApiTest_Data_Spec().decode(encodedEmpty.bytes)
+        val decodedEmpty = EntityClassApiTest_Data.decode(encodedEmpty.bytes)
         assertEquals(
             "Encoding and Decoding an empty entity results in the same entity",
             empty,
@@ -36,7 +36,7 @@ class EntityClassApiTest : TestBase<EntityClassApiTest_Errors>(
             flg = true
         )
         val encodedFull = full.encodeEntity()
-        val decodedFull = EntityClassApiTest_Data_Spec().decode(encodedFull.bytes)
+        val decodedFull = EntityClassApiTest_Data.decode(encodedFull.bytes)
         assertEquals(
             "Encoding and Decoding an full entity results in the same entity",
             full,

--- a/javatests/arcs/sdk/wasm/SpecialSchemaFieldsTest.kt
+++ b/javatests/arcs/sdk/wasm/SpecialSchemaFieldsTest.kt
@@ -13,10 +13,10 @@ package arcs.sdk.wasm
 
 class SpecialSchemaFieldsTest : TestBase<SpecialSchemaFieldsTest_Errors>(
     ::SpecialSchemaFieldsTest_Errors,
-    SpecialSchemaFieldsTest_Errors_Spec()
+    SpecialSchemaFieldsTest_Errors
 ) {
     private val unused = WasmSingletonImpl(
-        this, "fields", SpecialSchemaFieldsTest_Fields_Spec()
+        this, "fields", SpecialSchemaFieldsTest_Fields
     )
 
     /** Run tests on particle initialization */

--- a/src/tools/plan-generator.ts
+++ b/src/tools/plan-generator.ts
@@ -80,10 +80,10 @@ export class PlanGenerator {
     ]);
   }
 
-  /** Aggregate mapping of schema hashes and schema properties from particle connections */
+  /** Aggregate mapping of schema hashes and schema properties from particle connections. */
   async collectParticleConnectionSpecs(particle: Particle): Promise<void> {
     for (const connection of particle.spec.connections) {
-      const specName = [particle.spec.name, upperFirst(connection.name), 'Spec'].join('_');
+      const specName = [particle.spec.name, upperFirst(connection.name)].join('_');
       const schemaHash = await connection.type.getEntitySchema().hash();
       this.specRegistry[schemaHash] = specName;
     }

--- a/src/tools/tests/goldens/WriterReaderExample.kt
+++ b/src/tools/tests/goldens/WriterReaderExample.kt
@@ -19,7 +19,7 @@ object IngestionPlan : Plan(
                 "data" to HandleConnection(
                     CreateableStorageKey("my-handle-id"),
                     HandleMode.Write,
-                    EntityType(Writer_Data_Spec.SCHEMA),
+                    EntityType(Writer_Data.SCHEMA),
                     Ttl.Days(20)
                 )
             )
@@ -37,7 +37,7 @@ object ConsumptionPlan : Plan(
                         "reference-mode://{db://25e71af4e9fc8b6958fc46a8f4b7cdf6b5f31516@arcs/Thing}{db://25e71af4e9fc8b6958fc46a8f4b7cdf6b5f31516@arcs/!:writingArcId/handle/my-handle-id}"
                     ),
                     HandleMode.Read,
-                    EntityType(Reader_Data_Spec.SCHEMA),
+                    EntityType(Reader_Data.SCHEMA),
                     Ttl.Infinite
                 )
             )

--- a/src/tools/tests/goldens/generated-schemas.jvm.kt
+++ b/src/tools/tests/goldens/generated-schemas.jvm.kt
@@ -48,8 +48,6 @@ class GoldInternal1(val_: String = "") : Entity {
     override fun hashCode(): Int =
         if (internalId.isNotEmpty()) internalId.hashCode() else toString().hashCode()
 
-    override fun schemaHash() = "485712110d89359a3e539dac987329cd2649d889"
-
     override fun serialize() = RawEntity(
         internalId,
         mapOf("val" to val_.toReferencable())
@@ -57,23 +55,10 @@ class GoldInternal1(val_: String = "") : Entity {
 
     override fun toString() =
       "GoldInternal1(val_ = $val_)"
-}
 
-class GoldInternal1_Spec() : EntitySpec<GoldInternal1> {
+    companion object : EntitySpec<GoldInternal1> {
 
-    override fun create() = GoldInternal1()
-
-    override fun deserialize(data: RawEntity): GoldInternal1 {
-        // TODO: only handles singletons for now
-        val rtn = create().copy(val_ = data.singletons["val_"].toPrimitiveValue(String::class, ""))
-        rtn.internalId = data.id
-        return rtn
-    }
-
-    override fun schema() = SCHEMA
-
-    companion object {
-        val SCHEMA = Schema(
+        override val SCHEMA = Schema(
             listOf(),
             SchemaFields(
                 singletons = mapOf("val" to FieldType.Text),
@@ -82,18 +67,23 @@ class GoldInternal1_Spec() : EntitySpec<GoldInternal1> {
             "485712110d89359a3e539dac987329cd2649d889",
             refinement = { _ -> true },
             query = null
-          )
+        ).also { SchemaRegistry.register(it) }
 
-        init {
-            SchemaRegistry.register(SCHEMA)
+        override fun create() = GoldInternal1()
+
+        override fun deserialize(data: RawEntity): GoldInternal1 {
+            // TODO: only handles singletons for now
+            val rtn = create().copy(
+                val_ = data.singletons["val_"].toPrimitiveValue(String::class, "")
+            )
+            rtn.internalId = data.id
+            return rtn
         }
     }
 }
 
 typealias Gold_Data_Ref = GoldInternal1
-typealias Gold_Data_Ref_Spec = GoldInternal1_Spec
 typealias Gold_Alias = GoldInternal1
-typealias Gold_Alias_Spec = GoldInternal1_Spec
 
 class Gold_QCollection(
     name: String = "",
@@ -188,8 +178,6 @@ class Gold_QCollection(
     override fun hashCode(): Int =
         if (internalId.isNotEmpty()) internalId.hashCode() else toString().hashCode()
 
-    override fun schemaHash() = "ccd14452cc01e1b00b94cdb25bfe34a5a632daaa"
-
     override fun serialize() = RawEntity(
         internalId,
         mapOf(
@@ -205,31 +193,10 @@ class Gold_QCollection(
 
     override fun toString() =
       "Gold_QCollection(name = $name, age = $age, lastCall = $lastCall, address = $address, favoriteColor = $favoriteColor, birthDayMonth = $birthDayMonth, birthDayDOM = $birthDayDOM)"
-}
 
-class Gold_QCollection_Spec() : EntitySpec<Gold_QCollection> {
+    companion object : EntitySpec<Gold_QCollection> {
 
-    override fun create() = Gold_QCollection()
-
-    override fun deserialize(data: RawEntity): Gold_QCollection {
-        // TODO: only handles singletons for now
-        val rtn = create().copy(
-            name = data.singletons["name"].toPrimitiveValue(String::class, ""),
-            age = data.singletons["age"].toPrimitiveValue(Double::class, 0.0),
-            lastCall = data.singletons["lastCall"].toPrimitiveValue(Double::class, 0.0),
-            address = data.singletons["address"].toPrimitiveValue(String::class, ""),
-            favoriteColor = data.singletons["favoriteColor"].toPrimitiveValue(String::class, ""),
-            birthDayMonth = data.singletons["birthDayMonth"].toPrimitiveValue(Double::class, 0.0),
-            birthDayDOM = data.singletons["birthDayDOM"].toPrimitiveValue(Double::class, 0.0)
-        )
-        rtn.internalId = data.id
-        return rtn
-    }
-
-    override fun schema() = SCHEMA
-
-    companion object {
-        val SCHEMA = Schema(
+        override val SCHEMA = Schema(
             listOf(SchemaName("People")),
             SchemaFields(
                 singletons = mapOf(
@@ -251,10 +218,23 @@ class Gold_QCollection_Spec() : EntitySpec<Gold_QCollection> {
                 val queryArgument = queryArgs as String
                 ((lastCall < 259200) && (name == queryArgument))
             }
-          )
+        ).also { SchemaRegistry.register(it) }
 
-        init {
-            SchemaRegistry.register(SCHEMA)
+        override fun create() = Gold_QCollection()
+
+        override fun deserialize(data: RawEntity): Gold_QCollection {
+            // TODO: only handles singletons for now
+            val rtn = create().copy(
+                name = data.singletons["name"].toPrimitiveValue(String::class, ""),
+                age = data.singletons["age"].toPrimitiveValue(Double::class, 0.0),
+                lastCall = data.singletons["lastCall"].toPrimitiveValue(Double::class, 0.0),
+                address = data.singletons["address"].toPrimitiveValue(String::class, ""),
+                favoriteColor = data.singletons["favoriteColor"].toPrimitiveValue(String::class, ""),
+                birthDayMonth = data.singletons["birthDayMonth"].toPrimitiveValue(Double::class, 0.0),
+                birthDayDOM = data.singletons["birthDayDOM"].toPrimitiveValue(Double::class, 0.0)
+            )
+            rtn.internalId = data.id
+            return rtn
         }
     }
 }
@@ -321,8 +301,6 @@ class Gold_Data(
     override fun hashCode(): Int =
         if (internalId.isNotEmpty()) internalId.hashCode() else toString().hashCode()
 
-    override fun schemaHash() = "d8058d336e472da47b289eafb39733f77eadb111"
-
     override fun serialize() = RawEntity(
         internalId,
         mapOf(
@@ -335,28 +313,10 @@ class Gold_Data(
 
     override fun toString() =
       "Gold_Data(num = $num, txt = $txt, lnk = $lnk, flg = $flg)"
-}
 
-class Gold_Data_Spec() : EntitySpec<Gold_Data> {
+    companion object : EntitySpec<Gold_Data> {
 
-    override fun create() = Gold_Data()
-
-    override fun deserialize(data: RawEntity): Gold_Data {
-        // TODO: only handles singletons for now
-        val rtn = create().copy(
-            num = data.singletons["num"].toPrimitiveValue(Double::class, 0.0),
-            txt = data.singletons["txt"].toPrimitiveValue(String::class, ""),
-            lnk = data.singletons["lnk"].toPrimitiveValue(String::class, ""),
-            flg = data.singletons["flg"].toPrimitiveValue(Boolean::class, false)
-        )
-        rtn.internalId = data.id
-        return rtn
-    }
-
-    override fun schema() = SCHEMA
-
-    companion object {
-        val SCHEMA = Schema(
+        override val SCHEMA = Schema(
             listOf(),
             SchemaFields(
                 singletons = mapOf(
@@ -370,10 +330,20 @@ class Gold_Data_Spec() : EntitySpec<Gold_Data> {
             "d8058d336e472da47b289eafb39733f77eadb111",
             refinement = { _ -> true },
             query = null
-          )
+        ).also { SchemaRegistry.register(it) }
 
-        init {
-            SchemaRegistry.register(SCHEMA)
+        override fun create() = Gold_Data()
+
+        override fun deserialize(data: RawEntity): Gold_Data {
+            // TODO: only handles singletons for now
+            val rtn = create().copy(
+                num = data.singletons["num"].toPrimitiveValue(Double::class, 0.0),
+                txt = data.singletons["txt"].toPrimitiveValue(String::class, ""),
+                lnk = data.singletons["lnk"].toPrimitiveValue(String::class, ""),
+                flg = data.singletons["flg"].toPrimitiveValue(Boolean::class, false)
+            )
+            rtn.internalId = data.id
+            return rtn
         }
     }
 }
@@ -381,11 +351,7 @@ class Gold_Data_Spec() : EntitySpec<Gold_Data> {
 
 class GoldHandles : HandleHolderBase(
     "Gold",
-    mapOf(
-        "data" to Gold_Data_Spec(),
-        "qCollection" to Gold_QCollection_Spec(),
-        "alias" to Gold_Alias_Spec()
-    )
+    mapOf("data" to Gold_Data, "qCollection" to Gold_QCollection, "alias" to Gold_Alias)
 ) {
     val data: ReadSingletonHandle<Gold_Data> by handles
     val qCollection: ReadQueryCollectionHandle<Gold_QCollection, String> by handles

--- a/src/tools/tests/goldens/generated-schemas.wasm.kt
+++ b/src/tools/tests/goldens/generated-schemas.wasm.kt
@@ -44,8 +44,6 @@ class GoldInternal1(val_: String = "") : WasmEntity {
     override fun hashCode(): Int =
         if (internalId.isNotEmpty()) internalId.hashCode() else toString().hashCode()
 
-    override fun schemaHash() = "485712110d89359a3e539dac987329cd2649d889"
-
     override fun encodeEntity(): NullTermByteArray {
         val encoder = StringEncoder()
         encoder.encode("", internalId)
@@ -55,54 +53,52 @@ class GoldInternal1(val_: String = "") : WasmEntity {
 
     override fun toString() =
       "GoldInternal1(val_ = $val_)"
-}
 
-class GoldInternal1_Spec() : WasmEntitySpec<GoldInternal1> {
-
-    override fun create() = GoldInternal1()
+    companion object : WasmEntitySpec<GoldInternal1> {
 
 
-    override fun decode(encoded: ByteArray): GoldInternal1? {
-        if (encoded.isEmpty()) return null
+        override fun create() = GoldInternal1()
 
-        val decoder = StringDecoder(encoded)
-        val internalId = decoder.decodeText()
-        decoder.validate("|")
+        override fun decode(encoded: ByteArray): GoldInternal1? {
+            if (encoded.isEmpty()) return null
 
-        var val_ = ""
-        var i = 0
-        while (i < 1 && !decoder.done()) {
-            val _name = decoder.upTo(':').toUtf8String()
-            when (_name) {
-                "val" -> {
-                    decoder.validate("T")
-                    val_ = decoder.decodeText()
-                }
-                else -> {
-                    // Ignore unknown fields until type slicing is fully implemented.
-                    when (decoder.chomp(1).toUtf8String()) {
-                        "T", "U" -> decoder.decodeText()
-                        "N" -> decoder.decodeNum()
-                        "B" -> decoder.decodeBool()
-                    }
-                    i--
-                }
-            }
+            val decoder = StringDecoder(encoded)
+            val internalId = decoder.decodeText()
             decoder.validate("|")
-            i++
+
+            var val_ = ""
+            var i = 0
+            while (i < 1 && !decoder.done()) {
+                val _name = decoder.upTo(':').toUtf8String()
+                when (_name) {
+                    "val" -> {
+                        decoder.validate("T")
+                        val_ = decoder.decodeText()
+                    }
+                    else -> {
+                        // Ignore unknown fields until type slicing is fully implemented.
+                        when (decoder.chomp(1).toUtf8String()) {
+                            "T", "U" -> decoder.decodeText()
+                            "N" -> decoder.decodeNum()
+                            "B" -> decoder.decodeBool()
+                        }
+                        i--
+                    }
+                }
+                decoder.validate("|")
+                i++
+            }
+            val _rtn = create().copy(
+                val_ = val_
+            )
+            _rtn.internalId = internalId
+            return _rtn
         }
-        val _rtn = create().copy(
-            val_ = val_
-        )
-        _rtn.internalId = internalId
-        return _rtn
     }
 }
 
 typealias Gold_Data_Ref = GoldInternal1
-typealias Gold_Data_Ref_Spec = GoldInternal1_Spec
 typealias Gold_Alias = GoldInternal1
-typealias Gold_Alias_Spec = GoldInternal1_Spec
 
 class Gold_QCollection(
     name: String = "",
@@ -197,8 +193,6 @@ class Gold_QCollection(
     override fun hashCode(): Int =
         if (internalId.isNotEmpty()) internalId.hashCode() else toString().hashCode()
 
-    override fun schemaHash() = "ccd14452cc01e1b00b94cdb25bfe34a5a632daaa"
-
     override fun encodeEntity(): NullTermByteArray {
         val encoder = StringEncoder()
         encoder.encode("", internalId)
@@ -214,73 +208,72 @@ class Gold_QCollection(
 
     override fun toString() =
       "Gold_QCollection(name = $name, age = $age, lastCall = $lastCall, address = $address, favoriteColor = $favoriteColor, birthDayMonth = $birthDayMonth, birthDayDOM = $birthDayDOM)"
-}
 
-class Gold_QCollection_Spec() : WasmEntitySpec<Gold_QCollection> {
-
-    override fun create() = Gold_QCollection()
+    companion object : WasmEntitySpec<Gold_QCollection> {
 
 
-    override fun decode(encoded: ByteArray): Gold_QCollection? {
-        if (encoded.isEmpty()) return null
+        override fun create() = Gold_QCollection()
 
-        val decoder = StringDecoder(encoded)
-        val internalId = decoder.decodeText()
-        decoder.validate("|")
+        override fun decode(encoded: ByteArray): Gold_QCollection? {
+            if (encoded.isEmpty()) return null
 
-        var name = ""
-        var age = 0.0
-        var lastCall = 0.0
-        var address = ""
-        var favoriteColor = ""
-        var birthDayMonth = 0.0
-        var birthDayDOM = 0.0
-        var i = 0
-        while (i < 7 && !decoder.done()) {
-            val _name = decoder.upTo(':').toUtf8String()
-            when (_name) {
-                "name" -> {
-                    decoder.validate("T")
-                    name = decoder.decodeText()
-                }
-                "age" -> {
-                    decoder.validate("N")
-                    age = decoder.decodeNum()
-                }
-                "lastCall" -> {
-                    decoder.validate("N")
-                    lastCall = decoder.decodeNum()
-                }
-                "address" -> {
-                    decoder.validate("T")
-                    address = decoder.decodeText()
-                }
-                "favoriteColor" -> {
-                    decoder.validate("T")
-                    favoriteColor = decoder.decodeText()
-                }
-                "birthDayMonth" -> {
-                    decoder.validate("N")
-                    birthDayMonth = decoder.decodeNum()
-                }
-                "birthDayDOM" -> {
-                    decoder.validate("N")
-                    birthDayDOM = decoder.decodeNum()
-                }
-                else -> {
-                    // Ignore unknown fields until type slicing is fully implemented.
-                    when (decoder.chomp(1).toUtf8String()) {
-                        "T", "U" -> decoder.decodeText()
-                        "N" -> decoder.decodeNum()
-                        "B" -> decoder.decodeBool()
-                    }
-                    i--
-                }
-            }
+            val decoder = StringDecoder(encoded)
+            val internalId = decoder.decodeText()
             decoder.validate("|")
-            i++
-        }
-        val _rtn = create().copy(
+
+            var name = ""
+            var age = 0.0
+            var lastCall = 0.0
+            var address = ""
+            var favoriteColor = ""
+            var birthDayMonth = 0.0
+            var birthDayDOM = 0.0
+            var i = 0
+            while (i < 7 && !decoder.done()) {
+                val _name = decoder.upTo(':').toUtf8String()
+                when (_name) {
+                    "name" -> {
+                        decoder.validate("T")
+                        name = decoder.decodeText()
+                    }
+                    "age" -> {
+                        decoder.validate("N")
+                        age = decoder.decodeNum()
+                    }
+                    "lastCall" -> {
+                        decoder.validate("N")
+                        lastCall = decoder.decodeNum()
+                    }
+                    "address" -> {
+                        decoder.validate("T")
+                        address = decoder.decodeText()
+                    }
+                    "favoriteColor" -> {
+                        decoder.validate("T")
+                        favoriteColor = decoder.decodeText()
+                    }
+                    "birthDayMonth" -> {
+                        decoder.validate("N")
+                        birthDayMonth = decoder.decodeNum()
+                    }
+                    "birthDayDOM" -> {
+                        decoder.validate("N")
+                        birthDayDOM = decoder.decodeNum()
+                    }
+                    else -> {
+                        // Ignore unknown fields until type slicing is fully implemented.
+                        when (decoder.chomp(1).toUtf8String()) {
+                            "T", "U" -> decoder.decodeText()
+                            "N" -> decoder.decodeNum()
+                            "B" -> decoder.decodeBool()
+                        }
+                        i--
+                    }
+                }
+                decoder.validate("|")
+                i++
+            }
+            val _rtn = create().copy(
 
             name = name,
             age = age,
@@ -290,9 +283,10 @@ class Gold_QCollection_Spec() : WasmEntitySpec<Gold_QCollection> {
             birthDayMonth = birthDayMonth,
             birthDayDOM = birthDayDOM
 
-        )
-        _rtn.internalId = internalId
-        return _rtn
+            )
+            _rtn.internalId = internalId
+            return _rtn
+        }
     }
 }
 
@@ -358,8 +352,6 @@ class Gold_Data(
     override fun hashCode(): Int =
         if (internalId.isNotEmpty()) internalId.hashCode() else toString().hashCode()
 
-    override fun schemaHash() = "d8058d336e472da47b289eafb39733f77eadb111"
-
     override fun encodeEntity(): NullTermByteArray {
         val encoder = StringEncoder()
         encoder.encode("", internalId)
@@ -372,62 +364,62 @@ class Gold_Data(
 
     override fun toString() =
       "Gold_Data(num = $num, txt = $txt, lnk = $lnk, flg = $flg)"
-}
 
-class Gold_Data_Spec() : WasmEntitySpec<Gold_Data> {
-
-    override fun create() = Gold_Data()
+    companion object : WasmEntitySpec<Gold_Data> {
 
 
-    override fun decode(encoded: ByteArray): Gold_Data? {
-        if (encoded.isEmpty()) return null
+        override fun create() = Gold_Data()
 
-        val decoder = StringDecoder(encoded)
-        val internalId = decoder.decodeText()
-        decoder.validate("|")
+        override fun decode(encoded: ByteArray): Gold_Data? {
+            if (encoded.isEmpty()) return null
 
-        var num = 0.0
-        var txt = ""
-        var lnk = ""
-        var flg = false
-        var i = 0
-        while (i < 5 && !decoder.done()) {
-            val _name = decoder.upTo(':').toUtf8String()
-            when (_name) {
-                "num" -> {
-                    decoder.validate("N")
-                    num = decoder.decodeNum()
-                }
-                "txt" -> {
-                    decoder.validate("T")
-                    txt = decoder.decodeText()
-                }
-                "lnk" -> {
-                    decoder.validate("U")
-                    lnk = decoder.decodeText()
-                }
-                "flg" -> {
-                    decoder.validate("B")
-                    flg = decoder.decodeBool()
-                }
-                else -> {
-                    // Ignore unknown fields until type slicing is fully implemented.
-                    when (decoder.chomp(1).toUtf8String()) {
-                        "T", "U" -> decoder.decodeText()
-                        "N" -> decoder.decodeNum()
-                        "B" -> decoder.decodeBool()
-                    }
-                    i--
-                }
-            }
+            val decoder = StringDecoder(encoded)
+            val internalId = decoder.decodeText()
             decoder.validate("|")
-            i++
+
+            var num = 0.0
+            var txt = ""
+            var lnk = ""
+            var flg = false
+            var i = 0
+            while (i < 5 && !decoder.done()) {
+                val _name = decoder.upTo(':').toUtf8String()
+                when (_name) {
+                    "num" -> {
+                        decoder.validate("N")
+                        num = decoder.decodeNum()
+                    }
+                    "txt" -> {
+                        decoder.validate("T")
+                        txt = decoder.decodeText()
+                    }
+                    "lnk" -> {
+                        decoder.validate("U")
+                        lnk = decoder.decodeText()
+                    }
+                    "flg" -> {
+                        decoder.validate("B")
+                        flg = decoder.decodeBool()
+                    }
+                    else -> {
+                        // Ignore unknown fields until type slicing is fully implemented.
+                        when (decoder.chomp(1).toUtf8String()) {
+                            "T", "U" -> decoder.decodeText()
+                            "N" -> decoder.decodeNum()
+                            "B" -> decoder.decodeBool()
+                        }
+                        i--
+                    }
+                }
+                decoder.validate("|")
+                i++
+            }
+            val _rtn = create().copy(
+                num = num, txt = txt, lnk = lnk, flg = flg
+            )
+            _rtn.internalId = internalId
+            return _rtn
         }
-        val _rtn = create().copy(
-            num = num, txt = txt, lnk = lnk, flg = flg
-        )
-        _rtn.internalId = internalId
-        return _rtn
     }
 }
 
@@ -435,9 +427,9 @@ class Gold_Data_Spec() : WasmEntitySpec<Gold_Data> {
 class GoldHandles(
     particle: WasmParticleImpl
 ) {
-    val data: WasmSingletonImpl<Gold_Data> = WasmSingletonImpl(particle, "data", Gold_Data_Spec())
-    val qCollection: WasmCollectionImpl<Gold_QCollection> = WasmCollectionImpl(particle, "qCollection", Gold_QCollection_Spec())
-    val alias: WasmSingletonImpl<Gold_Alias> = WasmSingletonImpl(particle, "alias", Gold_Alias_Spec())
+    val data: WasmSingletonImpl<Gold_Data> = WasmSingletonImpl(particle, "data", Gold_Data)
+    val qCollection: WasmCollectionImpl<Gold_QCollection> = WasmCollectionImpl(particle, "qCollection", Gold_QCollection)
+    val alias: WasmSingletonImpl<Gold_Alias> = WasmSingletonImpl(particle, "alias", Gold_Alias)
 }
 
 abstract class AbstractGold : WasmParticleImpl() {

--- a/src/tools/tests/plan-generator-tests.ts
+++ b/src/tools/tests/plan-generator-tests.ts
@@ -46,7 +46,7 @@ describe('recipe2plan', () => {
       await emptyGenerator.collectParticleConnectionSpecs(manifest.recipes[0].particles[0]);
       const actual = await emptyGenerator.createType(manifest.particles[0].handleConnections[0].type);
 
-      assert.include(actual, 'EntityType(A_Data_Spec.SCHEMA)');
+      assert.include(actual, 'EntityType(A_Data.SCHEMA)');
       assert.notInclude(actual, 'SingletonType');
     });
     it('creates valid types that are derived from other types (via nesting)', async () => {
@@ -62,7 +62,7 @@ describe('recipe2plan', () => {
       await emptyGenerator.collectParticleConnectionSpecs(manifest.recipes[0].particles[0]);
       const actual = await emptyGenerator.createType(manifest.particles[0].handleConnections[0].type);
 
-      assert.include(actual, 'EntityType(A_Data_Spec.SCHEMA)');
+      assert.include(actual, 'EntityType(A_Data.SCHEMA)');
       assert.notInclude(actual, 'SingletonType');
       assert.include(actual, 'CollectionType');
     });
@@ -79,7 +79,7 @@ describe('recipe2plan', () => {
       await emptyGenerator.collectParticleConnectionSpecs(manifest.recipes[0].particles[0]);
       const actual = await emptyGenerator.createType(manifest.particles[0].handleConnections[0].type);
 
-      assert.include(actual, 'EntityType(A_Data_Spec.SCHEMA)');
+      assert.include(actual, 'EntityType(A_Data.SCHEMA)');
       assert.notInclude(actual, 'SingletonType');
       assert.include(actual, 'CollectionType');
       assert.include(actual, 'ReferenceType');


### PR DESCRIPTION
Moved it to a companion object on the generated Entity subclasses. Also deleted `schemaHash()` since you can just use `SCHEMA.hash`.
