### PR TITLE
Add timeout behavior to ReferenceModeStore's HoldQueue

### DIFF
--- a/java/arcs/core/storage/ReferenceModeStore.kt
+++ b/java/arcs/core/storage/ReferenceModeStore.kt
@@ -315,7 +315,8 @@ class ReferenceModeStore private constructor(
                         // clear-out the collection store before re-attempting the sync.
                         val ops = buildClearContainerStoreOps()
                         log.warning {
-                            "SyncRequest timed out, backing store is likely corrupted - sending " +
+                            "SyncRequest timed out after $BLOCKING_QUEUE_TIMEOUT_MILLIS " +
+                                "milliseconds, backing store is likely corrupted - sending " +
                                 "clear operations to container store."
                         }
                         log.debug { "Clear ops = $ops" }

--- a/java/arcs/core/storage/ReferenceModeStore.kt
+++ b/java/arcs/core/storage/ReferenceModeStore.kt
@@ -315,7 +315,7 @@ class ReferenceModeStore private constructor(
                         // clear-out the collection store before re-attempting the sync.
                         val ops = buildClearContainerStoreOps()
                         log.warning {
-                            "SyncRequest timed out, backing store is likely corrputed - sending " +
+                            "SyncRequest timed out, backing store is likely corrupted - sending " +
                                 "clear operations to container store."
                         }
                         log.debug { "Clear ops = $ops" }

--- a/java/arcs/core/storage/ReferenceModeStore.kt
+++ b/java/arcs/core/storage/ReferenceModeStore.kt
@@ -668,7 +668,8 @@ class ReferenceModeStore private constructor(
     companion object {
         /**
          * Timeout duration in milliseconds we are allowed to wait for results from the
-         * [BackingStore] during a [SyncRequest] or a call to [ReferenceModeStore.getLocalData].
+         * [BackingStore] during a [SyncRequest].
+         *
          * If this timeout is exceeded, we will assume the backing store is corrupt and will log a
          * warning and clear the container store.
          *

--- a/java/arcs/core/storage/util/HoldQueue.kt
+++ b/java/arcs/core/storage/util/HoldQueue.kt
@@ -74,11 +74,7 @@ class HoldQueue {
             // the onRelease method.
             queue[id]?.forEach { record ->
                 record.ids[id]
-                    ?.takeIf {
-                        val res = version dominates it
-                        if (!res) println("waiting for >= $it, but saw $version")
-                        res
-                    }
+                    ?.takeIf { version dominates it }
                     ?.let { record.ids.remove(id) }
 
                 if (record.ids.isEmpty()) {

--- a/java/arcs/core/storage/util/HoldQueue.kt
+++ b/java/arcs/core/storage/util/HoldQueue.kt
@@ -33,6 +33,9 @@ class HoldQueue {
     /**
      * Enqueues a collection of [Entities] into the [HoldQueue]. When they are ready, [onRelease]
      * will be called.
+     *
+     * @return an identifier for the hold record which can be used to remove a hold using
+     * [removeFromQueue].
      */
     suspend fun enqueue(entities: Collection<Entity>, onRelease: suspend () -> Unit): Int {
         val holdRecord = Record(
@@ -57,7 +60,7 @@ class HoldQueue {
      */
     suspend fun removeFromQueue(enqueueId: Int) = mutex.withLock {
         queue.values.forEach { records ->
-            records.removeIf { it.hashCode() == enqueueId }
+            records.removeAll { it.hashCode() == enqueueId }
         }
     }
 

--- a/java/arcs/core/storage/util/SendQueue.kt
+++ b/java/arcs/core/storage/util/SendQueue.kt
@@ -14,6 +14,14 @@ package arcs.core.storage.util
 import arcs.core.common.ReferenceId
 import arcs.core.crdt.VersionMap
 import arcs.core.storage.Reference
+import kotlin.coroutines.coroutineContext
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
@@ -48,17 +56,52 @@ class SendQueue(
      * Enqueues a send function on the send queue, blocking on its execution until the provided
      * [references] are all available in the [backingStore].
      */
-    suspend fun enqueueBlocking(references: List<Reference>, runnable: suspend () -> Unit) {
-        mutex.withLock {
+    suspend fun enqueueBlocking(references: List<Reference>, runnable: suspend () -> Unit): Deferred<Unit> {
+        val completableDeferred = CompletableDeferred<Unit>()
+        val queuedBlockName = mutex.withLock {
             val block = "${currentBlock++}"
-            queue.add(PendingSend.Blocking(block, runnable))
-            holdQueue.enqueue(references.map { HoldQueue.Entity(it.id, it.version?.copy()) }) {
+            val holdQueueId = holdQueue.enqueue(
+                references.map { HoldQueue.Entity(it.id, it.version?.copy()) }
+            ) {
                 drain(block)
             }
+            queue.add(
+                PendingSend.Blocking(block, holdQueueId) {
+                    try {
+                        runnable()
+                    } finally {
+                        completableDeferred.complete(Unit)
+                    }
+                }
+            )
+            block
         }
 
         // Additionally, we can drain any non-blocked items.
         if (drainOnEnqueue) drain()
+
+        val localScope = CoroutineScope(Dispatchers.Unconfined + Job())
+        completableDeferred.invokeOnCompletion {
+            if (it is CancellationException) localScope.launch {
+                removeBlocking(queuedBlockName)
+            }
+        }
+
+        return completableDeferred
+    }
+
+    /**
+     * Removes a send function from the send queue which was blocking on the availability of
+     * references in a [backingStore].
+     */
+    suspend fun removeBlocking(enqueueId: String) = mutex.withLock {
+        val toRemove = queue.filter {
+            if (it is PendingSend.Blocking && it.block == enqueueId) {
+                holdQueue.removeFromQueue(it.holdQueueId)
+                true
+            } else false
+        }
+        queue.removeAll(toRemove)
     }
 
     /**
@@ -109,6 +152,7 @@ class SendQueue(
          */
         data class Blocking(
             val block: String,
+            val holdQueueId: Int,
             override val fn: suspend () -> Unit
         ) : PendingSend(fn)
     }

--- a/java/arcs/core/storage/util/SendQueue.kt
+++ b/java/arcs/core/storage/util/SendQueue.kt
@@ -14,7 +14,6 @@ package arcs.core.storage.util
 import arcs.core.common.ReferenceId
 import arcs.core.crdt.VersionMap
 import arcs.core.storage.Reference
-import kotlin.coroutines.coroutineContext
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
@@ -56,7 +55,10 @@ class SendQueue(
      * Enqueues a send function on the send queue, blocking on its execution until the provided
      * [references] are all available in the [backingStore].
      */
-    suspend fun enqueueBlocking(references: List<Reference>, runnable: suspend () -> Unit): Deferred<Unit> {
+    suspend fun enqueueBlocking(
+        references: List<Reference>,
+        runnable: suspend () -> Unit
+    ): Deferred<Unit> {
         val completableDeferred = CompletableDeferred<Unit>()
         val queuedBlockName = mutex.withLock {
             val block = "${currentBlock++}"

--- a/java/arcs/core/storage/util/SendQueue.kt
+++ b/java/arcs/core/storage/util/SendQueue.kt
@@ -54,6 +54,9 @@ class SendQueue(
     /**
      * Enqueues a send function on the send queue, blocking on its execution until the provided
      * [references] are all available in the [backingStore].
+     *
+     * The [Deferred] returned by this method will be resolved when the [runnable] has finished
+     * executing.
      */
     suspend fun enqueueBlocking(
         references: List<Reference>,
@@ -84,6 +87,7 @@ class SendQueue(
 
         val localScope = CoroutineScope(Dispatchers.Unconfined + Job())
         completableDeferred.invokeOnCompletion {
+            // If the deferred was canceled, remove the runnable block from the queue.
             if (it is CancellationException) localScope.launch {
                 removeBlocking(queuedBlockName)
             }

--- a/javatests/arcs/core/storage/ReferenceModeStoreStabilityTest.kt
+++ b/javatests/arcs/core/storage/ReferenceModeStoreStabilityTest.kt
@@ -1,0 +1,391 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.core.storage
+
+import arcs.core.crdt.CrdtEntity
+import arcs.core.crdt.CrdtSet
+import arcs.core.crdt.CrdtSingleton
+import arcs.core.crdt.VersionMap
+import arcs.core.data.CollectionType
+import arcs.core.data.EntityType
+import arcs.core.data.FieldType
+import arcs.core.data.RawEntity
+import arcs.core.data.Schema
+import arcs.core.data.SchemaFields
+import arcs.core.data.SingletonType
+import arcs.core.data.util.toReferencable
+import arcs.core.storage.driver.RamDisk
+import arcs.core.storage.driver.RamDiskDriverProvider
+import arcs.core.storage.driver.VolatileEntry
+import arcs.core.storage.keys.RamDiskStorageKey
+import arcs.core.storage.referencemode.RefModeStoreData
+import arcs.core.storage.referencemode.RefModeStoreOp
+import arcs.core.storage.referencemode.ReferenceModeStorageKey
+import arcs.core.util.testutil.LogRule
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class ReferenceModeStoreStabilityTest {
+    @get:Rule
+    val log = LogRule()
+
+    private val backingKey = RamDiskStorageKey("backing_data")
+    private val containerKey = RamDiskStorageKey("container")
+    private val storageKey = ReferenceModeStorageKey(backingKey, containerKey)
+    private val schema = Schema(
+        emptySet(),
+        SchemaFields(mapOf("name" to FieldType.Text), emptyMap()),
+        "abc"
+    )
+
+    @Before
+    fun setUp() {
+        ReferenceModeStore.BLOCKING_QUEUE_TIMEOUT_MILLIS = 2000
+        RamDisk.clear()
+        RamDiskDriverProvider()
+    }
+
+    @Test
+    fun singleton_syncRequest_missingBackingData_timesOutAnd_resolvesAsEmpty() = runBlocking {
+        val singletonCrdt = CrdtSingleton<Reference>()
+        singletonCrdt.applyOperation(
+            CrdtSingleton.Operation.Update(
+                "foo",
+                VersionMap("foo" to 1),
+                Reference(
+                    "foo_value",
+                    backingKey,
+                    VersionMap("foo" to 1)
+                )
+            )
+        )
+        RamDisk.memory[containerKey] = VolatileEntry(singletonCrdt.data, 1)
+
+        val store = Store(
+            StoreOptions<RefModeStoreData, RefModeStoreOp, RawEntity?>(
+                storageKey,
+                SingletonType(EntityType(schema)),
+                StorageMode.ReferenceMode
+            )
+        ).activate()
+
+        val modelValue = CompletableDeferred<RefModeStoreData.Singleton>()
+        val id = store.on(
+            ProxyCallback {
+                if (it is ProxyMessage.ModelUpdate<*, *, *>) {
+                    modelValue.complete(it.model as RefModeStoreData.Singleton)
+                }
+            }
+        )
+
+        store.onProxyMessage(ProxyMessage.SyncRequest(id))
+
+        assertThat(modelValue.await().values).isEmpty()
+        assertThat(RamDisk.memory.get<CrdtSingleton.Data<RawEntity>>(containerKey)?.data?.values)
+            .isEmpty()
+    }
+
+    @Test
+    fun singleton_getLocalData_missingBackingData_timesOutAnd_resolvesAsEmpty() = runBlocking {
+        val singletonCrdt = CrdtSingleton<Reference>()
+        singletonCrdt.applyOperation(
+            CrdtSingleton.Operation.Update(
+                "foo",
+                VersionMap("foo" to 1),
+                Reference(
+                    "foo_value",
+                    backingKey,
+                    VersionMap("foo" to 1)
+                )
+            )
+        )
+        RamDisk.memory[containerKey] = VolatileEntry(singletonCrdt.data, 1)
+
+        val store = Store(
+            StoreOptions<RefModeStoreData, RefModeStoreOp, RawEntity?>(
+                storageKey,
+                SingletonType(EntityType(schema)),
+                StorageMode.ReferenceMode
+            )
+        ).activate()
+
+        assertThat(store.getLocalData().values).isEmpty()
+        assertThat(RamDisk.memory.get<CrdtSingleton.Data<RawEntity>>(containerKey)?.data?.values)
+            .isEmpty()
+    }
+
+    @Test
+    fun collection_syncRequest_missingBackingData_timesOutAnd_resolvesAsEmpty() = runBlocking {
+        val setCrdt = CrdtSet<Reference>()
+        setCrdt.applyOperation(
+            CrdtSet.Operation.Add(
+                "foo",
+                VersionMap("foo" to 1),
+                Reference(
+                    "foo_value",
+                    backingKey,
+                    VersionMap("foo" to 1)
+                )
+            )
+        )
+        RamDisk.memory[containerKey] = VolatileEntry(setCrdt.data, 1)
+
+        val store = Store(
+            StoreOptions<RefModeStoreData, RefModeStoreOp, RawEntity?>(
+                storageKey,
+                CollectionType(EntityType(schema)),
+                StorageMode.ReferenceMode
+            )
+        ).activate()
+
+        val modelValue = CompletableDeferred<RefModeStoreData.Set>()
+        val id = store.on(
+            ProxyCallback {
+                if (it is ProxyMessage.ModelUpdate<*, *, *>) {
+                    modelValue.complete(it.model as RefModeStoreData.Set)
+                }
+            }
+        )
+
+        store.onProxyMessage(ProxyMessage.SyncRequest(id))
+
+        assertThat(modelValue.await().values).isEmpty()
+        assertThat(RamDisk.memory.get<CrdtSet.Data<RawEntity>>(containerKey)?.data?.values)
+            .isEmpty()
+    }
+
+    @Test
+    fun collection_getLocalData_missingBackingData_timesOutAnd_resolvesAsEmpty() = runBlocking {
+        val setCrdt = CrdtSet<Reference>()
+        setCrdt.applyOperation(
+            CrdtSet.Operation.Add(
+                "foo",
+                VersionMap("foo" to 1),
+                Reference(
+                    "foo_value",
+                    backingKey,
+                    VersionMap("foo" to 1)
+                )
+            )
+        )
+        RamDisk.memory[containerKey] = VolatileEntry(setCrdt.data, 1)
+
+        val store = Store(
+            StoreOptions<RefModeStoreData, RefModeStoreOp, RawEntity?>(
+                storageKey,
+                CollectionType(EntityType(schema)),
+                StorageMode.ReferenceMode
+            )
+        ).activate()
+
+        assertThat(store.getLocalData().values).isEmpty()
+        assertThat(RamDisk.memory.get<CrdtSet.Data<RawEntity>>(containerKey)?.data?.values)
+            .isEmpty()
+    }
+
+    @Test
+    fun collection_partiallyMissingBackingData_timesOutAnd_resolvesAsEmpty() = runBlocking {
+        val setCrdt = CrdtSet<Reference>()
+        setCrdt.applyOperation(
+            CrdtSet.Operation.Add(
+                "foo",
+                VersionMap("foo" to 1),
+                Reference(
+                    "foo_value",
+                    backingKey,
+                    VersionMap("foo" to 1)
+                )
+            )
+        )
+        setCrdt.applyOperation(
+            CrdtSet.Operation.Add(
+                "foo",
+                VersionMap("foo" to 2),
+                Reference(
+                    "foo_value_2",
+                    backingKey,
+                    VersionMap("foo" to 2)
+                )
+            )
+        )
+        RamDisk.memory[containerKey] = VolatileEntry(setCrdt.data, 1)
+
+        val entityCrdt = CrdtEntity(VersionMap(), RawEntity("foo_value", setOf("name"), emptySet()))
+        entityCrdt.applyOperation(
+            CrdtEntity.Operation.SetSingleton(
+                "foo",
+                VersionMap("foo" to 1),
+                "name",
+                CrdtEntity.ReferenceImpl("Alice".toReferencable().id)
+            )
+        )
+        RamDisk.memory[backingKey.childKeyWithComponent("foo_value")] =
+            VolatileEntry(entityCrdt.data, 1)
+
+        val store = Store(
+            StoreOptions<RefModeStoreData, RefModeStoreOp, RawEntity?>(
+                storageKey,
+                CollectionType(EntityType(schema)),
+                StorageMode.ReferenceMode
+            )
+        ).activate()
+
+        val modelValue = CompletableDeferred<RefModeStoreData.Set>()
+        val id = store.on(
+            ProxyCallback {
+                if (it is ProxyMessage.ModelUpdate<*, *, *>) {
+                    modelValue.complete(it.model as RefModeStoreData.Set)
+                }
+            }
+        )
+
+        store.onProxyMessage(ProxyMessage.SyncRequest(id))
+
+        assertThat(modelValue.await().values).isEmpty()
+        assertThat(RamDisk.memory.get<CrdtSet.Data<RawEntity>>(containerKey)?.data?.values)
+            .isEmpty()
+    }
+
+    @Test
+    fun singleton_existingButOldBackingData_timesOutAnd_resolvesAsEmpty() = runBlocking {
+        val singletonCrdt = CrdtSingleton<Reference>()
+        singletonCrdt.applyOperation(
+            CrdtSingleton.Operation.Update(
+                "foo",
+                VersionMap("foo" to 1),
+                Reference(
+                    "foo_value",
+                    backingKey,
+                    VersionMap("foo" to 1)
+                )
+            )
+        )
+        singletonCrdt.applyOperation(
+            CrdtSingleton.Operation.Update(
+                "foo",
+                VersionMap("foo" to 2),
+                Reference(
+                    "foo_value",
+                    backingKey,
+                    VersionMap("foo" to 2)
+                )
+            )
+        )
+        RamDisk.memory[containerKey] = VolatileEntry(singletonCrdt.data, 1)
+
+        val entityCrdt = CrdtEntity(VersionMap(), RawEntity("foo_value", setOf("name"), emptySet()))
+        entityCrdt.applyOperation(
+            CrdtEntity.Operation.SetSingleton(
+                "foo",
+                VersionMap("foo" to 1),
+                "name",
+                CrdtEntity.ReferenceImpl("Alice".toReferencable().id)
+            )
+        )
+        RamDisk.memory[backingKey.childKeyWithComponent("foo_value")] =
+            VolatileEntry(entityCrdt.data, 1)
+
+        val store = Store(
+            StoreOptions<RefModeStoreData, RefModeStoreOp, RawEntity?>(
+                storageKey,
+                SingletonType(EntityType(schema)),
+                StorageMode.ReferenceMode
+            )
+        ).activate()
+
+        val modelValue = CompletableDeferred<RefModeStoreData.Singleton>()
+        val id = store.on(
+            ProxyCallback {
+                if (it is ProxyMessage.ModelUpdate<*, *, *>) {
+                    modelValue.complete(it.model as RefModeStoreData.Singleton)
+                }
+            }
+        )
+
+        store.onProxyMessage(ProxyMessage.SyncRequest(id))
+
+        assertThat(modelValue.await().values).isEmpty()
+        assertThat(RamDisk.memory.get<CrdtSingleton.Data<RawEntity>>(containerKey)?.data?.values)
+            .isEmpty()
+    }
+
+    @Test
+    fun collection_existingButOldBackingData_timesOutAnd_resolvesAsEmpty() = runBlocking {
+        val setCrdt = CrdtSet<Reference>()
+        setCrdt.applyOperation(
+            CrdtSet.Operation.Add(
+                "foo",
+                VersionMap("foo" to 1),
+                Reference(
+                    "foo_value",
+                    backingKey,
+                    VersionMap("foo" to 1)
+                )
+            )
+        )
+        setCrdt.applyOperation(
+            CrdtSet.Operation.Add(
+                "foo",
+                VersionMap("foo" to 2),
+                Reference(
+                    "foo_value",
+                    backingKey,
+                    VersionMap("foo" to 2)
+                )
+            )
+        )
+        RamDisk.memory[containerKey] = VolatileEntry(setCrdt.data, 1)
+
+        val entityCrdt = CrdtEntity(VersionMap(), RawEntity("foo_value", setOf("name"), emptySet()))
+        entityCrdt.applyOperation(
+            CrdtEntity.Operation.SetSingleton(
+                "foo",
+                VersionMap("foo" to 1),
+                "name",
+                CrdtEntity.ReferenceImpl("Alice".toReferencable().id)
+            )
+        )
+        RamDisk.memory[backingKey.childKeyWithComponent("foo_value")] =
+            VolatileEntry(entityCrdt.data, 1)
+
+        val store = Store(
+            StoreOptions<RefModeStoreData, RefModeStoreOp, RawEntity?>(
+                storageKey,
+                CollectionType(EntityType(schema)),
+                StorageMode.ReferenceMode
+            )
+        ).activate()
+
+        val modelValue = CompletableDeferred<RefModeStoreData.Set>()
+        val id = store.on(
+            ProxyCallback {
+                if (it is ProxyMessage.ModelUpdate<*, *, *>) {
+                    modelValue.complete(it.model as RefModeStoreData.Set)
+                }
+            }
+        )
+
+        store.onProxyMessage(ProxyMessage.SyncRequest(id))
+
+        assertThat(modelValue.await().values).isEmpty()
+        assertThat(RamDisk.memory.get<CrdtSet.Data<RawEntity>>(containerKey)?.data?.values)
+            .isEmpty()
+    }
+}

--- a/javatests/arcs/core/storage/ReferenceModeStoreTest.kt
+++ b/javatests/arcs/core/storage/ReferenceModeStoreTest.kt
@@ -586,7 +586,6 @@ class ReferenceModeStoreTest {
         val job = Job(coroutineContext[Job.Key])
         var backingStoreSent = false
         val id = activeStore.on(ProxyCallback {
-            log("active store saw: $it")
             if (!backingStoreSent) {
                 job.completeExceptionally(
                     AssertionError("Backing store data should've been sent first.")
@@ -605,9 +604,7 @@ class ReferenceModeStoreTest {
         })
 
         val containerJob = launch {
-            log("sending data to container")
             activeStore.containerStore.onReceive(referenceCollection.data, id + 1)
-            log("data sent to container")
         }
         containerJob.join()
 
@@ -633,10 +630,8 @@ class ReferenceModeStoreTest {
 
         val backingStore = activeStore.backingStore.store("an-id")
         backingStore.store.onReceive(entityCrdt.data, id + 2)
-        log("data sent to backing store")
 
         activeStore.idle()
-        log("store went idle")
 
         job.join()
         containerJob.join()

--- a/javatests/arcs/core/storage/ReferenceModeStoreTest.kt
+++ b/javatests/arcs/core/storage/ReferenceModeStoreTest.kt
@@ -634,7 +634,6 @@ class ReferenceModeStoreTest {
         activeStore.idle()
 
         job.join()
-        containerJob.join()
     }
 
     // region Helpers


### PR DESCRIPTION
Makes the ReferenceModeStore clear its collection/singleton if the backing store times out during a sync.

Fixes http://b/158490596