### PR TITLE
Creates an applyPolicy function, and adds egress particle checking to it

### DIFF
--- a/java/arcs/core/policy/BUILD
+++ b/java/arcs/core/policy/BUILD
@@ -11,6 +11,7 @@ arcs_kt_library(
     name = "policy",
     srcs = glob(["*.kt"]),
     deps = [
+        "//java/arcs/core/analysis",
         "//java/arcs/core/data",
     ],
 )

--- a/java/arcs/core/policy/PolicyTranslation.kt
+++ b/java/arcs/core/policy/PolicyTranslation.kt
@@ -3,8 +3,8 @@ package arcs.core.policy
 import arcs.core.analysis.RecipeGraph
 
 /**
- * Translates the given [Policy] into dataflow analysis checks and claims on the given
- * [RecipeGraph], returning a modified copy of the graph.
+ * Translates the given [policy] into dataflow analysis checks and claims on the given [graph],
+ * returning a modified copy of the graph.
  */
 fun applyPolicy(policy: Policy, graph: RecipeGraph): RecipeGraph {
     checkEgressParticles(policy, graph)

--- a/java/arcs/core/policy/PolicyTranslation.kt
+++ b/java/arcs/core/policy/PolicyTranslation.kt
@@ -5,6 +5,8 @@ import arcs.core.analysis.RecipeGraph
 /**
  * Translates the given [policy] into dataflow analysis checks and claims on the given [graph],
  * returning a modified copy of the graph.
+ *
+ * @throws PolicyViolation if the [graph] violates the [policy]
  */
 fun applyPolicy(policy: Policy, graph: RecipeGraph): RecipeGraph {
     checkEgressParticles(policy, graph)

--- a/java/arcs/core/policy/PolicyTranslation.kt
+++ b/java/arcs/core/policy/PolicyTranslation.kt
@@ -14,7 +14,7 @@ fun applyPolicy(policy: Policy, graph: RecipeGraph): RecipeGraph {
 
 private fun checkEgressParticles(policy: Policy, graph: RecipeGraph) {
     val invalidEgressParticles = graph.particleNodes
-        .map { it.particle.spec  }
+        .map { it.particle.spec }
         .filter { !it.isolated && it.name != policy.egressParticleName }
     if (invalidEgressParticles.isNotEmpty()) {
         throw PolicyViolation.InvalidEgressParticle(policy, invalidEgressParticles.map { it.name })

--- a/java/arcs/core/policy/PolicyTranslation.kt
+++ b/java/arcs/core/policy/PolicyTranslation.kt
@@ -1,0 +1,37 @@
+package arcs.core.policy
+
+import arcs.core.analysis.RecipeGraph
+
+/**
+ * Translates the given [Policy] into dataflow analysis checks and claims on the given
+ * [RecipeGraph], returning a modified copy of the graph.
+ */
+fun applyPolicy(policy: Policy, graph: RecipeGraph): RecipeGraph {
+    checkEgressParticles(policy, graph)
+    // TODO(b/157605232): Modify the graph and attach checks and claims.
+    return graph
+}
+
+private fun checkEgressParticles(policy: Policy, graph: RecipeGraph) {
+    val invalidEgressParticles = graph.particleNodes
+        .map { it.particle.spec  }
+        .filter { !it.isolated && it.name != policy.egressParticleName }
+    if (invalidEgressParticles.isNotEmpty()) {
+        throw PolicyViolation.InvalidEgressParticle(policy, invalidEgressParticles.map { it.name })
+    }
+}
+
+/** Indicates that a policy was violated by a recipe. */
+sealed class PolicyViolation(val policy: Policy, message: String) : Exception(
+    "Policy ${policy.name} violated: $message"
+) {
+    /** Thrown when egress particles were found in the recipe that are not allowed by policy. */
+    class InvalidEgressParticle(
+        policy: Policy,
+        val particleNames: List<String>
+    ) : PolicyViolation(
+        policy,
+        "Egress particle allowed by policy is ${policy.egressParticleName} but found: " +
+            particleNames.joinToString()
+    )
+}

--- a/javatests/arcs/core/policy/BUILD
+++ b/javatests/arcs/core/policy/BUILD
@@ -9,6 +9,7 @@ arcs_kt_jvm_test_suite(
     name = "policy",
     package = "arcs.core.policy",
     deps = [
+        "//java/arcs/core/analysis",
         "//java/arcs/core/data",
         "//java/arcs/core/policy",
         "//third_party/java/junit:junit-android",

--- a/javatests/arcs/core/policy/PolicyTranslationTest.kt
+++ b/javatests/arcs/core/policy/PolicyTranslationTest.kt
@@ -1,0 +1,83 @@
+package arcs.core.policy
+
+import arcs.core.analysis.RecipeGraph
+import arcs.core.data.ParticleSpec
+import arcs.core.data.Recipe
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import kotlin.test.assertFailsWith
+
+@RunWith(JUnit4::class)
+class PolicyTranslationTest {
+    @Test
+    fun applyPolicy_checksEgressParticles_acceptsIsolatedParticles() {
+        val graph = RecipeGraph(
+            Recipe(
+                name = "Recipe",
+                handles = emptyMap(),
+                particles = listOf(
+                    createParticle("Isolated1", isolated = true),
+                    createParticle("Isolated2", isolated = true)
+                )
+            )
+        )
+
+        val result = applyPolicy(BLANK_POLICY, graph)
+
+        assertThat(result).isEqualTo(graph)
+    }
+
+    @Test
+    fun applyPolicy_checksEgressParticles_acceptsValidEgressParticles() {
+        val graph = RecipeGraph(
+            Recipe(
+                name = "Recipe",
+                handles = emptyMap(),
+                particles = listOf(createParticle("Egress_$BLANK_POLICY_NAME", isolated = false))
+            )
+        )
+
+        val result = applyPolicy(BLANK_POLICY, graph)
+
+        assertThat(result).isEqualTo(graph)
+    }
+
+    @Test
+    fun applyPolicy_checksEgressParticles_rejectsInvalidEgressParticles() {
+        val graph = RecipeGraph(
+            Recipe(
+                name = "Recipe",
+                handles = emptyMap(),
+                particles = listOf(
+                    createParticle("Egress1", isolated = false),
+                    createParticle("Egress2", isolated = false)
+                )
+            )
+        )
+
+        val e = assertFailsWith<PolicyViolation.InvalidEgressParticle> {
+            applyPolicy(BLANK_POLICY, graph)
+        }
+        assertThat(e.policy).isEqualTo(BLANK_POLICY)
+        assertThat(e.particleNames).containsExactly("Egress1", "Egress2")
+    }
+
+    companion object {
+        private const val BLANK_POLICY_NAME = "BlankPolicy"
+        private val BLANK_POLICY = Policy(name = BLANK_POLICY_NAME, egressType = EgressType.LOGGING)
+
+        private fun createParticle(name: String, isolated: Boolean): Recipe.Particle {
+            return Recipe.Particle(
+                spec = ParticleSpec(
+                    name = name,
+                    connections = emptyMap(),
+                    location = "location",
+                    isolated = isolated
+                ),
+                handleConnections = emptyList()
+            )
+        }
+    }
+}


### PR DESCRIPTION
I'm still not particularly content with the way we match egress particles to policies, but this is the plan of record so far (and it will be easy to update later if we have to): each policy has a corresponding egress particle with the name `Egress_<PolicyName>`.

This PR adds the `applyPolicy` function, but all it does so far is check that no invalid egress particles are present in it. More to come later.