### PR TITLE
Platform-specific kotlin-native repo rules

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -135,7 +135,7 @@ emsdk_repo()
 
 load("//build_defs/kotlin_native:repo.bzl", "kotlin_native_repo")
 
-kotlin_native_repo()
+kotlin_native_repo(name = "kotlin_native_local")
 
 # Android SDK
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -135,7 +135,7 @@ emsdk_repo()
 
 load("//build_defs/kotlin_native:repo.bzl", "kotlin_native_repo")
 
-kotlin_native_repo(name = "kotlin_native_local")
+kotlin_native_repo(name = "kotlin_native_compiler")
 
 # Android SDK
 

--- a/build_defs/kotlin_native/BUILD
+++ b/build_defs/kotlin_native/BUILD
@@ -3,6 +3,6 @@
 sh_binary(
     name = "kotlinc_wrapper",
     srcs = ["kotlinc_wrapper.sh"],
-    data = ["@kotlin_native_local//:all_artifacts"],
+    data = ["@kotlin_native_compiler//:all_artifacts"],
     visibility = ["//visibility:public"],
 )

--- a/build_defs/kotlin_native/BUILD
+++ b/build_defs/kotlin_native/BUILD
@@ -1,24 +1,8 @@
 # Wrapper script around Kotlin-Native command line tools (i.e. kotlinc).
-load("//build_defs/kotlin_native:repo.bzl", "get_dependencies")
-
-KOTLIN_PLATFORM_TMPL = "@kotlin_native_{0}//:all_files"
-
-KOTLIN_DEP_TMPL = "@{0}//:all_files"
 
 sh_binary(
     name = "kotlinc_wrapper",
     srcs = ["kotlinc_wrapper.sh"],
-    data = select({
-               "@bazel_tools//src/conditions:windows": [KOTLIN_PLATFORM_TMPL.format("windows")],
-               "@bazel_tools//src/conditions:darwin": [KOTLIN_PLATFORM_TMPL.format("macos")],
-               "@bazel_tools//src/conditions:darwin_x86_64": [KOTLIN_PLATFORM_TMPL.format("macos")],
-               "@bazel_tools//src/conditions:linux_x86_64": [KOTLIN_PLATFORM_TMPL.format("linux")],
-           }) +
-           select({
-               "@bazel_tools//src/conditions:windows": [KOTLIN_DEP_TMPL.format(name) for name, _ in get_dependencies("windows")],
-               "@bazel_tools//src/conditions:darwin": [KOTLIN_DEP_TMPL.format(name) for name, _ in get_dependencies("macos")],
-               "@bazel_tools//src/conditions:darwin_x86_64": [KOTLIN_DEP_TMPL.format(name) for name, _ in get_dependencies("macos")],
-               "@bazel_tools//src/conditions:linux_x86_64": [KOTLIN_DEP_TMPL.format(name) for name, _ in get_dependencies("linux")],
-           }),
+    data = ["@kotlin_native_local//:all_artifacts"],
     visibility = ["//visibility:public"],
 )

