### PR TITLE
Handle.close()

### DIFF
--- a/java/arcs/core/host/AbstractArcHost.kt
+++ b/java/arcs/core/host/AbstractArcHost.kt
@@ -188,7 +188,7 @@ abstract class AbstractArcHost(vararg initialParticles: ParticleRegistration) : 
 
         override fun setHandle(handleName: String, handle: Handle) = Unit
 
-        override fun clear() = Unit
+        override fun reset() = Unit
     }
 
     /** A placeholder no-op [Particle] for failures of instantiateParticle. */
@@ -481,7 +481,7 @@ abstract class AbstractArcHost(vararg initialParticles: ParticleRegistration) : 
      */
     private suspend fun cleanupHandles(handles: HandleHolder) {
         // TODO: disconnect/unregister handles
-        handles.clear()
+        handles.reset()
     }
 
     override suspend fun isHostForParticle(particle: Plan.Particle) =

--- a/java/arcs/core/host/EntityHandleManager.kt
+++ b/java/arcs/core/host/EntityHandleManager.kt
@@ -241,6 +241,10 @@ abstract class BaseHandleAdapter(
     override suspend fun onSync(action: () -> Unit) = storageHandle.addOnSync(action)
 
     override suspend fun onDesync(action: () -> Unit) = storageHandle.addOnDesync(action)
+
+    override suspend fun close() {
+        storageHandle.close()
+    }
 }
 
 /** Delegate this interface in a concrete singleton handle impl to mixin read operations. */

--- a/java/arcs/core/host/api/HandleHolder.kt
+++ b/java/arcs/core/host/api/HandleHolder.kt
@@ -31,6 +31,6 @@ interface HandleHolder {
     /** Sets the given [Handle]. */
     fun setHandle(handleName: String, handle: Handle)
 
-    /** Erase all handle references from the [HandleHolder]. */
-    fun clear()
+    /** Erase and release all handle references from the [HandleHolder]. */
+    fun reset()
 }

--- a/java/arcs/core/storage/Handle.kt
+++ b/java/arcs/core/storage/Handle.kt
@@ -62,6 +62,9 @@ open class Handle<Data : CrdtData, Op : CrdtOperationAtTime, T>(
 ) {
     protected val log = TaggedLog { "Handle($name)" }
 
+    /** Whether this handle can no longer be operated on .*/
+    var closed = false
+
     /** Add an action to be performed whenever the contents of the [Handle]'s data changes. */
     suspend fun addOnUpdate(action: (value: T) -> Unit) {
         storageProxy.addOnUpdate(name, action)
@@ -117,5 +120,16 @@ open class Handle<Data : CrdtData, Op : CrdtOperationAtTime, T>(
             is Set<*> -> this.forEach { it.injectDereferencer() }
         }
         return this
+    }
+
+    protected fun checkNotClosed() {
+        if (closed) {
+            throw IllegalArgumentException("Handle $name is closed.")
+        }
+    }
+
+    suspend fun close() {
+        closed = true
+        removeAllCallbacks()
     }
 }

--- a/java/arcs/core/storage/api/Handle.kt
+++ b/java/arcs/core/storage/api/Handle.kt
@@ -20,6 +20,9 @@ interface Handle {
 
     /** Assign a callback when the handle is desynced. */
     suspend fun onDesync(action: () -> Unit)
+
+    /** Release resources needed by this, unregister all callbacks. */
+    suspend fun close()
 }
 
 interface ReadableHandle<T> : Handle {

--- a/java/arcs/core/storage/handle/SingletonHandle.kt
+++ b/java/arcs/core/storage/handle/SingletonHandle.kt
@@ -78,7 +78,6 @@ class SingletonHandle<T : Referencable>(
             )
         )
     }
