### PR TITLE
Restrict Plan.Handle Type in recipe2plan.

### DIFF
--- a/java/arcs/core/data/testdata/WriterReaderExample.arcs
+++ b/java/arcs/core/data/testdata/WriterReaderExample.arcs
@@ -5,7 +5,13 @@ particle Reader in 'arcs.core.data.testdata.Reader'
   data: reads Thing {name: Text}
 
 particle Writer in 'arcs.core.data.testdata.Writer'
-   data: writes Thing {name: Text}
+   data: writes Thing {name: Text, description: Text}
+
+@arcId('writingOnlyArcId')
+recipe IngestionOnly
+  thing: create 'my-handle-id-www' @persistent @ttl('20d')
+  Writer
+    data: writes thing
 
 @arcId('writingArcId')
 recipe Ingestion

--- a/java/arcs/core/data/testdata/WriterReaderPoliciesExample.arcs
+++ b/java/arcs/core/data/testdata/WriterReaderPoliciesExample.arcs
@@ -1,0 +1,9 @@
+schema Thing
+  name: Text
+
+policy WriterReaderExamplePolicy {
+  @allowedRetention(medium: 'Disk', encryption: true)
+  @allowedRetention(medium: 'Ram', encryption: false)
+  @maxAge('100d')
+  from Thing access { name }
+}

--- a/src/runtime/type.ts
+++ b/src/runtime/type.ts
@@ -44,6 +44,8 @@ export abstract class Type {
 
   abstract toLiteral(): TypeLiteral;
 
+  abstract restrictToType(type: Type): Type|null;
+
   static unwrapPair(type1: Type, type2: Type): [Type, Type] {
     if (type1.tag === type2.tag) {
       const contained1 = type1.getContainedType();
@@ -316,6 +318,10 @@ export class CountType extends Type {
     return {tag: 'Count'};
   }
 
+  restrictToType(type: Type): Type|null {
+    throw new Error(`'restrictToType' is not supported for ${this.tag}`);
+  }
+
   crdtInstanceConstructor() {
     return CRDTCount;
   }
@@ -363,6 +369,10 @@ export class SingletonType<T extends Type> extends Type {
 
   get canReadSubset() {
     return this.innerType.canReadSubset;
+  }
+
+  restrictToType(type: Type): Type|null {
+    return new SingletonType(this.innerType.restrictToType(type));
   }
 }
 
@@ -443,6 +453,17 @@ export class EntityType extends Type {
     // Currently using SingletonHandle as the implementation for Entity handles.
     // TODO: Make an EntityHandle class that uses the proper Entity CRDT.
     throw new Error(`Entity handle not yet implemented - you probably want to use a SingletonType`);
+  }
+
+  restrictToType(type: Type): Type|null {
+    const fields = {};
+    for (const [fieldName, field] of Object.entries(this.getEntitySchema().fields)) {
+      const policyField = type.getEntitySchema().fields[fieldName];
+      if (policyField) {
+        fields[fieldName] = Schema.restrictField(field, policyField);
+      }
+    }
+    return EntityType.make([type.getEntitySchema().name], fields, type.getEntitySchema());
   }
 }
 
@@ -545,8 +566,14 @@ export class TypeVariable extends Type {
   toPrettyString(): string {
     return this.variable.isResolved() ? this.resolvedType().toPrettyString() : `[~${this.variable.name}]`;
   }
-}
 
+  restrictToType(type: Type): Type|null {
+    if (!this.variable.isResolved()) return null;
+    const typeVar = new TypeVariable(new TypeVariableInfo(this.variable.name));
+    typeVar.variable.resolution = this.variable.resolution.restrictToType(type);
+    return typeVar;
+  }
+}
 
 export class CollectionType<T extends Type> extends Type {
   readonly collectionType: T;
@@ -641,6 +668,10 @@ export class CollectionType<T extends Type> extends Type {
   handleConstructor<T>() {
     return CollectionType.handleClass;
   }
+
+  restrictToType(type: Type): Type|null {
+    return new CollectionType(this.collectionType.restrictToType(type));
+  }
 }
 
 export class BigCollectionType<T extends Type> extends Type {
@@ -727,6 +758,10 @@ export class BigCollectionType<T extends Type> extends Type {
     }
     return `Collection of ${this.bigCollectionType.toPrettyString()}`;
   }
+
+  restrictToType(type: Type): Type|null {
+    throw new Error(`'restrictToType' is not supported for ${this.tag}`);
+  }
 }
 
 export class TupleType extends Type {
@@ -800,6 +835,11 @@ export class TupleType extends Type {
 
   toPrettyString(): string {
     return 'Tuple of ' + this.innerTypes.map(t => t.toPrettyString()).join(', ');
+  }
+
+  restrictToType(type: Type): Type|null {
+    // TODO(b/159143604): implement.
+    throw new Error(`'restrictToType' is not supported for ${this.tag}`);
   }
 }
 
@@ -888,6 +928,10 @@ export class InterfaceType extends Type {
   toPrettyString(): string {
     return this.interfaceInfo.toPrettyString();
   }
+
+  restrictToType(type: Type): Type|null {
+    throw new Error(`'restrictToType' is not supported for ${this.tag}`);
+  }
 }
 
 
@@ -950,6 +994,10 @@ export class SlotType extends Type {
       fieldsString = ` {${fields.join(', ')}}`;
     }
     return `Slot${fieldsString}`;
+  }
+
+  restrictToType(type: Type): Type|null {
+    throw new Error(`'restrictToType' is not supported for ${this.tag}`);
   }
 }
 
