### PR TITLE
Replaces VersionMap.isDominatedBy

### DIFF
--- a/java/arcs/core/crdt/CrdtSet.kt
+++ b/java/arcs/core/crdt/CrdtSet.kt
@@ -78,7 +78,7 @@ class CrdtSet<T : Referencable>(
         }
 
         _data.values.forEach { (id, myEntry) ->
-            if (id !in other.values && other.versionMap isDominatedBy myEntry.versionMap) {
+            if (id !in other.values && other.versionMap doesNotDominate myEntry.versionMap) {
                 // Value was added by this model.
                 mergedData.values[id] = myEntry
                 fastForwardOp.added += myEntry
@@ -90,7 +90,7 @@ class CrdtSet<T : Referencable>(
         val (myOperations, otherOperations) = if (
             fastForwardOp.added.isNotEmpty() ||
             fastForwardOp.removed.isNotEmpty() ||
-            oldClock isDominatedBy newClock
+            oldClock doesNotDominate newClock
         ) {
             CrdtChange.Data<Data<T>, IOperation<T>>(mergedData) to
                 Operations<Data<T>, IOperation<T>>(fastForwardOp.simplify().toMutableList())
@@ -231,7 +231,7 @@ class CrdtSet<T : Referencable>(
 
                 // Can't remove the item unless the clock value dominates that of the item already
                 // in the set.
-                if (clock isDominatedBy existingDatum.versionMap) return false
+                if (clock doesNotDominate existingDatum.versionMap) return false
 
                 // No need to edit actual data during a dry run.
                 if (isDryRun) return true
@@ -263,7 +263,7 @@ class CrdtSet<T : Referencable>(
 
             override fun applyTo(data: Data<T>, isDryRun: Boolean): Boolean {
                 // Can't fast-forward when current data's clock is behind oldClock.
-                if (data.versionMap isDominatedBy oldClock) return false
+                if (data.versionMap doesNotDominate oldClock) return false
 
                 // If the current data already knows about everything in the fast-forward op, we
                 // don't have to do anything.
@@ -279,7 +279,7 @@ class CrdtSet<T : Referencable>(
                             DataValue(
                                 addedClock mergeWith existingValue.versionMap, existingValue.value
                             )
-                    } else if (data.versionMap isDominatedBy addedClock) {
+                    } else if (data.versionMap doesNotDominate addedClock) {
                         data.values[addedValue.id] = DataValue(addedClock, addedValue)
                     }
                 }

--- a/java/arcs/core/crdt/VersionMap.kt
+++ b/java/arcs/core/crdt/VersionMap.kt
@@ -74,12 +74,7 @@ class VersionMap(initialData: Map<Actor, Version> = emptyMap()) {
     infix fun dominates(other: VersionMap): Boolean =
         other.backingMap.all { this[it.key] >= it.value }
 
-    /**
-     * Determines whether or not this [VersionMap] is 'dominated by' another.
-     *
-     * See [dominates] for more details.
-     */
-    infix fun isDominatedBy(other: VersionMap): Boolean = !(this dominates other)
+    infix fun doesNotDominate(other: VersionMap): Boolean = !(this dominates other)
 
     /**
      * Merges this [VersionMap] with another [VersionMap] by taking the maximum version values for
@@ -99,7 +94,7 @@ class VersionMap(initialData: Map<Actor, Version> = emptyMap()) {
      */
     operator fun minus(other: VersionMap): VersionMap {
         // Return an empty result if the other map is newer than this one.
-        if (this isDominatedBy other) return VersionMap()
+        if (other dominates this) return VersionMap()
 
         return VersionMap(
             backingMap.mapValues { (actor, version) -> version - other[actor] }

--- a/java/arcs/core/crdt/VersionMap.kt
+++ b/java/arcs/core/crdt/VersionMap.kt
@@ -90,7 +90,7 @@ class VersionMap(initialData: Map<Actor, Version> = emptyMap()) {
 
     /**
      * Subtracts the other [VersionMap] from the receiver and returns the actor-by-actor difference
-     * in a new [VersionMap].
+     * in a new [VersionMap]. Only non-zero differences will be returned.
      */
     operator fun minus(other: VersionMap): VersionMap {
         // Return an empty result if the other map is newer than this one.

--- a/java/arcs/core/crdt/VersionMap.kt
+++ b/java/arcs/core/crdt/VersionMap.kt
@@ -90,7 +90,7 @@ class VersionMap(initialData: Map<Actor, Version> = emptyMap()) {
 
     /**
      * Subtracts the other [VersionMap] from the receiver and returns the actor-by-actor difference
-     * in a new [VersionMap]. Only non-zero differences will be returned.
+     * in a new [VersionMap]. Only greater-than-zero differences will be returned.
      */
     operator fun minus(other: VersionMap): VersionMap {
         // Return an empty result if the other map is newer than this one.

--- a/javatests/arcs/core/crdt/CrdtSetTest.kt
+++ b/javatests/arcs/core/crdt/CrdtSetTest.kt
@@ -253,6 +253,30 @@ class CrdtSetTest {
     }
 
     @Test
+    fun merge_canMergeAdditionsByTwoActors() {
+        assertThat(alice.applyOperation(Add("alice", VersionMap("alice" to 1), "a"))).isTrue()
+        assertThat(bob.applyOperation(Add("bob", VersionMap("bob" to 1), "b"))).isTrue()
+
+        val changes = alice.merge(bob.data)
+
+        val modelChanges = requireNotNull(
+            changes.modelChange as? CrdtChange.Data<Data<Reference>, IOperation<Reference>>
+        )
+        val otherChanges = requireNotNull(
+            changes.otherChange as? CrdtChange.Operations<Data<Reference>, IOperation<Reference>>
+        )
+        val expectedVersionMap = VersionMap("alice" to 1, "bob" to 1)
+        assertThat(modelChanges.data.versionMap).isEqualTo(expectedVersionMap)
+        assertThat(modelChanges.data.values).containsExactly(
+            "a", CrdtSet.DataValue(VersionMap("alice" to 1), Reference("a")),
+            "b", CrdtSet.DataValue(VersionMap("bob" to 1), Reference("b"))
+        )
+        assertThat(otherChanges.ops).containsExactly(
+            Add("alice", VersionMap("alice" to 1), "a")
+        )
+    }
+
+    @Test
     fun fastForward_canSimplifySingleActorAddOps() {
         listOf(
             Add("alice", VersionMap("alice" to 1), "zero"),

--- a/javatests/arcs/core/crdt/VersionMapTest.kt
+++ b/javatests/arcs/core/crdt/VersionMapTest.kt
@@ -85,42 +85,11 @@ class VersionMapTest {
     }
 
     @Test
-    fun isDominatedByReturnsFalse_whenVersionMapsAreEqual() {
-        var a = VersionMap()
-        a["alice"]++
-        a["bob"] = 42
-        var b = VersionMap(a)
-        assertThat(a isDominatedBy b).isFalse()
-
-        a = VersionMap()
-        b = VersionMap(a)
-        assertThat(a isDominatedBy b).isFalse()
-    }
-
-    @Test
-    fun isDominatedByReturnsTrue_whenVersionMapIsDominatedByAnother() {
-        val a = VersionMap()
-        val b = VersionMap()
-
-        a["alice"]++
-        assertThat(b isDominatedBy a).isTrue()
-
-        a["bob"] = 2
-        b["bob"] = 2
-        assertThat(b isDominatedBy a).isTrue()
-    }
-
-    @Test
-    fun isDominatedByReturnsFalse_whenVersionMapDominatesAnother() {
-        val a = VersionMap()
-        val b = VersionMap()
-
-        b["alice"]++
-        assertThat(b isDominatedBy a).isFalse()
-
-        a["bob"] = 2
-        b["bob"] = 2
-        assertThat(b isDominatedBy a).isFalse()
+    fun dominatesReturnsFalse_whenNeitherDominates() {
+        val a = VersionMap("a" to 1)
+        val b = VersionMap("b" to 1)
+        assertThat(a dominates b).isFalse()
+        assertThat(b dominates a).isFalse()
     }
 
     @Test

--- a/src/runtime/crdt/crdt-collection.ts
+++ b/src/runtime/crdt/crdt-collection.ts
@@ -304,11 +304,6 @@ export function simplifyFastForwardOp<T>(fastForwardOp: CollectionFastForwardOp<
  * there's more than one such actor, returns null.
  */
 function getSingleActorIncrement(oldVersion: VersionMap, newVersion: VersionMap): string | null {
-  const oldNumActors = Object.keys(oldVersion).length;
-  const newNumActors = Object.keys(newVersion).length;
-  if (newNumActors < oldNumActors || newNumActors > oldNumActors + 1) {
-    return null;
-  }
   const incrementedActors = Object.entries(newVersion).filter(([k, v]) => v > (oldVersion[k] || 0));
   return incrementedActors.length === 1 ? incrementedActors[0][0] : null;
 }

--- a/src/runtime/crdt/crdt-collection.ts
+++ b/src/runtime/crdt/crdt-collection.ts
@@ -276,7 +276,7 @@ export function simplifyFastForwardOp<T>(fastForwardOp: CollectionFastForwardOp<
   }
   // Sort the add ops in increasing order by the actor's version.
   const addOps = [...fastForwardOp.added].sort(([elem1, v1], [elem2, v2]) => (v1[actor] || 0) - (v2[actor] || 0));
-  let expectedVersion = fastForwardOp.oldClock[actor];
+  let expectedVersion = fastForwardOp.oldClock[actor] || 0;
   for (const [elem, version] of addOps) {
     if (++expectedVersion !== version[actor]) {
       // The add op didn't match the expected increment-by-one pattern. Can't
@@ -304,9 +304,11 @@ export function simplifyFastForwardOp<T>(fastForwardOp: CollectionFastForwardOp<
  * there's more than one such actor, returns null.
  */
 function getSingleActorIncrement(oldVersion: VersionMap, newVersion: VersionMap): string | null {
-  if (Object.keys(oldVersion).length !== Object.keys(newVersion).length) {
+  const oldNumActors = Object.keys(oldVersion).length;
+  const newNumActors = Object.keys(newVersion).length;
+  if (newNumActors < oldNumActors || newNumActors > oldNumActors + 1) {
     return null;
   }
-  const incrementedActors = Object.entries(oldVersion).filter(([k, v]) => newVersion[k] > v);
+  const incrementedActors = Object.entries(newVersion).filter(([k, v]) => v > (oldVersion[k] || 0));
   return incrementedActors.length === 1 ? incrementedActors[0][0] : null;
 }


### PR DESCRIPTION
The logic for this function was incorrect, `a isDominatedBy b` should not imply that `a !dominates b`, which is how this was implemented.

I've replaced all of the usages of this method with explicit calls to `dominates`, and added a clearer helper method `doesNotDominate`.

Also added a few new test cases to ensure the behaviour of merging fast forward ops is correct.