### PR TITLE
Revert #5615 as it breaks Firebase emulator tests.

### DIFF
--- a/javatests/arcs/core/entity/DifferentHandleManagerDifferentStoresTest.kt
+++ b/javatests/arcs/core/entity/DifferentHandleManagerDifferentStoresTest.kt
@@ -8,6 +8,8 @@ import arcs.jvm.host.JvmSchedulerProvider
 import kotlin.coroutines.EmptyCoroutineContext
 import org.junit.After
 import org.junit.Before
+import org.junit.Ignore
+import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
@@ -40,4 +42,34 @@ class DifferentHandleManagerDifferentStoresTest : HandleManagerTestBase() {
 
     @After
     override fun tearDown() = super.tearDown()
+
+    @Test
+    override fun collection_removingFromA_isRemovedFromB() {
+        super.collection_removingFromA_isRemovedFromB()
+    }
+
+    @Test
+    override fun singleton_referenceLiveness() {
+        super.singleton_referenceLiveness()
+    }
+
+    @Test
+    override fun collection_referenceLiveness() {
+        super.collection_referenceLiveness()
+    }
+
+    @Test
+    override fun singleton_dereferenceEntity() {
+        super.singleton_dereferenceEntity()
+    }
+
+    @Test
+    override fun collection_entityDereference() {
+        super.collection_entityDereference()
+    }
+
+    @Test
+    override fun singleton_clearOnAClearDataWrittenByB() {
+        super.singleton_clearOnAClearDataWrittenByB()
+    }
 }

--- a/javatests/arcs/core/entity/DifferentHandleManagerTest.kt
+++ b/javatests/arcs/core/entity/DifferentHandleManagerTest.kt
@@ -8,6 +8,8 @@ import arcs.jvm.host.JvmSchedulerProvider
 import kotlin.coroutines.EmptyCoroutineContext
 import org.junit.After
 import org.junit.Before
+import org.junit.Ignore
+import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
@@ -41,4 +43,39 @@ class DifferentHandleManagerTest : HandleManagerTestBase() {
 
     @After
     override fun tearDown() = super.tearDown()
+
+    @Test
+    override fun collection_referenceLiveness() {
+        super.collection_referenceLiveness()
+    }
+
+    @Test
+    override fun collection_clearingElementsFromA_clearsThemFromB() {
+        super.collection_clearingElementsFromA_clearsThemFromB()
+    }
+
+    @Test
+    override fun collection_noTTL() {
+        super.collection_noTTL()
+    }
+
+    @Test
+    override fun singleton_referenceLiveness() {
+        super.singleton_referenceLiveness()
+    }
+
+    @Test
+    override fun singleton_clearOnAClearDataWrittenByB() {
+        super.singleton_clearOnAClearDataWrittenByB()
+    }
+
+    @Test
+    override fun singleton_dereferenceEntity() {
+        super.singleton_dereferenceEntity()
+    }
+
+    @Test
+    override fun collection_addingToA_showsUpInB() {
+        super.collection_addingToA_showsUpInB()
+    }
 }

--- a/javatests/arcs/core/entity/HandleManagerTestBase.kt
+++ b/javatests/arcs/core/entity/HandleManagerTestBase.kt
@@ -172,7 +172,7 @@ open class HandleManagerTestBase {
     }
 
     @Test