--- a/build_defs/kotlin_native/build_defs.bzl
+++ b/build_defs/kotlin_native/build_defs.bzl
@@ -1,5 +1,3 @@
-load("//build_defs/kotlin_native:repo.bzl", "get_dependencies")
-
 KtNativeInfo = provider(
     doc = "The minimum info about a Kotlin/Native dependency",
     fields = dict(
@@ -9,12 +7,6 @@ KtNativeInfo = provider(
 
 def _common_args(ctx, klibs):
     args = ctx.actions.args()
-
-    # Pass dependencies for all platforms to wrapper script
-    args.add("|".join([
-        ",".join([name for name, _ in get_dependencies(target)])
-        for target in ["windows", "macos", "linux"]
-    ]))
 
     # Arguments for kotlinc
     args.add_all([

--- a/build_defs/kotlin_native/kotlinc.BUILD
+++ b/build_defs/kotlin_native/kotlinc.BUILD
@@ -1,7 +1,0 @@
-_files_without_spaces = [f for f in glob(["**"]) if " " not in f]
-
-filegroup(
-    name = "all_files",
-    srcs = _files_without_spaces,
-    visibility = ["//visibility:public"],
-)

--- a/build_defs/kotlin_native/kotlinc_wrapper.sh
+++ b/build_defs/kotlin_native/kotlinc_wrapper.sh
@@ -5,7 +5,7 @@ abspath() {
   echo "$(cd "$(dirname "$1")"; pwd -P)/$(basename "$1")"
 }
 
-case $(ls "${BASH_SOURCE[0]}.runfiles/kotlin_native_local/kotlin-native-1.3.50/" | grep "kotlin-native-") in
+case $(ls "${BASH_SOURCE[0]}.runfiles/kotlin_native_compiler/kotlin-native-"*) in
   *windows*)
     PLATFORM="windows"
   ;;
@@ -20,7 +20,7 @@ case $(ls "${BASH_SOURCE[0]}.runfiles/kotlin_native_local/kotlin-native-1.3.50/"
     exit 1
 esac
 
-wrapper_root="${BASH_SOURCE[0]}.runfiles/kotlin_native_local"
+wrapper_root="${BASH_SOURCE[0]}.runfiles/kotlin_native_compiler"
 repo_rel="$wrapper_root/kotlin-native-1.3.50/kotlin-native-$PLATFORM-1.3.50"
 repo=$(abspath "$repo_rel")
 deps=$(abspath "$wrapper_root")

--- a/build_defs/kotlin_native/kotlinc_wrapper.sh
+++ b/build_defs/kotlin_native/kotlinc_wrapper.sh
@@ -1,83 +1,31 @@
 #!/bin/bash
 # Script to run the Kotlin Native Compiler.
-# Expects a comma-delimited list of dependency files as a first argument.
-# The rest of the arguments are passed in to the `kotlinc` compiler.
 
-
-# Create directory if it doesn't exist
-soft_mkdir() {
-  if [ ! -d "$1" ]; then
-   mkdir $1
-  fi
+abspath() {
+  echo "$(cd "$(dirname "$1")"; pwd -P)/$(basename "$1")"
 }
 
-
-# Create file if it doesn't exist
-soft_touch() {
-  if [ ! -f "$1" ]; then
-    touch $1
-  fi
-}
-
-_DEPENDENCIES=$1
-shift 1
-
-case $(ls "${BASH_SOURCE[0]}.runfiles/" | grep "kotlin_native_") in
+case $(ls "${BASH_SOURCE[0]}.runfiles/kotlin_native_local/kotlin-native-1.3.50/" | grep "kotlin-native-") in
   *windows*)
     PLATFORM="windows"
-    idx=0
-    ;;
+  ;;
   *macos*)
     PLATFORM="macos"
-    idx=1
   ;;
   *linux*)
     PLATFORM="linux"
-    idx=2
   ;;
   *)
     echo "Unknown Kotlin Native Compiler platform!"
     exit 1
 esac
 
-# Get only relevant platform's dependencies
-set -f
-_ALL_DEPS=(${_DEPENDENCIES//|/ })
-set +f
-DEPENDENCIES=${_ALL_DEPS[idx]}
+wrapper_root="${BASH_SOURCE[0]}.runfiles/kotlin_native_local"
+repo_rel="$wrapper_root/kotlin-native-1.3.50/kotlin-native-$PLATFORM-1.3.50"
+repo=$(abspath "$repo_rel")
+deps=$(abspath "$wrapper_root")
 
-
-repo_rel="${BASH_SOURCE[0]}.runfiles/kotlin_native_$PLATFORM/kotlin-native-$PLATFORM-1.3.50"
-repo=$(python -c '
-import sys
-import os.path
-print(os.path.abspath(sys.argv[1]))' "$repo_rel")
-
-konan_deps=${BASH_SOURCE[0]}.runfiles/
-deps=$(python -c '
-import sys
-import os.path
-print(os.path.abspath(sys.argv[1]))' "$konan_deps")
-
-# Space for setting up required environment variables
-
-
-soft_mkdir "$deps/dependencies"
-soft_touch "$deps/dependencies/.extracted"
-soft_mkdir "$deps/cache"
-soft_touch "$deps/cache/.lock"
-export KONAN_DATA_DIR="$deps"
-
-IFS=$','
-for i in $DEPENDENCIES; do
-  src="$deps/$i/$i"
-  dst="$deps/dependencies/$i"
-  if [ ! -e "$dst" ]; then
-    ln -s "$src" "$dst"
-    echo "$i" >> "$deps/dependencies/.extracted"
-  fi
-done
-unset IFS
+export KONAN_DATA_DIR="$deps/"
 
 # Run the command line args that were passed to this script.
 exec "$repo/bin/kotlinc" "$@"

--- a/build_defs/kotlin_native/repo.bzl
+++ b/build_defs/kotlin_native/repo.bzl
@@ -71,7 +71,7 @@ filegroup(
 def _impl(repository_ctx):
     os_name = to_platform(repository_ctx.os.name)
 
-    src_path = repository_ctx.path()
+    src_path = repository_ctx.path(repository_ctx.attr.path)
 
     repository_ctx.execute(["mkdir", "-p", src_path])
     repository_ctx.execute(["mkdir", "-p", "{0}/dependencies".format(src_path)])
@@ -110,6 +110,9 @@ def _impl(repository_ctx):
 
 kotlin_native_repo = repository_rule(
     implementation = _impl,
+    attrs = {
+        "path": attr.string(default = ""),
+    },
     doc = """Downloads the kotlin-native release and "installs" the kotlinc compiler.
 
     Kotlin-Native is used to compile Kotlin into Wasm. This rule downloads the latest

--- a/build_defs/kotlin_native/repo.bzl
+++ b/build_defs/kotlin_native/repo.bzl
@@ -1,33 +1,31 @@
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+KOTLIN_NATIVE_VERSION = "1.3.50"
 
-_kotlin_native_version = "1.3.50"
-
-_repo_tmpl = _kotlin_native_version.join([
+_repo_tmpl = KOTLIN_NATIVE_VERSION.join([
     "https://github.com/JetBrains/kotlin/releases/download/v",
     "/kotlin-native-{platform}-",
     ".{ext}",
 ])
 
-_WINDOWS_DEPENDENCIES = [
-    ("libffi-3.2.1-mingw-w64-x86-64", "2047faedec4ca6bc074e12642ecf3a14545cbb248224ef3637965714d7e7ea5f"),
-    ("msys2-mingw-w64-x86_64-gcc-7.3.0-clang-llvm-lld-6.0.1", "931131ae6545bc8afc497281cbd0a2c39eb2c067f3bfac53a993886fa00ba131"),
-    ("target-toolchain-1-mingw-wasm", "b0e814436eafa9f4971696ecdbbf23a34185500085d6257c46464ef69561101d"),
-    ("target-sysroot-2-wasm", "039958041b364458d652237aaa06c12b89973ef0934819cca9d47299f1a76b64"),
-]
+_WINDOWS_DEPENDENCIES = {
+    "libffi-3.2.1": ("libffi-3.2.1-mingw-w64-x86-64", "2047faedec4ca6bc074e12642ecf3a14545cbb248224ef3637965714d7e7ea5f"),
+    "clang-llvm-6.0.1": ("libffi-3.2.1-mingw-w64-x86-64", "2047faedec4ca6bc074e12642ecf3a14545cbb248224ef3637965714d7e7ea5f"),
+    "target-toolchain-wasm": ("target-toolchain-1-mingw-wasm", "b0e814436eafa9f4971696ecdbbf23a34185500085d6257c46464ef69561101d"),
+    "target-sysroot-wasm": ("target-sysroot-2-wasm", "039958041b364458d652237aaa06c12b89973ef0934819cca9d47299f1a76b64"),
+}
 
-_MACOS_DEPENDENCIES = [
-    ("libffi-3.2.1-3-darwin-macos", "b83357b2d4ad4be9d5466ac3cbf12570928d84109521ab687672ec8ef47d9edc"),
-    ("clang-llvm-6.0.1-darwin-macos", "21b1bfb5d11c07aad7627c121b323202da257ed2276afa6942d4086ab393509a"),
-    ("target-toolchain-3-macos-wasm", "21841134a97e287507d426b1ce767a55416ef4b639ca88b691f125185600ea3d"),
-    ("target-sysroot-2-wasm", "039958041b364458d652237aaa06c12b89973ef0934819cca9d47299f1a76b64"),
-]
+_MACOS_DEPENDENCIES = {
+    "libffi-3.2.1": ("libffi-3.2.1-3-darwin-macos", "b83357b2d4ad4be9d5466ac3cbf12570928d84109521ab687672ec8ef47d9edc"),
+    "clang-llvm-6.0.1": ("clang-llvm-6.0.1-darwin-macos", "21b1bfb5d11c07aad7627c121b323202da257ed2276afa6942d4086ab393509a"),
+    "target-toolchain-wasm": ("target-toolchain-3-macos-wasm", "21841134a97e287507d426b1ce767a55416ef4b639ca88b691f125185600ea3d"),
+    "target-sysroot-wasm": ("target-sysroot-2-wasm", "039958041b364458d652237aaa06c12b89973ef0934819cca9d47299f1a76b64"),
+}
 
-_LINUX_DEPENDENCIES = [
-    ("libffi-3.2.1-2-linux-x86-64", "5608bd3845f28151265ec38554763c32b05fe1c8b53dcd7eef9362c919a13b67"),
-    ("clang-llvm-6.0.1-linux-x86-64", "93a23e63cbf16bf24cbc52e9fef1291be5c4796559d90f3918c3c149ee8582bf"),
-    ("target-toolchain-2-linux-wasm", "d5cd155377b3a389430303972ff0f85b9550895b7b088a26fb9c51cb8538387c"),
-    ("target-sysroot-2-wasm", "039958041b364458d652237aaa06c12b89973ef0934819cca9d47299f1a76b64"),
-]
+_LINUX_DEPENDENCIES = {
+    "libffi-3.2.1": ("libffi-3.2.1-2-linux-x86-64", "5608bd3845f28151265ec38554763c32b05fe1c8b53dcd7eef9362c919a13b67"),
+    "clang-llvm-6.0.1": ("clang-llvm-6.0.1-linux-x86-64", "93a23e63cbf16bf24cbc52e9fef1291be5c4796559d90f3918c3c149ee8582bf"),
+    "target-toolchain-wasm": ("target-toolchain-2-linux-wasm", "d5cd155377b3a389430303972ff0f85b9550895b7b088a26fb9c51cb8538387c"),
+    "target-sysroot-wasm": ("target-sysroot-2-wasm", "039958041b364458d652237aaa06c12b89973ef0934819cca9d47299f1a76b64"),
+}
 
 PLATFORMS = {
     "windows": {
@@ -50,29 +48,71 @@ PLATFORMS = {
     },
 }
 
-def get_dependencies(target):
-    return PLATFORMS[target]["deps"]
+def to_platform(os_name):
+    """Convert an os-name string into a Kotlin-Native platform."""
+    os_name = os_name.lower().replace(" ", "")
+    if os_name.startswith("macos"):
+        return "macos"
+    elif os_name.startswith("windows"):
+        return "windows"
+    else:
+        return "linux"
 
-def kotlin_native_repo():
-    """Downloads the kotlin-native release and "installs" the kotlinc compiler.
+KOTLIN_NATIVE_BUILD_FILE = """
+# TODO(alxr): Replace wrapper script with rule here.
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+  name = "all_artifacts",
+  srcs = glob(["**/*"]),
+)
+"""
+
+def _impl(repository_ctx):
+    os_name = to_platform(repository_ctx.os.name)
+
+    src_path = repository_ctx.path()
+
+    repository_ctx.execute(["mkdir", "-p", src_path])
+    repository_ctx.execute(["mkdir", "-p", "{0}/dependencies".format(src_path)])
+    repository_ctx.execute(["mkdir", "-p", "{0}/cache".format(src_path)])
+
+    plat = PLATFORMS[os_name]
+
+    repository_ctx.download_and_extract(
+        url = _repo_tmpl.format(**plat),
+        output = repository_ctx.path(
+            "{0}/kotlin-native-{1}".format(
+                src_path,
+                KOTLIN_NATIVE_VERSION,
+            ),
+        ),
+        type = plat["ext"],
+        sha256 = plat["sha"],
+    )
+
+    deps_names = []
+    for key, (dep, sha) in plat["deps"].items():
+        repository_ctx.download_and_extract(
+            output = src_path,
+            url = "https://bintray.com/jetbrains/kotlin-native-dependencies/download_file?file_path={0}.{ext}".format(dep, **plat),
+            type = plat["ext"],
+            sha256 = sha,
+        )
+        deps_names.append(dep)
+        alias = repository_ctx.path("{0}/dependencies/{1}".format(src_path, dep))
+        repository_ctx.symlink("{0}/{1}".format(src_path, dep), alias)
+
+    repository_ctx.file("{0}/dependencies/.extracted".format(src_path), "\n".join(deps_names))
+    repository_ctx.file("{0}/cache/.lock".format(src_path), "")
+
+    repository_ctx.file("{0}/BUILD".format(src_path), KOTLIN_NATIVE_BUILD_FILE)
+
+kotlin_native_repo = repository_rule(
+    implementation = _impl,
+    doc = """Downloads the kotlin-native release and "installs" the kotlinc compiler.
 
     Kotlin-Native is used to compile Kotlin into Wasm. This rule downloads the latest
     experimental repository and makes the kotlinc compiler available for BUILD rules.
-    """
-    for p in PLATFORMS.values():
-        http_archive(
-            name = "kotlin_native_{0}".format(p["platform"]),
-            url = _repo_tmpl.format(**p),
-            type = p["ext"],
-            sha256 = p["sha"],
-            build_file = "//build_defs/kotlin_native:kotlinc.BUILD",
-        )
-
-        for x, sha in p["deps"]:
-            http_archive(
-                name = x,
-                urls = ["https://bintray.com/jetbrains/kotlin-native-dependencies/download_file?file_path={0}.{ext}".format(x, **p)],
-                type = p["ext"],
-                sha256 = sha,
-                build_file = "//build_defs/kotlin_native:kotlinc.BUILD",
-            )
+    """,
+)

--- a/build_defs/kotlin_native/repo.bzl
+++ b/build_defs/kotlin_native/repo.bzl
@@ -49,7 +49,14 @@ PLATFORMS = {
 }
 
 def to_platform(os_name):
-    """Convert an os-name string into a Kotlin-Native platform."""
+    """Convert an os-name string into a Kotlin-Native platform.
+
+    Args:
+      os_name: name of the host OS from the repository ctx.
+
+    Returns:
+      Option from PLATFORMS.
+    """
     os_name = os_name.lower().replace(" ", "")
     if os_name.startswith("macos"):
         return "macos"

--- a/build_defs/kotlin_native/repo.bzl
+++ b/build_defs/kotlin_native/repo.bzl
@@ -84,26 +84,26 @@ def _impl(repository_ctx):
     repository_ctx.execute(["mkdir", "-p", "{0}/dependencies".format(src_path)])
     repository_ctx.execute(["mkdir", "-p", "{0}/cache".format(src_path)])
 
-    plat = PLATFORMS[os_name]
+    platform = PLATFORMS[os_name]
 
     repository_ctx.download_and_extract(
-        url = _repo_tmpl.format(**plat),
+        url = _repo_tmpl.format(**platform),
         output = repository_ctx.path(
             "{0}/kotlin-native-{1}".format(
                 src_path,
                 KOTLIN_NATIVE_VERSION,
             ),
         ),
-        type = plat["ext"],
-        sha256 = plat["sha"],
+        type = platform["ext"],
+        sha256 = platform["sha"],
     )
 
     deps_names = []
-    for key, (dep, sha) in plat["deps"].items():
+    for key, (dep, sha) in platform["deps"].items():
         repository_ctx.download_and_extract(
             output = src_path,
-            url = "https://bintray.com/jetbrains/kotlin-native-dependencies/download_file?file_path={0}.{ext}".format(dep, **plat),
-            type = plat["ext"],
+            url = "https://bintray.com/jetbrains/kotlin-native-dependencies/download_file?file_path={0}.{ext}".format(dep, **platform),
+            type = platform["ext"],
             sha256 = sha,
         )
         deps_names.append(dep)


### PR DESCRIPTION
After this change, the workplace rule will be able to detect the host platform and only download platform-specific artifacts.  

This will have a few productivity impacts to the project: 
- This can help us create a smaller docker image for the GC run that still has cached kotlin-native artifacts.
- This should make local builds from clean faster.
- This reduces the downloading surface area, making flakes less likely. 

As a side-effect of this change, a lot of the kotlin-native tool logic has been simplified. I didn't get this far, but it's possible that we could replace the `kotlinc_wrapper` with logic from the custom repo_rule. 