### PR TITLE
Adds --outformat=proto to recipe2plan

### DIFF
--- a/java/arcs/core/data/proto/BUILD
+++ b/java/arcs/core/data/proto/BUILD
@@ -14,6 +14,12 @@ licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])
 
+# This target is needed in Google internal repo when running TypeScript with Bazel.
+filegroup(
+    name = "proto_files",
+    srcs = ["manifest.proto"],
+)
+
 arcs_kt_library(
     name = "proto",
     srcs = glob(

--- a/src/tools/manifest2proto-cli.ts
+++ b/src/tools/manifest2proto-cli.ts
@@ -11,7 +11,7 @@ import minimist from 'minimist';
 import fs from 'fs';
 import path from 'path';
 import {Runtime} from '../runtime/runtime.js';
-import {serialize2proto} from './manifest2proto.js';
+import {encodeManifestToProto} from './manifest2proto.js';
 
 const opts = minimist(process.argv.slice(2), {
   string: ['outdir', 'outfile'],
@@ -56,7 +56,7 @@ async function main() {
     Runtime.init('../..');
     fs.mkdirSync(opts.outdir, {recursive: true});
 
-    const buffer = await serialize2proto(opts._[0]);
+    const buffer = await encodeManifestToProto(opts._[0]);
 
     const outPath = path.join(opts.outdir, opts.outfile);
     console.log(outPath);

--- a/src/tools/manifest2proto.ts
+++ b/src/tools/manifest2proto.ts
@@ -20,26 +20,38 @@ import {Manifest} from '../runtime/manifest.js';
 import {Capabilities} from '../runtime/capabilities.js';
 import {ManifestProto, FateEnum, CapabilityEnum, DirectionEnum, PrimitiveTypeEnum} from './manifest-proto.js';
 
-export async function serialize2proto(path: string): Promise<Uint8Array> {
+export async function encodeManifestToProto(path: string): Promise<Uint8Array> {
   const manifest = await Runtime.parseFile(path);
 
   if (manifest.imports.length) {
     throw Error('Only single-file manifests are currently supported');
   }
-
-  const json = await manifestToProtoPayload(manifest);
-
-  const error = ManifestProto.verify(json);
-  if (error) throw Error(error);
-
-  return ManifestProto.encode(ManifestProto.create(json)).finish();
+  return encodePayload(await manifestToProtoPayload(manifest));
 }
 
 export async function manifestToProtoPayload(manifest: Manifest) {
+  return makeManifestProtoPayload(manifest.particles, manifest.recipes);
+}
+
+export async function encodePlansToProto(plans: Recipe[]) {
+  const specMap = new Map<string, ParticleSpec>();
+  for (const spec of [].concat(...plans.map(r => r.particles)).map(p => p.spec)) {
+    specMap.set(spec.name, spec);
+  }
+  return encodePayload(await makeManifestProtoPayload([...specMap.values()], plans));
+}
+
+async function makeManifestProtoPayload(particles: ParticleSpec[], recipes: Recipe[]) {
   return {
-    particleSpecs: await Promise.all(manifest.particles.map(p => particleSpecToProtoPayload(p))),
-    recipes: await Promise.all(manifest.recipes.map(r => recipeToProtoPayload(r))),
+    particleSpecs: await Promise.all(particles.map(p => particleSpecToProtoPayload(p))),
+    recipes: await Promise.all(recipes.map(r => recipeToProtoPayload(r))),
   };
+}
+
+function encodePayload(payload: {}): Uint8Array {
+  const error = ManifestProto.verify(payload);
+  if (error) throw Error(error);
+  return ManifestProto.encode(ManifestProto.create(payload)).finish();
 }
 
 async function particleSpecToProtoPayload(spec: ParticleSpec) {
@@ -61,7 +73,7 @@ async function particleSpecToProtoPayload(spec: ParticleSpec) {
 }
 
 async function recipeToProtoPayload(recipe: Recipe) {
-  assert(recipe.normalize());
+  recipe.normalize();
 
   const handleToProtoPayload = new Map<Handle, {name: string}>();
   for (const h of recipe.handles) {

--- a/src/tools/recipe2plan-cli.ts
+++ b/src/tools/recipe2plan-cli.ts
@@ -11,13 +11,12 @@ import minimist from 'minimist';
 import fs from 'fs';
 import path from 'path';
 import {Runtime} from '../runtime/runtime.js';
-import {recipe2plan} from './recipe2plan.js';
-import {Flags} from '../runtime/flags.js';
+import {recipe2plan, OutputFormat} from './recipe2plan.js';
 
 const opts = minimist(process.argv.slice(2), {
-  string: ['outdir', 'outfile'],
+  string: ['outdir', 'outfile', 'format', 'recipe'],
   alias: {d: 'outdir', f: 'outfile'},
-  default: {outdir: '.'}
+  default: {outdir: '.', format: 'kotlin'}
 });
 
 if (opts.help || opts._.length === 0) {
@@ -29,8 +28,11 @@ Description
   Generates Kotlin plans from recipes in a manifest. 
 
 Options
-  --outfile, -f output filename; required
+  --outfile, -f  output filename; required
   --outdir, -d  output directory; defaults to '.'
+  --format  output format, 'kotlin' or 'proto', defaults to 'kotlin'
+  --recipe  a name of the recipe to turn into a plan. If not
+            provided all recipes in the manifest will be encoded.
   --help        usage info
 `);
   process.exit(0);
@@ -51,12 +53,22 @@ if (opts._.some((file) => !file.endsWith('.arcs'))) {
   process.exit(1);
 }
 
+const outFormat = (() => {
+  switch (opts.format.toLowerCase()) {
+    case 'kotlin': return OutputFormat.Kotlin;
+    case 'proto': return OutputFormat.Proto;
+    default:
+      console.error(`Only Kotlin and Proto output format is supported.`);
+      process.exit(1);
+  }
+})();
+
 async function main() {
   try {
     Runtime.init('../..');
     fs.mkdirSync(opts.outdir, {recursive: true});
 
-    const plans: string = await recipe2plan(opts._[0]);
+    const plans = await recipe2plan(opts._[0], outFormat, opts.recipe);
 
     const outPath = path.join(opts.outdir, opts.outfile);
     console.log(outPath);

--- a/src/tools/tests/manifest2proto-test.ts
+++ b/src/tools/tests/manifest2proto-test.ts
@@ -8,7 +8,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 import {assert} from '../../platform/chai-web.js';
-import {serialize2proto, typeToProtoPayload, manifestToProtoPayload, capabilitiesToProtoOrdinals} from '../manifest2proto.js';
+import {encodeManifestToProto, typeToProtoPayload, manifestToProtoPayload, capabilitiesToProtoOrdinals} from '../manifest2proto.js';
 import {EntityType, Type} from '../../runtime/type.js';
 import {Manifest} from '../../runtime/manifest.js';
 import {Capabilities} from '../../runtime/capabilities.js';
@@ -258,7 +258,7 @@ describe('manifest2proto', () => {
   // and deserialized in Kotlin to the extent that they are present in the .textproto file.
   it('encodes the Manifest2ProtoTest manifest', async () => {
     assert.deepStrictEqual(
-      await serialize2proto('java/arcs/core/data/testdata/Manifest2ProtoTest.arcs'),
+      await encodeManifestToProto('java/arcs/core/data/testdata/Manifest2ProtoTest.arcs'),
       fs.readFileSync('java/arcs/core/data/testdata/Manifest2ProtoTest.pb.bin'),
       `The output of manifest2proto for Manifest2ProtoTest.arcs does not match the expectation.\n
 If you want to update the expected output please run:\n

--- a/src/tools/tests/recipe2plan-test.ts
+++ b/src/tools/tests/recipe2plan-test.ts
@@ -9,16 +9,34 @@
  */
 import {assert} from '../../platform/chai-web.js';
 import {fs} from '../../platform/fs-web.js';
-import {recipe2plan} from '../recipe2plan.js';
+import {recipe2plan, OutputFormat} from '../recipe2plan.js';
 import {Flags} from '../../runtime/flags.js';
+import {ManifestProto} from '../manifest-proto.js';
+
+const inputManifestPath = 'java/arcs/core/data/testdata/WriterReaderExample.arcs';
 
 describe('recipe2plan', () => {
-  it('generates plans from recipes in a manifest', Flags.withDefaultReferenceMode(async () => {
+  it('generates Kotlin plans from recipes in a manifest', Flags.withDefaultReferenceMode(async () => {
     assert.deepStrictEqual(
-      await recipe2plan('java/arcs/core/data/testdata/WriterReaderExample.arcs'),
+      await recipe2plan(inputManifestPath, OutputFormat.Kotlin),
       fs.readFileSync('src/tools/tests/goldens/WriterReaderExample.kt', 'utf8'),
       `Golden is out of date! Make sure the new script is correct. If it is, consider updating the golden with: 
 $ tools/sigh recipe2plan --outfile src/tools/tests/goldens/WriterReaderExample.kt java/arcs/core/data/testdata/WriterReaderExample.arcs \n\n`
     );
+  }));
+  it('generates Proto plans from recipes in a manifest', Flags.withDefaultReferenceMode(async () => {
+    const encoded = await recipe2plan(inputManifestPath, OutputFormat.Proto) as Uint8Array;
+    const decoded = ManifestProto.decode(encoded);
+
+    // Only validating that the output can be can be decoded as a ManifestProto and right counts.
+    // Tests for for encoding works are in manifest2proto-test.ts.
+    assert.lengthOf(decoded['recipes'], 5);
+    assert.lengthOf(decoded['particleSpecs'], 3);
+  }));
+  it('filters generated plans by provided name', Flags.withDefaultReferenceMode(async () => {
+    const encoded = await recipe2plan(inputManifestPath, OutputFormat.Proto, 'Consumption') as Uint8Array;
+    const decoded = ManifestProto.decode(encoded);
+    assert.lengthOf(decoded['recipes'], 1);
+    assert.lengthOf(decoded['particleSpecs'], 1);
   }));
 });


### PR DESCRIPTION
Adds 2 new arguments to recipe2plan:
`--outformat` with `kotlin` and `proto` being the options.
`--recipe` allowing filtering down to a single recipe in the output.

`outformat` serves 2 masters:

- ability to produce a resolved recipe in order to send it dynamically to the Android device.
- unlocks experimentation with moving codegen from recipe2plan to KotlinPoet.

`recipeFilter` is needed, as recipe2plan cannot do imports yet and we need to produce a proto with a single recipe inside for the dynamic delivery.