### PR TITLE
recipe2plan: Updating Macros, improvements to generation

### DIFF
--- a/java/arcs/core/data/testdata/BUILD
+++ b/java/arcs/core/data/testdata/BUILD
@@ -1,6 +1,7 @@
 load(
     "//third_party/java/arcs/build_defs:build_defs.bzl",
     "arcs_kt_plan",
+    "arcs_kt_schema",
     "arcs_manifest_proto",
 )
 
@@ -21,8 +22,14 @@ arcs_manifest_proto(
     visibility = ["//visibility:public"],
 )
 
+arcs_kt_schema(
+    name = "example_schema",
+    srcs = ["WriterReaderExample.arcs"],
+)
+
 arcs_kt_plan(
     name = "example_plan",
     src = "WriterReaderExample.arcs",
     visibility = ["//visibility:public"],
+    deps = [":example_schema"],
 )

--- a/java/arcs/core/data/testdata/BUILD
+++ b/java/arcs/core/data/testdata/BUILD
@@ -29,7 +29,7 @@ arcs_kt_schema(
 
 arcs_kt_plan(
     name = "example_plan",
-    src = "WriterReaderExample.arcs",
+    srcs = ["WriterReaderExample.arcs"],
     visibility = ["//visibility:public"],
     deps = [":example_schema"],
 )

--- a/src/tools/plan-generator.ts
+++ b/src/tools/plan-generator.ts
@@ -117,12 +117,12 @@ export class PlanGenerator {
       return ktUtils.applyFun('StorageKeyParser.parse', [quote(handle.storageKey.toString())]);
     }
     if (handle.fate === 'create') {
-      return ktUtils.applyFun('CreateableStorageKey', [quote(handle.id || this.createHandleName())]);
+      return ktUtils.applyFun('CreateableStorageKey', [quote(handle.id || this.createRandomHandleId())]);
     }
     throw new PlanGeneratorError(`Problematic handle '${handle.id}': Only 'create' Handles can have null 'StorageKey's.`);
   }
 
