### PR TITLE
Refactor RefModeStore cleanup behavior and add tests for its behavior

### DIFF
--- a/java/arcs/core/storage/ActiveStore.kt
+++ b/java/arcs/core/storage/ActiveStore.kt
@@ -38,7 +38,7 @@ abstract class ActiveStore<Data : CrdtData, Op : CrdtOperation, ConsumerData>(
     abstract fun on(callback: ProxyCallback<Data, Op, ConsumerData>): Int
 
     /** Unregisters a callback associated with the given [callbackToken]. */
-    abstract fun off(callbackToken: Int)
+    abstract suspend fun off(callbackToken: Int)
 
     /** Handles a message from the storage proxy. */
     abstract suspend fun onProxyMessage(message: ProxyMessage<Data, Op, ConsumerData>): Boolean
@@ -58,6 +58,6 @@ abstract class ActiveStore<Data : CrdtData, Op : CrdtOperation, ConsumerData>(
             message: ProxyMessage<Data, Op, ConsumerData>
         ) = this@ActiveStore.onProxyMessage(message.withId(id))
 
-        override fun close() = off(id)
+        override suspend fun close() = off(id)
     }
 }

--- a/java/arcs/core/storage/DirectStore.kt
+++ b/java/arcs/core/storage/DirectStore.kt
@@ -102,7 +102,7 @@ class DirectStore<Data : CrdtData, Op : CrdtOperation, T> /* internal */ constru
         }
     }
 
