### PR TITLE
Memory Optimization: prevent flow from caching listenersByNamespace.listeners of Agenda

### DIFF
--- a/java/arcs/core/util/Scheduler.kt
+++ b/java/arcs/core/util/Scheduler.kt
@@ -229,16 +229,18 @@ class Scheduler(
      * [Task.Listener]s, collated by [Task.Listener.namespace].
      */
     private data class ListenersByNamespace(
-        private var listeners: Map<String, ListenersByName> = emptyMap()
+        val listeners: MutableMap<String, ListenersByName> = mutableMapOf()
     ) : Iterable<Task> {
         fun addListener(listener: Task.Listener): ListenersByNamespace {
             val listeners = (listeners[listener.namespace] ?: ListenersByName())
                 .addListener(listener)
 
-            return copy(listeners = this.listeners + (listener.namespace to listeners))
+            return copy(
+                listeners = (this.listeners + (listener.namespace to listeners)).toMutableMap()
+            )
         }
 
-        fun clear() { listeners = emptyMap() }
+        fun clear() = listeners.clear()
 
         override fun iterator(): Iterator<Task> = listeners.values.flatten().iterator()
     }

--- a/java/arcs/core/util/Scheduler.kt
+++ b/java/arcs/core/util/Scheduler.kt
@@ -87,6 +87,7 @@ class Scheduler(
                 try {
                     withTimeout(agendaProcessingTimeoutMs) { executeAgenda(agenda) }
                 } finally {
+                    agenda.listenersByNamespace.clear()
                     val agendasLeft = agendasInFlight.getAndDecrement()
                     if (agendasLeft == 1) {
                         idlenessChannel.send(true)
@@ -228,7 +229,7 @@ class Scheduler(
      * [Task.Listener]s, collated by [Task.Listener.namespace].
      */
     private data class ListenersByNamespace(
-        val listeners: Map<String, ListenersByName> = emptyMap()
+        private var listeners: Map<String, ListenersByName> = emptyMap()
     ) : Iterable<Task> {
         fun addListener(listener: Task.Listener): ListenersByNamespace {
             val listeners = (listeners[listener.namespace] ?: ListenersByName())
@@ -236,6 +237,8 @@ class Scheduler(
 
             return copy(listeners = this.listeners + (listener.namespace to listeners))
         }
+
+        fun clear() { listeners = emptyMap() }
 
         override fun iterator(): Iterator<Task> = listeners.values.flatten().iterator()
     }


### PR DESCRIPTION
The PR is for eliminating the reference holding chain to keep run-time memory footprint minimal.
<img width="697" alt="leakage_ref_chain" src="https://user-images.githubusercontent.com/55406481/83468905-0147ee00-a433-11ea-94af-0716cb79121a.png">
