### PR TITLE
Remove `lifecycle` from ServiceStore API

### DIFF
--- a/java/arcs/android/demo/BUILD
+++ b/java/arcs/android/demo/BUILD
@@ -50,7 +50,6 @@ arcs_kt_android_library(
         "//java/arcs/sdk/android/storage/service",
         "//java/arcs/sdk/storage",
         "//third_party/java/androidx/appcompat",
-        "//third_party/java/androidx/lifecycle",
         "//third_party/java/androidx/work",
         "//third_party/kotlin/kotlinx_coroutines",
         "//third_party/kotlin/kotlinx_coroutines:kotlinx_coroutines_android",

--- a/java/arcs/android/host/prod/ProdArcHostService.kt
+++ b/java/arcs/android/host/prod/ProdArcHostService.kt
@@ -45,7 +45,7 @@ open class ProdArcHostService : ArcHostService() {
     override val arcHost: ArcHost by lazy {
         ProdAndroidHost(
             this,
-            this.lifecycle,
+            lifecycle,
             JvmSchedulerProvider(scope.coroutineContext),
             *scanForParticles()
         )

--- a/java/arcs/android/sdk/host/AndroidHost.kt
+++ b/java/arcs/android/sdk/host/AndroidHost.kt
@@ -11,9 +11,9 @@
 package arcs.android.sdk.host
 
 import android.content.Context
+import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleObserver
-import androidx.lifecycle.OnLifecycleEvent
+import androidx.lifecycle.LifecycleOwner
 import arcs.core.host.ArcHost
 import arcs.core.host.ParticleRegistration
 import arcs.core.host.SchedulerProvider
@@ -34,7 +34,7 @@ abstract class AndroidHost(
     schedulerProvider: SchedulerProvider,
     override val activationFactory: ActivationFactory,
     vararg particles: ParticleRegistration
-) : JvmHost(schedulerProvider, *particles), LifecycleObserver {
+) : JvmHost(schedulerProvider, *particles), DefaultLifecycleObserver {
 
     @ExperimentalCoroutinesApi
     constructor(
@@ -46,7 +46,7 @@ abstract class AndroidHost(
         context,
         lifecycle,
         schedulerProvider,
-        ServiceStoreFactory(context, lifecycle),
+        ServiceStoreFactory(context),
         *particles
     )
 
@@ -54,17 +54,18 @@ abstract class AndroidHost(
         lifecycle.addObserver(this)
     }
 
-    /*
-     * Android uses [StorageService] which is a persistent process, so we don't share
-     * [ActiveStore] between [EntityHandleManager]s, but use a new [StoreManager] for each
-     * new arc. Otherwise, when closing an [ActiveStore] when one Arc is shutdown leads to the
-     * handles being unusable in other arcs that are still active.
-     */
     @ExperimentalCoroutinesApi
-    override val stores: StoreManager get() = StoreManager(activationFactory)
+    override val stores: StoreManager = StoreManager(activationFactory)
 
-    @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)
-    fun onLifecycleDestroyed() = runBlocking {
+    override fun onDestroy(owner: LifecycleOwner) {
+        super.onDestroy(owner)
+        runBlocking {
             shutdown()
+        }
+    }
+
+    override suspend fun shutdown() {
+        super.shutdown()
+        stores.reset()
     }
 }

--- a/java/arcs/core/storage/ActiveStore.kt
+++ b/java/arcs/core/storage/ActiveStore.kt
@@ -43,6 +43,9 @@ abstract class ActiveStore<Data : CrdtData, Op : CrdtOperation, ConsumerData>(
     /** Handles a message from the storage proxy. */
     abstract suspend fun onProxyMessage(message: ProxyMessage<Data, Op, ConsumerData>): Boolean
 
+    /** Performs any operations that are needed to release resources held by this [ActiveStore]. */
+    open fun close() = Unit
+
     /**
      * Return a storage endpoint that will receive messages from the store via the
      * provided callback

--- a/java/arcs/core/storage/DirectStore.kt
+++ b/java/arcs/core/storage/DirectStore.kt
@@ -109,7 +109,7 @@ class DirectStore<Data : CrdtData, Op : CrdtOperation, T> /* internal */ constru
     }
 
     /** Closes the store. Once closed, it cannot be re-opened. A new instance must be created. */
-    fun close() {
+    override fun close() {
         synchronized(proxyManager) {
             proxyManager.callbacks.clear()
             closeInternal()

--- a/java/arcs/core/storage/StoreManager.kt
+++ b/java/arcs/core/storage/StoreManager.kt
@@ -50,5 +50,13 @@ class StoreManager(
     /**
      * Drops all [Store] instances.
      */
-    suspend fun reset() = storesMutex.withLock { stores.clear() }
+    suspend fun reset() {
+        storesMutex.withLock {
+            stores.values.also {
+                stores.clear()
+            }
+        }.forEach {
+            it.close()
+        }
+    }
 }

--- a/javatests/arcs/android/e2e/testapp/BUILD
+++ b/javatests/arcs/android/e2e/testapp/BUILD
@@ -52,7 +52,6 @@ arcs_kt_android_library(
         "//java/arcs/sdk/android/storage/service",
         "//java/arcs/sdk/storage",
         "//third_party/java/androidx/appcompat",
-        "//third_party/java/androidx/lifecycle",
         "//third_party/java/androidx/work",
         "//third_party/kotlin/kotlinx_coroutines",
         "//third_party/kotlin/kotlinx_coroutines:kotlinx_coroutines_android",

--- a/javatests/arcs/android/e2e/testapp/TestActivity.kt
+++ b/javatests/arcs/android/e2e/testapp/TestActivity.kt
@@ -75,6 +75,10 @@ class TestActivity : AppCompatActivity() {
 
     private var devToolsService: IDevToolsService? = null
 
+    private val stores = StoreManager(
+        activationFactory = ServiceStoreFactory(context = this@TestActivity)
+    )
+
     private val connection = object : ServiceConnection {
         override fun onServiceConnected(className: ComponentName, service: IBinder) {
             devToolsService = IDevToolsService.Stub.asInterface(service)
@@ -162,6 +166,9 @@ class TestActivity : AppCompatActivity() {
         )
         stopService(intent)
         scope.cancel()
+        runBlocking {
+            stores.reset()
+        }
         super.onDestroy()
     }
 
@@ -172,12 +179,8 @@ class TestActivity : AppCompatActivity() {
             EntityHandleManager(
                 time = JvmTime,
                 scheduler = schedulerProvider("readWriteArc"),
-                stores = StoreManager(
-                    activationFactory = ServiceStoreFactory(
-                        context = this@TestActivity,
-                        lifecycle = this@TestActivity.lifecycle
-                    )
-                )
+                stores = stores
+
             )
         )
         allocator?.startArcForPlan(PersonRecipePlan)
@@ -192,10 +195,7 @@ class TestActivity : AppCompatActivity() {
                 time = JvmTime,
                 scheduler = schedulerProvider("resurrectionArc"),
                 stores = StoreManager(
-                    activationFactory = ServiceStoreFactory(
-                        context = this@TestActivity,
-                        lifecycle = this@TestActivity.lifecycle
-                    )
+                    activationFactory = ServiceStoreFactory(context = this@TestActivity)
                 )
             )
         )
@@ -231,10 +231,7 @@ class TestActivity : AppCompatActivity() {
                 time = JvmTime,
                 scheduler = schedulerProvider("allocator"),
                 stores = StoreManager(
-                    activationFactory = ServiceStoreFactory(
-                        context = this@TestActivity,
-                        lifecycle = this@TestActivity.lifecycle
-                    )
+                    activationFactory = ServiceStoreFactory(context = this@TestActivity)
                 )
             )
         )
@@ -269,10 +266,7 @@ class TestActivity : AppCompatActivity() {
             time = JvmTime,
             scheduler = schedulerProvider("handle"),
             stores = StoreManager(
-                activationFactory = ServiceStoreFactory(
-                    this,
-                    lifecycle
-                )
+                activationFactory = ServiceStoreFactory(this)
             )
         )
         if (isCollection) {

--- a/javatests/arcs/android/entity/BUILD
+++ b/javatests/arcs/android/entity/BUILD
@@ -33,7 +33,6 @@ arcs_kt_android_test_suite(
         "//javatests/arcs/core/entity:lib",
         "//third_party/android/androidx_test/core",
         "//third_party/android/androidx_test/ext/junit",
-        "//third_party/java/androidx/lifecycle",
         "//third_party/java/androidx/work:testing",
         "//third_party/java/junit:junit-android",
         "//third_party/java/truth:truth-android",

--- a/javatests/arcs/android/entity/DifferentAndroidHandleManagerDifferentStoresTest.kt
+++ b/javatests/arcs/android/entity/DifferentAndroidHandleManagerDifferentStoresTest.kt
@@ -1,9 +1,6 @@
 package arcs.android.entity
 
 import android.app.Application
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleOwner
-import androidx.lifecycle.LifecycleRegistry
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.work.testing.WorkManagerTestInitHelper
@@ -16,6 +13,7 @@ import arcs.jvm.host.JvmSchedulerProvider
 import arcs.sdk.android.storage.ServiceStoreFactory
 import arcs.sdk.android.storage.service.testutil.TestConnectionFactory
 import kotlin.coroutines.EmptyCoroutineContext
+import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Before
 import org.junit.runner.RunWith
@@ -23,39 +21,38 @@ import org.junit.runner.RunWith
 @Suppress("EXPERIMENTAL_API_USAGE")
 @RunWith(AndroidJUnit4::class)
 class DifferentAndroidHandleManagerDifferentStoresTest : HandleManagerTestBase() {
-
-    lateinit var fakeLifecycleOwner: FakeLifecycleOwner
     lateinit var app: Application
+
+    lateinit var readStores: StoreManager
+    lateinit var writeStores: StoreManager
 
     @Before
     override fun setUp() {
         super.setUp()
         testTimeout = 60000
-        fakeLifecycleOwner = FakeLifecycleOwner()
-        fakeLifecycleOwner.lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_CREATE)
-        fakeLifecycleOwner.lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_START)
         val dbFactory = AndroidSqliteDatabaseManager(ApplicationProvider.getApplicationContext())
         DatabaseDriverProvider.configure(dbFactory) { throw UnsupportedOperationException() }
         app = ApplicationProvider.getApplicationContext()
         activationFactory = ServiceStoreFactory(
             app,
-            fakeLifecycleOwner.lifecycle,
             connectionFactory = TestConnectionFactory(app)
         )
         schedulerProvider = JvmSchedulerProvider(EmptyCoroutineContext)
+        readStores = StoreManager(activationFactory)
         readHandleManager = EntityHandleManager(
             arcId = "arcId",
             hostId = "hostId",
             time = fakeTime,
             scheduler = schedulerProvider("reader"),
-            stores = StoreManager(activationFactory)
+            stores = readStores
         )
+        writeStores = StoreManager(activationFactory)
         writeHandleManager = EntityHandleManager(
             arcId = "arcId",
             hostId = "hostId",
             time = fakeTime,
             scheduler = schedulerProvider("writer"),
-            stores = StoreManager(activationFactory)
+            stores = writeStores
         )
         // Initialize WorkManager for instrumentation tests.
         WorkManagerTestInitHelper.initializeTestWorkManager(app)
@@ -64,11 +61,9 @@ class DifferentAndroidHandleManagerDifferentStoresTest : HandleManagerTestBase()
     @After
     override fun tearDown() {
         super.tearDown()
-        fakeLifecycleOwner.lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
-    }
-
-    class FakeLifecycleOwner : LifecycleOwner {
-        val lifecycleRegistry = LifecycleRegistry(this)
-        override fun getLifecycle() = lifecycleRegistry
+        runBlocking {
+            readStores.reset()
+            writeStores.reset()
+        }
     }
 }

--- a/javatests/arcs/android/entity/DifferentHandleManagerTest.kt
+++ b/javatests/arcs/android/entity/DifferentHandleManagerTest.kt
@@ -1,9 +1,6 @@
 package arcs.android.entity
 
 import android.app.Application
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleOwner
-import androidx.lifecycle.LifecycleRegistry
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.work.testing.WorkManagerTestInitHelper
@@ -16,6 +13,7 @@ import arcs.jvm.host.JvmSchedulerProvider
 import arcs.sdk.android.storage.ServiceStoreFactory
 import arcs.sdk.android.storage.service.testutil.TestConnectionFactory
 import kotlin.coroutines.EmptyCoroutineContext
+import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Before
 import org.junit.runner.RunWith
@@ -24,25 +22,22 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class DifferentHandleManagerTest : HandleManagerTestBase() {
 
-    lateinit var fakeLifecycleOwner: FakeLifecycleOwner
     lateinit var app: Application
+
+    lateinit var stores: StoreManager
 
     @Before
     override fun setUp() {
         super.setUp()
         testTimeout = 60000
-        fakeLifecycleOwner = FakeLifecycleOwner()
-        fakeLifecycleOwner.lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_CREATE)
-        fakeLifecycleOwner.lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_START)
         val dbFactory = AndroidSqliteDatabaseManager(ApplicationProvider.getApplicationContext())
         DatabaseDriverProvider.configure(dbFactory) { throw UnsupportedOperationException() }
         app = ApplicationProvider.getApplicationContext()
         activationFactory = ServiceStoreFactory(
             app,
-            fakeLifecycleOwner.lifecycle,
             connectionFactory = TestConnectionFactory(app)
         )
-        val stores = StoreManager(activationFactory)
+        stores = StoreManager(activationFactory)
         schedulerProvider = JvmSchedulerProvider(EmptyCoroutineContext)
         readHandleManager = EntityHandleManager(
             arcId = "arcId",
@@ -65,11 +60,8 @@ class DifferentHandleManagerTest : HandleManagerTestBase() {
     @After
     override fun tearDown() {
         super.tearDown()
-        fakeLifecycleOwner.lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
-    }
-
-    class FakeLifecycleOwner : LifecycleOwner {
-        val lifecycleRegistry = LifecycleRegistry(this)
-        override fun getLifecycle() = lifecycleRegistry
+        runBlocking {
+            stores.reset()
+        }
     }
 }

--- a/javatests/arcs/android/host/AndroidEntityHandleManagerTest.kt
+++ b/javatests/arcs/android/host/AndroidEntityHandleManagerTest.kt
@@ -1,9 +1,6 @@
 package arcs.android.host
 
 import android.app.Application
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleOwner
-import androidx.lifecycle.LifecycleRegistry
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.work.testing.WorkManagerTestInitHelper
@@ -63,13 +60,11 @@ fun Person.withQuery(): PersonWithQuery {
 
 @Suppress("EXPERIMENTAL_API_USAGE", "UNCHECKED_CAST")
 @RunWith(AndroidJUnit4::class)
-class AndroidEntityHandleManagerTest : LifecycleOwner {
+class AndroidEntityHandleManagerTest {
     @get:Rule
     val log = LogRule()
 
     private lateinit var app: Application
-    private lateinit var lifecycle: LifecycleRegistry
-    override fun getLifecycle() = lifecycle
 
     val entity1 = Person("Jason", 21.0, false)
     val entity2 = Person("Jason", 22.0, true)
@@ -92,11 +87,6 @@ class AndroidEntityHandleManagerTest : LifecycleOwner {
         RamDisk.clear()
         DriverAndKeyConfigurator.configure(null)
         app = ApplicationProvider.getApplicationContext()
-        lifecycle = LifecycleRegistry(this@AndroidEntityHandleManagerTest).apply {
-            currentState = Lifecycle.State.CREATED
-            currentState = Lifecycle.State.STARTED
-            currentState = Lifecycle.State.RESUMED
-        }
 
         // Initialize WorkManager for instrumentation tests.
         WorkManagerTestInitHelper.initializeTestWorkManager(app)
@@ -111,7 +101,6 @@ class AndroidEntityHandleManagerTest : LifecycleOwner {
             StoreManager(
                 activationFactory = ServiceStoreFactory(
                     context = app,
-                    lifecycle = lifecycle,
                     connectionFactory = TestConnectionFactory(app)
                 )
             )

--- a/javatests/arcs/android/host/BUILD
+++ b/javatests/arcs/android/host/BUILD
@@ -93,7 +93,6 @@ arcs_kt_android_library(
         "//javatests/arcs/core/host:particle",
         "//javatests/arcs/core/host:testhost",
         "//third_party/java/androidx/appcompat",
-        "//third_party/java/androidx/lifecycle",
         "//third_party/java/robolectric",
         "//third_party/kotlin/kotlinx_coroutines",
         "//third_party/kotlin/kotlinx_coroutines:kotlinx_coroutines_test",

--- a/javatests/arcs/android/host/TestExternalArcHostService.kt
+++ b/javatests/arcs/android/host/TestExternalArcHostService.kt
@@ -4,8 +4,6 @@ import android.app.Service
 import android.content.Context
 import android.content.Intent
 import android.os.IBinder
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleObserver
 import arcs.android.sdk.host.ArcHostHelper
 import arcs.android.sdk.host.ResurrectableHost
 import arcs.core.data.Capabilities
@@ -46,12 +44,6 @@ abstract class TestExternalArcHostService : Service() {
         scope.cancel()
     }
 
-    class FakeLifecycle : Lifecycle() {
-        override fun addObserver(p0: LifecycleObserver) = Unit
-        override fun removeObserver(p0: LifecycleObserver) = Unit
-        override fun getCurrentState(): State = State.CREATED
-    }
-
     @ExperimentalCoroutinesApi
     abstract class TestingAndroidHost(
         context: Context,
@@ -62,9 +54,8 @@ abstract class TestExternalArcHostService : Service() {
         override val stores = StoreManager(
             activationFactory = ServiceStoreFactory(
                 context,
-                FakeLifecycle(),
-                Dispatchers.Default,
-                testConnectionFactory
+                coroutineContext = Dispatchers.Default,
+                connectionFactory = testConnectionFactory
             )
         )
 

--- a/javatests/arcs/android/systemhealth/testapp/BUILD
+++ b/javatests/arcs/android/systemhealth/testapp/BUILD
@@ -46,7 +46,6 @@ arcs_kt_android_library(
         "//java/arcs/sdk/android/storage/service",
         "//java/arcs/sdk/storage",
         "//third_party/java/androidx/appcompat",
-        "//third_party/java/androidx/lifecycle",
         "//third_party/java/androidx/work",
         "//third_party/kotlin/kotlinx_atomicfu",
         "//third_party/kotlin/kotlinx_coroutines",

--- a/javatests/arcs/android/systemhealth/testapp/LocalService.kt
+++ b/javatests/arcs/android/systemhealth/testapp/LocalService.kt
@@ -11,11 +11,11 @@
 
 package arcs.android.systemhealth.testapp
 
+import android.app.Service
 import android.content.Intent
 import android.os.Binder
 import android.os.IBinder
 import android.os.Process
-import androidx.lifecycle.LifecycleService
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 
 /**
@@ -24,8 +24,8 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
  * stability of storage service, etc.
  */
 @ExperimentalCoroutinesApi
-class LocalService : LifecycleService() {
-    private val storageCore = StorageCore(this, lifecycle)
+class LocalService : Service() {
+    private val storageCore = StorageCore(this)
     private val binder = Binder()
 
     override fun onDestroy() {

--- a/javatests/arcs/android/systemhealth/testapp/RemoteService.kt
+++ b/javatests/arcs/android/systemhealth/testapp/RemoteService.kt
@@ -11,10 +11,10 @@
 
 package arcs.android.systemhealth.testapp
 
+import android.app.Service
 import android.content.Intent
 import android.os.Binder
 import android.os.IBinder
-import androidx.lifecycle.LifecycleService
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 
 /**
@@ -23,8 +23,8 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
  * stability of storage clients, etc.
  */
 @ExperimentalCoroutinesApi
-class RemoteService : LifecycleService() {
-    private val storageCore = StorageCore(this, lifecycle)
+class RemoteService : Service() {
+    private val storageCore = StorageCore(this)
     private val binder = Binder()
 
     override fun onBind(intent: Intent): IBinder {

--- a/javatests/arcs/android/systemhealth/testapp/StorageCore.kt
+++ b/javatests/arcs/android/systemhealth/testapp/StorageCore.kt
@@ -15,7 +15,6 @@ import android.content.Context
 import android.content.Intent
 import android.os.Debug
 import android.os.Trace
-import androidx.lifecycle.Lifecycle
 import arcs.android.systemhealth.testapp.Dispatchers as ArcsDispatchers
 import arcs.core.data.CollectionType
 import arcs.core.data.EntityType
@@ -96,7 +95,7 @@ private typealias TaskEventQueue<T> = Pair<ReadWriteLock, MutableList<T>>
 
 /** System health test core for performance, power, memory footprint and stability. */
 @ExperimentalCoroutinesApi
-class StorageCore(val context: Context, val lifecycle: Lifecycle) {
+class StorageCore(val context: Context) {
     /** Query the last record of system-health stats */
     val statsBulletin: String
         get() = _statsBulletin.value
@@ -267,6 +266,7 @@ class StorageCore(val context: Context, val lifecycle: Lifecycle) {
 
         // Task and handle manager assignments
         controllers = arrayOfNulls(numOfTasks)
+
         handles = tasks.mapIndexed { id, task ->
             // Per-task single-threaded execution context with Watchdog monitoring instabilities
             val taskCoroutineContext =
@@ -277,28 +277,29 @@ class StorageCore(val context: Context, val lifecycle: Lifecycle) {
                         performanceExceptionHandler(id)
                     }
 
+            val stores = StoreManager(
+                activationFactory = ServiceStoreFactory(
+                    context,
+                    taskCoroutineContext,
+                    DefaultConnectionFactory(
+                        context,
+                        if (settings.function == Function.STABILITY_TEST) {
+                            StabilityStorageServiceBindingDelegate(context)
+                        } else {
+                            PerformanceStorageServiceBindingDelegate(context)
+                        },
+                        taskCoroutineContext
+                    )
+                )
+            )
             TaskHandle(
                 EntityHandleManager(
                     time = JvmTime,
-                    stores = StoreManager(
-                        activationFactory = ServiceStoreFactory(
-                            context,
-                            lifecycle,
-                            taskCoroutineContext,
-                            DefaultConnectionFactory(
-                                context,
-                                if (settings.function == Function.STABILITY_TEST) {
-                                    StabilityStorageServiceBindingDelegate(context)
-                                } else {
-                                    PerformanceStorageServiceBindingDelegate(context)
-                                },
-                                taskCoroutineContext
-                            )
-                        )
-                    ),
+                    stores = stores,
                     // Per-task single-threaded Scheduler being cascaded with Watchdog capabilities
                     scheduler = TestSchedulerProvider(taskCoroutineContext)("sysHealthStorageCore")
                 ),
+                stores,
                 taskCoroutineContext
             ).apply {
                 val taskType = when {
@@ -725,6 +726,7 @@ class StorageCore(val context: Context, val lifecycle: Lifecycle) {
             handles.forEach {
                 runBlocking {
                     it.handleManager.close()
+                    it.stores.reset()
                 }
             }
             handles = emptyArray()
@@ -1150,6 +1152,7 @@ class StorageCore(val context: Context, val lifecycle: Lifecycle) {
 
     private data class TaskHandle(
         val handleManager: EntityHandleManager,
+        val stores: StoreManager,
         val coroutineContext: CoroutineContext,
         var handle: Any? = null
     )

--- a/javatests/arcs/android/systemhealth/testapp/TestActivity.kt
+++ b/javatests/arcs/android/systemhealth/testapp/TestActivity.kt
@@ -90,6 +90,13 @@ class TestActivity : AppCompatActivity() {
         override fun onServiceDisconnected(name: ComponentName) = bound.update { false }
     }
 
+    private val stores = StoreManager(
+        activationFactory = ServiceStoreFactory(
+            this,
+            coroutineContext
+        )
+    )
+
     init {
         // Supply the default settings being displayed on UI at app. startup.
         SystemHealthData.Settings().let {
@@ -113,13 +120,8 @@ class TestActivity : AppCompatActivity() {
         handleManager = EntityHandleManager(
             time = JvmTime,
             scheduler = schedulerProvider("sysHealthTestActivity"),
-            stores = StoreManager(
-                activationFactory = ServiceStoreFactory(
-                    this,
-                    lifecycle,
-                    coroutineContext
-                )
-            )
+            stores = stores
+
         )
 
         resultTextView = findViewById(R.id.result)
@@ -394,6 +396,7 @@ class TestActivity : AppCompatActivity() {
         runBlocking(coroutineContext) {
             singletonHandle?.close()
             collectionHandle?.close()
+            stores.reset()
         }
 
         scope.cancel()

--- a/javatests/arcs/core/entity/DifferentHandleManagerDifferentStoresTest.kt
+++ b/javatests/arcs/core/entity/DifferentHandleManagerDifferentStoresTest.kt
@@ -6,6 +6,7 @@ import arcs.core.storage.StoreWriteBack
 import arcs.core.storage.testutil.WriteBackForTesting
 import arcs.jvm.host.JvmSchedulerProvider
 import kotlin.coroutines.EmptyCoroutineContext
+import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Before
 import org.junit.runner.RunWith
@@ -16,28 +17,39 @@ import org.junit.runners.JUnit4
 class DifferentHandleManagerDifferentStoresTest : HandleManagerTestBase() {
     private var i = 0
 
+    private lateinit var readStores: StoreManager
+    private lateinit var writeStores: StoreManager
+
     @Before
     override fun setUp() {
         super.setUp()
         i++
         StoreWriteBack.writeBackFactoryOverride = WriteBackForTesting
         schedulerProvider = JvmSchedulerProvider(EmptyCoroutineContext)
+        readStores = StoreManager()
         readHandleManager = EntityHandleManager(
             arcId = "testArcId",
             hostId = "testHostId",
             time = fakeTime,
             scheduler = schedulerProvider("reader-#$i"),
-            stores = StoreManager()
+            stores = readStores
         )
+        writeStores = StoreManager()
         writeHandleManager = EntityHandleManager(
             arcId = "testArcId",
             hostId = "testHostId",
             time = fakeTime,
             scheduler = schedulerProvider("writer"),
-            stores = StoreManager()
+            stores = writeStores
         )
     }
 
     @After
-    override fun tearDown() = super.tearDown()
+    override fun tearDown() {
+        super.tearDown()
+        runBlocking {
+            readStores.reset()
+            writeStores.reset()
+        }
+    }
 }

--- a/javatests/arcs/sdk/android/storage/BUILD
+++ b/javatests/arcs/sdk/android/storage/BUILD
@@ -41,7 +41,6 @@ arcs_kt_android_test_suite(
         "//third_party/android/androidx_test/core",
         "//third_party/android/androidx_test/ext/junit",
         "//third_party/android/androidx_test/runner/monitor",
-        "//third_party/java/androidx/lifecycle",
         "//third_party/java/junit:junit-android",
         "//third_party/java/robolectric",
         "//third_party/java/robolectric:shadows",

--- a/javatests/arcs/showcase/BUILD
+++ b/javatests/arcs/showcase/BUILD
@@ -30,7 +30,6 @@ arcs_kt_android_library(
         "//java/arcs/sdk/android/storage/service",
         "//java/arcs/sdk/android/storage/service/testutil",
         "//third_party/android/androidx_test/core",
-        "//third_party/java/androidx/lifecycle",
         "//third_party/java/androidx/work:testing",
         "//third_party/java/junit:junit-android",
         "//third_party/kotlin/kotlinx_coroutines",

--- a/javatests/arcs/showcase/ShowcaseEnvironment.kt
+++ b/javatests/arcs/showcase/ShowcaseEnvironment.kt
@@ -3,9 +3,6 @@
 package arcs.showcase
 
 import android.app.Application
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleOwner
-import androidx.lifecycle.LifecycleRegistry
 import androidx.test.core.app.ApplicationProvider
 import androidx.work.testing.WorkManagerTestInitHelper
 import arcs.android.storage.database.AndroidSqliteDatabaseManager
@@ -33,7 +30,6 @@ import kotlin.coroutines.EmptyCoroutineContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import org.junit.rules.TestRule
 import org.junit.runner.Description
@@ -161,19 +157,12 @@ class ShowcaseEnvironment(
 
         DriverAndKeyConfigurator.configure(dbManager)
 
-        // Set up an android lifecycle for our arc host and store managers.
-        val lifecycleOwner = FakeLifecycleOwner()
-        withContext(Dispatchers.Main.immediate) {
-            lifecycleOwner.lifecycle.currentState = Lifecycle.State.RESUMED
-        }
-
         // Create a single scheduler provider for both the ArcHost as well as the Allocator.
         val schedulerProvider = JvmSchedulerProvider(EmptyCoroutineContext)
 
         // Ensure we're using the StorageService (via the TestConnectionFactory)
         val activationFactory = ServiceStoreFactory(
             context,
-            lifecycleOwner.lifecycle,
             connectionFactory = TestConnectionFactory(context)
         )
 
@@ -196,13 +185,14 @@ class ShowcaseEnvironment(
             }
         )
 
-        return ShowcaseArcsComponents(dbManager, arcHostStoreManager, lifecycleOwner, arcHost)
+        return ShowcaseArcsComponents(dbManager, arcHostStoreManager, arcHost)
     }
 
     private suspend fun teardownArcs(components: ShowcaseArcsComponents) {
         // Stop all the arcs and shut down the arcHost.
         startedArcs.forEach { it.stop() }
         components.arcHost.shutdown()
+        components.arcHostStoreManager.reset()
 
         // Reset the Databases and close them.
         components.dbManager.resetAll()
@@ -212,14 +202,8 @@ class ShowcaseEnvironment(
     private data class ShowcaseArcsComponents(
         val dbManager: AndroidSqliteDatabaseManager,
         val arcHostStoreManager: StoreManager,
-        val arcHostLifecycle: FakeLifecycleOwner,
         val arcHost: ArcHost
     )
-
-    private class FakeLifecycleOwner : LifecycleOwner {
-        private val lifecycle = LifecycleRegistry(this)
-        override fun getLifecycle() = lifecycle
-    }
 }
 
 /**

--- a/javatests/arcs/showcase/references/BUILD
+++ b/javatests/arcs/showcase/references/BUILD
@@ -39,7 +39,6 @@ arcs_kt_android_library(
         "//java/arcs/sdk/android/storage",
         "//java/arcs/sdk/android/storage/service",
         "//javatests/arcs/showcase",
-        "//third_party/java/androidx/lifecycle",
         "//third_party/kotlin/kotlinx_coroutines",
     ],
 )


### PR DESCRIPTION
 lot has changed since ServiceStore was originally built, and this
feature doesn't make as much sense now (and is causing difficulties).

The primary reasons to move forward on removing this now are:
1) LifecycleRegistry is not thread safe. In a recent update, it now also
enforces main thread interaction.

2) AiAi's current usage patterns are not owned by a lifecycle at all, so
we have to synthetically create one, anyway.

We're only using the lifecycle functionality to trigger cleanup on
destroy, so we don't lose a lot by removing this. But we need to take
care in some contexts to make sure to clean up any owned stores.