### PR TITLE
Adds "implication" DFA checks, of the form `(A => B)`

### DIFF
--- a/java/arcs/core/data/proto/manifest.proto
+++ b/java/arcs/core/data/proto/manifest.proto
@@ -230,11 +230,16 @@ message InformationFlowLabelProto {
     message Not {
       Predicate predicate = 1;
     }
+    message Implies {
+      Predicate antecedent = 1;
+      Predicate consequent = 2;
+    }
     oneof predicate {
       InformationFlowLabelProto label = 1;
       And and = 2;
       Or or = 3;
       Not not = 4;
+      Implies implies = 5;
     }
   }
 

--- a/src/dataflow/analysis/tests/analysis-test.ts
+++ b/src/dataflow/analysis/tests/analysis-test.ts
@@ -1436,6 +1436,123 @@ describe('FlowGraph validation', () => {
     });
   });
 
+  describe(`checks using the 'implies' operator`, () => {
+    it('succeeds when antecedent is not met', async () => {
+      const graph = await buildFlowGraph(`
+        particle P1
+          output: writes Foo {}
+          claim output is t2
+        particle P2
+          inputToCheck: reads Foo {}
+          check inputToCheck (is t1 => is t2)
+        recipe R
+          P1
+            output: writes h
+          P2
+            inputToCheck: reads h
+      `);
+      markParticlesWithIngress(graph, 'P1');
+      assert.isTrue(validateGraph(graph).isValid);
+    });
+
+    it('fails when antecedent is met but consequent is not', async () => {
+      const graph = await buildFlowGraph(`
+        particle P1
+          output: writes Foo {}
+          claim output is t1
+        particle P2
+          inputToCheck: reads Foo {}
+          check inputToCheck (is t1 => is t2)
+        recipe R
+          P1
+            output: writes h
+          P2
+            inputToCheck: reads h
+      `);
+      markParticlesWithIngress(graph, 'P1');
+      assertGraphFailures(graph, [
+        `'check inputToCheck (is t1 => is t2)' failed for path: P1.output -> P2.inputToCheck`,
+      ]);
+    });
+
+    it('succeeds when both antecedent and consequent are met', async () => {
+      const graph = await buildFlowGraph(`
+        particle P1
+          output: writes Foo {}
+          claim output is t1 and is t2
+        particle P2
+          inputToCheck: reads Foo {}
+          check inputToCheck (is t1 => is t2)
+        recipe R
+          P1
+            output: writes h
+          P2
+            inputToCheck: reads h
+      `);
+      markParticlesWithIngress(graph, 'P1');
+      assert.isTrue(validateGraph(graph).isValid);
+    });
+
+    it(`handles complex nesting`, async () => {
+      const validateCondition = async (checkCondition: string) => {
+        const graph = await buildFlowGraph(`
+          particle P1
+            output: writes Foo {}
+            claim output is trusted and is private
+          particle P2
+            trustedSource: reads Foo {}
+            inputToCheck: reads Foo {}
+            check inputToCheck ${checkCondition}
+          recipe R
+            P1
+              output: writes h
+            P2
+              trustedSource: reads h
+              inputToCheck: reads h
+        `);
+        markParticlesWithIngress(graph, 'P1');
+        return validateGraph(graph).isValid;
+      };
+
+      // Basic implications of form A => B, in lots of different permutations.
+      assert.isTrue(await validateCondition('is from handle trustedSource'));
+      assert.isTrue(await validateCondition('(is from handle trustedSource => is trusted)'));
+      assert.isTrue(await validateCondition('(is trusted => is from handle trustedSource)'));
+      assert.isTrue(await validateCondition('(is not from handle trustedSource => is trusted)'));
+      assert.isTrue(await validateCondition('(is not trusted => is from handle trustedSource)'));
+      assert.isTrue(await validateCondition('(is not from handle trustedSource => is not trusted)'));
+      assert.isTrue(await validateCondition('(is not trusted => is not from handle trustedSource)'));
+      assert.isFalse(await validateCondition('(is from handle trustedSource => is someOtherTag)'));
+      assert.isTrue(await validateCondition('(is someOtherTag => is not from handle trustedSource)'));
+
+      // Implications of form A => (B op C).
+      assert.isTrue(await validateCondition('(is from handle trustedSource => (is trusted and is private))'));
+      assert.isTrue(await validateCondition('(is from handle trustedSource => (is trusted or is someOtherTag))'));
+      assert.isFalse(await validateCondition('(is from handle trustedSource => (is trusted and is someOtherTag))'));
+
+      // Implications of form (A or B) => C.
+      assert.isTrue(await validateCondition('((is from handle trustedSource and is trusted) => is private)'));
+      assert.isFalse(await validateCondition('((is from handle trustedSource and is trusted) => is someOtherTag)'));
+      assert.isTrue(await validateCondition('((is from handle trustedSource and is someOtherTag) => is yetAnotherTag)'));
+      assert.isTrue(await validateCondition('((is from handle trustedSource or is someOtherTag) => is private)'));
+      assert.isFalse(await validateCondition('((is from handle trustedSource or is someOtherTag) => is yetAnotherTag)'));
+
+      // Implications of form (A => B) => C.
+      assert.isTrue(await validateCondition('((is from handle trustedSource => is trusted) => is private)'));
+      assert.isFalse(await validateCondition('((is from handle trustedSource => is trusted) => is someOtherTag)'));
+      assert.isTrue(await validateCondition('((is from handle trustedSource => is someOtherTag) => is yetAnotherTag)'));
+      assert.isTrue(await validateCondition('((is someOtherTag => is yetAnotherTag) => is private)'));
+      assert.isFalse(await validateCondition('((is someOtherTag => is yetAnotherTag) => is stillOneMoreTag)'));
+
+      // Implications of form A => (B => C).
+      assert.isTrue(await validateCondition('(is from handle trustedSource => (is trusted => is private))'));
+      assert.isFalse(await validateCondition('(is from handle trustedSource => (is trusted => is someOtherTag))'));
+      assert.isTrue(await validateCondition('(is from handle trustedSource => (is someOtherTag => is yetAnotherTag))'));
+      assert.isTrue(await validateCondition('(is someOtherTag => (is trusted => is private))'));
+      assert.isTrue(await validateCondition('(is someOtherTag => (is yetAnotherTag => is stillOneMoreTag))'));
+    });
+  });
+
   describe('checks on slots', () => {
     it('succeeds for tag checks when the slot consumer has the right tag', async () => {
       const graph = await buildFlowGraph(`

--- a/src/dataflow/analysis/tests/graph-internals-test.ts
+++ b/src/dataflow/analysis/tests/graph-internals-test.ts
@@ -187,6 +187,56 @@ describe('Flow', () => {
       assert.isTrue(checkWithTags('t1', 't3'));
       assert.isFalse(checkWithTags('t2', 't3'));
     });
+
+    it(`handles 'implies' operators`, () => {
+      const check: FlowCheck = {operator: 'implies', children: [
+        {type: 'tag', value: 't1', negated: false},
+        {type: 'tag', value: 't2', negated: false},
+      ]};
+      const flow = new Flow();
+      assert.isTrue(flow.evaluateCheck(check));
+
+      flow.tags.add('t1');
+      assert.isFalse(flow.evaluateCheck(check));
+
+      flow.tags.add('t2');
+      assert.isTrue(flow.evaluateCheck(check));
+    });
+
+    it(`handles nested 'implies' operators`, () => {
+      const check: FlowCheck = {operator: 'implies', children: [
+        {type: 'tag', value: 't1', negated: false},
+        {operator: 'implies', children: [
+          {type: 'tag', value: 't2', negated: false},
+          {type: 'tag', value: 't3', negated: false},
+        ]},
+      ]};
+      const flow = new Flow();
+      assert.isTrue(flow.evaluateCheck(check));
+
+      flow.tags.add('t1');
+      assert.isTrue(flow.evaluateCheck(check));
+
+      flow.tags.add('t2');
+      assert.isFalse(flow.evaluateCheck(check));
+
+      flow.tags.add('t3');
+      assert.isTrue(flow.evaluateCheck(check));
+    });
+
+    it(`rejects 'implies' operations that don't have 2 children`, () => {
+      const flow = new Flow();
+
+      assert.throws(() => flow.evaluateCheck({operator: 'implies', children: [
+        {type: 'tag', value: 't1', negated: false},
+      ]}), `Implications must have exactly 2 children.`);
+
+      assert.throws(() => flow.evaluateCheck({operator: 'implies', children: [
+        {type: 'tag', value: 't1', negated: false},
+        {type: 'tag', value: 't2', negated: false},
+        {type: 'tag', value: 't3', negated: false},
+      ]}), `Implications must have exactly 2 children.`);
+    });
   });
 
   it('can create a copy', () => {

--- a/src/runtime/manifest-ast-nodes.ts
+++ b/src/runtime/manifest-ast-nodes.ts
@@ -290,7 +290,7 @@ export interface ParticleCheckBooleanExpression extends BaseNode {
 
 export type ParticleCheckExpression = ParticleCheckBooleanExpression | ParticleCheckCondition;
 
-export type ParticleCheckCondition = ParticleCheckHasTag | ParticleCheckIsFromHandle | ParticleCheckIsFromOutput | ParticleCheckIsFromStore;
+export type ParticleCheckCondition = ParticleCheckHasTag | ParticleCheckIsFromHandle | ParticleCheckIsFromOutput | ParticleCheckIsFromStore | ParticleCheckImplication;
 
 export interface ParticleCheckHasTag extends BaseNode {
   kind: 'particle-trust-check-has-tag';
@@ -318,6 +318,13 @@ export interface ParticleCheckIsFromStore extends BaseNode {
   checkType: CheckType.IsFromStore;
   isNot: boolean;
   storeRef: StoreReference;
+}
+
+export interface ParticleCheckImplication extends BaseNode {
+  kind: 'particle-trust-check-implication';
+  checkType: CheckType.Implication;
+  antecedent: ParticleCheckCondition;
+  consequent: ParticleCheckCondition;
 }
 
 export interface StoreReference extends BaseNode {

--- a/src/runtime/manifest-parser.pegjs
+++ b/src/runtime/manifest-parser.pegjs
@@ -593,10 +593,22 @@ ParticleCheckExpression
   / '(' whiteSpace? condition:ParticleCheckExpressionBody whiteSpace? ')' { return condition; }
 
 ParticleCheckCondition
-  = ParticleCheckIsFromHandle
+  = ParticleCheckImplication
+  / ParticleCheckIsFromHandle
   / ParticleCheckIsFromStore
   / ParticleCheckIsFromOutput
   / ParticleCheckHasTag
+
+ParticleCheckImplication
+  = '(' whiteSpace? antecedent:ParticleCheckExpression whiteSpace? '=>' whiteSpace? consequent:ParticleCheckExpression whiteSpace? ')'
+  {
+    return toAstNode<AstNode.ParticleCheckImplication>({
+      kind: 'particle-trust-check-implication',
+      checkType: CheckType.Implication,
+      antecedent,
+      consequent,
+    });
+  }
 
 ParticleCheckHasTag
   = 'is' isNot:(whiteSpace 'not')? whiteSpace tag:lowerIdent

--- a/src/runtime/particle-check.ts
+++ b/src/runtime/particle-check.ts
@@ -20,6 +20,7 @@ export enum CheckType {
   IsFromHandle = 'is-from-handle',
   IsFromOutput = 'is-from-output',
   IsFromStore = 'is-from-store',
+  Implication = 'implication',
 }
 
 export type CheckTarget = HandleConnectionSpecInterface | ProvideSlotConnectionSpecInterface;
@@ -97,7 +98,7 @@ export class CheckBooleanExpression {
 export type CheckExpression = CheckBooleanExpression | CheckCondition;
 
 /** A single check condition inside a trust check. */
-export type CheckCondition = CheckHasTag | CheckIsFromHandle | CheckIsFromOutput | CheckIsFromStore;
+export type CheckCondition = CheckHasTag | CheckIsFromHandle | CheckIsFromOutput | CheckIsFromStore | CheckImplication;
 
 /** A check condition of the form 'check x is <tag>'. */
 export class CheckHasTag {
@@ -178,6 +179,24 @@ export class CheckIsFromStore {
   }
 }
 
+/** A check condition of the form 'check x (A => B)'. */
+export class CheckImplication {
+  readonly type: CheckType.Implication = CheckType.Implication;
+  readonly isNot = false;
+
+  constructor(readonly antecedent: CheckExpression, readonly consequent: CheckExpression) {}
+
+  static fromASTNode(astNode: AstNode.ParticleCheckImplication, handleConnectionMap: Map<string, HandleConnectionSpecInterface>) {
+    const antecedent = createCheckExpression(astNode.antecedent, handleConnectionMap);
+    const consequent = createCheckExpression(astNode.consequent, handleConnectionMap);
+    return new CheckImplication(antecedent, consequent);
+  }
+
+  toManifestString() {
+    return `(${this.antecedent.toManifestString(/* requireParens= */ true)} => ${this.consequent.toManifestString(/* requireParens= */ true)})`;
+  }
+}
+
 /** Converts the given AST node into a CheckCondition object. */
 function createCheckCondition(astNode: AstNode.ParticleCheckCondition, handleConnectionMap: Map<string, HandleConnectionSpecInterface>): CheckCondition {
   switch (astNode.checkType) {
@@ -189,8 +208,10 @@ function createCheckCondition(astNode: AstNode.ParticleCheckCondition, handleCon
       return CheckIsFromStore.fromASTNode(astNode);
     case CheckType.IsFromOutput:
       return CheckIsFromOutput.fromASTNode(astNode, handleConnectionMap);
+    case CheckType.Implication:
+      return CheckImplication.fromASTNode(astNode, handleConnectionMap);
     default:
-      throw new Error('Unknown check type.');
+      throw new Error(`Unknown check type: ${JSON.stringify(astNode)}`);
   }
 }
 

--- a/src/tools/manifest2proto.ts
+++ b/src/tools/manifest2proto.ts
@@ -202,6 +202,13 @@ function checkExpressionToProtoPayload(
             return {label: tag};
           }
         }
+        case CheckType.Implication:
+          return {
+            implies: {
+              antecedent: checkExpressionToProtoPayload(condition.antecedent),
+              consequent: checkExpressionToProtoPayload(condition.consequent),
+            },
+          };
         case CheckType.IsFromHandle:
         case CheckType.IsFromOutput:
         case CheckType.IsFromStore:


### PR DESCRIPTION
e.g. `check input (derives from store 'x' => is redacted)` means the `redacted` tag is required if the input derives from store 'x'.

This PR includes support for DFA implications in the manifest language, in the DFA algorithm, and also in the manifest proto output.