### PR TITLE
Add a `close` method to `StorageProxy` and `EntityHandleManager`

### DIFF
--- a/java/arcs/core/host/AbstractArcHost.kt
+++ b/java/arcs/core/host/AbstractArcHost.kt
@@ -442,6 +442,7 @@ abstract class AbstractArcHost(
             stopParticle(particleContext)
         }
         maybeCancelResurrection(context)
+        context.entityHandleManager.close()
         context.arcState = ArcState.Stopped
         updateArcHostContext(arcId, context)
     }

--- a/javatests/arcs/android/e2e/testapp/StorageAccessService.kt
+++ b/javatests/arcs/android/e2e/testapp/StorageAccessService.kt
@@ -76,6 +76,7 @@ class StorageAccessService : LifecycleService() {
                     }
 
                     singletonHandle.close()
+                    handleManager.close()
                 }
             }
 

--- a/javatests/arcs/core/entity/BUILD
+++ b/javatests/arcs/core/entity/BUILD
@@ -35,10 +35,12 @@ arcs_kt_jvm_test_suite(
         "//java/arcs/core/testutil",
         "//java/arcs/core/util",
         "//java/arcs/core/util/testutil",
+        "//java/arcs/jvm/host",
         "//java/arcs/jvm/util/testutil",
         "//third_party/java/junit:junit-android",
         "//third_party/java/truth:truth-android",
         "//third_party/kotlin/kotlinx_coroutines",
+        "//third_party/kotlin/kotlinx_coroutines:kotlinx_coroutines_test",
     ],
 )
 

--- a/javatests/arcs/core/entity/HandleManagerCloseTest.kt
+++ b/javatests/arcs/core/entity/HandleManagerCloseTest.kt
@@ -1,0 +1,149 @@
+package arcs.core.entity
+
+import arcs.core.data.HandleMode
+import arcs.core.data.Ttl
+import arcs.core.entity.HandleManagerTestBase.Hat
+import arcs.core.entity.HandleManagerTestBase.Person
+import arcs.core.host.EntityHandleManager
+import arcs.core.storage.StorageKey
+import arcs.core.storage.api.DriverAndKeyConfigurator
+import arcs.core.storage.keys.RamDiskStorageKey
+import arcs.core.storage.referencemode.ReferenceModeStorageKey
+import arcs.core.testutil.assertSuspendingThrows
+import arcs.jvm.host.JvmSchedulerProvider
+import arcs.jvm.util.testutil.FakeTime
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import java.lang.IllegalStateException
+import kotlin.coroutines.EmptyCoroutineContext
+
+@RunWith(JUnit4::class)
+class HandleManagerCloseTest {
+
+    val scheduler = JvmSchedulerProvider(EmptyCoroutineContext).invoke("test")
+
+    private val backingKey = RamDiskStorageKey("entities")
+    private val singletonRefKey = RamDiskStorageKey("single-ent")
+    private val singletonKey = ReferenceModeStorageKey(
+        backingKey = backingKey,
+        storageKey = singletonRefKey
+    )
+
+    private val collectionRefKey = RamDiskStorageKey("collection-ent")
+    private val collectionKey = ReferenceModeStorageKey(
+        backingKey = backingKey,
+        storageKey = collectionRefKey
+    )
+
+    @Before
+    fun setup() {
+        DriverAndKeyConfigurator.configure(null)
+        SchemaRegistry.register(Person)
+        SchemaRegistry.register(Hat)
+    }
+
+    fun createHandleManager() = EntityHandleManager("testArc", "", FakeTime(), scheduler)
+
+    @Test
+    fun closehandleManagerStopUpdates() = runBlockingTest {
+        val handleManagerA = createHandleManager()
+        val handleManagerB = createHandleManager()
+
+        val handleA = handleManagerA.createSingletonHandle()
+
+        val handleB = handleManagerB.createSingletonHandle()
+        var updates = 0
+        handleB.onUpdate {
+            updates++
+        }
+
+        handleA.store(Person("e1", "p1", 1, true))
+        assertThat(updates).isEqualTo(1)
+
+        handleManagerB.close()
+
+        handleA.store(Person("e2", "p2", 2, true))
+        assertThat(updates).isEqualTo(1)
+    }
+
+    @Test
+    fun singleton_closeHandleManagerThrowsExceptionOnOperations() = runBlockingTest {
+        val handleManager = createHandleManager()
+
+        val handle = handleManager.createSingletonHandle()
+
+        handleManager.close()
+
+        val person = Person("1","p",1,true)
+
+        listOf(
+            suspend { handle.store(person) },
+            suspend { handle.onUpdate {} },
+            suspend { handle.onReady {} },
+            suspend { handle.onResync{} },
+            suspend { handle.onDesync{} },
+            suspend { handle.clear() },
+            suspend { handle.createReference(person); Unit },
+            suspend { handle.fetch(); Unit }
+        ).forEach { assertSuspendingThrows(IllegalStateException::class) { it() } }
+    }
+
+    @Test
+    fun collection_closeHandleManagerThrowsExceptionOnOperations() = runBlockingTest {
+        val handleManager = createHandleManager()
+
+        val handle = handleManager.createCollectionHandle()
+
+        handleManager.close()
+
+        val person = Person("1","p",1,true)
+
+        listOf(
+            suspend { handle.store(person) },
+            suspend { handle.remove(person) },
+            suspend { handle.onUpdate {} },
+            suspend { handle.onReady {} },
+            suspend { handle.onResync {} },
+            suspend { handle.onDesync {} },
+            suspend { handle.clear() },
+            suspend { handle.createReference(person); Unit },
+            suspend { handle.fetchAll(); Unit },
+            suspend { handle.size(); Unit },
+            suspend { handle.isEmpty(); Unit }
+        ).forEach { assertSuspendingThrows(IllegalStateException::class) { it() } }
+    }
+
+    private suspend fun EntityHandleManager.createSingletonHandle(
+        storageKey: StorageKey = singletonKey,
+        name: String = "singletonHandle",
+        ttl: Ttl = Ttl.Infinite
+    ) = createHandle(
+        HandleSpec(
+            name,
+            HandleMode.ReadWrite,
+            HandleContainerType.Singleton,
+            Person
+        ),
+        storageKey,
+        ttl
+    ) as ReadWriteSingletonHandle<Person>
+
+    private suspend fun EntityHandleManager.createCollectionHandle(
+        storageKey: StorageKey = collectionKey,
+        name: String = "collecitonKey",
+        ttl: Ttl = Ttl.Infinite
+    ) = createHandle(
+        HandleSpec(
+            name,
+            HandleMode.ReadWrite,
+            HandleContainerType.Collection,
+            Person
+        ),
+        storageKey,
+        ttl
+    ) as ReadWriteCollectionHandle<Person>
+}

