### PR TITLE
Utility to convert a predicate to Disjuntive Normal Form (DNF).

### DIFF
--- a/java/arcs/core/analysis/InformationFlowLabels.kt
+++ b/java/arcs/core/analysis/InformationFlowLabels.kt
@@ -57,6 +57,18 @@ data class InformationFlowLabels(
         }
     }
 
+    private fun BitSet.toString(transform: ((Int) -> String)?): String {
+        if (transform == null) return "$this"
+        var labels = mutableListOf<String>()
+        var nextBit = nextSetBit(0)
+        while (nextBit != -1) {
+            labels.add(transform(nextBit))
+            if (nextBit == Int.MAX_VALUE) break
+            nextBit = nextSetBit(nextBit + 1)
+        }
+        return labels.joinToString(prefix = "{", postfix = "}")
+    }
+
     companion object {
         fun getBottom() = InformationFlowLabels(AbstractSet.getBottom<BitSet>())
         fun getTop() = InformationFlowLabels(AbstractSet.getTop<BitSet>())

--- a/java/arcs/core/analysis/PredicateUtils.kt
+++ b/java/arcs/core/analysis/PredicateUtils.kt
@@ -16,11 +16,24 @@ import arcs.core.data.InformationFlowLabel.Predicate
 import java.util.BitSet
 
 /**
- * Returns the predicate in Disjunctive Normal Form (DNF) as a set of [BitSet] pairs.
+ * Represents a conjunct in a Disjunctive Normal Form (DNF).
  *
- * The first [BitSet] in the pair is a mask that determines the set of valid bits in the second
- * [BitSet]. The [indices] map is used to determine the index of an [InformationFlowLabel] in the
- * bitset. Suppose that the universe of labels is {A, B, C}. Here are some examples:
+ * [mask] determines the set of indices that are valid in [bits]. Suppose that the universe of
+ * labels is {A, B, C}. Here are some examples of how various conjuncts are represented:
+ *
+ *      Conjunction : (mask, bits)
+ *                A : (100, 100)
+ *           not(A) : (100, 000)
+ *          A and B : (110, 110)
+ *     A and not(B) : (110, 100)
+ */
+data class Conjunct(val mask: BitSet, val bits: BitSet)
+
+/**
+ * Returns the predicate in Disjunctive Normal Form (DNF) as [Set<Conjunct>].
+ *
+ * The [indices] map is used to determine the index of an [InformationFlowLabel] in the bitset of
+ * the conjuncts. Suppose that the universe of labels is {A, B, C}. Here are some examples:
  *
  *          Predicate : {(mask, bits)}
  *                  A : {(100, 100)}
@@ -33,14 +46,14 @@ import java.util.BitSet
  */
 fun InformationFlowLabel.Predicate.asDNF(
     indices: Map<InformationFlowLabel, Int>
-): Set<Pair<BitSet, BitSet>> {
+): Set<Conjunct> {
     // TODO(b/157530728): This is not very efficient. We will want to replace this with
     // an implementation that uses a Binary Decision Diagram (BDD).
     when (this) {
         is Predicate.Label -> {
-            val index = requireNotNull(indices[label])
+            val index = indices.getValue(label)
             val result = BitSet(indices.size).apply { set(index) }
-            return setOf(result to result)
+            return setOf(Conjunct(result, result))
         }
         is Predicate.Not -> {
             val labelPredicate = requireNotNull(predicate as? Predicate.Label) {
@@ -48,49 +61,57 @@ fun InformationFlowLabel.Predicate.asDNF(
                 // datastructure like BDDs. For now, we only support `not` on labels.
                 "Not is only supported for label predicates when converting to bitsets!"
             }
-            val index = requireNotNull(indices[labelPredicate.label])
+            val index = indices.getValue(labelPredicate.label)
             val mask = BitSet(indices.size).apply { set(index) }
             val result = BitSet(indices.size)
-            return setOf(mask to result)
+            return setOf(Conjunct(mask, result))
         }
         is Predicate.Or -> {
-            val lhsBitSets = lhs.asDNF(indices)
-            val rhsBitSets = rhs.asDNF(indices)
-            return lhsBitSets union rhsBitSets
+            val lhsConjuncts = lhs.asDNF(indices)
+            val rhsConjuncts = rhs.asDNF(indices)
+            return lhsConjuncts union rhsConjuncts
         }
         is Predicate.And -> {
-            val lhsBitSets = lhs.asDNF(indices)
-            val rhsBitSets = rhs.asDNF(indices)
-            val result = mutableSetOf<Pair<BitSet, BitSet>>()
-            // Apply distributivity law.
-            lhsBitSets.forEach { (lhsMask, lhsBitSet) ->
-                rhsBitSets.forEach { (rhsMask, rhsBitSet) ->
-                    val commonLhsBits = BitSet(indices.size).apply {
-                        or(lhsMask)
-                        and(rhsMask)
-                        and(lhsBitSet)
-                    }
-                    val commonRhsBits = BitSet(indices.size).apply {
-                        or(lhsMask)
-                        and(rhsMask)
-                        and(rhsBitSet)
-                    }
-                    // Make sure that the common bits match. If they don't match, then this
-                    // combination is contradiction and, therefore, is not included in the result.
-                    if (commonRhsBits == commonLhsBits) {
-                        val combinedMask = BitSet(indices.size).apply {
-                            or(lhsMask)
-                            or(rhsMask)
-                        }
-                        val combined = BitSet(indices.size).apply {
-                            or(lhsBitSet)
-                            or(rhsBitSet)
-                        }
-                        result.add(combinedMask to combined)
-                    }
-                }
-            }
-            return result.toSet()
+            val lhsConjuncts = lhs.asDNF(indices)
+            val rhsConjuncts = rhs.asDNF(indices)
+            return lhsConjuncts.and(rhsConjuncts, indices)
         }
     }
+}
+
+/** Returns the DNF form for ([this] and [that]) by applying distributivity law. */
+private fun Set<Conjunct>.and(
+    that: Set<Conjunct>,
+    indices: Map<InformationFlowLabel, Int>
+): Set<Conjunct> {
+    val result = mutableSetOf<Conjunct>()
+    // Apply distributivity law.
+    forEach { (thisMask, thisBits) ->
+        that.forEach { (thatMask, thatBits) ->
+            val commonThisBits = BitSet(indices.size).apply {
+                or(thisMask)
+                and(thatMask)
+                and(thisBits)
+            }
+            val commonThatBits = BitSet(indices.size).apply {
+                or(thisMask)
+                and(thatMask)
+                and(thatBits)
+            }
+            // Make sure that the common bits match. If they don't match, then this
+            // combination is contradiction and, therefore, is not included in the result.
+            if (commonThatBits == commonThisBits) {
+                val combinedMask = BitSet(indices.size).apply {
+                    or(thisMask)
+                    or(thatMask)
+                }
+                val combinedBits = BitSet(indices.size).apply {
+                    or(thisBits)
+                    or(thatBits)
+                }
+                result.add(Conjunct(combinedMask, combinedBits))
+            }
+        }
+    }
+    return result.toSet()
 }


### PR DESCRIPTION
This PR renames `asSetOfBitSets` into `asDNF`, which was its original intention. However, it turns out that the implementation of `asSetOfBitSets` did not provide a way to correctly represent negated literals in a conjunction. e.g., it was not possible to represent `(A and !B)`. This PR returns a set of pair of bitsets, where the first bitset acts as a mask that identifies which bits are valid in the second bitset. 

This PR also moves the `BitSet.toString` back as a private extension in `InformationFlowLabels`.