### PR TITLE
Create the Scheduler.

### DIFF
--- a/java/arcs/core/util/Scheduler.kt
+++ b/java/arcs/core/util/Scheduler.kt
@@ -1,0 +1,240 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.core.util
+
+import kotlin.coroutines.CoroutineContext
+import kotlinx.atomicfu.atomic
+import kotlinx.atomicfu.update
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withTimeout
+
+/**
+ * The [Scheduler] is responsible for scheduling the execution of a batch of [Task]s (known as an
+ * [Agenda]), at a defined maximum [scheduleRateHz], where each agenda is limited to running within
+ * the specified [agendaProcessingTimeout] window.
+ */
+class Scheduler(
+    private val time: Time,
+    context: CoroutineContext,
+    private val agendaProcessingTimeout: Long = DEFAULT_AGENDA_PROCESSING_TIMEOUT,
+    private val scheduleRateHz: Int = DEFAULT_SCHEDULE_RATE_HZ
+) {
+    private val log = TaggedLog { "Scheduler(${hashCode()})" }
+    /* internal */
+    val launches = atomic(0)
+    /* internal */
+    val loops = atomic(0)
+    private var processingJob: Job? = null
+    private val scope = CoroutineScope(context)
+    private val isIdle = atomic(true)
+    private val isPaused = atomic(false)
+    private val agenda = atomic(Agenda())
+
+    /** Schedule a single [Task] to be run as part of the next agenda. */
+    fun schedule(task: Task) {
+        agenda.update { it.addTask(task) }
+        if (isIdle.value) scope.startProcessingJob()
+    }
+
+    /** Schedule some [Task]s to be run as part of the next agenda. */
+    fun schedule(tasks: Iterable<Task>) {
+        agenda.update { it.addTasks(tasks) }
+        if (isIdle.value) scope.startProcessingJob()
+    }
+
+    /** Pause evaluation of the agenda. */
+    fun pause() {
+        isPaused.value = true
+    }
+
+    /** Resume evaluation of scheduled [Task]s in the agenda. */
+    fun resume() {
+        if (!isPaused.compareAndSet(expect = true, update = false)) return
+        // If we were paused, we can re-start.
+        scope.startProcessingJob()
+    }
+
+    /** Wait for the [Scheduler] to become idle. */
+    suspend fun waitForIdle() {
+        processingJob?.join()
+    }
+
+    private fun CoroutineScope.startProcessingJob() {
+        isIdle.value = false
+        processingJob = launch {
+            launches.incrementAndGet()
+
+            var shallContinue = true
+            while (shallContinue) {
+                val startTime = time.currentTimeMillis
+                shallContinue = withTimeout(agendaProcessingTimeout) {
+                    suspendCancellableCoroutine<Boolean> {
+                        it.resume(process()) { throwable ->
+                            if (throwable is TimeoutCancellationException) {
+                                log.error(throwable) { "Scheduled tasks timed out." }
+                            }
+                        }
+                    }
+                }
+                val elapsed = time.currentTimeMillis - startTime
+
+                if (shallContinue) {
+                    loops.incrementAndGet()
+
+                    // If the operation was super fast, let's delay a little bit to allow the
+                    // thread to chill out.
+                    val delayLength = scheduleRateHz.hzToMillisPerIteration() - elapsed
+                    if (delayLength > 0) delay(delayLength)
+                }
+            }
+        }.also { it.invokeOnCompletion { isIdle.value = true } }
+    }
+
+    private fun process(): Boolean {
+        if (isPaused.value) return false
+
+        val agenda = agenda.getAndSet(Agenda())
+        if (agenda.isEmpty()) return false
+
+        log.debug { "Processing agenda: $agenda" }
+
+        // Process agenda
+        agenda.processors.forEach { it() }
+        agenda.listenersByNamespace.listeners.asSequence()
+            .flatMap { (_, listenersByName) -> listenersByName.listeners.values.asSequence() }
+            .flatten()
+            .forEach { it() }
+
+        return true
+    }
+
+    private fun Int.hzToMillisPerIteration(): Long = ((1.0 / toDouble()) * 1000L).toLong()
+
+    sealed class Task(private val block: () -> Unit) {
+        /**
+         * [Task]s will be invoked by the [Scheduler] when their turn has arrived.
+         */
+        operator fun invoke() = block()
+
+        /**
+         * A [Processor] [Task] is responsible for computing data ahead of the execution of any
+         * [Listener] tasks.
+         *
+         * For example: [StorageProxy]'s usage of the [Scheduler] schedules [Processor] [Task]s when
+         * a [ProxyMessage] comes in from the [Store] - these [Processor] tasks are responsible for
+         * updating the [StorageProxy]'s local [CrdtModel].
+         */
+        abstract class Processor(block: () -> Unit) : Task(block)
+
+        /**
+         * [Listener] [Task]s are invoked after all scheduled [Processor] tasks have finished. The
+         * idea is that they are meant to react to changes that [Processor] tasks have triggered.
+         */
+        abstract class Listener(
+            /**
+             * In situations where [name]s can collide, it's helpful to have an additional dimension.
+             *
+             * For example: [StorageProxy]'s usage of [Scheduler] uses a handle's owning Particle's
+             * name as the [namespace].
+             */
+            val namespace: String,
+            /**
+             * The name of the [Listener].
+             *
+             * For example: [StorageProxy]'s usage of [Scheduler] uses a handle's name as the
+             * [Listener]'s [name].
+             */
+            val name: String,
+            block: () -> Unit
+        ) : Task(block)
+    }
+
+    /**
+     * Agenda of [Task]s to be executed by the [Scheduler] on a pass.
+     *
+     * The [Scheduler] should execute all [processors] before executing [listeners] on a
+     * namespace-by-namespace basis.
+     */
+    private data class Agenda(
+        /**
+         * Scheduled [Task.Processor]s.
+         */
+        val processors: List<Task.Processor> = emptyList(),
+        /**
+         * Scheduled [Task.Listener]s, collated by [Task.Listener.namespace].
+         */
+        val listenersByNamespace: ListenersByNamespace = ListenersByNamespace()
+    ) {
+        fun addTasks(tasks: Iterable<Task>): Agenda =
+            tasks.fold(this) { agenda, task -> agenda.addTask(task) }
+
+        fun addTask(task: Task): Agenda = when (task) {
+            is Task.Processor -> addProcessor(task)
+            is Task.Listener -> addListener(task)
+        }
+
+        fun addProcessor(processor: Task.Processor): Agenda =
+            copy(processors = processors + processor)
+
+        fun addListener(listener: Task.Listener): Agenda =
+            copy(listenersByNamespace = listenersByNamespace.addListener(listener))
+
+        fun isEmpty(): Boolean =
+            processors.isEmpty() && listenersByNamespace.isEmpty()
+    }
+
+    /**
+     * [Task.Listener]s, collated by [Task.Listener.namespace].
+     */
+    private data class ListenersByNamespace(
+        val listeners: Map<String, ListenersByName> = emptyMap()
+    ) {
+        fun addListener(listener: Task.Listener): ListenersByNamespace {
+            val listeners = (listeners[listener.namespace] ?: ListenersByName())
+                .addListener(listener)
+
+            return copy(listeners = this.listeners + (listener.namespace to listeners))
+        }
+
+        fun isEmpty(): Boolean = listeners.isEmpty()
+    }
+
+    /**
+     * [Task.Listener]s, collated by [Task.Listener.name].
+     */
+    private data class ListenersByName(
+        val listeners: Map<String, List<Task.Listener>> = emptyMap()
+    ) {
+        fun addListener(listener: Task.Listener): ListenersByName {
+            val resultList = (listeners[listener.name] ?: emptyList()) + listener
+            return copy(listeners = listeners + (listener.name to resultList))
+        }
+    }
+
+    companion object {
+        /**
+         * The default maximum duration each iteration of scheduled tasks' execution is allowed to
+         * take.
+         */
+        const val DEFAULT_AGENDA_PROCESSING_TIMEOUT = 5000L
+
+        /**
+         * The default maximum rate at which iterations of agenda processing are allowed to operate.
+         */
+        const val DEFAULT_SCHEDULE_RATE_HZ = 60
+    }
+}

