### PR TITLE
AndroidHost non-resurrectable by default

### DIFF
--- a/java/arcs/android/sdk/host/AndroidHost.kt
+++ b/java/arcs/android/sdk/host/AndroidHost.kt
@@ -15,47 +15,30 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.OnLifecycleEvent
 import arcs.core.host.ArcHost
-import arcs.core.host.ArcHostContext
-import arcs.core.host.ArcState
 import arcs.core.host.ParticleRegistration
 import arcs.core.host.SchedulerProvider
 import arcs.core.storage.StoreManager
 import arcs.jvm.host.JvmHost
-import arcs.sdk.android.storage.ResurrectionHelper
 import arcs.sdk.android.storage.ServiceStoreFactory
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
 
 /**
- * An [ArcHost] that runs on Android inside of a [Service], uses [StorageService] for storage, and
- * can be resurrected via [ResurrectorService] if the [ArcHost] is embedded in its own service.
+ * An [ArcHost] that runs on Android inside of a [Service], uses [StorageService] for storage.
  */
 abstract class AndroidHost(
     val context: Context,
     val lifecycle: Lifecycle,
     schedulerProvider: SchedulerProvider,
     vararg particles: ParticleRegistration
-) : JvmHost(schedulerProvider, *particles), ResurrectableHost, LifecycleObserver {
+) : JvmHost(schedulerProvider, *particles), LifecycleObserver {
 
     init {
         lifecycle.addObserver(this)
     }
 
-    override val resurrectionHelper: ResurrectionHelper = ResurrectionHelper(context,
-        ::onResurrected)
-
     @ExperimentalCoroutinesApi
     override val activationFactory = ServiceStoreFactory(context, lifecycle)
-
-    override fun maybeRequestResurrection(context: ArcHostContext) {
-        if (context.arcState == ArcState.Running) {
-            resurrectionHelper.requestResurrection(context.arcId, context.allReadableStorageKeys())
-        }
-    }
-
-    override fun maybeCancelResurrection(context: ArcHostContext) {
-        resurrectionHelper.cancelResurrectionRequest(context.arcId)
-    }
 
     /*
      * Android uses [StorageService] which is a persistent process, so we don't share

--- a/java/arcs/android/sdk/host/AndroidResurrectableHost.kt
+++ b/java/arcs/android/sdk/host/AndroidResurrectableHost.kt
@@ -30,8 +30,10 @@ abstract class AndroidResurrectableHost(
     vararg particles: ParticleRegistration
 ) : AndroidHost(context, lifecycle, schedulerProvider, *particles), ResurrectableHost {
 
-    override val resurrectionHelper: ResurrectionHelper = ResurrectionHelper(context,
-        ::onResurrected)
+    override val resurrectionHelper: ResurrectionHelper = ResurrectionHelper(
+        context,
+        ::onResurrected
+    )
 
     override fun maybeRequestResurrection(context: ArcHostContext) {
         if (context.arcState == ArcState.Running) {

--- a/java/arcs/android/sdk/host/AndroidResurrectableHost.kt
+++ b/java/arcs/android/sdk/host/AndroidResurrectableHost.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+package arcs.android.sdk.host
+
+import android.content.Context
+import androidx.lifecycle.Lifecycle
+import arcs.core.host.ArcHost
+import arcs.core.host.ArcHostContext
+import arcs.core.host.ArcState
+import arcs.core.host.ParticleRegistration
+import arcs.core.host.SchedulerProvider
+import arcs.sdk.android.storage.ResurrectionHelper
+
+/**
+ * An [AndroidHost] that can be resurrected via [ResurrectorService] if the [ArcHost] is
+ * embedded in its own service.
+ */
+abstract class AndroidResurrectableHost(
+    context: Context,
+    lifecycle: Lifecycle,
+    schedulerProvider: SchedulerProvider,
+    vararg particles: ParticleRegistration
+) : AndroidHost(context, lifecycle, schedulerProvider, *particles), ResurrectableHost {
+
+    override val resurrectionHelper: ResurrectionHelper = ResurrectionHelper(context,
+        ::onResurrected)
+
+    override fun maybeRequestResurrection(context: ArcHostContext) {
+        if (context.arcState == ArcState.Running) {
+            resurrectionHelper.requestResurrection(context.arcId, context.allReadableStorageKeys())
+        }
+    }
+
+    override fun maybeCancelResurrection(context: ArcHostContext) {
+        resurrectionHelper.cancelResurrectionRequest(context.arcId)
+    }
+}


### PR DESCRIPTION
Now use AndroidResurrectableHost when you want a resurrectable host, by default, AndroidHost is not resurrectable.
