### PR TITLE
[WIP] Adds a type-safe StateMachine builder to be used for life cycles.

### DIFF
--- a/.bazelproject
+++ b/.bazelproject
@@ -1,16 +1,16 @@
 directories:
   java
   javatests
-  build_defs
-  tools
-  third_party
-  particles
-  src
+#  build_defs
+#  tools
+#  third_party
+#  particles
+#  src
 
 targets:
   //java/...
   //javatests/...
-  //particles/...
+#  //particles/...
 
 test_sources:
   javatests/

--- a/java/arcs/core/host/ArcHostContext.kt
+++ b/java/arcs/core/host/ArcHostContext.kt
@@ -29,7 +29,7 @@ data class ParticleContext(
     var particleState: ParticleState = ParticleState.Instantiated,
     /** Used to detect infinite-crash loop particles */
     var consecutiveFailureCount: Int = 0
-)
+) : ParticleStateMachine(particleState)
 
 /**
  * Runtime context state needed by the [ArcHost] on a per [ArcId] basis. For each [Arc],

--- a/java/arcs/core/host/ArcState.kt
+++ b/java/arcs/core/host/ArcState.kt
@@ -57,6 +57,7 @@ enum class ParticleState {
     Instantiated,
     /** onCreate() has been successfully called. */
     Created,
+    Ready,
     /** onStart() has been successfully called. */
     Started,
     /** onStop() has been successfully called. */

--- a/java/arcs/core/host/ParticleStateMachine.kt
+++ b/java/arcs/core/host/ParticleStateMachine.kt
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+package arcs.core.host
+
+import arcs.core.entity.Handle
+import arcs.core.host.ParticleEvent.CreateEvent
+import arcs.core.host.ParticleEvent.FailedEvent
+import arcs.core.host.ParticleEvent.MaxFailedEvent
+import arcs.core.host.ParticleEvent.ReadyEvent
+import arcs.core.host.ParticleEvent.StartEvent
+import arcs.core.host.ParticleState.Created
+import arcs.core.host.ParticleState.Failed
+import arcs.core.host.ParticleState.Failed_NeverStarted
+import arcs.core.host.ParticleState.Instantiated
+import arcs.core.host.ParticleState.MaxFailed
+import arcs.core.host.ParticleState.Ready
+import arcs.core.host.ParticleState.Started
+import arcs.core.host.ParticleState.Stopped
+import arcs.core.host.api.Particle
+import arcs.core.util.StateMachine
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+
+enum class ParticleEvent {
+    StartEvent,
+    StopEvent,
+    FailedEvent,
+    MaxFailedEvent,
+    CreateEvent,
+    ReadyEvent
+}
+
+/**
+ * A [StateMachine] for [Particle] lifecycle. This class defines what are the valid states of the
+ * particle, what to do when transitioning into each state, and what the valid transitions are.
+ */
+open class ParticleStateMachine constructor(
+    currentState: ParticleState
+) : StateMachine<ParticleState, ParticleEvent, ParticleContext>(currentState) {
+    init {
+        declareStateMachine {
+            state(Instantiated) {
+                onEntry {
+                    particle.onCreate()
+                    trigger(CreateEvent)
+                }
+
+                onError(::markParticleAsFailed)
+
+                on(StartEvent, Created)
+                on(FailedEvent, Failed_NeverStarted)
+            }
+
+            state(Started) {
+                // Starting while already started will stop, this occurs during crash recovery
+                on(StartEvent, Stopped) {
+                    // Trigger a restart after moving to Stopped state
+                    trigger(StartEvent)
+                }
+            }
+
+            state(Stopped) {
+                onEntry {
+                    particle.onShutdown()
+                }
+
+                onError(::markParticleAsFailed)
+
+                on(StartEvent, Created)
+                on(FailedEvent, Failed)
+            }
+
+            state(Created) {
+                onEntry {
+                    val waitingSet = mutableSetOf<Handle>()
+                    waitingSet.addAll(handles.values)
+
+                    handles.values.forEach { handle ->
+                        handle.onReady {
+                            waitingSet.remove(handle)
+                            if (waitingSet.isEmpty()) {
+                                GlobalScope.launch {
+                                    triggerImmediate(ReadyEvent)
+                                }
+                            }
+                        }
+                    }
+                }
+
+                onError(::markParticleAsFailed)
+
+                on(ReadyEvent, Ready)
+                on(FailedEvent, Failed)
+            }
+
+            state(Ready) {
+                onEntry {
+                    particle.onReady()
+                    trigger(StartEvent)
+                }
+
+                onError(::markParticleAsFailed)
+
+                on(FailedEvent, Failed)
+                on(StartEvent, Started)
+            }
+
+            state(Failed) {
+                onEntry {
+                    consecutiveFailureCount++
+                    if (consecutiveFailureCount >= MAX_CONSECUTIVE_FAILURES) {
+                        trigger(MaxFailedEvent)
+                    }
+                }
+                on(MaxFailedEvent, MaxFailed)
+                on(StartEvent, Created)
+            }
+
+            state(Failed_NeverStarted) {
+                onEntry {
+                    if (consecutiveFailureCount >= MAX_CONSECUTIVE_FAILURES) {
+                        trigger(MaxFailedEvent)
+                    }
+                }
+                on(StartEvent, Instantiated)
+                on(MaxFailedEvent, MaxFailed)
+            }
+
+            state(MaxFailed) {
+                // There is no escape
+            }
+        }
+    }
+
+    companion object {
+        /**
+         * Move to [ParticleState.Failed] if this particle had previously successfully invoked
+         * [Particle.onCreate()], else move to [ParticleState.Failed_NeverStarted]. Increments
+         * consecutive failure count, and if it reaches maximum, transitions to
+         * [ParticleState.MaxFailed].
+         */
+        private suspend fun markParticleAsFailed(
+            particleContext: ParticleContext,
+            exception: Exception
+        ) = particleContext.run {
+            trigger(FailedEvent)
+        }
+    }
+}

