### PR TITLE
Fix `BackingStore` race and `Volatile` race

### DIFF
--- a/java/arcs/core/storage/driver/Volatile.kt
+++ b/java/arcs/core/storage/driver/Volatile.kt
@@ -71,13 +71,15 @@ data class VolatileDriverProvider(private val arcId: ArcId) : DriverProvider {
             storageKey is VolatileStorageKey || storageKey is RamDiskStorageKey
         ) { "Invalid storage key type: $storageKey" }
 
-        val dataForCriteria: VolatileEntry<Data> = memory.get<Data>(storageKey)?.also {
-            pendingModel = it.data
-            pendingVersion = it.version
-        } ?: VolatileEntry()
+        synchronized(memory) {
+            val dataForCriteria: VolatileEntry<Data> = memory.get<Data>(storageKey)?.also {
+                pendingModel = it.data
+                pendingVersion = it.version
+            } ?: VolatileEntry()
 
-        // Add the data to the memory.
-        memory[storageKey] = dataForCriteria.copy(drivers = dataForCriteria.drivers + this)
+            // Add the data to the memory.
+            memory[storageKey] = dataForCriteria.copy(drivers = dataForCriteria.drivers + this)
+        }
         log.debug { "Created" }
     }
 

--- a/javatests/arcs/core/storage/BUILD
+++ b/javatests/arcs/core/storage/BUILD
@@ -22,6 +22,7 @@ arcs_kt_android_test_suite(
         "//java/arcs/core/data",
         "//java/arcs/core/data/util:data-util",
         "//java/arcs/core/storage",
+        "//java/arcs/core/storage/api",
         "//java/arcs/core/storage/database",
         "//java/arcs/core/storage/driver",
         "//java/arcs/core/storage/keys",

--- a/javatests/arcs/core/storage/BackingStoreTest.kt
+++ b/javatests/arcs/core/storage/BackingStoreTest.kt
@@ -1,0 +1,102 @@
+package arcs.core.storage
+
+import arcs.core.crdt.CrdtEntity
+import arcs.core.crdt.CrdtSingleton
+import arcs.core.crdt.VersionMap
+import arcs.core.data.EntityType
+import arcs.core.data.FieldType
+import arcs.core.data.Schema
+import arcs.core.data.SchemaFields
+import arcs.core.data.util.toReferencable
+import arcs.core.storage.api.DriverAndKeyConfigurator
+import arcs.core.storage.keys.RamDiskStorageKey
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class BackingStoreTest {
+
+    @Test
+    fun backingStoreNoRace() = runBlocking<Unit>(Dispatchers.IO) {
+        DriverAndKeyConfigurator.configure(null)
+
+        val storageKey = RamDiskStorageKey("test")
+
+        val schema = Schema(
+            emptySet(),
+            SchemaFields(
+                singletons = mapOf(
+                    "field" to FieldType.Text
+                ),
+                collections =emptyMap()
+            ),
+            "abc"
+        )
+
+        var callbacks = 0
+        val callback = ProxyCallback<CrdtEntity.Data, CrdtEntity.Operation, CrdtEntity> {
+            callbacks++
+        }
+
+        val backingStore = BackingStore(
+            storageKey = storageKey,
+            backingType = EntityType(schema),
+            callbackFactory = { callback }
+        )
+
+        val vm1 = VersionMap("first" to 1)
+        val value = CrdtSingleton(
+            initialVersion = vm1,
+            initialData = CrdtEntity.Reference.buildReference("xyz".toReferencable())
+        )
+        val data = CrdtEntity.Data(
+            versionMap = vm1,
+            singletons = mapOf(
+                "field" to value
+            )
+        )
+
+        // Attempt to trigger a child store setup race
+        coroutineScope {
+            launch { backingStore.getLocalData("a") }
+            launch { backingStore.onProxyMessage(ProxyMessage.ModelUpdate(data, 1), "a") }
+            launch { backingStore.getLocalData("a") }
+            launch { backingStore.onProxyMessage(ProxyMessage.ModelUpdate(data, 1), "a") }
+            launch { backingStore.getLocalData("a") }
+            launch { backingStore.onProxyMessage(ProxyMessage.ModelUpdate(data, 1), "a") }
+        }
+
+        val otherStore = DirectStore.create<CrdtEntity.Data, CrdtEntity.Operation, CrdtEntity>(
+            StoreOptions(
+                storageKey = storageKey.childKeyWithComponent("a"),
+                type = EntityType(schema)
+            )
+        )
+
+        val newValue = CrdtSingleton(
+            initialVersion= VersionMap("other" to 2),
+            initialData =  CrdtEntity.Reference.buildReference("asdfadf".toReferencable())
+        )
+        val newData = CrdtEntity.Data(
+            versionMap = VersionMap("other" to 2),
+            singletons = mapOf(
+                "field" to newValue
+            )
+        )
+
+        coroutineScope {
+            otherStore.onProxyMessage(
+                ProxyMessage.ModelUpdate(
+                    newData, 1
+                )
+            )
+        }
+        assertThat(callbacks).isEqualTo(1)
+    }
+}

--- a/javatests/arcs/core/storage/ReferenceModeStoreTest.kt
+++ b/javatests/arcs/core/storage/ReferenceModeStoreTest.kt
@@ -594,8 +594,7 @@ class ReferenceModeStoreTest {
             )
         )
 
-        val backingStore = activeStore.backingStore.stores["an-id"]
-            ?: activeStore.backingStore.setupStore("an-id")
+        val backingStore = activeStore.backingStore.store("an-id")
         backingStore.store.onReceive(entityCrdt.data, id + 2)
 
         activeStore.idle()


### PR DESCRIPTION
Discovered a BackingStore race while debugging an e2e test.

While trying to write a test to verify the BackingStore race fix, I
discovered a `VolatileDriver` init race, as well.