### PR TITLE
Add a utility extension function to merge maps.

### DIFF
--- a/java/arcs/core/util/collection.kt
+++ b/java/arcs/core/util/collection.kt
@@ -14,3 +14,39 @@ package arcs.core.util
 /** Implementation of Java's `compute` which expects, and returns, a non-null result. */
 fun <K, V> MutableMap<K, V>.computeNotNull(key: K, updater: (K, V?) -> V): V =
     updater(key, this[key]).also { this[key] = it }
+
+/**
+ * Returns a map obtained by merging [this] map with [that] map by applying [combine] for values.
+ *
+ * The [combine] function is passed a key and the corresponding values from both the maps. If a key
+ * is absent in a map, the corresponding value argument to [combine] is set to `null`. The result
+ * of the [combine] function is used as the value for the key in the returned map. If [combine]
+ * returns null, the corresponding key is ignored in the result.
+ *
+ * Here is an example usage:
+ * ```
+ * val result = m1.mergeWith(m2) { k, v1, v2 ->
+ *     when {
+ *         v1 != null && v2 != null -> // k is present in both maps
+ *         v1 != null -> // k is only present in m1
+ *         v2 != null -> // k is only present in m2
+ *         else -> // should never happen.
+ *     }
+ * }
+ * ```
+ */
+fun <K, V> Map<K, V>.mergeWith(
+    that: Map<K, V>,
+    combine: (K, V?, V?) -> V?
+): Map<K, V> {
+    val thisKeys = this.asSequence()
+        .mapNotNull { (key, value) ->
+            combine(key, value, that[key])?.let { result -> key to result }
+        }
+    val thatOnlyKeys = that.asSequence()
+        .filter { this[it.key] == null }
+        .mapNotNull { (key, value) ->
+            combine(key, null, value)?.let { result -> key to result }
+        }
+    return (thisKeys + thatOnlyKeys).toMap()
+}

--- a/javatests/arcs/core/util/CollectionTest.kt
+++ b/javatests/arcs/core/util/CollectionTest.kt
@@ -1,0 +1,74 @@
+package arcs.core.util
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class CollectionTest {
+    private val m1 = mapOf("A" to 1, "B" to 2, "C" to 3)
+    private val m2 = mapOf("A" to 4, "B" to 5,  "D" to 6)
+
+    @Test
+    fun mergeMapValuesInBothMaps() {
+        val m1andm2Values = m1.mergeWith(m2) { _, v1, v2 ->
+            when {
+                v1 != null && v2 != null -> v1 + v2
+                else -> null
+            }
+        }
+        assertThat(m1andm2Values).isEqualTo(mapOf("A" to 5, "B" to 7))
+    }
+
+    @Test
+    fun mergeWithValuesInFirstMap() {
+        val m1Values = m1.mergeWith(m2) { _, v1, v2 ->
+            when {
+                v1 != null && v2 == null -> v1
+                else -> null
+            }
+        }
+        assertThat(m1Values).isEqualTo(mapOf("C" to 3))
+    }
+
+    @Test
+    fun mergeWithValuesInSecondMap() {
+        val m2Values = m1.mergeWith(m2) { _, v1, v2 ->
+            when {
+                v1 == null && v2 != null -> v2
+                else -> null
+            }
+        }
+        assertThat(m2Values).isEqualTo(mapOf("D" to 6))
+    }
+
+    @Test
+    fun mergeWithValuesInEitherMap() {
+        val m1orm2Values = m1.mergeWith(m2) { _, v1, v2 ->
+            when {
+                v1 != null && v2 != null -> v1 + v2
+                v1 != null -> v1
+                v2 != null -> v2
+                else -> null
+            }
+        }
+        assertThat(m1orm2Values).isEqualTo(
+            mapOf("A" to 5, "B" to 7, "C" to 3, "D" to 6)
+        )
+    }
+
+    @Test
+    fun mergeWithValuesWithKeyFilter() {
+        val onlyAorDValues = m1.mergeWith(m2) { k, v1, v2 ->
+            when {
+                k != "A" && k != "D" -> null
+                v1 != null && v2 != null -> v1 + v2
+                v1 != null -> v1
+                v2 != null -> v2
+                else -> null
+            }
+        }
+        assertThat(onlyAorDValues).isEqualTo(mapOf("A" to 5, "D" to 6))
+    }
+}


### PR DESCRIPTION
This PR introduces a `mergeWith` extension function for `Map<K, V>` to combine two maps. Here is an example usage:
```
val result = m1.mergeWith(m2) { k, v1, v2 ->
      when { 
             v1 != null && v2 != null -> // k is present in both maps
             v1 != null -> // k is only present in m1
             v2 != null -> // k is only present in m2
             else -> // should never happen.
     }
}
```

This utility will be useful for which will be useful for various data flow analysis tasks.  