### PR TITLE
Replaces `validateFieldPath` with `evaluateFieldPath`

### DIFF
--- a/src/runtime/field-path.ts
+++ b/src/runtime/field-path.ts
@@ -14,15 +14,15 @@ import {SchemaPrimitiveTypeValue} from './manifest-ast-nodes.js';
 export type FieldPathType = Type | SchemaPrimitiveTypeValue;
 
 /**
- * Evaluates a field path against the given Type. Returns the Type referenced by
+ * Resolves a field path against the given Type. Returns the Type referenced by
  * the field path if valid. Throws an exception if the field path is invalid.
  */
-export function evaluateFieldPath(fieldPath: string[], type: Type): FieldPathType {
+export function resolveFieldPathType(fieldPath: string[], type: Type): FieldPathType {
   if (fieldPath.length === 0) {
     return type;
   }
   if (type.isTypeContainer()) {
-    return evaluateFieldPath(fieldPath, type.getContainedType());
+    return resolveFieldPathType(fieldPath, type.getContainedType());
   }
 
   const schema = type.getEntitySchema();
@@ -31,17 +31,17 @@ export function evaluateFieldPath(fieldPath: string[], type: Type): FieldPathTyp
       if (type.canWriteSuperset == null) {
         throw new FieldPathError(`Type variable ${type} does not contain field '${fieldPath[0]}'.`);
       }
-      return evaluateFieldPath(fieldPath, type.canWriteSuperset);
+      return resolveFieldPathType(fieldPath, type.canWriteSuperset);
     } else {
       throw new FieldPathError(`Expected type to contain an entity schema: ${type}.`);
     }
   }
 
-  return evaluateAgainstSchema(fieldPath, schema);
+  return resolveForSchema(fieldPath, schema);
 }
 
 /** Checks a field path for a particular field definition. */
