### PR TITLE
Deflake Core SameHandleManagerTest

### DIFF
--- a/java/arcs/core/crdt/CrdtSet.kt
+++ b/java/arcs/core/crdt/CrdtSet.kt
@@ -60,11 +60,17 @@ class CrdtSet<T : Referencable>(
                     // Both models have the same value at the same version. Add it to the merge.
                     mergedData.values[id] = myEntry
                 } else {
-                    // Models have different versions for the same value. Merge the versions,
-                    // and update other.
+                    // Models have different versions for the value with the same id.
+                    // Merge the versions, and update the value to whichever is newer.
                     DataValue(
                         myVersion mergeWith otherVersion,
-                        myValue
+                        if (myVersion dominates otherVersion) myValue
+                        else if (otherVersion dominates myVersion) otherValue
+                        else {
+                            // Concurrent changes. Pick value with smaller hashcode.
+                            if (myValue.hashCode() <= otherValue.hashCode()) myValue
+                            else otherValue
+                        }
                     ).also {
                         mergedData.values[id] = it
                         fastForwardOp.added += it

--- a/java/arcs/core/entity/Handle.kt
+++ b/java/arcs/core/entity/Handle.kt
@@ -69,9 +69,9 @@ data class HandleSpec(
     @Deprecated(
         "Use main constructor",
         ReplaceWith(
-            //ktlint-disable: max-line-length
+            /* ktlint-disable max-line-length */
             "HandleSpec(baseName, mode, toType(entitySpec, dataType, containerType), setOf(entitySpec))"
-            //ktlint-enable: max-line-length
+            /* ktlint-enable max-line-length */
         )
     )
     constructor(

--- a/java/arcs/core/entity/Handle.kt
+++ b/java/arcs/core/entity/Handle.kt
@@ -66,7 +66,14 @@ data class HandleSpec(
     val entitySpecs: Set<EntitySpec<*>>
 ) {
 
-    @Deprecated("Use main constructor")
+    @Deprecated(
+        "Use main constructor",
+        ReplaceWith(
+            //ktlint-disable: max-line-length
+            "HandleSpec(baseName, mode, toType(entitySpec, dataType, containerType), setOf(entitySpec))"
+            //ktlint-enable: max-line-length
+        )
+    )
     constructor(
         baseName: String,
         mode: HandleMode,
@@ -80,7 +87,7 @@ data class HandleSpec(
         setOf(entitySpec)
     )
 
-    @Deprecated("Use all entity specs.")
+    @Deprecated("Use all entity specs.", ReplaceWith("entitySpecs.single()"))
     val entitySpec: EntitySpec<*>
         get() = entitySpecs.single()
 
@@ -106,7 +113,7 @@ data class HandleSpec(
         }
 
     companion object {
-        private fun toType(
+        fun toType(
             entitySpec: EntitySpec<*>,
             dataType: HandleDataType,
             containerType: HandleContainerType

--- a/java/arcs/core/storage/StorageProxy.kt
+++ b/java/arcs/core/storage/StorageProxy.kt
@@ -383,7 +383,9 @@ class StorageProxy<Data : CrdtData, Op : CrdtOperationAtTime, T>(
     }
 
     private fun processModelUpdate(model: Data) {
+        log.debug { "Handling Model Update: $model" }
         // TODO: send the returned merge changes to notifyUpdate()
+        log.debug { "Current value: ${crdt.data}" }
         val valueBefore = crdt.consumerView
         crdt.merge(model)
 
@@ -401,7 +403,10 @@ class StorageProxy<Data : CrdtData, Op : CrdtOperationAtTime, T>(
 
         when (priorState) {
             ProxyState.AWAITING_SYNC -> notifyReady()
-            ProxyState.SYNC -> if (valueBefore != value) notifyUpdate(value)
+            ProxyState.SYNC -> {
+                if (valueBefore != value) notifyUpdate(value)
+                else log.debug { "valueBefore:\n$valueBefore\nis same as value after:\n$value" }
+            }
             ProxyState.DESYNC -> notifyResync()
             ProxyState.NO_SYNC,
             ProxyState.READY_TO_SYNC,
@@ -412,6 +417,7 @@ class StorageProxy<Data : CrdtData, Op : CrdtOperationAtTime, T>(
     }
 
     private fun processModelOps(operations: List<Op>) {
+        log.debug { "Handling ops" }
         // Ignore update ops when not synchronized.
         if (stateHolder.value.state != ProxyState.SYNC) return
 

--- a/java/arcs/core/storage/StorageProxy.kt
+++ b/java/arcs/core/storage/StorageProxy.kt
@@ -383,9 +383,7 @@ class StorageProxy<Data : CrdtData, Op : CrdtOperationAtTime, T>(
     }
 
     private fun processModelUpdate(model: Data) {
-        log.debug { "Handling Model Update: $model" }
         // TODO: send the returned merge changes to notifyUpdate()
-        log.debug { "Current value: ${crdt.data}" }
         val valueBefore = crdt.consumerView
         crdt.merge(model)
 
@@ -403,10 +401,7 @@ class StorageProxy<Data : CrdtData, Op : CrdtOperationAtTime, T>(
 
         when (priorState) {
             ProxyState.AWAITING_SYNC -> notifyReady()
-            ProxyState.SYNC -> {
-                if (valueBefore != value) notifyUpdate(value)
-                else log.debug { "valueBefore:\n$valueBefore\nis same as value after:\n$value" }
-            }
+            ProxyState.SYNC -> if (valueBefore != value) notifyUpdate(value)
             ProxyState.DESYNC -> notifyResync()
             ProxyState.NO_SYNC,
             ProxyState.READY_TO_SYNC,
@@ -417,7 +412,6 @@ class StorageProxy<Data : CrdtData, Op : CrdtOperationAtTime, T>(
     }
 
     private fun processModelOps(operations: List<Op>) {
-        log.debug { "Handling ops" }
         // Ignore update ops when not synchronized.
         if (stateHolder.value.state != ProxyState.SYNC) return
 

--- a/javatests/arcs/android/entity/DifferentAndroidHandleManagerDifferentStoresTest.kt
+++ b/javatests/arcs/android/entity/DifferentAndroidHandleManagerDifferentStoresTest.kt
@@ -33,10 +33,6 @@ class DifferentAndroidHandleManagerDifferentStoresTest : HandleManagerTestBase()
 
     lateinit var app: Application
 
-    override var testRunner = { block: suspend CoroutineScope.() -> Unit ->
-        runBlocking { this.block() }
-    }
-
     @Before
     override fun setUp() {
         super.setUp()

--- a/javatests/arcs/android/entity/DifferentHandleManagerTest.kt
+++ b/javatests/arcs/android/entity/DifferentHandleManagerTest.kt
@@ -33,10 +33,6 @@ class DifferentHandleManagerTest : HandleManagerTestBase() {
 
     lateinit var app: Application
 
-    override var testRunner = { block: suspend CoroutineScope.() -> Unit ->
-        runBlocking { this.block() }
-    }
-
     @Before
     override fun setUp() {
         super.setUp()

--- a/javatests/arcs/android/entity/SameHandleManagerTest.kt
+++ b/javatests/arcs/android/entity/SameHandleManagerTest.kt
@@ -32,10 +32,6 @@ class SameHandleManagerTest : HandleManagerTestBase() {
 
     lateinit var app: Application
 
-    override var testRunner = { block: suspend CoroutineScope.() -> Unit ->
-        runBlocking { this.block() }
-    }
-
     @Before
     override fun setUp() {
         super.setUp()

--- a/javatests/arcs/core/crdt/BUILD
+++ b/javatests/arcs/core/crdt/BUILD
@@ -14,7 +14,7 @@ arcs_kt_jvm_test_suite(
         "//java/arcs/core/common",
         "//java/arcs/core/crdt",
         "//java/arcs/core/data",
-        "//java/arcs/core/data/util",
+        "//java/arcs/core/util",
         "//third_party/java/junit:junit-android",
         "//third_party/java/truth:truth-android",
         "//third_party/kotlin/kotlin:kotlin_test",

--- a/javatests/arcs/core/crdt/BUILD
+++ b/javatests/arcs/core/crdt/BUILD
@@ -14,6 +14,7 @@ arcs_kt_jvm_test_suite(
         "//java/arcs/core/common",
         "//java/arcs/core/crdt",
         "//java/arcs/core/data",
+        "//java/arcs/core/data/util",
         "//third_party/java/junit:junit-android",
         "//third_party/java/truth:truth-android",
         "//third_party/kotlin/kotlin:kotlin_test",

--- a/javatests/arcs/core/crdt/BUILD
+++ b/javatests/arcs/core/crdt/BUILD
@@ -14,7 +14,7 @@ arcs_kt_jvm_test_suite(
         "//java/arcs/core/common",
         "//java/arcs/core/crdt",
         "//java/arcs/core/data",
-        "//java/arcs/core/util",
+        "//java/arcs/core/data/util:data-util",
         "//third_party/java/junit:junit-android",
         "//third_party/java/truth:truth-android",
         "//third_party/kotlin/kotlin:kotlin_test",

--- a/javatests/arcs/core/entity/HandleManagerTestBase.kt
+++ b/javatests/arcs/core/entity/HandleManagerTestBase.kt
@@ -112,10 +112,10 @@ open class HandleManagerTestBase {
             stores = StoreManager()
         )
         runBlocking {
-            //withTimeout(10000) { block() }
-            block()
+            withTimeout(10000) { block() }
+            //block()
             schedulerProvider.cancelAll()
-            //monitorHandleManager.close()
+            monitorHandleManager.close()
         }
     }
 
@@ -132,8 +132,8 @@ open class HandleManagerTestBase {
         // TODO(b/151366899): this is less than ideal - we should investigate how to make the entire
         //  test process cancellable/stoppable, even when we cross scopes into a BindingContext or
         //  over to other RamDisk listeners.
-        //readHandleManager.close()
-        //writeHandleManager.close()
+        readHandleManager.close()
+        writeHandleManager.close()
     }
 
     @Test

--- a/javatests/arcs/core/entity/HandleManagerTestBase.kt
+++ b/javatests/arcs/core/entity/HandleManagerTestBase.kt
@@ -439,8 +439,13 @@ open class HandleManagerTestBase {
 
         // Modify the entity.
         val modEntity1 = entity1.copy(name = "Ben")
-        val entityModified = monitorHandle.onUpdateDeferred { it.single().name == "Ben" }
-        withContext(writeEntityHandle.dispatcher) { writeEntityHandle.store(modEntity1) }
+        val entityModified = monitorHandle.onUpdateDeferred {
+            it.all { person -> person.name == "Ben" }
+        }
+        withContext(writeEntityHandle.dispatcher) {
+            writeEntityHandle.store(modEntity1)
+            assertThat(writeEntityHandle.size()).isEqualTo(1)
+        }
         withTimeout(1500) {
             entityModified.await()
         }
@@ -954,9 +959,8 @@ open class HandleManagerTestBase {
         // Modify the entities.
         val modEntity1 = entity1.copy(name = "Ben")
         val modEntity2 = entity2.copy(name = "Ben")
-        var count = 0
         val entitiesWritten = monitorHandle.onUpdateDeferred {
-            ++count == 2
+            it.all { person -> person.name == "Ben" }
         }
         withContext(writeEntityHandle.dispatcher) {
             writeEntityHandle.store(modEntity1)

--- a/javatests/arcs/core/entity/HandleManagerTestBase.kt
+++ b/javatests/arcs/core/entity/HandleManagerTestBase.kt
@@ -118,7 +118,6 @@ open class HandleManagerTestBase {
         )
         runBlocking {
             withTimeout(10000) { block() }
-            //block()
             schedulerProvider.cancelAll()
             monitorHandleManager.close()
         }

--- a/javatests/arcs/core/entity/HandleManagerTestBase.kt
+++ b/javatests/arcs/core/entity/HandleManagerTestBase.kt
@@ -124,6 +124,7 @@ open class HandleManagerTestBase {
         }
     }
 
+    @Suppress("NON_APPLICABLE_CALL_FOR_BUILDER_INFERENCE")
     private var ramDiskActivity = callbackFlow {
         offer(Unit)
         val listener: (StorageKey, Any?) -> Unit = { _, _ -> offer(Unit) }
@@ -421,7 +422,6 @@ open class HandleManagerTestBase {
     open fun singleton_referenceLiveness() = testRunner {
         // Create and store an entity.
         val writeEntityHandle = writeHandleManager.createCollectionHandle()
-        val readEntityHandle = readHandleManager.createCollectionHandle()
         val monitorHandle = monitorHandleManager.createCollectionHandle()
         val initialEntityStored = monitorHandle.onUpdateDeferred { it.size == 1 }
         withContext(writeEntityHandle.dispatcher) { writeEntityHandle.store(entity1) }
@@ -764,8 +764,12 @@ open class HandleManagerTestBase {
             HandleSpec(
                 "hatCollection",
                 HandleMode.ReadWrite,
-                HandleContainerType.Collection,
-                Hat
+                toType(
+                    Hat,
+                    HandleDataType.Entity,
+                    HandleContainerType.Collection
+                ),
+                setOf(Hat)
             ),
             hatCollectionKey
         ).awaitReady() as ReadWriteCollectionHandle<Hat>

--- a/javatests/arcs/core/entity/SameHandleManagerTest.kt
+++ b/javatests/arcs/core/entity/SameHandleManagerTest.kt
@@ -34,25 +34,21 @@ class SameHandleManagerTest : HandleManagerTestBase() {
     @After
     override fun tearDown() = super.tearDown()
 
-    @Ignore("b/156865977 - Deflake")
     @Test
     override fun collection_noTTL() {
         super.collection_noTTL()
     }
 
-    @Ignore("b/157052996 - Deflake")
     @Test
     override fun singleton_referenceLiveness() {
         super.singleton_referenceLiveness()
     }
 
-    @Ignore("b/157203248 - Deflake")
     @Test
     override fun collection_referenceLiveness() {
         super.collection_referenceLiveness()
     }
 
-    @Ignore("b/157267026 - Deflake")
     @Test
     override fun collection_clearingElementsFromA_clearsThemFromB() {
         super.collection_clearingElementsFromA_clearsThemFromB()


### PR DESCRIPTION
In addition to deflaking core's SameHandleManagerTest, this uncovered and fixed a bug in `CrdtSet.merge` that didn't update values for items which had been changed.

Related Bugs:

http://b/156865977
http://b/157052996
http://b/157203248
http://b/157267026