--- a/javatests/arcs/core/entity/HandleManagerTestBase.kt
+++ b/javatests/arcs/core/entity/HandleManagerTestBase.kt
@@ -13,7 +13,6 @@ import arcs.core.data.util.ReferencablePrimitive
 import arcs.core.data.util.toReferencable
 import arcs.core.host.EntityHandleManager
 import arcs.core.storage.DriverFactory
-import arcs.core.storage.Reference as StorageReference
 import arcs.core.storage.StorageKey
 import arcs.core.storage.api.DriverAndKeyConfigurator
 import arcs.core.storage.driver.RamDisk
@@ -30,6 +29,7 @@ import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Test
+import arcs.core.storage.Reference as StorageReference
 
 @Suppress("EXPERIMENTAL_API_USAGE", "UNCHECKED_CAST")
 open class HandleManagerTestBase {
@@ -838,6 +838,7 @@ open class HandleManagerTestBase {
         storageKey,
         ttl
     ) as ReadWriteQueryCollectionHandle<Reference<Person>, Any>
+
     private suspend fun <T> ReadableHandle<T>.onUpdateDeferred(
         predicate: (T) -> Boolean = { true }
     ): Deferred<T> = CompletableDeferred<T>().also { deferred ->

--- a/javatests/arcs/core/storage/StorageProxyTest.kt
+++ b/javatests/arcs/core/storage/StorageProxyTest.kt
@@ -415,6 +415,13 @@ class StorageProxyTest {
         assertThat(proxyMap).isNotEqualTo(proxy.getVersionMap())
     }
 
+    @Test
+    fun closeStorageProxy_closesStoreEndpoint() = runBlockingTest {
+        val proxy = StorageProxy(mockStorageEndpointProvider, mockCrdtModel, scheduler)
+        proxy.close()
+        assertThat(fakeStoreEndpoint.closed)
+    }
+
     // Convenience wrapper for destructuring.
     private data class ActionMocks (
         val onReady: () -> Unit = mock(),

--- a/javatests/arcs/core/storage/StoreEndpointFake.kt
+++ b/javatests/arcs/core/storage/StoreEndpointFake.kt
@@ -13,6 +13,7 @@ class StoreEndpointFake<Data : CrdtData, Op : CrdtOperation, T> :
     StorageCommunicationEndpoint<Data, Op, T> {
     private val mutex = Mutex()
     private var proxyMessages = mutableListOf<ProxyMessage<Data, Op, T>>()
+    var closed = false
 
     // Tests can change this field to alter the value returned by `onProxyMessage`.
     var onProxyMessageReturn = true
@@ -30,5 +31,7 @@ class StoreEndpointFake<Data : CrdtData, Op : CrdtOperation, T> :
         mutex.withLock { proxyMessages.clear() }
     }
 
-    override fun close() {}
+    override fun close() {
+        closed = true
+    }
 }


### PR DESCRIPTION
The `close` method on `StorageProxy` will disconnect it from storage,
and render it unusable. Attempting a subsequent operation will cause it
throw an exception.

The `close` method on `EntityHandleManager` will call `close` on all
`StorageProxy` instances that `EntityHandleManager` is currently
holding.