### PR TITLE
Remove the channel from `ServiceStore`

### DIFF
--- a/java/arcs/sdk/android/storage/ServiceStore.kt
+++ b/java/arcs/sdk/android/storage/ServiceStore.kt
@@ -45,17 +45,9 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancelChildren
-import kotlinx.coroutines.channels.BroadcastChannel
-import kotlinx.coroutines.channels.ClosedSendChannelException
-import kotlinx.coroutines.channels.ConflatedBroadcastChannel
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.asFlow
-import kotlinx.coroutines.flow.buffer
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 
 /**
@@ -118,26 +110,7 @@ class ServiceStore<Data : CrdtData, Op : CrdtOperation, ConsumerData>(
     private val scope = CoroutineScope(coroutineContext)
     private var storageService: IStorageService? = null
     private var serviceConnection: StorageServiceConnection? = null
-    private var channel: BroadcastChannel<suspend () -> Unit>? = null
-    private var channelConsumptionJob: Job? = null
     private val outgoingMessages = atomic(0)
-
-    init {
-        initChannel()
-    }
-
-    // Channel has an internal queue which can retain work if stopped
-    // So we need to create fresh instances when off() invoked
-    private fun initChannel() {
-        synchronized(this) {
-            channel?.takeIf { !it.isClosedForSend }?.cancel()
-            channel = ConflatedBroadcastChannel<suspend () -> Unit>().also {
-                channelConsumptionJob = it.asFlow().buffer()
-                    .onEach { it() }
-                    .launchIn(scope)
-            }
-        }
-    }
 
     override suspend fun idle() = coroutineScope {
         log.debug { "Waiting for service store to be idle" }
@@ -165,22 +138,7 @@ class ServiceStore<Data : CrdtData, Op : CrdtOperation, ConsumerData>(
 
     override fun off(callbackToken: Int) {
         val service = checkNotNull(storageService)
-        runBlocking {
-            send {
-                service.unregisterCallback(callbackToken)
-                initChannel()
-            }
-        }
-    }
-
-    private suspend fun send(block: suspend () -> Unit) = requireNotNull(channel) {
-        "Channel is not initialized"
-    }.apply {
-        try {
-            send(block)
-        } catch (e: ClosedSendChannelException) {
-            log.debug { "Channel is closed, ignoring" }
-        }
+        service.unregisterCallback(callbackToken)
     }
 
     override suspend fun onProxyMessage(message: ProxyMessage<Data, Op, ConsumerData>): Boolean {
@@ -188,12 +146,8 @@ class ServiceStore<Data : CrdtData, Op : CrdtOperation, ConsumerData>(
         val result = DeferredResult(coroutineContext)
         // Trick: make an indirect access to the message to keep kotlin flow
         // from holding the entire message that might encapsulate a large size data.
-        var messageRef: ProxyMessage<Data, Op, ConsumerData>? = message
         outgoingMessages.incrementAndGet()
-        send {
-            service.sendProxyMessage(messageRef!!.toProto().toByteArray(), result)
-            messageRef = null
-        }
+        service.sendProxyMessage(message.toProto().toByteArray(), result)
         // Just return false if the message couldn't be applied.
         return try {
             result.await()
@@ -224,8 +178,6 @@ class ServiceStore<Data : CrdtData, Op : CrdtOperation, ConsumerData>(
     override fun close() {
         serviceConnection?.disconnect()
         storageService = null
-        channel?.cancel()
-        channel = null
         scope.coroutineContext[Job.Key]?.cancelChildren()
     }
 


### PR DESCRIPTION
It doesn't appear to be providing us benefits anymore, as the
ServiceStore code has evolved:

`onProxyMessage` and `off` were queueing work onto the channel. It seems
this was to prevent concurrent runs of onProxyMessage but since that
method is markedi `oneway`, and the result await did not block channel
execution, I'm not sure it was providing that guarantee.

All existing tests pass with this change; if there's a case that this
was addressing that I haven't considered, then we need a test for it.