### PR TITLE
Add a method DriverFactory.getAllStorageKeys() that returns all stora…

### DIFF
--- a/java/arcs/android/storage/database/AndroidSqliteDatabaseManager.kt
+++ b/java/arcs/android/storage/database/AndroidSqliteDatabaseManager.kt
@@ -12,6 +12,7 @@
 package arcs.android.storage.database
 
 import android.content.Context
+import arcs.core.storage.StorageKey
 import arcs.core.storage.database.Database
 import arcs.core.storage.database.DatabaseIdentifier
 import arcs.core.storage.database.DatabaseManager
@@ -38,6 +39,12 @@ class AndroidSqliteDatabaseManager(context: Context) : DatabaseManager {
         mutex.withLock { dbCache.mapValues { it.value.snapshotStatistics() } }
 
     suspend fun resetAll() = mutex.withLock {
+        // TODO: this should reset all existing databases (including those not in dbCache).
         dbCache.forEach { (_, db) -> db.reset() }
+    }
+
+    override suspend fun getAllStorageKeys(): Set<StorageKey> {
+        // TODO: this should check all existing databases (including those not in dbCache).
+        return dbCache.flatMap { (_, db) -> db.getAllStorageKeys() }.toSet()
     }
 }

--- a/java/arcs/android/storage/database/DatabaseImpl.kt
+++ b/java/arcs/android/storage/database/DatabaseImpl.kt
@@ -721,6 +721,12 @@ class DatabaseImpl(
         }
     }
 
+    override suspend fun getAllStorageKeys(): Set<StorageKey> {
+        return readableDatabase
+            .rawQuery("SELECT storage_keys.storage_key FROM storage_keys", emptyArray())
+            .map { StorageKeyParser.parse(it.getString(0)) }.toSet()
+    }
+
     @VisibleForTesting
     suspend fun getSchemaTypeId(
         schema: Schema,

--- a/java/arcs/android/storage/service/IStorageServiceManager.aidl
+++ b/java/arcs/android/storage/service/IStorageServiceManager.aidl
@@ -24,5 +24,5 @@ interface IStorageServiceManager {
     void clearAll(IResultCallback resultCallback);
 
     /** Clear all arcs data created within the provided time window. */
-    void clearDataBetween(int clearingArea, long startTimeMillis, long endTimeMillis, IResultCallback resultCallback);
+    void clearDataBetween(long startTimeMillis, long endTimeMillis, IResultCallback resultCallback);
 }

--- a/java/arcs/android/storage/service/StorageServiceManager.kt
+++ b/java/arcs/android/storage/service/StorageServiceManager.kt
@@ -11,31 +11,41 @@
 
 package arcs.android.storage.service
 
+import arcs.core.storage.DriverFactory
 import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 
 /**
  * A [StorageServiceManager] is used by a client of the [StorageService] to manage
  * data stored within the [StorageService].
  */
 class StorageServiceManager(
-    /** [CoroutineContext] on which to build one specific to this [BindingContext]. */
-    parentCoroutineContext: CoroutineContext,
-    /** Sink to use for recording statistics about accessing data. */
-    private val bindingContextStatisticsSink: BindingContextStatisticsSink
+    /** [CoroutineContext] on which to build one specific to this [StorageServiceManager]. */
+    parentCoroutineContext: CoroutineContext
 ) : IStorageServiceManager.Stub() {
 
+    /** The local [CoroutineContext]. */
+    private val coroutineContext = parentCoroutineContext + CoroutineName("StorageServiceManager")
+
     override fun clearAll(resultCallback: IResultCallback) {
-        // TODO: implement.
+        CoroutineScope(coroutineContext).launch {
+            // TODO: clear data for all storage keys.
+            DriverFactory.getAllStorageKeys()
+        }
         resultCallback.onResult(null)
     }
 
     override fun clearDataBetween(
-        clearingArea: Int,
         startTimeMillis: Long,
         endTimeMillis: Long,
         resultCallback: IResultCallback
     ) {
-        // TODO: implement.
+        CoroutineScope(coroutineContext).launch {
+            // TODO: clear data for all storage keys.
+            DriverFactory.getAllStorageKeys()
+        }
         resultCallback.onResult(null)
     }
 }

--- a/java/arcs/core/storage/DriverFactory.kt
+++ b/java/arcs/core/storage/DriverFactory.kt
@@ -53,6 +53,11 @@ object DriverFactory {
 
     /** Reset the driver registration to an empty set. For use in tests only. */
     fun clearRegistrations() = providers.lazySet(setOf())
+
+    /** Return the set of all storage keys that each DriverProvider has seen. */
+    suspend fun getAllStorageKeys(): Set<StorageKey> {
+        return providers.value.flatMap { it.getAllStorageKeys() }.toSet()
+    }
 }
 
 /** Provider of information on the [Driver] and characteristics of the storage behind it. */
@@ -65,4 +70,7 @@ interface DriverProvider {
         storageKey: StorageKey,
         dataClass: KClass<Data>
     ): Driver<Data>
+
+    /** Returns all storage keys for which a driver has been created. */
+    suspend fun getAllStorageKeys(): Set<StorageKey>
 }

