### PR TITLE
Making the syshelath app able to evaluate all threading models

### DIFF
--- a/javatests/arcs/android/systemhealth/testapp/AndroidManifest.xml
+++ b/javatests/arcs/android/systemhealth/testapp/AndroidManifest.xml
@@ -40,6 +40,11 @@
     </activity>
 
     <service
+      android:name="arcs.sdk.android.storage.service.StorageService"
+      android:exported="false"
+      tools:node="replace"/>
+
+    <service
       android:name=".PerformanceStorageService"
       android:exported="false"/>
 

--- a/javatests/arcs/android/systemhealth/testapp/AndroidManifest.xml
+++ b/javatests/arcs/android/systemhealth/testapp/AndroidManifest.xml
@@ -40,12 +40,11 @@
     </activity>
 
     <service
-      android:name="arcs.sdk.android.storage.service.StorageService"
-      android:exported="false"
-      tools:node="replace"/>
+      android:name=".PerformanceStorageService"
+      android:exported="false"/>
 
     <service
-      android:name=".TestStorageService"
+      android:name=".StabilityStorageService"
       android:exported="false"
       android:process=":storage_remote"/>
 

--- a/javatests/arcs/android/systemhealth/testapp/Dispatchers.kt
+++ b/javatests/arcs/android/systemhealth/testapp/Dispatchers.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.android.systemhealth.testapp
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+
+/** Collection of Arcs coroutine dispatchers. */
+object Dispatchers {
+    /**
+     * For jobs and operations happening at clients, typically
+     * arc-host, service store, handle dereferencer, etc.
+     *
+     * If it's null, taking the dispatchers that clients manage on their own.
+     */
+    var clients: CoroutineDispatcher? = null
+
+    /**
+     * For jobs and operations happening at server, typically
+     * storage service, ref-mode-store, etc.
+     */
+    var server: CoroutineDispatcher = Dispatchers.Default
+}

--- a/javatests/arcs/android/systemhealth/testapp/Executors.kt
+++ b/javatests/arcs/android/systemhealth/testapp/Executors.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.android.systemhealth.testapp
+
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.SynchronousQueue
+import java.util.concurrent.ThreadPoolExecutor
+import java.util.concurrent.TimeUnit
+
+/** Collection of Arcs JVM executors. */
+object Executors {
+    /**
+     * A [Scheduler] is per-arc-per-archost single-threaded.
+     * Each of them is managed directly by the [JvmSchedulerProvider] on JVM builds.
+     * Can be overridden as the globally-single-threaded design by:
+     *     iterator { while (true) yield(someExecutor) }
+     */
+    var schedulers: Iterator<ExecutorService>? = null
+
+    /**
+     * I/O (dynamic-sizing thread pool)
+     * On Arcs there are two sorts of databases: data and metadata.
+     * On sqlite WAL there are three databases: main journal, wal and wal-index.
+     *
+     * Taking size two as default as one feature is updating metadata and another
+     * is updating data.
+     */
+    var io: ExecutorService = ThreadPoolExecutor(
+        0, 2, 10L, TimeUnit.SECONDS, SynchronousQueue()
+    ) { runnable -> Thread(runnable).apply { name = "arcs-io" } }
+}

--- a/javatests/arcs/android/systemhealth/testapp/Executors.kt
+++ b/javatests/arcs/android/systemhealth/testapp/Executors.kt
@@ -12,9 +12,7 @@
 package arcs.android.systemhealth.testapp
 
 import java.util.concurrent.ExecutorService