-  createHandleName(): string {
+  createRandomHandleId(): string {
     const rand = Math.floor(Random.next() * Math.pow(2, 50));
     return `handle/${rand}`;
   }

--- a/src/tools/plan-generator.ts
+++ b/src/tools/plan-generator.ts
@@ -16,8 +16,6 @@ import {Direction} from '../runtime/manifest-ast-nodes.js';
 import {Handle} from '../runtime/recipe/handle.js';
 import {Ttl, TtlUnits} from '../runtime/recipe/ttl.js';
 import {Dictionary} from '../runtime/hot.js';
-import {digest} from '../platform/digest-web.js';
-import {IdGenerator} from '../runtime/id.js';
 import {Random} from '../runtime/random.js';
 
 const ktUtils = new KotlinGenerationUtils();

--- a/src/tools/recipe2plan-cli.ts
+++ b/src/tools/recipe2plan-cli.ts
@@ -41,8 +41,6 @@ if (!opts.outfile) {
   process.exit(1);
 }
 
-
-// TODO(alxr): Support generation from multiple manifests
 if (opts._.length > 1) {
   console.error(`Only a single manifest is allowed`);
   process.exit(1);

--- a/src/tools/recipe2plan.ts
+++ b/src/tools/recipe2plan.ts
@@ -18,7 +18,6 @@ import {assert} from '../platform/assert-node.js';
  * Generates Kotlin Plans from recipes in an arcs manifest.
  *
  * @param path path/to/manifest.arcs
- * @param scope kotlin package name
  * @return Generated Kotlin code.
  */
 export async function recipe2plan(path: string): Promise<string> {

--- a/src/tools/storage-key-recipe-resolver.ts
+++ b/src/tools/storage-key-recipe-resolver.ts
@@ -38,7 +38,7 @@ export class StorageKeyRecipeResolver {
    * Produces resolved recipes with storage keys.
    *
    * @throws Error if recipe fails to resolve on first or second pass.
-   * @returns Resolved Recipes (with Storage Keys).
+   * @returns Resolved recipes (with Storage Keys).
    */
   async resolve(): Promise<Recipe[]> {
     const recipes = [];

--- a/src/tools/storage-key-recipe-resolver.ts
+++ b/src/tools/storage-key-recipe-resolver.ts
@@ -127,6 +127,10 @@ export class StorageKeyRecipeResolver {
    */
   validateHandles(recipe: Recipe) {
     recipe.handles
+      .filter(h => h.fate === 'create' && !h.capabilities.isTiedToArc && !h.id)
+      .forEach(h => console.warn(`Create handle '${h.localName}' should have an id.`));
+
+    recipe.handles
       .filter(h => h.fate === 'map' || h.fate === 'copy')
       .forEach(handle => {
         const matches = this.runtime.context.findHandlesById(handle.id)

--- a/src/tools/storage-key-recipe-resolver.ts
+++ b/src/tools/storage-key-recipe-resolver.ts
@@ -38,7 +38,7 @@ export class StorageKeyRecipeResolver {
    * Produces resolved recipes with storage keys.
    *
    * @throws Error if recipe fails to resolve on first or second pass.
-   * @yields Resolved recipes with storage keys
+   * @returns Resolved Recipe (with Storage Keys).
    */
   async resolve(): Promise<Recipe[]> {
     const recipes = [];

--- a/src/tools/storage-key-recipe-resolver.ts
+++ b/src/tools/storage-key-recipe-resolver.ts
@@ -38,7 +38,7 @@ export class StorageKeyRecipeResolver {
    * Produces resolved recipes with storage keys.
    *
    * @throws Error if recipe fails to resolve on first or second pass.
-   * @returns Resolved Recipe (with Storage Keys).
+   * @returns Resolved Recipes (with Storage Keys).
    */
   async resolve(): Promise<Recipe[]> {
     const recipes = [];
@@ -126,10 +126,6 @@ export class StorageKeyRecipeResolver {
    * @param recipe long-running or ephemeral recipe
    */
   validateHandles(recipe: Recipe) {
-    recipe.handles
-      .filter(h => h.fate === 'create' && !h.capabilities.isTiedToArc && !h.id)
-      .forEach(h => console.warn(`Create handle '${h.localName}' should have an id.`));
-
     recipe.handles
       .filter(h => h.fate === 'map' || h.fate === 'copy')
       .forEach(handle => {

--- a/src/tools/tests/plan-generator-tests.ts
+++ b/src/tools/tests/plan-generator-tests.ts
@@ -123,7 +123,7 @@ describe('recipe2plan', () => {
       }
     });
     it('creates a stable create handle name from resolved recipes when the id is missing', async () => {
-      const manifest = await Manifest.parse(`\ 
+      const manifest = await Manifest.parse(`\
      particle A
        data: writes Thing {num: Number}
        

--- a/src/tools/tests/plan-generator-tests.ts
+++ b/src/tools/tests/plan-generator-tests.ts
@@ -12,6 +12,7 @@ import {PlanGenerator} from '../plan-generator.js';
 import {assert} from '../../platform/chai-node.js';
 import {Manifest} from '../../runtime/manifest.js';
 import {Ttl, TtlUnits} from '../../runtime/recipe/ttl.js';
+import {StorageKeyRecipeResolver} from '../storage-key-recipe-resolver.js';
 
 describe('recipe2plan', () => {
   describe('plan-generator', () => {
@@ -93,6 +94,64 @@ describe('recipe2plan', () => {
       const ttl = new Ttl(30, TtlUnits.Day);
       const actual = emptyGenerator.createTtl(ttl);
       assert.deepStrictEqual(actual, 'Ttl.Days(30)');
+    });
+    it('creates a stable create handle name when the id is missing', async () => {
+      const manifest = await Manifest.parse(`\
+     particle A
+       data: writes Thing {num: Number}
+       
+     recipe R
+       h0: create persistent 
+       h1: create persistent #test
+       h2: create persistent #test2
+       h3: create persistent #test
+       A
+         data: writes h0
+       A
+         data: writes h1
+       A
+         data: writes h2
+       A
+         data: writes h3`);
+      const actuals: string[] = [];
+      for (const handle of manifest.recipes[0].handles) {
+        const newActual = await emptyGenerator.createStorageKey(handle);
+        assert.match(newActual, /CreateableStorageKey\("handle\/[\w\d]+"\)/); for (const existing of actuals) {
+          assert.notDeepEqual(existing, newActual);
+        }
+        actuals.push(newActual);
+      }
+    });
+    it('creates a stable create handle name from resolved recipes when the id is missing', async () => {
+      const manifest = await Manifest.parse(`\ 
+     particle A
+       data: writes Thing {num: Number}
+       
+     recipe R
+       h0: create persistent 
+       h1: create persistent #test
+       h2: create persistent #test2
+       h3: create persistent #test
+       A
+         data: writes h0
+       A
+         data: writes h1
+       A
+         data: writes h2
+       A
+         data: writes h3`);
+      const recipeResolver = new StorageKeyRecipeResolver(manifest);
+      const recipes = await recipeResolver.resolve();
+      const generator = new PlanGenerator(recipes, '');
+      const actuals: string[] = [];
+      for (const handle of recipes[0].handles) {
+        const newActual = await generator.createStorageKey(handle);
+        assert.match(newActual, /CreateableStorageKey\("handle\/[\w\d]+"\)/);
+        for (const existing of actuals) {
+          assert.notDeepEqual(existing, newActual);
+        }
+        actuals.push(newActual);
+      }
     });
   });
 });

--- a/third_party/java/arcs/build_defs/internal/kotlin.bzl
+++ b/third_party/java/arcs/build_defs/internal/kotlin.bzl
@@ -334,15 +334,22 @@ def arcs_kt_plan(name, src, deps = [], out = None, visibility = None):
       out: the name of the output artifact (a Kotlin file).
       visibility: list of visibilities
     """
-    outs = [out] if out != None else [replace_arcs_suffix(src, ".kt")]
+    outs = [out] if out != None else [replace_arcs_suffix(src, "_GeneratedPlan.kt")]
 
     sigh_command(
-        name = name,
+        name = name + "_GeneratedPlan",
         srcs = [src],
         outs = outs,
         deps = deps,
         progress_message = "Generating Plans",
         sigh_cmd = "recipe2plan --outdir $(dirname {OUT}) --outfile $(basename {OUT}) {SRC}",
+    )
+
+    arcs_kt_library(
+        name = name,
+        srcs = outs,
+        platforms = ["jvm"],
+        deps = ARCS_SDK_DEPS + deps,
     )
 
 def arcs_kt_jvm_test_suite(name, package, srcs = None, tags = [], deps = [], data = []):

--- a/third_party/java/arcs/build_defs/internal/kotlin.bzl
+++ b/third_party/java/arcs/build_defs/internal/kotlin.bzl
@@ -324,26 +324,29 @@ def arcs_kt_android_test_suite(name, manifest, package, srcs = None, tags = [], 
             data = data,
         )
 
-def arcs_kt_plan(name, src, deps = [], out = None, visibility = None):
+def arcs_kt_plan(name, srcs = [], deps = [], visibility = None):
     """Converts recipes in manifests into Kotlin Plans.
 
     Args:
       name: the name of the target to create
-      src: an Arcs manifest file
+      srcs: list of Arcs manifest files
       deps: list of dependencies (other manifests)
-      out: the name of the output artifact (a Kotlin file).
       visibility: list of visibilities
     """
-    outs = [out] if out != None else [replace_arcs_suffix(src, "_GeneratedPlan.kt")]
+    outs = []
 
-    sigh_command(
-        name = name + "_GeneratedPlan",
-        srcs = [src],
-        outs = outs,
-        deps = deps,
-        progress_message = "Generating Plans",
-        sigh_cmd = "recipe2plan --outdir $(dirname {OUT}) --outfile $(basename {OUT}) {SRC}",
-    )
+    for src in srcs:
+        genrule_name = replace_arcs_suffix(src, "_GeneratedPlan")
+        out = replace_arcs_suffix(src, "_GeneratedPlan.kt")
+        outs.append(out)
+        sigh_command(
+            name = genrule_name,
+            srcs = [src],
+            outs = [out],
+            deps = deps,
+            progress_message = "Generating Kotlin Plans",
+            sigh_cmd = "recipe2plan --outdir $(dirname {OUT}) --outfile $(basename {OUT}) {SRC}",
+        )
 
     arcs_kt_library(
         name = name,


### PR DESCRIPTION
## Summary
- Modified `arcs_kt_plan` rule to accept multiple srcs and to produce Jars (via arcs_kt_library)
- Fixed a few small issues with generation:
  - Updating how we find locations
  - Creating random `CreateableStorageKey` name when no handle id is present. 
- Increased test coverage. 