### PR TITLE
Support `first`, `second`, ... accessors for tuple field paths

### DIFF
--- a/src/runtime/tests/field-path-test.ts
+++ b/src/runtime/tests/field-path-test.ts
@@ -262,10 +262,10 @@ describe('field path validation', () => {
       `);
       const tupleType = new TupleType([fooType, barType]);
       assert.deepEqual(resolveFieldPathType([], tupleType), tupleType);
-      assert.deepEqual(resolveFieldPathType(['component0'], tupleType), fooType);
-      assert.strictEqual(resolveFieldPathType(['component0', 'foo'], tupleType), 'Text');
-      assert.deepEqual(resolveFieldPathType(['component1'], tupleType), barType);
-      assert.strictEqual(resolveFieldPathType(['component1', 'bar'], tupleType), 'Text');
+      assert.deepEqual(resolveFieldPathType(['first'], tupleType), fooType);
+      assert.strictEqual(resolveFieldPathType(['first', 'foo'], tupleType), 'Text');
+      assert.deepEqual(resolveFieldPathType(['second'], tupleType), barType);
+      assert.strictEqual(resolveFieldPathType(['second', 'bar'], tupleType), 'Text');
     });
 
     it('rejects invalid tuple components', async () => {
@@ -275,11 +275,11 @@ describe('field path validation', () => {
       `);
       const tupleType = new TupleType([entityType, entityType]);
       assert.throws(
-          () => resolveFieldPathType(['component2'], tupleType),
-          `'component2' requested but largest component in tuple is 'component1'.`);
+          () => resolveFieldPathType(['third'], tupleType),
+          `The third tuple component was requested but tuple only has 2 components.`);
       assert.throws(
           () => resolveFieldPathType(['missing'], tupleType),
-          `Expected a tuple component accessor of the form 'componentN' but found 'missing'.`);
+          `Expected a tuple component accessor of the form 'first', 'second', etc., but found 'missing'.`);
     });
 
     it('rejects missing fields nested inside tuples', async () => {
@@ -289,7 +289,7 @@ describe('field path validation', () => {
       `);
       const tupleType = new TupleType([entityType, entityType]);
       assert.throws(
-          () => resolveFieldPathType(['component1', 'missing'], tupleType),
+          () => resolveFieldPathType(['second', 'missing'], tupleType),
           `Schema 'Foo {foo: Text}' does not contain field 'missing'.`);
     });
   });

--- a/src/runtime/tests/field-path-test.ts
+++ b/src/runtime/tests/field-path-test.ts
@@ -9,7 +9,7 @@
  */
 
 import {resolveFieldPathType} from '../field-path.js';
-import {EntityType, SingletonType, CollectionType, TypeVariable} from '../type.js';
+import {EntityType, SingletonType, CollectionType, TypeVariable, TupleType} from '../type.js';
 import {Manifest} from '../manifest.js';
 import {assert} from '../../platform/chai-web.js';
 import {deleteFieldRecursively} from '../util.js';
@@ -247,6 +247,50 @@ describe('field path validation', () => {
       assert.strictEqual(resolveFieldPathType(['name'], type), 'Text');
       assert.deepEqual(resolveFieldPathType(['friends'], type), expectedPersonType);
       assert.strictEqual(resolveFieldPathType(['friends', 'name'], type), 'Text');
+    });
+  });
+
+  describe('tuples', () => {
+    it('supports tuples', async () => {
+      const fooType = await parseTypeFromSchema(`
+        schema Foo
+          foo: Text
+      `);
+      const barType = await parseTypeFromSchema(`
+        schema Bar
+          bar: Text
+      `);
+      const tupleType = new TupleType([fooType, barType]);
+      assert.deepEqual(resolveFieldPathType([], tupleType), tupleType);
+      assert.deepEqual(resolveFieldPathType(['component0'], tupleType), fooType);
+      assert.strictEqual(resolveFieldPathType(['component0', 'foo'], tupleType), 'Text');
+      assert.deepEqual(resolveFieldPathType(['component1'], tupleType), barType);
+      assert.strictEqual(resolveFieldPathType(['component1', 'bar'], tupleType), 'Text');
+    });
+
+    it('rejects invalid tuple components', async () => {
+      const entityType = await parseTypeFromSchema(`
+        schema Foo
+          foo: Text
+      `);
+      const tupleType = new TupleType([entityType, entityType]);
+      assert.throws(
+          () => resolveFieldPathType(['component2'], tupleType),
+          `'component2' requested but largest component in tuple is 'component1'.`);
+      assert.throws(
+          () => resolveFieldPathType(['missing'], tupleType),
+          `Expected a tuple component accessor of the form 'componentN' but found 'missing'.`);
+    });
+
+    it('rejects missing fields nested inside tuples', async () => {
+      const entityType = await parseTypeFromSchema(`
+        schema Foo
+          foo: Text
+      `);
+      const tupleType = new TupleType([entityType, entityType]);
+      assert.throws(
+          () => resolveFieldPathType(['component1', 'missing'], tupleType),
+          `Schema 'Foo {foo: Text}' does not contain field 'missing'.`);
     });
   });
 });


### PR DESCRIPTION
(Only need to review commits f71e117 and 7dd8681)