### PR TITLE
Avoid hanging when calling clear() on an empty CollectionHandle.

### DIFF
--- a/javatests/arcs/core/entity/HandleManagerTestBase.kt
+++ b/javatests/arcs/core/entity/HandleManagerTestBase.kt
@@ -125,9 +125,9 @@ open class HandleManagerTestBase {
 
     @Test
     fun singleton_initialState() = testRunner {
-        val readHandle = readHandleManager.createSingletonHandle()
-            as ReadSingletonHandle<*>
-        assertThat(readHandle.fetch()).isNull()
+        val handle = readHandleManager.createSingletonHandle()
+        assertThat(handle.fetch()).isNull()
+        handle.clear().join()
     }
 
     @Test
@@ -474,8 +474,11 @@ open class HandleManagerTestBase {
     @Test
     fun collection_initialState() = testRunner {
         val handle = writeHandleManager.createCollectionHandle()
-            as ReadCollectionHandle<*>
+        assertThat(handle.size()).isEqualTo(0)
+        assertThat(handle.isEmpty()).isEqualTo(true)
         assertThat(handle.fetchAll()).isEmpty()
+        handle.clear().join()
+        handle.remove(entity1).join()
     }
 
     @Test

--- a/javatests/arcs/core/entity/HandleManagerTestBase.kt
+++ b/javatests/arcs/core/entity/HandleManagerTestBase.kt
@@ -127,6 +127,8 @@ open class HandleManagerTestBase {
     fun singleton_initialState() = testRunner {
         val handle = readHandleManager.createSingletonHandle()
         assertThat(handle.fetch()).isNull()
+
+        // Verify that clear works on an empty singleton (including the join op).
         handle.clear().join()
     }
 
@@ -477,6 +479,9 @@ open class HandleManagerTestBase {
         assertThat(handle.size()).isEqualTo(0)
         assertThat(handle.isEmpty()).isEqualTo(true)
         assertThat(handle.fetchAll()).isEmpty()
+
+        // Verify that clear works on an empty collection (including the join op),
+        // and that removing any entity is also safe.
         handle.clear().join()
         handle.remove(entity1).join()
     }


### PR DESCRIPTION
Also avoid needlessly invoking `adaptValues` for `size` and `isEmpty`.