### PR TITLE
Make StorageKey in Plan immutable

### DIFF
--- a/java/arcs/core/allocator/Allocator.kt
+++ b/java/arcs/core/allocator/Allocator.kt
@@ -26,7 +26,6 @@ import arcs.core.host.ParticleNotFoundException
 import arcs.core.storage.CapabilitiesResolver
 import arcs.core.storage.StorageKey
 import arcs.core.type.Type
-import arcs.core.util.lens
 import arcs.core.util.plus
 import arcs.core.util.traverse
 
@@ -116,13 +115,10 @@ class Allocator(val hostRegistry: HostRegistry) {
         plan: Plan
     ): Plan {
         val createdKeys: MutableMap<StorageKey, StorageKey> = mutableMapOf()
-        val particles = lens(Plan::particles) { t, f -> Plan(particles = f, arcId = t.arcId) }
-        val handles = lens(Plan.Particle::handles) { t, f -> t.copy(handles = f) }
-        val allHandles = particles.traverse() + handles.traverse()
-        val keyLens = lens(Plan.HandleConnection::storageKey) { t, f -> t.copy(storageKey = f) }
+        val allHandles = Plan.particleLens.traverse() + Plan.Particle.handlesLens.traverse()
 
         return allHandles.mod(plan) { handle ->
-            keyLens.mod(handle) {
+            Plan.HandleConnection.storageKeyLens.mod(handle) {
                 replaceCreateKey(createdKeys, arcId, idGenerator, it, handle.type)
             }
         }

--- a/java/arcs/core/allocator/Allocator.kt
+++ b/java/arcs/core/allocator/Allocator.kt
@@ -132,7 +132,7 @@ class Allocator(val hostRegistry: HostRegistry) {
         type: Type
     ): StorageKey {
         if (storageKey is CreateableStorageKey) {
-            createdKeys.getOrPut(storageKey) {
+            return createdKeys.getOrPut(storageKey) {
                 createStorageKey(arcId, idGenerator, storageKey, type)
             }
         }

--- a/java/arcs/core/allocator/Allocator.kt
+++ b/java/arcs/core/allocator/Allocator.kt
@@ -132,15 +132,9 @@ class Allocator(val hostRegistry: HostRegistry) {
         type: Type
     ): StorageKey {
         if (storageKey is CreateableStorageKey) {
-            if (!createdKeys.containsKey(storageKey)) {
-                createdKeys[storageKey] = createStorageKey(
-                    arcId,
-                    idGenerator,
-                    storageKey,
-                    type
-                )
+            createdKeys.getOrPut(storageKey) {
+                createStorageKey(arcId, idGenerator, storageKey, type)
             }
-            return createdKeys[storageKey]!!
         }
         return storageKey
     }

--- a/java/arcs/core/allocator/Allocator.kt
+++ b/java/arcs/core/allocator/Allocator.kt
@@ -26,6 +26,9 @@ import arcs.core.host.ParticleNotFoundException
 import arcs.core.storage.CapabilitiesResolver
 import arcs.core.storage.StorageKey
 import arcs.core.type.Type
+import arcs.core.util.lens
+import arcs.core.util.plus
+import arcs.core.util.traverse
 
 /**
  * An [Allocator] is responsible for starting and stopping arcs via a distributed
@@ -48,8 +51,8 @@ class Allocator(val hostRegistry: HostRegistry) {
         val idGenerator = Id.Generator.newSession()
         val arcId = plan.arcId?.toArcId() ?: idGenerator.newArcId(arcName)
         // Any unresolved handles ('create' fate) need storage keys
-        createStorageKeysIfNecessary(arcId, idGenerator, plan)
-        val partitions = computePartitions(arcId, plan)
+        val newPlan = createStorageKeysIfNecessary(arcId, idGenerator, plan)
+        val partitions = computePartitions(arcId, newPlan)
         // Store computed partitions for later
         writePartitionMap(arcId, partitions)
         startPlanPartitionsOnHosts(partitions)
@@ -107,26 +110,43 @@ class Allocator(val hostRegistry: HostRegistry) {
      * Finds [HandleConnection] instances which were unresolved at build time
      * [CreateableStorageKey]) and attaches generated keys via [CapabilitiesResolver].
      */
-    private fun createStorageKeysIfNecessary(arcId: ArcId, idGenerator: Id.Generator, plan: Plan) {
+    private fun createStorageKeysIfNecessary(
+        arcId: ArcId,
+        idGenerator: Id.Generator,
+        plan: Plan
+    ): Plan {
         val createdKeys: MutableMap<StorageKey, StorageKey> = mutableMapOf()
+        val particles = lens(Plan::particles) { t, f -> Plan(particles = f, arcId = t.arcId) }
+        val handles = lens(Plan.Particle::handles) { t, f -> t.copy(handles = f) }
+        val allHandles = particles.traverse() + handles.traverse()
+        val keyLens = lens(Plan.HandleConnection::storageKey) { t, f -> t.copy(storageKey = f) }
 
-        plan.particles.forEach {
-            it.handles.values.forEach { spec ->
-                spec.apply {
-                    if (storageKey is CreateableStorageKey) {
-                        if (!createdKeys.containsKey(storageKey)) {
-                            createdKeys[storageKey] = createStorageKey(
-                                arcId,
-                                idGenerator,
-                                storageKey as CreateableStorageKey,
-                                type
-                            )
-                        }
-                        storageKey = createdKeys[storageKey]!!
-                    }
-                }
+        return allHandles.mod(plan) { handle ->
+            keyLens.mod(handle) {
+                replaceCreateKey(createdKeys, arcId, idGenerator, it, handle.type)
             }
         }
+    }
+
+    fun replaceCreateKey(
+        createdKeys: MutableMap<StorageKey, StorageKey>,
+        arcId: ArcId,
+        idGenerator: Id.Generator,
+        storageKey: StorageKey,
+        type: Type
+    ): StorageKey {
+        if (storageKey is CreateableStorageKey) {
+            if (!createdKeys.containsKey(storageKey)) {
+                createdKeys[storageKey] = createStorageKey(
+                    arcId,
+                    idGenerator,
+                    storageKey,
+                    type
+                )
+            }
+            return createdKeys[storageKey]!!
+        }
+        return storageKey
     }
 
     /**

--- a/java/arcs/core/allocator/BUILD
+++ b/java/arcs/core/allocator/BUILD
@@ -16,5 +16,6 @@ arcs_kt_library(
         "//java/arcs/core/storage/api",
         "//java/arcs/core/storage/driver",
         "//java/arcs/core/type",
+        "//java/arcs/core/util",
     ],
 )

--- a/java/arcs/core/data/Plan.kt
+++ b/java/arcs/core/data/Plan.kt
@@ -12,6 +12,7 @@ package arcs.core.data
 
 import arcs.core.storage.StorageKey
 import arcs.core.type.Type
+import arcs.core.util.lens
 
 /**
  * A [Plan] is usually produced by running the build time Particle Accelerator tool, it consists
@@ -33,7 +34,11 @@ open class Plan(
         val particleName: String,
         val location: String,
         val handles: Map<String, HandleConnection>
-    )
+    ) {
+        companion object {
+            val handlesLens = lens(Particle::handles) { t, f -> t.copy(handles = f) }
+        }
+    }
 
     /** Represents a use of a [Handle] by a [Particle]. */
     data class HandleConnection(
@@ -41,7 +46,12 @@ open class Plan(
         val mode: HandleMode,
         val type: Type,
         val ttl: Ttl? = null
-    )
+    ) {
+        companion object {
+            val storageKeyLens =
+                lens(HandleConnection::storageKey) { t, f -> t.copy(storageKey = f) }
+        }
+    }
 
     /**
      * A [Plan.Partition] is a part of a [Plan] that runs on an [ArcHost]. Since [Plan]s may span
@@ -51,7 +61,11 @@ open class Plan(
         val arcId: String,
         val arcHost: String,
         val particles: List<Particle>
-    )
+    ) {
+        companion object {
+            val particlesLens = lens(Partition::particles) { t, f -> t.copy(particles = f) }
+        }
+    }
 
     // Because Plan is not a data class to allow sub-classing, these are required.
     override fun equals(other: Any?): Boolean {
@@ -61,4 +75,8 @@ open class Plan(
     }
 
     override fun hashCode(): Int = particles.hashCode()
+
+    companion object {
+        val particleLens = lens(Plan::particles) { t, f -> Plan(particles = f, arcId = t.arcId) }
+    }
 }

--- a/java/arcs/core/data/Plan.kt
+++ b/java/arcs/core/data/Plan.kt
@@ -37,7 +37,7 @@ open class Plan(
 
     /** Represents a use of a [Handle] by a [Particle]. */
     data class HandleConnection(
-        var storageKey: StorageKey,
+        val storageKey: StorageKey,
         val mode: HandleMode,
         val type: Type,
         val ttl: Ttl? = null


### PR DESCRIPTION
* Removes mutable StorageKey field (which Allocator used to mutate in place) leading to bugs
* Uses new Lens utility
* Updates tests that relied on mutating keys in place
