### PR TITLE
Add targetId to resurrection registrations

### DIFF
--- a/java/arcs/android/common/resurrection/DbHelper.kt
+++ b/java/arcs/android/common/resurrection/DbHelper.kt
@@ -192,7 +192,11 @@ class DbHelper(
                 val notifierId = it.getString(5)
 
                 ResurrectionRequest(
-                    componentName, type, action, extras?.deepCopy(), notifierId,
+                    componentName,
+                    type,
+                    action,
+                    extras?.deepCopy(),
+                    notifierId,
                     notifiersByComponentName[RequestedNotifier(notifierId, componentName)]
                         ?: emptyList()
                 )

--- a/java/arcs/android/common/resurrection/ResurrectionRequest.kt
+++ b/java/arcs/android/common/resurrection/ResurrectionRequest.kt
@@ -153,11 +153,16 @@ data class ResurrectionRequest(
             notifierId: String
         ): ResurrectionRequest {
             return ResurrectionRequest(
-                ComponentName(context, context::class.java), when (context) {
+                ComponentName(context, context::class.java),
+                when (context) {
                     is Service -> ComponentType.Service
                     is Activity -> ComponentType.Activity
                     else -> ComponentType.Service
-                }, ACTION_RESURRECT, null, notifierId, resurrectOn
+                },
+                ACTION_RESURRECT,
+                null,
+                notifierId,
+                resurrectOn
             )
         }
 
@@ -183,9 +188,12 @@ data class ResurrectionRequest(
             } catch (e: IllegalArgumentException) { return null }
 
             return ResurrectionRequest(
-                ComponentName(packageName, className), componentType,
+                ComponentName(packageName, className),
+                componentType,
                 extras.getString(EXTRA_REGISTRATION_ACTION),
-                extras.getParcelable(EXTRA_REGISTRATION_EXTRAS), notifierId, notifiers
+                extras.getParcelable(EXTRA_REGISTRATION_EXTRAS),
+                notifierId,
+                notifiers
             )
         }
 

