### PR TITLE
Extract logic related to partition serialization into a separate object.

### DIFF
--- a/java/arcs/core/allocator/Allocator.kt
+++ b/java/arcs/core/allocator/Allocator.kt
@@ -14,18 +14,8 @@ import arcs.core.common.ArcId
 import arcs.core.common.Id
 import arcs.core.common.toArcId
 import arcs.core.data.CreateableStorageKey
-import arcs.core.data.FieldType
-import arcs.core.data.HandleMode
 import arcs.core.data.Plan
-import arcs.core.data.RawEntity
-import arcs.core.data.Schema
-import arcs.core.data.SchemaFields
-import arcs.core.data.SchemaName
-import arcs.core.entity.EntityBase
-import arcs.core.entity.EntityBaseSpec
-import arcs.core.entity.HandleContainerType
 import arcs.core.entity.HandleSpec
-import arcs.core.entity.ReadWriteCollectionHandle
 import arcs.core.host.ArcHost
 import arcs.core.host.ArcHostException
 import arcs.core.host.ArcHostNotFoundException
@@ -34,16 +24,10 @@ import arcs.core.host.HostRegistry
 import arcs.core.host.ParticleNotFoundException
 import arcs.core.storage.CapabilitiesResolver
 import arcs.core.storage.StorageKey
-import arcs.core.storage.keys.RamDiskStorageKey
-import arcs.core.storage.referencemode.ReferenceModeStorageKey
 import arcs.core.type.Type
 import arcs.core.util.TaggedLog
 import arcs.core.util.plus
 import arcs.core.util.traverse
-import kotlin.coroutines.resume
-import kotlin.coroutines.suspendCoroutine
-import kotlinx.coroutines.joinAll
-import kotlinx.coroutines.withContext
 
 /**
  * An [Allocator] is responsible for starting and stopping arcs via a distributed
@@ -54,13 +38,38 @@ import kotlinx.coroutines.withContext
  * [arcs.core.data.Schema], a set of [Particle]s to instantiate, and connections between each
  * [HandleSpec] and [Particle].
  */
