### PR TITLE
CreatableStorageKey implementation for TypeScript

### DIFF
--- a/src/runtime/capabilities.ts
+++ b/src/runtime/capabilities.ts
@@ -9,7 +9,6 @@
  */
 
 import {AnnotationRef} from './recipe/annotation.js';
-import {Dictionary} from './hot.js';
 
 export enum Capability {
   Persistent = 'persistent',
@@ -19,7 +18,7 @@ export enum Capability {
 }
 
 export class Capabilities {
-  private readonly capabilities: Set<Capability>;
+  readonly capabilities: Set<Capability>;
 
   constructor(capabilities: Capability[]) {
     this.capabilities = new Set(capabilities);

--- a/src/runtime/storageNG/creatable-storage-key.ts
+++ b/src/runtime/storageNG/creatable-storage-key.ts
@@ -1,0 +1,62 @@
+/**
+ * @license
+ * Copyright 2019 Google LLC.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {StorageKey} from './storage-key.js';
+import {Capabilities, Capability} from '../capabilities.js';
+
+/**
+ * Represents a store that will be created once the recipe is instantiated.
+ * Capabilities from the storage key will inform what storage driver should be used.
+ */
+export class CreatableStorageKey extends StorageKey {
+  public static readonly protocol = 'create';
+
+  constructor(readonly name: string, readonly capabilities = Capabilities.empty) {
+    super(CreatableStorageKey.protocol);
+  }
+
+  toString() {
+    const separator = this.capabilities.isEmpty() ? '' : '?';
+    const capabilities = [...this.capabilities.capabilities]
+        // This is sad: expectation of casing of
+        // serialized capability names differ across the system.
+        .map(c => c[0].toUpperCase() + c.substring(1))
+        .join(',');
+    return `${CreatableStorageKey.protocol}://${this.name}${separator}${capabilities}`;
+  }
+
+  childWithComponent(_: string): StorageKey {
+    throw new Error('childWithComponent is not available for CreatableStorageKeys');
+  }
+
+  subKeyWithComponent(_: string): StorageKey {
+    throw new Error('subKeyWithComponent is not available for CreatableStorageKeys');
+  }
+
+  static fromString(key: string): CreatableStorageKey {
+    const match = key.match(/^create:\/\/([^?]+)(?:\?([a-zA-Z,]*))?$/);
+    if (!match) {
+      throw new Error(`Not a valid CreatableStorageKey: ${key}.`);
+    }
+    const [_, name, capabilitiesString] = match;
+
+    if (capabilitiesString === undefined || capabilitiesString === '') {
+      return new CreatableStorageKey(name, Capabilities.empty);
+    }
+
+    const capabilities = new Capabilities(capabilitiesString.split(',').map(name => {
+      const capability = Capability[name] as Capability;
+      if (!capability) throw new Error(`Capability not recognized: ${name}.`);
+      return capability;
+    }));
+
+    return new CreatableStorageKey(name, capabilities);
+  }
+}

--- a/src/runtime/storageNG/tests/creatable-storage-key-test.ts
+++ b/src/runtime/storageNG/tests/creatable-storage-key-test.ts
@@ -1,0 +1,72 @@
+/**
+ * @license
+ * Copyright (c) 2020 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {assert} from '../../../platform/chai-web.js';
+import {CreatableStorageKey} from '../creatable-storage-key.js';
+import {Capabilities} from '../../capabilities.js';
+
+describe('Creatable storage key', async () => {
+  it('parses without capabilities', () => {
+    const sk = CreatableStorageKey.fromString('create://abc');
+    assert.equal(sk.name, 'abc');
+    assert.isTrue(sk.capabilities.isEmpty());
+  });
+  it('parses without capabilities and extra separator', () => {
+    const sk = CreatableStorageKey.fromString('create://abc?');
+    assert.equal(sk.name, 'abc');
+    assert.isTrue(sk.capabilities.isEmpty());
+  });
+  it('parses with a single capability', () => {
+    const sk = CreatableStorageKey.fromString('create://abc?TiedToRuntime');
+    assert.equal(sk.name, 'abc');
+    assert.isTrue(sk.capabilities.isTiedToRuntime);
+    assert.isFalse(sk.capabilities.isTiedToArc);
+    assert.isFalse(sk.capabilities.isPersistent);
+    assert.isFalse(sk.capabilities.isQueryable);
+  });
+  it('parses with multiple capabilities', () => {
+    const sk = CreatableStorageKey.fromString('create://abc?Persistent,Queryable');
+    assert.equal(sk.name, 'abc');
+    assert.isFalse(sk.capabilities.isTiedToRuntime);
+    assert.isFalse(sk.capabilities.isTiedToArc);
+    assert.isTrue(sk.capabilities.isPersistent);
+    assert.isTrue(sk.capabilities.isQueryable);
+  });
+  it('does not parse invalid string', () => {
+    assert.throws(
+      () => CreatableStorageKey.fromString('create:///abc?abc?abc@/woohoo'),
+      /Not a valid CreatableStorageKey/
+    );
+  });
+  it('complains about unknown capability', () => {
+    assert.throws(
+      () => CreatableStorageKey.fromString('create://abc?Pertinent'),
+      /Capability not recognized: Pertinent./
+    );
+  });
+  it('serializes to string with empty capabilities', () => {
+    assert.equal(
+      new CreatableStorageKey('my-handle-id').toString(),
+      'create://my-handle-id'
+    );
+  });
+  it('serializes to string with one capability', () => {
+    assert.equal(
+      new CreatableStorageKey('my-handle-id', Capabilities.tiedToArc).toString(),
+      'create://my-handle-id?TiedToArc'
+    );
+  });
+  it('serializes to string with multiple capabilities', () => {
+    assert.equal(
+      new CreatableStorageKey('my-handle-id', Capabilities.tiedToRuntimeQueryable).toString(),
+      'create://my-handle-id?TiedToRuntime,Queryable'
+    );
+  });
+});

--- a/src/tools/manifest2proto.ts
+++ b/src/tools/manifest2proto.ts
@@ -276,11 +276,7 @@ async function recipeHandleToProtoPayload(handle: Handle) {
 }
 
 export function capabilitiesToProtoOrdinals(capabilities: Capabilities) {
-  // We bypass the inteface and grab the underlying set of capability strings for the purpose of
-  // serialization. It is rightfully hidden in the Capabilities object, but this use is justified.
-  // Tests will continue to ensure we access the right field.
-  // tslint:disable-next-line: no-any
-  return [...(capabilities as any).capabilities].map(c => {
+  return [...capabilities.capabilities].map(c => {
     const ordinal = CapabilityEnum.values[c.replace(/([A-Z])/g, '_$1').toUpperCase()];
     if (ordinal === undefined) {
       throw Error(`Capability ${c} is not supported`);


### PR DESCRIPTION
We need to have creatable storage key in the proto output of recipe2plan. Currently creatable storage keys are handled in the kotlin codegen layer (plan-generater.ts). We should move the logic which creates them one layer up, so that both Kotlin and Proto output of recipe2plan uses the same logic and just outputs StorageKeys as strings. The cleanest way to do this is to have CreatableStorageKey properly represented in Ts.