-function evaluateAgainstField(fieldPath: string[], field): FieldPathType {
+function resolveForField(fieldPath: string[], field): FieldPathType {
   switch (field.kind) {
     case 'schema-primitive': {
       // Field path must end here.
@@ -53,11 +53,11 @@ function evaluateAgainstField(fieldPath: string[], field): FieldPathType {
     }
     case 'schema-collection': {
       // Check inner type.
-      return evaluateAgainstField(fieldPath, field.schema);
+      return resolveForField(fieldPath, field.schema);
     }
     case 'schema-reference': {
       // Check rest of field path against inner type.
-      return evaluateAgainstSchema(fieldPath.slice(1), field.schema.model.entitySchema);
+      return resolveForSchema(fieldPath.slice(1), field.schema.model.entitySchema);
     }
     default:
       throw new FieldPathError(`Unsupported field type: ${JSON.stringify(field)}`);
@@ -65,7 +65,7 @@ function evaluateAgainstField(fieldPath: string[], field): FieldPathType {
 }
 
 /** Checks a field path against the given Schema. */
-function evaluateAgainstSchema(fieldPath: string[], schema: Schema): FieldPathType {
+function resolveForSchema(fieldPath: string[], schema: Schema): FieldPathType {
   if (fieldPath.length === 0) {
     return new EntityType(schema);
   }
@@ -74,7 +74,7 @@ function evaluateAgainstSchema(fieldPath: string[], schema: Schema): FieldPathTy
     throw new FieldPathError(`Schema '${schema.toInlineSchemaString()}' does not contain field '${fieldName}'.`);
   }
   const field = schema.fields[fieldName];
-  return evaluateAgainstField(fieldPath, field);
+  return resolveForField(fieldPath, field);
 }
 
 class FieldPathError extends Error {}

--- a/src/runtime/field-path.ts
+++ b/src/runtime/field-path.ts
@@ -8,68 +8,73 @@
  * http://polymer.github.io/PATENTS.txt
  */
 import {Schema} from './schema.js';
-import {InterfaceInfo, Type} from './type.js';
+import {InterfaceInfo, Type, EntityType} from './type.js';
+import {SchemaPrimitiveTypeValue} from './manifest-ast-nodes.js';
+
+export type FieldPathType = Type | SchemaPrimitiveTypeValue;
 
 /**
- * Validates a field path against the given Type. Throws an exception if the
- * field path is invalid.
+ * Evaluates a field path against the given Type. Returns the Type referenced by
+ * the field path if valid. Throws an exception if the field path is invalid.
  */
-export function validateFieldPath(fieldPath: string[], type: Type) {
+export function evaluateFieldPath(fieldPath: string[], type: Type): FieldPathType {
   if (fieldPath.length === 0) {
-    return;
+    return type;
   }
   if (type.isTypeContainer()) {
-    validateFieldPath(fieldPath, type.getContainedType());
-    return;
+    return evaluateFieldPath(fieldPath, type.getContainedType());
   }
 
   const schema = type.getEntitySchema();
   if (!schema) {
     if (InterfaceInfo.isTypeVar(type)) {
       if (type.canWriteSuperset == null) {
-        throw new Error(`Type variable ${type} does not contain field '${fieldPath[0]}'.`);
+        throw new FieldPathError(`Type variable ${type} does not contain field '${fieldPath[0]}'.`);
       }
-      validateFieldPath(fieldPath, type.canWriteSuperset);
-      return;
+      return evaluateFieldPath(fieldPath, type.canWriteSuperset);
     } else {
-      throw new Error(`Expected type to contain an entity schema: ${type}.`);
+      throw new FieldPathError(`Expected type to contain an entity schema: ${type}.`);
     }
   }
 
-  if (!checkSchema(fieldPath, schema)) {
-    throw new Error(`Field '${fieldPath.join('.')}' does not exist in: ${schema.toManifestString()}`);
-  }
+  return evaluateAgainstSchema(fieldPath, schema);
 }
 
 /** Checks a field path for a particular field definition. */
-function checkField(fieldPath: string[], field): boolean {
+function evaluateAgainstField(fieldPath: string[], field): FieldPathType {
   switch (field.kind) {
     case 'schema-primitive': {
       // Field path must end here.
-      return fieldPath.length === 1;
+      if (fieldPath.length === 1) {
+        return field.type;
+      } else {
+        throw new FieldPathError(`Field path '${fieldPath.join('.')}' could not be resolved because '${fieldPath[1]}' is a primitive.`);
+      }
     }
     case 'schema-collection': {
       // Check inner type.
-      return checkField(fieldPath, field.schema);
+      return evaluateAgainstField(fieldPath, field.schema);
     }
     case 'schema-reference': {
       // Check rest of field path against inner type.
-      return checkSchema(fieldPath.slice(1), field.schema.model.entitySchema);
+      return evaluateAgainstSchema(fieldPath.slice(1), field.schema.model.entitySchema);
     }
     default:
-      throw new Error(`Unsupported field type: ${JSON.stringify(field)}`);
+      throw new FieldPathError(`Unsupported field type: ${JSON.stringify(field)}`);
   }
 }
 
 /** Checks a field path against the given Schema. */
-function checkSchema(fieldPath: string[], schema: Schema): boolean {
+function evaluateAgainstSchema(fieldPath: string[], schema: Schema): FieldPathType {
   if (fieldPath.length === 0) {
-    return true;
+    return new EntityType(schema);
   }
   const fieldName = fieldPath[0];
   if (!(fieldName in schema.fields)) {
-    return false;
+    throw new FieldPathError(`Schema '${schema.toInlineSchemaString()}' does not contain field '${fieldName}'.`);
   }
   const field = schema.fields[fieldName];
-  return checkField(fieldPath, field);
+  return evaluateAgainstField(fieldPath, field);
 }
+
+class FieldPathError extends Error {}

--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -50,7 +50,7 @@ import {Annotation, AnnotationRef} from './recipe/annotation.js';
 import {SchemaPrimitiveTypeValue} from './manifest-ast-nodes.js';
 import {canonicalManifest} from './canonical-manifest.js';
 import {Policy} from './policy/policy.js';
-import {evaluateFieldPath} from './field-path.js';
+import {resolveFieldPathType} from './field-path.js';
 
 export enum ErrorSeverity {
   Error = 'error',
@@ -1379,7 +1379,7 @@ ${e.message}
 
     const claims: Map<string, ClaimIsTag[]> = new Map();
     item.claims.forEach(claim => {
-      evaluateFieldPath(claim.fieldPath, type);
+      resolveFieldPathType(claim.fieldPath, type);
       const target = claim.fieldPath.join('.');
       if (claims.has(target)) {
         throw new ManifestError(claim.location, `A claim for target ${target} already exists in store ${name}`);

--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -50,7 +50,7 @@ import {Annotation, AnnotationRef} from './recipe/annotation.js';
 import {SchemaPrimitiveTypeValue} from './manifest-ast-nodes.js';
 import {canonicalManifest} from './canonical-manifest.js';
 import {Policy} from './policy/policy.js';
-import {validateFieldPath} from './field-path.js';
+import {evaluateFieldPath} from './field-path.js';
 
 export enum ErrorSeverity {
   Error = 'error',
@@ -1379,7 +1379,7 @@ ${e.message}
 
     const claims: Map<string, ClaimIsTag[]> = new Map();
     item.claims.forEach(claim => {
-      validateFieldPath(claim.fieldPath, type);
+      evaluateFieldPath(claim.fieldPath, type);
       const target = claim.fieldPath.join('.');
       if (claims.has(target)) {
         throw new ManifestError(claim.location, `A claim for target ${target} already exists in store ${name}`);

--- a/src/runtime/particle-claim.ts
+++ b/src/runtime/particle-claim.ts
@@ -10,7 +10,7 @@
 
 import {HandleConnectionSpec} from './particle-spec.js';
 import {ParticleClaimIsTag, ParticleClaimDerivesFrom, ParticleClaimStatement, Direction} from './manifest-ast-nodes.js';
-import {validateFieldPath} from './field-path.js';
+import {evaluateFieldPath} from './field-path.js';
 
 /** The different types of trust claims that particles can make. */
 export enum ClaimType {
@@ -72,7 +72,7 @@ export class ClaimDerivesFrom {
       throw new Error(`Unknown "derives from" handle name: ${parentHandle}.`);
     }
 
-    validateFieldPath(astNode.fieldPath, parentHandle.type);
+    evaluateFieldPath(astNode.fieldPath, parentHandle.type);
 
     return new ClaimDerivesFrom(parentHandle, astNode.fieldPath);
   }

--- a/src/runtime/particle-claim.ts
+++ b/src/runtime/particle-claim.ts
@@ -10,7 +10,7 @@
 
 import {HandleConnectionSpec} from './particle-spec.js';
 import {ParticleClaimIsTag, ParticleClaimDerivesFrom, ParticleClaimStatement, Direction} from './manifest-ast-nodes.js';
-import {evaluateFieldPath} from './field-path.js';
+import {resolveFieldPathType} from './field-path.js';
 
 /** The different types of trust claims that particles can make. */
 export enum ClaimType {
@@ -72,7 +72,7 @@ export class ClaimDerivesFrom {
       throw new Error(`Unknown "derives from" handle name: ${parentHandle}.`);
     }
 
-    evaluateFieldPath(astNode.fieldPath, parentHandle.type);
+    resolveFieldPathType(astNode.fieldPath, parentHandle.type);
 
     return new ClaimDerivesFrom(parentHandle, astNode.fieldPath);
   }

--- a/src/runtime/particle-spec.ts
+++ b/src/runtime/particle-spec.ts
@@ -20,7 +20,7 @@ import {ParticleClaim, createParticleClaim} from './particle-claim.js';
 import {ManifestStringBuilder} from './manifest-string-builder.js';
 import * as AstNode from './manifest-ast-nodes.js';
 import {AnnotationRef} from './recipe/annotation.js';
-import {evaluateFieldPath} from './field-path.js';
+import {resolveFieldPathType} from './field-path.js';
 
 // TODO: clean up the real vs. literal separation in this file
 
@@ -567,7 +567,7 @@ export class ParticleSpec {
         if (!handle.isOutput) {
           throw new Error(`Can't make a claim on handle ${statement.handle} (not an output handle).`);
         }
-        evaluateFieldPath(statement.fieldPath, handle.type);
+        resolveFieldPathType(statement.fieldPath, handle.type);
         if (!handle.claims) {
           handle.claims = [];
         } else if (handle.claims.some(claim => claim.target === target)) {
@@ -601,7 +601,7 @@ export class ParticleSpec {
             } else if (!handle.isInput) {
               throw new Error(`Can't make a check on handle ${handleName} with direction ${handle.direction} (not an input handle).`);
             }
-            evaluateFieldPath(check.target.fieldPath, handle.type);
+            resolveFieldPathType(check.target.fieldPath, handle.type);
             const checkObject = createCheck(handle, check, this.handleConnectionMap);
             if (!handle.checks) {
               handle.checks = [];

--- a/src/runtime/particle-spec.ts
+++ b/src/runtime/particle-spec.ts
@@ -20,7 +20,7 @@ import {ParticleClaim, createParticleClaim} from './particle-claim.js';
 import {ManifestStringBuilder} from './manifest-string-builder.js';
 import * as AstNode from './manifest-ast-nodes.js';
 import {AnnotationRef} from './recipe/annotation.js';
-import {validateFieldPath} from './field-path.js';
+import {evaluateFieldPath} from './field-path.js';
 
 // TODO: clean up the real vs. literal separation in this file
 
@@ -567,7 +567,7 @@ export class ParticleSpec {
         if (!handle.isOutput) {
           throw new Error(`Can't make a claim on handle ${statement.handle} (not an output handle).`);
         }
-        validateFieldPath(statement.fieldPath, handle.type);
+        evaluateFieldPath(statement.fieldPath, handle.type);
         if (!handle.claims) {
           handle.claims = [];
         } else if (handle.claims.some(claim => claim.target === target)) {
@@ -601,7 +601,7 @@ export class ParticleSpec {
             } else if (!handle.isInput) {
               throw new Error(`Can't make a check on handle ${handleName} with direction ${handle.direction} (not an input handle).`);
             }
-            validateFieldPath(check.target.fieldPath, handle.type);
+            evaluateFieldPath(check.target.fieldPath, handle.type);
             const checkObject = createCheck(handle, check, this.handleConnectionMap);
             if (!handle.checks) {
               handle.checks = [];

--- a/src/runtime/policy/tests/policy-parser-test.ts
+++ b/src/runtime/policy/tests/policy-parser-test.ts
@@ -10,7 +10,7 @@
 
 import {parse} from '../../../gen/runtime/manifest-parser.js';
 import {assert} from '../../../platform/chai-web.js';
-import {mapToDictionary} from '../../util.js';
+import {mapToDictionary, deleteFieldRecursively} from '../../util.js';
 
 const noParamAnnotationRef = {
   kind: 'annotation-ref',
@@ -26,20 +26,6 @@ const oneParamAnnotationRef = {
     value: 'aaa',
   }],
 };
-
-/** Recursively delete all fields with the given name. */
-// tslint:disable-next-line: no-any
-function deleteFieldRecursively(node: any, field: string) {
-  if (node == null || typeof node !== 'object') {
-    return;
-  }
-  if (field in node) {
-    delete node[field];
-  }
-  for (const value of Object.values(node)) {
-    deleteFieldRecursively(value, field);
-  }
-}
 
 function parsePolicy(str: string) {
   const nodes = parse(str);

--- a/src/runtime/tests/field-path-test.ts
+++ b/src/runtime/tests/field-path-test.ts
@@ -8,15 +8,18 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {validateFieldPath} from '../field-path.js';
+import {evaluateFieldPath} from '../field-path.js';
 import {EntityType, SingletonType, CollectionType, TypeVariable} from '../type.js';
 import {Manifest} from '../manifest.js';
 import {assert} from '../../platform/chai-web.js';
+import {deleteFieldRecursively} from '../util.js';
 
-async function parseSchema(manifestStr: string) {
+async function parseTypeFromSchema(manifestStr: string) {
   const manifest = await Manifest.parse(manifestStr);
   assert.lengthOf(manifest.allSchemas, 1);
-  return manifest.allSchemas[0];
+  const schema = manifest.allSchemas[0];
+  deleteFieldRecursively(schema, 'location');
+  return new EntityType(schema);
 }
 
 async function parseTypeFromHandle(handleName: string, manifestStr: string) {
@@ -25,17 +28,19 @@ async function parseTypeFromHandle(handleName: string, manifestStr: string) {
   const particle = manifest.allParticles[0];
   assert.isTrue(particle.handleConnectionMap.has(handleName));
   const handleSpec = particle.handleConnectionMap.get(handleName);
-  return handleSpec.type;
+  const type = handleSpec.type;
+  deleteFieldRecursively(type, 'location');
+  return type;
 }
 
 describe('field path validation', () => {
   it('empty field path is valid', async () => {
-    const type = new EntityType(await parseSchema('schema Foo'));
-    validateFieldPath([], type);
+    const type = await parseTypeFromSchema('schema Foo');
+    assert.deepEqual(evaluateFieldPath([], type), type);
   });
 
   it('top-level entity fields are valid', async () => {
-    const type = new EntityType(await parseSchema(`
+    const type = await parseTypeFromSchema(`
       schema Foo
         txt: Text
         num: Number
@@ -43,113 +48,125 @@ describe('field path validation', () => {
         txts: [Text]
         nums: [Number]
         bools: [Boolean]
-    `));
-    validateFieldPath(['txt'], type);
-    validateFieldPath(['num'], type);
-    validateFieldPath(['bool'], type);
-    validateFieldPath(['txts'], type);
-    validateFieldPath(['nums'], type);
-    validateFieldPath(['bools'], type);
+    `);
+    assert.strictEqual(evaluateFieldPath(['txt'], type), 'Text');
+    assert.strictEqual(evaluateFieldPath(['num'], type), 'Number');
+    assert.strictEqual(evaluateFieldPath(['bool'], type), 'Boolean');
+    assert.strictEqual(evaluateFieldPath(['txts'], type), 'Text');
+    assert.strictEqual(evaluateFieldPath(['nums'], type), 'Number');
+    assert.strictEqual(evaluateFieldPath(['bools'], type), 'Boolean');
   });
 
   it('unknown top-level fields are invalid', async () => {
-    const type = new EntityType(await parseSchema(`
+    const type = await parseTypeFromSchema(`
       schema Foo
         real: Number
-    `));
+    `);
     assert.throws(
-        () => validateFieldPath(['missing'], type),
-        `Field 'missing' does not exist in: schema Foo`);
+        () => evaluateFieldPath(['missing'], type),
+        `Schema 'Foo {real: Number}' does not contain field 'missing'.`);
   });
 
   it('cannot refer to fields inside a primitive', async () => {
-    const type = new EntityType(await parseSchema(`
+    const type = await parseTypeFromSchema(`
       schema Foo
         txt: Text
         txts: [Text]
-    `));
+    `);
     assert.throws(
-        () => validateFieldPath(['txt.inside'], type),
-        `Field 'txt.inside' does not exist in: schema Foo`);
+        () => evaluateFieldPath(['txt.inside'], type),
+        `Schema 'Foo {txt: Text, txts: [Text]}' does not contain field 'txt.inside'.`);
     assert.throws(
-        () => validateFieldPath(['txts.inside'], type),
-        `Field 'txts.inside' does not exist in: schema Foo`);
+        () => evaluateFieldPath(['txts.inside'], type),
+        `Schema 'Foo {txt: Text, txts: [Text]}' does not contain field 'txts.inside'.`);
   });
 
   it('reference fields are valid', async () => {
-    const type = new EntityType(await parseSchema(`
+    const type = await parseTypeFromSchema(`
       schema Foo
         person: &Person {name: Text}
-    `));
-    validateFieldPath(['person'], type);
+    `);
+    const expectedPersonType = await parseTypeFromSchema(`
+      schema Person
+        name: Text
+    `);
+    assert.deepEqual(evaluateFieldPath(['person'], type), expectedPersonType);
   });
 
   it('can refer to fields inside references', async () => {
-    const type = new EntityType(await parseSchema(`
+    const type = await parseTypeFromSchema(`
       schema Foo
         person: &Person {name: Text}
-    `));
-    validateFieldPath(['person', 'name'], type);
+    `);
+    assert.strictEqual(evaluateFieldPath(['person', 'name'], type), 'Text');
   });
 
   it('missing fields inside references are rejected', async () => {
-    const type = new EntityType(await parseSchema(`
+    const type = await parseTypeFromSchema(`
       schema Foo
         person: &Person {name: Text}
-    `));
+    `);
     assert.throws(
-        () => validateFieldPath(['person', 'missing'], type),
-        `Field 'person.missing' does not exist in: schema Foo`);
+        () => evaluateFieldPath(['person', 'missing'], type),
+        `Schema 'Person {name: Text}' does not contain field 'missing'.`);
   });
 
   it('can refer to fields inside collections of references', async () => {
-    const type = new EntityType(await parseSchema(`
+    const type = await parseTypeFromSchema(`
       schema Foo
         person: [&Person {name: Text}]
-    `));
-    validateFieldPath(['person', 'name'], type);
+    `);
+    assert.strictEqual(evaluateFieldPath(['person', 'name'], type), 'Text');
   });
 
   it('missing fields inside collections of references are rejected', async () => {
-    const type = new EntityType(await parseSchema(`
+    const type = await parseTypeFromSchema(`
       schema Foo
         person: [&Person {name: Text}]
-    `));
+    `);
     assert.throws(
-        () => validateFieldPath(['person', 'missing'], type),
-        `Field 'person.missing' does not exist in: schema Foo`);
+        () => evaluateFieldPath(['person', 'missing'], type),
+        `Schema 'Person {name: Text}' does not contain field 'missing'.`);
   });
 
   it('can refer to fields inside deeply nested references', async () => {
-    const type = new EntityType(await parseSchema(`
+    const type = await parseTypeFromSchema(`
       schema Foo
         aaa: [&Aaa {bbb: [&Bbb {ccc: [Number]}]}]
-    `));
-    validateFieldPath(['aaa'], type);
-    validateFieldPath(['aaa', 'bbb'], type);
-    validateFieldPath(['aaa', 'bbb', 'ccc'], type);
+    `);
+    const expectedAaaType = await parseTypeFromSchema(`
+      schema Aaa
+        bbb: [&Bbb {ccc: [Number]}]
+    `);
+    const expectedBbbType = await parseTypeFromSchema(`
+      schema Bbb
+        ccc: [Number]
+    `);
+    assert.deepEqual(evaluateFieldPath(['aaa'], type), expectedAaaType);
+    assert.deepEqual(evaluateFieldPath(['aaa', 'bbb'], type), expectedBbbType);
+    assert.strictEqual(evaluateFieldPath(['aaa', 'bbb', 'ccc'], type), 'Number');
   });
 
   it('works transparently with SingletonType', async () => {
-    const type = new SingletonType(new EntityType(await parseSchema(`
+    const type = new SingletonType(await parseTypeFromSchema(`
       schema Foo
         name: Text
-    `)));
-    validateFieldPath(['name'], type);
+    `));
+    assert.strictEqual(evaluateFieldPath(['name'], type), 'Text');
     assert.throws(
-      () => validateFieldPath(['missing'], type),
-      `Field 'missing' does not exist in: schema Foo`);
+      () => evaluateFieldPath(['missing'], type),
+      `Schema 'Foo {name: Text}' does not contain field 'missing'.`);
   });
 
   it('works transparently with CollectionType', async () => {
-    const type = new CollectionType(new EntityType(await parseSchema(`
+    const type = new CollectionType(await parseTypeFromSchema(`
       schema Foo
         name: Text
-    `)));
-    validateFieldPath(['name'], type);
+    `));
+    assert.strictEqual(evaluateFieldPath(['name'], type), 'Text');
     assert.throws(
-      () => validateFieldPath(['missing'], type),
-      `Field 'missing' does not exist in: schema Foo`);
+      () => evaluateFieldPath(['missing'], type),
+      `Schema 'Foo {name: Text}' does not contain field 'missing'.`);
   });
 
   describe('type variables', () => {
@@ -160,7 +177,7 @@ describe('field path validation', () => {
       `);
       assert.instanceOf(type, TypeVariable);
       assert.throws(
-          () => validateFieldPath(['foo'], type),
+          () => evaluateFieldPath(['foo'], type),
           `Type variable ~a does not contain field 'foo'.`);
     });
 
@@ -169,7 +186,7 @@ describe('field path validation', () => {
         particle P
           foo: reads ~a with {name: Text}
       `);
-      validateFieldPath(['name'], type);
+      assert.strictEqual(evaluateFieldPath(['name'], type), 'Text');
     });
 
     it('can refer to known fields inside type variables with write constraints', async () => {
@@ -177,7 +194,7 @@ describe('field path validation', () => {
         particle P
           foo: writes ~a with {name: Text}
       `);
-      validateFieldPath(['name'], type);
+      assert.strictEqual(evaluateFieldPath(['name'], type), 'Text');
     });
 
     it('can refer to known fields inside type variables with read-write constraints', async () => {
@@ -185,7 +202,7 @@ describe('field path validation', () => {
         particle P
           foo: reads writes ~a with {name: Text}
       `);
-      validateFieldPath(['name'], type);
+      assert.strictEqual(evaluateFieldPath(['name'], type), 'Text');
     });
 
     it('cannot refer to missing fields inside type variables that do not match the constraints', async () => {
@@ -194,8 +211,8 @@ describe('field path validation', () => {
           foo: reads ~a with {name: Text}
       `);
       assert.throws(
-          () => validateFieldPath(['missing'], type),
-          `Field 'missing' does not exist in`);
+          () => evaluateFieldPath(['missing'], type),
+          `Schema '* {name: Text}' does not contain field 'missing'.`);
     });
 
     it('can refer to known fields inside type variables constraints from other handles', async () => {
@@ -204,7 +221,7 @@ describe('field path validation', () => {
           foo: reads ~a with {name: Text}
           bar: writes ~a
       `);
-      validateFieldPath(['name'], type);
+      assert.strictEqual(evaluateFieldPath(['name'], type), 'Text');
     });
 
     it('can refer to known fields inside type variables from numerous constraints', async () => {
@@ -213,8 +230,8 @@ describe('field path validation', () => {
           foo: reads ~a with {name: Text}
           bar: writes ~a with {age: Number}
       `);
-      validateFieldPath(['name'], type);
-      validateFieldPath(['age'], type);
+      assert.strictEqual(evaluateFieldPath(['name'], type), 'Text');
+      assert.strictEqual(evaluateFieldPath(['age'], type), 'Number');
     });
 
     it('supports complex nesting inside type variables', async () => {
@@ -223,9 +240,13 @@ describe('field path validation', () => {
           foo1: reads ~a with {name: Text, friends: [&Person {name: Text}]}
           bar: writes ~a
       `);
-      validateFieldPath(['name'], type);
-      validateFieldPath(['friends'], type);
-      validateFieldPath(['friends', 'name'], type);
+      const expectedPersonType = await parseTypeFromSchema(`
+        schema Person
+          name: Text
+      `);
+      assert.strictEqual(evaluateFieldPath(['name'], type), 'Text');
+      assert.deepEqual(evaluateFieldPath(['friends'], type), expectedPersonType);
+      assert.strictEqual(evaluateFieldPath(['friends', 'name'], type), 'Text');
     });
   });
 });

--- a/src/runtime/tests/manifest-test.ts
+++ b/src/runtime/tests/manifest-test.ts
@@ -3118,19 +3118,19 @@ resource SomeName
         particle A
           output: writes T {foo: Text}
           claim output.bar is something
-      `), `Field 'bar' does not exist`);
+      `), `Schema 'T {foo: Text}' does not contain field 'bar'.`);
 
       await assertThrowsAsync(async () => await parseManifest(`
         particle A
           output: writes T {foo: &Bar {bar: Number}}
           claim output.foo.baz is something
-      `), `Field 'foo.baz' does not exist`);
+      `), `Schema 'Bar {bar: Number}' does not contain field 'baz'.`);
 
       await assertThrowsAsync(async () => await parseManifest(`
         particle A
           output: writes [T {foo: [&Bar {bar: Number}]}]
           claim output.foo.bar.baz is something
-      `), `Field 'foo.bar.baz' does not exist`);
+      `), `Field path 'bar.baz' could not be resolved because 'baz' is a primitive.`);
     });
 
     it('supports claim statement with multiple tags', async () => {
@@ -3212,7 +3212,7 @@ resource SomeName
           input: writes T {foo: Text}
           output: writes T {foo: Text}
           claim output.foo derives from input.bar
-      `), `Field 'bar' does not exist`);
+      `), `Schema 'T {foo: Text}' does not contain field 'bar'.`);
     });
 
     it('supports mixed claims with multiple tags, not tags, and "derives from"', async () => {
@@ -3315,19 +3315,19 @@ resource SomeName
         particle A
           input: reads T {foo: Text}
           check input.bar is something
-      `), `Field 'bar' does not exist`);
+      `), `Schema 'T {foo: Text}' does not contain field 'bar'.`);
 
       await assertThrowsAsync(async () => await parseManifest(`
         particle A
           input: reads T {foo: &Bar {bar: Number}}
           check input.foo.baz is something
-      `), `Field 'foo.baz' does not exist`);
+      `), `Schema 'Bar {bar: Number}' does not contain field 'baz'.`);
 
       await assertThrowsAsync(async () => await parseManifest(`
         particle A
           input: reads [T {foo: [&Bar {bar: Number}]}]
           check input.foo.bar.baz is something
-      `), `Field 'foo.bar.baz' does not exist`);
+      `), `Field path 'bar.baz' could not be resolved because 'baz' is a primitive.`);
     });
 
     it(`supports 'is from store' checks`, async () => {
@@ -3627,7 +3627,7 @@ resource SomeName
         resource NobIdJson
           start
           ${data}
-      `), `Field 'foo' does not exist in`);
+      `), `Schema 'NobIdStore {nobId: Text}' does not contain field 'foo'.`);
 
       await assertThrowsAsync(async () => await parseManifest(`
         store NobId of NobIdStore {nobId: Text, someRef: [&Foo {foo: [Text]}]} in NobIdJson
@@ -3635,7 +3635,7 @@ resource SomeName
         resource NobIdJson
           start
           ${data}
-      `), `Field 'someRef.bar' does not exist in`);
+      `), `Schema 'Foo {foo: [Text]}' does not contain field 'bar'.`);
     });
 
     it(`doesn't allow mixing 'and' and 'or' operations without nesting`, async () => {

--- a/src/runtime/util.ts
+++ b/src/runtime/util.ts
@@ -106,3 +106,17 @@ export function mapToDictionary<T>(map: Map<string, T>): Dictionary<T> {
   }
   return dict;
 }
+
+/** Recursively delete all fields with the given name. */
+// tslint:disable-next-line: no-any
+export function deleteFieldRecursively(node: any, field: string) {
+  if (node == null || typeof node !== 'object') {
+    return;
+  }
+  if (field in node) {
+    delete node[field];
+  }
+  for (const value of Object.values(node)) {
+    deleteFieldRecursively(value, field);
+  }
+}


### PR DESCRIPTION
and makes it return the type pointed to by the field path.