### PR TITLE
Simplify ArcHost serialization code to use references

### DIFF
--- a/java/arcs/core/host/AbstractArcHost.kt
+++ b/java/arcs/core/host/AbstractArcHost.kt
@@ -138,11 +138,10 @@ abstract class AbstractArcHost(
      * to storage.
      */
     private suspend fun createArcHostContextParticle(arcHostContext: ArcHostContext) =
-        ArcHostContextParticle().apply {
+        ArcHostContextParticle(hostId, this::instantiateParticle).apply {
             val partition = createArcHostContextPersistencePlan(
                 arcHostContextCapability,
-                arcHostContext.arcId,
-                hostId
+                arcHostContext.arcId
             )
             partition.particles[0].handles.forEach { handleSpec ->
                 createHandle(arcHostContext, handleSpec.key, handleSpec.value, handles)
@@ -160,7 +159,7 @@ abstract class AbstractArcHost(
     protected open suspend fun readContextFromStorage(
         arcHostContext: ArcHostContext
     ): ArcHostContext = createArcHostContextParticle(arcHostContext).let {
-        it.readArcHostContext(arcHostContext, hostId, this::instantiateParticle)
+        it.readArcHostContext(arcHostContext)
     }?.also {
         contextCache[arcHostContext.arcId] = it
     } ?: arcHostContext
@@ -173,7 +172,7 @@ abstract class AbstractArcHost(
      */
     protected open suspend fun writeContextToStorage(arcId: String, context: ArcHostContext) =
         createArcHostContextParticle(context).run {
-            writeArcHostContext(context.arcId, hostId, context)
+            writeArcHostContext(context.arcId, context)
         }
 
     override suspend fun startArc(partition: Plan.Partition) {

--- a/java/arcs/core/host/ArcHostContext.arcs
+++ b/java/arcs/core/host/ArcHostContext.arcs
@@ -1,7 +1,7 @@
 meta
   namespace: arcs.core.host
 
-// Represents a de-normalized Map<String, Plan.HandleConnection>
+// Represents a Plan.HandleConnection
 schema HandleConnection
   handleName: Text
   storageKey: Text
@@ -12,7 +12,7 @@ schema HandleConnection
   // Ttl object's count field in minutes
   ttl: Number
 
-// Represents a de-normalized ParticleContext
+// Represents a ParticleContext and Plan.Particle
 schema Particle
   particleName: Text
   location: Text

--- a/java/arcs/core/host/ArcHostContext.arcs
+++ b/java/arcs/core/host/ArcHostContext.arcs
@@ -1,34 +1,44 @@
 meta
   namespace: arcs.core.host
-// These schema definitions are used to store a de-normalized version of ArcHostContext via ArcHostContextParticle
 
-particle ArcHostParticle
-  // Represents the ArcHostContext
+// Represents a de-normalized Map<String, Plan.HandleConnection>
+schema HandleConnection
+  handleName: Text
+  storageKey: Text
+  // HandleMode enum name
+  mode: Text
+  // Type.Tag enum name
+  type: Text
+  // Ttl object's count field in minutes
+  ttl: Number
+
+// Represents a de-normalized ParticleContext
+schema Particle
+  particleName: Text
+  location: Text
+  // ParticleState enum name
+  particleState: Text
+  consecutiveFailures: Number
+  handles: [&HandleConnection]
+
+particle ArcHostContextParticle
   arcHostContext: reads writes ArcHostContext {
     arcId: Text,
-    arcHost: Text,
+    hostId: Text,
     // ArcState enum name
-    arcState: Text
+    arcState: Text,
+    particles: [&Particle]
   }
-  // Represents a de-normalized ParticleContext
-  particles: reads writes [Particle {
-    arcId: Text,
-    particleName: Text,
-    location: Text,
-    // ParticleState enum name
-    particleState: Text,
-    consecutiveFailures: Number
-  }]
-  // Represents a de-normalized Map<String, Plan.HandleConnection>
-  handleConnections: reads writes [HandleConnection {
-    arcId: Text,
-    particleName: Text,
-    handleName: Text,
-    storageKey: Text,
-    // HandleMode enum name
-    mode: Text,
-    // Type.Tag enum name
-    type: Text,
-    // Ttl object's count field in minutes
-    ttl: Number
-  }]
+  particles: reads writes [Particle]
+  handleConnections: reads writes [HandleConnection]
+
+recipe ArcHostContext
+  arcHostContext: create 'arcHostContext'
+  particles: create 'particles'
+  handleConnections: create 'handleConnections'
+
+  ArcHostContextParticle
+    arcHostContext: reads writes arcHostContext
+    particles: reads writes particles
+    handleConnections: reads writes handleConnections
+

--- a/java/arcs/core/host/BUILD
+++ b/java/arcs/core/host/BUILD
@@ -1,4 +1,4 @@
-load("//third_party/java/arcs/build_defs:build_defs.bzl", "arcs_kt_library", "arcs_kt_schema")
+load("//third_party/java/arcs/build_defs:build_defs.bzl", "arcs_kt_library", "arcs_kt_plan", "arcs_kt_schema")
 
 licenses(["notice"])
 
@@ -11,10 +11,21 @@ arcs_kt_schema(
     ],
 )
 
+arcs_kt_plan(
+    name = "plan",
+    srcs = [
+        "ArcHostContext.arcs",
+    ],
+    deps = [
+        ":schemas",
+    ],
+)
+
 arcs_kt_library(
     name = "host",
     srcs = glob(["*.kt"]),
     deps = [
+        ":plan",
         ":schemas",
         "//java/arcs/core/common",
         "//java/arcs/core/crdt",

--- a/javatests/arcs/android/host/ArcHostHelperTest.kt
+++ b/javatests/arcs/android/host/ArcHostHelperTest.kt
@@ -16,12 +16,9 @@ import android.content.Intent
 import android.os.Bundle
 import android.os.Handler
 import android.os.ResultReceiver
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleObserver
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import arcs.android.sdk.host.ArcHostHelper
-import arcs.android.sdk.host.ResurrectableHost
 import arcs.android.sdk.host.createGetRegisteredParticlesIntent
 import arcs.android.sdk.host.createStartArcHostIntent
 import arcs.android.sdk.host.createStopArcHostIntent
@@ -36,10 +33,8 @@ import arcs.core.data.SchemaName
 import arcs.core.host.ArcHost
 import arcs.core.data.HandleMode
 import arcs.core.host.ParticleIdentifier
-import arcs.core.storage.StorageKey
 import arcs.core.storage.keys.VolatileStorageKey
 import arcs.core.util.guardedBy
-import arcs.sdk.android.storage.ResurrectionHelper
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking


### PR DESCRIPTION
* Change recipe to use references instead of denormalization
* Use recipe2plan to construct Plan.Particle
* minor tweaks for readability

Not Done:
* currently removes and replaces entities when updating instead of mutate-in-place
* creates storage-keys per-arc/per-host when it could be using a single key for all arcs, and leverage queries. However, queries end up loading all data into memory, so I punted on this for fear of making system health worse.
* until Schema is serializable,  the de-serializer still needs to instantiate particles. There's a one-pager on fixing this if approved.
