### PR TITLE
Add ingress and violation directives to the test file itself.

### DIFF
--- a/javatests/arcs/core/analysis/testdata/BUILD
+++ b/javatests/arcs/core/analysis/testdata/BUILD
@@ -12,7 +12,8 @@ ALL_MANIFESTS = VALID_MANIFESTS + INVALID_MANIFESTS
 
 filegroup(
     name = "example_manifest_protos",
-    srcs = [":%s" % m.replace(".arcs", "") for m in ALL_MANIFESTS],
+    srcs = [":%s" % m.replace(".arcs", "") for m in ALL_MANIFESTS] +
+           [":%s" % m for m in ALL_MANIFESTS],
 )
 
 [arcs_manifest_proto(

--- a/javatests/arcs/core/analysis/testdata/fail_check_multiple_or_tags.arcs
+++ b/javatests/arcs/core/analysis/testdata/fail_check_multiple_or_tags.arcs
@@ -1,4 +1,7 @@
 // fails when a check including multiple tags isn't met
+// #Ingress: P1
+// #Ingress: P2
+// #Fail: hc:P3.bar is (tag1 or tag2)
 particle P1
   foo: writes Foo {}
   claim foo is tag1

--- a/javatests/arcs/core/analysis/testdata/fail_different_tag.arcs
+++ b/javatests/arcs/core/analysis/testdata/fail_different_tag.arcs
@@ -1,4 +1,6 @@
 // Fails when different tag is claimed.
+// #Ingress: P1
+// #Fail: hc:P2.bar is trusted
 particle P1
   foo: writes Foo {}
   claim foo is notTrusted

--- a/javatests/arcs/core/analysis/testdata/fail_mixer.arcs
+++ b/javatests/arcs/core/analysis/testdata/fail_mixer.arcs
@@ -1,3 +1,8 @@
+// #Ingress: IngestionAppName
+// #Ingress: IngestionLocation
+// #Fail: hc:Egress2.data is (packageName and coarseLocation)
+// #Fail: hc:Egress4.data is safeToLog
+// #Fail: hc:Egress5.data is ((packageName and safeToLog) or (coarseLocation and safeToLog))
 particle IngestionAppName
   data: writes [AppName {
     packageName: Text

--- a/javatests/arcs/core/analysis/testdata/fail_multiple_checks.arcs
+++ b/javatests/arcs/core/analysis/testdata/fail_multiple_checks.arcs
@@ -1,4 +1,7 @@
-// can detect failures for different checks', async () => {
+// can detect failures for different checks'
+// #Ingress: P1
+// #Fail: hc:P2.bar1 is trusted
+// #Fail: hc:P2.bar2 is extraTrusted
 particle P1
   foo1: writes Foo {}
   foo2: writes Foo {}

--- a/javatests/arcs/core/analysis/testdata/fail_multiple_inputs_one_untagged.arcs
+++ b/javatests/arcs/core/analysis/testdata/fail_multiple_inputs_one_untagged.arcs
@@ -1,4 +1,7 @@
 // fails when handle has multiple inputs but one is untagged
+// #Ingress: P1
+// #Ingress: P2
+// #Fail: hc:P3.bar is trusted
 particle P1
   foo: writes Foo {}
   claim foo is trusted

--- a/javatests/arcs/core/analysis/testdata/fail_negated_tag_present.arcs
+++ b/javatests/arcs/core/analysis/testdata/fail_negated_tag_present.arcs
@@ -1,5 +1,7 @@
 // fails for a negated tag check when the tag is present
-particle P1
+// #Ingress: P1
+// #Fail: hc:P2.bar is not private
+ particle P1
   foo: writes Foo {}
   claim foo is private
 particle P2

--- a/javatests/arcs/core/analysis/testdata/fail_no_inputs.arcs
+++ b/javatests/arcs/core/analysis/testdata/fail_no_inputs.arcs
@@ -1,4 +1,6 @@
 // fails when handle has no inputs
+// #Ingress: P.bar
+// #Fail: hc:P.bar is trusted
 particle P
   bar: reads Foo {}
   check bar is trusted

--- a/javatests/arcs/core/analysis/testdata/fail_no_tags.arcs
+++ b/javatests/arcs/core/analysis/testdata/fail_no_tags.arcs
@@ -1,4 +1,6 @@
 // fails when no tag is claimed
+// #Ingress: P1
+// #Fail: hc:P2.bar is trusted
 particle P1
   foo: writes Foo {}
 particle P2

--- a/javatests/arcs/core/analysis/testdata/fail_not_tag_cancels.arcs
+++ b/javatests/arcs/core/analysis/testdata/fail_not_tag_cancels.arcs
@@ -1,4 +1,6 @@
 // fails when a "not tag" cancels a tag
+// #Ingress: P1
+// #Fail: hc:P3.bye is trusted
 particle P1
   foo: writes Foo {}
   claim foo is trusted

--- a/javatests/arcs/core/analysis/testdata/fail_not_tag_claim.arcs
+++ b/javatests/arcs/core/analysis/testdata/fail_not_tag_claim.arcs
@@ -1,5 +1,7 @@
 // fails when a "not tag" is claimed and the tag is checked for
-particle P1
+// #Ingress: P1
+// #Fail: hc:P2.bar is trusted
+ particle P1
   foo: writes Foo {}
   claim foo is not trusted
 particle P2

--- a/javatests/arcs/core/analysis/testdata/fail_read_write_mismatch_claim_check.arcs
+++ b/javatests/arcs/core/analysis/testdata/fail_read_write_mismatch_claim_check.arcs
@@ -1,4 +1,6 @@
 // fails when an inout handle claims a different tag from the one it checks
+// #Ingress: P
+// #Fail: hc:P.foo is t1
 particle P
   foo: reads writes Foo {}
   check foo is t1

--- a/javatests/arcs/core/analysis/testdata/ok_check_multiple_and_single_claim.arcs
+++ b/javatests/arcs/core/analysis/testdata/ok_check_multiple_and_single_claim.arcs
@@ -1,4 +1,6 @@
 // succeeds when a check including multiple anded tags is met by a single claim
+// #Ingress: P1
+// #OK
 particle P1
   foo: writes Foo {}
   claim foo is tag1 and is tag2

--- a/javatests/arcs/core/analysis/testdata/ok_check_multiple_or_single_claim.arcs
+++ b/javatests/arcs/core/analysis/testdata/ok_check_multiple_or_single_claim.arcs
@@ -1,4 +1,6 @@
 // succeeds when a check including multiple 'or'd tags is met by a single claim
+// #Ingress: P1
+// #OK
 particle P1
   foo: writes Foo {}
   claim foo is tag1 and is tag2

--- a/javatests/arcs/core/analysis/testdata/ok_check_multiple_or_tags.arcs
+++ b/javatests/arcs/core/analysis/testdata/ok_check_multiple_or_tags.arcs
@@ -1,4 +1,7 @@
 // succeeds when a check includes multiple tags
+// #Ingress: P1
+// #Ingress: P2
+// #OK
 particle P1
   foo: writes Foo {}
   claim foo is tag1

--- a/javatests/arcs/core/analysis/testdata/ok_claim_not_overriden_later.arcs
+++ b/javatests/arcs/core/analysis/testdata/ok_claim_not_overriden_later.arcs
@@ -1,4 +1,6 @@
 // a claim made later in a chain of particles does not override claims made earlier
+// #Ingress: P1
+// #OK
 particle P1
   foo: writes Foo {}
   claim foo is trusted

--- a/javatests/arcs/core/analysis/testdata/ok_claim_propagates.arcs
+++ b/javatests/arcs/core/analysis/testdata/ok_claim_propagates.arcs
@@ -1,4 +1,6 @@
 // claim propagates through a chain of particles
+// #Ingress: P1
+// #OK
 particle P1
   foo: writes Foo {}
   claim foo is trusted

--- a/javatests/arcs/core/analysis/testdata/ok_directly_satisfied.arcs
+++ b/javatests/arcs/core/analysis/testdata/ok_directly_satisfied.arcs
@@ -1,4 +1,6 @@
 // DFA succeeds when a check is satisfied directly
+// #Ingress: P1
+// #OK
 particle P1
   foo: writes Foo {}
   claim foo is trusted

--- a/javatests/arcs/core/analysis/testdata/ok_multiple_inputs_correct_tags.arcs
+++ b/javatests/arcs/core/analysis/testdata/ok_multiple_inputs_correct_tags.arcs
@@ -1,4 +1,7 @@
 // succeeds when handle has multiple inputs with the right tags
+// #Ingress: P1
+// #Ingress: P2
+// #OK
 particle P1
   foo: writes Foo {}
   claim foo is trusted

--- a/javatests/arcs/core/analysis/testdata/ok_negated_missing_tag.arcs
+++ b/javatests/arcs/core/analysis/testdata/ok_negated_missing_tag.arcs
@@ -1,4 +1,6 @@
 // succeeds for a negated tag check when the tag is missing
+// #Ingress: P
+// #OK
 particle P
   bar: reads Foo {}
   check bar is not private

--- a/javatests/arcs/core/analysis/testdata/ok_not_tag_claim_no_checks.arcs
+++ b/javatests/arcs/core/analysis/testdata/ok_not_tag_claim_no_checks.arcs
@@ -1,4 +1,6 @@
 // succeeds when a "not tag" is claimed and there are no checks
+// #Ingress: P1
+// #OK
 particle P1
   foo: writes Foo {}
   claim foo is not trusted

--- a/javatests/arcs/core/analysis/testdata/ok_not_tag_claim_reclaimed.arcs
+++ b/javatests/arcs/core/analysis/testdata/ok_not_tag_claim_reclaimed.arcs
@@ -1,4 +1,6 @@
 // succeeds when a "not tag" cancels a tag that is reclaimed downstream
+// #Ingress: P1
+// #OK
 particle P1
   foo: writes Foo {}
   claim foo is trusted

--- a/javatests/arcs/core/analysis/testdata/ok_read_write_match_claim_check.arcs
+++ b/javatests/arcs/core/analysis/testdata/ok_read_write_match_claim_check.arcs
@@ -1,4 +1,6 @@
 // succeeds when an inout handle claims the same tag it checks
+// #Ingress: P
+// #OK
 particle P
   foo: reads writes Foo {}
   check foo is t


### PR DESCRIPTION
This eliminates the need for having them specified explicitly in the kotlin tests. This change also allows us to refactor the typescript tests in a straightforward manner.