### PR TITLE
Started implementation of policy parser.

### DIFF
--- a/src/runtime/manifest-ast-nodes.ts
+++ b/src/runtime/manifest-ast-nodes.ts
@@ -807,6 +807,32 @@ export interface NumberedUnits extends BaseNode {
   units: string;
 }
 
+export interface Policy extends BaseNode {
+  kind: 'policy';
+  name: string;
+  targets: PolicyTarget[];
+  configs: PolicyConfig[];
+  annotationRefs?: AnnotationRef[];
+}
+
+export interface PolicyTarget extends BaseNode {
+  kind: 'policy-target';
+  storeId: string;
+  fields: PolicyField[];
+}
+
+export interface PolicyField extends BaseNode {
+  kind: 'policy-field';
+  name: string;
+  subfields: PolicyField[];
+}
+
+export interface PolicyConfig extends BaseNode {
+  kind: 'policy-config';
+  name: string;
+  metadata: Map<string, string>;
+}
+
 // Aliases to simplify ts-pegjs returnTypes requirement in sigh.
 export type Triggers = [string, string][][];
 export type Indent = number;

--- a/src/runtime/manifest-ast-nodes.ts
+++ b/src/runtime/manifest-ast-nodes.ts
@@ -817,7 +817,7 @@ export interface Policy extends BaseNode {
 
 export interface PolicyTarget extends BaseNode {
   kind: 'policy-target';
-  storeId: string;
+  schemaName: string;
   fields: PolicyField[];
 }
 

--- a/src/runtime/manifest-parser.pegjs
+++ b/src/runtime/manifest-parser.pegjs
@@ -1779,11 +1779,11 @@ PolicyItem
 
 // TODO(b/157605585): Annotations on policy targets.
 PolicyTarget
-  = 'from' whiteSpace storeId:id whiteSpace 'access' fields:PolicyFieldSet
+  = 'from' whiteSpace schemaName:upperIdent whiteSpace 'access' fields:PolicyFieldSet
   {
     return toAstNode<AstNode.PolicyTarget>({
       kind: 'policy-target',
-      storeId,
+      schemaName,
       fields,
     });
   }

--- a/src/runtime/policy/tests/policy-parser-test.ts
+++ b/src/runtime/policy/tests/policy-parser-test.ts
@@ -60,30 +60,30 @@ describe('policy parser', () => {
   describe('targets', () => {
     it('parses a single empty target', () => {
       const policy = parsePolicy(`policy MyPolicy {
-        from 'abc' access {}
+        from Abc access {}
       }`);
       assert.deepStrictEqual(policy.targets, [{
         kind: 'policy-target',
-        storeId: 'abc',
+        schemaName: 'Abc',
         fields: [],
       }]);
     });
 
     it('parses multiple targets', () => {
       const policy = parsePolicy(`policy MyPolicy {
-        from 'abc' access {}
-        from 'xyz' access {}
+        from Abc access {}
+        from Xyz access {}
       }`);
       assert.lengthOf(policy.targets, 2);
-      assert.deepStrictEqual(policy.targets.map(target => target.storeId), [
-        'abc',
-        'xyz',
+      assert.deepStrictEqual(policy.targets.map(target => target.schemaName), [
+        'Abc',
+        'Xyz',
       ]);
     });
 
     it('parses a single field', () => {
       const policy = parsePolicy(`policy MyPolicy {
-        from 'abc' access {
+        from Abc access {
           someField,
         }
       }`);
@@ -96,7 +96,7 @@ describe('policy parser', () => {
 
     it('parses multiple fields', () => {
       const policy = parsePolicy(`policy MyPolicy {
-        from 'abc' access {
+        from Abc access {
           someField1,
           someField2,
           someField3
@@ -111,7 +111,7 @@ describe('policy parser', () => {
 
     it('parses nested fields', () => {
       const policy = parsePolicy(`policy MyPolicy {
-        from 'abc' access {
+        from Abc access {
           grandParent {
             parent1 {
               child1,

--- a/src/runtime/policy/tests/policy-parser-test.ts
+++ b/src/runtime/policy/tests/policy-parser-test.ts
@@ -1,0 +1,240 @@
+/**
+ * @license
+ * Copyright (c) 2020 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {parse} from '../../../gen/runtime/manifest-parser.js';
+import {assert} from '../../../platform/chai-web.js';
+import {Dictionary} from '../../hot.js';
+
+// Recursively delete all fields with the given name.
+// tslint:disable-next-line: no-any
+function deleteFieldRecursively(node: any, field: string) {
+  if (typeof node !== 'object') {
+    return;
+  }
+  if (field in node) {
+    delete node[field];
+  }
+  for (const value of Object.values(node)) {
+    deleteFieldRecursively(value, field);
+  }
+}
+
+function parsePolicy(str: string) {
+  const nodes = parse(str);
+  assert.lengthOf(nodes, 1, `Expected a single policy, found ${nodes.length}.`);
+  const node = nodes[0];
+  assert.strictEqual(
+    node.kind, 'policy',
+    `Expected a single policy node, found node with kind ${node.kind}.`);
+  deleteFieldRecursively(node, 'location');
+  return node;
+}
+
+function mapToDictionary(map: Map<string, string>): Dictionary<string> {
+  const dict = {};
+  for (const [k, v] of map) {
+    dict[k] = v;
+  }
+  return dict;
+}
+
+describe('policy parser', () => {
+  it('parses an empty policy', () => {
+    const policy = parsePolicy(`policy MyPolicy {}`);
+    assert.deepEqual(policy, {
+      kind: 'policy',
+      name: 'MyPolicy',
+      targets: [],
+      configs: [],
+      annotationRefs: [],
+    });
+  });
+
+  describe('targets', () => {
+    it('parses a single empty target', () => {
+      const policy = parsePolicy(`policy MyPolicy {
+        from 'abc' access {}
+      }`);
+      assert.deepStrictEqual(policy.targets, [{
+        kind: 'policy-target',
+        storeId: 'abc',
+        fields: [],
+      }]);
+    });
+
+    it('parses multiple targets', () => {
+      const policy = parsePolicy(`policy MyPolicy {
+        from 'abc' access {}
+        from 'xyz' access {}
+      }`);
+      assert.lengthOf(policy.targets, 2);
+      assert.deepStrictEqual(policy.targets.map(target => target.storeId), [
+        'abc',
+        'xyz',
+      ]);
+    });
+
+    it('parses a single field', () => {
+      const policy = parsePolicy(`policy MyPolicy {
+        from 'abc' access {
+          someField,
+        }
+      }`);
+      assert.deepStrictEqual(policy.targets[0].fields, [{
+        kind: 'policy-field',
+        name: 'someField',
+        subfields: [],
+      }]);
+    });
+
+    it('parses multiple fields', () => {
+      const policy = parsePolicy(`policy MyPolicy {
+        from 'abc' access {
+          someField1,
+          someField2,
+          someField3
+        }
+      }`);
+      assert.deepStrictEqual(policy.targets[0].fields.map(field => field.name), [
+        'someField1',
+        'someField2',
+        'someField3',
+      ]);
+    });
+
+    it('parses nested fields', () => {
+      const policy = parsePolicy(`policy MyPolicy {
+        from 'abc' access {
+          grandParent {
+            parent1 {
+              child1,
+              child2
+            },
+            parent2 { child3, },
+          },
+          parent3 { child4, child5 }
+          child6
+          child7,
+        }
+      }`);
+      deleteFieldRecursively(policy, 'kind');
+      assert.deepStrictEqual(policy.targets[0].fields, [
+        {name: 'grandParent', subfields: [
+          {name: 'parent1', subfields: [
+            {name: 'child1', subfields: []},
+            {name: 'child2', subfields: []},
+          ]},
+          {name: 'parent2', subfields: [
+            {name: 'child3', subfields: []},
+          ]},
+        ]},
+        {name: 'parent3', subfields: [
+          {name: 'child4', subfields: []},
+          {name: 'child5', subfields: []},
+        ]},
+        {name: 'child6', subfields: []},
+        {name: 'child7', subfields: []},
+      ]);
+    });
+  });
+
+  describe('configs', () => {
+    it('parses an empty config', () => {
+      const policy = parsePolicy(`policy MyPolicy {
+          config myConfig {}
+        }`);
+      const config = policy.configs[0];
+      assert.strictEqual(config.name, 'myConfig');
+      assert.isEmpty(config.metadata);
+    });
+
+    it('parses multiple configs', () => {
+      const policy = parsePolicy(`policy MyPolicy {
+          config myConfig1 {}
+          config myConfig2 {}
+          config myConfig3 {}
+        }`);
+      assert.lengthOf(policy.configs, 3);
+      assert.deepStrictEqual(policy.configs.map(config => config.name), [
+        'myConfig1',
+        'myConfig2',
+        'myConfig3',
+      ]);
+    });
+
+    it('parses a single config value', () => {
+      const policy = parsePolicy(`policy MyPolicy {
+          config myConfig {abc:'xyz'}
+        }`);
+      assert.deepStrictEqual(mapToDictionary(policy.configs[0].metadata), {
+        abc: 'xyz',
+      });
+    });
+
+    it('accepts trailing commas', () => {
+      const policy = parsePolicy(`policy MyPolicy {
+          config myConfig { abc: 'xyz', }
+        }`);
+      assert.deepStrictEqual(mapToDictionary(policy.configs[0].metadata), {
+        abc: 'xyz',
+      });
+    });
+
+    it('parses multiple config values on the same line', () => {
+      const policy = parsePolicy(`policy MyPolicy {
+          config myConfig { abc1: 'xyz1', abc2: 'xyz2', abc3: 'xyz3' }
+        }`);
+      assert.deepStrictEqual(mapToDictionary(policy.configs[0].metadata), {
+        abc1: 'xyz1',
+        abc2: 'xyz2',
+        abc3: 'xyz3',
+      });
+    });
+
+    it('parses multiple config values on different lines with commas', () => {
+      const policy = parsePolicy(`policy MyPolicy {
+          config myConfig {
+            abc1: 'xyz1',
+            abc2: 'xyz2',
+            abc3: 'xyz3',
+          }
+        }`);
+      assert.deepStrictEqual(mapToDictionary(policy.configs[0].metadata), {
+        abc1: 'xyz1',
+        abc2: 'xyz2',
+        abc3: 'xyz3',
+      });
+    });
+
+    it('parses multiple config values on different lines without commas', () => {
+      const policy = parsePolicy(`policy MyPolicy {
+          config myConfig {
+            abc1: 'xyz1'
+            abc2: 'xyz2'
+            abc3: 'xyz3'
+          }
+        }`);
+      assert.deepStrictEqual(mapToDictionary(policy.configs[0].metadata), {
+        abc1: 'xyz1',
+        abc2: 'xyz2',
+        abc3: 'xyz3',
+      });
+    });
+
+    it('rejects duplicate keys', () => {
+      assert.throws(() => parsePolicy(`policy MyPolicy {
+        config myConfig {
+          abc: '123'
+          abc: '456'
+        }
+      }`), `Duplicate key in policy config: abc`);
+    });
+  });
+});

--- a/src/runtime/tests/manifest-parser-test.ts
+++ b/src/runtime/tests/manifest-parser-test.ts
@@ -13,7 +13,7 @@ import {assert} from '../../platform/chai-web.js';
 import {Flags} from '../flags.js';
 
 describe('manifest parser', () => {
-  it('parses an empy manifest', () => {
+  it('parses an empty manifest', () => {
     parse('');
   });
   it('parses a trivial recipe', () => {

--- a/src/runtime/tests/manifest-test.ts
+++ b/src/runtime/tests/manifest-test.ts
@@ -4371,7 +4371,6 @@ recipe
     assert.equal(recipe.handles[0].annotations.toString(), `@ttl(value: '3d')`);
 
     const isolatedParticleAnnotations = manifest.findParticleByName('IsolatedParticle').annotations;
-    console.error(manifest.findParticleByName('IsolatedParticle'));
     assert.lengthOf(isolatedParticleAnnotations, 1);
     assert.equal(isolatedParticleAnnotations[0].name, 'isolated');
     assert.lengthOf(Object.entries(isolatedParticleAnnotations[0].params), 0);


### PR DESCRIPTION
Currently supports:
* Store targets: `from 'store-id' access { ... }`
* Nested fields: `foo { bar, baz }`
* Configs: `config myConf { abc: 123, def: 456 }`

Remaining TODOs:
* Annotations on policy definition.
* Annotations on policy targets.
* Annotations on fields and nested fields.
* Convert parsed AST to proto.