--- a/java/arcs/core/host/api/Particle.kt
+++ b/java/arcs/core/host/api/Particle.kt
@@ -29,6 +29,9 @@ interface Particle {
      */
     suspend fun onCreate() = Unit
 
+    /** Called when all [Handle]s used by this [Particle] have signalled [onReady]. */
+    suspend fun onReady() = Unit
+
     /**
      * React to handle updates.
      *

--- a/java/arcs/core/util/StateMachine.kt
+++ b/java/arcs/core/util/StateMachine.kt
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+package arcs.core.util
+
+typealias EntryHandler<MACHINE> = suspend (MACHINE).() -> Unit
+typealias ErrorHandler<MACHINE> = suspend (MACHINE).(Exception) -> Unit
+
+/**
+ * [StateMachine] is an immutable directed graph of vertices representing states, and edges
+ * representing transitions. Each [STATE] can have an associated [onEntry], [onExit], [onError]
+ * handler and one or more [on] event transition handlers.
+ *
+ * [onEntry] handlers are invoked each time a [STATE] is entered, and [onExit] each time a state
+ * is left. [onError] is invoked if an exception is thrown by a handler.
+ *
+ * [on] event transition handlers specify which [EVENT] they trigger on, and the new [STATE] to
+ * transition to, effectively inserting an edge between the current state, and the new state
+ * into the graph.
+ *
+ * To trigger a transition, you [trigger] the [EVENT] associated with that edge. Events are queued,
+ * and then handlers are run in the following order:
+ * 1) [onExit] is invoked for the current state
+ * 2) If an exception occurs, [onError] is invoked and current and pending transitions are aborted
+ * 3) [on] event transition handler is invoked, if an exception occurs, [onError] is invoked
+ * and the transition and pending transitions are aborted.
+ * 4) The current state is set to the transition's new state.
+ * 5) The new state's [onEntry] handler is invoked.
+ * 6) If an exception occurs, [onError] is invoked.
+ * 7) Any [trigger] events that happen during these sequence are queued and processed as the last
+ * step. [onError] flushes pending events.
+ *
+ * [StateMachine] represents the only legal transitions possible. Triggering events
+ * which are not relevant for the current state results in an exception. Invalid state transition
+ * attempts are not silently ignored.
+ *
+ * Loosely inspired by those used in gaming or protocol frameworks, like Fettle
+ * [http://thehiflyer.github.io/Fettle/] but simplified for Arcs needs, and constructed via
+ * idiomatic Kotlin type-safe builders.
+ *
+ * @param STATE usually an enum or sealed class representing possible states
+ * @param EVENT usually an enum or sealed class representing possible event triggered transitions
+ * @param MACHINE the subclass type that extends [StateMachine]
+ * @property state the current/starting state of the machine.
+ */
+abstract class StateMachine<STATE, EVENT, MACHINE : StateMachine<STATE, EVENT, MACHINE>>(
+    var state: STATE
+) {
+    private lateinit var states: Map<STATE, StateNode<STATE, EVENT, MACHINE>>
+    private val eventQueue = mutableListOf<EVENT>()
+
+    /** True if there are no pending events to process. */
+    val idle = eventQueue.isEmpty()
+
+    internal data class Transition<EVENT, STATE, MACHINE>(
+        val nextState: STATE,
+        val block: suspend (MACHINE).(STATE) -> Unit
+    )
+
+    internal data class StateNode<STATE, EVENT, MACHINE>(
+        val entryHandler: EntryHandler<MACHINE>,
+        val exitHandler: EntryHandler<MACHINE>,
+        val errorHandler: ErrorHandler<MACHINE>,
+        val eventHandlers: Map<EVENT, Transition<EVENT, STATE, MACHINE>>
+    )
+
+    /**
+     * Triggers an event to be queued and processed immediately. This should only be called from
+     * external code, never from state machine handlers.
+     */
+    suspend fun triggerImmediate(event: EVENT) {
+        trigger(event)
+        triggerInternal()
+    }
+
+    /**
+     * Called by state machine handlers to queue an event to be processed after processing the
+     * current event is finished processing.
+     */
+    protected suspend fun trigger(event: EVENT) {
+        eventQueue += event
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private suspend fun triggerInternal() {
+        if (eventQueue.isEmpty()) {
+            return
+        }
+        val event = eventQueue.removeAt(0)
+        val stateNode = requireNotNull(states[state])
+        val eventHandler = requireNotNull(stateNode.eventHandlers[event]) {
+            "Illegal state transition $event while in state $state"
+        }
+
+        try {
+            stateNode.exitHandler.invoke(this as MACHINE)
+            eventHandler.block(this, eventHandler.nextState)
+            transitionTo(eventHandler.nextState)
+        } catch (e: Exception) {
+            eventQueue.clear()
+            stateNode.errorHandler.invoke(this as MACHINE, e)
+        }
+
+        triggerInternal()
+    }
+
+    /**
+     * Invoked when transitioning to a new state. Verifies this is a valid transition, invokes
+     * an entry handlers, forwarding exceptions to the error handlers.
+     */
+    @Suppress("UNCHECKED_CAST")
+    protected suspend fun transitionTo(newState: STATE) {
+        val destination = requireNotNull(states[newState]) {
+            "$newState is not defined in the state machine."
+        }
+
+        state = newState
+        try {
+            destination.entryHandler.invoke(this as MACHINE)
+        } catch (e: Exception) {
+            eventQueue.clear()
+            destination.errorHandler.invoke(this as MACHINE, e)
+        }
+    }
+
+    /** Type-Safe builder for StateMachine. */
+    inner class StateMachineBuilder {
+        private var builderStates = mutableMapOf<STATE, StateNode<STATE, EVENT, MACHINE>>()
+
+
+        /** Type-Safe builder for a given state. */
+        inner class StateHandler(val state: STATE) {
+
+            private var entryHandler: EntryHandler<MACHINE>? = null
+            private var exitHandler: EntryHandler<MACHINE>? = null
+            private var errorHandler: ErrorHandler<MACHINE>? = null
+            private val eventHandlers: MutableMap<EVENT, Transition<EVENT, STATE, MACHINE>> =
+                mutableMapOf()
+
+            /** Invoked whenever this state is entered. */
+            fun onEntry(handler: suspend (MACHINE).() -> Unit) {
+                require(entryHandler == null) {
+                    "$state already has entry handler. Only one entry handler allowed per state."
+                }
+                entryHandler = handler
+            }
+
+            /** Invoked whenever this state is exited. */
+            fun onExit(handler: suspend (MACHINE).() -> Unit) {
+                require(exitHandler == null) {
+                    "$state already has exit handler. Only one exit handler allowed per state."
+                }
+                exitHandler = handler
+            }
+
+            /** Invoked whenever an exception occurs transitioning to this state. */
+            fun onError(handler: suspend (MACHINE).(Exception) -> Unit) {
+                require(errorHandler == null) {
+                    "$state already has error handler. Only one error handler allowed per state."
+                }
+                errorHandler = handler
+            }
+
+            fun on(
+                event: EVENT,
+                nextState: STATE,
+                handler: suspend (MACHINE).(state: STATE) -> Unit = {}
+            ) {
+                require(event !in eventHandlers) {
+                    """$event already registered for $state. Only one event handler allowed per 
+                       |state per event allowed.""".trimMargin()
+                }
+                eventHandlers[event] = Transition(nextState, handler)
+            }
+
+            internal fun build() = StateNode(
+                entryHandler ?: {},
+                exitHandler ?: {},
+                errorHandler ?: {},
+                eventHandlers
+            )
+        }
+
+        /**
+         * Defines a state in the machine and returns builder to register entry and error handlers.
+         */
+        fun state(newState: STATE, block: (StateHandler).() -> Unit) =
+            StateHandler(newState).apply(block).apply {
+                require(state !in builderStates) {
+                    "State $state defined twice."
+                }
+                builderStates[state] = build()
+            }
+
+        internal fun build() {
+            states = builderStates
+        }
+    }
+
+    /** Creates and applies a type-safe builder for the state machine. */
+    fun declareStateMachine(builder: (StateMachineBuilder).() -> Unit) =
+        StateMachineBuilder().apply(builder).build()
+}

--- a/javatests/arcs/core/host/BUILD
+++ b/javatests/arcs/core/host/BUILD
@@ -6,7 +6,7 @@ load(
     "arcs_kt_plan",
     "arcs_kt_schema",
 )
-
+#  item < 0 or item > 9 and item < unicode(a)  or item > unicode(f)
 licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])

