### PR TITLE
Deflake singleton_clearOnAClearDataWrittenByB

### DIFF
--- a/javatests/arcs/android/entity/SameHandleManagerTest.kt
+++ b/javatests/arcs/android/entity/SameHandleManagerTest.kt
@@ -64,12 +64,6 @@ class SameHandleManagerTest : HandleManagerTestBase() {
 
     @Ignore("b/154947352 - Deflake")
     @Test
-    override fun singleton_clearOnAClearDataWrittenByB() {
-        super.singleton_clearOnAClearDataWrittenByB()
-    }
-
-    @Ignore("b/154947352 - Deflake")
-    @Test
     override fun collection_clearingElementsFromA_clearsThemFromB() {
         super.collection_clearingElementsFromA_clearsThemFromB()
     }


### PR DESCRIPTION
Passes 100/100 times on all HandleManagerTest variants.