### PR TITLE
Memory optimization: remove duplicate store instantiations of singleton handles

### DIFF
--- a/java/arcs/core/common/Id.kt
+++ b/java/arcs/core/common/Id.kt
@@ -65,6 +65,10 @@ interface Id {
         fun newChildId(parentId: Id, subComponent: String = ""): Id =
             IdImpl(currentSessionId, parentId.idTree + listOf("$subComponent${nextComponentId++}"))
 
+        /** Returns the [Id] of the child [subComponent] of the given [parentId]. */
+        fun getChildId(parentId: Id, subComponent: String): Id =
+            IdImpl(currentSessionId, parentId.idTree + listOf(subComponent))
+
         companion object {
             /** Creates a new random session id and returns a [Generator] using it. */
             fun newSession(): Generator = Generator(Random.nextSafeRandomLong().toString())

--- a/java/arcs/core/entity/Entity.kt
+++ b/java/arcs/core/entity/Entity.kt
@@ -35,6 +35,7 @@ interface Entity : Storable {
     fun ensureEntityFields(
         idGenerator: Id.Generator,
         handleName: String,
+        handleSpec: HandleSpec<out Entity>,
         time: Time,
         ttl: Ttl = Ttl.Infinite
     )

--- a/java/arcs/core/entity/EntityBase.kt
+++ b/java/arcs/core/entity/EntityBase.kt
@@ -23,6 +23,7 @@ import arcs.core.data.Ttl
 import arcs.core.data.util.ReferencableList
 import arcs.core.data.util.ReferencablePrimitive
 import arcs.core.data.util.toReferencable
+import arcs.core.entity.HandleContainerType.Singleton
 import arcs.core.storage.Reference as StorageReference
 import arcs.core.util.Time
 import kotlin.reflect.KProperty
@@ -271,15 +272,24 @@ open class EntityBase(
     override fun ensureEntityFields(
         idGenerator: Id.Generator,
         handleName: String,
+        handleSpec: HandleSpec<out Entity>,
         time: Time,
         ttl: Ttl
     ) {
         if (entityId == null) {
-            entityId = idGenerator.newChildId(
-                // TODO: should we allow this to be plumbed through?
-                idGenerator.newArcId("dummy-arc"),
-                handleName
-            ).toString()
+            entityId =
+                if (handleSpec.containerType == Singleton)
+                    idGenerator.getChildId(
+                        // TODO: should we allow this to be plumbed through?
+                        idGenerator.newArcId("dummy-arc"),
+                        handleName
+                    ).toString()
+                else
+                    idGenerator.newChildId(
+                        // TODO: should we allow this to be plumbed through?
+                        idGenerator.newArcId("dummy-arc"),
+                        handleName
+                    ).toString()
         }
         if (creationTimestamp == UNINITIALIZED_TIMESTAMP) {
             creationTimestamp = time.currentTimeMillis

--- a/java/arcs/core/entity/StorageAdapter.kt
+++ b/java/arcs/core/entity/StorageAdapter.kt
@@ -33,6 +33,7 @@ sealed class StorageAdapter<T : Storable, R : Referencable> {
 @Suppress("GoodTime") // use Instant
 class EntityStorageAdapter<T : Entity>(
     val handleName: String,
+    val handleSpec: HandleSpec<out Entity>,
     val idGenerator: Id.Generator,
     val entitySpec: EntitySpec<T>,
     private val ttl: Ttl,
@@ -40,7 +41,7 @@ class EntityStorageAdapter<T : Entity>(
     private val dereferencerFactory: EntityDereferencerFactory
 ) : StorageAdapter<T, RawEntity>() {
     override fun storableToReferencable(value: T): RawEntity {
-        value.ensureEntityFields(idGenerator, handleName, time, ttl)
+        value.ensureEntityFields(idGenerator, handleName, handleSpec, time, ttl)
 
         val rawEntity = value.serialize()
 

--- a/java/arcs/core/host/EntityHandleManager.kt
+++ b/java/arcs/core/host/EntityHandleManager.kt
@@ -117,6 +117,7 @@ class EntityHandleManager(
             HandleDataType.Entity -> {
                 EntityStorageAdapter(
                     handleName,
+                    spec,
                     idGenerator,
                     spec.entitySpec,
                     ttl,


### PR DESCRIPTION
Currently writing N entities to a singleton handle would create N stores in the service side.
Each write generates an unique id which is suffixed by `<handle name><rolling number>`

For singleton handle, the rolling number seems not necessary (collection handle does need it).
By removing the rolling number, it ensures only one single Store instance per singleton handle
in the service side.

dalvik heap before the optimization: +54372 KB
dalvik heap after the optimization: +1068 KB