### PR TITLE
Create `AndroidEntityHandleManager` helper

### DIFF
--- a/java/arcs/android/host/AndroidEntityHandleManager.kt
+++ b/java/arcs/android/host/AndroidEntityHandleManager.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+package arcs.android.host
+
+import android.content.Context
+import androidx.lifecycle.Lifecycle
+import arcs.android.storage.handle.AndroidHandleManager
+import arcs.core.common.Id
+import arcs.core.host.EntityHandleManager
+import arcs.core.storage.handle.Stores
+import arcs.sdk.android.storage.service.ConnectionFactory
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+
+fun AndroidEntityHandleManager(
+    context: Context,
+    lifecycle: Lifecycle,
+    arcId: String = Id.Generator.newSession().newArcId("arc").toString(),
+    hostId: String = "nohost",
+    coroutineContext: CoroutineContext = EmptyCoroutineContext,
+    connectionFactory: ConnectionFactory? = null,
+    stores: Stores = Stores()
+) = EntityHandleManager(
+    AndroidHandleManager(
+        context,
+        lifecycle,
+        coroutineContext,
+        connectionFactory,
+        stores
+    ),
+    arcId,
+    hostId
+)

--- a/java/arcs/android/host/AndroidProdHost.kt
+++ b/java/arcs/android/host/AndroidProdHost.kt
@@ -12,9 +12,7 @@ package arcs.android.host
 
 import android.content.Context
 import androidx.lifecycle.Lifecycle
-import arcs.android.storage.handle.AndroidHandleManager
 import arcs.core.host.ArcHost
-import arcs.core.host.EntityHandleManager
 import arcs.core.host.ParticleRegistration
 import arcs.jvm.host.AnnotationBasedJvmProdHost
 import arcs.jvm.host.JvmProdHost
@@ -31,13 +29,10 @@ class AndroidProdHost(
     val lifecycle: Lifecycle,
     vararg additionalParticles: ParticleRegistration
 ) : AnnotationBasedJvmProdHost(JvmProdHost::class, additionalParticles = *additionalParticles) {
-    override fun entityHandleManager(arcId: String) = EntityHandleManager(
-        AndroidHandleManager(
-            context,
-            lifecycle,
-            Dispatchers.Default
-        ),
+    override fun entityHandleManager(arcId: String) = AndroidEntityHandleManager(
+        context,
+        lifecycle,
         arcId,
-        hostId
+        coroutineContext = Dispatchers.Default
     )
 }

--- a/java/arcs/android/host/BUILD
+++ b/java/arcs/android/host/BUILD
@@ -18,6 +18,7 @@ kt_android_library(
         "//java/arcs/core/host",
         "//java/arcs/core/host/api",
         "//java/arcs/core/storage/api",
+        "//java/arcs/core/storage/handle",
         "//java/arcs/jvm/host",
         "//third_party/java/androidx/annotation",
         "//third_party/java/androidx/lifecycle",

--- a/javatests/arcs/android/host/AndroidEntityHandleManagerTest.kt
+++ b/javatests/arcs/android/host/AndroidEntityHandleManagerTest.kt
@@ -7,19 +7,18 @@ import androidx.lifecycle.LifecycleRegistry
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.work.testing.WorkManagerTestInitHelper
-import arcs.android.storage.handle.AndroidHandleManager
 import arcs.core.data.FieldType
+import arcs.core.data.HandleMode
 import arcs.core.data.Schema
 import arcs.core.data.SchemaFields
 import arcs.core.data.SchemaName
-import arcs.core.host.EntityHandleManager
-import arcs.core.data.HandleMode
 import arcs.core.entity.ReadCollectionHandle
 import arcs.core.entity.ReadSingletonHandle
 import arcs.core.entity.ReadWriteCollectionHandle
 import arcs.core.entity.ReadWriteSingletonHandle
 import arcs.core.entity.WriteCollectionHandle
 import arcs.core.entity.WriteSingletonHandle
+import arcs.core.host.EntityHandleManager
 import arcs.core.storage.driver.RamDisk
 import arcs.core.storage.keys.RamDiskStorageKey
 import arcs.core.storage.referencemode.ReferenceModeStorageKey
@@ -32,7 +31,6 @@ import kotlinx.coroutines.runBlocking
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import java.lang.IllegalStateException
 import kotlin.coroutines.experimental.suspendCoroutine
 
 private typealias Person = TestParticleInternal1
@@ -85,12 +83,10 @@ class AndroidEntityHandleManagerTest : LifecycleOwner {
 
         handleHolder = TestParticleHandles()
 
-        handleManager = EntityHandleManager(
-            AndroidHandleManager(
-                lifecycle = lifecycle,
-                context = app,
-                connectionFactory = TestConnectionFactory(app)
-            )
+        handleManager = AndroidEntityHandleManager(
+            lifecycle = lifecycle,
+            context = app,
+            connectionFactory = TestConnectionFactory(app)
         )
     }
 

--- a/javatests/arcs/android/host/TestExternalArcHostService.kt
+++ b/javatests/arcs/android/host/TestExternalArcHostService.kt
@@ -7,10 +7,8 @@ import android.os.IBinder
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleObserver
 import arcs.android.sdk.host.ArcHostHelper
-import arcs.android.storage.handle.AndroidHandleManager
 import arcs.core.allocator.TestingHost
 import arcs.core.data.Capabilities
-import arcs.core.host.EntityHandleManager
 import arcs.core.host.ParticleRegistration
 import arcs.core.storage.handle.Stores
 import arcs.sdk.android.storage.service.ConnectionFactory
@@ -44,16 +42,14 @@ open class TestExternalArcHostService(val arcHost: TestingAndroidHost) : Service
 
         private val stores = Stores()
 
-        override fun entityHandleManager(arcId: String) = EntityHandleManager(
-            AndroidHandleManager(
-                serviceContext,
-                FakeLifecycle(),
-                Dispatchers.Default,
-                testConnectionFactory,
-                stores
-            ),
+        override fun entityHandleManager(arcId: String) = AndroidEntityHandleManager(
+            serviceContext,
+            FakeLifecycle(),
             arcId,
-            hostId
+            hostId,
+            Dispatchers.Default,
+            testConnectionFactory,
+            stores
         )
 
         override val arcHostContextCapability = testingCapability

--- a/javatests/arcs/android/host/TestProdArcHostService.kt
+++ b/javatests/arcs/android/host/TestProdArcHostService.kt
@@ -2,9 +2,7 @@ package arcs.android.host
 
 import android.content.Context
 import androidx.lifecycle.Lifecycle
-import arcs.android.storage.handle.AndroidHandleManager
 import arcs.core.host.TestingJvmProdHost
-import arcs.core.host.EntityHandleManager
 import kotlinx.coroutines.Dispatchers
 
 class TestProdArcHostService : ProdArcHostService() {
@@ -14,15 +12,13 @@ class TestProdArcHostService : ProdArcHostService() {
         val context: Context,
         val lifecycle: Lifecycle
     ) : TestingJvmProdHost() {
-        override fun entityHandleManager(arcId: String) = EntityHandleManager(
-            AndroidHandleManager(
-                context,
-                lifecycle,
-                Dispatchers.Default,
-                TestExternalArcHostService.testConnectionFactory
-            ),
+        override fun entityHandleManager(arcId: String) = AndroidEntityHandleManager(
+            context,
+            lifecycle,
             arcId,
-            hostId
+            hostId,
+            Dispatchers.Default,
+            TestExternalArcHostService.testConnectionFactory
         )
     }
 }


### PR DESCRIPTION
This is to remove direct usage of `HandleManager`, which is slated for
removal.