### PR TITLE
Implement new Particle/Handle lifecycle APIs

### DIFF
--- a/java/arcs/core/entity/Handle.kt
+++ b/java/arcs/core/entity/Handle.kt
@@ -12,6 +12,7 @@
 package arcs.core.entity
 
 import arcs.core.data.HandleMode
+import arcs.core.storage.StorageProxy.StorageEvent
 import kotlin.coroutines.resume
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Job
@@ -30,11 +31,16 @@ interface Handle {
      */
     val dispatcher: CoroutineDispatcher
 
+    // TODO(b/157188866): move this to ReadableHandle (write-only handles should not receive this)
+    // TODO: pass the Handle to the action callbacks: handles.foo.onReady { it.fetch() }
     /** Assign a callback when the handle is synced for the first time. */
     fun onReady(action: () -> Unit)
 
     /** Release resources needed by this, unregister all callbacks. */
     fun close()
+
+    /** Internal method used to connect [StorageProxy] events to the [ParticleContext]. */
+    fun registerForStorageEvents(notify: (StorageEvent) -> Unit)
 }
 
 /** Suspends until the [Handle] has synced with the store. */

--- a/java/arcs/core/host/ArcHostContext.kt
+++ b/java/arcs/core/host/ArcHostContext.kt
@@ -15,15 +15,20 @@ import arcs.core.common.toArcId
 import arcs.core.data.Plan
 import arcs.core.entity.Handle
 import arcs.core.host.api.Particle
+import arcs.core.storage.StorageProxy.StorageEvent
 import arcs.core.util.TaggedLog
 
 /**
  * Holds per-[Particle] context state needed by [ArcHost] to implement [Particle] lifecycle.
+ * TODO: this now has active logic and probably shouldn't be a data class
  *
  * @property particle currently instantiated [Particle] class
- * @property handles handles a map of each handle created for this [Particle]
+ * @property planParticle the [Plan.Particle] used to instantiate [particle]
+ * @property handles a map of each handle created for [particle]
  * @property particleState the current state the particle lifecycle is in
  * @property consecutiveFailureCount how many times this particle failed to start in a row
+ * @property awaitingReady set of handles that expect to receive a `ready` StorageEvent
+ * @property desyncedHandles set of handles that are currently desynchronized from storage
  */
 data class ParticleContext(
     val particle: Particle,
@@ -32,7 +37,61 @@ data class ParticleContext(
     var particleState: ParticleState = ParticleState.Instantiated,
     /** Used to detect infinite-crash loop particles */
     var consecutiveFailureCount: Int = 0
-)
+) {
+    private val awaitingReady: MutableSet<Handle> = mutableSetOf()
+    private val desyncedHandles: MutableSet<Handle> = mutableSetOf()
+
+    /**
+     * Track which handles are expecting [StorageEvent.READY] notifications,
+     * so we can invoke [Particle.onReady] once they have all fired.
+     */
+    fun expectReady(handle: Handle) {
+        awaitingReady.add(handle)
+    }
+
+    /**
+     * Particles with only write-only handles won't receive any storage events and thus
+     * need to have their `onReady` method invoked as a special case.
+     */
+    fun notifyWriteOnlyParticles() {
+        if (awaitingReady.isEmpty()) {
+            particleState = ParticleState.Started
+            particle.onReady()
+        }
+    }
+
+    /**
+     * Called by [StorageProxy] when it receives storage events. This is responsible for
+     * driving the particle lifecycle API and managing the running particle state.
+     *
+     * This will be executed in the context of the StorageProxy's scheduler.
+     */
+    fun notify(event: StorageEvent, handle: Handle) {
+        when (event) {
+            StorageEvent.READY -> {
+                if (awaitingReady.remove(handle) && awaitingReady.isEmpty()) {
+                    particleState = ParticleState.Started
+                    particle.onReady()
+                }
+            }
+            StorageEvent.UPDATE -> particle.onUpdate()
+            StorageEvent.DESYNC -> {
+                if (desyncedHandles.isEmpty()) {
+                    particleState = ParticleState.Desynced
+                    particle.onDesync()
+                }
+                desyncedHandles.add(handle)
+            }
+            StorageEvent.RESYNC -> {
+                desyncedHandles.remove(handle)
+                if (desyncedHandles.isEmpty()) {
+                    particleState = ParticleState.Started
+                    particle.onResync()
+                }
+            }
+        }
+    }
+}
 
 /**
  * Runtime context state needed by the [ArcHost] on a per [ArcId] basis. For each [Arc],

--- a/java/arcs/core/host/api/Particle.kt
+++ b/java/arcs/core/host/api/Particle.kt
@@ -24,10 +24,51 @@ interface Particle {
     /**
      * Called the first time this [Particle] is instantiated in an [Arc].
      *
-     * A typical example of the use of [onFirstStart] is to initialize handles to default values
-     * needed before particle startup.
+     * This should be used to initialize writeable handles to their starting state prior to the
+     * arc starting. Readable handles cannot be read in this method.
+     * TODO: remove suspend when internal code no longer uses it
      */
     suspend fun onFirstStart() = Unit
+
+    /**
+     * Called whenever this [Particle] is instantiated, both initially and when an arc is
+     * re-started.
+     *
+     * This should be used to attach any handle-specific actions via [Handle.onReady],
+     * [Handle.onUpdate], etc. Readable handles cannot be read in this method.
+     */
+    fun onStart() = Unit
+
+    /**
+     * Called when all readable handles have been synchronized with their storage, or just after
+     * [onStart] for write-only particles.
+     *
+     * Particles should initialize their internal, non-handle state and will generally initiate
+     * their main processing logic at this point.
+     */
+    fun onReady() = Unit
+
+    /**
+     * Called when any readable handle is updated.
+     *
+     * This provides a central event for processing all handle data, whenever a change is observed.
+     */
+    fun onUpdate() = Unit
+
+    /**
+     * Called once when any readable handle is desynchronized from its storage.
+     *
+     * This will not be called again until after a resync event.
+     */
+    fun onDesync() = Unit
+
+    /**
+     * Called once when all desynchronized handles have recovered.
+     *
+     * By default this will automatically invoke onUpdate; particles may override this should they
+     * want resync-specific behaviour. When overriding, do not call super.onResync.
+     */
+    fun onResync() = Unit
 
     /**
      * React to handle updates.
@@ -36,6 +77,7 @@ interface Particle {
      *
      * @param handle Singleton or Collection handle
      */
+    @Deprecated("Use Handle.onUpdate")
     suspend fun onHandleUpdate(handle: Handle) = Unit
 
     /**
@@ -47,6 +89,7 @@ interface Particle {
      * @param handle Singleton or Collection handle
      * @param allSynced flag indicating if all handles are synchronized
      */
+    @Deprecated("Use Handle.onReady and/or Handle.onResync")
     suspend fun onHandleSync(handle: Handle, allSynced: Boolean) = Unit
 
     /**

--- a/java/arcs/core/storage/StorageProxy.kt
+++ b/java/arcs/core/storage/StorageProxy.kt
@@ -21,7 +21,6 @@ import arcs.core.util.TaggedLog
 import kotlinx.atomicfu.atomic
 import kotlinx.atomicfu.getAndUpdate
 import kotlinx.atomicfu.update
-import kotlinx.atomicfu.updateAndGet
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Deferred
@@ -60,7 +59,7 @@ class StorageProxy<Data : CrdtData, Op : CrdtOperationAtTime, T>(
 
     private val log = TaggedLog { "StorageProxy" }
     private val handleCallbacks = atomic(HandleCallbacks<T>())
-    private val stateHolder = atomic(StateHolder<T>(ProxyState.INIT))
+    private val stateHolder = atomic(StateHolder<T>(ProxyState.NO_SYNC))
     private val store: StorageCommunicationEndpoint<Data, Op, T> =
         storeEndpointProvider.getStorageEndpoint(ProxyCallback(::onMessage))
 
@@ -68,79 +67,103 @@ class StorageProxy<Data : CrdtData, Op : CrdtOperationAtTime, T>(
     fun getStateForTesting(): ProxyState = stateHolder.value.state
 
     /**
-     * Add a [Handle] `onReady` action, associated with a [Handle] name.
-     *
-     * If the [StorageProxy] is synchronized when the action is added, it will be called
-     * on the next iteration of the [Scheduler].
-     *
-     * If the [StorageProxy] is in its initial state, the first call to any of the action methods
-     * will trigger a request for synchronization.
+     * If the [StorageProxy] is associated with any readable handles, it will need to operate
+     * in synchronized mode. This is done via a two-step process:
+     *   1) When constructed, all readable handles call this method to move the proxy from its
+     *      initial state of [NO_SYNC] to [READY_TO_SYNC].
+     *   2) [EntityHandleManager] then triggers the actual sync request after the arc has been
+     *      set up and all particles have received their onStart events.
      */
