### PR TITLE
Adding query to manifest.proto

### DIFF
--- a/java/arcs/core/data/proto/manifest.proto
+++ b/java/arcs/core/data/proto/manifest.proto
@@ -138,6 +138,7 @@ message SchemaProto {
   repeated string names = 1;
   map<string, TypeProto> fields = 2;
   string hash = 3;
+  RefinementExpressionProto query = 4;
 }
 
 enum OPERATOR {


### PR DESCRIPTION
Currently, refinements are encoded in the proto representation on the type (i.e. schema field). However, there's no recording of a query. 

This CL added a refinement expression to the schema, which will be used to express queries. 

This implies future changes to `Schema.kt` -- currently, both the refinements and queries reside on the `Schema` data class. Should refinements move to the fields? Also salted for the future: data class representations of refinement expressions. 