-import java.util.concurrent.SynchronousQueue
-import java.util.concurrent.ThreadPoolExecutor
-import java.util.concurrent.TimeUnit
+import java.util.concurrent.Executors
 
 /** Collection of Arcs JVM executors. */
 object Executors {
@@ -31,10 +29,11 @@ object Executors {
      * On Arcs there are two sorts of databases: data and metadata.
      * On sqlite WAL there are three databases: main journal, wal and wal-index.
      *
-     * Taking size two as default as one feature is updating metadata and another
-     * is updating data.
+     * Recommending taking max size two as default as
+     * one can be updating metadata and another one is writing data, i.e.
+     * ThreadPoolExecutor(0, 2, 10L, TimeUnit.SECONDS, ...)
      */
-    var io: ExecutorService = ThreadPoolExecutor(
-        0, 2, 10L, TimeUnit.SECONDS, SynchronousQueue()
-    ) { runnable -> Thread(runnable).apply { name = "arcs-io" } }
+    var io: ExecutorService = Executors.newCachedThreadPool {
+        Thread(it).apply { name = "arcs-io" }
+    }
 }

--- a/javatests/arcs/android/systemhealth/testapp/PerformanceStorageService.kt
+++ b/javatests/arcs/android/systemhealth/testapp/PerformanceStorageService.kt
@@ -1,0 +1,55 @@
+package arcs.android.systemhealth.testapp
+
+import android.content.Context
+import android.content.Intent
+import android.content.ServiceConnection
+import arcs.android.storage.ParcelableStoreOptions
+import arcs.android.systemhealth.testapp.Dispatchers as ArcsDispatchers
+import arcs.android.systemhealth.testapp.Executors as ArcsExecutors
+import arcs.sdk.android.storage.service.StorageService
+import arcs.sdk.android.storage.service.StorageServiceBindingDelegate
+import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.asCoroutineDispatcher
+
+/**
+ * Arcs system-health-test storage service designed for performance tests.
+ */
+class PerformanceStorageService : StorageService() {
+    override val coroutineContext =
+        ArcsDispatchers.server + CoroutineName("PerformanceStorageService")
+    override val writeBackScope: CoroutineScope = CoroutineScope(
+        ArcsExecutors.io.asCoroutineDispatcher() + SupervisorJob()
+    )
+
+    companion object {
+        fun createBindIntent(context: Context, storeOptions: ParcelableStoreOptions): Intent =
+            Intent(context, PerformanceStorageService::class.java).apply {
+                action = storeOptions.actual.storageKey.toString()
+                putExtra(EXTRA_OPTIONS, storeOptions)
+            }
+    }
+}
+
+/** Implementation of the [StorageServiceBindingDelegate] which uses [PerformanceStorageService]. */
+class PerformanceStorageServiceBindingDelegate(
+    private val context: Context
+) : StorageServiceBindingDelegate {
+    @Suppress("NAME_SHADOWING")
+    override fun bindStorageService(
+        conn: ServiceConnection,
+        flags: Int,
+        options: ParcelableStoreOptions?
+    ): Boolean {
+        val options = requireNotNull(options) {
+            "ParcelableStoreOptions are required when binding to " +
+                "the PerformanceStorageService from a ServiceStore."
+        }
+        return context.bindService(
+            PerformanceStorageService.createBindIntent(context, options), conn, flags)
+    }
+
+    override fun unbindStorageService(conn: ServiceConnection) =
+        context.unbindService(conn)
+}

--- a/javatests/arcs/android/systemhealth/testapp/StabilityStorageService.kt
+++ b/javatests/arcs/android/systemhealth/testapp/StabilityStorageService.kt
@@ -20,9 +20,9 @@ import kotlinx.coroutines.launch
 /**
  * Arcs system-health-test storage service. Supports crashing itself when needed.
  */
-class TestStorageService : StorageService() {
+class StabilityStorageService : StorageService() {
     override val coroutineContext =
-        ArcsDispatchers.server + CoroutineName("TestStorageService")
+        ArcsDispatchers.server + CoroutineName("StabilityStorageService")
     override val writeBackScope: CoroutineScope = CoroutineScope(
         ArcsExecutors.io.asCoroutineDispatcher() + SupervisorJob()
     )
@@ -49,20 +49,20 @@ class TestStorageService : StorageService() {
         const val EXTRA_CRASH = "crash"
 
         fun createBindIntent(context: Context, storeOptions: ParcelableStoreOptions): Intent =
-            Intent(context, TestStorageService::class.java).apply {
+            Intent(context, StabilityStorageService::class.java).apply {
                 action = storeOptions.actual.storageKey.toString()
                 putExtra(EXTRA_OPTIONS, storeOptions)
             }
 
         fun createCrashIntent(context: Context): Intent =
-            Intent(context, TestStorageService::class.java).apply {
+            Intent(context, StabilityStorageService::class.java).apply {
                 putExtra(EXTRA_CRASH, true)
             }
     }
 }
 
-/** implementation of the [StorageServiceBindingDelegate] which uses [TestStorageService]. */
-class TestStorageServiceBindingDelegate(
+/** Implementation of the [StorageServiceBindingDelegate] which uses [StabilityStorageService]. */
+class StabilityStorageServiceBindingDelegate(
     private val context: Context
 ) : StorageServiceBindingDelegate {
     @Suppress("NAME_SHADOWING")
@@ -73,10 +73,10 @@ class TestStorageServiceBindingDelegate(
     ): Boolean {
         val options = requireNotNull(options) {
             "ParcelableStoreOptions are required when binding to " +
-                "the TestStorageService from a ServiceStore."
+                "the StabilityStorageService from a ServiceStore."
         }
         return context.bindService(
-            TestStorageService.createBindIntent(context, options), conn, flags)
+            StabilityStorageService.createBindIntent(context, options), conn, flags)
     }
 
     override fun unbindStorageService(conn: ServiceConnection) =

--- a/javatests/arcs/android/systemhealth/testapp/StorageCore.kt
+++ b/javatests/arcs/android/systemhealth/testapp/StorageCore.kt
@@ -286,7 +286,11 @@ class StorageCore(val context: Context, val lifecycle: Lifecycle) {
                             taskCoroutineContext,
                             DefaultConnectionFactory(
                                 context,
-                                TestStorageServiceBindingDelegate(context),
+                                if (settings.function == Function.STABILITY_TEST) {
+                                    StabilityStorageServiceBindingDelegate(context)
+                                } else {
+                                    PerformanceStorageServiceBindingDelegate(context)
+                                },
                                 taskCoroutineContext
                             )
                         )
@@ -722,7 +726,7 @@ class StorageCore(val context: Context, val lifecycle: Lifecycle) {
 
     private fun maybeCrashStorageService(rate: Int) {
         if (Random.nextInt(0, 100) < rate) {
-            context.startService(TestStorageService.createCrashIntent(context))
+            context.startService(StabilityStorageService.createCrashIntent(context))
         }
     }
 

--- a/javatests/arcs/android/systemhealth/testapp/StorageCore.kt
+++ b/javatests/arcs/android/systemhealth/testapp/StorageCore.kt
@@ -31,7 +31,6 @@ import arcs.core.storage.keys.DatabaseStorageKey
 import arcs.core.storage.keys.RamDiskStorageKey
 import arcs.core.storage.referencemode.ReferenceModeStorageKey
 import arcs.core.util.TaggedLog
-import arcs.jvm.host.JvmSchedulerProvider
 import arcs.jvm.util.JvmTime
 import arcs.sdk.ReadWriteCollectionHandle
 import arcs.sdk.ReadWriteSingletonHandle

--- a/javatests/arcs/android/systemhealth/testapp/StorageCore.kt
+++ b/javatests/arcs/android/systemhealth/testapp/StorageCore.kt
@@ -64,6 +64,7 @@ import kotlin.apply
 import kotlin.arrayOfNulls
 import kotlin.concurrent.withLock
 import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.coroutineContext
 import kotlin.emptyArray
 import kotlin.let
 import kotlin.math.ceil
@@ -544,7 +545,7 @@ class StorageCore(val context: Context, val lifecycle: Lifecycle) {
             }
 
             SystemHealthTestEntity.entityReference?.let {
-                val elapsedTime = measureTimeMillis { it.dereference() }
+                val elapsedTime = measureTimeMillis { it.dereference(coroutineContext) }
                 tasksEvents[taskController.taskId]?.writer?.withLock {
                     tasksEvents[taskController.taskId]?.queue?.add(
                         TaskEvent(TaskEventId.DEREFERENCE_LATENCY, elapsedTime)

--- a/javatests/arcs/android/systemhealth/testapp/TestApplication.kt
+++ b/javatests/arcs/android/systemhealth/testapp/TestApplication.kt
@@ -21,7 +21,7 @@ import arcs.core.storage.api.DriverAndKeyConfigurator
 import arcs.core.storage.driver.RamDisk
 
 /** Application class for Arcs System Health measures. */
-class TestApplication : Application(), Configuration.Provider {
+open class TestApplication : Application(), Configuration.Provider {
 
     override fun getWorkManagerConfiguration() =
         Configuration.Builder()

--- a/javatests/arcs/android/systemhealth/testapp/TestSchedulerProvider.kt
+++ b/javatests/arcs/android/systemhealth/testapp/TestSchedulerProvider.kt
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.android.systemhealth.testapp
+
+import arcs.android.systemhealth.testapp.Executors as ArcsExecutors
+import arcs.core.host.SchedulerProvider
+import arcs.core.util.Scheduler
+import arcs.core.util.TaggedLog
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import kotlin.coroutines.CoroutineContext
+import kotlinx.atomicfu.atomic
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.asCoroutineDispatcher
+
+/**
+ * A [JvmSchedulerProvider] variant supports evaluations on diverse threading
+ * models by dependency injections of executors.
+ */
+class TestSchedulerProvider(
+    private val baseCoroutineContext: CoroutineContext,
+    private val maxThreadCount: Int =
+        maxOf(1, Runtime.getRuntime().availableProcessors() / 2),
+    private val threadPriority: Int = DEFAULT_THREAD_PRIORITY
+) : SchedulerProvider {
+    private val log = TaggedLog { "TestSchedulerProvider" }
+    private val providedSoFar = atomic(0)
+    private val threads = arrayOfNulls<Thread>(maxThreadCount)
+    private val dispatchers = mutableListOf<CoroutineDispatcher>()
+    private val executors = mutableListOf<ExecutorService>()
+    private val schedulersByArcId = ConcurrentHashMap<String, Scheduler>()
+
+    @Synchronized
+    override fun invoke(arcId: String): Scheduler {
+        schedulersByArcId[arcId]?.let { return it }
+
+        val dispatcher = if (dispatchers.size == maxThreadCount) {
+            dispatchers[providedSoFar.getAndIncrement() % maxThreadCount]
+        } else {
+            val threadIndex = providedSoFar.getAndIncrement()
+            (ArcsExecutors.schedulers?.next() ?: Executors
+                .newSingleThreadExecutor {
+                    val thread = threads[threadIndex % maxThreadCount]
+                    if (thread != null && thread.isAlive) return@newSingleThreadExecutor thread
+
+                    if (thread?.isAlive == false) log.info {
+                        "Creating a new thread (index: ${threadIndex % maxThreadCount}) because " +
+                            "a previously-created one had died."
+                    }
+
+                    Thread(it).apply {
+                        priority = threadPriority
+                        name = "Scheduler-Thread#${threadIndex % maxThreadCount}"
+                        threads[threadIndex % maxThreadCount] = this
+                    }
+                })
+                .also { executors.add(it) }
+                .asCoroutineDispatcher()
+                .also { dispatchers.add(it) }
+        }
+
+        val schedulerParentJob = Job(baseCoroutineContext[Job])
+        schedulerParentJob.invokeOnCompletion {
+            schedulersByArcId.remove(arcId)
+        }
+
+        val schedulerContext = baseCoroutineContext +
+            schedulerParentJob +
+            CoroutineName("ArcId::$arcId") +
+            dispatcher
+
+        return Scheduler(schedulerContext).also { schedulersByArcId[arcId] = it }
+    }
+
+    @Synchronized
+    override fun cancelAll() {
+        schedulersByArcId.forEach { (_, scheduler) -> scheduler.cancel() }
+        if (ArcsExecutors.schedulers == null) {
+            // Shutting down the executors this scheduler spun up.
+            // Delegated executors are managed outside the scheduler.
+            executors.forEach {
+                it.shutdown()
+                it.awaitTermination(1, TimeUnit.SECONDS)
+            }
+        }
+        threads.forEach { it?.interrupt() }
+    }
+
+    companion object {
+        private const val DEFAULT_THREAD_PRIORITY = Thread.NORM_PRIORITY + 1
+    }
+}

--- a/javatests/arcs/android/systemhealth/testapp/TestStorageService.kt
+++ b/javatests/arcs/android/systemhealth/testapp/TestStorageService.kt
@@ -4,12 +4,15 @@ import android.content.Context
 import android.content.Intent
 import android.content.ServiceConnection
 import arcs.android.storage.ParcelableStoreOptions
+import arcs.android.systemhealth.testapp.Dispatchers as ArcsDispatchers
+import arcs.android.systemhealth.testapp.Executors as ArcsExecutors
 import arcs.sdk.android.storage.service.StorageService
 import arcs.sdk.android.storage.service.StorageServiceBindingDelegate
 import kotlin.random.Random
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -18,7 +21,11 @@ import kotlinx.coroutines.launch
  * Arcs system-health-test storage service. Supports crashing itself when needed.
  */
 class TestStorageService : StorageService() {
-    override val coroutineContext = Dispatchers.Main + CoroutineName("TestStorageService")
+    override val coroutineContext =
+        ArcsDispatchers.server + CoroutineName("TestStorageService")
+    override val writeBackScope: CoroutineScope = CoroutineScope(
+        ArcsExecutors.io.asCoroutineDispatcher() + SupervisorJob()
+    )
     private val scope = CoroutineScope(coroutineContext)
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {


### PR DESCRIPTION
Implement GH changes of [go/arcs-threading-strategies-on-apps](http://go/arcs-threading-strategies-on-apps)
The collaboration cl in g3: [cl/321082727](http://cl/321082727)

Using `--define <threading model picker>` to pick up target threading model, else take the default threading model.