### PR TITLE
Standalone Kotlin Schema Generation

### DIFF
--- a/src/tools/kotlin-schema-generator.ts
+++ b/src/tools/kotlin-schema-generator.ts
@@ -8,81 +8,100 @@
  * http://polymer.github.io/PATENTS.txt
  */
 import {KotlinGenerationUtils, leftPad, quote} from './kotlin-generation-utils.js';
-import {SchemaNode} from './schema2graph.js';
 import {Schema} from '../runtime/schema.js';
-import {AddFieldOptions, SchemaDescriptorBase} from './schema2base.js';
 import {KTExtracter} from './kotlin-refinement-generator.js';
-import {escapeIdentifier, getTypeInfo} from './kotlin-codegen-shared.js';
+import {assert} from '../platform/assert-web.js';
 
 const ktUtils = new KotlinGenerationUtils();
 
 /**
- * Metadata about a field in a schema.
+ * Generates a Kotlin schema instance.
  */
-export type KotlinSchemaField = AddFieldOptions & {
-  type: string,
-  decodeFn: string,
-  defaultVal: string,
-  schemaType: string,
-  escaped: string,
-  nullableType: string
-};
-
-/**
- * Composes and holds a list of KotlinSchemaField for a SchemaNode.
- */
-export class KotlinSchemaDescriptor extends SchemaDescriptorBase {
-
-  readonly fields: KotlinSchemaField[] = [];
-
-  constructor(node: SchemaNode, private forWasm: boolean) {
-    super(node);
-    this.process();
-  }
-
-  addField(opts: AddFieldOptions) {
-    if (opts.typeName === 'Reference' && this.forWasm) return;
-
-    const typeInfo = getTypeInfo({name: opts.typeName, ...opts});
-    const type = typeInfo.type;
-
-    this.fields.push({
-      ...opts,
-      ...typeInfo,
-      escaped: escapeIdentifier(opts.field),
-      nullableType: type.endsWith('?') ? type : `${type}?`
-    });
-  }
-}
-
-/**
- * Generates a schema instance for a given KotlinSchemaDescriptor
- */
-export function generateSchema(descriptor: KotlinSchemaDescriptor): string {
-  const schema = descriptor.node.schema;
+export async function generateSchema(schema: Schema): Promise<string> {
   if (schema.equals(Schema.EMPTY)) return `Schema.EMPTY`;
 
   const schemaNames = schema.names.map(n => `SchemaName("${n}")`);
   const {refinement, query} = generatePredicates(schema);
 
-  function generateFieldMap(isCollection: boolean): string {
-    const fieldPairs = descriptor.fields
-        .filter(f => !!f.isCollection === isCollection)
-        .map(({field, schemaType}) => `"${field}" to ${schemaType}`);
-    return leftPad(ktUtils.mapOf(fieldPairs, 30), 8, true);
-  }
+  const singletons: string[] = [];
+  const collections: string[] = [];
+
+  await visitSchemaFields(schema, ({isCollection, field, schemaType}) =>
+      (isCollection ? collections : singletons).push(`"${field}" to ${schemaType}`));
 
   return `\
 Schema(
     setOf(${ktUtils.joinWithIndents(schemaNames, {startIndent: 8})}),
     SchemaFields(
-        singletons = ${generateFieldMap(false)},
-        collections = ${generateFieldMap(true)}
+        singletons = ${leftPad(ktUtils.mapOf(singletons, 30), 8, true)},
+        collections = ${leftPad(ktUtils.mapOf(collections, 30), 8, true)}
     ),
-    ${quote(descriptor.node.hash)},
+    ${quote(await schema.hash())},
     refinement = ${refinement},
     query = ${query}
 )`;
+}
+
+interface SchemaField {
+  field: string;
+  isCollection: boolean;
+  schemaType: string;
+}
+
+async function visitSchemaFields(schema: Schema, visitor: (field: SchemaField) => void) {
+  for (const [field, descriptor] of Object.entries(schema.fields)) {
+    switch (descriptor.kind) {
+      case 'schema-collection':
+        visitor({field, isCollection: true, schemaType: await getSchemaType(field, descriptor.schema)});
+        break;
+      case 'schema-primitive':
+      case 'kotlin-primitive':
+      case 'schema-reference':
+      case 'schema-nested':
+        visitor({field, isCollection: false, schemaType: await getSchemaType(field, descriptor)});
+        break;
+      case 'schema-ordered-list':
+        visitor({field, isCollection: false, schemaType: await getSchemaType(field, {
+          ...descriptor,
+          innerType: await getSchemaType(field, descriptor.schema)
+        })});
+        break;
+      default:
+        throw new Error(`Schema kind '${descriptor.kind}' for field '${field}' is not supported`);
+    }
+  }
+}
+
+async function getSchemaType(field: string, {kind, schema, type, innerType}): Promise<string> {
+  if (kind === 'schema-primitive') {
+    switch (type) {
+      case 'Text': return 'FieldType.Text';
+      case 'URL': return 'FieldType.Text';
+      case 'Number': return 'FieldType.Number';
+      case 'Boolean': return 'FieldType.Boolean';
+      default: break;
+    }
+  } else if (kind === 'kotlin-primitive') {
+    switch (type) {
+      case 'Byte': return 'FieldType.Byte';
+      case 'Short': return 'FieldType.Short';
+      case 'Int': return 'FieldType.Int';
+      case 'Long': return 'FieldType.Long';
+      case 'Char': return 'FieldType.Char';
+      case 'Float': return 'FieldType.Float';
+      case 'Double': return 'FieldType.Double';
+      default: break;
+    }
+  } else if (kind === 'schema-reference') {
+    return `FieldType.EntityRef(${quote(await schema.model.getEntitySchema().hash())})`;
+  } else if (kind === 'schema-nested') {
+    return `FieldType.InlineEntity(${quote(await schema.model.getEntitySchema().hash())})`;
+  } else if (kind === 'schema-ordered-list') {
+    assert(innerType, 'innerType must be provided for Lists');
+    return `FieldType.ListOf(${innerType})`;
+  }
+
+  throw new Error(`Schema kind '${kind}' for field '${field}' is not supported`);
 }
 
 function generatePredicates(schema: Schema): {query: string, refinement: string} {

--- a/src/tools/schema2base.ts
+++ b/src/tools/schema2base.ts
@@ -38,7 +38,7 @@ export class NodeAndGenerator {
 /**
  * Iterates over schema fields and composes metadata useful for entity codegen.
  */
-export abstract class SchemaDescriptorBase {
+export abstract class EntityDescriptorBase {
 
   constructor(readonly node: SchemaNode) {}
 
@@ -158,7 +158,7 @@ export abstract class Schema2Base {
         continue;
       }
 
-      classes.push(this.generateParticleClass(particle, nodes));
+      classes.push(await this.generateParticleClass(particle, nodes));
     }
     return classes;
   }
@@ -187,7 +187,7 @@ export abstract class Schema2Base {
 
   abstract getEntityGenerator(node: SchemaNode): EntityGenerator;
 
-  abstract generateParticleClass(particle: ParticleSpec, nodes: NodeAndGenerator[]): string;
+  abstract async generateParticleClass(particle: ParticleSpec, nodes: NodeAndGenerator[]): Promise<string>;
 
   abstract generateTestHarness(particle: ParticleSpec, nodes: SchemaNode[]): string;
 }

--- a/src/tools/schema2cpp.ts
+++ b/src/tools/schema2cpp.ts
@@ -7,7 +7,7 @@
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
-import {Schema2Base, EntityGenerator, AddFieldOptions, SchemaDescriptorBase} from './schema2base.js';
+import {Schema2Base, EntityGenerator, AddFieldOptions, EntityDescriptorBase} from './schema2base.js';
 import {SchemaNode} from './schema2graph.js';
 import {ParticleSpec} from '../runtime/particle-spec.js';
 import {Type} from '../runtime/type.js';
@@ -87,7 +87,7 @@ export class Schema2Cpp extends Schema2Base {
     return new CppGenerator(node, this.namespace.replace(/\./g, '::'));
   }
 
-  generateParticleClass(particle: ParticleSpec): string {
+  async generateParticleClass(particle: ParticleSpec): Promise<string> {
     const particleName = particle.name;
     const handleDecls: string[] = [];
 
@@ -123,7 +123,7 @@ protected:
   }
 }
 
-class CppSchemaDescriptor extends SchemaDescriptorBase {
+class CppEntityDescriptor extends EntityDescriptorBase {
 
   constructor(node: SchemaNode) {
     super(node);
@@ -212,10 +212,10 @@ class CppSchemaDescriptor extends SchemaDescriptorBase {
 
 class CppGenerator implements EntityGenerator {
 
-  private descriptor: CppSchemaDescriptor;
+  private descriptor: CppEntityDescriptor;
 
   constructor(readonly node: SchemaNode, readonly namespace: string) {
-    this.descriptor = new CppSchemaDescriptor(node);
+    this.descriptor = new CppEntityDescriptor(node);
   }
 
   typeFor(name: string): string {

--- a/src/tools/schema2kotlin.ts
+++ b/src/tools/schema2kotlin.ts
@@ -190,8 +190,8 @@ ${imports.join('\n')}
     );
   }
 
-  generateParticleClass(particle: ParticleSpec, nodeGenerators: NodeAndGenerator[]): string {
-    const {typeAliases, classes, handleClassDecl} = this.generateParticleClassComponents(particle, nodeGenerators);
+  async generateParticleClass(particle: ParticleSpec, nodeGenerators: NodeAndGenerator[]): Promise<string> {
+    const {typeAliases, classes, handleClassDecl} = await this.generateParticleClassComponents(particle, nodeGenerators);
     return `
 ${typeAliases.join(`\n`)}
 
@@ -205,18 +205,18 @@ abstract class Abstract${particle.name} : ${this.opts.wasm ? 'WasmParticleImpl' 
 `;
   }
 
-  generateParticleClassComponents(particle: ParticleSpec, nodeGenerators: NodeAndGenerator[]) {
+  async generateParticleClassComponents(particle: ParticleSpec, nodeGenerators: NodeAndGenerator[]) {
     const particleName = particle.name;
     const handleDecls: string[] = [];
     const specDecls: string[] = [];
     const classes: string[] = [];
     const typeAliases: string[] = [];
 
-    nodeGenerators.forEach(nodeGenerator => {
+    for (const nodeGenerator of nodeGenerators) {
       const kotlinGenerator = <KotlinEntityGenerator>nodeGenerator.generator;
-      classes.push(kotlinGenerator.generateClasses());
+      classes.push(await kotlinGenerator.generateClasses());
       typeAliases.push(...kotlinGenerator.generateAliases(particleName));
-    });
+    }
 
     const nodes = nodeGenerators.map(ng => ng.node);
     for (const connection of particle.connections) {

--- a/src/tools/tests/kotlin-schema-generator-test.ts
+++ b/src/tools/tests/kotlin-schema-generator-test.ts
@@ -9,7 +9,7 @@
  */
 
 import {assert} from '../../platform/chai-node.js';
-import {KotlinSchemaDescriptor, generateSchema} from '../kotlin-schema-generator.js';
+import {generateSchema} from '../kotlin-schema-generator.js';
 import {Manifest} from '../../runtime/manifest.js';
 import {SchemaGraph} from '../schema2graph.js';
 
@@ -21,8 +21,8 @@ describe('Kotlin Schema Generator', () => {
   ));
   it('generates a schema with multiple names', async () => await assertSchemas(
     `particle T
-         h1: reads Person Friend Parent {}`, [
-`Schema(
+         h1: reads Person Friend Parent {}`, [`\
+Schema(
     setOf(SchemaName("Person"), SchemaName("Friend"), SchemaName("Parent")),
     SchemaFields(
         singletons = emptyMap(),
@@ -36,8 +36,8 @@ describe('Kotlin Schema Generator', () => {
   ));
   it('generates a schema with primitive fields', async () => await assertSchemas(
     `particle T
-         h1: reads Person {name: Text, age: Number, friendNames: [Text]}`, [
-`Schema(
+         h1: reads Person {name: Text, age: Number, friendNames: [Text]}`, [`\
+Schema(
     setOf(SchemaName("Person")),
     SchemaFields(
         singletons = mapOf("name" to FieldType.Text, "age" to FieldType.Number),
@@ -49,20 +49,59 @@ describe('Kotlin Schema Generator', () => {
 )`
     ]
   ));
-  it('generates schemas for a reference', async () => await assertSchemas(
-    `particle T
-         h1: reads Person {address: &Address {streetAddress: Text}}`, [
-`Schema(
-    setOf(SchemaName("Address")),
+  it('generates a schema with Kotlin types', async () => await assertSchemas(`
+    particle T
+      h1: reads Data {
+        bt: Byte,
+        shrt: Short,
+        nt: Int,
+        lng: Long,
+        chr: Char,
+        flt: Float,
+        dbl: Double,
+      }`, [`\
+Schema(
+    setOf(SchemaName("Data")),
     SchemaFields(
-        singletons = mapOf("streetAddress" to FieldType.Text),
+        singletons = mapOf(
+            "bt" to FieldType.Byte,
+            "shrt" to FieldType.Short,
+            "nt" to FieldType.Int,
+            "lng" to FieldType.Long,
+            "chr" to FieldType.Char,
+            "flt" to FieldType.Float,
+            "dbl" to FieldType.Double
+        ),
         collections = emptyMap()
     ),
-    "41a3bd27b7c53f1c5846754291653d13f49e3e8d",
+    "e444f20e280c14494a71cc6838bb97a18a14ea49",
     refinement = { _ -> true },
     query = null
-)`,
-`Schema(
+)`
+    ]
+  ));
+  it('generates a schema with lists of primitive fields', async () => await assertSchemas(
+    `particle T
+         h1: reads Person {names: List<Text>, favNumbers: List<Number>}`, [`\
+Schema(
+    setOf(SchemaName("Person")),
+    SchemaFields(
+        singletons = mapOf(
+            "names" to FieldType.ListOf(FieldType.Text),
+            "favNumbers" to FieldType.ListOf(FieldType.Number)
+        ),
+        collections = emptyMap()
+    ),
+    "601707171fccbedc3f8d2506c326d6f0fddaaa04",
+    refinement = { _ -> true },
+    query = null
+)`
+    ]
+  ));
+  it('generates schemas for a reference', async () => await assertSchemas(
+    `particle T
+         h1: reads Person {address: &Address {streetAddress: Text}}`, [`\
+Schema(
     setOf(SchemaName("Person")),
     SchemaFields(
         singletons = mapOf(
@@ -73,13 +112,122 @@ describe('Kotlin Schema Generator', () => {
     "d44c98a544cbbdd187a7e0529046166ed6a4bcb0",
     refinement = { _ -> true },
     query = null
+)`, `\
+Schema(
+    setOf(SchemaName("Address")),
+    SchemaFields(
+        singletons = mapOf("streetAddress" to FieldType.Text),
+        collections = emptyMap()
+    ),
+    "41a3bd27b7c53f1c5846754291653d13f49e3e8d",
+    refinement = { _ -> true },
+    query = null
+)`
+    ]
+  ));
+  it('generates schemas for a collection of references', async () => await assertSchemas(
+    `particle T
+         h1: reads Person {address: [&Address {streetAddress: Text}]}`, [`\
+Schema(
+    setOf(SchemaName("Person")),
+    SchemaFields(
+        singletons = emptyMap(),
+        collections = mapOf(
+            "address" to FieldType.EntityRef("41a3bd27b7c53f1c5846754291653d13f49e3e8d")
+        )
+    ),
+    "e386e5e1ae663a3b491008c6e931d81a5166ce20",
+    refinement = { _ -> true },
+    query = null
+)`, `\
+Schema(
+    setOf(SchemaName("Address")),
+    SchemaFields(
+        singletons = mapOf("streetAddress" to FieldType.Text),
+        collections = emptyMap()
+    ),
+    "41a3bd27b7c53f1c5846754291653d13f49e3e8d",
+    refinement = { _ -> true },
+    query = null
+)`,
+    ]
+  ));
+  it('generates schemas for a nested entity', async () => await assertSchemas(
+    `particle T
+         h1: reads Person {address: inline Address {streetAddress: Text}}`, [`\
+Schema(
+    setOf(SchemaName("Person")),
+    SchemaFields(
+        singletons = mapOf(
+            "address" to FieldType.InlineEntity("41a3bd27b7c53f1c5846754291653d13f49e3e8d")
+        ),
+        collections = emptyMap()
+    ),
+    "0c8f412660e502d17b310fadf8e950083965e3d5",
+    refinement = { _ -> true },
+    query = null
+)`, `\
+Schema(
+    setOf(SchemaName("Address")),
+    SchemaFields(
+        singletons = mapOf("streetAddress" to FieldType.Text),
+        collections = emptyMap()
+    ),
+    "41a3bd27b7c53f1c5846754291653d13f49e3e8d",
+    refinement = { _ -> true },
+    query = null
+)`
+    ]
+  ));
+  it('generates schemas for a double nested entity', async () => await assertSchemas(`
+    particle T
+      h1: reads Person {
+        address: inline Address {
+          streetAddress: Text,
+          city: inline City {name: Text}
+        }
+      }`, [`\
+Schema(
+    setOf(SchemaName("Person")),
+    SchemaFields(
+        singletons = mapOf(
+            "address" to FieldType.InlineEntity("357fa6d61d95ea4234984c2341bf1eb4664cc534")
+        ),
+        collections = emptyMap()
+    ),
+    "3932685180303cb50fc7493ab5ca4543ac176866",
+    refinement = { _ -> true },
+    query = null
+)`, `\
+Schema(
+    setOf(SchemaName("Address")),
+    SchemaFields(
+        singletons = mapOf(
+            "streetAddress" to FieldType.Text,
+            "city" to FieldType.InlineEntity("783a4126e47d586196d9e80810b67199edcb04da")
+        ),
+        collections = emptyMap()
+    ),
+    "357fa6d61d95ea4234984c2341bf1eb4664cc534",
+    refinement = { _ -> true },
+    query = null
+)`, `\
+Schema(
+    setOf(SchemaName("City")),
+    SchemaFields(
+        singletons = mapOf("name" to FieldType.Text),
+        collections = emptyMap()
+    ),
+    "783a4126e47d586196d9e80810b67199edcb04da",
+    refinement = { _ -> true },
+    query = null
 )`
     ]
   ));
   it('generates a schema with a refinement', async () => await assertSchemas(
     `particle T
-         h1: reads Person {name: Text, age: Number} [age >= 21]`, [
-`Schema(
+         h1: reads Person {name: Text, age: Number} [age >= 21]`, [`\
+Schema(
     setOf(SchemaName("Person")),
     SchemaFields(
         singletons = mapOf("name" to FieldType.Text, "age" to FieldType.Number),
@@ -96,8 +244,8 @@ describe('Kotlin Schema Generator', () => {
   ));
   it('generates a schema with a query', async () => await assertSchemas(
     `particle T
-         h1: reads Person {name: Text, age: Number} [age >= ?]`, [
-`Schema(
+         h1: reads Person {name: Text, age: Number} [age >= ?]`, [`\
+Schema(
     setOf(SchemaName("Person")),
     SchemaFields(
         singletons = mapOf("name" to FieldType.Text, "age" to FieldType.Number),
@@ -115,8 +263,8 @@ describe('Kotlin Schema Generator', () => {
   ));
   it('generates schemas for a tuple connection', async () => await assertSchemas(
     `particle T
-         h1: reads (&Person {name: Text}, &Product {sku: Text})`, [
-`Schema(
+         h1: reads (&Person {name: Text}, &Product {sku: Text})`, [`\
+Schema(
     setOf(SchemaName("Person")),
     SchemaFields(
         singletons = mapOf("name" to FieldType.Text),
@@ -125,8 +273,8 @@ describe('Kotlin Schema Generator', () => {
     "0149326a894f2d81705e1a08480330826f919cf0",
     refinement = { _ -> true },
     query = null
-)`,
-`Schema(
+)`, `\
+Schema(
     setOf(SchemaName("Product")),
     SchemaFields(
         singletons = mapOf("sku" to FieldType.Text),
@@ -149,8 +297,7 @@ describe('Kotlin Schema Generator', () => {
     const actualValues = [];
     for (const node of graph.nodes) {
       await Promise.all([node, ...node.refs.values()].map(n => n.calculateHash()));
-      const schemaDescriptor = new KotlinSchemaDescriptor(node, /* forWasm= */ false);
-      actualValues.push(generateSchema(schemaDescriptor));
+      actualValues.push(await generateSchema(node.schema));
     }
 
     assert.sameDeepMembers(actualValues, expectedValues);

--- a/src/tools/tests/schema2kotlin-test.ts
+++ b/src/tools/tests/schema2kotlin-test.ts
@@ -397,7 +397,7 @@ class PTestHarness<P : AbstractP>(
 
     const schema2kotlin = new Schema2Kotlin({_: []});
     const generators = await schema2kotlin.calculateNodeAndGenerators(particle);
-    const components = schema2kotlin.generateParticleClassComponents(particle, generators);
+    const components = await schema2kotlin.generateParticleClassComponents(particle, generators);
     assert.deepEqual(extractor(components), expectedValue);
   }
 });

--- a/src/tools/tests/schema2wasm-test.ts
+++ b/src/tools/tests/schema2wasm-test.ts
@@ -10,7 +10,7 @@
 import {assert} from '../../platform/chai-web.js';
 import {Manifest} from '../../runtime/manifest.js';
 import {Dictionary} from '../../runtime/hot.js';
-import {Schema2Base, EntityGenerator, AddFieldOptions, SchemaDescriptorBase} from '../schema2base.js';
+import {Schema2Base, EntityGenerator, AddFieldOptions, EntityDescriptorBase} from '../schema2base.js';
 import {SchemaNode} from '../schema2graph.js';
 import {Schema2Cpp} from '../schema2cpp.js';
 import {Schema2Kotlin} from '../schema2kotlin.js';
@@ -31,7 +31,7 @@ class Schema2Mock extends Schema2Base {
     const collector = [];
     this.res[node.entityClassName] = collector;
 
-    new class extends SchemaDescriptorBase {
+    new class extends EntityDescriptorBase {
       addField({field, typeName, isOptional, refClassName}: AddFieldOptions) {
         const refInfo = refClassName ? `<${refClassName}>` : '';
         collector.push(field + ':' + typeName[0] + refInfo + (isOptional ? '?' : ''));
@@ -45,7 +45,7 @@ class Schema2Mock extends Schema2Base {
     };
   }
 
-  generateParticleClass(particle: ParticleSpec) {
+  async generateParticleClass(particle: ParticleSpec) {
     return '';
   }
 


### PR DESCRIPTION
Before this PR Kotlin Schemas were generated for particle connections, which materialized in code as generating the schema for SchemaNode (which is a result of traversing the particle spec). This PR pulls out the Schema generation logic to be entirely standalone, i.e. `generateSchema` takes `schema: Schema` and nothing else.

This is needed to generate schemas that don't pertain to any particle, e.g. to generate a type of a handle in the recipe2plan. This PR will unlock fixing a bug causing the store type to be based of the first processed handle connection, instead of the resolved handle type as well as unlock progress with Adapters work.

I'm also adding a some unit tests for Kotlin schema generation to increase coverage in order to decrease dependency on golden files.