### PR TITLE
Support Reference Handles in schema2kotlin

### DIFF
--- a/javatests/arcs/sdk/spec/ReferenceSpecTest.kt
+++ b/javatests/arcs/sdk/spec/ReferenceSpecTest.kt
@@ -1,7 +1,5 @@
 package arcs.sdk.spec
 
-import arcs.sdk.ReadWriteCollectionHandle
-import arcs.sdk.ReadWriteSingletonHandle
 import arcs.sdk.Reference
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -79,13 +77,44 @@ class ReferenceSpecTest {
     }
 
     @Test
-    fun storeReference_insideSingletonReferenceHandle() {
-        // TODO(csilvestrini): Implement me.
+    fun storeReference_insideSingletonReferenceHandle() = runBlocking {
+        val child1 = Child(age = 10.0)
+        val child2 = Child(age = 9.0)
+        val childRef1 = createChildReference(child1)
+        val childRef2 = createChildReference(child2)
+
+        // Store a reference in the handle.
+        harness.singletonChildRef.store(childRef1)
+        var childRefOut = harness.singletonChildRef.fetch()
+        assertThat(childRefOut).isEqualTo(childRef1)
+        assertThat(childRefOut!!.dereference()).isEqualTo(child1)
+
+        // Store a different reference in the handle.
+        harness.singletonChildRef.store(childRef2)
+        childRefOut = harness.singletonChildRef.fetch()
+        assertThat(childRefOut).isEqualTo(childRef2)
+        assertThat(childRefOut!!.dereference()).isEqualTo(child2)
     }
 
     @Test
-    fun storeReference_insideCollectionReferenceHandle() {
-        // TODO(csilvestrini): Implement me.
+    fun storeReference_insideCollectionReferenceHandle() = runBlocking {
+        val child1 = Child(age = 10.0)
+        val child2 = Child(age = 9.0)
+        val childRef1 = createChildReference(child1)
+        val childRef2 = createChildReference(child2)
+
+        // Store some references in the handle.
+        harness.collectionChildRef.store(childRef1)
+        var childRefsOut = harness.collectionChildRef.fetchAll()
+        assertThat(childRefsOut).containsExactly(childRef1)
+        assertThat(childRefsOut.map { it.dereference() }).containsExactly(child1)
+
+        // Store another reference in the handle.
+        harness.collectionChildRef.store(childRef2)
+        childRefsOut = harness.collectionChildRef.fetchAll()
+        assertThat(childRefsOut).containsExactly(childRef1, childRef2)
+        assertThat(childRefsOut.map { it.dereference() }).containsExactly(child1, child2)
+        Unit
     }
 
     /** Creates a [Reference] for the given [Child]. */

--- a/javatests/arcs/sdk/spec/reference.arcs
+++ b/javatests/arcs/sdk/spec/reference.arcs
@@ -14,6 +14,5 @@ particle ReferenceSpecParticle
   collectionChild: reads writes [Child {age}]
   parents: reads writes [Parent {age, favorite, children}]
 
-  // TODO: Test singleton and collection handles containing references.
-  // singletonChildRef: reads writes &Child
-  // collectionChildRef: reads writes [&Child]
+  singletonChildRef: reads writes &Child
+  collectionChildRef: reads writes [&Child]

--- a/src/runtime/capabilities-resolver.ts
+++ b/src/runtime/capabilities-resolver.ts
@@ -119,6 +119,8 @@ export class CapabilitiesResolver {
     }
     const backingKey = creator.create(new BackingStorageKeyOptions(
         this.options.arcId, schemaHash, entitySchema.name));
+    // TODO(b/152436411): Don't return reference-mode storage keys for
+    // Reference-typed handles.
     return new ReferenceModeStorageKey(
         backingKey, containerKey.childKeyForHandle(handleId));
   }

--- a/src/tools/tests/goldens/generated-schemas.wasm.kt
+++ b/src/tools/tests/goldens/generated-schemas.wasm.kt
@@ -624,10 +624,10 @@ abstract class AbstractGold : WasmParticleImpl() {
     class Handles(
         particle: WasmParticleImpl
     ) {
-        val data: WasmSingletonImpl<Gold_Data> = WasmSingletonImpl(particle, "data", Gold_Data)
-        val allPeople: WasmCollectionImpl<Gold_AllPeople> = WasmCollectionImpl(particle, "allPeople", Gold_AllPeople)
-        val qCollection: WasmCollectionImpl<Gold_QCollection> = WasmCollectionImpl(particle, "qCollection", Gold_QCollection)
-        val alias: WasmSingletonImpl<Gold_Alias> = WasmSingletonImpl(particle, "alias", Gold_Alias)
-        val collection: WasmCollectionImpl<Gold_Collection> = WasmCollectionImpl(particle, "collection", Gold_Collection)
+        val data: WasmSingletonImpl<Gold_Data> = WasmSingletonImpl<Gold_Data>(particle, "data", Gold_Data)
+        val allPeople: WasmCollectionImpl<Gold_AllPeople> = WasmCollectionImpl<Gold_AllPeople>(particle, "allPeople", Gold_AllPeople)
+        val qCollection: WasmCollectionImpl<Gold_QCollection> = WasmCollectionImpl<Gold_QCollection>(particle, "qCollection", Gold_QCollection)
+        val alias: WasmSingletonImpl<Gold_Alias> = WasmSingletonImpl<Gold_Alias>(particle, "alias", Gold_Alias)
+        val collection: WasmCollectionImpl<Gold_Collection> = WasmCollectionImpl<Gold_Collection>(particle, "collection", Gold_Collection)
     }
 }

--- a/src/tools/tests/goldens/generated-test-harness.kt
+++ b/src/tools/tests/goldens/generated-test-harness.kt
@@ -9,6 +9,7 @@ package arcs.golden
 // Current implementation doesn't support optional field detection
 
 import arcs.core.entity.HandleContainerType
+import arcs.core.entity.HandleDataType
 import arcs.core.entity.HandleMode
 import arcs.core.entity.HandleSpec
 import arcs.sdk.*
@@ -18,15 +19,15 @@ import kotlinx.coroutines.CoroutineScope
 class GoldTestHarness<P : AbstractGold>(
     factory : (CoroutineScope) -> P
 ) : BaseTestHarness<P>(factory, listOf(
-    HandleSpec("data", HandleMode.ReadWrite, HandleContainerType.Singleton, Gold_Data),
-    HandleSpec("allPeople", HandleMode.ReadWrite, HandleContainerType.Collection, Gold_AllPeople),
-    HandleSpec("qCollection", HandleMode.ReadWrite, HandleContainerType.Collection, Gold_QCollection),
-    HandleSpec("alias", HandleMode.ReadWrite, HandleContainerType.Singleton, Gold_Alias),
-    HandleSpec("collection", HandleMode.ReadWrite, HandleContainerType.Collection, Gold_Collection)
+    HandleSpec("data", HandleMode.ReadWrite, HandleContainerType.Singleton, Gold_Data, HandleDataType.Entity),
+    HandleSpec("allPeople", HandleMode.ReadWrite, HandleContainerType.Collection, Gold_AllPeople, HandleDataType.Entity),
+    HandleSpec("qCollection", HandleMode.ReadWrite, HandleContainerType.Collection, Gold_QCollection, HandleDataType.Entity),
+    HandleSpec("alias", HandleMode.ReadWrite, HandleContainerType.Singleton, Gold_Alias, HandleDataType.Entity),
+    HandleSpec("collection", HandleMode.ReadWrite, HandleContainerType.Collection, Gold_Collection, HandleDataType.Entity)
 )) {
     val data: ReadWriteSingletonHandle<Gold_Data> by handleMap
     val allPeople: ReadWriteCollectionHandle<Gold_AllPeople> by handleMap
-    val qCollection: ReadWriteCollectionHandle<Gold_QCollection> by handleMap
+    val qCollection: ReadWriteQueryCollectionHandle<Gold_QCollection, String> by handleMap
     val alias: ReadWriteSingletonHandle<Gold_Alias> by handleMap
     val collection: ReadWriteCollectionHandle<Gold_Collection> by handleMap
 }


### PR DESCRIPTION
Also adds a spec test for reference handles, and cleans up the handle declaration code in the code generator a bit.