### PR TITLE
Add an [Outcome] class to capture results of analysis.

### DIFF
--- a/java/arcs/core/analysis/BUILD
+++ b/java/arcs/core/analysis/BUILD
@@ -1,0 +1,20 @@
+load(
+    "//third_party/java/arcs/build_defs:build_defs.bzl",
+    "arcs_kt_library",
+)
+
+licenses(["notice"])
+
+package(default_visibility = ["//visibility:public"])
+
+arcs_kt_library(
+    name = "analysis",
+    srcs = glob(
+        ["*.kt"],
+    ),
+    deps = [
+        "//java/arcs/core/data",
+        "//java/arcs/core/type",
+        "//java/arcs/core/util",
+    ],
+)

--- a/java/arcs/core/analysis/Outcome.kt
+++ b/java/arcs/core/analysis/Outcome.kt
@@ -11,7 +11,7 @@
 
 package arcs.core.analysis
 
-/** A simple sealed class that captures the outcome af an analysis. */
+/** A simple sealed class that captures the outcome of an analysis. */
 sealed class Outcome<T>() {
     /** Wraps the result of a successful operation. */
     class Success<T>(val value: T) : Outcome<T>()

--- a/java/arcs/core/analysis/Outcome.kt
+++ b/java/arcs/core/analysis/Outcome.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.core.analysis
+
+/** A simple sealed class that captures the outcome af an analysis. */
+sealed class Outcome<T>() {
+    /** Wraps the result of a successful operation. */
+    class Success<T>(val value: T) : Outcome<T>()
+
+    /** Wraps the reason for the failure of an operation. */
+    class Failure<T>(val reason: String) : Outcome<T>()
+
+    /** Returns the wrapped value on success. Otherwise, result of applying [onFailure]. */
+    inline fun getOrElse(onFailure: (reason: String) -> T): T = when (this) {
+        is Outcome.Success -> value
+        is Outcome.Failure -> onFailure(reason)
+    }
+
+    /** Returns the wrapped value on success. Otherwise, returns null. */
+    fun getOrNull(): T? = when (this) {
+        is Outcome.Success -> value
+        is Outcome.Failure -> null
+    }
+
+    /** Returns the reason if [this] is [Outcome.Failure]. Otherwise returns null. */
+    fun getFailureReason(): String? = when (this) {
+        is Outcome.Success -> null
+        is Outcome.Failure -> reason
+    }
+}
+
+/** A helper extension to wrap a value of type [T] in an [Outcome<T>.Success]. */
+fun <T> T.toSuccess(): Outcome<T> = Outcome.Success(this)

--- a/javatests/arcs/core/analysis/BUILD
+++ b/javatests/arcs/core/analysis/BUILD
@@ -1,0 +1,28 @@
+load(
+    "//third_party/java/arcs/build_defs:build_defs.bzl",
+    "arcs_kt_jvm_test_suite",
+)
+
+licenses(["notice"])
+
+package(default_visibility = ["//visibility:public"])
+
+arcs_kt_jvm_test_suite(
+    name = "analysis",
+    data = ["//java/arcs/core/data/testdata:examples"],
+    package = "arcs.core.analysis",
+    deps = [
+        "//java/arcs/core/analysis",
+        "//java/arcs/core/data",
+        "//java/arcs/core/data/proto:proto_for_test",
+        "//java/arcs/core/data/proto:recipe_java_proto",
+        "//java/arcs/core/storage",
+        "//java/arcs/core/storage/keys",
+        "//java/arcs/core/testutil",
+        "//java/arcs/core/util",
+        "//java/arcs/repoutils",
+        "//third_party/java/arcs/deps:protobuf_java",
+        "//third_party/java/junit:junit-android",
+        "//third_party/java/truth:truth-android",
+    ],
+)

--- a/javatests/arcs/core/analysis/OutcomeTest.kt
+++ b/javatests/arcs/core/analysis/OutcomeTest.kt
@@ -1,0 +1,41 @@
+package arcs.core.analysis
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.fail
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+/** Tests for [Outcome]. */
+@RunWith(JUnit4::class)
+class OutcomeTest {
+    val success = Outcome.Success<Int>(10)
+    val failure = Outcome.Failure<Int>("Failure Example")
+
+    @Test
+    fun failureReasonTests() {
+        assertNull(success.getFailureReason())
+        assertThat(failure.getFailureReason()).contains("Failure Example")
+    }
+
+    @Test
+    fun getOrElseTests() {
+        assertThat(success.getOrElse { 20 }).isEqualTo(10)
+        assertThat(failure.getOrElse { 20 }).isEqualTo(20)
+    }
+
+    @Test
+    fun getOrNullTests() {
+        assertThat(success.getOrNull()).isEqualTo(10)
+        assertNull(failure.getOrNull())
+    }
+
+    @Test
+    fun toSuccessTests() {
+        val success = (42).toSuccess()
+        assertThat(success.getOrNull()).isEqualTo(42)
+    }
+}

--- a/javatests/arcs/core/analysis/OutcomeTest.kt
+++ b/javatests/arcs/core/analysis/OutcomeTest.kt
@@ -1,8 +1,6 @@
 package arcs.core.analysis
 
 import com.google.common.truth.Truth.assertThat
-import org.junit.Assert.assertNull
-import org.junit.Assert.assertNotNull
 import org.junit.Assert.fail
 import org.junit.Before
 import org.junit.Test
@@ -12,30 +10,26 @@ import org.junit.runners.JUnit4
 /** Tests for [Outcome]. */
 @RunWith(JUnit4::class)
 class OutcomeTest {
-    val success = Outcome.Success<Int>(10)
-    val failure = Outcome.Failure<Int>("Failure Example")
-
     @Test
     fun failureReasonTests() {
-        assertNull(success.getFailureReason())
-        assertThat(failure.getFailureReason()).contains("Failure Example")
+        assertThat(Outcome.Success<Int>(10).getFailureReason()).isNull()
+        assertThat(Outcome.Failure<Int>("Failed!").getFailureReason()).contains("Failed!")
     }
 
     @Test
     fun getOrElseTests() {
-        assertThat(success.getOrElse { 20 }).isEqualTo(10)
-        assertThat(failure.getOrElse { 20 }).isEqualTo(20)
+        assertThat(Outcome.Success<Int>(10).getOrElse { 20 }).isEqualTo(10)
+        assertThat(Outcome.Failure<Int>("Failed!").getOrElse { 20 }).isEqualTo(20)
     }
 
     @Test
     fun getOrNullTests() {
-        assertThat(success.getOrNull()).isEqualTo(10)
-        assertNull(failure.getOrNull())
+        assertThat(Outcome.Success<Int>(10).getOrNull()).isEqualTo(10)
+        assertThat(Outcome.Failure<Int>("Failed!").getOrNull()).isNull()
     }
 
     @Test
     fun toSuccessTests() {
-        val success = (42).toSuccess()
-        assertThat(success.getOrNull()).isEqualTo(42)
+        assertThat(42.toSuccess().getOrNull()).isEqualTo(42)
     }
 }


### PR DESCRIPTION
A light-weight class that will be used to capture the outcome of analysis (like type inference/dataflow analysis). The existing `arcs.core.util.Result` requires us to use exceptions to indicate error, which is an overkill for what we want.

For example usage, see https://github.com/PolymerLabs/arcs/pull/5029/commits/d20f5dd2b129a59121f051329f886cf4bf5de5d7#diff-7764e1b235321c657f96dd66de43ba39