### PR TITLE
recipe2plan verifies ingress capabilities:

### DIFF
--- a/java/arcs/core/data/testdata/WriterReaderExample.arcs
+++ b/java/arcs/core/data/testdata/WriterReaderExample.arcs
@@ -9,7 +9,7 @@ particle Writer in 'arcs.core.data.testdata.Writer'
 
 @arcId('writingOnlyArcId')
 recipe IngestionOnly
-  thing: create 'my-handle-id-www' @persistent @ttl('20d')
+  thing: create 'my-handle-id-writing' @persistent @ttl('20d')
   Writer
     data: writes thing
 
@@ -28,7 +28,7 @@ recipe Consumption
     data: reads data
 
 recipe EphemeralWriting
-  thing: create 'my-ephemeral-handle-id'
+  thing: create 'my-ephemeral-handle-id' @inMemory @ttl('99d')
   Writer
     data: writes thing
 
@@ -43,8 +43,8 @@ particle ReadWriteReferences
 
 @arcId('referencesArcId')
 recipe ReferencesRecipe
-  things: create 'my-refs-id' @persistent
-  thing: create 'my-ref-id' @ttl('1d')
+  things: create 'my-refs-id' @persistent @ttl('99d')
+  thing: create 'my-ref-id' @inMemory @ttl('1d')
   ReadWriteReferences
     inThingRefs: things
     outThingRef: thing

--- a/java/arcs/core/data/testdata/WriterReaderPoliciesExample.arcs
+++ b/java/arcs/core/data/testdata/WriterReaderPoliciesExample.arcs
@@ -2,7 +2,7 @@ schema Thing
   name: Text
 
 policy WriterReaderExamplePolicy {
-  @allowedRetention(medium: 'Disk', encryption: true)
+  @allowedRetention(medium: 'Disk', encryption: false)
   @allowedRetention(medium: 'Ram', encryption: false)
   @maxAge('100d')
   from Thing access { name }

--- a/src/runtime/canonical-manifest.ts
+++ b/src/runtime/canonical-manifest.ts
@@ -42,6 +42,11 @@ annotation encrypted
   retention: Runtime
   doc: 'storage capability: encrypted'
 
+annotation shareable
+  targets: [Handle, Store, HandleConnection]
+  retention: Runtime
+  doc: 'storage capability: shareable'
+
 annotation inMemory
   targets: [Handle]
   retention: Runtime

--- a/src/runtime/capabilities.ts
+++ b/src/runtime/capabilities.ts
@@ -55,7 +55,7 @@ export abstract class Capability {
   }
 
   /**
-   * Returns true, if the given capability is not null and stricter than this.
+   * Returns true, if the given Capability is not null and at least as strict as this.
    */
   isAllowedForIngress(other: Capability|null): boolean {
     return other && this.isSameOrLessStrict(other);
@@ -138,6 +138,13 @@ export class Persistence extends Capability {
       return CapabilityComparison.Stricter;
     }
     return CapabilityComparison.LessStrict;
+  }
+
+  /**
+   * Returns true, Persistence kinds are equivalent.
+   */
+  isAllowedForIngress(other: Capability|null): boolean {
+    return other && this.isEquivalent(other);
   }
 
   toDebugString(): string { return this.kind.toString(); }
@@ -582,8 +589,8 @@ export class Capabilities {
       if (!range.isAllowedForIngress(handleRange)) {
         return IngressValidationResult.failWith(this,
             `Capabilities ${this.toDebugString()} failed to validate ingress: ` +
-            `${range.min.toDebugString()} is stricter than ` +
-            `${handleRange ? handleRange.toDebugString() : 'unspecified'}`);
+            `'${range.min.toDebugString()}' is not compatible for ingress with ` +
+            `'${handleRange ? handleRange.toDebugString() : 'unspecified'}'`);
       }
     }
     return IngressValidationResult.success(this);

--- a/src/runtime/policy/ingress-validation.ts
+++ b/src/runtime/policy/ingress-validation.ts
@@ -62,39 +62,84 @@ export class IngressValidation {
             .map(h => this.validateHandleCapabilities(h)));
   }
 
