### PR TITLE
Make creationTimestamp and expiryTimestamp arguments in the construct…

### DIFF
--- a/java/arcs/core/common/Referencable.kt
+++ b/java/arcs/core/common/Referencable.kt
@@ -20,14 +20,12 @@ interface Referencable {
     val id: ReferenceId
 
     /** Creation timestamp (in millis) on the Referencable object. */
-    var creationTimestamp: Long
+    val creationTimestamp: Long
         get() = TODO("not implemented")
-        set(@Suppress("UNUSED_PARAMETER") value) = TODO("not implemented")
 
     /** Expiration timestamp (in millis) on the Referencable object. */
-    var expirationTimestamp: Long
+    val expirationTimestamp: Long
         get() = TODO("not implemented")
-        set(@Suppress("UNUSED_PARAMETER") value) = TODO("not implemented")
 
     /**
      * If the implementation of [Referencable] supports it, this function returns a realized-version

--- a/java/arcs/core/crdt/CrdtEntity.kt
+++ b/java/arcs/core/crdt/CrdtEntity.kt
@@ -86,10 +86,8 @@ class CrdtEntity(
             if (_data.creationTimestamp == RawEntity.UNINITIALIZED_TIMESTAMP) {
                 _data.creationTimestamp = other.creationTimestamp
             } else if (other.creationTimestamp != RawEntity.UNINITIALIZED_TIMESTAMP) {
-                // Two different values, we keep the earlier creationTimestamp.
-                // TODO: change this to throw an exception instead, creation timestamp should only
-                // be set when the id is created, then never change.
-                _data.creationTimestamp = minOf(_data.creationTimestamp, other.creationTimestamp)
+                // Two different values, this should be impossible.
+                throw CrdtException("Cannot merge different values for creationTimestamp.")
             }
         }
         if (_data.expirationTimestamp != other.expirationTimestamp) {
@@ -97,7 +95,7 @@ class CrdtEntity(
             if (_data.expirationTimestamp == RawEntity.UNINITIALIZED_TIMESTAMP) {
                 _data.expirationTimestamp = other.expirationTimestamp
             } else if (other.expirationTimestamp != RawEntity.UNINITIALIZED_TIMESTAMP) {
-                // Two different values, we don't how to merge this.
+                // Two different values, this should be impossible.
                 throw CrdtException("Cannot merge different values for expirationTimestamp.")
             }
         }

--- a/java/arcs/core/entity/Entity.kt
+++ b/java/arcs/core/entity/Entity.kt
@@ -15,7 +15,9 @@ import arcs.core.common.Id
 import arcs.core.common.Referencable
 import arcs.core.data.RawEntity
 import arcs.core.data.Schema
+import arcs.core.data.Ttl
 import arcs.core.data.util.ReferencablePrimitive
+import arcs.core.util.Time
 import kotlin.IllegalArgumentException
 import kotlin.reflect.KClass
 
@@ -23,8 +25,16 @@ interface Entity {
     /** The ID for the entity, or null if it is does not have one yet. */
     val entityId: String?
 
-    /** Generates a new ID for the Entity, if it doesn't already have one. */
-    fun ensureIdentified(idGenerator: Id.Generator, handleName: String)
+    /**
+     * Generates a new ID for the Entity, if it doesn't already have one. Also sets creation
+     * timestamp, and expiry timestamp if a ttl is given
+     * */
+    fun ensureIdentified(
+        idGenerator: Id.Generator,
+        handleName: String,
+        time: Time,
+        ttl: Ttl = Ttl.Infinite
+    )
 
     fun serialize(): RawEntity
 

--- a/java/arcs/core/entity/Entity.kt
+++ b/java/arcs/core/entity/Entity.kt
@@ -29,7 +29,7 @@ interface Entity {
      * Generates a new ID for the Entity, if it doesn't already have one. Also sets creation
      * timestamp, and expiry timestamp if a ttl is given
      * */
-    fun ensureIdentified(
+    fun ensureEntityFields(
         idGenerator: Id.Generator,
         handleName: String,
         time: Time,

--- a/java/arcs/core/entity/EntityBase.kt
+++ b/java/arcs/core/entity/EntityBase.kt
@@ -191,7 +191,7 @@ open class EntityBase(
         expirationTimestamp = rawEntity.expirationTimestamp
     }
 
-    override fun ensureIdentified(
+    override fun ensureEntityFields(
         idGenerator: Id.Generator,
         handleName: String,
         time: Time,

--- a/java/arcs/core/entity/EntityBase.kt
+++ b/java/arcs/core/entity/EntityBase.kt
@@ -17,9 +17,12 @@ import arcs.core.data.FieldType
 import arcs.core.data.PrimitiveType
 import arcs.core.data.RawEntity
 import arcs.core.data.RawEntity.Companion.NO_REFERENCE_ID
+import arcs.core.data.RawEntity.Companion.UNINITIALIZED_TIMESTAMP
 import arcs.core.data.Schema
+import arcs.core.data.Ttl
 import arcs.core.data.util.ReferencablePrimitive
 import arcs.core.data.util.toReferencable
+import arcs.core.util.Time
 import kotlin.reflect.KProperty
 
 open class EntityBase(
@@ -33,6 +36,8 @@ open class EntityBase(
 
     private val singletons: MutableMap<String, Any?> = mutableMapOf()
     private val collections: MutableMap<String, Set<Any>> = mutableMapOf()
+    private var creationTimestamp: Long = UNINITIALIZED_TIMESTAMP
+    private var expirationTimestamp: Long = UNINITIALIZED_TIMESTAMP
 
     // Initialize all fields. After this point, if a key is not present in singletons/collections,
     // it will not be considered a valid field for the entity.
@@ -164,7 +169,9 @@ open class EntityBase(
         collections = collections.mapValues { (field, values) ->
             val type = getCollectionType(field)
             values.map { toReferencable(it, type) }.toSet()
-        }
+        },
+        creationTimestamp = creationTimestamp,
+        expirationTimestamp = expirationTimestamp
     )
 
     /**
@@ -180,15 +187,26 @@ open class EntityBase(
             val type = getCollectionType(field)
             setCollectionValue(field, values.map { fromReferencable(it, type) }.toSet())
         }
+        creationTimestamp = rawEntity.creationTimestamp
+        expirationTimestamp = rawEntity.expirationTimestamp
     }
 
-    override fun ensureIdentified(idGenerator: Id.Generator, handleName: String) {
+    override fun ensureIdentified(
+        idGenerator: Id.Generator,
+        handleName: String,
+        time: Time,
+        ttl: Ttl
+    ) {
         if (_entityId == null) {
             _entityId = idGenerator.newChildId(
                 // TODO: should we allow this to be plumbed through?
                 idGenerator.newArcId("dummy-arc"),
                 handleName
             ).toString()
+            creationTimestamp = requireNotNull(time).currentTimeMillis
+            if (ttl != Ttl.Infinite) {
+                expirationTimestamp = ttl.calculateExpiration(time)
+            }
         }
     }
 

--- a/java/arcs/core/entity/EntityPreparer.kt
+++ b/java/arcs/core/entity/EntityPreparer.kt
@@ -26,7 +26,7 @@ class EntityPreparer<T : Entity>(
     val time: Time
 ) {
     fun prepareEntity(entity: T): RawEntity {
-        entity.ensureIdentified(idGenerator, handleName, time, ttl)
+        entity.ensureEntityFields(idGenerator, handleName, time, ttl)
 
         val rawEntity = entity.serialize()
 

--- a/java/arcs/core/entity/EntityPreparer.kt
+++ b/java/arcs/core/entity/EntityPreparer.kt
@@ -26,16 +26,12 @@ class EntityPreparer<T : Entity>(
     val time: Time
 ) {
     fun prepareEntity(entity: T): RawEntity {
-        entity.ensureIdentified(idGenerator, handleName)
+        entity.ensureIdentified(idGenerator, handleName, time, ttl)
 
         val rawEntity = entity.serialize()
 
-        rawEntity.creationTimestamp = time.currentTimeMillis
         require(schema.refinement(rawEntity)) {
             "Invalid entity stored to handle $handleName(failed refinement)"
-        }
-        if (ttl != Ttl.Infinite) {
-            rawEntity.expirationTimestamp = ttl.calculateExpiration(time)
         }
         return rawEntity
     }

--- a/java/arcs/core/storage/Reference.kt
+++ b/java/arcs/core/storage/Reference.kt
@@ -29,37 +29,17 @@ import kotlinx.coroutines.Dispatchers
 data class Reference(
     override val id: ReferenceId,
     val storageKey: StorageKey,
-    val version: VersionMap?
+    val version: VersionMap?,
+    /** Reference creation time (in milliseconds). */
+    override val creationTimestamp: Long = RawEntity.UNINITIALIZED_TIMESTAMP,
+    /** Reference expiration time (in milliseconds). */
+    override val expirationTimestamp: Long = RawEntity.UNINITIALIZED_TIMESTAMP
 ) : Referencable, arcs.core.data.Reference<RawEntity> {
     /* internal */
     var dereferencer: Dereferencer<RawEntity>? = null
 
     override suspend fun dereference(coroutineContext: CoroutineContext): RawEntity? =
-        checkNotNull(dereferencer) {
-            "A dereferencer is required in order to dereference."
-        }.dereference(this, coroutineContext)
-
-    /** Entity creation time (in millis). */
-    @Suppress("GoodTime") // use Instant
-    override var creationTimestamp: Long = RawEntity.UNINITIALIZED_TIMESTAMP
-        set(value) {
-            require(this.creationTimestamp == RawEntity.UNINITIALIZED_TIMESTAMP) {
-                "cannot override creationTimestamp $value"
-            }
-            @Suppress("GoodTime") // use Instant
-            field = value
-        }
-
-    /** Entity expiration time (in millis). */
-    @Suppress("GoodTime") // use Instant
-    override var expirationTimestamp: Long = RawEntity.UNINITIALIZED_TIMESTAMP
-        set(value) {
-            require(this.expirationTimestamp == RawEntity.UNINITIALIZED_TIMESTAMP) {
-                "cannot override expirationTimestamp $value"
-            }
-            @Suppress("GoodTime") // use Instant
-            field = value
-    }
+        requireNotNull(dereferencer).dereference(this, coroutineContext)
 }
 
 /** Defines an object capable of de-referencing a [Reference]. */
@@ -87,19 +67,4 @@ interface Dereferencer<T> {
 
 /** Converts any [Referencable] object into a reference-mode-friendly [Reference] object. */
 fun Referencable.toReference(storageKey: StorageKey, version: VersionMap? = null) =
-    Reference(id, storageKey, version)
-
-fun Reference(
-    id: ReferenceId,
-    storageKey: StorageKey,
-    version: VersionMap?,
-    creationTimestamp: Long,
-    expirationTimestamp: Long
-) = Reference(
-    id,
-    storageKey,
-    version
-).also {
-    it.creationTimestamp = creationTimestamp
-    it.expirationTimestamp = expirationTimestamp
-}
+    Reference(id, storageKey, version, creationTimestamp, expirationTimestamp)

--- a/java/arcs/jvm/util/testutil/TimeImpl.kt
+++ b/java/arcs/jvm/util/testutil/TimeImpl.kt
@@ -13,9 +13,9 @@ package arcs.jvm.util.testutil
 
 import arcs.core.util.Time
 
-class TimeImpl : Time() {
+class TimeImpl(val millis: Long? = null) : Time() {
     override val currentTimeNanos: Long
         get() = System.nanoTime()
     override val currentTimeMillis: Long
-        get() = System.currentTimeMillis()
+        get() = millis ?: System.currentTimeMillis()
 }

--- a/java/arcs/sdk/android/dev/api/CollectionProxy.java
+++ b/java/arcs/sdk/android/dev/api/CollectionProxy.java
@@ -292,17 +292,7 @@ class CollectionProxy extends StorageProxy implements CollectionStore {
     }
 
     @Override
-    public void setCreationTimestamp(long creationTimestamp) {
-      throw new AssertionError("ModelEntry::setCreationTimestamp not implemented");
-    }
-
-    @Override
     public long getExpirationTimestamp() {
-      throw new AssertionError("ModelEntry::setExpiration not implemented");
-    }
-
-    @Override
-    public void setExpirationTimestamp(long expirationTimestamp) {
       throw new AssertionError("ModelEntry::setExpiration not implemented");
     }
   }

--- a/javatests/arcs/android/storage/ReferenceModeStoreDatabaseImplIntegrationTest.kt
+++ b/javatests/arcs/android/storage/ReferenceModeStoreDatabaseImplIntegrationTest.kt
@@ -288,9 +288,15 @@ class ReferenceModeStoreDatabaseImplIntegrationTest {
     fun keepsEntityTimestamps() = runBlockingTest {
         val activeStore = createReferenceModeStore()
         val actor = activeStore.crdtKey
-        val bob = createPersonEntity("an-id", "bob", 42)
-        bob.creationTimestamp = 10
-        bob.expirationTimestamp = 20
+        val bob = RawEntity(
+            id = "an-id",
+            singletons = mapOf(
+                "name" to "bob".toReferencable(),
+                "age" to 42.toReferencable()
+            ),
+            creationTimestamp = 10,
+            expirationTimestamp = 20
+        )
 
         // Add Bob to collection.
         val addOp = RefModeStoreOp.SetAdd(actor, VersionMap(actor to 1), bob)

--- a/javatests/arcs/core/crdt/CrdtEntityTest.kt
+++ b/javatests/arcs/core/crdt/CrdtEntityTest.kt
@@ -101,6 +101,7 @@ class CrdtEntityTest {
     @Test
     fun canApply_anAddOperation_toASingleField() {
         val rawEntity = RawEntity(
+            singletonFields = setOf(),
             collectionFields = setOf("foo")
         )
         val entity = CrdtEntity(VersionMap(), rawEntity)
@@ -227,7 +228,10 @@ class CrdtEntityTest {
 
     @Test
     fun failsWhen_singletonOperations_areProvidedTo_collectionFields() {
-        val entity = CrdtEntity(VersionMap(), RawEntity(collectionFields = setOf("things")))
+        val entity = CrdtEntity(VersionMap(), RawEntity(
+            singletonFields = setOf(),
+            collectionFields = setOf("things"))
+        )
 
         assertThrows(CrdtException::class) {
             entity.applyOperation(
@@ -289,8 +293,9 @@ class CrdtEntityTest {
         
         entity = entity(creation=5)
         entity2 = entity(creation=1)
-        entity.merge(entity2.data)
-        assertThat(entity.data.creationTimestamp).isEqualTo(1)
+        assertThrows(CrdtException::class) {
+            entity.merge(entity2.data)
+        }
     }
 
     @Test

--- a/javatests/arcs/core/entity/BUILD
+++ b/javatests/arcs/core/entity/BUILD
@@ -55,6 +55,7 @@ arcs_kt_jvm_library(
         "//java/arcs/core/storage/keys",
         "//java/arcs/core/storage/referencemode",
         "//java/arcs/core/testutil",
+        "//java/arcs/core/util",
         "//third_party/java/junit:junit-android",
         "//third_party/java/truth:truth-android",
         "//third_party/kotlin/kotlinx_coroutines",

--- a/javatests/arcs/core/entity/EntityBaseTest.kt
+++ b/javatests/arcs/core/entity/EntityBaseTest.kt
@@ -238,7 +238,7 @@ class EntityBaseTest {
         )
 
         // Different ID.
-        entity2.ensureIdentified(Id.Generator.newForTest("session"), "handle", TimeImpl())
+        entity2.ensureEntityFields(Id.Generator.newForTest("session"), "handle", TimeImpl())
         assertThat(entity1).isNotEqualTo(entity2)
     }
 
@@ -266,12 +266,12 @@ class EntityBaseTest {
     }
 
     @Test
-    fun ensureIdentified() {
+    fun ensureEntityFields() {
         // ID starts off null.
         assertThat(entity.entityId).isNull()
 
         // Calling once generates a new ID.
-        entity.ensureIdentified(Id.Generator.newForTest("session1"), "handle2", TimeImpl(10), Ttl.Minutes(1))
+        entity.ensureEntityFields(Id.Generator.newForTest("session1"), "handle2", TimeImpl(10), Ttl.Minutes(1))
         val id = entity.entityId
         assertThat(id).isNotNull()
         assertThat(id).isNotEmpty()
@@ -281,7 +281,7 @@ class EntityBaseTest {
         assertThat(serialized.expirationTimestamp).isEqualTo(60010)
 
         // Calling again doesn't change the value.
-        entity.ensureIdentified(Id.Generator.newForTest("session2"), "handle2", TimeImpl(20))
+        entity.ensureEntityFields(Id.Generator.newForTest("session2"), "handle2", TimeImpl(20))
         assertThat(entity.entityId).isEqualTo(id)
         assertThat(entity.serialize().creationTimestamp).isEqualTo(10)
     }

--- a/javatests/arcs/core/entity/EntityBaseTest.kt
+++ b/javatests/arcs/core/entity/EntityBaseTest.kt
@@ -15,9 +15,11 @@ import arcs.core.common.Id
 import arcs.core.crdt.VersionMap
 import arcs.core.data.Schema
 import arcs.core.data.SchemaFields
+import arcs.core.data.Ttl
 import arcs.core.storage.testutil.DummyStorageKey
 import arcs.core.storage.Reference as StorageReference
 import arcs.core.testutil.assertThrows
+import arcs.jvm.util.testutil.TimeImpl
 import com.google.common.truth.Truth.assertThat
 import org.junit.After
 import org.junit.Before
@@ -236,7 +238,7 @@ class EntityBaseTest {
         )
 
         // Different ID.
-        entity2.ensureIdentified(Id.Generator.newForTest("session"), "handle")
+        entity2.ensureIdentified(Id.Generator.newForTest("session"), "handle", TimeImpl())
         assertThat(entity1).isNotEqualTo(entity2)
     }
 
@@ -269,14 +271,19 @@ class EntityBaseTest {
         assertThat(entity.entityId).isNull()
 
         // Calling once generates a new ID.
-        entity.ensureIdentified(Id.Generator.newForTest("session1"), "handle2")
+        entity.ensureIdentified(Id.Generator.newForTest("session1"), "handle2", TimeImpl(10), Ttl.Minutes(1))
         val id = entity.entityId
         assertThat(id).isNotNull()
         assertThat(id).isNotEmpty()
 
+        val serialized = entity.serialize()
+        assertThat(serialized.creationTimestamp).isEqualTo(10)
+        assertThat(serialized.expirationTimestamp).isEqualTo(60010)
+
         // Calling again doesn't change the value.
-        entity.ensureIdentified(Id.Generator.newForTest("session2"), "handle2")
+        entity.ensureIdentified(Id.Generator.newForTest("session2"), "handle2", TimeImpl(20))
         assertThat(entity.entityId).isEqualTo(id)
+        assertThat(entity.serialize().creationTimestamp).isEqualTo(10)
     }
 
     @Test

--- a/javatests/arcs/core/entity/HandleManagerTestBase.kt
+++ b/javatests/arcs/core/entity/HandleManagerTestBase.kt
@@ -11,6 +11,7 @@ import arcs.core.data.SchemaName
 import arcs.core.data.Ttl
 import arcs.core.data.util.ReferencablePrimitive
 import arcs.core.data.util.toReferencable
+import arcs.core.util.Time
 import arcs.core.host.EntityHandleManager
 import arcs.core.storage.DriverFactory
 import arcs.core.storage.Reference
@@ -44,8 +45,15 @@ open class HandleManagerTestBase {
     ) : Entity {
 
         var raw: RawEntity? = null
+        var creationTimestamp : Long = RawEntity.UNINITIALIZED_TIMESTAMP
+        var expirationTimestamp : Long = RawEntity.UNINITIALIZED_TIMESTAMP
 
-        override fun ensureIdentified(idGenerator: Generator, handleName: String) {}
+        override fun ensureIdentified(idGenerator: Generator, handleName: String, time: Time, ttl: Ttl) {
+            creationTimestamp = requireNotNull(time).currentTimeMillis
+            if (ttl != Ttl.Infinite) {
+                expirationTimestamp = ttl.calculateExpiration(time)
+            }
+        }
 
         override fun serialize() = RawEntity(
             entityId,
@@ -56,7 +64,9 @@ open class HandleManagerTestBase {
                 "best_friend" to bestFriend,
                 "hat" to hat
             ),
-            collections = emptyMap()
+            collections = emptyMap(),
+            creationTimestamp = creationTimestamp,
+            expirationTimestamp = expirationTimestamp
         )
 
         override fun reset() = throw NotImplementedError()
@@ -123,7 +133,7 @@ open class HandleManagerTestBase {
         override val entityId: ReferenceId,
         val style: String
     ) : Entity {
-        override fun ensureIdentified(idGenerator: Generator, handleName: String) {}
+        override fun ensureIdentified(idGenerator: Generator, handleName: String, time: Time, ttl: Ttl) {}
 
         override fun serialize() = RawEntity(
             entityId,

--- a/javatests/arcs/core/entity/HandleManagerTestBase.kt
+++ b/javatests/arcs/core/entity/HandleManagerTestBase.kt
@@ -48,7 +48,7 @@ open class HandleManagerTestBase {
         var creationTimestamp : Long = RawEntity.UNINITIALIZED_TIMESTAMP
         var expirationTimestamp : Long = RawEntity.UNINITIALIZED_TIMESTAMP
 
-        override fun ensureIdentified(idGenerator: Generator, handleName: String, time: Time, ttl: Ttl) {
+        override fun ensureEntityFields(idGenerator: Generator, handleName: String, time: Time, ttl: Ttl) {
             creationTimestamp = requireNotNull(time).currentTimeMillis
             if (ttl != Ttl.Infinite) {
                 expirationTimestamp = ttl.calculateExpiration(time)
@@ -133,7 +133,7 @@ open class HandleManagerTestBase {
         override val entityId: ReferenceId,
         val style: String
     ) : Entity {
-        override fun ensureIdentified(idGenerator: Generator, handleName: String, time: Time, ttl: Ttl) {}
+        override fun ensureEntityFields(idGenerator: Generator, handleName: String, time: Time, ttl: Ttl) {}
 
         override fun serialize() = RawEntity(
             entityId,

--- a/javatests/arcs/core/host/HandleAdapterTest.kt
+++ b/javatests/arcs/core/host/HandleAdapterTest.kt
@@ -103,7 +103,7 @@ class HandleAdapterTest {
             "Entity must have an ID before it can be referenced."
         )
 
-        entity.ensureIdentified(idGenerator, READ_WRITE_HANDLE)
+        entity.ensureIdentified(idGenerator, READ_WRITE_HANDLE, TimeImpl())
 
         // Fails when the entity is not in the collection.
         e = assertSuspendingThrows(IllegalArgumentException::class) {
@@ -205,7 +205,7 @@ class HandleAdapterTest {
             "Entity must have an ID before it can be referenced."
         )
 
-        entity.ensureIdentified(idGenerator, READ_WRITE_HANDLE)
+        entity.ensureIdentified(idGenerator, READ_WRITE_HANDLE, TimeImpl())
 
         // Fails when the entity is not in the collection.
         e = assertSuspendingThrows(IllegalArgumentException::class) {

--- a/javatests/arcs/core/host/HandleAdapterTest.kt
+++ b/javatests/arcs/core/host/HandleAdapterTest.kt
@@ -103,7 +103,7 @@ class HandleAdapterTest {
             "Entity must have an ID before it can be referenced."
         )
 
-        entity.ensureIdentified(idGenerator, READ_WRITE_HANDLE, TimeImpl())
+        entity.ensureEntityFields(idGenerator, READ_WRITE_HANDLE, TimeImpl())
 
         // Fails when the entity is not in the collection.
         e = assertSuspendingThrows(IllegalArgumentException::class) {
@@ -205,7 +205,7 @@ class HandleAdapterTest {
             "Entity must have an ID before it can be referenced."
         )
 
-        entity.ensureIdentified(idGenerator, READ_WRITE_HANDLE, TimeImpl())
+        entity.ensureEntityFields(idGenerator, READ_WRITE_HANDLE, TimeImpl())
 
         // Fails when the entity is not in the collection.
         e = assertSuspendingThrows(IllegalArgumentException::class) {

--- a/javatests/arcs/sdk/spec/BUILD
+++ b/javatests/arcs/sdk/spec/BUILD
@@ -16,6 +16,7 @@ arcs_kt_jvm_test_suite(
         ":schemas",
         ":schemas_test_harness",
         "//java/arcs/core/common",
+        "//java/arcs/jvm/util/testutil",
         "//java/arcs/sdk",
         "//third_party/java/junit:junit-android",
         "//third_party/java/truth:truth-android",

--- a/javatests/arcs/sdk/spec/EntitySpecTest.kt
+++ b/javatests/arcs/sdk/spec/EntitySpecTest.kt
@@ -78,11 +78,11 @@ class EntitySpecTest {
     }
 
     @Test
-    fun ensureIdentified() {
+    fun ensureEntityFields() {
         val entity = Foo()
         assertThat(entity.entityId).isNull()
 
-        entity.ensureIdentified(idGenerator, "handle", TimeImpl(currentTime))
+        entity.ensureEntityFields(idGenerator, "handle", TimeImpl(currentTime))
         val entityId = entity.entityId
 
         // Check that the entity ID has been set to *something*.
@@ -95,7 +95,7 @@ class EntitySpecTest {
         assertThat(creationTimestamp).isEqualTo(currentTime)
 
         // Calling it again doesn't overwrite id and timestamp.
-        entity.ensureIdentified(idGenerator, "something-else", TimeImpl(currentTime+10))
+        entity.ensureEntityFields(idGenerator, "something-else", TimeImpl(currentTime+10))
         assertThat(entity.entityId).isEqualTo(entityId)
         assertThat(entity.serialize().creationTimestamp).isEqualTo(creationTimestamp)
     }
@@ -104,7 +104,7 @@ class EntitySpecTest {
     fun expiryTimestamp() {
         val entity = Foo()
         
-        entity.ensureIdentified(idGenerator, "handle", TimeImpl(currentTime), Ttl.Minutes(1))
+        entity.ensureEntityFields(idGenerator, "handle", TimeImpl(currentTime), Ttl.Minutes(1))
         
         val expirationTimestamp = entity.serialize().expirationTimestamp
         assertThat(expirationTimestamp).isEqualTo(currentTime + 60000) // 1 minute = 60'000 milliseconds
@@ -217,7 +217,7 @@ class EntitySpecTest {
     /** Generates and returns an ID for the entity. */
     private fun (Foo).identify(): String {
         assertThat(entityId).isNull()
-        ensureIdentified(idGenerator, "handleName", TimeImpl(currentTime))
+        ensureEntityFields(idGenerator, "handleName", TimeImpl(currentTime))
         assertThat(entityId).isNotNull()
         return entityId!!
     }


### PR DESCRIPTION
…or of RawEntity, so that they cannot be changed later, and have them set at the same time the id is created. This avoids problems when the same entity is stored in two handles (potentially with different ttl), now timestamps are set the first time the entity is stored. This makes it possible to remove merging behavior for creation timestamp in the crdt entity, instead throwing an exception.