### PR TITLE
Fix incorrect data version in WriteBack flush jobs

### DIFF
--- a/java/arcs/core/storage/WriteBack.kt
+++ b/java/arcs/core/storage/WriteBack.kt
@@ -89,12 +89,9 @@ open class StoreWriteBack /* internal */ constructor(
     val scope: CoroutineScope?
 ) : WriteBack,
     Mutex by Mutex() {
-    // Only apply write-back to physical storage media(s).
+    // Only apply write-back to physical storage media(s) unless forceEnable is specified.
     private val passThrough = atomic(
-        !forceEnable
-        // TODO(b/158529276): Re-enable WriteBack for physical storage media once we understand why
-        //   some collection_entries were not flushed to disk.
-        // scope == null || protocol != Protocols.DATABASE_DRIVER
+        !forceEnable && (scope == null || protocol != Protocols.DATABASE_DRIVER)
     )
 
     // The number of active flush jobs.

--- a/java/arcs/jvm/storage/database/testutil/FakeDatabaseManager.kt
+++ b/java/arcs/jvm/storage/database/testutil/FakeDatabaseManager.kt
@@ -46,12 +46,18 @@ class FakeDatabaseManager : DatabaseManager {
         by guardedBy(mutex, mutableMapOf())
 
     private val _manifest = FakeDatabaseRegistry()
+    private val clients = arrayListOf<DatabaseClient>()
     override val registry: DatabaseRegistry = _manifest
+
+    fun addClients(vararg clients: DatabaseClient) = this.clients.addAll(clients)
 
     override suspend fun getDatabase(name: String, persistent: Boolean): Database = mutex.withLock {
         _manifest.register(name, persistent)
         cache[name to persistent]
-            ?: FakeDatabase().also { cache[name to persistent] = it }
+            ?: FakeDatabase().also {
+                clients.forEach { client -> it.addClient(client) }
+                cache[name to persistent] = it
+            }
     }
 
     override suspend fun snapshotStatistics():
@@ -112,7 +118,7 @@ open class FakeDatabase : Database {
         if (isNew) {
             clientFlow.filter { it.storageKey == storageKey }
                 .onEach { it.onDatabaseUpdate(data, version, originatingClientId) }
-                .launchIn(CoroutineScope(coroutineContext))
+                .launchIn(CoroutineScope(coroutineContext + Job())).join()
         }
 
         isNew
@@ -131,7 +137,7 @@ open class FakeDatabase : Database {
         stats.delete.timeSuspending {
             dataMutex.withLock { data.remove(storageKey) }
             clientFlow.onEach { it.onDatabaseDelete(originatingClientId) }
-                .launchIn(CoroutineScope(coroutineContext))
+                .launchIn(CoroutineScope(coroutineContext + Job())).join()
             Unit
         }
 


### PR DESCRIPTION
Prior to the change, the `version` in `updateStateAndAct` may occasionally become incorrect
when there are a bunch of `consecutive` writes taking place in a short period.

The root cause is the atomic `version.value` is only updated during flushing WritBack jobs.
A new job is queued with current `version.value` which could be an intermediate version number duplicate to one of previously-queued jobs if there are still unfinished flush jobs.

The solution is simply moving the flush job one level up from `updateStateAndAct` to
`processModelChange` since the `processModelChange` is guaranteed with the latest
observed data version.