### PR TITLE
Adds a utility to convert a predicate into a set of BitSets.

### DIFF
--- a/java/arcs/core/analysis/InformationFlowLabels.kt
+++ b/java/arcs/core/analysis/InformationFlowLabels.kt
@@ -57,18 +57,6 @@ data class InformationFlowLabels(
         }
     }
 
-    private fun BitSet.toString(transform: ((Int) -> String)?): String {
-        if (transform == null) return "$this"
-        var labels = mutableListOf<String>()
-        var nextBit = nextSetBit(0)
-        while (nextBit != -1) {
-            labels.add(transform(nextBit))
-            if (nextBit == Int.MAX_VALUE) break
-            nextBit = nextSetBit(nextBit + 1)
-        }
-        return labels.joinToString(prefix = "{", postfix = "}")
-    }
-
     companion object {
         fun getBottom() = InformationFlowLabels(AbstractSet.getBottom<BitSet>())
         fun getTop() = InformationFlowLabels(AbstractSet.getTop<BitSet>())

--- a/java/arcs/core/analysis/PredicateUtils.kt
+++ b/java/arcs/core/analysis/PredicateUtils.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.core.analysis
+
+import arcs.core.data.InformationFlowLabel
+import arcs.core.data.InformationFlowLabel.Predicate
+import java.util.BitSet
+
+fun BitSet.toString(transform: ((Int) -> String)?): String {
+    if (transform == null) return "$this"
+    var labels = mutableListOf<String>()
+    var nextBit = nextSetBit(0)
+    while (nextBit != -1) {
+        labels.add(transform(nextBit))
+        if (nextBit == Int.MAX_VALUE) break
+        nextBit = nextSetBit(nextBit + 1)
+    }
+    return labels.joinToString(prefix = "{", postfix = "}")
+}
+
+/**
+ * Returns a set of [BitSet] representation for the predicate using the given [indices] to
+ * determine the index of an [InformationFlowLabel] in the bitset.
+ */
+fun InformationFlowLabel.Predicate.asSetOfBitSets(
+    indices: Map<InformationFlowLabel, Int>
+): Set<BitSet> {
+    // TODO(b/157530728): This is not very efficient. We will want to replace this with
+    // an implementation that uses a Binary Decision Diagram (BDD).
+    when (this) {
+        is Predicate.Label -> {
+            val result = BitSet(indices.size)
+            result.set(requireNotNull(indices[label]))
+            return setOf(result)
+        }
+        is Predicate.Not -> {
+            val labelPredicate = requireNotNull(predicate as? Predicate.Label) {
+                // TODO(b/157530728): It will be easy to handle `not` when we have a proper
+                // datastructure like BDDs. For now, we only support `not` on labels.
+                "Not is only supported for label predicates when converting to bitsets!"
+            }
+            val labelIndex = requireNotNull(indices[labelPredicate.label])
+            // Not(A) = B \/ C ...
+            return (0..(indices.size - 1)).mapNotNull { index ->
+                if (index == labelIndex) null else BitSet(indices.size).apply { set(index) }
+            }.toSet()
+        }
+        is Predicate.Or -> {
+            val lhsBitSets = lhs.asSetOfBitSets(indices)
+            val rhsBitSets = rhs.asSetOfBitSets(indices)
+            return lhsBitSets union rhsBitSets
+        }
+        is Predicate.And -> {
+            val lhsBitSets = lhs.asSetOfBitSets(indices)
+            val rhsBitSets = rhs.asSetOfBitSets(indices)
+            val result = mutableSetOf<BitSet>()
+            lhsBitSets.forEach { lhsBitSet ->
+                rhsBitSets.forEach { rhsBitSet ->
+                    val combined = BitSet(indices.size)
+                    combined.or(lhsBitSet)
+                    combined.or(rhsBitSet)
+                    result.add(combined)
+                }
+            }
+            return result.toSet()
+        }
+    }
+}

--- a/java/arcs/core/analysis/PredicateUtils.kt
+++ b/java/arcs/core/analysis/PredicateUtils.kt
@@ -49,10 +49,12 @@ fun InformationFlowLabel.Predicate.asSetOfBitSets(
                 "Not is only supported for label predicates when converting to bitsets!"
             }
             val labelIndex = requireNotNull(indices[labelPredicate.label])
-            // Not(A) = B \/ C ...
-            return (0..(indices.size - 1)).mapNotNull { index ->
-                if (index == labelIndex) null else BitSet(indices.size).apply { set(index) }
-            }.toSet()
+            // Not(A) = empty \/ B \/ C ...
+            return (0..(indices.size - 1))
+                .filter { it != labelIndex }
+                .map { index -> BitSet(indices.size).apply { set(index) } }
+                .plus(BitSet(indices.size))
+                .toSet()
         }
         is Predicate.Or -> {
             val lhsBitSets = lhs.asSetOfBitSets(indices)

--- a/java/arcs/core/data/InformationFlowLabel.kt
+++ b/java/arcs/core/data/InformationFlowLabel.kt
@@ -30,5 +30,9 @@ sealed class InformationFlowLabel {
         data class Not(val predicate: Predicate) : Predicate()
         data class Or(val lhs: Predicate, val rhs: Predicate) : Predicate()
         data class And(val lhs: Predicate, val rhs: Predicate) : Predicate()
+
+        infix fun and(other: Predicate) = Predicate.And(this, other)
+        infix fun or(other: Predicate) = Predicate.Or(this, other)
+        fun not() = Predicate.Not(this)
     }
 }