--- a/javatests/arcs/core/util/StateMachineTest.kt
+++ b/javatests/arcs/core/util/StateMachineTest.kt
@@ -1,0 +1,367 @@
+package arcs.core.util
+
+import arcs.core.testutil.assertSuspendingThrows
+import arcs.core.util.StateMachineTest.TestEvent.*
+import arcs.core.util.StateMachineTest.TestState.Before
+import arcs.core.util.StateMachineTest.TestState.TestEventQueue
+import arcs.core.util.StateMachineTest.TestState.TestEventQueue2
+import arcs.core.util.StateMachineTest.TestState.TestEventQueue3
+import arcs.core.util.StateMachineTest.TestState.TestExceptionInEntry
+import arcs.core.util.StateMachineTest.TestState.TestExceptionInExit
+import arcs.core.util.StateMachineTest.TestState.TestExceptionInTransition
+import arcs.core.util.StateMachineTest.TestState.TestIllegalTransition
+import arcs.core.util.StateMachineTest.TestState.TestState
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+
+/** Tests for [StateMachine]. */
+@RunWith(JUnit4::class)
+class StateMachineTest {
+
+    @Test
+    fun testSimpleTransitions() = runBlockingTest {
+        val machine = TestMachine()
+        assertThat(machine.state).isEqualTo(Before)
+        machine.triggerImmediate(TestEntryAndExitEvent)
+        assertThat(machine.state).isEqualTo(TestState)
+        assertThat(machine.actionsHandled).containsExactly(
+            exit(Before),
+            transition(Before, TestState),
+            enter(TestState)
+        )
+        assertThat(machine.idle).isTrue()
+    }
+
+    @Test
+    fun testErrorDuringExit() = runBlockingTest {
+        val machine = TestMachine(TestExceptionInExit)
+        machine.triggerImmediate(TestEntryAndExitEvent)
+        assertThat(machine.state).isEqualTo(TestExceptionInExit)
+        assertThat(machine.actionsHandled).containsExactly(
+            exit(TestExceptionInExit),
+            error(TestExceptionInExit, "Boom!")
+        )
+        assertThat(machine.idle).isTrue()
+    }
+
+    @Test
+    fun testTriggerQueue() = runBlockingTest {
+        val machine = TestMachine(TestExceptionInExit)
+        machine.triggerImmediate(TestEntryAndExitEvent)
+        assertThat(machine.state).isEqualTo(TestExceptionInExit)
+        assertThat(machine.actionsHandled).containsExactly(
+            exit(TestExceptionInExit),
+            error(TestExceptionInExit, "Boom!")
+        )
+        assertThat(machine.idle).isTrue()
+    }
+
+    @Test
+    fun testErrorDuringTransition() = runBlockingTest {
+        val machine = TestMachine(TestExceptionInTransition)
+        machine.triggerImmediate(TestEntryAndExitEvent)
+        assertThat(machine.state).isEqualTo(TestExceptionInTransition)
+        assertThat(machine.actionsHandled).containsExactly(
+            exit(TestExceptionInTransition),
+            transition(TestExceptionInTransition, TestState),
+            error(TestExceptionInTransition, "Boom!")
+        )
+        assertThat(machine.idle).isTrue()
+    }
+
+    @Test
+    fun testErrorDuringEntry() = runBlockingTest {
+        val machine = TestMachine()
+        machine.triggerImmediate(TestExceptionInEntryEvent)
+        assertThat(machine.state).isEqualTo(TestExceptionInEntry)
+        assertThat(machine.actionsHandled).containsExactly(
+            exit(Before),
+            transition(Before, TestExceptionInEntry),
+            enter(TestExceptionInEntry),
+            error(TestExceptionInEntry, "Boom!")
+        )
+        assertThat(machine.idle).isTrue()
+    }
+
+    @Test
+    fun testEventQueue() = runBlockingTest {
+        val machine = TestMachine(TestEventQueue)
+        machine.triggerImmediate(TestEventQueueEvent)
+        assertThat(machine.state).isEqualTo(TestEventQueue3)
+        assertThat(machine.actionsHandled).containsExactly(
+            exit(TestEventQueue),
+            transition(TestEventQueue, TestEventQueue2),
+            enter(TestEventQueue2),
+            exit(TestEventQueue2),
+            transition(TestEventQueue2, TestEventQueue3),
+            enter(TestEventQueue3),
+            exit(TestEventQueue3),
+            transition(TestEventQueue3, TestEventQueue3),
+            enter(TestEventQueue3),
+            exit(TestEventQueue3),
+            transition(TestEventQueue3, TestEventQueue3),
+            enter(TestEventQueue3)
+        )
+        assertThat(machine.idle).isTrue()
+    }
+
+    @Test
+    fun testIllegalTransition() = runBlockingTest {
+        val machine = TestMachine(TestEventQueue)
+        assertSuspendingThrows(IllegalArgumentException::class) {
+            machine.triggerImmediate(TestEntryAndExitEvent)
+        }
+    }
+
+
+
+    @Test
+    fun testIllegalMachines() = runBlockingTest {
+        assertSuspendingThrows(IllegalArgumentException::class) {
+            IllegalMachineDupState()
+        }
+        assertSuspendingThrows(IllegalArgumentException::class) {
+            IllegalMachineDupEntry()
+        }
+        assertSuspendingThrows(IllegalArgumentException::class) {
+            IllegalMachineDupExit()
+        }
+        assertSuspendingThrows(IllegalArgumentException::class) {
+            IllegalMachineDupError()
+        }
+        assertSuspendingThrows(IllegalArgumentException::class) {
+            IllegalMachineDupTransition()
+        }
+    }
+
+    enum class TestEvent {
+        TestEntryAndExitEvent,
+        TestExceptionInEntryEvent,
+        TestEventQueueEvent,
+        TestEventQueueEvent2,
+        TestEventQueueEvent3,
+        TestEventQueueEvent4,
+        ShouldBeDiscarded
+    }
+
+    enum class TestState {
+        Before,
+        TestExceptionInExit,
+        TestExceptionInTransition,
+        TestExceptionInEntry,
+        TestEventQueue,
+        TestEventQueue2,
+        TestEventQueue3,
+        TestState,
+        TestIllegalTransition,
+    }
+
+    class TestMachine(
+        initial: TestState = Before
+    ) : StateMachine<TestState, TestEvent, TestMachine>(initial) {
+        val actionsHandled = mutableListOf<Any>()
+
+        private suspend fun entered(machine: (TestMachine)) {
+            actionsHandled += enter(machine.state)
+        }
+
+        private suspend fun exited(machine: (TestMachine)) {
+            actionsHandled += exit(machine.state)
+        }
+
+        private suspend fun errored(machine: (TestMachine), exception: Exception) {
+            actionsHandled += error(machine.state, exception.message.toString())
+        }
+
+        private suspend fun transitioned(machine: (TestMachine), nextState: TestState) {
+            actionsHandled += transition(machine.state, nextState)
+        }
+
+        init {
+            declareStateMachine {
+                state(Before) {
+                    onEntry(::entered)
+                    on(TestEntryAndExitEvent, TestState, ::transitioned)
+                    on(TestExceptionInEntryEvent, TestExceptionInEntry, ::transitioned)
+                    onError(::errored)
+                    onExit(::exited)
+                }
+
+                state(TestState) {
+                    onEntry(::entered)
+                    onError(::errored)
+                    onExit(::exited)
+                }
+
+                state(TestExceptionInExit) {
+                    onExit {
+                        exited(this)
+                        trigger(ShouldBeDiscarded)
+                        throw IllegalStateException("Boom!")
+                    }
+
+                    onError(::errored)
+                    on(TestEntryAndExitEvent, TestState, ::transitioned)
+                }
+
+                state(TestExceptionInTransition) {
+                    onExit {
+                        exited(this)
+                        trigger(ShouldBeDiscarded)
+                    }
+
+                    onError(::errored)
+                    on(TestEntryAndExitEvent, TestState) {
+                        transitioned(this, TestState)
+                        trigger(ShouldBeDiscarded)
+                        throw IllegalStateException("Boom!")
+                    }
+                }
+
+                state(TestExceptionInEntry) {
+                    onEntry {
+                        entered(this)
+                        trigger(ShouldBeDiscarded)
+                        throw IllegalStateException("Boom!")
+                    }
+                    onExit {
+                        exited(this)
+                        trigger(ShouldBeDiscarded)
+                    }
+
+                    onError(::errored)
+                }
+
+                state(TestEventQueue) {
+                    onExit {
+                        exited(this)
+                        trigger(TestEventQueueEvent2)
+                    }
+
+                    onError(::errored)
+
+                    on(TestEventQueueEvent, TestEventQueue2) { newState ->
+                        transitioned(this, newState)
+                        trigger(TestEventQueueEvent3)
+                    }
+                }
+
+                state(TestEventQueue2) {
+                    onEntry {
+                        entered(this)
+                        trigger(TestEventQueueEvent4)
+                    }
+
+                    onExit(::exited)
+
+                    on(TestEventQueueEvent2, TestEventQueue3, ::transitioned)
+                    on(TestEventQueueEvent3, TestEventQueue3, ::transitioned)
+                    on(TestEventQueueEvent4, TestEventQueue3, ::transitioned)
+                }
+
+                state(TestEventQueue3) {
+                    onEntry(::entered)
+                    onExit(::exited)
+                    on(TestEventQueueEvent3, TestEventQueue3, ::transitioned)
+                    on(TestEventQueueEvent4, TestEventQueue3, ::transitioned)
+                }
+
+                state(TestIllegalTransition) {
+
+                }
+            }
+        }
+    }
+
+    class IllegalMachineDupState
+        : StateMachine<TestState, TestEvent, IllegalMachineDupState>(Before) {
+        init {
+            declareStateMachine {
+                state(TestState.Before) {
+
+                }
+
+                state(TestState.Before) {
+
+                }
+            }
+        }
+    }
+
+    class IllegalMachineDupEntry
+        : StateMachine<TestState, TestEvent, IllegalMachineDupState>(Before) {
+        init {
+            declareStateMachine {
+                state(TestState.Before) {
+                    onEntry {
+
+                    }
+
+                    onEntry {
+
+                    }
+                }
+            }
+        }
+    }
+
+    class IllegalMachineDupExit
+        : StateMachine<TestState, TestEvent, IllegalMachineDupState>(Before) {
+        init {
+            declareStateMachine {
+                state(TestState.Before) {
+                    onExit {
+
+                    }
+
+                    onExit {
+
+                    }
+                }
+            }
+        }
+    }
+
+    class IllegalMachineDupError
+        : StateMachine<TestState, TestEvent, IllegalMachineDupState>(Before) {
+        init {
+            declareStateMachine {
+                state(TestState.Before) {
+                    onError {
+
+                    }
+
+                    onError {
+
+                    }
+                }
+            }
+        }
+    }
+
+    class IllegalMachineDupTransition
+        : StateMachine<TestState, TestEvent, IllegalMachineDupState>(Before) {
+        init {
+            declareStateMachine {
+                state(TestState.Before) {
+                    on(TestEvent.TestEntryAndExitEvent, TestState.Before) {
+
+                    }
+                    on(TestEvent.TestEntryAndExitEvent, TestState.Before) {
+
+                    }
+                }
+            }
+        }
+    }
+}
+
+fun enter(state: StateMachineTest.TestState) = "enter:${state.name}"
+fun exit(state: StateMachineTest.TestState) = "exit:${state.name}"
+fun error(state: StateMachineTest.TestState, msg: String) = "error:${state.name}:$msg"
+fun transition(from: StateMachineTest.TestState, to: StateMachineTest.TestState) =
+    "transition:${from.name}:${to.name}"


### PR DESCRIPTION
Adds a declarative type-safe StateMachine immutable builder DSL to be used for life cycles. This is inspired by various frameworks I've used before in games and protocols (e.g. Fettle). 

Each state may have onEntry, onExit, onError handlers attached, as well as  event->newstate transition mappings.

All legal states are defined, as well as event-driven transitions, with attached event and error handlers, in the DSL. 

a PlantUML or GraphViz dump of the structure can be obtained. 

The machine uses an internal queue to manage any events triggered by handlers. A sample implementation of AbstractArcHost.performParticleLifecycle() has been ported.

I'm still working on how the queue will be processed or drained, and whether I'll use another thread (e.g. like a browser microtasks queue). Additionally, its currently not thread safe (no mutexes around the mutate state field or eventQueue)

Comments welcome.