-class Allocator private constructor(
+class Allocator(
     private val hostRegistry: HostRegistry,
-    private val collection: ReadWriteCollectionHandle<EntityBase>
+    /** Currently active Arcs and their associated [Plan.Partition]s. */
+    private val partitionMap: PartitionSerialization
 ) {
     private val log = TaggedLog { "Allocator" }
-    /** Currently active Arcs and their associated [Plan.Partition]s. */
-    private val partitionMap: MutableMap<ArcId, List<Plan.Partition>> = mutableMapOf()
+
+    /**
+     * A [PartitionSerialization] is an interface for storing the [Plan.Partition] items created when an
+     * Arc is started. If only single-process support is required, a simple map object can be used.
+     * For full cross-process support, use an implementation like [CollectionHandlePartitionMap],
+     * which will store partitions for started Arcs in a collection handle.
+     */
+    interface PartitionSerialization {
+        /**
+         * Stores the provided list of [Plan.Parition] for the provided [ArcId]. Existing values
+         * will be replaced.
+         */
+        suspend fun set(arcId: ArcId, partitions: List<Plan.Partition>)
+
+        /**
+         * Return the current list of [Plan.Partition] for the provided [ArcId]. If an Arc with
+         * the provided [ArcId] is not started, an empty list will be returned.
+         */
+        suspend fun readPartitions(arcId: ArcId): List<Plan.Partition>
+
+        /**
+         * Return partitions as in [readPartitions], and then immmediately clear the values stored
+         * for the provided [ArcId].
+         */
+        suspend fun readAndClearPartitions(arcId: ArcId): List<Plan.Partition>
+    }
 
     /**
      * Start a new Arc given a [Plan] and return an [Arc].
@@ -71,9 +80,10 @@ class Allocator private constructor(
      * Start a new Arc given a [Plan] and return an [Arc].
      */
     private suspend fun startArcForPlan(plan: Plan, nameForTesting: String): Arc {
-        if (plan.arcId !== null) {
-            if (readPartitions(plan.arcId!!.toArcId()).isNotEmpty()) {
-                return Arc(plan.arcId!!.toArcId(), this)
+        plan.arcId?.toArcId()?.let { arcId ->
+            val existingPartitions = partitionMap.readPartitions(arcId)
+            if (existingPartitions.isNotEmpty()) {
+                return Arc(arcId, this, existingPartitions)
             }
         }
         val idGenerator = Id.Generator.newSession()
@@ -84,10 +94,10 @@ class Allocator private constructor(
         val partitions = computePartitions(arcId, newPlan)
         log.debug { "Computed partitions" }
         // Store computed partitions for later
-        writePartitionMap(arcId, partitions)
+        partitionMap.set(arcId, partitions)
         try {
             startPlanPartitionsOnHosts(partitions)
-            return Arc(arcId, this)
+            return Arc(arcId, this, partitions)
         } catch (e: ArcHostException) {
             stopArc(arcId)
             throw e
@@ -98,13 +108,8 @@ class Allocator private constructor(
      * Stop an Arc given its [ArcId].
      */
     suspend fun stopArc(arcId: ArcId) {
-        val partitions = readAndClearPartitions(arcId)
+        val partitions = partitionMap.readAndClearPartitions(arcId)
         stopPlanPartitionsOnHosts(partitions)
-    }
-
-    // VisibleForTesting
-    fun getPartitionsFor(arcId: ArcId): List<Plan.Partition>? {
-        return partitionMap[arcId]
     }
 
     /**
@@ -124,57 +129,6 @@ class Allocator private constructor(
         hostRegistry.availableArcHosts().filter { it ->
             it.hostId == arcHost
         }.firstOrNull() ?: throw ArcHostNotFoundException(arcHost)
-
-    /** Persists [ArcId] and associated [PlanPartition]s */
-    private suspend fun writePartitionMap(arcId: ArcId, partitions: List<Plan.Partition>) {
-        partitionMap[arcId] = partitions
-
-        log.debug { "writePartitionMap()" }
-
-        val writes = withContext(collection.dispatcher) {
-            partitions.map { partition ->
-                val entity = EntityBase("EntityBase", SCHEMA)
-                entity.setSingletonValue("arc", arcId.toString())
-                entity.setSingletonValue("host", partition.arcHost)
-                entity.setCollectionValue(
-                    "particles",
-                    partition.particles.map { it.particleName }.toSet()
-                )
-                log.debug { "Writing $entity" }
-                collection.store(entity)
-            }
-        }
-
-        writes.joinAll()
-    }
-
-    /** Looks up [RawEntity]s representing [PlanPartition]s for a given [ArcId] */
-    private suspend fun entitiesForArc(arcId: ArcId): List<EntityBase> =
-        withContext(collection.dispatcher) { collection.fetchAll() }
-            .filter { it.getSingletonValue("arc") == arcId.toString() }
-
-    /** Converts a [RawEntity] to a [Plan.Partition] */
-    private fun entityToPartition(entity: EntityBase): Plan.Partition =
-        Plan.Partition(
-            entity.getSingletonValue("arc") as String,
-            entity.getSingletonValue("host") as String,
-            entity.getCollectionValue("particles").map {
-                Plan.Particle(it as String, "", mapOf())
-            }
-        )
-
-    /** Reads associated [PlanPartition]s with an [ArcId]. */
-    private suspend fun readPartitions(arcId: ArcId): List<Plan.Partition> =
-        entitiesForArc(arcId).map { entityToPartition(it) }
-
-    private suspend fun readAndClearPartitions(arcId: ArcId): List<Plan.Partition> {
-        val entities = entitiesForArc(arcId)
-        val removals = withContext(collection.dispatcher) {
-            entities.map { collection.remove(it) }
-        }
-        removals.joinAll()
-        return entities.map { entityToPartition(it) }
-    }
 
     /**
      * Finds [HandleConnection] instances which were unresolved at build time
@@ -257,45 +211,13 @@ class Allocator private constructor(
             ?: throw ParticleNotFoundException(particle)
 
     companion object {
-        /** Schema for persistent storage of [PlanPartition] information */
-        private val SCHEMA = Schema(
-            setOf(SchemaName("partition")),
-            SchemaFields(
-                mapOf(
-                    "arc" to FieldType.Text,
-                    "host" to FieldType.Text
-                ),
-                mapOf(
-                    "particles" to FieldType.Text
-                )),
-            "plan-partition-schema"
-        )
-
-        private val STORAGE_KEY = ReferenceModeStorageKey(
-            RamDiskStorageKey("partition"),
-            RamDiskStorageKey("partitions")
-        )
-
-        @Suppress("UNCHECKED_CAST")
-        suspend fun create(
+        fun create(
             hostRegistry: HostRegistry,
             handleManager: EntityHandleManager
         ): Allocator {
-            val collection = handleManager.createHandle(
-                HandleSpec(
-                    "partitions",
-                    HandleMode.ReadWrite,
-                    HandleContainerType.Collection,
-                    EntityBaseSpec(SCHEMA)
-                ),
-                STORAGE_KEY
-            )
-
-            suspendCoroutine<Unit> { collection.onReady { it.resume(Unit) } }
-
             return Allocator(
                 hostRegistry,
-                collection as ReadWriteCollectionHandle<EntityBase>
+                CollectionHandlePartitionMap(handleManager)
             )
         }
     }

--- a/java/arcs/core/allocator/Arc.kt
+++ b/java/arcs/core/allocator/Arc.kt
@@ -12,6 +12,7 @@
 package arcs.core.allocator
 
 import arcs.core.common.ArcId
+import arcs.core.data.Plan
 import arcs.core.host.ArcState
 import arcs.core.host.ArcState.Deleted
 import arcs.core.host.ArcState.Error
@@ -36,6 +37,7 @@ import kotlinx.coroutines.runBlocking
 class Arc internal constructor(
     val id: ArcId,
     private val allocator: Allocator,
+    val partitions: List<Plan.Partition>,
     private var arcStateInternal: ArcState = NeverStarted
 ) {
     private val arcStateChangeHandlers = mutableListOf<(ArcState) -> Unit>()
@@ -111,8 +113,7 @@ class Arc internal constructor(
     }
 
     private suspend fun fetchCurrentStates() {
-        val partitionsFor = allocator.getPartitionsFor(id)
-        partitionsFor?.forEach {
+        partitions.forEach {
             val arcHost = allocator.lookupArcHost(it.arcHost)
             arcStatesByHostId[it.arcHost] = arcHost.lookupArcHostStatus(it)
         }
@@ -122,13 +123,12 @@ class Arc internal constructor(
         require(registration == null) {
             "registration called more than once"
         }
-        val partitionsFor = allocator.getPartitionsFor(id)
         runBlocking {
             // first poll the current states of all hosts
             fetchCurrentStates()
 
             // Register event listeners
-            partitionsFor?.forEach { partition ->
+            partitions.forEach { partition ->
                 val arcHost = allocator.lookupArcHost(partition.arcHost)
                 registration = arcHost.addOnArcStateChange(id) { _, state ->
                     sync(this) {

--- a/java/arcs/core/allocator/CollectionHandlePartitionMap.kt
+++ b/java/arcs/core/allocator/CollectionHandlePartitionMap.kt
@@ -1,0 +1,131 @@
+package arcs.core.allocator
+
+import arcs.core.common.ArcId
+import arcs.core.data.FieldType
+import arcs.core.data.HandleMode
+import arcs.core.data.Plan
+import arcs.core.data.RawEntity
+import arcs.core.data.Schema
+import arcs.core.data.SchemaFields
+import arcs.core.data.SchemaName
+import arcs.core.entity.EntityBase
+import arcs.core.entity.EntityBaseSpec
+import arcs.core.entity.HandleContainerType
+import arcs.core.entity.HandleSpec
+import arcs.core.entity.ReadWriteCollectionHandle
+import arcs.core.entity.awaitReady
+import arcs.core.host.EntityHandleManager
+import arcs.core.storage.keys.RamDiskStorageKey
+import arcs.core.storage.referencemode.ReferenceModeStorageKey
+import arcs.core.util.TaggedLog
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+
+/**
+ * An implementation of [Allocator.PartitionSerialization] that stores partition information in an Arcs
+ * collection handle, created by the [EntityHandleManager] provided at construction. The handle
+ * will be created the first time any of the publicly exposed methods is called.
+ */
+class CollectionHandlePartitionMap(
+    private val handleManager: EntityHandleManager
+) : Allocator.PartitionSerialization {
+
+    private val log = TaggedLog { "CollectionHandlePartitionMap" }
+
+    private val collectionMutex = Mutex()
+    private lateinit var _collection: ReadWriteCollectionHandle<EntityBase>
+
+    private suspend fun collection() = collectionMutex.withLock {
+        if (!::_collection.isInitialized) {
+            _collection = handleManager.createHandle(
+                HandleSpec(
+                    "partitions",
+                    HandleMode.ReadWrite,
+                    HandleContainerType.Collection,
+                    EntityBaseSpec(SCHEMA)
+                ),
+                STORAGE_KEY
+            ) as ReadWriteCollectionHandle<EntityBase>
+        }
+        _collection.awaitReady()
+        _collection
+    }
+
+    /** Persists [ArcId] and associated [Plan.Partition]s */
+    override suspend fun set(arcId: ArcId, partitions: List<Plan.Partition>) {
+        log.debug { "writePartitionMap(arcId=$arcId)" }
+
+        val writes = withContext(collection().dispatcher) {
+            partitions.map { partition ->
+                val entity = EntityBase("EntityBase", SCHEMA)
+                entity.setSingletonValue("arc", arcId.toString())
+                entity.setSingletonValue("host", partition.arcHost)
+                entity.setCollectionValue(
+                    "particles",
+                    partition.particles.map { it.particleName }.toSet()
+                )
+                log.debug { "Writing $entity" }
+                collection().store(entity)
+            }
+        }
+
+        writes.joinAll()
+    }
+
+    /** Converts a [RawEntity] to a [Plan.Partition] */
+    private fun entityToPartition(entity: EntityBase): Plan.Partition =
+        Plan.Partition(
+            entity.getSingletonValue("arc") as String,
+            entity.getSingletonValue("host") as String,
+            entity.getCollectionValue("particles").map {
+                Plan.Particle(it as String, "", mapOf())
+            }
+        )
+
+    /** Reads associated [PlanPartition]s with an [ArcId]. */
+    override suspend fun readPartitions(arcId: ArcId): List<Plan.Partition> =
+        entitiesForArc(arcId).map { entityToPartition(it) }
+
+    /**
+     * Reads associated [PlanPartition]s with an [ArcId] and then immediately clears the entries
+     * for that [Arcid].
+     */
+    override suspend fun readAndClearPartitions(arcId: ArcId): List<Plan.Partition> {
+        val entities = entitiesForArc(arcId)
+        val removals = withContext(collection().dispatcher) {
+            entities.map { collection().remove(it) }
+        }
+        removals.joinAll()
+        return entities.map { entityToPartition(it) }
+    }
+
+    /** Looks up [RawEntity]s representing [PlanPartition]s for a given [ArcId] */
+    private suspend fun entitiesForArc(arcId: ArcId): List<EntityBase> {
+        return withContext(collection().dispatcher) {
+            collection().fetchAll()
+        }.filter { it.getSingletonValue("arc") == arcId.toString() }
+    }
+
+    companion object {
+        /** Schema for persistent storage of [PlanPartition] information */
+        private val SCHEMA = Schema(
+            setOf(SchemaName("partition")),
+            SchemaFields(
+                mapOf(
+                    "arc" to FieldType.Text,
+                    "host" to FieldType.Text
+                ),
+                mapOf(
+                    "particles" to FieldType.Text
+                )),
+            "plan-partition-schema"
+        )
+
+        private val STORAGE_KEY = ReferenceModeStorageKey(
+            RamDiskStorageKey("partition"),
+            RamDiskStorageKey("partitions")
+        )
+    }
+}


### PR DESCRIPTION
This helps to clarify the actions that the Allocator performs, and opens
up the possibility of providing alternate partition-serialization
strategies, if desired.

This also removes the parallel "Map<ArcId, Partition>" which seemed to
be used for testing, or to provide partitions to an arc. Instead, the
partitions used to create an Arc object are now stored directly in that
Arc object.

Note that as a part of this change, `Allocator.create` is no longer a
suspend function, which will make it easier to construct these.