### PR TITLE
Add refinement support for Kotlin Long and Kotlin Int

### DIFF
--- a/src/runtime/manifest-ast-nodes.ts
+++ b/src/runtime/manifest-ast-nodes.ts
@@ -744,8 +744,8 @@ export interface NumberNode extends BaseNode {
   units?: string[];
 }
 
-export type BigIntType = Primitive.BIGINT | Primitive.INT | Primitive.LONG | Primitive.BOOLEAN;
-export const bigIntTypes: Primitive[] = [
+export type DiscreteType = Primitive.BIGINT | Primitive.INT | Primitive.LONG | Primitive.BOOLEAN;
+export const discreteTypes: Primitive[] = [
   Primitive.BIGINT,
   Primitive.LONG,
   Primitive.INT
@@ -754,7 +754,7 @@ export const bigIntTypes: Primitive[] = [
 export interface DiscreteNode extends BaseNode {
   kind: 'discrete-node';
   value: bigint;
-  type: BigIntType;
+  type: DiscreteType;
   units?: string[];
 }
 

--- a/src/runtime/manifest-ast-nodes.ts
+++ b/src/runtime/manifest-ast-nodes.ts
@@ -32,6 +32,7 @@ export interface SourceLocation {
   filename?: string;
   start: SourcePosition;
   end: SourcePosition;
+  text?: string; // Optionally keeps a copy of the raw/unparsed text.
 }
 
 /**

--- a/src/runtime/manifest-ast-nodes.ts
+++ b/src/runtime/manifest-ast-nodes.ts
@@ -679,7 +679,7 @@ export interface RefinementNode extends BaseNode {
   expression: RefinementExpressionNode;
 }
 
-export type RefinementExpressionNode = BinaryExpressionNode | UnaryExpressionNode | FieldNode | QueryNode | BuiltInNode | NumberNode | BigIntNode | BooleanNode | TextNode;
+export type RefinementExpressionNode = BinaryExpressionNode | UnaryExpressionNode | FieldNode | QueryNode | BuiltInNode | NumberNode | DiscreteNode | BooleanNode | TextNode;
 
 export enum Op {
   AND = 'and',
@@ -728,15 +728,33 @@ export interface BuiltInNode extends BaseNode {
   value: string;
 }
 
+export enum Primitive {
+  BOOLEAN = 'Boolean',
+  NUMBER = 'Number',
+  BIGINT = 'BigInt',
+  LONG = 'Long',
+  INT = 'Int',
+  TEXT = 'Text',
+  UNKNOWN = '~query_arg_type',
+}
+
 export interface NumberNode extends BaseNode {
   kind: 'number-node';
-  value: number ;
+  value: number;
   units?: string[];
 }
 
-export interface BigIntNode extends BaseNode {
-  kind: 'bigint-node';
-  value: bigint ;
+export type BigIntType = Primitive.BIGINT | Primitive.INT | Primitive.LONG | Primitive.BOOLEAN;
+export const bigIntTypes: Primitive[] = [
+  Primitive.BIGINT,
+  Primitive.LONG,
+  Primitive.INT
+];
+
+export interface DiscreteNode extends BaseNode {
+  kind: 'discrete-node';
+  value: bigint;
+  type: BigIntType;
   units?: string[];
 }
 
@@ -977,3 +995,18 @@ export type All = Import|Meta|MetaName|MetaStorageKey|MetaNamespace|Particle|Par
 
 export type ManifestItem =
     RecipeNode|Particle|Import|Schema|ManifestStorage|Interface|Meta|Resource;
+
+export function viewAst(ast: unknown, viewLocation = false) {
+  // Helper function useful for viewing ast information while working on the parser and test code:
+  // Optionally, strips location information.
+  console.log(
+    JSON.stringify(ast, (_key, value) => {
+    if (!viewLocation && value != null && value['location']) {
+      delete value['location'];
+    }
+    return typeof value === 'bigint'
+      ? value.toString() // Workaround for JSON not supporting bigint.
+      : value;
+  }, // return everything else unchanged
+  2));
+}

--- a/src/runtime/manifest-parser.pegjs
+++ b/src/runtime/manifest-parser.pegjs
@@ -94,9 +94,7 @@
 
   function toAstNode<T extends {location: IFileRange} & Omit<T, 'location'>>(data: Omit<T, 'location'>): T {
     const loc = location();
-    // For debugging:
-    // const txt = text();
-    // loc['text'] = txt;
+    loc['text'] = text();
     return {...data, location: loc} as T;
   }
 

--- a/src/runtime/manifest-parser.pegjs
+++ b/src/runtime/manifest-parser.pegjs
@@ -93,7 +93,11 @@
   }
 
   function toAstNode<T extends {location: IFileRange} & Omit<T, 'location'>>(data: Omit<T, 'location'>): T {
-    return {...data, location: location()} as T;
+    const loc = location();
+    // For debugging:
+    // const txt = text();
+    // loc['text'] = txt;
+    return {...data, location: loc} as T;
   }
 
   function buildInterfaceArgument(name: string, direction: AstNode.Direction | AstNode.SlotDirection, isOptional: boolean, type: AstNode.ParticleHandleConnectionType) {
@@ -1815,14 +1819,8 @@ PrimaryExpression
     const operator = op[0];
     return toAstNode<AstNode.UnaryExpressionNode>({kind: 'unary-expression-node', expr, operator});
   }
-  / num: BigIntType units:Units?
-  {
-    return toAstNode<AstNode.BigIntNode>({kind: 'bigint-node', value: num, units});
-  }
-  / num: NumberType units:Units?
-  {
-    return toAstNode<AstNode.NumberNode>({kind: 'number-node', value: num, units});
-  }
+  / DiscreteValue
+  / NumberValue
   / bool:('true'i / 'false'i)
   {
     return toAstNode<AstNode.BooleanNode>({kind: 'boolean-node', value: bool.toLowerCase() === 'true'});
@@ -1868,16 +1866,26 @@ UnitName
     return unit+'s';
   }
 
-NumberType
-  = whole:[0-9]+ fractional:('.' [0-9]+)?
+NumberValue
+  = neg:'-'? whole:[0-9]+ decimal:('.' [0-9]*)? units:Units?
   {
-    return Number(text());
+    const value = Number(`${neg || ''}${whole.join('')}.${decimal ? decimal[1].join('') : ''}`);
+    return toAstNode<AstNode.NumberNode>({kind: 'number-node', value, units});
   }
 
-BigIntType
-  = whole:[0-9]+ 'n'
+DiscreteValue
+  = neg:'-'? val:[0-9]+ typeIdentifier:('n'/'i'/'l') units:Units?
   {
-    return BigInt(whole.join(''));
+    const type = () => {
+      switch (typeIdentifier) {
+        case 'n': return AstNode.Primitive.BIGINT;
+        case 'i': return AstNode.Primitive.INT;
+        case 'l': return AstNode.Primitive.LONG;
+      }
+      throw new Error(`Unexpected type identifier ${typeIdentifier} (expected one of n, i or l)`);
+    };
+    const value = BigInt(`${neg || ''}${val.join('')}`);
+    return toAstNode<AstNode.DiscreteNode>({kind: 'discrete-node', value, units, type: type()});
   }
 
 Version "a version number (e.g. @012)"

--- a/src/runtime/refiner.ts
+++ b/src/runtime/refiner.ts
@@ -8,21 +8,11 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {RefinementNode, Op, RefinementExpressionNode, BinaryExpressionNode, UnaryExpressionNode, FieldNode, QueryNode, BuiltInNode, BigIntNode, NumberNode, BooleanNode, TextNode} from './manifest-ast-nodes.js';
+import {RefinementNode, Op, RefinementExpressionNode, BinaryExpressionNode, UnaryExpressionNode, FieldNode, QueryNode, BuiltInNode, DiscreteNode, NumberNode, BooleanNode, TextNode, Primitive, BigIntType, bigIntTypes} from './manifest-ast-nodes.js';
 import {Dictionary} from './hot.js';
 import {Schema} from './schema.js';
 import {Entity} from './entity.js';
 import {AuditException} from './arc-exceptions.js';
-
-export enum Primitive {
-  BOOLEAN = 'Boolean',
-  NUMBER = 'Number',
-  BIGINT = 'BigInt',
-  LONG = 'Long',
-  INT = 'Int',
-  TEXT = 'Text',
-  UNKNOWN = '~query_arg_type',
-}
 
 export enum AtLeastAsSpecific {
   YES = 'YES',
@@ -190,7 +180,7 @@ export interface RefinementExpressionLiteral {
   [propName: string]: any;
 }
 
-export type RefinementExpressionNodeType = 'BinaryExpressionNode' | 'UnaryExpressionNode' | 'FieldNamePrimitiveNode' | 'QueryArgumentPrimitiveNode' | 'NumberPrimitiveNode' | 'BigIntPrimitiveNode' | 'BooleanPrimitiveNode' | 'TextPrimitiveNode' | 'BuiltInNode';
+export type RefinementExpressionNodeType = 'BinaryExpressionNode' | 'UnaryExpressionNode' | 'FieldNamePrimitiveNode' | 'QueryArgumentPrimitiveNode' | 'NumberPrimitiveNode' | 'DiscretePrimitiveNode' | 'BooleanPrimitiveNode' | 'TextPrimitiveNode' | 'BuiltInNode';
 
 abstract class RefinementExpression {
   evalType: Primitive;
@@ -200,7 +190,6 @@ abstract class RefinementExpression {
     if (!expr) {
       return null;
     }
-    console.log('>>> ', expr.kind);
     switch (expr.kind) {
       case 'binary-expression-node': return BinaryExpression.fromAst(expr, typeData);
       case 'unary-expression-node': return UnaryExpression.fromAst(expr, typeData);
@@ -208,7 +197,7 @@ abstract class RefinementExpression {
       case 'built-in-node': return BuiltIn.fromAst(expr, typeData);
       case 'query-argument-node': return QueryArgumentPrimitive.fromAst(expr, typeData);
       case 'number-node': return NumberPrimitive.fromAst(expr);
-      case 'bigint-node': return BigIntPrimitive.fromAst(expr);
+      case 'discrete-node': return DiscretePrimitive.fromAst(expr);
       case 'boolean-node': return BooleanPrimitive.fromAst(expr);
       case 'text-node': return TextPrimitive.fromAst(expr);
       default:
@@ -218,6 +207,9 @@ abstract class RefinementExpression {
   }
 
   abstract toLiteral(): RefinementExpressionLiteral;
+  isConstant(): boolean {
+    return true;
+  }
 
   static fromLiteral(expr: {kind: RefinementExpressionNodeType}): RefinementExpression {
     switch (expr.kind) {
@@ -251,6 +243,20 @@ abstract class RefinementExpression {
 
   abstract applyOperator(data: Dictionary<ExpressionPrimitives>): ExpressionPrimitives;
 
+  getValue(): RefinementExpression {
+    const value = this.applyOperator({});
+    switch (this.evalType) {
+      case Primitive.BOOLEAN: return new BooleanPrimitive(value);
+      case Primitive.INT:
+      case Primitive.LONG:
+      case Primitive.BIGINT:
+        return new DiscretePrimitive(value, [], this.evalType);
+      case Primitive.NUMBER:
+        return new NumberPrimitive(value, []);
+      default: throw new Error('Couldn\'t force evaluation of ${this.toString()}');
+    }
+  }
+
   getFieldParams(): Map<string, Primitive> {
     return new Map<string, Primitive>();
   }
@@ -275,9 +281,7 @@ export class BinaryExpression extends RefinementExpression {
     this.leftExpr = leftExpr;
     this.rightExpr = rightExpr;
     this.operator = op;
-    this.operator.validateOperandCompatibility([this.leftExpr, this.rightExpr]);
-    const evalType = this.operator.evalType();
-    this.evalType = evalType === 'same' ? this.leftExpr.evalType : evalType;
+    this.evalType = this.operator.validateOperandCompatibility([this.leftExpr, this.rightExpr]);
   }
 
   static fromAst(expression: BinaryExpressionNode, typeData: Dictionary<ExpressionPrimitives>): RefinementExpression {
@@ -303,9 +307,10 @@ export class BinaryExpression extends RefinementExpression {
 
   static fromLiteral(expr): RefinementExpression {
     return new BinaryExpression(
-            RefinementExpression.fromLiteral(expr.leftExpr),
-            RefinementExpression.fromLiteral(expr.rightExpr),
-            RefinementOperator.fromLiteral(expr.operator));
+      RefinementExpression.fromLiteral(expr.leftExpr),
+      RefinementExpression.fromLiteral(expr.rightExpr),
+      RefinementOperator.fromLiteral(expr.operator)
+    );
   }
 
   update(expr: BinaryExpression): void {
@@ -344,23 +349,6 @@ export class BinaryExpression extends RefinementExpression {
     this.operator.flip();
   }
 
-  simplifyPrimitive(): RefinementExpression {
-    if (this.leftExpr instanceof BooleanPrimitive && this.rightExpr instanceof BooleanPrimitive) {
-      return new BooleanPrimitive(this.applyOperator());
-    } else if (this.leftExpr instanceof NumberPrimitive && this.rightExpr instanceof NumberPrimitive) {
-      if (this.evalType === Primitive.BOOLEAN) {
-        return new BooleanPrimitive(this.applyOperator());
-      }
-      return new NumberPrimitive(this.applyOperator());
-    } else if (this.leftExpr instanceof BigIntPrimitive && this.rightExpr instanceof BigIntPrimitive) {
-      if (this.evalType === Primitive.BOOLEAN) {
-        return new BooleanPrimitive(this.applyOperator());
-      }
-      return new BigIntPrimitive(this.applyOperator());
-    }
-    return null;
-  }
-
   rearrange(): RefinementExpression {
     const numberTypes = [Primitive.NUMBER, Primitive.BIGINT];
     const leftNumeric = numberTypes.includes(this.leftExpr.evalType);
@@ -380,12 +368,9 @@ export class BinaryExpression extends RefinementExpression {
   }
 
   normalize(): RefinementExpression {
+    if (this.isConstant()) { return this.getValue(); }
     this.leftExpr = this.leftExpr.normalize();
     this.rightExpr = this.rightExpr.normalize();
-    const sp = this.simplifyPrimitive();
-    if (sp) {
-      return sp;
-    }
     if (this.leftExpr.toString() < this.rightExpr.toString() ) {
       this.swapChildren();
     }
@@ -426,7 +411,7 @@ export class BinaryExpression extends RefinementExpression {
           if (this.rightExpr instanceof NumberPrimitive && this.rightExpr.value === 1) {
               return this.leftExpr;
           }
-          if (this.rightExpr instanceof BigIntPrimitive && this.rightExpr.value === BigInt(1)) {
+          if (this.rightExpr instanceof DiscretePrimitive && this.rightExpr.value === BigInt(1)) {
               return this.leftExpr;
           }
           return this;
@@ -435,13 +420,13 @@ export class BinaryExpression extends RefinementExpression {
           if (this.leftExpr instanceof NumberPrimitive && this.leftExpr.value === 1) {
               return this.rightExpr;
           }
-          if (this.leftExpr instanceof BigIntPrimitive && this.leftExpr.value === BigInt(1)) {
+          if (this.leftExpr instanceof DiscretePrimitive && this.leftExpr.value === BigInt(1)) {
               return this.rightExpr;
           }
           if (this.rightExpr instanceof NumberPrimitive && this.rightExpr.value === 1) {
               return this.leftExpr;
           }
-          if (this.rightExpr instanceof BigIntPrimitive && this.rightExpr.value === BigInt(1)) {
+          if (this.rightExpr instanceof DiscretePrimitive && this.rightExpr.value === BigInt(1)) {
               return this.leftExpr;
           }
           return this;
@@ -489,6 +474,10 @@ export class BinaryExpression extends RefinementExpression {
     const fn2 = this.rightExpr.getTextPrimitives();
     return new Set<string>([...fn1, ...fn2]);
   }
+
+  isConstant(): boolean {
+    return this.leftExpr.isConstant() && this.rightExpr.isConstant();
+  }
 }
 
 export class UnaryExpression extends RefinementExpression {
@@ -500,9 +489,7 @@ export class UnaryExpression extends RefinementExpression {
     super('UnaryExpressionNode');
     this.expr = expr;
     this.operator = op;
-    this.operator.validateOperandCompatibility([this.expr]);
-    const evalType = this.operator.evalType();
-    this.evalType = evalType === 'same' ? this.expr.evalType : evalType;
+    this.evalType = this.operator.validateOperandCompatibility([this.expr]);
   }
 
   static fromAst(expression: UnaryExpressionNode, typeData: Dictionary<ExpressionPrimitives>): RefinementExpression {
@@ -522,8 +509,9 @@ export class UnaryExpression extends RefinementExpression {
 
   static fromLiteral(expr): RefinementExpression {
     return new UnaryExpression(
-            RefinementExpression.fromLiteral(expr.expr),
-            RefinementOperator.fromLiteral(expr.operator));
+      RefinementExpression.fromLiteral(expr.expr),
+      RefinementOperator.fromLiteral(expr.operator)
+    );
   }
 
   toString(): string {
@@ -538,23 +526,9 @@ export class UnaryExpression extends RefinementExpression {
     return this.operator.eval([expression]);
   }
 
-  simplifyPrimitive(): RefinementExpression  {
-    if (this.expr instanceof BooleanPrimitive && this.operator.op === Op.NOT) {
-      return new BooleanPrimitive(this.applyOperator());
-    } else if (this.expr instanceof NumberPrimitive && this.operator.op === Op.NEG) {
-      return new NumberPrimitive(this.applyOperator());
-    } else if (this.expr instanceof BigIntPrimitive && this.operator.op === Op.NEG) {
-      return new BigIntPrimitive(this.applyOperator());
-    }
-    return null;
-  }
-
   normalize(): RefinementExpression {
+    if (this.isConstant()) { return this.getValue(); }
     this.expr = this.expr.normalize();
-    const sp = this.simplifyPrimitive();
-    if (sp) {
-      return sp;
-    }
     switch (this.operator.op) {
       case Op.NOT: {
         if (this.expr instanceof UnaryExpression && this.expr.operator.op === Op.NOT) {
@@ -590,6 +564,10 @@ export class UnaryExpression extends RefinementExpression {
 
   getTextPrimitives(): Set<string> {
     return this.expr.getTextPrimitives();
+  }
+
+  isConstant(): boolean {
+    return this.expr.isConstant();
   }
 }
 
@@ -636,6 +614,10 @@ export class FieldNamePrimitive extends RefinementExpression {
   getFieldParams(): Map<string, Primitive> {
     return new Map<string, Primitive>([[this.value, this.evalType]]);
   }
+
+  isConstant(): boolean {
+    return false;
+  }
 }
 
 export class QueryArgumentPrimitive extends RefinementExpression {
@@ -678,6 +660,10 @@ export class QueryArgumentPrimitive extends RefinementExpression {
 
   getQueryParams(): Map<string, Primitive> {
     return new Map<string, Primitive>([[this.value, this.evalType]]);
+  }
+
+  isConstant(): boolean {
+    return false;
   }
 }
 
@@ -732,13 +718,19 @@ export class BuiltIn extends RefinementExpression {
   getFieldParams(): Map<string, Primitive> {
     return new Map<string, Primitive>();
   }
+
+  isConstant(): boolean {
+    return false;
+  }
 }
 
-export class BigIntPrimitive extends RefinementExpression {
-  evalType = Primitive.BIGINT;
-
-  constructor(public value: bigint, units: string[] = []) {
-    super('BigIntPrimitiveNode');
+export class DiscretePrimitive extends RefinementExpression {
+  constructor(
+    public value: bigint,
+    units: string[] = [],
+    public evalType: BigIntType,
+  ) {
+    super('DiscretePrimitiveNode');
 
     // Convert to Si units.
     // For time units, the base unit is milliseconds.
@@ -764,8 +756,8 @@ export class BigIntPrimitive extends RefinementExpression {
     }
   }
 
-  static fromAst(expression: BigIntNode): RefinementExpression {
-    return new BigIntPrimitive(expression.value, expression.units || []);
+  static fromAst(expression: DiscreteNode): RefinementExpression {
+    return new DiscretePrimitive(expression.value, expression.units || [], expression.type);
   }
 
   toLiteral() {
@@ -776,12 +768,20 @@ export class BigIntPrimitive extends RefinementExpression {
     };
   }
 
-  static fromLiteral(expr): RefinementExpression {
-    return new BigIntPrimitive(expr.value, expr.units);
+  static fromLiteral(expr: unknown): RefinementExpression {
+    return new DiscretePrimitive(expr['value'], expr['units'], expr['evalType']);
   }
 
   toString(): string {
-    return `${this.value}n`;
+    const typeIndicator = () => {
+      switch (this.evalType) {
+        case Primitive.BIGINT: return 'n';
+        case Primitive.INT: return 'i';
+        case Primitive.LONG: return 'l';
+        default: throw new Error(`unexpected type ${this.evalType}`);
+      }
+    };
+    return `${this.value}${typeIndicator()}`;
   }
 
   applyOperator(): ExpressionPrimitives {
@@ -853,6 +853,7 @@ export class NumberPrimitive extends RefinementExpression {
 }
 
 export class BooleanPrimitive extends RefinementExpression {
+  // TODO: Deprecate in favour of DiscretePrimitiveNode with type BOOLEAN.
   evalType = Primitive.BOOLEAN;
   value: boolean;
 
@@ -1023,7 +1024,6 @@ export class NumberRange {
         break;
       }
     }
-
     let j = this.segments.length;
     for (const subRange of this.segments.slice().reverse()) {
       if (seg.isLessThan(subRange, false)) {
@@ -1053,10 +1053,10 @@ export class NumberRange {
   static fromExpression(expr: RefinementExpression, textToNum: Dictionary<number> = {}): NumberRange {
     if (expr instanceof BinaryExpression) {
       if (expr.leftExpr instanceof FieldNamePrimitive && expr.rightExpr instanceof NumberPrimitive) {
-        return NumberRange.makeInitialGivenOp(expr.operator.op, expr.rightExpr.value);
+        return NumberRange.makeInitialGivenOp(expr.rightExpr.evalType, expr.operator.op, expr.rightExpr.value);
       }
       if (expr.leftExpr instanceof FieldNamePrimitive && expr.rightExpr instanceof TextPrimitive) {
-        return NumberRange.makeInitialGivenOp(expr.operator.op, textToNum[expr.rightExpr.value]);
+        return NumberRange.makeInitialGivenOp(expr.rightExpr.evalType, expr.operator.op, textToNum[expr.rightExpr.value]);
       }
       const left = NumberRange.fromExpression(expr.leftExpr, textToNum);
       const right = NumberRange.fromExpression(expr.rightExpr, textToNum);
@@ -1077,14 +1077,14 @@ export class NumberRange {
     return null;
   }
 
-  static makeInitialGivenOp(op: Op, val: ExpressionPrimitives): NumberRange {
+  static makeInitialGivenOp(type: Primitive, op: Op, val: ExpressionPrimitives): NumberRange {
     switch (op) {
-      case Op.LT: return new NumberRange([NumberSegment.closedOpen(Number.NEGATIVE_INFINITY, val)]);
-      case Op.LTE: return new NumberRange([NumberSegment.closedClosed(Number.NEGATIVE_INFINITY, val)]);
-      case Op.GT: return new NumberRange([NumberSegment.openClosed(val, Number.POSITIVE_INFINITY)]);
-      case Op.GTE: return new NumberRange([NumberSegment.closedClosed(val, Number.POSITIVE_INFINITY)]);
-      case Op.EQ: return new NumberRange([NumberSegment.closedClosed(val, val)]);
-      case Op.NEQ: return new NumberRange([NumberSegment.closedClosed(val, val)]).complement();
+      case Op.LT: return new NumberRange([NumberSegment.closedOpen(Number.NEGATIVE_INFINITY, val)], type);
+      case Op.LTE: return new NumberRange([NumberSegment.closedClosed(Number.NEGATIVE_INFINITY, val)], type);
+      case Op.GT: return new NumberRange([NumberSegment.openClosed(val, Number.POSITIVE_INFINITY)], type);
+      case Op.GTE: return new NumberRange([NumberSegment.closedClosed(val, Number.POSITIVE_INFINITY)], type);
+      case Op.EQ: return new NumberRange([NumberSegment.closedClosed(val, val)], type);
+      case Op.NEQ: return new NumberRange([NumberSegment.closedClosed(val, val)], type).complement();
       default: throw new Error(`Unsupported operator: field ${op} number`);
     }
   }
@@ -1255,11 +1255,10 @@ export class BigIntRange {
   }
 
   static universal(type: Primitive): BigIntRange {
+    const b0 = BigInt(0);
+    const b1 = BigInt(1);
     switch (type) {
-        // TODO: Support long, int etc.
       case Primitive.BOOLEAN:
-        const b0 = BigInt(0);
-        const b1 = BigInt(1);
         return new BigIntRange([BigIntSegment.closedClosed(b0, b0), BigIntSegment.closedClosed(b1, b1)], type);
       case Primitive.INT:
         return new BigIntRange([BigIntSegment.closedClosed(INT_MIN, INT_MAX)], type);
@@ -1382,11 +1381,13 @@ export class BigIntRange {
   // TODO(ragdev): Currently only BigInt and Boolean types are supported. Add String support.
   static fromExpression(expr: RefinementExpression, textToNum: Dictionary<bigint> = {}): BigIntRange {
     if (expr instanceof BinaryExpression) {
-      if (expr.leftExpr instanceof FieldNamePrimitive && expr.rightExpr instanceof BigIntPrimitive) {
-        return BigIntRange.makeInitialGivenOp(expr.rightExpr.evalType, expr.operator.op, expr.rightExpr.value);
-      }
-      if (expr.leftExpr instanceof FieldNamePrimitive && expr.rightExpr instanceof TextPrimitive) {
-        return BigIntRange.makeInitialGivenOp(expr.rightExpr.evalType, expr.operator.op, textToNum[expr.rightExpr.value]);
+      if (expr.leftExpr instanceof FieldNamePrimitive) {
+        if (expr.rightExpr instanceof DiscretePrimitive) {
+          return BigIntRange.makeInitialGivenOp(expr.leftExpr.evalType, expr.operator.op, expr.rightExpr.value);
+        }
+        if (expr.rightExpr instanceof TextPrimitive) {
+          return BigIntRange.makeInitialGivenOp(expr.leftExpr.evalType, expr.operator.op, textToNum[expr.rightExpr.value]);
+        }
       }
       const left = BigIntRange.fromExpression(expr.leftExpr, textToNum);
       const right = BigIntRange.fromExpression(expr.rightExpr, textToNum);
@@ -1410,15 +1411,18 @@ export class BigIntRange {
   static makeInitialGivenOp(type: Primitive, op: Op, val: ExpressionPrimitives): BigIntRange {
     const getRange = () => {
       switch (op) {
-        case Op.LT:  return new BigIntRange([BigIntSegment.closedOpen('NEGATIVE_INFINITY', val)]);
-        case Op.LTE: return new BigIntRange([BigIntSegment.closedClosed('NEGATIVE_INFINITY', val)]);
-        case Op.GT:  return new BigIntRange([BigIntSegment.openClosed(val, 'POSITIVE_INFINITY')]);
-        case Op.GTE: return new BigIntRange([BigIntSegment.closedClosed(val, 'POSITIVE_INFINITY')]);
-        case Op.EQ:  return new BigIntRange([BigIntSegment.closedClosed(val, val)]);
-        case Op.NEQ: return new BigIntRange([BigIntSegment.closedClosed(val, val)]).complement();
+        case Op.LT:  return new BigIntRange([BigIntSegment.closedOpen('NEGATIVE_INFINITY', val)], type);
+        case Op.LTE: return new BigIntRange([BigIntSegment.closedClosed('NEGATIVE_INFINITY', val)], type);
+        case Op.GT:  return new BigIntRange([BigIntSegment.openClosed(val, 'POSITIVE_INFINITY')], type);
+        case Op.GTE: return new BigIntRange([BigIntSegment.closedClosed(val, 'POSITIVE_INFINITY')], type);
+        case Op.EQ:  return new BigIntRange([BigIntSegment.closedClosed(val, val)], type);
+        case Op.NEQ: return new BigIntRange([
+          BigIntSegment.closedOpen('NEGATIVE_INFINITY', val),
+          BigIntSegment.openClosed(val, 'POSITIVE_INFINITY')
+        ], type);
         default: throw new Error(`Unsupported operator: field ${op} bigint`);
       }
-    }
+    };
     return BigIntRange.universal(type).intersect(getRange());
   }
 
@@ -1480,11 +1484,11 @@ export class BigIntSegment {
   }
 
   toString(): string {
-    const from_val = this.from.val === 'NEGATIVE_INFINITY' ? '-∞' : this.from.val;
-    const to_val = this.to.val === 'POSITIVE_INFINITY' ? '∞' : this.to.val;
-    const from_bound = this.from.isOpen ? '(' : '[';
-    const to_bound = this.to.isOpen ? ')' : ']';
-    return `${from_bound}${from_val}, ${to_val}${to_bound}`;
+    const fromVal = this.from.val === 'NEGATIVE_INFINITY' ? '-∞' : this.from.val;
+    const toVal = this.to.val === 'POSITIVE_INFINITY' ? '∞' : this.to.val;
+    const fromBound = this.from.isOpen ? '(' : '[';
+    const toBound = this.to.isOpen ? ')' : ']';
+    return `${fromBound}${fromVal}, ${toVal}${toBound}`;
   }
 
   static isValid(from: Boundary<BigIntValue>, to: Boundary<BigIntValue>): boolean {
@@ -1614,12 +1618,6 @@ interface OperatorInfo {
   // type should be the same as the type of the first argument.
   evalType: Primitive | 'same';
 }
-
-const bigIntTypes: Primitive[] = [
-  Primitive.BIGINT,
-  Primitive.LONG,
-  Primitive.INT
-];
 
 const numericTypes: Primitive[] = [Primitive.NUMBER].concat(bigIntTypes);
 
@@ -1751,57 +1749,71 @@ export class RefinementOperator {
     return this.opInfo.evalType;
   }
 
-  validateOperandCompatibility(operands: RefinementExpression[]): void {
+  validateOperandCompatibility(operands: RefinementExpression[]): Primitive {
+    const operandStr = operands.map(x => x.toString()).join(' and ');
+    const operandTys = operands.map(op => op.evalType).join(' and ');
+    const expected = () => {
+      if (this.opInfo.argType === 'same') {
+        return 'arguments to be of the same type';
+      } else if (this.opInfo.argType.length > 1) {
+        const front = this.opInfo.argType.slice(0, this.opInfo.argType.length-1);
+        const last = this.opInfo.argType[this.opInfo.argType.length-1];
+        return `${front.join(', ')} or ${last}`;
+      }
+      return this.opInfo.argType[0];
+    };
     // TODO(cypher1): Use the type checker here (with type variables) as this is not typesafe.
     // E.g. if both arguments are unknown, the types will be unknown but not enforced to be equal.
-    // console.log(operands.map(op => `${op.toString()} : ${op.evalType}`).join(', '));
-    // console.log(`(${this.opInfo.argType}) -> ${this.opInfo.evalType}\n`);
     if (operands.length !== this.opInfo.nArgs) {
       throw new Error(`Expected ${this.opInfo.nArgs} operands. Got ${operands.length}.`);
     }
-    let argType: Primitive = Primitive.UNKNOWN;
-    // Discover the shared argument type.
-    for (const operand of operands) {
-      if (this.opInfo.argType === 'same') {
-        if (operand.evalType !== Primitive.UNKNOWN) {
+    const getArgType = () => {
+      let argType: Primitive = Primitive.UNKNOWN;
+      // Discover the shared argument type.
+      for (const operand of operands) {
+        if (this.opInfo.argType === 'same') {
+          // The type's validity depends on the other arguments.
+          if (operand.evalType !== Primitive.UNKNOWN) {
+            argType = operand.evalType;
+            break;
+          }
+        } else if (this.opInfo.argType.includes(operand.evalType)) {
+          // A possible, valid type.
           argType = operand.evalType;
+          break;
+        } else {
+          // This type is not valid, no matter the other arguments.
+          throw new Error(
+            `Refinement expression ${operand.toString()} has type ${operand.evalType}. Expected ${expected()}`
+          );
         }
-      } else if (this.opInfo.argType.includes(operand.evalType)) {
-        argType = operand.evalType;
       }
-    }
+      return argType;
+    };
+    const argType = getArgType();
     // Set the query argument type.
     for (const operand of operands) {
-      if (operand.evalType === Primitive.UNKNOWN) {
+      if (operand instanceof QueryArgumentPrimitive && operand.evalType === Primitive.UNKNOWN) {
         operand.evalType = argType;
       }
-    }
-    // Update the eval type if necessary.
-    if (this.opInfo.evalType === 'same') {
-      this.opInfo.evalType = argType;
     }
     // Check that all args match the expected type.
     for (const operand of operands) {
       // Check that the argument types are valid.
       if (this.opInfo.argType === 'same') {
-        const usesBigInts = bigIntTypes.includes(operand.evalType) && bigIntTypes.includes(argType);
-        if (operand.evalType !== argType && !usesBigInts) {
-          const operandStr = operands.join(' and ');
-          const operandTys = operands.map(op => op.evalType).join(' and ');
+        if (operand.evalType !== argType) {
           throw new Error(
-            `Expected refinement expression ${operandStr} to have the same types. But found types ${operandTys}.`
+            `Expected refinement expressions ${operandStr} to have the same types. Found types ${operandTys}.`
           );
         }
-      } else if (!this.opInfo.argType.includes(operand.evalType)) {
-        const last = this.opInfo.argType[this.opInfo.argType.length-1];
-        const front = this.opInfo.argType.slice(0, this.opInfo.argType.length-1);
-        let argString = `${front.join(`, `)} or ${last}`;
+      } else if (operand.evalType !== argType) {
         throw new Error(
-          `Refinement expression ${operand} has type ${operand.evalType}. Expected ${argString}.`
+          `Expected refinement expressions ${operandStr} to have the same types. Found types ${operandTys}.`
         );
       }
     }
     // Passed type checking.
+    return (this.opInfo.evalType === 'same') ? argType : this.opInfo.evalType;
   }
 }
 
@@ -1811,6 +1823,7 @@ const CONSTANT = '{}';
 export class NumberFraction {
   num: NumberMultinomial;
   den: NumberMultinomial;
+  type = Primitive.NUMBER;
 
   constructor(n?: NumberMultinomial, d?: NumberMultinomial) {
     this.num = n ? NumberMultinomial.copyOf(n) : new NumberMultinomial();
@@ -1843,6 +1856,37 @@ export class NumberFraction {
   static divide(a: NumberFraction, b: NumberFraction): NumberFraction {
     const invB = new NumberFraction(b.den, b.num);
     return NumberFraction.multiply(a, invB);
+  }
+
+  fracLessThanZero(): RefinementExpression {
+    const ngt0 = this.num.toExpression(Op.GT);
+    const nlt0 = this.num.toExpression(Op.LT);
+    const dgt0 = this.den.toExpression(Op.GT);
+    const dlt0 = this.den.toExpression(Op.LT);
+    const left = new BinaryExpression(ngt0, dlt0, new RefinementOperator(Op.AND));
+    const right = new BinaryExpression(nlt0, dgt0, new RefinementOperator(Op.AND));
+    return new BinaryExpression(left, right, new RefinementOperator(Op.OR));
+  }
+
+  fracGreaterThanZero(): BinaryExpression {
+    const ngt0 = this.num.toExpression(Op.GT);
+    const nlt0 = this.num.toExpression(Op.LT);
+    const dgt0 = this.den.toExpression(Op.GT);
+    const dlt0 = this.den.toExpression(Op.LT);
+    return new BinaryExpression(
+      new BinaryExpression(ngt0, dgt0, new RefinementOperator(Op.AND)),
+      new BinaryExpression(nlt0, dlt0, new RefinementOperator(Op.AND)),
+      new RefinementOperator(Op.OR)
+    );
+  }
+
+  fracEqualsToZero(): RefinementExpression {
+    const neq0 = this.num.toExpression(Op.EQ);
+    if (this.den.isConstant() && !this.den.isZero()) {
+      return neq0; // TODO(cypher1): This normalizer should be doing this for us.
+    }
+    const dneq0 = this.den.toExpression(Op.NEQ);
+    return new BinaryExpression(neq0, dneq0, new RefinementOperator(Op.AND));
   }
 
   reduce() {
@@ -1908,42 +1952,93 @@ export class BigIntFraction {
   num: BigIntMultinomial;
   den: BigIntMultinomial;
 
-  constructor(n?: BigIntMultinomial, d?: BigIntMultinomial) {
-    this.num = n ? BigIntMultinomial.copyOf(n) : new BigIntMultinomial();
-    this.den = d ? BigIntMultinomial.copyOf(d) : new BigIntMultinomial({[CONSTANT]: BigInt(1)});
+  constructor(n: BigIntMultinomial, d: BigIntMultinomial, public type: BigIntType) {
+    this.num = BigIntMultinomial.copyOf(n);
+    this.den = BigIntMultinomial.copyOf(d);
     if (this.den.isZero()) {
       throw new Error('Division by zero.');
     }
     this.reduce();
   }
 
+  static onOne(n: BigIntMultinomial, type: BigIntType): BigIntFraction {
+    return new BigIntFraction(n, BigIntMultinomial.one(), type);
+  }
+
+  static one(type: BigIntType): BigIntFraction {
+    return BigIntFraction.onOne(BigIntMultinomial.one(), type);
+  }
+
   static add(a: BigIntFraction, b: BigIntFraction): BigIntFraction {
+    if (a.type !== b.type) {
+      throw new Error(`cannot combine ${a.toString()} and ${b.toString()}, types do not match.`);
+    }
     const den = BigIntMultinomial.multiply(a.den, b.den);
     const num = BigIntMultinomial.add(BigIntMultinomial.multiply(a.num, b.den), BigIntMultinomial.multiply(b.num, a.den));
-    return new BigIntFraction(num, den);
+    return new BigIntFraction(num, den, a.type);
   }
 
   static negate(a: BigIntFraction): BigIntFraction {
-    return new BigIntFraction(BigIntMultinomial.negate(a.num), a.den);
+    return new BigIntFraction(BigIntMultinomial.negate(a.num), a.den, a.type);
   }
 
   static subtract(a: BigIntFraction, b: BigIntFraction): BigIntFraction {
+    if (a.type !== b.type) {
+      throw new Error(`cannot combine ${a.toString()} and ${b.toString()}, types do not match.`);
+    }
     const negB = BigIntFraction.negate(b);
     return BigIntFraction.add(a, negB);
   }
 
   static multiply(a: BigIntFraction, b: BigIntFraction): BigIntFraction {
-    return new BigIntFraction(BigIntMultinomial.multiply(a.num, b.num), BigIntMultinomial.multiply(a.den, b.den));
+    if (a.type !== b.type) {
+      throw new Error(`cannot combine ${a.toString()} and ${b.toString()}, types do not match.`);
+    }
+    return new BigIntFraction(BigIntMultinomial.multiply(a.num, b.num), BigIntMultinomial.multiply(a.den, b.den), a.type);
   }
 
   static divide(a: BigIntFraction, b: BigIntFraction): BigIntFraction {
-    const invB = new BigIntFraction(b.den, b.num);
+    if (a.type !== b.type) {
+      throw new Error(`cannot combine ${a.toString()} and ${b.toString()}, types do not match.`);
+    }
+    const invB = new BigIntFraction(b.den, b.num, a.type);
     return BigIntFraction.multiply(a, invB);
+  }
+
+  fracLessThanZero(): RefinementExpression {
+    const ngt0 = this.num.toExpression(Op.GT, this.type);
+    const nlt0 = this.num.toExpression(Op.LT, this.type);
+    const dgt0 = this.den.toExpression(Op.GT, this.type);
+    const dlt0 = this.den.toExpression(Op.LT, this.type);
+    const left = new BinaryExpression(ngt0, dlt0, new RefinementOperator(Op.AND));
+    const right = new BinaryExpression(nlt0, dgt0, new RefinementOperator(Op.AND));
+    return new BinaryExpression(left, right, new RefinementOperator(Op.OR));
+  }
+
+  fracGreaterThanZero(): BinaryExpression {
+    const ngt0 = this.num.toExpression(Op.GT, this.type);
+    const nlt0 = this.num.toExpression(Op.LT, this.type);
+    const dgt0 = this.den.toExpression(Op.GT, this.type);
+    const dlt0 = this.den.toExpression(Op.LT, this.type);
+    return new BinaryExpression(
+      new BinaryExpression(ngt0, dgt0, new RefinementOperator(Op.AND)),
+      new BinaryExpression(nlt0, dlt0, new RefinementOperator(Op.AND)),
+      new RefinementOperator(Op.OR)
+    );
+  }
+
+  fracEqualsToZero(): RefinementExpression {
+    const neq0 = this.num.toExpression(Op.EQ, this.type);
+    if (this.den.isConstant() && !this.den.isZero()) {
+      return neq0; // TODO(cypher1): This normalizer should be doing this for us.
+    }
+    const dneq0 = this.den.toExpression(Op.NEQ, this.type);
+    return new BinaryExpression(neq0, dneq0, new RefinementOperator(Op.AND));
   }
 
   reduce() {
     if (this.num.isZero()) {
-      this.den = new BigIntMultinomial({[CONSTANT]: BigInt(1)});
+      this.den = BigIntMultinomial.one();
       return;
     }
     if (this.num.isConstant() &&
@@ -1972,14 +2067,17 @@ export class BigIntFraction {
       const fn = BigIntFraction.fromExpression(expr.expr);
       return BigIntFraction.updateGivenOp(expr.operator.op, [fn]);
     } else if (expr instanceof FieldNamePrimitive) {
-      if (expr.evalType === Primitive.BIGINT) {
+      if (bigIntTypes.includes(expr.evalType)) {
         const term = new BigIntTerm({[expr.value]: BigInt(1)});
-        return new BigIntFraction(new BigIntMultinomial({[term.toKey()]: BigInt(1)}));
+        return BigIntFraction.onOne(
+          new BigIntMultinomial({[term.toKey()]: BigInt(1)}),
+          expr.evalType as BigIntType // Safe due to manual check of bigIntTypes list.
+        );
       } else {
         throw new Error(`Cannot model expression as BigIntFraction: ${expr.toString()}, wrong type: ${expr.evalType}`);
       }
-    } else if (expr instanceof BigIntPrimitive) {
-      return new BigIntFraction(new BigIntMultinomial({[CONSTANT]: expr.value}));
+    } else if (expr instanceof DiscretePrimitive) {
+      return BigIntFraction.onOne(new BigIntMultinomial({[CONSTANT]: expr.value}), expr.evalType);
     }
     throw new Error(`Cannot model expression as BigIntFraction: ${expr.toString()}`);
   }
@@ -2296,6 +2394,10 @@ export class BigIntMultinomial {
     this._terms = terms;
   }
 
+  static one(): BigIntMultinomial {
+    return new BigIntMultinomial({[CONSTANT]: BigInt(1)});
+  }
+
   static copyOf(mn: BigIntMultinomial): BigIntMultinomial {
     return new BigIntMultinomial(mn.terms);
   }
@@ -2391,11 +2493,11 @@ export class BigIntMultinomial {
   }
 
   // returns <multinomial> <op> CONSTANT
-  toExpression(op: Op): RefinementExpression {
+  toExpression(op: Op, type: BigIntType): RefinementExpression {
     if (this.isConstant()) {
       return new BinaryExpression(
-        new BigIntPrimitive(this.isZero() ? BigInt(0) : this.terms[CONSTANT]),
-        new BigIntPrimitive(BigInt(0)),
+        new DiscretePrimitive(this.isZero() ? BigInt(0) : this.terms[CONSTANT], [], type),
+        new DiscretePrimitive(BigInt(0), [], type),
         new RefinementOperator(op));
     }
     if (this.isUnivariate() && this.degree() === BigInt(1)) {
@@ -2410,7 +2512,7 @@ export class BigIntMultinomial {
       const scaledCnst: bigint = cnst/leadingCoeff;
       return new BinaryExpression(
         new FieldNamePrimitive(indeterminate, Primitive.BIGINT),
-        new BigIntPrimitive(-scaledCnst),
+        new DiscretePrimitive(-scaledCnst, [], type),
         operator);
     }
     const termToExpression = (tKey: string, tCoeff: bigint) => {
@@ -2419,7 +2521,7 @@ export class BigIntMultinomial {
         return termExpr;
       }
       return new BinaryExpression(
-        new BigIntPrimitive(tCoeff),
+        new DiscretePrimitive(tCoeff, [], type),
         termExpr,
         new RefinementOperator(Op.MUL)
       );
@@ -2434,7 +2536,7 @@ export class BigIntMultinomial {
         expr = expr ? new BinaryExpression(expr, termExpr, new RefinementOperator(Op.ADD)) : termExpr;
       }
     }
-    return new BinaryExpression(expr, new BigIntPrimitive(-cnst), new RefinementOperator(op));
+    return new BinaryExpression(expr, new DiscretePrimitive(-cnst, [], type), new RefinementOperator(op));
   }
 }
 
@@ -2449,9 +2551,9 @@ export class Normalizer {
       const frac = NumberFraction.subtract(lF, rF);
       let rearranged = null;
       switch (expr.operator.op) {
-        case Op.LT: rearranged = Normalizer.fracLessThanZero(frac); break;
-        case Op.GT: rearranged = Normalizer.fracGreaterThanZero(frac); break;
-        case Op.EQ: rearranged = Normalizer.fracEqualsToZero(frac); break;
+        case Op.LT: rearranged = frac.fracLessThanZero(); break;
+        case Op.GT: rearranged = frac.fracGreaterThanZero(); break;
+        case Op.EQ: rearranged = frac.fracEqualsToZero(); break;
         default:
             throw new Error(`Unsupported operator ${expr.operator.op}: cannot rearrange numerical expression.`);
       }
@@ -2462,45 +2564,14 @@ export class Normalizer {
       const frac = BigIntFraction.subtract(lF, rF);
       let rearranged = null;
       switch (expr.operator.op) {
-        case Op.LT: rearranged = Normalizer.fracLessThanZero(frac); break;
-        case Op.GT: rearranged = Normalizer.fracGreaterThanZero(frac); break;
-        case Op.EQ: rearranged = Normalizer.fracEqualsToZero(frac); break;
+        case Op.LT: rearranged = frac.fracLessThanZero(); break;
+        case Op.GT: rearranged = frac.fracGreaterThanZero(); break;
+        case Op.EQ: rearranged = frac.fracEqualsToZero(); break;
         default:
             throw new Error(`Unsupported operator ${expr.operator.op}: cannot rearrange numerical expression.`);
       }
       expr.update(rearranged);
     }
-  }
-
-  static fracLessThanZero(frac: NumberFraction | BigIntFraction): RefinementExpression {
-    const ngt0 = frac.num.toExpression(Op.GT);
-    const nlt0 = frac.num.toExpression(Op.LT);
-    const dgt0 = frac.den.toExpression(Op.GT);
-    const dlt0 = frac.den.toExpression(Op.LT);
-    const left = new BinaryExpression(ngt0, dlt0, new RefinementOperator(Op.AND));
-    const right = new BinaryExpression(nlt0, dgt0, new RefinementOperator(Op.AND));
-    return new BinaryExpression(left, right, new RefinementOperator(Op.OR));
-  }
-
-  static fracGreaterThanZero(frac: NumberFraction | BigIntFraction): BinaryExpression {
-    const ngt0 = frac.num.toExpression(Op.GT);
-    const nlt0 = frac.num.toExpression(Op.LT);
-    const dgt0 = frac.den.toExpression(Op.GT);
-    const dlt0 = frac.den.toExpression(Op.LT);
-    return new BinaryExpression(
-      new BinaryExpression(ngt0, dgt0, new RefinementOperator(Op.AND)),
-      new BinaryExpression(nlt0, dlt0, new RefinementOperator(Op.AND)),
-      new RefinementOperator(Op.OR)
-    );
-  }
-
-  static fracEqualsToZero(frac: NumberFraction | BigIntFraction): RefinementExpression {
-    const neq0 = frac.num.toExpression(Op.EQ);
-    if (frac.den.isConstant() && !frac.den.isZero()) {
-      return neq0; // TODO(cypher1): This normalizer should be doing this for us.
-    }
-    const dneq0 = frac.den.toExpression(Op.NEQ);
-    return new BinaryExpression(neq0, dneq0, new RefinementOperator(Op.AND));
   }
 }
 
@@ -2519,16 +2590,14 @@ export abstract class RefinementExpressionVisitor<T> {
     switch (expression.kind) {
       case 'BinaryExpressionNode':
         return this.visitBinaryExpression(expression as BinaryExpression);
-      case 'BooleanPrimitiveNode':
-        return this.visitBooleanPrimitive(expression as BooleanPrimitive);
       case 'BuiltInNode':
         return this.visitBuiltIn(expression as BuiltIn);
       case 'FieldNamePrimitiveNode':
         return this.visitFieldNamePrimitive(expression as FieldNamePrimitive);
       case 'NumberPrimitiveNode':
         return this.visitNumberPrimitive(expression as NumberPrimitive);
-      case 'BigIntPrimitiveNode':
-        return this.visitBigIntPrimitive(expression as BigIntPrimitive);
+      case 'DiscretePrimitiveNode':
+        return this.visitDiscretePrimitive(expression as DiscretePrimitive);
       case 'QueryArgumentPrimitiveNode':
         return this.visitQueryArgumentPrimitive(expression as QueryArgumentPrimitive);
       case 'TextPrimitiveNode':
@@ -2546,7 +2615,6 @@ export abstract class RefinementExpressionVisitor<T> {
   abstract visitQueryArgumentPrimitive(expr: QueryArgumentPrimitive): T;
   abstract visitBuiltIn(expr: BuiltIn): T;
   abstract visitNumberPrimitive(expr: NumberPrimitive): T;
-  abstract visitBigIntPrimitive(expr: BigIntPrimitive): T;
-  abstract visitBooleanPrimitive(expr: BooleanPrimitive): T;
+  abstract visitDiscretePrimitive(expr: DiscretePrimitive): T;
   abstract visitTextPrimitive(expr: TextPrimitive): T;
 }

--- a/src/runtime/sql-refinement-generator.ts
+++ b/src/runtime/sql-refinement-generator.ts
@@ -8,10 +8,10 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {Op} from './manifest-ast-nodes.js';
+import {Op, Primitive} from './manifest-ast-nodes.js';
 import {Dictionary} from './hot.js';
 import {Schema} from './schema.js';
-import {RefinementExpressionVisitor, BinaryExpression, UnaryExpression, FieldNamePrimitive, QueryArgumentPrimitive, BuiltIn, NumberPrimitive, BigIntPrimitive, BooleanPrimitive, TextPrimitive, Primitive} from './refiner.js';
+import {RefinementExpressionVisitor, BinaryExpression, UnaryExpression, FieldNamePrimitive, QueryArgumentPrimitive, BuiltIn, NumberPrimitive, DiscretePrimitive, TextPrimitive} from './refiner.js';
 
 const sqlOperator: Dictionary<string> = {
   [Op.AND]: 'AND',
@@ -61,14 +61,16 @@ class SqlRefinementGenerator extends RefinementExpressionVisitor<string> {
     // TODO: Implement SQL getter for 'creationTimeStamp'
     throw new Error(`Unhandled BuiltInNode '${expr.value}' in toSQLExpression`);
   }
-  visitBigIntPrimitive(expr: BigIntPrimitive): string {
-    return expr.value.toString();
+  visitDiscretePrimitive(expr: DiscretePrimitive): string {
+    switch (expr.evalType) {
+      case Primitive.BOOLEAN:
+        throw new Error('BooleanPrimitive.toSQLExpression should never be called. The expression is assumed to be normalized.');
+      default:
+        return expr.value.toString();
+    }
   }
   visitNumberPrimitive(expr: NumberPrimitive): string {
     return expr.value.toString();
-  }
-  visitBooleanPrimitive(_: BooleanPrimitive): string {
-    throw new Error('BooleanPrimitive.toSQLExpression should never be called. The expression is assumed to be normalized.');
   }
   visitTextPrimitive(expr: TextPrimitive): string {
     // TODO(cypher1): Consider escaping this for SQL code generation.

--- a/src/runtime/tests/refiner-test.ts
+++ b/src/runtime/tests/refiner-test.ts
@@ -8,7 +8,8 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {Primitive, NumberRange, NumberSegment, Refinement, BinaryExpression, NumberMultinomial, NumberFraction, NumberTerm, BigIntTerm, BigIntRange, BigIntFraction, BigIntMultinomial, BigIntSegment, Normalizer} from '../refiner.js';
+import {NumberRange, NumberSegment, Refinement, BinaryExpression, NumberMultinomial, NumberFraction, NumberTerm, BigIntTerm, BigIntRange, BigIntFraction, BigIntMultinomial, BigIntSegment, Normalizer} from '../refiner.js';
+import {Primitive, viewAst} from '../manifest-ast-nodes.js';
 import {parse} from '../../gen/runtime/manifest-parser.js';
 import {assert} from '../../platform/chai-web.js';
 import {Manifest} from '../manifest.js';
@@ -17,19 +18,19 @@ import {Schema} from '../schema.js';
 import {Flags} from '../flags.js';
 
 describe('refiner', () => {
-    it('Refines data given an expression 1', Flags.withFieldRefinementsAllowed(async () => {
+    it('Refines data given an expression 1', () => {
         const manifestAst = parse(`
             particle Foo
-                input: reads Something {num: Number [ (num/-3 < 0 and num*num == 36) or num == 0 ]}
+                input: reads Something {num: Number} [ (num/-3 < 0 and num*num == 36) or num == 0 ]
         `);
         const typeData = {'num': 'Number'};
-        const ref = Refinement.fromAst(manifestAst[0].args[0].type.fields[0].type.refinement, typeData);
+        const ref = Refinement.fromAst(manifestAst[0].args[0].type.refinement, typeData);
         const data = {
             num: 6
         };
         const res = ref.validateData(data);
         assert.strictEqual(res, data.num === 0 || data.num === 6);
-    }));
+    });
     it('Refines data given an expression 2', () => {
       const manifestAst = parse(`
           particle Foo
@@ -43,20 +44,20 @@ describe('refiner', () => {
       const res = ref.validateData(data);
       assert.strictEqual(res, data.num === 0 || data.num === 6);
   });
-    it('Throws error when field name not found 1', Flags.withFieldRefinementsAllowed(async () => {
+    it('Throws error when field name not found 1', () => {
         assert.throws(() => {
             const manifestAst = parse(`
                 particle Foo
-                    input: reads Something {num: Number [ num < num2 ]}
+                    input: reads Something {num: Number} [ num < num2 ]
             `);
             const typeData = {'num': 'Number'};
-            const ref = Refinement.fromAst(manifestAst[0].args[0].type.fields[0].type.refinement, typeData);
+            const ref = Refinement.fromAst(manifestAst[0].args[0].type.refinement, typeData);
             const data = {
                 num: 6,
             };
             ref.validateData(data);
-        }, `Unresolved field name 'num2' in the refinement expression.`);
-    }));
+        }, `Unresolved field name 'num2' in the refinement expression`);
+    });
     it('Throws error when field name not found 2', () => {
       assert.throws(() => {
           const manifestAst = parse(`
@@ -69,95 +70,101 @@ describe('refiner', () => {
               num: 6,
           };
           ref.validateData(data);
-      }, `Unresolved field name 'num2' in the refinement expression.`);
+      }, `Unresolved field name 'num2' in the refinement expression`);
   });
-    it('Throws error when expression does not produce boolean result', Flags.withFieldRefinementsAllowed(async () => {
+    it('Throws error when expression does not produce boolean result', () => {
         assert.throws(() => {
             const manifestAst = parse(`
                 particle Foo
-                    input: reads Something {num: Number [ num + 5 ]}
+                    input: reads Something {num: Number} [ num + 5 ]
             `);
             const typeData = {'num': 'Number'};
-            const ref = Refinement.fromAst(manifestAst[0].args[0].type.fields[0].type.refinement, typeData);
+            const ref = Refinement.fromAst(manifestAst[0].args[0].type.refinement, typeData);
             const data = {
                 num: 6,
             };
             ref.validateData(data);
-        }, `Refinement expression (num + 5) evaluated to a non-boolean type.`);
-    }));
-    it('Throws error when operators and operands are incompatible: Number', Flags.withFieldRefinementsAllowed(async () => {
+        }, `Refinement expression (num + 5) evaluated to a non-boolean type`);
+    });
+    it('Throws error when operators and operands are incompatible: Number', () => {
         assert.throws(() => {
             const manifestAst = parse(`
                 particle Foo
-                    input: reads Something {num: Number [ (num < 5) + 3 == 0 ]}
+                    input: reads Something {num: Number} [ (num < 5) + 3 == 0 ]
             `);
             const typeData = {'num': 'Number'};
-            const ref = Refinement.fromAst(manifestAst[0].args[0].type.fields[0].type.refinement, typeData);
+            const ref = Refinement.fromAst(manifestAst[0].args[0].type.refinement, typeData);
             const data = {
                 num: 6,
             };
             ref.validateData(data);
-        }, `Refinement expression (num < 5) has type Boolean. Expected Number.`);
+        }, `Refinement expression (num < 5) has type Boolean. Expected Number, BigInt, Long or Int`);
         assert.throws(() => {
             const manifestAst = parse(`
                 particle Foo
-                    input: reads Something {num: Number [ (num and 3) == 0 ]}
+                    input: reads Something {num: Number} [ (num and 3) == 0 ]
             `);
             const typeData = {'num': 'Number'};
-            const ref = Refinement.fromAst(manifestAst[0].args[0].type.fields[0].type.refinement, typeData);
+            const ref = Refinement.fromAst(manifestAst[0].args[0].type.refinement, typeData);
             const data = {
                 num: 6,
             };
             ref.validateData(data);
-        }, `Refinement expression num has type Number. Expected Boolean.`);
+        }, `Refinement expression num has type Number. Expected Boolean`);
         assert.throws(() => {
           const manifestAst = parse(`
               particle Foo
-                  input: reads Something {name: Text [ name > 'Ragav' ]}
+                  input: reads Something {name: Text} [ name > 'Ragav' ]
           `);
           const typeData = {'name': 'Text'};
-          const ref = Refinement.fromAst(manifestAst[0].args[0].type.fields[0].type.refinement, typeData);
-          const data = {
-              name: 'Josh',
-          };
-            ref.validateData(data);
-        }, `Refinement expression name has type Text. Expected Number, BigInt, Long or Int.`);
-    }));
-    it('Throws error when operators and operands are incompatible: BigInt', Flags.withFieldRefinementsAllowed(async () => {
-      const validate = (data: object, relation: string) => {
+          const ref = Refinement.fromAst(manifestAst[0].args[0].type.refinement, typeData);
+          const data = {name: 'Josh'};
+          ref.validateData(data);
+        }, `Refinement expression name has type Text. Expected Number, BigInt, Long or Int`);
+    });
+    describe('Throws error when operators and operands are incompatible: BigInt', async () => {
+      const validate = (data: {num: bigint | number }, relation: string) => {
+        const typeData = {'num': 'BigInt'};
         const manifest = `
         particle Foo
-            input: reads Something {num: BigInt [ ${relation} ]}`;
+            input: reads Something {num: BigInt}[${relation}]`;
         const manifestAst = parse(manifest);
-        const typeData = {'num': 'BigInt'};
-        const ref = Refinement.fromAst(manifestAst[0].args[0].type.fields[0].type.refinement, typeData);
+        const ref = Refinement.fromAst(manifestAst[0].args[0].type.refinement, typeData);
+        ref.normalize();
         return ref.validateData(data);
       };
-      assert.isTrue(validate({num: BigInt(6)}, `(num - 6n) == 0n`), 'this should be valid');
-      assert.throws(() => {
-          validate({num: BigInt(6)}, `(num < 5n) + 3n == 0n`);
-      }, `Refinement expression (num < 5n) has type Boolean. Expected BigInt.`);
-      assert.throws(() => {
-          validate({num: BigInt(6)}, `(num + 3) == 0n`);
-      }, `Refinement expression num has type BigInt. Expected Number.`);
-      assert.throws(() => {
-          validate({num: 6}, `(num + 3) == 0n`);
-      }, `Refinement expression num has type BigInt. Expected Number.`);
-      assert.throws(() => {
-          validate({num: 6}, `(num + 3) == 0n`);
-      }, `Refinement expression num has type BigInt. Expected Number.`);
-      assert.throws(() => {
-          validate({num: 6}, `(num and 3) == 0`);
-      }, `Refinement expression num has type BigInt. Expected Boolean.`);
-    }));
-    it('tests simple expression to range conversion', Flags.withFieldRefinementsAllowed(async () => {
-      const validate = (refinement, segments: NumberSegment[]) => {
+      it('equality and subtraction function as expected', async () =>
+        assert.isTrue(validate({num: BigInt(6)}, `(num - 6n) == 0n`), 'this should be valid')
+      );
+      it('comparisons produce a boolean that cannot be added to a bigint', async () =>
+        assert.throws(
+          () => validate({num: BigInt(6)}, `(num < 5n) + 3n == 0n`),
+          `Refinement expression (num < 5n) has type Boolean. Expected Number, BigInt, Long or Int`
+      ));
+      it('bigint and explicitly floating point number cannot be added (to ensure correctness)', async () =>
+        assert.throws(
+          () => validate({num: BigInt(6)}, `(num + 3.0) == 0n`),
+          `Expected refinement expressions num and 3 to have the same types. Found types BigInt and Number`
+      ));
+      it('bigint and implicit floating point number cannot be added (to ensure correctness)', async () =>
+        assert.throws(
+          () => validate({num: BigInt(6)}, `(num + 3) == 0`),
+          `Expected refinement expressions num and 3 to have the same types. Found types BigInt and Number`
+      ));
+      it('incorrectly typed data fails at runtime', async () =>
+        assert.throws(() =>
+            validate({num: 6}, `(num and 3) == 0n`)
+        , `Refinement expression num has type BigInt. Expected Boolean`)
+      );
+    });
+    it('tests simple expression to range conversion', () => {
+      const validate = (refinement: string, segments: NumberSegment[]) => {
         const typeData = {'num': `Number`};
         const manifestAst = parse(`
             particle Foo
-                input: reads Something {num: Number [ ${refinement} ]}
+                input: reads Something {num: Number} [ ${refinement} ]
         `);
-        const ref = Refinement.fromAst(manifestAst[0].args[0].type.fields[0].type.refinement, typeData);
+        const ref = Refinement.fromAst(manifestAst[0].args[0].type.refinement, typeData);
         const range = NumberRange.fromExpression(ref.expression);
         assert.deepEqual(range, new NumberRange(segments));
       };
@@ -168,67 +175,86 @@ describe('refiner', () => {
         NumberSegment.closedOpen(Number.NEGATIVE_INFINITY, 10),
         NumberSegment.openClosed(10, Number.POSITIVE_INFINITY)
       ]);
-    }));
-    describe.only('tests simple expression to range conversions using int', async () => {
+    });
+    describe('tests simple expression to range conversions using int', async () => {
       const validate = (refinement: string, segments: BigIntSegment[]) => {
         const typeData = {'num': `Int`};
         const manifestAst = parse(`
             particle Foo
-                input: reads Something {num: Int [ ${refinement} ]}
+                input: reads Something {num: Int} [ ${refinement} ]
         `);
-        const ref_ast = manifestAst[0].args[0].type.fields[0].type.refinement;
-        console.log(ref_ast);
-        const ref = Refinement.fromAst(ref_ast, typeData);
+        const refAst = manifestAst[0].args[0].type.refinement;
+        const ref = Refinement.fromAst(refAst, typeData);
         const range = BigIntRange.fromExpression(ref.expression);
-        assert.deepEqual(range, new BigIntRange(segments));
+        assert.deepEqual(range, new BigIntRange(segments, Primitive.INT));
       };
-      it.only('unbounded', Flags.withFieldRefinementsAllowed(async () => {
-        validate(`(num != 0n)`, [BigIntSegment.closedOpen(-(BigInt(2)**BigInt(31)), BigInt(0)), BigIntSegment.openClosed(BigInt(0), (BigInt(2)**BigInt(31)) - BigInt(1))]);
-      }));
-      it('with lower bound', Flags.withFieldRefinementsAllowed(async () => {
-        validate(`(num > 0n)`, [BigIntSegment.openClosed(BigInt(0), (BigInt(2)**BigInt(31)) - BigInt(1))]);
-      }));
-      it('with upper bound', Flags.withFieldRefinementsAllowed(async () => {
-        validate(`(num < 0n)`, [BigIntSegment.closedOpen(-(BigInt(2)**BigInt(31)), BigInt(0))]);
-      }));
-      it('with upper and lower bounds', Flags.withFieldRefinementsAllowed(async () => {
-        validate(`(num >= 2n) and (num < 3n)`, [BigIntSegment.closedClosed(BigInt(2), BigInt(2))]);
-      }));
+      it('unbounded', () => {
+        validate(`(num != 0i)`, [BigIntSegment.closedOpen(-(BigInt(2)**BigInt(31)), BigInt(0)), BigIntSegment.openClosed(BigInt(0), (BigInt(2)**BigInt(31)) - BigInt(1))]);
+      });
+      it('with lower bound', () => {
+        validate(`(num > 0i)`, [BigIntSegment.openClosed(BigInt(0), (BigInt(2)**BigInt(31)) - BigInt(1))]);
+      });
+      it('with upper bound', () => {
+        validate(`(num < 0i)`, [BigIntSegment.closedOpen(-(BigInt(2)**BigInt(31)), BigInt(0))]);
+      });
+      it('with upper and lower bounds', () => {
+        validate(`(num >= 2i) and (num < 3i)`, [BigIntSegment.closedClosed(BigInt(2), BigInt(2))]);
+      });
     });
-    it('tests simple expression to range conversions using long', Flags.withFieldRefinementsAllowed(async () => {
+    it('tests simple expression to range conversions using long', () => {
       const validate = (refinement: string, segments: BigIntSegment[]) => {
         const typeData = {'num': `Long`};
         const manifestAst = parse(`
             particle Foo
-                input: reads Something {num: Long [ ${refinement} ]}
+                input: reads Something {num: Long} [ ${refinement} ]
         `);
-        let ref = Refinement.fromAst(manifestAst[0].args[0].type.fields[0].type.refinement, typeData);
-        let range = BigIntRange.fromExpression(ref.expression);
+        const ast = manifestAst[0].args[0].type.refinement;
+        const ref = Refinement.fromAst(ast, typeData);
+        const range = BigIntRange.fromExpression(ref.expression);
+        assert.deepEqual(range, new BigIntRange(segments, Primitive.LONG));
+      };
+      validate(`(num >= 2l) and (num < 3l)`, [BigIntSegment.closedClosed(BigInt(2), BigInt(2))]);
+      assert.throws(
+        () => validate(`(num >= 2i) and (num < 3i)`, []),
+        'Expected refinement expressions num and 2i to have the same types. Found types Long and Int'
+      );
+      assert.throws(
+        () => validate(`(num >= 2n) and (num < 3n)`, []),
+        'Expected refinement expressions num and 2n to have the same types. Found types Long and BigInt'
+      );
+    });
+    it('tests simple expression to range conversions using bigint 1', () => {
+      const validate = (refinement: string, segments: BigIntSegment[]) => {
+        const typeData = {'num': 'BigInt'};
+        const manifestAst = parse(`
+            particle Foo
+                input: reads Something {num: BigInt} [ ${refinement} ]
+        `);
+        const ref = Refinement.fromAst(manifestAst[0].args[0].type.refinement, typeData);
+        const range = BigIntRange.fromExpression(ref.expression);
         assert.deepEqual(range, new BigIntRange(segments));
       };
-      validate(`(num >= 2n) and (num < 3n)`, [BigIntSegment.closedClosed(BigInt(2), BigInt(2))]);
-    }));
-    it('tests simple expression to range conversions using bigint 1', Flags.withFieldRefinementsAllowed(async () => {
+      validate('num < 3n', [BigIntSegment.closedOpen('NEGATIVE_INFINITY', BigInt(3))]);
+      assert.throws(
+        () => validate(`(num >= 2i) and (num < 3i)`, []),
+        'Expected refinement expressions num and 2i to have the same types. Found types BigInt and Int'
+      );
+      assert.throws(
+        () => validate(`(num >= 2l) and (num < 3l)`, []),
+        'Expected refinement expressions num and 2l to have the same types. Found types BigInt and Long'
+      );
+    });
+    it('tests simple expression to range conversions using bigint 2', () => {
         const typeData = {'num': 'BigInt'};
         const manifestAst = parse(`
             particle Foo
-                input: reads Something {num: BigInt [ num < 3n ]}
+                input: reads Something {num: BigInt} [(num > 10n)]
         `);
-        const ref = Refinement.fromAst(manifestAst[0].args[0].type.fields[0].type.refinement, typeData);
-        const range = BigIntRange.fromExpression(ref.expression);
-        assert.deepEqual(range, new BigIntRange([BigIntSegment.closedOpen('NEGATIVE_INFINITY', BigInt(3))]));
-    }));
-    it('tests simple expression to range conversions using bigint 2', Flags.withFieldRefinementsAllowed(async () => {
-        const typeData = {'num': 'BigInt'};
-        const manifestAst = parse(`
-            particle Foo
-                input: reads Something {num: BigInt [(num > 10n)]}
-        `);
-        const ref = Refinement.fromAst(manifestAst[0].args[0].type.fields[0].type.refinement, typeData);
+        const ref = Refinement.fromAst(manifestAst[0].args[0].type.refinement, typeData);
         const range = BigIntRange.fromExpression(ref.expression);
         assert.deepEqual(range, new BigIntRange([BigIntSegment.openClosed(BigInt(10), 'POSITIVE_INFINITY')]));
-    }));
-    it('tests complement BigIntRange', Flags.withFieldRefinementsAllowed(async () => {
+    });
+    it('tests complement BigIntRange', () => {
       const ten = BigInt(10);
       const singleValue = new BigIntRange([BigIntSegment.closedClosed(ten, ten)]);
       assert.deepEqual(singleValue.segmentsForTesting(), [
@@ -241,58 +267,58 @@ describe('refiner', () => {
         {from: {val: 'NEGATIVE_INFINITY', isOpen: false}, to: {val: BigInt(9), isOpen: false}},
         {from: {val: BigInt(11), isOpen: false}, to: {val: 'POSITIVE_INFINITY', isOpen: false}},
       ]);
-    }));
-    it('tests simple expression to range conversions using bigint 3', Flags.withFieldRefinementsAllowed(async () => {
+    });
+    it('tests simple expression to range conversions using bigint 3', () => {
         const typeData = {'num': 'BigInt'};
         const manifestAst = parse(`
             particle Foo
-                input: reads Something {num: BigInt [not (num != 10n)]}
+                input: reads Something {num: BigInt} [not (num != 10n)]
         `);
-        const ref = Refinement.fromAst(manifestAst[0].args[0].type.fields[0].type.refinement, typeData);
+        const ref = Refinement.fromAst(manifestAst[0].args[0].type.refinement, typeData);
         const range = BigIntRange.fromExpression(ref.expression);
         assert.deepEqual(range, new BigIntRange([BigIntSegment.closedClosed(BigInt(10), BigInt(10))]));
-    }));
-    it('tests expression to range conversion 1', Flags.withFieldRefinementsAllowed(async () => {
+    });
+    it('tests expression to range conversion 1', () => {
         const typeData = {'num': 'Number'};
         const manifestAst = parse(`
             particle Foo
-                input: reads Something {num: Number [ (num < 3) and (num > 0) ]}
+                input: reads Something {num: Number} [ (num < 3) and (num > 0) ]
         `);
-        const ref = Refinement.fromAst(manifestAst[0].args[0].type.fields[0].type.refinement, typeData);
+        const ref = Refinement.fromAst(manifestAst[0].args[0].type.refinement, typeData);
         const range = NumberRange.fromExpression(ref.expression);
         assert.deepEqual(range, new NumberRange([NumberSegment.openOpen(0, 3)]));
-    }));
-    it('tests expression to range conversion 2', Flags.withFieldRefinementsAllowed(async () => {
+    });
+    it('tests expression to range conversion 2', () => {
         const typeData = {'num': 'Number'};
         const manifestAst = parse(`
             particle Foo
-                input: reads Something {num: Number [ ((num < 3) and (num > 0)) or (num == 5) ]}
+                input: reads Something {num: Number} [ ((num < 3) and (num > 0)) or (num == 5) ]
         `);
-        const ref = Refinement.fromAst(manifestAst[0].args[0].type.fields[0].type.refinement, typeData);
+        const ref = Refinement.fromAst(manifestAst[0].args[0].type.refinement, typeData);
         const range = NumberRange.fromExpression(ref.expression);
         assert.deepEqual(range, new NumberRange([NumberSegment.openOpen(0, 3), NumberSegment.closedClosed(5, 5)]));
-    }));
-    it('tests expression to range conversion 3', Flags.withFieldRefinementsAllowed(async () => {
+    });
+    it('tests expression to range conversion 3', () => {
         const typeData = {'num': 'Number'};
         const manifestAst = parse(`
             particle Foo
-                input: reads Something {num: Number [(num > 10) == (num >= 20)]}
+                input: reads Something {num: Number} [(num > 10) == (num >= 20)]
         `);
-        const ref = Refinement.fromAst(manifestAst[0].args[0].type.fields[0].type.refinement, typeData);
+        const ref = Refinement.fromAst(manifestAst[0].args[0].type.refinement, typeData);
         const range = NumberRange.fromExpression(ref.expression);
         assert.deepEqual(range, new NumberRange([NumberSegment.closedClosed(Number.NEGATIVE_INFINITY, 10), NumberSegment.closedClosed(20, Number.POSITIVE_INFINITY)]));
-    }));
-    it('tests expression to range conversion 4', Flags.withFieldRefinementsAllowed(async () => {
+    });
+    it('tests expression to range conversion 4', () => {
         const typeData = {'num': 'Number'};
         const manifestAst = parse(`
             particle Foo
-                input: reads Something {num: Number [not (num != 10)]}
+                input: reads Something {num: Number} [not (num != 10)]
         `);
-        const ref = Refinement.fromAst(manifestAst[0].args[0].type.fields[0].type.refinement, typeData);
+        const ref = Refinement.fromAst(manifestAst[0].args[0].type.refinement, typeData);
         const range = NumberRange.fromExpression(ref.expression);
         assert.deepEqual(range, new NumberRange([NumberSegment.closedClosed(10, 10)]));
 
-    }));
+    });
     it('regression test for parse failure on operator ordering', () => {
       parse(`
       particle Foo
@@ -300,7 +326,7 @@ describe('refiner', () => {
       `);
   });
 
-  describe('refiner enforcement', () => {
+  describe('refiner enforcement', async () => {
       let schema: Schema;
       let entityClass: EntityClass;
       let exceptions: Error[] = [];
@@ -338,18 +364,18 @@ describe('refiner', () => {
   });
 
   describe('dynamic refinements', () => {
-      describe('Parses and type checks a particle with dynamic refinements', Flags.withFieldRefinementsAllowed(async () => {
+      describe('Parses and type checks a particle with dynamic refinements', async () => {
           let ref: Refinement;
-          before(Flags.withFieldRefinementsAllowed(async () => {
+          before(() => {
             const manifestAst = parse(`
               particle AddressBook
-                contacts: reads [Contact {name: Text [ name == ? ]}]
+                contacts: reads [Contact {name: Text} [ name == ? ]]
             `);
             const typeData = {'name': 'Text'};
             const contacts = manifestAst[0].args[0];
-            const nameType = contacts.type.type.fields[0].type;
+            const nameType = contacts.type.type;
             ref = Refinement.fromAst(nameType.refinement, typeData);
-          }));
+          });
           it('field names, query argument names and query argument types', () => {
             assert.deepEqual(JSON.stringify([...ref.expression.getFieldParams()]), '[["name","Text"]]', 'should infer indexes from refinement');
             assert.deepEqual(JSON.stringify([...ref.expression.getQueryParams()]), '[["?","Text"]]', 'should infer query args from refinement');
@@ -372,10 +398,10 @@ describe('refiner', () => {
             };
             assert.isFalse(ref.validateData(dataWithQuery), 'Data is not valid');
           });
-      }));
+      });
       describe('Parses and type checks a particle with dynamic and static refinements', () => {
           let ref: Refinement;
-          before(Flags.withFieldRefinementsAllowed(async () => {
+          before(() => {
             const manifestAst = parse(`
               particle AddressBook
                 contacts: reads [Contact {name: Text, age: Number} [ name == ?  and age > 10]]
@@ -383,7 +409,7 @@ describe('refiner', () => {
             const typeData = {'name': 'Text', 'age': 'Number'};
             const contacts = manifestAst[0].args[0];
             ref = Refinement.fromAst(contacts.type.type.refinement, typeData);
-          }));
+          });
           it('field names, query argument names and query argument types', () => {
             assert.deepEqual(JSON.stringify([...ref.expression.getFieldParams()]), '[["name","Text"],["age","Number"]]', 'should infer indexes from refinement');
             assert.deepEqual(JSON.stringify([...ref.expression.getQueryParams()]), '[["?","Text"]]', 'should infer query args from refinement');
@@ -427,240 +453,241 @@ describe('refiner', () => {
   });
 
   describe('normalisation', () => {
-    it('tests if field name is rearranged to left in a binary node', Flags.withFieldRefinementsAllowed(async () => {
+    it('tests if field name is rearranged to left in a binary node', () => {
         const manifestAst1 = parse(`
             particle Foo
-                input: reads Something {num: Number [ (10+2) > num ]}
+                input: reads Something {num: Number} [ (10+2) > num ]
         `);
         const typeData = {'num': 'Number'};
-        const ref1 = Refinement.fromAst(manifestAst1[0].args[0].type.fields[0].type.refinement, typeData);
+        const ref1 = Refinement.fromAst(manifestAst1[0].args[0].type.refinement, typeData);
         ref1.normalize();
         const manifestAst2 = parse(`
             particle Foo
-                input: reads Something {num: Number [ num < 12 ]}
+                input: reads Something {num: Number} [ num < 12 ]
         `);
-        const ref2 = Refinement.fromAst(manifestAst2[0].args[0].type.fields[0].type.refinement, typeData);
+        const ref2 = Refinement.fromAst(manifestAst2[0].args[0].type.refinement, typeData);
         // normalized version of ref1 should be the same as ref2
         assert.strictEqual(ref1.toString(), ref2.toString());
-    }));
-    it('tests if primitive boolean expressions are automatically evaluated', Flags.withFieldRefinementsAllowed(async () => {
+    });
+    it('tests if primitive boolean expressions are automatically evaluated', () => {
         const manifestAst1 = parse(`
             particle Foo
-                input: reads Something {num: Boolean [ num == not (true or false) ]}
+                input: reads Something {num: Boolean} [ num == not (true or false) ]
         `);
         const typeData = {'num': 'Boolean'};
-        const ref1 = Refinement.fromAst(manifestAst1[0].args[0].type.fields[0].type.refinement, typeData);
+        const ref1 = Refinement.fromAst(manifestAst1[0].args[0].type.refinement, typeData);
         ref1.normalize();
         const manifestAst2 = parse(`
             particle Foo
-                input: reads Something {num: Boolean [ not num ]}
+                input: reads Something {num: Boolean} [ not num ]
         `);
-        const ref2 = Refinement.fromAst(manifestAst2[0].args[0].type.fields[0].type.refinement, typeData);
+        const ref2 = Refinement.fromAst(manifestAst2[0].args[0].type.refinement, typeData);
         // normalized version of ref1 should be the same as ref2
         assert.strictEqual(ref1.toString(), ref2.toString());
-    }));
-    it('tests if primitive math expressions are automatically evaluated', Flags.withFieldRefinementsAllowed(async () => {
+    });
+    it('tests if primitive math expressions are automatically evaluated', () => {
         const manifestAst1 = parse(`
             particle Foo
-                input: reads Something {num: Number [ (2+11-9) > num or False ]}
+                input: reads Something {num: Number} [ (2+11-9) > num or False ]
         `);
+        viewAst(manifestAst1);
         const typeData = {'num': 'Number'};
-        const ref1 = Refinement.fromAst(manifestAst1[0].args[0].type.fields[0].type.refinement, typeData);
+        const ref1 = Refinement.fromAst(manifestAst1[0].args[0].type.refinement, typeData);
         ref1.normalize();
         const manifestAst2 = parse(`
             particle Foo
-                input: reads Something {num: Number [ num < 4 ]}
+                input: reads Something {num: Number} [ num < 4 ]
         `);
-        const ref2 = Refinement.fromAst(manifestAst2[0].args[0].type.fields[0].type.refinement, typeData);
+        const ref2 = Refinement.fromAst(manifestAst2[0].args[0].type.refinement, typeData);
         // normalized version of ref1 should be the same as ref2
         assert.strictEqual(ref1.toString(), ref2.toString());
-    }));
-    it(`tests if multiple 'not's are cancelled. `, Flags.withFieldRefinementsAllowed(async () => {
+    });
+    it(`tests if multiple 'not's are cancelled. `, () => {
         const manifestAst1 = parse(`
             particle Foo
-                input: reads Something {num: Boolean [ not (not num) ]}
+                input: reads Something {num: Boolean} [ not (not num) ]
         `);
         const typeData = {'num': 'Boolean'};
-        const ref1 = Refinement.fromAst(manifestAst1[0].args[0].type.fields[0].type.refinement, typeData);
+        const ref1 = Refinement.fromAst(manifestAst1[0].args[0].type.refinement, typeData);
         ref1.normalize();
         const manifestAst2 = parse(`
             particle Foo
-                input: reads Something {num: Boolean [ num ]}
+                input: reads Something {num: Boolean} [ num ]
         `);
-        const ref2 = Refinement.fromAst(manifestAst2[0].args[0].type.fields[0].type.refinement, typeData);
+        const ref2 = Refinement.fromAst(manifestAst2[0].args[0].type.refinement, typeData);
         // normalized version of ref1 should be the same as ref2
         assert.strictEqual(ref1.toString(), ref2.toString());
-    }));
-    it(`tests if expressions are rearranged 0`, Flags.withFieldRefinementsAllowed(async () => {
+    });
+    it(`tests if expressions are rearranged 0`, () => {
       const manifestAst1 = parse(`
           particle Foo
-              input: reads Something {num: Number [ (num + 5) <= 0 ]}
+              input: reads Something {num: Number} [ (num + 5) <= 0 ]
       `);
       const typeData = {'num': 'Number'};
-      const ref1 = Refinement.fromAst(manifestAst1[0].args[0].type.fields[0].type.refinement, typeData);
+      const ref1 = Refinement.fromAst(manifestAst1[0].args[0].type.refinement, typeData);
       ref1.normalize();
       const manifestAst2 = parse(`
           particle Foo
-              input: reads Something {num: Number [ num <= -5 ]}
+              input: reads Something {num: Number} [ num <= -5 ]
       `);
-      const ref2 = Refinement.fromAst(manifestAst2[0].args[0].type.fields[0].type.refinement, typeData);
+      const ref2 = Refinement.fromAst(manifestAst2[0].args[0].type.refinement, typeData);
       ref2.normalize();
       // normalized version of ref1 should be the same as ref2
       assert.strictEqual(ref1.toString(), ref2.toString());
       assert.deepEqual(ref1, ref2);
-    }));
-    it(`tests if expressions are rearranged 1`, Flags.withFieldRefinementsAllowed(async () => {
+    });
+    it(`tests if expressions are rearranged 1`, () => {
       const manifestAst1 = parse(`
           particle Foo
-              input: reads Something {num: Number [ num <= -5 ]}
+              input: reads Something {num: Number} [ num <= -5 ]
       `);
       const typeData = {'num': 'Number'};
-      const ref1 = Refinement.fromAst(manifestAst1[0].args[0].type.fields[0].type.refinement, typeData);
+      const ref1 = Refinement.fromAst(manifestAst1[0].args[0].type.refinement, typeData);
       ref1.normalize();
       const manifestAst2 = parse(`
           particle Foo
-              input: reads Something {num: Number [ -5 >= num ]}
+              input: reads Something {num: Number} [ -5 >= num ]
       `);
-      const ref2 = Refinement.fromAst(manifestAst2[0].args[0].type.fields[0].type.refinement, typeData);
+      const ref2 = Refinement.fromAst(manifestAst2[0].args[0].type.refinement, typeData);
       ref2.normalize();
       // normalized version of ref1 should be the same as ref2
       assert.strictEqual(ref1.toString(), ref2.toString());
       assert.deepEqual(ref1, ref2);
-    }));
-    it(`tests if expressions are rearranged 2`, Flags.withFieldRefinementsAllowed(async () => {
+    });
+    it(`tests if expressions are rearranged 2`, async () => {
       const manifestAst1 = parse(`
           particle Foo
-              input: reads Something {num: Number [ (num + 5) <= (2*num - 11) ]}
+              input: reads Something {num: Number} [ (num + 5) <= (2*num - 11) ]
       `);
       const typeData = {'num': 'Number'};
-      const ref1 = Refinement.fromAst(manifestAst1[0].args[0].type.fields[0].type.refinement, typeData);
+      const ref1 = Refinement.fromAst(manifestAst1[0].args[0].type.refinement, typeData);
       ref1.normalize();
       const manifestAst2 = parse(`
           particle Foo
-              input: reads Something {num: Number [ num > 16 or num == 16]}
+              input: reads Something {num: Number} [ num > 16 or num == 16]
       `);
-      const ref2 = Refinement.fromAst(manifestAst2[0].args[0].type.fields[0].type.refinement, typeData);
+      const ref2 = Refinement.fromAst(manifestAst2[0].args[0].type.refinement, typeData);
       // normalized version of ref1 should be the same as ref2
       assert.strictEqual(ref1.toString(), ref2.toString());
       assert.deepEqual(ref1, ref2);
-    }));
-    it(`tests if expressions are rearranged 3`, Flags.withFieldRefinementsAllowed(async () => {
+    });
+    it(`tests if expressions are rearranged 3`, async () => {
       const manifestAst1 = parse(`
           particle Foo
-              input: reads Something {num: Number [ (num - 5)/(num - 2) <= 0 ]}
+              input: reads Something {num: Number} [ (num - 5)/(num - 2) <= 0 ]
       `);
       const typeData = {'num': 'Number'};
-      const ref1 = Refinement.fromAst(manifestAst1[0].args[0].type.fields[0].type.refinement, typeData);
+      const ref1 = Refinement.fromAst(manifestAst1[0].args[0].type.refinement, typeData);
       ref1.normalize();
       const manifestAst2 = parse(`
           particle Foo
-              input: reads Something {num: Number [ ((num > 5 and num < 2) or (num < 5 and num > 2)) or (num == 5 and num != 2) ]}
+              input: reads Something {num: Number} [ ((num > 5 and num < 2) or (num < 5 and num > 2)) or (num == 5 and num != 2) ]
       `);
-      const ref2 = Refinement.fromAst(manifestAst2[0].args[0].type.fields[0].type.refinement, typeData);
+      const ref2 = Refinement.fromAst(manifestAst2[0].args[0].type.refinement, typeData);
       ref2.normalize();
       // normalized version of ref1 should be the same as ref2
       assert.strictEqual(ref1.toString(), ref2.toString());
-    }));
-    it(`tests if expressions are rearranged 4`, Flags.withFieldRefinementsAllowed(async () => {
+    });
+    it(`tests if expressions are rearranged 4`, () => {
       const manifestAst1 = parse(`
           particle Foo
-              input: reads Something {num: Number [ (num+2)*(num+1)+3 > 6 ]}
+              input: reads Something {num: Number} [ (num+2)*(num+1)+3 > 6 ]
       `);
       const typeData = {'num': 'Number'};
-      const ref1 = Refinement.fromAst(manifestAst1[0].args[0].type.fields[0].type.refinement, typeData);
+      const ref1 = Refinement.fromAst(manifestAst1[0].args[0].type.refinement, typeData);
       ref1.normalize();
       const manifestAst2 = parse(`
           particle Foo
-              input: reads Something {num: Number [ num*3 + num*num > 1 ]}
+              input: reads Something {num: Number} [ num*3 + num*num > 1 ]
       `);
-      const ref2 = Refinement.fromAst(manifestAst2[0].args[0].type.fields[0].type.refinement, typeData);
+      const ref2 = Refinement.fromAst(manifestAst2[0].args[0].type.refinement, typeData);
       ref2.normalize();
       // normalized version of ref1 should be the same as ref2
       assert.strictEqual(ref1.toString(), ref2.toString());
-    }));
-    it(`tests if expressions are rearranged 5`, Flags.withFieldRefinementsAllowed(async () => {
+    });
+    it(`tests if expressions are rearranged 5`, () => {
       const manifestAst1 = parse(`
           particle Foo
-              input: reads Something {num: Number [ num == 3 ]}
+              input: reads Something {num: Number} [ num == 3 ]
       `);
       const typeData = {'num': 'Number'};
-      const ref1 = Refinement.fromAst(manifestAst1[0].args[0].type.fields[0].type.refinement, typeData);
+      const ref1 = Refinement.fromAst(manifestAst1[0].args[0].type.refinement, typeData);
 
       Normalizer.rearrangeNumericalExpression(ref1.expression as BinaryExpression);
       assert.strictEqual(ref1.toString(), '[(num == 3)]');
-    }));
-    it(`tests if expressions are rearranged 4.0`, Flags.withFieldRefinementsAllowed(async () => {
+    });
+    it(`tests if expressions are rearranged 4.0`, () => {
       const manifestAst1 = parse(`
           particle Foo
-              input: reads Something {num: Number [ 3 == num ]}
+              input: reads Something {num: Number} [ 3 == num ]
       `);
       const typeData = {'num': 'Number'};
-      const ref1 = Refinement.fromAst(manifestAst1[0].args[0].type.fields[0].type.refinement, typeData);
+      const ref1 = Refinement.fromAst(manifestAst1[0].args[0].type.refinement, typeData);
 
       Normalizer.rearrangeNumericalExpression(ref1.expression as BinaryExpression);
       assert.strictEqual(ref1.toString(), '[(num == 3)]');
-    }));
-    it(`tests if expressions are rearranged 4.1`, Flags.withFieldRefinementsAllowed(async () => {
+    });
+    it(`tests if expressions are rearranged 4.1`, () => {
       const manifestAst1 = parse(`
           particle Foo
-              input: reads Something {num: Number [ 2 == (num-1) ]}
+              input: reads Something {num: Number} [ 2 == (num-1) ]
       `);
       const typeData = {'num': 'Number'};
-      const ref1 = Refinement.fromAst(manifestAst1[0].args[0].type.fields[0].type.refinement, typeData);
+      const ref1 = Refinement.fromAst(manifestAst1[0].args[0].type.refinement, typeData);
 
       Normalizer.rearrangeNumericalExpression(ref1.expression as BinaryExpression);
       assert.strictEqual(ref1.toString(), '[(num == 3)]');
-    }));
-    it(`tests if expressions are rearranged 4.2`, Flags.withFieldRefinementsAllowed(async () => {
+    });
+    it(`tests if expressions are rearranged 4.2`, () => {
       const manifestAst1 = parse(`
           particle Foo
-              input: reads Something {num: Number [ (num+2) == (2*num-1) ]}
+              input: reads Something {num: Number} [ (num+2) == (2*num-1) ]
       `);
       const typeData = {'num': 'Number'};
-      const ref1 = Refinement.fromAst(manifestAst1[0].args[0].type.fields[0].type.refinement, typeData);
+      const ref1 = Refinement.fromAst(manifestAst1[0].args[0].type.refinement, typeData);
 
       Normalizer.rearrangeNumericalExpression(ref1.expression as BinaryExpression);
       assert.strictEqual(ref1.toString(), '[(num == 3)]');
-    }));
-    it(`tests if expressions are rearranged 4.3`, Flags.withFieldRefinementsAllowed(async () => {
+    });
+    it(`tests if expressions are rearranged 4.3`, () => {
       const manifestAst1 = parse(`
           particle Foo
-              input: reads Something {num: Number [ ((num+2)/(2*num-1)) == 1 ]}
+              input: reads Something {num: Number} [ ((num+2)/(2*num-1)) == 1 ]
       `);
       const typeData = {'num': 'Number'};
-      const ref1 = Refinement.fromAst(manifestAst1[0].args[0].type.fields[0].type.refinement, typeData);
+      const ref1 = Refinement.fromAst(manifestAst1[0].args[0].type.refinement, typeData);
 
       Normalizer.rearrangeNumericalExpression(ref1.expression as BinaryExpression);
       assert.strictEqual(ref1.toString(), '[((num == 3) and (num != 0.5))]');
-    }));
-    it(`tests if expressions are rearranged 4.4`, Flags.withFieldRefinementsAllowed(async () => {
+    });
+    it(`tests if expressions are rearranged 4.4`, () => {
       const manifestAst1 = parse(`
           particle Foo
-              input: reads Something {num: Number [ ((num+2)/(2*num-1))+3 == 4 ]}
+              input: reads Something {num: Number} [ ((num+2)/(2*num-1))+3 == 4 ]
       `);
       const typeData = {'num': 'Number'};
-      const ref1 = Refinement.fromAst(manifestAst1[0].args[0].type.fields[0].type.refinement, typeData);
+      const ref1 = Refinement.fromAst(manifestAst1[0].args[0].type.refinement, typeData);
 
       Normalizer.rearrangeNumericalExpression(ref1.expression as BinaryExpression);
       assert.strictEqual(ref1.toString(), '[((num == 3) and (num != 0.5))]');
-    }));
-    it(`tests if expressions are rearranged 4.5`, Flags.withFieldRefinementsAllowed(async () => {
+    });
+    it(`tests if expressions are rearranged 4.5`, () => {
       const manifestAst1 = parse(`
           particle Foo
-              input: reads Something {num: Number [ ((num+2)/(2*num-1))+3 == 4 ]}
+              input: reads Something {num: Number} [ ((num+2)/(2*num-1))+3 == 4 ]
       `);
       const typeData = {'num': 'Number'};
-      const ref1 = Refinement.fromAst(manifestAst1[0].args[0].type.fields[0].type.refinement, typeData);
+      const ref1 = Refinement.fromAst(manifestAst1[0].args[0].type.refinement, typeData);
 
       ref1.normalize();
       const manifestAst2 = parse(`
           particle Foo
-              input: reads Something {num: Number [ num == 3 and num != 0.5 ]}
+              input: reads Something {num: Number} [ num == 3 and num != 0.5 ]
       `);
-      const ref2 = Refinement.fromAst(manifestAst2[0].args[0].type.fields[0].type.refinement, typeData);
+      const ref2 = Refinement.fromAst(manifestAst2[0].args[0].type.refinement, typeData);
       // normalized version of ref1 should be the same as ref2
       assert.strictEqual(ref1.toString(), ref2.toString());
-    }));
+    });
     it(`tests if expressions are rearranged 5`, () => {
       const manifestAst1 = parse(`
           particle Foo
@@ -781,7 +808,7 @@ describe('refiner', () => {
           triviallyTrue('1n day != 24n hours + 1n second');
         });
         it('handles simple linear solving', () => {
-          triviallyTrue('num + 1n milliseconds > num', 'BigInt');
+          triviallyTrue('(num + 1n milliseconds) > num', 'BigInt');
         });
         it.skip('handles simple polynomial solving', () => {
           triviallyTrue('num >= 0n or num <= 0n', 'BigInt');
@@ -1352,7 +1379,7 @@ describe('refiner', () => {
       const den1 = new BigIntMultinomial({
         [a.toKey()]: BigInt(2),                     // 2a
       }); // 2a
-      const frac1 = new BigIntFraction(num1, den1); // (a^2+a+9)/2a
+      const frac1 = new BigIntFraction(num1, den1, Primitive.BIGINT); // (a^2+a+9)/2a
       const num2 = new BigIntMultinomial({
         [a.toKey()]: BigInt(1),                     // a
         [cnst.toKey()]: BigInt(5)                   // 5
@@ -1360,7 +1387,7 @@ describe('refiner', () => {
       const den2 = new BigIntMultinomial({
         [cnst.toKey()]: BigInt(3)                   // 3
       }); // 3
-      const frac2 = new BigIntFraction(num2, den2); // (a+5)/3
+      const frac2 = new BigIntFraction(num2, den2, Primitive.BIGINT); // (a+5)/3
       const sum = BigIntFraction.add(frac1, frac2); // (5a^2+13a+27)/6a
       assert.deepEqual(sum.num.terms, {
         [a2.toKey()]: BigInt(5),                    // 5a^2
@@ -1375,14 +1402,14 @@ describe('refiner', () => {
       const num1 = new BigIntMultinomial({
         [a.toKey()]: BigInt(1),                     // a
       }); // a
-      const frac1 = new BigIntFraction(num1);           // a/1
+      const frac1 = BigIntFraction.onOne(num1, Primitive.BIGINT);           // a/1
       const num2 = new BigIntMultinomial({
         [cnst.toKey()]: BigInt(5)                   // 5
       }); // 5
       const den2 = new BigIntMultinomial({
         [cnst.toKey()]: BigInt(9)                   // 9
       }); // 9
-      const frac2 = new BigIntFraction(num2, den2);     // 5/9
+      const frac2 = new BigIntFraction(num2, den2, Primitive.BIGINT);     // 5/9
       const sum = BigIntFraction.add(frac1, frac2);     // (9a+5)/9
       assert.deepEqual(sum.num.terms, {
         [a.toKey()]: BigInt(9),                     // 9a
@@ -1401,7 +1428,7 @@ describe('refiner', () => {
       const den1 = new BigIntMultinomial({
         [a.toKey()]: BigInt(2),                             // 2a
       }); // 2a
-      const frac1 = new BigIntFraction(num1, den1);       // (a^2+a+9)/2a
+      const frac1 = new BigIntFraction(num1, den1, Primitive.BIGINT);       // (a^2+a+9)/2a
       const num2 = new BigIntMultinomial({
         [a.toKey()]: BigInt(1),                             // a
         [cnst.toKey()]: BigInt(5)                           // 5
@@ -1409,7 +1436,7 @@ describe('refiner', () => {
       const den2 = new BigIntMultinomial({
         [cnst.toKey()]: BigInt(3)                           // 3
       }); // 3
-      const frac2 = new BigIntFraction(num2, den2);       // (a+5)/3
+      const frac2 = new BigIntFraction(num2, den2, Primitive.BIGINT);       // (a+5)/3
       const sum = BigIntFraction.subtract(frac1, frac2);  // (a^2-7a+27)/6a
       assert.deepEqual(sum.num.terms, {
         [a2.toKey()]: BigInt(1),                            // a^2
@@ -1429,7 +1456,7 @@ describe('refiner', () => {
       const den1 = new BigIntMultinomial({
         [a.toKey()]: BigInt(2),                             // 2a
       }); // 2a
-      const frac1 = new BigIntFraction(num1, den1);       // (a^2+a+9)/2a
+      const frac1 = new BigIntFraction(num1, den1, Primitive.BIGINT);       // (a^2+a+9)/2a
       const neg = BigIntFraction.negate(frac1);           // (-a^2-a+-9)/2a
       assert.deepEqual(neg.num.terms, {
           [a2.toKey()]: -BigInt(1),                         // a^2
@@ -1441,14 +1468,14 @@ describe('refiner', () => {
       });
     });
     it('tests fraction multiplication works', () => {
-      let num1 = new BigIntMultinomial({
+      const num1 = new BigIntMultinomial({
           [a.toKey()]: BigInt(1),                           // a
           [cnst.toKey()]: BigInt(9)                         // 9
       }); // a + 9
       const den1 = new BigIntMultinomial({
         [a.toKey()]: BigInt(2),                             // 2a
       }); // 2a
-      let frac1 = new BigIntFraction(num1, den1);         // (a+9)/2a
+      const frac1 = new BigIntFraction(num1, den1, Primitive.BIGINT);         // (a+9)/2a
       const num2 = new BigIntMultinomial({
         [a.toKey()]: BigInt(1),                             // a
         [cnst.toKey()]: BigInt(5)                           // 5
@@ -1456,8 +1483,8 @@ describe('refiner', () => {
       const den2 = new BigIntMultinomial({
         [cnst.toKey()]: BigInt(3)                           // 9
       }); // a + 9
-      let frac2 = new BigIntFraction(num2, den2);         // (a+5)/3
-      let sum = BigIntFraction.multiply(frac1, frac2);    // (a^2+14a+45)/6a
+      const frac2 = new BigIntFraction(num2, den2, Primitive.BIGINT);         // (a+5)/3
+      const sum = BigIntFraction.multiply(frac1, frac2);    // (a^2+14a+45)/6a
       assert.deepEqual(sum.num.terms, {
         [a2.toKey()]: BigInt(1),                            // a^2
         [a.toKey()]: BigInt(14),                            // 14a
@@ -1466,15 +1493,15 @@ describe('refiner', () => {
       assert.deepEqual(sum.den.terms, {
         [a.toKey()]: BigInt(6),                             // 14a
       });
-      num1 = new BigIntMultinomial({
+      const num3 = new BigIntMultinomial({
         [a2.toKey()]: BigInt(1),                            // a^2
         [a.toKey()]: BigInt(1),                             // a
       });
-      frac1 = new BigIntFraction(num1);                   // (a^2+a)/1
-      frac2 = new BigIntFraction();                       // 0 / 1
-      sum = BigIntFraction.multiply(frac1, frac2);        // 0/1
-      assert.deepEqual(sum.num.terms, {});
-      assert.deepEqual(sum.den.terms, {
+      const frac3 = BigIntFraction.onOne(num3, Primitive.BIGINT);                   // (a^2+a)/1
+      const frac4 = BigIntFraction.onOne(new BigIntMultinomial(), Primitive.BIGINT);                       // 0 / 1
+      const sum2 = BigIntFraction.multiply(frac3, frac4);        // 0/1
+      assert.deepEqual(sum2.num.terms, {});
+      assert.deepEqual(sum2.den.terms, {
         [cnst.toKey()]: BigInt(1)                           // 1
       });
     });
@@ -1486,7 +1513,7 @@ describe('refiner', () => {
       const den1 = new BigIntMultinomial({
         [a.toKey()]: BigInt(2),                             // 2a
       }); // 2a
-      const frac1 = new BigIntFraction(num1, den1);       // (a+9)/2a
+      const frac1 = new BigIntFraction(num1, den1, Primitive.BIGINT);       // (a+9)/2a
       const num2 = new BigIntMultinomial({
         [a.toKey()]: BigInt(1),                             // a
         [cnst.toKey()]: BigInt(5)                           // 5
@@ -1494,7 +1521,7 @@ describe('refiner', () => {
       const den2 = new BigIntMultinomial({
         [cnst.toKey()]: BigInt(3)                           // 9
       }); // a + 9
-      const frac2 = new BigIntFraction(num2, den2);       // (a+5)/3
+      const frac2 = new BigIntFraction(num2, den2, Primitive.BIGINT);       // (a+5)/3
       const sum = BigIntFraction.divide(frac1, frac2);    // (3a+27)/(2a^2+10a)
       assert.deepEqual(sum.num.terms, {
         [a.toKey()]: BigInt(3),                             // 3a

--- a/src/tools/tests/golden_kt.arcs
+++ b/src/tools/tests/golden_kt.arcs
@@ -13,8 +13,8 @@ particle KotlinPrimitivesGolden
     ref: &{val: Text},
     bt: Byte,
     shrt: Short,
-    nt: Int,
-    lng: Long,
+    integer: Int,
+    long_val: Long,
     big: BigInt,
     chr: Char,
     flt: Float,
@@ -40,4 +40,4 @@ particle KotlinPrimitivesGolden
       price: Float,
       stock: Int
     }>
-  } [(2n * big + 3n > 5n) and (5i*nt + 10i*nt > 30i) and (10l*lng >= 100000l and 10l*lng < 1000000l) and (num < 1000)]
+  } [(2n * big + 3n > 5n) and (5i*integer + 10i*integer > 30i) and (10l*long_val >= 100000l and 10l*long_val < 1000000l) and (num < 1000)]

--- a/src/tools/tests/golden_kt.arcs
+++ b/src/tools/tests/golden_kt.arcs
@@ -40,4 +40,4 @@ particle KotlinPrimitivesGolden
       price: Float,
       stock: Int
     }>
-  } [(2n * big + 3n > 5n) and (5n*nt + 10n*nt > 30n) and (lng >= 100000n and lng < 1000000n) and (num < 1000)]
+  } [(2n * big + 3n > 5n) and (5i*nt + 10i*nt > 30i) and (10l*lng >= 100000l and 10l*lng < 1000000l) and (num < 1000)]

--- a/src/tools/tests/golden_kt.arcs
+++ b/src/tools/tests/golden_kt.arcs
@@ -40,4 +40,4 @@ particle KotlinPrimitivesGolden
       price: Float,
       stock: Int
     }>
-  } [(2n * big + 3n > 5n) and (num < 1000)]
+  } [(2n * big + 3n > 5n) and (5n*nt + 10n*nt > 30n) and (lng >= 100000n and lng < 1000000n) and (num < 1000)]

--- a/src/tools/tests/goldens/kt_generated-schemas.jvm.kt
+++ b/src/tools/tests/goldens/kt_generated-schemas.jvm.kt
@@ -451,8 +451,8 @@ abstract class AbstractKotlinPrimitivesGolden : arcs.sdk.BaseParticle() {
         ref: arcs.sdk.Reference<KotlinPrimitivesGolden_Data_Ref>? = null,
         bt: Byte = 0.toByte(),
         shrt: Short = 0.toShort(),
-        nt: Int = 0,
-        lng: Long = 0L,
+        integer: Int = 0,
+        long_val: Long = 0L,
         big: BigInteger = BigInteger.ZERO,
         chr: Char = '\u0000',
         flt: Float = 0.0f,
@@ -496,12 +496,12 @@ abstract class AbstractKotlinPrimitivesGolden : arcs.sdk.BaseParticle() {
         var shrt: Short
             get() = super.getSingletonValue("shrt") as Short? ?: 0.toShort()
             private set(_value) = super.setSingletonValue("shrt", _value)
-        var nt: Int
-            get() = super.getSingletonValue("nt") as Int? ?: 0
-            private set(_value) = super.setSingletonValue("nt", _value)
-        var lng: Long
-            get() = super.getSingletonValue("lng") as Long? ?: 0L
-            private set(_value) = super.setSingletonValue("lng", _value)
+        var integer: Int
+            get() = super.getSingletonValue("integer") as Int? ?: 0
+            private set(_value) = super.setSingletonValue("integer", _value)
+        var long_val: Long
+            get() = super.getSingletonValue("long_val") as Long? ?: 0L
+            private set(_value) = super.setSingletonValue("long_val", _value)
         var big: BigInteger
             get() = super.getSingletonValue("big") as BigInteger? ?: BigInteger.ZERO
             private set(_value) = super.setSingletonValue("big", _value)
@@ -541,8 +541,8 @@ abstract class AbstractKotlinPrimitivesGolden : arcs.sdk.BaseParticle() {
             this.ref = ref
             this.bt = bt
             this.shrt = shrt
-            this.nt = nt
-            this.lng = lng
+            this.integer = integer
+            this.long_val = long_val
             this.big = big
             this.chr = chr
             this.flt = flt
@@ -567,8 +567,8 @@ abstract class AbstractKotlinPrimitivesGolden : arcs.sdk.BaseParticle() {
             ref: arcs.sdk.Reference<KotlinPrimitivesGolden_Data_Ref>? = this.ref,
             bt: Byte = this.bt,
             shrt: Short = this.shrt,
-            nt: Int = this.nt,
-            lng: Long = this.lng,
+            integer: Int = this.integer,
+            long_val: Long = this.long_val,
             big: BigInteger = this.big,
             chr: Char = this.chr,
             flt: Float = this.flt,
@@ -587,8 +587,8 @@ abstract class AbstractKotlinPrimitivesGolden : arcs.sdk.BaseParticle() {
             ref = ref,
             bt = bt,
             shrt = shrt,
-            nt = nt,
-            lng = lng,
+            integer = integer,
+            long_val = long_val,
             big = big,
             chr = chr,
             flt = flt,
@@ -613,8 +613,8 @@ abstract class AbstractKotlinPrimitivesGolden : arcs.sdk.BaseParticle() {
             ref: arcs.sdk.Reference<KotlinPrimitivesGolden_Data_Ref>? = this.ref,
             bt: Byte = this.bt,
             shrt: Short = this.shrt,
-            nt: Int = this.nt,
-            lng: Long = this.lng,
+            integer: Int = this.integer,
+            long_val: Long = this.long_val,
             big: BigInteger = this.big,
             chr: Char = this.chr,
             flt: Float = this.flt,
@@ -633,8 +633,8 @@ abstract class AbstractKotlinPrimitivesGolden : arcs.sdk.BaseParticle() {
             ref = ref,
             bt = bt,
             shrt = shrt,
-            nt = nt,
-            lng = lng,
+            integer = integer,
+            long_val = long_val,
             big = big,
             chr = chr,
             flt = flt,
@@ -663,8 +663,8 @@ abstract class AbstractKotlinPrimitivesGolden : arcs.sdk.BaseParticle() {
                         "ref" to arcs.core.data.FieldType.EntityRef("485712110d89359a3e539dac987329cd2649d889"),
                         "bt" to arcs.core.data.FieldType.Byte,
                         "shrt" to arcs.core.data.FieldType.Short,
-                        "nt" to arcs.core.data.FieldType.Int,
-                        "lng" to arcs.core.data.FieldType.Long,
+                        "integer" to arcs.core.data.FieldType.Int,
+                        "long_val" to arcs.core.data.FieldType.Long,
                         "big" to arcs.core.data.FieldType.BigInt,
                         "chr" to arcs.core.data.FieldType.Char,
                         "flt" to arcs.core.data.FieldType.Float,
@@ -679,13 +679,13 @@ abstract class AbstractKotlinPrimitivesGolden : arcs.sdk.BaseParticle() {
                         "colors" to arcs.core.data.FieldType.InlineEntity("e9ba6d9fa458ec35a966e462bb30a082e3f0d2f8")
                     )
                 ),
-                "44b8dccc1ae0cf6fa00a7dfeef0b0e6b1d565e24",
+                "1b1cb0b0d53a8af5158ea9b532e73ab2f9b31add",
                 refinement = { data ->
                     val big = data.singletons["big"].toPrimitiveValue(BigInteger::class, BigInteger.ZERO)
-                    val nt = data.singletons["nt"].toPrimitiveValue(Int::class, 0)
-                    val lng = data.singletons["lng"].toPrimitiveValue(Long::class, 0L)
+                    val integer = data.singletons["integer"].toPrimitiveValue(Int::class, 0)
+                    val long_val = data.singletons["long_val"].toPrimitiveValue(Long::class, 0L)
                     val num = data.singletons["num"].toPrimitiveValue(Double::class, 0.0)
-                    ((num < 1000) && (((big > BigInteger("1")) && (30 < ((nt * 5) + (nt * 10)))) && ((1000000L > (lng * 10L)) && ((100000L == (lng * 10L)) || (100000L < (lng * 10L))))))
+                    ((num < 1000) && (((big > BigInteger("1")) && (30 < ((integer * 5) + (integer * 10)))) && ((1000000L > (long_val * 10L)) && ((100000L == (long_val * 10L)) || (100000L < (long_val * 10L))))))
                 },
                 query = null
             )

--- a/src/tools/tests/goldens/kt_generated-schemas.jvm.kt
+++ b/src/tools/tests/goldens/kt_generated-schemas.jvm.kt
@@ -682,8 +682,10 @@ abstract class AbstractKotlinPrimitivesGolden : arcs.sdk.BaseParticle() {
                 "44b8dccc1ae0cf6fa00a7dfeef0b0e6b1d565e24",
                 refinement = { data ->
                     val big = data.singletons["big"].toPrimitiveValue(BigInteger::class, BigInteger.ZERO)
+                    val nt = data.singletons["nt"].toPrimitiveValue(Int::class, 0)
+                    val lng = data.singletons["lng"].toPrimitiveValue(Long::class, 0L)
                     val num = data.singletons["num"].toPrimitiveValue(Double::class, 0.0)
-                    ((num < 1000) && (big > BigInteger("1")))
+                    ((num < 1000) && (((big > BigInteger("1")) && (30 < ((nt * 5) + (nt * 10)))) && ((1000000L > (lng * 10L)) && ((100000L == (lng * 10L)) || (100000L < (lng * 10L))))))
                 },
                 query = null
             )


### PR DESCRIPTION
- Also adds support for literals in refinements (e.g. `2n`, `2l` and `2i` for 2 as a BigInt, Long and Int respectively.
- Currently `2` is left as a Javascript Number for backwards compatibility).

- As `BigInt` is now used to represent `Discrete` values of several different types, some `BigInt` related identifiers are renamed (unless referring to the use of the Javascript data type e.g. `BigIntRange`).