### PR TITLE
Add a CrdtSet.Clear operation.

### DIFF
--- a/java/arcs/android/crdt/CrdtSetProto.kt
+++ b/java/arcs/android/crdt/CrdtSetProto.kt
@@ -33,6 +33,12 @@ fun CrdtSetProto.Operation.toOperation(): CrdtSet.Operation<Referencable> = when
             removed = removed.toReferencable()!!
         )
     }
+    CrdtSetProto.Operation.OperationCase.CLEAR -> with(clear) {
+        CrdtSet.Operation.Clear<Referencable>(
+            actor = actor,
+            clock = fromProto(versionMap)
+        )
+    }
     CrdtSetProto.Operation.OperationCase.FAST_FORWARD -> with(fastForward) {
         CrdtSet.Operation.FastForward<Referencable>(
             oldClock = fromProto(oldVersionMap),
@@ -63,6 +69,7 @@ fun CrdtSet.Operation<*>.toProto(): CrdtSetProto.Operation {
     when (this) {
         is CrdtSet.Operation.Add<*> -> proto.add = toProto()
         is CrdtSet.Operation.Remove<*> -> proto.remove = toProto()
+        is CrdtSet.Operation.Clear<*> -> proto.clear = toProto()
         is CrdtSet.Operation.FastForward<*> -> proto.fastForward = toProto()
     }
     return proto.build()
@@ -80,6 +87,12 @@ private fun CrdtSet.Operation.Remove<*>.toProto() = CrdtSetProto.Operation.Remov
     .setVersionMap(clock.toProto())
     .setActor(actor)
     .setRemoved(removed.toProto())
+    .build()
+
+/** Serializes a [CrdtSet.Operation.Clear] to its proto form. */
+private fun CrdtSet.Operation.Clear<*>.toProto() = CrdtSetProto.Operation.Clear.newBuilder()
+    .setVersionMap(clock.toProto())
+    .setActor(actor)
     .build()
 
 /** Serializes a [CrdtSet.Operation.FastForward] to its proto form. */

--- a/java/arcs/android/crdt/crdt_set.proto
+++ b/java/arcs/android/crdt/crdt_set.proto
@@ -33,6 +33,11 @@ message CrdtSetProto {
       ReferencableProto removed = 3;
     }
 
+    message Clear {
+      VersionMapProto version_map = 1;
+      string actor = 2;
+    }
+
     message FastForward {
       VersionMapProto old_version_map = 1;
       VersionMapProto new_version_map = 2;
@@ -43,6 +48,7 @@ message CrdtSetProto {
     oneof operation {
       Add add = 1;
       Remove remove = 2;
+      Clear clear = 4;
       FastForward fast_forward = 3;
     }
   }

--- a/java/arcs/android/util/ProtoPrefetcher.kt
+++ b/java/arcs/android/util/ProtoPrefetcher.kt
@@ -102,6 +102,8 @@ object ProtoPrefetcher {
         CrdtSetProto.Operation.Add.newBuilder()::build,
         CrdtSetProto.Operation.Remove::getDefaultInstance,
         CrdtSetProto.Operation.Remove.newBuilder()::build,
+        CrdtSetProto.Operation.Clear::getDefaultInstance,
+        CrdtSetProto.Operation.Clear.newBuilder()::build,
         CrdtSetProto.Operation.FastForward::getDefaultInstance,
         CrdtSetProto.Operation.FastForward.newBuilder()::build,
         CrdtSingletonProto::getDefaultInstance,

--- a/java/arcs/core/crdt/CrdtEntity.kt
+++ b/java/arcs/core/crdt/CrdtEntity.kt
@@ -182,12 +182,7 @@ class CrdtEntity(
                     it.applyOperation(CrdtSingleton.Operation.Clear(op.actor, versionMap))
                 }
                 _data.collections.values.forEach {
-                    collection ->
-                        collection.consumerView.forEach {
-                            collection.applyOperation(
-                                CrdtSet.Operation.Remove(op.actor, versionMap, it)
-                            )
-                        }
+                    it.applyOperation(CrdtSet.Operation.Clear(op.actor, versionMap))
                 }
                 _data.creationTimestamp = RawEntity.UNINITIALIZED_TIMESTAMP
                 _data.expirationTimestamp = RawEntity.UNINITIALIZED_TIMESTAMP

--- a/java/arcs/core/crdt/CrdtEntity.kt
+++ b/java/arcs/core/crdt/CrdtEntity.kt
@@ -213,7 +213,7 @@ class CrdtEntity(
     private fun ISetOp<Reference>.toEntityOp(fieldName: FieldName): Operation = when (this) {
         is SetOp.Add -> Operation.AddToSet(actor, clock, fieldName, added)
         is SetOp.Remove -> Operation.RemoveFromSet(actor, clock, fieldName, removed)
-        else -> throw CrdtException("Cannot convert FastForward to CrdtEntity Operation")
+        else -> throw CrdtException("Cannot convert FastForward or Clear to CrdtEntity Operation")
     }
 
     /** Defines the type of data managed by [CrdtEntity] for its singletons and collections. */

--- a/java/arcs/core/storage/ReferenceModeStore.kt
+++ b/java/arcs/core/storage/ReferenceModeStore.kt
@@ -250,27 +250,28 @@ class ReferenceModeStore private constructor(
 
         return@fn when (val proxyMessage = message.message) {
             is ProxyMessage.Operations -> {
-                proxyMessage.operations.toBridgingOps(backingStore.storageKey)
-                    .all { op ->
-                        if (op is BridgingOperation.ClearSingleton ||
-                            op is BridgingOperation.UpdateSingleton) {
+                proxyMessage.operations.toBridgingOps(backingStore.storageKey).all { op ->
+                    when (op) {
+                        is BridgingOperation.UpdateSingleton,
+                        is BridgingOperation.ClearSingleton -> {
                             // Free up the memory used by the previous instance (for a Singleton,
                             // there would be only one instance).
                             backingStore.clearStoresCache()
+                            op.entityValue?.let { updateBackingStore(it) }
                         }
-                        op.entityValue?.let {
-                            if (op is BridgingOperation.RemoveFromSet) {
-                                // If this is a removal, we clear the entity rather than updating it
-                                // to the given value.
-                                clearEntityInBackingStore(it)
-                            } else {
-                                updateBackingStore(it)
-                            }
-                        }
-                        containerStore.onProxyMessage(
-                            ProxyMessage.Operations(listOf(op.containerOp), proxyMessage.id)
-                        )
+
+                        is BridgingOperation.AddToSet ->
+                            op.entityValue?.let { updateBackingStore(it) }
+
+                        is BridgingOperation.RemoveFromSet ->
+                            op.entityValue?.let { clearEntityInBackingStore(it) }
+
+                        is BridgingOperation.ClearSet -> clearAllEntitiesInBackingStore()
                     }
+                    containerStore.onProxyMessage(
+                        ProxyMessage.Operations(listOf(op.containerOp), proxyMessage.id)
+                    )
+                }
             }
             is ProxyMessage.ModelUpdate -> {
                 val newModelsResult = proxyMessage.model.toBridgingData(
@@ -479,6 +480,18 @@ class ReferenceModeStore private constructor(
         return backingStore.onProxyMessage(ProxyMessage.Operations(op, id = null), referencable.id)
     }
 
+    /** Clear all entities from the backing store, using the container store to retrieve the ids. */
+    private suspend fun clearAllEntitiesInBackingStore(): Boolean {
+        val containerModel = containerStore.getLocalData()
+        if (containerModel !is CrdtSet.Data<*>) {
+            throw UnsupportedOperationException()
+        }
+        return containerModel.values.all { (refId, data) ->
+            val clearOp = listOf(CrdtEntity.Operation.ClearAll(crdtKey, data.versionMap))
+            backingStore.onProxyMessage(ProxyMessage.Operations(clearOp, id = null), refId)
+        }
+    }
+
     /**
      * Returns a function that can construct a [RefModeStoreData] object of a Container of Entities
      * based off the provided Container of References or a container of references from a provided
@@ -660,13 +673,13 @@ class ReferenceModeStore private constructor(
         val containerModel = containerStore.getLocalData()
         val actor = "ReferenceModeStore(${hashCode()})"
         val containerVersion = containerModel.versionMap.copy()
-        return if (containerModel is CrdtSet.Data<*>) {
-            containerModel.values.map { dataValue ->
-                CrdtSet.Operation.Remove(actor, containerVersion, dataValue.value.value)
-            }
-        } else if (containerModel is CrdtSingleton.Data<*>) {
-            listOf(CrdtSingleton.Operation.Clear<Reference>(actor, containerVersion))
-        } else throw UnsupportedOperationException()
+        return listOf(when (containerModel) {
+            is CrdtSet.Data<*> ->
+                CrdtSet.Operation.Clear<Reference>(actor, containerVersion)
+            is CrdtSingleton.Data<*> ->
+                CrdtSingleton.Operation.Clear<Reference>(actor, containerVersion)
+            else -> throw UnsupportedOperationException()
+        })
     }
 
     companion object {

--- a/java/arcs/core/storage/referencemode/BridgingOperation.kt
+++ b/java/arcs/core/storage/referencemode/BridgingOperation.kt
@@ -21,9 +21,9 @@ import arcs.core.data.RawEntity
 import arcs.core.storage.Reference
 import arcs.core.storage.StorageKey
 import arcs.core.storage.referencemode.BridgingOperation.AddToSet
+import arcs.core.storage.referencemode.BridgingOperation.ClearSet
 import arcs.core.storage.referencemode.BridgingOperation.ClearSingleton
 import arcs.core.storage.referencemode.BridgingOperation.RemoveFromSet
-import arcs.core.storage.referencemode.BridgingOperation.ClearSet
 import arcs.core.storage.referencemode.BridgingOperation.UpdateSingleton
 import arcs.core.storage.toReference
 

--- a/java/arcs/core/storage/referencemode/Message.kt
+++ b/java/arcs/core/storage/referencemode/Message.kt
@@ -135,6 +135,9 @@ private fun List<CrdtOperation>.toReferenceModeMessageOps(): List<CrdtOperationA
                 CrdtSet.Operation.Add(op.actor, op.clock, op.added)
             is CrdtSet.Operation.Remove<*> ->
                 CrdtSet.Operation.Remove(op.actor, op.clock, op.removed)
+            is CrdtSet.Operation.Clear<*> ->
+                // We have nothing from which to deduce T, so use Referencable.
+                CrdtSet.Operation.Clear<Referencable>(op.actor, op.clock)
             else -> throw CrdtException("Unsupported operation for ReferenceModeStore: $this")
         }
     }

--- a/java/arcs/core/storage/referencemode/Message.kt
+++ b/java/arcs/core/storage/referencemode/Message.kt
@@ -136,7 +136,6 @@ private fun List<CrdtOperation>.toReferenceModeMessageOps(): List<CrdtOperationA
             is CrdtSet.Operation.Remove<*> ->
                 CrdtSet.Operation.Remove(op.actor, op.clock, op.removed)
             is CrdtSet.Operation.Clear<*> ->
-                // We have nothing from which to deduce T, so use Referencable.
                 CrdtSet.Operation.Clear<Referencable>(op.actor, op.clock)
             else -> throw CrdtException("Unsupported operation for ReferenceModeStore: $this")
         }

--- a/java/arcs/core/storage/referencemode/RefModeCrdtTypes.kt
+++ b/java/arcs/core/storage/referencemode/RefModeCrdtTypes.kt
@@ -115,6 +115,13 @@ interface RefModeStoreOp : CrdtOperationAtTime {
         CrdtSet.Operation.Remove<RawEntity>(actor, clock, removed) {
         constructor(setOp: Remove<RawEntity>) : this(setOp.actor, setOp.clock, setOp.removed)
     }
+
+    class SetClear(actor: Actor, clock: VersionMap) :
+        Set,
+        RefModeSet,
+        CrdtSet.Operation.Clear<RawEntity>(actor, clock) {
+        constructor(setOp: Clear<RawEntity>) : this(setOp.actor, setOp.clock)
+    }
 }
 
 /** Consumer data value of the [arcs.core.storage.ReferenceModeStore]. */
@@ -251,6 +258,8 @@ private fun CrdtOperation.toRefModeStoreSetOp(): RefModeStoreOp =
             RefModeStoreOp.SetAdd(this as CrdtSet.Operation.Add<RawEntity>)
         is CrdtSet.Operation.Remove<*> ->
             RefModeStoreOp.SetRemove(this as CrdtSet.Operation.Remove<RawEntity>)
+        is CrdtSet.Operation.Clear<*> ->
+            RefModeStoreOp.SetClear(this as CrdtSet.Operation.Clear<RawEntity>)
         is CrdtSet.Operation.FastForward<*> ->
             throw IllegalArgumentException(
                 "ReferenceModeStore does not support FastForward"

--- a/javatests/arcs/android/crdt/CrdtSetProtoTest.kt
+++ b/javatests/arcs/android/crdt/CrdtSetProtoTest.kt
@@ -100,6 +100,23 @@ class CrdtSetProtoTest {
     }
 
     @Test
+    fun operationClear_parcelableRoundTrip_works() {
+        val op = CrdtSet.Operation.Clear<Referencable>("alice", versionMap)
+
+        val marshalled = with(Parcel.obtain()) {
+            writeOperation(op)
+            marshall()
+        }
+        val unmarshalled = with(Parcel.obtain()) {
+            unmarshall(marshalled, 0, marshalled.size)
+            setDataPosition(0)
+            readOperation()
+        }
+
+        assertThat(unmarshalled).isEqualTo(op)
+    }
+
+    @Test
     fun operationFastForward_parcelableRoundTrip_works() {
         val oldClock = VersionMap("alice" to 1)
         val newClock = VersionMap("alice" to 1, "bob" to 1)

--- a/javatests/arcs/core/crdt/CrdtEntityTest.kt
+++ b/javatests/arcs/core/crdt/CrdtEntityTest.kt
@@ -193,8 +193,8 @@ class CrdtEntityTest {
                 id = "an-id",
                 singletonFields = setOf("foo"),
                 collectionFields = setOf("bar", "baz"),
-                creationTimestamp = -1L,
-                expirationTimestamp = -1L
+                creationTimestamp = RawEntity.UNINITIALIZED_TIMESTAMP,
+                expirationTimestamp = RawEntity.UNINITIALIZED_TIMESTAMP
             )
         )
     }

--- a/javatests/arcs/core/crdt/CrdtEntityTest.kt
+++ b/javatests/arcs/core/crdt/CrdtEntityTest.kt
@@ -12,6 +12,7 @@
 package arcs.core.crdt
 
 import arcs.core.crdt.CrdtEntity.Operation.AddToSet
+import arcs.core.crdt.CrdtEntity.Operation.ClearAll
 import arcs.core.crdt.CrdtEntity.Operation.ClearSingleton
 import arcs.core.crdt.CrdtEntity.Operation.RemoveFromSet
 import arcs.core.crdt.CrdtEntity.Operation.SetSingleton
@@ -170,6 +171,32 @@ class CrdtEntityTest {
                     )
                 )
             )
+    }
+
+    @Test
+    fun clearAll() {
+        val rawEntity = RawEntity(
+            id = "an-id",
+            singletons = mapOf("foo" to Reference("fooRef")),
+            collections = mapOf(
+                "bar" to setOf(Reference("barRef1"), Reference("barRef2")),
+                "baz" to setOf(Reference("bazRef"))
+            ),
+            creationTimestamp = 10L,
+            expirationTimestamp = 20L
+        )
+        val entity = CrdtEntity(VersionMap(), rawEntity)
+
+        assertThat(entity.applyOperation(ClearAll("me", VersionMap()))).isTrue()
+        assertThat(entity.consumerView).isEqualTo(
+            RawEntity(
+                id = "an-id",
+                singletonFields = setOf("foo"),
+                collectionFields = setOf("bar", "baz"),
+                creationTimestamp = -1L,
+                expirationTimestamp = -1L
+            )
+        )
     }
 
     @Test

--- a/javatests/arcs/core/crdt/CrdtSetTest.kt
+++ b/javatests/arcs/core/crdt/CrdtSetTest.kt
@@ -147,6 +147,68 @@ class CrdtSetTest {
     }
 
     @Test
+    fun clear_matchingVersionMap() {
+        alice.add("alice", VersionMap("alice" to 1), "one")
+        alice.add("bob", VersionMap("bob" to 1), "two")
+        alice.add("bob", VersionMap("bob" to 2), "one")
+        alice.add("charlie", VersionMap("charlie" to 1), "three")
+
+        // Non-actor counts can be larger the store's clock, but the actor's count must match.
+        assertThat(alice.versionMap).isEqualTo(VersionMap("alice" to 1, "bob" to 2, "charlie" to 1))
+        assertThat(
+            alice.applyOperation(
+                Clear("charlie", VersionMap("alice" to 2, "bob" to 2, "charlie" to 1))
+            )
+        ).isTrue()
+        assertThat(alice.consumerView).isEmpty()
+    }
+
+    @Test
+    fun clear_laggingVersionMap() {
+        alice.add("alice", VersionMap("alice" to 1), "one")
+        alice.add("bob", VersionMap("bob" to 1), "two")
+        alice.add("bob", VersionMap("bob" to 2), "three")
+        alice.add("charlie", VersionMap("charlie" to 1), "four")
+
+        // Charlie's view of Bob's clock is behind Alice's, so one of Bob's entries isn't removed.
+        assertThat(alice.versionMap).isEqualTo(VersionMap("alice" to 1, "bob" to 2, "charlie" to 1))
+        assertThat(
+            alice.applyOperation(
+                Clear("charlie", VersionMap("alice" to 1, "bob" to 1, "charlie" to 1))
+            )
+        ).isTrue()
+        assertThat(alice.consumerView).containsExactly(Reference("three"))
+    }
+
+    @Test
+    fun clear_noVersionMap() {
+        alice.add("alice", VersionMap("alice" to 1), "one")
+        alice.add("bob", VersionMap("bob" to 1), "two")
+        alice.add("bob", VersionMap("bob" to 2), "one")
+        alice.add("charlie", VersionMap("charlie" to 1), "three")
+
+        assertThat(alice.applyOperation(Clear("charlie", VersionMap()))).isTrue()
+        assertThat(alice.consumerView).isEmpty()
+    }
+
+    @Test
+    fun clear_invalidVersionMap() {
+        alice.add("alice", VersionMap("alice" to 1), "one")
+        alice.add("charlie", VersionMap("charlie" to 1), "two")
+        alice.add("charlie", VersionMap("charlie" to 2), "three")
+
+        // Charlie's count must match for any items to be removed.
+        assertThat(alice.versionMap).isEqualTo(VersionMap("alice" to 1, "charlie" to 2))
+        assertThat(
+            alice.applyOperation(
+                Clear("charlie", VersionMap("alice" to 1, "charlie" to 1))
+            )
+        ).isFalse()
+        assertThat(alice.consumerView)
+            .containsExactly(Reference("one"), Reference("two"), Reference("three"))
+    }
+
+    @Test
     fun merge_canMergeTwoModels() {
         listOf(
             Add("charlie", VersionMap("charlie" to 1), "kept by both"),
@@ -649,6 +711,10 @@ class CrdtSetTest {
     /** Pseudo-constructor for [CrdtSet.Operation.Remove]. */
     private fun Remove(actor: Actor, versions: VersionMap, id: ReferenceId) =
         CrdtSet.Operation.Remove(actor, versions, Reference(id))
+
+    /** Pseudo-constructor for [CrdtSet.Operation.Remove]. */
+    private fun Clear(actor: Actor, versions: VersionMap) =
+        CrdtSet.Operation.Clear<Reference>(actor, versions)
 
     private fun CrdtSet<Reference>.add(
         actor: Actor,

--- a/javatests/arcs/core/entity/HandleManagerTestBase.kt
+++ b/javatests/arcs/core/entity/HandleManagerTestBase.kt
@@ -48,7 +48,9 @@ import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.withTimeoutOrNull
 import org.junit.Rule
@@ -163,106 +165,120 @@ open class HandleManagerTestBase {
     }
 
     @Test
-    fun singleton_initialState() = testRunner {
-        val handle = readHandleManager.createSingletonHandle()
-        assertThat(handle.dispatchFetch()).isNull()
+    fun singleton_initialStateAndSingleHandleOperations() = testRunner {
+        val handle = writeHandleManager.createSingletonHandle()
 
-        // Verify that clear works on an empty singleton (including the join op).
-        handle.dispatchClear()
+        // Don't use the dispatchX helpers so we can test the immediate effect of the handle ops.
+        withContext(handle.dispatcher) {
+            // Initial state.
+            assertThat(handle.fetch()).isNull()
+
+            // Verify that clear works on an empty singleton.
+            val jobs = mutableListOf<Job>()
+            jobs.add(handle.clear())
+            assertThat(handle.fetch()).isNull()
+
+            // All handle ops should be locally immediate (no joins needed).
+            jobs.add(handle.store(entity1))
+            assertThat(handle.fetch()).isEqualTo(entity1)
+            jobs.add(handle.clear())
+            assertThat(handle.fetch()).isNull()
+
+            // The joins should still work.
+            jobs.joinAll()
+        }
     }
 
     @Test
-    fun singleton_writeAndReadBackAndClear() = testRunner {
-        val writeHandle = writeHandleManager.createSingletonHandle()
-        val readHandle = readHandleManager.createSingletonHandle()
+    fun singleton_writeAndReadBack_unidirectional() = testRunner {
+        // Write-only handle -> read-only handle
+        val writeHandle = writeHandleManager.createHandle(
+            HandleSpec(
+                "writeOnlySingleton",
+                HandleMode.Write,
+                SingletonType(EntityType(Person.SCHEMA)),
+                Person
+            ),
+            singletonKey
+        ).awaitReady() as WriteSingletonHandle<Person>
 
-        var readHandleUpdated = readHandle.onUpdateDeferred()
+        val readHandle = readHandleManager.createHandle(
+            HandleSpec(
+                "readOnlySingleton",
+                HandleMode.Read,
+                SingletonType(EntityType(Person.SCHEMA)),
+                Person
+            ),
+            singletonKey
+        ).awaitReady() as ReadSingletonHandle<Person>
+
+        var received = CompletableDeferred<Person?>()
+        readHandle.onUpdate { received.complete(it) }
+
+        // Verify store against empty.
         writeHandle.dispatchStore(entity1)
+        assertThat(received.await()).isEqualTo(entity1)
+        assertThat(readHandle.dispatchFetch()).isEqualTo(entity1)
 
-        // Now read back from a different handle
-        readHandleUpdated.await()
-        val readBack = readHandle.dispatchFetch()
-        assertThat(readBack).isEqualTo(entity1)
-
-        readHandleUpdated = readHandle.onUpdateDeferred()
+        // Verify store overwrites existing.
+        received = CompletableDeferred()
         writeHandle.dispatchStore(entity2)
-        readHandleUpdated.await()
-        val readBack2 = readHandle.dispatchFetch()
-        assertThat(readBack2).isEqualTo(entity2)
+        assertThat(received.await()).isEqualTo(entity2)
+        assertThat(readHandle.dispatchFetch()).isEqualTo(entity2)
 
-        readHandleUpdated = readHandle.onUpdateDeferred()
+        // Verify clear.
+        received = CompletableDeferred()
         writeHandle.dispatchClear()
-        readHandleUpdated.await()
-        val readBack3 = readHandle.dispatchFetch()
-        assertThat(readBack3).isNull()
+        assertThat(received.await()).isNull()
+        assertThat(readHandle.dispatchFetch()).isNull()
     }
 
     @Test
-    fun singleton_writeAndReadBack() = testRunner {
-        val writeHandle = writeHandleManager.createSingletonHandle()
-        val readHandle = readHandleManager.createSingletonHandle()
-        val readHandleUpdated = readHandle.onUpdateDeferred()
-        writeHandle.dispatchStore(entity1)
+    fun singleton_writeAndReadBack_bidirectional() = testRunner {
+        // Read/write handle <-> read/write handle
+        val handle1 = writeHandleManager.createHandle(
+            HandleSpec(
+                "readWriteSingleton1",
+                HandleMode.ReadWrite,
+                SingletonType(EntityType(Person.SCHEMA)),
+                Person
+            ),
+            singletonKey
+        ).awaitReady() as ReadWriteSingletonHandle<Person>
 
-        // Now read back from a different handle
-        readHandleUpdated.await()
-        val readBack = readHandle.dispatchFetch()
-        assertThat(readBack).isEqualTo(entity1)
-    }
+        val handle2 = readHandleManager.createHandle(
+            HandleSpec(
+                "readWriteSingleton2",
+                HandleMode.ReadWrite,
+                SingletonType(EntityType(Person.SCHEMA)),
+                Person
+            ),
+            singletonKey
+        ).awaitReady() as ReadWriteSingletonHandle<Person>
 
-    @Test
-    fun singleton_clearOnAClearDataWrittenByA() = testRunner {
-        val handleA = writeHandleManager.createSingletonHandle()
-        val handleB = readHandleManager.createSingletonHandle()
+        // handle1 -> handle2
+        val received1to2 = CompletableDeferred<Person?>()
+        handle2.onUpdate { received1to2.complete(it) }
 
-        var handleBUpdated = handleB.onUpdateDeferred()
-        handleA.dispatchStore(entity1)
-        handleBUpdated.await()
+        // Verify that handle2 sees the entity stored by handle1.
+        handle1.dispatchStore(entity1)
+        assertThat(received1to2.await()).isEqualTo(entity1)
+        assertThat(handle2.dispatchFetch()).isEqualTo(entity1)
 
-        // Now read back from a different handle
-        assertThat(handleB.dispatchFetch()).isEqualTo(entity1)
+        // handle2 -> handle1
+        var received2to1 = CompletableDeferred<Person?>()
+        handle1.onUpdate { received2to1.complete(it) }
 
-        handleBUpdated = handleB.onUpdateDeferred {
-            log("handleB updated: $it")
-            it == null
-        }
-        handleA.dispatchClear()
-        handleBUpdated.await()
+        // Verify that handle2 can clear the entity stored by handle1.
+        handle2.dispatchClear()
+        assertThat(received2to1.await()).isNull()
+        assertThat(handle1.dispatchFetch()).isNull()
 
-        assertThat(handleB.dispatchFetch()).isNull()
-    }
-
-    @Test
-    fun singleton_clearOnAClearDataWrittenByB() = testRunner {
-        val handleA = writeHandleManager.createSingletonHandle()
-        val handleB = readHandleManager.createSingletonHandle()
-        val handleBUpdated = handleB.onUpdateDeferred { it != null }
-        handleA.dispatchStore(entity1)
-        handleBUpdated.await()
-
-        // Now read back from a different handle
-        val updateADeferred = handleA.onUpdateDeferred { it == null }
-        handleB.dispatchClear()
-        assertThat(handleB.dispatchFetch()).isNull()
-
-        updateADeferred.await()
-        assertThat(handleA.dispatchFetch()).isNull()
-    }
-
-    @Test
-    fun singleton_writeAndOnUpdate() = testRunner {
-        val writeHandle = writeHandleManager.createSingletonHandle()
-            as WriteSingletonHandle<Person>
-
-        // Now read back from a different handle
-        val readHandle = readHandleManager.createSingletonHandle()
-
-        val updateDeferred = CompletableDeferred<Person?>()
-        readHandle.onUpdate {
-            updateDeferred.complete(it)
-        }
-        writeHandle.dispatchStore(entity1)
-        assertThat(updateDeferred.await()).isEqualTo(entity1)
+        // Verify that handle1 sees the entity stored by handle2.
+        received2to1 = CompletableDeferred()
+        handle2.dispatchStore(entity2)
+        assertThat(received2to1.await()).isEqualTo(entity2)
+        assertThat(handle1.dispatchFetch()).isEqualTo(entity2)
     }
 
     @Test
@@ -489,67 +505,155 @@ open class HandleManagerTestBase {
     }
 
     @Test
-    fun collection_initialState() = testRunner {
+    fun collection_initialStateAndSingleHandleOperations() = testRunner {
         val handle = writeHandleManager.createCollectionHandle()
-        assertThat(handle.dispatchSize()).isEqualTo(0)
-        assertThat(handle.dispatchIsEmpty()).isEqualTo(true)
-        assertThat(handle.dispatchFetchAll()).isEmpty()
 
-        // Verify that clear works on an empty collection (including the join op),
-        // and that removing any entity is also safe.
-        handle.dispatchClear()
-        handle.dispatchRemove(entity1)
-    }
+        // Don't use the dispatchX helpers so we can test the immediate effect of the handle ops.
+        withContext(handle.dispatcher) {
+            // Initial state.
+            assertThat(handle.size()).isEqualTo(0)
+            assertThat(handle.isEmpty()).isEqualTo(true)
+            assertThat(handle.fetchAll()).isEmpty()
 
-    @Test
-    fun collection_addingToA_showsUpInB() = testRunner {
-        val handleA = writeHandleManager.createCollectionHandle()
-            as ReadWriteCollectionHandle<Person>
-        val handleB = readHandleManager.createCollectionHandle()
-        var gotUpdate = handleB.onUpdateDeferred()
-        handleA.dispatchStore(entity1)
-        assertThat(handleA.dispatchFetchAll()).containsExactly(entity1)
-        gotUpdate.await()
-        assertThat(handleB.dispatchFetchAll()).containsExactly(entity1)
+            // Verify that both clear and removing a random entity with an empty collection are ok.
+            val jobs = mutableListOf<Job>()
+            jobs.add(handle.clear())
+            jobs.add(handle.remove(entity1))
 
-        // Ensure we get update from A before checking.
-        // Since some test configurations may result in the handles
-        // operating on different threads.
-        gotUpdate = handleA.onUpdateDeferred()
-        handleB.dispatchStore(entity2)
-        assertThat(handleB.dispatchFetchAll()).containsExactly(entity1, entity2)
-        gotUpdate.await()
-        assertThat(handleA.dispatchFetchAll()).containsExactly(entity1, entity2)
-    }
+            // All handle ops should be locally immediate (no joins needed).
+            jobs.add(handle.store(entity1))
+            jobs.add(handle.store(entity2))
+            assertThat(handle.size()).isEqualTo(2)
+            assertThat(handle.isEmpty()).isEqualTo(false)
+            assertThat(handle.fetchAll()).containsExactly(entity1, entity2)
 
-    @Test
-    fun collection_writeAndReadBack() = testRunner {
-        val writeHandle = writeHandleManager.createCollectionHandle()
-        val readHandle = readHandleManager.createCollectionHandle()
-        val allHeard = Job()
-        readHandle.onUpdate {
-            if (it.size == 2) allHeard.complete()
+            jobs.add(handle.remove(entity1))
+            assertThat(handle.size()).isEqualTo(1)
+            assertThat(handle.isEmpty()).isEqualTo(false)
+            assertThat(handle.fetchAll()).containsExactly(entity2)
+
+            jobs.add(handle.clear())
+            assertThat(handle.size()).isEqualTo(0)
+            assertThat(handle.isEmpty()).isEqualTo(true)
+            assertThat(handle.fetchAll()).isEmpty()
+
+            // The joins should still work.
+            jobs.joinAll()
         }
-        writeHandle.dispatchStore(entity1, entity2)
-
-        // Now read back from a different handle, after hearing the updates.
-        allHeard.join()
-        val readBack = readHandle.dispatchFetchAll()
-        assertThat(readBack).containsExactly(entity1, entity2)
     }
 
     @Test
-    fun collection_writeAndOnUpdate() = testRunner {
-        val writeHandle = writeHandleManager.createCollectionHandle()
-            as WriteCollectionHandle<Person>
+    fun collection_writeAndReadBack_unidirectional() = testRunner {
+        // Write-only handle -> read-only handle
+        val writeHandle = writeHandleManager.createHandle(
+            HandleSpec(
+                "writeOnlyCollection",
+                HandleMode.Write,
+                CollectionType(EntityType(Person.SCHEMA)),
+                Person
+            ),
+            collectionKey
+        ).awaitReady() as WriteCollectionHandle<Person>
 
-        // Now read back from a different handle
-        val readHandle = readHandleManager.createCollectionHandle()
-            as ReadWriteCollectionHandle<Person>
+        val readHandle = readHandleManager.createHandle(
+            HandleSpec(
+                "readOnlyCollection",
+                HandleMode.Read,
+                CollectionType(EntityType(Person.SCHEMA)),
+                Person
+            ),
+            collectionKey
+        ).awaitReady() as ReadCollectionHandle<Person>
 
-        val updateDeferred = readHandle.onUpdateDeferred { it.size == 2 }
-        writeHandle.dispatchStore(entity1, entity2)
-        assertThat(updateDeferred.await()).containsExactly(entity1, entity2)
+        val entity3 = Person("entity3", "Wanda", 60.0, true)
+
+        var received = Job()
+        var size = 3
+        readHandle.onUpdate { if (it.size == size) received.complete() }
+
+        // Verify store.
+        writeHandle.dispatchStore(entity1, entity2, entity3)
+        received.join()
+        assertThat(readHandle.dispatchSize()).isEqualTo(3)
+        assertThat(readHandle.dispatchIsEmpty()).isEqualTo(false)
+        assertThat(readHandle.dispatchFetchAll()).containsExactly(entity1, entity2, entity3)
+
+        // Verify remove.
+        received = Job()
+        size = 2
+        writeHandle.dispatchRemove(entity2)
+        received.join()
+        assertThat(readHandle.dispatchSize()).isEqualTo(2)
+        assertThat(readHandle.dispatchIsEmpty()).isEqualTo(false)
+        assertThat(readHandle.dispatchFetchAll()).containsExactly(entity1, entity3)
+
+        // Verify clear.
+        received = Job()
+        size = 0
+        writeHandle.dispatchClear()
+        received.join()
+        assertThat(readHandle.dispatchSize()).isEqualTo(0)
+        assertThat(readHandle.dispatchIsEmpty()).isEqualTo(true)
+        assertThat(readHandle.dispatchFetchAll()).isEmpty()
+    }
+
+    @Test
+    fun collection_writeAndReadBack_bidirectional() = testRunner {
+        // Read/write handle <-> read/write handle
+        val handle1 = writeHandleManager.createHandle(
+            HandleSpec(
+                "readWriteCollection1",
+                HandleMode.ReadWrite,
+                CollectionType(EntityType(Person.SCHEMA)),
+                Person
+            ),
+            collectionKey
+        ).awaitReady() as ReadWriteCollectionHandle<Person>
+
+        val handle2 = readHandleManager.createHandle(
+            HandleSpec(
+                "readWriteCollection2",
+                HandleMode.ReadWrite,
+                CollectionType(EntityType(Person.SCHEMA)),
+                Person
+            ),
+            collectionKey
+        ).awaitReady() as ReadWriteCollectionHandle<Person>
+
+        val entity3 = Person("entity3", "William", 35.0, false)
+
+        // handle1 -> handle2
+        val received1to2 = CompletableDeferred<Set<Person>>()
+        handle2.onUpdate { if (it.size == 3) received1to2.complete(it) }
+
+        // Verify that handle2 sees entities stored by handle1.
+
+        handle1.dispatchStore(entity1, entity2, entity3)
+        assertThat(received1to2.await()).containsExactly(entity1, entity2, entity3)
+        assertThat(handle2.dispatchSize()).isEqualTo(3)
+        assertThat(handle2.dispatchIsEmpty()).isEqualTo(false)
+        assertThat(handle2.dispatchFetchAll()).containsExactly(entity1, entity2, entity3)
+
+        // handle2 -> handle1
+        var received2to1 = CompletableDeferred<Set<Person>>()
+        var size2to1 = 2
+        handle1.onUpdate { if (it.size == size2to1) received2to1.complete(it) }
+
+        // Verify that handle2 can remove entities stored by handle1.
+        handle2.dispatchRemove(entity2)
+        assertThat(received2to1.await()).containsExactly(entity1, entity3)
+        assertThat(handle1.dispatchSize()).isEqualTo(2)
+        assertThat(handle1.dispatchIsEmpty()).isEqualTo(false)
+        assertThat(handle1.dispatchFetchAll()).containsExactly(entity1, entity3)
+
+        // Verify that handle1 sees an empty collection after a clear op from handle2.
+        received2to1 = CompletableDeferred()
+        size2to1 = 0
+        handle2.dispatchClear()
+        assertThat(received2to1.await()).isEmpty()
+        assertThat(handle1.dispatchSize()).isEqualTo(0)
+        assertThat(handle1.dispatchIsEmpty()).isEqualTo(true)
+        assertThat(handle1.dispatchFetchAll()).isEmpty()
     }
 
     @Test
@@ -627,69 +731,6 @@ open class HandleManagerTestBase {
 
         assertThat(handle.dispatchFetchAll()).containsExactly(entity, entity2)
         assertThat(entity2.creationTimestamp).isEqualTo(20)
-    }
-
-    @Test
-    fun collection_removingFromA_isRemovedFromB() = testRunner {
-        val handleA = readHandleManager.createCollectionHandle()
-        val handleB = writeHandleManager.createCollectionHandle()
-
-        log("Handles ready")
-
-        val gotUpdateAtA = handleA.onUpdateDeferred {
-            log("Size of A: ${it.size}")
-            it.size == 2
-        }
-        log("storing in B")
-        handleB.dispatchStore(entity1, entity2)
-        assertThat(handleB.dispatchFetchAll()).containsExactly(entity1, entity2)
-
-        gotUpdateAtA.await()
-        log("checking a")
-        assertThat(handleA.dispatchFetchAll()).containsExactly(entity1, entity2)
-
-        val gotUpdateAtB = handleB.onUpdateDeferred {
-            log("B size later = ${it.size}")
-            it.size == 1
-        }
-        log("removing")
-        handleA.dispatchRemove(entity1)
-        assertThat(handleA.dispatchFetchAll()).containsExactly(entity2)
-
-        gotUpdateAtB.await()
-        log("checking after removal")
-        assertThat(handleB.dispatchFetchAll()).containsExactly(entity2)
-    }
-
-    @Test
-    fun collection_clearingElementsFromA_clearsThemFromB() = testRunner {
-        val handleA = readHandleManager.createCollectionHandle()
-        val handleB = writeHandleManager.createCollectionHandle()
-
-        val handleBGotAll7 = handleB.onUpdateDeferred { it.size == 7 }
-        handleA.dispatchStore(
-            Person("a", "a", 1.0, true),
-            Person("b", "b", 2.0, false),
-            Person("c", "c", 3.0, true),
-            Person("d", "d", 4.0, false, favoriteWords = listOf("uncool")),
-            Person("e", "e", 5.0, true, favoriteWords = listOf("waycool")),
-            Person("f", "f", 6.0, false, favoriteWords = listOf("salami", "wurst")),
-            Person("g", "g", 7.0, true)
-        )
-        assertThat(handleA.dispatchFetchAll()).hasSize(7)
-
-        handleBGotAll7.await()
-        assertThat(handleB.dispatchFetchAll()).hasSize(7)
-
-        // Ensure we get update from A before checking.
-        // Since some test configurations may result in the handles
-        // operating on different threads.
-        val gotUpdate = handleA.onUpdateDeferred { it.isEmpty() }
-        handleB.dispatchClear()
-        assertThat(handleB.dispatchFetchAll()).isEmpty()
-        gotUpdate.await()
-
-        assertThat(handleA.dispatchFetchAll()).isEmpty()
     }
 
     @Test

--- a/javatests/arcs/core/entity/HandleManagerTestBase.kt
+++ b/javatests/arcs/core/entity/HandleManagerTestBase.kt
@@ -627,7 +627,6 @@ open class HandleManagerTestBase {
         handle2.onUpdate { if (it.size == 3) received1to2.complete(it) }
 
         // Verify that handle2 sees entities stored by handle1.
-
         handle1.dispatchStore(entity1, entity2, entity3)
         assertThat(received1to2.await()).containsExactly(entity1, entity2, entity3)
         assertThat(handle2.dispatchSize()).isEqualTo(3)


### PR DESCRIPTION
This allows collection.clear() to execute without needing to read the current contents of the collection, which in turn will allow write-only handles to avoid syncing any data.