### PR TITLE
Make the database interface's ttl method return a job that can be waited upon for completion asynchronously.

### DIFF
--- a/java/arcs/android/storage/database/AndroidSqliteDatabaseManager.kt
+++ b/java/arcs/android/storage/database/AndroidSqliteDatabaseManager.kt
@@ -17,6 +17,9 @@ import arcs.core.storage.database.DatabaseIdentifier
 import arcs.core.storage.database.DatabaseManager
 import arcs.core.storage.database.DatabasePerformanceStatistics.Snapshot
 import arcs.core.util.guardedBy
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
@@ -50,9 +53,11 @@ class AndroidSqliteDatabaseManager(context: Context) : DatabaseManager {
             .forEach { it.reset() }
     }
 
-    override suspend fun removeExpiredEntities() {
-        registry.fetchAll()
-            .map { getDatabase(it.name, it.isPersistent) as DatabaseImpl }
-            .forEach { it.removeExpiredEntities() }
+    override suspend fun removeExpiredEntities(): Job = coroutineScope {
+        launch {
+            registry.fetchAll()
+                .map { getDatabase(it.name, it.isPersistent) as DatabaseImpl }
+                .forEach { it.removeExpiredEntities() }
+        }
     }
 }

--- a/java/arcs/core/storage/database/BUILD
+++ b/java/arcs/core/storage/database/BUILD
@@ -18,5 +18,6 @@ arcs_kt_library(
         "//java/arcs/core/storage:storage_key",
         "//java/arcs/core/type",
         "//java/arcs/core/util/performance",
+        "//third_party/kotlin/kotlinx_coroutines",
     ],
 )

--- a/java/arcs/core/storage/database/DatabaseManager.kt
+++ b/java/arcs/core/storage/database/DatabaseManager.kt
@@ -11,6 +11,8 @@
 
 package arcs.core.storage.database
 
+import kotlinx.coroutines.Job
+
 /**
  * Defines an abstract factory capable of instantiating (or re-using, when necessary) a [Database].
  */
@@ -39,7 +41,7 @@ interface DatabaseManager {
         Map<DatabaseIdentifier, DatabasePerformanceStatistics.Snapshot>
 
     /** Clears all expired entities, in all known databases.  */
-    suspend fun removeExpiredEntities()
+    suspend fun removeExpiredEntities(): Job
 }
 
 /** Identifier for an individual [Database] instance. */

--- a/java/arcs/jvm/storage/database/testutil/FakeDatabaseManager.kt
+++ b/java/arcs/jvm/storage/database/testutil/FakeDatabaseManager.kt
@@ -30,6 +30,7 @@ import java.time.Instant
 import kotlin.coroutines.coroutineContext
 import kotlin.reflect.KClass
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.flow
@@ -57,7 +58,7 @@ class FakeDatabaseManager : DatabaseManager {
         Map<DatabaseIdentifier, DatabasePerformanceStatistics.Snapshot> =
         mutex.withLock { cache.mapValues { it.value.snapshotStatistics() } }
 
-    override suspend fun removeExpiredEntities() {
+    override suspend fun removeExpiredEntities(): Job {
         throw UnsupportedOperationException("Fake databases cannot remove expired entities.")
     }
 }


### PR DESCRIPTION
This will be nice to have in general, and is important to ensure the correct functioning of unit tests in the post-scheduler world.