+  // For the given handle's type, returns a map of all allowed Capabilities by
+  // field name:
+  // - If Handle's type is covered by the policy, all fields in the Handle's
+  // type schema must be included in the policy.
+  // - Otherwise the capabilities will be determined by capabilities of all the
+  // Handles its data is derived from.
+  private findHandleCapabilities(handle: Handle, capabilitiesByField: Map<string, Capabilities[]>, seenHandles = new Set<Handle>()): IngressValidationResult {
+    assert(handle.type.maybeEnsureResolved());
+    seenHandles.add(handle);
+    const restrictedType = this.restrictType(handle.type.resolvedType());
+    if (restrictedType) {
+      const fieldPaths = this.collectSchemaFieldPaths(restrictedType.getEntitySchema());
+      for (const fieldPath of fieldPaths) {
+        const fieldCapabilities = this.getFieldCapabilities(fieldPath);
+        assert(fieldCapabilities, `Missing capabilities for ${fieldPath}`);
+        if (!capabilitiesByField.has(fieldPath)) {
+          capabilitiesByField.set(fieldPath, []);
+        }
+        capabilitiesByField.get(fieldPath).push(...fieldCapabilities);
+      }
+    } else {
+      // All input connections of all particles writing into this handle.
+      const sourceParticles = handle.connections.filter(conn => conn.isOutput)
+          .map(conn => conn.particle);
+      if (sourceParticles.length === 0) {
+        return IngressValidationResult.failWith(handle,
+            `Handle '${handle.id}' has no matching target type ` +
+            `${handle.type.resolvedType().toString()} in policies, and no source particles.`);
+      }
+      const sourceConnections = [];
+      for (const sourceParticle of sourceParticles) {
+        const particleInputs = Object.values(sourceParticle.connections)
+            .filter(conn => conn.isInput && !seenHandles.has(conn.handle));
+        if (particleInputs.length === 0) {
+          return IngressValidationResult.failWith(handle,
+              `Handle '${handle.id}' has no matching target type ` +
+              `${handle.type.resolvedType().toString()} in policies, and ` +
+              `contributing Particle ${sourceParticle.name} has no inputs.`);
+        }
+        sourceConnections.push(...particleInputs);
+      }
+      for (const sourceConn of sourceConnections) {
+        const result = this.findHandleCapabilities(sourceConn.handle, capabilitiesByField);
+        if (!result.success) {
+          return result;
+        }
+      }
+    }
+    return IngressValidationResult.success(handle);
+  }
+
   // Returns success, if the type of the handle, restricted according with the
   // set of policies, has capabilities that are compliant with the policies'
   // retention and maxAge permissions. Otherwise, returns a combination of all
   // encountered errors.
   private validateHandleCapabilities(handle: Handle): IngressValidationResult {
-    assert(handle.type.maybeEnsureResolved());
-    const result = IngressValidationResult.success(handle);
-    const restrictedType = this.restrictType(handle.type.resolvedType());
-    if (restrictedType) {
-      const fieldPaths = [];
-      for (const [fieldName, field] of Object.entries(restrictedType.getEntitySchema().fields)) {
-        fieldPaths.push(
-            ...this.collectFieldPaths(restrictedType.getEntitySchema().name, fieldName, field));
+    const capabilitiesByField = new Map<string, Capabilities[]>();
+    const result = this.findHandleCapabilities(handle, capabilitiesByField);
+    if (!result.success) return result;
+    for (const [fieldPath, fieldCapabilities] of capabilitiesByField.entries()) {
+      const fieldResults = fieldCapabilities.map(
+          fc => fc.isAllowedForIngress(handle.capabilities));
+      if (!fieldResults.some(r => r.success)) {
+        result.addResult(IngressValidationResult.failWith(handle,
+            `Failed validating ingress for field '${fieldPath}' of Handle ` +
+            `'${handle.id || handle.connections[0].getQualifiedName()}'`,
+            fieldResults.filter(r => !r.success)));
       }
-
-      for (const fieldPath of fieldPaths) {
-        const fieldCapabilities = this.getFieldCapabilities(fieldPath);
-        assert(fieldCapabilities, `Missing capabilities for ${fieldPath}`);
-        const fieldResults = fieldCapabilities.map(
-            fc => fc.isAllowedForIngress(handle.capabilities));
-        if (!fieldResults.some(r => r.success)) {
-          result.addResult(IngressValidationResult.failWith(handle,
-              `Failed validating ingress for field '${fieldPath}'` +
-              ` of '${handle.id || handle.connections[0].getQualifiedName()}`,
-              fieldResults.filter(r => !r.success)));
-        }
-      }
-    } else {
-      result.addError(
-        `Handle '${handle.id}' has no matching target type ` +
-            `${handle.type.resolvedType().toString()} in policies`);
     }
     return result;
+  }
+
+  private collectSchemaFieldPaths(schema: Schema) {
+    const fieldPaths = [];
+    for (const [fieldName, field] of Object.entries(schema.fields)) {
+      fieldPaths.push(...this.collectFieldPaths(schema.name, fieldName, field));
+    }
+    return fieldPaths;
   }
 
   private collectFieldPaths(fieldPrefix: string, fieldName: string, field) {

--- a/src/runtime/policy/tests/ingress-validation-test.ts
+++ b/src/runtime/policy/tests/ingress-validation-test.ts
@@ -92,7 +92,8 @@ policy PolicyThree {
   });
 
   it('fails validating handle with no policy target', async () => {
-    const ingressValidation = new IngressValidation((await Manifest.parse(`
+    const assertFailsWithNoPolicy = async (recipeHandleStr) => {
+      const ingressValidation = new IngressValidation((await Manifest.parse(`
 ${personSchema}
 policy MyPolicy {
   @allowedRetention(medium: 'Disk', encryption: true)
@@ -102,18 +103,21 @@ policy MyPolicy {
     `)).policies);
     const recipe = (await Manifest.parse(`
 particle P1
-  foo: reads writes Foo {value: Text}
+  ${recipeHandleStr}
 recipe
   fooHandle: create 'my-id' @persistent @ttl('2d')
   P1
     foo: fooHandle
-    `)).recipes[0];
-    assert.isTrue(recipe.normalize());
-    assert.isTrue(recipe.isResolved());
-    const result = ingressValidation.validateIngressCapabilities(recipe);
-    assert.isFalse(result.success);
-    assert.isTrue(result.toString().includes(
-        `Handle 'my-id' has no matching target type Foo {value: Text} in policies`));
+      `)).recipes[0];
+      assert.isTrue(recipe.normalize() && recipe.isResolved());
+      const result = ingressValidation.validateIngressCapabilities(recipe);
+      assert.isFalse(result.success);
+      assert.isTrue(result.toString().includes(
+          `Handle 'my-id' has no matching target type Foo {value: Text} in policies`),
+          `Unexpected error: ${result.toString()}`);
+    };
+    await assertFailsWithNoPolicy(`foo: reads writes Foo {value: Text}`);
+    await assertFailsWithNoPolicy(`foo: writes Foo {value: Text}`);
   });
 
   const manifestString = (annotations = '') => {
@@ -154,7 +158,7 @@ policy MyPolicy {
   from Person access { name, age }
 }
     `)).policies[0];
-    await assertHandleIngressNotAllowed(manifestString(), policy, 'inMemory is stricter than unspecified');
+    await assertHandleIngressNotAllowed(manifestString(), policy, `'inMemory' is not compatible for ingress with 'unspecified'`);
   });
 
   it('fails validates missing handle capability ttls', async () => {
@@ -166,19 +170,19 @@ policy MyPolicy {
   from Person access { name, age }
 }
     `)).policies[0];
-    await assertHandleIngressNotAllowed(manifestString(`@inMemory`), policy, '2d is stricter than unspecified');
+    await assertHandleIngressNotAllowed(manifestString(`@inMemory`), policy, `'2d' is not compatible for ingress with 'unspecified'`);
   });
 
   it('fails validating missing handle capability encryption', async () => {
     const policy = (await Manifest.parse(`
 ${personSchema}
 policy MyPolicy {
-  @allowedRetention(medium: 'Disk', encryption: true)
+  @allowedRetention(medium: 'Ram', encryption: true)
   @maxAge('2d')
   from Person access { name, age }
 }
     `)).policies[0];
-    await assertHandleIngressNotAllowed(manifestString(`@inMemory @ttl('48h')`), policy, 'encrypted is stricter than unspecified');
+    await assertHandleIngressNotAllowed(manifestString(`@inMemory @ttl('48h')`), policy, `'encrypted' is not compatible for ingress with 'unspecified'`);
   });
 
   it('successfully validates default persistence', async () => {
@@ -203,7 +207,6 @@ policy MyPolicy {
 }
     `)).policies[0];
     await assertHandleIngressAllowed(manifestString(`@persistent @ttl('10h')`), policy);
-    await assertHandleIngressAllowed(manifestString(`@tiedToArc @ttl('10h')`), policy);
   });
 
   it('fails validating non restrictive enough handle capabilities', async () => {
@@ -216,11 +219,11 @@ policy MyPolicy {
 }
     `)).policies[0];
     await assertHandleIngressNotAllowed(
-        manifestString(`@persistent @encrypted @ttl('1d')`), policy, 'inMemory is stricter than onDisk');
+        manifestString(`@persistent @encrypted @ttl('1d')`), policy, `'inMemory' is not compatible for ingress with 'onDisk'`);
     await assertHandleIngressNotAllowed(
-        manifestString(`@tiedToArc @ttl('1d')`), policy, 'encrypted is stricter than unspecified');
+        manifestString(`@tiedToArc @ttl('1d')`), policy, `'encrypted' is not compatible for ingress with 'unspecified'`);
     await assertHandleIngressNotAllowed(
-        manifestString(`@tiedToArc @encrypted @ttl('10d')`), policy, '2d is stricter than 10d');
+        manifestString(`@tiedToArc @encrypted @ttl('10d')`), policy, `'2d' is not compatible for ingress with '10d'`);
   });
 
   it('validates handle capabilities', async () => {
@@ -409,5 +412,207 @@ anotherField: Text
         await parseAndResolveRecipe(inlineSchema, `@inMemory @ttl('2days')`)).success);
     assert.isTrue(ingressValidation.validateIngressCapabilities(
         await parseAndResolveRecipe(inlineSchema, `@inMemory @encrypted @ttl('2hours')`)).success);
