### PR TITLE
add a test to demonstrate how to specify an id for an entity so that …

### DIFF
--- a/java/arcs/core/crdt/CrdtEntity.kt
+++ b/java/arcs/core/crdt/CrdtEntity.kt
@@ -86,8 +86,8 @@ class CrdtEntity(
             if (_data.creationTimestamp == RawEntity.UNINITIALIZED_TIMESTAMP) {
                 _data.creationTimestamp = other.creationTimestamp
             } else if (other.creationTimestamp != RawEntity.UNINITIALIZED_TIMESTAMP) {
-                // Two different values, this should be impossible.
-                throw CrdtException("Cannot merge different values for creationTimestamp.")
+                // Two different values, take minimum.
+                _data.creationTimestamp = minOf(_data.creationTimestamp, other.creationTimestamp)
             }
         }
         if (_data.expirationTimestamp != other.expirationTimestamp) {
@@ -95,8 +95,9 @@ class CrdtEntity(
             if (_data.expirationTimestamp == RawEntity.UNINITIALIZED_TIMESTAMP) {
                 _data.expirationTimestamp = other.expirationTimestamp
             } else if (other.expirationTimestamp != RawEntity.UNINITIALIZED_TIMESTAMP) {
-                // Two different values, this should be impossible.
-                throw CrdtException("Cannot merge different values for expirationTimestamp.")
+                // Two different values, take minimum.
+                _data.expirationTimestamp =
+                    minOf(_data.expirationTimestamp, other.expirationTimestamp)
             }
         }
         if (_data.id != other.id) {

--- a/java/arcs/core/entity/EntityBase.kt
+++ b/java/arcs/core/entity/EntityBase.kt
@@ -252,6 +252,8 @@ open class EntityBase(
                 idGenerator.newArcId("dummy-arc"),
                 handleName
             ).toString()
+        }
+        if (creationTimestamp == UNINITIALIZED_TIMESTAMP) {
             creationTimestamp = time.currentTimeMillis
             if (ttl != Ttl.Infinite) {
                 expirationTimestamp = ttl.calculateExpiration(time)

--- a/java/arcs/jvm/util/testutil/FakeTime.kt
+++ b/java/arcs/jvm/util/testutil/FakeTime.kt
@@ -15,8 +15,16 @@ import arcs.core.util.Time
 
 class FakeTime(var millis: Long = 999_999) : Time() {
     override val nanoTime: Long
-        get() = millis * 1_000_000
+        get() {
+            millis += autoincrement
+            return millis * 1_000_000
+        }
 
     override val currentTimeMillis: Long
-        get() = millis
+        get() {
+            millis += autoincrement
+            return millis
+        }
+
+    var autoincrement = 0
 }

--- a/javatests/arcs/core/crdt/CrdtEntityTest.kt
+++ b/javatests/arcs/core/crdt/CrdtEntityTest.kt
@@ -350,7 +350,7 @@ class CrdtEntityTest {
 
         entity = CrdtEntity(VersionMap(), RawEntity(id = "id"))
         entity2 = CrdtEntity(VersionMap(), RawEntity(id = "id2"))
-        assertThrows(CrdtException::class) {
+        assertFailsWith<CrdtException> {
             entity.merge(entity2.data)
         }
     }

--- a/javatests/arcs/core/crdt/CrdtEntityTest.kt
+++ b/javatests/arcs/core/crdt/CrdtEntityTest.kt
@@ -259,8 +259,10 @@ class CrdtEntityTest {
         }
     }
 
-    fun entity(creation: Long = RawEntity.UNINITIALIZED_TIMESTAMP,
-        expiration: Long = RawEntity.UNINITIALIZED_TIMESTAMP) =
+    fun entity(
+        creation: Long = RawEntity.UNINITIALIZED_TIMESTAMP,
+        expiration: Long = RawEntity.UNINITIALIZED_TIMESTAMP
+    ) =
             CrdtEntity(VersionMap(), RawEntity(
                 id = "an-id",
                 singletons = mapOf(),
@@ -276,26 +278,25 @@ class CrdtEntityTest {
         entity.merge(entity2.data)
         assertThat(entity.data.creationTimestamp).isEqualTo(RawEntity.UNINITIALIZED_TIMESTAMP)
 
-        entity = entity(creation=5)
+        entity = entity(creation = 5)
         entity2 = entity()
         entity.merge(entity2.data)
         assertThat(entity.data.creationTimestamp).isEqualTo(5)
 
         entity = entity()
-        entity2 = entity(creation=5)
+        entity2 = entity(creation = 5)
         entity.merge(entity2.data)
         assertThat(entity.data.creationTimestamp).isEqualTo(5)
 
-        entity = entity(creation=5)
-        entity2 = entity(creation=5)
+        entity = entity(creation = 5)
+        entity2 = entity(creation = 5)
         entity.merge(entity2.data)
         assertThat(entity.data.creationTimestamp).isEqualTo(5)
 
-        entity = entity(creation=5)
-        entity2 = entity(creation=1)
-        assertFailsWith<CrdtException> {
-            entity.merge(entity2.data)
-        }
+        entity = entity(creation = 5)
+        entity2 = entity(creation = 1)
+        entity.merge(entity2.data)
+        assertThat(entity.data.creationTimestamp).isEqualTo(1)
     }
 
     @Test
@@ -305,26 +306,25 @@ class CrdtEntityTest {
         entity.merge(entity2.data)
         assertThat(entity.data.expirationTimestamp).isEqualTo(RawEntity.UNINITIALIZED_TIMESTAMP)
 
-        entity = entity(expiration=5)
+        entity = entity(expiration = 5)
         entity2 = entity()
         entity.merge(entity2.data)
         assertThat(entity.data.expirationTimestamp).isEqualTo(5)
 
         entity = entity()
-        entity2 = entity(expiration=5)
+        entity2 = entity(expiration = 5)
         entity.merge(entity2.data)
         assertThat(entity.data.expirationTimestamp).isEqualTo(5)
 
-        entity = entity(expiration=5)
-        entity2 = entity(expiration=5)
+        entity = entity(expiration = 5)
+        entity2 = entity(expiration = 5)
         entity.merge(entity2.data)
         assertThat(entity.data.expirationTimestamp).isEqualTo(5)
 
-        entity = entity(expiration=5)
-        entity2 = entity(expiration=1)
-        assertFailsWith<CrdtException> {
-            entity.merge(entity2.data)
-        }
+        entity = entity(expiration = 5)
+        entity2 = entity(expiration = 1)
+        entity.merge(entity2.data)
+        assertThat(entity.data.expirationTimestamp).isEqualTo(1)
     }
 
     @Test
@@ -334,25 +334,24 @@ class CrdtEntityTest {
         entity.merge(entity2.data)
         assertThat(entity.data.id).isEqualTo(RawEntity.NO_REFERENCE_ID)
 
-        entity = CrdtEntity(VersionMap(), RawEntity(id="id"))
+        entity = CrdtEntity(VersionMap(), RawEntity(id = "id"))
         entity2 = CrdtEntity(VersionMap(), RawEntity())
         entity.merge(entity2.data)
         assertThat(entity.data.id).isEqualTo("id")
 
         entity = CrdtEntity(VersionMap(), RawEntity())
-        entity2 = CrdtEntity(VersionMap(), RawEntity(id="id"))
+        entity2 = CrdtEntity(VersionMap(), RawEntity(id = "id"))
         entity.merge(entity2.data)
         assertThat(entity.data.id).isEqualTo("id")
 
-        entity = CrdtEntity(VersionMap(), RawEntity(id="id"))
-        entity2 = CrdtEntity(VersionMap(), RawEntity(id="id"))
+        entity = CrdtEntity(VersionMap(), RawEntity(id = "id"))
+        entity2 = CrdtEntity(VersionMap(), RawEntity(id = "id"))
         assertThat(entity.data.id).isEqualTo("id")
 
-        entity = CrdtEntity(VersionMap(), RawEntity(id="id"))
-        entity2 = CrdtEntity(VersionMap(), RawEntity(id="id2"))
-        assertFailsWith<CrdtException> {
+        entity = CrdtEntity(VersionMap(), RawEntity(id = "id"))
+        entity2 = CrdtEntity(VersionMap(), RawEntity(id = "id2"))
+        assertThrows(CrdtException::class) {
             entity.merge(entity2.data)
         }
     }
-
 }

--- a/javatests/arcs/core/entity/HandleManagerTestBase.kt
+++ b/javatests/arcs/core/entity/HandleManagerTestBase.kt
@@ -547,6 +547,31 @@ open class HandleManagerTestBase {
 
         handle.store(modified)
         assertThat(handle.fetchAll()).containsExactly(modified)
+    }   
+
+    @Test
+    open fun clientCanSetEntityId() = testRunner {
+        fakeTime.millis = 0
+        // Ask faketime to increment to test with changing timestamps.
+        fakeTime.autoincrement = 1
+        val id = "MyId"
+        val entity = TestParticle_Entities(text = "Hello", number = 1.0, entityId = id)
+        val handle = writeHandleManager.createCollectionHandle(entitySpec = TestParticle_Entities)
+        withContext(handle.dispatcher) {
+            handle.store(entity)
+            assertThat(handle.fetchAll()).containsExactly(entity)
+
+            // A different entity, with the same ID, should replace the first.
+            val entity2 = TestParticle_Entities(text = "New Hello", number = 1.1, entityId = id)
+            handle.store(entity2)
+            assertThat(handle.fetchAll()).containsExactly(entity2)
+            assertThat(entity2.creationTimestamp).isNotEqualTo(RawEntity.UNINITIALIZED_TIMESTAMP)
+
+            // An entity with a different ID.
+            val entity3 = TestParticle_Entities(text = "Bye", number = 2.0, entityId = "OtherId")
+            handle.store(entity3)
+            assertThat(handle.fetchAll()).containsExactly(entity3, entity2)
+        }
     }
 
     @Test

--- a/javatests/arcs/core/entity/HandleManagerTestBase.kt
+++ b/javatests/arcs/core/entity/HandleManagerTestBase.kt
@@ -565,7 +565,8 @@ open class HandleManagerTestBase {
             val entity2 = TestParticle_Entities(text = "New Hello", number = 1.1, entityId = id)
             handle.store(entity2)
             assertThat(handle.fetchAll()).containsExactly(entity2)
-            assertThat(entity2.creationTimestamp).isNotEqualTo(RawEntity.UNINITIALIZED_TIMESTAMP)
+            // Timestamps also get updated.
+            assertThat(entity2.creationTimestamp).isEqualTo(2)
 
             // An entity with a different ID.
             val entity3 = TestParticle_Entities(text = "Bye", number = 2.0, entityId = "OtherId")


### PR DESCRIPTION
…you can later replace it, and make CrdtEntity handle different timestamps