### PR TITLE
Fix db racing creation

### DIFF
--- a/java/arcs/android/storage/database/AndroidSqliteDatabaseRegistry.kt
+++ b/java/arcs/android/storage/database/AndroidSqliteDatabaseRegistry.kt
@@ -163,7 +163,7 @@ class AndroidSqliteDatabaseRegistry(
         private val MANIFEST_NAME = "arcs_database_manifest"
 
         private val SCHEMA = """
-            CREATE TABLE arcs_databases (
+            CREATE TABLE IF NOT EXISTS arcs_databases (
                 name TEXT NOT NULL UNIQUE,
                 created INTEGER NOT NULL,
                 last_accessed INTEGER NOT NULL


### PR DESCRIPTION
Multiple read sessions and write sessions may be prepared in advanced at creation time especially at some journal modes like wal, etc to expedite performance.
There is a chance of read/write sessions being created at roughly the same time which invokes onCreate() simultaneously.
`CREATE TABLE IF NOT EXISTS` is always the best practice for such a race condition.