### PR TITLE
Add check statements to policy translator

### DIFF
--- a/java/arcs/core/policy/PolicyTranslation.kt
+++ b/java/arcs/core/policy/PolicyTranslation.kt
@@ -22,7 +22,11 @@ fun applyPolicy(policy: Policy, graph: RecipeGraph): RecipeGraph {
     val additionalChecks = egressParticleNodes.associateWith { node ->
         // Each handle connection needs its own check statement.
         node.particle.spec.connections.values
-            .filter { it.direction.canRead }
+            .filter {
+                // TODO(b/157605232): Also check canQuery -- but first, need to add QUERY to the
+                // Direction enum in the manifest proto.
+                it.direction.canRead
+            }
             .map { connectionSpec ->
                 Check.Assert(AccessPath(node.particle, connectionSpec), egressCheckPredicate)
             }

--- a/java/arcs/core/policy/PolicyTranslation.kt
+++ b/java/arcs/core/policy/PolicyTranslation.kt
@@ -101,8 +101,8 @@ private fun RecipeGraph.copyWith(
         particleNodes.map { node ->
             RecipeGraph.Node.Particle(
                 node.particle,
-                node.claims + additionalClaims.getOrDefault(node, emptyList()),
-                node.checks + additionalChecks.getOrDefault(node, emptyList())
+                node.claims + (additionalClaims[node] ?: emptyList()),
+                node.checks + (additionalChecks[node] ?: emptyList())
             )
         },
         handleNodes

--- a/java/arcs/core/policy/PolicyTranslation.kt
+++ b/java/arcs/core/policy/PolicyTranslation.kt
@@ -31,6 +31,14 @@ fun applyPolicy(policy: Policy, graph: RecipeGraph): RecipeGraph {
     // TODO(b/157605232): Add additional claims.
     val additionalClaims = emptyMap<RecipeGraph.Node.Particle, List<Claim>>()
 
+    // TODO(b/157605232): This doesn't work! The edges between the nodes aren't updated correctly.
+    // Delete the copyWith method, and update the API for applyPolicy to instead look roughly like
+    // so:
+    //
+    // fun applyPolicy(
+    //     policy: Policy,
+    //     particles: List<ParticleSpec>
+    // ): Map<ParticleSpec, Pair<Claims, Checks>>
     return graph.copyWith(additionalClaims, additionalChecks)
 }
 

--- a/javatests/arcs/core/policy/BUILD
+++ b/javatests/arcs/core/policy/BUILD
@@ -1,19 +1,33 @@
 load(
     "//third_party/java/arcs/build_defs:build_defs.bzl",
     "arcs_kt_jvm_test_suite",
+    "arcs_manifest_proto",
 )
 
 licenses(["notice"])
 
 arcs_kt_jvm_test_suite(
     name = "policy",
+    data = [":testdata"],
     package = "arcs.core.policy",
     deps = [
         "//java/arcs/core/analysis",
         "//java/arcs/core/data",
         "//java/arcs/core/policy",
+        "//java/arcs/core/policy/proto",
+        "//java/arcs/core/testutil/protoloader",
         "//third_party/java/junit:junit-android",
         "//third_party/java/truth:truth-android",
         "//third_party/kotlin/kotlin:kotlin_test",
     ],
+)
+
+filegroup(
+    name = "testdata",
+    srcs = [":PolicyTranslationTestData"],
+)
+
+arcs_manifest_proto(
+    name = "PolicyTranslationTestData",
+    src = "PolicyTranslationTestData.arcs",
 )

--- a/javatests/arcs/core/policy/BUILD
+++ b/javatests/arcs/core/policy/BUILD
@@ -13,6 +13,8 @@ arcs_kt_jvm_test_suite(
     deps = [
         "//java/arcs/core/analysis",
         "//java/arcs/core/data",
+        "//java/arcs/core/data/proto",
+        "//java/arcs/core/data/proto:manifest_java_proto_lite",
         "//java/arcs/core/policy",
         "//java/arcs/core/policy/proto",
         "//java/arcs/core/testutil/protoloader",

--- a/javatests/arcs/core/policy/PolicyTranslationTest.kt
+++ b/javatests/arcs/core/policy/PolicyTranslationTest.kt
@@ -1,9 +1,18 @@
 package arcs.core.policy
 
 import arcs.core.analysis.RecipeGraph
+import arcs.core.data.AccessPath
+import arcs.core.data.Check
+import arcs.core.data.HandleConnectionSpec
+import arcs.core.data.InformationFlowLabel
+import arcs.core.data.InformationFlowLabel.Predicate
 import arcs.core.data.ParticleSpec
 import arcs.core.data.Recipe
+import arcs.core.data.proto.decodeRecipes
+import arcs.core.policy.proto.decode
+import arcs.core.testutil.protoloader.loadManifestBinaryProto
 import com.google.common.truth.Truth.assertThat
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
@@ -11,17 +20,24 @@ import kotlin.test.assertFailsWith
 
 @RunWith(JUnit4::class)
 class PolicyTranslationTest {
+    // Loaded from binary proto, maps all keyed by name.
+    private lateinit var recipes: Map<String, Recipe>
+    private lateinit var policies: Map<String, Policy>
+
+    @Before
+    fun setUp() {
+        val proto = loadManifestBinaryProto(
+            "javatests/arcs/core/policy/PolicyTranslationTestData.pb.bin"
+        )
+        recipes = proto.decodeRecipes().associateBy { it.name!! }
+        policies = proto.policiesList.map { it.decode() }.associateBy { it.name }
+    }
+
     @Test
     fun applyPolicy_checksEgressParticles_acceptsIsolatedParticles() {
-        val graph = RecipeGraph(
-            Recipe(
-                name = "Recipe",
-                handles = emptyMap(),
-                particles = listOf(
-                    createParticle("Isolated1", isolated = true),
-                    createParticle("Isolated2", isolated = true)
-                )
-            )
+        val graph = createRecipeGraph(
+            createParticle("Isolated1", isolated = true),
+            createParticle("Isolated2", isolated = true)
         )
 
         val result = applyPolicy(BLANK_POLICY, graph)
@@ -31,12 +47,8 @@ class PolicyTranslationTest {
 
     @Test
     fun applyPolicy_checksEgressParticles_acceptsValidEgressParticles() {
-        val graph = RecipeGraph(
-            Recipe(
-                name = "Recipe",
-                handles = emptyMap(),
-                particles = listOf(createParticle("Egress_$BLANK_POLICY_NAME", isolated = false))
-            )
+        val graph = createRecipeGraph(
+            createParticle(BLANK_EGRESS_PARTICLE_NAME, isolated = false)
         )
 
         val result = applyPolicy(BLANK_POLICY, graph)
@@ -46,15 +58,9 @@ class PolicyTranslationTest {
 
     @Test
     fun applyPolicy_checksEgressParticles_rejectsInvalidEgressParticles() {
-        val graph = RecipeGraph(
-            Recipe(
-                name = "Recipe",
-                handles = emptyMap(),
-                particles = listOf(
-                    createParticle("Egress1", isolated = false),
-                    createParticle("Egress2", isolated = false)
-                )
-            )
+        val graph = createRecipeGraph(
+            createParticle("Egress1", isolated = false),
+            createParticle("Egress2", isolated = false)
         )
 
         val e = assertFailsWith<PolicyViolation.InvalidEgressParticle> {
@@ -64,20 +70,117 @@ class PolicyTranslationTest {
         assertThat(e.particleNames).containsExactly("Egress1", "Egress2")
     }
 
+    @Test
+    fun applyPolicy_egressCheck_withoutRedactionLabels() {
+        val policy = BLANK_POLICY.copy(name = "SingleInput")
+        val recipe = recipes.getValue("SingleInput")
+        val particle = recipe.particles.single()
+        val graph = RecipeGraph(recipe)
+
+        val result = applyPolicy(policy, graph)
+
+        val particleNode = result.particleNodes.single()
+        assertThat(particleNode.checks).containsExactly(
+            Check.Assert(
+                AccessPath(AccessPath.Root.HandleConnection(
+                    particle,
+                    particle.spec.connections.values.single())
+                ),
+                labelPredicate("allowedForEgress")
+            )
+        )
+    }
+
+    @Test
+    fun applyPolicy_egressCheck_withRedactionLabels() {
+        val policy = policies.getValue("FooRedactions")
+        val recipe = recipes.getValue("SingleInput").forceMatchPolicyName("FooRedactions")
+        val graph = RecipeGraph(recipe)
+
+        val result = applyPolicy(policy, graph)
+
+        val particleNode = result.particleNodes.single()
+        val check = particleNode.checks.single() as Check.Assert
+        assertThat(check.predicate).isEqualTo(
+            Predicate.or(
+                labelPredicate("allowedForEgress"),
+                labelPredicate("allowedForEgress_redaction1") and labelPredicate("redaction1"),
+                labelPredicate("allowedForEgress_redaction2") and labelPredicate("redaction2"),
+                labelPredicate("allowedForEgress_redaction3") and labelPredicate("redaction3")
+            )
+        )
+    }
+
+    @Test
+    fun applyPolicy_egressCheck_preservesExistingChecks() {
+        val policy = BLANK_POLICY.copy(name = "ExistingChecks")
+        val recipe = recipes.getValue("ExistingChecks")
+        val graph = RecipeGraph(recipe)
+
+        val result = applyPolicy(policy, graph)
+
+        val particleNode = result.particleNodes.single()
+        val checkPredicates = particleNode.checks.map { (it as Check.Assert).predicate }
+        assertThat(checkPredicates).contains(labelPredicate("existing"))
+    }
+
+    @Test
+    fun applyPolicy_egressCheck_ignoresWriteOnlyConnections() {
+        val policy = BLANK_POLICY.copy(name = "SingleOutput")
+        val recipe = recipes.getValue("SingleOutput")
+        val graph = RecipeGraph(recipe)
+
+        val result = applyPolicy(policy, graph)
+
+        val particleNode = result.particleNodes.single()
+        assertThat(particleNode.checks).isEmpty()
+    }
+
     companion object {
         private const val BLANK_POLICY_NAME = "BlankPolicy"
+        private const val BLANK_EGRESS_PARTICLE_NAME = "Egress_BlankPolicy"
+
         private val BLANK_POLICY = Policy(name = BLANK_POLICY_NAME, egressType = EgressType.LOGGING)
 
-        private fun createParticle(name: String, isolated: Boolean): Recipe.Particle {
+        private fun createParticle(
+            name: String,
+            isolated: Boolean,
+            connectionSpecs: List<HandleConnectionSpec> = emptyList()
+        ): Recipe.Particle {
             return Recipe.Particle(
                 spec = ParticleSpec(
                     name = name,
-                    connections = emptyMap(),
+                    connections = connectionSpecs.associateBy { it.name },
                     location = "location",
                     isolated = isolated
                 ),
                 handleConnections = emptyList()
             )
         }
+
+        private fun createRecipeGraph(vararg particles: Recipe.Particle): RecipeGraph {
+            return RecipeGraph(
+                Recipe(
+                    name = "Recipe",
+                    handles = emptyMap(),
+                    particles = particles.toList()
+                )
+            )
+        }
+
+        private fun labelPredicate(label: String): Predicate.Label {
+            return Predicate.Label(InformationFlowLabel.SemanticTag(label))
+        }
+
+        private fun Recipe.forceMatchPolicyName(policyName: String): Recipe {
+            val egressParticles = particles.filter { !it.spec.isolated }
+            require(egressParticles.size == 1) { "Must have exactly one egress particle." }
+            val particle = egressParticles.single()
+            val updatedParticle = particle.copy(
+                spec = particle.spec.copy(name = "Egress_$policyName")
+            )
+            return copy(particles = particles.filter { it.spec.isolated } + listOf(updatedParticle))
+        }
     }
 }
+

--- a/javatests/arcs/core/policy/PolicyTranslationTest.kt
+++ b/javatests/arcs/core/policy/PolicyTranslationTest.kt
@@ -71,6 +71,19 @@ class PolicyTranslationTest {
     }
 
     @Test
+    fun applyPolicy_checksEgressParticles_rejectsMultipleEgressParticles() {
+        val graph = createRecipeGraph(
+            createParticle(BLANK_EGRESS_PARTICLE_NAME, isolated = false),
+            createParticle(BLANK_EGRESS_PARTICLE_NAME, isolated = false)
+        )
+
+        val e = assertFailsWith<PolicyViolation.MultipleEgressParticles> {
+            applyPolicy(BLANK_POLICY, graph)
+        }
+        assertThat(e.policy).isEqualTo(BLANK_POLICY)
+    }
+
+    @Test
     fun applyPolicy_egressCheck_withoutRedactionLabels() {
         val policy = BLANK_POLICY.copy(name = "SingleInput")
         val recipe = recipes.getValue("SingleInput")

--- a/javatests/arcs/core/policy/PolicyTranslationTestData.arcs
+++ b/javatests/arcs/core/policy/PolicyTranslationTestData.arcs
@@ -1,0 +1,49 @@
+// Test data for PolicyTranslationTest.
+
+// An empty policy.
+@egressType('Logging')
+policy BlankPolicy {}
+
+schema Foo
+  a: Text
+  b: Number
+  c: Boolean
+
+
+// Particle with a single input.
+particle Egress_SingleInput
+  input: reads Foo {a, b, c}
+recipe SingleInput
+  input: create
+  Egress_SingleInput
+    input: input
+
+// Policy allows access to fields a, b, c with redactions redaction1, redaction2, redaction3.
+@egressType('Logging')
+policy FooRedactions {
+  from Foo access {
+    @allowedUsage(label: 'redaction1', usageType: 'egress')
+    a,
+    @allowedUsage(label: 'redaction2', usageType: 'egress')
+    b,
+    @allowedUsage(label: 'redaction3', usageType: 'egress')
+    c,
+  }
+}
+
+// Particle with existing checks.
+particle Egress_ExistingChecks
+  input: reads Foo {}
+  check input is existing
+recipe ExistingChecks
+  input: create
+  Egress_ExistingChecks
+    input: input
+
+// Particle with a single output.
+particle Egress_SingleOutput
+  output: writes Foo {a, b, c}
+recipe SingleOutput
+  output: create
+  Egress_SingleOutput
+    output: output

--- a/javatests/arcs/core/policy/PolicyTranslationTestData.arcs
+++ b/javatests/arcs/core/policy/PolicyTranslationTestData.arcs
@@ -9,7 +9,6 @@ schema Foo
   b: Number
   c: Boolean
 
-
 // Particle with a single input.
 particle Egress_SingleInput
   input: reads Foo {a, b, c}


### PR DESCRIPTION
Adds a check statement of the form:

```
check input is allowedForEgress
  or (is allowedForEgress_redaction1 and redaction1)
  or (is allowedForEgress_redaction2 and redaction2)
```

to every readable handle of the egress particle.

Doesn't do field-level statements yet. Also no claims yet, so we can't run DFA on the resulting graphs.

I'm not heaps happy with the way I've done the unit tests here. It converts a .arcs file to a proto and loads that, and that's where I get the particle specs, recipes and policies for the test cases. I tried constructing the Kotlin data classes manually in the test file but it way very complicated and unreadable.