-
     /**
      * Clears the value in the backing [StorageProxy]. If this returns `false`, your operation
      * did not apply fully. Fetch the latest value and retry.

--- a/java/arcs/core/storage/handle/SingletonHandle.kt
+++ b/java/arcs/core/storage/handle/SingletonHandle.kt
@@ -52,7 +52,10 @@ class SingletonHandle<T : Referencable>(
     dereferencer = dereferencer
 ) {
     /** Get the current value from the backing [StorageProxy]. */
-    suspend fun fetch() = value()
+    suspend fun fetch() = run {
+        checkNotClosed()
+        value()
+    }
 
     /**
      * Sends a new value to the backing [StorageProxy]. If this returns `false`, your operation
@@ -60,6 +63,7 @@ class SingletonHandle<T : Referencable>(
      * */
     suspend fun store(entity: T): Boolean {
         log.debug { "storing $entity" }
+        checkNotClosed()
 
         @Suppress("GoodTime") // use Instant
         entity.creationTimestamp = requireNotNull(time).currentTimeMillis
@@ -84,6 +88,7 @@ class SingletonHandle<T : Referencable>(
      * did not apply fully. Fetch the latest value and retry.
      * */
     suspend fun clear(): Boolean {
+        checkNotClosed()
         // Sync before clearing in order to get an updated versionMap. This ensures we can clear
         // values set by other actors.
         fetch()

--- a/java/arcs/core/storage/handle/SingletonHandle.kt
+++ b/java/arcs/core/storage/handle/SingletonHandle.kt
@@ -78,6 +78,7 @@ class SingletonHandle<T : Referencable>(
             )
         )
     }
+
     /**
      * Clears the value in the backing [StorageProxy]. If this returns `false`, your operation
      * did not apply fully. Fetch the latest value and retry.

--- a/java/arcs/sdk/BUILD
+++ b/java/arcs/sdk/BUILD
@@ -84,5 +84,6 @@ arcs_kt_jvm_library(
         "//java/arcs/core/storage/api",
         "//java/arcs/sdk",
         "//java/arcs/sdk/storage",
+        "//third_party/kotlin/kotlinx_coroutines",
     ],
 )

--- a/java/arcs/sdk/Particle.kt
+++ b/java/arcs/sdk/Particle.kt
@@ -63,7 +63,6 @@ open class HandleHolderBase(
         handles.clear()
     }
 
-
     private fun checkHandleIsValid(handleName: String) {
         // entitySpecs is passed in the constructor with the full set of specs, so it can be
         // considered an authoritative list of which handles are valid and which aren't.

--- a/java/arcs/sdk/Particle.kt
+++ b/java/arcs/sdk/Particle.kt
@@ -12,6 +12,7 @@
 package arcs.sdk
 
 import arcs.core.host.api.Particle
+import kotlinx.coroutines.runBlocking
 
 /**
  * Interface used by [ArcHost]s to interact dynamically with code-generated [Handle] fields
@@ -55,7 +56,13 @@ open class HandleHolderBase(
         handles[handleName] = handle
     }
 
-    override fun clear() = handles.clear()
+    override fun reset() {
+        runBlocking {
+            handles.forEach { (_, handle) -> handle.close() }
+        }
+        handles.clear()
+    }
+
 
     private fun checkHandleIsValid(handleName: String) {
         // entitySpecs is passed in the constructor with the full set of specs, so it can be

--- a/javatests/arcs/android/host/AndroidEntityHandleManagerTest.kt
+++ b/javatests/arcs/android/host/AndroidEntityHandleManagerTest.kt
@@ -235,7 +235,7 @@ class AndroidEntityHandleManagerTest : LifecycleOwner {
             HandleMode.Write
         )
 
-        handleHolder.clear()
+        handleHolder.reset()
 
         val shandle2 = createSingletonHandle(
             handleManager,


### PR DESCRIPTION
When stopParticle() is called, Handles can still receive callbacks, even after an Arc is stopped. 

This cleans up the callback references. However, the ActiveStore still needs to be closed when the last handle is detached from the proxy.
