### PR TITLE
API for Backing Storage Proxy implemented

### DIFF
--- a/src/runtime/api-channel.ts
+++ b/src/runtime/api-channel.ts
@@ -29,6 +29,7 @@ import {workerPool} from './worker-pool.js';
 import {Ttl} from './recipe/ttl.js';
 import {Handle} from './storageNG/handle.js';
 import {BackingStore} from './storageNG/backing-store.js';
+import {BackingStorageProxy} from './storageNG/backing-storage-proxy.js';
 
 type StorageProxy = StorageProxyNG<CRDTTypeRecord>;
 
@@ -539,8 +540,9 @@ export abstract class PECOuterPort extends APIPort {
   AwaitIdle(@Direct version: number) {}
 
   abstract onRegister(handle: Store<CRDTTypeRecord>, messagesCallback: number, idCallback: number);
+  abstract onBackingRegister(handle: BackingStore<CRDTTypeRecord>, messagesCallback: number, idCallback: number);
   abstract onProxyMessage(handle: Store<CRDTTypeRecord>, message: ProxyMessage<CRDTTypeRecord>, callback: number);
-  abstract onBackingProxyMessage(handle: BackingStore<CRDTTypeRecord>, message: ProxyMessage<CRDTTypeRecord>, entityId: string, callback: number);
+  abstract onBackingProxyMessage(handle: BackingStore<CRDTTypeRecord>, message: ProxyMessage<CRDTTypeRecord>, callback: number);
 
   abstract onIdle(version: number, relevance: Map<recipeParticle.Particle, number[]>);
 
@@ -599,15 +601,18 @@ export abstract class PECInnerPort extends APIPort {
   Register(
     @Mapped handle: StorageProxy,
     @LocalMapped messagesCallback: ProxyCallback<CRDTTypeRecord>,
+    @LocalMapped idCallback: Consumer<number>): void  {}
+  BackingRegister(
+    @Mapped handle: BackingStorageProxy<CRDTTypeRecord>,
+    @LocalMapped messagesCallback: ProxyCallback<CRDTTypeRecord>,
     @LocalMapped idCallback: Consumer<number>): void {}
   ProxyMessage(
     @Mapped handle: StorageProxy,
     @Direct message: ProxyMessage<CRDTTypeRecord>,
-    @LocalMapped callback: Consumer<Promise<boolean>>): void {}
+    @LocalMapped callback: Consumer<Promise<boolean>>): void  {}
   BackingProxyMessage(
-    @Mapped handle: StorageProxy,
+    @Mapped handle: BackingStorageProxy<CRDTTypeRecord>,
     @Direct message: ProxyMessage<CRDTTypeRecord>,
-    @Direct entityId: string,
     @LocalMapped callback: Consumer<Promise<boolean>>): void {}
 
   Idle(@Direct version: number, @ObjectMap(MappingType.Mapped, MappingType.Direct) relevance: Map<Particle, number[]>) {}

--- a/src/runtime/api-channel.ts
+++ b/src/runtime/api-channel.ts
@@ -601,7 +601,7 @@ export abstract class PECInnerPort extends APIPort {
   Register(
     @Mapped handle: StorageProxy,
     @LocalMapped messagesCallback: ProxyCallback<CRDTTypeRecord>,
-    @LocalMapped idCallback: Consumer<number>): void  {}
+    @LocalMapped idCallback: Consumer<number>): void {}
   BackingRegister(
     @Mapped handle: BackingStorageProxy<CRDTTypeRecord>,
     @LocalMapped messagesCallback: ProxyCallback<CRDTTypeRecord>,
@@ -609,7 +609,7 @@ export abstract class PECInnerPort extends APIPort {
   ProxyMessage(
     @Mapped handle: StorageProxy,
     @Direct message: ProxyMessage<CRDTTypeRecord>,
-    @LocalMapped callback: Consumer<Promise<boolean>>): void  {}
+    @LocalMapped callback: Consumer<Promise<boolean>>): void {}
   BackingProxyMessage(
     @Mapped handle: BackingStorageProxy<CRDTTypeRecord>,
     @Direct message: ProxyMessage<CRDTTypeRecord>,

--- a/src/runtime/particle-execution-context.ts
+++ b/src/runtime/particle-execution-context.ts
@@ -176,7 +176,7 @@ export class ParticleExecutionContext implements StorageCommunicationEndpointPro
     let id: number = null;
     if (storageProxy instanceof StorageProxy) {
       return {
-      async onProxyMessage(message: ProxyMessage<CRDTTypeRecord>, entityId?: string): Promise<boolean> {
+      async onProxyMessage(message: ProxyMessage<CRDTTypeRecord>): Promise<boolean> {
         if (idPromise == null) {
           throw new Error('onProxyMessage called without first calling setCallback!');
         }

--- a/src/runtime/particle-execution-context.ts
+++ b/src/runtime/particle-execution-context.ts
@@ -216,8 +216,8 @@ export class ParticleExecutionContext implements StorageCommunicationEndpointPro
           }
           message.id = id;
 
-          // The presence of an entity id indicates the message should be sent to a Backing store. Proxy messages sent to
-          // Backing stores requires an entity id in order to redirect the message to the correct store.
+          // Ensure muxId exists. Proxy messages sent to Backing stores requires
+          // a muxId in order to redirect the message to the correct store.
           assert(message.muxId != null);
           return  new Promise((resolve) =>
             pec.apiPort.BackingProxyMessage(storageProxy, message, ret => resolve(ret)));

--- a/src/runtime/particle-execution-context.ts
+++ b/src/runtime/particle-execution-context.ts
@@ -173,20 +173,17 @@ export class ParticleExecutionContext implements StorageCommunicationEndpointPro
   getStorageEndpoint(storageProxy: StorageProxy<CRDTTypeRecord> | BackingStorageProxy<CRDTTypeRecord>): StorageCommunicationEndpoint<CRDTTypeRecord> {
     const pec = this;
     let idPromise: Promise<number> = null;
-    let id: number = null;
     if (storageProxy instanceof StorageProxy) {
       return {
         async onProxyMessage(message: ProxyMessage<CRDTTypeRecord>): Promise<boolean> {
           if (idPromise == null) {
             throw new Error('onProxyMessage called without first calling setCallback!');
           }
-          if (id == null) {
-            id = await idPromise;
-            if (id == null) {
-              throw new Error('undefined id received .. somehow');
-            }
+          message.id = await idPromise;
+          if (message.id == null) {
+            throw new Error('undefined id received .. somehow');
           }
-          message.id = id;
+
           return new Promise(resolve =>
               pec.apiPort.ProxyMessage(storageProxy, message, resolve));
         },
@@ -207,16 +204,12 @@ export class ParticleExecutionContext implements StorageCommunicationEndpointPro
           if (idPromise == null) {
             throw new Error('onProxyMessage called without first calling setCallback!');
           }
-          if (id == null) {
-            id = await idPromise;
-            if (id == null) {
-              throw new Error('undefined id received .. somehow');
-            }
+          message.id = await idPromise;
+          if (message.id == null) {
+            throw new Error('undefined id received .. somehow');
           }
-          message.id = id;
 
-          // Ensure muxId exists. Proxy messages sent to Backing stores requires
-          // a muxId in order to redirect the message to the correct store.
+          // Proxy messages sent to Backing stores require a muxId in order to redirect the message to the correct store.
           assert(message.muxId != null);
           return new Promise(resolve =>
             pec.apiPort.BackingProxyMessage(storageProxy, message, resolve));

--- a/src/runtime/particle-execution-context.ts
+++ b/src/runtime/particle-execution-context.ts
@@ -176,24 +176,23 @@ export class ParticleExecutionContext implements StorageCommunicationEndpointPro
     let id: number = null;
     if (storageProxy instanceof StorageProxy) {
       return {
-      async onProxyMessage(message: ProxyMessage<CRDTTypeRecord>): Promise<boolean> {
-        if (idPromise == null) {
-          throw new Error('onProxyMessage called without first calling setCallback!');
-        }
-        if (id == null) {
-          id = await idPromise;
-          if (id == null) {
-            throw new Error('undefined id received .. somehow');
+        async onProxyMessage(message: ProxyMessage<CRDTTypeRecord>): Promise<boolean> {
+          if (idPromise == null) {
+            throw new Error('onProxyMessage called without first calling setCallback!');
           }
-        }
-        message.id = id;
-        return  new Promise((resolve) =>
-            pec.apiPort.ProxyMessage(storageProxy, message, ret => resolve(ret)));
+          if (id == null) {
+            id = await idPromise;
+            if (id == null) {
+              throw new Error('undefined id received .. somehow');
+            }
+          }
+          message.id = id;
+          return new Promise(resolve =>
+              pec.apiPort.ProxyMessage(storageProxy, message, resolve));
         },
-
         setCallback(callback: ProxyCallback<CRDTTypeRecord>): void {
-          idPromise = new Promise<number>((resolve) =>
-          pec.apiPort.Register(storageProxy, callback, retId => resolve(retId)));
+          idPromise = new Promise<number>(resolve =>
+            pec.apiPort.Register(storageProxy, callback, resolve));
         },
         reportExceptionInHost(exception: PropagatedException): void {
           pec.apiPort.ReportExceptionInHost(exception);
@@ -219,13 +218,12 @@ export class ParticleExecutionContext implements StorageCommunicationEndpointPro
           // Ensure muxId exists. Proxy messages sent to Backing stores requires
           // a muxId in order to redirect the message to the correct store.
           assert(message.muxId != null);
-          return  new Promise((resolve) =>
-            pec.apiPort.BackingProxyMessage(storageProxy, message, ret => resolve(ret)));
+          return new Promise(resolve =>
+            pec.apiPort.BackingProxyMessage(storageProxy, message, resolve));
         },
-
         setCallback(callback: ProxyCallback<CRDTTypeRecord>): void {
-          idPromise = new Promise<number>((resolve) =>
-            pec.apiPort.BackingRegister(storageProxy, callback, retId => resolve(retId)));
+          idPromise = new Promise<number>(resolve =>
+            pec.apiPort.BackingRegister(storageProxy, callback, resolve));
         },
         reportExceptionInHost(exception: PropagatedException): void {
           pec.apiPort.ReportExceptionInHost(exception);

--- a/src/runtime/particle-execution-host.ts
+++ b/src/runtime/particle-execution-host.ts
@@ -183,6 +183,14 @@ class PECOuterPortImpl extends PECOuterPort {
     this.SimpleCallback(idCallback, id);
   }
 
+  async onBackingRegister(store: BackingStore<CRDTTypeRecord>, messagesCallback: number, idCallback: number) {
+    const id = store.on(async data => {
+      this.SimpleCallback(messagesCallback, data);
+      return Promise.resolve(true);
+    });
+    this.SimpleCallback(idCallback, id);
+  }
+
   async onProxyMessage(store: Store<CRDTTypeRecord>, message: ProxyMessage<CRDTTypeRecord>, callback: number) {
     // Need an ActiveStore here in order to forward messages. Calling
     // .activate() should generally be a no-op.
@@ -194,12 +202,12 @@ class PECOuterPortImpl extends PECOuterPort {
     this.SimpleCallback(callback, res);
   }
 
-  async onBackingProxyMessage(store: BackingStore<CRDTTypeRecord>, message: ProxyMessage<CRDTTypeRecord>, entityId: string, callback: number) {
+  async onBackingProxyMessage(store: BackingStore<CRDTTypeRecord>, message: ProxyMessage<CRDTTypeRecord>, callback: number) {
     if (!(store instanceof BackingStore)) {
       this.onReportExceptionInHost(new SystemException(new Error('expected BackingStore for onBackingProxyMessage'), 'onBackingProxyMessage', ''));
       return;
     }
-    const res = await store.onProxyMessage(message, entityId);
+    const res = await store.onProxyMessage(message);
     this.SimpleCallback(callback, res);
   }
 

--- a/src/runtime/storageNG/backing-storage-proxy.ts
+++ b/src/runtime/storageNG/backing-storage-proxy.ts
@@ -35,6 +35,9 @@ export class BackingStorageProxy<T extends CRDTTypeRecord> implements StorageCom
     const backingStorageProxy = this;
     const storageEndpoint = this.storageEndpoint;
     const muxId = Object.keys(this.storageProxies).find(key => this.storageProxies[key] === storageProxy);
+    if (muxId == undefined) {
+      throw new Error('storage proxy is not registered with backing storage proxy');
+    }
     return {
       async onProxyMessage(message: ProxyMessage<CRDTTypeRecord>): Promise<boolean> {
         message.muxId = muxId;

--- a/src/runtime/storageNG/backing-storage-proxy.ts
+++ b/src/runtime/storageNG/backing-storage-proxy.ts
@@ -20,7 +20,7 @@ import {assert} from '../../platform/assert-web.js';
 import {BiMap} from '../bimap.js';
 
 export class BackingStorageProxy<T extends CRDTTypeRecord> implements StorageCommunicationEndpointProvider<CRDTTypeRecord> {
-  private storageProxies: BiMap<string, StorageProxy<CRDTTypeRecord>> = new BiMap<string, StorageProxy<CRDTTypeRecord>>();
+  private storageProxies = new BiMap<string, StorageProxy<CRDTTypeRecord>>();
   private callbacks: Dictionary<ProxyCallback<CRDTTypeRecord>> = {};
   private storageEndpoint: StorageCommunicationEndpoint<T>;
   private storageKey: string;

--- a/src/runtime/storageNG/backing-storage-proxy.ts
+++ b/src/runtime/storageNG/backing-storage-proxy.ts
@@ -1,0 +1,67 @@
+/**
+ * @license
+ * Copyright (c) 2017 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {CRDTTypeRecord} from '../crdt/crdt.js';
+import {StorageCommunicationEndpointProvider, ProxyMessage, ProxyCallback, StorageCommunicationEndpoint} from './store.js';
+import {PropagatedException} from '../arc-exceptions.js';
+import {ChannelConstructor} from '../channel-constructor.js';
+import {StorageProxy} from './storage-proxy.js';
+import {Dictionary} from '../hot.js';
+import {Handle} from './handle.js';
+import {Type} from '../type.js';
+
+export class BackingStorageProxy<T extends CRDTTypeRecord> implements StorageCommunicationEndpointProvider<CRDTTypeRecord> {
+  private storageProxies: Dictionary<StorageProxy<CRDTTypeRecord>> = {};
+  private callbacks: Dictionary<ProxyCallback<CRDTTypeRecord>> = {};
+  private storageEndpoint;
+  private storageKey: string;
+  private type: Type;
+
+  constructor(storeProvider: StorageCommunicationEndpointProvider<T>, type: Type, storageKey: string) {
+    this.storageEndpoint = storeProvider.getStorageEndpoint(this);
+    this.storageEndpoint.setCallback(this.onMessage.bind(this));
+    this.storageKey = storageKey;
+    this.type = type;
+  }
+  getStorageEndpoint(storageProxy: StorageProxy<CRDTTypeRecord>): StorageCommunicationEndpoint<CRDTTypeRecord> {
+    const backingStorageProxy = this;
+    const storageEndpoint = this.storageEndpoint;
+    const muxId = Object.keys(this.storageProxies).find(key => this.storageProxies[key] === storageProxy);
+    return {
+      async onProxyMessage(message: ProxyMessage<CRDTTypeRecord>): Promise<boolean> {
+        message.muxId = muxId;
+        return storageEndpoint.onProxyMessage(message);
+      },
+      setCallback(callback: ProxyCallback<CRDTTypeRecord>): void {
+        backingStorageProxy.callbacks[muxId] = callback;
+      },
+      reportExceptionInHost(exception: PropagatedException): void {
+        storageEndpoint.reportExceptionInHost(exception);
+      },
+      getChannelConstructor(): ChannelConstructor {
+        return storageEndpoint.getChannelConstructor();
+      }
+    };
+  }
+
+  registerHandle(handle: Handle<T>, muxId: string): void {
+    if (!this.storageProxies[muxId]) {
+      this.storageProxies[muxId] = new StorageProxy('unnecessary-id', this, this.type, this.storageKey);
+    }
+    this.storageProxies[muxId].registerHandle(handle);
+  }
+
+  async onMessage(message: ProxyMessage<T>, muxId: string): Promise<boolean> {
+    if (!this.callbacks[muxId]) {
+      throw new Error('callback has not been set');
+    }
+    return this.callbacks[muxId](message);
+  }
+}

--- a/src/runtime/storageNG/store-interface.ts
+++ b/src/runtime/storageNG/store-interface.ts
@@ -18,6 +18,7 @@ import {StorageProxy} from './storage-proxy.js';
 import {Store} from './store.js';
 import {Producer} from '../hot.js';
 import {ChannelConstructor} from '../channel-constructor.js';
+import {BackingStorageProxy} from './backing-storage-proxy.js';
 
 /**
  * This file exists to break a circular dependency between Store and the ActiveStore implementations.
@@ -29,9 +30,10 @@ export enum StorageMode {Direct, Backing, ReferenceMode}
 
 export enum ProxyMessageType {SyncRequest, ModelUpdate, Operations}
 
-export type ProxyMessage<T extends CRDTTypeRecord> = {type: ProxyMessageType.SyncRequest, id?: number} |
-  {type: ProxyMessageType.ModelUpdate, model: T['data'], id?: number} |
-  {type: ProxyMessageType.Operations, operations: T['operation'][], id?: number};
+export type ProxyMessage<T extends CRDTTypeRecord> =
+  {type: ProxyMessageType.SyncRequest, id?: number, muxId?: string} |
+  {type: ProxyMessageType.ModelUpdate, model: T['data'], id?: number, muxId?: string} |
+  {type: ProxyMessageType.Operations, operations: T['operation'][], id?: number, muxId?: string};
 
 export type ProxyCallback<T extends CRDTTypeRecord> = (message: ProxyMessage<T>) => Promise<boolean>;
 
@@ -59,12 +61,12 @@ export type StoreConstructor = {
 export interface StorageCommunicationEndpoint<T extends CRDTTypeRecord> {
   setCallback(callback: ProxyCallback<T>): void;
   reportExceptionInHost(exception: PropagatedException): void;
-  onProxyMessage(message: ProxyMessage<T>, entityId?: string): Promise<boolean>;
+  onProxyMessage(message: ProxyMessage<T>): Promise<boolean>;
   getChannelConstructor: Producer<ChannelConstructor>;
 }
 
 export interface StorageCommunicationEndpointProvider<T extends CRDTTypeRecord> {
-  getStorageEndpoint(storageProxy: StorageProxy<T>): StorageCommunicationEndpoint<T>;
+  getStorageEndpoint(storageProxy: StorageProxy<T> | BackingStorageProxy<T>): StorageCommunicationEndpoint<T>;
 }
 
 // A representation of an active store. Subclasses of this class provide specific

--- a/src/runtime/storageNG/tests/ramdisk-backing-store-integration-test.ts
+++ b/src/runtime/storageNG/tests/ramdisk-backing-store-integration-test.ts
@@ -58,7 +58,7 @@ describe('RamDisk + Backing Store Integration', async () => {
     await store.idle();
     let message: ProxyMessage<CRDTCountTypeRecord>;
     let muxId: string;
-    const id2 = store.on(async (m) => {message = m; muxId = message.muxId; return true;});
+    const id2 = store.on(async (m) => {message = m; muxId = m.muxId; return true;});
     await store.onProxyMessage({type: ProxyMessageType.SyncRequest, id: id2, muxId: 'thing0'});
     assertHasModel(message, count1);
     assert.strictEqual(muxId, 'thing0');

--- a/src/runtime/storageNG/tests/ramdisk-backing-store-integration-test.ts
+++ b/src/runtime/storageNG/tests/ramdisk-backing-store-integration-test.ts
@@ -51,21 +51,21 @@ describe('RamDisk + Backing Store Integration', async () => {
     const count2 = new CRDTCount();
     count2.applyOperation({type: CountOpTypes.MultiIncrement, actor: 'them', version: {from: 0, to: 10}, value: 15});
 
-    const id = store.on(async (message, muxId) => true);
-    assert.isTrue(await store.onProxyMessage({type: ProxyMessageType.ModelUpdate, model: count1.getData(), id}, 'thing0'));
-    assert.isTrue(await store.onProxyMessage({type: ProxyMessageType.ModelUpdate, model: count2.getData(), id}, 'thing1'));
+    const id = store.on(async (message) => true);
+    assert.isTrue(await store.onProxyMessage({type: ProxyMessageType.ModelUpdate, model: count1.getData(), id, muxId: 'thing0'}));
+    assert.isTrue(await store.onProxyMessage({type: ProxyMessageType.ModelUpdate, model: count2.getData(), id, muxId: 'thing1'}));
 
     await store.idle();
     let message: ProxyMessage<CRDTCountTypeRecord>;
     let muxId: string;
-    const id2 = store.on(async (m, id) => {message = m; muxId = id; return true;});
-    await store.onProxyMessage({type: ProxyMessageType.SyncRequest, id: id2}, 'thing0');
+    const id2 = store.on(async (m) => {message = m; muxId = message.muxId; return true;});
+    await store.onProxyMessage({type: ProxyMessageType.SyncRequest, id: id2, muxId: 'thing0'});
     assertHasModel(message, count1);
     assert.strictEqual(muxId, 'thing0');
-    await store.onProxyMessage({type: ProxyMessageType.SyncRequest, id: id2}, 'thing1');
+    await store.onProxyMessage({type: ProxyMessageType.SyncRequest, id: id2, muxId: 'thing1'});
     assertHasModel(message, count2);
     assert.strictEqual(muxId, 'thing1');
-    await store.onProxyMessage({type: ProxyMessageType.SyncRequest, id: id2}, 'not-a-thing');
+    await store.onProxyMessage({type: ProxyMessageType.SyncRequest, id: id2, muxId: 'not-a-thing'});
     assertHasModel(message, new CRDTCount());
     assert.strictEqual(muxId, 'not-a-thing');
   });

--- a/src/runtime/storageNG/tests/reference-mode-store-test.ts
+++ b/src/runtime/storageNG/tests/reference-mode-store-test.ts
@@ -307,7 +307,7 @@ describe('Reference Mode Store', async () => {
     entityCRDT.applyOperation({type: EntityOpTypes.Set, field: 'age', value: {id: '42', value: 42}, actor, clock: {[actor]: 1}});
     entityCRDT.applyOperation({type: EntityOpTypes.Set, field: 'name', value: {id: 'bob'}, actor, clock: {[actor]: 1}});
 
-    await activeStore.backingStore.onProxyMessage({type: ProxyMessageType.ModelUpdate, model: entityCRDT.getData(), id: 1}, 'an-id');
+    await activeStore.backingStore.onProxyMessage({type: ProxyMessageType.ModelUpdate, model: entityCRDT.getData(), id: 1, muxId: 'an-id'});
 
     return new Promise(async (resolve, reject) => {
       const id = activeStore.on(async proxyMessage => {
@@ -363,7 +363,7 @@ describe('Reference Mode Store', async () => {
     remoteCollection.applyOperation({type: CollectionOpTypes.Add, clock: {them: 1}, actor: 'them', added: reference});
 
     // ensure remote entity is stored in backing store
-    await activeStore.backingStore.onProxyMessage({type: ProxyMessageType.ModelUpdate, model: {singletons: {name: {values: {}, version: {}}, age: {values: {}, version: {}}}, collections: {}, version: {}}, id: 2}, 'another-id');
+    await activeStore.backingStore.onProxyMessage({type: ProxyMessageType.ModelUpdate, model: {singletons: {name: {values: {}, version: {}}, age: {values: {}, version: {}}}, collections: {}, version: {}}, id: 2, muxId: 'another-id'});
 
     const driver = activeStore.containerStore['driver'] as MockDriver<CollectionData<Reference>>;
     let sendInvoked = false;

--- a/src/runtime/tests/api-channel-test.ts
+++ b/src/runtime/tests/api-channel-test.ts
@@ -92,6 +92,7 @@ describe('API channel', function() {
       onSynchronizeProxy() {}
       onInitializeProxy() {}
       onRegister() {}
+      onBackingRegister() {}
       onProxyMessage() {}
       onSystemTraceBegin() {}
       onSystemTraceEnd() {}


### PR DESCRIPTION
This patch also modifies ProxyMessage to include an optional muxID field. Communication between BackingStore and BackingStorageProxy requires the muxID to be a part of the Proxy Message. 