### PR TITLE
A bigger example for recipe2plan

### DIFF
--- a/java/arcs/core/data/testdata/BUILD
+++ b/java/arcs/core/data/testdata/BUILD
@@ -3,6 +3,8 @@ load(
     "arcs_kt_gen",
 )
 
+package(default_visibility = ["//visibility:public"])
+
 licenses(["notice"])
 
 filegroup(
@@ -11,11 +13,15 @@ filegroup(
         ["*"],
         exclude = ["BUILD"],
     ),
-    visibility = ["//visibility:public"],
 )
 
 arcs_kt_gen(
     name = "example_gen",
     srcs = ["WriterReaderExample.arcs"],
-    visibility = ["//visibility:public"],
 )
+
+# TODO(b/153689275): It doesn't resovle currently, can we investigate why?
+# arcs_kt_gen(
+#     name = "ingest_process_retrieve_gen",
+#     srcs = ["IngestProcessRetrieve.arcs"]
+# )

--- a/java/arcs/core/data/testdata/IngestProcessRetrieve.arcs
+++ b/java/arcs/core/data/testdata/IngestProcessRetrieve.arcs
@@ -1,0 +1,79 @@
+// Big example for recipe2plan generation.
+
+meta
+  namespace: arcs.core.data.testdata.gen
+
+schema Event
+    type: Text
+    timestamp: Number
+    value: Text
+
+particle Ingestion
+  events: writes [Event {type, timestamp, value}]
+
+// Example: Long running arc ingesting events into a collection.
+@trigger
+  launch startup
+  arcId eventIngestion
+recipe EventsIngestion
+  // Example: Handle created with id, capabilities and TTL.
+  events: create persistent 'raw-events' @ttl(1d)
+  Ingestion
+    events: events
+
+schema AnalyzedEvent
+  sentiment: Number
+  cohortIndex: Number
+
+particle AnalyzeSentiment
+  events: reads [Event {type, value}]
+  processed: writes [AnalyzedEvent {sentiment, cohortIndex}]
+
+particle SummarizeSentiment
+  pieces: reads [AnalyzedEvent {sentiment, cohortIndex}]
+  result: writes OverallSentiment {
+    overallSentiment: Number,
+    sentimentCohortBreakdown: [Number],
+    summary: Text
+  }
+
+// Example: Long running arc mapping data from another long running arc
+//          and providing data derived from the mapped data.
+@trigger
+  launch startup
+  arcId sentimentAnalysis
+recipe SentimentAnalyzer
+  // Example: Mapping by id and type; mapping a collection.
+  events: map 'raw-events'
+  // Example: Handle created without capabilities in a long running arc.
+  processed: create
+  summary: create 'events-summary' @ttl(15d)
+  AnalyzeSentiment
+    events: reads events
+    processed: writes processed
+  SummarizeSentiment
+    pieces: reads processed
+    result: writes summary
+
+particle RequestProvider
+  request: writes SentimentRequest {cohortId: Number}
+
+particle ResponseCalculator
+  request: reads SentimentRequest {cohortId: Number}
+  sentimentPerCohort: reads OverallSentiment {sentimentCohortBreakdown: [Number]}
+  response: writes SentimentResponse {sentimentValue: Number}
+
+// Example: Ephemeral arc mapping data from long running arc.
+recipe RequestHandler
+  // Example: Mapping through type alone; mapping a singleton.
+  sentimentSummary: map 'events-summary'
+  // Example: Handle created without capabilities in an ephemeral arc.
+  request: create
+  // Example: Handle created with capabilities in an ephemeral arc.
+  response: create tied-to-arc
+  RequestProvider
+    request: writes request
+  ResponseCalculator
+    request: reads request
+    sentimentPerCohort: reads sentimentSummary
+    response: writes response


### PR DESCRIPTION
This example has 3 recipes:
1) Ingestion of events into a collection
2) Processing of events into a summary
3) Ephemeral request handling using the calculated summary of events.

It contains a number of interesting cases:
1) Mapping from long running arc to long running arc
2) Mapping from long running arc to ephemeral arc
3) Collections and Singletons
4) Mapped as well as created handles
5) Create handles with and without capabilities
6) Create handles with and without ids
7) Reading / Writing type asymmetry

It currently does not work with the following error:
```
{ StorageKeyRecipeResolverError: Recipe RequestHandler failed to resolve:
Cannot find a handle matching requested type and tags.
Cannot find a handle matching requested type and tags.
cannot find associated store
Resolver generated 0 recipes
    at StorageKeyRecipeResolver.tryResolve (file:///Users/piotrs/arcsy/arcs/build/tools/storage-key-recipe-resolver.js:72:19) name: 'StorageKeyRecipeResolverError' }
```

Can we maybe land this and in the follow up patch we uncomment building and fix the problems?