### PR TITLE
support in-memory sqlite storage key generation in capabilities-resolver

### DIFF
--- a/java/arcs/core/data/testdata/WriterReaderExample.arcs
+++ b/java/arcs/core/data/testdata/WriterReaderExample.arcs
@@ -44,7 +44,7 @@ particle ReadWriteReferences
   arcId referencesArcId
 recipe ReferencesRecipe
   things: create persistent 'my-refs-id'
-  thing: create persistent 'my-ref-id'
+  thing: create 'my-ref-id' @ttl(1d)
   ReadWriteReferences
     inThingRefs: things
     outThingRef: thing

--- a/java/arcs/core/storage/CapabilitiesResolver.kt
+++ b/java/arcs/core/storage/CapabilitiesResolver.kt
@@ -127,6 +127,8 @@ class CapabilitiesResolver(
 
     /** Returns list of creator info corresponding to the given [Capabilities]. */
     /* internal */ fun findCreators(capabilities: Capabilities): List<StorageKeyCreatorInfo> {
+        var result = creators.filter { creator -> creator.capabilities.equals(capabilities) }
+        if (result.isNotEmpty()) return result
         return creators.filter { creator -> capabilities in creator.capabilities }
     }
 

--- a/java/arcs/core/storage/CapabilitiesResolver.kt
+++ b/java/arcs/core/storage/CapabilitiesResolver.kt
@@ -127,7 +127,7 @@ class CapabilitiesResolver(
 
     /** Returns list of creator info corresponding to the given [Capabilities]. */
     /* internal */ fun findCreators(capabilities: Capabilities): List<StorageKeyCreatorInfo> {
-        var result = creators.filter { creator -> creator.capabilities.equals(capabilities) }
+        var result = creators.filter { creator -> creator.capabilities == capabilities }
         if (result.isNotEmpty()) return result
         return creators.filter { creator -> capabilities in creator.capabilities }
     }

--- a/java/arcs/core/storage/keys/DatabaseStorageKey.kt
+++ b/java/arcs/core/storage/keys/DatabaseStorageKey.kt
@@ -102,6 +102,15 @@ sealed class DatabaseStorageKey(
                     storageKeyOptions.entitySchema.hash
                 )
             }
+            CapabilitiesResolver.registerKeyCreator(
+                MEMORY_DATABASE_DRIVER_PROTOCOL,
+                Capabilities.Queryable
+            ) { storageKeyOptions ->
+                DatabaseStorageKey.Memory(
+                    storageKeyOptions.location,
+                    storageKeyOptions.entitySchema.hash
+                )
+            }
         }
         /* internal */
         fun persistentFromString(rawKeyString: String): Persistent = fromString(rawKeyString)

--- a/javatests/arcs/core/storage/CapabilitiesResolverTest.kt
+++ b/javatests/arcs/core/storage/CapabilitiesResolverTest.kt
@@ -21,6 +21,7 @@ import arcs.core.data.SchemaFields
 import arcs.core.data.SchemaName
 import arcs.core.storage.keys.DATABASE_DRIVER_PROTOCOL
 import arcs.core.storage.keys.DatabaseStorageKey
+import arcs.core.storage.keys.MEMORY_DATABASE_DRIVER_PROTOCOL
 import arcs.core.storage.keys.RAMDISK_DRIVER_PROTOCOL
 import arcs.core.storage.keys.RamDiskStorageKey
 import arcs.core.storage.keys.VOLATILE_DRIVER_PROTOCOL
@@ -167,6 +168,11 @@ class CapabilitiesResolverTest {
             .containsExactly(RAMDISK_DRIVER_PROTOCOL)
         assertThat(resolver1.findStorageKeyProtocols(Capabilities.Persistent))
             .containsExactly(DATABASE_DRIVER_PROTOCOL)
+        assertThat(resolver1.findStorageKeyProtocols(Capabilities.PersistentQueryable))
+            .containsExactly(DATABASE_DRIVER_PROTOCOL)
+        assertThat(resolver1.findStorageKeyProtocols(Capabilities.Queryable))
+            .containsExactly(MEMORY_DATABASE_DRIVER_PROTOCOL)
+
         verifyStorageKey(
             resolver1.createStorageKey(Capabilities.TiedToArc, thingEntityType, handleId),
             VolatileStorageKey::class.java

--- a/src/runtime/capabilities-resolver.ts
+++ b/src/runtime/capabilities-resolver.ts
@@ -127,10 +127,17 @@ export class CapabilitiesResolver {
   findStorageKeyProtocols(inCapabilities: Capabilities): Set<string> {
     const protocols: Set<string> = new Set();
     for (const {protocol, capabilities} of this.creators) {
-      if (capabilities.contains(inCapabilities)) {
+      if (capabilities.isSame(inCapabilities)) {
           protocols.add(protocol);
       }
     }
+    if (protocols.size === 0) {
+      for (const {protocol, capabilities} of this.creators) {
+        if (capabilities.contains(inCapabilities)) {
+            protocols.add(protocol);
+        }
+      }
+      }
     return protocols;
   }
 }

--- a/src/runtime/capabilities-resolver.ts
+++ b/src/runtime/capabilities-resolver.ts
@@ -137,7 +137,7 @@ export class CapabilitiesResolver {
             protocols.add(protocol);
         }
       }
-      }
+    }
     return protocols;
   }
 }

