### PR TITLE
Adds a helper class [BoundedAbstractElement].

### DIFF
--- a/java/arcs/core/analysis/BoundedAbstractElement.kt
+++ b/java/arcs/core/analysis/BoundedAbstractElement.kt
@@ -33,7 +33,7 @@ package arcs.core.analysis
  * }
  * ```
  */
-data class BoundedAbstractElement<V: Any> private constructor(
+data class BoundedAbstractElement<V : Any> private constructor(
     private val kind: Kind,
     val value: V?
 ) {
@@ -88,12 +88,12 @@ data class BoundedAbstractElement<V: Any> private constructor(
 
     companion object {
         /** Returns a canonical top value. */
-        fun <V: Any> getTop() = BoundedAbstractElement<V>(Kind.TOP, null)
+        fun <V : Any> getTop() = BoundedAbstractElement<V>(Kind.TOP, null)
 
         /** Returns a canonical bottom value. */
-        fun <V: Any> getBottom() = BoundedAbstractElement<V>(Kind.BOTTOM, null)
+        fun <V : Any> getBottom() = BoundedAbstractElement<V>(Kind.BOTTOM, null)
 
         /** Returns an instance that wraps [value]. */
-        fun <V: Any> makeValue(value: V) = BoundedAbstractElement<V>(Kind.VALUE, value)
+        fun <V : Any> makeValue(value: V) = BoundedAbstractElement<V>(Kind.VALUE, value)
     }
 }

--- a/java/arcs/core/analysis/BoundedAbstractElement.kt
+++ b/java/arcs/core/analysis/BoundedAbstractElement.kt
@@ -63,6 +63,21 @@ data class BoundedAbstractElement<V: Any> private constructor(
         }
     }
 
+    /** A helper for implementing [AbstractValue.meet]. */
+    fun meet(other: BoundedAbstractElement<V>, meeter: (V, V) -> V): BoundedAbstractElement<V> {
+        return when (this.kind) {
+            Kind.BOTTOM -> this /* returns bottom */
+            Kind.TOP -> other
+            Kind.VALUE -> when (other.kind) {
+                Kind.VALUE -> makeValue(
+                    meeter(requireNotNull(this.value), requireNotNull(other.value))
+                )
+                Kind.TOP -> this
+                Kind.BOTTOM -> other /* returns bottom */
+            }
+        }
+    }
+
     companion object {
         /** Returns a canonical [Top] value. */
         fun <V: Any> getTop() = BoundedAbstractElement<V>(Kind.TOP, null)

--- a/java/arcs/core/analysis/BoundedAbstractElement.kt
+++ b/java/arcs/core/analysis/BoundedAbstractElement.kt
@@ -78,12 +78,14 @@ data class BoundedAbstractElement<V : Any> private constructor(
     }
 
     /** A helper for implementing [AbstractValue.isEquivalentTo]. */
-    fun isEquivalentTo(other: BoundedAbstractElement<V>, comparator: (V, V) -> Boolean) = when {
-        this.kind != other.kind -> false
-        this.kind == Kind.VALUE -> comparator(
+    fun isEquivalentTo(
+        other: BoundedAbstractElement<V>,
+        comparator: (V, V) -> Boolean
+    ) = when (kind) {
+        other.kind -> if (kind != Kind.VALUE) true else comparator(
             requireNotNull(this.value), requireNotNull(other.value)
         )
-        else -> true
+        else -> false
     }
 
     companion object {

--- a/java/arcs/core/analysis/BoundedAbstractElement.kt
+++ b/java/arcs/core/analysis/BoundedAbstractElement.kt
@@ -77,6 +77,15 @@ data class BoundedAbstractElement<V: Any> private constructor(
         }
     }
 
+    /** A helper for implementing [AbstractValue.isEquivalentTo]. */
+    fun isEquivalentTo(other: BoundedAbstractElement<V>, comparator: (V, V) -> Boolean) = when {
+        this.kind != other.kind -> false
+        this.kind == Kind.VALUE -> comparator(
+            requireNotNull(this.value), requireNotNull(other.value)
+        )
+        else -> true
+    }
+
     companion object {
         /** Returns a canonical top value. */
         fun <V: Any> getTop() = BoundedAbstractElement<V>(Kind.TOP, null)

--- a/java/arcs/core/analysis/BoundedAbstractElement.kt
+++ b/java/arcs/core/analysis/BoundedAbstractElement.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.core.analysis
+
+/**
+ * A class that lifts any type [V] with a special bottom and top value.
+ *
+ * This class may be used to represent the elements of a lattice when implementing the
+ * [AbstractValue] interface. Specifically, it provides helpers for various methods in the
+ * [AbstractValue] interface that have well-known semantics with respect to bottom (the smallest
+ * value) and top (the largest value) in the lattice. For example, `bottom.isLessThan(other)`
+ * is always true for any value of `other` because `bottom` is the lowest value in the lattice.
+ *
+ * Here is a sample use of this class for implementing an abstract domain of integer elements,
+ * where the elements are ordered by [Int]'s `<=` operator.
+ * ```
+ * class IntegerDomain(
+ *     val abstractInt: BoundedAbstractElement<Int>
+ * ) : AbstractValue<IntegerDomain> {
+ *     override infix fun isLessThanEqual(other: IntegerDomain): Boolean {
+ *         return abstractInt.isLessThanEqual(other.abstractInt) { a, b -> a <= b }
+ *     }
+ *     // . . .
+ * }
+ * ```
+ */
+sealed class BoundedAbstractElement<V> {
+    /** Represents the smallest value in a lattice. */
+    private class Bottom<V> : BoundedAbstractElement<V>()
+    /** Represents the largest value in a lattice. */
+    private class Top<V> : BoundedAbstractElement<V>()
+    /** Wraps a non-top/non-bottom value of type [V]. */
+    private data class Value<V>(val value: V) : BoundedAbstractElement<V>()
+
+    /** Returns true if this is a [Top] value. */
+    fun isTop() = this is Top
+
+    /** Returns true if this is a [Bottom] value. */
+    fun isBottom() = this is Bottom
+
+    /** Returns the underlying value if this is a [Value] type. Otherwise, returns null. */
+    fun value(): V? = if (this is Value) value else null
+
+    /** A helper for implementing [AbstractValue.isLessThanEqual]. */
+    fun isLessThanEqual(other: BoundedAbstractElement<V>, compare: (V, V) -> Boolean): Boolean {
+        return when (this) {
+            is Bottom -> true
+            is Top -> other is Top
+            is Value -> when (other) {
+                is Value -> compare(this.value, other.value)
+                is Top -> true
+                is Bottom -> false
+            }
+        }
+    }
+
+    companion object {
+        /** Returns a canonical [Top] value. */
+        fun <V> getTop(): BoundedAbstractElement<V> = lazy { Top<V>() }.value
+
+        /** Returns a canonical [Bottom] value. */
+        fun <V> getBottom(): BoundedAbstractElement<V> = lazy { Bottom<V>() }.value
+
+        /** Returns a [Value] instance that wraps [value]. */
+        fun <V> makeValue(value: V): BoundedAbstractElement<V> = Value<V>(value)
+    }
+}

--- a/java/arcs/core/analysis/BoundedAbstractElement.kt
+++ b/java/arcs/core/analysis/BoundedAbstractElement.kt
@@ -34,19 +34,18 @@ package arcs.core.analysis
  * ```
  */
 data class BoundedAbstractElement<V: Any> private constructor(
-    val kind: Kind,
+    private val kind: Kind,
     val value: V?
 ) {
     private enum class Kind { TOP, BOTTOM, VALUE }
 
-    /** Returns true if this is a [Top] value. */
-    fun isTop() = kind == Kind.TOP
+    /** True if this is top. */
+    val isTop: Boolean
+        get() = kind == Kind.TOP
 
-    /** Returns true if this is a [Bottom] value. */
-    fun isBottom() = kind == Kind.BOTTOM
-
-    /** Returns the underlying value if this is a [Value] type. Otherwise, returns null. */
-    fun value(): V? = value
+    /** True if this is bottom. */
+    val isBottom: Boolean
+        get() = kind == Kind.BOTTOM
 
     /** A helper for implementing [AbstractValue.join]. */
     fun join(other: BoundedAbstractElement<V>, joiner: (V, V) -> V): BoundedAbstractElement<V> {
@@ -79,13 +78,13 @@ data class BoundedAbstractElement<V: Any> private constructor(
     }
 
     companion object {
-        /** Returns a canonical [Top] value. */
+        /** Returns a canonical top value. */
         fun <V: Any> getTop() = BoundedAbstractElement<V>(Kind.TOP, null)
 
-        /** Returns a canonical [Bottom] value. */
+        /** Returns a canonical bottom value. */
         fun <V: Any> getBottom() = BoundedAbstractElement<V>(Kind.BOTTOM, null)
 
-        /** Returns a [Value] instance that wraps [value]. */
+        /** Returns an instance that wraps [value]. */
         fun <V: Any> makeValue(value: V) = BoundedAbstractElement<V>(Kind.VALUE, value)
     }
 }

--- a/javatests/arcs/core/analysis/BoundedAbstractElementTest.kt
+++ b/javatests/arcs/core/analysis/BoundedAbstractElementTest.kt
@@ -64,4 +64,33 @@ class BoundedAbstractElementTest {
             assertThat(join(ten, joinInts)).isEqualTo(ten)
         }
     }
