### PR TITLE
Remove name getter from Schema type

### DIFF
--- a/src/runtime/arc.ts
+++ b/src/runtime/arc.ts
@@ -667,7 +667,10 @@ export class Arc implements ArcInterface {
         return `list:${key}`;
       }
     } else if (type instanceof EntityType) {
-      return type.entitySchema.name;
+      // Note: This used to use 'name' a getter that returned names[0].
+      // This was a source of correctness bugs elsewhere (e.g. Schema.equals) and was considered
+      // incorrect. This is a patch to make unique keys for types using all their type names.
+      return type.entitySchema.names.sort().join('&');
     } else if (type instanceof InterfaceType) {
       // TODO we need to fix this too, otherwise all handles of interface type will
       // be of the 'same type' when searching by type.

--- a/src/runtime/entity.ts
+++ b/src/runtime/entity.ts
@@ -363,7 +363,9 @@ export abstract class Entity implements Storable {
     };
 
     // Override the name property to use the name of the entity given in the schema.
-    Object.defineProperty(clazz, 'name', {value: schema.name});
+    // TODO(cypher1): This is likely unsafe.
+    // There may be multiple schemas with the same name and names can be inherited.
+    Object.defineProperty(clazz, 'name', {value: schema.names[0]});
     return clazz;
   }
 

--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -770,6 +770,8 @@ ${e.message}
       names.push(...result.names);
     }
     names = [...new Set(names)];
