### PR TITLE
Rearrange handle interfaces to allow compile-time verification of access

### DIFF
--- a/java/arcs/core/host/EntityHandleManager.kt
+++ b/java/arcs/core/host/EntityHandleManager.kt
@@ -244,9 +244,13 @@ abstract class BaseHandleAdapter(
 }
 
 /** Delegate this interface in a concrete singleton handle impl to mixin read operations. */
-private interface ReadSingletonOperations<T : Entity> {
+private interface UpdateOperations<T> {
+    suspend fun onUpdate(action: (T) -> Unit)
+}
+
+/** Delegate this interface in a concrete singleton handle impl to mixin read operations. */
+private interface ReadSingletonOperations<T : Entity> : UpdateOperations<T?> {
     suspend fun fetch(): T?
-    suspend fun onUpdate(action: (T?) -> Unit)
 }
 
 /** Delegate this interface in a concrete singleton handle impl to mixin write operations. */
@@ -256,11 +260,10 @@ private interface WriteSingletonOperations<T : Entity> {
 }
 
 /** Delegate this interface in a concrete collection handle impl to mixin read operations. */
-private interface ReadCollectionOperations<T : Entity> {
+private interface ReadCollectionOperations<T : Entity> : UpdateOperations<Set<T>> {
     suspend fun size(): Int
     suspend fun isEmpty(): Boolean
     suspend fun fetchAll(): Set<T>
-    suspend fun onUpdate(action: (Set<T>) -> Unit)
 }
 
 /** Delegate this interface in a concrete collection handle impl to mixin write operations. */

--- a/java/arcs/core/storage/Handle.kt
+++ b/java/arcs/core/storage/Handle.kt
@@ -55,18 +55,6 @@ open class Handle<Data : CrdtData, Op : CrdtOperationAtTime, T>(
     val time: Time,
 
     /**
-     * [canRead] is whether this handle reads data so proxy can decide whether to keep its crdt
-     * up to date.
-     */
-    val canRead: Boolean = true,
-
-    /**
-     * [canWrite] is whether this handle is writable. This can be used to enforce additional runtime
-     * checks.
-     */
-    val canWrite: Boolean = true,
-
-    /**
      * [Dereferencer] to assign to any [Reference]s which are given as return values from
      * [value].
      */

--- a/java/arcs/core/storage/api/Handle.kt
+++ b/java/arcs/core/storage/api/Handle.kt
@@ -11,14 +11,9 @@
 
 package arcs.core.storage.api
 
-import arcs.core.data.HandleMode
-
 /** Base interface for all handle classes. */
 interface Handle {
     val name: String
-
-    /** Indicates whether this handle is read-only, write-only, or read-write. */
-    val mode: HandleMode
 
     /** Assign a callback when the handle is synced. */
     suspend fun onSync(action: () -> Unit)

--- a/java/arcs/core/storage/handle/CollectionHandle.kt
+++ b/java/arcs/core/storage/handle/CollectionHandle.kt
@@ -43,7 +43,6 @@ class CollectionHandle<T : Referencable>(
     storageProxy: CollectionProxy<T>,
     ttl: Ttl = Ttl.Infinite,
     time: Time,
-    canRead: Boolean = true,
     dereferencer: Dereferencer<RawEntity>? = null,
     private val schema: Schema? = null
 ) : CollectionBase<T>(
@@ -51,7 +50,6 @@ class CollectionHandle<T : Referencable>(
     storageProxy,
     ttl,
     time,
-    canRead,
     dereferencer = dereferencer
 ) {
     /** Return the number of items in the storage proxy view of the collection. */

--- a/java/arcs/core/storage/handle/HandleManager.kt
+++ b/java/arcs/core/storage/handle/HandleManager.kt
@@ -90,8 +90,7 @@ class HandleManager(
         storageKey: StorageKey,
         schema: Schema,
         name: String = storageKey.toKeyString(),
-        ttl: Ttl = Ttl.Infinite,
-        canRead: Boolean = true
+        ttl: Ttl = Ttl.Infinite
     ): SingletonHandle<RawEntity> {
         val storeOptions = SingletonStoreOptions<RawEntity>(
             storageKey = storageKey,
@@ -113,7 +112,6 @@ class HandleManager(
             storageProxy,
             ttl,
             time,
-            canRead,
             dereferencer = RawEntityDereferencer(schema, aff?.dereferenceFactory()),
             schema = schema
         )
@@ -127,8 +125,7 @@ class HandleManager(
         storageKey: StorageKey,
         schema: Schema,
         name: String = storageKey.toKeyString(),
-        ttl: Ttl = Ttl.Infinite,
-        canRead: Boolean = true
+        ttl: Ttl = Ttl.Infinite
     ): SingletonHandle<Reference> {
         val storeOptions = SingletonStoreOptions<Reference>(
             storageKey = storageKey,
@@ -150,7 +147,6 @@ class HandleManager(
             storageProxy,
             ttl,
             time,
-            canRead,
             dereferencer = RawEntityDereferencer(schema, aff?.dereferenceFactory()),
             schema = schema
         )
@@ -165,8 +161,7 @@ class HandleManager(
         storageKey: StorageKey,
         schema: Schema,
         name: String = storageKey.toKeyString(),
-        ttl: Ttl = Ttl.Infinite,
-        canRead: Boolean = true
+        ttl: Ttl = Ttl.Infinite
     ): CollectionHandle<RawEntity> {
         val storeOptions = CollectionStoreOptions<RawEntity>(
             storageKey = storageKey,
@@ -185,7 +180,6 @@ class HandleManager(
             storageProxy,
             ttl,
             time,
-            canRead,
             dereferencer = RawEntityDereferencer(schema, aff?.dereferenceFactory()),
             schema = schema
         )
@@ -199,8 +193,7 @@ class HandleManager(
         storageKey: StorageKey,
         schema: Schema,
         name: String = storageKey.toKeyString(),
-        ttl: Ttl = Ttl.Infinite,
-        canRead: Boolean = true
+        ttl: Ttl = Ttl.Infinite
     ): CollectionHandle<Reference> {
         val storeOptions = CollectionStoreOptions<Reference>(
             storageKey = storageKey,
@@ -222,7 +215,6 @@ class HandleManager(
             storageProxy = storageProxy,
             ttl = ttl,
             time = time,
-            canRead = canRead,
             dereferencer = RawEntityDereferencer(schema, aff?.dereferenceFactory()),
             schema = schema
         )

--- a/java/arcs/core/storage/handle/SingletonHandle.kt
+++ b/java/arcs/core/storage/handle/SingletonHandle.kt
@@ -42,7 +42,6 @@ class SingletonHandle<T : Referencable>(
     storageProxy: SingletonProxy<T>,
     ttl: Ttl = Ttl.Infinite,
     time: Time,
-    canRead: Boolean = true,
     dereferencer: Dereferencer<RawEntity>? = null,
     private val schema: Schema? = null
 ) : SingletonBase<T>(
@@ -50,7 +49,6 @@ class SingletonHandle<T : Referencable>(
     storageProxy,
     ttl,
     time,
-    canRead,
     dereferencer = dereferencer
 ) {
     /** Get the current value from the backing [StorageProxy]. */

--- a/javatests/arcs/android/host/AndroidEntityHandleManagerTest.kt
+++ b/javatests/arcs/android/host/AndroidEntityHandleManagerTest.kt
@@ -14,6 +14,12 @@ import arcs.core.data.SchemaFields
 import arcs.core.data.SchemaName
 import arcs.core.host.EntityHandleManager
 import arcs.core.data.HandleMode
+import arcs.core.storage.api.ReadCollectionHandle
+import arcs.core.storage.api.ReadSingletonHandle
+import arcs.core.storage.api.ReadWriteCollectionHandle
+import arcs.core.storage.api.ReadWriteSingletonHandle
+import arcs.core.storage.api.WriteCollectionHandle
+import arcs.core.storage.api.WriteSingletonHandle
 import arcs.core.storage.driver.RamDisk
 import arcs.core.storage.keys.RamDiskStorageKey
 import arcs.core.storage.referencemode.ReferenceModeStorageKey
@@ -128,7 +134,7 @@ class AndroidEntityHandleManagerTest : LifecycleOwner {
             HandleMode.Write
         )
 
-        assertThat(writeHandle.mode).isEqualTo(HandleMode.Write)
+        assertThat(writeHandle).isInstanceOf(WriteSingletonHandle::class.java)
         handleHolder.writeHandle.store(entity1)
 
         val readHandle = createSingletonHandle(
@@ -137,7 +143,7 @@ class AndroidEntityHandleManagerTest : LifecycleOwner {
             HandleMode.Read
         )
 
-        assertThat(readHandle.mode).isEqualTo(HandleMode.Read)
+        assertThat(readHandle).isInstanceOf(ReadSingletonHandle::class.java)
 
         val readBack = handleHolder.readHandle.fetch()
         assertThat(readBack).isEqualTo(entity1)
@@ -147,7 +153,7 @@ class AndroidEntityHandleManagerTest : LifecycleOwner {
             "readWriteHandle",
             HandleMode.ReadWrite
         )
-        assertThat(readWriteHandle.mode).isEqualTo(HandleMode.ReadWrite)
+        assertThat(readWriteHandle).isInstanceOf(ReadWriteSingletonHandle::class.java)
 
         val readBack2 = handleHolder.readWriteHandle.fetch()
         assertThat(readBack2).isEqualTo(entity1)
@@ -173,7 +179,7 @@ class AndroidEntityHandleManagerTest : LifecycleOwner {
             HandleMode.Write
         )
 
-        assertThat(writeCollectionHandle.mode).isEqualTo(HandleMode.Write)
+        assertThat(writeCollectionHandle).isInstanceOf(WriteCollectionHandle::class.java)
 
         handleHolder.writeCollectionHandle.store(entity1)
         handleHolder.writeCollectionHandle.store(entity2)
@@ -184,7 +190,7 @@ class AndroidEntityHandleManagerTest : LifecycleOwner {
             HandleMode.Read
         )
 
-        assertThat(readCollectionHandle.mode).isEqualTo(HandleMode.Read)
+        assertThat(readCollectionHandle).isInstanceOf(ReadCollectionHandle::class.java)
 
         val readBack = handleHolder.readCollectionHandle.fetchAll()
         assertThat(readBack).containsExactly(entity1, entity2)
@@ -195,7 +201,7 @@ class AndroidEntityHandleManagerTest : LifecycleOwner {
             HandleMode.ReadWrite
         )
 
-        assertThat(readWriteCollectionHandle.mode).isEqualTo(HandleMode.ReadWrite)
+        assertThat(readWriteCollectionHandle).isInstanceOf(ReadWriteCollectionHandle::class.java)
 
         val readBack2 = handleHolder.readWriteCollectionHandle.fetchAll()
         assertThat(readBack2).containsExactly(entity1, entity2)

--- a/javatests/arcs/core/allocator/AllocatorTestBase.kt
+++ b/javatests/arcs/core/allocator/AllocatorTestBase.kt
@@ -305,14 +305,12 @@ open class AllocatorTestBase {
 
         writePersonContext.particle.let { particle ->
             particle as WritePerson
-            assertThat(particle.handles.person.mode).isEqualTo(HandleMode.Write)
             assertThat(particle.createCalled).isTrue()
             assertThat(particle.wrote).isTrue()
         }
 
         readPersonContext.particle.let { particle ->
             particle as ReadPerson
-            assertThat(particle.handles.person.mode).isEqualTo(HandleMode.Read)
             assertThat(particle.createCalled).isTrue()
             assertThat(particle.name).isEqualTo("John Wick")
         }

--- a/javatests/arcs/core/host/BUILD
+++ b/javatests/arcs/core/host/BUILD
@@ -17,6 +17,7 @@ arcs_kt_jvm_test_suite(
         ":particle",  # buildcleaner: keep
         ":schemas",
         "//java/arcs/core/host",
+        "//java/arcs/core/storage/api",
         "//java/arcs/core/storage/driver",
         "//java/arcs/core/storage/handle",
         "//java/arcs/core/storage/keys",

--- a/javatests/arcs/core/storage/StorageProxyTest.kt
+++ b/javatests/arcs/core/storage/StorageProxyTest.kt
@@ -58,7 +58,7 @@ class StorageProxyTest {
     @Test
     fun propagatesStorageOpToReaders() = runBlockingTest {
         val storageProxy = StorageProxy(mockStorageEndpointProvider, mockCrdtModel)
-        val readHandle = newHandle("testReader", storageProxy, true)
+        val readHandle = newHandle("testReader", storageProxy)
         val readCallback = mock<(String)->Unit>().also { readHandle.addOnUpdate(it) }
         mockCrdtModel.appliesOpAs(mockCrdtOperation, true)
 
@@ -70,7 +70,7 @@ class StorageProxyTest {
     @Test
     fun propagatesStorageFullModelToReaders() = runBlockingTest {
         val storageProxy = StorageProxy(mockStorageEndpointProvider, mockCrdtModel)
-        val readHandle = newHandle("testReader", storageProxy, true)
+        val readHandle = newHandle("testReader", storageProxy)
         val syncCallback = mock<()->Unit>().also { readHandle.addOnSync(it) }
         mockCrdtModel.appliesOpAs(mockCrdtOperation, true)
 
@@ -94,7 +94,7 @@ class StorageProxyTest {
     @Test
     fun failedApplyOpTriggersSync() = runBlockingTest {
         val storageProxy = StorageProxy(mockStorageEndpointProvider, mockCrdtModel)
-        val readHandle = newHandle("testReader", storageProxy, true)
+        val readHandle = newHandle("testReader", storageProxy)
 
         // Local op will succeed
         mockCrdtModel.appliesOpAs(mockCrdtOperation, true)
@@ -114,7 +114,7 @@ class StorageProxyTest {
     fun getParticleViewReturnsSyncedState() = runBlockingTest {
         val storageProxy = StorageProxy(mockStorageEndpointProvider, mockCrdtModel)
         whenever(mockCrdtModel.consumerView).thenReturn("someData")
-        val readHandle = newHandle("testReader", storageProxy, true)
+        val readHandle = newHandle("testReader", storageProxy)
         mockCrdtModel.appliesOpAs(mockCrdtOperation, true)
 
         assertThat(storageProxy.onMessage(ProxyMessage.Operations(listOf(mockCrdtOperation), null)))
@@ -128,7 +128,7 @@ class StorageProxyTest {
     fun getParticleViewWhenUnsyncedQueues() = runBlockingTest {
         val storageProxy = StorageProxy(mockStorageEndpointProvider, mockCrdtModel)
         whenever(mockCrdtModel.consumerView).thenReturn("someData")
-        val readHandle = newHandle("testReader", storageProxy, true)
+        val readHandle = newHandle("testReader", storageProxy)
         mockCrdtModel.appliesOpAs(mockCrdtOperation, true)
 
         // get view when not synced
@@ -271,9 +271,8 @@ class StorageProxyTest {
 
     private fun newHandle(
         name: String,
-        storageProxy: StorageProxy<CrdtData, CrdtOperationAtTime, String>,
-        reader: Boolean
-    ) = Handle(name, storageProxy, Ttl.Infinite, TimeImpl(), reader, true)
+        storageProxy: StorageProxy<CrdtData, CrdtOperationAtTime, String>
+    ) = Handle(name, storageProxy, Ttl.Infinite, TimeImpl(), null)
 
     fun CrdtModel<CrdtData, CrdtOperationAtTime, String>.appliesOpAs(op: CrdtOperationAtTime, result: Boolean) {
         whenever(this.applyOperation(op)).thenReturn(result)


### PR DESCRIPTION
* Create interfaces and corresponding impls that can be used to expose
read and write operations by delegation in concrete class definitions.

* Update tests to verify access control

* Remove `canRead` and `canWrite` flags and run-time checks