### PR TITLE
Deflake AndroidAllocatorTest

### DIFF
--- a/java/arcs/android/sdk/host/IntentHostAdapter.kt
+++ b/java/arcs/android/sdk/host/IntentHostAdapter.kt
@@ -77,7 +77,7 @@ abstract class IntentHostAdapter(
     protected suspend fun <T> sendIntentToHostServiceForResult(
         intent: Intent,
         transformer: (Any?) -> T?
-    ): T? = withTimeout(ARCHOST_INTENT_TIMEOUT) {
+    ): T? = withTimeout(ARCHOST_INTENT_TIMEOUT_MS) {
         suspendCancellableCoroutine { continuation: CancellableContinuation<T?> ->
             ArcHostHelper.setResultReceiver(
                 intent,
@@ -100,6 +100,6 @@ abstract class IntentHostAdapter(
          * The maximum amount of time to wait for an [ArcHost] to process an [Intent]-base RPC call.
          * This timeout ensures requests don't wait forever.
          */
-        const val ARCHOST_INTENT_TIMEOUT = 2000L
+        const val ARCHOST_INTENT_TIMEOUT_MS = 5000L
     }
 }

--- a/java/arcs/core/util/testutil/LogRule.kt
+++ b/java/arcs/core/util/testutil/LogRule.kt
@@ -22,7 +22,9 @@ import org.junit.runner.Description
 import org.junit.runners.model.Statement
 
 /** JUnit [TestRule] which prints wrappers around the log output from each test. */
-class LogRule : TestRule {
+class LogRule(
+    private val logLevel: Log.Level = Log.Level.Debug
+) : TestRule {
     private val taggedLog = TaggedLog { "TEST" }
     lateinit var loggedMessages: List<String>
 
@@ -37,7 +39,7 @@ class LogRule : TestRule {
             println("|   ${desc.testName.padEnd(94, ' ')} |")
             println("+${"-".repeat(98)}+")
             println()
-            initLogForTest(messages)
+            initLogForTest(messages, logLevel)
             base.evaluate()
             println()
         }
@@ -50,9 +52,9 @@ class LogRule : TestRule {
 
     companion object {
         /** Initializes [Log] for tests on the JVM. */
-        private fun initLogForTest(collectedMessages: MutableList<String>) {
+        private fun initLogForTest(collectedMessages: MutableList<String>, logLevel: Log.Level) {
             Log.logIndex.value = 0
-            Log.level = Log.Level.Debug
+            Log.level = logLevel
             Log.writer = { level, renderedMessage, _ ->
                 collectedMessages.add(renderedMessage)
                 if (

--- a/javatests/arcs/android/host/BUILD
+++ b/javatests/arcs/android/host/BUILD
@@ -11,6 +11,7 @@ package(default_visibility = ["//visibility:public"])
 
 arcs_kt_android_test_suite(
     name = "host",
+    size = "medium",
     srcs = glob(["*Test.kt"]),
     manifest = "AndroidManifest.xml",
     package = "arcs.android.host",

--- a/javatests/arcs/core/allocator/AllocatorTestBase.kt
+++ b/javatests/arcs/core/allocator/AllocatorTestBase.kt
@@ -14,6 +14,7 @@ import arcs.core.storage.driver.VolatileDriverProvider
 import arcs.core.storage.keys.RamDiskStorageKey
 import arcs.core.storage.keys.VolatileStorageKey
 import arcs.core.testutil.assertSuspendingThrows
+import arcs.core.util.Log
 import arcs.core.util.Scheduler
 import arcs.core.util.plus
 import arcs.core.util.testutil.LogRule
@@ -41,7 +42,7 @@ import kotlin.coroutines.EmptyCoroutineContext
 @OptIn(ExperimentalCoroutinesApi::class)
 open class AllocatorTestBase {
     @get:Rule
-    val log = LogRule()
+    val log = LogRule(Log.Level.Warning)
 
     private val schedulerProvider = JvmSchedulerProvider(EmptyCoroutineContext)
 


### PR DESCRIPTION
A few tweaks:
* Increases RPC timeout from 2s to 5s
* Increases test size from small to medium
* Filters log level (test output was *very* spammy)

Towards #4781