### PR TITLE
Disable incremental dexing for system health app

### DIFF
--- a/javatests/arcs/android/systemhealth/testapp/BUILD
+++ b/javatests/arcs/android/systemhealth/testapp/BUILD
@@ -59,6 +59,7 @@ android_binary(
     name = "testapp",
     testonly = 1,
     dexopts = ["--force-jumbo"],
+    incremental_dexing = 0,
     manifest = ":AndroidManifest.xml",
     multidex = "native",
     deps = [":test_app_lib"],


### PR DESCRIPTION
force-jumbo mode is disabled when incremental dexing is enabled so devs might see the
following dex merging error if build caches are not cleared:
```
Use --sandbox_debug to see verbose messages from the sandbox
com.android.dex.DexIndexOverflowException: Cannot merge new index 65540 into a non-jumbo instruction!
```

Verified this when my local workspace got the error.