### PR TITLE
Fix some handle reference tests

### DIFF
--- a/javatests/arcs/android/entity/DifferentHandleManagerTest.kt
+++ b/javatests/arcs/android/entity/DifferentHandleManagerTest.kt
@@ -78,8 +78,4 @@ class DifferentHandleManagerTest : HandleManagerTestBase() {
 
     @After
     override fun tearDown() = super.tearDown()
-
-    // TODO(b/152436411): Fix these.
-    override fun collection_referenceLiveness() {}
-    override fun singleton_referenceLiveness() {}
 }

--- a/javatests/arcs/core/entity/DifferentHandleManagerDifferentStoresTest.kt
+++ b/javatests/arcs/core/entity/DifferentHandleManagerDifferentStoresTest.kt
@@ -43,10 +43,6 @@ class DifferentHandleManagerDifferentStoresTest : HandleManagerTestBase() {
     @After
     override fun tearDown() = super.tearDown()
 
-    // TODO(b/152436411): Fix these.
-    override fun collection_referenceLiveness() {}
-    override fun singleton_referenceLiveness() {}
-
     // We don't expect these to pass, since Operations won't make it through the driver level
     override fun singleton_writeAndOnUpdate() {}
     override fun collection_writeAndOnUpdate() {}

--- a/javatests/arcs/core/entity/DifferentHandleManagerTest.kt
+++ b/javatests/arcs/core/entity/DifferentHandleManagerTest.kt
@@ -43,8 +43,4 @@ class DifferentHandleManagerTest : HandleManagerTestBase() {
 
     @After
     override fun tearDown() = super.tearDown()
-
-    // TODO(b/152436411): Fix these.
-    override fun collection_referenceLiveness() {}
-    override fun singleton_referenceLiveness() {}
 }

--- a/javatests/arcs/core/entity/HandleManagerTestBase.kt
+++ b/javatests/arcs/core/entity/HandleManagerTestBase.kt
@@ -173,12 +173,14 @@ open class HandleManagerTestBase {
         backingKey = backingKey,
         storageKey = singletonRefKey
     )
+    private val singletonRefHandleKey = RamDiskStorageKey("singleton-reference-handle")
 
     private val collectionRefKey = RamDiskStorageKey("set-ent")
     private val collectionKey = ReferenceModeStorageKey(
         backingKey = backingKey,
         storageKey = collectionRefKey
     )
+    private val collectionRefHandleKey = RamDiskStorageKey("collection-reference-handle")
 
     private val hatCollectionRefKey = RamDiskStorageKey("set-hats")
     private val hatCollectionKey = ReferenceModeStorageKey(
@@ -403,7 +405,7 @@ open class HandleManagerTestBase {
     }
 
     @Test
-    open fun singleton_referenceLiveness() = runBlocking {
+    fun singleton_referenceLiveness() = runBlocking {
         // Create and store an entity.
         val writeEntityHandle = writeHandleManager.createCollectionHandle()
         writeEntityHandle.store(entity1)
@@ -701,7 +703,7 @@ open class HandleManagerTestBase {
     }
 
     @Test
-    open fun collection_referenceLiveness() = runBlocking<Unit> {
+    fun collection_referenceLiveness() = runBlocking<Unit> {
         // Create and store some entities.
         val writeEntityHandle = writeHandleManager.createCollectionHandle()
         writeEntityHandle.store(entity1)
@@ -760,7 +762,7 @@ open class HandleManagerTestBase {
             writeHandleManager.createReferenceCollectionHandle(
                 ReferenceModeStorageKey(
                     backingKey = backingKey,
-                    storageKey = collectionRefKey
+                    storageKey = collectionRefHandleKey
                 )
             )
         }
@@ -815,7 +817,7 @@ open class HandleManagerTestBase {
     ) as ReadWriteQueryCollectionHandle<T, Any>
 
     private suspend fun EntityHandleManager.createReferenceSingletonHandle(
-        storageKey: StorageKey = singletonRefKey,
+        storageKey: StorageKey = singletonRefHandleKey,
         name: String = "referenceSingletonWriteHandle",
         ttl: Ttl = Ttl.Infinite
     ) = createHandle(
@@ -831,7 +833,7 @@ open class HandleManagerTestBase {
     ) as ReadWriteSingletonHandle<Reference<Person>>
 
     private suspend fun EntityHandleManager.createReferenceCollectionHandle(
-        storageKey: StorageKey = collectionRefKey,
+        storageKey: StorageKey = collectionRefHandleKey,
         name: String = "referenceCollectionReadHandle",
         ttl: Ttl = Ttl.Infinite
     ) = createHandle(


### PR DESCRIPTION
The tests were incorrectly reusing the same storage key for the reference handles as for the backing entities, and this was causing issues.