### PR TITLE
Remove StorageMode from StoreOptions

### DIFF
--- a/java/arcs/android/storage/ParcelableStoreOptions.kt
+++ b/java/arcs/android/storage/ParcelableStoreOptions.kt
@@ -19,7 +19,6 @@ import arcs.android.type.writeType
 import arcs.core.crdt.CrdtData
 import arcs.core.crdt.CrdtOperation
 import arcs.core.storage.StorageKeyParser
-import arcs.core.storage.StorageMode
 import arcs.core.storage.StoreOptions
 
 /** [Parcelable] variant for [StoreOptions]. */
@@ -31,7 +30,6 @@ data class ParcelableStoreOptions(
         parcel.writeInt(crdtType.ordinal)
         parcel.writeString(actual.storageKey.toString())
         parcel.writeType(actual.type, flags)
-        parcel.writeInt(actual.mode.ordinal)
         // Skip StoreOptions.baseStore.
         parcel.writeString(actual.versionToken)
     }
@@ -43,14 +41,12 @@ data class ParcelableStoreOptions(
             val crdtType = ParcelableCrdtType.values()[parcel.readInt()]
             val storageKey = StorageKeyParser.parse(requireNotNull(parcel.readString()))
             val type = requireNotNull(parcel.readType()) { "Could not extract Type from Parcel" }
-            val mode = StorageMode.values()[parcel.readInt()]
             val versionToken = parcel.readString()
 
             return ParcelableStoreOptions(
                 StoreOptions(
                     storageKey = storageKey,
                     type = type,
-                    mode = mode,
                     baseStore = null, // Skip baseStore.
                     versionToken = versionToken
                 ),

--- a/java/arcs/core/host/EntityHandleManager.kt
+++ b/java/arcs/core/host/EntityHandleManager.kt
@@ -48,7 +48,6 @@ import arcs.core.entity.WriteQueryCollectionHandle
 import arcs.core.entity.WriteSingletonHandle
 import arcs.core.storage.ActivationFactory
 import arcs.core.storage.StorageKey
-import arcs.core.storage.StorageMode
 import arcs.core.storage.StoreManager
 import arcs.core.storage.referencemode.ReferenceModeStorageKey
 import arcs.core.util.Scheduler
@@ -207,8 +206,7 @@ class EntityHandleManager(
             spec = config.spec,
             proxy = singletonStoreProxy(
                 config.storageKey,
-                config.spec.entitySpecs.single().SCHEMA,
-                config.spec.dataType.toStorageMode()
+                config.spec.entitySpecs.single().SCHEMA
             ),
             storageAdapter = config.storageAdapter,
             dereferencerFactory = dereferencerFactory,
@@ -236,8 +234,7 @@ class EntityHandleManager(
             spec = config.spec,
             proxy = collectionStoreProxy(
                 config.storageKey,
-                config.spec.entitySpecs.single().SCHEMA,
-                config.spec.dataType.toStorageMode()
+                config.spec.entitySpecs.single().SCHEMA
             ),
             storageAdapter = config.storageAdapter,
             dereferencerFactory = dereferencerFactory,
@@ -265,15 +262,13 @@ class EntityHandleManager(
     @Suppress("UNCHECKED_CAST")
     private suspend fun <R : Referencable> singletonStoreProxy(
         storageKey: StorageKey,
-        schema: Schema,
-        storageMode: StorageMode
+        schema: Schema
     ): SingletonProxy<R> = proxyMutex.withLock {
         singletonStorageProxies.getOrPut(storageKey) {
             val activeStore = stores.get(
                 SingletonStoreOptions<Referencable>(
                     storageKey = storageKey,
-                    type = SingletonType(EntityType(schema)),
-                    mode = storageMode
+                    type = SingletonType(EntityType(schema))
                 )
             )
             SingletonProxy(activeStore, CrdtSingleton(), scheduler)
@@ -284,23 +279,16 @@ class EntityHandleManager(
     @Suppress("UNCHECKED_CAST")
     private suspend fun <R : Referencable> collectionStoreProxy(
         storageKey: StorageKey,
-        schema: Schema,
-        storageMode: StorageMode
+        schema: Schema
     ): CollectionProxy<R> = proxyMutex.withLock {
         collectionStorageProxies.getOrPut(storageKey) {
             val activeStore = stores.get(
                 CollectionStoreOptions<Referencable>(
                     storageKey = storageKey,
-                    type = CollectionType(EntityType(schema)),
-                    mode = storageMode
+                    type = CollectionType(EntityType(schema))
                 )
             )
             CollectionProxy(activeStore, CrdtSet(), scheduler)
         } as CollectionProxy<R>
     }
-}
-
-private fun HandleDataType.toStorageMode() = when (this) {
-    HandleDataType.Entity -> StorageMode.ReferenceMode
-    HandleDataType.Reference -> StorageMode.Direct
 }

--- a/java/arcs/core/storage/ActiveStore.kt
+++ b/java/arcs/core/storage/ActiveStore.kt
@@ -24,7 +24,6 @@ import arcs.core.type.Type
 abstract class ActiveStore<Data : CrdtData, Op : CrdtOperation, ConsumerData>(
     options: StoreOptions<Data, Op, ConsumerData>
 ) : IStore<Data, Op, ConsumerData>, StorageCommunicationEndpointProvider<Data, Op, ConsumerData> {
-    override val mode: StorageMode = options.mode
     override val storageKey: StorageKey = options.storageKey
     override val type: Type = options.type
     open val versionToken: String? = options.versionToken

--- a/java/arcs/core/storage/RawEntityDereferencer.kt
+++ b/java/arcs/core/storage/RawEntityDereferencer.kt
@@ -49,8 +49,7 @@ class RawEntityDereferencer(
 
         val options = StoreOptions<CrdtEntity.Data, CrdtEntity.Operation, RawEntity>(
             storageKey,
-            EntityType(schema),
-            StorageMode.Direct
+            EntityType(schema)
         )
 
         val store = Store(options).activate(entityActivationFactory)

--- a/java/arcs/core/storage/Store.kt
+++ b/java/arcs/core/storage/Store.kt
@@ -14,6 +14,7 @@ package arcs.core.storage
 import arcs.core.crdt.CrdtData
 import arcs.core.crdt.CrdtOperation
 import arcs.core.storage.Store.Companion.defaultFactory
+import arcs.core.storage.referencemode.ReferenceModeStorageKey
 import arcs.core.type.Type
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 
@@ -42,7 +43,6 @@ class Store<Data : CrdtData, Op : CrdtOperation, ConsumerData>(
     options: StoreOptions<Data, Op, ConsumerData>
 ) : IStore<Data, Op, ConsumerData> {
     override val storageKey: StorageKey = options.storageKey
-    override val mode: StorageMode = options.mode
     override val type: Type = options.type
     private var activeStore: ActiveStore<Data, Op, ConsumerData>? = null
         get() = synchronized(this) { field }
@@ -70,7 +70,6 @@ class Store<Data : CrdtData, Op : CrdtOperation, ConsumerData>(
         val options = StoreOptions(
             storageKey = storageKey,
             type = type,
-            mode = mode,
             baseStore = this,
             versionToken = parsedVersionToken
         )
@@ -95,10 +94,10 @@ class Store<Data : CrdtData, Op : CrdtOperation, ConsumerData>(
         val defaultFactory = object : ActivationFactory {
             override suspend fun <Data : CrdtData, Op : CrdtOperation, T> invoke(
                 options: StoreOptions<Data, Op, T>
-            ): ActiveStore<Data, Op, T> = when (options.mode) {
-                StorageMode.Direct -> DirectStore.create(options)
-                StorageMode.ReferenceMode ->
+            ): ActiveStore<Data, Op, T> = when (options.storageKey) {
+                is ReferenceModeStorageKey ->
                     ReferenceModeStore.create(options) as ActiveStore<Data, Op, T>
+                else -> DirectStore.create(options)
             }
         }
     }

--- a/java/arcs/core/storage/StoreInterface.kt
+++ b/java/arcs/core/storage/StoreInterface.kt
@@ -13,33 +13,18 @@ package arcs.core.storage
 
 import arcs.core.crdt.CrdtData
 import arcs.core.crdt.CrdtOperation
-import arcs.core.storage.referencemode.ReferenceModeStorageKey
 import arcs.core.type.Type
 
 /** Base interface which all store implementations must extend from. */
 interface IStore<Data : CrdtData, Op : CrdtOperation, ConsumerData> {
     val storageKey: StorageKey
-    val mode: StorageMode
     val type: Type
-}
-
-/**
- * Modes for Storage.
- *
- * TODO: need actual, helpful kdoc for these.
- */
-enum class StorageMode {
-    Direct,
-    ReferenceMode,
 }
 
 /** Wrapper for options which will be used to construct a [Store]. */
 data class StoreOptions<Data : CrdtData, Op : CrdtOperation, ConsumerData>(
     val storageKey: StorageKey,
     val type: Type,
-    val mode: StorageMode =
-        if (storageKey is ReferenceModeStorageKey) StorageMode.ReferenceMode
-        else StorageMode.Direct,
     val baseStore: IStore<Data, Op, ConsumerData>? = null,
     val versionToken: String? = null
 )

--- a/javatests/arcs/android/storage/ParcelableStoreOptionsTest.kt
+++ b/javatests/arcs/android/storage/ParcelableStoreOptionsTest.kt
@@ -16,7 +16,6 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import arcs.android.crdt.ParcelableCrdtType
 import arcs.core.crdt.CrdtCount
 import arcs.core.data.CountType
-import arcs.core.storage.StorageMode
 import arcs.core.storage.StoreOptions
 import arcs.core.storage.keys.RamDiskStorageKey
 import arcs.core.storage.referencemode.ReferenceModeStorageKey
@@ -32,7 +31,6 @@ class ParcelableStoreOptionsTest {
         val storeOptions = StoreOptions<CrdtCount.Data, CrdtCount.Operation, Int>(
             RamDiskStorageKey("test"),
             CountType(),
-            StorageMode.Direct,
             versionToken = "Foo"
         )
 
@@ -57,8 +55,7 @@ class ParcelableStoreOptionsTest {
                 RamDiskStorageKey("backing"),
                 RamDiskStorageKey("collection")
             ),
-            CountType(),
-            StorageMode.ReferenceMode
+            CountType()
         )
 
         val marshalled = with(Parcel.obtain()) {

--- a/javatests/arcs/android/storage/ReferenceModeStoreDatabaseImplIntegrationTest.kt
+++ b/javatests/arcs/android/storage/ReferenceModeStoreDatabaseImplIntegrationTest.kt
@@ -27,14 +27,12 @@ import arcs.core.data.SchemaFields
 import arcs.core.data.SchemaName
 import arcs.core.data.SingletonType
 import arcs.core.data.util.toReferencable
-import arcs.core.data.util.ReferencablePrimitive
 import arcs.core.storage.CapabilitiesResolver
 import arcs.core.storage.DriverFactory
 import arcs.core.storage.ProxyCallback
 import arcs.core.storage.ProxyMessage
 import arcs.core.storage.Reference
 import arcs.core.storage.ReferenceModeStore
-import arcs.core.storage.StorageMode
 import arcs.core.storage.StoreOptions
 import arcs.core.storage.StoreWriteBack
 import arcs.core.storage.database.DatabaseData
@@ -655,8 +653,7 @@ class ReferenceModeStoreDatabaseImplIntegrationTest {
         return ReferenceModeStore.create(
             StoreOptions<RefModeStoreData, RefModeStoreOp, RefModeStoreOutput>(
                 testKey,
-                CollectionType(EntityType(schema)),
-                StorageMode.ReferenceMode
+                CollectionType(EntityType(schema))
             )
         )
     }
@@ -665,8 +662,7 @@ class ReferenceModeStoreDatabaseImplIntegrationTest {
         return ReferenceModeStore.create(
             StoreOptions<RefModeStoreData, RefModeStoreOp, RefModeStoreOutput>(
                 testKey,
-                SingletonType(EntityType(schema)),
-                StorageMode.ReferenceMode
+                SingletonType(EntityType(schema))
             )
         )
     }

--- a/javatests/arcs/core/entity/StorageAdapterTest.kt
+++ b/javatests/arcs/core/entity/StorageAdapterTest.kt
@@ -16,6 +16,7 @@ import arcs.core.storage.testutil.DummyStorageKey
 import arcs.core.util.Scheduler
 import arcs.jvm.util.testutil.FakeTime
 import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.test.assertFailsWith
 import org.junit.Before
@@ -23,9 +24,9 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
+@ExperimentalCoroutinesApi
 @RunWith(JUnit4::class)
 class StorageAdapterTest {
-
     private val time = FakeTime()
     private val dereferencerFactory = EntityDereferencerFactory(Store.defaultFactory)
     private val idGenerator = Id.Generator.newForTest("session")

--- a/javatests/arcs/core/storage/ReferenceModeStoreDatabaseIntegrationTest.kt
+++ b/javatests/arcs/core/storage/ReferenceModeStoreDatabaseIntegrationTest.kt
@@ -609,8 +609,7 @@ class ReferenceModeStoreDatabaseIntegrationTest {
         return ReferenceModeStore.create(
             StoreOptions<RefModeStoreData, RefModeStoreOp, RefModeStoreOutput>(
                 testKey,
-                CollectionType(EntityType(schema)),
-                StorageMode.ReferenceMode
+                CollectionType(EntityType(schema))
             )
         )
     }
@@ -619,8 +618,7 @@ class ReferenceModeStoreDatabaseIntegrationTest {
         return ReferenceModeStore.create(
             StoreOptions<RefModeStoreData, RefModeStoreOp, RefModeStoreOutput>(
                 testKey,
-                SingletonType(EntityType(schema)),
-                StorageMode.ReferenceMode
+                SingletonType(EntityType(schema))
             )
         )
     }

--- a/javatests/arcs/core/storage/ReferenceModeStoreStabilityTest.kt
+++ b/javatests/arcs/core/storage/ReferenceModeStoreStabilityTest.kt
@@ -82,8 +82,7 @@ class ReferenceModeStoreStabilityTest {
         val store = Store(
             StoreOptions<RefModeStoreData, RefModeStoreOp, RawEntity?>(
                 storageKey,
-                SingletonType(EntityType(schema)),
-                StorageMode.ReferenceMode
+                SingletonType(EntityType(schema))
             )
         ).activate()
 
@@ -122,8 +121,7 @@ class ReferenceModeStoreStabilityTest {
         val store = Store(
             StoreOptions<RefModeStoreData, RefModeStoreOp, RawEntity?>(
                 storageKey,
-                CollectionType(EntityType(schema)),
-                StorageMode.ReferenceMode
+                CollectionType(EntityType(schema))
             )
         ).activate()
 
@@ -185,8 +183,7 @@ class ReferenceModeStoreStabilityTest {
         val store = Store(
             StoreOptions<RefModeStoreData, RefModeStoreOp, RawEntity?>(
                 storageKey,
-                CollectionType(EntityType(schema)),
-                StorageMode.ReferenceMode
+                CollectionType(EntityType(schema))
             )
         ).activate()
 
@@ -248,8 +245,7 @@ class ReferenceModeStoreStabilityTest {
         val store = Store(
             StoreOptions<RefModeStoreData, RefModeStoreOp, RawEntity?>(
                 storageKey,
-                SingletonType(EntityType(schema)),
-                StorageMode.ReferenceMode
+                SingletonType(EntityType(schema))
             )
         ).activate()
 
@@ -311,8 +307,7 @@ class ReferenceModeStoreStabilityTest {
         val store = Store(
             StoreOptions<RefModeStoreData, RefModeStoreOp, RawEntity?>(
                 storageKey,
-                CollectionType(EntityType(schema)),
-                StorageMode.ReferenceMode
+                CollectionType(EntityType(schema))
             )
         ).activate()
 

--- a/javatests/arcs/core/storage/ReferenceModeStoreTest.kt
+++ b/javatests/arcs/core/storage/ReferenceModeStoreTest.kt
@@ -92,8 +92,7 @@ class ReferenceModeStoreTest {
         val store = Store<RefModeStoreData, RefModeStoreOp, RefModeStoreOutput>(
             StoreOptions(
                 testKey,
-                SingletonType(EntityType(schema)),
-                StorageMode.ReferenceMode
+                SingletonType(EntityType(schema))
             )
         )
         assertSuspendingThrows(CrdtException::class) { store.activate() }
@@ -106,8 +105,7 @@ class ReferenceModeStoreTest {
         val store = Store<RefModeStoreData, RefModeStoreOp, RefModeStoreOutput>(
             StoreOptions(
                 testKey,
-                CollectionType(EntityType(schema)),
-                mode = StorageMode.ReferenceMode
+                CollectionType(EntityType(schema))
             )
         )
         val activeStore = store.activate()
@@ -647,8 +645,7 @@ class ReferenceModeStoreTest {
         return ReferenceModeStore.create(
             StoreOptions<RefModeStoreData, RefModeStoreOp, RefModeStoreOutput>(
                 testKey,
-                CollectionType(EntityType(schema)),
-                StorageMode.ReferenceMode
+                CollectionType(EntityType(schema))
             )
         )
     }
@@ -657,8 +654,7 @@ class ReferenceModeStoreTest {
         return ReferenceModeStore.create(
             StoreOptions<RefModeStoreData, RefModeStoreOp, RefModeStoreOutput>(
                 testKey,
-                SingletonType(EntityType(schema)),
-                StorageMode.ReferenceMode
+                SingletonType(EntityType(schema))
             )
         )
     }

--- a/javatests/arcs/core/storage/ReferenceTest.kt
+++ b/javatests/arcs/core/storage/ReferenceTest.kt
@@ -58,8 +58,7 @@ class ReferenceTest {
         val options =
             StoreOptions<CrdtSet.Data<RawEntity>, CrdtSet.Operation<RawEntity>, Set<RawEntity>>(
                 storageKey = refModeKey,
-                type = CollectionType(EntityType(Person.SCHEMA)),
-                mode = StorageMode.ReferenceMode
+                type = CollectionType(EntityType(Person.SCHEMA))
             )
         val store = Store(options).activate()
 
@@ -86,8 +85,7 @@ class ReferenceTest {
         val collectionOptions =
             StoreOptions<CrdtSet.Data<Reference>, CrdtSet.Operation<Reference>, Set<Reference>>(
                 storageKey = collectionKey,
-                type = CollectionType(ReferenceType(EntityType(Person.SCHEMA))),
-                mode = StorageMode.Direct
+                type = CollectionType(ReferenceType(EntityType(Person.SCHEMA)))
             )
 
         @Suppress("UNCHECKED_CAST")

--- a/javatests/arcs/core/storage/StoreWriteBackTest.kt
+++ b/javatests/arcs/core/storage/StoreWriteBackTest.kt
@@ -220,8 +220,7 @@ class StoreWriteBackTest {
         return ReferenceModeStore.create(
             StoreOptions<RefModeStoreData, RefModeStoreOp, RefModeStoreOutput>(
                 testKey,
-                CollectionType(EntityType(schema)),
-                StorageMode.ReferenceMode
+                CollectionType(EntityType(schema))
             )
         )
     }


### PR DESCRIPTION
Since this now only contains `Direct` mode and `Reference` modes, it can
be completely inferred from storage key.