### PR TITLE
Add support for Store in AccessPath

### DIFF
--- a/java/arcs/core/data/AccessPath.kt
+++ b/java/arcs/core/data/AccessPath.kt
@@ -11,6 +11,8 @@
 
 package arcs.core.data
 
+typealias StoreId = String
+
 /**
  * Specifies an access path in a claim or a check.
  *
@@ -65,7 +67,10 @@ data class AccessPath(val root: Root, val selectors: List<Selector> = emptyList(
         ) : Root() {
             override fun toString() = "hcs:$particleSpecName.${connectionSpec.name}"
         }
-        // TODO(bgogul): Store, etc.
+
+        data class Store(val storeId: StoreId) : Root() {
+            override fun toString() = "s:$storeId"
+        }
     }
 
     /** Represents an access to a part of the data (like a field). */

--- a/java/arcs/core/policy/PolicyConstraints.kt
+++ b/java/arcs/core/policy/PolicyConstraints.kt
@@ -7,8 +7,7 @@ import arcs.core.data.InformationFlowLabel.Predicate
 import arcs.core.data.InformationFlowLabel.SemanticTag
 import arcs.core.data.ParticleSpec
 import arcs.core.data.Recipe
-
-typealias StoreId = String
+import arcs.core.data.StoreId
 
 /**
  * Additional checks and claims that should be added to the particles in a recipe, which together

--- a/javatests/arcs/core/data/AccessPathTest.kt
+++ b/javatests/arcs/core/data/AccessPathTest.kt
@@ -94,17 +94,17 @@ class AccessPathTest {
         val handleAccessPath = AccessPath(handle, oneSelector)
         val particleAccessPath = AccessPath(particle, connectionSpec, oneSelector)
         val storeAccessPath = AccessPath(AccessPath.Root.Store("MySecretStore"), oneSelector)
-        with (particleAccessPath) {
+        with(particleAccessPath) {
             assertThat(isPrefixOf(particleAccessPath)).isTrue()
             assertThat(isPrefixOf(handleAccessPath)).isFalse()
             assertThat(isPrefixOf(storeAccessPath)).isFalse()
         }
-        with (handleAccessPath) {
+        with(handleAccessPath) {
             assertThat(isPrefixOf(particleAccessPath)).isFalse()
             assertThat(isPrefixOf(handleAccessPath)).isTrue()
             assertThat(isPrefixOf(storeAccessPath)).isFalse()
         }
-        with (storeAccessPath) {
+        with(storeAccessPath) {
             assertThat(isPrefixOf(particleAccessPath)).isFalse()
             assertThat(isPrefixOf(handleAccessPath)).isFalse()
             assertThat(isPrefixOf(storeAccessPath)).isTrue()

--- a/javatests/arcs/core/data/AccessPathTest.kt
+++ b/javatests/arcs/core/data/AccessPathTest.kt
@@ -40,6 +40,8 @@ class AccessPathTest {
             .isEqualTo("hc:Reader.data")
         assertThat("${AccessPath.Root.HandleConnectionSpec("Reader", connectionSpec)}")
             .isEqualTo("hcs:Reader.data")
+        assertThat("${AccessPath.Root.Store("MySecretStore")}")
+            .isEqualTo("s:MySecretStore")
     }
 
     @Test
@@ -51,6 +53,8 @@ class AccessPathTest {
     fun prettyPrintAccessPathNoSelectors() {
         assertThat("${AccessPath(handle)}").isEqualTo("h:thing")
         assertThat("${AccessPath(particle, connectionSpec)}").isEqualTo("hc:Reader.data")
+        assertThat("${AccessPath(AccessPath.Root.Store("MySecretStore"))}")
+            .isEqualTo("s:MySecretStore")
     }
 
     @Test
@@ -65,6 +69,10 @@ class AccessPathTest {
             .isEqualTo("hcs:Reader.data.foo")
         assertThat("${AccessPath("Reader", connectionSpec, multipleSelectors)}")
             .isEqualTo("hcs:Reader.data.foo.bar")
+        assertThat("${AccessPath(AccessPath.Root.Store("MySecretStore"), oneSelector)}")
+            .isEqualTo("s:MySecretStore.foo")
+        assertThat("${AccessPath(AccessPath.Root.Store("MySecretStore"), multipleSelectors)}")
+            .isEqualTo("s:MySecretStore.foo.bar")
     }
 
     @Test
@@ -85,13 +93,44 @@ class AccessPathTest {
     fun isPrefixOf_comparesRoots() {
         val handleAccessPath = AccessPath(handle, oneSelector)
         val particleAccessPath = AccessPath(particle, connectionSpec, oneSelector)
-        assertThat(handleAccessPath.isPrefixOf(particleAccessPath)).isFalse()
-        assertThat(particleAccessPath.isPrefixOf(handleAccessPath)).isFalse()
+        val storeAccessPath = AccessPath(AccessPath.Root.Store("MySecretStore"), oneSelector)
+        with (particleAccessPath) {
+            assertThat(isPrefixOf(particleAccessPath)).isTrue()
+            assertThat(isPrefixOf(handleAccessPath)).isFalse()
+            assertThat(isPrefixOf(storeAccessPath)).isFalse()
+        }
+        with (handleAccessPath) {
+            assertThat(isPrefixOf(particleAccessPath)).isFalse()
+            assertThat(isPrefixOf(handleAccessPath)).isTrue()
+            assertThat(isPrefixOf(storeAccessPath)).isFalse()
+        }
+        with (storeAccessPath) {
+            assertThat(isPrefixOf(particleAccessPath)).isFalse()
+            assertThat(isPrefixOf(handleAccessPath)).isFalse()
+            assertThat(isPrefixOf(storeAccessPath)).isTrue()
+        }
 
         val handleAccessPathMultiple = AccessPath(handle, multipleSelectors)
         val particleAccessPathMultiple = AccessPath(particle, connectionSpec, multipleSelectors)
-        assertThat(handleAccessPathMultiple.isPrefixOf(particleAccessPathMultiple)).isFalse()
-        assertThat(particleAccessPathMultiple.isPrefixOf(handleAccessPathMultiple)).isFalse()
+        val storeAccessPathMultiple = AccessPath(
+            AccessPath.Root.Store("MySecretStore"),
+            multipleSelectors
+        )
+        with(particleAccessPathMultiple) {
+            assertThat(isPrefixOf(particleAccessPathMultiple)).isTrue()
+            assertThat(isPrefixOf(handleAccessPathMultiple)).isFalse()
+            assertThat(isPrefixOf(storeAccessPathMultiple)).isFalse()
+        }
+        with(handleAccessPathMultiple) {
+            assertThat(isPrefixOf(particleAccessPathMultiple)).isFalse()
+            assertThat(isPrefixOf(handleAccessPathMultiple)).isTrue()
+            assertThat(isPrefixOf(storeAccessPathMultiple)).isFalse()
+        }
+        with(storeAccessPathMultiple) {
+            assertThat(isPrefixOf(particleAccessPathMultiple)).isFalse()
+            assertThat(isPrefixOf(handleAccessPathMultiple)).isFalse()
+            assertThat(isPrefixOf(storeAccessPathMultiple)).isTrue()
+        }
     }
 
     @Test


### PR DESCRIPTION
This is necessary to capture the claims that we need to put on ingress stores during data flow analysis. 