### PR TITLE
Register key creators in DriverAndKeyConfigurator

### DIFF
--- a/java/arcs/core/storage/api/DriverAndKeyConfigurator.kt
+++ b/java/arcs/core/storage/api/DriverAndKeyConfigurator.kt
@@ -58,8 +58,12 @@ object DriverAndKeyConfigurator {
         StorageKeyParser.reset()
 
         VolatileStorageKey.registerParser()
+        VolatileStorageKey.registerKeyCreator()
         RamDiskStorageKey.registerParser()
+        RamDiskStorageKey.registerKeyCreator()
         DatabaseStorageKey.registerParser()
+        DatabaseStorageKey.registerKeyCreator()
+        // ReferenceModeStorageKey has no key creator.
         ReferenceModeStorageKey.registerParser()
     }
 }

--- a/java/arcs/core/storage/keys/VolatileStorageKey.kt
+++ b/java/arcs/core/storage/keys/VolatileStorageKey.kt
@@ -38,8 +38,8 @@ data class VolatileStorageKey(
         private val VOLATILE_STORAGE_KEY_PATTERN = "^([^/]+)/(.*)\$".toRegex()
 
         init {
-            // When VolatileStorageKey is imported, this will register its parser with the storage
-            // key parsers.
+            // When VolatileStorageKey is instantiated, this will register its parser with the
+            // storage key parsers.
             registerParser()
         }
 


### PR DESCRIPTION
These key parsers are needed to use CapabiltiesResolver. IMO it makes
sense to set them up in this location as well.