### PR TITLE
Creates ManifestStringBuilder, a helper class for toManifestString().

### DIFF
--- a/src/dataflow/analysis/analysis.ts
+++ b/src/dataflow/analysis/analysis.ts
@@ -13,6 +13,7 @@ import {assert} from '../../platform/assert-web.js';
 import {Edge, FlowModifier, FlowSet, FlowModifierSet, Flow} from './graph-internals.js';
 import {Recipe} from '../../runtime/recipe/recipe.js';
 import {Manifest} from '../../runtime/manifest.js';
+import {ManifestStringBuilder} from '../../runtime/manifest-string-builder.js';
 
 /** Runs the dataflow analyser on the given recipe. */
 export function analyseDataflow(recipe: Recipe, manifest: Manifest): [FlowGraph, ValidationResult] {
@@ -190,18 +191,20 @@ export class EdgeExpression {
   }
 
   toString() {
-    const result: string[] = [`EdgeExpression(${this.edge.edgeId}) {`];
-
-    for (const flow of this.resolvedFlows) {
-      result.push('  ' + flow.toUniqueString());
-    }
-    for (const [edge, modifierSets] of this.unresolvedFlows) {
-      for (const modifiers of modifierSets) {
-        result.push(`  EdgeExpression(${edge.edgeId}) + ${modifiers.toUniqueString()}`);
+    const builder = new ManifestStringBuilder();
+    builder.push(`EdgeExpression(${this.edge.edgeId}) {`);
+    builder.withIndent(builder => {
+      for (const flow of this.resolvedFlows) {
+        builder.push(flow.toUniqueString());
       }
-    }
-    result.push('}');
-    return result.join('\n');
+      for (const [edge, modifierSets] of this.unresolvedFlows) {
+        for (const modifiers of modifierSets) {
+          builder.push(`EdgeExpression(${edge.edgeId}) + ${modifiers.toUniqueString()}`);
+        }
+      }
+    });
+    builder.push('}');
+    return builder.toString();
   }
 }
 

--- a/src/runtime/interface-info-impl.ts
+++ b/src/runtime/interface-info-impl.ts
@@ -162,8 +162,7 @@ class InterfaceInfoImpl extends InterfaceInfo {
     }));
   }
   // TODO: Include name as a property of the interface and normalize this to just toString()
