### PR TITLE
Plumbs serialized particle expression through data structures

### DIFF
--- a/java/arcs/android/host/parcelables/ParcelableHandleConnection.kt
+++ b/java/arcs/android/host/parcelables/ParcelableHandleConnection.kt
@@ -28,6 +28,7 @@ data class ParcelableHandleConnection(
         parcel.writeHandle(actual.handle, flags)
         parcel.writeType(actual.type, flags)
         parcel.writeInt(actual.mode.ordinal)
+        parcel.writeString(actual.expression)
     }
 
     override fun describeContents(): Int = 0
@@ -50,11 +51,15 @@ data class ParcelableHandleConnection(
                 "HandleMode ordinal unknown value $handleModeOrdinal"
             }
 
+            val expression = parcel.readString()
+
             return ParcelableHandleConnection(
                 Plan.HandleConnection(
                     handle,
                     handleMode,
-                    type
+                    type,
+                    emptyList(),
+                    expression
                 )
             )
         }

--- a/java/arcs/core/data/HandleConnectionSpec.kt
+++ b/java/arcs/core/data/HandleConnectionSpec.kt
@@ -16,5 +16,6 @@ import arcs.core.type.Type
 data class HandleConnectionSpec(
     val name: String,
     val direction: HandleMode,
-    val type: Type
+    val type: Type,
+    val expression: String? = null
 )

--- a/java/arcs/core/data/Plan.kt
+++ b/java/arcs/core/data/Plan.kt
@@ -87,7 +87,8 @@ data class Plan(
         val handle: Handle,
         val mode: HandleMode,
         val type: Type,
-        val annotations: List<Annotation> = emptyList()
+        val annotations: List<Annotation> = emptyList(),
+        val expression: String? = null
     ) {
         val storageKey: StorageKey
             get() = handle.storageKey

--- a/java/arcs/core/data/Recipe.kt
+++ b/java/arcs/core/data/Recipe.kt
@@ -81,7 +81,8 @@ fun Recipe.Particle.HandleConnection.toPlanHandleConnection() = Plan.HandleConne
     handle = handle.toPlanHandle(),
     mode = spec.direction,
     type = type,
-    annotations = handle.annotations
+    annotations = handle.annotations,
+    expression = spec.expression
 )
 
 /** Translates a [Recipe.Handle] into a [StorageKey] */

--- a/java/arcs/core/data/proto/ParticleSpecProtoDecoder.kt
+++ b/java/arcs/core/data/proto/ParticleSpecProtoDecoder.kt
@@ -36,7 +36,8 @@ fun DirectionProto.decode() =
 fun HandleConnectionSpecProto.decode() = HandleConnectionSpec(
     name = name,
     direction = direction.decode(),
-    type = type.decode()
+    type = type.decode(),
+    expression = expression.ifEmpty { null }
 )
 
 /** Converts a [ParticleSpecProto] to the corresponding [ParticleSpec] instance. */

--- a/java/arcs/core/data/proto/manifest.proto
+++ b/java/arcs/core/data/proto/manifest.proto
@@ -93,6 +93,7 @@ message HandleConnectionSpecProto {
   string name = 1;
   Direction direction = 2;
   TypeProto type = 3;
+  string expression = 4;
 }
 
 // Representation of a type in Arcs.

--- a/java/arcs/core/host/ArcHostContextParticle.kt
+++ b/java/arcs/core/host/ArcHostContextParticle.kt
@@ -72,7 +72,8 @@ class ArcHostContextParticle(
                         planHandle = handles.planHandles.createReference(planHandle),
                         storageKey = handle.value.storageKey.toString(),
                         mode = handle.value.mode.name, type = handle.value.type.tag.name,
-                        ttl = handle.value.ttl.minutes.toDouble()
+                        ttl = handle.value.ttl.minutes.toDouble(),
+                        expression = handle.value.expression ?: ""
                     )
                 }
             }
@@ -203,7 +204,8 @@ class ArcHostContextParticle(
                 listOf(Annotation.createTtl("$handle.ttl minutes"))
             } else {
                 emptyList()
-            }
+            },
+            handle.expression.ifEmpty { null }
         )
     }.toSet().associateBy({ it.first }, { it.second })
 

--- a/java/arcs/core/host/generated/ArcHostContext.arcs
+++ b/java/arcs/core/host/generated/ArcHostContext.arcs
@@ -17,6 +17,7 @@ schema HandleConnection
   type: Text
   // Ttl object's count field in minutes
   ttl: Number
