### PR TITLE
[WIP] Manifest/Recipe support for Adapters

### DIFF
--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -51,6 +51,7 @@ import {LoaderBase} from '../platform/loader-base.js';
 import {Annotation, AnnotationRef} from './recipe/annotation.js';
 import {SchemaPrimitiveTypeValue} from './manifest-ast-nodes.js';
 import {canonicalManifest} from './canonical-manifest.js';
+import {Adapter, AdaptedType, HandleAdapter} from "./recipe/adapter";
 import {Policy} from './policy/policy.js';
 
 export enum ErrorSeverity {
@@ -163,6 +164,7 @@ export class Manifest {
   private storeManifestUrls: Map<string, string> = new Map();
   readonly errors: ManifestError[] = [];
   private _annotations: Dictionary<Annotation> = {};
+  private _adapters: Adapter[] = [];
   // readonly warnings: ManifestError[] = [];
 
   constructor({id}: {id: Id | string}) {
@@ -191,6 +193,13 @@ export class Manifest {
   }
   get allRecipes() {
     return [...new Set(this._findAll(manifest => manifest._recipes))];
+  }
+  get adapters() {
+    return this._adapters;
+  }
+
+  get allAdapters() {
+    return [...new Set(this._findAll(manifest => Object.values(manifest._adapters)))];
   }
   get allHandles() {
     // TODO(#4820) Update `reduce` to use flatMap
@@ -311,6 +320,10 @@ export class Manifest {
   }
   findSchemaByName(name: string): Schema {
     return this._find(manifest => manifest._schemas[name]);
+  }
+
+  findAdapterByName(name: string): Adapter {
+    return this._find(manifest => manifest._adapters[name]);
   }
 
   findTypeByName(name: string): EntityType | InterfaceType | undefined {
@@ -584,6 +597,7 @@ ${e.message}
       await processItems('particle', item => Manifest._processParticle(manifest, item, loader));
       await processItems('store', item => Manifest._processStore(manifest, item, loader, memoryProvider));
       await processItems('recipe', item => Manifest._processRecipe(manifest, item));
+      await processItems('adapter-node', item => Manifest._processAdapter(manifest, item));
       await processItems('policy', item => Manifest._processPolicy(manifest, item));
     } catch (e) {
       dumpErrors(manifest);
@@ -719,6 +733,79 @@ ${e.message}
       }
     }();
     visitor.traverse(items);
+  }
+
+  private static _processAdapter(manifest: Manifest, adapterItem: AstNode.AdapterNode) {
+
+    // Initial scope is a dictionary of the adapter param types
+    const params = adapterItem.params.reduce((dict, param) => {
+      dict[param.name] = param.type['model'];
+      return dict;
+    }, {});
+
+    // We support Tuple.ordinal syntax up to 5-arity
+    const ordinals = ["first", "second", "third", "fourth", "fifth"]
+    const toOrdinal = num => ordinals[num]
+
+    /*
+     * Walks object graph defined by 'scope' according to scopeChain, which is an array of lookups to apply. Scope
+     * should either be the top level dictionary of params, a model object, or a leaf value if scopeChain is empty.
+     */
+    function lookupTypeInScope(scope: any, scopeChain: string[]): Type {
+      if (!scopeChain.length) {
+        return scope;
+      }
+      const next = scopeChain[0];
+      const rest = scopeChain.slice(1);
+      const scopeType = scope;
+
+      if (scope instanceof EntityType
+        || scope instanceof ReferenceType
+        || scope instanceof TypeVariable
+        || scope instanceof SingletonType
+        || scope instanceof CollectionType) {
+        scope.maybeEnsureResolved();
+        scope = scope.getEntitySchema().fields
+      } else if (scope instanceof TupleType) { // TODO: doesn't seem to occur
+        scope = scope.innerTypes.reduce((dict, type) => dict[toOrdinal(scope.innerTypes.indexOf(type))] = type);
+      } else if (scope instanceof Type) {
+        throw new ManifestError(adapterItem.location, `Unable to lookup entries in scope type ${scope.tag}`);
+      } else if (scope.kind === 'schema-primitive') {
+        if (scopeChain.length !== 0) {
+          throw new ManifestError(adapterItem.location, `Can't dereference ${next} on schema primitive`)
+        }
+        return scope;
+      } else if (scope.kind === 'schema-reference') {
+        return lookupTypeInScope(scope.schema, scopeChain);
+      } else if (scope.kind === 'schema-inline') {
+        return scope.model;
+      } else if (scope.kind === 'schema-tuple') {
+        scope = scope.types.reduce((dict, type) => {
+            dict[toOrdinal(scope.types.indexOf(type))] = type;
+            return dict;
+          }, {});
+      } else {
+        // Dictionary types are ok
+      }
+
+      if (next in scope) {
+        return lookupTypeInScope(scope[next], rest)
+      }
+      throw new ManifestError(adapterItem.location,
+        `Unknown field ${next} in scope type ${scopeType.constructor.name} with value
+         ${JSON.stringify(scope)} for adapter ${adapterItem.name}`);
+    }
+
+    // Creates a new Schema from the adapter body, with types computed from looking up scope expressions
+    const targetSchema = new Schema(adapterItem.body.names, adapterItem.body.fields.map(field => {
+        lookupTypeInScope(params, field.expression.scopeChain)
+      })
+    )
+    const targetType = new EntityType(targetSchema);
+    const target = new AdaptedType(targetType, adapterItem.body.fields);
+    const adapter = new Adapter(adapterItem.name, params, target);
+    manifest._adapters.push(adapter);
+    // TODO: should we push the schemas into the _schemas field?
   }
 
   private static _processSchema(manifest: Manifest, schemaItem) {
@@ -949,6 +1036,9 @@ ${e.message}
             handle.capabilities.merge(Capabilities.queryable);
           }
         }
+        if (item.adapter) {
+          // add handle.adapter
+        }
       }
       items.byHandle.set(handle, item);
     }
