### PR TITLE
Enable protos prefetcher on critical Arcs services and applications

### DIFF
--- a/java/arcs/android/sdk/host/ArcHostService.kt
+++ b/java/arcs/android/sdk/host/ArcHostService.kt
@@ -12,6 +12,7 @@ package arcs.android.sdk.host
 
 import android.content.Intent
 import androidx.lifecycle.LifecycleService
+import arcs.android.util.ProtoPrefetcher
 import arcs.core.host.ArcHost
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.MainScope
@@ -33,6 +34,11 @@ abstract class ArcHostService : LifecycleService() {
 
     val arcHostHelper: ArcHostHelper by lazy {
         ArcHostHelper(this, *arcHosts.toTypedArray())
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        ProtoPrefetcher.prefetch()
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {

--- a/java/arcs/android/sdk/host/BUILD
+++ b/java/arcs/android/sdk/host/BUILD
@@ -11,6 +11,7 @@ arcs_kt_android_library(
     deps = [
         "//java/arcs/android/host/parcelables",
         "//java/arcs/android/type",
+        "//java/arcs/android/util",
         "//java/arcs/core/data",
         "//java/arcs/core/host",
         "//java/arcs/core/storage",

--- a/java/arcs/sdk/android/storage/service/StorageService.kt
+++ b/java/arcs/sdk/android/storage/service/StorageService.kt
@@ -26,6 +26,7 @@ import arcs.android.storage.service.BindingContextStatsImpl
 import arcs.android.storage.service.StorageServiceManager
 import arcs.android.storage.ttl.PeriodicCleanupTask
 import arcs.android.util.AndroidBinderStats
+import arcs.android.util.ProtoPrefetcher
 import arcs.core.storage.ProxyMessage
 import arcs.core.storage.StorageKey
 import arcs.core.storage.Store
@@ -74,6 +75,7 @@ class StorageService : ResurrectorService() {
         log.debug { "onCreate" }
         startTime = startTime ?: System.currentTimeMillis()
 
+        ProtoPrefetcher.prefetch()
         StoreWriteBack.init(writeBackScope)
 
         val periodicCleanupTask =

--- a/javatests/arcs/android/systemhealth/testapp/TestApplication.kt
+++ b/javatests/arcs/android/systemhealth/testapp/TestApplication.kt
@@ -14,6 +14,7 @@ package arcs.android.systemhealth.testapp
 import android.app.Application
 import androidx.work.Configuration
 import arcs.android.storage.database.AndroidSqliteDatabaseManager
+import arcs.android.util.ProtoPrefetcher
 import arcs.android.util.initLogForAndroid
 import arcs.core.entity.SchemaRegistry
 import arcs.core.storage.api.DriverAndKeyConfigurator
@@ -29,6 +30,8 @@ class TestApplication : Application(), Configuration.Provider {
 
     override fun onCreate() {
         super.onCreate()
+
+        ProtoPrefetcher.prefetch()
 
         RamDisk.clear()
         SchemaRegistry.register(TestEntity)


### PR DESCRIPTION
This is a follow-up PR for #5225 

Enable it on:
a) client: ArcHostService
b) client: SystemHealth app
c) server: StorageService