### PR TITLE
Adds a new spec test for references

### DIFF
--- a/javatests/arcs/sdk/spec/EntitySpecTest.kt
+++ b/javatests/arcs/sdk/spec/EntitySpecTest.kt
@@ -192,9 +192,8 @@ class EntitySpecTest {
      * it.
      */
     private suspend fun createBarReference(bar: Bar): Reference<Bar> {
-        val handle = harness.particle.handles.bars
-        handle.store(bar)
-        return handle.createReference(bar)
+        harness.bars.store(bar)
+        return harness.bars.createReference(bar)
     }
 
     /** Generates and returns an ID for the entity. */

--- a/javatests/arcs/sdk/spec/ReferenceSpecTest.kt
+++ b/javatests/arcs/sdk/spec/ReferenceSpecTest.kt
@@ -1,0 +1,96 @@
+package arcs.sdk.spec
+
+import arcs.sdk.ReadWriteCollectionHandle
+import arcs.sdk.ReadWriteSingletonHandle
+import arcs.sdk.Reference
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+private typealias Child = ReferenceSpecParticle_SingletonChild
+private typealias Parent = ReferenceSpecParticle_Parents
+
+/** Specification tests for [Reference]. */
+@ExperimentalCoroutinesApi
+@RunWith(JUnit4::class)
+class ReferenceSpecTest {
+
+    class ReferenceSpecParticle : AbstractReferenceSpecParticle()
+
+    @get:Rule
+    val harness = ReferenceSpecParticleTestHarness { ReferenceSpecParticle() }
+
+    @Before
+    fun setUp() = runBlockingTest {
+        harness.start()
+    }
+
+    @Test
+    fun createReference_singletonHandle() = runBlocking {
+        val child = Child(age = 10.0)
+        harness.singletonChild.store(child)
+        val ref = harness.singletonChild.createReference(child)
+        assertThat(ref.dereference()).isEqualTo(child)
+    }
+
+    @Test
+    fun createReference_collectionHandle() = runBlocking {
+        val child = Child(age = 10.0)
+        harness.collectionChild.store(child)
+        val ref = harness.collectionChild.createReference(child)
+        assertThat(ref.dereference()).isEqualTo(child)
+    }
+
+    @Test
+    fun storeReference_insideSingletonField() = runBlocking {
+        val child = Child(age = 10.0)
+        val childRef = createChildReference(child)
+        val parent = Parent(age = 40.0, favorite = childRef)
+
+        harness.parents.store(parent)
+        val parentOut = harness.parents.fetchAll().single()
+
+        assertThat(parentOut).isEqualTo(parent)
+        assertThat(parentOut.favorite).isEqualTo(childRef)
+        assertThat(parentOut.favorite!!.dereference()).isEqualTo(child)
+    }
+
+    @Test
+    fun storeReference_insideCollectionField() = runBlocking {
+        val child1 = Child(age = 10.0)
+        val child2 = Child(age = 9.0)
+        val childRef1 = createChildReference(child1)
+        val childRef2 = createChildReference(child2)
+        val parent = Parent(age = 40.0, children = setOf(childRef1, childRef2))
+
+        harness.parents.store(parent)
+        val parentOut = harness.parents.fetchAll().single()
+
+        assertThat(parentOut).isEqualTo(parent)
+        assertThat(parentOut.children).containsExactly(childRef1, childRef2)
+        assertThat(parentOut.children.map { it.dereference() }).containsExactly(child1, child2)
+        Unit
+    }
+
+    @Test
+    fun storeReference_insideSingletonReferenceHandle() {
+        // TODO(csilvestrini): Implement me.
+    }
+
+    @Test
+    fun storeReference_insideCollectionReferenceHandle() {
+        // TODO(csilvestrini): Implement me.
+    }
+
+    /** Creates a [Reference] for the given [Child]. */
+    private suspend fun createChildReference(child: Child): Reference<Child> {
+        harness.collectionChild.store(child)
+        return harness.collectionChild.createReference(child)
+    }
+}

--- a/javatests/arcs/sdk/spec/reference.arcs
+++ b/javatests/arcs/sdk/spec/reference.arcs
@@ -1,0 +1,19 @@
+meta
+  namespace: arcs.sdk.spec
+
+schema Child
+  age: Number
+
+schema Parent
+  age: Number
+  favorite: &Child
+  children: [&Child]
+
+particle ReferenceSpecParticle
+  singletonChild: reads writes Child {age}
+  collectionChild: reads writes [Child {age}]
+  parents: reads writes [Parent {age, favorite, children}]
+
+  // TODO: Test singleton and collection handles containing references.
+  // singletonChildRef: reads writes &Child
+  // collectionChildRef: reads writes [&Child]


### PR DESCRIPTION
Tests creating new references, storing them inside entities, and dereferencing them. Doesn't test storing them inside Reference Handles, since that hasn't been implemented yet.