### PR TITLE
Adjust storage proxy interfaces to match usage expectations

### DIFF
--- a/java/arcs/core/storage/ActiveStore.kt
+++ b/java/arcs/core/storage/ActiveStore.kt
@@ -49,17 +49,20 @@ abstract class ActiveStore<Data : CrdtData, Op : CrdtOperation, ConsumerData>(
     /** Handles a message from the storage proxy. */
     abstract suspend fun onProxyMessage(message: ProxyMessage<Data, Op, ConsumerData>): Boolean
 
-    override fun getStorageEndpoint(): StorageCommunicationEndpoint<Data, Op, ConsumerData> {
-        return object : StorageCommunicationEndpoint<Data, Op, ConsumerData> {
-            var id: Int? = null
+    /**
+     * Return a storage endpoint that will receive messages from the store via the
+     * provided callback
+     */
+    override fun getStorageEndpoint(
+        callback: ProxyCallback<Data, Op, ConsumerData>
+    ) = object : StorageCommunicationEndpoint<Data, Op, ConsumerData> {
+        val id = on(callback)
 
-            override fun setCallback(callback: ProxyCallback<Data, Op, ConsumerData>): Int =
-                on(callback).also { id = it }
+        override suspend fun onProxyMessage(
+            message: ProxyMessage<Data, Op, ConsumerData>
+        ) = this@ActiveStore.onProxyMessage(message.withId(id!!))
 
-            override suspend fun onProxyMessage(
-                message: ProxyMessage<Data, Op, ConsumerData>
-            ) = this@ActiveStore.onProxyMessage(message.withId(id!!))
-        }
+        override fun close() = off(id)
     }
 
     /** Clones data from the given store into this one. */

--- a/java/arcs/core/storage/ActiveStore.kt
+++ b/java/arcs/core/storage/ActiveStore.kt
@@ -60,7 +60,7 @@ abstract class ActiveStore<Data : CrdtData, Op : CrdtOperation, ConsumerData>(
 
         override suspend fun onProxyMessage(
             message: ProxyMessage<Data, Op, ConsumerData>
-        ) = this@ActiveStore.onProxyMessage(message.withId(id!!))
+        ) = this@ActiveStore.onProxyMessage(message.withId(id))
 
         override fun close() = off(id)
     }

--- a/java/arcs/core/storage/ProxyInterface.kt
+++ b/java/arcs/core/storage/ProxyInterface.kt
@@ -105,12 +105,22 @@ fun <Data : CrdtData, Op : CrdtOperation, ConsumerData> MultiplexedProxyCallback
 
 /** Interface common to an [ActiveStore] and the PEC, used by the Storage Proxy. */
 interface StorageCommunicationEndpoint<Data : CrdtData, Op : CrdtOperation, ConsumerData> {
-    fun setCallback(callback: ProxyCallback<Data, Op, ConsumerData>): Int
     suspend fun onProxyMessage(message: ProxyMessage<Data, Op, ConsumerData>): Boolean
+
+    /** Signal to the endpoint provider that the clinet is finished using this endpoint */
+    fun close()
 }
 
 /** Provider of a [StorageCommunicationEndpoint]. */
 interface StorageCommunicationEndpointProvider<Data : CrdtData, Op : CrdtOperation, ConsumerData> {
-    fun getStorageEndpoint(): StorageCommunicationEndpoint<Data, Op, ConsumerData>
+    /**
+     * Implementers should return a [StorageCommunicationEndpoint] that signals information back to
+     * the agent using the provided `callback`.
+     */
+    fun getStorageEndpoint(
+        callback: ProxyCallback<Data, Op, ConsumerData>
+    ): StorageCommunicationEndpoint<Data, Op, ConsumerData>
+
+    /** Return the [StorageKey] that the store behind this implementation is representing. */
     val storageKey: StorageKey
 }

--- a/java/arcs/core/storage/ProxyInterface.kt
+++ b/java/arcs/core/storage/ProxyInterface.kt
@@ -107,7 +107,7 @@ fun <Data : CrdtData, Op : CrdtOperation, ConsumerData> MultiplexedProxyCallback
 interface StorageCommunicationEndpoint<Data : CrdtData, Op : CrdtOperation, ConsumerData> {
     suspend fun onProxyMessage(message: ProxyMessage<Data, Op, ConsumerData>): Boolean
 
-    /** Signal to the endpoint provider that the clinet is finished using this endpoint */
+    /** Signal to the endpoint provider that the client is finished using this endpoint. */
     fun close()
 }
 

--- a/java/arcs/core/storage/ProxyInterface.kt
+++ b/java/arcs/core/storage/ProxyInterface.kt
@@ -115,7 +115,7 @@ interface StorageCommunicationEndpoint<Data : CrdtData, Op : CrdtOperation, Cons
 interface StorageCommunicationEndpointProvider<Data : CrdtData, Op : CrdtOperation, ConsumerData> {
     /**
      * Implementers should return a [StorageCommunicationEndpoint] that signals information back to
-     * the agent using the provided `callback`.
+     * the agent using the provided [callback].
      */
     fun getStorageEndpoint(
         callback: ProxyCallback<Data, Op, ConsumerData>

--- a/java/arcs/core/storage/StorageProxy.kt
+++ b/java/arcs/core/storage/StorageProxy.kt
@@ -61,8 +61,7 @@ class StorageProxy<Data : CrdtData, Op : CrdtOperationAtTime, T>(
     private var isSynchronized: Boolean
         by guardedBy(syncMutex, false)
 
-    private val store = storeEndpointProvider.getStorageEndpoint()
-    private val storeListenerId = store.setCallback(ProxyCallback(::onMessage))
+    private val store = storeEndpointProvider.getStorageEndpoint(ProxyCallback(::onMessage))
 
     val storageKey = storeEndpointProvider.storageKey
 
@@ -228,10 +227,7 @@ class StorageProxy<Data : CrdtData, Op : CrdtOperationAtTime, T>(
                 // all ops from storage applied cleanly so resolve waiting syncs
                 futuresToResolve.forEach { it.complete(value) }
 
-                // Notify our handles of an update if these operations came from elsewhere.
-                if (message.id != storeListenerId) {
-                    notifyUpdate(value)
-                }
+                notifyUpdate(value)
             }
             is ProxyMessage.SyncRequest -> {
                 // storage wants our latest state

--- a/javatests/arcs/core/storage/StorageProxyTest.kt
+++ b/javatests/arcs/core/storage/StorageProxyTest.kt
@@ -6,6 +6,7 @@ import arcs.core.crdt.CrdtOperation
 import arcs.core.crdt.CrdtOperationAtTime
 import arcs.core.crdt.VersionMap
 import com.google.common.truth.Truth.assertThat
+import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
 import com.nhaarman.mockitokotlin2.whenever
@@ -28,7 +29,6 @@ import org.junit.runners.JUnit4
 import org.mockito.Mock
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
-import org.mockito.Mockito.any
 import org.mockito.MockitoAnnotations
 
 @Suppress("UNCHECKED_CAST", "UNUSED_VARIABLE")
@@ -47,7 +47,11 @@ class StorageProxyTest {
     fun setup() {
         MockitoAnnotations.initMocks(this)
         fakeStoreEndpoint = StoreEndpointFake()
-        whenever(mockStorageEndpointProvider.getStorageEndpoint()).thenReturn(fakeStoreEndpoint)
+        whenever(
+            mockStorageEndpointProvider.getStorageEndpoint(
+                any<ProxyCallback<CrdtData, CrdtOperationAtTime, String>>()
+            )
+        ).thenReturn(fakeStoreEndpoint)
         whenever(mockCrdtModel.data).thenReturn(mockCrdtData)
         whenever(mockCrdtModel.versionMap).thenReturn(VersionMap())
         whenever(mockCrdtOperation.clock).thenReturn(VersionMap())

--- a/javatests/arcs/core/storage/StoreEndpointFake.kt
+++ b/javatests/arcs/core/storage/StoreEndpointFake.kt
@@ -12,25 +12,10 @@ import kotlinx.coroutines.sync.withLock
 class StoreEndpointFake<Data : CrdtData, Op : CrdtOperation, T> :
     StorageCommunicationEndpoint<Data, Op, T> {
     private val mutex = Mutex()
-    private var callbacks = mutableListOf<ProxyCallback<Data, Op, T>>()
     private var proxyMessages = mutableListOf<ProxyMessage<Data, Op, T>>()
 
     // Tests can change this field to alter the value returned by `onProxyMessage`.
     var onProxyMessageReturn = true
-
-    override fun setCallback(callback: ProxyCallback<Data, Op, T>): Int {
-        // must be blocking since the storage impl is. Unlikely to be heavily contended.
-        return runBlocking {
-            mutex.withLock {
-                callbacks.add(callback)
-                callbacks.size
-            }
-        }
-    }
-
-    suspend fun getCallbacks(): List<ProxyCallback<Data, Op, T>> {
-        mutex.withLock { return callbacks.toList() }
-    }
 
     override suspend fun onProxyMessage(message: ProxyMessage<Data, Op, T>): Boolean {
         mutex.withLock { proxyMessages.add(message) }
@@ -40,4 +25,6 @@ class StoreEndpointFake<Data : CrdtData, Op : CrdtOperation, T> :
     suspend fun getProxyMessages() : List<ProxyMessage<Data, Op, T>> {
         mutex.withLock { return proxyMessages.toList() }
     }
+
+    override fun close() {}
 }


### PR DESCRIPTION
A given endpoint will have one callback set for it, so pass that
callback when creating the endpoint.

Introduce a `close` method, that can eventually tie into cleaning up
stores that aren't being used.