### PR TITLE
Handle implementation organization

### DIFF
--- a/java/arcs/core/allocator/Allocator.kt
+++ b/java/arcs/core/allocator/Allocator.kt
@@ -26,12 +26,12 @@ import arcs.core.data.SchemaName
 import arcs.core.data.SingletonType
 import arcs.core.entity.EntityBase
 import arcs.core.entity.EntityBaseSpec
+import arcs.core.entity.ReadWriteCollectionHandle
 import arcs.core.host.ArcHost
 import arcs.core.host.ArcHostNotFoundException
 import arcs.core.host.EntityHandleManager
 import arcs.core.host.HostRegistry
 import arcs.core.host.ParticleNotFoundException
-import arcs.core.host.ReadWriteCollectionHandleAdapter
 import arcs.core.storage.CapabilitiesResolver
 import arcs.core.storage.StorageKey
 import arcs.core.storage.keys.RamDiskStorageKey
@@ -51,7 +51,7 @@ import arcs.core.util.traverse
  */
 class Allocator private constructor(
     private val hostRegistry: HostRegistry,
-    private val collection: ReadWriteCollectionHandleAdapter<EntityBase>
+    private val collection: ReadWriteCollectionHandle<EntityBase>
 ) {
 
     /** Currently active Arcs and their associated [Plan.Partition]s. */
@@ -279,7 +279,7 @@ class Allocator private constructor(
             )
             return Allocator(
                 hostRegistry,
-                collection as ReadWriteCollectionHandleAdapter<EntityBase>
+                collection as ReadWriteCollectionHandle<EntityBase>
             )
         }
     }

