### PR TITLE
Simplify Handle callback management

### DIFF
--- a/java/arcs/core/storage/Handle.kt
+++ b/java/arcs/core/storage/Handle.kt
@@ -22,46 +22,6 @@ import arcs.core.util.TaggedLog
 import arcs.core.util.Time
 
 /**
- * The [Callbacks] interface is a simple stand-in for the callbacks that a [Handle] might want to
- * use to signal information back to a subscriber (like a handle).
- */
-interface Callbacks<Data : CrdtData, Op : CrdtOperationAtTime, T> {
-    /**
-     * [onUpdate] is called when a diff is received from storage, or from a handle. Handles can
-     * be notified for their own writes.
-     * This method is not called for every change! A model sync will call [onSync] instead.
-     * Do not depend on seeing every update via this callback.
-     */
-    fun onUpdate(handle: Handle<Data, Op, T>, op: Op) = Unit
-
-    /**
-     * [onSync] is called when the proxy is synced from its backing [Store].
-     */
-    fun onSync(handle: Handle<Data, Op, T>) = Unit
-
-    /**
-     * [onDesync] is called when the proxy realizes it is out of sync with its backing [Store].
-     */
-    fun onDesync(handle: Handle<Data, Op, T>) = Unit
-}
-
-/**
- * Basic wrapper around [Callbacks] which lets you supply lambdas for each method instead of
- * implementing the whole interface yourself.
- */
-class LambdaCallbacks<Data : CrdtData, Op : CrdtOperationAtTime, T>(
-    private val onSync: () -> Unit,
-    private val onDesync: () -> Unit,
-    private val onUpdate: (() -> Unit)?
-) : Callbacks<Data, Op, T> {
-    override fun onSync(handle: Handle<Data, Op, T>) = onSync()
-
-    override fun onDesync(handle: Handle<Data, Op, T>) = onDesync()
-
-    override fun onUpdate(handle: Handle<Data, Op, T>, op: Op) { onUpdate?.let { it() } }
-}
-
-/**
  * Base implementation of Arcs handles on the runtime.
  *
  * A handle is in charge of translating SDK data operations into the appropriate CRDT operation,
@@ -87,9 +47,6 @@ open class Handle<Data : CrdtData, Op : CrdtOperationAtTime, T>(
     /** [name] is the unique name for this handle, used to track state in the [VersionMap]. */
     val name: String,
     val storageProxy: StorageProxy<Data, Op, T>,
-
-    /** [callback] contains optional Handle-owner provided callbacks to add behavior. */
-    var callback: Callbacks<Data, Op, T>? = null,
 
     /** [ttl] applied to the data in the [Handle]. */
     val ttl: Ttl,
