### PR TITLE
Implements a worklist-based fixpoint iterator for [RecipeGraph].

### DIFF
--- a/java/arcs/core/analysis/RecipeGraphFixpointIterator.kt
+++ b/java/arcs/core/analysis/RecipeGraphFixpointIterator.kt
@@ -17,10 +17,10 @@ import arcs.core.data.Recipe
 /** An abstract class that implements dataflow analysis over abstract values of type [V]. */
 abstract class RecipeGraphFixpointIterator<V : AbstractValue<V>>(val bottom: V) {
     /** Results of the fixpoint computation. */
-    class FixpointResult<V: AbstractValue<V>>(
+    class FixpointResult<V : AbstractValue<V>>(
         private val bottom: V,
         private val nodeValues: Map<RecipeGraph.Node, V>
-    )  {
+    ) {
         /** Returns the value for the given particle.  */
         fun getValue(particle: Recipe.Particle): V =
             nodeValues[RecipeGraph.Node.Particle(particle)] ?: bottom

--- a/java/arcs/core/analysis/RecipeGraphFixpointIterator.kt
+++ b/java/arcs/core/analysis/RecipeGraphFixpointIterator.kt
@@ -68,16 +68,15 @@ abstract class RecipeGraphFixpointIterator<V : AbstractValue<V>>(val bottom: V) 
             // Pick and remove an element from the worklist.
             val current = worklist.first()
             worklist.remove(current)
-            val input = nodeValues[current]
-            // Treating as BOTTOM now. See `successors.forEach` below as well.
-            if (input == null) continue
+            val input = nodeValues[current] ?: bottom
+            if (input.isBottom) continue
             val output = nodeTransfer(current, input)
             current.successors.forEach { (succ, spec) ->
                 val edgeValue = edgeTransfer(current, succ, spec, output)
-                val oldValue = nodeValues[succ]
-                val newValue = oldValue?.join(edgeValue) ?: edgeValue
-                val changed = oldValue?.isEquivalentTo(newValue)?.not() ?: true
-                if (changed) {
+                val oldValue = nodeValues[succ] ?: bottom
+                val newValue = oldValue.join(edgeValue)
+                // Add successor to worklist if value changed.
+                if (!oldValue.isEquivalentTo(newValue)) {
                     worklist.add(succ)
                     nodeValues[succ] = newValue
                 }

--- a/java/arcs/core/analysis/RecipeGraphFixpointIterator.kt
+++ b/java/arcs/core/analysis/RecipeGraphFixpointIterator.kt
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.core.analysis
+
+import arcs.core.data.HandleConnectionSpec
+import arcs.core.data.Recipe
+
+/** An abstract class that implements dataflow analysis over abstract values of type [V]. */
+abstract class RecipeGraphFixpointIterator<V : AbstractValue<V>> {
+    /**
+     * Abstract state at the node, i.e., the join of the abstract values along the input edges.
+     *
+     * Absence of an entry for a node denotes BOTTOM.
+     */
+    private var nodeValues = mutableMapOf<RecipeGraph.Node, V>()
+
+    /** State transformer for a [Recipe.Handle] node. */
+    open fun transform(handle: Recipe.Handle, input: V): V = input
+
+    /** State transformer for a [Recipe.Particle] node. */
+    open fun transform(particle: Recipe.Particle, input: V): V = input
+
+    /** State transformer for a [Recipe.Handle] -> [Recipe.Particle] edge. */
+    open fun transform(
+        handle: Recipe.Handle,
+        particle: Recipe.Particle,
+        spec: HandleConnectionSpec,
+        input: V
+    ): V = input
+
+    /** State transformer for a [Recipe.Particle] -> [Recipe.Handle] edge. */
+    open fun transform(
+        particle: Recipe.Particle,
+        handle: Recipe.Handle,
+        spec: HandleConnectionSpec,
+        input: V
+    ): V = input
+
+    /**
+     * Returns the initial values for the nodes for starting a fixpoint iteration.
+     *
+     * The nodes in the returned map are used to initialize the worklist for the fixpoint iteration.
+     */
+    abstract fun getInitialValues(graph: RecipeGraph): Map<RecipeGraph.Node, V>
+
+    /** Returns the value for the given particle. Returns null if the value is BOTTOM. */
+    fun getValue(particle: Recipe.Particle): V? = nodeValues[RecipeGraph.Node.Particle(particle)]
+
+    /** Returns the value for the given handle. Returns null if the value is BOTTOM. */
+    fun getValue(handle: Recipe.Handle): V? = nodeValues[RecipeGraph.Node.Handle(handle)]
+
+    fun computeFixpoint(graph: RecipeGraph) {
+        // TODO(bgogul): If there are identical particles in the recipe, the results will be messed
+        // up. Need to fix the issue.
+        nodeValues = getInitialValues(graph).toMutableMap()
+        val worklist = nodeValues.keys.toMutableSet()
+        while (worklist.isNotEmpty()) {
+            // Pick and remove an element from the worklist.
+            val current = worklist.first()
+            worklist.remove(current)
+            val input = nodeValues[current]
+            // Treating as BOTTOM now. See `successors.forEach` below as well.
+            if (input == null) continue
+            val output = transform(current, input)
+            current.successors.forEach { (succ, spec) ->
+                val edgeValue = transform(current, succ, spec, output)
+                val oldValue = nodeValues[succ]
+                val newValue = oldValue?.join(edgeValue) ?: edgeValue
+                val changed = oldValue?.isEquivalentTo(newValue)?.not() ?: true
+                if (changed) {
+                    worklist.add(succ)
+                    nodeValues[succ] = newValue
+                }
+            }
+        }
+    }
+
+    private fun transform(node: RecipeGraph.Node, input: V) = when (node) {
+        is RecipeGraph.Node.Particle -> transform(node.particle, input)
+        is RecipeGraph.Node.Handle -> transform(node.handle, input)
+    }
+
+    private fun transform(
+        src: RecipeGraph.Node,
+        tgt: RecipeGraph.Node,
+        spec: HandleConnectionSpec,
+        input: V
+    ) = when (src) {
+        is RecipeGraph.Node.Particle -> {
+            require(tgt is RecipeGraph.Node.Handle)
+            transform(src.particle, tgt.handle, spec, input)
+        }
+        is RecipeGraph.Node.Handle -> {
+            require(tgt is RecipeGraph.Node.Particle)
+            transform(src.handle, tgt.particle, spec, input)
+        }
+    }
+}

--- a/java/arcs/core/analysis/RecipeGraphFixpointIterator.kt
+++ b/java/arcs/core/analysis/RecipeGraphFixpointIterator.kt
@@ -14,18 +14,22 @@ package arcs.core.analysis
 import arcs.core.data.HandleConnectionSpec
 import arcs.core.data.Recipe
 
-/** An abstract class that implements dataflow analysis over abstract values of type [V]. */
+/**
+ * An abstract class that implements dataflow analysis over abstract values of type [V].
+ *
+ * @param bottom the bottom (i.e., the smallest) value in a the lattice for [V].
+ */
 abstract class RecipeGraphFixpointIterator<V : AbstractValue<V>>(val bottom: V) {
     /** Results of the fixpoint computation. */
     class FixpointResult<V : AbstractValue<V>>(
         private val bottom: V,
         private val nodeValues: Map<RecipeGraph.Node, V>
     ) {
-        /** Returns the value for the given particle.  */
+        /** Returns the value for the given particle. */
         fun getValue(particle: Recipe.Particle): V =
             nodeValues[RecipeGraph.Node.Particle(particle)] ?: bottom
 
-        /** Returns the value for the given handle. Returns null if the value is BOTTOM. */
+        /** Returns the value for the given handle. */
         fun getValue(handle: Recipe.Handle): V =
             nodeValues[RecipeGraph.Node.Handle(handle)] ?: bottom
     }
@@ -38,16 +42,16 @@ abstract class RecipeGraphFixpointIterator<V : AbstractValue<V>>(val bottom: V) 
 
     /** State transfer function for a [Recipe.Handle] -> [Recipe.Particle] edge. */
     open fun edgeTransfer(
-        handle: Recipe.Handle,
-        particle: Recipe.Particle,
+        fromHandle: Recipe.Handle,
+        toParticle: Recipe.Particle,
         spec: HandleConnectionSpec,
         input: V
     ): V = input
 
     /** State transfer function for a [Recipe.Particle] -> [Recipe.Handle] edge. */
     open fun edgeTransfer(
-        particle: Recipe.Particle,
-        handle: Recipe.Handle,
+        fromParticle: Recipe.Particle,
+        toHandle: Recipe.Handle,
         spec: HandleConnectionSpec,
         input: V
     ): V = input
@@ -82,7 +86,7 @@ abstract class RecipeGraphFixpointIterator<V : AbstractValue<V>>(val bottom: V) 
                 }
             }
         }
-        return FixpointResult(bottom, nodeValues.filterNot { (node, value) -> value.isBottom })
+        return FixpointResult(bottom, nodeValues.filterNot { (_, value) -> value.isBottom })
     }
 
     private fun nodeTransfer(node: RecipeGraph.Node, input: V) = when (node) {

--- a/java/arcs/core/analysis/RecipeGraphFixpointIterator.kt
+++ b/java/arcs/core/analysis/RecipeGraphFixpointIterator.kt
@@ -91,18 +91,18 @@ abstract class RecipeGraphFixpointIterator<V : AbstractValue<V>>(val bottom: V) 
     }
 
     private fun edgeTransfer(
-        src: RecipeGraph.Node,
-        tgt: RecipeGraph.Node,
+        source: RecipeGraph.Node,
+        target: RecipeGraph.Node,
         spec: HandleConnectionSpec,
         input: V
-    ) = when (src) {
+    ) = when (source) {
         is RecipeGraph.Node.Particle -> {
-            require(tgt is RecipeGraph.Node.Handle)
-            edgeTransfer(src.particle, tgt.handle, spec, input)
+            require(target is RecipeGraph.Node.Handle)
+            edgeTransfer(source.particle, target.handle, spec, input)
         }
         is RecipeGraph.Node.Handle -> {
-            require(tgt is RecipeGraph.Node.Particle)
-            edgeTransfer(src.handle, tgt.particle, spec, input)
+            require(target is RecipeGraph.Node.Particle)
+            edgeTransfer(source.handle, target.particle, spec, input)
         }
     }
 }

--- a/javatests/arcs/core/analysis/RecipeGraphFixpointIteratorTest.kt
+++ b/javatests/arcs/core/analysis/RecipeGraphFixpointIteratorTest.kt
@@ -1,0 +1,267 @@
+package arcs.core.analysis
+
+import arcs.core.data.HandleConnectionSpec
+import arcs.core.data.HandleMode
+import arcs.core.data.ParticleSpec
+import arcs.core.data.Recipe
+import arcs.core.data.TypeVariable
+import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.Truth.assertWithMessage
+import org.junit.Assert.assertTrue
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+/** An abstract domain of set, where the elements are ordered by inclusion. */
+class AbstractSet<S>(
+    val value: BoundedAbstractElement<Set<S>>
+) : AbstractValue<AbstractSet<S>> {
+    override val isBottom = value.isBottom
+    override val isTop = value.isTop
+
+    val set: Set<S>? get() = value.value
+
+    constructor(s: Set<S>): this(BoundedAbstractElement.makeValue(s))
+
+    override infix fun isEquivalentTo(other: AbstractSet<S>) =
+        value.isEquivalentTo(other.value) { a, b -> a == b }
+
+    override infix fun join(other: AbstractSet<S>) = AbstractSet(
+        value.join(other.value) { a, b -> a union b }
+    )
+
+    override infix fun meet(other: AbstractSet<S>) = AbstractSet(
+        value.meet(other.value) { a, b -> a intersect b }
+    )
+
+    override fun toString() = when {
+        value.isTop -> "TOP"
+        value.isBottom -> "BOTTOM"
+        else -> "${set}"
+    }
+}
+
+/** Returns the name of the underlying handle or particle. */
+fun RecipeGraph.Node.getName() = when (this) {
+    is RecipeGraph.Node.Particle -> "p:${particle.spec.name}"
+    is RecipeGraph.Node.Handle -> "h:${handle.name}"
+}
+
+/** A simple Fixpoint iterator for the purposes of testing. */
+class TestAnalyzer(
+    val startNames: Set<String>
+) : RecipeGraphFixpointIterator<AbstractSet<String>>() {
+    override fun getInitialValues(graph: RecipeGraph) = graph.nodes.filter {
+        startNames.contains(it.getName())
+    }.associateWith {
+        AbstractSet<String>(setOf())
+    }
+
+    override fun transform(handle: Recipe.Handle, input: AbstractSet<String>) =
+        input.set?.let { AbstractSet<String>(it + "h:${handle.name}") } ?: input
+
+    override fun transform(particle: Recipe.Particle, input: AbstractSet<String>) =
+        input.set?.let { AbstractSet<String>(it + "p:${particle.spec.name}") } ?: input
+
+    override fun transform(
+        handle: Recipe.Handle,
+        particle: Recipe.Particle,
+        spec: HandleConnectionSpec,
+        input: AbstractSet<String>
+    ) = input.set?.let {
+        AbstractSet<String>(it + "h:${handle.name} -> p:${particle.spec.name}")
+    } ?: input
+
+    override fun transform(
+        particle: Recipe.Particle,
+        handle: Recipe.Handle,
+        spec: HandleConnectionSpec,
+        input: AbstractSet<String>
+    ) = input.set?.let {
+        AbstractSet<String>(it + "p:${particle.spec.name} -> h:${handle.name}")
+    } ?: input
+}
+
+@RunWith(JUnit4::class)
+class RecipeGraphFixpointIteratorTest {
+    private val thing = Recipe.Handle("thing", Recipe.Handle.Fate.CREATE, TypeVariable("thing"))
+    private val name = Recipe.Handle("name", Recipe.Handle.Fate.CREATE, TypeVariable("name"))
+    private val readCnxn = HandleConnectionSpec("r", HandleMode.Read, TypeVariable("r"))
+    private val writeCnxn = HandleConnectionSpec("w", HandleMode.Write, TypeVariable("w"))
+    private val readerSpec = ParticleSpec(
+        "Reader",
+        listOf(readCnxn).associateBy { it.name },
+        "ReaderLocation"
+    )
+    private val writerSpec = ParticleSpec(
+        "Writer",
+        listOf(writeCnxn).associateBy { it.name },
+        "WriterLocation"
+    )
+    private val anotherWriterSpec = ParticleSpec(
+        "AnotherWriter",
+        listOf(writeCnxn).associateBy { it.name },
+        "WriterLocation"
+    )
+    private val readerParticle = Recipe.Particle(
+        readerSpec,
+        listOf(Recipe.Particle.HandleConnection(readCnxn, thing))
+    )
+    private val writerParticle = Recipe.Particle(
+        writerSpec,
+        listOf(Recipe.Particle.HandleConnection(writeCnxn, thing))
+    )
+    private val anotherWriterParticle = Recipe.Particle(
+        anotherWriterSpec,
+        listOf(Recipe.Particle.HandleConnection(writeCnxn, thing))
+    )
+
+    @Test
+    fun straightLineFlow() {
+        // [Writer] -> (thing) -> [Reader]
+        val recipe = Recipe(
+            "StraightLine",
+            listOf(thing).associateBy { it.name },
+            listOf(readerParticle, writerParticle),
+            "arcId"
+        )
+        val graph = RecipeGraph(recipe)
+        val analyzer = TestAnalyzer(setOf("p:${writerParticle.spec.name}"))
+        analyzer.computeFixpoint(graph)
+        assertThat(analyzer.getValue(writerParticle)?.set).isEmpty()
+        assertThat(analyzer.getValue(thing)?.set)
+            .containsExactly("p:Writer", "p:Writer -> h:thing")
+        assertThat(analyzer.getValue(readerParticle)?.set)
+            .containsExactly("p:Writer", "p:Writer -> h:thing", "h:thing", "h:thing -> p:Reader")
+    }
+
+    @Test
+    fun joinsFlow() {
+        // [Writer] ---------> (thing) -> [Reader]
+        // [AnotherWriter] ------^
+        val recipe = Recipe(
+            "Join",
+            listOf(thing).associateBy { it.name },
+            listOf(readerParticle, writerParticle, anotherWriterParticle),
+            "arcId"
+        )
+        val graph = RecipeGraph(recipe)
+        val analyzer = TestAnalyzer(
+            setOf("p:${writerParticle.spec.name}", "p:${anotherWriterParticle.spec.name}")
+        )
+
+        analyzer.computeFixpoint(graph)
+        assertThat(analyzer.getValue(writerParticle)?.set).isEmpty()
+        assertThat(analyzer.getValue(anotherWriterParticle)?.set).isEmpty()
+        assertThat(analyzer.getValue(thing)?.set)
+            .containsExactly(
+                "p:Writer",
+                "p:AnotherWriter",
+                "p:Writer -> h:thing",
+                "p:AnotherWriter -> h:thing"
+            )
+        assertThat(analyzer.getValue(readerParticle)?.set)
+            .containsExactly(
+                "p:Writer",
+                "p:AnotherWriter",
+                "p:Writer -> h:thing",
+                "p:AnotherWriter -> h:thing",
+                "h:thing",
+                "h:thing -> p:Reader"
+            )
+    }
+
+    @Test
+    fun unreachable() {
+        // [Writer] ----------> (thing) -> [Reader]
+        // [AnotherWriter] -------^
+        val recipe = Recipe(
+            "Join",
+            listOf(thing).associateBy { it.name },
+            listOf(readerParticle, writerParticle, anotherWriterParticle),
+            "arcId"
+        )
+        val graph = RecipeGraph(recipe)
+        val analyzer = TestAnalyzer(setOf("p:${writerParticle.spec.name}"))
+        analyzer.computeFixpoint(graph)
+        assertThat(analyzer.getValue(writerParticle)?.set).isEmpty()
+        // AnotherWriter is unreachable as we don't mark it as a start node.
+        // Therefore, this should be bottom.
+        assertThat(analyzer.getValue(anotherWriterParticle)?.set).isNull()
+        // AnotherWriter should not be in the following sets.
+        assertThat(analyzer.getValue(thing)?.set)
+            .containsExactly(
+                "p:Writer",
+                "p:Writer -> h:thing"
+            )
+        assertThat(analyzer.getValue(readerParticle)?.set)
+            .containsExactly(
+                "p:Writer",
+                "p:Writer -> h:thing",
+                "h:thing",
+                "h:thing -> p:Reader"
+            )
+    }
+
+    @Test
+    fun loops() {
+        //                  /---> [Reader]
+        // [Writer] -> (thing) -> [Recognizer] -> (name) -> [Tagger] -+
+        //                ^-------------------------------------------+
+        val recognizerSpec = ParticleSpec(
+            "Recognizer",
+            listOf(writeCnxn, readCnxn).associateBy { it.name },
+            "RecognizerLocation"
+        )
+        val recognizerParticle = Recipe.Particle(
+            recognizerSpec,
+            listOf(
+                Recipe.Particle.HandleConnection(writeCnxn, name),
+                Recipe.Particle.HandleConnection(readCnxn, thing)
+            )
+        )
+        val taggerSpec = ParticleSpec(
+            "Tagger",
+            listOf(writeCnxn, readCnxn).associateBy { it.name },
+            "TaggerLocation"
+        )
+        val taggerParticle = Recipe.Particle(
+            taggerSpec,
+            listOf(
+                Recipe.Particle.HandleConnection(writeCnxn, thing),
+                Recipe.Particle.HandleConnection(readCnxn, name)
+            )
+        )
+        val recipe = Recipe(
+            "Loop",
+            listOf(thing, name).associateBy { it.name },
+            listOf(readerParticle, writerParticle, recognizerParticle, taggerParticle),
+            "arcId"
+        )
+
+        val graph = RecipeGraph(recipe)
+        val analyzer = TestAnalyzer(setOf("p:${writerParticle.spec.name}"))
+        analyzer.computeFixpoint(graph)
+        assertThat(analyzer.getValue(writerParticle)?.set).isEmpty()
+        // The values for the nodes in the loop are all the same.
+        val expectedLoopValue = setOf(
+            "p:Writer",
+            "p:Recognizer",
+            "p:Tagger",
+            "h:thing",
+            "h:name",
+            "p:Writer -> h:thing",
+            "h:thing -> p:Recognizer",
+            "p:Recognizer -> h:name",
+            "h:name -> p:Tagger",
+            "p:Tagger -> h:thing"
+        )
+        assertThat(analyzer.getValue(thing)?.set).isEqualTo(expectedLoopValue)
+        assertThat(analyzer.getValue(recognizerParticle)?.set).isEqualTo(expectedLoopValue)
+        assertThat(analyzer.getValue(name)?.set).isEqualTo(expectedLoopValue)
+        assertThat(analyzer.getValue(taggerParticle)?.set).isEqualTo(expectedLoopValue)
+        assertThat(analyzer.getValue(readerParticle)?.set)
+            .isEqualTo(expectedLoopValue + "h:thing -> p:Reader")
+    }
+}

--- a/javatests/arcs/core/analysis/RecipeGraphFixpointIteratorTest.kt
+++ b/javatests/arcs/core/analysis/RecipeGraphFixpointIteratorTest.kt
@@ -179,16 +179,16 @@ class RecipeGraphFixpointIteratorTest {
         val result = analyzer.computeFixpoint(graph)
 
         with(result) {
-            assertThat(getValue(writerParticle)?.set).isEmpty()
-            assertThat(getValue(anotherWriterParticle)?.set).isEmpty()
-            assertThat(getValue(thing)?.set)
+            assertThat(getValue(writerParticle).set).isEmpty()
+            assertThat(getValue(anotherWriterParticle).set).isEmpty()
+            assertThat(getValue(thing).set)
                 .containsExactly(
                     "p:Writer",
                     "p:AnotherWriter",
                     "p:Writer -> h:thing",
                     "p:AnotherWriter -> h:thing"
                 )
-            assertThat(getValue(readerParticle)?.set)
+            assertThat(getValue(readerParticle).set)
                 .containsExactly(
                     "p:Writer",
                     "p:AnotherWriter",
@@ -219,12 +219,12 @@ class RecipeGraphFixpointIteratorTest {
             // Therefore, this should be bottom.
             assertThat(getValue(anotherWriterParticle).isBottom).isTrue()
             // AnotherWriter should not be in the following sets.
-            assertThat(getValue(thing)?.set)
+            assertThat(getValue(thing).set)
                 .containsExactly(
                     "p:Writer",
                     "p:Writer -> h:thing"
                 )
-            assertThat(getValue(readerParticle)?.set)
+            assertThat(getValue(readerParticle).set)
                 .containsExactly(
                     "p:Writer",
                     "p:Writer -> h:thing",

--- a/javatests/arcs/core/analysis/RecipeGraphFixpointIteratorTest.kt
+++ b/javatests/arcs/core/analysis/RecipeGraphFixpointIteratorTest.kt
@@ -70,21 +70,21 @@ class TestAnalyzer(
         input.set?.let { AbstractSet<String>(it + "p:${particle.spec.name}") } ?: input
 
     override fun edgeTransfer(
-        handle: Recipe.Handle,
-        particle: Recipe.Particle,
+        fromHandle: Recipe.Handle,
+        toParticle: Recipe.Particle,
         spec: HandleConnectionSpec,
         input: AbstractSet<String>
     ) = input.set?.let {
-        AbstractSet<String>(it + "h:${handle.name} -> p:${particle.spec.name}")
+        AbstractSet<String>(it + "h:${fromHandle.name} -> p:${toParticle.spec.name}")
     } ?: input
 
     override fun edgeTransfer(
-        particle: Recipe.Particle,
-        handle: Recipe.Handle,
+        fromParticle: Recipe.Particle,
+        toHandle: Recipe.Handle,
         spec: HandleConnectionSpec,
         input: AbstractSet<String>
     ) = input.set?.let {
-        AbstractSet<String>(it + "p:${particle.spec.name} -> h:${handle.name}")
+        AbstractSet<String>(it + "p:${fromParticle.spec.name} -> h:${toHandle.name}")
     } ?: input
 }
 
@@ -126,14 +126,16 @@ class RecipeGraphFixpointIteratorTest {
         name: String,
         handles: List<Recipe.Handle>,
         particles: List<Recipe.Particle>
-    ) = RecipeGraph(
-        Recipe(
-            "StraightLine",
-            handles.associateBy { it.name },
-            particles,
-            "arcId"
+    ): RecipeGraph {
+        return RecipeGraph(
+            Recipe(
+                name,
+                handles.associateBy { it.name },
+                particles,
+                "arcId"
+            )
         )
-    )
+    }
 
     @Test
     fun straightLineFlow() {

--- a/javatests/arcs/core/analysis/RecipeGraphFixpointIteratorTest.kt
+++ b/javatests/arcs/core/analysis/RecipeGraphFixpointIteratorTest.kt
@@ -122,16 +122,27 @@ class RecipeGraphFixpointIteratorTest {
         listOf(Recipe.Particle.HandleConnection(writeConnection, thing))
     )
 
+    private fun createGraph(
+        name: String,
+        handles: List<Recipe.Handle>,
+        particles: List<Recipe.Particle>
+    ) = RecipeGraph(
+        Recipe(
+            "StraightLine",
+            handles.associateBy { it.name },
+            particles,
+            "arcId"
+        )
+    )
+
     @Test
     fun straightLineFlow() {
         // [Writer] -> (thing) -> [Reader]
-        val recipe = Recipe(
-            "StraightLine",
-            listOf(thing).associateBy { it.name },
-            listOf(readerParticle, writerParticle),
-            "arcId"
+        val graph = createGraph(
+            name = "StraightLine",
+            handles = listOf(thing),
+            particles = listOf(readerParticle, writerParticle)
         )
-        val graph = RecipeGraph(recipe)
         val analyzer = TestAnalyzer(setOf("p:${writerParticle.spec.name}"))
 
         val result = analyzer.computeFixpoint(graph)
@@ -154,13 +165,11 @@ class RecipeGraphFixpointIteratorTest {
     fun joinsFlow() {
         // [Writer] ---------> (thing) -> [Reader]
         // [AnotherWriter] ------^
-        val recipe = Recipe(
-            "Join",
-            listOf(thing).associateBy { it.name },
-            listOf(readerParticle, writerParticle, anotherWriterParticle),
-            "arcId"
+        val graph = createGraph(
+            name = "Join",
+            handles = listOf(thing),
+            particles = listOf(readerParticle, writerParticle, anotherWriterParticle)
         )
-        val graph = RecipeGraph(recipe)
         val analyzer = TestAnalyzer(
             setOf("p:${writerParticle.spec.name}", "p:${anotherWriterParticle.spec.name}")
         )
@@ -193,13 +202,11 @@ class RecipeGraphFixpointIteratorTest {
     fun unreachable() {
         // [Writer] ----------> (thing) -> [Reader]
         // [AnotherWriter] -------^
-        val recipe = Recipe(
-            "Join",
-            listOf(thing).associateBy { it.name },
-            listOf(readerParticle, writerParticle, anotherWriterParticle),
-            "arcId"
+        val graph = createGraph(
+            name = "Join",
+            handles = listOf(thing),
+            particles = listOf(readerParticle, writerParticle, anotherWriterParticle)
         )
-        val graph = RecipeGraph(recipe)
         val analyzer = TestAnalyzer(setOf("p:${writerParticle.spec.name}"))
 
         val result = analyzer.computeFixpoint(graph)
@@ -254,14 +261,11 @@ class RecipeGraphFixpointIteratorTest {
                 Recipe.Particle.HandleConnection(readConnection, name)
             )
         )
-        val recipe = Recipe(
-            "Loop",
-            listOf(thing, name).associateBy { it.name },
-            listOf(readerParticle, writerParticle, recognizerParticle, taggerParticle),
-            "arcId"
+        val graph = createGraph(
+            name = "Loop",
+            handles = listOf(thing, name),
+            particles = listOf(readerParticle, writerParticle, recognizerParticle, taggerParticle)
         )
-
-        val graph = RecipeGraph(recipe)
         val analyzer = TestAnalyzer(setOf("p:${writerParticle.spec.name}"))
 
         val result = analyzer.computeFixpoint(graph)

--- a/javatests/arcs/core/analysis/RecipeGraphFixpointIteratorTest.kt
+++ b/javatests/arcs/core/analysis/RecipeGraphFixpointIteratorTest.kt
@@ -59,13 +59,13 @@ class TestAnalyzer(
         AbstractSet<String>(setOf())
     }
 
-    override fun transform(handle: Recipe.Handle, input: AbstractSet<String>) =
+    override fun nodeTransfer(handle: Recipe.Handle, input: AbstractSet<String>) =
         input.set?.let { AbstractSet<String>(it + "h:${handle.name}") } ?: input
 
-    override fun transform(particle: Recipe.Particle, input: AbstractSet<String>) =
+    override fun nodeTransfer(particle: Recipe.Particle, input: AbstractSet<String>) =
         input.set?.let { AbstractSet<String>(it + "p:${particle.spec.name}") } ?: input
 
-    override fun transform(
+    override fun edgeTransfer(
         handle: Recipe.Handle,
         particle: Recipe.Particle,
         spec: HandleConnectionSpec,
@@ -74,7 +74,7 @@ class TestAnalyzer(
         AbstractSet<String>(it + "h:${handle.name} -> p:${particle.spec.name}")
     } ?: input
 
-    override fun transform(
+    override fun edgeTransfer(
         particle: Recipe.Particle,
         handle: Recipe.Handle,
         spec: HandleConnectionSpec,


### PR DESCRIPTION
This PR implements a standard worklist-based fixpoint iterator that operations on `AbstractValue` types. The iterator supports ways to provide semantics at various points in the graph: 
 - Particle
 - Handle
 - Particle -> Handle
 - Handle -> Particle 
(See the corresponding `transform` functions.)