### PR TITLE
Fix different-handle-manger tests, fix uncovered issues

### DIFF
--- a/java/arcs/core/storage/referencemode/Message.kt
+++ b/java/arcs/core/storage/referencemode/Message.kt
@@ -134,7 +134,7 @@ private fun List<CrdtOperation>.toReferenceModeMessageOps(): List<CrdtOperationA
             is CrdtSet.Operation.Add<*> ->
                 CrdtSet.Operation.Add(op.actor, op.clock, op.added)
             is CrdtSet.Operation.Remove<*> ->
-                CrdtSet.Operation.Add(op.actor, op.clock, op.removed)
+                CrdtSet.Operation.Remove(op.actor, op.clock, op.removed)
             else -> throw CrdtException("Unsupported operation for ReferenceModeStore: $this")
         }
     }

--- a/javatests/arcs/core/entity/HandleManagerTestBase.kt
+++ b/javatests/arcs/core/entity/HandleManagerTestBase.kt
@@ -537,9 +537,21 @@ open class HandleManagerTestBase {
         assertThat(handleA.fetchAll()).hasSize(7)
         assertThat(handleB.fetchAll()).hasSize(7)
 
+        // Ensure we get update from A before checking.
+        // Since some test configurations may result in the handles
+        // operating on different threads.
+        val gotUpdate = CompletableDeferred<Unit>()
+        handleA.onUpdate {
+            if (it.isEmpty()) {
+                gotUpdate.complete(Unit)
+            }
+        }
+
         handleB.clear()
-        assertThat(handleA.fetchAll()).isEmpty()
         assertThat(handleB.fetchAll()).isEmpty()
+
+        gotUpdate.await()
+        assertThat(handleA.fetchAll()).isEmpty()
     }
 
     @Test


### PR DESCRIPTION
* A bug in the helpers in `HandleManagerTestBase` meant that the
`DifferentHandleManager*` tests were not actually testing different
handle managers. Fixing this uncovered some failures.

* Singleton clear operations were not being signaled across the driver
layer because of a small issue in a reference mode store `Message`
translation helper.

* When `CrdtSet.merge` resulted in removing items in the local replica
due to a removal from the remote replica, the item was removed, but the
corresponding was not reported in the `MergeChanges.otherModel` result
set.