### PR TITLE
Use `ArcId` type as consistently as possible

### DIFF
--- a/java/arcs/android/host/parcelables/ParcelablePlanPartition.kt
+++ b/java/arcs/android/host/parcelables/ParcelablePlanPartition.kt
@@ -13,6 +13,7 @@ package arcs.android.host.parcelables
 
 import android.os.Parcel
 import android.os.Parcelable
+import arcs.core.common.toArcId
 import arcs.core.data.Plan
 
 /** [Parcelable] variant of [Plan.Partition]. */
@@ -20,7 +21,7 @@ data class ParcelablePlanPartition(
     override val actual: Plan.Partition
 ) : ActualParcelable<Plan.Partition> {
     override fun writeToParcel(parcel: Parcel, flags: Int) {
-        parcel.writeString(actual.arcId)
+        parcel.writeString(actual.arcId.toString())
         parcel.writeString(actual.arcHost)
         parcel.writeInt(actual.particles.size)
         actual.particles.forEach {
@@ -51,7 +52,7 @@ data class ParcelablePlanPartition(
                 )
             }
 
-            return ParcelablePlanPartition(Plan.Partition(arcId, arcHost, particles))
+            return ParcelablePlanPartition(Plan.Partition(arcId.toArcId(), arcHost, particles))
         }
 
         override fun newArray(size: Int): Array<ParcelablePlanPartition?> = arrayOfNulls(size)

--- a/java/arcs/core/allocator/Allocator.kt
+++ b/java/arcs/core/allocator/Allocator.kt
@@ -226,7 +226,7 @@ class Allocator private constructor(
             .groupBy({ it.first }, { it.second })
             .map { (host, particles) ->
                 Plan.Partition(
-                    arcId.toString(),
+                    arcId,
                     host.hostId,
                     particles
                 )

--- a/java/arcs/core/common/Id.kt
+++ b/java/arcs/core/common/Id.kt
@@ -103,7 +103,16 @@ data class ArcId /* internal */ constructor(
     override val root: String,
     override val idTree: List<String>
 ) : Id {
-    override fun toString() = idToString(this)
+
+    private val arcIdString: String by lazy {
+        idToString(this)
+    }
+
+    override fun toString() = arcIdString
+
+    override fun hashCode() = arcIdString.hashCode()
+
+    override fun equals(other: Any?) = (other as? ArcId)?.toString() == arcIdString
 
     companion object {
         /**

--- a/java/arcs/core/data/Plan.kt
+++ b/java/arcs/core/data/Plan.kt
@@ -10,6 +10,7 @@
  */
 package arcs.core.data
 
+import arcs.core.common.ArcId
 import arcs.core.storage.StorageKey
 import arcs.core.type.Type
 import arcs.core.util.lens
@@ -58,7 +59,7 @@ open class Plan(
      * multiple [ArcHost]s, an [Allocator] must partition a plan by [ArcHost].
      */
     data class Partition(
-        val arcId: String,
+        val arcId: ArcId,
         val arcHost: String,
         val particles: List<Particle>
     ) {

--- a/java/arcs/core/host/ArcHostContext.kt
+++ b/java/arcs/core/host/ArcHostContext.kt
@@ -10,6 +10,7 @@
  */
 package arcs.core.host
 
+import arcs.core.common.ArcId
 import arcs.core.data.Plan
 import arcs.core.host.api.Particle
 import arcs.core.storage.api.Handle
@@ -37,7 +38,7 @@ data class ParticleContext(
  * each participating [Particle] in the [Arc].
  */
 data class ArcHostContext(
-    var arcId: String,
+    var arcId: ArcId,
     var particles: MutableMap<String, ParticleContext> = mutableMapOf(),
     var arcState: ArcState = ArcState.NeverStarted,
     var entityHandleManager: EntityHandleManager

--- a/java/arcs/core/host/EntityHandleManager.kt
+++ b/java/arcs/core/host/EntityHandleManager.kt
@@ -10,8 +10,8 @@
  */
 package arcs.core.host
 
+import arcs.core.common.ArcId
 import arcs.core.common.Id
-import arcs.core.common.toArcId
 import arcs.core.data.HandleMode
 import arcs.core.data.RawEntity
 import arcs.core.data.Schema
@@ -40,7 +40,7 @@ import arcs.core.storage.handle.SingletonHandle
  */
 class EntityHandleManager(
     private val handleManager: HandleManager,
-    private val arcId: String = Id.Generator.newSession().newArcId("arc").toString(),
+    private val arcId: ArcId = Id.Generator.newSession().newArcId("arc"),
     private val hostId: String = "nohost"
 ) {
 
@@ -65,7 +65,7 @@ class EntityHandleManager(
         storageKey,
         schema,
         name = idGenerator.newChildId(
-            idGenerator.newChildId(arcId.toArcId(), hostId),
+            idGenerator.newChildId(arcId, hostId),
             name
         ).toString()
     ).let {
@@ -98,7 +98,7 @@ class EntityHandleManager(
             storageKey,
             schema,
             name = idGenerator.newChildId(
-                idGenerator.newChildId(arcId.toArcId(), hostId),
+                idGenerator.newChildId(arcId, hostId),
                 name
             ).toString()
         ).let {

--- a/javatests/arcs/android/host/ArcHostHelperTest.kt
+++ b/javatests/arcs/android/host/ArcHostHelperTest.kt
@@ -24,6 +24,7 @@ import arcs.android.sdk.host.createStartArcHostIntent
 import arcs.android.sdk.host.createStopArcHostIntent
 import arcs.android.sdk.host.toComponentName
 import arcs.core.common.ArcId
+import arcs.core.common.toArcId
 import arcs.core.data.EntityType
 import arcs.core.data.FieldType.Companion.Text
 import arcs.core.data.Plan
@@ -140,7 +141,7 @@ class ArcHostHelperTest {
             mapOf("foo" to connection)
         )
 
-        val planPartition = Plan.Partition("id", "FooHost", listOf(particleSpec))
+        val planPartition = Plan.Partition("id".toArcId(), "FooHost", listOf(particleSpec))
         val startIntent = planPartition.createStartArcHostIntent(
             TestAndroidArcHostService::class.toComponentName(context)
         )

--- a/javatests/arcs/android/host/TestExternalArcHostService.kt
+++ b/javatests/arcs/android/host/TestExternalArcHostService.kt
@@ -9,12 +9,12 @@ import androidx.lifecycle.LifecycleObserver
 import arcs.android.sdk.host.ArcHostHelper
 import arcs.android.storage.handle.AndroidHandleManager
 import arcs.core.allocator.TestingHost
+import arcs.core.common.ArcId
 import arcs.core.data.Capabilities
 import arcs.core.host.EntityHandleManager
 import arcs.core.host.ParticleRegistration
 import arcs.core.storage.handle.Stores
 import arcs.sdk.android.storage.service.ConnectionFactory
-import arcs.sdk.android.storage.service.testutil.TestConnectionFactory
 import kotlinx.coroutines.Dispatchers
 
 open class TestExternalArcHostService(val arcHost: TestingAndroidHost) : Service() {
@@ -45,7 +45,7 @@ open class TestExternalArcHostService(val arcHost: TestingAndroidHost) : Service
 
         private val stores = Stores()
 
-        override fun entityHandleManager(arcId: String) = EntityHandleManager(
+        override fun entityHandleManager(arcId: ArcId) = EntityHandleManager(
             AndroidHandleManager(
                 serviceContext,
                 FakeLifecycle(),

--- a/javatests/arcs/android/host/parcelables/ParcelablePlanPartitionTest.kt
+++ b/javatests/arcs/android/host/parcelables/ParcelablePlanPartitionTest.kt
@@ -14,6 +14,7 @@ package arcs.android.host.parcelables
 import android.os.Parcel
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import arcs.core.common.ArcId
+import arcs.core.common.toArcId
 import arcs.core.data.EntityType
 import arcs.core.data.FieldType
 import arcs.core.data.Plan
@@ -61,7 +62,7 @@ class ParcelablePlanPartitionTest {
             mapOf("foo2" to handleConnection2)
         )
 
-        val planPartition = Plan.Partition("arcId", "arcHost", listOf(particle, particle2))
+        val planPartition = Plan.Partition("arcId".toArcId(), "arcHost", listOf(particle, particle2))
 
 
         val marshalled = with(Parcel.obtain()) {

--- a/javatests/arcs/core/allocator/AllocatorTestBase.kt
+++ b/javatests/arcs/core/allocator/AllocatorTestBase.kt
@@ -156,13 +156,13 @@ open class AllocatorTestBase {
 
         assertThat(planPartitions).containsExactly(
             Plan.Partition(
-                arcId.toString(),
+                arcId,
                 readingHost.hostId,
                 // replace the CreateableKeys with the allocated keys
                 listOf(allStorageKeyLens.mod(readPersonParticle) { sharedKey })
             ),
             Plan.Partition(
-                arcId.toString(),
+                arcId,
                 writingHost.hostId,
                 // replace the CreateableKeys with the allocated keys
                 listOf(allStorageKeyLens.mod(writePersonParticle) { sharedKey })
@@ -281,10 +281,10 @@ open class AllocatorTestBase {
         )
 
         val readingContext = requireNotNull(
-            readingExternalHost.arcHostContext(arcId.toString())
+            readingExternalHost.arcHostContext(arcId)
         )
         val writingContext = requireNotNull(
-            writingExternalHost.arcHostContext(arcId.toString())
+            writingExternalHost.arcHostContext(arcId)
         )
 
         assertThat(readingContext.arcState).isEqualTo(ArcState.Running)
@@ -322,10 +322,10 @@ open class AllocatorTestBase {
         )
 
         val readingContext = requireNotNull(
-            readingExternalHost.arcHostContext(arcId.toString())
+            readingExternalHost.arcHostContext(arcId)
         )
         val writingContext = requireNotNull(
-            writingExternalHost.arcHostContext(arcId.toString())
+            writingExternalHost.arcHostContext(arcId)
         )
 
         assertThat(readingContext.arcState).isEqualTo(ArcState.Running)
@@ -362,10 +362,10 @@ open class AllocatorTestBase {
         )
 
         val readingContext = requireNotNull(
-            readingExternalHost.arcHostContext(arcId.toString())
+            readingExternalHost.arcHostContext(arcId)
         )
         val writingContext = requireNotNull(
-            writingExternalHost.arcHostContext(arcId.toString())
+            writingExternalHost.arcHostContext(arcId)
         )
 
         assertThat(readingContext.arcState).isEqualTo(ArcState.Running)
@@ -407,10 +407,10 @@ open class AllocatorTestBase {
         )
 
         val readingContext = requireNotNull(
-            readingExternalHost.arcHostContext(arcId.toString())
+            readingExternalHost.arcHostContext(arcId)
         )
         val writingContext = requireNotNull(
-            writingExternalHost.arcHostContext(arcId.toString())
+            writingExternalHost.arcHostContext(arcId)
         )
 
         assertThat(readingContext.arcState).isEqualTo(ArcState.Running)
@@ -432,10 +432,10 @@ open class AllocatorTestBase {
         )
 
         val readingContextAfter = requireNotNull(
-            readingExternalHost.arcHostContext(arcId.toString())
+            readingExternalHost.arcHostContext(arcId)
         )
         val writingContextAfter = requireNotNull(
-            writingExternalHost.arcHostContext(arcId.toString())
+            writingExternalHost.arcHostContext(arcId)
         )
 
         assertThat(readingContextAfter.arcState).isEqualTo(ArcState.Running)

--- a/javatests/arcs/core/allocator/TestingHost.kt
+++ b/javatests/arcs/core/allocator/TestingHost.kt
@@ -1,5 +1,6 @@
 package arcs.core.allocator
 
+import arcs.core.common.ArcId
 import arcs.core.data.Plan
 import arcs.core.host.AbstractArcHost
 import arcs.core.host.ParticleRegistration
@@ -9,7 +10,7 @@ import arcs.jvm.util.testutil.TimeImpl
 open class TestingHost(vararg particles: ParticleRegistration) :
     AbstractArcHost(*particles) {
 
-    fun arcHostContext(arcId: String) = getArcHostContext(arcId)
+    fun arcHostContext(arcId: ArcId) = getArcHostContext(arcId)
 
     var started = mutableListOf<Plan.Partition>()
 


### PR DESCRIPTION
Trying to use `String.toArcId()` and `ArcId.toString()` only at boundary
points.