### PR TITLE
Furthering manifest.proto to Kotlin conversion 

### DIFF
--- a/java/arcs/core/data/proto/TypeProtoDecoders.kt
+++ b/java/arcs/core/data/proto/TypeProtoDecoders.kt
@@ -12,9 +12,12 @@
 package arcs.core.data.proto
 
 import arcs.core.data.CollectionType
+import arcs.core.data.CountType
 import arcs.core.data.EntityType
 import arcs.core.data.FieldType
 import arcs.core.data.PrimitiveType
+import arcs.core.data.ReferenceType
+import arcs.core.data.SingletonType
 import arcs.core.type.Type
 
 /** Converts a [PrimitiveTypeProto] protobuf instance into a Kotlin [PrimitiveType] instance. */
@@ -48,15 +51,30 @@ fun TypeProto.decodeAsFieldType() = when (dataCase) {
 /** Converts a [EntityTypeProto] protobuf instance into a Kotlin [EntityType] instance. */
 fun EntityTypeProto.decode() = EntityType(schema.decode())
 
+/** Converts a [SingletonTypeProto] protobuf instance into a Kotlin [SingletonType] instance. */
+fun SingletonTypeProto.decode() = SingletonType(singletonType.decode())
+
 /** Converts a [CollectionTypeProto] protobuf instance into a Kotlin [CollectionType] instance. */
 fun CollectionTypeProto.decode() = CollectionType(collectionType.decode())
 
+/** Converts a [ReferenceTypeProto] protobuf instance into a Kotlin [ReferenceType] instance. */
+fun ReferenceTypeProto.decode() = ReferenceType(referredType.decode())
+
+/** Converts a [CountTypeProto] protobuf instance into a Kotlin [CountType] instance. */
+fun CountTypeProto.decode() = CountType()
+
 /** Converts a [TypeProto] protobuf instance into a Kotlin [Type] instance. */
-// TODO: optional, RefinementExpression.
+// TODO(b/155812915): RefinementExpression.
 fun TypeProto.decode(): Type = when (dataCase) {
     TypeProto.DataCase.ENTITY -> entity.decode()
+    TypeProto.DataCase.SINGLETON -> singleton.decode()
     TypeProto.DataCase.COLLECTION -> collection.decode()
-    TypeProto.DataCase.REFERENCE, TypeProto.DataCase.TUPLE, TypeProto.DataCase.VARIABLE ->
+    TypeProto.DataCase.REFERENCE -> reference.decode()
+    TypeProto.DataCase.COUNT -> count.decode()
+    // TODO(b/156003617) Support Kotlin Tuples
+    TypeProto.DataCase.TUPLE,
+    // TODO(b/154733929) Support Kotlin TypeVariables
+    TypeProto.DataCase.VARIABLE ->
         throw NotImplementedError(
             "Decoding of a ${dataCase.name} type to a [Type] is not implemented.")
     TypeProto.DataCase.DATA_NOT_SET ->

--- a/java/arcs/core/data/proto/manifest.proto
+++ b/java/arcs/core/data/proto/manifest.proto
@@ -102,7 +102,7 @@ message TypeProto {
     TupleTypeProto tuple = 5;
     TypeVariableProto variable = 6;
     SingletonTypeProto singleton = 7;
-    bool count = 8;
+    CountTypeProto count = 8;
   }
   bool optional = 10;
   RefinementExpressionProto refinement = 11;
@@ -126,6 +126,8 @@ message SingletonTypeProto {
   TypeProto singleton_type = 1;
 }
 
+message CountTypeProto {}
+
 message TupleTypeProto {
   repeated TypeProto elements = 1;
 }
@@ -146,8 +148,6 @@ message SchemaProto {
   map<string, TypeProto> fields = 2;
   string hash = 3;
 }
-
-message CountTypeProto {}
 
 enum OPERATOR {
   AND = 0;

--- a/java/arcs/core/data/proto/manifest.proto
+++ b/java/arcs/core/data/proto/manifest.proto
@@ -101,6 +101,8 @@ message TypeProto {
     ReferenceTypeProto reference = 4;
     TupleTypeProto tuple = 5;
     TypeVariableProto variable = 6;
+    SingletonTypeProto singleton = 7;
+    bool count = 8;
   }
   bool optional = 10;
   RefinementExpressionProto refinement = 11;
@@ -120,6 +122,10 @@ message CollectionTypeProto {
   TypeProto collection_type = 1;
 }
 
+message SingletonTypeProto {
+  TypeProto singleton_type = 1;
+}
+
 message TupleTypeProto {
   repeated TypeProto elements = 1;
 }
@@ -128,6 +134,7 @@ message ReferenceTypeProto {
   TypeProto referred_type = 1;
 }
 
+// TODO(b/155944755) more fields pending.
 message TypeVariableProto {
   // Identifies a type variable in a recipe or a particle spec.
   // Type variables with the same name are linked together.
@@ -139,6 +146,8 @@ message SchemaProto {
   map<string, TypeProto> fields = 2;
   string hash = 3;
 }
+
+message CountTypeProto {}
 
 enum OPERATOR {
   AND = 0;

--- a/javatests/arcs/core/data/proto/TypeProtoDecodersTest.kt
+++ b/javatests/arcs/core/data/proto/TypeProtoDecodersTest.kt
@@ -139,7 +139,7 @@ class TypeProtoDecodersTest {
             is CollectionType<*> -> assertThat(collectionType.collectionType).isEqualTo(
                 EntityType(expectedSchema)
             )
-            else -> fail("TypeProto should have been decoded to [EntityType].")
+            else -> fail("TypeProto should have been decoded to [CollectionType].")
         }
     }
 

--- a/src/tools/manifest2proto.ts
+++ b/src/tools/manifest2proto.ts
@@ -11,7 +11,7 @@ import {Runtime} from '../runtime/runtime.js';
 import {Recipe} from '../runtime/recipe/recipe.js';
 import {Handle} from '../runtime/recipe/handle.js';
 import {Particle} from '../runtime/recipe/particle.js';
-import {Type, CollectionType, ReferenceType} from '../runtime/type.js';
+import {Type, CollectionType, ReferenceType, SingletonType, TypeVariable} from '../runtime/type.js';
 import {Schema} from '../runtime/schema.js';
 import {ParticleSpec} from '../runtime/particle-spec.js';
 import {assert} from '../platform/assert-web.js';
@@ -150,6 +150,20 @@ export async function typeToProtoPayload(type: Type) {
         referredType: await typeToProtoPayload((type as ReferenceType<Type>).referredType)
       }
     };
+    case 'Singleton': return {
+      singleton: {
+        singletonType: await typeToProtoPayload((type as SingletonType<Type>).getContainedType())
+      }
+    };
+    case 'Count': return {
+      count: true
+    };
+    // TODO(b/155944755)
+    // case 'TypeVariable': return {
+    //   variable: {
+    //     name: (type as TypeVariable).variable.name,
+    //   }
+    // };
     default: throw Error(`Type ${type.tag} is not supported.`);
   }
 }

--- a/src/tools/manifest2proto.ts
+++ b/src/tools/manifest2proto.ts
@@ -161,7 +161,7 @@ export async function typeToProtoPayload(type: Type) {
       }
     };
     case 'Count': return {
-      count: true
+      count: {}
     };
     // TODO(b/154733929)
     // case 'TypeVariable': return {
