### PR TITLE
Simplify AccessPath.Root.HandleConnection.

### DIFF
--- a/java/arcs/core/data/AccessPath.kt
+++ b/java/arcs/core/data/AccessPath.kt
@@ -17,12 +17,15 @@ package arcs.core.data
  * Examples of access paths are `input.app.packageName`, `store.rawText`, store.entites[i], etc.
  */
 data class AccessPath(val root: Root, val selectors: List<Selector> = emptyList()) {
-    /** Constructs an [AccessPath] representing a [Recipe.Particle.HandleConnection]. */
+    /**
+     * Constructs an [AccessPath] starting at a connection in [particle] identified
+     * by [connectionSpec] followed by [selectors].
+     */
     constructor(
         particle: Recipe.Particle,
-        connection: Recipe.Particle.HandleConnection,
+        connectionSpec: HandleConnectionSpec,
         selectors: List<Selector> = emptyList()
-    ) : this(Root.HandleConnection(particle, connection), selectors)
+    ) : this(Root.HandleConnection(particle, connectionSpec), selectors)
 
     /** Constructs an [AccessPath] representing a [ParticleSpec.HandleConnectionSpec]. */
     constructor(
@@ -51,9 +54,9 @@ data class AccessPath(val root: Root, val selectors: List<Selector> = emptyList(
 
         data class HandleConnection(
             val particle: Recipe.Particle,
-            val connection: Recipe.Particle.HandleConnection
+            val connectionSpec: arcs.core.data.HandleConnectionSpec
         ) : Root() {
-            override fun toString() = "hc:${particle.spec.name}.${connection.spec.name}"
+            override fun toString() = "hc:${particle.spec.name}.${connectionSpec.name}"
         }
 
         data class HandleConnectionSpec(

--- a/javatests/arcs/core/data/AccessPathTest.kt
+++ b/javatests/arcs/core/data/AccessPathTest.kt
@@ -27,7 +27,7 @@ class AccessPathTest {
     @Test
     fun prettyPrintAccessPathRoot() {
         assertThat("${AccessPath.Root.Handle(handle)}").isEqualTo("h:thing")
-        assertThat("${AccessPath.Root.HandleConnection(particle, connection)}")
+        assertThat("${AccessPath.Root.HandleConnection(particle, connectionSpec)}")
             .isEqualTo("hc:Reader.data")
         assertThat("${AccessPath.Root.HandleConnectionSpec("Reader", connectionSpec)}")
             .isEqualTo("hcs:Reader.data")
@@ -41,7 +41,7 @@ class AccessPathTest {
     @Test
     fun prettyPrintAccessPathNoSelectors() {
         assertThat("${AccessPath(handle)}").isEqualTo("h:thing")
-        assertThat("${AccessPath(particle, connection)}").isEqualTo("hc:Reader.data")
+        assertThat("${AccessPath(particle, connectionSpec)}").isEqualTo("hc:Reader.data")
     }
 
     @Test
@@ -53,9 +53,9 @@ class AccessPathTest {
         )
         assertThat("${AccessPath(handle, oneSelector)}").isEqualTo("h:thing.bar")
         assertThat("${AccessPath(handle, multipleSelectors)}").isEqualTo("h:thing.foo.bar")
-        assertThat("${AccessPath(particle, connection, oneSelector)}")
+        assertThat("${AccessPath(particle, connectionSpec, oneSelector)}")
             .isEqualTo("hc:Reader.data.bar")
-        assertThat("${AccessPath(particle, connection, multipleSelectors)}")
+        assertThat("${AccessPath(particle, connectionSpec, multipleSelectors)}")
             .isEqualTo("hc:Reader.data.foo.bar")
         assertThat("${AccessPath("Reader", connectionSpec, oneSelector)}")
             .isEqualTo("hcs:Reader.data.bar")


### PR DESCRIPTION
In `AccessPath.Root.HandleConnection`, we now use `HandleConnectionSpec Instead of `Particle.HandleConnection`, which simplifies implementing some of the transformers in dataflow analysis. 

Note that this does not create any limitations as we can always look up the `Recipe.Handle` from the particle's connections.