### PR TITLE
Support importing .arcs files in manifest2proto

### DIFF
--- a/src/tools/manifest2proto.ts
+++ b/src/tools/manifest2proto.ts
@@ -29,15 +29,12 @@ import {policyToProtoPayload} from './policy2proto.js';
 
 export async function encodeManifestToProto(path: string): Promise<Uint8Array> {
   const manifest = await Runtime.parseFile(path);
-
-  if (manifest.imports.length) {
-    throw Error('Only single-file manifests are currently supported');
-  }
   return encodePayload(await manifestToProtoPayload(manifest));
 }
 
 export async function manifestToProtoPayload(manifest: Manifest) {
-  return makeManifestProtoPayload(manifest.particles, manifest.recipes, manifest.policies);
+  manifest.validateUniqueDefinitions();
+  return makeManifestProtoPayload(manifest.allParticles, manifest.allRecipes, manifest.allPolicies);
 }
 
 export async function encodePlansToProto(plans: Recipe[]) {
@@ -58,7 +55,7 @@ async function makeManifestProtoPayload(particles: ParticleSpec[], recipes: Reci
 
 function encodePayload(payload: {}): Uint8Array {
   const error = ManifestProto.verify(payload);
-  if (error) throw Error(error);
+  if (error) throw new Error(error);
   return ManifestProto.encode(ManifestProto.create(payload)).finish();
 }
 
@@ -79,7 +76,7 @@ async function particleSpecToProtoPayload(spec: ParticleSpec) {
 async function handleConnectionSpecToProtoPayload(spec: HandleConnectionSpec) {
   const directionOrdinal = DirectionEnum.values[spec.direction.replace(/ /g, '_').toUpperCase()];
   if (directionOrdinal === undefined) {
-    throw Error(`Handle connection direction ${spec.direction} is not supported`);
+    throw new Error(`Handle connection direction ${spec.direction} is not supported`);
   }
   return {
     name: spec.name,
@@ -252,7 +249,7 @@ function recipeParticleToProtoPayload(particle: Particle, handleMap: Map<Handle,
 async function recipeHandleToProtoPayload(handle: Handle) {
   const fateOrdinal = FateEnum.values[handle.fate.toUpperCase()];
   if (fateOrdinal === undefined) {
-    throw Error(`Handle fate ${handle.fate} is not supported`);
+    throw new Error(`Handle fate ${handle.fate} is not supported`);
   }
   const toName = handle => handle.localName || `handle${handle.recipe.handles.indexOf(handle)}`;
   const handleData = {
@@ -351,7 +348,7 @@ export async function typeToProtoPayload(type: Type) {
     //     name: (type as TypeVariable).variable.name,
     //   }
     // };
-    default: throw Error(`Type '${type.tag}' is not supported.`);
+    default: throw new Error(`Type '${type.tag}' is not supported.`);
   }
 }
 
@@ -377,7 +374,7 @@ async function schemaFieldToProtoPayload(fieldType: SchemaField) {
     case 'schema-primitive': {
       const primitive = PrimitiveTypeEnum.values[fieldType.type.toUpperCase()];
       if (primitive === undefined) {
-        throw Error(`Primitive field type ${fieldType.type} is not supported.`);
+        throw new Error(`Primitive field type ${fieldType.type} is not supported.`);
       }
       return {primitive};
     }
@@ -407,7 +404,7 @@ async function schemaFieldToProtoPayload(fieldType: SchemaField) {
     }
     // TODO(b/154947220) support schema-unions
     case 'schema-union':
-    default: throw Error(`Schema field kind ${fieldType.kind} is not supported.`);
+    default: throw new Error(`Schema field kind ${fieldType.kind} is not supported.`);
   }
 }
 
@@ -426,7 +423,7 @@ function toOpProto(op: Op): number {
     Op.EQ, Op.NEQ,
   ].indexOf(op);
 
-  if (opEnum === -1) throw Error(`Op type '${op}' is not supported.`);
+  if (opEnum === -1) throw new Error(`Op type '${op}' is not supported.`);
 
   return opEnum;
 }

--- a/src/tools/tests/manifest2proto-test.ts
+++ b/src/tools/tests/manifest2proto-test.ts
@@ -14,6 +14,8 @@ import {Manifest} from '../../runtime/manifest.js';
 import {Capabilities, Shareable, Persistence, Queryable} from '../../runtime/capabilities.js';
 import {fs} from '../../platform/fs-web.js';
 import {CapabilityEnum, ManifestProto, TypeProto} from '../manifest-proto.js';
+import {Loader} from '../../platform/loader.js';
+import {assertThrowsAsync} from '../../testing/test-util.js';
 
 describe('manifest2proto', () => {
 
@@ -917,6 +919,62 @@ describe('manifest2proto', () => {
         },
       },
     ]);
+  });
+
+  it('supports imports in .arcs files', async () => {
+    const loader = new Loader(null, {
+      '/a.arcs': `
+        particle ParticleA
+          foo: writes Person {name: Text}
+      `,
+      '/b.arcs': `
+        particle ParticleB
+          bar: reads Person {name: Text}
+      `,
+      '/c.arcs': `
+        import './a.arcs'
+        import './b.arcs'
+
+        recipe R
+          h: create
+          ParticleA
+            foo: h
+          ParticleB
+            bar: h
+      `,
+    });
+    const manifest = await Manifest.load('/c.arcs', loader);
+    const data = await toProtoAndBack(manifest);
+    const recipe = data.recipes[0];
+    const particleSpecs = data.particleSpecs;
+    assert.deepStrictEqual(recipe.particles.map(p => p.specName), ['ParticleA', 'ParticleB']);
+    assert.deepStrictEqual(particleSpecs.map(p => p.name), ['ParticleA', 'ParticleB']);
+  });
+
+  it('rejects duplicate definitions in imported .arcs files', async () => {
+    const loader = new Loader(null, {
+      '/a.arcs': `
+        particle Dupe
+          foo: reads Person {}
+      `,
+      '/b.arcs': `
+        particle Dupe
+          foo: reads Person {}
+      `,
+      '/c.arcs': `
+        import './a.arcs'
+        import './b.arcs'
+
+        recipe R
+          h: create
+          Dupe
+            foo: h
+      `,
+    });
+    const manifest = await Manifest.load('/c.arcs', loader);
+    await assertThrowsAsync(
+        async () => toProtoAndBack(manifest),
+        `Duplicate definition of particle named 'Dupe'.`);
   });
 
   // On the TypeScript side we serialize .arcs file and validate it equals the .pb.bin file.


### PR DESCRIPTION
Also introduces `Manifest.validateUniqueDefinitions()` to verify that there are no duplicates in the imported files. It'd be nice to have proper namespaces one day, so I don't want to go too far in that direction right now, so for now it's just a method on `Manifest` that you can optionally call (and we do call it, for manifest2proto).