### PR TITLE
Bug fix for code gen and type equality for refinements

### DIFF
--- a/java/arcs/core/type/Type.kt
+++ b/java/arcs/core/type/Type.kt
@@ -37,7 +37,7 @@ interface Type {
     fun maybeEnsureResolved(): Boolean = true
 
     /** Checks whether or not this [Type] is at least as specific as the given [other] [Type]. */
-    fun isAtleastAsSpecificAs(other: Type): Boolean {
+    fun isAtLeastAsSpecificAs(other: Type): Boolean {
         if (tag != other.tag) return false
 
         // Throw if they are the same tag but the implementation class hasn't overridden this

--- a/src/runtime/interface-info-impl.ts
+++ b/src/runtime/interface-info-impl.ts
@@ -112,7 +112,7 @@ class InterfaceInfoImpl extends InterfaceInfo {
     return this._cloneAndUpdate(typeVar => typeVar.canWriteSuperset);
   }
 
-  isAtleastAsSpecificAs(other: InterfaceInfo) : boolean {
+  isAtLeastAsSpecificAs(other: InterfaceInfo) : boolean {
     if (this.handleConnections.length !== other.handleConnections.length ||
         this.slots.length !== other.slots.length) {
       return false;
@@ -121,7 +121,7 @@ class InterfaceInfoImpl extends InterfaceInfo {
     for (let i = 0; i < this.typeVars.length; i++) {
       const thisTypeVar = this.typeVars[i];
       const otherTypeVar = other.typeVars[i];
-      if (!thisTypeVar.object[thisTypeVar.field].isAtleastAsSpecificAs(
+      if (!thisTypeVar.object[thisTypeVar.field].isAtLeastAsSpecificAs(
               otherTypeVar.object[otherTypeVar.field])) {
         return false;
       }

--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -354,7 +354,7 @@ export class Manifest {
     if (checkSubtype) {
       const [left, right] = Type.unwrapPair(candidate.type, resolvedType);
       if (left instanceof EntityType && right instanceof EntityType) {
-        return left.entitySchema.isAtleastAsSpecificAs(right.entitySchema);
+        return left.entitySchema.isAtLeastAsSpecificAs(right.entitySchema);
       }
       return false;
     }

--- a/src/runtime/recipe/type-checker.ts
+++ b/src/runtime/recipe/type-checker.ts
@@ -49,9 +49,9 @@ export class TypeChecker {
       // This variable cannot be concretized without losing information.
       return candidate;
     }
-    if (candidate.canReadSubset.isAtleastAsSpecificAs(candidate.canWriteSuperset)) {
+    if (candidate.canReadSubset.isAtLeastAsSpecificAs(candidate.canWriteSuperset)) {
       // The resolution is still possible, but we may not have more information then the current candidate.
-      if (candidate.canWriteSuperset.isAtleastAsSpecificAs(candidate.canReadSubset)) {
+      if (candidate.canWriteSuperset.isAtLeastAsSpecificAs(candidate.canReadSubset)) {
         // The type bounds have 'met', they are equivalent and are the resolution.
         candidate.variable.resolution = candidate.canReadSubset;
       }
@@ -248,7 +248,7 @@ export class TypeChecker {
     if (writtenType == null || handleType.canReadSubset == null) {
       return true;
     }
-    if (writtenType.isAtleastAsSpecificAs(handleType.canReadSubset)) {
+    if (writtenType.isAtLeastAsSpecificAs(handleType.canReadSubset)) {
       return true;
     }
     return false;
@@ -262,7 +262,7 @@ export class TypeChecker {
     if (readType == null || handleType.canWriteSuperset == null) {
       return true;
     }
-    if (handleType.canWriteSuperset.isAtleastAsSpecificAs(readType)) {
+    if (handleType.canWriteSuperset.isAtLeastAsSpecificAs(readType)) {
       return true;
     }
     return false;
@@ -321,8 +321,8 @@ export class TypeChecker {
       return false;
     }
 
-    const leftIsSub = leftType.entitySchema.isAtleastAsSpecificAs(rightType.entitySchema);
-    const leftIsSuper = rightType.entitySchema.isAtleastAsSpecificAs(leftType.entitySchema);
+    const leftIsSub = leftType.entitySchema.isAtLeastAsSpecificAs(rightType.entitySchema);
+    const leftIsSuper = rightType.entitySchema.isAtLeastAsSpecificAs(leftType.entitySchema);
 
     if (leftIsSuper && leftIsSub) {
        return true;

--- a/src/runtime/refiner.ts
+++ b/src/runtime/refiner.ts
@@ -21,7 +21,7 @@ export enum Primitive {
   UNKNOWN = '~query_arg_type',
 }
 
-export enum AtleastAsSpecific {
+export enum AtLeastAsSpecific {
   YES,
   NO,
   UNKNOWN
@@ -122,7 +122,7 @@ export class Refinement {
   }
 
   // checks if a is at least as specific as b, returns null if can't be determined
-  static isAtleastAsSpecificAs(a: Refinement, b: Refinement): AtleastAsSpecific {
+  static isAtLeastAsSpecificAs(a: Refinement, b: Refinement): AtLeastAsSpecific {
     // Ensure there is a refinement to check with.
     a = a || new Refinement(new BooleanPrimitive(true));
     b = b || new Refinement(new BooleanPrimitive(true));
@@ -139,10 +139,10 @@ export class Refinement {
       // Find the range of values for the field name over which the refinement is valid.
       const rangeA = Range.fromExpression(a.expression, textToNum);
       const rangeB = Range.fromExpression(b.expression, textToNum);
-      return rangeA.isSubsetOf(rangeB) ? AtleastAsSpecific.YES : AtleastAsSpecific.NO;
+      return rangeA.isSubsetOf(rangeB) ? AtLeastAsSpecific.YES : AtLeastAsSpecific.NO;
     } catch (e) {
       console.warn(`Unable to ascertain if ${a} is at least as specific as ${b}.`);
-      return AtleastAsSpecific.UNKNOWN;
+      return AtLeastAsSpecific.UNKNOWN;
     }
   }
 

--- a/src/runtime/schema.ts
+++ b/src/runtime/schema.ts
@@ -154,10 +154,11 @@ export class Schema {
   }
 
   equals(otherSchema: Schema): boolean {
-    // TODO(cypher1): Check equality without calling contains.
-    return this === otherSchema || (this.name === otherSchema.name
-       && (this.isEquivalentOrMoreSpecific(otherSchema) === AtLeastAsSpecific.YES)
-       && (otherSchema.isEquivalentOrMoreSpecific(this) === AtLeastAsSpecific.YES));
+    if (this === otherSchema) {
+      return true;
+    }
+    return (this.isEquivalentOrMoreSpecific(otherSchema) === AtLeastAsSpecific.YES)
+       && (otherSchema.isEquivalentOrMoreSpecific(this) === AtLeastAsSpecific.YES);
   }
 
   isEquivalentOrMoreSpecific(otherSchema: Schema): AtLeastAsSpecific {

--- a/src/runtime/schema.ts
+++ b/src/runtime/schema.ts
@@ -197,7 +197,7 @@ export class Schema {
     return best;
   }
 
-  isAtleastAsSpecificAs(otherSchema: Schema): boolean {
+  isAtLeastAsSpecificAs(otherSchema: Schema): boolean {
     // Implementation moved to isEquivalentOrMoreSpecific to allow handling 'unknowns' in code gen.
     return this.isEquivalentOrMoreSpecific(otherSchema) !== AtLeastAsSpecific.NO;
   }

--- a/src/runtime/tests/schema-test.ts
+++ b/src/runtime/tests/schema-test.ts
@@ -599,7 +599,7 @@ describe('schema', () => {
     assert.deepEqual(intersection.fields, schema3.fields);
     assert.deepEqual(intersection.refinement, schema3.refinement);
   }));
-  it('tests schema.isAtleastAsSpecificAs, case 1', Flags.withFieldRefinementsAllowed(async () => {
+  it('tests schema.isAtLeastAsSpecificAs, case 1', Flags.withFieldRefinementsAllowed(async () => {
     const manifest = await Manifest.parse(`
       particle Foo
         schema1: reads X {a: Number [a > 20], b: Number, c: Number} [a + c > 10]
@@ -607,9 +607,9 @@ describe('schema', () => {
     `);
     const schema1 = getSchemaFromManifest(manifest, 'schema1');
     const schema2 = getSchemaFromManifest(manifest, 'schema2');
-    assert.isTrue(schema1.isAtleastAsSpecificAs(schema2));
+    assert.isTrue(schema1.isAtLeastAsSpecificAs(schema2));
   }));
-  it('tests schema.isAtleastAsSpecificAs, case 2', Flags.withFieldRefinementsAllowed(async () => {
+  it('tests schema.isAtLeastAsSpecificAs, case 2', Flags.withFieldRefinementsAllowed(async () => {
     const manifest = await Manifest.parse(`
       particle Foo
         schema1: reads X {a: Number [a > 20], b: Number, c: Number}
@@ -617,9 +617,9 @@ describe('schema', () => {
     `);
     const schema1 = getSchemaFromManifest(manifest, 'schema1');
     const schema2 = getSchemaFromManifest(manifest, 'schema2');
-    assert.isFalse(schema1.isAtleastAsSpecificAs(schema2));
+    assert.isFalse(schema1.isAtLeastAsSpecificAs(schema2));
   }));
-  it('tests schema.isAtleastAsSpecificAs, case 3', Flags.withFieldRefinementsAllowed(async () => {
+  it('tests schema.isAtLeastAsSpecificAs, case 3', Flags.withFieldRefinementsAllowed(async () => {
     const manifest = await Manifest.parse(`
       particle Foo
         schema1: reads X {a: Number [a > 20], b: Boolean [not b]} [a < 100]
@@ -627,9 +627,9 @@ describe('schema', () => {
     `);
     const schema1 = getSchemaFromManifest(manifest, 'schema1');
     const schema2 = getSchemaFromManifest(manifest, 'schema2');
-    assert.isTrue(schema1.isAtleastAsSpecificAs(schema2));
+    assert.isTrue(schema1.isAtLeastAsSpecificAs(schema2));
   }));
-  it('tests schema.isAtleastAsSpecificAs, case 4', Flags.withFieldRefinementsAllowed(async () => {
+  it('tests schema.isAtLeastAsSpecificAs, case 4', Flags.withFieldRefinementsAllowed(async () => {
     const manifest = await Manifest.parse(`
       particle Foo
         schema1: reads X {a: Number [a > 20], b: Boolean [not b]} [a < 100]
@@ -637,9 +637,9 @@ describe('schema', () => {
     `);
     const schema1 = getSchemaFromManifest(manifest, 'schema1');
     const schema2 = getSchemaFromManifest(manifest, 'schema2');
-    assert.isFalse(schema1.isAtleastAsSpecificAs(schema2));
+    assert.isFalse(schema1.isAtLeastAsSpecificAs(schema2));
   }));
-  it('tests schema.isAtleastAsSpecificAs, case 5', Flags.withFieldRefinementsAllowed(async () => {
+  it('tests schema.isAtLeastAsSpecificAs, case 5', Flags.withFieldRefinementsAllowed(async () => {
     const manifest = await Manifest.parse(`
       particle Foo
         schema1: reads X {a: Text [a == 'abc']}
@@ -647,9 +647,9 @@ describe('schema', () => {
     `);
     const schema1 = getSchemaFromManifest(manifest, 'schema1');
     const schema2 = getSchemaFromManifest(manifest, 'schema2');
-    assert.isTrue(schema1.isAtleastAsSpecificAs(schema2));
+    assert.isTrue(schema1.isAtLeastAsSpecificAs(schema2));
   }));
-  it('tests schema.isAtleastAsSpecificAs, case 6', async () => {
+  it('tests schema.isAtLeastAsSpecificAs, case 6', async () => {
     const manifest = await Manifest.parse(`
       particle Foo
         schema1: reads X {a: Text} [a == 'abc' or a == 'josh']
@@ -657,9 +657,9 @@ describe('schema', () => {
     `);
     const schema1 = getSchemaFromManifest(manifest, 'schema1');
     const schema2 = getSchemaFromManifest(manifest, 'schema2');
-    assert.isFalse(schema1.isAtleastAsSpecificAs(schema2));
+    assert.isFalse(schema1.isAtLeastAsSpecificAs(schema2));
   });
-  it('tests schema.isAtleastAsSpecificAs, case 7', async () => {
+  it('tests schema.isAtLeastAsSpecificAs, case 7', async () => {
     const manifest = await Manifest.parse(`
       particle Foo
         schema1: reads X {a: Text} [a != 'abc']
@@ -667,7 +667,7 @@ describe('schema', () => {
     `);
     const schema1 = getSchemaFromManifest(manifest, 'schema1');
     const schema2 = getSchemaFromManifest(manifest, 'schema2');
-    assert.isTrue(schema1.isAtleastAsSpecificAs(schema2));
+    assert.isTrue(schema1.isAtLeastAsSpecificAs(schema2));
   });
   it('tests warning when refinement specificity is unknown', async () => {
     const manifest = await Manifest.parse(`
@@ -677,7 +677,7 @@ describe('schema', () => {
     `);
     const schema1 = getSchemaFromManifest(manifest, 'schema1');
     const schema2 = getSchemaFromManifest(manifest, 'schema2');
-    const refWarning = ConCap.capture(() => assert.isTrue(schema1.isAtleastAsSpecificAs(schema2)));
+    const refWarning = ConCap.capture(() => assert.isTrue(schema1.isAtLeastAsSpecificAs(schema2)));
     assert.match(refWarning.warn[0], /Unable to ascertain if/);
   });
 });

--- a/src/runtime/type.ts
+++ b/src/runtime/type.ts
@@ -239,12 +239,12 @@ export abstract class Type {
     throw new Error(`canReadSubset not implemented for ${this}`);
   }
 
-  isAtleastAsSpecificAs(type: Type): boolean {
-    return this.tag === type.tag && this._isAtleastAsSpecificAs(type);
+  isAtLeastAsSpecificAs(type: Type): boolean {
+    return this.tag === type.tag && this._isAtLeastAsSpecificAs(type);
   }
 
-  protected _isAtleastAsSpecificAs(type: Type): boolean {
-    throw new Error(`isAtleastAsSpecificAs not implemented for ${this}`);
+  protected _isAtLeastAsSpecificAs(type: Type): boolean {
+    throw new Error(`isAtLeastAsSpecificAs not implemented for ${this}`);
   }
 
   /**
@@ -389,8 +389,8 @@ export class EntityType extends Type {
     return this;
   }
 
-  _isAtleastAsSpecificAs(type: EntityType): boolean {
-    return this.entitySchema.isAtleastAsSpecificAs(type.entitySchema);
+  _isAtLeastAsSpecificAs(type: EntityType): boolean {
+    return this.entitySchema.isAtLeastAsSpecificAs(type.entitySchema);
   }
 
   toLiteral(): TypeLiteral {
@@ -772,9 +772,9 @@ export class TupleType extends Type {
     return this.innerTypesSatisfy((type) => type.maybeEnsureResolved());
   }
 
-  _isAtleastAsSpecificAs(other: TupleType): boolean {
+  _isAtLeastAsSpecificAs(other: TupleType): boolean {
     if (this.innerTypes.length !== other.innerTypes.length) return false;
-    return this.innerTypesSatisfy((type, idx) => type.isAtleastAsSpecificAs(other.innerTypes[idx]));
+    return this.innerTypesSatisfy((type, idx) => type.isAtLeastAsSpecificAs(other.innerTypes[idx]));
   }
 
   private innerTypesSatisfy(predicate: ((type: Type, idx: number) => boolean)): boolean {
@@ -859,8 +859,8 @@ export class InterfaceType extends Type {
     return new InterfaceType(this.interfaceInfo.canReadSubset);
   }
 
-  _isAtleastAsSpecificAs(type: InterfaceType) {
-    return this.interfaceInfo.isAtleastAsSpecificAs(type.interfaceInfo);
+  _isAtLeastAsSpecificAs(type: InterfaceType) {
+    return this.interfaceInfo.isAtLeastAsSpecificAs(type.interfaceInfo);
   }
 
   _clone(variableMap: Map<string, Type>) {
@@ -910,7 +910,7 @@ export class SlotType extends Type {
     return this;
   }
 
-  _isAtleastAsSpecificAs(type: SlotType) {
+  _isAtLeastAsSpecificAs(type: SlotType) {
     // TODO: formFactor checking, etc.
     return true;
   }
@@ -1214,7 +1214,7 @@ export class TypeVariableInfo {
     if (!(constraint instanceof EntityType) || !(type instanceof EntityType)) {
       throw new Error(`constraint checking not implemented for ${this} and ${type}`);
     }
-    return type.getEntitySchema().isAtleastAsSpecificAs(constraint.getEntitySchema());
+    return type.getEntitySchema().isAtLeastAsSpecificAs(constraint.getEntitySchema());
   }
 
   get resolution(): Type|null {
@@ -1402,7 +1402,7 @@ export abstract class InterfaceInfo {
 
   abstract readonly  canWriteSuperset : InterfaceInfo;
 
-  abstract isAtleastAsSpecificAs(other: InterfaceInfo) : boolean;
+  abstract isAtLeastAsSpecificAs(other: InterfaceInfo) : boolean;
 
   abstract _applyExistenceTypeTest(test: Predicate<TypeVarReference>) : boolean;
 

--- a/src/tools/schema2graph.ts
+++ b/src/tools/schema2graph.ts
@@ -83,6 +83,9 @@ export class SchemaGraph {
       for (const previous of this.nodes) {
         for (const [a, b] of [[node, previous], [previous, node]]) {
           if (b.schema.isEquivalentOrMoreSpecific(a.schema) === AtLeastAsSpecific.YES) {
+            if (b.descendants.has(a)) {
+              throw new Error(`Cannot add ${b} to ${a}.descendants as it would create a cycle.`);
+            }
             a.descendants.add(b);  // b can be sliced to a
             b.parents = [];        // non-null to indicate this has parents; will be filled later
           }
@@ -94,7 +97,7 @@ export class SchemaGraph {
     // Recurse on any nested schemas in reference-typed fields. We need to do this even if we've
     // seen this schema before, to ensure any nested schemas end up aliased appropriately.
     for (const [field, descriptor] of Object.entries(schema.fields)) {
-      let nestedSchema;
+      let nestedSchema: Schema | undefined;
       if (descriptor.kind === 'schema-reference') {
         nestedSchema = descriptor.schema.model.entitySchema;
       } else if (descriptor.kind === 'schema-collection' && descriptor.schema.kind === 'schema-reference') {

--- a/src/tools/schema2graph.ts
+++ b/src/tools/schema2graph.ts
@@ -10,6 +10,7 @@
 import {Schema} from '../runtime/schema.js';
 import {ParticleSpec} from '../runtime/particle-spec.js';
 import {upperFirst} from './kotlin-generation-utils.js';
+import {AtLeastAsSpecific} from '../runtime/refiner.js';
 
 export class SchemaNode {
   schema: Schema;
@@ -81,7 +82,7 @@ export class SchemaGraph {
       node = new SchemaNode(schema, name);
       for (const previous of this.nodes) {
         for (const [a, b] of [[node, previous], [previous, node]]) {
-          if (b.schema.isAtleastAsSpecificAs(a.schema)) {
+          if (b.schema.isEquivalentOrMoreSpecific(a.schema) === AtLeastAsSpecific.YES) {
             a.descendants.add(b);  // b can be sliced to a
             b.parents = [];        // non-null to indicate this has parents; will be filled later
           }

--- a/src/tools/schema2kotlin.ts
+++ b/src/tools/schema2kotlin.ts
@@ -419,7 +419,7 @@ ${this.opts.wasm ? `
         override fun deserialize(data: RawEntity) = ${name}().apply { deserialize(data) }` : `
         override fun decode(encoded: ByteArray): ${name}? {
             if (encoded.isEmpty()) return null
-    
+
             val decoder = StringDecoder(encoded)
             val entityId = decoder.decodeText()
             decoder.validate("|")

--- a/src/tools/tests/golden.arcs
+++ b/src/tools/tests/golden.arcs
@@ -6,6 +6,9 @@ meta
 particle Gold
   data: reads {num: Number, txt: Text, lnk: URL, flg: Boolean, ref: &{val: Text}}
 
+  // Same as qCollection but without refinement + query (to ensure that types with refinements generated properly using their base class.
+  allPeople: reads [People {name: Text, age: Number, lastCall: Number, address: Text, favoriteColor: Text, birthDayMonth: Number, birthDayDOM: Number}]
+
   // These are People that have a lastCall value less than three (24 hour) days ago
   // lastCall represents the time since last phone call to/from this contact (in seconds)
   qCollection: reads [People {name: Text, age: Number, lastCall: Number, address: Text, favoriteColor: Text, birthDayMonth: Number, birthDayDOM: Number}[lastCall < 3*24*60*60 and name == ?]]

--- a/src/tools/tests/goldens/generated-schemas.h
+++ b/src/tools/tests/goldens/generated-schemas.h
@@ -151,6 +151,271 @@ struct std::hash<arcs::GoldInternal1> {
 
 namespace arcs::golden {
 
+class Gold_AllPeople {
+public:
+  // Entities must be copied with arcs::clone_entity(), which will exclude the internal id.
+  // Move operations are ok (and will include the internal id).
+  Gold_AllPeople() = default;
+  Gold_AllPeople(Gold_AllPeople&&) = default;
+  Gold_AllPeople& operator=(Gold_AllPeople&&) = default;
+
+  template<typename T>
+  Gold_AllPeople(const T& other) :
+    name_(other.name()), name_valid_(other.has_name()),
+    age_(other.age()), age_valid_(other.has_age()),
+    lastCall_(other.lastCall()), lastCall_valid_(other.has_lastCall()),
+    address_(other.address()), address_valid_(other.has_address()),
+    favoriteColor_(other.favoriteColor()), favoriteColor_valid_(other.has_favoriteColor()),
+    birthDayMonth_(other.birthDayMonth()), birthDayMonth_valid_(other.has_birthDayMonth()),
+    birthDayDOM_(other.birthDayDOM()), birthDayDOM_valid_(other.has_birthDayDOM())
+  {}
+
+  const std::string& name() const { return name_; }
+  void set_name(const std::string& value) { name_ = value; name_valid_ = true; }
+
+  double age() const { return age_; }
+  void set_age(double value) { age_ = value; age_valid_ = true; }
+
+  double lastCall() const { return lastCall_; }
+  void set_lastCall(double value) { lastCall_ = value; lastCall_valid_ = true; }
+
+  const std::string& address() const { return address_; }
+  void set_address(const std::string& value) { address_ = value; address_valid_ = true; }
+
+  const std::string& favoriteColor() const { return favoriteColor_; }
+  void set_favoriteColor(const std::string& value) { favoriteColor_ = value; favoriteColor_valid_ = true; }
+
+  double birthDayMonth() const { return birthDayMonth_; }
+  void set_birthDayMonth(double value) { birthDayMonth_ = value; birthDayMonth_valid_ = true; }
+
+  double birthDayDOM() const { return birthDayDOM_; }
+  void set_birthDayDOM(double value) { birthDayDOM_ = value; birthDayDOM_valid_ = true; }
+
+  // Equality ops compare internal ids and all data fields.
+  // Use arcs::fields_equal() to compare only the data fields.
+  bool operator==(const Gold_AllPeople& other) const;
+  bool operator!=(const Gold_AllPeople& other) const { return !(*this == other); }
+
+  // For STL containers.
+  friend bool operator<(const Gold_AllPeople& a, const Gold_AllPeople& b) {
+    if (int cmp = a._internal_id_.compare(b._internal_id_)) {
+      return cmp < 0;
+    }
+    if (0) {
+    } else if (int cmp = a.name_.compare(b.name_)) {
+      return cmp < 0;
+    }
+    if (0) {
+    } else if (a.age_ != b.age_) {
+      return a.age_ < b.age_;
+    }
+    if (0) {
+    } else if (a.lastCall_ != b.lastCall_) {
+      return a.lastCall_ < b.lastCall_;
+    }
+    if (0) {
+    } else if (int cmp = a.address_.compare(b.address_)) {
+      return cmp < 0;
+    }
+    if (0) {
+    } else if (int cmp = a.favoriteColor_.compare(b.favoriteColor_)) {
+      return cmp < 0;
+    }
+    if (0) {
+    } else if (a.birthDayMonth_ != b.birthDayMonth_) {
+      return a.birthDayMonth_ < b.birthDayMonth_;
+    }
+    if (0) {
+    } else if (a.birthDayDOM_ != b.birthDayDOM_) {
+      return a.birthDayDOM_ < b.birthDayDOM_;
+    }
+    return false;
+  }
+
+protected:
+  // Allow private copying for use in Handles.
+  Gold_AllPeople(const Gold_AllPeople&) = default;
+  Gold_AllPeople& operator=(const Gold_AllPeople&) = default;
+
+  static const char* _schema_hash() { return "ccd14452cc01e1b00b94cdb25bfe34a5a632daaa"; }
+  static const int _field_count = 7;
+
+  std::string name_ = "";
+  bool name_valid_ = false;
+
+  double age_ = 0;
+  bool age_valid_ = false;
+
+  double lastCall_ = 0;
+  bool lastCall_valid_ = false;
+
+  std::string address_ = "";
+  bool address_valid_ = false;
+
+  std::string favoriteColor_ = "";
+  bool favoriteColor_valid_ = false;
+
+  double birthDayMonth_ = 0;
+  bool birthDayMonth_valid_ = false;
+
+  double birthDayDOM_ = 0;
+  bool birthDayDOM_valid_ = false;
+
+  std::string _internal_id_;
+
+  friend class Singleton<Gold_AllPeople>;
+  friend class Collection<Gold_AllPeople>;
+  friend class Ref<Gold_AllPeople>;
+  friend class internal::Accessor;
+};
+
+template<>
+inline Gold_AllPeople internal::Accessor::clone_entity(const Gold_AllPeople& entity) {
+  Gold_AllPeople clone;
+  clone.name_ = entity.name_;
+  clone.name_valid_ = entity.name_valid_;
+  clone.age_ = entity.age_;
+  clone.age_valid_ = entity.age_valid_;
+  clone.lastCall_ = entity.lastCall_;
+  clone.lastCall_valid_ = entity.lastCall_valid_;
+  clone.address_ = entity.address_;
+  clone.address_valid_ = entity.address_valid_;
+  clone.favoriteColor_ = entity.favoriteColor_;
+  clone.favoriteColor_valid_ = entity.favoriteColor_valid_;
+  clone.birthDayMonth_ = entity.birthDayMonth_;
+  clone.birthDayMonth_valid_ = entity.birthDayMonth_valid_;
+  clone.birthDayDOM_ = entity.birthDayDOM_;
+  clone.birthDayDOM_valid_ = entity.birthDayDOM_valid_;
+  return clone;
+}
+
+template<>
+inline size_t internal::Accessor::hash_entity(const Gold_AllPeople& entity) {
+  size_t h = 0;
+  internal::hash_combine(h, entity._internal_id_);
+  internal::hash_combine(h, entity.name_);
+  internal::hash_combine(h, entity.age_);
+  internal::hash_combine(h, entity.lastCall_);
+  internal::hash_combine(h, entity.address_);
+  internal::hash_combine(h, entity.favoriteColor_);
+  internal::hash_combine(h, entity.birthDayMonth_);
+  internal::hash_combine(h, entity.birthDayDOM_);
+  return h;
+}
+
+template<>
+inline bool internal::Accessor::fields_equal(const Gold_AllPeople& a, const Gold_AllPeople& b) {
+  return (a.name_ == b.name_) &&
+         (a.age_ == b.age_) &&
+         (a.lastCall_ == b.lastCall_) &&
+         (a.address_ == b.address_) &&
+         (a.favoriteColor_ == b.favoriteColor_) &&
+         (a.birthDayMonth_ == b.birthDayMonth_) &&
+         (a.birthDayDOM_ == b.birthDayDOM_);
+}
+
+inline bool Gold_AllPeople::operator==(const Gold_AllPeople& other) const {
+  return _internal_id_ == other._internal_id_ && fields_equal(*this, other);
+}
+
+template<>
+inline std::string internal::Accessor::entity_to_str(const Gold_AllPeople& entity, const char* join, bool with_id) {
+  internal::StringPrinter printer;
+  if (with_id) {
+    printer.addId(entity._internal_id_);
+  }
+  if (entity.name_valid_) printer.add("name: ", entity.name_);
+  if (entity.age_valid_) printer.add("age: ", entity.age_);
+  if (entity.lastCall_valid_) printer.add("lastCall: ", entity.lastCall_);
+  if (entity.address_valid_) printer.add("address: ", entity.address_);
+  if (entity.favoriteColor_valid_) printer.add("favoriteColor: ", entity.favoriteColor_);
+  if (entity.birthDayMonth_valid_) printer.add("birthDayMonth: ", entity.birthDayMonth_);
+  if (entity.birthDayDOM_valid_) printer.add("birthDayDOM: ", entity.birthDayDOM_);
+  return printer.result(join);
+}
+
+template<>
+inline void internal::Accessor::decode_entity(Gold_AllPeople* entity, const char* str) {
+  if (str == nullptr) return;
+  internal::StringDecoder decoder(str);
+  decoder.decode(entity->_internal_id_);
+  decoder.validate("|");
+  for (int i = 0; !decoder.done() && i < Gold_AllPeople::_field_count; i++) {
+    std::string name = decoder.upTo(':');
+    if (0) {
+    } else if (name == "name") {
+      decoder.validate("T");
+      decoder.decode(entity->name_);
+      entity->name_valid_ = true;
+    } else if (name == "age") {
+      decoder.validate("N");
+      decoder.decode(entity->age_);
+      entity->age_valid_ = true;
+    } else if (name == "lastCall") {
+      decoder.validate("N");
+      decoder.decode(entity->lastCall_);
+      entity->lastCall_valid_ = true;
+    } else if (name == "address") {
+      decoder.validate("T");
+      decoder.decode(entity->address_);
+      entity->address_valid_ = true;
+    } else if (name == "favoriteColor") {
+      decoder.validate("T");
+      decoder.decode(entity->favoriteColor_);
+      entity->favoriteColor_valid_ = true;
+    } else if (name == "birthDayMonth") {
+      decoder.validate("N");
+      decoder.decode(entity->birthDayMonth_);
+      entity->birthDayMonth_valid_ = true;
+    } else if (name == "birthDayDOM") {
+      decoder.validate("N");
+      decoder.decode(entity->birthDayDOM_);
+      entity->birthDayDOM_valid_ = true;
+    } else {
+      // Ignore unknown fields until type slicing is fully implemented.
+      std::string typeChar = decoder.chomp(1);
+      if (typeChar == "T" || typeChar == "U") {
+        std::string s;
+        decoder.decode(s);
+      } else if (typeChar == "N") {
+        double d;
+        decoder.decode(d);
+      } else if (typeChar == "B") {
+        bool b;
+        decoder.decode(b);
+      }
+      i--;
+    }
+    decoder.validate("|");
+  }
+}
+
+template<>
+inline std::string internal::Accessor::encode_entity(const Gold_AllPeople& entity) {
+  internal::StringEncoder encoder;
+  encoder.encode("", entity._internal_id_);
+  encoder.encode("name:T", entity.name_);
+  encoder.encode("age:N", entity.age_);
+  encoder.encode("lastCall:N", entity.lastCall_);
+  encoder.encode("address:T", entity.address_);
+  encoder.encode("favoriteColor:T", entity.favoriteColor_);
+  encoder.encode("birthDayMonth:N", entity.birthDayMonth_);
+  encoder.encode("birthDayDOM:N", entity.birthDayDOM_);
+  return encoder.result();
+}
+
+}  // namespace arcs::golden
+
+// For STL unordered associative containers. Entities will need to be std::move()-inserted.
+template<>
+struct std::hash<arcs::Gold_AllPeople> {
+  size_t operator()(const arcs::Gold_AllPeople& entity) const {
+    return arcs::hash_entity(entity);
+  }
+};
+
+namespace arcs::golden {
+
 class Gold_QCollection {
 public:
   // Entities must be copied with arcs::clone_entity(), which will exclude the internal id.
@@ -779,6 +1044,7 @@ struct std::hash<arcs::Gold_Data> {
 class AbstractGold : public arcs::Particle {
 protected:
   arcs::Singleton<arcs::Gold_Data> data_{this, "data"};
+  arcs::Collection<arcs::Gold_AllPeople> allPeople_{this, "allPeople"};
   arcs::Collection<arcs::Gold_QCollection> qCollection_{this, "qCollection"};
   arcs::Singleton<arcs::Gold_Alias> alias_{this, "alias"};
   arcs::Collection<arcs::Gold_Collection> collection_{this, "collection"};

--- a/src/tools/tests/goldens/generated-schemas.jvm.kt
+++ b/src/tools/tests/goldens/generated-schemas.jvm.kt
@@ -121,7 +121,7 @@ class Gold_AllPeople(
     companion object : EntitySpec<Gold_AllPeople> {
 
         override val SCHEMA = Schema(
-            listOf(SchemaName("People")),
+            setOf(SchemaName("People")),
             SchemaFields(
                 singletons = mapOf(
                     "name" to FieldType.Text,
@@ -143,7 +143,6 @@ class Gold_AllPeople(
             SchemaRegistry.register(this)
         }
 
-        // TODO: only handles singletons for now
         override fun deserialize(data: RawEntity) = Gold_AllPeople().apply { deserialize(data) }
     }
 }
@@ -353,6 +352,8 @@ class Gold_Data(
     }
 }
 
+
+
 abstract class AbstractGold : BaseParticle() {
     override val handles: Handles = Handles()
 
@@ -360,12 +361,14 @@ abstract class AbstractGold : BaseParticle() {
         "Gold",
         mapOf(
             "data" to Gold_Data,
+            "allPeople" to Gold_AllPeople,
             "qCollection" to Gold_QCollection,
             "alias" to Gold_Alias,
             "collection" to Gold_Collection
         )
     ) {
         val data: ReadSingletonHandle<Gold_Data> by handles
+        val allPeople: ReadCollectionHandle<Gold_AllPeople> by handles
         val qCollection: ReadQueryCollectionHandle<Gold_QCollection, String> by handles
         val alias: WriteSingletonHandle<Gold_Alias> by handles
         val collection: ReadCollectionHandle<Gold_Collection> by handles

--- a/src/tools/tests/goldens/generated-schemas.jvm.kt
+++ b/src/tools/tests/goldens/generated-schemas.jvm.kt
@@ -57,6 +57,99 @@ typealias Gold_Data_Ref = GoldInternal1
 typealias Gold_Alias = GoldInternal1
 
 @Suppress("UNCHECKED_CAST")
+class Gold_AllPeople(
+    name: String = "",
+    age: Double = 0.0,
+    lastCall: Double = 0.0,
+    address: String = "",
+    favoriteColor: String = "",
+    birthDayMonth: Double = 0.0,
+    birthDayDOM: Double = 0.0
+) : EntityBase("Gold_AllPeople", SCHEMA) {
+
+    var name: String
+        get() = super.getSingletonValue("name") as String? ?: ""
+        private set(_value) = super.setSingletonValue("name", _value)
+    var age: Double
+        get() = super.getSingletonValue("age") as Double? ?: 0.0
+        private set(_value) = super.setSingletonValue("age", _value)
+    var lastCall: Double
+        get() = super.getSingletonValue("lastCall") as Double? ?: 0.0
+        private set(_value) = super.setSingletonValue("lastCall", _value)
+    var address: String
+        get() = super.getSingletonValue("address") as String? ?: ""
+        private set(_value) = super.setSingletonValue("address", _value)
+    var favoriteColor: String
+        get() = super.getSingletonValue("favoriteColor") as String? ?: ""
+        private set(_value) = super.setSingletonValue("favoriteColor", _value)
+    var birthDayMonth: Double
+        get() = super.getSingletonValue("birthDayMonth") as Double? ?: 0.0
+        private set(_value) = super.setSingletonValue("birthDayMonth", _value)
+    var birthDayDOM: Double
+        get() = super.getSingletonValue("birthDayDOM") as Double? ?: 0.0
+        private set(_value) = super.setSingletonValue("birthDayDOM", _value)
+
+    init {
+        this.name = name
+        this.age = age
+        this.lastCall = lastCall
+        this.address = address
+        this.favoriteColor = favoriteColor
+        this.birthDayMonth = birthDayMonth
+        this.birthDayDOM = birthDayDOM
+    }
+
+    fun copy(
+        name: String = this.name,
+        age: Double = this.age,
+        lastCall: Double = this.lastCall,
+        address: String = this.address,
+        favoriteColor: String = this.favoriteColor,
+        birthDayMonth: Double = this.birthDayMonth,
+        birthDayDOM: Double = this.birthDayDOM
+    ) = Gold_AllPeople(
+        name = name,
+        age = age,
+        lastCall = lastCall,
+        address = address,
+        favoriteColor = favoriteColor,
+        birthDayMonth = birthDayMonth,
+        birthDayDOM = birthDayDOM
+    )
+
+
+    companion object : EntitySpec<Gold_AllPeople> {
+
+        override val SCHEMA = Schema(
+            listOf(SchemaName("People")),
+            SchemaFields(
+                singletons = mapOf(
+                    "name" to FieldType.Text,
+                    "age" to FieldType.Number,
+                    "lastCall" to FieldType.Number,
+                    "address" to FieldType.Text,
+                    "favoriteColor" to FieldType.Text,
+                    "birthDayMonth" to FieldType.Number,
+                    "birthDayDOM" to FieldType.Number
+                ),
+                collections = emptyMap()
+            ),
+            "ccd14452cc01e1b00b94cdb25bfe34a5a632daaa",
+            refinement = { _ -> true },
+            query = null
+        )
+
+        init {
+            SchemaRegistry.register(this)
+        }
+
+        // TODO: only handles singletons for now
+        override fun deserialize(data: RawEntity) = Gold_AllPeople().apply { deserialize(data) }
+    }
+}
+
+
+@Suppress("UNCHECKED_CAST")
 class Gold_QCollection(
     name: String = "",
     age: Double = 0.0,
@@ -259,8 +352,6 @@ class Gold_Data(
         override fun deserialize(data: RawEntity) = Gold_Data().apply { deserialize(data) }
     }
 }
-
-
 
 abstract class AbstractGold : BaseParticle() {
     override val handles: Handles = Handles()

--- a/src/tools/tests/goldens/generated-schemas.wasm.kt
+++ b/src/tools/tests/goldens/generated-schemas.wasm.kt
@@ -84,6 +84,180 @@ typealias Gold_Data_Ref = GoldInternal1
 typealias Gold_Alias = GoldInternal1
 
 @Suppress("UNCHECKED_CAST")
+class Gold_AllPeople(
+    name: String = "",
+    age: Double = 0.0,
+    lastCall: Double = 0.0,
+    address: String = "",
+    favoriteColor: String = "",
+    birthDayMonth: Double = 0.0,
+    birthDayDOM: Double = 0.0
+) : WasmEntity {
+
+    var name = name
+        get() = field
+        private set(_value) {
+            field = _value
+        }
+    var age = age
+        get() = field
+        private set(_value) {
+            field = _value
+        }
+    var lastCall = lastCall
+        get() = field
+        private set(_value) {
+            field = _value
+        }
+    var address = address
+        get() = field
+        private set(_value) {
+            field = _value
+        }
+    var favoriteColor = favoriteColor
+        get() = field
+        private set(_value) {
+            field = _value
+        }
+    var birthDayMonth = birthDayMonth
+        get() = field
+        private set(_value) {
+            field = _value
+        }
+    var birthDayDOM = birthDayDOM
+        get() = field
+        private set(_value) {
+            field = _value
+        }
+
+    override var entityId = ""
+
+    fun copy(
+        name: String = this.name,
+        age: Double = this.age,
+        lastCall: Double = this.lastCall,
+        address: String = this.address,
+        favoriteColor: String = this.favoriteColor,
+        birthDayMonth: Double = this.birthDayMonth,
+        birthDayDOM: Double = this.birthDayDOM
+    ) = Gold_AllPeople(
+        name = name,
+        age = age,
+        lastCall = lastCall,
+        address = address,
+        favoriteColor = favoriteColor,
+        birthDayMonth = birthDayMonth,
+        birthDayDOM = birthDayDOM
+    )
+
+
+    fun reset() {
+      name = ""
+        age = 0.0
+        lastCall = 0.0
+        address = ""
+        favoriteColor = ""
+        birthDayMonth = 0.0
+        birthDayDOM = 0.0
+    }
+
+    override fun encodeEntity(): NullTermByteArray {
+        val encoder = StringEncoder()
+        encoder.encode("", entityId)
+        name.let { encoder.encode("name:T", name) }
+        age.let { encoder.encode("age:N", age) }
+        lastCall.let { encoder.encode("lastCall:N", lastCall) }
+        address.let { encoder.encode("address:T", address) }
+        favoriteColor.let { encoder.encode("favoriteColor:T", favoriteColor) }
+        birthDayMonth.let { encoder.encode("birthDayMonth:N", birthDayMonth) }
+        birthDayDOM.let { encoder.encode("birthDayDOM:N", birthDayDOM) }
+        return encoder.toNullTermByteArray()
+    }
+
+    override fun toString() =
+        "Gold_AllPeople(name = $name, age = $age, lastCall = $lastCall, address = $address, favoriteColor = $favoriteColor, birthDayMonth = $birthDayMonth, birthDayDOM = $birthDayDOM)"
+
+    companion object : WasmEntitySpec<Gold_AllPeople> {
+
+
+        override fun decode(encoded: ByteArray): Gold_AllPeople? {
+            if (encoded.isEmpty()) return null
+
+            val decoder = StringDecoder(encoded)
+            val entityId = decoder.decodeText()
+            decoder.validate("|")
+
+            var name = ""
+            var age = 0.0
+            var lastCall = 0.0
+            var address = ""
+            var favoriteColor = ""
+            var birthDayMonth = 0.0
+            var birthDayDOM = 0.0
+            var i = 0
+            while (i < 7 && !decoder.done()) {
+                val _name = decoder.upTo(':').toUtf8String()
+                when (_name) {
+                    "name" -> {
+                        decoder.validate("T")
+                        name = decoder.decodeText()
+                    }
+                    "age" -> {
+                        decoder.validate("N")
+                        age = decoder.decodeNum()
+                    }
+                    "lastCall" -> {
+                        decoder.validate("N")
+                        lastCall = decoder.decodeNum()
+                    }
+                    "address" -> {
+                        decoder.validate("T")
+                        address = decoder.decodeText()
+                    }
+                    "favoriteColor" -> {
+                        decoder.validate("T")
+                        favoriteColor = decoder.decodeText()
+                    }
+                    "birthDayMonth" -> {
+                        decoder.validate("N")
+                        birthDayMonth = decoder.decodeNum()
+                    }
+                    "birthDayDOM" -> {
+                        decoder.validate("N")
+                        birthDayDOM = decoder.decodeNum()
+                    }
+                    else -> {
+                        // Ignore unknown fields until type slicing is fully implemented.
+                        when (decoder.chomp(1).toUtf8String()) {
+                            "T", "U" -> decoder.decodeText()
+                            "N" -> decoder.decodeNum()
+                            "B" -> decoder.decodeBool()
+                        }
+                        i--
+                    }
+                }
+                decoder.validate("|")
+                i++
+            }
+            val _rtn = Gold_AllPeople().copy(
+
+            name = name,
+            age = age,
+            lastCall = lastCall,
+            address = address,
+            favoriteColor = favoriteColor,
+            birthDayMonth = birthDayMonth,
+            birthDayDOM = birthDayDOM
+
+            )
+            _rtn.entityId = entityId
+            return _rtn
+        }
+    }
+}
+
+
+@Suppress("UNCHECKED_CAST")
 class Gold_QCollection(
     name: String = "",
     age: Double = 0.0,
@@ -441,7 +615,6 @@ class Gold_Data(
         }
     }
 }
-
 
 
 abstract class AbstractGold : WasmParticleImpl() {

--- a/src/tools/tests/goldens/generated-schemas.wasm.kt
+++ b/src/tools/tests/goldens/generated-schemas.wasm.kt
@@ -617,6 +617,7 @@ class Gold_Data(
 }
 
 
+
 abstract class AbstractGold : WasmParticleImpl() {
     val handles: Handles = Handles(this)
 
@@ -624,6 +625,7 @@ abstract class AbstractGold : WasmParticleImpl() {
         particle: WasmParticleImpl
     ) {
         val data: WasmSingletonImpl<Gold_Data> = WasmSingletonImpl(particle, "data", Gold_Data)
+        val allPeople: WasmCollectionImpl<Gold_AllPeople> = WasmCollectionImpl(particle, "allPeople", Gold_AllPeople)
         val qCollection: WasmCollectionImpl<Gold_QCollection> = WasmCollectionImpl(particle, "qCollection", Gold_QCollection)
         val alias: WasmSingletonImpl<Gold_Alias> = WasmSingletonImpl(particle, "alias", Gold_Alias)
         val collection: WasmCollectionImpl<Gold_Collection> = WasmCollectionImpl(particle, "collection", Gold_Collection)

--- a/src/tools/tests/goldens/generated-test-harness.kt
+++ b/src/tools/tests/goldens/generated-test-harness.kt
@@ -16,11 +16,13 @@ class GoldTestHarness<P : AbstractGold>(
     factory : (CoroutineScope) -> P
 ) : BaseTestHarness<P>(factory, listOf(
     HandleDescriptor("data", Gold_Data, HandleFlavor.SINGLETON),
+    HandleDescriptor("allPeople", Gold_AllPeople, HandleFlavor.COLLECTION),
     HandleDescriptor("qCollection", Gold_QCollection, HandleFlavor.COLLECTION),
     HandleDescriptor("alias", Gold_Alias, HandleFlavor.SINGLETON),
     HandleDescriptor("collection", Gold_Collection, HandleFlavor.COLLECTION)
 )) {
     val data: ReadWriteSingletonHandle<Gold_Data> by handleMap
+    val allPeople: ReadWriteCollectionHandle<Gold_AllPeople> by handleMap
     val qCollection: ReadWriteCollectionHandle<Gold_QCollection> by handleMap
     val alias: ReadWriteSingletonHandle<Gold_Alias> by handleMap
     val collection: ReadWriteCollectionHandle<Gold_Collection> by handleMap


### PR DESCRIPTION
Fixes schema 2 graph modeling of type equality. 

`[{field: Type}[f(field)]]` being considered eq to
`[{field: Type}[g(field)]]` where `f` and `g` can't be rewritten to one another.