### PR TITLE
Change `Schema.name` field to hold a set.

### DIFF
--- a/java/arcs/android/storage/database/DatabaseImpl.kt
+++ b/java/arcs/android/storage/database/DatabaseImpl.kt
@@ -745,7 +745,7 @@ class DatabaseImpl(
                 // TODO: keep track of and return the actual schema type.
                 val eType: Type = EntityType(
                     Schema(
-                        listOf<SchemaName>(),
+                        setOf<SchemaName>(),
                         SchemaFields(emptyMap(), emptyMap()),
                         ""
                     )

--- a/java/arcs/android/type/ParcelableSchema.kt
+++ b/java/arcs/android/type/ParcelableSchema.kt
@@ -33,6 +33,7 @@ data class ParcelableSchema(val actual: Schema) : Parcelable {
             val names = mutableListOf<String>()
                 .also { parcel.readStringList(it) }
                 .map { SchemaName(it) }
+                .toSet()
 
             val fields = requireNotNull(parcel.readSchemaFields()) {
                 "No SchemaFields found in Parcel"

--- a/java/arcs/core/allocator/Allocator.kt
+++ b/java/arcs/core/allocator/Allocator.kt
@@ -265,7 +265,7 @@ class Allocator private constructor(
     companion object {
         /** Schema for persistent storage of [PlanPartition] information */
         private val SCHEMA = Schema(
-            listOf(SchemaName("partition")),
+            setOf(SchemaName("partition")),
             SchemaFields(
                 mapOf(
                     "arc" to FieldType.Text,

--- a/java/arcs/core/data/Schema.kt
+++ b/java/arcs/core/data/Schema.kt
@@ -22,7 +22,7 @@ typealias Refinement = (data: RawEntity) -> Boolean
 typealias Query = (data: RawEntity, queryArgs: Any) -> Boolean
 
 data class Schema(
-    val names: List<SchemaName>,
+    val names: Set<SchemaName>,
     val fields: SchemaFields,
     /**
      * The hash code for the schema (note that this is not the same as this object's [hashCode]
@@ -46,7 +46,7 @@ data class Schema(
     fun createCrdtEntityModel(): CrdtEntity = CrdtEntity(VersionMap(), emptyRawEntity)
 
     data class Literal(
-        val names: List<SchemaName>,
+        val names: Set<SchemaName>,
         val fields: SchemaFields,
         val hash: String
     ) : arcs.core.common.Literal {

--- a/java/arcs/core/data/proto/SchemaProtoDecoder.kt
+++ b/java/arcs/core/data/proto/SchemaProtoDecoder.kt
@@ -18,7 +18,7 @@ import arcs.core.data.SchemaFields
 import arcs.core.data.SchemaName
 
 /** Returns the names in the [SchemaProto] as List<SchemaName>. */
-fun SchemaProto.decodeNames(): List<SchemaName> = getNamesList().map { SchemaName(it) }
+fun SchemaProto.decodeNames() = getNamesList().map { SchemaName(it) }.toSet()
 
 /** Returns the fields in the [SchemaProto] as a Kotlin [SchemaFields] instance. */
 fun SchemaProto.decodeFields(): SchemaFields {

--- a/java/arcs/core/storage/driver/RamDisk.kt
+++ b/java/arcs/core/storage/driver/RamDisk.kt
@@ -15,7 +15,6 @@ import arcs.core.data.CollectionType
 import arcs.core.data.EntityType
 import arcs.core.data.Schema
 import arcs.core.data.SchemaFields
-import arcs.core.data.SchemaName
 import arcs.core.storage.Driver
 import arcs.core.storage.DriverFactory
 import arcs.core.storage.DriverProvider
@@ -55,7 +54,7 @@ class RamDiskDriverProvider : DriverProvider {
         // TODO: keep track of and return the actual schema type.
         val type = EntityType(
             Schema(
-                listOf<SchemaName>(),
+                setOf(),
                 SchemaFields(emptyMap(), emptyMap()),
                 ""
             )

--- a/java/arcs/jvm/storage/database/testutil/FakeDatabaseManager.kt
+++ b/java/arcs/jvm/storage/database/testutil/FakeDatabaseManager.kt
@@ -133,7 +133,7 @@ open class FakeDatabase : Database {
     override suspend fun getAllStorageKeys(): Map<StorageKey, Type> {
         val entityType = EntityType(
             Schema(
-                listOf<SchemaName>(),
+                setOf<SchemaName>(),
                 SchemaFields(emptyMap(), emptyMap()),
                 ""
             )

--- a/javatests/arcs/android/host/AndroidEntityHandleManagerTest.kt
+++ b/javatests/arcs/android/host/AndroidEntityHandleManagerTest.kt
@@ -50,7 +50,7 @@ class AndroidEntityHandleManagerTest : LifecycleOwner {
     private lateinit var handleManager: EntityHandleManager
 
     private val schema = Schema(
-        listOf(SchemaName("Person")),
+        setOf(SchemaName("Person")),
         SchemaFields(
             singletons = mapOf(
                 "name" to FieldType.Text,

--- a/javatests/arcs/android/host/ArcHostHelperTest.kt
+++ b/javatests/arcs/android/host/ArcHostHelperTest.kt
@@ -123,7 +123,7 @@ class ArcHostHelperTest {
     @Test
     fun onStartCommand_callsOnStartArcStopArc_whenStarsAlign() = runBlockingTest {
         val personSchema = Schema(
-            listOf(SchemaName("Person")),
+            setOf(SchemaName("Person")),
             SchemaFields(mapOf("name" to Text), emptyMap()),
             "42"
         )

--- a/javatests/arcs/android/host/parcelables/ParcelableHandleConnectionTest.kt
+++ b/javatests/arcs/android/host/parcelables/ParcelableHandleConnectionTest.kt
@@ -31,7 +31,7 @@ import org.junit.runner.RunWith
 class ParcelableHandleConnectionTest {
 
     private val personSchema = Schema(
-        listOf(SchemaName("Person")),
+        setOf(SchemaName("Person")),
         SchemaFields(mapOf("name" to Text), emptyMap()),
         "42"
     )

--- a/javatests/arcs/android/host/parcelables/ParcelableParticleTest.kt
+++ b/javatests/arcs/android/host/parcelables/ParcelableParticleTest.kt
@@ -33,7 +33,7 @@ class ParcelableParticleTest {
     @Test
     fun particle_parcelableRoundTrip_works() {
         val personSchema = Schema(
-            listOf(SchemaName("Person")),
+            setOf(SchemaName("Person")),
             SchemaFields(mapOf("name" to Text), emptyMap()),
             "42"
         )

--- a/javatests/arcs/android/host/parcelables/ParcelablePlanPartitionTest.kt
+++ b/javatests/arcs/android/host/parcelables/ParcelablePlanPartitionTest.kt
@@ -31,7 +31,7 @@ import org.junit.runner.RunWith
 class ParcelablePlanPartitionTest {
 
     private val personSchema = Schema(
-        listOf(SchemaName("Person")),
+        setOf(SchemaName("Person")),
         SchemaFields(mapOf("name" to FieldType.Text), emptyMap()),
         "42"
     )

--- a/javatests/arcs/android/host/parcelables/ParcelablePlanTest.kt
+++ b/javatests/arcs/android/host/parcelables/ParcelablePlanTest.kt
@@ -31,7 +31,7 @@ import org.junit.runner.RunWith
 class ParcelablePlanTest {
 
     private val personSchema = Schema(
-        listOf(SchemaName("Person")),
+        setOf(SchemaName("Person")),
         SchemaFields(mapOf("name" to FieldType.Text), emptyMap()),
         "42"
     )

--- a/javatests/arcs/android/storage/ReferenceModeStoreDatabaseImplIntegrationTest.kt
+++ b/javatests/arcs/android/storage/ReferenceModeStoreDatabaseImplIntegrationTest.kt
@@ -68,7 +68,7 @@ class ReferenceModeStoreDatabaseImplIntegrationTest {
         DatabaseStorageKey.Persistent("set", hash)
     )
     private var schema = Schema(
-        listOf(SchemaName("person")),
+        setOf(SchemaName("person")),
         SchemaFields(
             singletons = mapOf("name" to FieldType.Text, "age" to FieldType.Number),
             collections = emptyMap()

--- a/javatests/arcs/android/storage/database/DatabaseImplTest.kt
+++ b/javatests/arcs/android/storage/database/DatabaseImplTest.kt
@@ -1371,7 +1371,7 @@ private fun newSchema(
     hash: String,
     fields: SchemaFields = SchemaFields(emptyMap(), emptyMap())
 ) = Schema(
-    names = emptyList(),
+    names = emptySet(),
     fields = fields,
     hash = hash
 )

--- a/javatests/arcs/android/type/ParcelableSchemaTest.kt
+++ b/javatests/arcs/android/type/ParcelableSchemaTest.kt
@@ -27,7 +27,7 @@ class ParcelableSchemaTest {
     @Test
     fun parcelableRoundtrip_works() {
         val schema = Schema(
-            names = listOf(SchemaName("MySchema"), SchemaName("AlsoMySchema")),
+            names = setOf(SchemaName("MySchema"), SchemaName("AlsoMySchema")),
             fields = SchemaFields(
                 singletons = mapOf("name" to FieldType.Text, "age" to FieldType.Number),
                 collections = mapOf("friends" to FieldType.EntityRef("hash"))
@@ -52,7 +52,7 @@ class ParcelableSchemaTest {
     @Test
     fun parcelableRoundtrip_works_empty() {
         val schema = Schema(
-            names = emptyList(),
+            names = emptySet(),
             fields = SchemaFields(singletons = emptyMap(), collections = emptyMap()),
             hash = "hash"
         )

--- a/javatests/arcs/android/type/ParcelableTypeTest.kt
+++ b/javatests/arcs/android/type/ParcelableTypeTest.kt
@@ -139,7 +139,7 @@ class ParcelableTypeTest {
     }
 
     private val entitySchema = Schema(
-        names = listOf(SchemaName("Person")),
+        names = setOf(SchemaName("Person")),
         fields = SchemaFields(
             singletons = mapOf("name" to FieldType.Text, "age" to FieldType.Number),
             collections = mapOf("friends" to FieldType.EntityRef("hash"))

--- a/javatests/arcs/core/data/proto/ParticleSpecProtoDecoderTest.kt
+++ b/javatests/arcs/core/data/proto/ParticleSpecProtoDecoderTest.kt
@@ -77,7 +77,7 @@ class ParticleSpecProtoDecoderTest {
         val fields = SchemaFields(singletons, mapOf<FieldName, FieldType>())
         // TODO: Hash.
         val handleConnectionSpecProto = getHandleConnectionSpecProto("data", "READS", "Thing")
-        val schema = Schema(listOf(SchemaName("Thing")), fields, hash="")
+        val schema = Schema(setOf(SchemaName("Thing")), fields, hash="")
         val connectionSpec = decodeHandleConnectionSpecProto(handleConnectionSpecProto)
         assertThat(connectionSpec.name).isEqualTo("data")
         assertThat(connectionSpec.direction).isEqualTo(HandleConnectionSpec.Direction.READS)

--- a/javatests/arcs/core/data/proto/RecipeProtoDecoderTest.kt
+++ b/javatests/arcs/core/data/proto/RecipeProtoDecoderTest.kt
@@ -37,7 +37,7 @@ class RecipeProtoDecoderTest {
         "thing", Handle.Fate.CREATE, ramdiskStorageKey, TypeVariable("thing"), emptyList()
     )
     val thingSchema = Schema(
-            names = listOf(SchemaName("Thing")),
+            names = setOf(SchemaName("Thing")),
             fields = SchemaFields(singletons=mapOf("name" to FieldType.Text), collections=mapOf()),
             hash = ""
     )

--- a/javatests/arcs/core/data/proto/SchemaProtoDecoderTest.kt
+++ b/javatests/arcs/core/data/proto/SchemaProtoDecoderTest.kt
@@ -29,7 +29,7 @@ class SchemaProtoDecoderTest {
         names:  "Object"
         """.trimIndent()
         val schema = decodeSchemaProtoText(schemaProtoText)
-        assertThat(schema.names).isEqualTo(listOf(SchemaName("Thing"), SchemaName("Object")))
+        assertThat(schema.names).containsExactly(SchemaName("Thing"), SchemaName("Object"))
     }
 
     @Test

--- a/javatests/arcs/core/data/proto/TypeProtoDecodersTest.kt
+++ b/javatests/arcs/core/data/proto/TypeProtoDecodersTest.kt
@@ -76,7 +76,7 @@ class TypeProtoDecodersTest {
         """.trimIndent()
         val entityType = parseTypeProtoText(entityTypeProto).decode()
         val expectedSchema = Schema(
-            names = listOf(SchemaName("Person")),
+            names = setOf(SchemaName("Person")),
             fields = SchemaFields(singletons=mapOf("name" to FieldType.Text), collections=mapOf()),
             hash = ""
         )

--- a/javatests/arcs/core/entity/DummyEntity.kt
+++ b/javatests/arcs/core/entity/DummyEntity.kt
@@ -65,7 +65,7 @@ class DummyEntity : EntityBase(ENTITY_CLASS_NAME, SCHEMA) {
         const val SCHEMA_HASH = "hash"
 
         override val SCHEMA = Schema(
-            names = listOf(SchemaName(ENTITY_CLASS_NAME)),
+            names = setOf(SchemaName(ENTITY_CLASS_NAME)),
             fields = SchemaFields(
                 singletons = mapOf(
                     "text" to FieldType.Text,

--- a/javatests/arcs/core/entity/EntityBaseTest.kt
+++ b/javatests/arcs/core/entity/EntityBaseTest.kt
@@ -231,7 +231,7 @@ class EntityBaseTest {
         assertThat(entity1).isNotEqualTo(
             EntityBase(
                 "Foo",
-                Schema(emptyList(), SchemaFields(emptyMap(), emptyMap()), "hash")
+                Schema(emptySet(), SchemaFields(emptyMap(), emptyMap()), "hash")
             )
         )
 

--- a/javatests/arcs/core/storage/CapabilitiesResolverTest.kt
+++ b/javatests/arcs/core/storage/CapabilitiesResolverTest.kt
@@ -36,7 +36,7 @@ import org.junit.runners.JUnit4
 @RunWith(JUnit4::class)
 class CapabilitiesResolverTest {
     private val thingSchema = Schema(
-        listOf(SchemaName("Thing")),
+        setOf(SchemaName("Thing")),
         SchemaFields(mapOf("name" to FieldType.Text), emptyMap()),
         "42"
     )

--- a/javatests/arcs/core/storage/ReferenceModeStoreDatabaseIntegrationTest.kt
+++ b/javatests/arcs/core/storage/ReferenceModeStoreDatabaseIntegrationTest.kt
@@ -58,7 +58,7 @@ class ReferenceModeStoreDatabaseIntegrationTest {
         DatabaseStorageKey.Persistent("set", hash)
     )
     private var schema = Schema(
-        listOf(SchemaName("person")),
+        setOf(SchemaName("person")),
         SchemaFields(
             singletons = mapOf("name" to FieldType.Text, "age" to FieldType.Number),
             collections = emptyMap()

--- a/javatests/arcs/core/storage/ReferenceModeStoreTest.kt
+++ b/javatests/arcs/core/storage/ReferenceModeStoreTest.kt
@@ -66,7 +66,7 @@ class ReferenceModeStoreTest {
         )
         baseStore = Store(StoreOptions(testKey, CountType()))
         schema = Schema(
-            listOf(SchemaName("person")),
+            setOf(SchemaName("person")),
             SchemaFields(
                 singletons = mapOf("name" to FieldType.Text, "age" to FieldType.Number),
                 collections = emptyMap()

--- a/javatests/arcs/core/storage/ReferenceTest.kt
+++ b/javatests/arcs/core/storage/ReferenceTest.kt
@@ -135,7 +135,7 @@ class ReferenceTest {
 
         companion object {
             val SCHEMA = Schema(
-                emptyList(),
+                emptySet(),
                 SchemaFields(
                     singletons = mapOf(
                         "name" to FieldType.Text,

--- a/javatests/arcs/core/storage/driver/DatabaseDriverProviderTest.kt
+++ b/javatests/arcs/core/storage/driver/DatabaseDriverProviderTest.kt
@@ -162,7 +162,7 @@ class DatabaseDriverProviderTest {
 
     companion object {
         private val DUMMY_SCHEMA = Schema(
-            listOf(SchemaName("mySchema")),
+            setOf(SchemaName("mySchema")),
             SchemaFields(
                 mapOf("name" to FieldType.Text),
                 mapOf("cities_lived_in" to FieldType.Text)

--- a/javatests/arcs/core/storage/driver/DatabaseDriverTest.kt
+++ b/javatests/arcs/core/storage/driver/DatabaseDriverTest.kt
@@ -382,7 +382,7 @@ class DatabaseDriverTest {
             dbName = "testdb"
         )
         private val DEFAULT_SCHEMA = Schema(
-            listOf(SchemaName("foo")),
+            setOf(SchemaName("foo")),
             SchemaFields(
                 singletons = mapOf("name" to FieldType.Text),
                 collections = mapOf("phone_numbers" to FieldType.Text)

--- a/javatests/arcs/core/storage/handle/CollectionIntegrationTest.kt
+++ b/javatests/arcs/core/storage/handle/CollectionIntegrationTest.kt
@@ -252,7 +252,7 @@ class CollectionIntegrationTest {
         }
 
         private val SCHEMA_A = Schema(
-            listOf(SchemaName("Person")),
+            setOf(SchemaName("Person")),
             SchemaFields(
                 singletons = mapOf(
                     "name" to FieldType.Text,
@@ -268,7 +268,7 @@ class CollectionIntegrationTest {
         )
 
         private val SCHEMA_B = Schema(
-            listOf(SchemaName("Person")),
+            setOf(SchemaName("Person")),
             SchemaFields(
                 singletons = mapOf(
                     "name" to FieldType.Text,

--- a/javatests/arcs/core/storage/handle/HandleManagerTestBase.kt
+++ b/javatests/arcs/core/storage/handle/HandleManagerTestBase.kt
@@ -46,7 +46,7 @@ open class HandleManagerTestBase {
     )
 
     private val schema = Schema(
-        listOf(SchemaName("Person")),
+        setOf(SchemaName("Person")),
         SchemaFields(
             singletons = mapOf(
                 "name" to FieldType.Text,

--- a/javatests/arcs/core/storage/handle/RawEntityDereferencerTest.kt
+++ b/javatests/arcs/core/storage/handle/RawEntityDereferencerTest.kt
@@ -40,7 +40,7 @@ import org.junit.runners.JUnit4
 class RawEntityDereferencerTest {
     // Self-referential schema.
     private val schema = Schema(
-        emptyList(),
+        emptySet(),
         SchemaFields(
             singletons = mapOf(
                 "name" to FieldType.Text,
@@ -133,7 +133,7 @@ class RawEntityDereferencerTest {
     fun rawEntity_matches_schema_isTrue_whenEntityIsEmpty_andSchemaIsEmpty() {
         val entity = RawEntity(singletons = emptyMap(), collections = emptyMap())
         val schema = Schema(
-            emptyList(),
+            emptySet(),
             SchemaFields(
                 singletons = emptyMap(),
                 collections = emptyMap()
@@ -148,7 +148,7 @@ class RawEntityDereferencerTest {
     fun rawEntity_matches_schema_isFalse_whenEntityIsEmpty_butSchemaIsNot() {
         val entity = RawEntity(singletons = emptyMap(), collections = emptyMap())
         val schemaOne = Schema(
-            emptyList(),
+            emptySet(),
             SchemaFields(
                 singletons = mapOf("name" to FieldType.Text),
                 collections = emptyMap()
@@ -156,7 +156,7 @@ class RawEntityDereferencerTest {
             "abc"
         )
         val schemaTwo = Schema(
-            emptyList(),
+            emptySet(),
             SchemaFields(
                 singletons = emptyMap(),
                 collections = mapOf("friends" to FieldType.EntityRef("def"))
@@ -175,7 +175,7 @@ class RawEntityDereferencerTest {
             collections = emptyMap()
         )
         val schema = Schema(
-            emptyList(),
+            emptySet(),
             SchemaFields(
                 singletons = mapOf(
                     "name" to FieldType.Text,
@@ -196,7 +196,7 @@ class RawEntityDereferencerTest {
             collections = emptyMap()
         )
         val schema = Schema(
-            emptyList(),
+            emptySet(),
             SchemaFields(
                 singletons = mapOf(
                     "name" to FieldType.Text,
@@ -221,7 +221,7 @@ class RawEntityDereferencerTest {
             )
         )
         val schema = Schema(
-            emptyList(),
+            emptySet(),
             SchemaFields(
                 singletons = emptyMap(),
                 collections = mapOf("friends" to FieldType.EntityRef("def"))
@@ -243,7 +243,7 @@ class RawEntityDereferencerTest {
             )
         )
         val schema = Schema(
-            emptyList(),
+            emptySet(),
             SchemaFields(
                 singletons = emptyMap(),
                 collections = mapOf("friends" to FieldType.EntityRef("def"))

--- a/javatests/arcs/core/storage/handle/SingletonIntegrationTest.kt
+++ b/javatests/arcs/core/storage/handle/SingletonIntegrationTest.kt
@@ -205,7 +205,7 @@ class SingletonIntegrationTest {
         )
 
         private val SCHEMA = Schema(
-            listOf(SchemaName("Person")),
+            setOf(SchemaName("Person")),
             SchemaFields(
                 singletons = mapOf(
                     "name" to FieldType.Text,

--- a/javatests/arcs/core/storage/ttl/RemovalManagerTest.kt
+++ b/javatests/arcs/core/storage/ttl/RemovalManagerTest.kt
@@ -52,7 +52,7 @@ class RemovalManagerTest {
     )
 
     private val schema = Schema(
-        listOf(SchemaName("Person")),
+        setOf(SchemaName("Person")),
         SchemaFields(
             singletons = mapOf("name" to FieldType.Text),
             collections = emptyMap()

--- a/src/tools/schema2kotlin.ts
+++ b/src/tools/schema2kotlin.ts
@@ -316,7 +316,7 @@ export class KotlinGenerator implements ClassGenerator {
     const schemaNames = this.node.schema.names.map(n => `SchemaName("${n}")`);
     return `\
 Schema(
-    listOf(${ktUtils.joinWithIndents(schemaNames, 8)}),
+    setOf(${ktUtils.joinWithIndents(schemaNames, 8)}),
     SchemaFields(
         singletons = ${leftPad(ktUtils.mapOf(this.singletonSchemaFields, 30), 8, true)},
         collections = ${leftPad(ktUtils.mapOf(this.collectionSchemaFields, 30), 8, true)}

--- a/src/tools/tests/goldens/generated-schemas.jvm.kt
+++ b/src/tools/tests/goldens/generated-schemas.jvm.kt
@@ -35,7 +35,7 @@ class GoldInternal1(
     companion object : EntitySpec<GoldInternal1> {
 
         override val SCHEMA = Schema(
-            listOf(),
+            setOf(),
             SchemaFields(
                 singletons = mapOf("val" to FieldType.Text),
                 collections = emptyMap()
@@ -121,7 +121,7 @@ class Gold_QCollection(
     companion object : EntitySpec<Gold_QCollection> {
 
         override val SCHEMA = Schema(
-            listOf(SchemaName("People")),
+            setOf(SchemaName("People")),
             SchemaFields(
                 singletons = mapOf(
                     "name" to FieldType.Text,
@@ -172,7 +172,7 @@ class Gold_Collection(
     companion object : EntitySpec<Gold_Collection> {
 
         override val SCHEMA = Schema(
-            listOf(),
+            setOf(),
             SchemaFields(
                 singletons = mapOf("num" to FieldType.Number),
                 collections = emptyMap()
@@ -236,7 +236,7 @@ class Gold_Data(
     companion object : EntitySpec<Gold_Data> {
 
         override val SCHEMA = Schema(
-            listOf(),
+            setOf(),
             SchemaFields(
                 singletons = mapOf(
                     "num" to FieldType.Number,


### PR DESCRIPTION
This better reflects lack of importance of order of the names associated
with the Schema.