--- a/java/arcs/core/storage/database/Database.kt
+++ b/java/arcs/core/storage/database/Database.kt
@@ -46,6 +46,9 @@ interface Database {
     /** Removes everything associated with the given [storageKey] from the database. */
     suspend fun delete(storageKey: StorageKey, originatingClientId: Int? = null)
 
+    /** Returns all storage keys stored in this database. */
+    suspend fun getAllStorageKeys(): Set<StorageKey>
+
     /** Takes a snapshot of the current [DatabasePerformanceStatistics] for the database. */
     suspend fun snapshotStatistics(): DatabasePerformanceStatistics.Snapshot
 

--- a/java/arcs/core/storage/database/DatabaseManager.kt
+++ b/java/arcs/core/storage/database/DatabaseManager.kt
@@ -11,6 +11,8 @@
 
 package arcs.core.storage.database
 
+import arcs.core.storage.StorageKey
+
 /**
  * Defines an abstract factory capable of instantiating (or re-using, when necessary) a [Database].
  */
@@ -34,6 +36,9 @@ interface DatabaseManager {
      */
     suspend fun snapshotStatistics():
         Map<DatabaseIdentifier, DatabasePerformanceStatistics.Snapshot>
+
+    /* Returns the set of storage keys in all known databases. */
+    suspend fun getAllStorageKeys(): Set<StorageKey>
 }
 
 /** Identifier for an individual [Database] instance. */

--- a/java/arcs/core/storage/driver/Database.kt
+++ b/java/arcs/core/storage/driver/Database.kt
@@ -90,6 +90,10 @@ object DatabaseDriverProvider : DriverProvider {
         ).register()
     }
 
+    override suspend fun getAllStorageKeys(): Set<StorageKey> {
+        return manager.getAllStorageKeys()
+    }
+
     /**
      * Configures the [DatabaseDriverProvider] with the given [schemaLookup] and registers it
      * with the [DriverFactory].
@@ -178,7 +182,7 @@ class DatabaseDriver<Data : Any>(
         log.debug {
             """
                 registerReceiver($token) - calling receiver(
-                    $pendingReceiverData, 
+                    $pendingReceiverData,
                     $pendingReceiverVersion
                 )
             """.trimIndent()
@@ -191,7 +195,7 @@ class DatabaseDriver<Data : Any>(
         log.debug {
             """
                 send(
-                    $data, 
+                    $data,
                     $version
                 )
             """.trimIndent()
@@ -269,8 +273,8 @@ class DatabaseDriver<Data : Any>(
         log.debug {
             """
                 onDatabaseUpdate(
-                    $data, 
-                    version: $version, 
+                    $data,
+                    version: $version,
                     originatingClientId: $originatingClientId
                 )
             """.trimIndent()

--- a/java/arcs/core/storage/driver/RamDisk.kt
+++ b/java/arcs/core/storage/driver/RamDisk.kt
@@ -44,6 +44,8 @@ class RamDiskDriverProvider : DriverProvider {
         return VolatileDriver(storageKey, RamDisk.memory)
     }
 
+    override suspend fun getAllStorageKeys(): Set<StorageKey> = RamDisk.memory.keys()
+
     /*
      * These ensure that if/when RamDiskDriverProvider is placed in a set, or used as a key for a
      * map, it's only used once.

--- a/java/arcs/core/storage/driver/Volatile.kt
+++ b/java/arcs/core/storage/driver/Volatile.kt
@@ -43,6 +43,8 @@ data class VolatileDriverProvider(private val arcId: ArcId) : DriverProvider {
         ) { "This provider does not support storageKey: $storageKey" }
         return VolatileDriver(storageKey, arcMemory)
     }
+
+    override suspend fun getAllStorageKeys(): Set<StorageKey> = arcMemory.keys()
 }
 
 /** [Driver] implementation for an in-memory store of data. */
