### PR TITLE
Bazel update to arcs_kt_gen, arcs_manifest, and arcs_manifest_parse_test

### DIFF
--- a/java/arcs/android/demo/BUILD
+++ b/java/arcs/android/demo/BUILD
@@ -2,6 +2,7 @@ load(
     "//third_party/java/arcs/build_defs:build_defs.bzl",
     "arcs_kt_android_library",
     "arcs_kt_gen",
+    "arcs_manifest_parse_test",
 )
 load("//tools/build_defs/android:rules.bzl", "android_binary")
 
@@ -12,6 +13,12 @@ package(default_visibility = ["//visibility:public"])
 arcs_kt_gen(
     name = "manifest",
     srcs = ["person.arcs"],
+)
+
+arcs_manifest_parse_test(
+    name = "manifest_test",
+    srcs = ["person.arcs"],
+    deps = glob(["*.kt"]),
 )
 
 arcs_kt_android_library(

--- a/java/arcs/core/data/testdata/BUILD
+++ b/java/arcs/core/data/testdata/BUILD
@@ -16,6 +16,12 @@ filegroup(
 )
 
 arcs_kt_gen(
+    name = "import_example_gen",
+    srcs = ["ImportExample.arcs"],
+    deps = ["Schemas.arcs"],
+)
+
+arcs_kt_gen(
     name = "example_gen",
     srcs = ["WriterReaderExample.arcs"],
 )

--- a/java/arcs/core/data/testdata/ImportExample.arcs
+++ b/java/arcs/core/data/testdata/ImportExample.arcs
@@ -1,0 +1,17 @@
+meta
+  namespace: arcs.core.data.testdata.gen
+
+import './Schemas.arcs'
+
+external particle Writer
+  data: writes Thing
+
+external particle Reader
+  data: reads Thing
+
+recipe PassThrough
+  thing: create
+  Writer
+    data: writes thing
+  Reader
+    data: reads thing

--- a/java/arcs/core/data/testdata/Schemas.arcs
+++ b/java/arcs/core/data/testdata/Schemas.arcs
@@ -1,0 +1,5 @@
+meta
+  namespace: arcs.core.data.testdata.gen
+
+schema Thing
+  name: Text

--- a/particles/PipeApps/BUILD
+++ b/particles/PipeApps/BUILD
@@ -1,4 +1,8 @@
-load("//third_party/java/arcs/build_defs:build_defs.bzl", "arcs_manifest")
+load(
+    "//third_party/java/arcs/build_defs:build_defs.bzl",
+    "arcs_manifest",
+    "arcs_manifest_parse_test",
+)
 
 package(default_visibility = ["//visibility:public"])
 
@@ -14,6 +18,16 @@ arcs_manifest(
 
 arcs_manifest(
     name = "AndroidAutofill",
+    srcs = ["AndroidAutofill.arcs"],
+    deps = [
+        ":IncomingEntity",
+        ":Person",
+        ":source/DummyAutofillResponder.js",
+    ],
+)
+
+arcs_manifest_parse_test(
+    name = "Autofill_test",
     srcs = ["AndroidAutofill.arcs"],
     deps = [
         ":IncomingEntity",

--- a/src/platform/loader-base.ts
+++ b/src/platform/loader-base.ts
@@ -64,6 +64,7 @@ export abstract class LoaderBase {
     this.staticMap = staticMap;
     this.compileRegExp(this.urlMap);
   }
+  abstract clone(): LoaderBase;
   setParticleExecutionContext(pec: ParticleExecutionContext): void {
     this.pec = pec;
   }
@@ -81,6 +82,13 @@ export abstract class LoaderBase {
       return this.loadUrl(path);
     }
     return this.loadFile(path);
+  }
+  /** https://regex101.com/r/0qpxfW/2 */
+  isJvmClasspath(candidate: string): boolean {
+    return /^(?:[a-z]\w*|[a-z]\w*\.)+(?:[A-Z]\w*|[A-Z]\w*\.)+$/.test(candidate);
+  }
+  jvmClassExists(classPath: string): boolean {
+    return false;
   }
   async loadBinaryResource(file: string): Promise<ArrayBuffer> {
     const content = this.loadStaticBinary(file);

--- a/src/tools/manifest-checker.ts
+++ b/src/tools/manifest-checker.ts
@@ -64,7 +64,7 @@ async function main() {
   if (opts.help || !opts.src) {
     console.log(`
 Usage
-  $ tools/sigh run manifestChecker --src [files...]
+  $ tools/sigh run manifestChecker --src path/to/target.arcs [--src other/other.arcs] ...
 
 Description
   Loads the given .arcs manifest file and checks it for errors.

--- a/src/tools/manifest-checker.ts
+++ b/src/tools/manifest-checker.ts
@@ -10,8 +10,7 @@
 
 import minimist from 'minimist';
 import {Manifest, ManifestWarning} from '../runtime/manifest.js';
-import {Loader} from '../platform/loader.js';
-import {RuntimeCacheService} from '../runtime/runtime-cache.js';
+import {Loader} from '../platform/loader-node.js';
 import {SimpleVolatileMemoryProvider} from '../runtime/storageNG/drivers/volatile.js';
 
 // Script to check that a bundle of Arcs manifest files, particle
@@ -40,20 +39,44 @@ async function checkManifest(src: string) {
 
   // Check particle impls can be loaded.
   for (const particle of manifest.particles) {
-    if (!particle.external) {
-      if (particle.implFile) {
-        await loader.loadResource(particle.implFile);
-      } else {
-        throw new Error(`Particle ${particle.name} does not have an implementation file and is not marked external.`);
+    if (particle.external) {
+      continue;
+    }
+    if (!particle.implFile) {
+      throw new Error(`Particle ${particle.name} does not have an implementation file and is not marked external.`);
+    }
+    if (loader.isJvmClasspath(particle.implFile)) {
+      if (!loader.jvmClassExists(particle.implFile)) {
+        throw new Error(`Particle ${particle.name} does not have a valid classpath: '${particle.implFile}'.`);
       }
+    } else {
+      await loader.loadResource(particle.implFile);
     }
   }
 }
+
 
 async function main() {
   const opts = minimist(process.argv.slice(2), {
     string: ['src'],
   });
+
+  if (opts.help || !opts.src) {
+    console.log(`
+Usage
+  $ tools/sigh run manifestChecker --src [files...]
+
+Description
+  Loads the given .arcs manifest file and checks it for errors.
+  Errors are thrown as an exception.
+  
+Options
+  --src         manifest (*.arcs) files(s); required.
+  --help        usage info
+`);
+    process.exit(0);
+  }
+
   const srcs: string[] = typeof opts.src === 'string' ? [opts.src] : opts.src;
 
   let foundError = false;

--- a/third_party/java/arcs/build_defs/internal/manifest.bzl
+++ b/third_party/java/arcs/build_defs/internal/manifest.bzl
@@ -1,10 +1,6 @@
 """Arcs manifest bundling rules."""
 
 load("//third_party/java/arcs/build_defs:sigh.bzl", "sigh_command")
-load(
-    "//third_party/java/arcs/build_defs/internal:tools.oss.bzl",
-    "arcs_manifest_parse_test",
-)
 load(":util.bzl", "replace_arcs_suffix")
 
 def arcs_manifest(name, srcs, deps = [], visibility = None):
@@ -29,12 +25,6 @@ def arcs_manifest(name, srcs, deps = [], visibility = None):
         name = name,
         srcs = all_files,
         visibility = visibility,
-    )
-
-    arcs_manifest_parse_test(
-        name = name + "_parse_test",
-        srcs = srcs,
-        deps = deps,
     )
 
 def arcs_manifest_json(name, srcs = [], deps = [], out = None, visibility = None):

--- a/third_party/java/arcs/build_defs/internal/schemas.bzl
+++ b/third_party/java/arcs/build_defs/internal/schemas.bzl
@@ -186,11 +186,10 @@ def arcs_kt_gen(
     schema_name = name + "_schema"
     plan_name = name + "_plan"
 
-
     arcs_manifest(
         name = manifest_name,
         srcs = srcs,
-        deps = [d for d in deps if d.endswith(".arcs")]
+        deps = [d for d in deps if d.endswith(".arcs")],
     )
 
     deps = [d for d in deps if not d.endswith(".arcs")]

--- a/third_party/java/arcs/build_defs/internal/schemas.bzl
+++ b/third_party/java/arcs/build_defs/internal/schemas.bzl
@@ -7,6 +7,7 @@ load("//devtools/build_cleaner/skylark:build_defs.bzl", "register_extension_info
 load("//third_party/java/arcs/build_defs:sigh.bzl", "sigh_command")
 load("//third_party/java/arcs/build_defs/internal:util.bzl", "replace_arcs_suffix")
 load(":kotlin.bzl", "ARCS_SDK_DEPS", "arcs_kt_library", "arcs_kt_plan")
+load(":manifest.bzl", "arcs_manifest")
 
 def _run_schema2wasm(
         name,
@@ -180,12 +181,24 @@ def arcs_kt_gen(
       test_harness: whether to generate a test harness target
       visibility: visibility of the generated arcs_kt_library
     """
+
+    manifest_name = name + "_manifest"
     schema_name = name + "_schema"
     plan_name = name + "_plan"
+
+
+    arcs_manifest(
+        name = manifest_name,
+        srcs = srcs,
+        deps = [d for d in deps if d.endswith(".arcs")]
+    )
+
+    deps = [d for d in deps if not d.endswith(".arcs")]
+
     schema = arcs_kt_schema(
         name = schema_name,
         srcs = srcs,
-        deps = deps,
+        deps = deps + [":" + manifest_name],
         platforms = platforms,
         test_harness = test_harness,
         visibility = visibility,

--- a/third_party/java/arcs/build_defs/internal/tools.oss.bzl
+++ b/third_party/java/arcs/build_defs/internal/tools.oss.bzl
@@ -11,7 +11,7 @@ def arcs_manifest_parse_test(name, srcs, deps = []):
       deps: list of dependencies (e.g. other imported manifest files)
     """
 
-    test_args = " ".join(["--src $(location %s)" % src for src in srcs])
+    test_args = " ".join(["$(location %s)" % src for src in srcs])
 
     sigh_command(
         name = name,

--- a/third_party/java/arcs/build_defs/internal/tools.oss.bzl
+++ b/third_party/java/arcs/build_defs/internal/tools.oss.bzl
@@ -1,6 +1,7 @@
 """Rules that invoke sigh scripts."""
 
 load("//third_party/java/arcs/build_defs:sigh.bzl", "sigh_command")
+load(":manifest.bzl", "arcs_manifest")
 
 def arcs_manifest_parse_test(name, srcs, deps = []):
     """Tests that Arcs manifest files parse correctly.
@@ -8,15 +9,26 @@ def arcs_manifest_parse_test(name, srcs, deps = []):
     Args:
       name: the name of the test target to create
       srcs: list of Arcs manifest files to test
-      deps: list of dependencies (e.g. other imported manifest files)
+      deps: list of dependencies (e.g. other imported manifest files, particle code, etc.)
     """
+    for src in srcs:
+        if not src.endswith(".arcs"):
+            fail("src must be an .arcs manifest file, found %s" % src)
 
-    test_args = " ".join(["$(location %s)" % src for src in srcs])
+    manifest_name = name + "_sources"
+
+    arcs_manifest(
+        name = manifest_name,
+        srcs = srcs,
+        deps = deps,
+    )
+
+    test_args = " ".join(["--src $(location %s)" % src for src in srcs])
 
     sigh_command(
         name = name,
         srcs = srcs,
-        deps = deps,
+        deps = deps + [":" + manifest_name],
         sigh_cmd = "run manifestChecker " + test_args,
         progress_message = "Checking Arcs manifest",
         execute = False,


### PR DESCRIPTION
## Summary

### `arcs_manifest` is now a simple bundler (i.e. filegroup)
Manifest checking has to be decoupled from manifest bunding because the `arcs_manifest` rule cannot take in Jvm source files (causes cyclic dependency). Thus, the manifest checker functionality had to be pulled out. 

### `arcs_manifest_parse_test` will verify Jvm partiles
This improvement involved changes to the loader to verify Java-style classpaths. In addition, the `manifest.ts` was modified to refer to the abstract base loader (more generic). Lastly, I updated the manifest checker CLI to print help docs on `--help` or no-arg invocation.

I added a few examples of use of this rule in the android demo and in PipeApps. Now, manifests should be passed in to `srcs` and particle code should be passed into `deps`. 


### `arcs_kt_gen` supports manifest dependencies
Developers may want to write `Schema.arcs` files that contain shared schemas. This breaks Ben's `arcs_kt_gen` tool, which also offers a lot of developer convenience. 

This change allows one to specify an .arcs file as a dependency in `arcs_kt_gen`. 
