### PR TITLE
Creates EntityBase class

### DIFF
--- a/java/arcs/core/host/EntityHandleManager.kt
+++ b/java/arcs/core/host/EntityHandleManager.kt
@@ -182,7 +182,7 @@ private class WriteSingletonOperationsImpl<T : Entity>(
 ) : WriteSingletonOperations<T> {
     override suspend fun store(entity: T) {
         storageHandle.store(
-            entity.ensureIdentified(idGenerator, storageHandle.name).serialize()
+            entity.apply { ensureIdentified(idGenerator, storageHandle.name) }.serialize()
         )
     }
 
@@ -216,7 +216,7 @@ private class WriteCollectionOperationsImpl<T : Entity>(
 ) : WriteCollectionOperations<T> {
     override suspend fun store(entity: T) {
         storageHandle.store(
-            entity.ensureIdentified(idGenerator, storageHandle.name).serialize()
+            entity.apply { ensureIdentified(idGenerator, storageHandle.name) }.serialize()
         )
     }
 
@@ -271,15 +271,4 @@ private interface WriteCollectionOperations<T : Entity> {
     suspend fun store(entity: T)
     suspend fun clear()
     suspend fun remove(entity: T)
-}
-
-private fun <T : Entity> T.ensureIdentified(idGenerator: Id.Generator, handleName: String): T {
-    if (this.internalId == "") {
-        this.internalId = idGenerator.newChildId(
-            // TODO: should we allow this to be plumbed through?
-            idGenerator.newArcId("dummy-arc"),
-            handleName
-        ).toString()
-    }
-    return this
 }

--- a/java/arcs/core/storage/api/Entity.kt
+++ b/java/arcs/core/storage/api/Entity.kt
@@ -11,6 +11,7 @@
 
 package arcs.core.storage.api
 
+import arcs.core.common.Id
 import arcs.core.common.Referencable
 import arcs.core.data.RawEntity
 import arcs.core.data.Schema
@@ -19,8 +20,16 @@ import kotlin.IllegalArgumentException
 import kotlin.reflect.KClass
 
 interface Entity {
-    var internalId: String
+    /** The ID for the entity, or null if it is does not have one yet. */
+    val entityId: String?
+
+    /** Generates a new ID for the Entity, if it doesn't already have one. */
+    fun ensureIdentified(idGenerator: Id.Generator, handleName: String)
+
     fun serialize(): RawEntity
+
+    /** Resets all fields to the default value. */
+    fun reset()
 }
 
 /**

--- a/java/arcs/core/storage/api/EntityBase.kt
+++ b/java/arcs/core/storage/api/EntityBase.kt
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.core.storage.api
+
+import arcs.core.common.Id
+import arcs.core.common.Referencable
+import arcs.core.data.FieldType
+import arcs.core.data.PrimitiveType
+import arcs.core.data.RawEntity
+import arcs.core.data.RawEntity.Companion.NO_REFERENCE_ID
+import arcs.core.data.Schema
+import arcs.core.data.util.ReferencablePrimitive
+import arcs.core.data.util.toReferencable
+
+open class EntityBase(
+    private val entityClassName: String,
+    private val schema: Schema
+) : Entity {
+    // Private var _entityId with public getter. Only this class can set this field.
+    private var _entityId: String? = null
+    override val entityId: String?
+        get() = _entityId
+
+    private val singletons: MutableMap<String, Any?> = mutableMapOf()
+    private val collections: MutableMap<String, Set<Any>> = mutableMapOf()
+
+    // Initialize all fields. After this point, if a key is not present in singletons/collections,
+    // it will not be considered a valid field for the entity.
+    init {
+        reset()
+    }
+
+    /** Returns the value for the given singleton field. */
+    protected fun getSingletonValue(field: String): Any? = if (field in singletons) {
+        singletons[field]
+    } else {
+        throw InvalidFieldNameException(entityClassName, field, isCollection = false)
+    }
+
+    /** Returns the value for the given collection field. */
+    protected fun getCollectionValue(field: String): Set<Any> = collections.getOrElse(field) {
+        throw InvalidFieldNameException(entityClassName, field, isCollection = true)
+    }
+
+    /** Sets the value for the given singleton field. */
+    protected fun setSingletonValue(field: String, value: Any?) {
+        val expectedType = getSingletonType(field)
+        checkType(field, value, expectedType)
+        singletons[field] = value
+    }
+
+    /** Sets the value for the given collection field. */
+    protected fun setCollectionValue(field: String, values: Set<Any>) {
+        val expectedType = getCollectionType(field)
+        values.forEach { checkType(field, it, expectedType) }
+        collections[field] = values
+    }
+
+    /** Returns the [FieldType] for the given singleton field. */
+    private fun getSingletonType(field: String) = schema.fields.singletons[field]
+        ?: throw InvalidFieldNameException(entityClassName, field, isCollection = false)
+
+    /** Returns the [FieldType] for the given collection field. */
+    private fun getCollectionType(field: String) = schema.fields.collections[field]
+        ?: throw InvalidFieldNameException(entityClassName, field, isCollection = true)
+
+    /** Checks that the given value is of the expected type. */
+    private fun checkType(field: String, value: Any?, type: FieldType) = when (type) {
+        is FieldType.Primitive -> when (type.primitiveType) {
+            PrimitiveType.Boolean -> require(value is Boolean) {
+                "Expected Boolean for $entityClassName.$field, but received $value."
+            }
+            PrimitiveType.Number -> require(value is Double) {
+                "Expected Double for $entityClassName.$field, but received $value."
+            }
+            PrimitiveType.Text -> require(value is String) {
+                "Expected String for $entityClassName.$field, but received $value."
+            }
+        }
+        is FieldType.EntityRef -> {
+            // TODO: Handle References.
+            throw NotImplementedError("References aren't supported yet.")
+        }
+    }
+
+    /** Combines all singleton/collection field data into a single map. */
+    private fun allFields(): Map<String, Any?> = mutableMapOf<String, Any?>().apply {
+        putAll(singletons)
+        putAll(collections)
+    }
+
+    final override fun reset() {
+        schema.fields.singletons.keys.forEach { singletons[it] = null }
+        schema.fields.collections.keys.forEach { collections[it] = emptySet() }
+    }
+
+    override fun serialize() = RawEntity(
+        id = entityId ?: NO_REFERENCE_ID,
+        singletons = singletons.mapValues { (field, value) ->
+            value?.let { toReferencable(it, getSingletonType(field)) }
+        },
+        collections = collections.mapValues { (field, values) ->
+            val type = getCollectionType(field)
+            values.map { toReferencable(it, type) }.toSet()
+        }
+    )
+
+    /**
+     * Populates the entity from the given [RawEntity] serialization. Must only be called on a
+     * fresh, empty instance.
+     */
+    protected fun deserialize(rawEntity: RawEntity) {
+        _entityId = if (rawEntity.id == NO_REFERENCE_ID) null else rawEntity.id
+        rawEntity.singletons.forEach { (field, value) ->
+            setSingletonValue(field, value?.let { fromReferencable(it, getSingletonType(field)) })
+        }
+        rawEntity.collections.forEach { (field, values) ->
+            val type = getCollectionType(field)
+            setCollectionValue(field, values.map { fromReferencable(it, type) }.toSet())
+        }
+    }
+
+    override fun ensureIdentified(idGenerator: Id.Generator, handleName: String) {
+        if (_entityId == null) {
+            _entityId = idGenerator.newChildId(
+                // TODO: should we allow this to be plumbed through?
+                idGenerator.newArcId("dummy-arc"),
+                handleName
+            ).toString()
+        }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is EntityBase) return false
+        if (entityClassName != other.entityClassName) return false
+        if (schema != other.schema) return false
+        if (_entityId != other._entityId) return false
+        if (singletons != other.singletons) return false
+        if (collections != other.collections) return false
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = entityClassName.hashCode()
+        result = 31 * result + schema.hashCode()
+        result = 31 * result + _entityId.hashCode()
+        result = 31 * result + singletons.hashCode()
+        result = 31 * result + collections.hashCode()
+        return result
+    }
+
+    override fun toString(): String {
+        val fields = allFields().entries
+            .sortedBy { it.key }
+            .joinToString(", ") { (field, value) ->
+                "$field = $value"
+            }
+        return "$entityClassName($fields)"
+    }
+}
+
+class InvalidFieldNameException(
+    entityClassName: String,
+    field: String,
+    isCollection: Boolean
+) : IllegalArgumentException(
+    "$entityClassName does not have a ${if (isCollection) "collection" else "singleton"} field " +
+        "called \"$field\"."
+)
+
+private fun toReferencable(value: Any, type: FieldType): Referencable = when (type) {
+    is FieldType.Primitive -> when (type.primitiveType) {
+        PrimitiveType.Boolean -> (value as Boolean).toReferencable()
+        PrimitiveType.Number -> (value as Double).toReferencable()
+        PrimitiveType.Text -> (value as String).toReferencable()
+    }
+    is FieldType.EntityRef -> {
+        // TODO: Handle References.
+        throw NotImplementedError("References aren't supported yet.")
+    }
+}
+
+private fun fromReferencable(referencable: Referencable, type: FieldType): Any = when (type) {
+    is FieldType.Primitive -> {
+        require(referencable is ReferencablePrimitive<*>) {
+            "Expected ReferencablePrimitive but was $referencable."
+        }
+        requireNotNull(referencable.value) {
+            "ReferencablePrimitive encoded an unexpected null value."
+        }
+    }
+    is FieldType.EntityRef -> {
+        // TODO: Handle References.
+        throw NotImplementedError("References aren't supported yet.")
+    }
+}

