### PR TITLE
Allow mutating an entity in a collection without having to remove it …

### DIFF
--- a/java/arcs/core/crdt/CrdtSet.kt
+++ b/java/arcs/core/crdt/CrdtSet.kt
@@ -205,10 +205,7 @@ class CrdtSet<T : Referencable>(
 
                 data.versionMap[actor] = clock[actor]
                 val previousVersion = data.values[added.id]?.versionMap ?: VersionMap()
-                val previousValue = data.values[added.id]?.value
-                // If a value is already stored for this id, we do not overwrite it. 
-                data.values[added.id] =
-                    DataValue(clock mergeWith previousVersion, previousValue ?: added)
+                data.values[added.id] = DataValue(clock mergeWith previousVersion, added)
                 return true
             }
 

--- a/javatests/arcs/core/crdt/CrdtSetTest.kt
+++ b/javatests/arcs/core/crdt/CrdtSetTest.kt
@@ -59,12 +59,12 @@ class CrdtSetTest {
     }
 
     @Test
-    fun supportsAddingSameValueAgain_keepsFirst() {
+    fun supportsAddingSameValueAgain_keepsNewValue() {
         val alice: CrdtSet<ReferenceWithValue> = CrdtSet()
         alice.applyOperation(CrdtSet.Operation.Add("alice", VersionMap("alice" to 1), ReferenceWithValue("one", 1)))
         alice.applyOperation(CrdtSet.Operation.Add("alice", VersionMap("alice" to 2), ReferenceWithValue("one", 2)))
 
-        assertThat(alice.consumerView).containsExactly(ReferenceWithValue("one", 1))
+        assertThat(alice.consumerView).containsExactly(ReferenceWithValue("one", 2))
     }
 
     @Test

--- a/javatests/arcs/core/entity/HandleManagerTestBase.kt
+++ b/javatests/arcs/core/entity/HandleManagerTestBase.kt
@@ -478,7 +478,12 @@ open class HandleManagerTestBase {
 
         val modified = entity.mutate(text = "Changed")
         assertThat(modified).isNotEqualTo(entity)
-        handle.remove(modified)
+
+        // Entity internals should not change.
+        assertThat(modified.entityId).isEqualTo(entity.entityId)
+        assertThat(modified.creationTimestamp).isEqualTo(entity.creationTimestamp)
+        assertThat(modified.expirationTimestamp).isEqualTo(entity.expirationTimestamp)
+
         handle.store(modified)
         assertThat(handle.fetchAll()).containsExactly(modified)
     }

--- a/src/tools/schema2kotlin.ts
+++ b/src/tools/schema2kotlin.ts
@@ -30,7 +30,7 @@ const keywords = [
   'init', 'param', 'property', 'receiver', 'set', 'setparam', 'where', 'actual', 'abstract', 'annotation', 'companion',
   'const', 'crossinline', 'data', 'enum', 'expect', 'external', 'final', 'infix', 'inline', 'inner', 'internal',
   'lateinit', 'noinline', 'open', 'operator', 'out', 'override', 'private', 'protected', 'public', 'reified', 'sealed',
-  'suspend', 'tailrec', 'vararg', 'it', 'entityId'
+  'suspend', 'tailrec', 'vararg', 'it', 'entityId', 'creationTimestamp', 'expirationTimestamp'
 ];
 
 export interface KotlinTypeInfo {
@@ -462,19 +462,19 @@ ${lines}
     class ${name}(`;
     const baseClass = this.opts.wasm
         ? 'WasmEntity'
-        : ktUtils.applyFun('EntityBase', [quote(name), 'SCHEMA', 'entityId', 'expirationTimestamp', 'creationTimestamp']);
+        : ktUtils.applyFun('EntityBase', [quote(name), 'SCHEMA', 'entityId', 'creationTimestamp', 'expirationTimestamp']);
     const classInterface = `) : ${baseClass} {`;
 
     const constructorFields = this.fields.concat(this.opts.wasm ? [] : [
       'entityId: String? = null',
-      'expirationTimestamp:  Long = RawEntity.UNINITIALIZED_TIMESTAMP',
       'creationTimestamp: Long = RawEntity.UNINITIALIZED_TIMESTAMP',
+      'expirationTimestamp:  Long = RawEntity.UNINITIALIZED_TIMESTAMP',
     ]);
 
     const fieldsForMutate = this.fieldsForCopy.concat(this.opts.wasm ? [] : [
       'entityId = entityId',
-      'expirationTimestamp = expirationTimestamp',
-      'creationTimestamp = creationTimestamp'
+      'creationTimestamp = creationTimestamp',
+      'expirationTimestamp = expirationTimestamp'
     ]);
 
     const constructorArguments =

--- a/src/tools/tests/goldens/generated-schemas.jvm.kt
+++ b/src/tools/tests/goldens/generated-schemas.jvm.kt
@@ -31,9 +31,9 @@ abstract class AbstractGold : BaseParticle() {
     class GoldInternal1(
         val_: String = "",
         entityId: String? = null,
-        expirationTimestamp:  Long = RawEntity.UNINITIALIZED_TIMESTAMP,
-        creationTimestamp: Long = RawEntity.UNINITIALIZED_TIMESTAMP
-    ) : EntityBase("GoldInternal1", SCHEMA, entityId, expirationTimestamp, creationTimestamp) {
+        creationTimestamp: Long = RawEntity.UNINITIALIZED_TIMESTAMP,
+        expirationTimestamp:  Long = RawEntity.UNINITIALIZED_TIMESTAMP
+    ) : EntityBase("GoldInternal1", SCHEMA, entityId, creationTimestamp, expirationTimestamp) {
 
         var val_: String
             get() = super.getSingletonValue("val") as String? ?: ""
@@ -54,8 +54,8 @@ abstract class AbstractGold : BaseParticle() {
         fun mutate(val_: String = this.val_) = GoldInternal1(
             val_ = val_,
             entityId = entityId,
-            expirationTimestamp = expirationTimestamp,
-            creationTimestamp = creationTimestamp
+            creationTimestamp = creationTimestamp,
+            expirationTimestamp = expirationTimestamp
         )
 
         companion object : EntitySpec<GoldInternal1> {
@@ -89,9 +89,9 @@ abstract class AbstractGold : BaseParticle() {
         birthDayMonth: Double = 0.0,
         birthDayDOM: Double = 0.0,
         entityId: String? = null,
-        expirationTimestamp:  Long = RawEntity.UNINITIALIZED_TIMESTAMP,
-        creationTimestamp: Long = RawEntity.UNINITIALIZED_TIMESTAMP
-    ) : EntityBase("Gold_AllPeople", SCHEMA, entityId, expirationTimestamp, creationTimestamp) {
+        creationTimestamp: Long = RawEntity.UNINITIALIZED_TIMESTAMP,
+        expirationTimestamp:  Long = RawEntity.UNINITIALIZED_TIMESTAMP
+    ) : EntityBase("Gold_AllPeople", SCHEMA, entityId, creationTimestamp, expirationTimestamp) {
 
         var name: String
             get() = super.getSingletonValue("name") as String? ?: ""
@@ -166,8 +166,8 @@ abstract class AbstractGold : BaseParticle() {
             birthDayMonth = birthDayMonth,
             birthDayDOM = birthDayDOM,
             entityId = entityId,
-            expirationTimestamp = expirationTimestamp,
-            creationTimestamp = creationTimestamp
+            creationTimestamp = creationTimestamp,
+            expirationTimestamp = expirationTimestamp
         )
 
         companion object : EntitySpec<Gold_AllPeople> {
@@ -203,9 +203,9 @@ abstract class AbstractGold : BaseParticle() {
     class Gold_Collection(
         num: Double = 0.0,
         entityId: String? = null,
-        expirationTimestamp:  Long = RawEntity.UNINITIALIZED_TIMESTAMP,
-        creationTimestamp: Long = RawEntity.UNINITIALIZED_TIMESTAMP
-    ) : EntityBase("Gold_Collection", SCHEMA, entityId, expirationTimestamp, creationTimestamp) {
+        creationTimestamp: Long = RawEntity.UNINITIALIZED_TIMESTAMP,
+        expirationTimestamp:  Long = RawEntity.UNINITIALIZED_TIMESTAMP
+    ) : EntityBase("Gold_Collection", SCHEMA, entityId, creationTimestamp, expirationTimestamp) {
 
         var num: Double
             get() = super.getSingletonValue("num") as Double? ?: 0.0
@@ -226,8 +226,8 @@ abstract class AbstractGold : BaseParticle() {
         fun mutate(num: Double = this.num) = Gold_Collection(
             num = num,
             entityId = entityId,
-            expirationTimestamp = expirationTimestamp,
-            creationTimestamp = creationTimestamp
+            creationTimestamp = creationTimestamp,
+            expirationTimestamp = expirationTimestamp
         )
 
         companion object : EntitySpec<Gold_Collection> {
@@ -261,9 +261,9 @@ abstract class AbstractGold : BaseParticle() {
         birthDayMonth: Double = 0.0,
         birthDayDOM: Double = 0.0,
         entityId: String? = null,
-        expirationTimestamp:  Long = RawEntity.UNINITIALIZED_TIMESTAMP,
-        creationTimestamp: Long = RawEntity.UNINITIALIZED_TIMESTAMP
-    ) : EntityBase("Gold_QCollection", SCHEMA, entityId, expirationTimestamp, creationTimestamp) {
+        creationTimestamp: Long = RawEntity.UNINITIALIZED_TIMESTAMP,
+        expirationTimestamp:  Long = RawEntity.UNINITIALIZED_TIMESTAMP
+    ) : EntityBase("Gold_QCollection", SCHEMA, entityId, creationTimestamp, expirationTimestamp) {
 
         var name: String
             get() = super.getSingletonValue("name") as String? ?: ""
@@ -338,8 +338,8 @@ abstract class AbstractGold : BaseParticle() {
             birthDayMonth = birthDayMonth,
             birthDayDOM = birthDayDOM,
             entityId = entityId,
-            expirationTimestamp = expirationTimestamp,
-            creationTimestamp = creationTimestamp
+            creationTimestamp = creationTimestamp,
+            expirationTimestamp = expirationTimestamp
         )
 
         companion object : EntitySpec<Gold_QCollection> {
@@ -384,9 +384,9 @@ abstract class AbstractGold : BaseParticle() {
         flg: Boolean = false,
         ref: Reference<GoldInternal1>? = null,
         entityId: String? = null,
-        expirationTimestamp:  Long = RawEntity.UNINITIALIZED_TIMESTAMP,
-        creationTimestamp: Long = RawEntity.UNINITIALIZED_TIMESTAMP
-    ) : EntityBase("Gold_Data", SCHEMA, entityId, expirationTimestamp, creationTimestamp) {
+        creationTimestamp: Long = RawEntity.UNINITIALIZED_TIMESTAMP,
+        expirationTimestamp:  Long = RawEntity.UNINITIALIZED_TIMESTAMP
+    ) : EntityBase("Gold_Data", SCHEMA, entityId, creationTimestamp, expirationTimestamp) {
 
         var num: Double
             get() = super.getSingletonValue("num") as Double? ?: 0.0
@@ -439,8 +439,8 @@ abstract class AbstractGold : BaseParticle() {
             flg = flg,
             ref = ref,
             entityId = entityId,
-            expirationTimestamp = expirationTimestamp,
-            creationTimestamp = creationTimestamp
+            creationTimestamp = creationTimestamp,
+            expirationTimestamp = expirationTimestamp
         )
 
         companion object : EntitySpec<Gold_Data> {


### PR DESCRIPTION
…first, this will preserve the ID and timestamps (expiry and creation times will not change). Note: it is important to use mutate when adding the same entity twice to the same collection, as it will preserve id and timestamps. Also fix a bug with schema2kotlin passing the two timestamps in the wrong order to EntityBase