### PR TITLE
recipe2plan: `create` handle fixes

### DIFF
--- a/java/arcs/core/data/testdata/WriterReaderExample.arcs
+++ b/java/arcs/core/data/testdata/WriterReaderExample.arcs
@@ -1,10 +1,10 @@
 meta
   namespace: arcs.core.data.testdata
 
-particle Reader
+particle Reader in 'arcs.core.data.testdata.Reader'
   data: reads Thing {name: Text}
 
-particle Writer
+particle Writer in 'arcs.core.data.testdata.Writer'
    data: writes Thing {name: Text}
 
 @trigger
@@ -14,6 +14,8 @@ recipe Ingestion
   thing: create persistent 'my-handle-id' @ttl(20d)
   Writer
     data: writes thing
+  Reader
+    data: reads thing
 
 @trigger
   launch startup

--- a/src/tools/storage-key-recipe-resolver.ts
+++ b/src/tools/storage-key-recipe-resolver.ts
@@ -78,14 +78,14 @@ export class StorageKeyRecipeResolver {
   }
 
   /**
-   * Create stores with keys for all create handles.
+   * Create stores with keys for all create handles with ids.
    *
    * @param recipe should be long running.
    * @param arc Arc is associated with current recipe.
    */
   async createStoresForCreateHandles(recipe: Recipe, arc: Arc) {
     const resolver = new CapabilitiesResolver({arcId: arc.id});
-    for (const createHandle of recipe.handles.filter(h => h.fate === 'create')) {
+    for (const createHandle of recipe.handles.filter(h => h.fate === 'create' && !!h.id)) {
       if (createHandle.type instanceof TypeVariable && !createHandle.type.isResolved()) {
         // TODO(mmandlis): should already be resolved.
         assert(createHandle.type.maybeEnsureResolved());

--- a/src/tools/tests/goldens/WriterReaderExample.kt
+++ b/src/tools/tests/goldens/WriterReaderExample.kt
@@ -13,8 +13,20 @@ import arcs.core.storage.StorageKeyParser
 object IngestionPlan : Plan(
     listOf(
         Particle(
+            "Reader",
+            "arcs.core.data.testdata.Reader",
+            mapOf(
+                "data" to HandleConnection(
+                    CreateableStorageKey("my-handle-id"),
+                    HandleMode.Read,
+                    EntityType(Reader_Data.SCHEMA),
+                    Ttl.Days(20)
+                )
+            )
+        ),
+        Particle(
             "Writer",
-            "",
+            "arcs.core.data.testdata.Writer",
             mapOf(
                 "data" to HandleConnection(
                     CreateableStorageKey("my-handle-id"),
@@ -31,7 +43,7 @@ object ConsumptionPlan : Plan(
     listOf(
         Particle(
             "Reader",
-            "",
+            "arcs.core.data.testdata.Reader",
             mapOf(
                 "data" to HandleConnection(
                     StorageKeyParser.parse(

--- a/src/tools/tests/plan-generator-tests.ts
+++ b/src/tools/tests/plan-generator-tests.ts
@@ -19,7 +19,7 @@ describe('recipe2plan', () => {
     const collectOccurrences = (corpus: string, targetPrefix: string, targetSuffix: string): string[] => {
       let idx = 0;
       const collection: string[] = [];
-      while (idx != -1) {
+      while (idx !== -1) {
         const start = corpus.indexOf(targetPrefix, idx);
         const end = corpus.indexOf(targetSuffix, start);
         if (start === -1 || end === -1) break;

--- a/src/tools/tests/storage-key-recipe-resolver-test.ts
+++ b/src/tools/tests/storage-key-recipe-resolver-test.ts
@@ -274,6 +274,26 @@ describe('recipe2plan', () => {
       const resolver = new StorageKeyRecipeResolver(manifest);
       await assertThrowsAsync(async () => await resolver.resolve(), Error, 'More than one handle found for data.');
     });
+    it('does not create storage keys for create handles with no IDs', async () => {
+      const manifest = await Manifest.parse(`\
+    particle Writer
+       data: writes Thing {name: Text}
+    
+    @trigger
+      launch startup
+      arcId writeArcId
+    recipe WritingRecipe
+      thing: create persistent 'my-handle-id' 
+      thing2: create persistent
+      Writer
+        data: writes thing
+      Writer
+        data: writes thing2`);
+
+      const resolver = new StorageKeyRecipeResolver(manifest);
+      await resolver.resolve();
+      assert.deepStrictEqual(manifest.stores.map(s => s.id), ['my-handle-id']);
+    });
     it.skip('No Handle: If there is no writing handle, it is not valid', () => {
     });
   });


### PR DESCRIPTION
`recipe2plan` should only try to create storage keys for `create` handles that have IDs. If a recipe does not provide an ID for these handles, they will need to be created by the allocator. 

This PR also fixes an issue that @cromwellian pointed out: Now the `plan-generator.ts` will use the same identifier for all HandleConnections connected to the same handle.