@@ -169,7 +169,7 @@ export async function typeToProtoPayload(type: Type) {
     //     name: (type as TypeVariable).variable.name,
     //   }
     // };
-    default: throw Error(`Type ${type.tag} is not supported.`);
+    default: throw Error(`Type '${type.tag}' is not supported.`);
   }
 }
 

--- a/src/tools/manifest2proto.ts
+++ b/src/tools/manifest2proto.ts
@@ -11,7 +11,7 @@ import {Runtime} from '../runtime/runtime.js';
 import {Recipe} from '../runtime/recipe/recipe.js';
 import {Handle} from '../runtime/recipe/handle.js';
 import {Particle} from '../runtime/recipe/particle.js';
-import {Type, CollectionType, ReferenceType, SingletonType, TypeVariable} from '../runtime/type.js';
+import {Type, CollectionType, ReferenceType, SingletonType, TypeVariable, TupleType} from '../runtime/type.js';
 import {Schema} from '../runtime/schema.js';
 import {ParticleSpec} from '../runtime/particle-spec.js';
 import {assert} from '../platform/assert-web.js';
@@ -150,6 +150,11 @@ export async function typeToProtoPayload(type: Type) {
         referredType: await typeToProtoPayload((type as ReferenceType<Type>).referredType)
       }
     };
