### PR TITLE
Remove baseStore from StoreOptions

### DIFF
--- a/java/arcs/android/storage/ParcelableStoreOptions.kt
+++ b/java/arcs/android/storage/ParcelableStoreOptions.kt
@@ -16,21 +16,18 @@ import android.os.Parcelable
 import arcs.android.crdt.ParcelableCrdtType
 import arcs.android.type.readType
 import arcs.android.type.writeType
-import arcs.core.crdt.CrdtData
-import arcs.core.crdt.CrdtOperation
 import arcs.core.storage.StorageKeyParser
 import arcs.core.storage.StoreOptions
 
 /** [Parcelable] variant for [StoreOptions]. */
 data class ParcelableStoreOptions(
-    val actual: StoreOptions<out CrdtData, out CrdtOperation, out Any?>,
+    val actual: StoreOptions,
     val crdtType: ParcelableCrdtType
 ) : Parcelable {
     override fun writeToParcel(parcel: Parcel, flags: Int) {
         parcel.writeInt(crdtType.ordinal)
         parcel.writeString(actual.storageKey.toString())
         parcel.writeType(actual.type, flags)
-        // Skip StoreOptions.baseStore.
         parcel.writeString(actual.versionToken)
     }
 
@@ -47,7 +44,6 @@ data class ParcelableStoreOptions(
                 StoreOptions(
                     storageKey = storageKey,
                     type = type,
-                    baseStore = null, // Skip baseStore.
                     versionToken = versionToken
                 ),
                 crdtType
@@ -61,17 +57,17 @@ data class ParcelableStoreOptions(
 /**
  * Wraps the [StoreOptions] in a [ParcelableStoreOptions], using the [ParcelableCrdtType] as a hint.
  */
-fun StoreOptions<out CrdtData, out CrdtOperation, out Any?>.toParcelable(
+fun StoreOptions.toParcelable(
     crdtType: ParcelableCrdtType
 ): ParcelableStoreOptions = ParcelableStoreOptions(this, crdtType)
 
 /** Writes [StoreOptions] to the [Parcel]. */
 fun Parcel.writeStoreOptions(
-    storeOptions: StoreOptions<out CrdtData, out CrdtOperation, out Any?>,
+    storeOptions: StoreOptions,
     representingCrdtType: ParcelableCrdtType,
     flags: Int
 ) = writeTypedObject(storeOptions.toParcelable(representingCrdtType), flags)
 
 /** Reads [StoreOptions] from the [Parcel]. */
-fun Parcel.readStoreOptions(): StoreOptions<out CrdtData, out CrdtOperation, out Any?>? =
+fun Parcel.readStoreOptions(): StoreOptions? =
     readTypedObject(ParcelableStoreOptions)?.actual

--- a/java/arcs/core/entity/CollectionHandle.kt
+++ b/java/arcs/core/entity/CollectionHandle.kt
@@ -14,12 +14,8 @@ import arcs.core.common.Referencable
 import arcs.core.crdt.CrdtSet
 import arcs.core.data.RawEntity
 import arcs.core.storage.StorageProxy
-import arcs.core.storage.StoreOptions
 import kotlinx.coroutines.Job
 
-typealias CollectionData<T> = CrdtSet.Data<T>
-typealias CollectionOp<T> = CrdtSet.IOperation<T>
-typealias CollectionStoreOptions<T> = StoreOptions<CollectionData<T>, CollectionOp<T>, Set<T>>
 typealias CollectionProxy<T> = StorageProxy<CrdtSet.Data<T>, CrdtSet.IOperation<T>, Set<T>>
 
 /**

--- a/java/arcs/core/entity/SingletonHandle.kt
+++ b/java/arcs/core/entity/SingletonHandle.kt
@@ -14,13 +14,11 @@ import arcs.core.common.Referencable
 import arcs.core.crdt.CrdtSingleton
 import arcs.core.data.RawEntity
 import arcs.core.storage.StorageProxy
-import arcs.core.storage.StoreOptions
 import kotlinx.coroutines.Job
 
-typealias SingletonProxy<T> = StorageProxy<SingletonData<T>, SingletonOp<T>, T?>
 typealias SingletonData<T> = CrdtSingleton.Data<T>
 typealias SingletonOp<T> = CrdtSingleton.IOperation<T>
-typealias SingletonStoreOptions<T> = StoreOptions<SingletonData<T>, SingletonOp<T>, T?>
+typealias SingletonProxy<T> = StorageProxy<SingletonData<T>, SingletonOp<T>, T?>
 
 /**
  * This class implements all of the methods that are needed by the various singleton [Handle]

--- a/java/arcs/core/storage/ActiveStore.kt
+++ b/java/arcs/core/storage/ActiveStore.kt
@@ -22,13 +22,11 @@ import arcs.core.type.Type
  * within the [StoreOptions].
  */
 abstract class ActiveStore<Data : CrdtData, Op : CrdtOperation, ConsumerData>(
-    options: StoreOptions<Data, Op, ConsumerData>
+    options: StoreOptions
 ) : IStore<Data, Op, ConsumerData>, StorageCommunicationEndpointProvider<Data, Op, ConsumerData> {
     override val storageKey: StorageKey = options.storageKey
     override val type: Type = options.type
     open val versionToken: String? = options.versionToken
-    /** The [IStore] this instance is fronting. */
-    val baseStore: IStore<Data, Op, ConsumerData>? = options.baseStore
 
     /** Suspends until all pending operations are complete. */
     open suspend fun idle() = Unit

--- a/java/arcs/core/storage/DirectStore.kt
+++ b/java/arcs/core/storage/DirectStore.kt
@@ -45,7 +45,7 @@ import kotlinx.coroutines.runBlocking
  */
 @Suppress("EXPERIMENTAL_API_USAGE")
 class DirectStore<Data : CrdtData, Op : CrdtOperation, T> /* internal */ constructor(
-    options: StoreOptions<Data, Op, T>,
+    options: StoreOptions,
     /* internal */
     val localModel: CrdtModel<Data, Op, T>,
     /* internal */
@@ -498,7 +498,7 @@ class DirectStore<Data : CrdtData, Op : CrdtOperation, T> /* internal */ constru
 
         @Suppress("UNCHECKED_CAST")
         suspend fun <Data : CrdtData, Op : CrdtOperation, T> create(
-            options: StoreOptions<Data, Op, T>
+            options: StoreOptions
         ): DirectStore<Data, Op, T> {
             val crdtType = requireNotNull(options.type as CrdtModelType<Data, Op, T>) {
                 "Type not supported: ${options.type}"

--- a/java/arcs/core/storage/DirectStoreMuxer.kt
+++ b/java/arcs/core/storage/DirectStoreMuxer.kt
@@ -104,8 +104,8 @@ class DirectStoreMuxer<Data : CrdtData, Op : CrdtOperation, T>(
     }
 
     /* internal */ suspend fun setupStore(referenceId: String): StoreRecord<Data, Op, T> {
-        val store = DirectStore.create(
-            StoreOptions<Data, Op, T>(
+        val store = DirectStore.create<Data, Op, T>(
+            StoreOptions(
                 storageKey = storageKey.childKeyWithComponent(referenceId),
                 type = backingType
             )

--- a/java/arcs/core/storage/RawEntityDereferencer.kt
+++ b/java/arcs/core/storage/RawEntityDereferencer.kt
@@ -23,6 +23,8 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
+typealias EntityStore = ActiveStore<CrdtEntity.Data, CrdtEntity.Operation, CrdtEntity>
+
 /**
  * [Dereferencer] to use when de-referencing a [Reference] to an [Entity].
  *
@@ -47,12 +49,13 @@ class RawEntityDereferencer(
 
         val storageKey = reference.referencedStorageKey()
 
-        val options = StoreOptions<CrdtEntity.Data, CrdtEntity.Operation, RawEntity>(
+        val options = StoreOptions(
             storageKey,
             EntityType(schema)
         )
 
-        val store = (entityActivationFactory ?: Store.defaultFactory).invoke(options)
+        val store: EntityStore = (entityActivationFactory ?: Store.defaultFactory).invoke(options)
+
         val deferred = CompletableDeferred<RawEntity?>()
         var token = -1
         token = store.on(

--- a/java/arcs/core/storage/ReferenceModeStore.kt
+++ b/java/arcs/core/storage/ReferenceModeStore.kt
@@ -90,7 +90,7 @@ import kotlinx.coroutines.withTimeout
  */
 @ExperimentalCoroutinesApi
 class ReferenceModeStore private constructor(
-    options: StoreOptions<RefModeStoreData, RefModeStoreOp, RefModeStoreOutput>,
+    options: StoreOptions,
     /* internal */
     val containerStore: DirectStore<CrdtData, CrdtOperation, Any?>,
     /* internal */
@@ -698,13 +698,13 @@ class ReferenceModeStore private constructor(
         /* internal */ var BLOCKING_QUEUE_TIMEOUT_MILLIS = 30000L
 
         @Suppress("UNCHECKED_CAST")
-        suspend fun <Data : CrdtData, Op : CrdtOperation, T> create(
-            options: StoreOptions<Data, Op, T>
+        suspend fun create(
+            options: StoreOptions
         ): ReferenceModeStore {
             val refableOptions =
                 requireNotNull(
                     /* ktlint-disable max-line-length */
-                    options as? StoreOptions<RefModeStoreData, RefModeStoreOp, RefModeStoreOutput>
+                    options as? StoreOptions
                     /* ktlint-enable max-line-length */
                 ) { "ReferenceMode stores only manage singletons/collections of Entities." }
 

--- a/java/arcs/core/storage/StoreInterface.kt
+++ b/java/arcs/core/storage/StoreInterface.kt
@@ -22,9 +22,8 @@ interface IStore<Data : CrdtData, Op : CrdtOperation, ConsumerData> {
 }
 
 /** Wrapper for options which will be used to construct a [Store]. */
-data class StoreOptions<Data : CrdtData, Op : CrdtOperation, ConsumerData>(
+data class StoreOptions(
     val storageKey: StorageKey,
     val type: Type,
-    val baseStore: IStore<Data, Op, ConsumerData>? = null,
     val versionToken: String? = null
 )

--- a/java/arcs/core/storage/StoreManager.kt
+++ b/java/arcs/core/storage/StoreManager.kt
@@ -31,13 +31,13 @@ class StoreManager(
     private val storesMutex = Mutex()
     private val stores by guardedBy(storesMutex, mutableMapOf<StorageKey, ActiveStore<*, *, *>>())
 
-    @ExperimentalCoroutinesApi
     @Suppress("UNCHECKED_CAST")
+    @ExperimentalCoroutinesApi
     suspend fun <Data : CrdtData, Op : CrdtOperationAtTime, T> get(
-        storeOptions: StoreOptions<Data, Op, T>
+        storeOptions: StoreOptions
     ) = storesMutex.withLock {
         stores.getOrPut(storeOptions.storageKey) {
-            (activationFactory ?: Store.defaultFactory).invoke(storeOptions)
+            (activationFactory ?: Store.defaultFactory).invoke<Data, Op, T>(storeOptions)
         } as ActiveStore<Data, Op, T>
     }
 

--- a/java/arcs/sdk/android/storage/ServiceStore.kt
+++ b/java/arcs/sdk/android/storage/ServiceStore.kt
@@ -73,7 +73,7 @@ class ServiceStoreFactory(
     private val connectionFactory: ConnectionFactory? = null
 ) : ActivationFactory {
     override suspend operator fun <Data : CrdtData, Op : CrdtOperation, ConsumerData> invoke(
-        options: StoreOptions<Data, Op, ConsumerData>
+        options: StoreOptions
     ): ServiceStore<Data, Op, ConsumerData> {
         val storeContext = coroutineContext + CoroutineName("ServiceStore(${options.storageKey})")
         val parcelableType = when (options.type) {
@@ -84,7 +84,7 @@ class ServiceStoreFactory(
             else ->
                 throw IllegalArgumentException("Service store can't handle type ${options.type}")
         }
-        return ServiceStore(
+        return ServiceStore<Data, Op, ConsumerData>(
             options = options,
             crdtType = parcelableType,
             lifecycle = lifecycle,
@@ -100,7 +100,7 @@ class ServiceStoreFactory(
 @OptIn(FlowPreview::class)
 @ExperimentalCoroutinesApi
 class ServiceStore<Data : CrdtData, Op : CrdtOperation, ConsumerData>(
-    private val options: StoreOptions<Data, Op, ConsumerData>,
+    private val options: StoreOptions,
     private val crdtType: ParcelableCrdtType,
     lifecycle: Lifecycle,
     private val connectionFactory: ConnectionFactory,

--- a/java/arcs/sdk/android/storage/service/BUILD
+++ b/java/arcs/sdk/android/storage/service/BUILD
@@ -17,6 +17,7 @@ arcs_kt_android_library(
         "//java/arcs/android/storage/service:aidl",
         "//java/arcs/android/storage/ttl",
         "//java/arcs/android/util",
+        "//java/arcs/core/crdt",
         "//java/arcs/core/storage",
         "//java/arcs/core/storage/database",
         "//java/arcs/core/storage/driver",

--- a/java/arcs/sdk/android/storage/service/StorageService.kt
+++ b/java/arcs/sdk/android/storage/service/StorageService.kt
@@ -28,6 +28,8 @@ import arcs.android.storage.service.BindingContextStatsImpl
 import arcs.android.storage.service.StorageServiceManager
 import arcs.android.storage.ttl.PeriodicCleanupTask
 import arcs.android.util.AndroidBinderStats
+import arcs.core.crdt.CrdtData
+import arcs.core.crdt.CrdtOperationAtTime
 import arcs.core.storage.ProxyMessage
 import arcs.core.storage.StorageKey
 import arcs.core.storage.Store
@@ -153,7 +155,9 @@ open class StorageService : ResurrectorService() {
 
         val options = parcelableOptions.actual
         return BindingContext(
-            stores.computeIfAbsent(options.storageKey) { Store(options) },
+            stores.computeIfAbsent(options.storageKey) {
+                Store<CrdtData, CrdtOperationAtTime, Any>(options)
+            },
             coroutineContext,
             stats
         ) { storageKey, message ->

--- a/java/arcs/sdk/android/storage/service/StorageServiceConnection.kt
+++ b/java/arcs/sdk/android/storage/service/StorageServiceConnection.kt
@@ -30,7 +30,7 @@ import kotlinx.coroutines.Job
 
 /** A [ConnectionFactory] is capable of creating a [StorageServiceConnection]. */
 typealias ConnectionFactory =
-        (StoreOptions<*, *, *>, ParcelableCrdtType) -> StorageServiceConnection
+        (StoreOptions, ParcelableCrdtType) -> StorageServiceConnection
 
 typealias ManagerConnectionFactory = () -> StorageServiceConnection
 

--- a/javatests/arcs/android/storage/ParcelableStoreOptionsTest.kt
+++ b/javatests/arcs/android/storage/ParcelableStoreOptionsTest.kt
@@ -28,7 +28,7 @@ import org.junit.runner.RunWith
 class ParcelableStoreOptionsTest {
     @Test
     fun parcelableRoundtrip_works() {
-        val storeOptions = StoreOptions<CrdtCount.Data, CrdtCount.Operation, Int>(
+        val storeOptions = StoreOptions(
             RamDiskStorageKey("test"),
             CountType(),
             versionToken = "Foo"
@@ -50,7 +50,7 @@ class ParcelableStoreOptionsTest {
 
     @Test
     fun parcelableRoundtrip_works_withAllowableNullDefaults() {
-        val storeOptions = StoreOptions<CrdtCount.Data, CrdtCount.Operation, Int>(
+        val storeOptions = StoreOptions(
             ReferenceModeStorageKey(
                 RamDiskStorageKey("backing"),
                 RamDiskStorageKey("collection")

--- a/javatests/arcs/android/storage/ReferenceModeStoreDatabaseImplIntegrationTest.kt
+++ b/javatests/arcs/android/storage/ReferenceModeStoreDatabaseImplIntegrationTest.kt
@@ -693,7 +693,7 @@ class ReferenceModeStoreDatabaseImplIntegrationTest {
 
     private suspend fun createReferenceModeStore(): ReferenceModeStore {
         return ReferenceModeStore.create(
-            StoreOptions<RefModeStoreData, RefModeStoreOp, RefModeStoreOutput>(
+            StoreOptions(
                 testKey,
                 CollectionType(EntityType(schema))
             )
@@ -702,7 +702,7 @@ class ReferenceModeStoreDatabaseImplIntegrationTest {
 
     private suspend fun createSingletonReferenceModeStore(): ReferenceModeStore {
         return ReferenceModeStore.create(
-            StoreOptions<RefModeStoreData, RefModeStoreOp, RefModeStoreOutput>(
+            StoreOptions(
                 testKey,
                 SingletonType(EntityType(schema))
             )

--- a/javatests/arcs/core/storage/ReferenceModeStoreDatabaseIntegrationTest.kt
+++ b/javatests/arcs/core/storage/ReferenceModeStoreDatabaseIntegrationTest.kt
@@ -606,7 +606,7 @@ class ReferenceModeStoreDatabaseIntegrationTest {
 
     private suspend fun createReferenceModeStore(): ReferenceModeStore {
         return ReferenceModeStore.create(
-            StoreOptions<RefModeStoreData, RefModeStoreOp, RefModeStoreOutput>(
+            StoreOptions(
                 testKey,
                 CollectionType(EntityType(schema))
             )
@@ -615,7 +615,7 @@ class ReferenceModeStoreDatabaseIntegrationTest {
 
     private suspend fun createSingletonReferenceModeStore(): ReferenceModeStore {
         return ReferenceModeStore.create(
-            StoreOptions<RefModeStoreData, RefModeStoreOp, RefModeStoreOutput>(
+            StoreOptions(
                 testKey,
                 SingletonType(EntityType(schema))
             )

--- a/javatests/arcs/core/storage/ReferenceModeStoreStabilityTest.kt
+++ b/javatests/arcs/core/storage/ReferenceModeStoreStabilityTest.kt
@@ -79,8 +79,8 @@ class ReferenceModeStoreStabilityTest {
         )
         RamDisk.memory[containerKey] = VolatileEntry(singletonCrdt.data, 1)
 
-        val store = Store(
-            StoreOptions<RefModeStoreData, RefModeStoreOp, RawEntity?>(
+        val store = Store<RefModeStoreData, RefModeStoreOp, RawEntity?>(
+            StoreOptions(
                 storageKey,
                 SingletonType(EntityType(schema))
             )
@@ -118,8 +118,8 @@ class ReferenceModeStoreStabilityTest {
         )
         RamDisk.memory[containerKey] = VolatileEntry(setCrdt.data, 1)
 
-        val store = Store(
-            StoreOptions<RefModeStoreData, RefModeStoreOp, RawEntity?>(
+        val store = Store<RefModeStoreData, RefModeStoreOp, RawEntity?>(
+            StoreOptions(
                 storageKey,
                 CollectionType(EntityType(schema))
             )
@@ -180,8 +180,8 @@ class ReferenceModeStoreStabilityTest {
         RamDisk.memory[backingKey.childKeyWithComponent("foo_value")] =
             VolatileEntry(entityCrdt.data, 1)
 
-        val store = Store(
-            StoreOptions<RefModeStoreData, RefModeStoreOp, RawEntity?>(
+        val store = Store<RefModeStoreData, RefModeStoreOp, RawEntity?>(
+            StoreOptions(
                 storageKey,
                 CollectionType(EntityType(schema))
             )
@@ -242,8 +242,8 @@ class ReferenceModeStoreStabilityTest {
         RamDisk.memory[backingKey.childKeyWithComponent("foo_value")] =
             VolatileEntry(entityCrdt.data, 1)
 
-        val store = Store(
-            StoreOptions<RefModeStoreData, RefModeStoreOp, RawEntity?>(
+        val store = Store<RefModeStoreData, RefModeStoreOp, RawEntity?>(
+            StoreOptions(
                 storageKey,
                 SingletonType(EntityType(schema))
             )
@@ -304,8 +304,8 @@ class ReferenceModeStoreStabilityTest {
         RamDisk.memory[backingKey.childKeyWithComponent("foo_value")] =
             VolatileEntry(entityCrdt.data, 1)
 
-        val store = Store(
-            StoreOptions<RefModeStoreData, RefModeStoreOp, RawEntity?>(
+        val store = Store<RefModeStoreData, RefModeStoreOp, RawEntity?>(
+            StoreOptions(
                 storageKey,
                 CollectionType(EntityType(schema))
             )

--- a/javatests/arcs/core/storage/ReferenceModeStoreTest.kt
+++ b/javatests/arcs/core/storage/ReferenceModeStoreTest.kt
@@ -683,7 +683,7 @@ class ReferenceModeStoreTest {
 
     private suspend fun createReferenceModeStore(): ReferenceModeStore {
         return ReferenceModeStore.create(
-            StoreOptions<RefModeStoreData, RefModeStoreOp, RefModeStoreOutput>(
+            StoreOptions(
                 testKey,
                 CollectionType(EntityType(schema))
             )
@@ -692,7 +692,7 @@ class ReferenceModeStoreTest {
 
     private suspend fun createSingletonReferenceModeStore(): ReferenceModeStore {
         return ReferenceModeStore.create(
-            StoreOptions<RefModeStoreData, RefModeStoreOp, RefModeStoreOutput>(
+            StoreOptions(
                 testKey,
                 SingletonType(EntityType(schema))
             )

--- a/javatests/arcs/core/storage/StoreTest.kt
+++ b/javatests/arcs/core/storage/StoreTest.kt
@@ -249,10 +249,11 @@ class StoreTest {
             SchemaFields(mapOf("name" to FieldType.Text), emptyMap()),
             "abc"
         )
-        val store = Store(StoreOptions<CrdtSet.Data<RawEntity>, CrdtSet.Operation<RawEntity>, Set<RawEntity>>(
-            testKey,
-            CollectionType(EntityType(schema))
-        )).activate()
+        val store = Store<CrdtSet.Data<RawEntity>, CrdtSet.Operation<RawEntity>, Set<RawEntity>>(
+            StoreOptions(
+                testKey,
+                CollectionType(EntityType(schema))
+            )).activate()
 
         val remoteSet = CrdtSet<RawEntity>()
         val entity = RawEntity(

--- a/javatests/arcs/core/storage/StoreWriteBackTest.kt
+++ b/javatests/arcs/core/storage/StoreWriteBackTest.kt
@@ -218,7 +218,7 @@ class StoreWriteBackTest {
 
     private suspend fun createReferenceModeStore(): ReferenceModeStore {
         return ReferenceModeStore.create(
-            StoreOptions<RefModeStoreData, RefModeStoreOp, RefModeStoreOutput>(
+            StoreOptions(
                 testKey,
                 CollectionType(EntityType(schema))
             )

--- a/javatests/arcs/sdk/android/storage/service/StorageServiceConnectionTest.kt
+++ b/javatests/arcs/sdk/android/storage/service/StorageServiceConnectionTest.kt
@@ -140,7 +140,7 @@ class StorageServiceConnectionTest {
     }
 
     companion object {
-        private val OPTIONS = StoreOptions<CrdtCount.Data, CrdtCount.Operation, Int>(
+        private val OPTIONS = StoreOptions(
             RamDiskStorageKey("myData"),
             CountType()
         ).toParcelable(ParcelableCrdtType.Count)

--- a/javatests/arcs/sdk/android/storage/service/StorageServiceTest.kt
+++ b/javatests/arcs/sdk/android/storage/service/StorageServiceTest.kt
@@ -46,7 +46,7 @@ import org.robolectric.Shadows.shadowOf
 @RunWith(AndroidJUnit4::class)
 class StorageServiceTest {
     private lateinit var app: Application
-    private lateinit var storeOptions: StoreOptions<CrdtCount.Data, CrdtCount.Operation, Int>
+    private lateinit var storeOptions: StoreOptions
     private lateinit var workManager: WorkManager
 
     private val ttlTag = PeriodicCleanupTask.WORKER_TAG
@@ -203,7 +203,7 @@ class StorageServiceTest {
     }
 
     private fun lifecycle(
-        storeOptions: StoreOptions<*, *, *>,
+        storeOptions: StoreOptions,
         block: (StorageService, BindingContext) -> Unit
     ) {
         val intent = StorageService.createBindIntent(


### PR DESCRIPTION
It was not used in a meaningful way. With it removed, StoreOptions no longer takes type parameters, which required fixing up a few other sections of the codebase.