### PR TITLE
Support sub-path checks in InformationFlow analysis. 

### DIFF
--- a/java/arcs/core/analysis/AccessPathLabels.kt
+++ b/java/arcs/core/analysis/AccessPathLabels.kt
@@ -67,6 +67,24 @@ data class AccessPathLabels private constructor(
 
     override fun toString() = toString(linePrefix = "", transform = null)
 
+    /**
+     * Returns the join of labels for the access paths for which the given [accessPath] is a prefix.
+     *
+     * For example, suppose that there is an entry for `root.foo` (say `fooValue`) and an entry for
+     * `root.bar` (say `barValue`), then [getLabels] on `root` returns `fooValue join barValue`.
+     */
+    fun getLabels(accessPath: AccessPath): InformationFlowLabels {
+        val combinedLabels = accessPathLabels?.entries
+            ?.fold(InformationFlowLabels.getBottom()) { acc, (curAccessPath, curLabels) ->
+                if (accessPath.isPrefixOf(curAccessPath)) {
+                    acc join curLabels
+                } else {
+                    acc
+                }
+            }
+        return combinedLabels ?: InformationFlowLabels.getBottom()
+    }
+
     fun toString(linePrefix: String = "", transform: ((Int) -> String)?): String {
         return when {
             _accessPathLabels.isTop -> "${linePrefix}TOP"

--- a/java/arcs/core/analysis/InformationFlow.kt
+++ b/java/arcs/core/analysis/InformationFlow.kt
@@ -431,8 +431,7 @@ fun InformationFlow.AnalysisResult.verify(particle: Recipe.Particle, check: Chec
     if (result.isTop) return false
 
     val assert = requireNotNull(check as? Check.Assert)
-    val accessPathLabels =
-        result.accessPathLabels?.get(assert.accessPath) ?: InformationFlowLabels.getBottom()
+    val accessPathLabels = result.getLabels(assert.accessPath)
 
     // Unreachable => check is trivially satisfied.
     if (accessPathLabels.isBottom) return true

--- a/java/arcs/core/data/AccessPath.kt
+++ b/java/arcs/core/data/AccessPath.kt
@@ -81,6 +81,13 @@ data class AccessPath(val root: Root, val selectors: List<Selector> = emptyList(
         return selectors.joinToString(separator = ".", prefix = "$root.")
     }
 
+    /** Returns true if this [AccessPath] is a prefix of [other]. */
+    fun isPrefixOf(other: AccessPath) = when {
+        root != other.root -> false
+        selectors.size > other.selectors.size -> false
+        else -> selectors == other.selectors.subList(0, selectors.size)
+    }
+
     /**
      * Converts an [AccessPath] with [Root.HandleConnectionSpec] as root into a
      * [AccessPath] with the corresponding [Root.HandleConnection] as root.

--- a/javatests/arcs/core/analysis/AccessPathLabelsTest.kt
+++ b/javatests/arcs/core/analysis/AccessPathLabelsTest.kt
@@ -318,4 +318,21 @@ class AccessPathLabelsTest {
         assertThat(inputAgeIsABorAC join inputNameIsABorACAgeIsAB)
             .isEqualTo(inputNameIsABorACAgeIsABorAC)
     }
+
+    @Test
+    fun getLabels_matchesExactPaths() {
+        assertThat(inputNameIsABorACAgeIsAB.getLabels(inputName)).isEqualTo(setOfABorAC)
+        assertThat(inputNameIsABorACAgeIsAB.getLabels(inputAge)).isEqualTo(setOfAB)
+        assertThat(inputNameIsNoneAgeIsAB.getLabels(inputName)).isEqualTo(emptyLabels)
+        assertThat(inputNameIsNoneAgeIsAB.getLabels(inputAge)).isEqualTo(setOfAB)
+    }
+
+    @Test
+    fun getLabels_matchesPartialPaths() {
+        val input = AccessPath(particleName, inputSpec)
+        assertThat(inputNameIsABorACAgeIsAB.getLabels(input)).isEqualTo(setOfABorAC)
+
+        val setOfNoneAndAB = InformationFlowLabels(setOf(BitSet(labels.size), setAB))
+        assertThat(inputNameIsNoneAgeIsAB.getLabels(input)).isEqualTo(setOfNoneAndAB)
+    }
 }

--- a/javatests/arcs/core/analysis/InformationFlowTest.kt
+++ b/javatests/arcs/core/analysis/InformationFlowTest.kt
@@ -81,7 +81,7 @@ class InformationFlowTest {
         }
         assertWithMessage("Unexpected DFA behavior for test '$test'")
             .that(actualViolations)
-            .isEqualTo(violations)
+            .containsExactlyElementsIn(violations)
     }
 
     @Test
@@ -100,7 +100,8 @@ class InformationFlowTest {
             "fail-mixer",
             "fail-derives-from-cycle",
             "fail-derives-from-multiple",
-            "fail-join-tuple-components"
+            "fail-join-tuple-components",
+            "fail-check-on-subpaths"
         )
         val okTests = listOf(
             "ok-directly-satisfied",
@@ -117,7 +118,8 @@ class InformationFlowTest {
             "ok-derives-from-cycle",
             "ok-derives-from-multiple",
             "ok-join-simple",
-            "ok-join-tuple-components"
+            "ok-join-tuple-components",
+            "ok-check-on-subpaths"
         )
         val failingFieldTests = listOf(
             "fail-field-entity-direct",

--- a/javatests/arcs/core/analysis/testdata/fail_check_on_subpaths.arcs
+++ b/javatests/arcs/core/analysis/testdata/fail_check_on_subpaths.arcs
@@ -1,0 +1,14 @@
+// #Ingress: P1
+// #FAIL: hc:P2.foo is trusted
+particle P1
+  foo: writes Foo {a: Text, b: Number}
+  claim foo.a is trusted
+  claim foo.b is loggable
+particle P2
+  foo: reads Foo {a: Text, b: Number}
+  check foo is trusted
+recipe R
+  P1
+    foo: writes h
+  P2
+    foo: reads h

--- a/javatests/arcs/core/analysis/testdata/fail_mixer.arcs
+++ b/javatests/arcs/core/analysis/testdata/fail_mixer.arcs
@@ -1,5 +1,8 @@
 // #Ingress: IngestionAppName
 // #Ingress: IngestionLocation
+// #Fail: hc:Egress2.data is (packageName and coarseLocation)
+// #Fail: hc:Egress4.data is safeToLog
+// #Fail: hc:Egress5.data is ((packageName and safeToLog) or (coarseLocation and safeToLog))
 // #Fail: hc:Egress2.data.whoKnowsWhat is (packageName and coarseLocation)
 // #Fail: hc:Egress4.data.whoKnowsWhat is safeToLog
 // #Fail: hc:Egress5.data.whoKnowsWhat is ((packageName and safeToLog) or (coarseLocation and safeToLog))
@@ -24,26 +27,32 @@ particle Mixer
 particle Egress1
   data: reads [MixedData {whoKnowsWhat: Text}]
   check data.whoKnowsWhat is packageName or is coarseLocation
+  check data is packageName or is coarseLocation
 
 // DFA fail
 particle Egress2
   data: reads [MixedData {whoKnowsWhat: Text}]
   check data.whoKnowsWhat is packageName and is coarseLocation
+  check data is packageName and is coarseLocation
 
 // DFA pass
 particle Egress3
   data: reads [MixedData {whoKnowsWhat: Text}]
   check data.whoKnowsWhat is packageName or is coarseLocation or is safeToLog
+  check data is packageName or is coarseLocation or is safeToLog
+
 
 // DFA fail
 particle Egress4
   data: reads [MixedData {whoKnowsWhat: Text}]
   check data.whoKnowsWhat is safeToLog
+  check data is safeToLog
 
 // DFA fail
 particle Egress5
   data: reads [MixedData {whoKnowsWhat: Text}]
   check data.whoKnowsWhat (is packageName and is safeToLog) or (is coarseLocation and is safeToLog)
+  check data (is packageName and is safeToLog) or (is coarseLocation and is safeToLog)
 
 recipe Test
   data: create

--- a/javatests/arcs/core/analysis/testdata/ok_check_on_subpaths.arcs
+++ b/javatests/arcs/core/analysis/testdata/ok_check_on_subpaths.arcs
@@ -1,0 +1,14 @@
+// #Ingress: P1
+// #OK
+particle P1
+  foo: writes Foo {a: Text, b: Number}
+  claim foo.a is trusted
+  claim foo.b is loggable
+particle P2
+  foo: reads Foo {a: Text, b: Number}
+  check foo is trusted or is loggable
+recipe R
+  P1
+    foo: writes h
+  P2
+    foo: reads h

--- a/javatests/arcs/core/data/AccessPathTest.kt
+++ b/javatests/arcs/core/data/AccessPathTest.kt
@@ -23,6 +23,11 @@ class AccessPathTest {
     private val connection = Recipe.Particle.HandleConnection(connectionSpec, handle)
     private val particleSpec = ParticleSpec("Reader", mapOf("data" to connectionSpec), "Location")
     private val particle = Recipe.Particle(particleSpec, listOf(connection))
+    private val oneSelector = listOf(AccessPath.Selector.Field("foo"))
+    private val multipleSelectors = listOf(
+        AccessPath.Selector.Field("foo"),
+        AccessPath.Selector.Field("bar")
+    )
 
     @Test
     fun prettyPrintAccessPathRoot() {
@@ -46,39 +51,66 @@ class AccessPathTest {
 
     @Test
     fun prettyPrintAccessPathWithSelectors() {
-        val oneSelector = listOf(AccessPath.Selector.Field("bar"))
-        val multipleSelectors = listOf(
-            AccessPath.Selector.Field("foo"),
-            AccessPath.Selector.Field("bar")
-        )
-        assertThat("${AccessPath(handle, oneSelector)}").isEqualTo("h:thing.bar")
+        assertThat("${AccessPath(handle, oneSelector)}").isEqualTo("h:thing.foo")
         assertThat("${AccessPath(handle, multipleSelectors)}").isEqualTo("h:thing.foo.bar")
         assertThat("${AccessPath(particle, connectionSpec, oneSelector)}")
-            .isEqualTo("hc:Reader.data.bar")
+            .isEqualTo("hc:Reader.data.foo")
         assertThat("${AccessPath(particle, connectionSpec, multipleSelectors)}")
             .isEqualTo("hc:Reader.data.foo.bar")
         assertThat("${AccessPath("Reader", connectionSpec, oneSelector)}")
-            .isEqualTo("hcs:Reader.data.bar")
+            .isEqualTo("hcs:Reader.data.foo")
         assertThat("${AccessPath("Reader", connectionSpec, multipleSelectors)}")
             .isEqualTo("hcs:Reader.data.foo.bar")
     }
 
     @Test
     fun instantiateForParticle_oneSelector() {
-        val oneSelector = listOf(AccessPath.Selector.Field("bar"))
         val readerConnectionSpec = AccessPath("Reader", connectionSpec, oneSelector)
         val readerConnection = readerConnectionSpec.instantiateFor(particle)
-        assertThat("$readerConnection").isEqualTo("hc:Reader.data.bar")
+        assertThat("$readerConnection").isEqualTo("hc:Reader.data.foo")
     }
 
     @Test
     fun instantiateForParticle_multipleSelectors() {
-        val multipleSelectors = listOf(
-            AccessPath.Selector.Field("foo"),
-            AccessPath.Selector.Field("bar")
-        )
         val readerConnectionSpecMultiple = AccessPath("Reader", connectionSpec, multipleSelectors)
         val readerConnectionMultiple = readerConnectionSpecMultiple.instantiateFor(particle)
         assertThat("$readerConnectionMultiple").isEqualTo("hc:Reader.data.foo.bar")
+    }
+
+    @Test
+    fun isPrefixOf_comparesRoots() {
+        val handleAccessPath = AccessPath(handle, oneSelector)
+        val particleAccessPath = AccessPath(particle, connectionSpec, oneSelector)
+        assertThat(handleAccessPath.isPrefixOf(particleAccessPath)).isFalse()
+        assertThat(particleAccessPath.isPrefixOf(handleAccessPath)).isFalse()
+
+        val handleAccessPathMultiple = AccessPath(handle, multipleSelectors)
+        val particleAccessPathMultiple = AccessPath(particle, connectionSpec, multipleSelectors)
+        assertThat(handleAccessPathMultiple.isPrefixOf(particleAccessPathMultiple)).isFalse()
+        assertThat(particleAccessPathMultiple.isPrefixOf(handleAccessPathMultiple)).isFalse()
+    }
+
+    @Test
+    fun isPrefixOf_comparesSelectors() {
+        val anotherSelector = listOf(AccessPath.Selector.Field("baz"))
+        val handleAccessPath = AccessPath(handle, oneSelector)
+        val handleAccessPathMultiple = AccessPath(handle, multipleSelectors)
+        val handleAccessPathAnother = AccessPath(handle, anotherSelector)
+
+        with(handleAccessPath) {
+            assertThat(isPrefixOf(handleAccessPath)).isTrue()
+            assertThat(isPrefixOf(handleAccessPathMultiple)).isTrue()
+            assertThat(isPrefixOf(handleAccessPathAnother)).isFalse()
+        }
+        with(handleAccessPathMultiple) {
+            assertThat(isPrefixOf(handleAccessPath)).isFalse()
+            assertThat(isPrefixOf(handleAccessPathMultiple)).isTrue()
+            assertThat(isPrefixOf(handleAccessPathAnother)).isFalse()
+        }
+        with(handleAccessPathAnother) {
+            assertThat(isPrefixOf(handleAccessPath)).isFalse()
+            assertThat(isPrefixOf(handleAccessPathMultiple)).isFalse()
+            assertThat(isPrefixOf(handleAccessPathAnother)).isTrue()
+        }
     }
 }


### PR DESCRIPTION
This PR adds support for check on subpaths like `check data is loggable` instead of having to explicitly specify fields like `check data.field is loggable`. Specifically, this PR makes the following changes:
 - Adds a `isPrefixOf` method to `AccessPath`.
 - Adds a `getLabels` method to `AccessPathLabels` that matches sub paths.
 - Updates `InformationFlow` to support checks on subpaths.