### PR TITLE
Refactors proto loading in TS

### DIFF
--- a/src/tools/manifest-proto.ts
+++ b/src/tools/manifest-proto.ts
@@ -1,0 +1,21 @@
+/**
+ * @license
+ * Copyright (c) 2020 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import protobuf from 'protobufjs';
+import {runfilesDir} from './runfiles-dir.oss.js';
+
+// These variables store classes that deal with protos, upper case name is justified.
+// tslint:disable: variable-name
+const RootNamespace = protobuf.loadSync(runfilesDir + 'java/arcs/core/data/proto/manifest.proto');
+export const ManifestProto = RootNamespace.lookupType('arcs.ManifestProto');
+export const FateEnum = RootNamespace.lookupEnum('arcs.Fate');
+export const CapabilityEnum = RootNamespace.lookupEnum('arcs.Capability');
+export const DirectionEnum = RootNamespace.lookupEnum('arcs.Direction');
+export const PrimitiveTypeEnum = RootNamespace.lookupEnum('arcs.PrimitiveTypeProto');

--- a/src/tools/runfiles-dir.oss.ts
+++ b/src/tools/runfiles-dir.oss.ts
@@ -1,0 +1,16 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+// A prefix that ought to be added when reading files bundled with the binary tool.
+//
+// This constant is overridden in Google internal repo to allow reading files bundled
+// with the executable using the Bazel 'data' attribute.
+
+export const runfilesDir = '';


### PR DESCRIPTION
As suggested in #5242 pulls loading of the manifest proto into its own module, so that right classes can be imported from it without the need to refer to the .proto definition.

Adds an explicit constant for runfilesDir, that we will override in the internal Google repo to make these tools runnable with Blaze and using its data attribute.

Pulled into its own PR as landing #5242 will break internal repo if we don't land runfilesDir and appropriate override first.