### PR TITLE
Add cancelAll to SchedulerProvider interface

### DIFF
--- a/java/arcs/core/host/AbstractArcHost.kt
+++ b/java/arcs/core/host/AbstractArcHost.kt
@@ -123,6 +123,7 @@ abstract class AbstractArcHost(
         contextCache.clear()
         pausedArcs.clear()
         scope.cancel()
+        schedulerProvider.cancelAll()
     }
 
     /**

--- a/java/arcs/core/host/SchedulerProvider.kt
+++ b/java/arcs/core/host/SchedulerProvider.kt
@@ -21,4 +21,7 @@ import arcs.core.util.Scheduler
  */
 interface SchedulerProvider {
     operator fun invoke(arcId: String): Scheduler
+
+    /** Cancel all schedulers that this [SchedulerProvider] has created. */
+    fun cancelAll()
 }

--- a/java/arcs/jvm/host/JvmHost.kt
+++ b/java/arcs/jvm/host/JvmHost.kt
@@ -25,11 +25,4 @@ open class JvmHost(
     vararg particles: ParticleRegistration
 ) : AbstractArcHost(schedulerProvider, *particles) {
     override val platformTime: Time = JvmTime
-
-    override suspend fun shutdown() {
-        super.shutdown()
-        if (schedulerProvider is JvmSchedulerProvider) {
-            schedulerProvider.cancelAll()
-        }
-    }
 }

--- a/java/arcs/jvm/host/JvmSchedulerProvider.kt
+++ b/java/arcs/jvm/host/JvmSchedulerProvider.kt
@@ -88,7 +88,7 @@ class JvmSchedulerProvider(
     }
 
     @Synchronized
-    fun cancelAll() {
+    override fun cancelAll() {
         schedulersByArcId.values.toList().forEach { it.cancel() }
         threads.forEach { it?.interrupt() }
     }

--- a/javatests/arcs/core/host/TestHost.kt
+++ b/javatests/arcs/core/host/TestHost.kt
@@ -9,6 +9,7 @@ class TestHost(
 ) : AbstractArcHost(
     object : SchedulerProvider {
         override fun invoke(arcId: String) = scheduler
+        override fun cancelAll() = scheduler.cancel()
     },
     *particles
 ) {


### PR DESCRIPTION
This seems like a reasonable piece of functionality to expose as part of
the SchedulerProvider interface, and removes the need for a runtime type
check.