### PR TITLE
Log channel closed, ignore send

### DIFF
--- a/java/arcs/sdk/android/storage/ServiceStore.kt
+++ b/java/arcs/sdk/android/storage/ServiceStore.kt
@@ -179,10 +179,11 @@ class ServiceStore<Data : CrdtData, Op : CrdtOperation, ConsumerData>(
     private suspend fun send(block: suspend () -> Unit) = requireNotNull(channel) {
         "Channel is not initialized"
     }.apply {
-        require(!isClosedForSend) {
-            "Channel is closed"
+        if (isClosedForSend) {
+            log.debug { "Channel is closed, ignoring" }
+        } else {
+            send(block)
         }
-        send(block)
     }
 
     override suspend fun onProxyMessage(message: ProxyMessage<Data, Op, ConsumerData>): Boolean {


### PR DESCRIPTION
This shouldn't be needed as send() is not supposed to be invoked after a close(), but I'm removing this to reduce the number of variables to look at during deflaking.
