### PR TITLE
Fixing Kotlin-Native Compiler "Read-Only" issue

### DIFF
--- a/build_defs/kotlin_native/repo.bzl
+++ b/build_defs/kotlin_native/repo.bzl
@@ -111,7 +111,6 @@ def _impl(repository_ctx):
         repository_ctx.symlink("{0}/{1}".format(src_path, dep), alias)
 
     repository_ctx.file("{0}/dependencies/.extracted".format(src_path), "\n".join(deps_names))
-    repository_ctx.file("{0}/cache/.lock".format(src_path), "")
 
     repository_ctx.file("{0}/BUILD".format(src_path), KOTLIN_NATIVE_BUILD_FILE)
 


### PR DESCRIPTION
Investigation / credit to @mykmartin 

In #5344, a command was moved from a bash script to bazel that created a `.lock` file in a dependencies folder. This causes a file permissions issues on some systems. The root cause is that bazel has less access over file creation, whereas previously, the shell script had the same permissions (write) as the compiler. 

Myk [found](shared/blob/master/src/main/kotlin/org/jetbrains/kotlin/konan/util/DependencyProcessor.kt#L101) that the compiler creates the `.lock` file if it doesn't exist, meaning this line can be removed. 