### PR TITLE
Adds an abstract value representing a set of label sets.

### DIFF
--- a/java/arcs/core/analysis/InformationFlowLabels.kt
+++ b/java/arcs/core/analysis/InformationFlowLabels.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.core.analysis
+
+import java.util.BitSet
+
+/**
+ * An abstract value that is capable of representing a set of set of labels.
+ *
+ * Suppose that we have an universe of labels {A, B, C}. This class may be used to represents sets
+ * of sets of labels like {{A,B}, {A,C}}, {{A}, {B}, {C}}.
+ *
+ * Currently, we use a set of bitsets for the underlying representation, where each bitset
+ * represents a set of labels. Later, we can switch to more efficient representations like
+ * Binary Decision Diagrams (BDD) without changing the interface.
+ */
+data class InformationFlowLabels(
+    private val abstractSetOfLabelSets: AbstractSet<BitSet>
+) : AbstractValue<InformationFlowLabels> {
+
+    override val isBottom = abstractSetOfLabelSets.isBottom
+    override val isTop = abstractSetOfLabelSets.isTop
+
+    /** Returns the underlying set of set of labels if this is not `Top` or `Bottom`. */
+    val setOfLabelSets: Set<BitSet>?
+        get() = abstractSetOfLabelSets.set
+
+    constructor(s: Set<BitSet>) : this(AbstractSet<BitSet>(s))
+
+    override infix fun isEquivalentTo(other: InformationFlowLabels) =
+        abstractSetOfLabelSets.isEquivalentTo(other.abstractSetOfLabelSets)
+
+    override infix fun join(other: InformationFlowLabels) = InformationFlowLabels(
+        abstractSetOfLabelSets.join(other.abstractSetOfLabelSets)
+    )
+
+    override infix fun meet(other: InformationFlowLabels) = InformationFlowLabels(
+        abstractSetOfLabelSets.meet(other.abstractSetOfLabelSets)
+    )
+
+    override fun toString() = toString(transform = null)
+
+    fun toString(transform: ((Int) -> String)?): String {
+        return when {
+            abstractSetOfLabelSets.isTop -> "TOP"
+            abstractSetOfLabelSets.isBottom -> "BOTTOM"
+            else -> requireNotNull(setOfLabelSets).joinToString(prefix = "{", postfix = "}") {
+                it.toString(transform)
+            }
+        }
+    }
+
+    private fun BitSet.toString(transform: ((Int) -> String)?): String {
+        if (transform == null) return "$this"
+        var labels = mutableListOf<String>()
+        var nextBit = nextSetBit(0)
+        while (nextBit != -1) {
+            labels.add(transform(nextBit))
+            if (nextBit == Int.MAX_VALUE) break
+            nextBit = nextSetBit(nextBit + 1)
+        }
+        return labels.joinToString(prefix = "{", postfix = "}")
+    }
+
+    companion object {
+        fun getBottom() = InformationFlowLabels(AbstractSet.getBottom<BitSet>())
+        fun getTop() = InformationFlowLabels(AbstractSet.getTop<BitSet>())
+    }
+}

