### PR TITLE
Escalate Kotlin Warnings to Errors in CI only + Warnings Paydown.

### DIFF
--- a/tools/cloud-presubmit
+++ b/tools/cloud-presubmit
@@ -18,7 +18,7 @@ status "Testing all of the things."
 set -x
 
 ./tools/sigh webpack
-./tools/bazelisk ${BAZELRC_OPTS} test //java/... //javatests/... //src/... //particles/... -- -Werror
+./tools/bazelisk ${BAZELRC_OPTS} test //java/... //javatests/... //src/... //particles/... --worker_extra_flag=kotlin=-Werror
 ./tools/sigh testShells
 ./tools/sigh lint
 ./tools/sigh test --all

--- a/tools/cloud-presubmit
+++ b/tools/cloud-presubmit
@@ -18,7 +18,7 @@ status "Testing all of the things."
 set -x
 
 ./tools/sigh webpack
-./tools/bazelisk ${BAZELRC_OPTS} test //java/... //javatests/... //src/... //particles/...
+./tools/bazelisk ${BAZELRC_OPTS} test //java/... //javatests/... //src/... //particles/... -- -Werror
 ./tools/sigh testShells
 ./tools/sigh lint
 ./tools/sigh test --all


### PR DESCRIPTION
## Notes
- Feedback from Shane, Walter, and Myk and unknown others: A key constraint in this experiment is to not mess with anyone's development workflow. This change should affect CI (and maybe presubmit) checks only. 
- The Kotlin compiler uses `-Werror` to promote warnings to errors. Thus, the problem reduces to finding a good way to pass this argument to the compiler from our Bazel build invocation. 