### PR TITLE
fix bug in fastforward op, where an op with no changes was returned (…

### DIFF
--- a/java/arcs/core/crdt/CrdtSet.kt
+++ b/java/arcs/core/crdt/CrdtSet.kt
@@ -317,8 +317,14 @@ class CrdtSet<T : Referencable>(
                 // Remove ops can't be replayed in order.
                 if (removed.isNotEmpty()) return listOf(this)
 
-                // This is just a version bump, since there are no additions and no removals.
-                if (added.isEmpty()) return listOf(this)
+                if (added.isEmpty()) {
+                    if (oldClock == newClock) {
+                        // No added, no removed, and no clock changes: op should be empty.
+                        return emptyList()
+                    }
+                    // This is just a version bump, since there are no additions and no removals.
+                    return listOf(this)
+                }
 
                 // Can only return a simplified list of ops if all additions come from a single
                 // actor.

--- a/javatests/arcs/core/crdt/CrdtSetTest.kt
+++ b/javatests/arcs/core/crdt/CrdtSetTest.kt
@@ -561,6 +561,16 @@ class CrdtSetTest {
     }
 
     @Test
+    fun returnsEmptyOtherChange_whenMergingIntoEmptyModel() {
+        // Alice is empty, Bob has an item.
+        bob.add("a", VersionMap("a" to 1), "foo")
+        
+        val (modelChange, otherChange) = alice.merge(bob.data)
+        assertThat(modelChange.isEmpty()).isFalse()
+        assertThat(otherChange.isEmpty()).isTrue()
+    }
+
+    @Test
     fun merge_handlesRawEntityChange() {
         val new = CrdtSet(
             CrdtSet.DataImpl(

--- a/src/runtime/crdt/crdt-collection.ts
+++ b/src/runtime/crdt/crdt-collection.ts
@@ -267,6 +267,10 @@ export function simplifyFastForwardOp<T>(fastForwardOp: CollectionFastForwardOp<
     return null;
   }
   if (fastForwardOp.added.length === 0) {
+    if (sameVersions(fastForwardOp.oldClock, fastForwardOp.newClock)) {
+      // No added, no removed, and no clock changes: op should be empty.
+      return [];
+    }
     // Just a version bump, no add ops to replay.
     return null;
   }

--- a/src/runtime/crdt/tests/crdt-collection-test.ts
+++ b/src/runtime/crdt/tests/crdt-collection-test.ts
@@ -670,7 +670,17 @@ describe('CRDTCollection', () => {
       assert.isFalse(isEmptyChange(modelChange3));
       assert.isFalse(isEmptyChange(otherChange3));
     });
+
+    it('returns empty other change when merging into empty model', () => {
+      const set = new CRDTCollection<{id: string}>();
+      const set2 = new CRDTCollection<{id: string}>();
+      set2.applyOperation({type: CollectionOpTypes.Add, actor: 'a', added: {id: 'foo'}, clock: {'a': 1}});
+
+      const {modelChange: modelChange, otherChange: otherChange} = set.merge(set2.getData());
+      assert.isFalse(isEmptyChange(modelChange));
+      assert.isTrue(isEmptyChange(otherChange));
+    });
   });
 });
 
-// Note: if/when adding more tests to this file, please, also update CrdtTest.java
+// Note: if/when adding more tests to this file, please, also update CrdtSetTest.kt

--- a/src/runtime/storageNG/tests/reference-mode-store-test.ts
+++ b/src/runtime/storageNG/tests/reference-mode-store-test.ts
@@ -400,13 +400,13 @@ describe('Reference Mode Store', async () => {
     e3.id = 'e3';
     e3.creationTimestamp = now;
 
-    void activeStore.onProxyMessage({type: ProxyMessageType.Operations, id: 1, operations: [
+    await activeStore.onProxyMessage({type: ProxyMessageType.Operations, id: 1, operations: [
       {type: CollectionOpTypes.Add, actor: 'me', clock: {me: 1}, added: e1}
     ]});
-    void activeStore.onProxyMessage({type: ProxyMessageType.Operations, id: 1, operations: [
+    await activeStore.onProxyMessage({type: ProxyMessageType.Operations, id: 1, operations: [
       {type: CollectionOpTypes.Add, actor: 'me', clock: {me: 2}, added: e2}
     ]});
-    void activeStore.onProxyMessage({type: ProxyMessageType.Operations, id: 1, operations: [
+    await activeStore.onProxyMessage({type: ProxyMessageType.Operations, id: 1, operations: [
       {type: CollectionOpTypes.Add, actor: 'me', clock: {me: 3}, added: e3}
     ]});
 


### PR DESCRIPTION
…no added, no removed and no clock changes) in both typescript and kotlin implementation (b/160005025).