### PR TITLE
Use a single TestConnectionFactory for all hosts

### DIFF
--- a/javatests/arcs/android/host/AndroidAllocatorTest.kt
+++ b/javatests/arcs/android/host/AndroidAllocatorTest.kt
@@ -20,6 +20,7 @@ import arcs.android.sdk.host.toComponentName
 import arcs.core.allocator.AllocatorTestBase
 import arcs.core.data.Capabilities
 import arcs.core.host.HostRegistry
+import arcs.sdk.android.storage.service.testutil.TestConnectionFactory
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.GlobalScope
@@ -74,6 +75,7 @@ open class AndroidAllocatorTest : AllocatorTestBase() {
         // Initialize WorkManager for instrumentation tests.
         WorkManagerTestInitHelper.initializeTestWorkManager(context)
 
+        TestExternalArcHostService.testConnectionFactory = TestConnectionFactory(context)
         readingService = Robolectric.setupService(TestReadingExternalHostService::class.java)
         writingService = Robolectric.setupService(TestWritingExternalHostService::class.java)
         super.setUp()

--- a/javatests/arcs/android/host/AndroidAllocatorWithSqliteTest.kt
+++ b/javatests/arcs/android/host/AndroidAllocatorWithSqliteTest.kt
@@ -37,7 +37,7 @@ class AndroidAllocatorWithSqliteTest : AndroidAllocatorTest() {
 
     @Before
     override fun setUp() = runBlocking {
-        TestExternalArcHostService.TestingAndroidHost.testingCapability = Capabilities.Persistent
+        TestExternalArcHostService.testingCapability = Capabilities.Persistent
         super.setUp()
         AndroidDriverAndKeyConfigurator.configure(context)
         Unit

--- a/javatests/arcs/android/host/TestExternalArcHostService.kt
+++ b/javatests/arcs/android/host/TestExternalArcHostService.kt
@@ -12,6 +12,7 @@ import arcs.core.allocator.TestingHost
 import arcs.core.data.Capabilities
 import arcs.core.host.EntityHandleManager
 import arcs.core.host.ParticleRegistration
+import arcs.sdk.android.storage.service.ConnectionFactory
 import arcs.sdk.android.storage.service.testutil.TestConnectionFactory
 import kotlinx.coroutines.Dispatchers
 
@@ -46,16 +47,17 @@ open class TestExternalArcHostService(val arcHost: TestingAndroidHost) : Service
                 serviceContext,
                 FakeLifecycle(),
                 Dispatchers.Default,
-                TestConnectionFactory(serviceContext)
+                testConnectionFactory
             ),
             arcId,
             hostId
         )
 
         override val arcHostContextCapability = testingCapability
+    }
 
-        companion object {
-            var testingCapability = Capabilities.TiedToRuntime
-        }
+    companion object {
+        lateinit var testConnectionFactory: ConnectionFactory
+        var testingCapability = Capabilities.TiedToRuntime
     }
 }


### PR DESCRIPTION
This is needed because every TestConnectionFactory spins up another Robolectric instance of StorageService according to Jbble. On real devices, SS runs as a shared service.

