### PR TITLE
Trace sqlite transactions

### DIFF
--- a/java/arcs/android/common/SqlUtils.kt
+++ b/java/arcs/android/common/SqlUtils.kt
@@ -16,13 +16,13 @@ import android.database.sqlite.SQLiteDatabase
 import android.database.sqlite.SQLiteProgram
 
 inline fun <T : Any?> SQLiteDatabase.transaction(block: SQLiteDatabase.() -> T): T {
-    beginTransaction()
+    scopedTrace("beginTransaction", ::beginTransaction)
     return try {
         block().also {
             setTransactionSuccessful()
         }
     } finally {
-        endTransaction()
+        scopedTrace("endTransaction", ::endTransaction)
     }
 }
 

--- a/java/arcs/android/common/TraceUtils.kt
+++ b/java/arcs/android/common/TraceUtils.kt
@@ -17,8 +17,9 @@ import android.os.Trace
  * Harness [android.os.Trace] trace points identified by
  * the trace [tag] to the entry and the exit of the [block].
  */
-inline fun scopedTrace(tag: String, block: () -> Unit) {
+inline fun <T> scopedTrace(tag: String, block: () -> T): T {
     Trace.beginSection(tag)
-    block()
+    val result = block()
     Trace.endSection()
+    return result
 }

--- a/java/arcs/android/common/TraceUtils.kt
+++ b/java/arcs/android/common/TraceUtils.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.android.common
+
+import android.os.Trace
+
+/**
+ * Harness [android.os.Trace] trace points identified by
+ * the trace [tag] to the entry and the exit of the [block].
+ */
+inline fun scopedTrace(tag: String, block: () -> Unit) {
+    Trace.beginSection(tag)
+    block()
+    Trace.endSection()
+}


### PR DESCRIPTION
To trace contention of database accesses under single file-based rw lock, adding trace points to `beginTransaction` as well as `endTransaction`.

This is part of work from [cl/317806991](http://cl/317806991) 