### PR TITLE
Removes randomness from recipe2plan tests and make them more explicit

### DIFF
--- a/src/tools/recipe2plan.ts
+++ b/src/tools/recipe2plan.ts
@@ -38,7 +38,7 @@ export async function recipe2plan(
     switch (format) {
       case OutputFormat.Kotlin:
         assert(manifest.meta.namespace, `Namespace is required in '${manifest.fileName}' for Kotlin code generation.`);
-        return new PlanGenerator(plans, manifest.meta.namespace).generate();
+        return new PlanGenerator(plans, manifest.meta.namespace, `salt_${Math.random()}`).generate();
       case OutputFormat.Proto:
         return Buffer.from(await encodePlansToProto(plans));
       default: throw new Error('Output Format should be Kotlin or Proto');

--- a/src/tools/tests/plan-generator-tests.ts
+++ b/src/tools/tests/plan-generator-tests.ts
@@ -14,35 +14,21 @@ import {Manifest} from '../../runtime/manifest.js';
 import {Ttl} from '../../runtime/capabilities-new.js';
 import {StorageKeyRecipeResolver} from '../storage-key-recipe-resolver.js';
 import {Capabilities, Capability} from '../../runtime/capabilities.js';
+import {Recipe} from '../../runtime/recipe/recipe.js';
+
+const randomSalt = 'test-random-seed';
 
 describe('recipe2plan', () => {
   describe('plan-generator', () => {
-    const collectOccurrences = (corpus: string, targetPrefix: string, targetSuffix: string): string[] => {
-      let idx = 0;
-      const collection: string[] = [];
-      while (idx !== -1) {
-        const start = corpus.indexOf(targetPrefix, idx);
-        const end = corpus.indexOf(targetSuffix, start);
-        if (start === -1 || end === -1) break;
-        idx = end;
-        const target = corpus.substring(start + targetPrefix.length, end);
-        collection.push(target);
-      }
-      return collection;
-    };
-    let emptyGenerator: PlanGenerator;
-    beforeEach(() => {
-      emptyGenerator = new PlanGenerator([], '');
-    });
     it('imports arcs.core.data when the package is different', () => {
-      const generator = new PlanGenerator([], 'some.package');
+      const generator = new PlanGenerator([], 'some.package', randomSalt);
 
       const actual = generator.fileHeader();
 
       assert.include(actual, 'import arcs.core.data.*');
     });
     it('does not import arcs.core.data when the package is the same', () => {
-      const generator = new PlanGenerator([], 'arcs.core.data');
+      const generator = new PlanGenerator([], 'arcs.core.data', randomSalt);
 
       const actual = generator.fileHeader();
 
@@ -50,16 +36,16 @@ describe('recipe2plan', () => {
     });
     it('can create Infinite Ttl objects', () => {
       const ttl = Ttl.infinite();
-      const actual = emptyGenerator.createTtl(ttl);
+      const actual = PlanGenerator.createTtl(ttl);
       assert.deepStrictEqual(actual, 'Ttl.Infinite');
     });
     it('can create Ttls at a valid time resolution', () => {
       const ttl = Ttl.days(30);
-      const actual = emptyGenerator.createTtl(ttl);
+      const actual = PlanGenerator.createTtl(ttl);
       assert.deepStrictEqual(actual, 'Ttl.Days(30)');
     });
-    it('creates a stable create handle name when the id is missing', async () => {
-      const manifest = await Manifest.parse(`\
+    it('creates a unique identifiers for create handles with no id', async () => {
+      const {recipes, generator} = await process(`
      particle A
        data: writes Thing {num: Number}
        
@@ -76,99 +62,111 @@ describe('recipe2plan', () => {
          data: writes h2
        A
          data: writes h3`);
-      const actuals: string[] = [];
-      for (const handle of manifest.recipes[0].handles) {
-        const newActual = await emptyGenerator.createStorageKey(handle);
-        assert.match(newActual, /CreateableStorageKey\("handle\/[\w\d]+"/); for (const existing of actuals) {
-          assert.notDeepEqual(existing, newActual);
-        }
-        actuals.push(newActual);
-      }
+
+      assert.deepEqual(
+        await Promise.all(recipes[0].handles.map(h => generator.createStorageKey(h))), [
+        'CreateableStorageKey("f737c995c77b2ff1399521941b82d1045da61daf", Capabilities.Persistent)',
+        'CreateableStorageKey("6b8932a97188a3c9da089604035c80afa72d6fab", Capabilities.Persistent)',
+        'CreateableStorageKey("399c4cefdc8a611a6aedb43b7cb6497e36e89896", Capabilities.Persistent)',
+        'CreateableStorageKey("088b16e75e8a4d44ef92e1bb497370e8ab108053", Capabilities.Persistent)'
+      ]);
     });
-    it('creates a stable create handle name from resolved recipes when the id is missing', async () => {
-      const manifest = await Manifest.parse(`\
-     particle A
-       data: writes Thing {num: Number}
-       
-     recipe R
-       h0: create @persistent
-       h1: create #test @persistent
-       h2: create #test2 @persistent
-       h3: create #test @persistent
-       A
-         data: writes h0
-       A
-         data: writes h1
-       A
-         data: writes h2
-       A
-         data: writes h3`);
-      const recipeResolver = new StorageKeyRecipeResolver(manifest);
-      const recipes = await recipeResolver.resolve();
-      const generator = new PlanGenerator(recipes, '');
-      const actuals: string[] = [];
-      for (const handle of recipes[0].handles) {
-        const newActual = await generator.createStorageKey(handle);
-        assert.match(newActual, /CreateableStorageKey\("handle\/[\w\d]+"/);
-        for (const existing of actuals) {
-          assert.notDeepEqual(existing, newActual);
-        }
-        actuals.push(newActual);
-      }
+    it('uses the same identifier for created and mapped handle', async () => {
+      const {recipes, generator} = await process(`
+        particle A
+          data: writes Thing {num: Number}
+        particle B
+          data: reads Thing {num: Number}
+        
+        @arcId('ingestion')
+        recipe Ingest
+          h: create 'data' @persistent
+          A
+            data: writes h
+        
+        recipe Retrieve
+          h: map 'data'
+          B
+            data: reads h`);
+
+      assert.equal(
+        await generator.createStorageKey(recipes.find(r => r.name === 'Ingest').handles[0]),
+        'StorageKeyParser.parse("db://66ab3cd8dbc1462e9bcfba539dfa5c852558ad64@arcs/!:ingestion/handle/data")'
+      );
+      assert.equal(
+        await generator.createStorageKey(recipes.find(r => r.name === 'Retrieve').handles[0]),
+        'StorageKeyParser.parse("db://66ab3cd8dbc1462e9bcfba539dfa5c852558ad64@arcs/!:ingestion/handle/data")'
+      );
     });
     it('creates a createable storage key with correct capabilities', async () => {
-      const manifest = await Manifest.parse(`\
-     particle A
-       data: writes Thing {num: Number}
-       
-     recipe R
-       h0: create
-       h1: create @ttl('12h')
-       h2: create @persistent
-       h3: create @persistent @ttl('24h')
-       A
-         data: writes h0
-       A
-         data: writes h1
-       A
-         data: writes h2
-       A
-         data: writes h3`);
-      const recipeResolver = new StorageKeyRecipeResolver(manifest);
-      const recipe = (await recipeResolver.resolve())[0];
-      const generator = new PlanGenerator([recipe], '');
-      const h0Key = await generator.createStorageKey(recipe.handles[0]);
-      assert.isFalse(h0Key.includes('Capabilities'));
-      const h1Key = await generator.createStorageKey(recipe.handles[1]);
-      assert.match(h1Key, /CreateableStorageKey\("handle\/[\d]+", Capabilities.Queryable\)/);
-      const h2Key = await generator.createStorageKey(recipe.handles[2]);
-      assert.match(h2Key, /CreateableStorageKey\("handle\/[\d]+", Capabilities.Persistent\)/);
-      const h3Key = await generator.createStorageKey(recipe.handles[3]);
-      assert.isTrue(h3Key.includes('Capabilities(setOf(Capabilities.Capability.Persistent, Capabilities.Capability.Queryable))'));
+      const {recipes, generator} = await process(`
+        particle A
+          data: writes Thing {num: Number}
+          
+        recipe R
+          h0: create
+          h1: create @ttl('12h')
+          h2: create @persistent
+          h3: create @tiedToArc @ttl('24h')
+          A
+            data: writes h0
+          A
+            data: writes h1
+          A
+            data: writes h2
+          A
+            data: writes h3`);
+
+      assert.deepEqual(
+        await Promise.all(recipes[0].handles.map(h => generator.createStorageKey(h))), [
+'CreateableStorageKey("f737c995c77b2ff1399521941b82d1045da61daf")',
+// TODO: Investigate if Queryable should be here? If so, explain with a comment.
+'CreateableStorageKey("6b8932a97188a3c9da089604035c80afa72d6fab", Capabilities.Queryable)',
+'CreateableStorageKey("399c4cefdc8a611a6aedb43b7cb6497e36e89896", Capabilities.Persistent)',
+// TODO: Investigate if Queryable should be here? If so, explain with a comment.
+`CreateableStorageKey(
+    "088b16e75e8a4d44ef92e1bb497370e8ab108053",
+    Capabilities(setOf(Capabilities.Capability.Queryable, Capabilities.Capability.TiedToArc))
+)`
+      ]);
     });
     it('uses the same identifier for all HandleConnections connected to the same handle', async () => {
-      const manifest = await Manifest.parse(`\
-     particle A
-       data: writes Thing {num: Number}
-     particle B
-       data: reads Thing {num: Number}
-       
-     recipe R
-       h: create 
-       A
-         data: writes h
-       B
-         data: reads h`);
-      const recipeResolver = new StorageKeyRecipeResolver(manifest);
-      const recipes = await recipeResolver.resolve();
-      const generator = new PlanGenerator(recipes, '');
-      const plan = await generator.generate();
-      const keys = collectOccurrences(plan, 'CreateableStorageKey("', '")');
-      assert.lengthOf(keys, 2);
-      assert.deepStrictEqual(keys[0], keys[1]);
+      const {recipes, generator} = await process(`
+        particle A
+          data: writes Thing {num: Number}
+        particle B
+          data: reads Thing {num: Number}
+          
+        recipe R
+          h: create 
+          A
+            data: writes h
+          B
+            data: reads h`);
+
+      const [writer, reader] = recipes[0].particles;
+
+      assert.equal(
+        await generator.createHandleConnection(writer.connections['data']),
+`HandleConnection(
+    CreateableStorageKey("f737c995c77b2ff1399521941b82d1045da61daf"),
+    HandleMode.Write,
+    SingletonType(EntityType(A_Data.SCHEMA)),
+    Ttl.Infinite
+)`
+      );
+      assert.equal(
+        await generator.createHandleConnection(reader.connections['data']),
+`HandleConnection(
+    CreateableStorageKey("f737c995c77b2ff1399521941b82d1045da61daf"),
+    HandleMode.Read,
+    SingletonType(EntityType(B_Data.SCHEMA)),
+    Ttl.Infinite
+)`
+      );
     });
     it('creates particles in the same order as the recipe and not the manifest', async () => {
-      const manifest = await Manifest.parse(`\
+      const {plan} = await process(`
      particle D in 'particle.D'
        data: reads Thing {num: Number}
      particle C in 'particle.C'
@@ -189,10 +187,6 @@ describe('recipe2plan', () => {
          data: writes h1
        D
          data: reads h1`);
-      const recipeResolver = new StorageKeyRecipeResolver(manifest);
-      const recipes = await recipeResolver.resolve();
-      const generator = new PlanGenerator(recipes, 'blah');
-      const plan = await generator.generate();
 
       assert.include(plan, 'particle.A');
       assert.include(plan, 'particle.B');
@@ -203,36 +197,43 @@ describe('recipe2plan', () => {
       assert.isBelow(plan.indexOf('particle.C'), plan.indexOf('particle.D'));
     });
     it('refers to static constants when translating a single capability', () => {
-      const generator = new PlanGenerator([], 'blah');
-
       assert.deepStrictEqual(
-        generator.createCapabilities(Capabilities.persistent),
+        PlanGenerator.createCapabilities(Capabilities.persistent),
         `Capabilities.Persistent`
       );
       assert.deepStrictEqual(
-        generator.createCapabilities(Capabilities.queryable),
+        PlanGenerator.createCapabilities(Capabilities.queryable),
         `Capabilities.Queryable`
       );
       assert.deepStrictEqual(
-        generator.createCapabilities(Capabilities.tiedToArc),
+        PlanGenerator.createCapabilities(Capabilities.tiedToArc),
         `Capabilities.TiedToArc`
       );
       assert.deepStrictEqual(
-        generator.createCapabilities(Capabilities.tiedToRuntime),
+        PlanGenerator.createCapabilities(Capabilities.tiedToRuntime),
         `Capabilities.TiedToRuntime`
       );
     });
     it('constructs a capabilities object when translating multiple capabilities', () => {
-      const generator = new PlanGenerator([], 'blah');
-
       assert.deepStrictEqual(
-        generator.createCapabilities(Capabilities.persistentQueryable),
+        PlanGenerator.createCapabilities(Capabilities.persistentQueryable),
         `Capabilities(setOf(Capabilities.Capability.Persistent, Capabilities.Capability.Queryable))`
       );
       assert.deepStrictEqual(
-        generator.createCapabilities(new Capabilities([Capability.TiedToArc, Capability.Persistent])),
+        PlanGenerator.createCapabilities(new Capabilities([Capability.TiedToArc, Capability.Persistent])),
         `Capabilities(setOf(Capabilities.Capability.Persistent, Capabilities.Capability.TiedToArc))`
       );
     });
   });
+  async function process(manifestString: string): Promise<{
+      recipes: Recipe[],
+      generator: PlanGenerator,
+      plan: string
+  }> {
+    const manifest = await Manifest.parse(manifestString);
+    const recipes = await new StorageKeyRecipeResolver(manifest).resolve();
+    const generator = new PlanGenerator(recipes, 'test.namespace', randomSalt);
+    const plan = await generator.generate();
+    return {recipes, generator, plan};
+  }
 });


### PR DESCRIPTION
Pull out the seed of randomness outside of PlanGenerator, which allows making tests much more explicit and more readable. Instead of analyzing the plan output by searching substrings, tests now assert explicitly on what is generated. This is easier to reason about, guards against bugs in testing code itself and helps to visualize what the code actually outputs.

This is in preparation for more changes soon, some that come to mind:
* Pulling out creation of creatable storage keys outside PlanGenerator, as it also needs to happen for proto output.
* Adding support for type variables.