### PR TITLE
Define AnnotationRefProto and use it in PolicyProto.

### DIFF
--- a/java/arcs/core/data/proto/BUILD
+++ b/java/arcs/core/data/proto/BUILD
@@ -53,6 +53,27 @@ arcs_kt_library(
 )
 
 proto_library(
+    name = "annotation_proto",
+    srcs = ["annotation.proto"],
+)
+
+android_proto_library(
+    name = "annotation_java_proto_lite",
+    deps = [":annotation_proto"],
+)
+
+java_proto_library(
+    name = "annotation_java_proto",
+    deps = [":annotation_proto"],
+)
+
+py_proto_library(
+    name = "annotation_py_proto",
+    api_version = 2,
+    deps = [":annotation_proto"],
+)
+
+proto_library(
     name = "manifest_proto",
     srcs = ["manifest.proto"],
     deps = [
@@ -79,6 +100,7 @@ py_proto_library(
 proto_library(
     name = "policy_proto",
     srcs = ["policy.proto"],
+    deps = [":annotation_proto"],
 )
 
 android_proto_library(

--- a/java/arcs/core/data/proto/annotation.proto
+++ b/java/arcs/core/data/proto/annotation.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+
+package arcs;
+
+option java_package = "arcs.core.data.proto";
+option java_multiple_files = true;
+
+// Represents the usage of an annotation.
+// TODO(b/155796088): Add support for all annotation functionality, including
+// annotation definitions and all parameter types.
+message AnnotationRefProto {
+  string name = 1;
+
+  // Maps from param name to value.
+  // TODO(b/155796088): Support parameter types other than just string.
+  map<string, string> params = 2;
+}

--- a/java/arcs/core/data/proto/policy.proto
+++ b/java/arcs/core/data/proto/policy.proto
@@ -5,6 +5,8 @@ package arcs;
 option java_package = "arcs.core.data.proto";
 option java_multiple_files = true;
 
+import "java/arcs/core/data/proto/annotation.proto";
+
 // Defines a data usage policy.
 message PolicyProto {
   // Policy name.
@@ -26,6 +28,9 @@ message PolicyProto {
   }
   // Egress type permitted by the policy.
   EgressType egress_type = 5;
+
+  // Annotations on the policy.
+  repeated AnnotationRefProto annotations = 6;
 }
 
 message PolicyTargetProto {
@@ -41,6 +46,9 @@ message PolicyTargetProto {
 
   // Allowed usages for all fields in this target type.
   repeated PolicyFieldProto fields = 4;
+
+  // Annotations on the policy target.
+  repeated AnnotationRefProto annotations = 5;
 }
 
 message PolicyFieldProto {
@@ -72,6 +80,9 @@ message PolicyFieldProto {
 
   // Specified usages for subfields nested inside this field.
   repeated PolicyFieldProto subfields = 4;
+
+  // Annotations on the policy field.
+  repeated AnnotationRefProto annotations = 5;
 }
 
 // Storage retention options for a policy target.


### PR DESCRIPTION
Annotation definitions themselves aren't encoded in protos, yet. Also the only parameter type supported so far is strings. This is just to unblock work on policy2proto, the other features will be added later.