### PR TITLE
Improve clear_N latency

### DIFF
--- a/java/arcs/android/storage/service/BindingContextStats.kt
+++ b/java/arcs/android/storage/service/BindingContextStats.kt
@@ -74,7 +74,12 @@ class BindingContextStatsImpl : BindingContextStatistics {
 
     override fun measure(context: CoroutineContext, block: suspend () -> Unit) {
         val startTime = System.currentTimeMillis()
-        runBlocking(context) {
+        // TODO(ianchang):
+        // Should remove all runBlocking calls at least runBlocking(someCtx)
+        // at AIDLs and their sub-functions.
+        // Already tried CoroutineScope(context).launch {...} but a few tests like
+        // StorageServiceTest, BindingContextTest, etc become flaky.
+        runBlocking {
             try {
                 block()
             } finally {


### PR DESCRIPTION
Improvement(N: 25), from 100+ ms to 7-8 ms.

When a client and the service run at **the same process** and the client runs at a **single-threaded pool** (T_client) and the service runs at another thread pool (T_service), such a configuration causes T_client **must** wait until all clear jobs get done at T_service if using runBlocking(T_service_context) { ... }

runBlocking { ... } would enter/re-use current thread's event loop while runBlocking(T_service_context) { ... }
would **block current thread** then switches to T_service_context event loop.

So, the original flow:
T_client -> sendProxyMessage -> BindingContext.measure -> runBlocking(T_service_context) { ... }
The T_client is blocked so the result.complete() would not be able to resume any coroutines at T_client until runBlocking(T_service_context) { ... } completed.