### PR TITLE
De-flake the arcs.core.entity.ReferenceTest

### DIFF
--- a/java/arcs/core/testutil/BUILD
+++ b/java/arcs/core/testutil/BUILD
@@ -11,5 +11,6 @@ arcs_kt_jvm_library(
     srcs = glob(["*.kt"]),
     deps = [
         "//third_party/java/junit:junit-android",
+        "//third_party/kotlin/kotlinx_coroutines",
     ],
 )

--- a/java/arcs/core/testutil/RunTest.kt
+++ b/java/arcs/core/testutil/RunTest.kt
@@ -11,11 +11,11 @@
 
 package arcs.core.testutil
 
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
-import kotlin.coroutines.CoroutineContext
-import kotlin.coroutines.EmptyCoroutineContext
 
 /**
  * Alternative to [runBlocking] which always returns [Unit] (safe for JUnit tests) and enforces a

--- a/java/arcs/core/testutil/RunTest.kt
+++ b/java/arcs/core/testutil/RunTest.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.core.testutil
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+
+/**
+ * Alternative to [runBlocking] which always returns [Unit] (safe for JUnit tests) and enforces a
+ * timeout, to help avoid waiting forever for a test to finish/time-out.
+ *
+ * When necessary, you can provide a specific dispatcher for the [coroutineContext] parameter,
+ * for example: a handle's dispatcher.
+ *
+ * The default value for [timeoutMillis] is 5,000ms (5 seconds).
+ */
+fun runTest(
+    coroutineContext: CoroutineContext = EmptyCoroutineContext,
+    timeoutMillis: Long = 5000,
+    block: suspend CoroutineScope.() -> Unit
+) = runBlocking(coroutineContext) {
+    withTimeout(timeoutMillis) { this.block() }
+}

--- a/javatests/arcs/core/entity/ReferenceTest.kt
+++ b/javatests/arcs/core/entity/ReferenceTest.kt
@@ -3,42 +3,39 @@ package arcs.core.entity
 import arcs.core.data.HandleMode
 import arcs.core.data.RawEntity
 import arcs.core.data.Schema
-import arcs.core.data.util.toReferencable
 import arcs.core.host.EntityHandleManager
 import arcs.core.storage.DriverFactory
 import arcs.core.storage.api.DriverAndKeyConfigurator
 import arcs.core.storage.Reference as StorageReference
 import arcs.core.storage.RawEntityDereferencer
+import arcs.core.storage.StoreManager
+import arcs.core.storage.driver.RamDisk
 import arcs.core.storage.keys.RamDiskStorageKey
 import arcs.core.storage.referencemode.ReferenceModeStorageKey
+import arcs.core.testutil.runTest
 import arcs.core.util.Scheduler
+import arcs.core.util.testutil.LogRule
 import arcs.jvm.util.testutil.FakeTime
 import com.google.common.truth.Truth.assertThat
-import kotlin.test.assertFailsWith
 import kotlinx.coroutines.asCoroutineDispatcher
-import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import java.util.concurrent.Executors
 
 @RunWith(JUnit4::class)
-@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
 @Suppress("UNCHECKED_CAST")
 class ReferenceTest {
-    private val scheduler = Scheduler(
-        Executors.newSingleThreadExecutor().asCoroutineDispatcher()
-    )
-    private val dereferencer = RawEntityDereferencer(DummyEntity.SCHEMA, scheduler = scheduler)
-    private val entityHandleManager = EntityHandleManager(
-        "testArc",
-        "",
-        FakeTime(),
-        scheduler = scheduler
-    )
+    @get:Rule
+    val log = LogRule()
 
+    private lateinit var scheduler: Scheduler
+    private lateinit var dereferencer: RawEntityDereferencer
+    private lateinit var entityHandleManager: EntityHandleManager
+    private lateinit var stores: StoreManager
     private lateinit var handle: ReadWriteCollectionHandle<DummyEntity>
 
     private val STORAGE_KEY = ReferenceModeStorageKey(
@@ -47,9 +44,25 @@ class ReferenceTest {
     )
 
     @Before
-    fun setUp() = runBlocking {
+    fun setUp() = runTest {
+        RamDisk.clear()
         DriverAndKeyConfigurator.configure(null)
         SchemaRegistry.register(DummyEntity.SCHEMA)
+
+        scheduler = Scheduler(Executors.newSingleThreadExecutor().asCoroutineDispatcher())
+        stores = StoreManager()
+        dereferencer = RawEntityDereferencer(
+            DummyEntity.SCHEMA,
+            scheduler = scheduler,
+            storeManager = stores
+        )
+        entityHandleManager = EntityHandleManager(
+            "testArc",
+            "",
+            FakeTime(),
+            scheduler = scheduler,
+            stores = stores
+        )
 
         handle = entityHandleManager.createHandle(
             HandleSpec(
@@ -63,21 +76,23 @@ class ReferenceTest {
     }
 
     @After
-    fun tearDown() = runBlocking {
+    fun tearDown() = runTest {
         scheduler.waitForIdle()
+        stores.waitForIdle()
         entityHandleManager.close()
+        scheduler.cancel()
+
         SchemaRegistry.clearForTest()
         DriverFactory.clearRegistrations()
     }
 
     @Test
-    fun dereference() = runBlocking {
+    fun dereference() = runTest(handle.dispatcher) {
         val entity = DummyEntity().apply {
             text = "Watson"
             num = 6.0
         }
-        handle.store(entity)
-        scheduler.waitForIdle()
+        handle.store(entity).join()
 
         val reference = handle.createReference(entity)
         val entityOut = reference.dereference()
@@ -86,7 +101,7 @@ class ReferenceTest {
     }
 
     @Test
-    fun missingEntity_returnsNull() = runBlocking {
+    fun missingEntity_returnsNull() = runTest {
         val reference = createReference("id", "key", DummyEntity)
         assertThat(reference.dereference()).isNull()
     }


### PR DESCRIPTION
No existing bug specifically for this test's flakiness, but it is part of the umbrella: http://b/157513559

```
//javatests/arcs/core/entity:ReferenceTest     PASSED in 55.6s
  Stats over 100000 runs: max = 55.6s, min = 1.3s, avg = 3.1s, dev = 1.5s

Executed 1 out of 1 test: 1 test passes.
```