### PR TITLE
Pulls schema generation code out of kotlin-class-generator

### DIFF
--- a/src/tools/BUILD
+++ b/src/tools/BUILD
@@ -1,11 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
 filegroup(
-    name = "schema2wasm_srcs",
-    srcs = glob(["schema2*.ts"]) + [":kotlin-class-generator.ts"],
-)
-
-filegroup(
     name = "all_srcs",
     srcs = glob(["**"]),
 )

--- a/src/tools/kotlin-codegen-shared.ts
+++ b/src/tools/kotlin-codegen-shared.ts
@@ -78,14 +78,6 @@ export interface KotlinTypeInfo {
   schemaType: string;
 }
 
-export function typeFor(name: string): string {
-  return getTypeInfo({name}).type;
-}
-
-export function defaultValFor(name: string): string {
-  return getTypeInfo({name}).defaultVal;
-}
-
 export function getTypeInfo(opts: { name: string, isCollection?: boolean, refClassName?: string, listTypeName?: string, refSchemaHash?: string }): KotlinTypeInfo {
   if (opts.name === 'List') {
     assert(opts.listTypeName, 'listTypeName must be provided for Lists');

--- a/src/tools/kotlin-refinement-generator.ts
+++ b/src/tools/kotlin-refinement-generator.ts
@@ -11,7 +11,7 @@
 import {Op} from '../runtime/manifest-ast-nodes.js';
 import {Dictionary} from '../runtime/hot.js';
 import {Schema} from '../runtime/schema.js';
-import {escapeIdentifier, typeFor, defaultValFor} from './kotlin-codegen-shared.js';
+import {escapeIdentifier, getTypeInfo} from './kotlin-codegen-shared.js';
 import {RefinementExpressionVisitor, BinaryExpression, UnaryExpression, FieldNamePrimitive, QueryArgumentPrimitive, BuiltIn, NumberPrimitive, BooleanPrimitive, TextPrimitive} from '../runtime/refiner.js';
 
 // The variable name used for the query argument in generated Kotlin code.
@@ -83,7 +83,7 @@ export class KTExtracter {
     const genFieldAsLocal = (fieldName: string) => {
       const type = schema.fields[fieldName].type;
       const fixed = escapeIdentifier(fieldName);
-      return `val ${fixed} = data.singletons["${fieldName}"].toPrimitiveValue(${typeFor(type)}::class, ${defaultValFor(type)})`;
+      return `val ${fixed} = data.singletons["${fieldName}"].toPrimitiveValue(${typeFor(type)}::class, ${getTypeInfo({name: type}).defaultVal})`;
     };
 
     const genQueryArgAsLocal = ([_, type]: [string, string]) => {
@@ -112,4 +112,8 @@ export class KTExtracter {
 
     return `${locals.map(x => `${x}\n`).join('')}${expr}`;
   }
+}
+
+function typeFor(name: string) {
+  return getTypeInfo({name}).type;
 }

--- a/src/tools/kotlin-schema-generator.ts
+++ b/src/tools/kotlin-schema-generator.ts
@@ -1,0 +1,102 @@
+/**
+ * @license
+ * Copyright (c) 2020 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+import {KotlinGenerationUtils, leftPad, quote} from './kotlin-generation-utils.js';
+import {SchemaNode} from './schema2graph.js';
+import {Schema} from '../runtime/schema.js';
+import {AddFieldOptions, SchemaDescriptorBase} from './schema2base.js';
+import {KTExtracter} from './kotlin-refinement-generator.js';
+import {escapeIdentifier, getTypeInfo} from './kotlin-codegen-shared.js';
+
+const ktUtils = new KotlinGenerationUtils();
+
+/**
+ * Metadata about a field in a schema.
+ */
+export type KotlinSchemaField = AddFieldOptions & {
+  type: string,
+  decodeFn: string,
+  defaultVal: string,
+  schemaType: string,
+  escaped: string,
+  nullableType: string
+};
+
+/**
+ * Composes and holds a list of KotlinSchemaField for a SchemaNode.
+ */
+export class KotlinSchemaDescriptor extends SchemaDescriptorBase {
+
+  readonly fields: KotlinSchemaField[] = [];
+
+  constructor(node: SchemaNode, private forWasm: boolean) {
+    super(node);
+    this.process();
+  }
+
+  addField(opts: AddFieldOptions) {
+    if (opts.typeName === 'Reference' && this.forWasm) return;
+
+    const typeInfo = getTypeInfo({name: opts.typeName, ...opts});
+    const type = typeInfo.type;
+
+    this.fields.push({
+      ...opts,
+      ...typeInfo,
+      escaped: escapeIdentifier(opts.field),
+      nullableType: type.endsWith('?') ? type : `${type}?`
+    });
+  }
+}
+
+/**
+ * Generates a schema instance for a given KotlinSchemaDescriptor
+ */
+export function generateSchema(descriptor: KotlinSchemaDescriptor): string {
+  const schema = descriptor.node.schema;
+  if (schema.equals(Schema.EMPTY)) return `Schema.EMPTY`;
+
+  const schemaNames = schema.names.map(n => `SchemaName("${n}")`);
+  const {refinement, query} = generatePredicates(schema);
+
+  function generateFieldMap(isCollection: boolean): string {
+    const fieldPairs = descriptor.fields
+        .filter(f => !!f.isCollection === isCollection)
+        .map(({field, schemaType}) => `"${field}" to ${schemaType}`);
+    return leftPad(ktUtils.mapOf(fieldPairs, 30), 8, true);
+  }
+
+  return `\
+Schema(
+    setOf(${ktUtils.joinWithIndents(schemaNames, {startIndent: 8})}),
+    SchemaFields(
+        singletons = ${generateFieldMap(false)},
+        collections = ${generateFieldMap(true)}
+    ),
+    ${quote(descriptor.node.hash)},
+    refinement = ${refinement},
+    query = ${query}
+)`;
+}
+
+function generatePredicates(schema: Schema): {query: string, refinement: string} {
+  const hasRefinement = !!schema.refinement;
+  const hasQuery = hasRefinement && schema.refinement.getQueryParams().get('?');
+  const expression = leftPad(KTExtracter.fromSchema(schema), 8);
+
+  return {
+    // TODO(cypher1): Support multiple queries.
+    query: hasQuery ? `{ data, queryArgs ->
+${expression}
+    }` : 'null',
+    refinement: (hasRefinement && !hasQuery) ? `{ data ->
+${expression}
+    }` : `{ _ -> true }`
+  };
+}

--- a/src/tools/schema2base.ts
+++ b/src/tools/schema2base.ts
@@ -12,7 +12,7 @@ import path from 'path';
 import minimist from 'minimist';
 import {Manifest} from '../runtime/manifest.js';
 import {Runtime} from '../runtime/runtime.js';
-import {SchemaGraph, SchemaNode, SchemaSource} from './schema2graph.js';
+import {SchemaGraph, SchemaNode} from './schema2graph.js';
 import {ParticleSpec} from '../runtime/particle-spec.js';
 
 export type AddFieldOptions = Readonly<{
@@ -25,14 +25,58 @@ export type AddFieldOptions = Readonly<{
   isCollection?: boolean;
 }>;
 
-export interface ClassGenerator {
-  addField(opts: AddFieldOptions): void;
-  generate(fieldCount: number): string;
+export interface EntityGenerator {
+  generate(): string;
 }
 
 export class NodeAndGenerator {
   node: SchemaNode;
-  generator: ClassGenerator;
+  generator: EntityGenerator;
+}
+
+/**
+ * Iterates over schema fields and composes metadata useful for entity codegen.
+ */
+export abstract class SchemaDescriptorBase {
+
+  constructor(readonly node: SchemaNode) {}
+
+  process() {
+    for (const [field, descriptor] of Object.entries(this.node.schema.fields)) {
+      if (descriptor.kind === 'schema-primitive') {
+        if (['Text', 'URL', 'Number', 'Boolean'].includes(descriptor.type)) {
+          this.addField({field, typeName: descriptor.type});
+        } else {
+          throw new Error(`Schema type '${descriptor.type}' for field '${field}' is not supported`);
+        }
+      } else if (descriptor.kind === 'schema-reference' || (descriptor.kind === 'schema-collection' && descriptor.schema.kind === 'schema-reference')) {
+        const isCollection = descriptor.kind === 'schema-collection';
+        const schemaNode = this.node.refs.get(field);
+        this.addField({
+          field,
+          typeName: 'Reference',
+          isCollection,
+          refClassName: schemaNode.entityClassName,
+          refSchemaHash: schemaNode.hash,
+        });
+      } else if (descriptor.kind === 'schema-collection') {
+        const schema = descriptor.schema;
+         if (!((schema.kind === 'kotlin-primitive') || ['Text', 'URL', 'Number', 'Boolean'].includes(schema.type))) {
+          throw new Error(`Schema type '${schema.type}' for field '${field}' is not supported`);
+        }
+        this.addField({field, typeName: schema.type, isCollection: true});
+      } else if (descriptor.kind === 'kotlin-primitive') {
+        this.addField({field, typeName: descriptor.type});
+      } else if (descriptor.kind === 'schema-ordered-list') {
+        this.addField({field, typeName: 'List', listTypeName: descriptor.schema.type});
+      }
+      else {
+        throw new Error(`Schema kind '${descriptor.kind}' for field '${field}' is not supported`);
+      }
+    }
+  }
+
+  abstract addField(opts: AddFieldOptions): void;
 }
 
 export abstract class Schema2Base {
@@ -91,8 +135,7 @@ export abstract class Schema2Base {
     for (const particle of manifest.particles) {
       const nodes = await this.calculateNodeAndGenerators(particle);
 
-      classes.push(...nodes.map(({generator, node}) =>
-        generator.generate(Object.entries(node.schema.fields).length)));
+      classes.push(...nodes.map(ng => ng.generator.generate()));
 
       if (this.opts.test_harness) {
         classes.push(this.generateTestHarness(particle, nodes.map(n => n.node)));
@@ -108,39 +151,7 @@ export abstract class Schema2Base {
     const graph = new SchemaGraph(particle);
     const nodes: NodeAndGenerator[] = [];
     for (const node of graph.walk()) {
-      const generator = this.getClassGenerator(node);
-      for (const [field, descriptor] of Object.entries(node.schema.fields)) {
-        if (descriptor.kind === 'schema-primitive') {
-          if (['Text', 'URL', 'Number', 'Boolean'].includes(descriptor.type)) {
-            generator.addField({field, typeName: descriptor.type});
-          } else {
-            throw new Error(`Schema type '${descriptor.type}' for field '${field}' is not supported`);
-          }
-        } else if (descriptor.kind === 'schema-reference' || (descriptor.kind === 'schema-collection' && descriptor.schema.kind === 'schema-reference')) {
-          const isCollection = descriptor.kind === 'schema-collection';
-          const schemaNode = node.refs.get(field);
-          generator.addField({
-            field,
-            typeName: 'Reference',
-            isCollection,
-            refClassName: schemaNode.entityClassName,
-            refSchemaHash: await schemaNode.schema.hash(),
-          });
-        } else if (descriptor.kind === 'schema-collection') {
-          const schema = descriptor.schema;
-           if (!((schema.kind === 'kotlin-primitive') || ['Text', 'URL', 'Number', 'Boolean'].includes(schema.type))) {
-            throw new Error(`Schema type '${schema.type}' for field '${field}' is not supported`);
-          }
-          generator.addField({field, typeName: schema.type, isCollection: true});
-        } else if (descriptor.kind === 'kotlin-primitive') {
-          generator.addField({field, typeName: descriptor.type});
-        } else if (descriptor.kind === 'schema-ordered-list') {
-          generator.addField({field, typeName: 'List', listTypeName: descriptor.schema.type});
-        }
-        else {
-          throw new Error(`Schema kind '${descriptor.kind}' for field '${field}' is not supported`);
-        }
-      }
+      const generator = this.getEntityGenerator(node);
       await node.calculateHash();
       nodes.push({node, generator});
     }
@@ -158,7 +169,7 @@ export abstract class Schema2Base {
 
   fileFooter(): string { return ''; }
 
-  abstract getClassGenerator(node: SchemaNode): ClassGenerator;
+  abstract getEntityGenerator(node: SchemaNode): EntityGenerator;
 
   abstract generateParticleClass(particle: ParticleSpec, nodes: NodeAndGenerator[]): string;
 

--- a/src/tools/schema2kotlin.ts
+++ b/src/tools/schema2kotlin.ts
@@ -7,14 +7,14 @@
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
-import {ClassGenerator, NodeAndGenerator, Schema2Base} from './schema2base.js';
+import {EntityGenerator, NodeAndGenerator, Schema2Base} from './schema2base.js';
 import {SchemaNode} from './schema2graph.js';
 import {generateConnectionSpecType, getTypeInfo} from './kotlin-codegen-shared.js';
 import {HandleConnectionSpec, ParticleSpec} from '../runtime/particle-spec.js';
 import {CollectionType, EntityType, Type, TypeVariable} from '../runtime/type.js';
 import {KotlinGenerationUtils} from './kotlin-generation-utils.js';
 import {Direction} from '../runtime/manifest-ast-nodes.js';
-import {KotlinGenerator} from './kotlin-class-generator.js';
+import {KotlinEntityGenerator} from './kotlin-entity-generator.js';
 
 // TODO: use the type lattice to generate interfaces
 
@@ -88,8 +88,8 @@ ${imports.join('\n')}
 `;
   }
 
-  getClassGenerator(node: SchemaNode): ClassGenerator {
-    return new KotlinGenerator(node, this.opts);
+  getEntityGenerator(node: SchemaNode): EntityGenerator {
+    return new KotlinEntityGenerator(node, this.opts);
   }
 
   /** Returns the container type of the handle, e.g. Singleton or Collection. */
@@ -213,7 +213,7 @@ abstract class Abstract${particle.name} : ${this.opts.wasm ? 'WasmParticleImpl' 
     const typeAliases: string[] = [];
 
     nodeGenerators.forEach(nodeGenerator => {
-      const kotlinGenerator = <KotlinGenerator>nodeGenerator.generator;
+      const kotlinGenerator = <KotlinEntityGenerator>nodeGenerator.generator;
       classes.push(kotlinGenerator.generateClasses());
       typeAliases.push(...kotlinGenerator.generateAliases(particleName));
     });
@@ -299,4 +299,3 @@ class ${particleName}TestHarness<P : Abstract${particleName}>(
     return getTypeInfo({name: type}).type;
   }
 }
-

--- a/src/tools/tests/kotlin-entity-generator-test.ts
+++ b/src/tools/tests/kotlin-entity-generator-test.ts
@@ -8,7 +8,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {KotlinGenerator} from '../kotlin-class-generator.js';
+import {KotlinEntityGenerator} from '../kotlin-entity-generator.js';
 import {Manifest} from '../../runtime/manifest.js';
 import {assert} from '../../platform/chai-web.js';
 import {Schema2Kotlin} from '../schema2kotlin.js';
@@ -119,143 +119,19 @@ describe('kotlin-class-generator', () => {
         
         override var entityId = ""`
   ));
-  it('generates empty schema', async () => await assertSchemas(
-    `particle T
-         h1: reads {}`,
-    [`Schema.EMPTY`]
-  ));
-  it('generates a schema with multiple names', async () => await assertSchemas(
-    `particle T
-         h1: reads Person Friend Parent {}`, [
-`Schema(
-    setOf(SchemaName("Person"), SchemaName("Friend"), SchemaName("Parent")),
-    SchemaFields(
-        singletons = emptyMap(),
-        collections = emptyMap()
-    ),
-    "cd956ff7d2d4a14f434aa1427b84097d5c47037b",
-    refinement = { _ -> true },
-    query = null
-)`
-    ]
-  ));
-  it('generates a schema with primitive fields', async () => await assertSchemas(
-    `particle T
-         h1: reads Person {name: Text, age: Number, friendNames: [Text]}`, [
-`Schema(
-    setOf(SchemaName("Person")),
-    SchemaFields(
-        singletons = mapOf("name" to FieldType.Text, "age" to FieldType.Number),
-        collections = mapOf("friendNames" to FieldType.Text)
-    ),
-    "accd28212161fc896d658e8c22c06051d1239e18",
-    refinement = { _ -> true },
-    query = null
-)`
-    ]
-  ));
-  it('generates schemas for a reference', async () => await assertSchemas(
-    `particle T
-         h1: reads Person {address: &Address {streetAddress: Text}}`, [
-`Schema(
-    setOf(SchemaName("Address")),
-    SchemaFields(
-        singletons = mapOf("streetAddress" to FieldType.Text),
-        collections = emptyMap()
-    ),
-    "41a3bd27b7c53f1c5846754291653d13f49e3e8d",
-    refinement = { _ -> true },
-    query = null
-)`,
-`Schema(
-    setOf(SchemaName("Person")),
-    SchemaFields(
-        singletons = mapOf(
-            "address" to FieldType.EntityRef("41a3bd27b7c53f1c5846754291653d13f49e3e8d")
-        ),
-        collections = emptyMap()
-    ),
-    "d44c98a544cbbdd187a7e0529046166ed6a4bcb0",
-    refinement = { _ -> true },
-    query = null
-)`
-    ]
-  ));
-  it('generates a schema with a refinement', async () => await assertSchemas(
-    `particle T
-         h1: reads Person {name: Text, age: Number} [age >= 21]`, [
-`Schema(
-    setOf(SchemaName("Person")),
-    SchemaFields(
-        singletons = mapOf("name" to FieldType.Text, "age" to FieldType.Number),
-        collections = emptyMap()
-    ),
-    "edabcee36cb653ff468fb77804911ddfa9303d67",
-    refinement = { data ->
-        val age = data.singletons["age"].toPrimitiveValue(Double::class, 0.0)
-        ((age > 21) || (age == 21))
-    },
-    query = null
-)`
-    ]
-  ));
-  it('generates a schema with a query', async () => await assertSchemas(
-    `particle T
-         h1: reads Person {name: Text, age: Number} [age >= ?]`, [
-`Schema(
-    setOf(SchemaName("Person")),
-    SchemaFields(
-        singletons = mapOf("name" to FieldType.Text, "age" to FieldType.Number),
-        collections = emptyMap()
-    ),
-    "edabcee36cb653ff468fb77804911ddfa9303d67",
-    refinement = { _ -> true },
-    query = { data, queryArgs ->
-        val age = data.singletons["age"].toPrimitiveValue(Double::class, 0.0)
-        val queryArgument = queryArgs as Double
-        ((age > queryArgument) || (age == queryArgument))
-    }
-)`
-    ]
-  ));
-  it('generates schemas for a tuple connection', async () => await assertSchemas(
-    `particle T
-         h1: reads (&Person {name: Text}, &Product {sku: Text})`, [
-`Schema(
-    setOf(SchemaName("Person")),
-    SchemaFields(
-        singletons = mapOf("name" to FieldType.Text),
-        collections = emptyMap()
-    ),
-    "0149326a894f2d81705e1a08480330826f919cf0",
-    refinement = { _ -> true },
-    query = null
-)`,
-`Schema(
-    setOf(SchemaName("Product")),
-    SchemaFields(
-        singletons = mapOf("sku" to FieldType.Text),
-        collections = emptyMap()
-    ),
-    "32bcfc983b9ea6145aa42fbc525abb96baafbc1f",
-    refinement = { _ -> true },
-    query = null
-)`
-    ]
-  ));
 
   async function assertClassDefinition(manifestString: string, expectedValue: string) {
     await assertGeneratorComponents<string>(
       manifestString,
       generator => generator.generateClassDefinition(),
-      [expectedValue]);
+      expectedValue);
   }
 
   async function assertCopyMethodsForWasm(manifestString: string, expectedValue: string) {
     await assertGeneratorComponents<string>(
       manifestString,
       generator => generator.generateCopyMethods(),
-      [expectedValue],
+      expectedValue,
       {_: [], wasm: true});
   }
 
@@ -263,54 +139,39 @@ describe('kotlin-class-generator', () => {
     await assertGeneratorComponents<string>(
       manifestString,
       generator => generator.generateCopyMethods(),
-      [expectedValue]);
+      expectedValue);
   }
 
   async function assertFieldsDefinition(manifestString: string, expectedValue: string) {
     await assertGeneratorComponents<string>(
       manifestString,
       generator => generator.generateFieldsDefinitions(),
-      [expectedValue]);
+      expectedValue);
   }
 
   async function assertFieldsDefinitionForWasm(manifestString: string, expectedValue: string) {
     await assertGeneratorComponents<string>(
       manifestString,
       generator => generator.generateFieldsDefinitions(),
-      [expectedValue],
+      expectedValue,
       {_: [], wasm: true});
-  }
-
-  async function assertSchemas(manifestString: string, expectedValues: string[]) {
-    await assertGeneratorComponents<string>(
-      manifestString,
-      generator => generator.generateSchema(),
-      expectedValues);
   }
 
   // Asserts that a certain component from the Kotlin Generator, equals the
   // expected value.
   async function assertGeneratorComponents<T>(
     manifestString: string,
-    extractor: (generator: KotlinGenerator) => T,
-    expectedValues: T[],
+    extractor: (generator: KotlinEntityGenerator) => T,
+    expectedValue: T,
     opts: minimist.ParsedArgs = {_: []}) {
     const manifest = await Manifest.parse(manifestString);
     assert.lengthOf(manifest.particles, 1);
     const [particle] = manifest.particles;
 
     const schema2kotlin = new Schema2Kotlin(opts);
-    const generators = await schema2kotlin.calculateNodeAndGenerators(particle);
-    const actualValues = generators.map(g => extractor(g.generator as KotlinGenerator));
+    const generator = (await schema2kotlin.calculateNodeAndGenerators(particle))[0];
+    const actualValue = extractor(generator.generator as KotlinEntityGenerator);
 
-    // We could do the followiong asserting with a one liner, e.g.
-    //   assert.sameDeepMembers(actualValues, expectedValues);
-    // But comparing values one by one gives much nicer debug messages
-    // for multiline strings, diffing each string line by line and
-    // printing '\n' with new lines.
-    assert.equal(actualValues.length, expectedValues.length);
-    for (let i = 0; i < actualValues.length; i++) {
-      assert.equal(actualValues[i], expectedValues[i]);
-    }
+    assert.deepEqual(actualValue, expectedValue);
   }
 });

--- a/src/tools/tests/kotlin-schema-generator-test.ts
+++ b/src/tools/tests/kotlin-schema-generator-test.ts
@@ -1,0 +1,158 @@
+/**
+ * @license
+ * Copyright (c) 2020 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {assert} from '../../platform/chai-node.js';
+import {KotlinSchemaDescriptor, generateSchema} from '../kotlin-schema-generator.js';
+import {Manifest} from '../../runtime/manifest.js';
+import {SchemaGraph} from '../schema2graph.js';
+
+describe('Kotlin Schema Generator', () => {
+  it('generates empty schema', async () => await assertSchemas(
+    `particle T
+         h1: reads {}`,
+    [`Schema.EMPTY`]
+  ));
+  it('generates a schema with multiple names', async () => await assertSchemas(
+    `particle T
+         h1: reads Person Friend Parent {}`, [
+`Schema(
+    setOf(SchemaName("Person"), SchemaName("Friend"), SchemaName("Parent")),
+    SchemaFields(
+        singletons = emptyMap(),
+        collections = emptyMap()
+    ),
+    "cd956ff7d2d4a14f434aa1427b84097d5c47037b",
+    refinement = { _ -> true },
+    query = null
+)`
+    ]
+  ));
+  it('generates a schema with primitive fields', async () => await assertSchemas(
+    `particle T
+         h1: reads Person {name: Text, age: Number, friendNames: [Text]}`, [
+`Schema(
+    setOf(SchemaName("Person")),
+    SchemaFields(
+        singletons = mapOf("name" to FieldType.Text, "age" to FieldType.Number),
+        collections = mapOf("friendNames" to FieldType.Text)
+    ),
+    "accd28212161fc896d658e8c22c06051d1239e18",
+    refinement = { _ -> true },
+    query = null
+)`
+    ]
+  ));
+  it('generates schemas for a reference', async () => await assertSchemas(
+    `particle T
+         h1: reads Person {address: &Address {streetAddress: Text}}`, [
+`Schema(
+    setOf(SchemaName("Address")),
+    SchemaFields(
+        singletons = mapOf("streetAddress" to FieldType.Text),
+        collections = emptyMap()
+    ),
+    "41a3bd27b7c53f1c5846754291653d13f49e3e8d",
+    refinement = { _ -> true },
+    query = null
+)`,
+`Schema(
+    setOf(SchemaName("Person")),
+    SchemaFields(
+        singletons = mapOf(
+            "address" to FieldType.EntityRef("41a3bd27b7c53f1c5846754291653d13f49e3e8d")
+        ),
+        collections = emptyMap()
+    ),
+    "d44c98a544cbbdd187a7e0529046166ed6a4bcb0",
+    refinement = { _ -> true },
+    query = null
+)`
+    ]
+  ));
+  it('generates a schema with a refinement', async () => await assertSchemas(
+    `particle T
+         h1: reads Person {name: Text, age: Number} [age >= 21]`, [
+`Schema(
+    setOf(SchemaName("Person")),
+    SchemaFields(
+        singletons = mapOf("name" to FieldType.Text, "age" to FieldType.Number),
+        collections = emptyMap()
+    ),
+    "edabcee36cb653ff468fb77804911ddfa9303d67",
+    refinement = { data ->
+        val age = data.singletons["age"].toPrimitiveValue(Double::class, 0.0)
+        ((age > 21) || (age == 21))
+    },
+    query = null
+)`
+    ]
+  ));
+  it('generates a schema with a query', async () => await assertSchemas(
+    `particle T
+         h1: reads Person {name: Text, age: Number} [age >= ?]`, [
+`Schema(
+    setOf(SchemaName("Person")),
+    SchemaFields(
+        singletons = mapOf("name" to FieldType.Text, "age" to FieldType.Number),
+        collections = emptyMap()
+    ),
+    "edabcee36cb653ff468fb77804911ddfa9303d67",
+    refinement = { _ -> true },
+    query = { data, queryArgs ->
+        val age = data.singletons["age"].toPrimitiveValue(Double::class, 0.0)
+        val queryArgument = queryArgs as Double
+        ((age > queryArgument) || (age == queryArgument))
+    }
+)`
+    ]
+  ));
+  it('generates schemas for a tuple connection', async () => await assertSchemas(
+    `particle T
+         h1: reads (&Person {name: Text}, &Product {sku: Text})`, [
+`Schema(
+    setOf(SchemaName("Person")),
+    SchemaFields(
+        singletons = mapOf("name" to FieldType.Text),
+        collections = emptyMap()
+    ),
+    "0149326a894f2d81705e1a08480330826f919cf0",
+    refinement = { _ -> true },
+    query = null
+)`,
+`Schema(
+    setOf(SchemaName("Product")),
+    SchemaFields(
+        singletons = mapOf("sku" to FieldType.Text),
+        collections = emptyMap()
+    ),
+    "32bcfc983b9ea6145aa42fbc525abb96baafbc1f",
+    refinement = { _ -> true },
+    query = null
+)`
+    ]
+  ));
+
+  async function assertSchemas(manifestString: string, expectedValues: string[]) {
+    const manifest = await Manifest.parse(manifestString);
+    assert.lengthOf(manifest.particles, 1);
+    const [particle] = manifest.particles;
+
+    const graph = new SchemaGraph(particle);
+
+    const actualValues = [];
+    for (const node of graph.nodes) {
+      await Promise.all([node, ...node.refs.values()].map(n => n.calculateHash()));
+      const schemaDescriptor = new KotlinSchemaDescriptor(node, /* forWasm= */ false);
+      actualValues.push(generateSchema(schemaDescriptor));
+    }
+
+    assert.sameDeepMembers(actualValues, expectedValues);
+  }
+});

