### PR TITLE
Fixes a bug in path joining in loader

### DIFF
--- a/src/platform/loader-base.ts
+++ b/src/platform/loader-base.ts
@@ -199,8 +199,8 @@ export abstract class LoaderBase {
     // remove './'
     path = path.replace(/\/\.\//g, '/');
     // remove 'foo/..'
-    const norm = s => s.replace(/(?:^|\/)[^./]*\/\.\./g, '');
-    // keep removing `<name>/..` until there are no more
+    const norm = (s: string) => s.replace(/[^./]+\/\.\.\//g, '');
+    // keep removing `<name>/../` until there are no more
     for (let n = norm(path); n !== path; path = n, n = norm(path));
     // remove '//' except after `:`
     path = path.replace(/([^:])(\/\/)/g, '$1/');

--- a/src/platform/tests/loader-test.ts
+++ b/src/platform/tests/loader-test.ts
@@ -52,6 +52,20 @@ describe('PlatformLoader', () => {
     assert.equal(loader.resolve('https://$macro/Feature.arcs'),
         '../../over/here/Feature.arcs');
   });
+  it('can joins paths', async () => {
+    const loader = new Loader({});
+
+    assert.equal(loader.join('', 'foo.arcs'), 'foo.arcs');
+    assert.equal(loader.join('/', 'a.arcs'), '/a.arcs');
+    assert.equal(loader.join('a/b/c/', 'x.arcs'), 'a/b/c/x.arcs');
+    assert.equal(loader.join('a/b/c/', ''), 'a/b/c/');
+    assert.equal(loader.join('a/b/c/', 'd/e/f'), 'a/b/c/d/e/f');
+    assert.equal(loader.join('a/b/c/', './d/e/f'), 'a/b/c/d/e/f');
+    assert.equal(loader.join('a/b/c/', '/d/e/f'), '/d/e/f');
+    assert.equal(loader.join('a/b/c/', '../../d/e/f'), 'a/d/e/f');
+    assert.equal(loader.join('a/b/c/', '../../../d/e/f'), 'd/e/f');
+    assert.equal(loader.join('/a/b/c/', '../../../d/e/f'), '/d/e/f');
+  });
   it('recognizes JVM classpaths', () => {
     const loader = new Loader();
 


### PR DESCRIPTION
In the loader path normalizing we were turning:
`a/../b.txt` into `/b.txt`, while `b.txt` should have been the output.