### PR TITLE
Cleanup coroutine usage with Stores

### DIFF
--- a/java/arcs/core/data/Reference.kt
+++ b/java/arcs/core/data/Reference.kt
@@ -12,8 +12,6 @@
 package arcs.core.data
 
 import arcs.core.common.Referencable
-import kotlin.coroutines.CoroutineContext
-import kotlinx.coroutines.Dispatchers
 
 /**
  * A reference to an [Entity] of type [T].
@@ -33,13 +31,11 @@ interface Reference<T : Referencable> : arcs.core.crdt.CrdtEntity.Reference {
      *
      * Returns `null` if this [Reference] is no longer alive.
      */
-    suspend fun dereference(coroutineContext: CoroutineContext = Dispatchers.Default): T?
+    suspend fun dereference(): T?
 
     /** Returns whether or not the [Entity] being referenced still exists. */
-    suspend fun isAlive(coroutineContext: CoroutineContext = Dispatchers.Default): Boolean =
-        dereference(coroutineContext) != null
+    suspend fun isAlive(): Boolean = dereference() != null
 
     /** Returns whether or not the [Entity] being referenced has been removed from storage. */
-    suspend fun isDead(coroutineContext: CoroutineContext = Dispatchers.Default): Boolean =
-        !isAlive(coroutineContext)
+    suspend fun isDead(): Boolean = !isAlive()
 }

