### PR TITLE
Visitor pattern for refinement expressions

### DIFF
--- a/src/runtime/sql-refinement-generator.ts
+++ b/src/runtime/sql-refinement-generator.ts
@@ -1,0 +1,90 @@
+/**
+ * @license
+ * Copyright (c) 2020 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {Op} from './manifest-ast-nodes.js';
+import {Dictionary} from './hot.js';
+import {Schema} from './schema.js';
+import {RefinementExpressionVisitor, BinaryExpression, UnaryExpression, FieldNamePrimitive, QueryArgumentPrimitive, BuiltIn, NumberPrimitive, BooleanPrimitive, TextPrimitive, Primitive} from './refiner.js';
+
+const sqlOperator: Dictionary<string> = {
+  [Op.AND]: 'AND',
+  [Op.OR]: 'OR',
+  [Op.LT]: '<',
+  [Op.GT]: '>',
+  [Op.LTE]: '<=',
+  [Op.GTE]: '>=',
+  [Op.ADD]: '+',
+  [Op.SUB]: '-',
+  [Op.MUL]: '*',
+  [Op.DIV]: '/',
+  [Op.NOT]: 'NOT',
+  [Op.NEG]: '-',
+  [Op.EQ]: '=',
+  [Op.NEQ]: '<>',
+};
+
+/**
+ * This class is EXPERIMENTAL.
+ *
+ * Before using this on an actual SQL DB please review the SQL injection possibilities
+ * and fix the expression generator accordingly.
+ */
+class SqlRefinementGenerator extends RefinementExpressionVisitor<string> {
+
+  visitBinaryExpression(expr: BinaryExpression): string {
+    return `(${this.visit(expr.leftExpr)} ${sqlOperator[expr.operator.op]} ${this.visit(expr.rightExpr)})`;
+  }
+  visitUnaryExpression(expr: UnaryExpression): string {
+    return `(${sqlOperator[expr.operator.op]} ${this.visit(expr.expr)})`;
+  }
+  visitFieldNamePrimitive(expr: FieldNamePrimitive): string {
+    const fixed = (expr.value.toString());
+    if (expr.evalType === Primitive.BOOLEAN) {
+      return `(${fixed} = 1)`;
+    }
+    return fixed;
+  }
+  visitQueryArgumentPrimitive(expr: QueryArgumentPrimitive): string {
+    return expr.value.toString();
+  }
+  visitBuiltIn(expr: BuiltIn): string {
+    if (expr.value === 'now()') {
+      return expr.value;
+    }
+    // TODO: Implement SQL getter for 'creationTimeStamp'
+    throw new Error(`Unhandled BuiltInNode '${expr.value}' in toSQLExpression`);
+  }
+  visitNumberPrimitive(expr: NumberPrimitive): string {
+    return expr.value.toString();
+  }
+  visitBooleanPrimitive(_: BooleanPrimitive): string {
+    throw new Error('BooleanPrimitive.toSQLExpression should never be called. The expression is assumed to be normalized.');
+  }
+  visitTextPrimitive(expr: TextPrimitive): string {
+    // TODO(cypher1): Consider escaping this for SQL code generation.
+    return `'${expr.value}'`;
+  }
+}
+
+export class SQLExtracter {
+  private static generator = new SqlRefinementGenerator();
+  static fromSchema(schema: Schema, table: string, ): string {
+    const filterTerms = [];
+    if (schema.refinement) {
+      filterTerms.push(this.generator.generate(schema.refinement));
+    }
+    for (const field of Object.values(schema.fields)) {
+      if (field.refinement) {
+        filterTerms.push(this.generator.generate(field.refinement));
+      }
+    }
+    return `SELECT * FROM ${table}` + (filterTerms.length ? ` WHERE ${filterTerms.join(' AND ')}` : '') + ';';
+  }
+}

