### PR TITLE
Don't store the 'raw' label in the policy proto.

### DIFF
--- a/src/runtime/policy/policy.ts
+++ b/src/runtime/policy/policy.ts
@@ -168,6 +168,11 @@ export class PolicyField {
   constructor(
       readonly name: string,
       readonly subfields: PolicyField[],
+      /**
+       * The acceptable usages this field. Each (label, usage) pair defines a
+       * usage type that is acceptable for a given redaction label. The empty
+       * string label describes the usage for the raw data, given no redaction.
+       */
       readonly allowedUsages: {label: string, usage: PolicyAllowedUsageType}[],
       readonly customAnnotations: AnnotationRef[],
       private readonly allAnnotations: AnnotationRef[]) {
@@ -221,17 +226,21 @@ export class PolicyField {
       }
     }
 
+    if (allowedUsages.length === 0) {
+      allowedUsages.push({label: '', usage: PolicyAllowedUsageType.Any});
+    }
+
     return new PolicyField(node.name, subfields, allowedUsages, customAnnotations, allAnnotations);
   }
 
   private static toAllowedUsage(annotation: AnnotationRef) {
-    // TODO(b/157605585): Handle "raw" label separately?
     assert(annotation.name === allowedUsageAnnotationName);
     const usageType = annotation.params['usageType'] as string;
     checkValueInEnum(usageType, PolicyAllowedUsageType);
+    const label = annotation.params['label'] as string;
     return {
       usage: usageType as PolicyAllowedUsageType,
-      label: annotation.params['label'] as string,
+      label: label === 'raw' ? '' : label,
     };
   }
 }

--- a/src/runtime/policy/tests/policy-test.ts
+++ b/src/runtime/policy/tests/policy-test.ts
@@ -193,7 +193,7 @@ policy MyPolicy {
     assert.strictEqual(child2.name, 'child2');
     assert.deepStrictEqual(child2.allowedUsages, [{
       usage: PolicyAllowedUsageType.Any,
-      label: 'raw',
+      label: '',
     }]);
     assert.lengthOf(child2.customAnnotations, 0);
   });
@@ -241,6 +241,19 @@ policy MyPolicy {
     }
   }
 }`), 'A definition for child already exists.');
+  });
+
+  it('allowed usages defaults to any', async () => {
+    const policy = await parsePolicy(`
+policy MyPolicy {
+  from Abc access {
+    field,
+  }
+}`);
+    assert.deepStrictEqual(policy.targets[0].fields[0].allowedUsages, [{
+      label: '',
+      usage: PolicyAllowedUsageType.Any,
+    }]);
   });
 
   it('policy configs work', async () => {

--- a/src/runtime/policy/tests/policy-test.ts
+++ b/src/runtime/policy/tests/policy-test.ts
@@ -244,16 +244,19 @@ policy MyPolicy {
   });
 
   it('allowed usages defaults to any', async () => {
-    const policy = await parsePolicy(`
+    const policyStr = `
 policy MyPolicy {
   from Abc access {
     field,
   }
-}`);
+}`.trim();
+    const policy = await parsePolicy(policyStr);
     assert.deepStrictEqual(policy.targets[0].fields[0].allowedUsages, [{
       label: '',
       usage: PolicyAllowedUsageType.Any,
     }]);
+
+    assert.strictEqual(policy.toManifestString(), policyStr);
   });
 
   it('policy configs work', async () => {

--- a/src/tools/tests/policy2proto-test.ts
+++ b/src/tools/tests/policy2proto-test.ts
@@ -116,7 +116,7 @@ policy MyPolicy {
             },
             {
               name: 'child2',
-              usages: [{redactionLabel: 'raw', usage: 'ANY'}],
+              usages: [{redactionLabel: '', usage: 'ANY'}],
             },
           ],
           annotations: [{name: 'custom'}],


### PR DESCRIPTION
Instead, store it as the empty string. This follows the contract described in the PolicyProto definition, which expects an empty/missing string for redaction_label.

Also sets the default allowedUsage to "any" (when no annotation is supplied).