+  });
+  // Validate ingress capabilities for derived data
+  // WriteFoo --> (Foo) --> ReadFooWriteBar --> (Bar)
+  const particleSpecs = `
+particle ReadFooWriteBar
+  foo: reads Foo {f1: Text}
+  bar: reads writes Bar {br1: Text}
+particle WriteFoo
+  foo: writes Foo {f1: Text, f2: Text}
+  `;
+  const recipeStr = (opts: {fooCapabilities: string, barCapabilities: string} = {fooCapabilities: '', barCapabilities: ''}) =>
+  `
+recipe Bar
+  fooHandle: create 'foo' ${opts.fooCapabilities}
+  barHandle: create 'bar' ${opts.barCapabilities}
+  ReadFooWriteBar
+    foo: fooHandle
+    bar: barHandle
+  WriteFoo
+    foo: fooHandle
+  `;
+
+  it('fails validating derived data with no policy for source', async () => {
+    const ingressValidation = new IngressValidation([]);
+    const recipe = (await Manifest.parse(`
+${particleSpecs}
+${recipeStr()}
+    `)).recipes[0];
+    assert.isTrue(recipe.normalize() && recipe.isResolved());
+    const result = ingressValidation.validateIngressCapabilities(recipe);
+    assert.isFalse(result.success);
+    assert.isTrue(result.toString().includes(
+        `Handle 'foo' has no matching target type Foo {f1: Text} in policies, and contributing Particle WriteFoo has no inputs`),
+        `Unexpected error: ${result.toString()}`);
+  });
+  const fooIngressPolicy = () => {
+    return `
+schema Foo
+  f1: Text
+  f2: Text
+schema Bar
+  br1: Text
+policy MyPolicy {
+  @allowedRetention(medium: 'Ram', encryption: false)
+  @maxAge('3h')
+  from Foo access { f1 }
+}`;
+  };
+
+  it('fails validating derived data with non restrictive capabilities for source', async () => {
+    const ingressValidation = new IngressValidation((await Manifest.parse(fooIngressPolicy())).policies);
+    const recipe = (await Manifest.parse(`
+${particleSpecs}
+${recipeStr({fooCapabilities: `@persistent @ttl('2d')`, barCapabilities: `@persistent @ttl('1d')`})}
+    `)).recipes[0];
+    assert.isTrue(recipe.normalize() && recipe.isResolved());
+    const result = ingressValidation.validateIngressCapabilities(recipe);
+    assert.isFalse(result.success);
+    assert.isTrue(result.toString().includes(`Failed validating ingress for field 'Foo.f1' of Handle 'bar'`)
+        && result.toString().includes(`'inMemory' is not compatible for ingress with 'onDisk'`),
+        `Unexpected error: ${result.toString()}`);
+  });
+
+  it('successfully validates derived data', async () => {
+    const ingressValidation = new IngressValidation((await Manifest.parse(fooIngressPolicy())).policies);
+    const recipe = (await Manifest.parse(`
+${particleSpecs}
+${recipeStr({fooCapabilities: `@inMemory @ttl('2h')`, barCapabilities: `@inMemory @ttl('3h')`})}
+    `)).recipes[0];
+    assert.isTrue(recipe.normalize() && recipe.isResolved());
+    assert.isTrue(ingressValidation.validateIngressCapabilities(recipe).success);
+  });
+
+  it('successfully validates derived data and reads-writes fate', async () => {
+    // Verifies `reads writes` fate isn't considered a cycle
+    const ingressValidation = new IngressValidation((await Manifest.parse(fooIngressPolicy())).policies);
+    const particleSpecsWithUpdatedFate = particleSpecs.replace('foo: writes Foo', 'foo: reads writes Foo');
+    assert.notEqual(particleSpecsWithUpdatedFate, particleSpecs);
+    const recipe = (await Manifest.parse(`
+${particleSpecsWithUpdatedFate}
+${recipeStr({fooCapabilities: `@inMemory @ttl('2h')`, barCapabilities: `@inMemory @ttl('3h')`})}
+    `)).recipes[0];
+    assert.isTrue(recipe.normalize() && recipe.isResolved());
+    assert.isTrue(ingressValidation.validateIngressCapabilities(recipe).success);
+  });
+
+  it('fails gracefully when recipe has cycles', async () => {
+    const ingressValidation = new IngressValidation((await Manifest.parse(fooIngressPolicy())).policies);
+    const recipe = (await Manifest.parse(`
+${particleSpecs}
+  bar: reads Bar {br1: Text}
+${recipeStr({fooCapabilities: `@inMemory @ttl('2h')`, barCapabilities: `@inMemory @ttl('3h')`})}
+    bar: barHandle
+    `)).recipes[0];
+    assert.isTrue(recipe.normalize() && recipe.isResolved());
+    assert.isTrue(ingressValidation.validateIngressCapabilities(recipe).success);
+  });
+
+  // WriteFoo --> (Foo) --> ReadFooWriteBar --> (Bar) --> ReadBarWriteBaz -> (Baz)
+  it('validates multi level derived data', async () => {
+    const validateBaz = async (bazCapabilities: string) =>  {
+      const ingressValidation = new IngressValidation((await Manifest.parse(fooIngressPolicy())).policies);
+      const recipe = (await Manifest.parse(`
+${particleSpecs}
+particle ReadBarWriteBaz
+  bar: reads Bar {br1: Text}
+  baz: writes Baz {bz1: Text}
+${recipeStr({fooCapabilities: `@inMemory @ttl('2h')`, barCapabilities: `@inMemory @ttl('3h')`})}
+  bazHandle: create 'baz' ${bazCapabilities}
+  ReadBarWriteBaz
+    bar: barHandle
+    baz: bazHandle
+      `)).recipes[0];
+      assert.isTrue(recipe.normalize() && recipe.isResolved());
+      return ingressValidation.validateIngressCapabilities(recipe);
+    };
+    const resultFail = await validateBaz(`@inMemory @ttl('2 days')`);
+    assert.isFalse(resultFail.success);
+    assert.isTrue(resultFail.toString().includes(`'3h' is not compatible for ingress with '2d'`),
+        `Unexpected error: ${resultFail.toString}`);
+    const resultSuccess = await validateBaz(`@inMemory @ttl('2 hours')`);
+    assert.isTrue(resultSuccess.success, resultSuccess.toString());
+  });
+
+  // Validate ingress capabilities for derived data
+  // WriteFoo --> (Foo) -->
+  //                            ReadFooWriteBar --> (Bar)
+  // WriteFooA --> (FooA) -->
+  it('successfully validates data derived from multiple sources', async () => {
+    const manifestStr = `
+particle ReadFoosWriteBar
+  foo: reads Foo {f1: Text}
+  fooA: reads FooA {fa1: Text, fa2: Text}
+  bar: writes Bar {br1: Text}
+particle WriteFoo
+  foo: writes Foo {f1: Text, f2: Text}
+particle WriteFooA
+  fooA: writes FooA {fa1: Text, fa2: Text}
+recipe Bar
+  fooHandle: create 'foo' @persistent @ttl('2d')
+  fooAHandle: create 'fooA' @inMemory @ttl('10m')
+  barHandle: create 'bar' @inMemory @ttl('10m')
+  ReadFoosWriteBar
+    foo: fooHandle
+    fooA: fooAHandle
+    bar: barHandle
+  WriteFoo
+    foo: fooHandle
+  WriteFooA
+    fooA: fooAHandle
+    `;
+    const recipe = (await Manifest.parse(manifestStr)).recipes[0];
+    assert.isTrue(recipe.normalize() && recipe.isResolved());
+    const verifyFails = async (policiesStr: string, expectedError: string = '') => {
+      const result = new IngressValidation((await Manifest.parse(policiesStr)).policies).validateIngressCapabilities(recipe);
+      assert.isFalse(result.success, `Policies ${policiesStr} were expected to fail.`);
+      if (expectedError) {
+        assert.isTrue(result.toString().includes(expectedError), `Unexpected error: ${result.toString()}`);
+      }
+    };
+    await verifyFails(``);
+    const schemaStr = `
+schema Foo
+  f1: Text
+  f2: Text
+schema FooA
+  fa1: Text
+  fa2: Text
+    `;
+    const fooPolicy = (type: string, fields: string[], medium: string, maxAge: string) => `
+policy Policy_${type}${fields.join('')}${medium}${maxAge} {
+  @allowedRetention(medium: '${medium}', encryption: false)
+  @maxAge('${maxAge}')
+  from ${type} access { ${fields.join(', ')} }
+}
+    `;
+    await verifyFails(`
+        ${schemaStr}
+        ${fooPolicy('Foo', ['f1'], 'Disk', '2d')}`);
+
+    await verifyFails(`
+        ${schemaStr}
+        ${fooPolicy('Foo', ['f1'], 'Disk', '2d')}
+        ${fooPolicy('FooA', ['fa1'], 'Ram', '1h')}
+        ${fooPolicy('FooA', ['fa2'], 'Ram', '5m')}`);
+
+    await verifyFails(`
+        ${schemaStr}
+        ${fooPolicy('Foo', ['f1'], 'Disk', '2d')}
+        ${fooPolicy('FooA', ['fa1'], 'Ram', '1h')}
+        ${fooPolicy('FooA', ['fa2'], 'Ram', '5m')}
+        ${fooPolicy('FooA', ['fa1', 'fa2'], 'Disk', '5h')}
+    `);
+
+    assert.isTrue(new IngressValidation((await Manifest.parse(`
+        ${schemaStr}
+        ${fooPolicy('Foo', ['f1'], 'Disk', '2d')}
+        ${fooPolicy('Foo', ['f1'], 'Ram', '2d')}
+        ${fooPolicy('FooA', ['fa1'], 'Ram', '1h')}
+        ${fooPolicy('FooA', ['fa2'], 'Ram', '5m')}
+        ${fooPolicy('FooA', ['fa1', 'fa2'], 'Ram', '5h')}
+    `)).policies).validateIngressCapabilities(recipe).success);
   });
 });

