### PR TITLE
send Close to channel when last callback is de-registered

### DIFF
--- a/.bazelproject
+++ b/.bazelproject
@@ -1,16 +1,16 @@
 directories:
   java
   javatests
-  build_defs
-  tools
-  third_party
-  particles
-  src
+#  build_defs
+#  tools
+#  third_party
+#  particles
+#  src
 
 targets:
   //java/...
   //javatests/...
-  //particles/...
+#  //particles/...
 
 test_sources:
   javatests/

--- a/.bazelproject
+++ b/.bazelproject
@@ -1,16 +1,16 @@
 directories:
   java
   javatests
-#  build_defs
-#  tools
-#  third_party
-#  particles
-#  src
+  build_defs
+  tools
+  third_party
+  particles
+  src
 
 targets:
   //java/...
   //javatests/...
-#  //particles/...
+  //particles/...
 
 test_sources:
   javatests/

--- a/java/arcs/android/storage/database/AndroidSqliteDatabaseManager.kt
+++ b/java/arcs/android/storage/database/AndroidSqliteDatabaseManager.kt
@@ -70,6 +70,7 @@ class AndroidSqliteDatabaseManager(
     fun close() = runBlocking {
         mutex.withLock {
             dbCache.values.forEach { it.close() }
+            dbCache.clear()
         }
 
         registry.close()

--- a/java/arcs/core/storage/BackingStore.kt
+++ b/java/arcs/core/storage/BackingStore.kt
@@ -40,6 +40,7 @@ class BackingStore<Data : CrdtData, Op : CrdtOperation, T>(
     private val storeMutex = Mutex()
     // TODO(b/158262634): Make this CacheMap Weak.
     /* internal */ val stores = LruCacheMap<String, StoreRecord<Data, Op, T>>(
+        50,
         livenessPredicate = { _, sr -> !sr.store.closed }
     ) { _, sr ->
         if (!sr.store.closed) {

--- a/java/arcs/core/storage/BackingStore.kt
+++ b/java/arcs/core/storage/BackingStore.kt
@@ -40,9 +40,9 @@ class BackingStore<Data : CrdtData, Op : CrdtOperation, T>(
     private val storeMutex = Mutex()
     // TODO(b/158262634): Make this CacheMap Weak.
     /* internal */ val stores = LruCacheMap<String, StoreRecord<Data, Op, T>>(
-        livenessPredicate = { _, sr -> !sr.store.isClosed() }
+        livenessPredicate = { _, sr -> !sr.store.closed }
     ) { _, sr ->
-        if (!sr.store.isClosed()) {
+        if (!sr.store.closed) {
             sr.store.close()
         }
     }

--- a/java/arcs/core/storage/DirectStore.kt
+++ b/java/arcs/core/storage/DirectStore.kt
@@ -32,6 +32,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.ConflatedBroadcastChannel
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.runBlocking
 
 // import kotlinx.coroutines.flow.debounce
 // import kotlinx.coroutines.flow.filter
@@ -118,12 +119,15 @@ class DirectStore<Data : CrdtData, Op : CrdtOperation, T> /* internal */ constru
 
     private fun closeInternal() {
         if (!closed) {
+            closed = true
             stateChannel.offer(State.Closed())
             stateChannel.close()
-            state.value = State.Closed<Data>() as State.StateWithData<Data>
+            state.value = State.Closed()
             closeWriteBack()
+            runBlocking {
+                driver.close()
+            }
         }
-        closed = true
     }
 
     /**

--- a/java/arcs/core/storage/DirectStore.kt
+++ b/java/arcs/core/storage/DirectStore.kt
@@ -158,7 +158,9 @@ class DirectStore<Data : CrdtData, Op : CrdtOperation, T> /* internal */ constru
                             message.operations.toMutableList()
                         )
                         processModelChange(
-                            change, otherChange = null, version = version.value,
+                            change,
+                            otherChange = null,
+                            version = version.value,
                             channel = message.id
                         )
                     }
@@ -170,7 +172,10 @@ class DirectStore<Data : CrdtData, Op : CrdtOperation, T> /* internal */ constru
                     localModel.merge(message.model)
                 }
                 processModelChange(
-                    modelChange, otherChange, version.value, channel = message.id
+                    modelChange,
+                    otherChange,
+                    version.value,
+                    channel = message.id
                 )
                 true
             }
@@ -230,7 +235,9 @@ class DirectStore<Data : CrdtData, Op : CrdtOperation, T> /* internal */ constru
                 if (modelChange.isEmpty() && otherChange.isEmpty()) return@forEach
                 deliverCallbacks(modelChange, null)
                 noDriverSideChanges = noDriverSideChanges && noDriverSideChanges(
-                    modelChange, otherChange, messageFromDriver = true
+                    modelChange,
+                    otherChange,
+                    messageFromDriver = true
                 )
                 log.debug { "No driver side changes? $noDriverSideChanges" }
             } catch (e: Exception) {
@@ -265,12 +272,14 @@ class DirectStore<Data : CrdtData, Op : CrdtOperation, T> /* internal */ constru
         when (thisChange) {
             is CrdtChange.Operations -> {
                 proxyManager.send(
-                    message = ProxyMessage.Operations(thisChange.ops, source), exceptTo = source
+                    message = ProxyMessage.Operations(thisChange.ops, source),
+                    exceptTo = source
                 )
             }
             is CrdtChange.Data -> {
                 proxyManager.send(
-                    message = ProxyMessage.ModelUpdate(thisChange.data, source), exceptTo = source
+                    message = ProxyMessage.ModelUpdate(thisChange.data, source),
+                    exceptTo = source
                 )
             }
         }
@@ -472,7 +481,9 @@ class DirectStore<Data : CrdtData, Op : CrdtOperation, T> /* internal */ constru
 
             val driver = CrdtException.requireNotNull(
                 DriverFactory.getDriver(
-                    options.storageKey, crdtType.crdtModelDataClass, options.type
+                    options.storageKey,
+                    crdtType.crdtModelDataClass,
+                    options.type
                 ) as? Driver<Data>
             ) { "No driver exists to support storage key ${options.storageKey}" }
 
@@ -481,7 +492,9 @@ class DirectStore<Data : CrdtData, Op : CrdtOperation, T> /* internal */ constru
             }
 
             return DirectStore(
-                options, localModel = localModel, driver = driver
+                options,
+                localModel = localModel,
+                driver = driver
             ).also { store ->
                 driver.registerReceiver(options.versionToken) { data, version ->
                     store.onReceive(data, version)

--- a/java/arcs/core/storage/DirectStore.kt
+++ b/java/arcs/core/storage/DirectStore.kt
@@ -180,7 +180,9 @@ class DirectStore<Data : CrdtData, Op : CrdtOperation, T> /* internal */ constru
     }
 
     private suspend fun processModelChange(
-        modelChange: CrdtChange<Data, Op>, otherChange: CrdtChange<Data, Op>?, version: Int,
+        modelChange: CrdtChange<Data, Op>,
+        otherChange: CrdtChange<Data, Op>?,
+        version: Int,
         channel: Int?
     ) {
         if (modelChange.isEmpty() && otherChange?.isEmpty() == true) return
@@ -248,7 +250,8 @@ class DirectStore<Data : CrdtData, Op : CrdtOperation, T> /* internal */ constru
      * model before we've applied the operations.
      */
     private fun noDriverSideChanges(
-        thisChange: CrdtChange<Data, Op>, otherChange: CrdtChange<Data, Op>?,
+        thisChange: CrdtChange<Data, Op>,
+        otherChange: CrdtChange<Data, Op>?,
         messageFromDriver: Boolean
     ): Boolean {
         return if (messageFromDriver) {
@@ -258,9 +261,7 @@ class DirectStore<Data : CrdtData, Op : CrdtOperation, T> /* internal */ constru
         }
     }
 
-    private suspend fun deliverCallbacks(
-        thisChange: CrdtChange<Data, Op>, source: Int?
-    ) {
+    private suspend fun deliverCallbacks(thisChange: CrdtChange<Data, Op>, source: Int?) {
         when (thisChange) {
             is CrdtChange.Operations -> {
                 proxyManager.send(
@@ -282,7 +283,9 @@ class DirectStore<Data : CrdtData, Op : CrdtOperation, T> /* internal */ constru
      * [here](https://github.com/PolymerLabs/arcs/wiki/Store-object-State-Machine).
      */
     private suspend fun updateStateAndAct(
-        noDriverSideChanges: Boolean, version: Int, messageFromDriver: Boolean
+        noDriverSideChanges: Boolean,
+        version: Int,
+        messageFromDriver: Boolean
     ) {
         if (closed) return
 
@@ -371,7 +374,8 @@ class DirectStore<Data : CrdtData, Op : CrdtOperation, T> /* internal */ constru
          * The [DirectStore] is currently idle.
          */
         class Idle<Data : CrdtData>(
-            idleDeferred: AtomicRef<IdleDeferred>, driver: Driver<Data>
+            idleDeferred: AtomicRef<IdleDeferred>,
+            driver: Driver<Data>
         ) : StateWithData<Data>(Idle, idleDeferred, driver) {
             init {
                 // When a new idle state is created, complete the deferred so anything waiting on it
@@ -383,7 +387,9 @@ class DirectStore<Data : CrdtData, Op : CrdtOperation, T> /* internal */ constru
             override suspend fun idle() = Unit
 
             override suspend fun update(
-                version: Int, messageFromDriver: Boolean, localModel: Data
+                version: Int,
+                messageFromDriver: Boolean,
+                localModel: Data
             ): Pair<Int, StateWithData<Data>> {
                 // On update() and when idle, we're ready to await the next version.
                 return (version + 1) to AwaitingResponse(idleDeferred, driver)
@@ -394,7 +400,8 @@ class DirectStore<Data : CrdtData, Op : CrdtOperation, T> /* internal */ constru
          * On update: sends the local model to the driver and awaits a response.
          */
         class AwaitingResponse<Data : CrdtData>(
-            idleDeferred: AtomicRef<IdleDeferred>, driver: Driver<Data>
+            idleDeferred: AtomicRef<IdleDeferred>,
+            driver: Driver<Data>
         ) : StateWithData<Data>(AwaitingResponse, idleDeferred, driver) {
             override fun shouldApplyPendingDriverModelsOnReceive(data: Data, version: Int) = false
 
@@ -416,7 +423,8 @@ class DirectStore<Data : CrdtData, Op : CrdtOperation, T> /* internal */ constru
          * Awaiting a model from the driver after a failed send.
          */
         class AwaitingDriverModel<Data : CrdtData>(
-            idleDeferred: AtomicRef<IdleDeferred>, driver: Driver<Data>
+            idleDeferred: AtomicRef<IdleDeferred>,
+            driver: Driver<Data>
         ) : StateWithData<Data>(AwaitingDriverModel, idleDeferred, driver) {
             override suspend fun update(
                 version: Int, messageFromDriver: Boolean, localModel: Data

--- a/java/arcs/core/storage/DirectStore.kt
+++ b/java/arcs/core/storage/DirectStore.kt
@@ -32,7 +32,6 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.ConflatedBroadcastChannel
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.combine
-
 // import kotlinx.coroutines.flow.debounce
 // import kotlinx.coroutines.flow.filter
 // import kotlinx.coroutines.flow.first

--- a/java/arcs/core/storage/DirectStore.kt
+++ b/java/arcs/core/storage/DirectStore.kt
@@ -68,7 +68,7 @@ class DirectStore<Data : CrdtData, Op : CrdtOperation, T> /* internal */ constru
      */
     private var pendingDriverModels = atomic(listOf<PendingDriverModel<Data>>())
     private var version = atomic(0)
-    private var state: AtomicRef<State<Data>> = atomic(State.Idle(idleDeferred, driver))
+    private var state: AtomicRef<State.StateWithData<Data>> = atomic(State.Idle(idleDeferred, driver))
     private val stateChannel =
         ConflatedBroadcastChannel<State<Data>>(State.Idle(idleDeferred, driver))
     private val stateFlow = stateChannel.asFlow()

--- a/java/arcs/core/storage/DirectStore.kt
+++ b/java/arcs/core/storage/DirectStore.kt
@@ -107,7 +107,6 @@ class DirectStore<Data : CrdtData, Op : CrdtOperation, T> /* internal */ constru
             }
 
             val token = proxyManager.register(callback)
-            closedMutex.unlock()
             return token
         } finally {
             closedMutex.unlock()

--- a/java/arcs/core/storage/DirectStore.kt
+++ b/java/arcs/core/storage/DirectStore.kt
@@ -78,7 +78,8 @@ class DirectStore<Data : CrdtData, Op : CrdtOperation, T> /* internal */ constru
         ConflatedBroadcastChannel<State<Data>>(State.Idle(idleDeferred, driver))
     private val stateFlow = stateChannel.asFlow()
     private val proxyManager = RandomProxyCallbackManager<Data, Op, T>(
-        "direct", Random
+        "direct",
+        Random
     )
 
     private val storeIdlenessFlow =
@@ -318,7 +319,9 @@ class DirectStore<Data : CrdtData, Op : CrdtOperation, T> /* internal */ constru
         do {
             val localModel = synchronized(this) { localModel.data }
             val (newVersion, newState) = currentState.update(
-                currentVersion, messageFromDriver, localModel
+                currentVersion,
+                messageFromDriver,
+                localModel
             )
             // TODO: use a lock instead here, rather than two separate atomics.
             this.state.value = newState.also { stateChannel.send(it) }

--- a/java/arcs/core/storage/DirectStore.kt
+++ b/java/arcs/core/storage/DirectStore.kt
@@ -119,7 +119,6 @@ class DirectStore<Data : CrdtData, Op : CrdtOperation, T> /* internal */ constru
     private fun closeInternal() {
         if (!closed) {
             stateChannel.offer(State.Closed())
-            stateChannel.close()
             closeWriteBack()
         }
         closed = true
@@ -297,8 +296,6 @@ class DirectStore<Data : CrdtData, Op : CrdtOperation, T> /* internal */ constru
         version: Int,
         messageFromDriver: Boolean
     ) {
-        if (closed) return
-
         if (noDriverSideChanges) {
             // TODO: use a single lock here, rather than two separate atomics.
             this.state.value = State.Idle(idleDeferred, driver).also { stateChannel.send(it) }

--- a/java/arcs/core/storage/DirectStore.kt
+++ b/java/arcs/core/storage/DirectStore.kt
@@ -90,13 +90,17 @@ class DirectStore<Data : CrdtData, Op : CrdtOperation, T> /* internal */ constru
     override suspend fun getLocalData(): Data = synchronized(this) { localModel.data }
 
     override fun on(callback: ProxyCallback<Data, Op, T>): Int {
-        return proxyManager.register(callback)
+        synchronized(proxyManager) {
+            return proxyManager.register(callback)
+        }
     }
 
     override fun off(callbackToken: Int) {
-        proxyManager.unregister(callbackToken)
-        if (proxyManager.isEmpty()) {
-            close()
+        synchronized(proxyManager) {
+            proxyManager.unregister(callbackToken)
+            if (proxyManager.isEmpty()) {
+                close()
+            }
         }
     }
 

--- a/java/arcs/core/storage/DirectStore.kt
+++ b/java/arcs/core/storage/DirectStore.kt
@@ -312,15 +312,15 @@ class DirectStore<Data : CrdtData, Op : CrdtOperation, T> /* internal */ constru
             return
         }
 
+        if (state.value is State.Closed<Data>) {
+            return
+        }
+
         // Wait until we're idle before we continue, unless - of course - we've been waiting on
         // driver model information, in which case - we can start without being idle.
         if (state.value !is State.AwaitingDriverModel<Data>) {
             // Await is called on the old value of idleDeferred.
             idleDeferred.getAndSet(IdleDeferred()).await()
-        }
-
-        if (state.value is State.Closed<Data>) {
-            return
         }
 
         var currentState = state.value as State.StateWithData<Data>

--- a/java/arcs/core/storage/DirectStore.kt
+++ b/java/arcs/core/storage/DirectStore.kt
@@ -277,7 +277,7 @@ class DirectStore<Data : CrdtData, Op : CrdtOperation, T> /* internal */ constru
     ) {
         if (noDriverSideChanges) {
             // TODO: use a single lock here, rather than two separate atomics.
-            this.state.value = State.Idle(idleDeferred, driver).also { /* stateChannel.send(it) */ }
+            this.state.value = State.Idle(idleDeferred, driver).also { stateChannel.send(it) }
             this.version.value = version
             return
         }

--- a/java/arcs/core/storage/DirectStore.kt
+++ b/java/arcs/core/storage/DirectStore.kt
@@ -340,7 +340,9 @@ class DirectStore<Data : CrdtData, Op : CrdtOperation, T> /* internal */ constru
         enum class Name { Idle, AwaitingResponse, AwaitingDriverModel, Closed }
 
         open class StateWithData<Data : CrdtData>(
-            stateName: Name, val idleDeferred: AtomicRef<IdleDeferred>, val driver: Driver<Data>
+            stateName: Name,
+            val idleDeferred: AtomicRef<IdleDeferred>,
+            val driver: Driver<Data>
         ) : State<Data>(stateName) {
             /** Waits until the [idleDeferred] signal is triggered. */
             open suspend fun idle() = idleDeferred.value.await()
@@ -353,7 +355,9 @@ class DirectStore<Data : CrdtData, Op : CrdtOperation, T> /* internal */ constru
              * determine what state to transition into and perform any necessary operations.
              */
             open suspend fun update(
-                version: Int, messageFromDriver: Boolean, localModel: Data
+                version: Int,
+                messageFromDriver: Boolean,
+                localModel: Data
             ): Pair<Int, StateWithData<Data>> = version to this
 
             /**
@@ -406,7 +410,9 @@ class DirectStore<Data : CrdtData, Op : CrdtOperation, T> /* internal */ constru
             override fun shouldApplyPendingDriverModelsOnReceive(data: Data, version: Int) = false
 
             override suspend fun update(
-                version: Int, messageFromDriver: Boolean, localModel: Data
+                version: Int,
+                messageFromDriver: Boolean,
+                localModel: Data
             ): Pair<Int, StateWithData<Data>> {
                 val response = driver.send(localModel, version)
                 return if (response) {
@@ -427,7 +433,9 @@ class DirectStore<Data : CrdtData, Op : CrdtOperation, T> /* internal */ constru
             driver: Driver<Data>
         ) : StateWithData<Data>(AwaitingDriverModel, idleDeferred, driver) {
             override suspend fun update(
-                version: Int, messageFromDriver: Boolean, localModel: Data
+                version: Int,
+                messageFromDriver: Boolean,
+                localModel: Data
             ): Pair<Int, StateWithData<Data>> {
                 // If the message didn't come from the driver, we can't do anything.
                 if (!messageFromDriver) return version to this

--- a/java/arcs/core/storage/DirectStore.kt
+++ b/java/arcs/core/storage/DirectStore.kt
@@ -101,6 +101,7 @@ class DirectStore<Data : CrdtData, Op : CrdtOperation, T> /* internal */ constru
 
     fun close() {
         stateChannel.offer(State.Closed())
+        closeWriteBack()
     }
 
     /**

--- a/java/arcs/core/storage/WriteBack.kt
+++ b/java/arcs/core/storage/WriteBack.kt
@@ -42,6 +42,9 @@ interface WriteBack {
     /** A flow which can be collected to observe idle->busy->idle transitions. */
     val writebackIdlenessFlow: Flow<Boolean>
 
+    /** Dispose of this [WriteBack] and any resources it's using. */
+    fun closeWriteBack() = Unit
+
     /**
      * Write-through: flush directly all data updates to the next storage layer.
      */
@@ -128,6 +131,10 @@ open class StoreWriteBack /* internal */ constructor(
                 }
                 .launchIn(scope)
         }
+    }
+
+    override fun closeWriteBack() {
+        channel.cancel()
     }
 
     override suspend fun flush(job: suspend () -> Unit) {

--- a/java/arcs/core/storage/WriteBack.kt
+++ b/java/arcs/core/storage/WriteBack.kt
@@ -133,9 +133,7 @@ open class StoreWriteBack /* internal */ constructor(
         }
     }
 
-    override fun closeWriteBack() {
-        channel.cancel()
-    }
+    override fun closeWriteBack() = channel.cancel()
 
     override suspend fun flush(job: suspend () -> Unit) {
         if (!passThrough.value) flushSection { job() }

--- a/java/arcs/core/storage/util/ProxyCallbackManager.kt
+++ b/java/arcs/core/storage/util/ProxyCallbackManager.kt
@@ -59,6 +59,14 @@ class ProxyCallbackManager<Data : CrdtData, Op : CrdtOperation, ConsumerData>(
         return res
     }
 
+    /** True if no callbacks are registered. */
+    fun isEmpty() {
+        while (!mutex.tryLock()) { /* Wait. */ }
+        val isEmpty = callbacks.isEmpty()
+        mutex.unlock()
+        return isEmpty
+    }
+
     /**
      * Notifies all registered [ProxyCallbackManager] of a [message].
      *

--- a/java/arcs/core/storage/util/ProxyCallbackManager.kt
+++ b/java/arcs/core/storage/util/ProxyCallbackManager.kt
@@ -60,7 +60,7 @@ class ProxyCallbackManager<Data : CrdtData, Op : CrdtOperation, ConsumerData>(
     }
 
     /** True if no callbacks are registered. */
-    fun isEmpty() {
+    fun isEmpty(): Boolean {
         while (!mutex.tryLock()) { /* Wait. */ }
         val isEmpty = callbacks.isEmpty()
         mutex.unlock()

--- a/javatests/arcs/core/util/LruCacheMapTest.kt
+++ b/javatests/arcs/core/util/LruCacheMapTest.kt
@@ -44,6 +44,29 @@ class LruCacheMapTest {
     }
 
     @Test
+    fun lruCache_calls_onEvict_for_deadEntries() {
+        val shouldBeEvicted = mutableSetOf<Int>()
+
+        for (x in 1..5) {
+            if (x % 2 == 1) {
+                shouldBeEvicted.add(x)
+            }
+        }
+
+        val cache = LruCacheMap<Int, String>(livenessPredicate = { k, _ -> k % 2 == 0 }) { k, _ ->
+           assertThat(k).isIn(shouldBeEvicted)
+        }
+
+        for (x in 1..5) {
+            cache.put(x, "value$x")
+        }
+
+        shouldBeEvicted.forEach {
+            assertThat(cache.get(it)).isNull()
+        }
+    }
+
+    @Test
     fun lruCache_calls_onEvict_for_evictedEntries() {
         val shouldBeEvicted: MutableMap<String, String> = mutableMapOf()
 


### PR DESCRIPTION
Close() offered to StateChannel drops the Idle() message in the Conflated channel, since Idle holds a driver/directstore ref, this allows it to be GCed.
