### PR TITLE
Refactors handle connection type generation and moves it to a shared file.

### DIFF
--- a/src/tools/kotlin-codegen-shared.ts
+++ b/src/tools/kotlin-codegen-shared.ts
@@ -1,0 +1,49 @@
+/**
+ * @license
+ * Copyright (c) 2020 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {KotlinGenerationUtils} from './kotlin-generation-utils.js';
+import {SchemaNode, SchemaGraph} from './schema2graph.js';
+import {HandleConnectionSpec} from '../runtime/particle-spec.js';
+import {Type} from '../runtime/type.js';
+import {HandleConnection} from '../runtime/recipe/handle-connection.js';
+
+const ktUtils = new KotlinGenerationUtils();
+
+/**
+ * Generates a Kotlin type instance for the given handle connection.
+ */
+export function generateConnectionType(connection: HandleConnection): string {
+  return generateConnectionSpecType(connection.spec, new SchemaGraph(connection.particle.spec).nodes);
+}
+
+export function generateConnectionSpecType(connection: HandleConnectionSpec, nodes: SchemaNode[]): string {
+  let type = connection.type;
+  if (type.isEntity || type.isReference) {
+    // Moving to the new style types with explicit singleton.
+    type = type.singletonOf();
+  }
+
+  return (function generateType(type: Type): string {
+    if (type.isEntity) {
+      const node = nodes.find(n => n.schema.equals(type.getEntitySchema()));
+      return ktUtils.applyFun('EntityType', [`${node.fullName(connection)}.SCHEMA`]);
+    } else if (type.isCollection) {
+      return ktUtils.applyFun('CollectionType', [generateType(type.getContainedType())]);
+    } else if (type.isSingleton) {
+      return ktUtils.applyFun('SingletonType', [generateType(type.getContainedType())]);
+    } else if (type.isReference) {
+      return ktUtils.applyFun('ReferenceType', [generateType(type.getContainedType())]);
+    } else if (type.isTuple) {
+      return ktUtils.applyFun('TupleType.of', type.getContainedTypes().map(t => generateType(t)));
+    } else {
+      throw new Error(`Type '${type.tag}' not supported as code generated handle connection type.`);
+    }
+  })(type);
+}

--- a/src/tools/tests/goldens/WriterReaderExample.kt
+++ b/src/tools/tests/goldens/WriterReaderExample.kt
@@ -107,7 +107,7 @@ object ReferencesRecipePlan : Plan(
                         "db://25e71af4e9fc8b6958fc46a8f4b7cdf6b5f31516@arcs/!:referencesArcId/handle/my-refs-id"
                     ),
                     HandleMode.Read,
