### PR TITLE
Fix a BUILD file to conform to strictdeps

### DIFF
--- a/java/arcs/core/entity/BUILD
+++ b/java/arcs/core/entity/BUILD
@@ -15,6 +15,7 @@ arcs_kt_library(
         "//java/arcs/core/data/util:data-util",
         "//java/arcs/core/storage",
         "//java/arcs/core/storage/referencemode",
+        "//java/arcs/core/type",
         "//java/arcs/core/util",
         "//third_party/kotlin/kotlinx_atomicfu",
         "//third_party/kotlin/kotlinx_coroutines",

--- a/javatests/arcs/core/entity/BUILD
+++ b/javatests/arcs/core/entity/BUILD
@@ -36,7 +36,6 @@ arcs_kt_jvm_test_suite(
         "//java/arcs/core/storage/referencemode",
         "//java/arcs/core/storage/testutil",
         "//java/arcs/core/testutil",
-        "//java/arcs/core/type",
         "//java/arcs/core/util",
         "//java/arcs/core/util/testutil",
         "//java/arcs/jvm/host",


### PR DESCRIPTION
I've added the dep on the wrong target by mistake and now strictdeps is unhappy :(