### PR TITLE
support multiple hosts per service

### DIFF
--- a/java/arcs/android/host/prod/ProdArcHostService.kt
+++ b/java/arcs/android/host/prod/ProdArcHostService.kt
@@ -39,7 +39,7 @@ open class ProdArcHostService : ArcHostService() {
     /**
      * This is open for tests to override, but normally isn't necessary.
      */
-    override val arcHost: ArcHost by lazy {
+    val arcHost: ArcHost by lazy {
         ProdAndroidHost(
             this,
             this.lifecycle,
@@ -47,4 +47,6 @@ open class ProdArcHostService : ArcHostService() {
             *scanForParticles()
         )
     }
+
+    override val arcHosts = listOf(arcHost)
 }

--- a/java/arcs/android/host/prod/ProdArcHostService.kt
+++ b/java/arcs/android/host/prod/ProdArcHostService.kt
@@ -39,7 +39,7 @@ open class ProdArcHostService : ArcHostService() {
     /**
      * This is open for tests to override, but normally isn't necessary.
      */
-    open val arcHost: ArcHost by lazy {
+    override val arcHost: ArcHost by lazy {
         ProdAndroidHost(
             this,
             this.lifecycle,

--- a/java/arcs/android/host/prod/ProdArcHostService.kt
+++ b/java/arcs/android/host/prod/ProdArcHostService.kt
@@ -39,7 +39,7 @@ open class ProdArcHostService : ArcHostService() {
     /**
      * This is open for tests to override, but normally isn't necessary.
      */
-    val arcHost: ArcHost by lazy {
+    open val arcHost: ArcHost by lazy {
         ProdAndroidHost(
             this,
             this.lifecycle,

--- a/java/arcs/android/sdk/host/ArcHostService.kt
+++ b/java/arcs/android/sdk/host/ArcHostService.kt
@@ -23,10 +23,13 @@ import kotlinx.coroutines.cancel
 abstract class ArcHostService : LifecycleService() {
     protected val scope: CoroutineScope = MainScope()
 
+    // TODO: remove after G3 fixed
+    abstract val arcHost: ArcHost
+
     /**
      * Subclasses must override this with their own [ArcHost]s.
      */
-    abstract val arcHosts: List<ArcHost>
+    open val arcHosts: List<ArcHost> = listOf(arcHost)
 
     val arcHostHelper: ArcHostHelper by lazy {
         ArcHostHelper(this, *arcHosts.toTypedArray())

--- a/java/arcs/android/sdk/host/ArcHostService.kt
+++ b/java/arcs/android/sdk/host/ArcHostService.kt
@@ -29,7 +29,7 @@ abstract class ArcHostService : LifecycleService() {
     /**
      * Subclasses must override this with their own [ArcHost]s.
      */
-    open val arcHosts: List<ArcHost> = listOf(arcHost)
+    open val arcHosts: List<ArcHost> by lazy { listOf(arcHost) }
 
     val arcHostHelper: ArcHostHelper by lazy {
         ArcHostHelper(this, *arcHosts.toTypedArray())

--- a/java/arcs/android/sdk/host/ArcHostService.kt
+++ b/java/arcs/android/sdk/host/ArcHostService.kt
@@ -24,12 +24,12 @@ abstract class ArcHostService : LifecycleService() {
     protected val scope: CoroutineScope = MainScope()
 
     /**
-     * Subclasses must override this with their own [ArcHost].
+     * Subclasses must override this with their own [ArcHost]s.
      */
-    abstract val arcHost: ArcHost
+    abstract val arcHosts: List<ArcHost>
 
     val arcHostHelper: ArcHostHelper by lazy {
-        ArcHostHelper(this, arcHost)
+        ArcHostHelper(this, *arcHosts.toTypedArray())
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {

--- a/java/arcs/android/sdk/host/IntentArcHostAdapter.kt
+++ b/java/arcs/android/sdk/host/IntentArcHostAdapter.kt
@@ -12,35 +12,28 @@ package arcs.android.sdk.host
 
 import android.content.ComponentName
 import android.content.Intent
-import android.os.Bundle
-import android.os.Handler
-import android.os.ResultReceiver
 import arcs.android.host.parcelables.ParcelableParticleIdentifier
 import arcs.core.data.Plan
 import arcs.core.host.ArcHost
 import arcs.core.host.ParticleIdentifier
-import kotlinx.coroutines.CancellableContinuation
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.suspendCancellableCoroutine
-import kotlinx.coroutines.withTimeout
 
 /**
- * An [ArcHost] stub that translates API calls to [Intent]s directed at a [Service] using
- * [ArcHostHelper] to handle them.
+ * An [ArcHost] stub that translates API calls into [Intent]s directed at a [Service] using
+ * [ArcHostHelper] to dispatch them to corresponding [ArcHost] methods.
  *
- * @property arcHostComponentName the [ComponentName] of the [Service]
- * @property sender a callback used to fire the [Intent], overridable to allow testing.
+ * @param arcHostComponentName the [ComponentName] of the [Service]
+ * @property hostId the hostId of the remote [ArcHost] instance
+ * @param sender a callback used to fire the [Intent], overridable to allow testing
  */
 class IntentArcHostAdapter(
-    private val arcHostComponentName: ComponentName,
-    private val sender: (Intent) -> Unit
-) : ArcHost {
-
-    override val hostId = arcHostComponentName.flattenToString()
+    arcHostComponentName: ComponentName,
+    override val hostId: String,
+    sender: (Intent) -> Unit
+) : IntentHostAdapter(arcHostComponentName, sender), ArcHost {
 
     override suspend fun registeredParticles(): List<ParticleIdentifier> {
-        return sendIntentToArcHostServiceForResult(
-            arcHostComponentName.createGetRegisteredParticlesIntent()
+        return sendIntentToHostServiceForResult(
+            hostComponentName.createGetRegisteredParticlesIntent(hostId)
         ) {
             (it as? List<*>)?.map { identifier ->
                 (identifier as ParcelableParticleIdentifier).actual
@@ -49,73 +42,19 @@ class IntentArcHostAdapter(
     }
 
     override suspend fun startArc(partition: Plan.Partition) {
-        sendIntentToArcHostServiceForResult(
-            partition.createStartArcHostIntent(
-                arcHostComponentName
-            )
+        sendIntentToHostServiceForResult(
+            partition.createStartArcHostIntent(hostComponentName, hostId)
         )
     }
 
     override suspend fun stopArc(partition: Plan.Partition) {
-        sendIntentToArcHostServiceForResult(
-            partition.createStopArcHostIntent(
-                arcHostComponentName
-            )
+        sendIntentToHostServiceForResult(
+            partition.createStopArcHostIntent(hostComponentName, hostId)
         )
     }
 
     override suspend fun isHostForParticle(particle: Plan.Particle) =
         registeredParticles().contains(ParticleIdentifier.from(particle.location))
-
-    /**
-     * Asynchronously send an [ArcHost] command via [Intent] without waiting for return result.
-     */
-    private fun sendIntentToArcHostService(intent: Intent) {
-        sender(intent)
-    }
-
-    @OptIn(ExperimentalCoroutinesApi::class)
-    class ResultReceiverContinuation<T>(
-        val continuation: CancellableContinuation<T?>,
-        val block: (Any?) -> T?
-    ) : ResultReceiver(Handler()) {
-        override fun onReceiveResult(resultCode: Int, resultData: Bundle?) =
-            continuation.resume(
-                block(
-                    resultData?.get(
-                        ArcHostHelper.EXTRA_OPERATION_RESULT
-                    )
-                )
-            ) {}
-    }
-
-    /**
-     * Sends an asynchronous [ArcHost] command via [Intent] to a [Service] and waits for a
-     * result using a suspendable coroutine.
-     *
-     * @property intent the [ArcHost] command, usually from [ArcHostHelper]
-     * @property transformer a lambda to map return values from a [Bundle] into other types.
-     */
-    private suspend fun <T> sendIntentToArcHostServiceForResult(
-        intent: Intent,
-        transformer: (Any?) -> T?
-    ): T? = withTimeout(ARCHOST_INTENT_TIMEOUT) {
-        suspendCancellableCoroutine { cancelableContinuation: CancellableContinuation<T?> ->
-            ArcHostHelper.setResultReceiver(
-                intent,
-                ResultReceiverContinuation(cancelableContinuation, transformer)
-            )
-            sendIntentToArcHostService(intent)
-        }
-    }
-
-    /**
-     * Sends an asynchronous [ArcHost] command via [Intent] and waits for it to complete
-     * with no return value.
-     */
-    private suspend fun sendIntentToArcHostServiceForResult(
-        intent: Intent
-    ): Unit? = sendIntentToArcHostServiceForResult(intent) {}
 
     override fun hashCode(): Int = hostId.hashCode()
 
@@ -124,13 +63,5 @@ class IntentArcHostAdapter(
         if (javaClass != other?.javaClass) return false
         other as ArcHost
         return hostId == other.hostId
-    }
-
-    companion object {
-        /**
-         * The maximum amount of time to wait for an [ArcHost] to process an [Intent]-base RPC call.
-         * This timeout ensures requests don't wait forever.
-         */
-        const val ARCHOST_INTENT_TIMEOUT = 2000L
     }
 }

--- a/java/arcs/android/sdk/host/IntentHostAdapter.kt
+++ b/java/arcs/android/sdk/host/IntentHostAdapter.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+package arcs.android.sdk.host
+
+import android.content.ComponentName
+import android.content.Intent
+import android.os.Bundle
+import android.os.Handler
+import android.os.ResultReceiver
+import arcs.core.host.ArcHost
+import kotlinx.coroutines.CancellableContinuation
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withTimeout
+
+/**
+ * A stub that translates API calls into [Intent]s directed at a [Service] using
+ * [ArcHostHelper] to handle them.
+ *
+ * @property hostComponentName the [ComponentName] of the [Service]
+ * @property sender a callback used to fire the [Intent], overridable to allow testing.
+ */
+abstract class IntentHostAdapter(
+    protected val hostComponentName: ComponentName,
+    protected val sender: (Intent) -> Unit
+) {
+    /**
+     * Asynchronously send a command via [Intent] without waiting for return result.
+     */
+    protected fun sendIntentToHostService(intent: Intent) {
+        sender(intent)
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    class ResultReceiverContinuation<T>(
+        val continuation: CancellableContinuation<T?>,
+        val block: (Any?) -> T?
+    ) : ResultReceiver(Handler()) {
+        override fun onReceiveResult(resultCode: Int, resultData: Bundle?) =
+            continuation.resume(
+                block(
+                    resultData?.get(
+                        ArcHostHelper.EXTRA_OPERATION_RESULT
+                    )
+                )
+            ) {}
+    }
+
+    /**
+     * Sends an asynchronous command via [Intent] to a [Service] and waits for a
+     * result using a suspendable coroutine.
+     *
+     * @property intent the command, usually from [ArcHostHelper]
+     * @property transformer a lambda to map return values from a [Bundle] into other types.
+     */
+    protected suspend fun <T> sendIntentToHostServiceForResult(
+        intent: Intent,
+        transformer: (Any?) -> T?
+    ): T? = withTimeout(ARCHOST_INTENT_TIMEOUT) {
+        suspendCancellableCoroutine { cancelableContinuation: CancellableContinuation<T?> ->
+            ArcHostHelper.setResultReceiver(
+                intent,
+                ResultReceiverContinuation(cancelableContinuation, transformer)
+            )
+            sendIntentToHostService(intent)
+        }
+    }
+
+    /**
+     * Sends an asynchronous command via [Intent] and waits for it to complete
+     * with no return value.
+     */
+    protected suspend fun sendIntentToHostServiceForResult(
+        intent: Intent
+    ): Unit? = sendIntentToHostServiceForResult(intent) {}
+
+    companion object {
+        /**
+         * The maximum amount of time to wait for an [ArcHost] to process an [Intent]-base RPC call.
+         * This timeout ensures requests don't wait forever.
+         */
+        const val ARCHOST_INTENT_TIMEOUT = 2000L
+    }
+}

--- a/java/arcs/android/sdk/host/IntentRegistryAdapter.kt
+++ b/java/arcs/android/sdk/host/IntentRegistryAdapter.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+package arcs.android.sdk.host
+
+import android.content.ComponentName
+import android.content.Intent
+import arcs.core.host.ArcHost
+
+/**
+ * Queries [ArcHostHelper] for registered hosts, to support one-to-many [Service] to [ArcHost] fan
+ * out.
+ *
+ * @param hostComponentName the [ComponentName] of the [Service]
+ * @param sender a callback used to fire the [Intent], overridable to allow testing.
+ */
+open class IntentRegistryAdapter(
+    hostComponentName: ComponentName,
+    sender: (Intent) -> Unit
+) : IntentHostAdapter(hostComponentName, sender) {
+
+    suspend fun registeredHosts(): List<ArcHost> {
+        return sendIntentToHostServiceForResult(
+            hostComponentName.createAvailableHostsIntent()
+        ) {
+            (it as? List<*>)?.map { hostId ->
+                IntentArcHostAdapter(hostComponentName, hostId.toString(), sender)
+            }
+        } ?: emptyList()
+    }
+}

--- a/java/arcs/core/host/AbstractArcHost.kt
+++ b/java/arcs/core/host/AbstractArcHost.kt
@@ -63,7 +63,8 @@ abstract class AbstractArcHost(
     /** Arcs currently running in memory. */
     private val runningArcs: MutableMap<String, ArcHostContext> = mutableMapOf()
 
-    override val hostId = this::class.className()
+    // There can be more then one instance of a host, hashCode is used to disambiguate them
+    override val hostId = "${this::class.className()}@${this.hashCode()}"
 
     // TODO: refactor to allow clients to supply this
     private val coroutineContext = Dispatchers.Unconfined + CoroutineName("AbstractArcHost")

--- a/javatests/arcs/android/e2e/testapp/PersonHostService.kt
+++ b/javatests/arcs/android/e2e/testapp/PersonHostService.kt
@@ -35,7 +35,7 @@ class PersonHostService : ArcHostService() {
 
     private val coroutineContext = Job() + Dispatchers.Main
 
-    val arcHost = MyArcHost(
+    override val arcHost = MyArcHost(
         this,
         this.lifecycle,
         JvmSchedulerProvider(coroutineContext),

--- a/javatests/arcs/android/e2e/testapp/PersonHostService.kt
+++ b/javatests/arcs/android/e2e/testapp/PersonHostService.kt
@@ -35,13 +35,15 @@ class PersonHostService : ArcHostService() {
 
     private val coroutineContext = Job() + Dispatchers.Main
 
-    override val arcHost = MyArcHost(
+    val arcHost = MyArcHost(
         this,
         this.lifecycle,
         JvmSchedulerProvider(coroutineContext),
         ::ReadPerson.toRegistration(),
         ::WritePerson.toRegistration()
     )
+
+    override val arcHosts = listOf(arcHost)
 
     inner class MyArcHost(
         context: Context,

--- a/javatests/arcs/android/e2e/testapp/ReadAnimalHostService.kt
+++ b/javatests/arcs/android/e2e/testapp/ReadAnimalHostService.kt
@@ -34,12 +34,14 @@ class ReadAnimalHostService : ArcHostService() {
 
     private val coroutineContext = Job() + Dispatchers.Main
 
-    override val arcHost: ArcHost = MyArcHost(
+    val arcHost: ArcHost = MyArcHost(
         this,
         this.lifecycle,
         JvmSchedulerProvider(coroutineContext),
         ::ReadAnimal.toRegistration()
     )
+
+    override val arcHosts = listOf(arcHost)
 
     class MyArcHost(
         context: Context,

--- a/javatests/arcs/android/e2e/testapp/ReadAnimalHostService.kt
+++ b/javatests/arcs/android/e2e/testapp/ReadAnimalHostService.kt
@@ -34,7 +34,7 @@ class ReadAnimalHostService : ArcHostService() {
 
     private val coroutineContext = Job() + Dispatchers.Main
 
-    val arcHost: ArcHost = MyArcHost(
+    override val arcHost: ArcHost = MyArcHost(
         this,
         this.lifecycle,
         JvmSchedulerProvider(coroutineContext),

--- a/javatests/arcs/android/e2e/testapp/WriteAnimalHostService.kt
+++ b/javatests/arcs/android/e2e/testapp/WriteAnimalHostService.kt
@@ -33,7 +33,7 @@ class WriteAnimalHostService : ArcHostService() {
 
     private val coroutineContext = Job() + Dispatchers.Main
 
-    val arcHost: MyArcHost = MyArcHost(
+    override val arcHost: MyArcHost = MyArcHost(
         this,
         this.lifecycle,
         JvmSchedulerProvider(coroutineContext),

--- a/javatests/arcs/android/e2e/testapp/WriteAnimalHostService.kt
+++ b/javatests/arcs/android/e2e/testapp/WriteAnimalHostService.kt
@@ -33,12 +33,14 @@ class WriteAnimalHostService : ArcHostService() {
 
     private val coroutineContext = Job() + Dispatchers.Main
 
-    override val arcHost: MyArcHost = MyArcHost(
+    val arcHost: MyArcHost = MyArcHost(
         this,
         this.lifecycle,
         JvmSchedulerProvider(coroutineContext),
         ::WriteAnimal.toRegistration()
     )
+
+    override val arcHosts = listOf(arcHost)
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         val arcId = intent?.getStringExtra(ARC_ID_EXTRA)

--- a/javatests/arcs/android/host/AndroidHostRegistryTest.kt
+++ b/javatests/arcs/android/host/AndroidHostRegistryTest.kt
@@ -43,8 +43,9 @@ class AndroidHostRegistryTest {
 
     @Test
     fun hostRegistry_availableArcHosts_containsTestArcHost() = runBlockingTest {
+        val service = TestReadingExternalHostService()
         assertThat(hostRegistry.availableArcHosts()).contains(
-            TestReadingExternalHostService().toArcHost(context, sender)
+            service.toArcHost(context, service.arcHost.hostId, sender)
         )
     }
 }

--- a/javatests/arcs/android/host/AndroidHostRegistryTest.kt
+++ b/javatests/arcs/android/host/AndroidHostRegistryTest.kt
@@ -43,7 +43,6 @@ class AndroidHostRegistryTest {
 
     @Test
     fun hostRegistry_availableArcHosts_containsTestArcHost() = runBlockingTest {
-        val service = TestReadingExternalHostService()
         assertThat(hostRegistry.availableArcHosts()).contains(
             service.toArcHost(context, service.arcHost.hostId, sender)
         )

--- a/javatests/arcs/android/host/ArcHostHelperTest.kt
+++ b/javatests/arcs/android/host/ArcHostHelperTest.kt
@@ -42,6 +42,7 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Robolectric
@@ -142,10 +143,12 @@ class ArcHostHelperTest {
 
         val planPartition = Plan.Partition("id", "FooHost", listOf(particleSpec))
         val startIntent = planPartition.createStartArcHostIntent(
-            TestAndroidArcHostService::class.toComponentName(context)
+            TestAndroidArcHostService::class.toComponentName(context),
+            arcHost.hostId
         )
         val stopIntent = planPartition.createStopArcHostIntent(
-            TestAndroidArcHostService::class.toComponentName(context)
+            TestAndroidArcHostService::class.toComponentName(context),
+            arcHost.hostId
         )
         helper.onStartCommandSuspendable(startIntent)
         assertThat(arcHost.startCalls()).containsExactly(planPartition)
@@ -163,7 +166,7 @@ class ArcHostHelperTest {
         arcHost.registerParticle(particleIdentifier2)
 
         val getParticlesIntent = TestAndroidArcHostService::class.toComponentName(context)
-            .createGetRegisteredParticlesIntent()
+            .createGetRegisteredParticlesIntent(arcHost.hostId)
 
         // Wait for async result
         runBlocking {

--- a/javatests/arcs/android/host/TestProdArcHostService.kt
+++ b/javatests/arcs/android/host/TestProdArcHostService.kt
@@ -11,13 +11,13 @@ import arcs.sdk.android.storage.ServiceStoreFactory
 import arcs.sdk.android.storage.service.testutil.TestConnectionFactory
 
 class TestProdArcHostService : ProdArcHostService() {
-    val testArcHost = TestingAndroidProdHost(
+    override val arcHost = TestingAndroidProdHost(
         this,
         this.lifecycle,
         JvmSchedulerProvider(scope.coroutineContext)
     )
 
-    override val arcHosts = listOf(testArcHost)
+    override val arcHosts = listOf(arcHost)
 
     class TestingAndroidProdHost(
         val context: Context,

--- a/javatests/arcs/android/host/TestProdArcHostService.kt
+++ b/javatests/arcs/android/host/TestProdArcHostService.kt
@@ -11,11 +11,13 @@ import arcs.sdk.android.storage.ServiceStoreFactory
 import arcs.sdk.android.storage.service.testutil.TestConnectionFactory
 
 class TestProdArcHostService : ProdArcHostService() {
-    override val arcHost = TestingAndroidProdHost(
+    val testArcHost = TestingAndroidProdHost(
         this,
         this.lifecycle,
         JvmSchedulerProvider(scope.coroutineContext)
     )
+
+    override val arcHosts = listOf(testArcHost)
 
     class TestingAndroidProdHost(
         val context: Context,


### PR DESCRIPTION
* Extends ArcHostHelper to accept a variable number of ArcHosts.
* Allows a single-service to host more than 1 service
