### PR TITLE
Fix memory leaks

### DIFF
--- a/.bazelproject
+++ b/.bazelproject
@@ -4,13 +4,13 @@ directories:
   build_defs
   tools
   third_party
-  particles
-  src
+#  particles
+#  src
 
 targets:
   //java/...
   //javatests/...
-  //particles/...
+#  //particles/...
 
 test_sources:
   javatests/

--- a/.bazelproject
+++ b/.bazelproject
@@ -4,13 +4,13 @@ directories:
   build_defs
   tools
   third_party
-#  particles
-#  src
+  particles
+  src
 
 targets:
   //java/...
   //javatests/...
-#  //particles/...
+  //particles/...
 
 test_sources:
   javatests/

--- a/java/arcs/core/storage/StorageProxy.kt
+++ b/java/arcs/core/storage/StorageProxy.kt
@@ -12,10 +12,8 @@
 package arcs.core.storage
 
 import arcs.core.crdt.CrdtData
-import arcs.core.crdt.CrdtEntity
 import arcs.core.crdt.CrdtModel
 import arcs.core.crdt.CrdtOperationAtTime
-import arcs.core.crdt.CrdtSet
 import arcs.core.crdt.VersionMap
 import arcs.core.util.Scheduler
 import arcs.core.util.SchedulerDispatcher