@@ -117,6 +74,25 @@ open class Handle<Data : CrdtData, Op : CrdtOperationAtTime, T>(
 ) {
     protected val log = TaggedLog { "Handle($name)" }
 
+    /** Add an action to be performed whenever the contents of the [Handle]'s data changes. */
+    suspend fun addOnUpdate(action: (value: T) -> Unit) {
+        storageProxy.addOnUpdate(name, action)
+    }
+
+    /** Add an action to be performed whenever the [Handle] becomes synchronized. */
+    suspend fun addOnSync(action: () -> Unit) { storageProxy.addOnSync(name, action) }
+
+    /** Add an action to be performed whenever the [Handle] becomes de-synchronized. */
+    suspend fun addOnDesync(action: () -> Unit) { storageProxy.addOnDesync(name, action) }
+
+    /**
+     * Remove any `onUpdate`, `onSync`, or `onDesync` callbacks that this [Handle] has registered
+     * with its [StorageProxy].
+     */
+    suspend fun removeAllCallbacks() {
+        storageProxy.removeCallbacksForName(name)
+    }
+
     /** Creates a [Reference] for a given [Referencable] and backing [StorageKey]. */
     fun createReference(referencable: Referencable, backingKey: StorageKey): Reference {
         return Reference(referencable.id, backingKey, null).also {
@@ -137,30 +113,6 @@ open class Handle<Data : CrdtData, Op : CrdtOperationAtTime, T>(
     protected fun VersionMap.increment(): VersionMap {
         this[name]++
         return this
-    }
-
-    /**
-     * This should be called by the [StorageProxy] this [Handle] has been registered with,
-     * after a model update has been cleanly applied to the [StorageProxy]'s local copy.
-     */
-    internal fun onUpdate(op: Op) {
-        callback?.onUpdate(this, op)
-    }
-
-    /**
-     * This should be called by the [StorageProxy] this [Handle] has been registered with,
-     * after a full sync has occurred.
-     */
-    internal fun onSync() {
-        callback?.onSync(this)
-    }
-
-    /**
-     * This should be called by the [StorageProxy] this [Handle] has been registered with,
-     * when the [StorageProxy] has detected that its local model is out of sync.
-     */
-    internal fun onDesync() {
-        callback?.onDesync(this)
     }
 
     /**

--- a/java/arcs/core/storage/StorageProxy.kt
+++ b/java/arcs/core/storage/StorageProxy.kt
@@ -39,10 +39,19 @@ class StorageProxy<Data : CrdtData, Op : CrdtOperationAtTime, T>(
 ) {
     private val log = TaggedLog { "StorageProxy" }
 
-    private val handlesMutex = Mutex()
-
-    private val readHandles: MutableSet<Handle<Data, Op, T>>
-        by guardedBy(handlesMutex, mutableSetOf())
+    private val callbackMutex = Mutex()
+    private val onUpdateActions by guardedBy(
+        callbackMutex,
+        mutableMapOf<String, MutableList<(T)->Unit>>()
+    )
+    private val onSyncActions by guardedBy(
+        callbackMutex,
+        mutableMapOf<String, MutableList<() -> Unit>>()
+    )
+    private val onDesyncActions by guardedBy(
+        callbackMutex,
+        mutableMapOf<String, MutableList<() -> Unit>>()
+    )
 
     private val syncMutex = Mutex()
     private val crdt: CrdtModel<Data, Op, T>
@@ -55,32 +64,68 @@ class StorageProxy<Data : CrdtData, Op : CrdtOperationAtTime, T>(
     private val store = storeEndpointProvider.getStorageEndpoint()
     private val storeListenerId = store.setCallback(ProxyCallback(::onMessage))
 
-    /**
-     * Connects a [Handle]. If the handle is readable, it will receive the configured callbacks.
-     */
-    suspend fun registerHandle(handle: Handle<Data, Op, T>) {
-        // non-readers don't get callbacks, return early
-        if (!handle.canRead) return
-
-        log.debug { "Registering handle: $handle" }
-
-        val firstReader = handlesMutex.withLock {
-            readHandles.add(handle)
-            readHandles.size == 1
+    /** Add a [Handle] `onUpdate` action, associated with a [Handle] name. */
+    suspend fun addOnUpdate(handleName: String, action: (value: T) -> Unit) {
+        callbackMutex.withLock {
+            onUpdateActions.getOrPut(handleName) { mutableListOf() }.add(action)
         }
-
-        val hasSynced = syncMutex.withLock { isSynchronized }
-
-        if (firstReader) requestSynchronization()
-        else if (hasSynced) coroutineScope { launch { handle.onSync() } }
     }
 
     /**
-     * Disconnects a handle so it no longer receives callbacks.
+     * Add a [Handle] `onSync` action, associated with a [Handle] name.
+     *
+     * If the handle is synchronized when the action is added, it will be called immediately.
+     * */
+    suspend fun addOnSync(handleName: String, action: () -> Unit) {
+        val runNow = syncMutex.withLock {
+            callbackMutex.withLock {
+                onSyncActions.getOrPut(handleName) { mutableListOf() }.add(action)
+            }
+            isSynchronized
+        }
+        if (runNow) {
+            coroutineScope {
+                launch {
+                    action
+                }
+            }
+        }
+    }
+
+    /**
+     * Add a [Handle] `onDesync` action, associated with a [Handle] name.
+     *
+     * If the handle is not synchronized when the action is added, it will be called immediately.
      */
-    suspend fun deregisterHandle(handle: Handle<Data, Op, T>) {
-        log.debug { "Unregistering handle: $handle" }
-        handlesMutex.withLock { readHandles.remove(handle) }
+    suspend fun addOnDesync(handleName: String, action: () -> Unit) {
+        val runNow = syncMutex.withLock {
+            callbackMutex.withLock {
+                onDesyncActions.getOrPut(handleName) { mutableListOf() }.add(action)
+            }
+            !isSynchronized
+        }
+        if (runNow) {
+            coroutineScope {
+                launch {
+                    action
+                }
+            }
+        }
+    }
+
+    /**
+     *  Remove all `onUpdate`, `onSync`, and `onDesync` callbacks associated with the provided
+     * `handleName`.
+     *
+     * A [Handle] that is being removed from active usage should make sure to trigger this method
+     * on its associated [StorageProxy].
+     */
+    suspend fun removeCallbacksForName(handleName: String) {
+        callbackMutex.withLock {
+            onUpdateActions.remove(handleName)
+            onSyncActions.remove(handleName)
+            onDesyncActions.remove(handleName)
+        }
     }
 
     /**
@@ -89,7 +134,9 @@ class StorageProxy<Data : CrdtData, Op : CrdtOperationAtTime, T>(
      */
     suspend fun applyOp(op: Op): Boolean {
         log.debug { "Applying operation: $op" }
-        val localSuccess = syncMutex.withLock { crdt.applyOperation(op) }
+        val (localSuccess, value) = syncMutex.withLock {
+            crdt.applyOperation(op) to crdt.consumerView
+        }
         if (!localSuccess) return false
 
         val msg = ProxyMessage.Operations<Data, Op, T>(listOf(op), null)
@@ -101,7 +148,7 @@ class StorageProxy<Data : CrdtData, Op : CrdtOperationAtTime, T>(
             requestSynchronization()
         }
 
-        notifyUpdate(listOf(op))
+        notifyUpdate(value)
 
         return true
     }
@@ -185,7 +232,7 @@ class StorageProxy<Data : CrdtData, Op : CrdtOperationAtTime, T>(
 
                 // Notify our handles of an update if these operations came from elsewhere.
                 if (message.id != storeListenerId) {
-                    notifyUpdate(message.operations)
+                    notifyUpdate(value)
                 }
             }
             is ProxyMessage.SyncRequest -> {
@@ -199,28 +246,23 @@ class StorageProxy<Data : CrdtData, Op : CrdtOperationAtTime, T>(
         return true
     }
 
-    private suspend fun notifyUpdate(ops: List<Op>) = forEachHandle { handle ->
-        ops.forEach {
-            handle.onUpdate(it)
-        }
-    }
-
-    private suspend fun notifySync() = forEachHandle {
-        it.onSync()
-    }
-
-    private suspend fun notifyDesync() = forEachHandle { it.onDesync() }
-
-    private suspend inline fun forEachHandle(crossinline block: (Handle<Data, Op, T>) -> Unit) {
-        val handlesToNotify = handlesMutex.withLock { readHandles.toSet() }
-
-        // suspends until all handles have completed (in parallel)
+    /** Safely make a copy of the specified action set, and launch each action on a coroutine */
+    private suspend fun <FT : Function<Unit>> applyCallbacks(
+        actions: () -> Map<String, List<FT>>,
+        block: (FT) -> Unit
+    ) = callbackMutex.withLock {
         coroutineScope {
-            handlesToNotify.forEach { handle ->
-                launch { block(handle) }
+            actions().values.flatten().forEach { action ->
+                launch {
+                    block(action)
+                }
             }
         }
     }
+
+    private suspend fun notifyUpdate(data: T) = applyCallbacks(::onUpdateActions) { it(data) }
+    private suspend fun notifySync() = applyCallbacks(::onSyncActions) { it() }
+    private suspend fun notifyDesync() = applyCallbacks(::onDesyncActions) { it() }
 
     private suspend fun requestSynchronization(): Boolean {
         val msg = ProxyMessage.SyncRequest<Data, Op, T>(null)

--- a/java/arcs/core/storage/api/Handle.kt
+++ b/java/arcs/core/storage/api/Handle.kt
@@ -21,10 +21,10 @@ interface Handle {
     val mode: HandleMode
 
     /** Assign a callback when the handle is synced. */
-    fun onSync(action: (Handle) -> Unit)
+    suspend fun onSync(action: () -> Unit)
 
     /** Assign a callback when the handle is desynced. */
-    fun onDesync(action: (Handle) -> Unit)
+    suspend fun onDesync(action: () -> Unit)
 }
 
 /** A singleton handle with read access. */
@@ -32,7 +32,7 @@ interface ReadSingletonHandle<T : Entity> : Handle {
     /** Returns the value of the singleton. */
     suspend fun fetch(): T?
 
-    fun onUpdate(action: (T?) -> Unit)
+    suspend fun onUpdate(action: (T?) -> Unit)
 }
 
 /** A singleton handle with write access. */
@@ -59,7 +59,7 @@ interface ReadCollectionHandle<T : Entity> : Handle {
     suspend fun fetchAll(): Set<T>
 
     /** Assign a callback when the collection is Updated. */
-    fun onUpdate(action: (Set<T>) -> Unit)
+    suspend fun onUpdate(action: (Set<T>) -> Unit)
 }
 
 /** A collection handle with read access. */

--- a/java/arcs/core/storage/handle/CollectionHandle.kt
+++ b/java/arcs/core/storage/handle/CollectionHandle.kt
@@ -17,7 +17,6 @@ import arcs.core.data.RawEntity
 import arcs.core.data.Schema
 import arcs.core.data.Ttl
 import arcs.core.storage.ActivationFactory
-import arcs.core.storage.Callbacks
 import arcs.core.storage.Dereferencer
 import arcs.core.storage.Handle
 import arcs.core.storage.StorageProxy
@@ -32,7 +31,6 @@ typealias CollectionActivationFactory<T> =
     ActivationFactory<CollectionData<T>, CollectionOp<T>, Set<T>>
 typealias CollectionProxy<T> = StorageProxy<CrdtSet.Data<T>, CrdtSet.IOperation<T>, Set<T>>
 typealias CollectionBase<T> = Handle<CrdtSet.Data<T>, CrdtSet.IOperation<T>, Set<T>>
-typealias CollectionCallbacks<T> = Callbacks<CollectionData<T>, CollectionOp<T>, Set<T>>
 
 /**
  * Collection Handle implementation for the runtime.
@@ -43,7 +41,6 @@ typealias CollectionCallbacks<T> = Callbacks<CollectionData<T>, CollectionOp<T>,
 class CollectionHandle<T : Referencable>(
     name: String,
     storageProxy: CollectionProxy<T>,
-    callbacks: CollectionCallbacks<T>? = null,
     ttl: Ttl = Ttl.Infinite,
     time: Time,
     canRead: Boolean = true,
@@ -52,7 +49,6 @@ class CollectionHandle<T : Referencable>(
 ) : CollectionBase<T>(
     name,
     storageProxy,
-    callbacks,
     ttl,
     time,
     canRead,

--- a/java/arcs/core/storage/handle/HandleManager.kt
+++ b/java/arcs/core/storage/handle/HandleManager.kt
@@ -89,7 +89,6 @@ class HandleManager(
     suspend fun rawEntitySingletonHandle(
         storageKey: StorageKey,
         schema: Schema,
-        callbacks: SingletonCallbacks<RawEntity>? = null,
         name: String = storageKey.toKeyString(),
         ttl: Ttl = Ttl.Infinite,
         canRead: Boolean = true
@@ -112,39 +111,13 @@ class HandleManager(
         return SingletonHandle(
             name,
             storageProxy,
-            callbacks,
             ttl,
             time,
             canRead,
             dereferencer = RawEntityDereferencer(schema, aff?.dereferenceFactory()),
             schema = schema
-        ).also { storageProxy.registerHandle(it) }
+        )
     }
-
-    /**
-     * @deprecated use [rawEntitySingletonHandle] instead.
-     */
-    /* ktlint-disable max-line-length */
-    @Deprecated(
-        "Use rawEntitySingletonHandle instead",
-        replaceWith = ReplaceWith("this.rawEntitySingletonHandle(storageKey, schema, callbacks, name, ttl, canRead)")
-    )
-    /* ktlint-enable max-line-length */
-    suspend fun singletonHandle(
-        storageKey: StorageKey,
-        schema: Schema,
-        callbacks: SingletonCallbacks<RawEntity>? = null,
-        name: String = storageKey.toKeyString(),
-        ttl: Ttl = Ttl.Infinite,
-        canRead: Boolean = true
-    ): SingletonHandle<RawEntity> = rawEntitySingletonHandle(
-        storageKey,
-        schema,
-        callbacks,
-        name,
-        ttl,
-        canRead
-    )
 
     /**
      * Creates a new [SingletonHandle] which manages a singleton of type: [Reference], where the
@@ -153,7 +126,6 @@ class HandleManager(
     suspend fun referenceSingletonHandle(
         storageKey: StorageKey,
         schema: Schema,
-        callbacks: SingletonCallbacks<Reference>? = null,
         name: String = storageKey.toKeyString(),
         ttl: Ttl = Ttl.Infinite,
         canRead: Boolean = true
@@ -176,13 +148,12 @@ class HandleManager(
         return SingletonHandle(
             name,
             storageProxy,
-            callbacks,
             ttl,
             time,
             canRead,
             dereferencer = RawEntityDereferencer(schema, aff?.dereferenceFactory()),
             schema = schema
-        ).also { storageProxy.registerHandle(it) }
+        )
     }
 
     /**
@@ -193,7 +164,6 @@ class HandleManager(
     suspend fun rawEntityCollectionHandle(
         storageKey: StorageKey,
         schema: Schema,
-        callbacks: CollectionCallbacks<RawEntity>? = null,
         name: String = storageKey.toKeyString(),
         ttl: Ttl = Ttl.Infinite,
         canRead: Boolean = true
@@ -213,39 +183,13 @@ class HandleManager(
         return CollectionHandle(
             name,
             storageProxy,
-            callbacks,
             ttl,
             time,
             canRead,
             dereferencer = RawEntityDereferencer(schema, aff?.dereferenceFactory()),
             schema = schema
-        ).also { storageProxy.registerHandle(it) }
+        )
     }
-
-    /**
-     * @deprecated Use [rawEntityCollectionHandle] instead.
-     */
-    /* ktlint-disable max-line-length */
-    @Deprecated(
-        "Use rawEntityCollectionHandle instead",
-        replaceWith = ReplaceWith("this.rawEntityCollectionHandle(storageKey, schema, callbacks, name, ttl, canRead)")
-    )
-    /* ktlint-enable max-line-length */
-    suspend fun collectionHandle(
-        storageKey: StorageKey,
-        schema: Schema,
-        callbacks: CollectionCallbacks<RawEntity>? = null,
-        name: String = storageKey.toKeyString(),
-        ttl: Ttl = Ttl.Infinite,
-        canRead: Boolean = true
-    ): CollectionHandle<RawEntity> = rawEntityCollectionHandle(
-        storageKey,
-        schema,
-        callbacks,
-        name,
-        ttl,
-        canRead
-    )
 
     /**
      * Creates a new [CollectionHandle] which manages a singleton of type: [Reference], where the
@@ -254,7 +198,6 @@ class HandleManager(
     suspend fun referenceCollectionHandle(
         storageKey: StorageKey,
         schema: Schema,
-        callbacks: CollectionCallbacks<Reference>? = null,
         name: String = storageKey.toKeyString(),
         ttl: Ttl = Ttl.Infinite,
         canRead: Boolean = true
@@ -277,12 +220,11 @@ class HandleManager(
         return CollectionHandle(
             name = name,
             storageProxy = storageProxy,
-            callbacks = callbacks,
             ttl = ttl,
             time = time,
             canRead = canRead,
             dereferencer = RawEntityDereferencer(schema, aff?.dereferenceFactory()),
             schema = schema
-        ).also { storageProxy.registerHandle(it) }
+        )
     }
 }

--- a/java/arcs/core/storage/handle/SingletonHandle.kt
+++ b/java/arcs/core/storage/handle/SingletonHandle.kt
@@ -17,7 +17,6 @@ import arcs.core.data.RawEntity
 import arcs.core.data.Schema
 import arcs.core.data.Ttl
 import arcs.core.storage.ActivationFactory
-import arcs.core.storage.Callbacks
 import arcs.core.storage.Dereferencer
 import arcs.core.storage.Handle
 import arcs.core.storage.StorageProxy
@@ -31,7 +30,6 @@ typealias SingletonData<T> = CrdtSingleton.Data<T>
 typealias SingletonOp<T> = CrdtSingleton.IOperation<T>
 typealias SingletonStoreOptions<T> = StoreOptions<SingletonData<T>, SingletonOp<T>, T?>
 typealias SingletonActivationFactory<T> = ActivationFactory<SingletonData<T>, SingletonOp<T>, T?>
-typealias SingletonCallbacks<T> = Callbacks<SingletonData<T>, SingletonOp<T>, T?>
 
 /**
  * Singleton [Handle] implementation for the runtime.
@@ -42,7 +40,6 @@ typealias SingletonCallbacks<T> = Callbacks<SingletonData<T>, SingletonOp<T>, T?
 class SingletonHandle<T : Referencable>(
     name: String,
     storageProxy: SingletonProxy<T>,
-    callbacks: SingletonCallbacks<T>? = null,
     ttl: Ttl = Ttl.Infinite,
     time: Time,
     canRead: Boolean = true,
@@ -51,7 +48,6 @@ class SingletonHandle<T : Referencable>(
 ) : SingletonBase<T>(
     name,
     storageProxy,
-    callbacks,
     ttl,
     time,
     canRead,

--- a/javatests/arcs/core/storage/StoreEndpointFake.kt
+++ b/javatests/arcs/core/storage/StoreEndpointFake.kt
@@ -15,6 +15,9 @@ class StoreEndpointFake<Data : CrdtData, Op : CrdtOperation, T> :
     private var callbacks = mutableListOf<ProxyCallback<Data, Op, T>>()
     private var proxyMessages = mutableListOf<ProxyMessage<Data, Op, T>>()
 
+    // Tests can change this field to alter the value returned by `onProxyMessage`.
+    var onProxyMessageReturn = true
+
     override fun setCallback(callback: ProxyCallback<Data, Op, T>): Int {
         // must be blocking since the storage impl is. Unlikely to be heavily contended.
         return runBlocking {
@@ -31,7 +34,7 @@ class StoreEndpointFake<Data : CrdtData, Op : CrdtOperation, T> :
 
     override suspend fun onProxyMessage(message: ProxyMessage<Data, Op, T>): Boolean {
         mutex.withLock { proxyMessages.add(message) }
-        return true
+        return onProxyMessageReturn
     }
 
     suspend fun getProxyMessages() : List<ProxyMessage<Data, Op, T>> {

--- a/javatests/arcs/core/storage/handle/CollectionIntegrationTest.kt
+++ b/javatests/arcs/core/storage/handle/CollectionIntegrationTest.kt
@@ -67,10 +67,8 @@ class CollectionIntegrationTest {
         testStore = Store(STORE_OPTIONS)
         storageProxy = StorageProxy(testStore.activate(), CrdtSet<RawEntity>())
 
-        collectionA = CollectionHandle("collectionA", storageProxy, null, Ttl.Infinite, TimeImpl(), schema = SCHEMA_A)
-        storageProxy.registerHandle(collectionA)
-        collectionB = CollectionHandle("collectionB", storageProxy, null, Ttl.Infinite, TimeImpl(), schema = SCHEMA_B)
-        storageProxy.registerHandle(collectionB)
+        collectionA = CollectionHandle("collectionA", storageProxy, Ttl.Infinite, TimeImpl(), schema = SCHEMA_A)
+        collectionB = CollectionHandle("collectionB", storageProxy, Ttl.Infinite, TimeImpl(), schema = SCHEMA_B)
         Unit
     }
 
@@ -186,15 +184,13 @@ class CollectionIntegrationTest {
         assertThat(collectionA.fetchAll().first().expirationTimestamp)
             .isEqualTo(RawEntity.UNINITIALIZED_TIMESTAMP)
 
-        val collectionC = CollectionHandle("collectionC", storageProxy, null, Ttl.Days(2), TimeImpl(), schema = SCHEMA_A)
-        storageProxy.registerHandle(collectionC)
+        val collectionC = CollectionHandle("collectionC", storageProxy, Ttl.Days(2), TimeImpl(), schema = SCHEMA_A)
         assertThat(collectionC.store(person.toRawEntity())).isTrue()
         val entityC = collectionC.fetchAll().first()
         assertThat(entityC.creationTimestamp).isGreaterThan(creationTimestampA)
         assertThat(entityC.expirationTimestamp).isGreaterThan(RawEntity.UNINITIALIZED_TIMESTAMP)
 
-        val collectionD = CollectionHandle("collectionD", storageProxy, null, Ttl.Minutes(1), TimeImpl(), schema = SCHEMA_B)
-        storageProxy.registerHandle(collectionD)
+        val collectionD = CollectionHandle("collectionD", storageProxy, Ttl.Minutes(1), TimeImpl(), schema = SCHEMA_B)
         assertThat(collectionD.store(person.toRawEntity())).isTrue()
         val entityD = collectionD.fetchAll().first()
         assertThat(entityD.creationTimestamp).isGreaterThan(creationTimestampA)

--- a/javatests/arcs/core/storage/handle/SingletonIntegrationTest.kt
+++ b/javatests/arcs/core/storage/handle/SingletonIntegrationTest.kt
@@ -65,10 +65,8 @@ class SingletonIntegrationTest {
         store = Store(STORE_OPTIONS)
         storageProxy = StorageProxy(store.activate(), CrdtSingleton<RawEntity>())
 
-        singletonA = SingletonHandle("singletonA", storageProxy, null, Ttl.Infinite, TimeImpl(), schema = SCHEMA)
-        storageProxy.registerHandle(singletonA)
-        singletonB = SingletonHandle("singletonB", storageProxy, null, Ttl.Infinite, TimeImpl(), schema = SCHEMA)
-        storageProxy.registerHandle(singletonB)
+        singletonA = SingletonHandle("singletonA", storageProxy, Ttl.Infinite, TimeImpl(), schema = SCHEMA)
+        singletonB = SingletonHandle("singletonB", storageProxy, Ttl.Infinite, TimeImpl(), schema = SCHEMA)
         Unit
     }
 
@@ -142,15 +140,13 @@ class SingletonIntegrationTest {
         assertThat(requireNotNull(singletonA.fetch()).expirationTimestamp)
             .isEqualTo(RawEntity.UNINITIALIZED_TIMESTAMP)
 
-        val singletonC = SingletonHandle("singletonC", storageProxy, null, Ttl.Days(2), TimeImpl(), schema = SCHEMA)
-        storageProxy.registerHandle(singletonC)
+        val singletonC = SingletonHandle("singletonC", storageProxy, Ttl.Days(2), TimeImpl(), schema = SCHEMA)
         assertThat(singletonC.store(person.toRawEntity())).isTrue()
         val entityC = requireNotNull(singletonC.fetch())
         assertThat(entityC.creationTimestamp).isGreaterThan(creationTimestampA)
         assertThat(entityC.expirationTimestamp).isGreaterThan(RawEntity.UNINITIALIZED_TIMESTAMP)
 
-        val singletonD = SingletonHandle("singletonD", storageProxy, null, Ttl.Minutes(1), TimeImpl(), schema = SCHEMA)
-        storageProxy.registerHandle(singletonD)
+        val singletonD = SingletonHandle("singletonD", storageProxy, Ttl.Minutes(1), TimeImpl(), schema = SCHEMA)
         assertThat(singletonD.store(person.toRawEntity())).isTrue()
         val entityD = requireNotNull(singletonD.fetch())
         assertThat(entityD.creationTimestamp).isGreaterThan(creationTimestampA)

--- a/javatests/arcs/core/storage/ttl/RemovalManagerTest.kt
+++ b/javatests/arcs/core/storage/ttl/RemovalManagerTest.kt
@@ -83,7 +83,6 @@ class RemovalManagerTest {
         singletonHandle = hm.rawEntitySingletonHandle(
             singletonKey,
             schema,
-            null,
             "name1",
             Ttl.Minutes(5)
         )
@@ -91,7 +90,6 @@ class RemovalManagerTest {
         collectionHandle = hm.rawEntityCollectionHandle(
             setKey,
             schema,
-            null,
             "name2",
             Ttl.Hours(2)
         )


### PR DESCRIPTION
* Remove the `core` `Callbacks` interface type, in favor of
  finer-grained action functions
* Move ownerships of data activity callbacks into `StorageProxy`
* Remove some deprecated functions
* Remove the `registerHandle` and `deregisterHandle` methods on
  `StorageProxy`
* Fix the `failedApplyOpTriggersSync` test in `StorageProxy` that wasn't
  quite right.

What started as adding `start`/`stop` functionality to handles turned
into a re-imagining of the callbacks pattern.

Observations:
* `registerHandle` (which was to be called via a `start` method on the
handle) is only setting up callbacks to the handle.
* The only action a handle takes when receiving `storageProxy` callback
calls is to trigger any developer-supplied callbacks.
* Adapting between the single-interface-with-all-3-callbacks and
callbacks-as-individual-methods approach seemed to cause some
complicated interface adaption needs.