### PR TITLE
Make Volatile Storage a default

### DIFF
--- a/java/arcs/core/allocator/Allocator.kt
+++ b/java/arcs/core/allocator/Allocator.kt
@@ -15,7 +15,6 @@ import arcs.core.common.Id
 import arcs.core.common.toArcId
 import arcs.core.data.Annotation
 import arcs.core.data.Capabilities
-import arcs.core.data.Capability.Shareable
 import arcs.core.data.CreatableStorageKey
 import arcs.core.data.Plan
 import arcs.core.entity.HandleSpec
@@ -194,11 +193,7 @@ class Allocator(
     ): StorageKey {
         val capabilities = Capabilities.fromAnnotations(annotations)
         return CapabilitiesResolver(CapabilitiesResolver.Options(arcId))
-            .createStorageKey(
-                if (capabilities.isEmpty) Capabilities(Shareable(true)) else capabilities,
-                type,
-                idGenerator.newChildId(arcId, "").toString()
-        )
+            .createStorageKey(capabilities, type, idGenerator.newChildId(arcId, "").toString())
     }
 
     /**

--- a/java/arcs/core/storage/api/DriverAndKeyConfigurator.kt
+++ b/java/arcs/core/storage/api/DriverAndKeyConfigurator.kt
@@ -11,7 +11,6 @@
 
 package arcs.core.storage.api
 
-import arcs.core.common.ArcId
 import arcs.core.data.CreatableStorageKey
 import arcs.core.data.SchemaRegistry
 import arcs.core.storage.CapabilitiesResolver
@@ -20,7 +19,7 @@ import arcs.core.storage.StorageKeyParser
 import arcs.core.storage.database.DatabaseManager
 import arcs.core.storage.driver.DatabaseDriverProvider
 import arcs.core.storage.driver.RamDiskDriverProvider
-import arcs.core.storage.driver.VolatileDriverProvider
+import arcs.core.storage.driver.VolatileDriverProviderFactory
 import arcs.core.storage.keys.DatabaseStorageKey
 import arcs.core.storage.keys.JoinStorageKey
 import arcs.core.storage.keys.RamDiskStorageKey
@@ -36,12 +35,14 @@ object DriverAndKeyConfigurator {
      * [StorageKeyParser].
      */
     // TODO: make the set of drivers/keyparsers configurable.
