### PR TITLE
Fix AppVeyor: disable problematic `npm list` command

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -21,6 +21,6 @@ build: off
 test_script:
   - node --version
   - npm --version
-  - npm list --depth=0
+  #- npm list --depth=0
   - tools\sigh test
   - npm run test-extension


### PR DESCRIPTION
Looks like the only reason AppVeyor was failing due to `npm list`, which apparently can have non-zero exit in some scenarios. Rather than chase that down, I simply disabled that command (it's not semantic, the list is for the log only).