-  toManifestString(builder?: ManifestStringBuilder) : string {
-    builder = builder || new ManifestStringBuilder();
+  toManifestString(builder = new ManifestStringBuilder()) : string {
     builder.push(`interface ${this.name}`);
     builder.withIndent(builder => {
       this._handleConnectionsToManifestString(builder);

--- a/src/runtime/interface-info-impl.ts
+++ b/src/runtime/interface-info-impl.ts
@@ -15,6 +15,7 @@ import {Type, TypeVariable, TypeLiteral, HandleConnection, Slot, InterfaceInfo,
         InterfaceInfoLiteral, MatchResult} from './type.js';
 import * as AstNode from './manifest-ast-nodes.js';
 import {ParticleSpec} from './particle-spec.js';
+import {ManifestStringBuilder} from './manifest-string-builder.js';
 
 const handleConnectionFields = ['type', 'name', 'direction'];
 const slotFields = ['name', 'direction', 'isRequired', 'isSet'];
@@ -139,35 +140,36 @@ class InterfaceInfoImpl extends InterfaceInfo {
     return false;
   }
 
-  _handleConnectionsToManifestString() {
-    return this.handleConnections
-      .map(h => {
-        const parts = [];
-        if (h.name) {
-          parts.push(`${h.name}:`);
-        }
-        if (h.direction !== undefined && h.direction !== 'any') {
-          parts.push(h.direction);
-        }
-        parts.push(h.type.toString());
-        return `  ${parts.join(' ')}`;
-      }).join('\n');
+  _handleConnectionsToManifestString(builder: ManifestStringBuilder) {
+    builder.push(...this.handleConnections.map(h => {
+      const parts = [];
+      if (h.name) {
+        parts.push(`${h.name}:`);
+      }
+      if (h.direction !== undefined && h.direction !== 'any') {
+        parts.push(h.direction);
+      }
+      parts.push(h.type.toString());
+      return parts.join(' ');
+    }));
   }
 
-  _slotsToManifestString() {
+  _slotsToManifestString(builder: ManifestStringBuilder) {
     // TODO deal with isRequired
-    return this.slots
-      .map(slot => {
-        const nameStr = slot.name ? `${slot.name}: ` : '';
-        return `  ${nameStr}${slot.direction}${slot.isRequired ? '' : '?'} ${slot.isSet ? '[Slot]' : 'Slot'}`;
-      })
-      .join('\n');
+    builder.push(...this.slots.map(slot => {
+      const nameStr = slot.name ? `${slot.name}: ` : '';
+      return `${nameStr}${slot.direction}${slot.isRequired ? '' : '?'} ${slot.isSet ? '[Slot]' : 'Slot'}`;
+    }));
   }
   // TODO: Include name as a property of the interface and normalize this to just toString()
-  toString() : string {
-    return `interface ${this.name}
-${this._handleConnectionsToManifestString()}
-${this._slotsToManifestString()}`;
+  toManifestString(builder?: ManifestStringBuilder) : string {
+    builder = builder || new ManifestStringBuilder();
+    builder.push(`interface ${this.name}`);
+    builder.withIndent(builder => {
+      this._handleConnectionsToManifestString(builder);
+      this._slotsToManifestString(builder);
+    });
+    return builder.toString();
   }
 
   clone(variableMap: Map<string, Type>) : InterfaceInfo {

--- a/src/runtime/manifest-string-builder.ts
+++ b/src/runtime/manifest-string-builder.ts
@@ -1,0 +1,67 @@
+/**
+ * @license
+ * Copyright (c) 2020 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+const spacesPerIndent = 2;
+
+export class ManifestStringBuilder {
+  private readonly lines: string[];
+  private readonly indent: number;
+  private readonly startIndex: number;
+
+  constructor(parentBuilder?: ManifestStringBuilder) {
+    if (parentBuilder) {
+      this.lines = parentBuilder.lines;
+      this.indent = parentBuilder.indent + 1;
+      this.startIndex = this.lines.length;
+    } else {
+      this.lines = [];
+      this.indent = 0;
+      this.startIndex = 0;
+    }
+  }
+
+  /** Add the given line(s) with the correct indent level. */
+  push(...lines: string[]) {
+    this.lines.push(...lines.map(line => ' '.repeat(this.indent * spacesPerIndent) + line));
+  }
+
+  /**
+   * Allow indenting a block at a time. Can be used either via a lambda argument
+   * or via the return value.
+   *
+   * Example 1:
+   *
+   * ```
+   * const indented = builder.withIndent()
+   * indented.push('a');
+   * indented.push('a');
+   * ```
+   *
+   * Example 2:
+   *
+   * ```
+   * builder.withIndent(indented => {
+   *   indented.push('a');
+   *   indented.push('a');
+   * });
+   * ```
+   */
+  withIndent(fn?: (builder: ManifestStringBuilder) => void): ManifestStringBuilder {
+    const indentedBuilder = new ManifestStringBuilder(this);
+    if (fn) {
+      fn(indentedBuilder);
+    }
+    return indentedBuilder;
+  }
+
+  toString() {
+    return this.lines.slice(this.startIndex).join('\n');
+  }
+}

--- a/src/runtime/manifest-string-builder.ts
+++ b/src/runtime/manifest-string-builder.ts
@@ -39,7 +39,7 @@ export class ManifestStringBuilder {
    * Example 1:
    *
    * ```
-   * const indented = builder.withIndent()
+   * const indented = builder.withIndent();
    * indented.push('a');
    * indented.push('a');
    * ```

--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -1514,7 +1514,7 @@ ${e.message}
     });
 
     Object.values(this._annotations).forEach(a => {
-      results.push(a.toString());
+      results.push(a.toManifestString());
     });
 
     Object.values(this._schemas).forEach(s => {

--- a/src/runtime/particle-spec.ts
+++ b/src/runtime/particle-spec.ts
@@ -455,8 +455,7 @@ export class ParticleSpec {
     return InterfaceType.make(this.name, handles, slots);
   }
 
-  toManifestString(builder?: ManifestStringBuilder): string {
-    builder = builder || new ManifestStringBuilder();
+  toManifestString(builder = new ManifestStringBuilder()): string {
     for (const annotation of this.annotations) {
       builder.push(annotation.toString());
     }

--- a/src/runtime/policy/policy.ts
+++ b/src/runtime/policy/policy.ts
@@ -50,8 +50,7 @@ export class Policy {
       readonly customAnnotations: AnnotationRef[],
       private readonly allAnnotations: AnnotationRef[]) {}
 
-  toManifestString(builder?: ManifestStringBuilder): string {
-    builder = builder || new ManifestStringBuilder();
+  toManifestString(builder = new ManifestStringBuilder()): string {
     builder.push(...this.allAnnotations.map(annotation => annotation.toString()));
     builder.push(`policy ${this.name} {`);
     builder.withIndent(builder => {
@@ -114,8 +113,7 @@ export class PolicyTarget {
       readonly customAnnotations: AnnotationRef[],
       private readonly allAnnotations: AnnotationRef[]) {}
 
-  toManifestString(builder?: ManifestStringBuilder): string {
-    builder = builder || new ManifestStringBuilder();
+  toManifestString(builder = new ManifestStringBuilder()): string {
     builder.push(...this.allAnnotations.map(annotation => annotation.toString()));
     builder.push(`from ${this.schemaName} access {`);
     this.fields.forEach(field => field.toManifestString(builder.withIndent()));
@@ -177,8 +175,7 @@ export class PolicyField {
     // TODO(b/157605585): Validate field structure against Type.
   }
 
-  toManifestString(builder?: ManifestStringBuilder): string {
-    builder = builder || new ManifestStringBuilder();
+  toManifestString(builder = new ManifestStringBuilder()): string {
     builder.push(...this.allAnnotations.map(annotation => annotation.toString()));
     if (this.subfields.length) {
       builder.push(`${this.name} {`);
@@ -242,8 +239,7 @@ export class PolicyField {
 export class PolicyConfig {
   constructor(readonly name: string, readonly metadata: Map<string, string>) {}
 
-  toManifestString(builder?: ManifestStringBuilder): string {
-    builder = builder || new ManifestStringBuilder();
+  toManifestString(builder = new ManifestStringBuilder()): string {
     builder.push(`config ${this.name} {`);
     builder.withIndent(builder => {
       for (const [k, v] of this.metadata) {

--- a/src/runtime/recipe/annotation.ts
+++ b/src/runtime/recipe/annotation.ts
@@ -12,6 +12,7 @@ import {assert} from '../../platform/assert-web.js';
 import {Comparable, compareStrings, compareArrays, compareBools} from './comparable.js';
 import {Dictionary} from '../hot.js';
 import {AnnotationTargetValue, AnnotationRetentionValue, SchemaPrimitiveTypeValue} from '../manifest-ast-nodes.js';
+import {ManifestStringBuilder} from '../manifest-string-builder.js';
 
 export class Annotation implements Comparable<Annotation> {
   constructor(public readonly name: string,
@@ -31,24 +32,26 @@ export class Annotation implements Comparable<Annotation> {
     return 0;
   }
 
-  toString(): string {
-    const result: string[] = [];
+  toManifestString(builder?: ManifestStringBuilder): string {
+    builder = builder || new ManifestStringBuilder();
     let paramStr = '';
     if (Object.keys(this.params).length > 0) {
       paramStr = `(${Object.keys(this.params).map(name => `${name}: ${this.params[name]}`).join(', ')})`;
     }
-    result.push(`annotation ${this.name}${paramStr}`);
-    if (this.targets.length > 0) {
-      result.push(`  targets: [${this.targets.join(', ')}]`);
-    }
-    result.push(`  retention: ${this.retention}`);
-    if (this.allowMultiple) {
-      result.push(`  allowMultiple: ${this.allowMultiple}`);
-    }
-    if (this.doc) {
-      result.push(`  doc: '${this.doc}'`);
-    }
-    return result.filter(s => s !== '').join('\n');
+    builder.push(`annotation ${this.name}${paramStr}`);
+    builder.withIndent(builder => {
+      if (this.targets.length > 0) {
+        builder.push(`targets: [${this.targets.join(', ')}]`);
+      }
+      builder.push(`retention: ${this.retention}`);
+      if (this.allowMultiple) {
+        builder.push(`allowMultiple: ${this.allowMultiple}`);
+      }
+      if (this.doc) {
+        builder.push(`doc: '${this.doc}'`);
+      }
+    });
+    return builder.toString();
   }
 }
 
@@ -88,7 +91,6 @@ export class AnnotationRef {
   }
 
   toString(): string {
-    const result: string[] = [];
     let paramStr = '';
     if (Object.keys(this.params).length > 0) {
       const params: string[] = [];
@@ -98,7 +100,6 @@ export class AnnotationRef {
       }
       paramStr = `(${params.join(', ')})`;
     }
-    result.push(`@${this.name}${paramStr}`);
-    return result.filter(s => s !== '').join('\n');
+    return `@${this.name}${paramStr}`;
   }
 }

--- a/src/runtime/recipe/annotation.ts
+++ b/src/runtime/recipe/annotation.ts
@@ -32,8 +32,7 @@ export class Annotation implements Comparable<Annotation> {
     return 0;
   }
 
-  toManifestString(builder?: ManifestStringBuilder): string {
-    builder = builder || new ManifestStringBuilder();
+  toManifestString(builder = new ManifestStringBuilder()): string {
     let paramStr = '';
     if (Object.keys(this.params).length > 0) {
       paramStr = `(${Object.keys(this.params).map(name => `${name}: ${this.params[name]}`).join(', ')})`;

--- a/src/runtime/recipe/slot-connection.ts
+++ b/src/runtime/recipe/slot-connection.ts
@@ -180,9 +180,9 @@ export class SlotConnection implements Comparable<SlotConnection> {
     consumeRes.push(`${this.name}:`);
     consumeRes.push('consumes');
     if (this.targetSlot) {
-      consumeRes.push(`${
+      consumeRes.push(
           (nameMap && nameMap.get(this.targetSlot)) ||
-          this.targetSlot.localName}`);
+          this.targetSlot.localName);
     }
 
     if (options && options.showUnresolved) {

--- a/src/runtime/schema.ts
+++ b/src/runtime/schema.ts
@@ -314,8 +314,7 @@ export class Schema {
     return `${names} {${fields.length > 0 && options && options.hideFields ? '...' : fields}}${this.refinement ? this.refinement.toString() : ''}`;
   }
 
-  toManifestString(builder?: ManifestStringBuilder): string {
-    builder = builder || new ManifestStringBuilder();
+  toManifestString(builder = new ManifestStringBuilder()): string {
     builder.push(...this.annotations.map(a => a.toString()));
     builder.push(`schema ${this.names.join(' ')}`);
     builder.withIndent(builder => {

--- a/src/runtime/tests/interface-info-test.ts
+++ b/src/runtime/tests/interface-info-test.ts
@@ -25,7 +25,7 @@ describe('interface', () => {
     assert.lengthOf(manifest.interfaces, 1);
     const interf = manifest.interfaces[0];
 
-    assert.strictEqual(interf.toString(), interfStr);
+    assert.strictEqual(interf.toManifestString(), interfStr);
   });
 
   it('finds type variable references in handle connections', () => {

--- a/src/runtime/tests/manifest-string-builder-test.ts
+++ b/src/runtime/tests/manifest-string-builder-test.ts
@@ -1,0 +1,86 @@
+/**
+ * @license
+ * Copyright (c) 2020 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {ManifestStringBuilder} from '../manifest-string-builder.js';
+import {assert} from '../../platform/chai-web.js';
+
+describe('ManifestStringBuilder', () => {
+  let builder: ManifestStringBuilder;
+
+  beforeEach(() => {
+    builder = new ManifestStringBuilder();
+  });
+
+  it('starts empty', () => {
+    assert.strictEqual(builder.toString(), '');
+  });
+
+  it('can add lines', () => {
+    builder.push('111');
+    builder.push('222');
+    builder.push('333');
+    assert.strictEqual(builder.toString(),
+`111
+222
+333`);
+  });
+
+  it('can indent via lambda', () => {
+    builder.push('111');
+    builder.withIndent(indentedBuilder => {
+      indentedBuilder.push('222');
+      indentedBuilder.push('333');
+      assert.strictEqual(indentedBuilder.toString(),
+`  222
+  333`);
+    });
+    builder.push('444');
+    assert.strictEqual(builder.toString(),
+`111
+  222
+  333
+444`);
+  });
+
+  it('can indent via return val', () => {
+    builder.push('111');
+    const indentedBuilder = builder.withIndent();
+    indentedBuilder.push('222');
+    indentedBuilder.push('333');
+    assert.strictEqual(indentedBuilder.toString(),
+`  222
+  333`);
+    builder.push('444');
+    assert.strictEqual(builder.toString(),
+`111
+  222
+  333
+444`);
+    assert.strictEqual(indentedBuilder.toString(),
+`  222
+  333
+444`);
+  });
+
+  it('can indent multiple levels', () => {
+    const indent1 = builder.withIndent();
+    const indent2 = indent1.withIndent();
+    const indent3 = indent2.withIndent();
+    builder.push('111');
+    indent1.push('222');
+    indent2.push('333');
+    indent3.push('444');
+    assert.strictEqual(builder.toString(),
+`111
+  222
+    333
+      444`);
+  });
+});

--- a/src/runtime/tests/type-test.ts
+++ b/src/runtime/tests/type-test.ts
@@ -415,7 +415,7 @@ describe('types', () => {
       const entity = EntityType.make(['Foo'], {value: 'Text'});
       const variable = TypeVariable.make('a');
       const iface = InterfaceType.make('i', [{type: entity, name: 'foo'}, {type: variable}], [{name: 'x', direction: 'consumes'}]);
-      assert.strictEqual(iface.interfaceInfo.toString(),
+      assert.strictEqual(iface.interfaceInfo.toManifestString(),
 `interface i
   foo: Foo {value: Text}
   ~a
@@ -427,10 +427,9 @@ describe('types', () => {
       const variable = TypeVariable.make('a');
       variable.variable.resolution = EntityType.make(['Foo'], {value: 'Text'});
       const iface = InterfaceType.make('i', [{type: variable}], []);
-      assert.strictEqual(iface.interfaceInfo.toString(),
+      assert.strictEqual(iface.interfaceInfo.toManifestString(),
 `interface i
-  ~a
-`);
+  ~a`);
     });
   });
 

--- a/src/runtime/type.ts
+++ b/src/runtime/type.ts
@@ -20,6 +20,7 @@ import * as AstNode from './manifest-ast-nodes.js';
 import {ParticleSpec} from './particle-spec.js';
 import {Refinement} from './refiner.js';
 import {AnnotationRef} from './recipe/annotation.js';
+import {ManifestStringBuilder} from './manifest-string-builder.js';
 
 export interface TypeLiteral extends Literal {
   tag: string;
@@ -1415,7 +1416,7 @@ export abstract class InterfaceInfo {
 
   abstract _applyExistenceTypeTest(test: Predicate<TypeVarReference>) : boolean;
 
-  abstract toString() : string;
+  abstract toManifestString(builder?: ManifestStringBuilder) : string;
 
   static make : Maker = null;
 


### PR DESCRIPTION
This class makes it much easier to get indentation correct, via the `withIndent()` method.

e.g.

```
const builder = new ManifestStringBuilder();
builder.push('particle Foo');
builder.withIndent(builder => {
  builder.push('foo: reads Foo');
  builder.push('bar: writes Bar');
});
return builder.toString();
```

produces

```
particle Foo
  foo: reads Foo
  bar: writes Bar
```

I've updated some toManifestString/toString methods to use the new class, but it's not comprehensive.