### PR TITLE
Tidy javatests BUILD files

### DIFF
--- a/javatests/arcs/android/BUILD
+++ b/javatests/arcs/android/BUILD
@@ -1,3 +1,1 @@
 licenses(["notice"])
-
-package(default_visibility = ["//visibility:public"])

--- a/javatests/arcs/android/common/resurrection/BUILD
+++ b/javatests/arcs/android/common/resurrection/BUILD
@@ -1,14 +1,12 @@
 load(
     "//third_party/java/arcs/build_defs:build_defs.bzl",
+    "arcs_kt_android_library",
     "arcs_kt_android_test_suite",
 )
-load("//tools/build_defs/kotlin:rules.bzl", "kt_android_library")
 
 licenses(["notice"])
 
-package(default_visibility = ["//visibility:public"])
-
-kt_android_library(
+arcs_kt_android_library(
     name = "support",
     testonly = 1,
     srcs = [
@@ -17,7 +15,6 @@ kt_android_library(
         "ResurrectorServiceImpl.kt",
     ],
     manifest = "AndroidManifest.xml",
-    visibility = ["//visibility:private"],
     deps = [
         "//java/arcs/android/common/resurrection",
         "//java/arcs/sdk/android/storage",

--- a/javatests/arcs/android/crdt/BUILD
+++ b/javatests/arcs/android/crdt/BUILD
@@ -5,8 +5,6 @@ load(
 
 licenses(["notice"])
 
-package(default_visibility = ["//visibility:public"])
-
 arcs_kt_android_test_suite(
     name = "crdt",
     manifest = "//java/arcs/android/common:AndroidManifest.xml",

--- a/javatests/arcs/android/host/BUILD
+++ b/javatests/arcs/android/host/BUILD
@@ -1,13 +1,11 @@
 load(
     "//third_party/java/arcs/build_defs:build_defs.bzl",
+    "arcs_kt_android_library",
     "arcs_kt_android_test_suite",
     "arcs_kt_schema",
 )
-load("//tools/build_defs/kotlin:rules.bzl", "kt_android_library")
 
 licenses(["notice"])
-
-package(default_visibility = ["//visibility:public"])
 
 arcs_kt_android_test_suite(
     name = "host",
@@ -58,7 +56,7 @@ arcs_kt_schema(
     ],
 )
 
-kt_android_library(
+arcs_kt_android_library(
     name = "services",
     testonly = True,
     srcs = glob(

--- a/javatests/arcs/android/host/parcelables/BUILD
+++ b/javatests/arcs/android/host/parcelables/BUILD
@@ -5,8 +5,6 @@ load(
 
 licenses(["notice"])
 
-package(default_visibility = ["//visibility:public"])
-
 arcs_kt_android_test_suite(
     name = "parcelables",
     manifest = "//java/arcs/android/common:AndroidManifest.xml",

--- a/javatests/arcs/android/storage/BUILD
+++ b/javatests/arcs/android/storage/BUILD
@@ -5,8 +5,6 @@ load(
 
 licenses(["notice"])
 
-package(default_visibility = ["//visibility:public"])
-
 arcs_kt_android_test_suite(
     name = "storage",
     manifest = "//java/arcs/android/common:AndroidManifest.xml",

--- a/javatests/arcs/android/storage/database/BUILD
+++ b/javatests/arcs/android/storage/database/BUILD
@@ -5,8 +5,6 @@ load(
 
 licenses(["notice"])
 
-package(default_visibility = ["//visibility:public"])
-
 arcs_kt_android_test_suite(
     name = "database",
     size = "medium",

--- a/javatests/arcs/android/storage/handle/BUILD
+++ b/javatests/arcs/android/storage/handle/BUILD
@@ -6,8 +6,6 @@ load(
 
 licenses(["notice"])
 
-package(default_visibility = ["//visibility:public"])
-
 arcs_kt_android_library(
     name = "testlib",
     testonly = 1,

--- a/javatests/arcs/android/storage/service/BUILD
+++ b/javatests/arcs/android/storage/service/BUILD
@@ -5,8 +5,6 @@ load(
 
 licenses(["notice"])
 
-package(default_visibility = ["//visibility:public"])
-
 arcs_kt_android_test_suite(
     name = "service",
     manifest = "//java/arcs/android/common:AndroidManifest.xml",

--- a/javatests/arcs/android/type/BUILD
+++ b/javatests/arcs/android/type/BUILD
@@ -5,8 +5,6 @@ load(
 
 licenses(["notice"])
 
-package(default_visibility = ["//visibility:public"])
-
 arcs_kt_android_test_suite(
     name = "type",
     manifest = "//java/arcs/android/common:AndroidManifest.xml",

--- a/javatests/arcs/core/BUILD
+++ b/javatests/arcs/core/BUILD
@@ -1,3 +1,1 @@
 licenses(["notice"])
-
-package(default_visibility = ["//visibility:public"])

--- a/javatests/arcs/core/allocator/BUILD
+++ b/javatests/arcs/core/allocator/BUILD
@@ -6,8 +6,6 @@ load(
 
 licenses(["notice"])
 
-package(default_visibility = ["//visibility:public"])
-
 arcs_kt_jvm_test_suite(
     name = "allocator",
     srcs = glob(["*Test.kt"]),
@@ -26,6 +24,7 @@ arcs_kt_jvm_library(
         "AllocatorTestBase.kt",
         "TestingHost.kt",
     ],
+    visibility = ["//visibility:public"],
     deps = [
         "//java/arcs/core/allocator",  # buildcleaner: keep
         "//java/arcs/core/common",

--- a/javatests/arcs/core/analysis/BUILD
+++ b/javatests/arcs/core/analysis/BUILD
@@ -5,8 +5,6 @@ load(
 
 licenses(["notice"])
 
-package(default_visibility = ["//visibility:public"])
-
 arcs_kt_jvm_test_suite(
     name = "analysis",
     data = ["//java/arcs/core/data/testdata:examples"],

--- a/javatests/arcs/core/common/BUILD
+++ b/javatests/arcs/core/common/BUILD
@@ -5,8 +5,6 @@ load(
 
 licenses(["notice"])
 
-package(default_visibility = ["//visibility:public"])
-
 arcs_kt_jvm_test_suite(
     name = "common",
     package = "arcs.core.common",

--- a/javatests/arcs/core/crdt/BUILD
+++ b/javatests/arcs/core/crdt/BUILD
@@ -5,8 +5,6 @@ load(
 
 licenses(["notice"])
 
-package(default_visibility = ["//visibility:public"])
-
 arcs_kt_jvm_test_suite(
     name = "crdt",
     package = "arcs.core.crdt",

--- a/javatests/arcs/core/data/BUILD
+++ b/javatests/arcs/core/data/BUILD
@@ -5,8 +5,6 @@ load(
 
 licenses(["notice"])
 
-package(default_visibility = ["//visibility:public"])
-
 arcs_kt_jvm_test_suite(
     name = "data",
     data = ["//java/arcs/core/data/testdata:examples"],

--- a/javatests/arcs/core/data/proto/BUILD
+++ b/javatests/arcs/core/data/proto/BUILD
@@ -5,8 +5,6 @@ load(
 
 licenses(["notice"])
 
-package(default_visibility = ["//visibility:public"])
-
 arcs_kt_jvm_test_suite(
     name = "proto",
     data = ["//java/arcs/core/data/testdata:examples"],

--- a/javatests/arcs/core/storage/BUILD
+++ b/javatests/arcs/core/storage/BUILD
@@ -1,19 +1,16 @@
 load(
     "//third_party/java/arcs/build_defs:build_defs.bzl",
-    "arcs_kt_android_test_suite",
     "arcs_kt_jvm_library",
+    "arcs_kt_jvm_test_suite",
 )
 
 licenses(["notice"])
 
-package(default_visibility = ["//visibility:public"])
-
 TEST_SRCS = glob(["*Test.kt"])
 
-arcs_kt_android_test_suite(
+arcs_kt_jvm_test_suite(
     name = "storage",
     srcs = TEST_SRCS,
-    manifest = "//java/arcs/android/common:AndroidManifest.xml",
     package = "arcs.core.storage",
     deps = [
         ":fakes",

--- a/javatests/arcs/core/storage/driver/BUILD
+++ b/javatests/arcs/core/storage/driver/BUILD
@@ -5,8 +5,6 @@ load(
 
 licenses(["notice"])
 
-package(default_visibility = ["//visibility:public"])
-
 arcs_kt_jvm_test_suite(
     name = "driver",
     package = "arcs.core.storage.driver",

--- a/javatests/arcs/core/storage/handle/BUILD
+++ b/javatests/arcs/core/storage/handle/BUILD
@@ -1,12 +1,10 @@
 load(
     "//third_party/java/arcs/build_defs:build_defs.bzl",
-    "arcs_kt_android_test_suite",
     "arcs_kt_jvm_library",
+    "arcs_kt_jvm_test_suite",
 )
 
 licenses(["notice"])
-
-package(default_visibility = ["//visibility:public"])
 
 TEST_SRCS = glob(["*Test.kt"])
 
@@ -14,6 +12,7 @@ arcs_kt_jvm_library(
     name = "testbase",
     testonly = 1,
     srcs = ["HandleManagerTestBase.kt"],
+    visibility = ["//visibility:public"],
     deps = [
         "//java/arcs/core/data",
         "//java/arcs/core/data/util:data-util",
@@ -29,10 +28,9 @@ arcs_kt_jvm_library(
     ],
 )
 
-arcs_kt_android_test_suite(
+arcs_kt_jvm_test_suite(
     name = "handle",
     srcs = TEST_SRCS,
-    manifest = "//java/arcs/android/common:AndroidManifest.xml",
     package = "arcs.core.storage.handle",
     deps = [
         ":testbase",
@@ -51,7 +49,6 @@ arcs_kt_android_test_suite(
         "//java/arcs/core/util",
         "//java/arcs/core/util/testutil",
         "//java/arcs/jvm/util/testutil",
-        "//javatests/arcs/core/storage",  # buildcleaner: keep
         "//third_party/java/junit:junit-android",
         "//third_party/java/mockito:mockito-android",
         "//third_party/java/truth:truth-android",

--- a/javatests/arcs/core/storage/keys/BUILD
+++ b/javatests/arcs/core/storage/keys/BUILD
@@ -1,18 +1,12 @@
 load(
     "//third_party/java/arcs/build_defs:build_defs.bzl",
-    "arcs_kt_android_test_suite",
+    "arcs_kt_jvm_test_suite",
 )
 
 licenses(["notice"])
 
-package(default_visibility = ["//visibility:public"])
-
-TEST_SRCS = glob(["*Test.kt"])
-
-arcs_kt_android_test_suite(
+arcs_kt_jvm_test_suite(
     name = "keys",
-    srcs = TEST_SRCS,
-    manifest = "//java/arcs/android/common:AndroidManifest.xml",
     package = "arcs.core.storage.keys",
     deps = [
         "//java/arcs/core/common",

--- a/javatests/arcs/core/storage/referencemode/BUILD
+++ b/javatests/arcs/core/storage/referencemode/BUILD
@@ -1,15 +1,12 @@
 load(
     "//third_party/java/arcs/build_defs:build_defs.bzl",
-    "arcs_kt_android_test_suite",
+    "arcs_kt_jvm_test_suite",
 )
 
 licenses(["notice"])
 
-package(default_visibility = ["//visibility:public"])
-
-arcs_kt_android_test_suite(
+arcs_kt_jvm_test_suite(
     name = "referencemode",
-    manifest = "//java/arcs/android/common:AndroidManifest.xml",
     package = "arcs.core.storage.referencemode",
     deps = [
         "//java/arcs/core/common",

--- a/javatests/arcs/core/storage/util/BUILD
+++ b/javatests/arcs/core/storage/util/BUILD
@@ -5,8 +5,6 @@ load(
 
 licenses(["notice"])
 
-package(default_visibility = ["//visibility:public"])
-
 arcs_kt_jvm_test_suite(
     name = "util",
     package = "arcs.core.storage.util",

--- a/javatests/arcs/core/type/BUILD
+++ b/javatests/arcs/core/type/BUILD
@@ -5,8 +5,6 @@ load(
 
 licenses(["notice"])
 
-package(default_visibility = ["//visibility:public"])
-
 arcs_kt_jvm_test_suite(
     name = "type",
     package = "arcs.core.type",

--- a/javatests/arcs/core/util/BUILD
+++ b/javatests/arcs/core/util/BUILD
@@ -5,8 +5,6 @@ load(
 
 licenses(["notice"])
 
-package(default_visibility = ["//visibility:public"])
-
 PERFORMANCE_SRCS = [
     "Base64PerformanceTest.kt",
 ]

--- a/javatests/arcs/core/util/performance/BUILD
+++ b/javatests/arcs/core/util/performance/BUILD
@@ -5,11 +5,8 @@ load(
 
 licenses(["notice"])
 
-package(default_visibility = ["//visibility:public"])
-
 arcs_kt_jvm_test_suite(
     name = "performance",
-    srcs = glob(["*.kt"]),
     package = "arcs.core.util.performance",
     deps = [
         "//java/arcs/core/testutil",

--- a/javatests/arcs/sdk/BUILD
+++ b/javatests/arcs/sdk/BUILD
@@ -8,8 +8,6 @@ load(
 
 licenses(["notice"])
 
-package(default_visibility = ["//visibility:public"])
-
 arcs_kt_jvm_test_suite(
     name = "host",
     srcs = glob(["*Test.kt"]),

--- a/javatests/arcs/sdk/android/BUILD
+++ b/javatests/arcs/sdk/android/BUILD
@@ -1,3 +1,1 @@
 licenses(["notice"])
-
-package(default_visibility = ["//visibility:public"])

--- a/javatests/arcs/sdk/android/dev/BUILD
+++ b/javatests/arcs/sdk/android/dev/BUILD
@@ -1,1 +1,1 @@
-package(default_visibility = ["//visibility:public"])
+licenses(["notice"])

--- a/javatests/arcs/sdk/android/storage/BUILD
+++ b/javatests/arcs/sdk/android/storage/BUILD
@@ -1,19 +1,15 @@
 load(
     "//third_party/java/arcs/build_defs:build_defs.bzl",
+    "arcs_kt_android_library",
     "arcs_kt_android_test_suite",
 )
-load("//tools/build_defs/kotlin:rules.bzl", "kt_android_library")
 
 licenses(["notice"])
 
-package(default_visibility = ["//visibility:public"])
-
-kt_android_library(
+arcs_kt_android_library(
     name = "support",
     testonly = 1,
-    srcs = [
-        "ResurrectionHelperDummyService.kt",
-    ],
+    srcs = ["ResurrectionHelperDummyService.kt"],
     manifest = "AndroidManifest.xml",
 )
 

--- a/javatests/arcs/sdk/android/storage/service/BUILD
+++ b/javatests/arcs/sdk/android/storage/service/BUILD
@@ -5,8 +5,6 @@ load(
 
 licenses(["notice"])
 
-package(default_visibility = ["//visibility:public"])
-
 arcs_kt_android_test_suite(
     name = "service",
     manifest = "AndroidManifest.xml",


### PR DESCRIPTION
1. Replace extraneous usages of arcs_kt_android_test_suite with arcs_kt_jvm_test_suite for all core tests
2. Remove default public visibility (really nothing under javatests should have public visibility, but moving them was a bit too much effort)