### PR TITLE
Add Predicate.or() and Predicate.and() util functions

### DIFF
--- a/java/arcs/core/data/InformationFlowLabel.kt
+++ b/java/arcs/core/data/InformationFlowLabel.kt
@@ -42,8 +42,31 @@ sealed class InformationFlowLabel {
             override fun toString() = "($lhs and $rhs)"
         }
 
-        infix fun and(other: Predicate) = Predicate.And(this, other)
-        infix fun or(other: Predicate) = Predicate.Or(this, other)
-        fun not() = Predicate.Not(this)
+        infix fun and(other: Predicate) = And(this, other)
+        infix fun or(other: Predicate) = Or(this, other)
+        fun not() = Not(this)
+
+        companion object {
+            /** Combines a list of >= 2 predicates via the [And] operator. */
+            fun and(predicates: List<Predicate>): And = combine(predicates) { a, b -> a and b }
+
+            /** Combines a list of >= 2 predicates via the [Or] operator. */
+            fun or(predicates: List<Predicate>): Or = combine(predicates) { a, b -> a or b }
+
+            /** Combines a list of >= 2 predicates with the given accumulator. */
+            private fun <T : Predicate> combine(
+                predicates: List<Predicate>,
+                acc: (Predicate, Predicate) -> T
+            ): T {
+                require(predicates.size >= 2) {
+                    "Require at least 2 predicates, received ${predicates.size}."
+                }
+                val initial = acc(predicates[0], predicates[1])
+                if (predicates.size == 2) {
+                    return initial
+                }
+                return predicates.subList(2, predicates.size).fold(initial, acc)
+            }
+        }
     }
 }

--- a/java/arcs/core/data/InformationFlowLabel.kt
+++ b/java/arcs/core/data/InformationFlowLabel.kt
@@ -47,15 +47,15 @@ sealed class InformationFlowLabel {
         fun not() = Not(this)
 
         companion object {
-            /** Combines a list of >= 2 predicates via the [And] operator. */
-            fun and(predicates: List<Predicate>): And = combine(predicates) { a, b -> a and b }
+            /** Combines predicates via the [And] operator (must supply at least two). */
+            fun and(vararg predicates: Predicate): And = combine(predicates) { a, b -> a and b }
 
-            /** Combines a list of >= 2 predicates via the [Or] operator. */
-            fun or(predicates: List<Predicate>): Or = combine(predicates) { a, b -> a or b }
+            /** Combines predicates via the [Or] operator (must supply at least two). */
+            fun or(vararg predicates: Predicate): Or = combine(predicates) { a, b -> a or b }
 
             /** Combines a list of >= 2 predicates with the given accumulator. */
             private fun <T : Predicate> combine(
-                predicates: List<Predicate>,
+                predicates: Array<out Predicate>,
                 acc: (Predicate, Predicate) -> T
             ): T {
                 require(predicates.size >= 2) {
@@ -65,7 +65,7 @@ sealed class InformationFlowLabel {
                 if (predicates.size == 2) {
                     return initial
                 }
-                return predicates.subList(2, predicates.size).fold(initial, acc)
+                return predicates.toList().subList(2, predicates.size).fold(initial, acc)
             }
         }
     }

--- a/javatests/arcs/core/data/InformationFlowLabelTest.kt
+++ b/javatests/arcs/core/data/InformationFlowLabelTest.kt
@@ -25,7 +25,7 @@ class InformationFlowLabelTest {
         A, B, C, D;
 
         val asPredicate: Predicate.Label
-            get() = Predicate.Label(InformationFlowLabel.SemanticTag(name))
+            get() = Predicate.Label(SemanticTag(name))
     }
     private val labels = enumValues<Labels>().map { it.name }
     private val indicesMap: Map<InformationFlowLabel, Int> = enumValues<Labels>().map {
@@ -61,25 +61,25 @@ class InformationFlowLabelTest {
     @Test
     fun andSequence() {
         assertThat(
-            Predicate.and(listOf(Labels.A.asPredicate, Labels.B.asPredicate, Labels.C.asPredicate))
+            Predicate.and(Labels.A.asPredicate, Labels.B.asPredicate, Labels.C.asPredicate)
         ).isEqualTo((Labels.A.asPredicate and Labels.B.asPredicate) and Labels.C.asPredicate)
     }
 
     @Test
     fun andSequence_tooShort() {
-        assertFailsWith<IllegalArgumentException> { Predicate.and(listOf(Labels.A.asPredicate)) }
+        assertFailsWith<IllegalArgumentException> { Predicate.and(Labels.A.asPredicate) }
     }
 
     @Test
     fun orSequence() {
         assertThat(
-            Predicate.or(listOf(Labels.A.asPredicate, Labels.B.asPredicate, Labels.C.asPredicate))
+            Predicate.or(Labels.A.asPredicate, Labels.B.asPredicate, Labels.C.asPredicate)
         ).isEqualTo((Labels.A.asPredicate or Labels.B.asPredicate) or Labels.C.asPredicate)
     }
 
     @Test
     fun orSequence_tooShort() {
-        assertFailsWith<IllegalArgumentException> { Predicate.or(listOf(Labels.A.asPredicate)) }
+        assertFailsWith<IllegalArgumentException> { Predicate.or(Labels.A.asPredicate) }
     }
 
     @Test

--- a/javatests/arcs/core/data/InformationFlowLabelTest.kt
+++ b/javatests/arcs/core/data/InformationFlowLabelTest.kt
@@ -17,6 +17,7 @@ import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
+import kotlin.test.assertFailsWith
 
 @RunWith(JUnit4::class)
 class InformationFlowLabelTest {
@@ -55,6 +56,30 @@ class InformationFlowLabelTest {
             .isEqualTo(Predicate.Not(Labels.A.asPredicate))
         assertThat((Labels.A.asPredicate and Labels.B.asPredicate).not())
             .isEqualTo(Predicate.Not(Predicate.And(Labels.A.asPredicate, Labels.B.asPredicate)))
+    }
+
+    @Test
+    fun andSequence() {
+        assertThat(
+            Predicate.and(listOf(Labels.A.asPredicate, Labels.B.asPredicate, Labels.C.asPredicate))
+        ).isEqualTo((Labels.A.asPredicate and Labels.B.asPredicate) and Labels.C.asPredicate)
+    }
+
+    @Test
+    fun andSequence_tooShort() {
+        assertFailsWith<IllegalArgumentException> { Predicate.and(listOf(Labels.A.asPredicate)) }
+    }
+
+    @Test
+    fun orSequence() {
+        assertThat(
+            Predicate.or(listOf(Labels.A.asPredicate, Labels.B.asPredicate, Labels.C.asPredicate))
+        ).isEqualTo((Labels.A.asPredicate or Labels.B.asPredicate) or Labels.C.asPredicate)
+    }
+
+    @Test
+    fun orSequence_tooShort() {
+        assertFailsWith<IllegalArgumentException> { Predicate.or(listOf(Labels.A.asPredicate)) }
     }
 
     @Test


### PR DESCRIPTION
These let you combine a list of predicates with ORs or ANDs easily.