### PR TITLE
remove Time from Allocator ctor 

### DIFF
--- a/java/arcs/android/demo/DemoActivity.kt
+++ b/java/arcs/android/demo/DemoActivity.kt
@@ -19,7 +19,6 @@ import arcs.android.storage.handle.AndroidHandleManager
 import arcs.core.allocator.Allocator
 import arcs.core.host.HostRegistry
 import arcs.core.storage.handle.Stores
-import arcs.jvm.util.JvmTime
 import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -47,7 +46,6 @@ class DemoActivity : AppCompatActivity() {
             hostRegistry = AndroidManifestHostRegistry.create(this@DemoActivity)
             allocator = Allocator.create(
                 hostRegistry,
-                JvmTime,
                 AndroidHandleManager(
                     this@DemoActivity,
                     this@DemoActivity.getLifecycle(),

--- a/java/arcs/core/allocator/Allocator.kt
+++ b/java/arcs/core/allocator/Allocator.kt
@@ -37,7 +37,6 @@ import arcs.core.storage.handle.HandleManager
 import arcs.core.storage.keys.RamDiskStorageKey
 import arcs.core.storage.referencemode.ReferenceModeStorageKey
 import arcs.core.type.Type
-import arcs.core.util.Time
 import arcs.core.util.plus
 import arcs.core.util.traverse
 
@@ -64,7 +63,6 @@ fun fieldAsStrings(entity: RawEntity, field: String): List<String> {
  */
 class Allocator private constructor(
     private val hostRegistry: HostRegistry,
-    private val time: Time,
     private val collection: CollectionHandle<RawEntity>
 ) {
 
@@ -284,11 +282,10 @@ class Allocator private constructor(
 
         suspend fun create(
             hostRegistry: HostRegistry,
-            time: Time,
             handleManager: HandleManager
         ): Allocator {
             val collection = handleManager.rawEntityCollectionHandle(STORAGE_KEY, SCHEMA)
-            return Allocator(hostRegistry, time, collection)
+            return Allocator(hostRegistry, collection)
         }
     }
 }

--- a/javatests/arcs/core/allocator/AllocatorTestBase.kt
+++ b/javatests/arcs/core/allocator/AllocatorTestBase.kt
@@ -94,7 +94,7 @@ open class AllocatorTestBase {
         pureHost = pureHost()
 
         hostRegistry = hostRegistry()
-        allocator = Allocator.create(hostRegistry, TimeImpl(), HandleManager(TimeImpl()))
+        allocator = Allocator.create(hostRegistry, HandleManager(TimeImpl()))
 
         readPersonParticle =
             requireNotNull(PersonPlan.particles.find { it.particleName == "ReadPerson" }) {
@@ -454,7 +454,7 @@ open class AllocatorTestBase {
         assertThat(readingContext.arcState).isEqualTo(ArcState.Running)
         assertThat(writingContext.arcState).isEqualTo(ArcState.Running)
 
-        val allocator2 = Allocator.create(hostRegistry, TimeImpl(), HandleManager(TimeImpl()))
+        val allocator2 = Allocator.create(hostRegistry, HandleManager(TimeImpl()))
 
         allocator2.stopArc(arcId)
 


### PR DESCRIPTION
(followup for #4976 - `time` was needed earlier to create the handle, but now a `handleManager` is being passed instead)
