### PR TITLE
A simple Optics/Lens utility for modifying immutable object graphs

### DIFF
--- a/java/arcs/core/util/Lens.kt
+++ b/java/arcs/core/util/Lens.kt
@@ -1,0 +1,131 @@
+package arcs.core.util
+
+/**
+ * A miniature lightweight "Optics" utility for Arcs. Mostly used to modifying immutable graph
+ * data structures used by the [Allocator].
+ *
+ * A lens is an kind of optic in functional programming that allows immutable data structures to
+ * be updated compactly and elegantly. A [Lens] is constructed around a data structure and
+ * allows its focus target (e.g. field member of a type) to be fetched, modified, or set.
+ *
+ * @property getter a lambda which given [Target] returns [Focus]
+ * @property setter a lambda which given [Target] and [Focus] returns new [Target] set with [Focus]
+ *
+ * Based on the ideas in
+ * http://davids-code.blogspot.com/2014/02/immutable-domain-and-lenses-in-java-8.html
+ */
+open class Lens<Target, Focus>(
+    private val getter: (Target) -> Focus,
+    private val setter: (Target, Focus) -> Target
+) {
+    /** Invokes a getter on the [Target] and returns a [Focus] value. */
+    fun get(target: Target) : Focus = getter(target)
+
+    /** Invokes a setter on the [Target] with the given [Focus] value and returns a new [Target]. */
+    fun set(target: Target, value: Focus) : Target = setter(target, value)
+
+    /**
+     * Applies a function to the value of invoking [get] on the [Target], and then invokes
+     * [set] on the [Target] with the value, returning a new [Target].
+     */
+    fun mod(target: Target, f: (Focus) -> Focus): Target {
+        return set(target, f(get(target)))
+    }
+
+    /**
+     * Allows two or more [Lens] to be composed and chained so that a deeply nested immutable
+     * data structure can be elegantly updated. Returns a new [Lens].
+     */
+    fun <Parent> comp(parentLens: Lens<Parent, Target>) : Lens<Parent, Focus> =
+        object : Lens<Parent, Focus>(
+            { parent : Parent -> get(parentLens.get(parent)) },
+            { parent : Parent, focus: Focus ->
+                parentLens.mod(parent) { target: Target ->
+                    set(target, focus)
+                }
+            }
+        ) {}
+}
+
+/**
+ * A [Traversal] is sort of a [Lens] with more than one focii. A [Lens] could be considered a
+ * [Traversal] with a single focii.
+ */
+interface Traversal<Target, Focus> {
+    /**
+     * Apply [f] to every focii in this traversal and return an updated target.
+     */
+    fun mod(target: Target, f: (Focus) -> Focus): Target
+}
+
+/**
+ * A [Traversal] over the [List] returned by a [Lens] whose focus type is a `List<Focus>`.
+ */
+class ListLensTraversal<Target, Focus>(
+    private val listLens: Lens<Target, List<Focus>>
+) : Traversal<Target, Focus> {
+    override fun mod(target: Target, f: (Focus) -> Focus) = listLens.mod(target) {
+        it.map(f)
+    }
+}
+
+/**
+ * A [Traversal] over the values of the [Map] returned by a [Lens] whose focus is the type
+ * `Map<String, Focus>`.
+ */
+class MapLensTraversal<Target, Focus>(
+    private val mapLens: Lens<Target, Map<String, Focus>>
+) : Traversal<Target, Focus> {
+    override fun mod(target: Target, f: (Focus) -> Focus) = mapLens.mod(target) {
+        it.mapValues { (_, v) -> f(v) }
+    }
+}
+
+/** Pseudo-constructor for creating a [Lens]. */
+fun <Target, Focus> lens(getter: (Target) -> Focus, setter: (Target, Focus) -> Target) =
+    Lens(getter, setter)
+
+/** Extension function converts a `Lens<T, List<F>>` into a `Traversal<T, F>`. */
+fun <Target, Focus> Lens<Target, List<Focus>>.traverse() = ListLensTraversal(this)
+
+/** Extension function converts a `Lens<T, Map<String, F>>` into a `Traversal<T, F>`. */
+fun <Target, Focus> Lens<Target, Map<String, Focus>>.traverse() = MapLensTraversal(this)
+
+/** Compose two [Lens]s to create a new lens which accesses the nested [Focus]. */
+infix fun <Parent, Target, Focus> Lens<Parent, Target>.compose(other: Lens<Target, Focus>) =
+    other.comp(this)
+
+
+/**
+ * Compose two [Traversal]s into a new [Traversal] which is the cartesian product of the
+ * two sequences they traverse.
+ */
+infix fun <Parent, Target, Focus> Traversal<Parent, Target>.compose(
+    other: Traversal<Target, Focus>
+) = object : Traversal<Parent, Focus> {
+    override fun mod(target: Parent, f: (Focus) -> Focus) = this@compose.mod(target) {
+        other.mod(it, f)
+    }
+}
+
+/**
+ * Compose a [Traversal] and a [Lens] into a [Traversal] that applies the [Lens] for each
+ * element in the [Traversal].
+ */
+infix fun <Parent, Target, Focus> Traversal<Parent, Target>.compose(
+    lens: Lens<Target, Focus>
+) = object : Traversal<Parent, Focus> {
+    override fun mod(target: Parent, f: (Focus) -> Focus) = this@compose.mod(target) {
+        lens.mod(it, f)
+    }
+}
+
+operator fun <Parent, Target, Focus> Lens<Parent, Target>.plus(other: Lens<Target, Focus>) =
+    this compose other
+
+operator fun <Parent, Target, Focus> Traversal<Parent, Target>.plus(
+    other: Traversal<Target, Focus>
+) = this compose other
+
+operator fun <Parent, Target, Focus> Traversal<Parent, Target>.plus(lens: Lens<Target, Focus>) =
+    this compose lens

