### PR TITLE
Don't send update notifications for local writes prior to onReady.

### DIFF
--- a/java/arcs/core/host/ArcHostContext.kt
+++ b/java/arcs/core/host/ArcHostContext.kt
@@ -48,6 +48,9 @@ data class ArcHostContext(
         _arcState = arcState
     }
 
+    override fun toString() = "ArcHostContext(arcId=$arcId, arcState=$arcState, " +
+            "particles=$particles, entityHandleManager=$entityHandleManager)"
+
     internal fun addOnArcStateChange(
         registration: ArcStateChangeRegistration,
         block: ArcStateChangeCallback

--- a/java/arcs/core/host/ParticleContext.kt
+++ b/java/arcs/core/host/ParticleContext.kt
@@ -64,6 +64,10 @@ class ParticleContext(
 
     private val dispatcher = scheduler?.asCoroutineDispatcher()
 
+    override fun toString() = "ParticleContext(particle=$particle, particleState=$particleState, " +
+            "consecutiveFailureCount=$consecutiveFailureCount, isWriteOnly=$isWriteOnly, " +
+            "awaitingReady=$awaitingReady, desyncedHandles=$desyncedHandles)"
+
     /** Create a copy of [ParticleContext] with a new [particle]. */
     fun copyWith(newParticle: Particle) = ParticleContext(
         newParticle,

--- a/java/arcs/core/storage/StorageProxy.kt
+++ b/java/arcs/core/storage/StorageProxy.kt
@@ -291,8 +291,12 @@ class StorageProxy<Data : CrdtData, Op : CrdtOperationAtTime, T>(
         val result = CompletableDeferred<Boolean>()
         sendMessageToStore(ProxyMessage.Operations(listOf(op), null), result)
 
-        // TODO: the returned Deferred doesn't account for this update propagation; should it?
-        notifyUpdate(value)
+        // Don't send update notifications for local writes that occur prior to sync (these should
+        // only be in onFirstStart and onStart, and as such particles aren't ready for updates yet).
+        if (stateHolder.value.state in arrayOf(ProxyState.SYNC, ProxyState.DESYNC)) {
+            // TODO: the returned Deferred doesn't account for this update propagation; should it?
+            notifyUpdate(value)
+        }
         return result
     }
 

--- a/javatests/arcs/core/host/HandleAdapterTest.kt
+++ b/javatests/arcs/core/host/HandleAdapterTest.kt
@@ -209,56 +209,6 @@ class HandleAdapterTest {
         assertThat(writeOnlyHandle).isNotInstanceOf(ReadWriteCollectionHandle::class.java)
     }
 
-    @Test
-    fun singletonHandleAdapter_onUpdateTest() = runTest {
-        val handle = manager.createHandle(
-            HandleSpec(
-                READ_WRITE_HANDLE,
-                HandleMode.ReadWrite,
-                SingletonType(EntityType(Person.SCHEMA)),
-                Person
-            ),
-            STORAGE_KEY
-        ) as ReadWriteSingletonHandle<Person>
-
-        var x = 0
-        handle.onUpdate { p ->
-            if (p?.name == "Eliza Hamilton") {
-                x++
-            }
-        }
-
-        handle.dispatchStore(Person("Eliza Hamilton"))
-        scheduler.waitForIdle()
-
-        assertThat(x).isEqualTo(1)
-    }
-
-    @Test
-    fun collectionHandleAdapter_onUpdateTest() = runTest {
-        val handle = manager.createHandle(
-            HandleSpec(
-                READ_WRITE_HANDLE,
-                HandleMode.ReadWrite,
-                CollectionType(EntityType(Person.SCHEMA)),
-                Person
-            ),
-            STORAGE_KEY
-        ) as ReadWriteCollectionHandle<Person>
-
-        var x = 0
-        handle.onUpdate { people ->
-            if (people.elementAtOrNull(0)?.name == "Elder Price") {
-                x += people.size
-            }
-        }
-
-        handle.dispatchStore(Person("Elder Price"))
-        scheduler.waitForIdle()
-
-        assertThat(x).isEqualTo(1)
-    }
-
     @Ignore("b/157390221 - Deflake")
     @Test
     fun collectionHandleAdapter_createReference() = runTest {

--- a/javatests/arcs/core/host/LifecycleParticles.kt
+++ b/javatests/arcs/core/host/LifecycleParticles.kt
@@ -229,3 +229,34 @@ class ReadWriteAccessParticle : AbstractReadWriteAccessParticle() {
         }
     }
 }
+
+class PipelineProducerParticle : AbstractPipelineProducerParticle() {
+    override fun onFirstStart() {
+        handles.sngWrite.store(Value("sng"))
+        handles.colWrite.store(Value("col"))
+    }
+}
+
+class PipelineTransportParticle : AbstractPipelineTransportParticle() {
+    override fun onReady() {
+        handles.sngRead.fetch()!!.let {
+            handles.sngWrite.store(it.copy(txt = it.txt + "_mod"))
+        }
+        handles.colRead.fetchAll().forEach {
+            handles.colWrite.store(it.copy(txt = it.txt + "_mod"))
+        }
+    }
+}
+
+class PipelineConsumerParticle : AbstractPipelineConsumerParticle() {
+    val values = mutableListOf<String>()
+
+    override fun onStart() {
+        handles.sngRead.onUpdate {
+            values.add("${it?.txt}")
+        }
+        handles.colRead.onUpdate { set ->
+            values.add("${set.map { it.txt }}")
+        }
+    }
+}

--- a/javatests/arcs/core/host/LifecycleTest.kt
+++ b/javatests/arcs/core/host/LifecycleTest.kt
@@ -62,7 +62,10 @@ class LifecycleTest {
             ::SingleWriteHandleParticle.toRegistration(),
             ::MultiHandleParticle.toRegistration(),
             ::PausingParticle.toRegistration(),
-            ::ReadWriteAccessParticle.toRegistration()
+            ::ReadWriteAccessParticle.toRegistration(),
+            ::PipelineProducerParticle.toRegistration(),
+            ::PipelineTransportParticle.toRegistration(),
+            ::PipelineConsumerParticle.toRegistration()
         )
         hostRegistry = ExplicitHostRegistry().also { it.registerHost(testHost) }
         storeManager = StoreManager()
@@ -211,5 +214,15 @@ class LifecycleTest {
         val arc = allocator.startArcForPlan(ReadWriteAccessTestPlan).waitForStart()
         val particle: ReadWriteAccessParticle = testHost.getParticle(arc.id, name)
         assertThat(particle.errors).isEmpty()
+    }
+
+    @Test
+    fun pipeline() = runTest {
+        val name = "PipelineConsumerParticle"
+        val arc = allocator.startArcForPlan(PipelineTestPlan).waitForStart()
+        val particle: PipelineConsumerParticle = testHost.getParticle(arc.id, name)
+        arc.stop()
+        arc.waitForStop()
+        assertThat(particle.values).containsExactly("sng_mod", "[col_mod]")
     }
 }

--- a/javatests/arcs/core/host/lifecycle.arcs
+++ b/javatests/arcs/core/host/lifecycle.arcs
@@ -3,7 +3,7 @@ meta
 
 // -----------------------------------------------------------------------------
 
-particle SingleReadHandleParticle in 'arcs.core.host.SingleReadHandleParticle'
+particle SingleReadHandleParticle in '.SingleReadHandleParticle'
   data: reads Data {num: Number}
 
 recipe SingleReadHandleTest
@@ -12,7 +12,7 @@ recipe SingleReadHandleTest
 
 // -----------------------------------------------------------------------------
 
-particle SingleWriteHandleParticle in 'arcs.core.host.SingleWriteHandleParticle'
+particle SingleWriteHandleParticle in '.SingleWriteHandleParticle'
   data: writes Data {num: Number}
 
 recipe SingleWriteHandleTest
@@ -21,7 +21,7 @@ recipe SingleWriteHandleTest
 
 // -----------------------------------------------------------------------------
 
-particle MultiHandleParticle in 'arcs.core.host.MultiHandleParticle'
+particle MultiHandleParticle in '.MultiHandleParticle'
   data: reads Data {num: Number}
   list: reads writes [List {txt: Text}]
   result: writes [Result {idx: Number}]
@@ -36,7 +36,7 @@ recipe MultiHandleTest
 
 // -----------------------------------------------------------------------------
 
-particle PausingParticle in 'arcs.core.host.PausingParticle'
+particle PausingParticle in '.PausingParticle'
   data: reads Data {num: Number}
   list: reads [List {txt: Text}]
 
@@ -47,7 +47,7 @@ recipe PausingTest
 
 // -----------------------------------------------------------------------------
 
-particle ReadWriteAccessParticle in 'arcs.core.host.ReadWriteAccessParticle'
+particle ReadWriteAccessParticle in '.ReadWriteAccessParticle'
   sngRead: reads Value {txt: Text}
   sngWrite: writes Value {txt: Text}
   sngReadWrite: reads writes Value {txt: Text}
@@ -70,17 +70,17 @@ recipe ReadWriteAccessTest
 
 // -----------------------------------------------------------------------------
 
-particle PipelineProducerParticle in 'arcs.core.host.PipelineProducerParticle'
+particle PipelineProducerParticle in '.PipelineProducerParticle'
   sngWrite: writes Value {txt: Text}
   colWrite: writes [Value {txt: Text}]
 
-particle PipelineTransportParticle in 'arcs.core.host.PipelineTransportParticle'
+particle PipelineTransportParticle in '.PipelineTransportParticle'
   sngRead: reads Value {txt: Text}
   sngWrite: writes Value {txt: Text}
   colRead: reads [Value {txt: Text}]
   colWrite: writes [Value {txt: Text}]
 
-particle PipelineConsumerParticle in 'arcs.core.host.PipelineConsumerParticle'
+particle PipelineConsumerParticle in '.PipelineConsumerParticle'
   sngRead: reads Value {txt: Text}
   colRead: reads [Value {txt: Text}]
 

--- a/javatests/arcs/core/host/lifecycle.arcs
+++ b/javatests/arcs/core/host/lifecycle.arcs
@@ -67,3 +67,32 @@ recipe ReadWriteAccessTest
     colReadWrite: reads writes h2
     sngPersist: reads writes h3
     colPersist: reads writes h4
+
+// -----------------------------------------------------------------------------
+
+particle PipelineProducerParticle in 'arcs.core.host.PipelineProducerParticle'
+  sngWrite: writes Value {txt: Text}
+  colWrite: writes [Value {txt: Text}]
+
+particle PipelineTransportParticle in 'arcs.core.host.PipelineTransportParticle'
+  sngRead: reads Value {txt: Text}
+  sngWrite: writes Value {txt: Text}
+  colRead: reads [Value {txt: Text}]
+  colWrite: writes [Value {txt: Text}]
+
+particle PipelineConsumerParticle in 'arcs.core.host.PipelineConsumerParticle'
+  sngRead: reads Value {txt: Text}
+  colRead: reads [Value {txt: Text}]
+
+recipe PipelineTest
+  PipelineProducerParticle
+    sngWrite: writes s1
+    colWrite: writes c1
+  PipelineTransportParticle
+    sngRead: reads s1
+    sngWrite: writes s2
+    colRead: reads c1
+    colWrite: writes c2
+  PipelineConsumerParticle
+    sngRead: reads s2
+    colRead: reads c2


### PR DESCRIPTION
Particles can write to handles in onFirstStart and onStart, but if those writes trigger update notifiactions it can cause events to be received before the particle has reached onReady.