### PR TITLE
Add Java class version of toParticleIdentifier.

### DIFF
--- a/java/arcs/core/host/ParticleIdentifier.kt
+++ b/java/arcs/core/host/ParticleIdentifier.kt
@@ -27,3 +27,9 @@ data class ParticleIdentifier(val id: String) {
 
 /** Creates a [ParticleIdenfifier] from a [KClass] */
 fun KClass<out Particle>.toParticleIdentifier() = ParticleIdentifier.from(className())
+
+/**
+ * Creates a [ParticleIdentifier] from a [Class]. Older versions of Kotlin required kotlin-reflect
+ * to use KClass, so this method can be used instead.
+ */
+fun Class<out Particle>.toParticleIdentifier() = ParticleIdentifier.from(name)


### PR DESCRIPTION
This is needed as internal tools treat this use of KClass as requiring
kotlin-reflect. This may also be useful if we have any Java particles.