### PR TITLE
Add Checks and Claims to manifest.proto and serialize claims.

### DIFF
--- a/java/arcs/core/data/proto/manifest.proto
+++ b/java/arcs/core/data/proto/manifest.proto
@@ -215,9 +215,6 @@ message AccessPathProto {
 
 message InformationFlowLabelProto {
   message Predicate {
-    message Literal {
-      InformationFlowLabelProto label = 1;
-    }
     message And {
       Predicate conjunct0 = 1;
       Predicate conjunct1 = 2;
@@ -230,7 +227,7 @@ message InformationFlowLabelProto {
       Predicate predicate = 1;
     }
     oneof predicate {
-      Literal literal = 1;
+      InformationFlowLabelProto label = 1;
       And and = 2;
       Or or = 3;
       Not not = 4;

--- a/java/arcs/core/data/proto/manifest.proto
+++ b/java/arcs/core/data/proto/manifest.proto
@@ -76,6 +76,10 @@ message ParticleSpecProto {
   repeated HandleConnectionSpecProto connections = 2;
   // Location of the implementation.
   string location = 3;
+  // Conjunction of all claims.
+  repeated ClaimProto claims = 4;
+  // Conjunction of all checks.
+  repeated CheckProto checks = 5;
 }
 
 // Defines a single connection of a particle spec.
@@ -196,4 +200,67 @@ message BinaryExpressionProto {
 message UnaryExpressionProto {
   RefinementExpressionProto expr = 1;
   OPERATOR operator = 2;
+}
+
+message AccessPathProto {
+  message Selector {
+    oneof selector {
+      string field = 1;
+      // TODO(bgogul): Other selectors like dereferencing, index, etc.
+    }
+  }
+  string handle_connection = 1;
+  repeated Selector selectors = 2;
+}
+
+message InformationFlowLabelProto {
+  message Predicate {
+    message Literal {
+      InformationFlowLabelProto label = 1;
+    }
+    message And {
+      Predicate conjunct0 = 1;
+      Predicate conjunct1 = 2;
+    }
+    message Or {
+      Predicate disjunct0 = 1;
+      Predicate disjunct1 = 2;
+    }
+    message Not {
+      Predicate predicate = 1;
+    }
+    oneof predicate {
+      Literal literal = 1;
+      And and = 2;
+      Or or = 3;
+      Not not = 4;
+    }
+  }
+
+  oneof label {
+    string semantic_tag = 1;
+    // TODO(bgogul): Other kinds of labels: stores, handles, etc.
+  }
+};
+
+message ClaimProto {
+  message DerivesFrom {
+    AccessPathProto target = 1;
+    AccessPathProto source = 2;
+  }
+
+  message Assume {
+    AccessPathProto access_path = 1;
+    InformationFlowLabelProto.Predicate predicate = 2;
+  }
+
+  oneof claim {
+    DerivesFrom derives_from = 1;
+    Assume assume = 2;
+  }
+}
+
+message CheckProto {
+  AccessPathProto access_path = 1;
+  InformationFlowLabelProto.Predicate predicate = 2;
 }

--- a/src/tools/manifest2proto.ts
+++ b/src/tools/manifest2proto.ts
@@ -95,13 +95,13 @@ function claimsToProtoPayload(cs: HandleConnectionSpec, proto: {}) {
           predicate = {
             not: {
               predicate: {
-                literal: {label: tag}
+                label: tag
               }
             }
           };
         } else {
           predicate = {
-            literal: {label: tag}
+            label: tag
           };
         }
         return {

--- a/src/tools/tests/manifest2proto-test.ts
+++ b/src/tools/tests/manifest2proto-test.ts
@@ -424,6 +424,111 @@ describe('manifest2proto', () => {
     });
   });
 
+  it('encodes particle spec with semanticTag claims', async () => {
+    const manifest = await Manifest.parse(`
+      particle Test in 'a/b/c.js'
+        private: writes {name: Text}
+        public: writes {name: Text}
+        claim private is private_tag
+        claim public is not private_tag
+     `);
+    const spec = await toProtoAndBack(manifest);
+    assert.deepStrictEqual(spec.particleSpecs[0].claims, [
+      {
+        assume: {
+          accessPath: {
+            handleConnection: 'private'
+          },
+          predicate: {
+            literal: {
+              label: {
+                semanticTag: 'private_tag'
+              }
+            }
+          }
+        }
+      },
+      {
+        assume: {
+          accessPath: {
+            handleConnection: 'public'
+          },
+          predicate: {
+            not: {
+              predicate: {
+                literal: {
+                  label: {
+                    semanticTag: 'private_tag'
+                  }
+                }
+              }
+            }
+          }
+        }
+      }]);
+
+  });
+
+  it('encodes particle spec with derivesFrom claims', async () => {
+    const manifest = await Manifest.parse(`
+      particle Test in 'a/b/c.js'
+        input: reads {name: Text}
+        output: writes {name: Text}
+        dontcare: writes {name: Text}
+        claim output derives from input
+     `);
+    const spec = await toProtoAndBack(manifest);
+    assert.deepStrictEqual(spec.particleSpecs[0].claims, [
+      {
+        derivesFrom: {
+          source: {
+            handleConnection: 'input'
+          },
+          target: {
+            handleConnection: 'output'
+          }
+        }
+      }
+    ]);
+  });
+
+  it('encodes particle spec with derivesFrom and hasTag claims', async () => {
+    const manifest = await Manifest.parse(`
+      particle Test in 'a/b/c.js'
+        input: reads {name: Text}
+        output: writes {name: Text}
+        dontcare: writes {name: Text}
+        claim output derives from input and is public
+     `);
+    const spec = await toProtoAndBack(manifest);
+    assert.deepStrictEqual(spec.particleSpecs[0].claims, [
+      {
+        derivesFrom: {
+          source: {
+            handleConnection: 'input'
+          },
+          target: {
+            handleConnection: 'output'
+          }
+        }
+      },
+      {
+        assume: {
+          accessPath: {
+            handleConnection: 'output'
+          },
+          predicate: {
+            literal: {
+              label: {
+                semanticTag: 'public'
+              }
+            }
+          }
+        }
+      },
+    ]);
+  });
+
   // On the TypeScript side we serialize .arcs file and validate it equals the .pb.bin file.
   // On the Kotlin side we deserialize .pb.bin and validate it equals deserialized .textproto file.
   // This ensures that at least all the constructs used in the .arcs file can be serialized in TS

--- a/src/tools/tests/manifest2proto-test.ts
+++ b/src/tools/tests/manifest2proto-test.ts
@@ -440,10 +440,8 @@ describe('manifest2proto', () => {
             handleConnection: 'private'
           },
           predicate: {
-            literal: {
-              label: {
-                semanticTag: 'private_tag'
-              }
+            label: {
+              semanticTag: 'private_tag'
             }
           }
         }
@@ -456,10 +454,8 @@ describe('manifest2proto', () => {
           predicate: {
             not: {
               predicate: {
-                literal: {
-                  label: {
-                    semanticTag: 'private_tag'
-                  }
+                label: {
+                  semanticTag: 'private_tag'
                 }
               }
             }
@@ -518,10 +514,8 @@ describe('manifest2proto', () => {
             handleConnection: 'output'
           },
           predicate: {
-            literal: {
-              label: {
-                semanticTag: 'public'
-              }
+            label: {
+              semanticTag: 'public'
             }
           }
         }


### PR DESCRIPTION
This PR introduces the `ClaimProto`, `CheckProto` and other related protos in the `manifest.proto` file. 

This PR also serializes the claims in the `ParticleSpec`.