### PR TITLE
database migration to prevent problems with #5403

### DIFF
--- a/java/arcs/core/data/SchemaFields.kt
+++ b/java/arcs/core/data/SchemaFields.kt
@@ -56,18 +56,27 @@ sealed class FieldType(
     }
 }
 
-/** Arcs primitive types. */
-enum class PrimitiveType {
-    Boolean,
-    Number,
-    Text,
-    Byte,
-    Short,
-    Int,
-    Long,
-    Char,
-    Float,
-    Double
+/**
+ * Arcs primitive types.
+ *
+ * Reordering the ids in this enum will require a DB migration. It is safe to append
+ * additional entries, up to the limit of [DatabaseImpl.REFERENCE_TYPE_SENTINEL].
+ * Note that the order of appearance in this list doesn't matter, just the values
+ * associated with each PrimitiveType.
+ *
+ * When adding new entries, ensure each PrimitiveType gets assigned a unique id!
+ */
+enum class PrimitiveType(val id: kotlin.Int) {
+    Boolean(0),
+    Number(1),
+    Text(2),
+    Byte(3),
+    Short(4),
+    Int(5),
+    Long(6),
+    Char(7),
+    Float(8),
+    Double(9)
 }
 
 val LARGEST_PRIMITIVE_TYPE_ID = PrimitiveType.values().size - 1

--- a/java/arcs/core/data/SchemaFields.kt
+++ b/java/arcs/core/data/SchemaFields.kt
@@ -59,12 +59,17 @@ sealed class FieldType(
 /**
  * Arcs primitive types.
  *
- * Reordering the ids in this enum will require a DB migration. It is safe to append
- * additional entries, up to the limit of [DatabaseImpl.REFERENCE_TYPE_SENTINEL].
- * Note that the order of appearance in this list doesn't matter, just the values
- * associated with each PrimitiveType.
- *
- * When adding new entries, ensure each PrimitiveType gets assigned a unique id!
+ * Modifying this enum will require a DB migration.
+ * - It is safe to append additional entries, up to the limit of
+ *   [DatabaseImpl.REFERENCE_TYPE_SENTINEL]. However, the new types will need to be inserted into
+ *   active databases, as primitive types are only added in onCreate.
+ * - Modifying DatabaseImpl.REFERENCE_TYPE_SENTINEL is significantly more fraught, and migration
+ *   would putatively require finding all impacted references (i.e. references with typeId less
+ *   than the new REFERENCE_TYPE_SENTINEL) and rewriting them.
+ * - Do not change the established mapping from PrimitiveType to id.
+ * - When adding new entries, ensure each PrimitiveType gets assigned a unique id, and that the
+ *   unique ids are tightly packed in the range 0..size - 1. Note that this requirement is guarded
+ *   by a test in [SchemaFieldsTest].
  */
 enum class PrimitiveType(val id: kotlin.Int) {
     Boolean(0),

--- a/javatests/arcs/android/storage/database/DatabaseImplTest.kt
+++ b/javatests/arcs/android/storage/database/DatabaseImplTest.kt
@@ -2283,7 +2283,7 @@ class DatabaseImplTest {
 
     companion object {
         /** The first free Type ID after all primitive types have been assigned. */
-        private const val FIRST_ENTITY_TYPE_ID = 10
+        private const val FIRST_ENTITY_TYPE_ID = DatabaseImpl.REFERENCE_TYPE_SENTINEL + 1
 
         private const val FIRST_VERSION_NUMBER = 1
         private val VERSION_MAP = VersionMap("first" to 1, "second" to 2)

--- a/javatests/arcs/core/data/SchemaFieldsTest.kt
+++ b/javatests/arcs/core/data/SchemaFieldsTest.kt
@@ -97,4 +97,13 @@ class SchemaFieldsTest {
             "{name: Text, dimensions: (Number, Number, Number), manufacturer: &x1y2z3}"
         )
     }
+
+    @Test
+    fun primitiveTypeIsWellStructured() {
+        val seenValues = PrimitiveType.values().map { it.id }.toSet()
+        for (i in 0..seenValues.size - 1) {
+            assertThat(seenValues).contains(i);
+        }
+        assertThat(seenValues.size).isEqualTo(LARGEST_PRIMITIVE_TYPE_ID + 1)
+    }
 }


### PR DESCRIPTION
Also take the opportunity to shift reference types out to make
way for future additions to the list of primitive types; and to
explicitly number the primitive types to help avoid reordering
problems.