--- a/javatests/arcs/core/analysis/PredicateUtilsTest.kt
+++ b/javatests/arcs/core/analysis/PredicateUtilsTest.kt
@@ -1,0 +1,134 @@
+package arcs.core.analysis
+
+import arcs.core.data.InformationFlowLabel
+import arcs.core.data.InformationFlowLabel.Predicate
+import com.google.common.truth.Truth.assertThat
+import java.util.BitSet
+import kotlin.test.assertFailsWith
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class PredicateUtilsTest {
+    enum class Labels {
+        A, B, C, D;
+
+        val asPredicate: Predicate.Label
+            get() = Predicate.Label(InformationFlowLabel.SemanticTag(name))
+    }
+    private val labels = enumValues<Labels>().map { it.name }
+    private val indicesMap: Map<InformationFlowLabel, Int> = enumValues<Labels>().map {
+        it.asPredicate.label to it.ordinal
+    }.toMap()
+
+    fun Predicate.asStringList(): List<String> {
+        return asSetOfBitSets(indicesMap).map { bitset ->
+            bitset.toString { bit ->
+                labels[bit]
+            }
+        }
+    }
+
+    @Test
+    fun prettyPrintBitSet() {
+        val setAC = BitSet(labels.size).apply {
+            set(Labels.A.ordinal)
+            set(Labels.C.ordinal)
+        }
+        assertThat(setAC.toString { bit -> labels[bit] }).isEqualTo("{A, C}")
+        assertThat(setAC.toString { _ -> "HAHA" }).isEqualTo("{HAHA, HAHA}")
+    }
+
+    @Test
+    fun LabelPredicate() {
+        assertThat(Labels.A.asPredicate.asStringList())
+            .containsExactly("{A}")
+        assertThat(Labels.B.asPredicate.asStringList())
+            .containsExactly("{B}")
+    }
+
+    @Test
+    fun SimpleAndPredicate() {
+        val predicateAandB = Labels.A.asPredicate and Labels.B.asPredicate
+        assertThat(predicateAandB.asStringList()).containsExactly("{A, B}")
+        val predicateAandBandC =
+            Labels.C.asPredicate and Labels.A.asPredicate and Labels.B.asPredicate
+        assertThat(predicateAandBandC.asStringList()).containsExactly("{A, B, C}")
+    }
+
+    @Test
+    fun SimpleOrPredicate() {
+        val predicateAorB = Labels.A.asPredicate or Labels.B.asPredicate
+        assertThat((predicateAorB).asStringList()).containsExactly("{A}", "{B}")
+        val predicateAorBorC =
+            Labels.C.asPredicate or Labels.A.asPredicate or Labels.B.asPredicate
+        assertThat(predicateAorBorC.asStringList()).containsExactly("{A}", "{B}", "{C}")
+    }
+
+    @Test
+    fun SimpleNotPredicate() {
+        val notA = Predicate.Not(Labels.A.asPredicate)
+        assertThat(notA.asStringList()).containsExactly("{B}", "{C}", "{D}")
+    }
+
+    @Test
+    fun AndOrPredicate() {
+        // (A \/ B) /\ C
+        val predicate_AorB_and_C = Labels.A.asPredicate
+            .or(Labels.B.asPredicate)
+            .and(Labels.C.asPredicate)
+        assertThat(predicate_AorB_and_C.asStringList())
+            .containsExactly("{A, C}", "{B, C}")
+        // (A \/ B) /\ (C \/ D)
+        val predicate_AorB_and_CorD =  Labels.A.asPredicate
+            .or(Labels.B.asPredicate)
+            .and(Labels.C.asPredicate.or(Labels.D.asPredicate))
+        assertThat(predicate_AorB_and_CorD.asStringList())
+            .containsExactly("{A, C}", "{A, D}", "{B, C}", "{B, D}")
+    }
+
+    @Test
+    fun OrAndPredicate() {
+        // (A /\ B) \/ C
+        val predicate_AandB_or_C = Labels.A.asPredicate
+            .and(Labels.B.asPredicate)
+            .or(Labels.C.asPredicate)
+        assertThat(predicate_AandB_or_C.asStringList())
+            .containsExactly("{A, B}", "{C}")
+        // (A /\ B) \/ (C /\ D)
+        val predicate_AorB_and_CorD =  Labels.A.asPredicate
+            .and(Labels.B.asPredicate)
+            .or(Labels.C.asPredicate.and(Labels.D.asPredicate))
+        assertThat(predicate_AorB_and_CorD.asStringList())
+            .containsExactly("{A, B}", "{C, D}")
+    }
+
+    @Test
+    fun NotOverAnd_throwsError() {
+        val e = assertFailsWith<IllegalArgumentException> {
+            // !(A /\ B)
+            Labels.A.asPredicate
+                .and(Labels.B.asPredicate)
+                .not()
+                .asStringList()
+        }
+        assertThat(e)
+            .hasMessageThat()
+            .isEqualTo("Not is only supported for label predicates when converting to bitsets!")
+    }
+
+    @Test
+    fun NotOverOr_throwsError() {
+        val e = assertFailsWith<IllegalArgumentException> {
+            // !(A \/ B)
+            Labels.A.asPredicate
+                .or(Labels.B.asPredicate)
+                .not()
+                .asStringList()
+        }
+        assertThat(e)
+            .hasMessageThat()
+            .isEqualTo("Not is only supported for label predicates when converting to bitsets!")
+    }
+}

