### PR TITLE
Move handle classes

### DIFF
--- a/javatests/arcs/android/host/AndroidEntityHandleManagerTest.kt
+++ b/javatests/arcs/android/host/AndroidEntityHandleManagerTest.kt
@@ -46,7 +46,7 @@ class AndroidEntityHandleManagerTest : LifecycleOwner {
 
     val entity1 = Person("Jason", 21.0, false)
     val entity2 = Person("Jason", 22.0, true)
-    lateinit var handleHolder: TestParticleHandles
+    lateinit var handleHolder: AbstractTestParticle.TestParticleHandles
     private lateinit var handleManager: EntityHandleManager
 
     private val schema = Schema(
@@ -83,7 +83,7 @@ class AndroidEntityHandleManagerTest : LifecycleOwner {
         // Initialize WorkManager for instrumentation tests.
         WorkManagerTestInitHelper.initializeTestWorkManager(app)
 
-        handleHolder = TestParticleHandles()
+        handleHolder = AbstractTestParticle.TestParticleHandles()
 
         handleManager = EntityHandleManager(
             AndroidHandleManager(

--- a/javatests/arcs/android/host/AndroidEntityHandleManagerTest.kt
+++ b/javatests/arcs/android/host/AndroidEntityHandleManagerTest.kt
@@ -46,7 +46,7 @@ class AndroidEntityHandleManagerTest : LifecycleOwner {
 
     val entity1 = Person("Jason", 21.0, false)
     val entity2 = Person("Jason", 22.0, true)
-    lateinit var handleHolder: AbstractTestParticle.TestParticleHandles
+    lateinit var handleHolder: AbstractTestParticle.Handles
     private lateinit var handleManager: EntityHandleManager
 
     private val schema = Schema(
@@ -83,7 +83,7 @@ class AndroidEntityHandleManagerTest : LifecycleOwner {
         // Initialize WorkManager for instrumentation tests.
         WorkManagerTestInitHelper.initializeTestWorkManager(app)
 
-        handleHolder = AbstractTestParticle.TestParticleHandles()
+        handleHolder = AbstractTestParticle.Handles()
 
         handleManager = EntityHandleManager(
             AndroidHandleManager(

--- a/src/tools/schema2kotlin.ts
+++ b/src/tools/schema2kotlin.ts
@@ -171,12 +171,13 @@ ${imports.join('\n')}
 
     }
     return `
-${this.getHandlesClassDecl(particleName, specDecls)} {
-    ${handleDecls.join('\n    ')}
-}
 
 abstract class Abstract${particleName} : ${this.opts.wasm ? 'WasmParticleImpl' : 'BaseParticle'}() {
     ${this.opts.wasm ? '' : 'override '}val handles: ${particleName}Handles = ${particleName}Handles(${this.opts.wasm ? 'this' : ''})
+
+    ${this.getHandlesClassDecl(particleName, specDecls)} {
+        ${handleDecls.join('\n        ')}
+    }
 }
 `;
   }
@@ -227,13 +228,13 @@ class ${particleName}TestHarness<P : Abstract${particleName}>(
   private getHandlesClassDecl(particleName: string, entitySpecs: string[]): string {
     if (this.opts.wasm) {
       return `class ${particleName}Handles(
-    particle: WasmParticleImpl
-)`;
+        particle: WasmParticleImpl
+    )`;
     } else {
       return `class ${particleName}Handles : HandleHolderBase(
-    "${particleName}",
-    mapOf(${ktUtils.joinWithIndents(entitySpecs, 8, 2)})
-)`;
+        "${particleName}",
+        mapOf(${ktUtils.joinWithIndents(entitySpecs, 4, 3)})
+    )`;
     }
   }
 

--- a/src/tools/schema2kotlin.ts
+++ b/src/tools/schema2kotlin.ts
@@ -173,7 +173,7 @@ ${imports.join('\n')}
     return `
 
 abstract class Abstract${particleName} : ${this.opts.wasm ? 'WasmParticleImpl' : 'BaseParticle'}() {
-    ${this.opts.wasm ? '' : 'override '}val handles: ${particleName}Handles = ${particleName}Handles(${this.opts.wasm ? 'this' : ''})
+    ${this.opts.wasm ? '' : 'override '}val handles: Handles = Handles(${this.opts.wasm ? 'this' : ''})
 
     ${this.getHandlesClassDecl(particleName, specDecls)} {
         ${handleDecls.join('\n        ')}
@@ -227,11 +227,11 @@ class ${particleName}TestHarness<P : Abstract${particleName}>(
 
   private getHandlesClassDecl(particleName: string, entitySpecs: string[]): string {
     if (this.opts.wasm) {
-      return `class ${particleName}Handles(
+      return `class Handles(
         particle: WasmParticleImpl
     )`;
     } else {
-      return `class ${particleName}Handles : HandleHolderBase(
+      return `class Handles : HandleHolderBase(
         "${particleName}",
         mapOf(${ktUtils.joinWithIndents(entitySpecs, 4, 3)})
     )`;

--- a/src/tools/tests/goldens/generated-schemas.jvm.kt
+++ b/src/tools/tests/goldens/generated-schemas.jvm.kt
@@ -263,9 +263,9 @@ class Gold_Data(
 
 
 abstract class AbstractGold : BaseParticle() {
-    override val handles: GoldHandles = GoldHandles()
+    override val handles: Handles = Handles()
 
-    class GoldHandles : HandleHolderBase(
+    class Handles : HandleHolderBase(
         "Gold",
         mapOf(
             "data" to Gold_Data,

--- a/src/tools/tests/goldens/generated-schemas.jvm.kt
+++ b/src/tools/tests/goldens/generated-schemas.jvm.kt
@@ -49,7 +49,6 @@ class GoldInternal1(
             SchemaRegistry.register(this)
         }
 
-        // TODO: only handles singletons for now
         override fun deserialize(data: RawEntity) = GoldInternal1().apply { deserialize(data) }
     }
 }
@@ -149,7 +148,6 @@ class Gold_QCollection(
             SchemaRegistry.register(this)
         }
 
-        // TODO: only handles singletons for now
         override fun deserialize(data: RawEntity) = Gold_QCollection().apply { deserialize(data) }
     }
 }
@@ -188,7 +186,6 @@ class Gold_Collection(
             SchemaRegistry.register(this)
         }
 
-        // TODO: only handles singletons for now
         override fun deserialize(data: RawEntity) = Gold_Collection().apply { deserialize(data) }
     }
 }
@@ -250,7 +247,7 @@ class Gold_Data(
                 ),
                 collections = emptyMap()
             ),
-            "d8058d336e472da47b289eafb39733f77eadb111",
+            "c539be82943f3c24e2503cb0410b865fa3688d06",
             refinement = { _ -> true },
             query = null
         )
@@ -259,27 +256,27 @@ class Gold_Data(
             SchemaRegistry.register(this)
         }
 
-        // TODO: only handles singletons for now
         override fun deserialize(data: RawEntity) = Gold_Data().apply { deserialize(data) }
     }
 }
 
 
-class GoldHandles : HandleHolderBase(
-    "Gold",
-    mapOf(
-        "data" to Gold_Data,
-        "qCollection" to Gold_QCollection,
-        "alias" to Gold_Alias,
-        "collection" to Gold_Collection
-    )
-) {
-    val data: ReadSingletonHandle<Gold_Data> by handles
-    val qCollection: ReadQueryCollectionHandle<Gold_QCollection, String> by handles
-    val alias: WriteSingletonHandle<Gold_Alias> by handles
-    val collection: ReadSingletonHandle<Gold_Collection> by handles
-}
 
 abstract class AbstractGold : BaseParticle() {
     override val handles: GoldHandles = GoldHandles()
+
+    class GoldHandles : HandleHolderBase(
+        "Gold",
+        mapOf(
+            "data" to Gold_Data,
+            "qCollection" to Gold_QCollection,
+            "alias" to Gold_Alias,
+            "collection" to Gold_Collection
+        )
+    ) {
+        val data: ReadSingletonHandle<Gold_Data> by handles
+        val qCollection: ReadQueryCollectionHandle<Gold_QCollection, String> by handles
+        val alias: WriteSingletonHandle<Gold_Alias> by handles
+        val collection: ReadCollectionHandle<Gold_Collection> by handles
+    }
 }

--- a/src/tools/tests/goldens/generated-schemas.jvm.kt
+++ b/src/tools/tests/goldens/generated-schemas.jvm.kt
@@ -49,6 +49,7 @@ class GoldInternal1(
             SchemaRegistry.register(this)
         }
 
+        // TODO: only handles singletons for now
         override fun deserialize(data: RawEntity) = GoldInternal1().apply { deserialize(data) }
     }
 }
@@ -148,6 +149,7 @@ class Gold_QCollection(
             SchemaRegistry.register(this)
         }
 
+        // TODO: only handles singletons for now
         override fun deserialize(data: RawEntity) = Gold_QCollection().apply { deserialize(data) }
     }
 }
@@ -186,6 +188,7 @@ class Gold_Collection(
             SchemaRegistry.register(this)
         }
 
+        // TODO: only handles singletons for now
         override fun deserialize(data: RawEntity) = Gold_Collection().apply { deserialize(data) }
     }
 }
@@ -247,7 +250,7 @@ class Gold_Data(
                 ),
                 collections = emptyMap()
             ),
-            "c539be82943f3c24e2503cb0410b865fa3688d06",
+            "d8058d336e472da47b289eafb39733f77eadb111",
             refinement = { _ -> true },
             query = null
         )
@@ -256,6 +259,7 @@ class Gold_Data(
             SchemaRegistry.register(this)
         }
 
+        // TODO: only handles singletons for now
         override fun deserialize(data: RawEntity) = Gold_Data().apply { deserialize(data) }
     }
 }
@@ -273,7 +277,7 @@ class GoldHandles : HandleHolderBase(
     val data: ReadSingletonHandle<Gold_Data> by handles
     val qCollection: ReadQueryCollectionHandle<Gold_QCollection, String> by handles
     val alias: WriteSingletonHandle<Gold_Alias> by handles
-    val collection: ReadCollectionHandle<Gold_Collection> by handles
+    val collection: ReadSingletonHandle<Gold_Collection> by handles
 }
 
 abstract class AbstractGold : BaseParticle() {

--- a/src/tools/tests/goldens/generated-schemas.wasm.kt
+++ b/src/tools/tests/goldens/generated-schemas.wasm.kt
@@ -449,7 +449,7 @@ class GoldHandles(
     val data: WasmSingletonImpl<Gold_Data> = WasmSingletonImpl(particle, "data", Gold_Data)
     val qCollection: WasmCollectionImpl<Gold_QCollection> = WasmCollectionImpl(particle, "qCollection", Gold_QCollection)
     val alias: WasmSingletonImpl<Gold_Alias> = WasmSingletonImpl(particle, "alias", Gold_Alias)
-    val collection: WasmCollectionImpl<Gold_Collection> = WasmCollectionImpl(particle, "collection", Gold_Collection)
+    val collection: WasmSingletonImpl<Gold_Collection> = WasmSingletonImpl(particle, "collection", Gold_Collection)
 }
 
 abstract class AbstractGold : WasmParticleImpl() {

--- a/src/tools/tests/goldens/generated-schemas.wasm.kt
+++ b/src/tools/tests/goldens/generated-schemas.wasm.kt
@@ -443,15 +443,16 @@ class Gold_Data(
 }
 
 
-class GoldHandles(
-    particle: WasmParticleImpl
-) {
-    val data: WasmSingletonImpl<Gold_Data> = WasmSingletonImpl(particle, "data", Gold_Data)
-    val qCollection: WasmCollectionImpl<Gold_QCollection> = WasmCollectionImpl(particle, "qCollection", Gold_QCollection)
-    val alias: WasmSingletonImpl<Gold_Alias> = WasmSingletonImpl(particle, "alias", Gold_Alias)
-    val collection: WasmSingletonImpl<Gold_Collection> = WasmSingletonImpl(particle, "collection", Gold_Collection)
-}
 
 abstract class AbstractGold : WasmParticleImpl() {
     val handles: GoldHandles = GoldHandles(this)
+
+    class GoldHandles(
+        particle: WasmParticleImpl
+    ) {
+        val data: WasmSingletonImpl<Gold_Data> = WasmSingletonImpl(particle, "data", Gold_Data)
+        val qCollection: WasmCollectionImpl<Gold_QCollection> = WasmCollectionImpl(particle, "qCollection", Gold_QCollection)
+        val alias: WasmSingletonImpl<Gold_Alias> = WasmSingletonImpl(particle, "alias", Gold_Alias)
+        val collection: WasmCollectionImpl<Gold_Collection> = WasmCollectionImpl(particle, "collection", Gold_Collection)
+    }
 }

--- a/src/tools/tests/goldens/generated-schemas.wasm.kt
+++ b/src/tools/tests/goldens/generated-schemas.wasm.kt
@@ -445,9 +445,9 @@ class Gold_Data(
 
 
 abstract class AbstractGold : WasmParticleImpl() {
-    val handles: GoldHandles = GoldHandles(this)
+    val handles: Handles = Handles(this)
 
-    class GoldHandles(
+    class Handles(
         particle: WasmParticleImpl
     ) {
         val data: WasmSingletonImpl<Gold_Data> = WasmSingletonImpl(particle, "data", Gold_Data)


### PR DESCRIPTION
Move the handle holder class to be within the abstract class. This is the first step in improving the autogenerated names for Kotlin Entity classes.