### PR TITLE
Add Driver.close() and ability to close DB when all clients removed

### DIFF
--- a/java/arcs/android/storage/database/DatabaseImpl.kt
+++ b/java/arcs/android/storage/database/DatabaseImpl.kt
@@ -170,7 +170,10 @@ class DatabaseImpl(
 
     override suspend fun removeClient(identifier: Int) = clientMutex.withLock {
         clients.remove(nextClientId)
-        // TODO: When all clients are done with the database, close the connection.
+        // When all clients are done with the database, close the connection.
+        if (clients.isEmpty()) {
+            super.close()
+        }
         Unit
     }
 

--- a/java/arcs/core/storage/Driver.kt
+++ b/java/arcs/core/storage/Driver.kt
@@ -43,4 +43,7 @@ interface Driver<Data : Any> {
 
     /** Sends data to the [Driver] for storage. */
     suspend fun send(data: Data, version: Int): Boolean
+
+    /** Closes the driver and releases any held resources. */
+    suspend fun close() = Unit
 }

--- a/java/arcs/core/storage/driver/Database.kt
+++ b/java/arcs/core/storage/driver/Database.kt
@@ -159,6 +159,11 @@ class DatabaseDriver<Data : Any>(
         receiver(pendingReceiverData, pendingReceiverVersion)
     }
 
+    override suspend fun close() {
+        receiver = null
+        database.removeClient(clientId)
+    }
+
     @Suppress("UNCHECKED_CAST")
     override suspend fun send(data: Data, version: Int): Boolean {
         log.debug {


### PR DESCRIPTION
In preparation of a PR that allows DirectStore.close() to invoke Driver.close() and clean up, additionally allowing LruCacheMap onEvict handler in AndroidSqliteDatabaseManager to close databases when evicted.
