### PR TITLE
Adds some helper vals to the Policy class

### DIFF
--- a/java/arcs/core/policy/Policy.kt
+++ b/java/arcs/core/policy/Policy.kt
@@ -27,22 +27,19 @@ data class Policy(
     /** The name of the egress particle that matches this policy. */
     val egressParticleName = "Egress_$name"
 
-    /** The set of all fields (included nested fields). */
+    /** The set of all fields (includes nested fields). */
     val allFields: Set<PolicyField> = computeAllFields()
 
     /** The set of all redaction labels mentioned in the policy. */
     val allRedactionLabels: Set<String> = allFields.flatMap { it.redactedUsages.keys }.toSet()
 
     private fun computeAllFields(): Set<PolicyField> {
-        val result = mutableSetOf<PolicyField>()
-        fun addField(field: PolicyField) {
-            result.add(field)
-            field.subfields.forEach { addField(it) }
+        fun getAllFields(field: PolicyField): List<PolicyField> {
+            return listOf(field) + field.subfields.flatMap { getAllFields(it) }
         }
-        targets.forEach { target ->
-            target.fields.forEach { addField(it) }
-        }
-        return result
+        return targets.flatMap { target ->
+            target.fields.flatMap { getAllFields(it) }
+        }.toSet()
     }
 }
 

--- a/java/arcs/core/policy/Policy.kt
+++ b/java/arcs/core/policy/Policy.kt
@@ -18,21 +18,42 @@ import arcs.core.data.Capability
 /** Defines a data usage policy. See [PolicyProto] for the canonical definition of a policy. */
 data class Policy(
     val name: String,
-    val description: String,
     val egressType: EgressType,
-    val targets: List<PolicyTarget>,
-    val configs: Map<String, PolicyConfig>,
-    val annotations: List<Annotation>
-)
+    val description: String = "",
+    val targets: List<PolicyTarget> = emptyList(),
+    val configs: Map<String, PolicyConfig> = emptyMap(),
+    val annotations: List<Annotation> = emptyList()
+) {
+    /** The name of the egress particle that matches this policy. */
+    val egressParticleName = "Egress_$name"
+
+    /** The set of all fields (included nested fields). */
+    val allFields: Set<PolicyField> = computeAllFields()
+
+    /** The set of all redaction labels mentioned in the policy. */
+    val allRedactionLabels: Set<String> = allFields.flatMap { it.redactedUsages.keys }.toSet()
+
+    private fun computeAllFields(): Set<PolicyField> {
+        val result = mutableSetOf<PolicyField>()
+        fun addField(field: PolicyField) {
+            result.add(field)
+            field.subfields.forEach { addField(it) }
+        }
+        targets.forEach { target ->
+            target.fields.forEach { addField(it) }
+        }
+        return result
+    }
+}
 
 /** Target schema governed by a policy, see [PolicyTargetProto]. */
 data class PolicyTarget(
     // TODO(b/157605232): Resolve the schema name to a type.
     val schemaName: String,
-    val maxAgeMs: Long,
-    val retentions: List<PolicyRetention>,
-    val fields: List<PolicyField>,
-    val annotations: List<Annotation>
+    val maxAgeMs: Long = 0,
+    val retentions: List<PolicyRetention> = emptyList(),
+    val fields: List<PolicyField> = emptyList(),
+    val annotations: List<Annotation> = emptyList()
 ) {
 
     fun toCapabilities(): List<Capabilities> {
@@ -56,11 +77,11 @@ data class PolicyField(
     // TODO(b/157605232): Resolve the field name to a type.
     val fieldName: String,
     /** Valid usages of this field without redaction. */
-    val rawUsages: Set<UsageType>,
+    val rawUsages: Set<UsageType> = emptySet(),
     /** Valid usages of this field with redaction first. Maps from redaction label to usages. */
-    val redactedUsages: Map<String, Set<UsageType>>,
-    val subfields: List<PolicyField>,
-    val annotations: List<Annotation>
+    val redactedUsages: Map<String, Set<UsageType>> = emptyMap(),
+    val subfields: List<PolicyField> = emptyList(),
+    val annotations: List<Annotation> = emptyList()
 )
 
 /** Retention options for storing data, see [PolicyRetentionProto]. */

--- a/java/arcs/core/policy/Policy.kt
+++ b/java/arcs/core/policy/Policy.kt
@@ -27,19 +27,19 @@ data class Policy(
     /** The name of the egress particle that matches this policy. */
     val egressParticleName = "Egress_$name"
 
-    /** The set of all fields (includes nested fields). */
-    val allFields: Set<PolicyField> = computeAllFields()
+    /** All fields mentioned the policy (includes nested fields). */
+    val allFields: List<PolicyField> = collectAllFields()
 
     /** The set of all redaction labels mentioned in the policy. */
     val allRedactionLabels: Set<String> = allFields.flatMap { it.redactedUsages.keys }.toSet()
 
-    private fun computeAllFields(): Set<PolicyField> {
+    private fun collectAllFields(): List<PolicyField> {
         fun getAllFields(field: PolicyField): List<PolicyField> {
             return listOf(field) + field.subfields.flatMap { getAllFields(it) }
         }
         return targets.flatMap { target ->
             target.fields.flatMap { getAllFields(it) }
-        }.toSet()
+        }
     }
 }
 

--- a/javatests/arcs/core/policy/PolicyTest.kt
+++ b/javatests/arcs/core/policy/PolicyTest.kt
@@ -41,4 +41,58 @@ class PolicyTest {
             )
         ).isTrue()
     }
+
+    fun policy_allFields() {
+        val child = PolicyField("child")
+        val parent = PolicyField("parent", subfields = listOf(child))
+        val other = PolicyField("other")
+        val policy = Policy(
+            name = "MyPolicy",
+            targets = listOf(
+                PolicyTarget("target1", fields = listOf(parent)),
+                PolicyTarget("target2", fields = listOf(other))
+            ),
+            egressType = EgressType.LOGGING
+        )
+
+        assertThat(policy.allFields).containsExactly(child, parent, other)
+    }
+
+    @Test
+    fun policy_allRedactionLabels() {
+        val child = PolicyField(
+            fieldName = "child",
+            redactedUsages = mapOf(
+                "label1" to setOf(UsageType.EGRESS),
+                "label2" to setOf(UsageType.JOIN)
+            )
+        )
+        val parent = PolicyField(
+            fieldName = "parent",
+            subfields = listOf(child),
+            redactedUsages = mapOf(
+                "label2" to setOf(UsageType.EGRESS),
+                "label3" to setOf(UsageType.EGRESS)
+            )
+        )
+        val other = PolicyField(
+            fieldName = "other",
+            redactedUsages = mapOf("label4" to setOf(UsageType.EGRESS))
+        )
+        val policy = Policy(
+            name = "MyPolicy",
+            targets = listOf(
+                PolicyTarget("target1", fields = listOf(parent)),
+                PolicyTarget("target2", fields = listOf(other))
+            ),
+            egressType = EgressType.LOGGING
+        )
+
+        assertThat(policy.allRedactionLabels).containsExactly(
+            "label1",
+            "label2",
+            "label3",
+            "label4"
+        )
+    }
 }


### PR DESCRIPTION
This lets you grab all the redaction labels used in the policy (which we'll need for the policy translator).

Also adds some default args to the policy classes, which makes using them in tests much easier