--- a/src/tools/tests/schema2wasm-test.ts
+++ b/src/tools/tests/schema2wasm-test.ts
@@ -10,7 +10,7 @@
 import {assert} from '../../platform/chai-web.js';
 import {Manifest} from '../../runtime/manifest.js';
 import {Dictionary} from '../../runtime/hot.js';
-import {Schema2Base, ClassGenerator, AddFieldOptions} from '../schema2base.js';
+import {Schema2Base, EntityGenerator, AddFieldOptions, SchemaDescriptorBase} from '../schema2base.js';
 import {SchemaNode} from '../schema2graph.js';
 import {Schema2Cpp} from '../schema2cpp.js';
 import {Schema2Kotlin} from '../schema2kotlin.js';
@@ -19,7 +19,7 @@ import {ParticleSpec} from '../../runtime/particle-spec.js';
 /* eslint key-spacing: ["error", {"mode": "minimum"}] */
 
 class Schema2Mock extends Schema2Base {
-  res: Dictionary<{count: number, adds: string[]}> = {};
+  res: Dictionary<string[]> = {};
 
   static async create(manifest: Manifest): Promise<Schema2Mock> {
     const mock = new Schema2Mock({'_': []});
@@ -27,17 +27,19 @@ class Schema2Mock extends Schema2Base {
     return mock;
   }
 
-  getClassGenerator(node: SchemaNode): ClassGenerator {
-    const collector = {count: 0, adds: []};
+  getEntityGenerator(node: SchemaNode): EntityGenerator {
+    const collector = [];
     this.res[node.entityClassName] = collector;
-    return {
+
+    new class extends SchemaDescriptorBase {
       addField({field, typeName, isOptional, refClassName}: AddFieldOptions) {
         const refInfo = refClassName ? `<${refClassName}>` : '';
-        collector.adds.push(field + ':' + typeName[0] + refInfo + (isOptional ? '?' : ''));
-      },
+        collector.push(field + ':' + typeName[0] + refInfo + (isOptional ? '?' : ''));
+      }
+    }(node).process();
 
-      generate(fieldCount: number): string {
-        collector.count = fieldCount;
+    return {
+      generate() {
         return '';
       }
     };
@@ -62,9 +64,9 @@ describe('schema2wasm', () => {
     `);
     const mock = await Schema2Mock.create(manifest);
     assert.deepStrictEqual(mock.res, {
-      'FooInternal1': {count: 1, adds: ['txt:T']},
-      'Site':         {count: 2, adds: ['url:U', 'ref:R<FooInternal1>']},
-      'Foo_Input2':   {count: 2, adds: ['txt:T', 'num:N']},
+      'FooInternal1': ['txt:T'],
+      'Site':         ['url:U', 'ref:R<FooInternal1>'],
+      'Foo_Input2':   ['txt:T', 'num:N'],
     });
   });
 
@@ -76,7 +78,7 @@ describe('schema2wasm', () => {
     `);
     const mock = await Schema2Mock.create(manifest);
     assert.deepStrictEqual(mock.res, {
-      'Foo_Input': {count: 4, adds: ['txt:T', 'url:U', 'num:N', 'flg:B']}
+      'Foo_Input': ['txt:T', 'url:U', 'num:N', 'flg:B']
     });
   });
 
@@ -88,11 +90,11 @@ describe('schema2wasm', () => {
     `);
     const mock = await Schema2Mock.create(manifest);
     assert.deepStrictEqual(mock.res, {
-      'Foo_H1':     {count: 2, adds: ['a:T', 'r:R<Foo_H1_R>']},
-      'Foo_H1_R':   {count: 1, adds: ['b:T']},
-      'Foo_H2':     {count: 1, adds: ['s:R<Foo_H2_S>']},
-      'Foo_H2_S':   {count: 2, adds: ['f:B', 't:R<Foo_H2_S_T>']},
-      'Foo_H2_S_T': {count: 1, adds: ['x:N']},
+      'Foo_H1':     ['a:T', 'r:R<Foo_H1_R>'],
+      'Foo_H1_R':   ['b:T'],
+      'Foo_H2':     ['s:R<Foo_H2_S>'],
+      'Foo_H2_S':   ['f:B', 't:R<Foo_H2_S_T>'],
+      'Foo_H2_S_T': ['x:N'],
     });
   });
 


### PR DESCRIPTION
_No functional changes, only cleanup_

We want to start creating schema instances in recipe2plan, but the schema generation code was tied closely to the entity generator - this PR separates the schema generation from the entity generation.

The fundamental refactoring of this this PR is the creation of the `SchemaDescriptor` object, which holds the metadata about fields in the schema. This object allows code reuse, as the schema generation code no longer depends on the internal state of schema2kotlin, instead it accepts a single `SchemaDescriptor`, which can be created from the `SchemaNode`, which recipe2plan is already using.

The `SchemaDescriptor` object also allows to clean up the boundaries between the components, which is illustrated by the simplification of the `EntityGenerator` interface (previously `ClassGenerator`, which IMO was not descriptive enough given we generate now multiple different objects: particle base classes, entities, schemas):

Before:
```
interface ClassGenerator {
  addField(opts: AddFieldOptions): void;
  generate(fieldCount: number): string;
}
```
After:
```
export interface EntityGenerator {
  generate(): string;
}
```

For Kotlin I've also cleaned up the split of code generation logic, where some of the code blocks were generated in `addField` method, and then composed in other places. I've instead inlined all the codegen blocks from `SchemaDescriptor.addField` to the actual place of code generation in the kotlin EntityGenerator, which allows understanding better how the generated code looks like. I didn't do it for CPP, but there's less of a need there as the descriptor and entity generator still live close to each other, while for Kotlin I wanted to put them in separate files.

Schema generation code lives now in `kotlin-schema-generator` together with the schema descriptor object for Kotlin, while entity generation code lives in `kotlin-entity-generator`.