### PR TITLE
Don't close HandleManager until after arc state written

### DIFF
--- a/java/arcs/core/host/AbstractArcHost.kt
+++ b/java/arcs/core/host/AbstractArcHost.kt
@@ -442,9 +442,9 @@ abstract class AbstractArcHost(
             stopParticle(particleContext)
         }
         maybeCancelResurrection(context)
-        context.entityHandleManager.close()
         context.arcState = ArcState.Stopped
         updateArcHostContext(arcId, context)
+        context.entityHandleManager.close()
     }
 
     /**


### PR DESCRIPTION
Since the state writing could use handles created by that handle
manager.