### PR TITLE
Allow multiple instances of particles in recipes

### DIFF
--- a/java/arcs/core/host/AbstractArcHost.kt
+++ b/java/arcs/core/host/AbstractArcHost.kt
@@ -412,9 +412,6 @@ abstract class AbstractArcHost(
     private suspend fun performParticleStartup(particleContexts: Collection<ParticleContext>) {
         if (particleContexts.isEmpty()) return
 
-        println("performParticleStartup")
-        particleContexts.forEach { println(it) }
-
         // Call the lifecycle startup methods.
         particleContexts.forEach { it.initParticle() }
 

--- a/java/arcs/core/host/ArcHostContext.kt
+++ b/java/arcs/core/host/ArcHostContext.kt
@@ -22,7 +22,7 @@ import arcs.core.util.TaggedLog
  */
 data class ArcHostContext(
     var arcId: String,
-    var particles: MutableMap<String, ParticleContext> = mutableMapOf(),
+    var particles: MutableList<ParticleContext> = mutableListOf(),
     var entityHandleManager: EntityHandleManager
 ) {
     private val stateChangeCallbacks: MutableMap<ArcStateChangeRegistration,
@@ -41,7 +41,7 @@ data class ArcHostContext(
 
     constructor(
         arcId: String,
-        particles: MutableMap<String, ParticleContext> = mutableMapOf(),
+        particles: MutableList<ParticleContext> = mutableListOf(),
         arcState: ArcState = ArcState.NeverStarted,
         entityHandleManager: EntityHandleManager
     ) : this(arcId, particles, entityHandleManager) {
@@ -79,7 +79,7 @@ data class ArcHostContext(
      * Traverse every handle and return a distinct collection of all [StorageKey]s
      * that are readable by this arc.
      */
-    fun allReadableStorageKeys() = particles.flatMap { (_, particleContext) ->
+    fun allReadableStorageKeys() = particles.flatMap { particleContext ->
         particleContext.planParticle.handles.filter {
             it.value.mode.canRead
         }.map { it.value.storageKey }

--- a/java/arcs/core/host/ArcHostContextParticle.kt
+++ b/java/arcs/core/host/ArcHostContextParticle.kt
@@ -60,7 +60,7 @@ class ArcHostContextParticle(
         try {
             handles.planHandles.clear()
             val connections = context.particles.flatMap {
-                it.value.planParticle.handles.map { handle ->
+                it.planParticle.handles.map { handle ->
                     val planHandle = ArcHostContextParticle_PlanHandle(
                         storageKey = handle.value.handle.storageKey.toString(),
                         type = handle.value.handle.type.tag.name
@@ -83,10 +83,10 @@ class ArcHostContextParticle(
 
             val particles = context.particles.map {
                 ArcHostContextParticle_Particles(
-                    particleName = it.key,
-                    location = it.value.planParticle.location,
-                    particleState = it.value.particleState.toString(),
-                    consecutiveFailures = it.value.consecutiveFailureCount.toDouble(),
+                    particleName = it.planParticle.particleName,
+                    location = it.planParticle.location,
+                    particleState = it.particleState.toString(),
+                    consecutiveFailures = it.consecutiveFailureCount.toDouble(),
                     handles = connections.map { connection ->
                         handles.handleConnections.createReference(connection)
                     }.toSet()
@@ -137,15 +137,15 @@ class ArcHostContextParticle(
                     arcId, particleEntity.particleName, particle, particleEntity.handles
                 )
 
-                particleEntity.particleName to ParticleContext(
+                ParticleContext(
                     particle,
                     Plan.Particle(particleEntity.particleName, particleEntity.location, handlesMap)
                 )
-            }.toSet().associateBy({ it.first }, { it.second })
+            }
 
             return@onHandlesReady ArcHostContext(
                 arcId,
-                particles.toMutableMap(),
+                particles.toMutableList(),
                 ArcState.fromString(arcStateEntity.arcState),
                 entityHandleManager = arcHostContext.entityHandleManager
             )

--- a/javatests/arcs/android/e2e/testapp/WriteAnimalHostService.kt
+++ b/javatests/arcs/android/e2e/testapp/WriteAnimalHostService.kt
@@ -46,7 +46,9 @@ class WriteAnimalHostService : ArcHostService() {
         val arcId = intent?.getStringExtra(ARC_ID_EXTRA)
         val context = arcId?.let { arcHost.arcHostContext(it) }
         val writeAnimalParticle =
-            context?.particles?.get("WriteAnimal")?.particle as? WriteAnimal
+            context?.particles?.first {
+                it.planParticle.particleName == "WriteAnimal"
+            }?.particle as? WriteAnimal
         writeAnimalParticle?.apply {
             scope.launch(handles.dispatcher) {
                 handles.animal.store(WriteAnimal_Animal("capybara"))

--- a/javatests/arcs/core/allocator/AllocatorTestBase.kt
+++ b/javatests/arcs/core/allocator/AllocatorTestBase.kt
@@ -7,6 +7,7 @@ import arcs.core.data.Capability.Shareable
 import arcs.core.data.CreatableStorageKey
 import arcs.core.data.EntityType
 import arcs.core.data.Plan
+import arcs.core.host.ArcHostContext
 import arcs.core.host.ArcState
 import arcs.core.host.DeserializedException
 import arcs.core.host.EntityHandleManager
@@ -354,6 +355,11 @@ open class AllocatorTestBase {
         }
     }
 
+    private fun particleToContext(context: ArcHostContext, particle: Plan.Particle) =
+        context.particles.first {
+            it.planParticle.particleName == particle.particleName
+        }
+
     @Test
     open fun allocator_canStartArcInTwoExternalHosts() = runAllocatorTest {
         val arc = allocator.startArcForPlan(PersonPlan)
@@ -380,13 +386,9 @@ open class AllocatorTestBase {
 
         assertAllStatus(arc, ArcState.Running)
 
-        val readPersonContext = requireNotNull(
-            readingContext.particles[readPersonParticle.particleName]
-        )
+        val readPersonContext = particleToContext(readingContext, readPersonParticle)
 
-        val writePersonContext = requireNotNull(
-            writingContext.particles[writePersonParticle.particleName]
-        )
+        val writePersonContext = particleToContext(writingContext, writePersonParticle)
 
         assertThat(readPersonContext.particleState).isEqualTo(ParticleState.Running)
         assertThat(writePersonContext.particleState).isEqualTo(ParticleState.Running)
@@ -424,13 +426,9 @@ open class AllocatorTestBase {
 
         assertAllStatus(arc, ArcState.Stopped)
 
-        val readPersonContext = requireNotNull(
-            readingContext.particles[readPersonParticle.particleName]
-        )
+        val readPersonContext = particleToContext(readingContext, readPersonParticle)
 
-        val writePersonContext = requireNotNull(
-            writingContext.particles[writePersonParticle.particleName]
-        )
+        val writePersonContext = particleToContext(writingContext, writePersonParticle)
 
         assertThat(readPersonContext.particleState).isEqualTo(ParticleState.Stopped)
         assertThat(writePersonContext.particleState).isEqualTo(ParticleState.Stopped)
@@ -472,13 +470,9 @@ open class AllocatorTestBase {
 
         assertAllStatus(arc, ArcState.Running)
 
-        val readPersonContext = requireNotNull(
-            readingContextAfter.particles[readPersonParticle.particleName]
-        )
+        val readPersonContext = particleToContext(readingContextAfter, readPersonParticle)
 
-        val writePersonContext = requireNotNull(
-            writingContextAfter.particles[writePersonParticle.particleName]
-        )
+        val writePersonContext = particleToContext(writingContextAfter, writePersonParticle)
 
         assertThat(readPersonContext.particleState).isEqualTo(ParticleState.Running)
         assertThat(writePersonContext.particleState).isEqualTo(ParticleState.Running)

--- a/javatests/arcs/core/allocator/AllocatorTestBase.kt
+++ b/javatests/arcs/core/allocator/AllocatorTestBase.kt
@@ -365,7 +365,7 @@ open class AllocatorTestBase {
     open fun allocator_canRunArcWithSameParticleTwice() = runAllocatorTest {
         val arc = allocator.startArcForPlan(HelloHelloPlan)
         val arcId = arc.id
-        
+
         arc.waitForStart()
 
         val readingContext = requireNotNull(

--- a/javatests/arcs/core/host/AbstractArcHostTest.kt
+++ b/javatests/arcs/core/host/AbstractArcHostTest.kt
@@ -52,7 +52,9 @@ open class AbstractArcHostTest {
 
         @Suppress("UNCHECKED_CAST")
         fun getFooHandle(): ReadWriteSingletonHandle<DummyEntity> {
-            val p = getArcHostContext("arcId")!!.particles["Foobar"]!!.particle as TestParticle
+            val p = getArcHostContext("arcId")!!.particles.first {
+                it.planParticle.particleName == "Foobar"
+            }.particle as TestParticle
             return p.handles.getHandle("foo") as ReadWriteSingletonHandle<DummyEntity>
         }
     }

--- a/javatests/arcs/core/host/TestingHost.kt
+++ b/javatests/arcs/core/host/TestingHost.kt
@@ -60,11 +60,18 @@ open class TestingHost(
         deferred.await()
     }
 
-    /** Retrieve a test particle by name. */
+    /**
+     * Retrieve a test particle by name.
+     *
+     * Note that this will always give you the first particle of the provided name, if
+     * there are multiple instances of the same particle in the recipe.
+     */
     fun <T : Particle> getParticle(arcId: ArcId, particleName: String): T {
         val arcHostContext = requireNotNull(getArcHostContext(arcId.toString()))
         @Suppress("UNCHECKED_CAST")
-        return arcHostContext.particles[particleName]!!.particle as T
+        return arcHostContext.particles.first {
+            it.planParticle.particleName == particleName
+        }.particle as T
     }
 
     /** Create a read/write singleton handle for tests to access an arc's stores. */
@@ -97,7 +104,9 @@ open class TestingHost(
         handleName: String
     ): Handle {
         val arcHostContext = requireNotNull(getArcHostContext(arcId.toString()))
-        val particleContext = requireNotNull(arcHostContext.particles[particleName])
+        val particleContext = arcHostContext.particles.first {
+            it.planParticle.particleName == particleName
+        }
         val handleConnection = requireNotNull(particleContext.planParticle.handles[handleName])
         val readWriteConnection = handleConnection.copy(mode = HandleMode.ReadWrite)
         val entitySpecs = particleContext.particle.handles.getEntitySpecs(handleName)

--- a/javatests/arcs/core/host/person.arcs
+++ b/javatests/arcs/core/host/person.arcs
@@ -42,3 +42,22 @@ recipe People
 
   WritePeople
     people: writes people
+
+recipe HelloHello
+  inputPerson: create 'inputPerson'
+  inbetween: create 'inbetween'
+  outputPerson: create 'outputPerson'
+
+  WritePerson
+    person: writes inputPerson
+
+  PurePerson
+    inputPerson: reads inputPerson
+    outputPerson: writes inbetween
+
+  PurePerson
+    inputPerson: reads inbetween
+    outputPerson: writes outputPerson
+      
+  ReadPerson
+    person: reads outputPerson  

--- a/javatests/arcs/showcase/ShowcaseEnvironment.kt
+++ b/javatests/arcs/showcase/ShowcaseEnvironment.kt
@@ -245,7 +245,9 @@ class ShowcaseHost(
         val arcHostContext = requireNotNull(getArcHostContext(arcId)) {
             "ArcHost: No arc host context found for $arcId"
         }
-        val particleContext = requireNotNull(arcHostContext.particles[particleName]) {
+        val particleContext = requireNotNull(arcHostContext.particles.first {
+            it.planParticle.particleName == particleName
+        }) {
             "ArcHost: No particle named $particleName found in $arcId"
         }
         val allowableStartStates = arrayOf(ParticleState.Running, ParticleState.Waiting)


### PR DESCRIPTION
Our plan & serialization formats support multiple instances of the same particle, but prior to this fix we would collapse these list representations into a map representation at runtime, which would therefore conflate those instances.

Note that there are currently no new tests demonstrating that this fix works; I'd love some suggestions on where to add them. Additionally, the pending inlines showcase will make use of this functionality.

There's likely further work to be done here - if there are multiple instances of a particle that need to be accessed from outside the context of an arc, then we need a way to disambiguate between them (or possibly just a way to return all instances matching a particular particle name).

