### PR TITLE
Clean up in Arcs particle API

### DIFF
--- a/java/arcs/android/demo/DemoService.kt
+++ b/java/arcs/android/demo/DemoService.kt
@@ -13,7 +13,6 @@ import arcs.core.host.SchedulerProvider
 import arcs.core.host.toRegistration
 import arcs.jvm.host.JvmSchedulerProvider
 import arcs.jvm.util.JvmTime
-import arcs.sdk.Handle
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
@@ -61,24 +60,24 @@ class DemoService : ArcHostService() {
     }
 
     inner class ReadPerson : AbstractReadPerson() {
-        override suspend fun onHandleSync(handle: Handle, allSynced: Boolean) {
+        override fun onReady() {
             val name = handles.person.fetch()?.name ?: ""
             val notification =
                 Notification.Builder(this@DemoService, "arcs-demo-service")
                     .setSmallIcon(R.drawable.notification_template_icon_bg)
-                    .setContentTitle("onHandleSync")
+                    .setContentTitle("onReady")
                     .setContentText(name)
                     .setAutoCancel(true)
                     .build()
 
             scope.launch {
-                notificationManager.notify(handle.hashCode(), notification)
+                notificationManager.notify(handles.person.hashCode(), notification)
             }
         }
     }
 
     inner class WritePerson : AbstractWritePerson() {
-        override suspend fun onHandleSync(handle: Handle, allSynced: Boolean) {
+        override fun onFirstStart() {
             handles.person.store(WritePerson_Person("John Wick"))
         }
     }

--- a/java/arcs/core/entity/Handle.kt
+++ b/java/arcs/core/entity/Handle.kt
@@ -32,7 +32,6 @@ interface Handle {
     val dispatcher: CoroutineDispatcher
 
     // TODO(b/157188866): move this to ReadableHandle (write-only handles should not receive this)
-    // TODO: pass the Handle to the action callbacks: handles.foo.onReady { it.fetch() }
     /** Assign a callback when the handle is synced for the first time. */
     fun onReady(action: () -> Unit)
 

--- a/java/arcs/core/host/AbstractArcHost.kt
+++ b/java/arcs/core/host/AbstractArcHost.kt
@@ -461,7 +461,6 @@ abstract class AbstractArcHost(
             val context = lookupOrCreateArcHostContext(arcId)
             val partition = contextToPartition(arcId, context)
             startArc(partition)
-            // TODO: should invoke onHandleUpdate for readable affectedKeys?
         }
     }
 

--- a/java/arcs/core/host/ArcHostContext.kt
+++ b/java/arcs/core/host/ArcHostContext.kt
@@ -55,7 +55,7 @@ data class ParticleContext(
      */
     fun notifyWriteOnlyParticles() {
         if (awaitingReady.isEmpty()) {
-            particleState = ParticleState.Started
+            particleState = ParticleState.Running
             particle.onReady()
         }
     }
@@ -70,7 +70,7 @@ data class ParticleContext(
         when (event) {
             StorageEvent.READY -> {
                 if (awaitingReady.remove(handle) && awaitingReady.isEmpty()) {
-                    particleState = ParticleState.Started
+                    particleState = ParticleState.Running
                     particle.onReady()
                 }
             }
@@ -85,7 +85,7 @@ data class ParticleContext(
             StorageEvent.RESYNC -> {
                 desyncedHandles.remove(handle)
                 if (desyncedHandles.isEmpty()) {
-                    particleState = ParticleState.Started
+                    particleState = ParticleState.Running
                     particle.onResync()
                 }
             }

--- a/java/arcs/core/host/ArcState.kt
+++ b/java/arcs/core/host/ArcState.kt
@@ -67,8 +67,7 @@ enum class ParticleState {
     /** onStart() has been called; the particle is awaiting handle synchronization. */
     Waiting,
     /** onReady() has been called; the particle is ready for execution. */
-    // TODO: rename to Running (needs to be co-ordinated with google code)
-    Started,
+    Running,
     /** onDesync() has been called; one or more handles have desynchronized from their storage. */
     Desynced,
     /** onStop() has been called; the arc is no longer executing. */
@@ -92,7 +91,7 @@ enum class ParticleState {
      * succeeded at least once).
      */
     val hasBeenStarted: Boolean
-        get() = listOf(FirstStart, Waiting, Started, Desynced, Stopped, Failed).contains(this)
+        get() = listOf(FirstStart, Waiting, Running, Desynced, Stopped, Failed).contains(this)
 
     /**
      * Indicates whether the particle has failed during its lifecycle.

--- a/java/arcs/core/host/api/Particle.kt
+++ b/java/arcs/core/host/api/Particle.kt
@@ -26,9 +26,8 @@ interface Particle {
      *
      * This should be used to initialize writeable handles to their starting state prior to the
      * arc starting. Readable handles cannot be read in this method.
-     * TODO: remove suspend when internal code no longer uses it
      */
-    suspend fun onFirstStart() = Unit
+    fun onFirstStart() = Unit
 
     /**
      * Called whenever this [Particle] is instantiated, both initially and when an arc is
@@ -69,28 +68,6 @@ interface Particle {
      * want resync-specific behaviour. When overriding, do not call super.onResync.
      */
     fun onResync() = Unit
-
-    /**
-     * React to handle updates.
-     *
-     * Called for handles when change events are received from the backing store.
-     *
-     * @param handle Singleton or Collection handle
-     */
-    @Deprecated("Use Handle.onUpdate")
-    suspend fun onHandleUpdate(handle: Handle) = Unit
-
-    /**
-     * React to handle synchronization.
-     *
-     * Called for handles that are marked for synchronization at connection, when they are updated with the full model
-     * of their data. This will occur once after setHandles() and any time thereafter if the handle is resynchronized.
-     *
-     * @param handle Singleton or Collection handle
-     * @param allSynced flag indicating if all handles are synchronized
-     */
-    @Deprecated("Use Handle.onReady and/or Handle.onResync")
-    suspend fun onHandleSync(handle: Handle, allSynced: Boolean) = Unit
 
     /**
      *  Called when an [Arc] is shutdown.

--- a/java/arcs/sdk/examples/testing/ComputePeopleStats.kt
+++ b/java/arcs/sdk/examples/testing/ComputePeopleStats.kt
@@ -1,7 +1,6 @@
 package arcs.sdk.examples.testing
 
 import arcs.core.util.TaggedLog
-import arcs.sdk.Handle
 
 typealias Person = ComputePeopleStats_People
 typealias Stats = ComputePeopleStats_Stats
@@ -12,13 +11,15 @@ typealias Stats = ComputePeopleStats_Stats
 class ComputePeopleStats : AbstractComputePeopleStats() {
     private val log = TaggedLog { "ComputePeopleStats" }
 
-    override suspend fun onHandleSync(handle: Handle, allSynced: Boolean) {
-        if (!allSynced) return
-        calculateMedian(handles.people.fetchAll())
+    override fun onStart() {
         handles.people.onUpdate {
             log.info { "onUpdate: ${it.map(Person::age)}" }
             calculateMedian(it)
         }
+    }
+
+    override fun onReady() {
+        calculateMedian(handles.people.fetchAll())
     }
 
     fun calculateMedian(people: Set<Person>) = when {

--- a/javatests/arcs/android/e2e/testapp/PersonHostService.kt
+++ b/javatests/arcs/android/e2e/testapp/PersonHostService.kt
@@ -62,21 +62,19 @@ class PersonHostService : ArcHostService() {
     }
 
     inner class ReadPerson : AbstractReadPerson() {
-        override suspend fun onHandleSync(handle: arcs.core.entity.Handle, allSynced: Boolean) {
-            super.onHandleSync(handle, allSynced)
-            sendResult(handles.person.fetch()?.name ?: "")
+        override fun onStart() {
             handles.person.onUpdate { person ->
                 person?.name?.let { sendResult(it) }
             }
         }
+
+        override fun onReady() {
+            sendResult(handles.person.fetch()?.name ?: "")
+        }
     }
 
     inner class WritePerson : AbstractWritePerson() {
-        override suspend fun onHandleSync(handle: Handle, allSynced: Boolean) {
-            // Always clear and re-write John Wick.
-            handles.person.clear()
-
-            // Write John Wick
+        override fun onFirstStart() {
             handles.person.store(WritePerson_Person("John Wick"))
         }
     }

--- a/javatests/arcs/android/e2e/testapp/WriteAnimalHostService.kt
+++ b/javatests/arcs/android/e2e/testapp/WriteAnimalHostService.kt
@@ -69,9 +69,8 @@ class WriteAnimalHostService : ArcHostService() {
         fun arcHostContext(arcId: String) = getArcHostContext(arcId)
     }
 
-    inner class WriteAnimal: AbstractWriteAnimal() {
-
-        override suspend fun onHandleSync(handle: Handle, allSynced: Boolean) {
+    inner class WriteAnimal : AbstractWriteAnimal() {
+        override fun onFirstStart() {
             handles.animal.store(WriteAnimal_Animal("platypus"))
         }
     }

--- a/javatests/arcs/core/allocator/AllocatorTestBase.kt
+++ b/javatests/arcs/core/allocator/AllocatorTestBase.kt
@@ -379,8 +379,8 @@ open class AllocatorTestBase {
             writingContext.particles[writePersonParticle.particleName]
         )
 
-        assertThat(readPersonContext.particleState).isEqualTo(ParticleState.Started)
-        assertThat(writePersonContext.particleState).isEqualTo(ParticleState.Started)
+        assertThat(readPersonContext.particleState).isEqualTo(ParticleState.Running)
+        assertThat(writePersonContext.particleState).isEqualTo(ParticleState.Running)
 
         writePersonContext.particle.let { particle ->
             particle as WritePerson
@@ -468,8 +468,8 @@ open class AllocatorTestBase {
             writingContextAfter.particles[writePersonParticle.particleName]
         )
 
-        assertThat(readPersonContext.particleState).isEqualTo(ParticleState.Started)
-        assertThat(writePersonContext.particleState).isEqualTo(ParticleState.Started)
+        assertThat(readPersonContext.particleState).isEqualTo(ParticleState.Running)
+        assertThat(writePersonContext.particleState).isEqualTo(ParticleState.Running)
 
         // onFirstStart() not called a second time
         assertThat((writePersonContext.particle as WritePerson).firstStartCalled).isFalse()

--- a/javatests/arcs/core/host/LifecycleParticles.kt
+++ b/javatests/arcs/core/host/LifecycleParticles.kt
@@ -3,7 +3,7 @@ package arcs.core.host
 class SingleReadHandleParticle : AbstractSingleReadHandleParticle() {
     val events = mutableListOf<String>()
 
-    override suspend fun onFirstStart() { events.add("onFirstStart") }
+    override fun onFirstStart() { events.add("onFirstStart") }
     override fun onStart() {
         handles.data.onReady { events.add("data.onReady:${data()}") }
         handles.data.onUpdate { events.add("data.onUpdate:${data()}") }
@@ -19,7 +19,7 @@ class SingleReadHandleParticle : AbstractSingleReadHandleParticle() {
 class SingleWriteHandleParticle : AbstractSingleWriteHandleParticle() {
     val events = mutableListOf<String>()
 
-    override suspend fun onFirstStart() { events.add("onFirstStart") }
+    override fun onFirstStart() { events.add("onFirstStart") }
     override fun onStart() { events.add("onStart") }
     override fun onReady() { events.add("onReady") }
     override fun onUpdate() { events.add("onUpdate") }
@@ -29,7 +29,7 @@ class SingleWriteHandleParticle : AbstractSingleWriteHandleParticle() {
 class MultiHandleParticle : AbstractMultiHandleParticle() {
     val events = mutableListOf<String>()
 
-    override suspend fun onFirstStart() { events.add("onFirstStart") }
+    override fun onFirstStart() { events.add("onFirstStart") }
     override fun onStart() {
         handles.data.onReady { events.add("data.onReady:${data()}") }
         handles.data.onUpdate { events.add("data.onUpdate:${data()}") }
@@ -51,7 +51,7 @@ class MultiHandleParticle : AbstractMultiHandleParticle() {
 class PausingParticle : AbstractPausingParticle() {
     val events = mutableListOf<String>()
 
-    override suspend fun onFirstStart() { events.add("onFirstStart") }
+    override fun onFirstStart() { events.add("onFirstStart") }
     override fun onStart() {
         handles.data.onReady { events.add("data.onReady:${data()}") }
         handles.data.onUpdate { events.add("data.onUpdate:${data()}") }

--- a/javatests/arcs/core/host/ReadPerson.kt
+++ b/javatests/arcs/core/host/ReadPerson.kt
@@ -9,7 +9,7 @@ class ReadPerson : AbstractReadPerson() {
 
     var deferred = CompletableDeferred<Boolean>()
 
-    override suspend fun onFirstStart() {
+    override fun onFirstStart() {
         firstStartCalled = true
     }
 

--- a/javatests/arcs/core/host/WritePerson.kt
+++ b/javatests/arcs/core/host/WritePerson.kt
@@ -10,7 +10,7 @@ class WritePerson : AbstractWritePerson() {
 
     var deferred = CompletableDeferred<Boolean>()
 
-    override suspend fun onFirstStart() {
+    override fun onFirstStart() {
         firstStartCalled = true
         if (throws) {
             throw IllegalArgumentException("Boom!")


### PR DESCRIPTION
- Remove 'suspend' from onFirstStart
- Remove onHandleSync and onHandleUpdate
- Rename ParticleState.Started to Running

This is the GitHub side of the change; a CL with the same API change will be submitted in Google first.