### PR TITLE
Some fixes for cleardata: introduce a test connection for the manager…

### DIFF
--- a/java/arcs/android/storage/service/StorageServiceManager.kt
+++ b/java/arcs/android/storage/service/StorageServiceManager.kt
@@ -13,6 +13,9 @@ package arcs.android.storage.service
 
 import arcs.core.host.ArcHostManager
 import arcs.core.storage.DriverFactory
+import arcs.core.storage.StorageKey
+import arcs.core.storage.Store
+import java.util.concurrent.ConcurrentHashMap
 import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.runBlocking
@@ -23,7 +26,9 @@ import kotlinx.coroutines.runBlocking
  */
 class StorageServiceManager(
     /** [CoroutineContext] on which to build one specific to this [StorageServiceManager]. */
-    parentCoroutineContext: CoroutineContext
+    parentCoroutineContext: CoroutineContext,
+    /** The stores managed by StorageService. */
+    val stores: ConcurrentHashMap<StorageKey, Store<*, *, *>>
 ) : IStorageServiceManager.Stub() {
 
     /** The local [CoroutineContext]. */
@@ -33,6 +38,7 @@ class StorageServiceManager(
         runBlocking(coroutineContext) {
             ArcHostManager.pauseAllHostsFor {
                 DriverFactory.removeAllEntities().join()
+                stores.clear()
             }
         }
         resultCallback.onResult(null)

--- a/java/arcs/core/host/AbstractArcHost.kt
+++ b/java/arcs/core/host/AbstractArcHost.kt
@@ -110,6 +110,7 @@ abstract class AbstractArcHost(
     }
 
     override suspend fun unpause() {
+        stores.reset()
         paused = false
         pausedArcs.forEach {
             try {

--- a/java/arcs/core/storage/StoreManager.kt
+++ b/java/arcs/core/storage/StoreManager.kt
@@ -38,4 +38,5 @@ class StoreManager {
             stores.values.forEach { it.waitForActiveIdle() }
         }
     }
+    suspend fun reset() = storesMutex.withLock { stores.clear() }
 }

--- a/java/arcs/core/storage/StoreManager.kt
+++ b/java/arcs/core/storage/StoreManager.kt
@@ -38,5 +38,6 @@ class StoreManager {
             stores.values.forEach { it.waitForActiveIdle() }
         }
     }
+
     suspend fun reset() = storesMutex.withLock { stores.clear() }
 }

--- a/java/arcs/core/storage/StoreManager.kt
+++ b/java/arcs/core/storage/StoreManager.kt
@@ -39,5 +39,8 @@ class StoreManager {
         }
     }
 
+    /**
+     * Drops all [Store] instances.
+     */
     suspend fun reset() = storesMutex.withLock { stores.clear() }
 }

