### PR TITLE
Allow inline declarations to reference schemas that are already defined

### DIFF
--- a/src/runtime/manifest-parser.pegjs
+++ b/src/runtime/manifest-parser.pegjs
@@ -1613,7 +1613,7 @@ SchemaPrimitiveType
     });
   }
 
-NestedSchemaType = 'inline' whiteSpace? schema:SchemaInline
+NestedSchemaType = 'inline' whiteSpace? schema:(SchemaInline / TypeName)
   {
     return toAstNode<AstNode.NestedSchema>({
       kind: 'schema-nested',

--- a/src/runtime/tests/entity-test.ts
+++ b/src/runtime/tests/entity-test.ts
@@ -17,7 +17,7 @@ import {SYMBOL_INTERNALS} from '../symbols.js';
 import {ConCap} from '../../testing/test-util.js';
 import {Ttl} from '../capabilities.js';
 
-describe.only('Entity', () => {
+describe('Entity', () => {
 
   let schema: Schema;
   let entityClass: EntityClass;

--- a/src/runtime/tests/entity-test.ts
+++ b/src/runtime/tests/entity-test.ts
@@ -17,12 +17,15 @@ import {SYMBOL_INTERNALS} from '../symbols.js';
 import {ConCap} from '../../testing/test-util.js';
 import {Ttl} from '../capabilities.js';
 
-describe('Entity', () => {
+describe.only('Entity', () => {
 
   let schema: Schema;
   let entityClass: EntityClass;
   before(async () => {
     const manifest = await Manifest.parse(`
+      schema ExternalInline
+        txt: Text
+
       schema Foo
         txt: Text
         lnk: URL
@@ -35,13 +38,14 @@ describe('Entity', () => {
         kt: Long
         lst: List<Number>
         inner: inline { txt: Text, num: Number }
+        inner2: inline ExternalInline
     `);
     schema = manifest.findSchemaByName('Foo');
     entityClass = Entity.createEntityClass(schema, null);
   });
 
   it('behaves like a regular object except writing to any field fails', () => {
-    const e = new entityClass({txt: 'abc', num: 56, lst: [1, 2, 5, 4, 3], inner: {txt: 'def', num: 78}});
+    const e = new entityClass({txt: 'abc', num: 56, lst: [1, 2, 5, 4, 3], inner: {txt: 'def', num: 78}, inner2: {txt: 'ghi'}});
 
     assert.strictEqual(e.txt, 'abc');
     assert.strictEqual(e.num, 56);
@@ -58,13 +62,13 @@ describe('Entity', () => {
     assert.throws(() => { e.notInSchema = 3; }, `Tried to modify entity field 'notInSchema'`);
     assert.throws(() => {e['lst'] = []; }, `Tried to modify entity field 'lst'`);
 
-    assert.strictEqual(JSON.stringify(e), '{"txt":"abc","num":56,"lst":[1,2,5,4,3],"inner":{"txt":"def","num":78}}');
-    assert.strictEqual(e.toString(), 'Foo { txt: "abc", num: 56, lst: [1,2,5,4,3], inner: { txt: "def", num: 78 } }');
-    assert.strictEqual(`${e}`, 'Foo { txt: "abc", num: 56, lst: [1,2,5,4,3], inner: { txt: "def", num: 78 } }');
+    assert.strictEqual(JSON.stringify(e), '{"txt":"abc","num":56,"lst":[1,2,5,4,3],"inner":{"txt":"def","num":78},"inner2":{"txt":"ghi"}}');
+    assert.strictEqual(e.toString(), 'Foo { txt: "abc", num: 56, lst: [1,2,5,4,3], inner: { txt: "def", num: 78 }, inner2: { txt: "ghi" } }');
+    assert.strictEqual(`${e}`, 'Foo { txt: "abc", num: 56, lst: [1,2,5,4,3], inner: { txt: "def", num: 78 }, inner2: { txt: "ghi" } }');
 
-    assert.deepEqual(Object.entries(e), [['txt', 'abc'], ['num', 56], ['lst', [1, 2, 5, 4, 3]], ['inner', {txt: 'def', num: 78}]]);
-    assert.deepEqual(Object.keys(e), ['txt', 'num', 'lst', 'inner']);
-    assert.deepEqual(Object.values(e), ['abc', 56, [1, 2, 5, 4, 3], {txt: 'def', num: 78}]);
+    assert.deepEqual(Object.entries(e), [['txt', 'abc'], ['num', 56], ['lst', [1, 2, 5, 4, 3]], ['inner', {txt: 'def', num: 78}], ['inner2', {txt: 'ghi'}]]);
+    assert.deepEqual(Object.keys(e), ['txt', 'num', 'lst', 'inner', 'inner2']);
+    assert.deepEqual(Object.values(e), ['abc', 56, [1, 2, 5, 4, 3], {txt: 'def', num: 78}, {txt: 'ghi'}]);
   });
 
   it('static Entity API maps onto EntityInternals methods', () => {
@@ -201,6 +205,11 @@ describe('Entity', () => {
     const e = new entityClass({});
     assert.throws(() => Entity.mutate(e, {inner: 77}), 'Cannot set nested schema inner with non-object');
     assert.throws(() => Entity.mutate(e, {inner: {txt: 3}}), 'Type mismatch setting field txt');
+    assert.throws(() => Entity.mutate(e, {inner: {blah: 77}}), 'not in schema undefined');
+
+    assert.throws(() => Entity.mutate(e, {inner2: 77}), 'Cannot set nested schema inner2 with non-object');
+    assert.throws(() => Entity.mutate(e, {inner2: {txt: 3}}), 'Type mismatch setting field txt');
+    assert.throws(() => Entity.mutate(e, {inner2: {num: 77}}), 'not in schema ExternalInline');
   });
 
   it('prevents mutations of Kotlin types', () => {

--- a/src/runtime/tests/manifest-parser-test.ts
+++ b/src/runtime/tests/manifest-parser-test.ts
@@ -510,7 +510,7 @@ describe('manifest parser', () => {
       schema ContainsExternalNested
         nestyMcNestFace: inline GetsNested
         text: Text
-    `)
+    `);
   });
   it('parses a schema with ordered list types', () => {
     parse(`

--- a/src/runtime/tests/manifest-parser-test.ts
+++ b/src/runtime/tests/manifest-parser-test.ts
@@ -502,6 +502,16 @@ describe('manifest parser', () => {
         }
     `);
   });
+  it('parses an schema that inlines another schema', () => {
+    parse(`
+      schema GetsNested
+        num: Number
+
+      schema ContainsExternalNested
+        nestyMcNestFace: inline GetsNested
+        text: Text
+    `)
+  });
   it('parses a schema with ordered list types', () => {
     parse(`
       schema OrderedLists

--- a/src/tools/tests/goldens/kotlin-schema-generation.cgtest
+++ b/src/tools/tests/goldens/kotlin-schema-generation.cgtest
@@ -199,6 +199,42 @@ Schema(
 [end]
 
 [name]
+generates schemas for a nested entity referencing an external schema
+[input]
+schema External
+  name: Text
+
+particle P
+  h1: reads Thing {
+    other: inline External
+  }
+[results]
+Schema(
+    setOf(SchemaName("Thing")),
+    SchemaFields(
+        singletons = mapOf(
+            "other" to FieldType.InlineEntity("dde7385227a50a4a4654027dba6feefccd1a7a39")
+        ),
+        collections = emptyMap()
+    ),
+    "0e998e43c23c1ae55fe4c7d9c819669aa4ee9681",
+    refinement = { _ -> true },
+    query = null
+)
+[next]
+Schema(
+    setOf(SchemaName("External")),
+    SchemaFields(
+        singletons = mapOf("name" to FieldType.Text),
+        collections = emptyMap()
+    ),
+    "dde7385227a50a4a4654027dba6feefccd1a7a39",
+    refinement = { _ -> true },
+    query = null
+)
+[end]
+
+[name]
 generates schemas for a double nested entity
 [input]
 particle P


### PR DESCRIPTION
The aim is to get things like this working:

```
schema ExternallyDefined
  ...

schema LookAtMe 
  field: inline ExternallyDefined
```

It turns out this is an extremely small change because the processing of TypeName in manifest.ts is universal (we always replace a TypeName with the actual schema, regardless of the position in the AST). Sometimes we can have Nice Things!