### PR TITLE
Remove FailureParticle

### DIFF
--- a/java/arcs/core/host/ArcState.kt
+++ b/java/arcs/core/host/ArcState.kt
@@ -73,5 +73,12 @@ enum class ParticleState {
      */
     Failed_NeverStarted,
     /** [Particle] has failed to start too many times and won't be started in this [Arc] anymore. */
-    MaxFailed,
+    MaxFailed;
+
+    /**
+     * Indicates whether a particle in this state has ever been created before (i.e. startup
+     * succeeded at least once).
+     */
+    val hasBeenCreated: Boolean
+        get() = this == Created || this == Started || this == Stopped || this == Failed
 }


### PR DESCRIPTION
Instead of creating a FailureParticle, just throw an exception.

This construction was only used in one place (instantiateParticle), and likely indicates a programmer error in Arcs itself that we should know about (and which should bring down the process), rather than an error in the particle author's code. So I've removed it and replaced it with an exception.

Some of the error-handling logic surrounding this becomes simpler as a result.