### PR TITLE
DFA: Set conservative value for fields when an ingress claim is absent.

### DIFF
--- a/java/arcs/core/analysis/InformationFlow.kt
+++ b/java/arcs/core/analysis/InformationFlow.kt
@@ -103,10 +103,18 @@ class InformationFlow private constructor(
             }
     }
 
-    private fun getInitialValues(ingresses: IngressInfo): AccessPathLabels {
-        // The initial value is (accessPath -> emptyLabels) followed by applying all the claims.
-        return mutableMapOf(AccessPath(ingresses.handleNode.handle) to getEmptyLabels())
-            .apply { applyAssumes(ingresses.claims) }
+    private fun getInitialValues(ingress: IngressInfo): AccessPathLabels {
+        // The initial value is (accessPaths -> emptyLabels) followed by applying all the claims.
+        val handle = ingress.handleNode.handle
+        val root = AccessPath.Root.Handle(handle)
+        // 1. accessPaths -> emptyLabels
+        val emptyLabelsMap = mutableMapOf<AccessPath, InformationFlowLabels>()
+        for (accessPath in handle.type.getAccessPaths(root)) {
+            emptyLabelsMap[accessPath] = getEmptyLabels()
+        }
+        // 2. Apply any initial claims.
+        return emptyLabelsMap
+            .apply { applyAssumes(ingress.claims) }
             .let { AccessPathLabels.makeValue(it.toMap()) }
     }
 

--- a/javatests/arcs/core/analysis/InformationFlowTest.kt
+++ b/javatests/arcs/core/analysis/InformationFlowTest.kt
@@ -89,7 +89,8 @@ class InformationFlowTest {
             "fail-derives-from-cycle",
             "fail-derives-from-multiple",
             "fail-join-tuple-components",
-            "fail-check-on-subpaths"
+            "fail-check-on-subpaths",
+            "fail-no-claim-is-empty-labels"
         )
         val okTests = listOf(
             "ok-directly-satisfied",

--- a/javatests/arcs/core/analysis/testdata/fail_no_claim_is_empty_labels.arcs
+++ b/javatests/arcs/core/analysis/testdata/fail_no_claim_is_empty_labels.arcs
@@ -1,0 +1,26 @@
+// This checks that DFA assumes empty labels when no claims are specified for
+// a field of an ingress handle.
+// #Ingress: Ingress
+// #FAIL: hc:Egress.egress.age is allowedToEgress
+
+schema Person
+  name: Text
+  age: Number
+
+particle Ingress
+  person: writes Person
+  claim person.name is allowedToEgress
+
+particle Egress
+  egress: reads Person
+  check egress.name is allowedToEgress
+  // Following should fail as egress.age should be empty
+  check egress.age is allowedToEgress
+
+recipe R
+  h: create
+  Ingress
+    person: h
+  Egress
+    egress: h
+ 


### PR DESCRIPTION
This PR ensures that when initial values of ingress fields are sets them conservatively to empty set if they are not explicitly specified. This prevents us from letting some checks to pass accidentally. (See the test in this PR.)