+
+    @Test
+    fun meetRespectsBottomTopOrder() {
+        val meetInts: (Int, Int) -> Int = { a, b -> minOf(a, b) }
+        with(bottom) {
+            assertThat(meet(bottom, meetInts)).isEqualTo(bottom)
+            assertThat(meet(top, meetInts)).isEqualTo(bottom)
+            assertThat(meet(nine, meetInts)).isEqualTo(bottom)
+            assertThat(meet(ten, meetInts)).isEqualTo(bottom)
+        }
+        with(top) {
+            assertThat(meet(bottom, meetInts)).isEqualTo(bottom)
+            assertThat(meet(top, meetInts)).isEqualTo(top)
+            assertThat(meet(nine, meetInts)).isEqualTo(nine)
+            assertThat(meet(ten, meetInts)).isEqualTo(ten)
+        }
+        with(nine) {
+            assertThat(meet(bottom, meetInts)).isEqualTo(bottom)
+            assertThat(meet(top, meetInts)).isEqualTo(nine)
+            assertThat(meet(nine, meetInts)).isEqualTo(nine)
+            assertThat(meet(ten, meetInts)).isEqualTo(nine)
+        }
+        with(ten) {
+            assertThat(meet(bottom, meetInts)).isEqualTo(bottom)
+            assertThat(meet(top, meetInts)).isEqualTo(ten)
+            assertThat(meet(nine, meetInts)).isEqualTo(nine)
+            assertThat(meet(ten, meetInts)).isEqualTo(ten)
+        }
+    }
 }

