### PR TITLE
Add test files for DataFlow Analysis in Kotlin

### DIFF
--- a/javatests/arcs/core/analysis/BUILD
+++ b/javatests/arcs/core/analysis/BUILD
@@ -9,7 +9,10 @@ package(default_visibility = ["//visibility:public"])
 
 arcs_kt_jvm_test_suite(
     name = "analysis",
-    data = ["//java/arcs/core/data/testdata:examples"],
+    data = [
+        "//java/arcs/core/data/testdata:examples",
+        "//javatests/arcs/core/analysis/testdata:example_manifest_protos",
+    ],
     package = "arcs.core.analysis",
     deps = [
         "//java/arcs/core/analysis",

--- a/javatests/arcs/core/analysis/testdata/BUILD
+++ b/javatests/arcs/core/analysis/testdata/BUILD
@@ -4,42 +4,18 @@ package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])
 
-INVALID_MANIFESTS = [
-    "fail_check_multiple_or_tags",
-    "fail_different_tag",
-    "fail_no_tags",
-    "fail_not_tag_cancels",
-    "fail_not_tag_claim",
-    "fail_negated_tag_present",
-    "fail_read_write_mismatch_claim_check",
-    "fail_multiple_inputs_one_untagged",
-    "fail_multiple_checks",
-    "fail_no_inputs",
-    "fail_mixer",
-]
+INVALID_MANIFESTS = glob(["fail_*.arcs"])
 
-VALID_MANIFESTS = [
-    "ok_directly_satisfied",
-    "ok_not_tag_claim_no_checks",
-    "ok_not_tag_claim_reclaimed",
-    "ok_negated_missing_tag",
-    "ok_read_write_match_claim_check",
-    "ok_multiple_inputs_correct_tags",
-    "ok_claim_propagates",
-    "ok_claim_not_overriden_later",
-    "ok_check_multiple_and_single_claim",
-    "ok_check_multiple_or_single_claim",
-    "ok_check_multiple_or_tags",
-]
+VALID_MANIFESTS = glob(["ok_*.arcs"])
 
 ALL_MANIFESTS = VALID_MANIFESTS + INVALID_MANIFESTS
 
 filegroup(
     name = "example_manifest_protos",
-    srcs = [":%s" % m for m in ALL_MANIFESTS],
+    srcs = [":%s" % m.replace(".arcs", "") for m in ALL_MANIFESTS],
 )
 
 [arcs_manifest_proto(
-    name = manifest,
-    src = "%s.arcs" % manifest,
+    name = manifest.replace(".arcs", ""),
+    src = "%s" % manifest,
 ) for manifest in ALL_MANIFESTS]

--- a/javatests/arcs/core/analysis/testdata/BUILD
+++ b/javatests/arcs/core/analysis/testdata/BUILD
@@ -1,0 +1,45 @@
+load("//third_party/java/arcs/build_defs:build_defs.bzl", "arcs_manifest_proto")
+
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+INVALID_MANIFESTS = [
+    "fail_check_multiple_or_tags",
+    "fail_different_tag",
+    "fail_no_tags",
+    "fail_not_tag_cancels",
+    "fail_not_tag_claim",
+    "fail_negated_tag_present",
+    "fail_read_write_mismatch_claim_check",
+    "fail_multiple_inputs_one_untagged",
+    "fail_multiple_checks",
+    "fail_no_inputs",
+    "fail_mixer",
+]
+
+VALID_MANIFESTS = [
+    "ok_directly_satisfied",
+    "ok_not_tag_claim_no_checks",
+    "ok_not_tag_claim_reclaimed",
+    "ok_negated_missing_tag",
+    "ok_read_write_match_claim_check",
+    "ok_multiple_inputs_correct_tags",
+    "ok_claim_propagates",
+    "ok_claim_not_overriden_later",
+    "ok_check_multiple_and_single_claim",
+    "ok_check_multiple_or_single_claim",
+    "ok_check_multiple_or_tags",
+]
+
+ALL_MANIFESTS = VALID_MANIFESTS + INVALID_MANIFESTS
+
+filegroup(
+    name = "example_manifest_protos",
+    srcs = [":%s" % m for m in ALL_MANIFESTS],
+)
+
+[arcs_manifest_proto(
+    name = manifest,
+    src = "%s.arcs" % manifest,
+) for manifest in ALL_MANIFESTS]