-    fun singleton_writeAndReadBackAndClear() = testRunner {
+    open fun singleton_writeAndReadBackAndClear() = testRunner {
         val writeHandle = writeHandleManager.createSingletonHandle()
         val readHandle = readHandleManager.createSingletonHandle()
 
@@ -211,7 +211,7 @@ open class HandleManagerTestBase {
     }
 
     @Test
-    fun singleton_clearOnAClearDataWrittenByA() = testRunner {
+    open fun singleton_clearOnAClearDataWrittenByA() = testRunner {
         val handleA = writeHandleManager.createSingletonHandle()
         val handleB = readHandleManager.createSingletonHandle()
 
@@ -233,7 +233,7 @@ open class HandleManagerTestBase {
     }
 
     @Test
-    fun singleton_clearOnAClearDataWrittenByB() = testRunner {
+    open fun singleton_clearOnAClearDataWrittenByB() = testRunner {
         val handleA = writeHandleManager.createSingletonHandle()
         val handleB = readHandleManager.createSingletonHandle()
         val handleBUpdated = handleB.onUpdateDeferred { it != null }
@@ -250,7 +250,7 @@ open class HandleManagerTestBase {
     }
 
     @Test
-    fun singleton_writeAndOnUpdate() = testRunner {
+    open fun singleton_writeAndOnUpdate() = testRunner {
         val writeHandle = writeHandleManager.createSingletonHandle()
             as WriteSingletonHandle<Person>
 
@@ -266,7 +266,7 @@ open class HandleManagerTestBase {
     }
 
     @Test
-    fun singleton_dereferenceEntity() = testRunner {
+    open fun singleton_dereferenceEntity() = testRunner {
         val writeHandle = writeHandleManager.createSingletonHandle()
         val readHandle = readHandleManager.createSingletonHandle()
         val readHandleUpdated = readHandle.onUpdateDeferred()
@@ -302,7 +302,7 @@ open class HandleManagerTestBase {
     }
 
     @Test
-    fun singleton_dereferenceEntity_nestedReference() = testRunner {
+    open fun singleton_dereferenceEntity_nestedReference() = testRunner {
         // Create a stylish new hat, and create a reference to it.
         val hatCollection = writeHandleManager.createHandle(
             HandleSpec(
@@ -365,7 +365,7 @@ open class HandleManagerTestBase {
     }
 
     @Test
-    fun singleton_withTTL() = testRunner {
+    open fun singleton_withTTL() = testRunner {
         fakeTime.millis = 0
         val handle = writeHandleManager.createSingletonHandle(ttl = Ttl.Days(2))
         val handleB = readHandleManager.createSingletonHandle()
@@ -415,7 +415,7 @@ open class HandleManagerTestBase {
     }
 
     @Test
-    fun singleton_referenceLiveness() = testRunner {
+    open fun singleton_referenceLiveness() = testRunner {
         // Create and store an entity.
         val writeEntityHandle = writeHandleManager.createCollectionHandle()
         val monitorHandle = monitorHandleManager.createCollectionHandle()
@@ -502,7 +502,7 @@ open class HandleManagerTestBase {
     }
 
     @Test
-    fun collection_addingToA_showsUpInB() = testRunner {
+    open fun collection_addingToA_showsUpInB() = testRunner {
         val handleA = writeHandleManager.createCollectionHandle()
             as ReadWriteCollectionHandle<Person>
         val handleB = readHandleManager.createCollectionHandle()
@@ -523,7 +523,7 @@ open class HandleManagerTestBase {
     }
 
     @Test
-    fun collection_writeAndReadBack() = testRunner {
+    open fun collection_writeAndReadBack() = testRunner {
         val writeHandle = writeHandleManager.createCollectionHandle()
         val readHandle = readHandleManager.createCollectionHandle()
         val allHeard = Job()
@@ -539,7 +539,7 @@ open class HandleManagerTestBase {
     }
 
     @Test
-    fun collection_writeAndOnUpdate() = testRunner {
+    open fun collection_writeAndOnUpdate() = testRunner {
         val writeHandle = writeHandleManager.createCollectionHandle()
             as WriteCollectionHandle<Person>
 
@@ -553,7 +553,7 @@ open class HandleManagerTestBase {
     }
 
     @Test
-    fun collection_writeMutatedEntityReplaces() = testRunner {
+    open fun collection_writeMutatedEntityReplaces() = testRunner {
         val entity = TestParticle_Entities(text = "Hello")
         val handle = writeHandleManager.createCollectionHandle(entitySpec = TestParticle_Entities)
         handle.dispatchStore(entity)
@@ -630,7 +630,7 @@ open class HandleManagerTestBase {
     }
 
     @Test
-    fun collection_removingFromA_isRemovedFromB() = testRunner {
+    open fun collection_removingFromA_isRemovedFromB() = testRunner {
         val handleA = readHandleManager.createCollectionHandle()
         val handleB = writeHandleManager.createCollectionHandle()
 
@@ -662,7 +662,7 @@ open class HandleManagerTestBase {
     }
 
     @Test
-    fun collection_clearingElementsFromA_clearsThemFromB() = testRunner {
+    open fun collection_clearingElementsFromA_clearsThemFromB() = testRunner {
         val handleA = readHandleManager.createCollectionHandle()
         val handleB = writeHandleManager.createCollectionHandle()
 
@@ -693,7 +693,7 @@ open class HandleManagerTestBase {
     }
 
     @Test
-    fun collection_entityDereference() = testRunner {
+    open fun collection_entityDereference() = testRunner {
         val writeHandle = writeHandleManager.createCollectionHandle()
         val readHandle = readHandleManager.createCollectionHandle()
         val monitorHandle = monitorHandleManager.createCollectionHandle()
@@ -718,7 +718,7 @@ open class HandleManagerTestBase {
     }
 
     @Test
-    fun collection_dereferenceEntity_nestedReference() = testRunner {
+    open fun collection_dereferenceEntity_nestedReference() = testRunner {
         // Create a stylish new hat, and create a reference to it.
         val hatSpec = HandleSpec(
             "hatCollection",
@@ -774,7 +774,7 @@ open class HandleManagerTestBase {
     }
 
     @Test
-    fun collection_noTTL() = testRunner {
+    open fun collection_noTTL() = testRunner {
         val monitor = monitorHandleManager.createCollectionHandle()
         val handle = writeHandleManager.createCollectionHandle()
         val handleB = readHandleManager.createCollectionHandle()
@@ -794,7 +794,7 @@ open class HandleManagerTestBase {
     }
 
     @Test
-    fun collection_withTTL() = testRunner {
+    open fun collection_withTTL() = testRunner {
         fakeTime.millis = 0
         val handle = writeHandleManager.createCollectionHandle(ttl = Ttl.Days(2))
         val handleB = readHandleManager.createCollectionHandle()
@@ -845,7 +845,7 @@ open class HandleManagerTestBase {
     }
 
     @Test
-    fun collection_addingToA_showsUpInQueryOnB() = testRunner {
+    open fun collection_addingToA_showsUpInQueryOnB() = testRunner {
         val writeHandle = writeHandleManager.createCollectionHandle()
         val readHandle = readHandleManager.createCollectionHandle()
 
@@ -896,7 +896,7 @@ open class HandleManagerTestBase {
     }
 
     @Test
-    fun collection_referenceLiveness() = testRunner {
+    open fun collection_referenceLiveness() = testRunner {
         // Create and store some entities.
         val writeEntityHandle = writeHandleManager.createCollectionHandle()
         val monitorHandle = monitorHandleManager.createCollectionHandle()

--- a/javatests/arcs/core/entity/SameHandleManagerTest.kt
+++ b/javatests/arcs/core/entity/SameHandleManagerTest.kt
@@ -8,6 +8,8 @@ import arcs.jvm.host.JvmSchedulerProvider
 import kotlin.coroutines.EmptyCoroutineContext
 import org.junit.After
 import org.junit.Before
+import org.junit.Ignore
+import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
@@ -31,4 +33,24 @@ class SameHandleManagerTest : HandleManagerTestBase() {
 
     @After
     override fun tearDown() = super.tearDown()
+
+    @Test
+    override fun collection_noTTL() {
+        super.collection_noTTL()
+    }
+
+    @Test
+    override fun singleton_referenceLiveness() {
+        super.singleton_referenceLiveness()
+    }
+
+    @Test
+    override fun collection_referenceLiveness() {
+        super.collection_referenceLiveness()
+    }
+
+    @Test
+    override fun collection_clearingElementsFromA_clearsThemFromB() {
+        super.collection_clearingElementsFromA_clearsThemFromB()
+    }
 }


### PR DESCRIPTION
Revert "Remove obsolete test method overrides in handle manager tests (#5615)"

This reverts commit dfdbb2ed1d2886be7b5c496483bec58e275d9c48.