@@ -145,6 +147,8 @@ data class VolatileDriverProvider(private val arcId: ArcId) : DriverProvider {
     operator fun <Data : Any> get(key: StorageKey): VolatileEntry<Data>? = synchronized(lock) {
         entries[key] as VolatileEntry<Data>?
     }
+
+    fun keys(): Set<StorageKey> = synchronized(lock) { entries.keys }
 
     /**
      * Sets the value at the provided [key] to the given [VolatileEntry] and returns the old value,

--- a/java/arcs/jvm/storage/database/testutil/MockDatabaseManager.kt
+++ b/java/arcs/jvm/storage/database/testutil/MockDatabaseManager.kt
@@ -48,6 +48,10 @@ class MockDatabaseManager : DatabaseManager {
     override suspend fun snapshotStatistics():
         Map<DatabaseIdentifier, DatabasePerformanceStatistics.Snapshot> =
         mutex.withLock { cache.mapValues { it.value.snapshotStatistics() } }
+
+    override suspend fun getAllStorageKeys(): Set<StorageKey> {
+        return cache.flatMap { (_, db) -> db.getAllStorageKeys() }.toSet()
+    }
 }
 
 @Suppress("EXPERIMENTAL_API_USAGE")
@@ -109,6 +113,8 @@ open class MockDatabase : Database {
                 .launchIn(CoroutineScope(coroutineContext))
             Unit
         }
+
+    override suspend fun getAllStorageKeys() = data.keys
 
     override suspend fun snapshotStatistics() = stats.snapshot()
 

--- a/java/arcs/sdk/android/storage/service/StorageService.kt
+++ b/java/arcs/sdk/android/storage/service/StorageService.kt
@@ -79,7 +79,7 @@ class StorageService : ResurrectorService() {
         log.debug { "onBind: $intent" }
 
         if (intent.action == MANAGER_ACTION) {
-            return StorageServiceManager(coroutineContext, stats)
+            return StorageServiceManager(coroutineContext)
         }
 
         val parcelableOptions = requireNotNull(

--- a/javatests/arcs/android/storage/database/DatabaseImplTest.kt
+++ b/javatests/arcs/android/storage/database/DatabaseImplTest.kt
@@ -1106,6 +1106,20 @@ class DatabaseImplTest {
     }
 
     @Test
+    fun getAllStorageKeys_returnsAllKeys() = runBlockingTest {
+      val entityKey = DummyStorageKey("entity")
+      val entity = DatabaseData.Entity(
+          rawEntity = RawEntity("entity", singletons = emptyMap(), collections = emptyMap()),
+          schema = newSchema("hash"),
+          databaseVersion = 1,
+          versionMap = VERSION_MAP
+      )
+      database.insertOrUpdateEntity(entityKey, entity)
+
+      assertThat(database.getAllStorageKeys()).containsExactly(entityKey)
+    }
+
+    @Test
     fun delete_entity_getsRemoved() = runBlockingTest {
         val entityKey = DummyStorageKey("entity")
         val schema = newSchema("hash")

--- a/javatests/arcs/android/storage/database/DatabaseImplTest.kt
+++ b/javatests/arcs/android/storage/database/DatabaseImplTest.kt
@@ -1107,16 +1107,16 @@ class DatabaseImplTest {
 
     @Test
     fun getAllStorageKeys_returnsAllKeys() = runBlockingTest {
-      val entityKey = DummyStorageKey("entity")
-      val entity = DatabaseData.Entity(
-          rawEntity = RawEntity("entity", singletons = emptyMap(), collections = emptyMap()),
-          schema = newSchema("hash"),
-          databaseVersion = 1,
-          versionMap = VERSION_MAP
-      )
-      database.insertOrUpdateEntity(entityKey, entity)
+        val entityKey = DummyStorageKey("entity")
+        val entity = DatabaseData.Entity(
+            rawEntity = RawEntity("entity", singletons = emptyMap(), collections = emptyMap()),
+            schema = newSchema("hash"),
+            databaseVersion = 1,
+            versionMap = VERSION_MAP
+        )
+        database.insertOrUpdateEntity(entityKey, entity)
 
-      assertThat(database.getAllStorageKeys()).containsExactly(entityKey)
+        assertThat(database.getAllStorageKeys()).containsExactly(entityKey)
     }
 
     @Test

--- a/javatests/arcs/android/storage/service/StorageServiceManagerTest.kt
+++ b/javatests/arcs/android/storage/service/StorageServiceManagerTest.kt
@@ -14,7 +14,6 @@ package arcs.android.storage.service
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import kotlin.coroutines.coroutineContext
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.runBlocking
@@ -24,19 +23,16 @@ import org.junit.runner.RunWith
 /** Tests for [StorageServiceManager]. */
 @RunWith(AndroidJUnit4::class)
 class StorageServiceManagerTest {
-    private suspend fun buildContext() = StorageServiceManager(
-        coroutineContext,
-        BindingContextStatsImpl()
-    )
+    private suspend fun buildManager() = StorageServiceManager(coroutineContext)
 
     @Test
-    fun sendProxyMessage_propagatesToTheStore() = runBlocking {
-        val bindingContext = buildContext()
+    fun clearAll_clearsAllData() = runBlocking {
+        val manager = buildManager()
         val deferredResult = DeferredResult(coroutineContext)
-        bindingContext.clearAll(deferredResult)
+        manager.clearAll(deferredResult)
 
         assertThat(deferredResult.await()).isTrue()
-
+        // TODO: verify all data is cleared.
         coroutineContext[Job.Key]?.cancelChildren()
         Unit
     }

--- a/javatests/arcs/core/storage/ReferenceModeStoreTest.kt
+++ b/javatests/arcs/core/storage/ReferenceModeStoreTest.kt
@@ -696,6 +696,8 @@ class ReferenceModeStoreTest {
             storageKey: StorageKey,
             dataClass: KClass<Data>
         ): Driver<Data> = MockDriver(storageKey)
+
+        override suspend fun getAllStorageKeys(): Set<StorageKey> = setOf()
     }
 
     private class MockDriver<T : Any>(

--- a/javatests/arcs/core/storage/driver/RamDiskDriverProviderTest.kt
+++ b/javatests/arcs/core/storage/driver/RamDiskDriverProviderTest.kt
@@ -110,4 +110,15 @@ class RamDiskDriverProviderTest {
         assertThat(driver3Value).isEqualTo(42)
         assertThat(driver3Version).isEqualTo(1)
     }
+
+    @Test
+    fun getAllStorageKeys_retunsAllStorageKeys() = runBlocking<Unit> {
+        val provider = RamDiskDriverProvider()
+        val storageKey1 = RamDiskStorageKey("foo")
+        val storageKey2 = RamDiskStorageKey("foo2")
+        provider.getDriver(storageKey1, Int::class)
+        provider.getDriver(storageKey2, Int::class)
+
+        assertThat(provider.getAllStorageKeys()).containsExactly(storageKey1, storageKey2)
+    }
 }

--- a/javatests/arcs/core/storage/driver/VolatileDriverProviderTest.kt
+++ b/javatests/arcs/core/storage/driver/VolatileDriverProviderTest.kt
@@ -82,4 +82,14 @@ class VolatileDriverProviderTest {
         assertThat(driver).isNotNull()
         assertThat(driver.storageKey).isEqualTo(VolatileStorageKey(arcIdFoo, "myfoo"))
     }
+
+    @Test
+    fun getAllStorageKeys_retunsAllStorageKeys() = runBlocking<Unit> {
+        val storageKey1 = VolatileStorageKey(arcIdFoo, "myfoo")
+        val storageKey2 = VolatileStorageKey(arcIdFoo, "myfoo2")
+        fooProvider.getDriver(storageKey1, Int::class)
+        fooProvider.getDriver(storageKey2, Int::class)
+
+        assertThat(fooProvider.getAllStorageKeys()).containsExactly(storageKey1, storageKey2)
+    }
 }

--- a/javatests/arcs/core/storage/driver/VolatileMemoryTest.kt
+++ b/javatests/arcs/core/storage/driver/VolatileMemoryTest.kt
@@ -57,4 +57,13 @@ class VolatileMemoryTest {
         val value: VolatileEntry<Int>? = memory[bar]
         assertThat(value).isEqualTo(expectedValue)
     }
+
+    @Test
+    fun keys_returnsAllKeys() {
+        val memory = VolatileMemory()
+        memory[bar] = VolatileEntry(data = 42)
+        memory[baz] = VolatileEntry(data = 41)
+
+        assertThat(memory.keys()).containsExactly(bar, baz)
+    }
 }


### PR DESCRIPTION
…ge keys for which we have ever created a driver. This can be used to create handles to delete everything (or delete expired entities). Note: to create handles we also need to know the type, this should be passed along these storage keys.