### PR TITLE
Some cleanup to schema2kotlin in prep for tuples

### DIFF
--- a/src/tools/schema2cpp.ts
+++ b/src/tools/schema2cpp.ts
@@ -109,7 +109,7 @@ protected:
 `;
   }
 
-  generateTestHarness(particle: ParticleSpec): string {
+  generateTestHarness(particle: ParticleSpec, nodes: SchemaNode[]): string {
     throw new Error('Test Harness generation is not available for CPP');
   }
 }
@@ -212,8 +212,8 @@ class CppGenerator implements ClassGenerator {
   }
 
   generate(schemaHash: string, fieldCount: number): string {
-    const {name, aliases} = this.node;
-
+    const name = this.node.name;
+    const aliases = this.node.sources.map(s => s.fullName);
     // Template constructor allows implicit type slicing from appropriately matching entities.
     let templateCtor = '';
     if (this.ctor.length) {
@@ -228,7 +228,7 @@ class CppGenerator implements ClassGenerator {
     // 'using' declarations for equivalent entity types.
     let aliasComment = '';
     let usingDecls = '';
-    if (aliases.length) {
+    if (aliases.length > 1) {
       aliasComment = `\n// Aliased as ${aliases.join(', ')}`;
       usingDecls = '\n' + aliases.map(a => `using ${a} = ${name};`).join('\n') + '\n';
     }

