### PR TITLE
Moves schematests -> schematests/references

### DIFF
--- a/javatests/arcs/schematests/references/Arcs.kt
+++ b/javatests/arcs/schematests/references/Arcs.kt
@@ -1,19 +1,17 @@
 @file:Suppress("EXPERIMENTAL_IS_NOT_ENABLED")
 
-package arcs.schematests
+package arcs.schematests.references
 
 import android.content.Context
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleRegistry
 import arcs.android.sdk.host.AndroidHost
-import arcs.android.storage.database.AndroidSqliteDatabaseManager
 import arcs.core.allocator.Allocator
 import arcs.core.common.toArcId
 import arcs.core.host.EntityHandleManager
 import arcs.core.host.SchedulerProvider
 import arcs.core.host.toRegistration
-import arcs.core.storage.api.DriverAndKeyConfigurator
 import arcs.jvm.host.ExplicitHostRegistry
 import arcs.jvm.host.JvmSchedulerProvider
 import arcs.jvm.util.JvmTime
@@ -71,7 +69,7 @@ class Arcs(
             )
         )
 
-        allocator.startArcForPlan("", WriteRecipePlan)
+        allocator.startArcForPlan(WriteRecipePlan)
     }
 
     suspend fun stop() {

--- a/javatests/arcs/schematests/references/BUILD
+++ b/javatests/arcs/schematests/references/BUILD
@@ -45,7 +45,7 @@ arcs_kt_android_test_suite(
     name = "tests",
     srcs = glob(["*Test.kt"]),
     manifest = "//java/arcs/android/common:AndroidManifest.xml",
-    package = "arcs.schematests",
+    package = "arcs.schematests.references",
     deps = [
         ":particles",
         "//java/arcs/android/storage/database",

--- a/javatests/arcs/schematests/references/Items.kt
+++ b/javatests/arcs/schematests/references/Items.kt
@@ -1,4 +1,4 @@
-package arcs.schematests
+package arcs.schematests.references
 
 data class Level0(
     val name: String

--- a/javatests/arcs/schematests/references/ReadWriteTest.kt
+++ b/javatests/arcs/schematests/references/ReadWriteTest.kt
@@ -1,4 +1,4 @@
-package arcs.schematests
+package arcs.schematests.references
 
 import android.app.Application
 import androidx.test.core.app.ApplicationProvider

--- a/javatests/arcs/schematests/references/Reader.kt
+++ b/javatests/arcs/schematests/references/Reader.kt
@@ -1,8 +1,8 @@
 @file:Suppress("EXPERIMENTAL_FEATURE_WARNING")
 
-package arcs.schematests
+package arcs.schematests.references
 
-import arcs.core.entity.awaitReady
+import arcs.core.entity.awaitReady;
 import arcs.jvm.host.TargetHost
 import kotlinx.coroutines.withContext
 

--- a/javatests/arcs/schematests/references/Writer.kt
+++ b/javatests/arcs/schematests/references/Writer.kt
@@ -1,15 +1,12 @@
 @file:Suppress("EXPERIMENTAL_FEATURE_WARNING")
 
-package arcs.schematests
+package arcs.schematests.references
 
 import arcs.core.entity.awaitReady
 import arcs.jvm.host.TargetHost
 import arcs.sdk.Entity
-import arcs.sdk.ReadWriteCollectionHandle
 import arcs.sdk.ReadWriteSingletonHandle
 import arcs.sdk.Reference
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 
 suspend fun <T : Entity> T.toReference(handle: ReadWriteSingletonHandle<T>): Reference<T> {

--- a/javatests/arcs/schematests/references/schema.arcs
+++ b/javatests/arcs/schematests/references/schema.arcs
@@ -1,5 +1,5 @@
 meta
-  namespace: arcs.schematests
+  namespace: arcs.schematests.references
 
 schema Level0
   name: Text
@@ -16,25 +16,25 @@ schema Level3
   name: Text
   children: [&Level2]
 
-particle Writer0 in 'arcs.schematests.Writer0'
+particle Writer0 in 'arcs.schematests.references.Writer0'
   level0: writes [Level0]
 
-particle Reader0 in 'arcs.schematests.Reader0'
+particle Reader0 in 'arcs.schematests.references.Reader0'
   level0: reads [Level0]
 
-particle Writer1 in 'arcs.schematests.Writer1'
+particle Writer1 in 'arcs.schematests.references.Writer1'
   level0: reads writes Level0
   level1: writes [Level1]
 
-particle Reader1 in 'arcs.schematests.Reader1'
+particle Reader1 in 'arcs.schematests.references.Reader1'
   level1: reads [Level1]
 
-particle Writer2 in 'arcs.schematests.Writer2'
+particle Writer2 in 'arcs.schematests.references.Writer2'
   level0: reads writes Level0
   level1: reads writes Level1
   level2: writes [Level2]
 
-particle Reader2 in 'arcs.schematests.Reader2'
+particle Reader2 in 'arcs.schematests.references.Reader2'
   level2: reads [Level2]
 
 @trigger


### PR DESCRIPTION
I think these schematests for references are a good idea and I would like to do a similar thing for joins and tuples. So here I'm proposing we split them in directories to make them more manageable:

```
arcs/schematests/references
arcs/schematests/joins
...
```

I may end up pulling in some infra from `Arcs.kt` file into a toplevel `schematests` dir, but let's actually wait to see how this will look like when I try it :)