+  expression: Text
 
 // Represents a ParticleContext and Plan.Particle
 schema ParticleSchema

--- a/javatests/arcs/android/host/parcelables/ParcelableHandleConnectionTest.kt
+++ b/javatests/arcs/android/host/parcelables/ParcelableHandleConnectionTest.kt
@@ -36,11 +36,35 @@ class ParcelableHandleConnectionTest {
         SchemaFields(mapOf("name" to Text), emptyMap()),
         "42"
     )
+    private val storageKey = VolatileStorageKey(ArcId.newForTest("foo"), "bar")
+    private val personType = EntityType(personSchema)
 
     @Test
     fun handleConnection_parcelableRoundTrip_works() {
-        val storageKey = VolatileStorageKey(ArcId.newForTest("foo"), "bar")
-        val personType = EntityType(personSchema)
+        val handleConnection = HandleConnection(
+            Handle(storageKey, personType, emptyList()),
+            HandleMode.ReadWrite,
+            personType,
+            emptyList(),
+            "expression literal"
+        )
+
+        val marshalled = with(Parcel.obtain()) {
+            writeTypedObject(handleConnection.toParcelable(), 0)
+            marshall()
+        }
+
+        val unmarshalled = with(Parcel.obtain()) {
+            unmarshall(marshalled, 0, marshalled.size)
+            setDataPosition(0)
+            readTypedObject(requireNotNull(ParcelableHandleConnection.CREATOR))
+        }
+
+        assertThat(unmarshalled?.actual).isEqualTo(handleConnection)
+    }
+
+    @Test
+    fun handleConnection_parcelableRoundTrip_works_nullExpression() {
         val handleConnection = HandleConnection(
             Handle(storageKey, personType, emptyList()),
             HandleMode.ReadWrite,

--- a/javatests/arcs/core/data/RecipeTest.kt
+++ b/javatests/arcs/core/data/RecipeTest.kt
@@ -111,7 +111,7 @@ class RecipeTest {
             name = "ParticleName",
             location = "com.Particle",
             connections = listOf(
-                HandleConnectionSpec("data", HandleMode.Read, personCollectionType)
+                HandleConnectionSpec("data", HandleMode.Read, personCollectionType, "expression")
             ).associateBy { it.name }
         )
 
@@ -136,7 +136,8 @@ class RecipeTest {
                     "data" to Plan.HandleConnection(
                         handle = handle.toPlanHandle(),
                         mode = HandleMode.Read,
-                        type = contactCollectionType
+                        type = contactCollectionType,
+                        expression = "expression"
                     )
                 )
             )

--- a/src/devtools-connector/tests/devtools-arc-inspector-test.ts
+++ b/src/devtools-connector/tests/devtools-arc-inspector-test.ts
@@ -85,6 +85,7 @@ describe('DevtoolsArcInspector', () => {
           dependentConnections: [],
           direction: 'reads writes',
           isOptional: false,
+          expression: null,
           name: 'foo'
         }]
       }

--- a/src/runtime/manifest-ast-nodes.ts
+++ b/src/runtime/manifest-ast-nodes.ts
@@ -350,6 +350,7 @@ export interface ParticleHandleConnection extends BaseNode {
   name: string;
   tags: TagList;
   annotations: AnnotationRef[];
+  expression: Expression;
 }
 
 export type ParticleItem = ParticleModality | ParticleSlotConnection | Description | ParticleHandleConnection;
@@ -778,6 +779,8 @@ export interface SchemaAlias extends BaseNode {
   items: SchemaItem[];
   alias: string;
 }
+
+export type Expression = ExpressionEntity;
 
 export interface ExpressionEntity extends BaseNode {
   kind: 'expression-entity';

--- a/src/runtime/manifest-parser.pegjs
+++ b/src/runtime/manifest-parser.pegjs
@@ -688,6 +688,7 @@ ParticleHandleConnectionBody
       name: name || (maybeTags && maybeTags[0]) || expected(`either a name or tags to be supplied ${name} ${maybeTags}`),
       tags: maybeTags || [],
       annotations: annotations || [],
+      expression: expression && expression[2]
     });
   }
 

--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -849,8 +849,16 @@ ${e.message}
         }
         processArgTypes(arg.dependentConnections);
         arg.annotations = Manifest._buildAnnotationRefs(manifest, arg.annotations);
