### PR TITLE
construct EntityCRDT with collection and references

### DIFF
--- a/src/runtime/reference.ts
+++ b/src/runtime/reference.ts
@@ -32,7 +32,7 @@ export class Reference implements Storable {
   public entity: Entity|null = null;
   public type: ReferenceType<EntityType>;
 
-  protected readonly id: string;
+  public readonly id: string;
   private readonly creationTimestamp: string;
   private entityStorageKey: string;
   private readonly context: ChannelConstructor;

--- a/src/runtime/schema.ts
+++ b/src/runtime/schema.ts
@@ -217,7 +217,6 @@ export class Schema {
   crdtConstructor<S extends Dictionary<Referenceable>, C extends Dictionary<Referenceable>>() {
     const singletons = {};
     const collections = {};
-    // TODO(shans) do this properly
 
     // This implementation only supports:
     //   - singleton of a primitive,


### PR DESCRIPTION
Allow crdtConstructor to create EntityCRDTs that are more fun and interesting! This is a step towards creating storageProxies of type Entity. The crdt attribute of the storage proxy needs to be able to reflect the corresponding entity. 