### PR TITLE
Memory optimization: Prevent kotlin flow from holding data copies

### DIFF
--- a/java/arcs/sdk/android/storage/ServiceStore.kt
+++ b/java/arcs/sdk/android/storage/ServiceStore.kt
@@ -40,7 +40,6 @@ import arcs.sdk.android.storage.service.ConnectionFactory
 import arcs.sdk.android.storage.service.DefaultConnectionFactory
 import arcs.sdk.android.storage.service.StorageServiceConnection
 import kotlin.coroutines.CoroutineContext
-import kotlinx.atomicfu.AtomicRef
 import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
@@ -192,11 +191,11 @@ class ServiceStore<Data : CrdtData, Op : CrdtOperation, ConsumerData>(
         val result = DeferredResult(coroutineContext)
         // Trick: make an indirect access to the message to keep kotlin flow
         // from holding the entire message that might encapsulate a large size data.
-        val messageRef: AtomicRef<ProxyMessage<Data, Op, ConsumerData>?> = atomic(message)
+        var messageRef: ProxyMessage<Data, Op, ConsumerData>? = message
         outgoingMessages.incrementAndGet()
         send {
-            service.sendProxyMessage(messageRef.value!!.toProto().toByteArray(), result)
-            messageRef.value = null
+            service.sendProxyMessage(messageRef!!.toProto().toByteArray(), result)
+            messageRef = null
         }
         // Just return false if the message couldn't be applied.
         return try {


### PR DESCRIPTION
Before a storage proxy reaches its death (end of lifecycle), we should keep runtime memory usage as less as possible. Observed kotlin flow would capture/hold variables which might encapsulate a large size of data resulting in long memory footprint.

The PR eliminates the memory holding chain:
<img width="695" alt="Screen Shot 2020-05-21 at 6 03 10 PM" src="https://user-images.githubusercontent.com/55406481/82622631-2adf5a80-9b93-11ea-9bde-00dcc2353487.png">
