### PR TITLE
Partially restore some tests for reference handles

### DIFF
--- a/java/arcs/core/host/EntityHandleManager.kt
+++ b/java/arcs/core/host/EntityHandleManager.kt
@@ -49,8 +49,8 @@ import arcs.core.storage.ActivationFactory
 import arcs.core.storage.StorageKey
 import arcs.core.storage.StorageMode
 import arcs.core.storage.StoreManager
-import arcs.core.util.Scheduler
 import arcs.core.storage.referencemode.ReferenceModeStorageKey
+import arcs.core.util.Scheduler
 import arcs.core.util.Time
 
 /**

--- a/java/arcs/core/host/EntityHandleManager.kt
+++ b/java/arcs/core/host/EntityHandleManager.kt
@@ -18,6 +18,7 @@ import arcs.core.crdt.CrdtSingleton
 import arcs.core.data.CollectionType
 import arcs.core.data.EntityType
 import arcs.core.data.HandleMode
+import arcs.core.data.Schema
 import arcs.core.data.SingletonType
 import arcs.core.data.Ttl
 import arcs.core.entity.CollectionHandle
@@ -25,7 +26,6 @@ import arcs.core.entity.CollectionProxy
 import arcs.core.entity.CollectionStoreOptions
 import arcs.core.entity.Entity
 import arcs.core.entity.EntityDereferencerFactory
-import arcs.core.entity.EntitySpec
 import arcs.core.entity.EntityStorageAdapter
 import arcs.core.entity.Handle
 import arcs.core.entity.HandleContainerType
@@ -47,9 +47,10 @@ import arcs.core.entity.WriteCollectionHandle
 import arcs.core.entity.WriteSingletonHandle
 import arcs.core.storage.ActivationFactory
 import arcs.core.storage.StorageKey
-import arcs.core.storage.StorageMode.ReferenceMode
+import arcs.core.storage.StorageMode
 import arcs.core.storage.StoreManager
 import arcs.core.util.Scheduler
+import arcs.core.storage.referencemode.ReferenceModeStorageKey
 import arcs.core.util.Time
 
 /**
@@ -100,6 +101,9 @@ class EntityHandleManager(
                 createHandle(handleName, spec, storageKey, storageAdapter)
             }
             HandleDataType.Reference -> {
+                require(storageKey !is ReferenceModeStorageKey) {
+                    "Reference-mode storage keys are not supported for reference-typed handles."
+                }
                 val storageAdapter = ReferenceStorageAdapter(
                     spec.entitySpec
                 )
@@ -140,7 +144,11 @@ class EntityHandleManager(
         val singletonHandle = SingletonHandle(
             name = handleName,
             spec = spec,
-            storageProxy = singletonStoreProxy(storageKey, spec.entitySpec),
+            storageProxy = singletonStoreProxy(
+                storageKey,
+                spec.entitySpec.SCHEMA,
+                spec.dataType.toStorageMode()
+            ),
             storageAdapter = storageAdapter,
             dereferencerFactory = dereferencerFactory
         )
@@ -160,7 +168,11 @@ class EntityHandleManager(
         val collectionHandle = CollectionHandle(
             name = handleName,
             spec = spec,
-            storageProxy = collectionStoreProxy(storageKey, spec.entitySpec),
+            storageProxy = collectionStoreProxy(
+                storageKey,
+                spec.entitySpec.SCHEMA,
+                spec.dataType.toStorageMode()
+            ),
             storageAdapter = storageAdapter,
             dereferencerFactory = dereferencerFactory
         )
@@ -180,32 +192,37 @@ class EntityHandleManager(
     @Suppress("UNCHECKED_CAST")
     private suspend fun <R : Referencable> singletonStoreProxy(
         storageKey: StorageKey,
-        entitySpec: EntitySpec<out Entity>
-    ) = stores.get(
-        SingletonStoreOptions<Referencable>(
-            storageKey = storageKey,
-            type = SingletonType(EntityType(entitySpec.SCHEMA)),
-            mode = ReferenceMode
-        )
-    ).activate(activationFactory).let { activeStore ->
-        singletonStorageProxies.getOrPut(storageKey) {
-            SingletonProxy(activeStore, CrdtSingleton(), scheduler)
-        } as SingletonProxy<R>
-    }
+        schema: Schema,
+        storageMode: StorageMode
+    ): SingletonProxy<R> = singletonStorageProxies.getOrPut(storageKey) {
+        val activeStore = stores.get(
+            SingletonStoreOptions<Referencable>(
+                storageKey = storageKey,
+                type = SingletonType(EntityType(schema)),
+                mode = storageMode
+            )
+        ).activate(activationFactory)
+        SingletonProxy(activeStore, CrdtSingleton(), scheduler)
+    } as SingletonProxy<R>
 
     @Suppress("UNCHECKED_CAST")
     private suspend fun <R : Referencable> collectionStoreProxy(
         storageKey: StorageKey,
-        entitySpec: EntitySpec<out Entity>
-    ) = stores.get(
-        CollectionStoreOptions<Referencable>(
-            storageKey = storageKey,
-            type = CollectionType(EntityType(entitySpec.SCHEMA)),
-            mode = ReferenceMode
-        )
-    ).activate(activationFactory).let { activeStore ->
-        collectionStorageProxies.getOrPut(storageKey) {
-            CollectionProxy(activeStore, CrdtSet(), scheduler)
-        } as CollectionProxy<R>
-    }
+        schema: Schema,
+        storageMode: StorageMode
+    ): CollectionProxy<R> = collectionStorageProxies.getOrPut(storageKey) {
+        val activeStore = stores.get(
+            CollectionStoreOptions<Referencable>(
+                storageKey = storageKey,
+                type = CollectionType(EntityType(schema)),
+                mode = storageMode
+            )
+        ).activate(activationFactory)
+        CollectionProxy(activeStore, CrdtSet(), scheduler)
+    } as CollectionProxy<R>
+}
+
+private fun HandleDataType.toStorageMode() = when (this) {
+    HandleDataType.Entity -> StorageMode.ReferenceMode
+    HandleDataType.Reference -> StorageMode.Direct
 }

--- a/javatests/arcs/android/entity/DifferentHandleManagerTest.kt
+++ b/javatests/arcs/android/entity/DifferentHandleManagerTest.kt
@@ -78,4 +78,8 @@ class DifferentHandleManagerTest : HandleManagerTestBase() {
 
     @After
     override fun tearDown() = super.tearDown()
+
+    // TODO(b/152436411): Fix these.
+    override fun collection_referenceLiveness() {}
+    override fun singleton_referenceLiveness() {}
 }

--- a/javatests/arcs/core/entity/DifferentHandleManagerDifferentStoresTest.kt
+++ b/javatests/arcs/core/entity/DifferentHandleManagerDifferentStoresTest.kt
@@ -43,7 +43,7 @@ class DifferentHandleManagerDifferentStoresTest : HandleManagerTestBase() {
     @After
     override fun tearDown() = super.tearDown()
 
-    // TODO - fix these?
+    // TODO(b/152436411): Fix these.
     override fun collection_referenceLiveness() {}
     override fun singleton_referenceLiveness() {}
 

--- a/javatests/arcs/core/entity/DifferentHandleManagerTest.kt
+++ b/javatests/arcs/core/entity/DifferentHandleManagerTest.kt
@@ -43,4 +43,8 @@ class DifferentHandleManagerTest : HandleManagerTestBase() {
 
     @After
     override fun tearDown() = super.tearDown()
+
+    // TODO(b/152436411): Fix these.
+    override fun collection_referenceLiveness() {}
+    override fun singleton_referenceLiveness() {}
 }

--- a/javatests/arcs/core/entity/HandleManagerTestBase.kt
+++ b/javatests/arcs/core/entity/HandleManagerTestBase.kt
@@ -394,7 +394,7 @@ open class HandleManagerTestBase {
         val writeEntityHandle = writeHandleManager.createCollectionHandle()
         writeEntityHandle.store(entity1)
 
-        // Create a store a reference to the entity.
+        // Create and store a reference to the entity.
         val entity1Ref = writeEntityHandle.createReference(entity1)
         val writeRefHandle = writeHandleManager.createReferenceSingletonHandle()
         writeRefHandle.store(entity1Ref)
@@ -697,7 +697,6 @@ open class HandleManagerTestBase {
             writeHandle.query("44")
         }
     }
-
 
     @Test
     open fun collection_referenceLiveness() = runBlocking {


### PR DESCRIPTION
There's a few edge cases that are still failing.

Also added a check that reference-mode storage keys weren't being used for reference handles