+    case 'Tuple': return {
+      tuple: {
+        elements: await Promise.all((type as TupleType).innerTypes.map(typeToProtoPayload))
+      }
+    };
     case 'Singleton': return {
       singleton: {
         singletonType: await typeToProtoPayload((type as SingletonType<Type>).getContainedType())
@@ -158,7 +163,7 @@ export async function typeToProtoPayload(type: Type) {
     case 'Count': return {
       count: true
     };
-    // TODO(b/155944755)
+    // TODO(b/154733929)
     // case 'TypeVariable': return {
     //   variable: {
     //     name: (type as TypeVariable).variable.name,

--- a/src/tools/tests/manifest2proto-test.ts
+++ b/src/tools/tests/manifest2proto-test.ts
@@ -265,7 +265,7 @@ describe('manifest2proto', () => {
     assert.deepStrictEqual(await toProtoAndBackType(singletonOfCount), {
       singleton: {
         singletonType: {
-          count: true
+          count: {}
         }
       }
     });

--- a/src/tools/tests/manifest2proto-test.ts
+++ b/src/tools/tests/manifest2proto-test.ts
@@ -9,7 +9,7 @@
  */
 import {assert} from '../../platform/chai-web.js';
 import {encodeManifestToProto, typeToProtoPayload, manifestToProtoPayload, capabilitiesToProtoOrdinals} from '../manifest2proto.js';
-import {EntityType, Type} from '../../runtime/type.js';
+import {CountType, EntityType, SingletonType, Type, TypeVariable} from '../../runtime/type.js';
 import {Manifest} from '../../runtime/manifest.js';
 import {Capabilities} from '../../runtime/capabilities.js';
 import {fs} from '../../platform/fs-web.js';
@@ -196,6 +196,38 @@ describe('manifest2proto', () => {
               hash: '1c9b8f8d51ff6e11235ac13bf0c5ca74c88537e0',
             }
           }
+        }
+      }
+    });
+  });
+
+  it('encodes singleton type', async () => {
+    const singleton = EntityType.make(['Foo'], {value: 'Text'}).singletonOf();
+    assert.deepStrictEqual(await toProtoAndBackType(singleton), {
+      singleton: {
+        singletonType: {
+          entity: {
+            schema: {
+              names: ['Foo'],
+              fields: {
+                value: {
+                  primitive: 'TEXT'
+                }
+              },
+              hash: '1c9b8f8d51ff6e11235ac13bf0c5ca74c88537e0',
+            }
+          }
+        }
+      }
+    });
+  });
+
+  it('encodes count type', async () => {
+    const singletonOfCount = new SingletonType(new CountType());
+    assert.deepStrictEqual(await toProtoAndBackType(singletonOfCount), {
+      singleton: {
+        singletonType: {
+          count: true
         }
       }
     });

--- a/src/tools/tests/manifest2proto-test.ts
+++ b/src/tools/tests/manifest2proto-test.ts
@@ -9,7 +9,7 @@
  */
 import {assert} from '../../platform/chai-web.js';
 import {encodeManifestToProto, typeToProtoPayload, manifestToProtoPayload, capabilitiesToProtoOrdinals} from '../manifest2proto.js';
-import {CountType, EntityType, SingletonType, Type, TypeVariable} from '../../runtime/type.js';
+import {CountType, EntityType, SingletonType, TupleType, Type, TypeVariable} from '../../runtime/type.js';
 import {Manifest} from '../../runtime/manifest.js';
 import {Capabilities} from '../../runtime/capabilities.js';
 import {fs} from '../../platform/fs-web.js';
@@ -218,6 +218,44 @@ describe('manifest2proto', () => {
             }
           }
         }
+      }
+    });
+  });
+
+  it('encodes tuple types', async () => {
+    const first = EntityType.make(['Foo'], {value: 'Text'});
+    const second = EntityType.make(['Bar'], {value: 'Number'});
+    const tuple = new TupleType([first, second]);
+    assert.deepStrictEqual(await toProtoAndBackType(tuple), {
+      tuple: {
+        elements: [
+          {
+            entity: {
+              schema: {
+                names: ['Foo'],
+                fields: {
+                  value: {
+                    primitive: 'TEXT'
+                  }
+                },
+                hash: '1c9b8f8d51ff6e11235ac13bf0c5ca74c88537e0'
+              }
+            }
+          },
+          {
+            entity: {
+              schema: {
+                names: ['Bar'],
+                fields: {
+                  value: {
+                    primitive: 'NUMBER'
+                  }
+                },
+                hash: 'f0b9f39c14d12e1445ac70bbd28b65c0b9d30022'
+              }
+            }
+          }
+        ]
       }
     });
   });


### PR DESCRIPTION
- All `Tag.kt` types supported, except for TypeVariable, which will be handled separately. 
- TS --> proto + tests
- proto --> Kt + tests