### PR TITLE
Run periodic task on the default background thread.

### DIFF
--- a/java/arcs/android/storage/database/DatabaseGarbageCollectionPeriodicTask.kt
+++ b/java/arcs/android/storage/database/DatabaseGarbageCollectionPeriodicTask.kt
@@ -22,14 +22,14 @@ import kotlinx.coroutines.runBlocking
  * Implementation of a [Worker] which performs periodic scan of storage and deletes unused data.
  */
 class DatabaseGarbageCollectionPeriodicTask(
-    val appContext: Context,
+    appContext: Context,
     workerParams: WorkerParameters
 ) : Worker(appContext, workerParams) {
 
     private val log = TaggedLog { WORKER_TAG }
     init { log.debug { "Created." } }
 
-    override fun doWork(): Result = runBlocking(Dispatchers.IO) {
+    override fun doWork(): Result = runBlocking {
         log.debug { "Running." }
         // Use the DatabaseDriverProvider instance of the databaseManager to make sure changes by
         // GC are propagated to listening Stores.

--- a/java/arcs/android/storage/database/DatabaseGarbageCollectionPeriodicTask.kt
+++ b/java/arcs/android/storage/database/DatabaseGarbageCollectionPeriodicTask.kt
@@ -15,7 +15,6 @@ import androidx.work.Worker
 import androidx.work.WorkerParameters
 import arcs.core.storage.driver.DatabaseDriverProvider
 import arcs.core.util.TaggedLog
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 
 /**

--- a/java/arcs/android/storage/ttl/PeriodicCleanupTask.kt
+++ b/java/arcs/android/storage/ttl/PeriodicCleanupTask.kt
@@ -22,14 +22,14 @@ import kotlinx.coroutines.runBlocking
  * Implementation of a [Worker] which performs periodic scan of storage and deletes expired data.
  */
 class PeriodicCleanupTask(
-    val appContext: Context,
+    appContext: Context,
     workerParams: WorkerParameters
 ) : Worker(appContext, workerParams) {
 
     private val log = TaggedLog { WORKER_TAG }
     init { log.debug { "Created." } }
 
-    override fun doWork(): Result = runBlocking(Dispatchers.IO) {
+    override fun doWork(): Result = runBlocking {
         log.debug { "Running." }
         // Use the DatabaseDriverProvider instance of the databaseManager to make sure changes by
         // TTL expiry are propagated to listening Stores.

--- a/java/arcs/android/storage/ttl/PeriodicCleanupTask.kt
+++ b/java/arcs/android/storage/ttl/PeriodicCleanupTask.kt
@@ -15,7 +15,6 @@ import androidx.work.Worker
 import androidx.work.WorkerParameters
 import arcs.core.storage.driver.DatabaseDriverProvider
 import arcs.core.util.TaggedLog
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 
 /**


### PR DESCRIPTION
According https://developer.android.com/topic/libraries/architecture/workmanager/advanced/threading, WorkManager automatically creates background thread for jobs so we don't need to run these jobs on Dispatchers.IO.