### PR TITLE
Memory optimization: proactively evict more store caches and bug fix

### DIFF
--- a/java/arcs/core/storage/DirectStore.kt
+++ b/java/arcs/core/storage/DirectStore.kt
@@ -113,7 +113,9 @@ class DirectStore<Data : CrdtData, Op : CrdtOperation, T> /* internal */ constru
     /** Closes the store. Once closed, it cannot be re-opened. A new instance must be created. */
     fun close() {
         synchronized(proxyManager) {
-            closeInternal()
+            if (proxyManager.isEmpty()) {
+                closeInternal()
+            }
         }
     }
 

--- a/java/arcs/core/storage/DirectStoreMuxer.kt
+++ b/java/arcs/core/storage/DirectStoreMuxer.kt
@@ -55,7 +55,7 @@ class DirectStoreMuxer<Data : CrdtData, Op : CrdtOperation, T>(
 
     suspend fun clearStoresCache() = storeMutex.withLock {
         stores.forEach { _, sr ->
-            /** The same eviction logic as [stores]'s [LruCacheMap.onEvict]. */
+            /** Aligns with the logic of [stores]'s [LruCacheMap.onEvict]. */
             if (!sr.store.closed) {
                 sr.store.close()
             }

--- a/java/arcs/core/storage/DirectStoreMuxer.kt
+++ b/java/arcs/core/storage/DirectStoreMuxer.kt
@@ -54,7 +54,12 @@ class DirectStoreMuxer<Data : CrdtData, Op : CrdtOperation, T>(
     suspend fun getLocalData(referenceId: String) = store(referenceId).store.getLocalData()
 
     suspend fun clearStoresCache() = storeMutex.withLock {
-        stores.forEach { _, r -> r.store.close() }
+        stores.forEach { _, sr ->
+            /** The same eviction logic as [stores]'s [LruCacheMap.onEvict]. */
+            if (!sr.store.closed) {
+                sr.store.close()
+            }
+        }
         stores.clear()
     }
 

--- a/java/arcs/core/storage/DirectStoreMuxer.kt
+++ b/java/arcs/core/storage/DirectStoreMuxer.kt
@@ -19,6 +19,7 @@ import arcs.core.storage.ProxyMessage.Operations
 import arcs.core.storage.ProxyMessage.SyncRequest
 import arcs.core.type.Type
 import arcs.core.util.LruCacheMap
+import arcs.core.util.TaggedLog
 import kotlin.coroutines.coroutineContext
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
@@ -38,6 +39,8 @@ class DirectStoreMuxer<Data : CrdtData, Op : CrdtOperation, T>(
     val callbackFactory: (String) -> ProxyCallback<Data, Op, T>
 ) {
     private val storeMutex = Mutex()
+    private val log = TaggedLog { "BackingStore" }
+
     // TODO(b/158262634): Make this CacheMap Weak.
     /* internal */ val stores = LruCacheMap<String, StoreRecord<Data, Op, T>>(
         50,
@@ -47,8 +50,14 @@ class DirectStoreMuxer<Data : CrdtData, Op : CrdtOperation, T>(
     /** Safely closes a [DirectStore] and cleans up its resources. */
     private fun closeStore(storeRecord: StoreRecord<*, *, *>) {
         if (!storeRecord.store.closed) {
+            log.debug { "close the store(${storeRecord.id})" }
+
             // The store will be actually closed as soon as there are no connected proxies.
-            storeRecord.store.off(storeRecord.id)
+            try {
+                storeRecord.store.off(storeRecord.id)
+            } catch (e: Exception) {
+                log.warning { "failed to close the store(${storeRecord.id})" }
+            }
         }
     }
 

--- a/java/arcs/core/storage/DirectStoreMuxer.kt
+++ b/java/arcs/core/storage/DirectStoreMuxer.kt
@@ -53,7 +53,10 @@ class DirectStoreMuxer<Data : CrdtData, Op : CrdtOperation, T>(
      */
     suspend fun getLocalData(referenceId: String) = store(referenceId).store.getLocalData()
 
-    suspend fun clearStoresCache() = storeMutex.withLock { stores.clear() }
+    suspend fun clearStoresCache() = storeMutex.withLock {
+        stores.forEach { _, r -> r.store.close() }
+        stores.clear()
+    }
 
     /** Calls [idle] on all existing contained stores and waits for their completion. */
     suspend fun idle() = storeMutex.withLock {

--- a/java/arcs/core/storage/DirectStoreMuxer.kt
+++ b/java/arcs/core/storage/DirectStoreMuxer.kt
@@ -59,7 +59,7 @@ class DirectStoreMuxer<Data : CrdtData, Op : CrdtOperation, T>(
 
     /** Removes [DirectStore] caches and closes those that can be closed safely. */
     suspend fun clearStoresCache() = storeMutex.withLock {
-        stores.forEach { _, sr -> closeStore(sr) }
+        for ((_, sr) in stores) closeStore(sr)
         stores.clear()
     }
 

--- a/java/arcs/core/storage/ReferenceModeStore.kt
+++ b/java/arcs/core/storage/ReferenceModeStore.kt
@@ -58,7 +58,6 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 
 /**
  * [ReferenceModeStore]s adapt between a collection ([CrdtSet] or [CrdtSingleton]) of entities from
@@ -191,7 +190,7 @@ class ReferenceModeStore private constructor(
         callbacks.unregister(callbackToken)
 
         if (containerStore.closed) {
-            runBlocking { backingStore.clearStoresCache() }
+            backingStore.clearStoresCache()
         }
     }
 

--- a/java/arcs/core/storage/ReferenceModeStore.kt
+++ b/java/arcs/core/storage/ReferenceModeStore.kt
@@ -58,6 +58,7 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 
 /**
  * [ReferenceModeStore]s adapt between a collection ([CrdtSet] or [CrdtSingleton]) of entities from
@@ -188,6 +189,10 @@ class ReferenceModeStore private constructor(
     override fun off(callbackToken: Int) {
         containerStore.off(containerCallbackToken)
         callbacks.unregister(callbackToken)
+
+        if (containerStore.closed) {
+            runBlocking { backingStore.clearStoresCache() }
+        }
     }
 
     /*

--- a/java/arcs/core/storage/referencemode/BUILD
+++ b/java/arcs/core/storage/referencemode/BUILD
@@ -21,6 +21,7 @@ arcs_kt_library(
         "//java/arcs/core/storage/database",
         "//java/arcs/core/type",
         "//java/arcs/core/util",
+        "//third_party/kotlin/kotlinx_atomicfu",
         "//third_party/kotlin/kotlinx_coroutines",
     ],
 )

--- a/java/arcs/core/storage/referencemode/MessageQueue.kt
+++ b/java/arcs/core/storage/referencemode/MessageQueue.kt
@@ -12,9 +12,12 @@
 package arcs.core.storage.referencemode
 
 import kotlin.coroutines.coroutineContext
+import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.ConflatedBroadcastChannel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -31,18 +34,28 @@ class MessageQueue(
 ) {
     private val mutex = Mutex()
     private val queue = mutableListOf<Message>()
+    val size = atomic(0)
+    @ExperimentalCoroutinesApi
+    val sizeChannel = ConflatedBroadcastChannel(0)
 
     /**
      * Enqueues an incoming [Message] onto the queue and awaits the return value of processing that
      * [Message].
      */
+    @ExperimentalCoroutinesApi
     suspend fun enqueue(message: Message): Boolean {
         require(message !is Message.Enqueued) { "Cannot enqueue an already-enqueued message." }
-
+        size.incrementAndGet().let {
+            if (!sizeChannel.isClosedForSend) sizeChannel.send(it)
+        }
         val deferred = CompletableDeferred<Boolean>(coroutineContext[Job.Key])
         mutex.withLock { queue += message.toEnqueued(deferred) }
         CoroutineScope(coroutineContext).launch { drainQueue() }
-        return deferred.await()
+        return deferred.await().also {
+            size.decrementAndGet().let {
+                if (!sizeChannel.isClosedForSend) sizeChannel.send(it)
+            }
+        }
     }
 
     private suspend fun drainQueue() {


### PR DESCRIPTION
I'm gonna generate new memory/latency stats and get ready for system health review.
Want to get all known / in-flight optimizations in sooner.

Changes:
* Fix `BackingStore` `LruCacheMap.onEvict()` logic where a store is directly close w/out checking whether or not be able to close it i.e. there are still connected storage proxies.
* Check and proactively evict more `DirectStore` caches at `BackingStore` when the associated `ReferenceModeStore` becomes an orphan and when there are no ongoing messages being handled in receiving queue. This will help the cases where an archost stops and/or handles close.
* Unregister backing store client upon eviction (we missed `off()` unregistration for all stores in `BackingStore`).