--- a/java/arcs/core/allocator/BUILD
+++ b/java/arcs/core/allocator/BUILD
@@ -18,7 +18,6 @@ arcs_kt_library(
         "//java/arcs/core/storage:storage_key",
         "//java/arcs/core/storage/api",
         "//java/arcs/core/storage/driver",
-        "//java/arcs/core/storage/handle",
         "//java/arcs/core/storage/keys",
         "//java/arcs/core/storage/referencemode",
         "//java/arcs/core/type",

--- a/java/arcs/core/entity/BUILD
+++ b/java/arcs/core/entity/BUILD
@@ -9,10 +9,12 @@ arcs_kt_library(
     srcs = glob(["*.kt"]),
     deps = [
         "//java/arcs/core/common",
+        "//java/arcs/core/crdt",
         "//java/arcs/core/data",
         "//java/arcs/core/data:rawentity",
         "//java/arcs/core/data/util:data-util",
         "//java/arcs/core/storage",
-        "//java/arcs/core/storage/handle",
+        "//java/arcs/core/storage/referencemode",
+        "//java/arcs/core/util",
     ],
 )

--- a/java/arcs/core/entity/BaseHandle.kt
+++ b/java/arcs/core/entity/BaseHandle.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+package arcs.core.entity
+
+import arcs.core.storage.StorageProxy
+
+/** Base functionality common to all read/write singleton and collection handles. */
+abstract class BaseHandle(
+    override val name: String,
+    private val storageProxy: StorageProxy<*, *, *>
+) : Handle {
+    override suspend fun onSync(action: () -> Unit) = storageProxy.addOnSync(name, action)
+
+    override suspend fun onDesync(action: () -> Unit) = storageProxy.addOnDesync(name, action)
+
+    override suspend fun close() = storageProxy.removeCallbacksForName(name)
+}

--- a/java/arcs/core/entity/CollectionHandle.kt
+++ b/java/arcs/core/entity/CollectionHandle.kt
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+package arcs.core.entity
+
+import arcs.core.crdt.CrdtSet
+import arcs.core.data.RawEntity
+import arcs.core.storage.StorageProxy
+import arcs.core.storage.StoreOptions
+import arcs.core.storage.referencemode.ReferenceModeStorageKey
+
+typealias CollectionData<T> = CrdtSet.Data<T>
+typealias CollectionOp<T> = CrdtSet.IOperation<T>
+typealias CollectionStoreOptions<T> = StoreOptions<CollectionData<T>, CollectionOp<T>, Set<T>>
+typealias CollectionProxy<T> = StorageProxy<CrdtSet.Data<T>, CrdtSet.IOperation<T>, Set<T>>
+
+/**
+ * This class implements all of the methods that are needed by the various collection [Handle]
+ * interfaces:
+ * * [Handle]
+ * * [ReadableHandle<T>]
+ * * [ReadCollectionHandle<T>]
+ * * [WriteCollectionHandle<T>]
+ * * [ReadWriteCollectionHandle<T>]
+ * * [QueryCollectionHandle<T>]
+ * * [ReadQueryCollectionHandle<T>]
+ * * [ReadWriteQueryCollectionHandle<T>]
+ *
+ * It manages the storage and retrieval of items of the specified [Entity] type, including
+ * their conversion to and from the backing [RawEntity] type that the storage layer requires.
+ *
+ * This class won't be returned directly; instead it will be wrapped in a facade object that
+ * exposes only the methods that should be exposed.
+ */
+class CollectionHandle<T : Entity>(
+    name: String,
+    /** Provides the [Schema] and a `deserialize` method. */
+    val entitySpec: EntitySpec<T>,
+    /** Interface to storage for [RawEntity] objects backing an `entity: T`. */
+    val storageProxy: CollectionProxy<RawEntity>,
+    /** Will ensure that necessary fields are present on the [RawEntity] before storage. */
+    val entityPreparer: EntityPreparer<T>,
+    /** Provides logic to fetch [RawEntity] object backing a [Reference] field. */
+    val dereferencerFactory: EntityDereferencerFactory
+) : BaseHandle(name, storageProxy), ReadWriteCollectionHandle<T> {
+
+    // region implement ReadCollectionHandle<T>
+    override suspend fun size() = fetchAll().size
+
+    override suspend fun isEmpty() = fetchAll().isEmpty()
+
+    override suspend fun fetchAll() = adaptValues(storageProxy.getParticleView())
+    // endregion
+
+    // region implement WriteCollectionHandle<T>
+    override suspend fun store(entity: T) {
+        storageProxy.applyOp(
+            CrdtSet.Operation.Add(
+                name,
+                storageProxy.getVersionMap().increment(name),
+                entityPreparer.prepareEntity(entity)
+            )
+        )
+    }
+
+    override suspend fun clear() {
+        storageProxy.getParticleView().forEach {
+            storageProxy.applyOp(
+                CrdtSet.Operation.Remove(
+                    name,
+                    storageProxy.getVersionMap(),
+                    it
+                )
+            )
+        }
+    }
+
+    override suspend fun remove(entity: T) {
+        storageProxy.applyOp(
+            CrdtSet.Operation.Remove(
+                name,
+                storageProxy.getVersionMap(),
+                entity.serialize()
+            )
+        )
+    }
+    // endregion
+
+    // region implement ReadableHandle<T>
+    override suspend fun onUpdate(action: suspend (Set<T>) -> Unit) =
+        storageProxy.addOnUpdate(name) {
+            action(adaptValues(it))
+        }
+
+    override suspend fun createReference(entity: T): Reference<T> {
+        val entityId = requireNotNull(entity.entityId) {
+            "Entity must have an ID before it can be referenced."
+        }
+        val storageKey = requireNotNull(storageProxy.storageKey as? ReferenceModeStorageKey) {
+            "ReferenceModeStorageKey required in order to create references."
+        }
+        require(fetchAll().any { it.entityId == entityId }) {
+            "Entity is not stored in the Collection."
+        }
+
+        return Reference(
+            entitySpec,
+            arcs.core.storage.Reference(entity.serialize().id, storageKey.backingKey, null).also {
+                it.dereferencer = dereferencerFactory.create(entitySpec.SCHEMA)
+            }
+        )
+    }
+    // endregion
+
+    private fun adaptValues(values: Set<RawEntity>) = values.map {
+        dereferencerFactory.injectDereferencers(entitySpec.SCHEMA, it)
+        entitySpec.deserialize(it)
+    }.toSet()
+}

--- a/java/arcs/core/entity/EntityDereferencerFactory.kt
+++ b/java/arcs/core/entity/EntityDereferencerFactory.kt
@@ -5,9 +5,9 @@ import arcs.core.data.RawEntity
 import arcs.core.data.Schema
 import arcs.core.storage.ActivationFactory
 import arcs.core.storage.Dereferencer
+import arcs.core.storage.RawEntityDereferencer
 import arcs.core.storage.Reference
 import arcs.core.storage.StoreManager
-import arcs.core.storage.handle.RawEntityDereferencer
 
 /** A [Dereferencer.Factory] for [Reference] and [RawEntity] classes. */
 class EntityDereferencerFactory(

--- a/java/arcs/core/entity/EntityPreparer.kt
+++ b/java/arcs/core/entity/EntityPreparer.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+package arcs.core.entity
+
+import arcs.core.common.Id
+import arcs.core.data.RawEntity
+import arcs.core.data.Schema
+import arcs.core.data.Ttl
+import arcs.core.util.Time
+
+/** Prepares the provided entity and serializes it for storage. */
+@Suppress("GoodTime") // use Instant
+class EntityPreparer<T : Entity>(
+    val handleName: String,
+    val idGenerator: Id.Generator,
+    val schema: Schema,
+    val ttl: Ttl,
+    val time: Time
+) {
+    fun prepareEntity(entity: T): RawEntity {
+        entity.ensureIdentified(idGenerator, handleName)
+
+        val rawEntity = entity.serialize()
+
+        rawEntity.creationTimestamp = time.currentTimeMillis
+        require(schema.refinement(rawEntity)) {
+            "Invalid entity stored to handle $handleName(failed refinement)"
+        }
+        if (ttl != Ttl.Infinite) {
+            rawEntity.expirationTimestamp = ttl.calculateExpiration(time)
+        }
+        return rawEntity
+    }
+}

--- a/java/arcs/core/entity/SingletonHandle.kt
+++ b/java/arcs/core/entity/SingletonHandle.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+package arcs.core.entity
+
+import arcs.core.crdt.CrdtSingleton
+import arcs.core.data.RawEntity
+import arcs.core.storage.StorageProxy
+import arcs.core.storage.StoreOptions
+import arcs.core.storage.referencemode.ReferenceModeStorageKey
+
+typealias SingletonProxy<T> = StorageProxy<SingletonData<T>, SingletonOp<T>, T?>
+typealias SingletonData<T> = CrdtSingleton.Data<T>
+typealias SingletonOp<T> = CrdtSingleton.IOperation<T>
+typealias SingletonStoreOptions<T> = StoreOptions<SingletonData<T>, SingletonOp<T>, T?>
+
+/**
+ * This class implements all of the methods that are needed by the various singleton [Handle]
+ * interfaces:
+ * * [Handle]
+ * * [ReadableHandle<T>]
+ * * [ReadSingletonHandle<T>]
+ * * [WriteSingletonHandle<T>]
+ * * [ReadWriteSingletonHandle<T>]
+ *
+ * It manages the storage and retrieval of items of the specified [Entity] type, including
+ * their conversion to and from the backing [RawEntity] type that the storage layer requires.
+ *
+ * This class won't be returned directly; instead it will be wrapped in a facade object that
+ * exposes only the methods that should be exposed.
+ */
+class SingletonHandle<T : Entity>(
+    name: String,
+    /** Provides the [Schema] and a `deserialize` method. */
+    val entitySpec: EntitySpec<T>,
+    /** Interface to storage for [RawEntity] objects backing an `entity: T`. */
+    val storageProxy: SingletonProxy<RawEntity>,
+    /** Will ensure that necessary fields are present on the [RawEntity] before storage. */
+    val entityPreparer: EntityPreparer<T>,
+    /** Provides logic to fetch [RawEntity] object backing a [Reference] field. */
+    val dereferencerFactory: EntityDereferencerFactory
+) : BaseHandle(name, storageProxy), ReadWriteSingletonHandle<T> {
+
+    // region implement ReadSingletonHandle<T>
+    override suspend fun fetch() = adaptValue(storageProxy.getParticleView())
+    // endregion
+
+    // region implement WriteSingletonHandle<T>
+    override suspend fun store(entity: T) {
+        storageProxy.applyOp(
+            CrdtSingleton.Operation.Update(
+                name,
+                storageProxy.getVersionMap().increment(name),
+                entityPreparer.prepareEntity(entity)
+            )
+        )
+    }
+
+    override suspend fun clear() {
+        storageProxy.applyOp(
+            CrdtSingleton.Operation.Clear(
+                name,
+                storageProxy.getVersionMap()
+            )
+        )
+    }
+    // endregion
+
+    // region implement ReadbleHandle<T>
+    override suspend fun onUpdate(action: suspend (T?) -> Unit) =
+        storageProxy.addOnUpdate(name) {
+            action(adaptValue(it))
+        }
+
+    override suspend fun createReference(entity: T): Reference<T> {
+        val entityId = requireNotNull(entity.entityId) {
+            "Entity must have an ID before it can be referenced."
+        }
+        val storageKey = requireNotNull(storageProxy.storageKey as? ReferenceModeStorageKey) {
+            "ReferenceModeStorageKey required in order to create references."
+        }
+        require(fetch()?.entityId == entityId) {
+            "Entity is not stored in the Singleton."
+        }
+
+        return Reference(
+            entitySpec,
+            arcs.core.storage.Reference(entity.serialize().id, storageKey.backingKey, null).also {
+                it.dereferencer = dereferencerFactory.create(entitySpec.SCHEMA)
+            }
+        )
+    }
+    // endregion
+
+    private fun adaptValue(value: RawEntity?): T? = value?.let {
+        dereferencerFactory.injectDereferencers(entitySpec.SCHEMA, value)
+        entitySpec.deserialize(value)
+    }
+}

--- a/java/arcs/core/host/EntityHandleManager.kt
+++ b/java/arcs/core/host/EntityHandleManager.kt
@@ -18,11 +18,14 @@ import arcs.core.data.CollectionType
 import arcs.core.data.EntityType
 import arcs.core.data.HandleMode
 import arcs.core.data.RawEntity
-import arcs.core.data.Schema
 import arcs.core.data.SingletonType
 import arcs.core.data.Ttl
+import arcs.core.entity.CollectionHandle
+import arcs.core.entity.CollectionProxy
+import arcs.core.entity.CollectionStoreOptions
 import arcs.core.entity.Entity
 import arcs.core.entity.EntityDereferencerFactory
+import arcs.core.entity.EntityPreparer
 import arcs.core.entity.EntitySpec
 import arcs.core.entity.Handle
 import arcs.core.entity.ReadCollectionHandle
@@ -30,19 +33,15 @@ import arcs.core.entity.ReadSingletonHandle
 import arcs.core.entity.ReadWriteCollectionHandle
 import arcs.core.entity.ReadWriteSingletonHandle
 import arcs.core.entity.Reference
+import arcs.core.entity.SingletonHandle
+import arcs.core.entity.SingletonProxy
+import arcs.core.entity.SingletonStoreOptions
 import arcs.core.entity.WriteCollectionHandle
 import arcs.core.entity.WriteSingletonHandle
 import arcs.core.storage.ActivationFactory
-import arcs.core.storage.Reference as StorageReference
 import arcs.core.storage.StorageKey
 import arcs.core.storage.StorageMode.ReferenceMode
-import arcs.core.storage.StorageProxy
 import arcs.core.storage.StoreManager
-import arcs.core.storage.handle.CollectionProxy
-import arcs.core.storage.handle.CollectionStoreOptions
-import arcs.core.storage.handle.SingletonProxy
-import arcs.core.storage.handle.SingletonStoreOptions
-import arcs.core.storage.referencemode.ReferenceModeStorageKey
 import arcs.core.util.Time
 
 /**
@@ -50,6 +49,8 @@ import arcs.core.util.Time
  * [ReadSingletonHandle] for [HandleMode.Read]. To obtain a [HandleHolder], use
  * `arcs_kt_schema` on a manifest file to generate a `{ParticleName}Handles' class, and
  * invoke its default constructor, or obtain it from the [BaseParticle.handles] field.
+ *
+ * Instances of this class are not thread-safe.
  *
  * TODO(csilvestrini): Add support for creating Singleton/Set handles of [Reference]s.
  */
@@ -60,7 +61,6 @@ class EntityHandleManager(
     private val stores: StoreManager = StoreManager(),
     private val activationFactory: ActivationFactory? = null
 ) {
-
     private val singletonStorageProxies = mutableMapOf<StorageKey, SingletonProxy<RawEntity>>()
     private val collectionStorageProxies = mutableMapOf<StorageKey, CollectionProxy<RawEntity>>()
     private val dereferencerFactory = EntityDereferencerFactory(stores, activationFactory)
@@ -79,53 +79,22 @@ class EntityHandleManager(
         storageKey: StorageKey,
         ttl: Ttl = Ttl.Infinite,
         idGenerator: Id.Generator = Id.Generator.newSession()
-    ): BaseHandleAdapter {
-        val name = idGenerator.newChildId(
-            idGenerator.newChildId(arcId.toArcId(), hostId),
-            baseName
-        ).toString()
-
-        val entityPrep = EntityPreparer<T>(
-            name,
-            idGenerator,
-            entitySpec.SCHEMA,
-            ttl,
-            time
-        )
-
-        val store = stores.get(
-            SingletonStoreOptions<RawEntity>(
-                storageKey = storageKey,
-                type = SingletonType(EntityType(entitySpec.SCHEMA)),
-                mode = ReferenceMode
-            )
-        ).activate(activationFactory)
-
-        val storageProxy = singletonStorageProxies.getOrPut(storageKey) {
-            SingletonProxy(store, CrdtSingleton())
-        }
-
-        return when (mode) {
-            HandleMode.Read -> ReadSingletonHandleAdapter(
-                name = name,
+    ): Handle =
+        idGenerator.handleName(baseName).let { name ->
+            SingletonHandle(
+                name = idGenerator.handleName(baseName),
                 entitySpec = entitySpec,
-                storageProxy = storageProxy,
+                storageProxy = singletonStoreProxy(storageKey, entitySpec),
+                entityPreparer = EntityPreparer(name, idGenerator, entitySpec.SCHEMA, ttl, time),
                 dereferencerFactory = dereferencerFactory
             )
-            HandleMode.Write -> WriteSingletonHandleAdapter<T>(
-                name = name,
-                storageProxy = storageProxy,
-                entityPreparer = entityPrep
-            )
-            HandleMode.ReadWrite -> ReadWriteSingletonHandleAdapter(
-                name = name,
-                entitySpec = entitySpec,
-                storageProxy = storageProxy,
-                entityPreparer = entityPrep,
-                dereferencerFactory = dereferencerFactory
-            )
+        }.let { handle ->
+            return when (mode) {
+                HandleMode.Read -> object : ReadSingletonHandle<T> by handle {}
+                HandleMode.Write -> object : WriteSingletonHandle<T> by handle {}
+                HandleMode.ReadWrite -> object : ReadWriteSingletonHandle<T> by handle {}
+            }
         }
-    }
 
     /**
      * Creates and returns a new collection handle for a set of [Entity]s.
@@ -142,360 +111,55 @@ class EntityHandleManager(
         storageKey: StorageKey,
         ttl: Ttl = Ttl.Infinite,
         idGenerator: Id.Generator = Id.Generator.newSession()
-    ): BaseHandleAdapter {
-        val name = idGenerator.newChildId(
-            idGenerator.newChildId(arcId.toArcId(), hostId),
-            baseName
-        ).toString()
-
-        val entityPrep = EntityPreparer<T>(
-            name,
-            idGenerator,
-            entitySpec.SCHEMA,
-            ttl,
-            time
-        )
-
-        val store = stores.get(
-            CollectionStoreOptions<RawEntity>(
-                storageKey = storageKey,
-                type = CollectionType(EntityType(entitySpec.SCHEMA)),
-                mode = ReferenceMode
-            )
-        ).activate(activationFactory)
-
-        val storageProxy = collectionStorageProxies.getOrPut(storageKey) {
-            CollectionProxy(store, CrdtSet())
-        }
-
-        return when (mode) {
-            HandleMode.Read -> ReadCollectionHandleAdapter(
-                name = name,
+    ): Handle =
+        idGenerator.handleName(baseName).let { name ->
+            CollectionHandle(
+                name = idGenerator.handleName(baseName),
                 entitySpec = entitySpec,
-                storageProxy = storageProxy,
+                storageProxy = collectionStoreProxy(storageKey, entitySpec),
+                entityPreparer = EntityPreparer(name, idGenerator, entitySpec.SCHEMA, ttl, time),
                 dereferencerFactory = dereferencerFactory
             )
-            HandleMode.Write -> WriteCollectionHandleAdapter(
-                name = name,
-                storageProxy = storageProxy,
-                entityPreparer = entityPrep
-            )
-            HandleMode.ReadWrite -> ReadWriteCollectionHandleAdapter(
-                name = name,
-                entitySpec = entitySpec,
-                storageProxy = storageProxy,
-                entityPreparer = entityPrep,
-                dereferencerFactory = dereferencerFactory
-            )
-        }
-    }
-}
-
-/** A concrete readable singleton handle implementation. */
-class ReadSingletonHandleAdapter<T : Entity>(
-    name: String,
-    entitySpec: EntitySpec<T>,
-    storageProxy: SingletonProxy<RawEntity>,
-    dereferencerFactory: EntityDereferencerFactory
-) : BaseHandleAdapter(name, storageProxy),
-    ReadSingletonHandle<T>,
-    ReadSingletonOperations<T> by ReadSingletonOperationsImpl<T>(
-        name,
-        entitySpec,
-        storageProxy,
-        dereferencerFactory
-    )
-
-/** A concrete writable singleton handle implementation. */
-class WriteSingletonHandleAdapter<T : Entity>(
-    name: String,
-    storageProxy: SingletonProxy<RawEntity>,
-    entityPreparer: EntityPreparer<T>
-) : BaseHandleAdapter(name, storageProxy),
-    WriteSingletonHandle<T>,
-    WriteSingletonOperations<T> by WriteSingletonOperationsImpl<T>(
-        name,
-        storageProxy,
-        entityPreparer
-    )
-
-/** A concrete readable + writable singleton handle implementation. */
-class ReadWriteSingletonHandleAdapter<T : Entity>(
-    name: String,
-    entitySpec: EntitySpec<T>,
-    storageProxy: SingletonProxy<RawEntity>,
-    entityPreparer: EntityPreparer<T>,
-    dereferencerFactory: EntityDereferencerFactory
-) : BaseHandleAdapter(name, storageProxy),
-    ReadWriteSingletonHandle<T>,
-    ReadSingletonOperations<T> by ReadSingletonOperationsImpl<T>(
-        name,
-        entitySpec,
-        storageProxy,
-        dereferencerFactory
-    ),
-    WriteSingletonOperations<T> by WriteSingletonOperationsImpl<T>(
-        name,
-        storageProxy,
-        entityPreparer
-    )
-
-/** A concrete readable collection handle implementation. */
-class ReadCollectionHandleAdapter<T : Entity>(
-    name: String,
-    entitySpec: EntitySpec<T>,
-    storageProxy: CollectionProxy<RawEntity>,
-    dereferencerFactory: EntityDereferencerFactory
-) : BaseHandleAdapter(name, storageProxy),
-    ReadCollectionHandle<T>,
-    ReadCollectionOperations<T> by ReadCollectionOperationsImpl<T>(
-        name,
-        entitySpec,
-        storageProxy,
-        dereferencerFactory
-    )
-
-/** A concrete writable collection handle implementation. */
-class WriteCollectionHandleAdapter<T : Entity>(
-    name: String,
-    storageProxy: CollectionProxy<RawEntity>,
-    entityPreparer: EntityPreparer<T>
-) : BaseHandleAdapter(name, storageProxy),
-    WriteCollectionHandle<T>,
-    WriteCollectionOperations<T> by WriteCollectionOperationsImpl<T>(
-        name,
-        storageProxy,
-        entityPreparer
-    )
-
-/** A concrete readable & writable collection handle implementation. */
-class ReadWriteCollectionHandleAdapter<T : Entity>(
-    name: String,
-    entitySpec: EntitySpec<T>,
-    storageProxy: CollectionProxy<RawEntity>,
-    entityPreparer: EntityPreparer<T>,
-    dereferencerFactory: EntityDereferencerFactory
-) : BaseHandleAdapter(name, storageProxy),
-    ReadWriteCollectionHandle<T>,
-    ReadCollectionOperations<T> by ReadCollectionOperationsImpl<T>(
-        name,
-        entitySpec,
-        storageProxy,
-        dereferencerFactory
-    ),
-    WriteCollectionOperations<T> by WriteCollectionOperationsImpl<T>(
-        name,
-        storageProxy,
-        entityPreparer
-    )
-
-/** Implementation of singleton read operations to mix into concrete instances. */
-private class ReadSingletonOperationsImpl<T : Entity>(
-    private val name: String,
-    private val entitySpec: EntitySpec<T>,
-    private val storageProxy: SingletonProxy<RawEntity>,
-    private val dereferencerFactory: EntityDereferencerFactory
-) : ReadSingletonOperations<T> {
-
-    private fun adaptValue(value: RawEntity?): T? = value?.let {
-        dereferencerFactory.injectDereferencers(entitySpec.SCHEMA, value)
-        entitySpec.deserialize(value)
-    }
-
-    override suspend fun fetch() = adaptValue(storageProxy.getParticleView())
-
-    override suspend fun onUpdate(action: suspend (T?) -> Unit) = storageProxy.addOnUpdate(name) {
-        action(adaptValue(it))
-    }
-
-    override suspend fun createReference(entity: T): Reference<T> {
-        val entityId = requireNotNull(entity.entityId) {
-            "Entity must have an ID before it can be referenced."
-        }
-        val storageKey = requireNotNull(storageProxy.storageKey as? ReferenceModeStorageKey) {
-            "ReferenceModeStorageKey required in order to create references."
-        }
-        if (fetch()?.entityId != entityId) {
-            throw IllegalArgumentException("Entity is not stored in the Singleton.")
-        }
-
-        return Reference(
-            entitySpec,
-            StorageReference(entity.serialize().id, storageKey.backingKey, null).also {
-                it.dereferencer = dereferencerFactory.create(entitySpec.SCHEMA)
+        }.let {
+            when (mode) {
+                HandleMode.Read -> object : ReadCollectionHandle<T> by it {}
+                HandleMode.Write -> object : WriteCollectionHandle<T> by it {}
+                HandleMode.ReadWrite -> object : ReadWriteCollectionHandle<T> by it {}
             }
+        }
+
+    private fun Id.Generator.handleName(baseName: String) = newChildId(
+        newChildId(arcId.toArcId(), hostId),
+        baseName
+    ).toString()
+
+    private suspend fun <T : Entity> singletonStoreProxy(
+        storageKey: StorageKey,
+        entitySpec: EntitySpec<T>
+    ) = stores.get(
+        SingletonStoreOptions<RawEntity>(
+            storageKey = storageKey,
+            type = SingletonType(EntityType(entitySpec.SCHEMA)),
+            mode = ReferenceMode
         )
-    }
-}
-
-/** Implementation of singleton write operations to mix into concrete instances. */
-private class WriteSingletonOperationsImpl<T : Entity>(
-    private val name: String,
-    private val storageProxy: SingletonProxy<RawEntity>,
-    private val entityPreparer: EntityPreparer<T>
-) : WriteSingletonOperations<T> {
-    override suspend fun store(entity: T) {
-        storageProxy.applyOp(CrdtSingleton.Operation.Update(
-            name,
-            storageProxy.getVersionMap().increment(name),
-            entityPreparer.prepareEntity(entity)
-        ))
+    ).activate(activationFactory).let { activeStore ->
+        singletonStorageProxies.getOrPut(storageKey) {
+            SingletonProxy(activeStore, CrdtSingleton())
+        }
     }
 
-    override suspend fun clear() {
-        storageProxy.applyOp(CrdtSingleton.Operation.Clear(
-            name,
-            storageProxy.getVersionMap()
-        ))
-    }
-}
-
-/** Implementation of collection read operations to mix into concrete instances. */
-private class ReadCollectionOperationsImpl<T : Entity>(
-    private val name: String,
-    private val entitySpec: EntitySpec<T>,
-    private val storageProxy: CollectionProxy<RawEntity>,
-    private val dereferencerFactory: EntityDereferencerFactory
-) : ReadCollectionOperations<T> {
-    override suspend fun size() = fetchAll().size
-    override suspend fun isEmpty() = fetchAll().isEmpty()
-
-    private fun adaptValues(values: Set<RawEntity>) = values.mapTo(mutableSetOf()) {
-        dereferencerFactory.injectDereferencers(entitySpec.SCHEMA, it)
-        entitySpec.deserialize(it)
-    }
-
-    override suspend fun fetchAll() = adaptValues(storageProxy.getParticleView())
-
-    override suspend fun onUpdate(action: suspend (Set<T>) -> Unit) =
-        storageProxy.addOnUpdate(name) {
-            action(adaptValues(it))
-        }
-
-    override suspend fun createReference(entity: T): Reference<T> {
-        val entityId = requireNotNull(entity.entityId) {
-            "Entity must have an ID before it can be referenced."
-        }
-        val storageKey = requireNotNull(storageProxy.storageKey as? ReferenceModeStorageKey) {
-            "ReferenceModeStorageKey required in order to create references."
-        }
-        if (!fetchAll().any { it.entityId == entityId }) {
-            throw IllegalArgumentException("Entity is not stored in the Collection.")
-        }
-
-        return Reference(
-            entitySpec,
-            StorageReference(entity.serialize().id, storageKey.backingKey, null).also {
-                it.dereferencer = dereferencerFactory.create(entitySpec.SCHEMA)
-            }
+    private suspend fun <T : Entity> collectionStoreProxy(
+        storageKey: StorageKey,
+        entitySpec: EntitySpec<T>
+    ) = stores.get(
+        CollectionStoreOptions<RawEntity>(
+            storageKey = storageKey,
+            type = CollectionType(EntityType(entitySpec.SCHEMA)),
+            mode = ReferenceMode
         )
-    }
-}
-
-/** Implementation of collection write operations to mix into concrete instances. */
-private class WriteCollectionOperationsImpl<T : Entity>(
-    private val name: String,
-    private val storageProxy: CollectionProxy<RawEntity>,
-    private val entityPreparer: EntityPreparer<T>
-) : WriteCollectionOperations<T> {
-    override suspend fun store(entity: T) {
-        storageProxy.applyOp(CrdtSet.Operation.Add(
-            name,
-            storageProxy.getVersionMap().increment(name),
-            entityPreparer.prepareEntity(entity)
-        ))
-    }
-
-    override suspend fun clear() {
-        storageProxy.getParticleView().forEach {
-            storageProxy.applyOp(CrdtSet.Operation.Remove(
-                name,
-                storageProxy.getVersionMap(),
-                it
-            ))
+    ).activate(activationFactory).let { activeStore ->
+        collectionStorageProxies.getOrPut(storageKey) {
+            CollectionProxy(activeStore, CrdtSet())
         }
-    }
-
-    override suspend fun remove(entity: T) {
-        storageProxy.applyOp(CrdtSet.Operation.Remove(
-            name,
-            storageProxy.getVersionMap(),
-            entity.serialize()
-        ))
-    }
-}
-
-/** Base functionality common to all read/write singleton and collection handles. */
-abstract class BaseHandleAdapter(
-    override val name: String,
-    private val storageProxy: StorageProxy<*, *, *>
-) : Handle {
-    override suspend fun onSync(action: () -> Unit) = storageProxy.addOnSync(name, action)
-
-    override suspend fun onDesync(action: () -> Unit) = storageProxy.addOnDesync(name, action)
-
-    override suspend fun close() {
-        storageProxy.removeCallbacksForName(name)
-    }
-}
-
-/** Delegate this interface in a concrete singleton handle impl to mixin read operations. */
-private interface UpdateOperations<T> {
-    suspend fun onUpdate(action: suspend (T) -> Unit)
-}
-
-private interface ReferenceOperations<T : Entity> {
-    suspend fun createReference(entity: T): Reference<T>
-}
-
-/** Delegate this interface in a concrete singleton handle impl to mixin read operations. */
-private interface ReadSingletonOperations<T : Entity> :
-    UpdateOperations<T?>, ReferenceOperations<T> {
-    suspend fun fetch(): T?
-}
-
-/** Delegate this interface in a concrete singleton handle impl to mixin write operations. */
-private interface WriteSingletonOperations<T : Entity> {
-    suspend fun store(entity: T)
-    suspend fun clear()
-}
-
-/** Delegate this interface in a concrete collection handle impl to mixin read operations. */
-private interface ReadCollectionOperations<T : Entity> :
-    UpdateOperations<Set<T>>, ReferenceOperations<T> {
-    suspend fun size(): Int
-    suspend fun isEmpty(): Boolean
-    suspend fun fetchAll(): Set<T>
-}
-
-/** Delegate this interface in a concrete collection handle impl to mixin write operations. */
-private interface WriteCollectionOperations<T : Entity> {
-    suspend fun store(entity: T)
-    suspend fun clear()
-    suspend fun remove(entity: T)
-}
-
-/** Prepares the provided entity and serializes it for storage */
-@Suppress("GoodTime") // use Instant
-class EntityPreparer<T : Entity>(
-    val handleName: String,
-    val idGenerator: Id.Generator,
-    val schema: Schema,
-    val ttl: Ttl,
-    val time: Time
-) {
-    fun prepareEntity(entity: T): RawEntity {
-        entity.ensureIdentified(idGenerator, handleName)
-
-        val rawEntity = entity.serialize()
-
-        rawEntity.creationTimestamp = time.currentTimeMillis
-        require(schema.refinement(rawEntity)) {
-            "Invalid entity stored to handle $handleName(failed refinement)"
-        }
-        if (ttl != Ttl.Infinite) {
-            rawEntity.expirationTimestamp = ttl.calculateExpiration(time)
-        }
-        return rawEntity
     }
 }

--- a/java/arcs/core/storage/RawEntityDereferencer.kt
+++ b/java/arcs/core/storage/RawEntityDereferencer.kt
@@ -9,20 +9,12 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-package arcs.core.storage.handle
+package arcs.core.storage
 
 import arcs.core.crdt.CrdtEntity
 import arcs.core.data.EntityType
 import arcs.core.data.RawEntity
 import arcs.core.data.Schema
-import arcs.core.storage.ActivationFactory
-import arcs.core.storage.Dereferencer
-import arcs.core.storage.ProxyCallback
-import arcs.core.storage.ProxyMessage
-import arcs.core.storage.Reference
-import arcs.core.storage.StorageMode
-import arcs.core.storage.StoreManager
-import arcs.core.storage.StoreOptions
 import arcs.core.util.TaggedLog
 import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CompletableDeferred

--- a/java/arcs/core/storage/handle/HandleManager.kt
+++ b/java/arcs/core/storage/handle/HandleManager.kt
@@ -21,6 +21,7 @@ import arcs.core.data.SingletonType
 import arcs.core.data.Ttl
 import arcs.core.storage.ActivationFactory
 import arcs.core.storage.ActiveStore
+import arcs.core.storage.RawEntityDereferencer
 import arcs.core.storage.Reference
 import arcs.core.storage.StorageKey
 import arcs.core.storage.StorageMode

--- a/javatests/arcs/core/entity/ReferenceTest.kt
+++ b/javatests/arcs/core/entity/ReferenceTest.kt
@@ -8,7 +8,7 @@ import arcs.core.host.EntityHandleManager
 import arcs.core.storage.DriverFactory
 import arcs.core.storage.api.DriverAndKeyConfigurator
 import arcs.core.storage.Reference as StorageReference
-import arcs.core.storage.handle.RawEntityDereferencer
+import arcs.core.storage.RawEntityDereferencer
 import arcs.core.storage.keys.RamDiskStorageKey
 import arcs.core.storage.referencemode.ReferenceModeStorageKey
 import arcs.core.testutil.assertThrows

--- a/javatests/arcs/core/storage/ReferenceTest.kt
+++ b/javatests/arcs/core/storage/ReferenceTest.kt
@@ -23,7 +23,6 @@ import arcs.core.data.SchemaFields
 import arcs.core.data.util.ReferencablePrimitive
 import arcs.core.data.util.toReferencable
 import arcs.core.storage.driver.RamDiskDriverProvider
-import arcs.core.storage.handle.RawEntityDereferencer
 import arcs.core.storage.keys.RamDiskStorageKey
 import arcs.core.storage.referencemode.ReferenceModeStorageKey
 import arcs.core.util.testutil.LogRule

--- a/javatests/arcs/core/storage/handle/RawEntityDereferencerTest.kt
+++ b/javatests/arcs/core/storage/handle/RawEntityDereferencerTest.kt
@@ -23,10 +23,12 @@ import arcs.core.data.SchemaFields
 import arcs.core.data.util.toReferencable
 import arcs.core.storage.Driver
 import arcs.core.storage.DriverFactory
+import arcs.core.storage.RawEntityDereferencer
 import arcs.core.storage.Reference
 import arcs.core.storage.driver.RamDisk
 import arcs.core.storage.driver.RamDiskDriverProvider
 import arcs.core.storage.keys.RamDiskStorageKey
+import arcs.core.storage.matches
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runBlockingTest


### PR DESCRIPTION
* Move single,collection implementation into separate files
* Simplify implementation strategy: always instantiate full handle, wrap
  in object that only exposes proper interface.
* Remove dependencies on storage.handle (including moving
  RawEntityDereferencer to different package, since we still need it