### PR TITLE
Defines `@isolated` and `@egress` annotations in the canonical manifest.

### DIFF
--- a/src/runtime/canonical-manifest.ts
+++ b/src/runtime/canonical-manifest.ts
@@ -13,9 +13,20 @@ annotation arcId(id: Text)
   targets: [Recipe]
   retention: Source
   doc: 'predefined ID of a long running arc'
+
 annotation ttl(value: Text)
   // Atm TTL is only supported for recipes handles.
   targets: [Handle]
   retention: Runtime
   doc: 'data time-to-live'
+
+annotation isolated
+  targets: [Particle]
+  retention: Source
+  doc: 'Indicates that the given particle is an isolated particle, and does not egress data.'
+
+annotation egress
+  targets: [Particle]
+  retention: Source
+  doc: 'Indicates that the given particle can egress data out of the system (i.e. is not isolated).'
 `;

--- a/src/runtime/particle-spec.ts
+++ b/src/runtime/particle-spec.ts
@@ -358,6 +358,28 @@ export class ParticleSpec {
     this._annotations = annotations;
   }
 
+  /**
+   * Indicates whether the particle is an isolated (non-egress) particle.
+   *
+   * Particles are considered egress particles by default, must have an explicit
+   * `@isolated` annotation to be considered isolated.
+   */
+  get isolated(): boolean {
+    const isolated = this.annotations.some(annotation => annotation.name === 'isolated');
+    const egress = this.annotations.some(annotation => annotation.name === 'egress');
+    assert(!(isolated && egress), 'Particle cannot be tagged with both @isolated and @egress.');
+    return isolated;
+  }
+
+  /**
+   * Indicates whether the particle is an egress (non-isolated) particle.
+   *
+   * Particles are considered egress particles by default.
+   */
+  get egress(): boolean {
+    return !this.isolated;
+  }
+
   isCompatible(modality: Modality): boolean {
     return this.slandleConnectionNames().length === 0 || this.modality.intersection(modality).isResolved();
   }

--- a/src/runtime/tests/manifest-test.ts
+++ b/src/runtime/tests/manifest-test.ts
@@ -4315,14 +4315,71 @@ recipe
       @arcId('myFavoriteArc')
       recipe
         foo: create persistent @ttl(2d) @ttl('2d')
+
+      @isolated()
+      particle IsolatedParticle
+
+      @egress()
+      particle EgressingParticle
     `));
     const recipeAnnotations = manifest.recipes[0].annotations;
     assert.lengthOf(recipeAnnotations, 1);
     assert.equal(recipeAnnotations[0].name, 'arcId');
     assert.equal(recipeAnnotations[0].params['id'], 'myFavoriteArc');
+
     const handleAnnotations = manifest.recipes[0].handles[0].annotations;
     assert.lengthOf(handleAnnotations, 1);
     assert.equal(handleAnnotations[0].name, 'ttl');
     assert.equal(handleAnnotations[0].params['value'], '2d');
+
+    const isolatedParticleAnnotations = manifest.findParticleByName('IsolatedParticle').annotations;
+    console.error(manifest.findParticleByName('IsolatedParticle'));
+    assert.lengthOf(isolatedParticleAnnotations, 1);
+    assert.equal(isolatedParticleAnnotations[0].name, 'isolated');
+    assert.lengthOf(Object.entries(isolatedParticleAnnotations[0].params), 0);
+
+    const egressParticleAnnotations = manifest.findParticleByName('EgressingParticle').annotations;
+    assert.lengthOf(egressParticleAnnotations, 1);
+    assert.equal(egressParticleAnnotations[0].name, 'egress');
+    assert.lengthOf(Object.entries(egressParticleAnnotations[0].params), 0);
+  });
+
+  describe('isolated and egress particles', () => {
+    it('particles are egress by default', async () => {
+      const manifest = await Manifest.parse(`
+        particle P
+      `);
+      assert.isTrue(manifest.particles[0].egress);
+      assert.isFalse(manifest.particles[0].isolated);
+    });
+
+    it('egress annotation works', async () => {
+      const manifest = await Manifest.parse(`
+        @egress()
+        particle P
+      `);
+      assert.isTrue(manifest.particles[0].egress);
+      assert.isFalse(manifest.particles[0].isolated);
+    });
+
+    it('isolated annotation works', async () => {
+      const manifest = await Manifest.parse(`
+        @isolated()
+        particle P
+      `);
+      assert.isFalse(manifest.particles[0].egress);
+      assert.isTrue(manifest.particles[0].isolated);
+    });
+
+    it('throws if both isolated and egress annotations are applied', async () => {
+      const manifest = await Manifest.parse(`
+        @egress()
+        @isolated()
+        particle P
+      `);
+      assert.throws(
+        () => manifest.particles[0].isolated,
+        `Particle cannot be tagged with both @isolated and @egress.`);
+    });
   });
 });


### PR DESCRIPTION
These will be used to designate particles are either isolated or egress, for DFA/policy purposes.

Currently they have no effect and aren't enforced anywhere, but one day we would like to enforce that isolated particles are sandboxed.