### PR TITLE
Generate Handles for the Plan.kt

### DIFF
--- a/java/arcs/core/data/Plan.kt
+++ b/java/arcs/core/data/Plan.kt
@@ -20,9 +20,10 @@ import arcs.core.util.lens
  * A [Plan] is usually produced by running the build time Particle Accelerator tool, it consists
  * of a set of specs for handles, particles used in a recipe, and mappings between them.
  */
-open class Plan(
+data class Plan(
     // TODO(cromwellian): add more fields as needed (e.g. RecipeName, etc for debugging)
     val particles: List<Particle>,
+    val handles: List<Handle> = emptyList(),
     val annotations: List<Annotation> = emptyList()
 ) {
     val arcId: String?
@@ -48,6 +49,13 @@ open class Plan(
             val handlesLens = lens(Particle::handles) { t, f -> t.copy(handles = f) }
         }
     }
+
+    /** A [Handle] representation for the [Plan]. */
+    data class Handle(
+        val storageKey: StorageKey,
+        val type: Type,
+        val annotations: List<Annotation>
+    )
 
     /** Represents the expression to be evaluated to produce a new field. */
     data class AdapterField<T>(
@@ -105,18 +113,9 @@ open class Plan(
         }
     }
 
-    // Because Plan is not a data class to allow sub-classing, these are required.
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-
-        return (other as? Plan)?.particles == particles
-    }
-
-    override fun hashCode(): Int = particles.hashCode()
-
     companion object {
         val particleLens = lens(Plan::particles) { t, f ->
-            Plan(particles = f, annotations = t.annotations)
+            Plan(particles = f, handles = t.handles, annotations = t.annotations)
         }
     }
 }

