### PR TITLE
Deflake Core DifferentHandleManagerDifferentStoresTest

### DIFF
--- a/javatests/arcs/core/entity/DifferentHandleManagerDifferentStoresTest.kt
+++ b/javatests/arcs/core/entity/DifferentHandleManagerDifferentStoresTest.kt
@@ -40,37 +40,31 @@ class DifferentHandleManagerDifferentStoresTest : HandleManagerTestBase() {
     @After
     override fun tearDown() = super.tearDown()
 
-    @Ignore("b/154947352 - Deflake")
     @Test
     override fun collection_removingFromA_isRemovedFromB() {
         super.collection_removingFromA_isRemovedFromB()
     }
 
-    @Ignore("b/156433279 - Deflake")
     @Test
     override fun singleton_referenceLiveness() {
         super.singleton_referenceLiveness()
     }
 
-    @Ignore("b/157185966 - Deflake")
     @Test
     override fun collection_referenceLiveness() {
         super.collection_referenceLiveness()
     }
 
-    @Ignore("b/157201431 - Deflake")
     @Test
     override fun singleton_dereferenceEntity() {
         super.singleton_dereferenceEntity()
     }
 
-    @Ignore("b/157201835 - Deflake")
     @Test
     override fun collection_entityDereference() {
         super.collection_entityDereference()
     }
 
-    @Ignore("b/157266863 - Deflake")
     @Test
     override fun singleton_clearOnAClearDataWrittenByB() {
         super.singleton_clearOnAClearDataWrittenByB()

--- a/javatests/arcs/core/entity/DifferentHandleManagerDifferentStoresTest.kt
+++ b/javatests/arcs/core/entity/DifferentHandleManagerDifferentStoresTest.kt
@@ -16,16 +16,19 @@ import org.junit.runners.JUnit4
 @Suppress("EXPERIMENTAL_API_USAGE")
 @RunWith(JUnit4::class)
 class DifferentHandleManagerDifferentStoresTest : HandleManagerTestBase() {
+    private var i = 0
+
     @Before
     override fun setUp() {
         super.setUp()
+        i++
         StoreWriteBack.writeBackFactoryOverride = WriteBackForTesting
         schedulerProvider = JvmSchedulerProvider(EmptyCoroutineContext)
         readHandleManager = EntityHandleManager(
             arcId = "testArcId",
             hostId = "testHostId",
             time = fakeTime,
-            scheduler = schedulerProvider("reader"),
+            scheduler = schedulerProvider("reader-#$i"),
             stores = StoreManager()
         )
         writeHandleManager = EntityHandleManager(


### PR DESCRIPTION
No actual logic changes were needed for this PR. Just some additional awaiting before checking in singleton_dereferenceEntity.

Related Bugs:

http://b/154947352
http://b/156433279
http://b/157185966
http://b/157201431
http://b/157201835
http://b/157266863