### PR TITLE
Blaze fix -- appropriate plan dependencies in arcs_kt_gen

### DIFF
--- a/third_party/java/arcs/build_defs/internal/kotlin.bzl
+++ b/third_party/java/arcs/build_defs/internal/kotlin.bzl
@@ -31,7 +31,7 @@ load(
 )
 load(":kotlin_serviceloader_registry.bzl", "kotlin_serviceloader_registry")
 load(":kotlin_wasm_annotations.bzl", "kotlin_wasm_annotations")
-load(":util.bzl", "merge_lists", "replace_arcs_suffix")
+load(":util.bzl", "merge_lists", "replace_arcs_suffix", "manifest_only")
 
 ARCS_SDK_DEPS = ["//third_party/java/arcs"]
 
@@ -453,7 +453,7 @@ def arcs_kt_plan(name, srcs = [], deps = [], platforms = ["jvm"], visibility = N
             deps = deps,
         )
 
-    deps = [d for d in deps if not d.endswith(".arcs")]
+    deps = manifest_only(deps, inverse = True)
 
     arcs_kt_library(
         name = name,

--- a/third_party/java/arcs/build_defs/internal/kotlin.bzl
+++ b/third_party/java/arcs/build_defs/internal/kotlin.bzl
@@ -31,7 +31,7 @@ load(
 )
 load(":kotlin_serviceloader_registry.bzl", "kotlin_serviceloader_registry")
 load(":kotlin_wasm_annotations.bzl", "kotlin_wasm_annotations")
-load(":util.bzl", "merge_lists", "replace_arcs_suffix", "manifest_only")
+load(":util.bzl", "manifest_only", "merge_lists", "replace_arcs_suffix")
 
 ARCS_SDK_DEPS = ["//third_party/java/arcs"]
 

--- a/third_party/java/arcs/build_defs/internal/kotlin.bzl
+++ b/third_party/java/arcs/build_defs/internal/kotlin.bzl
@@ -453,6 +453,8 @@ def arcs_kt_plan(name, srcs = [], deps = [], platforms = ["jvm"], visibility = N
             deps = deps,
         )
 
+    deps = [d for d in deps if not d.endswith(".arcs")]
+
     arcs_kt_library(
         name = name,
         srcs = outs,
@@ -460,7 +462,7 @@ def arcs_kt_plan(name, srcs = [], deps = [], platforms = ["jvm"], visibility = N
         visibility = visibility,
         deps = ARCS_SDK_DEPS + deps,
     )
-    return {"outs": outs, "deps": ARCS_SDK_DEPS + deps}
+    return {"outs": outs, "deps": ARCS_SDK_DEPS}
 
 def arcs_kt_jvm_test_suite(
         name,

--- a/third_party/java/arcs/build_defs/internal/schemas.bzl
+++ b/third_party/java/arcs/build_defs/internal/schemas.bzl
@@ -5,7 +5,7 @@ Rules are re-exported in build_defs.bzl -- use those instead.
 
 load("//devtools/build_cleaner/skylark:build_defs.bzl", "register_extension_info")
 load("//third_party/java/arcs/build_defs:sigh.bzl", "sigh_command")
-load("//third_party/java/arcs/build_defs/internal:util.bzl", "replace_arcs_suffix")
+load("//third_party/java/arcs/build_defs/internal:util.bzl", "replace_arcs_suffix", "manifest_only")
 load(":kotlin.bzl", "ARCS_SDK_DEPS", "arcs_kt_library", "arcs_kt_plan")
 load(":manifest.bzl", "arcs_manifest")
 
@@ -186,15 +186,11 @@ def arcs_kt_gen(
     schema_name = name + "_schema"
     plan_name = name + "_plan"
 
-    manifest_deps = [d for d in deps if d.endswith(".arcs")]
-
     arcs_manifest(
         name = manifest_name,
         srcs = srcs,
-        deps = manifest_deps,
+        deps = manifest_only(deps),
     )
-
-    deps = [d for d in deps if not d.endswith(".arcs")]
 
     schema = arcs_kt_schema(
         name = schema_name,
@@ -207,7 +203,7 @@ def arcs_kt_gen(
     plan = arcs_kt_plan(
         name = plan_name,
         srcs = srcs,
-        deps = deps + [":" + schema_name] + manifest_deps,
+        deps = deps + [":" + schema_name],
         platforms = platforms,
         visibility = visibility,
     )

--- a/third_party/java/arcs/build_defs/internal/schemas.bzl
+++ b/third_party/java/arcs/build_defs/internal/schemas.bzl
@@ -5,7 +5,7 @@ Rules are re-exported in build_defs.bzl -- use those instead.
 
 load("//devtools/build_cleaner/skylark:build_defs.bzl", "register_extension_info")
 load("//third_party/java/arcs/build_defs:sigh.bzl", "sigh_command")
-load("//third_party/java/arcs/build_defs/internal:util.bzl", "replace_arcs_suffix", "manifest_only")
+load("//third_party/java/arcs/build_defs/internal:util.bzl", "manifest_only", "replace_arcs_suffix")
 load(":kotlin.bzl", "ARCS_SDK_DEPS", "arcs_kt_library", "arcs_kt_plan")
 load(":manifest.bzl", "arcs_manifest")
 

--- a/third_party/java/arcs/build_defs/internal/schemas.bzl
+++ b/third_party/java/arcs/build_defs/internal/schemas.bzl
@@ -186,10 +186,12 @@ def arcs_kt_gen(
     schema_name = name + "_schema"
     plan_name = name + "_plan"
 
+    manifest_deps = [d for d in deps if d.endswith(".arcs")]
+
     arcs_manifest(
         name = manifest_name,
         srcs = srcs,
-        deps = [d for d in deps if d.endswith(".arcs")],
+        deps = manifest_deps,
     )
 
     deps = [d for d in deps if not d.endswith(".arcs")]
@@ -205,14 +207,10 @@ def arcs_kt_gen(
     plan = arcs_kt_plan(
         name = plan_name,
         srcs = srcs,
-        deps = deps + [schema_name],
+        deps = deps + [":" + schema_name] + manifest_deps,
         platforms = platforms,
         visibility = visibility,
     )
-
-    # The following `arcs_kt_library` call will be generating the schema symbols,
-    # so remove this from the plan deps.
-    plan["deps"].remove(schema_name)
 
     # generates combined library. This allows developers to more easily see what is generated.
     arcs_kt_library(

--- a/third_party/java/arcs/build_defs/internal/util.bzl
+++ b/third_party/java/arcs/build_defs/internal/util.bzl
@@ -26,5 +26,5 @@ def merge_lists(*lists):
 def manifest_only(deps = [], inverse = False):
     """Returns only .arcs files"""
     if inverse:
-      return [d for d in deps if not d.endswith(".arcs")]
+        return [d for d in deps if not d.endswith(".arcs")]
     return [d for d in deps if d.endswith(".arcs")]

--- a/third_party/java/arcs/build_defs/internal/util.bzl
+++ b/third_party/java/arcs/build_defs/internal/util.bzl
@@ -22,3 +22,9 @@ def merge_lists(*lists):
         for elem in x:
             result[elem] = 1
     return result.keys()
+
+def manifest_only(deps = [], inverse = False):
+    """Returns only .arcs files"""
+    if inverse:
+      return [d for d in deps if not d.endswith(".arcs")]
+    return [d for d in deps if d.endswith(".arcs")]


### PR DESCRIPTION
- Found a simpler solution to Jibbl's "multiple includes" fix
- Found a way to represent schema decencies for plan generation -- necessary for imports. 