### PR TITLE
Implement basic handling for time units in refinement expressions

### DIFF
--- a/src/runtime/manifest-ast-nodes.ts
+++ b/src/runtime/manifest-ast-nodes.ts
@@ -660,7 +660,7 @@ export interface RefinementNode extends BaseNode {
   expression: RefinementExpressionNode;
 }
 
-export type RefinementExpressionNode = BinaryExpressionNode | UnaryExpressionNode | FieldNode | QueryNode | NumberNode | BooleanNode | TextNode;
+export type RefinementExpressionNode = BinaryExpressionNode | UnaryExpressionNode | FieldNode | QueryNode | BuiltInNode | NumberNode | BooleanNode | TextNode;
 
 export enum Op {
   AND = 'and',
@@ -704,9 +704,15 @@ export interface QueryNode extends BaseNode {
   value: string;
 }
 
+export interface BuiltInNode extends BaseNode {
+  kind: 'built-in-node';
+  value: string;
+}
+
 export interface NumberNode extends BaseNode {
   kind: 'number-node';
   value: number;
+  units?: string[];
 }
 
 export interface BooleanNode extends BaseNode {

--- a/src/runtime/manifest-parser.pegjs
+++ b/src/runtime/manifest-parser.pegjs
@@ -1707,13 +1707,17 @@ PrimaryExpression
     const operator = op[0];
     return toAstNode<AstNode.UnaryExpressionNode>({kind: 'unary-expression-node', expr, operator});
   }
-  / num: NumberType
+  / num: NumberType units:Units?
   {
-    return toAstNode<AstNode.NumberNode>({kind: 'number-node', value: num});
+    return toAstNode<AstNode.NumberNode>({kind: 'number-node', value: num, units});
   }
   / bool:('true'i / 'false'i)
   {
     return toAstNode<AstNode.BooleanNode>({kind: 'boolean-node', value: bool.toLowerCase() === 'true'});
+  }
+  / fn: ('now()' / 'creationTimestamp')
+  {
+    return toAstNode<AstNode.BuiltInNode>({kind: 'built-in-node', value: fn});
   }
   / fn: fieldName
   {
@@ -1727,6 +1731,21 @@ PrimaryExpression
   / "'" txt:[^'\n]* "'"
   {
     return toAstNode<AstNode.TextNode>({kind: 'text-node', value: txt.join('')});
+  }
+
+Units = whiteSpace? name: Unitname {
+  // TODO: Support complex units like metres per second.
+  return [name];
+}
+
+Unitname
+  = unit:('day'
+  / 'hour'
+  / 'minute'
+  / 'second'
+  / 'millisecond'
+  ) 's'? {
+    return unit+'s';
   }
 
 NumberType

--- a/src/runtime/manifest-parser.pegjs
+++ b/src/runtime/manifest-parser.pegjs
@@ -1733,12 +1733,12 @@ PrimaryExpression
     return toAstNode<AstNode.TextNode>({kind: 'text-node', value: txt.join('')});
   }
 
-Units = whiteSpace? name: Unitname {
+Units = whiteSpace? name: UnitName {
   // TODO: Support complex units like metres per second.
   return [name];
 }
 
-Unitname
+UnitName
   = unit:('day'
   / 'hour'
   / 'minute'

--- a/src/runtime/refiner.ts
+++ b/src/runtime/refiner.ts
@@ -731,7 +731,7 @@ export class BuiltIn extends RefinementExpression {
     if (this.value === 'now()') {
       return this.value;
     }
-    // TODO: Implement SQL getter for 'currentTime'
+    // TODO: Implement SQL getter for 'creationTimeStamp'
     throw new Error(`Unhandled BuiltInNode '${this.value}' in toSQLExpression`);
   }
 
@@ -741,7 +741,7 @@ export class BuiltIn extends RefinementExpression {
       return `System.currentTimeMillis()`;
     }
 
-    // TODO: Implement KT getter for 'currentTime'
+    // TODO: Implement KT getter for 'creationTimeStamp'
     throw new Error(`Unhandled BuiltInNode '${this.value}' in toKTExpression`);
   }
 
@@ -750,7 +750,7 @@ export class BuiltIn extends RefinementExpression {
       return new Date().getTime(); // milliseconds since epoch;
     }
 
-    // TODO: Implement TS getter for 'currentTime'
+    // TODO: Implement TS getter for 'creationTimeStamp'
     throw new Error(`Unhandled BuiltInNode '${this.value}' in applyOperator`);
   }
 

--- a/src/runtime/tests/refiner-test.ts
+++ b/src/runtime/tests/refiner-test.ts
@@ -455,7 +455,7 @@ describe('normalisation', () => {
       const ref1 = Refinement.fromAst(manifestAst1[0].args[0].type.refinement, typeData);
       ref1.normalize();
       // normalized version of ref1 should be the same as ref2
-      assert.isTrue(ref1.expression.kind == 'BooleanPrimitiveNode');
+      assert.isTrue(ref1.expression.kind === 'BooleanPrimitiveNode');
       assert.isTrue(ref1.expression['value'], `expected expression (${expr}) to be trivially true`);
   };
   describe('Correctly handles date time units', () => {

--- a/src/runtime/tests/refiner-test.ts
+++ b/src/runtime/tests/refiner-test.ts
@@ -432,10 +432,68 @@ describe('normalisation', () => {
             input: reads Something {a: Number, b: Number } [a > 0]
     `);
     const ref2 = Refinement.fromAst(manifestAst2[0].args[0].type.refinement, typeData);
-    console.log(ref1.toString());
-    console.log(`${ref2}`);
     // normalized version of ref1 should be the same as ref2
     assert.strictEqual(JSON.stringify(ref1), JSON.stringify(ref2));
+  });
+
+  const evaluatesToTrue = (expr: string, data: object = {}) => {
+      const manifestAst1 = parse(`
+          particle Foo
+              input: reads Something {num: Number} [ ${expr} ]
+      `);
+      const typeData = {'num': 'Number'};
+      const ref1 = Refinement.fromAst(manifestAst1[0].args[0].type.refinement, typeData);
+      // normalized version of ref1 should be the same as ref2
+      assert.isTrue(ref1.validateData(data), `expected expression (${expr}) to evaluate to true`);
+  };
+  const triviallyTrue = (expr: string) => {
+      const manifestAst1 = parse(`
+          particle Foo
+              input: reads Something {num: Number} [ ${expr} ]
+      `);
+      const typeData = {'num': 'Number'};
+      const ref1 = Refinement.fromAst(manifestAst1[0].args[0].type.refinement, typeData);
+      ref1.normalize();
+      // normalized version of ref1 should be the same as ref2
+      assert.isTrue(ref1.expression.kind == 'BooleanPrimitiveNode');
+      assert.isTrue(ref1.expression['value'], `expected expression (${expr}) to be trivially true`);
+  };
+  describe('Correctly handles date time units', () => {
+    it('control (ensure that the test approach works)', async () => {
+      triviallyTrue('1 == 1');
+      triviallyTrue('1 != 2');
+    });
+    it('uses millseconds by default', async () => {
+      triviallyTrue('1 == 1 milliseconds');
+    });
+    it('seconds to milliseconds', async () => {
+      triviallyTrue('1000 == 1 seconds');
+      triviallyTrue('2000 == 2 seconds');
+    });
+    it('minutes to seconds', async () => {
+      triviallyTrue('1 minutes == 60 seconds');
+      triviallyTrue('2 minutes == 120000 milliseconds');
+    });
+    it('hours to minutes', async () => {
+      triviallyTrue('1 hours == 60 minutes');
+      triviallyTrue('2 hours == 7200 seconds');
+    });
+    it('days to hours', async () => {
+      triviallyTrue('1 days == 24 hours');
+      triviallyTrue('2 days == 2880 minutes');
+    });
+    it('handles singular and plural forms', async () => {
+      triviallyTrue('2 * 1 day == 2 days');
+      triviallyTrue('1 day == 24 hours');
+      triviallyTrue('1 day != 24 hours + 1 second');
+    });
+  });
+  describe('Correctly handles date time using now()', () => {
+    it('now() is after time of writing', async () => {
+      // Checks that 'now' is after 04/22/2020 @ 7:19am (UTC).
+      evaluatesToTrue('now() > 1587539956');
+      evaluatesToTrue('not (now() < 1587539956)');
+    });
   });
 });
 


### PR DESCRIPTION
Kotlin side tests to come along with some added sanity checks for maths with time values and support for 'creationTimestamp'