### PR TITLE
Let the system-health test activity run in remote process

### DIFF
--- a/javatests/arcs/android/systemhealth/testapp/AndroidManifest.xml
+++ b/javatests/arcs/android/systemhealth/testapp/AndroidManifest.xml
@@ -30,7 +30,8 @@
     <activity
       android:name=".TestActivity"
       android:launchMode="singleTask"
-      android:theme="@style/Theme.AppCompat.Light">
+      android:theme="@style/Theme.AppCompat.Light"
+      android:process=":syshealth_app">
       <intent-filter>
         <action android:name="android.intent.action.MAIN"/>
         <category android:name="android.intent.category.LAUNCHER"/>


### PR DESCRIPTION
Like how it was originally designed in g3 for the purposes:
1) debug remote ipc and proto (de)serialization overhead from UI.
2) e2e auto breakdown tool can generate better report due to more clear process boundary between StorageService, a remote writer and a remote reader, all of them run in different processes.