--- a/src/runtime/capabilities.ts
+++ b/src/runtime/capabilities.ts
@@ -50,5 +50,7 @@ export class Capabilities {
   static readonly tiedToRuntime = new Capabilities(['tied-to-runtime']);
   static readonly persistent = new Capabilities(['persistent']);
   static readonly queryable = new Capabilities(['queryable']);
+  static readonly tiedToArcQueryable = new Capabilities(['tied-to-arc', 'queryable']);
+  static readonly tiedToRuntimeQueryable = new Capabilities(['tied-to-runtime', 'queryable']);
   static readonly persistentQueryable = new Capabilities(['persistent', 'queryable']);
 }

--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -892,18 +892,20 @@ ${e.message}
         items.byName.set(item.name, {item, handle});
       }
       handle.fate = item.kind === 'handle' && item.fate ? item.fate : null;
-      if (item.kind === 'handle' && item.capabilities) {
-        handle.capabilities = new Capabilities(item.capabilities);
-      }
-      if (item.kind === 'handle' && item.annotation) {
-        assert(item.annotation.simpleAnnotation === 'ttl',
-               `unsupported recipe handle annotation ${item.annotation.simpleAnnotation}`);
-        handle.ttl = new Ttl(
-            item.annotation.parameter.count,
-            Ttl.ttlUnitsFromString(item.annotation.parameter.units));
-      }
-      if (item.kind === 'handle' && item.annotations) {
-        handle.annotations = Manifest._buildAnnotationRefs(manifest, item.annotations);
+      if (item.kind === 'handle') {
+        if (item.annotation) {
+          assert(item.annotation.simpleAnnotation === 'ttl',
+                `unsupported recipe handle annotation ${item.annotation.simpleAnnotation}`);
+          handle.ttl = new Ttl(
+              item.annotation.parameter.count,
+              Ttl.ttlUnitsFromString(item.annotation.parameter.units));
+        }
+        if (item.capabilities) {
+          handle.capabilities = new Capabilities(handle.ttl.isInfinite ? item.capabilities : [...item.capabilities, 'queryable']);
+        }
+        if (item.annotations) {
+          handle.annotations = Manifest._buildAnnotationRefs(manifest, item.annotations);
+        }
       }
       items.byHandle.set(handle, item);
     }

--- a/src/runtime/manual_tests/loader-test.ts
+++ b/src/runtime/manual_tests/loader-test.ts
@@ -14,7 +14,7 @@ import {path} from '../../platform/path-web.js';
 import {Loader} from '../../platform/loader.js';
 import {Manifest} from '../manifest.js';
 
