### PR TITLE
Adds a specification test for generated entities.

### DIFF
--- a/javatests/arcs/sdk/spec/BUILD
+++ b/javatests/arcs/sdk/spec/BUILD
@@ -10,8 +10,8 @@ TEST_SRCS = glob(["*Test.kt"])
 
 arcs_kt_jvm_test_suite(
     name = "spec",
-    package = "arcs.sdk.spec",
     srcs = TEST_SRCS,
+    package = "arcs.sdk.spec",
     deps = [
         ":schemas",
         ":schemas_test_harness",

--- a/javatests/arcs/sdk/spec/BUILD
+++ b/javatests/arcs/sdk/spec/BUILD
@@ -1,0 +1,29 @@
+load(
+    "//third_party/java/arcs/build_defs:build_defs.bzl",
+    "arcs_kt_jvm_test_suite",
+    "arcs_kt_schema",
+)
+
+licenses(["notice"])
+
+TEST_SRCS = glob(["*Test.kt"])
+
+arcs_kt_jvm_test_suite(
+    name = "spec",
+    package = "arcs.sdk.spec",
+    srcs = TEST_SRCS,
+    deps = [
+        ":schemas",
+        ":schemas_test_harness",
+        "//java/arcs/sdk",
+        "//third_party/java/junit:junit-android",
+        "//third_party/java/truth:truth-android",
+        "//third_party/kotlin/kotlinx_coroutines",
+        "//third_party/kotlin/kotlinx_coroutines:kotlinx_coroutines_test",
+    ],
+)
+
+arcs_kt_schema(
+    name = "schemas",
+    srcs = glob(["*.arcs"]),
+)

--- a/javatests/arcs/sdk/spec/BUILD
+++ b/javatests/arcs/sdk/spec/BUILD
@@ -15,6 +15,7 @@ arcs_kt_jvm_test_suite(
     deps = [
         ":schemas",
         ":schemas_test_harness",
+        "//java/arcs/core/common",
         "//java/arcs/sdk",
         "//third_party/java/junit:junit-android",
         "//third_party/java/truth:truth-android",

--- a/javatests/arcs/sdk/spec/EntitySpecTest.kt
+++ b/javatests/arcs/sdk/spec/EntitySpecTest.kt
@@ -89,20 +89,28 @@ class EntitySpecTest {
             text = "abc",
             ref = ref1
         )
-        entity.identify()
 
-        val entityCopy = entity.copy(
+        // Copying an unidentified entity should give an exact copy of the entity.
+        assertThat(entity.copy()).isEqualTo(entity)
+
+        // Copying an identified entity should reset the ID.
+        entity.identify()
+        val copy1 = entity.copy()
+        assertThat(copy1.entityId).isNull()
+        assertThat(copy1).isNotEqualTo(entity)
+
+        // Copying an entity with replacement fields should overwrite those fields in the copy.
+        val copy2 = entity.copy(
             bool = false,
             num = 456.0,
             text = "xyz",
             ref = ref2
         )
-
-        assertThat(entityCopy.entityId).isNull()
-        assertThat(entityCopy.bool).isFalse()
-        assertThat(entityCopy.num).isEqualTo(456.0)
-        assertThat(entityCopy.text).isEqualTo("xyz")
-        assertThat(entityCopy.ref).isEqualTo(ref2)
+        assertThat(copy2.entityId).isNull()
+        assertThat(copy2.bool).isFalse()
+        assertThat(copy2.num).isEqualTo(456.0)
+        assertThat(copy2.text).isEqualTo("xyz")
+        assertThat(copy2.ref).isEqualTo(ref2)
     }
 
     @Test

--- a/javatests/arcs/sdk/spec/EntitySpecTest.kt
+++ b/javatests/arcs/sdk/spec/EntitySpecTest.kt
@@ -1,0 +1,161 @@
+package arcs.sdk.spec
+
+import arcs.core.common.Id
+import arcs.core.data.RawEntity
+import arcs.core.data.RawEntity.Companion.NO_REFERENCE_ID
+import arcs.core.data.util.toReferencable
+import arcs.core.entity.SchemaRegistry
+import arcs.sdk.Reference
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+private typealias Foo = EntitySpecParticle_Foo
+private typealias Bar = EntitySpecParticle_Bars
+
+/** Specification tests for entities. */
+@ExperimentalCoroutinesApi
+@RunWith(JUnit4::class)
+class EntitySpecTest {
+
+    class EntitySpecParticle : AbstractEntitySpecParticle()
+
+    private lateinit var idGenerator: Id.Generator
+
+    @get:Rule
+    val harness = EntitySpecParticleTestHarness { EntitySpecParticle() }
+
+    @Before
+    fun setUp() = runBlockingTest {
+        idGenerator = Id.Generator.newForTest("session")
+        harness.start()
+    }
+
+    @Test
+    fun createEmptyInstance() {
+        val entity = Foo()
+        assertThat(entity.bool).isFalse()
+        assertThat(entity.num).isEqualTo(0.0)
+        assertThat(entity.text).isEqualTo("")
+        assertThat(entity.ref).isNull()
+    }
+
+    @Test
+    fun createWithFieldValues() = runBlockingTest {
+        val dummyRef = createBarReference(Bar(value = "dummy"))
+        val entity = Foo(
+            bool = true,
+            num = 123.0,
+            text = "abc",
+            ref = dummyRef
+        )
+        assertThat(entity.bool).isEqualTo(true)
+        assertThat(entity.num).isEqualTo(123.0)
+        assertThat(entity.text).isEqualTo("abc")
+        assertThat(entity.ref).isEqualTo(dummyRef)
+    }
+
+    @Test
+    fun ensureIdentified() {
+        val entity = Foo()
+        assertThat(entity.entityId).isNull()
+
+        entity.ensureIdentified(idGenerator, "handle")
+        val entityId = entity.entityId
+
+        // Check that the entity ID has been set to *something*.
+        assertThat(entityId).isNotNull()
+        assertThat(entityId).isNotEmpty()
+        assertThat(entityId).isNotEqualTo(NO_REFERENCE_ID)
+        assertThat(entityId).contains("handle")
+
+        // Calling it again doesn't overwrite it.
+        entity.ensureIdentified(idGenerator, "something-else")
+        assertThat(entity.entityId).isEqualTo(entityId)
+    }
+
+    @Test
+    fun copy() = runBlockingTest {
+        val ref1 = createBarReference(Bar(value = "bar1"))
+        val ref2 = createBarReference(Bar(value = "bar2"))
+        val entity = Foo(
+            bool = true,
+            num = 123.0,
+            text = "abc",
+            ref = ref1
+        )
+        entity.identify()
+
+        val entityCopy = entity.copy(
+            bool = false,
+            num = 456.0,
+            text = "xyz",
+            ref = ref2
+        )
+
+        assertThat(entityCopy.entityId).isNull()
+        assertThat(entityCopy.bool).isFalse()
+        assertThat(entityCopy.num).isEqualTo(456.0)
+        assertThat(entityCopy.text).isEqualTo("xyz")
+        assertThat(entityCopy.ref).isEqualTo(ref2)
+    }
+
+    @Test
+    fun serialize_roundTrip() = runBlockingTest {
+        val dummyRef = createBarReference(Bar(value = "dummy"))
+        val entity = Foo(
+            bool = true,
+            num = 123.0,
+            text = "abc",
+            ref = dummyRef
+        )
+        val entityId = entity.identify()
+
+        val rawEntity = entity.serialize()
+
+        assertThat(rawEntity).isEqualTo(
+            RawEntity(
+                entityId,
+                singletons = mapOf(
+                    "bool" to true.toReferencable(),
+                    "num" to 123.0.toReferencable(),
+                    "text" to "abc".toReferencable(),
+                    "ref" to dummyRef.toReferencable()
+                ),
+                collections = emptyMap()
+            )
+        )
+        assertThat(Foo.deserialize(rawEntity)).isEqualTo(entity)
+    }
+
+    @Test
+    fun schemaRegistry() {
+        // The entity class should have registered itself statically.
+        val hash = Foo.SCHEMA.hash
+        assertThat(SchemaRegistry.getEntitySpec(hash)).isEqualTo(Foo)
+        assertThat(SchemaRegistry.getSchema(hash)).isEqualTo(Foo.SCHEMA)
+    }
+
+    /**
+     * Stores the given [Bar] entity in a collection, and then creates and returns a reference to
+     * it.
+     */
+    private suspend fun createBarReference(bar: Bar): Reference<Bar> {
+        val handle = harness.particle.handles.bars
+        handle.store(bar)
+        return handle.createReference(bar)
+    }
+
+    /** Generates and returns an ID for the entity. */
+    private fun (Foo).identify(): String {
+        assertThat(entityId).isNull()
+        ensureIdentified(idGenerator, "handleName")
+        assertThat(entityId).isNotNull()
+        return entityId!!
+    }
+}

--- a/javatests/arcs/sdk/spec/entity.arcs
+++ b/javatests/arcs/sdk/spec/entity.arcs
@@ -1,0 +1,25 @@
+meta
+  namespace: arcs.sdk.spec
+
+schema Bar
+  value: Text
+
+schema Foo
+  text: Text
+  num: Number
+  bool: Boolean
+  ref: &Bar
+
+  // TODO: Primitive collections
+  // texts: [Text]
+  // nums: [Number]
+  // bools: [Boolean]
+
+  // TODO: Collections of references.
+  refs: [&Bar]
+
+particle EntitySpecParticle
+  foo: writes Foo {text, num, bool, ref}
+
+  // Used to obtain references to Bar entities.
+  bars: reads writes [Bar {value}]

--- a/src/tools/schema2kotlin.ts
+++ b/src/tools/schema2kotlin.ts
@@ -405,7 +405,6 @@ ${this.opts.wasm ? `
             SchemaRegistry.register(this)
         }`}
         ${!this.opts.wasm ? `
-        // TODO: only handles singletons for now
         override fun deserialize(data: RawEntity) = ${name}().apply { deserialize(data) }` : `
         override fun decode(encoded: ByteArray): ${name}? {
             if (encoded.isEmpty()) return null

--- a/src/tools/tests/goldens/generated-schemas.jvm.kt
+++ b/src/tools/tests/goldens/generated-schemas.jvm.kt
@@ -49,7 +49,6 @@ class GoldInternal1(
             SchemaRegistry.register(this)
         }
 
-        // TODO: only handles singletons for now
         override fun deserialize(data: RawEntity) = GoldInternal1().apply { deserialize(data) }
     }
 }
@@ -149,7 +148,6 @@ class Gold_QCollection(
             SchemaRegistry.register(this)
         }
 
-        // TODO: only handles singletons for now
         override fun deserialize(data: RawEntity) = Gold_QCollection().apply { deserialize(data) }
     }
 }
@@ -188,7 +186,6 @@ class Gold_Collection(
             SchemaRegistry.register(this)
         }
 
-        // TODO: only handles singletons for now
         override fun deserialize(data: RawEntity) = Gold_Collection().apply { deserialize(data) }
     }
 }
@@ -259,7 +256,6 @@ class Gold_Data(
             SchemaRegistry.register(this)
         }
 
-        // TODO: only handles singletons for now
         override fun deserialize(data: RawEntity) = Gold_Data().apply { deserialize(data) }
     }
 }


### PR DESCRIPTION
This test serves as a contract for the code generated Entity classes. It's purpose is to document the API of the generated classes, to document whether a given feature has been implemented (eventually, for now there is only the one test file), and to ensure that the generated code doesn't change without intention.

I'm hoping that others will add more specification tests for their own features as time goes on.

I'll figure out what's going on with collections and add those in a later PR. They don't seem to work properly.