### PR TITLE
Memory optimization: Remove one duplicate data copy at storage client

### DIFF
--- a/java/arcs/core/data/util/ReferencablePrimitive.kt
+++ b/java/arcs/core/data/util/ReferencablePrimitive.kt
@@ -31,8 +31,9 @@ data class ReferencablePrimitive<T>(
     val valueRepr: String = value.toString()
 ) : Referencable {
     // TODO: consider other 'serialization' mechanisms.
-    override val id: ReferenceId =
-        "Primitive<${primitiveKClassMap.getOrElse(klass, klass::toString)}>($valueRepr)"
+    private val klassRepr = "Primitive<${primitiveKClassMap.getOrElse(klass, klass::toString)}>"
+    override val id: ReferenceId
+        get() = "$klassRepr($valueRepr)"
 
     override fun toString(): String = "Primitive($valueRepr)"
 


### PR DESCRIPTION
Before a storage proxy reaches its death (end of lifecycle), we should keep runtime memory usage as less as possible. We have very strict criteria of memory footprint: only one single data copy is allowed in client's storage proxy.