### PR TITLE
Marks the BUILD rules for three test suites as flaky.

### DIFF
--- a/javatests/arcs/android/entity/BUILD
+++ b/javatests/arcs/android/entity/BUILD
@@ -8,6 +8,7 @@ licenses(["notice"])
 arcs_kt_android_test_suite(
     name = "entity",
     size = "medium",
+    # TODO(b/157513765): Deflake this test suite.
     flaky = True,
     manifest = "AndroidManifest.xml",
     package = "arcs.android.entity",

--- a/javatests/arcs/android/entity/BUILD
+++ b/javatests/arcs/android/entity/BUILD
@@ -8,6 +8,7 @@ licenses(["notice"])
 arcs_kt_android_test_suite(
     name = "entity",
     size = "medium",
+    flaky = True,
     manifest = "AndroidManifest.xml",
     package = "arcs.android.entity",
     deps = [

--- a/javatests/arcs/core/entity/BUILD
+++ b/javatests/arcs/core/entity/BUILD
@@ -17,6 +17,7 @@ arcs_kt_schema(
 arcs_kt_jvm_test_suite(
     name = "entity",
     srcs = TEST_SRCS,
+    # TODO(b/157513559): Deflake this test suite.
     flaky = True,
     package = "arcs.core.entity",
     deps = [

--- a/javatests/arcs/core/entity/BUILD
+++ b/javatests/arcs/core/entity/BUILD
@@ -17,6 +17,7 @@ arcs_kt_schema(
 arcs_kt_jvm_test_suite(
     name = "entity",
     srcs = TEST_SRCS,
+    flaky = True,
     package = "arcs.core.entity",
     deps = [
         ":lib",

--- a/javatests/arcs/core/host/BUILD
+++ b/javatests/arcs/core/host/BUILD
@@ -15,6 +15,7 @@ arcs_kt_jvm_test_suite(
     name = "host",
     srcs = glob(["*Test.kt"]),
     constraints = ["android"],
+    # TODO(b/157513871): Deflake this test suite.
     flaky = True,
     package = "arcs.core.host",
     deps = [

--- a/javatests/arcs/core/host/BUILD
+++ b/javatests/arcs/core/host/BUILD
@@ -15,6 +15,7 @@ arcs_kt_jvm_test_suite(
     name = "host",
     srcs = glob(["*Test.kt"]),
     constraints = ["android"],
+    flaky = True,
     package = "arcs.core.host",
     deps = [
         ":particle",  # buildcleaner: keep

--- a/src/wasm/tests/BUILD
+++ b/src/wasm/tests/BUILD
@@ -14,6 +14,7 @@ filegroup(
 arcs_ts_test(
     name = "wasm-api-test",
     src = "wasm-api-test.ts",
+    # TODO(b/157514127): Deflake this test.
     flaky = True,
     deps = [
         ":manifest_srcs",

--- a/third_party/java/arcs/build_defs/internal/kotlin.bzl
+++ b/third_party/java/arcs/build_defs/internal/kotlin.bzl
@@ -355,7 +355,16 @@ def arcs_kt_particles(
             visibility = visibility,
         )
 
-def arcs_kt_android_test_suite(name, manifest, package, srcs = None, tags = [], deps = [], data = [], size = "small"):
+def arcs_kt_android_test_suite(
+        name,
+        manifest,
+        package,
+        srcs = None,
+        tags = [],
+        deps = [],
+        data = [],
+        size = "small",
+        flaky = False):
     """Defines Kotlin Android test targets for a directory.
 
     Defines a Kotlin Android library (kt_android_library) for all of the sources
@@ -371,7 +380,10 @@ def arcs_kt_android_test_suite(name, manifest, package, srcs = None, tags = [], 
       tags: optional list of tags for the test targets
       deps: list of dependencies for the kt_android_library
       data: list of files available to the test at runtime
-      size: the size of the test, defaults to "small". Options are: "small", "medium", "large", etc.
+      size: the size of the test, defaults to "small". Options are: "small",
+        "medium", "large".
+      flaky: boolean indicating whether the test is flaky and should be re-run
+        on failure.
     """
     if not srcs:
         srcs = native.glob(["*.kt"])
@@ -393,6 +405,7 @@ def arcs_kt_android_test_suite(name, manifest, package, srcs = None, tags = [], 
         android_local_test(
             name = class_name,
             size = size,
+            flaky = flaky,
             data = data,
             manifest = manifest,
             tags = tags,
@@ -473,7 +486,9 @@ def arcs_kt_jvm_test_suite(
         tags = [],
         deps = [],
         data = [],
-        constraints = []):
+        constraints = [],
+        size = "small",
+        flaky = False):
     """Defines Kotlin JVM test targets for a directory.
 
     Defines a Kotlin JVM library (kt_jvm_library) for all of the sources
@@ -489,6 +504,10 @@ def arcs_kt_jvm_test_suite(
       deps: list of dependencies for the kt_jvm_library
       data: list of files available to the test at runtime
       constraints: list of constraints, e.g android
+      size: the size of the test, defaults to "small". Options are: "small",
+        "medium", "large".
+      flaky: boolean indicating whether the test is flaky and should be re-run
+        on failure.
     """
     if not srcs:
         srcs = native.glob(["*.kt"])
@@ -507,6 +526,7 @@ def arcs_kt_jvm_test_suite(
         java_test(
             name = class_name,
             size = "small",
+            flaky = flaky,
             data = data,
             tags = tags,
             test_class = "%s.%s" % (package, class_name),


### PR DESCRIPTION
These have been consistently flaking. With `flaky = True` bazel will retry them up to 3 times before declaring them a failure.