### PR TITLE
Centralize all Dispatchers

### DIFF
--- a/java/arcs/android/common/resurrection/ResurrectorService.kt
+++ b/java/arcs/android/common/resurrection/ResurrectorService.kt
@@ -18,10 +18,10 @@ import androidx.annotation.VisibleForTesting
 import arcs.android.common.resurrection.ResurrectionRequest.UnregisterRequest
 import arcs.core.storage.StorageKey
 import arcs.core.util.guardedBy
+import arcs.jvm.util.JvmDispatchers
 import java.io.PrintWriter
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.cancelChildren
@@ -40,7 +40,7 @@ abstract class ResurrectorService : Service() {
     protected open val resurrectionDatabaseName: String = DbHelper.RESURRECTION_DB_NAME
 
     protected open val job =
-        Job() + Dispatchers.IO + CoroutineName("ResurrectorService")
+        Job() + JvmDispatchers.IO + CoroutineName("ResurrectorService")
 
     private val dbHelper: DbHelper by lazy { DbHelper(this, resurrectionDatabaseName) }
 

--- a/java/arcs/android/devtools/DevToolsService.kt
+++ b/java/arcs/android/devtools/DevToolsService.kt
@@ -14,9 +14,9 @@ package arcs.android.devtools
 import android.app.Service
 import android.content.Intent
 import android.os.IBinder
+import arcs.core.util.CoreDispatchers
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
 
 /**
@@ -25,7 +25,7 @@ import kotlinx.coroutines.cancel
  */
 class DevToolsService : Service() {
 
-    private val coroutineContext = Dispatchers.Default + CoroutineName("DevtoolsService")
+    private val coroutineContext = CoreDispatchers.Default + CoroutineName("DevtoolsService")
     private val scope = CoroutineScope(coroutineContext)
     private val binder = DevToolsBinder(scope)
 

--- a/java/arcs/android/sdk/host/IntentArcHostAdapter.kt
+++ b/java/arcs/android/sdk/host/IntentArcHostAdapter.kt
@@ -25,10 +25,10 @@ import arcs.core.host.ArcState
 import arcs.core.host.ArcStateChangeCallback
 import arcs.core.host.ArcStateChangeRegistration
 import arcs.core.host.ParticleIdentifier
+import arcs.core.util.CoreDispatchers
 import kotlin.coroutines.EmptyCoroutineContext
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 
@@ -96,7 +96,7 @@ class IntentArcHostAdapter(
     ) : ResultReceiver(Handler(Looper.getMainLooper())) {
         override fun onReceiveResult(resultCode: Int, resultData: Bundle?) {
             val scope = CoroutineScope(
-                EmptyCoroutineContext + Dispatchers.Default + Job() + CoroutineName(
+                EmptyCoroutineContext + CoreDispatchers.Default + Job() + CoroutineName(
                     "ArcStateChange"
                 )
             )

--- a/java/arcs/android/storage/ttl/PeriodicCleanupTask.kt
+++ b/java/arcs/android/storage/ttl/PeriodicCleanupTask.kt
@@ -15,7 +15,7 @@ import androidx.work.Worker
 import androidx.work.WorkerParameters
 import arcs.core.storage.driver.DatabaseDriverProvider
 import arcs.core.util.TaggedLog
-import kotlinx.coroutines.Dispatchers
+import arcs.jvm.util.JvmDispatchers
 import kotlinx.coroutines.runBlocking
 
 /**
@@ -29,7 +29,7 @@ class PeriodicCleanupTask(
     private val log = TaggedLog { WORKER_TAG }
     init { log.debug { "Created." } }
 
-    override fun doWork(): Result = runBlocking(Dispatchers.IO) {
+    override fun doWork(): Result = runBlocking(JvmDispatchers.IO) {
         log.debug { "Running." }
         // Use the DatabaseDriverProvider instance of the databaseManager to make sure changes by
         // TTL expiry are propagated to listening Stores.

--- a/java/arcs/core/data/Reference.kt
+++ b/java/arcs/core/data/Reference.kt
@@ -12,8 +12,8 @@
 package arcs.core.data
 
 import arcs.core.common.Referencable
+import arcs.core.util.CoreDispatchers
 import kotlin.coroutines.CoroutineContext
-import kotlinx.coroutines.Dispatchers
 
 /**
  * A reference to an [Entity] of type [T].
@@ -33,13 +33,13 @@ interface Reference<T : Referencable> : arcs.core.crdt.CrdtEntity.Reference {
      *
      * Returns `null` if this [Reference] is no longer alive.
      */
-    suspend fun dereference(coroutineContext: CoroutineContext = Dispatchers.Default): T?
+    suspend fun dereference(coroutineContext: CoroutineContext = CoreDispatchers.Default): T?
 
     /** Returns whether or not the [Entity] being referenced still exists. */
-    suspend fun isAlive(coroutineContext: CoroutineContext = Dispatchers.Default): Boolean =
+    suspend fun isAlive(coroutineContext: CoroutineContext = CoreDispatchers.Default): Boolean =
         dereference(coroutineContext) != null
 
     /** Returns whether or not the [Entity] being referenced has been removed from storage. */
-    suspend fun isDead(coroutineContext: CoroutineContext = Dispatchers.Default): Boolean =
+    suspend fun isDead(coroutineContext: CoroutineContext = CoreDispatchers.Default): Boolean =
         !isAlive(coroutineContext)
 }

--- a/java/arcs/core/storage/Reference.kt
+++ b/java/arcs/core/storage/Reference.kt
@@ -17,9 +17,9 @@ import arcs.core.crdt.VersionMap
 import arcs.core.data.Capability.Ttl
 import arcs.core.data.RawEntity
 import arcs.core.data.Schema
+import arcs.core.util.CoreDispatchers
 import arcs.core.util.Time
 import kotlin.coroutines.CoroutineContext
-import kotlinx.coroutines.Dispatchers
 
 /**
  * [arcs.core.storage.ReferenceModeStore] uses an expanded notion of Reference that also includes a
@@ -84,7 +84,7 @@ data class Reference(
 interface Dereferencer<T> {
     suspend fun dereference(
         reference: Reference,
-        coroutineContext: CoroutineContext = Dispatchers.Default
+        coroutineContext: CoroutineContext = CoreDispatchers.Default
     ): T?
 
     /**

--- a/java/arcs/core/storage/ReferenceModeStore.kt
+++ b/java/arcs/core/storage/ReferenceModeStore.kt
@@ -49,6 +49,7 @@ import arcs.core.storage.referencemode.toReferenceModeMessage
 import arcs.core.storage.util.RandomProxyCallbackManager
 import arcs.core.storage.util.SendQueue
 import arcs.core.type.Type
+import arcs.core.util.CoreDispatchers
 import arcs.core.util.Random
 import arcs.core.util.Result
 import arcs.core.util.TaggedLog
@@ -56,7 +57,6 @@ import arcs.core.util.computeNotNull
 import arcs.core.util.nextSafeRandomLong
 import kotlin.coroutines.coroutineContext
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
@@ -462,7 +462,7 @@ class ReferenceModeStore private constructor(
                 callbacksStateChannel.close()
             }
         }
-        .launchIn(CoroutineScope(Dispatchers.Default + Job()))
+        .launchIn(CoroutineScope(CoreDispatchers.Default + Job()))
 
     private fun newBackingInstance(): CrdtModel<CrdtData, CrdtOperationAtTime, Referencable> =
         crdtType.createCrdtModel()

--- a/java/arcs/core/storage/StorageProxy.kt
+++ b/java/arcs/core/storage/StorageProxy.kt
@@ -16,6 +16,7 @@ import arcs.core.crdt.CrdtData
 import arcs.core.crdt.CrdtModel
 import arcs.core.crdt.CrdtOperationAtTime
 import arcs.core.crdt.VersionMap
+import arcs.core.util.CoreDispatchers
 import arcs.core.util.Scheduler
 import arcs.core.util.TaggedLog
 import arcs.core.util.Time
@@ -25,7 +26,6 @@ import kotlinx.atomicfu.update
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Deferred
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.ConflatedBroadcastChannel
 import kotlinx.coroutines.coroutineScope
@@ -128,7 +128,7 @@ class StorageProxy<Data : CrdtData, Op : CrdtOperationAtTime, T>(
                     busySendingMessagesChannel.send(false)
                 }
             }
-            .flowOn(Dispatchers.Default)
+            .flowOn(CoreDispatchers.Default)
             .launchIn(scheduler.scope)
     }
 

--- a/java/arcs/core/util/CoreDispatchers.kt
+++ b/java/arcs/core/util/CoreDispatchers.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.core.util
+
+import kotlinx.coroutines.Dispatchers
+
+/**
+ * A set of dispatchers used by Arcs for launching coroutines. These mostly mimic those
+ * in the builtin Kotlin [Dispatchers] but can be overridden via source inclusion/exclusion.
+ */
+object CoreDispatchers {
+    val Default = Dispatchers.Default
+}

--- a/java/arcs/core/util/performance/PerformanceStatistics.kt
+++ b/java/arcs/core/util/performance/PerformanceStatistics.kt
@@ -11,12 +11,12 @@
 
 package arcs.core.util.performance
 
+import arcs.core.util.CoreDispatchers
 import arcs.core.util.RunningStatistics
 import arcs.core.util.guardedBy
 import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
@@ -79,7 +79,7 @@ class PerformanceStatistics private constructor(
 
     /** Asynchronously takes a [Snapshot] of the current performance statistics. */
     fun snapshotAsync(
-        coroutineContext: CoroutineContext = Dispatchers.Default
+        coroutineContext: CoroutineContext = CoreDispatchers.Default
     ): Deferred<Snapshot> = CoroutineScope(coroutineContext).async { snapshot() }
 
     /**
@@ -95,7 +95,7 @@ class PerformanceStatistics private constructor(
         }
         val (result, counts) = timedResult
 
-        CoroutineScope(Dispatchers.Default).launch {
+        CoroutineScope(CoreDispatchers.Default).launch {
             mutex.withLock {
                 runtimeStats.logStat(elapsed.toDouble())
                 counters.append(counts)

--- a/java/arcs/jvm/util/BUILD
+++ b/java/arcs/jvm/util/BUILD
@@ -9,5 +9,6 @@ arcs_kt_jvm_library(
     srcs = glob(["*.kt"]),
     deps = [
         "//java/arcs/core/util",
+        "//third_party/kotlin/kotlinx_coroutines",
     ],
 )

--- a/java/arcs/jvm/util/JvmDispatchers.kt
+++ b/java/arcs/jvm/util/JvmDispatchers.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.jvm.util
+
+import arcs.core.util.CoreDispatchers
+import kotlinx.coroutines.Dispatchers
+
+/**
+ * A set of dispatchers used by Arcs for launching coroutines. These mostly mimic those
+ * in the builtin Kotlin [Dispatchers] for the JVM but can be overridden via source
+ * inclusion/exclusion.
+ */
+object JvmDispatchers {
+    val Default = CoreDispatchers.Default
+    val IO = Dispatchers.IO
+}

--- a/java/arcs/sdk/android/storage/ServiceStore.kt
+++ b/java/arcs/sdk/android/storage/ServiceStore.kt
@@ -35,6 +35,7 @@ import arcs.core.storage.ProxyCallback
 import arcs.core.storage.ProxyMessage
 import arcs.core.storage.StoreOptions
 import arcs.core.util.TaggedLog
+import arcs.jvm.util.JvmDispatchers
 import arcs.sdk.android.storage.service.ConnectionFactory
 import arcs.sdk.android.storage.service.DefaultConnectionFactory
 import arcs.sdk.android.storage.service.StorageServiceConnection
@@ -42,7 +43,6 @@ import kotlin.coroutines.CoroutineContext
 import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
@@ -69,7 +69,7 @@ import kotlinx.coroutines.withTimeout
 class ServiceStoreFactory(
     private val context: Context,
     private val lifecycle: Lifecycle,
-    private val coroutineContext: CoroutineContext = Dispatchers.IO,
+    private val coroutineContext: CoroutineContext = JvmDispatchers.IO,
     private val connectionFactory: ConnectionFactory? = null
 ) : ActivationFactory {
     override suspend operator fun <Data : CrdtData, Op : CrdtOperation, ConsumerData> invoke(

--- a/java/arcs/sdk/android/storage/service/StorageService.kt
+++ b/java/arcs/sdk/android/storage/service/StorageService.kt
@@ -39,6 +39,7 @@ import arcs.core.storage.driver.RamDiskDriverProvider
 import arcs.core.util.TaggedLog
 import arcs.core.util.performance.MemoryStats
 import arcs.core.util.performance.PerformanceStatistics
+import arcs.jvm.util.JvmDispatchers
 import java.io.FileDescriptor
 import java.io.PrintWriter
 import java.util.concurrent.ConcurrentHashMap
@@ -46,7 +47,6 @@ import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.asCoroutineDispatcher
@@ -58,7 +58,7 @@ import kotlinx.coroutines.runBlocking
  * the [IStorageService] interface when bound-to by a client.
  */
 open class StorageService : ResurrectorService() {
-    private val coroutineContext = Dispatchers.IO + CoroutineName("StorageService")
+    private val coroutineContext = JvmDispatchers.IO + CoroutineName("StorageService")
     private val scope = CoroutineScope(coroutineContext)
     open val writeBackScope = CoroutineScope(
         Executors.newCachedThreadPool {

--- a/java/arcs/sdk/android/storage/service/StorageServiceConnection.kt
+++ b/java/arcs/sdk/android/storage/service/StorageServiceConnection.kt
@@ -19,12 +19,12 @@ import arcs.android.crdt.ParcelableCrdtType
 import arcs.android.storage.ParcelableStoreOptions
 import arcs.android.storage.toParcelable
 import arcs.core.storage.StoreOptions
+import arcs.core.util.CoreDispatchers
 import kotlin.coroutines.CoroutineContext
 import kotlinx.atomicfu.atomic
 import kotlinx.atomicfu.update
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Deferred
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 
@@ -44,7 +44,7 @@ typealias ManagerConnectionFactory = () -> StorageServiceConnection
 fun DefaultConnectionFactory(
     context: Context,
     bindingDelegate: StorageServiceBindingDelegate = DefaultStorageServiceBindingDelegate(context),
-    coroutineContext: CoroutineContext = Dispatchers.Default
+    coroutineContext: CoroutineContext = CoreDispatchers.Default
 ): ConnectionFactory = { options, crdtType ->
     StorageServiceConnection(bindingDelegate, options.toParcelable(crdtType), coroutineContext)
 }
@@ -59,7 +59,7 @@ fun DefaultConnectionFactory(
 fun ManagerConnectionFactory(
     context: Context,
     bindingDelegate: StorageServiceBindingDelegate = StorageServiceManagerBindingDelegate(context),
-    coroutineContext: CoroutineContext = Dispatchers.Default
+    coroutineContext: CoroutineContext = CoreDispatchers.Default
 ): ManagerConnectionFactory = { StorageServiceConnection(bindingDelegate, null, coroutineContext) }
 
 /** Defines an object capable of binding-to and unbinding-from the [StorageService]. */
@@ -125,7 +125,7 @@ class StorageServiceConnection(
     /** Parcelable [StoreOptions] to pass to the [bindingDelegate] when connecting. */
     private val storeOptions: ParcelableStoreOptions?,
     /** Parent [CoroutineContext] for the [Deferred] returned by [connectAsync]. */
-    private val coroutineContext: CoroutineContext = Dispatchers.Default
+    private val coroutineContext: CoroutineContext = CoreDispatchers.Default
 ) : ServiceConnection {
     private var needsDisconnect = false
     private var service = atomic<CompletableDeferred<IBinder>?>(null)


### PR DESCRIPTION
Regardless of Option #1 vs #2, this changes all Dispatcher references to use central objects we can easily control in the future.