--- a/javatests/arcs/core/analysis/testdata/fail_check_multiple_or_tags.arcs
+++ b/javatests/arcs/core/analysis/testdata/fail_check_multiple_or_tags.arcs
@@ -1,0 +1,17 @@
+// fails when a check including multiple tags isn't met
+particle P1
+  foo: writes Foo {}
+  claim foo is tag1
+particle P2
+  foo: writes Foo {}
+  claim foo is someOtherTag
+particle P3
+  bar: reads Foo {}
+  check bar is tag1 or is tag2
+recipe R
+  P1
+    foo: writes h
+  P2
+    foo: writes h
+  P3
+    bar: reads h

--- a/javatests/arcs/core/analysis/testdata/fail_different_tag.arcs
+++ b/javatests/arcs/core/analysis/testdata/fail_different_tag.arcs
@@ -1,0 +1,12 @@
+// Fails when different tag is claimed.
+particle P1
+  foo: writes Foo {}
+  claim foo is notTrusted
+particle P2
+  bar: reads Foo {}
+  check bar is trusted
+recipe R
+  P1
+    foo: writes h
+  P2
+    bar: reads h

--- a/javatests/arcs/core/analysis/testdata/fail_mixer.arcs
+++ b/javatests/arcs/core/analysis/testdata/fail_mixer.arcs
@@ -1,0 +1,64 @@
+particle IngestionAppName
+  data: writes [AppName {
+    packageName: Text
+  }]
+  claim data is safeToLog and is packageName
+
+particle IngestionLocation
+  data: writes [Location {
+    location: Text
+  }]
+  claim data is coarseLocation
+
+particle Mixer
+  input1: reads [AppName {packageName: Text}]
+  input2: reads [Location {location: Text}]
+  output: writes [MixedData {whoKnowsWhat: Text}]
+
+// DFA Pass
+particle Egress1
+  data: reads [MixedData {whoKnowsWhat: Text}]
+  check data is packageName or is coarseLocation
+
+// DFA fail
+particle Egress2
+  data: reads [MixedData {whoKnowsWhat: Text}]
+  check data is packageName and is coarseLocation
+
+// DFA pass
+particle Egress3
+  data: reads [MixedData {whoKnowsWhat: Text}]
+  check data is packageName or is coarseLocation or is safeToLog
+
+// DFA fail
+particle Egress4
+  data: reads [MixedData {whoKnowsWhat: Text}]
+  check data is safeToLog
+
+// DFA fail
+particle Egress5
+  data: reads [MixedData {whoKnowsWhat: Text}]
+  check data (is packageName and is safeToLog) or (is coarseLocation and is safeToLog)
+
+recipe Test
+  data: create
+  appName: create
+  location: create
+  IngestionAppName
+    data: appName
+  IngestionLocation
+    data: location
+  Mixer
+    input1: appName
+    input2: location
+    output: data
+  Egress1
+    data: data
+  Egress2
+    data: data
+  Egress3
+    data: data
+  Egress4
+    data: data 
+  Egress5
+    data: data

--- a/javatests/arcs/core/analysis/testdata/fail_multiple_checks.arcs
+++ b/javatests/arcs/core/analysis/testdata/fail_multiple_checks.arcs
@@ -1,0 +1,18 @@
+// can detect failures for different checks', async () => {
+particle P1
+  foo1: writes Foo {}
+  foo2: writes Foo {}
+  claim foo1 is notTrusted
+  claim foo2 is trusted
+particle P2
+  bar1: reads Foo {}
+  bar2: reads Foo {}
+  check bar1 is trusted
+  check bar2 is extraTrusted
+recipe R
+  P1
+    foo1: writes h1
+    foo2: writes h2
+  P2
+    bar1: reads h1
+    bar2: reads h2

--- a/javatests/arcs/core/analysis/testdata/fail_multiple_inputs_one_untagged.arcs
+++ b/javatests/arcs/core/analysis/testdata/fail_multiple_inputs_one_untagged.arcs
@@ -1,0 +1,17 @@
+// fails when handle has multiple inputs but one is untagged
+particle P1
+  foo: writes Foo {}
+  claim foo is trusted
+particle P2
+  foo: writes Foo {}
+particle P3
+  bar: reads Foo {}
+  check bar is trusted
+recipe R
+  P1
+    foo: writes h
+  P2
+    foo: writes h
+  P3
+    bar: reads h
+

--- a/javatests/arcs/core/analysis/testdata/fail_negated_tag_present.arcs
+++ b/javatests/arcs/core/analysis/testdata/fail_negated_tag_present.arcs
@@ -1,0 +1,12 @@
+// fails for a negated tag check when the tag is present
+particle P1
+  foo: writes Foo {}
+  claim foo is private
+particle P2
+  bar: reads Foo {}
+  check bar is not private
+recipe R
+  P1
+    foo: writes h
+  P2
+    bar: reads h

