### PR TITLE
Fixes bug with parsing of DFA field paths and type variables.

### DIFF
--- a/src/runtime/field-path.ts
+++ b/src/runtime/field-path.ts
@@ -8,7 +8,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 import {Schema} from './schema.js';
-import {InterfaceInfo, Type, EntityType, TupleType} from './type.js';
+import {InterfaceInfo, Type, EntityType, TupleType, TypeVariable} from './type.js';
 import {SchemaPrimitiveTypeValue, KotlinPrimitiveTypeValue} from './manifest-ast-nodes.js';
 import {Dictionary} from './hot.js';
 
@@ -34,7 +34,8 @@ export function resolveFieldPathType(fieldPath: string[], type: FieldPathType): 
   const schema = type.getEntitySchema();
   if (!schema) {
     if (InterfaceInfo.isTypeVar(type)) {
-      if (type.canWriteSuperset == null) {
+      const innerType = type.canWriteSuperset || (type as TypeVariable).variable.resolution;
+      if (innerType == null) {
         throw new FieldPathError(`Type variable ${type} does not contain field '${fieldPath[0]}'.`);
       }
       return resolveFieldPathType(fieldPath, type.canWriteSuperset);


### PR DESCRIPTION
The field path validation code currently only works against unresolved type variables (i.e. type variables with constraints). However, when that type variable gets fully resolved, the type constraints are lost. (To repro this bug, call `normalize()` and `clone()` on a recipe with a type variable.)

The fix is to fallback to the type variable's resolved type if the constraint is missing. This should be safe, since the original ParticleSpec from the manifest is known to have already passed validation, meaning the resolved type (a subset of the constraints) should also pass.

This PR includes another fix, where resolved types were not being copied across to the new ParticleSpec until after the constructor had already run (and the constructor is where the validation code was invoked, hence this would fail).