### PR TITLE
Getting rid of most Kotlin warnings

### DIFF
--- a/java/arcs/android/sdk/host/AndroidHost.kt
+++ b/java/arcs/android/sdk/host/AndroidHost.kt
@@ -21,6 +21,7 @@ import arcs.core.storage.StoreManager
 import arcs.jvm.host.JvmHost
 import arcs.sdk.android.storage.ResurrectionHelper
 import arcs.sdk.android.storage.ServiceStoreFactory
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 
 /**
  * An [ArcHost] that runs on Android inside of a [Service], uses [StorageService] for storage, and
@@ -36,6 +37,7 @@ abstract class AndroidHost(
     override val resurrectionHelper: ResurrectionHelper = ResurrectionHelper(context,
         ::onResurrected)
 
+    @ExperimentalCoroutinesApi
     override val activationFactory = ServiceStoreFactory(context, lifecycle)
 
     override fun maybeRequestResurrection(context: ArcHostContext) {

--- a/java/arcs/core/entity/SingletonHandle.kt
+++ b/java/arcs/core/entity/SingletonHandle.kt
@@ -53,12 +53,12 @@ class SingletonHandle<T : Storable, R : Referencable>(
     // endregion
 
     // region implement WriteSingletonHandle<T>
-    override suspend fun store(entity: T) = checkPreconditions<Unit> {
+    override suspend fun store(element: T) = checkPreconditions<Unit> {
         storageProxy.applyOp(
             CrdtSingleton.Operation.Update(
                 name,
                 storageProxy.getVersionMap().increment(name),
-                storageAdapter.storableToReferencable(entity)
+                storageAdapter.storableToReferencable(element)
             )
         )
     }

--- a/java/arcs/core/storage/ReferenceModeStore.kt
+++ b/java/arcs/core/storage/ReferenceModeStore.kt
@@ -142,7 +142,6 @@ class ReferenceModeStore private constructor(
                         PreEnqueuedFromBackingStore(message.toReferenceModeMessage(), muxId)
                     )
                 }
-                true
             }
         }
     )
@@ -157,7 +156,6 @@ class ReferenceModeStore private constructor(
             CoroutineScope(coroutineContext).launch {
                 receiveQueue.enqueue(Message.PreEnqueuedFromContainer(it.toReferenceModeMessage()))
             }
-            true
         })
     }
 
@@ -614,7 +612,7 @@ class ReferenceModeStore private constructor(
                     /* ktlint-enable max-line-length */
                 ) { "ReferenceMode stores only manage singletons/collections of Entities." }
 