--- a/javatests/arcs/core/analysis/BoundedAbstractElementTest.kt
+++ b/javatests/arcs/core/analysis/BoundedAbstractElementTest.kt
@@ -1,0 +1,67 @@
+package arcs.core.analysis
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+
+/** Tests for BoundedAbstractValue. */
+@RunWith(JUnit4::class)
+class BoundedAbstractElementTest {
+    private val top = BoundedAbstractElement.getTop<Int>()
+    private val bottom = BoundedAbstractElement.getBottom<Int>()
+    private val nine = BoundedAbstractElement.makeValue<Int>(9)
+    private val ten = BoundedAbstractElement.makeValue<Int>(10)
+
+    @Test
+    fun factoryMethodsAndPredicatesAreCorrect() {
+        with(top) {
+            assertFalse(isBottom())
+            assertTrue(isTop())
+            assertNull(value())
+        }
+        with(bottom) {
+            assertTrue(isBottom())
+            assertFalse(isTop())
+            assertNull(value())
+        }
+        with(ten) {
+            assertFalse(isBottom())
+            assertFalse(isTop())
+            assertThat(value()).isEqualTo(10)
+        }
+    }
+
+    @Test
+    fun isLessThanEqualRespectsBottomTopOrder() {
+        val compareInts: (Int, Int) -> Boolean = { a, b -> a <= b }
+        with(bottom) {
+            assertTrue(isLessThanEqual(bottom, compareInts))
+            assertTrue(isLessThanEqual(top, compareInts))
+            assertTrue(isLessThanEqual(nine, compareInts))
+            assertTrue(isLessThanEqual(ten, compareInts))
+        }
+        with(top) {
+            assertFalse(isLessThanEqual(bottom, compareInts))
+            assertTrue(isLessThanEqual(top, compareInts))
+            assertFalse(isLessThanEqual(nine, compareInts))
+            assertFalse(isLessThanEqual(ten, compareInts))
+        }
+        with(nine) {
+            assertFalse(isLessThanEqual(bottom, compareInts))
+            assertTrue(isLessThanEqual(top, compareInts))
+            assertTrue(isLessThanEqual(nine, compareInts))
+            assertTrue(isLessThanEqual(ten, compareInts))
+        }
+        with(ten) {
+            assertFalse(isLessThanEqual(bottom, compareInts))
+            assertTrue(isLessThanEqual(top, compareInts))
+            assertFalse(isLessThanEqual(nine, compareInts))
+            assertTrue(isLessThanEqual(ten, compareInts))
+        }
+    }
+}

