### PR TITLE
Refactor handle creation methods

### DIFF
--- a/java/arcs/android/demo/DemoActivity.kt
+++ b/java/arcs/android/demo/DemoActivity.kt
@@ -23,10 +23,12 @@ import arcs.sdk.android.storage.ServiceStoreFactory
 import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 
 /** Entry UI to launch Arcs demo. */
+@OptIn(ExperimentalCoroutinesApi::class)
 class DemoActivity : AppCompatActivity() {
 
     private val coroutineContext: CoroutineContext = Job() + Dispatchers.Main

--- a/java/arcs/core/entity/BaseHandle.kt
+++ b/java/arcs/core/entity/BaseHandle.kt
@@ -13,23 +13,14 @@ package arcs.core.entity
 import arcs.core.storage.StorageProxy
 
 /** Base functionality common to all read/write singleton and collection handles. */
-abstract class BaseHandle(
+abstract class BaseHandle<T : Entity>(
     override val name: String,
+    protected val spec: HandleSpec<T>,
     private val storageProxy: StorageProxy<*, *, *>
 ) : Handle {
-    protected var closed = false
-
     override suspend fun onSync(action: () -> Unit) = storageProxy.addOnSync(name, action)
 
     override suspend fun onDesync(action: () -> Unit) = storageProxy.addOnDesync(name, action)
 
-    protected inline fun <T> checkPreconditions(block: () -> T): T {
-        check(!closed) { "Handle $name is closed" }
-        return block()
-    }
-
-    override suspend fun close() {
-        closed = true
-        storageProxy.removeCallbacksForName(name)
-    }
+    override suspend fun close() = storageProxy.removeCallbacksForName(name)
 }

--- a/java/arcs/core/entity/BaseHandle.kt
+++ b/java/arcs/core/entity/BaseHandle.kt
@@ -18,9 +18,19 @@ abstract class BaseHandle<T : Entity>(
     protected val spec: HandleSpec<T>,
     private val storageProxy: StorageProxy<*, *, *>
 ) : Handle {
+    protected var closed = false
+
     override suspend fun onSync(action: () -> Unit) = storageProxy.addOnSync(name, action)
 
     override suspend fun onDesync(action: () -> Unit) = storageProxy.addOnDesync(name, action)
 
-    override suspend fun close() = storageProxy.removeCallbacksForName(name)
+    protected inline fun <T> checkPreconditions(block: () -> T): T {
+        check(!closed) { "Handle $name is closed" }
+        return block()
+    }
+
+    override suspend fun close() {
+        closed = true
+        storageProxy.removeCallbacksForName(name)
+    }
 }

--- a/java/arcs/core/entity/Handle.kt
+++ b/java/arcs/core/entity/Handle.kt
@@ -11,6 +11,8 @@
 
 package arcs.core.entity
 
+import arcs.core.data.HandleMode
+
 /** Base interface for all handle classes. */
 interface Handle {
     val name: String
@@ -23,6 +25,20 @@ interface Handle {
 
     /** Release resources needed by this, unregister all callbacks. */
     suspend fun close()
+}
+
+data class HandleSpec<T : Entity>(
+    val baseName: String,
+    val mode: HandleMode,
+    val containerType: HandleContainerType,
+    val entitySpec: EntitySpec<T>
+)
+
+typealias HandleMode = HandleMode
+
+enum class HandleContainerType {
+    Singleton,
+    Collection
 }
 
 interface ReadableHandle<UpdateType, E : Entity> : Handle {

--- a/java/arcs/core/host/EntityHandleManager.kt
+++ b/java/arcs/core/host/EntityHandleManager.kt
@@ -28,6 +28,8 @@ import arcs.core.entity.EntityDereferencerFactory
 import arcs.core.entity.EntityPreparer
 import arcs.core.entity.EntitySpec
 import arcs.core.entity.Handle
+import arcs.core.entity.HandleContainerType
+import arcs.core.entity.HandleSpec
 import arcs.core.entity.ReadCollectionHandle
 import arcs.core.entity.ReadQueryCollectionHandle
 import arcs.core.entity.ReadSingletonHandle
@@ -61,85 +63,68 @@ class EntityHandleManager(
     private val hostId: String = "nohost",
     private val time: Time,
     private val stores: StoreManager = StoreManager(),
-    private val activationFactory: ActivationFactory? = null
+    private val activationFactory: ActivationFactory? = null,
+    private val idGenerator: Id.Generator = Id.Generator.newSession()
 ) {
     private val singletonStorageProxies = mutableMapOf<StorageKey, SingletonProxy<RawEntity>>()
     private val collectionStorageProxies = mutableMapOf<StorageKey, CollectionProxy<RawEntity>>()
     private val dereferencerFactory = EntityDereferencerFactory(stores, activationFactory)
 
-    /**
-     * Creates and returns a new singleton handle for managing an [Entity].
-     *
-     * @property mode indicates whether the handle is allowed to read or write
-     * @property baseName part of the name for the handle
-     * @property idGenerator used to generate unique IDs for newly stored entities.
-     */
-    suspend fun <T : Entity> createSingletonHandle(
-        mode: HandleMode,
-        baseName: String,
-        entitySpec: EntitySpec<T>,
+    suspend fun <T : Entity> createHandle(
+        spec: HandleSpec<T>,
         storageKey: StorageKey,
-        ttl: Ttl = Ttl.Infinite,
-        idGenerator: Id.Generator = Id.Generator.newSession()
-    ): Handle =
-        idGenerator.handleName(baseName).let { name ->
-            SingletonHandle(
-                name = idGenerator.handleName(baseName),
-                entitySpec = entitySpec,
-                storageProxy = singletonStoreProxy(storageKey, entitySpec),
-                entityPreparer = EntityPreparer(name, idGenerator, entitySpec.SCHEMA, ttl, time),
-                dereferencerFactory = dereferencerFactory
-            )
-        }.let { handle ->
-            return when (mode) {
-                HandleMode.Read -> object : ReadSingletonHandle<T> by handle {}
-                HandleMode.Write -> object : WriteSingletonHandle<T> by handle {}
-                HandleMode.ReadWrite -> object : ReadWriteSingletonHandle<T> by handle {}
-            }
-        }
-
-    /**
-     * Creates and returns a new collection handle for a set of [Entity]s.
-     *
-     * @property mode indicates whether the handle is allowed to read or write
-     * @property baseName part of the name for the handle
-     * @property storageKey a [StorageKey]
-     * @property idGenerator used to generate unique IDs for newly stored entities.
-     */
-    suspend fun <T : Entity> createCollectionHandle(
-        mode: HandleMode,
-        baseName: String,
-        entitySpec: EntitySpec<T>,
-        storageKey: StorageKey,
-        ttl: Ttl = Ttl.Infinite,
-        idGenerator: Id.Generator = Id.Generator.newSession()
-    ): Handle =
-        idGenerator.handleName(baseName).let { name ->
-            CollectionHandle(
-                name = idGenerator.handleName(baseName),
-                entitySpec = entitySpec,
-                storageProxy = collectionStoreProxy(storageKey, entitySpec),
-                entityPreparer = EntityPreparer(name, idGenerator, entitySpec.SCHEMA, ttl, time),
-                dereferencerFactory = dereferencerFactory
-            )
-        }.let {
-            when (mode) {
-                HandleMode.Read -> when (entitySpec.SCHEMA.query) {
-                    null -> object : ReadCollectionHandle<T> by it {}
-                    else -> object : ReadQueryCollectionHandle<T, Any> by it {}
+        ttl: Ttl = Ttl.Infinite
+    ): Handle {
+        val handleName = idGenerator.newChildId(
+            idGenerator.newChildId(arcId.toArcId(), hostId),
+            spec.baseName
+        ).toString()
+        val entityPreparer = EntityPreparer<T>(
+            handleName,
+            idGenerator,
+            spec.entitySpec.SCHEMA,
+            ttl,
+            time
+        )
+        return when (spec.containerType) {
+            HandleContainerType.Singleton -> {
+                val singletonHandle = SingletonHandle(
+                    name = handleName,
+                    spec = spec,
+                    storageProxy = singletonStoreProxy(storageKey, spec.entitySpec),
+                    entityPreparer = entityPreparer,
+                    dereferencerFactory = dereferencerFactory
+                )
+                when (spec.mode) {
+                    HandleMode.Read -> object : ReadSingletonHandle<T> by singletonHandle {}
+                    HandleMode.Write -> object : WriteSingletonHandle<T> by singletonHandle {}
+                    HandleMode.ReadWrite ->
+                        object : ReadWriteSingletonHandle<T> by singletonHandle {}
                 }
-                HandleMode.Write -> object : WriteCollectionHandle<T> by it {}
-                HandleMode.ReadWrite -> when (entitySpec.SCHEMA.query) {
-                    null -> object : ReadWriteCollectionHandle<T> by it {}
-                    else -> object : ReadWriteQueryCollectionHandle<T, Any> by it {}
+            }
+            HandleContainerType.Collection -> {
+                val collectionHandle = CollectionHandle(
+                    name = handleName,
+                    spec = spec,
+                    storageProxy = collectionStoreProxy(storageKey, spec.entitySpec),
+                    entityPreparer = entityPreparer,
+                    dereferencerFactory = dereferencerFactory
+                )
+                when (spec.mode) {
+                    HandleMode.Read -> when (spec.entitySpec.SCHEMA.query) {
+                        null -> object : ReadCollectionHandle<T> by collectionHandle {}
+                        else -> object : ReadQueryCollectionHandle<T, Any> by collectionHandle {}
+                    }
+                    HandleMode.Write -> object : WriteCollectionHandle<T> by collectionHandle {}
+                    HandleMode.ReadWrite -> when (spec.entitySpec.SCHEMA.query) {
+                        null -> object : ReadWriteCollectionHandle<T> by collectionHandle {}
+                        else -> object : ReadWriteQueryCollectionHandle<T, Any> by
+                            collectionHandle {}
+                    }
                 }
             }
         }
-
-    private fun Id.Generator.handleName(baseName: String) = newChildId(
-        newChildId(arcId.toArcId(), hostId),
-        baseName
-    ).toString()
+    }
 
     private suspend fun <T : Entity> singletonStoreProxy(
         storageKey: StorageKey,

--- a/javatests/arcs/android/host/AndroidEntityHandleManagerTest.kt
+++ b/javatests/arcs/android/host/AndroidEntityHandleManagerTest.kt
@@ -13,6 +13,8 @@ import arcs.core.data.SchemaFields
 import arcs.core.data.SchemaName
 import arcs.core.host.EntityHandleManager
 import arcs.core.data.HandleMode
+import arcs.core.entity.HandleContainerType
+import arcs.core.entity.HandleSpec
 import arcs.core.entity.ReadCollectionHandle
 import arcs.core.entity.ReadSingletonHandle
 import arcs.core.entity.ReadWriteCollectionHandle
@@ -291,10 +293,13 @@ class AndroidEntityHandleManagerTest : LifecycleOwner {
         handleManager: EntityHandleManager,
         handleName: String,
         handleMode: HandleMode
-    ) = handleManager.createSingletonHandle(
-        handleMode,
-        handleName,
-        handleHolder.getEntitySpec(handleName),
+    ) = handleManager.createHandle(
+        HandleSpec(
+            handleName,
+            handleMode,
+            HandleContainerType.Singleton,
+            handleHolder.getEntitySpec(handleName)
+        ),
         singletonKey
     ).also { handleHolder.setHandle(handleName, it) }
 
@@ -302,10 +307,13 @@ class AndroidEntityHandleManagerTest : LifecycleOwner {
         handleManager: EntityHandleManager,
         handleName: String,
         handleMode: HandleMode
-    ) = handleManager.createCollectionHandle(
-        handleMode,
-        handleName,
-        handleHolder.getEntitySpec(handleName),
+    ) = handleManager.createHandle(
+        HandleSpec(
+            handleName,
+            handleMode,
+            HandleContainerType.Collection,
+            handleHolder.getEntitySpec(handleName)
+        ),
         collectionKey
     ).also { handleHolder.setHandle(handleName, it) }
 }

--- a/javatests/arcs/core/entity/HandleManagerTestBase.kt
+++ b/javatests/arcs/core/entity/HandleManagerTestBase.kt
@@ -362,10 +362,13 @@ open class HandleManagerTestBase {
     @Test
     fun singleton_dereferenceEntity_nestedReference() = testRunner {
         // Create a stylish new hat, and create a reference to it.
-        val hatCollection = writeHandleManager.createCollectionHandle(
-            HandleMode.ReadWrite,
-            "hatCollection",
-            Hat,
+        val hatCollection = writeHandleManager.createHandle(
+            HandleSpec(
+                "hatCollection",
+                HandleMode.ReadWrite,
+                HandleContainerType.Collection,
+                Hat
+            ),
             hatCollectionKey
         ) as ReadWriteCollectionHandle<Hat>
         val fez = Hat(entityId = "fez-id", style = "fez")
@@ -584,10 +587,13 @@ open class HandleManagerTestBase {
     @Test
     fun collection_dereferenceEntity_nestedReference() = testRunner {
         // Create a stylish new hat, and create a reference to it.
-        val hatCollection = writeHandleManager.createCollectionHandle(
-            HandleMode.ReadWrite,
-            "hatCollection",
-            Hat,
+        val hatCollection = writeHandleManager.createHandle(
+            HandleSpec(
+                "hatCollection",
+                HandleMode.ReadWrite,
+                HandleContainerType.Collection,
+                Hat
+            ),
             hatCollectionKey
         ) as ReadWriteCollectionHandle<Hat>
         val fez = Hat(entityId = "fez-id", style = "fez")
@@ -707,10 +713,13 @@ open class HandleManagerTestBase {
         storageKey: StorageKey = singletonKey,
         name: String = "singletonWriteHandle",
         ttl: Ttl = Ttl.Infinite
-    ) = writeHandleManager.createSingletonHandle(
-        HandleMode.ReadWrite,
-        name,
-        Person,
+    ) = readHandleManager.createHandle(
+        HandleSpec(
+            name,
+            HandleMode.ReadWrite,
+            HandleContainerType.Singleton,
+            Person
+        ),
         storageKey,
         ttl
     ) as ReadWriteSingletonHandle<Person>
@@ -719,10 +728,13 @@ open class HandleManagerTestBase {
         storageKey: StorageKey = collectionKey,
         name: String = "collectionRefReadHandle",
         ttl: Ttl = Ttl.Infinite
-    ) = readHandleManager.createCollectionHandle(
-        HandleMode.ReadWrite,
-        name,
-        Person,
+    ) = readHandleManager.createHandle(
+        HandleSpec(
+            name,
+            HandleMode.ReadWrite,
+            HandleContainerType.Collection,
+            Person
+        ),
         storageKey,
         ttl
     ) as ReadWriteQueryCollectionHandle<Person, Any>

--- a/javatests/arcs/core/entity/ReferenceTest.kt
+++ b/javatests/arcs/core/entity/ReferenceTest.kt
@@ -44,10 +44,13 @@ class ReferenceTest {
         DriverAndKeyConfigurator.configure(null)
         SchemaRegistry.register(DummyEntity)
 
-        handle = entityHandleManager.createCollectionHandle(
-            HandleMode.ReadWrite,
-            "testHandle",
-            DummyEntity,
+        handle = entityHandleManager.createHandle(
+            HandleSpec(
+                "testHandle",
+                HandleMode.ReadWrite,
+                HandleContainerType.Collection,
+                DummyEntity
+            ),
             STORAGE_KEY
         ) as ReadWriteCollectionHandle<DummyEntity>
     }

--- a/javatests/arcs/core/host/HandleAdapterTest.kt
+++ b/javatests/arcs/core/host/HandleAdapterTest.kt
@@ -12,6 +12,8 @@
 package arcs.core.host
 
 import arcs.core.common.Id
+import arcs.core.entity.HandleContainerType
+import arcs.core.entity.HandleSpec
 import arcs.core.entity.ReadCollectionHandle
 import arcs.core.entity.ReadSingletonHandle
 import arcs.core.entity.ReadWriteCollectionHandle
@@ -62,10 +64,13 @@ class HandleAdapterTest {
 
     @Test
     fun singletonHandleAdapter_readOnlyCantWrite() = runBlockingTest {
-        val readOnlyHandle = manager.createSingletonHandle(
-            HandleMode.Read,
-            READ_ONLY_HANDLE,
-            Person,
+        val readOnlyHandle = manager.createHandle(
+            HandleSpec(
+                READ_ONLY_HANDLE,
+                HandleMode.Read,
+                HandleContainerType.Singleton,
+                Person
+            ),
             STORAGE_KEY
         )
 
@@ -76,10 +81,13 @@ class HandleAdapterTest {
 
     @Test
     fun singletonHandleAdapter_writeOnlyCantRead() = runBlockingTest {
-        val writeOnlyHandle = manager.createSingletonHandle(
-            HandleMode.Write,
-            WRITE_ONLY_HANDLE,
-            Person,
+        val writeOnlyHandle = manager.createHandle(
+            HandleSpec(
+                WRITE_ONLY_HANDLE,
+                HandleMode.Write,
+                HandleContainerType.Singleton,
+                Person
+            ),
             STORAGE_KEY
         )
         assertThat(writeOnlyHandle).isInstanceOf(WriteSingletonHandle::class.java)
@@ -89,10 +97,13 @@ class HandleAdapterTest {
 
     @Test
     fun singletonHandleAdapter_createReference() = runBlocking {
-        val handle = manager.createSingletonHandle(
-            HandleMode.ReadWrite,
-            READ_WRITE_HANDLE,
-            Person,
+        val handle = manager.createHandle(
+            HandleSpec(
+                READ_WRITE_HANDLE,
+                HandleMode.ReadWrite,
+                HandleContainerType.Singleton,
+                Person
+            ),
             STORAGE_KEY
         ) as ReadWriteSingletonHandle<Person>
         val entity = Person("Watson")
@@ -140,10 +151,13 @@ class HandleAdapterTest {
 
     @Test
     fun collectionHandleAdapter_readOnlyCantWrite() = runBlockingTest {
-        val readOnlyHandle = manager.createCollectionHandle(
-            HandleMode.Read,
-            READ_ONLY_HANDLE,
-            Person,
+        val readOnlyHandle = manager.createHandle(
+            HandleSpec(
+                READ_ONLY_HANDLE,
+                HandleMode.Read,
+                HandleContainerType.Collection,
+                Person
+            ),
             STORAGE_KEY
         )
 
@@ -154,10 +168,13 @@ class HandleAdapterTest {
 
     @Test
     fun collectionHandleAdapter_writeOnlyCantRead() = runBlockingTest {
-        val writeOnlyHandle = manager.createCollectionHandle(
-            HandleMode.Write,
-            WRITE_ONLY_HANDLE,
-            Person,
+        val writeOnlyHandle = manager.createHandle(
+            HandleSpec(
+                WRITE_ONLY_HANDLE,
+                HandleMode.Write,
+                HandleContainerType.Collection,
+                Person
+            ),
             STORAGE_KEY
         )
 
@@ -168,10 +185,13 @@ class HandleAdapterTest {
 
     @Test
     fun singletonHandleAdapter_onUpdateTest() = runBlockingTest {
-        val handle = manager.createSingletonHandle(
-            HandleMode.ReadWrite,
-            READ_WRITE_HANDLE,
-            Person,
+        val handle = manager.createHandle(
+            HandleSpec(
+                READ_WRITE_HANDLE,
+                HandleMode.ReadWrite,
+                HandleContainerType.Singleton,
+                Person
+            ),
             STORAGE_KEY
         ) as ReadWriteSingletonHandle<Person>
 
@@ -187,10 +207,13 @@ class HandleAdapterTest {
 
     @Test
     fun collectionHandleAdapter_onUpdateTest() = runBlockingTest {
-        val handle = manager.createCollectionHandle(
-            HandleMode.ReadWrite,
-            READ_WRITE_HANDLE,
-            Person,
+        val handle = manager.createHandle(
+            HandleSpec(
+                READ_WRITE_HANDLE,
+                HandleMode.ReadWrite,
+                HandleContainerType.Collection,
+                Person
+            ),
             STORAGE_KEY
         ) as ReadWriteCollectionHandle<Person>
 
@@ -206,10 +229,13 @@ class HandleAdapterTest {
 
     @Test
     fun collectionHandleAdapter_createReference() = runBlocking {
-        val handle = manager.createCollectionHandle(
-            HandleMode.ReadWrite,
-            READ_WRITE_HANDLE,
-            Person,
+        val handle = manager.createHandle(
+            HandleSpec(
+                READ_WRITE_HANDLE,
+                HandleMode.ReadWrite,
+                HandleContainerType.Collection,
+                Person
+            ),
             STORAGE_KEY
         ) as ReadWriteCollectionHandle<Person>
         val entity = Person("Watson")

--- a/javatests/arcs/core/host/HandleAdapterTest.kt
+++ b/javatests/arcs/core/host/HandleAdapterTest.kt
@@ -136,10 +136,13 @@ class HandleAdapterTest {
 
     @Test
     fun singleton_noOpsAfterClose() = runBlockingTest {
-       val handle = manager.createSingletonHandle(
-           HandleMode.ReadWrite,
-           READ_WRITE_HANDLE,
-           Person,
+       val handle = manager.createHandle(
+           HandleSpec(
+               READ_WRITE_HANDLE,
+               HandleMode.ReadWrite,
+               HandleContainerType.Singleton,
+               Person
+           ),
            STORAGE_KEY
        ) as ReadWriteSingletonHandle<Person>
         handle.store(Person("test"))
@@ -268,10 +271,13 @@ class HandleAdapterTest {
 
     @Test
     fun collection_noOpsAfterClose() = runBlockingTest {
-        val handle = manager.createCollectionHandle(
-            HandleMode.ReadWrite,
-            READ_WRITE_HANDLE,
-            QueryPerson,
+        val handle = manager.createHandle(
+            HandleSpec(
+                READ_WRITE_HANDLE,
+                HandleMode.ReadWrite,
+                HandleContainerType.Collection,
+                QueryPerson
+            ),
             STORAGE_KEY
         ) as ReadWriteQueryCollectionHandle<Person, Any>
         val testPerson = Person("test")

--- a/javatests/arcs/sdk/BUILD
+++ b/javatests/arcs/sdk/BUILD
@@ -20,6 +20,7 @@ arcs_kt_jvm_test_suite(
         "//java/arcs/core/common",
         "//java/arcs/core/entity",
         "//java/arcs/core/host",
+        "//java/arcs/core/storage:storage_key",
         "//java/arcs/core/storage/driver",
         "//java/arcs/core/storage/keys",
         "//java/arcs/core/storage/referencemode",

--- a/javatests/arcs/sdk/HandleUtilsTest.kt
+++ b/javatests/arcs/sdk/HandleUtilsTest.kt
@@ -11,10 +11,13 @@
 
 package arcs.sdk
 
+import arcs.core.entity.HandleContainerType
+import arcs.core.entity.HandleSpec
 import arcs.core.entity.ReadWriteCollectionHandle
 import arcs.core.entity.ReadWriteSingletonHandle
 import arcs.core.host.EntityHandleManager
 import arcs.core.host.HandleMode
+import arcs.core.storage.StorageKey
 import arcs.core.storage.driver.RamDisk
 import arcs.core.storage.driver.RamDiskDriverProvider
 import arcs.core.storage.keys.RamDiskStorageKey
@@ -35,407 +38,321 @@ private typealias Person = ReadSdkPerson_Person
 @OptIn(ExperimentalCoroutinesApi::class)
 @Suppress("UNCHECKED_CAST", "UNUSED_PARAMETER")
 class HandleUtilsTest {
-  private lateinit var manager: EntityHandleManager
+    private lateinit var manager: EntityHandleManager
 
-  @Before
-  fun setUp() {
-    RamDiskDriverProvider()
-    ReferenceModeStorageKey.registerParser()
-      manager = EntityHandleManager(
-          "testArc",
-          "testHost",
-          TimeImpl()
-      )
-  }
-
-  @After
-  fun tearDown() {
-    RamDisk.clear()
-  }
-
-  @Test
-  fun handleUtils_combineTwoUpdatesTest() = runBlockingTest {
-    val collection = manager.createCollectionHandle(
-      HandleMode.ReadWrite,
-      READ_WRITE_HANDLE,
-      Person,
-      STORAGE_KEY_ONE
-    ) as ReadWriteCollectionHandle<Person>
-
-    val singleton = manager.createSingletonHandle(
-      HandleMode.ReadWrite,
-      READ_WRITE_HANDLE,
-      Person,
-      STORAGE_KEY_TWO
-    ) as ReadWriteSingletonHandle<Person>
-
-    var x = 0
-    var y = 0
-    combineUpdates(collection, singleton) { people, e2 ->
-      if (people.elementAtOrNull(0)?.name == "George") {
-        x += 1
-      }
-      if (e2?.name == "Martha") {
-        y += 1
-      }
-    }
-    collection.store(Person("George"))
-    assertWithMessage("Expected Collection to include George").that(x).isEqualTo(1)
-    assertWithMessage("Expected Singleton to not Equal Martha").that(y).isEqualTo(0)
-    singleton.store(Person("Martha"))
-    assertWithMessage("Expected Collection to include George").that(x).isEqualTo(2)
-    assertWithMessage("Expected Singleton to include Martha").that(y).isEqualTo(1)
-  }
-
-  @Test
-  fun handleUtils_combineThreeUpdatesTest() = runBlockingTest {
-    val handle1 = manager.createCollectionHandle(
-      HandleMode.ReadWrite,
-      READ_WRITE_HANDLE,
-      Person,
-      STORAGE_KEY_ONE
-    ) as ReadWriteCollectionHandle<Person>
-
-    val handle2 = manager.createSingletonHandle(
-      HandleMode.ReadWrite,
-      READ_WRITE_HANDLE,
-      Person,
-      STORAGE_KEY_TWO
-    ) as ReadWriteSingletonHandle<Person>
-
-    val handle3 = manager.createCollectionHandle(
-      HandleMode.ReadWrite,
-      READ_WRITE_HANDLE,
-      Person,
-      STORAGE_KEY_THREE
-    ) as ReadWriteCollectionHandle<Person>
-
-    var handle1Tracking = 0
-    var handle2Tracking = 0
-    var handle3Tracking = 0
-    combineUpdates(handle1, handle2, handle3) { e1, e2, e3 ->
-      if (e1.elementAtOrNull(0)?.name == "A") {
-        handle1Tracking += 1
-      }
-      if (e2?.name == "B") {
-        handle2Tracking += 1
-      }
-      if (e3.elementAtOrNull(0)?.name == "C") {
-        handle3Tracking += 1
-      }
-    }
-    handle1.store(Person("A"))
-    assertWithMessage("Expected handle1 to include A").that(handle1Tracking).isEqualTo(1)
-    assertWithMessage("Expected handle2 to not equal B").that(handle2Tracking).isEqualTo(0)
-    assertWithMessage("Expected handle3 to not include C").that(handle3Tracking).isEqualTo(0)
-    handle2.store(Person("B"))
-    assertWithMessage("Expected handle1 to include A").that(handle1Tracking).isEqualTo(2)
-    assertWithMessage("Expected handle2 to equal B").that(handle2Tracking).isEqualTo(1)
-    assertWithMessage("Expected handle3 to not include C").that(handle3Tracking).isEqualTo(0)
-    handle3.store(Person("C"))
-    assertWithMessage("Expected handle1 to include A").that(handle1Tracking).isEqualTo(3)
-    assertWithMessage("Expected handle2 to equal B").that(handle2Tracking).isEqualTo(2)
-    assertWithMessage("Expected handle3 to include C").that(handle3Tracking).isEqualTo(1)
-  }
-
-  @Test
-  fun handleUtils_combineFourUpdatesTest() = runBlockingTest {
-    val handle1 = manager.createCollectionHandle(
-      HandleMode.ReadWrite,
-      READ_WRITE_HANDLE,
-      Person,
-      STORAGE_KEY_ONE
-    ) as ReadWriteCollectionHandle<Person>
-
-    val handle2 = manager.createSingletonHandle(
-      HandleMode.ReadWrite,
-      READ_WRITE_HANDLE,
-      Person,
-      STORAGE_KEY_TWO
-    ) as ReadWriteSingletonHandle<Person>
-
-    val handle3 = manager.createCollectionHandle(
-      HandleMode.ReadWrite,
-      READ_WRITE_HANDLE,
-      Person,
-      STORAGE_KEY_THREE
-    ) as ReadWriteCollectionHandle<Person>
-
-    val handle4 = manager.createSingletonHandle(
-      HandleMode.ReadWrite,
-      READ_WRITE_HANDLE,
-      Person,
-      STORAGE_KEY_FOUR
-    ) as ReadWriteSingletonHandle<Person>
-
-    var handle1Tracking = 0
-    var handle2Tracking = 0
-    var handle3Tracking = 0
-    var handle4Tracking = 0
-
-    combineUpdates(handle1, handle2, handle3, handle4) { e1, e2, e3, e4 ->
-      if (e1.elementAtOrNull(0)?.name == "A") {
-        handle1Tracking += 1
-      }
-      if (e2?.name == "B") {
-        handle2Tracking += 1
-      }
-      if (e3.elementAtOrNull(0)?.name == "C") {
-        handle3Tracking += 1
-      }
-      if (e4?.name == "D") {
-        handle4Tracking += 1
-      }
-    }
-    handle1.store(Person("A"))
-    assertWithMessage("Expected handle1 to include A").that(handle1Tracking).isEqualTo(1)
-    assertWithMessage("Expected handle2 to not equal B").that(handle2Tracking).isEqualTo(0)
-    assertWithMessage("Expected handle3 to not include C").that(handle3Tracking).isEqualTo(0)
-    assertWithMessage("Expected handle4 to not equal D").that(handle4Tracking).isEqualTo(0)
-
-    handle2.store(Person("B"))
-    assertWithMessage("Expected handle1 to include A").that(handle1Tracking).isEqualTo(2)
-    assertWithMessage("Expected handle2 to equal B").that(handle2Tracking).isEqualTo(1)
-    assertWithMessage("Expected handle3 to not include C").that(handle3Tracking).isEqualTo(0)
-    assertWithMessage("Expected handle4 to not equal D").that(handle4Tracking).isEqualTo(0)
-
-    handle3.store(Person("C"))
-    assertWithMessage("Expected handle1 to include A").that(handle1Tracking).isEqualTo(3)
-    assertWithMessage("Expected handle2 to equal B").that(handle2Tracking).isEqualTo(2)
-    assertWithMessage("Expected handle3 to include C").that(handle3Tracking).isEqualTo(1)
-    assertWithMessage("Expected handle4 to not equal D").that(handle4Tracking).isEqualTo(0)
-
-    handle4.store(Person("D"))
-    assertWithMessage("Expected handle1 to include A").that(handle1Tracking).isEqualTo(4)
-    assertWithMessage("Expected handle2 to equal B").that(handle2Tracking).isEqualTo(3)
-    assertWithMessage("Expected handle3 to include C").that(handle3Tracking).isEqualTo(2)
-    assertWithMessage("Expected handle4 to equal D").that(handle4Tracking).isEqualTo(1)
-  }
-
-  @Test
-  fun handleUtils_combineTenUpdatesTest() = runBlockingTest {
-    val handle1 = manager.createCollectionHandle(
-      HandleMode.ReadWrite,
-      READ_WRITE_HANDLE,
-      Person,
-      STORAGE_KEY_ONE
-    ) as ReadWriteCollectionHandle<Person>
-
-    val handle2 = manager.createSingletonHandle(
-      HandleMode.ReadWrite,
-      READ_WRITE_HANDLE,
-      Person,
-      STORAGE_KEY_TWO
-    ) as ReadWriteSingletonHandle<Person>
-
-    val handle3 = manager.createCollectionHandle(
-      HandleMode.ReadWrite,
-      READ_WRITE_HANDLE,
-      Person,
-      STORAGE_KEY_THREE
-    ) as ReadWriteCollectionHandle<Person>
-
-    val handle4 = manager.createSingletonHandle(
-      HandleMode.ReadWrite,
-      READ_WRITE_HANDLE,
-      Person,
-      STORAGE_KEY_FOUR
-    ) as ReadWriteSingletonHandle<Person>
-
-    val handle5 = manager.createCollectionHandle(
-      HandleMode.ReadWrite,
-      READ_WRITE_HANDLE,
-      Person,
-      STORAGE_KEY_FIVE
-    ) as ReadWriteCollectionHandle<Person>
-
-    val handle6 = manager.createSingletonHandle(
-      HandleMode.ReadWrite,
-      READ_WRITE_HANDLE,
-      Person,
-      STORAGE_KEY_SIX
-    ) as ReadWriteSingletonHandle<Person>
-
-    val handle7 = manager.createCollectionHandle(
-      HandleMode.ReadWrite,
-      READ_WRITE_HANDLE,
-      Person,
-      STORAGE_KEY_SEVEN
-    ) as ReadWriteCollectionHandle<Person>
-
-    val handle8 = manager.createSingletonHandle(
-      HandleMode.ReadWrite,
-      READ_WRITE_HANDLE,
-      Person,
-      STORAGE_KEY_EIGHT
-    ) as ReadWriteSingletonHandle<Person>
-
-    val handle9 = manager.createCollectionHandle(
-      HandleMode.ReadWrite,
-      READ_WRITE_HANDLE,
-      Person,
-      STORAGE_KEY_NINE
-    ) as ReadWriteCollectionHandle<Person>
-
-    val handle10 = manager.createSingletonHandle(
-      HandleMode.ReadWrite,
-      READ_WRITE_HANDLE,
-      Person,
-      STORAGE_KEY_TEN
-    ) as ReadWriteSingletonHandle<Person>
-
-    var tracking5 = 0
-    var tracking6 = 0
-    var tracking7 = 0
-    var tracking8 = 0
-    var tracking9 = 0
-    var tracking10 = 0
-
-    combineUpdates(
-      handle1,
-      handle2,
-      handle3,
-      handle4,
-      handle5
-    ) { _, _, _, _, _ ->
-      tracking5 += 1
+    @Before
+    fun setUp() {
+        RamDiskDriverProvider()
+        ReferenceModeStorageKey.registerParser()
+        manager = EntityHandleManager(
+            "testArc",
+            "testHost",
+            TimeImpl()
+        )
     }
 
-    combineUpdates(
-      handle1,
-      handle2,
-      handle3,
-      handle4,
-      handle5,
-      handle6
-    ) { _, _, _, _, _, _ ->
-      tracking6 += 1
+    @After
+    fun tearDown() {
+        RamDisk.clear()
     }
 
-    combineUpdates(
-      handle1,
-      handle2,
-      handle3,
-      handle4,
-      handle5,
-      handle6,
-      handle7
-    ) { _, _, _, _, _, _, _ ->
-      tracking7 += 1
+    @Test
+    fun handleUtils_combineTwoUpdatesTest() = runBlockingTest {
+        val collection = createCollectionHandle(STORAGE_KEY_ONE)
+        val singleton = createSingletonHandle(STORAGE_KEY_TWO)
+
+        var x = 0
+        var y = 0
+        combineUpdates(collection, singleton) { people, e2 ->
+            if (people.elementAtOrNull(0)?.name == "George") {
+                x += 1
+            }
+            if (e2?.name == "Martha") {
+                y += 1
+            }
+        }
+        collection.store(Person("George"))
+        assertWithMessage("Expected Collection to include George").that(x).isEqualTo(1)
+        assertWithMessage("Expected Singleton to not Equal Martha").that(y).isEqualTo(0)
+        singleton.store(Person("Martha"))
+        assertWithMessage("Expected Collection to include George").that(x).isEqualTo(2)
+        assertWithMessage("Expected Singleton to include Martha").that(y).isEqualTo(1)
     }
 
-    combineUpdates(
-      handle1,
-      handle2,
-      handle3,
-      handle4,
-      handle5,
-      handle6,
-      handle7,
-      handle8
-    ) { _, _, _, _, _, _, _, _ ->
-      tracking8 += 1
+    @Test
+    fun handleUtils_combineThreeUpdatesTest() = runBlockingTest {
+        val handle1 = createCollectionHandle(STORAGE_KEY_ONE)
+        val handle2 = createSingletonHandle(STORAGE_KEY_TWO)
+        val handle3 = createCollectionHandle(STORAGE_KEY_THREE)
+
+        var handle1Tracking = 0
+        var handle2Tracking = 0
+        var handle3Tracking = 0
+        combineUpdates(handle1, handle2, handle3) { e1, e2, e3 ->
+            if (e1.elementAtOrNull(0)?.name == "A") {
+                handle1Tracking += 1
+            }
+            if (e2?.name == "B") {
+                handle2Tracking += 1
+            }
+            if (e3.elementAtOrNull(0)?.name == "C") {
+                handle3Tracking += 1
+            }
+        }
+        handle1.store(Person("A"))
+        assertWithMessage("Expected handle1 to include A").that(handle1Tracking).isEqualTo(1)
+        assertWithMessage("Expected handle2 to not equal B").that(handle2Tracking).isEqualTo(0)
+        assertWithMessage("Expected handle3 to not include C").that(handle3Tracking).isEqualTo(0)
+        handle2.store(Person("B"))
+        assertWithMessage("Expected handle1 to include A").that(handle1Tracking).isEqualTo(2)
+        assertWithMessage("Expected handle2 to equal B").that(handle2Tracking).isEqualTo(1)
+        assertWithMessage("Expected handle3 to not include C").that(handle3Tracking).isEqualTo(0)
+        handle3.store(Person("C"))
+        assertWithMessage("Expected handle1 to include A").that(handle1Tracking).isEqualTo(3)
+        assertWithMessage("Expected handle2 to equal B").that(handle2Tracking).isEqualTo(2)
+        assertWithMessage("Expected handle3 to include C").that(handle3Tracking).isEqualTo(1)
     }
 
-    combineUpdates(
-      handle1,
-      handle2,
-      handle3,
-      handle4,
-      handle5,
-      handle6,
-      handle7,
-      handle8,
-      handle9
-    ) { _, _, _, _, _, _, _, _, _ ->
-      tracking9 += 1
+    @Test
+    fun handleUtils_combineFourUpdatesTest() = runBlockingTest {
+        val handle1 = createCollectionHandle(STORAGE_KEY_ONE)
+        val handle2 = createSingletonHandle(STORAGE_KEY_TWO)
+        val handle3 = createCollectionHandle(STORAGE_KEY_THREE)
+        val handle4 = createSingletonHandle(STORAGE_KEY_FOUR)
+
+        var handle1Tracking = 0
+        var handle2Tracking = 0
+        var handle3Tracking = 0
+        var handle4Tracking = 0
+
+        combineUpdates(handle1, handle2, handle3, handle4) { e1, e2, e3, e4 ->
+            if (e1.elementAtOrNull(0)?.name == "A") {
+                handle1Tracking += 1
+            }
+            if (e2?.name == "B") {
+                handle2Tracking += 1
+            }
+            if (e3.elementAtOrNull(0)?.name == "C") {
+                handle3Tracking += 1
+            }
+            if (e4?.name == "D") {
+                handle4Tracking += 1
+            }
+        }
+        handle1.store(Person("A"))
+        assertWithMessage("Expected handle1 to include A").that(handle1Tracking).isEqualTo(1)
+        assertWithMessage("Expected handle2 to not equal B").that(handle2Tracking).isEqualTo(0)
+        assertWithMessage("Expected handle3 to not include C").that(handle3Tracking).isEqualTo(0)
+        assertWithMessage("Expected handle4 to not equal D").that(handle4Tracking).isEqualTo(0)
+
+        handle2.store(Person("B"))
+        assertWithMessage("Expected handle1 to include A").that(handle1Tracking).isEqualTo(2)
+        assertWithMessage("Expected handle2 to equal B").that(handle2Tracking).isEqualTo(1)
+        assertWithMessage("Expected handle3 to not include C").that(handle3Tracking).isEqualTo(0)
+        assertWithMessage("Expected handle4 to not equal D").that(handle4Tracking).isEqualTo(0)
+
+        handle3.store(Person("C"))
+        assertWithMessage("Expected handle1 to include A").that(handle1Tracking).isEqualTo(3)
+        assertWithMessage("Expected handle2 to equal B").that(handle2Tracking).isEqualTo(2)
+        assertWithMessage("Expected handle3 to include C").that(handle3Tracking).isEqualTo(1)
+        assertWithMessage("Expected handle4 to not equal D").that(handle4Tracking).isEqualTo(0)
+
+        handle4.store(Person("D"))
+        assertWithMessage("Expected handle1 to include A").that(handle1Tracking).isEqualTo(4)
+        assertWithMessage("Expected handle2 to equal B").that(handle2Tracking).isEqualTo(3)
+        assertWithMessage("Expected handle3 to include C").that(handle3Tracking).isEqualTo(2)
+        assertWithMessage("Expected handle4 to equal D").that(handle4Tracking).isEqualTo(1)
     }
 
-    combineUpdates(
-      handle1,
-      handle2,
-      handle3,
-      handle4,
-      handle5,
-      handle6,
-      handle7,
-      handle8,
-      handle9,
-      handle10
-    ) { _, _, _, _, _, _, _, _, _, _ ->
-      tracking10 += 1
+    @Test
+    fun handleUtils_combineTenUpdatesTest() = runBlockingTest {
+        val handle1 = createCollectionHandle(STORAGE_KEY_ONE)
+        val handle2 = createSingletonHandle(STORAGE_KEY_TWO)
+        val handle3 = createCollectionHandle(STORAGE_KEY_THREE)
+        val handle4 = createSingletonHandle(STORAGE_KEY_FOUR)
+        val handle5 = createCollectionHandle(STORAGE_KEY_FIVE)
+        val handle6 = createSingletonHandle(STORAGE_KEY_SIX)
+        val handle7 = createCollectionHandle(STORAGE_KEY_SEVEN)
+        val handle8 = createSingletonHandle(STORAGE_KEY_EIGHT)
+        val handle9 = createCollectionHandle(STORAGE_KEY_NINE)
+        val handle10 = createSingletonHandle(STORAGE_KEY_TEN)
+
+        var tracking5 = 0
+        var tracking6 = 0
+        var tracking7 = 0
+        var tracking8 = 0
+        var tracking9 = 0
+        var tracking10 = 0
+
+        combineUpdates(
+            handle1,
+            handle2,
+            handle3,
+            handle4,
+            handle5
+        ) { _, _, _, _, _ ->
+            tracking5 += 1
+        }
+
+        combineUpdates(
+            handle1,
+            handle2,
+            handle3,
+            handle4,
+            handle5,
+            handle6
+        ) { _, _, _, _, _, _ ->
+            tracking6 += 1
+        }
+
+        combineUpdates(
+            handle1,
+            handle2,
+            handle3,
+            handle4,
+            handle5,
+            handle6,
+            handle7
+        ) { _, _, _, _, _, _, _ ->
+            tracking7 += 1
+        }
+
+        combineUpdates(
+            handle1,
+            handle2,
+            handle3,
+            handle4,
+            handle5,
+            handle6,
+            handle7,
+            handle8
+        ) { _, _, _, _, _, _, _, _ ->
+            tracking8 += 1
+        }
+
+        combineUpdates(
+            handle1,
+            handle2,
+            handle3,
+            handle4,
+            handle5,
+            handle6,
+            handle7,
+            handle8,
+            handle9
+        ) { _, _, _, _, _, _, _, _, _ ->
+            tracking9 += 1
+        }
+
+        combineUpdates(
+            handle1,
+            handle2,
+            handle3,
+            handle4,
+            handle5,
+            handle6,
+            handle7,
+            handle8,
+            handle9,
+            handle10
+        ) { _, _, _, _, _, _, _, _, _, _ ->
+            tracking10 += 1
+        }
+
+        handle1.store(Person("A"))
+        handle2.store(Person("B"))
+        handle3.store(Person("C"))
+        handle4.store(Person("D"))
+        handle5.store(Person("E"))
+        handle6.store(Person("F"))
+        handle7.store(Person("G"))
+        handle8.store(Person("H"))
+        handle9.store(Person("I"))
+        handle10.store(Person("J"))
+
+        assertWithMessage("Expected 5 combineUpdates to be called.").that(tracking5).isEqualTo(5)
+        assertWithMessage("Expected 6 combineUpdates to be called.").that(tracking6).isEqualTo(6)
+        assertWithMessage("Expected 7 combineUpdates to be called.").that(tracking7).isEqualTo(7)
+        assertWithMessage("Expected 8 combineUpdates to be called.").that(tracking8).isEqualTo(8)
+        assertWithMessage("Expected 9 combineUpdates to be called.").that(tracking9).isEqualTo(9)
+        assertWithMessage("Expected 10 combineUpdates to be called.").that(tracking10).isEqualTo(10)
     }
-    
-    handle1.store(Person("A"))
-    handle2.store(Person("B"))
-    handle3.store(Person("C"))
-    handle4.store(Person("D"))
-    handle5.store(Person("E"))
-    handle6.store(Person("F"))
-    handle7.store(Person("G"))
-    handle8.store(Person("H"))
-    handle9.store(Person("I"))
-    handle10.store(Person("J"))
-    
-    assertWithMessage("Expected 5 combineUpdates to be called.").that(tracking5).isEqualTo(5)
-    assertWithMessage("Expected 6 combineUpdates to be called.").that(tracking6).isEqualTo(6)
-    assertWithMessage("Expected 7 combineUpdates to be called.").that(tracking7).isEqualTo(7)
-    assertWithMessage("Expected 8 combineUpdates to be called.").that(tracking8).isEqualTo(8)
-    assertWithMessage("Expected 9 combineUpdates to be called.").that(tracking9).isEqualTo(9)
-    assertWithMessage("Expected 10 combineUpdates to be called.").that(tracking10).isEqualTo(10)
-  }
 
-  private companion object {
-    private const val READ_WRITE_HANDLE = "readWriteHandle"
+    private suspend fun createCollectionHandle(
+        storageKey: StorageKey
+    ) = manager.createHandle(
+        HandleSpec(
+            READ_WRITE_HANDLE,
+            HandleMode.ReadWrite,
+            HandleContainerType.Collection,
+            Person
+        ),
+        storageKey
+    ) as ReadWriteCollectionHandle<Person>
 
-    private val STORAGE_KEY_ONE = ReferenceModeStorageKey(
-      backingKey = RamDiskStorageKey("backing"),
-      storageKey = RamDiskStorageKey("entity")
-    )
+    private suspend fun createSingletonHandle(
+        storageKey: StorageKey
+    ) = manager.createHandle(
+        HandleSpec(
+            READ_WRITE_HANDLE,
+            HandleMode.ReadWrite,
+            HandleContainerType.Singleton,
+            Person
+        ),
+        storageKey
+    ) as ReadWriteSingletonHandle<Person>
 
-    private val STORAGE_KEY_TWO = ReferenceModeStorageKey(
-      backingKey = RamDiskStorageKey("backing2"),
-      storageKey = RamDiskStorageKey("entity2")
-    )
+    private companion object {
+        private const val READ_WRITE_HANDLE = "readWriteHandle"
 
-    private val STORAGE_KEY_THREE = ReferenceModeStorageKey(
-      backingKey = RamDiskStorageKey("backing3"),
-      storageKey = RamDiskStorageKey("entity3")
-    )
+        private val STORAGE_KEY_ONE = ReferenceModeStorageKey(
+            backingKey = RamDiskStorageKey("backing"),
+            storageKey = RamDiskStorageKey("entity")
+        )
 
-    private val STORAGE_KEY_FOUR = ReferenceModeStorageKey(
-      backingKey = RamDiskStorageKey("backing4"),
-      storageKey = RamDiskStorageKey("entity4")
-    )
+        private val STORAGE_KEY_TWO = ReferenceModeStorageKey(
+            backingKey = RamDiskStorageKey("backing2"),
+            storageKey = RamDiskStorageKey("entity2")
+        )
 
-    private val STORAGE_KEY_FIVE = ReferenceModeStorageKey(
-      backingKey = RamDiskStorageKey("backing5"),
-      storageKey = RamDiskStorageKey("entity5")
-    )
+        private val STORAGE_KEY_THREE = ReferenceModeStorageKey(
+            backingKey = RamDiskStorageKey("backing3"),
+            storageKey = RamDiskStorageKey("entity3")
+        )
 
-    private val STORAGE_KEY_SIX = ReferenceModeStorageKey(
-      backingKey = RamDiskStorageKey("backing6"),
-      storageKey = RamDiskStorageKey("entity6")
-    )
+        private val STORAGE_KEY_FOUR = ReferenceModeStorageKey(
+            backingKey = RamDiskStorageKey("backing4"),
+            storageKey = RamDiskStorageKey("entity4")
+        )
 
-    private val STORAGE_KEY_SEVEN = ReferenceModeStorageKey(
-      backingKey = RamDiskStorageKey("backing7"),
-      storageKey = RamDiskStorageKey("entity7")
-    )
+        private val STORAGE_KEY_FIVE = ReferenceModeStorageKey(
+            backingKey = RamDiskStorageKey("backing5"),
+            storageKey = RamDiskStorageKey("entity5")
+        )
 
-    private val STORAGE_KEY_EIGHT = ReferenceModeStorageKey(
-      backingKey = RamDiskStorageKey("backing8"),
-      storageKey = RamDiskStorageKey("entity8")
-    )
+        private val STORAGE_KEY_SIX = ReferenceModeStorageKey(
+            backingKey = RamDiskStorageKey("backing6"),
+            storageKey = RamDiskStorageKey("entity6")
+        )
 
-    private val STORAGE_KEY_NINE = ReferenceModeStorageKey(
-      backingKey = RamDiskStorageKey("backing9"),
-      storageKey = RamDiskStorageKey("entity9")
-    )
+        private val STORAGE_KEY_SEVEN = ReferenceModeStorageKey(
+            backingKey = RamDiskStorageKey("backing7"),
+            storageKey = RamDiskStorageKey("entity7")
+        )
 
-    private val STORAGE_KEY_TEN = ReferenceModeStorageKey(
-      backingKey = RamDiskStorageKey("backing10"),
-      storageKey = RamDiskStorageKey("entity10")
-    )
-  }
+        private val STORAGE_KEY_EIGHT = ReferenceModeStorageKey(
+            backingKey = RamDiskStorageKey("backing8"),
+            storageKey = RamDiskStorageKey("entity8")
+        )
+
+        private val STORAGE_KEY_NINE = ReferenceModeStorageKey(
+            backingKey = RamDiskStorageKey("backing9"),
+            storageKey = RamDiskStorageKey("entity9")
+        )
+
+        private val STORAGE_KEY_TEN = ReferenceModeStorageKey(
+            backingKey = RamDiskStorageKey("backing10"),
+            storageKey = RamDiskStorageKey("entity10")
+        )
+    }
 }

--- a/src/tools/schema2kotlin.ts
+++ b/src/tools/schema2kotlin.ts
@@ -88,6 +88,9 @@ export class Schema2Kotlin extends Schema2Base {
 
     if (this.opts.test_harness) {
       imports.push(
+        'import arcs.core.entity.HandleContainerType',
+        'import arcs.core.entity.HandleMode',
+        'import arcs.core.entity.HandleSpec',
         'import arcs.sdk.testing.*',
         'import kotlinx.coroutines.CoroutineScope',
       );
@@ -185,21 +188,21 @@ abstract class Abstract${particleName} : ${this.opts.wasm ? 'WasmParticleImpl' :
   generateTestHarness(particle: ParticleSpec): string {
     const particleName = particle.name;
     const handleDecls: string[] = [];
-    const handleDescriptors: string[] = [];
+    const handleSpecs: string[] = [];
 
     for (const connection of particle.connections) {
       const handleName = connection.name;
       const entityType = this.entityTypeName(particle, connection);
       const handleConcreteType = connection.type.isCollectionType() ? 'Collection' : 'Singleton';
       handleDecls.push(`val ${handleName}: ReadWrite${handleConcreteType}Handle<${entityType}> by handleMap`);
-      handleDescriptors.push(`HandleDescriptor("${handleName}", ${entityType}, HandleFlavor.${handleConcreteType.toUpperCase()})`);
+      handleSpecs.push(`HandleSpec("${handleName}", HandleMode.ReadWrite, HandleContainerType.${handleConcreteType}, ${entityType})`);
     }
 
     return `
 class ${particleName}TestHarness<P : Abstract${particleName}>(
     factory : (CoroutineScope) -> P
 ) : BaseTestHarness<P>(factory, listOf(
-    ${handleDescriptors.join(',\n    ')}
+    ${handleSpecs.join(',\n    ')}
 )) {
     ${handleDecls.join('\n    ')}
 }

--- a/src/tools/tests/goldens/generated-test-harness.kt
+++ b/src/tools/tests/goldens/generated-test-harness.kt
@@ -8,6 +8,9 @@ package arcs.golden
 //
 // Current implementation doesn't support optional field detection
 
+import arcs.core.entity.HandleContainerType
+import arcs.core.entity.HandleMode
+import arcs.core.entity.HandleSpec
 import arcs.sdk.*
 import arcs.sdk.testing.*
 import kotlinx.coroutines.CoroutineScope
@@ -15,11 +18,11 @@ import kotlinx.coroutines.CoroutineScope
 class GoldTestHarness<P : AbstractGold>(
     factory : (CoroutineScope) -> P
 ) : BaseTestHarness<P>(factory, listOf(
-    HandleDescriptor("data", Gold_Data, HandleFlavor.SINGLETON),
-    HandleDescriptor("allPeople", Gold_AllPeople, HandleFlavor.COLLECTION),
-    HandleDescriptor("qCollection", Gold_QCollection, HandleFlavor.COLLECTION),
-    HandleDescriptor("alias", Gold_Alias, HandleFlavor.SINGLETON),
-    HandleDescriptor("collection", Gold_Collection, HandleFlavor.COLLECTION)
+    HandleSpec("data", HandleMode.ReadWrite, HandleContainerType.Singleton, Gold_Data),
+    HandleSpec("allPeople", HandleMode.ReadWrite, HandleContainerType.Collection, Gold_AllPeople),
+    HandleSpec("qCollection", HandleMode.ReadWrite, HandleContainerType.Collection, Gold_QCollection),
+    HandleSpec("alias", HandleMode.ReadWrite, HandleContainerType.Singleton, Gold_Alias),
+    HandleSpec("collection", HandleMode.ReadWrite, HandleContainerType.Collection, Gold_Collection)
 )) {
     val data: ReadWriteSingletonHandle<Gold_Data> by handleMap
     val allPeople: ReadWriteCollectionHandle<Gold_AllPeople> by handleMap


### PR DESCRIPTION
Introduces HandleSpec, which collects all of the configuration options for starting a handle. This reduces a bunch of duplicated code, and will make it much easier to introduce Reference Handles in a follow-up PR.