### PR TITLE
Introduce an [AbstractSet] type.

### DIFF
--- a/java/arcs/core/analysis/AbstractSet.kt
+++ b/java/arcs/core/analysis/AbstractSet.kt
@@ -1,0 +1,37 @@
+package arcs.core.analysis
+
+/** An abstract domain representing a set of values, where the elements are ordered by inclusion. */
+data class AbstractSet<S>(
+    val value: BoundedAbstractElement<Set<S>>
+) : AbstractValue<AbstractSet<S>> {
+    override val isBottom = value.isBottom
+    override val isTop = value.isTop
+
+    /** Returns the underling set. Returns null if this is `Top` or `Bottom`. */
+    val set: Set<S>?
+        get() = value.value
+
+    constructor(s: Set<S>) : this(BoundedAbstractElement.makeValue(s))
+
+    override infix fun isEquivalentTo(other: AbstractSet<S>) =
+        value.isEquivalentTo(other.value) { a, b -> a == b }
+
+    override infix fun join(other: AbstractSet<S>) = AbstractSet(
+        value.join(other.value) { a, b -> a union b }
+    )
+
+    override infix fun meet(other: AbstractSet<S>) = AbstractSet(
+        value.meet(other.value) { a, b -> a intersect b }
+    )
+
+    override fun toString() = when {
+        value.isTop -> "TOP"
+        value.isBottom -> "BOTTOM"
+        else -> "$set"
+    }
+
+    companion object {
+        fun <S> getBottom() = AbstractSet<S>(BoundedAbstractElement.getBottom<Set<S>>())
+        fun <S> getTop() = AbstractSet<S>(BoundedAbstractElement.getTop<Set<S>>())
+    }
+}

