### PR TITLE
Add syntax for inline entities in data stores

### DIFF
--- a/src/runtime/manifest-ast-nodes.ts
+++ b/src/runtime/manifest-ast-nodes.ts
@@ -48,10 +48,6 @@ export class BaseNodeWithRefinement extends BaseNode {
     refinement?: RefinementNode;
 }
 
-// Inline entities can have arbitrary field names, so we need a symbol-based field
-// to hold the BaseNode kind/location info.
-export const INLINE_ENTITY = Symbol('inline_entity');
-
 //  PARTICLE TYPES
 export interface BigCollectionType extends BaseNode {
   kind: 'big-collection-type';
@@ -181,53 +177,16 @@ export interface ManifestStorageInlineSource extends ManifestStorageSource {
   entities: ManifestStorageInlineEntity[];
 }
 
-// Inline entities can have arbitrary field names, which means they could clash
-// with BaseNode's 'kind' and 'location', so this interface cannot extend BaseNode.
-// However, we still want to keep those fields, so put them under a symbol.
-export interface ManifestStorageInlineEntity {
-  [INLINE_ENTITY]: BaseNode;
+export type ManifestStorageInlineData =
+  string | number | boolean | Uint8Array | {id: string, entityStorageKey: string};
 
-  [key: string]: ManifestStorageInlinePrimitiveType | ManifestStorageInlineReference |
-                 ManifestStorageInlineCollection | ManifestStorageInlineTuple;
-}
-
-export type ManifestStorageInlinePrimitiveType =
-  ManifestStorageInlineString | ManifestStorageInlineNumber |
-  ManifestStorageInlineBoolean | ManifestStorageInlineBytes;
-
-export interface ManifestStorageInlineString extends BaseNode {
-  kind: 'entity-string';
-  value: string;
-}
-
-export interface ManifestStorageInlineNumber extends BaseNode {
-  kind: 'entity-number';
-  value: number;
-}
-
-export interface ManifestStorageInlineBoolean extends BaseNode {
-  kind: 'entity-boolean';
-  value: boolean;
-}
-
-export interface ManifestStorageInlineBytes extends BaseNode {
-  kind: 'entity-bytes';
-  value: number[];
-}
-
-export interface ManifestStorageInlineReference extends BaseNode {
-  kind: 'entity-reference';
-  value: {id: string, storageKey: string};
-}
-
-export interface ManifestStorageInlineCollection extends BaseNode {
-  kind: 'entity-collection';
-  value: ManifestStorageInlinePrimitiveType[];
-}
-
-export interface ManifestStorageInlineTuple extends BaseNode {
-  kind: 'entity-tuple';
-  value: (ManifestStorageInlinePrimitiveType | ManifestStorageInlineReference)[];
+export interface ManifestStorageInlineEntity extends BaseNode {
+  kind: 'entity-inline';
+  fields: {[key: string]:
+    {kind: 'entity-value', value: ManifestStorageInlineData} |
+    {kind: 'entity-collection', value: ManifestStorageInlineData[]} |
+    {kind: 'entity-tuple', value: ManifestStorageInlineData[]}
+  };
 }
 
 export interface Meta extends BaseNode {

--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -84,12 +84,12 @@ class ManifestVisitor {
       }
       return;
     }
-    if (AstNode.INLINE_ENTITY in ast) {
+    assert(ast.location, 'expected manifest node to have `location`');
+    assert(ast.kind, 'expected manifest node to have `kind`');
+    if (ast.kind === 'entity-inline') {
       // This node holds an inline entity and will be handled by _processStore().
       return;
     }
-    assert(ast.location, 'expected manifest node to have `location`');
-    assert(ast.kind, 'expected manifest node to have `kind`');
     let childrenVisited = false;
     const visitChildren = () => {
       if (childrenVisited) {

--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -84,6 +84,10 @@ class ManifestVisitor {
       }
       return;
     }
+    if (AstNode.INLINE_ENTITY in ast) {
+      // This node holds an inline entity and will be handled by _processStore().
+      return;
+    }
     assert(ast.location, 'expected manifest node to have `location`');
     assert(ast.kind, 'expected manifest node to have `kind`');
     let childrenVisited = false;
@@ -239,7 +243,7 @@ export class Manifest {
       description?: string,
       version?: string,
       source?: string,
-      origin?: 'file' | 'resource' | 'storage',
+      origin?: 'file' | 'resource' | 'storage' | 'inline',
       referenceMode?: boolean,
       model?: {}[],
   }) {
@@ -1261,6 +1265,10 @@ ${e.message}
         version: item.version,
         origin: item.origin,
       });
+    }
+
+    if (item.origin === 'inline') {
+      throw new ManifestError(item.location, 'TODO: support inline data stores');
     }
 
     let json: string;

--- a/src/runtime/storageNG/abstract-store.ts
+++ b/src/runtime/storageNG/abstract-store.ts
@@ -153,7 +153,7 @@ export type StoreInfo = {
   name?: string;  // TODO: Find a way to make this readonly.
   readonly originalId?: string;
   readonly source?: string;
-  readonly origin?: 'file' | 'resource' | 'storage';
+  readonly origin?: 'file' | 'resource' | 'storage' | 'inline';
   readonly description?: string;
 
   /** Trust tags claimed by this data store. */


### PR DESCRIPTION
This updates the manifest grammar. Actually populating the inline store will be in a follow-up CL.