### PR TITLE
Add annotations in kt and start using them in Plan and Handle

### DIFF
--- a/java/arcs/core/data/Annotation.kt
+++ b/java/arcs/core/data/Annotation.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.core.data
+
+/**
+ * An Arcs annotations containing additional information on an Arcs manifest element.
+ * An Annotation may be attached to a plan, particle, handle, type etc.
+ */
+data class Annotation(val name: String, val params: Map<String, AnnotationParam>)

--- a/java/arcs/core/data/AnnotationParam.kt
+++ b/java/arcs/core/data/AnnotationParam.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.core.data
+
+/** [Annotation] parameter's value: may be string, numeric or boolean. */
+sealed class AnnotationParam {
+    data class Str(val value: String) : AnnotationParam()
+    data class Num(val value: Int) : AnnotationParam()
+    data class Bool(val value: Boolean) : AnnotationParam()
+}

--- a/java/arcs/core/data/Plan.kt
+++ b/java/arcs/core/data/Plan.kt
@@ -40,10 +40,13 @@ open class Plan(
     val arcId: String?
         get() {
             return annotations.find { it.name == "arcId" }?.let {
-                val idParam = requireNotNull(it.params["id"])
+                val idParam = requireNotNull(it.params["id"]) {
+                    "Annotation arcId missing 'id' parameter"
+                }
                 return when (idParam) {
                     is AnnotationParam.Str -> idParam.value
-                    else -> throw UnsupportedOperationException("Unexpected arcId param $idParam")
+                    else -> throw IllegalStateException(
+                        "Annotation arcId param id must be string, instead got $idParam")
                 }
             }
         }

--- a/java/arcs/core/data/Plan.kt
+++ b/java/arcs/core/data/Plan.kt
@@ -21,8 +21,33 @@ import arcs.core.util.lens
 open class Plan(
     // TODO(cromwellian): add more fields as needed (e.g. RecipeName, etc for debugging)
     val particles: List<Particle>,
-    val arcId: String? = null
+    val annotations: List<Annotation>
 ) {
+    // TODO(b/155796088): get rid of these ctors and use annotations in PlanPartition and Recipe.
+    constructor(particles: List<Particle>, arcId: String? = null) :
+        this(
+            particles,
+            if (arcId != null)
+                listOf(Annotation("arcId", mapOf("id" to AnnotationParam.Str(arcId))))
+            else emptyList()
+        )
+
+    constructor(particles: List<Particle>, annotations: List<Annotation>, arcId: String) :
+        this(particles, annotations) {
+        require(this.arcId == arcId)
+    }
+
+    val arcId: String?
+        get() {
+            return annotations.find { it.name == "arcId" }?.let {
+                val idParam = requireNotNull(it.params["id"])
+                return when (idParam) {
+                    is AnnotationParam.Str -> idParam.value
+                    else -> throw UnsupportedOperationException("Unexpected arcId param $idParam")
+                }
+            }
+        }
+
     /**
      * A [Particle] consists of the information necessary to instantiate a particle
      * when starting an arc.
@@ -45,7 +70,8 @@ open class Plan(
         val storageKey: StorageKey,
         val mode: HandleMode,
         val type: Type,
-        val ttl: Ttl? = null
+        val ttl: Ttl? = null,
+        val annotations: List<Annotation>? = emptyList()
     ) {
         companion object {
             val storageKeyLens =

--- a/src/tools/tests/goldens/WriterReaderExample.kt
+++ b/src/tools/tests/goldens/WriterReaderExample.kt
@@ -22,7 +22,11 @@ object IngestionPlan : Plan(
                     ),
                     HandleMode.Read,
                     SingletonType(EntityType(Reader_Data.SCHEMA)),
-                    Ttl.Days(20)
+                    Ttl.Days(20),
+                    listOf(
+                        Annotation("persistent", emptyMap()),
+                        Annotation("ttl", mapOf("value" to AnnotationParam.Str("20d")))
+                    )
                 )
             )
         ),
@@ -36,11 +40,16 @@ object IngestionPlan : Plan(
                     ),
                     HandleMode.Write,
                     SingletonType(EntityType(Writer_Data.SCHEMA)),
-                    Ttl.Days(20)
+                    Ttl.Days(20),
+                    listOf(
+                        Annotation("persistent", emptyMap()),
+                        Annotation("ttl", mapOf("value" to AnnotationParam.Str("20d")))
+                    )
                 )
             )
         )
     ),
+    listOf(Annotation("arcId", mapOf("id" to AnnotationParam.Str("writingArcId")))),
     "writingArcId"
 )
 object ConsumptionPlan : Plan(
@@ -55,11 +64,13 @@ object ConsumptionPlan : Plan(
                     ),
                     HandleMode.Read,
                     SingletonType(EntityType(Reader_Data.SCHEMA)),
-                    Ttl.Infinite
+                    Ttl.Infinite,
+                    emptyList()
                 )
             )
         )
     ),
+    listOf(Annotation("arcId", mapOf("id" to AnnotationParam.Str("readingArcId")))),
     "readingArcId"
 )
 object EphemeralWritingPlan : Plan(
@@ -72,7 +83,8 @@ object EphemeralWritingPlan : Plan(
                     StorageKeyParser.parse("create://my-ephemeral-handle-id"),
                     HandleMode.Write,
                     SingletonType(EntityType(Writer_Data.SCHEMA)),
-                    Ttl.Infinite
+                    Ttl.Infinite,
+                    emptyList()
                 )
             )
         )
@@ -90,7 +102,8 @@ object EphemeralReadingPlan : Plan(
                     ),
                     HandleMode.Read,
                     SingletonType(EntityType(Reader_Data.SCHEMA)),
-                    Ttl.Infinite
+                    Ttl.Infinite,
+                    emptyList()
                 )
             )
         )
@@ -108,7 +121,8 @@ object ReferencesRecipePlan : Plan(
                     ),
                     HandleMode.Read,
                     CollectionType(ReferenceType(EntityType(ReadWriteReferences_InThingRefs.SCHEMA))),
-                    Ttl.Infinite
+                    Ttl.Infinite,
+                    listOf(Annotation("persistent", emptyMap()))
                 ),
                 "outThingRef" to HandleConnection(
                     StorageKeyParser.parse(
@@ -116,10 +130,12 @@ object ReferencesRecipePlan : Plan(
                     ),
                     HandleMode.Write,
                     SingletonType(ReferenceType(EntityType(ReadWriteReferences_OutThingRef.SCHEMA))),
-                    Ttl.Days(1)
+                    Ttl.Days(1),
+                    listOf(Annotation("ttl", mapOf("value" to AnnotationParam.Str("1d"))))
                 )
             )
         )
     ),
+    listOf(Annotation("arcId", mapOf("id" to AnnotationParam.Str("referencesArcId")))),
     "referencesArcId"
 )

--- a/src/tools/tests/plan-generator-tests.ts
+++ b/src/tools/tests/plan-generator-tests.ts
@@ -90,7 +90,8 @@ describe('recipe2plan', () => {
     StorageKeyParser.parse("create://67835270998a62139f8b366f1cb545fb9b72a90b"),
     HandleMode.Write,
     SingletonType(EntityType(A_Data.SCHEMA)),
-    Ttl.Infinite
+    Ttl.Infinite,
+    emptyList()
 )`
       );
       assert.equal(
@@ -99,7 +100,8 @@ describe('recipe2plan', () => {
     StorageKeyParser.parse("create://67835270998a62139f8b366f1cb545fb9b72a90b"),
     HandleMode.Read,
     SingletonType(EntityType(B_Data.SCHEMA)),
-    Ttl.Infinite
+    Ttl.Infinite,
+    emptyList()
 )`
       );
     });
@@ -161,7 +163,8 @@ Particle(
             StorageKeyParser.parse("create://some-handle?Persistent"),
             HandleMode.Write,
             SingletonType(EntityType(Writer_Data.SCHEMA)),
-            Ttl.Infinite
+            Ttl.Infinite,
+            listOf(Annotation("persistent", emptyMap()))
         )
     )
 )`
@@ -193,7 +196,8 @@ Particle(
             StorageKeyParser.parse("create://some-handle?Persistent"),
             HandleMode.ReadWrite,
             SingletonType(EntityType(Intermediary_Data.SCHEMA)),
-            Ttl.Infinite
+            Ttl.Infinite,
+            listOf(Annotation("persistent", emptyMap()))
         )
     )
 )`


### PR DESCRIPTION
Another attempt at: #5515
- get rid of fromString method
- move AnnotationParam as nested class of Annotation
- pass recipe and particle's handle annotations as part of recipe2plan
- use recipe's annotation to extract arcId (more work needed to use annotations everywhere for arcId)