### PR TITLE
Decode ClaimProto in Kotlin.

### DIFF
--- a/java/arcs/core/data/AccessPath.kt
+++ b/java/arcs/core/data/AccessPath.kt
@@ -24,6 +24,13 @@ data class AccessPath(val root: Root, val selectors: List<Selector> = emptyList(
         selectors: List<Selector> = emptyList()
     ) : this(Root.HandleConnection(particle, connection), selectors)
 
+    /** Constructs an [AccessPath] representing a [ParticleSpec.HandleConnectionSpec]. */
+    constructor(
+        particleSpecName: String,
+        connectionSpec: HandleConnectionSpec,
+        selectors: List<Selector> = emptyList()
+    ) : this(Root.HandleConnectionSpec(particleSpecName, connectionSpec), selectors)
+
     /** Constructs an [AccessPath] representing a [Recipe.Handle]. */
     constructor(
         handle: Recipe.Handle,
@@ -41,11 +48,19 @@ data class AccessPath(val root: Root, val selectors: List<Selector> = emptyList(
         data class Handle(val handle: Recipe.Handle) : Root() {
             override fun toString() = "h:${handle.name}"
         }
+
         data class HandleConnection(
             val particle: Recipe.Particle,
             val connection: Recipe.Particle.HandleConnection
         ) : Root() {
             override fun toString() = "hc:${particle.spec.name}.${connection.spec.name}"
+        }
+
+        data class HandleConnectionSpec(
+            val particleSpecName: String,
+            val connectionSpec: arcs.core.data.HandleConnectionSpec
+        ) : Root() {
+            override fun toString() = "hcs:$particleSpecName.${connectionSpec.name}"
         }
         // TODO(bgogul): Store, etc.
     }

--- a/java/arcs/core/data/proto/AccessPathProtoDecoder.kt
+++ b/java/arcs/core/data/proto/AccessPathProtoDecoder.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.core.data.proto
+
+import arcs.core.data.AccessPath
+import arcs.core.data.HandleConnectionSpec
+
+/** Decodes an [AccessPathProto] into [AccesssPath]. */
+fun AccessPathProto.decode(
+    particleSpecName: String,
+    connectionSpecs: Map<String, HandleConnectionSpec>
+): AccessPath {
+    val connectionSpec = connectionSpecs[handleConnection]
+    requireNotNull(connectionSpec) {
+        "Connection '$handleConnection' not found in connection specs!"
+    }
+    // TODO(bgogul): Selectors
+    return AccessPath(particleSpecName, connectionSpec)
+}

--- a/java/arcs/core/data/proto/AccessPathProtoDecoder.kt
+++ b/java/arcs/core/data/proto/AccessPathProtoDecoder.kt
@@ -16,7 +16,6 @@ import arcs.core.data.HandleConnectionSpec
 
 /** Decodes an [AccessPathProto] into [AccesssPath]. */
 fun AccessPathProto.decode(
-    particleSpecName: String,
     connectionSpecs: Map<String, HandleConnectionSpec>
 ): AccessPath {
     val connectionSpec = connectionSpecs[handleConnection]
@@ -24,5 +23,5 @@ fun AccessPathProto.decode(
         "Connection '$handleConnection' not found in connection specs!"
     }
     // TODO(bgogul): Selectors
-    return AccessPath(particleSpecName, connectionSpec)
+    return AccessPath(particleSpec, connectionSpec)
 }

--- a/java/arcs/core/data/proto/ClaimProtoDecoder.kt
+++ b/java/arcs/core/data/proto/ClaimProtoDecoder.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.core.data.proto
+
+import arcs.core.data.Claim
+import arcs.core.data.HandleConnectionSpec
+
+/** Decodes an [ClaimProto] into [Claim]. */
+fun ClaimProto.decode(
+    particleSpecName: String,
+    connectionSpecs: Map<String, HandleConnectionSpec>
+) = when (claimCase) {
+    ClaimProto.ClaimCase.DERIVES_FROM -> Claim.DerivesFrom(
+        target = derivesFrom.target.decode(particleSpecName, connectionSpecs),
+        source = derivesFrom.source.decode(particleSpecName, connectionSpecs)
+    )
+    ClaimProto.ClaimCase.ASSUME -> Claim.Assume(
+        assume.accessPath.decode(particleSpecName, connectionSpecs),
+        assume.predicate.decode()
+    )
+    ClaimProto.ClaimCase.CLAIM_NOT_SET ->
+        throw IllegalArgumentException("ClaimProto has unknown value.")
+    else -> throw IllegalArgumentException("Cannot decode a [ClaimProto].")
+}

--- a/java/arcs/core/data/proto/ClaimProtoDecoder.kt
+++ b/java/arcs/core/data/proto/ClaimProtoDecoder.kt
@@ -16,18 +16,19 @@ import arcs.core.data.HandleConnectionSpec
 
 /** Decodes an [ClaimProto] into [Claim]. */
 fun ClaimProto.decode(
-    particleSpecName: String,
     connectionSpecs: Map<String, HandleConnectionSpec>
-) = when (claimCase) {
-    ClaimProto.ClaimCase.DERIVES_FROM -> Claim.DerivesFrom(
-        target = derivesFrom.target.decode(particleSpecName, connectionSpecs),
-        source = derivesFrom.source.decode(particleSpecName, connectionSpecs)
-    )
-    ClaimProto.ClaimCase.ASSUME -> Claim.Assume(
-        assume.accessPath.decode(particleSpecName, connectionSpecs),
-        assume.predicate.decode()
-    )
-    ClaimProto.ClaimCase.CLAIM_NOT_SET ->
-        throw IllegalArgumentException("ClaimProto has unknown value.")
-    else -> throw IllegalArgumentException("Cannot decode a [ClaimProto].")
+): Claim {
+    return when (claimCase) {
+        ClaimProto.ClaimCase.DERIVES_FROM -> Claim.DerivesFrom(
+            target = derivesFrom.target.decode(connectionSpecs),
+            source = derivesFrom.source.decode(connectionSpecs)
+        )
+        ClaimProto.ClaimCase.ASSUME -> Claim.Assume(
+            assume.accessPath.decode(connectionSpecs),
+            assume.predicate.decode()
+        )
+        ClaimProto.ClaimCase.CLAIM_NOT_SET ->
+            throw IllegalArgumentException("ClaimProto has unknown value.")
+        else -> throw IllegalArgumentException("Cannot decode a [ClaimProto].")
+    }
 }

--- a/java/arcs/core/data/proto/PredicateProtoDecoder.kt
+++ b/java/arcs/core/data/proto/PredicateProtoDecoder.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.core.data.proto
+
+import arcs.core.data.InformationFlowLabel
+import arcs.core.data.InformationFlowLabel.Predicate
+
+/** Decodes an [InformationFlowLabelProto] into [InformationFlowLabel]. */
+fun InformationFlowLabelProto.decode() = when (labelCase) {
+    InformationFlowLabelProto.LabelCase.SEMANTIC_TAG ->
+        InformationFlowLabel.SemanticTag(semanticTag)
+    InformationFlowLabelProto.LabelCase.LABEL_NOT_SET ->
+        throw IllegalArgumentException("Unknown information flow label.")
+    else -> throw IllegalArgumentException("Cannot decode a [InformationLabelProto].")
+}
+
+/** Decodes an [InformationFlowLabelProto.Predicate] into [InformationFlowLabel.Predicate]. */
+fun InformationFlowLabelProto.Predicate.decode(): Predicate = when (predicateCase) {
+    InformationFlowLabelProto.Predicate.PredicateCase.LABEL ->
+        Predicate.Label(label.decode())
+    InformationFlowLabelProto.Predicate.PredicateCase.NOT ->
+        Predicate.Not(not.predicate.decode())
+    else -> TODO("TODO(bgogul): Implement the rest of the predicate cases.")
+}

--- a/java/arcs/core/data/proto/manifest.proto
+++ b/java/arcs/core/data/proto/manifest.proto
@@ -202,6 +202,9 @@ message UnaryExpressionProto {
   OPERATOR operator = 2;
 }
 
+// Note that this proto only allows encoding access paths where the root is
+// a `HandleConnectionSpec`. This should be sufficient as the root of an access
+// path in a claim or check can only refer to a `HandleConnectionSpec`.
 message AccessPathProto {
   message Selector {
     oneof selector {
@@ -209,8 +212,10 @@ message AccessPathProto {
       // TODO(bgogul): Other selectors like dereferencing, index, etc.
     }
   }
-  string handle_connection = 1;
-  repeated Selector selectors = 2;
+  // (particle_spec, handle_connection) identifies a `HandleConnectionSpec`.
+  string particle_spec = 1;
+  string handle_connection = 2;
+  repeated Selector selectors = 3;
 }
 
 message InformationFlowLabelProto {

--- a/javatests/arcs/core/data/AccessPathTest.kt
+++ b/javatests/arcs/core/data/AccessPathTest.kt
@@ -29,6 +29,8 @@ class AccessPathTest {
         assertThat("${AccessPath.Root.Handle(handle)}").isEqualTo("h:thing")
         assertThat("${AccessPath.Root.HandleConnection(particle, connection)}")
             .isEqualTo("hc:Reader.data")
+        assertThat("${AccessPath.Root.HandleConnectionSpec("Reader", connectionSpec)}")
+            .isEqualTo("hcs:Reader.data")
     }
 
     @Test
@@ -55,5 +57,9 @@ class AccessPathTest {
             .isEqualTo("hc:Reader.data.bar")
         assertThat("${AccessPath(particle, connection, multipleSelectors)}")
             .isEqualTo("hc:Reader.data.foo.bar")
+        assertThat("${AccessPath("Reader", connectionSpec, oneSelector)}")
+            .isEqualTo("hcs:Reader.data.bar")
+        assertThat("${AccessPath("Reader", connectionSpec, multipleSelectors)}")
+            .isEqualTo("hcs:Reader.data.foo.bar")
     }
 }

--- a/javatests/arcs/core/data/proto/AccessPathProtoDecoderTest.kt
+++ b/javatests/arcs/core/data/proto/AccessPathProtoDecoderTest.kt
@@ -24,7 +24,8 @@ class AccessPathProtoDecoderTest {
     @Test
     fun decodesAccessPathNoSelectors() {
         val protoText = """
-        handle_connection: "input"
+            particle_spec: "TestSpec"
+            handle_connection: "input"
         """.trimIndent()
         val handleConnectionSpec = HandleConnectionSpec(
             "input",
@@ -32,7 +33,7 @@ class AccessPathProtoDecoderTest {
             TypeVariable("input")
         )
         val connectionSpecs = listOf(handleConnectionSpec).associateBy { it.name }
-        val accessPath = parseAccessPathProto(protoText).decode("TestSpec", connectionSpecs)
+        val accessPath = parseAccessPathProto(protoText).decode(connectionSpecs)
         val root = accessPath.root as AccessPath.Root.HandleConnectionSpec
         assertThat(root.particleSpecName).isEqualTo("TestSpec")
         assertThat(root.connectionSpec).isEqualTo(handleConnectionSpec)
@@ -44,7 +45,7 @@ class AccessPathProtoDecoderTest {
         handle_connection: "input"
         """.trimIndent()
         val exception = assertThrows(IllegalArgumentException::class) {
-            parseAccessPathProto(protoText).decode("TestSpec", emptyMap())
+            parseAccessPathProto(protoText).decode(emptyMap())
         }
         assertThat(exception)
             .hasMessageThat()

--- a/javatests/arcs/core/data/proto/AccessPathProtoDecoderTest.kt
+++ b/javatests/arcs/core/data/proto/AccessPathProtoDecoderTest.kt
@@ -1,0 +1,53 @@
+package arcs.core.data.proto
+
+import arcs.core.data.AccessPath
+import arcs.core.data.HandleConnectionSpec
+import arcs.core.data.HandleMode
+import arcs.core.data.TypeVariable
+import arcs.core.testutil.assertThrows
+import arcs.core.testutil.fail
+import com.google.common.truth.Truth.assertThat
+import com.google.protobuf.TextFormat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+/** Parses a given proto text as [AccessPathProto]. */
+fun parseAccessPathProto(protoText: String): AccessPathProto {
+    val builder = AccessPathProto.newBuilder()
+    TextFormat.getParser().merge(protoText, builder)
+    return builder.build()
+}
+
+@RunWith(JUnit4::class)
+class AccessPathProtoDecoderTest {
+    @Test
+    fun decodesAccessPathNoSelectors() {
+        val protoText = """
+        handle_connection: "input"
+        """.trimIndent()
+        val handleConnectionSpec = HandleConnectionSpec(
+            "input",
+            HandleMode.Write,
+            TypeVariable("input")
+        )
+        val connectionSpecs = listOf(handleConnectionSpec).associateBy { it.name }
+        val accessPath = parseAccessPathProto(protoText).decode("TestSpec", connectionSpecs)
+        val root = accessPath.root as AccessPath.Root.HandleConnectionSpec
+        assertThat(root.particleSpecName).isEqualTo("TestSpec")
+        assertThat(root.connectionSpec).isEqualTo(handleConnectionSpec)
+    }
+
+    @Test
+    fun detectsMissingConnections() {
+        val protoText = """
+        handle_connection: "input"
+        """.trimIndent()
+        val exception = assertThrows(IllegalArgumentException::class) {
+            parseAccessPathProto(protoText).decode("TestSpec", emptyMap())
+        }
+        assertThat(exception)
+            .hasMessageThat()
+            .contains("Connection 'input' not found in connection specs!")
+    }
+}

--- a/javatests/arcs/core/data/proto/ClaimProtoDecoderTest.kt
+++ b/javatests/arcs/core/data/proto/ClaimProtoDecoderTest.kt
@@ -1,0 +1,92 @@
+package arcs.core.data.proto
+
+import arcs.core.data.AccessPath
+import arcs.core.data.Claim
+import arcs.core.data.HandleConnectionSpec
+import arcs.core.data.HandleMode
+import arcs.core.data.TypeVariable
+import arcs.core.data.InformationFlowLabel
+import arcs.core.data.InformationFlowLabel.Predicate
+import arcs.core.testutil.assertThrows
+import arcs.core.testutil.fail
+import com.google.common.truth.Truth.assertThat
+import com.google.protobuf.TextFormat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+/** Parses a given proto text as [ClaimProto]. */
+fun parseClaimProto(protoText: String): ClaimProto {
+    val builder = ClaimProto.newBuilder()
+    TextFormat.getParser().merge(protoText, builder)
+    return builder.build()
+}
+
+@RunWith(JUnit4::class)
+class ClaimProtoDecoderTest {
+    @Test
+    fun decodesAssumeClaim() {
+        val protoText = """
+        assume {
+            access_path {
+                handle_connection: "output"
+            }
+            predicate {
+                label {
+                    semantic_tag: "public"
+                }
+            }
+        }
+        """.trimIndent()
+        val handleConnectionSpec = HandleConnectionSpec(
+            "output",
+            HandleMode.Write,
+            TypeVariable("output")
+        )
+        val connectionSpecs = listOf(handleConnectionSpec).associateBy { it.name }
+        val claim = parseClaimProto(protoText).decode("TestSpec", connectionSpecs)
+        val assume = requireNotNull(claim as Claim.Assume)
+        assertThat(assume).isEqualTo(
+            Claim.Assume(
+                AccessPath("TestSpec", handleConnectionSpec),
+                Predicate.Label(
+                    InformationFlowLabel.SemanticTag("public")
+                )
+            )
+        )
+    }
+
+    @Test
+    fun decodesDerivesFromClaim() {
+        val protoText = """
+        derives_from {
+            target {
+                handle_connection: "output"
+            }
+            source {
+                handle_connection: "input"
+            }
+        }
+        """.trimIndent()
+        val outputSpec = HandleConnectionSpec(
+            "output",
+            HandleMode.Write,
+            TypeVariable("output")
+        )
+        val inputSpec = HandleConnectionSpec(
+            "input",
+            HandleMode.Read,
+            TypeVariable("output")
+        )
+        val connectionSpecs = listOf(inputSpec, outputSpec).associateBy { it.name }
+        val claim = parseClaimProto(protoText).decode("TestSpec", connectionSpecs)
+        val derivesFrom = requireNotNull(claim as Claim.DerivesFrom)
+        assertThat(derivesFrom).isEqualTo(
+            Claim.DerivesFrom(
+                target = AccessPath("TestSpec", outputSpec),
+                source = AccessPath("TestSpec", inputSpec)
+            )
+        )
+    }
+}
+

--- a/javatests/arcs/core/data/proto/ClaimProtoDecoderTest.kt
+++ b/javatests/arcs/core/data/proto/ClaimProtoDecoderTest.kt
@@ -27,16 +27,17 @@ class ClaimProtoDecoderTest {
     @Test
     fun decodesAssumeClaim() {
         val protoText = """
-        assume {
+          assume {
             access_path {
-                handle_connection: "output"
+              particle_spec: "TestSpec"
+              handle_connection: "output"
             }
             predicate {
-                label {
-                    semantic_tag: "public"
-                }
+              label {
+                semantic_tag: "public"
+              }
             }
-        }
+          }
         """.trimIndent()
         val handleConnectionSpec = HandleConnectionSpec(
             "output",
@@ -44,7 +45,7 @@ class ClaimProtoDecoderTest {
             TypeVariable("output")
         )
         val connectionSpecs = listOf(handleConnectionSpec).associateBy { it.name }
-        val claim = parseClaimProto(protoText).decode("TestSpec", connectionSpecs)
+        val claim = parseClaimProto(protoText).decode(connectionSpecs)
         val assume = requireNotNull(claim as Claim.Assume)
         assertThat(assume).isEqualTo(
             Claim.Assume(
@@ -59,14 +60,16 @@ class ClaimProtoDecoderTest {
     @Test
     fun decodesDerivesFromClaim() {
         val protoText = """
-        derives_from {
+          derives_from {
             target {
-                handle_connection: "output"
+              particle_spec: "TestSpec"
+              handle_connection: "output"
             }
             source {
-                handle_connection: "input"
+              particle_spec: "TestSpec"
+              handle_connection: "input"
             }
-        }
+          }
         """.trimIndent()
         val outputSpec = HandleConnectionSpec(
             "output",
@@ -79,7 +82,7 @@ class ClaimProtoDecoderTest {
             TypeVariable("output")
         )
         val connectionSpecs = listOf(inputSpec, outputSpec).associateBy { it.name }
-        val claim = parseClaimProto(protoText).decode("TestSpec", connectionSpecs)
+        val claim = parseClaimProto(protoText).decode(connectionSpecs)
         val derivesFrom = requireNotNull(claim as Claim.DerivesFrom)
         assertThat(derivesFrom).isEqualTo(
             Claim.DerivesFrom(

--- a/javatests/arcs/core/data/proto/PredicateProtoDecoderTest.kt
+++ b/javatests/arcs/core/data/proto/PredicateProtoDecoderTest.kt
@@ -1,0 +1,68 @@
+package arcs.core.data.proto
+
+import arcs.core.data.InformationFlowLabel
+import arcs.core.data.InformationFlowLabel.Predicate
+import arcs.core.testutil.assertThrows
+import arcs.core.testutil.fail
+import com.google.common.truth.Truth.assertThat
+import com.google.protobuf.TextFormat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+/** Parses a given proto text as [InfomrationFlowLabelProto]. */
+fun parseInformationFlowLabelProto(protoText: String): InformationFlowLabelProto {
+    val builder = InformationFlowLabelProto.newBuilder()
+    TextFormat.getParser().merge(protoText, builder)
+    return builder.build()
+}
+
+/** Parses a given proto text as [InfomrationFlowLabelProto.Predicate]. */
+fun parsePredicateProto(protoText: String): InformationFlowLabelProto.Predicate {
+    val builder = InformationFlowLabelProto.Predicate.newBuilder()
+    TextFormat.getParser().merge(protoText, builder)
+    return builder.build()
+}
+
+@RunWith(JUnit4::class)
+class PredicateProtoDecoderTest {
+    @Test
+    fun decodesInformationFlowLabels() {
+        val protoText = """ semantic_tag: "public" """
+        val label = parseInformationFlowLabelProto(protoText).decode()
+        val semanticTag = requireNotNull(label as? InformationFlowLabel.SemanticTag)
+        assertThat(semanticTag.name).isEqualTo("public")
+    }
+
+    @Test
+    fun decodesLabelPredicate() {
+        val protoText = """
+        label {
+            semantic_tag: "public"
+        }
+        """.trimIndent()
+        val predicate = parsePredicateProto(protoText).decode()
+        val labelPredicate = requireNotNull(predicate as? Predicate.Label)
+        assertThat(labelPredicate.label)
+            .isEqualTo(InformationFlowLabel.SemanticTag("public"))
+    }
+
+    @Test
+    fun decodesNotPredicate() {
+        val protoText = """
+        not {
+            predicate {
+                label {
+                    semantic_tag: "public"
+                }
+            }
+        }
+        """.trimIndent()
+        val predicate = parsePredicateProto(protoText).decode()
+        val notPredicate = requireNotNull(predicate as? Predicate.Not)
+        assertThat(notPredicate).isEqualTo(
+            Predicate.Not(Predicate.Label(InformationFlowLabel.SemanticTag("public")))
+        )
+    }
+}
+

--- a/javatests/arcs/core/data/proto/PredicateProtoDecoderTest.kt
+++ b/javatests/arcs/core/data/proto/PredicateProtoDecoderTest.kt
@@ -37,9 +37,9 @@ class PredicateProtoDecoderTest {
     @Test
     fun decodesLabelPredicate() {
         val protoText = """
-        label {
+          label {
             semantic_tag: "public"
-        }
+          }
         """.trimIndent()
         val predicate = parsePredicateProto(protoText).decode()
         val labelPredicate = requireNotNull(predicate as? Predicate.Label)
@@ -50,13 +50,13 @@ class PredicateProtoDecoderTest {
     @Test
     fun decodesNotPredicate() {
         val protoText = """
-        not {
+          not {
             predicate {
-                label {
-                    semantic_tag: "public"
-                }
+              label {
+                semantic_tag: "public"
+              }
             }
-        }
+          }
         """.trimIndent()
         val predicate = parsePredicateProto(protoText).decode()
         val notPredicate = requireNotNull(predicate as? Predicate.Not)

--- a/src/tools/manifest2proto.ts
+++ b/src/tools/manifest2proto.ts
@@ -69,7 +69,7 @@ async function particleSpecToProtoPayload(spec: ParticleSpec) {
       direction: directionOrdinal,
       type: await typeToProtoPayload(cs.type)
     };
-    const claimsProto = claimsToProtoPayload(cs, proto);
+    const claimsProto = claimsToProtoPayload(spec, cs, proto);
     if (claimsProto != null) {
       claims = claims.concat(claimsProto);
     }
@@ -84,9 +84,13 @@ async function particleSpecToProtoPayload(spec: ParticleSpec) {
 }
 
 // Converts the claims in HandleConnectionSpec.
-function claimsToProtoPayload(cs: HandleConnectionSpec, proto: {}) {
+function claimsToProtoPayload(
+  spec: ParticleSpec,
+  cs: HandleConnectionSpec,
+  proto: {}
+) {
   return cs.claims?.map(claim => {
-    const accessPath = {handleConnection: cs.name};
+    const accessPath = {particleSpec: spec.name, handleConnection: cs.name};
     switch (claim.type) {
       case ClaimType.IsTag: {
         const tag = {semanticTag: claim.tag};
@@ -112,7 +116,10 @@ function claimsToProtoPayload(cs: HandleConnectionSpec, proto: {}) {
         return {
           derivesFrom: {
             target: accessPath,
-            source: {handleConnection: claim.parentHandle.name}
+            source: {
+              particleSpec: spec.name,
+              handleConnection: claim.parentHandle.name
+            }
           }
         };
       }

--- a/src/tools/manifest2proto.ts
+++ b/src/tools/manifest2proto.ts
@@ -86,11 +86,14 @@ async function particleSpecToProtoPayload(spec: ParticleSpec) {
 // Converts the claims in HandleConnectionSpec.
 function claimsToProtoPayload(
   spec: ParticleSpec,
-  cs: HandleConnectionSpec,
+  connectionSpec: HandleConnectionSpec,
   proto: {}
 ) {
-  return cs.claims?.map(claim => {
-    const accessPath = {particleSpec: spec.name, handleConnection: cs.name};
+  return connectionSpec.claims?.map(claim => {
+    const accessPath = {
+      particleSpec: spec.name,
+      handleConnection: connectionSpec.name
+    };
     switch (claim.type) {
       case ClaimType.IsTag: {
         const tag = {semanticTag: claim.tag};

--- a/src/tools/tests/manifest2proto-test.ts
+++ b/src/tools/tests/manifest2proto-test.ts
@@ -437,6 +437,7 @@ describe('manifest2proto', () => {
       {
         assume: {
           accessPath: {
+            particleSpec: 'Test',
             handleConnection: 'private'
           },
           predicate: {
@@ -449,6 +450,7 @@ describe('manifest2proto', () => {
       {
         assume: {
           accessPath: {
+            particleSpec: 'Test',
             handleConnection: 'public'
           },
           predicate: {
@@ -478,9 +480,11 @@ describe('manifest2proto', () => {
       {
         derivesFrom: {
           source: {
+            particleSpec: 'Test',
             handleConnection: 'input'
           },
           target: {
+            particleSpec: 'Test',
             handleConnection: 'output'
           }
         }
@@ -501,9 +505,11 @@ describe('manifest2proto', () => {
       {
         derivesFrom: {
           source: {
+            particleSpec: 'Test',
             handleConnection: 'input'
           },
           target: {
+            particleSpec: 'Test',
             handleConnection: 'output'
           }
         }
@@ -511,6 +517,7 @@ describe('manifest2proto', () => {
       {
         assume: {
           accessPath: {
+            particleSpec: 'Test',
             handleConnection: 'output'
           },
           predicate: {


### PR DESCRIPTION
All the necessary code to decode a `ClaimProto` in Kotlin. This also adds a new type of access path root, namely `AccessPath.Root.HandleConnectionSpec` needed for claims.