### PR TITLE
Fix unbounded Store leaks

### DIFF
--- a/java/arcs/core/storage/DirectStoreMuxer.kt
+++ b/java/arcs/core/storage/DirectStoreMuxer.kt
@@ -52,9 +52,8 @@ class DirectStoreMuxer<Data : CrdtData, Op : CrdtOperation, T>(
         if (!storeRecord.store.closed) {
             log.debug { "close the store(${storeRecord.id})" }
 
-            // The store will be actually closed as soon as there are no connected proxies.
             try {
-                storeRecord.store.off(storeRecord.id)
+                storeRecord.store.close()
             } catch (e: Exception) {
                 // TODO(b/160251910): Make logging detail more cleanly conditional.
                 log.debug(e) { "failed to close the store(${storeRecord.id})" }


### PR DESCRIPTION
#5588 removed the `closeInternal` at `DirectStoreMuxer.off` which are used to either clear all Stores cache or evict lru ones
ends up Stores cache becomes unbounded over time, this PR addresses this.

This PR should be copybara'd and cherry-picked to Q.21 asap.