-                    CollectionType(ReferenceType(EntityType(ReadWriteReferences_OutThingRef.SCHEMA))),
+                    CollectionType(ReferenceType(EntityType(ReadWriteReferences_InThingRefs.SCHEMA))),
                     Ttl.Infinite
                 ),
                 "outThingRef" to HandleConnection(

--- a/src/tools/tests/kotlin-codegen-shared-tests.ts
+++ b/src/tools/tests/kotlin-codegen-shared-tests.ts
@@ -1,0 +1,61 @@
+/**
+ * @license
+ * Copyright (c) 2020 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {assert} from '../../platform/chai-node.js';
+import {generateConnectionSpecType} from '../kotlin-codegen-shared.js';
+import {Manifest} from '../../runtime/manifest.js';
+import {SchemaGraph} from '../schema2graph.js';
+
+describe('Kotlin Handle Connection Type Generation', () => {
+  it('generates type for singleton entity', async () => await assertConnectionType(`
+    particle Module
+      data: reads Thing {name: Text}
+    `,
+    'SingletonType(EntityType(Module_Data.SCHEMA))'
+  ));
+  it('generates type for singleton reference', async () => await assertConnectionType(`
+    particle Module
+      data: reads &Thing {name: Text}
+    `,
+    'SingletonType(ReferenceType(EntityType(Module_Data.SCHEMA)))'
+  ));
+  it('generates type for collection of entities', async () => await assertConnectionType(`
+    particle Module
+      data: reads [Thing {name: Text}]
+    `,
+    'CollectionType(EntityType(Module_Data.SCHEMA))'
+  ));
+  it('generates type for collection of references', async () => await assertConnectionType(`
+    particle Module
+      data: reads [&Thing {name: Text}]
+    `,
+    'CollectionType(ReferenceType(EntityType(Module_Data.SCHEMA)))'
+  ));
+  it('generates type for collection of tuples', async () => await assertConnectionType(`
+    particle Module
+      data: reads [(&Thing {name: Text}, &Other {age: Number})]
+    `,
+`CollectionType(
+    TupleType.of(
+        ReferenceType(EntityType(Module_Data_0.SCHEMA)),
+        ReferenceType(EntityType(Module_Data_1.SCHEMA))
+    )
+)`
+  ));
+
+  async function assertConnectionType(manifestString: string, expected: string) {
+    const manifest = await Manifest.parse(manifestString);
+    const [particle] = manifest.particles;
+    const schemaGraph = new SchemaGraph(particle);
+    const [connection] = particle.handleConnections;
+    const actual = generateConnectionSpecType(connection, schemaGraph.nodes);
+    assert.equal(actual, expected);
+  }
+});

--- a/src/tools/tests/plan-generator-tests.ts
+++ b/src/tools/tests/plan-generator-tests.ts
@@ -13,7 +13,6 @@ import {assert} from '../../platform/chai-node.js';
 import {Manifest} from '../../runtime/manifest.js';
 import {Ttl, TtlUnits} from '../../runtime/recipe/ttl.js';
 import {StorageKeyRecipeResolver} from '../storage-key-recipe-resolver.js';
-import {Handle} from '../../runtime/recipe/handle.js';
 import {Capabilities, Capability} from '../../runtime/capabilities.js';
 
 describe('recipe2plan', () => {
@@ -48,66 +47,6 @@ describe('recipe2plan', () => {
       const actual = generator.fileHeader();
 
       assert.notInclude(actual, 'import arcs.core.data.*');
-    });
-    it('creates valid singleton entity types with schemas', async () => {
-      const manifest = await Manifest.parse(`\
-     particle A
-       data: writes Thing {num: Number}
-     
-     recipe R
-       h: create 'some-id' @persistent
-       A
-         data: writes h`);
-
-      await emptyGenerator.collectParticleConnectionSpecs(manifest.recipes[0].particles[0]);
-      const actual = await emptyGenerator.createType(manifest.particles[0].handleConnections[0].type);
-
-      assert.include(actual, 'A_Data.SCHEMA');
-      assert.include(actual, 'EntityType');
-      assert.notInclude(actual, 'ReferenceType');
-      assert.include(actual, 'SingletonType');
-      assert.notInclude(actual, 'CollectionType');
-      assert.isBelow(actual.indexOf('SingletonType'), actual.indexOf('EntityType'));
-    });
-    it('creates valid collection entity types with schemas', async () => {
-      const manifest = await Manifest.parse(`\
-     particle A
-       data: writes [Thing {num: Number}]
-       
-     recipe R
-       h: create 'some-id' @persistent
-       A
-         data: writes h`);
-
-      await emptyGenerator.collectParticleConnectionSpecs(manifest.recipes[0].particles[0]);
-      const actual = await emptyGenerator.createType(manifest.particles[0].handleConnections[0].type);
-
-      assert.include(actual, 'A_Data.SCHEMA');
-      assert.include(actual, 'EntityType');
-      assert.notInclude(actual, 'ReferenceType');
-      assert.notInclude(actual, 'SingletonType');
-      assert.include(actual, 'CollectionType');
-      assert.isBelow(actual.indexOf('CollectionType'), actual.indexOf('EntityType'));
-    });
-    it('creates valid collection reference types with schemas', async () => {
-      const manifest = await Manifest.parse(`\
-     particle A
-       data: writes [&Thing {num: Number}]
-       
-     recipe R
-       h: create 'some-id' @persistent
-       A
-         data: writes h`);
-
-      await emptyGenerator.collectParticleConnectionSpecs(manifest.recipes[0].particles[0]);
-      const actual = await emptyGenerator.createType(manifest.particles[0].handleConnections[0].type);
-
-      assert.include(actual, 'A_Data.SCHEMA');
-      assert.include(actual, 'EntityType');
-      assert.include(actual, 'ReferenceType');
-      assert.notInclude(actual, 'SingletonType');
-      assert.include(actual, 'CollectionType');
-      assert.isBelow(actual.indexOf('CollectionType'), actual.indexOf('ReferenceType'));
     });
     it('can create Infinite Ttl objects', () => {
       const ttl = Ttl.infinite;


### PR DESCRIPTION
A few changes:
* Moves from hand-rolled string concatenation to the new schema naming methods in SchemaGraph, providing better names (reflected in updated golden)
* Removes the need for entity names registry (`collectParticleConnectionSpecs` and friends) in recipe2plan .
* Moves the type generation to a shared file, as it will be needed in schema2kotlin as well (see #5468).