### PR TITLE
collection_referenceLiveness is no-longer flaky

### DIFF
--- a/javatests/arcs/android/entity/DifferentAndroidHandleManagerDifferentStoresTest.kt
+++ b/javatests/arcs/android/entity/DifferentAndroidHandleManagerDifferentStoresTest.kt
@@ -73,13 +73,6 @@ class DifferentAndroidHandleManagerDifferentStoresTest : HandleManagerTestBase()
     @After
     override fun tearDown() = super.tearDown()
 
-    // TODO - fix these?
-    @Ignore("b/152436411 - deflake")
-    @Test
-    override fun collection_referenceLiveness() {
-        super.collection_referenceLiveness()
-    }
-
     @Ignore("b/154947352 - Deflake")
     @Test
     override fun collection_entityDereference() {

--- a/javatests/arcs/android/entity/DifferentHandleManagerTest.kt
+++ b/javatests/arcs/android/entity/DifferentHandleManagerTest.kt
@@ -74,13 +74,6 @@ class DifferentHandleManagerTest : HandleManagerTestBase() {
     @After
     override fun tearDown() = super.tearDown()
 
-    // TODO(b/152436411): Fix these.
-    @Ignore("b/152436411 - deflake")
-    @Test
-    override fun collection_referenceLiveness() {
-        super.collection_referenceLiveness()
-    }
-
     @Ignore("b/154947352 - Deflake")
     @Test
     override fun collection_entityDereference() {

--- a/javatests/arcs/android/entity/SameHandleManagerTest.kt
+++ b/javatests/arcs/android/entity/SameHandleManagerTest.kt
@@ -64,12 +64,6 @@ class SameHandleManagerTest : HandleManagerTestBase() {
 
     @Ignore("b/154947352 - Deflake")
     @Test
-    override fun collection_referenceLiveness() {
-        super.collection_referenceLiveness()
-    }
-
-    @Ignore("b/154947352 - Deflake")
-    @Test
     override fun collection_entityDereference() {
         super.collection_entityDereference()
     }

--- a/javatests/arcs/core/entity/DifferentHandleManagerDifferentStoresTest.kt
+++ b/javatests/arcs/core/entity/DifferentHandleManagerDifferentStoresTest.kt
@@ -37,13 +37,6 @@ class DifferentHandleManagerDifferentStoresTest : HandleManagerTestBase() {
     @After
     override fun tearDown() = super.tearDown()
 
-    // TODO(b/152436411): Fix these.
-    @Test
-    @Ignore("b/152436411 - deflake")
-    override fun collection_referenceLiveness() {
-        super.collection_referenceLiveness()
-    }
-
     // We don't expect these to pass, since Operations won't make it through the driver level
     override fun singleton_writeAndOnUpdate() {}
     override fun collection_writeAndOnUpdate() {}

--- a/javatests/arcs/core/entity/DifferentHandleManagerTest.kt
+++ b/javatests/arcs/core/entity/DifferentHandleManagerTest.kt
@@ -40,11 +40,4 @@ class DifferentHandleManagerTest : HandleManagerTestBase() {
 
     @After
     override fun tearDown() = super.tearDown()
-
-    // TODO(b/152436411): Fix these.
-    @Test
-    @Ignore("b/152436411 - deflake")
-    override fun collection_referenceLiveness() {
-        super.collection_referenceLiveness()
-    }
 }


### PR DESCRIPTION
Turns out this one is no-longer flaky. All HMT variants passed this test at least 100/100 times (1000/1000 for the core-HMT variants).

Until it's merged, https://github.com/PolymerLabs/arcs/pull/5261 is the diffbase for this.  Changes in this PR only include removal of the overrides for `collection_referenceLiveness`.