--- a/java/arcs/core/storage/StorageProxy.kt
+++ b/java/arcs/core/storage/StorageProxy.kt
@@ -162,7 +162,9 @@ class StorageProxy<Data : CrdtData, Op : CrdtOperationAtTime, T>(
      * being thrown.
      */
     fun close() {
-        _crdt = null
+        scheduler.scope.launch(dispatcher) {
+            _crdt = null
+        }
         store.close()
         stateHolder.update { it.setState(ProxyState.CLOSED) }
     }

--- a/java/arcs/core/storage/StorageProxy.kt
+++ b/java/arcs/core/storage/StorageProxy.kt
@@ -160,7 +160,7 @@ class StorageProxy<Data : CrdtData, Op : CrdtOperationAtTime, T>(
      * being thrown.
      */
     fun close() {
-        scheduler.scope.launch(dispatcher) {
+        scheduler.scope.launch {
             _crdt = null
         }
         store.close()

--- a/java/arcs/core/storage/StorageProxy.kt
+++ b/java/arcs/core/storage/StorageProxy.kt
@@ -46,9 +46,7 @@ class StorageProxy<Data : CrdtData, Op : CrdtOperationAtTime, T>(
     private var _crdt: CrdtModel<Data, Op, T>? = crdt
 
     private val crdt: CrdtModel<Data, Op, T>
-        get() = requireNotNull(_crdt) {
-            "crdt field is null, StorageProxy closed?"
-        }
+        get() = _crdt?.let { it } ?: throw IllegalStateException("StorageProxy closed")
 
     /**
      * If you need to interact with the data managed by this [StorageProxy], and you're not a

--- a/java/arcs/sdk/android/storage/ServiceStore.kt
+++ b/java/arcs/sdk/android/storage/ServiceStore.kt
@@ -49,9 +49,9 @@ import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach

--- a/java/arcs/sdk/android/storage/ServiceStore.kt
+++ b/java/arcs/sdk/android/storage/ServiceStore.kt
@@ -46,7 +46,8 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
-import kotlinx.coroutines.cancel
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.coroutineScope
@@ -215,7 +216,7 @@ class ServiceStore<Data : CrdtData, Op : CrdtOperation, ConsumerData>(
         serviceConnection?.disconnect()
         storageService = null
         channel = null
-        scope.cancel()
+        scope.coroutineContext[Job.Key]?.cancelChildren()
     }
 
     companion object {

--- a/javatests/arcs/android/systemhealth/testapp/StorageCore.kt
+++ b/javatests/arcs/android/systemhealth/testapp/StorageCore.kt
@@ -71,6 +71,7 @@ import kotlin.toString
 import kotlinx.atomicfu.atomic
 import kotlinx.atomicfu.update
 import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.cancel
@@ -153,6 +154,9 @@ class StorageCore(val context: Context, val lifecycle: Lifecycle) {
                             try {
                                 closeHandle(it.handle, it.coroutineContext)
                                 it.handle = null
+                                launchIfContext(it.coroutineContext) {
+                                    it.handleManager.close()
+                                }
                             } catch (e: Exception) {
                                 log.error { "#$id: failed to close handle, reason: $e" }
                                 e.printStackTrace()
@@ -425,16 +429,21 @@ class StorageCore(val context: Context, val lifecycle: Lifecycle) {
         if (handle is Handle) withContext(handle.dispatcher) { handle.close() }
     }
 
+    private fun launchIfContext(
+        coroutineContext: CoroutineContext?,
+        block: suspend CoroutineScope.() -> Unit
+    ) {
+        if (coroutineContext == null) {
+            runBlocking { block() }
+        } else {
+            GlobalScope.launch(coroutineContext) { block() }
+        }
+    }
+
     private fun <T> closeHandle(
         handle: T?,
         coroutineContext: CoroutineContext? = null
-    ) {
-        if (coroutineContext == null) {
-            runBlocking { closeHandleSuspend(handle) }
-        } else {
-            GlobalScope.launch(coroutineContext) { closeHandleSuspend(handle) }
-        }
-    }
+    ) = launchIfContext(coroutineContext) { closeHandleSuspend(handle) }
 
     private suspend fun listenerTask(
         taskHandle: TaskHandle,
@@ -585,9 +594,9 @@ class StorageCore(val context: Context, val lifecycle: Lifecycle) {
 
             notify { "Progress 100%: populating stats and report" }
             // Close all Handles and EntityHandleManagers
+            // TODO: remove this when terminated() works to clean up?
             handles.forEach {
                 runBlocking {
-                    (it.handle as Handle).close()
                     it.handleManager.close()
                 }
             }

--- a/javatests/arcs/android/systemhealth/testapp/StorageCore.kt
+++ b/javatests/arcs/android/systemhealth/testapp/StorageCore.kt
@@ -584,6 +584,14 @@ class StorageCore(val context: Context, val lifecycle: Lifecycle) {
             }
 
             notify { "Progress 100%: populating stats and report" }
+            // Close all Handles and EntityHandleManagers
+            handles.forEach {
+                runBlocking {
+                    (it.handle as Handle).close()
+                    it.handleManager.close()
+                }
+            }
+            handles = emptyArray()
             populateStatsBulletin()
         }
     }

--- a/javatests/arcs/core/entity/HandleManagerTestBase.kt
+++ b/javatests/arcs/core/entity/HandleManagerTestBase.kt
@@ -113,6 +113,8 @@ open class HandleManagerTestBase {
 
     // Must call from subclasses
     open fun tearDown() = runBlocking {
+        readHandleManager.close()
+        writeHandleManager.close()
         schedulerProvider.cancelAll()
         // TODO(b/151366899): this is less than ideal - we should investigate how to make the entire
         //  test process cancellable/stoppable, even when we cross scopes into a BindingContext or

--- a/javatests/arcs/core/entity/HandleManagerTestBase.kt
+++ b/javatests/arcs/core/entity/HandleManagerTestBase.kt
@@ -113,13 +113,14 @@ open class HandleManagerTestBase {
 
     // Must call from subclasses
     open fun tearDown() = runBlocking {
-        readHandleManager.close()
-        writeHandleManager.close()
         schedulerProvider.cancelAll()
         // TODO(b/151366899): this is less than ideal - we should investigate how to make the entire
         //  test process cancellable/stoppable, even when we cross scopes into a BindingContext or
         //  over to other RamDisk listeners.
         delay(100) // Let things calm down.
+        readHandleManager.close()
+        writeHandleManager.close()
+        delay(100)
     }
 
     @Test


### PR DESCRIPTION
(Root #1)
TaskHandle (from testapp) holds an EntityHandleManager
EntityHandleManager holds StorageProxies
StorageProxy holds a crdt field
crdt field holds a RawEntity

(Root #2)
(serviceConnection -> service.registerCallback -> onProxyMessage holds ServiceStore, also held by StorageProxy)
ServiceStore holds a Channel
channel has a Flow attached
channel can hold a lambda
lambda has in it {   service.sendProxyMessage(message.toProto().toByteArray(), result) }
that lambda has in it a captured 'message' parameter from the function call
message contains ModelUpdate which holds RawEntity

Fixes to TestApp
1) Invoke EntityHandleManager.close() after tests finish

Fixed to Core
1) make StorageProxy.crdt a nullable field and make close() null it
2) change onLifecycleDestroyed() to invoke scope.cancel() (cancel the flow)
3) add channel.cancel() to ServiceStore.off()  and reinitialize channel & flow with new fresh copies