### PR TITLE
Update SchedulerProvider usage in handle manager tests.

### DIFF
--- a/java/arcs/core/entity/BUILD
+++ b/java/arcs/core/entity/BUILD
@@ -16,6 +16,6 @@ arcs_kt_library(
         "//java/arcs/core/storage",
         "//java/arcs/core/storage/referencemode",
         "//java/arcs/core/util",
-	"//third_party/kotlin/kotlinx_atomicfu",
+        "//third_party/kotlin/kotlinx_atomicfu",
     ],
 )

--- a/java/arcs/core/entity/BUILD
+++ b/java/arcs/core/entity/BUILD
@@ -16,5 +16,6 @@ arcs_kt_library(
         "//java/arcs/core/storage",
         "//java/arcs/core/storage/referencemode",
         "//java/arcs/core/util",
+	"//third_party/kotlin/kotlinx_atomicfu",
     ],
 )

--- a/java/arcs/core/storage/Reference.kt
+++ b/java/arcs/core/storage/Reference.kt
@@ -42,6 +42,24 @@ data class Reference(
         requireNotNull(dereferencer).dereference(this, coroutineContext)
 
     fun referencedStorageKey() = storageKey.childKeyWithComponent(id)
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as Reference
+
+        if (id != other.id) return false
+        if (storageKey != other.storageKey) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = id.hashCode()
+        result = 31 * result + storageKey.hashCode()
+        return result
+    }
 }
 
 /** Defines an object capable of de-referencing a [Reference]. */