--- a/java/arcs/core/storage/driver/Volatile.kt
+++ b/java/arcs/core/storage/driver/Volatile.kt
@@ -102,7 +102,8 @@ data class VolatileDriverProvider(private val arcId: ArcId) : DriverProvider {
 
     override suspend fun send(data: Data, version: Int): Boolean {
         log.debug { "send($data, $version)" }
-        val (success, newEntry) = memory.update<Data>(storageKey) { currentValue ->
+        val (success, newEntry) = memory.update<Data>(storageKey) { optCurrentValue ->
+            val currentValue = optCurrentValue ?: VolatileEntry<Data>()
             val currentVersion = currentValue!!.version
             // If the new version isn't immediately after this one, return false.
             if (currentVersion != version - 1) {

--- a/java/arcs/core/storage/driver/Volatile.kt
+++ b/java/arcs/core/storage/driver/Volatile.kt
@@ -104,7 +104,7 @@ data class VolatileDriverProvider(private val arcId: ArcId) : DriverProvider {
         log.debug { "send($data, $version)" }
         val (success, newEntry) = memory.update<Data>(storageKey) { optCurrentValue ->
             val currentValue = optCurrentValue ?: VolatileEntry<Data>()
-            val currentVersion = currentValue!!.version
+            val currentVersion = currentValue.version
             // If the new version isn't immediately after this one, return false.
             if (currentVersion != version - 1) {
                 log.debug { "current entry version = ${currentValue.version}, incoming = $version" }

--- a/java/arcs/core/storage/driver/Volatile.kt
+++ b/java/arcs/core/storage/driver/Volatile.kt
@@ -210,7 +210,7 @@ data class VolatileDriverProvider(private val arcId: ArcId) : DriverProvider {
     }
 
     /** Clears everything from storage. */
-    fun clear() = entries.clear()
+    fun clear() = synchronized(lock) { entries.clear() }
 
     /* internal */ fun addListener(listener: (StorageKey, Any?) -> Unit) = synchronized(lock) {
         listeners.add(listener)

--- a/java/arcs/sdk/android/storage/service/StorageService.kt
+++ b/java/arcs/sdk/android/storage/service/StorageService.kt
@@ -94,7 +94,7 @@ open class StorageService : ResurrectorService() {
         log.debug { "onBind: $intent" }
 
         if (intent.action == MANAGER_ACTION) {
-            return StorageServiceManager(coroutineContext)
+            return StorageServiceManager(coroutineContext, stores)
         }
 
         val parcelableOptions = requireNotNull(

--- a/java/arcs/sdk/android/storage/service/StorageServiceConnection.kt
+++ b/java/arcs/sdk/android/storage/service/StorageServiceConnection.kt
@@ -32,6 +32,8 @@ import kotlinx.coroutines.Job
 typealias ConnectionFactory =
         (StoreOptions<*, *, *>, ParcelableCrdtType) -> StorageServiceConnection
 
+typealias ManagerConnectionFactory = () -> StorageServiceConnection
+
 /**
  * Returns a default [ConnectionFactory] implementation which uses the provided [context] to bind to
  * the [StorageService] and the provided [coroutineContext] as the parent for
@@ -48,17 +50,17 @@ fun DefaultConnectionFactory(
 }
 
 /**
- * Returns a [Connection] implementation which uses the provided [context] to bind to
+ * Returns a [ManagerConnectionFactory] implementation which uses the provided [context] to bind to
  * the [StorageService] and the provided [coroutineContext] as the parent for
  * [StorageServiceConnection.connectAsync]'s [Deferred] return value.
  */
 @Suppress("FunctionName")
 @ExperimentalCoroutinesApi
-fun GetManagerConnection(
+fun ManagerConnectionFactory(
     context: Context,
     bindingDelegate: StorageServiceBindingDelegate = StorageServiceManagerBindingDelegate(context),
     coroutineContext: CoroutineContext = Dispatchers.Default
-): StorageServiceConnection = StorageServiceConnection(bindingDelegate, null, coroutineContext)
+): ManagerConnectionFactory = { StorageServiceConnection(bindingDelegate, null, coroutineContext) }
 
 /** Defines an object capable of binding-to and unbinding-from the [StorageService]. */
 interface StorageServiceBindingDelegate {

--- a/java/arcs/sdk/android/storage/service/StorageServiceConnection.kt
+++ b/java/arcs/sdk/android/storage/service/StorageServiceConnection.kt
@@ -50,6 +50,20 @@ fun DefaultConnectionFactory(
 }
 
 /**
+ * Returns a [Connection] implementation which uses the provided [context] to bind to
+ * the [StorageService] and the provided [coroutineContext] as the parent for
+ * [StorageServiceConnection.connectAsync]'s [Deferred] return value.
+ */
+@Suppress("FunctionName")
+@ExperimentalCoroutinesApi
+@Deprecated("Use ManagerConnectionFactory")
+fun GetManagerConnection(
+    context: Context,
+    bindingDelegate: StorageServiceBindingDelegate = StorageServiceManagerBindingDelegate(context),
+    coroutineContext: CoroutineContext = Dispatchers.Default
+): StorageServiceConnection = StorageServiceConnection(bindingDelegate, null, coroutineContext)
+
+/**
  * Returns a [ManagerConnectionFactory] implementation which uses the provided [context] to bind to
  * the [StorageService] and the provided [coroutineContext] as the parent for
  * [StorageServiceConnection.connectAsync]'s [Deferred] return value.

--- a/java/arcs/sdk/android/storage/service/StorageServiceConnection.kt
+++ b/java/arcs/sdk/android/storage/service/StorageServiceConnection.kt
@@ -56,7 +56,10 @@ fun DefaultConnectionFactory(
  */
 @Suppress("FunctionName")
 @ExperimentalCoroutinesApi
-@Deprecated("Use ManagerConnectionFactory")
+@Deprecated(
+    "Use ManagerConnectionFactory to get a Factory",
+    ReplaceWith("ManagerConnectionFactory(context, bindingDelegate, coroutineContext)")
+)
 fun GetManagerConnection(
     context: Context,
     bindingDelegate: StorageServiceBindingDelegate = StorageServiceManagerBindingDelegate(context),

--- a/javatests/arcs/android/storage/service/StorageServiceManagerTest.kt
+++ b/javatests/arcs/android/storage/service/StorageServiceManagerTest.kt
@@ -24,6 +24,7 @@ import arcs.core.entity.SchemaRegistry
 import arcs.core.entity.awaitReady
 import arcs.core.host.EntityHandleManager
 import arcs.core.storage.StorageKey
+import arcs.core.storage.Store
 import arcs.core.storage.StoreWriteBack
 import arcs.core.storage.driver.RamDisk
 import arcs.core.storage.keys.DatabaseStorageKey
@@ -36,8 +37,6 @@ import arcs.jvm.host.JvmSchedulerProvider
 import arcs.jvm.util.testutil.FakeTime
 import arcs.sdk.android.storage.AndroidDriverAndKeyConfigurator
 import com.google.common.truth.Truth.assertThat
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
@@ -46,6 +45,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.util.concurrent.ConcurrentHashMap
 import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.coroutines.coroutineContext
 
@@ -56,7 +56,8 @@ class StorageServiceManagerTest {
     @get:Rule
     val log = LogRule()
 
-    private suspend fun buildManager() = StorageServiceManager(coroutineContext)
+    private suspend fun buildManager() =
+        StorageServiceManager(coroutineContext, ConcurrentHashMap<StorageKey, Store<*, *, *>>())
     private val time = FakeTime()
     private val scheduler = JvmSchedulerProvider(EmptyCoroutineContext).invoke("test")
     private val ramdiskKey = ReferenceModeStorageKey(

--- a/javatests/arcs/core/host/LifecycleTest.kt
+++ b/javatests/arcs/core/host/LifecycleTest.kt
@@ -236,6 +236,8 @@ class LifecycleTest {
                 "onReady:1.1:[first]",
                 "data.onUpdate:2.2",
                 "onUpdate:2.2:[first]",
+                "data.onUpdate:2.2",
+                "onUpdate:2.2:[first]",
                 "list.onUpdate:[first, second]",
                 "onUpdate:2.2:[first, second]",
                 "onShutdown"


### PR DESCRIPTION
… (in the same way as the default connection). Reset the stores when unpausing an allocator. Deal better with nulls in volatile memory (values will be null after cleardata). This is in preparation for an e2e g3 test.