### PR TITLE
Convert [HandleProto] to [Recipe.Handle], instead of [Plan.Handle].

### DIFF
--- a/java/arcs/core/data/Recipe.kt
+++ b/java/arcs/core/data/Recipe.kt
@@ -23,6 +23,7 @@ data class Recipe(val name: String) {
         val type: Type,
         val associatedHandles: List<String>
     ) {
+        // TODO(bgogul): associatedHandles should be changed to List<Handle>.
         enum class Fate {
             CREATE, USE, MAP, COPY, JOIN
         }

--- a/java/arcs/core/data/Recipe.kt
+++ b/java/arcs/core/data/Recipe.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.core.data
+
+import arcs.core.type.Type
+
+/** Representation of recipe in an Arcs manifest. */
+data class Recipe(val name: String) {
+    /** Definition of a handle in a recipe. */
+    data class Handle(
+        val name: String,
+        val fate: Fate,
+        val storageKey: String,
+        val type: Type,
+        val associatedHandles: List<String>
+    ) {
+        enum class Fate {
+            CREATE, USE, MAP, COPY, JOIN
+        }
+    }
+}

--- a/java/arcs/core/data/proto/HandleProtoDecoder.kt
+++ b/java/arcs/core/data/proto/HandleProtoDecoder.kt
@@ -26,7 +26,8 @@ fun HandleProto.Fate.decode(): Handle.Fate =
             throw IllegalArgumentException("Invalid HandleProto.Fate value.")
     }
 
-/** Converts [HandleProto] into [Handle].
+/**
+ *Converts [HandleProto] into [Handle].
  *
  * If a type is not set in the [HandleProto], it is initialized to a newly created TypeVariable.
 */

--- a/java/arcs/core/data/proto/HandleProtoDecoder.kt
+++ b/java/arcs/core/data/proto/HandleProtoDecoder.kt
@@ -27,7 +27,7 @@ fun HandleProto.Fate.decode(): Handle.Fate =
     }
 
 /**
- *Converts [HandleProto] into [Handle].
+ * Converts [HandleProto] into [Handle].
  *
  * If a type is not set in the [HandleProto], it is initialized to a newly created TypeVariable.
 */

--- a/java/arcs/core/data/proto/HandleProtoDecoder.kt
+++ b/java/arcs/core/data/proto/HandleProtoDecoder.kt
@@ -11,20 +11,29 @@
 
 package arcs.core.data.proto
 
-import arcs.core.data.HandleMode
-import arcs.core.data.Plan.HandleConnection
+import arcs.core.data.Recipe.Handle
 import arcs.core.data.TypeVariable
-import arcs.core.storage.StorageKeyParser
 
-/**
- * Converts a [HandleProto] into [HandleConnection].
+/** Converts [HandleProto.Fate] into [Handle.Fate]. */
+fun HandleProto.Fate.decode(): Handle.Fate =
+    when (this) {
+        HandleProto.Fate.CREATE -> Handle.Fate.CREATE
+        HandleProto.Fate.USE -> Handle.Fate.USE
+        HandleProto.Fate.MAP -> Handle.Fate.MAP
+        HandleProto.Fate.COPY -> Handle.Fate.COPY
+        HandleProto.Fate.JOIN -> Handle.Fate.JOIN
+        HandleProto.Fate.UNRECOGNIZED ->
+            throw IllegalArgumentException("Invalid HandleProto.Fate value.")
+    }
+
+/** Converts [HandleProto] into [Handle].
  *
  * If a type is not set in the [HandleProto], it is initialized to a newly created TypeVariable.
 */
