### PR TITLE
Drive fakeLifecycle during setUp()/tearDown()

### DIFF
--- a/javatests/arcs/android/entity/DifferentAndroidHandleManagerDifferentStoresTest.kt
+++ b/javatests/arcs/android/entity/DifferentAndroidHandleManagerDifferentStoresTest.kt
@@ -1,6 +1,7 @@
 package arcs.android.entity
 
 import android.app.Application
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleRegistry
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -68,10 +69,14 @@ class DifferentAndroidHandleManagerDifferentStoresTest : HandleManagerTestBase()
         )
         // Initialize WorkManager for instrumentation tests.
         WorkManagerTestInitHelper.initializeTestWorkManager(app)
+        (fakeLifecycleOwner as LifecycleRegistry).currentState = Lifecycle.State.STARTED
     }
 
     @After
-    override fun tearDown() = super.tearDown()
+    override fun tearDown() {
+        super.tearDown()
+        (fakeLifecycleOwner as LifecycleRegistry).currentState = Lifecycle.State.DESTROYED
+    }
 
     @Ignore("b/157166918 - Deflake")
     @Test

--- a/javatests/arcs/android/entity/DifferentAndroidHandleManagerDifferentStoresTest.kt
+++ b/javatests/arcs/android/entity/DifferentAndroidHandleManagerDifferentStoresTest.kt
@@ -69,13 +69,13 @@ class DifferentAndroidHandleManagerDifferentStoresTest : HandleManagerTestBase()
         )
         // Initialize WorkManager for instrumentation tests.
         WorkManagerTestInitHelper.initializeTestWorkManager(app)
-        (fakeLifecycleOwner as LifecycleRegistry).currentState = Lifecycle.State.STARTED
+        (fakeLifecycleOwner.lifecycle as LifecycleRegistry).currentState = Lifecycle.State.STARTED
     }
 
     @After
     override fun tearDown() {
         super.tearDown()
-        (fakeLifecycleOwner as LifecycleRegistry).currentState = Lifecycle.State.DESTROYED
+        (fakeLifecycleOwner.lifecycle as LifecycleRegistry).currentState = Lifecycle.State.DESTROYED
     }
 
     @Ignore("b/157166918 - Deflake")

--- a/javatests/arcs/android/entity/DifferentHandleManagerTest.kt
+++ b/javatests/arcs/android/entity/DifferentHandleManagerTest.kt
@@ -1,6 +1,7 @@
 package arcs.android.entity
 
 import android.app.Application
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleRegistry
 import androidx.test.core.app.ApplicationProvider
@@ -69,10 +70,14 @@ class DifferentHandleManagerTest : HandleManagerTestBase() {
         )
         // Initialize WorkManager for instrumentation tests.
         WorkManagerTestInitHelper.initializeTestWorkManager(app)
+        (fakeLifecycleOwner as LifecycleRegistry).currentState = Lifecycle.State.STARTED
     }
 
     @After
-    override fun tearDown() = super.tearDown()
+    override fun tearDown() {
+        super.tearDown()
+        (fakeLifecycleOwner as LifecycleRegistry).currentState = Lifecycle.State.DESTROYED
+    }
 
     @Ignore("b/154947352 - Deflake")
     @Test

--- a/javatests/arcs/android/entity/DifferentHandleManagerTest.kt
+++ b/javatests/arcs/android/entity/DifferentHandleManagerTest.kt
@@ -70,13 +70,13 @@ class DifferentHandleManagerTest : HandleManagerTestBase() {
         )
         // Initialize WorkManager for instrumentation tests.
         WorkManagerTestInitHelper.initializeTestWorkManager(app)
-        (fakeLifecycleOwner as LifecycleRegistry).currentState = Lifecycle.State.STARTED
+        (fakeLifecycleOwner.lifecycle as LifecycleRegistry).currentState = Lifecycle.State.STARTED
     }
 
     @After
     override fun tearDown() {
         super.tearDown()
-        (fakeLifecycleOwner as LifecycleRegistry).currentState = Lifecycle.State.DESTROYED
+        (fakeLifecycleOwner.lifecycle as LifecycleRegistry).currentState = Lifecycle.State.DESTROYED
     }
 
     @Ignore("b/154947352 - Deflake")


### PR DESCRIPTION
Give storage layer and others listening to ON_DESTROY a chance to cleanup between tests.
