### PR TITLE
Use a config object to instantiate handles.

### DIFF
--- a/java/arcs/core/entity/CollectionHandle.kt
+++ b/java/arcs/core/entity/CollectionHandle.kt
@@ -40,15 +40,10 @@ typealias CollectionProxy<T> = StorageProxy<CrdtSet.Data<T>, CrdtSet.IOperation<
  * exposes only the methods that should be exposed.
  */
 class CollectionHandle<T : Storable, R : Referencable>(
-    name: String,
-    spec: HandleSpec<out Entity>,
-    /** Interface to storage for [RawEntity] objects backing an `entity: T`. */
-    val storageProxy: CollectionProxy<R>,
-    /** Will ensure that necessary fields are present on the [RawEntity] before storage. */
-    val storageAdapter: StorageAdapter<T, R>,
-    dereferencerFactory: EntityDereferencerFactory
-) : BaseHandle<T>(name, spec, storageProxy, dereferencerFactory),
-    ReadWriteQueryCollectionHandle<T, Any> {
+    config: Config<T, R>
+) : BaseHandle<T>(config), ReadWriteQueryCollectionHandle<T, Any> {
+    private val storageProxy = config.proxy
+    private val storageAdapter = config.storageAdapter
 
     init {
         check(spec.containerType == HandleContainerType.Collection)
@@ -142,4 +137,24 @@ class CollectionHandle<T : Storable, R : Referencable>(
     }.filterNotTo(mutableSetOf()) {
         storageAdapter.isExpired(it)
     }
+
+    /** Configuration required to instantiate a [CollectionHandle]. */
+    class Config<T : Storable, R : Referencable>(
+        /** See [BaseHandleConfig.name]. */
+        name: String,
+        /** See [BaseHandleConfig.spec]. */
+        spec: HandleSpec<out Entity>,
+        /**
+         * Interface to storage for [RawEntity] objects backing an `entity: T`.
+         *
+         * See [BaseHandleConfig.storageProxy].
+         */
+        val proxy: CollectionProxy<R>,
+        /** Will ensure that necessary fields are present on the [RawEntity] before storage. */
+        val storageAdapter: StorageAdapter<T, R>,
+        /** See [BaseHandleConfig.dereferencerFactory]. */
+        dereferencerFactory: EntityDereferencerFactory,
+        /** See [BaseHandleConfig.particleId]. */
+        particleId: String
+    ) : BaseHandleConfig(name, spec, proxy, dereferencerFactory, particleId)
 }

--- a/java/arcs/core/entity/SingletonHandle.kt
+++ b/java/arcs/core/entity/SingletonHandle.kt
@@ -37,14 +37,10 @@ typealias SingletonStoreOptions<T> = StoreOptions<SingletonData<T>, SingletonOp<
  * exposes only the methods that should be exposed.
  */
 class SingletonHandle<T : Storable, R : Referencable>(
-    name: String,
-    spec: HandleSpec<out Entity>,
-    /** Interface to storage for [RawEntity] objects backing an `entity: T`. */
-    val storageProxy: SingletonProxy<R>,
-    /** Will ensure that necessary fields are present on the [RawEntity] before storage. */
-    private val storageAdapter: StorageAdapter<T, R>,
-    dereferencerFactory: EntityDereferencerFactory
-) : BaseHandle<T>(name, spec, storageProxy, dereferencerFactory), ReadWriteSingletonHandle<T> {
+    config: Config<T, R>
+) : BaseHandle<T>(config), ReadWriteSingletonHandle<T> {
+    private val storageProxy = config.proxy
+    private val storageAdapter = config.storageAdapter
 
     init {
         check(spec.containerType == HandleContainerType.Singleton)
@@ -105,4 +101,24 @@ class SingletonHandle<T : Storable, R : Referencable>(
     }?.takeUnless {
         storageAdapter.isExpired(it)
     }
+
+    /** Configuration required to instantiate a [SingletonHandle]. */
+    class Config<T : Storable, R : Referencable>(
+        /** See [BaseHandleConfig.name]. */
+        name: String,
+        /** See [BaseHandleConfig.spec]. */
+        spec: HandleSpec<out Entity>,
+        /**
+         * Interface to storage for [RawEntity] objects backing an `entity: T`.
+         *
+         * See [BaseHandleConfig.storageProxy].
+         */
+        val proxy: SingletonProxy<R>,
+        /** Will ensure that necessary fields are present on the [RawEntity] before storage. */
+        val storageAdapter: StorageAdapter<T, R>,
+        /** See [BaseHandleConfig.dereferencerFactory]. */
+        dereferencerFactory: EntityDereferencerFactory,
+        /** See [BaseHandleConfig.particleId]. */
+        particleId: String
+    ) : BaseHandleConfig(name, spec, proxy, dereferencerFactory, particleId)
 }

--- a/java/arcs/core/entity/StorageAdapter.kt
+++ b/java/arcs/core/entity/StorageAdapter.kt
@@ -63,11 +63,13 @@ class EntityStorageAdapter<T : Entity>(
 
 /** [StorageAdapter] for converting [Reference] to/from [StorageReference]. */
 class ReferenceStorageAdapter<E : Entity>(
-    private val entitySpec: EntitySpec<E>
+    private val entitySpec: EntitySpec<E>,
+    private val dereferencerFactory: EntityDereferencerFactory
 ) : StorageAdapter<Reference<E>, StorageReference>() {
     override fun storableToReferencable(value: Reference<E>) = value.toReferencable()
 
     override fun referencableToStorable(referencable: StorageReference): Reference<E> {
+        dereferencerFactory.injectDereferencers(entitySpec.SCHEMA, referencable)
         return Reference(entitySpec, referencable)
     }
 

--- a/java/arcs/core/host/AbstractArcHost.kt
+++ b/java/arcs/core/host/AbstractArcHost.kt
@@ -245,7 +245,8 @@ abstract class AbstractArcHost(
                 context,
                 handleSpec.key,
                 handleSpec.value,
-                particle.handles
+                particle.handles,
+                particle.toString()
             )
         }
 
@@ -304,7 +305,7 @@ abstract class AbstractArcHost(
 
         // Should only happen if host crashes, restarts, and last persisted state was Running
         if (particleContext.particleState == ParticleState.Started) {
-            particleContext.particleState == ParticleState.Stopped
+            particleContext.particleState = ParticleState.Stopped
         }
 
         // If we reach here, particle is being restarted
@@ -392,12 +393,16 @@ abstract class AbstractArcHost(
     /**
      * Given a handle name, a [Plan.HandleConnection], and a [HandleHolder] construct an Entity
      * [Handle] of the right type.
+     *
+     * [particleId] is meant to be a namespace for the handle, wherein handle callbacks will be
+     * triggered according to the rules of the [Scheduler].
      */
     private suspend fun createHandle(
         arcHostContext: ArcHostContext,
         handleName: String,
         connectionSpec: Plan.HandleConnection,
-        holder: HandleHolder
+        holder: HandleHolder,
+        particleId: String = ""
     ): Handle {
         val containerType = when (connectionSpec.type) {
             is SingletonType<*>, is EntityType -> HandleContainerType.Singleton
@@ -413,7 +418,8 @@ abstract class AbstractArcHost(
         return arcHostContext.entityHandleManager.createHandle(
             handleSpec,
             connectionSpec.storageKey,
-            connectionSpec.ttl ?: Ttl.Infinite
+            connectionSpec.ttl ?: Ttl.Infinite,
+            particleId
         ).also { holder.setHandle(handleName, it) }
     }
 

--- a/javatests/arcs/core/entity/StorageAdapterTest.kt
+++ b/javatests/arcs/core/entity/StorageAdapterTest.kt
@@ -58,7 +58,7 @@ class StorageAdapterTest {
 
     @Test
     fun referenceStorageAdapter() {
-        val adapter = ReferenceStorageAdapter(DummyEntity)
+        val adapter = ReferenceStorageAdapter(DummyEntity, dereferencerFactory)
         val storageReference = StorageReference(
             "id",
             DummyStorageKey("storage-key"),


### PR DESCRIPTION
The amount of arguments for Handles' constructors has grown to where It makes sense to use a config object instead.

Also, this PR adds `particleId` to the handle config, which will be used to provide a namespace for callbacks so that a particle's callbacks for all its handles are grouped together when iterating over the scheduler's agenda.   Currently particleId is set up with a default empty string... we should pass to this a unique id for a particle in an arc on an arc-host.

Lastly, this PR adds dereferencerFactory to the reference storage adapter.  When working on fixing tests (coming in future PRs), I found that it was needed...