### PR TITLE
Improve policy translation API

### DIFF
--- a/java/arcs/core/analysis/InformationFlow.kt
+++ b/java/arcs/core/analysis/InformationFlow.kt
@@ -408,12 +408,12 @@ class InformationFlow private constructor(
 
 /** Returns the instantiated [List<Claim>] for this particle. */
 private fun RecipeGraph.Node.Particle.instantiatedClaims(): List<Claim> {
-    return claims.map { it.instantiateFor(particle) }
+    return particle.spec.claims.map { it.instantiateFor(particle) }
 }
 
 /** Returns the instantiated [List<Check>] for this particle. */
 private fun RecipeGraph.Node.Particle.instantiatedChecks(): List<Check> {
-    return checks.map { it.instantiateFor(particle) }
+    return particle.spec.checks.map { it.instantiateFor(particle) }
 }
 
 /** Return the [InformationFlowLabel] occurrences in the predicate. */

--- a/java/arcs/core/analysis/RecipeGraph.kt
+++ b/java/arcs/core/analysis/RecipeGraph.kt
@@ -11,8 +11,6 @@
 
 package arcs.core.analysis
 
-import arcs.core.data.Check
-import arcs.core.data.Claim
 import arcs.core.data.HandleConnectionSpec
 import arcs.core.data.HandleMode
 import arcs.core.data.Recipe
@@ -95,17 +93,7 @@ data class RecipeGraph(
         }
 
         /** A node representing a particle. */
-        data class Particle(
-            val particle: Recipe.Particle,
-            val claims: List<Claim>,
-            val checks: List<Check>
-        ) : Node() {
-            constructor(particle: Recipe.Particle) : this(
-                particle,
-                particle.spec.claims,
-                particle.spec.checks
-            )
-
+        data class Particle(val particle: Recipe.Particle) : Node() {
             val particleName = particle.spec.name
 
             override val debugName = "p:$particleName"

--- a/java/arcs/core/analysis/RecipeGraph.kt
+++ b/java/arcs/core/analysis/RecipeGraph.kt
@@ -23,11 +23,10 @@ import arcs.core.data.Recipe
  * `p -s-> h` in the graph. Similarly, for every read connection from a particle `p` to a handle `h`
  * using a connection spec `s`, there is a labeled edge `h -s-> p` in the graph.
 */
-data class RecipeGraph(
-    val particleNodes: List<Node.Particle>,
-    val handleNodes: List<Node.Handle>
-) {
-    val nodes: List<Node> = particleNodes + handleNodes
+data class RecipeGraph(val recipe: Recipe) {
+    val nodes: List<Node> = convertRecipeToNodes(recipe)
+    val particleNodes: List<Node.Particle> = nodes.filterIsInstance<Node.Particle>()
+    val handleNodes: List<Node.Handle> = nodes.filterIsInstance<Node.Handle>()
 
     /**
      * A class representing the properties of a join.
@@ -110,13 +109,13 @@ data class RecipeGraph(
     }
 
     companion object {
-        /** Factory method to convert a [Recipe] into a [RecipeGraph]. */
-        operator fun invoke(recipe: Recipe): RecipeGraph {
+        /** Converts the given [recipe] to [Node]s. */
+        fun convertRecipeToNodes(recipe: Recipe): List<Node> {
             val handleNodesMap = recipe.handles.mapValues { (_, handle) -> Node.Handle(handle) }
             val handleNodes = handleNodesMap.values.toList()
             handleNodes.forEach { it.addJoinEdges(handleNodesMap) }
             val particleNodes = recipe.particles.map { it.getNode(handleNodesMap) as Node.Particle }
-            return RecipeGraph(particleNodes, handleNodes)
+            return particleNodes + handleNodes
         }
 
         /**

--- a/java/arcs/core/policy/BUILD
+++ b/java/arcs/core/policy/BUILD
@@ -11,7 +11,6 @@ arcs_kt_library(
     name = "policy",
     srcs = glob(["*.kt"]),
     deps = [
-        "//java/arcs/core/analysis",
         "//java/arcs/core/data",
     ],
 )

--- a/javatests/arcs/core/policy/PolicyConstraintsTest.kt
+++ b/javatests/arcs/core/policy/PolicyConstraintsTest.kt
@@ -1,6 +1,5 @@
 package arcs.core.policy
 
-import arcs.core.analysis.RecipeGraph
 import arcs.core.data.AccessPath
 import arcs.core.data.Check
 import arcs.core.data.HandleConnectionSpec
@@ -19,7 +18,7 @@ import org.junit.runners.JUnit4
 import kotlin.test.assertFailsWith
 
 @RunWith(JUnit4::class)
-class PolicyTranslationTest {
+class PolicyConstraintsTest {
     // Loaded from binary proto, maps all keyed by name.
     private lateinit var recipes: Map<String, Recipe>
     private lateinit var policies: Map<String, Policy>
@@ -35,36 +34,36 @@ class PolicyTranslationTest {
 
     @Test
     fun applyPolicy_checksEgressParticles_acceptsIsolatedParticles() {
-        val graph = createRecipeGraph(
+        val recipe = createRecipe(
             createParticle("Isolated1", isolated = true),
             createParticle("Isolated2", isolated = true)
         )
 
-        val result = applyPolicy(BLANK_POLICY, graph)
+        val result = translatePolicy(BLANK_POLICY, recipe)
 
-        assertThat(result).isEqualTo(graph)
+        assertThat(result).isEqualTo(
+            PolicyConstraints(BLANK_POLICY, recipe, emptyMap())
+        )
     }
 
     @Test
     fun applyPolicy_checksEgressParticles_acceptsValidEgressParticles() {
-        val graph = createRecipeGraph(
+        val recipe = createRecipe(
             createParticle(BLANK_EGRESS_PARTICLE_NAME, isolated = false)
         )
 
-        val result = applyPolicy(BLANK_POLICY, graph)
-
-        assertThat(result).isEqualTo(graph)
+        translatePolicy(BLANK_POLICY, recipe)
     }
 
     @Test
     fun applyPolicy_checksEgressParticles_rejectsInvalidEgressParticles() {
-        val graph = createRecipeGraph(
+        val recipe = createRecipe(
             createParticle("Egress1", isolated = false),
             createParticle("Egress2", isolated = false)
         )
 
         val e = assertFailsWith<PolicyViolation.InvalidEgressParticle> {
-            applyPolicy(BLANK_POLICY, graph)
+            translatePolicy(BLANK_POLICY, recipe)
         }
         assertThat(e.policy).isEqualTo(BLANK_POLICY)
         assertThat(e.particleNames).containsExactly("Egress1", "Egress2")
@@ -72,13 +71,13 @@ class PolicyTranslationTest {
 
     @Test
     fun applyPolicy_checksEgressParticles_rejectsMultipleEgressParticles() {
-        val graph = createRecipeGraph(
+        val recipe = createRecipe(
             createParticle(BLANK_EGRESS_PARTICLE_NAME, isolated = false),
             createParticle(BLANK_EGRESS_PARTICLE_NAME, isolated = false)
         )
 
         val e = assertFailsWith<PolicyViolation.MultipleEgressParticles> {
-            applyPolicy(BLANK_POLICY, graph)
+            translatePolicy(BLANK_POLICY, recipe)
         }
         assertThat(e.policy).isEqualTo(BLANK_POLICY)
     }
@@ -88,18 +87,19 @@ class PolicyTranslationTest {
         val policy = BLANK_POLICY.copy(name = "SingleInput")
         val recipe = recipes.getValue("SingleInput")
         val particle = recipe.particles.single()
-        val graph = RecipeGraph(recipe)
 
-        val result = applyPolicy(policy, graph)
+        val result = translatePolicy(policy, recipe)
 
-        val particleNode = result.particleNodes.single()
-        assertThat(particleNode.checks).containsExactly(
-            Check.Assert(
-                AccessPath(AccessPath.Root.HandleConnection(
-                    particle,
-                    particle.spec.connections.values.single())
-                ),
-                labelPredicate("allowedForEgress")
+        assertThat(result.egressChecks).containsExactly(
+            particle,
+            listOf(
+                Check.Assert(
+                    AccessPath(AccessPath.Root.HandleConnection(
+                        particle,
+                        particle.spec.connections.values.single())
+                    ),
+                    labelPredicate("allowedForEgress")
+                )
             )
         )
     }
@@ -108,12 +108,10 @@ class PolicyTranslationTest {
     fun applyPolicy_egressCheck_withRedactionLabels() {
         val policy = policies.getValue("FooRedactions")
         val recipe = recipes.getValue("SingleInput").forceMatchPolicyName("FooRedactions")
-        val graph = RecipeGraph(recipe)
 
-        val result = applyPolicy(policy, graph)
-
-        val particleNode = result.particleNodes.single()
-        val check = particleNode.checks.single() as Check.Assert
+        val result = translatePolicy(policy, recipe)
+        
+        val check = result.egressChecks.values.single().single() as Check.Assert
         assertThat(check.predicate).isEqualTo(
             Predicate.or(
                 labelPredicate("allowedForEgress"),
@@ -125,28 +123,14 @@ class PolicyTranslationTest {
     }
 
     @Test
-    fun applyPolicy_egressCheck_preservesExistingChecks() {
-        val policy = BLANK_POLICY.copy(name = "ExistingChecks")
-        val recipe = recipes.getValue("ExistingChecks")
-        val graph = RecipeGraph(recipe)
-
-        val result = applyPolicy(policy, graph)
-
-        val particleNode = result.particleNodes.single()
-        val checkPredicates = particleNode.checks.map { (it as Check.Assert).predicate }
-        assertThat(checkPredicates).contains(labelPredicate("existing"))
-    }
-
-    @Test
     fun applyPolicy_egressCheck_ignoresWriteOnlyConnections() {
         val policy = BLANK_POLICY.copy(name = "SingleOutput")
         val recipe = recipes.getValue("SingleOutput")
-        val graph = RecipeGraph(recipe)
 
-        val result = applyPolicy(policy, graph)
+        val result = translatePolicy(policy, recipe)
 
-        val particleNode = result.particleNodes.single()
-        assertThat(particleNode.checks).isEmpty()
+        val particle = recipe.particles.single()
+        assertThat(result.egressChecks).containsExactly(particle, emptyList<Check>())
     }
 
     companion object {
@@ -171,13 +155,11 @@ class PolicyTranslationTest {
             )
         }
 
-        private fun createRecipeGraph(vararg particles: Recipe.Particle): RecipeGraph {
-            return RecipeGraph(
-                Recipe(
-                    name = "Recipe",
-                    handles = emptyMap(),
-                    particles = particles.toList()
-                )
+        private fun createRecipe(vararg particles: Recipe.Particle): Recipe {
+            return Recipe(
+                name = "Recipe",
+                handles = emptyMap(),
+                particles = particles.toList()
             )
         }
 


### PR DESCRIPTION
Now returns additional checks/claims rather than mutating a RecipeGraph. Reverted previous changes to RecipeGraph where claims/checks could be added to nodes -- mutating a graph was more subtle and error prone than that...