### PR TITLE
prefetch protos and build schemas at syshealth app startup

### DIFF
--- a/javatests/arcs/android/systemhealth/testapp/TestApplication.kt
+++ b/javatests/arcs/android/systemhealth/testapp/TestApplication.kt
@@ -39,9 +39,9 @@ open class TestApplication : Application(), Configuration.Provider {
         // will be destroyed after 1-second idleness.
         ProtoPrefetcher.prefetch(
             ThreadPoolExecutor(
-                0,
-                1,
-                1L,
+                /*corePoolSize=*/0,
+                /*maximumPoolSize=*/1,
+                /*keepAliveTime=*/1L,
                 TimeUnit.SECONDS,
                 SynchronousQueue<Runnable>()
             )

--- a/javatests/arcs/android/systemhealth/testapp/TestApplication.kt
+++ b/javatests/arcs/android/systemhealth/testapp/TestApplication.kt
@@ -14,11 +14,15 @@ package arcs.android.systemhealth.testapp
 import android.app.Application
 import androidx.work.Configuration
 import arcs.android.storage.database.AndroidSqliteDatabaseManager
+import arcs.android.util.ProtoPrefetcher
 import arcs.android.util.connectMemoryStatsPipe
 import arcs.android.util.initLogForAndroid
 import arcs.core.data.SchemaRegistry
 import arcs.core.storage.api.DriverAndKeyConfigurator
 import arcs.core.storage.driver.RamDisk
+import java.util.concurrent.SynchronousQueue
+import java.util.concurrent.ThreadPoolExecutor
+import java.util.concurrent.TimeUnit
 
 /** Application class for Arcs System Health measures. */
 open class TestApplication : Application(), Configuration.Provider {
@@ -30,6 +34,18 @@ open class TestApplication : Application(), Configuration.Provider {
 
     override fun onCreate() {
         super.onCreate()
+
+        // Prefetch protos and build proto schemas at a thread which
+        // will be destroyed after 1-second idleness.
+        ProtoPrefetcher.prefetch(
+            ThreadPoolExecutor(
+                0,
+                1,
+                1L,
+                TimeUnit.SECONDS,
+                SynchronousQueue<Runnable>()
+            )
+        )
 
         RamDisk.clear()
         SchemaRegistry.register(TestEntity.SCHEMA)


### PR DESCRIPTION
Given we removed ProtoPrefetcher at Arcs and StorageService startup, apps need to do this on their own.