### PR TITLE
Updates a couple of Reference Handle tests

### DIFF
--- a/java/arcs/jvm/util/testutil/FakeTime.kt
+++ b/java/arcs/jvm/util/testutil/FakeTime.kt
@@ -13,15 +13,10 @@ package arcs.jvm.util.testutil
 
 import arcs.core.util.Time
 
-class FakeTime(millisInit: Long = 999_999) : Time() {
-    init { millis = millisInit }
+class FakeTime(var millis: Long = 999_999) : Time() {
     override val nanoTime: Long
         get() = millis * 1_000_000
 
     override val currentTimeMillis: Long
         get() = millis
-
-    companion object {
-        var millis: Long = 999_999
-    }
 }

--- a/javatests/arcs/android/entity/DifferentAndroidHandleManagerDifferentStoresTest.kt
+++ b/javatests/arcs/android/entity/DifferentAndroidHandleManagerDifferentStoresTest.kt
@@ -44,9 +44,9 @@ class DifferentAndroidHandleManagerDifferentStoresTest : HandleManagerTestBase()
         readHandleManager = EntityHandleManager(
             arcId = "arcId",
             hostId = "hostId",
-            time = FakeTime(),
+            time = fakeTime,
             scheduler = Scheduler(
-                FakeTime(),
+                fakeTime,
                 Executors.newSingleThreadExecutor().asCoroutineDispatcher()
             ),
             stores = StoreManager(),
@@ -59,9 +59,9 @@ class DifferentAndroidHandleManagerDifferentStoresTest : HandleManagerTestBase()
         writeHandleManager = EntityHandleManager(
             arcId = "arcId",
             hostId = "hostId",
-            time = FakeTime(),
+            time = fakeTime,
             scheduler = Scheduler(
-                FakeTime(),
+                fakeTime,
                 Executors.newSingleThreadExecutor().asCoroutineDispatcher()
             ),
             stores = StoreManager(),

--- a/javatests/arcs/android/entity/DifferentHandleManagerTest.kt
+++ b/javatests/arcs/android/entity/DifferentHandleManagerTest.kt
@@ -45,9 +45,9 @@ class DifferentHandleManagerTest : HandleManagerTestBase() {
         readHandleManager = EntityHandleManager(
             arcId = "arcId",
             hostId = "hostId",
-            time = FakeTime(),
+            time = fakeTime,
             scheduler = Scheduler(
-                FakeTime(),
+                fakeTime,
                 Executors.newSingleThreadExecutor().asCoroutineDispatcher()
             ),
             stores = stores,
@@ -60,9 +60,9 @@ class DifferentHandleManagerTest : HandleManagerTestBase() {
         writeHandleManager = EntityHandleManager(
             arcId = "arcId",
             hostId = "hostId",
-            time = FakeTime(),
+            time = fakeTime,
             scheduler = Scheduler(
-                FakeTime(),
+                fakeTime,
                 Executors.newSingleThreadExecutor().asCoroutineDispatcher()
             ),
             stores = stores,

--- a/javatests/arcs/android/entity/SameHandleManagerTest.kt
+++ b/javatests/arcs/android/entity/SameHandleManagerTest.kt
@@ -43,9 +43,9 @@ class SameHandleManagerTest : HandleManagerTestBase() {
         readHandleManager = EntityHandleManager(
             arcId = "arcId",
             hostId = "hostId",
-            time = FakeTime(),
+            time = fakeTime,
             scheduler = Scheduler(
-                FakeTime(),
+                fakeTime,
                 Executors.newSingleThreadExecutor().asCoroutineDispatcher()
             ),
             stores = StoreManager(),

--- a/javatests/arcs/core/entity/DifferentHandleManagerDifferentStoresTest.kt
+++ b/javatests/arcs/core/entity/DifferentHandleManagerDifferentStoresTest.kt
@@ -21,9 +21,9 @@ class DifferentHandleManagerDifferentStoresTest : HandleManagerTestBase() {
         readHandleManager = EntityHandleManager(
             arcId = "testArcId",
             hostId = "testHostId",
-            time = FakeTime(),
+            time = fakeTime,
             scheduler = Scheduler(
-                FakeTime(),
+                fakeTime,
                 Executors.newSingleThreadExecutor().asCoroutineDispatcher()
             ),
             stores = StoreManager()
@@ -31,9 +31,9 @@ class DifferentHandleManagerDifferentStoresTest : HandleManagerTestBase() {
         writeHandleManager = EntityHandleManager(
             arcId = "testArcId",
             hostId = "testHostId",
-            time = FakeTime(),
+            time = fakeTime,
             scheduler = Scheduler(
-                FakeTime(),
+                fakeTime,
                 Executors.newSingleThreadExecutor().asCoroutineDispatcher()
             ),
             stores = StoreManager()

--- a/javatests/arcs/core/entity/DifferentHandleManagerTest.kt
+++ b/javatests/arcs/core/entity/DifferentHandleManagerTest.kt
@@ -22,9 +22,9 @@ class DifferentHandleManagerTest : HandleManagerTestBase() {
         readHandleManager = EntityHandleManager(
             arcId = "testArc",
             hostId = "testHost",
-            time = FakeTime(),
+            time = fakeTime,
             scheduler = Scheduler(
-                FakeTime(),
+                fakeTime,
                 Executors.newSingleThreadExecutor().asCoroutineDispatcher()
             ),
             stores = stores
@@ -32,9 +32,9 @@ class DifferentHandleManagerTest : HandleManagerTestBase() {
         writeHandleManager = EntityHandleManager(
             arcId = "testArc",
             hostId = "testHost",
-            time = FakeTime(),
+            time = fakeTime,
             scheduler = Scheduler(
-                FakeTime(),
+                fakeTime,
                 Executors.newSingleThreadExecutor().asCoroutineDispatcher()
             ),
             stores = stores

--- a/javatests/arcs/core/entity/HandleManagerTestBase.kt
+++ b/javatests/arcs/core/entity/HandleManagerTestBase.kt
@@ -439,7 +439,7 @@ open class HandleManagerTestBase {
         writeEntityHandle.remove(entity1)
 
         // Reference should be dead. (Removed entities currently aren't actually deleted, but
-        // instead are "nulled out".
+        // instead are "nulled out".)
         assertThat(storageReference.dereference()).isEqualTo(createNulledOutPerson("entity1"))
     }
 
@@ -747,7 +747,7 @@ open class HandleManagerTestBase {
         writeEntityHandle.remove(entity2)
 
         // Reference should be dead. (Removed entities currently aren't actually deleted, but
-        // instead are "nulled out".
+        // instead are "nulled out".)
         assertThat(references.map { it.toReferencable().dereference() }).containsExactly(
             createNulledOutPerson("entity1"),
             createNulledOutPerson("entity2")

--- a/javatests/arcs/core/entity/SameHandleManagerTest.kt
+++ b/javatests/arcs/core/entity/SameHandleManagerTest.kt
@@ -25,9 +25,9 @@ class SameHandleManagerTest : HandleManagerTestBase() {
         readHandleManager = EntityHandleManager(
             arcId = "testArc",
             hostId = "testHost",
-            time = FakeTime(),
+            time = fakeTime,
             scheduler = Scheduler(
-                FakeTime(),
+                fakeTime,
                 Executors.newSingleThreadExecutor().asCoroutineDispatcher()
             ),
             stores = StoreManager()


### PR DESCRIPTION
I realised that this isn't actually a bug, it's working as intended (for now, at least).

Removed entities don't get fully removed, they get all of their field data nulled out. Updates tests to check this.

Also reverted a change to FakeTime, to remove its static variable. This was causing the ordering of test cases to affect the outcome (test cases were not resetting the static value). Now we use a fresh instance every time.