### PR TITLE
Change Handle.onUpdate to receive a delta object instead of the model.

### DIFF
--- a/java/arcs/core/entity/SingletonHandle.kt
+++ b/java/arcs/core/entity/SingletonHandle.kt
@@ -24,10 +24,10 @@ typealias SingletonProxy<T> = StorageProxy<SingletonData<T>, SingletonOp<T>, T?>
  * This class implements all of the methods that are needed by the various singleton [Handle]
  * interfaces:
  * * [Handle]
- * * [ReadableHandle<T>]
- * * [ReadSingletonHandle<T>]
- * * [WriteSingletonHandle<T>]
- * * [ReadWriteSingletonHandle<T>]
+ * * [ReadableHandle]
+ * * [ReadSingletonHandle]
+ * * [WriteSingletonHandle]
+ * * [ReadWriteSingletonHandle]
  *
  * It manages the storage and retrieval of items of the specified [Entity] type, including
  * their conversion to and from the backing [RawEntity] type that the storage layer requires.
@@ -73,8 +73,10 @@ class SingletonHandle<T : Storable, R : Referencable>(
     // endregion
 
     // region implement ReadableHandle<T>
-    override fun onUpdate(action: (T?) -> Unit) =
-        storageProxy.addOnUpdate(callbackIdentifier) { action(adaptValue(it)) }
+    override fun onUpdate(action: (SingletonDelta<T>) -> Unit) =
+        storageProxy.addOnUpdate(callbackIdentifier) { oldValue, newValue ->
+            action(SingletonDelta(adaptValue(oldValue), adaptValue(newValue)))
+        }
 
     override fun onDesync(action: () -> Unit) =
         storageProxy.addOnDesync(callbackIdentifier, action)

--- a/java/arcs/core/storage/StorageProxy.kt
+++ b/java/arcs/core/storage/StorageProxy.kt
@@ -90,7 +90,6 @@ class StorageProxy<Data : CrdtData, Op : CrdtOperationAtTime, T>(
     private val busySendingMessagesChannel = ConflatedBroadcastChannel(false)
 
     private var firstUpdateSent = false
-    private var lastDataUpdateHash: Int? = null
     private var lastSyncRequestTimestampMillis: Long? = null
 
     init {
@@ -219,7 +218,7 @@ class StorageProxy<Data : CrdtData, Op : CrdtOperationAtTime, T>(
     /**
      * Add a [Handle] `onUpdate` action associated with a [Handle] name.
      */
-    fun addOnUpdate(id: CallbackIdentifier, action: (value: T) -> Unit) {
+    fun addOnUpdate(id: CallbackIdentifier, action: (oldValue: T, newValue: T) -> Unit) {
         checkNotClosed()
         checkWillSync()
         handleCallbacks.update { it.addOnUpdate(id, action) }
@@ -284,10 +283,11 @@ class StorageProxy<Data : CrdtData, Op : CrdtOperationAtTime, T>(
         checkInDispatcher()
         log.verbose { "Applying operation: $op" }
 
+        val oldValue = crdt.consumerView
         if (!crdt.applyOperation(op)) {
             return CompletableDeferred(false)
         }
-        val value = crdt.consumerView
+        val newValue = crdt.consumerView
 
         // Let the store know about the op by piping it into our outgoing messages channel.
         val result = CompletableDeferred<Boolean>()
@@ -297,7 +297,7 @@ class StorageProxy<Data : CrdtData, Op : CrdtOperationAtTime, T>(
         // only be in onFirstStart and onStart, and as such particles aren't ready for updates yet).
         if (stateHolder.value.state in arrayOf(ProxyState.SYNC, ProxyState.DESYNC)) {
             // TODO: the returned Deferred doesn't account for this update propagation; should it?
-            notifyUpdate(value)
+            notifyUpdate(oldValue, newValue)
         }
         return result
     }
@@ -430,10 +430,10 @@ class StorageProxy<Data : CrdtData, Op : CrdtOperationAtTime, T>(
     }
 
     private fun processModelUpdate(model: Data) {
-        // TODO: send the returned merge changes to notifyUpdate()
+        val oldValue = crdt.consumerView
         crdt.merge(model)
 
-        val value = crdt.consumerView
+        val newValue = crdt.consumerView
         val toResolve = mutableSetOf<CompletableDeferred<T>>()
         val priorState = stateHolder.getAndUpdate {
             toResolve.addAll(it.waitingSyncs)
@@ -443,17 +443,17 @@ class StorageProxy<Data : CrdtData, Op : CrdtOperationAtTime, T>(
         }.state
 
         log.debug { "Completing ${toResolve.size} waiting syncs" }
-        toResolve.forEach { it.complete(value) }
+        toResolve.forEach { it.complete(newValue) }
 
         when (priorState) {
             ProxyState.AWAITING_SYNC -> {
                 notifyReady()
                 applyPostSyncModelOps()
             }
-            ProxyState.SYNC -> notifyUpdate(value)
+            ProxyState.SYNC -> notifyUpdate(oldValue, newValue)
             ProxyState.DESYNC -> {
                 notifyResync()
-                notifyUpdate(value)
+                notifyUpdate(oldValue, newValue)
                 applyPostSyncModelOps()
             }
             ProxyState.NO_SYNC,
@@ -484,6 +484,7 @@ class StorageProxy<Data : CrdtData, Op : CrdtOperationAtTime, T>(
             return
         }
 
+        val oldValue = crdt.consumerView
         val couldApplyAllOps = operations.all { crdt.applyOperation(it) }
 
         if (!couldApplyAllOps) {
@@ -499,12 +500,12 @@ class StorageProxy<Data : CrdtData, Op : CrdtOperationAtTime, T>(
                 it.clearWaitingSyncs()
             }
 
-            val newConsumerView = crdt.consumerView
-            futuresToResolve.forEach { it.complete(newConsumerView) }
+            val newValue = crdt.consumerView
+            futuresToResolve.forEach { it.complete(newValue) }
 
             log.debug { "Notifying onUpdate listeners" }
 
-            notifyUpdate(newConsumerView)
+            notifyUpdate(oldValue, newValue)
         }
     }
 
@@ -526,17 +527,16 @@ class StorageProxy<Data : CrdtData, Op : CrdtOperationAtTime, T>(
         if (tasks.isNotEmpty()) scheduler.schedule(tasks)
     }
 
-    private fun notifyUpdate(data: T) {
+    private fun notifyUpdate(oldValue: T, newValue: T) {
         // If this isn't our first update and the data's hashCode is equivalent to the old data's
         // hashCode, no need to send an update.
-        if (firstUpdateSent && lastDataUpdateHash == data?.hashCode()) return
+        if (firstUpdateSent && oldValue.hashCode() == newValue.hashCode()) return
         firstUpdateSent = true
-        lastDataUpdateHash = data?.hashCode()
 
         log.debug { "notifying update" }
         val tasks = handleCallbacks.value.let {
             buildCallbackTasks(handleCallbacks.value.onUpdate, "onUpdate") {
-                it(data)
+                it(oldValue, newValue)
             } + buildCallbackTasks(handleCallbacks.value.notify, "notify(UPDATE)") {
                 it(StorageEvent.UPDATE)
             }
@@ -619,7 +619,7 @@ class StorageProxy<Data : CrdtData, Op : CrdtOperationAtTime, T>(
 
     private data class HandleCallbacks<T>(
         val onReady: Map<CallbackIdentifier, List<() -> Unit>> = emptyMap(),
-        val onUpdate: Map<CallbackIdentifier, List<(T) -> Unit>> = emptyMap(),
+        val onUpdate: Map<CallbackIdentifier, List<(T, T) -> Unit>> = emptyMap(),
         val onDesync: Map<CallbackIdentifier, List<() -> Unit>> = emptyMap(),
         val onResync: Map<CallbackIdentifier, List<() -> Unit>> = emptyMap(),
         val notify: Map<CallbackIdentifier, List<(StorageEvent) -> Unit>> = emptyMap()
@@ -627,7 +627,7 @@ class StorageProxy<Data : CrdtData, Op : CrdtOperationAtTime, T>(
         fun addOnReady(id: CallbackIdentifier, block: () -> Unit) =
             copy(onReady = onReady + (id to ((onReady[id] ?: emptyList()) + block)))
 
-        fun addOnUpdate(id: CallbackIdentifier, block: (T) -> Unit) =
+        fun addOnUpdate(id: CallbackIdentifier, block: (T, T) -> Unit) =
             copy(onUpdate = onUpdate + (id to ((onUpdate[id] ?: emptyList()) + block)))
 
         fun addOnDesync(id: CallbackIdentifier, block: () -> Unit) =

--- a/java/arcs/core/testutil/handles/HandleHelpers.kt
+++ b/java/arcs/core/testutil/handles/HandleHelpers.kt
@@ -28,7 +28,7 @@ import kotlinx.coroutines.withContext
 suspend fun <H : Handle> H.dispatchClose() = withContext(dispatcher) { close() }
 
 /** Calls [ReadableHandle.createReference] with the handle's dispatcher context. */
-suspend fun <H : ReadableHandle<U>, U, E : Entity>
+suspend fun <H : ReadableHandle<T, U>, T, U, E : Entity>
             H.dispatchCreateReference(entity: E): Reference<E> =
     withContext(dispatcher) { createReference(entity) }
 

--- a/java/arcs/sdk/HandleUtils.kt
+++ b/java/arcs/sdk/HandleUtils.kt
@@ -12,8 +12,6 @@ package arcs.sdk
 
 import arcs.core.entity.ReadCollectionHandle
 import arcs.core.entity.ReadSingletonHandle
-import arcs.core.entity.ReadWriteCollectionHandle
-import arcs.core.entity.ReadWriteSingletonHandle
 import arcs.core.entity.ReadableHandle
 
 /**
@@ -23,9 +21,10 @@ import arcs.core.entity.ReadableHandle
  * @param handle2 The second handle the callback will be assigned to
  * @param action callback
  */
-fun <T1, T2> combineUpdates(
-    handle1: ReadableHandle<T1>,
-    handle2: ReadableHandle<T2>,
+
+fun <T1, U1, T2, U2> combineUpdates(
+    handle1: ReadableHandle<T1, U1>,
+    handle2: ReadableHandle<T2, U2>,
     action: (T1, T2) -> Unit
 ) {
     val handles = listOf(handle1, handle2)
@@ -38,10 +37,10 @@ fun <T1, T2> combineUpdates(
     }
 }
 
-fun <T1, T2, T3> combineUpdates(
-    handle1: ReadableHandle<T1>,
-    handle2: ReadableHandle<T2>,
-    handle3: ReadableHandle<T3>,
+fun <T1, U1, T2, U2, T3, U3> combineUpdates(
+    handle1: ReadableHandle<T1, U1>,
+    handle2: ReadableHandle<T2, U2>,
+    handle3: ReadableHandle<T3, U3>,
     action: (T1, T2, T3) -> Unit
 ) {
     val handles = listOf(handle1, handle2, handle3)
@@ -55,11 +54,11 @@ fun <T1, T2, T3> combineUpdates(
     }
 }
 
-fun <T1, T2, T3, T4> combineUpdates(
-    handle1: ReadableHandle<T1>,
-    handle2: ReadableHandle<T2>,
-    handle3: ReadableHandle<T3>,
-    handle4: ReadableHandle<T4>,
+fun <T1, U1, T2, U2, T3, U3, T4, U4> combineUpdates(
+    handle1: ReadableHandle<T1, U1>,
+    handle2: ReadableHandle<T2, U2>,
+    handle3: ReadableHandle<T3, U3>,
+    handle4: ReadableHandle<T4, U4>,
     action: (T1, T2, T3, T4) -> Unit
 ) {
     val handles = listOf(handle1, handle2, handle3, handle4)
@@ -74,12 +73,12 @@ fun <T1, T2, T3, T4> combineUpdates(
     }
 }
 
-fun <T1, T2, T3, T4, T5> combineUpdates(
-    handle1: ReadableHandle<T1>,
-    handle2: ReadableHandle<T2>,
-    handle3: ReadableHandle<T3>,
-    handle4: ReadableHandle<T4>,
-    handle5: ReadableHandle<T5>,
+fun <T1, U1, T2, U2, T3, U3, T4, U4, T5, U5> combineUpdates(
+    handle1: ReadableHandle<T1, U1>,
+    handle2: ReadableHandle<T2, U2>,
+    handle3: ReadableHandle<T3, U3>,
+    handle4: ReadableHandle<T4, U4>,
+    handle5: ReadableHandle<T5, U5>,
     action: (T1, T2, T3, T4, T5) -> Unit
 ) {
     val handles = listOf(
@@ -101,13 +100,13 @@ fun <T1, T2, T3, T4, T5> combineUpdates(
     }
 }
 
-fun <T1, T2, T3, T4, T5, T6> combineUpdates(
-    handle1: ReadableHandle<T1>,
-    handle2: ReadableHandle<T2>,
-    handle3: ReadableHandle<T3>,
-    handle4: ReadableHandle<T4>,
-    handle5: ReadableHandle<T5>,
-    handle6: ReadableHandle<T6>,
+fun <T1, U1, T2, U2, T3, U3, T4, U4, T5, U5, T6, U6> combineUpdates(
+    handle1: ReadableHandle<T1, U1>,
+    handle2: ReadableHandle<T2, U2>,
+    handle3: ReadableHandle<T3, U3>,
+    handle4: ReadableHandle<T4, U4>,
+    handle5: ReadableHandle<T5, U5>,
+    handle6: ReadableHandle<T6, U6>,
     action: (T1, T2, T3, T4, T5, T6) -> Unit
 ) {
     val handles = listOf(
@@ -131,14 +130,14 @@ fun <T1, T2, T3, T4, T5, T6> combineUpdates(
     }
 }
 
-fun <T1, T2, T3, T4, T5, T6, T7> combineUpdates(
-    handle1: ReadableHandle<T1>,
-    handle2: ReadableHandle<T2>,
-    handle3: ReadableHandle<T3>,
-    handle4: ReadableHandle<T4>,
-    handle5: ReadableHandle<T5>,
-    handle6: ReadableHandle<T6>,
-    handle7: ReadableHandle<T7>,
+fun <T1, U1, T2, U2, T3, U3, T4, U4, T5, U5, T6, U6, T7, U7> combineUpdates(
+    handle1: ReadableHandle<T1, U1>,
+    handle2: ReadableHandle<T2, U2>,
+    handle3: ReadableHandle<T3, U3>,
+    handle4: ReadableHandle<T4, U4>,
+    handle5: ReadableHandle<T5, U5>,
+    handle6: ReadableHandle<T6, U6>,
+    handle7: ReadableHandle<T7, U7>,
     action: (T1, T2, T3, T4, T5, T6, T7) -> Unit
 ) {
     val handles = listOf(
@@ -164,15 +163,15 @@ fun <T1, T2, T3, T4, T5, T6, T7> combineUpdates(
     }
 }
 
-fun <T1, T2, T3, T4, T5, T6, T7, T8> combineUpdates(
-    handle1: ReadableHandle<T1>,
-    handle2: ReadableHandle<T2>,
-    handle3: ReadableHandle<T3>,
-    handle4: ReadableHandle<T4>,
-    handle5: ReadableHandle<T5>,
-    handle6: ReadableHandle<T6>,
-    handle7: ReadableHandle<T7>,
-    handle8: ReadableHandle<T8>,
+fun <T1, U1, T2, U2, T3, U3, T4, U4, T5, U5, T6, U6, T7, U7, T8, U8> combineUpdates(
+    handle1: ReadableHandle<T1, U1>,
+    handle2: ReadableHandle<T2, U2>,
+    handle3: ReadableHandle<T3, U3>,
+    handle4: ReadableHandle<T4, U4>,
+    handle5: ReadableHandle<T5, U5>,
+    handle6: ReadableHandle<T6, U6>,
+    handle7: ReadableHandle<T7, U7>,
+    handle8: ReadableHandle<T8, U8>,
     action: (T1, T2, T3, T4, T5, T6, T7, T8) -> Unit
 ) {
     val handles = listOf(
@@ -200,16 +199,16 @@ fun <T1, T2, T3, T4, T5, T6, T7, T8> combineUpdates(
     }
 }
 
-fun <T1, T2, T3, T4, T5, T6, T7, T8, T9> combineUpdates(
-    handle1: ReadableHandle<T1>,
-    handle2: ReadableHandle<T2>,
-    handle3: ReadableHandle<T3>,
-    handle4: ReadableHandle<T4>,
-    handle5: ReadableHandle<T5>,
-    handle6: ReadableHandle<T6>,
-    handle7: ReadableHandle<T7>,
-    handle8: ReadableHandle<T8>,
-    handle9: ReadableHandle<T9>,
+fun <T1, U1, T2, U2, T3, U3, T4, U4, T5, U5, T6, U6, T7, U7, T8, U8, T9, U9> combineUpdates(
+    handle1: ReadableHandle<T1, U1>,
+    handle2: ReadableHandle<T2, U2>,
+    handle3: ReadableHandle<T3, U3>,
+    handle4: ReadableHandle<T4, U4>,
+    handle5: ReadableHandle<T5, U5>,
+    handle6: ReadableHandle<T6, U6>,
+    handle7: ReadableHandle<T7, U7>,
+    handle8: ReadableHandle<T8, U8>,
+    handle9: ReadableHandle<T9, U9>,
     action: (T1, T2, T3, T4, T5, T6, T7, T8, T9) -> Unit
 ) {
     val handles = listOf(
@@ -239,17 +238,18 @@ fun <T1, T2, T3, T4, T5, T6, T7, T8, T9> combineUpdates(
     }
 }
 
-fun <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> combineUpdates(
-    handle1: ReadableHandle<T1>,
-    handle2: ReadableHandle<T2>,
-    handle3: ReadableHandle<T3>,
-    handle4: ReadableHandle<T4>,
-    handle5: ReadableHandle<T5>,
-    handle6: ReadableHandle<T6>,
-    handle7: ReadableHandle<T7>,
-    handle8: ReadableHandle<T8>,
-    handle9: ReadableHandle<T9>,
-    handle10: ReadableHandle<T10>,
+fun <T1, U1, T2, U2, T3, U3, T4, U4, T5, U5, T6, U6, T7, U7, T8, U8, T9, U9, T10, U10>
+combineUpdates(
+    handle1: ReadableHandle<T1, U1>,
+    handle2: ReadableHandle<T2, U2>,
+    handle3: ReadableHandle<T3, U3>,
+    handle4: ReadableHandle<T4, U4>,
+    handle5: ReadableHandle<T5, U5>,
+    handle6: ReadableHandle<T6, U6>,
+    handle7: ReadableHandle<T7, U7>,
+    handle8: ReadableHandle<T8, U8>,
+    handle9: ReadableHandle<T9, U9>,
+    handle10: ReadableHandle<T10, U10>,
     action: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10) -> Unit
 ) {
     val handles = listOf(
@@ -282,11 +282,9 @@ fun <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> combineUpdates(
 }
 
 @Suppress("UNCHECKED_CAST")
-private fun <T> ReadableHandle<T>.getContent(): T =
+private fun <T, U> ReadableHandle<T, U>.getContent(): T =
     when (this) {
-        is ReadWriteSingletonHandle<*> -> fetch() as T
         is ReadSingletonHandle<*> -> fetch() as T
-        is ReadWriteCollectionHandle<*> -> fetchAll() as T
         is ReadCollectionHandle<*> -> fetchAll() as T
         else -> throw IllegalArgumentException("Unknown ReadableHandle type found")
     }

--- a/java/arcs/sdk/examples/testing/ComputePeopleStats.kt
+++ b/java/arcs/sdk/examples/testing/ComputePeopleStats.kt
@@ -2,9 +2,6 @@ package arcs.sdk.examples.testing
 
 import arcs.core.util.TaggedLog
 
-typealias Person = ComputePeopleStats_People
-typealias Stats = ComputePeopleStats_Stats
-
 /**
  * Particle computing a median age of input people - an example for unit testing.
  */
@@ -13,8 +10,9 @@ class ComputePeopleStats : AbstractComputePeopleStats() {
 
     override fun onStart() {
         handles.people.onUpdate {
-            log.info { "onUpdate: ${it.map(Person::age)}" }
-            calculateMedian(it)
+            val people = handles.people.fetchAll()
+            log.info { "onUpdate: ${people.map(Person::age)}" }
+            calculateMedian(people)
         }
     }
 

--- a/javatests/arcs/android/e2e/testapp/PersonHostService.kt
+++ b/javatests/arcs/android/e2e/testapp/PersonHostService.kt
@@ -63,8 +63,8 @@ class PersonHostService : ArcHostService() {
 
     inner class ReadPerson : AbstractReadPerson() {
         override fun onStart() {
-            handles.person.onUpdate { person ->
-                person?.name?.let { sendResult(it) }
+            handles.person.onUpdate { delta ->
+                delta.new?.name?.let { sendResult(it) }
             }
         }
 

--- a/javatests/arcs/android/host/AndroidEntityHandleManagerTest.kt
+++ b/javatests/arcs/android/host/AndroidEntityHandleManagerTest.kt
@@ -11,6 +11,7 @@ import arcs.core.data.CollectionType
 import arcs.core.data.EntityType
 import arcs.core.data.HandleMode
 import arcs.core.data.SingletonType
+import arcs.core.entity.CollectionDelta
 import arcs.core.entity.Handle
 import arcs.core.entity.HandleSpec
 import arcs.core.entity.ReadCollectionHandle
@@ -18,6 +19,7 @@ import arcs.core.entity.ReadSingletonHandle
 import arcs.core.entity.ReadWriteCollectionHandle
 import arcs.core.entity.ReadWriteQueryCollectionHandle
 import arcs.core.entity.ReadWriteSingletonHandle
+import arcs.core.entity.SingletonDelta
 import arcs.core.entity.WriteCollectionHandle
 import arcs.core.entity.WriteSingletonHandle
 import arcs.core.entity.awaitReady
@@ -215,7 +217,7 @@ class AndroidEntityHandleManagerTest : LifecycleOwner {
 
         assertThat(handleHolder.readWriteHandle.dispatchFetch()).isEqualTo(entity1)
 
-        val updatedEntity: Person? = suspendCoroutine { continuation ->
+        val updatedEntity: SingletonDelta<Person> = suspendCoroutine { continuation ->
             // Verify callbacks work
             launch {
                 handleHolder.readWriteHandle.onUpdate {
@@ -225,7 +227,7 @@ class AndroidEntityHandleManagerTest : LifecycleOwner {
             }
         }
 
-        assertThat(updatedEntity).isEqualTo(entity2)
+        assertThat(updatedEntity).isEqualTo(SingletonDelta(old = entity1, new = entity2))
     }
 
     @Test
@@ -265,7 +267,7 @@ class AndroidEntityHandleManagerTest : LifecycleOwner {
 
         val entity3 = entity2.copy(name = "Ray")
 
-        val updatedEntities: Set<Person> = suspendCoroutine { continuation ->
+        val updatedEntities: CollectionDelta<Person> = suspendCoroutine { continuation ->
             // Verify callbacks work
             launch {
                 handleHolder.readWriteCollectionHandle.onUpdate {
@@ -274,7 +276,7 @@ class AndroidEntityHandleManagerTest : LifecycleOwner {
                 handleHolder.writeCollectionHandle.dispatchStore(entity3)
             }
         }
-        assertThat(updatedEntities).containsExactly(entity1, entity2, entity3)
+        assertThat(updatedEntities).isEqualTo(CollectionDelta(added = setOf(entity3)))
     }
 
     @Test

--- a/javatests/arcs/android/systemhealth/testapp/StorageCore.kt
+++ b/javatests/arcs/android/systemhealth/testapp/StorageCore.kt
@@ -424,7 +424,7 @@ class StorageCore(val context: Context, val lifecycle: Lifecycle) {
                 }
             }
 
-            handle.onUpdate { entity ->
+            handle.onUpdate { delta ->
                 if (settings.function == Function.LATENCY_BACKPRESSURE_TEST) {
                     val time = System.currentTimeMillis()
                     tasksEvents[taskId]?.writer?.withLock {
@@ -435,7 +435,7 @@ class StorageCore(val context: Context, val lifecycle: Lifecycle) {
                                 else
                                     TaskEventId.HANDLE_STORE_READER_END,
                                 time,
-                                entity?.number
+                                delta.new?.number
                             )
                         )
                     }
@@ -474,7 +474,7 @@ class StorageCore(val context: Context, val lifecycle: Lifecycle) {
                 }
             }
 
-            handle.onUpdate { entity ->
+            handle.onUpdate {
                 if (settings.function == Function.LATENCY_BACKPRESSURE_TEST) {
                     val time = System.currentTimeMillis()
                     tasksEvents[taskId]?.writer?.withLock {
@@ -485,7 +485,7 @@ class StorageCore(val context: Context, val lifecycle: Lifecycle) {
                                 else
                                     TaskEventId.HANDLE_STORE_READER_END,
                                 time,
-                                entity.map { it.number }.toSet()
+                                handle.fetchAll().mapTo(mutableSetOf(), TestEntity::number)
                             )
                         )
                     }

--- a/javatests/arcs/core/entity/HandleManagerTestBase.kt
+++ b/javatests/arcs/core/entity/HandleManagerTestBase.kt
@@ -45,9 +45,7 @@ import arcs.jvm.host.JvmSchedulerProvider
 import arcs.jvm.util.testutil.FakeTime
 import com.google.common.truth.Truth.assertThat
 import kotlin.test.assertFailsWith
-import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.callbackFlow
@@ -215,24 +213,24 @@ open class HandleManagerTestBase {
             singletonKey
         ).awaitReady() as ReadSingletonHandle<Person>
 
-        var received = CompletableDeferred<Person?>()
-        readHandle.onUpdate { received.complete(it) }
+        var received = Job()
+        readHandle.onUpdate { received.complete() }
 
         // Verify store against empty.
         writeHandle.dispatchStore(entity1)
-        assertThat(received.await()).isEqualTo(entity1)
+        received.join()
         assertThat(readHandle.dispatchFetch()).isEqualTo(entity1)
 
         // Verify store overwrites existing.
-        received = CompletableDeferred()
+        received = Job()
         writeHandle.dispatchStore(entity2)
-        assertThat(received.await()).isEqualTo(entity2)
+        received.join()
         assertThat(readHandle.dispatchFetch()).isEqualTo(entity2)
 
         // Verify clear.
-        received = CompletableDeferred()
+        received = Job()
         writeHandle.dispatchClear()
-        assertThat(received.await()).isNull()
+        received.join()
         assertThat(readHandle.dispatchFetch()).isNull()
     }
 
@@ -260,27 +258,27 @@ open class HandleManagerTestBase {
         ).awaitReady() as ReadWriteSingletonHandle<Person>
 
         // handle1 -> handle2
-        val received1to2 = CompletableDeferred<Person?>()
-        handle2.onUpdate { received1to2.complete(it) }
+        val received1to2 = Job()
+        handle2.onUpdate { received1to2.complete() }
 
         // Verify that handle2 sees the entity stored by handle1.
         handle1.dispatchStore(entity1)
-        assertThat(received1to2.await()).isEqualTo(entity1)
+        received1to2.join()
         assertThat(handle2.dispatchFetch()).isEqualTo(entity1)
 
         // handle2 -> handle1
-        var received2to1 = CompletableDeferred<Person?>()
-        handle1.onUpdate { received2to1.complete(it) }
+        var received2to1 = Job()
+        handle1.onUpdate { received2to1.complete() }
 
         // Verify that handle2 can clear the entity stored by handle1.
         handle2.dispatchClear()
-        assertThat(received2to1.await()).isNull()
+        received2to1.join()
         assertThat(handle1.dispatchFetch()).isNull()
 
         // Verify that handle1 sees the entity stored by handle2.
-        received2to1 = CompletableDeferred()
+        received2to1 = Job()
         handle2.dispatchStore(entity2)
-        assertThat(received2to1.await()).isEqualTo(entity2)
+        received2to1.join()
         assertThat(handle1.dispatchFetch()).isEqualTo(entity2)
     }
 
@@ -290,7 +288,7 @@ open class HandleManagerTestBase {
         val readHandle = readHandleManager.createSingletonHandle()
         val readHandleUpdated = readHandle.onUpdateDeferred()
         writeHandle.dispatchStore(entity1)
-        readHandleUpdated.await()
+        readHandleUpdated.join()
         log("Wrote entity1 to writeHandle")
 
         // Create a second handle for the second entity, so we can store it.
@@ -305,8 +303,8 @@ open class HandleManagerTestBase {
         val refReadKnows = refReadHandle.onUpdateDeferred()
 
         refWriteHandle.dispatchStore(entity2)
-        monitorKnows.await()
-        refReadKnows.await()
+        monitorKnows.join()
+        refReadKnows.join()
 
         // Now read back entity1, and dereference its best_friend.
         log("Checking entity1's best friend")
@@ -361,7 +359,7 @@ open class HandleManagerTestBase {
         writeHandle.dispatchStore(personWithHat)
 
         RamDisk.waitUntilSet(fezStorageRef.referencedStorageKey())
-        readOnUpdate.await()
+        readOnUpdate.join()
 
         // Read out the entity, and fetch its hat.
         val entityOut = readHandle.dispatchFetch()!!
@@ -382,7 +380,7 @@ open class HandleManagerTestBase {
         fakeTime.millis = expectedCreateTime
 
         handle.dispatchStore(entity1)
-        handleBUpdated.await()
+        handleBUpdated.join()
 
         val readBack = handleB.dispatchFetch()!!
         assertThat(readBack.creationTimestamp).isEqualTo(expectedCreateTime)
@@ -397,7 +395,7 @@ open class HandleManagerTestBase {
 
         var handleBUpdated = handleB.onUpdateDeferred()
         handle.dispatchStore(entity1)
-        handleBUpdated.await()
+        handleBUpdated.join()
 
         val readBack = handleB.dispatchFetch()!!
         assertThat(readBack.creationTimestamp).isEqualTo(0)
@@ -406,7 +404,7 @@ open class HandleManagerTestBase {
         val handleC = readHandleManager.createSingletonHandle(ttl = Ttl.Minutes(2))
         handleBUpdated = handleB.onUpdateDeferred()
         handleC.dispatchStore(entity2)
-        handleBUpdated.await()
+        handleBUpdated.join()
 
         val readBack2 = handleB.dispatchFetch()!!
         assertThat(readBack2.creationTimestamp).isEqualTo(0)
@@ -425,7 +423,7 @@ open class HandleManagerTestBase {
         val refHandle = writeHandleManager.createReferenceSingletonHandle(ttl = Ttl.Minutes(2))
         val updated = entityHandle.onUpdateDeferred()
         entityHandle.dispatchStore(entity1)
-        updated.await()
+        updated.join()
 
         // Create and store a reference with TTL.
         val entity1Ref = entityHandle.dispatchCreateReference(entity1)
@@ -444,9 +442,9 @@ open class HandleManagerTestBase {
         // Create and store an entity.
         val writeEntityHandle = writeHandleManager.createCollectionHandle()
         val monitorHandle = monitorHandleManager.createCollectionHandle()
-        val initialEntityStored = monitorHandle.onUpdateDeferred { it.size == 1 }
+        val initialEntityStored = monitorHandle.onUpdateDeferred { it.size() == 1 }
         writeEntityHandle.dispatchStore(entity1)
-        initialEntityStored.await()
+        initialEntityStored.join()
         log("Created and stored an entity")
 
         // Create and store a reference to the entity.
@@ -458,7 +456,7 @@ open class HandleManagerTestBase {
         log("Created and stored a reference")
 
         RamDisk.waitUntilSet(entity1Ref.toReferencable().referencedStorageKey())
-        refHeard.await()
+        refHeard.join()
 
         // Now read back the reference from a different handle.
         var reference = readRefHandle.dispatchFetch()!!
@@ -473,11 +471,11 @@ open class HandleManagerTestBase {
         // Modify the entity.
         val modEntity1 = entity1.copy(name = "Ben")
         val entityModified = monitorHandle.onUpdateDeferred {
-            it.all { person -> person.name == "Ben" }
+            it.fetchAll().all { person -> person.name == "Ben" }
         }
         writeEntityHandle.dispatchStore(modEntity1)
         assertThat(writeEntityHandle.dispatchSize()).isEqualTo(1)
-        entityModified.await()
+        entityModified.join()
 
         // Reference should still be alive.
         reference = readRefHandle.dispatchFetch()!!
@@ -491,7 +489,7 @@ open class HandleManagerTestBase {
         // Remove the entity from the collection.
         val heardTheDelete = monitorHandle.onUpdateDeferred { it.isEmpty() }
         writeEntityHandle.dispatchRemove(entity1)
-        heardTheDelete.await()
+        heardTheDelete.join()
 
         // Reference should be dead. (Removed entities currently aren't actually deleted, but
         // instead are "nulled out".)
@@ -578,7 +576,7 @@ open class HandleManagerTestBase {
 
         var received = Job()
         var size = 3
-        readHandle.onUpdate { if (it.size == size) received.complete() }
+        readHandle.onUpdate { if (readHandle.size() == size) received.complete() }
 
         // Verify store.
         writeHandle.dispatchStore(entity1, entity2, entity3)
@@ -637,33 +635,33 @@ open class HandleManagerTestBase {
         )
 
         // handle1 -> handle2
-        val received1to2 = CompletableDeferred<Set<Person>>()
-        handle2.onUpdate { if (it.size == 3) received1to2.complete(it) }
+        val received1to2 = Job()
+        handle2.onUpdate { if (handle2.size() == 3) received1to2.complete() }
 
         // Verify that handle2 sees entities stored by handle1.
         handle1.dispatchStore(entity1, entity2, entity3)
-        assertThat(received1to2.await()).containsExactly(entity1, entity2, entity3)
+        received1to2.join()
         assertThat(handle2.dispatchSize()).isEqualTo(3)
         assertThat(handle2.dispatchIsEmpty()).isEqualTo(false)
         assertThat(handle2.dispatchFetchAll()).containsExactly(entity1, entity2, entity3)
 
         // handle2 -> handle1
-        var received2to1 = CompletableDeferred<Set<Person>>()
+        var received2to1 = Job()
         var size2to1 = 2
-        handle1.onUpdate { if (it.size == size2to1) received2to1.complete(it) }
+        handle1.onUpdate { if (handle1.size() == size2to1) received2to1.complete() }
 
         // Verify that handle2 can remove entities stored by handle1.
         handle2.dispatchRemove(entity2)
-        assertThat(received2to1.await()).containsExactly(entity1, entity3)
+        received2to1.join()
         assertThat(handle1.dispatchSize()).isEqualTo(2)
         assertThat(handle1.dispatchIsEmpty()).isEqualTo(false)
         assertThat(handle1.dispatchFetchAll()).containsExactly(entity1, entity3)
 
         // Verify that handle1 sees an empty collection after a clear op from handle2.
-        received2to1 = CompletableDeferred()
+        received2to1 = Job()
         size2to1 = 0
         handle2.dispatchClear()
-        assertThat(received2to1.await()).isEmpty()
+        received2to1.join()
         assertThat(handle1.dispatchSize()).isEqualTo(0)
         assertThat(handle1.dispatchIsEmpty()).isEqualTo(true)
         assertThat(handle1.dispatchFetchAll()).isEmpty()
@@ -702,9 +700,10 @@ open class HandleManagerTestBase {
             entitySpec = TestParticle_Entities
         )
 
-        val updateDeferred = readHandle.onUpdateDeferred { it.size == 1 }
+        val updateDeferred = readHandle.onUpdateDeferred { it.size() == 1 }
         writeHandle.dispatchStore(entity)
-        assertThat(updateDeferred.await()).containsExactly(entity)
+        updateDeferred.join()
+        assertThat(readHandle.dispatchFetchAll()).containsExactly(entity)
     }
 
     @Test
@@ -734,9 +733,10 @@ open class HandleManagerTestBase {
             entitySpec = TestInlineParticle_Entities
         )
 
-        val updateDeferred = readHandle.onUpdateDeferred { it.size == 1 }
+        val updateDeferred = readHandle.onUpdateDeferred { it.size() == 1 }
         writeHandle.dispatchStore(entity)
-        assertThat(updateDeferred.await()).containsExactly(entity)
+        updateDeferred.join()
+        assertThat(readHandle.dispatchFetchAll()).containsExactly(entity)
     }
 
     @Test
@@ -779,9 +779,10 @@ open class HandleManagerTestBase {
             entitySpec = TestReferencesParticle_Entities
         )
 
-        val updateDeferred = readHandle.onUpdateDeferred { it.size == 3 }
+        val updateDeferred = readHandle.onUpdateDeferred { it.size() == 3 }
         entities.forEach { writeHandle.dispatchStore(it) }
-        val entitiesOut = updateDeferred.await()
+        updateDeferred.join()
+        val entitiesOut = readHandle.dispatchFetchAll()
         assertThat(entitiesOut).containsExactlyElementsIn(entities)
         entitiesOut.forEach { entity ->
             entity.references.forEach { it.dereference() }
@@ -845,14 +846,14 @@ open class HandleManagerTestBase {
         val writeHandle = writeHandleManager.createCollectionHandle()
         val readHandle = readHandleManager.createCollectionHandle()
         val monitorHandle = monitorHandleManager.createCollectionHandle()
-        val monitorInitialized = monitorHandle.onUpdateDeferred { it.size == 2 }
-        val readUpdated = readHandle.onUpdateDeferred { it.size == 2 }
+        val monitorInitialized = monitorHandle.onUpdateDeferred { it.size() == 2 }
+        val readUpdated = readHandle.onUpdateDeferred { it.size() == 2 }
 
         writeHandle.dispatchStore(entity1, entity2)
         log("wrote entity1 and entity2 to writeHandle")
 
-        monitorInitialized.await()
-        readUpdated.await()
+        monitorInitialized.join()
+        readUpdated.join()
         log("readHandle and the ramDisk have heard of the update")
 
         readHandle.dispatchFetchAll()
@@ -887,7 +888,7 @@ open class HandleManagerTestBase {
 
         val fez = Hat(entityId = "fez-id", style = "fez")
         val hatMonitorKnows = hatMonitor.onUpdateDeferred {
-            it.find { hat -> hat.entityId == "fez-id" } != null
+            it.fetchAll().find { hat -> hat.entityId == "fez-id" } != null
         }
         hatCollection.dispatchStore(fez)
         val fezRef = hatCollection.dispatchCreateReference(fez)
@@ -906,19 +907,19 @@ open class HandleManagerTestBase {
             )
         )
         val readHandleKnows = readHandle.onUpdateDeferred {
-            it.find { person -> person.entityId == "a-hatted-individual" } != null
+            it.fetchAll().find { person -> person.entityId == "a-hatted-individual" } != null
         }
         writeHandle.dispatchStore(personWithHat)
 
         // Read out the entity, and fetch its hat.
-        readHandleKnows.await()
+        readHandleKnows.join()
         val entityOut = readHandle.dispatchFetchAll().single {
             it.entityId == "a-hatted-individual"
         }
         val hatRef = entityOut.coolnessIndex.hat!!
         assertThat(hatRef).isEqualTo(fezStorageRef)
 
-        hatMonitorKnows.await()
+        hatMonitorKnows.join()
         val rawHat = hatRef.dereference()!!
         val hat = Hat.deserialize(rawHat)
         assertThat(hat).isEqualTo(fez)
@@ -936,8 +937,8 @@ open class HandleManagerTestBase {
         fakeTime.millis = expectedCreateTime
 
         handle.dispatchStore(entity1)
-        monitorNotified.await()
-        handleBChanged.await()
+        monitorNotified.join()
+        handleBChanged.join()
 
         val readBack = handleB.dispatchFetchAll().first { it.entityId == entity1.entityId }
         assertThat(readBack.creationTimestamp).isEqualTo(expectedCreateTime)
@@ -951,7 +952,7 @@ open class HandleManagerTestBase {
         val handleB = readHandleManager.createCollectionHandle()
         var handleBChanged = handleB.onUpdateDeferred()
         handle.dispatchStore(entity1)
-        handleBChanged.await()
+        handleBChanged.join()
 
         val readBack = handleB.dispatchFetchAll().first { it.entityId == entity1.entityId }
         assertThat(readBack.creationTimestamp).isEqualTo(0)
@@ -960,7 +961,7 @@ open class HandleManagerTestBase {
         val handleC = readHandleManager.createCollectionHandle(ttl = Ttl.Minutes(2))
         handleBChanged = handleB.onUpdateDeferred()
         handleC.dispatchStore(entity2)
-        handleBChanged.await()
+        handleBChanged.join()
         val readBack2 = handleB.dispatchFetchAll().first { it.entityId == entity2.entityId }
         assertThat(readBack2.creationTimestamp).isEqualTo(0)
         assertThat(readBack2.expirationTimestamp).isEqualTo(2 * 60 * 1000)
@@ -980,7 +981,7 @@ open class HandleManagerTestBase {
         // Create and store an entity with no TTL.
         val updated = entityHandle.onUpdateDeferred()
         entityHandle.dispatchStore(entity1)
-        updated.await()
+        updated.join()
 
         // Create and store a reference with TTL.
         val entity1Ref = entityHandle.dispatchCreateReference(entity1)
@@ -1000,16 +1001,9 @@ open class HandleManagerTestBase {
         val writeHandle = writeHandleManager.createCollectionHandle()
         val readHandle = readHandleManager.createCollectionHandle()
 
-        val readUpdatedTwice = readHandle.onUpdateDeferred {
-            log("B.onUpdate(${it.map(Person::entityId)})")
-            it.size == 2
-        }
-
-        log("Writing entities to A")
+        val readUpdatedTwice = readHandle.onUpdateDeferred { it.size() == 2 }
         writeHandle.dispatchStore(entity1, entity2)
-
-        log("Waiting for entities on B")
-        readUpdatedTwice.await()
+        readUpdatedTwice.join()
 
         // Ensure that the query argument is being used.
         assertThat(readHandle.dispatchQuery(21.0)).containsExactly(entity1)
@@ -1061,14 +1055,14 @@ open class HandleManagerTestBase {
         }
         val monitorSawEntities = monitorHandle.onUpdateDeferred {
             log("First batch of entities - so far: $it")
-            it.size == 2
+            it.size() == 2
         }
         writeEntityHandle.dispatchStore(entity1, entity2)
 
         // Wait for the monitor to see the entities (monitor handle is on a separate storage proxy
         // with a separate stores-cache, so it requires the entities to have made it to the storage
         // media.
-        monitorSawEntities.await()
+        monitorSawEntities.join()
 
         // Create a store a reference to the entity.
         val entity1Ref = writeEntityHandle.dispatchCreateReference(entity1)
@@ -1077,12 +1071,12 @@ open class HandleManagerTestBase {
         val readRefHandle = readHandleManager.createReferenceCollectionHandle()
         val refWritesHappened = readRefHandle.onUpdateDeferred {
             log("References created so far: $it")
-            it.size == 2
+            it.size() == 2
         }
         writeRefHandle.dispatchStore(entity1Ref, entity2Ref)
 
         // Now read back the references from a different handle.
-        refWritesHappened.await()
+        refWritesHappened.join()
         var references = readRefHandle.dispatchFetchAll()
         assertThat(references).containsExactly(entity1Ref, entity2Ref)
 
@@ -1099,10 +1093,10 @@ open class HandleManagerTestBase {
         val modEntity2 = entity2.copy(name = "Ben")
         val entitiesWritten = monitorHandle.onUpdateDeferred {
             log("Heard update with $it")
-            it.all { person -> person.name == "Ben" }
+            it.fetchAll().all { person -> person.name == "Ben" }
         }
         writeEntityHandle.dispatchStore(modEntity1, modEntity2)
-        entitiesWritten.await()
+        entitiesWritten.join()
 
         // Reference should still be alive.
         references = readRefHandle.dispatchFetchAll()
@@ -1118,7 +1112,7 @@ open class HandleManagerTestBase {
         // Remove the entities from the collection.
         val entitiesDeleted = monitorHandle.onUpdateDeferred { it.isEmpty() }
         writeEntityHandle.dispatchRemove(entity1, entity2)
-        entitiesDeleted.await()
+        entitiesDeleted.join()
 
         log("Checking that they are empty when de-referencing.")
 
@@ -1222,12 +1216,13 @@ open class HandleManagerTestBase {
         ttl
     ).also { it.awaitReady() } as ReadWriteQueryCollectionHandle<Reference<Person>, Any>
 
-    private fun <T> ReadableHandle<T>.onUpdateDeferred(
-        predicate: (T) -> Boolean = { true }
-    ): Deferred<T> = CompletableDeferred<T>().also { deferred ->
+    // Note the predicate receives the *handle*, not onUpdate's delta argument.
+    private fun <H : ReadableHandle<T, U>, T, U> H.onUpdateDeferred(
+        predicate: (H) -> Boolean = { true }
+    ) = Job().also { deferred ->
         onUpdate {
-            if (deferred.isActive && predicate(it)) {
-                deferred.complete(it)
+            if (deferred.isActive && predicate(this)) {
+                deferred.complete()
             }
         }
     }

--- a/javatests/arcs/core/host/HandleAdapterTest.kt
+++ b/javatests/arcs/core/host/HandleAdapterTest.kt
@@ -275,7 +275,7 @@ class HandleAdapterTest {
 
         val monitorKnows = CompletableDeferred<Unit>()
         monitorHandle.onUpdate {
-            if (it.contains(entity)) monitorKnows.complete(Unit)
+            if (it.added.contains(entity)) monitorKnows.complete(Unit)
         }
         handle.dispatchStore(entity)
 

--- a/javatests/arcs/core/host/lifecycle.arcs
+++ b/javatests/arcs/core/host/lifecycle.arcs
@@ -96,3 +96,14 @@ recipe PipelineTest
   PipelineConsumerParticle
     sngRead: reads s2
     colRead: reads c2
+
+// -----------------------------------------------------------------------------
+
+particle UpdateDeltasParticle in '.UpdateDeltasParticle'
+  sng: reads Data {num: Int}
+  col: reads [Data {num: Int}]
+
+recipe UpdateDeltasTest
+  UpdateDeltasParticle
+    sng: reads h1
+    col: reads h2

--- a/javatests/arcs/core/storage/StorageProxyTest.kt
+++ b/javatests/arcs/core/storage/StorageProxyTest.kt
@@ -154,7 +154,7 @@ class StorageProxyTest {
             assertThat(exception).hasMessageThat().startsWith("Action handlers are not valid")
         }
         check { proxy.addOnReady(callbackId) {} }
-        check { proxy.addOnUpdate(callbackId) {} }
+        check { proxy.addOnUpdate(callbackId) { _, _ -> Unit } }
         check { proxy.addOnDesync(callbackId) {} }
         check { proxy.addOnResync(callbackId) {} }
     }
@@ -345,7 +345,7 @@ class StorageProxyTest {
         channels.onResync.receiveOrTimeout()
         assertThat(proxy.getStateForTesting()).isEqualTo(ProxyState.SYNC)
         verify(onResync).invoke()
-        verify(onUpdate).invoke(any())
+        verify(onUpdate).invoke("data")
         verifyNoMoreInteractions(onReady, onDesync)
     }
 
@@ -840,7 +840,7 @@ class StorageProxyTest {
 
     private data class ActionChannels(
         val onReady: Channel<Unit> = Channel(Channel.BUFFERED),
-        val onUpdate: Channel<String> = Channel(Channel.BUFFERED),
+        val onUpdate: Channel<Unit> = Channel(Channel.BUFFERED),
         val onDesync: Channel<Unit> = Channel(Channel.BUFFERED),
         val onResync: Channel<Unit> = Channel(Channel.BUFFERED)
     )
@@ -855,9 +855,9 @@ class StorageProxyTest {
                 mocks.onReady()
                 channels.onReady.offer(Unit)
             }
-            proxy.addOnUpdate(id) {
-                mocks.onUpdate(it)
-                channels.onUpdate.offer(it)
+            proxy.addOnUpdate(id) { _, new ->
+                mocks.onUpdate(new)
+                channels.onUpdate.offer(Unit)
             }
             proxy.addOnDesync(id) {
                 mocks.onDesync()

--- a/javatests/arcs/sdk/examples/testing/ComputePeopleStatsTest.kt
+++ b/javatests/arcs/sdk/examples/testing/ComputePeopleStatsTest.kt
@@ -16,6 +16,8 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
+typealias Person = AbstractComputePeopleStats.Person
+
 /**
  * Example of particle Unit Testing.
  */
@@ -57,7 +59,7 @@ class ComputePeopleStatsTest {
         assertThat(harness.stats.dispatchFetch()).isNull()
 
         var statsUpdateAge = CompletableDeferred<Double?>()
-        harness.stats.onUpdate { statsUpdateAge.complete(it?.medianAge) }
+        harness.stats.onUpdate { statsUpdateAge.complete(it.new?.medianAge) }
 
         val person20 = Person(20.0)
         statsUpdateAge = CompletableDeferred()


### PR DESCRIPTION
The onUpdate callback currently receives the result of `handle.fetch()` or `.fetchAll()` as its argument. This is replaced by a `SingletonDelta` or `CollectionDelta` object that indicates how the handle's data has changed (the singleton case is just the old and new entities; we may make that more detailed in the future).