### PR TITLE
Performance optimization: introduce WriteBack / Flushers

### DIFF
--- a/java/arcs/core/storage/BUILD
+++ b/java/arcs/core/storage/BUILD
@@ -86,7 +86,9 @@ arcs_kt_library(
     srcs = WRITEBACK_SRCS,
     deps = [
         "//java/arcs/core/storage/keys:protocols",
+        "//java/arcs/core/util",
         "//third_party/java/androidx/annotation",
+        "//third_party/kotlin/kotlinx_atomicfu",
         "//third_party/kotlin/kotlinx_coroutines",
     ],
 )

--- a/java/arcs/core/storage/BUILD
+++ b/java/arcs/core/storage/BUILD
@@ -85,6 +85,7 @@ arcs_kt_library(
     name = "writeback",
     srcs = WRITEBACK_SRCS,
     deps = [
+        "//java/arcs/core/storage/keys:protocols",
         "//third_party/java/androidx/annotation",
         "//third_party/kotlin/kotlinx_coroutines",
     ],

--- a/java/arcs/core/storage/BUILD
+++ b/java/arcs/core/storage/BUILD
@@ -20,21 +20,27 @@ REFERENCE_SRCS = [
     "Reference.kt",
 ]
 
+WRITEBACK_SRCS = [
+    "WriteBack.kt",
+]
+
 arcs_kt_library(
     name = "storage",
     srcs = glob(
         ["*.kt"],
-        exclude = PROXY_SRCS + STORAGE_KEY_SRCS + REFERENCE_SRCS,
+        exclude = PROXY_SRCS + STORAGE_KEY_SRCS + REFERENCE_SRCS + WRITEBACK_SRCS,
     ),
     exports = [
         ":proxy",
         ":reference",
         ":storage_key",
+        ":writeback",
     ],
     deps = [
         ":proxy",
         ":reference",
         ":storage_key",
+        ":writeback",
         "//java/arcs/core/common",
         "//java/arcs/core/crdt",
         "//java/arcs/core/data",
@@ -72,5 +78,14 @@ arcs_kt_library(
     deps = [
         ":storage_key",
         "//java/arcs/core/crdt",
+    ],
+)
+
+arcs_kt_library(
+    name = "writeback",
+    srcs = WRITEBACK_SRCS,
+    deps = [
+        "//third_party/java/androidx/annotation",
+        "//third_party/kotlin/kotlinx_coroutines",
     ],
 )

--- a/java/arcs/core/storage/DirectStore.kt
+++ b/java/arcs/core/storage/DirectStore.kt
@@ -23,7 +23,6 @@ import arcs.core.storage.DirectStore.State.Name.Idle
 import arcs.core.storage.util.RandomProxyCallbackManager
 import arcs.core.util.Random
 import arcs.core.util.TaggedLog
-import java.util.concurrent.Executors
 import kotlin.coroutines.coroutineContext
 import kotlinx.atomicfu.AtomicRef
 import kotlinx.atomicfu.atomic
@@ -43,7 +42,7 @@ class DirectStore<Data : CrdtData, Op : CrdtOperation, T> /* internal */ constru
     /* internal */
     val driver: Driver<Data>
 ) : ActiveStore<Data, Op, T>(options),
-    WriteBack by StoreWriteBack.create(driver.storageKey.protocol, writeBackThreads) {
+    WriteBack by StoreWriteBack.create(driver.storageKey.protocol) {
     override val versionToken: String?
         get() = driver.token
 
@@ -411,11 +410,6 @@ class DirectStore<Data : CrdtData, Op : CrdtOperation, T> /* internal */ constru
     }
 
     companion object {
-        /** The write-back thread pool is shared among all [DirectStore]s. */
-        private val writeBackThreads = Executors.newCachedThreadPool {
-            Thread(it).apply { name = "WriteBack #$id" }
-        }
-
         /**
          * To avoid an infinite loop OMG situation, set a maximum number of update spins for the
          * state machine to something large, but not *infinite*.

--- a/java/arcs/core/storage/DirectStore.kt
+++ b/java/arcs/core/storage/DirectStore.kt
@@ -43,8 +43,7 @@ class DirectStore<Data : CrdtData, Op : CrdtOperation, T> /* internal */ constru
     /* internal */
     val driver: Driver<Data>
 ) : ActiveStore<Data, Op, T>(options),
-    WriteBack by StoreWriteBack.create(driver.storageKey.protocol, writeBackThreads)
-{
+    WriteBack by StoreWriteBack.create(driver.storageKey.protocol, writeBackThreads) {
     override val versionToken: String?
         get() = driver.token
 

--- a/java/arcs/core/storage/DirectStore.kt
+++ b/java/arcs/core/storage/DirectStore.kt
@@ -196,10 +196,7 @@ class DirectStore<Data : CrdtData, Op : CrdtOperation, T> /* internal */ constru
                 throw e
             }
         }
-
-        // As the localModel has already be merged with the pending model changes,
-        // leave the flush job with write-back threads.
-        asyncFlush { updateStateAndAct(noDriverSideChanges, theVersion, messageFromDriver = true) }
+        updateStateAndAct(noDriverSideChanges, theVersion, messageFromDriver = true)
     }
 
     /**

--- a/java/arcs/core/storage/DirectStore.kt
+++ b/java/arcs/core/storage/DirectStore.kt
@@ -43,7 +43,7 @@ class DirectStore<Data : CrdtData, Op : CrdtOperation, T> /* internal */ constru
     /* internal */
     val driver: Driver<Data>
 ) : ActiveStore<Data, Op, T>(options),
-    WriteBack by StoreWriteBack(driver.storageKey.protocol, writeBackThreads)
+    WriteBack by StoreWriteBack.create(driver.storageKey.protocol, writeBackThreads)
 {
     override val versionToken: String?
         get() = driver.token

--- a/java/arcs/core/storage/DirectStore.kt
+++ b/java/arcs/core/storage/DirectStore.kt
@@ -148,7 +148,7 @@ class DirectStore<Data : CrdtData, Op : CrdtOperation, T> /* internal */ constru
 
         deliverCallbacks(modelChange, source = channel)
 
-        // As the localModel has already be applied with new operations and/or merged with
+        // As the localModel has already been applied with new operations and/or merged with
         // new model updates, leave the flush job with write-back threads.
         val noDriverSideChanges = noDriverSideChanges(modelChange, otherChange, false)
         asyncFlush { updateStateAndAct(noDriverSideChanges, version, messageFromDriver = false) }

--- a/java/arcs/core/storage/WriteBack.kt
+++ b/java/arcs/core/storage/WriteBack.kt
@@ -12,6 +12,7 @@
 package arcs.core.storage
 
 import androidx.annotation.VisibleForTesting
+import arcs.core.storage.keys.Protocols
 import java.util.concurrent.ExecutorService
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -71,7 +72,7 @@ class StoreWriteBack private constructor(
     ),
     Mutex by Mutex() {
     // Only apply write-back to physical storage medias.
-    private val passThrough = protocol != "db"
+    private val passThrough = protocol != Protocols.DATABASE_DRIVER
 
     // The number of active flush jobs.
     private var activeJobs = 0

--- a/java/arcs/core/storage/WriteBack.kt
+++ b/java/arcs/core/storage/WriteBack.kt
@@ -12,6 +12,7 @@
 package arcs.core.storage
 
 import androidx.annotation.VisibleForTesting
+import java.util.concurrent.ExecutorService
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.asCoroutineDispatcher
@@ -19,7 +20,6 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import java.util.concurrent.ExecutorService
 
 /**
  * A layer to decouple local data updates and underlying storage layers write-back.
@@ -55,7 +55,7 @@ interface WriteBackFactory {
          * The maximum queue size above which new incoming flush jobs will be suspended.
          */
         queueSize: Int = 10
-    ) : WriteBack
+    ): WriteBack
 }
 
 /** Write-back implementation for Arcs Stores.*/
