### PR TITLE
Created java binary, library alias to third_party

### DIFF
--- a/third_party/bazel_rules/rules_java/java/defs.bzl
+++ b/third_party/bazel_rules/rules_java/java/defs.bzl
@@ -1,0 +1,4 @@
+load("@rules_java//java:defs.bzl", _java_binary = "java_binary", _java_library = "java_library")
+
+java_binary = _java_binary
+java_library = _java_library


### PR DESCRIPTION
This change will allow us to create java_binary and java_library rules that are compatible with G3.