--- a/javatests/arcs/android/entity/BUILD
+++ b/javatests/arcs/android/entity/BUILD
@@ -7,6 +7,7 @@ licenses(["notice"])
 
 arcs_kt_android_test_suite(
     name = "entity",
+    size = "small",
     manifest = "AndroidManifest.xml",
     package = "arcs.android.entity",
     deps = [
@@ -19,6 +20,8 @@ arcs_kt_android_test_suite(
         "//java/arcs/core/storage/keys",
         "//java/arcs/core/storage/referencemode",
         "//java/arcs/core/util",
+        "//java/arcs/core/util/testutil",
+        "//java/arcs/jvm/host",
         "//java/arcs/jvm/util/testutil",
         "//java/arcs/sdk/android/storage",
         "//java/arcs/sdk/android/storage/service/testutil",

--- a/javatests/arcs/android/entity/DifferentAndroidHandleManagerDifferentStoresTest.kt
+++ b/javatests/arcs/android/entity/DifferentAndroidHandleManagerDifferentStoresTest.kt
@@ -9,17 +9,15 @@ import androidx.work.testing.WorkManagerTestInitHelper
 import arcs.core.entity.HandleManagerTestBase
 import arcs.core.host.EntityHandleManager
 import arcs.core.storage.StoreManager
-import arcs.core.util.Scheduler
-import arcs.jvm.util.testutil.FakeTime
+import arcs.jvm.host.JvmSchedulerProvider
 import arcs.sdk.android.storage.ServiceStoreFactory
 import arcs.sdk.android.storage.service.testutil.TestConnectionFactory
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Before
 import org.junit.runner.RunWith
-import java.util.concurrent.Executors
+import kotlin.coroutines.EmptyCoroutineContext
 
 @Suppress("EXPERIMENTAL_API_USAGE")
 @RunWith(AndroidJUnit4::class)
@@ -41,14 +39,12 @@ class DifferentAndroidHandleManagerDifferentStoresTest : HandleManagerTestBase()
         super.setUp()
         app = ApplicationProvider.getApplicationContext()
         val testConnectionFactory = TestConnectionFactory(app)
+        schedulerProvider = JvmSchedulerProvider(EmptyCoroutineContext)
         readHandleManager = EntityHandleManager(
             arcId = "arcId",
             hostId = "hostId",
             time = fakeTime,
-            scheduler = Scheduler(
-                fakeTime,
-                Executors.newSingleThreadExecutor().asCoroutineDispatcher()
-            ),
+            scheduler = schedulerProvider("reader"),
             stores = StoreManager(),
             activationFactory = ServiceStoreFactory(
                 app,
@@ -60,10 +56,7 @@ class DifferentAndroidHandleManagerDifferentStoresTest : HandleManagerTestBase()
             arcId = "arcId",
             hostId = "hostId",
             time = fakeTime,
-            scheduler = Scheduler(
-                fakeTime,
-                Executors.newSingleThreadExecutor().asCoroutineDispatcher()
-            ),
+            scheduler = schedulerProvider("writer"),
             stores = StoreManager(),
             activationFactory = ServiceStoreFactory(
                 app,

--- a/javatests/arcs/android/entity/DifferentHandleManagerTest.kt
+++ b/javatests/arcs/android/entity/DifferentHandleManagerTest.kt
@@ -9,17 +9,15 @@ import androidx.work.testing.WorkManagerTestInitHelper
 import arcs.core.entity.HandleManagerTestBase
 import arcs.core.host.EntityHandleManager
 import arcs.core.storage.StoreManager
-import arcs.core.util.Scheduler
-import arcs.jvm.util.testutil.FakeTime
+import arcs.jvm.host.JvmSchedulerProvider
 import arcs.sdk.android.storage.ServiceStoreFactory
 import arcs.sdk.android.storage.service.testutil.TestConnectionFactory
+import kotlin.coroutines.EmptyCoroutineContext
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Before
 import org.junit.runner.RunWith
-import java.util.concurrent.Executors
 
 @Suppress("EXPERIMENTAL_API_USAGE")
 @RunWith(AndroidJUnit4::class)
@@ -42,14 +40,12 @@ class DifferentHandleManagerTest : HandleManagerTestBase() {
         app = ApplicationProvider.getApplicationContext()
         val stores = StoreManager()
         val testConnectionFactory = TestConnectionFactory(app)
+        schedulerProvider = JvmSchedulerProvider(EmptyCoroutineContext)
         readHandleManager = EntityHandleManager(
             arcId = "arcId",
             hostId = "hostId",
             time = fakeTime,
-            scheduler = Scheduler(
-                fakeTime,
-                Executors.newSingleThreadExecutor().asCoroutineDispatcher()
-            ),
+            scheduler = schedulerProvider("reader"),
             stores = stores,
             activationFactory = ServiceStoreFactory(
                 app,
@@ -61,10 +57,7 @@ class DifferentHandleManagerTest : HandleManagerTestBase() {
             arcId = "arcId",
             hostId = "hostId",
             time = fakeTime,
-            scheduler = Scheduler(
-                fakeTime,
-                Executors.newSingleThreadExecutor().asCoroutineDispatcher()
-            ),
+            scheduler = schedulerProvider("writer"),
             stores = stores,
             activationFactory = ServiceStoreFactory(
                 app,

--- a/javatests/arcs/android/entity/SameHandleManagerTest.kt
+++ b/javatests/arcs/android/entity/SameHandleManagerTest.kt
@@ -9,17 +9,15 @@ import androidx.work.testing.WorkManagerTestInitHelper
 import arcs.core.entity.HandleManagerTestBase
 import arcs.core.host.EntityHandleManager
 import arcs.core.storage.StoreManager
-import arcs.core.util.Scheduler
-import arcs.jvm.util.testutil.FakeTime
+import arcs.jvm.host.JvmSchedulerProvider
 import arcs.sdk.android.storage.ServiceStoreFactory
 import arcs.sdk.android.storage.service.testutil.TestConnectionFactory
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.asCoroutineDispatcher
+import kotlin.coroutines.EmptyCoroutineContext
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Before
 import org.junit.runner.RunWith
-import java.util.concurrent.Executors
 
 @Suppress("EXPERIMENTAL_API_USAGE")
 @RunWith(AndroidJUnit4::class)
@@ -40,14 +38,12 @@ class SameHandleManagerTest : HandleManagerTestBase() {
     override fun setUp() {
         super.setUp()
         app = ApplicationProvider.getApplicationContext()
+        schedulerProvider = JvmSchedulerProvider(EmptyCoroutineContext)
         readHandleManager = EntityHandleManager(
             arcId = "arcId",
             hostId = "hostId",
             time = fakeTime,
-            scheduler = Scheduler(
-                fakeTime,
-                Executors.newSingleThreadExecutor().asCoroutineDispatcher()
-            ),
+            scheduler = schedulerProvider("test"),
             stores = StoreManager(),
             activationFactory = ServiceStoreFactory(
                 app,

--- a/javatests/arcs/android/host/BUILD
+++ b/javatests/arcs/android/host/BUILD
@@ -33,6 +33,8 @@ arcs_kt_android_test_suite(
         "//java/arcs/core/storage/referencemode",
         "//java/arcs/core/testutil",
         "//java/arcs/core/util",
+        "//java/arcs/core/util/testutil",
+        "//java/arcs/jvm/host",
         "//java/arcs/jvm/util/testutil",
         "//java/arcs/sdk/android/storage",
         "//java/arcs/sdk/android/storage/service",

--- a/javatests/arcs/core/entity/BUILD
+++ b/javatests/arcs/core/entity/BUILD
@@ -66,6 +66,8 @@ arcs_kt_jvm_library(
         "//java/arcs/core/storage/referencemode",
         "//java/arcs/core/testutil",
         "//java/arcs/core/util",
+        "//java/arcs/core/util/testutil",
+        "//java/arcs/jvm/host",
         "//java/arcs/jvm/util/testutil",
         "//third_party/java/junit:junit-android",
         "//third_party/java/truth:truth-android",

--- a/javatests/arcs/core/entity/DifferentHandleManagerDifferentStoresTest.kt
+++ b/javatests/arcs/core/entity/DifferentHandleManagerDifferentStoresTest.kt
@@ -2,40 +2,32 @@ package arcs.core.entity
 
 import arcs.core.host.EntityHandleManager
 import arcs.core.storage.StoreManager
-import arcs.core.util.Scheduler
-import arcs.jvm.util.testutil.FakeTime
-import kotlinx.coroutines.asCoroutineDispatcher
+import arcs.jvm.host.JvmSchedulerProvider
+import kotlin.coroutines.EmptyCoroutineContext
 import org.junit.After
 import org.junit.Before
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
-import java.util.concurrent.Executors
 
 @Suppress("EXPERIMENTAL_API_USAGE")
 @RunWith(JUnit4::class)
 class DifferentHandleManagerDifferentStoresTest : HandleManagerTestBase() {
-
     @Before
     override fun setUp() {
         super.setUp()
+        schedulerProvider = JvmSchedulerProvider(EmptyCoroutineContext)
         readHandleManager = EntityHandleManager(
             arcId = "testArcId",
             hostId = "testHostId",
             time = fakeTime,
-            scheduler = Scheduler(
-                fakeTime,
-                Executors.newSingleThreadExecutor().asCoroutineDispatcher()
-            ),
+            scheduler = schedulerProvider("reader"),
             stores = StoreManager()
         )
         writeHandleManager = EntityHandleManager(
             arcId = "testArcId",
             hostId = "testHostId",
             time = fakeTime,
-            scheduler = Scheduler(
-                fakeTime,
-                Executors.newSingleThreadExecutor().asCoroutineDispatcher()
-            ),
+            scheduler = schedulerProvider("writer"),
             stores = StoreManager()
         )
     }

--- a/javatests/arcs/core/entity/DifferentHandleManagerTest.kt
+++ b/javatests/arcs/core/entity/DifferentHandleManagerTest.kt
@@ -2,41 +2,36 @@ package arcs.core.entity
 
 import arcs.core.host.EntityHandleManager
 import arcs.core.storage.StoreManager
-import arcs.core.util.Scheduler
-import arcs.jvm.util.testutil.FakeTime
-import kotlinx.coroutines.asCoroutineDispatcher
+import arcs.jvm.host.JvmSchedulerProvider
+import kotlin.coroutines.EmptyCoroutineContext
 import org.junit.After
 import org.junit.Before
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
-import java.util.concurrent.Executors
 
 @Suppress("EXPERIMENTAL_API_USAGE")
 @RunWith(JUnit4::class)
 class DifferentHandleManagerTest : HandleManagerTestBase() {
+    private var i = 0
 
     @Before
     override fun setUp() {
         super.setUp()
         val stores = StoreManager()
+        i++
+        schedulerProvider = JvmSchedulerProvider(EmptyCoroutineContext)
         readHandleManager = EntityHandleManager(
             arcId = "testArc",
             hostId = "testHost",
             time = fakeTime,
-            scheduler = Scheduler(
-                fakeTime,
-                Executors.newSingleThreadExecutor().asCoroutineDispatcher()
-            ),
+            scheduler = schedulerProvider("reader-#$i"),
             stores = stores
         )
         writeHandleManager = EntityHandleManager(
             arcId = "testArc",
             hostId = "testHost",
             time = fakeTime,
-            scheduler = Scheduler(
-                fakeTime,
-                Executors.newSingleThreadExecutor().asCoroutineDispatcher()
-            ),
+            scheduler = schedulerProvider("writer-#$i"),
             stores = stores
         )
     }

--- a/javatests/arcs/core/entity/HandleManagerTestBase.kt
+++ b/javatests/arcs/core/entity/HandleManagerTestBase.kt
@@ -109,9 +109,9 @@ open class HandleManagerTestBase {
     // Must call from subclasses
     open fun tearDown() = runBlocking {
         schedulerProvider.cancelAll()
-        // TODO: this is less than ideal - we should investigate how to make the entire test process
-        //  cancellable/stoppable, even when we cross scopes into a BindingContext or over to other
-        //  RamDisk listeners.
+        // TODO(b/151366899): this is less than ideal - we should investigate how to make the entire
+        //  test process cancellable/stoppable, even when we cross scopes into a BindingContext or
+        //  over to other RamDisk listeners.
         delay(100) // Let things calm down.
     }
 

--- a/javatests/arcs/core/entity/HandleManagerTestBase.kt
+++ b/javatests/arcs/core/entity/HandleManagerTestBase.kt
@@ -22,101 +22,36 @@ import arcs.core.storage.referencemode.ReferenceModeStorageKey
 import arcs.core.testutil.assertSuspendingThrows
 import arcs.core.util.Time
 import arcs.jvm.util.testutil.FakeTime
+import arcs.core.util.testutil.LogRule
+import arcs.jvm.host.JvmSchedulerProvider
 import com.google.common.truth.Truth.assertThat
 import kotlin.coroutines.coroutineContext
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.runBlockingTest
-import org.junit.Ignore
+import org.junit.Rule
 import org.junit.Test
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
 import arcs.core.storage.Reference as StorageReference
 
 @Suppress("EXPERIMENTAL_API_USAGE", "UNCHECKED_CAST")
 open class HandleManagerTestBase {
+    @get:Rule
+    val log = LogRule()
+
+    init {
+        SchemaRegistry.register(Person)
+        SchemaRegistry.register(Hat)
+    }
+
     private val backingKey = RamDiskStorageKey("entities")
     private val hatsBackingKey = RamDiskStorageKey("hats")
     protected lateinit var fakeTime: FakeTime
-
-    data class Person(
-        override val entityId: ReferenceId,
-        val name: String,
-        val age: Double,
-        val isCool: Boolean,
-        val bestFriend: StorageReference? = null,
-        val hat: StorageReference? = null
-    ) : Entity {
-
-        var raw: RawEntity? = null
-        var creationTimestamp : Long = RawEntity.UNINITIALIZED_TIMESTAMP
-        override var expirationTimestamp : Long = RawEntity.UNINITIALIZED_TIMESTAMP
-
-        override fun ensureEntityFields(idGenerator: Generator, handleName: String, time: Time, ttl: Ttl) {
-            creationTimestamp = time.currentTimeMillis
-            if (ttl != Ttl.Infinite) {
-                expirationTimestamp = ttl.calculateExpiration(time)
-            }
-        }
-
-        override fun serialize() = RawEntity(
-            entityId,
-            singletons = mapOf(
-                "name" to name.toReferencable(),
-                "age" to age.toReferencable(),
-                "is_cool" to isCool.toReferencable(),
-                "best_friend" to bestFriend,
-                "hat" to hat
-            ),
-            collections = emptyMap(),
-            creationTimestamp = creationTimestamp,
-            expirationTimestamp = expirationTimestamp
-        )
-
-        override fun reset() = throw NotImplementedError()
-
-        companion object : EntitySpec<Person> {
-
-            private val queryByAge = { value: RawEntity, args: Any ->
-                value.singletons["age"].toPrimitiveValue(Double::class, 0.0) == (args as Double)
-            }
-
-            private val refinementAgeGtZero = { value: RawEntity ->
-                value.singletons["age"].toPrimitiveValue(Double::class, 0.0) > 0.0
-            }
-
-            @Suppress("UNCHECKED_CAST")
-            override fun deserialize(data: RawEntity) = Person(
-                entityId = data.id,
-                name = data.singletons["name"].toPrimitiveValue(String::class, ""),
-                age = data.singletons["age"].toPrimitiveValue(Double::class, 0.0),
-                isCool = data.singletons["is_cool"].toPrimitiveValue(Boolean::class, false),
-                bestFriend = data.singletons["best_friend"] as? StorageReference,
-                hat = data.singletons["hat"] as? StorageReference
-            ).apply {
-                raw = data
-                expirationTimestamp = data.expirationTimestamp
-                creationTimestamp = data.creationTimestamp
-            }
-
-            override val SCHEMA = Schema(
-                setOf(SchemaName("Person")),
-                SchemaFields(
-                    singletons = mapOf(
-                        "name" to FieldType.Text,
-                        "age" to FieldType.Number,
-                        "is_cool" to FieldType.Boolean,
-                        "best_friend" to FieldType.EntityRef("person-hash"),
-                        "hat" to FieldType.EntityRef("hat-hash")
-                    ),
-                    collections = emptyMap()
-                ),
-                "person-hash",
-                query = queryByAge,
-                refinement = refinementAgeGtZero
-            )
-        }
-    }
 
     private val entity1 = Person(
         entityId = "entity1",
@@ -134,40 +69,6 @@ open class HandleManagerTestBase {
         bestFriend = StorageReference("entity1", backingKey, null),
         hat = null
     )
-
-    data class Hat(
-        override val entityId: ReferenceId,
-        val style: String
-    ) : Entity {
-        override var expirationTimestamp : Long = RawEntity.UNINITIALIZED_TIMESTAMP
-        override fun ensureEntityFields(idGenerator: Generator, handleName: String, time: Time, ttl: Ttl) {}
-
-        override fun serialize() = RawEntity(
-            entityId,
-            singletons = mapOf(
-                "style" to style.toReferencable()
-            ),
-            collections = emptyMap()
-        )
-
-        override fun reset() = throw NotImplementedError()
-
-        companion object : EntitySpec<Entity> {
-            override fun deserialize(data: RawEntity) = Hat(
-                entityId = data.id,
-                style = data.singletons["style"].toPrimitiveValue(String::class, "")
-            )
-
-            override val SCHEMA = Schema(
-                setOf(SchemaName("Hat")),
-                SchemaFields(
-                    singletons = mapOf("style" to FieldType.Text),
-                    collections = emptyMap()
-                ),
-                "hat-hash"
-            )
-        }
-    }
 
     private val singletonRefKey = RamDiskStorageKey("single-ent")
     private val singletonKey = ReferenceModeStorageKey(
@@ -187,27 +88,31 @@ open class HandleManagerTestBase {
         storageKey = hatCollectionRefKey
     )
 
+    lateinit var schedulerProvider: JvmSchedulerProvider
     lateinit var readHandleManager: EntityHandleManager
     lateinit var writeHandleManager: EntityHandleManager
 
     open var testRunner = { block: suspend CoroutineScope.() -> Unit ->
-        runBlockingTest { this.block() }
+        runBlocking {
+            this.block()
+            schedulerProvider.cancelAll()
+        }
     }
 
     // Must call from subclasses.
     open fun setUp() {
         fakeTime = FakeTime()
         DriverAndKeyConfigurator.configure(null)
-        SchemaRegistry.register(Person)
-        SchemaRegistry.register(Hat)
-        DriverFactory.register(RamDiskDriverProvider())
+        RamDisk.clear()
     }
 
     // Must call from subclasses
-    open fun tearDown() {
-        RamDisk.clear()
-        DriverFactory.clearRegistrations()
-        SchemaRegistry.clearForTest()
+    open fun tearDown() = runBlocking {
+        schedulerProvider.cancelAll()
+        // TODO: this is less than ideal - we should investigate how to make the entire test process
+        //  cancellable/stoppable, even when we cross scopes into a BindingContext or over to other
+        //  RamDisk listeners.
+        delay(100) // Let things calm down.
     }
 
     @Test
@@ -649,7 +554,7 @@ open class HandleManagerTestBase {
                 Hat
             ),
             hatCollectionKey
-        ) as ReadWriteCollectionHandle<Hat>
+        ).also { it.awaitReady() } as ReadWriteCollectionHandle<Hat>
 
         val fez = Hat(entityId = "fez-id", style = "fez")
         hatCollection.store(fez)
@@ -848,12 +753,10 @@ open class HandleManagerTestBase {
         )
     }
 
-    private suspend fun Handle.awaitReady() {
-        val deferred = CompletableDeferred<Unit>()
-        onReady {
-            deferred.complete(Unit)
-        }
-        deferred.await()
+    private suspend fun Handle.awaitReady() = coroutineScope {
+        val job = Job()
+        onReady { job.complete() }
+        job.join()
     }
 
     private suspend fun EntityHandleManager.createSingletonHandle(
@@ -869,7 +772,7 @@ open class HandleManagerTestBase {
         ),
         storageKey,
         ttl
-    ) as ReadWriteSingletonHandle<Person>
+    ).also { it.awaitReady() } as ReadWriteSingletonHandle<Person>
 
     private suspend fun EntityHandleManager.createCollectionHandle(
         storageKey: StorageKey = collectionKey,
@@ -891,7 +794,7 @@ open class HandleManagerTestBase {
         ),
         storageKey,
         ttl
-    ) as ReadWriteQueryCollectionHandle<T, Any>
+    ).also { it.awaitReady() } as ReadWriteQueryCollectionHandle<T, Any>
 
     private suspend fun EntityHandleManager.createReferenceSingletonHandle(
         storageKey: StorageKey = singletonRefKey,
@@ -907,7 +810,7 @@ open class HandleManagerTestBase {
         ),
         storageKey,
         ttl
-    ) as ReadWriteSingletonHandle<Reference<Person>>
+    ).also { it.awaitReady() } as ReadWriteSingletonHandle<Reference<Person>>
 
     private suspend fun EntityHandleManager.createReferenceCollectionHandle(
         storageKey: StorageKey = collectionRefKey,
@@ -923,7 +826,7 @@ open class HandleManagerTestBase {
         ),
         storageKey,
         ttl
-    ) as ReadWriteQueryCollectionHandle<Reference<Person>, Any>
+    ).also { it.awaitReady() } as ReadWriteQueryCollectionHandle<Reference<Person>, Any>
 
     private suspend fun <T> ReadableHandle<T>.onUpdateDeferred(
         predicate: (T) -> Boolean = { true }
@@ -948,4 +851,128 @@ open class HandleManagerTestBase {
         creationTimestamp = fakeTime.millis,
         expirationTimestamp = RawEntity.UNINITIALIZED_TIMESTAMP
     )
+
+    data class Person(
+        override val entityId: ReferenceId,
+        val name: String,
+        val age: Double,
+        val isCool: Boolean,
+        val bestFriend: StorageReference? = null,
+        val hat: StorageReference? = null
+    ) : Entity {
+
+        var raw: RawEntity? = null
+        var creationTimestamp: Long = RawEntity.UNINITIALIZED_TIMESTAMP
+        override var expirationTimestamp: Long = RawEntity.UNINITIALIZED_TIMESTAMP
+
+        override fun ensureEntityFields(
+            idGenerator: Generator,
+            handleName: String,
+            time: Time,
+            ttl: Ttl
+        ) {
+            creationTimestamp = time.currentTimeMillis
+            if (ttl != Ttl.Infinite) {
+                expirationTimestamp = ttl.calculateExpiration(time)
+            }
+        }
+
+        override fun serialize() = RawEntity(
+            entityId,
+            singletons = mapOf(
+                "name" to name.toReferencable(),
+                "age" to age.toReferencable(),
+                "is_cool" to isCool.toReferencable(),
+                "best_friend" to bestFriend,
+                "hat" to hat
+            ),
+            collections = emptyMap(),
+            creationTimestamp = creationTimestamp,
+            expirationTimestamp = expirationTimestamp
+        )
+
+        override fun reset() = throw NotImplementedError()
+
+        companion object : EntitySpec<Person> {
+
+            private val queryByAge = { value: RawEntity, args: Any ->
+                value.singletons["age"].toPrimitiveValue(Double::class, 0.0) == (args as Double)
+            }
+
+            private val refinementAgeGtZero = { value: RawEntity ->
+                value.singletons["age"].toPrimitiveValue(Double::class, 0.0) > 0
+            }
+
+            @Suppress("UNCHECKED_CAST")
+            override fun deserialize(data: RawEntity) = Person(
+                entityId = data.id,
+                name = (data.singletons["name"] as ReferencablePrimitive<String>).value,
+                age = (data.singletons["age"] as ReferencablePrimitive<Double>).value,
+                isCool = (data.singletons["is_cool"] as ReferencablePrimitive<Boolean>).value,
+                bestFriend = data.singletons["best_friend"] as? StorageReference,
+                hat = data.singletons["hat"] as? StorageReference
+            ).apply {
+                raw = data
+                creationTimestamp = data.creationTimestamp
+                expirationTimestamp = data.expirationTimestamp
+            }
+
+            override val SCHEMA = Schema(
+                setOf(SchemaName("Person")),
+                SchemaFields(
+                    singletons = mapOf(
+                        "name" to FieldType.Text,
+                        "age" to FieldType.Number,
+                        "is_cool" to FieldType.Boolean,
+                        "best_friend" to FieldType.EntityRef("person-hash"),
+                        "hat" to FieldType.EntityRef("hat-hash")
+                    ),
+                    collections = emptyMap()
+                ),
+                "person-hash",
+                query = queryByAge,
+                refinement = refinementAgeGtZero
+            )
+        }
+    }
+
+    data class Hat(
+        override val entityId: ReferenceId,
+        val style: String
+    ) : Entity {
+        override var expirationTimestamp : Long = RawEntity.UNINITIALIZED_TIMESTAMP
+
+        override fun ensureEntityFields(
+            idGenerator: Generator,
+            handleName: String,
+            time: Time,
+            ttl: Ttl
+        ) = Unit
+
+        override fun serialize() = RawEntity(
+            entityId,
+            singletons = mapOf(
+                "style" to style.toReferencable()
+            ),
+            collections = emptyMap()
+        )
+
+        override fun reset() = throw NotImplementedError()
+
+        companion object : EntitySpec<Entity> {
+            override fun deserialize(data: RawEntity) = Hat(
+                entityId = data.id,
+                style = (data.singletons["style"] as ReferencablePrimitive<String>).value
+            )
+
+            override val SCHEMA = Schema(
+                setOf(SchemaName("Hat")),
+                SchemaFields(
+                    singletons = mapOf("style" to FieldType.Text),
+                    collections = emptyMap()
+                ),
+                "hat-hash"
+            )
+        }
+    }
 }

--- a/javatests/arcs/core/entity/SameHandleManagerTest.kt
+++ b/javatests/arcs/core/entity/SameHandleManagerTest.kt
@@ -2,34 +2,25 @@ package arcs.core.entity
 
 import arcs.core.host.EntityHandleManager
 import arcs.core.storage.StoreManager
-import arcs.core.util.Scheduler
-import arcs.core.util.testutil.LogRule
-import arcs.jvm.util.testutil.FakeTime
-import kotlinx.coroutines.asCoroutineDispatcher
+import arcs.jvm.host.JvmSchedulerProvider
+import kotlin.coroutines.EmptyCoroutineContext
 import org.junit.After
 import org.junit.Before
-import org.junit.Rule
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
-import java.util.concurrent.Executors
 
 @Suppress("EXPERIMENTAL_API_USAGE")
 @RunWith(JUnit4::class)
 class SameHandleManagerTest : HandleManagerTestBase() {
-
-    @get:Rule var logRule = LogRule()
-
     @Before
     override fun setUp() {
         super.setUp()
+        schedulerProvider = JvmSchedulerProvider(EmptyCoroutineContext)
         readHandleManager = EntityHandleManager(
             arcId = "testArc",
             hostId = "testHost",
             time = fakeTime,
-            scheduler = Scheduler(
-                fakeTime,
-                Executors.newSingleThreadExecutor().asCoroutineDispatcher()
-            ),
+            scheduler = schedulerProvider("test"),
             stores = StoreManager()
         )
         writeHandleManager = readHandleManager


### PR DESCRIPTION
Yet another piece of prepwork for the Scheduler usage PR.

Includes:

* Updating the various subclasses of HandleManagerTestBase to correctly provide schedulers for their HandleManagers.
* Updating HandleManagerTestBase's handle creation helper methods to suspend returning handle instances until the handles are ready (very important for what's coming) -- this is the `awaitReady` stuff.
* Cleaning up HandleManagerTestBase somewhat - by moving inner classes to the bottom, where they're supposed to be.
* Changing HandleManagerTestBase's tearDown method to trigger cancellation of schedulerProvider's created schedulers.

Also:

* I noticed that the reference liveness tests were sometimes failing because References were not implementing equals/hashcode correctly before.. so this adds that as well.