-    fun addOnReady(id: CallbackIdentifier, action: () -> Unit) {
-        val currentState = addAction { handleCallbacks.update { it.addOnReady(id, action) } }
-        if (currentState == ProxyState.SYNC) {
-            scheduler.schedule(HandleCallbackTask(id, action))
-        }
-    }
-
-    /**
-     * Add a [Handle] `onUpdate` action, associated with a [Handle] name.
-     *
-     * If the [StorageProxy] is in its initial state, the first call to any of the action methods
-     * will trigger a request for synchronization.
-     */
-    fun addOnUpdate(id: CallbackIdentifier, action: (value: T) -> Unit) {
-        addAction { handleCallbacks.update { it.addOnUpdate(id, action) } }
-    }
-
-    /**
-     * Add a [Handle] `onDesync` action, associated with a [Handle] name.
-     *
-     * If the [StorageProxy] is desynchronized when the action is added, it will be called
-     * on the next iteration of the [Scheduler].
-     *
-     * If the [StorageProxy] is in its initial state, the first call to any of the action methods
-     * will trigger a request for synchronization.
-     */
-    fun addOnDesync(id: CallbackIdentifier, action: () -> Unit) {
-        val currentState = addAction { handleCallbacks.update { it.addOnDesync(id, action) } }
-        if (currentState == ProxyState.DESYNC) {
-            scheduler.schedule(HandleCallbackTask(id, action))
-        }
-    }
-
-    /**
-     * Add a [Handle] `onResync` action, associated with a [Handle] name.
-     *
-     * If the [StorageProxy] is in its initial state, the first call to any of the action methods
-     * will trigger a request for synchronization.
-     */
-    fun addOnResync(id: CallbackIdentifier, action: () -> Unit) {
-        addAction { handleCallbacks.update { it.addOnResync(id, action) } }
-    }
-
-    /**
-     * Run the `add` function to add a storage event action method.
-     *
-     * If the [StorageProxy] is in the INIT state, send a sync request and move to AWAITING_SYNC.
-     */
-    private fun addAction(add: () -> Unit): ProxyState {
+    fun prepareForSync() {
         checkNotClosed()
-        add()
+        stateHolder.update {
+            if (it.state == ProxyState.NO_SYNC) {
+                it.setState(ProxyState.READY_TO_SYNC)
+            } else {
+                it
+            }
+        }
+    }
 
+    /**
+     * If the [StorageProxy] has previously been set up for synchronized mode, send a sync request
+     * to the backing store and move to [AWAITING_SYNC].
+     */
+    fun maybeInitiateSync() {
+        checkNotClosed()
         var needsSync = false
-        val currentState = stateHolder.updateAndGet {
-            if (it.state == ProxyState.INIT) {
+        stateHolder.update {
+            // TODO(b/157188866): remove reliance on ready signal for write-only handles in tests
+            // If there are no readable handles observing this proxy, it will be in the NO_SYNC
+            // state and will never deliver any onReady notifications, which breaks tests that
+            // call awaitReady on write-only handles.
+            if (it.state == ProxyState.READY_TO_SYNC || it.state == ProxyState.NO_SYNC) {
                 needsSync = true
                 it.setState(ProxyState.AWAITING_SYNC)
             } else {
                 needsSync = false
                 it
             }
-        }.state
-
+        }
+        // TODO: add timeout for stores that fail to sync
         if (needsSync) requestSynchronization()
-        return currentState
+    }
+
+    /**
+     * [AbstractArcHost] calls this (via [Handle]) to thread storage events back
+     * to the [ParticleContext], which manages the [Particle] lifecycle API.
+     */
+    fun registerForStorageEvents(id: CallbackIdentifier, notify: (StorageEvent) -> Unit) {
+        checkNotClosed()
+        handleCallbacks.update { it.addNotify(id, notify) }
+    }
+
+    /**
+     * Add a [Handle] `onReady` action associated with a [Handle] name.
+     *
+     * If the [StorageProxy] is synchronized when the action is added, it will be called
+     * on the next iteration of the [Scheduler].
+     */
+    fun addOnReady(id: CallbackIdentifier, action: () -> Unit) {
+        checkNotClosed()
+        checkWillSync()
+        handleCallbacks.update { it.addOnReady(id, action) }
+        if (stateHolder.value.state == ProxyState.SYNC) {
+            scheduler.schedule(HandleCallbackTask(id, action))
+        }
+    }
+
+    /**
+     * Add a [Handle] `onUpdate` action associated with a [Handle] name.
+     */
+    fun addOnUpdate(id: CallbackIdentifier, action: (value: T) -> Unit) {
+        checkNotClosed()
+        checkWillSync()
+        handleCallbacks.update { it.addOnUpdate(id, action) }
+    }
+
+    /**
+     * Add a [Handle] `onDesync` action associated with a [Handle] name.
+     *
+     * If the [StorageProxy] is desynchronized when the action is added, it will be called
+     * on the next iteration of the [Scheduler].
+     */
+    fun addOnDesync(id: CallbackIdentifier, action: () -> Unit) {
+        checkNotClosed()
+        checkWillSync()
+        handleCallbacks.update { it.addOnDesync(id, action) }
+        if (stateHolder.value.state == ProxyState.DESYNC) {
+            scheduler.schedule(HandleCallbackTask(id, action))
+        }
+    }
+
+    /**
+     * Add a [Handle] `onResync` action associated with a [Handle] name.
+     */
+    fun addOnResync(id: CallbackIdentifier, action: () -> Unit) {
+        checkNotClosed()
+        checkWillSync()
+        handleCallbacks.update { it.addOnResync(id, action) }
     }
 
     /**
@@ -216,8 +239,10 @@ class StorageProxy<Data : CrdtData, Op : CrdtOperationAtTime, T>(
         checkNotClosed()
         log.debug { "Getting particle view (lifecycle)" }
 
+        // TODO: handle desync state?
         check(stateHolder.value.state == ProxyState.SYNC) {
-            "Cannot get particle view directly while the storage proxy is unsynced"
+            "Cannot get particle view directly while the storage proxy is unsynced; " +
+            "current state is ${stateHolder.value.state}"
         }
 
         return crdt.consumerView
@@ -225,6 +250,10 @@ class StorageProxy<Data : CrdtData, Op : CrdtOperationAtTime, T>(
 
     fun getParticleViewAsync(): Deferred<T> {
         checkNotClosed()
+        check(stateHolder.value.state != ProxyState.NO_SYNC) {
+            "getParticleView not valid on non-readable StorageProxy"
+        }
+
         log.debug { "Getting particle view" }
         val future = CompletableDeferred<T>()
 
@@ -233,17 +262,17 @@ class StorageProxy<Data : CrdtData, Op : CrdtOperationAtTime, T>(
                 // Already synced, exit early to avoid adding a waiting sync.
                 ProxyState.SYNC -> return@getAndUpdate it
                 // Time to sync.
-                ProxyState.INIT -> it.setState(ProxyState.AWAITING_SYNC)
+                ProxyState.READY_TO_SYNC -> it.setState(ProxyState.AWAITING_SYNC)
                 // Either already awaiting first sync, or a re-sync at this point.
                 else -> it
             }.addWaitingSync(future)
-        }
+        }.state
 
         // If this was our first state transition - it means we need to request sync.
-        if (priorState.state == ProxyState.INIT) requestSynchronization()
+        if (priorState == ProxyState.READY_TO_SYNC) requestSynchronization()
 
         // If this was called while already synced, resolve the future with the current value.
-        if (priorState.state == ProxyState.SYNC) {
+        if (priorState == ProxyState.SYNC) {
             scheduler.scope.launch {
                 val result = crdt.consumerView
                 log.debug { "Already synchronized, returning $result" }
@@ -268,7 +297,7 @@ class StorageProxy<Data : CrdtData, Op : CrdtOperationAtTime, T>(
             // Storage wants our latest state.
             launch {
                 val data = withContext(this@StorageProxy.dispatcher) { crdt.data }
-                store.onProxyMessage(ProxyMessage.ModelUpdate<Data, Op, T>(data, null))
+                store.onProxyMessage(ProxyMessage.ModelUpdate(data, null))
             }
             return@coroutineScope
         }
@@ -291,23 +320,25 @@ class StorageProxy<Data : CrdtData, Op : CrdtOperationAtTime, T>(
 
         val value = crdt.consumerView
         val toResolve = mutableSetOf<CompletableDeferred<T>>()
-        val oldState = stateHolder.getAndUpdate {
+        val priorState = stateHolder.getAndUpdate {
             toResolve.addAll(it.waitingSyncs)
 
             it.clearWaitingSyncs()
                 .setState(ProxyState.SYNC)
-        }
+        }.state
 
         log.debug { "Completing ${toResolve.size} waiting syncs" }
         toResolve.forEach { it.complete(value) }
 
-        when (oldState.state) {
-            ProxyState.INIT,
+        when (priorState) {
             ProxyState.AWAITING_SYNC -> notifyReady()
             ProxyState.SYNC -> notifyUpdate(value)
             ProxyState.DESYNC -> notifyResync()
-            ProxyState.CLOSED ->
-                throw IllegalStateException("processModelUpdate on closed StorageProxy")
+            ProxyState.NO_SYNC,
+            ProxyState.READY_TO_SYNC,
+            ProxyState.CLOSED -> throw IllegalStateException(
+                "received ModelUpdate on StorageProxy in state $priorState"
+            )
         }
     }
 
@@ -346,15 +377,25 @@ class StorageProxy<Data : CrdtData, Op : CrdtOperationAtTime, T>(
     private fun notifyReady() {
         log.debug { "notifying ready" }
         scheduleCallbackTasks(handleCallbacks.value.onReady) { it() }
+        scheduleCallbackTasks(handleCallbacks.value.notify) { it(StorageEvent.READY) }
     }
+
     private fun notifyUpdate(data: T) {
         log.debug { "notifying update" }
         scheduleCallbackTasks(handleCallbacks.value.onUpdate) { it(data) }
+        scheduleCallbackTasks(handleCallbacks.value.notify) { it(StorageEvent.UPDATE) }
     }
-    private fun notifyDesync() = scheduleCallbackTasks(handleCallbacks.value.onDesync) { it() }
+
+    private fun notifyDesync() {
+        log.debug { "notifying desync" }
+        scheduleCallbackTasks(handleCallbacks.value.onDesync) { it() }
+        scheduleCallbackTasks(handleCallbacks.value.notify) { it(StorageEvent.DESYNC) }
+    }
+
     private fun notifyResync() {
         log.debug { "notifying resync" }
         scheduleCallbackTasks(handleCallbacks.value.onResync) { it() }
+        scheduleCallbackTasks(handleCallbacks.value.notify) { it(StorageEvent.RESYNC) }
     }
 
     /** Schedule [HandleCallbackTask]s for all given [callbacks] with the [Scheduler]. */
@@ -378,6 +419,11 @@ class StorageProxy<Data : CrdtData, Op : CrdtOperationAtTime, T>(
         "Unexpected operation on closed StorageProxy"
     }
 
+    private fun checkWillSync() = check(stateHolder.value.state != ProxyState.NO_SYNC) {
+        "Action handlers are not valid on a StorageProxy that has not been set up to sync " +
+        "(i.e. there are no readable handles observing this proxy)"
+    }
+
     /**
      * Two-dimensional identifier for handle callbacks. Typically this will be the handle's name,
      * as well as its particle's ID.
@@ -399,7 +445,8 @@ class StorageProxy<Data : CrdtData, Op : CrdtOperationAtTime, T>(
         val onReady: Map<CallbackIdentifier, List<() -> Unit>> = emptyMap(),
         val onUpdate: Map<CallbackIdentifier, List<(T) -> Unit>> = emptyMap(),
         val onDesync: Map<CallbackIdentifier, List<() -> Unit>> = emptyMap(),
-        val onResync: Map<CallbackIdentifier, List<() -> Unit>> = emptyMap()
+        val onResync: Map<CallbackIdentifier, List<() -> Unit>> = emptyMap(),
+        val notify: Map<CallbackIdentifier, List<(StorageEvent) -> Unit>> = emptyMap()
     ) {
         fun addOnReady(id: CallbackIdentifier, block: () -> Unit) =
             copy(onReady = onReady + (id to ((onReady[id] ?: emptyList()) + block)))
@@ -413,12 +460,16 @@ class StorageProxy<Data : CrdtData, Op : CrdtOperationAtTime, T>(
         fun addOnResync(id: CallbackIdentifier, block: () -> Unit) =
             copy(onResync = onResync + (id to ((onResync[id] ?: emptyList()) + block)))
 
+        fun addNotify(id: CallbackIdentifier, block: (StorageEvent) -> Unit) =
+            copy(notify = notify + (id to ((notify[id] ?: emptyList()) + block)))
+
         fun removeCallbacks(id: CallbackIdentifier) =
             copy(
                 onReady = onReady - id,
                 onUpdate = onUpdate - id,
                 onDesync = onDesync - id,
-                onResync = onResync - id
+                onResync = onResync - id,
+                notify = notify - id
             )
     }
 
@@ -434,17 +485,34 @@ class StorageProxy<Data : CrdtData, Op : CrdtOperationAtTime, T>(
         fun clearWaitingSyncs() = copy(waitingSyncs = emptyList())
     }
 
+    /**
+     * Event types used for notifying the [ParticleContext] to drive the [Particle]'s
+     * storage events API.
+     */
+    enum class StorageEvent {
+        READY,
+        UPDATE,
+        DESYNC,
+        RESYNC
+    }
+
     // Visible for testing
     enum class ProxyState {
         /**
-         * The [StorageProxy] has not received any actions to invoke on storage events. A call to
-         * `onReady`, `onUpdate`, `onDesync` or `onResync` will change the state to [AWAITING_SYNC].
+         * [prepareForSync] has not been called. Proxies that are only associated with
+         * write-only handles will remain in this state.
          */
-        INIT,
+        NO_SYNC,
 
         /**
-         * The [StorageProxy] has received at least one action for storage events. A sync request
-         * has been sent to storage, but the response has not been received yet.
+         * [prepareForSync] has been called to indicate that this proxy will be moving to
+         * synchronized mode when [maybeInitiateSync] is called.
+         */
+        READY_TO_SYNC,
+
+        /**
+         * [maybeInitiateSync] has been called. A sync request has been sent to storage,
+         * but the response has not been received yet.
          */
         AWAITING_SYNC,
 

--- a/java/arcs/core/storage/Store.kt
+++ b/java/arcs/core/storage/Store.kt
@@ -81,6 +81,10 @@ class Store<Data : CrdtData, Op : CrdtOperation, ConsumerData>(
         return activeStore
     }
 
+    suspend fun waitForActiveIdle() {
+        activeStore?.idle()
+    }
+
     @Suppress("UNCHECKED_CAST")
     companion object {
         /**

--- a/java/arcs/core/storage/StoreManager.kt
+++ b/java/arcs/core/storage/StoreManager.kt
@@ -32,4 +32,10 @@ class StoreManager {
             Store(storeOptions)
         } as Store<Data, Op, T>
     }
+
+    suspend fun waitForIdle() {
+        storesMutex.withLock {
+            stores.values.forEach { it.waitForActiveIdle() }
+        }
+    }
 }

--- a/java/arcs/sdk/jvm/BaseParticle.kt
+++ b/java/arcs/sdk/jvm/BaseParticle.kt
@@ -12,4 +12,10 @@
 package arcs.sdk
 
 /** Implementation of [Particle] for the JVM. */
-abstract class BaseParticle : Particle
+abstract class BaseParticle : Particle {
+    /**
+     * Default behaviour is to automatically invoke onUpdate; override this if you want
+     * resync-specific behaviour. When overriding, do not call super.onResync.
+     */
+    override fun onResync() = onUpdate()
+}

--- a/javatests/arcs/android/e2e/testapp/ReadAnimalHostService.kt
+++ b/javatests/arcs/android/e2e/testapp/ReadAnimalHostService.kt
@@ -25,8 +25,6 @@ import arcs.sdk.android.storage.ServiceStoreFactory
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 /**
  * Service wrapping an ArcHost which hosts a particle writing data to a handle.
@@ -55,8 +53,7 @@ class ReadAnimalHostService : ArcHostService() {
     }
 
     inner class ReadAnimal: AbstractReadAnimal() {
-        override suspend fun onFirstStart() {
-            super.onFirstStart()
+        override fun onStart() {
             handles.animal.onUpdate {
                 val name = handles.animal.fetch()?.name ?: ""
 

--- a/javatests/arcs/android/host/BUILD
+++ b/javatests/arcs/android/host/BUILD
@@ -41,7 +41,6 @@ arcs_kt_android_test_suite(
         "//java/arcs/sdk/android/storage/service",
         "//java/arcs/sdk/android/storage/service/testutil",
         "//javatests/arcs/core/allocator:allocator-test-util",
-        "//javatests/arcs/core/host",
         "//javatests/arcs/core/host:particle",
         "//javatests/arcs/core/host:plans",
         "//javatests/arcs/core/host:testhost",

--- a/javatests/arcs/core/entity/ReferenceTest.kt
+++ b/javatests/arcs/core/entity/ReferenceTest.kt
@@ -64,7 +64,9 @@ class ReferenceTest {
     }
 
     @After
-    fun tearDown() {
+    fun tearDown() = runBlocking {
+        scheduler.waitForIdle()
+        entityHandleManager.close()
         SchemaRegistry.clearForTest()
         DriverFactory.clearRegistrations()
     }
@@ -76,6 +78,7 @@ class ReferenceTest {
             num = 6.0
         }
         handle.store(entity)
+        scheduler.waitForIdle()
 
         val reference = handle.createReference(entity)
         val entityOut = reference.dereference()

--- a/javatests/arcs/core/host/ArcHostContextTest.kt
+++ b/javatests/arcs/core/host/ArcHostContextTest.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+package arcs.core.host
+
+import arcs.core.data.Plan
+import arcs.core.entity.Handle
+import arcs.core.host.api.Particle
+import arcs.core.storage.StorageProxy.StorageEvent
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.times
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.mockito.Mock
+import org.mockito.MockitoAnnotations
+
+@RunWith(JUnit4::class)
+@OptIn(ExperimentalCoroutinesApi::class)
+open class ArcHostContextTest {
+
+    @Mock private lateinit var particle: Particle
+    private var planParticle = Plan.Particle("name", "location", mapOf())
+
+    @Before
+    fun setup() {
+        MockitoAnnotations.initMocks(this)
+    }
+
+    @Test
+    fun particleContext_writeOnlyParticle() = runBlocking {
+        val context = ParticleContext(particle, planParticle)
+        context.notifyWriteOnlyParticles()
+        verify(particle).onReady()
+    }
+
+    @Test
+    fun particleContext_singleReadHandle() = runBlocking {
+        val context = ParticleContext(particle, planParticle)
+        val handle = mock<Handle>().also { context.expectReady(it) }
+
+        context.notifyWriteOnlyParticles()
+        verifyNoMoreInteractions(particle)
+
+        context.notify(StorageEvent.READY, handle)
+        verify(particle).onReady()
+
+        context.notify(StorageEvent.UPDATE, handle)
+        verify(particle).onUpdate()
+
+        context.notify(StorageEvent.DESYNC, handle)
+        verify(particle).onDesync()
+
+        context.notify(StorageEvent.RESYNC, handle)
+        verify(particle).onResync()
+    }
+
+    @Test
+    fun particleContext_multipleReadHandles() = runBlocking {
+        val context = ParticleContext(particle, planParticle)
+        val handle1 = mock<Handle>().also { context.expectReady(it) }
+        val handle2 = mock<Handle>().also { context.expectReady(it) }
+        val handle3 = mock<Handle>().also { context.expectReady(it) }
+
+        context.notifyWriteOnlyParticles()
+        verifyNoMoreInteractions(particle)
+
+        // All handle.onReady calls are required for particle.onReady
+        context.notify(StorageEvent.READY, handle1)
+        context.notify(StorageEvent.READY, handle2)
+        context.notify(StorageEvent.READY, handle3)
+        verify(particle).onReady()
+
+        // Every handle.onUpdate triggers particle.onUpdate
+        context.notify(StorageEvent.UPDATE, handle1)
+        context.notify(StorageEvent.UPDATE, handle2)
+        context.notify(StorageEvent.UPDATE, handle3)
+        verify(particle, times(3)).onUpdate()
+
+        // Only the first handle.onDesync triggers particle.onDesync
+        // All handle.onResyncs are required for particle.onResync
+        context.notify(StorageEvent.DESYNC, handle1)
+        verify(particle).onDesync()
+
+        context.notify(StorageEvent.DESYNC, handle2)
+        context.notify(StorageEvent.RESYNC, handle1)
+        context.notify(StorageEvent.DESYNC, handle3)
+        context.notify(StorageEvent.RESYNC, handle2)
+        verifyNoMoreInteractions(particle)
+
+        context.notify(StorageEvent.RESYNC, handle3)
+        verify(particle).onResync()
+    }
+}

--- a/javatests/arcs/core/host/BUILD
+++ b/javatests/arcs/core/host/BUILD
@@ -14,7 +14,6 @@ package(default_visibility = ["//visibility:public"])
 arcs_kt_jvm_test_suite(
     name = "host",
     srcs = glob(["*Test.kt"]),
-    constraints = ["android"],
     # TODO(b/157513871): Deflake this test suite.
     flaky = True,
     package = "arcs.core.host",
@@ -22,12 +21,14 @@ arcs_kt_jvm_test_suite(
         ":particle",  # buildcleaner: keep
         ":plans",
         ":schemas",
+        ":testhost",
         "//java/arcs/core/allocator",  # buildcleaner: keep
         "//java/arcs/core/common",
         "//java/arcs/core/data",
         "//java/arcs/core/entity",
         "//java/arcs/core/host",
         "//java/arcs/core/host/api",
+        "//java/arcs/core/storage:storage-kt",
         "//java/arcs/core/storage/api",
         "//java/arcs/core/storage/driver",
         "//java/arcs/core/storage/keys",
@@ -39,16 +40,19 @@ arcs_kt_jvm_test_suite(
         "//java/arcs/jvm/util/testutil",
         "//java/arcs/sdk",
         "//javatests/arcs/core/entity:lib",
-        "//third_party/java/junit:junit-android",
-        "//third_party/java/truth:truth-android",
+        "//third_party/java/junit",
+        "//third_party/java/mockito",
+        "//third_party/java/truth",
         "//third_party/kotlin/kotlinx_coroutines",
         "//third_party/kotlin/kotlinx_coroutines:kotlinx_coroutines_test",
+        "//third_party/kotlin/mockito_kotlin",
     ],
 )
 
 arcs_kt_schema(
     name = "schemas",
     srcs = [
+        "lifecycle.arcs",
         "person.arcs",
         "reflective.arcs",
         "test.arcs",
@@ -58,6 +62,7 @@ arcs_kt_schema(
 arcs_kt_plan(
     name = "plans",
     srcs = [
+        "lifecycle.arcs",
         "person.arcs",
         "reflective.arcs",
     ],
@@ -91,11 +96,15 @@ arcs_kt_jvm_library(
     ],
     constraints = ["android"],
     deps = [
+        "//java/arcs/core/common",
         "//java/arcs/core/data",
+        "//java/arcs/core/entity",
         "//java/arcs/core/host",
+        "//java/arcs/core/host/api",
         "//java/arcs/core/util",
         "//java/arcs/jvm/host",
         "//java/arcs/jvm/util/testutil",
+        "//java/arcs/sdk:sdk-kt",
         "//third_party/kotlin/kotlinx_coroutines",
     ],
 )
@@ -104,6 +113,7 @@ arcs_kt_jvm_library(
     name = "particle",
     testonly = 1,
     srcs = [
+        "LifecycleParticles.kt",
         "ReadPerson.kt",
         "TestHost.kt",
         "TestHostParticle.kt",

--- a/javatests/arcs/core/host/LifecycleParticles.kt
+++ b/javatests/arcs/core/host/LifecycleParticles.kt
@@ -1,0 +1,68 @@
+package arcs.core.host
+
+class SingleReadHandleParticle : AbstractSingleReadHandleParticle() {
+    val events = mutableListOf<String>()
+
+    override suspend fun onFirstStart() { events.add("onFirstStart") }
+    override fun onStart() {
+        handles.data.onReady { events.add("data.onReady:${data()}") }
+        handles.data.onUpdate { events.add("data.onUpdate:${data()}") }
+        events.add("onStart")
+    }
+    override fun onReady() { events.add("onReady:${data()}") }
+    override fun onUpdate() { events.add("onUpdate:${data()}") }
+    override fun onShutdown() { events.add("onShutdown") }
+
+    fun data() = handles.data.fetch()?.num.toString()
+}
+
+class SingleWriteHandleParticle : AbstractSingleWriteHandleParticle() {
+    val events = mutableListOf<String>()
+
+    override suspend fun onFirstStart() { events.add("onFirstStart") }
+    override fun onStart() { events.add("onStart") }
+    override fun onReady() { events.add("onReady") }
+    override fun onUpdate() { events.add("onUpdate") }
+    override fun onShutdown() { events.add("onShutdown") }
+}
+
+class MultiHandleParticle : AbstractMultiHandleParticle() {
+    val events = mutableListOf<String>()
+
+    override suspend fun onFirstStart() { events.add("onFirstStart") }
+    override fun onStart() {
+        handles.data.onReady { events.add("data.onReady:${data()}") }
+        handles.data.onUpdate { events.add("data.onUpdate:${data()}") }
+        handles.list.onReady { events.add("list.onReady:${list()}") }
+        handles.list.onUpdate { events.add("list.onUpdate:${list()}") }
+        handles.config.onReady { events.add("config.onReady:${config()}") }
+        handles.config.onUpdate { events.add("config.onUpdate:${config()}") }
+        events.add("onStart")
+    }
+    override fun onReady() { events.add("onReady:${data()}:${list()}:${config()}") }
+    override fun onUpdate() { events.add("onUpdate:${data()}:${list()}:${config()}") }
+    override fun onShutdown() { events.add("onShutdown") }
+
+    fun data() = handles.data.fetch()?.num.toString()
+    fun list() = handles.list.fetchAll().map { it.txt }.toSortedSet()
+    fun config() = handles.config.fetch()?.flg.toString()
+}
+
+class PausingParticle : AbstractPausingParticle() {
+    val events = mutableListOf<String>()
+
+    override suspend fun onFirstStart() { events.add("onFirstStart") }
+    override fun onStart() {
+        handles.data.onReady { events.add("data.onReady:${data()}") }
+        handles.data.onUpdate { events.add("data.onUpdate:${data()}") }
+        handles.list.onReady { events.add("list.onReady:${list()}") }
+        handles.list.onUpdate { events.add("list.onUpdate:${list()}") }
+        events.add("onStart")
+    }
+    override fun onReady() { events.add("onReady:${data()}:${list()}") }
+    override fun onUpdate() { events.add("onUpdate:${data()}:${list()}") }
+    override fun onShutdown() { events.add("onShutdown") }
+
+    fun data() = handles.data.fetch()?.num.toString()
+    fun list() = handles.list.fetchAll().map { it.txt }.toSortedSet()
+}

--- a/javatests/arcs/core/host/LifecycleTest.kt
+++ b/javatests/arcs/core/host/LifecycleTest.kt
@@ -1,0 +1,245 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+package arcs.core.host
+
+import arcs.core.allocator.Allocator
+import arcs.core.allocator.Arc
+import arcs.core.data.Plan
+import arcs.core.storage.StoreManager
+import arcs.core.storage.api.DriverAndKeyConfigurator
+import arcs.core.storage.driver.RamDisk
+import arcs.core.util.Scheduler
+import arcs.jvm.host.ExplicitHostRegistry
+import arcs.jvm.host.JvmSchedulerProvider
+import arcs.jvm.util.testutil.FakeTime
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.fail
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import kotlin.coroutines.EmptyCoroutineContext
+
+// TODO: test errors in lifecycle methods
+// TODO: test desync/resync
+
+@RunWith(JUnit4::class)
+@OptIn(ExperimentalCoroutinesApi::class)
+class LifecycleTest {
+    private val schedulerProvider = JvmSchedulerProvider(EmptyCoroutineContext)
+
+    private lateinit var scheduler: Scheduler
+    private lateinit var testHost: TestingHost
+    private lateinit var hostRegistry: HostRegistry
+    private lateinit var storeManager: StoreManager
+    private lateinit var entityHandleManager: EntityHandleManager
+    private lateinit var allocator: Allocator
+
+    private fun runTest(
+        testBody: suspend CoroutineScope.() -> Unit
+    ) = runBlocking(EmptyCoroutineContext) { testBody() }
+
+    @Before
+    fun setUp() = runBlocking {
+        DriverAndKeyConfigurator.configure(null)
+        scheduler = schedulerProvider("test")
+        testHost = TestingHost(
+            schedulerProvider,
+            ::SingleReadHandleParticle.toRegistration(),
+            ::SingleWriteHandleParticle.toRegistration(),
+            ::MultiHandleParticle.toRegistration(),
+            ::PausingParticle.toRegistration()
+        )
+        hostRegistry = ExplicitHostRegistry().also { it.registerHost(testHost) }
+        storeManager = StoreManager()
+        entityHandleManager = EntityHandleManager(
+            time = FakeTime(),
+            scheduler = scheduler,
+            stores = storeManager
+        )
+        allocator = Allocator.create(hostRegistry, entityHandleManager)
+        testHost.setup()
+    }
+
+    @After
+    fun tearDown() = runBlocking {
+        scheduler.waitForIdle()
+        storeManager.waitForIdle()
+        entityHandleManager.close()
+        RamDisk.clear()
+    }
+
+    /**
+     * Asserts that a list of values matches a sequence of groups, where a List group must be in
+     * order while a Set group may be any order. For example:
+     *   assertVariableOrdering(listOf(1, 2, 77, 55, 66, 3, 4),
+     *                          listOf(1, 2), setOf(55, 66, 77), listOf(3, 4)) => matches
+     * TODO: improve error reporting, move to general testutil?
+     */
+    fun <T> assertVariableOrdering(actual: List<T>, vararg groups: Collection<T>) {
+        val expectedSize = groups.fold(0) { sum, group -> sum + group.size }
+        if (expectedSize != actual.size) {
+            fail("expected $expectedSize elements but found ${actual.size}: $actual")
+        }
+
+        var start = 0
+        for (group in groups) {
+            val slice = actual.subList(start, start + group.size)
+            when (group) {
+                is List -> assertThat(slice).isEqualTo(group)
+                is Set -> assertThat(slice).containsExactlyElementsIn(group)
+                else -> throw IllegalArgumentException(
+                    "assertVariableOrdering: only List and Set may be used " +
+                        "for the 'groups' argument"
+                )
+            }
+            start += group.size
+        }
+    }
+
+    private suspend fun startArc(plan: Plan): Arc {
+        val arc = allocator.startArcForPlan(plan).waitForStart()
+        waitForAllTheThings()
+        return arc
+    }
+
+    private suspend fun waitForAllTheThings() {
+        scheduler.waitForIdle()
+        storeManager.waitForIdle()
+    }
+
+    @Test
+    fun singleReadHandle() = runTest {
+        val name = "SingleReadHandleParticle"
+        val arc = startArc(SingleReadHandleTestPlan)
+        val particle: SingleReadHandleParticle = testHost.getParticle(arc.id, name)
+        val data = testHost.singletonForTest<SingleReadHandleParticle_Data>(arc.id, name, "data")
+        data.store(SingleReadHandleParticle_Data(5.0))
+        waitForAllTheThings()
+        arc.stop()
+        arc.waitForStop()
+        assertThat(particle.events).isEqualTo(listOf(
+            "onFirstStart",
+            "onStart",
+            "data.onReady:null",
+            "onReady:null",
+            "data.onUpdate:5.0",
+            "onUpdate:5.0",
+            "onShutdown"
+        ))
+    }
+
+    @Test
+    fun singleWriteHandle() = runTest {
+        val name = "SingleWriteHandleParticle"
+        val arc = startArc(SingleWriteHandleTestPlan)
+        val particle: SingleWriteHandleParticle = testHost.getParticle(arc.id, name)
+        val data = testHost.singletonForTest<SingleWriteHandleParticle_Data>(arc.id, name, "data")
+        data.store(SingleWriteHandleParticle_Data(12.0))
+        waitForAllTheThings()
+        arc.stop()
+        arc.waitForStop()
+        assertThat(particle.events)
+            .isEqualTo(listOf("onFirstStart", "onStart", "onReady", "onShutdown"))
+    }
+
+    @Test
+    fun multiHandle() = runTest {
+        val name = "MultiHandleParticle"
+        val arc = startArc(MultiHandleTestPlan)
+        val particle: MultiHandleParticle = testHost.getParticle(arc.id, name)
+        val data = testHost.singletonForTest<MultiHandleParticle_Data>(arc.id, name, "data")
+        val list = testHost.collectionForTest<MultiHandleParticle_List>(arc.id, name, "list")
+        val result = testHost.collectionForTest<MultiHandleParticle_Result>(arc.id, name, "result")
+        val config = testHost.singletonForTest<MultiHandleParticle_Config>(arc.id, name, "config")
+
+        data.store(MultiHandleParticle_Data(3.2))
+        waitForAllTheThings()
+        list.store(MultiHandleParticle_List("hi"))
+        waitForAllTheThings()
+        // Write-only handle ops do not trigger any lifecycle APIs.
+        result.store(MultiHandleParticle_Result(19.0))
+        waitForAllTheThings()
+        config.store(MultiHandleParticle_Config(true))
+        waitForAllTheThings()
+        arc.stop()
+        arc.waitForStop()
+
+        assertVariableOrdering(
+            particle.events,
+            listOf("onFirstStart", "onStart"),
+            // Handle onReady events are not guaranteed to be in any specific order.
+            setOf("data.onReady:null", "list.onReady:[]", "config.onReady:null"),
+            listOf(
+                "onReady:null:[]:null",
+                "data.onUpdate:3.2",
+                "onUpdate:3.2:[]:null",
+                "list.onUpdate:[hi]",
+                "onUpdate:3.2:[hi]:null",
+                "config.onUpdate:true",
+                "onUpdate:3.2:[hi]:true",
+                "onShutdown"
+            )
+        )
+    }
+
+    @Test
+    fun pausing() = runTest {
+        val name = "PausingParticle"
+        val arc = startArc(PausingTestPlan)
+
+        // Test handles use the same storage proxies as the real handles which will be closed
+        // when the arc is paused, so we need to re-create them after unpausing.
+        // TODO: allow test handles to persist across arc shutdown?
+        val makeHandles = suspend {
+            Pair(
+                testHost.singletonForTest<PausingParticle_Data>(arc.id, name, "data"),
+                testHost.collectionForTest<PausingParticle_List>(arc.id, name, "list")
+            )
+        }
+        val (data1, list1) = makeHandles()
+        data1.store(PausingParticle_Data(1.1))
+        list1.store(PausingParticle_List("first"))
+        waitForAllTheThings()
+
+        testHost.pause()
+        testHost.unpause()
+
+        val particle: PausingParticle = testHost.getParticle(arc.id, name)
+        val (data2, list2) = makeHandles()
+        data2.store(PausingParticle_Data(2.2))
+        waitForAllTheThings()
+        list2.store(PausingParticle_List("second"))
+        waitForAllTheThings()
+        arc.stop()
+        arc.waitForStop()
+
+        assertVariableOrdering(
+            particle.events,
+            // No onFirstStart.
+            listOf("onStart"),
+            // Values stored in the previous session should still be present.
+            setOf("data.onReady:1.1", "list.onReady:[first]"),
+            listOf(
+                "onReady:1.1:[first]",
+                "data.onUpdate:2.2",
+                "onUpdate:2.2:[first]",
+                "list.onUpdate:[first, second]",
+                "onUpdate:2.2:[first, second]",
+                "onShutdown"
+            )
+        )
+    }
+}

--- a/javatests/arcs/core/host/PurePerson.kt
+++ b/javatests/arcs/core/host/PurePerson.kt
@@ -4,7 +4,7 @@ import arcs.jvm.host.TargetHost
 
 @TargetHost(TestingJvmProdHost::class)
 class PurePerson : AbstractPurePerson() {
-    override suspend fun onFirstStart() {
+    override fun onStart() {
         handles.inputPerson.onUpdate {
             val name = handles.inputPerson.fetch()?.name
             if (name != null) {

--- a/javatests/arcs/core/host/ReadPerson.kt
+++ b/javatests/arcs/core/host/ReadPerson.kt
@@ -11,7 +11,9 @@ class ReadPerson : AbstractReadPerson() {
 
     override suspend fun onFirstStart() {
         firstStartCalled = true
-        name = ""
+    }
+
+    override fun onStart() {
         handles.person.onUpdate {
             name = handles.person.fetch()?.name ?: ""
             if (name != "") {

--- a/javatests/arcs/core/host/ReflectiveParticleConstructionTest.kt
+++ b/javatests/arcs/core/host/ReflectiveParticleConstructionTest.kt
@@ -39,9 +39,8 @@ class ReflectiveParticleConstructionTest {
     class AssertingReflectiveParticle(spec: Plan.Particle?) : TestReflectiveParticle(spec) {
         private val log = TaggedLog { "AssertingReflectiveParticle" }
 
-        override suspend fun onFirstStart() {
-            super.onFirstStart()
-            log.info { "onFirstStart()" }
+        override fun onStart() {
+            log.info { "onStart()" }
             handles.data
             assertThat(schema.name?.name).isEqualTo("Thing")
             assertThat(schema.fields.singletons).containsExactly("name", FieldType.Text)

--- a/javatests/arcs/core/host/TestingHost.kt
+++ b/javatests/arcs/core/host/TestingHost.kt
@@ -1,10 +1,15 @@
 package arcs.core.host
 
+import arcs.core.common.ArcId
 import arcs.core.data.Plan
-import arcs.core.host.AbstractArcHost
-import arcs.core.host.ParticleRegistration
+import arcs.core.entity.Storable
+import arcs.core.host.api.Particle
 import arcs.core.util.Time
 import arcs.jvm.util.testutil.FakeTime
+import arcs.sdk.Handle
+import arcs.sdk.HandleHolderBase
+import arcs.sdk.ReadWriteCollectionHandle
+import arcs.sdk.ReadWriteSingletonHandle
 import kotlinx.coroutines.CompletableDeferred
 import java.lang.IllegalArgumentException
 
@@ -33,7 +38,7 @@ open class TestingHost(
     }
 
     val isIdle = isArcHostIdle
-    
+
     override val platformTime: Time = FakeTime()
 
     fun setup() {
@@ -51,5 +56,53 @@ open class TestingHost(
         }
         waitingFor = arcId
         deferred.await()
+    }
+
+    /** Retrieve a test particle by name. */
+    fun <T : Particle> getParticle(arcId: ArcId, particleName: String): T {
+        val arcHostContext = requireNotNull(getArcHostContext(arcId.toString()))
+        @Suppress("UNCHECKED_CAST")
+        return arcHostContext.particles[particleName]!!.particle as T
+    }
+
+    /** Create a read/write singleton handle for tests to access an arc's stores. */
+    suspend fun <T : Storable> singletonForTest(
+        arcId: ArcId,
+        particleName: String,
+        handleName: String
+    ): ReadWriteSingletonHandle<T> {
+        @Suppress("UNCHECKED_CAST")
+        return createHandleForTest(arcId, particleName, handleName) as ReadWriteSingletonHandle<T>
+    }
+
+    /** Create a read/write collection handle for tests to access an arc's stores. */
+    suspend fun <T : Storable> collectionForTest(
+        arcId: ArcId,
+        particleName: String,
+        handleName: String
+    ): ReadWriteCollectionHandle<T> {
+        @Suppress("UNCHECKED_CAST")
+        return createHandleForTest(arcId, particleName, handleName) as ReadWriteCollectionHandle<T>
+    }
+
+    // TODO: is there a simpler way to do this?
+    // Currently requires tests to use the following seemingly redundant call construct:
+    //    singletonForTest<MyParticle_Data>(arcId, "MyParticle", "data")
+    // Alternatively, consider having an internal mechanism for test access to data stores?
+    private suspend fun createHandleForTest(
+        arcId: ArcId,
+        particleName: String,
+        handleName: String
+    ): Handle {
+        val arcHostContext = requireNotNull(getArcHostContext(arcId.toString()))
+        val particleContext = requireNotNull(arcHostContext.particles[particleName])
+        val handleConnection = requireNotNull(particleContext.planParticle.handles[handleName])
+        val readWriteConnection = handleConnection.copy(mode = HandleMode.ReadWrite)
+        val entitySpec = particleContext.particle.handles.getEntitySpec(handleName)
+        val handleHolder = HandleHolderBase("TestHolder", mapOf(handleName to entitySpec))
+        val handle = createHandle(
+            arcHostContext.entityHandleManager, handleName, readWriteConnection, handleHolder
+        )
+        return handle
     }
 }

--- a/javatests/arcs/core/host/WritePerson.kt
+++ b/javatests/arcs/core/host/WritePerson.kt
@@ -12,17 +12,16 @@ class WritePerson : AbstractWritePerson() {
 
     override suspend fun onFirstStart() {
         firstStartCalled = true
-        wrote = false
         if (throws) {
             throw IllegalArgumentException("Boom!")
         }
+    }
 
-        handles.person.onReady {
-            handles.person.store(WritePerson_Person("John Wick"))
-            wrote = true
-            if (!deferred.isCompleted) {
-                deferred.complete(true)
-            }
+    override fun onReady() {
+        handles.person.store(WritePerson_Person("John Wick"))
+        wrote = true
+        if (!deferred.isCompleted) {
+            deferred.complete(true)
         }
     }
 

--- a/javatests/arcs/core/host/lifecycle.arcs
+++ b/javatests/arcs/core/host/lifecycle.arcs
@@ -1,0 +1,46 @@
+meta
+  namespace: arcs.core.host
+
+// -----------------------------------------------------------------------------
+
+particle SingleReadHandleParticle in 'arcs.core.host.SingleReadHandleParticle'
+  data: reads Data {num: Number}
+
+recipe SingleReadHandleTest
+  SingleReadHandleParticle
+    data: reads h1
+
+// -----------------------------------------------------------------------------
+
+particle SingleWriteHandleParticle in 'arcs.core.host.SingleWriteHandleParticle'
+  data: writes Data {num: Number}
+
+recipe SingleWriteHandleTest
+  SingleWriteHandleParticle
+    data: writes h1
+
+// -----------------------------------------------------------------------------
+
+particle MultiHandleParticle in 'arcs.core.host.MultiHandleParticle'
+  data: reads Data {num: Number}
+  list: reads writes [List {txt: Text}]
+  result: writes [Result {idx: Number}]
+  config: reads Config {flg: Boolean}
+
+recipe MultiHandleTest
+  MultiHandleParticle
+    data: reads h1
+    list: reads writes h2
+    result: writes h3
+    config: reads h4
+
+// -----------------------------------------------------------------------------
+
+particle PausingParticle in 'arcs.core.host.PausingParticle'
+  data: reads Data {num: Number}
+  list: reads [List {txt: Text}]
+
+recipe PausingTest
+  PausingParticle
+    data: reads h1
+    list: reads h2

--- a/javatests/arcs/core/storage/StorageProxyTest.kt
+++ b/javatests/arcs/core/storage/StorageProxyTest.kt
@@ -17,6 +17,7 @@ import arcs.core.crdt.CrdtOperation
 import arcs.core.crdt.CrdtOperationAtTime
 import arcs.core.crdt.VersionMap
 import arcs.core.storage.StorageProxy.ProxyState
+import arcs.core.storage.StorageProxy.StorageEvent
 import arcs.core.util.Scheduler
 import arcs.core.util.testutil.LogRule
 import arcs.jvm.util.JvmTime
@@ -27,9 +28,8 @@ import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
 import com.nhaarman.mockitokotlin2.whenever
 import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.test.assertFailsWith
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.cancel
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import org.junit.Before
 import org.junit.Ignore
@@ -40,7 +40,6 @@ import org.junit.runners.JUnit4
 import org.mockito.Mock
 import org.mockito.MockitoAnnotations
 
-@Suppress("UNCHECKED_CAST", "UNUSED_VARIABLE")
 @ExperimentalCoroutinesApi
 @RunWith(JUnit4::class)
 class StorageProxyTest {
@@ -55,7 +54,8 @@ class StorageProxyTest {
     @Mock private lateinit var mockCrdtModel: CrdtModel<CrdtData, CrdtOperationAtTime, String>
     @Mock private lateinit var mockCrdtData: CrdtData
 
-    private val scheduler: Scheduler = Scheduler(JvmTime, EmptyCoroutineContext)
+    private val scheduler = Scheduler(JvmTime, EmptyCoroutineContext)
+    private val callbackId = StorageProxy.CallbackIdentifier("test")
 
     @Before
     fun setup() {
@@ -69,118 +69,139 @@ class StorageProxyTest {
         whenever(mockCrdtOperation.clock).thenReturn(VersionMap())
     }
 
-    @Ignore("b/157267211 - Deflake")
     @Test
-    fun addOnReadyTriggersSyncRequest() = runBlocking {
+    fun initiatingSyncWhenPreparedSendsSyncRequest() = runBlocking {
         val proxy = StorageProxy(mockStorageEndpointProvider, mockCrdtModel, scheduler)
-        val callbackId = StorageProxy.CallbackIdentifier("test")
-        proxy.addOnReady(callbackId) {}
+        assertThat(proxy.getStateForTesting()).isEqualTo(ProxyState.NO_SYNC)
 
-        delay(100)
+        // Readable handles are observing this proxy.
+        proxy.prepareForSync()
+        assertThat(proxy.getStateForTesting()).isEqualTo(ProxyState.READY_TO_SYNC)
+        proxy.prepareForSync()
+        assertThat(proxy.getStateForTesting()).isEqualTo(ProxyState.READY_TO_SYNC)
+        scheduler.waitForIdle()
+        assertThat(fakeStoreEndpoint.getProxyMessages()).isEmpty()
 
-        assertThat(fakeStoreEndpoint.getProxyMessages()).containsExactly(
-            ProxyMessage.SyncRequest<CrdtData, CrdtOperation, String>(null)
-        )
-        assertThat(proxy.getStateForTesting()).isEqualTo(ProxyState.AWAITING_SYNC)
-    }
-
-    @Test
-    fun addOnUpdateTriggersSyncRequest() = runBlocking {
-        val proxy = StorageProxy(mockStorageEndpointProvider, mockCrdtModel, scheduler)
-        val callbackId = StorageProxy.CallbackIdentifier("test")
-        proxy.addOnUpdate(callbackId) {}
-
-        delay(100)
-
-        assertThat(fakeStoreEndpoint.getProxyMessages()).containsExactly(
-            ProxyMessage.SyncRequest<CrdtData, CrdtOperation, String>(null)
-        )
-        assertThat(proxy.getStateForTesting()).isEqualTo(ProxyState.AWAITING_SYNC)
-    }
-
-    @Test
-    fun addOnDesyncTriggersSyncRequest() = runBlocking {
-        val proxy = StorageProxy(mockStorageEndpointProvider, mockCrdtModel, scheduler)
-        val callbackId = StorageProxy.CallbackIdentifier("test")
-        proxy.addOnDesync(callbackId) {}
-
-        delay(100)
-
-        assertThat(fakeStoreEndpoint.getProxyMessages()).containsExactly(
-            ProxyMessage.SyncRequest<CrdtData, CrdtOperation, String>(null)
-        )
-        assertThat(proxy.getStateForTesting()).isEqualTo(ProxyState.AWAITING_SYNC)
-    }
-
-    @Test
-    fun addOnResyncTriggersSyncRequest() = runBlocking {
-        val proxy = StorageProxy(mockStorageEndpointProvider, mockCrdtModel, scheduler)
-        val callbackId = StorageProxy.CallbackIdentifier("test")
-        proxy.addOnResync(callbackId) {}
-
-        fakeStoreEndpoint.waitFor(
-            ProxyMessage.SyncRequest(null)
-        )
-        assertThat(proxy.getStateForTesting()).isEqualTo(ProxyState.AWAITING_SYNC)
-    }
-
-    @Test
-    fun onlyOneSyncRequestIsSentWhenAddingMultipleActions() = runBlocking {
-        val proxy = StorageProxy(mockStorageEndpointProvider, mockCrdtModel, scheduler)
-        val callbackId = StorageProxy.CallbackIdentifier("test")
-        proxy.addOnReady(callbackId) {}
-        proxy.addOnUpdate(callbackId) {}
-        proxy.addOnDesync(callbackId) {}
-        proxy.addOnResync(callbackId) {}
-        fakeStoreEndpoint.waitFor(
-            ProxyMessage.SyncRequest(null)
-        )
+        // Sync request should be sent.
+        proxy.maybeInitiateSync()
         scheduler.waitForIdle()
         assertThat(fakeStoreEndpoint.getProxyMessages()).containsExactly(
             ProxyMessage.SyncRequest<CrdtData, CrdtOperation, String>(null)
         )
         assertThat(proxy.getStateForTesting()).isEqualTo(ProxyState.AWAITING_SYNC)
+    }
+
+    @Ignore("b/157188866 - remove onReady from write-only handles")
+    @Test
+    fun initiatingSyncWhenNotPreparedDoesNotSendSyncRequest() = runBlocking {
+        val proxy = StorageProxy(mockStorageEndpointProvider, mockCrdtModel, scheduler)
+        assertThat(proxy.getStateForTesting()).isEqualTo(ProxyState.NO_SYNC)
+
+        // No readable handles are observing this proxy; sync request should not be sent.
+        proxy.maybeInitiateSync()
+        scheduler.waitForIdle()
+        assertThat(proxy.getStateForTesting()).isEqualTo(ProxyState.NO_SYNC)
+        assertThat(fakeStoreEndpoint.getProxyMessages()).isEmpty()
+    }
+
+    @Test
+    fun cannotAddActionsOnNonSyncingProxy() = runBlocking {
+        val proxy = StorageProxy(mockStorageEndpointProvider, mockCrdtModel, scheduler)
+        assertThat(proxy.getStateForTesting()).isEqualTo(ProxyState.NO_SYNC)
+
+        val check = { block: () -> Unit ->
+            val exception = assertFailsWith<IllegalStateException> { block() }
+            assertThat(exception).hasMessageThat().startsWith("Action handlers are not valid")
+        }
+        check { proxy.addOnReady(callbackId) {} }
+        check { proxy.addOnUpdate(callbackId) {} }
+        check { proxy.addOnDesync(callbackId) {} }
+        check { proxy.addOnResync(callbackId) {} }
     }
 
     @Test
     fun addingActionsInvokesCallbacksBasedOnState() = runBlocking {
         val proxy = StorageProxy(mockStorageEndpointProvider, mockCrdtModel, scheduler)
-        val callbackId = StorageProxy.CallbackIdentifier("test")
-        assertThat(proxy.getStateForTesting()).isEqualTo(ProxyState.INIT)
 
-        // In INIT and AWAITING_SYNC, none of the notifiers are invoked immediately.
+        // READY_TO_SYNC and AWAITING_SYNC: none of the callbacks are invoked immediately.
+        proxy.prepareForSync()
+        assertThat(proxy.getStateForTesting()).isEqualTo(ProxyState.READY_TO_SYNC)
         val (onReady1, onUpdate1, onDesync1, onResync1) = addAllActions(callbackId, proxy)
-        assertThat(proxy.getStateForTesting()).isEqualTo(ProxyState.AWAITING_SYNC)
         verifyNoMoreInteractions(onReady1, onUpdate1, onDesync1, onResync1)
 
-        // In SYNC, addOnReady should invoke its callback immediately.
+        proxy.maybeInitiateSync()
+        assertThat(proxy.getStateForTesting()).isEqualTo(ProxyState.AWAITING_SYNC)
+        val (onReady2, onUpdate2, onDesync2, onResync2) = addAllActions(callbackId, proxy)
+        verifyNoMoreInteractions(onReady2, onUpdate2, onDesync2, onResync2)
+
+        // SYNC: addOnReady should invoke its callback immediately.
         proxy.onMessage(ProxyMessage.ModelUpdate(mockCrdtData, null))
         scheduler.waitForIdle()
         assertThat(proxy.getStateForTesting()).isEqualTo(ProxyState.SYNC)
 
-        val (onReady2, onUpdate2, onDesync2, onResync2) = addAllActions(callbackId, proxy)
-        scheduler.waitForIdle()
-        verify(onReady2).invoke()
-        verifyNoMoreInteractions(onUpdate2, onDesync2, onResync2)
+        val (onReady3, onUpdate3, onDesync3, onResync3) = addAllActions(callbackId, proxy)
+        verify(onReady3).invoke()
+        verifyNoMoreInteractions(onUpdate3, onDesync3, onResync3)
 
-        // In DESYNC, addOnDesync should invoke its callback immediately.
+        // DESYNC: addOnDesync should invoke its callback immediately.
         whenever(mockCrdtModel.applyOperation(mockCrdtOperation)).thenReturn(false)
         proxy.onMessage(ProxyMessage.Operations(listOf(mockCrdtOperation),null))
         scheduler.waitForIdle()
         assertThat(proxy.getStateForTesting()).isEqualTo(ProxyState.DESYNC)
 
-        val (onReady3, onUpdate3, onDesync3, onResync3) = addAllActions(callbackId, proxy)
-        scheduler.waitForIdle()
-        verify(onDesync3).invoke()
-        verifyNoMoreInteractions(onReady3, onUpdate3, onResync3)
+        val (onReady4, onUpdate4, onDesync4, onResync4) = addAllActions(callbackId, proxy)
+        verify(onDesync4).invoke()
+        verifyNoMoreInteractions(onReady4, onUpdate4, onResync4)
+    }
 
-        scheduler.scope.cancel()
+    @Test
+    fun storageEvents() = runBlocking {
+        val proxy = StorageProxy(mockStorageEndpointProvider, mockCrdtModel, scheduler)
+        val notify: (StorageEvent) -> Unit = mock()
+        proxy.registerForStorageEvents(callbackId, notify)
+
+        // NO_SYNC, READY_TO_SYNC, AWAITING_SYNC: should not notify.
+        assertThat(proxy.getStateForTesting()).isEqualTo(ProxyState.NO_SYNC)
+        proxy.prepareForSync()
+        assertThat(proxy.getStateForTesting()).isEqualTo(ProxyState.READY_TO_SYNC)
+        proxy.maybeInitiateSync()
+        assertThat(proxy.getStateForTesting()).isEqualTo(ProxyState.AWAITING_SYNC)
+        verifyNoMoreInteractions(notify)
+
+        // SYNC: should notify READY.
+        proxy.onMessage(ProxyMessage.ModelUpdate(mockCrdtData, null))
+        scheduler.waitForIdle()
+        assertThat(proxy.getStateForTesting()).isEqualTo(ProxyState.SYNC)
+        verify(notify).invoke(StorageEvent.READY)
+
+        whenever(mockCrdtModel.applyOperation(mockCrdtOperation))
+            .thenReturn(true)
+            .thenReturn(false)
+
+        // Successful model ops should notify UPDATE.
+        proxy.onMessage(ProxyMessage.Operations(listOf(mockCrdtOperation), null))
+        scheduler.waitForIdle()
+        verify(notify).invoke(StorageEvent.UPDATE)
+
+        // Failing model ops should notify DESYNC.
+        proxy.onMessage(ProxyMessage.Operations(listOf(mockCrdtOperation),null))
+        scheduler.waitForIdle()
+        assertThat(proxy.getStateForTesting()).isEqualTo(ProxyState.DESYNC)
+        verify(notify).invoke(StorageEvent.DESYNC)
+
+        // Syncing the proxy again should notify RESYNC.
+        proxy.onMessage(ProxyMessage.ModelUpdate(mockCrdtData, null))
+        scheduler.waitForIdle()
+        assertThat(proxy.getStateForTesting()).isEqualTo(ProxyState.SYNC)
+        verify(notify).invoke(StorageEvent.RESYNC)
     }
 
     @Test
     fun modelUpdatesTriggerOnReadyThenOnUpdate() = runBlocking {
         val proxy = StorageProxy(mockStorageEndpointProvider, mockCrdtModel, scheduler)
-        val callbackId = StorageProxy.CallbackIdentifier("test")
+        proxy.prepareForSync()
+        proxy.maybeInitiateSync()
+
         val (onReady, onUpdate, onDesync, onResync) = addAllActions(callbackId, proxy)
         assertThat(proxy.getStateForTesting()).isEqualTo(ProxyState.AWAITING_SYNC)
 
@@ -203,7 +224,9 @@ class StorageProxyTest {
     @Test
     fun modelOperationsTriggerOnUpdate() = runBlocking {
         val proxy = StorageProxy(mockStorageEndpointProvider, mockCrdtModel, scheduler)
-        val callbackId = StorageProxy.CallbackIdentifier("test")
+        proxy.prepareForSync()
+        proxy.maybeInitiateSync()
+
         val (onReady, onUpdate, onDesync, onResync) = addAllActions(callbackId, proxy)
         whenever(mockCrdtModel.applyOperation(mockCrdtOperation)).thenReturn(true)
 
@@ -234,13 +257,13 @@ class StorageProxyTest {
     @Test
     fun failingModelOperationsTriggerDesync() = runBlocking {
         val proxy = StorageProxy(mockStorageEndpointProvider, mockCrdtModel, scheduler)
-        val callbackId = StorageProxy.CallbackIdentifier("test")
-        val (onReady, onUpdate, onDesync, onResync) = addAllActions(callbackId, proxy)
+        proxy.prepareForSync()
+        proxy.maybeInitiateSync()
 
         // Sync the proxy.
+        val (onReady, onUpdate, onDesync, onResync) = addAllActions(callbackId, proxy)
         proxy.onMessage(ProxyMessage.ModelUpdate(mockCrdtData, null))
         scheduler.waitForIdle()
-
         assertThat(proxy.getStateForTesting()).isEqualTo(ProxyState.SYNC)
         verify(onReady).invoke()
 
@@ -280,11 +303,13 @@ class StorageProxyTest {
     @Test
     fun listOfModelOperationsWithOneFailing() = runBlocking {
         val proxy = StorageProxy(mockStorageEndpointProvider, mockCrdtModel, scheduler)
-        val callbackId = StorageProxy.CallbackIdentifier("test")
+        proxy.prepareForSync()
+        proxy.maybeInitiateSync()
+
+        // Sync the proxy.
         val (onReady, onUpdate, onDesync, onResync) = addAllActions(callbackId, proxy)
         proxy.onMessage(ProxyMessage.ModelUpdate(mockCrdtData, null))
         scheduler.waitForIdle()
-
         assertThat(proxy.getStateForTesting()).isEqualTo(ProxyState.SYNC)
         verify(onReady).invoke()
 
@@ -297,8 +322,7 @@ class StorageProxyTest {
         fakeStoreEndpoint.clearProxyMessages()
         val threeOps = listOf(mockCrdtOperation, mockCrdtOperation, mockCrdtOperation)
         proxy.onMessage(ProxyMessage.Operations(threeOps,null))
-
-        delay(100)
+        scheduler.waitForIdle()
 
         assertThat(fakeStoreEndpoint.getProxyMessages()).containsExactly(
             ProxyMessage.SyncRequest<CrdtData, CrdtOperation, String>(null)
@@ -311,25 +335,26 @@ class StorageProxyTest {
     @Test
     fun syncRequestReturnsTheLocalModel() = runBlocking {
         val proxy = StorageProxy(mockStorageEndpointProvider, mockCrdtModel, scheduler)
-        val callbackId = StorageProxy.CallbackIdentifier("test")
+        proxy.prepareForSync()
+        proxy.maybeInitiateSync()
+
         val (onReady, onUpdate, onDesync, onResync) = addAllActions(callbackId, proxy)
 
         // Wait until the sync request appears, then get rid of it so we can test for the
         // existence of the model update message in response to a store trying to sync.
-        delay(100)
+        scheduler.waitForIdle()
         fakeStoreEndpoint.clearProxyMessages()
 
         proxy.onMessage(ProxyMessage.SyncRequest(null))
-        fakeStoreEndpoint.waitFor(
-            ProxyMessage.ModelUpdate(mockCrdtData, null)
-        )
+        fakeStoreEndpoint.waitFor(ProxyMessage.ModelUpdate(mockCrdtData, null))
         verifyNoMoreInteractions(onReady, onUpdate, onDesync, onResync)
     }
 
     @Test
     fun removeCallbacksForName() = runBlocking {
         val proxy = StorageProxy(mockStorageEndpointProvider, mockCrdtModel, scheduler)
-        val callbackId = StorageProxy.CallbackIdentifier("test", "test")
+        proxy.prepareForSync()
+        proxy.maybeInitiateSync()
 
         // First sync usually triggers onReady.
         val (onReady1, onUpdate1, onDesync1, onResync1) = addAllActions(callbackId, proxy)
@@ -385,7 +410,9 @@ class StorageProxyTest {
     @Test
     fun applyOpSucceeds() = runBlocking {
         val proxy = StorageProxy(mockStorageEndpointProvider, mockCrdtModel, scheduler)
-        val callbackId = StorageProxy.CallbackIdentifier("test")
+        proxy.prepareForSync()
+        proxy.maybeInitiateSync()
+
         val (onReady, onUpdate, onDesync, onResync) = addAllActions(callbackId, proxy)
         whenever(mockCrdtModel.applyOperation(mockCrdtOperation)).thenReturn(true)
 
@@ -406,11 +433,14 @@ class StorageProxyTest {
     @Test
     fun applyOpFails() = runBlocking {
         val proxy = StorageProxy(mockStorageEndpointProvider, mockCrdtModel, scheduler)
-        val callbackId = StorageProxy.CallbackIdentifier("test")
+        proxy.prepareForSync()
+        proxy.maybeInitiateSync()
+
         val (onReady, onUpdate, onDesync, onResync) = addAllActions(callbackId, proxy)
         whenever(mockCrdtModel.applyOperation(mockCrdtOperation)).thenReturn(false)
 
-        delay(100) // Wait for sync, then clear it.
+        // Wait for sync, then clear it.
+        scheduler.waitForIdle()
         fakeStoreEndpoint.clearProxyMessages()
 
         assertThat(proxy.applyOp(mockCrdtOperation).await()).isFalse()
@@ -421,9 +451,10 @@ class StorageProxyTest {
     @Test
     fun getParticleViewReturnsSyncedState() = runBlocking {
         val proxy = StorageProxy(mockStorageEndpointProvider, mockCrdtModel, scheduler)
+        proxy.prepareForSync()
+        proxy.maybeInitiateSync()
         proxy.onMessage(ProxyMessage.ModelUpdate(mockCrdtData, null))
         scheduler.waitForIdle()
-
         assertThat(proxy.getStateForTesting()).isEqualTo(ProxyState.SYNC)
 
         fakeStoreEndpoint.clearProxyMessages()
@@ -433,16 +464,28 @@ class StorageProxyTest {
 
     @Ignore("b/157266813 - Deflake")
     @Test
-    fun getParticleViewWhenInInitialStateQueuesAndRequestsSync() = runBlocking {
+    fun getParticleViewWhenNotSyncingFails() = runBlocking {
         val proxy = StorageProxy(mockStorageEndpointProvider, mockCrdtModel, scheduler)
-        assertThat(proxy.getStateForTesting()).isEqualTo(ProxyState.INIT)
+        assertThat(proxy.getStateForTesting()).isEqualTo(ProxyState.NO_SYNC)
+
+        val exception = assertFailsWith<IllegalStateException> {
+            proxy.getParticleViewAsync()
+        }
+        assertThat(exception).hasMessageThat()
+            .isEqualTo("getParticleView not valid on non-readable StorageProxy")
+    }
+
+    @Test
+    fun getParticleViewWhenReadyToSyncQueuesAndRequestsSync() = runBlocking {
+        val proxy = StorageProxy(mockStorageEndpointProvider, mockCrdtModel, scheduler)
+        proxy.prepareForSync()
+        assertThat(proxy.getStateForTesting()).isEqualTo(ProxyState.READY_TO_SYNC)
 
         val future1 = proxy.getParticleViewAsync()
         assertThat(future1.isCompleted).isFalse()
         assertThat(proxy.getStateForTesting()).isEqualTo(ProxyState.AWAITING_SYNC)
 
-        delay(100) // wait for launch to have happened.
-
+        scheduler.waitForIdle()
         assertThat(fakeStoreEndpoint.getProxyMessages()).containsExactly(
             ProxyMessage.SyncRequest<CrdtData, CrdtOperation, String>(null)
         )
@@ -464,42 +507,18 @@ class StorageProxyTest {
 
     @Ignore("b/157266894 - Deflake")
     @Test
-    fun getParticleViewWhenAwaitingSyncQueues() = runBlocking {
-        val proxy = StorageProxy(mockStorageEndpointProvider, mockCrdtModel, scheduler)
-        proxy.addOnReady(StorageProxy.CallbackIdentifier("test")) {}
-
-        assertThat(proxy.getStateForTesting()).isEqualTo(ProxyState.AWAITING_SYNC)
-
-        delay(100)
-
-        assertThat(fakeStoreEndpoint.getProxyMessages()).containsExactly(
-            ProxyMessage.SyncRequest<CrdtData, CrdtOperationAtTime, String>(null)
-        )
-
-        fakeStoreEndpoint.clearProxyMessages()
-
-        val future = proxy.getParticleViewAsync()
-        assertThat(future.isCompleted).isFalse()
-        assertThat(proxy.getStateForTesting()).isEqualTo(ProxyState.AWAITING_SYNC)
-        assertThat(fakeStoreEndpoint.getProxyMessages()).isEmpty()
-
-        // Syncing the proxy should resolve the future.
-        proxy.onMessage(ProxyMessage.ModelUpdate(mockCrdtData, null))
-        scheduler.waitForIdle()
-
-        assertThat(proxy.getStateForTesting()).isEqualTo(ProxyState.SYNC)
-        assertThat(future.isCompleted).isTrue()
-        assertThat(future.await()).isEqualTo("data")
-    }
-
-    @Test
     fun getParticleViewWhenDesyncedQueues() = runBlocking {
         val proxy = StorageProxy(mockStorageEndpointProvider, mockCrdtModel, scheduler)
+        proxy.prepareForSync()
+        proxy.maybeInitiateSync()
+        proxy.onMessage(ProxyMessage.ModelUpdate(mockCrdtData, null))
+        scheduler.waitForIdle()
+        assertThat(proxy.getStateForTesting()).isEqualTo(ProxyState.SYNC)
+
         whenever(mockCrdtModel.applyOperation(mockCrdtOperation)).thenReturn(false)
         proxy.onMessage(ProxyMessage.ModelUpdate(mockCrdtData, null))
         proxy.onMessage(ProxyMessage.Operations(listOf(mockCrdtOperation),null))
         scheduler.waitForIdle()
-
         assertThat(proxy.getStateForTesting()).isEqualTo(ProxyState.DESYNC)
 
         fakeStoreEndpoint.clearProxyMessages()
@@ -534,6 +553,7 @@ class StorageProxyTest {
         val proxy = StorageProxy(mockStorageEndpointProvider, mockCrdtModel, scheduler)
         proxy.close()
         assertThat(fakeStoreEndpoint.closed).isTrue()
+        assertThat(proxy.getStateForTesting()).isEqualTo(ProxyState.CLOSED)
     }
 
     // Convenience wrapper for destructuring.
@@ -548,11 +568,13 @@ class StorageProxyTest {
         id: StorageProxy.CallbackIdentifier,
         proxy: StorageProxy<CrdtData, CrdtOperationAtTime, String>
     ): ActionMocks {
-        return ActionMocks().also { mocks ->
+        val mocks = ActionMocks().also { mocks ->
             proxy.addOnReady(id) { mocks.onReady() }
             proxy.addOnUpdate(id) { mocks.onUpdate(it) }
             proxy.addOnDesync(id) { mocks.onDesync() }
             proxy.addOnResync(id) { mocks.onResync() }
         }
+        scheduler.waitForIdle()
+        return mocks
     }
 }

--- a/javatests/arcs/sdk/ReadSdkPerson.kt
+++ b/javatests/arcs/sdk/ReadSdkPerson.kt
@@ -2,11 +2,11 @@ package arcs.sdk
 
 class ReadSdkPerson : AbstractReadSdkPerson() {
     var name = ""
-    var firstStartCalled = false
+    var onStartCalled = false
     var shutdownCalled = false
 
-    override suspend fun onFirstStart() {
-        firstStartCalled = true
+    override fun onStart() {
+        onStartCalled = true
         name = ""
         handles.person.onUpdate {
             name = handles.person.fetch()?.name ?: ""


### PR DESCRIPTION
Implements `onStart`, `onReady`, etc. for both particles and handles.

StorageProxy now has a much more explicit sync mode caused by any readable handle observing it. This replaces the current scheme of requesting a sync when any of the event methods (`onReady`, `onUpdate`, etc) are first called.

The logic for handling the particle/handle API interaction is fairly distributed, so here's a breakdown:

1. When constructed, readable Handles tell their proxy to be READY_TO_SYNC (`BaseHandle.init` calls `StorageProxy.prepareForSync`)

2. ParticleContext now manages the post-start state handling for the new API methods on Particles. `AbstractArcHost.startParticle` sets up a notification path from StorageProxy to ParticleContext:
   - calls `Handle.registerForStorageEvents` with a callback hook to `particleContext.notify` (`BaseHandle.registerForStorageEvents` passes that through to `StorageProxy.registerForStorageEvents`)
   - calls `ParticleContext.expectReady(handle)` to prime the onReady-after-all-handles-synced logic

3. Once the `onStart` method has been called for all particles, `AbstractArcHost.startArc` kicks off the `onReady` logic:
   - calls `EntityHandleManager.initiateProxySync`, which calls `StorageProxy.maybeInitiateSync` to move proxies to AWAITING_SYNC and send sync requests to their backing stores
   - calls `ParticleContext.notifyWriteOnlyParticles` for the special case of particles with only write-only handles

4. When a StorageProxy receives a message from the backing store, it sends a StorageEvent to ParticleContext (via the callback from step 2). ParticleContext then manages the lifecycle state based on those events.

Other notes:
- Write-only handles should *not* receive the onReady event, but this breaks too many things and is deferred to a follow-up CL.

- EntityHandleManager has a new `immediateSync` arg when creating handles. If true (the default), it will call `maybeInitiateSync` on the handle's proxy immediately. This means any handles created for tests wil automatically sync. AbstractArcHost sets the flag to false when creating the "real" handles for an arc.