--- a/src/tools/tests/schema2graph-test.ts
+++ b/src/tools/tests/schema2graph-test.ts
@@ -21,25 +21,18 @@ interface NodeInfo {
 function convert(graph: SchemaGraph) {
   const nodes: NodeInfo[] = [];
   const aliases: Dictionary<string[]> = {};
+  const fullName = (node: SchemaNode) => node.sources[0].fullName;
   for (const node of graph.walk()) {
     nodes.push({
-      name: node.name,
-      parents: node.parents.map(p => p.name).sort().join(', '),
-      children: node.children.map(p => p.name).sort().join(', '),
+      name: fullName(node),
+      parents: node.parents.map(p => fullName(p)).sort().join(', '),
+      children: node.children.map(p => fullName(p)).sort().join(', '),
     });
-    if (node.aliases.length) {
-      aliases[node.name] = [...node.aliases].sort();
+    if (node.sources.length) {
+      aliases[fullName(node)] = [...node.sources.map(p => p.fullName)].sort();
     }
   }
   return {nodes, aliases};
-}
-
-function dummyNameGenerator(node: SchemaNode, i: number) {
-  return `${node.particleName}_${node.connections[0]}`;
-}
-
-function dummyAliasGenerator(node: SchemaNode): string[] {
-  return node.connections.map((s: string) => `${node.particleName}_${s}`);
 }
 
 describe('schema2graph', () => {
@@ -49,7 +42,7 @@ describe('schema2graph', () => {
         root: consumes Slot
           tile: provides Slot
     `);
-    const graph = new SchemaGraph(manifest.particles[0], dummyNameGenerator, dummyAliasGenerator);
+    const graph = new SchemaGraph(manifest.particles[0]);
     assert.isEmpty([...graph.walk()]);
   });
 
@@ -60,7 +53,7 @@ describe('schema2graph', () => {
         h2: reads * {a: Text, b: Text}
         h3: reads * {a: Text, b: Text, c: Text}
     `);
-    const res = convert(new SchemaGraph(manifest.particles[0], dummyNameGenerator, dummyAliasGenerator));
+    const res = convert(new SchemaGraph(manifest.particles[0]));
     assert.deepStrictEqual(res.nodes, [
       {name: 'L_H1', parents: '',     children: 'L_H2'},
       {name: 'L_H2', parents: 'L_H1', children: 'L_H3'},
@@ -81,7 +74,7 @@ describe('schema2graph', () => {
         h3: reads * {a: Text, c: Text}              //   4
         h4: reads * {a: Text, b: Text, c: Text}
     `);
-    const res = convert(new SchemaGraph(manifest.particles[0], dummyNameGenerator, dummyAliasGenerator));
+    const res = convert(new SchemaGraph(manifest.particles[0]));
     assert.deepStrictEqual(res.nodes, [
       {name: 'D_H1', parents: '',           children: 'D_H2, D_H3'},
       {name: 'D_H2', parents: 'D_H1',       children: 'D_H4'},
@@ -106,7 +99,7 @@ describe('schema2graph', () => {
         d2: reads * {a: Text, b: Text}
         d4: reads * {a: Text, b: Text, c: Text}
     `);
-    const res = convert(new SchemaGraph(manifest.particles[0], dummyNameGenerator, dummyAliasGenerator));
+    const res = convert(new SchemaGraph(manifest.particles[0]));
     assert.deepStrictEqual(res.nodes, [
       {name: 'A_H1',       parents: '',                 children: 'A_H2, A_H3'},
       {name: 'A_H2', parents: 'A_H1',             children: 'A_H4'},
@@ -135,7 +128,7 @@ describe('schema2graph', () => {
         v8: reads * {c: URL, d: URL}
         v9: reads * {a: URL, b: URL, c: URL, d: URL}
     `);
-    const res = convert(new SchemaGraph(manifest.particles[0], dummyNameGenerator, dummyAliasGenerator));
+    const res = convert(new SchemaGraph(manifest.particles[0]));
 
     // Traversal is breadth-first; nodes within a row are in the same order as in the manifest.
     assert.deepStrictEqual(res.nodes, [
@@ -179,7 +172,7 @@ describe('schema2graph', () => {
         h4: reads * {a: Text, b: Text, d: Text}
         h5: reads * {a: Text, b: Text, c: Text, d: Text, e: Text}
     `);
-    const res = convert(new SchemaGraph(manifest.particles[0], dummyNameGenerator, dummyAliasGenerator));
+    const res = convert(new SchemaGraph(manifest.particles[0]));
     assert.deepStrictEqual(res.nodes, [
       {name: 'M_H1', parents: '',           children: 'M_H3, M_H4'},
       {name: 'M_H2', parents: '',           children: 'M_H3, M_H4'},
@@ -215,7 +208,7 @@ describe('schema2graph', () => {
         h4: reads * {a: Text, b: Text, c: Text}
         h5: reads * {a: Text, b: Text, c: Text, x: Text}
     `);
-    const res = convert(new SchemaGraph(manifest.particles[0], dummyNameGenerator, dummyAliasGenerator));
+    const res = convert(new SchemaGraph(manifest.particles[0]));
     assert.deepStrictEqual(res.nodes, [
       {name: 'J_H1', parents: '',           children: 'J_H3'},
       {name: 'J_H2', parents: '',           children: 'J_H5'},
@@ -243,7 +236,7 @@ describe('schema2graph', () => {
         oldness: reads writes [Data {n: Number}]
         mainAddress: writes &* {u: URL}
     `);
-    const res = convert(new SchemaGraph(manifest.particles[0], dummyNameGenerator, dummyAliasGenerator));
+    const res = convert(new SchemaGraph(manifest.particles[0]));
     assert.deepStrictEqual(res.nodes, [
       {name: 'Test_Name',        parents: '', children: ''},
       {name: 'Test_Age',         parents: '', children: ''},
@@ -266,7 +259,7 @@ describe('schema2graph', () => {
         h3: reads [&* {a: Text, b: Text, c: Text}]
         h4: reads * {a: Text, b: Text, r: [&* {d: Text}]}
     `);
-    const res = convert(new SchemaGraph(manifest.particles[0], dummyNameGenerator, dummyAliasGenerator));
+    const res = convert(new SchemaGraph(manifest.particles[0]));
     assert.deepStrictEqual(res.nodes, [
       {name: 'W_H1',   parents: '',     children: 'W_H2'},
       {name: 'W_H4_R', parents: '',     children: ''},
@@ -308,7 +301,7 @@ describe('schema2graph', () => {
         h5: reads * {a: Text, b: Text, d: Text}
         h3: reads * {a: Text, b: Text}
     `);
-    const res = convert(new SchemaGraph(manifest.particles[0], dummyNameGenerator, dummyAliasGenerator));
+    const res = convert(new SchemaGraph(manifest.particles[0]));
     assert.deepStrictEqual(res.nodes, [
       {name: 'X_H1', parents: '',           children: 'X_H3'},
       {name: 'X_H2', parents: '',           children: 'X_H4, X_H5'},
@@ -339,7 +332,7 @@ describe('schema2graph', () => {
         data: reads * {outer: &* {t: Text, inner: &* {u: URL}}}
         dupe: reads * {t: Text, inner: &* {u: URL}}
     `);
-    const graph = new SchemaGraph(manifest.particles[0], dummyNameGenerator, dummyAliasGenerator);
+    const graph = new SchemaGraph(manifest.particles[0]);
     const res = convert(graph);
     assert.deepStrictEqual(res.nodes.map(x => x.name), [
       'Names_Data_Outer_Inner', 'Names_Data_Outer', 'Names_Data'
@@ -360,7 +353,7 @@ describe('schema2graph', () => {
         h2: reads * {a: Text, r: &* {b: Text}}
         h3: reads * {a: Text, r: &* {b: Text}, c: Text}
     `);
-    const res = convert(new SchemaGraph(manifest.particles[0], dummyNameGenerator, dummyAliasGenerator));
+    const res = convert(new SchemaGraph(manifest.particles[0]));
     assert.deepStrictEqual(res.nodes, [
       {name: 'N_H1',   parents: '',     children: 'N_H2'},
       {name: 'N_H2_R', parents: '',     children: ''},
@@ -387,7 +380,7 @@ describe('schema2graph', () => {
         h2: reads * {a: Text}
         h3: reads * {v: &* {a: Text}}
     `);
-    const res = convert(new SchemaGraph(manifest.particles[0], dummyNameGenerator, dummyAliasGenerator));
+    const res = convert(new SchemaGraph(manifest.particles[0]));
     assert.deepStrictEqual(res.nodes, [
       {name: 'Q_H1_R_T_U', parents: '', children: ''},
       {name: 'Q_H3',       parents: '', children: ''},
@@ -416,7 +409,7 @@ describe('schema2graph', () => {
         h2: reads * {a: Text, b: Text, c: Text}
         h3: reads * {r: &* {a: Text, b: Text}, s: &* {a: Text, c: Text}}
     `);
-    const res = convert(new SchemaGraph(manifest.particles[0], dummyNameGenerator, dummyAliasGenerator));
+    const res = convert(new SchemaGraph(manifest.particles[0]));
     assert.deepStrictEqual(res.nodes, [
       {name: 'I_H1',   parents: '',               children: 'I_H3_R, I_H3_S'},
       {name: 'I_H3_R', parents: 'I_H1',           children: 'I_H2'},
@@ -442,7 +435,7 @@ describe('schema2graph', () => {
         h4: reads * {a: Text, d: Text, e: Text}
         h5: reads * {b: Text, c: Text, v: &* {d: Text}}
     `);
-    const res = convert(new SchemaGraph(manifest.particles[0], dummyNameGenerator, dummyAliasGenerator));
+    const res = convert(new SchemaGraph(manifest.particles[0]));
     assert.deepStrictEqual(res.nodes, [
       {name: 'Y_H1_R',     parents: '',                   children: 'Y_H2, Y_H4'},
       {name: 'Y_H3_T_U_V', parents: '',                   children: 'Y_H4'},
@@ -478,7 +471,7 @@ describe('schema2graph', () => {
         h3: reads * {a: Text, b: Text}
         h4: reads * {a: Text, b: Text, c: Text}
     `);
-    const res = convert(new SchemaGraph(manifest.particles[0], dummyNameGenerator, dummyAliasGenerator));
+    const res = convert(new SchemaGraph(manifest.particles[0]));
     assert.deepStrictEqual(res.nodes, [
       {name: 'V_H1',       parents: '',     children: 'V_H2, V_H3'},
       {name: 'V_H3',       parents: 'V_H1', children: 'V_H2_R'},
@@ -514,7 +507,7 @@ describe('schema2graph', () => {
         // Separate starting node with co-descendant reference
         k2: reads * {j: &* {n: Number, o: Number}}
     `);
-    const res = convert(new SchemaGraph(manifest.particles[0], dummyNameGenerator, dummyAliasGenerator));
+    const res = convert(new SchemaGraph(manifest.particles[0]));
     assert.deepStrictEqual(res.nodes, [
       {name: 'R_H1_R',     parents: '',           children: 'R_H2_S, R_H4_V'},
       {name: 'R_K1_I',     parents: '',           children: 'R_K2_J'},

--- a/src/tools/tests/schema2wasm-test.ts
+++ b/src/tools/tests/schema2wasm-test.ts
@@ -54,7 +54,7 @@ class Schema2Mock extends Schema2Base {
     return '';
   }
 
-  generateTestHarness(particle: ParticleSpec): string {
+  generateTestHarness(particle: ParticleSpec, nodes: SchemaNode[]): string {
     return '';
   }
 }


### PR DESCRIPTION
A cleanup around codegenned entity naming that I pulled ouf of my work on enabling tuples for handle connections.

Major changes:
1) Introduces `SchemaSource` class, which described where the schema was found. Currently its main contribution is to store the path of field names, which is filled for schemas found via references. Before this PR this information was stored as `_` concatenated field names attaches to the connection names in the `connections` field. Soon for tuples this path will also contain indexes in tuples.
2) Centralized entity name generation into SchemaNode / SchemaSource classes. No more concatenation of strings with `_` everywhere - this is needed as with tuples there is no top level entity that is generated with the `paticleName_connName` pattern.
3) Kills off the callbacks from schema2graph into schema2kotlin / schema2base / schema2cpp to assign names (yay!). Now the logic for when to generate aliases lives directly in schema2kotlin and schema2cpp, as it should.
