### PR TITLE
Create a arcs_manifest_parse_test build rule

### DIFF
--- a/third_party/java/arcs/build_defs/build_defs.bzl
+++ b/third_party/java/arcs/build_defs/build_defs.bzl
@@ -26,6 +26,10 @@ load(
     _arcs_cc_schema = "arcs_cc_schema",
     _arcs_kt_schema = "arcs_kt_schema",
 )
+load(
+    "//third_party/java/arcs/build_defs/internal:tools.oss.bzl",
+    _arcs_manifest_parse_test = "arcs_manifest_parse_test",
+)
 load(":sigh.bzl", "sigh_command")
 
 # Re-export rules from various other files.
@@ -53,6 +57,8 @@ arcs_manifest = _arcs_manifest
 arcs_manifest_bundle = _arcs_manifest_bundle
 
 arcs_manifest_json = _arcs_manifest_json
+
+arcs_manifest_parse_test = _arcs_manifest_parse_test
 
 arcs_manifest_proto = _arcs_manifest_proto
 

--- a/third_party/java/arcs/build_defs/internal/kotlin.bzl
+++ b/third_party/java/arcs/build_defs/internal/kotlin.bzl
@@ -23,17 +23,14 @@ load(
     "java_test",
 )
 load("//third_party/java/arcs/build_defs:sigh.bzl", "sigh_command")
-load(
-    "//third_party/java/arcs/build_defs/internal:kotlin_wasm_annotations.bzl",
-    "kotlin_wasm_annotations",
-)
-load("//third_party/java/arcs/build_defs/internal:util.bzl", "replace_arcs_suffix")
 load("//tools/build_defs/android:rules.bzl", "android_local_test")
 load(
     "//tools/build_defs/kotlin:rules.bzl",
     "kt_android_library",
     "kt_jvm_library",
 )
+load(":kotlin_wasm_annotations.bzl", "kotlin_wasm_annotations")
+load(":util.bzl", "merge_lists", "replace_arcs_suffix")
 
 ARCS_SDK_DEPS = ["//third_party/java/arcs"]
 _WASM_SUFFIX = "-wasm"
@@ -77,10 +74,10 @@ def arcs_kt_jvm_library(**kwargs):
     disable_lint_checks = kwargs.pop("disable_lint_checks", [])
     exports = kwargs.pop("exports", [])
     kotlincopts = kwargs.pop("kotlincopts", [])
-    kwargs["kotlincopts"] = _merge_lists(kotlincopts, KOTLINC_OPTS)
+    kwargs["kotlincopts"] = merge_lists(kotlincopts, KOTLINC_OPTS)
     if not IS_BAZEL:
         kwargs["constraints"] = constraints
-        kwargs["disable_lint_checks"] = _merge_lists(disable_lint_checks, DISABLED_LINT_CHECKS)
+        kwargs["disable_lint_checks"] = merge_lists(disable_lint_checks, DISABLED_LINT_CHECKS)
 
     if exports:
         # kt_jvm_library doesn't support the "exports" property. Instead, we
@@ -113,7 +110,7 @@ def arcs_kt_native_library(**kwargs):
       **kwargs: Set of args to forward to kt_native_library
     """
     kotlincopts = kwargs.pop("kotlincopts", [])
-    kwargs["kotlincopts"] = _merge_lists(kotlincopts, KOTLINC_OPTS)
+    kwargs["kotlincopts"] = merge_lists(kotlincopts, KOTLINC_OPTS)
     kt_native_library(**kwargs)
 
 def arcs_kt_js_library(**kwargs):
@@ -128,7 +125,7 @@ def arcs_kt_js_library(**kwargs):
         return
 
     kotlincopts = kwargs.pop("kotlincopts", [])
-    kwargs["kotlincopts"] = _merge_lists(kotlincopts, KOTLINC_OPTS)
+    kwargs["kotlincopts"] = merge_lists(kotlincopts, KOTLINC_OPTS)
     kt_js_library(**kwargs)
 
 def arcs_kt_library(
@@ -426,13 +423,6 @@ def _check_platforms(platforms):
                 platform,
                 ", ".join(ALL_PLATFORMS),
             )
-
-def _merge_lists(*lists):
-    result = {}
-    for x in lists:
-        for elem in x:
-            result[elem] = 1
-    return result.keys()
 
 def _to_jvm_dep(dep):
     return dep

--- a/third_party/java/arcs/build_defs/internal/manifest.bzl
+++ b/third_party/java/arcs/build_defs/internal/manifest.bzl
@@ -34,7 +34,7 @@ def arcs_manifest(name, srcs, deps = [], visibility = None):
     arcs_manifest_parse_test(
         name = name + "_parse_test",
         srcs = srcs,
-        deps = all_files,
+        deps = deps,
     )
 
 def arcs_manifest_json(name, srcs = [], deps = [], out = None, visibility = None):

--- a/third_party/java/arcs/build_defs/internal/manifest.bzl
+++ b/third_party/java/arcs/build_defs/internal/manifest.bzl
@@ -1,7 +1,11 @@
 """Arcs manifest bundling rules."""
 
+load(":util.bzl", "replace_arcs_suffix")
 load("//third_party/java/arcs/build_defs:sigh.bzl", "sigh_command")
-load("//third_party/java/arcs/build_defs/internal:util.bzl", "replace_arcs_suffix")
+load(
+    "//third_party/java/arcs/build_defs/internal:tools.oss.bzl",
+    "arcs_manifest_parse_test",
+)
 
 def arcs_manifest(name, srcs, deps = [], visibility = None):
     """Bundles .arcs manifest files with their particle implementations.