--- a/src/runtime/tests/sql-refinement-generator-test.ts
+++ b/src/runtime/tests/sql-refinement-generator-test.ts
@@ -1,0 +1,62 @@
+/**
+ * @license
+ * Copyright (c) 2019 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {SQLExtracter} from '../sql-refinement-generator.js';
+import {assert} from '../../platform/chai-web.js';
+import {Manifest} from '../../runtime/manifest.js';
+import {Flags} from '../../runtime/flags.js';
+
+describe('SQLExtracter', () => {
+  it('tests can create queries from refinement expressions involving math expressions', Flags.withFieldRefinementsAllowed(async () => {
+      const manifest = await Manifest.parse(`
+        particle Foo
+          input: reads Something {a: Number [ a > 3 and a != 100 ], b: Number [b > 20 and b < 100] } [a + b/3 > 100]
+      `);
+      const schema = manifest.particles[0].handleConnectionMap.get('input').type.getEntitySchema();
+      const query: string = SQLExtracter.fromSchema(schema, 'table');
+      assert.strictEqual(query, 'SELECT * FROM table WHERE ((b + (a * 3)) > 300) AND ((a > 3) AND (NOT (a = 100))) AND ((b > 20) AND (b < 100));');
+  }));
+  it('tests can create queries from refinement expressions involving boolean expressions', Flags.withFieldRefinementsAllowed(async () => {
+    const manifest = await Manifest.parse(`
+      particle Foo
+        input: reads Something {a: Boolean [ not (a == true) ], b: Boolean [not not b != false] } [a or b]
+    `);
+    const schema = manifest.particles[0].handleConnectionMap.get('input').type.getEntitySchema();
+    const query = SQLExtracter.fromSchema(schema, 'table');
+    assert.strictEqual(query, 'SELECT * FROM table WHERE ((b = 1) OR (a = 1)) AND (NOT (a = 1)) AND (b = 1);');
+  }));
+  it('tests can create queries where field refinement is null', async () => {
+    const manifest = await Manifest.parse(`
+      particle Foo
+        input: reads Something {a: Boolean, b: Boolean} [a and b]
+    `);
+    const schema = manifest.particles[0].handleConnectionMap.get('input').type.getEntitySchema();
+    const query = SQLExtracter.fromSchema(schema, 'table');
+    assert.strictEqual(query, 'SELECT * FROM table WHERE ((b = 1) AND (a = 1));');
+  });
+  it('tests can create queries where schema refinement is null', Flags.withFieldRefinementsAllowed(async () => {
+    const manifest = await Manifest.parse(`
+      particle Foo
+        input: reads Something {a: Boolean [not a], b: Boolean [b]}
+    `);
+    const schema = manifest.particles[0].handleConnectionMap.get('input').type.getEntitySchema();
+    const query = SQLExtracter.fromSchema(schema, 'table');
+    assert.strictEqual(query, 'SELECT * FROM table WHERE (NOT (a = 1)) AND (b = 1);');
+  }));
+  it('tests can create queries where there is no refinement', async () => {
+    const manifest = await Manifest.parse(`
+      particle Foo
+        input: reads Something {a: Boolean, b: Boolean}
+    `);
+    const schema = manifest.particles[0].handleConnectionMap.get('input').type.getEntitySchema();
+    const query = SQLExtracter.fromSchema(schema, 'table');
+    assert.strictEqual(query, 'SELECT * FROM table;');
+  });
+});

--- a/src/tools/kotlin-codegen-shared.ts
+++ b/src/tools/kotlin-codegen-shared.ts
@@ -18,6 +18,25 @@ import {Dictionary} from '../runtime/hot.js';
 
 const ktUtils = new KotlinGenerationUtils();
 
+// Includes reserve words for Entity Interface
+// https://kotlinlang.org/docs/reference/keyword-reference.html
+// [...document.getElementsByTagName('code')].map(x => x.innerHTML);
+const keywords = [
+  'as', 'as?', 'break', 'class', 'continue', 'do', 'else', 'false', 'for', 'fun', 'if', 'in', '!in', 'interface', 'is',
+  '!is', 'null', 'object', 'package', 'return', 'super', 'this', 'throw', 'true', 'try', 'typealias', 'val', 'var',
+  'when', 'while', 'by', 'catch', 'constructor', 'delegate', 'dynamic', 'field', 'file', 'finally', 'get', 'import',
+  'init', 'param', 'property', 'receiver', 'set', 'setparam', 'where', 'actual', 'abstract', 'annotation', 'companion',
+  'const', 'crossinline', 'data', 'enum', 'expect', 'external', 'final', 'infix', 'inline', 'inner', 'internal',
+  'lateinit', 'noinline', 'open', 'operator', 'out', 'override', 'private', 'protected', 'public', 'reified', 'sealed',
+  'suspend', 'tailrec', 'vararg', 'it', 'entityId', 'creationTimestamp', 'expirationTimestamp'
+];
+
+export function escapeIdentifier(name: string): string {
+  // TODO(cypher1): Check for complex keywords (e.g. cases where both 'final' and 'final_' are keywords).
+  // TODO(cypher1): Check for name overlaps (e.g. 'final' and 'final_' should not be escaped to the same identifier.
+  return name + (keywords.includes(name) ? '_' : '');
+}
+
 /**
  * Generates a Kotlin type instance for the given handle connection.
  */
