### PR TITLE
Safely run DriverProvider operations and collect errors

### DIFF
--- a/java/arcs/android/storage/database/AndroidSqliteDatabaseManager.kt
+++ b/java/arcs/android/storage/database/AndroidSqliteDatabaseManager.kt
@@ -23,9 +23,6 @@ import arcs.core.storage.database.DatabaseManager
 import arcs.core.storage.database.DatabasePerformanceStatistics.Snapshot
 import arcs.core.util.Log
 import arcs.core.util.guardedBy
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -58,8 +55,11 @@ class AndroidSqliteDatabaseManager(
      */
     private fun getLifecycle(): Lifecycle? {
         var lifecycleOwner = context
-        while (lifecycleOwner != null && lifecycleOwner !is LifecycleOwner &&
-            lifecycleOwner is ContextWrapper) {
+        while (
+            lifecycleOwner != null &&
+            lifecycleOwner !is LifecycleOwner &&
+            lifecycleOwner is ContextWrapper
+        ) {
             lifecycleOwner = lifecycleOwner.baseContext
         }
 
@@ -82,13 +82,13 @@ class AndroidSqliteDatabaseManager(
         val entry = registry.register(name, persistent)
         return mutex.withLock {
             dbCache[entry.name to entry.isPersistent]
-                ?: DatabaseImpl(context, name, persistent) {
-                    mutex.withLock {
-                        dbCache.remove(entry.name to entry.isPersistent)
-                    }
-                }.also {
-                    dbCache[entry.name to entry.isPersistent] = it
+            ?: DatabaseImpl(context, name, persistent) {
+                mutex.withLock {
+                    dbCache.remove(entry.name to entry.isPersistent)
                 }
+            }.also {
+                dbCache[entry.name to entry.isPersistent] = it
+            }
         }
     }
 
@@ -96,44 +96,39 @@ class AndroidSqliteDatabaseManager(
         dbCache.mapValues { it.value.snapshotStatistics() }
     }
 
-    override suspend fun resetAll() {
-        registry.fetchAll()
-            .map { getDatabase(it.name, it.isPersistent) as DatabaseImpl }
-            .forEach { it.reset() }
+    override suspend fun resetAll() = runOnAllDatabases { _, db ->
+        db.reset()
     }
 
-    override suspend fun removeExpiredEntities(): Job = coroutineScope {
-        launch {
-            registry.fetchAll()
-                .map { it.name to getDatabase(it.name, it.isPersistent) }
-                .forEach { (name, db) ->
-                    if (databaseSizeTooLarge(name)) {
-                        // If the database size is too large, we clear it entirely.
-                        db.removeAllEntities()
-                    } else {
-                        db.removeExpiredEntities()
-                    }
-                }
+    override suspend fun removeExpiredEntities() = runOnAllDatabases { name, db ->
+        if (databaseSizeTooLarge(name)) {
+            // If the database size is too large, we clear it entirely.
+            db.removeAllEntities()
+        } else {
+            db.removeExpiredEntities()
         }
     }
 
-    override suspend fun removeAllEntities() =
-        registry.fetchAll()
-            .map { getDatabase(it.name, it.isPersistent) }
-            .forEach { it.removeAllEntities() }
-
-    override suspend fun removeEntitiesCreatedBetween(startTimeMillis: Long, endTimeMillis: Long) =
-        registry.fetchAll()
-            .map { getDatabase(it.name, it.isPersistent) }
-            .forEach { it.removeEntitiesCreatedBetween(startTimeMillis, endTimeMillis) }
-
-    override suspend fun runGarbageCollection(): Job = coroutineScope {
-        launch {
-            registry.fetchAll()
-                .map { getDatabase(it.name, it.isPersistent) }
-                .forEach { it.runGarbageCollection() }
-        }
+    override suspend fun removeAllEntities() = runOnAllDatabases { _, db ->
+        db.removeAllEntities()
     }
+
+    override suspend fun removeEntitiesCreatedBetween(
+        startTimeMillis: Long,
+        endTimeMillis: Long
+    ) = runOnAllDatabases { _, db ->
+        db.removeEntitiesCreatedBetween(startTimeMillis, endTimeMillis)
+    }
+
+    override suspend fun runGarbageCollection() = runOnAllDatabases { _, db ->
+        db.runGarbageCollection()
+    }
+
+    /** Execute the provided block on each of the registered databases. */
+    private suspend fun runOnAllDatabases(block: suspend (name: String, db: Database) -> Unit) =
+        registry.fetchAll()
+            .map { it.name to getDatabase(it.name, it.isPersistent) }
+            .forEach { block(it.first, it.second) }
 
     private fun databaseSizeTooLarge(dbName: String): Boolean {
         return context.getDatabasePath(dbName).length() > maxDbSizeBytes

--- a/java/arcs/android/storage/database/DatabaseGarbageCollectionPeriodicTask.kt
+++ b/java/arcs/android/storage/database/DatabaseGarbageCollectionPeriodicTask.kt
@@ -33,7 +33,7 @@ class DatabaseGarbageCollectionPeriodicTask(
         // Use the DatabaseDriverProvider instance of the databaseManager to make sure changes by
         // GC are propagated to listening Stores.
         val databaseManager = DatabaseDriverProvider.manager
-        databaseManager.runGarbageCollection().join()
+        databaseManager.runGarbageCollection()
         log.debug { "Success." }
         // Indicate whether the task finished successfully with the Result
         Result.success()

--- a/java/arcs/android/storage/service/StorageServiceManager.kt
+++ b/java/arcs/android/storage/service/StorageServiceManager.kt
@@ -41,7 +41,7 @@ class StorageServiceManager(
     override fun clearAll(resultCallback: IResultCallback) {
         scope.launch {
             ArcHostManager.pauseAllHostsFor {
-                DriverFactory.removeAllEntities().join()
+                DriverFactory.removeAllEntities()
                 stores.clear()
             }
             resultCallback.onResult(null)
@@ -55,7 +55,7 @@ class StorageServiceManager(
     ) {
         scope.launch {
             ArcHostManager.pauseAllHostsFor {
-                DriverFactory.removeEntitiesCreatedBetween(startTimeMillis, endTimeMillis).join()
+                DriverFactory.removeEntitiesCreatedBetween(startTimeMillis, endTimeMillis)
             }
             resultCallback.onResult(null)
         }

--- a/java/arcs/android/storage/ttl/PeriodicCleanupTask.kt
+++ b/java/arcs/android/storage/ttl/PeriodicCleanupTask.kt
@@ -33,7 +33,7 @@ class PeriodicCleanupTask(
         // Use the DatabaseDriverProvider instance of the databaseManager to make sure changes by
         // TTL expiry are propagated to listening Stores.
         val databaseManager = DatabaseDriverProvider.manager
-        databaseManager.removeExpiredEntities().join()
+        databaseManager.removeExpiredEntities()
         log.debug { "Success." }
         // Indicate whether the task finished successfully with the Result
         Result.success()

--- a/java/arcs/core/storage/DriverFactory.kt
+++ b/java/arcs/core/storage/DriverFactory.kt
@@ -15,9 +15,9 @@ import arcs.core.type.Type
 import kotlin.reflect.KClass
 import kotlinx.atomicfu.atomic
 import kotlinx.atomicfu.update
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.supervisorScope
 
 /** Factory with which to register and retrieve [Driver]s. */
 object DriverFactory {
@@ -56,25 +56,27 @@ object DriverFactory {
      * memory ones don't), so after calling this method one should create new Store/StorageProxy
      * instances. Therefore using this method requires shutting down all arcs, and should be use
      * only in rare circumstances.
+     *
+     * If removal fails for any of the providers, it will be included as a map entry in the
+     * returned [OperationFailures] map.
      */
-    suspend fun removeAllEntities(): Job = coroutineScope {
-        launch {
-            providers.value.forEach { it.removeAllEntities() }
-        }
+    suspend fun removeAllEntities(): Collection<OperationFailure> = runSafelyOnAllProviders {
+        it.removeAllEntities()
     }
 
     /**
      * Clears all entities created in the given time range. See comments on [removeAllEntities] re
      * the need to recreate stores after calling this method.
+     *
+     * If removal fails for any of the providers, it will be included as a map entry in the
+     * returned [OperationFailures] map.
      */
-    suspend fun removeEntitiesCreatedBetween(startTimeMillis: Long, endTimeMillis: Long): Job =
-        coroutineScope {
-            launch {
-                providers.value.forEach {
-                    it.removeEntitiesCreatedBetween(startTimeMillis, endTimeMillis)
-                }
-            }
-        }
+    suspend fun removeEntitiesCreatedBetween(
+        startTimeMillis: Long,
+        endTimeMillis: Long
+    ): Collection<OperationFailure> = runSafelyOnAllProviders {
+        it.removeEntitiesCreatedBetween(startTimeMillis, endTimeMillis)
+    }
 
     /** Registers a new [DriverProvider]. */
     fun register(driverProvider: DriverProvider) = providers.update { it + setOf(driverProvider) }
@@ -84,7 +86,36 @@ object DriverFactory {
 
     /** Reset the driver registration to an empty set. For use in tests only. */
     fun clearRegistrations() = providers.lazySet(setOf())
+
+    /**
+     * A helper to launch a particle task on all registered providers.
+     *
+     * If any of the jobs throws an exception, it will not stop any of the other jobs or
+     * propagate upwards.
+     *
+     * Any failures will be represented as an [OperationFailure] in the returned collection.
+     */
+    private suspend fun runSafelyOnAllProviders(
+        block: suspend (DriverProvider) -> Unit
+    ): Collection<OperationFailure> = supervisorScope {
+        providers.value
+            .map { driverProvider ->
+                async {
+                    try {
+                        block(driverProvider)
+                        null
+                    } catch (throwable: Throwable) {
+                        OperationFailure(driverProvider, throwable)
+                    }
+                }
+            }
+            .awaitAll()
+            .filterNotNull()
+    }
 }
+
+/** A collection of [OperationFailure] is returned to indicate any failures in batch operations. */
+data class OperationFailure(val driverProvider: DriverProvider, val throwable: Throwable)
 
 /** Provider of information on the [Driver] and characteristics of the storage behind it. */
 interface DriverProvider {

--- a/java/arcs/core/storage/database/DatabaseManager.kt
+++ b/java/arcs/core/storage/database/DatabaseManager.kt
@@ -11,8 +11,6 @@
 
 package arcs.core.storage.database
 
-import kotlinx.coroutines.Job
-
 /**
  * Defines an abstract factory capable of instantiating (or re-using, when necessary) a [Database].
  */
@@ -41,7 +39,7 @@ interface DatabaseManager {
         Map<DatabaseIdentifier, DatabasePerformanceStatistics.Snapshot>
 
     /** Clears all expired entities, in all known databases.  */
-    suspend fun removeExpiredEntities(): Job
+    suspend fun removeExpiredEntities()
 
     /** Clears all entities, in all known databases.  */
     suspend fun removeAllEntities()
@@ -57,7 +55,7 @@ interface DatabaseManager {
     suspend fun resetAll()
 
     /** Garbage collection run: removes unused entities. */
-    suspend fun runGarbageCollection(): Job
+    suspend fun runGarbageCollection()
 }
 
 /** Identifier for an individual [Database] instance. */

--- a/java/arcs/jvm/storage/database/testutil/FakeDatabaseManager.kt
+++ b/java/arcs/jvm/storage/database/testutil/FakeDatabaseManager.kt
@@ -64,7 +64,7 @@ class FakeDatabaseManager : DatabaseManager {
         Map<DatabaseIdentifier, DatabasePerformanceStatistics.Snapshot> =
         mutex.withLock { cache.mapValues { it.value.snapshotStatistics() } }
 
-    override suspend fun removeExpiredEntities(): Job {
+    override suspend fun removeExpiredEntities() {
         throw UnsupportedOperationException("Fake database manager cannot remove entities.")
     }
 
@@ -76,7 +76,7 @@ class FakeDatabaseManager : DatabaseManager {
         throw UnsupportedOperationException("Fake database manager cannot remove entities.")
     }
 
-    override suspend fun runGarbageCollection(): Job {
+    override suspend fun runGarbageCollection() {
         throw UnsupportedOperationException("Fake database does not gargbage collect.")
     }
 

--- a/javatests/arcs/android/entity/TtlHandleTest.kt
+++ b/javatests/arcs/android/entity/TtlHandleTest.kt
@@ -124,7 +124,7 @@ class TtlHandleTest {
 
         // Simulate periodic job triggering.
         log("Removing Expired Entities")
-        databaseManager.removeExpiredEntities().join()
+        databaseManager.removeExpiredEntities()
         updateJob.join()
         assertThat(handle.dispatchFetch()).isEqualTo(null)
 
@@ -227,7 +227,7 @@ class TtlHandleTest {
 
         // Simulate periodic job triggering.
         log("removing expired entities")
-        databaseManager.removeExpiredEntities().join()
+        databaseManager.removeExpiredEntities()
         deferred.await()
         activeWrites.joinAll()
         activeWrites.clear()
@@ -301,7 +301,7 @@ class TtlHandleTest {
         }
 
         // Simulate periodic job triggering.
-        databaseManager.removeExpiredEntities().join()
+        databaseManager.removeExpiredEntities()
 
         deferred1.await()
         deferred2.await()
@@ -361,7 +361,7 @@ class TtlHandleTest {
 
         // Simulate periodic job triggering.
         log("Removing Expired Entities")
-        databaseManager.removeExpiredEntities().join()
+        databaseManager.removeExpiredEntities()
         updateJob.join()
 
         assertThat(handle.dispatchFetchAll()).isEmpty()


### PR DESCRIPTION
The original pattern,

```
fun doSomething = coroutineScope {
  launch {
    ...
  }
}
...
...
doSomething.join()
```

Would throw an exception upstream if anything failed. With this change,
we catch any failures and return them in a collection.