### PR TITLE
Explicit tests for parsing CreatableStorageKey from string + make ? optional.

### DIFF
--- a/java/arcs/core/data/CreateableStorageKey.kt
+++ b/java/arcs/core/data/CreateableStorageKey.kt
@@ -20,10 +20,11 @@ data class CreateableStorageKey(
     val nameFromManifest: String,
     val capabilities: Capabilities = Capabilities.TiedToRuntime
 ) : StorageKey(CREATEABLE_KEY_PROTOCOL) {
-    override fun toKeyString() =
-        "$nameFromManifest$CAPABILITY_ARG_SEPARATOR${capabilitiesToString()}"
 
-    fun capabilitiesToString() = capabilities.capabilities.map { it -> it.name }.joinToString(",")
+    override fun toKeyString() = capabilities.capabilities.joinToString(
+        prefix = "$nameFromManifest${if (capabilities.isEmpty()) "" else CAPABILITY_ARG_SEPARATOR}",
+        separator = ","
+    ) { it.name }
 
     override fun childKeyWithComponent(component: String): StorageKey {
         throw UnsupportedOperationException("CreateableStorageKey is used as a placeholder only.")
@@ -36,12 +37,10 @@ data class CreateableStorageKey(
         const val CAPABILITY_ARG_SEPARATOR = "?"
 
         private val CREATEABLE_STORAGE_KEY_PATTERN =
-            ("^([^:]*)\\$CAPABILITY_ARG_SEPARATOR(.*)\$").toRegex()
+            ("^([^:^?]*)(\\$CAPABILITY_ARG_SEPARATOR.*)?\$").toRegex()
 
-        init {
-            StorageKeyParser.addParser(
-                CREATEABLE_KEY_PROTOCOL, Companion::parse
-            )
+        fun registerParser() {
+            StorageKeyParser.addParser(CREATEABLE_KEY_PROTOCOL, ::parse)
         }
 
         private fun parse(rawKeyString: String): CreateableStorageKey {
@@ -57,9 +56,10 @@ data class CreateableStorageKey(
         }
 
         private fun parseCapabilities(capabilities: String): Capabilities {
-            val capabilityStrings =
-                if (capabilities == "") emptyList<String>()
-                else capabilities.split(',')
+            val capabilityStrings = when (capabilities) {
+                "", CAPABILITY_ARG_SEPARATOR -> emptyList()
+                else -> capabilities.substring(1).split(',')
+            }
             return Capabilities(
                 capabilityStrings.map { name -> Capabilities.Capability.valueOf(name) }.toSet()
             )

--- a/java/arcs/core/storage/api/BUILD
+++ b/java/arcs/core/storage/api/BUILD
@@ -12,6 +12,7 @@ arcs_kt_library(
     srcs = glob(["*.kt"]),
     deps = [
         "//java/arcs/core/common",
+        "//java/arcs/core/data",
         "//java/arcs/core/entity",
         "//java/arcs/core/storage",
         "//java/arcs/core/storage/database",

--- a/java/arcs/core/storage/api/DriverAndKeyConfigurator.kt
+++ b/java/arcs/core/storage/api/DriverAndKeyConfigurator.kt
@@ -12,6 +12,7 @@
 package arcs.core.storage.api
 
 import arcs.core.common.ArcId
+import arcs.core.data.CreateableStorageKey
 import arcs.core.entity.SchemaRegistry
 import arcs.core.storage.DriverFactory
 import arcs.core.storage.StorageKeyParser
@@ -64,9 +65,10 @@ object DriverAndKeyConfigurator {
         RamDiskStorageKey.registerKeyCreator()
         DatabaseStorageKey.registerParser()
         DatabaseStorageKey.registerKeyCreator()
-        // ReferenceModeStorageKey has no key creator.
+        // Below storage keys don't have respective drivers,
+        // and therefore they don't have key creators.
+        CreateableStorageKey.registerParser()
         ReferenceModeStorageKey.registerParser()
-        // JoinStorageKey has no key creator.
         JoinStorageKey.registerParser()
     }
 }

--- a/java/arcs/jvm/host/BUILD
+++ b/java/arcs/jvm/host/BUILD
@@ -9,7 +9,7 @@ arcs_kt_jvm_library(
     srcs = glob(["*.kt"]),
     disable_lint_checks = ["NewApi"],
     deps = [
-        "//java/arcs/core/data:data-kt",
+        "//java/arcs/core/data",
         "//java/arcs/core/host",
         "//java/arcs/core/host/api",
         "//java/arcs/core/storage/api",

--- a/java/arcs/jvm/storage/database/testutil/BUILD
+++ b/java/arcs/jvm/storage/database/testutil/BUILD
@@ -10,7 +10,7 @@ arcs_kt_jvm_library(
     srcs = glob(["*.kt"]),
     deps = [
         "//java/arcs/core/crdt",
-        "//java/arcs/core/data:data-kt",
+        "//java/arcs/core/data",
         "//java/arcs/core/storage:storage_key",
         "//java/arcs/core/storage/database",
         "//java/arcs/core/type",

--- a/javatests/arcs/core/data/CreateableStorageKeyTest.kt
+++ b/javatests/arcs/core/data/CreateableStorageKeyTest.kt
@@ -12,7 +12,9 @@
 package arcs.core.data
 
 import arcs.core.storage.StorageKeyParser
+import arcs.core.storage.api.DriverAndKeyConfigurator
 import com.google.common.truth.Truth.assertThat
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
@@ -21,33 +23,96 @@ import org.junit.runners.JUnit4
 @RunWith(JUnit4::class)
 class CreateableStorageKeyTest {
 
+    @Before
+    fun registerParsers() = DriverAndKeyConfigurator.configureKeyParsers()
+
     @Test
-    fun createableStorageKey_parses() {
+    fun serializesToString() {
+        assertThat(
+            CreateableStorageKey("abc", Capabilities.Empty).toString()
+        ).isEqualTo("create://abc")
+
+        assertThat(
+            CreateableStorageKey("abc", Capabilities.TiedToArc).toString()
+        ).isEqualTo("create://abc?TiedToArc")
+
+        assertThat(
+            CreateableStorageKey("abc", Capabilities.PersistentQueryable).toString()
+        ).isEqualTo("create://abc?Persistent,Queryable")
+    }
+
+    @Test
+    fun parsesFromString() {
+        val name = "abc"
+
+        run {
+            val storageKey = StorageKeyParser.parse("create://$name")
+            assertThat(storageKey).isInstanceOf(CreateableStorageKey::class.java)
+            storageKey as CreateableStorageKey
+            assertThat(storageKey.nameFromManifest).isEqualTo(name)
+            assertThat(storageKey.capabilities.isEmpty()).isTrue()
+        }
+
+        run {
+            val storageKey = StorageKeyParser.parse("create://$name?")
+            assertThat(storageKey).isInstanceOf(CreateableStorageKey::class.java)
+            storageKey as CreateableStorageKey
+            assertThat(storageKey.nameFromManifest).isEqualTo(name)
+            assertThat(storageKey.capabilities.isEmpty()).isTrue()
+        }
+
+        run {
+            val storageKey = StorageKeyParser.parse("create://$name?TiedToRuntime")
+            assertThat(storageKey).isInstanceOf(CreateableStorageKey::class.java)
+            storageKey as CreateableStorageKey
+            assertThat(storageKey.nameFromManifest).isEqualTo(name)
+            assertThat(storageKey.capabilities.isPersistent).isFalse()
+            assertThat(storageKey.capabilities.isQueryable).isFalse()
+            assertThat(storageKey.capabilities.isTiedToArc).isFalse()
+            assertThat(storageKey.capabilities.isTiedToRuntime).isTrue()
+        }
+
+        run {
+            val storageKey = StorageKeyParser.parse("create://$name?Persistent,Queryable")
+            assertThat(storageKey).isInstanceOf(CreateableStorageKey::class.java)
+            storageKey as CreateableStorageKey
+            assertThat(storageKey.nameFromManifest).isEqualTo(name)
+            assertThat(storageKey.capabilities.isPersistent).isTrue()
+            assertThat(storageKey.capabilities.isQueryable).isTrue()
+            assertThat(storageKey.capabilities.isTiedToArc).isFalse()
+            assertThat(storageKey.capabilities.isTiedToRuntime).isFalse()
+        }
+    }
+
+    @Test
+    fun serializationRoundTrip() {
         val name = "recipePerson"
-        val key = CreateableStorageKey(name, Capabilities.Persistent)
-        val parsedKey = StorageKeyParser.parse(key.toString())
-        assertThat(parsedKey).isInstanceOf(CreateableStorageKey::class.java)
-        assertThat(parsedKey).isEqualTo(key)
-        parsedKey as CreateableStorageKey
-        assertThat(parsedKey.capabilities.isPersistent).isTrue()
-        assertThat(parsedKey.capabilities.isTiedToArc).isFalse()
-        assertThat(parsedKey.capabilities.isTiedToRuntime).isFalse()
 
-        val noCapKey = CreateableStorageKey(name, Capabilities(setOf<Capabilities.Capability>()))
-        val parsedNoCapKey = StorageKeyParser.parse(noCapKey.toString())
-        parsedNoCapKey as CreateableStorageKey
-        assertThat(parsedNoCapKey).isEqualTo(noCapKey)
-        assertThat(parsedNoCapKey.capabilities.isEmpty()).isTrue()
+        run {
+            val key = CreateableStorageKey(name, Capabilities.Persistent)
+            val parsedKey = StorageKeyParser.parse(key.toString())
+            assertThat(parsedKey).isEqualTo(key)
+        }
 
-        val multiCapKey = CreateableStorageKey(name, Capabilities(setOf<Capabilities.Capability>(
-            Capabilities.Capability.Persistent, Capabilities.Capability.TiedToArc
-        )))
+        run {
+            val noCapKey = CreateableStorageKey(name, Capabilities(setOf()))
+            val parsedNoCapKey = StorageKeyParser.parse(noCapKey.toString())
+            parsedNoCapKey as CreateableStorageKey
+            assertThat(parsedNoCapKey).isEqualTo(noCapKey)
+        }
 
-        val parsedMultiCapKey = StorageKeyParser.parse(multiCapKey.toString())
-        parsedMultiCapKey as CreateableStorageKey
-        assertThat(parsedMultiCapKey).isEqualTo(multiCapKey)
-        assertThat(parsedMultiCapKey.capabilities.isPersistent).isTrue()
-        assertThat(parsedMultiCapKey.capabilities.isTiedToArc).isTrue()
-        assertThat(parsedMultiCapKey.capabilities.isTiedToRuntime).isFalse()
+        run {
+            val multiCapKey = CreateableStorageKey(name, Capabilities(setOf(
+                Capabilities.Capability.Persistent, Capabilities.Capability.TiedToArc
+            )))
+            val parsedMultiCapKey = StorageKeyParser.parse(multiCapKey.toString())
+            assertThat(parsedMultiCapKey).isEqualTo(multiCapKey)
+        }
+    }
+
+    @Test
+    fun keyWithoutCapabilitiesButWithSeparatorIsNormalized() {
+        val key = StorageKeyParser.parse("create://abc?")
+        assertThat(key.toString()).isEqualTo("create://abc")
     }
 }

--- a/javatests/arcs/schematests/joins/BUILD
+++ b/javatests/arcs/schematests/joins/BUILD
@@ -30,7 +30,7 @@ arcs_kt_jvm_test_suite(
     package = "arcs.schematests.joins",
     deps = [
         ":join_codegen",
-        "//java/arcs/core/data:data-kt",
+        "//java/arcs/core/data",
         "//java/arcs/core/storage/api",
         "//java/arcs/core/storage/keys",
         "//java/arcs/core/storage/referencemode",

--- a/javatests/arcs/sdk/android/storage/BUILD
+++ b/javatests/arcs/sdk/android/storage/BUILD
@@ -32,7 +32,6 @@ arcs_kt_android_test_suite(
         "//java/arcs/android/storage/service:aidl",
         "//java/arcs/core/crdt",
         "//java/arcs/core/data",
-        "//java/arcs/core/data:data-kt",
         "//java/arcs/core/storage",
         "//java/arcs/core/storage/driver",
         "//java/arcs/core/storage/keys",


### PR DESCRIPTION
I need to make creatable storage keys represented in manifest.proto output, which uses strings for storage keys. To make it slightly easier later on this PR:

* Adds explicit tests for parsing createable SKs from strings.
* Registers CSK Parser in the DriverAndKeyConfigurator
* Makes `?` optional if no capabilities are present.