### PR TITLE
Enhance applyOp reliability

### DIFF
--- a/java/arcs/core/storage/StorageProxy.kt
+++ b/java/arcs/core/storage/StorageProxy.kt
@@ -232,7 +232,7 @@ class StorageProxy<Data : CrdtData, Op : CrdtOperationAtTime, T>(
             notifyUpdate(value)
             return true
         }
-        log.debug { "Failed to apply operation: $op" }
+        log.error { "Failed to apply operation: $op" }
         return false
     }
 

--- a/javatests/arcs/core/storage/StorageProxyTest.kt
+++ b/javatests/arcs/core/storage/StorageProxyTest.kt
@@ -319,11 +319,17 @@ class StorageProxyTest {
     fun applyOpFails() = runBlockingTest {
         val proxy = StorageProxy(mockStorageEndpointProvider, mockCrdtModel, scheduler)
         val (onReady, onUpdate, onDesync, onResync) = addAllActions(proxy)
-        whenever(mockCrdtModel.applyOperation(mockCrdtOperation)).thenReturn(false)
 
-        fakeStoreEndpoint.clearProxyMessages()
+        // Failed to apply an operation the Store.
+        val onProxyMessageReturn = fakeStoreEndpoint.onProxyMessageReturn
+        fakeStoreEndpoint.onProxyMessageReturn = false
         assertThat(proxy.applyOp(mockCrdtOperation)).isFalse()
-        assertThat(fakeStoreEndpoint.getProxyMessages()).isEmpty()
+        fakeStoreEndpoint.onProxyMessageReturn = onProxyMessageReturn
+
+        // Failed to apply an operation to the local model.
+        whenever(mockCrdtModel.applyOperation(mockCrdtOperation)).thenReturn(false)
+        assertThat(proxy.applyOp(mockCrdtOperation)).isFalse()
+
         verifyNoMoreInteractions(onReady, onUpdate, onDesync, onResync)
     }
 

--- a/javatests/arcs/core/storage/StorageProxyTest.kt
+++ b/javatests/arcs/core/storage/StorageProxyTest.kt
@@ -320,7 +320,7 @@ class StorageProxyTest {
         val proxy = StorageProxy(mockStorageEndpointProvider, mockCrdtModel, scheduler)
         val (onReady, onUpdate, onDesync, onResync) = addAllActions(proxy)
 
-        // Failed to apply an operation the Store.
+        // Failed to process an operation in the Store.
         val onProxyMessageReturn = fakeStoreEndpoint.onProxyMessageReturn
         fakeStoreEndpoint.onProxyMessageReturn = false
         assertThat(proxy.applyOp(mockCrdtOperation)).isFalse()


### PR DESCRIPTION
I was generating random crash on the storage service end then found the storage service already crashed but storage clients could still write data and got their onUpdate() called which shouldn't have happened.

 