### PR TITLE
Make ServiceStore use Channels/Flows instead of sendQueue.

### DIFF
--- a/java/arcs/sdk/android/storage/BUILD
+++ b/java/arcs/sdk/android/storage/BUILD
@@ -21,6 +21,7 @@ arcs_kt_android_library(
         "//java/arcs/core/storage",
         "//java/arcs/core/storage/api",
         "//java/arcs/core/storage/util",
+        "//java/arcs/core/util",
         "//java/arcs/sdk/android/storage/service",
         "//third_party/java/androidx/annotation",
         "//third_party/java/androidx/lifecycle",

--- a/java/arcs/sdk/android/storage/ServiceStore.kt
+++ b/java/arcs/sdk/android/storage/ServiceStore.kt
@@ -35,7 +35,7 @@ import arcs.core.storage.ActiveStore
 import arcs.core.storage.ProxyCallback
 import arcs.core.storage.ProxyMessage
 import arcs.core.storage.StoreOptions
-import arcs.core.storage.util.SendQueue
+import arcs.core.util.TaggedLog
 import arcs.sdk.android.storage.service.ConnectionFactory
 import arcs.sdk.android.storage.service.DefaultConnectionFactory
 import arcs.sdk.android.storage.service.StorageServiceConnection
@@ -47,7 +47,13 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancelChildren
+import kotlinx.coroutines.channels.BroadcastChannel
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.buffer
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 
 /**
  * Factory which can be supplied to [Store.activate] to force store creation to use the
@@ -94,13 +100,18 @@ class ServiceStore<Data : CrdtData, Op : CrdtOperation, ConsumerData>(
     private val connectionFactory: ConnectionFactory,
     private val coroutineContext: CoroutineContext
 ) : ActiveStore<Data, Op, ConsumerData>(options), LifecycleObserver {
+    private val log = TaggedLog { "ServiceStore(${options.storageKey})" }
     private val scope = CoroutineScope(coroutineContext)
     private var storageService: IStorageService? = null
     private var serviceConnection: StorageServiceConnection? = null
-    private val sendQueue = SendQueue()
+    private var channel = BroadcastChannel<suspend () -> Unit>(100)
 
     init {
         lifecycle.addObserver(this)
+        channel.asFlow()
+            .buffer()
+            .onEach { it() }
+            .launchIn(scope)
     }
 
     @Suppress("UNCHECKED_CAST")
@@ -132,17 +143,15 @@ class ServiceStore<Data : CrdtData, Op : CrdtOperation, ConsumerData>(
 
     override fun off(callbackToken: Int) {
         val service = checkNotNull(storageService)
-        scope.launch {
-            sendQueue.enqueue {
-                service.unregisterCallback(callbackToken)
-            }
+        runBlocking {
+            channel.send { service.unregisterCallback(callbackToken) }
         }
     }
 
     override suspend fun onProxyMessage(message: ProxyMessage<Data, Op, ConsumerData>): Boolean {
         val service = checkNotNull(storageService)
         val result = DeferredResult(coroutineContext)
-        sendQueue.enqueue {
+        channel.send {
             service.sendProxyMessage(message.toParcelable(), result)
         }
         // Just return false if the message couldn't be applied.

--- a/javatests/arcs/sdk/android/storage/BUILD
+++ b/javatests/arcs/sdk/android/storage/BUILD
@@ -36,6 +36,7 @@ arcs_kt_android_test_suite(
         "//java/arcs/core/storage/driver",
         "//java/arcs/core/storage/keys",
         "//java/arcs/core/type",
+        "//java/arcs/core/util/testutil",
         "//java/arcs/sdk/android/storage",
         "//java/arcs/sdk/android/storage/service",
         "//third_party/android/androidx_test/core",

--- a/javatests/arcs/sdk/android/storage/ServiceStoreTest.kt
+++ b/javatests/arcs/sdk/android/storage/ServiceStoreTest.kt
@@ -30,15 +30,18 @@ import arcs.core.storage.StoreOptions
 import arcs.core.storage.driver.RamDisk
 import arcs.core.storage.driver.RamDiskDriverProvider
 import arcs.core.storage.keys.RamDiskStorageKey
+import arcs.core.util.testutil.LogRule
 import arcs.sdk.android.storage.service.ConnectionFactory
 import arcs.sdk.android.storage.service.StorageServiceBindingDelegate
 import arcs.sdk.android.storage.service.StorageServiceConnection
 import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.Dispatchers
 import kotlin.coroutines.coroutineContext
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.yield
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -46,6 +49,9 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 @OptIn(ExperimentalCoroutinesApi::class)
 class ServiceStoreTest {
+    @get:Rule
+    val log = LogRule()
+
     private lateinit var lifecycle: Lifecycle
     private val storeOptions = StoreOptions<CrdtCount.Data, CrdtCount.Operation, Int>(
         RamDiskStorageKey("myData"),
@@ -107,7 +113,7 @@ class ServiceStoreTest {
             ParcelableCrdtType.Count,
             lifecycle,
             connectionFactory,
-            coroutineContext
+            coroutineContext + Dispatchers.Default
         ).initialize()
 
         store.onProxyMessage(


### PR DESCRIPTION
While working through the scheduler usage stuff, in some of the flakes for HandleManagerTest's variants, I noticed race conditions in sendQueue as it was used in the ServiceStore. This approach works much better.

One caveat, I have the BroadcastChannel set to a max size of 100 before it blocks on add.. this seemed reasonable, but we can tune later.