### PR TITLE
Adds support for type slicing in Entity deserialisation.

### DIFF
--- a/java/arcs/core/entity/EntityBase.kt
+++ b/java/arcs/core/entity/EntityBase.kt
@@ -119,13 +119,19 @@ open class EntityBase(
         collections[field] = values
     }
 
-    /** Returns the [FieldType] for the given singleton field. */
-    private fun getSingletonType(field: String) = schema.fields.singletons[field]
+    /** Returns the [FieldType] for the given singleton field. Throws if it does not exist. */
+    private fun getSingletonType(field: String) = getOptionalSingletonType(field)
         ?: throw InvalidFieldNameException(entityClassName, field, isCollection = false)
 
-    /** Returns the [FieldType] for the given collection field. */
-    private fun getCollectionType(field: String) = schema.fields.collections[field]
+    /** Returns the [FieldType] for the given singleton field, or null if it does not exist. */
+    private fun getOptionalSingletonType(field: String) = schema.fields.singletons[field]
+
+    /** Returns the [FieldType] for the given collection field. Throws if it does not exist. */
+    private fun getCollectionType(field: String) = getOptionalCollectionType(field)
         ?: throw InvalidFieldNameException(entityClassName, field, isCollection = true)
+
+    /** Returns the [FieldType] for the given collection field, or null if it does not exist. */
+    private fun getOptionalCollectionType(field: String) = schema.fields.collections[field]
 
     /** Checks that the given value is of the expected type. */
     private fun checkType(field: String, value: Any?, type: FieldType) {
@@ -185,15 +191,21 @@ open class EntityBase(
     /**
      * Populates the entity from the given [RawEntity] serialization. Must only be called on a
      * fresh, empty instance.
+     *
+     * Supports type slicing: fields that are not present in the [Schema] for this [Entity] will be
+     * silently ignored.
      */
     fun deserialize(rawEntity: RawEntity) {
         entityId = if (rawEntity.id == NO_REFERENCE_ID) null else rawEntity.id
         rawEntity.singletons.forEach { (field, value) ->
-            setSingletonValue(field, value?.let { fromReferencable(it, getSingletonType(field)) })
+            getOptionalSingletonType(field)?.let { type ->
+                setSingletonValue(field, value?.let { fromReferencable(it, type) })
+            }
         }
         rawEntity.collections.forEach { (field, values) ->
-            val type = getCollectionType(field)
-            setCollectionValue(field, values.map { fromReferencable(it, type) }.toSet())
+            getOptionalCollectionType(field)?.let { type ->
+                setCollectionValue(field, values.map { fromReferencable(it, type) }.toSet())
+            }
         }
         creationTimestamp = rawEntity.creationTimestamp
         expirationTimestamp = rawEntity.expirationTimestamp

--- a/javatests/arcs/core/entity/EntityBaseTest.kt
+++ b/javatests/arcs/core/entity/EntityBaseTest.kt
@@ -13,9 +13,11 @@ package arcs.core.entity
 
 import arcs.core.common.Id
 import arcs.core.crdt.VersionMap
+import arcs.core.data.RawEntity
 import arcs.core.data.Schema
 import arcs.core.data.SchemaFields
 import arcs.core.data.Ttl
+import arcs.core.data.util.toReferencable
 import arcs.core.storage.testutil.DummyStorageKey
 import arcs.core.storage.Reference as StorageReference
 import arcs.core.testutil.assertThrows
@@ -217,6 +219,29 @@ class EntityBaseTest {
 
         assertThat(deserialized).isEqualTo(entity)
         assertThat(deserialized.serialize()).isEqualTo(rawEntity)
+    }
+
+    @Test
+    fun deserialize_typeSlicing() {
+        val rawEntity = RawEntity(
+            singletons = mapOf(
+                "text" to "abc".toReferencable(),
+                "some-other-singleton-field" to "def".toReferencable()
+            ),
+            collections = mapOf(
+                "nums" to setOf(11.0.toReferencable(), 22.0.toReferencable()),
+                "some-other-collection-field" to setOf(33.0.toReferencable(), 44.0.toReferencable())
+            )
+        )
+        val deserialized = DummyEntity()
+
+        deserialized.deserializeForTest(rawEntity)
+
+        val expected = DummyEntity().apply {
+            text = "abc"
+            nums = setOf(11.0, 22.0)
+        }
+        assertThat(deserialized).isEqualTo(expected)
     }
 
     @Test


### PR DESCRIPTION
Example of type slicing: a particle writes Person {age, height} to a handle, and another particle reads Person {age}. Previously this would throw an exception when deserialising, because height is not defined. Now unknown fields in the RawEntity will now be silently ignored when deserialising. This is a slight hack, but the behaviour is consistent with what we do for wasm.