### PR TITLE
Let StorageService drive cleanup of stores in onUnbind

### DIFF
--- a/java/arcs/core/storage/ActiveStore.kt
+++ b/java/arcs/core/storage/ActiveStore.kt
@@ -40,6 +40,9 @@ abstract class ActiveStore<Data : CrdtData, Op : CrdtOperation, ConsumerData>(
     /** Unregisters a callback associated with the given [callbackToken]. */
     abstract fun off(callbackToken: Int)
 
+    /** Releases any resources this store was using. */
+    abstract suspend fun close()
+
     /** Handles a message from the storage proxy. */
     abstract suspend fun onProxyMessage(message: ProxyMessage<Data, Op, ConsumerData>): Boolean
 

--- a/java/arcs/core/storage/DirectStore.kt
+++ b/java/arcs/core/storage/DirectStore.kt
@@ -32,7 +32,6 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.ConflatedBroadcastChannel
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.runBlocking
 
 // import kotlinx.coroutines.flow.debounce
 // import kotlinx.coroutines.flow.filter
@@ -109,23 +108,21 @@ class DirectStore<Data : CrdtData, Op : CrdtOperation, T> /* internal */ constru
     }
 
     /** Closes the store. Once closed, it cannot be re-opened. A new instance must be created. */
-    fun close() {
+    override suspend fun close() {
         synchronized(proxyManager) {
             proxyManager.callbacks.clear()
-            closeInternal()
         }
+        closeInternal()
     }
 
-    private fun closeInternal() {
+    private suspend fun closeInternal() {
         if (!closed) {
             closed = true
             stateChannel.offer(State.Closed())
             stateChannel.close()
             state.value = State.Closed()
             closeWriteBack()
-            runBlocking {
-                driver.close()
-            }
+            driver.close()
         }
     }
 

--- a/java/arcs/core/storage/DirectStoreMuxer.kt
+++ b/java/arcs/core/storage/DirectStoreMuxer.kt
@@ -23,6 +23,7 @@ import arcs.core.util.TaggedLog
 import kotlin.coroutines.coroutineContext
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
@@ -53,7 +54,9 @@ class DirectStoreMuxer<Data : CrdtData, Op : CrdtOperation, T>(
             log.debug { "close the store(${storeRecord.id})" }
 
             try {
-                storeRecord.store.close()
+                runBlocking {
+                    storeRecord.store.close()
+                }
             } catch (e: Exception) {
                 // TODO(b/160251910): Make logging detail more cleanly conditional.
                 log.debug(e) { "failed to close the store(${storeRecord.id})" }

--- a/java/arcs/core/storage/StoreManager.kt
+++ b/java/arcs/core/storage/StoreManager.kt
@@ -50,5 +50,12 @@ class StoreManager(
     /**
      * Drops all [Store] instances.
      */
-    suspend fun reset() = storesMutex.withLock { stores.clear() }
+    suspend fun reset() {
+        val toClose = storesMutex.withLock {
+            stores.values.also {
+                stores.clear()
+            }
+        }
+        toClose.forEach { it.close() }
+    }
 }

--- a/java/arcs/sdk/android/storage/ServiceStore.kt
+++ b/java/arcs/sdk/android/storage/ServiceStore.kt
@@ -217,6 +217,12 @@ class ServiceStore<Data : CrdtData, Op : CrdtOperation, ConsumerData>(
     @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)
     @VisibleForTesting(otherwise = VisibleForTesting.PACKAGE_PRIVATE)
     fun onLifecycleDestroyed() {
+        runBlocking {
+            close()
+        }
+    }
+
+    override suspend fun close() {
         serviceConnection?.disconnect()
         storageService = null
         channel?.cancel()


### PR DESCRIPTION
This replaces the internal cleanup flow in ReferenceModeStore with
behavior in StorageService that triggers cleanup of a store when it no
longer has any clients using it.

This is an alternative strategy to #5712 