### PR TITLE
Capture the error cause in ArcState for failing arcs.

### DIFF
--- a/java/arcs/android/sdk/host/IntentArcHostAdapter.kt
+++ b/java/arcs/android/sdk/host/IntentArcHostAdapter.kt
@@ -81,9 +81,9 @@ class IntentArcHostAdapter(
             partition.createLookupArcStatusIntent(hostComponentName, hostId)
         ) {
             try {
-                ArcState.valueOf(it.toString())
+                ArcState.fromString(it.toString())
             } catch (e: IllegalArgumentException) {
-                ArcState.Error
+                ArcState.errorWith(e)
             }
         } ?: ArcState.Error
     }
@@ -111,7 +111,7 @@ class IntentArcHostAdapter(
                 ) {
                     "Missing state in Intent for onArcStateChangeHandler callback."
                 }.let {
-                    ArcState.valueOf(it)
+                    ArcState.fromString(it)
                 }
                 block(arcId, arcState)
             }

--- a/java/arcs/core/allocator/Arc.kt
+++ b/java/arcs/core/allocator/Arc.kt
@@ -101,7 +101,7 @@ class Arc internal constructor(
 
     private fun recomputeArcState(states: Collection<ArcState>): ArcState {
         var commonState = ArcState.Indeterminate
-        for (state in states) {
+        states.forEach { state ->
             if (state == ArcState.Deleted || state == ArcState.Error) {
                 // Error states may carry an exception that caused the error;
                 // ensure this is kept when recomputing.

--- a/java/arcs/core/host/ArcHostContextParticle.kt
+++ b/java/arcs/core/host/ArcHostContextParticle.kt
@@ -74,7 +74,7 @@ class ArcHostContextParticle(
                 ArcHostContextParticle_Particles(
                     particleName = it.key,
                     location = it.value.planParticle.location,
-                    particleState = it.value.particleState.name,
+                    particleState = it.value.particleState.toString(),
                     consecutiveFailures = it.value.consecutiveFailureCount.toDouble(),
                     handles = connections.map { connection ->
                         handles.handleConnections.createReference(connection)
@@ -86,13 +86,13 @@ class ArcHostContextParticle(
             handles.particles.clear()
             particles.map { handles.particles.store(it) }.joinAll()
 
-            val arcState = AbstractArcHostContextParticle.ArcHostContext(
-                arcId = arcId, hostId = hostId, arcState = context.arcState.name,
+            val arcHostContext = AbstractArcHostContextParticle.ArcHostContext(
+                arcId = arcId, hostId = hostId, arcState = context.arcState.toString(),
                 particles = particles.map { handles.particles.createReference(it) }.toSet()
             )
 
             handles.arcHostContext.clear()
-            handles.arcHostContext.store(arcState).join()
+            handles.arcHostContext.store(arcHostContext).join()
         } catch (e: Exception) {
             // TODO: retry?
             throw IllegalStateException("Unable to serialize $arcId for $hostId", e)
@@ -135,7 +135,7 @@ class ArcHostContextParticle(
             return@onHandlesReady ArcHostContext(
                 arcId,
                 particles.toMutableMap(),
-                ArcState.valueOf(arcStateEntity.arcState),
+                ArcState.fromString(arcStateEntity.arcState),
                 entityHandleManager = arcHostContext.entityHandleManager
             )
         } catch (e: Exception) {

--- a/java/arcs/core/host/ArcState.kt
+++ b/java/arcs/core/host/ArcState.kt
@@ -11,47 +11,100 @@
 package arcs.core.host
 
 /**
+ * When an [Arc] in an error state is restarted after being serialized, this class is used to
+ * provide an exception attached to the error state object. The original exception type no longer
+ * matches, but information about the error is preserved to some extent.
+ */
+class DeserializedException(message: String) : Exception(message)
+
+/**
  * The current state of an [Arc] for a given [ArcHost]. An [Arc] may be in a different state
  * on each [ArcHost] at various times.
- *
  */
-enum class ArcState {
-    /**
-     * The [Arc] is inbetween [Stopped] and [Running] states, with some [ArcHost]s or
-     * [Particle]s started, and others not.
-     */
-    Indeterminate,
+data class ArcState private constructor(val state: State) {
 
-    /**
-     * The [Plan.Partition] is running on this particular [ArcHost]. An [Arc] is considered
-     * running if even one of its [ArcHost]s are in the [Running] state.
-     */
-    Running,
+    /** For ArcState.Error instances, this may hold an exception for the error. */
+    val cause: Exception?
+        get() = _cause
 
-    /**
-     * The [Plan.Partition] running on this particular [ArcHost] has been stopped, either because
-     * it was explicitly stopped, or the [ArcHost] was restarted, but the arc has not been
-     * resurrected yet. An [Arc] is considered stopped if and only if all of its participating
-     * [ArcHost]s have reached the [Stopped] state.
-     */
-    Stopped,
+    private var _cause: Exception? = null
 
-    /**
-     * This particular [ArcHost] has never started an [Arc] for this [Plan.Partition] yet.
-     */
-    NeverStarted,
+    override fun toString(): String {
+        return if (_cause != null) {
+            "${state.name}|$_cause"
+        } else {
+            state.name
+        }
+    }
 
-    /**
-     * The [Arc] could not be started for some reason, usually due to the failure of one of its
-     * [Particle]s to be instantiated properly.
-     */
-    Error,
+    enum class State {
+        /**
+         * The [Arc] is in between [Stopped] and [Running] states, with some [ArcHost]s or
+         * [Particle]s started, and others not.
+         */
+        Indeterminate,
 
-    /**
-     * [Deleted] implies [Stopped], but furthermore, subsequent attempts to restart this
-     * [Arc] will fail, and potentially any data used by the [Arc] may be reclaimed.
-     */
-    Deleted
+        /**
+         * The [Plan.Partition] is running on this particular [ArcHost]. An [Arc] is considered
+         * running if even one of its [ArcHost]s are in the [Running] state.
+         */
+        Running,
+
+        /**
+         * The [Plan.Partition] running on this particular [ArcHost] has been stopped, either
+         * because it was explicitly stopped, or the [ArcHost] was restarted, but the arc has
+         * not been resurrected yet. An [Arc] is considered stopped if and only if all of its
+         * participating [ArcHost]s have reached the [Stopped] state.
+         */
+        Stopped,
+
+        /**
+         * This particular [ArcHost] has never started an [Arc] for this [Plan.Partition] yet.
+         */
+        NeverStarted,
+
+        /**
+         * The [Arc] could not be started for some reason, usually due to the failure of one of its
+         * [Particle]s to be instantiated properly.
+         */
+        Error,
+
+        /**
+         * [Deleted] implies [Stopped], but furthermore, subsequent attempts to restart this
+         * [Arc] will fail, and potentially any data used by the [Arc] may be reclaimed.
+         */
+        Deleted
+    }
+
+    companion object {
+        val Indeterminate = ArcState(State.Indeterminate)
+        val Running = ArcState(State.Running)
+        val Stopped = ArcState(State.Stopped)
+        val NeverStarted = ArcState(State.NeverStarted)
+        val Error = ArcState(State.Error)
+        val Deleted = ArcState(State.Deleted)
+
+        /**
+         * Creates an ArcState.Error instance with an exception attached. Note that the exception
+         * is not included in equality comparisons, so two Error instances with different exceptions
+         * will still be considered equal, both to each other and to the singleton Error defined
+         * above.
+         */
+        fun errorWith(cause: Exception? = null) = ArcState(State.Error).apply { _cause = cause }
+
+        /**
+         * Creates an ArcState instance from the given string. For the Error case, this may have
+         * a reconstructed exception containing the original exception's toString result.
+         */
+        fun fromString(value: String): ArcState {
+            val parts = value.split("|", limit = 2)
+            return ArcState(State.valueOf(parts[0])).apply {
+                if (parts.size == 2) {
+                    _cause = DeserializedException(parts[1])
+                }
+            }
+        }
+    }
 }
 
 /**
@@ -59,48 +112,99 @@ enum class ArcState {
  * for some reason during the last time the [Arc] was started, and re-initialize them to the
  * needed state the next time the [Arc] is restarted.
  */
-enum class ParticleState {
-    /** Instantiated, but onFirstStart() has not been called. */
-    Instantiated,
-    /** onFirstStart() has been called, possibly in a previous execution session. */
-    FirstStart,
-    /** onStart() has been called; the particle is awaiting handle synchronization. */
-    Waiting,
-    /** onReady() has been called; the particle is ready for execution. */
-    Running,
-    /** onDesync() has been called; one or more handles have desynchronized from their storage. */
-    Desynced,
-    /** onStop() has been called; the arc is no longer executing. */
-    Stopped,
-    /**
-     * Previous attempt to start this particle failed, but it has previously started. In particular,
-     * we can transition from this state to [Waiting], but not [FirstStart] since the [onFirstStart]
-     * lifecycle has already executed.
-     */
-    Failed,
-    /**
-     * This particle has failed, but it has never succeeded yet. It is safe to transition to
-     * [FirstStart] from this state.
-     */
-    Failed_NeverStarted,
-    /** [Particle] has failed to start too many times and won't be started in this [Arc] anymore. */
-    MaxFailed;
-
+data class ParticleState private constructor(val state: State) {
     /**
      * Indicates whether a particle in this state has ever been created before (i.e. startup
      * succeeded at least once).
      */
     val hasBeenStarted: Boolean
-        get() = startedStates.contains(this)
+        get() = this in arrayOf(FirstStart, Waiting, Running, Desynced, Stopped, Failed)
 
     /**
      * Indicates whether the particle has failed during its lifecycle.
      */
     val failed: Boolean
-        get() = failedStates.contains(this)
+        get() = this in arrayOf(Failed, Failed_NeverStarted, MaxFailed)
+
+    /** For ParticleState failure instances, this may hold an exception for the error. */
+    val cause: Exception?
+        get() = _cause
+
+    private var _cause: Exception? = null
+
+    override fun toString(): String {
+        return if (_cause != null) {
+            "${state.name}|$_cause"
+        } else {
+            state.name
+        }
+    }
+
+    enum class State {
+        /** Instantiated, but onFirstStart() has not been called. */
+        Instantiated,
+
+        /** onFirstStart() has been called, possibly in a previous execution session. */
+        FirstStart,
+
+        /** onStart() has been called; the particle is awaiting handle synchronization. */
+        Waiting,
+
+        /** onReady() has been called; the particle is ready for execution. */
+        Running,
+
+        /** onDesync() has been called; one or more handles have desynchronized from storage. */
+        Desynced,
+
+        /** onStop() has been called; the arc is no longer executing. */
+        Stopped,
+
+        /**
+         * Previous attempt to start this particle failed, but it has previously started. In
+         * particular, we can transition from this state to [Waiting], but not [FirstStart] since
+         * the [onFirstStart] lifecycle has already executed.
+         */
+        Failed,
+
+        /**
+         * This particle has failed, but it has never succeeded yet. It is safe to transition to
+         * [FirstStart] from this state.
+         */
+        Failed_NeverStarted,
+
+        /**
+         * [Particle] has failed to start too many times and won't be started in this [Arc]
+         * anymore.
+         */
+        MaxFailed;
+    }
 
     companion object {
-        private val startedStates = arrayOf(FirstStart, Waiting, Running, Desynced, Stopped, Failed)
-        private val failedStates = arrayOf(Failed, Failed_NeverStarted, MaxFailed)
+        val Instantiated = ParticleState(State.Instantiated)
+        val FirstStart = ParticleState(State.FirstStart)
+        val Waiting = ParticleState(State.Waiting)
+        val Running = ParticleState(State.Running)
+        val Desynced = ParticleState(State.Desynced)
+        val Stopped = ParticleState(State.Stopped)
+        val Failed = ParticleState(State.Failed)
+        val Failed_NeverStarted = ParticleState(State.Failed_NeverStarted)
+        val MaxFailed = ParticleState(State.MaxFailed)
+
+        /**
+         * Creates a ParticleState.Failed instance with an exception attached. Note that the
+         * exception is not included in equality comparisons, so two Failed instances with different
+         * exceptions will still be considered equal, both to each other and to the singleton Failed
+         * defined above.
+         */
+        fun failedWith(cause: Exception? = null) =
+            ParticleState(State.Failed).apply { _cause = cause }
+
+        /** As per failedWith for ParticleState.Failed_NeverStarted. */
+        fun failedNeverStartedWith(cause: Exception? = null) =
+            ParticleState(State.Failed_NeverStarted).apply { _cause = cause }
+
+        /** As per failedWith for ParticleState.MaxFailed. */
+        fun maxFailedWith(cause: Exception? = null) =
+            ParticleState(State.MaxFailed).apply { _cause = cause }
     }
 }

--- a/java/arcs/core/host/generated/ArcHostContext.arcs
+++ b/java/arcs/core/host/generated/ArcHostContext.arcs
@@ -16,7 +16,7 @@ schema HandleConnection
 schema ParticleSchema
   particleName: Text
   location: Text
-  // ParticleState enum name
+  // ParticleState enum name and exception info for errors
   particleState: Text
   consecutiveFailures: Number
   handles: [&HandleConnection]
@@ -25,7 +25,7 @@ particle ArcHostContextParticle
   arcHostContext: reads writes ArcHostContext {
     arcId: Text,
     hostId: Text,
-    // ArcState enum name
+    // ArcState enum name and exception info for errors
     arcState: Text,
     particles: [&ParticleSchema]
   }

--- a/java/arcs/core/storage/StorageProxy.kt
+++ b/java/arcs/core/storage/StorageProxy.kt
@@ -317,12 +317,9 @@ class StorageProxy<Data : CrdtData, Op : CrdtOperationAtTime, T>(
         checkNotClosed()
         log.debug { "Getting particle view (lifecycle)" }
 
-        check(
-            stateHolder.value.state == ProxyState.SYNC ||
-                stateHolder.value.state == ProxyState.DESYNC
-        ) {
-            "Cannot get particle view directly while the storage proxy is unsynced; " +
-                "current state is ${stateHolder.value.state}"
+        check(stateHolder.value.state in arrayOf(ProxyState.SYNC, ProxyState.DESYNC)) {
+            "Read operations are not valid before onReady (storage proxy state is " +
+                    "${stateHolder.value.state})"
         }
 
         return crdt.consumerView

--- a/javatests/arcs/android/host/AndroidAllocatorTest.kt
+++ b/javatests/arcs/android/host/AndroidAllocatorTest.kt
@@ -173,7 +173,7 @@ open class AndroidAllocatorTest : AllocatorTestBase() {
         super.allocator_canStopArcInTwoExternalHosts()
     }
 
-    @Ignore("b/157266444 - Deflake")
+    //~ @Ignore("b/157266444 - Deflake")
     @Test
     override fun allocator_startArc_particleException_failsWaitForStart() {
         super.allocator_startArc_particleException_failsWaitForStart()

--- a/javatests/arcs/android/host/AndroidAllocatorTest.kt
+++ b/javatests/arcs/android/host/AndroidAllocatorTest.kt
@@ -173,6 +173,12 @@ open class AndroidAllocatorTest : AllocatorTestBase() {
         super.allocator_canStopArcInTwoExternalHosts()
     }
 
+    @Ignore("b/157266444 - Deflake")
+    @Test
+    override fun allocator_startArc_particleException_failsWaitForStart() {
+        super.allocator_startArc_particleException_failsWaitForStart()
+    }
+
     @Test
     fun arc_testHandlerRegistrationRace() = runAllocatorTest {
         val waitForIteration = CompletableDeferred<Unit>()

--- a/javatests/arcs/android/host/AndroidAllocatorTest.kt
+++ b/javatests/arcs/android/host/AndroidAllocatorTest.kt
@@ -173,7 +173,7 @@ open class AndroidAllocatorTest : AllocatorTestBase() {
         super.allocator_canStopArcInTwoExternalHosts()
     }
 
-    //~ @Ignore("b/157266444 - Deflake")
+    @Ignore("b/157266444 - Deflake")
     @Test
     override fun allocator_startArc_particleException_failsWaitForStart() {
         super.allocator_startArc_particleException_failsWaitForStart()

--- a/javatests/arcs/core/allocator/AllocatorTestBase.kt
+++ b/javatests/arcs/core/allocator/AllocatorTestBase.kt
@@ -8,6 +8,7 @@ import arcs.core.data.CreatableStorageKey
 import arcs.core.data.EntityType
 import arcs.core.data.Plan
 import arcs.core.host.ArcState
+import arcs.core.host.DeserializedException
 import arcs.core.host.EntityHandleManager
 import arcs.core.host.HostRegistry
 import arcs.core.host.ParticleNotFoundException

--- a/javatests/arcs/core/allocator/AllocatorTestBase.kt
+++ b/javatests/arcs/core/allocator/AllocatorTestBase.kt
@@ -25,6 +25,7 @@ import arcs.core.storage.driver.RamDisk
 import arcs.core.storage.driver.RamDiskDriverProvider
 import arcs.core.storage.driver.VolatileDriverProvider
 import arcs.core.testutil.assertSuspendingThrows
+import arcs.core.testutil.fail
 import arcs.core.util.Log
 import arcs.core.util.plus
 import arcs.core.util.testutil.LogRule
@@ -569,9 +570,14 @@ open class AllocatorTestBase {
         }
         // TODO(b//160933123): the containing exception is somehow "duplicated",
         //                     so the real cause is a second level down
-        error.cause!!.cause.let {
-            assertThat(it).isInstanceOf(IllegalArgumentException::class.java)
-            assertThat(it).hasMessageThat().isEqualTo("Boom!")
+        val cause = error.cause!!.cause
+        when (cause) {
+            // For CoreAllocatorTest
+            is IllegalArgumentException -> assertThat(cause.message).isEqualTo("Boom!")
+            // For AndroidAllocatorTest
+            is DeserializedException ->
+                assertThat(cause.message).isEqualTo("java.lang.IllegalArgumentException: Boom!")
+            else -> fail("Expected IllegalArgumentException or DeserializedException; got $cause")
         }
     }
 }

--- a/javatests/arcs/core/host/AbstractArcHostTest.kt
+++ b/javatests/arcs/core/host/AbstractArcHostTest.kt
@@ -34,6 +34,14 @@ open class AbstractArcHostTest {
             "TestParticle",
             mapOf("foo" to setOf(EntityBaseSpec(DummyEntity.SCHEMA)))
         )
+
+        override fun onFirstStart() {
+            if (failAtStart) throw IllegalStateException("boom")
+        }
+
+        companion object {
+            var failAtStart = false
+        }
     }
 
     class MyTestHost(
@@ -54,6 +62,7 @@ open class AbstractArcHostTest {
         RamDisk.clear()
         DriverAndKeyConfigurator.configureKeyParsers()
         RamDiskDriverProvider()
+        TestParticle.failAtStart = false
     }
 
     @Test
@@ -113,6 +122,41 @@ open class AbstractArcHostTest {
         // Should expire in 2 minutes.
         val expectedExpiry = 2 * 60 * 1000 + FakeTime().currentTimeMillis
         assertThat(entity.expirationTimestamp).isEqualTo(expectedExpiry)
+
+        schedulerProvider.cancelAll()
+    }
+
+    @Test
+    fun errorStateHoldsExceptionsFromParticles() = runBlocking {
+        TestParticle.failAtStart = true
+
+        val schedulerProvider = JvmSchedulerProvider(coroutineContext)
+        val host = MyTestHost(schedulerProvider, ::TestParticle.toRegistration())
+        val particle = Plan.Particle(
+            "Test",
+            "arcs.core.host.AbstractArcHostTest.TestParticle",
+            mapOf()
+        )
+        val partition = Plan.Partition("arcId", "arcHost", listOf(particle))
+        host.startArc(partition)
+
+        host.lookupArcHostStatus(partition).let {
+            assertThat(it).isEqualTo(ArcState.Error)
+            assertThat(it.cause).isInstanceOf(IllegalStateException::class.java)
+            assertThat(it.cause).hasMessageThat().isEqualTo("boom")
+        }
+
+        // Check that the error state persists across serialization.
+        host.pause()
+        host.clearCache()
+        host.unpause()
+
+        // The exact type of the exception is lost, but its toString form is retainted.
+        host.lookupArcHostStatus(partition).let {
+            assertThat(it).isEqualTo(ArcState.Error)
+            assertThat(it.cause).isInstanceOf(DeserializedException::class.java)
+            assertThat(it.cause).hasMessageThat().isEqualTo("java.lang.IllegalStateException: boom")
+        }
 
         schedulerProvider.cancelAll()
     }

--- a/javatests/arcs/core/host/LifecycleParticles.kt
+++ b/javatests/arcs/core/host/LifecycleParticles.kt
@@ -25,7 +25,7 @@ class SingleReadHandleParticle : AbstractSingleReadHandleParticle() {
         events.add("onShutdown")
     }
 
-    fun data() = handles.data.fetch()?.num.toString()
+    private fun data() = handles.data.fetch()?.num.toString()
 }
 
 class SingleWriteHandleParticle : AbstractSingleWriteHandleParticle() {
@@ -81,9 +81,9 @@ class MultiHandleParticle : AbstractMultiHandleParticle() {
         events.add("onShutdown")
     }
 
-    fun data() = handles.data.fetch()?.num.toString()
-    fun list() = handles.list.fetchAll().map { it.txt }.toSortedSet()
-    fun config() = handles.config.fetch()?.flg.toString()
+    private fun data() = handles.data.fetch()?.num.toString()
+    private fun list() = handles.list.fetchAll().map { it.txt }.toSortedSet()
+    private fun config() = handles.config.fetch()?.flg.toString()
 }
 
 class PausingParticle : AbstractPausingParticle() {
@@ -113,6 +113,119 @@ class PausingParticle : AbstractPausingParticle() {
         events.add("onShutdown")
     }
 
-    fun data() = handles.data.fetch()?.num.toString()
-    fun list() = handles.list.fetchAll().map { it.txt }.toSortedSet()
+    private fun data() = handles.data.fetch()?.num.toString()
+    private fun list() = handles.list.fetchAll().map { it.txt }.toSortedSet()
+}
+
+class ReadWriteAccessParticle : AbstractReadWriteAccessParticle() {
+    val errors = mutableListOf<String>()
+    private var method = ""
+    private val value = Value("x")
+
+    override fun onFirstStart() {
+        method = "onFirstStart"
+
+        // Reads are not valid now; writes are.
+        checkAllReadsFail()
+        checkAllWritesSucceed()
+
+        // Check that read ops work in the onReady listener for each readable handle.
+        handles.sngRead.onReady {
+            checkSuccess("sngRead.fetch") { handles.sngRead.fetch() }
+        }
+        handles.sngReadWrite.onReady {
+            checkSuccess("sngReadWrite.fetch") { handles.sngReadWrite.fetch() }
+        }
+        handles.colRead.onReady {
+            checkSuccess("colRead.fetchAll") { handles.colRead.fetchAll() }
+        }
+        handles.colReadWrite.onReady {
+            checkSuccess("colReadWrite.fetchAll") { handles.colReadWrite.fetchAll() }
+        }
+
+        // Check that entities stored now can be read back in onReady.
+        handles.sngPersist.store(Value("sng"))
+        handles.colPersist.store(Value("col"))
+    }
+
+    override fun onStart() {
+        method = "onStart"
+
+        // Reads are not valid now; writes are.
+        checkAllReadsFail()
+        checkAllWritesSucceed()
+    }
+
+    override fun onReady() {
+        method = "onReady"
+
+        // Reads and writes are valid now.
+        checkAllReadsSucceed()
+        checkAllWritesSucceed()
+
+        // Verify the entities stored in onFirstStart.
+        val sval = handles.sngPersist.fetch()
+        if (sval?.txt != "sng") {
+            errors.add("expected Value(txt = sng) in sngPersist; got $sval")
+        }
+        val cval = handles.colPersist.fetchAll().firstOrNull()
+        if (cval?.txt != "col") {
+            errors.add("expected Value(txt = col) in colPersist; got $cval")
+        }
+    }
+
+    private fun checkAllReadsFail() {
+        checkReadFailure("sngRead.fetch") { handles.sngRead.fetch() }
+        checkReadFailure("sngReadWrite.fetch") { handles.sngReadWrite.fetch() }
+        checkReadFailure("colRead.size") { handles.colRead.size() }
+        checkReadFailure("colRead.isEmpty") { handles.colRead.isEmpty() }
+        checkReadFailure("colRead.fetchAll") { handles.colRead.fetchAll() }
+        checkReadFailure("colReadWrite.size") { handles.colReadWrite.size() }
+        checkReadFailure("colReadWrite.isEmpty") { handles.colReadWrite.isEmpty() }
+        checkReadFailure("colReadWrite.fetchAll") { handles.colReadWrite.fetchAll() }
+    }
+
+    private fun checkAllReadsSucceed() {
+        checkSuccess("sngRead.fetch") { handles.sngRead.fetch() }
+        checkSuccess("sngReadWrite.fetch") { handles.sngReadWrite.fetch() }
+        checkSuccess("colRead.size") { handles.colRead.size() }
+        checkSuccess("colRead.isEmpty") { handles.colRead.isEmpty() }
+        checkSuccess("colRead.fetchAll") { handles.colRead.fetchAll() }
+        checkSuccess("colReadWrite.size") { handles.colReadWrite.size() }
+        checkSuccess("colReadWrite.isEmpty") { handles.colReadWrite.isEmpty() }
+        checkSuccess("colReadWrite.fetchAll") { handles.colReadWrite.fetchAll() }
+    }
+
+    private fun checkAllWritesSucceed() {
+        checkSuccess("sngWrite.store") { handles.sngWrite.store(value) }
+        checkSuccess("sngWrite.clear") { handles.sngWrite.clear() }
+        checkSuccess("sngReadWrite.store") { handles.sngReadWrite.store(value) }
+        checkSuccess("sngReadWrite.clear") { handles.sngReadWrite.clear() }
+        checkSuccess("colWrite.store") { handles.colWrite.store(value) }
+        checkSuccess("colWrite.remove") { handles.colWrite.remove(value) }
+        checkSuccess("colWrite.clear") { handles.colWrite.clear() }
+        checkSuccess("colReadWrite.store") { handles.colReadWrite.store(value) }
+        checkSuccess("colReadWrite.remove") { handles.colReadWrite.remove(value) }
+        checkSuccess("colReadWrite.clear") { handles.colReadWrite.clear() }
+    }
+
+    private fun checkReadFailure(action: String, block: () -> Unit) {
+        try {
+            block()
+            errors.add("$action should have failed in $method")
+        } catch (e: Exception) {
+            if (e !is IllegalStateException ||
+                    !e.message!!.startsWith("Read operations are not valid before onReady")) {
+                errors.add("$action failed with an unexpected exception type or message: $e")
+            }
+        }
+    }
+
+    private fun checkSuccess(action: String, block: () -> Unit) {
+        try {
+            block()
+        } catch (e: Exception) {
+            errors.add("$action failed unexpectedly in $method")
+        }
+    }
 }

--- a/javatests/arcs/core/host/LifecycleTest.kt
+++ b/javatests/arcs/core/host/LifecycleTest.kt
@@ -61,7 +61,8 @@ class LifecycleTest {
             ::SingleReadHandleParticle.toRegistration(),
             ::SingleWriteHandleParticle.toRegistration(),
             ::MultiHandleParticle.toRegistration(),
-            ::PausingParticle.toRegistration()
+            ::PausingParticle.toRegistration(),
+            ::ReadWriteAccessParticle.toRegistration()
         )
         hostRegistry = ExplicitHostRegistry().also { it.registerHost(testHost) }
         storeManager = StoreManager()
@@ -202,5 +203,13 @@ class LifecycleTest {
                 "onShutdown"
             )
         )
+    }
+
+    @Test
+    fun readWriteAccess() = runTest {
+        val name = "ReadWriteAccessParticle"
+        val arc = allocator.startArcForPlan(ReadWriteAccessTestPlan).waitForStart()
+        val particle: ReadWriteAccessParticle = testHost.getParticle(arc.id, name)
+        assertThat(particle.errors).isEmpty()
     }
 }

--- a/javatests/arcs/core/host/lifecycle.arcs
+++ b/javatests/arcs/core/host/lifecycle.arcs
@@ -44,3 +44,26 @@ recipe PausingTest
   PausingParticle
     data: reads h1
     list: reads h2
+
+// -----------------------------------------------------------------------------
+
+particle ReadWriteAccessParticle in 'arcs.core.host.ReadWriteAccessParticle'
+  sngRead: reads Value {txt: Text}
+  sngWrite: writes Value {txt: Text}
+  sngReadWrite: reads writes Value {txt: Text}
+  colRead: reads [Value {txt: Text}]
+  colWrite: writes [Value {txt: Text}]
+  colReadWrite: reads writes [Value {txt: Text}]
+  sngPersist: reads writes Value {txt: Text}
+  colPersist: reads writes [Value {txt: Text}]
+
+recipe ReadWriteAccessTest
+  ReadWriteAccessParticle
+    sngRead: reads h1
+    sngWrite: writes h1
+    sngReadWrite: reads writes h1
+    colRead: reads h2
+    colWrite: writes h2
+    colReadWrite: reads writes h2
+    sngPersist: reads writes h3
+    colPersist: reads writes h4


### PR DESCRIPTION
This allows errors in particles (like trying to read from a handle before onReady) to surface.

Also add unit tests for read/write access controls during particle startup.