### PR TITLE
Remove SchemaRegistry.getEntitySpec().

### DIFF
--- a/java/arcs/core/entity/EntityBase.kt
+++ b/java/arcs/core/entity/EntityBase.kt
@@ -19,7 +19,6 @@ import arcs.core.data.RawEntity
 import arcs.core.data.RawEntity.Companion.NO_REFERENCE_ID
 import arcs.core.data.RawEntity.Companion.UNINITIALIZED_TIMESTAMP
 import arcs.core.data.Schema
-import arcs.core.data.SchemaName
 import arcs.core.data.Ttl
 import arcs.core.data.util.ReferencablePrimitive
 import arcs.core.data.util.toReferencable
@@ -209,7 +208,7 @@ open class EntityBase(
      * Supports type slicing: fields that are not present in the [Schema] for this [Entity] will be
      * silently ignored.
      *
-     * @param nestedEntitySpecs mapping from [SchemaName] to [EntitySpec], used when dereferencing
+     * @param nestedEntitySpecs mapping from [SchemaHash] to [EntitySpec], used when dereferencing
      *     [Reference] fields inside the entity
      */
     fun deserialize(

--- a/java/arcs/core/entity/EntityBase.kt
+++ b/java/arcs/core/entity/EntityBase.kt
@@ -19,9 +19,11 @@ import arcs.core.data.RawEntity
 import arcs.core.data.RawEntity.Companion.NO_REFERENCE_ID
 import arcs.core.data.RawEntity.Companion.UNINITIALIZED_TIMESTAMP
 import arcs.core.data.Schema
+import arcs.core.data.SchemaName
 import arcs.core.data.Ttl
 import arcs.core.data.util.ReferencablePrimitive
 import arcs.core.data.util.toReferencable
+import arcs.core.storage.Reference as StorageReference
 import arcs.core.util.Time
 import kotlin.reflect.KProperty
 
@@ -206,17 +208,29 @@ open class EntityBase(
      *
      * Supports type slicing: fields that are not present in the [Schema] for this [Entity] will be
      * silently ignored.
+     *
+     * @param nestedEntitySpecs mapping from [SchemaName] to [EntitySpec], used when dereferencing
+     *     [Reference] fields inside the entity
      */
-    fun deserialize(rawEntity: RawEntity) {
+    fun deserialize(
+        rawEntity: RawEntity,
+        nestedEntitySpecs: Map<SchemaHash, EntitySpec<out Entity>> = mapOf()
+    ) {
         entityId = if (rawEntity.id == NO_REFERENCE_ID) null else rawEntity.id
         rawEntity.singletons.forEach { (field, value) ->
             getSingletonTypeOrNull(field)?.let { type ->
-                setSingletonValue(field, value?.let { fromReferencable(it, type) })
+                setSingletonValue(
+                    field,
+                    value?.let { fromReferencable(it, type, nestedEntitySpecs) }
+                )
             }
         }
         rawEntity.collections.forEach { (field, values) ->
             getCollectionTypeOrNull(field)?.let { type ->
-                setCollectionValue(field, values.map { fromReferencable(it, type) }.toSet())
+                setCollectionValue(
+                    field,
+                    values.map { fromReferencable(it, type, nestedEntitySpecs) }.toSet()
+                )
             }
         }
         creationTimestamp = rawEntity.creationTimestamp
@@ -275,7 +289,7 @@ open class EntityBase(
 class EntityBaseSpec(
     override val SCHEMA: Schema
 ) : EntitySpec<EntityBase> {
-    init { SchemaRegistry.register(this) }
+    init { SchemaRegistry.register(SCHEMA) }
     override fun deserialize(data: RawEntity): EntityBase =
         EntityBase("EntityBase", SCHEMA).apply { deserialize(data) }
 }
@@ -298,14 +312,28 @@ private fun toReferencable(value: Any, type: FieldType): Referencable = when (ty
     is FieldType.EntityRef -> (value as Reference<*>).toReferencable()
 }
 
-private fun fromReferencable(referencable: Referencable, type: FieldType): Any = when (type) {
-    is FieldType.Primitive -> {
-        require(referencable is ReferencablePrimitive<*>) {
-            "Expected ReferencablePrimitive but was $referencable."
+private fun fromReferencable(
+    referencable: Referencable,
+    type: FieldType,
+    nestedEntitySpecs: Map<SchemaHash, EntitySpec<out Entity>>
+): Any {
+    return when (type) {
+        is FieldType.Primitive -> {
+            require(referencable is ReferencablePrimitive<*>) {
+                "Expected ReferencablePrimitive but was $referencable."
+            }
+            requireNotNull(referencable.value) {
+                "ReferencablePrimitive encoded an unexpected null value."
+            }
         }
-        requireNotNull(referencable.value) {
-            "ReferencablePrimitive encoded an unexpected null value."
+        is FieldType.EntityRef -> {
+            require(referencable is StorageReference) {
+                "Expected Reference but was $referencable."
+            }
+            val entitySpec = requireNotNull(nestedEntitySpecs[type.schemaHash]) {
+                "Unknown schema with hash ${type.schemaHash}."
+            }
+            Reference(entitySpec, referencable)
         }
     }
-    is FieldType.EntityRef -> Reference.fromReferencable(referencable, type.schemaHash)
 }

--- a/java/arcs/core/entity/Reference.kt
+++ b/java/arcs/core/entity/Reference.kt
@@ -44,20 +44,4 @@ class Reference<T : Entity>(
         result = 31 * result + storageReference.hashCode()
         return result
     }
-
-    companion object {
-        /** Converts the given [Referencable] into a [Reference]. */
-        /* internal */ fun fromReferencable(
-            referencable: Referencable,
-            schemaHash: String
-        ): Reference<out Entity> {
-            require(referencable is StorageReference) {
-                "Expected Reference but was $referencable."
-            }
-            val entitySpec = requireNotNull(SchemaRegistry.getEntitySpec(schemaHash)) {
-                "Unknown schema with hash $schemaHash."
-            }
-            return Reference(entitySpec, referencable)
-        }
-    }
 }

--- a/java/arcs/core/entity/SchemaRegistry.kt
+++ b/java/arcs/core/entity/SchemaRegistry.kt
@@ -15,24 +15,21 @@ import arcs.core.data.Schema
 typealias SchemaHash = String
 
 /**
- * A registry for generated [Schema]s and [EntitySpec]s.
+ * A registry for generated [Schema]s.
  */
 object SchemaRegistry {
-    private val entitySpecs = mutableMapOf<SchemaHash, EntitySpec<out Entity>>()
+    private val schemas = mutableMapOf<SchemaHash, Schema>()
 
     /** Store a [Schema] in the registry. */
-    fun register(entitySpec: EntitySpec<out Entity>) {
-        entitySpecs[entitySpec.SCHEMA.hash] = entitySpec
+    fun register(schema: Schema) {
+        schemas[schema.hash] = schema
     }
 
-    /** Given a [SchemaHash], return the [EntitySpec] for that hash, if it exists. */
-    fun getEntitySpec(hash: SchemaHash) = entitySpecs[hash]
-
     /** Given a [SchemaHash], return the [Schema] for that hash, if it exists. */
-    fun getSchema(hash: SchemaHash) = entitySpecs[hash]?.SCHEMA
+    fun getSchema(hash: SchemaHash) = schemas[hash]
 
     /** Clears the registry, for testing purposes. */
     fun clearForTest() {
-        entitySpecs.clear()
+        schemas.clear()
     }
 }

--- a/javatests/arcs/android/e2e/testapp/TestEntity.kt
+++ b/javatests/arcs/android/e2e/testapp/TestEntity.kt
@@ -48,7 +48,7 @@ class TestEntity(
         )
 
         init {
-            SchemaRegistry.register(this)
+            SchemaRegistry.register(SCHEMA)
         }
 
         override fun deserialize(data: RawEntity) = TestEntity().apply { deserialize(data) }

--- a/javatests/arcs/android/entity/TtlHandleTest.kt
+++ b/javatests/arcs/android/entity/TtlHandleTest.kt
@@ -73,7 +73,7 @@ class TtlHandleTest {
         databaseManager = AndroidSqliteDatabaseManager(ApplicationProvider.getApplicationContext())
         StoreWriteBack.writeBackFactoryOverride = WriteBackForTesting
         DriverAndKeyConfigurator.configure(databaseManager)
-        SchemaRegistry.register(DummyEntity)
+        SchemaRegistry.register(DummyEntity.SCHEMA)
     }
 
     @After

--- a/javatests/arcs/android/storage/service/StorageServiceManagerTest.kt
+++ b/javatests/arcs/android/storage/service/StorageServiceManagerTest.kt
@@ -69,7 +69,7 @@ class StorageServiceManagerTest {
     fun setUp() {
         StoreWriteBack.writeBackFactoryOverride = WriteBackForTesting
         AndroidDriverAndKeyConfigurator.configure(ApplicationProvider.getApplicationContext(), arcId)
-        SchemaRegistry.register(DummyEntity)
+        SchemaRegistry.register(DummyEntity.SCHEMA)
     }
 
     @After

--- a/javatests/arcs/android/systemhealth/testapp/TestApplication.kt
+++ b/javatests/arcs/android/systemhealth/testapp/TestApplication.kt
@@ -34,7 +34,7 @@ class TestApplication : Application(), Configuration.Provider {
         ProtoPrefetcher.prefetch()
 
         RamDisk.clear()
-        SchemaRegistry.register(TestEntity)
+        SchemaRegistry.register(TestEntity.SCHEMA)
         DriverAndKeyConfigurator.configure(AndroidSqliteDatabaseManager(this))
 
         initLogForAndroid()

--- a/javatests/arcs/android/systemhealth/testapp/TestEntity.kt
+++ b/javatests/arcs/android/systemhealth/testapp/TestEntity.kt
@@ -59,7 +59,7 @@ class TestEntity(
         )
 
         init {
-            SchemaRegistry.register(this)
+            SchemaRegistry.register(SCHEMA)
         }
 
         override fun deserialize(data: RawEntity) = TestEntity().apply { deserialize(data) }

--- a/javatests/arcs/core/entity/DummyEntity.kt
+++ b/javatests/arcs/core/entity/DummyEntity.kt
@@ -21,6 +21,8 @@ class DummyEntity : EntityBase(ENTITY_CLASS_NAME, SCHEMA), Storable {
     var texts: Set<String> by CollectionProperty()
     var refs: Set<Reference<DummyEntity>> by CollectionProperty()
 
+    private val nestedEntitySpecs = mapOf(SCHEMA_HASH to DummyEntity)
+
     fun getSingletonValueForTest(field: String) = super.getSingletonValue(field)
 
     fun getCollectionValueForTest(field: String) = super.getCollectionValue(field)
@@ -31,7 +33,7 @@ class DummyEntity : EntityBase(ENTITY_CLASS_NAME, SCHEMA), Storable {
     fun setCollectionValueForTest(field: String, values: Set<Any>) =
         super.setCollectionValue(field, values)
 
-    fun deserializeForTest(rawEntity: RawEntity) = super.deserialize(rawEntity)
+    fun deserializeForTest(rawEntity: RawEntity) = super.deserialize(rawEntity, nestedEntitySpecs)
 
     companion object : EntitySpec<DummyEntity> {
         override fun deserialize(data: RawEntity) = DummyEntity().apply { deserialize(data) }

--- a/javatests/arcs/core/entity/EntityBaseTest.kt
+++ b/javatests/arcs/core/entity/EntityBaseTest.kt
@@ -36,7 +36,7 @@ class EntityBaseTest {
 
     @Before
     fun setUp() {
-        SchemaRegistry.register(DummyEntity)
+        SchemaRegistry.register(DummyEntity.SCHEMA)
         entity = DummyEntity()
     }
 
@@ -242,6 +242,41 @@ class EntityBaseTest {
             nums = setOf(11.0, 22.0)
         }
         assertThat(deserialized).isEqualTo(expected)
+    }
+
+    @Test
+    fun deserialize_wrongType() {
+        val rawEntity = RawEntity(
+            singletons = mapOf(
+                "ref" to "def".toReferencable()
+            ),
+            collections = mapOf()
+        )
+
+        val e = assertThrows(IllegalArgumentException::class) {
+            DummyEntity().deserializeForTest(rawEntity)
+        }
+        assertThat(e).hasMessageThat().isEqualTo(
+            "Expected Reference but was Primitive(def)."
+        )
+    }
+
+    @Test
+    fun deserialize_unknownHash() {
+        val rawEntity = RawEntity(
+            singletons = mapOf(
+                "ref" to StorageReference("id", DummyStorageKey("key"), version = null)
+            ),
+            collections = mapOf()
+        )
+
+        val e = assertThrows(IllegalArgumentException::class) {
+            // Call deserialize super method, and don't give the right nestedEntitySpecs map.
+            DummyEntity().deserialize(rawEntity, nestedEntitySpecs = emptyMap())
+        }
+        assertThat(e).hasMessageThat().isEqualTo(
+            "Unknown schema with hash abcdef."
+        )
     }
 
     @Test

--- a/javatests/arcs/core/entity/HandleManagerCloseTest.kt
+++ b/javatests/arcs/core/entity/HandleManagerCloseTest.kt
@@ -47,8 +47,8 @@ class HandleManagerCloseTest {
     @Before
     fun setup() {
         DriverAndKeyConfigurator.configure(null)
-        SchemaRegistry.register(Person)
-        SchemaRegistry.register(HandleManagerTestBase.Hat)
+        SchemaRegistry.register(Person.SCHEMA)
+        SchemaRegistry.register(HandleManagerTestBase.Hat.SCHEMA)
     }
 
     fun createHandleManager() = EntityHandleManager("testArc", "", FakeTime(), scheduler)

--- a/javatests/arcs/core/entity/HandleManagerTestBase.kt
+++ b/javatests/arcs/core/entity/HandleManagerTestBase.kt
@@ -50,8 +50,8 @@ open class HandleManagerTestBase {
     val log = LogRule()
 
     init {
-        SchemaRegistry.register(Person)
-        SchemaRegistry.register(Hat)
+        SchemaRegistry.register(Person.SCHEMA)
+        SchemaRegistry.register(Hat.SCHEMA)
     }
 
     private val backingKey = RamDiskStorageKey("entities")

--- a/javatests/arcs/core/entity/ReferenceTest.kt
+++ b/javatests/arcs/core/entity/ReferenceTest.kt
@@ -50,7 +50,7 @@ class ReferenceTest {
     @Before
     fun setUp() = runBlocking {
         DriverAndKeyConfigurator.configure(null)
-        SchemaRegistry.register(DummyEntity)
+        SchemaRegistry.register(DummyEntity.SCHEMA)
 
         handle = entityHandleManager.createHandle(
             HandleSpec(
@@ -108,43 +108,6 @@ class ReferenceTest {
                 get() = DummyEntity.SCHEMA
         }
         assertThat(reference).isNotEqualTo(createReference("id", "key", someOtherSpec))
-    }
-
-    @Test
-    fun fromReferencable_roundTrip() {
-        val storageReference = StorageReference("id", RamDiskStorageKey("key"), version = null)
-        val reference = Reference.fromReferencable(storageReference, DummyEntity.SCHEMA_HASH)
-
-        val referencable = reference.toReferencable()
-        assertThat(referencable).isEqualTo(storageReference)
-
-        val reference2 = Reference.fromReferencable(referencable, DummyEntity.SCHEMA_HASH)
-        assertThat(reference2).isEqualTo(reference)
-    }
-
-    @Test
-    fun fromReferencable_wrongType() {
-        val e = assertThrows(IllegalArgumentException::class) {
-            Reference.fromReferencable("abc".toReferencable(), DummyEntity.SCHEMA_HASH)
-        }
-        assertThat(e).hasMessageThat().isEqualTo(
-            "Expected Reference but was Primitive(abc)."
-        )
-    }
-
-    @Test
-    fun fromReferencable_unknownHash() {
-        SchemaRegistry.clearForTest()
-
-        val e = assertThrows(IllegalArgumentException::class) {
-            Reference.fromReferencable(
-                StorageReference("id", RamDiskStorageKey("key"), version = null),
-                DummyEntity.SCHEMA_HASH
-            )
-        }
-        assertThat(e).hasMessageThat().isEqualTo(
-            "Unknown schema with hash ${DummyEntity.SCHEMA_HASH}."
-        )
     }
 
     private fun createReference(

--- a/javatests/arcs/core/entity/StorageAdapterTest.kt
+++ b/javatests/arcs/core/entity/StorageAdapterTest.kt
@@ -27,7 +27,7 @@ class StorageAdapterTest {
 
     @Before
     fun setUp() {
-        SchemaRegistry.register(DummyEntity)
+        SchemaRegistry.register(DummyEntity.SCHEMA)
     }
 
     @Test

--- a/javatests/arcs/schematests/Reader.kt
+++ b/javatests/arcs/schematests/Reader.kt
@@ -4,7 +4,6 @@ package arcs.schematests
 
 import arcs.core.entity.awaitReady
 import arcs.jvm.host.TargetHost
-import arcs.sdk.Reference
 import kotlinx.coroutines.withContext
 
 @TargetHost(ArcHost::class)
@@ -25,20 +24,14 @@ class Reader1 : AbstractReader1() {
     private suspend fun initialize() = this.apply {
         handles.level1.awaitReady()
     }
-    // Due to note1 below, we now work with a different particle's type.
-    private fun Writer2_Level1_Children.fromArcs() = Level0(name)
+    private fun Reader1_Level1_Children.fromArcs() = Level0(name)
 
-    private suspend fun Reader1_Level1.fromArcs() = Level1(
-        name = name,
-        // Note1:
-        // Multiple types are created with the same schema hash.
-        // The schema registry stores only 1 type per hash.
-        // So the dereferencer will find the type associated with the hash, create it, and then
-        // try to return it as the Reference type. This causes a class cast exception.
-        // As a workaround, we can cast the Reference type to the type that actually made it into
-        // the schema registry.
-        children = children.map { (it as Reference<Writer2_Level1_Children>).dereference()!!.fromArcs() }.toSet()
-    )
+    private suspend fun Reader1_Level1.fromArcs(): Level1 {
+        return Level1(
+            name = name,
+            children = children.map { it.dereference()!!.fromArcs() }.toSet()
+        )
+    }
 
     suspend fun read(): List<Level1> = withContext(handles.level1.dispatcher) {
         initialize()
@@ -51,20 +44,21 @@ class Reader2 : AbstractReader2() {
     private suspend fun initialize() = this.apply {
         handles.level2.awaitReady()
     }
-    // Due to note1 above, we now work with a different particle's type.
-    private fun Writer2_Level2_Children_Children.fromArcs() = Level0(name)
+    private fun Reader2_Level2_Children_Children.fromArcs() = Level0(name)
 
-    // Due to note1 above, we now work with a different particle's type.
-    private suspend fun Writer2_Level2_Children.fromArcs() = Level1(
-        name = name,
-        children = children.map { it.dereference()!!.fromArcs() }.toSet()
-    )
+    private suspend fun Reader2_Level2_Children.fromArcs(): Level1 {
+        return Level1(
+            name = name,
+            children = children.map { it.dereference()!!.fromArcs() }.toSet()
+        )
+    }
 
-    private suspend fun Reader2_Level2.fromArcs() = Level2(
-        name = name,
-        // See Note1 above.
-        children = children.map { (it as Reference<Writer2_Level2_Children>).dereference()!!.fromArcs() }.toSet()
-    )
+    private suspend fun Reader2_Level2.fromArcs(): Level2 {
+        return Level2(
+            name = name,
+            children = children.map { it.dereference()!!.fromArcs() }.toSet()
+        )
+    }
 
     suspend fun read(): List<Level2> = withContext(handles.level2.dispatcher) {
         initialize()

--- a/javatests/arcs/sdk/spec/EntitySpecTest.kt
+++ b/javatests/arcs/sdk/spec/EntitySpecTest.kt
@@ -206,7 +206,6 @@ class EntitySpecTest {
     fun schemaRegistry() {
         // The entity class should have registered itself statically.
         val hash = Foo.SCHEMA.hash
-        assertThat(SchemaRegistry.getEntitySpec(hash)).isEqualTo(Foo)
         assertThat(SchemaRegistry.getSchema(hash)).isEqualTo(Foo.SCHEMA)
     }
 

--- a/src/tools/tests/goldens/generated-schemas.jvm.kt
+++ b/src/tools/tests/goldens/generated-schemas.jvm.kt
@@ -71,11 +71,16 @@ abstract class AbstractGold : BaseParticle() {
                 query = null
             )
 
+            private val nestedEntitySpecs: Map<SchemaHash, EntitySpec<out Entity>> =
+                emptyMap()
+
             init {
-                SchemaRegistry.register(this)
+                SchemaRegistry.register(SCHEMA)
             }
 
-            override fun deserialize(data: RawEntity) = GoldInternal1().apply { deserialize(data) }
+            override fun deserialize(data: RawEntity) = GoldInternal1().apply {
+                deserialize(data, nestedEntitySpecs)
+            }
         }
     }
 
@@ -191,11 +196,16 @@ abstract class AbstractGold : BaseParticle() {
                 query = null
             )
 
+            private val nestedEntitySpecs: Map<SchemaHash, EntitySpec<out Entity>> =
+                emptyMap()
+
             init {
-                SchemaRegistry.register(this)
+                SchemaRegistry.register(SCHEMA)
             }
 
-            override fun deserialize(data: RawEntity) = Gold_AllPeople().apply { deserialize(data) }
+            override fun deserialize(data: RawEntity) = Gold_AllPeople().apply {
+                deserialize(data, nestedEntitySpecs)
+            }
         }
     }
 
@@ -243,11 +253,16 @@ abstract class AbstractGold : BaseParticle() {
                 query = null
             )
 
+            private val nestedEntitySpecs: Map<SchemaHash, EntitySpec<out Entity>> =
+                emptyMap()
+
             init {
-                SchemaRegistry.register(this)
+                SchemaRegistry.register(SCHEMA)
             }
 
-            override fun deserialize(data: RawEntity) = Gold_Collection().apply { deserialize(data) }
+            override fun deserialize(data: RawEntity) = Gold_Collection().apply {
+                deserialize(data, nestedEntitySpecs)
+            }
         }
     }
 
@@ -368,11 +383,16 @@ abstract class AbstractGold : BaseParticle() {
                 }
             )
 
+            private val nestedEntitySpecs: Map<SchemaHash, EntitySpec<out Entity>> =
+                emptyMap()
+
             init {
-                SchemaRegistry.register(this)
+                SchemaRegistry.register(SCHEMA)
             }
 
-            override fun deserialize(data: RawEntity) = Gold_QCollection().apply { deserialize(data) }
+            override fun deserialize(data: RawEntity) = Gold_QCollection().apply {
+                deserialize(data, nestedEntitySpecs)
+            }
         }
     }
 
@@ -462,11 +482,16 @@ abstract class AbstractGold : BaseParticle() {
                 query = null
             )
 
+            private val nestedEntitySpecs: Map<SchemaHash, EntitySpec<out Entity>> =
+                mapOf("485712110d89359a3e539dac987329cd2649d889" to GoldInternal1)
+
             init {
-                SchemaRegistry.register(this)
+                SchemaRegistry.register(SCHEMA)
             }
 
-            override fun deserialize(data: RawEntity) = Gold_Data().apply { deserialize(data) }
+            override fun deserialize(data: RawEntity) = Gold_Data().apply {
+                deserialize(data, nestedEntitySpecs)
+            }
         }
     }
 

--- a/src/tools/tests/goldens/generated-schemas.jvm.kt
+++ b/src/tools/tests/goldens/generated-schemas.jvm.kt
@@ -71,7 +71,7 @@ abstract class AbstractGold : BaseParticle() {
                 query = null
             )
 
-            private val nestedEntitySpecs: Map<SchemaHash, EntitySpec<out Entity>> =
+            private val nestedEntitySpecs: Map<String, EntitySpec<out Entity>> =
                 emptyMap()
 
             init {
@@ -196,7 +196,7 @@ abstract class AbstractGold : BaseParticle() {
                 query = null
             )
 
-            private val nestedEntitySpecs: Map<SchemaHash, EntitySpec<out Entity>> =
+            private val nestedEntitySpecs: Map<String, EntitySpec<out Entity>> =
                 emptyMap()
 
             init {
@@ -253,7 +253,7 @@ abstract class AbstractGold : BaseParticle() {
                 query = null
             )
 
-            private val nestedEntitySpecs: Map<SchemaHash, EntitySpec<out Entity>> =
+            private val nestedEntitySpecs: Map<String, EntitySpec<out Entity>> =
                 emptyMap()
 
             init {
@@ -383,7 +383,7 @@ abstract class AbstractGold : BaseParticle() {
                 }
             )
 
-            private val nestedEntitySpecs: Map<SchemaHash, EntitySpec<out Entity>> =
+            private val nestedEntitySpecs: Map<String, EntitySpec<out Entity>> =
                 emptyMap()
 
             init {
@@ -482,7 +482,7 @@ abstract class AbstractGold : BaseParticle() {
                 query = null
             )
 
-            private val nestedEntitySpecs: Map<SchemaHash, EntitySpec<out Entity>> =
+            private val nestedEntitySpecs: Map<String, EntitySpec<out Entity>> =
                 mapOf("485712110d89359a3e539dac987329cd2649d889" to GoldInternal1)
 
             init {


### PR DESCRIPTION
The idea was unsound and was causing errors. It assumed that there was a 1:1 mapping between schema hash and EntitySpec, which is not true. We generate different EntitySpec classes (and Entity classes) for each particle, but if they use the same schema they will have the same schema hash, and will collide.

There was only one usage, so I worked around it by giving each Entity class it's own map of hash -> EntitySpec for all of the Entities classes it references.

There were a bunch of other small tidy ups this enabled too.