### PR TITLE
allow multiple annotation refs with the same name

### DIFF
--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -1312,10 +1312,6 @@ ${e.message}
   private static _buildAnnotationRefs(manifest: Manifest, annotationRefItems: AstNode.AnnotationRef[]): AnnotationRef[] {
     const annotationRefs: AnnotationRef[] = [];
     for (const aRefItem of annotationRefItems) {
-      if (annotationRefs.some(a => a.name === aRefItem.name)) {
-        throw new ManifestError(
-            aRefItem.location, `annotation '${aRefItem.name}' already exists.`);
-      }
       const annotation = manifest.findAnnotationByName(aRefItem.name);
       if (!annotation) {
         throw new ManifestError(

--- a/src/runtime/particle-spec.ts
+++ b/src/runtime/particle-spec.ts
@@ -151,7 +151,13 @@ export class HandleConnectionSpec implements HandleConnectionSpecInterface {
     this._annotations = annotations;
   }
   getAnnotation(name: string): AnnotationRef | null {
-    return this.annotations.find(a => a.name === name);
+    const annotations = this.findAnnotations(name);
+    assert(annotations.length <= 1,
+        `Multiple annotations found for '${name}'. Use findAnnotations instead.`);
+    return annotations.length === 0 ? null : annotations[0];
+  }
+  findAnnotations(name: string): AnnotationRef[] {
+    return this.annotations.filter(a => a.name === name);
   }
 }
 
@@ -361,7 +367,13 @@ export class ParticleSpec {
     this._annotations = annotations;
   }
   getAnnotation(name: string): AnnotationRef | null {
-    return this.annotations.find(a => a.name === name);
+    const annotations = this.findAnnotations(name);
+    assert(annotations.length <= 1,
+        `Multiple annotations found for '${name}'. Use findAnnotations instead.`);
+    return annotations.length === 0 ? null : annotations[0];
+  }
+  findAnnotations(name: string): AnnotationRef[] {
+    return this.annotations.filter(a => a.name === name);
   }
 
   /**

--- a/src/runtime/recipe/handle.ts
+++ b/src/runtime/recipe/handle.ts
@@ -238,7 +238,13 @@ export class Handle implements Comparable<Handle> {
     this._annotations = annotations;
   }
   getAnnotation(name: string): AnnotationRef | null {
-    return this.annotations.find(a => a.name === name);
+    const annotations = this.findAnnotations(name);
+    assert(annotations.length <= 1,
+        `Multiple annotations found for '${name}'. Use findAnnotations instead.`);
+    return annotations.length === 0 ? null : annotations[0];
+  }
+  findAnnotations(name: string): AnnotationRef[] {
+    return this.annotations.filter(a => a.name === name);
   }
 
   static effectiveType(handleType: Type, connections: {type?: Type, direction?: Direction, relaxed?: boolean}[]) {

--- a/src/runtime/recipe/recipe.ts
+++ b/src/runtime/recipe/recipe.ts
@@ -317,7 +317,13 @@ export class Recipe implements Cloneable<Recipe> {
     this._annotations = annotations;
   }
   getAnnotation(name: string): AnnotationRef | null {
-    return this.annotations.find(a => a.name === name);
+    const annotations = this.findAnnotations(name);
+    assert(annotations.length <= 1,
+        `Multiple annotations found for '${name}'. Use findAnnotations instead.`);
+    return annotations.length === 0 ? null : annotations[0];
+  }
+  findAnnotations(name: string): AnnotationRef[] {
+    return this.annotations.filter(a => a.name === name);
   }
 
   isEmpty(): boolean {

--- a/src/runtime/schema.ts
+++ b/src/runtime/schema.ts
@@ -108,7 +108,13 @@ export class Schema {
     this._annotations = annotations;
   }
   getAnnotation(name: string): AnnotationRef | null {
-    return this.annotations.find(a => a.name === name);
+    const annotations = this.findAnnotations(name);
+    assert(annotations.length <= 1,
+        `Multiple annotations found for '${name}'. Use findAnnotations instead.`);
+    return annotations.length === 0 ? null : annotations[0];
+  }
+  findAnnotations(name: string): AnnotationRef[] {
+    return this.annotations.filter(a => a.name === name);
   }
 
   static typesEqual(fieldType1, fieldType2): boolean {

--- a/src/runtime/tests/manifest-test.ts
+++ b/src/runtime/tests/manifest-test.ts
@@ -4543,4 +4543,18 @@ particle WriteFoo
     assert.equal(annotations3.find(a => a.name === 'ttl').params['value'], '3m');
     assert.equal(manifest.toString(), manifestStr.trim());
   });
+  it('parses for multiple annotation refs with same name', async () => {
+    const recipe = (await Manifest.parse(`
+        annotation oneParam(value: Text)
+          retention: Source
+          targets: [Recipe]
+          doc: 'doc'
+        @oneParam('hello')
+        @oneParam(value: 'world')
+        recipe
+    `)).recipes[0];
+    assert.lengthOf(recipe.annotations, 2);
+    assert.lengthOf(recipe.findAnnotations('oneParam'), 2);
+    assert.throws(() => recipe.getAnnotation('oneParam'));
+  });
 });


### PR DESCRIPTION
this should unblock the policy work.
i did explore couple more options:
1. make it part of the annotation declaration, whether multiple refs are allowed (it would be false in many cases, like `ttl` for example).
2. keep the AnnotationRef single, instead make the `params` dictionaries an array. It might be safer, as in you can't just ignore the second annotations with the same name, but it inconsistent with the manifest language...
WDYT?