### PR TITLE
Defines a new PolicyOptions class and corresponding proto.

### DIFF
--- a/java/arcs/core/data/proto/policy.proto
+++ b/java/arcs/core/data/proto/policy.proto
@@ -109,3 +109,9 @@ message PolicyConfigProto {
   // name.
   map<string, string> metadata = 2;
 }
+
+// General options for policy enforcement.
+message PolicyOptionsProto {
+  // Maps from store ID to type name.
+  map<string, string> store_id_to_type = 1;
+}

--- a/java/arcs/core/policy/PolicyConstraints.kt
+++ b/java/arcs/core/policy/PolicyConstraints.kt
@@ -23,16 +23,10 @@ data class PolicyConstraints(
  * Translates the given [policy] into dataflow analysis checks and claims, which are to be added to
  * the particles from the given [recipe].
  *
- * @param storeMap Maps from store ID to the schema name of the type it stores.
- *
  * @return additional checks and claims for the particles as a [PolicyConstraints] object
  * @throws PolicyViolation if the [particles] violate the [policy]
  */
-fun translatePolicy(
-    policy: Policy,
-    recipe: Recipe,
-    storeMap: Map<StoreId, String>
-): PolicyConstraints {
+fun translatePolicy(policy: Policy, recipe: Recipe, options: PolicyOptions): PolicyConstraints {
     val egressParticles = recipe.particles.filterNot { it.spec.isolated }
     checkEgressParticles(policy, egressParticles)
 
@@ -54,10 +48,10 @@ fun translatePolicy(
 
     // Add claim statements for stores.
     val targetBySchemaName = policy.targets.associateBy { it.schemaName }
-    val storeClaims = recipe.handles.values.filter { storeMap.containsKey(it.id) }
+    val storeClaims = recipe.handles.values.filter { options.storeMap.containsKey(it.id) }
         .associate { handle ->
             val storeId = handle.id
-            val claims = storeMap[storeId]?.let { schemaName ->
+            val claims = options.storeMap[storeId]?.let { schemaName ->
                 targetBySchemaName[schemaName]?.let { target ->
                     createClaims(handle, target)
                 }

--- a/java/arcs/core/policy/PolicyOptions.kt
+++ b/java/arcs/core/policy/PolicyOptions.kt
@@ -1,0 +1,14 @@
+package arcs.core.policy
+
+import arcs.core.data.StoreId
+
+/** Config options for policy enforcement. */
+data class PolicyOptions(
+    /**
+     * Maps from store ID to the schema name of the type it stores. Indicates all of the stores
+     * protected by policy
+     *
+     * Temporary measure until we have a proper way to designate these stores.
+     */
+    val storeMap: Map<StoreId, String>
+)

--- a/java/arcs/core/policy/proto/PolicyOptionsProto.kt
+++ b/java/arcs/core/policy/proto/PolicyOptionsProto.kt
@@ -1,0 +1,10 @@
+package arcs.core.policy.proto
+
+import arcs.core.data.proto.PolicyOptionsProto
+import arcs.core.policy.PolicyOptions
+
+fun PolicyOptionsProto.decode() = PolicyOptions(storeIdToTypeMap)
+
+fun PolicyOptions.encode(): PolicyOptionsProto {
+    return PolicyOptionsProto.newBuilder().putAllStoreIdToType(storeMap).build()
+}

--- a/javatests/arcs/core/policy/PolicyConstraintsTest.kt
+++ b/javatests/arcs/core/policy/PolicyConstraintsTest.kt
@@ -40,7 +40,7 @@ class PolicyConstraintsTest {
             createParticle("Isolated2", isolated = true)
         )
 
-        val result = translatePolicy(BLANK_POLICY, recipe, emptyMap())
+        val result = translatePolicy(BLANK_POLICY, recipe, EMPTY_OPTIONS)
 
         assertThat(result).isEqualTo(
             PolicyConstraints(BLANK_POLICY, emptyMap(), emptyMap())
@@ -53,7 +53,7 @@ class PolicyConstraintsTest {
             createParticle(BLANK_EGRESS_PARTICLE_NAME, isolated = false)
         )
 
-        translatePolicy(BLANK_POLICY, recipe, emptyMap())
+        translatePolicy(BLANK_POLICY, recipe, EMPTY_OPTIONS)
     }
 
     @Test
@@ -64,7 +64,7 @@ class PolicyConstraintsTest {
         )
 
         val e = assertFailsWith<PolicyViolation.InvalidEgressParticle> {
-            translatePolicy(BLANK_POLICY, recipe, emptyMap())
+            translatePolicy(BLANK_POLICY, recipe, EMPTY_OPTIONS)
         }
         assertThat(e.policy).isEqualTo(BLANK_POLICY)
         assertThat(e.particleNames).containsExactly("Egress1", "Egress2")
@@ -78,7 +78,7 @@ class PolicyConstraintsTest {
         )
 
         val e = assertFailsWith<PolicyViolation.MultipleEgressParticles> {
-            translatePolicy(BLANK_POLICY, recipe, emptyMap())
+            translatePolicy(BLANK_POLICY, recipe, EMPTY_OPTIONS)
         }
         assertThat(e.policy).isEqualTo(BLANK_POLICY)
     }
@@ -89,7 +89,7 @@ class PolicyConstraintsTest {
         val recipe = recipes.getValue("SingleInput")
         val particle = recipe.particles.single()
 
-        val result = translatePolicy(policy, recipe, emptyMap())
+        val result = translatePolicy(policy, recipe, EMPTY_OPTIONS)
 
         assertThat(result.egressChecks).containsExactly(
             particle.spec,
@@ -110,7 +110,7 @@ class PolicyConstraintsTest {
         val policy = policies.getValue("FooRedactions")
         val recipe = recipes.getValue("SingleInput").forceMatchPolicyName(policy.name)
 
-        val result = translatePolicy(policy, recipe, emptyMap())
+        val result = translatePolicy(policy, recipe, EMPTY_OPTIONS)
 
         val check = result.egressChecks.values.single().single() as Check.Assert
         assertThat(check.predicate).isEqualTo(
@@ -128,7 +128,7 @@ class PolicyConstraintsTest {
         val policy = BLANK_POLICY.copy(name = "SingleOutput")
         val recipe = recipes.getValue("SingleOutput")
 
-        val result = translatePolicy(policy, recipe, emptyMap())
+        val result = translatePolicy(policy, recipe, EMPTY_OPTIONS)
 
         val particle = recipe.particles.single()
         assertThat(result.egressChecks).containsExactly(particle.spec, emptyList<Check>())
@@ -140,7 +140,7 @@ class PolicyConstraintsTest {
         val recipe = recipes.getValue("SingleMappedInput").forceMatchPolicyName(policy.name)
         val storeMap = mapOf("my_store_id" to "Foo")
 
-        val result = translatePolicy(policy, recipe, storeMap)
+        val result = translatePolicy(policy, recipe, PolicyOptions(storeMap))
 
         val handle = recipe.handles.values.single()
         assertThat(result.storeClaims).containsExactly(
@@ -168,7 +168,7 @@ class PolicyConstraintsTest {
         val recipe = recipes.getValue("SingleMappedInput").forceMatchPolicyName(policy.name)
         val storeMap = mapOf("my_store_id" to "Foo")
 
-        val result = translatePolicy(policy, recipe, storeMap)
+        val result = translatePolicy(policy, recipe, PolicyOptions(storeMap))
 
         val handle = recipe.handles.values.single()
         assertThat(result.storeClaims).containsExactly(
@@ -188,7 +188,7 @@ class PolicyConstraintsTest {
         val recipe = recipes.getValue("SingleMappedInput").forceMatchPolicyName(policy.name)
         val storeMap = mapOf("some_other_store" to "Foo")
 
-        val result = translatePolicy(policy, recipe, storeMap)
+        val result = translatePolicy(policy, recipe, PolicyOptions(storeMap))
 
         assertThat(result.storeClaims).isEmpty()
     }
@@ -199,7 +199,7 @@ class PolicyConstraintsTest {
         val recipe = recipes.getValue("SingleMappedInput").forceMatchPolicyName(policy.name)
         val storeMap = mapOf("my_store_id" to "Foo")
 
-        val result = translatePolicy(policy, recipe, storeMap)
+        val result = translatePolicy(policy, recipe, PolicyOptions(storeMap))
 
         assertThat(result.storeClaims).isEmpty()
     }
@@ -209,7 +209,7 @@ class PolicyConstraintsTest {
         val recipe = recipes.getValue("SingleMappedInput").forceMatchPolicyName(BLANK_POLICY_NAME)
         val storeMap = mapOf("my_store_id" to "Foo")
 
-        val result = translatePolicy(BLANK_POLICY, recipe, storeMap)
+        val result = translatePolicy(BLANK_POLICY, recipe, PolicyOptions(storeMap))
 
         assertThat(result.storeClaims).isEmpty()
     }
@@ -220,7 +220,7 @@ class PolicyConstraintsTest {
         val recipe = recipes.getValue("SingleMappedInput").forceMatchPolicyName(policy.name)
         val storeMap = mapOf("my_store_id" to "Foo")
 
-        val result = translatePolicy(policy, recipe, storeMap)
+        val result = translatePolicy(policy, recipe, PolicyOptions(storeMap))
 
         assertThat(result.storeClaims).isEmpty()
     }
@@ -231,7 +231,7 @@ class PolicyConstraintsTest {
         val recipe = recipes.getValue("SingleMappedInput").forceMatchPolicyName(policy.name)
         val storeMap = mapOf("my_store_id" to "NestedFooBar")
 
-        val result = translatePolicy(policy, recipe, storeMap)
+        val result = translatePolicy(policy, recipe, PolicyOptions(storeMap))
 
         val handle = recipe.handles.values.single()
         val predicate = labelPredicate("allowedForEgress")
@@ -251,6 +251,8 @@ class PolicyConstraintsTest {
     companion object {
         private const val BLANK_POLICY_NAME = "BlankPolicy"
         private const val BLANK_EGRESS_PARTICLE_NAME = "Egress_BlankPolicy"
+
+        private val EMPTY_OPTIONS = PolicyOptions(storeMap = emptyMap())
 
         private val BLANK_POLICY = Policy(name = BLANK_POLICY_NAME, egressType = EgressType.LOGGING)
 

--- a/javatests/arcs/core/policy/proto/PolicyOptionsProtoTest.kt
+++ b/javatests/arcs/core/policy/proto/PolicyOptionsProtoTest.kt
@@ -1,0 +1,18 @@
+package arcs.core.policy.proto
+
+import arcs.core.policy.PolicyOptions
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class PolicyOptionsProtoTest {
+    @Test
+    fun roundTrip() {
+        val options = PolicyOptions(
+            storeMap = mapOf("a" to "One", "b" to "Two")
+        )
+        assertThat(options.encode().decode()).isEqualTo(options)
+    }
+}


### PR DESCRIPTION
This is used to customise the policy enforcement algorithm. Customers will define their own config textproto file and use that when invoking the policy algorithm.

Currently this just has the storeMap field, but we can add things in future (e.g. whitelist of particle specs).