### PR TITLE
Updates to proto pathway for Schemas

### DIFF
--- a/java/arcs/android/storage/database/DatabaseImpl.kt
+++ b/java/arcs/android/storage/database/DatabaseImpl.kt
@@ -1338,6 +1338,9 @@ class DatabaseImpl(
         is FieldType.EntityRef -> requireNotNull(schemaTypeMap[fieldType.schemaHash]) {
             "Unknown type ID for schema with hash ${fieldType.schemaHash}"
         }
+        // TODO(b/156003617)
+        is FieldType.Tuple ->
+            throw NotImplementedError("[FieldType.Tuple]s not currently supported.")
     }
 
     /** Test-only version of [getTypeId]. */

--- a/java/arcs/core/data/SchemaFields.kt
+++ b/java/arcs/core/data/SchemaFields.kt
@@ -21,9 +21,13 @@ sealed class FieldType(
     /** A reference to an entity. */
     data class EntityRef(val schemaHash: String) : FieldType(Tag.EntityRef)
 
+    /** A tuple of [FieldType]s */
+    data class Tuple(val types: List<FieldType>) : FieldType(Tag.Tuple)
+
     enum class Tag {
         Primitive,
-        EntityRef
+        EntityRef,
+        Tuple
     }
 
     // Convenient aliases for all of the primitive field types.

--- a/java/arcs/core/data/proto/SchemaProtoDecoder.kt
+++ b/java/arcs/core/data/proto/SchemaProtoDecoder.kt
@@ -39,6 +39,5 @@ fun SchemaProto.decodeFields(): SchemaFields {
     return SchemaFields(singletons, collections)
 }
 
-// TODO(b/155812915) decode refinement.
 /** Converts a [SchemaProto] proto instance into a Kotlin [Schema] instance. */
 fun SchemaProto.decode() = Schema(names = decodeNames(), fields = decodeFields(), hash = hash)

--- a/java/arcs/core/data/proto/SchemaProtoDecoder.kt
+++ b/java/arcs/core/data/proto/SchemaProtoDecoder.kt
@@ -24,16 +24,17 @@ fun SchemaProto.decodeNames() = getNamesList().map { SchemaName(it) }.toSet()
 fun SchemaProto.decodeFields(): SchemaFields {
     val singletons = mutableMapOf<FieldName, FieldType>()
     val collections = mutableMapOf<FieldName, FieldType>()
-    for ((name, type) in getFieldsMap()) {
-        when (type.getDataCase()) {
+    for ((name, type) in fieldsMap) {
+        when (type.dataCase) {
             TypeProto.DataCase.PRIMITIVE -> singletons[name] = type.decodeAsFieldType()
-            // TODO: TypeProto.DataCase.COLLECTIONS
-            // TODO: TypeProto.DataCase.REFERENCE
+            TypeProto.DataCase.REFERENCE -> singletons[name] = type.decodeAsFieldType()
+            TypeProto.DataCase.TUPLE -> singletons[name] = type.decodeAsFieldType()
+            TypeProto.DataCase.COLLECTION -> collections[name] = type.collection.collectionType.decodeAsFieldType()
             TypeProto.DataCase.DATA_NOT_SET ->
                 throw IllegalArgumentException("Unknown data field in TypeProto.")
             else ->
                 throw NotImplementedError(
-                    "decodeFields for ${type.getDataCase().name} is not implemented.")
+                    "decodeFields for ${type.dataCase.name} is not implemented.")
         }
     }
     return SchemaFields(singletons, collections)

--- a/java/arcs/core/data/proto/SchemaProtoDecoder.kt
+++ b/java/arcs/core/data/proto/SchemaProtoDecoder.kt
@@ -40,5 +40,4 @@ fun SchemaProto.decodeFields(): SchemaFields {
 }
 
 /** Converts a [SchemaProto] proto instance into a Kotlin [Schema] instance. */
-fun SchemaProto.decode() = Schema(names = decodeNames(), fields = decodeFields(), hash = "")
-// TODO: hash
+fun SchemaProto.decode() = Schema(names = decodeNames(), fields = decodeFields(), hash = hash)

--- a/java/arcs/core/data/proto/SchemaProtoDecoder.kt
+++ b/java/arcs/core/data/proto/SchemaProtoDecoder.kt
@@ -29,7 +29,8 @@ fun SchemaProto.decodeFields(): SchemaFields {
             TypeProto.DataCase.PRIMITIVE -> singletons[name] = type.decodeAsFieldType()
             TypeProto.DataCase.REFERENCE -> singletons[name] = type.decodeAsFieldType()
             TypeProto.DataCase.TUPLE -> singletons[name] = type.decodeAsFieldType()
-            TypeProto.DataCase.COLLECTION -> collections[name] = type.collection.collectionType.decodeAsFieldType()
+            TypeProto.DataCase.COLLECTION -> collections[name] =
+                type.collection.collectionType.decodeAsFieldType()
             TypeProto.DataCase.DATA_NOT_SET ->
                 throw IllegalArgumentException("Unknown data field in TypeProto.")
             else ->

--- a/java/arcs/core/data/proto/SchemaProtoDecoder.kt
+++ b/java/arcs/core/data/proto/SchemaProtoDecoder.kt
@@ -26,8 +26,8 @@ fun SchemaProto.decodeFields(): SchemaFields {
     val collections = mutableMapOf<FieldName, FieldType>()
     for ((name, type) in fieldsMap) {
         when (type.dataCase) {
-            TypeProto.DataCase.PRIMITIVE -> singletons[name] = type.decodeAsFieldType()
-            TypeProto.DataCase.REFERENCE -> singletons[name] = type.decodeAsFieldType()
+            TypeProto.DataCase.PRIMITIVE,
+            TypeProto.DataCase.REFERENCE,
             TypeProto.DataCase.TUPLE -> singletons[name] = type.decodeAsFieldType()
             TypeProto.DataCase.COLLECTION -> collections[name] =
                 type.collection.collectionType.decodeAsFieldType()

--- a/java/arcs/core/data/proto/SchemaProtoDecoder.kt
+++ b/java/arcs/core/data/proto/SchemaProtoDecoder.kt
@@ -39,5 +39,6 @@ fun SchemaProto.decodeFields(): SchemaFields {
     return SchemaFields(singletons, collections)
 }
 
+// TODO(b/155812915) decode refinement.
 /** Converts a [SchemaProto] proto instance into a Kotlin [Schema] instance. */
 fun SchemaProto.decode() = Schema(names = decodeNames(), fields = decodeFields(), hash = hash)

--- a/java/arcs/core/data/proto/TypeProtoDecoders.kt
+++ b/java/arcs/core/data/proto/TypeProtoDecoders.kt
@@ -30,7 +30,15 @@ fun PrimitiveTypeProto.decode() = when (this) {
 }
 
 /** Converts a [PrimitiveTypeProto] protobuf instance into a Kotlin [FieldType] instance. */
-fun PrimitiveTypeProto.decodeAsFieldType(): FieldType.Primitive = FieldType.Primitive(decode())
+fun PrimitiveTypeProto.decodeAsFieldType() = FieldType.Primitive(decode())
+
+/** Converts a [ReferenceTypeProto] protobuf instance into a Kotlin [FieldType] instance. */
+fun ReferenceTypeProto.decodeAsFieldType() = FieldType.EntityRef(decode().entitySchema!!.hash)
+
+/** Converts a [TupleTypeProto] protobuf instance into a Kotlin [FieldType] instance. */
+fun TupleTypeProto.decodeAsFieldType(): FieldType.Tuple = FieldType.Tuple(
+    elementsList.map { it.decodeAsFieldType() }
+)
 
 /**
  * Converts a [TypeProto] protobuf instance into a Kotlin [FieldType] instance.
@@ -39,8 +47,10 @@ fun PrimitiveTypeProto.decodeAsFieldType(): FieldType.Primitive = FieldType.Prim
  */
 fun TypeProto.decodeAsFieldType() = when (dataCase) {
     TypeProto.DataCase.PRIMITIVE -> primitive.decodeAsFieldType()
-    // TODO: Handle FieldType.EntityRef. It is not clear how it is
-    // represented in the proto.
+    TypeProto.DataCase.REFERENCE -> reference.decodeAsFieldType()
+    TypeProto.DataCase.TUPLE -> tuple.decodeAsFieldType()
+    TypeProto.DataCase.COLLECTION ->
+        throw IllegalArgumentException("Cannot have nested collections in a Schema")
     TypeProto.DataCase.DATA_NOT_SET ->
         throw IllegalArgumentException("Unknown data field in TypeProto.")
     else ->

--- a/java/arcs/core/data/proto/TypeProtoDecoders.kt
+++ b/java/arcs/core/data/proto/TypeProtoDecoders.kt
@@ -33,7 +33,12 @@ fun PrimitiveTypeProto.decode() = when (this) {
 fun PrimitiveTypeProto.decodeAsFieldType() = FieldType.Primitive(decode())
 
 /** Converts a [ReferenceTypeProto] protobuf instance into a Kotlin [FieldType] instance. */
-fun ReferenceTypeProto.decodeAsFieldType() = FieldType.EntityRef(decode().entitySchema!!.hash)
+fun ReferenceTypeProto.decodeAsFieldType(): FieldType.EntityRef {
+    val entitySchema = requireNotNull(decode().entitySchema) {
+        "Field that is a reference to an non-entity type is not possible."
+    }
+    return FieldType.EntityRef(entitySchema.hash)
+}
 
 /** Converts a [TupleTypeProto] protobuf instance into a Kotlin [FieldType] instance. */
 fun TupleTypeProto.decodeAsFieldType(): FieldType.Tuple = FieldType.Tuple(

--- a/java/arcs/core/data/proto/manifest.proto
+++ b/java/arcs/core/data/proto/manifest.proto
@@ -151,7 +151,6 @@ message SchemaProto {
   repeated string names = 1;
   map<string, TypeProto> fields = 2;
   string hash = 3;
-  RefinementExpressionProto query = 4;
 }
 
 enum OPERATOR {

--- a/java/arcs/core/entity/EntityBase.kt
+++ b/java/arcs/core/entity/EntityBase.kt
@@ -341,9 +341,8 @@ private fun fromReferencable(
             }
             Reference(entitySpec, referencable)
         }
+        // TODO(b/155025255)
+        is FieldType.Tuple ->
+            throw NotImplementedError("References cannot be converted [FieldType.Tuple]s.")
     }
-    is FieldType.EntityRef -> Reference.fromReferencable(referencable, type.schemaHash)
-    // TODO(b/155025255)
-    is FieldType.Tuple ->
-        throw NotImplementedError("References cannot be converted [FieldType.Tuple]s.")
 }

--- a/java/arcs/core/entity/EntityBase.kt
+++ b/java/arcs/core/entity/EntityBase.kt
@@ -173,6 +173,10 @@ open class EntityBase(
                         "schema hash ${value.schemaHash}."
                 }
             }
+            is FieldType.Tuple -> {
+                // TODO(b/156003617)
+                throw NotImplementedError("[FieldType.Tuple]s are not supported.")
+            }
         }
     }
 
@@ -296,6 +300,9 @@ private fun toReferencable(value: Any, type: FieldType): Referencable = when (ty
         PrimitiveType.Text -> (value as String).toReferencable()
     }
     is FieldType.EntityRef -> (value as Reference<*>).toReferencable()
+    // TODO(b/155025255)
+    is FieldType.Tuple ->
+        throw NotImplementedError("[FieldType.Tuple]s cannot be converted to references.")
 }
 
 private fun fromReferencable(referencable: Referencable, type: FieldType): Any = when (type) {
@@ -308,4 +315,7 @@ private fun fromReferencable(referencable: Referencable, type: FieldType): Any =
         }
     }
     is FieldType.EntityRef -> Reference.fromReferencable(referencable, type.schemaHash)
+    // TODO(b/155025255)
+    is FieldType.Tuple ->
+        throw NotImplementedError("References cannot be converted [FieldType.Tuple]s.")
 }

--- a/javatests/arcs/android/type/ParcelableSchemaFieldsTest.kt
+++ b/javatests/arcs/android/type/ParcelableSchemaFieldsTest.kt
@@ -66,4 +66,31 @@ class ParcelableSchemaFieldsTest {
 
         assertThat(unmarshalled).isEqualTo(fields)
     }
+
+    @Test
+    fun parcelableRoundtrip_works_tuples() {
+        val fields = SchemaFields(
+            singletons = mapOf(
+                "foo" to FieldType.Text,
+                "tup" to FieldType.Tuple(listOf(FieldType.Boolean, FieldType.Number))
+            ),
+            collections = mapOf(
+                "fooCollection" to FieldType.Text,
+                "tupCollection" to FieldType.Tuple(listOf(FieldType.Boolean, FieldType.Number))
+            )
+        )
+
+        val marshalled = with(Parcel.obtain()) {
+            writeSchemaFields(fields, 0)
+            marshall()
+        }
+
+        val unmarshalled = with(Parcel.obtain()) {
+            unmarshall(marshalled, 0, marshalled.size)
+            setDataPosition(0)
+            readSchemaFields()
+        }
+
+        assertThat(unmarshalled).isEqualTo(fields)
+    }
 }

--- a/javatests/arcs/core/data/proto/SchemaProtoDecoderTest.kt
+++ b/javatests/arcs/core/data/proto/SchemaProtoDecoderTest.kt
@@ -52,4 +52,150 @@ class SchemaProtoDecoderTest {
         assertThat(schema.fields.singletons).isEqualTo(
             mapOf("text" to FieldType.Text, "bool" to FieldType.Boolean))
     }
+
+    @Test
+    fun decodesCollectionsInSchemaProto() {
+        val schemaProtoText = """
+        fields {
+          key: "text"
+          value: {
+            collection {
+              collection_type: {
+                primitive: TEXT  
+              } 
+            }
+          }
+        }
+        fields {
+          key: "bool"
+          value: {
+            collection {
+              collection_type: {
+                primitive: BOOLEAN
+              } 
+            }
+          }
+        }
+        """.trimIndent()
+        val schema = decodeSchemaProtoText(schemaProtoText)
+        assertThat(schema.fields.collections).isEqualTo(
+            mapOf("text" to FieldType.Text, "bool" to FieldType.Boolean))
+    }
+
+    @Test
+    fun decodesCollectionsOfReferencesInSchemaProto() {
+        val schemaProtoText = """
+        fields {
+          key: "text"
+          value: {
+            collection {
+              collection_type: {
+                reference {
+                  referred_type {
+                    entity: {
+                      schema: {
+                        names: "Product"
+                        fields: {
+                          key: "name"
+                          value: { 
+                           primitive: TEXT
+                          } 
+                        }
+                        hash: "a76bdd3a638fc17a5b3e023edb542c1e891c4c89"
+                      }
+                    }
+                  }
+                }
+              } 
+            }
+          }
+        }
+        fields {
+          key: "num"
+          value: {
+            collection {
+              collection_type: {
+                reference {
+                  referred_type {
+                    entity: {
+                      schema: {
+                        names: "Review"
+                        fields: {
+                          key: "rating"
+                          value: { 
+                           primitive: NUMBER
+                          } 
+                        }
+                        hash: "2d3317e5ef54fbdf3fbc02ed481c2472ebe9ba66"
+                      }
+                    }
+                  }
+                }
+              } 
+            }
+          }
+        }
+        """.trimIndent()
+        val schema = decodeSchemaProtoText(schemaProtoText)
+        assertThat(schema.fields.collections).isEqualTo(
+            mapOf(
+                "text" to FieldType.EntityRef("a76bdd3a638fc17a5b3e023edb542c1e891c4c89"),
+                "num" to FieldType.EntityRef("2d3317e5ef54fbdf3fbc02ed481c2472ebe9ba66")
+            )
+        )
+    }
+
+    @Test
+    fun decodesSingletonsOfTuplesInSchemaProto() {
+        val schemaProtoText = """
+        fields {
+          key: "tuple"
+          value: {
+            tuple: {
+              elements: {
+                primitive: TEXT 
+              }
+              elements: {
+                primitive: NUMBER 
+              }
+            }
+          }
+        }
+        """.trimIndent()
+        val schema = decodeSchemaProtoText(schemaProtoText)
+        assertThat(schema.fields.singletons).isEqualTo(
+            mapOf(
+                "tuple" to FieldType.Tuple(listOf(FieldType.Text, FieldType.Number))
+            )
+        )
+    }
+
+    @Test
+    fun decodesCollectionsOfTuplesInSchemaProto() {
+        val schemaProtoText = """
+        fields {
+          key: "tuple"
+          value: {
+            collection: {
+              collection_type: {
+                tuple: {
+                  elements: {
+                    primitive: TEXT 
+                  }
+                  elements: {
+                    primitive: NUMBER 
+                  }
+                }
+              }
+            }
+          }
+        }
+        """.trimIndent()
+        val schema = decodeSchemaProtoText(schemaProtoText)
+        assertThat(schema.fields.collections).isEqualTo(
+            mapOf(
+                "tuple" to FieldType.Tuple(listOf(FieldType.Text, FieldType.Number))
+            )
+        )
+    }
 }