--- a/java/arcs/core/host/EntityHandleManager.kt
+++ b/java/arcs/core/host/EntityHandleManager.kt
@@ -277,8 +277,7 @@ class EntityHandleManager(
             val store: SingletonStore<Referencable> = stores.get(
                 StoreOptions(
                     storageKey = storageKey,
-                    type = SingletonType(EntityType(schema)),
-                    coroutineContext = coroutineContext
+                    type = SingletonType(EntityType(schema))
                 )
             )
             SingletonProxy(store, CrdtSingleton(), scheduler, time, analytics)
@@ -295,8 +294,7 @@ class EntityHandleManager(
             val store: CollectionStore<Referencable> = stores.get(
                 StoreOptions(
                     storageKey = storageKey,
-                    type = CollectionType(EntityType(schema)),
-                    coroutineContext = coroutineContext
+                    type = CollectionType(EntityType(schema))
                 )
             )
             CollectionProxy(store, CrdtSet(), scheduler, time, analytics)

--- a/java/arcs/core/storage/Reference.kt
+++ b/java/arcs/core/storage/Reference.kt
@@ -18,8 +18,6 @@ import arcs.core.data.Capability.Ttl
 import arcs.core.data.RawEntity
 import arcs.core.data.Schema
 import arcs.core.util.Time
-import kotlin.coroutines.CoroutineContext
-import kotlinx.coroutines.Dispatchers
 
 /**
  * [arcs.core.storage.ReferenceModeStore] uses an expanded notion of Reference that also includes a
@@ -52,10 +50,10 @@ data class Reference(
         }
     }
 
-    override suspend fun dereference(coroutineContext: CoroutineContext): RawEntity? =
+    override suspend fun dereference(): RawEntity? =
         requireNotNull(dereferencer) {
             "No dereferencer installed on Reference object"
-        }.dereference(this, coroutineContext)
+        }.dereference(this)
 
     fun referencedStorageKey() = storageKey.childKeyWithComponent(id)
 
@@ -83,8 +81,7 @@ data class Reference(
 /** Defines an object capable of de-referencing a [Reference]. */
 interface Dereferencer<T> {
     suspend fun dereference(
-        reference: Reference,
-        coroutineContext: CoroutineContext = Dispatchers.Default
+        reference: Reference
     ): T?
 
     /**

--- a/java/arcs/core/storage/ReferenceModeStore.kt
+++ b/java/arcs/core/storage/ReferenceModeStore.kt
@@ -145,7 +145,8 @@ class ReferenceModeStore private constructor(
      */
     private val versions = mutableMapOf<ReferenceId, MutableMap<FieldName, Int>>()
 
-    /** Tracks the state of callback:
+    /**
+     *  Tracks the state of callback:
      *    true: active callbacks, no callbacks have ever been registered.
      *    false: at least one callback has been registered in the past, but now there are none.
      */

--- a/java/arcs/core/storage/Store.kt
+++ b/java/arcs/core/storage/Store.kt
@@ -16,7 +16,6 @@ import arcs.core.crdt.CrdtOperation
 import arcs.core.storage.Store.Companion.defaultFactory
 import arcs.core.storage.referencemode.ReferenceModeStorageKey
 import arcs.core.type.Type
-import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 
 /**
@@ -45,7 +44,6 @@ class Store<Data : CrdtData, Op : CrdtOperation, ConsumerData>(
 ) : IStore<Data, Op, ConsumerData> {
     override val storageKey: StorageKey = options.storageKey
     override val type: Type = options.type
-    private val coroutineContext: CoroutineContext = options.coroutineContext
     private var activeStore: ActiveStore<Data, Op, ConsumerData>? = null
         get() = synchronized(this) { field }
         set(value) = synchronized(this) { field = value }
@@ -72,8 +70,7 @@ class Store<Data : CrdtData, Op : CrdtOperation, ConsumerData>(
         val options = StoreOptions(
             storageKey = storageKey,
             type = type,
-            versionToken = parsedVersionToken,
-            coroutineContext = coroutineContext
+            versionToken = parsedVersionToken
         )
         // If we were given a specific factory to use, use it; otherwise use the default factory.
         val activeStore =

--- a/java/arcs/core/storage/StoreInterface.kt
+++ b/java/arcs/core/storage/StoreInterface.kt
@@ -14,8 +14,6 @@ package arcs.core.storage
 import arcs.core.crdt.CrdtData
 import arcs.core.crdt.CrdtOperation
 import arcs.core.type.Type
-import kotlin.coroutines.CoroutineContext
-import kotlinx.coroutines.Dispatchers
 
 /** Base interface which all store implementations must extend from. */
 interface IStore<Data : CrdtData, Op : CrdtOperation, ConsumerData> {
@@ -27,6 +25,5 @@ interface IStore<Data : CrdtData, Op : CrdtOperation, ConsumerData> {
 data class StoreOptions(
     val storageKey: StorageKey,
     val type: Type,
-    val versionToken: String? = null,
-    val coroutineContext: CoroutineContext = Dispatchers.Default
+    val versionToken: String? = null
 )

--- a/java/arcs/sdk/android/storage/service/StorageService.kt
+++ b/java/arcs/sdk/android/storage/service/StorageService.kt
@@ -148,8 +148,7 @@ open class StorageService : ResurrectorService() {
             intent.getParcelableExtra<ParcelableStoreOptions?>(EXTRA_OPTIONS)
         ) { "No StoreOptions found in Intent" }
 
-        val options =
-            parcelableOptions.actual.copy(coroutineContext = coroutineContext)
+        val options = parcelableOptions.actual.copy()
         return BindingContext(
             stores.computeIfAbsent(options.storageKey) {
                 Store<CrdtData, CrdtOperationAtTime, Any>(options)

--- a/javatests/arcs/android/systemhealth/testapp/StorageCore.kt
+++ b/javatests/arcs/android/systemhealth/testapp/StorageCore.kt
@@ -545,7 +545,7 @@ class StorageCore(val context: Context, val lifecycle: Lifecycle) {
             }
 
             SystemHealthTestEntity.entityReference?.let {
-                val elapsedTime = measureTimeMillis { it.dereference(coroutineContext) }
+                val elapsedTime = measureTimeMillis { it.dereference() }
                 tasksEvents[taskController.taskId]?.writer?.withLock {
                     tasksEvents[taskController.taskId]?.queue?.add(
                         TaskEvent(TaskEventId.DEREFERENCE_LATENCY, elapsedTime)

--- a/javatests/arcs/core/entity/HandleManagerTestBase.kt
+++ b/javatests/arcs/core/entity/HandleManagerTestBase.kt
@@ -308,14 +308,14 @@ open class HandleManagerTestBase {
         // Now read back entity1, and dereference its best_friend.
         log("Checking entity1's best friend")
         val dereferencedRawEntity2 =
-            readHandle.dispatchFetch()!!.bestFriend!!.dereference(coroutineContext)!!
+            readHandle.dispatchFetch()!!.bestFriend!!.dereference()!!
         val dereferencedEntity2 = Person.deserialize(dereferencedRawEntity2)
         assertThat(dereferencedEntity2).isEqualTo(entity2)
 
         // Do the same for entity2's best_friend
         log("Checking entity2's best friend")
         val dereferencedRawEntity1 =
-            refReadHandle.dispatchFetch()!!.bestFriend!!.dereference(coroutineContext)!!
+            refReadHandle.dispatchFetch()!!.bestFriend!!.dereference()!!
         val dereferencedEntity1 = Person.deserialize(dereferencedRawEntity1)
         assertThat(dereferencedEntity1).isEqualTo(entity1)
     }
@@ -364,7 +364,7 @@ open class HandleManagerTestBase {
         val entityOut = readHandle.dispatchFetch()!!
         val hatRef = entityOut.coolnessIndex.hat!!
         assertThat(hatRef).isEqualTo(fezStorageRef)
-        val rawHat = hatRef.dereference(coroutineContext)!!
+        val rawHat = hatRef.dereference()!!
         val hat = Hat.deserialize(rawHat)
         assertThat(hat).isEqualTo(fez)
     }
@@ -464,8 +464,8 @@ open class HandleManagerTestBase {
         // Reference should be alive.
         assertThat(reference.dereference()).isEqualTo(entity1)
         var storageReference = reference.toReferencable()
-        assertThat(storageReference.isAlive(coroutineContext)).isTrue()
-        assertThat(storageReference.isDead(coroutineContext)).isFalse()
+        assertThat(storageReference.isAlive()).isTrue()
+        assertThat(storageReference.isDead()).isFalse()
 
         // Modify the entity.
         val modEntity1 = entity1.copy(name = "Ben")
@@ -482,8 +482,8 @@ open class HandleManagerTestBase {
         log("Dereferenced: $dereferenced")
         assertThat(dereferenced).isEqualTo(modEntity1)
         storageReference = reference.toReferencable()
-        assertThat(storageReference.isAlive(coroutineContext)).isTrue()
-        assertThat(storageReference.isDead(coroutineContext)).isFalse()
+        assertThat(storageReference.isAlive()).isTrue()
+        assertThat(storageReference.isDead()).isFalse()
 
         // Remove the entity from the collection.
         val heardTheDelete = monitorHandle.onUpdateDeferred { it.isEmpty() }
@@ -807,7 +807,7 @@ open class HandleManagerTestBase {
             .also { assertThat(it).hasSize(2) }
             .forEach { entity ->
                 val expectedBestFriend = if (entity.entityId == "entity1") entity2 else entity1
-                val actualRawBestFriend = entity.bestFriend!!.dereference(coroutineContext)!!
+                val actualRawBestFriend = entity.bestFriend!!.dereference()!!
                 val actualBestFriend = Person.deserialize(actualRawBestFriend)
                 assertThat(actualBestFriend).isEqualTo(expectedBestFriend)
             }
@@ -867,7 +867,7 @@ open class HandleManagerTestBase {
         assertThat(hatRef).isEqualTo(fezStorageRef)
 
         hatMonitorKnows.await()
-        val rawHat = hatRef.dereference(coroutineContext)!!
+        val rawHat = hatRef.dereference()!!
         val hat = Hat.deserialize(rawHat)
         assertThat(hat).isEqualTo(fez)
     }
@@ -1038,8 +1038,8 @@ open class HandleManagerTestBase {
         assertThat(references.map { it.dereference() }).containsExactly(entity1, entity2)
         references.forEach {
             val storageReference = it.toReferencable()
-            assertThat(storageReference.isAlive(coroutineContext)).isTrue()
-            assertThat(storageReference.isDead(coroutineContext)).isFalse()
+            assertThat(storageReference.isAlive()).isTrue()
+            assertThat(storageReference.isDead()).isFalse()
         }
 
         // Modify the entities.
@@ -1057,8 +1057,8 @@ open class HandleManagerTestBase {
         assertThat(references.map { it.dereference() }).containsExactly(modEntity1, modEntity2)
         references.forEach {
             val storageReference = it.toReferencable()
-            assertThat(storageReference.isAlive(coroutineContext)).isTrue()
-            assertThat(storageReference.isDead(coroutineContext)).isFalse()
+            assertThat(storageReference.isAlive()).isTrue()
+            assertThat(storageReference.isDead()).isFalse()
         }
 
         log("Removing the entities")

--- a/javatests/arcs/core/storage/RawEntityDereferencerTest.kt
+++ b/javatests/arcs/core/storage/RawEntityDereferencerTest.kt
@@ -99,7 +99,7 @@ class RawEntityDereferencerTest {
     @Test
     fun dereference_canDereference_friend() = runBlockingTest {
         val dereferencedBob = (alice.singletons["sibling"] as Reference)
-            .dereference(this.coroutineContext)
+            .dereference()
         assertThat(dereferencedBob!!.id).isEqualTo(bob.id)
         assertThat(dereferencedBob.singletons["name"]!!.unwrap())
             .isEqualTo(bob.singletons["name"]!!.unwrap())
@@ -110,15 +110,15 @@ class RawEntityDereferencerTest {
     @Test
     fun dereference_canDereference_sibling_of_sibling_of_sibling() = runBlockingTest {
         val dereferencedBob =
-            (alice.singletons["sibling"] as Reference).dereference(this.coroutineContext)!!
+            (alice.singletons["sibling"] as Reference).dereference()!!
         val dereferencedAliceFromBob =
             (dereferencedBob.singletons["sibling"] as Reference)
                 .also { it.dereferencer = dereferencer }
-                .dereference(this.coroutineContext)!!
+                .dereference()!!
         val dereferencedBobFromAliceFromBob =
             (dereferencedAliceFromBob.singletons["sibling"] as Reference)
                 .also { it.dereferencer = dereferencer }
-                .dereference(this.coroutineContext)!!
+                .dereference()!!
 
         assertThat(dereferencedAliceFromBob.id).isEqualTo(alice.id)
         assertThat(dereferencedAliceFromBob.singletons["name"]!!.unwrap())

--- a/javatests/arcs/core/storage/ReferenceTest.kt
+++ b/javatests/arcs/core/storage/ReferenceTest.kt
@@ -110,7 +110,7 @@ class ReferenceTest {
             val ref = it.value
             ref.dereferencer = dereferencer
             val expectedPerson = expectedPeople[ref.id] ?: error("Bad reference: $ref")
-            val dereferenced = ref.dereference(coroutineContext)
+            val dereferenced = ref.dereference()
             val actualPerson = requireNotNull(dereferenced).toPerson()
 
             assertThat(actualPerson).isEqualTo(expectedPerson)


### PR DESCRIPTION
* Remove the `coroutineContext` parameter from the Reference interface
methods. These are already suspend functions, so the caller should
switch to that context before invoking the function. I didn't notice any
use cases that required this.  The call in `dereference` to
`store.onProxyMessage(SyncRequest)` was being launch in a coroutine on
the provided context, but all tests pass running this method directly on
the current coroutine.

* Remove the `coroutineContext` property from `StoreOptions`. As best I
can tell, this was not actually being used, except by the
`cleanCoroutineContext` parameter of `ReferenceModeStore`.

* Initialize the `ReferenceModeStore` with the `coroutineContext` on
which construction occurs, to be used for the cleanup flow. Added a test
to ensure that the flow performs as expected.