### PR TITLE
Parse nested schemas inside manifests

### DIFF
--- a/src/runtime/manifest-ast-nodes.ts
+++ b/src/runtime/manifest-ast-nodes.ts
@@ -750,6 +750,11 @@ export interface SchemaInline extends BaseNodeWithRefinement {
   fields: SchemaInlineField[];
 }
 
+export interface NestedSchema extends BaseNodeWithRefinement {
+  kind: 'schema-nested';
+  fields: SchemaInlineField[];
+}
+
 export interface SchemaInlineField extends BaseNode {
   kind: 'schema-inline-field';
   name: string;

--- a/src/runtime/manifest-ast-nodes.ts
+++ b/src/runtime/manifest-ast-nodes.ts
@@ -752,7 +752,7 @@ export interface SchemaInline extends BaseNodeWithRefinement {
 
 export interface NestedSchema extends BaseNodeWithRefinement {
   kind: 'schema-nested';
-  fields: SchemaInlineField[];
+  schema: SchemaInline;
 }
 
 export interface SchemaInlineField extends BaseNode {

--- a/src/runtime/manifest-parser.pegjs
+++ b/src/runtime/manifest-parser.pegjs
@@ -1472,19 +1472,13 @@ RecipeSlot
   }
 
 SchemaInline
-  = names:((upperIdent / '*') whiteSpace?)* fields:SchemaInlineFields
+  = names:((upperIdent / '*') whiteSpace?)* '{' multiLineSpace fields:(SchemaInlineField (',' multiLineSpace SchemaInlineField)*)? ','? multiLineSpace '}'
   {
     return toAstNode<AstNode.SchemaInline>({
       kind: 'schema-inline',
       names: optional(names, names => names.map(name => name[0]).filter(name => name !== '*'), ['*']),
-      fields
+      fields: optional(fields, fields => [fields[0], ...fields[1].map(tail => tail[2])], [])
     });
-  }
-
-SchemaInlineFields
-  = '{' multiLineSpace fields:(SchemaInlineField (',' multiLineSpace SchemaInlineField)*)? ','? multiLineSpace '}'
-  {
-    return optional(fields, fields => [fields[0], ...fields[1].map(tail => tail[2])], []);
   }
 
 SchemaInlineField
@@ -1615,11 +1609,11 @@ SchemaPrimitiveType
     });
   }
 
-NestedSchemaType = fields:SchemaInlineFields
+NestedSchemaType = 'inline' whiteSpace? schema:SchemaInline
   {
     return toAstNode<AstNode.NestedSchema>({
       kind: 'schema-nested',
-      fields
+      schema
     }); 
   }
 

--- a/src/runtime/tests/manifest-parser-test.ts
+++ b/src/runtime/tests/manifest-parser-test.ts
@@ -470,7 +470,7 @@ describe('manifest parser', () => {
     parse(`
       schema ContainsNested
         fieldBefore: Double
-        nestedField: {someNums: List<Number>, aString: Text}
+        nestedField: inline * {someNums: List<Number>, aString: Text}
         fieldAfter: List<Long>
     `);
   });
@@ -479,7 +479,25 @@ describe('manifest parser', () => {
       particle Foo
         containsNested: reads ContainsNested {
           fieldBefore: Double,
-          nestedField: {someNums: List<Number>, aString: Text},
+          nestedField: inline Thing {someNums: List<Number>, aString: Text},
+          fieldAfter: Long
+        }
+    `);
+  });
+  it('parses a schema with a list of nested schemas', () => {
+    parse(`
+      schema ContainsNested
+        fieldBefore: Double
+        nestedField: List<inline * {someNums: List<Number>, aString: Text}>
+        fieldAfter: List<Long>
+    `);
+  });
+  it('parses an inline schema with a list of nested schemas', () => {
+    parse(`
+      particle Foo
+        containsNested: reads ContainsNested {
+          fieldBefore: Double,
+          nestedField: List<inline Thing {someNums: List<Number>, aString: Text}>,
           fieldAfter: Long
         }
     `);

--- a/src/runtime/tests/manifest-parser-test.ts
+++ b/src/runtime/tests/manifest-parser-test.ts
@@ -466,6 +466,24 @@ describe('manifest parser', () => {
         kotlinThings: reads KotlinThings {aByte: Byte, aShort: Short, anInt: Int, aLong: Long, aChar: Char, aFloat: Float, aDouble: Double}
     `);
   });
+  it('parses a schema with a nested schema', () => {
+    parse(`
+      schema ContainsNested
+        fieldBefore: Double
+        nestedField: {someNums: List<Number>, aString: Text}
+        fieldAfter: List<Long>
+    `);
+  });
+  it('parses an inline schema with a nested schema', () => {
+    parse(`
+      particle Foo
+        containsNested: reads ContainsNested {
+          fieldBefore: Double,
+          nestedField: {someNums: List<Number>, aString: Text},
+          fieldAfter: Long
+        }
+    `);
+  });
   it('parses a schema with ordered list types', () => {
     parse(`
       schema OrderedLists


### PR DESCRIPTION
The way that you can tell these apart from nested references (and eventually nested entities) is that these are anonymous. So:

* `{foo: {bar: Text, far: Long}}` is inline structure; foo.bar and foo.far will work but foo isn't a reference or sharable with other entities without copying.
* `{foo: &Thing {bar: Text, far: Long}}`: foo is a sharable reference
* `{foo: Thing {bar: Text, far: Long}}`: foo is stored normalized as a reference but the particle will treat it like it's inlined. foo.bar and foo.far will work, foo can be shared with other entities and you don't need to copy it.
