### PR TITLE
Resolve remaining deprecated usages of startArcForPlan.

### DIFF
--- a/java/arcs/core/allocator/Allocator.kt
+++ b/java/arcs/core/allocator/Allocator.kt
@@ -63,16 +63,6 @@ class Allocator private constructor(
     private val partitionMap: MutableMap<ArcId, List<Plan.Partition>> = mutableMapOf()
 
     /**
-     * Start a new Arc given a [Plan] and return the generated [ArcId].
-     */
-    @Deprecated(
-        "Use startArcForPlan(plan) to retrieve the ArcId via Arc.id",
-        replaceWith = ReplaceWith("startArcForPlan(plan).id", "arcs.core.allocator.Arc")
-    )
-    suspend fun startArcForPlan(arcName: String, plan: Plan) =
-        startArcForPlan(plan, arcName).waitForStart().id
-
-    /**
      * Start a new Arc given a [Plan] and return an [Arc].
      */
     suspend fun startArcForPlan(plan: Plan): Arc = startArcForPlan(plan, "arc")

--- a/javatests/arcs/android/e2e/testapp/TestActivity.kt
+++ b/javatests/arcs/android/e2e/testapp/TestActivity.kt
@@ -154,8 +154,8 @@ class TestActivity : AppCompatActivity() {
                 )
             )
         )
-        allocator?.startArcForPlan("Person", PersonRecipePlan)
-            ?.also { allocator?.stopArc(it) }
+        allocator?.startArcForPlan(PersonRecipePlan)
+            ?.also { allocator?.stopArc(it.id) }
     }
 
     private suspend fun startResurrectionArc() {
@@ -171,7 +171,7 @@ class TestActivity : AppCompatActivity() {
                 )
             )
         )
-        resurrectionArcId = allocator?.startArcForPlan("Animal", AnimalRecipePlan)
+        resurrectionArcId = allocator?.startArcForPlan(AnimalRecipePlan)?.id
     }
 
     private fun stopReadService() {
@@ -208,7 +208,7 @@ class TestActivity : AppCompatActivity() {
                 )
             )
         )
-        val arcId = allocator.startArcForPlan("Person", PersonRecipePlan)
+        val arcId = allocator.startArcForPlan(PersonRecipePlan).id
         allocator.stopArc(arcId)
     }
 


### PR DESCRIPTION
Not to land until cl/316190348 lands.