### PR TITLE
Render exceptions into logs correctly on Android.

### DIFF
--- a/java/arcs/android/util/AndroidLog.kt
+++ b/java/arcs/android/util/AndroidLog.kt
@@ -12,30 +12,22 @@
 package arcs.android.util
 
 import arcs.core.util.Log
-import java.io.PrintWriter
-import java.io.StringWriter
 import java.util.Locale
 
 /** Initializes [Log] for tests on the JVM. */
 fun initLogForAndroid(level: Log.Level = mapAndroidLogLevel("Arcs")) {
     Log.level = level
-    Log.writer = { lvl, renderedMessage ->
+    Log.writer = { lvl, renderedMessage, throwable ->
         when (lvl) {
-            Log.Level.Debug -> android.util.Log.d("Arcs", renderedMessage)
-            Log.Level.Info -> android.util.Log.i("Arcs", renderedMessage)
-            Log.Level.Warning -> android.util.Log.w("Arcs", renderedMessage)
-            Log.Level.Error -> android.util.Log.e("Arcs", renderedMessage)
-            Log.Level.Wtf -> android.util.Log.wtf("Arcs", renderedMessage)
+            Log.Level.Debug -> android.util.Log.d("Arcs", renderedMessage, throwable)
+            Log.Level.Info -> android.util.Log.i("Arcs", renderedMessage, throwable)
+            Log.Level.Warning -> android.util.Log.w("Arcs", renderedMessage, throwable)
+            Log.Level.Error -> android.util.Log.e("Arcs", renderedMessage, throwable)
+            Log.Level.Wtf -> android.util.Log.wtf("Arcs", renderedMessage, throwable)
         }
     }
     Log.formatter = { _, _, throwable, rawMessage ->
-        val stackTrace = throwable?.let {
-            val writer = StringWriter()
-            throwable.printStackTrace(PrintWriter(writer))
-            "\n$writer"
-        } ?: ""
-
-        String.format(Locale.ENGLISH, "%s%s", rawMessage, stackTrace)
+        String.format(Locale.ENGLISH, "%s", rawMessage)
     }
 }
 

--- a/java/arcs/android/util/AndroidLog.kt
+++ b/java/arcs/android/util/AndroidLog.kt
@@ -12,7 +12,6 @@
 package arcs.android.util
 
 import arcs.core.util.Log
-import java.util.Locale
 
 /** Initializes [Log] for tests on the JVM. */
 fun initLogForAndroid(level: Log.Level = mapAndroidLogLevel("Arcs")) {
@@ -26,9 +25,7 @@ fun initLogForAndroid(level: Log.Level = mapAndroidLogLevel("Arcs")) {
             Log.Level.Wtf -> android.util.Log.wtf("Arcs", renderedMessage, throwable)
         }
     }
-    Log.formatter = { _, _, throwable, rawMessage ->
-        String.format(Locale.ENGLISH, "%s", rawMessage)
-    }
+    Log.formatter = { _, _, _, rawMessage -> rawMessage }
 }
 
 private fun mapAndroidLogLevel(tag: String): Log.Level = arrayOf(

--- a/java/arcs/core/util/Log.kt
+++ b/java/arcs/core/util/Log.kt
@@ -40,7 +40,8 @@ object Log {
      *
      * Default implementation uses [println].
      */
-    var writer: (level: Level, renderedMessage: String) -> Unit = DEFAULT_WRITER
+    var writer: (level: Level, renderedMessage: String, throwable: Throwable?) -> Unit =
+        DEFAULT_WRITER
 
     /** Defines available logging-levels. */
     enum class Level {
@@ -78,7 +79,11 @@ object Log {
 
     private fun maybeLog(level: Level, throwable: Throwable? = null, messageBuilder: () -> String) {
         if (this.level <= level) {
-            writer(level, formatter(logIndex.incrementAndGet(), level, throwable, messageBuilder()))
+            writer(
+                level,
+                formatter(logIndex.incrementAndGet(), level, throwable, messageBuilder()),
+                throwable
+            )
         }
     }
 }
@@ -106,5 +111,7 @@ private val DEFAULT_FORMATTER: (
             } else ""
     }
 
-private val DEFAULT_WRITER: (level: Log.Level, renderedMessage: String) -> Unit =
-    { _, msg -> println(msg) }
+/* ktlint-disable max-line-length */
+private val DEFAULT_WRITER: (level: Log.Level, renderedMessage: String, throwable: Throwable?) -> Unit =
+    { _, msg, _ -> println(msg) }
+/* ktlint-enable max-line-length */

--- a/java/arcs/core/util/testutil/LogRule.kt
+++ b/java/arcs/core/util/testutil/LogRule.kt
@@ -16,6 +16,7 @@ import arcs.core.util.TaggedLog
 import java.io.PrintWriter
 import java.io.StringWriter
 import java.util.Locale
+import java.util.concurrent.CopyOnWriteArrayList
 import org.junit.rules.TestRule
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
@@ -27,7 +28,7 @@ class LogRule : TestRule {
 
     override fun apply(base: Statement, desc: Description): Statement = object : Statement() {
         override fun evaluate() {
-            val messages = mutableListOf<String>()
+            val messages = CopyOnWriteArrayList<String>()
             loggedMessages = messages
 
             println()
@@ -52,7 +53,7 @@ class LogRule : TestRule {
         private fun initLogForTest(collectedMessages: MutableList<String>) {
             Log.logIndex.value = 0
             Log.level = Log.Level.Debug
-            Log.writer = { level, renderedMessage ->
+            Log.writer = { level, renderedMessage, _ ->
                 collectedMessages.add(renderedMessage)
                 if (
                     level == Log.Level.Warning ||

--- a/javatests/arcs/core/util/LogTest.kt
+++ b/javatests/arcs/core/util/LogTest.kt
@@ -18,7 +18,7 @@ class LogTest {
         Log.logIndex.value = 0
         loggedMessages.clear()
 
-        Log.writer = { _, message -> loggedMessages.add(message) }
+        Log.writer = { _, message, _ -> loggedMessages.add(message) }
     }
 
     @Test


### PR DESCRIPTION
Up to now, if something tried to use `log.error` or another method while passing an exception, we'd crash - because Android doesn't allow you to print a stacktrace from an exception into a printwriter apparently.