--- a/java/arcs/sdk/Entity.kt
+++ b/java/arcs/sdk/Entity.kt
@@ -11,11 +11,11 @@
 
 package arcs.sdk
 
-import arcs.core.storage.api.Entity
-import arcs.core.storage.api.EntitySpec
+/** Interface of all generated [Entity] types. */
+typealias Entity = arcs.core.storage.api.Entity
 
 /** Base class of all generated [Entity] types. */
-typealias Entity = arcs.core.storage.api.Entity
+typealias EntityBase = arcs.core.storage.api.EntityBase
 
 /**
  * Spec for an [Entity] type. Can create and deserialize new entities.

--- a/java/arcs/sdk/wasm/WasmCollectionImpl.kt
+++ b/java/arcs/sdk/wasm/WasmCollectionImpl.kt
@@ -39,7 +39,7 @@ class WasmCollectionImpl<T : WasmEntity>(
                 val chunk = chomp(len)
                 // TODO: just get the id, no need to decode the full entity
                 val entity = requireNotNull(entitySpec.decode(chunk))
-                entities.remove(entity.internalId)
+                entities.remove(entity.entityId)
             }
         }
         notifyOnUpdateActions()
@@ -49,14 +49,14 @@ class WasmCollectionImpl<T : WasmEntity>(
 
     fun store(entity: T) {
         val encoded = entity.encodeEntity()
-        WasmRuntimeClient.collectionStore(particle, this, encoded)?.let { entity.internalId = it }
-        entities[entity.internalId] = entity
+        WasmRuntimeClient.collectionStore(particle, this, encoded)?.let { entity.entityId = it }
+        entities[entity.entityId] = entity
     }
 
     fun remove(entity: T) {
-        entities[entity.internalId]?.let {
+        entities[entity.entityId]?.let {
             val encoded = it.encodeEntity()
-            entities.remove(entity.internalId)
+            entities.remove(entity.entityId)
             WasmRuntimeClient.collectionRemove(particle, this, encoded)
         }
         notifyOnUpdateActions()
@@ -68,7 +68,7 @@ class WasmCollectionImpl<T : WasmEntity>(
                 val len = getInt(':')
                 val chunk = chomp(len)
                 val entity = requireNotNull(entitySpec.decode(chunk))
-                entities[entity.internalId] = entity
+                entities[entity.entityId] = entity
             }
         }
     }

--- a/java/arcs/sdk/wasm/WasmEntity.kt
+++ b/java/arcs/sdk/wasm/WasmEntity.kt
@@ -13,7 +13,7 @@ package arcs.sdk.wasm
 
 /** Wasm-specific extensions to the base [Entity] interface. */
 interface WasmEntity {
-    var internalId: String
+    var entityId: String
     fun encodeEntity(): NullTermByteArray
 }
 