-describe('loader', function() {
+describe.only('loader', function() {
   this.timeout(10000);
 
   const testDir = 'test-output';
@@ -24,21 +24,24 @@ describe('loader', function() {
     }
   });
 
-  it('correctly loads Thing as a dependency', async () => {
+  // TODO(#5322): reneable or delete.
+  it.skip('correctly loads Thing as a dependency', async () => {
     const loader = new Loader();
     const schemaString = await loader.loadResource('http://schema.org/Product');
     const manifest = await Manifest.parse(schemaString, {loader, fileName: 'http://schema.org/Product'});
     assert.strictEqual(manifest.schemas.Product.fields.description.type, 'Text');
   });
 
-  it('can read a schema.org schema that aliases another type', async () => {
+  // TODO(#5322): reneable or delete.
+  it.skip('can read a schema.org schema that aliases another type', async () => {
     const loader = new Loader();
     const schemaString = await loader.loadResource('http://schema.org/Restaurant');
     const manifest = await Manifest.parse(schemaString, {loader, fileName: 'http://schema.org/Restaurant'});
     assert.strictEqual(manifest.schemas.Restaurant.fields.servesCuisine.type, 'Text');
   });
 
-  it('can read a schema.org schema with multiple inheritance', async () => {
+  // TODO(#5322): reneable or delete.
+  it.skip('can read a schema.org schema with multiple inheritance', async () => {
     const loader = new Loader();
     const schemaString = await loader.loadResource('http://schema.org/LocalBusiness');
     const manifest = await Manifest.parse(schemaString, {loader, fileName: 'http://schema.org/LocalBusiness'});
@@ -68,7 +71,8 @@ describe('loader', function() {
     assert.deepEqual(new Uint8Array(buffer), data);
   });
 
-  it('loads a binary URL', async () => {
+  // TODO(#5322): reneable or delete.
+  it.skip('loads a binary URL', async () => {
     const loader = new Loader();
     const buffer = await loader.loadBinaryResource('http://schema.org/Thing');
     assert.instanceOf(buffer, ArrayBuffer);

--- a/src/runtime/storageNG/database-storage-key.ts
+++ b/src/runtime/storageNG/database-storage-key.ts
@@ -48,7 +48,7 @@ export abstract class DatabaseStorageKey extends StorageKey {
         (options: StorageKeyOptions) =>
             new PersistentDatabaseStorageKey(options.location(), options.schemaHash));
 
-    // TODO(mmandlis): registering all possible in-memory capabilities with `queryable`.
+    // Registering all possible in-memory capabilities with `queryable`.
     for (const capabilities of [Capabilities.queryable, Capabilities.tiedToArcQueryable, Capabilities.tiedToRuntimeQueryable]) {
       CapabilitiesResolver.registerKeyCreator(
           MemoryDatabaseStorageKey.protocol,

--- a/src/runtime/storageNG/database-storage-key.ts
+++ b/src/runtime/storageNG/database-storage-key.ts
@@ -48,13 +48,14 @@ export abstract class DatabaseStorageKey extends StorageKey {
         (options: StorageKeyOptions) =>
             new PersistentDatabaseStorageKey(options.location(), options.schemaHash));
 
-    // TODO(mmandlis): Register in-memory & queryable capabilities
-    // with in-memory database storage key.
-    // CapabilitiesResolver.registerKeyCreator(
-    //     MemoryDatabaseStorageKey.protocol,
-    //     Capabilities.TBD
-    //     (options: StorageKeyOptions) =>
-    //         new MemoryDatabaseStorageKey(options.location(), options.schemaHash));
+    // TODO(mmandlis): registering all possible in-memory capabilities with `queryable`.
+    for (const capabilities of [Capabilities.queryable, Capabilities.tiedToArcQueryable, Capabilities.tiedToRuntimeQueryable]) {
+      CapabilitiesResolver.registerKeyCreator(
+          MemoryDatabaseStorageKey.protocol,
+          capabilities,
+          (options: StorageKeyOptions) =>
+              new MemoryDatabaseStorageKey(options.location(), options.schemaHash));
+      }
   }
 }
 

--- a/src/runtime/tests/arc-test.ts
+++ b/src/runtime/tests/arc-test.ts
@@ -34,6 +34,8 @@ import {RamDiskStorageDriverProvider} from '../storageNG/drivers/ramdisk.js';
 import {ReferenceModeStorageKey} from '../storageNG/reference-mode-storage-key.js';
 import {TestVolatileMemoryProvider} from '../testing/test-volatile-memory-provider.js';
 import {SingletonEntityStore, CollectionEntityStore, handleForStore} from '../storageNG/storage-ng.js';
+import {Capabilities} from '../capabilities.js';
+import {CapabilitiesResolver, StorageKeyOptions} from '../capabilities-resolver.js';
 
 async function setup(storageKeyPrefix:  (arcId: ArcId) => StorageKey) {
   const loader = new Loader();
@@ -1036,6 +1038,11 @@ describe('Arc storage migration', () => {
   }));
 
   it('sets ttl on create entities', async () => {
+    CapabilitiesResolver.registerKeyCreator(
+        VolatileStorageKey.protocol,
+        Capabilities.queryable,
+        (options: StorageKeyOptions) => new VolatileStorageKey(options.arcId, options.unique(), ''));
+
     const id = ArcId.newForTest('test');
     const loader = new Loader(null, {
       'ThingAdder.js': `
@@ -1122,6 +1129,7 @@ describe('Arc storage migration', () => {
     // `foo` was added at the same time as `bar`, `bar` has a >1d longer ttl than `foo`.
     assert.isTrue(barThing2.expirationTimestamp - fooThing1.expirationTimestamp >
         24 * 60 * 60 * 1000);
+    CapabilitiesResolver.reset();
   });
 });
 

--- a/src/runtime/tests/recipe-test.ts
+++ b/src/runtime/tests/recipe-test.ts
@@ -802,10 +802,10 @@ describe('recipe', () => {
         h0: create persistent
         h1: create tied-to-runtime 'my-id'
         h2: create persistent tied-to-arc #myTag
-        h4: create persistent
-        h5: create persistent @ttl(20d)
-        h6: create @ttl(20d)
-        h7: create #otherTag`)).recipes[0];
+        h3: create persistent
+        h4: create persistent @ttl(20d)
+        h5: create @ttl(20d)
+        h6: create #otherTag`)).recipes[0];
     const verifyRecipeHandleCapabilities = (recipe) => {
       assert.lengthOf(recipe.handles, 7);
       assert.isTrue(

--- a/src/runtime/tests/recipe-test.ts
+++ b/src/runtime/tests/recipe-test.ts
@@ -802,16 +802,25 @@ describe('recipe', () => {
         h0: create persistent
         h1: create tied-to-runtime 'my-id'
         h2: create persistent tied-to-arc #myTag
-        h3: create #otherTag`)).recipes[0];
+        h4: create persistent
+        h5: create persistent @ttl(20d)
+        h6: create @ttl(20d)
+        h7: create #otherTag`)).recipes[0];
     const verifyRecipeHandleCapabilities = (recipe) => {
-      assert.lengthOf(recipe.handles, 4);
+      assert.lengthOf(recipe.handles, 7);
       assert.isTrue(
           recipe.handles[0].capabilities.isSame(new Capabilities(['persistent'])));
       assert.isTrue(
           recipe.handles[1].capabilities.isSame(new Capabilities(['tied-to-runtime'])));
       assert.isTrue(
           recipe.handles[2].capabilities.isSame(new Capabilities(['persistent', 'tied-to-arc'])));
-      assert.isTrue(recipe.handles[3].capabilities.isEmpty());
+      assert.isTrue(
+          recipe.handles[3].capabilities.isSame(new Capabilities(['persistent'])));
+      assert.isTrue(
+          recipe.handles[4].capabilities.isSame(new Capabilities(['persistent', 'queryable'])));
+      assert.isTrue(
+          recipe.handles[5].capabilities.isSame(new Capabilities(['queryable'])));
+      assert.isTrue(recipe.handles[6].capabilities.isEmpty());
     };
     verifyRecipeHandleCapabilities(recipe);
     verifyRecipeHandleCapabilities((await Manifest.parse(recipe.toString())).recipes[0]);

--- a/src/tools/tests/goldens/WriterReaderExample.kt
+++ b/src/tools/tests/goldens/WriterReaderExample.kt
@@ -112,11 +112,11 @@ object ReferencesRecipePlan : Plan(
                 ),
                 "outThingRef" to HandleConnection(
                     StorageKeyParser.parse(
-                        "db://25e71af4e9fc8b6958fc46a8f4b7cdf6b5f31516@arcs/!:referencesArcId/handle/my-ref-id"
+                        "memdb://25e71af4e9fc8b6958fc46a8f4b7cdf6b5f31516@arcs/!:referencesArcId/handle/my-ref-id"
                     ),
                     HandleMode.Write,
                     SingletonType(ReferenceType(EntityType(ReadWriteReferences_OutThingRef.SCHEMA))),
-                    Ttl.Infinite
+                    Ttl.Days(1)
                 )
             )
         )

--- a/src/tools/tests/storage-key-recipe-resolver-test.ts
+++ b/src/tools/tests/storage-key-recipe-resolver-test.ts
@@ -21,9 +21,6 @@ import {DatabaseStorageKey} from '../../runtime/storageNG/database-storage-key.j
 import {CapabilitiesResolver} from '../../runtime/capabilities-resolver.js';
 import {Flags} from '../../runtime/flags.js';
 
-// TODO: START HERE: validate sqlite in-memory keys!!!
-// TODO: Implement in KT!
-
 describe('recipe2plan', () => {
   describe('storage-key-recipe-resolver', () => {
     beforeEach(() => DatabaseStorageKey.register());

--- a/src/tools/tests/storage-key-recipe-resolver-test.ts
+++ b/src/tools/tests/storage-key-recipe-resolver-test.ts
@@ -21,6 +21,9 @@ import {DatabaseStorageKey} from '../../runtime/storageNG/database-storage-key.j
 import {CapabilitiesResolver} from '../../runtime/capabilities-resolver.js';
 import {Flags} from '../../runtime/flags.js';
 
+// TODO: START HERE: validate sqlite in-memory keys!!!
+// TODO: Implement in KT!
+
 describe('recipe2plan', () => {
   describe('storage-key-recipe-resolver', () => {
     beforeEach(() => DatabaseStorageKey.register());


### PR DESCRIPTION
the implemented heuristics is: if an in-memory handle specifies TTLs, this means it needs to be `queryable` (because ttls are implemented via queries), and so the constructed storage key uses the `memdb` protocol.