### PR TITLE
Move SchemaRegistry into arcs.core.data package

### DIFF
--- a/java/arcs/android/storage/database/DatabaseImpl.kt
+++ b/java/arcs/android/storage/database/DatabaseImpl.kt
@@ -42,10 +42,10 @@ import arcs.core.data.LARGEST_PRIMITIVE_TYPE_ID
 import arcs.core.data.PrimitiveType
 import arcs.core.data.RawEntity
 import arcs.core.data.Schema
+import arcs.core.data.SchemaRegistry
 import arcs.core.data.util.ReferencableList
 import arcs.core.data.util.ReferencablePrimitive
 import arcs.core.data.util.toReferencable
-import arcs.core.entity.SchemaRegistry
 import arcs.core.storage.Reference
 import arcs.core.storage.StorageKey
 import arcs.core.storage.StorageKeyParser
@@ -1709,9 +1709,7 @@ class DatabaseImpl(
     ): TypeId = when (fieldType) {
         is FieldType.Primitive -> fieldType.primitiveType.primitiveTypeId()
         is FieldType.EntityRef -> {
-            val schema = requireNotNull(SchemaRegistry.getSchema(fieldType.schemaHash)) {
-                "Unknown Schema with hash: ${fieldType.schemaHash} in SchemaRegistry"
-            }
+            val schema = SchemaRegistry.getSchema(fieldType.schemaHash)
             getSchemaTypeId(schema, database)
         }
         // TODO(b/156003617)
@@ -1719,9 +1717,7 @@ class DatabaseImpl(
             throw NotImplementedError("[FieldType.Tuple]s not currently supported.")
         is FieldType.ListOf -> getTypeId(fieldType.primitiveType, database)
         is FieldType.InlineEntity -> {
-            var schema = requireNotNull(SchemaRegistry.getSchema(fieldType.schemaHash)) {
-                "Unknown Schema with hash: ${fieldType.schemaHash} in SchemaRegistry"
-            }
+            val schema = SchemaRegistry.getSchema(fieldType.schemaHash)
             getSchemaTypeId(schema, database)
         }
     }

--- a/java/arcs/core/data/SchemaRegistry.kt
+++ b/java/arcs/core/data/SchemaRegistry.kt
@@ -8,9 +8,7 @@
  * grant found at
  * http://polymer.github.io/PATENTS.txt
  */
-package arcs.core.entity
-
-import arcs.core.data.Schema
+package arcs.core.data
 
 typealias SchemaHash = String
 
@@ -25,8 +23,10 @@ object SchemaRegistry {
         schemas[schema.hash] = schema
     }
 
-    /** Given a [SchemaHash], return the [Schema] for that hash, if it exists. */
-    fun getSchema(hash: SchemaHash) = schemas[hash]
+    /** Returns the [Schema] stored in the registry for the given [SchemaHash]. */
+    fun getSchema(hash: SchemaHash): Schema = schemas.getOrElse(hash) {
+        throw NoSuchElementException("Schema hash '$hash' not found in SchemaRegistry.")
+    }
 
     /** Clears the registry, for testing purposes. */
     fun clearForTest() {

--- a/java/arcs/core/data/SchemaRegistry.kt
+++ b/java/arcs/core/data/SchemaRegistry.kt
@@ -23,7 +23,11 @@ object SchemaRegistry {
         schemas[schema.hash] = schema
     }
 
-    /** Returns the [Schema] stored in the registry for the given [SchemaHash]. */
+    /**
+     * Returns the [Schema] stored in the registry for the given [SchemaHash].
+     *
+     * @throws NoSuchElementException if no schema has been registered for the requested schema hash
+     */
     fun getSchema(hash: SchemaHash): Schema = schemas.getOrElse(hash) {
         throw NoSuchElementException("Schema hash '$hash' not found in SchemaRegistry.")
     }

--- a/java/arcs/core/entity/EntityBase.kt
+++ b/java/arcs/core/entity/EntityBase.kt
@@ -20,6 +20,8 @@ import arcs.core.data.RawEntity
 import arcs.core.data.RawEntity.Companion.NO_REFERENCE_ID
 import arcs.core.data.RawEntity.Companion.UNINITIALIZED_TIMESTAMP
 import arcs.core.data.Schema
+import arcs.core.data.SchemaHash
+import arcs.core.data.SchemaRegistry
 import arcs.core.data.util.ReferencableList
 import arcs.core.data.util.ReferencablePrimitive
 import arcs.core.data.util.toReferencable

--- a/java/arcs/core/entity/EntityDereferencerFactory.kt
+++ b/java/arcs/core/entity/EntityDereferencerFactory.kt
@@ -3,6 +3,7 @@ package arcs.core.entity
 import arcs.core.data.FieldType
 import arcs.core.data.RawEntity
 import arcs.core.data.Schema
+import arcs.core.data.SchemaRegistry
 import arcs.core.storage.ActivationFactory
 import arcs.core.storage.Dereferencer
 import arcs.core.storage.RawEntityDereferencer
@@ -37,11 +38,7 @@ class EntityDereferencerFactory(
     private fun injectDereferencers(schema: Schema, rawEntity: RawEntity) {
         fun injectField(fieldType: FieldType?, fieldValue: Any?) {
             if (fieldType is FieldType.EntityRef) {
-                val fieldSchema = requireNotNull(
-                    SchemaRegistry.getSchema(fieldType.schemaHash)
-                ) {
-                    "Unknown schema with hash ${fieldType.schemaHash}."
-                }
+                val fieldSchema = SchemaRegistry.getSchema(fieldType.schemaHash)
                 injectDereferencers(fieldSchema, fieldValue)
             }
         }

--- a/java/arcs/core/entity/VariableEntityBase.kt
+++ b/java/arcs/core/entity/VariableEntityBase.kt
@@ -5,6 +5,7 @@ import arcs.core.data.FieldName
 import arcs.core.data.RawEntity
 import arcs.core.data.RawEntity.Companion.UNINITIALIZED_TIMESTAMP
 import arcs.core.data.Schema
+import arcs.core.data.SchemaHash
 
 /**
  * A base [Entity] to access data from type variables.

--- a/java/arcs/core/storage/api/DriverAndKeyConfigurator.kt
+++ b/java/arcs/core/storage/api/DriverAndKeyConfigurator.kt
@@ -13,7 +13,7 @@ package arcs.core.storage.api
 
 import arcs.core.common.ArcId
 import arcs.core.data.CreatableStorageKey
-import arcs.core.entity.SchemaRegistry
+import arcs.core.data.SchemaRegistry
 import arcs.core.storage.CapabilitiesResolver
 import arcs.core.storage.DriverFactory
 import arcs.core.storage.StorageKeyParser

--- a/javatests/arcs/android/e2e/testapp/TestEntity.kt
+++ b/javatests/arcs/android/e2e/testapp/TestEntity.kt
@@ -5,7 +5,7 @@ import arcs.core.data.RawEntity
 import arcs.core.data.Schema
 import arcs.core.data.SchemaFields
 import arcs.core.data.SchemaName
-import arcs.core.entity.SchemaRegistry
+import arcs.core.data.SchemaRegistry
 import arcs.core.storage.keys.DatabaseStorageKey
 import arcs.core.storage.keys.RamDiskStorageKey
 import arcs.core.storage.referencemode.ReferenceModeStorageKey

--- a/javatests/arcs/android/entity/SameHandleManagerTest.kt
+++ b/javatests/arcs/android/entity/SameHandleManagerTest.kt
@@ -9,20 +9,15 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.work.testing.WorkManagerTestInitHelper
 import arcs.android.storage.database.AndroidSqliteDatabaseManager
 import arcs.core.entity.HandleManagerTestBase
-import arcs.core.entity.SchemaRegistry
 import arcs.core.host.EntityHandleManager
 import arcs.core.storage.StoreManager
 import arcs.core.storage.driver.DatabaseDriverProvider
 import arcs.jvm.host.JvmSchedulerProvider
 import arcs.sdk.android.storage.ServiceStoreFactory
 import arcs.sdk.android.storage.service.testutil.TestConnectionFactory
-import kotlinx.coroutines.CoroutineScope
 import kotlin.coroutines.EmptyCoroutineContext
-import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Before
-import org.junit.Ignore
-import org.junit.Test
 import org.junit.runner.RunWith
 
 @Suppress("EXPERIMENTAL_API_USAGE")

--- a/javatests/arcs/android/entity/TtlHandleTest.kt
+++ b/javatests/arcs/android/entity/TtlHandleTest.kt
@@ -12,7 +12,7 @@ import arcs.core.entity.DummyEntity
 import arcs.core.entity.HandleSpec
 import arcs.core.entity.ReadWriteCollectionHandle
 import arcs.core.entity.ReadWriteSingletonHandle
-import arcs.core.entity.SchemaRegistry
+import arcs.core.data.SchemaRegistry
 import arcs.core.entity.awaitReady
 import arcs.core.host.EntityHandleManager
 import arcs.core.storage.StorageKey

--- a/javatests/arcs/android/storage/ReferenceModeStoreDatabaseImplIntegrationTest.kt
+++ b/javatests/arcs/android/storage/ReferenceModeStoreDatabaseImplIntegrationTest.kt
@@ -27,7 +27,7 @@ import arcs.core.data.SchemaFields
 import arcs.core.data.SchemaName
 import arcs.core.data.SingletonType
 import arcs.core.data.util.toReferencable
-import arcs.core.entity.SchemaRegistry
+import arcs.core.data.SchemaRegistry
 import arcs.core.storage.DriverFactory
 import arcs.core.storage.ProxyCallback
 import arcs.core.storage.ProxyMessage
@@ -42,7 +42,6 @@ import arcs.core.storage.driver.DatabaseDriverProvider
 import arcs.core.storage.keys.DatabaseStorageKey
 import arcs.core.storage.referencemode.RefModeStoreData
 import arcs.core.storage.referencemode.RefModeStoreOp
-import arcs.core.storage.referencemode.RefModeStoreOutput
 import arcs.core.storage.referencemode.ReferenceModeStorageKey
 import arcs.core.storage.testutil.WriteBackForTesting
 import arcs.core.storage.toReference

--- a/javatests/arcs/android/storage/database/DatabaseGarbageCollectionPeriodicTaskTest.kt
+++ b/javatests/arcs/android/storage/database/DatabaseGarbageCollectionPeriodicTaskTest.kt
@@ -10,7 +10,7 @@ import arcs.core.data.HandleMode
 import arcs.core.entity.DummyEntity
 import arcs.core.entity.HandleSpec
 import arcs.core.entity.ReadWriteCollectionHandle
-import arcs.core.entity.SchemaRegistry
+import arcs.core.data.SchemaRegistry
 import arcs.core.entity.awaitReady
 import arcs.core.host.EntityHandleManager
 import arcs.core.storage.api.DriverAndKeyConfigurator

--- a/javatests/arcs/android/storage/database/DatabaseImplTest.kt
+++ b/javatests/arcs/android/storage/database/DatabaseImplTest.kt
@@ -29,7 +29,7 @@ import arcs.core.data.Schema
 import arcs.core.data.SchemaFields
 import arcs.core.data.util.ReferencablePrimitive
 import arcs.core.data.util.toReferencable
-import arcs.core.entity.SchemaRegistry
+import arcs.core.data.SchemaRegistry
 import arcs.core.storage.Reference
 import arcs.core.storage.StorageKey
 import arcs.core.storage.StorageKeyParser
@@ -87,12 +87,12 @@ class DatabaseImplTest {
 
     @Test
     fun getTypeId_entity_throwsWhenMissing() = runBlockingTest {
-        val exception = assertSuspendingThrows(IllegalArgumentException::class) {
+        val exception = assertSuspendingThrows(NoSuchElementException::class) {
             database.getTypeIdForTest(FieldType.EntityRef("shouldnotexistanywhere"))
         }
-        assertThat(exception)
-            .hasMessageThat()
-            .contains("Unknown Schema with hash:")
+        assertThat(exception).hasMessageThat().isEqualTo(
+            "Schema hash 'shouldnotexistanywhere' not found in SchemaRegistry."
+        )
     }
 
     @Test

--- a/javatests/arcs/android/storage/service/StorageServiceManagerTest.kt
+++ b/javatests/arcs/android/storage/service/StorageServiceManagerTest.kt
@@ -22,7 +22,7 @@ import arcs.core.entity.DummyEntity
 import arcs.core.entity.HandleSpec
 import arcs.core.entity.ReadWriteCollectionHandle
 import arcs.core.entity.ReadWriteSingletonHandle
-import arcs.core.entity.SchemaRegistry
+import arcs.core.data.SchemaRegistry
 import arcs.core.entity.awaitReady
 import arcs.core.host.EntityHandleManager
 import arcs.core.storage.StorageKey

--- a/javatests/arcs/android/storage/ttl/PeriodicCleanupTaskTest.kt
+++ b/javatests/arcs/android/storage/ttl/PeriodicCleanupTaskTest.kt
@@ -13,7 +13,7 @@ import arcs.core.data.Capability.Ttl
 import arcs.core.entity.DummyEntity
 import arcs.core.entity.HandleSpec
 import arcs.core.entity.ReadWriteCollectionHandle
-import arcs.core.entity.SchemaRegistry
+import arcs.core.data.SchemaRegistry
 import arcs.core.entity.awaitReady
 import arcs.core.host.EntityHandleManager
 import arcs.core.storage.StoreWriteBack

--- a/javatests/arcs/android/systemhealth/testapp/TestApplication.kt
+++ b/javatests/arcs/android/systemhealth/testapp/TestApplication.kt
@@ -16,7 +16,7 @@ import androidx.work.Configuration
 import arcs.android.storage.database.AndroidSqliteDatabaseManager
 import arcs.android.util.connectMemoryStatsPipe
 import arcs.android.util.initLogForAndroid
-import arcs.core.entity.SchemaRegistry
+import arcs.core.data.SchemaRegistry
 import arcs.core.storage.api.DriverAndKeyConfigurator
 import arcs.core.storage.driver.RamDisk
 

--- a/javatests/arcs/android/systemhealth/testapp/TestEntity.kt
+++ b/javatests/arcs/android/systemhealth/testapp/TestEntity.kt
@@ -16,7 +16,7 @@ import arcs.core.data.RawEntity
 import arcs.core.data.Schema
 import arcs.core.data.SchemaFields
 import arcs.core.data.SchemaName
-import arcs.core.entity.SchemaRegistry
+import arcs.core.data.SchemaRegistry
 import arcs.core.storage.Reference
 import arcs.core.storage.keys.DatabaseStorageKey
 import arcs.core.storage.keys.RamDiskStorageKey

--- a/javatests/arcs/core/entity/EntityBaseTest.kt
+++ b/javatests/arcs/core/entity/EntityBaseTest.kt
@@ -17,6 +17,7 @@ import arcs.core.data.RawEntity
 import arcs.core.data.Schema
 import arcs.core.data.SchemaFields
 import arcs.core.data.Capability.Ttl
+import arcs.core.data.SchemaRegistry
 import arcs.core.data.util.toReferencable
 import arcs.core.storage.testutil.DummyStorageKey
 import arcs.core.storage.Reference as StorageReference

--- a/javatests/arcs/core/entity/HandleManagerCloseTest.kt
+++ b/javatests/arcs/core/entity/HandleManagerCloseTest.kt
@@ -5,6 +5,7 @@ import arcs.core.data.EntityType
 import arcs.core.data.HandleMode
 import arcs.core.data.SingletonType
 import arcs.core.data.Capability.Ttl
+import arcs.core.data.SchemaRegistry
 import arcs.core.entity.HandleManagerTestBase.Person
 import arcs.core.host.EntityHandleManager
 import arcs.core.storage.StorageKey

--- a/javatests/arcs/core/entity/HandleManagerTestBase.kt
+++ b/javatests/arcs/core/entity/HandleManagerTestBase.kt
@@ -13,6 +13,7 @@ import arcs.core.data.SchemaFields
 import arcs.core.data.SchemaName
 import arcs.core.data.SingletonType
 import arcs.core.data.Capability.Ttl
+import arcs.core.data.SchemaRegistry
 import arcs.core.data.util.ReferencableList
 import arcs.core.data.util.ReferencablePrimitive
 import arcs.core.data.util.toReferencable

--- a/javatests/arcs/core/entity/ReferenceTest.kt
+++ b/javatests/arcs/core/entity/ReferenceTest.kt
@@ -5,6 +5,7 @@ import arcs.core.data.EntityType
 import arcs.core.data.HandleMode
 import arcs.core.data.RawEntity
 import arcs.core.data.Schema
+import arcs.core.data.SchemaRegistry
 import arcs.core.host.EntityHandleManager
 import arcs.core.storage.DriverFactory
 import arcs.core.storage.api.DriverAndKeyConfigurator

--- a/javatests/arcs/core/entity/StorageAdapterTest.kt
+++ b/javatests/arcs/core/entity/StorageAdapterTest.kt
@@ -4,20 +4,18 @@ import arcs.core.common.Id
 import arcs.core.crdt.VersionMap
 import arcs.core.data.RawEntity.Companion.NO_REFERENCE_ID
 import arcs.core.data.Capability.Ttl
+import arcs.core.data.SchemaRegistry
 import arcs.core.data.util.toReferencable
 import arcs.core.storage.Reference as StorageReference
 import arcs.core.storage.StorageKey
 import arcs.core.storage.Store
-import arcs.core.storage.StoreManager
 import arcs.core.storage.keys.DatabaseStorageKey
 import arcs.core.storage.keys.RamDiskStorageKey
 import arcs.core.storage.referencemode.ReferenceModeStorageKey
 import arcs.core.storage.testutil.DummyStorageKey
-import arcs.core.util.Scheduler
 import arcs.jvm.util.testutil.FakeTime
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.test.assertFailsWith
 import org.junit.Before
 import org.junit.Test

--- a/javatests/arcs/core/entity/VariableEntityBaseTest.kt
+++ b/javatests/arcs/core/entity/VariableEntityBaseTest.kt
@@ -1,6 +1,7 @@
 package arcs.core.entity
 
 import arcs.core.crdt.VersionMap
+import arcs.core.data.SchemaRegistry
 import arcs.core.storage.testutil.DummyStorageKey
 import com.google.common.truth.Truth.assertThat
 import org.junit.After

--- a/javatests/arcs/sdk/spec/EntitySpecTest.kt
+++ b/javatests/arcs/sdk/spec/EntitySpecTest.kt
@@ -5,7 +5,7 @@ import arcs.core.data.RawEntity
 import arcs.core.data.RawEntity.Companion.NO_REFERENCE_ID
 import arcs.core.data.Capability.Ttl
 import arcs.core.data.util.toReferencable
-import arcs.core.entity.SchemaRegistry
+import arcs.core.data.SchemaRegistry
 import arcs.core.testutil.handles.dispatchCreateReference
 import arcs.core.testutil.handles.dispatchStore
 import arcs.core.testutil.runTest

--- a/src/tools/schema2kotlin.ts
+++ b/src/tools/schema2kotlin.ts
@@ -64,7 +64,7 @@ export class Schema2Kotlin extends Schema2Base {
         'import arcs.core.data.util.ReferencablePrimitive',
         'import arcs.core.entity.toPrimitiveValue',
         'import arcs.core.entity.Reference',
-        'import arcs.core.entity.SchemaRegistry',
+        'import arcs.core.data.SchemaRegistry',
         'import arcs.core.entity.Tuple1',
         'import arcs.core.entity.Tuple2',
         'import arcs.core.entity.Tuple3',

--- a/src/tools/tests/goldens/generated-schemas.jvm.kt
+++ b/src/tools/tests/goldens/generated-schemas.jvm.kt
@@ -9,10 +9,10 @@ package arcs.golden
 // Current implementation doesn't support optional field detection
 
 import arcs.core.data.*
+import arcs.core.data.SchemaRegistry
 import arcs.core.data.util.ReferencablePrimitive
 import arcs.core.data.util.toReferencable
 import arcs.core.entity.Reference
-import arcs.core.entity.SchemaRegistry
 import arcs.core.entity.Tuple1
 import arcs.core.entity.Tuple2
 import arcs.core.entity.Tuple3

--- a/src/tools/tests/goldens/kt_generated-schemas.jvm.kt
+++ b/src/tools/tests/goldens/kt_generated-schemas.jvm.kt
@@ -9,10 +9,10 @@ package arcs.golden
 // Current implementation doesn't support optional field detection
 
 import arcs.core.data.*
+import arcs.core.data.SchemaRegistry
 import arcs.core.data.util.ReferencablePrimitive
 import arcs.core.data.util.toReferencable
 import arcs.core.entity.Reference
-import arcs.core.entity.SchemaRegistry
 import arcs.core.entity.Tuple1
 import arcs.core.entity.Tuple2
 import arcs.core.entity.Tuple3


### PR DESCRIPTION
Also makes its API slightly nicer (return non-nullable).

I'll need to call SchemaRegistry from the data package in a future PR, so I need to move it to avoid circular deps.