--- a/javatests/arcs/core/storage/api/BUILD
+++ b/javatests/arcs/core/storage/api/BUILD
@@ -12,6 +12,7 @@ arcs_kt_jvm_test_suite(
     srcs = glob(["*.kt"]),
     package = "arcs.core.storage.api",
     deps = [
+        "//java/arcs/core/common",
         "//java/arcs/core/data",
         "//java/arcs/core/storage/api",
         "//java/arcs/core/testutil",

--- a/javatests/arcs/core/storage/api/BUILD
+++ b/javatests/arcs/core/storage/api/BUILD
@@ -1,0 +1,23 @@
+load(
+    "//third_party/java/arcs/build_defs:build_defs.bzl",
+    "arcs_kt_jvm_test_suite",
+)
+
+licenses(["notice"])
+
+package(default_visibility = ["//visibility:public"])
+
+TEST_SRCS = glob(["*Test.kt"])
+
+arcs_kt_jvm_test_suite(
+    name = "api",
+    srcs = glob(["*.kt"]),
+    package = "arcs.core.storage.api",
+    deps = [
+        "//java/arcs/core/data",
+        "//java/arcs/core/storage/api",
+        "//java/arcs/core/testutil",
+        "//third_party/java/junit:junit-android",
+        "//third_party/java/truth:truth-android",
+    ],
+)

--- a/javatests/arcs/core/storage/api/BUILD
+++ b/javatests/arcs/core/storage/api/BUILD
@@ -7,8 +7,6 @@ licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])
 