@@ -57,6 +76,14 @@ export interface KotlinTypeInfo {
   decodeFn: string;
   defaultVal: string;
   schemaType: string;
+}
+
+export function typeFor(name: string): string {
+  return getTypeInfo({name}).type;
+}
+
+export function defaultValFor(name: string): string {
+  return getTypeInfo({name}).defaultVal;
 }
 
 export function getTypeInfo(opts: { name: string, isCollection?: boolean, refClassName?: string, listTypeName?: string, refSchemaHash?: string }): KotlinTypeInfo {

--- a/src/tools/kotlin-refinement-generator.ts
+++ b/src/tools/kotlin-refinement-generator.ts
@@ -1,0 +1,115 @@
+/**
+ * @license
+ * Copyright (c) 2020 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {Op} from '../runtime/manifest-ast-nodes.js';
+import {Dictionary} from '../runtime/hot.js';
+import {Schema} from '../runtime/schema.js';
+import {escapeIdentifier, typeFor, defaultValFor} from './kotlin-codegen-shared.js';
+import {RefinementExpressionVisitor, BinaryExpression, UnaryExpression, FieldNamePrimitive, QueryArgumentPrimitive, BuiltIn, NumberPrimitive, BooleanPrimitive, TextPrimitive} from '../runtime/refiner.js';
+
+// The variable name used for the query argument in generated Kotlin code.
+const KOTLIN_QUERY_ARGUMENT_NAME = 'queryArgument';
+
+const kotlinOperator: Dictionary<string> = {
+  [Op.AND]: '&&',
+  [Op.OR]: '||',
+  [Op.LT]: '<',
+  [Op.GT]: '>',
+  [Op.LTE]: '<=',
+  [Op.GTE]: '>=',
+  [Op.ADD]: '+',
+  [Op.SUB]: '-',
+  [Op.MUL]: '*',
+  [Op.DIV]: '/',
+  [Op.NOT]: '!',
+  [Op.NEG]: '-',
+  [Op.EQ]: '==',
+  [Op.NEQ]: '!=',
+};
+
+class KotlinRefinementGenerator extends RefinementExpressionVisitor<string> {
+
+  visitBinaryExpression(expr: BinaryExpression): string {
+    return `(${this.visit(expr.leftExpr)} ${kotlinOperator[expr.operator.op]} ${this.visit(expr.rightExpr)})`;
+  }
+  visitUnaryExpression(expr: UnaryExpression): string {
+    return `(${kotlinOperator[expr.operator.op]}${this.visit(expr.expr)})`;
+  }
+  visitFieldNamePrimitive(expr: FieldNamePrimitive): string {
+    return (expr.value.toString());
+  }
+  visitQueryArgumentPrimitive(_: QueryArgumentPrimitive): string {
+    return KOTLIN_QUERY_ARGUMENT_NAME;
+  }
+  visitBuiltIn(expr: BuiltIn): string {
+    // TODO: Double check that millis are the correct default units.
+    if (expr.value === 'now()') {
+      return `System.currentTimeMillis()`;
+    }
+
+    // TODO: Implement KT getter for 'creationTimeStamp'
+    throw new Error(`Unhandled BuiltInNode '${expr.value}' in toKTExpression`);
+  }
+  visitNumberPrimitive(expr: NumberPrimitive): string {
+    // This assumes that the associated Kotlin type will be `double`.
+    if (expr.value === Infinity) {
+      return 'Double.POSITIVE_INFINITY';
+    }
+    if (expr.value === -Infinity) {
+        return 'Double.NEGATIVE_INFINITY';
+    }
+    return expr.value.toString();
+  }
+  visitBooleanPrimitive(expr: BooleanPrimitive): string {
+    return `${expr.value}`;
+  }
+  visitTextPrimitive(expr: TextPrimitive): string {
+    // TODO(b/159211498): Escape this for Kotlin code generation.
+    return `"${expr.value}"`;
+  }
+}
+
+export class KTExtracter {
+  private static generator = new KotlinRefinementGenerator();
+
+  static fromSchema(schema: Schema): string {
+    const genFieldAsLocal = (fieldName: string) => {
+      const type = schema.fields[fieldName].type;
+      const fixed = escapeIdentifier(fieldName);
+      return `val ${fixed} = data.singletons["${fieldName}"].toPrimitiveValue(${typeFor(type)}::class, ${defaultValFor(type)})`;
+    };
+
+    const genQueryArgAsLocal = ([_, type]: [string, string]) => {
+        return `val ${KOTLIN_QUERY_ARGUMENT_NAME} = queryArgs as ${typeFor(type)}`;
+    };
+
+    const fieldNames = new Set<string>();
+    const filterTerms = [];
+    if (schema.refinement) {
+      [...schema.refinement.getFieldParams().keys()].forEach(name => fieldNames.add(name));
+      filterTerms.push(this.generator.generate(schema.refinement));
+    }
+    for (const field of Object.values(schema.fields)) {
+      if (field.refinement) {
+        [...field.refinement.getFieldParams().keys()].forEach(name => fieldNames.add(name));
+        filterTerms.push(this.generator.generate(field.refinement));
+      }
+    }
+
+    const locals = [...fieldNames].map(genFieldAsLocal);
+    if (schema.refinement) {
+      const querysArgs = [...schema.refinement.getQueryParams()].map(genQueryArgAsLocal);
+      locals.push(...querysArgs);
+    }
+    const expr = filterTerms.length > 0 ? `${filterTerms.join(' && ')}` : 'true';
+
+    return `${locals.map(x => `${x}\n`).join('')}${expr}`;
+  }
+}

--- a/src/tools/schema2base.ts
+++ b/src/tools/schema2base.ts
@@ -27,7 +27,6 @@ export type AddFieldOptions = Readonly<{
 
 export interface ClassGenerator {
   addField(opts: AddFieldOptions): void;
-  escapeIdentifier(ident: string): string;
   generate(fieldCount: number): string;
 }
 

--- a/src/tools/schema2cpp.ts
+++ b/src/tools/schema2cpp.ts
@@ -32,6 +32,12 @@ const keywords = [
   'xor', 'xor_eq'
 ];
 
+function escapeIdentifier(name: string): string {
+  // TODO(cypher1): Check for complex keywords (e.g. cases where both 'final' and '_final' are keywords).
+  // TODO(cypher1): Check for name overlaps (e.g. 'final' and '_final' should not be escaped to the same identifier.
+  return (keywords.includes(name) ? '_' : '') + name;
+}
+
 export interface CppTypeInfo {
   type: string;
   defaultVal: string;
@@ -131,18 +137,12 @@ class CppGenerator implements ClassGenerator {
 
   constructor(readonly node: SchemaNode, readonly namespace: string) {}
 
-  escapeIdentifier(name: string): string {
-    // TODO(cypher1): Check for complex keywords (e.g. cases where both 'final' and '_final' are keywords).
-    // TODO(cypher1): Check for name overlaps (e.g. 'final' and '_final' should not be escaped to the same identifier.
-    return (keywords.includes(name) ? '_' : '') + name;
-  }
-
   addField({field, typeName, refClassName, isOptional = false, isCollection = false}: AddFieldOptions) {
     // Work around for schema2graph giving the Kotlin RefClassName.
     if (refClassName !== undefined) {
       refClassName = `${this.node.sources[0].fullName}_Ref`;
     }
-    const fixed = this.escapeIdentifier(field);
+    const fixed = escapeIdentifier(field);
     const valid = `${field}_valid_`;
     let {type, defaultVal, isString} = getTypeInfo(typeName);
     if (typeName === 'Reference') {

--- a/src/tools/tests/kotlin-refinement-generator-test.ts
+++ b/src/tools/tests/kotlin-refinement-generator-test.ts
@@ -1,0 +1,77 @@
+/**
+ * @license
+ * Copyright (c) 2020 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {KTExtracter} from '../kotlin-refinement-generator.js';
+import {assert} from '../../platform/chai-web.js';
+import {Manifest} from '../../runtime/manifest.js';
+import {Flags} from '../../runtime/flags.js';
+
+describe('KTExtracter', () => {
+  it('creates queries from refinement expressions involving math expressions', Flags.withFieldRefinementsAllowed(async () => {
+      const manifest = await Manifest.parse(`
+        particle Foo
+          input: reads Something {a: Number [ a > 3 and a != 100 ], b: Number [b > 20 and b < 100] } [a + b/3 > 100]
+      `);
+      const schema = manifest.particles[0].handleConnectionMap.get('input').type.getEntitySchema();
+      const query: string = KTExtracter.fromSchema(schema);
+      assert.strictEqual(query,
+        `\
+val a = data.singletons["a"].toPrimitiveValue(Double::class, 0.0)
+val b = data.singletons["b"].toPrimitiveValue(Double::class, 0.0)
+((b + (a * 3)) > 300) && ((a > 3) && (!(a == 100))) && ((b > 20) && (b < 100))`);
+  }));
+  it('creates queries from refinement expressions involving boolean expressions', Flags.withFieldRefinementsAllowed(async () => {
+    const manifest = await Manifest.parse(`
+      particle Foo
+        input: reads Something {a: Boolean [ not (a == true) ], b: Boolean [not not b != false] } [a or b]
+    `);
+    const schema = manifest.particles[0].handleConnectionMap.get('input').type.getEntitySchema();
+    const query = KTExtracter.fromSchema(schema);
+    //TODO(cypher1): Implement some simple boolean simplifications.
+    //This should simplify to, '(!a) && b'
+    assert.strictEqual(query, `\
+val a = data.singletons["a"].toPrimitiveValue(Boolean::class, false)
+val b = data.singletons["b"].toPrimitiveValue(Boolean::class, false)
+(b || a) && (!a) && b`);
+  }));
+  it('creates queries where field refinement is null', async () => {
+    const manifest = await Manifest.parse(`
+      particle Foo
+        input: reads Something {a: Boolean, b: Boolean} [a and b]
+    `);
+    const schema = manifest.particles[0].handleConnectionMap.get('input').type.getEntitySchema();
+    const query = KTExtracter.fromSchema(schema);
+    assert.strictEqual(query, `\
+val a = data.singletons["a"].toPrimitiveValue(Boolean::class, false)
+val b = data.singletons["b"].toPrimitiveValue(Boolean::class, false)
+(b && a)`);
+  });
+  it('creates queries where schema refinement is null', Flags.withFieldRefinementsAllowed(async () => {
+    const manifest = await Manifest.parse(`
+      particle Foo
+        input: reads Something {a: Boolean [not a], b: Boolean [b]}
+    `);
+    const schema = manifest.particles[0].handleConnectionMap.get('input').type.getEntitySchema();
+    const query = KTExtracter.fromSchema(schema);
+    assert.strictEqual(query, `\
+val a = data.singletons["a"].toPrimitiveValue(Boolean::class, false)
+val b = data.singletons["b"].toPrimitiveValue(Boolean::class, false)
+(!a) && b`);
+  }));
+  it('creates queries where there is no refinement', async () => {
+    const manifest = await Manifest.parse(`
+      particle Foo
+        input: reads Something {a: Boolean, b: Boolean}
+    `);
+    const schema = manifest.particles[0].handleConnectionMap.get('input').type.getEntitySchema();
+    const query = KTExtracter.fromSchema(schema);
+    assert.strictEqual(query, 'true');
+  });
+});

--- a/src/tools/tests/schema2wasm-test.ts
+++ b/src/tools/tests/schema2wasm-test.ts
@@ -31,10 +31,6 @@ class Schema2Mock extends Schema2Base {
     const collector = {count: 0, adds: []};
     this.res[node.entityClassName] = collector;
     return {
-      escapeIdentifier(name: string): string {
-        return name;
-      },
-
       addField({field, typeName, isOptional, refClassName}: AddFieldOptions) {
         const refInfo = refClassName ? `<${refClassName}>` : '';
         collector.adds.push(field + ':' + typeName[0] + refInfo + (isOptional ? '?' : ''));


### PR DESCRIPTION
* Separates Kotlin and SQL refinement expression generator from the core refinement data structures with a visitor pattern.
* Pulls Kotlin and SQL refinement expression generators into separate files.
* Removes dependency from the KTExtracter on the Kotlin class generator via `interface CodeGenerator`, which allows cleaning up some unnecessary methods from the CodeGenerator interface (`escapeIdentifier`) and from Kotlin code generator (`typeFor` and `defaultValFor`).

This is in preparation to separating Kotlin Schema generation from schema2kotlin so that it can be reused in recipe2plan.