--- a/java/arcs/core/analysis/InformationFlowLabels.kt
+++ b/java/arcs/core/analysis/InformationFlowLabels.kt
@@ -16,46 +16,44 @@ import java.util.BitSet
 /**
  * An abstract value that is capable of representing a set of set of labels.
  *
- * Suppose that we have an universe of labels {A, B, C}. This class may be used to represents sets
- * of sets of labels like {{A,B}, {A,C}}, {{A}, {B}, {C}}.
+ * Suppose that we have an universe of labels `{A, B, C}`. This class may be used to represents sets
+ * of sets of labels like `{{A, B}, {A, C}}, {{A}, {B}, {C}}`.
  *
  * Currently, we use a set of bitsets for the underlying representation, where each bitset
  * represents a set of labels. Later, we can switch to more efficient representations like
  * Binary Decision Diagrams (BDD) without changing the interface.
  */
 data class InformationFlowLabels(
-    private val abstractSetOfLabelSets: AbstractSet<BitSet>
+    private val abstractLabelSets: AbstractSet<BitSet>
 ) : AbstractValue<InformationFlowLabels> {
 
-    override val isBottom = abstractSetOfLabelSets.isBottom
-    override val isTop = abstractSetOfLabelSets.isTop
+    override val isBottom = abstractLabelSets.isBottom
+    override val isTop = abstractLabelSets.isTop
 
     /** Returns the underlying set of set of labels if this is not `Top` or `Bottom`. */
-    val setOfLabelSets: Set<BitSet>?
-        get() = abstractSetOfLabelSets.set
+    val labelSets: Set<BitSet>?
+        get() = abstractLabelSets.set
 
-    constructor(s: Set<BitSet>) : this(AbstractSet<BitSet>(s))
+    constructor(labelSets: Set<BitSet>) : this(AbstractSet<BitSet>(labelSets))
 
     override infix fun isEquivalentTo(other: InformationFlowLabels) =
-        abstractSetOfLabelSets.isEquivalentTo(other.abstractSetOfLabelSets)
+        abstractLabelSets.isEquivalentTo(other.abstractLabelSets)
 
     override infix fun join(other: InformationFlowLabels) = InformationFlowLabels(
-        abstractSetOfLabelSets.join(other.abstractSetOfLabelSets)
+        abstractLabelSets.join(other.abstractLabelSets)
     )
 
     override infix fun meet(other: InformationFlowLabels) = InformationFlowLabels(
-        abstractSetOfLabelSets.meet(other.abstractSetOfLabelSets)
+        abstractLabelSets.meet(other.abstractLabelSets)
     )
 
     override fun toString() = toString(transform = null)
 
-    fun toString(transform: ((Int) -> String)?): String {
-        return when {
-            abstractSetOfLabelSets.isTop -> "TOP"
-            abstractSetOfLabelSets.isBottom -> "BOTTOM"
-            else -> requireNotNull(setOfLabelSets).joinToString(prefix = "{", postfix = "}") {
-                it.toString(transform)
-            }
+    fun toString(transform: ((Int) -> String)?) = when {
+        abstractLabelSets.isTop -> "TOP"
+        abstractLabelSets.isBottom -> "BOTTOM"
+        else -> requireNotNull(labelSets).joinToString(prefix = "{", postfix = "}") {
+            it.toString(transform)
         }
     }
 

--- a/javatests/arcs/core/analysis/InformationFlowLabelsTest.kt
+++ b/javatests/arcs/core/analysis/InformationFlowLabelsTest.kt
@@ -1,0 +1,147 @@
+package arcs.core.analysis
+
+import com.google.common.truth.Truth.assertThat
+import java.util.BitSet
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class InformationFlowLabelsTest {
+    enum class Labels { A, B, C }
+    private val labels = enumValues<Labels>().map { it.name }
+    private val bottom = InformationFlowLabels.getBottom()
+    private val top = InformationFlowLabels.getTop()
+    private val setAB = BitSet(labels.size).apply {
+            set(Labels.A.ordinal)
+            set(Labels.B.ordinal)
+    }
+    private val setAC = BitSet(labels.size).apply {
+            set(Labels.A.ordinal)
+            set(Labels.C.ordinal)
+    }
+    val setOfAB = InformationFlowLabels(setOf(setAB))
+    val setOfAC = InformationFlowLabels(setOf(setAC))
+    val setOfABandAC = InformationFlowLabels(setOf(setAB, setAC))
+
+    @Test
+    fun bottomConstruction() {
+        assertThat(bottom.isBottom).isTrue()
+        assertThat(bottom.isTop).isFalse()
+        assertThat(bottom.setOfLabelSets).isNull()
+    }
+
+    @Test
+    fun topConstruction() {
+        assertThat(top.isBottom).isFalse()
+        assertThat(top.isTop).isTrue()
+        assertThat(top.setOfLabelSets).isNull()
+    }
+
+    @Test
+    fun valueConstruction() {
+        assertThat(setOfABandAC.isBottom).isFalse()
+        assertThat(setOfABandAC.isTop).isFalse()
+        assertThat(requireNotNull(setOfABandAC.setOfLabelSets)).containsExactly(setAB, setAC)
+    }
+
+    @Test
+    fun prettyPrint() {
+        assertThat("$top").isEqualTo("TOP")
+        assertThat("$bottom").isEqualTo("BOTTOM")
+        assertThat("$setOfAB").isEqualTo("{{0, 1}}")
+        assertThat("$setOfABandAC").isEqualTo("{{0, 1}, {0, 2}}")
+    }
+
+    @Test
+    fun prettyPrintCustomizeIndices() {
+        assertThat(top.toString { x -> labels[x] }).isEqualTo("TOP")
+        assertThat(bottom.toString { x -> labels[x] }).isEqualTo("BOTTOM")
+        assertThat(setOfAB.toString { x -> labels[x] }).isEqualTo("{{A, B}}")
+        assertThat(setOfABandAC.toString { x -> labels[x] }).isEqualTo("{{A, B}, {A, C}}")
+    }
+
+    @Test
+    fun isEquivalentTo_bottom() {
+        with(bottom) {
+            assertThat(isEquivalentTo(bottom)).isTrue()
+            assertThat(isEquivalentTo(top)).isFalse()
+            assertThat(isEquivalentTo(setOfABandAC)).isFalse()
+        }
+    }
+
+    @Test
+    fun isEquivalentTo_top() {
+        with(top) {
+            assertThat(isEquivalentTo(bottom)).isFalse()
+            assertThat(isEquivalentTo(top)).isTrue()
+            assertThat(isEquivalentTo(setOfABandAC)).isFalse()
+        }
+    }
+
+    @Test
+    fun isEquivalentTo_setOfABandAC() {
+        with(setOfABandAC) {
+            assertThat(isEquivalentTo(bottom)).isFalse()
+            assertThat(isEquivalentTo(top)).isFalse()
+            assertThat(isEquivalentTo(setOfABandAC)).isTrue()
+        }
+    }
+
+    @Test
+    fun meet_bottom() {
+        assertThat(bottom meet bottom).isEqualTo(bottom)
+        assertThat(bottom meet top).isEqualTo(bottom)
+        assertThat(bottom meet setOfABandAC).isEqualTo(bottom)
+    }
+
+    @Test
+    fun meet_top() {
+        assertThat(top meet bottom).isEqualTo(bottom)
+        assertThat(top meet top).isEqualTo(top)
+        assertThat(top meet setOfABandAC).isEqualTo(setOfABandAC)
+    }
+
+    @Test
+    fun meet_value() {
+        assertThat(setOfABandAC meet bottom).isEqualTo(bottom)
+        assertThat(setOfABandAC meet top).isEqualTo(setOfABandAC)
+        assertThat(setOfABandAC meet setOfABandAC).isEqualTo(setOfABandAC)
+
+        // {AB} meet {AC} is empty.
+        assertThat(setOfAB meet setOfAC).isEqualTo(InformationFlowLabels(emptySet()))
+
+        // {AB, AC} meet {AB} is {AB}
+        assertThat(setOfABandAC meet setOfAB).isEqualTo(setOfAB)
+        assertThat(setOfAB meet setOfABandAC).isEqualTo(setOfAB)
+    }
+
+    @Test
+    fun join_bottom() {
+        assertThat(bottom join bottom).isEqualTo(bottom)
+        assertThat(bottom join top).isEqualTo(top)
+        assertThat(bottom join setOfABandAC).isEqualTo(setOfABandAC)
+    }
+
+    @Test
+    fun join_top() {
+        assertThat(top join bottom).isEqualTo(top)
+        assertThat(top join top).isEqualTo(top)
+        assertThat(top join setOfABandAC).isEqualTo(top)
+    }
+
+    @Test
+    fun join_setOfABandAC() {
+        assertThat(setOfABandAC join bottom).isEqualTo(setOfABandAC)
+        assertThat(setOfABandAC join top).isEqualTo(top)
+        assertThat(setOfABandAC join setOfABandAC).isEqualTo(setOfABandAC)
+
+        // {AB} join {AC} is {AB, AC}
+        assertThat(setOfAB join setOfAC).isEqualTo(setOfABandAC)
+
+        // {AB, AC} join {AB} is {AB, AC}
+        assertThat(setOfABandAC join setOfAB).isEqualTo(setOfABandAC)
+        assertThat(setOfAB join setOfABandAC).isEqualTo(setOfABandAC)
+    }
+
+}

--- a/javatests/arcs/core/analysis/InformationFlowLabelsTest.kt
+++ b/javatests/arcs/core/analysis/InformationFlowLabelsTest.kt
@@ -13,12 +13,12 @@ class InformationFlowLabelsTest {
     private val bottom = InformationFlowLabels.getBottom()
     private val top = InformationFlowLabels.getTop()
     private val setAB = BitSet(labels.size).apply {
-            set(Labels.A.ordinal)
-            set(Labels.B.ordinal)
+        set(Labels.A.ordinal)
+        set(Labels.B.ordinal)
     }
     private val setAC = BitSet(labels.size).apply {
-            set(Labels.A.ordinal)
-            set(Labels.C.ordinal)
+        set(Labels.A.ordinal)
+        set(Labels.C.ordinal)
     }
     val setOfAB = InformationFlowLabels(setOf(setAB))
     val setOfAC = InformationFlowLabels(setOf(setAC))
@@ -28,21 +28,21 @@ class InformationFlowLabelsTest {
     fun bottomConstruction() {
         assertThat(bottom.isBottom).isTrue()
         assertThat(bottom.isTop).isFalse()
-        assertThat(bottom.setOfLabelSets).isNull()
+        assertThat(bottom.labelSets).isNull()
     }
 
     @Test
     fun topConstruction() {
         assertThat(top.isBottom).isFalse()
         assertThat(top.isTop).isTrue()
-        assertThat(top.setOfLabelSets).isNull()
+        assertThat(top.labelSets).isNull()
     }
 
     @Test
     fun valueConstruction() {
         assertThat(setOfABandAC.isBottom).isFalse()
         assertThat(setOfABandAC.isTop).isFalse()
-        assertThat(requireNotNull(setOfABandAC.setOfLabelSets)).containsExactly(setAB, setAC)
+        assertThat(requireNotNull(setOfABandAC.labelSets)).containsExactly(setAB, setAC)
     }
 
     @Test


### PR DESCRIPTION
An abstract value that is capable of representing a set of set of labels. Suppose that we have an universe of labels {A, B, C}. This class may be used to represents sets of label sets like {{A,B}, {A,C}}, {{A}, {B}, {C}}.

Currently, we use a set of bitsets for the underlying representation, where each bitset represents a set of labels. Later, we can switch to more efficient representations like * Binary Decision Diagrams (BDD) without changing the interface.