--- a/javatests/arcs/core/analysis/PredicateUtilsTest.kt
+++ b/javatests/arcs/core/analysis/PredicateUtilsTest.kt
@@ -69,7 +69,7 @@ class PredicateUtilsTest {
     @Test
     fun simpleNotPredicate() {
         val notA = Predicate.Not(Labels.A.asPredicate)
-        assertThat(notA.asStringList()).containsExactly("{B}", "{C}", "{D}")
+        assertThat(notA.asStringList()).containsExactly("{}", "{B}", "{C}", "{D}")
     }
 
     @Test

--- a/javatests/arcs/core/analysis/PredicateUtilsTest.kt
+++ b/javatests/arcs/core/analysis/PredicateUtilsTest.kt
@@ -41,7 +41,7 @@ class PredicateUtilsTest {
     }
 
     @Test
-    fun LabelPredicate() {
+    fun labelPredicate() {
         assertThat(Labels.A.asPredicate.asStringList())
             .containsExactly("{A}")
         assertThat(Labels.B.asPredicate.asStringList())
@@ -49,7 +49,7 @@ class PredicateUtilsTest {
     }
 
     @Test
-    fun SimpleAndPredicate() {
+    fun simpleAndPredicate() {
         val predicateAandB = Labels.A.asPredicate and Labels.B.asPredicate
         assertThat(predicateAandB.asStringList()).containsExactly("{A, B}")
         val predicateAandBandC =
@@ -58,7 +58,7 @@ class PredicateUtilsTest {
     }
 
     @Test
-    fun SimpleOrPredicate() {
+    fun simpleOrPredicate() {
         val predicateAorB = Labels.A.asPredicate or Labels.B.asPredicate
         assertThat((predicateAorB).asStringList()).containsExactly("{A}", "{B}")
         val predicateAorBorC =
@@ -67,13 +67,13 @@ class PredicateUtilsTest {
     }
 
     @Test
-    fun SimpleNotPredicate() {
+    fun simpleNotPredicate() {
         val notA = Predicate.Not(Labels.A.asPredicate)
         assertThat(notA.asStringList()).containsExactly("{B}", "{C}", "{D}")
     }
 
     @Test
-    fun AndOrPredicate() {
+    fun andOrPredicate() {
         // (A \/ B) /\ C
         val predicate_AorB_and_C = Labels.A.asPredicate
             .or(Labels.B.asPredicate)
@@ -89,7 +89,7 @@ class PredicateUtilsTest {
     }
 
     @Test
-    fun OrAndPredicate() {
+    fun orAndPredicate() {
         // (A /\ B) \/ C
         val predicate_AandB_or_C = Labels.A.asPredicate
             .and(Labels.B.asPredicate)
@@ -105,7 +105,7 @@ class PredicateUtilsTest {
     }
 
     @Test
-    fun NotOverAnd_throwsError() {
+    fun notOverAnd_throwsError() {
         val e = assertFailsWith<IllegalArgumentException> {
             // !(A /\ B)
             Labels.A.asPredicate
@@ -119,7 +119,7 @@ class PredicateUtilsTest {
     }
 
     @Test
-    fun NotOverOr_throwsError() {
+    fun notOverOr_throwsError() {
         val e = assertFailsWith<IllegalArgumentException> {
             // !(A \/ B)
             Labels.A.asPredicate


### PR DESCRIPTION
This PR introduces a utility to needed to convert a predicate into values in the [InformationFlowLabels](https://github.com/PolymerLabs/arcs/blob/1e133141c9385864cec257aa538abc109cc04749/java/arcs/core/analysis/InformationFlowLabels.kt#L26) lattice. 

Also, does some minor refactoring of the custom`BitSet.toString` method.