### PR TITLE
Memory optimization: Fix incorrect database client removal and evict db caches

### DIFF
--- a/java/arcs/android/storage/database/AndroidSqliteDatabaseManager.kt
+++ b/java/arcs/android/storage/database/AndroidSqliteDatabaseManager.kt
@@ -80,7 +80,11 @@ class AndroidSqliteDatabaseManager(
         val entry = registry.register(name, persistent)
         return mutex.withLock {
             dbCache[entry.name to entry.isPersistent]
-                ?: DatabaseImpl(context, name, persistent).also {
+                ?: DatabaseImpl(context, name, persistent) {
+                    mutex.withLock {
+                        dbCache.remove(entry.name to entry.isPersistent)
+                    }
+                }.also {
                     dbCache[entry.name to entry.isPersistent] = it
                 }
         }

--- a/java/arcs/android/storage/database/DatabaseImpl.kt
+++ b/java/arcs/android/storage/database/DatabaseImpl.kt
@@ -99,7 +99,8 @@ typealias ReferenceId = Long
 class DatabaseImpl(
     context: Context,
     databaseName: String,
-    persistent: Boolean = true
+    persistent: Boolean = true,
+    val onDatabaseClose: suspend () -> Unit = {}
 ) : Database, SQLiteOpenHelper(
     context,
     // Using `null` with SQLiteOpenHelper's database name makes it an in-memory database.
@@ -169,9 +170,10 @@ class DatabaseImpl(
     }
 
     override suspend fun removeClient(identifier: Int) = clientMutex.withLock {
-        clients.remove(nextClientId)
+        clients.remove(identifier)
         // When all clients are done with the database, close the connection.
         if (clients.isEmpty()) {
+            onDatabaseClose()
             super.close()
         }
         Unit


### PR DESCRIPTION
I'm gonna generate new memory/latency stats and get ready for system health review.
Want to get all known / in-flight optimizations in sooner.

Changes:
* `removeClient` removes the wrong client id turns out `clients` will never become empty.
* When all db clients are removed, proactively evicting the database from `AndroidSqliteDatabaseManager`'s database cache map.