--- a/java/arcs/core/util/testutil/LogRule.kt
+++ b/java/arcs/core/util/testutil/LogRule.kt
@@ -23,16 +23,20 @@ import org.junit.runners.model.Statement
 /** JUnit [TestRule] which prints wrappers around the log output from each test. */
 class LogRule : TestRule {
     private val taggedLog = TaggedLog { "TEST" }
+    lateinit var loggedMessages: List<String>
 
     override fun apply(base: Statement, desc: Description): Statement = object : Statement() {
         override fun evaluate() {
+            val messages = mutableListOf<String>()
+            loggedMessages = messages
+
             println()
             println("+${"-".repeat(98)}+")
             println("| Logs From ${" ".repeat(87)}|")
             println("|   ${desc.testName.padEnd(94, ' ')} |")
             println("+${"-".repeat(98)}+")
             println()
-            initLogForTest()
+            initLogForTest(messages)
             base.evaluate()
             println()
         }
@@ -45,10 +49,11 @@ class LogRule : TestRule {
 
     companion object {
         /** Initializes [Log] for tests on the JVM. */
-        private fun initLogForTest() {
+        private fun initLogForTest(collectedMessages: MutableList<String>) {
             Log.logIndex.value = 0
             Log.level = Log.Level.Debug
             Log.writer = { level, renderedMessage ->
+                collectedMessages.add(renderedMessage)
                 if (
                     level == Log.Level.Warning ||
                     level == Log.Level.Error ||

--- a/javatests/arcs/core/util/BUILD
+++ b/javatests/arcs/core/util/BUILD
@@ -21,6 +21,8 @@ arcs_kt_jvm_test_suite(
     deps = [
         "//java/arcs/core/testutil",
         "//java/arcs/core/util",
+        "//java/arcs/core/util/testutil",
+        "//java/arcs/jvm/util",
         "//third_party/java/junit:junit-android",
         "//third_party/java/truth:truth-android",
         "//third_party/kotlin/kotlinx_atomicfu",

--- a/javatests/arcs/core/util/SchedulerTest.kt
+++ b/javatests/arcs/core/util/SchedulerTest.kt
@@ -1,0 +1,244 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.core.util
+
+import arcs.core.testutil.assertSuspendingThrows
+import arcs.core.testutil.assertThrows
+import arcs.core.util.testutil.LogRule
+import arcs.jvm.util.JvmTime
+import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.Truth.assertWithMessage
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.supervisorScope
+import kotlinx.coroutines.yield
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import java.util.concurrent.Executors
+
+@RunWith(JUnit4::class)
+class SchedulerTest {
+    @get:Rule
+    val log = LogRule()
+
+    private val singleThreadDispatcher = Executors.newSingleThreadExecutor().asCoroutineDispatcher()
+
+    @Test
+    fun simpleTest() = runBlocking {
+        val scheduler = Scheduler(JvmTime, coroutineContext + singleThreadDispatcher)
+        val stateHolder = StateHolder()
+
+        val processors = (0 until 100).map {
+            createProcess(it, stateHolder)
+        }
+        val listeners = (0 until 100).map {
+            createListener(it, "foo", "FooListener", stateHolder)
+        }
+
+        scheduler.schedule(processors + listeners)
+        scheduler.waitForIdle()
+
+
+        assertThat(scheduler.launches.value).isEqualTo(1)
+        assertThat(scheduler.loops.value).isEqualTo(1)
+
+        assertWithMessage("Agenda runs Processors then Listeners, where each batch is in-order.")
+            .that(stateHolder.calls)
+            .containsExactlyElementsIn(
+                (0 until 100).map { it to "Processor" } +
+                    (0 until 100).map { it to "Listener(foo, FooListener)" }
+            )
+            .inOrder()
+    }
+
+    @Test
+    fun schedulingWhileProcessing_triggersAnotherLoop_notAnotherLaunch() = runBlocking {
+        val scheduler = Scheduler(JvmTime, coroutineContext + singleThreadDispatcher)
+        val stateHolder = StateHolder()
+
+        val longProcessor = TestProcessor {
+            Thread.sleep(300)
+            stateHolder.calls += 0 to "LongSleep"
+        }
+
+        val followupProcessor = TestProcessor {
+            stateHolder.calls += 1 to "Followup"
+        }
+
+        scheduler.schedule(longProcessor)
+        Thread.sleep(100) // let the first one start.
+        scheduler.schedule(followupProcessor)
+
+        scheduler.waitForIdle()
+
+        assertWithMessage("There should be only one coroutine launch")
+            .that(scheduler.launches.value)
+            .isEqualTo(1)
+        assertWithMessage("The coroutine launch should've looped twice")
+            .that(scheduler.loops.value)
+            .isEqualTo(2)
+        assertThat(stateHolder.calls)
+            .containsExactly(
+                0 to "LongSleep",
+                1 to "Followup"
+            )
+            .inOrder()
+    }
+
+    @Test
+    fun tasks_schedulingOtherTasks_dontDeadlock() = runBlocking {
+        val scheduler = Scheduler(JvmTime, coroutineContext + singleThreadDispatcher)
+        val stateHolder = StateHolder()
+
+        val processorsToCreate = 10
+        var processorsLeftToCreate = processorsToCreate
+        fun createProcessor(): TestProcessor {
+            return TestProcessor {
+                stateHolder.calls.add(processorsToCreate to "Generator")
+
+                processorsLeftToCreate--
+                if (processorsLeftToCreate > 0) {
+                    scheduler.schedule(createProcessor())
+                }
+            }
+        }
+
+        scheduler.schedule(createProcessor())
+        yield()
+        scheduler.waitForIdle()
+
+        assertWithMessage("There should only be one coroutine launch")
+            .that(scheduler.launches.value)
+            .isEqualTo(1)
+        assertWithMessage("There should have been a loop for each processor")
+            .that(scheduler.loops.value)
+            .isEqualTo(processorsToCreate)
+        assertThat(processorsLeftToCreate).isEqualTo(0)
+        assertThat(stateHolder.calls).hasSize(processorsToCreate)
+    }
+
+    @Test
+    fun tasks_canTimeout() = runBlocking<Unit> {
+        val scheduler = Scheduler(
+            JvmTime,
+            coroutineContext + singleThreadDispatcher,
+            agendaProcessingTimeout = 100
+        )
+
+        scheduler.schedule(
+            TestProcessor {
+                log("Starting to sleep")
+                Thread.sleep(200)
+                log("Done sleeping")
+            }
+        )
+        scheduler.waitForIdle()
+
+        assertThat(log.loggedMessages.joinToString("\n"))
+            .contains("Scheduled tasks timed out")
+    }
+
+    @Test
+    fun pause_pausesExecution_resume_resumesExecution() = runBlocking {
+        val scheduler = Scheduler(JvmTime, coroutineContext + singleThreadDispatcher)
+
+        var firstCalled = false
+        var secondCalled = false
+
+        val first = TestProcessor {
+            firstCalled = true
+            scheduler.pause()
+        }
+        val second = TestProcessor {
+            secondCalled = true
+        }
+
+        scheduler.schedule(first)
+        Thread.sleep(50) // Just to ensure that we launched the agenda-processing coroutine
+        // At this point, the scheduler should be paused, so `second` shouldn't get run.
+        scheduler.schedule(second)
+        scheduler.waitForIdle()
+
+        assertWithMessage("First should've been called")
+            .that(firstCalled).isTrue()
+        assertWithMessage("Second shouldn't have been called")
+            .that(secondCalled).isFalse()
+
+        // Now let's resume.
+        scheduler.resume()
+        scheduler.waitForIdle()
+
+        assertWithMessage("Second should have been called after resume")
+            .that(secondCalled).isTrue()
+    }
+
+    @Test
+    fun executesListenersByNamespaceAndName() = runBlocking {
+        val scheduler = Scheduler(JvmTime, coroutineContext + singleThreadDispatcher)
+        val stateHolder = StateHolder()
+
+        val firstNamespace = listOf(
+            createListener(0, "a", "A", stateHolder),
+            createListener(1, "a", "B", stateHolder),
+            createListener(2, "a", "C", stateHolder)
+        )
+
+        val secondNamespace = listOf(
+            createListener(0, "b", "A", stateHolder),
+            createListener(1, "b", "B", stateHolder),
+            createListener(2, "b", "C", stateHolder)
+        )
+
+        scheduler.schedule(firstNamespace + secondNamespace)
+        scheduler.waitForIdle()
+
+        assertWithMessage("all namespace'd listeners should be called together")
+            .that(stateHolder.calls)
+            .containsExactly(
+                0 to "Listener(a, A)",
+                1 to "Listener(a, B)",
+                2 to "Listener(a, C)",
+                0 to "Listener(b, A)",
+                1 to "Listener(b, B)",
+                2 to "Listener(b, C)"
+            )
+            .inOrder()
+    }
+
+    private fun createProcess(index: Int, stateHolder: StateHolder): Scheduler.Task =
+        TestProcessor {
+            stateHolder.calls.add(index to "Processor")
+        }
+
+    private fun createListener(
+        index: Int,
+        namespace: String,
+        name: String,
+        stateHolder: StateHolder
+    ): Scheduler.Task = TestListener(namespace, name) {
+        stateHolder.calls.add(index to "Listener($namespace, $name)")
+    }
+
+    private class StateHolder(
+        val calls: MutableList<Pair<Int, String>> = mutableListOf()
+    )
+
+    private class TestProcessor(block: () -> Unit) : Scheduler.Task.Processor(block)
+    private class TestListener(
+        namespace: String,
+        name: String,
+        block: () -> Unit
+    ) : Scheduler.Task.Listener(namespace, name, block)
+}

--- a/javatests/arcs/core/util/SchedulerTest.kt
+++ b/javatests/arcs/core/util/SchedulerTest.kt
@@ -50,7 +50,6 @@ class SchedulerTest {
         scheduler.schedule(processors + listeners)
         scheduler.waitForIdle()
 
-
         assertThat(scheduler.launches.value).isEqualTo(1)
         assertThat(scheduler.loops.value).isEqualTo(1)
 
@@ -134,7 +133,7 @@ class SchedulerTest {
         val scheduler = Scheduler(
             JvmTime,
             coroutineContext + singleThreadDispatcher,
-            agendaProcessingTimeout = 100
+            agendaProcessingTimeoutMs = 100
         )
 
         var firstProcRan = true


### PR DESCRIPTION
Creates a kotlin version of the Scheduler. This scheduler is more generic than what is used by TypeScript, but it's functionally similar. Also - this scheduler can schedule two classes of tasks: Processors and Listeners.

Processors will be responsible for mutating the storage proxy's local model in response to a change from the store, while Listeners will be... well... Handle listeners.

Listeners are collated by namespace and name, where for the StorageProxy usage of Schduler: `namespace` is equivalent to Particle name, and `name` is the Handle's name.