### PR TITLE
Implement policy verification in DFA

### DIFF
--- a/java/arcs/core/analysis/BUILD
+++ b/java/arcs/core/analysis/BUILD
@@ -15,6 +15,7 @@ arcs_kt_library(
     deps = [
         "//java/arcs/core/data",
         "//java/arcs/core/data:schema_fields",
+        "//java/arcs/core/policy",
         "//java/arcs/core/type",
         "//java/arcs/core/util",
     ],

--- a/java/arcs/core/analysis/PolicyVerifier.kt
+++ b/java/arcs/core/analysis/PolicyVerifier.kt
@@ -26,12 +26,12 @@ import arcs.core.policy.translatePolicy
 /** A class to verify that recipes are compliant with a policy. */
 class PolicyVerifier(val options: PolicyOptions) {
     /**
-     * Verifies that the recipe is compliant with the given policy.
+     * Returns true if the recipe is compliant with the given policy.
      *
-     * @throws [arcs.core.policy.PolicyViolation] if policy is violated by the recipe.
+     * @throws [PolicyViolation] if policy is violated by the recipe.
      */
     public fun verifyPolicy(recipe: Recipe, policy: Policy): Boolean {
-        // TODO(bgogul): This should be moved to the compilation step.
+        // TODO(b/162083814): This should be moved to the compilation step.
         val policyConstraints = translatePolicy(policy, options)
         val graph = RecipeGraph(recipe)
 
@@ -92,7 +92,7 @@ class PolicyVerifier(val options: PolicyOptions) {
     /**
      * Returns the egress checks.
      *
-     * @throws [arcs.core.policy.PolicyViolation] if recipe violates egress requirements.
+     * @throws [PolicyViolation] if recipe violates egress requirements.
      */
     private fun getEgressChecks(
         policy: Policy,

--- a/java/arcs/core/analysis/PolicyVerifier.kt
+++ b/java/arcs/core/analysis/PolicyVerifier.kt
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.core.analysis
+
+import arcs.core.data.AccessPath
+import arcs.core.data.Check
+import arcs.core.data.Claim
+import arcs.core.data.InformationFlowLabel.Predicate
+import arcs.core.data.ParticleSpec
+import arcs.core.data.Recipe
+import arcs.core.policy.Policy
+import arcs.core.policy.PolicyConstraints
+import arcs.core.policy.PolicyOptions
+import arcs.core.policy.PolicyViolation
+import arcs.core.policy.translatePolicy
+
+/** A class to verify that recipes are compliant with a policy. */
+class PolicyVerifier(val options: PolicyOptions) {
+    /**
+     * Verifies that the recipe is compliant with the given policy.
+     *
+     * @throws [arcs.core.policy.PolicyViolation] if policy is violated by the recipe.
+     */
+    public fun verifyPolicy(recipe: Recipe, policy: Policy): Boolean {
+        // TODO(bgogul): This should be moved to the compilation step.
+        val policyConstraints = translatePolicy(policy, options)
+        val graph = RecipeGraph(recipe)
+
+        // Map the storeClaims to the corresponding handles.
+        val ingresses = graph.handleNodes.mapNotNull { getIngressInfo(it, policyConstraints) }
+
+        // Compute the egress check map.
+        val egressCheckPredicate = policyConstraints.egressCheck
+        val egressParticles = recipe.particles.filterNot { it.spec.isolated }
+        checkEgressParticles(policy, egressParticles)
+        val egressChecks = egressParticles.associate { particle ->
+            // Each handle connection needs its own check statement.
+            val checks = particle.spec.connections.values
+                .filter {
+                    // TODO(b/157605232): Also check canQuery -- but first, need to add QUERY to
+                    // the Direction enum in the manifest proto.
+                    it.direction.canRead
+                }
+                .map { connectionSpec ->
+                    Check.Assert(AccessPath(particle, connectionSpec), egressCheckPredicate)
+                }
+            particle.spec to checks
+        }
+        val analysisResult = InformationFlow.computeLabels(graph, ingresses, egressChecks)
+        val violations = analysisResult.checks.flatMap { (particle, checks) ->
+            checks.filterNot { check -> analysisResult.verify(particle, check) }
+            .map { it as Check.Assert }
+        }
+
+        if (violations.isNotEmpty()) {
+            throw PolicyViolation.ChecksViolated(policy, violations)
+        }
+
+        // No violations.
+        return true
+    }
+
+    /**
+     * If there are any claims associated with this handle's stores, creates and returns a
+     * [InformationFlow.IngressInfo] after remapping the root of the claims from the store to this
+     * handle. Otherwise returns null.
+     */
+    private fun getIngressInfo(
+        handleNode: RecipeGraph.Node.Handle,
+        policyConstraints: PolicyConstraints
+    ): InformationFlow.IngressInfo? {
+        return policyConstraints.storeClaims[handleNode.handle.id]
+            ?.filterIsInstance<Claim.Assume>()
+            ?.map {
+                Claim.Assume(
+                    AccessPath(handleNode.handle, it.accessPath.selectors),
+                    it.predicate
+                )
+            }
+            ?.let { claims -> InformationFlow.IngressInfo(handleNode, claims) }
+    }
+
+    /**
+     * Returns the egress checks.
+     *
+     * @throws [arcs.core.policy.PolicyViolation] if recipe violates egress requirements.
+     */
+    private fun getEgressChecks(
+        policy: Policy,
+        recipe: Recipe,
+        egressCheck: Predicate
+    ): Map<ParticleSpec, List<Check>> {
+        // Check that egress particles are compliant with policy.
+        val egressParticles = recipe.particles.filterNot { it.spec.isolated }
+        checkEgressParticles(policy, egressParticles)
+
+        // Create a check for each handle connection needs in the egress particles.
+        return egressParticles.associate { particle ->
+            val checks = particle.spec.connections.values
+                .filter {
+                    // TODO(b/157605232): Also check canQuery -- but first, need to add QUERY to
+                    // the Direction enum in the manifest proto.
+                    it.direction.canRead
+                }
+                .map { connectionSpec ->
+                    Check.Assert(AccessPath(particle, connectionSpec), egressCheck)
+                }
+            particle.spec to checks
+        }
+    }
+
+    /**
+     * Verifies that the given egress particle nodes match the policy. The only egress particle
+     * allowed to be used with a policy named `Foo` is an egress particle named `Egress_Foo`.
+     */
+    private fun checkEgressParticles(policy: Policy, egressParticles: List<Recipe.Particle>) {
+        val numValidEgressParticles = egressParticles.count {
+            it.spec.name == policy.egressParticleName
+        }
+        if (numValidEgressParticles > 1) {
+            throw PolicyViolation.MultipleEgressParticles(policy)
+        }
+        val invalidEgressParticles = egressParticles
+            .map { it.spec }
+            .filter { it.name != policy.egressParticleName }
+        if (invalidEgressParticles.isNotEmpty()) {
+            throw PolicyViolation.InvalidEgressParticle(
+                policy,
+                invalidEgressParticles.map { it.name }
+            )
+        }
+    }
+}

--- a/java/arcs/core/policy/PolicyConstraints.kt
+++ b/java/arcs/core/policy/PolicyConstraints.kt
@@ -1,6 +1,7 @@
 package arcs.core.policy
 
 import arcs.core.data.AccessPath
+import arcs.core.data.Check
 import arcs.core.data.Claim
 import arcs.core.data.InformationFlowLabel.Predicate
 import arcs.core.data.InformationFlowLabel.SemanticTag
@@ -146,11 +147,18 @@ sealed class PolicyViolation(val policy: Policy, message: String) : Exception(
         "Multiple egress particles named ${policy.egressParticleName} found for policy"
     )
 
+    /** Thrown when there is no store associated with schema. */
     class NoStoreForPolicyTarget(
         policy: Policy,
         target: PolicyTarget
     ) : PolicyViolation(
         policy,
-        "No store found for policy target $target mentioned in ${policy.name}"
+        "No store found for policy target `${target.schemaName}` mentioned in ${policy.name}"
     )
+
+    /** Thrown when policy checks are violated by a recipe. */
+    class ChecksViolated(
+        policy: Policy,
+        checks: List<Check>
+    ) : PolicyViolation(policy, "Recipe violates egress checks: $checks")
 }

--- a/javatests/arcs/core/analysis/BUILD
+++ b/javatests/arcs/core/analysis/BUILD
@@ -20,6 +20,8 @@ arcs_kt_jvm_test_suite(
         "//java/arcs/core/data:schema_fields",
         "//java/arcs/core/data/proto",
         "//java/arcs/core/data/proto:manifest_java_proto_lite",
+        "//java/arcs/core/policy",
+        "//java/arcs/core/policy/proto",
         "//java/arcs/core/testutil/protoloader",
         "//java/arcs/core/util",
         "//java/arcs/repoutils",

--- a/javatests/arcs/core/analysis/PolicyVerifierTest.kt
+++ b/javatests/arcs/core/analysis/PolicyVerifierTest.kt
@@ -1,0 +1,127 @@
+package arcs.core.analysis
+
+import arcs.core.data.proto.decodeRecipes
+import arcs.core.policy.PolicyOptions
+import arcs.core.policy.PolicyViolation
+import arcs.core.policy.proto.decode
+import arcs.core.testutil.protoloader.loadManifestBinaryProto
+import com.google.common.truth.Truth.assertThat
+import kotlin.test.assertFailsWith
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class PolicyVerifierTest {
+    // Test context.
+    val storeMap = mapOf("action" to "Action", "selection" to "Selection")
+    val manifestProto = loadManifestBinaryProto(getManifestProtoBinPath("policy-test"))
+    val recipes = manifestProto.decodeRecipes().associateBy { it.name!! }
+    val policy = manifestProto.policiesList.map { it.decode() }.single()
+    val verifier = PolicyVerifier(PolicyOptions(storeMap))
+
+    @Test
+    fun egressingUnrestrictedFieldsIsAllowed() {
+        assertThat(
+            verifier.verifyPolicy(
+                recipes.getValue("EgressUnrestrictedFields"),
+                policy
+            )
+        ).isTrue()
+    }
+
+    @Test
+    fun egressingRedactedFieldsIsAllowed() {
+        assertThat(
+            verifier.verifyPolicy(
+                recipes.getValue("EgressRedactedField"),
+                policy
+            )
+        ).isTrue()
+    }
+
+    @Test
+    fun egressingRestrictedFieldsIsDisallowed() {
+        assertFailsWith<PolicyViolation.ChecksViolated> {
+            verifier.verifyPolicy(
+                recipes.getValue("EgressRestrictedFields"),
+                policy
+            )
+        }
+    }
+
+    @Test
+    fun egressingJoinOnlyFieldsIsDisallowed() {
+        assertFailsWith<PolicyViolation.ChecksViolated> {
+            verifier.verifyPolicy(
+                recipes.getValue("EgressJoinOnlyField"),
+                policy
+            )
+        }
+    }
+
+    @Test
+    fun egressingUnredactedFieldsIsDisallowed() {
+        assertFailsWith<PolicyViolation.ChecksViolated> {
+            verifier.verifyPolicy(
+                recipes.getValue("EgressUnredactedField"),
+                policy
+            )
+        }
+    }
+
+    @Test
+    fun multipleEgressIsDisallowed() {
+        assertFailsWith<PolicyViolation.MultipleEgressParticles> {
+            verifier.verifyPolicy(
+                recipes.getValue("MultipleEgressParticles"),
+                policy
+            )
+        }.also {
+            assertThat(it).hasMessageThat()
+                .contains("Multiple egress particles named Egress_TestPolicy found for policy")
+        }
+    }
+
+    @Test
+    fun invalidEgressIsDisallowed() {
+        assertFailsWith<PolicyViolation.InvalidEgressParticle> {
+            verifier.verifyPolicy(
+                recipes.getValue("InvalidEgressParticles"),
+                policy
+            )
+        }.also {
+            assertThat(it).hasMessageThat()
+                .contains(
+                    "Egress particle allowed by policy is Egress_TestPolicy but " +
+                    "found: Egress_AnotherPolicy"
+                )
+        }
+    }
+
+    @Test
+    fun missingStoreIsDetected() {
+        val incompleteStoreMap = mapOf("action" to "Action")
+        val testVerifier = PolicyVerifier(PolicyOptions(incompleteStoreMap))
+        assertFailsWith<PolicyViolation.NoStoreForPolicyTarget> {
+            testVerifier.verifyPolicy(
+                recipes.getValue("InvalidEgressParticles"),
+                policy
+            )
+        }.also {
+            assertThat(it).hasMessageThat()
+                .contains("No store found for policy target `Selection`")
+        }
+    }
+
+    /** Returns the path for the manifest proto binary file for the test. */
+    private fun getManifestProtoBinPath(test: String): String {
+        return "javatests/arcs/core/analysis/testdata/$test.pb.bin"
+    }
+
+    companion object {
+        val INGRESS_PREFIX = "// #Ingress:"
+        val FAIL_PREFIX = "// #Fail:"
+        val OK_PREFIX = "// #OK"
+    }
+}

--- a/javatests/arcs/core/analysis/testdata/BUILD
+++ b/javatests/arcs/core/analysis/testdata/BUILD
@@ -8,7 +8,9 @@ INVALID_MANIFESTS = glob(["fail_*.arcs"])
 
 VALID_MANIFESTS = glob(["ok_*.arcs"])
 
-ALL_MANIFESTS = VALID_MANIFESTS + INVALID_MANIFESTS
+POLICY_MANIFESTS = glob(["policy_*.arcs"])
+
+ALL_MANIFESTS = VALID_MANIFESTS + INVALID_MANIFESTS + POLICY_MANIFESTS
 
 filegroup(
     name = "example_manifest_protos",

--- a/javatests/arcs/core/analysis/testdata/policy_test.arcs
+++ b/javatests/arcs/core/analysis/testdata/policy_test.arcs
@@ -1,0 +1,210 @@
+schema Action
+  id: Text
+  action: Text
+  timestampInMs: Number
+
+schema Selection
+  id: Text
+  selection: Text
+  sensitiveSelection: Text
+  timestampInMs: Number
+
+schema ActionAtSelection
+  id: Text
+  actionDetails: Text
+
+@intendedPurpose('Test the implementation of policy verification.')
+@egressType('FederatedAggregation')
+policy TestPolicy {
+
+  from Action access {
+    id
+    action,
+
+    @allowedUsage(label: 'truncatedToDays', usageType: '*')
+    timestampInMs,
+  }
+
+  from Selection access {
+    id,
+    selection,
+    // sensitiveSelection is not allowed
+
+    @allowedUsage(label: 'raw', usageType: 'join')
+    timestampInMs,
+  }
+}
+
+@isolated
+particle ActionTimestampToDays
+  // Should ideally be as follows, but we don't have information about
+  // type variables in DFA yet.
+  //
+  // input: reads [~a with {timestampInMs: Number}]
+  // output: writes [~a]
+  // claim output.timestampInMs is truncatedToDays
+  input: reads [Action {
+     id,
+     action,
+     timestampInMs}]
+  output: writes [Action {
+     id,
+     action,
+     timestampInMs}]
+  claim output.timestampInMs derives from input.timestampInMs and is truncatedToDays
+  // The following claims are not needed if we use type variables as mentioned above.
+  claim output.id derives from input.id
+  claim output.action derives from input.action
+
+particle Egress_TestPolicy
+  joinData: reads [ActionAtSelection {
+    id,
+    actionDetails}]
+
+particle Egress_AnotherPolicy
+  joinData: reads [ActionAtSelection {
+    id,
+    actionDetails}]
+
+particle Egress_YetAnotherPolicy
+  joinData: reads [ActionAtSelection {
+    id,
+    actionDetails}]
+
+//-----------------------------------------------------------
+// Complying by not accessing restricted fields.
+//-----------------------------------------------------------
+@isolated
+particle JoinActionSelection_EgressUnrestrictedFields
+  action: reads [Action {id, action}]
+  selection: reads [Selection {id, selection}]
+  joinData: writes [ActionAtSelection {id, actionDetails}]
+
+recipe EgressUnrestrictedFields
+  action: create 'action'
+  selection: create 'selection'
+  joinData: create @ttl('30m')
+  JoinActionSelection_EgressUnrestrictedFields
+    action: action
+    selection: selection
+    joinData: joinData
+  Egress_TestPolicy
+    joinData: joinData
+
+//-----------------------------------------------------------
+// Complying by redacting `timestampInMs` in `selection`.
+//-----------------------------------------------------------
+@isolated
+particle JoinActionSelection_EgressRedactedField
+  action: reads [Action {id, action, timestampInMs}]
+  selection: reads [Selection {id, selection}]
+  joinData: writes [ActionAtSelection {id, actionDetails}]
+
+recipe EgressRedactedField
+  action: create 'action'
+  selection: create 'selection'
+  joinData: create @ttl('30m')
+  ActionTimestampToDays
+    input: action
+    output: actionRedacted
+  JoinActionSelection_EgressRedactedField
+    action: actionRedacted
+    selection: selection
+    joinData: joinData
+  Egress_TestPolicy
+    joinData: joinData
+
+//-----------------------------------------------------------------------
+// Policy violation by egressing `sensitiveSelection` in `Selection`.
+//-----------------------------------------------------------------------
+@isolated
+particle JoinActionSelection_EgressRestrictedFields
+  action: reads [Action {id, action, timestampInMs}]
+  selection: reads [Selection {id, selection, sensitiveSelection}]
+  joinData: writes [ActionAtSelection {id, actionDetails}]
+
+recipe EgressRestrictedFields
+  action: create 'action'
+  selection: create 'selection'
+  joinData: create @ttl('30m')
+  ActionTimestampToDays
+    input: action
+    output: actionRedacted
+  JoinActionSelection_EgressRestrictedFields
+    action: actionRedacted
+    selection: selection
+    joinData: joinData
+  Egress_TestPolicy
+    joinData: joinData
+
+//-----------------------------------------------------------------------
+// Policy violation by egressing `timestampInMs` in `Selection`,
+// which can only be used for joins.
+//-----------------------------------------------------------------------
+@isolated
+particle JoinActionSelection_EgressJoinOnlyField
+  action: reads [Action {id, action, timestampInMs}]
+  selection: reads [Selection {id, selection, sensitiveSelection}]
+  joinData: writes [ActionAtSelection {id, actionDetails}]
+
+recipe EgressJoinOnlyField
+  action: create 'action'
+  selection: create 'selection'
+  joinData: create @ttl('30m')
+  ActionTimestampToDays
+    input: action
+    output: actionRedacted
+  JoinActionSelection_EgressJoinOnlyField
+    action: actionRedacted
+    selection: selection
+    joinData: joinData
+  Egress_TestPolicy
+    joinData: joinData
+
+//-----------------------------------------------------------------------
+// Policy violation by not redacting `timestampInMs` in `Action`.
+//-----------------------------------------------------------------------
+recipe EgressUnredactedField
+  action: create 'action'
+  selection: create 'selection'
+  joinData: create @ttl('30m')
+  JoinActionSelection_EgressRedactedField
+    action: action
+    selection: selection
+    joinData: joinData
+  Egress_TestPolicy
+    joinData: joinData
+
+//-----------------------------------------------------------------------
+// Policy violation by having multiple egress particles.
+//-----------------------------------------------------------------------
+recipe MultipleEgressParticles
+  action: create 'action'
+  selection: create 'selection'
+  joinData: create @ttl('30m')
+  JoinActionSelection_EgressRedactedField
+    action: action
+    selection: selection
+    joinData: joinData
+  // Egress_AnotherPolicy
+  //   joinData: joinData
+  // Egress_YetAnotherPolicy
+  //   joinData: joinData
+  Egress_TestPolicy
+    joinData: joinData
+  Egress_TestPolicy
+    joinData: joinData
+
+//-----------------------------------------------------------------------
+// Policy violation due to invalid egress particle `Egress_AnotherPolicy`.
+//-----------------------------------------------------------------------
+recipe InvalidEgressParticles
+  action: create 'action'
+  selection: create 'selection'
+  joinData: create @ttl('30m')
+  JoinActionSelection_EgressRedactedField
+    action: action
+    selection: selection
+    joinData: joinData
+  Egress_AnotherPolicy
+    joinData: joinData


### PR DESCRIPTION
This PR provides the missing connection between policy and DFA. 

- Generate DFA checks and claims by invoking the policy translator. (This step will eventually move to compile time.)
- Incorporate the checks into the recipe, run DFA, and validate the checks.

If the recipe violates any aspect of the policy, a `PolicyViolation` exception is thrown. It is enough to review the second commit eb349ddaade5f07a63ba26d18a615598c3a80bf4. This PR is dependent on https://github.com/PolymerLabs/arcs/pull/5785.