### PR TITLE
Namespace-shortened class names in parser

### DIFF
--- a/src/platform/loader-base.ts
+++ b/src/platform/loader-base.ts
@@ -88,7 +88,7 @@ export abstract class LoaderBase {
    * Test to determine if string matches JVM package / class naming convention:
    * https://docs.oracle.com/javase/tutorial/java/package/namingpkgs.html
    */
-  isJvmClasspath(candidate: string): boolean {
+  static isJvmClasspath(candidate: string): boolean {
     if (!candidate) return false;
 
     const isCapitalized = (s: string) => s[0] === s[0].toUpperCase();

--- a/src/platform/tests/loader-test.ts
+++ b/src/platform/tests/loader-test.ts
@@ -67,26 +67,24 @@ describe('PlatformLoader', () => {
     assert.equal(loader.join('/a/b/c/', '../../../d/e/f'), '/d/e/f');
   });
   it('recognizes JVM classpaths', () => {
-    const loader = new Loader();
+    assert.isTrue(Loader.isJvmClasspath('com.package.Class'));
+    assert.isTrue(Loader.isJvmClasspath('com.package.Class.InnerClass'));
+    assert.isTrue(Loader.isJvmClasspath('com.package_.Class_.InnerClass'));
+    assert.isTrue(Loader.isJvmClasspath('com.package.cloud9.MyClass'));
 
-    assert.isTrue(loader.isJvmClasspath('com.package.Class'));
-    assert.isTrue(loader.isJvmClasspath('com.package.Class.InnerClass'));
-    assert.isTrue(loader.isJvmClasspath('com.package_.Class_.InnerClass'));
-    assert.isTrue(loader.isJvmClasspath('com.package.cloud9.MyClass'));
-
-    assert.isFalse(loader.isJvmClasspath('com'));
-    assert.isFalse(loader.isJvmClasspath('com.package'));
-    assert.isFalse(loader.isJvmClasspath('com.package.test'));
-    assert.isFalse(loader.isJvmClasspath('.'));
-    assert.isFalse(loader.isJvmClasspath('com.invalid.'));
-    assert.isFalse(loader.isJvmClasspath('com.invalid..ff'));
-    assert.isFalse(loader.isJvmClasspath(''));
-    assert.isFalse(loader.isJvmClasspath('com.package..Class.InnerClass'));
-    assert.isFalse(loader.isJvmClasspath('com.package.Class.InnerClass.class'));
-    assert.isFalse(loader.isJvmClasspath('.com.google.com.Class'));
-    assert.isFalse(loader.isJvmClasspath('Com.pkg.Class'));
-    assert.isFalse(loader.isJvmClasspath('0om.pkg.class'));
-    assert.isFalse(loader.isJvmClasspath('a.js'));
-    assert.isFalse(loader.isJvmClasspath('path/to/MyClass.kt'));
+    assert.isFalse(Loader.isJvmClasspath('com'));
+    assert.isFalse(Loader.isJvmClasspath('com.package'));
+    assert.isFalse(Loader.isJvmClasspath('com.package.test'));
+    assert.isFalse(Loader.isJvmClasspath('.'));
+    assert.isFalse(Loader.isJvmClasspath('com.invalid.'));
+    assert.isFalse(Loader.isJvmClasspath('com.invalid..ff'));
+    assert.isFalse(Loader.isJvmClasspath(''));
+    assert.isFalse(Loader.isJvmClasspath('com.package..Class.InnerClass'));
+    assert.isFalse(Loader.isJvmClasspath('com.package.Class.InnerClass.class'));
+    assert.isFalse(Loader.isJvmClasspath('.com.google.com.Class'));
+    assert.isFalse(Loader.isJvmClasspath('Com.pkg.Class'));
+    assert.isFalse(Loader.isJvmClasspath('0om.pkg.class'));
+    assert.isFalse(Loader.isJvmClasspath('a.js'));
+    assert.isFalse(Loader.isJvmClasspath('path/to/MyClass.kt'));
   });
 });

--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -818,9 +818,18 @@ ${e.message}
       manifest.errors.push(warning);
     }
 
+    if (particleItem.implFile
+        && particleItem.implFile.startsWith('.')
+        && manifest.meta.namespace) {
+      const classpath = manifest.meta.namespace + particleItem.implFile;
+      if (Loader.isJvmClasspath(classpath)) {
+        particleItem.implFile = classpath;
+      }
+    }
+
     // TODO: loader should not be optional.
     if (particleItem.implFile && loader) {
-      if (!loader.isJvmClasspath(particleItem.implFile)) {
+      if (!Loader.isJvmClasspath(particleItem.implFile)) {
         particleItem.implFile = loader.join(manifest.fileName, particleItem.implFile);
       }
     }

--- a/src/tools/manifest-checker.ts
+++ b/src/tools/manifest-checker.ts
@@ -45,13 +45,9 @@ async function checkManifest(src: string) {
     if (!particle.implFile) {
       throw new Error(`Particle ${particle.name} does not have an implementation file and is not marked external.`);
     }
-    let classpath = particle.implFile.substring(particle.implFile.lastIndexOf('/') + 1);
-    if (classpath.startsWith('.')) {
-      classpath = manifest.meta.namespace + classpath;
-    }
-    if (loader.isJvmClasspath(classpath)) {
-      if (!loader.jvmClassExists(classpath)) {
-        throw new Error(`Particle ${particle.name} does not have a valid classpath: '${classpath}'.`);
+    if (Loader.isJvmClasspath(particle.implFile)) {
+      if (!loader.jvmClassExists(particle.implFile)) {
+        throw new Error(`Particle ${particle.name} does not have a valid classpath: '${particle.implFile}'.`);
       }
     } else {
       await loader.loadResource(particle.implFile);

--- a/src/tools/plan-generator.ts
+++ b/src/tools/plan-generator.ts
@@ -75,11 +75,7 @@ export class PlanGenerator {
   /** Generates a Kotlin `Plan.Particle` instantiation from a Particle. */
   async createParticle(particle: Particle): Promise<string> {
     const spec = particle.spec;
-    let locationFromFile = (spec.implFile && spec.implFile.substring(spec.implFile.lastIndexOf('/') + 1));
-    if (locationFromFile && locationFromFile.startsWith('.')) {
-      locationFromFile = this.namespace + locationFromFile;
-    }
-    const location = (spec && (spec.implBlobUrl || locationFromFile)) || '';
+    const location = (spec && (spec.implBlobUrl || spec.implFile)) || '';
     const connectionMappings: string[] = [];
     for (const [key, conn] of Object.entries(particle.connections)) {
       connectionMappings.push(`"${key}" to ${await this.createHandleConnection(conn)}`);


### PR DESCRIPTION
Supports particle class names shortened  by namespace in the parser, instead of separately in the plan-generator and manifes-checker. The motivation is that they did not work in proto conversion, so instead of implementing them separately in a third place, I've moved the implementation to the parser instead.