### PR TITLE
Allow reading of entity creation timestamp, and check that is never s…

### DIFF
--- a/java/arcs/core/entity/Entity.kt
+++ b/java/arcs/core/entity/Entity.kt
@@ -25,6 +25,9 @@ interface Entity : Storable {
     /** The ID for the entity, or null if it is does not have one yet. */
     val entityId: String?
 
+    /** The creation timestamp of the entity. Set at the same time the ID is set. */
+    val creationTimestamp: Long
+
     /** The expiration timestamp of the entity. Set at the same time the ID is set. */
     val expirationTimestamp: Long
 

--- a/java/arcs/core/entity/EntityBase.kt
+++ b/java/arcs/core/entity/EntityBase.kt
@@ -41,7 +41,7 @@ open class EntityBase(
      */
     final override var entityId: String? = entityId
         private set
-    var creationTimestamp: Long = creationTimestamp
+    final override var creationTimestamp: Long = creationTimestamp
         private set
     final override var expirationTimestamp: Long = expirationTimestamp
         private set
@@ -281,11 +281,15 @@ open class EntityBase(
                 handleName
             ).toString()
         }
+        val now = time.currentTimeMillis
         if (creationTimestamp == UNINITIALIZED_TIMESTAMP) {
-            creationTimestamp = time.currentTimeMillis
+            creationTimestamp = now
             if (ttl != Ttl.Infinite) {
                 expirationTimestamp = ttl.calculateExpiration(time)
             }
+        }
+        require(creationTimestamp <= now) {
+            "Cannot set a future creationTimestamp=$creationTimestamp."
         }
     }
 

--- a/javatests/arcs/core/entity/EntityBaseTest.kt
+++ b/javatests/arcs/core/entity/EntityBaseTest.kt
@@ -347,6 +347,26 @@ class EntityBaseTest {
     }
 
     @Test
+    fun cannotSetFutureCreationTimestamp() {
+        val idGenerator = Id.Generator.newForTest("session1")
+        val time = FakeTime().also { it.millis = 100 }
+
+        // In the past, ok.
+        val entity = EntityBase("Foo", DummyEntity.SCHEMA, creationTimestamp = 20)
+        entity.ensureEntityFields(idGenerator, "handle", time, Ttl.Minutes(1))
+        assertThat(entity.creationTimestamp).isEqualTo(20)
+
+        // In the future, not ok.
+        val entity2 = EntityBase("Foo", DummyEntity.SCHEMA, creationTimestamp = 120)
+        val e = assertFailsWith<IllegalArgumentException> {
+            entity2.ensureEntityFields(idGenerator, "handle", time, Ttl.Minutes(1))
+        }
+        assertThat(e).hasMessageThat().isEqualTo(
+            "Cannot set a future creationTimestamp=120."
+        )
+    }
+
+    @Test
     fun testToString() {
         with (entity) {
             text = "abc"


### PR DESCRIPTION
…et to a future time.