--- a/java/arcs/core/util/Lens.kt
+++ b/java/arcs/core/util/Lens.kt
@@ -73,10 +73,10 @@ open class Lens<Subject, Focus>(
     private val setter: (Subject, Focus) -> Subject
 ) {
     /** Invokes a getter on the [Subject] and returns a [Focus] value. */
-    fun get(target: Subject) : Focus = getter(target)
+    fun get(target: Subject): Focus = getter(target)
 
     /** Invokes a setter on the [Subject] with the given [Focus] value and returns a new [Subject]. */
-    fun set(target: Subject, value: Focus) : Subject = setter(target, value)
+    fun set(target: Subject, value: Focus): Subject = setter(target, value)
 
     /**
      * Applies a function to the value of invoking [get] on the [Subject], and then invokes
@@ -90,10 +90,10 @@ open class Lens<Subject, Focus>(
      * Allows two or more [Lens] to be composed and chained so that a deeply nested immutable
      * data structure can be elegantly updated. Returns a new [Lens].
      */
-    fun <Parent> comp(parentLens: Lens<Parent, Subject>) : Lens<Parent, Focus> =
+    fun <Parent> comp(parentLens: Lens<Parent, Subject>): Lens<Parent, Focus> =
         object : Lens<Parent, Focus>(
-            { parent : Parent -> get(parentLens.get(parent)) },
-            { parent : Parent, focus: Focus ->
+            { parent: Parent -> get(parentLens.get(parent)) },
+            { parent: Parent, focus: Focus ->
                 parentLens.mod(parent) { target: Subject ->
                     set(target, focus)
                 }

--- a/javatests/arcs/core/util/LensTest.kt
+++ b/javatests/arcs/core/util/LensTest.kt
@@ -1,0 +1,126 @@
+package arcs.core.util
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+
+/** Tests for [Lens]. */
+@RunWith(JUnit4::class)
+class LensTest {
+
+    data class Mother(val motherName: String)
+    data class Child(val childName: String)
+    data class Person(
+        val name: String,
+        val age: Int,
+        val mother: Mother,
+        val children: Map<String, Child> = mapOf()
+    )
+
+    data class People(val people: List<Person>)
+
+    @Test
+    fun getAndSet_immutable() {
+        val sally = Mother("Sally")
+
+        val motherNameLens = lens(Mother::motherName) { t, f ->
+            t.copy(motherName = f)
+        }
+
+        // set the name field and return a new Person object with the modification
+        val rita = motherNameLens.set(sally, "Rita")
+
+        assertThat("Rita").isEqualTo(motherNameLens.get(rita))
+        assertThat(Mother("Rita")).isEqualTo(rita)
+    }
+
+    @Test
+    fun getAndSet_deepImmutable() {
+        val mother1 = Mother("Sally")
+        val mother2 = Mother("Rita")
+        val person1 = Person("John", 21, mother1)
+        val person2 = Person("Tom", 42, mother2)
+        val people = People(listOf(person1, person2))
+
+        val motherNameLens = lens(Mother::motherName) { t, f ->
+            t.copy(motherName = f)
+        }
+
+        val ageLens = lens(Person::age) { t, f ->
+            t.copy(age = f)
+        }
+
+        val motherLens = lens(Person::mother) { t, f ->
+            t.copy(mother = f)
+        }
+
+        // A Lens into the Person.mother.motherName field
+        val deepMotherName = motherLens + motherNameLens
+
+        val peopleLens = lens(People::people) { t, f ->
+            t.copy(people = f)
+        }
+
+        // We could probably compose these two better and pull off the mutations without making
+        // extra copies. 
+        val moddedMotherNames  = (peopleLens.traverse() + deepMotherName).mod(people) { "$it!" }
+        val moddedAges =  (peopleLens.traverse() + ageLens).mod(moddedMotherNames) { it + 2 }
+
+        val expected = People(
+            listOf(
+                person1.copy(age = 23, mother = Mother("Sally!")),
+                person2.copy(age = 44, mother = Mother("Rita!"))
+            )
+        )
+
+        assertThat(moddedAges).isEqualTo(expected)
+    }
+
+    @Test
+    fun mutate_with_traversalComposition() {
+        val mother = Mother("Mom")
+        val child1 = Child("Jack")
+        val child2 = Child("Jill")
+        val child3 = Child("Tom")
+        val child4 = Child("Jerry")
+
+        val person1 = Person("Sally", 21, mother, mapOf("child1" to child1, "child2" to child2))
+        val person2 = Person("Rita", 42, mother, mapOf("child3" to child3, "child4" to child4))
+        val people = People(listOf(person1, person2))
+
+        val peopleLens = lens(People::people) { t, f ->
+            t.copy(people = f)
+        }
+
+        val childrenLens = lens(Person::children) { t, f ->
+            t.copy(children = f)
+        }
+
+        val childrenNameLens = lens(Child::childName) { t, f ->
+            t.copy(childName = f)
+        }
+
+        // This traversal enumerates every leaf node Child.childName of the graph
+        val allChildrenNames =
+            peopleLens.traverse() + childrenLens.traverse() + childrenNameLens
+
+        // Modify every leaf node and return a new immutable data structure graph
+        val actualNewPeople = allChildrenNames.mod(people) {
+            "Baby $it"
+        }
+
+        val newchild1 = Child("Baby Jack")
+        val newchild2 = Child("Baby Jill")
+        val newchild3 = Child("Baby Tom")
+        val newchild4 = Child("Baby Jerry")
+        val newperson1 =
+            Person("Sally", 21, mother, mapOf("child1" to newchild1, "child2" to newchild2))
+        val newperson2 =
+            Person("Rita", 42, mother, mapOf("child3" to newchild3, "child4" to newchild4))
+        val expectedNewPeople = People(listOf(newperson1, newperson2))
+
+        assertThat(actualNewPeople).isEqualTo(expectedNewPeople)
+    }
+}


### PR DESCRIPTION
This allows keeping all of our data classes immutable, providing elegant code for deep mutation.

* No external dependencies, annotation processors, compiler plugins
* Removed most of the category theory typeclass stuff other libraries have, easier to understand
* Can only mutate object fields, lists, and map values

Consider the following:
```
data class Street(val number: Int, val name: String)
data class Address(val city: String, val street: Street)
data class Company(val name: String, val address: Address)
data class Employee(val name: String, val company: Company)

// And you want to update just the name:
val company = lens(Employee::company) { t, f -> t.copy(company=f) }
val address = lens(Company::address) { t,f -> t.copy(address=f) }
val street = lens(Address::street) { t,f -> t.copy(street=f) }
val name = lens(Street::name) { t,f -> t.copy(name = f) }

val employeeStreetName = company + address + street + name

val newEmployee = employeeStreetName.set(employee, "Elm Street")
```