@@ -1032,6 +1080,10 @@ export class ReferenceType<T extends Type> extends Type {
   crdtInstanceConstructor<T extends CRDTTypeRecord>(): new () => CRDTModel<T> {
     return this.referredType.crdtInstanceConstructor();
   }
+
+  restrictToType(type: Type): Type|null {
+    return new ReferenceType(this.referredType.restrictToType(type));
+  }
 }
 
 export class MuxType<T extends Type> extends Type {
@@ -1112,6 +1164,10 @@ export class MuxType<T extends Type> extends Type {
   handleConstructor<T>() {
     return MuxType.handleClass;
   }
+
+  restrictToType(type: Type): Type|null {
+    throw new Error(`'restrictToType' is not supported for ${this.tag}`);
+  }
 }
 
 export class HandleType extends Type {
@@ -1125,6 +1181,10 @@ export class HandleType extends Type {
 
   toLiteral(): TypeLiteral {
     return {tag: this.tag};
+  }
+
+  restrictToType(type: Type): Type|null {
+    throw new Error(`'restrictToType' is not supported for ${this.tag}`);
   }
 }
 

--- a/src/runtime/type.ts
+++ b/src/runtime/type.ts
@@ -44,6 +44,9 @@ export abstract class Type {
 
   abstract toLiteral(): TypeLiteral;
 
+  // Creates a Type with same tag as this (e.g. CollectionType, if this is a
+  // collection), with entity Schema fields restricted according to the fields
+  // in the given `type` parameter (used for ingress restricting).
   abstract restrictToType(type: Type): Type|null;
 
   static unwrapPair(type1: Type, type2: Type): [Type, Type] {
@@ -318,7 +321,7 @@ export class CountType extends Type {
     return {tag: 'Count'};
   }
 
-  restrictToType(type: Type): Type|null {
+  restrictToType(type: Type): Type {
     throw new Error(`'restrictToType' is not supported for ${this.tag}`);
   }
 
@@ -371,7 +374,7 @@ export class SingletonType<T extends Type> extends Type {
     return this.innerType.canReadSubset;
   }
 
-  restrictToType(type: Type): Type|null {
+  restrictToType(type: Type): Type {
     return new SingletonType(this.innerType.restrictToType(type));
   }
 }
@@ -455,7 +458,7 @@ export class EntityType extends Type {
     throw new Error(`Entity handle not yet implemented - you probably want to use a SingletonType`);
   }
 
-  restrictToType(type: Type): Type|null {
+  restrictToType(type: Type): Type {
     const fields = {};
     for (const [fieldName, field] of Object.entries(this.getEntitySchema().fields)) {
       const policyField = type.getEntitySchema().fields[fieldName];
@@ -567,7 +570,7 @@ export class TypeVariable extends Type {
     return this.variable.isResolved() ? this.resolvedType().toPrettyString() : `[~${this.variable.name}]`;
   }
 
-  restrictToType(type: Type): Type|null {
+  restrictToType(type: Type): Type {
     if (!this.variable.isResolved()) return null;
     const typeVar = new TypeVariable(new TypeVariableInfo(this.variable.name));
     typeVar.variable.resolution = this.variable.resolution.restrictToType(type);
@@ -669,7 +672,7 @@ export class CollectionType<T extends Type> extends Type {
     return CollectionType.handleClass;
   }
 
-  restrictToType(type: Type): Type|null {
+  restrictToType(type: Type): Type {
     return new CollectionType(this.collectionType.restrictToType(type));
   }
 }
@@ -759,7 +762,7 @@ export class BigCollectionType<T extends Type> extends Type {
     return `Collection of ${this.bigCollectionType.toPrettyString()}`;
   }
 
-  restrictToType(type: Type): Type|null {
+  restrictToType(type: Type): Type {
     throw new Error(`'restrictToType' is not supported for ${this.tag}`);
   }
 }
@@ -837,7 +840,7 @@ export class TupleType extends Type {
     return 'Tuple of ' + this.innerTypes.map(t => t.toPrettyString()).join(', ');
   }
 
-  restrictToType(type: Type): Type|null {
+  restrictToType(type: Type): Type {
     // TODO(b/159143604): implement.
     throw new Error(`'restrictToType' is not supported for ${this.tag}`);
   }
@@ -929,7 +932,7 @@ export class InterfaceType extends Type {
     return this.interfaceInfo.toPrettyString();
   }
 
-  restrictToType(type: Type): Type|null {
+  restrictToType(type: Type): Type {
     throw new Error(`'restrictToType' is not supported for ${this.tag}`);
   }
 }
@@ -996,7 +999,7 @@ export class SlotType extends Type {
     return `Slot${fieldsString}`;
   }
 
-  restrictToType(type: Type): Type|null {
+  restrictToType(type: Type): Type {
     throw new Error(`'restrictToType' is not supported for ${this.tag}`);
   }
 }
@@ -1081,7 +1084,7 @@ export class ReferenceType<T extends Type> extends Type {
     return this.referredType.crdtInstanceConstructor();
   }
 
-  restrictToType(type: Type): Type|null {
+  restrictToType(type: Type): Type {
     return new ReferenceType(this.referredType.restrictToType(type));
   }
 }
@@ -1165,7 +1168,7 @@ export class MuxType<T extends Type> extends Type {
     return MuxType.handleClass;
   }
 
-  restrictToType(type: Type): Type|null {
+  restrictToType(type: Type): Type {
     throw new Error(`'restrictToType' is not supported for ${this.tag}`);
   }
 }
@@ -1183,7 +1186,7 @@ export class HandleType extends Type {
     return {tag: this.tag};
   }
 
-  restrictToType(type: Type): Type|null {
+  restrictToType(type: Type): Type {
     throw new Error(`'restrictToType' is not supported for ${this.tag}`);
   }
 }

--- a/src/tools/recipe2plan-cli.ts
+++ b/src/tools/recipe2plan-cli.ts
@@ -35,6 +35,7 @@ Options
   --format  output format, 'kotlin' or 'proto', defaults to 'kotlin'
   --recipe  a name of the recipe to turn into a plan. If not
             provided all recipes in the manifest will be encoded.
+  --policies a name of the manifest file containing policies
   --quiet, -q  suppress log output
   --help        usage info
 `);
@@ -72,7 +73,10 @@ void Flags.withDefaultReferenceMode(async () => {
     fs.mkdirSync(opts.outdir, {recursive: true});
 
     const manifest = await Runtime.parseFile(opts._[0]);
-    const plans = await recipe2plan(manifest, outFormat, opts.recipe);
+    // TODO(b/159144612): Make policies manifest parameter mandatory.
+    const policiesManifest = opts.policies
+        ? await Runtime.parseFile(opts.policies) : await Runtime.parse(``);
+    const plans = await recipe2plan(manifest, policiesManifest, outFormat, opts.recipe);
 
     const outPath = path.join(opts.outdir, opts.outfile);
     if (!opts.quiet) {

--- a/src/tools/recipe2plan-cli.ts
+++ b/src/tools/recipe2plan-cli.ts
@@ -73,10 +73,9 @@ void Flags.withDefaultReferenceMode(async () => {
     fs.mkdirSync(opts.outdir, {recursive: true});
 
     const manifest = await Runtime.parseFile(opts._[0]);
-    // TODO(b/159144612): Make policies manifest parameter mandatory.
-    const policiesManifest = opts.policies
-        ? await Runtime.parseFile(opts.policies) : await Runtime.parse(``);
-    const plans = await recipe2plan(manifest, policiesManifest, outFormat, opts.recipe);
+    const policiesManifest =
+        opts.policies ? await Runtime.parseFile(opts.policies) : null;
+    const plans = await recipe2plan(manifest, outFormat, policiesManifest, opts.recipe);
 
     const outPath = path.join(opts.outdir, opts.outfile);
     if (!opts.quiet) {

--- a/src/tools/recipe2plan.ts
+++ b/src/tools/recipe2plan.ts
@@ -26,8 +26,8 @@ export enum OutputFormat { Kotlin, Proto }
  */
 export async function recipe2plan(
   manifest: Manifest,
-  policiesManifest: Manifest,
   format: OutputFormat,
+  policiesManifest?: Manifest,
   recipeFilter?: string,
   salt = `salt_${Math.random()}`): Promise<string | Uint8Array> {
   let plans = await (new AllocatorRecipeResolver(manifest, salt)).resolve();
@@ -37,8 +37,7 @@ export async function recipe2plan(
     if (plans.length === 0) throw Error(`Recipe '${recipeFilter}' not found.`);
   }
 
-  // TODO(b/159142859): Ingress validation shouldn't be optional.
-  const ingressValidation = policiesManifest.policies.length > 0
+  const ingressValidation = policiesManifest
       ? new IngressValidation(policiesManifest.policies) : null;
 
   switch (format) {

--- a/src/tools/recipe2plan.ts
+++ b/src/tools/recipe2plan.ts
@@ -12,6 +12,7 @@ import {PlanGenerator} from './plan-generator.js';
 import {assert} from '../platform/assert-node.js';
 import {encodePlansToProto} from './manifest2proto.js';
 import {Manifest} from '../runtime/manifest.js';
+import {IngressValidation} from '../runtime/policy/ingress-validation.js';
 
 export enum OutputFormat { Kotlin, Proto }
 
@@ -25,6 +26,7 @@ export enum OutputFormat { Kotlin, Proto }
  */
 export async function recipe2plan(
   manifest: Manifest,
+  policiesManifest: Manifest,
   format: OutputFormat,
   recipeFilter?: string,
   salt = `salt_${Math.random()}`): Promise<string | Uint8Array> {
@@ -35,10 +37,14 @@ export async function recipe2plan(
     if (plans.length === 0) throw Error(`Recipe '${recipeFilter}' not found.`);
   }
 
+  // TODO(b/159142859): Ingress validation shouldn't be optional.
+  const ingressValidation = policiesManifest.policies.length > 0
+      ? new IngressValidation(policiesManifest.policies) : null;
+
   switch (format) {
     case OutputFormat.Kotlin:
       assert(manifest.meta.namespace, `Namespace is required in '${manifest.fileName}' for Kotlin code generation.`);
-      return new PlanGenerator(plans, manifest.meta.namespace).generate();
+      return new PlanGenerator(plans, manifest.meta.namespace, ingressValidation).generate();
     case OutputFormat.Proto:
       return Buffer.from(await encodePlansToProto(plans, manifest));
     default: throw new Error('Output Format should be Kotlin or Proto');

--- a/src/tools/tests/goldens/WriterReaderExample.kt
+++ b/src/tools/tests/goldens/WriterReaderExample.kt
@@ -12,6 +12,48 @@ import arcs.core.data.Plan.*
 import arcs.core.storage.StorageKeyParser
 import arcs.core.entity.toPrimitiveValue
 
+val IngestionOnly_Handle0 = Handle(
+    StorageKeyParser.parse(
+        "reference-mode://{db://9ca32bb55138c5efc3b107bcd9d60a73e2428160@arcs/Thing}{db://9ca32bb55138c5efc3b107bcd9d60a73e2428160@arcs/!:writingOnlyArcId/handle/my-handle-id-www}"
+    ),
+    arcs.core.data.EntityType(
+        arcs.core.data.Schema(
+            setOf(arcs.core.data.SchemaName("Thing")),
+            arcs.core.data.SchemaFields(
+                singletons = mapOf("name" to arcs.core.data.FieldType.Text),
+                collections = emptyMap()
+            ),
+            "25e71af4e9fc8b6958fc46a8f4b7cdf6b5f31516",
+            refinement = { _ -> true },
+            query = null
+        )
+    ),
+    listOf(
+        Annotation("persistent", emptyMap()),
+        Annotation("ttl", mapOf("value" to AnnotationParam.Str("20d")))
+    )
+)
+val IngestionOnlyPlan = Plan(
+    listOf(
+        Particle(
+            "Writer",
+            "arcs.core.data.testdata.Writer",
+            mapOf(
+                "data" to HandleConnection(
+                    IngestionOnly_Handle0,
+                    HandleMode.Write,
+                    arcs.core.data.SingletonType(arcs.core.data.EntityType(Writer_Data.SCHEMA)),
+                    listOf(
+                        Annotation("persistent", emptyMap()),
+                        Annotation("ttl", mapOf("value" to AnnotationParam.Str("20d")))
+                    )
+                )
+            )
+        )
+    ),
+    listOf(IngestionOnly_Handle0),
+    listOf(Annotation("arcId", mapOf("id" to AnnotationParam.Str("writingOnlyArcId"))))
+)
 val Ingestion_Handle0 = Handle(
     StorageKeyParser.parse(
         "reference-mode://{db://25e71af4e9fc8b6958fc46a8f4b7cdf6b5f31516@arcs/Thing}{db://25e71af4e9fc8b6958fc46a8f4b7cdf6b5f31516@arcs/!:writingArcId/handle/my-handle-id}"

--- a/src/tools/tests/plan-generator-tests.ts
+++ b/src/tools/tests/plan-generator-tests.ts
@@ -13,6 +13,7 @@ import {assert} from '../../platform/chai-node.js';
 import {Manifest} from '../../runtime/manifest.js';
 import {AllocatorRecipeResolver} from '../allocator-recipe-resolver.js';
 import {Recipe} from '../../runtime/recipe/recipe.js';
+import {IngressValidation} from '../../runtime/policy/ingress-validation.js';
 
 describe('plan generator', () => {
   it('imports arcs.core.data when the package is different', () => {
@@ -293,14 +294,75 @@ val MyRecipe_Handle0 = Handle(
     emptyList()
 )`);
   });
-  async function process(manifestString: string): Promise<{
+
+  it('restricts handle types according to policies', async () => {
+    const schemaString = `
+schema Thing
+  a: Text
+  b: Text
+  c: Text
+    `;
+    const policiesManifest = `
+${schemaString}
+policy Policy0 {
+  @allowedRetention(medium: 'Ram', encryption: false)
+  @maxAge('10d')
+  from Thing access { a }
+}
+policy Policy1 {
+  @allowedRetention(medium: 'Ram', encryption: false)
+  @maxAge('10d')
+  from Thing access { b }
+}
+    `;
+    const {generator, recipes} = await process(`
+${schemaString}
+particle Writer
+  things: writes [Thing {a, b, c}]
+recipe ThingWriter
+  handle0: create 'my-things' @ttl('3d')
+  Writer
+    things: handle0
+    `, policiesManifest);
+    const handle = recipes[0].handles[0];
+    assert.deepEqual(Object.keys(handle.type.getEntitySchema().fields), ['a', 'b', 'c']);
+
+    // Verify field `c` is dropped, because it is not allowed by the policies.
+    const handleObject = await generator.createHandleVariable(handle);
+    assert.equal(handleObject, `\
+val ThingWriter_Handle0 = Handle(
+    StorageKeyParser.parse("create://my-things"),
+    arcs.core.data.CollectionType(
+        arcs.core.data.EntityType(
+            arcs.core.data.Schema(
+                setOf(arcs.core.data.SchemaName("Thing")),
+                arcs.core.data.SchemaFields(
+                    singletons = mapOf(
+                        "a" to arcs.core.data.FieldType.Text,
+                        "b" to arcs.core.data.FieldType.Text
+                    ),
+                    collections = emptyMap()
+                ),
+                "451b4c23ec9bf2d1973079fd0732539297806b3c",
+                refinement = { _ -> true },
+                query = null
+            )
+        )
+    ),
+    listOf(Annotation("ttl", mapOf("value" to AnnotationParam.Str("3d"))))
+)`);
+  });
+
+  async function process(manifestString: string, policiesManifestString?: string): Promise<{
       recipes: Recipe[],
       generator: PlanGenerator,
       plan: string
   }> {
     const manifest = await Manifest.parse(manifestString);
+    const ingressValidation = policiesManifestString
+        ? new IngressValidation((await Manifest.parse(policiesManifestString)).policies) : null;
     const recipes = await new AllocatorRecipeResolver(manifest, 'random_salt').resolve();
-    const generator = new PlanGenerator(recipes, manifest.meta.namespace || 'test.namespace');
+    const generator = new PlanGenerator(recipes, manifest.meta.namespace || 'test.namespace', ingressValidation);
     const plan = await generator.generate();
     return {recipes, generator, plan};
   }

--- a/src/tools/tests/recipe2plan-test.ts
+++ b/src/tools/tests/recipe2plan-test.ts
@@ -22,14 +22,14 @@ const readManifest = async (manifestPath) => await Runtime.parseFile(manifestPat
 describe('recipe2plan', () => {
   it('generates Kotlin plans from recipes in a manifest', Flags.withDefaultReferenceMode(async () => {
     assert.deepStrictEqual(
-      await recipe2plan(await readManifest(inputManifestPath), await readManifest(policiesManifestPath), OutputFormat.Kotlin),
+      await recipe2plan(await readManifest(inputManifestPath), OutputFormat.Kotlin, await readManifest(policiesManifestPath)),
       fs.readFileSync('src/tools/tests/goldens/WriterReaderExample.kt', 'utf8'),
       `Golden is out of date! Make sure the new script is correct. If it is, update the goldens with:
 $ tools/update-goldens \n\n`
     );
   }));
   it('generates Proto plans for multiple recipes in a manifest', Flags.withDefaultReferenceMode(async () => {
-    const encoded = await recipe2plan(await readManifest(inputManifestPath), await readManifest(policiesManifestPath), OutputFormat.Proto) as Uint8Array;
+    const encoded = await recipe2plan(await readManifest(inputManifestPath), OutputFormat.Proto, await readManifest(policiesManifestPath)) as Uint8Array;
     const decoded = ManifestProto.decode(encoded);
 
     // Only validating that the output can be can be decoded as a ManifestProto and right counts.
@@ -38,7 +38,7 @@ $ tools/update-goldens \n\n`
     assert.lengthOf(decoded['particleSpecs'], 3);
   }));
   it('filters generated plans by provided name', Flags.withDefaultReferenceMode(async () => {
-    const encoded = await recipe2plan(await readManifest(inputManifestPath), await readManifest(policiesManifestPath), OutputFormat.Proto, 'Consumption') as Uint8Array;
+    const encoded = await recipe2plan(await readManifest(inputManifestPath), OutputFormat.Proto, await readManifest(policiesManifestPath), 'Consumption') as Uint8Array;
     const decoded = ManifestProto.decode(encoded);
     assert.lengthOf(decoded['recipes'], 1);
     assert.lengthOf(decoded['particleSpecs'], 1);
@@ -282,7 +282,7 @@ $ tools/update-goldens \n\n`
   async function protoPayloadFor(manifestString: string) {
     const manifest = await Manifest.parse(manifestString);
     // We encode and decode back to ensure that data can be serialized to proto and deserialized back.
-    const encoded = await recipe2plan(manifest, await readManifest(policiesManifestPath), OutputFormat.Proto, /* recipeFilter= */ null, 'random_salt') as Uint8Array;
+    const encoded = await recipe2plan(manifest, OutputFormat.Proto, await readManifest(policiesManifestPath), /* recipeFilter= */ null, 'random_salt') as Uint8Array;
     return ManifestProto.decode(encoded).toJSON();
   }
 });

--- a/src/tools/tests/recipe2plan-test.ts
+++ b/src/tools/tests/recipe2plan-test.ts
@@ -16,28 +16,29 @@ import {Runtime} from '../../runtime/runtime.js';
 import {Manifest} from '../../runtime/manifest.js';
 
 const inputManifestPath = 'java/arcs/core/data/testdata/WriterReaderExample.arcs';
-const readManifest = async () => await Runtime.parseFile(inputManifestPath);
+const policiesManifestPath = 'java/arcs/core/data/testdata/WriterReaderPoliciesExample.arcs';
+const readManifest = async (manifestPath) => await Runtime.parseFile(manifestPath);
 
 describe('recipe2plan', () => {
   it('generates Kotlin plans from recipes in a manifest', Flags.withDefaultReferenceMode(async () => {
     assert.deepStrictEqual(
-      await recipe2plan(await readManifest(), OutputFormat.Kotlin),
+      await recipe2plan(await readManifest(inputManifestPath), await readManifest(policiesManifestPath), OutputFormat.Kotlin),
       fs.readFileSync('src/tools/tests/goldens/WriterReaderExample.kt', 'utf8'),
       `Golden is out of date! Make sure the new script is correct. If it is, update the goldens with:
 $ tools/update-goldens \n\n`
     );
   }));
   it('generates Proto plans for multiple recipes in a manifest', Flags.withDefaultReferenceMode(async () => {
-    const encoded = await recipe2plan(await readManifest(), OutputFormat.Proto) as Uint8Array;
+    const encoded = await recipe2plan(await readManifest(inputManifestPath), await readManifest(policiesManifestPath), OutputFormat.Proto) as Uint8Array;
     const decoded = ManifestProto.decode(encoded);
 
     // Only validating that the output can be can be decoded as a ManifestProto and right counts.
     // Tests for for encoding works are in manifest2proto-test.ts.
-    assert.lengthOf(decoded['recipes'], 5);
+    assert.lengthOf(decoded['recipes'], 6);
     assert.lengthOf(decoded['particleSpecs'], 3);
   }));
   it('filters generated plans by provided name', Flags.withDefaultReferenceMode(async () => {
-    const encoded = await recipe2plan(await readManifest(), OutputFormat.Proto, 'Consumption') as Uint8Array;
+    const encoded = await recipe2plan(await readManifest(inputManifestPath), await readManifest(policiesManifestPath), OutputFormat.Proto, 'Consumption') as Uint8Array;
     const decoded = ManifestProto.decode(encoded);
     assert.lengthOf(decoded['recipes'], 1);
     assert.lengthOf(decoded['particleSpecs'], 1);
@@ -281,7 +282,7 @@ $ tools/update-goldens \n\n`
   async function protoPayloadFor(manifestString: string) {
     const manifest = await Manifest.parse(manifestString);
     // We encode and decode back to ensure that data can be serialized to proto and deserialized back.
-    const encoded = await recipe2plan(manifest, OutputFormat.Proto, /* recipeFilter= */ null, 'random_salt') as Uint8Array;
+    const encoded = await recipe2plan(manifest, await readManifest(policiesManifestPath), OutputFormat.Proto, /* recipeFilter= */ null, 'random_salt') as Uint8Array;
     return ManifestProto.decode(encoded).toJSON();
   }
 });

--- a/tools/update-goldens
+++ b/tools/update-goldens
@@ -20,5 +20,5 @@ status "[ 4 / 5 ] Golden for Schema generation"
 tools/sigh schema2wasm --quiet --kotlin src/tools/tests/golden_kt.arcs --outdir src/tools/tests/goldens/ --outfile kt_generated-schemas.jvm.kt
 
 status "[ 5 / 5 ] Recipe2Plan Golden"
-tools/sigh recipe2plan --quiet --format kotlin java/arcs/core/data/testdata/WriterReaderExample.arcs --outdir src/tools/tests/goldens/ --outfile WriterReaderExample.kt
+tools/sigh recipe2plan --quiet --format kotlin java/arcs/core/data/testdata/WriterReaderExample.arcs --policies=java/arcs/core/data/testdata/WriterReaderPoliciesExample.arcs  --outdir src/tools/tests/goldens/ --outfile WriterReaderExample.kt
 


### PR DESCRIPTION
- Pass IngestionValidation object to:
    - recipe2plan (for capabilities verification - in follow up PR) and
    - plan-generator: to restrict Plan.Handle Type according to policies
    - Note: currently this is optional parameter, will be made mandatory in followup PRs
- Refactor IngressValidation’s restrictType method to produce a same tag Type (Collection if original type was Collection etc), with a restricted entitySchema (previously always returned EntityType with restricted Schema.
- Update WriterReaderExample.arc golden tests:
    - Add a corresponding Policies file
    - Add IngestionOnly recipe, so that Writer’s schema is restricted to policy allowed field only