### PR TITLE
Fix androidhost singleton stores

### DIFF
--- a/java/arcs/android/sdk/host/AndroidHost.kt
+++ b/java/arcs/android/sdk/host/AndroidHost.kt
@@ -48,5 +48,11 @@ abstract class AndroidHost(
         resurrectionHelper.cancelResurrectionRequest(context.arcId)
     }
 
-    override val stores: StoreManager = StoreManager()
+    /*
+     * Android uses [StorageService] which is a persistent process, so we don't share
+     * [ActiveStore] between [EntityHandleManager]s, but use a new [StoreManager] for each
+     * new arc. Otherwise, when closing an [ActiveStore] when one Arc is shutdown leads to the
+     * handles being unusable in other arcs that are still arctive.
+     */
+    override val stores: StoreManager get() = StoreManager()
 }

--- a/java/arcs/android/sdk/host/AndroidHost.kt
+++ b/java/arcs/android/sdk/host/AndroidHost.kt
@@ -17,6 +17,7 @@ import arcs.core.host.ArcHostContext
 import arcs.core.host.ArcState
 import arcs.core.host.ParticleRegistration
 import arcs.core.host.SchedulerProvider
+import arcs.core.storage.StoreManager
 import arcs.jvm.host.JvmHost
 import arcs.sdk.android.storage.ResurrectionHelper
 import arcs.sdk.android.storage.ServiceStoreFactory
@@ -46,4 +47,6 @@ abstract class AndroidHost(
     override fun maybeCancelResurrection(context: ArcHostContext) {
         resurrectionHelper.cancelResurrectionRequest(context.arcId)
     }
+
+    override val stores: StoreManager = StoreManager()
 }

--- a/java/arcs/android/sdk/host/BUILD
+++ b/java/arcs/android/sdk/host/BUILD
@@ -13,6 +13,7 @@ arcs_kt_android_library(
         "//java/arcs/android/type",
         "//java/arcs/core/data",
         "//java/arcs/core/host",
+        "//java/arcs/core/storage",
         "//java/arcs/core/storage:storage_key",
         "//java/arcs/jvm/host",
         "//java/arcs/sdk/android/storage",


### PR DESCRIPTION
On non-Android platforms, all ArcHosts share a single StoreManager so that they do not create multiple instances of the entire storage layer. 

However, on Android, the Storage layer runs as a persistent process, effectively a system wide singleton. Sharing the StoreManager between two ArcHosts here creates a problem, because ServiceStore is connected to Android Lifecycle, and it's onLifecycleDestroy method nulls out the service connection, meaning if one ArcHost shuts down, they all lose their connections. 

This override fixes the problem for Android, however we probably have to revisit the solution for non-Android hosts so better simulate the 'persistent storage process' that Android has, instead of faking it on the client connection side.

