### PR TITLE
Fix two issues with storage proxy

### DIFF
--- a/src/runtime/particle.ts
+++ b/src/runtime/particle.ts
@@ -48,7 +48,7 @@ export class Particle {
     // Typescript only sees this.constructor as a Function type.
     // TODO(shans): move spec off the constructor
     this.spec = this.constructor['spec'];
-    if (this.spec.inputs.length === 0) {
+    if (this.spec && this.spec.inputs.length === 0) {
       this.extraData = true;
     }
     this.created = false;

--- a/src/runtime/storageNG/handle.ts
+++ b/src/runtime/storageNG/handle.ts
@@ -145,7 +145,7 @@ export abstract class Handle<StorageType extends CRDTTypeRecord> {
   }
 
   protected reportUserExceptionInHost(exception: Error, particle: Particle, method: string) {
-    this.storageProxy.reportExceptionInHost(new UserException(exception, method, this.key, particle.spec.name));
+    this.storageProxy.reportExceptionInHost(new UserException(exception, method, this.key, particle.spec ? particle.spec.name : ''));
   }
 
   abstract onUpdate(update: StorageType['operation']): void;

--- a/src/runtime/storageNG/reference-mode-store.ts
+++ b/src/runtime/storageNG/reference-mode-store.ts
@@ -159,6 +159,7 @@ export class ReferenceModeStore<Entity extends SerializedEntity, S extends Dicti
 
   reportExceptionInHost(exception: PropagatedException): void {
     // TODO(shans): Figure out idle / exception store for reference mode stores.
+    throw new Error(exception.message);
   }
 
   // For referenceMode stores, the version tracked is just the version

--- a/src/runtime/storageNG/storage-proxy.ts
+++ b/src/runtime/storageNG/storage-proxy.ts
@@ -10,7 +10,7 @@
 
 import {mapStackTrace} from '../../platform/sourcemapped-stacktrace-web.js';
 import {PropagatedException, SystemException} from '../arc-exceptions.js';
-import {CRDTError, CRDTModel, CRDTOperation, CRDTTypeRecord, VersionMap} from '../crdt/crdt.js';
+import {CRDTError, CRDTModel, CRDTOperation, CRDTTypeRecord, VersionMap, ChangeType} from '../crdt/crdt.js';
 import {Runnable, Predicate} from '../hot.js';
 import {Particle} from '../particle.js';
 import {ParticleExecutionContext} from '../particle-execution-context.js';
@@ -89,6 +89,12 @@ export class StorageProxy<T extends CRDTTypeRecord> {
   }
 
   registerHandle(handle: Handle<T>): void {
+    // Check whether we're synchronized up-front; it's possible that calling requestSynchronization
+    // will result in immediate delivery of a message that causes us to become synchronized
+    // partway through running this method. If that's the case, the normal notifySync process
+    // will kick in and we don't need to notifySyncForHandle explicitly. We only need to do that
+    // if we were *already* synchronized
+    const isSynchronized = this.synchronized;
     // Attach an event listener to the backing store when the first handle is registered.
     if (!this.listenerAttached) {
       this.store.setCallback(x => this.onMessage(x));
@@ -100,11 +106,11 @@ export class StorageProxy<T extends CRDTTypeRecord> {
     }
     this.handles.push(handle);
 
-
     // Change to synchronized mode as soon as we get any handle configured with keepSynced and send
     // a request to get the full model (once).
     // TODO: drop back to non-sync mode if all handles re-configure to !keepSynced.
     if (handle.options.keepSynced) {
+
       if (!this.keepSynced) {
         this.requestSynchronization().catch(e => {
           this.reportExceptionInHost(new SystemException(
@@ -113,9 +119,11 @@ export class StorageProxy<T extends CRDTTypeRecord> {
         this.keepSynced = true;
       }
 
+
+
       // If a handle configured for sync notifications registers after we've received the full
       // model, notify it immediately.
-      if (handle.options.notifySync && this.synchronized) {
+      if (handle.options.notifySync && isSynchronized) {
         this.notifySyncForHandle(handle);
       }
     }
@@ -172,6 +180,11 @@ export class StorageProxy<T extends CRDTTypeRecord> {
     return this.crdt.getParticleView()!;
   }
 
+  /**
+   * Set synchronized state and call notifySync if not currently synced. If initialModel is
+   * provided, pass this to notifySync, otherwise notifySync will generate a model from
+   * the CRDT data.
+   */
   private setSynchronized(initialModel = null) {
     if (!this.synchronized) {
       this.synchronized = true;
@@ -189,11 +202,25 @@ export class StorageProxy<T extends CRDTTypeRecord> {
   async onMessage(message: ProxyMessage<T>): Promise<void> {
     switch (message.type) {
       case ProxyMessageType.ModelUpdate:
-        this.crdt.merge(message.model);
+        const {modelChange} = this.crdt.merge(message.model);
+        if (this.synchronized) {
+          // if the particle is already synchronized, try to interpret this update
+          // as a sequence of operations. If that's impossible (because merge returned)
+          // a model rather than operations) then clear synchronization so that
+          // the particle knows to expect a resync message with the new model
+          if (modelChange.changeType == ChangeType.Operations) {
+            modelChange.operations.forEach(
+              op => this.notifyUpdate(
+                  op, options => !options.keepSynced && options.notifyUpdate));
+            break;
+          }
+          
+          this.clearSynchronized();
+        }
         this.setSynchronized();
         // NOTE: this.modelHasSynced used to run after this.synchronized
         // was set to true but before notifySync() was called. Is that a problem?
-        this.modelHasSynced();
+        this.modelHasSynced();  
         break;
       case ProxyMessageType.Operations: {
         // Immediately notify any handles that are not configured with keepSynced but do want updates.

--- a/src/runtime/storageNG/storage-proxy.ts
+++ b/src/runtime/storageNG/storage-proxy.ts
@@ -120,7 +120,6 @@ export class StorageProxy<T extends CRDTTypeRecord> {
       }
 
 
-
       // If a handle configured for sync notifications registers after we've received the full
       // model, notify it immediately.
       if (handle.options.notifySync && isSynchronized) {
@@ -202,26 +201,28 @@ export class StorageProxy<T extends CRDTTypeRecord> {
   async onMessage(message: ProxyMessage<T>): Promise<void> {
     switch (message.type) {
       case ProxyMessageType.ModelUpdate:
+      {
         const {modelChange} = this.crdt.merge(message.model);
         if (this.synchronized) {
           // if the particle is already synchronized, try to interpret this update
           // as a sequence of operations. If that's impossible (because merge returned)
           // a model rather than operations) then clear synchronization so that
           // the particle knows to expect a resync message with the new model
-          if (modelChange.changeType == ChangeType.Operations) {
+          if (modelChange.changeType === ChangeType.Operations) {
             modelChange.operations.forEach(
               op => this.notifyUpdate(
                   op, options => !options.keepSynced && options.notifyUpdate));
             break;
           }
-          
+
           this.clearSynchronized();
         }
         this.setSynchronized();
         // NOTE: this.modelHasSynced used to run after this.synchronized
         // was set to true but before notifySync() was called. Is that a problem?
-        this.modelHasSynced();  
+        this.modelHasSynced();
         break;
+      }
       case ProxyMessageType.Operations: {
         // Immediately notify any handles that are not configured with keepSynced but do want updates.
         message.operations.forEach(

--- a/src/runtime/storageNG/tests/reference-mode-store-integration-test.ts
+++ b/src/runtime/storageNG/tests/reference-mode-store-integration-test.ts
@@ -13,10 +13,10 @@ import {RamDiskStorageKey, RamDiskStorageDriverProvider} from '../drivers/ramdis
 import {DriverFactory} from '../drivers/driver-factory.js';
 import {Runtime} from '../../runtime.js';
 import {EntityType} from '../../type.js';
-import { ReferenceModeStorageKey } from '../reference-mode-storage-key.js';
-import { newHandle } from '../storage-ng.js';
-import { Schema } from '../../schema.js';
-import { Particle } from '../../particle.js';
+import {ReferenceModeStorageKey} from '../reference-mode-storage-key.js';
+import {newHandle} from '../storage-ng.js';
+import {Schema} from '../../schema.js';
+import {Particle} from '../../particle.js';
 
 describe('ReferenceModeStore Integration', async () => {
 
@@ -28,9 +28,9 @@ describe('ReferenceModeStore Integration', async () => {
     const runtime = new Runtime();
     RamDiskStorageDriverProvider.register(runtime.getMemoryProvider());
     const storageKey = new ReferenceModeStorageKey(new RamDiskStorageKey('backing'), new RamDiskStorageKey('container'));
-    const arc = Runtime.newForNodeTesting().newArc("testArc");
+    const arc = Runtime.newForNodeTesting().newArc('testArc');
 
-    const type = new EntityType(new Schema(["AnEntity"], {foo: "Text"})).collectionOf();
+    const type = new EntityType(new Schema(['AnEntity'], {foo: 'Text'})).collectionOf();
 
     // Use newHandle here rather than setting up a store inside the arc, as this ensures writeHandle and readHandle
     // are on top of different storage stacks.
@@ -39,12 +39,12 @@ describe('ReferenceModeStore Integration', async () => {
 
 
     readHandle.particle = new Particle();
-    return new Promise(async (resolve, reject) => {
+    const returnPromise = new Promise((resolve, reject) => {
 
       let state = 0;
 
       readHandle.particle['onHandleSync'] = async (handle, model) => {
-        if (state == 0) {
+        if (state === 0) {
           assert.deepEqual(model, []);
           state = 1;
         } else {
@@ -52,9 +52,11 @@ describe('ReferenceModeStore Integration', async () => {
           assert.equal(model[0].foo, 'This is text in foo');
           resolve();
         }
-      }
+      };
 
-      await writeHandle.addFromData({foo: "This is text in foo"});
     });
+
+    await writeHandle.addFromData({foo: 'This is text in foo'});
+    return returnPromise;
   });
 });

--- a/src/runtime/storageNG/tests/reference-mode-store-integration-test.ts
+++ b/src/runtime/storageNG/tests/reference-mode-store-integration-test.ts
@@ -1,0 +1,60 @@
+/**
+ * @license
+ * Copyright (c) 2020 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {assert} from '../../../platform/chai-web.js';
+import {RamDiskStorageKey, RamDiskStorageDriverProvider} from '../drivers/ramdisk.js';
+import {DriverFactory} from '../drivers/driver-factory.js';
+import {Runtime} from '../../runtime.js';
+import {EntityType} from '../../type.js';
+import { ReferenceModeStorageKey } from '../reference-mode-storage-key.js';
+import { newHandle } from '../storage-ng.js';
+import { Schema } from '../../schema.js';
+import { Particle } from '../../particle.js';
+
+describe('ReferenceModeStore Integration', async () => {
+
+  afterEach(() => {
+    DriverFactory.clearRegistrationsForTesting();
+  });
+
+  it('will store and retrieve entities through referenceModeStores', async () => {
+    const runtime = new Runtime();
+    RamDiskStorageDriverProvider.register(runtime.getMemoryProvider());
+    const storageKey = new ReferenceModeStorageKey(new RamDiskStorageKey('backing'), new RamDiskStorageKey('container'));
+    const arc = Runtime.newForNodeTesting().newArc("testArc");
+
+    const type = new EntityType(new Schema(["AnEntity"], {foo: "Text"})).collectionOf();
+
+    // Use newHandle here rather than setting up a store inside the arc, as this ensures writeHandle and readHandle
+    // are on top of different storage stacks.
+    const writeHandle = await newHandle(type, storageKey, arc, {id: 'write-handle'});
+    const readHandle = await newHandle(type, storageKey, arc, {id: 'read-handle'});
+
+
+    readHandle.particle = new Particle();
+    return new Promise(async (resolve, reject) => {
+
+      let state = 0;
+
+      readHandle.particle['onHandleSync'] = async (handle, model) => {
+        if (state == 0) {
+          assert.deepEqual(model, []);
+          state = 1;
+        } else {
+          assert.equal(model.length, 1);
+          assert.equal(model[0].foo, 'This is text in foo');
+          resolve();
+        }
+      }
+
+      await writeHandle.addFromData({foo: "This is text in foo"});
+    });
+  });
+});


### PR DESCRIPTION
(1) duplicated onSync message when first setting up. This was happening
because we call requestSynchronization() inside registerHandle. This
can cause a message to be delivered to the proxy which causes it to
become synchronized. When we register a new handle, if the proxy is
already synchronized before the handle is added to the list then we need
to send a "fake" onSync so the particle gets the right sequence of
messages. However, if we don't check synchronization state until the
end of the method then the message delivered as a consequence of
requestSynchronization might result in there being duplicate onSyncs,
one from that message and one from this check.

(2) swallowed updates. When the store sends a model to the storageProxy,
we were only delivering it upwards if the model wasn't already synced.
However, this loses state that should be converted to an update message.
Sometimes we won't be able to deliver an update, because we can't
recover the change as a set of operations. In these cases, we still
need to deliver the udpate as a sync; so we need to desync first in
order to do so.