--- a/src/tools/plan-generator.ts
+++ b/src/tools/plan-generator.ts
@@ -83,7 +83,7 @@ export class PlanGenerator {
   async createHandleVariable(handle: Handle): Promise<string> {
     handle.type.maybeEnsureResolved();
     const valInit = `val ${this.handleVariableName(handle)} = `;
-    let handleRestrictedType = null;
+    let handleRestrictedType: Type = null;
     if (this.ingressValidation) {
       handleRestrictedType = this.ingressValidation.restrictType(handle.type);
     }

--- a/src/tools/plan-generator.ts
+++ b/src/tools/plan-generator.ts
@@ -83,8 +83,13 @@ export class PlanGenerator {
   async createHandleVariable(handle: Handle): Promise<string> {
     handle.type.maybeEnsureResolved();
     const valInit = `val ${this.handleVariableName(handle)} = `;
-    const handleRestrictedType = this.ingressValidation
-        ? this.ingressValidation.restrictType(handle.type) : handle.type.resolvedType();
+    let handleRestrictedType = null;
+    if (this.ingressValidation) {
+      handleRestrictedType = this.ingressValidation.restrictType(handle.type);
+    }
+    if (!handleRestrictedType) {
+      handleRestrictedType = handle.type.resolvedType();
+    }
     return valInit + ktUtils.applyFun(`Handle`, [
       await this.createStorageKey(handle),
       await generateType(handleRestrictedType),

--- a/src/tools/tests/goldens/WriterReaderExample.kt
+++ b/src/tools/tests/goldens/WriterReaderExample.kt
@@ -14,7 +14,7 @@ import arcs.core.entity.toPrimitiveValue
 
 val IngestionOnly_Handle0 = Handle(
     StorageKeyParser.parse(
-        "reference-mode://{db://9ca32bb55138c5efc3b107bcd9d60a73e2428160@arcs/Thing}{db://9ca32bb55138c5efc3b107bcd9d60a73e2428160@arcs/!:writingOnlyArcId/handle/my-handle-id-www}"
+        "reference-mode://{db://9ca32bb55138c5efc3b107bcd9d60a73e2428160@arcs/Thing}{db://9ca32bb55138c5efc3b107bcd9d60a73e2428160@arcs/!:writingOnlyArcId/handle/my-handle-id-writing}"
     ),
     arcs.core.data.EntityType(
         arcs.core.data.Schema(
@@ -161,7 +161,10 @@ val EphemeralWriting_Handle0 = Handle(
             query = null
         )
     ),
-    emptyList()
+    listOf(
+        Annotation("inMemory", emptyMap()),
+        Annotation("ttl", mapOf("value" to AnnotationParam.Str("99d")))
+    )
 )
 val EphemeralWritingPlan = Plan(
     listOf(
@@ -173,7 +176,10 @@ val EphemeralWritingPlan = Plan(
                     EphemeralWriting_Handle0,
                     HandleMode.Write,
                     arcs.core.data.SingletonType(arcs.core.data.EntityType(Writer_Data.SCHEMA)),
-                    emptyList()
+                    listOf(
+                        Annotation("inMemory", emptyMap()),
+                        Annotation("ttl", mapOf("value" to AnnotationParam.Str("99d")))
+                    )
                 )
             )
         )
@@ -237,7 +243,10 @@ val ReferencesRecipe_Handle0 = Handle(
             )
         )
     ),
-    listOf(Annotation("persistent", emptyMap()))
+    listOf(
+        Annotation("persistent", emptyMap()),
+        Annotation("ttl", mapOf("value" to AnnotationParam.Str("99d")))
+    )
 )
 val ReferencesRecipe_Handle1 = Handle(
     StorageKeyParser.parse(
@@ -257,7 +266,10 @@ val ReferencesRecipe_Handle1 = Handle(
             )
         )
     ),
-    listOf(Annotation("ttl", mapOf("value" to AnnotationParam.Str("1d"))))
+    listOf(
+        Annotation("inMemory", emptyMap()),
+        Annotation("ttl", mapOf("value" to AnnotationParam.Str("1d")))
+    )
 )
 val ReferencesRecipePlan = Plan(
     listOf(
@@ -271,7 +283,10 @@ val ReferencesRecipePlan = Plan(
                     arcs.core.data.CollectionType(
                         arcs.core.data.ReferenceType(arcs.core.data.EntityType(ReadWriteReferences_InThingRefs.SCHEMA))
                     ),
-                    listOf(Annotation("persistent", emptyMap()))
+                    listOf(
+                        Annotation("persistent", emptyMap()),
+                        Annotation("ttl", mapOf("value" to AnnotationParam.Str("99d")))
+                    )
                 ),
                 "outThingRef" to HandleConnection(
                     ReferencesRecipe_Handle1,
@@ -279,7 +294,10 @@ val ReferencesRecipePlan = Plan(
                     arcs.core.data.SingletonType(
                         arcs.core.data.ReferenceType(arcs.core.data.EntityType(ReadWriteReferences_OutThingRef.SCHEMA))
                     ),
-                    listOf(Annotation("ttl", mapOf("value" to AnnotationParam.Str("1d"))))
+                    listOf(
+                        Annotation("inMemory", emptyMap()),
+                        Annotation("ttl", mapOf("value" to AnnotationParam.Str("1d")))
+                    )
                 )
             )
         )

--- a/src/tools/tests/recipe2plan-test.ts
+++ b/src/tools/tests/recipe2plan-test.ts
@@ -14,6 +14,7 @@ import {Flags} from '../../runtime/flags.js';
 import {ManifestProto} from '../manifest-proto.js';
 import {Runtime} from '../../runtime/runtime.js';
 import {Manifest} from '../../runtime/manifest.js';
+import {DriverFactory} from '../../runtime/storage/drivers/driver-factory.js';
 
 const inputManifestPath = 'java/arcs/core/data/testdata/WriterReaderExample.arcs';
 const policiesManifestPath = 'java/arcs/core/data/testdata/WriterReaderPoliciesExample.arcs';
@@ -53,7 +54,7 @@ $ tools/update-goldens \n\n`
 
         @arcId('writeArcId')
         recipe WritingRecipe
-          thing: create 'my-handle-id' @persistent
+          thing: create 'my-handle-id' @persistent @ttl('30d')
           Writer
             data: writes thing
 
@@ -64,7 +65,7 @@ $ tools/update-goldens \n\n`
             data: reads data
 
         recipe ReadWriteRecipe
-          thing: create
+          thing: create @inMemory @ttl('10d')
           Writer
             data: writes thing
           Reader
@@ -108,7 +109,16 @@ $ tools/update-goldens \n\n`
           fate: 'CREATE',
           name: 'handle0',
           id: 'my-handle-id',
-          annotations: [{name: 'persistent'}],
+          annotations: [{
+            name: 'persistent'
+          },
+          {
+            'name': 'ttl',
+            'params': [{
+              'name': 'value',
+              'strValue': '30d'
+            }]
+          }],
           storageKey: 'reference-mode://{db://25e71af4e9fc8b6958fc46a8f4b7cdf6b5f31516@arcs/Thing}{db://25e71af4e9fc8b6958fc46a8f4b7cdf6b5f31516@arcs/!:writeArcId/handle/my-handle-id}',
           type: {entity: {schema: {
             names: ['Thing'],
@@ -171,7 +181,17 @@ $ tools/update-goldens \n\n`
             names: ['Thing'],
             fields: {name: {primitive: 'TEXT'}},
             hash: '25e71af4e9fc8b6958fc46a8f4b7cdf6b5f31516',
-          }}}
+          }}},
+          annotations: [{
+            name: 'inMemory'
+          },
+          {
+            'name': 'ttl',
+            'params': [{
+              'name': 'value',
+              'strValue': '10d'
+            }]
+          }],
         }],
         particles: [{
           specName: 'Reader',
@@ -208,7 +228,7 @@ $ tools/update-goldens \n\n`
           data: reads [~a]
 
         recipe ReadWriteRecipe
-          thing: create
+          thing: create @inMemory @ttl('12d')
           Writer
             data: writes thing
           Reader
@@ -226,7 +246,7 @@ $ tools/update-goldens \n\n`
               fields: {name: {primitive: 'TEXT'}},
               hash: '25e71af4e9fc8b6958fc46a8f4b7cdf6b5f31516',
             }}}