--- a/javatests/arcs/core/analysis/testdata/fail_no_inputs.arcs
+++ b/javatests/arcs/core/analysis/testdata/fail_no_inputs.arcs
@@ -1,0 +1,7 @@
+// fails when handle has no inputs
+particle P
+  bar: reads Foo {}
+  check bar is trusted
+recipe R
+  P
+    bar: reads h

--- a/javatests/arcs/core/analysis/testdata/fail_no_tags.arcs
+++ b/javatests/arcs/core/analysis/testdata/fail_no_tags.arcs
@@ -1,0 +1,11 @@
+// fails when no tag is claimed
+particle P1
+  foo: writes Foo {}
+particle P2
+  bar: reads Foo {}
+  check bar is trusted
+recipe R
+  P1
+    foo: writes h
+  P2
+    bar: reads h

--- a/javatests/arcs/core/analysis/testdata/fail_not_tag_cancels.arcs
+++ b/javatests/arcs/core/analysis/testdata/fail_not_tag_cancels.arcs
@@ -1,0 +1,19 @@
+// fails when a "not tag" cancels a tag
+particle P1
+  foo: writes Foo {}
+  claim foo is trusted
+particle P2
+  bar: reads Foo {}
+  baz: writes Foo {}
+  claim baz is not trusted
+particle P3
+  bye: reads Foo {}
+  check bye is trusted
+recipe R
+  P1
+    foo: writes h
+  P2
+    bar: reads h
+    baz: writes h1
+  P3
+    bye: reads h1

--- a/javatests/arcs/core/analysis/testdata/fail_not_tag_claim.arcs
+++ b/javatests/arcs/core/analysis/testdata/fail_not_tag_claim.arcs
@@ -1,0 +1,12 @@
+// fails when a "not tag" is claimed and the tag is checked for
+particle P1
+  foo: writes Foo {}
+  claim foo is not trusted
+particle P2
+  bar: reads Foo {}
+  check bar is trusted
+recipe R
+  P1
+    foo: writes h
+  P2
+    bar: reads h

--- a/javatests/arcs/core/analysis/testdata/fail_read_write_mismatch_claim_check.arcs
+++ b/javatests/arcs/core/analysis/testdata/fail_read_write_mismatch_claim_check.arcs
@@ -1,0 +1,9 @@
+// fails when an inout handle claims a different tag from the one it checks
+particle P
+  foo: reads writes Foo {}
+  check foo is t1
+  claim foo is t2
+recipe R
+  P
+    foo: reads writes h
+

--- a/javatests/arcs/core/analysis/testdata/ok_check_multiple_and_single_claim.arcs
+++ b/javatests/arcs/core/analysis/testdata/ok_check_multiple_and_single_claim.arcs
@@ -1,0 +1,12 @@
+// succeeds when a check including multiple anded tags is met by a single claim
+particle P1
+  foo: writes Foo {}
+  claim foo is tag1 and is tag2
+particle P2
+  bar: reads Foo {}
+  check bar is tag1 and is tag2
+recipe R
+  P1
+    foo: writes h
+  P2
+    bar: reads h

--- a/javatests/arcs/core/analysis/testdata/ok_check_multiple_or_single_claim.arcs
+++ b/javatests/arcs/core/analysis/testdata/ok_check_multiple_or_single_claim.arcs
@@ -1,0 +1,12 @@
+// succeeds when a check including multiple 'or'd tags is met by a single claim
+particle P1
+  foo: writes Foo {}
+  claim foo is tag1 and is tag2
+particle P2
+  bar: reads Foo {}
+  check bar is tag1 or is tag2
+recipe R
+  P1
+    foo: writes h
+  P2
+    bar: reads h

--- a/javatests/arcs/core/analysis/testdata/ok_check_multiple_or_tags.arcs
+++ b/javatests/arcs/core/analysis/testdata/ok_check_multiple_or_tags.arcs
@@ -1,0 +1,17 @@
+// succeeds when a check includes multiple tags
+particle P1
+  foo: writes Foo {}
+  claim foo is tag1
+particle P2
+  foo: writes Foo {}
+  claim foo is tag2
+particle P3
+  bar: reads Foo {}
+  check bar is tag1 or is tag2
+recipe R
+  P1
+    foo: writes h
+  P2
+    foo: writes h
+  P3
+    bar: reads h

