### PR TITLE
Refactors EntityHandleManager

### DIFF
--- a/java/arcs/android/storage/handle/AndroidHandleManager.kt
+++ b/java/arcs/android/storage/handle/AndroidHandleManager.kt
@@ -33,7 +33,7 @@ import kotlin.coroutines.EmptyCoroutineContext
 typealias SingletonServiceStoreFactory<T> =
     ServiceStoreFactory<SingletonData<T>, SingletonOp<T>, T?>
 @UseExperimental(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
-typealias SetServiceStoreFactory<T> =
+typealias CollectionServiceStoreFactory<T> =
     ServiceStoreFactory<CollectionData<T>, CollectionOp<T>, Set<T>>
 @UseExperimental(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
 typealias EntityServiceStoreFactory =
@@ -81,7 +81,7 @@ fun AndroidHandleManager(
          * Create a ActivationFactory that will create [ServiceStore] instances that can manage
          * sets of [RawEntities]
          */
-        override fun <T : Referencable> setFactory() = SetServiceStoreFactory<T>(
+        override fun <T : Referencable> setFactory() = CollectionServiceStoreFactory<T>(
             context,
             lifecycle,
             ParcelableCrdtType.Set,

--- a/java/arcs/core/data/HandleMode.kt
+++ b/java/arcs/core/data/HandleMode.kt
@@ -19,5 +19,13 @@ enum class HandleMode {
     /** [Handle] is write only. */
     Write,
     /** [Handle] is read-write. */
-    ReadWrite
+    ReadWrite;
+
+    /** True if reading is supported by this mode. */
+    val canRead: Boolean
+        get() = this != Write
+
+    /** True if writing is supported by this mode. */
+    val canWrite: Boolean
+        get() = this != Read
 }

--- a/java/arcs/core/host/AbstractArcHost.kt
+++ b/java/arcs/core/host/AbstractArcHost.kt
@@ -378,7 +378,7 @@ abstract class AbstractArcHost(vararg initialParticles: ParticleRegistration) : 
     }
 
     /**
-     * Given a handle name, a [HandleConnection], and a [HandleHolder] construct an Entity
+     * Given a handle name, a [Plan.HandleConnection], and a [HandleHolder] construct an Entity
      * [Handle] of the right type.
      */
     private suspend fun createHandle(
@@ -388,19 +388,19 @@ abstract class AbstractArcHost(vararg initialParticles: ParticleRegistration) : 
     ) = when (handleSpec.type) {
         is SingletonType<*> ->
             entityHandleManager.createSingletonHandle(
-                holder.getEntitySpec(handleName),
+                handleSpec.mode,
                 handleName,
+                holder.getEntitySpec(handleName),
                 handleSpec.storageKey,
-                handleSpec.type.toSchema(),
-                handleSpec.mode
+                handleSpec.type.toSchema()
             )
         is CollectionType<*> ->
             entityHandleManager.createCollectionHandle(
-                holder.getEntitySpec(handleName),
+                handleSpec.mode,
                 handleName,
+                holder.getEntitySpec(handleName),
                 handleSpec.storageKey,
-                handleSpec.type.toSchema(),
-                handleSpec.mode
+                handleSpec.type.toSchema()
             )
         else -> throw IllegalArgumentException("Unknown type ${handleSpec.type}")
     }.also { holder.setHandle(handleName, it) }

--- a/java/arcs/core/host/EntityHandleManager.kt
+++ b/java/arcs/core/host/EntityHandleManager.kt
@@ -111,34 +111,34 @@ sealed class HandleAdapter(
     override val mode: HandleMode,
     override val name: String
 ) : Handle {
-    private val onSyncActions: MutableList<() -> Unit> = mutableListOf()
-    private val onDesyncActions: MutableList<() -> Unit> = mutableListOf()
+    private val onSyncActions: MutableList<(Handle) -> Unit> = mutableListOf()
+    private val onDesyncActions: MutableList<(Handle) -> Unit> = mutableListOf()
 
-    override fun onSync(action: () -> Unit) {
+    override fun onSync(action: (Handle) -> Unit) {
         onSyncActions.add(action)
     }
 
-    override fun onDesync(action: () -> Unit) {
+    override fun onDesync(action: (Handle) -> Unit) {
         onSyncActions.add(action)
     }
 
     protected fun fireSync() {
-        onSyncActions.forEach { it() }
+        onSyncActions.forEach { it(this) }
     }
 
     protected fun fireDesync() {
-        onDesyncActions.forEach { it() }
+        onDesyncActions.forEach { it(this) }
     }
 
     protected fun checkCanRead() {
         if (!mode.canRead) {
-            throw IllegalArgumentException("Handle does not support reads.")
+            throw IllegalArgumentException("Handle $name does not support reads.")
         }
     }
 
     protected fun checkCanWrite() {
         if (!mode.canWrite) {
-            throw IllegalArgumentException("Handle does not support writes.")
+            throw IllegalArgumentException("Handle $name does not support writes.")
         }
     }
 }

--- a/java/arcs/core/storage/Handle.kt
+++ b/java/arcs/core/storage/Handle.kt
@@ -46,6 +46,22 @@ interface Callbacks<Data : CrdtData, Op : CrdtOperationAtTime, T> {
 }
 
 /**
+ * Basic wrapper around [Callbacks] which lets you supply lambdas for each method instead of
+ * implementing the whole interface yourself.
+ */
+class LambdaCallbacks<Data : CrdtData, Op : CrdtOperationAtTime, T>(
+    private val onSync: () -> Unit,
+    private val onDesync: () -> Unit,
+    private val onUpdate: (() -> Unit)?
+) : Callbacks<Data, Op, T> {
+    override fun onSync(handle: Handle<Data, Op, T>) = onSync()
+
+    override fun onDesync(handle: Handle<Data, Op, T>) = onDesync()
+
+    override fun onUpdate(handle: Handle<Data, Op, T>, op: Op) { onUpdate?.let { it() } }
+}
+
+/**
  * Base implementation of Arcs handles on the runtime.
  *
  * A handle is in charge of translating SDK data operations into the appropriate CRDT operation,

--- a/java/arcs/core/storage/api/Handle.kt
+++ b/java/arcs/core/storage/api/Handle.kt
@@ -11,9 +11,20 @@
 
 package arcs.core.storage.api
 
+import arcs.core.data.HandleMode
+
 /** Base interface for all handle classes. */
 interface Handle {
     val name: String
+
+    /** Indicates whether this handle is read-only, write-only, or read-write. */
+    val mode: HandleMode
+
+    /** Assign a callback when the handle is synced. */
+    fun onSync(action: () -> Unit)
+
+    /** Assign a callback when the handle is desynced. */
+    fun onDesync(action: () -> Unit)
 }
 
 /** A singleton handle with read access. */
@@ -21,13 +32,7 @@ interface ReadSingletonHandle<T : Entity> : Handle {
     /** Returns the value of the singleton. */
     suspend fun fetch(): T?
 
-    suspend fun onUpdate(action: (T?) -> Unit)
-
-    /** Assign a callback when the handle is synced. */
-    suspend fun onSync(action: (ReadSingletonHandle<T>) -> Unit)
-
-    /** Assign a callback when the handle is sdeynced. */
-    suspend fun onDesync(action: (ReadSingletonHandle<T>) -> Unit)
+    fun onUpdate(action: (T?) -> Unit)
 }
 
 /** A singleton handle with write access. */
@@ -50,17 +55,11 @@ interface ReadCollectionHandle<T : Entity> : Handle {
     /** Returns true if the collection is empty. */
     suspend fun isEmpty(): Boolean
 
-    /** Assign a callback when the collection is Updated. */
-    suspend fun onUpdate(action: (Set<T>) -> Unit)
-
-    /** Assign a callback when the collection handle is synced. */
-    suspend fun onSync(action: (ReadCollectionHandle<T>) -> Unit)
-
-    /** Assign a callback when the collection handle is desynced. */
-    suspend fun onDesync(action: (ReadCollectionHandle<T>) -> Unit)
-
     /** Returns a set with all the entities in the collection. */
     suspend fun fetchAll(): Set<T>
+
+    /** Assign a callback when the collection is Updated. */
+    fun onUpdate(action: (Set<T>) -> Unit)
 }
 
 /** A collection handle with read access. */

--- a/java/arcs/core/storage/api/Handle.kt
+++ b/java/arcs/core/storage/api/Handle.kt
@@ -21,10 +21,10 @@ interface Handle {
     val mode: HandleMode
 
     /** Assign a callback when the handle is synced. */
-    fun onSync(action: () -> Unit)
+    fun onSync(action: (Handle) -> Unit)
 
     /** Assign a callback when the handle is desynced. */
-    fun onDesync(action: () -> Unit)
+    fun onDesync(action: (Handle) -> Unit)
 }
 
 /** A singleton handle with read access. */

--- a/javatests/arcs/android/host/AndroidEntityHandleManagerTest.kt
+++ b/javatests/arcs/android/host/AndroidEntityHandleManagerTest.kt
@@ -16,12 +16,7 @@ import arcs.core.host.EntityHandleManager
 import arcs.core.data.HandleMode
 import arcs.core.storage.keys.RamDiskStorageKey
 import arcs.core.storage.referencemode.ReferenceModeStorageKey
-import arcs.core.testutil.assertSuspendingThrows
 import arcs.core.testutil.assertThrows
-import arcs.sdk.ReadCollectionHandle
-import arcs.sdk.ReadSingletonHandle
-import arcs.sdk.WriteCollectionHandle
-import arcs.sdk.WriteSingletonHandle
 import arcs.sdk.android.storage.service.testutil.TestConnectionFactory
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.launch
@@ -31,7 +26,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import kotlin.coroutines.experimental.suspendCoroutine
 
-typealias Person = TestParticleInternal1
+private typealias Person = TestParticleInternal1
 
 @Suppress("EXPERIMENTAL_API_USAGE", "UNCHECKED_CAST")
 @RunWith(AndroidJUnit4::class)
@@ -62,8 +57,8 @@ class AndroidEntityHandleManagerTest : LifecycleOwner {
         backingKey = RamDiskStorageKey("single-back"), storageKey = RamDiskStorageKey("single-ent")
     )
 
-    private val setKey = ReferenceModeStorageKey(
-        backingKey = RamDiskStorageKey("set-back"), storageKey = RamDiskStorageKey("set-ent")
+    private val collectionKey = ReferenceModeStorageKey(
+        backingKey = RamDiskStorageKey("collection-back"), storageKey = RamDiskStorageKey("collection-ent")
     )
 
     @Before
@@ -237,7 +232,7 @@ class AndroidEntityHandleManagerTest : LifecycleOwner {
         handleMode,
         handleName,
         handleHolder.getEntitySpec(handleName),
-        setKey,
+        collectionKey,
         schema
     ).also { handleHolder.setHandle(handleName, it) }
 }

--- a/javatests/arcs/android/host/AndroidEntityHandleManagerTest.kt
+++ b/javatests/arcs/android/host/AndroidEntityHandleManagerTest.kt
@@ -16,9 +16,8 @@ import arcs.core.host.EntityHandleManager
 import arcs.core.data.HandleMode
 import arcs.core.storage.keys.RamDiskStorageKey
 import arcs.core.storage.referencemode.ReferenceModeStorageKey
+import arcs.core.testutil.assertSuspendingThrows
 import arcs.core.testutil.assertThrows
-import arcs.sdk.ReadWriteCollectionHandle
-import arcs.sdk.ReadWriteSingletonHandle
 import arcs.sdk.ReadCollectionHandle
 import arcs.sdk.ReadSingletonHandle
 import arcs.sdk.WriteCollectionHandle
@@ -34,7 +33,7 @@ import kotlin.coroutines.experimental.suspendCoroutine
 
 typealias Person = TestParticleInternal1
 
-@Suppress("EXPERIMENTAL_API_USAGE")
+@Suppress("EXPERIMENTAL_API_USAGE", "UNCHECKED_CAST")
 @RunWith(AndroidJUnit4::class)
 class AndroidEntityHandleManagerTest : LifecycleOwner {
     private lateinit var app: Application
@@ -132,8 +131,7 @@ class AndroidEntityHandleManagerTest : LifecycleOwner {
             HandleMode.Write
         )
 
-        assertThat(writeHandle).isInstanceOf(WriteSingletonHandle::class.java)
-        assertThat(writeHandle).isNotInstanceOf(ReadSingletonHandle::class.java)
+        assertThat(writeHandle.mode).isEqualTo(HandleMode.Write)
         handleHolder.writeHandle.store(entity1)
 
         val readHandle = createSingletonHandle(
@@ -142,8 +140,7 @@ class AndroidEntityHandleManagerTest : LifecycleOwner {
             HandleMode.Read
         )
 
-        assertThat(readHandle).isInstanceOf(ReadSingletonHandle::class.java)
-        assertThat(readHandle).isNotInstanceOf(WriteSingletonHandle::class.java)
+        assertThat(readHandle.mode).isEqualTo(HandleMode.Read)
 
         val readBack = handleHolder.readHandle.fetch()
         assertThat(readBack).isEqualTo(entity1)
@@ -153,7 +150,7 @@ class AndroidEntityHandleManagerTest : LifecycleOwner {
             "readWriteHandle",
             HandleMode.ReadWrite
         )
-        assertThat(readWriteHandle).isInstanceOf(ReadWriteSingletonHandle::class.java)
+        assertThat(readWriteHandle.mode).isEqualTo(HandleMode.ReadWrite)
 
         val readBack2 = handleHolder.readWriteHandle.fetch()
         assertThat(readBack2).isEqualTo(entity1)
@@ -172,15 +169,14 @@ class AndroidEntityHandleManagerTest : LifecycleOwner {
     }
 
     @Test
-    fun setHandle_writeFollowedByReadWithOnUpdate() = runBlocking<Unit> {
+    fun collectionHandle_writeFollowedByReadWithOnUpdate() = runBlocking<Unit> {
         val writeCollectionHandle = createCollectionHandle(
             handleManager,
             "writeCollectionHandle",
             HandleMode.Write
         )
 
-        assertThat(writeCollectionHandle).isInstanceOf(WriteCollectionHandle::class.java)
-        assertThat(writeCollectionHandle).isNotInstanceOf(ReadCollectionHandle::class.java)
+        assertThat(writeCollectionHandle.mode).isEqualTo(HandleMode.Write)
 
         handleHolder.writeCollectionHandle.store(entity1)
         handleHolder.writeCollectionHandle.store(entity2)
@@ -191,8 +187,7 @@ class AndroidEntityHandleManagerTest : LifecycleOwner {
             HandleMode.Read
         )
 
-        assertThat(readCollectionHandle).isInstanceOf(ReadCollectionHandle::class.java)
-        assertThat(readCollectionHandle).isNotInstanceOf(WriteCollectionHandle::class.java)
+        assertThat(readCollectionHandle.mode).isEqualTo(HandleMode.Read)
 
         val readBack = handleHolder.readCollectionHandle.fetchAll()
         assertThat(readBack).containsExactly(entity1, entity2)
@@ -203,7 +198,7 @@ class AndroidEntityHandleManagerTest : LifecycleOwner {
             HandleMode.ReadWrite
         )
 
-        assertThat(readWriteCollectionHandle).isInstanceOf(ReadWriteCollectionHandle::class.java)
+        assertThat(readWriteCollectionHandle.mode).isEqualTo(HandleMode.ReadWrite)
 
         val readBack2 = handleHolder.readWriteCollectionHandle.fetchAll()
         assertThat(readBack2).containsExactly(entity1, entity2)
@@ -227,11 +222,11 @@ class AndroidEntityHandleManagerTest : LifecycleOwner {
         handleName: String,
         handleMode: HandleMode
     ) = handleManager.createSingletonHandle(
-        handleHolder.getEntitySpec(handleName),
+        handleMode,
         handleName,
+        handleHolder.getEntitySpec(handleName),
         singletonKey,
-        schema,
-        handleMode
+        schema
     ).also { handleHolder.setHandle(handleName, it) }
 
     private suspend fun createCollectionHandle(
@@ -239,10 +234,10 @@ class AndroidEntityHandleManagerTest : LifecycleOwner {
         handleName: String,
         handleMode: HandleMode
     ) = handleManager.createCollectionHandle(
-        handleHolder.getEntitySpec(handleName),
+        handleMode,
         handleName,
+        handleHolder.getEntitySpec(handleName),
         setKey,
-        schema,
-        handleMode
+        schema
     ).also { handleHolder.setHandle(handleName, it) }
 }

--- a/javatests/arcs/core/allocator/AllocatorTestBase.kt
+++ b/javatests/arcs/core/allocator/AllocatorTestBase.kt
@@ -291,17 +291,14 @@ open class AllocatorTestBase {
 
         writePersonContext.particle.let { particle ->
             particle as WritePerson
-            assertThat(particle.handles.person).isInstanceOf(WriteSingletonHandle::class.java)
-            assertThat(particle.handles.person).isNotInstanceOf(ReadSingletonHandle::class.java)
+            assertThat(particle.handles.person.mode).isEqualTo(HandleMode.Write)
             assertThat(particle.createCalled).isTrue()
             assertThat(particle.wrote).isTrue()
         }
 
-
         readPersonContext.particle.let { particle ->
             particle as ReadPerson
-            assertThat(particle.handles.person).isInstanceOf(ReadSingletonHandle::class.java)
-            assertThat(particle.handles.person).isNotInstanceOf(WriteSingletonHandle::class.java)
+            assertThat(particle.handles.person.mode).isEqualTo(HandleMode.Read)
             assertThat(particle.createCalled).isTrue()
             assertThat(particle.name).isEqualTo("John Wick")
         }

--- a/javatests/arcs/core/host/BUILD
+++ b/javatests/arcs/core/host/BUILD
@@ -15,9 +15,15 @@ arcs_kt_jvm_test_suite(
     package = "arcs.core.host",
     deps = [
         ":particle",  # buildcleaner: keep
+        ":schemas",
         "//java/arcs/core/host",
+        "//java/arcs/core/storage/driver",
+        "//java/arcs/core/storage/handle",
+        "//java/arcs/core/storage/keys",
+        "//java/arcs/core/storage/referencemode",
         "//java/arcs/core/testutil",
         "//java/arcs/jvm/host",
+        "//java/arcs/jvm/util/testutil",
         "//third_party/java/junit:junit-android",
         "//third_party/java/truth:truth-android",
         "//third_party/kotlin/kotlinx_coroutines",

--- a/javatests/arcs/core/host/BUILD
+++ b/javatests/arcs/core/host/BUILD
@@ -16,6 +16,7 @@ arcs_kt_jvm_test_suite(
     deps = [
         ":particle",  # buildcleaner: keep
         "//java/arcs/core/host",
+        "//java/arcs/core/testutil",
         "//java/arcs/jvm/host",
         "//third_party/java/junit:junit-android",
         "//third_party/java/truth:truth-android",

--- a/javatests/arcs/core/host/HandleAdapterTest.kt
+++ b/javatests/arcs/core/host/HandleAdapterTest.kt
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.core.host
+
+import arcs.core.storage.driver.RamDisk
+import arcs.core.storage.driver.RamDiskDriverProvider
+import arcs.core.storage.handle.HandleManager
+import arcs.core.storage.keys.RamDiskStorageKey
+import arcs.core.storage.referencemode.ReferenceModeStorageKey
+import arcs.core.testutil.assertSuspendingThrows
+import arcs.jvm.util.testutil.TimeImpl
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+private typealias Person = ReadPerson_Person
+
+@RunWith(JUnit4::class)
+@UseExperimental(ExperimentalCoroutinesApi::class)
+class HandleAdapterTest {
+    private lateinit var manager: EntityHandleManager
+
+    @Before
+    fun setUp() {
+        RamDiskDriverProvider()
+        manager = EntityHandleManager(HandleManager(TimeImpl()))
+    }
+
+    @After
+    fun tearDown() {
+        RamDisk.clear()
+    }
+
+    @Test
+    fun singletonHandleAdapter_readOnlyCantWrite() = runBlockingTest {
+        val readOnlyHandle = manager.createSingletonHandle(
+            HandleMode.Read,
+            READ_ONLY_HANDLE,
+            Person,
+            STORAGE_KEY,
+            Person.SCHEMA
+        )
+
+        checkThrowsWriteError { readOnlyHandle.clear() }
+        checkThrowsWriteError { readOnlyHandle.store(Person()) }
+    }
+
+    @Test
+    fun singletonHandleAdapter_writeOnlyCantRead() = runBlockingTest {
+        val writeOnlyHandle = manager.createSingletonHandle(
+            HandleMode.Write,
+            WRITE_ONLY_HANDLE,
+            Person,
+            STORAGE_KEY,
+            Person.SCHEMA
+        )
+
+        checkThrowsReadError { writeOnlyHandle.fetch() }
+        checkThrowsReadError { writeOnlyHandle.onUpdate { } }
+    }
+
+    @Test
+    fun collectionHandleAdapter_readOnlyCantWrite() = runBlockingTest {
+        val readOnlyHandle = manager.createCollectionHandle(
+            HandleMode.Read,
+            READ_ONLY_HANDLE,
+            Person,
+            STORAGE_KEY,
+            Person.SCHEMA
+        )
+
+        checkThrowsWriteError { readOnlyHandle.clear() }
+        checkThrowsWriteError { readOnlyHandle.store(Person()) }
+        checkThrowsWriteError { readOnlyHandle.remove(Person()) }
+    }
+
+    @Test
+    fun collectionHandleAdapter_writeOnlyCantRead() = runBlockingTest {
+        val writeOnlyHandle = manager.createCollectionHandle(
+            HandleMode.Write,
+            WRITE_ONLY_HANDLE,
+            Person,
+            STORAGE_KEY,
+            Person.SCHEMA
+        )
+
+        checkThrowsReadError { writeOnlyHandle.fetchAll() }
+        checkThrowsReadError { writeOnlyHandle.isEmpty() }
+        checkThrowsReadError { writeOnlyHandle.size() }
+        checkThrowsReadError { writeOnlyHandle.onUpdate { } }
+    }
+
+    private suspend fun checkThrowsReadError(action: suspend () -> Unit) {
+        val e = assertSuspendingThrows(IllegalArgumentException::class, action)
+        assertThat(e).hasMessageThat().isEqualTo(
+            "Handle $WRITE_ONLY_HANDLE does not support reads."
+        )
+    }
+
+    private suspend fun checkThrowsWriteError(action: suspend () -> Unit) {
+        val e = assertSuspendingThrows(IllegalArgumentException::class, action)
+        assertThat(e).hasMessageThat().isEqualTo(
+            "Handle $READ_ONLY_HANDLE does not support writes."
+        )
+    }
+
+    private companion object {
+        private const val READ_ONLY_HANDLE = "readOnlyHandle"
+        private const val WRITE_ONLY_HANDLE = "writeOnlyHandle"
+
+        private val STORAGE_KEY = ReferenceModeStorageKey(
+            backingKey = RamDiskStorageKey("backing"),
+            storageKey = RamDiskStorageKey("entity")
+        )
+    }
+}


### PR DESCRIPTION
Diffbase against #4917

This is a fairly big refactor. The whole point was to move onSync and onDesync to the base Handle interface, so that we can call Particle.onHandleSync at the right time more easily. I went deep down the rabbit hole...

The main changes are:
    * The adapter handles (in EntityHandleManager) have a simpler class hierarchy
    * Their callbacks are a bit more straight forward
    * Shared onSync and onDesync code has been hoisted to their common base class
    * There are now no longer separate class impls for read/write handles. I was sad to lose that, but there was no good way to combine the read and write methods happily in the one place. I think this version is easier to read though, and it's just as safe (you can't cast to the other read/write interface in order to bypass the checks, because we check the HandleMode before running any operations)

After this change, it should be really really easy to hook up the handle onUpdate methods to the particle onHandleUpdate method.