### PR TITLE
Fixes BUILD dependencies

### DIFF
--- a/javatests/arcs/core/host/BUILD
+++ b/javatests/arcs/core/host/BUILD
@@ -25,6 +25,7 @@ arcs_kt_jvm_test_suite(
         "//java/arcs/core/storage/referencemode",
         "//java/arcs/jvm/host",
         "//java/arcs/jvm/util/testutil",
+        "//java/arcs/sdk:sdk-kt",
         "//third_party/java/junit:junit-android",
         "//third_party/java/truth:truth-android",
         "//third_party/kotlin/kotlinx_coroutines",


### PR DESCRIPTION
javatests/arcs/core/host/HandleAdapterTest.kt depends on combineUpdates