### PR TITLE
Remove unused cloneFrom functionality

### DIFF
--- a/java/arcs/core/storage/ActiveStore.kt
+++ b/java/arcs/core/storage/ActiveStore.kt
@@ -66,9 +66,4 @@ abstract class ActiveStore<Data : CrdtData, Op : CrdtOperation, ConsumerData>(
 
         override fun close() = off(id)
     }
-
-    /** Clones data from the given store into this one. */
-    suspend fun cloneFrom(store: ActiveStore<Data, Op, ConsumerData>) {
-        onProxyMessage(ProxyMessage.ModelUpdate(store.getLocalData(), id = null))
-    }
 }

--- a/javatests/arcs/android/storage/ReferenceModeStoreDatabaseImplIntegrationTest.kt
+++ b/javatests/arcs/android/storage/ReferenceModeStoreDatabaseImplIntegrationTest.kt
@@ -150,30 +150,6 @@ class ReferenceModeStoreDatabaseImplIntegrationTest {
     }
 
     @Test
-    fun canCloneData_fromAnotherStore() = runBlockingTest {
-        val activeStore = createReferenceModeStore()
-
-        // Add some data.
-        val collection = CrdtSet<RawEntity>()
-        val entity = createPersonEntity("an-id", "bob", 42)
-        collection.applyOperation(
-            CrdtSet.Operation.Add("me", VersionMap("me" to 1), entity)
-        )
-        activeStore.onProxyMessage(
-            ProxyMessage.ModelUpdate(RefModeStoreData.Set(collection.data), 1)
-        )
-
-        logRule("Creating activeStore2")
-        // Clone
-        val activeStore2 = createReferenceModeStore()
-        logRule("Cloning into activeStore2")
-        activeStore2.cloneFrom(activeStore)
-
-        assertThat(activeStore2.getLocalData()).isEqualTo(activeStore.getLocalData())
-        assertThat(activeStore2.getLocalData()).isNotSameInstanceAs(activeStore.getLocalData())
-    }
-
-    @Test
     fun appliesAndPropagatesOperationUpdate_fromProxies_toDrivers() = runBlockingTest {
         val activeStore = createReferenceModeStore()
         val actor = activeStore.crdtKey

--- a/javatests/arcs/core/storage/ReferenceModeStoreDatabaseIntegrationTest.kt
+++ b/javatests/arcs/core/storage/ReferenceModeStoreDatabaseIntegrationTest.kt
@@ -137,28 +137,6 @@ class ReferenceModeStoreDatabaseIntegrationTest {
     }
 
     @Test
-    fun canCloneData_fromAnotherStore() = runBlockingTest {
-        val activeStore = createReferenceModeStore()
-
-        // Add some data.
-        val collection = CrdtSet<RawEntity>()
-        val entity = createPersonEntity("an-id", "bob", 42)
-        collection.applyOperation(
-            CrdtSet.Operation.Add("me", VersionMap("me" to 1), entity)
-        )
-        activeStore.onProxyMessage(
-            ProxyMessage.ModelUpdate(RefModeStoreData.Set(collection.data), 1)
-        )
-
-        // Clone
-        val activeStore2 = createReferenceModeStore()
-        activeStore2.cloneFrom(activeStore)
-
-        assertThat(activeStore2.getLocalData()).isEqualTo(activeStore.getLocalData())
-        assertThat(activeStore2.getLocalData()).isNotSameInstanceAs(activeStore.getLocalData())
-    }
-
-    @Test
     fun databaseRoundtrip() = runBlockingTest {
         val activeStore = createReferenceModeStore()
 

--- a/javatests/arcs/core/storage/ReferenceModeStoreTest.kt
+++ b/javatests/arcs/core/storage/ReferenceModeStoreTest.kt
@@ -160,30 +160,6 @@ class ReferenceModeStoreTest {
     }
 
     @Test
-    fun canCloneData_fromAnotherStore() = runBlockingTest {
-        DriverFactory.register(MockDriverProvider())
-
-        val activeStore = createReferenceModeStore()
-
-        // Add some data.
-        val collection = CrdtSet<RawEntity>()
-        val entity = createPersonEntity("an-id", "bob", 42)
-        collection.applyOperation(
-            CrdtSet.Operation.Add("me", VersionMap("me" to 1), entity)
-        )
-        activeStore.onProxyMessage(
-            ProxyMessage.ModelUpdate(RefModeStoreData.Set(collection.data), 1)
-        )
-
-        // Clone
-        val activeStore2 = createReferenceModeStore()
-        activeStore2.cloneFrom(activeStore)
-
-        assertThat(activeStore2.getLocalData()).isEqualTo(activeStore.getLocalData())
-        assertThat(activeStore2.getLocalData()).isNotSameInstanceAs(activeStore.getLocalData())
-    }
-
-    @Test
     fun appliesAndPropagatesOperationUpdate_fromProxies_toDrivers() = runBlockingTest {
         DriverFactory.register(MockDriverProvider())
 

--- a/javatests/arcs/core/storage/StoreTest.kt
+++ b/javatests/arcs/core/storage/StoreTest.kt
@@ -209,24 +209,6 @@ class StoreTest {
     }
 
     @Test
-    fun clonesData_fromAnotherStore() = runBlockingTest {
-        setupMocks()
-
-        val activeStore = createStore().activate()
-
-        // Write some data.
-        val count = CrdtCount()
-        count.applyOperation(Increment("me", 0 to 1))
-        activeStore.onProxyMessage(ProxyMessage.ModelUpdate(count.data, 1))
-        assertThat(activeStore.getLocalData()).isEqualTo(count.data)
-
-        // Clone into another store.
-        val activeStore2 = createStore().activate()
-        activeStore2.cloneFrom(activeStore)
-        assertThat(activeStore2.getLocalData()).isEqualTo(count.data)
-    }
-
-    @Test
     fun doesntSendUpdateToDriver_afterDriverOriginatedMessages() = runBlockingTest {
         val (driver, _) = setupMocks()
         val receiverCaptor = argumentCaptor<suspend (CrdtCount.Data, Int) -> Unit>()


### PR DESCRIPTION
Part of a larger cleanup around store communications patterns