### PR TITLE
Created VariableEntityBase to support Entities for Type Variables.

### DIFF
--- a/java/arcs/core/entity/EntityBase.kt
+++ b/java/arcs/core/entity/EntityBase.kt
@@ -135,7 +135,7 @@ open class EntityBase(
     private fun getSingletonTypeOrNull(field: String) = schema.fields.singletons[field]
 
     /** Returns true if the singleton has the [FieldType]. */
-    protected fun hasSingletonField(field: String) = getSingletonTypeOrNull(field) != null
+    protected inline fun hasSingletonField(field: String) = getSingletonTypeOrNull(field) != null
 
     /**
      * Returns the [FieldType] for the given collection field.
@@ -151,7 +151,7 @@ open class EntityBase(
     private fun getCollectionTypeOrNull(field: String) = schema.fields.collections[field]
 
     /** Returns true if the collection has the [FieldType]. */
-    protected fun hasCollectionField(field: String) = getCollectionTypeOrNull(field) != null
+    protected inline fun hasCollectionField(field: String) = getCollectionTypeOrNull(field) != null
 
     /** Checks that the given value is of the expected type. */
     private fun checkType(field: String, value: Any?, type: FieldType, context: String = "") {

--- a/java/arcs/core/entity/EntityBase.kt
+++ b/java/arcs/core/entity/EntityBase.kt
@@ -134,6 +134,9 @@ open class EntityBase(
     /** Returns the [FieldType] for the given singleton field, or null if it does not exist. */
     private fun getSingletonTypeOrNull(field: String) = schema.fields.singletons[field]
 
+    /** Returns true if the singleton has the [FieldType]. */
+    protected fun hasSingletonField(field: String) = getSingletonTypeOrNull(field) != null
+
     /**
      * Returns the [FieldType] for the given collection field.
      *
@@ -146,6 +149,9 @@ open class EntityBase(
 
     /** Returns the [FieldType] for the given collection field, or null if it does not exist. */
     private fun getCollectionTypeOrNull(field: String) = schema.fields.collections[field]
+
+    /** Returns true if the collection has the [FieldType]. */
+    protected fun hasCollectionField(field: String) = getCollectionTypeOrNull(field) != null
 
     /** Checks that the given value is of the expected type. */
     private fun checkType(field: String, value: Any?, type: FieldType, context: String = "") {
@@ -243,7 +249,7 @@ open class EntityBase(
      * @param nestedEntitySpecs mapping from [SchemaHash] to [EntitySpec], used when dereferencing
      *     [Reference] fields inside the entity
      */
-    fun deserialize(
+    open fun deserialize(
         rawEntity: RawEntity,
         nestedEntitySpecs: Map<SchemaHash, EntitySpec<out Entity>> = mapOf()
     ) {

--- a/java/arcs/core/entity/EntityBase.kt
+++ b/java/arcs/core/entity/EntityBase.kt
@@ -134,7 +134,7 @@ open class EntityBase(
     /** Returns the [FieldType] for the given singleton field, or null if it does not exist. */
     private fun getSingletonTypeOrNull(field: String) = schema.fields.singletons[field]
 
-    /** Returns true if the singleton has the [FieldType]. */
+    /** Returns true if the singleton has the Field. */
     protected fun hasSingletonField(field: String) = getSingletonTypeOrNull(field) != null
 
     /**
@@ -150,7 +150,7 @@ open class EntityBase(
     /** Returns the [FieldType] for the given collection field, or null if it does not exist. */
     private fun getCollectionTypeOrNull(field: String) = schema.fields.collections[field]
 
-    /** Returns true if the collection has the [FieldType]. */
+    /** Returns true if the collection has the Field. */
     protected fun hasCollectionField(field: String) = getCollectionTypeOrNull(field) != null
 
     /** Checks that the given value is of the expected type. */

--- a/java/arcs/core/entity/EntityBase.kt
+++ b/java/arcs/core/entity/EntityBase.kt
@@ -135,7 +135,7 @@ open class EntityBase(
     private fun getSingletonTypeOrNull(field: String) = schema.fields.singletons[field]
 
     /** Returns true if the singleton has the [FieldType]. */
-    protected inline fun hasSingletonField(field: String) = getSingletonTypeOrNull(field) != null
+    protected fun hasSingletonField(field: String) = getSingletonTypeOrNull(field) != null
 
     /**
      * Returns the [FieldType] for the given collection field.
@@ -151,7 +151,7 @@ open class EntityBase(
     private fun getCollectionTypeOrNull(field: String) = schema.fields.collections[field]
 
     /** Returns true if the collection has the [FieldType]. */
-    protected inline fun hasCollectionField(field: String) = getCollectionTypeOrNull(field) != null
+    protected fun hasCollectionField(field: String) = getCollectionTypeOrNull(field) != null
 
     /** Checks that the given value is of the expected type. */
     private fun checkType(field: String, value: Any?, type: FieldType, context: String = "") {

--- a/java/arcs/core/entity/VariableEntityBase.kt
+++ b/java/arcs/core/entity/VariableEntityBase.kt
@@ -14,13 +14,24 @@ import arcs.core.data.Schema
  * In this way, an entity representing a type variable will pass data through the system without
  * a specific description of the data (an exact match with a [Schema]).
  */
-open class VariableEntityBase(
-    entityClassName: String,
-    schema: Schema,
-    entityId: String? = null,
-    creationTimestamp: Long = RawEntity.UNINITIALIZED_TIMESTAMP,
-    expirationTimestamp: Long = RawEntity.UNINITIALIZED_TIMESTAMP
-) : EntityBase(entityClassName, schema, entityId, creationTimestamp, expirationTimestamp) {
+open class VariableEntityBase : EntityBase {
+
+    constructor(entityClassName: String, schema: Schema): super(entityClassName, schema)
+
+    constructor(
+        entityClassName: String,
+        schema: Schema,
+        entityId: String?
+    ) : super(entityClassName, schema, entityId)
+
+    constructor(
+        entityClassName: String,
+        schema: Schema,
+        entityId: String?,
+        creationTimestamp: Long,
+        expirationTimestamp: Long
+    ) : super(entityClassName, schema, entityId, creationTimestamp, expirationTimestamp)
+
 
     private val rawSingletons = mutableMapOf<FieldName, Referencable?>()
     private val rawCollections = mutableMapOf<FieldName, Set<Referencable>>()

--- a/java/arcs/core/entity/VariableEntityBase.kt
+++ b/java/arcs/core/entity/VariableEntityBase.kt
@@ -17,9 +17,9 @@ import arcs.core.data.Schema
 open class VariableEntityBase(
     entityClassName: String,
     schema: Schema,
-    entityId: String,
-    creationTimestamp: Long,
-    expirationTimestamp: Long
+    entityId: String? = null,
+    creationTimestamp: Long = RawEntity.UNINITIALIZED_TIMESTAMP,
+    expirationTimestamp: Long = RawEntity.UNINITIALIZED_TIMESTAMP
 ) : EntityBase(entityClassName, schema, entityId, creationTimestamp, expirationTimestamp) {
 
     private val rawSingletons = mutableMapOf<FieldName, Referencable?>()

--- a/java/arcs/core/entity/VariableEntityBase.kt
+++ b/java/arcs/core/entity/VariableEntityBase.kt
@@ -6,7 +6,7 @@ import arcs.core.data.RawEntity
 import arcs.core.data.Schema
 
 /**
- * A base [Entity] for type variables.
+ * A base [Entity] to access data from type variables.
  *
  * This class behaves just like [EntityBase], except for (de)serialization. During deserialization,
  * all the fields from [RawEntity] are stored for later use in serialization.

--- a/java/arcs/core/entity/VariableEntityBase.kt
+++ b/java/arcs/core/entity/VariableEntityBase.kt
@@ -16,7 +16,7 @@ import arcs.core.data.Schema
  */
 open class VariableEntityBase : EntityBase {
 
-    constructor(entityClassName: String, schema: Schema): super(entityClassName, schema)
+    constructor(entityClassName: String, schema: Schema) : super(entityClassName, schema)
 
     constructor(
         entityClassName: String,
@@ -31,7 +31,6 @@ open class VariableEntityBase : EntityBase {
         creationTimestamp: Long,
         expirationTimestamp: Long
     ) : super(entityClassName, schema, entityId, creationTimestamp, expirationTimestamp)
-
 
     private val rawSingletons = mutableMapOf<FieldName, Referencable?>()
     private val rawCollections = mutableMapOf<FieldName, Set<Referencable>>()

--- a/java/arcs/core/entity/VariableEntityBase.kt
+++ b/java/arcs/core/entity/VariableEntityBase.kt
@@ -1,0 +1,41 @@
+package arcs.core.entity
+
+import arcs.core.common.Referencable
+import arcs.core.data.FieldName
+import arcs.core.data.RawEntity
+import arcs.core.data.Schema
+
+open class VariableEntityBase(
+    entityClassName: String,
+    schema: Schema,
+    entityId: String? = null,
+    creationTimestamp: Long = RawEntity.UNINITIALIZED_TIMESTAMP,
+    expirationTimestamp: Long = RawEntity.UNINITIALIZED_TIMESTAMP
+) : EntityBase(entityClassName, schema, entityId, creationTimestamp, expirationTimestamp) {
+
+    private val rawSingletons = mutableMapOf<FieldName, Referencable?>()
+    private val rawCollections = mutableMapOf<FieldName, Set<Referencable>>()
+
+    override fun serialize(): RawEntity {
+        val rawEntity = super.serialize()
+        return rawEntity.copy(
+            singletons = rawSingletons + rawEntity.singletons,
+            collections = rawCollections + rawEntity.collections
+        )
+    }
+
+    override fun deserialize(
+        rawEntity: RawEntity,
+        nestedEntitySpecs: Map<SchemaHash, EntitySpec<out Entity>>
+    ) {
+        rawEntity.singletons
+            .filter { !hasSingletonField(it.key) }
+            .forEach { rawSingletons[it.key] = it.value }
+
+        rawEntity.collections
+            .filter { !hasCollectionField(it.key) }
+            .forEach { rawCollections[it.key] = it.value }
+
+        super.deserialize(rawEntity, nestedEntitySpecs)
+    }
+}

--- a/java/arcs/core/entity/VariableEntityBase.kt
+++ b/java/arcs/core/entity/VariableEntityBase.kt
@@ -5,12 +5,21 @@ import arcs.core.data.FieldName
 import arcs.core.data.RawEntity
 import arcs.core.data.Schema
 
+/**
+ * A base [Entity] for type variables.
+ *
+ * This class behaves just like [EntityBase], except for (de)serialization. During deserialization,
+ * all the fields from [RawEntity] are stored for later use in serialization.
+ *
+ * In this way, an entity representing a type variable will pass data through the system without
+ * a specific description of the data (an exact match with a [Schema]).
+ */
 open class VariableEntityBase(
     entityClassName: String,
     schema: Schema,
-    entityId: String? = null,
-    creationTimestamp: Long = RawEntity.UNINITIALIZED_TIMESTAMP,
-    expirationTimestamp: Long = RawEntity.UNINITIALIZED_TIMESTAMP
+    entityId: String,
+    creationTimestamp: Long,
+    expirationTimestamp: Long
 ) : EntityBase(entityClassName, schema, entityId, creationTimestamp, expirationTimestamp) {
 
     private val rawSingletons = mutableMapOf<FieldName, Referencable?>()

--- a/java/arcs/sdk/Entity.kt
+++ b/java/arcs/sdk/Entity.kt
@@ -14,12 +14,16 @@ package arcs.sdk
 import arcs.core.entity.Entity
 import arcs.core.entity.EntityBase
 import arcs.core.entity.EntitySpec
+import arcs.core.entity.VariableEntityBase
 
 /** Interface of all generated [Entity] types. */
 typealias Entity = Entity
 
 /** Base class of all generated [Entity] types. */
 typealias EntityBase = EntityBase
+
+/** Base class of generated [Entity]s for type variables. */
+typealias VariableEntityBase = VariableEntityBase
 
 /**
  * Spec for an [Entity] type. Can create and deserialize new entities.

--- a/javatests/arcs/core/entity/DummyVariableEntity.kt
+++ b/javatests/arcs/core/entity/DummyVariableEntity.kt
@@ -2,6 +2,9 @@ package arcs.core.entity
 
 import arcs.core.data.*
 
+/**
+ * An [Entity] similar to [DummyEntity], except with only a subset of its properties.
+ */
 class DummyVariableEntity : VariableEntityBase(ENTITY_CLASS_NAME, SCHEMA), Storable {
     var text: String? by SingletonProperty()
     var ref: Reference<DummyEntity>? by SingletonProperty()
@@ -11,16 +14,6 @@ class DummyVariableEntity : VariableEntityBase(ENTITY_CLASS_NAME, SCHEMA), Stora
     private val nestedEntitySpecs = mapOf(
         DummyEntity.SCHEMA_HASH to DummyEntity
     )
-
-    fun getSingletonValueForTest(field: String) = super.getSingletonValue(field)
-
-    fun getCollectionValueForTest(field: String) = super.getCollectionValue(field)
-
-    fun setSingletonValueForTest(field: String, value: Any?) =
-        super.setSingletonValue(field, value)
-
-    fun setCollectionValueForTest(field: String, values: Set<Any>) =
-        super.setCollectionValue(field, values)
 
     fun deserializeForTest(rawEntity: RawEntity) = super.deserialize(rawEntity, nestedEntitySpecs)
 

--- a/javatests/arcs/core/entity/DummyVariableEntity.kt
+++ b/javatests/arcs/core/entity/DummyVariableEntity.kt
@@ -1,0 +1,52 @@
+package arcs.core.entity
+
+import arcs.core.data.*
+
+class DummyVariableEntity : VariableEntityBase(ENTITY_CLASS_NAME, SCHEMA), Storable {
+    var text: String? by SingletonProperty()
+    var ref: Reference<DummyEntity>? by SingletonProperty()
+    var bools: Set<Boolean> by CollectionProperty()
+    var nums: Set<Double> by CollectionProperty()
+
+    private val nestedEntitySpecs = mapOf(
+        DummyEntity.SCHEMA_HASH to DummyEntity
+    )
+
+    fun getSingletonValueForTest(field: String) = super.getSingletonValue(field)
+
+    fun getCollectionValueForTest(field: String) = super.getCollectionValue(field)
+
+    fun setSingletonValueForTest(field: String, value: Any?) =
+        super.setSingletonValue(field, value)
+
+    fun setCollectionValueForTest(field: String, values: Set<Any>) =
+        super.setCollectionValue(field, values)
+
+    fun deserializeForTest(rawEntity: RawEntity) = super.deserialize(rawEntity, nestedEntitySpecs)
+
+    companion object : EntitySpec<DummyVariableEntity> {
+        override fun deserialize(data: RawEntity) =
+            DummyVariableEntity().apply {
+                deserialize(data, mapOf(SCHEMA_HASH to DummyVariableEntity))
+            }
+
+        const val ENTITY_CLASS_NAME = "DummyVariableEntity"
+
+        const val SCHEMA_HASH = "hijklmn"
+
+        override val SCHEMA = Schema(
+            names = setOf(SchemaName(ENTITY_CLASS_NAME)),
+            fields = SchemaFields(
+                singletons = mapOf(
+                    "text" to FieldType.Text,
+                    "ref" to FieldType.EntityRef(DummyEntity.SCHEMA_HASH)
+                ),
+                collections = mapOf(
+                    "bools" to FieldType.Boolean,
+                    "nums" to FieldType.Number
+                )
+            ),
+            hash = SCHEMA_HASH
+        )
+    }
+}

--- a/javatests/arcs/core/entity/VariableEntityBaseTest.kt
+++ b/javatests/arcs/core/entity/VariableEntityBaseTest.kt
@@ -16,22 +16,14 @@ import kotlin.test.assertFailsWith
 class VariableEntityBaseTest {
 
     private lateinit var entity: DummyVariableEntity
+    private lateinit var biggerEntity: DummyEntity
 
     @Before
     fun setUp() {
         SchemaRegistry.register(DummyEntity.SCHEMA)
         SchemaRegistry.register(DummyVariableEntity.SCHEMA)
         entity = DummyVariableEntity()
-    }
-
-    @After
-    fun tearDown() {
-        SchemaRegistry.clearForTest()
-    }
-
-    @Test
-    fun serializationRoundTrip() {
-        val biggerEntity = DummyEntity()
+        biggerEntity = DummyEntity()
             .apply {
                 text = "abc"
                 num = 12.0
@@ -43,6 +35,15 @@ class VariableEntityBaseTest {
                 refs = setOf(createDummyReference("ref1"), createDummyReference("ref2"))
             }
 
+    }
+
+    @After
+    fun tearDown() {
+        SchemaRegistry.clearForTest()
+    }
+
+    @Test
+    fun serializationRoundTrip() {
         val biggerRaw = biggerEntity.serialize()
 
         val variableEntity = DummyVariableEntity()
@@ -57,19 +58,7 @@ class VariableEntityBaseTest {
     }
 
     @Test
-    fun variableSerialization_propertyAccess() {
-        val biggerEntity = DummyEntity()
-            .apply {
-                text = "abc"
-                num = 12.0
-                bool = true
-                ref = createDummyReference("foo")
-                texts = setOf("aa", "bb")
-                nums = setOf(1.0, 2.0)
-                bools = setOf(true, false)
-                refs = setOf(createDummyReference("ref1"), createDummyReference("ref2"))
-            }
-
+    fun onlyFieldsListedInSchemaAreAccessible() {
         val biggerRaw = biggerEntity.serialize()
 
         val variableEntity = DummyVariableEntity()
@@ -81,7 +70,7 @@ class VariableEntityBaseTest {
         assertThat(variableEntity.nums).isEqualTo(setOf(1.0, 2.0))
 
         val e = assertFailsWith<InvalidFieldNameException> {
-            variableEntity.getSingletonValueForTest("num")
+            variableEntity.getSingletonValue("num")
         }
         assertThat(e).hasMessageThat().isEqualTo(
             "${DummyVariableEntity.ENTITY_CLASS_NAME} does not have a singleton field called \"num\"."

--- a/javatests/arcs/core/entity/VariableEntityBaseTest.kt
+++ b/javatests/arcs/core/entity/VariableEntityBaseTest.kt
@@ -1,0 +1,95 @@
+package arcs.core.entity
+
+import arcs.core.crdt.VersionMap
+import arcs.core.storage.testutil.DummyStorageKey
+import com.google.common.truth.Truth.assertThat
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import kotlin.test.assertFailsWith
+
+
+@RunWith(JUnit4::class)
+@Suppress("UNCHECKED_CAST")
+class VariableEntityBaseTest {
+
+    private lateinit var entity: DummyVariableEntity
+
+    @Before
+    fun setUp() {
+        SchemaRegistry.register(DummyEntity.SCHEMA)
+        SchemaRegistry.register(DummyVariableEntity.SCHEMA)
+        entity = DummyVariableEntity()
+    }
+
+    @After
+    fun tearDown() {
+        SchemaRegistry.clearForTest()
+    }
+
+    @Test
+    fun serializationRoundTrip() {
+        val biggerEntity = DummyEntity()
+            .apply {
+                text = "abc"
+                num = 12.0
+                bool = true
+                ref = createDummyReference("foo")
+                texts = setOf("aa", "bb")
+                nums = setOf(1.0, 2.0)
+                bools = setOf(true, false)
+                refs = setOf(createDummyReference("ref1"), createDummyReference("ref2"))
+            }
+
+        val biggerRaw = biggerEntity.serialize()
+
+        val variableEntity = DummyVariableEntity()
+        variableEntity.deserializeForTest(biggerRaw)
+
+        val backToBiggerRaw = variableEntity.serialize()
+        assertThat(backToBiggerRaw).isEqualTo(biggerRaw)
+
+        val backToBigger = DummyEntity()
+        backToBigger.deserializeForTest(backToBiggerRaw)
+        assertThat(backToBigger).isEqualTo(biggerEntity)
+    }
+
+    @Test
+    fun variableSerialization_propertyAccess() {
+        val biggerEntity = DummyEntity()
+            .apply {
+                text = "abc"
+                num = 12.0
+                bool = true
+                ref = createDummyReference("foo")
+                texts = setOf("aa", "bb")
+                nums = setOf(1.0, 2.0)
+                bools = setOf(true, false)
+                refs = setOf(createDummyReference("ref1"), createDummyReference("ref2"))
+            }
+
+        val biggerRaw = biggerEntity.serialize()
+
+        val variableEntity = DummyVariableEntity()
+        variableEntity.deserializeForTest(biggerRaw)
+
+        assertThat(variableEntity.text).isEqualTo("abc")
+        assertThat(variableEntity.ref).isEqualTo(createDummyReference("foo"))
+        assertThat(variableEntity.bools).isEqualTo(setOf(true, false))
+        assertThat(variableEntity.nums).isEqualTo(setOf(1.0, 2.0))
+
+        val e = assertFailsWith<InvalidFieldNameException> {
+            variableEntity.getSingletonValueForTest("num")
+        }
+        assertThat(e).hasMessageThat().isEqualTo(
+            "${DummyVariableEntity.ENTITY_CLASS_NAME} does not have a singleton field called \"num\"."
+        )
+    }
+
+    private fun createDummyReference(id: String) = Reference(
+        DummyEntity,
+        arcs.core.storage.Reference(id, DummyStorageKey(id), VersionMap("id" to 1))
+    )
+}


### PR DESCRIPTION
This PR breaks out a sliver of #5431. 

@piotrswigon pointed out in the other PR that we overlooked a scenario for Variable entities. EntityBase in the (de)serialization process checks that fields in RawEntities match the schema fields. If they don't match, the data is dropped. 

For type variables, we want to preserve the data from RawEntities, even if they don't match the schema.  