### PR TITLE
Introduce ArcHost configuration, with migration path

### DIFF
--- a/java/arcs/android/host/prod/BUILD
+++ b/java/arcs/android/host/prod/BUILD
@@ -13,6 +13,7 @@ arcs_kt_android_library(
         "//java/arcs/core/host",
         "//java/arcs/core/host/api",
         "//java/arcs/jvm/host",
+        "//java/arcs/jvm/util",
         "//java/arcs/sdk/android/storage",
         "//third_party/java/androidx/annotation",
         "//third_party/java/androidx/lifecycle",

--- a/java/arcs/android/host/prod/ProdArcHostService.kt
+++ b/java/arcs/android/host/prod/ProdArcHostService.kt
@@ -13,14 +13,16 @@ package arcs.android.host.prod
 import android.content.Context
 import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.Lifecycle
-import arcs.android.sdk.host.AndroidHost
 import arcs.android.sdk.host.ArcHostService
+import arcs.android.sdk.host.androidArcHostConfiguration
+import arcs.core.host.AbstractArcHost
 import arcs.core.host.ArcHost
+import arcs.core.host.BaseArcHost
 import arcs.core.host.ParticleRegistration
 import arcs.core.host.ProdHost
-import arcs.core.host.SchedulerProvider
-import arcs.jvm.host.JvmSchedulerProvider
 import arcs.jvm.host.scanForParticles
+import arcs.jvm.util.JvmTime
+import kotlin.coroutines.CoroutineContext
 
 /**
  * An isolatable (can run in another process) [Service] that has a [ProdHost] inside. [Particle]
@@ -32,9 +34,16 @@ open class ProdArcHostService : ArcHostService() {
     class ProdAndroidHost(
         context: Context,
         lifecycle: Lifecycle,
-        schedulerProvider: SchedulerProvider,
+        parentCoroutineContext: CoroutineContext,
         vararg particles: ParticleRegistration
-    ) : AndroidHost(context, lifecycle, schedulerProvider, *particles), ProdHost
+    ) : BaseArcHost(
+        androidArcHostConfiguration(
+            context,
+            lifecycle,
+            parentCoroutineContext
+        ),
+        *particles
+    ), ProdHost
 
     /**
      * This is open for tests to override, but normally isn't necessary.
@@ -43,7 +52,7 @@ open class ProdArcHostService : ArcHostService() {
         ProdAndroidHost(
             this,
             this.lifecycle,
-            JvmSchedulerProvider(scope.coroutineContext),
+            scope.coroutineContext,
             *scanForParticles()
         )
     }

--- a/java/arcs/android/sdk/host/AndroidArcHostConfiguration.kt
+++ b/java/arcs/android/sdk/host/AndroidArcHostConfiguration.kt
@@ -1,0 +1,25 @@
+package arcs.android.sdk.host
+
+import android.content.Context
+import androidx.lifecycle.Lifecycle
+import arcs.core.host.AbstractArcHost
+import arcs.sdk.android.storage.service.ConnectionFactory
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Provide an [AbstractArcHost.Configuration] that configures the [AbstractArcHost] for usage
+ * on an Android platform, using the Android [StorageService].
+ */
+fun androidArcHostConfiguration(
+    context: Context,
+    lifecycle: Lifecycle,
+    parentCoroutineContext: CoroutineContext,
+    connectionFactory: ConnectionFactory? = null
+) = AbstractArcHost.Configuration(
+    AndroidHandleManagerProvider(
+        context,
+        lifecycle,
+        parentCoroutineContext,
+        connectionFactory
+    )
+)

--- a/java/arcs/android/sdk/host/AndroidHandleManagerProvider.kt
+++ b/java/arcs/android/sdk/host/AndroidHandleManagerProvider.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+package arcs.android.sdk.host
+
+import android.content.Context
+import androidx.lifecycle.Lifecycle
+import arcs.core.host.AbstractArcHost
+import arcs.core.host.EntityHandleManager
+import arcs.core.storage.StoreManager
+import arcs.jvm.host.JvmSchedulerProvider
+import arcs.jvm.util.JvmTime
+import arcs.sdk.android.storage.ServiceStoreFactory
+import arcs.sdk.android.storage.service.ConnectionFactory
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+
+/**
+ * Provides an [EntityHandleManager] for [ArcHost]s that will use the [StorageService]-backed
+ * store implementations on Android platforms.
+ *
+ * @param context An Android application context that can be used to bind to the storage service.
+ * @param lifecycle The lifecycle bounding all of the handles this provider will create.
+ * @param parentCoroutineContext An optional coroutine context that can be used for cancellation.
+ * @param connectionFactory allow specifying a different ConnectionFactory for testing
+ */
+class AndroidHandleManagerProvider(
+    context: Context,
+    lifecycle: Lifecycle,
+    parentCoroutineContext: CoroutineContext = EmptyCoroutineContext,
+    connnectionFactory: ConnectionFactory? = null
+) : AbstractArcHost.Configuration.HandleManagerProvider {
+    private val schedulerProvider = JvmSchedulerProvider(parentCoroutineContext)
+
+    private val activationFactory = ServiceStoreFactory(
+        context,
+        lifecycle,
+        parentCoroutineContext,
+        connnectionFactory
+    )
+
+    override fun invoke(arcId: String, hostId: String) = EntityHandleManager(
+        arcId = arcId,
+        hostId = hostId,
+        time = JvmTime,
+        stores = StoreManager(),
+        activationFactory = activationFactory,
+        scheduler = schedulerProvider.invoke(arcId)
+    )
+}

--- a/java/arcs/android/sdk/host/AndroidHost.kt
+++ b/java/arcs/android/sdk/host/AndroidHost.kt
@@ -8,6 +8,8 @@
  * grant found at
  * http://polymer.github.io/PATENTS.txt
  */
+@file:Suppress("DEPRECATION")
+
 package arcs.android.sdk.host
 
 import android.content.Context
@@ -19,10 +21,12 @@ import arcs.core.host.ParticleRegistration
 import arcs.core.host.SchedulerProvider
 import arcs.core.storage.StoreManager
 import arcs.jvm.host.JvmHost
+import arcs.jvm.util.JvmTime
 import arcs.sdk.android.storage.ResurrectionHelper
 import arcs.sdk.android.storage.ServiceStoreFactory
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 
+@Deprecated("Create or extend a BaseArcHost with an AndroidConfiguration")
 /**
  * An [ArcHost] that runs on Android inside of a [Service], uses [StorageService] for storage, and
  * can be resurrected via [ResurrectorService] if the [ArcHost] is embedded in its own service.
@@ -33,6 +37,9 @@ abstract class AndroidHost(
     schedulerProvider: SchedulerProvider,
     vararg particles: ParticleRegistration
 ) : JvmHost(schedulerProvider, *particles), ResurrectableHost {
+
+    @Deprecated("Create or extend a BaseArcHost with an AndroidConfiguration")
+    override val platformTime = JvmTime
 
     override val resurrectionHelper: ResurrectionHelper = ResurrectionHelper(context,
         ::onResurrected)

--- a/java/arcs/android/sdk/host/BUILD
+++ b/java/arcs/android/sdk/host/BUILD
@@ -18,6 +18,7 @@ arcs_kt_android_library(
         "//java/arcs/core/storage",
         "//java/arcs/core/storage:storage_key",
         "//java/arcs/jvm/host",
+        "//java/arcs/jvm/util",
         "//java/arcs/sdk/android/storage",
         "//third_party/java/androidx/annotation",
         "//third_party/java/androidx/lifecycle",

--- a/java/arcs/jvm/host/BUILD
+++ b/java/arcs/jvm/host/BUILD
@@ -12,6 +12,7 @@ arcs_kt_jvm_library(
         "//java/arcs/core/data:data-kt",
         "//java/arcs/core/host",
         "//java/arcs/core/host/api",
+        "//java/arcs/core/storage",
         "//java/arcs/core/storage/api",
         "//java/arcs/core/util",
         "//java/arcs/jvm/util",

--- a/java/arcs/jvm/host/JvmArcHostConfiguration.kt
+++ b/java/arcs/jvm/host/JvmArcHostConfiguration.kt
@@ -1,0 +1,18 @@
+package arcs.jvm.host
+
+import arcs.core.host.AbstractArcHost
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Provide an [AbstractArcHost.Configuration] that is suitable for use on a generic JVM-based
+ * target platform. Storage will be provided by default [ActiveStore] instances managed in the
+ * same process as the [AbstractArcHost].
+ */
+fun jvmArcHostConfiguration(
+    parentCoroutineContext: CoroutineContext
+) = AbstractArcHost.Configuration(
+    JvmHandleManagerProvider(
+        storeManagerProvider = { AbstractArcHost.singletonStores },
+        parentCoroutineContext = parentCoroutineContext
+    )
+)

--- a/java/arcs/jvm/host/JvmHandleManagerProvider.kt
+++ b/java/arcs/jvm/host/JvmHandleManagerProvider.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+package arcs.jvm.host
+
+import arcs.core.host.AbstractArcHost
+import arcs.core.host.EntityHandleManager
+import arcs.core.storage.StoreManager
+import arcs.jvm.util.JvmTime
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+
+/**
+ * Provides an [EntityHandleManager] for a JVM-based platform.
+ */
+class JvmHandleManagerProvider(
+    private val storeManagerProvider: () -> StoreManager,
+    parentCoroutineContext: CoroutineContext = EmptyCoroutineContext
+) : AbstractArcHost.Configuration.HandleManagerProvider {
+
+    private val schedulerProvider = JvmSchedulerProvider(parentCoroutineContext)
+
+    override fun invoke(arcId: String, hostId: String) = EntityHandleManager(
+            arcId = arcId,
+            hostId = hostId,
+            time = JvmTime,
+            stores = storeManagerProvider(),
+            scheduler = schedulerProvider.invoke(arcId)
+        )
+}

--- a/java/arcs/jvm/host/JvmHost.kt
+++ b/java/arcs/jvm/host/JvmHost.kt
@@ -17,6 +17,7 @@ import arcs.core.host.SchedulerProvider
 import arcs.core.util.Time
 import arcs.jvm.util.JvmTime
 
+@Deprecated("Instantiate a BaseArcHost with a JvmConfiguration")
 /**
  * An [ArcHost] that runs on Java VM platforms.
  */

--- a/java/arcs/jvm/util/BUILD
+++ b/java/arcs/jvm/util/BUILD
@@ -8,6 +8,7 @@ arcs_kt_jvm_library(
     name = "util",
     srcs = glob(["*.kt"]),
     deps = [
+        "//java/arcs/core/host",
         "//java/arcs/core/util",
     ],
 )

--- a/java/arcs/jvm/util/testutil/BUILD
+++ b/java/arcs/jvm/util/testutil/BUILD
@@ -9,6 +9,9 @@ arcs_kt_jvm_library(
     testonly = True,
     srcs = glob(["*.kt"]),
     deps = [
+        "//java/arcs/core/host",
+        "//java/arcs/core/storage",
         "//java/arcs/core/util",
+        "//java/arcs/jvm/host",
     ],
 )

--- a/java/arcs/jvm/util/testutil/TestHandleManagerProvider.kt
+++ b/java/arcs/jvm/util/testutil/TestHandleManagerProvider.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+package arcs.jvm.util.testutil
+
+import arcs.core.host.AbstractArcHost
+import arcs.core.host.EntityHandleManager
+import arcs.core.storage.StoreManager
+import arcs.jvm.host.JvmSchedulerProvider
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+
+/**
+ * Provides an [EntityHandleManager] for a JVM-based platform.
+ */
+class TestHandleManagerProvider(
+    private val storeManagerProvider: () -> StoreManager,
+    coroutineContext: CoroutineContext = EmptyCoroutineContext
+) : AbstractArcHost.Configuration.HandleManagerProvider {
+
+    val schedulerProvider = JvmSchedulerProvider(coroutineContext)
+
+    override fun invoke(arcId: String, hostId: String) = EntityHandleManager(
+        arcId = arcId,
+        hostId = hostId,
+        time = FakeTime(),
+        stores = storeManagerProvider(),
+        scheduler = schedulerProvider.invoke(arcId)
+    )
+}

--- a/javatests/arcs/android/e2e/testapp/WriteAnimalHostService.kt
+++ b/javatests/arcs/android/e2e/testapp/WriteAnimalHostService.kt
@@ -14,18 +14,16 @@ package arcs.android.e2e.testapp
 import android.content.Context
 import android.content.Intent
 import androidx.lifecycle.Lifecycle
-import arcs.android.sdk.host.AndroidHost
 import arcs.android.sdk.host.ArcHostService
+import arcs.android.sdk.host.androidArcHostConfiguration
+import arcs.core.host.BaseArcHost
 import arcs.core.host.ParticleRegistration
-import arcs.core.host.SchedulerProvider
 import arcs.core.host.toRegistration
-import arcs.jvm.host.JvmSchedulerProvider
 import arcs.sdk.Handle
-import arcs.sdk.android.storage.ServiceStoreFactory
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
+import kotlin.coroutines.CoroutineContext
 
 /**
  * Service wrapping an ArcHost which hosts a particle writing data to a handle.
@@ -37,7 +35,7 @@ class WriteAnimalHostService : ArcHostService() {
     override val arcHost: MyArcHost = MyArcHost(
         this,
         this.lifecycle,
-        JvmSchedulerProvider(coroutineContext),
+        coroutineContext,
         ::WriteAnimal.toRegistration()
     )
 
@@ -60,12 +58,16 @@ class WriteAnimalHostService : ArcHostService() {
     class MyArcHost(
         context: Context,
         lifecycle: Lifecycle,
-        schedulerProvider: SchedulerProvider,
+        parentCoroutineContext: CoroutineContext,
         vararg initialParticles: ParticleRegistration
-    ) : AndroidHost(context, lifecycle, schedulerProvider, *initialParticles) {
-        @ExperimentalCoroutinesApi
-        override val activationFactory = ServiceStoreFactory(context, lifecycle)
-
+    ) : BaseArcHost(
+        androidArcHostConfiguration(
+            context,
+            lifecycle,
+            parentCoroutineContext
+        ),
+        *initialParticles
+    ) {
         fun arcHostContext(arcId: String) = getArcHostContext(arcId)
     }
 

--- a/javatests/arcs/core/host/ParticleRegistrationTest.kt
+++ b/javatests/arcs/core/host/ParticleRegistrationTest.kt
@@ -9,12 +9,13 @@ import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
+import kotlin.coroutines.CoroutineContext
 
 @RunWith(JUnit4::class)
 @OptIn(ExperimentalCoroutinesApi::class)
 class ParticleRegistrationTest {
     class JvmProdHost(
-        schedulerProvider: SchedulerProvider,
+        schedulerProvider: JvmSchedulerProvider,
         vararg particles: ParticleRegistration
     ) : JvmHost(schedulerProvider, *particles), ProdHost
 
@@ -26,13 +27,20 @@ class ParticleRegistrationTest {
         val hostRegistry = ExplicitHostRegistry()
         val schedulerProvider = JvmSchedulerProvider(coroutineContext)
 
-        hostRegistry.registerHost(JvmProdHost(schedulerProvider,
-                                              ::TestProdParticle.toRegistration(),
-                                              ::TestReflectiveParticle.toRegistration())
+        hostRegistry.registerHost(
+            JvmProdHost(
+                schedulerProvider,
+                ::TestProdParticle.toRegistration(),
+                ::TestReflectiveParticle.toRegistration()
+            )
         )
 
-        hostRegistry.registerHost(TestHost(schedulerProvider("foo"),
-                                           ::TestHostParticle.toRegistration()))
+        hostRegistry.registerHost(
+            TestHost(
+                schedulerProvider("foo"),
+                ::TestHostParticle.toRegistration()
+            )
+        )
 
         hostRegistry.availableArcHosts().forEach { host: ArcHost ->
             when (host) {

--- a/javatests/arcs/core/host/ReflectiveParticleConstructionTest.kt
+++ b/javatests/arcs/core/host/ReflectiveParticleConstructionTest.kt
@@ -32,7 +32,7 @@ class ReflectiveParticleConstructionTest {
     val log = LogRule()
 
     class JvmProdHost(
-        schedulerProvider: SchedulerProvider,
+        schedulerProvider: JvmSchedulerProvider,
         vararg particles: ParticleRegistration
     ) : JvmHost(schedulerProvider, *particles), ProdHost
 


### PR DESCRIPTION
This is a version of #5176 that doesn't remove the existing API for ArcHosts, to allow gradual transition to a newer API.

This introduces the structures and constructors needed to present the
configuration-object based approach to ArcHost creation.

This PR doesn't require that all usage points switch over to the new
method. A migration path has been provided. Fields and methods providing
backwards compatibility have been marked with deprecated.

When this is merged, new code can use this pattern, and old code can be
migrated in a piecewise fashion.