--- a/javatests/arcs/core/analysis/BoundedAbstractElementTest.kt
+++ b/javatests/arcs/core/analysis/BoundedAbstractElementTest.kt
@@ -37,31 +37,31 @@ class BoundedAbstractElementTest {
     }
 
     @Test
-    fun isLessThanEqualRespectsBottomTopOrder() {
-        val compareInts: (Int, Int) -> Boolean = { a, b -> a <= b }
+    fun joinRespectsBottomTopOrder() {
+        val joinInts: (Int, Int) -> Int = { a, b -> maxOf(a, b) }
         with(bottom) {
-            assertTrue(isLessThanEqual(bottom, compareInts))
-            assertTrue(isLessThanEqual(top, compareInts))
-            assertTrue(isLessThanEqual(nine, compareInts))
-            assertTrue(isLessThanEqual(ten, compareInts))
+            assertThat(join(bottom, joinInts)).isEqualTo(bottom)
+            assertThat(join(top, joinInts)).isEqualTo(top)
+            assertThat(join(nine, joinInts)).isEqualTo(nine)
+            assertThat(join(ten, joinInts)).isEqualTo(ten)
         }
         with(top) {
-            assertFalse(isLessThanEqual(bottom, compareInts))
-            assertTrue(isLessThanEqual(top, compareInts))
-            assertFalse(isLessThanEqual(nine, compareInts))
-            assertFalse(isLessThanEqual(ten, compareInts))
+            assertThat(join(bottom, joinInts)).isEqualTo(top)
+            assertThat(join(top, joinInts)).isEqualTo(top)
+            assertThat(join(nine, joinInts)).isEqualTo(top)
+            assertThat(join(ten, joinInts)).isEqualTo(top)
         }
         with(nine) {
-            assertFalse(isLessThanEqual(bottom, compareInts))
-            assertTrue(isLessThanEqual(top, compareInts))
-            assertTrue(isLessThanEqual(nine, compareInts))
-            assertTrue(isLessThanEqual(ten, compareInts))
+            assertThat(join(bottom, joinInts)).isEqualTo(nine)
+            assertThat(join(top, joinInts)).isEqualTo(top)
+            assertThat(join(nine, joinInts)).isEqualTo(nine)
+            assertThat(join(ten, joinInts)).isEqualTo(ten)
         }
         with(ten) {
-            assertFalse(isLessThanEqual(bottom, compareInts))
-            assertTrue(isLessThanEqual(top, compareInts))
-            assertFalse(isLessThanEqual(nine, compareInts))
-            assertTrue(isLessThanEqual(ten, compareInts))
+            assertThat(join(bottom, joinInts)).isEqualTo(ten)
+            assertThat(join(top, joinInts)).isEqualTo(top)
+            assertThat(join(nine, joinInts)).isEqualTo(ten)
+            assertThat(join(ten, joinInts)).isEqualTo(ten)
         }
     }
 }