-fun HandleProto.decodeAsHandleConnection(mode: HandleMode) = HandleConnection(
-    // TODO(bgogul): name, fate, associatedHandles, ttl,
-    storageKey = StorageKeyParser.parse(storageKey),
-    mode = mode,
+fun HandleProto.decode() = Handle(
+    name = name,
+    fate = fate.decode(),
+    storageKey = storageKey,
     type = if (hasType()) type.decode() else TypeVariable("$name"),
-    ttl = null
+    associatedHandles = getAssociatedHandlesList()
 )

--- a/javatests/arcs/core/data/proto/HandleProtoDecoderTest.kt
+++ b/javatests/arcs/core/data/proto/HandleProtoDecoderTest.kt
@@ -41,39 +41,42 @@ class HandleProtoDecoderTest {
         val storageKey = "ramdisk://a"
         val handleText = buildHandleProtoText("notype_thing", "CREATE", "", storageKey, "handle_c")
         val handleProto = parseHandleProtoText(handleText)
-        val handle = handleProto.decode()
-        assertThat(handle.name).isEqualTo("notype_thing")
-        assertThat(handle.fate).isEqualTo(Handle.Fate.CREATE)
-        assertThat(handle.storageKey).isEqualTo("ramdisk://a")
-        assertThat(handle.associatedHandles).containsExactly("handle1", "handle_c")
-        assertThat(handle.type).isEqualTo(TypeVariable("notype_thing"))
+        with(handleProto.decode()) {
+            assertThat(name).isEqualTo("notype_thing")
+            assertThat(fate).isEqualTo(Handle.Fate.CREATE)
+            assertThat(storageKey).isEqualTo("ramdisk://a")
+            assertThat(associatedHandles).containsExactly("handle1", "handle_c")
+            assertThat(type).isEqualTo(TypeVariable("notype_thing"))
+        }
    }
 
     @Test
     fun decodesHandleProtoWithType() {
-        val entityTypeProto = """
-          entity {
-            schema {
-              names: "Thing"
-              fields {
-                key: "name"
-                value: { primitive: TEXT }
+        val entityTypeProto =
+            """
+              entity {
+                schema {
+                  names: "Thing"
+                  fields {
+                    key: "name"
+                    value: { primitive: TEXT }
+                  }
+                }
               }
-            }
-          }
-        """.trimIndent()
+            """.trimIndent()
         val storageKey = "ramdisk://b"
         val entityType = parseTypeProtoText(entityTypeProto).decode()
         val handleText = buildHandleProtoText(
             "thing", "JOIN", "type { ${entityTypeProto} }", storageKey, "handle_join"
         )
         val handleProto = parseHandleProtoText(handleText)
-        val handle = handleProto.decode()
-        assertThat(handle.name).isEqualTo("thing")
-        assertThat(handle.fate).isEqualTo(Handle.Fate.JOIN)
-        assertThat(handle.storageKey).isEqualTo("ramdisk://b")
-        assertThat(handle.associatedHandles).isEqualTo(listOf("handle1", "handle_join"))
-        assertThat(handle.type).isEqualTo(entityType)
+        with(handleProto.decode()) {
+            assertThat(name).isEqualTo("thing")
+            assertThat(fate).isEqualTo(Handle.Fate.JOIN)
+            assertThat(storageKey).isEqualTo("ramdisk://b")
+            assertThat(associatedHandles).isEqualTo(listOf("handle1", "handle_join"))
+            assertThat(type).isEqualTo(entityType)
+        }
     }
 
     /** A helper function to build a handle proto in text format. */
@@ -83,12 +86,13 @@ class HandleProtoDecoderTest {
         type: String,
         storageKey: String,
         associatedHandle: String
-    ) = """
-      name: "${name}"
-      fate: ${fate}
-      storage_key: "$storageKey"
-      associated_handles: "handle1"
-      associated_handles: "${associatedHandle}"
-      ${type}
-    """.trimIndent()
+    ) =
+        """
+          name: "${name}"
+          fate: ${fate}
+          storage_key: "$storageKey"
+          associated_handles: "handle1"
+          associated_handles: "${associatedHandle}"
+          ${type}
+        """.trimIndent()
 }


### PR DESCRIPTION
It is useful for type inference and other analysis to have a separate `Recipe` class. This also lets me make progress without interfering with the `Plan` and `StorageProxy` work.