### PR TITLE
Adds an ephemeral reader to WriterReaderExample.arcs

### DIFF
--- a/java/arcs/core/data/testdata/WriterReaderExample.arcs
+++ b/java/arcs/core/data/testdata/WriterReaderExample.arcs
@@ -29,3 +29,8 @@ recipe EphemeralWriting
   thing: create 'my-ephemeral-handle-id'
   Writer
     data: writes thing
+
+recipe EphemeralReading
+  data: map 'my-handle-id'
+  Reader
+    data: reads data

--- a/src/runtime/capabilities-resolver.ts
+++ b/src/runtime/capabilities-resolver.ts
@@ -110,7 +110,7 @@ export class CapabilitiesResolver {
     } else if (protocols.size > 1) {
       console.warn(`Multiple storage key creators for handle '${handleId}' with capabilities ${capabilities.toString()}`);
     }
-    const creator = this.creators.find(({protocol, create}) => protocol === [...protocols][0]);
+    const creator = this.creators.find(({protocol}) => protocol === [...protocols][0]);
     const schemaHash = await entitySchema.hash();
     const containerKey = creator.create(new ContainerStorageKeyOptions(
         this.options.arcId, schemaHash, entitySchema.name));

--- a/src/tools/storage-key-recipe-resolver.ts
+++ b/src/tools/storage-key-recipe-resolver.ts
@@ -16,12 +16,10 @@ import {IsValidOptions, Recipe, RecipeComponent} from '../runtime/recipe/recipe.
 import {volatileStorageKeyPrefixForTest} from '../runtime/testing/handle-for-test.js';
 import {Arc} from '../runtime/arc.js';
 import {RecipeResolver} from '../runtime/recipe/recipe-resolver.js';
-import {CapabilitiesResolver, StorageKeyCreatorInfo} from '../runtime/capabilities-resolver.js';
+import {CapabilitiesResolver} from '../runtime/capabilities-resolver.js';
 import {Store} from '../runtime/storageNG/store.js';
 import {Exists} from '../runtime/storageNG/drivers/driver.js';
-import {TypeVariable} from '../runtime/type.js';
-import {DatabaseStorageKey, PersistentDatabaseStorageKey} from '../runtime/storageNG/database-storage-key.js';
-import {Capabilities} from '../runtime/capabilities.js';
+import {DatabaseStorageKey} from '../runtime/storageNG/database-storage-key.js';
 
 export class StorageKeyRecipeResolverError extends Error {
   constructor(message: string) {

--- a/src/tools/tests/goldens/WriterReaderExample.kt
+++ b/src/tools/tests/goldens/WriterReaderExample.kt
@@ -78,3 +78,21 @@ object EphemeralWritingPlan : Plan(
         )
     )
 )
+object EphemeralReadingPlan : Plan(
+    listOf(
+        Particle(
+            "Reader",
+            "arcs.core.data.testdata.Reader",
+            mapOf(
+                "data" to HandleConnection(
+                    StorageKeyParser.parse(
+                        "reference-mode://{db://25e71af4e9fc8b6958fc46a8f4b7cdf6b5f31516@arcs/Thing}{db://25e71af4e9fc8b6958fc46a8f4b7cdf6b5f31516@arcs/!:writingArcId/handle/my-handle-id}"
+                    ),
+                    HandleMode.Read,
+                    SingletonType(EntityType(Reader_Data.SCHEMA)),
+                    Ttl.Infinite
+                )
+            )
+        )
+    )
+)


### PR DESCRIPTION
Also clean up some unused imports etc.

This is to demonstrate that mapping from an ephemeral arc works well as well as to have an ephemeral reader example from other tools - e.g. the manifest2proto I'm currently working on.