### PR TITLE
in the database, when storing a crdt set/singleton, store a version m…

### DIFF
--- a/java/arcs/core/storage/database/Database.kt
+++ b/java/arcs/core/storage/database/Database.kt
@@ -100,14 +100,14 @@ sealed class DatabaseData(
     open val versionMap: VersionMap
 ) {
     data class Singleton(
-        val reference: Reference?,
+        val value: ReferenceWithVersion?,
         override val schema: Schema,
         override val databaseVersion: Int,
         override val versionMap: VersionMap
     ) : DatabaseData(schema, databaseVersion, versionMap)
 
     data class Collection(
-        val values: Set<Reference>,
+        val values: Set<ReferenceWithVersion>,
         override val schema: Schema,
         override val databaseVersion: Int,
         override val versionMap: VersionMap
@@ -120,3 +120,8 @@ sealed class DatabaseData(
         override val versionMap: VersionMap
     ) : DatabaseData(schema, databaseVersion, versionMap)
 }
+
+data class ReferenceWithVersion(
+    val reference: Reference,
+    val versionMap: VersionMap
+)

--- a/java/arcs/core/storage/referencemode/BUILD
+++ b/java/arcs/core/storage/referencemode/BUILD
@@ -18,6 +18,7 @@ arcs_kt_library(
         "//java/arcs/core/storage:proxy",
         "//java/arcs/core/storage:reference",
         "//java/arcs/core/storage:storage_key",
+        "//java/arcs/core/storage/database",
         "//java/arcs/core/type",
         "//java/arcs/core/util",
         "//third_party/kotlin/kotlinx_coroutines",

--- a/javatests/arcs/android/storage/database/DatabaseImplTest.kt
+++ b/javatests/arcs/android/storage/database/DatabaseImplTest.kt
@@ -34,6 +34,7 @@ import arcs.core.storage.StorageKey
 import arcs.core.storage.StorageKeyParser
 import arcs.core.storage.database.DatabaseClient
 import arcs.core.storage.database.DatabaseData
+import arcs.core.storage.database.ReferenceWithVersion
 import arcs.core.storage.testutil.DummyStorageKey
 import arcs.core.testutil.assertSuspendingThrows
 import arcs.core.util.guardedBy
@@ -862,8 +863,14 @@ class DatabaseImplTest {
         val schema = newSchema("hash")
         val inputCollection = DatabaseData.Collection(
             values = setOf(
-                Reference("ref1", backingKey, VersionMap("ref1" to 1)),
-                Reference("ref2", backingKey, VersionMap("ref2" to 2))
+                ReferenceWithVersion(
+                    Reference("ref1", backingKey, VersionMap("ref1" to 1)),
+                    VersionMap("actor" to 1)
+                ),
+                ReferenceWithVersion(
+                    Reference("ref2", backingKey, VersionMap("ref2" to 2)),
+                    VersionMap("actor" to 2)
+                )
             ),
             schema = schema,
             databaseVersion = 1,
@@ -882,8 +889,14 @@ class DatabaseImplTest {
         val backingKey = DummyStorageKey("backing")
         val schema = newSchema("hash")
         val values = mutableSetOf(
-            Reference("ref", backingKey, VersionMap("ref" to 1)),
-            Reference("ref-to-remove", backingKey, VersionMap("ref-to-remove" to 2))
+            ReferenceWithVersion(
+                Reference("ref", backingKey, VersionMap("ref" to 1)),
+                VersionMap("actor" to 1)
+            ),
+            ReferenceWithVersion(
+                Reference("ref-to-remove", backingKey, VersionMap("ref-to-remove" to 2)),
+                VersionMap("actor" to 2)
+            )
         )
         val inputCollection1 = DatabaseData.Collection(
             values = values,
@@ -894,13 +907,16 @@ class DatabaseImplTest {
         database.insertOrUpdate(collectionKey, inputCollection1)
 
         // Test removal of old elements.
-        values.removeIf { it.id == "ref-to-remove" }
+        values.removeIf { it.reference.id == "ref-to-remove" }
         val inputCollection2 = inputCollection1.copy(values = values, databaseVersion = 2)
         database.insertOrUpdate(collectionKey, inputCollection2)
         assertThat(database.getCollection(collectionKey, schema)).isEqualTo(inputCollection2)
 
         // Test addition of new elements.
-        values.add(Reference("new-ref", backingKey, VersionMap("new-ref" to 3)))
+        values.add(ReferenceWithVersion(
+            Reference("new-ref", backingKey, VersionMap("new-ref" to 3)),
+            VersionMap( "actor" to 3)
+        ))
         val inputCollection3 = inputCollection2.copy(values = values, databaseVersion = 3)
         database.insertOrUpdate(collectionKey, inputCollection3)
         assertThat(database.getCollection(collectionKey, schema)).isEqualTo(inputCollection3)
@@ -917,7 +933,10 @@ class DatabaseImplTest {
         val key = DummyStorageKey("collection")
         val collection = DatabaseData.Collection(
             values = mutableSetOf(
-                Reference("ref", DummyStorageKey("backing"), VersionMap("ref" to 1))
+                ReferenceWithVersion(
+                    Reference("ref", DummyStorageKey("backing"), VersionMap("ref" to 1)),
+                    VersionMap("actor" to 1)
+                )
             ),
             schema = newSchema("hash"),
             databaseVersion = 2,
@@ -939,7 +958,7 @@ class DatabaseImplTest {
         val key = DummyStorageKey("key")
         val schema = newSchema("hash")
         val inputSingleton = DatabaseData.Singleton(
-            reference = null,
+            value = null,
             schema = schema,
             databaseVersion = 1,
             versionMap = VERSION_MAP
@@ -957,7 +976,10 @@ class DatabaseImplTest {
         val backingKey = DummyStorageKey("backing")
         val schema = newSchema("hash")
         val inputSingleton = DatabaseData.Singleton(
-            reference = Reference("ref", backingKey, VersionMap("ref" to 1)),
+            value = ReferenceWithVersion(
+                Reference("ref", backingKey, VersionMap("ref" to 1)),
+                VersionMap("actor" to 1)
+            ),
             schema = schema,
             databaseVersion = 1,
             versionMap = VERSION_MAP
@@ -975,7 +997,10 @@ class DatabaseImplTest {
         val backingKey = DummyStorageKey("backing")
         val schema = newSchema("hash")
         val inputSingleton1 = DatabaseData.Singleton(
-            reference = Reference("ref", backingKey, VersionMap("ref" to 1)),
+            value = ReferenceWithVersion(
+                Reference("ref", backingKey, VersionMap("ref" to 1)),
+                VersionMap("actor" to 1)
+            ),
             schema = schema,
             databaseVersion = 1,
             versionMap = VERSION_MAP
@@ -984,7 +1009,10 @@ class DatabaseImplTest {
 
         // Test can change timestamps.
         val inputSingleton2 = inputSingleton1.copy(
-            reference = Reference("ref", backingKey, VersionMap("ref" to 1), 1, 2),
+            value = ReferenceWithVersion(
+                Reference("ref", backingKey, VersionMap("ref" to 1), 1, 2),
+                VersionMap("actor" to 1)
+            ),
             databaseVersion = 2
         )
         database.insertOrUpdateSingleton(singletonKey, inputSingleton2)
@@ -992,14 +1020,17 @@ class DatabaseImplTest {
 
         // Test can change reference.
         val inputSingleton3 = inputSingleton1.copy(
-            reference = Reference("new-ref", backingKey, VersionMap("new-ref" to 2)),
+            value = ReferenceWithVersion(
+                Reference("new-ref", backingKey, VersionMap("new-ref" to 2)),
+                VersionMap("actor" to 2)
+            ),
             databaseVersion = 3
         )
         database.insertOrUpdateSingleton(singletonKey, inputSingleton3)
         assertThat(database.getSingleton(singletonKey, schema)).isEqualTo(inputSingleton3)
 
         // Test can clear value.
-        val inputSingleton4 = inputSingleton3.copy(reference = null, databaseVersion = 4)
+        val inputSingleton4 = inputSingleton3.copy(value = null, databaseVersion = 4)
         database.insertOrUpdateSingleton(singletonKey, inputSingleton4)
         assertThat(database.getSingleton(singletonKey, schema)).isEqualTo(inputSingleton4)
     }
@@ -1008,7 +1039,10 @@ class DatabaseImplTest {
     fun insertAndGet_singleton_mustIncrementVersion() = runBlockingTest {
         val key = DummyStorageKey("singleton")
         val singleton = DatabaseData.Singleton(
-            reference = Reference("ref", DummyStorageKey("backing"), VersionMap("ref" to 1)),
+            value = ReferenceWithVersion(
+                Reference("ref", DummyStorageKey("backing"), VersionMap("ref" to 1)),
+                VersionMap("actor" to 1)
+            ),
             schema = newSchema("hash"),
             databaseVersion = 2,
             versionMap = VERSION_MAP
@@ -1088,7 +1122,7 @@ class DatabaseImplTest {
         val singletonKey = DummyStorageKey("singleton")
         val schema = newSchema("hash")
         val singleton = DatabaseData.Singleton(
-            reference = null,
+            value = null,
             schema = schema,
             databaseVersion = 1,
             versionMap = VERSION_MAP
@@ -1180,8 +1214,14 @@ class DatabaseImplTest {
         )
         val collection = DatabaseData.Collection(
             values = setOf(
-                Reference("entity1", backingKey, VersionMap("ref1" to 1)),
-                Reference("entity2", backingKey, VersionMap("ref2" to 2))
+                ReferenceWithVersion(
+                    Reference("entity1", backingKey, VersionMap("ref1" to 1)),
+                    VersionMap("actor" to 1)
+                ),
+                ReferenceWithVersion(
+                    Reference("entity2", backingKey, VersionMap("ref2" to 2)),
+                    VersionMap("actor" to 2)
+                )
             ),
             schema = schema,
             databaseVersion = FIRST_VERSION_NUMBER,
@@ -1277,9 +1317,18 @@ class DatabaseImplTest {
         )
         val collection = DatabaseData.Collection(
             values = setOf(
-                Reference("entity1", backingKey, VersionMap("ref1" to 1)),
-                Reference("entity2", backingKey, VersionMap("ref2" to 2)),
-                Reference("entity3", backingKey, VersionMap("ref3" to 3))
+                ReferenceWithVersion(
+                    Reference("entity1", backingKey, VersionMap("ref1" to 1)),
+                    VersionMap("actor" to 1)
+                ),
+                ReferenceWithVersion(
+                    Reference("entity2", backingKey, VersionMap("ref2" to 2)),
+                    VersionMap("actor" to 2)
+                ),
+                ReferenceWithVersion(
+                    Reference("entity3", backingKey, VersionMap("ref3" to 3)),
+                    VersionMap("actor" to 3)
+                )
             ),
             schema = schema,
             databaseVersion = FIRST_VERSION_NUMBER,
@@ -1311,8 +1360,14 @@ class DatabaseImplTest {
         assertThat(database.getEntity(entity3Key, schema)).isEqualTo(entity3)
 
         val newValues = setOf(
-            Reference("entity1", backingKey, VersionMap("ref1" to 1)),
-            Reference("entity3", backingKey, VersionMap("ref3" to 3))
+            ReferenceWithVersion(
+                Reference("entity1", backingKey, VersionMap("ref1" to 1)),
+                VersionMap("actor" to 1)
+            ),
+            ReferenceWithVersion(
+                Reference("entity3", backingKey, VersionMap("ref3" to 3)),
+                VersionMap("actor" to 3)
+            )
         )
         assertThat(database.getCollection(collectionKey, schema))
             .isEqualTo(collection.copy(values = newValues))
@@ -1335,7 +1390,11 @@ class DatabaseImplTest {
             VERSION_MAP
         )
         suspend fun updateCollection(vararg entities: DatabaseData.Entity) {
-            val values = entities.map { Reference(it.rawEntity.id, backingKey, VersionMap("ref" to 1)) }
+            val values = entities.map { 
+                ReferenceWithVersion(
+                    Reference(it.rawEntity.id, backingKey, VersionMap("ref" to 1)),
+                    VersionMap("actor" to 1))
+            }
             val collection = DatabaseData.Collection(
                 values = values.toSet(),
                 schema = schema,
@@ -1424,7 +1483,10 @@ class DatabaseImplTest {
             VERSION_MAP
         )
         suspend fun updateCollection(vararg entities: DatabaseData.Entity) {
-            val values = entities.map { Reference(it.rawEntity.id, backingKey, VersionMap("ref" to 1)) }
+            val values = entities.map { ReferenceWithVersion(
+                Reference(it.rawEntity.id, backingKey, VersionMap("ref" to 1)),
+                VersionMap("actor" to 1)
+            ) }
             val collection = DatabaseData.Collection(
                 values = values.toSet(),
                 schema = schema,
@@ -1496,9 +1558,12 @@ class DatabaseImplTest {
             VERSION_MAP
         )
         suspend fun updateSingleton(entity: DatabaseData.Entity?) {
-            val ref = entity?.let{Reference(it.rawEntity.id, backingKey, VersionMap("ref" to 1))}
+            val ref = entity?.let{ReferenceWithVersion(
+                Reference(it.rawEntity.id, backingKey, VersionMap("ref" to 1)),
+                VersionMap("actor" to 1)
+            )}
             val singleton = DatabaseData.Singleton(
-                reference = ref,
+                value = ref,
                 schema = schema,
                 databaseVersion = version++,
                 versionMap = VERSION_MAP
@@ -1618,9 +1683,18 @@ class DatabaseImplTest {
 
         // Add all of them to a collection.
         val values = setOf(
-            Reference("entity", backingKey, VersionMap("ref" to 1)),
-            Reference("expiredEntity", backingKey, VersionMap("ref-to-remove" to 2)),
-            Reference("entity2", backingKey, VersionMap("ref" to 1))
+            ReferenceWithVersion(
+                Reference("entity", backingKey, VersionMap("ref" to 1)),
+                VersionMap("actor" to 1)
+            ),
+            ReferenceWithVersion(
+                Reference("expiredEntity", backingKey, VersionMap("ref-to-remove" to 2)),
+                VersionMap("actor" to 2)
+            ),
+            ReferenceWithVersion(
+                Reference("entity2", backingKey, VersionMap("ref" to 1)),
+                VersionMap("actor" to 3)
+            )
         )
         val collection = DatabaseData.Collection(
             values = values,
@@ -1669,8 +1743,14 @@ class DatabaseImplTest {
 
         // Check the collection only contain the non expired entities.
         val newValues = setOf(
-            Reference("entity", backingKey, VersionMap("ref" to 1)),
-            Reference("entity2", backingKey, VersionMap("ref" to 1))
+            ReferenceWithVersion(
+                Reference("entity", backingKey, VersionMap("ref" to 1)),
+                VersionMap("actor" to 1)
+            ),
+            ReferenceWithVersion(
+                Reference("entity2", backingKey, VersionMap("ref" to 1)),
+                VersionMap("actor" to 3)
+            )
         )
         assertThat(database.getCollection(collectionKey, schema))
             .isEqualTo(collection.copy(values = newValues))
@@ -1750,7 +1830,10 @@ class DatabaseImplTest {
         )
         // Singleton with expired entity.
         var singleton = DatabaseData.Singleton(
-            reference = Reference("expiredEntity", backingKey, VersionMap("ref-to-remove" to 2)),
+            value = ReferenceWithVersion(
+                Reference("expiredEntity", backingKey, VersionMap("ref-to-remove" to 2)),
+                VersionMap("actor" to 2)
+            ),
             schema = schema,
             databaseVersion = FIRST_VERSION_NUMBER,
             versionMap = VERSION_MAP
@@ -1791,7 +1874,7 @@ class DatabaseImplTest {
 
         // Check the singleton now contains null.
         assertThat(database.getSingleton(singletonKey, schema))
-            .isEqualTo(singleton.copy(reference = null))
+            .isEqualTo(singleton.copy(value = null))
 
         // Check the corrent clients were notified.
         singletonClient.eventMutex.withLock {
@@ -1806,7 +1889,10 @@ class DatabaseImplTest {
 
         // Change the singleton to point to the non expired entity.
         singleton = singleton.copy(
-            reference = Reference("entity", backingKey, VersionMap("ref" to 1)),
+            value = ReferenceWithVersion(
+                Reference("entity", backingKey, VersionMap("ref" to 1)),
+                VersionMap("actor" to 2)
+            ),
             databaseVersion = FIRST_VERSION_NUMBER+1
         )
         database.insertOrUpdate(singletonKey, singleton)
@@ -1860,8 +1946,14 @@ class DatabaseImplTest {
         )
         // Add both of them to a collection.
         val values = setOf(
-            Reference("entity1", backingKey, VersionMap("ref1" to 1)),
-            Reference("entity2", backingKey, VersionMap("ref2" to 2))
+            ReferenceWithVersion(
+                Reference("entity1", backingKey, VersionMap("ref1" to 1)),
+                VersionMap("actor" to 1)
+            ),
+            ReferenceWithVersion(
+                Reference("entity2", backingKey, VersionMap("ref2" to 2)),
+                VersionMap("actor" to 2)
+            )
         )
         val collection = DatabaseData.Collection(
             values = values,
@@ -1961,8 +2053,14 @@ class DatabaseImplTest {
             VERSION_MAP
         )
         val timeInPast = JvmTime.currentTimeMillis - 10000
-        val expiredRef = Reference("entity", backingKey, VersionMap("ref" to 1), 11L, timeInPast)
-        val okRef = Reference("entity2", backingKey, VersionMap("ref" to 1), 12L) // no expiration
+        val expiredRef = ReferenceWithVersion(
+            Reference("entity", backingKey, VersionMap("ref" to 1), 11L, timeInPast),
+            VersionMap("actor" to 1)
+        )
+        val okRef = ReferenceWithVersion(
+            Reference("entity2", backingKey, VersionMap("ref" to 1), 12L),
+            VersionMap("actor" to 2)
+        ) // no expiration
         val collection = DatabaseData.Collection(
             values = setOf(expiredRef, okRef),
             schema = schema,
@@ -2062,7 +2160,10 @@ class DatabaseImplTest {
         val backingKey = DummyStorageKey("backing")
         val schema = newSchema("hash")
         val collection = DatabaseData.Collection(
-            values = setOf(Reference("ref1", backingKey, VersionMap("ref1" to 1))),
+            values = setOf(ReferenceWithVersion(
+                Reference("ref1", backingKey, VersionMap("ref1" to 1)),
+                VersionMap("actor" to 1)
+            )),
             schema = schema,
             databaseVersion = 1,
             versionMap = VERSION_MAP
@@ -2084,7 +2185,10 @@ class DatabaseImplTest {
         val backingKey = DummyStorageKey("backing")
         val schema = newSchema("hash")
         val collection = DatabaseData.Collection(
-            values = setOf(Reference("ref1", backingKey, VersionMap("ref1" to 1))),
+            values = setOf(ReferenceWithVersion(
+                Reference("ref1", backingKey, VersionMap("ref1" to 1)),
+                VersionMap("actor" to 1)
+            )),
             schema = schema,
             databaseVersion = 1,
             versionMap = VERSION_MAP
@@ -2104,7 +2208,10 @@ class DatabaseImplTest {
         val backingKey = DummyStorageKey("backing")
         val schema = newSchema("hash")
         val singleton = DatabaseData.Singleton(
-            reference = Reference("ref1", backingKey, VersionMap("ref1" to 1)),
+            value = ReferenceWithVersion(
+                Reference("ref1", backingKey, VersionMap("ref1" to 1)),
+                VersionMap("actor" to 1)
+            ),
             schema = schema,
             databaseVersion = 1,
             versionMap = VERSION_MAP
@@ -2125,7 +2232,10 @@ class DatabaseImplTest {
         val keyToDelete = DummyStorageKey("key-to-delete")
         val backingKey = DummyStorageKey("backing")
         val schema = newSchema("hash")
-        val reference = Reference("ref1", backingKey, VersionMap("ref1" to 1))
+        val reference = ReferenceWithVersion(
+            Reference("ref1", backingKey, VersionMap("ref1" to 1)),
+            VersionMap("actor" to 1)
+        )
         val singleton = DatabaseData.Singleton(reference, schema, 1, VERSION_MAP)
         database.insertOrUpdateSingleton(keyToKeep, singleton)
         database.insertOrUpdateSingleton(keyToDelete, singleton)
@@ -2151,7 +2261,10 @@ class DatabaseImplTest {
         val clientBId = database.addClient(clientB)
         assertThat(clientBId).isEqualTo(2)
 
-        val reference = Reference("ref1", backingKey, VersionMap("ref1" to 1))
+        val reference = ReferenceWithVersion(
+            Reference("ref1", backingKey, VersionMap("ref1" to 1)),
+            VersionMap("actor" to 1)
+        )
         val singleton = DatabaseData.Singleton(reference, schema, 1, VERSION_MAP)
 
         database.insertOrUpdate(storageKeyA, singleton, clientAId)
@@ -2180,7 +2293,10 @@ class DatabaseImplTest {
         val clientBId = database.addClient(clientB)
         assertThat(clientBId).isEqualTo(2)
 
-        val reference = Reference("ref1", backingKey, VersionMap("ref1" to 1))
+        val reference = ReferenceWithVersion(
+            Reference("ref1", backingKey, VersionMap("ref1" to 1)),
+            VersionMap("actor" to 1)
+        )
         val singleton = DatabaseData.Singleton(reference, schema, 1, VERSION_MAP)
 
         database.insertOrUpdate(storageKeyA, singleton, clientAId)


### PR DESCRIPTION
…ap for each entry (in a new field in collection_entries) which is the version at which the item was added to the set, and fix BridgingData to use that version when reconstructing crdts from database data