-            val (type, containedTypeClass) = requireNotNull(
+            val (type, _) = requireNotNull(
                 options.type as? Type.TypeContainer<*>
             ) { "Type ${options.type} does not implement TypeContainer" }.let {
                 /* ktlint-disable max-line-length */

--- a/java/arcs/core/storage/Store.kt
+++ b/java/arcs/core/storage/Store.kt
@@ -81,6 +81,7 @@ class Store<Data : CrdtData, Op : CrdtOperation, ConsumerData>(
         return activeStore
     }
 
+    @Suppress("UNCHECKED_CAST")
     companion object {
         /**
          * This is a helper method to reduce the space of UNCHECKED_CAST suppression when accessing

--- a/java/arcs/core/storage/driver/Database.kt
+++ b/java/arcs/core/storage/driver/Database.kt
@@ -283,6 +283,7 @@ class DatabaseDriver<Data : Any>(
         token = Random.nextInt().toString()
     }
 
+    @Suppress("UNCHECKED_CAST")
     private suspend fun getDatabaseData(): Pair<Data?, Int?> {
         var dataAndVersion: Pair<Data?, Int?> = null to null
         database.get(

--- a/java/arcs/sdk/testing/BaseTestHarness.kt
+++ b/java/arcs/sdk/testing/BaseTestHarness.kt
@@ -129,7 +129,7 @@ open class BaseTestHarness<P : Particle>(
         particle.onCreate()
 
         val readySoFar = atomic(0)
-        val readyJobs = handles.map { (name, handle) ->
+        val readyJobs = handles.map { (_, handle) ->
             launch {
                 // TODO: switch to this version when onReady is non-suspending:
                 // suspendCoroutine<Unit> { cont ->

--- a/javatests/arcs/android/e2e/testapp/ReadAnimalHostService.kt
+++ b/javatests/arcs/android/e2e/testapp/ReadAnimalHostService.kt
@@ -23,6 +23,7 @@ import arcs.core.host.toRegistration
 import arcs.jvm.host.JvmSchedulerProvider
 import arcs.sdk.android.storage.ServiceStoreFactory
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -49,6 +50,7 @@ class ReadAnimalHostService : ArcHostService() {
         schedulerProvider: SchedulerProvider,
         vararg initialParticles: ParticleRegistration
     ) : AndroidHost(context, lifecycle, schedulerProvider, *initialParticles) {
+        @ExperimentalCoroutinesApi
         override val activationFactory = ServiceStoreFactory(context, lifecycle)
     }
 

--- a/javatests/arcs/android/e2e/testapp/StorageAccessService.kt
+++ b/javatests/arcs/android/e2e/testapp/StorageAccessService.kt
@@ -14,6 +14,7 @@ import arcs.sdk.android.storage.ServiceStoreFactory
 import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
@@ -23,6 +24,7 @@ class StorageAccessService : LifecycleService() {
     private val coroutineContext: CoroutineContext = Job() + Dispatchers.Main
     private val scope: CoroutineScope = CoroutineScope(coroutineContext)
 
+    @ExperimentalCoroutinesApi
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         super.onStartCommand(intent, flags, startId)
 
@@ -45,6 +47,7 @@ class StorageAccessService : LifecycleService() {
                     lifecycle
                 )
             )
+            @Suppress("UNCHECKED_CAST")
             val singletonHandle = handleManager.createHandle(
                 HandleSpec(
                     "singletonHandle",

--- a/javatests/arcs/android/e2e/testapp/TestActivity.kt
+++ b/javatests/arcs/android/e2e/testapp/TestActivity.kt
@@ -33,12 +33,14 @@ import arcs.sdk.android.storage.ServiceStoreFactory
 import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlin.coroutines.EmptyCoroutineContext
 
 /** Entry UI to launch Arcs Test. */
+@ExperimentalCoroutinesApi
 class TestActivity : AppCompatActivity() {
 
     private lateinit var resultView1: TextView
@@ -119,9 +121,9 @@ class TestActivity : AppCompatActivity() {
         super.onNewIntent(intent)
 
         intent?.run {
-            if (intent.hasExtra(RESULT_NAME)) {
+            if (this@run.hasExtra(RESULT_NAME)) {
                 scope.launch {
-                    appendResultText(intent.getStringExtra(RESULT_NAME))
+                    appendResultText(this@run.getStringExtra(RESULT_NAME))
                 }
             }
         }
@@ -235,6 +237,7 @@ class TestActivity : AppCompatActivity() {
             )
         )
         if (isCollection) {
+            @Suppress("UNCHECKED_CAST")
             collectionHandle = handleManager.createHandle(
                 HandleSpec(
                     "collectionHandle",
@@ -273,6 +276,7 @@ class TestActivity : AppCompatActivity() {
                 }
             }
         } else {
+            @Suppress("UNCHECKED_CAST")
             singletonHandle = handleManager.createHandle(
                 HandleSpec(
                     "singletonHandle",

--- a/javatests/arcs/android/e2e/testapp/WriteAnimalHostService.kt
+++ b/javatests/arcs/android/e2e/testapp/WriteAnimalHostService.kt
@@ -23,6 +23,7 @@ import arcs.jvm.host.JvmSchedulerProvider
 import arcs.sdk.Handle
 import arcs.sdk.android.storage.ServiceStoreFactory
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 
@@ -62,6 +63,7 @@ class WriteAnimalHostService : ArcHostService() {
         schedulerProvider: SchedulerProvider,
         vararg initialParticles: ParticleRegistration
     ) : AndroidHost(context, lifecycle, schedulerProvider, *initialParticles) {
+        @ExperimentalCoroutinesApi
         override val activationFactory = ServiceStoreFactory(context, lifecycle)
 
         fun arcHostContext(arcId: String) = getArcHostContext(arcId)

--- a/javatests/arcs/android/entity/TtlHandleTest.kt
+++ b/javatests/arcs/android/entity/TtlHandleTest.kt
@@ -194,6 +194,7 @@ class TtlHandleTest {
         assertThat(handle2.fetch()).isEqualTo(entity2)
     }
 
+    @Suppress("UNCHECKED_CAST")
     private suspend fun createCollectionHandle(
             ttl: Ttl = Ttl.Hours(1),
             key: StorageKey = collectionKey
@@ -215,6 +216,7 @@ class TtlHandleTest {
             ttl
         ) as ReadWriteCollectionHandle<DummyEntity>
 
+    @Suppress("UNCHECKED_CAST")
     private suspend fun createSingletonHandle() =
         EntityHandleManager(
             time = fakeTime,

--- a/javatests/arcs/android/host/TestExternalArcHostService.kt
+++ b/javatests/arcs/android/host/TestExternalArcHostService.kt
@@ -58,6 +58,7 @@ abstract class TestExternalArcHostService : Service() {
         override val resurrectionHelper: ResurrectionHelper =
             ResurrectionHelper(context, ::onResurrected)
 
+        @kotlinx.coroutines.ExperimentalCoroutinesApi
         override val activationFactory =  ServiceStoreFactory(
                 context,
                 FakeLifecycle(),

--- a/javatests/arcs/android/host/TestProdArcHostService.kt
+++ b/javatests/arcs/android/host/TestProdArcHostService.kt
@@ -25,6 +25,8 @@ class TestProdArcHostService : ProdArcHostService() {
         schedulerProvider: SchedulerProvider,
         vararg particles: ParticleRegistration
     ) : TestingJvmProdHost(schedulerProvider, *particles) {
+
+        @kotlinx.coroutines.ExperimentalCoroutinesApi
         override val activationFactory = ServiceStoreFactory(
             context,
             lifecycle,

--- a/javatests/arcs/core/entity/DummyEntity.kt
+++ b/javatests/arcs/core/entity/DummyEntity.kt
@@ -11,7 +11,7 @@ import arcs.core.data.SchemaName
  * in the test. Also adds convenient getters and setters for entity fields, similar to what a
  * code-generated subclass would do.
  */
-class DummyEntity : EntityBase(ENTITY_CLASS_NAME, SCHEMA) {
+class DummyEntity : EntityBase(ENTITY_CLASS_NAME, SCHEMA), Storable {
     var bool: Boolean? by SingletonProperty()
     var num: Double? by SingletonProperty()
     var text: String? by SingletonProperty()

--- a/javatests/arcs/core/entity/HandleManagerCloseTest.kt
+++ b/javatests/arcs/core/entity/HandleManagerCloseTest.kt
@@ -22,6 +22,7 @@ import java.lang.IllegalStateException
 import kotlin.coroutines.EmptyCoroutineContext
 
 @RunWith(JUnit4::class)
+@kotlinx.coroutines.ExperimentalCoroutinesApi
 class HandleManagerCloseTest {
 
     val scheduler = JvmSchedulerProvider(EmptyCoroutineContext).invoke("test")
@@ -117,6 +118,7 @@ class HandleManagerCloseTest {
         ).forEach { assertSuspendingThrows(IllegalStateException::class) { it() } }
     }
 
+    @Suppress("UNCHECKED_CAST")
     private suspend fun EntityHandleManager.createSingletonHandle(
         storageKey: StorageKey = singletonKey,
         name: String = "singletonHandle",
@@ -132,6 +134,7 @@ class HandleManagerCloseTest {
         ttl
     ) as ReadWriteSingletonHandle<Person>
 
+    @Suppress("UNCHECKED_CAST")
     private suspend fun EntityHandleManager.createCollectionHandle(
         storageKey: StorageKey = collectionKey,
         name: String = "collecitonKey",


### PR DESCRIPTION
The remaining warnings are about deprecations or require a longer fix.