@@ -68,8 +68,7 @@ class StoreWriteBack private constructor(
     CoroutineScope by CoroutineScope(
         writebackThreads?.asCoroutineDispatcher() ?: Dispatchers.IO
     ),
-    Mutex by Mutex()
-{
+    Mutex by Mutex() {
     // Only apply write-back to physical storage medias.
     private val passThrough = protocol != "db"
 

--- a/java/arcs/core/storage/WriteBack.kt
+++ b/java/arcs/core/storage/WriteBack.kt
@@ -54,8 +54,12 @@ interface WriteBackFactory {
     fun create(
         /** One of supported storage [Protocols]. */
         protocol: String = "",
-        /** The maximum queue size above which new incoming flush jobs will be suspended. */
-        queueSize: Int = Channel.UNLIMITED
+        /**
+         * The maximum queue size above which new incoming flush jobs will be suspended.
+         * By default we take two-steps-ahead policy for the balance between efficiency
+         * and reliability.
+         */
+        queueSize: Int = 1
     ): WriteBack
 }
 

--- a/java/arcs/core/storage/WriteBack.kt
+++ b/java/arcs/core/storage/WriteBack.kt
@@ -99,9 +99,9 @@ class StoreWriteBack private constructor(
                     // Upon cancellation of the write-back scope, change to write-through mode,
                     // consume all pending flush jobs then release all awaitings.
                     passThrough.update { true }
-                    channel.consumeEach { exitFlushSection {
-                        try { it() } catch (_: Exception) {}
-                    }}
+                    channel.consumeEach {
+                        exitFlushSection { try { it() } catch (_: Exception) {} }
+                    }
                     if (awaitSignal.isLocked) awaitSignal.unlock()
                 }
                 .launchIn(scope)

--- a/java/arcs/core/storage/WriteBack.kt
+++ b/java/arcs/core/storage/WriteBack.kt
@@ -99,8 +99,10 @@ open class StoreWriteBack /* internal */ constructor(
                     // Upon cancellation of the write-back scope, change to write-through mode,
                     // consume all pending flush jobs then release all awaitings.
                     passThrough.update { true }
-                    channel.consumeEach {
-                        exitFlushSection { try { it() } catch (_: Exception) {} }
+                    if (!channel.isEmpty && !channel.isClosedForReceive) {
+                        channel.consumeEach {
+                            exitFlushSection { try { it() } catch (_: Exception) {} }
+                        }
                     }
                     if (awaitSignal.isLocked) awaitSignal.unlock()
                 }

--- a/java/arcs/core/storage/WriteBack.kt
+++ b/java/arcs/core/storage/WriteBack.kt
@@ -64,7 +64,7 @@ interface WriteBackFactory {
  * It implements [Mutex] that provides the capability of temporary lock-down and resume.
  */
 @ExperimentalCoroutinesApi
-class StoreWriteBack private constructor(
+open class StoreWriteBack /* internal */ constructor(
     protocol: String,
     queueSize: Int,
     val scope: CoroutineScope?
@@ -146,7 +146,7 @@ class StoreWriteBack private constructor(
         var writeBackFactoryOverride: WriteBackFactory? = null
 
         /** The factory of creating [WriteBack] instances. */
-        override fun create(protocol: String, queueSize: Int) =
+        override fun create(protocol: String, queueSize: Int): WriteBack =
             writeBackFactoryOverride?.create(protocol, queueSize)
                 ?: StoreWriteBack(protocol, queueSize, writeBackScope)
 

--- a/java/arcs/core/storage/WriteBack.kt
+++ b/java/arcs/core/storage/WriteBack.kt
@@ -16,12 +16,15 @@ import kotlinx.atomicfu.atomic
 import kotlinx.atomicfu.update
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.consumeEach
 import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
@@ -56,10 +59,10 @@ interface WriteBackFactory {
         protocol: String = "",
         /**
          * The maximum queue size above which new incoming flush jobs will be suspended.
-         * By default we take two-steps-ahead policy for the balance between efficiency
-         * and reliability.
+         * By default we take the [RendezvousChannel] to implement one-step-ahead policy
+         * for balancing efficiency and reliability.
          */
-        queueSize: Int = 1
+        queueSize: Int = 0
     ): WriteBack
 }
 
@@ -95,9 +98,12 @@ open class StoreWriteBack /* internal */ constructor(
         if (!passThrough.value && scope != null) {
             channel.consumeAsFlow()
                 .onEach {
-                    // Neither black out pending flush jobs in this channel nor propagate
-                    // the exception within the scope to affect flush jobs at other stores.
-                    try { it() } catch (_: Exception) {}
+                    // Ensure the current flush job can actually run till completion even
+                    // if the shared write-back scope was cancelled at `StorageService.onDestroy`
+                    CoroutineScope(scope.coroutineContext + Job()).run {
+                        launch { it() }.join()
+                        cancel()
+                    }
                 }
                 .onCompletion {
                     // Upon cancellation of the write-back scope, change to write-through mode,

--- a/java/arcs/core/storage/WriteBack.kt
+++ b/java/arcs/core/storage/WriteBack.kt
@@ -48,7 +48,8 @@ interface WriteBackFactory {
     fun create(
         protocol: String = "",
         /**
-         * Provide a dedicated write-back thread pool, otherwise just use kotlin I/O dispatchers.
+         * Provide a dedicated write-back thread pool or leave it to implementations to decide
+         * what threads to be designated as the write-backers.
          */
         writebackThreads: ExecutorService? = null,
         /**

--- a/java/arcs/core/storage/WriteBack.kt
+++ b/java/arcs/core/storage/WriteBack.kt
@@ -39,6 +39,7 @@ interface WriteBack {
      * Write-through: flush directly all data updates to the next storage layer.
      */
     suspend fun flush(job: suspend () -> Unit)
+
     /**
      * Write-back: queue up data updates and let write-back threads decide how and
      * when to flush all data updates to the next storage layer.

--- a/java/arcs/core/storage/WriteBack.kt
+++ b/java/arcs/core/storage/WriteBack.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.core.storage
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.consumeEach
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+
+/**
+ * A layer to decouple local data updates and underlying storage layers write-back.
+ *
+ * The modern storage stacks including VFS page dirty write-back, underlying flash drivers
+ * batched-write/flush, etc are all implemented in an efficient way where no data/metadata is
+ * written through to the storage media for every single write operation unless being requested.
+ */
+interface WriteBack {
+    /**
+     * Write-through: block current thread to flush all data updates to the next storage layer.
+     */
+    suspend fun flush(job: suspend () -> Unit)
+    /**
+     * Write-back: queue up data updates and let write-back threads decide how and when to
+     * flush all data updates to the next storage layer.
+     */
+    suspend fun asyncFlush(job: suspend () -> Unit)
+}
+
+/** Write-back implementation for Arcs Stores.*/
+class StoreWriteBack(
+    private val protocol: String = "",
+    /**
+     * Provide a dedicated write-back thread pool, otherwise just use kotlin I/O dispatchers.
+     */
+    private val writebackThreads: ExecutorService? = null,
+    /**
+     * The maximum queue size above which new incoming flush jobs will be suspended.
+     */
+    private val queueSize: Int = 10
+) : WriteBack,
+    Channel<suspend () -> Unit> by Channel(queueSize),
+    CoroutineScope by CoroutineScope(
+        writebackThreads?.asCoroutineDispatcher() ?: Dispatchers.IO
+    ),
+    Mutex by Mutex()
+{
+    // Only apply write-back to physical storage medias.
+    private val passThrough = protocol != "db"
+
+    init {
+        // One of write-back thread(s) will wake up and execute flush jobs in FIFO order
+        // when there are pending flush jobs in queue. Powerful features like batching,
+        // merging, filtering, etc can be implemented at this call-site in the future.
+        if (!passThrough) {
+            launch { consumeEach { it() } }
+        }
+    }
+
+    override suspend fun flush(job: suspend () -> Unit) {
+        if (!passThrough) withLock { job() }
+        else job()
+    }
+
+    override suspend fun asyncFlush(job: suspend () -> Unit) {
+        // Queue up a flush task can run 3x-5x faster than launching it.
+        if (!passThrough) send(job)
+        else job()
+    }
+}

--- a/java/arcs/core/storage/WriteBackForTesting.kt
+++ b/java/arcs/core/storage/WriteBackForTesting.kt
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.core.storage
+
+import arcs.core.util.TaggedLog
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.ExecutorService
+
+/** A [WriteBack] implementation for tests. */
+class WriteBackForTesting private constructor(protocol: String):
+    WriteBack,
+    Channel<suspend () -> Unit> by Channel(10),
+    Mutex by Mutex()
+{
+    private val passThrough = protocol != "db"
+    private var activeJobs = 0
+    private val awaitSignal = Mutex()
+
+    init {
+        track(this)
+        if (!passThrough) {
+            writeBackScope?.launch {
+                try {
+                    while (true) {
+                        exitFlushSection { receive()() }
+                    }
+                } finally {
+                    if (awaitSignal.isLocked) {
+                        awaitSignal.unlock()
+                    }
+                }
+            }
+        }
+    }
+
+    override suspend fun flush(job: suspend () -> Unit) = flushSection { job() }
+
+    override suspend fun asyncFlush(job: suspend () -> Unit) {
+        if (!passThrough && writeBackScope != null) {
+            enterFlushSection { send(job) }
+        } else {
+            flush(job)
+        }
+    }
+
+    override suspend fun awaitIdle() = awaitSignal.withLock {}
+
+    private suspend inline fun flushSection(job: () -> Unit) {
+        enterFlushSection()
+        job()
+        exitFlushSection()
+    }
+
+    private suspend inline fun enterFlushSection(job: () -> Unit = {}) {
+        withLock {
+            if (++activeJobs == 1) awaitSignal.lock()
+            log.debug { "activeJobs: $activeJobs, isLocked: ${awaitSignal.isLocked}" }
+        }
+        job()
+    }
+
+    private suspend inline fun exitFlushSection(job: () -> Unit = {}) {
+        job()
+        withLock {
+            if (--activeJobs == 0) awaitSignal.unlock()
+            log.debug { "activeJobs: $activeJobs, isLocked: ${awaitSignal.isLocked}" }
+        }
+    }
+
+    companion object : WriteBackFactory {
+        /**
+         * To get around the runBlockingTest bug:
+         * java.lang.IllegalStateException: This job has not completed yet
+         * the scope should be overwritten by test classes' [TestCoroutineScope]
+         * instances.
+         *
+         * Reference:
+         * https://medium.com/@eyalg/testing-androidx-room-kotlin-coroutines-2d1faa3e674f
+         */
+        var writeBackScope: CoroutineScope? = null
+
+        private var instances = CopyOnWriteArrayList<WriteBackForTesting>()
+        private val log = TaggedLog(::toString)
+
+        /** Track [WriteBack] instances. */
+        private fun track(instance: WriteBackForTesting) = instances.add(instance)
+
+        /** Clear all created write-back instances after test iteration(s). */
+        fun clear() {
+            instances.clear()
+        }
+
+        /** Await completion of the flush jobs of all created write-back instances. */
+        fun awaitAllIdle() = runBlocking {
+            for (instance in instances) instance.awaitIdle()
+            log.debug { "passed awaitAllIdle()" }
+        }
+
+        override fun create(
+            protocol: String,
+            writebackThreads: ExecutorService?,
+            queueSize: Int
+        ) = WriteBackForTesting(protocol)
+    }
+}

--- a/java/arcs/core/storage/WriteBackForTesting.kt
+++ b/java/arcs/core/storage/WriteBackForTesting.kt
@@ -54,14 +54,14 @@ class WriteBackForTesting private constructor(
         }
     }
 
-    override suspend fun flush(job: suspend () -> Unit) = flushSection { job() }
+    override suspend fun flush(job: suspend () -> Unit) {
+        if (!passThrough) flushSection { job() }
+        else job()
+    }
 
     override suspend fun asyncFlush(job: suspend () -> Unit) {
-        if (!passThrough && writeBackScope != null) {
-            enterFlushSection { send(job) }
-        } else {
-            flush(job)
-        }
+        if (!passThrough && writeBackScope != null) enterFlushSection { send(job) }
+        else job()
     }
 
     override suspend fun awaitIdle() = awaitSignal.withLock {}

--- a/java/arcs/core/storage/WriteBackForTesting.kt
+++ b/java/arcs/core/storage/WriteBackForTesting.kt
@@ -21,7 +21,13 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
-/** A [WriteBack] implementation for tests. */
+/**
+ * A special [WriteBack] implementation for unit tests.
+ *
+ * Specifically it accepts scope/dispatcher being overwritten which is required
+ * at unit tests that are run by runBlockingTest. Furthermore, cross-stores idle
+ * awaiting and logging are supported.
+ */
 class WriteBackForTesting private constructor(
     protocol: String
 ) : WriteBack,
@@ -84,7 +90,7 @@ class WriteBackForTesting private constructor(
 
     companion object : WriteBackFactory {
         /**
-         * To get around the runBlockingTest bug:
+         * To get around the known runBlockingTest issue:
          * java.lang.IllegalStateException: This job has not completed yet
          * the scope should be overwritten by test classes' [TestCoroutineScope]
          * instances.
@@ -105,7 +111,7 @@ class WriteBackForTesting private constructor(
             instances.clear()
         }
 
-        /** Await completion of the flush jobs of all created write-back instances. */
+        /** Await completion of the flush jobs of all created [WriteBack] instances. */
         fun awaitAllIdle() = runBlocking {
             for (instance in instances) instance.awaitIdle()
             log.debug { "passed awaitAllIdle()" }

--- a/java/arcs/core/storage/WriteBackForTesting.kt
+++ b/java/arcs/core/storage/WriteBackForTesting.kt
@@ -12,21 +12,21 @@
 package arcs.core.storage
 
 import arcs.core.util.TaggedLog
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.ExecutorService
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import java.util.concurrent.CopyOnWriteArrayList
-import java.util.concurrent.ExecutorService
 
 /** A [WriteBack] implementation for tests. */
-class WriteBackForTesting private constructor(protocol: String):
-    WriteBack,
+class WriteBackForTesting private constructor(
+    protocol: String
+) : WriteBack,
     Channel<suspend () -> Unit> by Channel(10),
-    Mutex by Mutex()
-{
+    Mutex by Mutex() {
     private val passThrough = protocol != "db"
     private var activeJobs = 0
     private val awaitSignal = Mutex()

--- a/java/arcs/core/storage/keys/BUILD
+++ b/java/arcs/core/storage/keys/BUILD
@@ -7,20 +7,20 @@ licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])
 
-PROTOCL_SRCS = [
+PROTOCOL_SRCS = [
     "Protocols.kt",
 ]
 
 arcs_kt_library(
     name = "protocols",
-    srcs = PROTOCL_SRCS,
+    srcs = PROTOCOL_SRCS,
 )
 
 arcs_kt_library(
     name = "keys",
     srcs = glob(
         ["*.kt"],
-        exclude = PROTOCL_SRCS,
+        exclude = PROTOCOL_SRCS,
     ),
     deps = [
         ":protocols",

--- a/java/arcs/core/storage/keys/BUILD
+++ b/java/arcs/core/storage/keys/BUILD
@@ -7,10 +7,23 @@ licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])
 
+PROTOCL_SRCS = [
+    "Protocols.kt",
+]
+
+arcs_kt_library(
+    name = "protocols",
+    srcs = PROTOCL_SRCS,
+)
+
 arcs_kt_library(
     name = "keys",
-    srcs = glob(["*.kt"]),
+    srcs = glob(
+        ["*.kt"],
+        exclude = PROTOCL_SRCS,
+    ),
     deps = [
+        ":protocols",
         "//java/arcs/core/common",
         "//java/arcs/core/data",
         "//java/arcs/core/storage",

--- a/java/arcs/core/storage/keys/DatabaseStorageKey.kt
+++ b/java/arcs/core/storage/keys/DatabaseStorageKey.kt
@@ -17,10 +17,10 @@ import arcs.core.storage.StorageKey
 import arcs.core.storage.StorageKeyParser
 
 /** Protocol to be used with the database driver for persistent databases. */
-const val DATABASE_DRIVER_PROTOCOL = "db"
+const val DATABASE_DRIVER_PROTOCOL = Protocols.DATABASE_DRIVER
 
 /** Protocol to be used with the database driver for in-memory databases. */
-const val MEMORY_DATABASE_DRIVER_PROTOCOL = "memdb"
+const val MEMORY_DATABASE_DRIVER_PROTOCOL = Protocols.MEMORY_DATABASE_DRIVER
 
 /**
  * Default database name for DatabaseDriver usage, and referencing using [DatabaseStorageKey]s.

--- a/java/arcs/core/storage/keys/Protocols.kt
+++ b/java/arcs/core/storage/keys/Protocols.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.core.storage.keys
+
+/** All supported Arcs storage protocols. */
+object Protocols {
+    /** Protocol to be used with the database driver */
+    const val DATABASE_DRIVER = "db"
+
+    /** Protocol to be used with the database driver for in-memory databases. */
+    const val MEMORY_DATABASE_DRIVER = "memdb"
+
+    /** Protocol to be used with the ramdisk driver. */
+    const val RAMDISK_DRIVER = "ramdisk"
+
+    /** Protocol to be used with the volatile driver. */
+    const val VOLATILE_DRIVER = "volatile"
+}

--- a/java/arcs/core/storage/keys/RamDiskStorageKey.kt
+++ b/java/arcs/core/storage/keys/RamDiskStorageKey.kt
@@ -17,7 +17,7 @@ import arcs.core.storage.StorageKey
 import arcs.core.storage.StorageKeyParser
 
 /** Protocol to be used with the ramdisk driver. */
-const val RAMDISK_DRIVER_PROTOCOL = "ramdisk"
+const val RAMDISK_DRIVER_PROTOCOL = Protocols.RAMDISK_DRIVER
 
 /** Storage key for a piece of data managed by the ramdisk driver. */
 data class RamDiskStorageKey(private val unique: String) : StorageKey(RAMDISK_DRIVER_PROTOCOL) {

--- a/java/arcs/core/storage/keys/VolatileStorageKey.kt
+++ b/java/arcs/core/storage/keys/VolatileStorageKey.kt
@@ -18,7 +18,7 @@ import arcs.core.storage.StorageKey
 import arcs.core.storage.StorageKeyParser
 
 /** Protocol to be used with the volatile driver. */
-const val VOLATILE_DRIVER_PROTOCOL = "volatile"
+const val VOLATILE_DRIVER_PROTOCOL = Protocols.VOLATILE_DRIVER
 
 /** Storage key for a piece of data kept in the volatile driver. */
 data class VolatileStorageKey(

--- a/java/arcs/core/storage/testutil/BUILD
+++ b/java/arcs/core/storage/testutil/BUILD
@@ -11,6 +11,7 @@ arcs_kt_jvm_library(
     deps = [
         "//java/arcs/core/storage:storage_key",
         "//java/arcs/core/storage:writeback",
+        "//java/arcs/core/storage/keys:protocols",
         "//java/arcs/core/util",
         "//third_party/kotlin/kotlinx_coroutines:kotlinx_coroutines_test",
     ],

--- a/java/arcs/core/storage/testutil/BUILD
+++ b/java/arcs/core/storage/testutil/BUILD
@@ -10,5 +10,8 @@ arcs_kt_jvm_library(
     srcs = glob(["*.kt"]),
     deps = [
         "//java/arcs/core/storage:storage_key",
+        "//java/arcs/core/storage:writeback",
+        "//java/arcs/core/util",
+        "//third_party/kotlin/kotlinx_coroutines:kotlinx_coroutines_test",
     ],
 )

--- a/java/arcs/core/storage/testutil/BUILD
+++ b/java/arcs/core/storage/testutil/BUILD
@@ -13,6 +13,7 @@ arcs_kt_jvm_library(
         "//java/arcs/core/storage:writeback",
         "//java/arcs/core/storage/keys:protocols",
         "//java/arcs/core/util",
+        "//third_party/kotlin/kotlinx_coroutines",
         "//third_party/kotlin/kotlinx_coroutines:kotlinx_coroutines_test",
     ],
 )

--- a/java/arcs/core/storage/testutil/WriteBackForTesting.kt
+++ b/java/arcs/core/storage/testutil/WriteBackForTesting.kt
@@ -32,8 +32,8 @@ import kotlinx.coroutines.test.TestCoroutineScope
  * Specifically it implements the identical logics as [StoreWriteBack]s' but
  * allows scope/dispatcher being designated which is required for unit tests
  * who are annotated by `@Test` since no addtional coroutine Jobs are allowed
- * alive and checked after each test iteration, the check blocks the test for
- * good till a timeout.
+ * active and checked after each test iteration, such a check blocks the test
+ * till a timeout.
  *
  * E.g., runBlockingTest exception:
  * java.lang.IllegalStateException: This job has not completed yet

--- a/java/arcs/core/storage/testutil/WriteBackForTesting.kt
+++ b/java/arcs/core/storage/testutil/WriteBackForTesting.kt
@@ -127,7 +127,6 @@ class WriteBackForTesting private constructor(
 
         override fun create(
             protocol: String,
-            writebackThreads: ExecutorService?,
             queueSize: Int
         ) = WriteBackForTesting(protocol)
     }

--- a/java/arcs/core/storage/testutil/WriteBackForTesting.kt
+++ b/java/arcs/core/storage/testutil/WriteBackForTesting.kt
@@ -13,6 +13,7 @@ package arcs.core.storage.testutil
 
 import arcs.core.storage.WriteBack
 import arcs.core.storage.WriteBackFactory
+import arcs.core.storage.keys.Protocols
 import arcs.core.util.TaggedLog
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.ExecutorService
@@ -47,7 +48,7 @@ class WriteBackForTesting private constructor(
 ) : WriteBack,
     Channel<suspend () -> Unit> by Channel(10),
     Mutex by Mutex() {
-    private val passThrough = protocol != "db"
+    private val passThrough = protocol != Protocols.DATABASE_DRIVER
     private var activeJobs = 0
     private val awaitSignal = Mutex()
 

--- a/java/arcs/core/storage/testutil/WriteBackForTesting.kt
+++ b/java/arcs/core/storage/testutil/WriteBackForTesting.kt
@@ -16,7 +16,6 @@ import arcs.core.storage.WriteBackFactory
 import arcs.core.storage.keys.Protocols
 import arcs.core.util.TaggedLog
 import java.util.concurrent.CopyOnWriteArrayList
-import java.util.concurrent.ExecutorService
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.launch

--- a/java/arcs/core/storage/testutil/WriteBackForTesting.kt
+++ b/java/arcs/core/storage/testutil/WriteBackForTesting.kt
@@ -30,11 +30,11 @@ import kotlinx.coroutines.test.TestCoroutineScope
  *
  * Specifically it implements the identical logics as [StoreWriteBack]s' but
  * allows scope/dispatcher being designated which is required for unit tests
- * which are annotated by @Test since no addtional coroutine Jobs are allowed
- * alive which is checked post each test, the check blocks the test itself for
+ * who are annotated by `@Test` since no addtional coroutine Jobs are allowed
+ * alive and checked after each test iteration, the check blocks the test for
  * good till a timeout.
  *
- * An example of runBlockingTest exception:
+ * E.g., runBlockingTest exception:
  * java.lang.IllegalStateException: This job has not completed yet
  * The workaround is configuring coroutine scope to [TestCoroutineScope]
  *

--- a/java/arcs/sdk/android/storage/service/StorageService.kt
+++ b/java/arcs/sdk/android/storage/service/StorageService.kt
@@ -40,6 +40,7 @@ import arcs.core.util.performance.PerformanceStatistics
 import java.io.FileDescriptor
 import java.io.PrintWriter
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
@@ -48,7 +49,6 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.runBlocking
-import java.util.concurrent.Executors
 
 /**
  * Implementation of a [Service] which manages [Store]s and exposes the ability to access them via

--- a/java/arcs/sdk/android/storage/service/StorageService.kt
+++ b/java/arcs/sdk/android/storage/service/StorageService.kt
@@ -46,6 +46,7 @@ import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.runBlocking
@@ -60,7 +61,7 @@ class StorageService : ResurrectorService() {
     private val writeBackScope = CoroutineScope(
         Executors.newCachedThreadPool {
             Thread(it).apply { name = "WriteBack #$id" }
-        }.asCoroutineDispatcher()
+        }.asCoroutineDispatcher() + SupervisorJob()
     )
     private val stores = ConcurrentHashMap<StorageKey, Store<*, *, *>>()
     private var startTime: Long? = null

--- a/javatests/arcs/android/entity/BUILD
+++ b/javatests/arcs/android/entity/BUILD
@@ -19,6 +19,7 @@ arcs_kt_android_test_suite(
         "//java/arcs/core/storage/api",
         "//java/arcs/core/storage/keys",
         "//java/arcs/core/storage/referencemode",
+        "//java/arcs/core/storage/testutil",
         "//java/arcs/core/util",
         "//java/arcs/core/util/testutil",
         "//java/arcs/jvm/host",

--- a/javatests/arcs/android/entity/TtlHandleTest.kt
+++ b/javatests/arcs/android/entity/TtlHandleTest.kt
@@ -15,6 +15,8 @@ import arcs.core.entity.SchemaRegistry
 import arcs.core.entity.awaitReady
 import arcs.core.host.EntityHandleManager
 import arcs.core.storage.StorageKey
+import arcs.core.storage.StoreWriteBack
+import arcs.core.storage.WriteBackForTesting
 import arcs.core.storage.api.DriverAndKeyConfigurator
 import arcs.core.storage.keys.DatabaseStorageKey
 import arcs.core.storage.referencemode.ReferenceModeStorageKey
@@ -55,7 +57,7 @@ class TtlHandleTest {
     )
     private lateinit var databaseManager: AndroidSqliteDatabaseManager
     private lateinit var fakeTime: FakeTime
-    
+
     private lateinit var scheduler: Scheduler
     private val handleManager: EntityHandleManager
         // Create a new handle manager on each call, to check different storage proxies.

--- a/javatests/arcs/android/entity/TtlHandleTest.kt
+++ b/javatests/arcs/android/entity/TtlHandleTest.kt
@@ -16,10 +16,10 @@ import arcs.core.entity.awaitReady
 import arcs.core.host.EntityHandleManager
 import arcs.core.storage.StorageKey
 import arcs.core.storage.StoreWriteBack
-import arcs.core.storage.WriteBackForTesting
 import arcs.core.storage.api.DriverAndKeyConfigurator
 import arcs.core.storage.keys.DatabaseStorageKey
 import arcs.core.storage.referencemode.ReferenceModeStorageKey
+import arcs.core.storage.testutil.WriteBackForTesting
 import arcs.core.util.Scheduler
 import arcs.core.util.testutil.LogRule
 import arcs.jvm.host.JvmSchedulerProvider
@@ -57,7 +57,6 @@ class TtlHandleTest {
         backingKey = backingKey,
         storageKey = DatabaseStorageKey.Persistent("singleton", DummyEntity.SCHEMA_HASH)
     )
-    private val testScope = TestCoroutineScope(TestCoroutineDispatcher())
     private lateinit var databaseManager: AndroidSqliteDatabaseManager
     private lateinit var fakeTime: FakeTime
     private lateinit var scheduler: Scheduler
@@ -73,7 +72,6 @@ class TtlHandleTest {
         fakeTime = FakeTime()
         scheduler = schedulerProvider("myArc")
         databaseManager = AndroidSqliteDatabaseManager(ApplicationProvider.getApplicationContext())
-        WriteBackForTesting.writeBackScope = testScope
         StoreWriteBack.writeBackFactoryOverride = WriteBackForTesting
         DriverAndKeyConfigurator.configure(databaseManager)
         SchemaRegistry.register(DummyEntity)

--- a/javatests/arcs/android/entity/TtlHandleTest.kt
+++ b/javatests/arcs/android/entity/TtlHandleTest.kt
@@ -29,8 +29,6 @@ import kotlin.coroutines.EmptyCoroutineContext
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.TestCoroutineDispatcher
-import kotlinx.coroutines.test.TestCoroutineScope
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import org.junit.After

--- a/javatests/arcs/android/storage/BUILD
+++ b/javatests/arcs/android/storage/BUILD
@@ -26,6 +26,7 @@ arcs_kt_android_test_suite(
         "//java/arcs/core/storage/driver",
         "//java/arcs/core/storage/keys",
         "//java/arcs/core/storage/referencemode",
+        "//java/arcs/core/storage/testutil",
         "//java/arcs/core/util",
         "//java/arcs/core/util/testutil",
         "//java/arcs/jvm/util",

--- a/javatests/arcs/android/storage/ReferenceModeStoreDatabaseImplIntegrationTest.kt
+++ b/javatests/arcs/android/storage/ReferenceModeStoreDatabaseImplIntegrationTest.kt
@@ -35,7 +35,6 @@ import arcs.core.storage.ReferenceModeStore
 import arcs.core.storage.StorageMode
 import arcs.core.storage.StoreOptions
 import arcs.core.storage.StoreWriteBack
-import arcs.core.storage.WriteBackForTesting
 import arcs.core.storage.database.DatabaseData
 import arcs.core.storage.driver.DatabaseDriver
 import arcs.core.storage.driver.DatabaseDriverProvider
@@ -44,14 +43,13 @@ import arcs.core.storage.referencemode.RefModeStoreData
 import arcs.core.storage.referencemode.RefModeStoreOp
 import arcs.core.storage.referencemode.RefModeStoreOutput
 import arcs.core.storage.referencemode.ReferenceModeStorageKey
+import arcs.core.storage.testutil.WriteBackForTesting
 import arcs.core.storage.toReference
 import arcs.core.util.testutil.LogRule
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.test.TestCoroutineDispatcher
-import kotlinx.coroutines.test.TestCoroutineScope
 import kotlinx.coroutines.test.runBlockingTest
 import org.junit.After
 import org.junit.Before
@@ -79,14 +77,12 @@ class ReferenceModeStoreDatabaseImplIntegrationTest {
         ),
         hash
     )
-    private val testScope = TestCoroutineScope(TestCoroutineDispatcher())
     private lateinit var databaseFactory: AndroidSqliteDatabaseManager
 
     @Before
     fun setUp() = runBlockingTest {
         DriverFactory.clearRegistrations()
         databaseFactory = AndroidSqliteDatabaseManager(ApplicationProvider.getApplicationContext())
-        WriteBackForTesting.writeBackScope = testScope
         StoreWriteBack.writeBackFactoryOverride = WriteBackForTesting
         DatabaseDriverProvider.configure(databaseFactory) { schema }
     }

--- a/javatests/arcs/android/storage/service/BUILD
+++ b/javatests/arcs/android/storage/service/BUILD
@@ -25,6 +25,7 @@ arcs_kt_android_test_suite(
         "//java/arcs/core/storage/driver",
         "//java/arcs/core/storage/keys",
         "//java/arcs/core/storage/referencemode",
+        "//java/arcs/core/storage/testutil",
         "//java/arcs/core/util",
         "//java/arcs/jvm/host",
         "//java/arcs/jvm/util/testutil",

--- a/javatests/arcs/android/storage/service/StorageServiceManagerTest.kt
+++ b/javatests/arcs/android/storage/service/StorageServiceManagerTest.kt
@@ -22,6 +22,8 @@ import arcs.core.entity.ReadWriteSingletonHandle
 import arcs.core.entity.SchemaRegistry
 import arcs.core.entity.awaitReady
 import arcs.core.host.EntityHandleManager
+import arcs.core.storage.StoreWriteBack
+import arcs.core.storage.WriteBackForTesting
 import arcs.core.storage.keys.DatabaseStorageKey
 import arcs.core.storage.referencemode.ReferenceModeStorageKey
 import arcs.core.util.Time
@@ -32,6 +34,8 @@ import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.TestCoroutineScope
 import kotlinx.coroutines.test.runBlockingTest
 import kotlinx.coroutines.withContext
 import org.junit.Before
@@ -50,9 +54,12 @@ class StorageServiceManagerTest {
         time = time,
         scheduler = JvmSchedulerProvider(EmptyCoroutineContext).invoke("test")
     )
+    private val testScope = TestCoroutineScope(TestCoroutineDispatcher())
 
     @Before
     fun setUp() {
+        WriteBackForTesting.writeBackScope = testScope
+        StoreWriteBack.writeBackFactoryOverride = WriteBackForTesting
         AndroidDriverAndKeyConfigurator.configure(ApplicationProvider.getApplicationContext())
         SchemaRegistry.register(DummyEntity)
     }

--- a/javatests/arcs/android/storage/service/StorageServiceManagerTest.kt
+++ b/javatests/arcs/android/storage/service/StorageServiceManagerTest.kt
@@ -34,8 +34,6 @@ import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.TestCoroutineDispatcher
-import kotlinx.coroutines.test.TestCoroutineScope
 import kotlinx.coroutines.test.runBlockingTest
 import kotlinx.coroutines.withContext
 import org.junit.Before

--- a/javatests/arcs/android/storage/service/StorageServiceManagerTest.kt
+++ b/javatests/arcs/android/storage/service/StorageServiceManagerTest.kt
@@ -23,9 +23,9 @@ import arcs.core.entity.SchemaRegistry
 import arcs.core.entity.awaitReady
 import arcs.core.host.EntityHandleManager
 import arcs.core.storage.StoreWriteBack
-import arcs.core.storage.WriteBackForTesting
 import arcs.core.storage.keys.DatabaseStorageKey
 import arcs.core.storage.referencemode.ReferenceModeStorageKey
+import arcs.core.storage.testutil.WriteBackForTesting
 import arcs.core.util.Time
 import arcs.jvm.host.JvmSchedulerProvider
 import arcs.jvm.util.testutil.FakeTime
@@ -54,11 +54,9 @@ class StorageServiceManagerTest {
         time = time,
         scheduler = JvmSchedulerProvider(EmptyCoroutineContext).invoke("test")
     )
-    private val testScope = TestCoroutineScope(TestCoroutineDispatcher())
 
     @Before
     fun setUp() {
-        WriteBackForTesting.writeBackScope = testScope
         StoreWriteBack.writeBackFactoryOverride = WriteBackForTesting
         AndroidDriverAndKeyConfigurator.configure(ApplicationProvider.getApplicationContext())
         SchemaRegistry.register(DummyEntity)

--- a/javatests/arcs/core/entity/DifferentHandleManagerDifferentStoresTest.kt
+++ b/javatests/arcs/core/entity/DifferentHandleManagerDifferentStoresTest.kt
@@ -2,6 +2,8 @@ package arcs.core.entity
 
 import arcs.core.host.EntityHandleManager
 import arcs.core.storage.StoreManager
+import arcs.core.storage.StoreWriteBack
+import arcs.core.storage.testutil.WriteBackForTesting
 import arcs.jvm.host.JvmSchedulerProvider
 import kotlin.coroutines.EmptyCoroutineContext
 import org.junit.After
@@ -16,6 +18,7 @@ class DifferentHandleManagerDifferentStoresTest : HandleManagerTestBase() {
     @Before
     override fun setUp() {
         super.setUp()
+        StoreWriteBack.writeBackFactoryOverride = WriteBackForTesting
         schedulerProvider = JvmSchedulerProvider(EmptyCoroutineContext)
         readHandleManager = EntityHandleManager(
             arcId = "testArcId",

--- a/javatests/arcs/core/entity/DifferentHandleManagerTest.kt
+++ b/javatests/arcs/core/entity/DifferentHandleManagerTest.kt
@@ -2,6 +2,8 @@ package arcs.core.entity
 
 import arcs.core.host.EntityHandleManager
 import arcs.core.storage.StoreManager
+import arcs.core.storage.StoreWriteBack
+import arcs.core.storage.testutil.WriteBackForTesting
 import arcs.jvm.host.JvmSchedulerProvider
 import kotlin.coroutines.EmptyCoroutineContext
 import org.junit.After
@@ -21,6 +23,7 @@ class DifferentHandleManagerTest : HandleManagerTestBase() {
         super.setUp()
         val stores = StoreManager()
         i++
+        StoreWriteBack.writeBackFactoryOverride = WriteBackForTesting
         schedulerProvider = JvmSchedulerProvider(EmptyCoroutineContext)
         readHandleManager = EntityHandleManager(
             arcId = "testArc",

--- a/javatests/arcs/core/entity/SameHandleManagerTest.kt
+++ b/javatests/arcs/core/entity/SameHandleManagerTest.kt
@@ -2,6 +2,8 @@ package arcs.core.entity
 
 import arcs.core.host.EntityHandleManager
 import arcs.core.storage.StoreManager
+import arcs.core.storage.StoreWriteBack
+import arcs.core.storage.testutil.WriteBackForTesting
 import arcs.jvm.host.JvmSchedulerProvider
 import kotlin.coroutines.EmptyCoroutineContext
 import org.junit.After
@@ -15,6 +17,7 @@ class SameHandleManagerTest : HandleManagerTestBase() {
     @Before
     override fun setUp() {
         super.setUp()
+        StoreWriteBack.writeBackFactoryOverride = WriteBackForTesting
         schedulerProvider = JvmSchedulerProvider(EmptyCoroutineContext)
         readHandleManager = EntityHandleManager(
             arcId = "testArc",

--- a/javatests/arcs/core/storage/ReferenceModeStoreDatabaseIntegrationTest.kt
+++ b/javatests/arcs/core/storage/ReferenceModeStoreDatabaseIntegrationTest.kt
@@ -24,7 +24,6 @@ import arcs.core.data.SchemaFields
 import arcs.core.data.SchemaName
 import arcs.core.data.util.toReferencable
 import arcs.core.storage.StoreWriteBack
-import arcs.core.storage.WriteBackForTesting
 import arcs.core.storage.database.DatabaseData
 import arcs.core.storage.driver.DatabaseDriver
 import arcs.core.storage.driver.DatabaseDriverProvider
@@ -33,14 +32,13 @@ import arcs.core.storage.referencemode.RefModeStoreData
 import arcs.core.storage.referencemode.RefModeStoreOp
 import arcs.core.storage.referencemode.RefModeStoreOutput
 import arcs.core.storage.referencemode.ReferenceModeStorageKey
+import arcs.core.storage.testutil.WriteBackForTesting
 import arcs.core.util.testutil.LogRule
 import arcs.jvm.storage.database.testutil.FakeDatabaseManager
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.test.TestCoroutineDispatcher
-import kotlinx.coroutines.test.TestCoroutineScope
 import kotlinx.coroutines.test.runBlockingTest
 import org.junit.After
 import org.junit.Before
@@ -69,14 +67,12 @@ class ReferenceModeStoreDatabaseIntegrationTest {
         ),
         hash
     )
-    private val testScope = TestCoroutineScope(TestCoroutineDispatcher())
     private lateinit var databaseFactory: FakeDatabaseManager
 
     @Before
     fun setUp() = runBlockingTest {
         DriverFactory.clearRegistrations()
         databaseFactory = FakeDatabaseManager()
-        WriteBackForTesting.writeBackScope = testScope
         StoreWriteBack.writeBackFactoryOverride = WriteBackForTesting
         DatabaseDriverProvider.configure(databaseFactory) { schema }
     }


### PR DESCRIPTION
The modern storage stacks including VFS page dirty write-back, io-scheduler
merging and re-ordering, flash device turbo-write and/or buffer flush, etc
are all implemented in an efficient way where data/metadata is sent to the next
storage layer by dedicated flushers, writebackers, data-movers, etc.

The notion improves the latency and parallelism of both Backing and Container stores.
It saves us 25+ ms for every write-to-read trip.