### PR TITLE
Policy Translation: claims should be associated with stores and not handles.

### DIFF
--- a/java/arcs/core/policy/PolicyConstraints.kt
+++ b/java/arcs/core/policy/PolicyConstraints.kt
@@ -53,45 +53,48 @@ fun translatePolicy(
     }
 
     // Add claim statements for stores.
-    val targetBySchemaName = policy.targets.associateBy { it.schemaName }
-    val storeClaims = recipe.handles.values.filter { storeMap.containsKey(it.id) }
-        .associate { handle ->
-            val storeId = handle.id
-            val claims = storeMap[storeId]?.let { schemaName ->
-                targetBySchemaName[schemaName]?.let { target ->
-                    createClaims(handle, target)
-                }
-            }
-            handle.id to (claims ?: emptyList())
+    val storeClaims = mutableMapOf<StoreId, List<Claim>>()
+    policy.targets.forEach { target ->
+        val stores = storeMap.mapNotNull { (storeId, schemaName) ->
+            if (schemaName == target.schemaName) storeId else null
         }
-        .filterValues { it.isNotEmpty() }
+        if (stores.isEmpty()) {
+            throw PolicyViolation.NoStoreForPolicyTarget(policy, target)
+        }
+        stores.forEach { storeId ->
+            val storeRoot = AccessPath.Root.Store(storeId)
+            storeClaims[storeId] = target.createClaims(storeRoot)
+        }
+    }
 
-    return PolicyConstraints(policy, egressChecks, storeClaims)
+    return PolicyConstraints(
+        policy,
+        egressChecks,
+        storeClaims.filterValues { it.isNotEmpty() }
+    )
 }
 
 /** Returns a list of store [Claim]s for the given [handle] and corresponding [target]. */
