### PR TITLE
Ensure that all lifecycle methods are called on the correct Scheduler.

### DIFF
--- a/java/arcs/core/host/ArcHostContext.kt
+++ b/java/arcs/core/host/ArcHostContext.kt
@@ -52,6 +52,8 @@ data class ParticleContext(
     /**
      * Particles with only write-only handles won't receive any storage events and thus
      * need to have their `onReady` method invoked as a special case.
+     *
+     * This will be executed in the context of the StorageProxy's scheduler.
      */
     fun notifyWriteOnlyParticles() {
         if (awaitingReady.isEmpty()) {

--- a/java/arcs/core/storage/StorageProxy.kt
+++ b/java/arcs/core/storage/StorageProxy.kt
@@ -16,7 +16,6 @@ import arcs.core.crdt.CrdtModel
 import arcs.core.crdt.CrdtOperationAtTime
 import arcs.core.crdt.VersionMap
 import arcs.core.util.Scheduler
-import arcs.core.util.SchedulerDispatcher
 import arcs.core.util.TaggedLog
 import kotlinx.atomicfu.atomic
 import kotlinx.atomicfu.getAndUpdate
@@ -66,7 +65,8 @@ class StorageProxy<Data : CrdtData, Op : CrdtOperationAtTime, T>(
      * [Store], you must either be performing your interactions within a handle callback or on this
      * [CoroutineDispatcher].
      */
-    val dispatcher: CoroutineDispatcher = SchedulerDispatcher(scheduler)
+    val dispatcher: CoroutineDispatcher
+        get() = scheduler.asCoroutineDispatcher()
 
     /** Identifier of the data this [StorageProxy] is managing. */
     val storageKey: StorageKey = storeEndpointProvider.storageKey

--- a/javatests/arcs/core/host/LifecycleTest.kt
+++ b/javatests/arcs/core/host/LifecycleTest.kt
@@ -16,17 +16,20 @@ import arcs.core.data.Plan
 import arcs.core.storage.StoreManager
 import arcs.core.storage.api.DriverAndKeyConfigurator
 import arcs.core.storage.driver.RamDisk
+import arcs.core.testutil.runTest
 import arcs.core.util.Scheduler
+import arcs.core.util.testutil.LogRule
 import arcs.jvm.host.ExplicitHostRegistry
 import arcs.jvm.host.JvmSchedulerProvider
 import arcs.jvm.util.testutil.FakeTime
 import com.google.common.truth.Truth.assertThat
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
 import org.junit.After
 import org.junit.Assert.fail
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
@@ -38,8 +41,10 @@ import kotlin.coroutines.EmptyCoroutineContext
 @RunWith(JUnit4::class)
 @OptIn(ExperimentalCoroutinesApi::class)
 class LifecycleTest {
-    private val schedulerProvider = JvmSchedulerProvider(EmptyCoroutineContext)
+    @get:Rule
+    val log = LogRule()
 
+    private lateinit var schedulerProvider: JvmSchedulerProvider
     private lateinit var scheduler: Scheduler
     private lateinit var testHost: TestingHost
     private lateinit var hostRegistry: HostRegistry
@@ -47,13 +52,11 @@ class LifecycleTest {
     private lateinit var entityHandleManager: EntityHandleManager
     private lateinit var allocator: Allocator
 
-    private fun runTest(
-        testBody: suspend CoroutineScope.() -> Unit
-    ) = runBlocking(EmptyCoroutineContext) { testBody() }
-
     @Before
     fun setUp() = runBlocking {
+        RamDisk.clear()
         DriverAndKeyConfigurator.configure(null)
+        schedulerProvider = JvmSchedulerProvider(EmptyCoroutineContext)
         scheduler = schedulerProvider("test")
         testHost = TestingHost(
             schedulerProvider,
@@ -75,49 +78,13 @@ class LifecycleTest {
 
     @After
     fun tearDown() = runBlocking {
-        scheduler.waitForIdle()
-        storeManager.waitForIdle()
-        entityHandleManager.close()
-        RamDisk.clear()
-    }
-
-    /**
-     * Asserts that a list of values matches a sequence of groups, where a List group must be in
-     * order while a Set group may be any order. For example:
-     *   assertVariableOrdering(listOf(1, 2, 77, 55, 66, 3, 4),
-     *                          listOf(1, 2), setOf(55, 66, 77), listOf(3, 4)) => matches
-     * TODO: improve error reporting, move to general testutil?
-     */
-    fun <T> assertVariableOrdering(actual: List<T>, vararg groups: Collection<T>) {
-        val expectedSize = groups.fold(0) { sum, group -> sum + group.size }
-        if (expectedSize != actual.size) {
-            fail("expected $expectedSize elements but found ${actual.size}: $actual")
+        try {
+            scheduler.waitForIdle()
+            storeManager.waitForIdle()
+            entityHandleManager.close()
+        } finally {
+            schedulerProvider.cancelAll()
         }
-
-        var start = 0
-        for (group in groups) {
-            val slice = actual.subList(start, start + group.size)
-            when (group) {
-                is List -> assertThat(slice).isEqualTo(group)
-                is Set -> assertThat(slice).containsExactlyElementsIn(group)
-                else -> throw IllegalArgumentException(
-                    "assertVariableOrdering: only List and Set may be used " +
-                        "for the 'groups' argument"
-                )
-            }
-            start += group.size
-        }
-    }
-
-    private suspend fun startArc(plan: Plan): Arc {
-        val arc = allocator.startArcForPlan(plan).waitForStart()
-        waitForAllTheThings()
-        return arc
-    }
-
-    private suspend fun waitForAllTheThings() {
-        scheduler.waitForIdle()
-        storeManager.waitForIdle()
     }
 
     @Test
@@ -126,7 +93,9 @@ class LifecycleTest {
         val arc = startArc(SingleReadHandleTestPlan)
         val particle: SingleReadHandleParticle = testHost.getParticle(arc.id, name)
         val data = testHost.singletonForTest<SingleReadHandleParticle_Data>(arc.id, name, "data")
-        data.store(SingleReadHandleParticle_Data(5.0))
+        withContext(data.dispatcher) {
+            data.store(SingleReadHandleParticle_Data(5.0))
+        }
         waitForAllTheThings()
         arc.stop()
         arc.waitForStop()
@@ -147,7 +116,9 @@ class LifecycleTest {
         val arc = startArc(SingleWriteHandleTestPlan)
         val particle: SingleWriteHandleParticle = testHost.getParticle(arc.id, name)
         val data = testHost.singletonForTest<SingleWriteHandleParticle_Data>(arc.id, name, "data")
-        data.store(SingleWriteHandleParticle_Data(12.0))
+        withContext(data.dispatcher) {
+            data.store(SingleWriteHandleParticle_Data(12.0))
+        }
         waitForAllTheThings()
         arc.stop()
         arc.waitForStop()
@@ -165,14 +136,18 @@ class LifecycleTest {
         val result = testHost.collectionForTest<MultiHandleParticle_Result>(arc.id, name, "result")
         val config = testHost.singletonForTest<MultiHandleParticle_Config>(arc.id, name, "config")
 
-        data.store(MultiHandleParticle_Data(3.2))
-        waitForAllTheThings()
-        list.store(MultiHandleParticle_List("hi"))
+        withContext(data.dispatcher) {
+            data.store(MultiHandleParticle_Data(3.2))
+            waitForAllTheThings()
+            list.store(MultiHandleParticle_List("hi"))
+        }
         waitForAllTheThings()
         // Write-only handle ops do not trigger any lifecycle APIs.
-        result.store(MultiHandleParticle_Result(19.0))
-        waitForAllTheThings()
-        config.store(MultiHandleParticle_Config(true))
+        withContext(result.dispatcher) {
+            result.store(MultiHandleParticle_Result(19.0))
+            waitForAllTheThings()
+            config.store(MultiHandleParticle_Config(true))
+        }
         waitForAllTheThings()
         arc.stop()
         arc.waitForStop()
@@ -210,8 +185,11 @@ class LifecycleTest {
             )
         }
         val (data1, list1) = makeHandles()
-        data1.store(PausingParticle_Data(1.1))
-        list1.store(PausingParticle_List("first"))
+        withContext(data1.dispatcher) {
+            data1.store(PausingParticle_Data(1.1))
+            waitForAllTheThings()
+            list1.store(PausingParticle_List("first"))
+        }
         waitForAllTheThings()
 
         testHost.pause()
@@ -219,9 +197,11 @@ class LifecycleTest {
 
         val particle: PausingParticle = testHost.getParticle(arc.id, name)
         val (data2, list2) = makeHandles()
-        data2.store(PausingParticle_Data(2.2))
-        waitForAllTheThings()
-        list2.store(PausingParticle_List("second"))
+        withContext(data2.dispatcher) {
+            data2.store(PausingParticle_Data(2.2))
+            waitForAllTheThings()
+            list2.store(PausingParticle_List("second"))
+        }
         waitForAllTheThings()
         arc.stop()
         arc.waitForStop()
@@ -243,5 +223,44 @@ class LifecycleTest {
                 "onShutdown"
             )
         )
+    }
+
+    /**
+     * Asserts that a list of values matches a sequence of groups, where a List group must be in
+     * order while a Set group may be any order. For example:
+     *   assertVariableOrdering(listOf(1, 2, 77, 55, 66, 3, 4),
+     *                          listOf(1, 2), setOf(55, 66, 77), listOf(3, 4)) => matches
+     * TODO: improve error reporting, move to general testutil?
+     */
+    fun <T> assertVariableOrdering(actual: List<T>, vararg groups: Collection<T>) {
+        val expectedSize = groups.fold(0) { sum, group -> sum + group.size }
+        if (expectedSize != actual.size) {
+            fail("expected $expectedSize elements but found ${actual.size}: $actual")
+        }
+
+        var start = 0
+        groups.forEach { group ->
+            val slice = actual.subList(start, start + group.size)
+            when (group) {
+                is List -> assertThat(slice).isEqualTo(group)
+                is Set -> assertThat(slice).containsExactlyElementsIn(group)
+                else -> throw IllegalArgumentException(
+                    "assertVariableOrdering: only List and Set may be used " +
+                        "for the 'groups' argument"
+                )
+            }
+            start += group.size
+        }
+    }
+
+    private suspend fun startArc(plan: Plan): Arc {
+        val arc = allocator.startArcForPlan(plan).waitForStart()
+        waitForAllTheThings()
+        return arc
+    }
+
+    private suspend fun waitForAllTheThings() {
+        scheduler.waitForIdle()
+        storeManager.waitForIdle()
     }
 }


### PR DESCRIPTION
Also, have the scheduler create its own dispatcher and provide `asCoroutineDispatcher` instead of having other classes create the dispatcher themselves.