--- a/javatests/arcs/core/analysis/AbstractSetTest.kt
+++ b/javatests/arcs/core/analysis/AbstractSetTest.kt
@@ -1,0 +1,110 @@
+package arcs.core.analysis
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+
+/** Tests for BoundedAbstractValue. */
+@RunWith(JUnit4::class)
+class AbstractSetTest {
+
+    private val bottom = AbstractSet.getBottom<Int>()
+    private val top = AbstractSet.getTop<Int>()
+    private val odds = AbstractSet<Int>(setOf(1, 3, 5, 7, 9))
+    private val evens = AbstractSet<Int>(setOf(0, 2, 4, 6, 8))
+    private val multiplesOfThree = AbstractSet<Int>(setOf(3, 6, 9, 15))
+    private val naturals = AbstractSet<Int>(setOf(0, 1, 2, 3, 4, 5, 6, 7, 8, 9))
+
+    @Test
+    fun bottomConstruction() {
+        assertThat(bottom.isBottom).isTrue()
+        assertThat(bottom.isTop).isFalse()
+        assertThat(bottom.set).isNull()
+    }
+
+    @Test
+    fun topConstruction() {
+        assertThat(top.isBottom).isFalse()
+        assertThat(top.isTop).isTrue()
+        assertThat(top.set).isNull()
+    }
+
+    @Test
+    fun valueConstruction() {
+        assertThat(odds.isBottom).isFalse()
+        assertThat(odds.isTop).isFalse()
+        assertThat(requireNotNull(odds.set)).containsExactly(1, 3, 5, 7, 9)
+    }
+
+    @Test
+    fun prettyPrint() {
+        assertThat("$top").isEqualTo("TOP")
+        assertThat("$bottom").isEqualTo("BOTTOM")
+        assertThat("$odds").isEqualTo("[1, 3, 5, 7, 9]")
+    }
+
+    @Test
+    fun isEquivalentTo() {
+        with(bottom) {
+            assertThat(isEquivalentTo(bottom)).isTrue()
+            assertThat(isEquivalentTo(top)).isFalse()
+            assertThat(isEquivalentTo(odds)).isFalse()
+            assertThat(isEquivalentTo(evens)).isFalse()
+        }
+        with(top) {
+            assertThat(isEquivalentTo(bottom)).isFalse()
+            assertThat(isEquivalentTo(top)).isTrue()
+            assertThat(isEquivalentTo(odds)).isFalse()
+            assertThat(isEquivalentTo(evens)).isFalse()
+        }
+        with(odds) {
+            assertThat(isEquivalentTo(bottom)).isFalse()
+            assertThat(isEquivalentTo(top)).isFalse()
+            assertThat(isEquivalentTo(odds)).isTrue()
+            assertThat(isEquivalentTo(evens)).isFalse()
+        }
+    }
+
+    @Test
+    fun meet() {
+        // bottom |`| something
+        assertThat(bottom meet bottom).isEqualTo(bottom)
+        assertThat(bottom meet top).isEqualTo(bottom)
+        assertThat(bottom meet odds).isEqualTo(bottom)
+        assertThat(bottom meet evens).isEqualTo(bottom)
+        // top |`| something
+        assertThat(top meet bottom).isEqualTo(bottom)
+        assertThat(top meet top).isEqualTo(top)
+        assertThat(top meet odds).isEqualTo(odds)
+        assertThat(top meet evens).isEqualTo(evens)
+        // odds |`| something
+        assertThat(odds meet bottom).isEqualTo(bottom)
+        assertThat(odds meet top).isEqualTo(odds)
+        assertThat(odds meet odds).isEqualTo(odds)
+        assertThat(odds meet evens).isEqualTo(AbstractSet<Int>(emptySet()))
+        assertThat(odds meet multiplesOfThree).isEqualTo(AbstractSet<Int>(setOf(3, 9)))
+    }
+
+    @Test
+    fun join() {
+        // bottom |_| something
+        assertThat(bottom join bottom).isEqualTo(bottom)
+        assertThat(bottom join top).isEqualTo(top)
+        assertThat(bottom join odds).isEqualTo(odds)
+        assertThat(bottom join evens).isEqualTo(evens)
+        // top |_| something
+        assertThat(top join bottom).isEqualTo(top)
+        assertThat(top join top).isEqualTo(top)
+        assertThat(top join odds).isEqualTo(top)
+        assertThat(top join evens).isEqualTo(top)
+        // odds |_| something
+        assertThat(odds join bottom).isEqualTo(odds)
+        assertThat(odds join top).isEqualTo(top)
+        assertThat(odds join odds).isEqualTo(odds)
+        assertThat(odds join evens).isEqualTo(naturals)
+        assertThat(odds join multiplesOfThree)
+            .isEqualTo(AbstractSet<Int>(setOf(1, 3, 5, 6, 7, 9, 15)))
+    }
+}

