### PR TITLE
Move LocalService/RemoteService/StorageService out of background cpu set

### DIFF
--- a/javatests/arcs/android/systemhealth/testapp/LocalService.kt
+++ b/javatests/arcs/android/systemhealth/testapp/LocalService.kt
@@ -11,8 +11,9 @@
 
 package arcs.android.systemhealth.testapp
 
-import android.app.Service
 import android.content.Intent
+import android.os.Binder
+import android.os.IBinder
 import androidx.lifecycle.LifecycleService
 
 /**
@@ -22,90 +23,87 @@ import androidx.lifecycle.LifecycleService
  */
 class LocalService : LifecycleService() {
     private val storageCore = StorageCore(this, lifecycle)
+    private val binder = Binder()
 
-    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        super.onStartCommand(intent, flags, startId)
-
+    override fun onBind(intent: Intent): IBinder {
         // Parse local service's specific settings.
-        val settings = intent?.let {
-            SystemHealthData.Settings(
-                enumValueOf(
-                    it.getStringExtra(
-                        intentExtras.function
-                    ) ?: defaultSettings.function.name
+        val settings = SystemHealthData.Settings(
+            enumValueOf(
+                intent.getStringExtra(
+                    intentExtras.function
+                ) ?: defaultSettings.function.name
+            ),
+            enumValueOf(
+                intent.getStringExtra(
+                    intentExtras.handleType
+                ) ?: defaultSettings.handleType.name
+            ),
+            enumValueOf(
+                intent.getStringExtra(
+                    intentExtras.storage_mode
+                ) ?: defaultSettings.storageMode.name
+            ),
+            maxOf(
+                intent.getIntExtra(
+                    intentExtras.numOfListenerThreads,
+                    defaultSettings.numOfListenerThreads
                 ),
-                enumValueOf(
-                    it.getStringExtra(
-                        intentExtras.handleType
-                    ) ?: defaultSettings.handleType.name
+                0
+            ),
+            maxOf(
+                intent.getIntExtra(
+                    intentExtras.numOfWriterThreads,
+                    defaultSettings.numOfWriterThreads
                 ),
-                enumValueOf(
-                    it.getStringExtra(
-                        intentExtras.storage_mode
-                    ) ?: defaultSettings.storageMode.name
+                0
+            ),
+            maxOf(
+                intent.getIntExtra(
+                    intentExtras.timesOfIterations,
+                    defaultSettings.timesOfIterations
                 ),
-                maxOf(
-                    it.getIntExtra(
-                        intentExtras.numOfListenerThreads,
-                        defaultSettings.numOfListenerThreads
-                    ),
-                    0
+                0
+            ),
+            maxOf(
+                intent.getIntExtra(
+                    intentExtras.iterationIntervalMs,
+                    defaultSettings.iterationIntervalMs
                 ),
-                maxOf(
-                    it.getIntExtra(
-                        intentExtras.numOfWriterThreads,
-                        defaultSettings.numOfWriterThreads
-                    ),
-                    0
+                0
+            ),
+            maxOf(
+                intent.getIntExtra(
+                    intentExtras.dataSizeInBytes,
+                    defaultSettings.dataSizeInBytes
                 ),
-                maxOf(
-                    it.getIntExtra(
-                        intentExtras.timesOfIterations,
-                        defaultSettings.timesOfIterations
-                    ),
-                    0
+                0
+            ),
+            maxOf(
+                intent.getIntExtra(
+                    intentExtras.delayedStartMs,
+                    defaultSettings.delayedStartMs
                 ),
-                maxOf(
-                    it.getIntExtra(
-                        intentExtras.iterationIntervalMs,
-                        defaultSettings.iterationIntervalMs
-                    ),
-                    0
+                0
+            ),
+            minOf(
+                intent.getIntExtra(
+                    intentExtras.storageServiceCrashRate,
+                    defaultSettings.storageServiceCrashRate
                 ),
-                maxOf(
-                    it.getIntExtra(
-                        intentExtras.dataSizeInBytes,
-                        defaultSettings.dataSizeInBytes
-                    ),
-                    0
+                100
+            ),
+            minOf(
+                intent.getIntExtra(
+                    intentExtras.storageClientCrashRate,
+                    defaultSettings.storageClientCrashRate
                 ),
-                maxOf(
-                    it.getIntExtra(
-                        intentExtras.delayedStartMs,
-                        defaultSettings.delayedStartMs
-                    ),
-                    0
-                ),
-                minOf(
-                    it.getIntExtra(
-                        intentExtras.storageServiceCrashRate,
-                        defaultSettings.storageServiceCrashRate
-                    ),
-                    100
-                ),
-                minOf(
-                    it.getIntExtra(
-                        intentExtras.storageClientCrashRate,
-                        defaultSettings.storageClientCrashRate
-                    ),
-                    100
-                )
+                100
             )
-        } ?: defaultSettings
+        )
 
         storageCore.accept(settings)
 
-        return Service.START_NOT_STICKY
+        return binder
     }
 
     companion object {

--- a/javatests/arcs/android/systemhealth/testapp/RemoteService.kt
+++ b/javatests/arcs/android/systemhealth/testapp/RemoteService.kt
@@ -11,8 +11,9 @@
 
 package arcs.android.systemhealth.testapp
 
-import android.app.Service
 import android.content.Intent
+import android.os.Binder
+import android.os.IBinder
 import androidx.lifecycle.LifecycleService
 
 /**
@@ -22,90 +23,87 @@ import androidx.lifecycle.LifecycleService
  */
 class RemoteService : LifecycleService() {
     private val storageCore = StorageCore(this, lifecycle)
+    private val binder = Binder()
 
-    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        super.onStartCommand(intent, flags, startId)
-
+    override fun onBind(intent: Intent): IBinder {
         // Parse remote service's specific settings.
-        val settings = intent?.let {
-            SystemHealthData.Settings(
-                enumValueOf(
-                    it.getStringExtra(
-                        intentExtras.function
-                    ) ?: defaultSettings.function.name
+        val settings = SystemHealthData.Settings(
+            enumValueOf(
+                intent.getStringExtra(
+                    intentExtras.function
+                ) ?: defaultSettings.function.name
+            ),
+            enumValueOf(
+                intent.getStringExtra(
+                    intentExtras.handleType
+                ) ?: defaultSettings.handleType.name
+            ),
+            enumValueOf(
+                intent.getStringExtra(
+                    intentExtras.storage_mode
+                ) ?: defaultSettings.storageMode.name
+            ),
+            maxOf(
+                intent.getIntExtra(
+                    intentExtras.numOfListenerThreads,
+                    defaultSettings.numOfListenerThreads
                 ),
-                enumValueOf(
-                    it.getStringExtra(
-                        intentExtras.handleType
-                    ) ?: defaultSettings.handleType.name
+                0
+            ),
+            maxOf(
+                intent.getIntExtra(
+                    intentExtras.numOfWriterThreads,
+                    defaultSettings.numOfWriterThreads
                 ),
-                enumValueOf(
-                    it.getStringExtra(
-                        intentExtras.storage_mode
-                    ) ?: defaultSettings.storageMode.name
+                0
+            ),
+            maxOf(
+                intent.getIntExtra(
+                    intentExtras.timesOfIterations,
+                    defaultSettings.timesOfIterations
                 ),
-                maxOf(
-                    it.getIntExtra(
-                        intentExtras.numOfListenerThreads,
-                        defaultSettings.numOfListenerThreads
-                    ),
-                    0
+                0
+            ),
+            maxOf(
+                intent.getIntExtra(
+                    intentExtras.iterationIntervalMs,
+                    defaultSettings.iterationIntervalMs
                 ),
-                maxOf(
-                    it.getIntExtra(
-                        intentExtras.numOfWriterThreads,
-                        defaultSettings.numOfWriterThreads
-                    ),
-                    0
+                0
+            ),
+            maxOf(
+                intent.getIntExtra(
+                    intentExtras.dataSizeInBytes,
+                    defaultSettings.dataSizeInBytes
                 ),
-                maxOf(
-                    it.getIntExtra(
-                        intentExtras.timesOfIterations,
-                        defaultSettings.timesOfIterations
-                    ),
-                    0
+                0
+            ),
+            maxOf(
+                intent.getIntExtra(
+                    intentExtras.delayedStartMs,
+                    defaultSettings.delayedStartMs
                 ),
-                maxOf(
-                    it.getIntExtra(
-                        intentExtras.iterationIntervalMs,
-                        defaultSettings.iterationIntervalMs
-                    ),
-                    0
+                0
+            ),
+            minOf(
+                intent.getIntExtra(
+                    intentExtras.storageServiceCrashRate,
+                    defaultSettings.storageServiceCrashRate
                 ),
-                maxOf(
-                    it.getIntExtra(
-                        intentExtras.dataSizeInBytes,
-                        defaultSettings.dataSizeInBytes
-                    ),
-                    0
+                100
+            ),
+            minOf(
+                intent.getIntExtra(
+                    intentExtras.storageClientCrashRate,
+                    defaultSettings.storageClientCrashRate
                 ),
-                maxOf(
-                    it.getIntExtra(
-                        intentExtras.delayedStartMs,
-                        defaultSettings.delayedStartMs
-                    ),
-                    0
-                ),
-                minOf(
-                    it.getIntExtra(
-                        intentExtras.storageServiceCrashRate,
-                        defaultSettings.storageServiceCrashRate
-                    ),
-                    100
-                ),
-                minOf(
-                    it.getIntExtra(
-                        intentExtras.storageClientCrashRate,
-                        defaultSettings.storageClientCrashRate
-                    ),
-                    100
-                )
+                100
             )
-        } ?: defaultSettings
+        )
 
         storageCore.accept(settings)
 
-        return Service.START_NOT_STICKY
+        return binder
     }
 
     companion object {

--- a/javatests/arcs/android/systemhealth/testapp/TestActivity.kt
+++ b/javatests/arcs/android/systemhealth/testapp/TestActivity.kt
@@ -39,11 +39,11 @@ import arcs.sdk.ReadCollectionHandle
 import arcs.sdk.ReadWriteCollectionHandle
 import arcs.sdk.ReadWriteSingletonHandle
 import arcs.sdk.android.storage.ServiceStoreFactory
-import kotlinx.atomicfu.atomic
-import kotlinx.atomicfu.update
 import java.util.concurrent.Executors
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
+import kotlinx.atomicfu.atomic
+import kotlinx.atomicfu.update
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.asCoroutineDispatcher

--- a/javatests/arcs/android/systemhealth/testapp/TestActivity.kt
+++ b/javatests/arcs/android/systemhealth/testapp/TestActivity.kt
@@ -12,10 +12,13 @@
 package arcs.android.systemhealth.testapp
 
 import android.content.BroadcastReceiver
+import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.content.ServiceConnection
 import android.os.Bundle
+import android.os.IBinder
 import android.text.Editable
 import android.text.TextWatcher
 import android.view.View
@@ -36,6 +39,8 @@ import arcs.sdk.ReadCollectionHandle
 import arcs.sdk.ReadWriteCollectionHandle
 import arcs.sdk.ReadWriteSingletonHandle
 import arcs.sdk.android.storage.ServiceStoreFactory
+import kotlinx.atomicfu.atomic
+import kotlinx.atomicfu.update
 import java.util.concurrent.Executors
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
@@ -71,6 +76,11 @@ class TestActivity : AppCompatActivity() {
     private var storageServiceCrashRate: Int
     private var storageClientCrashRate: Int
     private var intentReceiver: BroadcastReceiver? = null
+    private var bound = atomic(false)
+    private val connection = object : ServiceConnection {
+        override fun onServiceConnected(name: ComponentName, service: IBinder) = bound.update { true }
+        override fun onServiceDisconnected(name: ComponentName) = bound.update { false }
+    }
 
     init {
         // Supply the default settings being displayed on UI at app. startup.
@@ -317,7 +327,8 @@ class TestActivity : AppCompatActivity() {
                 intent.putExtra(it.storageServiceCrashRate, storageServiceCrashRate)
                 intent.putExtra(it.storageClientCrashRate, storageClientCrashRate)
 
-                startService(intent)
+                if (bound.value) unbindService(connection)
+                bindService(intent, connection, Context.BIND_AUTO_CREATE)
             }
         }
 
@@ -342,7 +353,8 @@ class TestActivity : AppCompatActivity() {
                 intent.putExtra(it.storageServiceCrashRate, storageServiceCrashRate)
                 intent.putExtra(it.storageClientCrashRate, storageClientCrashRate)
 
-                startService(intent)
+                if (bound.value) unbindService(connection)
+                bindService(intent, connection, Context.BIND_AUTO_CREATE)
             }
         }
     }
@@ -358,6 +370,7 @@ class TestActivity : AppCompatActivity() {
         }
 
         scope.cancel()
+        if (bound.value) unbindService(connection)
         super.onDestroy()
     }
 


### PR DESCRIPTION
To reflect the actual latency numbers as if running the whole storage stack on com.google.android.as, using bindService/unbindService in lieu of startService/stopService.

Using startService will launch all services in `background` cpuset, which allows threads only running on the first two silver cpus, whereas bindService launches services in slightly less-privileged cpuset than `top-app`'s, that is `foreground` cpuset which allows threads running on most of silver + gold cpus.

The current Arcs customers would live inside com.google.android.as which is in `foreground` cpuset. So the bound StorageService would run in `foreground` cpuset as well.

