### PR TITLE
Only generate test harness if requested

### DIFF
--- a/java/arcs/sdk/examples/testing/BUILD
+++ b/java/arcs/sdk/examples/testing/BUILD
@@ -11,6 +11,7 @@ package(default_visibility = ["//java/arcs:allowed-packages"])
 arcs_kt_schema(
     name = "codegen",
     srcs = ["ComputePeopleStats.arcs"],
+    test_harness = True,
 )
 
 arcs_kt_jvm_library(

--- a/javatests/arcs/core/host/BUILD
+++ b/javatests/arcs/core/host/BUILD
@@ -58,6 +58,7 @@ arcs_kt_schema(
         "reflective.arcs",
         "test.arcs",
     ],
+    test_harness = True,
 )
 
 arcs_kt_plan(

--- a/javatests/arcs/sdk/spec/BUILD
+++ b/javatests/arcs/sdk/spec/BUILD
@@ -31,4 +31,5 @@ arcs_kt_jvm_test_suite(
 arcs_kt_schema(
     name = "schemas",
     srcs = glob(["*.arcs"]),
+    test_harness = True,
 )

--- a/javatests/arcs/showcase/typevariables/BUILD
+++ b/javatests/arcs/showcase/typevariables/BUILD
@@ -10,7 +10,6 @@ licenses(["notice"])
 arcs_kt_gen(
     name = "var_generation",
     srcs = ["variable.arcs"],
-    test_harness = False,
 )
 
 arcs_kt_android_library(

--- a/src/tools/tests/BUILD
+++ b/src/tools/tests/BUILD
@@ -40,6 +40,7 @@ arcs_kt_schema(
 arcs_kt_schema(
     name = "kt_schemas",
     srcs = ["golden.arcs"],
+    test_harness = True,
 )
 
 arcs_kt_schema(

--- a/third_party/java/arcs/build_defs/internal/schemas.bzl
+++ b/third_party/java/arcs/build_defs/internal/schemas.bzl
@@ -65,7 +65,7 @@ def arcs_kt_schema(
         data = [],
         deps = [],
         platforms = ["jvm"],
-        test_harness = True,
+        test_harness = False,
         visibility = None):
     """Generates a Kotlin schemas, entities, specs, handle holders, and base particles for input .arcs manifest files.
 
@@ -170,7 +170,7 @@ def arcs_kt_gen(
         data = [],
         deps = [],
         platforms = ["jvm"],
-        test_harness = True,
+        test_harness = False,
         visibility = None):
     """Generates Kotlin files for the given .arcs files.
 


### PR DESCRIPTION
We haven't yet made test harness work with type variables (may be trivial, may not be, TBD), which is causing some issues with internal builds.

Making the test harness only generated on request, which is IMO the right thing to do regardless of the issues with typevars.