### PR TITLE
Fixes bug where wrong schema is used to dereference nested references

### DIFF
--- a/java/arcs/core/entity/BUILD
+++ b/java/arcs/core/entity/BUILD
@@ -13,5 +13,6 @@ arcs_kt_library(
         "//java/arcs/core/data:rawentity",
         "//java/arcs/core/data/util:data-util",
         "//java/arcs/core/storage",
+        "//java/arcs/core/storage/handle",
     ],
 )

--- a/java/arcs/core/entity/EntityDereferencerFactory.kt
+++ b/java/arcs/core/entity/EntityDereferencerFactory.kt
@@ -1,0 +1,54 @@
+package arcs.core.entity
+
+import arcs.core.data.FieldType
+import arcs.core.data.RawEntity
+import arcs.core.data.Schema
+import arcs.core.storage.ActivationFactory
+import arcs.core.storage.Dereferencer
+import arcs.core.storage.Reference
+import arcs.core.storage.StoreManager
+import arcs.core.storage.handle.RawEntityDereferencer
+
+/** A [Dereferencer.Factory] for [Reference] and [RawEntity] classes. */
+class EntityDereferencerFactory(
+    private val stores: StoreManager,
+    private val entityActivationFactory: ActivationFactory? = null
+) : Dereferencer.Factory<RawEntity> {
+    private val dereferencers = mutableMapOf<Schema, RawEntityDereferencer>()
+
+    override fun create(schema: Schema) = dereferencers.getOrPut(
+        schema,
+        { RawEntityDereferencer(schema, stores, entityActivationFactory) }
+    )
+
+    /**
+     * Recursively inject the [Dereferencer] into any [Reference]s in the receiving object.
+     */
+    override fun injectDereferencers(schema: Schema, value: Any?) {
+        if (value == null) return
+        when (value) {
+            is Reference -> value.dereferencer = create(schema)
+            is RawEntity -> injectDereferencers(schema, value)
+            is Set<*> -> value.forEach { injectDereferencers(schema, it) }
+        }
+    }
+
+    private fun injectDereferencers(schema: Schema, rawEntity: RawEntity) {
+        fun injectField(fieldType: FieldType?, fieldValue: Any?) {
+            if (fieldType is FieldType.EntityRef) {
+                val fieldSchema = requireNotNull(
+                    SchemaRegistry.getSchema(fieldType.schemaHash)
+                ) {
+                    "Unknown schema with hash ${fieldType.schemaHash}."
+                }
+                injectDereferencers(fieldSchema, fieldValue)
+            }
+        }
+        rawEntity.singletons.forEach { (field, value) ->
+            injectField(schema.fields.singletons[field], value)
+        }
+        rawEntity.collections.forEach { (field, value) ->
+            injectField(schema.fields.singletons[field], value)
+        }
+    }
+}

