### PR TITLE
A number of small improvements and tests for Schema2kotlin / KotlinGenerator

### DIFF
--- a/src/tools/kotlin-generation-utils.ts
+++ b/src/tools/kotlin-generation-utils.ts
@@ -91,6 +91,15 @@ export class KotlinGenerationUtils {
   indent(block: string, numberOfIndents: number = 1): string  {
     return leftPad(block, this.pref.indent * numberOfIndents);
   }
+
+  /**
+   * Joins a list of lines, indenting all but the first one.
+   */
+  indentFollowing(lines: string[], numberOfIndents: number) {
+    return lines
+      .map((line, idx) => idx > 0 ? ' '.repeat(this.pref.indent * numberOfIndents) + line : line)
+      .join('\n');
+  }
 }
 
 /** Everyone's favorite NPM module, install not required. */

--- a/src/tools/schema2cpp.ts
+++ b/src/tools/schema2cpp.ts
@@ -12,7 +12,9 @@ import {SchemaNode} from './schema2graph.js';
 import {ParticleSpec} from '../runtime/particle-spec.js';
 import {Type} from '../runtime/type.js';
 import {Dictionary} from '../runtime/hot.js';
-import {CONSOLE_CLIENT_NAME} from '../tracelib/systrace-clients.js';
+
+// TODO(cypher1): Generate refinements and predicates for cpp
+// https://github.com/PolymerLabs/arcs/issues/4884
 
 // https://en.cppreference.com/w/cpp/keyword
 // [...document.getElementsByClassName('wikitable')[0].getElementsByTagName('code')].map(x => x.innerHTML);
@@ -211,12 +213,7 @@ class CppGenerator implements ClassGenerator {
     return getTypeInfo(name).defaultVal;
   }
 
