### PR TITLE
Clear handles and detach callbacks

### DIFF
--- a/java/arcs/core/host/AbstractArcHost.kt
+++ b/java/arcs/core/host/AbstractArcHost.kt
@@ -480,7 +480,7 @@ abstract class AbstractArcHost(vararg initialParticles: ParticleRegistration) : 
      * Unregisters [Handle]s from [StorageProxy]s, and clears references to them from [Particle]s.
      */
     private suspend fun cleanupHandles(handles: HandleHolder) {
-        // TODO: disconnect/unregister handles
+        // TODO: cleans up handles and detaches callbacks, but doesn't use close [ActiveStore]
         handles.reset()
     }
 

--- a/java/arcs/core/host/AbstractArcHost.kt
+++ b/java/arcs/core/host/AbstractArcHost.kt
@@ -480,7 +480,7 @@ abstract class AbstractArcHost(vararg initialParticles: ParticleRegistration) : 
      * Unregisters [Handle]s from [StorageProxy]s, and clears references to them from [Particle]s.
      */
     private suspend fun cleanupHandles(handles: HandleHolder) {
-        // TODO: cleans up handles and detaches callbacks, but doesn't use close [ActiveStore]
+        // TODO: cleans up handles and detaches callbacks, but doesn't close [ActiveStore]
         handles.reset()
     }
 


### PR DESCRIPTION
* clears all handles from HandleHolder
* prevents using Handle operations (by those still holding references)
* unregisters all callbacks

- Does not yet close an ActiveStore/ServiceConnection if all handles using a StorageProxy are closed
