### PR TITLE
Silence some kt warnings

### DIFF
--- a/java/arcs/android/demo/DemoService.kt
+++ b/java/arcs/android/demo/DemoService.kt
@@ -95,7 +95,7 @@ class DemoService : Service() {
 
     inner class WritePerson : AbstractWritePerson() {
 
-        override suspend fun onHandleSync(handle: Handle, allSync: Boolean) {
+        override suspend fun onHandleSync(handle: Handle, allSynced: Boolean) {
             handles.person.store(WritePerson_Person("John Wick"))
         }
     }

--- a/java/arcs/android/sdk/host/IntentArcHostAdapter.kt
+++ b/java/arcs/android/sdk/host/IntentArcHostAdapter.kt
@@ -74,7 +74,7 @@ class IntentArcHostAdapter(
         sender(intent)
     }
 
-    @UseExperimental(ExperimentalCoroutinesApi::class)
+    @OptIn(ExperimentalCoroutinesApi::class)
     class ResultReceiverContinuation<T>(
         val continuation: CancellableContinuation<T?>,
         val block: (Any?) -> T?

--- a/java/arcs/android/storage/handle/AndroidHandleManager.kt
+++ b/java/arcs/android/storage/handle/AndroidHandleManager.kt
@@ -25,7 +25,7 @@ import kotlin.coroutines.EmptyCoroutineContext
  * [ActivationFactory] with one that generates [ServiceStore] instances that can
  * communication with a running [StorageService].
  */
-@UseExperimental(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
 fun AndroidHandleManager(
     context: Context,
     lifecycle: Lifecycle,

--- a/java/arcs/sdk/android/storage/ServiceStore.kt
+++ b/java/arcs/sdk/android/storage/ServiceStore.kt
@@ -54,7 +54,7 @@ import kotlinx.coroutines.launch
  * [ServiceStore].
  */
 @ExperimentalCoroutinesApi
-@UseExperimental(FlowPreview::class)
+@OptIn(FlowPreview::class)
 class ServiceStoreFactory(
     private val context: Context,
     private val lifecycle: Lifecycle,
@@ -85,7 +85,7 @@ class ServiceStoreFactory(
 }
 
 /** Implementation of [ActiveStore] which pipes [ProxyMessage]s to and from the [StorageService]. */
-@UseExperimental(FlowPreview::class)
+@OptIn(FlowPreview::class)
 @ExperimentalCoroutinesApi
 class ServiceStore<Data : CrdtData, Op : CrdtOperation, ConsumerData>(
     private val options: StoreOptions<Data, Op, ConsumerData>,

--- a/java/arcs/sdk/android/storage/service/StorageServiceConnection.kt
+++ b/java/arcs/sdk/android/storage/service/StorageServiceConnection.kt
@@ -112,7 +112,7 @@ class StorageServiceManagerBindingDelegate(
 }
 
 /** Object capable of managing a connection to the [StorageService]. */
-@UseExperimental(ExperimentalCoroutinesApi::class)
+@OptIn(ExperimentalCoroutinesApi::class)
 class StorageServiceConnection(
     /**
      * Delegate which is responsible for actually initiating and tearing-down a binding to the

--- a/java/arcs/sdk/android/storage/service/testutil/TestConnectionFactory.kt
+++ b/java/arcs/sdk/android/storage/service/testutil/TestConnectionFactory.kt
@@ -24,7 +24,7 @@ import org.robolectric.Robolectric
  * instances.
  */
 @Suppress("EXPERIMENTAL_IS_NOT_ENABLED")
-@UseExperimental(ExperimentalCoroutinesApi::class)
+@OptIn(ExperimentalCoroutinesApi::class)
 fun TestConnectionFactory(ctx: Context) = DefaultConnectionFactory(ctx, TestBindingDelegate(ctx))
 
 /**

--- a/java/arcs/sdk/testing/BaseTestHarness.kt
+++ b/java/arcs/sdk/testing/BaseTestHarness.kt
@@ -69,6 +69,7 @@ open class BaseTestHarness<P : Particle>(
         val flavor: HandleFlavor
     )
 
+    @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
     private val scope = TestCoroutineScope()
     private val handles = mutableMapOf<String, Handle>()
 

--- a/javatests/arcs/android/host/AndroidAllocatorTest.kt
+++ b/javatests/arcs/android/host/AndroidAllocatorTest.kt
@@ -36,7 +36,7 @@ import org.robolectric.Robolectric
  *
  */
 @RunWith(AndroidJUnit4::class)
-@UseExperimental(ExperimentalCoroutinesApi::class)
+@OptIn(ExperimentalCoroutinesApi::class)
 open class AndroidAllocatorTest : AllocatorTestBase() {
 
     protected lateinit var context: Context

--- a/javatests/arcs/android/host/AndroidAllocatorWithSqliteTest.kt
+++ b/javatests/arcs/android/host/AndroidAllocatorWithSqliteTest.kt
@@ -29,7 +29,7 @@ import org.junit.runner.RunWith
  */
 @Ignore("2% Flaky (runs_per_test=100) on TAP, disabled for now.")
 @RunWith(AndroidJUnit4::class)
-@UseExperimental(ExperimentalCoroutinesApi::class)
+@OptIn(ExperimentalCoroutinesApi::class)
 class AndroidAllocatorWithSqliteTest : AndroidAllocatorTest() {
 
     override val storageCapability = Capabilities.Persistent

--- a/javatests/arcs/android/host/AndroidHostRegistryTest.kt
+++ b/javatests/arcs/android/host/AndroidHostRegistryTest.kt
@@ -26,7 +26,7 @@ import org.junit.runner.RunWith
 import org.robolectric.Robolectric
 
 @RunWith(AndroidJUnit4::class)
-@UseExperimental(ExperimentalCoroutinesApi::class)
+@OptIn(ExperimentalCoroutinesApi::class)
 class AndroidHostRegistryTest {
     private lateinit var context: Context
     private lateinit var service: TestReadingExternalHostService

--- a/javatests/arcs/android/host/ArcHostHelperTest.kt
+++ b/javatests/arcs/android/host/ArcHostHelperTest.kt
@@ -48,7 +48,7 @@ import org.robolectric.Robolectric
 import kotlin.coroutines.experimental.suspendCoroutine
 
 @RunWith(AndroidJUnit4::class)
-@UseExperimental(ExperimentalCoroutinesApi::class)
+@OptIn(ExperimentalCoroutinesApi::class)
 class ArcHostHelperTest {
     private lateinit var context: Context
     private lateinit var helper: ArcHostHelper

--- a/javatests/arcs/android/storage/ReferenceModeStoreDatabaseImplIntegrationTest.kt
+++ b/javatests/arcs/android/storage/ReferenceModeStoreDatabaseImplIntegrationTest.kt
@@ -56,7 +56,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 @Suppress("UNCHECKED_CAST", "EXPERIMENTAL_IS_NOT_ENABLED")
-@UseExperimental(ExperimentalCoroutinesApi::class)
+@OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(AndroidJUnit4::class)
 class ReferenceModeStoreDatabaseImplIntegrationTest {
     @get:Rule

--- a/javatests/arcs/android/storage/service/BindingContextTest.kt
+++ b/javatests/arcs/android/storage/service/BindingContextTest.kt
@@ -46,7 +46,7 @@ import org.junit.runner.RunWith
 
 /** Tests for [BindingContext]. */
 @RunWith(AndroidJUnit4::class)
-@UseExperimental(ExperimentalCoroutinesApi::class, FlowPreview::class)
+@OptIn(ExperimentalCoroutinesApi::class, FlowPreview::class)
 class BindingContextTest {
     private lateinit var store: Store<CrdtCount.Data, CrdtCount.Operation, Int>
     private lateinit var storageKey: StorageKey

--- a/javatests/arcs/android/storage/service/DeferredResultTest.kt
+++ b/javatests/arcs/android/storage/service/DeferredResultTest.kt
@@ -25,7 +25,7 @@ import org.junit.runner.RunWith
 
 /** Tests for [DeferredResult]. */
 @RunWith(AndroidJUnit4::class)
-@UseExperimental(ExperimentalCoroutinesApi::class)
+@OptIn(ExperimentalCoroutinesApi::class)
 class DeferredResultTest {
     @Test
     fun test_nullException_resolvesToTrue() = runBlockingTest {

--- a/javatests/arcs/core/allocator/AllocatorTestBase.kt
+++ b/javatests/arcs/core/allocator/AllocatorTestBase.kt
@@ -38,7 +38,7 @@ import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
 
 @RunWith(JUnit4::class)
-@UseExperimental(ExperimentalCoroutinesApi::class)
+@OptIn(ExperimentalCoroutinesApi::class)
 open class AllocatorTestBase {
     /**
      * Recipe hand translated from 'person.arcs'

--- a/javatests/arcs/core/allocator/CoreAllocatorTest.kt
+++ b/javatests/arcs/core/allocator/CoreAllocatorTest.kt
@@ -8,5 +8,5 @@ import org.junit.runners.JUnit4
  * Tests run on JVM.
  */
 @RunWith(JUnit4::class)
-@UseExperimental(ExperimentalCoroutinesApi::class)
+@OptIn(ExperimentalCoroutinesApi::class)
 open class CoreAllocatorTest : AllocatorTestBase()

--- a/javatests/arcs/core/entity/ReferenceTest.kt
+++ b/javatests/arcs/core/entity/ReferenceTest.kt
@@ -24,7 +24,7 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 @RunWith(JUnit4::class)
-@UseExperimental(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
 @Suppress("UNCHECKED_CAST")
 class ReferenceTest {
     private val dereferencer = RawEntityDereferencer(DummyEntity.SCHEMA)

--- a/javatests/arcs/core/host/HandleAdapterTest.kt
+++ b/javatests/arcs/core/host/HandleAdapterTest.kt
@@ -38,7 +38,7 @@ import org.junit.runners.JUnit4
 private typealias Person = ReadPerson_Person
 
 @RunWith(JUnit4::class)
-@UseExperimental(ExperimentalCoroutinesApi::class)
+@OptIn(ExperimentalCoroutinesApi::class)
 @Suppress("UNCHECKED_CAST")
 class HandleAdapterTest {
     private lateinit var manager: EntityHandleManager

--- a/javatests/arcs/core/host/ParticleRegistrationTest.kt
+++ b/javatests/arcs/core/host/ParticleRegistrationTest.kt
@@ -10,7 +10,7 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 @RunWith(JUnit4::class)
-@UseExperimental(ExperimentalCoroutinesApi::class)
+@OptIn(ExperimentalCoroutinesApi::class)
 class ParticleRegistrationTest {
     @Test
     fun explicit_allParticlesAreRegistered() = runBlockingTest {

--- a/javatests/arcs/core/storage/ReferenceModeStoreDatabaseIntegrationTest.kt
+++ b/javatests/arcs/core/storage/ReferenceModeStoreDatabaseIntegrationTest.kt
@@ -46,7 +46,7 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 @Suppress("UNCHECKED_CAST")
-@UseExperimental(ExperimentalCoroutinesApi::class)
+@OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(JUnit4::class)
 class ReferenceModeStoreDatabaseIntegrationTest {
     @get:Rule

--- a/javatests/arcs/core/storage/handle/BUILD
+++ b/javatests/arcs/core/storage/handle/BUILD
@@ -41,6 +41,7 @@ arcs_kt_android_test_suite(
         "//java/arcs/core/data",
         "//java/arcs/core/data:rawentity",
         "//java/arcs/core/data/util:data-util",
+        "//java/arcs/core/entity",
         "//java/arcs/core/storage",
         "//java/arcs/core/storage/driver",
         "//java/arcs/core/storage/handle",

--- a/javatests/arcs/core/storage/handle/CollectionIntegrationTest.kt
+++ b/javatests/arcs/core/storage/handle/CollectionIntegrationTest.kt
@@ -22,6 +22,7 @@ import arcs.core.data.SchemaName
 import arcs.core.data.Ttl
 import arcs.core.data.util.ReferencablePrimitive
 import arcs.core.data.util.toReferencable
+import arcs.core.entity.toPrimitiveValue
 import arcs.core.storage.CapabilitiesResolver
 import arcs.core.storage.StorageMode
 import arcs.core.storage.StorageProxy
@@ -245,10 +246,10 @@ class CollectionIntegrationTest {
         )
 
         private val refinementAgeGtZero = { value: RawEntity ->
-            (value.singletons["age"] as ReferencablePrimitive<Double>?)!!.value > 0
+            value.singletons["age"].toPrimitiveValue(Double::class, 0.0) > 0
         }
         private val queryByAge = { value: RawEntity, args: Any ->
-            value.singletons["age"] == (args as Double).toReferencable()
+            value.singletons["age"].toPrimitiveValue(Double::class, 0.0) == (args as Double)
         }
 
         private val SCHEMA_A = Schema(

--- a/javatests/arcs/sdk/HandleUtilsTest.kt
+++ b/javatests/arcs/sdk/HandleUtilsTest.kt
@@ -35,7 +35,7 @@ import org.junit.runners.JUnit4
 private typealias Person = ReadSdkPerson_Person
 
 @RunWith(JUnit4::class)
-@UseExperimental(ExperimentalCoroutinesApi::class)
+@OptIn(ExperimentalCoroutinesApi::class)
 @Suppress("UNCHECKED_CAST")
 class HandleUtilsTest {
   private lateinit var manager: EntityHandleManager

--- a/javatests/arcs/sdk/android/storage/ServiceStoreTest.kt
+++ b/javatests/arcs/sdk/android/storage/ServiceStoreTest.kt
@@ -44,7 +44,7 @@ import org.junit.runner.RunWith
 
 /** Unit-Tests for the [ServiceStore]. */
 @RunWith(AndroidJUnit4::class)
-@UseExperimental(ExperimentalCoroutinesApi::class)
+@OptIn(ExperimentalCoroutinesApi::class)
 class ServiceStoreTest {
     private lateinit var lifecycle: Lifecycle
     private val storeOptions = StoreOptions<CrdtCount.Data, CrdtCount.Operation, Int>(

--- a/javatests/arcs/sdk/android/storage/service/StorageServiceConnectionTest.kt
+++ b/javatests/arcs/sdk/android/storage/service/StorageServiceConnectionTest.kt
@@ -39,7 +39,7 @@ import org.junit.runner.RunWith
 
 /** Tests for [StorageServiceConnection]. */
 @RunWith(AndroidJUnit4::class)
-@UseExperimental(ExperimentalCoroutinesApi::class)
+@OptIn(ExperimentalCoroutinesApi::class)
 class StorageServiceConnectionTest {
     private lateinit var delegateMock: StorageServiceBindingDelegate
     private lateinit var serviceMock: IStorageService


### PR DESCRIPTION
Bazel produces a lot of text while compiling Kotlin, there were a few low hanging fruit to pick off.