### PR TITLE
Generates claims for stores

### DIFF
--- a/java/arcs/core/policy/Policy.kt
+++ b/java/arcs/core/policy/Policy.kt
@@ -120,9 +120,7 @@ enum class UsageType {
 }
 
 /** Convenience method for checking if any usage in a set allows egress. */
-fun Set<UsageType>.canEgress(): Boolean {
-    return any { it.canEgress }
-}
+fun Set<UsageType>.canEgress(): Boolean = any { it.canEgress }
 
 /** Target schema governed by a policy, see [PolicyRetentionProto.Medium]. */
 enum class StorageMedium {

--- a/java/arcs/core/policy/Policy.kt
+++ b/java/arcs/core/policy/Policy.kt
@@ -113,7 +113,15 @@ enum class EgressType {
 enum class UsageType {
     ANY,
     EGRESS,
-    JOIN,
+    JOIN;
+
+    val canEgress
+        get() = this == ANY || this == EGRESS
+}
+
+/** Convenience method for checking if any usage in a set allows egress. */
+fun Set<UsageType>.canEgress(): Boolean {
+    return any { it.canEgress }
 }
 
 /** Target schema governed by a policy, see [PolicyRetentionProto.Medium]. */

--- a/java/arcs/core/policy/PolicyConstraints.kt
+++ b/java/arcs/core/policy/PolicyConstraints.kt
@@ -2,9 +2,12 @@ package arcs.core.policy
 
 import arcs.core.data.AccessPath
 import arcs.core.data.Check
+import arcs.core.data.Claim
 import arcs.core.data.InformationFlowLabel.Predicate
 import arcs.core.data.InformationFlowLabel.SemanticTag
 import arcs.core.data.Recipe
+
+typealias StoreId = String
 
 /**
  * Additional checks and claims that should be added to the particles in a recipe, which together
@@ -13,18 +16,24 @@ import arcs.core.data.Recipe
 data class PolicyConstraints(
     val policy: Policy,
     val recipe: Recipe,
-    val egressChecks: Map<Recipe.Particle, List<Check>>
-    // TODO(b/157605232): Add store claims.
+    val egressChecks: Map<Recipe.Particle, List<Check>>,
+    val storeClaims: Map<StoreId, List<Claim>>
 )
 
 /**
  * Translates the given [policy] into dataflow analysis checks and claims, which are to be added to
  * the particles from the given [recipe].
  *
+ * @param storeMap Maps from store ID to the schema name of the type it stores.
+ *
  * @return additional checks and claims for the particles as a [PolicyConstraints] object
  * @throws PolicyViolation if the [particles] violate the [policy]
  */
-fun translatePolicy(policy: Policy, recipe: Recipe): PolicyConstraints {
+fun translatePolicy(
+    policy: Policy,
+    recipe: Recipe,
+    storeMap: Map<StoreId, String>
+): PolicyConstraints {
     val egressParticles = recipe.particles.filterNot { it.spec.isolated }
     checkEgressParticles(policy, egressParticles)
 
@@ -43,8 +52,69 @@ fun translatePolicy(policy: Policy, recipe: Recipe): PolicyConstraints {
             }
     }
 
-    // TODO(b/157605232): Add store claims.
-    return PolicyConstraints(policy, recipe, egressChecks)
+    // Add claim statements for stores.
+    val targetBySchemaName = policy.targets.associateBy { it.schemaName }
+    val storeClaims = recipe.handles.values.filter { storeMap.containsKey(it.id) }
+        .associate { handle ->
+            val storeId = handle.id
+            val claims = storeMap[storeId]?.let { schemaName ->
+                targetBySchemaName[schemaName]?.let { target ->
+                    createClaims(handle, target)
+                }
+            }
+            handle.id to (claims ?: emptyList())
+        }
+        .filterValues { it.isNotEmpty() }
+
+    return PolicyConstraints(policy, recipe, egressChecks, storeClaims)
+}
+
+/** Returns a list of store [Claim]s for the given [handle] and corresponding [target]. */
+private fun createClaims(handle: Recipe.Handle, target: PolicyTarget): List<Claim> {
+    return target.fields.flatMap { field -> createClaims(handle, field) }
+}
+
+/**
+ * Returns a list of claims for the given [field] (and all subfields), using the given [handle]
+ * as the root for the claims.
+ */
+private fun createClaims(handle: Recipe.Handle, field: PolicyField): List<Claim> {
+    val claims = mutableListOf<Claim>()
+
+    // Create claim for this field.
+    val predicate = createStoreClaimPredicate(field)
+    if (predicate != null) {
+        val selectors = field.fieldPath.map { AccessPath.Selector.Field(it) }
+        // TODO(b/157605232): This AccessPath is rooted by the handle's name in the recipe. The name
+        // might not be the same across different recipes, so this needs to be store ID instead.
+        val accessPath = AccessPath(handle, selectors)
+        claims.add(Claim.Assume(accessPath, predicate))
+    }
+
+    // Add claims for subfields.
+    field.subfields.flatMapTo(claims) { subfield -> createClaims(handle, subfield) }
+
+    return claims
+}
+
+/**
+ * Constructs the [Predicate] for the given [field] in a [Policy], to be used in constructing
+ * [Claim]s on the corresponding handles for the field in a recipe.
+ */
+private fun createStoreClaimPredicate(field: PolicyField): Predicate? {
+    val predicates = mutableListOf<Predicate>()
+    if (field.rawUsages.canEgress()) {
+        predicates.add(labelPredicate(ALLOWED_FOR_EGRESS_LABEL))
+    }
+    val egressRedactionLabels = field.redactedUsages.filterValues { it.canEgress() }.keys
+    egressRedactionLabels.forEach { label ->
+        predicates.add(labelPredicate("${ALLOWED_FOR_EGRESS_LABEL}_$label"))
+    }
+    return when (predicates.size) {
+        0 -> null
+        1 -> predicates.single()
+        else -> Predicate.and(*predicates.toTypedArray())
+    }
 }
 
 /**

--- a/java/arcs/core/policy/PolicyConstraints.kt
+++ b/java/arcs/core/policy/PolicyConstraints.kt
@@ -82,8 +82,7 @@ private fun createClaims(handle: Recipe.Handle, field: PolicyField): List<Claim>
     val claims = mutableListOf<Claim>()
 
     // Create claim for this field.
-    val predicate = createStoreClaimPredicate(field)
-    if (predicate != null) {
+    createStoreClaimPredicate(field)?.let { predicate ->
         val selectors = field.fieldPath.map { AccessPath.Selector.Field(it) }
         // TODO(b/157605232): This AccessPath is rooted by the handle's name in the recipe. The name
         // might not be the same across different recipes, so this needs to be store ID instead.

--- a/javatests/arcs/core/policy/PolicyTranslationTestData.arcs
+++ b/javatests/arcs/core/policy/PolicyTranslationTestData.arcs
@@ -1,13 +1,16 @@
 // Test data for PolicyTranslationTest.
 
-// An empty policy.
-@egressType('Logging')
-policy BlankPolicy {}
-
 schema Foo
   a: Text
   b: Number
   c: Boolean
+
+schema Bar
+  a: Text
+
+schema NestedFooBar
+  foo: &Foo {a, b, c}
+  bar: &Bar {a}
 
 // Particle with a single input.
 particle Egress_SingleInput
@@ -30,6 +33,42 @@ policy FooRedactions {
   }
 }
 
+// Policy allows access only to field a with redactions redaction1.
+@egressType('Logging')
+policy SingleFooRedaction {
+  from Foo access {
+    @allowedUsage(label: 'redaction1', usageType: 'egress')
+    a,
+  }
+}
+
+// Policy allows access only to field a by joins.
+@egressType('Logging')
+policy FooJoinPolicy {
+  from Foo access {
+    @allowedUsage(label: 'raw', usageType: 'join')
+    a,
+  }
+}
+
+// Policy allows access only to field a with redactions redaction1.
+@egressType('Logging')
+policy SingleBarRedaction {
+  from Bar access {
+    @allowedUsage(label: 'redaction1', usageType: 'egress')
+    a,
+  }
+}
+
+// Policy allows access to fields a, b, c with redactions redaction1, redaction2, redaction3.
+@egressType('Logging')
+policy NestedFooBarPolicy {
+  from NestedFooBar access {
+    foo { a, b, c }
+    bar { a }
+  }
+}
+
 // Particle with existing checks.
 particle Egress_ExistingChecks
   input: reads Foo {}
@@ -46,3 +85,9 @@ recipe SingleOutput
   output: create
   Egress_SingleOutput
     output: output
+
+// Recipe with a single mapped input.
+recipe SingleMappedInput
+  input: map 'my_store_id'
+  Egress_SingleInput
+    input: input


### PR DESCRIPTION
Accepts a `storeMap` parameter which dictates which handles in the recipe are to receive claims. We've deferred for now the logic to figure out what those handles are.