### PR TITLE
idle() on its own scope in BindingContext().

### DIFF
--- a/java/arcs/android/storage/service/BindingContext.kt
+++ b/java/arcs/android/storage/service/BindingContext.kt
@@ -27,7 +27,6 @@ import kotlin.coroutines.CoroutineContext
 import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
@@ -63,7 +62,7 @@ class BindingContext(
 
     override fun idle(timeoutMillis: Long, resultCallback: IResultCallback) {
         bindingContextStatisticsSink.traceTransaction("idle") {
-            bindingContextStatisticsSink.measure(coroutineContext + Dispatchers.IO) {
+            bindingContextStatisticsSink.measure(coroutineContext) {
                 val activeStore = store.activate()
                 try {
                     withTimeout(timeoutMillis) {


### PR DESCRIPTION
Seems this should be good enough unless we want to pass in another CoroutineContext which is just used for idle().