### PR TITLE
Encode the full field path in PolicyField, not just the field name

### DIFF
--- a/java/arcs/core/policy/Policy.kt
+++ b/java/arcs/core/policy/Policy.kt
@@ -71,15 +71,24 @@ data class PolicyTarget(
 
 /** Allowed usages for fields in a schema, see [PolicyFieldProto]. */
 data class PolicyField(
-    // TODO(b/157605232): Resolve the field name to a type.
-    val fieldName: String,
+    /** List of field names leading from the [PolicyTarget] to this nested field. */
+    val fieldPath: List<String>,
     /** Valid usages of this field without redaction. */
     val rawUsages: Set<UsageType> = emptySet(),
     /** Valid usages of this field with redaction first. Maps from redaction label to usages. */
     val redactedUsages: Map<String, Set<UsageType>> = emptyMap(),
     val subfields: List<PolicyField> = emptyList(),
     val annotations: List<Annotation> = emptyList()
-)
+) {
+    init {
+        subfields.forEach { subfield ->
+            require(subfield.fieldPath.subList(0, subfield.fieldPath.size - 1) == fieldPath) {
+                "Subfield's field path must be nested inside parent's field path, " +
+                    "but got parent: '$fieldPath', child: '${subfield.fieldPath}'."
+            }
+        }
+    }
+}
 
 /** Retention options for storing data, see [PolicyRetentionProto]. */
 data class PolicyRetention(

--- a/java/arcs/core/policy/Policy.kt
+++ b/java/arcs/core/policy/Policy.kt
@@ -14,6 +14,7 @@ package arcs.core.policy
 import arcs.core.data.Annotation
 import arcs.core.data.Capabilities
 import arcs.core.data.Capability
+import arcs.core.data.FieldName
 
 /** Defines a data usage policy. See [PolicyProto] for the canonical definition of a policy. */
 data class Policy(
@@ -72,7 +73,7 @@ data class PolicyTarget(
 /** Allowed usages for fields in a schema, see [PolicyFieldProto]. */
 data class PolicyField(
     /** List of field names leading from the [PolicyTarget] to this nested field. */
-    val fieldPath: List<String>,
+    val fieldPath: List<FieldName>,
     /** Valid usages of this field without redaction. */
     val rawUsages: Set<UsageType> = emptySet(),
     /** Valid usages of this field with redaction first. Maps from redaction label to usages. */

--- a/java/arcs/core/policy/proto/PolicyProto.kt
+++ b/java/arcs/core/policy/proto/PolicyProto.kt
@@ -48,7 +48,7 @@ private fun PolicyTargetProto.decode(): PolicyTarget {
     )
 }
 
-private fun PolicyFieldProto.decode(): PolicyField {
+private fun PolicyFieldProto.decode(parentFieldPath: List<String> = emptyList()): PolicyField {
     val rawUsages = mutableSetOf<UsageType>()
     val redactedUsages = mutableMapOf<String, MutableSet<UsageType>>()
     for (usage in usagesList) {
@@ -60,11 +60,12 @@ private fun PolicyFieldProto.decode(): PolicyField {
             }.add(usage.usage.decode())
         }
     }
+    val fieldPath = parentFieldPath + name
     return PolicyField(
-        fieldName = name,
+        fieldPath = fieldPath,
         rawUsages = rawUsages,
         redactedUsages = redactedUsages,
-        subfields = subfieldsList.map { it.decode() },
+        subfields = subfieldsList.map { it.decode(fieldPath) },
         annotations = annotationsList.map { it.decode() }
     )
 }

--- a/java/arcs/core/policy/proto/PolicyProto.kt
+++ b/java/arcs/core/policy/proto/PolicyProto.kt
@@ -11,6 +11,7 @@
 
 package arcs.core.policy.proto
 
+import arcs.core.data.FieldName
 import arcs.core.data.proto.PolicyFieldProto
 import arcs.core.data.proto.PolicyProto
 import arcs.core.data.proto.PolicyRetentionProto
@@ -48,7 +49,7 @@ private fun PolicyTargetProto.decode(): PolicyTarget {
     )
 }
 
-private fun PolicyFieldProto.decode(parentFieldPath: List<String> = emptyList()): PolicyField {
+private fun PolicyFieldProto.decode(parentFieldPath: List<FieldName> = emptyList()): PolicyField {
     val rawUsages = mutableSetOf<UsageType>()
     val redactedUsages = mutableMapOf<String, MutableSet<UsageType>>()
     for (usage in usagesList) {

--- a/javatests/arcs/core/policy/PolicyTest.kt
+++ b/javatests/arcs/core/policy/PolicyTest.kt
@@ -5,6 +5,7 @@ import arcs.core.data.Capability.Encryption
 import arcs.core.data.Capability.Persistence
 import arcs.core.data.Capability.Ttl
 import com.google.common.truth.Truth.assertThat
+import kotlin.test.assertFailsWith
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4

--- a/javatests/arcs/core/policy/PolicyTest.kt
+++ b/javatests/arcs/core/policy/PolicyTest.kt
@@ -37,10 +37,11 @@ class PolicyTest {
         ).isTrue()
     }
 
+    @Test
     fun policy_allFields() {
-        val child = PolicyField("child")
-        val parent = PolicyField("parent", subfields = listOf(child))
-        val other = PolicyField("other")
+        val child = PolicyField(listOf("parent", "child"))
+        val parent = PolicyField(listOf("parent"), subfields = listOf(child))
+        val other = PolicyField(listOf("other"))
         val policy = Policy(
             name = "MyPolicy",
             targets = listOf(
@@ -56,14 +57,14 @@ class PolicyTest {
     @Test
     fun policy_allRedactionLabels() {
         val child = PolicyField(
-            fieldName = "child",
+            fieldPath = listOf("parent", "child"),
             redactedUsages = mapOf(
                 "label1" to setOf(UsageType.EGRESS),
                 "label2" to setOf(UsageType.JOIN)
             )
         )
         val parent = PolicyField(
-            fieldName = "parent",
+            fieldPath = listOf("parent"),
             subfields = listOf(child),
             redactedUsages = mapOf(
                 "label2" to setOf(UsageType.EGRESS),
@@ -71,7 +72,7 @@ class PolicyTest {
             )
         )
         val other = PolicyField(
-            fieldName = "other",
+            fieldPath = listOf("other"),
             redactedUsages = mapOf("label4" to setOf(UsageType.EGRESS))
         )
         val policy = Policy(
@@ -89,5 +90,29 @@ class PolicyTest {
             "label3",
             "label4"
         )
+    }
+
+    @Test
+    fun policyField_fieldPathMustBeNestedInsideParent() {
+        val childWithRightParent = PolicyField(
+            fieldPath = listOf("correct", "child")
+        )
+        val childWithWrongParent = PolicyField(
+            fieldPath = listOf("incorrect", "child")
+        )
+
+        // Passes:
+        PolicyField(
+            fieldPath = listOf("correct"),
+            subfields = listOf(childWithRightParent)
+        )
+
+        // Fails:
+        assertFailsWith<IllegalArgumentException> {
+            PolicyField(
+                fieldPath = listOf("correct"),
+                subfields = listOf(childWithWrongParent)
+            )
+        }
     }
 }

--- a/javatests/arcs/core/policy/proto/PolicyProtoTest.kt
+++ b/javatests/arcs/core/policy/proto/PolicyProtoTest.kt
@@ -127,7 +127,7 @@ class PolicyProtoTest {
         val policy = proto.decode()
 
         val expected = PolicyField(
-            fieldName = "field",
+            fieldPath = listOf("field"),
             rawUsages = setOf(UsageType.JOIN),
             redactedUsages = mapOf("label" to setOf(UsageType.EGRESS, UsageType.JOIN)),
             subfields = emptyList(),
@@ -157,12 +157,12 @@ class PolicyProtoTest {
         val policy = proto.decode()
 
         val expected = PolicyField(
-            fieldName = "parent",
+            fieldPath = listOf("parent"),
             rawUsages = emptySet(),
             redactedUsages = emptyMap(),
             subfields = listOf(
                 PolicyField(
-                    fieldName = "child",
+                    fieldPath = listOf("parent", "child"),
                     rawUsages = emptySet(),
                     redactedUsages = emptyMap(),
                     subfields = emptyList(),


### PR DESCRIPTION
This ensures that equality tests between different fields works correctly (they might have different nesting), and makes creating AccessPaths for them much easier.