### PR TITLE
Fix build error of importing .aidl

### DIFF
--- a/java/arcs/android/storage/service/BUILD
+++ b/java/arcs/android/storage/service/BUILD
@@ -7,7 +7,6 @@ package(default_visibility = ["//visibility:public"])
 
 android_library(
     name = "aidl",
-    idl_import_root = ".",
     idl_srcs = glob(["*.aidl"]),
     manifest = "//java/arcs/android/common:AndroidManifest.xml",
 )


### PR DESCRIPTION
Mainly idl_import_root = "." make some build targets fail to properly look for .aidl files.

ERROR: /usr/local/google/home/ianchang/workspace/arcs/java/arcs/android/storage/service/BUILD:8:1: Android IDL generation failed (Exit 1) aidl_binary failed: error executing command bazel-out/host/bin/external/androidsdk/aidl_binary -b -Ijava/arcs/android/storage/service -pexternal/androidsdk/platforms/android-29/framework.aidl ... (remaining 2 argument(s) skipped)

Use --sandbox_debug to see verbose messages from the sandbox
ERROR: arcs.android.storage.service.IResultCallback: couldn't find import for class arcs.android.storage.service.IResultCallback