### PR TITLE
Add support for joins in DFA. 

### DIFF
--- a/java/arcs/core/analysis/RecipeGraph.kt
+++ b/java/arcs/core/analysis/RecipeGraph.kt
@@ -44,9 +44,9 @@ class RecipeGraph(recipe: Recipe) {
      */
     private fun Node.Handle.addJoinEdges(handleNodesMap: Map<String, Node.Handle>) {
         if (handle.fate != Recipe.Handle.Fate.JOIN) return
-        handle.associatedHandles.forEach {
-            val joinHandleNode = requireNotNull(handleNodesMap[it.name])
-            joinHandleNode.addSuccessor(this, JoinSpec())
+        handle.associatedHandles.forEachIndexed { index, targetHandle ->
+            val joinHandleNode = requireNotNull(handleNodesMap[targetHandle.name])
+            joinHandleNode.addSuccessor(this, JoinSpec(index))
         }
     }
 
@@ -74,7 +74,7 @@ class RecipeGraph(recipe: Recipe) {
      *
      * This is a dummy class for the time being, but will have more information when the support
      * for join is fully flshed out. This should also move out of this file. */
-    data class JoinSpec(val type: String = "INNER")
+    data class JoinSpec(val component: Int, val type: String = "INNER")
 
     /** Represents an edge kind. */
     sealed class EdgeKind {
@@ -87,7 +87,7 @@ class RecipeGraph(recipe: Recipe) {
          * The [spec] just a dummy state for the time being. When the support for join is fully
          * fleshed out, this would consist of things like refinements, etc.
          */
-        data class JoinConnection(val spec: JoinSpec = JoinSpec()) : EdgeKind()
+        data class JoinConnection(val spec: JoinSpec) : EdgeKind()
     }
 
     /** Represents a node in a [RecipeGraph]. */

--- a/javatests/arcs/core/analysis/InformationFlowTest.kt
+++ b/javatests/arcs/core/analysis/InformationFlowTest.kt
@@ -115,6 +115,7 @@ class InformationFlowTest {
             "ok-check-multiple-or-single-claim",
             "ok-derives-from-cycle",
             "ok-derives-from-multiple"
+            "ok-join-simple"
         )
         val failingFieldTests = listOf(
             "fail-field-entity-direct",

--- a/javatests/arcs/core/analysis/InformationFlowTest.kt
+++ b/javatests/arcs/core/analysis/InformationFlowTest.kt
@@ -114,7 +114,7 @@ class InformationFlowTest {
             "ok-check-multiple-and-single-claim",
             "ok-check-multiple-or-single-claim",
             "ok-derives-from-cycle",
-            "ok-derives-from-multiple"
+            "ok-derives-from-multiple",
             "ok-join-simple"
         )
         val failingFieldTests = listOf(

--- a/javatests/arcs/core/analysis/RecipeGraphTest.kt
+++ b/javatests/arcs/core/analysis/RecipeGraphTest.kt
@@ -27,7 +27,7 @@ class RecipeGraphTest {
             name = "joined",
             fate = Recipe.Handle.Fate.JOIN,
             type = TypeVariable("joined"),
-            associatedHandles=listOf(someHandle, thingHandle)
+            associatedHandles=listOf(thingHandle, someHandle)
         )
         val readConnectionSpec = HandleConnectionSpec(
             "r",
@@ -130,7 +130,6 @@ class RecipeGraphTest {
     private fun testAllConnections(testRecipe: TestRecipe) {
         with (testRecipe) {
             val graph = RecipeGraph(recipe)
-            val joinSpec = RecipeGraph.JoinSpec()
             val readerNode = RecipeGraph.Node.Particle(readerParticle)
             val writerNode = RecipeGraph.Node.Particle(writerParticle)
             val thingNode = RecipeGraph.Node.Handle(thingHandle)
@@ -154,7 +153,7 @@ class RecipeGraphTest {
                 RecipeGraph.Node.Neighbor(writerNode, readConnectionSpec),
                 RecipeGraph.Node.Neighbor(writerNode, rwConnectionSpec),
                 RecipeGraph.Node.Neighbor(readerNode, readConnectionSpec),
-                RecipeGraph.Node.Neighbor(joinedNode, joinSpec)
+                RecipeGraph.Node.Neighbor(joinedNode, RecipeGraph.JoinSpec(0))
             )
             val thingPredecessors = listOf(
                 RecipeGraph.Node.Neighbor(writerNode, writeConnectionSpec),
@@ -162,15 +161,15 @@ class RecipeGraphTest {
             )
             val someSuccessors = listOf(
                 RecipeGraph.Node.Neighbor(readerNode, readSomeConnectionSpec),
-                RecipeGraph.Node.Neighbor(joinedNode, joinSpec)
+                RecipeGraph.Node.Neighbor(joinedNode, RecipeGraph.JoinSpec(1))
             )
             val somePredecessors = emptyList<RecipeGraph.Node.Neighbor>()
             val joinedSuccessors = listOf(
                 RecipeGraph.Node.Neighbor(readerNode, readJoinConnectionSpec)
             )
             val joinedPredecessors = listOf(
-                RecipeGraph.Node.Neighbor(thingNode, joinSpec),
-                RecipeGraph.Node.Neighbor(someNode, joinSpec)
+                RecipeGraph.Node.Neighbor(thingNode, RecipeGraph.JoinSpec(0)),
+                RecipeGraph.Node.Neighbor(someNode, RecipeGraph.JoinSpec(1))
             )
             val expectedSuccessors = mapOf(
                 readerNode to readerSuccessors,

--- a/javatests/arcs/core/analysis/testdata/ok_join_simple.arcs
+++ b/javatests/arcs/core/analysis/testdata/ok_join_simple.arcs
@@ -1,0 +1,52 @@
+// #Ingress: IngestPerson
+// #Ingress: IngestAddress
+// #OK
+particle IngestPerson
+  person: writes [Person {name: Text, age: Number, education: Text}]
+  claim person.age is sensitive
+
+particle IngestAddress
+  address: writes [Address {name: Text, street: Text, city: Text}]
+  claim address.street is sensitive
+
+particle SensitiveInfo
+  details: reads [(
+    &Person {name: Text, age: Number, education: Text},
+    &Address {name: Text, street: Text, city: Text}
+  )]
+  info: writes Info {info: Text}
+
+particle PublicInfo
+  details: reads [(
+    &Person {name: Text, education: Text},
+    &Address {name: Text, city: Text}
+  )]
+  info: writes Info {info: Text}
+
+particle EgressPublic
+  info: reads Info {info: Text}
+  check info.info is not sensitive
+
+particle EgressSensitive
+  info: reads Info {info: Text}
+
+recipe R
+  person: create
+  address: create
+  all: join (person, address)
+  publicInfo: create
+  sensitiveInfo: create
+  IngestPerson
+    person: person
+  IngestAddress
+    address: address
+  PublicInfo
+    details: all
+    info: publicInfo
+  SensitiveInfo
+    details: all
+    info: sensitiveInfo
+  EgressPublic
+    info: publicInfo
+  EgressSensitive
+    info: sensitiveInfo


### PR DESCRIPTION
This PR adds support for analyzing joins during DFA. This PR also has a few related changes:
  - Augment `JoinSpec` in `RecipeGraph` with component id information. 
 - Some minor refactoring of helper functions
 - Add support for tuples in DFA to a limited extent.