### PR TITLE
TupleType and Schema.toString() for Kotlin

### DIFF
--- a/java/arcs/android/type/ParcelableType.kt
+++ b/java/arcs/android/type/ParcelableType.kt
@@ -18,6 +18,7 @@ import arcs.core.data.CountType
 import arcs.core.data.EntityType
 import arcs.core.data.ReferenceType
 import arcs.core.data.SingletonType
+import arcs.core.data.TupleType
 import arcs.core.data.TypeVariable
 import arcs.core.type.Tag
 import arcs.core.type.Type
@@ -113,6 +114,31 @@ sealed class ParcelableType(open val actual: Type) : Parcelable {
         }
     }
 
+    /** [Parcelable] variant of [arcs.core.data.TupleType]. */
+    class TupleType(
+        override val actual: arcs.core.data.TupleType
+    ) : ParcelableType(actual) {
+        override fun writeToParcel(parcel: Parcel, flags: Int) {
+            super.writeToParcel(parcel, flags)
+            parcel.writeInt(actual.elementTypes.size)
+            for (element in actual.elementTypes) {
+                parcel.writeType(element, flags)
+            }
+        }
+
+        companion object CREATOR : Parcelable.Creator<TupleType> {
+            override fun createFromParcel(parcel: Parcel): TupleType {
+                val elements = mutableListOf<Type>()
+                repeat(parcel.readInt()) {
+                    elements.add(requireNotNull(parcel.readType()))
+                }
+                return TupleType(actual = TupleType(elements))
+            }
+
+            override fun newArray(size: Int): Array<TupleType?> = arrayOfNulls(size)
+        }
+    }
+
     /** [Parcelable] variant of [arcs.core.data.TypeVariable]. */
     data class TypeVariable(
         override val actual: arcs.core.data.TypeVariable
@@ -139,6 +165,7 @@ sealed class ParcelableType(open val actual: Type) : Parcelable {
                 Tag.Entity -> EntityType.createFromParcel(parcel)
                 Tag.Reference -> ReferenceType.createFromParcel(parcel)
                 Tag.Singleton -> SingletonType.createFromParcel(parcel)
+                Tag.Tuple -> TupleType.createFromParcel(parcel)
                 Tag.TypeVariable -> TypeVariable.createFromParcel(parcel)
             }
 
@@ -153,6 +180,7 @@ fun Type.toParcelable(): ParcelableType = when (tag) {
     Tag.Entity -> ParcelableType.EntityType(this as EntityType)
     Tag.Reference -> ParcelableType.ReferenceType(this as ReferenceType<*>)
     Tag.Singleton -> ParcelableType.SingletonType(this as SingletonType<*>)
+    Tag.Tuple -> ParcelableType.TupleType(this as TupleType)
     Tag.TypeVariable -> ParcelableType.TypeVariable(this as TypeVariable)
 }
 

--- a/java/arcs/core/data/EntityType.kt
+++ b/java/arcs/core/data/EntityType.kt
@@ -40,8 +40,7 @@ data class EntityType(override val entitySchema: Schema) :
     override fun toLiteral() = Literal(tag, entitySchema.toLiteral())
 
     override fun toString(options: Type.ToStringOptions): String {
-        return entitySchema.name?.toPrettyString()
-            ?: entitySchema.toLiteral().toJson()
+        return entitySchema.toString(options)
     }
 
     /** Serialization-friendly [TypeLiteral] for [EntityType]. */

--- a/java/arcs/core/data/Schema.kt
+++ b/java/arcs/core/data/Schema.kt
@@ -55,6 +55,14 @@ data class Schema(
 
     fun createCrdtEntityModel(): CrdtEntity = CrdtEntity(VersionMap(), emptyRawEntity)
 
+    override fun toString() = toString(Type.ToStringOptions())
+
+    /**
+     * @param options granular options, e.g. whether to list Schema fields.
+     */
+    fun toString(options: Type.ToStringOptions) =
+        names.map { it.name }.plusElement(fields.toString(options)).joinToString(" ")
+
     data class Literal(
         val names: Set<SchemaName>,
         val fields: SchemaFields,

--- a/java/arcs/core/data/SchemaFields.kt
+++ b/java/arcs/core/data/SchemaFields.kt
@@ -11,18 +11,26 @@
 
 package arcs.core.data
 
+import arcs.core.type.Type
+
 /** The possible types for a field in a [Schema]. */
 sealed class FieldType(
     val tag: Tag
 ) {
     /** An Arcs primitive type. */
-    data class Primitive(val primitiveType: PrimitiveType) : FieldType(Tag.Primitive)
+    data class Primitive(val primitiveType: PrimitiveType) : FieldType(Tag.Primitive) {
+        override fun toString() = primitiveType.name
+    }
 
     /** A reference to an entity. */
-    data class EntityRef(val schemaHash: String) : FieldType(Tag.EntityRef)
+    data class EntityRef(val schemaHash: String) : FieldType(Tag.EntityRef) {
+        override fun toString() = "&$schemaHash"
+    }
 
     /** A tuple of [FieldType]s */
-    data class Tuple(val types: List<FieldType>) : FieldType(Tag.Tuple)
+    data class Tuple(val types: List<FieldType>) : FieldType(Tag.Tuple) {
+        override fun toString() = "(${types.joinToString()})"
+    }
 
     enum class Tag {
         Primitive,
@@ -65,4 +73,18 @@ val LARGEST_PRIMITIVE_TYPE_ID = PrimitiveType.values().size - 1
 data class SchemaFields(
     val singletons: Map<FieldName, FieldType>,
     val collections: Map<FieldName, FieldType>
-)
+) {
+
+    override fun toString() = toString(Type.ToStringOptions())
+
+    fun toString(options: Type.ToStringOptions): String {
+        val fields = when (options.hideFields) {
+            true -> "..."
+            false -> listOf(
+                singletons.map { (name, type) -> "$name: $type" },
+                collections.map { (name, type) -> "$name: [$type]" }
+            ).flatten().joinToString()
+        }
+        return "{$fields}"
+    }
+}

--- a/java/arcs/core/data/TupleType.kt
+++ b/java/arcs/core/data/TupleType.kt
@@ -1,0 +1,45 @@
+package arcs.core.data
+
+import arcs.core.common.LiteralList
+import arcs.core.type.Tag
+import arcs.core.type.Type
+import arcs.core.type.TypeFactory
+import arcs.core.type.TypeLiteral
+
+/** [Type] representation of a tuple. */
+data class TupleType(val elementTypes: List<Type>) : Type {
+
+    override val tag = Tag.Tuple
+
+    override fun copy(variableMap: MutableMap<Any, Any>): Type =
+        TypeFactory.getType(Literal(tag, LiteralList(elementTypes.map { it.toLiteral() })))
+
+    override fun copyWithResolutions(variableMap: MutableMap<Any, Any>): Type =
+        TupleType(elementTypes.map { it.copyWithResolutions(variableMap) })
+
+    override fun toLiteral() = Literal(tag, LiteralList(elementTypes.map { it.toLiteral() }))
+
+    override fun toString(options: Type.ToStringOptions) =
+        "(${elementTypes.joinToString { it.toString(options) }})"
+
+    /** [Literal] representation of a [TupleType]. */
+    data class Literal(
+        override val tag: Tag,
+        override val data: LiteralList<TypeLiteral>
+    ) : TypeLiteral
+
+    companion object {
+        init {
+            TypeFactory.registerBuilder(Tag.Tuple) { literal ->
+                TupleType((literal as Literal).data.map { TypeFactory.getType(it) })
+            }
+        }
+
+        /**
+         * Utility function for constructing [TupleType] from the passed types.
+         *
+         * @param types the list of types from which to construct the tuple.
+         */
+        fun of(vararg types: Type) = TupleType(types.toList())
+    }
+}

--- a/java/arcs/core/type/Tag.kt
+++ b/java/arcs/core/type/Tag.kt
@@ -22,7 +22,7 @@ enum class Tag {
     // Handle,
     // Interface,
     Reference,
-    // Tuple,
+    Tuple,
     Singleton,
     // Slot,
     TypeVariable,

--- a/javatests/arcs/android/type/ParcelableTypeTest.kt
+++ b/javatests/arcs/android/type/ParcelableTypeTest.kt
@@ -22,6 +22,7 @@ import arcs.core.data.Schema
 import arcs.core.data.SchemaFields
 import arcs.core.data.SchemaName
 import arcs.core.data.SingletonType
+import arcs.core.data.TupleType
 import arcs.core.data.TypeVariable
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
@@ -118,6 +119,24 @@ class ParcelableTypeTest {
         }
 
         assertThat(unmarshalled).isEqualTo(singletonType)
+    }
+
+    @Test
+    fun parcelableRoundtrip_works_forTupleType() {
+        val tupleType = TupleType.of(EntityType(entitySchema), TypeVariable("a"))
+
+        val marshalled = with(Parcel.obtain()) {
+            writeType(tupleType, 0)
+            marshall()
+        }
+
+        val unmarshalled = with(Parcel.obtain()) {
+            unmarshall(marshalled, 0, marshalled.size)
+            setDataPosition(0)
+            readType()
+        }
+
+        assertThat(unmarshalled).isEqualTo(tupleType)
     }
 
     @Test

--- a/javatests/arcs/core/data/SchemaFieldsTest.kt
+++ b/javatests/arcs/core/data/SchemaFieldsTest.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.core.data
+
+import arcs.core.type.Type.ToStringOptions
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class SchemaFieldsTest {
+
+    @Test
+    fun toStringCanHideFields() {
+        assertThat(
+            SchemaFields(
+                mapOf("name" to FieldType.Text),
+                mapOf()
+            ).toString(ToStringOptions(hideFields = true))
+        ).isEqualTo("{...}")
+    }
+
+    @Test
+    fun toStringWorksForPrimitiveFields() {
+        assertThat(
+            SchemaFields(
+                singletons = mapOf(
+                    "name" to FieldType.Text,
+                    "sku" to FieldType.Text
+                ),
+                collections = mapOf(
+                    "ratings" to FieldType.Number
+                )
+            ).toString(ToStringOptions())
+        ).isEqualTo(
+            "{name: Text, sku: Text, ratings: [Number]}"
+        )
+    }
+
+    @Test
+    fun toStringWorksForTupleFields() {
+        assertThat(
+            SchemaFields(
+                singletons = mapOf("dimensions" to FieldType.Tuple(listOf(
+                    FieldType.Number,
+                    FieldType.Number,
+                    FieldType.Number
+                ))),
+                collections = mapOf("reviews" to FieldType.Tuple(listOf(
+                    FieldType.Text,
+                    FieldType.Number
+                )))
+            ).toString(ToStringOptions())
+        ).isEqualTo(
+            "{dimensions: (Number, Number, Number), reviews: [(Text, Number)]}"
+        )
+    }
+
+    @Test
+    fun toStringWorksForReferenceFields() {
+        assertThat(
+            SchemaFields(
+                singletons = mapOf("manufacturer" to FieldType.EntityRef(schemaHash = "x1y2z3")),
+                collections = mapOf("reviews" to FieldType.EntityRef(schemaHash = "a1b2c3d4"))
+            ).toString(ToStringOptions())
+        ).isEqualTo(
+            "{manufacturer: &x1y2z3, reviews: [&a1b2c3d4]}"
+        )
+    }
+
+    @Test
+    fun toStringWithoutArgumentsWorks() {
+        assertThat(
+            SchemaFields(
+                singletons = mapOf(
+                    "name" to FieldType.Text,
+                    "dimensions" to FieldType.Tuple(listOf(
+                        FieldType.Number,
+                        FieldType.Number,
+                        FieldType.Number
+                    )),
+                    "manufacturer" to FieldType.EntityRef(schemaHash = "x1y2z3")
+                ),
+                collections = mapOf()
+            ).toString()
+        ).isEqualTo(
+            "{name: Text, dimensions: (Number, Number, Number), manufacturer: &x1y2z3}"
+        )
+    }
+}

--- a/javatests/arcs/core/data/SchemaTest.kt
+++ b/javatests/arcs/core/data/SchemaTest.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.core.data
+
+import arcs.core.type.Type.ToStringOptions
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class SchemaTest {
+
+    @Test
+    fun toStringWithArgumentsPrintsOutTheSchema() {
+        assertThat(PRODUCT_SCHEMA.toString(ToStringOptions())).isEqualTo(
+            "Product Thing {name: Text, ratings: [Number]}"
+        )
+    }
+
+    @Test
+    fun toStringWithoutArgumentsPrintsOutTheSchema() {
+        assertThat(PRODUCT_SCHEMA.toString()).isEqualTo(
+            "Product Thing {name: Text, ratings: [Number]}"
+        )
+    }
+
+    @Test
+    fun toStringCanHideFields() {
+        assertThat(PRODUCT_SCHEMA.toString(ToStringOptions(hideFields = true))).isEqualTo(
+            "Product Thing {...}"
+        )
+    }
+
+    companion object {
+        private val PRODUCT_SCHEMA = Schema(
+            setOf(SchemaName("Product"), SchemaName("Thing")),
+            SchemaFields(
+                mapOf("name" to FieldType.Text),
+                mapOf("ratings" to FieldType.Number)
+            ),
+            "fake-hash"
+        )
+    }
+}

--- a/javatests/arcs/core/data/TupleTypeTest.kt
+++ b/javatests/arcs/core/data/TupleTypeTest.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.core.data
+
+import arcs.core.type.Tag
+import arcs.core.type.Type.ToStringOptions
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class TupleTypeTest {
+
+    @Test
+    fun tagIsTuple() {
+        assertThat(TupleType.of().tag).isEqualTo(Tag.Tuple)
+    }
+
+    @Test
+    fun toStringListsElementTypes() {
+        assertThat(
+            TupleType.of(
+                TypeVariable("a"),
+                ReferenceType(EntityType(PRODUCT_SCHEMA))
+            ).toString(ToStringOptions())
+        ).isEqualTo(
+            "(~a, &Product {})"
+        )
+    }
+
+    companion object {
+        private val PRODUCT_SCHEMA = Schema(
+            setOf(SchemaName("Product")),
+            SchemaFields(mapOf(), mapOf()),
+            "fake-hash"
+        )
+    }
+}


### PR DESCRIPTION
I need TupleType to specify the type for join handles and respective handle connections.

I couldn't properly test toString() on the TupleType so I implemented toString() properly for Schemas.