### PR TITLE
Moves CreatableSK generation to an earlier layer in recipe2plan

### DIFF
--- a/java/arcs/core/data/CreateableStorageKey.kt
+++ b/java/arcs/core/data/CreateableStorageKey.kt
@@ -18,7 +18,7 @@ import arcs.core.storage.StorageKeyParser
  */
 data class CreateableStorageKey(
     val nameFromManifest: String,
-    val capabilities: Capabilities = Capabilities.TiedToRuntime
+    val capabilities: Capabilities = Capabilities.Empty
 ) : StorageKey(CREATEABLE_KEY_PROTOCOL) {
 
     override fun toKeyString() = capabilities.capabilities.joinToString(
@@ -37,7 +37,7 @@ data class CreateableStorageKey(
         const val CAPABILITY_ARG_SEPARATOR = "?"
 
         private val CREATEABLE_STORAGE_KEY_PATTERN =
-            ("^([^:^?]*)(\\$CAPABILITY_ARG_SEPARATOR.*)?\$").toRegex()
+            ("^([^:^?]*)(?:\\$CAPABILITY_ARG_SEPARATOR(.*))?\$").toRegex()
 
         fun registerParser() {
             StorageKeyParser.addParser(CREATEABLE_KEY_PROTOCOL, ::parse)
@@ -55,14 +55,11 @@ data class CreateableStorageKey(
             )
         }
 
-        private fun parseCapabilities(capabilities: String): Capabilities {
-            val capabilityStrings = when (capabilities) {
-                "", CAPABILITY_ARG_SEPARATOR -> emptyList()
-                else -> capabilities.substring(1).split(',')
-            }
-            return Capabilities(
-                capabilityStrings.map { name -> Capabilities.Capability.valueOf(name) }.toSet()
-            )
+        private fun parseCapabilities(capabilities: String) = when (capabilities) {
+            "" -> Capabilities.Empty
+            else -> Capabilities(capabilities.split(',').map {
+                Capabilities.Capability.valueOf(it)
+            }.toSet())
         }
     }
 }

--- a/java/arcs/core/storage/CapabilitiesResolver.kt
+++ b/java/arcs/core/storage/CapabilitiesResolver.kt
@@ -82,10 +82,13 @@ class CapabilitiesResolver(
         type: Type,
         handleId: String
     ): StorageKey? {
+        // RamDisk is the default driver.
+        val capabilitiesToUse = if (capabilities.isEmpty())
+            Capabilities.TiedToRuntime else capabilities
         // TODO: This is a naive and basic solution for picking the appropriate
         // storage key creator for the given capabilities. As more capabilities are
         // added the heuristics will become more robust.
-        val creators = findCreators(capabilities)
+        val creators = findCreators(capabilitiesToUse)
         require(creators.isNotEmpty()) {
             "Cannot create a suitable storage key for $capabilities"
         }

--- a/javatests/arcs/core/allocator/AllocatorTestBase.kt
+++ b/javatests/arcs/core/allocator/AllocatorTestBase.kt
@@ -8,11 +8,10 @@ import arcs.core.data.EntityType
 import arcs.core.data.Plan
 import arcs.core.host.*
 import arcs.core.storage.CapabilitiesResolver
+import arcs.core.storage.api.DriverAndKeyConfigurator
 import arcs.core.storage.driver.RamDisk
 import arcs.core.storage.driver.RamDiskDriverProvider
 import arcs.core.storage.driver.VolatileDriverProvider
-import arcs.core.storage.keys.RamDiskStorageKey
-import arcs.core.storage.keys.VolatileStorageKey
 import arcs.core.testutil.assertSuspendingThrows
 import arcs.core.util.Log
 import arcs.core.util.plus
@@ -94,10 +93,8 @@ open class AllocatorTestBase {
     @Before
     open fun setUp() = runBlocking {
         RamDisk.clear()
-        RamDiskStorageKey.registerKeyCreator()
+        DriverAndKeyConfigurator.configureKeyParsers()
         RamDiskDriverProvider()
-
-        VolatileStorageKey.registerKeyCreator()
 
         readingExternalHost = readingHost()
         writingExternalHost = writingHost()

--- a/javatests/arcs/core/data/CreateableStorageKeyTest.kt
+++ b/javatests/arcs/core/data/CreateableStorageKeyTest.kt
@@ -29,6 +29,10 @@ class CreateableStorageKeyTest {
     @Test
     fun serializesToString() {
         assertThat(
+            CreateableStorageKey("abc").toString()
+        ).isEqualTo("create://abc")
+
+        assertThat(
             CreateableStorageKey("abc", Capabilities.Empty).toString()
         ).isEqualTo("create://abc")
 

--- a/javatests/arcs/core/host/AbstractArcHostTest.kt
+++ b/javatests/arcs/core/host/AbstractArcHostTest.kt
@@ -8,6 +8,7 @@ import arcs.core.entity.DummyEntity
 import arcs.core.entity.EntityBaseSpec
 import arcs.core.entity.ReadWriteSingletonHandle
 import arcs.core.host.api.HandleHolder
+import arcs.core.storage.api.DriverAndKeyConfigurator
 import arcs.core.storage.driver.RamDisk
 import arcs.core.storage.driver.RamDiskDriverProvider
 import arcs.core.storage.keys.RamDiskStorageKey
@@ -49,7 +50,7 @@ open class AbstractArcHostTest {
     @Before
     fun setUp() {
         RamDisk.clear()
-        RamDiskStorageKey.registerKeyCreator()
+        DriverAndKeyConfigurator.configureKeyParsers()
         RamDiskDriverProvider()
     }
 

--- a/javatests/arcs/core/host/ArcHostManagerTest.kt
+++ b/javatests/arcs/core/host/ArcHostManagerTest.kt
@@ -1,9 +1,9 @@
 package arcs.core.host
 
 import arcs.core.data.Plan
+import arcs.core.storage.api.DriverAndKeyConfigurator
 import arcs.core.storage.driver.RamDisk
 import arcs.core.storage.driver.RamDiskDriverProvider
-import arcs.core.storage.keys.RamDiskStorageKey
 import arcs.jvm.host.ExplicitHostRegistry
 import arcs.jvm.host.JvmSchedulerProvider
 import com.google.common.truth.Truth.assertThat
@@ -21,7 +21,7 @@ open class ArcHostManagerTest {
     @Before
     fun setUp() {
         RamDisk.clear()
-        RamDiskStorageKey.registerKeyCreator()
+        DriverAndKeyConfigurator.configureKeyParsers()
         RamDiskDriverProvider()
     }
 

--- a/javatests/arcs/core/host/ReflectiveParticleConstructionTest.kt
+++ b/javatests/arcs/core/host/ReflectiveParticleConstructionTest.kt
@@ -3,8 +3,10 @@ package arcs.core.host
 import arcs.core.allocator.Allocator
 import arcs.core.data.FieldType
 import arcs.core.data.Plan
+import arcs.core.storage.api.DriverAndKeyConfigurator
 import arcs.core.storage.driver.RamDisk
 import arcs.core.storage.driver.RamDiskDriverProvider
+import arcs.core.storage.driver.VolatileDriverProvider
 import arcs.core.storage.keys.RamDiskStorageKey
 import arcs.core.storage.keys.VolatileStorageKey
 import arcs.core.util.TaggedLog
@@ -56,10 +58,8 @@ class ReflectiveParticleConstructionTest {
     @Test
     fun host_canCreateReflectiveParticle() = runBlocking {
         RamDisk.clear()
-        RamDiskStorageKey.registerKeyCreator()
+        DriverAndKeyConfigurator.configureKeyParsers()
         RamDiskDriverProvider()
-
-        VolatileStorageKey.registerKeyCreator()
 
         val hostRegistry = ExplicitHostRegistry()
         val schedulerProvider = JvmSchedulerProvider(EmptyCoroutineContext)

--- a/javatests/arcs/core/storage/CapabilitiesResolverTest.kt
+++ b/javatests/arcs/core/storage/CapabilitiesResolverTest.kt
@@ -81,12 +81,12 @@ class CapabilitiesResolverTest {
         )
         assertThat(resolver.createStorageKey(Capabilities.TiedToArc, thingReferenceType, handleId))
             .isInstanceOf(VolatileStorageKey::class.java)
-        verifyStorageKey(
-            resolver.createStorageKey(Capabilities.Empty, thingEntityType, handleId),
-            VolatileStorageKey::class.java
-        )
-        assertThat(resolver.createStorageKey(Capabilities.Empty, thingReferenceType, handleId))
-            .isInstanceOf(VolatileStorageKey::class.java)
+        assertFailsWith<IllegalArgumentException> {
+            resolver.createStorageKey(Capabilities.Empty, thingEntityType, handleId)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            resolver.createStorageKey(Capabilities.Empty, thingReferenceType, handleId)
+        }
         assertFailsWith<IllegalArgumentException> {
             resolver.createStorageKey(Capabilities.TiedToRuntime, thingEntityType, handleId)
         }
@@ -138,12 +138,12 @@ class CapabilitiesResolverTest {
         assertFailsWith<IllegalArgumentException> {
             resolver.createStorageKey(Capabilities.TiedToArc, thingReferenceType, handleId)
         }
-        assertFailsWith<IllegalArgumentException> {
-            resolver.createStorageKey(Capabilities.Empty, thingEntityType, handleId)
-        }
-        assertFailsWith<IllegalArgumentException> {
-            resolver.createStorageKey(Capabilities.Empty, thingReferenceType, handleId)
-        }
+        verifyStorageKey(
+            resolver.createStorageKey(Capabilities.Empty, thingEntityType, handleId),
+            RamDiskStorageKey::class.java
+        )
+        assertThat(resolver.createStorageKey(Capabilities.Empty, thingReferenceType, handleId))
+            .isInstanceOf(RamDiskStorageKey::class.java)
         verifyStorageKey(
             resolver.createStorageKey(Capabilities.TiedToRuntime, thingEntityType, handleId),
             RamDiskStorageKey::class.java
@@ -181,10 +181,10 @@ class CapabilitiesResolverTest {
             .isInstanceOf(VolatileStorageKey::class.java)
         verifyStorageKey(
             resolver1.createStorageKey(Capabilities.Empty, thingEntityType, handleId),
-            VolatileStorageKey::class.java
+            RamDiskStorageKey::class.java
         )
         assertThat(resolver1.createStorageKey(Capabilities.Empty, thingReferenceType, handleId))
-            .isInstanceOf(VolatileStorageKey::class.java)
+            .isInstanceOf(RamDiskStorageKey::class.java)
         val ramdiskKey =
             resolver1.createStorageKey(Capabilities.TiedToRuntime, thingEntityType, handleId)
         verifyStorageKey(ramdiskKey, RamDiskStorageKey::class.java)

--- a/src/tools/recipe2plan.ts
+++ b/src/tools/recipe2plan.ts
@@ -28,7 +28,7 @@ export async function recipe2plan(
     recipeFilter?: string): Promise<string | Uint8Array> {
   return await Flags.withDefaultReferenceMode(async () => {
     const manifest = await Runtime.parseFile(path);
-    let plans = await (new StorageKeyRecipeResolver(manifest)).resolve();
+    let plans = await (new StorageKeyRecipeResolver(manifest, `salt_${Math.random()}`)).resolve();
 
     if (recipeFilter) {
       plans = plans.filter(p => p.name === recipeFilter);
@@ -38,7 +38,7 @@ export async function recipe2plan(
     switch (format) {
       case OutputFormat.Kotlin:
         assert(manifest.meta.namespace, `Namespace is required in '${manifest.fileName}' for Kotlin code generation.`);
-        return new PlanGenerator(plans, manifest.meta.namespace, `salt_${Math.random()}`).generate();
+        return new PlanGenerator(plans, manifest.meta.namespace).generate();
       case OutputFormat.Proto:
         return Buffer.from(await encodePlansToProto(plans));
       default: throw new Error('Output Format should be Kotlin or Proto');

--- a/src/tools/tests/goldens/WriterReaderExample.kt
+++ b/src/tools/tests/goldens/WriterReaderExample.kt
@@ -69,7 +69,7 @@ object EphemeralWritingPlan : Plan(
             "arcs.core.data.testdata.Writer",
             mapOf(
                 "data" to HandleConnection(
-                    CreateableStorageKey("my-ephemeral-handle-id"),
+                    StorageKeyParser.parse("create://my-ephemeral-handle-id"),
                     HandleMode.Write,
                     SingletonType(EntityType(Writer_Data.SCHEMA)),
                     Ttl.Infinite

--- a/src/tools/tests/recipe2plan-test.ts
+++ b/src/tools/tests/recipe2plan-test.ts
@@ -20,8 +20,8 @@ describe('recipe2plan', () => {
     assert.deepStrictEqual(
       await recipe2plan(inputManifestPath, OutputFormat.Kotlin),
       fs.readFileSync('src/tools/tests/goldens/WriterReaderExample.kt', 'utf8'),
-      `Golden is out of date! Make sure the new script is correct. If it is, consider updating the golden with: 
-$ tools/sigh recipe2plan --outfile src/tools/tests/goldens/WriterReaderExample.kt java/arcs/core/data/testdata/WriterReaderExample.arcs \n\n`
+      `Golden is out of date! Make sure the new script is correct. If it is, update the goldens with: 
+$ tools/update-goldens \n\n`
     );
   }));
   it('generates Proto plans from recipes in a manifest', Flags.withDefaultReferenceMode(async () => {


### PR DESCRIPTION
This PR moves handling of creatable storage keys from PlanGenerator (Kotlin codegen layer) to StorageKeyRecipeResolver (Recipe resolution for ProdEx).

This is beneficial, as now creatable storage keys will also appear in Proto output, which so far didn't have them - which was breaking a big class of recipes.

As we change the way CreateableStorageKey is instantiated, this stopped us from using the default in the constructor. I decided to have the default being Empty consistent across: Handle impl in Kotlin, TypeScript and CreateableStorageKey implementations in both. I've pushed the default to be in CapabilitiesResolver now, we can reconsider later.