### PR TITLE
Enhance memory stats

### DIFF
--- a/javatests/arcs/android/systemhealth/testapp/BUILD
+++ b/javatests/arcs/android/systemhealth/testapp/BUILD
@@ -37,6 +37,7 @@ arcs_kt_android_library(
         "//java/arcs/core/storage/referencemode",
         "//java/arcs/core/type",
         "//java/arcs/core/util",
+        "//java/arcs/core/util/performance",
         "//java/arcs/jvm/host",
         "//java/arcs/jvm/util",
         "//java/arcs/sdk:sdk-kt",

--- a/javatests/arcs/android/systemhealth/testapp/MemoryStats.kt
+++ b/javatests/arcs/android/systemhealth/testapp/MemoryStats.kt
@@ -12,16 +12,34 @@
 package arcs.android.systemhealth.testapp
 
 import android.os.Debug
+import arcs.core.util.performance.MemoryIdentifier
 
-/**
- * Don't use apis of [arcs.core.util.performance.MemoryStats] to track memory stats as
- * the system health test app/services aim to find out memory leakage of Arcs storage stack
- * as well as ProdEx stack where we care about the usage of private-dirty dalvik heap excluding
- * the proportional pss usage counted for boot.img.
- */
+/** Utility of generating statistics of memory footprint. */
 object MemoryStats {
+    /**
+     * App-specific JVM heap usage.
+     *
+     * Don't use [MemoryIdentifier.JAVA_HEAP] as it counts not only app-specific private-dirty
+     * dalvik heap usage but also dirty pages of boot images in current process. The former can
+     * properly represent memory footprint of Arcs-specific JVM stack whereas the latter reflects
+     * how many codes/heaps in boot images are visited and allocated which is not our concern.
+     */
     val appJvmHeapKbytes: Long
         get() = with(Debug.MemoryInfo().apply { Debug.getMemoryInfo(this) }) {
             dalvikPrivateDirty.toLong()
         }
+
+    /**
+     * App-specific native heap usage.
+     */
+    val appNativeHeapKbytes: Long
+        get() = arcs.core.util.performance.MemoryStats.stat(MemoryIdentifier.NATIVE_HEAP)[0]
+
+    /**
+     * Typically is [appJvmHeapKbytes] + [appNativeHeapKbytes] + pss of boot images.
+     */
+    val allHeapsKbytes: Long
+        get() = arcs.core.util.performance.MemoryStats.stat(
+            MemoryIdentifier.JAVA_HEAP, MemoryIdentifier.NATIVE_HEAP
+        ).sum()
 }

--- a/javatests/arcs/android/systemhealth/testapp/MemoryStats.kt
+++ b/javatests/arcs/android/systemhealth/testapp/MemoryStats.kt
@@ -13,6 +13,7 @@ package arcs.android.systemhealth.testapp
 
 import android.os.Debug
 import arcs.core.util.performance.MemoryIdentifier
+import arcs.core.util.performance.MemoryStats as MemoryStatsUtil
 
 /** Utility of generating statistics of memory footprint. */
 object MemoryStats {
@@ -33,13 +34,13 @@ object MemoryStats {
      * App-specific native heap usage.
      */
     val appNativeHeapKbytes: Long
-        get() = arcs.core.util.performance.MemoryStats.stat(MemoryIdentifier.NATIVE_HEAP)[0]
+        get() = MemoryStatsUtil.stat(MemoryIdentifier.NATIVE_HEAP)[0]
 
     /**
      * Typically is [appJvmHeapKbytes] + [appNativeHeapKbytes] + pss of boot images.
      */
     val allHeapsKbytes: Long
-        get() = arcs.core.util.performance.MemoryStats.stat(
+        get() = MemoryStatsUtil.stat(
             MemoryIdentifier.JAVA_HEAP, MemoryIdentifier.NATIVE_HEAP
         ).sum()
 }

--- a/javatests/arcs/android/systemhealth/testapp/StorageCore.kt
+++ b/javatests/arcs/android/systemhealth/testapp/StorageCore.kt
@@ -831,13 +831,13 @@ class StorageCore(val context: Context, val lifecycle: Lifecycle) {
                     |Private-dirty dalvik heap (after GC): ${
                         formatter.format(appJvmHeapAfterGc - it[0]) } KB
                     |Private-dirty native heap (before GC): ${
-                    formatter.format(appNativeHeapBeforeGc - it[1]) } KB
+                        formatter.format(appNativeHeapBeforeGc - it[1]) } KB
                     |Private-dirty native heap (after GC): ${
-                    formatter.format(appNativeHeapAfterGc - it[1]) } KB
+                        formatter.format(appNativeHeapAfterGc - it[1]) } KB
                     |All(dalvik+native) heaps (before GC): ${
-                    formatter.format(allHeapsBeforeGc - it[2]) } KB
+                        formatter.format(allHeapsBeforeGc - it[2]) } KB
                     |All(dalvik+native) heaps (after GC): ${
-                    formatter.format(allHeapsAfterGc - it[2]) } KB
+                        formatter.format(allHeapsAfterGc - it[2]) } KB
                     |Heap dump: $hprofFilePath
                     ${platformNewline.repeat(1)}
                     """.trimMargin("|")

--- a/javatests/arcs/android/systemhealth/testapp/StorageCore.kt
+++ b/javatests/arcs/android/systemhealth/testapp/StorageCore.kt
@@ -206,7 +206,8 @@ class StorageCore(val context: Context, val lifecycle: Lifecycle) {
                                     MemoryStats.appJvmHeapKbytes,
                                     MemoryStats.appNativeHeapKbytes,
                                     MemoryStats.allHeapsKbytes
-                                ))
+                                )
+                            )
                         )
                         this@StorageCore.execute(settings)
                     } catch (e: Exception) {

--- a/javatests/arcs/android/systemhealth/testapp/StorageCore.kt
+++ b/javatests/arcs/android/systemhealth/testapp/StorageCore.kt
@@ -199,7 +199,14 @@ class StorageCore(val context: Context, val lifecycle: Lifecycle) {
                         Thread.sleep(GcWaitTimeMs)
 
                         taskManagerEvents.queue.add(
-                            TaskEvent(TaskEventId.MEMORY_STATS, 0, MemoryStats.appJvmHeapKbytes)
+                            TaskEvent(
+                                TaskEventId.MEMORY_STATS,
+                                0,
+                                listOf(
+                                    MemoryStats.appJvmHeapKbytes,
+                                    MemoryStats.appNativeHeapKbytes,
+                                    MemoryStats.allHeapsKbytes
+                                ))
                         )
                         this@StorageCore.execute(settings)
                     } catch (e: Exception) {
@@ -786,11 +793,14 @@ class StorageCore(val context: Context, val lifecycle: Lifecycle) {
         }
 
         fun clearAndGenerateMemoryUsageReport(): Stats = also {
-            var memInitial: Long? = null
+            var memInitial: List<Long>? = null
             taskManagerEvents.reader.withLock {
-                memInitial = taskManagerEvents.queue.filter {
+                // [0]: appJvmHeapKbytes
+                // [1]: appNativeHeapKbytes
+                // [2]: allHeapsKbytes
+                memInitial = (taskManagerEvents.queue.filter {
                     it.eventId == TaskEventId.MEMORY_STATS
-                }.first().instance as? Long
+                }.first().instance as? List<*>)?.filterIsInstance<Long>()?.takeIf { it.size == 3 }
             }
 
             tasksEvents.forEach { _, taskEvents ->
@@ -801,19 +811,33 @@ class StorageCore(val context: Context, val lifecycle: Lifecycle) {
             memInitial?.let {
                 val formatter = DecimalFormat("+#;-#")
                 val hprofFilePath = context.applicationInfo.dataDir + "/" + hprofFile
-                val memBeforeGc = MemoryStats.appJvmHeapKbytes
+                val appJvmHeapBeforeGc = MemoryStats.appJvmHeapKbytes
+                val appNativeHeapBeforeGc = MemoryStats.appNativeHeapKbytes
+                val allHeapsBeforeGc = MemoryStats.allHeapsKbytes
 
                 // Whether gc or not is not guaranteed, synchronous or asynchronous gc is also
                 // JVM implementation-dependent.
                 Runtime.getRuntime().gc()
                 Thread.sleep(GcWaitTimeMs)
 
-                val memAfterGc = MemoryStats.appJvmHeapKbytes
+                val appJvmHeapAfterGc = MemoryStats.appJvmHeapKbytes
+                val appNativeHeapAfterGc = MemoryStats.appNativeHeapKbytes
+                val allHeapsAfterGc = MemoryStats.allHeapsKbytes
                 bulletin +=
                     """
                     |[Memory Stats]