-    fun configure(databaseManager: DatabaseManager?, vararg arcIds: ArcId) {
+    fun configure(databaseManager: DatabaseManager?) {
         // Start fresh.
         DriverFactory.clearRegistrations()
 
-        // Register volatile driver providers for every ArcId
-        arcIds.forEach { VolatileDriverProvider(it) }
+        // Register volatile driver provider factory (it creates volatile driver providers per arc
+        // on demand).
+        VolatileDriverProviderFactory()
+        // Register ramdisk driver provider.
         RamDiskDriverProvider()
         // Only register the database driver provider if a database manager was provided.
         databaseManager?.let {

--- a/java/arcs/core/storage/driver/Volatile.kt
+++ b/java/arcs/core/storage/driver/Volatile.kt
@@ -49,8 +49,13 @@ data class VolatileDriverProvider(private val arcId: ArcId) : DriverProvider {
         removeAllEntities()
 }
 
+/** [DriverProvider] that creates an instance of [VolatileDriverProvider] per arc on demand. */
 class VolatileDriverProviderFactory : DriverProvider {
     private val driverProvidersByArcId = mutableMapOf<ArcId, VolatileDriverProvider>()
+
+    /** Returns a set of all known [ArcId]s. */
+    val arcIds: Set<ArcId>
+        get() = driverProvidersByArcId.keys
 
     init {
         DriverFactory.register(this)
@@ -89,9 +94,6 @@ class VolatileDriverProviderFactory : DriverProvider {
             it.removeEntitiesCreatedBetween(startTimeMillis, endTimeMillis)
         }
     }
-
-    val arcIds: Set<ArcId>
-        get() = driverProvidersByArcId.keys
 }
 
 /** [Driver] implementation for an in-memory store of data. */

--- a/java/arcs/core/storage/driver/Volatile.kt
+++ b/java/arcs/core/storage/driver/Volatile.kt
@@ -28,10 +28,6 @@ import kotlinx.atomicfu.atomic
 data class VolatileDriverProvider(private val arcId: ArcId) : DriverProvider {
     private val arcMemory = VolatileMemory()
 
-    init {
-        DriverFactory.register(this)
-    }
-
     override fun willSupport(storageKey: StorageKey): Boolean =
         storageKey is VolatileStorageKey && storageKey.arcId == arcId
 
@@ -51,6 +47,51 @@ data class VolatileDriverProvider(private val arcId: ArcId) : DriverProvider {
     override suspend fun removeEntitiesCreatedBetween(startTimeMillis: Long, endTimeMillis: Long) =
         // Volatile storage is opaque, so remove all entities.
         removeAllEntities()
+}
+
+class VolatileDriverProviderFactory : DriverProvider {
+    private val driverProvidersByArcId = mutableMapOf<ArcId, VolatileDriverProvider>()
+
+    init {
+        DriverFactory.register(this)
+    }
+
+    override fun willSupport(storageKey: StorageKey): Boolean {
+        if (storageKey !is VolatileStorageKey) return false
+        // Register a new VolatileDriverProvider, if the arcId hasn't been seen before.
+        if (storageKey.arcId !in driverProvidersByArcId) {
+            driverProvidersByArcId[storageKey.arcId] = VolatileDriverProvider(storageKey.arcId)
+        }
+        return true
+    }
+
+    /** Gets a [Driver] for the given [storageKey] and type [Data] (declared by [dataClass]). */
+    override suspend fun <Data : Any> getDriver(
+        storageKey: StorageKey,
+        dataClass: KClass<Data>,
+        type: Type
+    ): Driver<Data> {
+        require(storageKey is VolatileStorageKey) {
+            "Unexpected non-volatile storageKey: $storageKey"
+        }
+        require(willSupport(storageKey)) {
+            "This provider does not support storageKey: $storageKey"
+        }
+        return driverProvidersByArcId[storageKey.arcId]!!.getDriver(storageKey, dataClass, type)
+    }
+
+    override suspend fun removeAllEntities() {
+        driverProvidersByArcId.values.forEach { it.removeAllEntities() }
+    }
+
+    override suspend fun removeEntitiesCreatedBetween(startTimeMillis: Long, endTimeMillis: Long) {
+        driverProvidersByArcId.values.forEach {
+            it.removeEntitiesCreatedBetween(startTimeMillis, endTimeMillis)
+        }
+    }
+
+    val arcIds: Set<ArcId>
+        get() = driverProvidersByArcId.keys
 }
 
 /** [Driver] implementation for an in-memory store of data. */

--- a/java/arcs/sdk/android/storage/AndroidDriverAndKeyConfigurator.kt
+++ b/java/arcs/sdk/android/storage/AndroidDriverAndKeyConfigurator.kt
@@ -25,12 +25,7 @@ import arcs.sdk.android.storage.AndroidDriverAndKeyConfigurator.configure
  *
  * ```kotlin
  * override fun onCreate() {
- *     DriverAndKeyConfigurator.configure(
- *         this,
- *         "myArcId1",
- *         "myArcId2",
- *         // ...
- *     )
+ *     DriverAndKeyConfigurator.configure(this)
  * }
  * ```
  *

--- a/java/arcs/sdk/android/storage/AndroidDriverAndKeyConfigurator.kt
+++ b/java/arcs/sdk/android/storage/AndroidDriverAndKeyConfigurator.kt
@@ -13,7 +13,6 @@ package arcs.sdk.android.storage
 
 import android.content.Context
 import arcs.android.storage.database.AndroidSqliteDatabaseManager
-import arcs.core.common.ArcId
 import arcs.core.storage.api.DriverAndKeyConfigurator
 import arcs.sdk.android.storage.AndroidDriverAndKeyConfigurator.configure
 
@@ -44,8 +43,8 @@ object AndroidDriverAndKeyConfigurator {
      * Allows the caller to configure & register [DriverProvider]s for the [StorageService].
      */
     // TODO: make the set of drivers/keyparsers configurable.
-    fun configure(context: Context, vararg arcIds: ArcId) {
-        DriverAndKeyConfigurator.configure(AndroidSqliteDatabaseManager(context), *arcIds)
+    fun configure(context: Context) {
+        DriverAndKeyConfigurator.configure(AndroidSqliteDatabaseManager(context))
     }
 
     /**

--- a/javatests/arcs/android/storage/service/StorageServiceManagerTest.kt
+++ b/javatests/arcs/android/storage/service/StorageServiceManagerTest.kt
@@ -84,9 +84,7 @@ class StorageServiceManagerTest {
     @Before
     fun setUp() {
         StoreWriteBack.writeBackFactoryOverride = WriteBackForTesting
-        AndroidDriverAndKeyConfigurator.configure(
-            ApplicationProvider.getApplicationContext()
-        )
+        AndroidDriverAndKeyConfigurator.configure(ApplicationProvider.getApplicationContext())
         SchemaRegistry.register(DummyEntity.SCHEMA)
     }
 

--- a/javatests/arcs/android/storage/service/StorageServiceManagerTest.kt
+++ b/javatests/arcs/android/storage/service/StorageServiceManagerTest.kt
@@ -25,6 +25,7 @@ import arcs.core.entity.ReadWriteCollectionHandle
 import arcs.core.entity.ReadWriteSingletonHandle
 import arcs.core.entity.awaitReady
 import arcs.core.host.EntityHandleManager
+import arcs.core.storage.DriverFactory
 import arcs.core.storage.StorageKey
 import arcs.core.storage.StoreWriteBack
 import arcs.core.storage.database.DatabaseData
@@ -84,8 +85,7 @@ class StorageServiceManagerTest {
     fun setUp() {
         StoreWriteBack.writeBackFactoryOverride = WriteBackForTesting
         AndroidDriverAndKeyConfigurator.configure(
-            ApplicationProvider.getApplicationContext(),
-            arcId
+            ApplicationProvider.getApplicationContext()
         )
         SchemaRegistry.register(DummyEntity.SCHEMA)
     }
@@ -95,6 +95,7 @@ class StorageServiceManagerTest {
         WriteBackForTesting.clear()
         scheduler.cancel()
         RamDisk.clear()
+        DriverFactory.clearRegistrations()
     }
 
     @Test

--- a/javatests/arcs/core/allocator/AllocatorTestBase.kt
+++ b/javatests/arcs/core/allocator/AllocatorTestBase.kt
@@ -24,7 +24,7 @@ import arcs.core.storage.CapabilitiesResolver
 import arcs.core.storage.api.DriverAndKeyConfigurator
 import arcs.core.storage.driver.RamDisk
 import arcs.core.storage.driver.RamDiskDriverProvider
-import arcs.core.storage.driver.VolatileDriverProvider
+import arcs.core.storage.driver.VolatileDriverProviderFactory
 import arcs.core.testutil.assertSuspendingThrows
 import arcs.core.testutil.fail
 import arcs.core.util.Log
@@ -268,9 +268,9 @@ open class AllocatorTestBase {
 
     @Test
     open fun allocator_verifyStorageKeysNotOverwritten() = runAllocatorTest {
+        VolatileDriverProviderFactory()
         val idGenerator = Id.Generator.newSession()
         val testArcId = idGenerator.newArcId("Test")
-        VolatileDriverProvider(testArcId)
 
         val resolver = CapabilitiesResolver(CapabilitiesResolver.Options(testArcId))
         val inputPerson = resolver.createStorageKey(

--- a/javatests/arcs/core/allocator/AllocatorTestBase.kt
+++ b/javatests/arcs/core/allocator/AllocatorTestBase.kt
@@ -111,6 +111,7 @@ open class AllocatorTestBase {
         RamDisk.clear()
         DriverAndKeyConfigurator.configureKeyParsers()
         RamDiskDriverProvider()
+        VolatileDriverProviderFactory()
 
         readingExternalHost = readingHost()
         writingExternalHost = writingHost()
@@ -268,7 +269,6 @@ open class AllocatorTestBase {
 
     @Test
     open fun allocator_verifyStorageKeysNotOverwritten() = runAllocatorTest {
-        VolatileDriverProviderFactory()
         val idGenerator = Id.Generator.newSession()
         val testArcId = idGenerator.newArcId("Test")
 

--- a/javatests/arcs/core/host/ReflectiveParticleConstructionTest.kt
+++ b/javatests/arcs/core/host/ReflectiveParticleConstructionTest.kt
@@ -6,6 +6,7 @@ import arcs.core.data.Plan
 import arcs.core.storage.api.DriverAndKeyConfigurator
 import arcs.core.storage.driver.RamDisk
 import arcs.core.storage.driver.RamDiskDriverProvider
+import arcs.core.storage.driver.VolatileDriverProviderFactory
 import arcs.core.util.TaggedLog
 import arcs.core.util.testutil.LogRule
 import arcs.jvm.host.ExplicitHostRegistry
@@ -56,6 +57,7 @@ class ReflectiveParticleConstructionTest {
         RamDisk.clear()
         DriverAndKeyConfigurator.configureKeyParsers()
         RamDiskDriverProvider()
+        VolatileDriverProviderFactory()
 
         val hostRegistry = ExplicitHostRegistry()
         val schedulerProvider = JvmSchedulerProvider(EmptyCoroutineContext)


### PR DESCRIPTION
- Introduce VolatileDriverProviderFactory to avoid explicitly registering VolatileDriverProvider per arcId (a per arcId VolatileDriverProvider is now created on demand)
- change Allocator default: create volatile storage key for empty capabilities (instead of ramdisk)

fixes: b/161264308