### PR TITLE
recipe2plan: Ensuring Entities and References are wrapped with SingletonType

### DIFF
--- a/src/tools/plan-generator.ts
+++ b/src/tools/plan-generator.ts
@@ -157,17 +157,22 @@ export class PlanGenerator {
 
   /** Generates a Kotlin `core.arc.type.Type` from a Type. */
   async createType(type: Type): Promise<string> {
+    const initialType = await this.createNestedType(type);
+    return (type.isEntity || type.isReference) ?
+      ktUtils.applyFun('SingletonType', [initialType]) : initialType;
+  }
+  async createNestedType(type: Type) {
     switch (type.tag) {
       case 'Collection':
-        return ktUtils.applyFun('CollectionType', [await this.createType(type.getContainedType())]);
+        return ktUtils.applyFun('CollectionType', [await this.createNestedType(type.getContainedType())]);
       case 'Count':
-        return ktUtils.applyFun('CountType', [await this.createType(type.getContainedType())]);
+        return ktUtils.applyFun('CountType', [await this.createNestedType(type.getContainedType())]);
       case 'Entity':
         return ktUtils.applyFun('EntityType', [`${this.specRegistry[await type.getEntitySchema().hash()]}.SCHEMA`]);
       case 'Reference':
-        return ktUtils.applyFun('ReferenceType', [await this.createType(type.getContainedType())]);
+        return ktUtils.applyFun('ReferenceType', [await this.createNestedType(type.getContainedType())]);
       case 'Singleton':
-        return ktUtils.applyFun('SingletonType', [await this.createType(type.getContainedType())]);
+        return ktUtils.applyFun('SingletonType', [await this.createNestedType(type.getContainedType())]);
       case 'TypeVariable':
       case 'Arc':
       case 'BigCollection':

--- a/src/tools/tests/goldens/WriterReaderExample.kt
+++ b/src/tools/tests/goldens/WriterReaderExample.kt
@@ -19,7 +19,7 @@ object IngestionPlan : Plan(
                 "data" to HandleConnection(
                     CreateableStorageKey("my-handle-id"),
                     HandleMode.Read,
-                    EntityType(Reader_Data.SCHEMA),
+                    SingletonType(EntityType(Reader_Data.SCHEMA)),
                     Ttl.Days(20)
                 )
             )
@@ -31,7 +31,7 @@ object IngestionPlan : Plan(
                 "data" to HandleConnection(
                     CreateableStorageKey("my-handle-id"),
                     HandleMode.Write,
-                    EntityType(Writer_Data.SCHEMA),
+                    SingletonType(EntityType(Writer_Data.SCHEMA)),
                     Ttl.Days(20)
                 )
             )
@@ -50,7 +50,7 @@ object ConsumptionPlan : Plan(
                         "reference-mode://{db://25e71af4e9fc8b6958fc46a8f4b7cdf6b5f31516@arcs/Thing}{db://25e71af4e9fc8b6958fc46a8f4b7cdf6b5f31516@arcs/!:writingArcId/handle/my-handle-id}"
                     ),
                     HandleMode.Read,
-                    EntityType(Reader_Data.SCHEMA),
+                    SingletonType(EntityType(Reader_Data.SCHEMA)),
                     Ttl.Infinite
                 )
             )

--- a/src/tools/tests/plan-generator-tests.ts
+++ b/src/tools/tests/plan-generator-tests.ts
@@ -47,7 +47,7 @@ describe('recipe2plan', () => {
 
       assert.notInclude(actual, 'import arcs.core.data.*');
     });
-    it('creates valid types that refer to registered Schemas', async () => {
+    it('creates valid singleton entity types with schemas', async () => {
       const manifest = await Manifest.parse(`\
      particle A
        data: writes Thing {num: Number}
@@ -60,10 +60,14 @@ describe('recipe2plan', () => {
       await emptyGenerator.collectParticleConnectionSpecs(manifest.recipes[0].particles[0]);
       const actual = await emptyGenerator.createType(manifest.particles[0].handleConnections[0].type);
 
-      assert.include(actual, 'EntityType(A_Data.SCHEMA)');
-      assert.notInclude(actual, 'SingletonType');
+      assert.include(actual, 'A_Data.SCHEMA');
+      assert.include(actual, 'EntityType');
+      assert.notInclude(actual, 'ReferenceType');
+      assert.include(actual, 'SingletonType');
+      assert.notInclude(actual, 'CollectionType');
+      assert.isBelow(actual.indexOf('SingletonType'), actual.indexOf('EntityType'));
     });
-    it('creates valid types that are derived from other types (via nesting)', async () => {
+    it('creates valid collection entity types with schemas', async () => {
       const manifest = await Manifest.parse(`\
      particle A
        data: writes [Thing {num: Number}]
@@ -76,11 +80,14 @@ describe('recipe2plan', () => {
       await emptyGenerator.collectParticleConnectionSpecs(manifest.recipes[0].particles[0]);
       const actual = await emptyGenerator.createType(manifest.particles[0].handleConnections[0].type);
 
-      assert.include(actual, 'EntityType(A_Data.SCHEMA)');
+      assert.include(actual, 'A_Data.SCHEMA');
+      assert.include(actual, 'EntityType');
+      assert.notInclude(actual, 'ReferenceType');
       assert.notInclude(actual, 'SingletonType');
       assert.include(actual, 'CollectionType');
+      assert.isBelow(actual.indexOf('CollectionType'), actual.indexOf('EntityType'));
     });
-    it('creates valid types that are derived from a few other types (via lots of nesting)', async () => {
+    it('creates valid collection reference types with schemas', async () => {
       const manifest = await Manifest.parse(`\
      particle A
        data: writes [&Thing {num: Number}]
@@ -93,10 +100,12 @@ describe('recipe2plan', () => {
       await emptyGenerator.collectParticleConnectionSpecs(manifest.recipes[0].particles[0]);
       const actual = await emptyGenerator.createType(manifest.particles[0].handleConnections[0].type);
 
-      assert.include(actual, 'EntityType(A_Data.SCHEMA)');
+      assert.include(actual, 'A_Data.SCHEMA');
+      assert.include(actual, 'EntityType');
+      assert.include(actual, 'ReferenceType');
       assert.notInclude(actual, 'SingletonType');
       assert.include(actual, 'CollectionType');
-      assert.include(actual, 'ReferenceType');
+      assert.isBelow(actual.indexOf('CollectionType'), actual.indexOf('ReferenceType'));
     });
     it('can create Infinite Ttl objects', () => {
       const ttl = Ttl.infinite;


### PR DESCRIPTION
`EntityType` or `ReferenceType` should not be a "top-level" type; this PR provides a correction that wraps these types in a `SingletonType` (without having to modify manifest parsing). 

Collections already produce `CollectionType`s, so this case doesn't need to be treated differently. 

This PR also expands testing on Kotlin Type generation. 