-    override fun off(callbackToken: Int) {
+    override suspend fun off(callbackToken: Int) {
         synchronized(proxyManager) {
             proxyManager.unregister(callbackToken)
         }

--- a/java/arcs/core/storage/ProxyInterface.kt
+++ b/java/arcs/core/storage/ProxyInterface.kt
@@ -105,7 +105,7 @@ interface StorageCommunicationEndpoint<Data : CrdtData, Op : CrdtOperation, Cons
     suspend fun onProxyMessage(message: ProxyMessage<Data, Op, ConsumerData>): Boolean
 
     /** Signal to the endpoint provider that the client is finished using this endpoint. */
-    fun close()
+    suspend fun close()
 }
 
 /** Provider of a [StorageCommunicationEndpoint]. */

--- a/java/arcs/core/storage/ReferenceModeStore.kt
+++ b/java/arcs/core/storage/ReferenceModeStore.kt
@@ -488,6 +488,11 @@ class ReferenceModeStore private constructor(
         backingStoreCleanupJob.join()
     }
 
+    @FlowPreview
+    suspend fun awaitCleanup() {
+        clearStoreCachesFlow.join()
+    }
+
     private fun newBackingInstance(): CrdtModel<CrdtData, CrdtOperationAtTime, Referencable> =
         crdtType.createCrdtModel()
 

--- a/java/arcs/core/storage/StorageProxy.kt
+++ b/java/arcs/core/storage/StorageProxy.kt
@@ -264,7 +264,7 @@ class StorageProxy<Data : CrdtData, Op : CrdtOperationAtTime, T>(
      * Attempting to perform an operation on a closed [StorageProxy] will result in an exception
      * being thrown.
      */
-    fun close() {
+    suspend fun close() {
         if (stateHolder.value.state == ProxyState.CLOSED) return
         scheduler.scope.launch {
             _crdt = null

--- a/java/arcs/core/storage/referencemode/MessageQueue.kt
+++ b/java/arcs/core/storage/referencemode/MessageQueue.kt
@@ -12,12 +12,10 @@
 package arcs.core.storage.referencemode
 
 import kotlin.coroutines.coroutineContext
-import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.channels.ConflatedBroadcastChannel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -30,13 +28,17 @@ import kotlinx.coroutines.sync.withLock
 class MessageQueue(
     private val onProxyMessage: suspend (Message.EnqueuedFromStorageProxy) -> Boolean,
     private val onContainerStoreMessage: suspend (Message.EnqueuedFromContainer) -> Boolean,
-    private val onBackingStoreMessage: suspend (Message.EnqueuedFromBackingStore) -> Boolean
+    private val onBackingStoreMessage: suspend (Message.EnqueuedFromBackingStore) -> Boolean,
+    private val onMessageQueueEmpty: suspend () -> Unit = {}
 ) {
+
+    private sealed class QueueEntry {
+        class MessageEntry(val message: Message) : QueueEntry()
+        object Flush : QueueEntry()
+    }
+
     private val mutex = Mutex()
-    private val queue = mutableListOf<Message>()
-    val size = atomic(0)
-    @ExperimentalCoroutinesApi
-    val sizeChannel = ConflatedBroadcastChannel(0)
+    private val queue = mutableListOf<QueueEntry>()
 
     /**
      * Enqueues an incoming [Message] onto the queue and awaits the return value of processing that
@@ -45,27 +47,47 @@ class MessageQueue(
     @ExperimentalCoroutinesApi
     suspend fun enqueue(message: Message): Boolean {
         require(message !is Message.Enqueued) { "Cannot enqueue an already-enqueued message." }
-        size.incrementAndGet().let {
-            if (!sizeChannel.isClosedForSend) sizeChannel.send(it)
-        }
         val deferred = CompletableDeferred<Boolean>(coroutineContext[Job.Key])
-        mutex.withLock { queue += message.toEnqueued(deferred) }
+        mutex.withLock { queue += QueueEntry.MessageEntry(message.toEnqueued(deferred)) }
         CoroutineScope(coroutineContext).launch { drainQueue() }
-        return deferred.await().also {
-            size.decrementAndGet().let {
-                if (!sizeChannel.isClosedForSend) sizeChannel.send(it)
-            }
-        }
+        return deferred.await()
     }
 
     private suspend fun drainQueue() {
         val messagesToProcess = mutex.withLock {
-            mutableListOf<Message>().also {
+            mutableListOf<QueueEntry>().also {
                 it.addAll(queue)
                 queue.clear()
             }
         }
-        messagesToProcess.forEach { processMessage(it); Unit }
+
+        messagesToProcess.forEach {
+            when (it) {
+                is QueueEntry.MessageEntry -> processMessage(it.message)
+                is QueueEntry.Flush -> Unit
+            }
+        }
+
+        mutex.withLock {
+            if (queue.isEmpty()) {
+                onMessageQueueEmpty()
+            }
+        }
+    }
+
+    /**
+     * Posts a message on the queue, and returns a [Job] this will be completed when the queue
+     * arrives at this message. This allows you to wait for all *current* pending messages to
+     * be processed.
+     */
+    suspend fun flush(): Job {
+        val job = Job(coroutineContext[Job.Key])
+        mutex.withLock { queue += QueueEntry.Flush }
+        CoroutineScope(coroutineContext).launch {
+            drainQueue()
+            job.complete()
+        }
+        return job
     }
 
     private suspend fun processMessage(message: Message): Boolean = when (message) {

--- a/java/arcs/sdk/android/storage/ServiceStore.kt
+++ b/java/arcs/sdk/android/storage/ServiceStore.kt
@@ -57,7 +57,6 @@ import kotlinx.coroutines.flow.buffer
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 
 /**
@@ -157,13 +156,11 @@ class ServiceStore<Data : CrdtData, Op : CrdtOperation, ConsumerData>(
         })
     }
 
-    override fun off(callbackToken: Int) {
+    override suspend fun off(callbackToken: Int) {
         val service = checkNotNull(storageService)
-        runBlocking {
-            send {
-                service.unregisterCallback(callbackToken)
-                initChannel()
-            }
+        send {
+            service.unregisterCallback(callbackToken)
+            initChannel()
         }
     }
 

--- a/javatests/arcs/core/storage/ReferenceModeStoreTest.kt
+++ b/javatests/arcs/core/storage/ReferenceModeStoreTest.kt
@@ -35,7 +35,6 @@ import arcs.core.testutil.assertSuspendingThrows
 import arcs.core.type.Type
 import arcs.core.util.testutil.LogRule
 import com.google.common.truth.Truth.assertThat
-import kotlinx.coroutines.Dispatchers
 import kotlin.reflect.KClass
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
@@ -672,7 +671,6 @@ class ReferenceModeStoreTest {
         job.join()
     }
 
-
     @Test
     fun backingStoresCleanedUpWhenLastCallbackRemoved() = runBlocking {
         DriverFactory.register(MockDriverProvider())
@@ -683,7 +681,6 @@ class ReferenceModeStoreTest {
         val collection = CrdtSet<RawEntity>()
         val entity = createPersonEntity("an-id", "bob", 42)
 
-        println("DO STUFF")
         collection.applyOperation(
             CrdtSet.Operation.Add("me", VersionMap("me" to 1), entity)
         )
@@ -694,7 +691,6 @@ class ReferenceModeStoreTest {
 
         store.off(token)
         store.idle()
-        store.awaitCleanup()
         assertThat(store.backingStore.stores.size).isEqualTo(0)
     }
 
@@ -705,7 +701,7 @@ class ReferenceModeStoreTest {
 
         val preToken = store.on(ProxyCallback {})
         store.off(preToken)
-        store.awaitCleanup()
+        store.idle()
 
         val token = store.on(ProxyCallback {})
         val collection = CrdtSet<RawEntity>()

--- a/javatests/arcs/core/storage/StoreEndpointFake.kt
+++ b/javatests/arcs/core/storage/StoreEndpointFake.kt
@@ -67,7 +67,7 @@ class StoreEndpointFake<Data : CrdtData, Op : CrdtOperation, T> :
         }.join()
     }
 
-    override fun close() {
+    override suspend fun close() {
         closed = true
     }
 


### PR DESCRIPTION
This set of changes began as a result of the tests added here, that
failed.

This refactor makes two improvements:
1. Fixes an issue where once cleanup was triggered for a store, it would
never be triggered again.
2. No need to launch a separate coroutine for cleanup, or to provide any
coroutineContext at construction time. Cleanup now occurs on the
coroutine that resulted in the internal state change that triggered
cleanup.

In order to enable cleanup to always occur on a caller coroutine, the
`ActiveStore.off` method needed to become a suspend method. This allows
us to post a message to the `MessageQueue` when `off` is called, to
ensure that cleanup occurs if `off` was called while the `MessageQueue`
was already idle.

Luckily, this `suspend` change didn't cause many downstream changes;
most calls to `off` were already in a coroutineContext. The one
exception to this was `storageProxy.close`. So this is now also a
suspending method.

An additional change here was to remove the use of a coroutine mutex in
ProxyCallbackManager, in favor of a symbol object monitor, since most of
the methods interacting with the component aren't suspendable, anyway.