### PR TITLE
Revert "Update Kotlin-Native repo hashes for 1.3.70"

### DIFF
--- a/build_defs/kotlin_native/build_defs.bzl
+++ b/build_defs/kotlin_native/build_defs.bzl
@@ -23,7 +23,7 @@ def _common_args(ctx, klibs):
         # Enable optimizations in the compilation
         "-opt",
         # Don't link the libraries from the dist/klib automatically
-        "-no-default-libs",
+        "-nodefaultlibs",
     ])
 
     args.add_all(klibs, before_each = "-l")
@@ -116,7 +116,7 @@ kt_wasm_library = rule(
     attrs = {
         "srcs": attr.label_list(
             allow_files = True,
-            allow_empty = False,
+            allow_empty = True,
         ),
         "deps": attr.label_list(providers = [KtNativeInfo]),
         "kotlinc_wrapper": attr.label(

--- a/build_defs/kotlin_native/kotlinc_wrapper.sh
+++ b/build_defs/kotlin_native/kotlinc_wrapper.sh
@@ -2,7 +2,15 @@
 # Script to run the Kotlin Native Compiler.
 # Expects a comma-delimited list of dependency files as a first argument.
 # The rest of the arguments are passed in to the `kotlinc` compiler.
-set -e
+
+
+# Create directory if it doesn't exist
+soft_mkdir() {
+  if [ ! -d "$1" ]; then
+   mkdir $1
+  fi
+}
+
 
 # Create file if it doesn't exist
 soft_touch() {
@@ -39,7 +47,7 @@ set +f
 DEPENDENCIES=${_ALL_DEPS[idx]}
 
 
-repo_rel="${BASH_SOURCE[0]}.runfiles/kotlin_native_$PLATFORM/kotlin-native-$PLATFORM-1.3.70"
+repo_rel="${BASH_SOURCE[0]}.runfiles/kotlin_native_$PLATFORM/kotlin-native-$PLATFORM-1.3.50"
 repo=$(python -c '
 import sys
 import os.path
@@ -54,9 +62,9 @@ print(os.path.abspath(sys.argv[1]))' "$konan_deps")
 # Space for setting up required environment variables
 
 
-mkdir -p "$deps/dependencies"
+soft_mkdir "$deps/dependencies"
 soft_touch "$deps/dependencies/.extracted"
-mkdir -p "$deps/cache"
+soft_mkdir "$deps/cache"
 soft_touch "$deps/cache/.lock"
 export KONAN_DATA_DIR="$deps"
 

--- a/build_defs/kotlin_native/repo.bzl
+++ b/build_defs/kotlin_native/repo.bzl
@@ -1,8 +1,6 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-# Release can be found at: https://github.com/JetBrains/kotlin/releases/tag/v<version>
-# For example, this version is located at: https://github.com/JetBrains/kotlin/releases/tag/v1.3.70
-_kotlin_native_version = "1.3.70"
+_kotlin_native_version = "1.3.50"
 
 _repo_tmpl = _kotlin_native_version.join([
     "https://github.com/JetBrains/kotlin/releases/download/v",
@@ -10,10 +8,6 @@ _repo_tmpl = _kotlin_native_version.join([
     ".{ext}",
 ])
 
-# `http_archives` expect a sha256 of the artifacts: https://docs.bazel.build/versions/0.17.1/be/workspace.html#http_archive.sha256
-# These can be calculated with https://linux.die.net/man/1/sha256sum on the artifacts from the Bintray repository:
-# https://bintray.com/package/files/jetbrains/kotlin-native-dependencies/dependencies
-# These are typically slow to change.
 _WINDOWS_DEPENDENCIES = [
     ("libffi-3.2.1-mingw-w64-x86-64", "2047faedec4ca6bc074e12642ecf3a14545cbb248224ef3637965714d7e7ea5f"),
     ("msys2-mingw-w64-x86_64-gcc-7.3.0-clang-llvm-lld-6.0.1", "931131ae6545bc8afc497281cbd0a2c39eb2c067f3bfac53a993886fa00ba131"),
@@ -35,26 +29,24 @@ _LINUX_DEPENDENCIES = [
     ("target-sysroot-2-wasm", "039958041b364458d652237aaa06c12b89973ef0934819cca9d47299f1a76b64"),
 ]
 
-# `http_archives` expect a sha256 of the artifacts: https://docs.bazel.build/versions/0.17.1/be/workspace.html#http_archive.sha256
-# These can be calculated with https://linux.die.net/man/1/sha256sum on the artifacts from the Github release page (see above).
 PLATFORMS = {
     "windows": {
         "platform": "windows",
         "ext": "zip",
         "deps": _WINDOWS_DEPENDENCIES,
-        "sha": "13b622aa414c230df8939b3a75d11c9e748660869cfc94a76625d7d52b412e17",
+        "sha": "2eed825696fcae19c49d3a32ee5a43971dd4992c2ce99a9a2be6e88334bcf875",
     },
     "macos": {
         "platform": "macos",
         "ext": "tar.gz",
         "deps": _MACOS_DEPENDENCIES,
-        "sha": "c189f26e70ff5617700ea8a3ddc8dcf3dc9c8f80413e005e2cef61c50d6d24d5",
+        "sha": "100920f1a3352846bc5a2990c87cb71f221abf8261251632ad10c6459d962393",
     },
     "linux": {
         "platform": "linux",
         "ext": "tar.gz",
         "deps": _LINUX_DEPENDENCIES,
-        "sha": "6b89467068be9a0f8197652bc0135c83bdbec0cb2d930763c3308b470982e8e0",
+        "sha": "15eb0589aef8dcb435e4cb04ef9a3ad90b8d936118b491618a70912cef742874",
     },
 }
 


### PR DESCRIPTION
Reverts PolymerLabs/arcs#5198

Reverting for now, will debug the internal / external rules difference in the meantime. 