### PR TITLE
Plan `registerSchemas` function adds all contained schemas to SchemaRegistry at start of Arc

### DIFF
--- a/java/arcs/core/allocator/Allocator.kt
+++ b/java/arcs/core/allocator/Allocator.kt
@@ -89,6 +89,7 @@ class Allocator(
      * Start a new Arc given a [Plan] and return an [Arc].
      */
     private suspend fun startArcForPlan(plan: Plan, nameForTesting: String): Arc = mutex.withLock {
+        plan.init()
         plan.arcId?.toArcId()?.let { arcId ->
             val existingPartitions = partitionMap.readPartitions(arcId)
             if (existingPartitions.isNotEmpty()) {

--- a/java/arcs/core/allocator/Allocator.kt
+++ b/java/arcs/core/allocator/Allocator.kt
@@ -89,7 +89,7 @@ class Allocator(
      * Start a new Arc given a [Plan] and return an [Arc].
      */
     private suspend fun startArcForPlan(plan: Plan, nameForTesting: String): Arc = mutex.withLock {
-        plan.init()
+        plan.registerSchemas()
         plan.arcId?.toArcId()?.let { arcId ->
             val existingPartitions = partitionMap.readPartitions(arcId)
             if (existingPartitions.isNotEmpty()) {

--- a/java/arcs/core/data/Plan.kt
+++ b/java/arcs/core/data/Plan.kt
@@ -44,7 +44,7 @@ data class Plan(
         allTypes.forEach { registerSchema(it) }
     }
 
-    /** Add contained [Schema]s to the [SchemaRegistry] */
+    /** Add contained [Schema] to the [SchemaRegistry] */
     private fun registerSchema(type: Type?): Unit = when(type) {
         null -> Unit
         is EntitySchemaProviderType -> type.entitySchema?.let { SchemaRegistry.register(it) } ?: Unit

--- a/java/arcs/core/data/Plan.kt
+++ b/java/arcs/core/data/Plan.kt
@@ -33,6 +33,25 @@ data class Plan(
             }
         }
 
+
+    /** Initialize the [Plan]. */
+    fun init() {
+        // Register all Schemas
+        val allTypes = handles.map { it.type } + particles
+            .flatMap { it.handles.values }
+            .map { it.type }
+
+        allTypes.forEach { registerSchema(it) }
+    }
+
+    /** Add contained [Schema]s to the [SchemaRegistry] */
+    private fun registerSchema(type: Type?): Unit = when(type) {
+        null -> Unit
+        is EntitySchemaProviderType -> type.entitySchema?.let { SchemaRegistry.register(it) } ?: Unit
+        is Type.TypeContainer<*> -> registerSchema(type.containedType)
+        else -> registerSchema(type.resolvedType)
+    }
+
     /**
      * A [Particle] consists of the information necessary to instantiate a particle
      * when starting an arc.

--- a/java/arcs/core/data/Plan.kt
+++ b/java/arcs/core/data/Plan.kt
@@ -33,22 +33,24 @@ data class Plan(
             }
         }
 
-
     /** Adds all [Schema]s from the [Plan] to the [SchemaRegistry]. */
     fun registerSchemas() {
-        // Register all Schemas
-        val allTypes = handles.map { it.type } + particles
-            .flatMap { it.handles.values }
-            .map { it.type }
+        val connections = particles.flatMap { it.handles.values }
+        val allTypes = handles.map { it.type } +
+            connections.map { it.type } +
+            connections.map { it.handle.type }
 
         allTypes.forEach { registerSchema(it) }
     }
 
     /** Add contained [Schema] to the [SchemaRegistry] */
-    private fun registerSchema(type: Type?): Unit = when(type) {
+    private fun registerSchema(type: Type?): Unit = when (type) {
         null -> Unit
-        is EntitySchemaProviderType -> type.entitySchema?.let { SchemaRegistry.register(it) } ?: Unit
+        is TypeVariable -> registerSchema(type.constraint)
         is Type.TypeContainer<*> -> registerSchema(type.containedType)
+        is EntitySchemaProviderType -> type.entitySchema?.let {
+            SchemaRegistry.register(it)
+        } ?: Unit
         else -> registerSchema(type.resolvedType)
     }
 

--- a/java/arcs/core/data/Plan.kt
+++ b/java/arcs/core/data/Plan.kt
@@ -34,8 +34,8 @@ data class Plan(
         }
 
 
-    /** Initialize the [Plan]. */
-    fun init() {
+    /** Adds all [Schema]s from the [Plan] to the [SchemaRegistry]. */
+    fun registerSchemas() {
         // Register all Schemas
         val allTypes = handles.map { it.type } + particles
             .flatMap { it.handles.values }

--- a/javatests/arcs/core/data/PlanTest.kt
+++ b/javatests/arcs/core/data/PlanTest.kt
@@ -1,0 +1,100 @@
+package arcs.core.data
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class PlanTest {
+
+    @Test
+    fun registerSchemas_fromHandle() {
+        val targetSchema = Schema(setOf(SchemaName("target")), Schema.EMPTY.fields, "someHash")
+        val handle = Plan.Handle(
+            CreatableStorageKey("bla"),
+            SingletonType(EntityType(targetSchema)),
+            emptyList()
+        )
+        val plan = Plan(emptyList(), listOf(handle), emptyList())
+
+        plan.registerSchemas()
+
+        // TODO(b/154855864) Replace with regular equality test when lambdas are gone
+        assertThat(SchemaRegistry.getSchema("someHash").toLiteral())
+            .isEqualTo(targetSchema.toLiteral())
+    }
+
+    @Test
+    fun registerSchemas_fromParticle_general() {
+        val handleSchema = Schema(setOf(SchemaName("Foo")), Schema.EMPTY.fields, "handleHash")
+        val connectionSchema = Schema(
+            setOf(SchemaName("Bar")),
+            Schema.EMPTY.fields,
+            "connectionHash"
+        )
+
+        val handle = Plan.Handle(
+            CreatableStorageKey("bla"),
+            SingletonType(EntityType(handleSchema)),
+            emptyList()
+        )
+        val handleConnection = Plan.HandleConnection(
+            handle = handle,
+            mode = HandleMode.ReadWrite,
+            type = CollectionType(ReferenceType(EntityType(connectionSchema)))
+
+        )
+        val particle = Plan.Particle(
+            "someName",
+            "someLocation",
+            mapOf(
+                "data" to handleConnection
+            )
+        )
+        val plan = Plan(listOf(particle), emptyList(), emptyList())
+
+        plan.registerSchemas()
+
+        // TODO(b/154855864) Replace with regular equality test when lambdas are gone
+        assertThat(SchemaRegistry.getSchema("handleHash").toLiteral())
+            .isEqualTo(handleSchema.toLiteral())
+        assertThat(SchemaRegistry.getSchema("connectionHash").toLiteral())
+            .isEqualTo(connectionSchema.toLiteral())
+        assertThat(SchemaRegistry.getSchema("connectionHash"))
+    }
+
+    @Test
+    fun registerSchemas_fromParticle_variable() {
+        val handleSchema = Schema(setOf(SchemaName("Foo")), Schema.EMPTY.fields, "handleHash")
+        val varSchema = Schema(setOf(SchemaName("Baz")), Schema.EMPTY.fields, "varHash")
+
+        val handle = Plan.Handle(
+            CreatableStorageKey("bla"),
+            SingletonType(EntityType(handleSchema)),
+            emptyList()
+        )
+
+        val variableHandleConnection = Plan.HandleConnection(
+            handle = handle,
+            mode = HandleMode.ReadWrite,
+            type = CollectionType(TypeVariable("a", EntityType(varSchema)))
+        )
+        val particle = Plan.Particle(
+            "someName",
+            "someLocation",
+            mapOf(
+                "data" to variableHandleConnection
+            )
+        )
+        val plan = Plan(listOf(particle), emptyList(), emptyList())
+
+        plan.registerSchemas()
+
+        // TODO(b/154855864) Replace with regular equality test when lambdas are gone
+        assertThat(SchemaRegistry.getSchema("handleHash").toLiteral())
+            .isEqualTo(handleSchema.toLiteral())
+        assertThat(SchemaRegistry.getSchema("varHash").toLiteral())
+            .isEqualTo(varSchema.toLiteral())
+    }
+}


### PR DESCRIPTION
Addresses bug (b/162099401) where schemas are not registered in plans. This occurs with type variables, and possible for other types. 

The solution proposed here is to add an initialization method to plans that traverse all `Type` objects in the data class and register their contained `Schema` into the `SchemaRegistry`. 