### PR TITLE
DFA: Use type in particle connection instead of the one in spec.

### DIFF
--- a/java/arcs/core/analysis/InformationFlow.kt
+++ b/java/arcs/core/analysis/InformationFlow.kt
@@ -143,7 +143,8 @@ class InformationFlow private constructor(
         particle.handleConnections.filter { it.spec.isWrite() }
             .flatMap { handleConnection ->
                 val root = AccessPath.Root.HandleConnection(particle, handleConnection.spec)
-                handleConnection.spec.type.getAccessPaths(root).map { it to mixedLabels.copy() }
+                val resolvedType = particle.getResolvedType(handleConnection.spec)
+                resolvedType.getAccessPaths(root).map { it to mixedLabels.copy() }
             }.toMap(resultAccessPathLabels)
 
         // Apply claims if any.
@@ -190,7 +191,8 @@ class InformationFlow private constructor(
         val accessPathLabels = input.accessPathLabels ?: return input
         val handleConnection = AccessPath.Root.HandleConnection(toParticle, spec)
         val handle = AccessPath.Root.Handle(fromHandle)
-        val targetSelectors = spec.type.accessPathSelectors()
+        val resolvedType = toParticle.getResolvedType(spec)
+        val targetSelectors = resolvedType.accessPathSelectors()
 
         // Filter out the information pertaining to the given handle -> handle-connection edge.
         // Also, convert the root of the access path from handle to handle-connection.
@@ -230,6 +232,14 @@ class InformationFlow private constructor(
                     AccessPath(toHandleRoot, component + accessPath.selectors) to labels
                 }.toMap()
         )
+    }
+
+    /** Returns the resolved type for the given handle connection spec in the particle. */
+    private fun Particle.getResolvedType(connectionSpec: HandleConnectionSpec): Type {
+        val connection = requireNotNull(handleConnections.find { it.spec == connectionSpec }) {
+            "Unable to find a handle connection for ${connectionSpec.name} in a particle."
+        }
+        return connection.type
     }
 
     /** Returns all the [AccessPath] instances for this [Type] with the given [root]. */

--- a/javatests/arcs/core/analysis/InformationFlowTest.kt
+++ b/javatests/arcs/core/analysis/InformationFlowTest.kt
@@ -115,6 +115,7 @@ class InformationFlowTest {
             "fail-field-entity-ref-direct",
             "fail-field-collection-direct",
             "fail-field-claim-propagates",
+            "fail-field-claim-propagates-type-variables",
             "fail-field-merge-multiple-paths"
         )
         val okFieldTests = listOf(
@@ -122,6 +123,7 @@ class InformationFlowTest {
             "ok-field-entity-ref-direct",
             "ok-field-collection-direct",
             "ok-field-claim-propagates",
+            "ok-field-claim-propagates-type-variables",
             "ok-field-merge-multiple-paths"
         )
         val okCycleTests = listOf(

--- a/javatests/arcs/core/analysis/testdata/fail_field_claim_propagates_type_variables.arcs
+++ b/javatests/arcs/core/analysis/testdata/fail_field_claim_propagates_type_variables.arcs
@@ -1,0 +1,27 @@
+// #Ingress: P1
+// #Fail: hc:P4.foo.b is untrusted
+particle P1
+  foo: writes Foo {a: Text, b: Number}
+  claim foo.a is trusted
+  claim foo.b is untrusted
+particle P2
+  foo: reads ~a with {a: Text}  // Constraints
+  bar: writes ~b
+particle P3
+  baz: reads Bar {b: Text}
+  foo: writes [~a]
+  check baz.b is trusted
+particle P4
+  foo: reads [Foo {b: Number}]
+  check foo.b is untrusted
+recipe R
+  P1
+    foo: writes h1
+  P2
+    foo: reads h1
+    bar: writes h2
+  P3
+    baz: reads h2
+    foo: writes h3
+  P4
+    foo: reads h3

--- a/javatests/arcs/core/analysis/testdata/fail_field_claim_propagates_type_variables.arcs
+++ b/javatests/arcs/core/analysis/testdata/fail_field_claim_propagates_type_variables.arcs
@@ -6,10 +6,13 @@ particle P1
   claim foo.b is untrusted
 particle P2
   foo: reads ~a with {a: Text}  // Constraints
-  bar: writes ~b
+  bar: writes Bar {b: Text}
+particle PassThrough
+  input: reads ~a
+  output: writes ~a
 particle P3
   baz: reads Bar {b: Text}
-  foo: writes [~a]
+  foo: writes [Foo {b: Number}]
   check baz.b is trusted
 particle P4
   foo: reads [Foo {b: Number}]
@@ -19,7 +22,10 @@ recipe R
     foo: writes h1
   P2
     foo: reads h1
-    bar: writes h2
+    bar: writes passThrough
+  PassThrough
+    input: passThrough
+    output: h2
   P3
     baz: reads h2
     foo: writes h3

--- a/javatests/arcs/core/analysis/testdata/ok_field_claim_propagates_type_variables.arcs
+++ b/javatests/arcs/core/analysis/testdata/ok_field_claim_propagates_type_variables.arcs
@@ -1,0 +1,27 @@
+// #Ingress: P1
+// #OK
+particle P1
+  foo: writes Foo {a: Text, b: Number}
+  claim foo.a is trusted
+  claim foo.b is untrusted
+particle P2
+  foo: reads ~a with {a: Text} // Constraints
+  bar: writes ~b
+particle P3
+  baz: reads Bar {b: Text}
+  foo: writes [~a]
+  check baz.b is trusted
+particle P4
+  foo: reads [Foo {b: Number}]
+  check foo.b is trusted
+recipe R
+  P1
+    foo: writes h1
+  P2
+    foo: reads h1
+    bar: writes h2
+  P3
+    baz: reads h2
+    foo: writes h3
+  P4
+    foo: reads h3

--- a/javatests/arcs/core/analysis/testdata/ok_field_claim_propagates_type_variables.arcs
+++ b/javatests/arcs/core/analysis/testdata/ok_field_claim_propagates_type_variables.arcs
@@ -6,10 +6,13 @@ particle P1
   claim foo.b is untrusted
 particle P2
   foo: reads ~a with {a: Text} // Constraints
-  bar: writes ~b
+  bar: writes Bar {b: Text}
+particle PassThrough
+  input: reads ~a
+  output: writes ~a
 particle P3
   baz: reads Bar {b: Text}
-  foo: writes [~a]
+  foo: writes [Foo {b:Number}]
   check baz.b is trusted
 particle P4
   foo: reads [Foo {b: Number}]
@@ -20,6 +23,9 @@ recipe R
   P2
     foo: reads h1
     bar: writes h2
+  PassThrough
+    input: passThrough
+    output: h2
   P3
     baz: reads h2
     foo: writes h3


### PR DESCRIPTION
The resolved type of a particle connection is stored in the Particle's handle connection objects. This PR fixes a bug where DFA was looking at the type in the handle connection spec, instead of the type in a Particle's handle connection. 