### PR TITLE
Fix broken e2e singleton test.

### DIFF
--- a/java/arcs/android/crdt/CrdtParcelables.kt
+++ b/java/arcs/android/crdt/CrdtParcelables.kt
@@ -43,10 +43,11 @@ fun Parcel.writeModelData(model: CrdtData?, flags: Int) {
         null -> writeTypedObject(null, flags)
         is CrdtCount.Data ->
             writeTypedObject((model as? CrdtCount.Data)?.toParcelable(), flags)
-        is CrdtSet.Data<*> ->
-            writeTypedObject((model as? CrdtSet.Data<Referencable>)?.toParcelable(), flags)
+        // Caution: CrdtSingleton.Data extends CrdtSet.Data, so we must check it first.
         is CrdtSingleton.Data<*> ->
             writeTypedObject((model as? CrdtSingleton.Data<Referencable>)?.toParcelable(), flags)
+        is CrdtSet.Data<*> ->
+            writeTypedObject((model as? CrdtSet.Data<Referencable>)?.toParcelable(), flags)
         is CrdtEntity.Data ->
             TODO("Implement me when ParcelableEntity is ready")
         else -> throw IllegalArgumentException("Unsupported CrdtData type: ${model.javaClass}")

--- a/java/arcs/core/crdt/CrdtSingleton.kt
+++ b/java/arcs/core/crdt/CrdtSingleton.kt
@@ -156,7 +156,8 @@ class CrdtSingleton<T : Referencable>(
 
             override fun hashCode(): Int = toString().hashCode()
 
-            override fun toString(): String = "CrdtSet.Operation.Update($clock, $actor, $value)"
+            override fun toString(): String =
+                "CrdtSingleton.Operation.Update($clock, $actor, $value)"
         }
 
         /** An [Operation] to clear the value stored by the [CrdtSingleton]. */
@@ -181,7 +182,7 @@ class CrdtSingleton<T : Referencable>(
 
             override fun hashCode(): Int = toString().hashCode()
 
-            override fun toString(): String = "CrdtSet.Operation.Clear($clock, $actor)"
+            override fun toString(): String = "CrdtSingleton.Operation.Clear($clock, $actor)"
         }
     }
 

--- a/javatests/arcs/android/crdt/CrdtSetProtoTest.kt
+++ b/javatests/arcs/android/crdt/CrdtSetProtoTest.kt
@@ -53,13 +53,13 @@ class CrdtSetProtoTest {
         ))
 
         val marshalled = with(Parcel.obtain()) {
-            writeProto(data.toProto())
+            writeModelData(data, 0)
             marshall()
         }
         val unmarshalled = with(Parcel.obtain()) {
             unmarshall(marshalled, 0, marshalled.size)
             setDataPosition(0)
-            readCrdtSetData()
+            readModelData(ParcelableCrdtType.Set)
         }
 
         assertThat(unmarshalled).isEqualTo(data)
