### PR TITLE
Test presence of comments in inline schemas with line breaks

### DIFF
--- a/src/runtime/tests/manifest-test.ts
+++ b/src/runtime/tests/manifest-test.ts
@@ -277,8 +277,9 @@ ${particleStr1}
     const manifest = await parseManifest(`
       particle Fooer
         foo: reads Foo {
+          // Comments can go here
           value: Text,
-          other: Number
+          other: Number // Or here.
         }
     `);
     const verify = (manifest: Manifest) => {


### PR DESCRIPTION
This should have been a part of the test in an earlier PR.