### PR TITLE
Use fully qualified symbols for all arc system classes in generated code

### DIFF
--- a/src/tools/kotlin-schema-field.ts
+++ b/src/tools/kotlin-schema-field.ts
@@ -153,7 +153,7 @@ class ReferenceType extends TypeContainer {
   }
 
   getKotlinType(contained: boolean) {
-    return `Reference<${this.innerKotlinType}>${contained ? '' : '?'}`;
+    return `arcs.sdk.Reference<${this.innerKotlinType}>${contained ? '' : '?'}`;
   }
 
   get defaultVal() {

--- a/src/tools/kotlin-schema-generator.ts
+++ b/src/tools/kotlin-schema-generator.ts
@@ -18,9 +18,9 @@ const ktUtils = new KotlinGenerationUtils();
  * Generates a Kotlin schema instance.
  */
 export async function generateSchema(schema: Schema): Promise<string> {
-  if (schema.equals(Schema.EMPTY)) return `Schema.EMPTY`;
+  if (schema.equals(Schema.EMPTY)) return `arcs.core.data.Schema.EMPTY`;
 
-  const schemaNames = schema.names.map(n => `SchemaName("${n}")`);
+  const schemaNames = schema.names.map(n => `arcs.core.data.SchemaName("${n}")`);
   const {refinement, query} = generatePredicates(schema);
 
   const singletons: string[] = [];
@@ -30,9 +30,9 @@ export async function generateSchema(schema: Schema): Promise<string> {
       (isCollection ? collections : singletons).push(`"${field}" to ${schemaType}`));
 
   return `\
-Schema(
+arcs.core.data.Schema(
     setOf(${ktUtils.joinWithIndents(schemaNames, {startIndent: 8})}),
-    SchemaFields(
+    arcs.core.data.SchemaFields(
         singletons = ${leftPad(ktUtils.mapOf(singletons, 30), 8, true)},
         collections = ${leftPad(ktUtils.mapOf(collections, 30), 8, true)}
     ),
@@ -73,33 +73,34 @@ async function visitSchemaFields(schema: Schema, visitor: (field: SchemaField) =
 }
 
 async function getSchemaType(field: string, {kind, schema, type, innerType}): Promise<string> {
+  const fieldType = 'arcs.core.data.FieldType'
   if (kind === 'schema-primitive') {
     switch (type) {
-      case 'Text': return 'FieldType.Text';
-      case 'URL': return 'FieldType.Text';
-      case 'Number': return 'FieldType.Number';
-      case 'BigInt': return 'FieldType.BigInt';
-      case 'Boolean': return 'FieldType.Boolean';
+      case 'Text': return `${fieldType}.Text`;
+      case 'URL': return `${fieldType}.Text`;
+      case 'Number': return `${fieldType}.Number`;
+      case 'BigInt': return `${fieldType}.BigInt`;
+      case 'Boolean': return `${fieldType}.Boolean`;
       default: break;
     }
   } else if (kind === 'kotlin-primitive') {
     switch (type) {
-      case 'Byte': return 'FieldType.Byte';
-      case 'Short': return 'FieldType.Short';
-      case 'Int': return 'FieldType.Int';
-      case 'Long': return 'FieldType.Long';
-      case 'Char': return 'FieldType.Char';
-      case 'Float': return 'FieldType.Float';
-      case 'Double': return 'FieldType.Double';
+      case 'Byte': return `${fieldType}.Byte`;
+      case 'Short': return `${fieldType}.Short`;
+      case 'Int': return `${fieldType}.Int`;
+      case 'Long': return `${fieldType}.Long`;
+      case 'Char': return `${fieldType}.Char`;
+      case 'Float': return `${fieldType}.Float`;
+      case 'Double': return `${fieldType}.Double`;
       default: break;
     }
   } else if (kind === 'schema-reference') {
-    return `FieldType.EntityRef(${quote(await schema.model.getEntitySchema().hash())})`;
+    return `${fieldType}.EntityRef(${quote(await schema.model.getEntitySchema().hash())})`;
   } else if (kind === 'schema-nested') {
-    return `FieldType.InlineEntity(${quote(await schema.model.getEntitySchema().hash())})`;
+    return `${fieldType}.InlineEntity(${quote(await schema.model.getEntitySchema().hash())})`;
   } else if (kind === 'schema-ordered-list') {
     assert(innerType, 'innerType must be provided for Lists');
-    return `FieldType.ListOf(${innerType})`;
+    return `${fieldType}.ListOf(${innerType})`;
   }
 
   throw new Error(`Schema kind '${kind}' for field '${field}' and type '${type}' is not supported`);

--- a/src/tools/kotlin-type-generator.ts
+++ b/src/tools/kotlin-type-generator.ts
@@ -36,7 +36,7 @@ export async function generateConnectionSpecType(connection: HandleConnectionSpe
     if (!type.isEntity) return null;
     if (connection.type.hasVariable) return null;
     const node = nodes.find(n => n.schema.equals(type.getEntitySchema()));
-    return ktUtils.applyFun('EntityType', [`${node.fullName(connection)}.SCHEMA`]);
+    return ktUtils.applyFun('arcs.core.data.EntityType', [`${node.fullName(connection)}.SCHEMA`]);
   });
 }
 
@@ -47,22 +47,23 @@ export async function generateConnectionSpecType(connection: HandleConnectionSpe
  */
 export async function generateType(type: Type, overrideFunction: (type: Type) => string | null = _ => null): Promise<string> {
   return (async function generate(type: Type): Promise<string> {
+    const pkg = 'arcs.core.data';
     const override = overrideFunction(type);
     if (override != null) {
       return override;
     } else if (type.isEntity) {
-      return ktUtils.applyFun('EntityType', [await generateSchema(type.getEntitySchema())]);
+      return ktUtils.applyFun(`${pkg}.EntityType`, [await generateSchema(type.getEntitySchema())]);
     } else if (type.isVariable) {
       assert(type.maybeEnsureResolved(), 'Unresolved type variables are not currently supported');
       return generate(type.resolvedType());
     } else if (type.isCollection) {
-      return ktUtils.applyFun('CollectionType', [await generate(type.getContainedType())]);
+      return ktUtils.applyFun(`${pkg}.CollectionType`, [await generate(type.getContainedType())]);
     } else if (type.isSingleton) {
-      return ktUtils.applyFun('SingletonType', [await generate(type.getContainedType())]);
+      return ktUtils.applyFun(`${pkg}.SingletonType`, [await generate(type.getContainedType())]);
     } else if (type.isReference) {
-      return ktUtils.applyFun('ReferenceType', [await generate(type.getContainedType())]);
+      return ktUtils.applyFun(`${pkg}.ReferenceType`, [await generate(type.getContainedType())]);
     } else if (type.isTuple) {
-      return ktUtils.applyFun('TupleType.of', await Promise.all(type.getContainedTypes().map(t => generate(t))));
+      return ktUtils.applyFun(`${pkg}.TupleType.of`, await Promise.all(type.getContainedTypes().map(t => generate(t))));
     } else {
       throw new Error(`Type '${type.tag}' not supported as code generated handle connection type.`);
     }

--- a/src/tools/schema2kotlin.ts
+++ b/src/tools/schema2kotlin.ts
@@ -29,26 +29,10 @@ export class Schema2Kotlin extends Schema2Base {
   }
 
   fileHeader(_outName: string): string {
-    const imports = [
-      'import arcs.sdk.*',
-    ];
+    const imports = [];
 
     if (this.opts.test_harness) {
       imports.push(
-        'import arcs.core.data.EntityType',
-        'import arcs.core.data.CollectionType',
-        'import arcs.core.data.ReferenceType',
-        'import arcs.core.data.SingletonType',
-        'import arcs.core.data.TupleType',
-        'import arcs.core.entity.HandleContainerType',
-        'import arcs.core.entity.HandleDataType',
-        'import arcs.core.entity.HandleMode',
-        'import arcs.core.entity.HandleSpec',
-        'import arcs.core.entity.Tuple1',
-        'import arcs.core.entity.Tuple2',
-        'import arcs.core.entity.Tuple3',
-        'import arcs.core.entity.Tuple4',
-        'import arcs.core.entity.Tuple5',
         'import arcs.sdk.testing.*',
         'import java.math.BigInteger',
         'import kotlinx.coroutines.CoroutineScope',
@@ -60,17 +44,8 @@ export class Schema2Kotlin extends Schema2Base {
     } else {
       // Imports for jvm.
       imports.push(
-        'import arcs.core.data.*',
         'import arcs.core.data.util.toReferencable',
-        'import arcs.core.data.util.ReferencablePrimitive',
         'import arcs.core.entity.toPrimitiveValue',
-        'import arcs.core.entity.Reference',
-        'import arcs.core.data.SchemaRegistry',
-        'import arcs.core.entity.Tuple1',
-        'import arcs.core.entity.Tuple2',
-        'import arcs.core.entity.Tuple3',
-        'import arcs.core.entity.Tuple4',
-        'import arcs.core.entity.Tuple5',
         'import java.math.BigInteger',
       );
     }
@@ -120,10 +95,10 @@ ${imports.join('\n')}
             : nodes.find(n => n.variableName && n.variableName.includes((type as TypeVariable).variable.name));
           return particleScope ? node.humanName(connection) : node.fullName(connection);
       } else if (type.isReference) {
-        return `Reference<${generateInnerType(type.getContainedType())}>`;
+        return `arcs.sdk.Reference<${generateInnerType(type.getContainedType())}>`;
       } else if (type.isTuple) {
         const innerTypes = type.getContainedTypes();
-        return `Tuple${innerTypes.length}<${innerTypes.map(t => generateInnerType(t)).join(', ')}>`;
+        return `arcs.core.entity.Tuple${innerTypes.length}<${innerTypes.map(t => generateInnerType(t)).join(', ')}>`;
       } else {
         throw new Error(`Type '${type.tag}' not supported on code generated particle handle connections.`);
       }
@@ -178,7 +153,7 @@ ${imports.join('\n')}
     if (queryType) {
       typeArguments.push(queryType);
     }
-    return `${handleMode}${containerType}Handle<${ktUtils.joinWithIndents(typeArguments, {startIndent: 4})}>`;
+    return `arcs.sdk.${handleMode}${containerType}Handle<${ktUtils.joinWithIndents(typeArguments, {startIndent: 4})}>`;
   }
 
   private async handleSpec(handleName: string, connection: HandleConnectionSpec, nodes: SchemaNode[]): Promise<string> {
@@ -187,8 +162,8 @@ ${imports.join('\n')}
     // Using full names of entities, as these are aliases available outside the particle scope.
     const entityNames = SchemaNode.topLevelNodes(connection, nodes).map(node => node.fullName(connection));
     return ktUtils.applyFun(
-        'HandleSpec',
-        [`"${handleName}"`, `HandleMode.${mode}`, type, ktUtils.setOf(entityNames)],
+        'arcs.core.entity.HandleSpec',
+        [`"${handleName}"`, `arcs.core.data.HandleMode.${mode}`, type, ktUtils.setOf(entityNames)],
         {numberOfIndents: 1}
     );
   }
@@ -198,7 +173,7 @@ ${imports.join('\n')}
     return `
 ${typeAliases.join(`\n`)}
 
-abstract class Abstract${particle.name} : ${this.opts.wasm ? 'WasmParticleImpl' : 'BaseParticle'}() {
+abstract class Abstract${particle.name} : ${this.opts.wasm ? 'WasmParticleImpl' : 'arcs.sdk.BaseParticle'}() {
     ${this.opts.wasm ? '' : 'override '}val handles: Handles = Handles(${this.opts.wasm ? 'this' : ''})
 
     ${ktUtils.indentFollowing(classes, 1)}
@@ -245,7 +220,7 @@ abstract class Abstract${particle.name} : ${this.opts.wasm ? 'WasmParticleImpl' 
       ? `${handleDecls.length ? '' : '@Suppress("UNUSED_PARAMETER")\n    '}class Handles(
         particle: WasmParticleImpl
     )`
-      : `class Handles : HandleHolderBase(
+      : `class Handles : arcs.sdk.HandleHolderBase(
         "${particleName}",
         mapOf(${ktUtils.joinWithIndents(entitySpecs, {startIndent: 4, numberOfIndents: 3})})
     )`;

--- a/src/tools/tests/goldens/WriterReaderExample.kt
+++ b/src/tools/tests/goldens/WriterReaderExample.kt
@@ -16,11 +16,11 @@ val Ingestion_Handle0 = Handle(
     StorageKeyParser.parse(
         "reference-mode://{db://25e71af4e9fc8b6958fc46a8f4b7cdf6b5f31516@arcs/Thing}{db://25e71af4e9fc8b6958fc46a8f4b7cdf6b5f31516@arcs/!:writingArcId/handle/my-handle-id}"
     ),
-    EntityType(
-        Schema(
-            setOf(SchemaName("Thing")),
-            SchemaFields(
-                singletons = mapOf("name" to FieldType.Text),
+    arcs.core.data.EntityType(
+        arcs.core.data.Schema(
+            setOf(arcs.core.data.SchemaName("Thing")),
+            arcs.core.data.SchemaFields(
+                singletons = mapOf("name" to arcs.core.data.FieldType.Text),
                 collections = emptyMap()
             ),
             "25e71af4e9fc8b6958fc46a8f4b7cdf6b5f31516",
@@ -42,7 +42,7 @@ val IngestionPlan = Plan(
                 "data" to HandleConnection(
                     Ingestion_Handle0,
                     HandleMode.Read,
-                    SingletonType(EntityType(Reader_Data.SCHEMA)),
+                    arcs.core.data.SingletonType(arcs.core.data.EntityType(Reader_Data.SCHEMA)),
                     listOf(
                         Annotation("persistent", emptyMap()),
                         Annotation("ttl", mapOf("value" to AnnotationParam.Str("20d")))
@@ -57,7 +57,7 @@ val IngestionPlan = Plan(
                 "data" to HandleConnection(
                     Ingestion_Handle0,
                     HandleMode.Write,
-                    SingletonType(EntityType(Writer_Data.SCHEMA)),
+                    arcs.core.data.SingletonType(arcs.core.data.EntityType(Writer_Data.SCHEMA)),
                     listOf(
                         Annotation("persistent", emptyMap()),
                         Annotation("ttl", mapOf("value" to AnnotationParam.Str("20d")))
@@ -73,11 +73,11 @@ val Consumption_Handle0 = Handle(
     StorageKeyParser.parse(
         "reference-mode://{db://25e71af4e9fc8b6958fc46a8f4b7cdf6b5f31516@arcs/Thing}{db://25e71af4e9fc8b6958fc46a8f4b7cdf6b5f31516@arcs/!:writingArcId/handle/my-handle-id}"
     ),
-    EntityType(
-        Schema(
-            setOf(SchemaName("Thing")),
-            SchemaFields(
-                singletons = mapOf("name" to FieldType.Text),
+    arcs.core.data.EntityType(
+        arcs.core.data.Schema(
+            setOf(arcs.core.data.SchemaName("Thing")),
+            arcs.core.data.SchemaFields(
+                singletons = mapOf("name" to arcs.core.data.FieldType.Text),
                 collections = emptyMap()
             ),
             "25e71af4e9fc8b6958fc46a8f4b7cdf6b5f31516",
@@ -96,7 +96,7 @@ val ConsumptionPlan = Plan(
                 "data" to HandleConnection(
                     Consumption_Handle0,
                     HandleMode.Read,
-                    SingletonType(EntityType(Reader_Data.SCHEMA)),
+                    arcs.core.data.SingletonType(arcs.core.data.EntityType(Reader_Data.SCHEMA)),
                     emptyList()
                 )
             )
@@ -107,11 +107,11 @@ val ConsumptionPlan = Plan(
 )
 val EphemeralWriting_Handle0 = Handle(
     StorageKeyParser.parse("create://my-ephemeral-handle-id"),
-    EntityType(
-        Schema(
-            setOf(SchemaName("Thing")),
-            SchemaFields(
-                singletons = mapOf("name" to FieldType.Text),
+    arcs.core.data.EntityType(
+        arcs.core.data.Schema(
+            setOf(arcs.core.data.SchemaName("Thing")),
+            arcs.core.data.SchemaFields(
+                singletons = mapOf("name" to arcs.core.data.FieldType.Text),
                 collections = emptyMap()
             ),
             "25e71af4e9fc8b6958fc46a8f4b7cdf6b5f31516",
@@ -130,7 +130,7 @@ val EphemeralWritingPlan = Plan(
                 "data" to HandleConnection(
                     EphemeralWriting_Handle0,
                     HandleMode.Write,
-                    SingletonType(EntityType(Writer_Data.SCHEMA)),
+                    arcs.core.data.SingletonType(arcs.core.data.EntityType(Writer_Data.SCHEMA)),
                     emptyList()
                 )
             )
@@ -143,11 +143,11 @@ val EphemeralReading_Handle0 = Handle(
     StorageKeyParser.parse(
         "reference-mode://{db://25e71af4e9fc8b6958fc46a8f4b7cdf6b5f31516@arcs/Thing}{db://25e71af4e9fc8b6958fc46a8f4b7cdf6b5f31516@arcs/!:writingArcId/handle/my-handle-id}"
     ),
-    EntityType(
-        Schema(
-            setOf(SchemaName("Thing")),
-            SchemaFields(
-                singletons = mapOf("name" to FieldType.Text),
+    arcs.core.data.EntityType(
+        arcs.core.data.Schema(
+            setOf(arcs.core.data.SchemaName("Thing")),
+            arcs.core.data.SchemaFields(
+                singletons = mapOf("name" to arcs.core.data.FieldType.Text),
                 collections = emptyMap()
             ),
             "25e71af4e9fc8b6958fc46a8f4b7cdf6b5f31516",
@@ -166,7 +166,7 @@ val EphemeralReadingPlan = Plan(
                 "data" to HandleConnection(
                     EphemeralReading_Handle0,
                     HandleMode.Read,
-                    SingletonType(EntityType(Reader_Data.SCHEMA)),
+                    arcs.core.data.SingletonType(arcs.core.data.EntityType(Reader_Data.SCHEMA)),
                     emptyList()
                 )
             )
@@ -179,13 +179,13 @@ val ReferencesRecipe_Handle0 = Handle(
     StorageKeyParser.parse(
         "db://25e71af4e9fc8b6958fc46a8f4b7cdf6b5f31516@arcs/!:referencesArcId/handle/my-refs-id"
     ),
-    CollectionType(
-        ReferenceType(
-            EntityType(
-                Schema(
-                    setOf(SchemaName("Thing")),
-                    SchemaFields(
-                        singletons = mapOf("name" to FieldType.Text),
+    arcs.core.data.CollectionType(
+        arcs.core.data.ReferenceType(
+            arcs.core.data.EntityType(
+                arcs.core.data.Schema(
+                    setOf(arcs.core.data.SchemaName("Thing")),
+                    arcs.core.data.SchemaFields(
+                        singletons = mapOf("name" to arcs.core.data.FieldType.Text),
                         collections = emptyMap()
                     ),
                     "25e71af4e9fc8b6958fc46a8f4b7cdf6b5f31516",
@@ -201,12 +201,12 @@ val ReferencesRecipe_Handle1 = Handle(
     StorageKeyParser.parse(
         "memdb://25e71af4e9fc8b6958fc46a8f4b7cdf6b5f31516@arcs/!:referencesArcId/handle/my-ref-id"
     ),
-    ReferenceType(
-        EntityType(
-            Schema(
-                setOf(SchemaName("Thing")),
-                SchemaFields(
-                    singletons = mapOf("name" to FieldType.Text),
+    arcs.core.data.ReferenceType(
+        arcs.core.data.EntityType(
+            arcs.core.data.Schema(
+                setOf(arcs.core.data.SchemaName("Thing")),
+                arcs.core.data.SchemaFields(
+                    singletons = mapOf("name" to arcs.core.data.FieldType.Text),
                     collections = emptyMap()
                 ),
                 "25e71af4e9fc8b6958fc46a8f4b7cdf6b5f31516",
@@ -226,13 +226,17 @@ val ReferencesRecipePlan = Plan(
                 "inThingRefs" to HandleConnection(
                     ReferencesRecipe_Handle0,
                     HandleMode.Read,
-                    CollectionType(ReferenceType(EntityType(ReadWriteReferences_InThingRefs.SCHEMA))),
+                    arcs.core.data.CollectionType(
+                        arcs.core.data.ReferenceType(arcs.core.data.EntityType(ReadWriteReferences_InThingRefs.SCHEMA))
+                    ),
                     listOf(Annotation("persistent", emptyMap()))
                 ),
                 "outThingRef" to HandleConnection(
                     ReferencesRecipe_Handle1,
                     HandleMode.Write,
-                    SingletonType(ReferenceType(EntityType(ReadWriteReferences_OutThingRef.SCHEMA))),
+                    arcs.core.data.SingletonType(
+                        arcs.core.data.ReferenceType(arcs.core.data.EntityType(ReadWriteReferences_OutThingRef.SCHEMA))
+                    ),
                     listOf(Annotation("ttl", mapOf("value" to AnnotationParam.Str("1d"))))
                 )
             )

--- a/src/tools/tests/goldens/generated-schemas.jvm.kt
+++ b/src/tools/tests/goldens/generated-schemas.jvm.kt
@@ -8,18 +8,8 @@ package arcs.golden
 //
 // Current implementation doesn't support optional field detection
 
-import arcs.core.data.*
-import arcs.core.data.SchemaRegistry
-import arcs.core.data.util.ReferencablePrimitive
 import arcs.core.data.util.toReferencable
-import arcs.core.entity.Reference
-import arcs.core.entity.Tuple1
-import arcs.core.entity.Tuple2
-import arcs.core.entity.Tuple3
-import arcs.core.entity.Tuple4
-import arcs.core.entity.Tuple5
 import arcs.core.entity.toPrimitiveValue
-import arcs.sdk.*
 import java.math.BigInteger
 
 typealias Gold_Data_Ref = AbstractGold.GoldInternal1
@@ -29,7 +19,7 @@ typealias Gold_Collection = AbstractGold.Foo
 typealias Gold_Data = AbstractGold.Gold_Data
 typealias Gold_QCollection = AbstractGold.Gold_QCollection
 
-abstract class AbstractGold : BaseParticle() {
+abstract class AbstractGold : arcs.sdk.BaseParticle() {
     override val handles: Handles = Handles()
 
 
@@ -37,9 +27,16 @@ abstract class AbstractGold : BaseParticle() {
     class GoldInternal1(
         val_: String = "",
         entityId: String? = null,
-        creationTimestamp: Long = RawEntity.UNINITIALIZED_TIMESTAMP,
-        expirationTimestamp: Long = RawEntity.UNINITIALIZED_TIMESTAMP
-    ) : EntityBase("GoldInternal1", SCHEMA, entityId, creationTimestamp, expirationTimestamp, false) {
+        creationTimestamp: Long = arcs.core.data.RawEntity.UNINITIALIZED_TIMESTAMP,
+        expirationTimestamp: Long = arcs.core.data.RawEntity.UNINITIALIZED_TIMESTAMP
+    ) : arcs.sdk.EntityBase(
+        "GoldInternal1",
+        SCHEMA,
+        entityId,
+        creationTimestamp,
+        expirationTimestamp,
+        false
+    ) {
 
         var val_: String
             get() = super.getSingletonValue("val") as String? ?: ""
@@ -54,6 +51,7 @@ abstract class AbstractGold : BaseParticle() {
          * Storing the copy will result in a new copy of the data being stored.
          */
         fun copy(val_: String = this.val_) = GoldInternal1(val_ = val_)
+
         /**
          * Use this method to create a new version of an existing entity.
          * Storing the mutation will overwrite the existing entity in the set, if it exists.
@@ -65,12 +63,12 @@ abstract class AbstractGold : BaseParticle() {
             expirationTimestamp = expirationTimestamp
         )
 
-        companion object : EntitySpec<GoldInternal1> {
+        companion object : arcs.sdk.EntitySpec<GoldInternal1> {
 
-            override val SCHEMA = Schema(
+            override val SCHEMA = arcs.core.data.Schema(
                 setOf(),
-                SchemaFields(
-                    singletons = mapOf("val" to FieldType.Text),
+                arcs.core.data.SchemaFields(
+                    singletons = mapOf("val" to arcs.core.data.FieldType.Text),
                     collections = emptyMap()
                 ),
                 "485712110d89359a3e539dac987329cd2649d889",
@@ -78,14 +76,14 @@ abstract class AbstractGold : BaseParticle() {
                 query = null
             )
 
-            private val nestedEntitySpecs: Map<String, EntitySpec<out Entity>> =
+            private val nestedEntitySpecs: Map<String, arcs.sdk.EntitySpec<out arcs.sdk.Entity>> =
                 emptyMap()
 
             init {
-                SchemaRegistry.register(SCHEMA)
+                arcs.core.data.SchemaRegistry.register(SCHEMA)
             }
 
-            override fun deserialize(data: RawEntity) = GoldInternal1().apply {
+            override fun deserialize(data: arcs.core.data.RawEntity) = GoldInternal1().apply {
                 deserialize(data, nestedEntitySpecs)
             }
         }
@@ -101,9 +99,16 @@ abstract class AbstractGold : BaseParticle() {
         birthDayMonth: Double = 0.0,
         birthDayDOM: Double = 0.0,
         entityId: String? = null,
-        creationTimestamp: Long = RawEntity.UNINITIALIZED_TIMESTAMP,
-        expirationTimestamp: Long = RawEntity.UNINITIALIZED_TIMESTAMP
-    ) : EntityBase("Gold_AllPeople", SCHEMA, entityId, creationTimestamp, expirationTimestamp, false) {
+        creationTimestamp: Long = arcs.core.data.RawEntity.UNINITIALIZED_TIMESTAMP,
+        expirationTimestamp: Long = arcs.core.data.RawEntity.UNINITIALIZED_TIMESTAMP
+    ) : arcs.sdk.EntityBase(
+        "Gold_AllPeople",
+        SCHEMA,
+        entityId,
+        creationTimestamp,
+        expirationTimestamp,
+        false
+    ) {
 
         var name: String
             get() = super.getSingletonValue("name") as String? ?: ""
@@ -158,6 +163,7 @@ abstract class AbstractGold : BaseParticle() {
             birthDayMonth = birthDayMonth,
             birthDayDOM = birthDayDOM
         )
+
         /**
          * Use this method to create a new version of an existing entity.
          * Storing the mutation will overwrite the existing entity in the set, if it exists.
@@ -183,19 +189,19 @@ abstract class AbstractGold : BaseParticle() {
             expirationTimestamp = expirationTimestamp
         )
 
-        companion object : EntitySpec<Gold_AllPeople> {
+        companion object : arcs.sdk.EntitySpec<Gold_AllPeople> {
 
-            override val SCHEMA = Schema(
-                setOf(SchemaName("People")),
-                SchemaFields(
+            override val SCHEMA = arcs.core.data.Schema(
+                setOf(arcs.core.data.SchemaName("People")),
+                arcs.core.data.SchemaFields(
                     singletons = mapOf(
-                        "name" to FieldType.Text,
-                        "age" to FieldType.Number,
-                        "lastCall" to FieldType.Number,
-                        "address" to FieldType.Text,
-                        "favoriteColor" to FieldType.Text,
-                        "birthDayMonth" to FieldType.Number,
-                        "birthDayDOM" to FieldType.Number
+                        "name" to arcs.core.data.FieldType.Text,
+                        "age" to arcs.core.data.FieldType.Number,
+                        "lastCall" to arcs.core.data.FieldType.Number,
+                        "address" to arcs.core.data.FieldType.Text,
+                        "favoriteColor" to arcs.core.data.FieldType.Text,
+                        "birthDayMonth" to arcs.core.data.FieldType.Number,
+                        "birthDayDOM" to arcs.core.data.FieldType.Number
                     ),
                     collections = emptyMap()
                 ),
@@ -204,14 +210,14 @@ abstract class AbstractGold : BaseParticle() {
                 query = null
             )
 
-            private val nestedEntitySpecs: Map<String, EntitySpec<out Entity>> =
+            private val nestedEntitySpecs: Map<String, arcs.sdk.EntitySpec<out arcs.sdk.Entity>> =
                 emptyMap()
 
             init {
-                SchemaRegistry.register(SCHEMA)
+                arcs.core.data.SchemaRegistry.register(SCHEMA)
             }
 
-            override fun deserialize(data: RawEntity) = Gold_AllPeople().apply {
+            override fun deserialize(data: arcs.core.data.RawEntity) = Gold_AllPeople().apply {
                 deserialize(data, nestedEntitySpecs)
             }
         }
@@ -221,9 +227,9 @@ abstract class AbstractGold : BaseParticle() {
     class Foo(
         num: Double = 0.0,
         entityId: String? = null,
-        creationTimestamp: Long = RawEntity.UNINITIALIZED_TIMESTAMP,
-        expirationTimestamp: Long = RawEntity.UNINITIALIZED_TIMESTAMP
-    ) : EntityBase("Foo", SCHEMA, entityId, creationTimestamp, expirationTimestamp, false) {
+        creationTimestamp: Long = arcs.core.data.RawEntity.UNINITIALIZED_TIMESTAMP,
+        expirationTimestamp: Long = arcs.core.data.RawEntity.UNINITIALIZED_TIMESTAMP
+    ) : arcs.sdk.EntityBase("Foo", SCHEMA, entityId, creationTimestamp, expirationTimestamp, false) {
 
         var num: Double
             get() = super.getSingletonValue("num") as Double? ?: 0.0
@@ -238,6 +244,7 @@ abstract class AbstractGold : BaseParticle() {
          * Storing the copy will result in a new copy of the data being stored.
          */
         fun copy(num: Double = this.num) = Foo(num = num)
+
         /**
          * Use this method to create a new version of an existing entity.
          * Storing the mutation will overwrite the existing entity in the set, if it exists.
@@ -249,12 +256,12 @@ abstract class AbstractGold : BaseParticle() {
             expirationTimestamp = expirationTimestamp
         )
 
-        companion object : EntitySpec<Foo> {
+        companion object : arcs.sdk.EntitySpec<Foo> {
 
-            override val SCHEMA = Schema(
-                setOf(SchemaName("Foo")),
-                SchemaFields(
-                    singletons = mapOf("num" to FieldType.Number),
+            override val SCHEMA = arcs.core.data.Schema(
+                setOf(arcs.core.data.SchemaName("Foo")),
+                arcs.core.data.SchemaFields(
+                    singletons = mapOf("num" to arcs.core.data.FieldType.Number),
                     collections = emptyMap()
                 ),
                 "9d5720cea6e06f5c3b1abff0a9af95dfe476fd3f",
@@ -262,14 +269,14 @@ abstract class AbstractGold : BaseParticle() {
                 query = null
             )
 
-            private val nestedEntitySpecs: Map<String, EntitySpec<out Entity>> =
+            private val nestedEntitySpecs: Map<String, arcs.sdk.EntitySpec<out arcs.sdk.Entity>> =
                 emptyMap()
 
             init {
-                SchemaRegistry.register(SCHEMA)
+                arcs.core.data.SchemaRegistry.register(SCHEMA)
             }
 
-            override fun deserialize(data: RawEntity) = Foo().apply {
+            override fun deserialize(data: arcs.core.data.RawEntity) = Foo().apply {
                 deserialize(data, nestedEntitySpecs)
             }
         }
@@ -281,11 +288,11 @@ abstract class AbstractGold : BaseParticle() {
         txt: String = "",
         lnk: String = "",
         flg: Boolean = false,
-        ref: Reference<GoldInternal1>? = null,
+        ref: arcs.sdk.Reference<GoldInternal1>? = null,
         entityId: String? = null,
-        creationTimestamp: Long = RawEntity.UNINITIALIZED_TIMESTAMP,
-        expirationTimestamp: Long = RawEntity.UNINITIALIZED_TIMESTAMP
-    ) : EntityBase("Gold_Data", SCHEMA, entityId, creationTimestamp, expirationTimestamp, false) {
+        creationTimestamp: Long = arcs.core.data.RawEntity.UNINITIALIZED_TIMESTAMP,
+        expirationTimestamp: Long = arcs.core.data.RawEntity.UNINITIALIZED_TIMESTAMP
+    ) : arcs.sdk.EntityBase("Gold_Data", SCHEMA, entityId, creationTimestamp, expirationTimestamp, false) {
 
         var num: Double
             get() = super.getSingletonValue("num") as Double? ?: 0.0
@@ -299,8 +306,8 @@ abstract class AbstractGold : BaseParticle() {
         var flg: Boolean
             get() = super.getSingletonValue("flg") as Boolean? ?: false
             private set(_value) = super.setSingletonValue("flg", _value)
-        var ref: Reference<GoldInternal1>?
-            get() = super.getSingletonValue("ref") as Reference<GoldInternal1>?
+        var ref: arcs.sdk.Reference<GoldInternal1>?
+            get() = super.getSingletonValue("ref") as arcs.sdk.Reference<GoldInternal1>?
             private set(_value) = super.setSingletonValue("ref", _value)
 
         init {
@@ -320,8 +327,9 @@ abstract class AbstractGold : BaseParticle() {
             txt: String = this.txt,
             lnk: String = this.lnk,
             flg: Boolean = this.flg,
-            ref: Reference<GoldInternal1>? = this.ref
+            ref: arcs.sdk.Reference<GoldInternal1>? = this.ref
         ) = Gold_Data(num = num, txt = txt, lnk = lnk, flg = flg, ref = ref)
+
         /**
          * Use this method to create a new version of an existing entity.
          * Storing the mutation will overwrite the existing entity in the set, if it exists.
@@ -331,7 +339,7 @@ abstract class AbstractGold : BaseParticle() {
             txt: String = this.txt,
             lnk: String = this.lnk,
             flg: Boolean = this.flg,
-            ref: Reference<GoldInternal1>? = this.ref
+            ref: arcs.sdk.Reference<GoldInternal1>? = this.ref
         ) = Gold_Data(
             num = num,
             txt = txt,
@@ -343,17 +351,17 @@ abstract class AbstractGold : BaseParticle() {
             expirationTimestamp = expirationTimestamp
         )
 
-        companion object : EntitySpec<Gold_Data> {
+        companion object : arcs.sdk.EntitySpec<Gold_Data> {
 
-            override val SCHEMA = Schema(
+            override val SCHEMA = arcs.core.data.Schema(
                 setOf(),
-                SchemaFields(
+                arcs.core.data.SchemaFields(
                     singletons = mapOf(
-                        "num" to FieldType.Number,
-                        "txt" to FieldType.Text,
-                        "lnk" to FieldType.Text,
-                        "flg" to FieldType.Boolean,
-                        "ref" to FieldType.EntityRef("485712110d89359a3e539dac987329cd2649d889")
+                        "num" to arcs.core.data.FieldType.Number,
+                        "txt" to arcs.core.data.FieldType.Text,
+                        "lnk" to arcs.core.data.FieldType.Text,
+                        "flg" to arcs.core.data.FieldType.Boolean,
+                        "ref" to arcs.core.data.FieldType.EntityRef("485712110d89359a3e539dac987329cd2649d889")
                     ),
                     collections = emptyMap()
                 ),
@@ -362,14 +370,14 @@ abstract class AbstractGold : BaseParticle() {
                 query = null
             )
 
-            private val nestedEntitySpecs: Map<String, EntitySpec<out Entity>> =
+            private val nestedEntitySpecs: Map<String, arcs.sdk.EntitySpec<out arcs.sdk.Entity>> =
                 mapOf("485712110d89359a3e539dac987329cd2649d889" to GoldInternal1)
 
             init {
-                SchemaRegistry.register(SCHEMA)
+                arcs.core.data.SchemaRegistry.register(SCHEMA)
             }
 
-            override fun deserialize(data: RawEntity) = Gold_Data().apply {
+            override fun deserialize(data: arcs.core.data.RawEntity) = Gold_Data().apply {
                 deserialize(data, nestedEntitySpecs)
             }
         }
@@ -385,9 +393,16 @@ abstract class AbstractGold : BaseParticle() {
         birthDayMonth: Double = 0.0,
         birthDayDOM: Double = 0.0,
         entityId: String? = null,
-        creationTimestamp: Long = RawEntity.UNINITIALIZED_TIMESTAMP,
-        expirationTimestamp: Long = RawEntity.UNINITIALIZED_TIMESTAMP
-    ) : EntityBase("Gold_QCollection", SCHEMA, entityId, creationTimestamp, expirationTimestamp, false) {
+        creationTimestamp: Long = arcs.core.data.RawEntity.UNINITIALIZED_TIMESTAMP,
+        expirationTimestamp: Long = arcs.core.data.RawEntity.UNINITIALIZED_TIMESTAMP
+    ) : arcs.sdk.EntityBase(
+        "Gold_QCollection",
+        SCHEMA,
+        entityId,
+        creationTimestamp,
+        expirationTimestamp,
+        false
+    ) {
 
         var name: String
             get() = super.getSingletonValue("name") as String? ?: ""
@@ -442,6 +457,7 @@ abstract class AbstractGold : BaseParticle() {
             birthDayMonth = birthDayMonth,
             birthDayDOM = birthDayDOM
         )
+
         /**
          * Use this method to create a new version of an existing entity.
          * Storing the mutation will overwrite the existing entity in the set, if it exists.
@@ -467,19 +483,19 @@ abstract class AbstractGold : BaseParticle() {
             expirationTimestamp = expirationTimestamp
         )
 
-        companion object : EntitySpec<Gold_QCollection> {
+        companion object : arcs.sdk.EntitySpec<Gold_QCollection> {
 
-            override val SCHEMA = Schema(
-                setOf(SchemaName("People")),
-                SchemaFields(
+            override val SCHEMA = arcs.core.data.Schema(
+                setOf(arcs.core.data.SchemaName("People")),
+                arcs.core.data.SchemaFields(
                     singletons = mapOf(
-                        "name" to FieldType.Text,
-                        "age" to FieldType.Number,
-                        "lastCall" to FieldType.Number,
-                        "address" to FieldType.Text,
-                        "favoriteColor" to FieldType.Text,
-                        "birthDayMonth" to FieldType.Number,
-                        "birthDayDOM" to FieldType.Number
+                        "name" to arcs.core.data.FieldType.Text,
+                        "age" to arcs.core.data.FieldType.Number,
+                        "lastCall" to arcs.core.data.FieldType.Number,
+                        "address" to arcs.core.data.FieldType.Text,
+                        "favoriteColor" to arcs.core.data.FieldType.Text,
+                        "birthDayMonth" to arcs.core.data.FieldType.Number,
+                        "birthDayDOM" to arcs.core.data.FieldType.Number
                     ),
                     collections = emptyMap()
                 ),
@@ -493,20 +509,20 @@ abstract class AbstractGold : BaseParticle() {
                 }
             )
 
-            private val nestedEntitySpecs: Map<String, EntitySpec<out Entity>> =
+            private val nestedEntitySpecs: Map<String, arcs.sdk.EntitySpec<out arcs.sdk.Entity>> =
                 emptyMap()
 
             init {
-                SchemaRegistry.register(SCHEMA)
+                arcs.core.data.SchemaRegistry.register(SCHEMA)
             }
 
-            override fun deserialize(data: RawEntity) = Gold_QCollection().apply {
+            override fun deserialize(data: arcs.core.data.RawEntity) = Gold_QCollection().apply {
                 deserialize(data, nestedEntitySpecs)
             }
         }
     }
 
-    class Handles : HandleHolderBase(
+    class Handles : arcs.sdk.HandleHolderBase(
         "Gold",
         mapOf(
             "data" to setOf(Gold_Data),
@@ -516,10 +532,10 @@ abstract class AbstractGold : BaseParticle() {
             "collection" to setOf(Foo)
         )
     ) {
-        val data: ReadSingletonHandle<Gold_Data> by handles
-        val allPeople: ReadCollectionHandle<Gold_AllPeople> by handles
-        val qCollection: ReadQueryCollectionHandle<Gold_QCollection, String> by handles
-        val alias: WriteSingletonHandle<Gold_Alias> by handles
-        val collection: ReadCollectionHandle<Foo> by handles
+        val data: arcs.sdk.ReadSingletonHandle<Gold_Data> by handles
+        val allPeople: arcs.sdk.ReadCollectionHandle<Gold_AllPeople> by handles
+        val qCollection: arcs.sdk.ReadQueryCollectionHandle<Gold_QCollection, String> by handles
+        val alias: arcs.sdk.WriteSingletonHandle<Gold_Alias> by handles
+        val collection: arcs.sdk.ReadCollectionHandle<Foo> by handles
     }
 }

--- a/src/tools/tests/goldens/generated-schemas.wasm.kt
+++ b/src/tools/tests/goldens/generated-schemas.wasm.kt
@@ -8,7 +8,6 @@ package arcs.golden
 //
 // Current implementation doesn't support optional field detection
 
-import arcs.sdk.*
 import arcs.sdk.wasm.*
 
 typealias Gold_Data = AbstractGold.Gold_Data
@@ -58,6 +57,7 @@ abstract class AbstractGold : WasmParticleImpl() {
             lnk: String = this.lnk,
             flg: Boolean = this.flg
         ) = Gold_Data(num = num, txt = txt, lnk = lnk, flg = flg)
+
 
 
         fun reset() {
@@ -204,6 +204,7 @@ abstract class AbstractGold : WasmParticleImpl() {
         )
 
 
+
         fun reset() {
             name = ""
             age = 0.0
@@ -323,6 +324,7 @@ abstract class AbstractGold : WasmParticleImpl() {
         fun copy(val_: String = this.val_) = Gold_Alias(val_ = val_)
 
 
+
         fun reset() {
             val_ = ""
         }
@@ -390,6 +392,7 @@ abstract class AbstractGold : WasmParticleImpl() {
         override var entityId = ""
 
         fun copy(num: Double = this.num) = Foo(num = num)
+
 
 
         fun reset() {
@@ -513,6 +516,7 @@ abstract class AbstractGold : WasmParticleImpl() {
             birthDayMonth = birthDayMonth,
             birthDayDOM = birthDayDOM
         )
+
 
 
         fun reset() {

--- a/src/tools/tests/goldens/generated-test-harness.kt
+++ b/src/tools/tests/goldens/generated-test-harness.kt
@@ -8,21 +8,6 @@ package arcs.golden
 //
 // Current implementation doesn't support optional field detection
 
-import arcs.core.data.CollectionType
-import arcs.core.data.EntityType
-import arcs.core.data.ReferenceType
-import arcs.core.data.SingletonType
-import arcs.core.data.TupleType
-import arcs.core.entity.HandleContainerType
-import arcs.core.entity.HandleDataType
-import arcs.core.entity.HandleMode
-import arcs.core.entity.HandleSpec
-import arcs.core.entity.Tuple1
-import arcs.core.entity.Tuple2
-import arcs.core.entity.Tuple3
-import arcs.core.entity.Tuple4
-import arcs.core.entity.Tuple5
-import arcs.sdk.*
 import arcs.sdk.testing.*
 import java.math.BigInteger
 import kotlinx.coroutines.CoroutineScope
@@ -31,35 +16,40 @@ import kotlinx.coroutines.CoroutineScope
 class GoldTestHarness<P : AbstractGold>(
     factory : (CoroutineScope) -> P
 ) : BaseTestHarness<P>(factory, listOf(
-    HandleSpec("data", HandleMode.Read, SingletonType(EntityType(Gold_Data.SCHEMA)), setOf(Gold_Data)),
-    HandleSpec(
+    arcs.core.entity.HandleSpec(
+        "data",
+        arcs.core.data.HandleMode.Read,
+        arcs.core.data.SingletonType(arcs.core.data.EntityType(Gold_Data.SCHEMA)),
+        setOf(Gold_Data)
+    ),
+    arcs.core.entity.HandleSpec(
         "allPeople",
-        HandleMode.Read,
-        CollectionType(EntityType(Gold_AllPeople.SCHEMA)),
+        arcs.core.data.HandleMode.Read,
+        arcs.core.data.CollectionType(arcs.core.data.EntityType(Gold_AllPeople.SCHEMA)),
         setOf(Gold_AllPeople)
     ),
-    HandleSpec(
+    arcs.core.entity.HandleSpec(
         "qCollection",
-        HandleMode.ReadQuery,
-        CollectionType(EntityType(Gold_QCollection.SCHEMA)),
+        arcs.core.data.HandleMode.ReadQuery,
+        arcs.core.data.CollectionType(arcs.core.data.EntityType(Gold_QCollection.SCHEMA)),
         setOf(Gold_QCollection)
     ),
-    HandleSpec(
+    arcs.core.entity.HandleSpec(
         "alias",
-        HandleMode.Write,
-        SingletonType(EntityType(Gold_Alias.SCHEMA)),
+        arcs.core.data.HandleMode.Write,
+        arcs.core.data.SingletonType(arcs.core.data.EntityType(Gold_Alias.SCHEMA)),
         setOf(Gold_Alias)
     ),
-    HandleSpec(
+    arcs.core.entity.HandleSpec(
         "collection",
-        HandleMode.Read,
-        CollectionType(EntityType(Gold_Collection.SCHEMA)),
+        arcs.core.data.HandleMode.Read,
+        arcs.core.data.CollectionType(arcs.core.data.EntityType(Gold_Collection.SCHEMA)),
         setOf(Gold_Collection)
     )
 )) {
-    val data: ReadWriteSingletonHandle<Gold_Data> by handleMap
-    val allPeople: ReadWriteCollectionHandle<Gold_AllPeople> by handleMap
-    val qCollection: ReadWriteQueryCollectionHandle<Gold_QCollection, String> by handleMap
-    val alias: ReadWriteSingletonHandle<Gold_Alias> by handleMap
-    val collection: ReadWriteCollectionHandle<Gold_Collection> by handleMap
+    val data: arcs.sdk.ReadWriteSingletonHandle<Gold_Data> by handleMap
+    val allPeople: arcs.sdk.ReadWriteCollectionHandle<Gold_AllPeople> by handleMap
+    val qCollection: arcs.sdk.ReadWriteQueryCollectionHandle<Gold_QCollection, String> by handleMap
+    val alias: arcs.sdk.ReadWriteSingletonHandle<Gold_Alias> by handleMap
+    val collection: arcs.sdk.ReadWriteCollectionHandle<Gold_Collection> by handleMap
 }

--- a/src/tools/tests/goldens/kotlin-connection-type-generator.cgtest
+++ b/src/tools/tests/goldens/kotlin-connection-type-generator.cgtest
@@ -11,7 +11,7 @@ generates type for singleton entity
 particle Module
   data: reads Thing {name: Text}
 [results]
-SingletonType(EntityType(Module_Data.SCHEMA))
+arcs.core.data.SingletonType(arcs.core.data.EntityType(Module_Data.SCHEMA))
 [end]
 
 [name]
@@ -20,7 +20,9 @@ generates type for singleton reference
 particle Module
   data: reads &Thing {name: Text}
 [results]
-SingletonType(ReferenceType(EntityType(Module_Data.SCHEMA)))
+arcs.core.data.SingletonType(
+    arcs.core.data.ReferenceType(arcs.core.data.EntityType(Module_Data.SCHEMA))
+)
 [end]
 
 [name]
@@ -29,7 +31,7 @@ generates type for collection of entities
 particle Module
   data: reads [Thing {name: Text}]
 [results]
-CollectionType(EntityType(Module_Data.SCHEMA))
+arcs.core.data.CollectionType(arcs.core.data.EntityType(Module_Data.SCHEMA))
 [end]
 
 [name]
@@ -38,7 +40,9 @@ generates type for collection of references
 particle Module
   data: reads [&Thing {name: Text}]
 [results]
-CollectionType(ReferenceType(EntityType(Module_Data.SCHEMA)))
+arcs.core.data.CollectionType(
+    arcs.core.data.ReferenceType(arcs.core.data.EntityType(Module_Data.SCHEMA))
+)
 [end]
 
 [name]
@@ -47,10 +51,10 @@ generates type for collection of tuples
 particle Module
   data: reads [(&Thing {name: Text}, &Other {age: Number})]
 [results]
-CollectionType(
-    TupleType.of(
-        ReferenceType(EntityType(Module_Data_0.SCHEMA)),
-        ReferenceType(EntityType(Module_Data_1.SCHEMA))
+arcs.core.data.CollectionType(
+    arcs.core.data.TupleType.of(
+        arcs.core.data.ReferenceType(arcs.core.data.EntityType(Module_Data_0.SCHEMA)),
+        arcs.core.data.ReferenceType(arcs.core.data.EntityType(Module_Data_1.SCHEMA))
     )
 )
 [end]

--- a/src/tools/tests/goldens/kotlin-entity-class.cgtest
+++ b/src/tools/tests/goldens/kotlin-entity-class.cgtest
@@ -16,9 +16,9 @@ particle T
     class Thing(
         num: Double = 0.0,
         entityId: String? = null,
-        creationTimestamp: Long = RawEntity.UNINITIALIZED_TIMESTAMP,
-        expirationTimestamp: Long = RawEntity.UNINITIALIZED_TIMESTAMP
-    ) : EntityBase("Thing", SCHEMA, entityId, creationTimestamp, expirationTimestamp, false) {
+        creationTimestamp: Long = arcs.core.data.RawEntity.UNINITIALIZED_TIMESTAMP,
+        expirationTimestamp: Long = arcs.core.data.RawEntity.UNINITIALIZED_TIMESTAMP
+    ) : arcs.sdk.EntityBase("Thing", SCHEMA, entityId, creationTimestamp, expirationTimestamp, false) {
         
         var num: Double
             get() = super.getSingletonValue("num") as Double? ?: 0.0
@@ -33,6 +33,7 @@ particle T
          * Storing the copy will result in a new copy of the data being stored.
          */
         fun copy(num: Double = this.num) = Thing(num = num)
+
         /**
          * Use this method to create a new version of an existing entity.
          * Storing the mutation will overwrite the existing entity in the set, if it exists.
@@ -44,12 +45,12 @@ particle T
             expirationTimestamp = expirationTimestamp
         )
         
-        companion object : EntitySpec<Thing> {
+        companion object : arcs.sdk.EntitySpec<Thing> {
             
-            override val SCHEMA = Schema(
-                setOf(SchemaName("Thing")),
-                SchemaFields(
-                    singletons = mapOf("num" to FieldType.Number),
+            override val SCHEMA = arcs.core.data.Schema(
+                setOf(arcs.core.data.SchemaName("Thing")),
+                arcs.core.data.SchemaFields(
+                    singletons = mapOf("num" to arcs.core.data.FieldType.Number),
                     collections = emptyMap()
                 ),
                 "66ab3cd8dbc1462e9bcfba539dfa5c852558ad64",
@@ -57,14 +58,14 @@ particle T
                 query = null
             )
 
-            private val nestedEntitySpecs: Map<String, EntitySpec<out Entity>> =
+            private val nestedEntitySpecs: Map<String, arcs.sdk.EntitySpec<out arcs.sdk.Entity>> =
                 emptyMap()
 
             init {
-                SchemaRegistry.register(SCHEMA)
+                arcs.core.data.SchemaRegistry.register(SCHEMA)
             }
             
-            override fun deserialize(data: RawEntity) = Thing().apply {
+            override fun deserialize(data: arcs.core.data.RawEntity) = Thing().apply {
                 deserialize(data, nestedEntitySpecs)
             }
         }
@@ -92,6 +93,7 @@ particle T
         override var entityId = ""
         
         fun copy(num: Double = this.num) = Thing(num = num)
+
         
         
         fun reset() {
@@ -161,9 +163,16 @@ particle T
     class T_H1 private constructor(
         num: Double = 0.0,
         entityId: String? = null,
-        creationTimestamp: Long = RawEntity.UNINITIALIZED_TIMESTAMP,
-        expirationTimestamp: Long = RawEntity.UNINITIALIZED_TIMESTAMP
-    ) : VariableEntityBase("T_H1", SCHEMA, entityId, creationTimestamp, expirationTimestamp, false) {
+        creationTimestamp: Long = arcs.core.data.RawEntity.UNINITIALIZED_TIMESTAMP,
+        expirationTimestamp: Long = arcs.core.data.RawEntity.UNINITIALIZED_TIMESTAMP
+    ) : arcs.core.entity.VariableEntityBase(
+        "T_H1",
+        SCHEMA,
+        entityId,
+        creationTimestamp,
+        expirationTimestamp,
+        false
+    ) {
         
         var num: Double
             get() = super.getSingletonValue("num") as Double? ?: 0.0
@@ -179,6 +188,7 @@ particle T
          */
         fun copy(num: Double = this.num) = T_H1(num = num)
             .also { this.copyLatentDataInto(it) }
+
         /**
          * Use this method to create a new version of an existing entity.
          * Storing the mutation will overwrite the existing entity in the set, if it exists.
@@ -190,12 +200,12 @@ particle T
             expirationTimestamp = expirationTimestamp
         ).also { this.copyLatentDataInto(it) }
         
-        companion object : EntitySpec<T_H1> {
+        companion object : arcs.sdk.EntitySpec<T_H1> {
             
-            override val SCHEMA = Schema(
+            override val SCHEMA = arcs.core.data.Schema(
                 setOf(),
-                SchemaFields(
-                    singletons = mapOf("num" to FieldType.Number),
+                arcs.core.data.SchemaFields(
+                    singletons = mapOf("num" to arcs.core.data.FieldType.Number),
                     collections = emptyMap()
                 ),
                 "1032e45209f910286cfb898c43a1c3ca7d07aea6",
@@ -203,14 +213,14 @@ particle T
                 query = null
             )
 
-            private val nestedEntitySpecs: Map<String, EntitySpec<out Entity>> =
+            private val nestedEntitySpecs: Map<String, arcs.sdk.EntitySpec<out arcs.sdk.Entity>> =
                 emptyMap()
 
             init {
-                SchemaRegistry.register(SCHEMA)
+                arcs.core.data.SchemaRegistry.register(SCHEMA)
             }
             
-            override fun deserialize(data: RawEntity) = T_H1().apply {
+            override fun deserialize(data: arcs.core.data.RawEntity) = T_H1().apply {
                 deserialize(data, nestedEntitySpecs)
             }
         }

--- a/src/tools/tests/goldens/kotlin-entity-fields.cgtest
+++ b/src/tools/tests/goldens/kotlin-entity-fields.cgtest
@@ -48,8 +48,8 @@ particle T
   h1: reads Thing {other: &Other {name: Text}}
 [results]
 
-        var other: Reference<Other>?
-            get() = super.getSingletonValue("other") as Reference<Other>?
+        var other: arcs.sdk.Reference<Other>?
+            get() = super.getSingletonValue("other") as arcs.sdk.Reference<Other>?
             private set(_value) = super.setSingletonValue("other", _value)
         
         init {
@@ -67,8 +67,8 @@ particle T
   h1: reads Thing {other: List<&Other {name: Text}>}
 [results]
 
-        var other: List<Reference<Other>>
-            get() = super.getSingletonValue("other") as List<Reference<Other>>? ?: emptyList()
+        var other: List<arcs.sdk.Reference<Other>>
+            get() = super.getSingletonValue("other") as List<arcs.sdk.Reference<Other>>? ?: emptyList()
             private set(_value) = super.setSingletonValue("other", _value)
         
         init {

--- a/src/tools/tests/goldens/kotlin-handle-interface-types.cgtest
+++ b/src/tools/tests/goldens/kotlin-handle-interface-types.cgtest
@@ -11,7 +11,7 @@ read singleton entity
 particle P
   h: reads Thing {name: Text}
 [results]
-ReadSingletonHandle<Thing>
+arcs.sdk.ReadSingletonHandle<Thing>
 [end]
 
 [name]
@@ -20,7 +20,7 @@ write singleton entity
 particle P
   h: writes Thing {name: Text}
 [results]
-WriteSingletonHandle<Thing>
+arcs.sdk.WriteSingletonHandle<Thing>
 [end]
 
 [name]
@@ -29,7 +29,7 @@ read write singleton entity
 particle P
   h: reads writes Thing {name: Text}
 [results]
-ReadWriteSingletonHandle<Thing>
+arcs.sdk.ReadWriteSingletonHandle<Thing>
 [end]
 
 [name]
@@ -38,7 +38,7 @@ read write anonymous entity
 particle P
   h: reads writes * {name: Text}
 [results]
-ReadWriteSingletonHandle<P_H>
+arcs.sdk.ReadWriteSingletonHandle<P_H>
 [end]
 
 [name]
@@ -47,7 +47,7 @@ read collection of entities
 particle P
   h: reads [Thing {name: Text}]
 [results]
-ReadCollectionHandle<Thing>
+arcs.sdk.ReadCollectionHandle<Thing>
 [end]
 
 [name]
@@ -56,7 +56,7 @@ write collection of entities
 particle P
   h: writes [Thing {name: Text}]
 [results]
-WriteCollectionHandle<Thing>
+arcs.sdk.WriteCollectionHandle<Thing>
 [end]
 
 [name]
@@ -65,7 +65,7 @@ read write collection of entities
 particle P
   h: reads writes [Thing {name: Text}]
 [results]
-ReadWriteCollectionHandle<Thing>
+arcs.sdk.ReadWriteCollectionHandle<Thing>
 [end]
 
 [name]
@@ -74,7 +74,7 @@ read collection of entities and query by string
 particle P
   h: reads [Thing {name: Text} [name == ?]]
 [results]
-ReadQueryCollectionHandle<Thing, String>
+arcs.sdk.ReadQueryCollectionHandle<Thing, String>
 [end]
 
 [name]
@@ -83,7 +83,7 @@ read write collection of entities and query by number
 particle P
   h: reads writes [Thing {age: Number} [age > ?]]
 [results]
-ReadWriteQueryCollectionHandle<Thing, Double>
+arcs.sdk.ReadWriteQueryCollectionHandle<Thing, Double>
 [end]
 
 [name]
@@ -92,7 +92,7 @@ read reference singleton
 particle P
   h: reads &Thing {name: Text}
 [results]
-ReadSingletonHandle<Reference<Thing>>
+arcs.sdk.ReadSingletonHandle<arcs.sdk.Reference<Thing>>
 [end]
 
 [name]
@@ -101,7 +101,7 @@ write reference singleton
 particle P
   h: writes &Thing {name: Text}
 [results]
-WriteSingletonHandle<Reference<Thing>>
+arcs.sdk.WriteSingletonHandle<arcs.sdk.Reference<Thing>>
 [end]
 
 [name]
@@ -110,7 +110,7 @@ read collection of references
 particle P
   h: reads [&Thing {name: Text}]
 [results]
-ReadCollectionHandle<Reference<Thing>>
+arcs.sdk.ReadCollectionHandle<arcs.sdk.Reference<Thing>>
 [end]
 
 [name]
@@ -119,7 +119,7 @@ write collection of references
 particle P
   h: writes [&Thing {name: Text}]
 [results]
-WriteCollectionHandle<Reference<Thing>>
+arcs.sdk.WriteCollectionHandle<arcs.sdk.Reference<Thing>>
 [end]
 
 [name]
@@ -128,7 +128,7 @@ read tuple of 2 references
 particle P
   h: reads (&Foo {name: Text}, &Bar {age: Number})
 [results]
-ReadSingletonHandle<Tuple2<Reference<Foo>, Reference<Bar>>>
+arcs.sdk.ReadSingletonHandle<arcs.core.entity.Tuple2<arcs.sdk.Reference<Foo>, arcs.sdk.Reference<Bar>>>
 [end]
 
 [name]
@@ -137,7 +137,9 @@ write collection of tuples of 3 references
 particle P
   h: writes [(&Foo {name: Text}, &Bar {age: Number}, &Baz {isThisIt: Boolean})]
 [results]
-WriteCollectionHandle<Tuple3<Reference<Foo>, Reference<Bar>, Reference<Baz>>>
+arcs.sdk.WriteCollectionHandle<
+    arcs.core.entity.Tuple3<arcs.sdk.Reference<Foo>, arcs.sdk.Reference<Bar>, arcs.sdk.Reference<Baz>>
+>
 [end]
 
 [name]
@@ -146,7 +148,7 @@ read singleton variable entity
 particle T
   h: reads ~a with {name: Text}
 [results]
-ReadSingletonHandle<T_H>
+arcs.sdk.ReadSingletonHandle<T_H>
 [end]
 
 [name]
@@ -155,7 +157,7 @@ write singleton variable entity
 particle T
   h: writes ~a with {name: Text}
 [results]
-WriteSingletonHandle<T_H>
+arcs.sdk.WriteSingletonHandle<T_H>
 [end]
 
 [name]
@@ -164,5 +166,5 @@ read write singleton unconstrained variable entity
 particle T
   h: reads writes ~a
 [results]
-ReadWriteSingletonHandle<T_H>
+arcs.sdk.ReadWriteSingletonHandle<T_H>
 [end]

--- a/src/tools/tests/goldens/kotlin-handles-class-declarations.cgtest
+++ b/src/tools/tests/goldens/kotlin-handles-class-declarations.cgtest
@@ -11,11 +11,11 @@ single read handle
 particle P
   h1: reads Person {name: Text}
 [results]
-class Handles : HandleHolderBase(
+class Handles : arcs.sdk.HandleHolderBase(
         "P",
         mapOf("h1" to setOf(Person))
     ) {
-        val h1: ReadSingletonHandle<Person> by handles
+        val h1: arcs.sdk.ReadSingletonHandle<Person> by handles
     }
 [end]
 
@@ -26,12 +26,12 @@ particle P
   h1: reads Person {name: Text}
   h2: reads Person {age: Number}
 [results]
-class Handles : HandleHolderBase(
+class Handles : arcs.sdk.HandleHolderBase(
         "P",
         mapOf("h1" to setOf(P_H1), "h2" to setOf(P_H2))
     ) {
-        val h1: ReadSingletonHandle<P_H1> by handles
-        val h2: ReadSingletonHandle<P_H2> by handles
+        val h1: arcs.sdk.ReadSingletonHandle<P_H1> by handles
+        val h2: arcs.sdk.ReadSingletonHandle<P_H2> by handles
     }
 [end]
 
@@ -43,13 +43,13 @@ particle P
   h2: writes Person {name: Text}
   h3: reads [Person {name: Text} [name == ?]]
 [results]
-class Handles : HandleHolderBase(
+class Handles : arcs.sdk.HandleHolderBase(
         "P",
         mapOf("h1" to setOf(P_H1), "h2" to setOf(P_H2), "h3" to setOf(P_H3))
     ) {
-        val h1: ReadSingletonHandle<P_H1> by handles
-        val h2: WriteSingletonHandle<P_H2> by handles
-        val h3: ReadQueryCollectionHandle<P_H3, String> by handles
+        val h1: arcs.sdk.ReadSingletonHandle<P_H1> by handles
+        val h2: arcs.sdk.WriteSingletonHandle<P_H2> by handles
+        val h3: arcs.sdk.ReadQueryCollectionHandle<P_H3, String> by handles
     }
 [end]
 
@@ -68,11 +68,11 @@ particle P
     }
   }
 [results]
-class Handles : HandleHolderBase(
+class Handles : arcs.sdk.HandleHolderBase(
         "P",
         mapOf("h1" to setOf(Person))
     ) {
-        val h1: ReadSingletonHandle<Person> by handles
+        val h1: arcs.sdk.ReadSingletonHandle<Person> by handles
     }
 [end]
 
@@ -86,11 +86,13 @@ particle P
     &Address {streetAddress: Text, postCode: Text}
   )
 [results]
-class Handles : HandleHolderBase(
+class Handles : arcs.sdk.HandleHolderBase(
         "P",
         mapOf("h1" to setOf(Person, Accommodation, Address))
     ) {
-        val h1: ReadSingletonHandle<Tuple3<Reference<Person>, Reference<Accommodation>, Reference<Address>>> by handles
+        val h1: arcs.sdk.ReadSingletonHandle<
+    arcs.core.entity.Tuple3<arcs.sdk.Reference<Person>, arcs.sdk.Reference<Accommodation>, arcs.sdk.Reference<Address>>
+> by handles
     }
 [end]
 
@@ -102,12 +104,12 @@ particle T
   h2: writes ~a with {amt: Number}
   h3: reads writes ~a with {name: Text, age: Number}
 [results]
-class Handles : HandleHolderBase(
+class Handles : arcs.sdk.HandleHolderBase(
         "T",
         mapOf("h1" to setOf(T_H1), "h2" to setOf(T_H2), "h3" to setOf(T_H3))
     ) {
-        val h1: ReadSingletonHandle<T_H1> by handles
-        val h2: WriteSingletonHandle<T_H2> by handles
-        val h3: ReadWriteSingletonHandle<T_H3> by handles
+        val h1: arcs.sdk.ReadSingletonHandle<T_H1> by handles
+        val h2: arcs.sdk.WriteSingletonHandle<T_H2> by handles
+        val h3: arcs.sdk.ReadWriteSingletonHandle<T_H3> by handles
     }
 [end]

--- a/src/tools/tests/goldens/kotlin-schema-fields.cgtest
+++ b/src/tools/tests/goldens/kotlin-schema-fields.cgtest
@@ -49,9 +49,9 @@ List<String>
 Other1
 Set<Other2>
 List<Other3>
-Reference<Ref1>?
-Set<Reference<Ref2>>
-List<Reference<Ref3>>
+arcs.sdk.Reference<Ref1>?
+Set<arcs.sdk.Reference<Ref2>>
+List<arcs.sdk.Reference<Ref3>>
 [end]
 
 [name]
@@ -62,5 +62,5 @@ schema Ref
 particle Foo
   num: reads Thing {ref: &Ref}
 [results]
-Reference<Ref>?
+arcs.sdk.Reference<Ref>?
 [end]

--- a/src/tools/tests/goldens/kotlin-schema-generation.cgtest
+++ b/src/tools/tests/goldens/kotlin-schema-generation.cgtest
@@ -11,7 +11,7 @@ generates empty schema
 particle P
   h1: reads {}
 [results]
-Schema.EMPTY
+arcs.core.data.Schema.EMPTY
 [end]
 
 [name]
@@ -20,9 +20,13 @@ generates a schema with multiple names
 particle P
   h1: reads Person Friend Parent {}
 [results]
-Schema(
-    setOf(SchemaName("Person"), SchemaName("Friend"), SchemaName("Parent")),
-    SchemaFields(
+arcs.core.data.Schema(
+    setOf(
+    arcs.core.data.SchemaName("Person"),
+    arcs.core.data.SchemaName("Friend"),
+    arcs.core.data.SchemaName("Parent")
+),
+    arcs.core.data.SchemaFields(
         singletons = emptyMap(),
         collections = emptyMap()
     ),
@@ -38,11 +42,14 @@ generates a schema with primitive fields
 particle P
   h1: reads Person {name: Text, age: Number, friendNames: [Text]}
 [results]
-Schema(
-    setOf(SchemaName("Person")),
-    SchemaFields(
-        singletons = mapOf("name" to FieldType.Text, "age" to FieldType.Number),
-        collections = mapOf("friendNames" to FieldType.Text)
+arcs.core.data.Schema(
+    setOf(arcs.core.data.SchemaName("Person")),
+    arcs.core.data.SchemaFields(
+        singletons = mapOf(
+            "name" to arcs.core.data.FieldType.Text,
+            "age" to arcs.core.data.FieldType.Number
+        ),
+        collections = mapOf("friendNames" to arcs.core.data.FieldType.Text)
     ),
     "accd28212161fc896d658e8c22c06051d1239e18",
     refinement = { _ -> true },
@@ -64,17 +71,17 @@ particle P
     dbl: Double,
   }
 [results]
-Schema(
-    setOf(SchemaName("Data")),
-    SchemaFields(
+arcs.core.data.Schema(
+    setOf(arcs.core.data.SchemaName("Data")),
+    arcs.core.data.SchemaFields(
         singletons = mapOf(
-            "bt" to FieldType.Byte,
-            "shrt" to FieldType.Short,
-            "nt" to FieldType.Int,
-            "lng" to FieldType.Long,
-            "chr" to FieldType.Char,
-            "flt" to FieldType.Float,
-            "dbl" to FieldType.Double
+            "bt" to arcs.core.data.FieldType.Byte,
+            "shrt" to arcs.core.data.FieldType.Short,
+            "nt" to arcs.core.data.FieldType.Int,
+            "lng" to arcs.core.data.FieldType.Long,
+            "chr" to arcs.core.data.FieldType.Char,
+            "flt" to arcs.core.data.FieldType.Float,
+            "dbl" to arcs.core.data.FieldType.Double
         ),
         collections = emptyMap()
     ),
@@ -90,12 +97,12 @@ generates a schema with lists of primitive fields
 particle P
   h1: reads Person {names: List<Text>, favNumbers: List<Number>}
 [results]
-Schema(
-    setOf(SchemaName("Person")),
-    SchemaFields(
+arcs.core.data.Schema(
+    setOf(arcs.core.data.SchemaName("Person")),
+    arcs.core.data.SchemaFields(
         singletons = mapOf(
-            "names" to FieldType.ListOf(FieldType.Text),
-            "favNumbers" to FieldType.ListOf(FieldType.Number)
+            "names" to arcs.core.data.FieldType.ListOf(arcs.core.data.FieldType.Text),
+            "favNumbers" to arcs.core.data.FieldType.ListOf(arcs.core.data.FieldType.Number)
         ),
         collections = emptyMap()
     ),
@@ -111,11 +118,11 @@ generates schemas for a reference
 particle P
   h1: reads Person {address: &Address {streetAddress: Text}}
 [results]
-Schema(
-    setOf(SchemaName("Person")),
-    SchemaFields(
+arcs.core.data.Schema(
+    setOf(arcs.core.data.SchemaName("Person")),
+    arcs.core.data.SchemaFields(
         singletons = mapOf(
-            "address" to FieldType.EntityRef("41a3bd27b7c53f1c5846754291653d13f49e3e8d")
+            "address" to arcs.core.data.FieldType.EntityRef("41a3bd27b7c53f1c5846754291653d13f49e3e8d")
         ),
         collections = emptyMap()
     ),
@@ -124,10 +131,10 @@ Schema(
     query = null
 )
 [next]
-Schema(
-    setOf(SchemaName("Address")),
-    SchemaFields(
-        singletons = mapOf("streetAddress" to FieldType.Text),
+arcs.core.data.Schema(
+    setOf(arcs.core.data.SchemaName("Address")),
+    arcs.core.data.SchemaFields(
+        singletons = mapOf("streetAddress" to arcs.core.data.FieldType.Text),
         collections = emptyMap()
     ),
     "41a3bd27b7c53f1c5846754291653d13f49e3e8d",
@@ -142,12 +149,12 @@ generates schemas for a collection of references
 particle P
   h1: reads Person {address: [&Address {streetAddress: Text}]}
 [results]
-Schema(
-    setOf(SchemaName("Person")),
-    SchemaFields(
+arcs.core.data.Schema(
+    setOf(arcs.core.data.SchemaName("Person")),
+    arcs.core.data.SchemaFields(
         singletons = emptyMap(),
         collections = mapOf(
-            "address" to FieldType.EntityRef("41a3bd27b7c53f1c5846754291653d13f49e3e8d")
+            "address" to arcs.core.data.FieldType.EntityRef("41a3bd27b7c53f1c5846754291653d13f49e3e8d")
         )
     ),
     "e386e5e1ae663a3b491008c6e931d81a5166ce20",
@@ -155,10 +162,10 @@ Schema(
     query = null
 )
 [next]
-Schema(
-    setOf(SchemaName("Address")),
-    SchemaFields(
-        singletons = mapOf("streetAddress" to FieldType.Text),
+arcs.core.data.Schema(
+    setOf(arcs.core.data.SchemaName("Address")),
+    arcs.core.data.SchemaFields(
+        singletons = mapOf("streetAddress" to arcs.core.data.FieldType.Text),
         collections = emptyMap()
     ),
     "41a3bd27b7c53f1c5846754291653d13f49e3e8d",
@@ -173,11 +180,11 @@ generates schemas for a nested entity
 particle P
   h1: reads Person {address: inline Address {streetAddress: Text}}
 [results]
-Schema(
-    setOf(SchemaName("Person")),
-    SchemaFields(
+arcs.core.data.Schema(
+    setOf(arcs.core.data.SchemaName("Person")),
+    arcs.core.data.SchemaFields(
         singletons = mapOf(
-            "address" to FieldType.InlineEntity("41a3bd27b7c53f1c5846754291653d13f49e3e8d")
+            "address" to arcs.core.data.FieldType.InlineEntity("41a3bd27b7c53f1c5846754291653d13f49e3e8d")
         ),
         collections = emptyMap()
     ),
@@ -186,10 +193,10 @@ Schema(
     query = null
 )
 [next]
-Schema(
-    setOf(SchemaName("Address")),
-    SchemaFields(
-        singletons = mapOf("streetAddress" to FieldType.Text),
+arcs.core.data.Schema(
+    setOf(arcs.core.data.SchemaName("Address")),
+    arcs.core.data.SchemaFields(
+        singletons = mapOf("streetAddress" to arcs.core.data.FieldType.Text),
         collections = emptyMap()
     ),
     "41a3bd27b7c53f1c5846754291653d13f49e3e8d",
@@ -209,11 +216,11 @@ particle P
     other: inline External
   }
 [results]
-Schema(
-    setOf(SchemaName("Thing")),
-    SchemaFields(
+arcs.core.data.Schema(
+    setOf(arcs.core.data.SchemaName("Thing")),
+    arcs.core.data.SchemaFields(
         singletons = mapOf(
-            "other" to FieldType.InlineEntity("dde7385227a50a4a4654027dba6feefccd1a7a39")
+            "other" to arcs.core.data.FieldType.InlineEntity("dde7385227a50a4a4654027dba6feefccd1a7a39")
         ),
         collections = emptyMap()
     ),
@@ -222,10 +229,10 @@ Schema(
     query = null
 )
 [next]
-Schema(
-    setOf(SchemaName("External")),
-    SchemaFields(
-        singletons = mapOf("name" to FieldType.Text),
+arcs.core.data.Schema(
+    setOf(arcs.core.data.SchemaName("External")),
+    arcs.core.data.SchemaFields(
+        singletons = mapOf("name" to arcs.core.data.FieldType.Text),
         collections = emptyMap()
     ),
     "dde7385227a50a4a4654027dba6feefccd1a7a39",
@@ -245,11 +252,11 @@ particle P
     }
   }
 [results]
-Schema(
-    setOf(SchemaName("Person")),
-    SchemaFields(
+arcs.core.data.Schema(
+    setOf(arcs.core.data.SchemaName("Person")),
+    arcs.core.data.SchemaFields(
         singletons = mapOf(
-            "address" to FieldType.InlineEntity("357fa6d61d95ea4234984c2341bf1eb4664cc534")
+            "address" to arcs.core.data.FieldType.InlineEntity("357fa6d61d95ea4234984c2341bf1eb4664cc534")
         ),
         collections = emptyMap()
     ),
@@ -258,12 +265,12 @@ Schema(
     query = null
 )
 [next]
-Schema(
-    setOf(SchemaName("Address")),
-    SchemaFields(
+arcs.core.data.Schema(
+    setOf(arcs.core.data.SchemaName("Address")),
+    arcs.core.data.SchemaFields(
         singletons = mapOf(
-            "streetAddress" to FieldType.Text,
-            "city" to FieldType.InlineEntity("783a4126e47d586196d9e80810b67199edcb04da")
+            "streetAddress" to arcs.core.data.FieldType.Text,
+            "city" to arcs.core.data.FieldType.InlineEntity("783a4126e47d586196d9e80810b67199edcb04da")
         ),
         collections = emptyMap()
     ),
@@ -272,10 +279,10 @@ Schema(
     query = null
 )
 [next]
-Schema(
-    setOf(SchemaName("City")),
-    SchemaFields(
-        singletons = mapOf("name" to FieldType.Text),
+arcs.core.data.Schema(
+    setOf(arcs.core.data.SchemaName("City")),
+    arcs.core.data.SchemaFields(
+        singletons = mapOf("name" to arcs.core.data.FieldType.Text),
         collections = emptyMap()
     ),
     "783a4126e47d586196d9e80810b67199edcb04da",
@@ -290,10 +297,13 @@ generates a schema with a refinement
 particle P
   h1: reads Person {name: Text, age: Number} [age >= 21]
 [results]
-Schema(
-    setOf(SchemaName("Person")),
-    SchemaFields(
-        singletons = mapOf("name" to FieldType.Text, "age" to FieldType.Number),
+arcs.core.data.Schema(
+    setOf(arcs.core.data.SchemaName("Person")),
+    arcs.core.data.SchemaFields(
+        singletons = mapOf(
+            "name" to arcs.core.data.FieldType.Text,
+            "age" to arcs.core.data.FieldType.Number
+        ),
         collections = emptyMap()
     ),
     "edabcee36cb653ff468fb77804911ddfa9303d67",
@@ -311,10 +321,13 @@ generates a schema with a query
 particle P
   h1: reads Person {name: Text, age: Number} [age >= ?]
 [results]
-Schema(
-    setOf(SchemaName("Person")),
-    SchemaFields(
-        singletons = mapOf("name" to FieldType.Text, "age" to FieldType.Number),
+arcs.core.data.Schema(
+    setOf(arcs.core.data.SchemaName("Person")),
+    arcs.core.data.SchemaFields(
+        singletons = mapOf(
+            "name" to arcs.core.data.FieldType.Text,
+            "age" to arcs.core.data.FieldType.Number
+        ),
         collections = emptyMap()
     ),
     "edabcee36cb653ff468fb77804911ddfa9303d67",
@@ -333,10 +346,10 @@ generates schemas for a tuple connection
 particle P
   h1: reads (&Person {name: Text}, &Product {sku: Text})
 [results]
-Schema(
-    setOf(SchemaName("Person")),
-    SchemaFields(
-        singletons = mapOf("name" to FieldType.Text),
+arcs.core.data.Schema(
+    setOf(arcs.core.data.SchemaName("Person")),
+    arcs.core.data.SchemaFields(
+        singletons = mapOf("name" to arcs.core.data.FieldType.Text),
         collections = emptyMap()
     ),
     "0149326a894f2d81705e1a08480330826f919cf0",
@@ -344,10 +357,10 @@ Schema(
     query = null
 )
 [next]
-Schema(
-    setOf(SchemaName("Product")),
-    SchemaFields(
-        singletons = mapOf("sku" to FieldType.Text),
+arcs.core.data.Schema(
+    setOf(arcs.core.data.SchemaName("Product")),
+    arcs.core.data.SchemaFields(
+        singletons = mapOf("sku" to arcs.core.data.FieldType.Text),
         collections = emptyMap()
     ),
     "32bcfc983b9ea6145aa42fbc525abb96baafbc1f",

--- a/src/tools/tests/goldens/kotlin-test-harness.cgtest
+++ b/src/tools/tests/goldens/kotlin-test-harness.cgtest
@@ -17,11 +17,21 @@ particle P
 class PTestHarness<P : AbstractP>(
     factory : (CoroutineScope) -> P
 ) : BaseTestHarness<P>(factory, listOf(
-    HandleSpec("h1", HandleMode.Read, SingletonType(EntityType(P_H1.SCHEMA)), setOf(P_H1)),
-    HandleSpec("h2", HandleMode.Write, SingletonType(EntityType(P_H2.SCHEMA)), setOf(P_H2))
+    arcs.core.entity.HandleSpec(
+        "h1",
+        arcs.core.data.HandleMode.Read,
+        arcs.core.data.SingletonType(arcs.core.data.EntityType(P_H1.SCHEMA)),
+        setOf(P_H1)
+    ),
+    arcs.core.entity.HandleSpec(
+        "h2",
+        arcs.core.data.HandleMode.Write,
+        arcs.core.data.SingletonType(arcs.core.data.EntityType(P_H2.SCHEMA)),
+        setOf(P_H2)
+    )
 )) {
-    val h1: ReadWriteSingletonHandle<P_H1> by handleMap
-    val h2: ReadWriteSingletonHandle<P_H2> by handleMap
+    val h1: arcs.sdk.ReadWriteSingletonHandle<P_H1> by handleMap
+    val h2: arcs.sdk.ReadWriteSingletonHandle<P_H2> by handleMap
 }
 
 [end]
@@ -41,47 +51,53 @@ particle P
 class PTestHarness<P : AbstractP>(
     factory : (CoroutineScope) -> P
 ) : BaseTestHarness<P>(factory, listOf(
-    HandleSpec(
+    arcs.core.entity.HandleSpec(
         "singletonEntity",
-        HandleMode.Read,
-        SingletonType(EntityType(P_SingletonEntity.SCHEMA)),
+        arcs.core.data.HandleMode.Read,
+        arcs.core.data.SingletonType(arcs.core.data.EntityType(P_SingletonEntity.SCHEMA)),
         setOf(P_SingletonEntity)
     ),
-    HandleSpec(
+    arcs.core.entity.HandleSpec(
         "singletonReference",
-        HandleMode.Write,
-        SingletonType(ReferenceType(EntityType(P_SingletonReference.SCHEMA))),
+        arcs.core.data.HandleMode.Write,
+        arcs.core.data.SingletonType(
+            arcs.core.data.ReferenceType(arcs.core.data.EntityType(P_SingletonReference.SCHEMA))
+        ),
         setOf(P_SingletonReference)
     ),
-    HandleSpec(
+    arcs.core.entity.HandleSpec(
         "collectionEntity",
-        HandleMode.Write,
-        CollectionType(EntityType(P_CollectionEntity.SCHEMA)),
+        arcs.core.data.HandleMode.Write,
+        arcs.core.data.CollectionType(arcs.core.data.EntityType(P_CollectionEntity.SCHEMA)),
         setOf(P_CollectionEntity)
     ),
-    HandleSpec(
+    arcs.core.entity.HandleSpec(
         "collectionReference",
-        HandleMode.Read,
-        CollectionType(ReferenceType(EntityType(P_CollectionReference.SCHEMA))),
+        arcs.core.data.HandleMode.Read,
+        arcs.core.data.CollectionType(
+            arcs.core.data.ReferenceType(arcs.core.data.EntityType(P_CollectionReference.SCHEMA))
+        ),
         setOf(P_CollectionReference)
     ),
-    HandleSpec(
+    arcs.core.entity.HandleSpec(
         "collectionTuples",
-        HandleMode.ReadWrite,
-        CollectionType(
-            TupleType.of(
-                ReferenceType(EntityType(P_CollectionTuples_0.SCHEMA)),
-                ReferenceType(EntityType(P_CollectionTuples_1.SCHEMA))
+        arcs.core.data.HandleMode.ReadWrite,
+        arcs.core.data.CollectionType(
+            arcs.core.data.TupleType.of(
+                arcs.core.data.ReferenceType(arcs.core.data.EntityType(P_CollectionTuples_0.SCHEMA)),
+                arcs.core.data.ReferenceType(arcs.core.data.EntityType(P_CollectionTuples_1.SCHEMA))
             )
         ),
         setOf(P_CollectionTuples_0, P_CollectionTuples_1)
     )
 )) {
-    val singletonEntity: ReadWriteSingletonHandle<P_SingletonEntity> by handleMap
-    val singletonReference: ReadWriteSingletonHandle<Reference<P_SingletonReference>> by handleMap
-    val collectionEntity: ReadWriteCollectionHandle<P_CollectionEntity> by handleMap
-    val collectionReference: ReadWriteCollectionHandle<Reference<P_CollectionReference>> by handleMap
-    val collectionTuples: ReadWriteCollectionHandle<Tuple2<Reference<P_CollectionTuples_0>, Reference<P_CollectionTuples_1>>> by handleMap
+    val singletonEntity: arcs.sdk.ReadWriteSingletonHandle<P_SingletonEntity> by handleMap
+    val singletonReference: arcs.sdk.ReadWriteSingletonHandle<arcs.sdk.Reference<P_SingletonReference>> by handleMap
+    val collectionEntity: arcs.sdk.ReadWriteCollectionHandle<P_CollectionEntity> by handleMap
+    val collectionReference: arcs.sdk.ReadWriteCollectionHandle<arcs.sdk.Reference<P_CollectionReference>> by handleMap
+    val collectionTuples: arcs.sdk.ReadWriteCollectionHandle<
+    arcs.core.entity.Tuple2<arcs.sdk.Reference<P_CollectionTuples_0>, arcs.sdk.Reference<P_CollectionTuples_1>>
+> by handleMap
 }
 
 [end]

--- a/src/tools/tests/goldens/kotlin-type-generator.cgtest
+++ b/src/tools/tests/goldens/kotlin-type-generator.cgtest
@@ -11,11 +11,11 @@ generates an entity type
 particle Module
   data: reads {count: Number}
 [results]
-EntityType(
-    Schema(
+arcs.core.data.EntityType(
+    arcs.core.data.Schema(
         setOf(),
-        SchemaFields(
-            singletons = mapOf("count" to FieldType.Number),
+        arcs.core.data.SchemaFields(
+            singletons = mapOf("count" to arcs.core.data.FieldType.Number),
             collections = emptyMap()
         ),
         "4c768720e83eca0f85355674ca87181718e8da9c",
@@ -31,12 +31,12 @@ generates a collection of entities
 particle Module
   data: reads [Thing {name: Text}]
 [results]
-CollectionType(
-    EntityType(
-        Schema(
-            setOf(SchemaName("Thing")),
-            SchemaFields(
-                singletons = mapOf("name" to FieldType.Text),
+arcs.core.data.CollectionType(
+    arcs.core.data.EntityType(
+        arcs.core.data.Schema(
+            setOf(arcs.core.data.SchemaName("Thing")),
+            arcs.core.data.SchemaFields(
+                singletons = mapOf("name" to arcs.core.data.FieldType.Text),
                 collections = emptyMap()
             ),
             "25e71af4e9fc8b6958fc46a8f4b7cdf6b5f31516",
@@ -53,12 +53,12 @@ generates a reference type
 particle Module
   data: reads &Thing {name: Text}
 [results]
-ReferenceType(
-    EntityType(
-        Schema(
-            setOf(SchemaName("Thing")),
-            SchemaFields(
-                singletons = mapOf("name" to FieldType.Text),
+arcs.core.data.ReferenceType(
+    arcs.core.data.EntityType(
+        arcs.core.data.Schema(
+            setOf(arcs.core.data.SchemaName("Thing")),
+            arcs.core.data.SchemaFields(
+                singletons = mapOf("name" to arcs.core.data.FieldType.Text),
                 collections = emptyMap()
             ),
             "25e71af4e9fc8b6958fc46a8f4b7cdf6b5f31516",

--- a/src/tools/tests/goldens/kt_generated-schemas.jvm.kt
+++ b/src/tools/tests/goldens/kt_generated-schemas.jvm.kt
@@ -8,18 +8,8 @@ package arcs.golden
 //
 // Current implementation doesn't support optional field detection
 
-import arcs.core.data.*
-import arcs.core.data.SchemaRegistry
-import arcs.core.data.util.ReferencablePrimitive
 import arcs.core.data.util.toReferencable
-import arcs.core.entity.Reference
-import arcs.core.entity.Tuple1
-import arcs.core.entity.Tuple2
-import arcs.core.entity.Tuple3
-import arcs.core.entity.Tuple4
-import arcs.core.entity.Tuple5
 import arcs.core.entity.toPrimitiveValue
-import arcs.sdk.*
 import java.math.BigInteger
 
 typealias KotlinPrimitivesGolden_Data_Ref = AbstractKotlinPrimitivesGolden.KotlinPrimitivesGolden_Data_Ref
@@ -30,7 +20,7 @@ typealias KotlinPrimitivesGolden_Data_Products = AbstractKotlinPrimitivesGolden.
 typealias KotlinPrimitivesGolden_Data_Detail = AbstractKotlinPrimitivesGolden.Detail
 typealias KotlinPrimitivesGolden_Data = AbstractKotlinPrimitivesGolden.KotlinPrimitivesGolden_Data
 
-abstract class AbstractKotlinPrimitivesGolden : BaseParticle() {
+abstract class AbstractKotlinPrimitivesGolden : arcs.sdk.BaseParticle() {
     override val handles: Handles = Handles()
 
 
@@ -38,16 +28,16 @@ abstract class AbstractKotlinPrimitivesGolden : BaseParticle() {
     class KotlinPrimitivesGolden_Data_Ref(
         val_: String = "",
         entityId: String? = null,
-        creationTimestamp: Long = RawEntity.UNINITIALIZED_TIMESTAMP,
-        expirationTimestamp: Long = RawEntity.UNINITIALIZED_TIMESTAMP
-    ) : EntityBase(
-    "KotlinPrimitivesGolden_Data_Ref",
-    SCHEMA,
-    entityId,
-    creationTimestamp,
-    expirationTimestamp,
-    false
-) {
+        creationTimestamp: Long = arcs.core.data.RawEntity.UNINITIALIZED_TIMESTAMP,
+        expirationTimestamp: Long = arcs.core.data.RawEntity.UNINITIALIZED_TIMESTAMP
+    ) : arcs.sdk.EntityBase(
+        "KotlinPrimitivesGolden_Data_Ref",
+        SCHEMA,
+        entityId,
+        creationTimestamp,
+        expirationTimestamp,
+        false
+    ) {
 
         var val_: String
             get() = super.getSingletonValue("val") as String? ?: ""
@@ -62,6 +52,7 @@ abstract class AbstractKotlinPrimitivesGolden : BaseParticle() {
          * Storing the copy will result in a new copy of the data being stored.
          */
         fun copy(val_: String = this.val_) = KotlinPrimitivesGolden_Data_Ref(val_ = val_)
+
         /**
          * Use this method to create a new version of an existing entity.
          * Storing the mutation will overwrite the existing entity in the set, if it exists.
@@ -73,12 +64,12 @@ abstract class AbstractKotlinPrimitivesGolden : BaseParticle() {
             expirationTimestamp = expirationTimestamp
         )
 
-        companion object : EntitySpec<KotlinPrimitivesGolden_Data_Ref> {
+        companion object : arcs.sdk.EntitySpec<KotlinPrimitivesGolden_Data_Ref> {
 
-            override val SCHEMA = Schema(
+            override val SCHEMA = arcs.core.data.Schema(
                 setOf(),
-                SchemaFields(
-                    singletons = mapOf("val" to FieldType.Text),
+                arcs.core.data.SchemaFields(
+                    singletons = mapOf("val" to arcs.core.data.FieldType.Text),
                     collections = emptyMap()
                 ),
                 "485712110d89359a3e539dac987329cd2649d889",
@@ -86,14 +77,14 @@ abstract class AbstractKotlinPrimitivesGolden : BaseParticle() {
                 query = null
             )
 
-            private val nestedEntitySpecs: Map<String, EntitySpec<out Entity>> =
+            private val nestedEntitySpecs: Map<String, arcs.sdk.EntitySpec<out arcs.sdk.Entity>> =
                 emptyMap()
 
             init {
-                SchemaRegistry.register(SCHEMA)
+                arcs.core.data.SchemaRegistry.register(SCHEMA)
             }
 
-            override fun deserialize(data: RawEntity) = KotlinPrimitivesGolden_Data_Ref().apply {
+            override fun deserialize(data: arcs.core.data.RawEntity) = KotlinPrimitivesGolden_Data_Ref().apply {
                 deserialize(data, nestedEntitySpecs)
             }
         }
@@ -103,9 +94,9 @@ abstract class AbstractKotlinPrimitivesGolden : BaseParticle() {
     class Thing(
         name: String = "",
         entityId: String? = null,
-        creationTimestamp: Long = RawEntity.UNINITIALIZED_TIMESTAMP,
-        expirationTimestamp: Long = RawEntity.UNINITIALIZED_TIMESTAMP
-    ) : EntityBase("Thing", SCHEMA, entityId, creationTimestamp, expirationTimestamp, false) {
+        creationTimestamp: Long = arcs.core.data.RawEntity.UNINITIALIZED_TIMESTAMP,
+        expirationTimestamp: Long = arcs.core.data.RawEntity.UNINITIALIZED_TIMESTAMP
+    ) : arcs.sdk.EntityBase("Thing", SCHEMA, entityId, creationTimestamp, expirationTimestamp, false) {
 
         var name: String
             get() = super.getSingletonValue("name") as String? ?: ""
@@ -120,6 +111,7 @@ abstract class AbstractKotlinPrimitivesGolden : BaseParticle() {
          * Storing the copy will result in a new copy of the data being stored.
          */
         fun copy(name: String = this.name) = Thing(name = name)
+
         /**
          * Use this method to create a new version of an existing entity.
          * Storing the mutation will overwrite the existing entity in the set, if it exists.
@@ -131,12 +123,12 @@ abstract class AbstractKotlinPrimitivesGolden : BaseParticle() {
             expirationTimestamp = expirationTimestamp
         )
 
-        companion object : EntitySpec<Thing> {
+        companion object : arcs.sdk.EntitySpec<Thing> {
 
-            override val SCHEMA = Schema(
-                setOf(SchemaName("Thing")),
-                SchemaFields(
-                    singletons = mapOf("name" to FieldType.Text),
+            override val SCHEMA = arcs.core.data.Schema(
+                setOf(arcs.core.data.SchemaName("Thing")),
+                arcs.core.data.SchemaFields(
+                    singletons = mapOf("name" to arcs.core.data.FieldType.Text),
                     collections = emptyMap()
                 ),
                 "25e71af4e9fc8b6958fc46a8f4b7cdf6b5f31516",
@@ -144,14 +136,14 @@ abstract class AbstractKotlinPrimitivesGolden : BaseParticle() {
                 query = null
             )
 
-            private val nestedEntitySpecs: Map<String, EntitySpec<out Entity>> =
+            private val nestedEntitySpecs: Map<String, arcs.sdk.EntitySpec<out arcs.sdk.Entity>> =
                 emptyMap()
 
             init {
-                SchemaRegistry.register(SCHEMA)
+                arcs.core.data.SchemaRegistry.register(SCHEMA)
             }
 
-            override fun deserialize(data: RawEntity) = Thing().apply {
+            override fun deserialize(data: arcs.core.data.RawEntity) = Thing().apply {
                 deserialize(data, nestedEntitySpecs)
             }
         }
@@ -162,9 +154,9 @@ abstract class AbstractKotlinPrimitivesGolden : BaseParticle() {
         txt: String = "",
         num: Double = 0.0,
         entityId: String? = null,
-        creationTimestamp: Long = RawEntity.UNINITIALIZED_TIMESTAMP,
-        expirationTimestamp: Long = RawEntity.UNINITIALIZED_TIMESTAMP
-    ) : EntityBase("Nested", SCHEMA, entityId, creationTimestamp, expirationTimestamp, false) {
+        creationTimestamp: Long = arcs.core.data.RawEntity.UNINITIALIZED_TIMESTAMP,
+        expirationTimestamp: Long = arcs.core.data.RawEntity.UNINITIALIZED_TIMESTAMP
+    ) : arcs.sdk.EntityBase("Nested", SCHEMA, entityId, creationTimestamp, expirationTimestamp, false) {
 
         var txt: String
             get() = super.getSingletonValue("txt") as String? ?: ""
@@ -183,6 +175,7 @@ abstract class AbstractKotlinPrimitivesGolden : BaseParticle() {
          * Storing the copy will result in a new copy of the data being stored.
          */
         fun copy(txt: String = this.txt, num: Double = this.num) = Nested(txt = txt, num = num)
+
         /**
          * Use this method to create a new version of an existing entity.
          * Storing the mutation will overwrite the existing entity in the set, if it exists.
@@ -195,12 +188,15 @@ abstract class AbstractKotlinPrimitivesGolden : BaseParticle() {
             expirationTimestamp = expirationTimestamp
         )
 
-        companion object : EntitySpec<Nested> {
+        companion object : arcs.sdk.EntitySpec<Nested> {
 
-            override val SCHEMA = Schema(
-                setOf(SchemaName("Nested")),
-                SchemaFields(
-                    singletons = mapOf("txt" to FieldType.Text, "num" to FieldType.Number),
+            override val SCHEMA = arcs.core.data.Schema(
+                setOf(arcs.core.data.SchemaName("Nested")),
+                arcs.core.data.SchemaFields(
+                    singletons = mapOf(
+                        "txt" to arcs.core.data.FieldType.Text,
+                        "num" to arcs.core.data.FieldType.Number
+                    ),
                     collections = emptyMap()
                 ),
                 "e8b8d30e041174ca9104dfba453615c934af27b3",
@@ -208,14 +204,14 @@ abstract class AbstractKotlinPrimitivesGolden : BaseParticle() {
                 query = null
             )
 
-            private val nestedEntitySpecs: Map<String, EntitySpec<out Entity>> =
+            private val nestedEntitySpecs: Map<String, arcs.sdk.EntitySpec<out arcs.sdk.Entity>> =
                 emptyMap()
 
             init {
-                SchemaRegistry.register(SCHEMA)
+                arcs.core.data.SchemaRegistry.register(SCHEMA)
             }
 
-            override fun deserialize(data: RawEntity) = Nested().apply {
+            override fun deserialize(data: arcs.core.data.RawEntity) = Nested().apply {
                 deserialize(data, nestedEntitySpecs)
             }
         }
@@ -227,9 +223,9 @@ abstract class AbstractKotlinPrimitivesGolden : BaseParticle() {
         green: Char = '\u0000',
         blue: Char = '\u0000',
         entityId: String? = null,
-        creationTimestamp: Long = RawEntity.UNINITIALIZED_TIMESTAMP,
-        expirationTimestamp: Long = RawEntity.UNINITIALIZED_TIMESTAMP
-    ) : EntityBase("Color", SCHEMA, entityId, creationTimestamp, expirationTimestamp, true) {
+        creationTimestamp: Long = arcs.core.data.RawEntity.UNINITIALIZED_TIMESTAMP,
+        expirationTimestamp: Long = arcs.core.data.RawEntity.UNINITIALIZED_TIMESTAMP
+    ) : arcs.sdk.EntityBase("Color", SCHEMA, entityId, creationTimestamp, expirationTimestamp, true) {
 
         var red: Char
             get() = super.getSingletonValue("red") as Char? ?: '\u0000'
@@ -252,6 +248,7 @@ abstract class AbstractKotlinPrimitivesGolden : BaseParticle() {
          * Storing the copy will result in a new copy of the data being stored.
          */
         fun copy(red: Char = this.red, green: Char = this.green, blue: Char = this.blue) = Color(red = red, green = green, blue = blue)
+
         /**
          * Use this method to create a new version of an existing entity.
          * Storing the mutation will overwrite the existing entity in the set, if it exists.
@@ -265,15 +262,15 @@ abstract class AbstractKotlinPrimitivesGolden : BaseParticle() {
             expirationTimestamp = expirationTimestamp
         )
 
-        companion object : EntitySpec<Color> {
+        companion object : arcs.sdk.EntitySpec<Color> {
 
-            override val SCHEMA = Schema(
-                setOf(SchemaName("Color")),
-                SchemaFields(
+            override val SCHEMA = arcs.core.data.Schema(
+                setOf(arcs.core.data.SchemaName("Color")),
+                arcs.core.data.SchemaFields(
                     singletons = mapOf(
-                        "red" to FieldType.Char,
-                        "green" to FieldType.Char,
-                        "blue" to FieldType.Char
+                        "red" to arcs.core.data.FieldType.Char,
+                        "green" to arcs.core.data.FieldType.Char,
+                        "blue" to arcs.core.data.FieldType.Char
                     ),
                     collections = emptyMap()
                 ),
@@ -282,14 +279,14 @@ abstract class AbstractKotlinPrimitivesGolden : BaseParticle() {
                 query = null
             )
 
-            private val nestedEntitySpecs: Map<String, EntitySpec<out Entity>> =
+            private val nestedEntitySpecs: Map<String, arcs.sdk.EntitySpec<out arcs.sdk.Entity>> =
                 emptyMap()
 
             init {
-                SchemaRegistry.register(SCHEMA)
+                arcs.core.data.SchemaRegistry.register(SCHEMA)
             }
 
-            override fun deserialize(data: RawEntity) = Color().apply {
+            override fun deserialize(data: arcs.core.data.RawEntity) = Color().apply {
                 deserialize(data, nestedEntitySpecs)
             }
         }
@@ -301,9 +298,9 @@ abstract class AbstractKotlinPrimitivesGolden : BaseParticle() {
         price: Float = 0.0f,
         stock: Int = 0,
         entityId: String? = null,
-        creationTimestamp: Long = RawEntity.UNINITIALIZED_TIMESTAMP,
-        expirationTimestamp: Long = RawEntity.UNINITIALIZED_TIMESTAMP
-    ) : EntityBase("Product", SCHEMA, entityId, creationTimestamp, expirationTimestamp, true) {
+        creationTimestamp: Long = arcs.core.data.RawEntity.UNINITIALIZED_TIMESTAMP,
+        expirationTimestamp: Long = arcs.core.data.RawEntity.UNINITIALIZED_TIMESTAMP
+    ) : arcs.sdk.EntityBase("Product", SCHEMA, entityId, creationTimestamp, expirationTimestamp, true) {
 
         var name: String
             get() = super.getSingletonValue("name") as String? ?: ""
@@ -326,6 +323,7 @@ abstract class AbstractKotlinPrimitivesGolden : BaseParticle() {
          * Storing the copy will result in a new copy of the data being stored.
          */
         fun copy(name: String = this.name, price: Float = this.price, stock: Int = this.stock) = Product(name = name, price = price, stock = stock)
+
         /**
          * Use this method to create a new version of an existing entity.
          * Storing the mutation will overwrite the existing entity in the set, if it exists.
@@ -339,15 +337,15 @@ abstract class AbstractKotlinPrimitivesGolden : BaseParticle() {
             expirationTimestamp = expirationTimestamp
         )
 
-        companion object : EntitySpec<Product> {
+        companion object : arcs.sdk.EntitySpec<Product> {
 
-            override val SCHEMA = Schema(
-                setOf(SchemaName("Product")),
-                SchemaFields(
+            override val SCHEMA = arcs.core.data.Schema(
+                setOf(arcs.core.data.SchemaName("Product")),
+                arcs.core.data.SchemaFields(
                     singletons = mapOf(
-                        "name" to FieldType.Text,
-                        "price" to FieldType.Float,
-                        "stock" to FieldType.Int
+                        "name" to arcs.core.data.FieldType.Text,
+                        "price" to arcs.core.data.FieldType.Float,
+                        "stock" to arcs.core.data.FieldType.Int
                     ),
                     collections = emptyMap()
                 ),
@@ -356,14 +354,14 @@ abstract class AbstractKotlinPrimitivesGolden : BaseParticle() {
                 query = null
             )
 
-            private val nestedEntitySpecs: Map<String, EntitySpec<out Entity>> =
+            private val nestedEntitySpecs: Map<String, arcs.sdk.EntitySpec<out arcs.sdk.Entity>> =
                 emptyMap()
 
             init {
-                SchemaRegistry.register(SCHEMA)
+                arcs.core.data.SchemaRegistry.register(SCHEMA)
             }
 
-            override fun deserialize(data: RawEntity) = Product().apply {
+            override fun deserialize(data: arcs.core.data.RawEntity) = Product().apply {
                 deserialize(data, nestedEntitySpecs)
             }
         }
@@ -375,9 +373,9 @@ abstract class AbstractKotlinPrimitivesGolden : BaseParticle() {
         txt: String = "",
         num: Double = 0.0,
         entityId: String? = null,
-        creationTimestamp: Long = RawEntity.UNINITIALIZED_TIMESTAMP,
-        expirationTimestamp: Long = RawEntity.UNINITIALIZED_TIMESTAMP
-    ) : EntityBase("Detail", SCHEMA, entityId, creationTimestamp, expirationTimestamp, false) {
+        creationTimestamp: Long = arcs.core.data.RawEntity.UNINITIALIZED_TIMESTAMP,
+        expirationTimestamp: Long = arcs.core.data.RawEntity.UNINITIALIZED_TIMESTAMP
+    ) : arcs.sdk.EntityBase("Detail", SCHEMA, entityId, creationTimestamp, expirationTimestamp, false) {
 
         var nested: Nested
             get() = super.getSingletonValue("nested") as Nested? ?: Nested()
@@ -400,6 +398,7 @@ abstract class AbstractKotlinPrimitivesGolden : BaseParticle() {
          * Storing the copy will result in a new copy of the data being stored.
          */
         fun copy(nested: Nested = this.nested, txt: String = this.txt, num: Double = this.num) = Detail(nested = nested, txt = txt, num = num)
+
         /**
          * Use this method to create a new version of an existing entity.
          * Storing the mutation will overwrite the existing entity in the set, if it exists.
@@ -413,15 +412,15 @@ abstract class AbstractKotlinPrimitivesGolden : BaseParticle() {
             expirationTimestamp = expirationTimestamp
         )
 
-        companion object : EntitySpec<Detail> {
+        companion object : arcs.sdk.EntitySpec<Detail> {
 
-            override val SCHEMA = Schema(
-                setOf(SchemaName("Detail")),
-                SchemaFields(
+            override val SCHEMA = arcs.core.data.Schema(
+                setOf(arcs.core.data.SchemaName("Detail")),
+                arcs.core.data.SchemaFields(
                     singletons = mapOf(
-                        "nested" to FieldType.InlineEntity("e8b8d30e041174ca9104dfba453615c934af27b3"),
-                        "txt" to FieldType.Text,
-                        "num" to FieldType.Number
+                        "nested" to arcs.core.data.FieldType.InlineEntity("e8b8d30e041174ca9104dfba453615c934af27b3"),
+                        "txt" to arcs.core.data.FieldType.Text,
+                        "num" to arcs.core.data.FieldType.Number
                     ),
                     collections = emptyMap()
                 ),
@@ -430,14 +429,14 @@ abstract class AbstractKotlinPrimitivesGolden : BaseParticle() {
                 query = null
             )
 
-            private val nestedEntitySpecs: Map<String, EntitySpec<out Entity>> =
+            private val nestedEntitySpecs: Map<String, arcs.sdk.EntitySpec<out arcs.sdk.Entity>> =
                 mapOf("e8b8d30e041174ca9104dfba453615c934af27b3" to Nested)
 
             init {
-                SchemaRegistry.register(SCHEMA)
+                arcs.core.data.SchemaRegistry.register(SCHEMA)
             }
 
-            override fun deserialize(data: RawEntity) = Detail().apply {
+            override fun deserialize(data: arcs.core.data.RawEntity) = Detail().apply {
                 deserialize(data, nestedEntitySpecs)
             }
         }
@@ -449,7 +448,7 @@ abstract class AbstractKotlinPrimitivesGolden : BaseParticle() {
         txt: String = "",
         lnk: String = "",
         flg: Boolean = false,
-        ref: Reference<KotlinPrimitivesGolden_Data_Ref>? = null,
+        ref: arcs.sdk.Reference<KotlinPrimitivesGolden_Data_Ref>? = null,
         bt: Byte = 0.toByte(),
         shrt: Short = 0.toShort(),
         nt: Int = 0,
@@ -460,21 +459,21 @@ abstract class AbstractKotlinPrimitivesGolden : BaseParticle() {
         dbl: Double = 0.0,
         txtlst: List<String> = emptyList(),
         lnglst: List<Long> = emptyList(),
-        thinglst: List<Reference<Thing>> = emptyList(),
+        thinglst: List<arcs.sdk.Reference<Thing>> = emptyList(),
         detail: Detail = Detail(),
         colors: Set<Color> = emptySet(),
         products: List<Product> = emptyList(),
         entityId: String? = null,
-        creationTimestamp: Long = RawEntity.UNINITIALIZED_TIMESTAMP,
-        expirationTimestamp: Long = RawEntity.UNINITIALIZED_TIMESTAMP
-    ) : EntityBase(
-    "KotlinPrimitivesGolden_Data",
-    SCHEMA,
-    entityId,
-    creationTimestamp,
-    expirationTimestamp,
-    false
-) {
+        creationTimestamp: Long = arcs.core.data.RawEntity.UNINITIALIZED_TIMESTAMP,
+        expirationTimestamp: Long = arcs.core.data.RawEntity.UNINITIALIZED_TIMESTAMP
+    ) : arcs.sdk.EntityBase(
+        "KotlinPrimitivesGolden_Data",
+        SCHEMA,
+        entityId,
+        creationTimestamp,
+        expirationTimestamp,
+        false
+    ) {
 
         var num: Double
             get() = super.getSingletonValue("num") as Double? ?: 0.0
@@ -488,8 +487,8 @@ abstract class AbstractKotlinPrimitivesGolden : BaseParticle() {
         var flg: Boolean
             get() = super.getSingletonValue("flg") as Boolean? ?: false
             private set(_value) = super.setSingletonValue("flg", _value)
-        var ref: Reference<KotlinPrimitivesGolden_Data_Ref>?
-            get() = super.getSingletonValue("ref") as Reference<KotlinPrimitivesGolden_Data_Ref>?
+        var ref: arcs.sdk.Reference<KotlinPrimitivesGolden_Data_Ref>?
+            get() = super.getSingletonValue("ref") as arcs.sdk.Reference<KotlinPrimitivesGolden_Data_Ref>?
             private set(_value) = super.setSingletonValue("ref", _value)
         var bt: Byte
             get() = super.getSingletonValue("bt") as Byte? ?: 0.toByte()
@@ -521,8 +520,8 @@ abstract class AbstractKotlinPrimitivesGolden : BaseParticle() {
         var lnglst: List<Long>
             get() = super.getSingletonValue("lnglst") as List<Long>? ?: emptyList()
             private set(_value) = super.setSingletonValue("lnglst", _value)
-        var thinglst: List<Reference<Thing>>
-            get() = super.getSingletonValue("thinglst") as List<Reference<Thing>>? ?: emptyList()
+        var thinglst: List<arcs.sdk.Reference<Thing>>
+            get() = super.getSingletonValue("thinglst") as List<arcs.sdk.Reference<Thing>>? ?: emptyList()
             private set(_value) = super.setSingletonValue("thinglst", _value)
         var detail: Detail
             get() = super.getSingletonValue("detail") as Detail? ?: Detail()
@@ -565,7 +564,7 @@ abstract class AbstractKotlinPrimitivesGolden : BaseParticle() {
             txt: String = this.txt,
             lnk: String = this.lnk,
             flg: Boolean = this.flg,
-            ref: Reference<KotlinPrimitivesGolden_Data_Ref>? = this.ref,
+            ref: arcs.sdk.Reference<KotlinPrimitivesGolden_Data_Ref>? = this.ref,
             bt: Byte = this.bt,
             shrt: Short = this.shrt,
             nt: Int = this.nt,
@@ -576,7 +575,7 @@ abstract class AbstractKotlinPrimitivesGolden : BaseParticle() {
             dbl: Double = this.dbl,
             txtlst: List<String> = this.txtlst,
             lnglst: List<Long> = this.lnglst,
-            thinglst: List<Reference<Thing>> = this.thinglst,
+            thinglst: List<arcs.sdk.Reference<Thing>> = this.thinglst,
             detail: Detail = this.detail,
             colors: Set<Color> = this.colors,
             products: List<Product> = this.products
@@ -601,6 +600,7 @@ abstract class AbstractKotlinPrimitivesGolden : BaseParticle() {
             colors = colors,
             products = products
         )
+
         /**
          * Use this method to create a new version of an existing entity.
          * Storing the mutation will overwrite the existing entity in the set, if it exists.
@@ -610,7 +610,7 @@ abstract class AbstractKotlinPrimitivesGolden : BaseParticle() {
             txt: String = this.txt,
             lnk: String = this.lnk,
             flg: Boolean = this.flg,
-            ref: Reference<KotlinPrimitivesGolden_Data_Ref>? = this.ref,
+            ref: arcs.sdk.Reference<KotlinPrimitivesGolden_Data_Ref>? = this.ref,
             bt: Byte = this.bt,
             shrt: Short = this.shrt,
             nt: Int = this.nt,
@@ -621,7 +621,7 @@ abstract class AbstractKotlinPrimitivesGolden : BaseParticle() {
             dbl: Double = this.dbl,
             txtlst: List<String> = this.txtlst,
             lnglst: List<Long> = this.lnglst,
-            thinglst: List<Reference<Thing>> = this.thinglst,
+            thinglst: List<arcs.sdk.Reference<Thing>> = this.thinglst,
             detail: Detail = this.detail,
             colors: Set<Color> = this.colors,
             products: List<Product> = this.products
@@ -650,33 +650,33 @@ abstract class AbstractKotlinPrimitivesGolden : BaseParticle() {
             expirationTimestamp = expirationTimestamp
         )
 
-        companion object : EntitySpec<KotlinPrimitivesGolden_Data> {
+        companion object : arcs.sdk.EntitySpec<KotlinPrimitivesGolden_Data> {
 
-            override val SCHEMA = Schema(
+            override val SCHEMA = arcs.core.data.Schema(
                 setOf(),
-                SchemaFields(
+                arcs.core.data.SchemaFields(
                     singletons = mapOf(
-                        "num" to FieldType.Number,
-                        "txt" to FieldType.Text,
-                        "lnk" to FieldType.Text,
-                        "flg" to FieldType.Boolean,
-                        "ref" to FieldType.EntityRef("485712110d89359a3e539dac987329cd2649d889"),
-                        "bt" to FieldType.Byte,
-                        "shrt" to FieldType.Short,
-                        "nt" to FieldType.Int,
-                        "lng" to FieldType.Long,
-                        "big" to FieldType.BigInt,
-                        "chr" to FieldType.Char,
-                        "flt" to FieldType.Float,
-                        "dbl" to FieldType.Double,
-                        "txtlst" to FieldType.ListOf(FieldType.Text),
-                        "lnglst" to FieldType.ListOf(FieldType.Long),
-                        "thinglst" to FieldType.ListOf(FieldType.EntityRef("25e71af4e9fc8b6958fc46a8f4b7cdf6b5f31516")),
-                        "detail" to FieldType.InlineEntity("efcc87f84735b2f83b285e0f2768ff577611a68c"),
-                        "products" to FieldType.ListOf(FieldType.InlineEntity("e84265ec7993502eb817dcff9f34dec4d164db05"))
+                        "num" to arcs.core.data.FieldType.Number,
+                        "txt" to arcs.core.data.FieldType.Text,
+                        "lnk" to arcs.core.data.FieldType.Text,
+                        "flg" to arcs.core.data.FieldType.Boolean,
+                        "ref" to arcs.core.data.FieldType.EntityRef("485712110d89359a3e539dac987329cd2649d889"),
+                        "bt" to arcs.core.data.FieldType.Byte,
+                        "shrt" to arcs.core.data.FieldType.Short,
+                        "nt" to arcs.core.data.FieldType.Int,
+                        "lng" to arcs.core.data.FieldType.Long,
+                        "big" to arcs.core.data.FieldType.BigInt,
+                        "chr" to arcs.core.data.FieldType.Char,
+                        "flt" to arcs.core.data.FieldType.Float,
+                        "dbl" to arcs.core.data.FieldType.Double,
+                        "txtlst" to arcs.core.data.FieldType.ListOf(arcs.core.data.FieldType.Text),
+                        "lnglst" to arcs.core.data.FieldType.ListOf(arcs.core.data.FieldType.Long),
+                        "thinglst" to arcs.core.data.FieldType.ListOf(arcs.core.data.FieldType.EntityRef("25e71af4e9fc8b6958fc46a8f4b7cdf6b5f31516")),
+                        "detail" to arcs.core.data.FieldType.InlineEntity("efcc87f84735b2f83b285e0f2768ff577611a68c"),
+                        "products" to arcs.core.data.FieldType.ListOf(arcs.core.data.FieldType.InlineEntity("e84265ec7993502eb817dcff9f34dec4d164db05"))
                     ),
                     collections = mapOf(
-                        "colors" to FieldType.InlineEntity("e9ba6d9fa458ec35a966e462bb30a082e3f0d2f8")
+                        "colors" to arcs.core.data.FieldType.InlineEntity("e9ba6d9fa458ec35a966e462bb30a082e3f0d2f8")
                     )
                 ),
                 "44b8dccc1ae0cf6fa00a7dfeef0b0e6b1d565e24",
@@ -688,7 +688,7 @@ abstract class AbstractKotlinPrimitivesGolden : BaseParticle() {
                 query = null
             )
 
-            private val nestedEntitySpecs: Map<String, EntitySpec<out Entity>> =
+            private val nestedEntitySpecs: Map<String, arcs.sdk.EntitySpec<out arcs.sdk.Entity>> =
                 mapOf(
     "485712110d89359a3e539dac987329cd2649d889" to KotlinPrimitivesGolden_Data_Ref,
     "25e71af4e9fc8b6958fc46a8f4b7cdf6b5f31516" to Thing,
@@ -698,19 +698,19 @@ abstract class AbstractKotlinPrimitivesGolden : BaseParticle() {
 )
 
             init {
-                SchemaRegistry.register(SCHEMA)
+                arcs.core.data.SchemaRegistry.register(SCHEMA)
             }
 
-            override fun deserialize(data: RawEntity) = KotlinPrimitivesGolden_Data().apply {
+            override fun deserialize(data: arcs.core.data.RawEntity) = KotlinPrimitivesGolden_Data().apply {
                 deserialize(data, nestedEntitySpecs)
             }
         }
     }
 
-    class Handles : HandleHolderBase(
+    class Handles : arcs.sdk.HandleHolderBase(
         "KotlinPrimitivesGolden",
         mapOf("data" to setOf(KotlinPrimitivesGolden_Data))
     ) {
-        val data: ReadSingletonHandle<KotlinPrimitivesGolden_Data> by handles
+        val data: arcs.sdk.ReadSingletonHandle<KotlinPrimitivesGolden_Data> by handles
     }
 }

--- a/src/tools/tests/plan-generator-tests.ts
+++ b/src/tools/tests/plan-generator-tests.ts
@@ -77,7 +77,7 @@ describe('plan generator', () => {
 `HandleConnection(
     R_Handle0,
     HandleMode.Write,
-    SingletonType(EntityType(A_Data.SCHEMA)),
+    arcs.core.data.SingletonType(arcs.core.data.EntityType(A_Data.SCHEMA)),
     emptyList()
 )`
     );
@@ -86,7 +86,7 @@ describe('plan generator', () => {
 `HandleConnection(
     R_Handle0,
     HandleMode.Read,
-    SingletonType(EntityType(B_Data.SCHEMA)),
+    arcs.core.data.SingletonType(arcs.core.data.EntityType(B_Data.SCHEMA)),
     emptyList()
 )`
     );
@@ -147,7 +147,7 @@ Particle(
         "data" to HandleConnection(
             Recipe_Handle0,
             HandleMode.Write,
-            SingletonType(EntityType(Writer_Data.SCHEMA)),
+            arcs.core.data.SingletonType(arcs.core.data.EntityType(Writer_Data.SCHEMA)),
             listOf(Annotation("persistent", emptyMap()))
         )
     )
@@ -179,7 +179,7 @@ Particle(
         "data" to HandleConnection(
             Recipe_Handle0,
             HandleMode.ReadWrite,
-            SingletonType(EntityType(Intermediary_Data.SCHEMA)),
+            arcs.core.data.SingletonType(arcs.core.data.EntityType(Intermediary_Data.SCHEMA)),
             listOf(Annotation("persistent", emptyMap()))
         )
     )
@@ -202,7 +202,7 @@ Particle(
 HandleConnection(
     R_Handle0,
     HandleMode.Write,
-    CollectionType(EntityType(A_Data.SCHEMA)),
+    arcs.core.data.CollectionType(arcs.core.data.EntityType(A_Data.SCHEMA)),
     emptyList()
 )`);
   });
@@ -230,12 +230,15 @@ HandleConnection(
 HandleConnection(
     R_Handle0,
     HandleMode.Read,
-    CollectionType(
-        EntityType(
-            Schema(
-                setOf(SchemaName("Person")),
-                SchemaFields(
-                    singletons = mapOf("a" to FieldType.Text, "b" to FieldType.Text),
+    arcs.core.data.CollectionType(
+        arcs.core.data.EntityType(
+            arcs.core.data.Schema(
+                setOf(arcs.core.data.SchemaName("Person")),
+                arcs.core.data.SchemaFields(
+                    singletons = mapOf(
+                        "a" to arcs.core.data.FieldType.Text,
+                        "b" to arcs.core.data.FieldType.Text
+                    ),
                     collections = emptyMap()
                 ),
                 "f33d42dee457673f13e166b4644b0eb42f37a156",
@@ -272,11 +275,14 @@ HandleConnection(
     assert.equal(handleObject, `\
 val MyRecipe_Handle0 = Handle(
     StorageKeyParser.parse("create://67835270998a62139f8b366f1cb545fb9b72a90b"),
-    EntityType(
-        Schema(
-            setOf(SchemaName("Person")),
-            SchemaFields(
-                singletons = mapOf("name" to FieldType.Text, "age" to FieldType.Number),
+    arcs.core.data.EntityType(
+        arcs.core.data.Schema(
+            setOf(arcs.core.data.SchemaName("Person")),
+            arcs.core.data.SchemaFields(
+                singletons = mapOf(
+                    "name" to arcs.core.data.FieldType.Text,
+                    "age" to arcs.core.data.FieldType.Number
+                ),
                 collections = emptyMap()
             ),
             "edabcee36cb653ff468fb77804911ddfa9303d67",

--- a/src/tools/tests/schema2wasm-test.ts
+++ b/src/tools/tests/schema2wasm-test.ts
@@ -58,7 +58,7 @@ describe('schema2wasm', () => {
     const mock = await Schema2Mock.create(manifest);
     assert.deepStrictEqual(mock.res, {
       'FooInternal1': ['txt:String'],
-      'Site':         ['url:String', 'ref:Reference<FooInternal1>?'],
+      'Site':         ['url:String', 'ref:arcs.sdk.Reference<FooInternal1>?'],
       'Foo_Input2':   ['txt:String', 'num:Double'],
     });
   });
@@ -83,10 +83,10 @@ describe('schema2wasm', () => {
     `);
     const mock = await Schema2Mock.create(manifest);
     assert.deepStrictEqual(mock.res, {
-      'Foo_H1':     ['a:String', 'r:Reference<Foo_H1_R>?'],
+      'Foo_H1':     ['a:String', 'r:arcs.sdk.Reference<Foo_H1_R>?'],
       'Foo_H1_R':   ['b:String'],
-      'Foo_H2':     ['s:Reference<Foo_H2_S>?'],
-      'Foo_H2_S':   ['f:Boolean', 't:Reference<Foo_H2_S_T>?'],
+      'Foo_H2':     ['s:arcs.sdk.Reference<Foo_H2_S>?'],
+      'Foo_H2_S':   ['f:Boolean', 't:arcs.sdk.Reference<Foo_H2_S_T>?'],
       'Foo_H2_S_T': ['x:Double'],
     });
   });


### PR DESCRIPTION
This prevents problems when schemas have names that can clash. Minimal manifest to show this:

```
schema Entity

schema Feedback
  selection_feedback: &SelectionFeedback

schema SelectionFeedback
  selected_entity: &Entity

particle FeedbackBatchWriter
  feedback: reads writes Feedback
```