### PR TITLE
Fix flakiness in CoreAllocatorTest

### DIFF
--- a/java/arcs/core/host/ArcHostContextParticle.kt
+++ b/java/arcs/core/host/ArcHostContextParticle.kt
@@ -66,7 +66,7 @@ class ArcHostContextParticle(
                         type = handle.value.handle.type.tag.name
                     )
                     // Write Plan.Handle
-                    handles.planHandles.store(planHandle)
+                    handles.planHandles.store(planHandle).join()
                     ArcHostContextParticle_HandleConnections(
                         connectionName = handle.key,
                         planHandle = handles.planHandles.createReference(planHandle),

--- a/javatests/arcs/core/allocator/AllocatorTestBase.kt
+++ b/javatests/arcs/core/allocator/AllocatorTestBase.kt
@@ -43,7 +43,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -518,7 +517,6 @@ open class AllocatorTestBase {
     }
 
     @Test
-    @Ignore("Flaking: b/161926251")
     open fun allocator_doesntCreateArcsOnDuplicateStartArc() = runAllocatorTest {
         val arc = allocator.startArcForPlan(PersonPlan).waitForStart()
 


### PR DESCRIPTION
There was a .store call missing a join, leading to races in the test.