### PR TITLE
Add a [require] section to cgtests.

### DIFF
--- a/src/tools/tests/codegen-unit-tests-runner-test.ts
+++ b/src/tools/tests/codegen-unit-tests-runner-test.ts
@@ -24,7 +24,8 @@ for (const unit of testSuite) {
       it(test.name, async () => {
         assert.deepEqual(await runCompute(unit, test), test.results);
         if (test.require) {
-          test.require.split("\n").forEach(requireCase => assert.isTrue(eval(requireCase)));
+          const results = test.results;
+          test.require.split('\n').forEach(requireCase => assert.isTrue(eval(requireCase)));
         }
       });
     }

--- a/src/tools/tests/codegen-unit-tests-runner-test.ts
+++ b/src/tools/tests/codegen-unit-tests-runner-test.ts
@@ -21,7 +21,12 @@ import {assert} from '../../platform/chai-web.js';
 for (const unit of testSuite) {
   describe(unit.title, async () => {
     for (const test of readTests(unit)) {
-      it(test.name, async () => assert.deepEqual(await runCompute(unit, test), test.results));
+      it(test.name, async () => {
+        assert.deepEqual(await runCompute(unit, test), test.results);
+        if (test.require) {
+          test.require.split("\n").forEach(requireCase => assert.isTrue(eval(requireCase)));
+        }
+      });
     }
   });
 }

--- a/src/tools/tests/goldens/kotlin-schema-generation.cgtest
+++ b/src/tools/tests/goldens/kotlin-schema-generation.cgtest
@@ -204,7 +204,7 @@ arcs.core.data.Schema(
     query = null
 )
 [require]
-test.results[0].match(/InlineEntity\("([a-f0-9]+)"\)/)[1] == test.results[1].match(/\n *"([a-f0-9]+)",\n/m)[1];
+results[0].match(/InlineEntity\("([a-f0-9]+)"\)/)[1] == results[1].match(/\n *"([a-f0-9]+)",\n/m)[1];
 [end]
 
 [name]
@@ -242,7 +242,7 @@ arcs.core.data.Schema(
     query = null
 )
 [require]
-test.results[0].match(/InlineEntity\("([a-f0-9]+)"\)/)[1] == test.results[1].match(/\n *"([a-f0-9]+)",\n/m)[1];
+results[0].match(/InlineEntity\("([a-f0-9]+)"\)/)[1] == results[1].match(/\n *"([a-f0-9]+)",\n/m)[1];
 [end]
 
 [name]
@@ -294,8 +294,8 @@ arcs.core.data.Schema(
     query = null
 )
 [require]
-test.results[0].match(/InlineEntity\("([a-f0-9]+)"\)/)[1] == test.results[1].match(/\n *"([a-f0-9]+)",\n/m)[1];
-test.results[1].match(/InlineEntity\("([a-f0-9]+)"\)/)[1] == test.results[2].match(/\n *"([a-f0-9]+)",\n/m)[1];
+results[0].match(/InlineEntity\("([a-f0-9]+)"\)/)[1] == results[1].match(/\n *"([a-f0-9]+)",\n/m)[1];
+results[1].match(/InlineEntity\("([a-f0-9]+)"\)/)[1] == results[2].match(/\n *"([a-f0-9]+)",\n/m)[1];
 [end]
 
 [name]

--- a/src/tools/tests/goldens/kotlin-schema-generation.cgtest
+++ b/src/tools/tests/goldens/kotlin-schema-generation.cgtest
@@ -203,6 +203,8 @@ arcs.core.data.Schema(
     refinement = { _ -> true },
     query = null
 )
+[require]
+test.results[0].match(/InlineEntity\("([a-f0-9]+)"\)/)[1] == test.results[1].match(/\n *"([a-f0-9]+)",\n/m)[1];
 [end]
 
 [name]
@@ -239,6 +241,8 @@ arcs.core.data.Schema(
     refinement = { _ -> true },
     query = null
 )
+[require]
+test.results[0].match(/InlineEntity\("([a-f0-9]+)"\)/)[1] == test.results[1].match(/\n *"([a-f0-9]+)",\n/m)[1];
 [end]
 
 [name]
@@ -289,6 +293,9 @@ arcs.core.data.Schema(
     refinement = { _ -> true },
     query = null
 )
+[require]
+test.results[0].match(/InlineEntity\("([a-f0-9]+)"\)/)[1] == test.results[1].match(/\n *"([a-f0-9]+)",\n/m)[1];
+test.results[1].match(/InlineEntity\("([a-f0-9]+)"\)/)[1] == test.results[2].match(/\n *"([a-f0-9]+)",\n/m)[1];
 [end]
 
 [name]


### PR DESCRIPTION
I've tested that the [require] section persists across cgtest updates.

The format / meaning of the section is up to the specific cgtest suite. I've
provided an example (for the codegen-unit-tests) that treats each
line in the require section as a statement that must evaluate to true.