### PR TITLE
Restore bazel cache in gcb.bazelrc and bump chromedriver version to 83

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN curl -sS -o - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-ke
 RUN echo "deb [arch=amd64]  http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list
 RUN apt-get -y update && apt-get -y install google-chrome-stable
 # Install Selenium
-RUN curl https://chromedriver.storage.googleapis.com/81.0.4044.69/chromedriver_linux64.zip -o  /usr/bin/chromedriver_linux64.zip
+RUN curl https://chromedriver.storage.googleapis.com/83.0.4103.39/chromedriver_linux64.zip -o  /usr/bin/chromedriver_linux64.zip
 RUN unzip /usr/bin/chromedriver_linux64.zip -d /usr/bin/chromedriver
 RUN chmod +x /usr/bin/chromedriver
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "bufferutil": "4.0.1",
     "c8": "4.1.5",
     "chai": "4.2.0",
-    "chromedriver": "81.0.0",
+    "chromedriver": "83.0.0",
     "concurrently": "4.1.2",
     "cross-env": "5.2.1",
     "diff": "4.0.1",

--- a/tools/gcb.bazelrc
+++ b/tools/gcb.bazelrc
@@ -1,4 +1,5 @@
 build --strategy=KotlinCompile=worker
+build --remote_cache=https://storage.googleapis.com/arcs-github-gcb-bazel-cache --google_default_credentials
 build --verbose_failures --spawn_strategy=sandboxed --jobs=32 --local_ram_resources=HOST_RAM*.3
 build --nostamp --noshow_progress --show_result 0
 test --spawn_strategy=sandboxed --nocache_test_results --test_output=errors --jobs=32 --local_ram_resources=HOST_RAM*.3


### PR DESCRIPTION
It might have been accidentally removed in https://github.com/PolymerLabs/arcs/pull/5229.