--- a/java/arcs/core/data/Recipe.kt
+++ b/java/arcs/core/data/Recipe.kt
@@ -58,6 +58,14 @@ data class Recipe(
 /** Translates a [Recipe] into a [Plan] */
 fun Recipe.toPlan() = Plan(
     particles = particles.map { it.toPlanParticle() },
+    handles = handles.values.map { it.toPlanHandle() },
+    annotations = annotations
+)
+
+/** Translates a [Recipe.Handle] into a [Plan.Handle] */
+fun Recipe.Handle.toPlanHandle() = Plan.Handle(
+    type = type,
+    storageKey = StorageKeyParser.parse(requireNotNull(storageKey)),
     annotations = annotations
 )
 

--- a/javatests/arcs/core/allocator/AllocatorTestBase.kt
+++ b/javatests/arcs/core/allocator/AllocatorTestBase.kt
@@ -444,6 +444,7 @@ open class AllocatorTestBase {
         val arc2 = allocator.startArcForPlan(
             Plan(
                 PersonPlan.particles,
+                PersonPlan.handles,
                 listOf(Annotation.createArcId(arcId.toString()))
             )
         )
@@ -523,6 +524,7 @@ open class AllocatorTestBase {
         val arc2 = allocator.startArcForPlan(
             Plan(
                 PersonPlan.particles,
+                PersonPlan.handles,
                 listOf(Annotation.createArcId(arc.id.toString()))
             )
         )

--- a/javatests/arcs/core/data/RecipeTest.kt
+++ b/javatests/arcs/core/data/RecipeTest.kt
@@ -142,6 +142,26 @@ class RecipeTest {
         )
     }
 
+
+    @Test
+    fun handleToPlanHandle() {
+        val storageKey = "reference-mode://{db://abcd@arcs/Person}{db://abcd@arcs//handle/people}"
+        assertThat(
+            Recipe.Handle(
+                name = "people",
+                fate = Fate.MAP,
+                type = personCollectionType,
+                storageKey = storageKey
+            ).toPlanHandle()
+        ).isEqualTo(
+            Plan.Handle(
+                storageKey = StorageKeyParser.parse(storageKey),
+                type = personCollectionType,
+                annotations = emptyList()
+            )
+        )
+    }
+
     @Test
     fun recipeToPlan_empty() {
         assertThat(
@@ -194,7 +214,6 @@ class RecipeTest {
     fun recipeToPlan_fullExample() {
 
         val peopleStorageKey = "reference-mode://{db://abcd@arcs/Person}{db://abcd@arcs//handle/people}"
-
         val peopleHandle = Recipe.Handle(
             name = "people",
             fate = Fate.MAP,
@@ -202,10 +221,12 @@ class RecipeTest {
             storageKey = peopleStorageKey
         )
 
+        val contactsStorageKey = "create://contacts"
         val contactsHandle = Recipe.Handle(
             name = "contacts",
             fate = Fate.CREATE,
-            type = contactCollectionType
+            type = contactCollectionType,
+            storageKey = contactsStorageKey
         )
 
         val convertToContactsSpec = ParticleSpec(
@@ -287,6 +308,18 @@ class RecipeTest {
                                 type = contactCollectionType
                             )
                         )
+                    )
+                ),
+                handles = listOf(
+                    Plan.Handle(
+                        storageKey = StorageKeyParser.parse(peopleStorageKey),
+                        type = personCollectionType,
+                        annotations = emptyList()
+                    ),
+                    Plan.Handle(
+                        storageKey = CreatableStorageKey("contacts"),
+                        type = contactCollectionType,
+                        annotations = emptyList()
                     )
                 ),
                 annotations = listOf(Annotation.createArcId("egress-contacts"))

--- a/src/tools/kotlin-codegen-shared.ts
+++ b/src/tools/kotlin-codegen-shared.ts
@@ -9,15 +9,8 @@
  */
 
 import {KotlinGenerationUtils} from './kotlin-generation-utils.js';
-import {SchemaGraph, SchemaNode} from './schema2graph.js';
-import {HandleConnectionSpec} from '../runtime/particle-spec.js';
-import {Type, TypeVariable} from '../runtime/type.js';
-import {HandleConnection} from '../runtime/recipe/handle-connection.js';
 import {assert} from '../platform/assert-web.js';
 import {Dictionary} from '../runtime/hot.js';
-import {Schema} from '../runtime/schema.js';
-
-const ktUtils = new KotlinGenerationUtils();
 
 // Includes reserve words for Entity Interface
 // https://kotlinlang.org/docs/reference/keyword-reference.html
@@ -36,47 +29,6 @@ export function escapeIdentifier(name: string): string {
   // TODO(cypher1): Check for complex keywords (e.g. cases where both 'final' and 'final_' are keywords).
   // TODO(cypher1): Check for name overlaps (e.g. 'final' and 'final_' should not be escaped to the same identifier.
   return name + (keywords.includes(name) ? '_' : '');
-}
-
-/**
- * Generates a Kotlin type instance for the given handle connection.
- */
-export function generateConnectionType(connection: HandleConnection,
-                                       schemaRegistry: {schema: Schema, generation: string}[] = []): string {
-  return generateConnectionSpecType(connection.spec, new SchemaGraph(connection.particle.spec).nodes, schemaRegistry);
-}
-
-export function generateConnectionSpecType(
-  connection: HandleConnectionSpec,
-  nodes: SchemaNode[],
-  schemaRegistry: {schema: Schema, generation: string}[] = []): string {
-  let type = connection.type;
-  if (type.isEntity || type.isReference) {
-    // Moving to the new style types with explicit singleton.
-    type = type.singletonOf();
-  }
-
-  return (function generateType(type: Type): string {
-    if (type.isEntity) {
-      const node = nodes.find(n => n.schema.equals(type.getEntitySchema()));
-      return ktUtils.applyFun('EntityType', [`${node.fullName(connection)}.SCHEMA`]);
-    } else if (type.isVariable) {
-      const node = nodes.find(n => n.variableName === (type as TypeVariable).variable.name);
-      const schemaPair = schemaRegistry.find(pair => pair.schema.equals(type.getEntitySchema())) || {generation: 'Schema.EMPTY'};
-      const schema = node != null ? `${node.fullName(connection)}.SCHEMA` : schemaPair.generation;
-      return ktUtils.applyFun('EntityType', [schema]);
-    } else if (type.isCollection) {
-      return ktUtils.applyFun('CollectionType', [generateType(type.getContainedType())]);
-    } else if (type.isSingleton) {
-      return ktUtils.applyFun('SingletonType', [generateType(type.getContainedType())]);
-    } else if (type.isReference) {
-      return ktUtils.applyFun('ReferenceType', [generateType(type.getContainedType())]);
-    } else if (type.isTuple) {
-      return ktUtils.applyFun('TupleType.of', type.getContainedTypes().map(t => generateType(t)));
-    } else {
-      throw new Error(`Type '${type.tag}' not supported as code generated handle connection type.`);
-    }
-  })(type);
 }
 
 export interface KotlinTypeInfo {

--- a/src/tools/kotlin-type-generator.ts
+++ b/src/tools/kotlin-type-generator.ts
@@ -1,0 +1,70 @@
+/**
+ * @license
+ * Copyright (c) 2020 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {KotlinGenerationUtils} from './kotlin-generation-utils.js';
+import {SchemaGraph, SchemaNode} from './schema2graph.js';
+import {HandleConnectionSpec} from '../runtime/particle-spec.js';
+import {Type} from '../runtime/type.js';
+import {HandleConnection} from '../runtime/recipe/handle-connection.js';
+import {assert} from '../platform/assert-web.js';
+import {generateSchema} from './kotlin-schema-generator.js';
+
+const ktUtils = new KotlinGenerationUtils();
+
+/**
+ * Generates a Kotlin type instance for the given handle connection.
+ */
+export async function generateConnectionType(connection: HandleConnection): Promise<string> {
+  return generateConnectionSpecType(connection.spec, new SchemaGraph(connection.particle.spec).nodes);
+}
+
+export async function generateConnectionSpecType(connection: HandleConnectionSpec, nodes: SchemaNode[]): Promise<string> {
+  let type = connection.type;
+  if (type.isEntity || type.isReference) {
+    // Moving to the new style types with explicit singleton.
+    type = type.singletonOf();
+  }
+
+  return generateType(type, type => {
+    if (!type.isEntity) return null;
+    if (connection.type.hasVariable) return null;
+    const node = nodes.find(n => n.schema.equals(type.getEntitySchema()));
+    return ktUtils.applyFun('EntityType', [`${node.fullName(connection)}.SCHEMA`]);
+  });
+}
+
+/**
+ * Generates a Kotlin representation of an Arcs type.
+ *
+ * @param overrideFunction optional lambda that allows overriding type generation at any place in the type hierarchy.
+ */
+export async function generateType(type: Type, overrideFunction: (type: Type) => string | null = _ => null): Promise<string> {
+  return (async function generate(type: Type): Promise<string> {
+    const override = overrideFunction(type);
+    if (override != null) {
+      return override;
+    } else if (type.isEntity) {
+      return ktUtils.applyFun('EntityType', [await generateSchema(type.getEntitySchema())]);
+    } else if (type.isVariable) {
+      assert(type.maybeEnsureResolved(), 'Unresolved type variables are not currently supported');
+      return generate(type.resolvedType());
+    } else if (type.isCollection) {
+      return ktUtils.applyFun('CollectionType', [await generate(type.getContainedType())]);
+    } else if (type.isSingleton) {
+      return ktUtils.applyFun('SingletonType', [await generate(type.getContainedType())]);
+    } else if (type.isReference) {
+      return ktUtils.applyFun('ReferenceType', [await generate(type.getContainedType())]);
+    } else if (type.isTuple) {
+      return ktUtils.applyFun('TupleType.of', await Promise.all(type.getContainedTypes().map(t => generate(t))));
+    } else {
+      throw new Error(`Type '${type.tag}' not supported as code generated handle connection type.`);
+    }
+  })(type);
+}

--- a/src/tools/schema2base.ts
+++ b/src/tools/schema2base.ts
@@ -154,7 +154,7 @@ export abstract class Schema2Base {
       classes.push(...nodes.map(ng => ng.generator.generate()));
 
       if (this.opts.test_harness) {
-        classes.push(this.generateTestHarness(particle, nodes.map(n => n.node)));
+        classes.push(await this.generateTestHarness(particle, nodes.map(n => n.node)));
         continue;
       }
 
@@ -189,5 +189,5 @@ export abstract class Schema2Base {
 
   abstract async generateParticleClass(particle: ParticleSpec, nodes: NodeAndGenerator[]): Promise<string>;
 
-  abstract generateTestHarness(particle: ParticleSpec, nodes: SchemaNode[]): string;
+  abstract async generateTestHarness(particle: ParticleSpec, nodes: SchemaNode[]): Promise<string>;
 }

--- a/src/tools/schema2cpp.ts
+++ b/src/tools/schema2cpp.ts
@@ -118,7 +118,7 @@ protected:
 `;
   }
 
-  generateTestHarness(particle: ParticleSpec, nodes: SchemaNode[]): string {
+  async generateTestHarness(particle: ParticleSpec, nodes: SchemaNode[]): Promise<string> {
     throw new Error('Test Harness generation is not available for CPP');
   }
 }

--- a/src/tools/schema2kotlin.ts
+++ b/src/tools/schema2kotlin.ts
@@ -9,7 +9,8 @@
  */
 import {EntityGenerator, NodeAndGenerator, Schema2Base} from './schema2base.js';
 import {SchemaNode} from './schema2graph.js';
-import {generateConnectionSpecType, getTypeInfo} from './kotlin-codegen-shared.js';
+import {getTypeInfo} from './kotlin-codegen-shared.js';
+import {generateConnectionSpecType} from './kotlin-type-generator.js';
 import {HandleConnectionSpec, ParticleSpec} from '../runtime/particle-spec.js';
 import {CollectionType, EntityType, Type, TypeVariable} from '../runtime/type.js';
 import {KotlinGenerationUtils} from './kotlin-generation-utils.js';
@@ -178,9 +179,9 @@ ${imports.join('\n')}
     return `${handleMode}${containerType}Handle<${ktUtils.joinWithIndents(typeArguments, {startIndent: 4})}>`;
   }
 
-  private handleSpec(handleName: string, connection: HandleConnectionSpec, nodes: SchemaNode[]): string {
+  private async handleSpec(handleName: string, connection: HandleConnectionSpec, nodes: SchemaNode[]): Promise<string> {
     const mode = this.handleMode(connection);
-    const type = generateConnectionSpecType(connection, nodes);
+    const type = await generateConnectionSpecType(connection, nodes);
     // Using full names of entities, as these are aliases available outside the particle scope.
     const entityNames = SchemaNode.topLevelNodes(connection, nodes).map(node => node.fullName(connection));
     return ktUtils.applyFun(
@@ -252,7 +253,7 @@ abstract class Abstract${particle.name} : ${this.opts.wasm ? 'WasmParticleImpl' 
     }`;
   }
 
-  generateTestHarness(particle: ParticleSpec, nodes: SchemaNode[]): string {
+  async generateTestHarness(particle: ParticleSpec, nodes: SchemaNode[]): Promise<string> {
     const particleName = particle.name;
     const handleDecls: string[] = [];
     const handleSpecs: string[] = [];
@@ -261,7 +262,7 @@ abstract class Abstract${particle.name} : ${this.opts.wasm ? 'WasmParticleImpl' 
       const handleName = connection.name;
 
       // Particle handles are set up with the read/write mode from the manifest.
-      handleSpecs.push(this.handleSpec(handleName, connection, nodes));
+      handleSpecs.push(await this.handleSpec(handleName, connection, nodes));
 
       // The harness has a "copy" of each handle with full read/write access.
       connection.direction = 'reads writes';

--- a/src/tools/tests/BUILD
+++ b/src/tools/tests/BUILD
@@ -57,6 +57,7 @@ arcs_ts_test(
 arcs_kt_gen(
     name = "variable_generation",
     srcs = ["Variable.arcs"],
+    test_harness = False,
 )
 
 arcs_kt_jvm_test_suite(

--- a/src/tools/tests/goldens/WriterReaderExample.kt
+++ b/src/tools/tests/goldens/WriterReaderExample.kt
@@ -8,18 +8,39 @@ package arcs.core.data.testdata
 //
 
 import arcs.core.data.*
+import arcs.core.data.Plan.*
 import arcs.core.storage.StorageKeyParser
+import arcs.core.entity.toPrimitiveValue
 
-object IngestionPlan : Plan(
+val Ingestion_Handle0 = Handle(
+    StorageKeyParser.parse(
+        "reference-mode://{db://25e71af4e9fc8b6958fc46a8f4b7cdf6b5f31516@arcs/Thing}{db://25e71af4e9fc8b6958fc46a8f4b7cdf6b5f31516@arcs/!:writingArcId/handle/my-handle-id}"
+    ),
+    EntityType(
+        Schema(
+            setOf(SchemaName("Thing")),
+            SchemaFields(
+                singletons = mapOf("name" to FieldType.Text),
+                collections = emptyMap()
+            ),
+            "25e71af4e9fc8b6958fc46a8f4b7cdf6b5f31516",
+            refinement = { _ -> true },
+            query = null
+        )
+    ),
+    listOf(
+        Annotation("persistent", emptyMap()),
+        Annotation("ttl", mapOf("value" to AnnotationParam.Str("20d")))
+    )
+)
+val IngestionPlan = Plan(
     listOf(
         Particle(
             "Reader",
             "arcs.core.data.testdata.Reader",
             mapOf(
                 "data" to HandleConnection(
-                    StorageKeyParser.parse(
-                        "reference-mode://{db://25e71af4e9fc8b6958fc46a8f4b7cdf6b5f31516@arcs/Thing}{db://25e71af4e9fc8b6958fc46a8f4b7cdf6b5f31516@arcs/!:writingArcId/handle/my-handle-id}"
-                    ),
+                    Ingestion_Handle0.storageKey,
                     HandleMode.Read,
                     SingletonType(EntityType(Reader_Data.SCHEMA)),
                     listOf(
@@ -34,9 +55,7 @@ object IngestionPlan : Plan(
             "arcs.core.data.testdata.Writer",
             mapOf(
                 "data" to HandleConnection(
-                    StorageKeyParser.parse(
-                        "reference-mode://{db://25e71af4e9fc8b6958fc46a8f4b7cdf6b5f31516@arcs/Thing}{db://25e71af4e9fc8b6958fc46a8f4b7cdf6b5f31516@arcs/!:writingArcId/handle/my-handle-id}"
-                    ),
+                    Ingestion_Handle0.storageKey,
                     HandleMode.Write,
                     SingletonType(EntityType(Writer_Data.SCHEMA)),
                     listOf(
@@ -47,18 +66,35 @@ object IngestionPlan : Plan(
             )
         )
     ),
+    listOf(Ingestion_Handle0),
     listOf(Annotation("arcId", mapOf("id" to AnnotationParam.Str("writingArcId"))))
 )
-object ConsumptionPlan : Plan(
+val Consumption_Handle0 = Handle(
+    StorageKeyParser.parse(
+        "reference-mode://{db://25e71af4e9fc8b6958fc46a8f4b7cdf6b5f31516@arcs/Thing}{db://25e71af4e9fc8b6958fc46a8f4b7cdf6b5f31516@arcs/!:writingArcId/handle/my-handle-id}"
+    ),
+    EntityType(
+        Schema(
+            setOf(SchemaName("Thing")),
+            SchemaFields(
+                singletons = mapOf("name" to FieldType.Text),
+                collections = emptyMap()
+            ),
+            "25e71af4e9fc8b6958fc46a8f4b7cdf6b5f31516",
+            refinement = { _ -> true },
+            query = null
+        )
+    ),
+    emptyList()
+)
+val ConsumptionPlan = Plan(
     listOf(
         Particle(
             "Reader",
             "arcs.core.data.testdata.Reader",
             mapOf(
                 "data" to HandleConnection(
-                    StorageKeyParser.parse(
-                        "reference-mode://{db://25e71af4e9fc8b6958fc46a8f4b7cdf6b5f31516@arcs/Thing}{db://25e71af4e9fc8b6958fc46a8f4b7cdf6b5f31516@arcs/!:writingArcId/handle/my-handle-id}"
-                    ),
+                    Consumption_Handle0.storageKey,
                     HandleMode.Read,
                     SingletonType(EntityType(Reader_Data.SCHEMA)),
                     emptyList()
@@ -66,60 +102,135 @@ object ConsumptionPlan : Plan(
             )
         )
     ),
+    listOf(Consumption_Handle0),
     listOf(Annotation("arcId", mapOf("id" to AnnotationParam.Str("readingArcId"))))
 )
-object EphemeralWritingPlan : Plan(
+val EphemeralWriting_Handle0 = Handle(
+    StorageKeyParser.parse("create://my-ephemeral-handle-id"),
+    EntityType(
+        Schema(
+            setOf(SchemaName("Thing")),
+            SchemaFields(
+                singletons = mapOf("name" to FieldType.Text),
+                collections = emptyMap()
+            ),
+            "25e71af4e9fc8b6958fc46a8f4b7cdf6b5f31516",
+            refinement = { _ -> true },
+            query = null
+        )
+    ),
+    emptyList()
+)
+val EphemeralWritingPlan = Plan(
     listOf(
         Particle(
             "Writer",
             "arcs.core.data.testdata.Writer",
             mapOf(
                 "data" to HandleConnection(
-                    StorageKeyParser.parse("create://my-ephemeral-handle-id"),
+                    EphemeralWriting_Handle0.storageKey,
                     HandleMode.Write,
                     SingletonType(EntityType(Writer_Data.SCHEMA)),
                     emptyList()
                 )
             )
         )
-    )
+    ),
+    listOf(EphemeralWriting_Handle0),
+    emptyList()
 )
-object EphemeralReadingPlan : Plan(
+val EphemeralReading_Handle0 = Handle(
+    StorageKeyParser.parse(
+        "reference-mode://{db://25e71af4e9fc8b6958fc46a8f4b7cdf6b5f31516@arcs/Thing}{db://25e71af4e9fc8b6958fc46a8f4b7cdf6b5f31516@arcs/!:writingArcId/handle/my-handle-id}"
+    ),
+    EntityType(
+        Schema(
+            setOf(SchemaName("Thing")),
+            SchemaFields(
+                singletons = mapOf("name" to FieldType.Text),
+                collections = emptyMap()
+            ),
+            "25e71af4e9fc8b6958fc46a8f4b7cdf6b5f31516",
+            refinement = { _ -> true },
+            query = null
+        )
+    ),
+    emptyList()
+)
+val EphemeralReadingPlan = Plan(
     listOf(
         Particle(
             "Reader",
             "arcs.core.data.testdata.Reader",
             mapOf(
                 "data" to HandleConnection(
-                    StorageKeyParser.parse(
-                        "reference-mode://{db://25e71af4e9fc8b6958fc46a8f4b7cdf6b5f31516@arcs/Thing}{db://25e71af4e9fc8b6958fc46a8f4b7cdf6b5f31516@arcs/!:writingArcId/handle/my-handle-id}"
-                    ),
+                    EphemeralReading_Handle0.storageKey,
                     HandleMode.Read,
                     SingletonType(EntityType(Reader_Data.SCHEMA)),
                     emptyList()
                 )
             )
         )
-    )
+    ),
+    listOf(EphemeralReading_Handle0),
+    emptyList()
 )
-object ReferencesRecipePlan : Plan(
+val ReferencesRecipe_Handle0 = Handle(
+    StorageKeyParser.parse(
+        "db://25e71af4e9fc8b6958fc46a8f4b7cdf6b5f31516@arcs/!:referencesArcId/handle/my-refs-id"
+    ),
+    CollectionType(
+        ReferenceType(
+            EntityType(
+                Schema(
+                    setOf(SchemaName("Thing")),
+                    SchemaFields(
+                        singletons = mapOf("name" to FieldType.Text),
+                        collections = emptyMap()
+                    ),
+                    "25e71af4e9fc8b6958fc46a8f4b7cdf6b5f31516",
+                    refinement = { _ -> true },
+                    query = null
+                )
+            )
+        )
+    ),
+    listOf(Annotation("persistent", emptyMap()))
+)
+val ReferencesRecipe_Handle1 = Handle(
+    StorageKeyParser.parse(
+        "memdb://25e71af4e9fc8b6958fc46a8f4b7cdf6b5f31516@arcs/!:referencesArcId/handle/my-ref-id"
+    ),
+    ReferenceType(
+        EntityType(
+            Schema(
+                setOf(SchemaName("Thing")),
+                SchemaFields(
+                    singletons = mapOf("name" to FieldType.Text),
+                    collections = emptyMap()
+                ),
+                "25e71af4e9fc8b6958fc46a8f4b7cdf6b5f31516",
+                refinement = { _ -> true },
+                query = null
+            )
+        )
+    ),
+    listOf(Annotation("ttl", mapOf("value" to AnnotationParam.Str("1d"))))
+)
+val ReferencesRecipePlan = Plan(
     listOf(
         Particle(
             "ReadWriteReferences",
             "",
             mapOf(
                 "inThingRefs" to HandleConnection(
-                    StorageKeyParser.parse(
-                        "db://25e71af4e9fc8b6958fc46a8f4b7cdf6b5f31516@arcs/!:referencesArcId/handle/my-refs-id"
-                    ),
+                    ReferencesRecipe_Handle0.storageKey,
                     HandleMode.Read,
                     CollectionType(ReferenceType(EntityType(ReadWriteReferences_InThingRefs.SCHEMA))),
                     listOf(Annotation("persistent", emptyMap()))
                 ),
                 "outThingRef" to HandleConnection(
-                    StorageKeyParser.parse(
-                        "memdb://25e71af4e9fc8b6958fc46a8f4b7cdf6b5f31516@arcs/!:referencesArcId/handle/my-ref-id"
-                    ),
+                    ReferencesRecipe_Handle1.storageKey,
                     HandleMode.Write,
                     SingletonType(ReferenceType(EntityType(ReadWriteReferences_OutThingRef.SCHEMA))),
                     listOf(Annotation("ttl", mapOf("value" to AnnotationParam.Str("1d"))))
@@ -127,5 +238,6 @@ object ReferencesRecipePlan : Plan(
             )
         )
     ),
+    listOf(ReferencesRecipe_Handle0, ReferencesRecipe_Handle1),
     listOf(Annotation("arcId", mapOf("id" to AnnotationParam.Str("referencesArcId"))))
 )

--- a/src/tools/tests/schema2kotlin-test.ts
+++ b/src/tools/tests/schema2kotlin-test.ts
@@ -380,7 +380,7 @@ class PTestHarness<P : AbstractP>(
       const schema2kotlin = new Schema2Kotlin({_: []});
       const generators = await schema2kotlin.calculateNodeAndGenerators(particle);
       const nodes = generators.map(g => g.node);
-      const actual = schema2kotlin.generateTestHarness(particle, nodes);
+      const actual = await schema2kotlin.generateTestHarness(particle, nodes);
       assert.equal(actual, expected);
     }
   });

--- a/src/tools/tests/schema2wasm-test.ts
+++ b/src/tools/tests/schema2wasm-test.ts
@@ -49,7 +49,7 @@ class Schema2Mock extends Schema2Base {
     return '';
   }
 
-  generateTestHarness(particle: ParticleSpec, nodes: SchemaNode[]): string {
+  async generateTestHarness(particle: ParticleSpec, nodes: SchemaNode[]): Promise<string> {
     return '';
   }
 }


### PR DESCRIPTION
Another PR on the journey to having top-level handles in Plan.kt (and to unify/merge it with Recipe.kt), in order to:
1) Fix the problem where stores are created based on the type of the first processed handle connection (b/160376325)
2) Unblock Ray's adapter work, which also requires distinction between handle and connection type.

The handles inside the Plan object are not yet used for anything inside ProdEx, that will be done in the follow up. Generation alone is a decent sized change.

Another small change I have sneaked in is changing the generated plans from being declared by object expressions (`object Xxx : Plan(...`) to being variables (`val Xxx = Plan(...`). This is desirable as it allows as to make `Plan` a regular data class, and therefore remove the need for custom equals and hashCode, which were already wrong by not including annotations.