### PR TITLE
Refactor StoreManager to contain an ActivationFactory

### DIFF
--- a/java/arcs/android/demo/DemoActivity.kt
+++ b/java/arcs/android/demo/DemoActivity.kt
@@ -18,6 +18,7 @@ import arcs.android.host.AndroidManifestHostRegistry
 import arcs.core.allocator.Allocator
 import arcs.core.host.EntityHandleManager
 import arcs.core.host.HostRegistry
+import arcs.core.storage.StoreManager
 import arcs.jvm.host.JvmSchedulerProvider
 import arcs.jvm.util.JvmTime
 import arcs.sdk.android.storage.ServiceStoreFactory
@@ -56,9 +57,11 @@ class DemoActivity : AppCompatActivity() {
                 EntityHandleManager(
                     time = JvmTime,
                     scheduler = schedulerProvider("personArc"),
-                    activationFactory = ServiceStoreFactory(
-                        context = this@DemoActivity,
-                        lifecycle = this@DemoActivity.lifecycle
+                    stores = StoreManager(
+                        activationFactory = ServiceStoreFactory(
+                            context = this@DemoActivity,
+                            lifecycle = this@DemoActivity.lifecycle
+                        )
                     )
                 )
             )

--- a/java/arcs/android/sdk/host/AndroidHost.kt
+++ b/java/arcs/android/sdk/host/AndroidHost.kt
@@ -17,6 +17,7 @@ import androidx.lifecycle.OnLifecycleEvent
 import arcs.core.host.ArcHost
 import arcs.core.host.ParticleRegistration
 import arcs.core.host.SchedulerProvider
+import arcs.core.storage.ActivationFactory
 import arcs.core.storage.StoreManager
 import arcs.jvm.host.JvmHost
 import arcs.sdk.android.storage.ServiceStoreFactory
@@ -29,16 +30,29 @@ import kotlinx.coroutines.runBlocking
 @ExperimentalCoroutinesApi
 abstract class AndroidHost(
     val context: Context,
-    val lifecycle: Lifecycle,
+    lifecycle: Lifecycle,
     schedulerProvider: SchedulerProvider,
+    override val activationFactory: ActivationFactory,
     vararg particles: ParticleRegistration
 ) : JvmHost(schedulerProvider, *particles), LifecycleObserver {
+
+    @ExperimentalCoroutinesApi
+    constructor(
+        context: Context,
+        lifecycle: Lifecycle,
+        schedulerProvider: SchedulerProvider,
+        vararg particles: ParticleRegistration
+    ) : this(
+        context,
+        lifecycle,
+        schedulerProvider,
+        ServiceStoreFactory(context, lifecycle),
+        *particles
+    )
 
     init {
         lifecycle.addObserver(this)
     }
-
-    override val activationFactory = ServiceStoreFactory(context, lifecycle)
 
     /*
      * Android uses [StorageService] which is a persistent process, so we don't share
@@ -46,7 +60,8 @@ abstract class AndroidHost(
      * new arc. Otherwise, when closing an [ActiveStore] when one Arc is shutdown leads to the
      * handles being unusable in other arcs that are still active.
      */
-    override val stores: StoreManager get() = StoreManager()
+    @ExperimentalCoroutinesApi
+    override val stores: StoreManager get() = StoreManager(activationFactory)
 
     @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)
     fun onLifecycleDestroyed() = runBlocking {

--- a/java/arcs/core/host/AbstractArcHost.kt
+++ b/java/arcs/core/host/AbstractArcHost.kt
@@ -54,8 +54,15 @@ typealias ParticleRegistration = Pair<ParticleIdentifier, ParticleConstructor>
 @ExperimentalCoroutinesApi
 abstract class AbstractArcHost(
     protected val schedulerProvider: SchedulerProvider,
+    open val activationFactory: ActivationFactory? = null,
     vararg initialParticles: ParticleRegistration
 ) : ArcHost {
+
+    constructor(
+        schedulerProvider: SchedulerProvider,
+        vararg initialParticles: ParticleRegistration
+    ) : this(schedulerProvider, null, *initialParticles)
+
     private val log = TaggedLog { "AbstractArcHost" }
     private val particleConstructors: MutableMap<ParticleIdentifier, ParticleConstructor> =
         mutableMapOf()
@@ -500,8 +507,7 @@ abstract class AbstractArcHost(
         hostId,
         platformTime,
         schedulerProvider(arcId),
-        stores,
-        activationFactory
+        stores
     )
 
     /**
@@ -509,12 +515,6 @@ abstract class AbstractArcHost(
      * singleton defined statically by this package.
      */
     open val stores = singletonStores
-
-    /**
-     * The [ActivationFactory] to use when activating stores. By default this is `null`,
-     * indicating that the default [ActivationFactory] will be used.
-     */
-    open val activationFactory: ActivationFactory? = null
 
     /**
      * Instantiate a [Particle] implementation for a given [ParticleIdentifier].

--- a/java/arcs/core/host/EntityHandleManager.kt
+++ b/java/arcs/core/host/EntityHandleManager.kt
@@ -55,6 +55,7 @@ import arcs.core.storage.referencemode.ReferenceModeStorageKey
 import arcs.core.util.Scheduler
 import arcs.core.util.Time
 import arcs.core.util.guardedBy
+import arcs.jvm.util.JvmTime
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -80,7 +81,10 @@ class EntityHandleManager(
     private val idGenerator: Id.Generator = Id.Generator.newSession()
 ) {
 
-    @Deprecated("prefer primary constructor")
+    @Deprecated(
+        message = "prefer primary constructor",
+        replaceWith = ReplaceWith("EntityHandleManager(arcId, hostId, time, scheduler, StoreManager(activationFactory), idGenerator )")
+    )
     constructor(
         arcId: String = Id.Generator.newSession().newArcId("arc").toString(),
         hostId: String = "nohost",
@@ -93,7 +97,7 @@ class EntityHandleManager(
         hostId,
         time,
         scheduler,
-        StoreManager(activationFactory ?: Store.defaultFactory),
+        StoreManager(activationFactory),
         idGenerator
     )
     

--- a/java/arcs/core/host/EntityHandleManager.kt
+++ b/java/arcs/core/host/EntityHandleManager.kt
@@ -95,8 +95,8 @@ class EntityHandleManager(
         scheduler,
         StoreManager(activationFactory ?: Store.defaultFactory),
         idGenerator
-
     )
+    
     private val proxyMutex = Mutex()
     private val singletonStorageProxies by guardedBy(
         proxyMutex,

--- a/java/arcs/core/host/EntityHandleManager.kt
+++ b/java/arcs/core/host/EntityHandleManager.kt
@@ -49,13 +49,11 @@ import arcs.core.entity.WriteSingletonHandle
 import arcs.core.storage.ActivationFactory
 import arcs.core.storage.StorageKey
 import arcs.core.storage.StorageMode
-import arcs.core.storage.Store
 import arcs.core.storage.StoreManager
 import arcs.core.storage.referencemode.ReferenceModeStorageKey
 import arcs.core.util.Scheduler
 import arcs.core.util.Time
 import arcs.core.util.guardedBy
-import arcs.jvm.util.JvmTime
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -83,7 +81,9 @@ class EntityHandleManager(
 
     @Deprecated(
         message = "prefer primary constructor",
-        replaceWith = ReplaceWith("EntityHandleManager(arcId, hostId, time, scheduler, StoreManager(activationFactory), idGenerator )")
+        /* ktlint-disable max-line-length */
+        replaceWith = ReplaceWith("EntityHandleManager(arcId, hostId, time, scheduler, StoreManager(activationFactory), idGenerator)")
+        /* ktlint-enable max-line-length */
     )
     constructor(
         arcId: String = Id.Generator.newSession().newArcId("arc").toString(),
@@ -100,7 +100,7 @@ class EntityHandleManager(
         StoreManager(activationFactory),
         idGenerator
     )
-    
+
     private val proxyMutex = Mutex()
     private val singletonStorageProxies by guardedBy(
         proxyMutex,

--- a/java/arcs/core/storage/Store.kt
+++ b/java/arcs/core/storage/Store.kt
@@ -94,7 +94,7 @@ class Store<Data : CrdtData, Op : CrdtOperation, ConsumerData>(
          * the [defaultFactory] instance.
          */
         @ExperimentalCoroutinesApi
-        private val defaultFactory = object : ActivationFactory {
+        val defaultFactory = object : ActivationFactory {
             override suspend fun <Data : CrdtData, Op : CrdtOperation, T> invoke(
                 options: StoreOptions<Data, Op, T>
             ): ActiveStore<Data, Op, T> = when (options.mode) {

--- a/java/arcs/core/storage/StoreManager.kt
+++ b/java/arcs/core/storage/StoreManager.kt
@@ -23,7 +23,7 @@ import kotlinx.coroutines.sync.withLock
 class StoreManager(
     /**
      * If a store doesn't yet exist in this [StoreManager] for a provided [StorageKey],
-     * it will be created using this [ActivationFactory]
+     * it will be created using this [ActivationFactory].
      */
     val activationFactory: ActivationFactory = Store.defaultFactory
 ) {

--- a/javatests/arcs/android/e2e/testapp/ReadAnimalHostService.kt
+++ b/javatests/arcs/android/e2e/testapp/ReadAnimalHostService.kt
@@ -20,6 +20,7 @@ import arcs.core.host.ArcHost
 import arcs.core.host.ParticleRegistration
 import arcs.core.host.SchedulerProvider
 import arcs.core.host.toRegistration
+import arcs.core.storage.StoreManager
 import arcs.jvm.host.JvmSchedulerProvider
 import arcs.sdk.android.storage.ServiceStoreFactory
 import kotlinx.coroutines.Dispatchers
@@ -49,9 +50,7 @@ class ReadAnimalHostService : ArcHostService() {
         lifecycle: Lifecycle,
         schedulerProvider: SchedulerProvider,
         vararg initialParticles: ParticleRegistration
-    ) : AndroidHost(context, lifecycle, schedulerProvider, *initialParticles) {
-        override val activationFactory = ServiceStoreFactory(context, lifecycle)
-    }
+    ) : AndroidHost(context, lifecycle, schedulerProvider, *initialParticles)
 
     inner class ReadAnimal: AbstractReadAnimal() {
         override fun onStart() {

--- a/javatests/arcs/android/e2e/testapp/StorageAccessService.kt
+++ b/javatests/arcs/android/e2e/testapp/StorageAccessService.kt
@@ -10,6 +10,7 @@ import arcs.core.entity.HandleDataType
 import arcs.core.entity.HandleSpec
 import arcs.core.entity.HandleSpec.Companion.toType
 import arcs.core.host.EntityHandleManager
+import arcs.core.storage.StoreManager
 import arcs.core.util.Scheduler
 import arcs.jvm.util.JvmTime
 import arcs.sdk.WriteSingletonHandle
@@ -42,9 +43,11 @@ class StorageAccessService : LifecycleService() {
             val handleManager = EntityHandleManager(
                 time = JvmTime,
                 scheduler = Scheduler(coroutineContext),
-                activationFactory = ServiceStoreFactory(
-                    this@StorageAccessService,
-                    lifecycle
+                stores = StoreManager(
+                    activationFactory = ServiceStoreFactory(
+                        this@StorageAccessService,
+                        lifecycle
+                    )
                 )
             )
             @Suppress("UNCHECKED_CAST")

--- a/javatests/arcs/android/e2e/testapp/TestActivity.kt
+++ b/javatests/arcs/android/e2e/testapp/TestActivity.kt
@@ -35,6 +35,7 @@ import arcs.core.entity.HandleSpec
 import arcs.core.entity.HandleSpec.Companion.toType
 import arcs.core.entity.awaitReady
 import arcs.core.host.EntityHandleManager
+import arcs.core.storage.StoreManager
 import arcs.jvm.host.JvmSchedulerProvider
 import arcs.jvm.util.JvmTime
 import arcs.sdk.ReadWriteCollectionHandle
@@ -172,9 +173,11 @@ class TestActivity : AppCompatActivity() {
             EntityHandleManager(
                 time = JvmTime,
                 scheduler = schedulerProvider("readWriteArc"),
-                activationFactory = ServiceStoreFactory(
-                    context = this@TestActivity,
-                    lifecycle = this@TestActivity.lifecycle
+                stores = StoreManager(
+                    activationFactory = ServiceStoreFactory(
+                        context = this@TestActivity,
+                        lifecycle = this@TestActivity.lifecycle
+                    )
                 )
             )
         )
@@ -189,9 +192,11 @@ class TestActivity : AppCompatActivity() {
             EntityHandleManager(
                 time = JvmTime,
                 scheduler = schedulerProvider("resurrectionArc"),
-                activationFactory = ServiceStoreFactory(
-                    context = this@TestActivity,
-                    lifecycle = this@TestActivity.lifecycle
+                stores = StoreManager(
+                    activationFactory = ServiceStoreFactory(
+                        context = this@TestActivity,
+                        lifecycle = this@TestActivity.lifecycle
+                    )
                 )
             )
         )
@@ -226,9 +231,11 @@ class TestActivity : AppCompatActivity() {
             EntityHandleManager(
                 time = JvmTime,
                 scheduler = schedulerProvider("allocator"),
-                activationFactory = ServiceStoreFactory(
-                    context = this@TestActivity,
-                    lifecycle = this@TestActivity.lifecycle
+                stores = StoreManager(
+                    activationFactory = ServiceStoreFactory(
+                        context = this@TestActivity,
+                        lifecycle = this@TestActivity.lifecycle
+                    )
                 )
             )
         )
@@ -262,9 +269,11 @@ class TestActivity : AppCompatActivity() {
         val handleManager = EntityHandleManager(
             time = JvmTime,
             scheduler = schedulerProvider("handle"),
-            activationFactory = ServiceStoreFactory(
-                this,
-                lifecycle
+            stores = StoreManager(
+                activationFactory = ServiceStoreFactory(
+                    this,
+                    lifecycle
+                )
             )
         )
         if (isCollection) {

--- a/javatests/arcs/android/e2e/testapp/WriteAnimalHostService.kt
+++ b/javatests/arcs/android/e2e/testapp/WriteAnimalHostService.kt
@@ -19,6 +19,7 @@ import arcs.android.sdk.host.ArcHostService
 import arcs.core.host.ParticleRegistration
 import arcs.core.host.SchedulerProvider
 import arcs.core.host.toRegistration
+import arcs.core.storage.StoreManager
 import arcs.jvm.host.JvmSchedulerProvider
 import arcs.sdk.android.storage.ServiceStoreFactory
 import kotlinx.coroutines.Dispatchers
@@ -64,8 +65,6 @@ class WriteAnimalHostService : ArcHostService() {
         schedulerProvider: SchedulerProvider,
         vararg initialParticles: ParticleRegistration
     ) : AndroidHost(context, lifecycle, schedulerProvider, *initialParticles) {
-        override val activationFactory = ServiceStoreFactory(context, lifecycle)
-
         fun arcHostContext(arcId: String) = getArcHostContext(arcId)
     }
 

--- a/javatests/arcs/android/e2e/testapp/WriteAnimalHostService.kt
+++ b/javatests/arcs/android/e2e/testapp/WriteAnimalHostService.kt
@@ -19,9 +19,7 @@ import arcs.android.sdk.host.ArcHostService
 import arcs.core.host.ParticleRegistration
 import arcs.core.host.SchedulerProvider
 import arcs.core.host.toRegistration
-import arcs.core.storage.StoreManager
 import arcs.jvm.host.JvmSchedulerProvider
-import arcs.sdk.android.storage.ServiceStoreFactory
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job

--- a/javatests/arcs/android/entity/DifferentAndroidHandleManagerDifferentStoresTest.kt
+++ b/javatests/arcs/android/entity/DifferentAndroidHandleManagerDifferentStoresTest.kt
@@ -44,11 +44,12 @@ class DifferentAndroidHandleManagerDifferentStoresTest : HandleManagerTestBase()
             hostId = "hostId",
             time = fakeTime,
             scheduler = schedulerProvider("reader"),
-            stores = StoreManager(),
-            activationFactory = ServiceStoreFactory(
-                app,
-                fakeLifecycleOwner.lifecycle,
-                connectionFactory = testConnectionFactory
+            stores = StoreManager(
+                activationFactory = ServiceStoreFactory(
+                    app,
+                    fakeLifecycleOwner.lifecycle,
+                    connectionFactory = testConnectionFactory
+                )
             )
         )
         writeHandleManager = EntityHandleManager(
@@ -56,11 +57,12 @@ class DifferentAndroidHandleManagerDifferentStoresTest : HandleManagerTestBase()
             hostId = "hostId",
             time = fakeTime,
             scheduler = schedulerProvider("writer"),
-            stores = StoreManager(),
-            activationFactory = ServiceStoreFactory(
-                app,
-                fakeLifecycleOwner.lifecycle,
-                connectionFactory = testConnectionFactory
+            stores = StoreManager(
+                activationFactory = ServiceStoreFactory(
+                    app,
+                    fakeLifecycleOwner.lifecycle,
+                    connectionFactory = testConnectionFactory
+                )
             )
         )
         // Initialize WorkManager for instrumentation tests.

--- a/javatests/arcs/android/entity/DifferentHandleManagerTest.kt
+++ b/javatests/arcs/android/entity/DifferentHandleManagerTest.kt
@@ -37,32 +37,28 @@ class DifferentHandleManagerTest : HandleManagerTestBase() {
     override fun setUp() {
         super.setUp()
         app = ApplicationProvider.getApplicationContext()
-        val stores = StoreManager()
         val testConnectionFactory = TestConnectionFactory(app)
-        schedulerProvider = JvmSchedulerProvider(EmptyCoroutineContext)
-        readHandleManager = EntityHandleManager(
-            arcId = "arcId",
-            hostId = "hostId",
-            time = fakeTime,
-            scheduler = schedulerProvider("reader"),
-            stores = stores,
+        val stores = StoreManager(
             activationFactory = ServiceStoreFactory(
                 app,
                 fakeLifecycleOwner.lifecycle,
                 connectionFactory = testConnectionFactory
             )
         )
+        schedulerProvider = JvmSchedulerProvider(EmptyCoroutineContext)
+        readHandleManager = EntityHandleManager(
+            arcId = "arcId",
+            hostId = "hostId",
+            time = fakeTime,
+            scheduler = schedulerProvider("reader"),
+            stores = stores
+        )
         writeHandleManager = EntityHandleManager(
             arcId = "arcId",
             hostId = "hostId",
             time = fakeTime,
             scheduler = schedulerProvider("writer"),
-            stores = stores,
-            activationFactory = ServiceStoreFactory(
-                app,
-                fakeLifecycleOwner.lifecycle,
-                connectionFactory = testConnectionFactory
-            )
+            stores = stores
         )
         // Initialize WorkManager for instrumentation tests.
         WorkManagerTestInitHelper.initializeTestWorkManager(app)

--- a/javatests/arcs/android/entity/SameHandleManagerTest.kt
+++ b/javatests/arcs/android/entity/SameHandleManagerTest.kt
@@ -42,11 +42,12 @@ class SameHandleManagerTest : HandleManagerTestBase() {
             hostId = "hostId",
             time = fakeTime,
             scheduler = schedulerProvider("test"),
-            stores = StoreManager(),
-            activationFactory = ServiceStoreFactory(
-                app,
-                fakeLifecycleOwner.lifecycle,
-                connectionFactory = TestConnectionFactory(app)
+            stores = StoreManager(
+                activationFactory = ServiceStoreFactory(
+                    app,
+                    fakeLifecycleOwner.lifecycle,
+                    connectionFactory = TestConnectionFactory(app)
+                )
             )
         )
         writeHandleManager = readHandleManager

--- a/javatests/arcs/android/host/AndroidEntityHandleManagerTest.kt
+++ b/javatests/arcs/android/host/AndroidEntityHandleManagerTest.kt
@@ -126,11 +126,12 @@ class AndroidEntityHandleManagerTest : LifecycleOwner {
             "testHost",
             FakeTime(),
             schedulerProvider("testArc"),
-            StoreManager(),
-            ServiceStoreFactory(
-                context = app,
-                lifecycle = lifecycle,
-                connectionFactory = TestConnectionFactory(app)
+            StoreManager(
+                activationFactory = ServiceStoreFactory(
+                    context = app,
+                    lifecycle = lifecycle,
+                    connectionFactory = TestConnectionFactory(app)
+                )
             )
         )
     }

--- a/javatests/arcs/android/host/BUILD
+++ b/javatests/arcs/android/host/BUILD
@@ -83,6 +83,7 @@ arcs_kt_android_library(
         "//java/arcs/android/sdk/host",
         "//java/arcs/core/data",
         "//java/arcs/core/host",
+        "//java/arcs/core/storage",
         "//java/arcs/jvm/host",
         "//java/arcs/sdk",
         "//java/arcs/sdk/android/storage",

--- a/javatests/arcs/android/host/TestExternalArcHostService.kt
+++ b/javatests/arcs/android/host/TestExternalArcHostService.kt
@@ -12,6 +12,7 @@ import arcs.core.data.Capabilities
 import arcs.core.host.ParticleRegistration
 import arcs.core.host.SchedulerProvider
 import arcs.core.host.TestingHost
+import arcs.core.storage.StoreManager
 import arcs.sdk.android.storage.ResurrectionHelper
 import arcs.sdk.android.storage.ServiceStoreFactory
 import arcs.sdk.android.storage.service.ConnectionFactory
@@ -56,18 +57,18 @@ abstract class TestExternalArcHostService : Service() {
         schedulerProvider: SchedulerProvider,
         vararg particles: ParticleRegistration
     ) : TestingHost(schedulerProvider, *particles), ResurrectableHost {
-        override val stores = singletonStores
-
-        override val resurrectionHelper: ResurrectionHelper =
-            ResurrectionHelper(context, ::onResurrected)
-
-        @kotlinx.coroutines.ExperimentalCoroutinesApi
-        override val activationFactory =  ServiceStoreFactory(
+        @ExperimentalCoroutinesApi
+        override val stores = StoreManager(
+            activationFactory = ServiceStoreFactory(
                 context,
                 FakeLifecycle(),
                 Dispatchers.Default,
                 testConnectionFactory
             )
+        )
+
+        override val resurrectionHelper: ResurrectionHelper =
+            ResurrectionHelper(context, ::onResurrected)
 
         override val arcHostContextCapability = testingCapability
     }

--- a/javatests/arcs/android/host/TestProdArcHostService.kt
+++ b/javatests/arcs/android/host/TestProdArcHostService.kt
@@ -6,6 +6,7 @@ import arcs.android.host.prod.ProdArcHostService
 import arcs.core.host.ParticleRegistration
 import arcs.core.host.SchedulerProvider
 import arcs.core.host.TestingJvmProdHost
+import arcs.core.storage.StoreManager
 import arcs.jvm.host.JvmSchedulerProvider
 import arcs.sdk.android.storage.ServiceStoreFactory
 import arcs.sdk.android.storage.service.testutil.TestConnectionFactory
@@ -28,11 +29,13 @@ class TestProdArcHostService : ProdArcHostService() {
         vararg particles: ParticleRegistration
     ) : TestingJvmProdHost(schedulerProvider, *particles) {
 
-        @kotlinx.coroutines.ExperimentalCoroutinesApi
-        override val activationFactory = ServiceStoreFactory(
-            context,
-            lifecycle,
-            connectionFactory = TestConnectionFactory(context)
+        @ExperimentalCoroutinesApi
+        override val stores = StoreManager(
+            activationFactory = ServiceStoreFactory(
+                context,
+                lifecycle,
+                connectionFactory = TestConnectionFactory(context)
+            )
         )
     }
 }

--- a/javatests/arcs/android/systemhealth/testapp/StorageCore.kt
+++ b/javatests/arcs/android/systemhealth/testapp/StorageCore.kt
@@ -26,6 +26,7 @@ import arcs.core.entity.HandleSpec.Companion.toType
 import arcs.core.entity.awaitReady
 import arcs.core.host.EntityHandleManager
 import arcs.core.storage.Reference
+import arcs.core.storage.StoreManager
 import arcs.core.storage.keys.DatabaseStorageKey
 import arcs.core.storage.keys.RamDiskStorageKey
 import arcs.core.storage.referencemode.ReferenceModeStorageKey
@@ -266,18 +267,20 @@ class StorageCore(val context: Context, val lifecycle: Lifecycle) {
             TaskHandle(
                 EntityHandleManager(
                     time = JvmTime,
-                    activationFactory = ServiceStoreFactory(
-                        context,
-                        lifecycle,
-                        taskCoroutineContext,
-                        DefaultConnectionFactory(
+                    stores = StoreManager(
+                        activationFactory = ServiceStoreFactory(
                             context,
-                            if (settings.function == Function.STABILITY_TEST) {
-                                TestStorageServiceBindingDelegate(context)
-                            } else {
-                                DefaultStorageServiceBindingDelegate(context)
-                            },
-                            taskCoroutineContext
+                            lifecycle,
+                            taskCoroutineContext,
+                            DefaultConnectionFactory(
+                                context,
+                                if (settings.function == Function.STABILITY_TEST) {
+                                    TestStorageServiceBindingDelegate(context)
+                                } else {
+                                    DefaultStorageServiceBindingDelegate(context)
+                                },
+                                taskCoroutineContext
+                            )
                         )
                     ),
                     // Per-task single-threaded Scheduler being cascaded with Watchdog capabilities

--- a/javatests/arcs/android/systemhealth/testapp/TestActivity.kt
+++ b/javatests/arcs/android/systemhealth/testapp/TestActivity.kt
@@ -36,6 +36,7 @@ import arcs.core.entity.HandleSpec.Companion.toType
 import arcs.core.entity.ReadSingletonHandle
 import arcs.core.entity.awaitReady
 import arcs.core.host.EntityHandleManager
+import arcs.core.storage.StoreManager
 import arcs.jvm.host.JvmSchedulerProvider
 import arcs.jvm.util.JvmTime
 import arcs.sdk.ReadCollectionHandle
@@ -109,10 +110,12 @@ class TestActivity : AppCompatActivity() {
         handleManager = EntityHandleManager(
             time = JvmTime,
             scheduler = schedulerProvider("sysHealthTestActivity"),
-            activationFactory = ServiceStoreFactory(
-                this,
-                lifecycle,
-                coroutineContext
+            stores = StoreManager(
+                activationFactory = ServiceStoreFactory(
+                    this,
+                    lifecycle,
+                    coroutineContext
+                )
             )
         )
 

--- a/javatests/arcs/core/entity/StorageAdapterTest.kt
+++ b/javatests/arcs/core/entity/StorageAdapterTest.kt
@@ -7,6 +7,7 @@ import arcs.core.data.Ttl
 import arcs.core.data.util.toReferencable
 import arcs.core.storage.Reference as StorageReference
 import arcs.core.storage.StorageKey
+import arcs.core.storage.Store
 import arcs.core.storage.StoreManager
 import arcs.core.storage.keys.DatabaseStorageKey
 import arcs.core.storage.keys.RamDiskStorageKey
@@ -26,7 +27,7 @@ import org.junit.runners.JUnit4
 class StorageAdapterTest {
 
     private val time = FakeTime()
-    private val dereferencerFactory = EntityDereferencerFactory()
+    private val dereferencerFactory = EntityDereferencerFactory(Store.defaultFactory)
     private val idGenerator = Id.Generator.newForTest("session")
     private val storageKey = DummyStorageKey("entities")
 

--- a/javatests/arcs/showcase/references/Arcs.kt
+++ b/javatests/arcs/showcase/references/Arcs.kt
@@ -12,6 +12,7 @@ import arcs.core.common.toArcId
 import arcs.core.host.EntityHandleManager
 import arcs.core.host.SchedulerProvider
 import arcs.core.host.toRegistration
+import arcs.core.storage.StoreManager
 import arcs.jvm.host.ExplicitHostRegistry
 import arcs.jvm.host.JvmSchedulerProvider
 import arcs.jvm.util.JvmTime
@@ -152,12 +153,14 @@ class ArcHost(
     ::Reader2.toRegistration(),
     ::Writer2.toRegistration()
 ) {
-    override val activationFactory = ServiceStoreFactory(
-        context,
-        lifecycle,
-        connectionFactory = connectionFactory
+    @ExperimentalCoroutinesApi
+    override val stores = StoreManager(
+        activationFactory = ServiceStoreFactory(
+            context,
+            lifecycle,
+            connectionFactory = connectionFactory
+        )
     )
-
     @Suppress("UNCHECKED_CAST")
     private fun <T> getParticle(name: String) =
         getArcHostContext("!:testArc")!!.particles[name]!!.particle as T

--- a/javatests/arcs/showcase/references/BUILD
+++ b/javatests/arcs/showcase/references/BUILD
@@ -31,6 +31,7 @@ arcs_kt_android_library(
         "//java/arcs/core/common",
         "//java/arcs/core/entity",
         "//java/arcs/core/host",
+        "//java/arcs/core/storage",
         "//java/arcs/core/storage/api",
         "//java/arcs/jvm/host",
         "//java/arcs/jvm/util",


### PR DESCRIPTION
Everywhere that used StoreManger was using a
`storeManager.get().activate(activationFactory)` pattern, which also
required passing around an activationFactory.

This refactor changes StoreManager to be constructed with an
activationFactory, so that it can create ActiveStores directly,
simplifying usage.