-          }}
+          }},
         }]
       }, {
         name: 'Reader',
@@ -251,7 +271,18 @@ $ tools/update-goldens \n\n`
               fields: {name: {primitive: 'TEXT'}},
               hash: '25e71af4e9fc8b6958fc46a8f4b7cdf6b5f31516',
             }}}
-          }}
+          }},
+          annotations: [{
+            name: 'inMemory'
+          },
+          {
+            'name': 'ttl',
+            'params': [{
+              'name': 'value',
+              'strValue': '12d'
+            }]
+          }],
+
         }],
         particles: [{
           specName: 'Reader',
@@ -285,4 +316,133 @@ $ tools/update-goldens \n\n`
     const encoded = await recipe2plan(manifest, OutputFormat.Proto, await readManifest(policiesManifestPath), /* recipeFilter= */ null, 'random_salt') as Uint8Array;
     return ManifestProto.decode(encoded).toJSON();
   }
+  const manifestMetaAndParticleSpecs = `
+meta
+  namespace: arcs.core.data.testdata
+particle WriteFoo
+  foo: writes [Foo {f1: Text, f2: Text, f3: Text}]
+particle WriteBar
+  bar: writes Bar {br1: Text, br2: Text}
+particle ReadFooWriteBaz
+  foo: reads [Foo {f1: Text, f2: Text}]
+  baz: writes Baz {bz1: Text}
+particle ReadFooBarWriteBazzz
+  foo: reads [Foo {f1: Text}]
+  bar: reads Bar {br1: Text}
+  bazzz: writes [Baz {bz1: Text}]
+particle ReadQuxWriteBazzz
+  qux: reads Qux {q1: Text}
+  bazzz: writes [Baz {bz1: Text}]
+  `;
+  const policiesManifestStr = `
+schema Foo
+  f1: Text
+  f2: Text
+  f3: Text
+schema Bar
+  br1: Text
+  br2: Text
+  br3: Text
+schema Qux
+  q: Text
+policy PolicyFooF1BarBr1Br2 {
+  @allowedRetention(medium: 'Disk', encryption: false)
+  @maxAge('1d')
+  from Foo access { f1 }
+
+  @allowedRetention(medium: 'Disk', encryption: false)
+  @maxAge('2d')
+  from Bar access { br1, br2 }
+
+  @allowedRetention(medium: 'Disk', encryption: false)
+  @maxAge('20h')
+  from Qux access { q }
+}
+policy PolicyFooF1F2 {
+  @allowedRetention(medium: 'Ram', encryption: false)
+  @maxAge('10h')
+  from Foo access { f1, f2 }
+}
+policy PolicyBarBr2Br3 {
+  @allowedRetention(medium: 'Ram', encryption: true)
+  @maxAge('10m')
+  from Bar access { br2, br3 }
+}
+  `;
+  const assertSuccess = async (recipeStr) => await verifyRecipeIngress(recipeStr, true);
+  const assertFailure = async (recipeStr) => await verifyRecipeIngress(recipeStr, false);
+  const verifyRecipeIngress = async (recipeStr: string, expectedSuccess: boolean) => {
+    DriverFactory.clearRegistrationsForTesting();
+    const recipesManifest = await Manifest.parse(`
+${manifestMetaAndParticleSpecs}
+${recipeStr}
+    `);
+    const policiesManifest = await Manifest.parse(policiesManifestStr);
+    const result = await recipe2plan(recipesManifest, OutputFormat.Kotlin, policiesManifest);
+    assert.equal(result.toString().includes(`val MyRecipePlan = Plan(`), expectedSuccess);
+  };
+  it('generates kotlin plans with derived data capabilities persistence verification', Flags.withDefaultReferenceMode(async () => {
+    const bazRecipeStr = (bazPersistence) => `
+recipe MyRecipe
+  fooHandle: create 'foos' @inMemory @ttl('10h')
+  barHandle: create 'bar' @persistent @ttl('2d')
+  bazHandle: create 'baz' @ttl('10h') ${bazPersistence}
+  WriteFoo
+    foo: fooHandle
+  WriteBar
+    bar: barHandle
+  ReadFooWriteBaz
+    foo: fooHandle
+    baz: bazHandle`;
+    await assertFailure(bazRecipeStr('@persistent'));
+    await assertSuccess(bazRecipeStr('@inMemory'));
+  }));
+
+  it('generates kotlin plans with derived data capabilities ttl verification', Flags.withDefaultReferenceMode(async () => {
+    const bazzzRecipeStr = (bazzzTtl) => `
+recipe MyRecipe
+  fooHandle: create 'foos' @inMemory @ttl('10h')
+  barHandle: create 'bar' @persistent @ttl('2d')
+  quxHandle: create 'qux' @persistent @ttl('20h')
+  bazzzHandle: create 'bazzz' @persistent @ttl('${bazzzTtl}') 
+  WriteFoo
+    foo: fooHandle
+  WriteBar
+    bar: barHandle
+  ReadFooBarWriteBazzz
+    foo: fooHandle
+    bar: barHandle
+    bazzz: bazzzHandle
+  ReadQuxWriteBazzz
+    qux: quxHandle
+    bazzz: bazzzHandle
+    `;
+    await assertFailure(bazzzRecipeStr('2d'));  // f1's maxAge is 1 day.
+    await assertSuccess(bazzzRecipeStr('20h'));
+  }));
+
+  it('generates kotlin plans with derived data capabilities verification', Flags.withDefaultReferenceMode(async () => {
+      const recipeStr = (bazzzPersistence) => `
+recipe MyRecipe
+  fooHandle: create 'foos' @inMemory @ttl('10h')
+  barHandle: create 'bar' @persistent @ttl('2d')
+  bazHandle: create 'baz' @inMemory @ttl('10h')
+  bazzzHandle: create 'bazzz' @persistent @ttl('10h')
+  WriteFoo
+    foo: fooHandle
+  WriteBar
+    bar: barHandle
+  ReadFooWriteBaz
+    foo: fooHandle
+    baz: bazHandle
+  ReadFooBarWriteBazzz
+    foo: fooHandle
+    bar: barHandle
+    bazzz: bazzzHandle
+      `;
+      // Foo.f2 'inMemory' is not compatible for ingress with 'onDisk'
+      await assertFailure(recipeStr('persistent'));
+      // Bar.br1 'onDisk' is not compatible for ingress with 'inMemory'
+      await assertFailure(recipeStr('inMemory'));
+  }));
 });


### PR DESCRIPTION
  - if set of policies is included, recipe2plan verifies capabilities of all `create` handles in all recipes
  - update ingress-validation to infer Policies' Capabilities for a Handle based on what the data is derived from (following handle connections in the recipe)

b/159144612