### PR TITLE
Fixes for propagation of PeriodicCleanupTask to stores and handles:

### DIFF
--- a/java/arcs/android/storage/database/AndroidSqliteDatabaseManager.kt
+++ b/java/arcs/android/storage/database/AndroidSqliteDatabaseManager.kt
@@ -119,14 +119,12 @@ class AndroidSqliteDatabaseManager(
 
     override suspend fun removeAllEntities() =
         registry.fetchAll()
-            // Use a separate instance for cleardata, to avoid race conditions.
-            .map { DatabaseImpl(context, it.name, it.isPersistent) }
+            .map { getDatabase(it.name, it.isPersistent) }
             .forEach { it.removeAllEntities() }
 
     override suspend fun removeEntitiesCreatedBetween(startTimeMillis: Long, endTimeMillis: Long) =
         registry.fetchAll()
-            // Use a separate instance for cleardata, to avoid race conditions.
-            .map { DatabaseImpl(context, it.name, it.isPersistent) }
+            .map { getDatabase(it.name, it.isPersistent) }
             .forEach { it.removeEntitiesCreatedBetween(startTimeMillis, endTimeMillis) }
 
     override suspend fun runGarbageCollection(): Job = coroutineScope {

--- a/java/arcs/android/storage/database/BUILD
+++ b/java/arcs/android/storage/database/BUILD
@@ -22,6 +22,7 @@ arcs_kt_android_library(
         "//java/arcs/core/storage",
         "//java/arcs/core/storage:storage_key",
         "//java/arcs/core/storage/database",
+        "//java/arcs/core/storage/driver",
         "//java/arcs/core/type",
         "//java/arcs/core/util",
         "//java/arcs/core/util/performance",

--- a/java/arcs/android/storage/database/DatabaseGarbageCollectionPeriodicTask.kt
+++ b/java/arcs/android/storage/database/DatabaseGarbageCollectionPeriodicTask.kt
@@ -13,6 +13,7 @@ package arcs.android.storage.database
 import android.content.Context
 import androidx.work.Worker
 import androidx.work.WorkerParameters
+import arcs.core.storage.driver.DatabaseDriverProvider
 import arcs.core.util.TaggedLog
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
@@ -30,9 +31,10 @@ class DatabaseGarbageCollectionPeriodicTask(
 
     override fun doWork(): Result = runBlocking(Dispatchers.IO) {
         log.debug { "Running." }
-        val databaseManager = AndroidSqliteDatabaseManager(appContext)
+        // Use the DatabaseDriverProvider instance of the databaseManager to make sure changes by
+        // GC are propagated to listening Stores.
+        val databaseManager = DatabaseDriverProvider.manager
         databaseManager.runGarbageCollection().join()
-        databaseManager.close()
         log.debug { "Success." }
         // Indicate whether the task finished successfully with the Result
         Result.success()

--- a/java/arcs/android/storage/database/DatabaseImpl.kt
+++ b/java/arcs/android/storage/database/DatabaseImpl.kt
@@ -174,10 +174,9 @@ class DatabaseImpl(
 
     override suspend fun removeClient(identifier: Int) = clientMutex.withLock {
         clients.remove(identifier)
-        // When all clients are done with the database, close the connection.
         if (clients.isEmpty()) {
             onDatabaseClose()
-            super.close()
+            // TODO: track bulk deletes, and if none is in progress we can close the connection.
         }
         Unit
     }

--- a/java/arcs/android/storage/ttl/BUILD
+++ b/java/arcs/android/storage/ttl/BUILD
@@ -10,6 +10,7 @@ arcs_kt_android_library(
     deps = [
         "//java/arcs/android/storage/database",
         "//java/arcs/core/storage/database",
+        "//java/arcs/core/storage/driver",
         "//java/arcs/core/util",
         "//third_party/java/androidx/work",
         "//third_party/kotlin/kotlinx_coroutines",

--- a/java/arcs/android/storage/ttl/PeriodicCleanupTask.kt
+++ b/java/arcs/android/storage/ttl/PeriodicCleanupTask.kt
@@ -13,7 +13,7 @@ package arcs.android.storage.ttl
 import android.content.Context
 import androidx.work.Worker
 import androidx.work.WorkerParameters
-import arcs.android.storage.database.AndroidSqliteDatabaseManager
+import arcs.core.storage.driver.DatabaseDriverProvider
 import arcs.core.util.TaggedLog
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
@@ -31,9 +31,10 @@ class PeriodicCleanupTask(
 
     override fun doWork(): Result = runBlocking(Dispatchers.IO) {
         log.debug { "Running." }
-        val databaseManager = AndroidSqliteDatabaseManager(appContext)
+        // Use the DatabaseDriverProvider instance of the databaseManager to make sure changes by
+        // TTL expiry are propagated to listening Stores.
+        val databaseManager = DatabaseDriverProvider.manager
         databaseManager.removeExpiredEntities().join()
-        databaseManager.close()
         log.debug { "Success." }
         // Indicate whether the task finished successfully with the Result
         Result.success()

--- a/java/arcs/core/storage/ReferenceModeStore.kt
+++ b/java/arcs/core/storage/ReferenceModeStore.kt
@@ -145,8 +145,8 @@ class ReferenceModeStore private constructor(
      */
     private val versions = mutableMapOf<ReferenceId, MutableMap<FieldName, Int>>()
 
-    /** Tracks the state of container store: Active (true) and Closed (false). */
-    private val containerStateChannel = ConflatedBroadcastChannel(true)
+    /** Tracks the state of callback: true: active callbacks, false: no callbacks registered. */
+    private val callbacksStateChannel = ConflatedBroadcastChannel(true)
 
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     val backingStore = DirectStoreMuxer<CrdtData, CrdtOperation, Any?>(
@@ -188,17 +188,15 @@ class ReferenceModeStore private constructor(
     ): Int = callbacks.register(callback)
 
     override fun off(callbackToken: Int) {
-        containerStore.off(containerCallbackToken)
         callbacks.unregister(callbackToken)
-
-        if (containerStore.closed && !containerStateChannel.isClosedForSend) {
+        if (callbacks.isEmpty() && !callbacksStateChannel.isClosedForSend) {
             try {
-                containerStateChannel.offer(false)
+                callbacksStateChannel.offer(false)
             } catch (e: ClosedSendChannelException) {
                 // No-op. If the channel is closed (which can happen between the if's check and the
                 // offer call above), then it's no big deal.
                 log.debug {
-                    "Attempted to send false to the containerStateChannel when it was already " +
+                    "Attempted to send false to the callbacksStateChannel when it was already " +
                         "closed."
                 }
             }
@@ -454,15 +452,15 @@ class ReferenceModeStore private constructor(
 
     @FlowPreview
     private val clearStoreCachesFlow = combine(
-        containerStateChannel.asFlow(),
+        callbacksStateChannel.asFlow(),
         receiveQueue.sizeChannel.asFlow()
-    ) { containerState, queueSize -> queueSize + if (containerState) 1 else 0 }
+    ) { callbacksState, queueSize -> queueSize + if (callbacksState) 1 else 0 }
         .filter { it == 0 }
         .onEach {
             if (receiveQueue.size.value == 0) {
                 backingStore.clearStoresCache()
                 receiveQueue.sizeChannel.close()
-                containerStateChannel.close()
+                callbacksStateChannel.close()
             }
         }
         .launchIn(CoroutineScope(Dispatchers.Default + Job()))

--- a/java/arcs/core/storage/ReferenceModeStore.kt
+++ b/java/arcs/core/storage/ReferenceModeStore.kt
@@ -163,15 +163,13 @@ class ReferenceModeStore private constructor(
         }
     )
 
-    private val containerCallbackToken: Int
-
     init {
         @Suppress("UNCHECKED_CAST")
         crdtType = requireNotNull(
             type as? Type.TypeContainer<CrdtModelType<CrdtData, CrdtOperationAtTime, Referencable>>
         ) { "Provided type must contain CrdtModelType" }.containedType
 
-        containerCallbackToken = containerStore.on(ProxyCallback {
+        containerStore.on(ProxyCallback {
             CoroutineScope(coroutineContext).launch {
                 receiveQueue.enqueue(Message.PreEnqueuedFromContainer(it.toReferenceModeMessage()))
             }

--- a/javatests/arcs/android/storage/ttl/BUILD
+++ b/javatests/arcs/android/storage/ttl/BUILD
@@ -15,6 +15,7 @@ arcs_kt_android_test_suite(
         "//java/arcs/core/data",
         "//java/arcs/core/entity",
         "//java/arcs/core/host",
+        "//java/arcs/core/storage:writeback",
         "//java/arcs/core/storage/api",
         "//java/arcs/core/storage/keys",
         "//java/arcs/core/storage/referencemode",

--- a/javatests/arcs/android/storage/ttl/BUILD
+++ b/javatests/arcs/android/storage/ttl/BUILD
@@ -18,6 +18,7 @@ arcs_kt_android_test_suite(
         "//java/arcs/core/storage/api",
         "//java/arcs/core/storage/keys",
         "//java/arcs/core/storage/referencemode",
+        "//java/arcs/core/storage/testutil",
         "//java/arcs/jvm/host",
         "//java/arcs/jvm/util/testutil",
         "//javatests/arcs/core/entity:lib",

--- a/javatests/arcs/android/storage/ttl/BUILD
+++ b/javatests/arcs/android/storage/ttl/BUILD
@@ -1,0 +1,34 @@
+load(
+    "//third_party/java/arcs/build_defs:build_defs.bzl",
+    "arcs_kt_android_test_suite",
+)
+
+licenses(["notice"])
+
+arcs_kt_android_test_suite(
+    name = "ttl",
+    manifest = "//java/arcs/android/common:AndroidManifest.xml",
+    package = "arcs.android.storage.ttl",
+    deps = [
+        "//java/arcs/android/storage/database",
+        "//java/arcs/android/storage/ttl",
+        "//java/arcs/core/data",
+        "//java/arcs/core/entity",
+        "//java/arcs/core/host",
+        "//java/arcs/core/storage/api",
+        "//java/arcs/core/storage/keys",
+        "//java/arcs/core/storage/referencemode",
+        "//java/arcs/jvm/host",
+        "//java/arcs/jvm/util/testutil",
+        "//javatests/arcs/core/entity:lib",
+        "//third_party/android/androidx_test/core",
+        "//third_party/android/androidx_test/ext/junit",
+        "//third_party/java/androidx/work",
+        "//third_party/java/androidx/work:testing",
+        "//third_party/java/junit:junit-android",
+        "//third_party/java/robolectric",
+        "//third_party/java/truth:truth-android",
+        "//third_party/kotlin/kotlin:kotlin_test",
+        "//third_party/kotlin/kotlinx_coroutines",
+    ],
+)

--- a/javatests/arcs/android/storage/ttl/PeriodicCleanupTaskTest.kt
+++ b/javatests/arcs/android/storage/ttl/PeriodicCleanupTaskTest.kt
@@ -1,0 +1,96 @@
+package arcs.android.storage.ttl
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.work.ListenableWorker.Result
+import androidx.work.testing.TestWorkerBuilder
+import arcs.android.storage.database.AndroidSqliteDatabaseManager
+import arcs.core.data.CollectionType
+import arcs.core.data.EntityType
+import arcs.core.data.HandleMode
+import arcs.core.data.Ttl
+import arcs.core.entity.DummyEntity
+import arcs.core.entity.HandleSpec
+import arcs.core.entity.ReadWriteCollectionHandle
+import arcs.core.entity.SchemaRegistry
+import arcs.core.entity.awaitReady
+import arcs.core.host.EntityHandleManager
+import arcs.core.storage.api.DriverAndKeyConfigurator
+import arcs.core.storage.keys.DatabaseStorageKey
+import arcs.core.storage.referencemode.ReferenceModeStorageKey
+import arcs.jvm.host.JvmSchedulerProvider
+import arcs.jvm.util.testutil.FakeTime
+import com.google.common.truth.Truth.assertThat
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@Suppress("EXPERIMENTAL_API_USAGE", "UNCHECKED_CAST")
+@RunWith(AndroidJUnit4::class)
+class PeriodicCleanupTaskTest {
+    private val collectionKey = ReferenceModeStorageKey(
+        backingKey = DatabaseStorageKey.Persistent("backing", DummyEntity.SCHEMA_HASH),
+        storageKey = DatabaseStorageKey.Persistent("collection", DummyEntity.SCHEMA_HASH)
+    )
+    private val fakeTime = FakeTime()
+    private lateinit var worker: PeriodicCleanupTask
+
+    @Before
+    fun setUp() {
+        val context : Context = ApplicationProvider.getApplicationContext()
+        DriverAndKeyConfigurator.configure(AndroidSqliteDatabaseManager(context))
+        SchemaRegistry.register(DummyEntity.SCHEMA)
+        worker = TestWorkerBuilder.from(context, PeriodicCleanupTask::class.java).build()
+    }
+
+    @Test
+    fun ttlWorkerTest() = runBlocking {
+        // Set time in the past so entity is already expired.
+        fakeTime.millis = 1L
+
+        val handle = createCollectionHandle()
+        val entity = DummyEntity().apply { num = 1.0 }
+        handle.storeAndWait(entity)
+        withContext(handle.dispatcher) {
+            assertThat(handle.fetchAll()).containsExactly(entity)
+        }
+
+        // Trigger worker.
+        assertThat(worker.doWork()).isEqualTo(Result.success())
+
+        // Verify entity is gone.
+        withContext(handle.dispatcher) {
+            assertThat(handle.fetchAll()).isEmpty()
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private suspend fun createCollectionHandle() =
+        EntityHandleManager(
+            time = fakeTime,
+            scheduler = JvmSchedulerProvider(EmptyCoroutineContext)("test")
+        ).createHandle(
+            HandleSpec(
+                "name",
+                HandleMode.ReadWrite,
+                CollectionType(EntityType(DummyEntity.SCHEMA)),
+                DummyEntity
+            ),
+            collectionKey,
+            Ttl.Days(2)
+        ).awaitReady() as ReadWriteCollectionHandle<DummyEntity>
+
+    private suspend fun ReadWriteCollectionHandle<DummyEntity>.storeAndWait(entity: DummyEntity) {
+        val deferred = CompletableDeferred<Unit>()
+        onUpdate { deferred.complete(Unit) }
+        runBlocking(dispatcher) {
+            store(entity).join()
+        }
+        deferred.await()
+    }
+}


### PR DESCRIPTION
- the periodic job needs to use the same DatabaseImpl instance as the stores, as that instance has the clients registered
- therefore, need to use the same DatabaseManager, which we can get from DatabaseDriverProvider
- avoid closing the database object, as there can be bulk deletes in progress
- ReferenceModeStore was closing the container store too eagerly (closing the container causes it to detach from the driver), handles can still be using the store after off() therefore we keep the container alive. However if there are no callbacks we can still clean the backing store.