### PR TITLE
Renamed backing storage stack

### DIFF
--- a/src/runtime/api-channel.ts
+++ b/src/runtime/api-channel.ts
@@ -28,8 +28,8 @@ import {NoTraceWithReason, SystemTrace} from '../tracelib/systrace.js';
 import {workerPool} from './worker-pool.js';
 import {Ttl} from './recipe/ttl.js';
 import {Handle} from './storageNG/handle.js';
-import {BackingStore} from './storageNG/backing-store.js';
-import {BackingStorageProxy} from './storageNG/backing-storage-proxy.js';
+import {DirectStoreMuxer} from './storageNG/direct-store-muxer.js';
+import {StorageProxyMuxer} from './storageNG/storage-proxy-muxer.js';
 
 type StorageProxy = StorageProxyNG<CRDTTypeRecord>;
 
@@ -540,14 +540,14 @@ export abstract class PECOuterPort extends APIPort {
   AwaitIdle(@Direct version: number) {}
 
   abstract onRegister(handle: Store<CRDTTypeRecord>, messagesCallback: number, idCallback: number);
-  abstract onBackingRegister(handle: BackingStore<CRDTTypeRecord>, messagesCallback: number, idCallback: number);
+  abstract onDirectStoreMuxerRegister(handle: DirectStoreMuxer<CRDTTypeRecord>, messagesCallback: number, idCallback: number);
   abstract onProxyMessage(handle: Store<CRDTTypeRecord>, message: ProxyMessage<CRDTTypeRecord>, callback: number);
-  abstract onBackingProxyMessage(handle: BackingStore<CRDTTypeRecord>, message: ProxyMessage<CRDTTypeRecord>, callback: number);
+  abstract onStorageProxyMuxerMessage(handle: DirectStoreMuxer<CRDTTypeRecord>, message: ProxyMessage<CRDTTypeRecord>, callback: number);
 
   abstract onIdle(version: number, relevance: Map<recipeParticle.Particle, number[]>);
 
-  abstract onGetBackingStore(callback: number, storageKey: string, type: Type);
-  GetBackingStoreCallback(@Initializer store: BackingStore<CRDTTypeRecord>, @RemoteMapped callback: number, @ByLiteral(Type) type: Type, @Direct name: string, @Identifier @Direct id: string, @Direct storageKey: string) {}
+  abstract onGetDirectStoreMuxer(callback: number, storageKey: string, type: Type);
+  GetDirectStoreMuxerCallback(@Initializer store: DirectStoreMuxer<CRDTTypeRecord>, @RemoteMapped callback: number, @ByLiteral(Type) type: Type, @Direct name: string, @Identifier @Direct id: string, @Direct storageKey: string) {}
 
   abstract onConstructInnerArc(callback: number, particle: recipeParticle.Particle);
   ConstructArcCallback(@RemoteMapped callback: number, @LocalMapped arc: {}) {}
@@ -602,17 +602,17 @@ export abstract class PECInnerPort extends APIPort {
     @Mapped handle: StorageProxy,
     @LocalMapped messagesCallback: ProxyCallback<CRDTTypeRecord>,
     @LocalMapped idCallback: Consumer<number>): void {}
-  BackingRegister(
-    @Mapped handle: BackingStorageProxy<CRDTTypeRecord>,
+  DirectStoreMuxerRegister(
+    @Mapped handle: StorageProxyMuxer<CRDTTypeRecord>,
     @LocalMapped messagesCallback: ProxyCallback<CRDTTypeRecord>,
     @LocalMapped idCallback: Consumer<number>): void {}
   ProxyMessage(@Mapped handle: StorageProxy, @Direct message: ProxyMessage<CRDTTypeRecord>): void {}
-  BackingProxyMessage(@Mapped handle: BackingStorageProxy<CRDTTypeRecord>, @Direct message: ProxyMessage<CRDTTypeRecord>): void {}
+  StorageProxyMuxerMessage(@Mapped handle: StorageProxyMuxer<CRDTTypeRecord>, @Direct message: ProxyMessage<CRDTTypeRecord>): void {}
 
   Idle(@Direct version: number, @ObjectMap(MappingType.Mapped, MappingType.Direct) relevance: Map<Particle, number[]>) {}
 
-  GetBackingStore(@LocalMapped callback: (proxy: BackingStorageProxy<CRDTTypeRecord>, key: string) => void, @Direct storageKey: string, @ByLiteral(Type) type: Type) {}
-  abstract onGetBackingStoreCallback(callback: (proxy: BackingStorageProxy<CRDTTypeRecord>, key: string) => void, type: Type, name: string, id: string, storageKey: string);
+  GetDirectStoreMuxer(@LocalMapped callback: (proxy: StorageProxyMuxer<CRDTTypeRecord>, key: string) => void, @Direct storageKey: string, @ByLiteral(Type) type: Type) {}
+  abstract onGetDirectStoreMuxerCallback(callback: (proxy: StorageProxyMuxer<CRDTTypeRecord>, key: string) => void, type: Type, name: string, id: string, storageKey: string);
 
   ConstructInnerArc(@LocalMapped callback: Consumer<string>, @Mapped particle: Particle) {}
   abstract onConstructArcCallback(callback: Consumer<string>, arc: string);

--- a/src/runtime/channel-constructor.ts
+++ b/src/runtime/channel-constructor.ts
@@ -19,7 +19,7 @@ import {PropagatedException} from './arc-exceptions.js';
  * that allows new storage stacks to be established.
  */
 export interface ChannelConstructor {
-  getBackingStorageProxy(storageKey: string | StorageKey, type: Type);
+  getStorageProxyMuxer(storageKey: string | StorageKey, type: Type);
   idGenerator: IdGenerator;
   generateID: Producer<string>;
   reportExceptionInHost(exception: PropagatedException);

--- a/src/runtime/storageNG/reference-mode-store.ts
+++ b/src/runtime/storageNG/reference-mode-store.ts
@@ -11,7 +11,7 @@
 import {CRDTSingletonTypeRecord, SingletonOperation, SingletonOpTypes, CRDTSingleton, SingletonOperationSet, SingletonOperationClear} from '../crdt/crdt-singleton.js';
 import {CRDTCollectionTypeRecord, Referenceable, CollectionOpTypes, CollectionOperation, CRDTCollection, CollectionOperationAdd, CollectionOperationRemove} from '../crdt/crdt-collection.js';
 import {ActiveStore, ProxyCallback, ProxyMessage, ProxyMessageType, StorageMode, StoreConstructorOptions} from './store-interface.js';
-import {BackingStore} from './backing-store.js';
+import {DirectStoreMuxer} from './direct-store-muxer.js';
 import {CRDTEntityTypeRecord, CRDTEntity, EntityData, EntityOperation, EntityOpTypes} from '../crdt/crdt-entity.js';
 import {DirectStore} from './direct-store.js';
 import {StorageKey} from './storage-key.js';
@@ -65,7 +65,7 @@ export class ReferenceModeStore<Entity extends SerializedEntity, S extends Dicti
   /*
    * The underlying backing store and container store that this reference view is built from
    */
-  backingStore: BackingStore<CRDTEntityTypeRecord<S, C>>;
+  backingStore: DirectStoreMuxer<CRDTEntityTypeRecord<S, C>>;
   containerStore: DirectStore<ReferenceContainer>;
 
   /*
@@ -118,7 +118,7 @@ export class ReferenceModeStore<Entity extends SerializedEntity, S extends Dicti
       options: StoreConstructorOptions<Container> & {storageKey: ReferenceModeStorageKey}) {
     const result = new ReferenceModeStore<Entity, S, C, ReferenceContainer, Container>(options);
     const {storageKey, type} = options;
-    result.backingStore = await BackingStore.construct({
+    result.backingStore = await DirectStoreMuxer.construct({
       storageKey: storageKey.backingKey,
       type: type.getContainedType(),
       mode: StorageMode.Backing,

--- a/src/runtime/storageNG/storage-proxy-muxer.ts
+++ b/src/runtime/storageNG/storage-proxy-muxer.ts
@@ -19,7 +19,7 @@ import {assert} from '../../platform/assert-web.js';
 import {BiMap} from '../bimap.js';
 import {noAwait} from '../util.js';
 
-export class BackingStorageProxy<T extends CRDTTypeRecord> {
+export class StorageProxyMuxer<T extends CRDTTypeRecord> {
   private readonly storageProxies = new BiMap<string, StorageProxy<T>>();
   private readonly callbacks: Dictionary<ProxyCallback<T>> = {};
   private readonly storageEndpoint: StorageCommunicationEndpoint<T>;
@@ -41,7 +41,7 @@ export class BackingStorageProxy<T extends CRDTTypeRecord> {
     return this.storageProxies.getL(muxId);
   }
 
-  createStorageCommunicationEndpointProvider(muxId: string, storageEndpoint: StorageCommunicationEndpoint<T>, backingStorageProxy: BackingStorageProxy<T>): StorageCommunicationEndpointProvider<T> {
+  createStorageCommunicationEndpointProvider(muxId: string, storageEndpoint: StorageCommunicationEndpoint<T>, storageProxyMuxer: StorageProxyMuxer<T>): StorageCommunicationEndpointProvider<T> {
     return {
       getStorageEndpoint(): StorageCommunicationEndpoint<T> {
         return {
@@ -50,7 +50,7 @@ export class BackingStorageProxy<T extends CRDTTypeRecord> {
             await storageEndpoint.onProxyMessage(message);
           },
           setCallback(callback: ProxyCallback<CRDTTypeRecord>): void {
-            backingStorageProxy.callbacks[muxId] = callback;
+            storageProxyMuxer.callbacks[muxId] = callback;
           },
           reportExceptionInHost(exception: PropagatedException): void {
             storageEndpoint.reportExceptionInHost(exception);

--- a/src/runtime/storageNG/store-interface.ts
+++ b/src/runtime/storageNG/store-interface.ts
@@ -18,7 +18,7 @@ import {StorageProxy} from './storage-proxy.js';
 import {Store} from './store.js';
 import {Producer} from '../hot.js';
 import {ChannelConstructor} from '../channel-constructor.js';
-import {BackingStorageProxy} from './backing-storage-proxy.js';
+import {StorageProxyMuxer} from './storage-proxy-muxer.js';
 import {noAwait} from '../util.js';
 
 /**
@@ -67,7 +67,7 @@ export interface StorageCommunicationEndpoint<T extends CRDTTypeRecord> {
 }
 
 export interface StorageCommunicationEndpointProvider<T extends CRDTTypeRecord> {
-  getStorageEndpoint(storageProxy: StorageProxy<T> | BackingStorageProxy<T>): StorageCommunicationEndpoint<T>;
+  getStorageEndpoint(storageProxy: StorageProxy<T> | StorageProxyMuxer<T>): StorageCommunicationEndpoint<T>;
 }
 
 // A representation of an active store. Subclasses of this class provide specific
@@ -141,7 +141,7 @@ export abstract class ActiveStore<T extends CRDTTypeRecord>
             throw new Error('References not yet supported outside of the PEC');
           },
           idGenerator: null,
-          getBackingStorageProxy() {
+          getStorageProxyMuxer() {
             throw new Error('References not yet supported outside of the PEC');
           },
           reportExceptionInHost(exception: PropagatedException): void {

--- a/src/runtime/storageNG/testing/test-storage.ts
+++ b/src/runtime/storageNG/testing/test-storage.ts
@@ -20,7 +20,7 @@ import {StorageKey} from '../storage-key.js';
 import {StorageProxy} from '../storage-proxy.js';
 import {ActiveStore, ProxyCallback, ProxyMessage, StorageMode, ProxyMessageType} from '../store.js';
 import {CountType} from '../../type.js';
-import {BackingStore} from '../backing-store.js';
+import {DirectStoreMuxer} from '../direct-store-muxer.js';
 
 
 /**
@@ -92,7 +92,7 @@ export class MockStore<T extends CRDTTypeRecord> extends ActiveStore<T> {
   }
 }
 
-export class MockBackingStore<T extends CRDTTypeRecord> extends BackingStore<T> {
+export class MockDirectStoreMuxer<T extends CRDTTypeRecord> extends DirectStoreMuxer<T> {
   lastCapturedMessage: ProxyMessage<T> = null;
   lastCapturedException: PropagatedException = null;
   callback: ProxyCallback<T> = null;

--- a/src/runtime/storageNG/tests/ramdisk-direct-store-muxer-integration-test.ts
+++ b/src/runtime/storageNG/tests/ramdisk-direct-store-muxer-integration-test.ts
@@ -15,7 +15,7 @@ import {RamDiskStorageKey, RamDiskStorageDriverProvider} from '../drivers/ramdis
 import {DriverFactory} from '../drivers/driver-factory.js';
 import {Exists} from '../drivers/driver.js';
 import {Runtime} from '../../runtime.js';
-import {BackingStore} from '../backing-store.js';
+import {DirectStoreMuxer} from '../direct-store-muxer.js';
 import {CountType} from '../../type.js';
 
 function assertHasModel(message: ProxyMessage<CRDTCountTypeRecord>, model: CRDTCount) {
@@ -26,7 +26,7 @@ function assertHasModel(message: ProxyMessage<CRDTCountTypeRecord>, model: CRDTC
   }
 }
 
-describe('RamDisk + Backing Store Integration', async () => {
+describe('RamDisk + Direct Store Muxer Integration', async () => {
   afterEach(() => {
     DriverFactory.clearRegistrationsForTesting();
   });
@@ -36,7 +36,7 @@ describe('RamDisk + Backing Store Integration', async () => {
     RamDiskStorageDriverProvider.register(runtime.getMemoryProvider());
     const storageKey = new RamDiskStorageKey('unique');
     const baseStore = new Store<CRDTCountTypeRecord>(new CountType(), {storageKey, exists: Exists.ShouldCreate, id: 'base-store-id'});
-    const store = await BackingStore.construct<CRDTCountTypeRecord>({
+    const store = await DirectStoreMuxer.construct<CRDTCountTypeRecord>({
       storageKey,
       exists: Exists.ShouldCreate,
       type: new CountType(),

--- a/src/runtime/storageNG/tests/storage-proxy-muxer-test.ts
+++ b/src/runtime/storageNG/tests/storage-proxy-muxer-test.ts
@@ -8,20 +8,20 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {MockBackingStore, MockHandle} from '../testing/test-storage.js';
+import {MockDirectStoreMuxer, MockHandle} from '../testing/test-storage.js';
 import {CRDTEntityTypeRecord, Identified, CRDTEntity, EntityOpTypes, EntityOperation} from '../../crdt/crdt-entity.js';
-import {BackingStore} from '../backing-store.js';
-import {BackingStorageProxy} from '../backing-storage-proxy.js';
-import {BackingType, EntityType} from '../../type.js';
+import {DirectStoreMuxer} from '../direct-store-muxer.js';
+import {StorageProxyMuxer} from '../storage-proxy-muxer.js';
+import {MuxType, EntityType} from '../../type.js';
 import {assert} from '../../../platform/chai-web.js';
 import {ProxyMessageType} from '../store.js';
 import {CRDTSingleton} from '../../crdt/crdt-singleton.js';
 
-function getBackingStorageProxy(store: BackingStore<CRDTEntityTypeRecord<Identified, Identified>>, entityType: EntityType): BackingStorageProxy<CRDTEntityTypeRecord<Identified, Identified>> {
-  return new BackingStorageProxy(store, new BackingType(entityType), store.storageKey.toString());
+function getStorageProxyMuxer(store: DirectStoreMuxer<CRDTEntityTypeRecord<Identified, Identified>>, entityType: EntityType): StorageProxyMuxer<CRDTEntityTypeRecord<Identified, Identified>> {
+  return new StorageProxyMuxer(store, new MuxType(entityType), store.storageKey.toString());
 }
 
-describe('BackingStorageProxy', async () => {
+describe('StorageProxyMuxer', async () => {
   const fooEntityType = EntityType.make(['Foo'], {value: 'Text'});
 
   const fooEntityCRDT = new CRDTEntity({value: new CRDTSingleton<{id: string, value: string}>()}, {});
@@ -31,31 +31,31 @@ describe('BackingStorageProxy', async () => {
   foo2EntityCRDT.applyOperation({type: EntityOpTypes.Set, field: 'value', value: {id: 'AlsoText', value: 'AlsoText'}, actor: 'me', clock: {'me': 1}});
 
   it('creation of storage proxies', async () => {
-    const mockBackingStore = new MockBackingStore<CRDTEntityTypeRecord<Identified, Identified>>();
-    const backingStorageProxy = getBackingStorageProxy(mockBackingStore, fooEntityType);
+    const mockDirectStoreMuxer = new MockDirectStoreMuxer<CRDTEntityTypeRecord<Identified, Identified>>();
+    const storageProxyMuxer = getStorageProxyMuxer(mockDirectStoreMuxer, fooEntityType);
 
-    const mockHandle = new MockHandle(backingStorageProxy.getStorageProxy('foo-id'));
-    const mockHandle2 = new MockHandle(backingStorageProxy.getStorageProxy('foo-id'));
+    const mockHandle = new MockHandle(storageProxyMuxer.getStorageProxy('foo-id'));
+    const mockHandle2 = new MockHandle(storageProxyMuxer.getStorageProxy('foo-id'));
     assert.strictEqual(mockHandle.storageProxy, mockHandle2.storageProxy);
 
     // a different muxId will create a different storage proxy
-    const mockHandle3 = new MockHandle(backingStorageProxy.getStorageProxy('foo-id-2'));
+    const mockHandle3 = new MockHandle(storageProxyMuxer.getStorageProxy('foo-id-2'));
     assert.notStrictEqual(mockHandle.storageProxy, mockHandle3.storageProxy);
   });
-  it('can direct ProxyMessages from storage proxy to backing stores', async () => {
-    const mockBackingStore = new MockBackingStore<CRDTEntityTypeRecord<Identified, Identified>>();
-    const backingStorageProxy = getBackingStorageProxy(mockBackingStore, fooEntityType);
-    const storageProxy = backingStorageProxy.getStorageProxy('foo-id');
+  it('can direct ProxyMessages from storage proxy to direct store muxer', async () => {
+    const mockDirectStoreMuxer = new MockDirectStoreMuxer<CRDTEntityTypeRecord<Identified, Identified>>();
+    const storageProxyMuxer = getStorageProxyMuxer(mockDirectStoreMuxer, fooEntityType);
+    const storageProxy = storageProxyMuxer.getStorageProxy('foo-id');
 
     // Ensure backing store receives SyncRequest proxy messages
     // (registering a handle to the storage proxy will trigger a sync request)
     const mockHandle = new MockHandle<CRDTEntityTypeRecord<Identified, Identified>>(storageProxy);
-    assert.deepEqual(mockBackingStore.lastCapturedMessage, {type: ProxyMessageType.SyncRequest, muxId: 'foo-id', id: 1});
+    assert.deepEqual(mockDirectStoreMuxer.lastCapturedMessage, {type: ProxyMessageType.SyncRequest, muxId: 'foo-id', id: 1});
 
     // Ensure backing store receives ModelUpdate proxy messages
     await storageProxy.onMessage({type: ProxyMessageType.ModelUpdate, model: fooEntityCRDT.getData(), id: 1, muxId: 'foo-id'});
     await storageProxy.onMessage({type: ProxyMessageType.SyncRequest, id: 1});
-    assert.deepEqual(mockBackingStore.lastCapturedMessage, {type: ProxyMessageType.ModelUpdate, id: 1, model: fooEntityCRDT.getData(), muxId: 'foo-id'});
+    assert.deepEqual(mockDirectStoreMuxer.lastCapturedMessage, {type: ProxyMessageType.ModelUpdate, id: 1, model: fooEntityCRDT.getData(), muxId: 'foo-id'});
 
     // Ensure backing store receives Operations proxy messages
     const op: EntityOperation<Identified, Identified> = {
@@ -67,21 +67,21 @@ describe('BackingStorageProxy', async () => {
     };
     const result = await storageProxy.applyOp(op);
     assert.isTrue(result);
-    assert.deepEqual(mockBackingStore.lastCapturedMessage, {
+    assert.deepEqual(mockDirectStoreMuxer.lastCapturedMessage, {
       type: ProxyMessageType.Operations,
       operations: [op],
       id: 1,
       muxId: 'foo-id'
     });
   });
-  it('propagates exceptions to the backing store', async () => {
-    const mockBackingStore = new MockBackingStore<CRDTEntityTypeRecord<Identified, Identified>>();
-    const backingStorageProxy = getBackingStorageProxy(mockBackingStore, fooEntityType);
-    mockBackingStore.mockCRDTData['foo-id'] = fooEntityCRDT.getData();
+  it('propagates exceptions to the direct store muxer', async () => {
+    const mockDirectStoreMuxer = new MockDirectStoreMuxer<CRDTEntityTypeRecord<Identified, Identified>>();
+    const storageProxyMuxer = getStorageProxyMuxer(mockDirectStoreMuxer, fooEntityType);
+    mockDirectStoreMuxer.mockCRDTData['foo-id'] = fooEntityCRDT.getData();
 
-    const mockHandle = new MockHandle(backingStorageProxy.getStorageProxy('foo-id'));
+    const mockHandle = new MockHandle(storageProxyMuxer.getStorageProxy('foo-id'));
     assert.deepEqual(
-      mockBackingStore.lastCapturedMessage,
+      mockDirectStoreMuxer.lastCapturedMessage,
       {type: ProxyMessageType.SyncRequest, id: 1, muxId: 'foo-id'}
     );
     mockHandle.onSync = () => {
@@ -91,21 +91,21 @@ describe('BackingStorageProxy', async () => {
     await mockHandle.storageProxy.getParticleView();
     await mockHandle.storageProxy.idle();
     assert.equal(
-      mockBackingStore.lastCapturedException.message,
+      mockDirectStoreMuxer.lastCapturedException.message,
       'SystemException: exception Error raised when invoking system function StorageProxyScheduler::_dispatch on behalf of particle handle: something wrong');
   });
-  it('can direct ModelUpdate ProxyMessages from the backing store to correct storage proxies', async () => {
-    const mockBackingStore = new MockBackingStore<CRDTEntityTypeRecord<Identified, Identified>>();
-    const backingStorageProxy = getBackingStorageProxy(mockBackingStore, fooEntityType);
+  it('can direct ModelUpdate ProxyMessages from the direct store muxer to correct storage proxies', async () => {
+    const mockDirectStoreMuxer = new MockDirectStoreMuxer<CRDTEntityTypeRecord<Identified, Identified>>();
+    const storageProxyMuxer = getStorageProxyMuxer(mockDirectStoreMuxer, fooEntityType);
 
-    const fooStorageProxy = backingStorageProxy.getStorageProxy('foo-id');
-    const foo2StorageProxy = backingStorageProxy.getStorageProxy('foo-id-2');
+    const fooStorageProxy = storageProxyMuxer.getStorageProxy('foo-id');
+    const foo2StorageProxy = storageProxyMuxer.getStorageProxy('foo-id-2');
     const fooMockHandle1 = new MockHandle<CRDTEntityTypeRecord<Identified, Identified>>(fooStorageProxy);
     const fooMockHandle2 = new MockHandle<CRDTEntityTypeRecord<Identified, Identified>>(fooStorageProxy);
     const foo2MockHandle = new MockHandle<CRDTEntityTypeRecord<Identified, Identified>>(foo2StorageProxy);
 
-    // act as though mockBackingStore calls the callback for backingStorageProxy to propagate a model update.
-    await backingStorageProxy.onMessage({type: ProxyMessageType.ModelUpdate, model: fooEntityCRDT.getData(), muxId: 'foo-id'});
+    // act as though mockDirectStoreMuxer calls the callback for storageProxyMuxer to propagate a model update.
+    await storageProxyMuxer.onMessage({type: ProxyMessageType.ModelUpdate, model: fooEntityCRDT.getData(), muxId: 'foo-id'});
     await fooStorageProxy.idle();
 
     assert.deepEqual(await fooStorageProxy.getParticleView(), fooEntityCRDT.getParticleView());
@@ -113,18 +113,18 @@ describe('BackingStorageProxy', async () => {
     assert.isTrue(fooMockHandle2.onSyncCalled);
     assert.isFalse(foo2MockHandle.onSyncCalled);
 
-    await mockBackingStore.onProxyMessage({type: ProxyMessageType.ModelUpdate, model: foo2EntityCRDT.getData(), muxId: 'foo-id-2'});
-    await backingStorageProxy.onMessage({type: ProxyMessageType.ModelUpdate, model: foo2EntityCRDT.getData(), muxId: 'foo-id-2'});
+    await mockDirectStoreMuxer.onProxyMessage({type: ProxyMessageType.ModelUpdate, model: foo2EntityCRDT.getData(), muxId: 'foo-id-2'});
+    await storageProxyMuxer.onMessage({type: ProxyMessageType.ModelUpdate, model: foo2EntityCRDT.getData(), muxId: 'foo-id-2'});
     await foo2StorageProxy.idle();
 
     assert.deepEqual(await foo2StorageProxy.getParticleView(), foo2EntityCRDT.getParticleView());
     assert.isTrue(foo2MockHandle.onSyncCalled);
   });
-  it('can direct Operations ProxyMessages from the backing store to correct storage proxies', async () => {
-    const mockBackingStore = new MockBackingStore<CRDTEntityTypeRecord<Identified, Identified>>();
-    const backingStorageProxy = getBackingStorageProxy(mockBackingStore, fooEntityType);
-    const fooStorageProxy = backingStorageProxy.getStorageProxy('foo-id');
-    const foo2StorageProxy = backingStorageProxy.getStorageProxy('foo-id-2');
+  it('can direct Operations ProxyMessages from the direct store muxer to correct storage proxies', async () => {
+    const mockDirectStoreMuxer = new MockDirectStoreMuxer<CRDTEntityTypeRecord<Identified, Identified>>();
+    const storageProxyMuxer = getStorageProxyMuxer(mockDirectStoreMuxer, fooEntityType);
+    const fooStorageProxy = storageProxyMuxer.getStorageProxy('foo-id');
+    const foo2StorageProxy = storageProxyMuxer.getStorageProxy('foo-id-2');
 
     const fooMockHandle1 = new MockHandle(fooStorageProxy);
     const fooMockHandle2 = new MockHandle(fooStorageProxy);
@@ -138,7 +138,7 @@ describe('BackingStorageProxy', async () => {
       clock: {'me': 1}
     };
 
-    await backingStorageProxy.onMessage({type: ProxyMessageType.Operations, operations: [op], id: 1, muxId: 'foo-id'});
+    await storageProxyMuxer.onMessage({type: ProxyMessageType.Operations, operations: [op], id: 1, muxId: 'foo-id'});
     await fooStorageProxy.idle();
 
     assert.deepEqual(fooMockHandle1.lastUpdate, op);

--- a/src/runtime/tests/api-channel-test.ts
+++ b/src/runtime/tests/api-channel-test.ts
@@ -72,9 +72,9 @@ describe('API channel', function() {
       onArcCreateHandle() {}
       onArcCreateSlot() {}
       onArcMapHandle() {}
-      onBackingProxyMessage() {}
+      onStorageProxyMuxerMessage() {}
       onConstructInnerArc() {}
-      onGetBackingStore() {}
+      onGetDirectStoreMuxer() {}
       onHandleClear() {}
       onHandleGet() {}
       onHandleRemove() {}
@@ -92,7 +92,7 @@ describe('API channel', function() {
       onSynchronizeProxy() {}
       onInitializeProxy() {}
       onRegister() {}
-      onBackingRegister() {}
+      onDirectStoreMuxerRegister() {}
       onProxyMessage() {}
       onSystemTraceBegin() {}
       onSystemTraceEnd() {}
@@ -106,7 +106,7 @@ describe('API channel', function() {
       onCreateHandleCallback() {}
       onCreateSlotCallback() {}
       onDefineHandle() {}
-      onGetBackingStoreCallback() {}
+      onGetDirectStoreMuxerCallback() {}
       onInnerArcRender() {}
       onInstantiateParticle() {}
       onReinstantiateParticle() {}

--- a/src/runtime/tests/arc-test.ts
+++ b/src/runtime/tests/arc-test.ts
@@ -25,7 +25,7 @@ import {VolatileStorageKey, VolatileDriver} from '../storageNG/drivers/volatile.
 import {StorageKey} from '../storageNG/storage-key.js';
 import {Store} from '../storageNG/store.js';
 import {ReferenceModeStore} from '../storageNG/reference-mode-store.js';
-import {BackingStore} from '../storageNG/backing-store.js';
+import {DirectStoreMuxer} from '../storageNG/direct-store-muxer.js';
 import {CRDTTypeRecord} from '../crdt/crdt.js';
 import {DirectStore} from '../storageNG/direct-store.js';
 import {ramDiskStorageKeyPrefixForTest, volatileStorageKeyPrefixForTest} from '../testing/handle-for-test.js';
@@ -1027,7 +1027,7 @@ describe('Arc storage migration', () => {
     assert.instanceOf(fooStore, Store);
     const activeStore = await fooStore.activate();
     assert.instanceOf(activeStore, ReferenceModeStore);
-    assert.instanceOf(activeStore['backingStore'], BackingStore);
+    assert.instanceOf(activeStore['backingStore'], DirectStoreMuxer);
     const backingStore = activeStore['containerStore'] as DirectStore<CRDTTypeRecord>;
     assert.instanceOf(backingStore.driver, VolatileDriver);
     assert.instanceOf(activeStore['containerStore'], DirectStore);

--- a/src/runtime/tests/reference-test.ts
+++ b/src/runtime/tests/reference-test.ts
@@ -9,7 +9,6 @@
  */
 
 import {assert} from '../../platform/chai-web.js';
-import {Arc} from '../arc.js';
 import {Manifest} from '../manifest.js';
 import {Loader} from '../../platform/loader.js';
 import {EntityType, ReferenceType, CollectionType, SingletonType} from '../type.js';
@@ -22,7 +21,7 @@ import {TestVolatileMemoryProvider} from '../testing/test-volatile-memory-provid
 import {Runtime} from '../runtime.js';
 import {storeType, handleForStore} from '../storageNG/storage-ng.js';
 
-describe('reference mode store tests', () => {
+describe('reference', () => {
   it('can parse & validate a recipe containing references', async () => {
     const manifest = await Manifest.parse(`
         schema Result

--- a/src/runtime/tests/type-test.ts
+++ b/src/runtime/tests/type-test.ts
@@ -11,7 +11,7 @@
 import {assert} from '../../platform/chai-web.js';
 import {Manifest} from '../manifest.js';
 import {BigCollectionType, CollectionType, EntityType, HandleType, InterfaceType,
-        ReferenceType, TupleType, SlotType, Type, TypeVariable, TypeVariableInfo, BackingType} from '../type.js';
+        ReferenceType, TupleType, SlotType, Type, TypeVariable, TypeVariableInfo, MuxType} from '../type.js';
 import {Entity} from '../entity.js';
 import {Refinement} from '../refiner.js';
 import {UnaryExpressionNode, FieldNode, Op} from '../manifest-ast-nodes.js';
@@ -25,7 +25,7 @@ import {UnaryExpressionNode, FieldNode, Op} from '../manifest-ast-nodes.js';
 //   InterfaceType     : InterfaceInfo
 //   SlotType          : SlotInfo
 //   ReferenceType     : Type
-//   BackingType       : Type
+//   MuxType           : Type
 //   ArcType           : none
 //   HandleType        : none
 
@@ -266,32 +266,32 @@ describe('types', () => {
       deepEqual(ref3, ref3.clone(new Map()));
     });
 
-    it('Backing', async () => {
-      // BackingType of an entity
+    it('Mux', async () => {
+      // MuxType of an entity
       const entity = EntityType.make(['Foo'], {value: 'Text'});
-      const backing1 = new BackingType(entity);
-      deepEqual(backing1.toLiteral(), {tag: 'Backing', data: entity.toLiteral()});
-      deepEqual(backing1, Type.fromLiteral(backing1.toLiteral()));
-      deepEqual(backing1, backing1.clone(new Map()));
+      const mux1 = new MuxType(entity);
+      deepEqual(mux1.toLiteral(), {tag: 'Mux', data: entity.toLiteral()});
+      deepEqual(mux1, Type.fromLiteral(mux1.toLiteral()));
+      deepEqual(mux1, mux1.clone(new Map()));
 
-      // BackingType of a reference variable
+      // MuxType of a reference variable
       const variable = TypeVariable.make('a');
       const inner = new ReferenceType(variable);
-      const backing2 = new BackingType(inner);
-      deepEqual(backing2.toLiteral(), {
-        tag: 'Backing',
+      const mux2 = new MuxType(inner);
+      deepEqual(mux2.toLiteral(), {
+        tag: 'Mux',
         data: {tag: 'Reference', data: variable.toLiteral()}
       });
-      deepEqual(backing2, Type.fromLiteral(backing2.toLiteral()));
-      deepEqual(backing2, backing2.clone(new Map()));
+      deepEqual(mux2, Type.fromLiteral(mux2.toLiteral()));
+      deepEqual(mux2, mux2.clone(new Map()));
 
-      // BackingType of a collection of slots
+      // MuxType of a collection of slots
       const slot = SlotType.make('f', 'h');
       const col = new CollectionType(slot);
-      const backing3 = new BackingType(col);
-      deepEqual(backing3.toLiteral(), {tag: 'Backing', data: col.toLiteral()});
-      deepEqual(backing3, Type.fromLiteral(backing3.toLiteral()));
-      deepEqual(backing3, backing3.clone(new Map()));
+      const mux3 = new MuxType(col);
+      deepEqual(mux3.toLiteral(), {tag: 'Mux', data: col.toLiteral()});
+      deepEqual(mux3, Type.fromLiteral(mux3.toLiteral()));
+      deepEqual(mux3, mux3.clone(new Map()));
     });
 
     it('HandleInfo', async () => {
@@ -305,7 +305,7 @@ describe('types', () => {
       const slot       = SlotType.make('f', 'h');
       const bigCol     = new BigCollectionType(slot);
       const reference  = new ReferenceType(bigCol);
-      const backedType = new BackingType(reference);
+      const muxType = new MuxType(reference);
 
       const entity     = EntityType.make(['Foo'], {value: 'Text'});
       const variable   = TypeVariable.make('a');
@@ -313,7 +313,7 @@ describe('types', () => {
 
       const handleInfo = new HandleType();
 
-      const tuple   = new TupleType([backedType, iface, handleInfo]);
+      const tuple   = new TupleType([muxType, iface, handleInfo]);
       const collection = new CollectionType(tuple);
 
       deepEqual(collection, Type.fromLiteral(collection.toLiteral()));

--- a/src/runtime/type-from-literal.ts
+++ b/src/runtime/type-from-literal.ts
@@ -10,7 +10,7 @@
 
 import {TypeLiteral, Type, EntityType, TypeVariable, CollectionType,
         BigCollectionType, TupleType, InterfaceType, SlotType, ReferenceType,
-        HandleType, SingletonType, TypeVariableInfo, InterfaceInfo, BackingType} from './type.js';
+        HandleType, SingletonType, TypeVariableInfo, InterfaceInfo, MuxType} from './type.js';
 import {Schema} from './schema.js';
 import {SlotInfo} from './slot-info.js';
 
@@ -32,8 +32,8 @@ function fromLiteral(literal: TypeLiteral) : Type {
       return new SlotType(SlotInfo.fromLiteral(literal.data));
     case 'Reference':
       return new ReferenceType(Type.fromLiteral(literal.data));
-    case 'Backing':
-      return new BackingType(Type.fromLiteral(literal.data));
+    case 'Mux':
+      return new MuxType(Type.fromLiteral(literal.data));
     case 'Handle':
       return new HandleType();
     case 'Singleton':


### PR DESCRIPTION
`BackingType` -> `MuxType`
`BackingStorageProxy` -> `StorageProxyMuxer`
`BackingStore` -> `DirectStoreMuxer`

API channel methods have also been renamed accordingly:
`onBackingProxyMessage` -> `onStorageProxyMuxerMessage`
`onBackingRegister` -> `onDirectStoreMuxerRegister`
`onGetBackingStore` -> `onGetDirectStoreMuxer`
`onGetBackingStoreCallback` -> `onGetDirectStoreMuxerCallback`