### PR TITLE
Supply Schedulers to the HandleManager(s)

### DIFF
--- a/java/arcs/android/demo/DemoActivity.kt
+++ b/java/arcs/android/demo/DemoActivity.kt
@@ -18,6 +18,7 @@ import arcs.android.host.AndroidManifestHostRegistry
 import arcs.core.allocator.Allocator
 import arcs.core.host.EntityHandleManager
 import arcs.core.host.HostRegistry
+import arcs.core.util.Scheduler
 import arcs.jvm.util.JvmTime
 import arcs.sdk.android.storage.ServiceStoreFactory
 import kotlin.coroutines.CoroutineContext
@@ -25,7 +26,9 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.launch
+import java.util.concurrent.Executors
 
 /** Entry UI to launch Arcs demo. */
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -51,6 +54,11 @@ class DemoActivity : AppCompatActivity() {
                 hostRegistry,
                 EntityHandleManager(
                     time = JvmTime,
+                    scheduler = Scheduler(
+                        JvmTime,
+                        coroutineContext +
+                            Executors.newSingleThreadExecutor().asCoroutineDispatcher()
+                    ),
                     activationFactory = ServiceStoreFactory(
                         context = this@DemoActivity,
                         lifecycle = this@DemoActivity.getLifecycle()

--- a/java/arcs/android/demo/DemoActivity.kt
+++ b/java/arcs/android/demo/DemoActivity.kt
@@ -21,6 +21,7 @@ import arcs.core.host.HostRegistry
 import arcs.core.util.Scheduler
 import arcs.jvm.util.JvmTime
 import arcs.sdk.android.storage.ServiceStoreFactory
+import java.util.concurrent.Executors
 import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -28,7 +29,6 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.launch
-import java.util.concurrent.Executors
 
 /** Entry UI to launch Arcs demo. */
 @OptIn(ExperimentalCoroutinesApi::class)

--- a/java/arcs/android/demo/DemoService.kt
+++ b/java/arcs/android/demo/DemoService.kt
@@ -10,7 +10,9 @@ import androidx.lifecycle.LifecycleService
 import arcs.android.sdk.host.AndroidHost
 import arcs.android.sdk.host.ArcHostHelper
 import arcs.core.host.ParticleRegistration
+import arcs.core.host.SchedulerProvider
 import arcs.core.host.toRegistration
+import arcs.jvm.host.JvmSchedulerProvider
 import arcs.jvm.util.JvmTime
 import arcs.sdk.Handle
 import kotlinx.coroutines.CoroutineScope
@@ -34,6 +36,7 @@ class DemoService : LifecycleService() {
         val host = MyArcHost(
             this,
             this.lifecycle,
+            JvmSchedulerProvider(coroutineContext),
             ::ReadPerson.toRegistration(),
             ::WritePerson.toRegistration()
         )
@@ -70,13 +73,13 @@ class DemoService : LifecycleService() {
     class MyArcHost(
         context: Context,
         lifecycle: Lifecycle,
+        schedulerProvider: SchedulerProvider,
         vararg initialParticles: ParticleRegistration
-    ) : AndroidHost(context, lifecycle, *initialParticles) {
+    ) : AndroidHost(context, lifecycle, schedulerProvider, *initialParticles) {
         override val platformTime = JvmTime
     }
 
     inner class ReadPerson : AbstractReadPerson() {
-
         override suspend fun onHandleSync(handle: Handle, allSynced: Boolean) {
             scope.launch {
                 val name = withContext(Dispatchers.IO) { handles.person.fetch()?.name ?: "" }
@@ -94,7 +97,6 @@ class DemoService : LifecycleService() {
     }
 
     inner class WritePerson : AbstractWritePerson() {
-
         override suspend fun onHandleSync(handle: Handle, allSynced: Boolean) {
             handles.person.store(WritePerson_Person("John Wick"))
         }

--- a/java/arcs/android/host/prod/BUILD
+++ b/java/arcs/android/host/prod/BUILD
@@ -17,5 +17,6 @@ arcs_kt_android_library(
         "//third_party/java/androidx/annotation",
         "//third_party/java/androidx/lifecycle",
         "//third_party/java/androidx/lifecycle/service",
+        "//third_party/kotlin/kotlinx_coroutines",
     ],
 )

--- a/java/arcs/android/host/prod/ProdArcHostService.kt
+++ b/java/arcs/android/host/prod/ProdArcHostService.kt
@@ -19,8 +19,8 @@ import arcs.core.host.ArcHost
 import arcs.core.host.ParticleRegistration
 import arcs.core.host.ProdHost
 import arcs.core.host.SchedulerProvider
-import arcs.jvm.host.scanForParticles
 import arcs.jvm.host.JvmSchedulerProvider
+import arcs.jvm.host.scanForParticles
 
 /**
  * An isolatable (can run in another process) [Service] that has a [ProdHost] inside. [Particle]

--- a/java/arcs/android/host/prod/ProdArcHostService.kt
+++ b/java/arcs/android/host/prod/ProdArcHostService.kt
@@ -18,7 +18,9 @@ import arcs.android.sdk.host.ArcHostService
 import arcs.core.host.ArcHost
 import arcs.core.host.ParticleRegistration
 import arcs.core.host.ProdHost
+import arcs.core.host.SchedulerProvider
 import arcs.jvm.host.scanForParticles
+import arcs.jvm.host.JvmSchedulerProvider
 
 /**
  * An isolatable (can run in another process) [Service] that has a [ProdHost] inside. [Particle]
@@ -27,17 +29,22 @@ import arcs.jvm.host.scanForParticles
  */
 @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
 open class ProdArcHostService : ArcHostService() {
-
     class ProdAndroidHost(
         context: Context,
         lifecycle: Lifecycle,
+        schedulerProvider: SchedulerProvider,
         vararg particles: ParticleRegistration
-    ) : AndroidHost(context, lifecycle, *particles), ProdHost
+    ) : AndroidHost(context, lifecycle, schedulerProvider, *particles), ProdHost
 
     /**
      * This is open for tests to override, but normally isn't necessary.
      */
     override val arcHost: ArcHost by lazy {
-        ProdAndroidHost(this, this.lifecycle, *scanForParticles())
+        ProdAndroidHost(
+            this,
+            this.lifecycle,
+            JvmSchedulerProvider(scope.coroutineContext),
+            *scanForParticles()
+        )
     }
 }

--- a/java/arcs/android/sdk/host/AndroidHost.kt
+++ b/java/arcs/android/sdk/host/AndroidHost.kt
@@ -16,6 +16,7 @@ import arcs.core.host.ArcHost
 import arcs.core.host.ArcHostContext
 import arcs.core.host.ArcState
 import arcs.core.host.ParticleRegistration
+import arcs.core.host.SchedulerProvider
 import arcs.jvm.host.JvmHost
 import arcs.sdk.android.storage.ResurrectionHelper
 import arcs.sdk.android.storage.ServiceStoreFactory
@@ -27,8 +28,9 @@ import arcs.sdk.android.storage.ServiceStoreFactory
 abstract class AndroidHost(
     val context: Context,
     val lifecycle: Lifecycle,
+    schedulerProvider: SchedulerProvider,
     vararg particles: ParticleRegistration
-) : JvmHost(*particles), ResurrectableHost {
+) : JvmHost(schedulerProvider, *particles), ResurrectableHost {
 
     override val resurrectionHelper: ResurrectionHelper = ResurrectionHelper(context,
         ::onResurrected)

--- a/java/arcs/android/sdk/host/ArcHostService.kt
+++ b/java/arcs/android/sdk/host/ArcHostService.kt
@@ -13,11 +13,16 @@ package arcs.android.sdk.host
 import android.content.Intent
 import androidx.lifecycle.LifecycleService
 import arcs.core.host.ArcHost
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.cancel
 
 /**
  * Base [Service] for embedders of [ArcHost].
  */
 abstract class ArcHostService : LifecycleService() {
+    protected val scope: CoroutineScope = MainScope()
+
     /**
      * Subclasses must override this with their own [ArcHost].
      */
@@ -31,5 +36,10 @@ abstract class ArcHostService : LifecycleService() {
         val result = super.onStartCommand(intent, flags, startId)
         arcHostHelper.onStartCommand(intent)
         return result
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        scope.cancel()
     }
 }

--- a/java/arcs/android/sdk/host/BUILD
+++ b/java/arcs/android/sdk/host/BUILD
@@ -21,5 +21,6 @@ arcs_kt_android_library(
         "//third_party/java/androidx/lifecycle/service",
         "//third_party/kotlin/kotlin:kotlin_reflect",
         "//third_party/kotlin/kotlinx_coroutines",
+        "//third_party/kotlin/kotlinx_coroutines:kotlinx_coroutines_android",
     ],
 )

--- a/java/arcs/core/entity/EntityDereferencerFactory.kt
+++ b/java/arcs/core/entity/EntityDereferencerFactory.kt
@@ -8,16 +8,18 @@ import arcs.core.storage.Dereferencer
 import arcs.core.storage.RawEntityDereferencer
 import arcs.core.storage.Reference
 import arcs.core.storage.StoreManager
+import arcs.core.util.Scheduler
 
 /** A [Dereferencer.Factory] for [Reference] and [RawEntity] classes. */
 class EntityDereferencerFactory(
     private val stores: StoreManager,
+    private val scheduler: Scheduler,
     private val entityActivationFactory: ActivationFactory? = null
 ) : Dereferencer.Factory<RawEntity> {
     private val dereferencers = mutableMapOf<Schema, RawEntityDereferencer>()
 
     override fun create(schema: Schema) = dereferencers.getOrPut(schema) {
-        RawEntityDereferencer(schema, stores, entityActivationFactory)
+        RawEntityDereferencer(schema, stores, scheduler, entityActivationFactory)
     }
 
     /**

--- a/java/arcs/core/host/AbstractArcHost.kt
+++ b/java/arcs/core/host/AbstractArcHost.kt
@@ -26,7 +26,6 @@ import arcs.core.storage.ActivationFactory
 import arcs.core.storage.StorageKey
 import arcs.core.storage.StoreManager
 import arcs.core.util.LruCacheMap
-import arcs.core.util.Scheduler
 import arcs.core.util.TaggedLog
 import arcs.core.util.Time
 import kotlinx.coroutines.CoroutineName

--- a/java/arcs/core/host/AbstractArcHost.kt
+++ b/java/arcs/core/host/AbstractArcHost.kt
@@ -26,6 +26,7 @@ import arcs.core.storage.ActivationFactory
 import arcs.core.storage.StorageKey
 import arcs.core.storage.StoreManager
 import arcs.core.util.LruCacheMap
+import arcs.core.util.Scheduler
 import arcs.core.util.TaggedLog
 import arcs.core.util.Time
 import kotlinx.coroutines.CoroutineName
@@ -50,7 +51,10 @@ const val MAX_CONSECUTIVE_FAILURES = 5
  *
  * @property initialParticles The initial set of [Particle]s that this host contains.
  */
-abstract class AbstractArcHost(vararg initialParticles: ParticleRegistration) : ArcHost {
+abstract class AbstractArcHost(
+    private val schedulerProvider: SchedulerProvider,
+    vararg initialParticles: ParticleRegistration
+) : ArcHost {
     private val log = TaggedLog { "AbstractArcHost" }
     private val particleConstructors: MutableMap<ParticleIdentifier, ParticleConstructor> =
         mutableMapOf()
@@ -485,6 +489,7 @@ abstract class AbstractArcHost(vararg initialParticles: ParticleRegistration) : 
         arcId,
         hostId,
         platformTime,
+        schedulerProvider(arcId),
         stores,
         activationFactory
     )

--- a/java/arcs/core/host/EntityHandleManager.kt
+++ b/java/arcs/core/host/EntityHandleManager.kt
@@ -49,6 +49,7 @@ import arcs.core.storage.ActivationFactory
 import arcs.core.storage.StorageKey
 import arcs.core.storage.StorageMode.ReferenceMode
 import arcs.core.storage.StoreManager
+import arcs.core.util.Scheduler
 import arcs.core.util.Time
 
 /**
@@ -57,19 +58,24 @@ import arcs.core.util.Time
  * `arcs_kt_schema` on a manifest file to generate a `{ParticleName}Handles' class, and
  * invoke its default constructor, or obtain it from the [BaseParticle.handles] field.
  *
+ * The [scheduler] provided to the [EntityHandlemManager] at construction-time will be shared across
+ * all handles and storage-proxies created by the [EntityHandleManager].
+ *
  * Instances of this class are not thread-safe.
  */
 class EntityHandleManager(
     private val arcId: String = Id.Generator.newSession().newArcId("arc").toString(),
     private val hostId: String = "nohost",
     private val time: Time,
+    private val scheduler: Scheduler,
     private val stores: StoreManager = StoreManager(),
     private val activationFactory: ActivationFactory? = null,
     private val idGenerator: Id.Generator = Id.Generator.newSession()
 ) {
     private val singletonStorageProxies = mutableMapOf<StorageKey, SingletonProxy<Referencable>>()
     private val collectionStorageProxies = mutableMapOf<StorageKey, CollectionProxy<Referencable>>()
-    private val dereferencerFactory = EntityDereferencerFactory(stores, activationFactory)
+    private val dereferencerFactory =
+        EntityDereferencerFactory(stores, scheduler, activationFactory)
 
     @Suppress("UNCHECKED_CAST")
     suspend fun createHandle(
@@ -183,7 +189,7 @@ class EntityHandleManager(
         )
     ).activate(activationFactory).let { activeStore ->
         singletonStorageProxies.getOrPut(storageKey) {
-            SingletonProxy(activeStore, CrdtSingleton())
+            SingletonProxy(activeStore, CrdtSingleton(), scheduler)
         } as SingletonProxy<R>
     }
 
@@ -199,7 +205,7 @@ class EntityHandleManager(
         )
     ).activate(activationFactory).let { activeStore ->
         collectionStorageProxies.getOrPut(storageKey) {
-            CollectionProxy(activeStore, CrdtSet())
+            CollectionProxy(activeStore, CrdtSet(), scheduler)
         } as CollectionProxy<R>
     }
 }

--- a/java/arcs/core/host/EntityHandleManager.kt
+++ b/java/arcs/core/host/EntityHandleManager.kt
@@ -58,7 +58,7 @@ import arcs.core.util.Time
  * `arcs_kt_schema` on a manifest file to generate a `{ParticleName}Handles' class, and
  * invoke its default constructor, or obtain it from the [BaseParticle.handles] field.
  *
- * The [scheduler] provided to the [EntityHandlemManager] at construction-time will be shared across
+ * The [scheduler] provided to the [EntityHandleManager] at construction-time will be shared across
  * all handles and storage-proxies created by the [EntityHandleManager].
  *
  * Instances of this class are not thread-safe.

--- a/java/arcs/core/host/SchedulerProvider.kt
+++ b/java/arcs/core/host/SchedulerProvider.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.core.host
+
+import arcs.core.util.Scheduler
+
+/**
+ * Responsible for provisioning [Scheduler]s for [ArcHost]s on an arc-by-arc basis.
+ *
+ * The [Scheduler]s will be used to choreograph particle/handle callback behavior from the
+ * [StorageProxy] instances created by the [ArcHost].
+ */
+interface SchedulerProvider {
+    operator fun invoke(arcId: String): Scheduler
+}

--- a/java/arcs/core/storage/RawEntityDereferencer.kt
+++ b/java/arcs/core/storage/RawEntityDereferencer.kt
@@ -15,6 +15,7 @@ import arcs.core.crdt.CrdtEntity
 import arcs.core.data.EntityType
 import arcs.core.data.RawEntity
 import arcs.core.data.Schema
+import arcs.core.util.Scheduler
 import arcs.core.util.TaggedLog
 import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CompletableDeferred
@@ -25,10 +26,13 @@ import kotlinx.coroutines.withContext
  * [Dereferencer] to use when de-referencing a [Reference] to an [Entity].
  *
  * [Handle] implementations should inject this into any [Reference] objects they encounter.
+ *
+ * TODO(jasonwyatt): Use the [Scheduler] here when dereferencing.
  */
 class RawEntityDereferencer(
     private val schema: Schema,
     private val storeManager: StoreManager = StoreManager(),
+    private val scheduler: Scheduler,
     private val entityActivationFactory: ActivationFactory? = null
 ) : Dereferencer<RawEntity> {
     private val log = TaggedLog { "Dereferencer(${schema.names})" }

--- a/java/arcs/core/storage/StorageProxy.kt
+++ b/java/arcs/core/storage/StorageProxy.kt
@@ -15,6 +15,7 @@ import arcs.core.crdt.CrdtData
 import arcs.core.crdt.CrdtModel
 import arcs.core.crdt.CrdtOperationAtTime
 import arcs.core.crdt.VersionMap
+import arcs.core.util.Scheduler
 import arcs.core.util.TaggedLog
 import arcs.core.util.guardedBy
 import kotlin.coroutines.coroutineContext
@@ -35,7 +36,8 @@ import kotlinx.coroutines.sync.withLock
  */
 class StorageProxy<Data : CrdtData, Op : CrdtOperationAtTime, T>(
     storeEndpointProvider: StorageCommunicationEndpointProvider<Data, Op, T>,
-    initialCrdt: CrdtModel<Data, Op, T>
+    initialCrdt: CrdtModel<Data, Op, T>,
+    private val scheduler: Scheduler
 ) {
     // Visible for testing
     enum class ProxyState {

--- a/java/arcs/core/util/Scheduler.kt
+++ b/java/arcs/core/util/Scheduler.kt
@@ -17,6 +17,7 @@ import kotlinx.atomicfu.update
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
@@ -72,6 +73,11 @@ class Scheduler(
     /** Wait for the [Scheduler] to become idle. */
     suspend fun waitForIdle() {
         processingJob?.join()
+    }
+
+    /** Cancel the [CoroutineScope] belonging to this Scheduler. */
+    fun cancel() {
+        scope.cancel()
     }
 
     private fun CoroutineScope.startProcessingJob() {

--- a/java/arcs/jvm/host/BUILD
+++ b/java/arcs/jvm/host/BUILD
@@ -14,5 +14,7 @@ arcs_kt_jvm_library(
         "//java/arcs/core/storage/api",
         "//java/arcs/core/util",
         "//java/arcs/jvm/util",
+        "//third_party/kotlin/kotlinx_atomicfu",
+        "//third_party/kotlin/kotlinx_coroutines",
     ],
 )

--- a/java/arcs/jvm/host/JvmHost.kt
+++ b/java/arcs/jvm/host/JvmHost.kt
@@ -13,6 +13,7 @@ package arcs.jvm.host
 import arcs.core.host.AbstractArcHost
 import arcs.core.host.ArcHost
 import arcs.core.host.ParticleRegistration
+import arcs.core.host.SchedulerProvider
 import arcs.core.util.Time
 import arcs.jvm.util.JvmTime
 
@@ -20,7 +21,8 @@ import arcs.jvm.util.JvmTime
  * An [ArcHost] that runs on Java VM platforms.
  */
 open class JvmHost(
+    schedulerProvider: SchedulerProvider,
     vararg particles: ParticleRegistration
-) : AbstractArcHost(*particles) {
+) : AbstractArcHost(schedulerProvider, *particles) {
     override val platformTime: Time = JvmTime
 }

--- a/java/arcs/jvm/host/JvmSchedulerProvider.kt
+++ b/java/arcs/jvm/host/JvmSchedulerProvider.kt
@@ -49,6 +49,9 @@ class JvmSchedulerProvider(
         } else {
             Executors
                 .newSingleThreadExecutor {
+                    // TODO(jasonwyatt): Create and cache this thread outside of the thread factory,
+                    //  so we can ensure we always return it - rather than creating new threads
+                    //  when/if the on the executor was created with failed or was killed.
                     Thread(it).apply {
                         priority = threadPriority
                     }

--- a/java/arcs/jvm/host/JvmSchedulerProvider.kt
+++ b/java/arcs/jvm/host/JvmSchedulerProvider.kt
@@ -35,7 +35,7 @@ class JvmSchedulerProvider(
     private val baseCoroutineContext: CoroutineContext,
     private val maxThreadCount: Int =
         maxOf(1, Runtime.getRuntime().availableProcessors() / 2),
-    private val threadPriority: Int = Thread.NORM_PRIORITY
+    private val threadPriority: Int = DEFAULT_THREAD_PRIORITY
 ) : SchedulerProvider {
     private val dispatchers = mutableListOf<CoroutineDispatcher>()
     private val schedulersByArcId = mutableMapOf<String, Scheduler>()
@@ -75,5 +75,9 @@ class JvmSchedulerProvider(
     @Synchronized
     fun cancelAll() {
         schedulersByArcId.values.toList().forEach { it.cancel() }
+    }
+
+    companion object {
+        private const val DEFAULT_THREAD_PRIORITY = Thread.NORM_PRIORITY + 1
     }
 }

--- a/java/arcs/jvm/host/JvmSchedulerProvider.kt
+++ b/java/arcs/jvm/host/JvmSchedulerProvider.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.jvm.host
+
+import arcs.core.host.SchedulerProvider
+import arcs.core.util.Scheduler
+import arcs.jvm.util.JvmTime
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.asCoroutineDispatcher
+import java.util.concurrent.Executors
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Implementation of a [SchedulerProvider] for the Java Virtual Machine (including Android).
+ *
+ * A new [Scheduler] is returned for each unique Arc ID encountered, and each [Scheduler] will be
+ * associated with a single-threaded [CoroutineDispatcher]. However, those dispatchers will be
+ * allocated to schedulers from a finite pool of dispatchers in a round-robin fashion - the size
+ * of that pool is defined by [maxThreadCount].
+ *
+ * Each [ArcHost] should generally use a separate [JvmSchedulerProvider].
+ */
+class JvmSchedulerProvider(
+    private val baseCoroutineContext: CoroutineContext,
+    private val maxThreadCount: Int =
+        maxOf(1, Runtime.getRuntime().availableProcessors() / 2)
+) : SchedulerProvider {
+    private val dispatchers = mutableListOf<CoroutineDispatcher>()
+    private val schedulersByArcId = mutableMapOf<String, Scheduler>()
+
+    @Synchronized
+    override fun invoke(arcId: String): Scheduler {
+        schedulersByArcId[arcId]?.let { return it }
+
+        val dispatcher = if (dispatchers.size == maxThreadCount) {
+            dispatchers[schedulersByArcId.size % maxThreadCount]
+        } else {
+            Executors
+                .newSingleThreadExecutor {
+                    Thread(it).apply {
+                        // TODO: Tune
+                        priority = Thread.NORM_PRIORITY
+                    }
+                }
+                .asCoroutineDispatcher()
+                .also { dispatchers.add(it) }
+        }
+
+        val schedulerParentJob = Job(baseCoroutineContext[Job])
+        schedulerParentJob.invokeOnCompletion { schedulersByArcId.remove(arcId) }
+
+        val schedulerContext = baseCoroutineContext +
+            schedulerParentJob +
+            CoroutineName("Scheduler::$arcId") +
+            dispatcher
+
+        return Scheduler(JvmTime, schedulerContext).also { schedulersByArcId[arcId] = it }
+    }
+
+
+    suspend fun cancelAll() {
+        schedulersByArcId.values.forEach { it.cancel() }
+    }
+}

--- a/java/arcs/jvm/host/JvmSchedulerProvider.kt
+++ b/java/arcs/jvm/host/JvmSchedulerProvider.kt
@@ -14,9 +14,9 @@ package arcs.jvm.host
 import arcs.core.host.SchedulerProvider
 import arcs.core.util.Scheduler
 import arcs.jvm.util.JvmTime
-import kotlinx.atomicfu.atomic
 import java.util.concurrent.Executors
 import kotlin.coroutines.CoroutineContext
+import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.Job

--- a/java/arcs/sdk/testing/BUILD
+++ b/java/arcs/sdk/testing/BUILD
@@ -10,6 +10,7 @@ arcs_kt_jvm_library(
     srcs = glob(["*.kt"]),
     deps = [
         "//java/arcs/core/host",
+        "//java/arcs/core/util",
         "//java/arcs/jvm/util",
         "//java/arcs/sdk",
         "//java/arcs/sdk/storage",

--- a/java/arcs/sdk/testing/BaseTestHarness.kt
+++ b/java/arcs/sdk/testing/BaseTestHarness.kt
@@ -8,6 +8,7 @@ import arcs.core.storage.driver.RamDisk
 import arcs.core.storage.driver.RamDiskDriverProvider
 import arcs.core.storage.keys.RamDiskStorageKey
 import arcs.core.storage.referencemode.ReferenceModeStorageKey
+import arcs.core.util.Scheduler
 import arcs.jvm.util.JvmTime
 import arcs.sdk.Handle
 import arcs.sdk.Particle
@@ -79,7 +80,8 @@ open class BaseTestHarness<P : Particle>(
                     val handleManager = EntityHandleManager(
                         arcId = "testHarness",
                         hostId = "testHarnessHost",
-                        time = JvmTime
+                        time = JvmTime,
+                        scheduler = Scheduler(JvmTime, scope.coroutineContext)
                     )
                     specs.forEach { spec ->
                         val storageKey = ReferenceModeStorageKey(

--- a/javatests/arcs/android/e2e/testapp/ArcHostService.kt
+++ b/javatests/arcs/android/e2e/testapp/ArcHostService.kt
@@ -19,17 +19,15 @@ import arcs.core.host.AbstractArcHost
 import arcs.core.host.ParticleRegistration
 import arcs.core.host.SchedulerProvider
 import arcs.core.host.toRegistration
-import arcs.core.util.Scheduler
+import arcs.jvm.host.JvmSchedulerProvider
 import arcs.jvm.util.JvmTime
 import arcs.sdk.Handle
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import java.util.concurrent.Executors
 
 /**
  * Service which wraps an ArcHost.
@@ -40,13 +38,8 @@ class ArcHostService : Service() {
     private val scope = CoroutineScope(coroutineContext)
 
     private val myHelper: ArcHostHelper by lazy {
-        val schedulerContext =
-            coroutineContext + Executors.newSingleThreadExecutor().asCoroutineDispatcher()
-        val scheduler = Scheduler(JvmTime, schedulerContext)
         val host = MyArcHost(
-            object : SchedulerProvider {
-                override fun invoke(arcId: String): Scheduler = scheduler
-            },
+            JvmSchedulerProvider(coroutineContext),
             ::ReadPerson.toRegistration(),
             ::WritePerson.toRegistration()
         )

--- a/javatests/arcs/android/e2e/testapp/StorageAccessService.kt
+++ b/javatests/arcs/android/e2e/testapp/StorageAccessService.kt
@@ -7,6 +7,7 @@ import arcs.core.data.HandleMode
 import arcs.core.entity.HandleContainerType
 import arcs.core.entity.HandleSpec
 import arcs.core.host.EntityHandleManager
+import arcs.core.util.Scheduler
 import arcs.jvm.util.JvmTime
 import arcs.sdk.WriteSingletonHandle
 import arcs.sdk.android.storage.ServiceStoreFactory
@@ -35,6 +36,10 @@ class StorageAccessService : LifecycleService() {
         scope.launch {
             val handleManager = EntityHandleManager(
                 time = JvmTime,
+                scheduler = Scheduler(
+                    JvmTime,
+                    coroutineContext
+                ),
                 activationFactory = ServiceStoreFactory(
                     this@StorageAccessService,
                     lifecycle

--- a/javatests/arcs/android/e2e/testapp/TestActivity.kt
+++ b/javatests/arcs/android/e2e/testapp/TestActivity.kt
@@ -24,6 +24,8 @@ import arcs.core.data.HandleMode
 import arcs.core.entity.HandleContainerType
 import arcs.core.entity.HandleSpec
 import arcs.core.host.EntityHandleManager
+import arcs.core.host.HostRegistry
+import arcs.core.util.Scheduler
 import arcs.jvm.util.JvmTime
 import arcs.sdk.ReadWriteCollectionHandle
 import arcs.sdk.ReadWriteSingletonHandle
@@ -32,8 +34,10 @@ import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
+import java.util.concurrent.Executors
 
 /** Entry UI to launch Arcs Test. */
 class TestActivity : AppCompatActivity() {
@@ -120,6 +124,11 @@ class TestActivity : AppCompatActivity() {
             AndroidManifestHostRegistry.create(this@TestActivity),
             EntityHandleManager(
                 time = JvmTime,
+	        scheduler = Scheduler(
+		    JvmTime,
+		    coroutineContext
+		        + Executors.newSingleThreadExecutor().asCoroutineDispatcher()
+	        ),
                 activationFactory = ServiceStoreFactory(
                     context = this@TestActivity,
                     lifecycle = this@TestActivity.lifecycle
@@ -151,6 +160,11 @@ class TestActivity : AppCompatActivity() {
 
         val handleManager = EntityHandleManager(
             time = JvmTime,
+            scheduler = Scheduler(
+                JvmTime,
+                coroutineContext
+                    + Executors.newSingleThreadExecutor().asCoroutineDispatcher()
+            ),
             activationFactory = ServiceStoreFactory(
                 this,
                 lifecycle

--- a/javatests/arcs/android/e2e/testapp/TestActivity.kt
+++ b/javatests/arcs/android/e2e/testapp/TestActivity.kt
@@ -124,11 +124,11 @@ class TestActivity : AppCompatActivity() {
             AndroidManifestHostRegistry.create(this@TestActivity),
             EntityHandleManager(
                 time = JvmTime,
-	        scheduler = Scheduler(
-		    JvmTime,
-		    coroutineContext
-		        + Executors.newSingleThreadExecutor().asCoroutineDispatcher()
-	        ),
+                scheduler = Scheduler(
+                    JvmTime,
+                    coroutineContext
+                        + Executors.newSingleThreadExecutor().asCoroutineDispatcher()
+                ),
                 activationFactory = ServiceStoreFactory(
                     context = this@TestActivity,
                     lifecycle = this@TestActivity.lifecycle

--- a/javatests/arcs/android/entity/DifferentAndroidHandleManagerDifferentStoresTest.kt
+++ b/javatests/arcs/android/entity/DifferentAndroidHandleManagerDifferentStoresTest.kt
@@ -9,14 +9,17 @@ import androidx.work.testing.WorkManagerTestInitHelper
 import arcs.core.entity.HandleManagerTestBase
 import arcs.core.host.EntityHandleManager
 import arcs.core.storage.StoreManager
+import arcs.core.util.Scheduler
 import arcs.jvm.util.testutil.FakeTime
 import arcs.sdk.android.storage.ServiceStoreFactory
 import arcs.sdk.android.storage.service.testutil.TestConnectionFactory
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Before
 import org.junit.runner.RunWith
+import java.util.concurrent.Executors
 
 @Suppress("EXPERIMENTAL_API_USAGE")
 @RunWith(AndroidJUnit4::class)
@@ -42,6 +45,10 @@ class DifferentAndroidHandleManagerDifferentStoresTest : HandleManagerTestBase()
             arcId = "arcId",
             hostId = "hostId",
             time = FakeTime(),
+            scheduler = Scheduler(
+                FakeTime(),
+                Executors.newSingleThreadExecutor().asCoroutineDispatcher()
+            ),
             stores = StoreManager(),
             activationFactory = ServiceStoreFactory(
                 app,
@@ -53,6 +60,10 @@ class DifferentAndroidHandleManagerDifferentStoresTest : HandleManagerTestBase()
             arcId = "arcId",
             hostId = "hostId",
             time = FakeTime(),
+            scheduler = Scheduler(
+                FakeTime(),
+                Executors.newSingleThreadExecutor().asCoroutineDispatcher()
+            ),
             stores = StoreManager(),
             activationFactory = ServiceStoreFactory(
                 app,

--- a/javatests/arcs/android/entity/DifferentHandleManagerTest.kt
+++ b/javatests/arcs/android/entity/DifferentHandleManagerTest.kt
@@ -9,14 +9,17 @@ import androidx.work.testing.WorkManagerTestInitHelper
 import arcs.core.entity.HandleManagerTestBase
 import arcs.core.host.EntityHandleManager
 import arcs.core.storage.StoreManager
+import arcs.core.util.Scheduler
 import arcs.jvm.util.testutil.FakeTime
 import arcs.sdk.android.storage.ServiceStoreFactory
 import arcs.sdk.android.storage.service.testutil.TestConnectionFactory
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Before
 import org.junit.runner.RunWith
+import java.util.concurrent.Executors
 
 @Suppress("EXPERIMENTAL_API_USAGE")
 @RunWith(AndroidJUnit4::class)
@@ -43,6 +46,10 @@ class DifferentHandleManagerTest : HandleManagerTestBase() {
             arcId = "arcId",
             hostId = "hostId",
             time = FakeTime(),
+            scheduler = Scheduler(
+                FakeTime(),
+                Executors.newSingleThreadExecutor().asCoroutineDispatcher()
+            ),
             stores = stores,
             activationFactory = ServiceStoreFactory(
                 app,
@@ -54,6 +61,10 @@ class DifferentHandleManagerTest : HandleManagerTestBase() {
             arcId = "arcId",
             hostId = "hostId",
             time = FakeTime(),
+            scheduler = Scheduler(
+                FakeTime(),
+                Executors.newSingleThreadExecutor().asCoroutineDispatcher()
+            ),
             stores = stores,
             activationFactory = ServiceStoreFactory(
                 app,

--- a/javatests/arcs/android/entity/SameHandleManagerTest.kt
+++ b/javatests/arcs/android/entity/SameHandleManagerTest.kt
@@ -9,14 +9,16 @@ import androidx.work.testing.WorkManagerTestInitHelper
 import arcs.core.entity.HandleManagerTestBase
 import arcs.core.host.EntityHandleManager
 import arcs.core.storage.StoreManager
-import arcs.jvm.util.testutil.FakeTime
+import arcs.core.util.Scheduler
 import arcs.sdk.android.storage.ServiceStoreFactory
 import arcs.sdk.android.storage.service.testutil.TestConnectionFactory
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Before
 import org.junit.runner.RunWith
+import java.util.concurrent.Executors
 
 @Suppress("EXPERIMENTAL_API_USAGE")
 @RunWith(AndroidJUnit4::class)
@@ -41,6 +43,10 @@ class SameHandleManagerTest : HandleManagerTestBase() {
             arcId = "arcId",
             hostId = "hostId",
             time = FakeTime(),
+            scheduler = Scheduler(
+                FakeTime(),
+                Executors.newSingleThreadExecutor().asCoroutineDispatcher()
+            ),
             stores = StoreManager(),
             activationFactory = ServiceStoreFactory(
                 app,

--- a/javatests/arcs/android/entity/SameHandleManagerTest.kt
+++ b/javatests/arcs/android/entity/SameHandleManagerTest.kt
@@ -10,6 +10,7 @@ import arcs.core.entity.HandleManagerTestBase
 import arcs.core.host.EntityHandleManager
 import arcs.core.storage.StoreManager
 import arcs.core.util.Scheduler
+import arcs.jvm.util.testutil.FakeTime
 import arcs.sdk.android.storage.ServiceStoreFactory
 import arcs.sdk.android.storage.service.testutil.TestConnectionFactory
 import kotlinx.coroutines.CoroutineScope

--- a/javatests/arcs/android/host/AndroidEntityHandleManagerTest.kt
+++ b/javatests/arcs/android/host/AndroidEntityHandleManagerTest.kt
@@ -27,6 +27,7 @@ import arcs.core.storage.driver.RamDisk
 import arcs.core.storage.keys.RamDiskStorageKey
 import arcs.core.storage.referencemode.ReferenceModeStorageKey
 import arcs.core.testutil.assertThrows
+import arcs.core.util.Scheduler
 import arcs.jvm.util.testutil.FakeTime
 import arcs.sdk.android.storage.ServiceStoreFactory
 import arcs.sdk.android.storage.service.testutil.TestConnectionFactory
@@ -34,6 +35,7 @@ import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -75,11 +77,11 @@ class AndroidEntityHandleManagerTest : LifecycleOwner {
     )
 
     @Before
-    fun setUp() {
+    fun setUp() = runBlockingTest {
         RamDisk.clear()
         DriverAndKeyConfigurator.configure(null)
         app = ApplicationProvider.getApplicationContext()
-        lifecycle = LifecycleRegistry(this).apply {
+        lifecycle = LifecycleRegistry(this@AndroidEntityHandleManagerTest).apply {
             setCurrentState(Lifecycle.State.CREATED)
             setCurrentState(Lifecycle.State.STARTED)
             setCurrentState(Lifecycle.State.RESUMED)
@@ -94,6 +96,10 @@ class AndroidEntityHandleManagerTest : LifecycleOwner {
             "testArc",
             "testHost",
             FakeTime(),
+            Scheduler(
+                FakeTime(),
+                coroutineContext
+            ),
             StoreManager(),
             ServiceStoreFactory(
                 context = app,

--- a/javatests/arcs/android/host/BUILD
+++ b/javatests/arcs/android/host/BUILD
@@ -77,6 +77,7 @@ arcs_kt_android_library(
         "//java/arcs/android/sdk/host",
         "//java/arcs/core/data",
         "//java/arcs/core/host",
+        "//java/arcs/jvm/host",
         "//java/arcs/sdk",
         "//java/arcs/sdk/android/storage",
         "//java/arcs/sdk/android/storage/service/testutil",

--- a/javatests/arcs/android/host/TestExternalArcHostService.kt
+++ b/javatests/arcs/android/host/TestExternalArcHostService.kt
@@ -15,9 +15,13 @@ import arcs.core.host.TestingHost
 import arcs.sdk.android.storage.ResurrectionHelper
 import arcs.sdk.android.storage.ServiceStoreFactory
 import arcs.sdk.android.storage.service.ConnectionFactory
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.cancel
 
 abstract class TestExternalArcHostService : Service() {
+    protected val scope: CoroutineScope = MainScope()
 
     abstract val arcHost: TestingAndroidHost
 
@@ -32,6 +36,11 @@ abstract class TestExternalArcHostService : Service() {
     }
 
     override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onDestroy() {
+        super.onDestroy()
+        scope.cancel()
+    }
 
     class FakeLifecycle : Lifecycle() {
         override fun addObserver(p0: LifecycleObserver) = Unit

--- a/javatests/arcs/android/host/TestExternalArcHostService.kt
+++ b/javatests/arcs/android/host/TestExternalArcHostService.kt
@@ -10,13 +10,14 @@ import arcs.android.sdk.host.ArcHostHelper
 import arcs.android.sdk.host.ResurrectableHost
 import arcs.core.data.Capabilities
 import arcs.core.host.ParticleRegistration
+import arcs.core.host.SchedulerProvider
 import arcs.core.host.TestingHost
 import arcs.sdk.android.storage.ResurrectionHelper
 import arcs.sdk.android.storage.ServiceStoreFactory
 import arcs.sdk.android.storage.service.ConnectionFactory
 import kotlinx.coroutines.Dispatchers
 
-abstract class TestExternalArcHostService() : Service() {
+abstract class TestExternalArcHostService : Service() {
 
     abstract val arcHost: TestingAndroidHost
 
@@ -40,9 +41,9 @@ abstract class TestExternalArcHostService() : Service() {
 
     abstract class TestingAndroidHost(
         context: Context,
+        schedulerProvider: SchedulerProvider,
         vararg particles: ParticleRegistration
-    ) : TestingHost(*particles), ResurrectableHost {
-
+    ) : TestingHost(schedulerProvider, *particles), ResurrectableHost {
         override val stores = singletonStores
 
         override val resurrectionHelper: ResurrectionHelper =

--- a/javatests/arcs/android/host/TestProdArcHostService.kt
+++ b/javatests/arcs/android/host/TestProdArcHostService.kt
@@ -20,7 +20,7 @@ class TestProdArcHostService : ProdArcHostService() {
     class TestingAndroidProdHost(
         val context: Context,
         val lifecycle: Lifecycle,
-        schedulerProvider: SchedulerProvider
+        schedulerProvider: SchedulerProvider,
         vararg particles: ParticleRegistration
     ) : TestingJvmProdHost(schedulerProvider, *particles) {
         override val activationFactory = ServiceStoreFactory(

--- a/javatests/arcs/android/host/TestProdArcHostService.kt
+++ b/javatests/arcs/android/host/TestProdArcHostService.kt
@@ -4,18 +4,25 @@ import android.content.Context
 import androidx.lifecycle.Lifecycle
 import arcs.android.host.prod.ProdArcHostService
 import arcs.core.host.ParticleRegistration
+import arcs.core.host.SchedulerProvider
 import arcs.core.host.TestingJvmProdHost
+import arcs.jvm.host.JvmSchedulerProvider
 import arcs.sdk.android.storage.ServiceStoreFactory
 import arcs.sdk.android.storage.service.testutil.TestConnectionFactory
 
 class TestProdArcHostService : ProdArcHostService() {
-    override val arcHost = TestingAndroidProdHost(this, this.lifecycle)
+    override val arcHost = TestingAndroidProdHost(
+        this,
+        this.lifecycle,
+        JvmSchedulerProvider(scope.coroutineContext)
+    )
 
     class TestingAndroidProdHost(
         val context: Context,
         val lifecycle: Lifecycle,
+        schedulerProvider: SchedulerProvider
         vararg particles: ParticleRegistration
-    ) : TestingJvmProdHost(*particles) {
+    ) : TestingJvmProdHost(schedulerProvider, *particles) {
         override val activationFactory = ServiceStoreFactory(
             context,
             lifecycle,

--- a/javatests/arcs/android/host/TestReadingExternalHostService.kt
+++ b/javatests/arcs/android/host/TestReadingExternalHostService.kt
@@ -2,15 +2,12 @@ package arcs.android.host
 
 import arcs.core.host.ReadPerson
 import arcs.core.host.toRegistration
-import arcs.core.util.Scheduler
-import arcs.jvm.util.JvmTime
-import kotlinx.coroutines.asCoroutineDispatcher
-import java.util.concurrent.Executors
+import arcs.jvm.host.JvmSchedulerProvider
 
 class TestReadingExternalHostService : TestExternalArcHostService() {
     override val arcHost = object : TestingAndroidHost(
         this@TestReadingExternalHostService,
-        Scheduler(JvmTime, Executors.newSingleThreadExecutor().asCoroutineDispatcher()),
+        JvmSchedulerProvider(scope.coroutineContext),
         ::ReadPerson.toRegistration()
     ) {}
 }

--- a/javatests/arcs/android/host/TestReadingExternalHostService.kt
+++ b/javatests/arcs/android/host/TestReadingExternalHostService.kt
@@ -2,10 +2,15 @@ package arcs.android.host
 
 import arcs.core.host.ReadPerson
 import arcs.core.host.toRegistration
+import arcs.core.util.Scheduler
+import arcs.jvm.util.JvmTime
+import kotlinx.coroutines.asCoroutineDispatcher
+import java.util.concurrent.Executors
 
 class TestReadingExternalHostService : TestExternalArcHostService() {
     override val arcHost = object : TestingAndroidHost(
         this@TestReadingExternalHostService,
+        Scheduler(JvmTime, Executors.newSingleThreadExecutor().asCoroutineDispatcher()),
         ::ReadPerson.toRegistration()
     ) {}
 }

--- a/javatests/arcs/android/host/TestWritingExternalHostService.kt
+++ b/javatests/arcs/android/host/TestWritingExternalHostService.kt
@@ -2,10 +2,15 @@ package arcs.android.host
 
 import arcs.core.host.WritePerson
 import arcs.core.host.toRegistration
+import arcs.core.util.Scheduler
+import arcs.jvm.util.JvmTime
+import kotlinx.coroutines.asCoroutineDispatcher
+import java.util.concurrent.Executors
 
 class TestWritingExternalHostService : TestExternalArcHostService() {
     override val arcHost = object : TestingAndroidHost(
         this@TestWritingExternalHostService,
+        Scheduler(JvmTime, Executors.newSingleThreadExecutor().asCoroutineDispatcher()),
         ::WritePerson.toRegistration()
     ) {}
 }

--- a/javatests/arcs/android/host/TestWritingExternalHostService.kt
+++ b/javatests/arcs/android/host/TestWritingExternalHostService.kt
@@ -2,15 +2,12 @@ package arcs.android.host
 
 import arcs.core.host.WritePerson
 import arcs.core.host.toRegistration
-import arcs.core.util.Scheduler
-import arcs.jvm.util.JvmTime
-import kotlinx.coroutines.asCoroutineDispatcher
-import java.util.concurrent.Executors
+import arcs.jvm.host.JvmSchedulerProvider
 
 class TestWritingExternalHostService : TestExternalArcHostService() {
     override val arcHost = object : TestingAndroidHost(
         this@TestWritingExternalHostService,
-        Scheduler(JvmTime, Executors.newSingleThreadExecutor().asCoroutineDispatcher()),
+        JvmSchedulerProvider(scope.coroutineContext),
         ::WritePerson.toRegistration()
     ) {}
 }

--- a/javatests/arcs/core/allocator/AllocatorTestBase.kt
+++ b/javatests/arcs/core/allocator/AllocatorTestBase.kt
@@ -463,7 +463,16 @@ open class AllocatorTestBase {
         assertThat(readingContext.arcState).isEqualTo(ArcState.Running)
         assertThat(writingContext.arcState).isEqualTo(ArcState.Running)
 
-        val allocator2 = Allocator.create(hostRegistry, EntityHandleManager(time = FakeTime(), scheduler = Scheduler(FakeTime(), Executors.newSingleThreadExecutor().asCoroutineDispatcher())))
+        val allocator2 = Allocator.create(
+            hostRegistry,
+            EntityHandleManager(
+                time = FakeTime(),
+                scheduler = Scheduler(
+                    FakeTime(),
+                    Executors.newSingleThreadExecutor().asCoroutineDispatcher()
+                )
+            )
+        )
 
         allocator2.stopArc(arcId)
 

--- a/javatests/arcs/core/allocator/AllocatorTestBase.kt
+++ b/javatests/arcs/core/allocator/AllocatorTestBase.kt
@@ -50,12 +50,12 @@ open class AllocatorTestBase {
     private lateinit var pureHost: TestingJvmProdHost
 
     private class WritingHost : TestingHost(
-        JvmSchedulerProvider(EmptyCoroutineContext)("writingHost"),
+        JvmSchedulerProvider(EmptyCoroutineContext),
         ::WritePerson.toRegistration()
     )
 
     private class ReadingHost : TestingHost(
-        JvmSchedulerProvider(EmptyCoroutineContext)("readingHost"),
+        JvmSchedulerProvider(EmptyCoroutineContext),
         ::ReadPerson.toRegistration()
     )
 

--- a/javatests/arcs/core/allocator/AllocatorTestBase.kt
+++ b/javatests/arcs/core/allocator/AllocatorTestBase.kt
@@ -12,18 +12,23 @@ import arcs.core.storage.driver.VolatileDriverProvider
 import arcs.core.storage.keys.RamDiskStorageKey
 import arcs.core.storage.keys.VolatileStorageKey
 import arcs.core.testutil.assertSuspendingThrows
+import arcs.core.util.Scheduler
 import arcs.core.util.plus
 import arcs.core.util.traverse
 import arcs.jvm.host.ExplicitHostRegistry
+import arcs.jvm.host.JvmSchedulerProvider
 import arcs.jvm.util.testutil.FakeTime
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.runBlocking
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
+import java.util.concurrent.Executors
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
 
@@ -44,8 +49,15 @@ open class AllocatorTestBase {
     private lateinit var writingExternalHost: TestingHost
     private lateinit var pureHost: TestingJvmProdHost
 
-    private class WritingHost : TestingHost(::WritePerson.toRegistration())
-    private class ReadingHost : TestingHost(::ReadPerson.toRegistration())
+    private class WritingHost : TestingHost(
+        JvmSchedulerProvider(EmptyCoroutineContext)("writingHost"),
+        ::WritePerson.toRegistration()
+    )
+
+    private class ReadingHost : TestingHost(
+        JvmSchedulerProvider(EmptyCoroutineContext)("readingHost"),
+        ::ReadPerson.toRegistration()
+    )
 
     /** Return the [ArcHost] that contains [ReadPerson]. */
     open fun readingHost(): TestingHost = ReadingHost()
@@ -54,7 +66,7 @@ open class AllocatorTestBase {
     open fun writingHost(): TestingHost = WritingHost()
 
     /** Return the [ArcHost] that contains all isolatable [Particle]s. */
-    open fun pureHost() = TestingJvmProdHost()
+    open fun pureHost() = TestingJvmProdHost(JvmSchedulerProvider(EmptyCoroutineContext))
 
     open val storageCapability = Capabilities.TiedToRuntime
     open fun runAllocatorTest(
@@ -84,7 +96,13 @@ open class AllocatorTestBase {
         pureHost = pureHost()
 
         hostRegistry = hostRegistry()
-        allocator = Allocator.create(hostRegistry, EntityHandleManager(time = FakeTime()))
+        allocator = Allocator.create(
+            hostRegistry,
+            EntityHandleManager(
+                time = FakeTime(),
+                scheduler = Scheduler(FakeTime(), coroutineContext)
+            )
+        )
 
         readPersonParticle =
             requireNotNull(PersonPlan.particles.find { it.particleName == "ReadPerson" }) {
@@ -445,7 +463,7 @@ open class AllocatorTestBase {
         assertThat(readingContext.arcState).isEqualTo(ArcState.Running)
         assertThat(writingContext.arcState).isEqualTo(ArcState.Running)
 
-        val allocator2 = Allocator.create(hostRegistry, EntityHandleManager(time = FakeTime()))
+        val allocator2 = Allocator.create(hostRegistry, EntityHandleManager(time = FakeTime(), scheduler = Scheduler(FakeTime(), Executors.newSingleThreadExecutor().asCoroutineDispatcher())))
 
         allocator2.stopArc(arcId)
 

--- a/javatests/arcs/core/entity/BUILD
+++ b/javatests/arcs/core/entity/BUILD
@@ -33,6 +33,7 @@ arcs_kt_jvm_test_suite(
         "//java/arcs/core/storage/referencemode",
         "//java/arcs/core/storage/testutil",
         "//java/arcs/core/testutil",
+        "//java/arcs/core/util",
         "//java/arcs/core/util/testutil",
         "//java/arcs/jvm/util/testutil",
         "//third_party/java/junit:junit-android",

--- a/javatests/arcs/core/entity/DifferentHandleManagerDifferentStoresTest.kt
+++ b/javatests/arcs/core/entity/DifferentHandleManagerDifferentStoresTest.kt
@@ -2,11 +2,14 @@ package arcs.core.entity
 
 import arcs.core.host.EntityHandleManager
 import arcs.core.storage.StoreManager
+import arcs.core.util.Scheduler
 import arcs.jvm.util.testutil.FakeTime
+import kotlinx.coroutines.asCoroutineDispatcher
 import org.junit.After
 import org.junit.Before
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
+import java.util.concurrent.Executors
 
 @Suppress("EXPERIMENTAL_API_USAGE")
 @RunWith(JUnit4::class)
@@ -19,12 +22,20 @@ class DifferentHandleManagerDifferentStoresTest : HandleManagerTestBase() {
             arcId = "testArcId",
             hostId = "testHostId",
             time = FakeTime(),
+            scheduler = Scheduler(
+                FakeTime(),
+                Executors.newSingleThreadExecutor().asCoroutineDispatcher()
+            ),
             stores = StoreManager()
         )
         writeHandleManager = EntityHandleManager(
             arcId = "testArcId",
             hostId = "testHostId",
             time = FakeTime(),
+            scheduler = Scheduler(
+                FakeTime(),
+                Executors.newSingleThreadExecutor().asCoroutineDispatcher()
+            ),
             stores = StoreManager()
         )
     }

--- a/javatests/arcs/core/entity/DifferentHandleManagerTest.kt
+++ b/javatests/arcs/core/entity/DifferentHandleManagerTest.kt
@@ -2,11 +2,14 @@ package arcs.core.entity
 
 import arcs.core.host.EntityHandleManager
 import arcs.core.storage.StoreManager
+import arcs.core.util.Scheduler
 import arcs.jvm.util.testutil.FakeTime
+import kotlinx.coroutines.asCoroutineDispatcher
 import org.junit.After
 import org.junit.Before
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
+import java.util.concurrent.Executors
 
 @Suppress("EXPERIMENTAL_API_USAGE")
 @RunWith(JUnit4::class)
@@ -20,12 +23,20 @@ class DifferentHandleManagerTest : HandleManagerTestBase() {
             arcId = "testArc",
             hostId = "testHost",
             time = FakeTime(),
+            scheduler = Scheduler(
+                FakeTime(),
+                Executors.newSingleThreadExecutor().asCoroutineDispatcher()
+            ),
             stores = stores
         )
         writeHandleManager = EntityHandleManager(
             arcId = "testArc",
             hostId = "testHost",
             time = FakeTime(),
+            scheduler = Scheduler(
+                FakeTime(),
+                Executors.newSingleThreadExecutor().asCoroutineDispatcher()
+            ),
             stores = stores
         )
     }

--- a/javatests/arcs/core/entity/ReferenceTest.kt
+++ b/javatests/arcs/core/entity/ReferenceTest.kt
@@ -12,24 +12,32 @@ import arcs.core.storage.RawEntityDereferencer
 import arcs.core.storage.keys.RamDiskStorageKey
 import arcs.core.storage.referencemode.ReferenceModeStorageKey
 import arcs.core.testutil.assertThrows
+import arcs.core.util.Scheduler
 import arcs.jvm.util.testutil.FakeTime
 import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
+import java.util.concurrent.Executors
 
 @RunWith(JUnit4::class)
 @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
 @Suppress("UNCHECKED_CAST")
 class ReferenceTest {
-    private val dereferencer = RawEntityDereferencer(DummyEntity.SCHEMA)
+    private val scheduler = Scheduler(
+        TimeImpl(),
+        Executors.newSingleThreadExecutor().asCoroutineDispatcher()
+    )
+    private val dereferencer = RawEntityDereferencer(DummyEntity.SCHEMA, scheduler = scheduler)
     private val entityHandleManager = EntityHandleManager(
         "testArc",
         "",
-        FakeTime()
+        FakeTime(),
+        scheduler = scheduler
     )
 
     private lateinit var handle: ReadWriteCollectionHandle<DummyEntity>

--- a/javatests/arcs/core/entity/ReferenceTest.kt
+++ b/javatests/arcs/core/entity/ReferenceTest.kt
@@ -29,7 +29,7 @@ import java.util.concurrent.Executors
 @Suppress("UNCHECKED_CAST")
 class ReferenceTest {
     private val scheduler = Scheduler(
-        TimeImpl(),
+        FakeTime(),
         Executors.newSingleThreadExecutor().asCoroutineDispatcher()
     )
     private val dereferencer = RawEntityDereferencer(DummyEntity.SCHEMA, scheduler = scheduler)

--- a/javatests/arcs/core/entity/SameHandleManagerTest.kt
+++ b/javatests/arcs/core/entity/SameHandleManagerTest.kt
@@ -2,13 +2,16 @@ package arcs.core.entity
 
 import arcs.core.host.EntityHandleManager
 import arcs.core.storage.StoreManager
+import arcs.core.util.Scheduler
 import arcs.core.util.testutil.LogRule
 import arcs.jvm.util.testutil.FakeTime
+import kotlinx.coroutines.asCoroutineDispatcher
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
+import java.util.concurrent.Executors
 
 @Suppress("EXPERIMENTAL_API_USAGE")
 @RunWith(JUnit4::class)
@@ -23,6 +26,10 @@ class SameHandleManagerTest : HandleManagerTestBase() {
             arcId = "testArc",
             hostId = "testHost",
             time = FakeTime(),
+            scheduler = Scheduler(
+                FakeTime(),
+                Executors.newSingleThreadExecutor().asCoroutineDispatcher()
+            ),
             stores = StoreManager()
         )
         writeHandleManager = readHandleManager

--- a/javatests/arcs/core/entity/StorageAdapterTest.kt
+++ b/javatests/arcs/core/entity/StorageAdapterTest.kt
@@ -7,20 +7,23 @@ import arcs.core.data.Ttl
 import arcs.core.data.util.toReferencable
 import arcs.core.storage.StoreManager
 import arcs.core.storage.testutil.DummyStorageKey
+import arcs.core.util.Scheduler
 import arcs.jvm.util.testutil.FakeTime
 import com.google.common.truth.Truth.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
+import kotlin.coroutines.EmptyCoroutineContext
 import arcs.core.storage.Reference as StorageReference
 
 @RunWith(JUnit4::class)
 class StorageAdapterTest {
 
-    private val dereferencerFactory = EntityDereferencerFactory(StoreManager())
-    private val idGenerator = Id.Generator.newForTest("session")
     private val time = FakeTime()
+    private val scheduler = Scheduler(time, EmptyCoroutineContext)
+    private val dereferencerFactory = EntityDereferencerFactory(StoreManager(), scheduler)
+    private val idGenerator = Id.Generator.newForTest("session")
 
     @Before
     fun setUp() {

--- a/javatests/arcs/core/host/BUILD
+++ b/javatests/arcs/core/host/BUILD
@@ -104,6 +104,7 @@ arcs_kt_jvm_library(
         ":pure-particles-jvm",
         ":schemas",
         "//java/arcs/core/host",
+        "//java/arcs/core/util",
         "//java/arcs/jvm/util/testutil",
         "//java/arcs/sdk",
         "//third_party/kotlin/kotlinx_coroutines",

--- a/javatests/arcs/core/host/BUILD
+++ b/javatests/arcs/core/host/BUILD
@@ -28,6 +28,7 @@ arcs_kt_jvm_test_suite(
         "//java/arcs/core/storage/keys",
         "//java/arcs/core/storage/referencemode",
         "//java/arcs/core/testutil",
+        "//java/arcs/core/util",
         "//java/arcs/jvm/host",
         "//java/arcs/jvm/util/testutil",
         "//third_party/java/junit:junit-android",

--- a/javatests/arcs/core/host/HandleAdapterTest.kt
+++ b/javatests/arcs/core/host/HandleAdapterTest.kt
@@ -27,6 +27,7 @@ import arcs.core.storage.keys.RamDiskStorageKey
 import arcs.core.storage.referencemode.ReferenceModeStorageKey
 import arcs.core.testutil.assertSuspendingThrows
 import arcs.core.util.Scheduler
+import arcs.jvm.util.testutil.FakeTime
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
@@ -55,7 +56,7 @@ class HandleAdapterTest {
             "",
             FakeTime(),
             scheduler = Scheduler(
-                TimeImpl(),
+                FakeTime(),
                 coroutineContext
             )
         )

--- a/javatests/arcs/core/host/HandleAdapterTest.kt
+++ b/javatests/arcs/core/host/HandleAdapterTest.kt
@@ -26,7 +26,7 @@ import arcs.core.storage.driver.RamDisk
 import arcs.core.storage.keys.RamDiskStorageKey
 import arcs.core.storage.referencemode.ReferenceModeStorageKey
 import arcs.core.testutil.assertSuspendingThrows
-import arcs.jvm.util.testutil.FakeTime
+import arcs.core.util.Scheduler
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
@@ -48,12 +48,16 @@ class HandleAdapterTest {
     private val idGenerator = Id.Generator.newForTest("session")
 
     @Before
-    fun setUp() {
+    fun setUp() = runBlockingTest {
         DriverAndKeyConfigurator.configure(null)
         manager = EntityHandleManager(
             "testArc",
             "",
-            FakeTime()
+            FakeTime(),
+            scheduler = Scheduler(
+                TimeImpl(),
+                coroutineContext
+            )
         )
     }
 

--- a/javatests/arcs/core/host/TestHost.kt
+++ b/javatests/arcs/core/host/TestHost.kt
@@ -1,9 +1,16 @@
 package arcs.core.host
 
+import arcs.core.util.Scheduler
 import arcs.jvm.util.testutil.FakeTime
 
 class TestHost(
+    scheduler: Scheduler,
     vararg particles: ParticleRegistration
-) : AbstractArcHost(*particles) {
+) : AbstractArcHost(
+    object : SchedulerProvider {
+        override fun invoke(arcId: String) = scheduler
+    },
+    *particles
+) {
     override val platformTime = FakeTime()
 }

--- a/javatests/arcs/core/host/TestingHost.kt
+++ b/javatests/arcs/core/host/TestingHost.kt
@@ -8,8 +8,9 @@ import arcs.jvm.util.testutil.FakeTime
 import kotlinx.coroutines.CompletableDeferred
 
 open class TestingHost(
+    schedulerProvider: SchedulerProvider,
     vararg particles: ParticleRegistration
-) : AbstractArcHost(*particles) {
+) : AbstractArcHost(schedulerProvider, *particles) {
 
     fun arcHostContext(arcId: String) = getArcHostContext(arcId)
 

--- a/javatests/arcs/core/host/TestingJvmProdHost.kt
+++ b/javatests/arcs/core/host/TestingJvmProdHost.kt
@@ -2,6 +2,8 @@ package arcs.core.host
 
 import arcs.jvm.host.scanForParticles
 
-open class TestingJvmProdHost(vararg particles: ParticleRegistration) :
-    TestingHost(*scanForParticles(TestingJvmProdHost::class), *particles),
+open class TestingJvmProdHost(
+    schedulerProvider: SchedulerProvider,
+    vararg particles: ParticleRegistration
+) : TestingHost(schedulerProvider, *scanForParticles(TestingJvmProdHost::class), *particles),
     ProdHost

--- a/javatests/arcs/core/storage/BUILD
+++ b/javatests/arcs/core/storage/BUILD
@@ -29,8 +29,10 @@ arcs_kt_android_test_suite(
         "//java/arcs/core/storage/testutil",  # buildcleaner: keep
         "//java/arcs/core/testutil",
         "//java/arcs/core/type",
+        "//java/arcs/core/util",
         "//java/arcs/core/util/testutil",
         "//java/arcs/jvm/storage/database/testutil",
+        "//java/arcs/jvm/util",
         "//java/arcs/jvm/util/testutil",
         "//third_party/java/junit:junit-android",
         "//third_party/java/mockito:mockito-android",

--- a/javatests/arcs/core/storage/RawEntityDereferencerTest.kt
+++ b/javatests/arcs/core/storage/RawEntityDereferencerTest.kt
@@ -24,7 +24,10 @@ import arcs.core.data.util.toReferencable
 import arcs.core.storage.driver.RamDisk
 import arcs.core.storage.driver.RamDiskDriverProvider
 import arcs.core.storage.keys.RamDiskStorageKey
+import arcs.core.util.Scheduler
+import arcs.jvm.util.JvmTime
 import com.google.common.truth.Truth.assertThat
+import kotlin.coroutines.EmptyCoroutineContext
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Before
@@ -51,7 +54,12 @@ class RawEntityDereferencerTest {
     private lateinit var aliceDriver: Driver<CrdtEntity.Data>
     private lateinit var bobDriver: Driver<CrdtEntity.Data>
     // TODO: Test with an activation factory in android-specific tests.
-    private val dereferencer = RawEntityDereferencer(schema, entityActivationFactory = null)
+    private val scheduler = Scheduler(JvmTime, EmptyCoroutineContext)
+    private val dereferencer = RawEntityDereferencer(
+        schema,
+        entityActivationFactory = null,
+        scheduler = scheduler
+    )
     private val referenceBuilder = { refable: Referencable ->
         if (refable is Reference) refable
         else buildReference(refable)

--- a/javatests/arcs/core/storage/ReferenceTest.kt
+++ b/javatests/arcs/core/storage/ReferenceTest.kt
@@ -25,8 +25,11 @@ import arcs.core.data.util.toReferencable
 import arcs.core.storage.driver.RamDiskDriverProvider
 import arcs.core.storage.keys.RamDiskStorageKey
 import arcs.core.storage.referencemode.ReferenceModeStorageKey
+import arcs.core.util.Scheduler
 import arcs.core.util.testutil.LogRule
+import arcs.jvm.util.JvmTime
 import com.google.common.truth.Truth.assertThat
+import kotlin.coroutines.EmptyCoroutineContext
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runBlockingTest
@@ -43,7 +46,10 @@ class ReferenceTest {
     val log = LogRule()
     private val collectionKey = RamDiskStorageKey("friends")
     private val backingKey = RamDiskStorageKey("people")
-    private val dereferencer = RawEntityDereferencer(Person.SCHEMA)
+    private val dereferencer = RawEntityDereferencer(
+        Person.SCHEMA,
+        scheduler = Scheduler(JvmTime, EmptyCoroutineContext)
+    )
     /* ktlint-disable: max-line-length */
     private lateinit var directCollection: ActiveStore<CrdtSet.Data<Reference>, CrdtSet.Operation<Reference>, Set<Reference>>
     /* ktlint-enable: max-line-length */

--- a/javatests/arcs/jvm/host/BUILD
+++ b/javatests/arcs/jvm/host/BUILD
@@ -1,0 +1,25 @@
+load(
+    "//third_party/java/arcs/build_defs:build_defs.bzl",
+    "arcs_kt_jvm_test_suite",
+)
+
+licenses(["notice"])
+
+package(default_visibility = ["//visibility:public"])
+
+arcs_kt_jvm_test_suite(
+    name = "host",
+    data = ["//java/arcs/core/data/testdata:examples"],
+    package = "arcs.jvm.host",
+    deps = [
+        "//java/arcs/core/util",
+        "//java/arcs/core/util/testutil",
+        "//java/arcs/jvm/host",
+        "//java/arcs/jvm/util",
+        "//java/arcs/jvm/util/testutil",
+        "//third_party/java/junit:junit-android",
+        "//third_party/java/truth:truth-android",
+        "//third_party/kotlin/kotlinx_coroutines",
+        "//third_party/kotlin/kotlinx_coroutines:kotlinx_coroutines_test",
+    ],
+)

--- a/javatests/arcs/jvm/host/BUILD
+++ b/javatests/arcs/jvm/host/BUILD
@@ -12,6 +12,7 @@ arcs_kt_jvm_test_suite(
     data = ["//java/arcs/core/data/testdata:examples"],
     package = "arcs.jvm.host",
     deps = [
+        "//java/arcs/core/testutil",
         "//java/arcs/core/util",
         "//java/arcs/core/util/testutil",
         "//java/arcs/jvm/host",

--- a/javatests/arcs/jvm/host/JvmSchedulerProviderTest.kt
+++ b/javatests/arcs/jvm/host/JvmSchedulerProviderTest.kt
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.jvm.host
+
+import arcs.core.testutil.assertSuspendingThrows
+import arcs.core.util.Scheduler
+import arcs.core.util.testutil.LogRule
+import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.Truth.assertWithMessage
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class JvmSchedulerProviderTest {
+    @get:Rule
+    val log = LogRule()
+
+    @Test
+    fun one_thread_multipleSchedulers() = runBlocking {
+        val schedulerProvider = JvmSchedulerProvider(coroutineContext, 1)
+
+        val schedulerA = schedulerProvider("a")
+        val schedulerB = schedulerProvider("b")
+        val schedulerC = schedulerProvider("c")
+
+        // All should be separate instances.
+        assertThat(schedulerA).isNotEqualTo(schedulerB)
+        assertThat(schedulerA).isNotEqualTo(schedulerC)
+        assertThat(schedulerB).isNotEqualTo(schedulerC)
+
+        // Re-fetching the provider with the same arc-id gives the same scheduler.
+        assertThat(schedulerProvider("a")).isSameInstanceAs(schedulerA)
+        assertThat(schedulerProvider("b")).isSameInstanceAs(schedulerB)
+        assertThat(schedulerProvider("c")).isSameInstanceAs(schedulerC)
+
+        val schedulerAThread = CompletableDeferred<Thread>()
+        val schedulerBThread = CompletableDeferred<Thread>()
+        val schedulerCThread = CompletableDeferred<Thread>()
+
+        // All three run on the same thread.
+        schedulerA.schedule(
+            SimpleProc { schedulerAThread.complete(Thread.currentThread()) }
+        )
+        schedulerB.schedule(
+            SimpleProc { schedulerBThread.complete(Thread.currentThread()) }
+        )
+        schedulerC.schedule(
+            SimpleProc { schedulerCThread.complete(Thread.currentThread()) }
+        )
+        assertThat(schedulerAThread.await()).isEqualTo(schedulerBThread.await())
+        assertThat(schedulerBThread.await()).isEqualTo(schedulerCThread.await())
+
+        schedulerProvider.cancelAll()
+    }
+
+    @Test
+    fun two_threads_threeSchedulers_roundRobin() = runBlocking {
+        val schedulerProvider = JvmSchedulerProvider(coroutineContext, 2)
+
+        val schedulerA = schedulerProvider("a")
+        val schedulerB = schedulerProvider("b")
+        val schedulerC = schedulerProvider("c")
+
+        val schedulerAThread = CompletableDeferred<Thread>()
+        val schedulerBThread = CompletableDeferred<Thread>()
+        val schedulerCThread = CompletableDeferred<Thread>()
+
+        // A and C run on the same thread, but B runs on a different one.
+        schedulerA.schedule(
+            SimpleProc { schedulerAThread.complete(Thread.currentThread()) }
+        )
+        schedulerB.schedule(
+            SimpleProc { schedulerBThread.complete(Thread.currentThread()) }
+        )
+        schedulerC.schedule(
+            SimpleProc { schedulerCThread.complete(Thread.currentThread()) }
+        )
+        assertThat(schedulerAThread.await()).isEqualTo(schedulerCThread.await())
+        assertThat(schedulerBThread.await()).isNotEqualTo(schedulerCThread.await())
+        assertThat(schedulerBThread.await()).isNotEqualTo(schedulerAThread.await())
+
+        schedulerProvider.cancelAll()
+    }
+
+    @Test
+    fun throwing_from_a_task_failsTheParentContext() = runBlocking {
+        val e = assertSuspendingThrows(IllegalStateException::class) {
+            withContext(coroutineContext) {
+                val schedulerProvider = JvmSchedulerProvider(coroutineContext, 1)
+
+                val scheduler = schedulerProvider("a")
+
+                scheduler.schedule (
+                    SimpleProc {
+                        throw IllegalStateException("Washington DC is not a state.")
+                    }
+                )
+
+                scheduler.waitForIdle()
+            }
+        }
+
+        assertThat(e).hasMessageThat().contains("Washington DC is not a state.")
+    }
+
+    @Test
+    fun canceling_thenReInvoking_givesNewScheduler() = runBlocking {
+        val schedulerProvider = JvmSchedulerProvider(coroutineContext, 1)
+
+        val scheduler = schedulerProvider("a")
+
+        assertWithMessage(
+            "While the scheduler is still active, the provider returns the same scheduler " +
+                "for additional calls with the same arcId."
+        ).that(schedulerProvider("a")).isSameInstanceAs(scheduler)
+
+        scheduler.cancel()
+
+        // Delay just a bit to ensure the `invokeOnCompletion` has been called for our scheduler
+        delay(100)
+
+
+        assertWithMessage(
+            "After canceling the original scheduler, we should get a new one, even with the " +
+                "same arcId."
+        ).that(schedulerProvider("a")).isNotEqualTo(scheduler)
+
+        schedulerProvider.cancelAll()
+    }
+
+    private class SimpleProc(block: () -> Unit) : Scheduler.Task.Processor(block)
+}

--- a/javatests/arcs/jvm/host/JvmSchedulerProviderTest.kt
+++ b/javatests/arcs/jvm/host/JvmSchedulerProviderTest.kt
@@ -134,7 +134,6 @@ class JvmSchedulerProviderTest {
         // Delay just a bit to ensure the `invokeOnCompletion` has been called for our scheduler
         delay(100)
 
-
         assertWithMessage(
             "After canceling the original scheduler, we should get a new one, even with the " +
                 "same arcId."

--- a/javatests/arcs/sdk/HandleUtilsTest.kt
+++ b/javatests/arcs/sdk/HandleUtilsTest.kt
@@ -22,15 +22,19 @@ import arcs.core.storage.driver.RamDisk
 import arcs.core.storage.driver.RamDiskDriverProvider
 import arcs.core.storage.keys.RamDiskStorageKey
 import arcs.core.storage.referencemode.ReferenceModeStorageKey
+import arcs.core.util.Scheduler
+import arcs.jvm.util.JvmTime
 import arcs.jvm.util.testutil.FakeTime
 import com.google.common.truth.Truth.assertWithMessage
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.test.runBlockingTest
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
+import java.util.concurrent.Executors
 
 private typealias Person = ReadSdkPerson_Person
 
@@ -41,13 +45,14 @@ class HandleUtilsTest {
     private lateinit var manager: EntityHandleManager
 
     @Before
-    fun setUp() {
+    fun setUp() = runBlockingTest {
         RamDiskDriverProvider()
         ReferenceModeStorageKey.registerParser()
         manager = EntityHandleManager(
             "testArc",
             "testHost",
-            FakeTime()
+            FakeTime(),
+            Scheduler(JvmTime, coroutineContext)
         )
     }
 


### PR DESCRIPTION
Creates `SchedulerProvider`, as well as its first implementation: JvmSchedulerProvider. 

The JvmSchedulerProvider allocates threads using a round-robin approach, up to a defined maximum number of threads allowed per instance.

The scheduler provided to the StorageProxy by the SchedulerProvider associated with the HandleManager isn't actually used yet, that will happen in a follow-on PR.