### PR TITLE
Add AccessPath.Root.Store to proto

### DIFF
--- a/java/arcs/core/data/proto/manifest.proto
+++ b/java/arcs/core/data/proto/manifest.proto
@@ -224,16 +224,25 @@ message UnaryExpressionProto {
 // a `HandleConnectionSpec`. This should be sufficient as the root of an access
 // path in a claim or check can only refer to a `HandleConnectionSpec`.
 message AccessPathProto {
+  message HandleRoot {
+    // (particle_spec, handle_connection) identifies a `HandleConnectionSpec`.
+    string particle_spec = 1;
+    string handle_connection = 2;
+  }
+  oneof root {
+    HandleRoot handle = 4;
+    string store_id = 5;
+  }
+
   message Selector {
     oneof selector {
       string field = 1;
       // TODO(bgogul): Other selectors like dereferencing, index, etc.
     }
   }
-  // (particle_spec, handle_connection) identifies a `HandleConnectionSpec`.
-  string particle_spec = 1;
-  string handle_connection = 2;
   repeated Selector selectors = 3;
+
+  reserved 1, 2;
 }
 
 message InformationFlowLabelProto {

--- a/javatests/arcs/core/data/proto/AccessPathProtoDecoderTest.kt
+++ b/javatests/arcs/core/data/proto/AccessPathProtoDecoderTest.kt
@@ -50,8 +50,20 @@ class AccessPathProtoDecoderTest {
     }
 
     @Test
+    fun roundTrip_storeRoot() {
+        val accessPath = AccessPath(
+            AccessPath.Root.Store("store_id"),
+            listOf(AccessPath.Selector.Field("some_field"))
+        )
+
+        assertThat(accessPath.encode().decode(emptyMap())).isEqualTo(accessPath)
+    }
+
+    @Test
     fun decode_detectsMissingConnections() {
-        val proto = AccessPathProto.newBuilder().setHandleConnection("input").build()
+        val proto = AccessPathProto.newBuilder()
+            .setHandle(AccessPathProto.HandleRoot.newBuilder().setHandleConnection("input"))
+            .build()
         val exception = assertFailsWith<IllegalArgumentException> {
             proto.decode(emptyMap())
         }

--- a/javatests/arcs/core/data/proto/ParticleSpecProtoDecoderTest.kt
+++ b/javatests/arcs/core/data/proto/ParticleSpecProtoDecoderTest.kt
@@ -146,8 +146,10 @@ class ParticleSpecProtoDecoderTest {
           claims {
             assume {
               access_path {
-                particle_spec: "ReaderWriter"
-                handle_connection: "write"
+                handle {
+                  particle_spec: "ReaderWriter"
+                  handle_connection: "write"
+                }
               }
               predicate {
                 label {
@@ -159,12 +161,16 @@ class ParticleSpecProtoDecoderTest {
           claims {
             derives_from {
               target {
-                particle_spec: "ReaderWriter"
-                handle_connection: "write"
+                handle {
+                  particle_spec: "ReaderWriter"
+                  handle_connection: "write"
+                }
               }
               source {
-                particle_spec: "ReaderWriter"
-                handle_connection: "read"
+                handle {
+                  particle_spec: "ReaderWriter"
+                  handle_connection: "read"
+                }
               }
             }
           }
@@ -193,8 +199,10 @@ class ParticleSpecProtoDecoderTest {
           location: "Nowhere"
           checks {
             access_path {
-              particle_spec: "ReaderWriter"
-              handle_connection: "read"
+              handle {
+                particle_spec: "ReaderWriter"
+                handle_connection: "read"
+              }
             }
             predicate {
               label {
@@ -204,8 +212,10 @@ class ParticleSpecProtoDecoderTest {
           }
           checks {
             access_path {
-              particle_spec: "ReaderWriter"
-              handle_connection: "read"
+              handle {
+                particle_spec: "ReaderWriter"
+                handle_connection: "read"
+              }
             }
             predicate {
               label {

--- a/src/tools/manifest2proto.ts
+++ b/src/tools/manifest2proto.ts
@@ -217,9 +217,11 @@ function accessPathProtoPayload(
     connectionSpec: HandleConnectionSpec,
     fieldPath: string[]
 ) {
-  const accessPath: {particleSpec: string, handleConnection: string, selectors?: {field: string}[]} = {
-    particleSpec: spec.name,
-    handleConnection: connectionSpec.name
+  const accessPath: {handle: {particleSpec: string, handleConnection: string}, selectors?: {field: string}[]} = {
+    handle: {
+      particleSpec: spec.name,
+      handleConnection: connectionSpec.name
+    }
   };
   if (fieldPath.length) {
     accessPath.selectors = fieldPath.map(field => ({field}));

--- a/src/tools/tests/manifest2proto-test.ts
+++ b/src/tools/tests/manifest2proto-test.ts
@@ -846,8 +846,10 @@ describe('manifest2proto', () => {
       {
         assume: {
           accessPath: {
-            particleSpec: 'Test',
-            handleConnection: 'private'
+            handle: {
+              particleSpec: 'Test',
+              handleConnection: 'private'
+            }
           },
           predicate: {
             label: {
@@ -859,8 +861,10 @@ describe('manifest2proto', () => {
       {
         assume: {
           accessPath: {
-            particleSpec: 'Test',
-            handleConnection: 'public'
+            handle: {
+              particleSpec: 'Test',
+              handleConnection: 'public'
+            }
           },
           predicate: {
             not: {
@@ -888,12 +892,16 @@ describe('manifest2proto', () => {
       {
         derivesFrom: {
           source: {
-            particleSpec: 'Test',
-            handleConnection: 'input'
+            handle: {
+              particleSpec: 'Test',
+              handleConnection: 'input'
+            },
           },
           target: {
-            particleSpec: 'Test',
-            handleConnection: 'output'
+            handle: {
+              particleSpec: 'Test',
+              handleConnection: 'output'
+            },
           }
         }
       }
@@ -913,20 +921,26 @@ describe('manifest2proto', () => {
       {
         derivesFrom: {
           source: {
-            particleSpec: 'Test',
-            handleConnection: 'input'
+            handle: {
+              particleSpec: 'Test',
+              handleConnection: 'input'
+            },
           },
           target: {
-            particleSpec: 'Test',
-            handleConnection: 'output'
+            handle: {
+              particleSpec: 'Test',
+              handleConnection: 'output'
+            },
           }
         }
       },
       {
         assume: {
           accessPath: {
-            particleSpec: 'Test',
-            handleConnection: 'output'
+            handle: {
+              particleSpec: 'Test',
+              handleConnection: 'output'
+            }
           },
           predicate: {
             label: {
@@ -952,8 +966,10 @@ describe('manifest2proto', () => {
       {
         assume: {
           accessPath: {
-            particleSpec: 'Test',
-            handleConnection: 'private',
+            handle: {
+              particleSpec: 'Test',
+              handleConnection: 'private',
+            }
           },
           predicate: {
             label: {
@@ -965,8 +981,10 @@ describe('manifest2proto', () => {
       {
         assume: {
           accessPath: {
-            particleSpec: 'Test',
-            handleConnection: 'private',
+            handle: {
+              particleSpec: 'Test',
+              handleConnection: 'private',
+            },
             selectors: [{field: 'ref'}, {field: 'foo'}],
           },
           predicate: {
@@ -983,13 +1001,17 @@ describe('manifest2proto', () => {
       {
         derivesFrom: {
           source: {
-            particleSpec: 'Test',
-            handleConnection: 'input',
+            handle: {
+              particleSpec: 'Test',
+              handleConnection: 'input',
+            },
             selectors: [{field: 'bar'}],
           },
           target: {
-            particleSpec: 'Test',
-            handleConnection: 'private',
+            handle: {
+              particleSpec: 'Test',
+              handleConnection: 'private',
+            },
             selectors: [{field: 'ref'}],
           },
         },
@@ -1009,8 +1031,10 @@ describe('manifest2proto', () => {
     assert.deepStrictEqual(spec.particleSpecs[0].checks, [
       {
         accessPath: {
-          particleSpec: 'Test',
-          handleConnection: 'private'
+          handle: {
+            particleSpec: 'Test',
+            handleConnection: 'private'
+          }
         },
         predicate: {
           label: {
@@ -1020,8 +1044,10 @@ describe('manifest2proto', () => {
       },
       {
         accessPath: {
-          particleSpec: 'Test',
-          handleConnection: 'public'
+          handle: {
+            particleSpec: 'Test',
+            handleConnection: 'public'
+          }
         },
         predicate: {
           not: {
@@ -1048,8 +1074,10 @@ describe('manifest2proto', () => {
     assert.deepStrictEqual(spec.particleSpecs[0].checks, [
       {
         accessPath: {
-          particleSpec: 'Test',
-          handleConnection: 'private'
+          handle: {
+            particleSpec: 'Test',
+            handleConnection: 'private'
+          },
         },
         predicate: {
           label: {
@@ -1059,8 +1087,10 @@ describe('manifest2proto', () => {
       },
       {
         accessPath: {
-          particleSpec: 'Test',
-          handleConnection: 'private',
+          handle: {
+            particleSpec: 'Test',
+            handleConnection: 'private',
+          },
           selectors: [{field: 'ref'}, {field: 'foo'}],
         },
         predicate: {
@@ -1075,8 +1105,10 @@ describe('manifest2proto', () => {
       },
       {
         accessPath: {
-          particleSpec: 'Test',
-          handleConnection: 'public',
+          handle: {
+            particleSpec: 'Test',
+            handleConnection: 'public',
+          },
           selectors: [{field: 'ref'}],
         },
         predicate: {
@@ -1099,8 +1131,10 @@ describe('manifest2proto', () => {
     assert.deepStrictEqual(spec.particleSpecs[0].checks, [
       {
         accessPath: {
-          particleSpec: 'Test',
-          handleConnection: 'private'
+          handle: {
+            particleSpec: 'Test',
+            handleConnection: 'private'
+          }
         },
         predicate: {
           and: {
@@ -1119,8 +1153,10 @@ describe('manifest2proto', () => {
       },
       {
         accessPath: {
-          particleSpec: 'Test',
-          handleConnection: 'public'
+          handle: {
+            particleSpec: 'Test',
+            handleConnection: 'public'
+          }
         },
         predicate: {
           or: {
@@ -1155,8 +1191,10 @@ describe('manifest2proto', () => {
     assert.deepStrictEqual(spec.particleSpecs[0].checks, [
       {
         accessPath: {
-          particleSpec: 'Test',
-          handleConnection: 'private'
+          handle: {
+            particleSpec: 'Test',
+            handleConnection: 'private'
+          }
         },
         predicate: {
           and: {
@@ -1184,8 +1222,10 @@ describe('manifest2proto', () => {
       },
       {
         accessPath: {
-          particleSpec: 'Test',
-          handleConnection: 'public'
+          handle: {
+            particleSpec: 'Test',
+            handleConnection: 'public'
+          }
         },
         predicate: {
           or: {
@@ -1227,8 +1267,10 @@ describe('manifest2proto', () => {
     assert.deepStrictEqual(spec.particleSpecs[0].checks, [
       {
         accessPath: {
-          particleSpec: 'Test',
-          handleConnection: 'input1'
+          handle: {
+            particleSpec: 'Test',
+            handleConnection: 'input1'
+          }
         },
         predicate: {
           implies: {
@@ -1239,8 +1281,10 @@ describe('manifest2proto', () => {
       },
       {
         accessPath: {
-          particleSpec: 'Test',
-          handleConnection: 'input2'
+          handle: {
+            particleSpec: 'Test',
+            handleConnection: 'input2'
+          }
         },
         predicate: {
           implies: {
@@ -1256,8 +1300,10 @@ describe('manifest2proto', () => {
       },
       {
         accessPath: {
-          particleSpec: 'Test',
-          handleConnection: 'input3'
+          handle: {
+            particleSpec: 'Test',
+            handleConnection: 'input3'
+          }
         },
         predicate: {
           implies: {


### PR DESCRIPTION
Root.Store was a new AccessPath root type, but doesn't have proto support yet.

I had to nest the existing fields inside a oneof, since the Store type doesn't have those fields, which meant updating a lot of tests.