@@ -971,6 +1061,12 @@ ${e.message}
         handle.joinDataFromHandle(associatedHandle);
       }
 
+      if (item.adapter) {
+        const adapter = manifest.findAdapterByName(item.adapter.name);
+        const handleAdapter = new HandleAdapter(adapter, (Object.keys(adapter.params) as string[])
+          .reduce((dict, paramName, index) => { dict[paramName] = item.associations[index]; return dict; }, {}));
+        handle.applyAdapter(handleAdapter);
+      }
       items.byHandle.set(handle, item);
     }
 
@@ -1523,6 +1619,10 @@ ${e.message}
 
     Object.values(this._particles).forEach(p => {
       results.push(p.toString());
+    });
+
+    Object.values(this._adapters).forEach(a => {
+      results.push(a.toString());
     });
 
     this._recipes.forEach(r => {

--- a/src/runtime/recipe/adapter.ts
+++ b/src/runtime/recipe/adapter.ts
@@ -1,0 +1,73 @@
+/**
+ * @license
+ * Copyright (c) 2020 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {Comparable, compareArrays, compareComparables, compareObjects, compareStrings} from './comparable.js';
+import {Dictionary} from '../hot.js';
+import {EntityType, Type} from "../type";
+import {AdapterField} from "../manifest-ast-nodes";
+
+/**
+ * Represents a type adapter that can be applied to a handle and produce an adapted type by
+ * evaluating a series of scope expressions.
+ */
+export class Adapter implements Comparable<Adapter> {
+  constructor(public readonly name: string,
+              public readonly params: Dictionary<Type>,
+              public readonly target: AdaptedType) {}
+
+  _compareTo(other: Adapter): number {
+    let cmp: number;
+    if ((cmp = compareStrings(this.name, other.name)) !== 0) return cmp;
+    // comparing Types by stringified inline schema, is there a better/more accurate way?
+    if ((cmp = compareObjects(this.params, other.params, (a,b) => compareStrings(`${a}`, `${b}`))) !== 0) return cmp;
+    if ((cmp = compareComparables(this.target, other.target)) !== 0) return cmp;
+    return 0;
+  }
+
+  toString(): string {
+    const result: string[] = [];
+    let paramStr = '(this)';
+    if (Object.keys(this.params).length > 0) {
+      paramStr = `(${Object.keys(this.params).map(name => `${name}: ${this.params[name].toString()}`).join(', ')})`;
+    }
+    const bodyStr = `${this.target.targetType.getEntitySchema().names.join(' ')}`;
+    const bodyFields = this.target.fields.map(field => `${field.name}: ${field.expression.scopeChain.join('.')}`);
+    result.push(`adapter ${this.name}${paramStr} => ${bodyStr} { ${bodyFields.join(',\n')} }`);
+    return result.join('\n');
+  }
+}
+
+/**
+ * Represents the resulting EntityType this adapter produces, along with the new fields which
+ * must be computed by applying expressions.
+ */
+export class AdaptedType implements Comparable<AdaptedType> {
+  constructor(public readonly targetType: EntityType, public readonly fields: AdapterField[]) {
+  }
+
+  _compareTo(other: AdaptedType): number {
+    let cmp: number;
+    if ((cmp = compareArrays(this.fields, other.fields, (a, b) => compareStrings(a.name, b.name))) !== 0) return cmp;
+    if ((cmp = compareArrays(this.fields, other.fields,
+      (a, b) => compareStrings(a.expression.scopeChain.join('.'), b.expression.scopeChain.join('.')))) !== 0) return cmp;
+    return 0;
+  }
+}
+
+/**
+ * A connection between a Handle and an Adapter which should be applied.
+ */
+export class HandleAdapter {
+  constructor(public readonly adapter: Adapter, public readonly adapterArguments: Dictionary<any>) {}
+
+  toString(): string {
+    return `apply ${this.adapter.name}(${Object.keys(this.adapter.params).join(', ')})`;
+  }
+}

--- a/src/runtime/recipe/handle.ts
+++ b/src/runtime/recipe/handle.ts
@@ -25,6 +25,8 @@ import {StorageKey} from '../storageNG/storage-key.js';
 import {Capabilities} from '../capabilities.js';
 import {AnnotationRef} from './annotation.js';
 import {StoreClaims} from '../storageNG/abstract-store.js';
+import {Dictionary} from "../hot";
+import {Adapter, HandleAdapter} from "./adapter";
 
 export class Handle implements Comparable<Handle> {
   private readonly _recipe: Recipe;
@@ -44,6 +46,8 @@ export class Handle implements Comparable<Handle> {
   // Whether this handle is being joined by other handles.
   // E.g. for `x: join (a, b, c)`, this field is true on a, b and c.
   private _isJoined = false;
+  // Whether this handle has an adapter applied, e.g. with an apply statement
+  private _adapter: HandleAdapter | undefined = undefined;
   private _mappedType: Type | undefined = undefined;
   private _storageKey: StorageKey | undefined = undefined;
   capabilities: Capabilities = Capabilities.empty;
@@ -113,6 +117,16 @@ export class Handle implements Comparable<Handle> {
       handle._pattern = this._pattern;
       for (const joined of this.joinedHandles) {
         handle.joinDataFromHandle(cloneMap.get(joined) as Handle);
+      }
+      if (this.adapter) {
+        const adapterArgs = this.adapter.adapterArguments;
+        const paramNames = Object.keys(adapterArgs) as string[];
+        handle.applyAdapter(new HandleAdapter(this.adapter.adapter,
+          paramNames.reduce((dict, name) => {
+            const arg = adapterArgs[name];
+            dict[name] = arg instanceof Handle ? cloneMap.get(arg) : arg;
+            return dict;
+          }, {})));
       }
     }
     return handle;
@@ -230,6 +244,7 @@ export class Handle implements Comparable<Handle> {
   set ttl(ttl: Ttl) { this._ttl = ttl; }
   get isSynthetic() { return this.fate === 'join'; } // Join handles are the first type of synthetic handles, other may come.
   get joinedHandles() { return this._joinedHandles; }
+  get adapter() { return this._adapter; }
   get isJoined() { return this._isJoined; }
 
   get annotations(): AnnotationRef[] { return this._annotations; }
@@ -279,6 +294,13 @@ export class Handle implements Comparable<Handle> {
       });
     }
 
+    // Applying an Adapter is a kin to writing into the Adapter type
+    if (this._adapter) {
+        typeSet.push({
+          type: this._adapter.adapter.target.targetType,
+          direction: 'writes'
+        });
+    }
     return TypeChecker.processTypeList(this._mappedType, typeSet, options);
   }
 
@@ -401,7 +423,9 @@ export class Handle implements Comparable<Handle> {
     if (this.annotations && this.annotations.length > 0) {
       result.push(this.annotations.map(a => a.toString()).join(' '));
     }
-
+    if (this.adapter) {
+      result.push(` ${this.adapter.toString()}`);
+    }
     // Debug information etc.
     if (this.type) {
       result.push('//');
@@ -430,6 +454,10 @@ export class Handle implements Comparable<Handle> {
 
   findConnectionByDirection(dir: Direction): HandleConnection|undefined {
     return this._connections.find(conn => conn.direction === dir);
+  }
+
+  applyAdapter(adapter: HandleAdapter) {
+    this._adapter = adapter;
   }
 
   joinDataFromHandle(handle: Handle) {


### PR DESCRIPTION
* Adapters create an inline schema output
* Scope expressions are looked up in the parameter scope via scope chain walking to fetch types 
* Adapters applied to handles add to the typeSet
* Tests (incomplete) for resolved recipe with adapters

o Missing tests for join handles
o Tests for error conditions/error reporting
o Scope chain resolution of types is not exhaustive (don't handle all positive subtypes of Type)