+
+        // TODO: Validate that the type of the expression matches the declared type.
+        // TODO: Transform the expression AST into a cross-platform text format.
+        arg.expression = arg.expression && arg.expression.kind;
       }
     };
+    if (particleItem.implFile && particleItem.args.some(arg => !!arg.expression)) {
+      const arg = particleItem.args.find(arg => !!arg.expression);
+      throw new ManifestError(arg.expression.location, `A particle with implementation cannot use result expressions.`);
+    }
     processArgTypes(particleItem.args);
     particleItem.annotations = Manifest._buildAnnotationRefs(manifest, particleItem.annotationRefs);
     manifest._particles[particleItem.name] = new ParticleSpec(particleItem);

--- a/src/runtime/tests/manifest-parser-test.ts
+++ b/src/runtime/tests/manifest-parser-test.ts
@@ -753,7 +753,7 @@ describe('manifest parser', () => {
     });
     it('parses new entity expression', () => {
       parse(`
-      particle Converter
+      particle Converter in 'lol.js'
         foo: reads Foo {x: Number}
         bar: writes Bar {y: Number} = new Bar {y: foo.x}
       `);

--- a/src/tools/manifest2proto.ts
+++ b/src/tools/manifest2proto.ts
@@ -87,7 +87,8 @@ async function handleConnectionSpecToProtoPayload(spec: HandleConnectionSpec) {
   return {
     name: spec.name,
     direction: directionOrdinal,
-    type: await typeToProtoPayload(spec.type)
+    type: await typeToProtoPayload(spec.type),
+    expression: spec.expression
   };
 }
 

--- a/src/tools/plan-generator.ts
+++ b/src/tools/plan-generator.ts
@@ -115,9 +115,12 @@ export class PlanGenerator {
     const mode = this.createHandleMode(connection.direction, connection.type);
     const type = await generateConnectionType(connection);
     const annotations = PlanGenerator.createAnnotations(connection.handle.annotations);
+    const args = [handle, mode, type, annotations];
+    if (connection.spec.expression) {
+      args.push(quote(connection.spec.expression));
+    }
 
-    return ktUtils.applyFun('HandleConnection', [handle, mode, type, annotations],
-        {startIndent: 24});
+    return ktUtils.applyFun('HandleConnection', args, {startIndent: 24});
   }
 
   /** Generates a Kotlin `HandleMode` from a Direction and Type. */

--- a/src/tools/tests/manifest2proto-test.ts
+++ b/src/tools/tests/manifest2proto-test.ts
@@ -182,6 +182,38 @@ describe('manifest2proto', () => {
     });
   });
 
+  it('encodes particle spec with expressions', async () => {
+    const manifest = await Manifest.parse(`
+      particle FooBar
+        bar: reads Y {b: Text}
+        foo: writes X {a: Text} = new X {a: bar.b}
+    `);
+    assert.deepStrictEqual(await toProtoAndBack(manifest), {
+      particleSpecs: [{
+        connections: [{
+          name: 'bar',
+          direction: 'READS',
+          type: {entity: {schema: {
+            names: ['Y'],
+            fields: {b: {primitive: 'TEXT'}},
+            hash: '555c20b532deda21eb146d1909b9fb372ba583b2',
+          }}}
+        }, {
+          name: 'foo',
+          direction: 'WRITES',
+          type: {entity: {schema: {
+            names: ['X'],
+            fields: {a: {primitive: 'TEXT'}},
+            hash: 'eb8597be8b72862d5580f567ab563cefe192508d',
+          }}},
+          expression: 'expression-entity' // This is temporary stop-gap.
+        }],
+        name: 'FooBar',
+        isolated: false,
+      }]
+    });
+  });
+
   it('encodes handle connection reads, writes and reads-writes', async () => {
     const manifest = await Manifest.parse(`
       particle Abc in 'a/b/c.js'


### PR DESCRIPTION
Assumption: We will pass expressions in a text format for which we have a Parser on the Kotlin side.

Plumbs expression as an optional field on the HandleConnectionSpec objects through all the data structures.

* Manifest AST nodes.
* Recipe data structure in TS.
* Protocol Buffer
* Recipe data structure in Kotlin.
* Plan data structure in Kotlin.
* Parcelable
* Arc Host serialized state

(whoa!)

We don't yet have TypeScript serializer for expression, so this is plumbing a AST node kind field as a stop-gap.