### PR TITLE
Test to show collections and lists of references work (& fix for lists)

### DIFF
--- a/java/arcs/core/entity/EntityDereferencerFactory.kt
+++ b/java/arcs/core/entity/EntityDereferencerFactory.kt
@@ -31,13 +31,11 @@ class EntityDereferencerFactory(
      */
     override fun injectDereferencers(schema: Schema, value: Any?) {
         if (value == null) return
-        println("inject $value")
         when (value) {
             is Reference -> value.dereferencer = create(schema)
             is RawEntity -> injectDereferencersIntoRawEntity(schema, value)
             is Set<*> -> value.forEach { injectDereferencers(schema, it) }
             is ReferencableList<*> -> value.value.forEach { injectDereferencers(schema, it) }
-            else -> println("skipping $value")
         }
     }
 

--- a/java/arcs/core/entity/EntityDereferencerFactory.kt
+++ b/java/arcs/core/entity/EntityDereferencerFactory.kt
@@ -40,30 +40,31 @@ class EntityDereferencerFactory(
     }
 
     private fun injectDereferencersIntoRawEntity(schema: Schema, rawEntity: RawEntity) {
-        fun injectField(fieldType: FieldType?, fieldValue: Any?) {
-            val schemaHash = when (fieldType) {
-                is FieldType.EntityRef -> fieldType.schemaHash
-                is FieldType.InlineEntity -> fieldType.schemaHash
-                is FieldType.ListOf -> {
-                    injectField(fieldType.primitiveType, fieldValue)
-                    null
-                }
-                else -> null
-            }
-            schemaHash?.let {
-                val fieldSchema = requireNotNull(
-                    SchemaRegistry.getSchema(it)
-                ) {
-                    "Unknown schema with hash $it."
-                }
-                injectDereferencers(fieldSchema, fieldValue)
-            }
-        }
         rawEntity.singletons.forEach { (field, value) ->
             injectField(schema.fields.singletons[field], value)
         }
         rawEntity.collections.forEach { (field, value) ->
             injectField(schema.fields.collections[field], value)
+        }
+    }
+
+    private fun injectField(fieldType: FieldType?, fieldValue: Any?) {
+        val schemaHash = when (fieldType) {
+            is FieldType.EntityRef -> fieldType.schemaHash
+            is FieldType.InlineEntity -> fieldType.schemaHash
+            is FieldType.ListOf -> {
+                injectField(fieldType.primitiveType, fieldValue)
+                null
+            }
+            else -> null
+        }
+        schemaHash?.let {
+            val fieldSchema = requireNotNull(
+                SchemaRegistry.getSchema(it)
+            ) {
+                "Unknown schema with hash $it."
+            }
+            injectDereferencers(fieldSchema, fieldValue)
         }
     }
 }

--- a/java/arcs/core/entity/EntityDereferencerFactory.kt
+++ b/java/arcs/core/entity/EntityDereferencerFactory.kt
@@ -4,6 +4,7 @@ import arcs.core.data.FieldType
 import arcs.core.data.RawEntity
 import arcs.core.data.Schema
 import arcs.core.data.SchemaRegistry
+import arcs.core.data.util.ReferencableList
 import arcs.core.storage.ActivationFactory
 import arcs.core.storage.Dereferencer
 import arcs.core.storage.RawEntityDereferencer
@@ -30,18 +31,25 @@ class EntityDereferencerFactory(
      */
     override fun injectDereferencers(schema: Schema, value: Any?) {
         if (value == null) return
+        println("inject $value")
         when (value) {
             is Reference -> value.dereferencer = create(schema)
-            is RawEntity -> injectDereferencers(schema, value)
+            is RawEntity -> injectDereferencersIntoRawEntity(schema, value)
             is Set<*> -> value.forEach { injectDereferencers(schema, it) }
+            is ReferencableList<*> -> value.value.forEach { injectDereferencers(schema, it) }
+            else -> println("skipping $value")
         }
     }
 
-    private fun injectDereferencers(schema: Schema, rawEntity: RawEntity) {
+    private fun injectDereferencersIntoRawEntity(schema: Schema, rawEntity: RawEntity) {
         fun injectField(fieldType: FieldType?, fieldValue: Any?) {
             val schemaHash = when (fieldType) {
                 is FieldType.EntityRef -> fieldType.schemaHash
                 is FieldType.InlineEntity -> fieldType.schemaHash
+                is FieldType.ListOf -> {
+                    injectField(fieldType.primitiveType, fieldValue)
+                    null
+                }
                 else -> null
             }
             schemaHash?.let {

--- a/javatests/arcs/core/entity/HandleManagerTestBase.kt
+++ b/javatests/arcs/core/entity/HandleManagerTestBase.kt
@@ -780,7 +780,7 @@ open class HandleManagerTestBase {
         val updateDeferred = readHandle.onUpdateDeferred { it.size == 3 }
         entities.forEach { writeHandle.dispatchStore(it) }
         val entitiesOut = updateDeferred.await()
-        assertThat(entitiesOut).containsExactly(*entities.toTypedArray())
+        assertThat(entitiesOut).containsExactlyElementsIn(entities)
         entitiesOut.forEach { entity ->
             entity.references.forEach { it.dereference() }
             entity.referenceList.forEach { it.dereference() }

--- a/javatests/arcs/core/entity/test.arcs
+++ b/javatests/arcs/core/entity/test.arcs
@@ -16,6 +16,7 @@ schema ReferencedSchema
 
 schema TestReferences
   references: [&ReferencedSchema]
+  referenceList: List<&ReferencedSchema>
 
 particle TestParticle
   entities: reads writes [TestEntity {text, number, list} [text == ?]]
@@ -24,7 +25,7 @@ particle TestInlineParticle
   entities: reads writes [TestInline {inline, inlines, inlineList}]
 
 particle TestReferencesParticle
-  entities: reads writes [TestReferences {references}]
+  entities: reads writes [TestReferences {references, referenceList}]
 
 recipe TestRecipe
   entities: create

--- a/javatests/arcs/core/entity/test.arcs
+++ b/javatests/arcs/core/entity/test.arcs
@@ -11,11 +11,20 @@ schema TestInline
   inlines: [inline AnotherInlineEntity {int: Int}]
   inlineList: List<inline MoreInline {mostInline: [inline MostInline {text: Text}]}>
 
+schema ReferencedSchema
+  number: Int
+
+schema TestReferences
+  references: [&ReferencedSchema]
+
 particle TestParticle
   entities: reads writes [TestEntity {text, number, list} [text == ?]]
 
 particle TestInlineParticle
   entities: reads writes [TestInline {inline, inlines, inlineList}]
+
+particle TestReferencesParticle
+  entities: reads writes [TestReferences {references}]
 
 recipe TestRecipe
   entities: create


### PR DESCRIPTION
As described in b/160556762, it looked like collections and lists of References would not correctly be injected with a Dereferencer.

This patch confirms that collections *are* handled correctly, demonstrates that lists *weren't*, and fixes the EntityDereferencerFactory logic for the list case.

The overloaded (private) injectDereferencers has also been renamed for clarity, and the inner function injectField broken out as a separate method. This may constitute sufficient clean-up to render the code in EntityDereferencerFactory clear - I know what it does now so I can't tell any more..