--- a/java/arcs/android/common/resurrection/ResurrectionRequest.kt
+++ b/java/arcs/android/common/resurrection/ResurrectionRequest.kt
@@ -33,9 +33,9 @@ data class ResurrectionRequest(
     /**
      * A string, which along with [componentName], uniquely identifies this request. When
      * clients are resurrected, the client receives a set of [StorageKeys] supplied in
-     * [notifyOn] along with the [notifierId] used to create the request.
+     * [notifyOn] along with the [targetId] used to create the request.
      */
-    val notifierId: String,
+    val targetId: String,
     /**
      * [StorageKey]s the requesting component is interested in being resurrected in response to
      * changes.
@@ -61,7 +61,7 @@ data class ResurrectionRequest(
                 EXTRA_REGISTRATION_NOTIFIERS,
                 ArrayList(notifyOn.map(StorageKey::toString))
             )
-            putExtra(EXTRA_REGISTRATION_NOTIFIER_ID, notifierId)
+            putExtra(EXTRA_REGISTRATION_TARGET_ID, targetId)
         }
     }
 
@@ -73,7 +73,7 @@ data class ResurrectionRequest(
             action = ACTION_REQUEST_NO_RESURRECTION
             putExtra(EXTRA_REGISTRATION_PACKAGE_NAME, componentName.packageName)
             putExtra(EXTRA_REGISTRATION_CLASS_NAME, componentName.className)
-            putExtra(EXTRA_REGISTRATION_NOTIFIER_ID, notifierId)
+            putExtra(EXTRA_REGISTRATION_TARGET_ID, targetId)
         }
     }
 
@@ -111,7 +111,7 @@ data class ResurrectionRequest(
         "ResurrectionRequest(" +
             "componentName=$componentName, componentType=$componentType, " +
             "intentAction=$intentAction, intentExtras=${intentExtras?.keySet()?.toSet()}, " +
-            "notifyOn=$notifyOn notifierId=$notifierId)"
+            "notifyOn=$notifyOn targetId=$targetId)"
 
     /**
      * Type of client requesting resurrection.
@@ -124,10 +124,10 @@ data class ResurrectionRequest(
     }
 
     /**
-     * A request to unregister [componentName] with associated [notifierId] from the resurrection
+     * A request to unregister [componentName] with associated [targetId] from the resurrection
      * service.
      */
-    data class UnregisterRequest(val componentName: ComponentName, val notifierId: String)
+    data class UnregisterRequest(val componentName: ComponentName, val targetId: String)
 
     companion object {
         const val ACTION_RESURRECT = "arcs.android.common.resurrection.TIME_TO_WAKEUP"
@@ -140,8 +140,8 @@ data class ResurrectionRequest(
         const val EXTRA_REGISTRATION_COMPONENT_TYPE = "registration_intent_component_type"
         const val EXTRA_REGISTRATION_ACTION = "registration_intent_action"
         const val EXTRA_REGISTRATION_EXTRAS = "registration_intent_extras"
-        const val EXTRA_REGISTRATION_NOTIFIER_ID = "registration_notifier_id"
         const val EXTRA_REGISTRATION_NOTIFIERS = "registration_notifiers"
+        const val EXTRA_REGISTRATION_TARGET_ID = "registration_target_id"
 
         /**
          * Creates a [ResurrectionRequest] for the component defined by the given [context] when the
@@ -150,7 +150,7 @@ data class ResurrectionRequest(
         fun createDefault(
             context: Context,
             resurrectOn: List<StorageKey>,
-            notifierId: String
+            targetId: String
         ): ResurrectionRequest {
             return ResurrectionRequest(
                 ComponentName(context, context::class.java),
@@ -161,7 +161,7 @@ data class ResurrectionRequest(
                 },
                 ACTION_RESURRECT,
                 null,
-                notifierId,
+                targetId,
                 resurrectOn
             )
         }
@@ -181,7 +181,7 @@ data class ResurrectionRequest(
                 ?: return null
             val notifiers = extras.getStringArrayList(EXTRA_REGISTRATION_NOTIFIERS)
                 ?.map { StorageKeyParser.parse(it) } ?: emptyList()
-            val notifierId = extras.getString(EXTRA_REGISTRATION_NOTIFIER_ID) ?: return null
+            val targetId = extras.getString(EXTRA_REGISTRATION_TARGET_ID) ?: return null
 
             val componentType = try {
                 ComponentType.valueOf(componentTypeName)
@@ -192,7 +192,7 @@ data class ResurrectionRequest(
                 componentType,
                 extras.getString(EXTRA_REGISTRATION_ACTION),
                 extras.getParcelable(EXTRA_REGISTRATION_EXTRAS),
-                notifierId,
+                targetId,
                 notifiers
             )
         }
@@ -208,9 +208,9 @@ data class ResurrectionRequest(
             val extras = intent.extras ?: return null
             val packageName = extras.getString(EXTRA_REGISTRATION_PACKAGE_NAME) ?: return null
             val className = extras.getString(EXTRA_REGISTRATION_CLASS_NAME) ?: return null
-            val notifierId = extras.getString(EXTRA_REGISTRATION_NOTIFIER_ID) ?: return null
+            val targetId = extras.getString(EXTRA_REGISTRATION_TARGET_ID) ?: return null
 
-            return UnregisterRequest(ComponentName(packageName, className), notifierId)
+            return UnregisterRequest(ComponentName(packageName, className), targetId)
         }
     }
 }

--- a/java/arcs/android/common/resurrection/ResurrectorService.kt
+++ b/java/arcs/android/common/resurrection/ResurrectorService.kt
@@ -168,7 +168,7 @@ abstract class ResurrectorService : Service() {
     }
 
     private fun CoroutineScope.unregisterRequest(unregisterRequest: UnregisterRequest) = launch {
-        dbHelper.unregisterRequest(unregisterRequest.componentName, unregisterRequest.notifierId)
+        dbHelper.unregisterRequest(unregisterRequest.componentName, unregisterRequest.targetId)
         loadRequests().join()
     }
 
@@ -192,7 +192,7 @@ abstract class ResurrectorService : Service() {
             ArrayList(events.toSet().map(StorageKey::toString))
         )
 
-        intent.putExtra(ResurrectionRequest.EXTRA_REGISTRATION_NOTIFIER_ID, this.notifierId)
+        intent.putExtra(ResurrectionRequest.EXTRA_REGISTRATION_TARGET_ID, this.targetId)
 
         when (this.componentType) {
             ResurrectionRequest.ComponentType.Activity -> startActivity(intent)

--- a/java/arcs/sdk/android/storage/ResurrectionHelper.kt
+++ b/java/arcs/sdk/android/storage/ResurrectionHelper.kt
@@ -56,7 +56,7 @@ import arcs.sdk.android.storage.service.StorageService
  */
 class ResurrectionHelper(
     private val context: Context,
-    private val onResurrected: (id: String, List<StorageKey>) -> Unit
+    private val onResurrected: (notifierId: String, List<StorageKey>) -> Unit
 ) {
     /**
      * Determines whether or not the given [intent] represents a resurrection, and if it does:

--- a/java/arcs/sdk/android/storage/ResurrectionHelper.kt
+++ b/java/arcs/sdk/android/storage/ResurrectionHelper.kt
@@ -56,7 +56,7 @@ import arcs.sdk.android.storage.service.StorageService
  */
 class ResurrectionHelper(
     private val context: Context,
-    private val onResurrected: (notifierId: String, List<StorageKey>) -> Unit
+    private val onResurrected: (targetId: String, List<StorageKey>) -> Unit
 ) {
     /**
      * Determines whether or not the given [intent] represents a resurrection, and if it does:
@@ -65,30 +65,30 @@ class ResurrectionHelper(
     fun onStartCommand(intent: Intent?) {
         if (intent?.action?.startsWith(ResurrectionRequest.ACTION_RESURRECT) != true) return
 
-        val notifierId =
-            intent.getStringExtra(ResurrectionRequest.EXTRA_REGISTRATION_NOTIFIER_ID) ?: return
+        val targetId =
+            intent.getStringExtra(ResurrectionRequest.EXTRA_REGISTRATION_TARGET_ID) ?: return
         val notifiers = intent.getStringArrayListExtra(
             ResurrectionRequest.EXTRA_RESURRECT_NOTIFIER
         ) ?: return
 
-        onResurrected(notifierId, notifiers.map(StorageKeyParser::parse))
+        onResurrected(targetId, notifiers.map(StorageKeyParser::parse))
     }
 
     /**
      * Issue a request to be resurrected by the [StorageService] whenever the data identified by
      * the provided [keys] changes.
      *
-     * **Note:** This will overwrite any previous request with the same [notifierId].
+     * **Note:** This will overwrite any previous request with the same [targetId].
      * In other words, [keys] should be an exhaustive list of the [StorageKey]s the caller is
      * interested in.
      */
     fun requestResurrection(
-        notifierId: String,
+        targetId: String,
         keys: List<StorageKey>,
         serviceClass: Class<out Service> = StorageService::class.java
     ) {
         val intent = Intent(context, serviceClass)
-        val request = ResurrectionRequest.createDefault(context, keys, notifierId)
+        val request = ResurrectionRequest.createDefault(context, keys, targetId)
         request.populateRequestIntent(intent)
         context.startService(intent)
     }
@@ -97,11 +97,11 @@ class ResurrectionHelper(
      * Issue a request to cancel any outstanding request for resurrection from the [StorageService].
      */
     fun cancelResurrectionRequest(
-        notifierId: String,
+        targetId: String,
         serviceClass: Class<out Service> = StorageService::class.java
     ) {
         val intent = Intent(context, serviceClass)
-        val request = ResurrectionRequest.createDefault(context, emptyList(), notifierId)
+        val request = ResurrectionRequest.createDefault(context, emptyList(), targetId)
         request.populateUnrequestIntent(intent)
         context.startService(intent)
     }

--- a/javatests/arcs/android/common/resurrection/DbHelperTest.kt
+++ b/javatests/arcs/android/common/resurrection/DbHelperTest.kt
@@ -29,7 +29,9 @@ class DbHelperTest {
         ComponentName("a", "A"),
         ResurrectionRequest.ComponentType.Service,
         ResurrectionRequest.ACTION_RESURRECT,
-        null
+        null,
+        emptyList(),
+        "requestA"
     )
     private val requestB = ResurrectionRequest(
         ComponentName("b", "B"),
@@ -41,7 +43,8 @@ class DbHelperTest {
         },
         listOf(
             RamDiskStorageKey("bThing")
-        )
+        ),
+        "requestB"
     )
     private val requestC = ResurrectionRequest(
         ComponentName("c", "C"),
@@ -52,7 +55,8 @@ class DbHelperTest {
             RamDiskStorageKey("bThing"),
             RamDiskStorageKey("cThing"),
             RamDiskStorageKey("somethingElse")
-        )
+        ),
+        "requestC"
     )
 
     @Before
@@ -83,7 +87,7 @@ class DbHelperTest {
         dbHelper.registerRequest(requestB)
         dbHelper.registerRequest(requestC)
 
-        dbHelper.unregisterRequest(requestB.componentName)
+        dbHelper.unregisterRequest(requestB.componentName, "requestB")
 
         assertThat(dbHelper.getRegistrations()).containsExactly(requestA, requestC)
     }

--- a/javatests/arcs/android/common/resurrection/DbHelperTest.kt
+++ b/javatests/arcs/android/common/resurrection/DbHelperTest.kt
@@ -26,37 +26,25 @@ import org.junit.runner.RunWith
 class DbHelperTest {
     private lateinit var dbHelper: DbHelper
     private val requestA = ResurrectionRequest(
-        ComponentName("a", "A"),
-        ResurrectionRequest.ComponentType.Service,
-        ResurrectionRequest.ACTION_RESURRECT,
-        null,
-        emptyList(),
-        "requestA"
+        ComponentName("a", "A"), ResurrectionRequest.ComponentType.Service,
+        ResurrectionRequest.ACTION_RESURRECT, null, "requestA", emptyList()
     )
     private val requestB = ResurrectionRequest(
-        ComponentName("b", "B"),
-        ResurrectionRequest.ComponentType.Activity,
-        "StartMeUp",
+        ComponentName("b", "B"), ResurrectionRequest.ComponentType.Activity, "StartMeUp",
         PersistableBundle().apply {
             putBoolean("foo", true)
             putInt("bar", 1)
-        },
-        listOf(
+        }, "requestB", listOf(
             RamDiskStorageKey("bThing")
-        ),
-        "requestB"
+        )
     )
     private val requestC = ResurrectionRequest(
-        ComponentName("c", "C"),
-        ResurrectionRequest.ComponentType.Activity,
-        ResurrectionRequest.ACTION_RESURRECT,
-        PersistableBundle.EMPTY,
-        listOf(
+        ComponentName("c", "C"), ResurrectionRequest.ComponentType.Activity,
+        ResurrectionRequest.ACTION_RESURRECT, PersistableBundle.EMPTY, "requestC", listOf(
             RamDiskStorageKey("bThing"),
             RamDiskStorageKey("cThing"),
             RamDiskStorageKey("somethingElse")
-        ),
-        "requestC"
+        )
     )
 
     @Before

--- a/javatests/arcs/android/common/resurrection/ResurrectionRequestTest.kt
+++ b/javatests/arcs/android/common/resurrection/ResurrectionRequestTest.kt
@@ -16,6 +16,7 @@ import android.content.Intent
 import android.os.PersistableBundle
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.ActivityTestRule
+import arcs.android.common.resurrection.ResurrectionRequest.UnregisterRequest
 import arcs.core.storage.StorageKey
 import arcs.core.storage.keys.RamDiskStorageKey
 import arcs.core.testutil.fail
@@ -38,6 +39,7 @@ class ResurrectionRequestTest {
         assertThat(request.intentAction).isEqualTo(ResurrectionRequest.ACTION_RESURRECT)
         assertThat(request.intentExtras).isNull()
         assertThat(request.notifyOn).isEmpty()
+        assertThat(request.notifierId).isEqualTo("test")
     }
 
     @Test
@@ -54,6 +56,7 @@ class ResurrectionRequestTest {
             action = ResurrectionRequest.ACTION_REQUEST_RESURRECTION
             putExtra(ResurrectionRequest.EXTRA_REGISTRATION_PACKAGE_NAME, "com.google.test")
             putExtra(ResurrectionRequest.EXTRA_REGISTRATION_CLASS_NAME, "MyService")
+            putExtra(ResurrectionRequest.EXTRA_REGISTRATION_NOTIFIER_ID, "test")
             putExtra(
                 ResurrectionRequest.EXTRA_REGISTRATION_COMPONENT_TYPE,
                 ResurrectionRequest.ComponentType.Service.name
@@ -75,6 +78,7 @@ class ResurrectionRequestTest {
         assertThat(actual.intentExtras?.getBoolean("foo")).isTrue()
         assertThat(actual.intentExtras?.getString("bar")).isEqualTo("hello")
         assertThat(actual.notifyOn).containsExactlyElementsIn(keys)
+        assertThat(actual.notifierId).isEqualTo("test")
     }
 
     @Test
@@ -206,9 +210,10 @@ class ResurrectionRequestTest {
             action = ResurrectionRequest.ACTION_REQUEST_NO_RESURRECTION
             putExtra(ResurrectionRequest.EXTRA_REGISTRATION_PACKAGE_NAME, "com.google.test")
             putExtra(ResurrectionRequest.EXTRA_REGISTRATION_CLASS_NAME, "MyService")
+            putExtra(ResurrectionRequest.EXTRA_REGISTRATION_NOTIFIER_ID, "test")
         }
         assertThat(ResurrectionRequest.unregisterRequestFromUnrequestIntent(intent))
-            .isEqualTo(ComponentName("com.google.test", "MyService"))
+            .isEqualTo(UnregisterRequest(ComponentName("com.google.test", "MyService"), "test"))
     }
 
     @Test
@@ -217,8 +222,10 @@ class ResurrectionRequestTest {
         val intent = Intent()
         request.populateUnrequestIntent(intent)
 
-        val componentName = ResurrectionRequest.unregisterRequestFromUnrequestIntent(intent)
+        val unregisterRequest = ResurrectionRequest.unregisterRequestFromUnrequestIntent(intent)
 
-        assertThat(componentName).isEqualTo(request.componentName)
+        assertThat(unregisterRequest?.componentName).isEqualTo(request.componentName)
+        assertThat(unregisterRequest?.notifierId).isEqualTo("test")
+
     }
 }

--- a/javatests/arcs/android/common/resurrection/ResurrectionRequestTest.kt
+++ b/javatests/arcs/android/common/resurrection/ResurrectionRequestTest.kt
@@ -39,7 +39,7 @@ class ResurrectionRequestTest {
         assertThat(request.intentAction).isEqualTo(ResurrectionRequest.ACTION_RESURRECT)
         assertThat(request.intentExtras).isNull()
         assertThat(request.notifyOn).isEmpty()
-        assertThat(request.notifierId).isEqualTo("test")
+        assertThat(request.targetId).isEqualTo("test")
     }
 
     @Test
@@ -56,7 +56,7 @@ class ResurrectionRequestTest {
             action = ResurrectionRequest.ACTION_REQUEST_RESURRECTION
             putExtra(ResurrectionRequest.EXTRA_REGISTRATION_PACKAGE_NAME, "com.google.test")
             putExtra(ResurrectionRequest.EXTRA_REGISTRATION_CLASS_NAME, "MyService")
-            putExtra(ResurrectionRequest.EXTRA_REGISTRATION_NOTIFIER_ID, "test")
+            putExtra(ResurrectionRequest.EXTRA_REGISTRATION_TARGET_ID, "test")
             putExtra(
                 ResurrectionRequest.EXTRA_REGISTRATION_COMPONENT_TYPE,
                 ResurrectionRequest.ComponentType.Service.name
@@ -78,7 +78,7 @@ class ResurrectionRequestTest {
         assertThat(actual.intentExtras?.getBoolean("foo")).isTrue()
         assertThat(actual.intentExtras?.getString("bar")).isEqualTo("hello")
         assertThat(actual.notifyOn).containsExactlyElementsIn(keys)
-        assertThat(actual.notifierId).isEqualTo("test")
+        assertThat(actual.targetId).isEqualTo("test")
     }
 
     @Test
@@ -210,7 +210,7 @@ class ResurrectionRequestTest {
             action = ResurrectionRequest.ACTION_REQUEST_NO_RESURRECTION
             putExtra(ResurrectionRequest.EXTRA_REGISTRATION_PACKAGE_NAME, "com.google.test")
             putExtra(ResurrectionRequest.EXTRA_REGISTRATION_CLASS_NAME, "MyService")
-            putExtra(ResurrectionRequest.EXTRA_REGISTRATION_NOTIFIER_ID, "test")
+            putExtra(ResurrectionRequest.EXTRA_REGISTRATION_TARGET_ID, "test")
         }
         assertThat(ResurrectionRequest.unregisterRequestFromUnrequestIntent(intent))
             .isEqualTo(UnregisterRequest(ComponentName("com.google.test", "MyService"), "test"))
@@ -225,7 +225,7 @@ class ResurrectionRequestTest {
         val unregisterRequest = ResurrectionRequest.unregisterRequestFromUnrequestIntent(intent)
 
         assertThat(unregisterRequest?.componentName).isEqualTo(request.componentName)
-        assertThat(unregisterRequest?.notifierId).isEqualTo("test")
+        assertThat(unregisterRequest?.targetId).isEqualTo("test")
 
     }
 }

--- a/javatests/arcs/android/common/resurrection/ResurrectionRequestTest.kt
+++ b/javatests/arcs/android/common/resurrection/ResurrectionRequestTest.kt
@@ -31,7 +31,7 @@ class ResurrectionRequestTest {
 
     @Test
     fun createDefault() {
-        val request = ResurrectionRequest.createDefault(activity.activity, emptyList())
+        val request = ResurrectionRequest.createDefault(activity.activity, emptyList(), "test")
 
         assertThat(request.componentName).isEqualTo(activity.activity.componentName)
         assertThat(request.componentType).isEqualTo(ResurrectionRequest.ComponentType.Activity)
@@ -83,7 +83,7 @@ class ResurrectionRequestTest {
             RamDiskStorageKey("blah"),
             RamDiskStorageKey("bleh")
         )
-        val request = ResurrectionRequest.createDefault(activity.activity, keys)
+        val request = ResurrectionRequest.createDefault(activity.activity, keys, "test")
         val intent = Intent().also(request::populateRequestIntent)
         val actual = ResurrectionRequest.createFromIntent(intent)
 
@@ -171,7 +171,7 @@ class ResurrectionRequestTest {
             putExtra(ResurrectionRequest.EXTRA_REGISTRATION_PACKAGE_NAME, "com.google.test")
             putExtra(ResurrectionRequest.EXTRA_REGISTRATION_CLASS_NAME, "MyService")
         }
-        assertThat(ResurrectionRequest.componentNameFromUnrequestIntent(intent)).isNull()
+        assertThat(ResurrectionRequest.unregisterRequestFromUnrequestIntent(intent)).isNull()
     }
 
     @Test
@@ -179,7 +179,7 @@ class ResurrectionRequestTest {
         val intent = Intent().apply {
             action = ResurrectionRequest.ACTION_REQUEST_NO_RESURRECTION
         }
-        assertThat(ResurrectionRequest.componentNameFromUnrequestIntent(intent)).isNull()
+        assertThat(ResurrectionRequest.unregisterRequestFromUnrequestIntent(intent)).isNull()
     }
 
     @Test
@@ -188,7 +188,7 @@ class ResurrectionRequestTest {
             action = ResurrectionRequest.ACTION_REQUEST_NO_RESURRECTION
             putExtra(ResurrectionRequest.EXTRA_REGISTRATION_CLASS_NAME, "MyService")
         }
-        assertThat(ResurrectionRequest.componentNameFromUnrequestIntent(intent)).isNull()
+        assertThat(ResurrectionRequest.unregisterRequestFromUnrequestIntent(intent)).isNull()
     }
 
     @Test
@@ -197,7 +197,7 @@ class ResurrectionRequestTest {
             action = ResurrectionRequest.ACTION_REQUEST_NO_RESURRECTION
             putExtra(ResurrectionRequest.EXTRA_REGISTRATION_PACKAGE_NAME, "com.google.test")
         }
-        assertThat(ResurrectionRequest.componentNameFromUnrequestIntent(intent)).isNull()
+        assertThat(ResurrectionRequest.unregisterRequestFromUnrequestIntent(intent)).isNull()
     }
 
     @Test
@@ -207,17 +207,17 @@ class ResurrectionRequestTest {
             putExtra(ResurrectionRequest.EXTRA_REGISTRATION_PACKAGE_NAME, "com.google.test")
             putExtra(ResurrectionRequest.EXTRA_REGISTRATION_CLASS_NAME, "MyService")
         }
-        assertThat(ResurrectionRequest.componentNameFromUnrequestIntent(intent))
+        assertThat(ResurrectionRequest.unregisterRequestFromUnrequestIntent(intent))
             .isEqualTo(ComponentName("com.google.test", "MyService"))
     }
 
     @Test
     fun populateRequestIntent() {
-        val request = ResurrectionRequest.createDefault(activity.activity, emptyList())
+        val request = ResurrectionRequest.createDefault(activity.activity, emptyList(), "test")
         val intent = Intent()
         request.populateUnrequestIntent(intent)
 
-        val componentName = ResurrectionRequest.componentNameFromUnrequestIntent(intent)
+        val componentName = ResurrectionRequest.unregisterRequestFromUnrequestIntent(intent)
 
         assertThat(componentName).isEqualTo(request.componentName)
     }

--- a/javatests/arcs/android/common/resurrection/ResurrectorServiceTest.kt
+++ b/javatests/arcs/android/common/resurrection/ResurrectorServiceTest.kt
@@ -18,6 +18,7 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import arcs.android.common.resurrection.ResurrectionRequest.Companion.ACTION_RESURRECT
 import arcs.android.common.resurrection.ResurrectionRequest.Companion.EXTRA_RESURRECT_NOTIFIER
+import arcs.android.common.resurrection.ResurrectionRequest.Companion.EXTRA_REGISTRATION_NOTIFIER_ID
 import arcs.core.storage.keys.RamDiskStorageKey
 import com.google.common.truth.Truth.assertThat
 import java.io.PrintWriter
@@ -43,7 +44,7 @@ class ResurrectorServiceTest {
     @Before
     fun setUp() {
         context = ApplicationProvider.getApplicationContext<Application>()
-        resurrectionRequest = ResurrectionRequest.createDefault(context, storageKeys)
+        resurrectionRequest = ResurrectionRequest.createDefault(context, storageKeys, "test")
         resurrectionRequestIntent = Intent(context, ResurrectorServiceImpl::class.java)
             .apply(resurrectionRequest::populateRequestIntent)
     }
@@ -59,6 +60,8 @@ class ResurrectorServiceTest {
         assertThat(resurrectIntent.action).isEqualTo(ACTION_RESURRECT)
         assertThat(resurrectIntent.getStringArrayListExtra(EXTRA_RESURRECT_NOTIFIER))
             .containsExactly(storageKeys[0].toString())
+        assertThat(resurrectIntent.getStringExtra(EXTRA_REGISTRATION_NOTIFIER_ID))
+            .isEqualTo("test")
     }
 
     @Test

--- a/javatests/arcs/android/common/resurrection/ResurrectorServiceTest.kt
+++ b/javatests/arcs/android/common/resurrection/ResurrectorServiceTest.kt
@@ -18,7 +18,7 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import arcs.android.common.resurrection.ResurrectionRequest.Companion.ACTION_RESURRECT
 import arcs.android.common.resurrection.ResurrectionRequest.Companion.EXTRA_RESURRECT_NOTIFIER
-import arcs.android.common.resurrection.ResurrectionRequest.Companion.EXTRA_REGISTRATION_NOTIFIER_ID
+import arcs.android.common.resurrection.ResurrectionRequest.Companion.EXTRA_REGISTRATION_TARGET_ID
 import arcs.core.storage.keys.RamDiskStorageKey
 import com.google.common.truth.Truth.assertThat
 import java.io.PrintWriter
@@ -60,7 +60,7 @@ class ResurrectorServiceTest {
         assertThat(resurrectIntent.action).isEqualTo(ACTION_RESURRECT)
         assertThat(resurrectIntent.getStringArrayListExtra(EXTRA_RESURRECT_NOTIFIER))
             .containsExactly(storageKeys[0].toString())
-        assertThat(resurrectIntent.getStringExtra(EXTRA_REGISTRATION_NOTIFIER_ID))
+        assertThat(resurrectIntent.getStringExtra(EXTRA_REGISTRATION_TARGET_ID))
             .isEqualTo("test")
     }
 

--- a/javatests/arcs/sdk/android/storage/ResurrectionHelperTest.kt
+++ b/javatests/arcs/sdk/android/storage/ResurrectionHelperTest.kt
@@ -20,7 +20,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import arcs.android.common.resurrection.ResurrectionRequest
 import arcs.android.common.resurrection.ResurrectionRequest.Companion.EXTRA_REGISTRATION_CLASS_NAME
 import arcs.android.common.resurrection.ResurrectionRequest.Companion.EXTRA_REGISTRATION_NOTIFIERS
-import arcs.android.common.resurrection.ResurrectionRequest.Companion.EXTRA_REGISTRATION_NOTIFIER_ID
+import arcs.android.common.resurrection.ResurrectionRequest.Companion.EXTRA_REGISTRATION_TARGET_ID
 import arcs.android.common.resurrection.ResurrectionRequest.Companion.EXTRA_REGISTRATION_PACKAGE_NAME
 import arcs.core.storage.StorageKey
 import arcs.core.storage.keys.RamDiskStorageKey
@@ -85,7 +85,7 @@ class ResurrectionHelperTest {
                 ResurrectionRequest.EXTRA_RESURRECT_NOTIFIER,
                 ArrayList(storageKeys.map(StorageKey::toString))
             )
-            putExtra(ResurrectionRequest.EXTRA_REGISTRATION_NOTIFIER_ID, "test")
+            putExtra(ResurrectionRequest.EXTRA_REGISTRATION_TARGET_ID, "test")
         }
 
         helper.onStartCommand(intent)
@@ -116,7 +116,7 @@ class ResurrectionHelperTest {
             .containsExactlyElementsIn(
                 expectedIntent.getStringArrayListExtra(EXTRA_REGISTRATION_NOTIFIERS)
             )
-        assertThat(actualIntent.getStringExtra(EXTRA_REGISTRATION_NOTIFIER_ID)).isEqualTo("test")
+        assertThat(actualIntent.getStringExtra(EXTRA_REGISTRATION_TARGET_ID)).isEqualTo("test")
     }
 
     @Test
@@ -135,6 +135,6 @@ class ResurrectionHelperTest {
             .isEqualTo(expectedIntent.getStringExtra(EXTRA_REGISTRATION_PACKAGE_NAME))
         assertThat(actualIntent.getStringExtra(EXTRA_REGISTRATION_CLASS_NAME))
             .isEqualTo(expectedIntent.getStringExtra(EXTRA_REGISTRATION_CLASS_NAME))
-        assertThat(actualIntent.getStringExtra(EXTRA_REGISTRATION_NOTIFIER_ID)).isEqualTo("test")
+        assertThat(actualIntent.getStringExtra(EXTRA_REGISTRATION_TARGET_ID)).isEqualTo("test")
     }
 }

--- a/javatests/arcs/sdk/android/storage/service/StorageServiceTest.kt
+++ b/javatests/arcs/sdk/android/storage/service/StorageServiceTest.kt
@@ -59,14 +59,16 @@ class StorageServiceTest {
         // Create a resurrection helper we'll use to collect updated storage keys coming from the
         // ShadowApplication-captured nextStartedService intents.
         val receivedUpdates = mutableListOf<List<StorageKey>>()
-        val resurrectionHelper = ResurrectionHelper(app) { keys: List<StorageKey> ->
+        val receivedIds = mutableListOf<String>()
+        val resurrectionHelper = ResurrectionHelper(app) { id: String, keys: List<StorageKey> ->
             receivedUpdates.add(keys)
+            receivedIds.add(id)
         }
 
         // Setup:
         // Add a resurrection request to the storage service.
         val resurrectionRequestIntent = Intent(app, StorageService::class.java).apply {
-            ResurrectionRequest.createDefault(app, listOf(storeOptions.storageKey))
+            ResurrectionRequest.createDefault(app, listOf(storeOptions.storageKey), "test")
                 .populateRequestIntent(this)
         }
         service.onStartCommand(resurrectionRequestIntent, 0, 0)
@@ -101,6 +103,7 @@ class StorageServiceTest {
         resurrectionHelper.onStartCommand(shadowApp.nextStartedService)
         assertThat(receivedUpdates).hasSize(1)
         assertThat(receivedUpdates[0]).containsExactly(storeOptions.storageKey)
+        assertThat(receivedIds[0]).isEqualTo("test")
     }
 
     private fun lifecycle(


### PR DESCRIPTION
* adds user supplied targetId (usually arcId) to primary key used for registrations
* resurrected clients are given the notifierId back along with storageKeys 
* I considered just using the notifierId as the primary key, however if ArcHosts didn't disambiguate (e.g. use targetId = arcId + hostId), they might conflict and overwrite each other's registrations. So I decided to keep the ComponentName as it makes for one less footgun.
