### PR TITLE
Splits Kotlin-Wasm golden from the rest

### DIFF
--- a/src/tools/tests/BUILD
+++ b/src/tools/tests/BUILD
@@ -18,8 +18,8 @@ filegroup(
     srcs = [
         ":golden.h",
         ":golden-kt_GeneratedSchemas.jvm.kt",
+        ":golden-wasm_GeneratedSchemas.wasm.kt",
         ":golden_GeneratedSchemas.jvm.kt",
-        ":golden_GeneratedSchemas.wasm.kt",
         ":golden_TestHarness.kt",
     ],
 )
@@ -40,10 +40,12 @@ arcs_kt_schema(
 arcs_kt_schema(
     name = "kt_schemas",
     srcs = ["golden.arcs"],
-    platforms = [
-        "jvm",
-        "wasm",
-    ],
+)
+
+arcs_kt_schema(
+    name = "kt_wasm_schemas",
+    srcs = ["golden_wasm.arcs"],
+    platforms = ["wasm"],
 )
 
 arcs_ts_test(

--- a/src/tools/tests/golden_wasm.arcs
+++ b/src/tools/tests/golden_wasm.arcs
@@ -1,0 +1,18 @@
+// Example manifest file, serving as a test for the schema2kotlin and schema2cpp
+// code generators.
+meta
+  namespace: arcs.golden
+
+particle Gold
+  data: reads {num: Number, txt: Text, lnk: URL, flg: Boolean}
+
+  // Same as qCollection but without refinement + query (to ensure that types with refinements generated properly using their base class.
+  allPeople: reads [People {name: Text, age: Number, lastCall: Number, address: Text, favoriteColor: Text, birthDayMonth: Number, birthDayDOM: Number}]
+
+  // These are People that have a lastCall value less than three (24 hour) days ago
+  // lastCall represents the time since last phone call to/from this contact (in seconds)
+  qCollection: reads [People {name: Text, age: Number, lastCall: Number, address: Text, favoriteColor: Text, birthDayMonth: Number, birthDayDOM: Number}[lastCall < 3*24*60*60 and name == ?]]
+
+  alias: writes {val: Text}
+
+  collection: reads [Foo {num: Number}]

--- a/src/tools/tests/goldens/generated-schemas.wasm.kt
+++ b/src/tools/tests/goldens/generated-schemas.wasm.kt
@@ -11,11 +11,10 @@ package arcs.golden
 import arcs.sdk.*
 import arcs.sdk.wasm.*
 
-typealias Gold_Data_Ref = AbstractGold.GoldInternal1
-typealias Gold_Alias = AbstractGold.GoldInternal1
-typealias Gold_AllPeople = AbstractGold.Gold_AllPeople
-typealias Gold_Collection = AbstractGold.Foo
 typealias Gold_Data = AbstractGold.Gold_Data
+typealias Gold_AllPeople = AbstractGold.Gold_AllPeople
+typealias Gold_Alias = AbstractGold.Gold_Alias
+typealias Gold_Collection = AbstractGold.Foo
 typealias Gold_QCollection = AbstractGold.Gold_QCollection
 
 abstract class AbstractGold : WasmParticleImpl() {
@@ -23,9 +22,29 @@ abstract class AbstractGold : WasmParticleImpl() {
 
 
     @Suppress("UNCHECKED_CAST")
-    class GoldInternal1(val_: String = "") : WasmEntity {
+    class Gold_Data(
+        num: Double = 0.0,
+        txt: String = "",
+        lnk: String = "",
+        flg: Boolean = false
+    ) : WasmEntity {
 
-        var val_ = val_
+        var num = num
+            get() = field
+            private set(_value) {
+                field = _value
+            }
+        var txt = txt
+            get() = field
+            private set(_value) {
+                field = _value
+            }
+        var lnk = lnk
+            get() = field
+            private set(_value) {
+                field = _value
+            }
+        var flg = flg
             get() = field
             private set(_value) {
                 field = _value
@@ -33,41 +52,67 @@ abstract class AbstractGold : WasmParticleImpl() {
 
         override var entityId = ""
 
-        fun copy(val_: String = this.val_) = GoldInternal1(val_ = val_)
+        fun copy(
+            num: Double = this.num,
+            txt: String = this.txt,
+            lnk: String = this.lnk,
+            flg: Boolean = this.flg
+        ) = Gold_Data(num = num, txt = txt, lnk = lnk, flg = flg)
 
 
         fun reset() {
-            val_ = ""
+            num = 0.0
+            txt = ""
+            lnk = ""
+            flg = false
         }
 
         override fun encodeEntity(): NullTermByteArray {
             val encoder = StringEncoder()
             encoder.encode("", entityId)
-            val_.let { encoder.encode("val:T", val_) }
+            num.let { encoder.encode("num:N", num) }
+            txt.let { encoder.encode("txt:T", txt) }
+            lnk.let { encoder.encode("lnk:U", lnk) }
+            flg.let { encoder.encode("flg:B", flg) }
             return encoder.toNullTermByteArray()
         }
 
         override fun toString() =
-            "GoldInternal1(val_ = $val_)"
+            "Gold_Data(num = $num, txt = $txt, lnk = $lnk, flg = $flg)"
 
-        companion object : WasmEntitySpec<GoldInternal1> {
+        companion object : WasmEntitySpec<Gold_Data> {
 
 
-            override fun decode(encoded: ByteArray): GoldInternal1? {
+            override fun decode(encoded: ByteArray): Gold_Data? {
                 if (encoded.isEmpty()) return null
 
                 val decoder = StringDecoder(encoded)
                 val entityId = decoder.decodeText()
                 decoder.validate("|")
 
-                var val_ = ""
+                var num = 0.0
+            var txt = ""
+            var lnk = ""
+            var flg = false
                 var i = 0
-                while (i < 1 && !decoder.done()) {
+                while (i < 4 && !decoder.done()) {
                     val _name = decoder.upTo(':').toUtf8String()
                     when (_name) {
-                        "val" -> {
+                        "num" -> {
+                        decoder.validate("N")
+                        num = decoder.decodeNum()
+                    }
+                    "txt" -> {
                         decoder.validate("T")
-                        val_ = decoder.decodeText()
+                        txt = decoder.decodeText()
+                    }
+                    "lnk" -> {
+                        decoder.validate("U")
+                        lnk = decoder.decodeText()
+                    }
+                    "flg" -> {
+                        decoder.validate("B")
+                        flg = decoder.decodeBool()
                     }
                         else -> {
                             // Ignore unknown fields until type slicing is fully implemented.
@@ -82,8 +127,8 @@ abstract class AbstractGold : WasmParticleImpl() {
                     decoder.validate("|")
                     i++
                 }
-                val _rtn = GoldInternal1().copy(
-                    val_ = val_
+                val _rtn = Gold_Data().copy(
+                    num = num, txt = txt, lnk = lnk, flg = flg
                 )
                _rtn.entityId = entityId
                 return _rtn
@@ -265,6 +310,75 @@ abstract class AbstractGold : WasmParticleImpl() {
     }
 
     @Suppress("UNCHECKED_CAST")
+    class Gold_Alias(val_: String = "") : WasmEntity {
+
+        var val_ = val_
+            get() = field
+            private set(_value) {
+                field = _value
+            }
+
+        override var entityId = ""
+
+        fun copy(val_: String = this.val_) = Gold_Alias(val_ = val_)
+
+
+        fun reset() {
+            val_ = ""
+        }
+
+        override fun encodeEntity(): NullTermByteArray {
+            val encoder = StringEncoder()
+            encoder.encode("", entityId)
+            val_.let { encoder.encode("val:T", val_) }
+            return encoder.toNullTermByteArray()
+        }
+
+        override fun toString() =
+            "Gold_Alias(val_ = $val_)"
+
+        companion object : WasmEntitySpec<Gold_Alias> {
+
+
+            override fun decode(encoded: ByteArray): Gold_Alias? {
+                if (encoded.isEmpty()) return null
+
+                val decoder = StringDecoder(encoded)
+                val entityId = decoder.decodeText()
+                decoder.validate("|")
+
+                var val_ = ""
+                var i = 0
+                while (i < 1 && !decoder.done()) {
+                    val _name = decoder.upTo(':').toUtf8String()
+                    when (_name) {
+                        "val" -> {
+                        decoder.validate("T")
+                        val_ = decoder.decodeText()
+                    }
+                        else -> {
+                            // Ignore unknown fields until type slicing is fully implemented.
+                            when (decoder.chomp(1).toUtf8String()) {
+                                "T", "U" -> decoder.decodeText()
+                                "N" -> decoder.decodeNum()
+                                "B" -> decoder.decodeBool()
+                            }
+                            i--
+                        }
+                    }
+                    decoder.validate("|")
+                    i++
+                }
+                val _rtn = Gold_Alias().copy(
+                    val_ = val_
+                )
+               _rtn.entityId = entityId
+                return _rtn
+            }
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
     class Foo(num: Double = 0.0) : WasmEntity {
 
         var num = num
@@ -326,121 +440,6 @@ abstract class AbstractGold : WasmParticleImpl() {
                 }
                 val _rtn = Foo().copy(
                     num = num
-                )
-               _rtn.entityId = entityId
-                return _rtn
-            }
-        }
-    }
-
-    @Suppress("UNCHECKED_CAST")
-    class Gold_Data(
-        num: Double = 0.0,
-        txt: String = "",
-        lnk: String = "",
-        flg: Boolean = false
-    ) : WasmEntity {
-
-        var num = num
-            get() = field
-            private set(_value) {
-                field = _value
-            }
-        var txt = txt
-            get() = field
-            private set(_value) {
-                field = _value
-            }
-        var lnk = lnk
-            get() = field
-            private set(_value) {
-                field = _value
-            }
-        var flg = flg
-            get() = field
-            private set(_value) {
-                field = _value
-            }
-
-        override var entityId = ""
-
-        fun copy(
-            num: Double = this.num,
-            txt: String = this.txt,
-            lnk: String = this.lnk,
-            flg: Boolean = this.flg
-        ) = Gold_Data(num = num, txt = txt, lnk = lnk, flg = flg)
-
-
-        fun reset() {
-            num = 0.0
-            txt = ""
-            lnk = ""
-            flg = false
-        }
-
-        override fun encodeEntity(): NullTermByteArray {
-            val encoder = StringEncoder()
-            encoder.encode("", entityId)
-            num.let { encoder.encode("num:N", num) }
-            txt.let { encoder.encode("txt:T", txt) }
-            lnk.let { encoder.encode("lnk:U", lnk) }
-            flg.let { encoder.encode("flg:B", flg) }
-            return encoder.toNullTermByteArray()
-        }
-
-        override fun toString() =
-            "Gold_Data(num = $num, txt = $txt, lnk = $lnk, flg = $flg)"
-
-        companion object : WasmEntitySpec<Gold_Data> {
-
-
-            override fun decode(encoded: ByteArray): Gold_Data? {
-                if (encoded.isEmpty()) return null
-
-                val decoder = StringDecoder(encoded)
-                val entityId = decoder.decodeText()
-                decoder.validate("|")
-
-                var num = 0.0
-            var txt = ""
-            var lnk = ""
-            var flg = false
-                var i = 0
-                while (i < 5 && !decoder.done()) {
-                    val _name = decoder.upTo(':').toUtf8String()
-                    when (_name) {
-                        "num" -> {
-                        decoder.validate("N")
-                        num = decoder.decodeNum()
-                    }
-                    "txt" -> {
-                        decoder.validate("T")
-                        txt = decoder.decodeText()
-                    }
-                    "lnk" -> {
-                        decoder.validate("U")
-                        lnk = decoder.decodeText()
-                    }
-                    "flg" -> {
-                        decoder.validate("B")
-                        flg = decoder.decodeBool()
-                    }
-                        else -> {
-                            // Ignore unknown fields until type slicing is fully implemented.
-                            when (decoder.chomp(1).toUtf8String()) {
-                                "T", "U" -> decoder.decodeText()
-                                "N" -> decoder.decodeNum()
-                                "B" -> decoder.decodeBool()
-                            }
-                            i--
-                        }
-                    }
-                    decoder.validate("|")
-                    i++
-                }
-                val _rtn = Gold_Data().copy(
-                    num = num, txt = txt, lnk = lnk, flg = flg
                 )
                _rtn.entityId = entityId
                 return _rtn

--- a/src/tools/tests/schema-generator-test.ts
+++ b/src/tools/tests/schema-generator-test.ts
@@ -24,7 +24,7 @@ const testData = [
   },
   {
     label: 'Kotlin (wasm)',
-    generated: 'src/tools/tests/golden_GeneratedSchemas.wasm.kt',
+    generated: 'src/tools/tests/golden-wasm_GeneratedSchemas.wasm.kt',
     golden: 'src/tools/tests/goldens/generated-schemas.wasm.kt',
   },
   {

--- a/tools/update-goldens
+++ b/tools/update-goldens
@@ -7,7 +7,7 @@ cd $ROOT
 
 status "[ 1 / 5 ] Kotlin Goldens for Jvm and Wasm"
 tools/sigh schema2wasm --quiet --kotlin src/tools/tests/golden.arcs --outdir src/tools/tests/goldens/ --outfile generated-schemas.jvm.kt
-tools/sigh schema2wasm --quiet --kotlin src/tools/tests/golden.arcs --outdir src/tools/tests/goldens/ --outfile generated-schemas.wasm.kt --wasm
+tools/sigh schema2wasm --quiet --kotlin src/tools/tests/golden_wasm.arcs --outdir src/tools/tests/goldens/ --outfile generated-schemas.wasm.kt --wasm
 
 status "[ 2 / 5 ] C++ Golden"
 tools/sigh schema2wasm --quiet --cpp src/tools/tests/golden.arcs --outdir src/tools/tests/goldens/


### PR DESCRIPTION
Field generation logic for WASM is funny in that it silently ignores references. This behaviour is a problem in my follow up PR where I have rewritten the logic for increased clarity.

This PR splits the source golden for wasm into golden_wasm.arcs and removes the field from a reference with it. This will unblock my change which allows `List<&Thing>` and in general cleans this stuff up.