### PR TITLE
Assembles join storage keys in recipe2plan output.

### DIFF
--- a/java/arcs/core/storage/api/DriverAndKeyConfigurator.kt
+++ b/java/arcs/core/storage/api/DriverAndKeyConfigurator.kt
@@ -20,6 +20,7 @@ import arcs.core.storage.driver.DatabaseDriverProvider
 import arcs.core.storage.driver.RamDiskDriverProvider
 import arcs.core.storage.driver.VolatileDriverProvider
 import arcs.core.storage.keys.DatabaseStorageKey
+import arcs.core.storage.keys.JoinStorageKey
 import arcs.core.storage.keys.RamDiskStorageKey
 import arcs.core.storage.keys.VolatileStorageKey
 import arcs.core.storage.referencemode.ReferenceModeStorageKey
@@ -65,5 +66,7 @@ object DriverAndKeyConfigurator {
         DatabaseStorageKey.registerKeyCreator()
         // ReferenceModeStorageKey has no key creator.
         ReferenceModeStorageKey.registerParser()
+        // JoinStorageKey has no key creator.
+        JoinStorageKey.registerParser()
     }
 }

--- a/java/arcs/core/storage/keys/JoinStorageKey.kt
+++ b/java/arcs/core/storage/keys/JoinStorageKey.kt
@@ -21,12 +21,12 @@ const val COMPOSITE_PROTOCOL = "join"
 
 /** Implementation for a composite [StorageKey] for joining entities. */
 class JoinStorageKey(
-    private val storageKeys: List<StorageKey>
+    val components: List<StorageKey>
 ) : StorageKey(COMPOSITE_PROTOCOL) {
     override fun toKeyString(): String {
         val builder = StringBuilder()
-        builder.append("${storageKeys.size}/")
-        storageKeys.forEach { builder.append("{${it.embed()}}") }
+        builder.append("${components.size}/")
+        components.forEach { builder.append("{${it.embed()}}") }
 
         return builder.toString()
     }

--- a/javatests/arcs/schematests/joins/BUILD
+++ b/javatests/arcs/schematests/joins/BUILD
@@ -1,15 +1,16 @@
 load(
     "//third_party/java/arcs/build_defs:build_defs.bzl",
+    "arcs_kt_gen",
     "arcs_kt_jvm_library",
-    "arcs_kt_schema",
+    "arcs_kt_jvm_test_suite",
 )
 
 licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])
 
