### PR TITLE
Only trigger onUpdate for ModelUpdates if the consumerView changed

### DIFF
--- a/java/arcs/core/storage/StorageProxy.kt
+++ b/java/arcs/core/storage/StorageProxy.kt
@@ -384,6 +384,7 @@ class StorageProxy<Data : CrdtData, Op : CrdtOperationAtTime, T>(
 
     private fun processModelUpdate(model: Data) {
         // TODO: send the returned merge changes to notifyUpdate()
+        val valueBefore = crdt.consumerView
         crdt.merge(model)
 
         val value = crdt.consumerView
@@ -400,7 +401,7 @@ class StorageProxy<Data : CrdtData, Op : CrdtOperationAtTime, T>(
 
         when (priorState) {
             ProxyState.AWAITING_SYNC -> notifyReady()
-            ProxyState.SYNC -> notifyUpdate(value)
+            ProxyState.SYNC -> if (valueBefore != value) notifyUpdate(value)
             ProxyState.DESYNC -> notifyResync()
             ProxyState.NO_SYNC,
             ProxyState.READY_TO_SYNC,
@@ -444,41 +445,55 @@ class StorageProxy<Data : CrdtData, Op : CrdtOperationAtTime, T>(
 
     private fun notifyReady() {
         log.debug { "notifying ready" }
-        scheduleCallbackTasks(handleCallbacks.value.onReady, "onReady") { it() }
-        scheduleCallbackTasks(handleCallbacks.value.notify, "notify") { it(StorageEvent.READY) }
+        val tasks = handleCallbacks.value.let {
+            buildCallbackTasks(handleCallbacks.value.onReady, "onReady") { it() } +
+                buildCallbackTasks(handleCallbacks.value.notify, "notify") {
+                    it(StorageEvent.READY)
+                }
+        }
+        if (tasks.isNotEmpty()) scheduler.schedule(tasks)
     }
 
     private fun notifyUpdate(data: T) {
         log.debug { "notifying update" }
-        scheduleCallbackTasks(handleCallbacks.value.onUpdate, "onUpdate") { it(data) }
-        scheduleCallbackTasks(handleCallbacks.value.notify, "notify(UPDATE)") {
-            it(StorageEvent.UPDATE)
+        val tasks = handleCallbacks.value.let {
+            buildCallbackTasks(handleCallbacks.value.onUpdate, "onUpdate") { it(data) } +
+                buildCallbackTasks(handleCallbacks.value.notify, "notify(UPDATE)") {
+                    it(StorageEvent.UPDATE)
+                }
         }
+        if (tasks.isNotEmpty()) scheduler.schedule(tasks)
     }
 
     private fun notifyDesync() {
         log.debug { "notifying desync" }
-        scheduleCallbackTasks(handleCallbacks.value.onDesync, "onDesync") { it() }
-        scheduleCallbackTasks(handleCallbacks.value.notify, "notify(DESYNC)") {
-            it(StorageEvent.DESYNC)
+        val tasks = handleCallbacks.value.let {
+            buildCallbackTasks(handleCallbacks.value.onDesync, "onDesync") { it() } +
+                buildCallbackTasks(handleCallbacks.value.notify, "notify(DESYNC)") {
+                    it(StorageEvent.DESYNC)
+                }
         }
+        if (tasks.isNotEmpty()) scheduler.schedule(tasks)
     }
 
     private fun notifyResync() {
         log.debug { "notifying resync" }
-        scheduleCallbackTasks(handleCallbacks.value.onResync, "onResync") { it() }
-        scheduleCallbackTasks(handleCallbacks.value.notify, "notify(RESYNC)") {
-            it(StorageEvent.RESYNC)
+        val tasks = handleCallbacks.value.let {
+            buildCallbackTasks(handleCallbacks.value.onResync, "onResync") { it() } +
+                buildCallbackTasks(handleCallbacks.value.notify, "notify(RESYNC)") {
+                    it(StorageEvent.RESYNC)
+                }
         }
+        if (tasks.isNotEmpty()) scheduler.schedule(tasks)
     }
 
     /** Schedule [HandleCallbackTask]s for all given [callbacks] with the [Scheduler]. */
-    private fun <FT : Function<Unit>> scheduleCallbackTasks(
+    private fun <FT : Function<Unit>> buildCallbackTasks(
         callbacks: Map<CallbackIdentifier, List<FT>>,
         callbackName: String,
         block: (FT) -> Unit
-    ) {
-        val tasks = callbacks.entries.flatMap { (id, callbacks) ->
+    ): List<Scheduler.Task> {
+        return callbacks.entries.flatMap { (id, callbacks) ->
             callbacks.map { callback ->
                 HandleCallbackTask(id, callbackName) {
                     log.debug { "Executing callback for $id" }
@@ -486,8 +501,6 @@ class StorageProxy<Data : CrdtData, Op : CrdtOperationAtTime, T>(
                 }
             }
         }
-
-        scheduler.schedule(tasks)
     }
 
     private fun checkNotClosed() = check(stateHolder.value.state != ProxyState.CLOSED) {

--- a/java/arcs/sdk/android/dev/service/demo/BUILD
+++ b/java/arcs/sdk/android/dev/service/demo/BUILD
@@ -18,6 +18,7 @@ android_binary(
     javacopts = ["-Xep:AndroidJdkLibsChecker:OFF"],
     licenses = ["notice"],
     manifest = "AndroidManifest.xml",
+    multidex = "native",
     resource_files = glob(["res/**"]),
     deps = [
         "//java/arcs/sdk/android/dev/api:api-android",

--- a/javatests/arcs/core/host/LifecycleTest.kt
+++ b/javatests/arcs/core/host/LifecycleTest.kt
@@ -13,6 +13,7 @@ package arcs.core.host
 import arcs.core.allocator.Allocator
 import arcs.core.allocator.Arc
 import arcs.core.data.Plan
+import arcs.core.entity.awaitReady
 import arcs.core.storage.StoreManager
 import arcs.core.storage.api.DriverAndKeyConfigurator
 import arcs.core.storage.driver.RamDisk
@@ -196,7 +197,7 @@ class LifecycleTest {
     }
 
     @Test
-    fun pausing() = runTest {
+    fun pausing() = runBlocking {
         val name = "PausingParticle"
         val arc = startArc(PausingTestPlan)
 
@@ -205,8 +206,8 @@ class LifecycleTest {
         // TODO: allow test handles to persist across arc shutdown?
         val makeHandles = suspend {
             Pair(
-                testHost.singletonForTest<PausingParticle_Data>(arc.id, name, "data"),
-                testHost.collectionForTest<PausingParticle_List>(arc.id, name, "list")
+                testHost.singletonForTest<PausingParticle_Data>(arc.id, name, "data").awaitReady(),
+                testHost.collectionForTest<PausingParticle_List>(arc.id, name, "list").awaitReady()
             )
         }
         val (data1, list1) = makeHandles()
@@ -234,8 +235,6 @@ class LifecycleTest {
             setOf("data.onReady:1.1", "list.onReady:[first]"),
             listOf(
                 "onReady:1.1:[first]",
-                "data.onUpdate:2.2",
-                "onUpdate:2.2:[first]",
                 "data.onUpdate:2.2",
                 "onUpdate:2.2:[first]",
                 "list.onUpdate:[first, second]",

--- a/javatests/arcs/core/storage/StorageProxyTest.kt
+++ b/javatests/arcs/core/storage/StorageProxyTest.kt
@@ -235,7 +235,10 @@ class StorageProxyTest {
         assertThat(proxy.getStateForTesting()).isEqualTo(ProxyState.SYNC)
         verify(onReady).invoke()
 
-        // Sending another model should trigger the onUpdate callback.
+        // Sending another model should trigger the onUpdate callback only if the data changed.
+        whenever(mockCrdtModel.consumerView)
+            .thenReturn("blah")
+            .thenReturn("data")
         proxy.onMessage(ProxyMessage.ModelUpdate(mockCrdtData, null))
 
         channels.onUpdate.receiveOrTimeout()
@@ -586,7 +589,6 @@ class StorageProxyTest {
         whenever(mockCrdtModel.applyOperation(mockCrdtOperation)).thenReturn(false)
         proxy.onMessage(ProxyMessage.ModelUpdate(mockCrdtData, null))
         proxy.onMessage(ProxyMessage.Operations(listOf(mockCrdtOperation),null))
-        assertThat(notifyChannel.receiveOrTimeout()).isEqualTo(StorageEvent.UPDATE)
         assertThat(notifyChannel.receiveOrTimeout()).isEqualTo(StorageEvent.DESYNC)
         assertThat(proxy.getStateForTesting()).isEqualTo(ProxyState.DESYNC)
 


### PR DESCRIPTION
This PR makes it so that a `ModelUpdate` received by the `StorageProxy` only triggers an `onUpdate` notification if both the state of the proxy is `SYNC` *and* the `consumerView` of the `CrdtModel` changed due to the `ModelUpdate`.

Additionally, it lumps the StorageEvent tasks together with the callback tasks in the agenda, rather than causing two Agenda-schedulings.