@@ -70,13 +70,13 @@ class CrdtSetProtoTest {
         val op = CrdtSet.Operation.Add("alice", versionMap, entity1)
 
         val marshalled = with(Parcel.obtain()) {
-            writeProto(op.toProto())
+            writeOperation(op, 0)
             marshall()
         }
         val unmarshalled = with(Parcel.obtain()) {
             unmarshall(marshalled, 0, marshalled.size)
             setDataPosition(0)
-            readCrdtSetOperation()
+            readOperation(ParcelableCrdtType.Set)
         }
 
         assertThat(unmarshalled).isEqualTo(op)
@@ -87,13 +87,13 @@ class CrdtSetProtoTest {
         val op = CrdtSet.Operation.Remove("alice", versionMap, entity1)
 
         val marshalled = with(Parcel.obtain()) {
-            writeProto(op.toProto())
+            writeOperation(op, 0)
             marshall()
         }
         val unmarshalled = with(Parcel.obtain()) {
             unmarshall(marshalled, 0, marshalled.size)
             setDataPosition(0)
-            readCrdtSetOperation()
+            readOperation(ParcelableCrdtType.Set)
         }
 
         assertThat(unmarshalled).isEqualTo(op)
@@ -111,13 +111,13 @@ class CrdtSetProtoTest {
         )
 
         val marshalled = with(Parcel.obtain()) {
-            writeProto(op.toProto())
+            writeOperation(op, 0)
             marshall()
         }
         val unmarshalled = with(Parcel.obtain()) {
             unmarshall(marshalled, 0, marshalled.size)
             setDataPosition(0)
-            readCrdtSetOperation()
+            readOperation(ParcelableCrdtType.Set)
         }
 
         assertThat(unmarshalled).isEqualTo(op)

--- a/javatests/arcs/android/crdt/ParcelableCrdtCountTest.kt
+++ b/javatests/arcs/android/crdt/ParcelableCrdtCountTest.kt
@@ -33,17 +33,17 @@ class ParcelableCrdtCountTest {
         )
 
         val marshalled = with(Parcel.obtain()) {
-            writeTypedObject(data.toParcelable(), 0)
+            writeModelData(data, 0)
             marshall()
         }
 
         val unmarshalled = with(Parcel.obtain()) {
             unmarshall(marshalled, 0, marshalled.size)
             setDataPosition(0)
-            readTypedObject(requireNotNull(ParcelableCrdtType.Count.crdtDataCreator))
+            readModelData(ParcelableCrdtType.Count)
         }
 
-        assertThat(unmarshalled?.actual).isEqualTo(data)
+        assertThat(unmarshalled).isEqualTo(data)
     }
 
     @Test
@@ -51,17 +51,17 @@ class ParcelableCrdtCountTest {
         val op = CrdtCount.Operation.Increment("alice", 0 to 1)
 
         val marshalled = with(Parcel.obtain()) {
-            writeTypedObject(op.toParcelable(), 0)
+            writeOperation(op, 0)
             marshall()
         }
 
         val unmarshalled = with(Parcel.obtain()) {
             unmarshall(marshalled, 0, marshalled.size)
             setDataPosition(0)
-            readTypedObject(requireNotNull(ParcelableCrdtType.Count.crdtOperationCreator))
+            readOperation(ParcelableCrdtType.Count)
         }
 
-        assertThat(unmarshalled?.actual).isEqualTo(op)
+        assertThat(unmarshalled).isEqualTo(op)
     }
 
     @Test
@@ -69,16 +69,16 @@ class ParcelableCrdtCountTest {
         val op = CrdtCount.Operation.MultiIncrement("alice", 0 to 1000, delta = 1000)
 
         val marshalled = with(Parcel.obtain()) {
-            writeTypedObject(op.toParcelable(), 0)
+            writeOperation(op, 0)
             marshall()
         }
 
         val unmarshalled = with(Parcel.obtain()) {
             unmarshall(marshalled, 0, marshalled.size)
             setDataPosition(0)
-            readTypedObject(requireNotNull(ParcelableCrdtType.Count.crdtOperationCreator))
+            readOperation(ParcelableCrdtType.Count)
         }
 
-        assertThat(unmarshalled?.actual).isEqualTo(op)
+        assertThat(unmarshalled).isEqualTo(op)
     }
 }

--- a/javatests/arcs/android/crdt/ParcelableCrdtSingletonTest.kt
+++ b/javatests/arcs/android/crdt/ParcelableCrdtSingletonTest.kt
@@ -36,16 +36,16 @@ class ParcelableCrdtSingletonTest {
         ))
 
         val marshalled = with(Parcel.obtain()) {
-            writeTypedObject(data.toParcelable(), 0)
+            writeModelData(data, 0)
             marshall()
         }
         val unmarshalled = with(Parcel.obtain()) {
             unmarshall(marshalled, 0, marshalled.size)
             setDataPosition(0)
-            readTypedObject(requireNotNull(ParcelableCrdtType.Singleton.crdtDataCreator))
+            readModelData(ParcelableCrdtType.Singleton)
         }
 
-        assertThat(unmarshalled?.actual).isEqualTo(data)
+        assertThat(unmarshalled).isEqualTo(data)
     }
 
     @Test
@@ -53,16 +53,16 @@ class ParcelableCrdtSingletonTest {
         val op = CrdtSingleton.Operation.Update("alice", versionMap, entity1)
 
         val marshalled = with(Parcel.obtain()) {
-            writeTypedObject(op.toParcelable(), 0)
+            writeOperation(op, 0)
             marshall()
         }
         val unmarshalled = with(Parcel.obtain()) {
             unmarshall(marshalled, 0, marshalled.size)
             setDataPosition(0)
-            readTypedObject(requireNotNull(ParcelableCrdtType.Singleton.crdtOperationCreator))
+            readOperation(ParcelableCrdtType.Singleton)
         }
 
-        assertThat(unmarshalled?.actual).isEqualTo(op)
+        assertThat(unmarshalled).isEqualTo(op)
     }
 
     @Test