-                    |Private-dirty dalvik heap (before GC): ${formatter.format(memBeforeGc - it)} KB
-                    |Private-dirty dalvik heap (after GC): ${formatter.format(memAfterGc - it)} KB
+                    |Private-dirty dalvik heap (before GC): ${
+                        formatter.format(appJvmHeapBeforeGc - it[0]) } KB
+                    |Private-dirty dalvik heap (after GC): ${
+                        formatter.format(appJvmHeapAfterGc - it[0]) } KB
+                    |Private-dirty native heap (before GC): ${
+                    formatter.format(appNativeHeapBeforeGc - it[1]) } KB
+                    |Private-dirty native heap (after GC): ${
+                    formatter.format(appNativeHeapAfterGc - it[1]) } KB
+                    |All(dalvik+native) heaps (before GC): ${
+                    formatter.format(allHeapsBeforeGc - it[2]) } KB
+                    |All(dalvik+native) heaps (after GC): ${
+                    formatter.format(allHeapsAfterGc - it[2]) } KB
                     |Heap dump: $hprofFilePath
                     ${platformNewline.repeat(1)}
                     """.trimMargin("|")

--- a/javatests/arcs/android/systemhealth/testapp/TestApplication.kt
+++ b/javatests/arcs/android/systemhealth/testapp/TestApplication.kt
@@ -15,6 +15,7 @@ import android.app.Application
 import androidx.work.Configuration
 import arcs.android.storage.database.AndroidSqliteDatabaseManager
 import arcs.android.util.ProtoPrefetcher
+import arcs.android.util.connectMemoryStatsPipe
 import arcs.android.util.initLogForAndroid
 import arcs.core.entity.SchemaRegistry
 import arcs.core.storage.api.DriverAndKeyConfigurator
@@ -38,5 +39,6 @@ class TestApplication : Application(), Configuration.Provider {
         DriverAndKeyConfigurator.configure(AndroidSqliteDatabaseManager(this))
 
         initLogForAndroid()
+        connectMemoryStatsPipe()
     }
 }


### PR DESCRIPTION
Add more stats w.r.t memory footprint:
* native heaps
* dalvik + native heaps

Native heap stats can tell the upper bound of db caches, etc.
dalvik + native can represent total run-time memory usage excluding most of mmap files, bss, etc.