-  generatePredicates() {
-    // TODO(cypher1): Generate refinements and predicates for cpp
-    // https://github.com/PolymerLabs/arcs/issues/4884
-  }
-
-  generate(schemaHash: string, fieldCount: number): string {
+  generate(fieldCount: number): string {
     const name = this.node.fullEntityClassName;
     console.log(`name: ${name}`);
     const aliases = this.node.sources.map(s => s.fullName);
@@ -277,7 +274,7 @@ protected:
   ${name}(const ${name}&) = default;
   ${name}& operator=(const ${name}&) = default;
 
-  static const char* _schema_hash() { return "${schemaHash}"; }
+  static const char* _schema_hash() { return "${this.node.hash}"; }
   static const int _field_count = ${fieldCount};
 
   ${this.fields.join('\n  ')}

--- a/src/tools/schema2graph.ts
+++ b/src/tools/schema2graph.ts
@@ -68,6 +68,13 @@ export class SchemaNode {
   // ensure that nested schemas are generated before the references that rely on them.
   refs = new Map<string, SchemaNode>();
 
+  hash: string | null = null;
+
+  async calculateHash(): Promise<void> {
+    this.hash = await this.schema.hash();
+    await Promise.all([...this.refs.values()].map(n => n.calculateHash));
+  }
+
   get uniqueSchema() {
     return !this.allSchemaNodes.some(s => s.schema !== this.schema && s.schema.name === this.schema.name);
   }

--- a/src/tools/schema2kotlin.ts
+++ b/src/tools/schema2kotlin.ts
@@ -198,7 +198,7 @@ ${typeAliases.join(`\n`)}
 abstract class Abstract${particle.name} : ${this.opts.wasm ? 'WasmParticleImpl' : 'BaseParticle'}() {
     ${this.opts.wasm ? '' : 'override '}val handles: Handles = Handles(${this.opts.wasm ? 'this' : ''})
 
-    ${classes.join(`\n    `)}
+    ${ktUtils.indentFollowing(classes, 1)}
 
     ${handleClassDecl}
 }
@@ -214,7 +214,7 @@ abstract class Abstract${particle.name} : ${this.opts.wasm ? 'WasmParticleImpl' 
 
     nodeGenerators.forEach(nodeGenerator => {
       const kotlinGenerator = <KotlinGenerator>nodeGenerator.generator;
-      classes.push(kotlinGenerator.generateClasses(nodeGenerator.hash));
+      classes.push(kotlinGenerator.generateClasses());
       typeAliases.push(...kotlinGenerator.generateAliases(particleName));
     });
 
@@ -248,7 +248,7 @@ abstract class Abstract${particle.name} : ${this.opts.wasm ? 'WasmParticleImpl' 
     )`;
 
     return `${header} {
-        ${handleDecls.join('\n        ')}
+        ${ktUtils.indentFollowing(handleDecls, 2)}
     }`;
   }
 

--- a/src/tools/tests/goldens/generated-schemas.wasm.kt
+++ b/src/tools/tests/goldens/generated-schemas.wasm.kt
@@ -37,7 +37,7 @@ abstract class AbstractGold : WasmParticleImpl() {
 
 
         fun reset() {
-          val_ = ""
+            val_ = ""
         }
 
         override fun encodeEntity(): NullTermByteArray {
@@ -160,7 +160,7 @@ abstract class AbstractGold : WasmParticleImpl() {
 
 
         fun reset() {
-          name = ""
+            name = ""
             age = 0.0
             lastCall = 0.0
             address = ""
@@ -173,12 +173,12 @@ abstract class AbstractGold : WasmParticleImpl() {
             val encoder = StringEncoder()
             encoder.encode("", entityId)
             name.let { encoder.encode("name:T", name) }
-        age.let { encoder.encode("age:N", age) }
-        lastCall.let { encoder.encode("lastCall:N", lastCall) }
-        address.let { encoder.encode("address:T", address) }
-        favoriteColor.let { encoder.encode("favoriteColor:T", favoriteColor) }
-        birthDayMonth.let { encoder.encode("birthDayMonth:N", birthDayMonth) }
-        birthDayDOM.let { encoder.encode("birthDayDOM:N", birthDayDOM) }
+            age.let { encoder.encode("age:N", age) }
+            lastCall.let { encoder.encode("lastCall:N", lastCall) }
+            address.let { encoder.encode("address:T", address) }
+            favoriteColor.let { encoder.encode("favoriteColor:T", favoriteColor) }
+            birthDayMonth.let { encoder.encode("birthDayMonth:N", birthDayMonth) }
+            birthDayDOM.let { encoder.encode("birthDayDOM:N", birthDayDOM) }
             return encoder.toNullTermByteArray()
         }
 
@@ -279,7 +279,7 @@ abstract class AbstractGold : WasmParticleImpl() {
 
 
         fun reset() {
-          num = 0.0
+            num = 0.0
         }
 
         override fun encodeEntity(): NullTermByteArray {
@@ -373,7 +373,7 @@ abstract class AbstractGold : WasmParticleImpl() {
 
 
         fun reset() {
-          num = 0.0
+            num = 0.0
             txt = ""
             lnk = ""
             flg = false
@@ -383,9 +383,9 @@ abstract class AbstractGold : WasmParticleImpl() {
             val encoder = StringEncoder()
             encoder.encode("", entityId)
             num.let { encoder.encode("num:N", num) }
-        txt.let { encoder.encode("txt:T", txt) }
-        lnk.let { encoder.encode("lnk:U", lnk) }
-        flg.let { encoder.encode("flg:B", flg) }
+            txt.let { encoder.encode("txt:T", txt) }
+            lnk.let { encoder.encode("lnk:U", lnk) }
+            flg.let { encoder.encode("flg:B", flg) }
             return encoder.toNullTermByteArray()
         }
 
@@ -517,7 +517,7 @@ abstract class AbstractGold : WasmParticleImpl() {
 
 
         fun reset() {
-          name = ""
+            name = ""
             age = 0.0
             lastCall = 0.0
             address = ""
@@ -530,12 +530,12 @@ abstract class AbstractGold : WasmParticleImpl() {
             val encoder = StringEncoder()
             encoder.encode("", entityId)
             name.let { encoder.encode("name:T", name) }
-        age.let { encoder.encode("age:N", age) }
-        lastCall.let { encoder.encode("lastCall:N", lastCall) }
-        address.let { encoder.encode("address:T", address) }
-        favoriteColor.let { encoder.encode("favoriteColor:T", favoriteColor) }
-        birthDayMonth.let { encoder.encode("birthDayMonth:N", birthDayMonth) }
-        birthDayDOM.let { encoder.encode("birthDayDOM:N", birthDayDOM) }
+            age.let { encoder.encode("age:N", age) }
+            lastCall.let { encoder.encode("lastCall:N", lastCall) }
+            address.let { encoder.encode("address:T", address) }
+            favoriteColor.let { encoder.encode("favoriteColor:T", favoriteColor) }
+            birthDayMonth.let { encoder.encode("birthDayMonth:N", birthDayMonth) }
+            birthDayDOM.let { encoder.encode("birthDayDOM:N", birthDayDOM) }
             return encoder.toNullTermByteArray()
         }
 

--- a/src/tools/tests/kotlin-generation-utils-test.ts
+++ b/src/tools/tests/kotlin-generation-utils-test.ts
@@ -148,4 +148,20 @@ mapOf(
       );
     });
   });
+  describe('indentFollowingLines', () => {
+    it('indents only following lines', () => {
+      assert.equal(`
+        ${ktUtils.indentFollowing(['foo', 'bar', 'baz'], 2)}
+            ${ktUtils.indentFollowing(['abc', 'def'], 3)}
+        ${ktUtils.indentFollowing(['yay'], 2)}
+      `, `
+        foo
+        bar
+        baz
+            abc
+            def
+        yay
+      `);
+    });
+  });
 });

--- a/src/tools/tests/schema2wasm-test.ts
+++ b/src/tools/tests/schema2wasm-test.ts
@@ -40,10 +40,7 @@ class Schema2Mock extends Schema2Base {
         collector.adds.push(field + ':' + typeName[0] + refInfo + (isOptional ? '?' : ''));
       },
 
-      generatePredicates() {
-      },
-
-      generate(schemaHash: string, fieldCount: number): string {
+      generate(fieldCount: number): string {
         collector.count = fieldCount;
         return '';
       }


### PR DESCRIPTION
A number of things:

* Hash of the schema is now placed on SchemaNode, instead of the NodeAndGenerator, which is conceptually a better place for it as well as frees us from passing the hash explicitly to the class generator.
* Removes `generatePredicates` from the `ClassGenerator` interface. It should never be placed there, as it add unnecessary state. Refinement and query code should be instead calculated when they are needed in the code generating the schema - which is what is done now.
* Adds `ktUtils.indentFollowing(lines: string[], numberOfIndents: number)` to fix up the `lines.join('\n --lots of spaces-- ')` pattern with something nicer. This leads to generating correct indentation for wasm files - which shows up in the update of goldens.
* A set of unit tests for schema object generation in Kotlin.
* Pulls out all the pieces of the Entity class generation into their own methods, so that we can test each piece in separation and have nicer code organization, see this:
```
  generateClasses(): string {
    return `\
    ${this.generateClassDefinition()} {
        ${this.generateFieldsDefinitions()}
        ${this.generateCopyMethods()}
        ${this.maybeGenerateWasmSpecificMethods()}
        ${this.generateEntitySpec()}
    }`;
  }
```