--- a/javatests/arcs/core/analysis/testdata/ok_claim_not_overriden_later.arcs
+++ b/javatests/arcs/core/analysis/testdata/ok_claim_not_overriden_later.arcs
@@ -1,0 +1,19 @@
+// a claim made later in a chain of particles does not override claims made earlier
+particle P1
+  foo: writes Foo {}
+  claim foo is trusted
+particle P2
+  bar: reads Foo {}
+  foo: writes Foo {}
+  claim foo is someOtherTag
+particle P3
+  bar: reads Foo {}
+  check bar is trusted
+recipe R
+  P1
+    foo: writes h1
+  P2
+    bar: reads h1
+    foo: writes h2
+  P3
+    bar: reads h2

--- a/javatests/arcs/core/analysis/testdata/ok_claim_propagates.arcs
+++ b/javatests/arcs/core/analysis/testdata/ok_claim_propagates.arcs
@@ -1,0 +1,18 @@
+// claim propagates through a chain of particles
+particle P1
+  foo: writes Foo {}
+  claim foo is trusted
+particle P2
+  bar: reads Foo {}
+  foo: writes Foo {}
+particle P3
+  bar: reads Foo {}
+  check bar is trusted
+recipe R
+  P1
+    foo: writes h1
+  P2
+    bar: reads h1
+    foo: writes h2
+  P3
+    bar: reads h2

--- a/javatests/arcs/core/analysis/testdata/ok_directly_satisfied.arcs
+++ b/javatests/arcs/core/analysis/testdata/ok_directly_satisfied.arcs
@@ -1,0 +1,12 @@
+// DFA succeeds when a check is satisfied directly
+particle P1
+  foo: writes Foo {}
+  claim foo is trusted
+particle P2
+  bar: reads Foo {}
+  check bar is trusted
+recipe R
+  P1
+    foo: writes h
+  P2
+    bar: reads h

--- a/javatests/arcs/core/analysis/testdata/ok_multiple_inputs_correct_tags.arcs
+++ b/javatests/arcs/core/analysis/testdata/ok_multiple_inputs_correct_tags.arcs
@@ -1,0 +1,17 @@
+// succeeds when handle has multiple inputs with the right tags
+particle P1
+  foo: writes Foo {}
+  claim foo is trusted
+particle P2
+  foo: writes Foo {}
+  claim foo is trusted
+particle P3
+  bar: reads Foo {}
+  check bar is trusted
+recipe R
+  P1
+    foo: writes h
+  P2
+    foo: writes h
+  P3
+    bar: reads h

--- a/javatests/arcs/core/analysis/testdata/ok_negated_missing_tag.arcs
+++ b/javatests/arcs/core/analysis/testdata/ok_negated_missing_tag.arcs
@@ -1,0 +1,7 @@
+// succeeds for a negated tag check when the tag is missing
+particle P
+  bar: reads Foo {}
+  check bar is not private
+recipe R
+  P
+    bar: reads h

--- a/javatests/arcs/core/analysis/testdata/ok_not_tag_claim_no_checks.arcs
+++ b/javatests/arcs/core/analysis/testdata/ok_not_tag_claim_no_checks.arcs
@@ -1,0 +1,11 @@
+// succeeds when a "not tag" is claimed and there are no checks
+particle P1
+  foo: writes Foo {}
+  claim foo is not trusted
+particle P2
+  bar: reads Foo {}
+recipe R
+  P1
+    foo: writes h
+  P2
+    bar: reads h

--- a/javatests/arcs/core/analysis/testdata/ok_not_tag_claim_reclaimed.arcs
+++ b/javatests/arcs/core/analysis/testdata/ok_not_tag_claim_reclaimed.arcs
@@ -1,0 +1,26 @@
+// succeeds when a "not tag" cancels a tag that is reclaimed downstream
+particle P1
+  foo: writes Foo {}
+  claim foo is trusted
+particle P2
+  bar: reads Foo {}
+  baz: writes Foo {}
+  claim baz is not trusted
+particle P3
+  bye: reads Foo {}
+  boy: writes Foo {}
+  claim boy is trusted
+particle P4
+  bit: reads Foo {}
+  check bit is trusted
+recipe R
+  P1
+    foo: writes h
+  P2
+    bar: reads h
+    baz: writes h1
+  P3
+    bye: reads h1
+    boy: writes h2
+  P4
+    bit: reads h2

--- a/javatests/arcs/core/analysis/testdata/ok_read_write_match_claim_check.arcs
+++ b/javatests/arcs/core/analysis/testdata/ok_read_write_match_claim_check.arcs
@@ -1,0 +1,8 @@
+// succeeds when an inout handle claims the same tag it checks
+particle P
+  foo: reads writes Foo {}
+  check foo is t
+  claim foo is t
+recipe R
+  P
+    foo: reads writes h


### PR DESCRIPTION
This PR copies over the inline tests from type script into individual files for use in Kotlin tests for DFA. This PR only includes the tests related to checks and claims of semantic labels. 