-TEST_SRCS = glob(["*Test.kt"])
-
 arcs_kt_jvm_test_suite(
     name = "api",
     srcs = glob(["*.kt"]),

--- a/javatests/arcs/core/storage/api/EntityBaseTest.kt
+++ b/javatests/arcs/core/storage/api/EntityBaseTest.kt
@@ -1,0 +1,298 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.core.storage.api
+
+import arcs.core.common.Id
+import arcs.core.data.FieldType
+import arcs.core.data.RawEntity
+import arcs.core.data.Schema
+import arcs.core.data.SchemaFields
+import arcs.core.data.SchemaName
+import arcs.core.testutil.assertThrows
+import com.google.common.truth.Truth.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+@Suppress("UNCHECKED_CAST")
+class EntityBaseTest {
+    private lateinit var entity: EntityBaseForTest
+
+    @Before
+    fun setUp() {
+        entity = EntityBaseForTest()
+    }
+
+    @Test
+    fun singletonFields_boolean() {
+        assertThat(entity.bool).isNull()
+        entity.bool = true
+        assertThat(entity.bool).isTrue()
+
+        val e = assertThrows(IllegalArgumentException::class) {
+            entity.setSingletonValueForTest("bool", 1.0)
+        }
+        assertThat(e).hasMessageThat().isEqualTo(
+            "Expected Boolean for MyEntity.bool, but received 1.0."
+        )
+    }
+
+    @Test
+    fun singletonFields_number() {
+        assertThat(entity.num).isNull()
+        entity.num = 12.0
+        assertThat(entity.num).isEqualTo(12.0)
+
+        val e = assertThrows(IllegalArgumentException::class) {
+            entity.setSingletonValueForTest("num", "abc")
+        }
+        assertThat(e).hasMessageThat().isEqualTo(
+            "Expected Double for MyEntity.num, but received abc."
+        )
+    }
+
+    @Test
+    fun singletonFields_text() {
+        assertThat(entity.text).isNull()
+        entity.text = "abc"
+        assertThat(entity.text).isEqualTo("abc")
+
+        val e = assertThrows(IllegalArgumentException::class) {
+            entity.setSingletonValueForTest("text", true)
+        }
+        assertThat(e).hasMessageThat().isEqualTo(
+            "Expected String for MyEntity.text, but received true."
+        )
+    }
+
+    @Test
+    fun singletonFields_getInvalidFieldName() {
+        val e = assertThrows(InvalidFieldNameException::class) {
+            entity.getSingletonValueForTest("not_a_real_field")
+        }
+        assertThat(e).hasMessageThat().isEqualTo(
+            "MyEntity does not have a singleton field called \"not_a_real_field\"."
+        )
+    }
+
+    @Test
+    fun singletonFields_setInvalidFieldName() {
+        val e = assertThrows(InvalidFieldNameException::class) {
+            entity.setSingletonValueForTest("not_a_real_field", "x")
+        }
+        assertThat(e).hasMessageThat().isEqualTo(
+            "MyEntity does not have a singleton field called \"not_a_real_field\"."
+        )
+    }
+
+    @Test
+    fun collectionFields_boolean() {
+        assertThat(entity.bools).isEmpty()
+        entity.bools = setOf(true)
+        assertThat(entity.bools).containsExactly(true)
+
+        val e = assertThrows(IllegalArgumentException::class) {
+            entity.setCollectionValueForTest("bools", setOf(true, 1.0))
+        }
+        assertThat(e).hasMessageThat().isEqualTo(
+            "Expected Boolean for MyEntity.bools, but received 1.0."
+        )
+    }
+
+    @Test
+    fun collectionFields_number() {
+        assertThat(entity.nums).isEmpty()
+        entity.nums = setOf(1.0, 2.0)
+        assertThat(entity.nums).containsExactly(1.0, 2.0)
+
+        val e = assertThrows(IllegalArgumentException::class) {
+            entity.setCollectionValueForTest("nums", setOf(1.0, "abc"))
+        }
+        assertThat(e).hasMessageThat().isEqualTo(
+            "Expected Double for MyEntity.nums, but received abc."
+        )
+    }
+
+    @Test
+    fun collectionFields_text() {
+        assertThat(entity.texts).isEmpty()
+        entity.texts = setOf("a", "b")
+        assertThat(entity.texts).containsExactly("a", "b")
+
+        val e = assertThrows(IllegalArgumentException::class) {
+            entity.setCollectionValueForTest("texts", setOf("a", true))
+        }
+        assertThat(e).hasMessageThat().isEqualTo(
+            "Expected String for MyEntity.texts, but received true."
+        )
+    }
+
+    @Test
+    fun collectionFields_getInvalidFieldName() {
+        val e = assertThrows(InvalidFieldNameException::class) {
+            entity.getCollectionValueForTest("not_a_real_field")
+        }
+        assertThat(e).hasMessageThat().isEqualTo(
+            "MyEntity does not have a collection field called \"not_a_real_field\"."
+        )
+    }
+
+    @Test
+    fun collectionFields_setInvalidFieldName() {
+        val e = assertThrows(InvalidFieldNameException::class) {
+            entity.setCollectionValueForTest("not_a_real_field", setOf("x"))
+        }
+        assertThat(e).hasMessageThat().isEqualTo(
+            "MyEntity does not have a collection field called \"not_a_real_field\"."
+        )
+    }
+
+    @Test
+    fun serializeRoundTrip() {
+        with (entity) {
+            text = "abc"
+            num = 12.0
+            bool = true
+            texts = setOf("aa", "bb")
+            nums = setOf(1.0, 2.0)
+            bools = setOf(true, false)
+        }
+
+        val rawEntity = entity.serialize()
+        val deserialized = EntityBaseForTest()
+        deserialized.deserializeForTest(rawEntity)
+
+        assertThat(deserialized).isEqualTo(entity)
+        assertThat(deserialized.serialize()).isEqualTo(rawEntity)
+    }
+
+    @Test
+    fun equality() {
+        val entity1 = EntityBase(ENTITY_CLASS_NAME, SCHEMA)
+        val entity2 = EntityBase(ENTITY_CLASS_NAME, SCHEMA)
+        assertThat(entity1).isEqualTo(entity1)
+        assertThat(entity1).isEqualTo(entity2)
+
+        // Different name.
+        assertThat(entity1).isNotEqualTo(EntityBase("x", SCHEMA))
+
+        // Different schema.
+        assertThat(entity1).isNotEqualTo(
+            EntityBase(
+                ENTITY_CLASS_NAME,
+                Schema(emptyList(), SchemaFields(emptyMap(), emptyMap()), "hash")
+            )
+        )
+
+        // Different ID.
+        entity2.ensureIdentified(Id.Generator.newForTest("session"), "handle")
+        assertThat(entity1).isNotEqualTo(entity2)
+    }
+
+    @Test
+    fun reset() {
+        with (entity) {
+            text = "abc"
+            num = 12.0
+            bool = true
+            texts = setOf("aa", "bb")
+            nums = setOf(1.0, 2.0)
+            bools = setOf(true, false)
+        }
+
+        entity.reset()
+
+        assertThat(entity).isEqualTo(EntityBaseForTest())
+    }
+
+    @Test
+    fun ensureIdentified() {
+        // ID starts off null.
+        assertThat(entity.entityId).isNull()
+
+        // Calling once generates a new ID.
+        entity.ensureIdentified(Id.Generator.newForTest("session1"), "handle2")
+        val id = entity.entityId
+        assertThat(id).isNotNull()
+        assertThat(id).isNotEmpty()
+
+        // Calling again doesn't change the value.
+        entity.ensureIdentified(Id.Generator.newForTest("session2"), "handle2")
+        assertThat(entity.entityId).isEqualTo(id)
+    }
+
+    /**
+     * Subclasses [EntityBase] and makes its protected methods public, so that we can call them
+     * in the test. Also adds convenient getters and setters for entity fields, similar to what a
+     * code-generated subclass would do.
+     */
+    private class EntityBaseForTest : EntityBase(ENTITY_CLASS_NAME, SCHEMA) {
+        var bool: Boolean?
+            get() = getSingletonValue("bool") as Boolean?
+            set(value) = setSingletonValue("bool", value)
+
+        var num: Double?
+            get() = getSingletonValue("num") as Double?
+            set(value) = setSingletonValue("num", value)
+
+        var text: String?
+            get() = getSingletonValue("text") as String?
+            set(value) = setSingletonValue("text", value)
+
+        var bools: Set<Boolean>
+            get() = getCollectionValue("bools") as Set<Boolean>
+            set(values) = setCollectionValue("bools", values)
+
+        var nums: Set<Double>
+            get() = getCollectionValue("nums") as Set<Double>
+            set(values) = setCollectionValue("nums", values)
+
+        var texts: Set<String>
+            get() = getCollectionValue("texts") as Set<String>
+            set(values) = setCollectionValue("texts", values)
+
+        fun getSingletonValueForTest(field: String) = super.getSingletonValue(field)
+
+        fun getCollectionValueForTest(field: String) = super.getCollectionValue(field)
+
+        fun setSingletonValueForTest(field: String, value: Any?) =
+            super.setSingletonValue(field, value)
+
+        fun setCollectionValueForTest(field: String, values: Set<Any>) =
+            super.setCollectionValue(field, values)
+
+        fun deserializeForTest(rawEntity: RawEntity) = super.deserialize(rawEntity)
+    }
+
+    companion object {
+        private const val ENTITY_CLASS_NAME = "MyEntity"
+
+        private val SCHEMA = Schema(
+            names = listOf(SchemaName(ENTITY_CLASS_NAME)),
+            fields = SchemaFields(
+                singletons = mapOf(
+                    "text" to FieldType.Text,
+                    "num" to FieldType.Number,
+                    "bool" to FieldType.Boolean
+                ),
+                collections = mapOf(
+                    "texts" to FieldType.Text,
+                    "nums" to FieldType.Number,
+                    "bools" to FieldType.Boolean
+                )
+            ),
+            hash = "hash"
+        )
+    }
+}

--- a/javatests/arcs/core/storage/api/EntityBaseTest.kt
+++ b/javatests/arcs/core/storage/api/EntityBaseTest.kt
@@ -201,6 +201,13 @@ class EntityBaseTest {
     }
 
     @Test
+    fun equality_separateSubclassesWithSameDataAreEqual() {
+        val entity1 = object : EntityBase("Foo", SCHEMA) {}
+        val entity2 = object : EntityBase("Foo", SCHEMA) {}
+        assertThat(entity1).isEqualTo(entity2)
+    }
+
+    @Test
     fun reset() {
         with (entity) {
             text = "abc"

--- a/javatests/arcs/sdk/wasm/SpecialSchemaFieldsTest.kt
+++ b/javatests/arcs/sdk/wasm/SpecialSchemaFieldsTest.kt
@@ -40,7 +40,7 @@ class SpecialSchemaFieldsTest : TestBase<SpecialSchemaFieldsTest_Errors>(
         val s = SpecialSchemaFieldsTest_Fields(
             for_ = "test",
             internal_id = 0.0,
-            internalId_ = 0.0
+            entityId_ = 0.0
         )
         val encoding = s.encodeEntity().bytes.toUtf8String()
         assertTrue("The encoding uses the language keyword", encoding.contains("|for:"))
@@ -50,15 +50,15 @@ class SpecialSchemaFieldsTest : TestBase<SpecialSchemaFieldsTest_Errors>(
     fun testInternalIdField() {
         val s = SpecialSchemaFieldsTest_Fields()
         assertEquals(
-            "Keyword field `internalId_` should start as assigned value",
+            "Keyword field `entityId_` should start as assigned value",
             0.0,
-            s.internalId_)
-        val s2 = s.copy(internalId_ = 10.0)
-        assertEquals("language keyword field copy works", 10.0, s2.internalId_)
+            s.entityId_)
+        val s2 = s.copy(entityId_ = 10.0)
+        assertEquals("language keyword field copy works", 10.0, s2.entityId_)
         assertNotEquals(
-            "The internalId field should be different from the internal identifier",
-            s2.internalId_,
-            s2.internalId
+            "The entityId field should be different from the internal identifier",
+            s2.entityId_,
+            s2.entityId
         )
     }
 
@@ -67,9 +67,9 @@ class SpecialSchemaFieldsTest : TestBase<SpecialSchemaFieldsTest_Errors>(
         val s = SpecialSchemaFieldsTest_Fields(
             for_ = "",
             internal_id = 0.0,
-            internalId_ = 10.0
+            entityId_ = 10.0
         )
         val encoding = s.encodeEntity().bytes.toUtf8String()
-        assertTrue("The encoding uses the keyword 'internalId'", encoding.contains("|internalId:"))
+        assertTrue("The encoding uses the keyword 'entityId'", encoding.contains("|entityId:"))
     }
 }

--- a/javatests/arcs/sdk/wasm/manifest.arcs
+++ b/javatests/arcs/sdk/wasm/manifest.arcs
@@ -79,8 +79,8 @@ recipe EntityClassApiTest
 // -----------------------------------------------------------------------------------------------
 
 particle SpecialSchemaFieldsTest in '$module.wasm'
-  // 'internal_id' is for C++; 'internalId' is for Kotlin
-  fields: reads {for: Text, internal_id: Number, internalId: Number}
+  // 'internal_id' is for C++; 'entityId' is for Kotlin
+  fields: reads {for: Text, internal_id: Number, entityId: Number}
   errors: writes [{msg: Text}]
 
 recipe SpecialSchemaFieldsTest

--- a/particles/Native/Wasm/source/TestParticle.kt
+++ b/particles/Native/Wasm/source/TestParticle.kt
@@ -125,7 +125,6 @@ class TestParticle : AbstractTestParticle() {
                 for_ = "",
                 val_ = 0.0
             )
-            info.internalId = "wasm" + (++storeCount)
             handles.info.store(info.copy(
                 val_ = (handles.info.size + storeCount).toDouble()
             ))

--- a/src/tools/tests/goldens/generated-schemas.jvm.kt
+++ b/src/tools/tests/goldens/generated-schemas.jvm.kt
@@ -15,46 +15,18 @@ import arcs.core.data.util.toReferencable
 import arcs.core.data.util.ReferencablePrimitive
 import arcs.core.storage.api.toPrimitiveValue
 
-class GoldInternal1(val_: String = "") : Entity {
+class GoldInternal1(val_: String = "") : EntityBase("GoldInternal1", SCHEMA) {
 
-    override var internalId = ""
+    var val_: String
+        get() = super.getSingletonValue("val") as String? ?: ""
+        private set(_value) = super.setSingletonValue("val", _value)
 
-    var val_ = val_
-        get() = field
-        private set(_value) {
-            field = _value
-        }
+    init {
+        this.val_ = val_
+    }
 
     fun copy(val_: String = this.val_) = GoldInternal1(val_ = val_)
 
-    fun reset() {
-        val_ = ""
-    }
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) {
-            return true
-        }
-
-        if (other is GoldInternal1) {
-            if (internalId.isNotEmpty()) {
-                return internalId == other.internalId
-            }
-            return toString() == other.toString()
-       }
-        return false;
-    }
-
-    override fun hashCode(): Int =
-        if (internalId.isNotEmpty()) internalId.hashCode() else toString().hashCode()
-
-    override fun serialize() = RawEntity(
-        internalId,
-        mapOf("val" to val_.toReferencable())
-    )
-
-    override fun toString() =
-      "GoldInternal1(val_ = $val_)"
 
     companion object : EntitySpec<GoldInternal1> {
 
@@ -71,14 +43,8 @@ class GoldInternal1(val_: String = "") : Entity {
 
         override fun create() = GoldInternal1()
 
-        override fun deserialize(data: RawEntity): GoldInternal1 {
-            // TODO: only handles singletons for now
-            val rtn = create().copy(
-                val_ = data.singletons["val_"].toPrimitiveValue(String::class, "")
-            )
-            rtn.internalId = data.id
-            return rtn
-        }
+        // TODO: only handles singletons for now
+        override fun deserialize(data: RawEntity) = create().apply { deserialize(data) }
     }
 }
 
@@ -93,45 +59,39 @@ class Gold_QCollection(
     favoriteColor: String = "",
     birthDayMonth: Double = 0.0,
     birthDayDOM: Double = 0.0
-) : Entity {
+) : EntityBase("Gold_QCollection", SCHEMA) {
 
-    override var internalId = ""
+    var name: String
+        get() = super.getSingletonValue("name") as String? ?: ""
+        private set(_value) = super.setSingletonValue("name", _value)
+    var age: Double
+        get() = super.getSingletonValue("age") as Double? ?: 0.0
+        private set(_value) = super.setSingletonValue("age", _value)
+    var lastCall: Double
+        get() = super.getSingletonValue("lastCall") as Double? ?: 0.0
+        private set(_value) = super.setSingletonValue("lastCall", _value)
+    var address: String
+        get() = super.getSingletonValue("address") as String? ?: ""
+        private set(_value) = super.setSingletonValue("address", _value)
+    var favoriteColor: String
+        get() = super.getSingletonValue("favoriteColor") as String? ?: ""
+        private set(_value) = super.setSingletonValue("favoriteColor", _value)
+    var birthDayMonth: Double
+        get() = super.getSingletonValue("birthDayMonth") as Double? ?: 0.0
+        private set(_value) = super.setSingletonValue("birthDayMonth", _value)
+    var birthDayDOM: Double
+        get() = super.getSingletonValue("birthDayDOM") as Double? ?: 0.0
+        private set(_value) = super.setSingletonValue("birthDayDOM", _value)
 
-    var name = name
-        get() = field
-        private set(_value) {
-            field = _value
-        }
-    var age = age
-        get() = field
-        private set(_value) {
-            field = _value
-        }
-    var lastCall = lastCall
-        get() = field
-        private set(_value) {
-            field = _value
-        }
-    var address = address
-        get() = field
-        private set(_value) {
-            field = _value
-        }
-    var favoriteColor = favoriteColor
-        get() = field
-        private set(_value) {
-            field = _value
-        }
-    var birthDayMonth = birthDayMonth
-        get() = field
-        private set(_value) {
-            field = _value
-        }
-    var birthDayDOM = birthDayDOM
-        get() = field
-        private set(_value) {
-            field = _value
-        }
+    init {
+        this.name = name
+        this.age = age
+        this.lastCall = lastCall
+        this.address = address
+        this.favoriteColor = favoriteColor
+        this.birthDayMonth = birthDayMonth
+        this.birthDayDOM = birthDayDOM
+    }
 
     fun copy(
         name: String = this.name,
@@ -151,48 +111,6 @@ class Gold_QCollection(
         birthDayDOM = birthDayDOM
     )
 
-    fun reset() {
-        name = ""
-        age = 0.0
-        lastCall = 0.0
-        address = ""
-        favoriteColor = ""
-        birthDayMonth = 0.0
-        birthDayDOM = 0.0
-    }
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) {
-            return true
-        }
-
-        if (other is Gold_QCollection) {
-            if (internalId.isNotEmpty()) {
-                return internalId == other.internalId
-            }
-            return toString() == other.toString()
-       }
-        return false;
-    }
-
-    override fun hashCode(): Int =
-        if (internalId.isNotEmpty()) internalId.hashCode() else toString().hashCode()
-
-    override fun serialize() = RawEntity(
-        internalId,
-        mapOf(
-            "name" to name.toReferencable(),
-            "age" to age.toReferencable(),
-            "lastCall" to lastCall.toReferencable(),
-            "address" to address.toReferencable(),
-            "favoriteColor" to favoriteColor.toReferencable(),
-            "birthDayMonth" to birthDayMonth.toReferencable(),
-            "birthDayDOM" to birthDayDOM.toReferencable()
-        )
-    )
-
-    override fun toString() =
-      "Gold_QCollection(name = $name, age = $age, lastCall = $lastCall, address = $address, favoriteColor = $favoriteColor, birthDayMonth = $birthDayMonth, birthDayDOM = $birthDayDOM)"
 
     companion object : EntitySpec<Gold_QCollection> {
 
@@ -222,64 +140,24 @@ class Gold_QCollection(
 
         override fun create() = Gold_QCollection()
 
-        override fun deserialize(data: RawEntity): Gold_QCollection {
-            // TODO: only handles singletons for now
-            val rtn = create().copy(
-                name = data.singletons["name"].toPrimitiveValue(String::class, ""),
-                age = data.singletons["age"].toPrimitiveValue(Double::class, 0.0),
-                lastCall = data.singletons["lastCall"].toPrimitiveValue(Double::class, 0.0),
-                address = data.singletons["address"].toPrimitiveValue(String::class, ""),
-                favoriteColor = data.singletons["favoriteColor"].toPrimitiveValue(String::class, ""),
-                birthDayMonth = data.singletons["birthDayMonth"].toPrimitiveValue(Double::class, 0.0),
-                birthDayDOM = data.singletons["birthDayDOM"].toPrimitiveValue(Double::class, 0.0)
-            )
-            rtn.internalId = data.id
-            return rtn
-        }
+        // TODO: only handles singletons for now
+        override fun deserialize(data: RawEntity) = create().apply { deserialize(data) }
     }
 }
 
 
-class Gold_Collection(num: Double = 0.0) : Entity {
+class Gold_Collection(num: Double = 0.0) : EntityBase("Gold_Collection", SCHEMA) {
 
-    override var internalId = ""
+    var num: Double
+        get() = super.getSingletonValue("num") as Double? ?: 0.0
+        private set(_value) = super.setSingletonValue("num", _value)
 
-    var num = num
-        get() = field
-        private set(_value) {
-            field = _value
-        }
+    init {
+        this.num = num
+    }
 
     fun copy(num: Double = this.num) = Gold_Collection(num = num)
 
-    fun reset() {
-        num = 0.0
-    }
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) {
-            return true
-        }
-
-        if (other is Gold_Collection) {
-            if (internalId.isNotEmpty()) {
-                return internalId == other.internalId
-            }
-            return toString() == other.toString()
-       }
-        return false;
-    }
-
-    override fun hashCode(): Int =
-        if (internalId.isNotEmpty()) internalId.hashCode() else toString().hashCode()
-
-    override fun serialize() = RawEntity(
-        internalId,
-        mapOf("num" to num.toReferencable())
-    )
-
-    override fun toString() =
-      "Gold_Collection(num = $num)"
 
     companion object : EntitySpec<Gold_Collection> {
 
@@ -296,14 +174,8 @@ class Gold_Collection(num: Double = 0.0) : Entity {
 
         override fun create() = Gold_Collection()
 
-        override fun deserialize(data: RawEntity): Gold_Collection {
-            // TODO: only handles singletons for now
-            val rtn = create().copy(
-                num = data.singletons["num"].toPrimitiveValue(Double::class, 0.0)
-            )
-            rtn.internalId = data.id
-            return rtn
-        }
+        // TODO: only handles singletons for now
+        override fun deserialize(data: RawEntity) = create().apply { deserialize(data) }
     }
 }
 
@@ -313,30 +185,27 @@ class Gold_Data(
     txt: String = "",
     lnk: String = "",
     flg: Boolean = false
-) : Entity {
+) : EntityBase("Gold_Data", SCHEMA) {
 
-    override var internalId = ""
+    var num: Double
+        get() = super.getSingletonValue("num") as Double? ?: 0.0
+        private set(_value) = super.setSingletonValue("num", _value)
+    var txt: String
+        get() = super.getSingletonValue("txt") as String? ?: ""
+        private set(_value) = super.setSingletonValue("txt", _value)
+    var lnk: String
+        get() = super.getSingletonValue("lnk") as String? ?: ""
+        private set(_value) = super.setSingletonValue("lnk", _value)
+    var flg: Boolean
+        get() = super.getSingletonValue("flg") as Boolean? ?: false
+        private set(_value) = super.setSingletonValue("flg", _value)
 
-    var num = num
-        get() = field
-        private set(_value) {
-            field = _value
-        }
-    var txt = txt
-        get() = field
-        private set(_value) {
-            field = _value
-        }
-    var lnk = lnk
-        get() = field
-        private set(_value) {
-            field = _value
-        }
-    var flg = flg
-        get() = field
-        private set(_value) {
-            field = _value
-        }
+    init {
+        this.num = num
+        this.txt = txt
+        this.lnk = lnk
+        this.flg = flg
+    }
 
     fun copy(
         num: Double = this.num,
@@ -345,42 +214,6 @@ class Gold_Data(
         flg: Boolean = this.flg
     ) = Gold_Data(num = num, txt = txt, lnk = lnk, flg = flg)
 
-    fun reset() {
-        num = 0.0
-        txt = ""
-        lnk = ""
-        flg = false
-    }
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) {
-            return true
-        }
-
-        if (other is Gold_Data) {
-            if (internalId.isNotEmpty()) {
-                return internalId == other.internalId
-            }
-            return toString() == other.toString()
-       }
-        return false;
-    }
-
-    override fun hashCode(): Int =
-        if (internalId.isNotEmpty()) internalId.hashCode() else toString().hashCode()
-
-    override fun serialize() = RawEntity(
-        internalId,
-        mapOf(
-            "num" to num.toReferencable(),
-            "txt" to txt.toReferencable(),
-            "lnk" to lnk.toReferencable(),
-            "flg" to flg.toReferencable()
-        )
-    )
-
-    override fun toString() =
-      "Gold_Data(num = $num, txt = $txt, lnk = $lnk, flg = $flg)"
 
     companion object : EntitySpec<Gold_Data> {
 
@@ -402,17 +235,8 @@ class Gold_Data(
 
         override fun create() = Gold_Data()
 
-        override fun deserialize(data: RawEntity): Gold_Data {
-            // TODO: only handles singletons for now
-            val rtn = create().copy(
-                num = data.singletons["num"].toPrimitiveValue(Double::class, 0.0),
-                txt = data.singletons["txt"].toPrimitiveValue(String::class, ""),
-                lnk = data.singletons["lnk"].toPrimitiveValue(String::class, ""),
-                flg = data.singletons["flg"].toPrimitiveValue(Boolean::class, false)
-            )
-            rtn.internalId = data.id
-            return rtn
-        }
+        // TODO: only handles singletons for now
+        override fun deserialize(data: RawEntity) = create().apply { deserialize(data) }
     }
 }
 

--- a/src/tools/tests/goldens/generated-schemas.wasm.kt
+++ b/src/tools/tests/goldens/generated-schemas.wasm.kt
@@ -13,46 +13,30 @@ import arcs.sdk.wasm.*
 
 class GoldInternal1(val_: String = "") : WasmEntity {
 
-    override var internalId = ""
-
     var val_ = val_
         get() = field
         private set(_value) {
             field = _value
         }
 
+    override var entityId = ""
+
     fun copy(val_: String = this.val_) = GoldInternal1(val_ = val_)
 
+
     fun reset() {
-        val_ = ""
+      val_ = ""
     }
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) {
-            return true
-        }
-
-        if (other is GoldInternal1) {
-            if (internalId.isNotEmpty()) {
-                return internalId == other.internalId
-            }
-            return toString() == other.toString()
-       }
-        return false;
-    }
-
-    override fun hashCode(): Int =
-        if (internalId.isNotEmpty()) internalId.hashCode() else toString().hashCode()
 
     override fun encodeEntity(): NullTermByteArray {
         val encoder = StringEncoder()
-        encoder.encode("", internalId)
+        encoder.encode("", entityId)
         val_.let { encoder.encode("val:T", val_) }
         return encoder.toNullTermByteArray()
     }
 
     override fun toString() =
-      "GoldInternal1(val_ = $val_)"
+        "GoldInternal1(val_ = $val_)"
 
     companion object : WasmEntitySpec<GoldInternal1> {
 
@@ -63,7 +47,7 @@ class GoldInternal1(val_: String = "") : WasmEntity {
             if (encoded.isEmpty()) return null
 
             val decoder = StringDecoder(encoded)
-            val internalId = decoder.decodeText()
+            val entityId = decoder.decodeText()
             decoder.validate("|")
 
             var val_ = ""
@@ -91,7 +75,7 @@ class GoldInternal1(val_: String = "") : WasmEntity {
             val _rtn = create().copy(
                 val_ = val_
             )
-            _rtn.internalId = internalId
+            _rtn.entityId = entityId
             return _rtn
         }
     }
@@ -109,8 +93,6 @@ class Gold_QCollection(
     birthDayMonth: Double = 0.0,
     birthDayDOM: Double = 0.0
 ) : WasmEntity {
-
-    override var internalId = ""
 
     var name = name
         get() = field
@@ -148,6 +130,8 @@ class Gold_QCollection(
             field = _value
         }
 
+    override var entityId = ""
+
     fun copy(
         name: String = this.name,
         age: Double = this.age,
@@ -166,8 +150,9 @@ class Gold_QCollection(
         birthDayDOM = birthDayDOM
     )
 
+
     fun reset() {
-        name = ""
+      name = ""
         age = 0.0
         lastCall = 0.0
         address = ""
@@ -176,26 +161,9 @@ class Gold_QCollection(
         birthDayDOM = 0.0
     }
 
-    override fun equals(other: Any?): Boolean {
-        if (this === other) {
-            return true
-        }
-
-        if (other is Gold_QCollection) {
-            if (internalId.isNotEmpty()) {
-                return internalId == other.internalId
-            }
-            return toString() == other.toString()
-       }
-        return false;
-    }
-
-    override fun hashCode(): Int =
-        if (internalId.isNotEmpty()) internalId.hashCode() else toString().hashCode()
-
     override fun encodeEntity(): NullTermByteArray {
         val encoder = StringEncoder()
-        encoder.encode("", internalId)
+        encoder.encode("", entityId)
         name.let { encoder.encode("name:T", name) }
         age.let { encoder.encode("age:N", age) }
         lastCall.let { encoder.encode("lastCall:N", lastCall) }
@@ -207,7 +175,7 @@ class Gold_QCollection(
     }
 
     override fun toString() =
-      "Gold_QCollection(name = $name, age = $age, lastCall = $lastCall, address = $address, favoriteColor = $favoriteColor, birthDayMonth = $birthDayMonth, birthDayDOM = $birthDayDOM)"
+        "Gold_QCollection(name = $name, age = $age, lastCall = $lastCall, address = $address, favoriteColor = $favoriteColor, birthDayMonth = $birthDayMonth, birthDayDOM = $birthDayDOM)"
 
     companion object : WasmEntitySpec<Gold_QCollection> {
 
@@ -218,7 +186,7 @@ class Gold_QCollection(
             if (encoded.isEmpty()) return null
 
             val decoder = StringDecoder(encoded)
-            val internalId = decoder.decodeText()
+            val entityId = decoder.decodeText()
             decoder.validate("|")
 
             var name = ""
@@ -284,7 +252,7 @@ class Gold_QCollection(
             birthDayDOM = birthDayDOM
 
             )
-            _rtn.internalId = internalId
+            _rtn.entityId = entityId
             return _rtn
         }
     }
@@ -293,46 +261,30 @@ class Gold_QCollection(
 
 class Gold_Collection(num: Double = 0.0) : WasmEntity {
 
-    override var internalId = ""
-
     var num = num
         get() = field
         private set(_value) {
             field = _value
         }
 
+    override var entityId = ""
+
     fun copy(num: Double = this.num) = Gold_Collection(num = num)
 
+
     fun reset() {
-        num = 0.0
+      num = 0.0
     }
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) {
-            return true
-        }
-
-        if (other is Gold_Collection) {
-            if (internalId.isNotEmpty()) {
-                return internalId == other.internalId
-            }
-            return toString() == other.toString()
-       }
-        return false;
-    }
-
-    override fun hashCode(): Int =
-        if (internalId.isNotEmpty()) internalId.hashCode() else toString().hashCode()
 
     override fun encodeEntity(): NullTermByteArray {
         val encoder = StringEncoder()
-        encoder.encode("", internalId)
+        encoder.encode("", entityId)
         num.let { encoder.encode("num:N", num) }
         return encoder.toNullTermByteArray()
     }
 
     override fun toString() =
-      "Gold_Collection(num = $num)"
+        "Gold_Collection(num = $num)"
 
     companion object : WasmEntitySpec<Gold_Collection> {
 
@@ -343,7 +295,7 @@ class Gold_Collection(num: Double = 0.0) : WasmEntity {
             if (encoded.isEmpty()) return null
 
             val decoder = StringDecoder(encoded)
-            val internalId = decoder.decodeText()
+            val entityId = decoder.decodeText()
             decoder.validate("|")
 
             var num = 0.0
@@ -371,7 +323,7 @@ class Gold_Collection(num: Double = 0.0) : WasmEntity {
             val _rtn = create().copy(
                 num = num
             )
-            _rtn.internalId = internalId
+            _rtn.entityId = entityId
             return _rtn
         }
     }
@@ -384,8 +336,6 @@ class Gold_Data(
     lnk: String = "",
     flg: Boolean = false
 ) : WasmEntity {
-
-    override var internalId = ""
 
     var num = num
         get() = field
@@ -408,6 +358,8 @@ class Gold_Data(
             field = _value
         }
 
+    override var entityId = ""
+
     fun copy(
         num: Double = this.num,
         txt: String = this.txt,
@@ -415,33 +367,17 @@ class Gold_Data(
         flg: Boolean = this.flg
     ) = Gold_Data(num = num, txt = txt, lnk = lnk, flg = flg)
 
+
     fun reset() {
-        num = 0.0
+      num = 0.0
         txt = ""
         lnk = ""
         flg = false
     }
 
-    override fun equals(other: Any?): Boolean {
-        if (this === other) {
-            return true
-        }
-
-        if (other is Gold_Data) {
-            if (internalId.isNotEmpty()) {
-                return internalId == other.internalId
-            }
-            return toString() == other.toString()
-       }
-        return false;
-    }
-
-    override fun hashCode(): Int =
-        if (internalId.isNotEmpty()) internalId.hashCode() else toString().hashCode()
-
     override fun encodeEntity(): NullTermByteArray {
         val encoder = StringEncoder()
-        encoder.encode("", internalId)
+        encoder.encode("", entityId)
         num.let { encoder.encode("num:N", num) }
         txt.let { encoder.encode("txt:T", txt) }
         lnk.let { encoder.encode("lnk:U", lnk) }
@@ -450,7 +386,7 @@ class Gold_Data(
     }
 
     override fun toString() =
-      "Gold_Data(num = $num, txt = $txt, lnk = $lnk, flg = $flg)"
+        "Gold_Data(num = $num, txt = $txt, lnk = $lnk, flg = $flg)"
 
     companion object : WasmEntitySpec<Gold_Data> {
 
@@ -461,7 +397,7 @@ class Gold_Data(
             if (encoded.isEmpty()) return null
 
             val decoder = StringDecoder(encoded)
-            val internalId = decoder.decodeText()
+            val entityId = decoder.decodeText()
             decoder.validate("|")
 
             var num = 0.0
@@ -504,7 +440,7 @@ class Gold_Data(
             val _rtn = create().copy(
                 num = num, txt = txt, lnk = lnk, flg = flg
             )
-            _rtn.internalId = internalId
+            _rtn.entityId = entityId
             return _rtn
         }
     }


### PR DESCRIPTION
All generated entities inherit from this base class.

It enforces that fields are the correct type, stores all data in Maps,
and handles serialization/deserialization to/from RawEntity for you.

Also makes entityId treatment better. The field is no longer writable by developers.