--- a/javatests/arcs/core/data/proto/SchemaProtoDecoderTest.kt
+++ b/javatests/arcs/core/data/proto/SchemaProtoDecoderTest.kt
@@ -22,6 +22,10 @@ fun decodeSchemaProtoText(protoText: String): Schema {
 
 @RunWith(JUnit4::class)
 class SchemaProtoDecoderTest {
+
+    /**
+     * schema Thing, Object
+     */
     @Test
     fun decodesNamesInSchemaProto() {
         val schemaProtoText = """
@@ -32,6 +36,11 @@ class SchemaProtoDecoderTest {
         assertThat(schema.names).containsExactly(SchemaName("Thing"), SchemaName("Object"))
     }
 
+    /**
+     * schema
+     *  text: Text
+     *  bool: Boolean
+     */
     @Test
     fun decodesSingletonsInSchemaProto() {
         val schemaProtoText = """
@@ -53,6 +62,11 @@ class SchemaProtoDecoderTest {
             mapOf("text" to FieldType.Text, "bool" to FieldType.Boolean))
     }
 
+    /**
+     * schema
+     *  text: [ Text ]
+     *  bool: [ Boolean ]
+     */
     @Test
     fun decodesCollectionsInSchemaProto() {
         val schemaProtoText = """
@@ -82,6 +96,11 @@ class SchemaProtoDecoderTest {
             mapOf("text" to FieldType.Text, "bool" to FieldType.Boolean))
     }
 
+    /**
+     * schema
+     *  text: [&Product {name: Text}]
+     *  num: [&Review {rating: Number}]
+     */
     @Test
     fun decodesCollectionsOfReferencesInSchemaProto() {
         val schemaProtoText = """
@@ -145,6 +164,10 @@ class SchemaProtoDecoderTest {
         )
     }
 
+    /**
+     * schema
+     *  tuple: (Text, Number)
+     */
     @Test
     fun decodesSingletonsOfTuplesInSchemaProto() {
         val schemaProtoText = """
@@ -170,11 +193,15 @@ class SchemaProtoDecoderTest {
         )
     }
 
+    /**
+     * schema
+     *  tuples: [(Text, Number)]
+     */
     @Test
     fun decodesCollectionsOfTuplesInSchemaProto() {
         val schemaProtoText = """
         fields {
-          key: "tuple"
+          key: "tuples"
           value: {
             collection: {
               collection_type: {
@@ -194,7 +221,7 @@ class SchemaProtoDecoderTest {
         val schema = decodeSchemaProtoText(schemaProtoText)
         assertThat(schema.fields.collections).isEqualTo(
             mapOf(
-                "tuple" to FieldType.Tuple(listOf(FieldType.Text, FieldType.Number))
+                "tuples" to FieldType.Tuple(listOf(FieldType.Text, FieldType.Number))
             )
         )
     }

--- a/javatests/arcs/core/data/proto/SchemaProtoDecoderTest.kt
+++ b/javatests/arcs/core/data/proto/SchemaProtoDecoderTest.kt
@@ -42,15 +42,11 @@ class SchemaProtoDecoderTest {
         val schemaProtoText = """
         fields {
           key: "text"
-          value: {
-            primitive: TEXT
-          }
+          value: { primitive: TEXT }
         }
         fields {
           key: "bool"
-          value: {
-            primitive: BOOLEAN
-          }
+          value: { primitive: BOOLEAN }
         }
         """.trimIndent()
         val schema = decodeSchemaProtoText(schemaProtoText)
@@ -67,21 +63,13 @@ class SchemaProtoDecoderTest {
         fields {
           key: "text"
           value: {
-            collection {
-              collection_type: {
-                primitive: TEXT  
-              } 
-            }
+            collection { collection_type: { primitive: TEXT } }
           }
         }
         fields {
           key: "bool"
           value: {
-            collection {
-              collection_type: {
-                primitive: BOOLEAN
-              } 
-            }
+            collection { collection_type: { primitive: BOOLEAN } }
           }
         }
         """.trimIndent()
@@ -99,51 +87,35 @@ class SchemaProtoDecoderTest {
         fields {
           key: "text"
           value: {
-            collection {
-              collection_type: {
-                reference {
-                  referred_type {
-                    entity: {
-                      schema: {
-                        names: "Product"
-                        fields: {
-                          key: "name"
-                          value: { 
-                           primitive: TEXT
-                          } 
-                        }
-                        hash: "a76bdd3a638fc17a5b3e023edb542c1e891c4c89"
-                      }
-                    }
+            collection { collection_type: { reference { referred_type {
+              entity: {
+                schema: {
+                  names: "Product"
+                  fields: {
+                    key: "name"
+                    value: { primitive: TEXT } 
                   }
+                  hash: "a76bdd3a638fc17a5b3e023edb542c1e891c4c89"
                 }
-              } 
-            }
+              }
+            } } } }
           }
         }
         fields {
           key: "num"
           value: {
-            collection {
-              collection_type: {
-                reference {
-                  referred_type {
-                    entity: {
-                      schema: {
-                        names: "Review"
-                        fields: {
-                          key: "rating"
-                          value: { 
-                           primitive: NUMBER
-                          } 
-                        }
-                        hash: "2d3317e5ef54fbdf3fbc02ed481c2472ebe9ba66"
-                      }
-                    }
+            collection { collection_type: { reference { referred_type {
+              entity: {
+                schema: {
+                  names: "Review"
+                  fields: {
+                    key: "rating"
+                    value: { primitive: NUMBER } 
                   }
+                  hash: "2d3317e5ef54fbdf3fbc02ed481c2472ebe9ba66"
                 }
-              } 
-            }
+              }
+            } } } }
           }
         }
         """.trimIndent()
@@ -165,12 +137,8 @@ class SchemaProtoDecoderTest {
           key: "tuple"
           value: {
             tuple: {
-              elements: {
-                primitive: TEXT 
-              }
-              elements: {
-                primitive: NUMBER 
-              }
+              elements: { primitive: TEXT }
+              elements: { primitive: NUMBER }
             }
           }
         }
@@ -194,12 +162,8 @@ class SchemaProtoDecoderTest {
             collection: {
               collection_type: {
                 tuple: {
-                  elements: {
-                    primitive: TEXT 
-                  }
-                  elements: {
-                    primitive: NUMBER 
-                  }
+                  elements: { primitive: TEXT }
+                  elements: { primitive: NUMBER }
                 }
               }
             }

--- a/javatests/arcs/core/data/proto/SchemaProtoDecoderTest.kt
+++ b/javatests/arcs/core/data/proto/SchemaProtoDecoderTest.kt
@@ -23,11 +23,9 @@ fun decodeSchemaProtoText(protoText: String): Schema {
 @RunWith(JUnit4::class)
 class SchemaProtoDecoderTest {
 
-    /**
-     * schema Thing, Object
-     */
     @Test
     fun decodesNamesInSchemaProto() {
+        // schema Thing, Object
         val schemaProtoText = """
         names:  "Thing"
         names:  "Object"
@@ -36,13 +34,11 @@ class SchemaProtoDecoderTest {
         assertThat(schema.names).containsExactly(SchemaName("Thing"), SchemaName("Object"))
     }
 
-    /**
-     * schema
-     *  text: Text
-     *  bool: Boolean
-     */
     @Test
     fun decodesSingletonsInSchemaProto() {
+        // schema
+        //   text: Text
+        //   bool: Boolean
         val schemaProtoText = """
         fields {
           key: "text"
@@ -62,13 +58,11 @@ class SchemaProtoDecoderTest {
             mapOf("text" to FieldType.Text, "bool" to FieldType.Boolean))
     }
 
-    /**
-     * schema
-     *  text: [ Text ]
-     *  bool: [ Boolean ]
-     */
     @Test
     fun decodesCollectionsInSchemaProto() {
+        // schema
+        //   text: [ Text ]
+        //   bool: [ Boolean ]
         val schemaProtoText = """
         fields {
           key: "text"
@@ -96,13 +90,11 @@ class SchemaProtoDecoderTest {
             mapOf("text" to FieldType.Text, "bool" to FieldType.Boolean))
     }
 
-    /**
-     * schema
-     *  text: [&Product {name: Text}]
-     *  num: [&Review {rating: Number}]
-     */
     @Test
     fun decodesCollectionsOfReferencesInSchemaProto() {
+        // schema
+        //   text: [&Product {name: Text}]
+        //   num: [&Review {rating: Number}]
         val schemaProtoText = """
         fields {
           key: "text"
@@ -164,12 +156,10 @@ class SchemaProtoDecoderTest {
         )
     }
 
-    /**
-     * schema
-     *  tuple: (Text, Number)
-     */
     @Test
     fun decodesSingletonsOfTuplesInSchemaProto() {
+        // schema
+        //   tuple: (Text, Number)
         val schemaProtoText = """
         fields {
           key: "tuple"
@@ -193,12 +183,10 @@ class SchemaProtoDecoderTest {
         )
     }
 
-    /**
-     * schema
-     *  tuples: [(Text, Number)]
-     */
     @Test
     fun decodesCollectionsOfTuplesInSchemaProto() {
+        // schema
+        //   tuples: [(Text, Number)]
         val schemaProtoText = """
         fields {
           key: "tuples"

--- a/src/runtime/schema.ts
+++ b/src/runtime/schema.ts
@@ -322,7 +322,7 @@ export class Schema {
       } else if (kind === 'schema-collection' && schema.kind === 'schema-primitive') {
         str += '[' + schema.type + ']';
       } else if (kind === 'schema-tuple') {
-        str += `(${types.map(t => t.type).join('|')})`
+        str += `(${types.map(t => t.type).join('|')})`;
       } else {
         throw new Error('Schema hash: unsupported field type');
       }

--- a/src/runtime/schema.ts
+++ b/src/runtime/schema.ts
@@ -311,7 +311,7 @@ export class Schema {
   normalizeForHash(): string {
     let str = this.names.slice().sort().join(' ') + '/';
     for (const field of Object.keys(this.fields).sort()) {
-      const {kind, type, schema} = this.fields[field];
+      const {kind, type, schema, types} = this.fields[field];
       str += field + ':';
       if (kind === 'schema-primitive') {
         str += type + '|';
@@ -321,6 +321,8 @@ export class Schema {
         str += '[&(' + schema.schema.model.entitySchema.normalizeForHash() + ')]';
       } else if (kind === 'schema-collection' && schema.kind === 'schema-primitive') {
         str += '[' + schema.type + ']';
+      } else if (kind === 'schema-tuple') {
+        str += `(${types.map(t => t.type).join('|')})`
       } else {
         throw new Error('Schema hash: unsupported field type');
       }

--- a/src/runtime/tests/schema-test.ts
+++ b/src/runtime/tests/schema-test.ts
@@ -511,6 +511,7 @@ describe('schema', () => {
         nestedRefs: reads Foo {num: Number, ref: &Bar {str: Text, inner: &* {val: Boolean}}}
         refCollection: reads * {rc: [&Wiz {str: Text}], z: Number}
         primitiveCollection: reads * {x: [Number], f: [Boolean], s: [Text]}
+        tuples: reads Tup {x: (Number, Text)}
     `);
     const getHash = handleName => {
       return manifest.particles[0].getConnectionByName(handleName).type.getEntitySchema().normalizeForHash();
@@ -526,6 +527,7 @@ describe('schema', () => {
     assert.strictEqual(getHash('nestedRefs'), 'Foo/num:Number|ref:&(Bar/inner:&(/val:Boolean|)str:Text|)');
     assert.strictEqual(getHash('refCollection'), '/rc:[&(Wiz/str:Text|)]z:Number|');
     assert.strictEqual(getHash('primitiveCollection'), '/f:[Boolean]s:[Text]x:[Number]');
+    assert.strictEqual(getHash('tuples'), 'Tup/x:(Number|Text)');
   });
   it('tests univariate schema level refinements are propagated to field level', Flags.withFieldRefinementsAllowed(async () => {
     const manifest = await Manifest.parse(`

--- a/src/tools/manifest2proto.ts
+++ b/src/tools/manifest2proto.ts
@@ -238,18 +238,12 @@ export async function typeToProtoPayload(type: Type) {
 }
 
 export async function schemaToProtoPayload(schema: Schema) {
-  const schemaPayload = {
+  return {
     names: schema.names,
     fields: objectFromEntries(await Promise.all(Object.entries(schema.fields).map(
       async ([key, value]) => [key, await schemaFieldToProtoPayload(value)]))),
     hash: await schema.hash(),
   };
-
-  if (schema.refinement) {
-    schemaPayload['query'] = refinementToProtoPayload(schema.refinement);
-  }
-
-  return schemaPayload;
 }
 
 type SchemaField = {

--- a/src/tools/manifest2proto.ts
+++ b/src/tools/manifest2proto.ts
@@ -242,7 +242,7 @@ export async function schemaToProtoPayload(schema: Schema) {
     names: schema.names,
     fields: objectFromEntries(await Promise.all(Object.entries(schema.fields).map(
       async ([key, value]) => [key, await schemaFieldToProtoPayload(value)]))),
-    hash: await schema.hash(),
+    hash: await schema.hash()
   };
 }
 

--- a/src/tools/manifest2proto.ts
+++ b/src/tools/manifest2proto.ts
@@ -238,12 +238,18 @@ export async function typeToProtoPayload(type: Type) {
 }
 
 export async function schemaToProtoPayload(schema: Schema) {
-  return {
+  const schemaPayload = {
     names: schema.names,
     fields: objectFromEntries(await Promise.all(Object.entries(schema.fields).map(
       async ([key, value]) => [key, await schemaFieldToProtoPayload(value)]))),
-    hash: await schema.hash()
+    hash: await schema.hash(),
   };
+
+  if (schema.refinement) {
+    schemaPayload['query'] = refinementToProtoPayload(schema.refinement);
+  }
+
+  return schemaPayload;
 }
 
 type SchemaField = {

--- a/src/tools/manifest2proto.ts
+++ b/src/tools/manifest2proto.ts
@@ -276,6 +276,13 @@ async function schemaFieldToProtoPayload(fieldType: SchemaField) {
         }
       };
     }
+    case 'schema-tuple': {
+      return {
+        tuple: {
+          elements: await Promise.all(fieldType.types.map(schemaFieldToProtoPayload))
+        }
+      };
+    }
     case 'schema-reference': {
       return {
         reference: {
@@ -286,6 +293,8 @@ async function schemaFieldToProtoPayload(fieldType: SchemaField) {
     case 'schema-inline': {
       return typeToProtoPayload(fieldType.model);
     }
+    // TODO(b/154947220) support schema-unions
+    case 'schema-union':
     default: throw Error(`Schema field kind ${fieldType.kind} is not supported.`);
   }
 }

--- a/src/tools/tests/manifest2proto-test.ts
+++ b/src/tools/tests/manifest2proto-test.ts
@@ -219,6 +219,9 @@ describe('manifest2proto', () => {
             }
           },
           hash: '6f1753a75cd024be11593acfbf34d1b92463e9ef',
+          query: {
+            "boolean": true
+          }
         },
       },
       refinement: {
@@ -243,6 +246,33 @@ describe('manifest2proto', () => {
             }
           },
           hash: '6f1753a75cd024be11593acfbf34d1b92463e9ef',
+          query: {
+            binary: {
+              leftExpr: {
+                binary: {
+                  leftExpr: {
+                    field: 'num',
+                  },
+                  operator: 'LESS_THAN',
+                  rightExpr: {
+                    number: 12
+                  }
+                }
+              },
+              operator: 'AND',
+              rightExpr: {
+                binary: {
+                  leftExpr: {
+                    field: 'num'
+                  },
+                  operator: 'GREATER_THAN',
+                  rightExpr: {
+                    number: -1
+                  }
+                }
+              },
+            }
+          }
         },
       },
       refinement: {
@@ -291,6 +321,17 @@ describe('manifest2proto', () => {
             }
           },
           hash: '6f1753a75cd024be11593acfbf34d1b92463e9ef',
+          query: {
+            binary: {
+              leftExpr: {
+                field: 'num'
+              },
+              operator: 'EQUALS',
+              rightExpr: {
+                queryArgument: '?'
+              },
+            }
+          }
         },
       },
       refinement: {
@@ -466,6 +507,21 @@ describe('manifest2proto', () => {
         },
         hash: '2d3317e5ef54fbdf3fbc02ed481c2472ebe9ba66'
       }}}}}}},
+    });
+  });
+
+  it('encodes schemas with tuple fields', async () => {
+    const manifest = await Manifest.parse(`
+      schema Foo
+        t: (Text, Number)
+      particle Abc in 'a/b/c.js'
+        input: reads Foo 
+    `);
+    const schema = (await toProtoAndBack(manifest)).particleSpecs[0].connections[0].type.entity.schema;
+
+    assert.deepStrictEqual(schema.names, ['Foo']);
+    assert.deepStrictEqual(schema.fields, {
+      t: {tuple: {elements: [{primitive: 'TEXT'}, {primitive: 'NUMBER'}]}}
     });
   });
 

--- a/src/tools/tests/manifest2proto-test.ts
+++ b/src/tools/tests/manifest2proto-test.ts
@@ -219,9 +219,6 @@ describe('manifest2proto', () => {
             }
           },
           hash: '6f1753a75cd024be11593acfbf34d1b92463e9ef',
-          query: {
-            "boolean": true
-          }
         },
       },
       refinement: {
@@ -246,33 +243,6 @@ describe('manifest2proto', () => {
             }
           },
           hash: '6f1753a75cd024be11593acfbf34d1b92463e9ef',
-          query: {
-            binary: {
-              leftExpr: {
-                binary: {
-                  leftExpr: {
-                    field: 'num',
-                  },
-                  operator: 'LESS_THAN',
-                  rightExpr: {
-                    number: 12
-                  }
-                }
-              },
-              operator: 'AND',
-              rightExpr: {
-                binary: {
-                  leftExpr: {
-                    field: 'num'
-                  },
-                  operator: 'GREATER_THAN',
-                  rightExpr: {
-                    number: -1
-                  }
-                }
-              },
-            }
-          }
         },
       },
       refinement: {
@@ -321,17 +291,6 @@ describe('manifest2proto', () => {
             }
           },
           hash: '6f1753a75cd024be11593acfbf34d1b92463e9ef',
-          query: {
-            binary: {
-              leftExpr: {
-                field: 'num'
-              },
-              operator: 'EQUALS',
-              rightExpr: {
-                queryArgument: '?'
-              },
-            }
-          }
         },
       },
       refinement: {

--- a/src/tools/tests/manifest2proto-test.ts
+++ b/src/tools/tests/manifest2proto-test.ts
@@ -471,10 +471,8 @@ describe('manifest2proto', () => {
 
   it('encodes schemas with tuple fields', async () => {
     const manifest = await Manifest.parse(`
-      schema Foo
-        t: (Text, Number)
       particle Abc in 'a/b/c.js'
-        input: reads Foo 
+        input: reads Foo {t: (Text, Number)}
     `);
     const schema = (await toProtoAndBack(manifest)).particleSpecs[0].connections[0].type.entity.schema;
 


### PR DESCRIPTION
- Added a new FieldType to Kolin Schemas: `Tuple`.
- Updated Schema normalization (part of hash) to support tuples. 
- Undid adding refinements to the schema proto -- tests revealed that it added redundant information. 
- Decoded collections, references, and tuples on Schema fields into Kotlin