### PR TITLE
Make checks and claims lists mutable in RecipeGraph

### DIFF
--- a/java/arcs/core/analysis/InformationFlow.kt
+++ b/java/arcs/core/analysis/InformationFlow.kt
@@ -38,27 +38,21 @@ import java.util.BitSet
  * TODO(bgogul): For the time being, we pass in the ingress handles.
 */
 class InformationFlow private constructor(
-    private val recipe: Recipe,
+    private val graph: RecipeGraph,
     private val ingresses: List<String> = emptyList()
 ) : RecipeGraphFixpointIterator<AccessPathLabels>(AccessPathLabels.getBottom()) {
 
     private val log = TaggedLog { "InformationFlow" }
 
-    private val particleClaims: Map<Particle, List<Claim>> = recipe.particles
-        .filterNot { it.spec.claims.isEmpty() }
-        .map { it to it.instantiatedClaims() }
-        .toMap()
+    private val particleClaims = graph.particleNodes.associateBy(
+        keySelector = { it.particle },
+        valueTransform = { it.instantiatedClaims() }
+    )
 
-    private val particleChecks = recipe.particles
-        .filterNot { it.spec.checks.isEmpty() }
-        .map { it to it.instantiatedChecks() }
-        .toMap()
-
-    /** Returns the instantiated [List<Claim>] for this particle. */
-    private fun Particle.instantiatedClaims() = spec.claims.map { it.instantiateFor(this) }
-
-    /** Returns the instantiated [List<Check>] for this particle. */
-    private fun Particle.instantiatedChecks() = spec.checks.map { it.instantiateFor(this) }
+    private val particleChecks = graph.particleNodes.associateBy(
+        keySelector = { it.particle },
+        valueTransform = { it.instantiatedChecks() }
+    )
 
     /** Represents all the labels mentioned in the particle claims. */
     private val labelsInClaims: Set<InformationFlowLabel> =
@@ -117,7 +111,7 @@ class InformationFlow private constructor(
         val connectionName = if (specParts.size == 2) specParts[1] else null
         val particleNode = graph.nodes.asSequence()
             .filterIsInstance<RecipeGraph.Node.Particle>()
-            .find { it.particle.spec.name == particleName }
+            .find { it.particleName == particleName }
         val initialValues = mutableMapOf<AccessPath, InformationFlowLabels>()
 
         val particle = particleNode?.particle ?: return null
@@ -398,7 +392,7 @@ class InformationFlow private constructor(
         /** Computes the labels for [recipe] when [ingress] is used as the ingress handles. */
         public fun computeLabels(recipe: Recipe, ingress: List<String>): AnalysisResult {
             val graph = RecipeGraph(recipe)
-            val analysis = InformationFlow(recipe, ingress)
+            val analysis = InformationFlow(graph, ingress)
             return AnalysisResult(
                 recipe = recipe,
                 fixpoint = analysis.computeFixpoint(graph) { value, prefix ->
@@ -412,7 +406,17 @@ class InformationFlow private constructor(
     }
 }
 
-/** Return the [InformationFlowLabel] occurences in the predicate. */
+/** Returns the instantiated [List<Claim>] for this particle. */
+private fun RecipeGraph.Node.Particle.instantiatedClaims(): List<Claim> {
+    return claims.map { it.instantiateFor(particle) }
+}
+
+/** Returns the instantiated [List<Check>] for this particle. */
+private fun RecipeGraph.Node.Particle.instantiatedChecks(): List<Check> {
+    return checks.map { it.instantiateFor(particle) }
+}
+
+/** Return the [InformationFlowLabel] occurrences in the predicate. */
 private fun Predicate.labels(): List<InformationFlowLabel> = when (this) {
     is Predicate.Label -> listOf(label)
     is Predicate.Not -> predicate.labels()

--- a/java/arcs/core/analysis/RecipeGraphFixpointIterator.kt
+++ b/java/arcs/core/analysis/RecipeGraphFixpointIterator.kt
@@ -15,12 +15,6 @@ import arcs.core.data.HandleConnectionSpec
 import arcs.core.data.Recipe
 import arcs.core.util.TaggedLog
 
-/** Returns the name of the underlying handle or particle. */
-fun RecipeGraph.Node.name() = when (this) {
-    is RecipeGraph.Node.Particle -> "p:${particle.spec.name}"
-    is RecipeGraph.Node.Handle -> "h:${handle.name}"
-}
-
 /**
  * An abstract class that implements dataflow analysis over abstract values of type [V].
  *
@@ -55,7 +49,7 @@ abstract class RecipeGraphFixpointIterator<V : AbstractValue<V>>(val bottom: V) 
             graph.nodes
                 .filterIsInstance<RecipeGraph.Node.Particle>()
                 .forEach {
-                    builder.append("${it.particle.spec.name}:\n")
+                    builder.append("${it.particleName}:\n")
                     val value = getValue(it.particle)
                     builder.append(prettyPrinter?.let { prettyPrinter(value, " ") } ?: "$value")
                     builder.append("\n")
@@ -140,7 +134,7 @@ abstract class RecipeGraphFixpointIterator<V : AbstractValue<V>>(val bottom: V) 
             val input = nodeValues[current] ?: bottom
             log.debug {
                 """
-                  |Processing node ${current.name()}:
+                  |Processing node ${current.debugName}:
                      ${prettyPrint(input, "|  ")}
                 """.trimMargin()
             }
@@ -152,7 +146,7 @@ abstract class RecipeGraphFixpointIterator<V : AbstractValue<V>>(val bottom: V) 
                 val newValue = oldValue.join(edgeValue)
                 log.debug {
                     """
-                      |Processing Edge ${current.name()} -> ${succ.name()}:
+                      |Processing Edge ${current.debugName} -> ${succ.debugName}:
                       |  changed : ${!oldValue.isEquivalentTo(newValue)}
                       |  edge:
                            ${prettyPrint(edgeValue, "|    ")}

--- a/javatests/arcs/core/analysis/RecipeGraphFixpointIteratorTest.kt
+++ b/javatests/arcs/core/analysis/RecipeGraphFixpointIteratorTest.kt
@@ -14,18 +14,12 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
-/** Returns the name of the underlying handle or particle. */
-fun RecipeGraph.Node.getName() = when (this) {
-    is RecipeGraph.Node.Particle -> "p:${particle.spec.name}"
-    is RecipeGraph.Node.Handle -> "h:${handle.name}"
-}
-
 /** A simple Fixpoint iterator for the purposes of testing. */
 class TestAnalyzer(
     val startNames: Set<String>
 ) : RecipeGraphFixpointIterator<AbstractSet<String>>(AbstractSet.getBottom<String>()) {
     override fun getInitialValues(graph: RecipeGraph) = graph.nodes.filter {
-        startNames.contains(it.getName())
+        startNames.contains(it.debugName)
     }.associateWith {
         AbstractSet<String>(setOf())
     }

--- a/javatests/arcs/core/analysis/RecipeGraphTest.kt
+++ b/javatests/arcs/core/analysis/RecipeGraphTest.kt
@@ -230,40 +230,4 @@ class RecipeGraphTest {
             )
         }
     }
-
-    @Test
-    fun particleNode_claimsAreMutable() {
-        with (TestRecipe()) {
-            val node = RecipeGraph.Node.Particle(readerParticle)
-            assertThat(node.claims).isEmpty()
-            val selector = listOf(AccessPath.Selector.Field("bar"))
-            val claim = Claim.Assume(
-                AccessPath("r", readConnectionSpec, selector),
-                InformationFlowLabel.Predicate.Label(
-                    InformationFlowLabel.SemanticTag("packageName")
-                )
-            )
-
-            node.claims.add(claim)
-            assertThat(node.claims).containsExactly(claim)
-        }
-    }
-
-    @Test
-    fun particleNode_checksAreMutable() {
-        with (TestRecipe()) {
-            val node = RecipeGraph.Node.Particle(readerParticle)
-            assertThat(node.checks).isEmpty()
-            val selector = listOf(AccessPath.Selector.Field("bar"))
-            val check = Check.Assert(
-                AccessPath("r", readConnectionSpec, selector),
-                InformationFlowLabel.Predicate.Label(
-                    InformationFlowLabel.SemanticTag("packageName")
-                )
-            )
-
-            node.checks.add(check)
-            assertThat(node.checks).containsExactly(check)
-        }
-    }
 }


### PR DESCRIPTION
Instead of reading from `node.particle.spec.checks`/`claims`, read from `node.checks`/`claims`. These lists are now mutable, to allow us to attach additional checks and claims to nodes in the RecipeGraph when translating policies.

Also added a couple of simplifications concerning `particle.spec.name` and debug strings like `p:ParticleName`