### PR TITLE
Remove flaky=True from core entity package

### DIFF
--- a/javatests/arcs/core/entity/BUILD
+++ b/javatests/arcs/core/entity/BUILD
@@ -17,8 +17,6 @@ arcs_kt_schema(
 arcs_kt_jvm_test_suite(
     name = "entity",
     srcs = TEST_SRCS,
-    # TODO(b/157513559): Deflake this test suite.
-    flaky = True,
     package = "arcs.core.entity",
     deps = [
         ":lib",


### PR DESCRIPTION
Removes flaky=True from the `//javatests/arcs/core/entity` test targets.

All tests passed 10000/10000 times in this package.

http://b/157513559