### PR TITLE
Reland: Add refinement support for Kotlin Long and Kotlin Int

### DIFF
--- a/src/runtime/manifest-ast-nodes.ts
+++ b/src/runtime/manifest-ast-nodes.ts
@@ -32,6 +32,7 @@ export interface SourceLocation {
   filename?: string;
   start: SourcePosition;
   end: SourcePosition;
+  text?: string; // Optionally keeps a copy of the raw/unparsed text.
 }
 
 /**
@@ -678,7 +679,7 @@ export interface RefinementNode extends BaseNode {
   expression: RefinementExpressionNode;
 }
 
-export type RefinementExpressionNode = BinaryExpressionNode | UnaryExpressionNode | FieldNode | QueryNode | BuiltInNode | NumberNode | BigIntNode | BooleanNode | TextNode;
+export type RefinementExpressionNode = BinaryExpressionNode | UnaryExpressionNode | FieldNode | QueryNode | BuiltInNode | NumberNode | DiscreteNode | BooleanNode | TextNode;
 
 export enum Op {
   AND = 'and',
@@ -727,15 +728,33 @@ export interface BuiltInNode extends BaseNode {
   value: string;
 }
 
+export enum Primitive {
+  BOOLEAN = 'Boolean',
+  NUMBER = 'Number',
+  BIGINT = 'BigInt',
+  LONG = 'Long',
+  INT = 'Int',
+  TEXT = 'Text',
+  UNKNOWN = '~query_arg_type',
+}
+
 export interface NumberNode extends BaseNode {
   kind: 'number-node';
-  value: number ;
+  value: number;
   units?: string[];
 }
 
-export interface BigIntNode extends BaseNode {
-  kind: 'bigint-node';
-  value: bigint ;
+export type DiscreteType = Primitive.BIGINT | Primitive.INT | Primitive.LONG | Primitive.BOOLEAN;
+export const discreteTypes: Primitive[] = [
+  Primitive.BIGINT,
+  Primitive.LONG,
+  Primitive.INT
+];
+
+export interface DiscreteNode extends BaseNode {
+  kind: 'discrete-node';
+  value: bigint;
+  type: DiscreteType;
   units?: string[];
 }
 
@@ -965,3 +984,18 @@ export type All = Import|Meta|MetaName|MetaStorageKey|MetaNamespace|Particle|Par
 
 export type ManifestItem =
     RecipeNode|Particle|Import|Schema|ManifestStorage|Interface|Meta|Resource;
+
+export function viewAst(ast: unknown, viewLocation = false) {
+  // Helper function useful for viewing ast information while working on the parser and test code:
+  // Optionally, strips location information.
+  console.log(
+    JSON.stringify(ast, (_key, value) => {
+    if (!viewLocation && value != null && value['location']) {
+      delete value['location'];
+    }
+    return typeof value === 'bigint'
+      ? value.toString() // Workaround for JSON not supporting bigint.
+      : value;
+  }, // return everything else unchanged
+  2));
+}

--- a/src/runtime/refiner.ts
+++ b/src/runtime/refiner.ts
@@ -1622,10 +1622,10 @@ interface OperatorInfo {
 const numericTypes: Primitive[] = [Primitive.NUMBER].concat(discreteTypes);
 
 // From https://kotlinlang.org/docs/reference/basic-types.html
-const INT_MIN: bigint = BigInt("-2147483648");
-const INT_MAX: bigint = BigInt("2147483647");
-const LONG_MIN: bigint = BigInt("-9223372036854775808");
-const LONG_MAX: bigint = BigInt("9223372036854775807");
+const INT_MIN: bigint = BigInt("-2147483648"); // -2**31
+const INT_MAX: bigint = BigInt("2147483647"); // 2**31 - 1
+const LONG_MIN: bigint = BigInt("-9223372036854775808"); // -2**63
+const LONG_MAX: bigint = BigInt("9223372036854775807"); // 2**63 - 1
 
 const operatorTable: Dictionary<OperatorInfo> = {
   // Booleans

--- a/src/runtime/refiner.ts
+++ b/src/runtime/refiner.ts
@@ -1621,27 +1621,11 @@ interface OperatorInfo {
 
 const numericTypes: Primitive[] = [Primitive.NUMBER].concat(discreteTypes);
 
-function powBigInt(x: bigint, n: bigint): bigint {
-  if (n < 0) {
-    throw new Error(`RangeError: Exponent must be non-negative`);
-  }
-  switch (n) {
-    case BigInt(0): return BigInt(1);
-    case BigInt(1): return x;
-    default: break;
-  }
-  const k = n/BigInt(2);
-  const d = n%BigInt(2);
-  const x_k = powBigInt(x, k);
-  const x_d = powBigInt(x, d);
-  return x_k*x_k*x_d;
-}
-
 // From https://kotlinlang.org/docs/reference/basic-types.html
-const INT_MIN: bigint = -powBigInt(BigInt(2), BigInt(31));
-const INT_MAX: bigint = powBigInt(BigInt(2), BigInt(31)) - BigInt(1);
-const LONG_MIN: bigint = -powBigInt(BigInt(2), BigInt(63));
-const LONG_MAX: bigint = powBigInt(BigInt(2), BigInt(63)) - BigInt(1);
+const INT_MIN: bigint = BigInt("-2147483648");
+const INT_MAX: bigint = BigInt("2147483647");
+const LONG_MIN: bigint = BigInt("-9223372036854775808");
+const LONG_MAX: bigint = BigInt("9223372036854775807");
 
 const operatorTable: Dictionary<OperatorInfo> = {
   // Booleans

--- a/src/runtime/refiner.ts
+++ b/src/runtime/refiner.ts
@@ -1584,7 +1584,26 @@ interface OperatorInfo {
   evalType: Primitive | 'same';
 }
 
-const numericTypes = [Primitive.NUMBER, Primitive.BIGINT];
+const numericTypes: Primitive[] = [Primitive.NUMBER].concat(discreteTypes);
+
+function powBigInt(x: bigint, n: bigint): bigint {
+  switch (n) {
+    case BigInt(0): return BigInt(1);
+    case BigInt(1): return x;
+    default: break;
+  }
+  const k = n/BigInt(2);
+  const d = n%BigInt(2);
+  const x_k = powBigInt(x, k);
+  const x_d = powBigInt(x, d);
+  return x_k*x_k*x_d;
+}
+
+// From https://kotlinlang.org/docs/reference/basic-types.html
+const INT_MIN: bigint = -powBigInt(BigInt(2), BigInt(31))
+const INT_MAX: bigint = powBigInt(BigInt(2), BigInt(31)) - BigInt(1);
+const LONG_MIN: bigint = -powBigInt(BigInt(2), BigInt(63));
+const LONG_MAX: bigint = powBigInt(BigInt(2), BigInt(63)) - BigInt(1);
 
 const operatorTable: Dictionary<OperatorInfo> = {
   // Booleans

--- a/src/runtime/refiner.ts
+++ b/src/runtime/refiner.ts
@@ -1622,10 +1622,10 @@ interface OperatorInfo {
 const numericTypes: Primitive[] = [Primitive.NUMBER].concat(discreteTypes);
 
 // From https://kotlinlang.org/docs/reference/basic-types.html
-const INT_MIN: bigint = BigInt("-2147483648"); // -2**31
-const INT_MAX: bigint = BigInt("2147483647"); // 2**31 - 1
-const LONG_MIN: bigint = BigInt("-9223372036854775808"); // -2**63
-const LONG_MAX: bigint = BigInt("9223372036854775807"); // 2**63 - 1
+const INT_MIN: bigint = BigInt('-2147483648'); // -2**31
+const INT_MAX: bigint = BigInt('2147483647'); // 2**31 - 1
+const LONG_MIN: bigint = BigInt('-9223372036854775808'); // -2**63
+const LONG_MAX: bigint = BigInt('9223372036854775807'); // 2**63 - 1
 
 const operatorTable: Dictionary<OperatorInfo> = {
   // Booleans

--- a/src/runtime/refiner.ts
+++ b/src/runtime/refiner.ts
@@ -1622,6 +1622,9 @@ interface OperatorInfo {
 const numericTypes: Primitive[] = [Primitive.NUMBER].concat(discreteTypes);
 
 function powBigInt(x: bigint, n: bigint): bigint {
+  if (n < 0) {
+    throw new Error(`RangeError: Exponent must be non-negative`);
+  }
   switch (n) {
     case BigInt(0): return BigInt(1);
     case BigInt(1): return x;

--- a/src/runtime/sql-refinement-generator.ts
+++ b/src/runtime/sql-refinement-generator.ts
@@ -8,10 +8,10 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {Op} from './manifest-ast-nodes.js';
+import {Op, Primitive} from './manifest-ast-nodes.js';
 import {Dictionary} from './hot.js';
 import {Schema} from './schema.js';
-import {RefinementExpressionVisitor, BinaryExpression, UnaryExpression, FieldNamePrimitive, QueryArgumentPrimitive, BuiltIn, NumberPrimitive, BigIntPrimitive, BooleanPrimitive, TextPrimitive, Primitive} from './refiner.js';
+import {RefinementExpressionVisitor, BinaryExpression, UnaryExpression, FieldNamePrimitive, QueryArgumentPrimitive, BuiltIn, NumberPrimitive, DiscretePrimitive, TextPrimitive} from './refiner.js';
 
 const sqlOperator: Dictionary<string> = {
   [Op.AND]: 'AND',
@@ -61,14 +61,16 @@ class SqlRefinementGenerator extends RefinementExpressionVisitor<string> {
     // TODO: Implement SQL getter for 'creationTimeStamp'
     throw new Error(`Unhandled BuiltInNode '${expr.value}' in toSQLExpression`);
   }
-  visitBigIntPrimitive(expr: BigIntPrimitive): string {
-    return expr.value.toString();
+  visitDiscretePrimitive(expr: DiscretePrimitive): string {
+    switch (expr.evalType) {
+      case Primitive.BOOLEAN:
+        throw new Error('BooleanPrimitive.toSQLExpression should never be called. The expression is assumed to be normalized.');
+      default:
+        return expr.value.toString();
+    }
   }
   visitNumberPrimitive(expr: NumberPrimitive): string {
     return expr.value.toString();
-  }
-  visitBooleanPrimitive(_: BooleanPrimitive): string {
-    throw new Error('BooleanPrimitive.toSQLExpression should never be called. The expression is assumed to be normalized.');
   }
   visitTextPrimitive(expr: TextPrimitive): string {
     // TODO(cypher1): Consider escaping this for SQL code generation.

--- a/src/tools/kotlin-refinement-generator.ts
+++ b/src/tools/kotlin-refinement-generator.ts
@@ -11,7 +11,6 @@
 import {Op} from '../runtime/manifest-ast-nodes.js';
 import {Dictionary} from '../runtime/hot.js';
 import {Schema} from '../runtime/schema.js';
-import {escapeIdentifier} from './kotlin-codegen-shared.js';
 import {getPrimitiveTypeInfo} from './kotlin-schema-field.js';
 import {
   RefinementExpressionVisitor,
@@ -21,9 +20,8 @@ import {
   QueryArgumentPrimitive,
   BuiltIn,
   NumberPrimitive,
-  BooleanPrimitive,
   TextPrimitive,
-  BigIntPrimitive,
+  DiscretePrimitive
 } from '../runtime/refiner.js';
 
 // The variable name used for the query argument in generated Kotlin code.
@@ -69,7 +67,7 @@ class KotlinRefinementGenerator extends RefinementExpressionVisitor<string> {
     // TODO: Implement KT getter for 'creationTimeStamp'
     throw new Error(`Unhandled BuiltInNode '${expr.value}' in toKTExpression`);
   }
-  visitBigIntPrimitive(expr: BigIntPrimitive): string {
+  visitDiscretePrimitive(expr: DiscretePrimitive): string {
     // This assumes that the associated Kotlin type will be `Java.math.BigInteger` and constructs
     // the BigInteger via String as there is no support for a literal form.
     return `NumberLiteralExpression(BigInteger("${expr.value}"))`;
@@ -83,9 +81,6 @@ class KotlinRefinementGenerator extends RefinementExpressionVisitor<string> {
         return 'NumberLiteralExpression(Double.NEGATIVE_INFINITY)';
     }
     return `${expr.value.toString()}.asExpr()`;
-  }
-  visitBooleanPrimitive(expr: BooleanPrimitive): string {
-    return `${expr.value}`;
   }
   visitTextPrimitive(expr: TextPrimitive): string {
     const escapeForKotlin = (value: string) => {

--- a/src/tools/tests/golden_kt.arcs
+++ b/src/tools/tests/golden_kt.arcs
@@ -13,8 +13,8 @@ particle KotlinPrimitivesGolden
     ref: &{val: Text},
     bt: Byte,
     shrt: Short,
-    nt: Int,
-    lng: Long,
+    integer: Int,
+    long_val: Long,
     big: BigInt,
     chr: Char,
     flt: Float,
@@ -40,4 +40,4 @@ particle KotlinPrimitivesGolden
       price: Float,
       stock: Int
     }>
-  } [(2n * big + 3n > 5n) and (num < 1000)]
+  } [(2n * big + 3n > 5n) and (5i*integer + 10i*integer > 30i) and (10l*long_val >= 100000l and 10l*long_val < 1000000l) and (num < 1000)]

--- a/src/tools/tests/goldens/kt_generated-schemas.jvm.kt
+++ b/src/tools/tests/goldens/kt_generated-schemas.jvm.kt
@@ -454,8 +454,8 @@ abstract class AbstractKotlinPrimitivesGolden : arcs.sdk.BaseParticle() {
         ref: arcs.sdk.Reference<KotlinPrimitivesGolden_Data_Ref>? = null,
         bt: Byte = 0.toByte(),
         shrt: Short = 0.toShort(),
-        nt: Int = 0,
-        lng: Long = 0L,
+        integer: Int = 0,
+        long_val: Long = 0L,
         big: BigInteger = BigInteger.ZERO,
         chr: Char = '\u0000',
         flt: Float = 0.0f,
@@ -499,12 +499,12 @@ abstract class AbstractKotlinPrimitivesGolden : arcs.sdk.BaseParticle() {
         var shrt: Short
             get() = super.getSingletonValue("shrt") as Short? ?: 0.toShort()
             private set(_value) = super.setSingletonValue("shrt", _value)
-        var nt: Int
-            get() = super.getSingletonValue("nt") as Int? ?: 0
-            private set(_value) = super.setSingletonValue("nt", _value)
-        var lng: Long
-            get() = super.getSingletonValue("lng") as Long? ?: 0L
-            private set(_value) = super.setSingletonValue("lng", _value)
+        var integer: Int
+            get() = super.getSingletonValue("integer") as Int? ?: 0
+            private set(_value) = super.setSingletonValue("integer", _value)
+        var long_val: Long
+            get() = super.getSingletonValue("long_val") as Long? ?: 0L
+            private set(_value) = super.setSingletonValue("long_val", _value)
         var big: BigInteger
             get() = super.getSingletonValue("big") as BigInteger? ?: BigInteger.ZERO
             private set(_value) = super.setSingletonValue("big", _value)
@@ -544,8 +544,8 @@ abstract class AbstractKotlinPrimitivesGolden : arcs.sdk.BaseParticle() {
             this.ref = ref
             this.bt = bt
             this.shrt = shrt
-            this.nt = nt
-            this.lng = lng
+            this.integer = integer
+            this.long_val = long_val
             this.big = big
             this.chr = chr
             this.flt = flt
@@ -570,8 +570,8 @@ abstract class AbstractKotlinPrimitivesGolden : arcs.sdk.BaseParticle() {
             ref: arcs.sdk.Reference<KotlinPrimitivesGolden_Data_Ref>? = this.ref,
             bt: Byte = this.bt,
             shrt: Short = this.shrt,
-            nt: Int = this.nt,
-            lng: Long = this.lng,
+            integer: Int = this.integer,
+            long_val: Long = this.long_val,
             big: BigInteger = this.big,
             chr: Char = this.chr,
             flt: Float = this.flt,
@@ -590,8 +590,8 @@ abstract class AbstractKotlinPrimitivesGolden : arcs.sdk.BaseParticle() {
             ref = ref,
             bt = bt,
             shrt = shrt,
-            nt = nt,
-            lng = lng,
+            integer = integer,
+            long_val = long_val,
             big = big,
             chr = chr,
             flt = flt,
@@ -616,8 +616,8 @@ abstract class AbstractKotlinPrimitivesGolden : arcs.sdk.BaseParticle() {
             ref: arcs.sdk.Reference<KotlinPrimitivesGolden_Data_Ref>? = this.ref,
             bt: Byte = this.bt,
             shrt: Short = this.shrt,
-            nt: Int = this.nt,
-            lng: Long = this.lng,
+            integer: Int = this.integer,
+            long_val: Long = this.long_val,
             big: BigInteger = this.big,
             chr: Char = this.chr,
             flt: Float = this.flt,
@@ -636,8 +636,8 @@ abstract class AbstractKotlinPrimitivesGolden : arcs.sdk.BaseParticle() {
             ref = ref,
             bt = bt,
             shrt = shrt,
-            nt = nt,
-            lng = lng,
+            integer = integer,
+            long_val = long_val,
             big = big,
             chr = chr,
             flt = flt,
@@ -666,8 +666,8 @@ abstract class AbstractKotlinPrimitivesGolden : arcs.sdk.BaseParticle() {
                         "ref" to arcs.core.data.FieldType.EntityRef("485712110d89359a3e539dac987329cd2649d889"),
                         "bt" to arcs.core.data.FieldType.Byte,
                         "shrt" to arcs.core.data.FieldType.Short,
-                        "nt" to arcs.core.data.FieldType.Int,
-                        "lng" to arcs.core.data.FieldType.Long,
+                        "integer" to arcs.core.data.FieldType.Int,
+                        "long_val" to arcs.core.data.FieldType.Long,
                         "big" to arcs.core.data.FieldType.BigInt,
                         "chr" to arcs.core.data.FieldType.Char,
                         "flt" to arcs.core.data.FieldType.Float,
@@ -682,8 +682,8 @@ abstract class AbstractKotlinPrimitivesGolden : arcs.sdk.BaseParticle() {
                         "colors" to arcs.core.data.FieldType.InlineEntity("e9ba6d9fa458ec35a966e462bb30a082e3f0d2f8")
                     )
                 ),
-                "44b8dccc1ae0cf6fa00a7dfeef0b0e6b1d565e24",
-                refinementExpression =         ((CurrentScope<Number>(mapOf())["num"] lt 1000.asExpr()) and (CurrentScope<Number>(mapOf())["big"] gt NumberLiteralExpression(BigInteger("1")))),
+                "1b1cb0b0d53a8af5158ea9b532e73ab2f9b31add",
+                refinementExpression =         ((CurrentScope<Number>(mapOf())["num"] lt 1000.asExpr()) and (((CurrentScope<Number>(mapOf())["big"] gt NumberLiteralExpression(BigInteger("1"))) and (NumberLiteralExpression(BigInteger("30")) lt ((CurrentScope<Number>(mapOf())["integer"] * NumberLiteralExpression(BigInteger("5"))) + (CurrentScope<Number>(mapOf())["integer"] * NumberLiteralExpression(BigInteger("10")))))) and ((NumberLiteralExpression(BigInteger("1000000")) gt (CurrentScope<Number>(mapOf())["long_val"] * NumberLiteralExpression(BigInteger("10")))) and ((NumberLiteralExpression(BigInteger("100000")) eq (CurrentScope<Number>(mapOf())["long_val"] * NumberLiteralExpression(BigInteger("10")))) or (NumberLiteralExpression(BigInteger("100000")) lt (CurrentScope<Number>(mapOf())["long_val"] * NumberLiteralExpression(BigInteger("10")))))))),
                 queryExpression = true.asExpr()
             )
 


### PR DESCRIPTION
Moving https://github.com/PolymerLabs/arcs/pull/5817 here to keep the associated discussion (as the original PR was reverted rather than fixing forward as I had initially planned).

This is a reland of https://github.com/PolymerLabs/arcs/pull/5770 with an added workaround for bug in the Closure compiler: replace BigInt `**` operator with recursive pow function

This replaces uses of the `**` (pow) operator in our typescript with powBigInt (a recursive handwritten function for BigInt).

This avoids a Closure compiler bug which translates `**` into `Math.pow` (which doesn't support `BigInt`).