### PR TITLE
Pinning Wasm compilers to Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -16,3 +16,6 @@ build
 devtools/build
 server/log.txt
 .git
+bazel-out
+bazel-arcs
+bazel-bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,8 +75,9 @@ COPY .bazelignore \
      ./
 RUN ./tools/bazelisk fetch @maven//...
 
-RUN bazel sync
+RUN ./tools/bazelisk fetch @kotlin_native_compiler//...
 
+RUN ./tools/bazelisk fetch @emsdk//...
 # Copy the contents of the working dir. After this the image should be ready for
 # use.
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,6 +75,8 @@ COPY .bazelignore \
      ./
 RUN ./tools/bazelisk fetch @maven//...
 
+RUN bazel sync
+
 # Copy the contents of the working dir. After this the image should be ready for
 # use.
 COPY . .


### PR DESCRIPTION
This PR helps reduce flakiness by caching Wasm-compilers to the GCB Docker image. There are a few options for what to cache, I've reported the tradeoffs below

## Space Complexity 
Image size according to GCP: 
- Status Quo: 1.6GB
- Kotlin Native + EMSDK: 2.98GB

## Time Complexity
- Status Quo: Docker pull ~ 1:00 ([source](https://pantheon.corp.google.com/cloud-build/builds/8b08ef7d-1924-4444-9ffb-b7cb894599e3;step=0?project=arcs-265404))
- Kotlin Native + EMSDK: Docker pull ~ 1:51 ([source](https://pantheon.corp.google.com/cloud-build/builds/613bf84b-a74b-4e73-a8a2-0c7df4bdf568;step=0?project=arcs-265404))