### PR TITLE
Fix clear metric (N >= 100) failing on some threading models

### DIFF
--- a/javatests/arcs/android/systemhealth/testapp/LocalService.kt
+++ b/javatests/arcs/android/systemhealth/testapp/LocalService.kt
@@ -89,6 +89,10 @@ class LocalService : LifecycleService() {
                 ),
                 0
             ),
+            intent.getIntExtra(
+                intentExtras.clearedEntities,
+                defaultSettings.clearedEntities
+            ),
             maxOf(
                 intent.getIntExtra(
                     intentExtras.delayedStartMs,

--- a/javatests/arcs/android/systemhealth/testapp/RemoteService.kt
+++ b/javatests/arcs/android/systemhealth/testapp/RemoteService.kt
@@ -80,6 +80,10 @@ class RemoteService : LifecycleService() {
                 ),
                 0
             ),
+            intent.getIntExtra(
+                intentExtras.clearedEntities,
+                defaultSettings.clearedEntities
+            ),
             maxOf(
                 intent.getIntExtra(
                     intentExtras.delayedStartMs,

--- a/javatests/arcs/android/systemhealth/testapp/res/layout/test_activity.xml
+++ b/javatests/arcs/android/systemhealth/testapp/res/layout/test_activity.xml
@@ -250,7 +250,7 @@
         android:ems="10"
         android:hint="@string/cleared_entities_hint"
         android:importantForAutofill="no"
-        android:inputType="numberDecimal"
+        android:inputType="numberDecimal|numberSigned"
         android:textSize="14sp" />
     </LinearLayout>
 


### PR DESCRIPTION
Exception is observed when invoking store-N-entities-then-clear at some threading models where N >= 100.

In the past, the app only supports running all tasks at the threads it created, managed and assigned.
The app was able to monitor thread status to determine whether one task is completed or not then shuts down threads accordingly.

Now the app supports designated thread models or pools, so additional per-task CompletableDeffereds are required to signal job completions.

Moreover, store-N-entities-then-clear is quite time-consuming and contending at storage service side, so disable clear metrics by default (by setting N to -1); 0 (clear on empty collection) would also contend at client side where one single thread is shared among all Schedulers at some threading models.