+    // TODO(cypher1): This is likely unsafe.
+    // There may be multiple schemas with the same name and names can be inherited.
     const name = schemaItem.alias || names[0];
     if (!name) {
       throw new ManifestError(

--- a/src/runtime/schema.ts
+++ b/src/runtime/schema.ts
@@ -96,11 +96,6 @@ export class Schema {
     };
   }
 
-  // TODO(cypher1): This should only be an ident used in manifest parsing.
-  get name() {
-    return this.names[0];
-  }
-
   get annotations(): AnnotationRef[] { return this._annotations; }
   set annotations(annotations: AnnotationRef[]) {
     annotations.every(a => assert(a.isValidForTarget('Schema'),
@@ -228,7 +223,8 @@ export class Schema {
   }
 
   // Returns true if there are fields in this.refinement, that are not in fields
-  refinementHasFieldsNotIn(fields): boolean {
+  // tslint:disable-next-line: no-any
+  refinementHasFieldsNotIn(fields: Dictionary<any>): boolean {
     const amb = Object.keys(this.fields).filter(k => !(k in fields));
     for (const field of amb) {
       if (this.refinement && this.refinement.containsField(field)) {

--- a/src/runtime/storageNG/tests/entity-handle-factory-test.ts
+++ b/src/runtime/storageNG/tests/entity-handle-factory-test.ts
@@ -98,7 +98,7 @@ describe('entity handle factory', () => {
     assert.strictEqual(recipe.handles[1].id, 'input:2');
     recipe.handles[1].type.maybeEnsureResolved();
     assert.instanceOf(recipe.handles[1].type, MuxType);
-    assert.strictEqual((recipe.handles[1].type.resolvedType() as MuxType<EntityType>).innerType.entitySchema.name, 'Result');
+    assert.deepEqual((recipe.handles[1].type.resolvedType() as MuxType<EntityType>).innerType.entitySchema.names, ['Result']);
   });
   it('generated entity handle can fetch entity', async () => {
     const storageKeyPrefix = (arcId: ArcId) => new ReferenceModeStorageKey(new VolatileStorageKey(arcId, 'a'), new VolatileStorageKey(arcId, 'b'));

--- a/src/runtime/tests/interface-info-test.ts
+++ b/src/runtime/tests/interface-info-test.ts
@@ -231,7 +231,7 @@ describe('interface', () => {
       assert.isTrue(resolved.canEnsureResolved());
       const canWriteSuperset = resolved.canWriteSuperset as EntityType;
       assert.isTrue(canWriteSuperset instanceof EntityType);
-      assert.strictEqual(canWriteSuperset.entitySchema.name, 'Burrito');
+      assert.deepStrictEqual(canWriteSuperset.entitySchema.names, ['Burrito']);
     }
   });
 

--- a/src/runtime/tests/reference-test.ts
+++ b/src/runtime/tests/reference-test.ts
@@ -52,7 +52,7 @@ describe('reference', () => {
     assert.strictEqual(recipe.handles[0].id, 'reference:1');
     recipe.handles[0].type.maybeEnsureResolved();
     assert.instanceOf(recipe.handles[0].type, ReferenceType);
-    assert.strictEqual((recipe.handles[0].type.resolvedType() as ReferenceType<EntityType>).referredType.entitySchema.name, 'Result');
+    assert.deepStrictEqual((recipe.handles[0].type.resolvedType() as ReferenceType<EntityType>).referredType.entitySchema.names, ['Result']);
   });
 
   it('exposes a dereference API to particles for singleton handles', async () => {
@@ -655,14 +655,14 @@ describe('reference', () => {
     await arc.instantiate(recipe);
 
     const handle = await handleForStore(inputStore, arc);
-    assert.strictEqual((handle.type.getContainedType() as EntityType).entitySchema.name, 'Result');
     const now = new Date().getTime();
+    assert.deepStrictEqual((handle.type.getContainedType() as EntityType).entitySchema.names, ['Result']);
     await handle.add(Entity.identify(new handle.entityClass({value: 'what a result!'}), 'id:1', null, now));
     await handle.add(Entity.identify(new handle.entityClass({value: 'what another result!'}), 'id:2', null, now));
 
     await arc.idle;
     const outputHandle = await handleForStore(refStore, arc);
-    assert.strictEqual(outputHandle.type.getContainedType().getEntitySchema().name, 'Foo');
+    assert.deepStrictEqual(outputHandle.type.getContainedType().getEntitySchema().names, ['Foo']);
     const outputRefs = await outputHandle.fetch();
     const ids = [...outputRefs.result].map(ref => ref.id);
     assert.sameMembers(ids, ['id:1', 'id:2']);

--- a/src/runtime/tests/reference-test.ts
+++ b/src/runtime/tests/reference-test.ts
@@ -404,7 +404,7 @@ describe('reference', () => {
     await arc.idle;
 
     const outHandle = await handleForStore(outStore, arc);
-    assert.strictEqual(outHandle.type.getContainedType().getEntitySchema().name, 'Result');
+    assert.deepEqual(outHandle.type.getContainedType().getEntitySchema().names, ['Result']);
     const out = await outHandle.fetch();
     assert.equal(out.value, 'what a result!');
   });
@@ -761,7 +761,7 @@ describe('reference', () => {
     await arc.idle;
 
     const outputHandle = await handleForStore(resultOutputStore, arc);
-    assert.strictEqual((outputHandle.type.getContainedType() as EntityType).entitySchema.name, 'Result');
+    assert.deepEqual((outputHandle.type.getContainedType() as EntityType).entitySchema.names, ['Result']);
     const values = await outputHandle.toList();
     assert.strictEqual(values.length, 2);
     assert.strictEqual(values[0].value, 'what a result!');

--- a/src/runtime/tests/schema-test.ts
+++ b/src/runtime/tests/schema-test.ts
@@ -66,7 +66,7 @@ describe('schema', () => {
   it('schemas load recursively', async () => {
     const manifest = await Manifest.load('./Product.schema', loader);
     const schema = manifest.findSchemaByName('Product');
-    assert.strictEqual(schema.name, 'Product');
+    assert.sameDeepMembers(schema.names, ['Product', 'Thing']);
     assert.include(schema.names, 'Thing');
 
     const kind = 'schema-primitive';

--- a/src/runtime/tests/type-checker-test.ts
+++ b/src/runtime/tests/type-checker-test.ts
@@ -23,10 +23,10 @@ describe('TypeChecker', () => {
     const canWriteSuperset = a.resolvedType().collectionType.canWriteSuperset as EntityType;
 
     assert.instanceOf(canWriteSuperset, EntityType);
-    assert.strictEqual(canWriteSuperset.entitySchema.name, 'Product');
-    assert.strictEqual((result.resolvedType() as CollectionType<EntityType>).collectionType.canWriteSuperset.entitySchema.name, 'Product');
+    assert.sameDeepMembers(canWriteSuperset.entitySchema.names, ['Product']);
+    assert.sameDeepMembers((result.resolvedType() as CollectionType<EntityType>).collectionType.canWriteSuperset.entitySchema.names, ['Product']);
     if (result.isCollectionType() && result.collectionType.canWriteSuperset instanceof EntityType) {
-      assert.strictEqual(result.collectionType.canWriteSuperset.entitySchema.name, 'Product');
+      assert.sameDeepMembers(result.collectionType.canWriteSuperset.entitySchema.names, ['Product']);
     }
     else {
       assert.fail('result should be a collection of a typeVariable with an entity constraint');
@@ -48,14 +48,14 @@ describe('TypeChecker', () => {
 
     let canWriteSuperset = a.resolvedType().bigCollectionType.canWriteSuperset as EntityType;
     assert.instanceOf(canWriteSuperset, EntityType);
-    assert.strictEqual(canWriteSuperset.entitySchema.name, 'Product');
+    assert.sameDeepMembers(canWriteSuperset.entitySchema.names, ['Product']);
 
     canWriteSuperset = (result.resolvedType() as BigCollectionType<EntityType>).bigCollectionType.canWriteSuperset as EntityType;
     assert.instanceOf(canWriteSuperset, EntityType);
-    assert.strictEqual(canWriteSuperset.entitySchema.name, 'Product');
+    assert.sameDeepMembers(canWriteSuperset.entitySchema.names, ['Product']);
 
     if (result.isBigCollectionType() && result.bigCollectionType.canWriteSuperset instanceof EntityType) {
-      assert.strictEqual(result.bigCollectionType.canWriteSuperset.entitySchema.name, 'Product');
+      assert.sameDeepMembers(result.bigCollectionType.canWriteSuperset.entitySchema.names, ['Product']);
     } else {
       assert.fail('result should be a bigCollection of a typeVariable with an entity constraint');
     }
@@ -67,8 +67,8 @@ describe('TypeChecker', () => {
     const c = EntityType.make(['Product', 'Thing'], {}).collectionOf();
     const result = TypeChecker.processTypeList(undefined, [{type: a, direction: 'reads'}, {type: b, direction: 'reads'}, {type: c, direction: 'writes'}]);
     if (result.isCollectionType() && result.collectionType.canReadSubset instanceof EntityType && result.collectionType.canWriteSuperset instanceof EntityType) {
-      assert.strictEqual(result.collectionType.canReadSubset.entitySchema.name, 'Product');
-      assert.strictEqual(result.collectionType.canWriteSuperset.entitySchema.name, 'Thing');
+      assert.sameDeepMembers(result.collectionType.canReadSubset.entitySchema.names, ['Product', 'Thing']);
+      assert.sameDeepMembers(result.collectionType.canWriteSuperset.entitySchema.names, ['Thing']);
     } else {
       assert.fail('result should be a collection of a typeVariable with an entity constraint');
     }
@@ -80,8 +80,8 @@ describe('TypeChecker', () => {
     const c = EntityType.make(['Product', 'Thing'], {}).bigCollectionOf();
     const result = TypeChecker.processTypeList(undefined, [{type: a, direction: 'reads'}, {type: b, direction: 'reads'}, {type: c, direction: 'writes'}]);
     if (result.isBigCollectionType() && result.bigCollectionType.canReadSubset instanceof EntityType && result.bigCollectionType.canWriteSuperset instanceof EntityType) {
-      assert.strictEqual(result.bigCollectionType.canReadSubset.entitySchema.name, 'Product');
-      assert.strictEqual(result.bigCollectionType.canWriteSuperset.entitySchema.name, 'Thing');
+      assert.sameDeepMembers(result.bigCollectionType.canReadSubset.entitySchema.names, ['Product', 'Thing']);
+      assert.sameDeepMembers(result.bigCollectionType.canWriteSuperset.entitySchema.names, ['Thing']);
     } else {
       assert.fail('result should be a bigCollection of a typeVariable with an entity constraint');
     }
@@ -93,8 +93,8 @@ describe('TypeChecker', () => {
     const c = EntityType.make(['Product', 'Thing'], {}).collectionOf();
     const result = TypeChecker.processTypeList(undefined, [{type: c, direction: 'writes'}, {type: a, direction: 'reads'}, {type: b, direction: 'reads'}]);
     if (result.isCollectionType() && result.collectionType.canReadSubset instanceof EntityType && result.collectionType.canWriteSuperset instanceof EntityType) {
-      assert.strictEqual(result.collectionType.canReadSubset.entitySchema.name, 'Product');
-      assert.strictEqual(result.collectionType.canWriteSuperset.entitySchema.name, 'Thing');
+      assert.sameDeepMembers(result.collectionType.canReadSubset.entitySchema.names, ['Product', 'Thing']);
+      assert.sameDeepMembers(result.collectionType.canWriteSuperset.entitySchema.names, ['Thing']);
     } else {
       assert.fail('result should be a collection of a typeVariable with an entity constraint');
     }
@@ -106,8 +106,8 @@ describe('TypeChecker', () => {
     const c = EntityType.make(['Product', 'Thing'], {}).bigCollectionOf();
     const result = TypeChecker.processTypeList(undefined, [{type: c, direction: 'writes'}, {type: a, direction: 'reads'}, {type: b, direction: 'reads'}]);
     if (result.isBigCollectionType() && result.bigCollectionType.canReadSubset instanceof EntityType && result.bigCollectionType.canWriteSuperset instanceof EntityType) {
-      assert.strictEqual(result.bigCollectionType.canReadSubset.entitySchema.name, 'Product');
-      assert.strictEqual(result.bigCollectionType.canWriteSuperset.entitySchema.name, 'Thing');
+      assert.sameDeepMembers(result.bigCollectionType.canReadSubset.entitySchema.names, ['Product', 'Thing']);
+      assert.sameDeepMembers(result.bigCollectionType.canWriteSuperset.entitySchema.names, ['Thing']);
     } else {
       assert.fail('result should be a bigCollection of a typeVariable with an entity constraint');
     }
@@ -122,8 +122,8 @@ describe('TypeChecker', () => {
     const c = EntityType.make(['Product', 'Thing'], {}).collectionOf();
     const result = TypeChecker.processTypeList(undefined, [{type: a, direction: 'reads'}, {type: b, direction: 'reads'}, {type: c, direction: 'writes'}]);
     if (result.isCollectionType() && result.collectionType.canReadSubset instanceof EntityType && result.collectionType.canWriteSuperset instanceof EntityType) {
-      assert.strictEqual(result.collectionType.canReadSubset.entitySchema.name, 'Product');
-      assert.strictEqual(result.collectionType.canWriteSuperset.entitySchema.name, 'Thing');
+      assert.sameDeepMembers(result.collectionType.canReadSubset.entitySchema.names, ['Product', 'Thing']);
+      assert.sameDeepMembers(result.collectionType.canWriteSuperset.entitySchema.names, ['Thing']);
     } else {
       assert.fail('result should be a collection of a typeVariable with an entity constraint');
     }
@@ -138,8 +138,8 @@ describe('TypeChecker', () => {
     const c = EntityType.make(['Product', 'Thing'], {}).bigCollectionOf();
     const result = TypeChecker.processTypeList(undefined, [{type: a, direction: 'reads'}, {type: b, direction: 'reads'}, {type: c, direction: 'writes'}]);
     if (result.isBigCollectionType() && result.bigCollectionType.canReadSubset instanceof EntityType && result.bigCollectionType.canWriteSuperset instanceof EntityType) {
-      assert.strictEqual(result.bigCollectionType.canReadSubset.entitySchema.name, 'Product');
-      assert.strictEqual(result.bigCollectionType.canWriteSuperset.entitySchema.name, 'Thing');
+      assert.sameDeepMembers(result.bigCollectionType.canReadSubset.entitySchema.names, ['Product', 'Thing']);
+      assert.sameDeepMembers(result.bigCollectionType.canWriteSuperset.entitySchema.names, ['Thing']);
     } else {
       assert.fail('result should be a bigCollection of a typeVariable with an entity constraint');
     }
@@ -151,9 +151,9 @@ describe('TypeChecker', () => {
     const c = EntityType.make(['Product', 'Thing'], {}).collectionOf();
     const result = TypeChecker.processTypeList(undefined, [{type: a, direction: 'reads'}, {type: c, direction: 'writes'}]);
     if (result.isCollectionType() && result.collectionType.canReadSubset instanceof EntityType && result.collectionType.canWriteSuperset instanceof EntityType) {
-      assert.strictEqual(result.collectionType.canReadSubset.entitySchema.name, 'Product');
+      assert.sameDeepMembers(result.collectionType.canReadSubset.entitySchema.names, ['Product', 'Thing']);
       assert.include(result.collectionType.canReadSubset.entitySchema.names, 'Thing');
-      assert.strictEqual(result.collectionType.canWriteSuperset.entitySchema.name, 'Thing');
+      assert.sameDeepMembers(result.collectionType.canWriteSuperset.entitySchema.names, ['Thing']);
     } else {
       assert.fail('result should be a collection of a typeVariable with an entity constraint');
     }
@@ -165,9 +165,9 @@ describe('TypeChecker', () => {
     const c = EntityType.make(['Product', 'Thing'], {}).bigCollectionOf();
     const result = TypeChecker.processTypeList(undefined, [{type: a, direction: 'reads'}, {type: c, direction: 'writes'}]);
     if (result.isBigCollectionType() && result.bigCollectionType.canReadSubset instanceof EntityType && result.bigCollectionType.canWriteSuperset instanceof EntityType) {
-      assert.strictEqual(result.bigCollectionType.canReadSubset.entitySchema.name, 'Product');
+      assert.sameDeepMembers(result.bigCollectionType.canReadSubset.entitySchema.names, ['Product', 'Thing']);
       assert.include(result.bigCollectionType.canReadSubset.entitySchema.names, 'Thing');
-      assert.strictEqual(result.bigCollectionType.canWriteSuperset.entitySchema.name, 'Thing');
+      assert.sameDeepMembers(result.bigCollectionType.canWriteSuperset.entitySchema.names, ['Thing']);
     } else {
       assert.fail('result should be a bigCollection of a typeVariable with an entity constraint');
     }
@@ -239,19 +239,19 @@ describe('TypeChecker', () => {
     let a = TypeVariable.make('a');
     const b = EntityType.make(['Product', 'Thing'], {});
     const c = EntityType.make(['Thing'], {});
-    let result = TypeChecker.processTypeList(undefined, [{type: a, direction: 'reads'}, {type: b, direction: 'writes'}, {type: c, direction: 'reads'}]);
+    TypeChecker.processTypeList(undefined, [{type: a, direction: 'reads'}, {type: b, direction: 'writes'}, {type: c, direction: 'reads'}]);
     if (a.variable.canReadSubset instanceof EntityType && a.variable.canWriteSuperset instanceof EntityType) {
-      assert.strictEqual(a.variable.canReadSubset.entitySchema.name, 'Product');
-      assert.strictEqual(a.variable.canWriteSuperset.entitySchema.name, 'Thing');
+      assert.sameDeepMembers(a.variable.canReadSubset.entitySchema.names, ['Product', 'Thing']);
+      assert.sameDeepMembers(a.variable.canWriteSuperset.entitySchema.names, ['Thing']);
     } else {
       assert.fail('a should be a type variable with EntityType constraints');
     }
 
     a = TypeVariable.make('a');
-    result = TypeChecker.processTypeList(undefined, [{type: a, direction: 'reads'}, {type: c, direction: 'reads'}, {type: b, direction: 'writes'}]);
+    TypeChecker.processTypeList(undefined, [{type: a, direction: 'reads'}, {type: c, direction: 'reads'}, {type: b, direction: 'writes'}]);
     if (a.variable.canReadSubset instanceof EntityType && a.variable.canWriteSuperset instanceof EntityType) {
-      assert.strictEqual(a.variable.canReadSubset.entitySchema.name, 'Product');
-      assert.strictEqual(a.variable.canWriteSuperset.entitySchema.name, 'Thing');
+      assert.sameDeepMembers(a.variable.canReadSubset.entitySchema.names, ['Product', 'Thing']);
+      assert.sameDeepMembers(a.variable.canWriteSuperset.entitySchema.names, ['Thing']);
     } else {
       assert.fail('a should be a type variable with EntityType constraints');
     }
@@ -282,7 +282,7 @@ describe('TypeChecker', () => {
     assert.strictEqual(true, type.canEnsureResolved());
     assert.strictEqual(true, type.maybeEnsureResolved());
     assert.strictEqual(true, type.isResolved());
-    assert.strictEqual('Product', (type.resolvedType() as CollectionType<EntityType>).collectionType.entitySchema.names[0]);
+    assert.sameDeepMembers((type.resolvedType() as CollectionType<EntityType>).collectionType.entitySchema.names, ['Product']);
 
     recipe.normalize();
     assert.strictEqual(true, recipe.isResolved());

--- a/src/runtime/tests/type-test.ts
+++ b/src/runtime/tests/type-test.ts
@@ -468,11 +468,11 @@ describe('types', () => {
       assert(recipe.normalize());
       assert(recipe.isResolved());
       assert.strictEqual(recipe.handles.length, 1);
-      assert.strictEqual((recipe.handles[0].type.getContainedType().canReadSubset as EntityType).entitySchema.name, 'Lego');
-      assert.strictEqual((recipe.handles[0].type.getContainedType().canWriteSuperset as EntityType).entitySchema.name, 'Product');
+      assert.deepStrictEqual((recipe.handles[0].type.getContainedType().canReadSubset as EntityType).entitySchema.names, ['Lego', 'Product']);
+      assert.deepStrictEqual((recipe.handles[0].type.getContainedType().canWriteSuperset as EntityType).entitySchema.names, ['Product']);
     });
 
-    it('a subtype matches to a supertype that wants to be read when a handle exists', async () => {
+    it('a subtype matches to a supertype that wants to be read when a handle exists (1)', async () => {
       const manifest = await Manifest.parse(manifestText);
       const recipe = manifest.recipes[1];
       recipe.handles[0].mapToStorage({
@@ -482,10 +482,10 @@ describe('types', () => {
       assert(recipe.normalize());
       assert(recipe.isResolved());
       assert.lengthOf(recipe.handles, 1);
-      assert.strictEqual((recipe.handles[0].type.getContainedType() as EntityType).entitySchema.name, 'Product');
+      assert.deepStrictEqual((recipe.handles[0].type.getContainedType() as EntityType).entitySchema.names, ['Product']);
     });
 
-    it('a subtype matches to a supertype that wants to be read when a handle exists', async () => {
+    it('a subtype matches to a supertype that wants to be read when a handle exists (2)', async () => {
       const manifest = await Manifest.parse(manifestText);
       const recipe = manifest.recipes[1];
       recipe.handles[0].mapToStorage({
@@ -495,7 +495,7 @@ describe('types', () => {
       assert(recipe.normalize());
       assert(recipe.isResolved());
       assert.lengthOf(recipe.handles, 1);
-      assert.strictEqual((recipe.handles[0].type.getContainedType() as EntityType).entitySchema.name, 'Lego');
+      assert.deepStrictEqual((recipe.handles[0].type.getContainedType() as EntityType).entitySchema.names, ['Lego', 'Product']);
     });
   });
 });

--- a/src/runtime/type.ts
+++ b/src/runtime/type.ts
@@ -421,8 +421,9 @@ export class EntityType extends Type {
     }
 
     // Spit MyTypeFOO to My Type FOO
-    if (this.entitySchema.name) {
-      return this.entitySchema.name.replace(/([^A-Z])([A-Z])/g, '$1 $2')
+    if (this.entitySchema.names) {
+      return this.entitySchema.names.join(' ')
+                                   .replace(/([^A-Z])([A-Z])/g, '$1 $2')
                                    .replace(/([A-Z][^A-Z])/g, ' $1')
                                    .replace(/[\s]+/g, ' ')
                                    .trim();


### PR DESCRIPTION
This leaves some open questions about how entity classes should be identified in each of our target languages, particularly where there are multiple schema names and under inheritance.