-arcs_kt_schema(
-    name = "join_schema_gen",
+arcs_kt_gen(
+    name = "join_codegen",
     srcs = ["Join.arcs"],
 )
 
@@ -18,7 +19,22 @@ arcs_kt_jvm_library(
     testonly = 1,
     srcs = ["TupleReader.kt"],
     deps = [
-        ":join_schema_gen",
+        ":join_codegen",
         "//java/arcs/core/entity",
+    ],
+)
+
+arcs_kt_jvm_test_suite(
+    name = "joins",
+    srcs = glob(["*Test.kt"]),
+    package = "arcs.schematests.joins",
+    deps = [
+        ":join_codegen",
+        "//java/arcs/core/data:data-kt",
+        "//java/arcs/core/storage/api",
+        "//java/arcs/core/storage/keys",
+        "//java/arcs/core/storage/referencemode",
+        "//third_party/java/junit:junit-android",
+        "//third_party/java/truth:truth-android",
     ],
 )

--- a/javatests/arcs/schematests/joins/Join.arcs
+++ b/javatests/arcs/schematests/joins/Join.arcs
@@ -1,15 +1,10 @@
 meta
   namespace: arcs.schematests.joins
 
-recipe ReadJoin
-  products: map 'products'
-  reviews: map 'reviews'
-  manufacturers: map 'manufacturers'
-
-  triples: join (products, reviews, manufacturers)
-
-  Reader
-    data: triples
+particle Writer
+  products: writes [Product {name: Text, photo: URL}]
+  reviews: writes [Review {author: Text, content: Text, rating: Number}]
+  manufacturers: writes [Manufacturer {name: Text, address: Text}]
 
 particle Reader in 'arcs.schematests.joins.Reader'
   data: reads [(
@@ -17,3 +12,22 @@ particle Reader in 'arcs.schematests.joins.Reader'
     &Review {author: Text, content: Text, rating: Number},
     &Manufacturer {name: Text, address: Text}
   )]
+
+@arcId('write-data-for-join')
+recipe WriteData
+  products: create 'products' @persistent
+  reviews: create 'reviews' @persistent
+  manufacturers: create 'manufacturers' @persistent
+  Writer
+    products: products
+    reviews: reviews
+    manufacturers: manufacturers
+
+recipe ReadJoin
+  products: map 'products'
+  reviews: map 'reviews'
+  manufacturers: map 'manufacturers'
+  triples: join (products, reviews, manufacturers)
+
+  Reader
+    data: triples

--- a/javatests/arcs/schematests/joins/JoinPlanTest.kt
+++ b/javatests/arcs/schematests/joins/JoinPlanTest.kt
@@ -1,0 +1,25 @@
+package arcs.schematests.joins
+
+import arcs.core.storage.api.DriverAndKeyConfigurator
+import arcs.core.storage.keys.JoinStorageKey
+import arcs.core.storage.referencemode.ReferenceModeStorageKey
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class JoinPlanTest {
+    @Test
+    fun canParseJoinStorageKey() {
+        DriverAndKeyConfigurator.configure(null);
+        val particle = ReadJoinPlan.particles.single()
+        val connection = particle.handles.values.single()
+
+        assertThat(connection.storageKey).isInstanceOf(JoinStorageKey::class.java)
+        val storageKey = connection.storageKey as JoinStorageKey
+
+        assertThat(storageKey.components).hasSize(3)
+        assertThat(storageKey.components[0]).isInstanceOf(ReferenceModeStorageKey::class.java)
+    }
+}

--- a/src/runtime/recipe/handle.ts
+++ b/src/runtime/recipe/handle.ts
@@ -230,6 +230,7 @@ export class Handle implements Comparable<Handle> {
   set ttl(ttl: Ttl) { this._ttl = ttl; }
   get isSynthetic() { return this.fate === 'join'; } // Join handles are the first type of synthetic handles, other may come.
   get joinedHandles() { return this._joinedHandles; }
+  get isJoined() { return this._isJoined; }
 
   get annotations(): AnnotationRef[] { return this._annotations; }
   set annotations(annotations: AnnotationRef[]) {

--- a/src/runtime/recipe/recipe-resolver.ts
+++ b/src/runtime/recipe/recipe-resolver.ts
@@ -38,14 +38,14 @@ export class ResolveWalker extends RecipeWalker {
       }
       return [];
     };
-    if (handle.fate === '`slot') {
+    if (handle.fate === '`slot' || handle.fate === 'join') {
       return [];
     }
     if (handle.type.slandleType()) {
       return [];
     }
     const arc = this.arc;
-    if (handle.connections.length === 0 ||
+    if ((handle.connections.length === 0 && !handle.isJoined) ||
         (handle.id && handle.storageKey) || (!handle.type) ||
         (!handle.fate)) {
       return error('No connections to handle or missing handle information');

--- a/src/runtime/storageNG/reference-mode-storage-key.ts
+++ b/src/runtime/storageNG/reference-mode-storage-key.ts
@@ -16,16 +16,8 @@ export class ReferenceModeStorageKey extends StorageKey {
     super(ReferenceModeStorageKey.protocol);
   }
 
-  embedKey(key: StorageKey) {
-    return key.toString().replace(/\{/g, '{{').replace(/\}/g, '}}');
-  }
-
-  static unembedKey(key: string) {
-    return key.replace(/\}\}/g, '}').replace(/\{\{/g, '}');
-  }
-
   toString(): string {
-    return `${this.protocol}://{${this.embedKey(this.backingKey)}}{${this.embedKey(this.storageKey)}}`;
+    return `${this.protocol}://{${this.backingKey.embedKey()}}{${this.storageKey.embedKey()}}`;
   }
 
   childWithComponent(component: string): StorageKey {
@@ -41,8 +33,8 @@ export class ReferenceModeStorageKey extends StorageKey {
     const [_, backingKey, storageKey] = match;
 
     return new ReferenceModeStorageKey(
-      parse(ReferenceModeStorageKey.unembedKey(backingKey)),
-      parse(ReferenceModeStorageKey.unembedKey(storageKey))
+      parse(StorageKey.unembedKey(backingKey)),
+      parse(StorageKey.unembedKey(storageKey))
     );
   }
 }

--- a/src/runtime/storageNG/storage-key.ts
+++ b/src/runtime/storageNG/storage-key.ts
@@ -46,4 +46,12 @@ export abstract class StorageKey {
   childKeyForSearch(id: string) {
     return this.subKeyWithComponent(`search/${id}`);
   }
+
+  embedKey() {
+    return this.toString().replace(/\{/g, '{{').replace(/\}/g, '}}');
+  }
+
+  static unembedKey(key: string) {
+    return key.replace(/\}\}/g, '}').replace(/\{\{/g, '}');
+  }
 }

--- a/src/tools/plan-generator.ts
+++ b/src/tools/plan-generator.ts
@@ -10,7 +10,7 @@
 import {Recipe} from '../runtime/recipe/recipe.js';
 import {Type} from '../runtime/type.js';
 import {Particle} from '../runtime/recipe/particle.js';
-import {KotlinGenerationUtils, quote, tryImport, upperFirst} from './kotlin-generation-utils.js';
+import {KotlinGenerationUtils, quote, tryImport} from './kotlin-generation-utils.js';
 import {generateConnectionType} from './kotlin-codegen-shared.js';
 import {HandleConnection} from '../runtime/recipe/handle-connection.js';
 import {Direction} from '../runtime/manifest-ast-nodes.js';
@@ -123,6 +123,12 @@ export class PlanGenerator {
         createKeyArgs.push(capabilities);
       }
       return ktUtils.applyFun('CreateableStorageKey', createKeyArgs);
+    }
+    if (handle.fate === 'join') {
+      // TODO(piotrs): Implement JoinStorageKey in TypeScript.
+      const components = handle.joinedHandles.map(h => h.storageKey);
+      const joinSk = `join://${components.length}/${components.map(sk => `{${sk.embedKey()}}`).join('/')}`;
+      return ktUtils.applyFun('StorageKeyParser.parse', [quote(joinSk)]);
     }
     throw new PlanGeneratorError(`Problematic handle '${handle.id}': Only 'create' Handles can have null 'StorageKey's.`);
   }

--- a/src/tools/tests/storage-key-recipe-resolver-test.ts
+++ b/src/tools/tests/storage-key-recipe-resolver-test.ts
@@ -365,4 +365,37 @@ Resolver generated 0 recipes`
       );
     }));
   });
+  it('resolves joining mapped handles and reading tuples of data', Flags.withDefaultReferenceMode(async () => {
+    const manifest = await Manifest.parse(`\
+  particle Writer
+    products: writes [Product {name: Text}]
+    manufacturers: writes [Manufacturer {address: Text}]
+
+  particle Reader
+    data: reads [(
+      &Product {name: Text},
+      &Manufacturer {address: Text}
+    )]
+
+  @arcId('write-data-for-join')
+  recipe WriteData
+    products: create 'products' @persistent
+    manufacturers: create 'manufacturers' @persistent
+    Writer
+      products: products
+      manufacturers: manufacturers
+
+  recipe ReadJoin
+    products: map 'products'
+    manufacturers: map 'manufacturers'
+    data: join (products, manufacturers)
+  
+    Reader
+      data: data`);
+
+    const resolver = new StorageKeyRecipeResolver(manifest);
+    for (const it of (await resolver.resolve())) {
+      assert.isTrue(it.isResolved());
+    }
+  }));
 });


### PR DESCRIPTION
Various small changes that unlock outputting join storage keys in recipe2plan output.

There are some basic tests, but overall to test this properly I would like to refactor recipe2plan testing to allow asserting on small pieces of code generated output - like what we did recently with schema2kotlin. This however will be a bigger PR and the one I will prepare soon.

In the meantime this PR puts basic safeguards in place that the functionality works and unblocks Satakshi to work on the JoinHandle implementation.