--- a/javatests/arcs/core/analysis/AbstractSetTest.kt
+++ b/javatests/arcs/core/analysis/AbstractSetTest.kt
@@ -5,11 +5,8 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
-
-/** Tests for BoundedAbstractValue. */
 @RunWith(JUnit4::class)
 class AbstractSetTest {
-
     private val bottom = AbstractSet.getBottom<Int>()
     private val top = AbstractSet.getTop<Int>()
     private val odds = AbstractSet<Int>(setOf(1, 3, 5, 7, 9))
@@ -46,19 +43,27 @@ class AbstractSetTest {
     }
 
     @Test
-    fun isEquivalentTo() {
+    fun isEquivalentTo_bottom() {
         with(bottom) {
             assertThat(isEquivalentTo(bottom)).isTrue()
             assertThat(isEquivalentTo(top)).isFalse()
             assertThat(isEquivalentTo(odds)).isFalse()
             assertThat(isEquivalentTo(evens)).isFalse()
         }
+    }
+
+    @Test
+    fun isEquivalentTo_top() {
         with(top) {
             assertThat(isEquivalentTo(bottom)).isFalse()
             assertThat(isEquivalentTo(top)).isTrue()
             assertThat(isEquivalentTo(odds)).isFalse()
             assertThat(isEquivalentTo(evens)).isFalse()
         }
+    }
+
+    @Test
+    fun isEquivalentTo_odds() {
         with(odds) {
             assertThat(isEquivalentTo(bottom)).isFalse()
             assertThat(isEquivalentTo(top)).isFalse()
@@ -68,17 +73,25 @@ class AbstractSetTest {
     }
 
     @Test
-    fun meet() {
+    fun meet_bottom() {
         // bottom |`| something
         assertThat(bottom meet bottom).isEqualTo(bottom)
         assertThat(bottom meet top).isEqualTo(bottom)
         assertThat(bottom meet odds).isEqualTo(bottom)
         assertThat(bottom meet evens).isEqualTo(bottom)
+    }
+
+    @Test
+    fun meet_top() {
         // top |`| something
         assertThat(top meet bottom).isEqualTo(bottom)
         assertThat(top meet top).isEqualTo(top)
         assertThat(top meet odds).isEqualTo(odds)
         assertThat(top meet evens).isEqualTo(evens)
+    }
+
+    @Test
+    fun meet_odds() {
         // odds |`| something
         assertThat(odds meet bottom).isEqualTo(bottom)
         assertThat(odds meet top).isEqualTo(odds)
@@ -88,17 +101,25 @@ class AbstractSetTest {
     }
 
     @Test
-    fun join() {
+    fun join_bottom() {
         // bottom |_| something
         assertThat(bottom join bottom).isEqualTo(bottom)
         assertThat(bottom join top).isEqualTo(top)
         assertThat(bottom join odds).isEqualTo(odds)
         assertThat(bottom join evens).isEqualTo(evens)
+    }
+
+    @Test
+    fun join_top() {
         // top |_| something
         assertThat(top join bottom).isEqualTo(top)
         assertThat(top join top).isEqualTo(top)
         assertThat(top join odds).isEqualTo(top)
         assertThat(top join evens).isEqualTo(top)
+    }
+
+    @Test
+    fun join_odds() {
         // odds |_| something
         assertThat(odds join bottom).isEqualTo(odds)
         assertThat(odds join top).isEqualTo(top)

--- a/javatests/arcs/core/analysis/RecipeGraphFixpointIteratorTest.kt
+++ b/javatests/arcs/core/analysis/RecipeGraphFixpointIteratorTest.kt
@@ -13,40 +13,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
-/** An abstract domain of set, where the elements are ordered by inclusion. */
-class AbstractSet<S>(
-    val value: BoundedAbstractElement<Set<S>>
-) : AbstractValue<AbstractSet<S>> {
-    override val isBottom = value.isBottom
-    override val isTop = value.isTop
-
-    val set: Set<S>?
-        get() = value.value
-
-    constructor(s: Set<S>): this(BoundedAbstractElement.makeValue(s))
-
-    override infix fun isEquivalentTo(other: AbstractSet<S>) =
-        value.isEquivalentTo(other.value) { a, b -> a == b }
-
-    override infix fun join(other: AbstractSet<S>) = AbstractSet(
-        value.join(other.value) { a, b -> a union b }
-    )
-
-    override infix fun meet(other: AbstractSet<S>) = AbstractSet(
-        value.meet(other.value) { a, b -> a intersect b }
-    )
-
-    override fun toString() = when {
-        value.isTop -> "TOP"
-        value.isBottom -> "BOTTOM"
-        else -> "${set}"
-    }
-
-    companion object {
-        fun <S> getBottom() = AbstractSet<S>(BoundedAbstractElement.getBottom<Set<S>>())
-    }
-}
-
 /** Returns the name of the underlying handle or particle. */
 fun RecipeGraph.Node.getName() = when (this) {
     is RecipeGraph.Node.Particle -> "p:${particle.spec.name}"


### PR DESCRIPTION
The `AbstractSet` datastructure allows us to treat a set of values of any kind to be an `AbstractValue` in a lattice. This will be useful for data flow Analysis in general.

We are using the Kotlin sets as the underlying representation. For dataflow analysis, it would generally be more efficient to use a [persistent data structure](https://en.wikipedia.org/wiki/Persistent_data_structure) like Patricia Tries for the underling representation. For the time being, Kotlin sets should do.