### PR TITLE
Deflake/Fix ReadWriteTest

### DIFF
--- a/java/arcs/android/storage/database/DatabaseImpl.kt
+++ b/java/arcs/android/storage/database/DatabaseImpl.kt
@@ -1019,18 +1019,7 @@ class DatabaseImpl(
 
     /** Deletes everything from the database. */
     override fun reset() {
-        writableDatabase.transaction {
-            execSQL("DELETE FROM collection_entries")
-            execSQL("DELETE FROM collections")
-            execSQL("DELETE FROM entities")
-            execSQL("DELETE FROM entity_refs")
-            execSQL("DELETE FROM field_values")
-            execSQL("DELETE FROM fields")
-            execSQL("DELETE FROM number_primitive_values")
-            execSQL("DELETE FROM storage_keys")
-            execSQL("DELETE FROM text_primitive_values")
-            execSQL("DELETE FROM types")
-        }
+        writableDatabase.transaction { TABLES.forEach { execSQL("DELETE FROM $it") } }
     }
 
     override suspend fun removeAllEntities() {

--- a/java/arcs/core/allocator/Allocator.kt
+++ b/java/arcs/core/allocator/Allocator.kt
@@ -262,24 +262,25 @@ class Allocator(
                     private val mutex = Mutex()
                     private val partitions = mutableMapOf<ArcId, List<Plan.Partition>>()
 
-                    override suspend fun set(arcId: ArcId, partitions: List<Plan.Partition>) {
-                        mutex.withLock {
-                            this.partitions[arcId] = partitions
-                        }
+                    override suspend fun set(
+                        arcId: ArcId,
+                        partitions: List<Plan.Partition>
+                    ) = mutex.withLock {
+                        this.partitions[arcId] = partitions
                     }
 
-                    override suspend fun readPartitions(arcId: ArcId): List<Plan.Partition> {
-                        return mutex.withLock {
-                            this.partitions[arcId] ?: emptyList()
-                        }
+                    override suspend fun readPartitions(
+                        arcId: ArcId
+                    ): List<Plan.Partition> = mutex.withLock {
+                        this.partitions[arcId] ?: emptyList()
                     }
 
-                    override suspend fun readAndClearPartitions(arcId: ArcId): List<Plan.Partition> {
-                        return mutex.withLock {
-                            val oldPartitions = this.partitions[arcId] ?: emptyList()
-                            this.partitions[arcId] = emptyList()
-                            oldPartitions
-                        }
+                    override suspend fun readAndClearPartitions(
+                        arcId: ArcId
+                    ): List<Plan.Partition> = mutex.withLock {
+                        val oldPartitions = this.partitions[arcId] ?: emptyList()
+                        this.partitions[arcId] = emptyList()
+                        oldPartitions
                     }
                 },
                 coroutineContext

--- a/java/arcs/core/allocator/Allocator.kt
+++ b/java/arcs/core/allocator/Allocator.kt
@@ -228,6 +228,10 @@ class Allocator(
             ?: throw ParticleNotFoundException(particle)
 
     companion object {
+        /**
+         * Creates an [Allocator] which serializes Arc/Particle state to the storage system backing
+         * the provided [handleManager].
+         */
         @ExperimentalCoroutinesApi
         fun create(
             hostRegistry: HostRegistry,
@@ -241,6 +245,12 @@ class Allocator(
             )
         }
 
+        /**
+         * Creates an [Allocator] which does not attempt to serialize Arc/Particle state to storage.
+         *
+         * This is primarily useful for tests, but also may be of limited use in production if Arc
+         * serialization and resurrection is not a requirement for your environment.
+         */
         @ExperimentalCoroutinesApi
         fun createNonSerializing(
             hostRegistry: HostRegistry,

--- a/java/arcs/sdk/android/storage/ServiceStore.kt
+++ b/java/arcs/sdk/android/storage/ServiceStore.kt
@@ -158,7 +158,7 @@ class ServiceStore<Data : CrdtData, Op : CrdtOperation, ConsumerData>(
     }
 
     override fun off(callbackToken: Int) {
-        val service = checkNotNull(storageService)
+        val service = storageService ?: return
         runBlocking {
             send {
                 service.unregisterCallback(callbackToken)

--- a/java/arcs/sdk/android/storage/ServiceStore.kt
+++ b/java/arcs/sdk/android/storage/ServiceStore.kt
@@ -133,10 +133,10 @@ class ServiceStore<Data : CrdtData, Op : CrdtOperation, ConsumerData>(
         }
     }
 
-    override suspend fun idle() = coroutineScope<Unit> {
+    override suspend fun idle() = coroutineScope {
         log.debug { "Waiting for service store to be idle" }
         while (outgoingMessages.value > 0) delay(10)
-        val service = checkNotNull(storageService)
+        val service = storageService ?: return@coroutineScope
         val callback = DeferredResult(this@coroutineScope.coroutineContext)
         service.idle(TIMEOUT_IDLE_WAIT_MILLIS, callback)
         withTimeout(TIMEOUT_IDLE_WAIT_MILLIS) { callback.await() }

--- a/java/arcs/sdk/android/storage/service/testutil/TestConnectionFactory.kt
+++ b/java/arcs/sdk/android/storage/service/testutil/TestConnectionFactory.kt
@@ -18,9 +18,9 @@ import arcs.sdk.android.storage.service.DefaultConnectionFactory
 import arcs.sdk.android.storage.service.ManagerConnectionFactory
 import arcs.sdk.android.storage.service.StorageService
 import arcs.sdk.android.storage.service.StorageServiceBindingDelegate
+import java.util.concurrent.ConcurrentHashMap
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.robolectric.Robolectric
-import java.util.concurrent.ConcurrentHashMap
 
 /**
  * Create a [ConnectionFactory] that creates service bindings using a [Robolectric] service

--- a/java/arcs/sdk/android/storage/service/testutil/TestConnectionFactory.kt
+++ b/java/arcs/sdk/android/storage/service/testutil/TestConnectionFactory.kt
@@ -11,6 +11,7 @@
 package arcs.sdk.android.storage.service.testutil
 
 import android.content.Context
+import android.content.Intent
 import android.content.ServiceConnection
 import arcs.android.storage.ParcelableStoreOptions
 import arcs.sdk.android.storage.service.DefaultConnectionFactory
@@ -19,6 +20,7 @@ import arcs.sdk.android.storage.service.StorageService
 import arcs.sdk.android.storage.service.StorageServiceBindingDelegate
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.robolectric.Robolectric
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * Create a [ConnectionFactory] that creates service bindings using a [Robolectric] service
@@ -46,6 +48,7 @@ class TestBindingDelegate(private val context: Context) : StorageServiceBindingD
     private val serviceController by lazy {
         Robolectric.buildService(StorageService::class.java, null).create()
     }
+    private val bindings = ConcurrentHashMap<ServiceConnection, Intent>()
 
     @ExperimentalCoroutinesApi
     override fun bindStorageService(
@@ -55,12 +58,17 @@ class TestBindingDelegate(private val context: Context) : StorageServiceBindingD
     ): Boolean {
         val intent = StorageService.createBindIntent(context, options!!)
         val binder = serviceController.get().onBind(intent)
+        bindings[conn] = intent
         conn.onServiceConnected(null, binder)
         return true
     }
 
     override fun unbindStorageService(conn: ServiceConnection) {
-        serviceController.destroy()
+        val intent = bindings.remove(conn)
+        serviceController.get().onUnbind(intent)
+        if (bindings.isEmpty()) {
+            serviceController.destroy()
+        }
     }
 }
 

--- a/javatests/arcs/showcase/BUILD
+++ b/javatests/arcs/showcase/BUILD
@@ -21,6 +21,7 @@ arcs_kt_android_library(
         "//java/arcs/core/host",
         "//java/arcs/core/storage",
         "//java/arcs/core/storage/api",
+        "//java/arcs/core/storage/database",
         "//java/arcs/core/storage/driver",
         "//java/arcs/core/util",
         "//java/arcs/jvm/host",

--- a/javatests/arcs/showcase/BUILD
+++ b/javatests/arcs/showcase/BUILD
@@ -33,5 +33,6 @@ arcs_kt_android_library(
         "//third_party/java/androidx/work:testing",
         "//third_party/java/junit:junit-android",
         "//third_party/kotlin/kotlinx_coroutines",
+        "//third_party/kotlin/kotlinx_coroutines:kotlinx_coroutines_android",
     ],
 )

--- a/javatests/arcs/showcase/BUILD
+++ b/javatests/arcs/showcase/BUILD
@@ -21,6 +21,8 @@ arcs_kt_android_library(
         "//java/arcs/core/host",
         "//java/arcs/core/storage",
         "//java/arcs/core/storage/api",
+        "//java/arcs/core/storage/driver",
+        "//java/arcs/core/util",
         "//java/arcs/jvm/host",
         "//java/arcs/jvm/util",
         "//java/arcs/sdk/android/storage",

--- a/javatests/arcs/showcase/ShowcaseEnvironment.kt
+++ b/javatests/arcs/showcase/ShowcaseEnvironment.kt
@@ -29,16 +29,14 @@ import arcs.jvm.util.JvmTime
 import arcs.sdk.Particle
 import arcs.sdk.android.storage.ServiceStoreFactory
 import arcs.sdk.android.storage.service.testutil.TestConnectionFactory
-import kotlinx.coroutines.Dispatchers
+import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import org.junit.rules.TestRule
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
-import kotlin.coroutines.CoroutineContext
 
 /**
  * A JUnit rule setting up an Arcs environment for showcasing features.

--- a/javatests/arcs/showcase/ShowcaseEnvironment.kt
+++ b/javatests/arcs/showcase/ShowcaseEnvironment.kt
@@ -226,7 +226,6 @@ class ShowcaseEnvironment(
             } catch (e: IllegalStateException) {
                 // There is a bug in LifecycleRegistry where occasionally we seem to get
                 // the lifecycles messed up, let's just ignore.
-                throw e
             }
         }
 

--- a/javatests/arcs/showcase/ShowcaseEnvironment.kt
+++ b/javatests/arcs/showcase/ShowcaseEnvironment.kt
@@ -167,12 +167,6 @@ class ShowcaseEnvironment(
 
         // Set up an android lifecycle for our arc host and store managers.
         val lifecycleOwner = FakeLifecycleOwner()
-        val observer = object : LifecycleObserver {
-            @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)
-            fun onDestroy() = Unit
-        }
-        lifecycleOwner.lifecycle.addObserver(observer)
-        // Initialize it to started.
         withContext(Dispatchers.Main.immediate) {
             lifecycleOwner.lifecycle.currentState = Lifecycle.State.RESUMED
         }
@@ -210,23 +204,9 @@ class ShowcaseEnvironment(
     }
 
     private suspend fun teardownArcs(components: ShowcaseArcsComponents) {
-        // Shutting down/cleaning-up...
-
         // Stop all the arcs and shut down the arcHost.
         startedArcs.forEach { it.stop() }
         components.arcHost.shutdown()
-
-        /*
-        // Tell the ServiceStores that they should unbind.
-        withContext(Dispatchers.Main.immediate) {
-            try {
-                components.arcHostLifecycle.lifecycle.currentState = Lifecycle.State.DESTROYED
-            } catch (e: IllegalStateException) {
-                // There is a bug in LifecycleRegistry where occasionally we seem to get
-                // the lifecycles messed up, let's just ignore.
-            }
-        }
-         */
 
         // Reset the Databases and close them.
         components.dbManager.resetAll()

--- a/javatests/arcs/showcase/ShowcaseEnvironment.kt
+++ b/javatests/arcs/showcase/ShowcaseEnvironment.kt
@@ -4,10 +4,8 @@ package arcs.showcase
 
 import android.app.Application
 import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleRegistry
-import androidx.lifecycle.OnLifecycleEvent
 import androidx.test.core.app.ApplicationProvider
 import androidx.work.testing.WorkManagerTestInitHelper
 import arcs.android.storage.database.AndroidSqliteDatabaseManager
@@ -16,14 +14,12 @@ import arcs.core.allocator.Arc
 import arcs.core.data.Plan
 import arcs.core.host.AbstractArcHost
 import arcs.core.host.ArcHost
-import arcs.core.host.EntityHandleManager
 import arcs.core.host.ParticleRegistration
 import arcs.core.host.ParticleState
 import arcs.core.host.SchedulerProvider
 import arcs.core.storage.ActivationFactory
 import arcs.core.storage.StoreManager
 import arcs.core.storage.api.DriverAndKeyConfigurator
-import arcs.core.storage.database.DatabaseManager
 import arcs.core.storage.driver.RamDisk
 import arcs.core.util.TaggedLog
 import arcs.jvm.host.ExplicitHostRegistry

--- a/javatests/arcs/showcase/ShowcaseEnvironment.kt
+++ b/javatests/arcs/showcase/ShowcaseEnvironment.kt
@@ -179,7 +179,15 @@ class ShowcaseEnvironment(
 
                     // Tell the ServiceStores that they should unbind.
                     withContext(Dispatchers.Main.immediate) {
-                        lifecycleOwner.lifecycle.currentState = Lifecycle.State.DESTROYED
+                        try {
+                            lifecycleOwner.lifecycle.currentState = Lifecycle.State.DESTROYED
+                        } catch (e: IllegalStateException) {
+                            // There is a bug in LifecycleRegistry where occasionally we seem to get
+                            // the lifecycles messed up.
+                            if (e.message?.contains("no event down") != true) {
+                                throw e
+                            }
+                        }
                     }
 
                     // Reset the Databases and close them.

--- a/javatests/arcs/showcase/ShowcaseEnvironment.kt
+++ b/javatests/arcs/showcase/ShowcaseEnvironment.kt
@@ -150,11 +150,15 @@ class ShowcaseEnvironment(
 
         // Initializing the environment...
         val context = ApplicationProvider.getApplicationContext<Application>()
+        WorkManagerTestInitHelper.initializeTestWorkManager(context)
 
         // Set up the Database manager, drivers, and keys/key-parsers.
-        val dbManager = AndroidSqliteDatabaseManager(context)
+        val dbManager = AndroidSqliteDatabaseManager(context).also {
+            // Be sure we always start with a fresh, empty database.
+            it.resetAll()
+        }
+
         DriverAndKeyConfigurator.configure(dbManager)
-        WorkManagerTestInitHelper.initializeTestWorkManager(context)
 
         // Set up an android lifecycle for our arc host and store managers.
         val lifecycleOwner = object : LifecycleOwner {

--- a/javatests/arcs/showcase/ShowcaseEnvironment.kt
+++ b/javatests/arcs/showcase/ShowcaseEnvironment.kt
@@ -175,7 +175,7 @@ class ShowcaseEnvironment(
                         arcHostStoreManager.waitForIdle()
 
                         // Tell the ServiceStores that they should unbind.
-                        withContext(Dispatchers.Main) {
+                        withContext(Dispatchers.Main.immediate) {
                             lifecycleOwner.lifecycle
                                 .handleLifecycleEvent(Lifecycle.Event.ON_PAUSE)
                             lifecycleOwner.lifecycle

--- a/javatests/arcs/showcase/ShowcaseEnvironment.kt
+++ b/javatests/arcs/showcase/ShowcaseEnvironment.kt
@@ -127,9 +127,9 @@ class ShowcaseEnvironment(
                     override fun getLifecycle() = lifecycle
                 }
                 // Initialize it to started.
-                lifecycleOwner.lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_CREATE)
-                lifecycleOwner.lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_START)
-                lifecycleOwner.lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_RESUME)
+                lifecycleOwner.lifecycle.currentState = Lifecycle.State.INITIALIZED
+                lifecycleOwner.lifecycle.currentState = Lifecycle.State.CREATED
+                lifecycleOwner.lifecycle.currentState = Lifecycle.State.STARTED
 
                 // Create a single scheduler provider for both the ArcHost as well as the Allocator.
                 val schedulerProvider = JvmSchedulerProvider(EmptyCoroutineContext)
@@ -176,12 +176,8 @@ class ShowcaseEnvironment(
 
                         // Tell the ServiceStores that they should unbind.
                         withContext(Dispatchers.Main.immediate) {
-                            lifecycleOwner.lifecycle
-                                .handleLifecycleEvent(Lifecycle.Event.ON_PAUSE)
-                            lifecycleOwner.lifecycle
-                                .handleLifecycleEvent(Lifecycle.Event.ON_STOP)
-                            lifecycleOwner.lifecycle
-                                .handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+                            lifecycleOwner.lifecycle.currentState = Lifecycle.State.CREATED
+                            lifecycleOwner.lifecycle.currentState = Lifecycle.State.DESTROYED
                         }
 
                         // Reset the Databases and close them.

--- a/javatests/arcs/showcase/ShowcaseEnvironment.kt
+++ b/javatests/arcs/showcase/ShowcaseEnvironment.kt
@@ -216,9 +216,7 @@ class ShowcaseEnvironment(
         startedArcs.forEach { it.stop() }
         components.arcHost.shutdown()
 
-        // Wait for our stores to become idle.
-        components.arcHostStoreManager.waitForIdle()
-
+        /*
         // Tell the ServiceStores that they should unbind.
         withContext(Dispatchers.Main.immediate) {
             try {
@@ -228,6 +226,7 @@ class ShowcaseEnvironment(
                 // the lifecycles messed up, let's just ignore.
             }
         }
+         */
 
         // Reset the Databases and close them.
         components.dbManager.resetAll()

--- a/javatests/arcs/showcase/references/ArcsStorage.kt
+++ b/javatests/arcs/showcase/references/ArcsStorage.kt
@@ -13,9 +13,7 @@ class ArcsStorage(private val env: ShowcaseEnvironment) {
     // wait for the result, and to wrap the suspend methods in a timeout, converting a potential
     // test timeout into a more specific test failure.
     private inline fun <T> run(crossinline block: suspend () -> T) = runBlocking {
-        withTimeout(15000) {
-            block()
-        }
+        withTimeout(30000) { block() }
     }
 
     fun all0(): List<MyLevel0> = run {

--- a/javatests/arcs/showcase/references/BUILD
+++ b/javatests/arcs/showcase/references/BUILD
@@ -57,6 +57,7 @@ arcs_kt_android_test_suite(
         "//java/arcs/core/storage/api",
         "//java/arcs/core/storage/database",
         "//java/arcs/core/testutil",
+        "//java/arcs/core/util/testutil",
         "//javatests/arcs/showcase",
         "//third_party/android/androidx_test/ext/junit",
         "//third_party/java/junit:junit-android",

--- a/javatests/arcs/showcase/references/BUILD
+++ b/javatests/arcs/showcase/references/BUILD
@@ -46,6 +46,7 @@ arcs_kt_android_library(
 
 arcs_kt_android_test_suite(
     name = "tests",
+    size = "medium",
     srcs = glob(["*Test.kt"]),
     manifest = "//java/arcs/android/common:AndroidManifest.xml",
     package = "arcs.showcase.references",

--- a/javatests/arcs/showcase/references/ReadWriteTest.kt
+++ b/javatests/arcs/showcase/references/ReadWriteTest.kt
@@ -2,10 +2,10 @@ package arcs.showcase.references
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import arcs.core.host.toRegistration
+import arcs.core.util.testutil.LogRule
 import arcs.showcase.ShowcaseEnvironment
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -13,6 +13,9 @@ import org.junit.runner.RunWith
 @ExperimentalCoroutinesApi
 @RunWith(AndroidJUnit4::class)
 class ReadWriteTest {
+
+    @get:Rule
+    val log = LogRule()
 
     @get:Rule
     val env = ShowcaseEnvironment(

--- a/javatests/arcs/showcase/references/ReadWriteTest.kt
+++ b/javatests/arcs/showcase/references/ReadWriteTest.kt
@@ -31,14 +31,12 @@ class ReadWriteTest {
     private val l2 = MyLevel2("l2-1", setOf(l1))
 
     @Test
-    @Ignore("b/156993103 - Deflake")
     fun writeAndReadBack0() {
         storage.put0(l0)
         assertThat(storage.all0()).containsExactly(l0)
     }
 
     @Test
-    @Ignore("b/157088298 - Deflake")
     fun writeAndReadBack1() {
         storage.put1(l1)
         assertThat(storage.all1()).containsExactly(l1)

--- a/javatests/arcs/showcase/references/Reader.kt
+++ b/javatests/arcs/showcase/references/Reader.kt
@@ -1,4 +1,4 @@
-@file:Suppress("EXPERIMENTAL_FEATURE_WARNING")
+@file:Suppress("EXPERIMENTAL_FEATURE_WARNING", "EXPERIMENTAL_API_USAGE")
 
 package arcs.showcase.references
 


### PR DESCRIPTION
* Fixes some issues in the `ShowcaseEnvironment` JUnit rule around the procedures required to start-up and shut-down Arcs in such a way as to keep the tests hermetic.
* Makes the `TestConnectionFactory` function more like how android works in when it invokes `onDestroy`/`onUnbind`.
* Minor cleanup in `DatabaseImpl` to use the latest list of table names when performing a reset op, rather than hard-coding them into the method directly.

Related bugs:

http://b/160632000
http://b/156993103
http://b/157088298