### PR TITLE
Let StorageService runs at testapp's default process

### DIFF
--- a/javatests/arcs/android/systemhealth/testapp/AndroidManifest.xml
+++ b/javatests/arcs/android/systemhealth/testapp/AndroidManifest.xml
@@ -42,7 +42,7 @@
     <service
       android:name="arcs.sdk.android.storage.service.StorageService"
       android:exported="false"
-      tools:remove="android:process"/>
+      tools:node="replace"/>
 
     <service
       android:name=".TestStorageService"

--- a/javatests/arcs/android/systemhealth/testapp/AndroidManifest.xml
+++ b/javatests/arcs/android/systemhealth/testapp/AndroidManifest.xml
@@ -41,7 +41,8 @@
 
     <service
       android:name="arcs.sdk.android.storage.service.StorageService"
-      android:exported="false"/>
+      android:exported="false"
+      tools:remove="android:process"/>
 
     <service
       android:name=".TestStorageService"


### PR DESCRIPTION
StorageService should have run at app's default/local process together with LocalService, otherwise memory dump and stats will be incorrect.

* Using tools:remove to remove default android:process=":storage"