### PR TITLE
Completing HandleProto (de)serialization

### DIFF
--- a/java/arcs/core/data/Recipe.kt
+++ b/java/arcs/core/data/Recipe.kt
@@ -40,8 +40,7 @@ data class Recipe(
         val type: Type,
         val storageKey: String? = null,
         val capabilities: Capabilities? = null,
-        val associatedHandleNames: List<String> = emptyList(),
-        val associatedHandles: MutableList<Handle> = mutableListOf<Handle>()
+        val associatedHandles: List<Handle> = emptyList()
     ) {
         enum class Fate {
             CREATE, USE, MAP, COPY, JOIN

--- a/java/arcs/core/data/Recipe.kt
+++ b/java/arcs/core/data/Recipe.kt
@@ -40,9 +40,9 @@ data class Recipe(
         val type: Type,
         val storageKey: String? = null,
         val capabilities: Capabilities? = null,
-        val associatedHandles: List<String> = emptyList()
+        val associatedHandleNames: List<String> = emptyList(),
+        val associatedHandles: MutableList<Handle> = mutableListOf<Handle>()
     ) {
-        // TODO(bgogul): associatedHandles should be changed to List<Handle>.
         enum class Fate {
             CREATE, USE, MAP, COPY, JOIN
         }

--- a/java/arcs/core/data/proto/HandleProtoDecoder.kt
+++ b/java/arcs/core/data/proto/HandleProtoDecoder.kt
@@ -47,11 +47,11 @@ fun List<HandleProto.Capability>.decode() = Capabilities(
  *
  * If a type is not set in the [HandleProto], it is initialized to a newly created TypeVariable.
  */
-fun HandleProto.decode() = Handle(
+fun HandleProto.decode(knownHandles: Map<String, Handle> = mutableMapOf()) = Handle(
     name = name,
     fate = fate.decode(),
     storageKey = storageKey,
     type = if (hasType()) type.decode() else TypeVariable("$name"),
     capabilities = capabilitiesList.decode(),
-    associatedHandleNames = associatedHandlesList
+    associatedHandles = associatedHandlesList.map { knownHandles[it]!! }
 )

--- a/java/arcs/core/data/proto/HandleProtoDecoder.kt
+++ b/java/arcs/core/data/proto/HandleProtoDecoder.kt
@@ -46,12 +46,13 @@ fun List<HandleProto.Capability>.decode() = Capabilities(
  * Converts [HandleProto] into [Handle].
  *
  * If a type is not set in the [HandleProto], it is initialized to a newly created TypeVariable.
+ * @param knownHandles is a map of [Handle]s used the the recipe level to decode associatedHandles.
  */
-fun HandleProto.decode(knownHandles: Map<String, Handle> = mutableMapOf()) = Handle(
+fun HandleProto.decode(knownHandles: Map<String, Handle> = emptyMap()) = Handle(
     name = name,
     fate = fate.decode(),
     storageKey = storageKey,
     type = if (hasType()) type.decode() else TypeVariable("$name"),
     capabilities = capabilitiesList.decode(),
-    associatedHandles = associatedHandlesList.map { knownHandles[it]!! }
+    associatedHandles = associatedHandlesList.map { requireNotNull(knownHandles[it]) }
 )

--- a/java/arcs/core/data/proto/HandleProtoDecoder.kt
+++ b/java/arcs/core/data/proto/HandleProtoDecoder.kt
@@ -53,5 +53,5 @@ fun HandleProto.decode() = Handle(
     storageKey = storageKey,
     type = if (hasType()) type.decode() else TypeVariable("$name"),
     capabilities = capabilitiesList.decode(),
-    associatedHandles = getAssociatedHandlesList()
+    associatedHandleNames = associatedHandlesList
 )

--- a/java/arcs/core/data/proto/RecipeProtoDecoder.kt
+++ b/java/arcs/core/data/proto/RecipeProtoDecoder.kt
@@ -36,4 +36,3 @@ fun RecipeProto.decode(particleSpecs: Map<String, ParticleSpec>): Recipe {
     val particles = particlesList.map { it.decode(context) }
     return Recipe(name.ifBlank { null }, recipeHandles, particles, arcId.ifBlank { null })
 }
-

--- a/java/arcs/core/data/proto/RecipeProtoDecoder.kt
+++ b/java/arcs/core/data/proto/RecipeProtoDecoder.kt
@@ -17,17 +17,23 @@ import arcs.core.data.Recipe
 /** Converts a [RecipeProto] into [Recipe]. */
 fun RecipeProto.decode(particleSpecs: Map<String, ParticleSpec>): Recipe {
     val recipeHandles = mutableMapOf<String, Recipe.Handle>()
-    handlesList.forEach {
-        val oldValue = recipeHandles.put(it.name, it.decode())
+    val decodeAndUpdate = { it: HandleProto ->
+        val oldValue = recipeHandles.put(it.name, it.decode(recipeHandles))
         require(oldValue == null) {
             "Duplicate handle '${it.name}' when decoding recipe '$name'."
         }
     }
-    // Support joins: Associate handles with each other
-    recipeHandles.values.forEach {
-        it.associatedHandleNames.forEach { name -> it.associatedHandles.add(recipeHandles[name]!!) }
-    }
+
+    handlesList
+        .filter { it.fate.decode() != Recipe.Handle.Fate.JOIN }
+        .forEach(decodeAndUpdate)
+
+    handlesList
+        .filter { it.fate.decode() == Recipe.Handle.Fate.JOIN }
+        .forEach(decodeAndUpdate)
+
     val context = DecodingContext(particleSpecs, recipeHandles)
     val particles = particlesList.map { it.decode(context) }
     return Recipe(name.ifBlank { null }, recipeHandles, particles, arcId.ifBlank { null })
 }
+

--- a/java/arcs/core/data/proto/RecipeProtoDecoder.kt
+++ b/java/arcs/core/data/proto/RecipeProtoDecoder.kt
@@ -17,10 +17,10 @@ import arcs.core.data.Recipe
 /** Converts a [RecipeProto] into [Recipe]. */
 fun RecipeProto.decode(particleSpecs: Map<String, ParticleSpec>): Recipe {
     val recipeHandles = mutableMapOf<String, Recipe.Handle>()
-    val decodeAndUpdate = { it: HandleProto ->
-        val oldValue = recipeHandles.put(it.name, it.decode(recipeHandles))
+    val decodeAndUpdate = { handleProto: HandleProto ->
+        val oldValue = recipeHandles.put(handleProto.name, handleProto.decode(recipeHandles))
         require(oldValue == null) {
-            "Duplicate handle '${it.name}' when decoding recipe '$name'."
+            "Duplicate handle '${handleProto.name}' when decoding recipe '$name'."
         }
     }
 

--- a/java/arcs/core/data/proto/RecipeProtoDecoder.kt
+++ b/java/arcs/core/data/proto/RecipeProtoDecoder.kt
@@ -23,6 +23,10 @@ fun RecipeProto.decode(particleSpecs: Map<String, ParticleSpec>): Recipe {
             "Duplicate handle '${it.name}' when decoding recipe '$name'."
         }
     }
+    // Support joins: Associate handles with each other
+    recipeHandles.values.forEach {
+        it.associatedHandleNames.forEach { name -> it.associatedHandles.add(recipeHandles[name]!!) }
+    }
     val context = DecodingContext(particleSpecs, recipeHandles)
     val particles = particlesList.map { it.decode(context) }
     return Recipe(name.ifBlank { null }, recipeHandles, particles, arcId.ifBlank { null })

--- a/javatests/arcs/core/data/proto/HandleProtoDecoderTest.kt
+++ b/javatests/arcs/core/data/proto/HandleProtoDecoderTest.kt
@@ -75,7 +75,7 @@ class HandleProtoDecoderTest {
             assertThat(name).isEqualTo("notype_thing")
             assertThat(fate).isEqualTo(Handle.Fate.CREATE)
             assertThat(storageKey).isEqualTo("ramdisk://a")
-            assertThat(associatedHandles.map { it.name }).containsExactly("handle1", "handle_c")
+            assertThat(associatedHandles).containsExactly(handles["handle1"], handles["handle_c"])
             assertThat(type).isEqualTo(TypeVariable("notype_thing"))
             assertThat(capabilities).isEqualTo(Capabilities.TiedToArc)
         }
@@ -115,7 +115,7 @@ class HandleProtoDecoderTest {
             assertThat(name).isEqualTo("thing")
             assertThat(fate).isEqualTo(Handle.Fate.JOIN)
             assertThat(storageKey).isEqualTo("ramdisk://b")
-            assertThat(associatedHandles.map { it.name }).isEqualTo(listOf("handle1", "handle_join"))
+            assertThat(associatedHandles).isEqualTo(listOf(handles["handle1"], handles["handle_join"]))
             assertThat(type).isEqualTo(entityType)
             assertThat(capabilities).isEqualTo(Capabilities.PersistentQueryable)
         }

--- a/javatests/arcs/core/data/proto/HandleProtoDecoderTest.kt
+++ b/javatests/arcs/core/data/proto/HandleProtoDecoderTest.kt
@@ -66,12 +66,16 @@ class HandleProtoDecoderTest {
         val handleText = buildHandleProtoText(
             "notype_thing", "CREATE", "", storageKey, "handle_c", listOf("TIED_TO_ARC")
         )
+        val handles = mapOf(
+            "handle_c" to Handle("handle_c", Handle.Fate.MAP, TypeVariable("handle_c")),
+            "handle1" to Handle("handle1", Handle.Fate.MAP, TypeVariable("handle1"))
+        )
         val handleProto = parseHandleProtoText(handleText)
-        with(handleProto.decode()) {
+        with(handleProto.decode(handles)) {
             assertThat(name).isEqualTo("notype_thing")
             assertThat(fate).isEqualTo(Handle.Fate.CREATE)
             assertThat(storageKey).isEqualTo("ramdisk://a")
-            assertThat(associatedHandleNames).containsExactly("handle1", "handle_c")
+            assertThat(associatedHandles.map { it.name }).containsExactly("handle1", "handle_c")
             assertThat(type).isEqualTo(TypeVariable("notype_thing"))
             assertThat(capabilities).isEqualTo(Capabilities.TiedToArc)
         }
@@ -102,11 +106,16 @@ class HandleProtoDecoderTest {
             listOf("PERSISTENT", "QUERYABLE")
         )
         val handleProto = parseHandleProtoText(handleText)
-        with(handleProto.decode()) {
+
+        val handles = mapOf(
+            "handle1" to Handle("handle1", Handle.Fate.MAP, TypeVariable("handle1")),
+            "handle_join" to Handle("handle_join", Handle.Fate.JOIN, TypeVariable("handle_join"))
+        )
+        with(handleProto.decode(handles)) {
             assertThat(name).isEqualTo("thing")
             assertThat(fate).isEqualTo(Handle.Fate.JOIN)
             assertThat(storageKey).isEqualTo("ramdisk://b")
-            assertThat(associatedHandleNames).isEqualTo(listOf("handle1", "handle_join"))
+            assertThat(associatedHandles.map { it.name }).isEqualTo(listOf("handle1", "handle_join"))
             assertThat(type).isEqualTo(entityType)
             assertThat(capabilities).isEqualTo(Capabilities.PersistentQueryable)
         }

--- a/javatests/arcs/core/data/proto/HandleProtoDecoderTest.kt
+++ b/javatests/arcs/core/data/proto/HandleProtoDecoderTest.kt
@@ -71,7 +71,7 @@ class HandleProtoDecoderTest {
             assertThat(name).isEqualTo("notype_thing")
             assertThat(fate).isEqualTo(Handle.Fate.CREATE)
             assertThat(storageKey).isEqualTo("ramdisk://a")
-            assertThat(associatedHandles).containsExactly("handle1", "handle_c")
+            assertThat(associatedHandleNames).containsExactly("handle1", "handle_c")
             assertThat(type).isEqualTo(TypeVariable("notype_thing"))
             assertThat(capabilities).isEqualTo(Capabilities.TiedToArc)
         }
@@ -106,7 +106,7 @@ class HandleProtoDecoderTest {
             assertThat(name).isEqualTo("thing")
             assertThat(fate).isEqualTo(Handle.Fate.JOIN)
             assertThat(storageKey).isEqualTo("ramdisk://b")
-            assertThat(associatedHandles).isEqualTo(listOf("handle1", "handle_join"))
+            assertThat(associatedHandleNames).isEqualTo(listOf("handle1", "handle_join"))
             assertThat(type).isEqualTo(entityType)
             assertThat(capabilities).isEqualTo(Capabilities.PersistentQueryable)
         }

--- a/javatests/arcs/core/data/proto/RecipeProtoDecoderTest.kt
+++ b/javatests/arcs/core/data/proto/RecipeProtoDecoderTest.kt
@@ -64,7 +64,6 @@ class RecipeProtoDecoderTest {
         TypeVariable("pairs"),
         ramdiskStorageKey + "pairs",
         Capabilities.Empty,
-        associatedHandleNames = listOf("thing", "thang"),
         associatedHandles = mutableListOf(thingHandle, thangHandle)
     )
     val readConnectionSpec = HandleConnectionSpec("data", HandleMode.Read, thingEntity)

--- a/javatests/arcs/core/data/proto/RecipeProtoDecoderTest.kt
+++ b/javatests/arcs/core/data/proto/RecipeProtoDecoderTest.kt
@@ -20,21 +20,53 @@ import org.junit.runners.JUnit4
 @RunWith(JUnit4::class)
 class RecipeProtoDecoderTest {
     // The test environment.
-    val ramdiskStorageKey = "ramdisk://thing"
+    val ramdiskStorageKey = "ramdisk://"
     val thingHandleProto = HandleProto.newBuilder()
         .setName("thing")
         .setFate(HandleProto.Fate.CREATE)
-        .setStorageKey(ramdiskStorageKey)
+        .setStorageKey(ramdiskStorageKey + "thing")
         .build()
     val thingHandle = Handle(
-        "thing", Handle.Fate.CREATE, TypeVariable("thing"), ramdiskStorageKey, Capabilities.Empty
+        "thing",
+        Handle.Fate.CREATE,
+        TypeVariable("thing"),
+        ramdiskStorageKey + "thing",
+        Capabilities.Empty
     )
     val thingSchema = Schema(
-            names = setOf(SchemaName("Thing")),
-            fields = SchemaFields(singletons=mapOf("name" to FieldType.Text), collections=mapOf()),
-            hash = ""
+        names = setOf(SchemaName("Thing")),
+        fields = SchemaFields(singletons = mapOf("name" to FieldType.Text), collections = mapOf()),
+        hash = ""
     )
     val thingEntity = EntityType(thingSchema)
+    val thangHandleProto = HandleProto.newBuilder()
+        .setName("thang")
+        .setFate(HandleProto.Fate.MAP)
+        .setStorageKey(ramdiskStorageKey + "thang")
+        .build()
+    val thangHandle = Handle(
+        "thang",
+        Handle.Fate.MAP,
+        TypeVariable("thang"),
+        ramdiskStorageKey + "thang",
+        Capabilities.Empty
+    )
+    val joinHandleProto = HandleProto.newBuilder()
+        .setName("pairs")
+        .setFate(HandleProto.Fate.JOIN)
+        .addAssociatedHandles("thing")
+        .addAssociatedHandles("thang")
+        .setStorageKey(ramdiskStorageKey + "pairs")
+        .build()
+    val joinHandle = Handle(
+        "pairs",
+        Handle.Fate.JOIN,
+        TypeVariable("pairs"),
+        ramdiskStorageKey + "pairs",
+        Capabilities.Empty,
+        associatedHandleNames = listOf("thing", "thang"),
+        associatedHandles = mutableListOf(thingHandle, thangHandle)
+    )
     val readConnectionSpec = HandleConnectionSpec("data", HandleMode.Read, thingEntity)
     val readerSpec = ParticleSpec("Reader", mapOf("data" to readConnectionSpec), "ReaderLocation")
     val writeConnectionSpec = HandleConnectionSpec("data", HandleMode.Write, thingEntity)
@@ -75,6 +107,15 @@ class RecipeProtoDecoderTest {
         .addParticles(writerParticle)
         .build()
 
+    val recipeWithJoin = RecipeProto.newBuilder()
+        .setName("WithJoin")
+        .setArcId("arc-with-join")
+        .addHandles(thingHandleProto)
+        .addHandles(thangHandleProto)
+        .addHandles(joinHandleProto)
+        .build()
+
+
     @Test
     fun decodesRecipe() {
         with(recipeProto.decode(context.particleSpecs)) {
@@ -113,5 +154,18 @@ class RecipeProtoDecoderTest {
         assertThat(exception).hasMessageThat().contains(
             "Duplicate handle 'thing' when decoding recipe 'Duplicates'."
         )
+    }
+
+    @Test
+    fun decodeRecipeWithJoins() {
+        with(recipeWithJoin.decode(context.particleSpecs)) {
+            assertThat(name).isEqualTo("WithJoin")
+            assertThat(arcId).isEqualTo("arc-with-join")
+            assertThat(handles).isEqualTo(mapOf(
+                "thing" to thingHandle,
+                "thang" to thangHandle,
+                "pairs" to joinHandle
+            ))
+        }
     }
 }

--- a/javatests/arcs/core/data/proto/RecipeProtoDecoderTest.kt
+++ b/javatests/arcs/core/data/proto/RecipeProtoDecoderTest.kt
@@ -114,7 +114,6 @@ class RecipeProtoDecoderTest {
         .addHandles(joinHandleProto)
         .build()
 
-
     @Test
     fun decodesRecipe() {
         with(recipeProto.decode(context.particleSpecs)) {
@@ -160,11 +159,13 @@ class RecipeProtoDecoderTest {
         with(recipeWithJoin.decode(context.particleSpecs)) {
             assertThat(name).isEqualTo("WithJoin")
             assertThat(arcId).isEqualTo("arc-with-join")
-            assertThat(handles).isEqualTo(mapOf(
-                "thing" to thingHandle,
-                "thang" to thangHandle,
-                "pairs" to joinHandle
-            ))
+            assertThat(handles).isEqualTo(
+                mapOf(
+                    "thing" to thingHandle,
+                    "thang" to thangHandle,
+                    "pairs" to joinHandle
+                )
+            )
         }
     }
 }

--- a/src/tools/manifest2proto.ts
+++ b/src/tools/manifest2proto.ts
@@ -102,16 +102,25 @@ async function recipeHandleToProtoPayload(handle: Handle) {
   if (fateOrdinal === undefined) {
     throw Error(`Handle fate ${handle.fate} is not supported`);
   }
-
-  return ({
-    name: handle.localName || `handle${handle.recipe.handles.indexOf(handle)}`,
+  const toName = handle => handle.localName || `handle${handle.recipe.handles.indexOf(handle)}`;
+  const handleData = {
+    name: toName(handle),
     id: handle.id,
     tags: handle.tags,
     fate: fateOrdinal,
     capabilities: capabilitiesToProtoOrdinals(handle.capabilities),
-    storageKey: handle.storageKey && handle.storageKey.toString(),
     type: await typeToProtoPayload(handle.type || handle.mappedType)
-  });
+  };
+
+  if (handle.storageKey) {
+    handleData['storageKey'] = handle.storageKey.toString();
+  }
+
+  if (handle.fate.toUpperCase() === 'JOIN' && handle.joinedHandles) {
+    handleData['associatedHandles'] = handle.joinedHandles.map(toName);
+  }
+
+  return handleData;
 }
 
 export function capabilitiesToProtoOrdinals(capabilities: Capabilities) {

--- a/src/tools/manifest2proto.ts
+++ b/src/tools/manifest2proto.ts
@@ -116,7 +116,7 @@ async function recipeHandleToProtoPayload(handle: Handle) {
     handleData['storageKey'] = handle.storageKey.toString();
   }
 
-  if (handle.fate.toUpperCase() === 'JOIN' && handle.joinedHandles) {
+  if (handle.fate === 'join' && handle.joinedHandles) {
     handleData['associatedHandles'] = handle.joinedHandles.map(toName);
   }
 

--- a/src/tools/tests/manifest2proto-test.ts
+++ b/src/tools/tests/manifest2proto-test.ts
@@ -125,11 +125,11 @@ describe('manifest2proto', () => {
       handles: [{
         fate: 'JOIN',
         name: 'handle0',
-        associatedHandles: ["handle1", "handle2"]
+        associatedHandles: ['handle1', 'handle2']
       }, {
         fate: 'USE',
         name: 'handle1',
-        id: "folks",
+        id: 'folks',
         tags: ['tag1'],
       }, {
         fate: 'MAP',

--- a/src/tools/tests/manifest2proto-test.ts
+++ b/src/tools/tests/manifest2proto-test.ts
@@ -101,6 +101,51 @@ describe('manifest2proto', () => {
     assert.deepEqual(capabilitiesToStrings(Capabilities.persistentQueryable), ['PERSISTENT', 'QUERYABLE']);
   });
 
+  it('encodes handle joins', async () => {
+    const manifest = await Manifest.parse(`
+      particle Foo
+        data: reads [(
+          &Person {name: Text},
+          &Place {address: Text},
+        )]
+      recipe
+        people: use 'folks' #tag1
+        pairs: join (people, places)
+        places: map 'locations'
+        Foo
+          data: reads pairs
+    `);
+    const recipe = (await toProtoAndBack(manifest)).recipes[0];
+
+    // Clear the type so that the test is more readable. Tests for types encoding below.
+    for (const handle of recipe.handles) {
+      delete handle.type;
+    }
+    assert.deepStrictEqual(recipe, {
+      handles: [{
+        fate: 'JOIN',
+        name: 'handle0',
+        associatedHandles: ["handle1", "handle2"]
+      }, {
+        fate: 'USE',
+        name: 'handle1',
+        id: "folks",
+        tags: ['tag1'],
+      }, {
+        fate: 'MAP',
+        name: 'handle2',
+        id: 'locations'
+      }],
+      particles: [{
+        specName: 'Foo',
+        connections: [{
+          handle: 'handle0',
+          name: 'data'
+        }]
+      }]
+    });
+  });
+
   it('encodes particle spec', async () => {
     const manifest = await Manifest.parse(`
       particle Abc in 'a/b/c.js'


### PR DESCRIPTION
- Fills in needed information into Handle proto from TS (associated_handles)
- Decodes Handles with associated handle information in Kotlin
- Supported with tests