### PR TITLE
Policy proto definition

### DIFF
--- a/java/arcs/core/data/proto/BUILD
+++ b/java/arcs/core/data/proto/BUILD
@@ -17,7 +17,7 @@ package(default_visibility = ["//visibility:public"])
 # This target is needed in Google internal repo when running TypeScript with Bazel.
 filegroup(
     name = "proto_files",
-    srcs = ["manifest.proto"],
+    srcs = glob(["*.proto"]),
 )
 
 arcs_kt_library(

--- a/java/arcs/core/data/proto/BUILD
+++ b/java/arcs/core/data/proto/BUILD
@@ -55,6 +55,9 @@ arcs_kt_library(
 proto_library(
     name = "manifest_proto",
     srcs = ["manifest.proto"],
+    deps = [
+        ":policy_proto",
+    ],
 )
 
 android_proto_library(
@@ -71,4 +74,25 @@ py_proto_library(
     name = "manifest_py_proto",
     api_version = 2,
     deps = [":manifest_proto"],
+)
+
+proto_library(
+    name = "policy_proto",
+    srcs = ["policy.proto"],
+)
+
+android_proto_library(
+    name = "policy_java_proto_lite",
+    deps = [":policy_proto"],
+)
+
+java_proto_library(
+    name = "policy_java_proto",
+    deps = [":policy_proto"],
+)
+
+py_proto_library(
+    name = "policy_py_proto",
+    api_version = 2,
+    deps = [":policy_proto"],
 )

--- a/java/arcs/core/data/proto/manifest.proto
+++ b/java/arcs/core/data/proto/manifest.proto
@@ -5,10 +5,13 @@ package arcs;
 option java_package = "arcs.core.data.proto";
 option java_multiple_files = true;
 
+import "java/arcs/core/data/proto/policy.proto";
+
 // A manifest containing multiple recipes and particle specs.
 message ManifestProto {
   repeated RecipeProto recipes = 1;
   repeated ParticleSpecProto particle_specs = 2;
+  repeated PolicyProto policies = 3;
 }
 
 // Plan: A resolved recipe that can be instantiated.

--- a/java/arcs/core/data/proto/policy.proto
+++ b/java/arcs/core/data/proto/policy.proto
@@ -22,32 +22,28 @@ message PolicyProto {
   enum EgressType {
     EGRESS_TYPE_UNSPECIFIED = 0;
     LOGGING = 1;
-    FEDERATED_ANALYTICS = 2;
+    FEDERATED_AGGREGATION = 2;
   }
   // Egress type permitted by the policy.
   EgressType egress_type = 5;
 
   // Whether user consent is required before using the policy.
   bool user_consent_required = 6;
-
-  enum ApprovalCondition {
-    APPROVAL_CONDITION_UNSPECIFIED = 0;
-    PRE_APPROVED = 1;
-    APPROVAL_REQUIRED = 2;
-  }
-  // Approval condition for the policy.
-  ApprovalCondition approval_condition = 7;
 }
 
 message PolicyTargetProto {
-  // ID of the store targeted by the policy.
-  string store_id = 1;
+  // Schema type of the store targeted by the policy.
+  string schema_type = 1;
+
+  // The maximum age of the data that can be used, as a duration (not timestamp)
+  // in milliseconds.
+  int64 max_age_ms = 2;
 
   // Valid retention options for storing the target data.
-  repeated PolicyRetentionProto retentions = 2;
+  repeated PolicyRetentionProto retentions = 3;
 
   // Allowed usages for all fields in this target type.
-  repeated PolicyFieldProto fields = 3;
+  repeated PolicyFieldProto fields = 4;
 }
 
 message PolicyFieldProto {
@@ -64,18 +60,18 @@ message PolicyFieldProto {
     JOIN = 3;
   }
 
-  message AllowedUsages {
-    // Indicates all types of usages that are permitted. An empty list indicates
-    // no usages are permitted.
-    repeated UsageType usages = 1;
+  message AllowedUsage {
+    // The type of usage that is permitted.
+    UsageType usage = 1;
+
+    // An redaction label that must be applied before the data can be used for
+    // this usage type. Optional: an empty string means no redaction is
+    // required.
+    string redaction_label = 2;
   }
 
   // Specifies the allowed usages of raw data.
-  AllowedUsages raw_usages = 2;
-
-  // Specifies the allowed usages given that certain redactions have been
-  // performed first. Maps from redaction label to AllowedUsages.
-  map<string, AllowedUsages> redacted_usages = 3;
+  repeated AllowedUsage usages = 2;
 
   // Specified usages for subfields nested inside this field.
   repeated PolicyFieldProto subfields = 4;

--- a/java/arcs/core/data/proto/policy.proto
+++ b/java/arcs/core/data/proto/policy.proto
@@ -26,9 +26,6 @@ message PolicyProto {
   }
   // Egress type permitted by the policy.
   EgressType egress_type = 5;
-
-  // Whether user consent is required before using the policy.
-  bool user_consent_required = 6;
 }
 
 message PolicyTargetProto {

--- a/java/arcs/core/data/proto/policy.proto
+++ b/java/arcs/core/data/proto/policy.proto
@@ -1,0 +1,107 @@
+syntax = "proto3";
+
+package arcs;
+
+option java_package = "arcs.core.data.proto";
+option java_multiple_files = true;
+
+// Defines a data usage policy.
+message PolicyProto {
+  // Policy name.
+  string name = 1;
+
+  // Targets governed by the policy.
+  repeated PolicyTargetProto targets = 2;
+
+  // Additional config metadata for the policy.
+  repeated PolicyConfigProto configs = 3;
+
+  // Human readable description for the policy.
+  string description = 4;
+
+  enum EgressType {
+    EGRESS_TYPE_UNSPECIFIED = 0;
+    LOGGING = 1;
+    FEDERATED_ANALYTICS = 2;
+  }
+  // Egress type permitted by the policy.
+  EgressType egress_type = 5;
+
+  // Whether user consent is required before using the policy.
+  bool user_consent_required = 6;
+
+  enum ApprovalCondition {
+    APPROVAL_CONDITION_UNSPECIFIED = 0;
+    PRE_APPROVED = 1;
+    APPROVAL_REQUIRED = 2;
+  }
+  // Approval condition for the policy.
+  ApprovalCondition approval_condition = 7;
+}
+
+message PolicyTargetProto {
+  // ID of the store targeted by the policy.
+  string store_id = 1;
+
+  // Valid retention options for storing the target data.
+  repeated PolicyRetentionProto retentions = 2;
+
+  // Allowed usages for all fields in this target type.
+  repeated PolicyFieldProto fields = 3;
+}
+
+message PolicyFieldProto {
+  // Field name.
+  string name = 1;
+
+  enum UsageType {
+    USAGE_TYPE_UNSPECIFIED = 0;
+    // Can be used for anything.
+    ANY = 1;
+    // Can be egressed.
+    EGRESS = 2;
+    // Can be used in joins, but not read.
+    JOIN = 3;
+  }
+
+  message AllowedUsages {
+    // Indicates all types of usages that are permitted. An empty list indicates
+    // no usages are permitted.
+    repeated UsageType usages = 1;
+  }
+
+  // Specifies the allowed usages of raw data.
+  AllowedUsages raw_usages = 2;
+
+  // Specifies the allowed usages given that certain redactions have been
+  // performed first. Maps from redaction label to AllowedUsages.
+  map<string, AllowedUsages> redacted_usages = 3;
+
+  // Specified usages for subfields nested inside this field.
+  repeated PolicyFieldProto subfields = 4;
+}
+
+// Storage retention options for a policy target.
+message PolicyRetentionProto {
+  enum Medium {
+    MEDIUM_UNSPECIFIED = 0;
+    RAM = 1;
+    DISK = 2;
+  }
+  // Allowed retention medium.
+  Medium medium = 1;
+
+  // Whether encryption is required when using this medium.
+  bool encryption_required = 2;
+}
+
+// Encode additional metadata for a policy.
+message PolicyConfigProto {
+  // Name for the config.
+  string name = 1;
+
+  // Data contained in the config. This encodes arbitrary metadata as string
+  // key-value pairs. The keys should all have a known meaning given the config
+  // name.
+  map<string, string> metadata = 2;
+}

--- a/src/tools/manifest-proto.ts
+++ b/src/tools/manifest-proto.ts
@@ -13,10 +13,14 @@ import {runfilesDir} from './runfiles-dir.oss.js';
 
 // These variables store classes that deal with protos, upper case name is justified.
 // tslint:disable: variable-name
-const RootNamespace = protobuf.loadSync(runfilesDir + 'java/arcs/core/data/proto/manifest.proto');
-export const ManifestProto = RootNamespace.lookupType('arcs.ManifestProto');
-export const FateEnum = RootNamespace.lookupEnum('arcs.Fate');
+const RootNamespace = protobuf.loadSync([
+  runfilesDir + 'java/arcs/core/data/proto/manifest.proto',
+  runfilesDir + 'java/arcs/core/data/proto/policy.proto',
+]);
 export const CapabilityEnum = RootNamespace.lookupEnum('arcs.Capability');
 export const DirectionEnum = RootNamespace.lookupEnum('arcs.Direction');
-export const PrimitiveTypeEnum = RootNamespace.lookupEnum('arcs.PrimitiveTypeProto');
+export const FateEnum = RootNamespace.lookupEnum('arcs.Fate');
+export const ManifestProto = RootNamespace.lookupType('arcs.ManifestProto');
 export const OperatorEnum = RootNamespace.lookupEnum('arcs.OPERATOR');
+export const PrimitiveTypeEnum = RootNamespace.lookupEnum('arcs.PrimitiveTypeProto');
+export const TypeProto = RootNamespace.lookupType('arcs.TypeProto');

--- a/src/tools/manifest2proto.ts
+++ b/src/tools/manifest2proto.ts
@@ -21,8 +21,8 @@ import {Capabilities} from '../runtime/capabilities.js';
 import {CapabilityEnum, DirectionEnum, FateEnum, ManifestProto, PrimitiveTypeEnum} from './manifest-proto.js';
 import {Refinement, RefinementExpressionLiteral} from '../runtime/refiner.js';
 import {Op} from '../runtime/manifest-ast-nodes.js';
-import {Claim, ClaimType} from '../runtime/particle-claim.js';
-import {Check, CheckCondition, CheckExpression, CheckType} from '../runtime/particle-check.js';
+import {ClaimType} from '../runtime/particle-claim.js';
+import {CheckCondition, CheckExpression, CheckType} from '../runtime/particle-check.js';
 import {flatMap} from '../runtime/util.js';
 
 export async function encodeManifestToProto(path: string): Promise<Uint8Array> {

--- a/src/tools/tests/manifest2proto-test.ts
+++ b/src/tools/tests/manifest2proto-test.ts
@@ -13,12 +13,7 @@ import {CountType, EntityType, SingletonType, TupleType, Type} from '../../runti
 import {Manifest} from '../../runtime/manifest.js';
 import {Capabilities} from '../../runtime/capabilities.js';
 import {fs} from '../../platform/fs-web.js';
-import protobuf from 'protobufjs';
-
-const rootNamespace = protobuf.loadSync('./java/arcs/core/data/proto/manifest.proto');
-const manifestProto = rootNamespace.lookupType('arcs.ManifestProto');
-const typeProto = rootNamespace.lookupType('arcs.TypeProto');
-const CAPABILITY_ENUM = rootNamespace.lookupEnum('arcs.Capability');
+import {CapabilityEnum, ManifestProto, TypeProto} from '../manifest-proto.js';
 
 describe('manifest2proto', () => {
 
@@ -27,10 +22,10 @@ describe('manifest2proto', () => {
   // from the proto object. This ensures that all JSON produced fits the
   // expectations of the protobufjs library and the shape of the proto declaration.
   async function toProtoAndBack(manifest: Manifest) {
-    return manifestProto.fromObject(await manifestToProtoPayload(manifest)).toJSON();
+    return ManifestProto.fromObject(await manifestToProtoPayload(manifest)).toJSON();
   }
   async function toProtoAndBackType(type: Type) {
-    return typeProto.fromObject(await typeToProtoPayload(type)).toJSON();
+    return TypeProto.fromObject(await typeToProtoPayload(type)).toJSON();
   }
 
   it('encodes a recipe with use, map, create handles, ids and tags', async () => {
@@ -90,7 +85,7 @@ describe('manifest2proto', () => {
 
   it('encodes handle capabilities', () => {
     function capabilitiesToStrings(capabilities: Capabilities) {
-      return capabilitiesToProtoOrdinals(capabilities).map(ordinal => CAPABILITY_ENUM.valuesById[ordinal]);
+      return capabilitiesToProtoOrdinals(capabilities).map(ordinal => CapabilityEnum.valuesById[ordinal]);
     }
 
     assert.deepEqual(capabilitiesToStrings(Capabilities.empty), []);


### PR DESCRIPTION
This is a proto representation of the policy specification language. It will be used to serialize policies after being parsed from a manifest file, to be used in Kotlin.