@@ -70,15 +70,15 @@ class ParcelableCrdtSingletonTest {
         val op = CrdtSingleton.Operation.Clear<Referencable>("alice", versionMap)
 
         val marshalled = with(Parcel.obtain()) {
-            writeTypedObject(op.toParcelable(), 0)
+            writeOperation(op, 0)
             marshall()
         }
         val unmarshalled = with(Parcel.obtain()) {
             unmarshall(marshalled, 0, marshalled.size)
             setDataPosition(0)
-            readTypedObject(requireNotNull(ParcelableCrdtType.Singleton.crdtOperationCreator))
+            readOperation(ParcelableCrdtType.Singleton)
         }
 
-        assertThat(unmarshalled?.actual).isEqualTo(op)
+        assertThat(unmarshalled).isEqualTo(op)
     }
 }

--- a/javatests/arcs/android/e2e/ArcsTests.kt
+++ b/javatests/arcs/android/e2e/ArcsTests.kt
@@ -96,7 +96,6 @@ class ArcsTest {
     }
 
     @Test
-    @Ignore("Broken: b/154181519")
     fun testSingleton_persistentLocalActivity() {
         // Configure handle options.
         clickOnTextIfPresent(SINGLETON_BTN_TEXT)

--- a/javatests/arcs/android/e2e/testapp/res/layout/test_activity.xml
+++ b/javatests/arcs/android/e2e/testapp/res/layout/test_activity.xml
@@ -9,197 +9,201 @@
   ~ grant found at
   ~ http://polymer.github.io/PATENTS.txt
   -->
-
-<LinearLayout
+<ScrollView
   xmlns:android="http://schemas.android.com/apk/res/android"
-  android:orientation="vertical"
   android:layout_width="match_parent"
   android:layout_height="match_parent">
 
-  <TextView
-    android:id="@+id/result1"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:textAllCaps="false"
-    android:text="@string/result_prompt"
-    android:fontFamily="sans-serif-black"
-    android:padding="8dp"
-    android:layout_marginTop="8dp"/>
-
-  <TextView
-    android:id="@+id/result2"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:textAllCaps="false"
-    android:text="@string/result_prompt"
-    android:fontFamily="sans-serif-black"
-    android:padding="8dp"
-    android:layout_marginBottom="8dp"/>
-
   <LinearLayout
     android:orientation="vertical"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:layout_margin="8dp">
+    android:layout_height="wrap_content">
 
     <TextView
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:fontFamily="sans-serif-medium"
-      android:text="@string/readwrite_test"/>
-
-    <Button
-      android:id="@+id/read_write_test"
+      android:id="@+id/result1"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:textAllCaps="false"
-      android:text="@string/read_write_test_btn"
-      style="?android:attr/buttonBarButtonStyle"/>
-
-    <Button
-      android:id="@+id/persistent_read_write_test"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:textAllCaps="false"
-      android:text="@string/persistent_read_write_test_btn"
-      style="?android:attr/buttonBarButtonStyle"/>
+      android:text="@string/result_prompt"
+      android:fontFamily="sans-serif-black"
+      android:padding="8dp"
+      android:layout_marginTop="8dp"/>
 
     <TextView
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:fontFamily="sans-serif-medium"
-      android:text="@string/resurrection_test"/>
-
-    <Button
-      android:id="@+id/start_resurrection_arc"
+      android:id="@+id/result2"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:textAllCaps="false"
-      android:text="@string/start_resurrection_arc_btn"
-      style="?android:attr/buttonBarButtonStyle"/>
-
-    <Button
-      android:id="@+id/stop_read_service"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:textAllCaps="false"
-      android:text="@string/stop_read_service_btn"
-      style="?android:attr/buttonBarButtonStyle"/>
-
-    <Button
-      android:id="@+id/trigger_write"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:textAllCaps="false"
-      android:text="@string/trigger_write_btn"
-      style="?android:attr/buttonBarButtonStyle"/>
-
-    <Button
-      android:id="@+id/stop_resurrection_arc"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:textAllCaps="false"
-      android:text="@string/stop_resurrection_arc_btn"
-      style="?android:attr/buttonBarButtonStyle"/>
-
-  </LinearLayout>
-
-  <LinearLayout
-    android:orientation="vertical"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:layout_margin="8dp">
-
-    <TextView
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:fontFamily="sans-serif-medium"
-      android:text="@string/storage_test"/>
-
-    <RadioGroup
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:orientation="horizontal">
-      <RadioButton
-        android:id="@+id/singleton"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/singleton"
-        android:checked="true"/>
-      <RadioButton
-        android:id="@+id/collection"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/collection"/>
-    </RadioGroup>
-
-    <RadioGroup
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:orientation="horizontal">
-      <RadioButton
-        android:id="@+id/in_memory"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/in_memory"
-        android:checked="true"/>
-      <RadioButton
-        android:id="@+id/persistent"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/persistent"/>
-    </RadioGroup>
-
-    <RadioGroup
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:orientation="horizontal">
-      <RadioButton
-        android:id="@+id/local"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/local_activity"
-        android:checked="true"/>
-      <RadioButton
-        android:id="@+id/remote"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/remote_service"/>
-    </RadioGroup>
+      android:text="@string/result_prompt"
+      android:fontFamily="sans-serif-black"
+      android:padding="8dp"
+      android:layout_marginBottom="8dp"/>
 
     <LinearLayout
+      android:orientation="vertical"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:orientation="horizontal"
-      style="?android:attr/buttonBarStyle">
+      android:layout_margin="8dp">
+
+      <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:fontFamily="sans-serif-medium"
+        android:text="@string/readwrite_test"/>
+
       <Button
-        android:id="@+id/create"
+        android:id="@+id/read_write_test"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:textAllCaps="false"
-        android:text="@string/create"
+        android:text="@string/read_write_test_btn"
         style="?android:attr/buttonBarButtonStyle"/>
+
       <Button
-        android:id="@+id/fetch"
+        android:id="@+id/persistent_read_write_test"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:textAllCaps="false"
-        android:text="@string/fetch"
+        android:text="@string/persistent_read_write_test_btn"
         style="?android:attr/buttonBarButtonStyle"/>
+
+      <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:fontFamily="sans-serif-medium"
+        android:text="@string/resurrection_test"/>
+
       <Button
-        android:id="@+id/set"
+        android:id="@+id/start_resurrection_arc"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:textAllCaps="false"
-        android:text="@string/set"
+        android:text="@string/start_resurrection_arc_btn"
         style="?android:attr/buttonBarButtonStyle"/>
+
       <Button
-        android:id="@+id/clear"
+        android:id="@+id/stop_read_service"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:textAllCaps="false"
-        android:text="@string/clear"
+        android:text="@string/stop_read_service_btn"
         style="?android:attr/buttonBarButtonStyle"/>
+
+      <Button
+        android:id="@+id/trigger_write"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textAllCaps="false"
+        android:text="@string/trigger_write_btn"
+        style="?android:attr/buttonBarButtonStyle"/>
+
+      <Button
+        android:id="@+id/stop_resurrection_arc"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textAllCaps="false"
+        android:text="@string/stop_resurrection_arc_btn"
+        style="?android:attr/buttonBarButtonStyle"/>
+
+    </LinearLayout>
+
+    <LinearLayout
+      android:orientation="vertical"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:layout_margin="8dp">
+
+      <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:fontFamily="sans-serif-medium"
+        android:text="@string/storage_test"/>
+
+      <RadioGroup
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+        <RadioButton
+          android:id="@+id/singleton"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="@string/singleton"
+          android:checked="true"/>
+        <RadioButton
+          android:id="@+id/collection"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="@string/collection"/>
+      </RadioGroup>
+
+      <RadioGroup
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+        <RadioButton
+          android:id="@+id/in_memory"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="@string/in_memory"
+          android:checked="true"/>
+        <RadioButton
+          android:id="@+id/persistent"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="@string/persistent"/>
+      </RadioGroup>
+
+      <RadioGroup
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+        <RadioButton
+          android:id="@+id/local"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="@string/local_activity"
+          android:checked="true"/>
+        <RadioButton
+          android:id="@+id/remote"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="@string/remote_service"/>
+      </RadioGroup>
+
+      <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        style="?android:attr/buttonBarStyle">
+        <Button
+          android:id="@+id/create"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:textAllCaps="false"
+          android:text="@string/create"
+          style="?android:attr/buttonBarButtonStyle"/>
+        <Button
+          android:id="@+id/fetch"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:textAllCaps="false"
+          android:text="@string/fetch"
+          style="?android:attr/buttonBarButtonStyle"/>
+        <Button
+          android:id="@+id/set"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:textAllCaps="false"
+          android:text="@string/set"
+          style="?android:attr/buttonBarButtonStyle"/>
+        <Button
+          android:id="@+id/clear"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:textAllCaps="false"
+          android:text="@string/clear"
+          style="?android:attr/buttonBarButtonStyle"/>
+      </LinearLayout>
     </LinearLayout>
   </LinearLayout>
-</LinearLayout>
+</ScrollView>


### PR DESCRIPTION
Re-enables the broken test (reverts #5161).

Serialisation bug was uncovered by #5145, which converted part of the serialisation code to protos. The bug was that the CrdtSingleton.Data interface implements CrdtSet.Data, but the when-statement was not ordered accordingly. So when trying to serialise the data, it would misinterpret it as CrdtSet.Data.

The real fix should be to break that inheritance chain, but I couldn't find an easy way to do that, so this will have to do for now.

Also fixed some incorrect toString debug messages, and put the test app's UI inside a scroll view, so that you can still push the buttons when the debug text is long.