### PR TITLE
add check to ReferenceModeStorageKey to prevent different protocols a…

### DIFF
--- a/java/arcs/core/storage/referencemode/ReferenceModeStorageKey.kt
+++ b/java/arcs/core/storage/referencemode/ReferenceModeStorageKey.kt
@@ -26,6 +26,17 @@ data class ReferenceModeStorageKey(
     val backingKey: StorageKey,
     val storageKey: StorageKey
 ) : StorageKey(REFERENCE_MODE_PROTOCOL) {
+
+    init {
+        // This is a overly strict check as some combinations of different protocols are fine, so it
+        // can be relaxed if needed (see [StorageAdapter] for a more precise check).
+        require(backingKey.protocol == storageKey.protocol) {
+            "Different protocols (${backingKey.protocol} and ${storageKey.protocol}) in a " +
+                "ReferenceModeStorageKey can cause problems with garbage collection if the " +
+                "backing key is in the database and the container key isn't."
+        }
+    }
+
     override fun childKeyWithComponent(component: String): StorageKey =
         ReferenceModeStorageKey(backingKey, storageKey.childKeyWithComponent(component))
 

--- a/javatests/arcs/core/entity/StorageAdapterTest.kt
+++ b/javatests/arcs/core/entity/StorageAdapterTest.kt
@@ -203,8 +203,8 @@ class StorageAdapterTest {
             entityStorageAdapterWithKey(dbKey).storableToReferencable(entityWithKey(dbRefMode))
         }
 
-        // Invalid refmode key, the container is in ramdisk but the backing store is in the db.
-        val invalidKey = ReferenceModeStorageKey(ramdiskKey, dbKey)
+        // Invalid refmode key, the container and backing store are in different dbs.
+        val invalidKey = ReferenceModeStorageKey(dbKey2, dbKey)
         assertFails { entityStorageAdapterWithKey(invalidKey).storableToReferencable(entityWithKey(dbKey)) }
     }
 

--- a/javatests/arcs/core/storage/referencemode/BUILD
+++ b/javatests/arcs/core/storage/referencemode/BUILD
@@ -20,6 +20,7 @@ arcs_kt_android_test_suite(
         "//java/arcs/core/storage/referencemode",
         "//third_party/java/junit:junit-android",
         "//third_party/java/truth:truth-android",
+        "//third_party/kotlin/kotlin:kotlin_test",
         "//third_party/kotlin/kotlinx_atomicfu",
         "//third_party/kotlin/kotlinx_coroutines",
         "//third_party/kotlin/kotlinx_coroutines:kotlinx_coroutines_test",

--- a/javatests/arcs/core/storage/referencemode/ReferenceModeStorageKeyTest.kt
+++ b/javatests/arcs/core/storage/referencemode/ReferenceModeStorageKeyTest.kt
@@ -12,15 +12,29 @@ package arcs.core.storage.referencemode
 
 import arcs.core.storage.embed
 import arcs.core.storage.StorageKeyParser
+import arcs.core.storage.keys.DatabaseStorageKey
 import arcs.core.storage.keys.RamDiskStorageKey
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
+import kotlin.test.assertFailsWith
 
 /** Tests for [ReferenceModeStorageKey]. */
 @RunWith(JUnit4::class)
 class ReferenceModeStorageKeyTest {
+    @Test
+    fun differentProtocolsThrows() {
+        val backing = DatabaseStorageKey.Persistent("db", "abcdef")
+        val direct = RamDiskStorageKey("direct")
+        val exception = assertFailsWith<IllegalArgumentException> { 
+            ReferenceModeStorageKey(backing, direct) 
+        }
+        assertThat(exception).hasMessageThat().startsWith(
+            "Different protocols (db and ramdisk) in a ReferenceModeStorageKey can cause problems"
+        )
+    }
+
     @Test
     fun toString_rendersCorrectly() {
         val backing = RamDiskStorageKey("backing")

--- a/src/runtime/capabilities-resolver.ts
+++ b/src/runtime/capabilities-resolver.ts
@@ -16,7 +16,6 @@ import {Capabilities} from './capabilities.js';
 import {ReferenceModeStorageKey} from './storageNG/reference-mode-storage-key.js';
 import {Flags} from './flags.js';
 import {StorageKeyFactory, FactorySelector, ContainerStorageKeyOptions, BackingStorageKeyOptions, SimpleCapabilitiesSelector} from './storage-key-factory.js';
-import {VolatileStorageKeyFactory} from './storageNG/drivers/volatile.js';
 import {ArcId} from './id.js';
 
 export type CapabilitiesResolverOptions = Readonly<{
@@ -70,6 +69,10 @@ export class CapabilitiesResolver {
     }
     const backingKey = factory.create(new BackingStorageKeyOptions(
         this.options.arcId, schemaHash, type.getEntitySchema().name));
+
+    // ReferenceModeStorageKeys in different drivers can cause problems with garbage collection.
+    assert(backingKey.protocol === containerKey.protocol);
+
     return new ReferenceModeStorageKey(backingKey, containerChildKey);
   }
 


### PR DESCRIPTION
…s some combinations have problems with garbage collection. Note that this is also checked at storing time by storage adapter.