### PR TITLE
support unnamed annotation param values

### DIFF
--- a/src/runtime/manifest-ast-nodes.ts
+++ b/src/runtime/manifest-ast-nodes.ts
@@ -420,10 +420,18 @@ export interface AnnotationRef extends BaseNode {
   params: AnnotationRefParam[];
 }
 
-export interface AnnotationRefParam extends BaseNode {
-  kind: 'annotation-ref-param';
+export type AnnotationRefParam = AnnotationRefNamedParam | AnnotationRefSimpleParam;
+export type AnnotationSimpleParamValue = ManifestStorageInlineData | NumberedUnits;
+
+export interface AnnotationRefNamedParam extends BaseNode {
+  kind: 'annotation-named-param';
   name: string;
   value: ManifestStorageInlineData;
+}
+
+export interface AnnotationRefSimpleParam extends BaseNode {
+  kind: 'annotation-simple-param';
+  value: AnnotationSimpleParamValue;
 }
 
 export interface RecipeNode extends BaseNode {

--- a/src/runtime/manifest-parser.pegjs
+++ b/src/runtime/manifest-parser.pegjs
@@ -1033,8 +1033,8 @@ AnnotationRefSimpleParam = value:(ManifestStorageInlineData / NumberedUnits) {
 }
 
 AnnotationRefList
-  = head:AnnotationRef tail:(whiteSpace AnnotationRefList)?
-  { return [head, ...(tail && tail[1] || [])]; }
+  = head:AnnotationRef tail:SpaceAnnotationRefList?
+  { return [head, ...(tail || [])]; }
 
 SpaceAnnotationRefList
   = whiteSpace tags:AnnotationRefList

--- a/src/runtime/manifest-parser.pegjs
+++ b/src/runtime/manifest-parser.pegjs
@@ -1013,12 +1013,23 @@ AnnotationRef = '@' name:lowerIdent params:('('whiteSpace? AnnotationRefParam? (
   });
 }
 
-AnnotationRefParam = name:lowerIdent whiteSpace? ':' whiteSpace? value:ManifestStorageInlineData {
-  return toAstNode<AstNode.AnnotationRefParam>({
-    kind: 'annotation-ref-param',
+AnnotationRefParam
+  = AnnotationRefNamedParam
+  / AnnotationRefSimpleParam
+
+AnnotationRefNamedParam = name:lowerIdent whiteSpace? ':' whiteSpace? value:ManifestStorageInlineData {
+  return toAstNode<AstNode.AnnotationRefNamedParam>({
+    kind: 'annotation-named-param',
     name,
     value
   });
+}
+
+AnnotationRefSimpleParam = value:(ManifestStorageInlineData / NumberedUnits) {
+  return toAstNode<AstNode.AnnotationRefSimpleParam>({
+    kind: 'annotation-simple-param',
+    value
+  })
 }
 
 AnnotationRefList

--- a/src/runtime/manifest-parser.pegjs
+++ b/src/runtime/manifest-parser.pegjs
@@ -1029,7 +1029,7 @@ AnnotationRefSimpleParam = value:(ManifestStorageInlineData / NumberedUnits) {
   return toAstNode<AstNode.AnnotationRefSimpleParam>({
     kind: 'annotation-simple-param',
     value
-  })
+  });
 }
 
 AnnotationRefList

--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -1308,7 +1308,7 @@ ${e.message}
         if (param.kind === 'annotation-named-param') {
           if (params[param.name]) {
             throw new ManifestError(
-                aRefItem.location, `annotation '${annotation.name}' already has param '${param.name}'`);
+                aRefItem.location, `annotation '${annotation.name}' can only have one value for: '${param.name}'`);
           }
           const aParam = annotation.params[param.name];
           if (!aParam) {
@@ -1317,7 +1317,7 @@ ${e.message}
           }
           params[param.name] = param.value;
         } else {
-          if (Object.keys(annotation.params).length != 1) {
+          if (Object.keys(annotation.params).length !== 1) {
             throw new ManifestError(
               aRefItem.location, `annotation '${annotation.name}' has unexpected unnamed param '${param.value}'`);
           }

--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -1305,16 +1305,24 @@ ${e.message}
       }
       const params: Dictionary<string|number|boolean|{}> = {};
       for (const param of aRefItem.params) {
-        if (params[param.name]) {
-          throw new ManifestError(
-              aRefItem.location, `annotation '${annotation.name}' already has param '${param.name}'`);
+        if (param.kind === 'annotation-named-param') {
+          if (params[param.name]) {
+            throw new ManifestError(
+                aRefItem.location, `annotation '${annotation.name}' already has param '${param.name}'`);
+          }
+          const aParam = annotation.params[param.name];
+          if (!aParam) {
+            throw new ManifestError(
+                aRefItem.location, `unexpected annotation param: '${param.name}'`);
+          }
+          params[param.name] = param.value;
+        } else {
+          if (Object.keys(annotation.params).length != 1) {
+            throw new ManifestError(
+              aRefItem.location, `annotation '${annotation.name}' has unexpected unnamed param '${param.value}'`);
+          }
+          params[Object.keys(annotation.params)[0]] = param.value;
         }
-        const aParam = annotation.params[param.name];
-        if (!aParam) {
-          throw new ManifestError(
-              aRefItem.location, `unexpected annotation param: '${param.name}'`);
-        }
-        params[param.name] = param.value;
       }
       annotationRefs.push(new AnnotationRef(annotation, params));
     }

--- a/src/runtime/tests/manifest-test.ts
+++ b/src/runtime/tests/manifest-test.ts
@@ -3855,6 +3855,13 @@ recipe
   it('parses recipe annotation with text param', async () => {
     await assertThrowsAsync(async () => await Manifest.parse(`
 ${oneParamAnnotation}
+@oneParam(foo: 'hello', foo: 'world')
+recipe
+    `), `annotation 'oneParam' can only have one value for: 'foo'`);
+  });
+  it('parses recipe annotation with text param', async () => {
+    await assertThrowsAsync(async () => await Manifest.parse(`
+${oneParamAnnotation}
 @oneParam(foo: 'hello', wrong: 'world')
 recipe
     `), `unexpected annotation param: 'wrong'`);


### PR DESCRIPTION
if an annotation only has a single parameter, it won't require specifying the parameter name to set the value. 
for example: `annotation foo(bar: Text)` could equally be used as either 
`@foo(bar: 'hello world')` or 
`@foo('hello world')`

part of #5291 