### PR TITLE
silence majority of warnings

### DIFF
--- a/.bazelproject
+++ b/.bazelproject
@@ -4,13 +4,13 @@ directories:
   build_defs
   tools
   third_party
-  particles
-  src
+#  particles
+#  src
 
 targets:
   //java/...
   //javatests/...
-  //particles/...
+#  //particles/...
 
 test_sources:
   javatests/

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -41,9 +41,9 @@ AUTO_VALUE_VERSION = "1.7"
 
 AUTO_SERVICE_VERSION = "1.0-rc6"
 
-KOTLINX_ATOMICFU_VERSION = "0.14.1"
+KOTLINX_ATOMICFU_VERSION = "0.14.2"
 
-KOTLINX_COROUTINES_VERSION = "1.3.3"
+KOTLINX_COROUTINES_VERSION = "1.3.4"
 
 ROBOLECTRIC_VERSION = "4.1"
 
@@ -82,7 +82,6 @@ maven_install(
         "com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0",
         "javax.inject:javax.inject:1",
         "junit:junit:4.11",
-        "org.jetbrains.kotlin:kotlin-reflect:1.3.61",
         "org.jetbrains.kotlinx:kotlinx-coroutines-android:" + KOTLINX_COROUTINES_VERSION,
         "org.jetbrains.kotlinx:kotlinx-coroutines-core:" + KOTLINX_COROUTINES_VERSION,
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-js:" + KOTLINX_COROUTINES_VERSION,
@@ -154,9 +153,9 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 git_repository(
     name = "io_bazel_rules_kotlin",
-    commit = "d4088d3f1d7a02d410d1cac203cb7bc2f65bd1ec",
+    commit = "eb353b2d3ed3a6634e9028ffb0e8af8321a12c9c",
     remote = "https://github.com/cromwellian/rules_kotlin.git",
-    shallow_since = "1583544131 -0800",
+    shallow_since = "1585186427 -0700",
 )
 
 load("@io_bazel_rules_kotlin//kotlin:dependencies.bzl", "kt_download_local_dev_dependencies")

--- a/java/arcs/android/common/BUILD
+++ b/java/arcs/android/common/BUILD
@@ -1,4 +1,4 @@
-load("//tools/build_defs/kotlin:rules.bzl", "kt_android_library")
+load("//third_party/java/arcs/build_defs:build_defs.bzl", "arcs_kt_android_library")
 
 licenses(["notice"])
 
@@ -6,7 +6,7 @@ package(default_visibility = ["//visibility:public"])
 
 exports_files(["AndroidManifest.xml"])
 
-kt_android_library(
+arcs_kt_android_library(
     name = "common",
     srcs = glob(["*.kt"]),
     manifest = "AndroidManifest.xml",

--- a/java/arcs/android/common/resurrection/BUILD
+++ b/java/arcs/android/common/resurrection/BUILD
@@ -1,10 +1,10 @@
-load("//tools/build_defs/kotlin:rules.bzl", "kt_android_library")
+load("//third_party/java/arcs/build_defs:build_defs.bzl", "arcs_kt_android_library")
 
 licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])
 
-kt_android_library(
+arcs_kt_android_library(
     name = "resurrection",
     srcs = glob(["*.kt"]),
     manifest = "//java/arcs/android/common:AndroidManifest.xml",

--- a/java/arcs/android/crdt/BUILD
+++ b/java/arcs/android/crdt/BUILD
@@ -3,13 +3,13 @@ load(
     "android_proto_library",
     "proto_library",
 )
-load("//tools/build_defs/kotlin:rules.bzl", "kt_android_library")
+load("//third_party/java/arcs/build_defs:build_defs.bzl", "arcs_kt_android_library")
 
 licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])
 
-kt_android_library(
+arcs_kt_android_library(
     name = "crdt",
     srcs = glob(["*.kt"]),
     idl_parcelables = glob(["*.aidl"]),

--- a/java/arcs/android/crdt/BUILD
+++ b/java/arcs/android/crdt/BUILD
@@ -1,9 +1,9 @@
+load("//third_party/java/arcs/build_defs:build_defs.bzl", "arcs_kt_android_library")
 load(
     "//third_party/java/arcs/build_defs:native.oss.bzl",
     "android_proto_library",
     "proto_library",
 )
-load("//third_party/java/arcs/build_defs:build_defs.bzl", "arcs_kt_android_library")
 
 licenses(["notice"])
 

--- a/java/arcs/android/demo/BUILD
+++ b/java/arcs/android/demo/BUILD
@@ -4,7 +4,7 @@ load(
     "arcs_kt_schema",
 )
 load("//tools/build_defs/android:rules.bzl", "android_binary")
-load("//tools/build_defs/kotlin:rules.bzl", "kt_android_library")
+load("//third_party/java/arcs/build_defs:build_defs.bzl", "arcs_kt_android_library")
 
 licenses(["notice"])
 
@@ -23,7 +23,7 @@ arcs_kt_plan(
     deps = [":schemas"],
 )
 
-kt_android_library(
+arcs_kt_android_library(
     name = "demo_lib",
     srcs = glob(["*.kt"]),
     manifest = ":AndroidManifest.xml",

--- a/java/arcs/android/demo/BUILD
+++ b/java/arcs/android/demo/BUILD
@@ -1,10 +1,10 @@
 load(
     "//third_party/java/arcs/build_defs:build_defs.bzl",
+    "arcs_kt_android_library",
     "arcs_kt_plan",
     "arcs_kt_schema",
 )
 load("//tools/build_defs/android:rules.bzl", "android_binary")
-load("//third_party/java/arcs/build_defs:build_defs.bzl", "arcs_kt_android_library")
 
 licenses(["notice"])
 

--- a/java/arcs/android/host/BUILD
+++ b/java/arcs/android/host/BUILD
@@ -1,10 +1,10 @@
-load("//tools/build_defs/kotlin:rules.bzl", "kt_android_library")
+load("//third_party/java/arcs/build_defs:build_defs.bzl", "arcs_kt_android_library")
 
 licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])
 
-kt_android_library(
+arcs_kt_android_library(
     name = "host",
     srcs = glob(["*.kt"]),
     idl_parcelables = glob(["*.aidl"]),

--- a/java/arcs/android/host/parcelables/BUILD
+++ b/java/arcs/android/host/parcelables/BUILD
@@ -1,10 +1,10 @@
-load("//tools/build_defs/kotlin:rules.bzl", "kt_android_library")
+load("//third_party/java/arcs/build_defs:build_defs.bzl", "arcs_kt_android_library")
 
 licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])
 
-kt_android_library(
+arcs_kt_android_library(
     name = "parcelables",
     srcs = glob(["*.kt"]),
     idl_parcelables = glob(["*.aidl"]),

--- a/java/arcs/android/sdk/host/ArcHostHelper.kt
+++ b/java/arcs/android/sdk/host/ArcHostHelper.kt
@@ -106,6 +106,7 @@ class ArcHostHelper(
         }
     }
 
+    @Suppress("UNUSED_PARAMETER")
     private suspend fun <T : ActualParcelable<U>, U, V> runWithResult(
         intent: Intent,
         parcelable: KClass<T>, // dummy argument for type inference

--- a/java/arcs/android/sdk/host/BUILD
+++ b/java/arcs/android/sdk/host/BUILD
@@ -1,10 +1,10 @@
-load("//tools/build_defs/kotlin:rules.bzl", "kt_android_library")
+load("//third_party/java/arcs/build_defs:build_defs.bzl", "arcs_kt_android_library")
 
 licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])
 
-kt_android_library(
+arcs_kt_android_library(
     name = "host",
     srcs = glob(["*.kt"]),
     idl_parcelables = glob(["*.aidl"]),

--- a/java/arcs/android/storage/BUILD
+++ b/java/arcs/android/storage/BUILD
@@ -1,10 +1,10 @@
-load("//tools/build_defs/kotlin:rules.bzl", "kt_android_library")
+load("//third_party/java/arcs/build_defs:build_defs.bzl", "arcs_kt_android_library")
 
 licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])
 
-kt_android_library(
+arcs_kt_android_library(
     name = "storage",
     srcs = glob(["*.kt"]),
     idl_parcelables = glob(["*.aidl"]),

--- a/java/arcs/android/storage/database/BUILD
+++ b/java/arcs/android/storage/database/BUILD
@@ -1,10 +1,10 @@
-load("//tools/build_defs/kotlin:rules.bzl", "kt_android_library")
+load("//third_party/java/arcs/build_defs:build_defs.bzl", "arcs_kt_android_library")
 
 licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])
 
-kt_android_library(
+arcs_kt_android_library(
     name = "database",
     srcs = glob(["*.kt"]),
     manifest = "//java/arcs/android/common:AndroidManifest.xml",

--- a/java/arcs/android/storage/handle/BUILD
+++ b/java/arcs/android/storage/handle/BUILD
@@ -1,10 +1,10 @@
-load("//tools/build_defs/kotlin:rules.bzl", "kt_android_library")
+load("//third_party/java/arcs/build_defs:build_defs.bzl", "arcs_kt_android_library")
 
 licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])
 
-kt_android_library(
+arcs_kt_android_library(
     name = "handle",
     srcs = glob(["*.kt"]),
     deps = [

--- a/java/arcs/android/storage/service/BUILD
+++ b/java/arcs/android/storage/service/BUILD
@@ -1,5 +1,5 @@
-load("//tools/build_defs/android:rules.bzl", "android_library")
 load("//third_party/java/arcs/build_defs:build_defs.bzl", "arcs_kt_android_library")
+load("//tools/build_defs/android:rules.bzl", "android_library")
 
 licenses(["notice"])
 

--- a/java/arcs/android/storage/service/BUILD
+++ b/java/arcs/android/storage/service/BUILD
@@ -1,5 +1,5 @@
 load("//tools/build_defs/android:rules.bzl", "android_library")
-load("//tools/build_defs/kotlin:rules.bzl", "kt_android_library")
+load("//third_party/java/arcs/build_defs:build_defs.bzl", "arcs_kt_android_library")
 
 licenses(["notice"])
 
@@ -16,7 +16,7 @@ android_library(
     ],
 )
 
-kt_android_library(
+arcs_kt_android_library(
     name = "service",
     srcs = glob(["*.kt"]),
     manifest = "//java/arcs/android/common:AndroidManifest.xml",

--- a/java/arcs/android/storage/ttl/BUILD
+++ b/java/arcs/android/storage/ttl/BUILD
@@ -1,10 +1,10 @@
-load("//tools/build_defs/kotlin:rules.bzl", "kt_android_library")
+load("//third_party/java/arcs/build_defs:build_defs.bzl", "arcs_kt_android_library")
 
 licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])
 
-kt_android_library(
+arcs_kt_android_library(
     name = "ttl",
     srcs = glob(["*.kt"]),
     deps = [

--- a/java/arcs/android/type/BUILD
+++ b/java/arcs/android/type/BUILD
@@ -1,10 +1,10 @@
-load("//tools/build_defs/kotlin:rules.bzl", "kt_android_library")
+load("//third_party/java/arcs/build_defs:build_defs.bzl", "arcs_kt_android_library")
 
 licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])
 
-kt_android_library(
+arcs_kt_android_library(
     name = "type",
     srcs = glob(["*.kt"]),
     idl_parcelables = glob(["*.aidl"]),

--- a/java/arcs/android/util/BUILD
+++ b/java/arcs/android/util/BUILD
@@ -1,10 +1,10 @@
-load("//tools/build_defs/kotlin:rules.bzl", "kt_android_library")
+load("//third_party/java/arcs/build_defs:build_defs.bzl", "arcs_kt_android_library")
 
 licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])
 
-kt_android_library(
+arcs_kt_android_library(
     name = "util",
     srcs = glob(["*.kt"]),
     manifest = "//java/arcs/android/common:AndroidManifest.xml",

--- a/java/arcs/core/host/AbstractArcHost.kt
+++ b/java/arcs/core/host/AbstractArcHost.kt
@@ -383,6 +383,7 @@ abstract class AbstractArcHost(vararg initialParticles: ParticleRegistration) : 
                 ArcState.NeverStarted -> stopArcError(context, "Arc $arcId was never started")
                 ArcState.Stopped -> stopArcError(context, "Arc $arcId already stopped")
                 ArcState.Deleted -> stopArcError(context, "Arc $arcId is deleted.")
+                ArcState.Error -> stopArcError(context, "Arc $arcId encounted an error.")
             }
         }
     }
@@ -391,6 +392,7 @@ abstract class AbstractArcHost(vararg initialParticles: ParticleRegistration) : 
      * If an attempt to [ArcHost.stopArc] fails, this method should report the error message.
      * For example, throw an exception or log.
      */
+    @Suppress("UNUSED_PARAMETER")
     private suspend fun stopArcError(context: ArcHostContext, message: String) {
         // TODO: decide how to propagate this
     }

--- a/java/arcs/core/storage/handle/RawEntityDereferencer.kt
+++ b/java/arcs/core/storage/handle/RawEntityDereferencer.kt
@@ -69,7 +69,6 @@ class RawEntityDereferencer(
                     is ProxyMessage.SyncRequest -> Unit
                     is ProxyMessage.Operations -> Unit
                 }
-                true
             }
         )
 

--- a/java/arcs/sdk/android/dev/api/BUILD
+++ b/java/arcs/sdk/android/dev/api/BUILD
@@ -1,11 +1,11 @@
+load("//tools/build_defs/android:rules.bzl", "android_library")
+
 licenses(["notice"])
 
 package(default_visibility = [
     "//java/arcs:__subpackages__",
     "//javatests/arcs:__subpackages__",
 ])
-
-load("//tools/build_defs/android:rules.bzl", "android_library")
 
 android_library(
     name = "api-android",

--- a/java/arcs/sdk/android/dev/service/BUILD
+++ b/java/arcs/sdk/android/dev/service/BUILD
@@ -1,11 +1,11 @@
+load("//tools/build_defs/android:rules.bzl", "android_library")
+
 package(default_visibility = [
     "//java/arcs:__subpackages__",
     "//javatests/arcs:__subpackages__",
 ])
 
 licenses(["notice"])
-
-load("//tools/build_defs/android:rules.bzl", "android_library")
 
 android_library(
     name = "service",

--- a/java/arcs/sdk/android/dev/service/demo/BUILD
+++ b/java/arcs/sdk/android/dev/service/demo/BUILD
@@ -1,10 +1,10 @@
-licenses(["notice"])
-
 load(
     "//third_party/java/arcs/build_defs:build_defs.bzl",
     "arcs_manifest_bundle",
 )
 load("//tools/build_defs/android:rules.bzl", "android_binary")
+
+licenses(["notice"])
 
 android_binary(
     name = "demo",

--- a/java/arcs/sdk/android/storage/BUILD
+++ b/java/arcs/sdk/android/storage/BUILD
@@ -1,10 +1,10 @@
-load("//tools/build_defs/kotlin:rules.bzl", "kt_android_library")
+load("//third_party/java/arcs/build_defs:build_defs.bzl", "arcs_kt_android_library")
 
 licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])
 
-kt_android_library(
+arcs_kt_android_library(
     name = "storage",
     srcs = glob(["*.kt"]),
     manifest = "//java/arcs/android/common:AndroidManifest.xml",

--- a/java/arcs/sdk/android/storage/service/BUILD
+++ b/java/arcs/sdk/android/storage/service/BUILD
@@ -1,10 +1,10 @@
-load("//tools/build_defs/kotlin:rules.bzl", "kt_android_library")
+load("//third_party/java/arcs/build_defs:build_defs.bzl", "arcs_kt_android_library")
 
 licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])
 
-kt_android_library(
+arcs_kt_android_library(
     name = "service",
     srcs = glob(["*.kt"]),
     manifest = "AndroidManifest.xml",

--- a/java/arcs/sdk/android/storage/service/StorageServiceConnection.kt
+++ b/java/arcs/sdk/android/storage/service/StorageServiceConnection.kt
@@ -75,6 +75,7 @@ interface StorageServiceBindingDelegate {
 class DefaultStorageServiceBindingDelegate(
     private val context: Context
 ) : StorageServiceBindingDelegate {
+    @Suppress("NAME_SHADOWING")
     override fun bindStorageService(
         conn: ServiceConnection,
         flags: Int,

--- a/java/arcs/sdk/android/storage/service/testutil/BUILD
+++ b/java/arcs/sdk/android/storage/service/testutil/BUILD
@@ -1,10 +1,10 @@
-load("//tools/build_defs/kotlin:rules.bzl", "kt_android_library")
+load("//third_party/java/arcs/build_defs:build_defs.bzl", "arcs_kt_android_library")
 
 licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])
 
-kt_android_library(
+arcs_kt_android_library(
     name = "testutil",
     testonly = 1,
     srcs = glob(["*.kt"]),

--- a/java/arcs/sdk/wasm/WasmHandleUtils.kt
+++ b/java/arcs/sdk/wasm/WasmHandleUtils.kt
@@ -372,7 +372,7 @@ fun <T, U, V, W, X, Y, Z, A, B, C> combineUpdates(
 
 @Suppress("UNCHECKED_CAST")
 private fun <T> WasmHandleEvents<T>.getContent(): T = when (this) {
-    is WasmCollectionImpl<*> -> this.fetchAll()
+    is WasmCollectionImpl<*> -> this.fetchAll() as T
     is WasmSingletonImpl<*> -> this.fetch() as T
     else -> throw IllegalArgumentException("Unknown WasmHandleEvents type found")
 }

--- a/java/arcs/sdk/wasm/WasmHandleUtils.kt
+++ b/java/arcs/sdk/wasm/WasmHandleUtils.kt
@@ -370,8 +370,9 @@ fun <T, U, V, W, X, Y, Z, A, B, C> combineUpdates(
     }
 }
 
+@Suppress("UNCHECKED_CAST")
 private fun <T> WasmHandleEvents<T>.getContent(): T = when (this) {
-    is WasmCollectionImpl<*> -> this.fetchAll() as T
+    is WasmCollectionImpl<*> -> this.fetchAll()
     is WasmSingletonImpl<*> -> this.fetch() as T
     else -> throw IllegalArgumentException("Unknown WasmHandleEvents type found")
 }

--- a/javatests/arcs/android/common/resurrection/BUILD
+++ b/javatests/arcs/android/common/resurrection/BUILD
@@ -2,13 +2,13 @@ load(
     "//third_party/java/arcs/build_defs:build_defs.bzl",
     "arcs_kt_android_test_suite",
 )
-load("//tools/build_defs/kotlin:rules.bzl", "kt_android_library")
+load("//third_party/java/arcs/build_defs:build_defs.bzl", "arcs_kt_android_library")
 
 licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])
 
-kt_android_library(
+arcs_kt_android_library(
     name = "support",
     testonly = 1,
     srcs = [

--- a/javatests/arcs/android/common/resurrection/BUILD
+++ b/javatests/arcs/android/common/resurrection/BUILD
@@ -1,8 +1,8 @@
 load(
     "//third_party/java/arcs/build_defs:build_defs.bzl",
+    "arcs_kt_android_library",
     "arcs_kt_android_test_suite",
 )
-load("//third_party/java/arcs/build_defs:build_defs.bzl", "arcs_kt_android_library")
 
 licenses(["notice"])
 

--- a/javatests/arcs/android/host/BUILD
+++ b/javatests/arcs/android/host/BUILD
@@ -3,7 +3,7 @@ load(
     "arcs_kt_android_test_suite",
     "arcs_kt_schema",
 )
-load("//tools/build_defs/kotlin:rules.bzl", "kt_android_library")
+load("//third_party/java/arcs/build_defs:build_defs.bzl", "arcs_kt_android_library")
 
 licenses(["notice"])
 
@@ -61,7 +61,7 @@ arcs_kt_schema(
     ],
 )
 
-kt_android_library(
+arcs_kt_android_library(
     name = "services",
     testonly = True,
     srcs = glob(

--- a/javatests/arcs/android/host/BUILD
+++ b/javatests/arcs/android/host/BUILD
@@ -1,9 +1,9 @@
 load(
     "//third_party/java/arcs/build_defs:build_defs.bzl",
+    "arcs_kt_android_library",
     "arcs_kt_android_test_suite",
     "arcs_kt_schema",
 )
-load("//third_party/java/arcs/build_defs:build_defs.bzl", "arcs_kt_android_library")
 
 licenses(["notice"])
 

--- a/javatests/arcs/android/storage/ReferenceModeStoreDatabaseImplIntegrationTest.kt
+++ b/javatests/arcs/android/storage/ReferenceModeStoreDatabaseImplIntegrationTest.kt
@@ -363,7 +363,6 @@ class ReferenceModeStoreDatabaseImplIntegrationTest {
         val id1 = activeStore.on(ProxyCallback {
             assertThat(it is ProxyMessage.ModelUpdate).isTrue()
             job.complete()
-            true
         })
 
         // another store
@@ -371,7 +370,6 @@ class ReferenceModeStoreDatabaseImplIntegrationTest {
         activeStore.on(
             ProxyCallback {
                 calledStore2 = true
-                true
             }
         )
 
@@ -532,7 +530,6 @@ class ReferenceModeStoreDatabaseImplIntegrationTest {
                 } else {
                     job.completeExceptionally(AssertionError("Invalid ProxyMessage type received"))
                 }
-                true
             }
         )
 

--- a/javatests/arcs/core/allocator/AllocatorTestBase.kt
+++ b/javatests/arcs/core/allocator/AllocatorTestBase.kt
@@ -147,7 +147,7 @@ open class AllocatorTestBase {
             planPartitions, "WritePerson"
         ).particles[0].handles["person"]?.storageKey!!
 
-        val purePartition = findPartitionFor(planPartitions, "PurePerson")!!
+        val purePartition = findPartitionFor(planPartitions, "PurePerson")
 
         val storageKeyLens = Plan.HandleConnection.storageKeyLens
 
@@ -198,12 +198,12 @@ open class AllocatorTestBase {
         val purePartition = findPartitionFor(planPartitions, "PurePerson")
         val writePartition = findPartitionFor(planPartitions, "WritePerson")
 
-        assertThat(readPartition.particles[0]?.handles["person"]?.storageKey).isEqualTo(
-            purePartition.particles[0]?.handles["outputPerson"]?.storageKey
+        assertThat(readPartition.particles[0].handles["person"].storageKey).isEqualTo(
+            purePartition.particles[0].handles["outputPerson"].storageKey
         )
 
-        assertThat(writePartition.particles[0]?.handles["person"]?.storageKey).isEqualTo(
-            purePartition.particles[0]?.handles["inputPerson"]?.storageKey
+        assertThat(writePartition.particles[0].handles["person"].storageKey).isEqualTo(
+            purePartition.particles[0].handles["inputPerson"].storageKey
         )
     }
 

--- a/javatests/arcs/core/allocator/AllocatorTestBase.kt
+++ b/javatests/arcs/core/allocator/AllocatorTestBase.kt
@@ -198,12 +198,12 @@ open class AllocatorTestBase {
         val purePartition = findPartitionFor(planPartitions, "PurePerson")
         val writePartition = findPartitionFor(planPartitions, "WritePerson")
 
-        assertThat(readPartition.particles[0].handles["person"].storageKey).isEqualTo(
-            purePartition.particles[0].handles["outputPerson"].storageKey
+        assertThat(readPartition.particles[0].handles["person"]?.storageKey).isEqualTo(
+            purePartition.particles[0].handles["outputPerson"]?.storageKey
         )
 
-        assertThat(writePartition.particles[0].handles["person"].storageKey).isEqualTo(
-            purePartition.particles[0].handles["inputPerson"].storageKey
+        assertThat(writePartition.particles[0].handles["person"]?.storageKey).isEqualTo(
+            purePartition.particles[0].handles["inputPerson"]?.storageKey
         )
     }
 

--- a/javatests/arcs/core/data/proto/ParticleProtoDecoderTest.kt
+++ b/javatests/arcs/core/data/proto/ParticleProtoDecoderTest.kt
@@ -108,7 +108,7 @@ class ParticleProtoDecoderTest {
             .setSpecName("Reader")
             .addConnections(readConnectionProto)
             .build()
-        val readConnection = readConnectionProto.decode(readerSpec, context)
+        readConnectionProto.decode(readerSpec, context)
         with(particleProto.decode(context)) {
             assertThat(spec).isEqualTo(readerSpec)
             assertThat(handleConnections).isEqualTo(
@@ -135,8 +135,8 @@ class ParticleProtoDecoderTest {
             .addConnections(readConnectionProto)
             .addConnections(writeConnectionProto)
             .build()
-        val readConnection = readConnectionProto.decode(readerWriterSpec, context)
-        val writeConnection = writeConnectionProto.decode(readerWriterSpec, context)
+        readConnectionProto.decode(readerWriterSpec, context)
+        writeConnectionProto.decode(readerWriterSpec, context)
         with(particleProto.decode(context)) {
             assertThat(spec).isEqualTo(readerWriterSpec)
             assertThat(handleConnections).containsExactly(

--- a/javatests/arcs/core/storage/util/ProxyCallbackManagerTest.kt
+++ b/javatests/arcs/core/storage/util/ProxyCallbackManagerTest.kt
@@ -52,7 +52,7 @@ class ProxyCallbackManagerTest {
         0.until(200).map {
             launch {
                 Thread.sleep(random.nextLong(0, 1000))
-                manager.register(ProxyCallback { true })
+                manager.register(ProxyCallback { })
             }
         }.joinAll()
 
@@ -64,11 +64,9 @@ class ProxyCallbackManagerTest {
         val registeredMessage = atomic<ProxyMessage<DummyData, DummyOp, String>?>(null)
         val registeredCallback = ProxyCallback<DummyData, DummyOp, String> {
             registeredMessage.value = it
-            true
         }
         val registeringCallback = ProxyCallback<DummyData, DummyOp, String> {
             manager.register(registeredCallback)
-            true
         }
 
         val shouldBeReceivedByRegistered = makeMessage("bar", 2)
@@ -88,12 +86,10 @@ class ProxyCallbackManagerTest {
         val registeredCallback =
             MultiplexedProxyCallback<DummyData, DummyOp, String> { message, _ ->
                 registeredMessage.value = message
-                true
             }
         val registeringCallback =
             MultiplexedProxyCallback<DummyData, DummyOp, String> { _, _ ->
                 manager.register(registeredCallback)
-                true
             }
 
         val shouldBeReceivedByRegistered = makeMessage("bar", 2)

--- a/javatests/arcs/sdk/HandleUtilsTest.kt
+++ b/javatests/arcs/sdk/HandleUtilsTest.kt
@@ -11,14 +11,12 @@
 
 package arcs.sdk
 
-import arcs.core.common.Id
 import arcs.core.entity.ReadWriteCollectionHandle
 import arcs.core.entity.ReadWriteSingletonHandle
 import arcs.core.host.EntityHandleManager
 import arcs.core.host.HandleMode
 import arcs.core.storage.driver.RamDisk
 import arcs.core.storage.driver.RamDiskDriverProvider
-import arcs.core.storage.handle.Stores
 import arcs.core.storage.keys.RamDiskStorageKey
 import arcs.core.storage.referencemode.ReferenceModeStorageKey
 import arcs.jvm.util.testutil.TimeImpl
@@ -38,7 +36,6 @@ private typealias Person = ReadSdkPerson_Person
 @Suppress("UNCHECKED_CAST", "UNUSED_PARAMETER")
 class HandleUtilsTest {
   private lateinit var manager: EntityHandleManager
-  private val idGenerator = Id.Generator.newForTest("session")
 
   @Before
   fun setUp() {
@@ -300,7 +297,7 @@ class HandleUtilsTest {
       handle3,
       handle4,
       handle5
-    ) { e1, e2, e3, e4, e5 ->
+    ) { _, _, _, _, _ ->
       tracking5 += 1
     }
 
@@ -311,7 +308,7 @@ class HandleUtilsTest {
       handle4,
       handle5,
       handle6
-    ) { e1, e2, e3, e4, e5, e6 ->
+    ) { _, _, _, _, _, _ ->
       tracking6 += 1
     }
 
@@ -323,7 +320,7 @@ class HandleUtilsTest {
       handle5,
       handle6,
       handle7
-    ) { e1, e2, e3, e4, e5, e6, e7 ->
+    ) { _, _, _, _, _, _, _ ->
       tracking7 += 1
     }
 
@@ -336,7 +333,7 @@ class HandleUtilsTest {
       handle6,
       handle7,
       handle8
-    ) { e1, e2, e3, e4, e5, e6, e7, e8 ->
+    ) { _, _, _, _, _, _, _, _ ->
       tracking8 += 1
     }
 
@@ -350,7 +347,7 @@ class HandleUtilsTest {
       handle7,
       handle8,
       handle9
-    ) { e1, e2, e3, e4, e5, e6, e7, e8, e9 ->
+    ) { _, _, _, _, _, _, _, _, _ ->
       tracking9 += 1
     }
 
@@ -365,7 +362,7 @@ class HandleUtilsTest {
       handle8,
       handle9,
       handle10
-    ) { e1, e2, e3, e4, e5, e6, e7, e8, e9, e10 ->
+    ) { _, _, _, _, _, _, _, _, _, _ ->
       tracking10 += 1
     }
     

--- a/javatests/arcs/sdk/HandleUtilsTest.kt
+++ b/javatests/arcs/sdk/HandleUtilsTest.kt
@@ -215,6 +215,7 @@ class HandleUtilsTest {
     assertWithMessage("Expected handle4 to equal D").that(handle4Tracking).isEqualTo(1)
   }
 
+  @Suppress("UNUSED_PARAMETER")
   @Test
   fun handleUtils_combineTenUpdatesTest() = runBlockingTest {
     val handle1 = manager.createCollectionHandle(

--- a/javatests/arcs/sdk/HandleUtilsTest.kt
+++ b/javatests/arcs/sdk/HandleUtilsTest.kt
@@ -35,7 +35,7 @@ private typealias Person = ReadSdkPerson_Person
 
 @RunWith(JUnit4::class)
 @OptIn(ExperimentalCoroutinesApi::class)
-@Suppress("UNCHECKED_CAST")
+@Suppress("UNCHECKED_CAST", "UNUSED_PARAMETER")
 class HandleUtilsTest {
   private lateinit var manager: EntityHandleManager
   private val idGenerator = Id.Generator.newForTest("session")
@@ -215,7 +215,6 @@ class HandleUtilsTest {
     assertWithMessage("Expected handle4 to equal D").that(handle4Tracking).isEqualTo(1)
   }
 
-  @Suppress("UNUSED_PARAMETER")
   @Test
   fun handleUtils_combineTenUpdatesTest() = runBlockingTest {
     val handle1 = manager.createCollectionHandle(

--- a/javatests/arcs/sdk/android/storage/BUILD
+++ b/javatests/arcs/sdk/android/storage/BUILD
@@ -2,13 +2,13 @@ load(
     "//third_party/java/arcs/build_defs:build_defs.bzl",
     "arcs_kt_android_test_suite",
 )
-load("//tools/build_defs/kotlin:rules.bzl", "kt_android_library")
+load("//third_party/java/arcs/build_defs:build_defs.bzl", "arcs_kt_android_library")
 
 licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])
 
-kt_android_library(
+arcs_kt_android_library(
     name = "support",
     testonly = 1,
     srcs = [

--- a/javatests/arcs/sdk/android/storage/BUILD
+++ b/javatests/arcs/sdk/android/storage/BUILD
@@ -1,8 +1,8 @@
 load(
     "//third_party/java/arcs/build_defs:build_defs.bzl",
+    "arcs_kt_android_library",
     "arcs_kt_android_test_suite",
 )
-load("//third_party/java/arcs/build_defs:build_defs.bzl", "arcs_kt_android_library")
 
 licenses(["notice"])
 

--- a/third_party/java/arcs/build_defs/internal/kotlin.bzl
+++ b/third_party/java/arcs/build_defs/internal/kotlin.bzl
@@ -131,6 +131,8 @@ def arcs_kt_android_library(**kwargs):
     if not IS_BAZEL:
         kwargs["disable_lint_checks"] = merge_lists(disable_lint_checks, DISABLED_LINT_CHECKS)
 
+    kotlincopts = kwargs.pop("kotlincopts", [])
+    kwargs["kotlincopts"] = merge_lists(kotlincopts, KOTLINC_OPTS)
     kt_android_library(**kwargs)
 
 def arcs_kt_native_library(**kwargs):
@@ -371,7 +373,7 @@ def arcs_kt_android_test_suite(name, manifest, package, srcs = None, tags = [], 
     if not srcs:
         srcs = native.glob(["*.kt"])
 
-    kt_android_library(
+    arcs_kt_android_library(
         name = name,
         testonly = True,
         srcs = srcs,

--- a/third_party/java/arcs/build_defs/internal/kotlin.bzl
+++ b/third_party/java/arcs/build_defs/internal/kotlin.bzl
@@ -44,11 +44,14 @@ _KT_SUFFIX = "-kt"
 IS_BAZEL = not (hasattr(native, "genmpm"))
 
 # Kotlin Compiler Options
-KOTLINC_OPTS = [
+COMMON_KOTLINC_OPTS = [
     "-Xallow-kotlin-package",
     "-Xinline-classes",
     "-Xmulti-platform",
     "-Xuse-experimental=kotlin.ExperimentalMultiplatform",
+]
+
+JVM_KOTLINC_OPTS = [
     "-Xskip-runtime-version-check",
 ]
 
@@ -86,7 +89,7 @@ def arcs_kt_jvm_library(**kwargs):
     constraints = kwargs.pop("constraints", ["android"] if add_android_constraints else [])
     disable_lint_checks = kwargs.pop("disable_lint_checks", [])
     exports = kwargs.pop("exports", [])
-    kotlincopts = merge_lists(kwargs.pop("kotlincopts", []), KOTLINC_OPTS)
+    kotlincopts = merge_lists(kwargs.pop("kotlincopts", []), COMMON_KOTLINC_OPTS + JVM_KOTLINC_OPTS)
 
     if not IS_BAZEL:
         kwargs["constraints"] = constraints
@@ -132,7 +135,7 @@ def arcs_kt_android_library(**kwargs):
         kwargs["disable_lint_checks"] = merge_lists(disable_lint_checks, DISABLED_LINT_CHECKS)
 
     kotlincopts = kwargs.pop("kotlincopts", [])
-    kwargs["kotlincopts"] = merge_lists(kotlincopts, KOTLINC_OPTS)
+    kwargs["kotlincopts"] = merge_lists(kotlincopts, COMMON_KOTLINC_OPTS + JVM_KOTLINC_OPTS)
     kt_android_library(**kwargs)
 
 def arcs_kt_native_library(**kwargs):
@@ -142,7 +145,7 @@ def arcs_kt_native_library(**kwargs):
       **kwargs: Set of args to forward to kt_native_library
     """
     kotlincopts = kwargs.pop("kotlincopts", [])
-    kwargs["kotlincopts"] = merge_lists(kotlincopts, KOTLINC_OPTS)
+    kwargs["kotlincopts"] = merge_lists(kotlincopts, COMMON_KOTLINC_OPTS)
     kt_native_library(**kwargs)
 
 def arcs_kt_js_library(**kwargs):
@@ -157,7 +160,7 @@ def arcs_kt_js_library(**kwargs):
         return
 
     kotlincopts = kwargs.pop("kotlincopts", [])
-    kwargs["kotlincopts"] = merge_lists(kotlincopts, KOTLINC_OPTS)
+    kwargs["kotlincopts"] = merge_lists(kotlincopts, COMMON_KOTLINC_OPTS)
     kt_js_library(**kwargs)
 
 def arcs_kt_library(

--- a/tools/gcb.bazelrc
+++ b/tools/gcb.bazelrc
@@ -1,8 +1,9 @@
 build --strategy=KotlinCompile=worker
 build --remote_cache=https://storage.googleapis.com/arcs-github-gcb-bazel-cache --google_default_credentials
 build --verbose_failures --spawn_strategy=sandboxed --jobs=32 --ram_utilization_factor=33
-build --nostamp --noshow_progress
+build --nostamp --noshow_progress --show_result 0
 test --spawn_strategy=sandboxed --nocache_test_results --test_output=errors --jobs=32 --ram_utilization_factor=33
-test --nostamp --noshow_progress
+test --nostamp --noshow_progress --show_result 0
+
 
 

--- a/tools/gcb.bazelrc
+++ b/tools/gcb.bazelrc
@@ -1,7 +1,8 @@
 build --strategy=KotlinCompile=worker
 build --remote_cache=https://storage.googleapis.com/arcs-github-gcb-bazel-cache --google_default_credentials
 build --verbose_failures --spawn_strategy=sandboxed --jobs=32 --ram_utilization_factor=33
-build --nostamp
+build --nostamp --noshow_progress
 test --spawn_strategy=sandboxed --nocache_test_results --test_output=errors --jobs=32 --ram_utilization_factor=33
-test --nostamp
+test --nostamp --noshow_progress
+
 


### PR DESCRIPTION
* switch kt_android_library to arcs_kt_android_library
* propagate kotlincopts for android targets
* fix up unused code
* update downstream dependencies to versions that use the same kotlin version (1.3.70)
