### PR TITLE
Kill RecipeEvelopeProto with Fire

### DIFF
--- a/java/arcs/core/data/proto/BUILD
+++ b/java/arcs/core/data/proto/BUILD
@@ -19,7 +19,7 @@ arcs_kt_library(
         ["*.kt"],
     ),
     deps = [
-        ":recipe_java_proto_lite",
+        ":manifest_java_proto_lite",
         "//java/arcs/core/data",
         "//java/arcs/core/storage:storage_key",
         "//java/arcs/core/type",
@@ -37,7 +37,7 @@ arcs_kt_library(
     ),
     add_android_constraints = False,
     deps = [
-        ":recipe_java_proto",
+        ":manifest_java_proto",
         "//java/arcs/core/data",
         "//java/arcs/core/storage:storage_key",
         "//java/arcs/core/type",
@@ -46,16 +46,16 @@ arcs_kt_library(
 )
 
 proto_library(
-    name = "recipe_proto",
-    srcs = ["recipe.proto"],
+    name = "manifest_proto",
+    srcs = ["manifest.proto"],
 )
 
 android_proto_library(
-    name = "recipe_java_proto_lite",
-    deps = [":recipe_proto"],
+    name = "manifest_java_proto_lite",
+    deps = [":manifest_proto"],
 )
 
 java_proto_library(
-    name = "recipe_java_proto",
-    deps = [":recipe_proto"],
+    name = "manifest_java_proto",
+    deps = [":manifest_proto"],
 )

--- a/java/arcs/core/data/proto/ManifestProtoDecoder.kt
+++ b/java/arcs/core/data/proto/ManifestProtoDecoder.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.core.data.proto
+
+import arcs.core.data.Recipe
+import arcs.core.util.Result
+
+/** Extracts [Recipe]s from the [ManifestProto]. */
+fun ManifestProto.decodeRecipes(): List<Recipe> {
+    val particleSpecs = decodeParticleSpecs().associateBy { it.name }
+    return recipesList.map { it.decode(particleSpecs) }
+}
+
+/** Extracts [ParticleSpec]s from the [ManifestProto]. */
+fun ManifestProto.decodeParticleSpecs() = particleSpecsList.map {
+    when (val result = it.decode()) {
+        is Result.Ok -> result.value
+        is Result.Err -> throw result.thrown
+    }
+}

--- a/java/arcs/core/data/proto/RecipeProtoDecoder.kt
+++ b/java/arcs/core/data/proto/RecipeProtoDecoder.kt
@@ -13,7 +13,6 @@ package arcs.core.data.proto
 
 import arcs.core.data.ParticleSpec
 import arcs.core.data.Recipe
-import arcs.core.util.Result
 
 /** Converts a [RecipeProto] into [Recipe]. */
 fun RecipeProto.decode(particleSpecs: Map<String, ParticleSpec>): Recipe {
@@ -27,17 +26,4 @@ fun RecipeProto.decode(particleSpecs: Map<String, ParticleSpec>): Recipe {
     val context = DecodingContext(particleSpecs, recipeHandles)
     val particles = particlesList.map { it.decode(context) }
     return Recipe(name.ifBlank { null }, recipeHandles, particles, arcId.ifBlank { null })
-}
-
-/** Extracts a [Recipe] from the [RecipeEnvelopeProto]. */
-fun RecipeEnvelopeProto.decodeRecipe(): Recipe {
-    val particleSpecsList = particleSpecsList.map {
-        val result = it.decode()
-        when (result) {
-            is Result.Ok -> result.value
-            is Result.Err -> throw result.thrown
-        }
-    }
-    val particleSpecs = particleSpecsList.associateBy { it.name }
-    return recipe.decode(particleSpecs)
 }

--- a/java/arcs/core/data/proto/manifest.proto
+++ b/java/arcs/core/data/proto/manifest.proto
@@ -11,12 +11,6 @@ message ManifestProto {
   repeated ParticleSpecProto particle_specs = 2;
 }
 
-// Holds a single plan and particle specs used by it.
-message RecipeEnvelopeProto {
-  RecipeProto recipe = 1;
-  repeated ParticleSpecProto particle_specs = 2;
-}
-
 // Plan: A resolved recipe that can be instantiated.
 message RecipeProto {
   // Optional recipe name.

--- a/java/arcs/core/data/testdata/query.textproto
+++ b/java/arcs/core/data/testdata/query.textproto
@@ -11,7 +11,7 @@
 #   Egress
 #     data: reads query
 
-recipe {
+recipes {
   handles {
     name: "shown"
     fate: MAP

--- a/javatests/arcs/core/analysis/BUILD
+++ b/javatests/arcs/core/analysis/BUILD
@@ -15,7 +15,7 @@ arcs_kt_jvm_test_suite(
         "//java/arcs/core/analysis",
         "//java/arcs/core/data",
         "//java/arcs/core/data/proto:proto_for_test",
-        "//java/arcs/core/data/proto:recipe_java_proto",
+        "//java/arcs/core/data/proto:manifest_java_proto",
         "//java/arcs/core/storage",
         "//java/arcs/core/storage/keys",
         "//java/arcs/core/testutil",

--- a/javatests/arcs/core/data/proto/BUILD
+++ b/javatests/arcs/core/data/proto/BUILD
@@ -13,8 +13,8 @@ arcs_kt_jvm_test_suite(
     package = "arcs.core.data.proto",
     deps = [
         "//java/arcs/core/data",
+        "//java/arcs/core/data/proto:manifest_java_proto",
         "//java/arcs/core/data/proto:proto_for_test",
-        "//java/arcs/core/data/proto:recipe_java_proto",
         "//java/arcs/core/storage",
         "//java/arcs/core/storage/keys",
         "//java/arcs/core/testutil",

--- a/javatests/arcs/core/data/proto/ManifestProtoDecoderTest.kt
+++ b/javatests/arcs/core/data/proto/ManifestProtoDecoderTest.kt
@@ -1,0 +1,39 @@
+package arcs.core.data.proto
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class ManifestProtoDecoderTest {
+
+    private val manifestProto = ManifestProto.newBuilder()
+        .addRecipes(RecipeProto.newBuilder()
+            .setName("FooRecipe")
+            .addParticles(ParticleProto.newBuilder()
+                .setSpecName("FooParticle")))
+        .addRecipes(RecipeProto.newBuilder()
+            .setName("BarRecipe")
+            .addParticles(ParticleProto.newBuilder()
+                .setSpecName("BarParticle")))
+        .addParticleSpecs(ParticleSpecProto.newBuilder()
+            .setName("FooParticle")
+            .setLocation("here"))
+        .addParticleSpecs(ParticleSpecProto.newBuilder()
+            .setName("BarParticle")
+            .setLocation("there"))
+        .build()
+
+    @Test
+    fun decodesRecipes() {
+        assertThat(manifestProto.decodeRecipes().map { it.name }).containsExactly(
+            "FooRecipe", "BarRecipe")
+    }
+
+    @Test
+    fun decodesParticleSpecs() {
+        assertThat(manifestProto.decodeParticleSpecs().map { it.name }).containsExactly(
+            "FooParticle", "BarParticle")
+    }
+}

--- a/javatests/arcs/core/data/proto/ParseManifestProtoTest.kt
+++ b/javatests/arcs/core/data/proto/ParseManifestProtoTest.kt
@@ -30,6 +30,6 @@ class ParseManifestProtoTest {
     @Test
     fun decodesQueryExampleInTextFormat() {
         val path = runfilesDir() + "java/arcs/core/data/testdata/query.textproto"
-        TextFormat.getParser().merge(File(path).readText(), RecipeEnvelopeProto.newBuilder())
+        TextFormat.getParser().merge(File(path).readText(), ManifestProto.newBuilder())
     }
 }

--- a/javatests/arcs/core/data/proto/RecipeProtoDecoderTest.kt
+++ b/javatests/arcs/core/data/proto/RecipeProtoDecoderTest.kt
@@ -12,18 +12,15 @@ import arcs.core.data.SchemaFields
 import arcs.core.data.SchemaName
 import arcs.core.data.TypeVariable
 import arcs.core.testutil.assertThrows
-import arcs.repoutils.runfilesDir
 import com.google.common.truth.Truth.assertThat
-import com.google.protobuf.TextFormat
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
-import java.io.File
 
 @RunWith(JUnit4::class)
 class RecipeProtoDecoderTest {
     // The test environment.
-    var ramdiskStorageKey = "ramdisk://thing"
+    val ramdiskStorageKey = "ramdisk://thing"
     val thingHandleProto = HandleProto.newBuilder()
         .setName("thing")
         .setFate(HandleProto.Fate.CREATE)

--- a/src/tools/manifest2proto.ts
+++ b/src/tools/manifest2proto.ts
@@ -21,7 +21,7 @@ import {Manifest} from '../runtime/manifest.js';
 import {Capabilities} from '../runtime/capabilities.js';
 
 // Import Proto declaration.
-const rootNamespace = protobuf.loadSync('./java/arcs/core/data/proto/recipe.proto');
+const rootNamespace = protobuf.loadSync('./java/arcs/core/data/proto/manifest.proto');
 const manifestProto = rootNamespace.lookupType('arcs.ManifestProto');
 const FATE_ENUM = rootNamespace.lookupEnum('arcs.Fate');
 const CAPABILITY_ENUM = rootNamespace.lookupEnum('arcs.Capability');

--- a/src/tools/tests/manifest2proto-test.ts
+++ b/src/tools/tests/manifest2proto-test.ts
@@ -15,7 +15,7 @@ import {Capabilities} from '../../runtime/capabilities.js';
 import {fs} from '../../platform/fs-web.js';
 import protobuf from 'protobufjs';
 
-const rootNamespace = protobuf.loadSync('./java/arcs/core/data/proto/recipe.proto');
+const rootNamespace = protobuf.loadSync('./java/arcs/core/data/proto/manifest.proto');
 const manifestProto = rootNamespace.lookupType('arcs.ManifestProto');
 const typeProto = rootNamespace.lookupType('arcs.TypeProto');
 const CAPABILITY_ENUM = rootNamespace.lookupEnum('arcs.Capability');


### PR DESCRIPTION
Original `recipe.proto` was intended as a way to serialize a single recipe only. This dictated the name (hence `recipe.proto`) and a top level proto (`RecipeEnvelopeProto`). Since then we agreed on trying to use the same proto as an input to codegen, hence we added `ManifestProto`.

Keeping `RecipeEnvelopeProto` and `ManifestProto` is now a pain  - because it's not clear what should be the output of the tools performing the serialization to proto.

This PR removes `RecipeEnvelopeProto` and renames the `recipe.proto` to `manifest.proto`, so that the name is truer to the content.

Wherever we used the `RecipeEnvelopeProto` we should now use `ManifestProto` with a single recipe.