### PR TITLE
Update BackingStore contract and simplify callback management

### DIFF
--- a/java/arcs/core/storage/BUILD
+++ b/java/arcs/core/storage/BUILD
@@ -43,6 +43,7 @@ arcs_kt_library(
         "//java/arcs/core/storage/util",
         "//java/arcs/core/type",
         "//java/arcs/core/util",
+        "//third_party/java/androidx/annotation",
         "//third_party/kotlin/kotlinx_atomicfu",
         "//third_party/kotlin/kotlinx_coroutines",
     ],

--- a/java/arcs/core/storage/BackingStore.kt
+++ b/java/arcs/core/storage/BackingStore.kt
@@ -16,8 +16,7 @@ import arcs.core.crdt.CrdtOperation
 import arcs.core.storage.ProxyMessage.ModelUpdate
 import arcs.core.storage.ProxyMessage.Operations
 import arcs.core.storage.ProxyMessage.SyncRequest
-import arcs.core.storage.util.RandomProxyCallbackManager
-import arcs.core.util.Random
+import arcs.core.type.Type
 import kotlin.coroutines.coroutineContext
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
@@ -26,45 +25,30 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 
 /**
- * An [ActiveStore] that allows multiple CRDT models to be stored as sub-keys of a single
- * storageKey location.
+ * An collection of [DirectStore]s that allows multiple CRDT models to be stored as sub-keys
+ * of a single [StorageKey] location.
  *
  * This is what *backs* Entities.
  */
 class BackingStore<Data : CrdtData, Op : CrdtOperation, T>(
-    private val options: StoreOptions<Data, Op, T>
-) : ActiveStore<Data, Op, T>(options) {
+    val storageKey: StorageKey,
+    val backingType: Type,
+    val callbackFactory: ((String) -> ProxyCallback<Data, Op, T>)
+) {
     private val storeMutex = Mutex()
     /* internal */ val stores = mutableMapOf<String, StoreRecord<Data, Op, T>>()
-    private val callbacks = RandomProxyCallbackManager<Data, Op, T>(
-        "backing",
-        Random
-    )
-
-    @Deprecated(
-        "Use getLocalData(muxId) instead",
-        replaceWith = ReplaceWith("getLocalData(muxId)")
-    )
-    override suspend fun getLocalData(): Data =
-        throw UnsupportedOperationException("Use getLocalData(muxId) instead.")
 
     /**
-     * Gets data from the store corresponding to the given [muxId].
+     * Gets data from the store corresponding to the given [referenceId].
      */
-    suspend fun getLocalData(muxId: String): Data {
-        val record = storeMutex.withLock { stores[muxId] }
-            ?: return setupStore(muxId).store.getLocalData()
+    suspend fun getLocalData(referenceId: String): Data {
+        val record = storeMutex.withLock { stores[referenceId] }
+            ?: return setupStore(referenceId).store.getLocalData()
         return record.store.getLocalData()
     }
 
-    override fun on(callback: ProxyCallback<Data, Op, T>): Int =
-        callbacks.register(callback)
-
-    override fun off(callbackToken: Int) {
-        callbacks.unregister(callbackToken)
-    }
-
-    override suspend fun idle() = storeMutex.withLock {
+    /** Calls [idle] on all existing contained stores and waits for their completion. */
+    suspend fun idle() = storeMutex.withLock {
         stores.values.map {
             withContext(coroutineContext) {
                 launch { it.store.idle() }
@@ -72,14 +56,16 @@ class BackingStore<Data : CrdtData, Op : CrdtOperation, T>(
         }.joinAll()
     }
 
-    override suspend fun onProxyMessage(message: ProxyMessage<Data, Op, T>) =
-        throw UnsupportedOperationException("Use onProxyMessage(message, muxId) instead.")
-
+    /**
+     * Sends the provided [ProxyMessage] to the store backing the provided [referenceId].
+     *
+     * A new store will be created for the [referenceId], if necessary.
+     */
     suspend fun onProxyMessage(
         message: ProxyMessage<Data, Op, T>,
-        muxId: String
+        referenceId: String
     ): Boolean {
-        val (id, store) = storeMutex.withLock { stores[muxId] } ?: setupStore(muxId)
+        val (id, store) = storeMutex.withLock { stores[referenceId] } ?: setupStore(referenceId)
         val deMuxedMessage: ProxyMessage<Data, Op, T> = when (message) {
             is SyncRequest -> SyncRequest(id)
             is ModelUpdate -> ModelUpdate(message.model, id)
@@ -90,24 +76,20 @@ class BackingStore<Data : CrdtData, Op : CrdtOperation, T>(
         return store.onProxyMessage(deMuxedMessage)
     }
 
-    @Suppress("UNCHECKED_CAST") // TODO: See if we can clean up this generics situation.
-    /* internal */ suspend fun setupStore(muxId: String): StoreRecord<Data, Op, T> {
+    /* internal */ suspend fun setupStore(referenceId: String): StoreRecord<Data, Op, T> {
         val store = DirectStore.create(
-            // Copy of our options, but with a child storage key using the muxId.
-            options.copy(options.storageKey.childKeyWithComponent(muxId))
+            StoreOptions<Data, Op, T>(
+                storageKey = storageKey.childKeyWithComponent(referenceId),
+                type = backingType
+            )
         )
 
-        val id = store.on(ProxyCallback { processStoreCallback(muxId, it) })
+        val id = store.on(callbackFactory(referenceId))
 
         // Return a new Record and add it to our local stores, keyed by muxId.
         return StoreRecord(id, store)
-            .also { record -> storeMutex.withLock { stores[muxId] = record } }
+            .also { record -> storeMutex.withLock { stores[referenceId] = record } }
     }
-
-    private suspend fun processStoreCallback(
-        muxId: String,
-        message: ProxyMessage<Data, Op, T>
-    ) = callbacks.sendMultiplexed(message, muxId)
 
     data class StoreRecord<Data : CrdtData, Op : CrdtOperation, T>(
         val id: Int,

--- a/java/arcs/core/storage/BackingStore.kt
+++ b/java/arcs/core/storage/BackingStore.kt
@@ -33,7 +33,7 @@ import kotlinx.coroutines.withContext
 class BackingStore<Data : CrdtData, Op : CrdtOperation, T>(
     val storageKey: StorageKey,
     val backingType: Type,
-    val callbackFactory: ((String) -> ProxyCallback<Data, Op, T>)
+    val callbackFactory: (String) -> ProxyCallback<Data, Op, T>
 ) {
     private val storeMutex = Mutex()
     /* internal */ val stores = mutableMapOf<String, StoreRecord<Data, Op, T>>()

--- a/java/arcs/core/storage/ProxyInterface.kt
+++ b/java/arcs/core/storage/ProxyInterface.kt
@@ -78,29 +78,17 @@ sealed class ProxyMessage<Data : CrdtData, Op : CrdtOperation, ConsumerData>(
  * ```
  */
 interface ProxyCallback<Data : CrdtData, Op : CrdtOperation, ConsumerData> {
-    val singleCallback: suspend (ProxyMessage<Data, Op, ConsumerData>) -> Unit
-        get() = throw UnsupportedOperationException("Single callback not supported.")
-    val multiCallback: suspend (ProxyMessage<Data, Op, ConsumerData>, String) -> Unit
-        get() = throw UnsupportedOperationException("Multiplexed callback not supported")
-
     suspend operator fun invoke(
-        message: ProxyMessage<Data, Op, ConsumerData>,
-        muxId: String? = null
-    ) = muxId?.let { multiCallback(message, muxId) } ?: singleCallback(message)
+        message: ProxyMessage<Data, Op, ConsumerData>
+    )
 }
 
-/** Pseudo-constructor for a [ProxyCallback] capable of receiving direct messages. */
 fun <Data : CrdtData, Op : CrdtOperation, ConsumerData> ProxyCallback(
-    callback: suspend (message: ProxyMessage<Data, Op, ConsumerData>) -> Unit
-): ProxyCallback<Data, Op, ConsumerData> = object : ProxyCallback<Data, Op, ConsumerData> {
-    override val singleCallback = callback
-}
-
-/** Pseudo-constructor for a [ProxyCallback] capable of receiving multiplexed messages. */
-fun <Data : CrdtData, Op : CrdtOperation, ConsumerData> MultiplexedProxyCallback(
-    callback: suspend (message: ProxyMessage<Data, Op, ConsumerData>, muxId: String) -> Unit
-): ProxyCallback<Data, Op, ConsumerData> = object : ProxyCallback<Data, Op, ConsumerData> {
-    override val multiCallback = callback
+    callback: suspend (ProxyMessage<Data, Op, ConsumerData>) -> Unit
+) = object : ProxyCallback<Data, Op, ConsumerData> {
+    override suspend operator fun invoke(
+        message: ProxyMessage<Data, Op, ConsumerData>
+    ) = callback(message)
 }
 
 /** Interface common to an [ActiveStore] and the PEC, used by the Storage Proxy. */

--- a/java/arcs/core/storage/ReferenceModeStore.kt
+++ b/java/arcs/core/storage/ReferenceModeStore.kt
@@ -76,9 +76,11 @@ import kotlinx.coroutines.Job
 class ReferenceModeStore private constructor(
     options: StoreOptions<RefModeStoreData, RefModeStoreOp, RefModeStoreOutput>,
     /* internal */
-    val backingStore: BackingStore<CrdtData, CrdtOperation, Any?>,
+    val containerStore: DirectStore<CrdtData, CrdtOperation, Any?>,
     /* internal */
-    val containerStore: DirectStore<CrdtData, CrdtOperation, Any?>
+    val backingKey: StorageKey,
+    /* internal */
+    backingType: Type
 ) : ActiveStore<RefModeStoreData, RefModeStoreOp, RefModeStoreOutput>(options) {
     private val log = TaggedLog { "Store($storageKey)" }
 
@@ -126,11 +128,27 @@ class ReferenceModeStore private constructor(
      */
     private val versions = mutableMapOf<ReferenceId, MutableMap<FieldName, Int>>()
 
+    val backingStore = BackingStore<CrdtData, CrdtOperation, Any?>(
+        storageKey = backingKey,
+        backingType = backingType,
+        callbackFactory = { muxId ->
+            ProxyCallback { message ->
+                receiveQueue.enqueue(
+                    PreEnqueuedFromBackingStore(message.toReferenceModeMessage(), muxId)
+                )
+            }
+        }
+    )
+
     init {
         @Suppress("UNCHECKED_CAST")
         crdtType = requireNotNull(
             type as? Type.TypeContainer<CrdtModelType<CrdtData, CrdtOperationAtTime, Referencable>>
         ) { "Provided type must contain CrdtModelType" }.containedType
+
+        containerStore.on(ProxyCallback {
+            receiveQueue.enqueue(Message.PreEnqueuedFromContainer(it.toReferenceModeMessage()))
+        })
     }
 
     override suspend fun idle() {
@@ -159,11 +177,6 @@ class ReferenceModeStore private constructor(
 
     override fun off(callbackToken: Int) = callbacks.unregister(callbackToken)
 
-    private fun registerStoreCallbacks() {
-        backingStore.on(backingStoreCallback)
-        containerStore.on(containerStoreCallback)
-    }
-
     /*
      * Messages are enqueued onto an object-wide queue and processed in order.
      * Internally, each handler (handleContainerStore, handleBackingStore, handleProxyMessage)
@@ -182,20 +195,6 @@ class ReferenceModeStore private constructor(
         val refModeMessage = message.sanitizeForRefModeStore(type)
         return receiveQueue.enqueue(Message.PreEnqueuedFromStorageProxy(refModeMessage))
     }
-
-    @Suppress("UNCHECKED_CAST")
-    private val backingStoreCallback: ProxyCallback<CrdtData, CrdtOperation, Any?> =
-        MultiplexedProxyCallback { message, muxId ->
-            receiveQueue.enqueue(
-                PreEnqueuedFromBackingStore(message.toReferenceModeMessage(), muxId)
-            )
-        }
-
-    @Suppress("UNCHECKED_CAST")
-    private val containerStoreCallback: ProxyCallback<CrdtData, CrdtOperation, Any?> =
-        ProxyCallback {
-            receiveQueue.enqueue(Message.PreEnqueuedFromContainer(it.toReferenceModeMessage()))
-        }
 
     /**
      * Handle an update from an upstream StorageProxy.
@@ -621,13 +620,6 @@ class ReferenceModeStore private constructor(
                 SingletonType(ReferenceType(type.containedType))
             }
 
-            val backingStore = BackingStore<CrdtData, CrdtOperation, Any?>(
-                StoreOptions(
-                    storageKey = storageKey.backingKey,
-                    type = type.containedType,
-                    mode = StorageMode.Backing
-                )
-            )
             val containerStore = DirectStore.create<CrdtData, CrdtOperation, Any?>(
                 StoreOptions(
                     storageKey = storageKey.storageKey,
@@ -636,9 +628,12 @@ class ReferenceModeStore private constructor(
                 )
             )
 
-            return ReferenceModeStore(refableOptions, backingStore, containerStore).apply {
-                registerStoreCallbacks()
-            }
+            return ReferenceModeStore(
+                refableOptions,
+                containerStore,
+                storageKey.backingKey,
+                type.containedType
+            )
         }
     }
 }

--- a/java/arcs/core/storage/ReferenceModeStore.kt
+++ b/java/arcs/core/storage/ReferenceModeStore.kt
@@ -11,6 +11,7 @@
 
 package arcs.core.storage
 
+import androidx.annotation.VisibleForTesting
 import arcs.core.common.Referencable
 import arcs.core.common.ReferenceId
 import arcs.core.crdt.CrdtData
@@ -128,6 +129,7 @@ class ReferenceModeStore private constructor(
      */
     private val versions = mutableMapOf<ReferenceId, MutableMap<FieldName, Int>>()
 
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     val backingStore = BackingStore<CrdtData, CrdtOperation, Any?>(
         storageKey = backingKey,
         backingType = backingType,

--- a/java/arcs/core/storage/Store.kt
+++ b/java/arcs/core/storage/Store.kt
@@ -91,7 +91,6 @@ class Store<Data : CrdtData, Op : CrdtOperation, ConsumerData>(
                 options: StoreOptions<Data, Op, T>
             ): ActiveStore<Data, Op, T> = when (options.mode) {
                 StorageMode.Direct -> DirectStore.create(options)
-                StorageMode.Backing -> BackingStore(options)
                 StorageMode.ReferenceMode ->
                     ReferenceModeStore.create(options) as ActiveStore<Data, Op, T>
             }

--- a/java/arcs/core/storage/StoreInterface.kt
+++ b/java/arcs/core/storage/StoreInterface.kt
@@ -15,7 +15,6 @@ import arcs.core.crdt.CrdtData
 import arcs.core.crdt.CrdtOperation
 import arcs.core.storage.referencemode.ReferenceModeStorageKey
 import arcs.core.type.Type
-import kotlin.reflect.KClass
 
 /** Base interface which all store implementations must extend from. */
 interface IStore<Data : CrdtData, Op : CrdtOperation, ConsumerData> {
@@ -25,44 +24,12 @@ interface IStore<Data : CrdtData, Op : CrdtOperation, ConsumerData> {
 }
 
 /**
- * Wrapper for a function which can be used to construct a store for a given model of type [Data] as
- * well as provide ample information to support looking the constructor up by expected types.
- */
-data class StoreConstructor(
-    /* internal */
-    val dataClass: KClass<out CrdtData>,
-    /* internal */
-    val opClass: KClass<out CrdtOperation>,
-    /* internal */
-    val consumerDataClass: KClass<*>,
-    private val constructor: suspend (StoreOptions<*, *, *>, KClass<*>) -> ActiveStore<*, *, *>
-) {
-    val typeParamString: String
-        get() = "<$dataClass, $opClass, $consumerDataClass>"
-
-    /* internal */ suspend operator fun <Data : CrdtData, Op : CrdtOperation, ConsumerData> invoke(
-        options: StoreOptions<Data, Op, ConsumerData>,
-        dataClass: KClass<*>
-    ) = constructor(options, dataClass)
-}
-
-/**
- * Pseudo-constructor which can be used to denote a suspending function capable of generating an
- * [ActiveStore] instance as a [StoreConstructor].
- */
-inline fun <reified Data, reified Op, reified ConsumerData> StoreConstructor(
-    noinline constructor: suspend (StoreOptions<*, *, *>, KClass<*>) -> ActiveStore<*, *, *>
-): StoreConstructor where Data : CrdtData, Op : CrdtOperation =
-    StoreConstructor(Data::class, Op::class, ConsumerData::class, constructor)
-
-/**
  * Modes for Storage.
  *
  * TODO: need actual, helpful kdoc for these.
  */
 enum class StorageMode {
     Direct,
-    Backing,
     ReferenceMode,
 }
 

--- a/java/arcs/core/storage/util/ProxyCallbackManager.kt
+++ b/java/arcs/core/storage/util/ProxyCallbackManager.kt
@@ -80,29 +80,6 @@ class ProxyCallbackManager<Data : CrdtData, Op : CrdtOperation, ConsumerData>(
         // registration.
         targets.forEach { it(message) }
     }
-
-    /**
-     * Notifies all multiplexed [ProxyCallback]s registered of a [message] for a particular [muxId].
-     *
-     * Optionally: you may specify [exceptTo] to omit sending to a particular callback. (with token
-     * value == [exceptTo])
-     */
-    suspend fun sendMultiplexed(
-        message: ProxyMessage<Data, Op, ConsumerData>,
-        muxId: String,
-        exceptTo: Int? = null
-    ) {
-        val targets = mutex.withLock {
-            if (exceptTo == null) {
-                ArrayList(callbacks.values)
-            } else {
-                ArrayList(callbacks.filter { it.key != exceptTo }.values)
-            }
-        }
-        // Call our targets outside of the mutex so we don't deadlock if a callback leads to another
-        // registration.
-        targets.forEach { it(message, muxId) }
-    }
 }
 
 /**

--- a/javatests/arcs/core/storage/util/ProxyCallbackManagerTest.kt
+++ b/javatests/arcs/core/storage/util/ProxyCallbackManagerTest.kt
@@ -14,7 +14,6 @@ package arcs.core.storage.util
 import arcs.core.crdt.CrdtData
 import arcs.core.crdt.CrdtOperation
 import arcs.core.crdt.VersionMap
-import arcs.core.storage.MultiplexedProxyCallback
 import arcs.core.storage.ProxyCallback
 import arcs.core.storage.ProxyMessage
 import com.google.common.truth.Truth.assertThat
@@ -77,29 +76,6 @@ class ProxyCallbackManagerTest {
         assertThat(registeredMessage.value).isNull()
 
         manager.send(shouldBeReceivedByRegistered)
-        assertThat(registeredMessage.value).isEqualTo(shouldBeReceivedByRegistered)
-    }
-
-    @Test
-    fun sendMultiplexedWhichCausesARegistration_doesntDeadlock() = runBlockingTest {
-        val registeredMessage = atomic<ProxyMessage<DummyData, DummyOp, String>?>(null)
-        val registeredCallback =
-            MultiplexedProxyCallback<DummyData, DummyOp, String> { message, _ ->
-                registeredMessage.value = message
-            }
-        val registeringCallback =
-            MultiplexedProxyCallback<DummyData, DummyOp, String> { _, _ ->
-                manager.register(registeredCallback)
-            }
-
-        val shouldBeReceivedByRegistered = makeMessage("bar", 2)
-
-        manager.register(registeringCallback)
-
-        manager.sendMultiplexed(makeMessage("foo", 1), "mux1")
-        assertThat(registeredMessage.value).isNull()
-
-        manager.sendMultiplexed(shouldBeReceivedByRegistered, "mux1")
         assertThat(registeredMessage.value).isEqualTo(shouldBeReceivedByRegistered)
     }
 


### PR DESCRIPTION
* Refactor BackingStore so that it's not extending ActiveStore, since it
doesn't implement the interface of an ActiveStore.
* Modify BackingStore to take a callback generator that sets callbacks
on DirectStores it creates
* Remove MultiplexProxyCallback, which is no longer needed