-private fun createClaims(handle: Recipe.Handle, target: PolicyTarget): List<Claim> {
-    return target.fields.flatMap { field -> createClaims(handle, field) }
+private fun PolicyTarget.createClaims(store: AccessPath.Root.Store): List<Claim> {
+    return fields.flatMap { field -> field.createClaims(store) }
 }
 
 /**
  * Returns a list of claims for the given [field] (and all subfields), using the given [handle]
  * as the root for the claims.
  */
-private fun createClaims(handle: Recipe.Handle, field: PolicyField): List<Claim> {
+private fun PolicyField.createClaims(store: AccessPath.Root.Store): List<Claim> {
     val claims = mutableListOf<Claim>()
 
     // Create claim for this field.
-    createStoreClaimPredicate(field)?.let { predicate ->
-        val selectors = field.fieldPath.map { AccessPath.Selector.Field(it) }
-        // TODO(b/157605232): This AccessPath is rooted by the handle's name in the recipe. The name
-        // might not be the same across different recipes, so this needs to be store ID instead.
-        val accessPath = AccessPath(handle, selectors)
+    createStoreClaimPredicate()?.let { predicate ->
+        val selectors = fieldPath.map { AccessPath.Selector.Field(it) }
+        val accessPath = AccessPath(store, selectors)
         claims.add(Claim.Assume(accessPath, predicate))
     }
 
     // Add claims for subfields.
-    field.subfields.flatMapTo(claims) { subfield -> createClaims(handle, subfield) }
+    subfields.flatMapTo(claims) { subfield -> subfield.createClaims(store) }
 
     return claims
 }
@@ -100,12 +103,12 @@ private fun createClaims(handle: Recipe.Handle, field: PolicyField): List<Claim>
  * Constructs the [Predicate] for the given [field] in a [Policy], to be used in constructing
  * [Claim]s on the corresponding handles for the field in a recipe.
  */
-private fun createStoreClaimPredicate(field: PolicyField): Predicate? {
+private fun PolicyField.createStoreClaimPredicate(): Predicate? {
     val predicates = mutableListOf<Predicate>()
-    if (field.rawUsages.canEgress()) {
+    if (rawUsages.canEgress()) {
         predicates.add(labelPredicate(ALLOWED_FOR_EGRESS_LABEL))
     }
-    val egressRedactionLabels = field.redactedUsages.filterValues { it.canEgress() }.keys
+    val egressRedactionLabels = redactedUsages.filterValues { it.canEgress() }.keys
     egressRedactionLabels.forEach { label ->
         predicates.add(labelPredicate("${ALLOWED_FOR_EGRESS_LABEL}_$label"))
     }
@@ -185,5 +188,13 @@ sealed class PolicyViolation(val policy: Policy, message: String) : Exception(
     class MultipleEgressParticles(policy: Policy) : PolicyViolation(
         policy,
         "Multiple egress particles named ${policy.egressParticleName} found for policy"
+    )
+
+    class NoStoreForPolicyTarget(
+        policy: Policy,
+        target: PolicyTarget
+    ) : PolicyViolation(
+        policy,
+        "No store found for policy target $target mentioned in ${policy.name}"
     )
 }

--- a/javatests/arcs/core/policy/PolicyConstraintsTest.kt
+++ b/javatests/arcs/core/policy/PolicyConstraintsTest.kt
@@ -110,7 +110,11 @@ class PolicyConstraintsTest {
         val policy = policies.getValue("FooRedactions")
         val recipe = recipes.getValue("SingleInput").forceMatchPolicyName(policy.name)
 
-        val result = translatePolicy(policy, recipe, emptyMap())
+        val result = translatePolicy(
+            policy,
+            recipe,
+            mapOf("my_store_id" to "Foo")
+        )
 
         val check = result.egressChecks.values.single().single() as Check.Assert
         assertThat(check.predicate).isEqualTo(
@@ -142,20 +146,20 @@ class PolicyConstraintsTest {
 
         val result = translatePolicy(policy, recipe, storeMap)
 
-        val handle = recipe.handles.values.single()
+        val store = AccessPath.Root.Store("my_store_id")
         assertThat(result.storeClaims).containsExactly(
             "my_store_id",
             listOf(
                 Claim.Assume(
-                    AccessPath(handle, selectors("a")),
+                    AccessPath(store, selectors("a")),
                     labelPredicate("allowedForEgress_redaction1")
                 ),
                 Claim.Assume(
-                    AccessPath(handle, selectors("b")),
+                    AccessPath(store, selectors("b")),
                     labelPredicate("allowedForEgress_redaction2")
                 ),
                 Claim.Assume(
-                    AccessPath(handle, selectors("c")),
+                    AccessPath(store, selectors("c")),
                     labelPredicate("allowedForEgress_redaction3")
                 )
             )
@@ -170,12 +174,12 @@ class PolicyConstraintsTest {
 
         val result = translatePolicy(policy, recipe, storeMap)
 
-        val handle = recipe.handles.values.single()
+        val store = AccessPath.Root.Store("my_store_id")
         assertThat(result.storeClaims).containsExactly(
             "my_store_id",
             listOf(
                 Claim.Assume(
-                    AccessPath(handle, selectors("a")),
+                    AccessPath(store, selectors("a")),
                     labelPredicate("allowedForEgress_redaction1")
                 )
             )
@@ -186,22 +190,11 @@ class PolicyConstraintsTest {
     fun applyPolicy_storeClaims_missingFromStoresMap() {
         val policy = policies.getValue("FooRedactions")
         val recipe = recipes.getValue("SingleMappedInput").forceMatchPolicyName(policy.name)
-        val storeMap = mapOf("some_other_store" to "Foo")
+        val storeMap = mapOf("some_other_store" to "Bar")
 
-        val result = translatePolicy(policy, recipe, storeMap)
-
-        assertThat(result.storeClaims).isEmpty()
-    }
-
-    @Test
-    fun applyPolicy_storeClaims_differentType() {
-        val policy = policies.getValue("SingleBarRedaction")
-        val recipe = recipes.getValue("SingleMappedInput").forceMatchPolicyName(policy.name)
-        val storeMap = mapOf("my_store_id" to "Foo")
-
-        val result = translatePolicy(policy, recipe, storeMap)
-
-        assertThat(result.storeClaims).isEmpty()
+        assertFailsWith<PolicyViolation.NoStoreForPolicyTarget> {
+            translatePolicy(policy, recipe, storeMap)
+        }
     }
 
     @Test
@@ -233,17 +226,17 @@ class PolicyConstraintsTest {
 
         val result = translatePolicy(policy, recipe, storeMap)
 
-        val handle = recipe.handles.values.single()
+        val store = AccessPath.Root.Store("my_store_id")
         val predicate = labelPredicate("allowedForEgress")
         assertThat(result.storeClaims).containsExactly(
             "my_store_id",
             listOf(
-                Claim.Assume(AccessPath(handle, selectors("foo")), predicate),
-                Claim.Assume(AccessPath(handle, selectors("foo", "a")), predicate),
-                Claim.Assume(AccessPath(handle, selectors("foo", "b")), predicate),
-                Claim.Assume(AccessPath(handle, selectors("foo", "c")), predicate),
-                Claim.Assume(AccessPath(handle, selectors("bar")), predicate),
-                Claim.Assume(AccessPath(handle, selectors("bar", "a")), predicate)
+                Claim.Assume(AccessPath(store, selectors("foo")), predicate),
+                Claim.Assume(AccessPath(store, selectors("foo", "a")), predicate),
+                Claim.Assume(AccessPath(store, selectors("foo", "b")), predicate),
+                Claim.Assume(AccessPath(store, selectors("foo", "c")), predicate),
+                Claim.Assume(AccessPath(store, selectors("bar")), predicate),
+                Claim.Assume(AccessPath(store, selectors("bar", "a")), predicate)
             )
         )
     }

--- a/javatests/arcs/core/policy/PolicyTranslationTestData.arcs
+++ b/javatests/arcs/core/policy/PolicyTranslationTestData.arcs
@@ -16,7 +16,7 @@ schema NestedFooBar
 particle Egress_SingleInput
   input: reads Foo {a, b, c}
 recipe SingleInput
-  input: create
+  input: create 'my_store_id'
   Egress_SingleInput
     input: input
 


### PR DESCRIPTION
This PR changes the policy translation so that it associates claims with the stores instead of handles. This is one of the steps that is needed to disassociate policy translation from the recipe. 