--- a/java/arcs/core/entity/EntityDereferencerFactory.kt
+++ b/java/arcs/core/entity/EntityDereferencerFactory.kt
@@ -16,10 +16,9 @@ class EntityDereferencerFactory(
 ) : Dereferencer.Factory<RawEntity> {
     private val dereferencers = mutableMapOf<Schema, RawEntityDereferencer>()
 
-    override fun create(schema: Schema) = dereferencers.getOrPut(
-        schema,
-        { RawEntityDereferencer(schema, stores, entityActivationFactory) }
-    )
+    override fun create(schema: Schema) = dereferencers.getOrPut(schema) {
+        RawEntityDereferencer(schema, stores, entityActivationFactory)
+    }
 
     /**
      * Recursively inject the [Dereferencer] into any [Reference]s in the receiving object.
@@ -48,7 +47,7 @@ class EntityDereferencerFactory(
             injectField(schema.fields.singletons[field], value)
         }
         rawEntity.collections.forEach { (field, value) ->
-            injectField(schema.fields.singletons[field], value)
+            injectField(schema.fields.collections[field], value)
         }
     }
 }

--- a/java/arcs/core/host/EntityHandleManager.kt
+++ b/java/arcs/core/host/EntityHandleManager.kt
@@ -22,6 +22,7 @@ import arcs.core.data.Schema
 import arcs.core.data.SingletonType
 import arcs.core.data.Ttl
 import arcs.core.entity.Entity
+import arcs.core.entity.EntityDereferencerFactory
 import arcs.core.entity.EntitySpec
 import arcs.core.entity.Handle
 import arcs.core.entity.ReadCollectionHandle
@@ -32,7 +33,6 @@ import arcs.core.entity.Reference
 import arcs.core.entity.WriteCollectionHandle
 import arcs.core.entity.WriteSingletonHandle
 import arcs.core.storage.ActivationFactory
-import arcs.core.storage.Dereferencer
 import arcs.core.storage.Reference as StorageReference
 import arcs.core.storage.StorageKey
 import arcs.core.storage.StorageMode.ReferenceMode
@@ -41,8 +41,6 @@ import arcs.core.storage.StoreManager
 import arcs.core.storage.handle.CollectionHandle
 import arcs.core.storage.handle.CollectionProxy
 import arcs.core.storage.handle.CollectionStoreOptions
-import arcs.core.storage.handle.RawEntityDereferencer
-import arcs.core.storage.handle.SingletonHandle
 import arcs.core.storage.handle.SingletonProxy
 import arcs.core.storage.handle.SingletonStoreOptions
 import arcs.core.storage.referencemode.ReferenceModeStorageKey
@@ -54,25 +52,25 @@ import arcs.core.util.Time
  * `arcs_kt_schema` on a manifest file to generate a `{ParticleName}Handles' class, and
  * invoke its default constructor, or obtain it from the [BaseParticle.handles] field.
  *
- * TODO(cromwellian): Add support for creating Singleton/Set handles of [Reference]s.
+ * TODO(csilvestrini): Add support for creating Singleton/Set handles of [Reference]s.
  */
 class EntityHandleManager(
     private val arcId: String = Id.Generator.newSession().newArcId("arc").toString(),
     private val hostId: String = "nohost",
     private val time: Time,
     private val stores: StoreManager = StoreManager(),
-    private val activationFactory: ActivationFactory? = null
+    activationFactory: ActivationFactory? = null
 ) {
 
     private val singletonStorageProxies = mutableMapOf<StorageKey, SingletonProxy<RawEntity>>()
     private val collectionStorageProxies = mutableMapOf<StorageKey, CollectionProxy<RawEntity>>()
+    private val dereferencerFactory = EntityDereferencerFactory(stores, activationFactory)
+
     /**
-     * Creates and returns a new [SingletonHandle] for managing an [Entity].
+     * Creates and returns a new singleton handle for managing an [Entity].
      *
      * @property mode indicates whether the handle is allowed to read or write
-     * @property name name for the handle
-     * @property storageKey a [StorageKey]
-     * @property sender block used to execute callback lambdas
+     * @property baseName part of the name for the handle
      * @property idGenerator used to generate unique IDs for newly stored entities.
      */
     suspend fun <T : Entity> createSingletonHandle(
@@ -107,18 +105,12 @@ class EntityHandleManager(
             SingletonProxy(store, CrdtSingleton())
         }
 
-        val dereferencer: Dereferencer<RawEntity>? = RawEntityDereferencer(
-            entitySpec.SCHEMA,
-            stores,
-            activationFactory
-        )
-
         return when (mode) {
             HandleMode.Read -> ReadSingletonHandleAdapter(
                 name = name,
                 entitySpec = entitySpec,
                 storageProxy = storageProxy,
-                dereferencer = dereferencer
+                dereferencerFactory = dereferencerFactory
             )
             HandleMode.Write -> WriteSingletonHandleAdapter<T>(
                 name = name,
@@ -126,22 +118,21 @@ class EntityHandleManager(
                 entityPreparer = entityPrep
             )
             HandleMode.ReadWrite -> ReadWriteSingletonHandleAdapter(
-                    name = name,
-                    entitySpec = entitySpec,
-                    storageProxy = storageProxy,
-                    entityPreparer = entityPrep,
-                    dereferencer = dereferencer
-                )
+                name = name,
+                entitySpec = entitySpec,
+                storageProxy = storageProxy,
+                entityPreparer = entityPrep,
+                dereferencerFactory = dereferencerFactory
+            )
         }
     }
 
     /**
-     * Creates and returns a new [CollectionHandle] for a set of [Entity]s.
+     * Creates and returns a new collection handle for a set of [Entity]s.
      *
      * @property mode indicates whether the handle is allowed to read or write
-     * @property name name for the handle
+     * @property baseName part of the name for the handle
      * @property storageKey a [StorageKey]
-     * @property sender block used to execute callback lambdas
      * @property idGenerator used to generate unique IDs for newly stored entities.
      */
     suspend fun <T : Entity> createCollectionHandle(
@@ -176,31 +167,25 @@ class EntityHandleManager(
             CollectionProxy(store, CrdtSet())
         }
 
-        val dereferencer: Dereferencer<RawEntity>? = RawEntityDereferencer(
-            entitySpec.SCHEMA,
-            stores,
-            activationFactory
-        )
-
         return when (mode) {
-            HandleMode.Read ->
-                ReadCollectionHandleAdapter(
-                    name = name,
-                    entitySpec = entitySpec,
-                    storageProxy = storageProxy,
-                    dereferencer = dereferencer
-                )
-            HandleMode.Write -> WriteCollectionHandleAdapter<T>(
+            HandleMode.Read -> ReadCollectionHandleAdapter(
                 name = name,
-                storageProxy = storageProxy, entityPreparer = entityPrep
+                entitySpec = entitySpec,
+                storageProxy = storageProxy,
+                dereferencerFactory = dereferencerFactory
+            )
+            HandleMode.Write -> WriteCollectionHandleAdapter(
+                name = name,
+                storageProxy = storageProxy,
+                entityPreparer = entityPrep
             )
             HandleMode.ReadWrite -> ReadWriteCollectionHandleAdapter(
-                    name = name,
-                    entitySpec = entitySpec,
-                    storageProxy = storageProxy,
-                    entityPreparer = entityPrep,
-                    dereferencer = dereferencer
-                )
+                name = name,
+                entitySpec = entitySpec,
+                storageProxy = storageProxy,
+                entityPreparer = entityPrep,
+                dereferencerFactory = dereferencerFactory
+            )
         }
     }
 }
@@ -210,11 +195,11 @@ class ReadSingletonHandleAdapter<T : Entity>(
     name: String,
     entitySpec: EntitySpec<T>,
     storageProxy: SingletonProxy<RawEntity>,
-    dereferencer: Dereferencer<RawEntity>?
+    dereferencerFactory: EntityDereferencerFactory
 ) : BaseHandleAdapter(name, storageProxy),
     ReadSingletonHandle<T>,
     ReadSingletonOperations<T> by
-        ReadSingletonOperationsImpl<T>(name, entitySpec, storageProxy, dereferencer)
+    ReadSingletonOperationsImpl<T>(name, entitySpec, storageProxy, dereferencerFactory)
 
 /** A concrete writable singleton handle implementation. */
 class WriteSingletonHandleAdapter<T : Entity>(
@@ -224,7 +209,7 @@ class WriteSingletonHandleAdapter<T : Entity>(
 ) : BaseHandleAdapter(name, storageProxy),
     WriteSingletonHandle<T>,
     WriteSingletonOperations<T> by
-        WriteSingletonOperationsImpl<T>(name, storageProxy, entityPreparer)
+    WriteSingletonOperationsImpl<T>(name, storageProxy, entityPreparer)
 
 /** A concrete readable + writable singleton handle implementation. */
 class ReadWriteSingletonHandleAdapter<T : Entity>(
@@ -232,24 +217,24 @@ class ReadWriteSingletonHandleAdapter<T : Entity>(
     entitySpec: EntitySpec<T>,
     storageProxy: SingletonProxy<RawEntity>,
     entityPreparer: EntityPreparer<T>,
-    dereferencer: Dereferencer<RawEntity>?
+    dereferencerFactory: EntityDereferencerFactory
 ) : BaseHandleAdapter(name, storageProxy),
     ReadWriteSingletonHandle<T>,
     ReadSingletonOperations<T> by
-        ReadSingletonOperationsImpl<T>(name, entitySpec, storageProxy, dereferencer),
+    ReadSingletonOperationsImpl<T>(name, entitySpec, storageProxy, dereferencerFactory),
     WriteSingletonOperations<T> by
-        WriteSingletonOperationsImpl<T>(name, storageProxy, entityPreparer)
+    WriteSingletonOperationsImpl<T>(name, storageProxy, entityPreparer)
 
 /** A concrete readable collection handle implementation. */
 class ReadCollectionHandleAdapter<T : Entity>(
     name: String,
     entitySpec: EntitySpec<T>,
     storageProxy: CollectionProxy<RawEntity>,
-    dereferencer: Dereferencer<RawEntity>?
+    dereferencerFactory: EntityDereferencerFactory
 ) : BaseHandleAdapter(name, storageProxy),
     ReadCollectionHandle<T>,
     ReadCollectionOperations<T> by
-        ReadCollectionOperationsImpl<T>(name, entitySpec, storageProxy, dereferencer)
+    ReadCollectionOperationsImpl<T>(name, entitySpec, storageProxy, dereferencerFactory)
 
 /** A concrete writable collection handle implementation. */
 class WriteCollectionHandleAdapter<T : Entity>(
@@ -259,7 +244,7 @@ class WriteCollectionHandleAdapter<T : Entity>(
 ) : BaseHandleAdapter(name, storageProxy),
     WriteCollectionHandle<T>,
     WriteCollectionOperations<T> by
-        WriteCollectionOperationsImpl<T>(name, storageProxy, entityPreparer)
+    WriteCollectionOperationsImpl<T>(name, storageProxy, entityPreparer)
 
 /** A concrete readable & writable collection handle implementation. */
 class ReadWriteCollectionHandleAdapter<T : Entity>(
@@ -267,26 +252,31 @@ class ReadWriteCollectionHandleAdapter<T : Entity>(
     entitySpec: EntitySpec<T>,
     storageProxy: CollectionProxy<RawEntity>,
     entityPreparer: EntityPreparer<T>,
-    dereferencer: Dereferencer<RawEntity>?
+    dereferencerFactory: EntityDereferencerFactory
 ) : BaseHandleAdapter(name, storageProxy),
     ReadWriteCollectionHandle<T>,
     ReadCollectionOperations<T> by
-        ReadCollectionOperationsImpl<T>(name, entitySpec, storageProxy, dereferencer),
+    ReadCollectionOperationsImpl<T>(name, entitySpec, storageProxy, dereferencerFactory),
     WriteCollectionOperations<T> by
-        WriteCollectionOperationsImpl<T>(name, storageProxy, entityPreparer)
+    WriteCollectionOperationsImpl<T>(name, storageProxy, entityPreparer)
 
 /** Implementation of singleton read operations to mix into concrete instances. */
 private class ReadSingletonOperationsImpl<T : Entity>(
     private val name: String,
     private val entitySpec: EntitySpec<T>,
     private val storageProxy: SingletonProxy<RawEntity>,
-    private val dereferencer: Dereferencer<RawEntity>?
+    private val dereferencerFactory: EntityDereferencerFactory
 ) : ReadSingletonOperations<T> {
-    override suspend fun fetch() =
-        storageProxy.getParticleView()?.let { entitySpec.deserialize(it) }
+
+    private fun adaptValue(value: RawEntity?): T? = value?.let {
+        dereferencerFactory.injectDereferencers(entitySpec.SCHEMA, value)
+        entitySpec.deserialize(value)
+    }
+
+    override suspend fun fetch() = adaptValue(storageProxy.getParticleView())
 
     override suspend fun onUpdate(action: suspend (T?) -> Unit) = storageProxy.addOnUpdate(name) {
-        action(it?.let { entitySpec.deserialize(it) })
+        action(adaptValue(it))
     }
 
     override suspend fun createReference(entity: T): Reference<T> {
@@ -303,7 +293,7 @@ private class ReadSingletonOperationsImpl<T : Entity>(
         return Reference(
             entitySpec,
             StorageReference(entity.serialize().id, storageKey.backingKey, null).also {
-                it.dereferencer = dereferencer
+                it.dereferencer = dereferencerFactory.create(entitySpec.SCHEMA)
             }
         )
     }
@@ -336,19 +326,21 @@ private class ReadCollectionOperationsImpl<T : Entity>(
     private val name: String,
     private val entitySpec: EntitySpec<T>,
     private val storageProxy: CollectionProxy<RawEntity>,
-    private val dereferencer: Dereferencer<RawEntity>?
+    private val dereferencerFactory: EntityDereferencerFactory
 ) : ReadCollectionOperations<T> {
     override suspend fun size() = fetchAll().size
     override suspend fun isEmpty() = fetchAll().isEmpty()
 
-    private fun Set<RawEntity>.adaptValues() =
-        map { entitySpec.deserialize(it) }.toSet()
+    private fun adaptValues(values: Set<RawEntity>) = values.map {
+        dereferencerFactory.injectDereferencers(entitySpec.SCHEMA, it)
+        entitySpec.deserialize(it)
+    }.toSet()
 
-    override suspend fun fetchAll() = storageProxy.getParticleView().adaptValues()
+    override suspend fun fetchAll() = adaptValues(storageProxy.getParticleView())
 
     override suspend fun onUpdate(action: suspend (Set<T>) -> Unit) =
         storageProxy.addOnUpdate(name) {
-            action(it.adaptValues())
+            action(adaptValues(it))
         }
 
     override suspend fun createReference(entity: T): Reference<T> {
@@ -365,7 +357,7 @@ private class ReadCollectionOperationsImpl<T : Entity>(
         return Reference(
             entitySpec,
             StorageReference(entity.serialize().id, storageKey.backingKey, null).also {
-                it.dereferencer = dereferencer
+                it.dereferencer = dereferencerFactory.create(entitySpec.SCHEMA)
             }
         )
     }
@@ -406,14 +398,9 @@ private class WriteCollectionOperationsImpl<T : Entity>(
 
 /** Base functionality common to all read/write singleton and collection handles. */
 abstract class BaseHandleAdapter(
-    name: String,
+    override val name: String,
     private val storageProxy: StorageProxy<*, *, *>
 ) : Handle {
-    // VisibleForTesting
-    val actorName = name
-
-    override val name = name
-
     override suspend fun onSync(action: () -> Unit) = storageProxy.addOnSync(name, action)
 
     override suspend fun onDesync(action: () -> Unit) = storageProxy.addOnDesync(name, action)
@@ -473,7 +460,7 @@ class EntityPreparer<T : Entity>(
 
         val rawEntity = entity.serialize()
 
-        rawEntity.creationTimestamp = requireNotNull(time).currentTimeMillis
+        rawEntity.creationTimestamp = time.currentTimeMillis
         require(schema.refinement(rawEntity)) {
             "Invalid entity stored to handle $handleName(failed refinement)"
         }

--- a/javatests/arcs/android/entity/DifferentAndroidHandleManagerDifferentStoresTest.kt
+++ b/javatests/arcs/android/entity/DifferentAndroidHandleManagerDifferentStoresTest.kt
@@ -15,6 +15,7 @@ import arcs.sdk.android.storage.service.testutil.TestConnectionFactory
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runBlockingTest
+import org.junit.After
 import org.junit.Before
 import org.junit.runner.RunWith
 
@@ -34,7 +35,8 @@ class DifferentAndroidHandleManagerDifferentStoresTest : HandleManagerTestBase()
     }
 
     @Before
-    fun setUp() {
+    override fun setUp() {
+        super.setUp()
         app = ApplicationProvider.getApplicationContext()
         val testConnectionFactory = TestConnectionFactory(app)
         readHandleManager = EntityHandleManager(
@@ -62,6 +64,9 @@ class DifferentAndroidHandleManagerDifferentStoresTest : HandleManagerTestBase()
         // Initialize WorkManager for instrumentation tests.
         WorkManagerTestInitHelper.initializeTestWorkManager(app)
     }
+
+    @After
+    override fun tearDown() = super.tearDown()
 
     // TODO - fix these?
     override fun collection_referenceLiveness() {}

--- a/javatests/arcs/android/entity/DifferentHandleManagerTest.kt
+++ b/javatests/arcs/android/entity/DifferentHandleManagerTest.kt
@@ -14,6 +14,7 @@ import arcs.sdk.android.storage.ServiceStoreFactory
 import arcs.sdk.android.storage.service.testutil.TestConnectionFactory
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.runBlocking
+import org.junit.After
 import org.junit.Before
 import org.junit.runner.RunWith
 
@@ -33,7 +34,8 @@ class DifferentHandleManagerTest : HandleManagerTestBase() {
     }
 
     @Before
-    fun setUp() {
+    override fun setUp() {
+        super.setUp()
         app = ApplicationProvider.getApplicationContext()
         val stores = StoreManager()
         val testConnectionFactory = TestConnectionFactory(app)
@@ -62,4 +64,7 @@ class DifferentHandleManagerTest : HandleManagerTestBase() {
         // Initialize WorkManager for instrumentation tests.
         WorkManagerTestInitHelper.initializeTestWorkManager(app)
     }
+
+    @After
+    override fun tearDown() = super.tearDown()
 }

--- a/javatests/arcs/android/entity/SameHandleManagerTest.kt
+++ b/javatests/arcs/android/entity/SameHandleManagerTest.kt
@@ -14,6 +14,7 @@ import arcs.sdk.android.storage.ServiceStoreFactory
 import arcs.sdk.android.storage.service.testutil.TestConnectionFactory
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.runBlocking
+import org.junit.After
 import org.junit.Before
 import org.junit.runner.RunWith
 
@@ -33,7 +34,8 @@ class SameHandleManagerTest : HandleManagerTestBase() {
     }
 
     @Before
-    fun setUp() {
+    override fun setUp() {
+        super.setUp()
         app = ApplicationProvider.getApplicationContext()
         readHandleManager = EntityHandleManager(
             arcId = "arcId",
@@ -51,4 +53,7 @@ class SameHandleManagerTest : HandleManagerTestBase() {
         // Initialize WorkManager for instrumentation tests.
         WorkManagerTestInitHelper.initializeTestWorkManager(app)
     }
+
+    @After
+    override fun tearDown() = super.tearDown()
 }

--- a/javatests/arcs/android/host/AndroidEntityHandleManagerTest.kt
+++ b/javatests/arcs/android/host/AndroidEntityHandleManagerTest.kt
@@ -283,8 +283,8 @@ class AndroidEntityHandleManagerTest : LifecycleOwner {
             HandleMode.Write
         )
 
-        assertThat(shandle1.actorName).isNotEqualTo(shandle2.actorName)
-        assertThat(chandle1.actorName).isNotEqualTo(chandle2.actorName)
+        assertThat(shandle1.name).isNotEqualTo(shandle2.name)
+        assertThat(chandle1.name).isNotEqualTo(chandle2.name)
     }
 
     private suspend fun createSingletonHandle(

--- a/javatests/arcs/core/entity/DifferentHandleManagerDifferentStoresTest.kt
+++ b/javatests/arcs/core/entity/DifferentHandleManagerDifferentStoresTest.kt
@@ -3,6 +3,7 @@ package arcs.core.entity
 import arcs.core.host.EntityHandleManager
 import arcs.core.storage.StoreManager
 import arcs.jvm.util.testutil.TimeImpl
+import org.junit.After
 import org.junit.Before
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
@@ -12,7 +13,8 @@ import org.junit.runners.JUnit4
 class DifferentHandleManagerDifferentStoresTest : HandleManagerTestBase() {
 
     @Before
-    fun setUp() {
+    override fun setUp() {
+        super.setUp()
         readHandleManager = EntityHandleManager(
             arcId = "testArcId",
             hostId = "testHostId",
@@ -26,6 +28,9 @@ class DifferentHandleManagerDifferentStoresTest : HandleManagerTestBase() {
             stores = StoreManager()
         )
     }
+
+    @After
+    override fun tearDown() = super.tearDown()
 
     // TODO - fix these?
     override fun collection_referenceLiveness() {}

--- a/javatests/arcs/core/entity/DifferentHandleManagerTest.kt
+++ b/javatests/arcs/core/entity/DifferentHandleManagerTest.kt
@@ -3,6 +3,7 @@ package arcs.core.entity
 import arcs.core.host.EntityHandleManager
 import arcs.core.storage.StoreManager
 import arcs.jvm.util.testutil.TimeImpl
+import org.junit.After
 import org.junit.Before
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
@@ -12,7 +13,8 @@ import org.junit.runners.JUnit4
 class DifferentHandleManagerTest : HandleManagerTestBase() {
 
     @Before
-    fun setUp() {
+    override fun setUp() {
+        super.setUp()
         val stores = StoreManager()
         readHandleManager = EntityHandleManager(
             arcId = "testArc",
@@ -27,4 +29,7 @@ class DifferentHandleManagerTest : HandleManagerTestBase() {
             stores = stores
         )
     }
+
+    @After
+    override fun tearDown() = super.tearDown()
 }

--- a/javatests/arcs/core/entity/HandleManagerTestBase.kt
+++ b/javatests/arcs/core/entity/HandleManagerTestBase.kt
@@ -18,13 +18,10 @@ import arcs.core.storage.driver.RamDisk
 import arcs.core.storage.driver.RamDiskDriverProvider
 import arcs.core.storage.keys.RamDiskStorageKey
 import arcs.core.storage.referencemode.ReferenceModeStorageKey
-import arcs.core.storage.toReference
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.runBlockingTest
-import org.junit.Before
 import org.junit.Ignore
 import org.junit.Test
 
@@ -37,7 +34,8 @@ open class HandleManagerTestBase {
         val name: String,
         val age: Int,
         val isCool: Boolean,
-        val bestFriend: Reference
+        val bestFriend: Reference?,
+        val hat: Reference?
     ) : Entity {
 
         override fun ensureIdentified(idGenerator: Generator, handleName: String) {}
@@ -48,41 +46,89 @@ open class HandleManagerTestBase {
                 "name" to name.toReferencable(),
                 "age" to age.toReferencable(),
                 "is_cool" to isCool.toReferencable(),
-                "best_friend" to bestFriend
+                "best_friend" to bestFriend,
+                "hat" to hat
             ),
             collections = emptyMap()
         )
 
-        override fun reset() {
-            TODO("Not yet implemented")
-        }
+        override fun reset() = throw NotImplementedError()
     }
 
-    val entity1 = Person("entity1", "Jason", 21, false, Reference("entity2", backingKey,null))
-    val entity2 = Person("entity2", "Jason", 22, true, Reference("entity1", backingKey, null))
+    private val entity1 = Person(
+        entityId = "entity1",
+        name = "Jason",
+        age = 21,
+        isCool = false,
+        bestFriend = Reference("entity2", backingKey, null),
+        hat = null
+    )
+    private val entity2 = Person(
+        entityId = "entity2",
+        name = "Jason",
+        age = 22,
+        isCool = true,
+        bestFriend = Reference("entity1", backingKey, null),
+        hat = null
+    )
 
-    val entitySpec = object : EntitySpec<Person> {
+    private val entitySpec = object : EntitySpec<Person> {
         @Suppress("UNCHECKED_CAST")
         override fun deserialize(data: RawEntity) = Person(
             entityId = data.id,
             name = (data.singletons["name"] as ReferencablePrimitive<String>).value,
             age = (data.singletons["age"] as ReferencablePrimitive<Int>).value,
             isCool = (data.singletons["is_cool"] as ReferencablePrimitive<Boolean>).value,
-            bestFriend = data.singletons["best_friend"]!!.toReference(backingKey, null)
+            bestFriend = data.singletons["best_friend"] as? Reference,
+            hat = data.singletons["hat"] as? Reference
         )
 
         override val SCHEMA = Schema(
-            listOf(SchemaName("Person")),
+            setOf(SchemaName("Person")),
             SchemaFields(
                 singletons = mapOf(
                     "name" to FieldType.Text,
                     "age" to FieldType.Number,
                     "is_cool" to FieldType.Boolean,
-                    "best_friend" to FieldType.EntityRef("1234acf")
+                    "best_friend" to FieldType.EntityRef("person-hash"),
+                    "hat" to FieldType.EntityRef("hat-hash")
                 ),
                 collections = emptyMap()
             ),
-            "1234acf"
+            "person-hash"
+        )
+    }
+
+    data class Hat(
+        override val entityId: ReferenceId,
+        val style: String
+    ) : Entity {
+        override fun ensureIdentified(idGenerator: Generator, handleName: String) {}
+
+        override fun serialize() = RawEntity(
+            entityId,
+            singletons = mapOf(
+                "style" to style.toReferencable()
+            ),
+            collections = emptyMap()
+        )
+
+        override fun reset() = throw NotImplementedError()
+    }
+
+    private val hatEntitySpec = object : EntitySpec<Entity> {
+        override fun deserialize(data: RawEntity) = Hat(
+            entityId = data.id,
+            style = (data.singletons["style"] as ReferencablePrimitive<String>).value
+        )
+
+        override val SCHEMA = Schema(
+            setOf(SchemaName("Hat")),
+            SchemaFields(
+                singletons = mapOf("style" to FieldType.Text),
+                collections = emptyMap()
+            ),
+            "hat-hash"
         )
     }
 
@@ -92,12 +138,18 @@ open class HandleManagerTestBase {
         storageKey = singletonRefKey
     )
 
-    private val setRefKey = RamDiskStorageKey("set-ent")
-    private val setKey = ReferenceModeStorageKey(
+    private val collectionRefKey = RamDiskStorageKey("set-ent")
+    private val collectionKey = ReferenceModeStorageKey(
         backingKey = backingKey,
-        storageKey = setRefKey
+        storageKey = collectionRefKey
     )
 
+    private val hatCollectionRefKey = RamDiskStorageKey("set-ent")
+    private val hatCollectionKey = ReferenceModeStorageKey(
+        // TODO: Don't use the same backing key as for the other collection.
+        backingKey = backingKey,
+        storageKey = hatCollectionRefKey
+    )
 
     lateinit var readHandleManager: EntityHandleManager
     lateinit var writeHandleManager: EntityHandleManager
@@ -106,10 +158,18 @@ open class HandleManagerTestBase {
         runBlockingTest { this.block() }
     }
 
-    @Before
-    fun setup() {
-        RamDisk.clear()
+    // Must call from subclasses.
+    open fun setUp() {
+        SchemaRegistry.register(entitySpec)
+        SchemaRegistry.register(hatEntitySpec)
         DriverFactory.register(RamDiskDriverProvider())
+    }
+
+    // Must call from subclasses
+    open fun tearDown() {
+        RamDisk.clear()
+        DriverFactory.clearRegistrations()
+        SchemaRegistry.clearForTest()
     }
 
     @Test
@@ -180,7 +240,6 @@ open class HandleManagerTestBase {
     }
 
     @Test
-    @Ignore("Fix when references are added in entity handles")
     fun singleton_dereferenceEntity() = testRunner {
         val writeHandle = createWriteSingletonHandle()
         val readHandle = createReadSingletonHandle()
@@ -194,20 +253,58 @@ open class HandleManagerTestBase {
         refWriteHandle.store(entity2)
 
         // Now read back entity1, and dereference its best_friend.
-        val dereferencedEntity2 =
-            (readHandle.fetch()!!.bestFriend)
+        val dereferencedRawEntity2 =
+            (readHandle.fetch()!!.bestFriend)!!
                 .also {
                     // Check that it's alive
                     assertThat(it.isAlive(coroutineContext)).isTrue()
                 }
-                .dereference(coroutineContext)
+                .dereference(coroutineContext)!!
+        val dereferencedEntity2 = entitySpec.deserialize(dereferencedRawEntity2)
         assertThat(dereferencedEntity2).isEqualTo(entity2)
 
         // Do the same for entity2's best_friend
-        val dereferencedEntity1 =
+        val dereferencedRawEntity1 =
             (refReadHandle.fetch()!!.bestFriend as Reference)
-                .dereference(coroutineContext)
+                .dereference(coroutineContext)!!
+        val dereferencedEntity1 = entitySpec.deserialize(dereferencedRawEntity1)
         assertThat(dereferencedEntity1).isEqualTo(entity1)
+    }
+
+    @Test
+    fun singleton_dereferenceEntity_nestedReference() = testRunner {
+        // Create a stylish new hat, and create a reference to it.
+        val hatCollection = writeHandleManager.createCollectionHandle(
+            HandleMode.ReadWrite,
+            "hatCollection",
+            hatEntitySpec,
+            hatCollectionKey
+        ) as ReadWriteCollectionHandle<Hat>
+        val fez = Hat(entityId = "fez-id", style = "fez")
+        hatCollection.store(fez)
+        val fezRef = hatCollection.createReference(fez)
+        val fezStorageRef = fezRef.toReferencable() as Reference
+
+        // Give the hat to an entity and store it.
+        val personWithHat = Person(
+            entityId = "a-hatted-individual",
+            name = "Jason",
+            age = 25,
+            isCool = true,
+            bestFriend = null,
+            hat = fezStorageRef
+        )
+        val writeHandle = createWriteSingletonHandle()
+        writeHandle.store(personWithHat)
+
+        // Read out the entity, and fetch its hat.
+        val readHandle = createReadSingletonHandle()
+        val entityOut = readHandle.fetch()!!
+        val hatRef = entityOut.hat!!
+        assertThat(hatRef).isEqualTo(fezStorageRef)
+        val rawHat = hatRef.dereference(coroutineContext)!!
+        val hat = hatEntitySpec.deserialize(rawHat)
+        assertThat(hat).isEqualTo(fez)
     }
 
     @Test
@@ -293,7 +390,6 @@ open class HandleManagerTestBase {
     }
 
     @Test
-    @Ignore("Fix when references are added in entity handles")
     fun collection_entityDereference() = testRunner {
         val writeHandle = createWriteCollectionHandle()
         writeHandle.store(entity1)
@@ -302,9 +398,47 @@ open class HandleManagerTestBase {
         val readHandle = createReadCollectionHandle()
         readHandle.fetchAll().also { assertThat(it).hasSize(2) }.forEach { entity ->
             val expectedBestFriend = if (entity.entityId == "entity1") entity2 else entity1
-            val actualBestFriend = entity.bestFriend.dereference(coroutineContext)
+            val actualRawBestFriend = entity.bestFriend!!.dereference(coroutineContext)!!
+            val actualBestFriend = entitySpec.deserialize(actualRawBestFriend)
             assertThat(actualBestFriend).isEqualTo(expectedBestFriend)
         }
+    }
+
+    @Test
+    @Ignore("Use a separate backing key for the Hats collection")
+    fun collection_dereferenceEntity_nestedReference() = testRunner {
+        // Create a stylish new hat, and create a reference to it.
+        val hatCollection = writeHandleManager.createCollectionHandle(
+            HandleMode.ReadWrite,
+            "hatCollection",
+            hatEntitySpec,
+            hatCollectionKey
+        ) as ReadWriteCollectionHandle<Hat>
+        val fez = Hat(entityId = "fez-id", style = "fez")
+        hatCollection.store(fez)
+        val fezRef = hatCollection.createReference(fez)
+        val fezStorageRef = fezRef.toReferencable() as Reference
+
+        // Give the hat to an entity and store it.
+        val personWithHat = Person(
+            entityId = "a-hatted-individual",
+            name = "Jason",
+            age = 25,
+            isCool = true,
+            bestFriend = null,
+            hat = fezStorageRef
+        )
+        val writeHandle = createWriteCollectionHandle()
+        writeHandle.store(personWithHat)
+
+        // Read out the entity, and fetch its hat.
+        val readHandle = createReadCollectionHandle()
+        val entityOut = readHandle.fetchAll().single { it.entityId == "a-hatted-individual" }
+        val hatRef = entityOut.hat!!
+        assertThat(hatRef).isEqualTo(fezStorageRef)
+        val rawHat = hatRef.dereference(coroutineContext)!!
+        val hat = hatEntitySpec.deserialize(rawHat)
+        assertThat(hat).isEqualTo(fez)
     }
 
     private suspend fun createWriteSingletonHandle(
@@ -348,7 +482,7 @@ open class HandleManagerTestBase {
     ) as ReadWriteSingletonHandle<Person>
 
     private suspend fun createWriteCollectionHandle(
-        storageKey: StorageKey = setKey,
+        storageKey: StorageKey = collectionKey,
         name: String = "collectionWriteHandle"
     ) = writeHandleManager.createCollectionHandle(
         HandleMode.ReadWrite,
@@ -358,7 +492,7 @@ open class HandleManagerTestBase {
     ) as ReadWriteCollectionHandle<Person>
 
     private suspend fun createReadCollectionHandle(
-        storageKey: StorageKey = setKey,
+        storageKey: StorageKey = collectionKey,
         name: String = "collectionReadHandle"
     ) = readHandleManager.createCollectionHandle(
         HandleMode.ReadWrite,
@@ -368,7 +502,7 @@ open class HandleManagerTestBase {
     ) as ReadWriteCollectionHandle<Person>
 
     private suspend fun createWriteReferenceCollectionHandle(
-        storageKey: StorageKey = setRefKey,
+        storageKey: StorageKey = collectionRefKey,
         name: String = "collectionRefWriteHandle"
     ) = writeHandleManager.createCollectionHandle(
         HandleMode.ReadWrite,
@@ -378,7 +512,7 @@ open class HandleManagerTestBase {
     ) as ReadWriteCollectionHandle<Person>
 
     private suspend fun createReadReferenceCollectionHandle(
-        storageKey: StorageKey = setRefKey,
+        storageKey: StorageKey = collectionRefKey,
         name: String = "collectionRefReadHandle"
     ) = readHandleManager.createCollectionHandle(
         HandleMode.ReadWrite,

--- a/javatests/arcs/core/entity/HandleManagerTestBase.kt
+++ b/javatests/arcs/core/entity/HandleManagerTestBase.kt
@@ -28,6 +28,7 @@ import org.junit.Test
 @Suppress("EXPERIMENTAL_API_USAGE", "UNCHECKED_CAST")
 open class HandleManagerTestBase {
     private val backingKey = RamDiskStorageKey("entities")
+    private val hatsBackingKey = RamDiskStorageKey("hats")
 
     data class Person(
         override val entityId: ReferenceId,
@@ -144,10 +145,9 @@ open class HandleManagerTestBase {
         storageKey = collectionRefKey
     )
 
-    private val hatCollectionRefKey = RamDiskStorageKey("set-ent")
+    private val hatCollectionRefKey = RamDiskStorageKey("set-hats")
     private val hatCollectionKey = ReferenceModeStorageKey(
-        // TODO: Don't use the same backing key as for the other collection.
-        backingKey = backingKey,
+        backingKey = hatsBackingKey,
         storageKey = hatCollectionRefKey
     )
 
@@ -405,7 +405,6 @@ open class HandleManagerTestBase {
     }
 
     @Test
-    @Ignore("Use a separate backing key for the Hats collection")
     fun collection_dereferenceEntity_nestedReference() = testRunner {
         // Create a stylish new hat, and create a reference to it.
         val hatCollection = writeHandleManager.createCollectionHandle(

--- a/javatests/arcs/core/entity/SameHandleManagerTest.kt
+++ b/javatests/arcs/core/entity/SameHandleManagerTest.kt
@@ -4,6 +4,7 @@ import arcs.core.host.EntityHandleManager
 import arcs.core.storage.StoreManager
 import arcs.core.util.testutil.LogRule
 import arcs.jvm.util.testutil.TimeImpl
+import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.runner.RunWith
@@ -16,7 +17,8 @@ class SameHandleManagerTest : HandleManagerTestBase() {
     @get:Rule var logRule = LogRule()
 
     @Before
-    fun setUp() {
+    override fun setUp() {
+        super.setUp()
         readHandleManager = EntityHandleManager(
             arcId = "testArc",
             hostId = "testHost",
@@ -25,4 +27,7 @@ class SameHandleManagerTest : HandleManagerTestBase() {
         )
         writeHandleManager = readHandleManager
     }
+
+    @After
+    override fun tearDown() = super.tearDown()
 }


### PR DESCRIPTION
Adds a new EntityDereferencerFactory class to manage Dereferencer instances. Includes an injectDereferencers method to recurse into the fields of a RawEntity and attach Dereferencers of the correct schema type.