@@ -27,15 +31,10 @@ def arcs_manifest(name, srcs, deps = [], visibility = None):
         visibility = visibility,
     )
 
-    test_args = " ".join(["--src $(location %s)" % src for src in srcs])
-
-    sigh_command(
-        name = name + "_test",
-        srcs = all_files,
-        sigh_cmd = "run manifestChecker " + test_args,
-        deps = [name],
-        progress_message = "Checking Arcs manifest",
-        execute = False,
+    arcs_manifest_parse_test(
+        name = name + "_parse_test",
+        srcs = srcs,
+        deps = all_files,
     )
 
 def arcs_manifest_json(name, srcs = [], deps = [], out = None, visibility = None):

--- a/third_party/java/arcs/build_defs/internal/manifest.bzl
+++ b/third_party/java/arcs/build_defs/internal/manifest.bzl
@@ -1,11 +1,11 @@
 """Arcs manifest bundling rules."""
 
-load(":util.bzl", "replace_arcs_suffix")
 load("//third_party/java/arcs/build_defs:sigh.bzl", "sigh_command")
 load(
     "//third_party/java/arcs/build_defs/internal:tools.oss.bzl",
     "arcs_manifest_parse_test",
 )
+load(":util.bzl", "replace_arcs_suffix")
 
 def arcs_manifest(name, srcs, deps = [], visibility = None):
     """Bundles .arcs manifest files with their particle implementations.

--- a/third_party/java/arcs/build_defs/internal/tools.oss.bzl
+++ b/third_party/java/arcs/build_defs/internal/tools.oss.bzl
@@ -1,0 +1,23 @@
+"""Rules that invoke sigh scripts."""
+
+load("//third_party/java/arcs/build_defs:sigh.bzl", "sigh_command")
+
+def arcs_manifest_parse_test(name, srcs, deps = []):
+    """Tests that Arcs manifest files parse correctly.
+
+    Args:
+      name: the name of the test target to create
+      srcs: list of Arcs manifest files to test
+      deps: list of dependencies (e.g. other imported manifest files)
+    """
+
+    test_args = " ".join(["--src $(location %s)" % src for src in srcs])
+
+    sigh_command(
+        name = name,
+        srcs = srcs,
+        deps = deps,
+        sigh_cmd = "run manifestChecker " + test_args,
+        progress_message = "Checking Arcs manifest",
+        execute = False,
+    )

--- a/third_party/java/arcs/build_defs/internal/util.bzl
+++ b/third_party/java/arcs/build_defs/internal/util.bzl
@@ -8,3 +8,17 @@ def replace_arcs_suffix(src, suffix = ""):
     if src.startswith("//"):
         src = src.split(":")[1]
     return src.replace(".arcs", "").replace("_", "-").replace(".", "-") + suffix
+
+def merge_lists(*lists):
+    """Merges the given lists, ignoring duplicate entries.
+
+    Args:
+      *lists: lists of strings to merge
+    Returns:
+      A list of strings
+    """
+    result = {}
+    for x in lists:
+        for elem in x:
+            result[elem] = 1
+    return result.keys()


### PR DESCRIPTION
This creates a dedicated rule to run the manifest checker.