--- a/javatests/arcs/core/analysis/BoundedAbstractElementTest.kt
+++ b/javatests/arcs/core/analysis/BoundedAbstractElementTest.kt
@@ -1,9 +1,6 @@
 package arcs.core.analysis
 
 import com.google.common.truth.Truth.assertThat
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Assert.assertNull
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
@@ -18,20 +15,28 @@ class BoundedAbstractElementTest {
     private val ten = BoundedAbstractElement.makeValue<Int>(10)
 
     @Test
-    fun factoryMethodsAndPredicatesAreCorrect() {
+    fun factoryMethodsAndPredicatesAreCorrect_top() {
         with(top) {
-            assertFalse(isBottom)
-            assertTrue(isTop)
-            assertNull(value)
+            assertThat(isBottom).isFalse()
+            assertThat(isTop).isTrue()
+            assertThat(value).isNull()
         }
+    }
+
+    @Test
+    fun factoryMethodsAndPredicatesAreCorrect_bottom() {
         with(bottom) {
-            assertTrue(isBottom)
-            assertFalse(isTop)
-            assertNull(value)
+            assertThat(isBottom).isTrue()
+            assertThat(isTop).isFalse()
+            assertThat(value).isNull()
         }
+    }
+
+    @Test
+    fun factoryMethodsAndPredicatesAreCorrect_value() {
         with(ten) {
-            assertFalse(isBottom)
-            assertFalse(isTop)
+            assertThat(isBottom).isFalse()
+            assertThat(isTop).isFalse()
             assertThat(value).isEqualTo(10)
         }
     }
@@ -98,29 +103,28 @@ class BoundedAbstractElementTest {
     fun isEquivalentToRespectsBottomTopOrder() {
         val compareInts: (Int, Int) -> Boolean = { a, b -> a == b }
         with(bottom) {
-            assertTrue(isEquivalentTo(bottom, compareInts))
-            assertFalse(isEquivalentTo(top, compareInts))
-            assertFalse(isEquivalentTo(nine, compareInts))
-            assertFalse(isEquivalentTo(ten, compareInts))
+            assertThat(isEquivalentTo(bottom, compareInts)).isTrue()
+            assertThat(isEquivalentTo(top, compareInts)).isFalse()
+            assertThat(isEquivalentTo(nine, compareInts)).isFalse()
+            assertThat(isEquivalentTo(ten, compareInts)).isFalse()
         }
         with(top) {
-            assertFalse(isEquivalentTo(bottom, compareInts))
-            assertTrue(isEquivalentTo(top, compareInts))
-            assertFalse(isEquivalentTo(nine, compareInts))
-            assertFalse(isEquivalentTo(ten, compareInts))
+            assertThat(isEquivalentTo(bottom, compareInts)).isFalse()
+            assertThat(isEquivalentTo(top, compareInts)).isTrue()
+            assertThat(isEquivalentTo(nine, compareInts)).isFalse()
+            assertThat(isEquivalentTo(ten, compareInts)).isFalse()
         }
         with(nine) {
-            assertFalse(isEquivalentTo(bottom, compareInts))
-            assertFalse(isEquivalentTo(top, compareInts))
-            assertTrue(isEquivalentTo(nine, compareInts))
-            assertFalse(isEquivalentTo(ten, compareInts))
+            assertThat(isEquivalentTo(bottom, compareInts)).isFalse()
+            assertThat(isEquivalentTo(top, compareInts)).isFalse()
+            assertThat(isEquivalentTo(nine, compareInts)).isTrue()
+            assertThat(isEquivalentTo(ten, compareInts)).isFalse()
         }
         with(ten) {
-            assertFalse(isEquivalentTo(bottom, compareInts))
-            assertFalse(isEquivalentTo(top, compareInts))
-            assertFalse(isEquivalentTo(nine, compareInts))
-            assertTrue(isEquivalentTo(ten, compareInts))
+            assertThat(isEquivalentTo(bottom, compareInts)).isFalse()
+            assertThat(isEquivalentTo(top, compareInts)).isFalse()
+            assertThat(isEquivalentTo(nine, compareInts)).isFalse()
+            assertThat(isEquivalentTo(ten, compareInts)).isTrue()
         }
     }
-
 }

--- a/javatests/arcs/core/analysis/BoundedAbstractElementTest.kt
+++ b/javatests/arcs/core/analysis/BoundedAbstractElementTest.kt
@@ -20,19 +20,19 @@ class BoundedAbstractElementTest {
     @Test
     fun factoryMethodsAndPredicatesAreCorrect() {
         with(top) {
-            assertFalse(isBottom())
-            assertTrue(isTop())
-            assertNull(value())
+            assertFalse(isBottom)
+            assertTrue(isTop)
+            assertNull(value)
         }
         with(bottom) {
-            assertTrue(isBottom())
-            assertFalse(isTop())
-            assertNull(value())
+            assertTrue(isBottom)
+            assertFalse(isTop)
+            assertNull(value)
         }
         with(ten) {
-            assertFalse(isBottom())
-            assertFalse(isTop())
-            assertThat(value()).isEqualTo(10)
+            assertFalse(isBottom)
+            assertFalse(isTop)
+            assertThat(value).isEqualTo(10)
         }
     }
 

--- a/javatests/arcs/core/analysis/BoundedAbstractElementTest.kt
+++ b/javatests/arcs/core/analysis/BoundedAbstractElementTest.kt
@@ -93,4 +93,34 @@ class BoundedAbstractElementTest {
             assertThat(meet(ten, meetInts)).isEqualTo(ten)
         }
     }
+
+    @Test
+    fun isEquivalentToRespectsBottomTopOrder() {
+        val compareInts: (Int, Int) -> Boolean = { a, b -> a == b }
+        with(bottom) {
+            assertTrue(isEquivalentTo(bottom, compareInts))
+            assertFalse(isEquivalentTo(top, compareInts))
+            assertFalse(isEquivalentTo(nine, compareInts))
+            assertFalse(isEquivalentTo(ten, compareInts))
+        }
+        with(top) {
+            assertFalse(isEquivalentTo(bottom, compareInts))
+            assertTrue(isEquivalentTo(top, compareInts))
+            assertFalse(isEquivalentTo(nine, compareInts))
+            assertFalse(isEquivalentTo(ten, compareInts))
+        }
+        with(nine) {
+            assertFalse(isEquivalentTo(bottom, compareInts))
+            assertFalse(isEquivalentTo(top, compareInts))
+            assertTrue(isEquivalentTo(nine, compareInts))
+            assertFalse(isEquivalentTo(ten, compareInts))
+        }
+        with(ten) {
+            assertFalse(isEquivalentTo(bottom, compareInts))
+            assertFalse(isEquivalentTo(top, compareInts))
+            assertFalse(isEquivalentTo(nine, compareInts))
+            assertTrue(isEquivalentTo(ten, compareInts))
+        }
+    }
+
 }


### PR DESCRIPTION
 This PR introduces a  class that lifts any type `V` with a special bottom and top value. This class may be used to represent the elements of a lattice when implementing the `AbstractValue` interface. Specifically, it provides helpers for various methods in the `AbstractValue` interface that have well-known semantics with respect to bottom (the smallest value) and top (the largest value) in the lattice. For example, `bottom.join(other)` is always equal to `other` for any value of `other`, because `bottom` is the lowest value in the lattice.

 Here is a sample use of this class for implementing an abstract domain of integer elements,
 where the elements are ordered by [Int]'s `<=` operator.
 ```
 class IntegerDomain(
     val abstractInt: BoundedAbstractElement<Int>
 ) : AbstractValue<IntegerDomain> {
     override infix fun join(other: IntegerDomain): IntegerDomain {
         return abstractInt.join(other.abstractInt) { a, b -> maxOf(a, b) }
     }
     // . . .
}
```