### PR TITLE
Fix parse error for dataflow check labels starting with 'not'

### DIFF
--- a/src/runtime/manifest-parser.pegjs
+++ b/src/runtime/manifest-parser.pegjs
@@ -613,7 +613,7 @@ CheckImplication
   }
 
 CheckHasTag
-  = 'is' isNot:(whiteSpace 'not')? whiteSpace tag:lowerIdent
+  = 'is' whiteSpace isNot:('not' whiteSpace)? tag:lowerIdent
   {
     return toAstNode<AstNode.CheckHasTag>({
       kind: 'check-has-tag',


### PR DESCRIPTION
The parser got confused, and interpreted a check like `is noteworthy` as `is not ...`.