### PR TITLE
Use fully qualified reference to particle in recipe2plan

### DIFF
--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -861,6 +861,7 @@ ${e.message}
     }
     processArgTypes(particleItem.args);
     particleItem.annotations = Manifest._buildAnnotationRefs(manifest, particleItem.annotationRefs);
+    particleItem.manifestNamespace = manifest.meta.namespace;
     manifest._particles[particleItem.name] = new ParticleSpec(particleItem);
   }
 

--- a/src/runtime/particle-spec.ts
+++ b/src/runtime/particle-spec.ts
@@ -243,6 +243,7 @@ export interface SerializedParticleSpec extends Literal {
   trustClaims?: ClaimStatement[];
   trustChecks?: CheckStatement[];
   annotations?: AnnotationRef[];
+  manifestNamespace?: string;
 }
 
 export interface StorableSerializedParticleSpec extends SerializedParticleSpec {
@@ -341,6 +342,10 @@ export class ParticleSpec {
     return this.connections.filter(a => a.isOutput);
   }
 
+  get manifestNamespace(): string | null {
+    return this.model.manifestNamespace;
+  }
+
   isInput(param: string): boolean {
     const connection = this.handleConnectionMap.get(param);
     return connection && connection.isInput;
@@ -428,19 +433,19 @@ export class ParticleSpec {
   }
 
   toLiteral(): SerializedParticleSpec {
-    const {args, name, verbs, description, external, implFile, implBlobUrl, modality, slotConnections, trustClaims, trustChecks, annotations} = this.model;
+    const {args, name, verbs, description, external, implFile, implBlobUrl, modality, slotConnections, trustClaims, trustChecks, annotations, manifestNamespace} = this.model;
     const connectionToLiteral : (input: SerializedHandleConnectionSpec) => SerializedHandleConnectionSpec =
       ({type, direction, relaxed, name, isOptional, dependentConnections, annotations, expression}) => ({type: asTypeLiteral(type), direction, relaxed, name, isOptional, dependentConnections: dependentConnections.map(connectionToLiteral), annotations: annotations || [], expression});
     const argsLiteral = args.map(a => connectionToLiteral(a));
-    return {args: argsLiteral, name, verbs, description, external, implFile, implBlobUrl, modality, slotConnections, trustClaims, trustChecks, annotations};
+    return {args: argsLiteral, name, verbs, description, external, implFile, implBlobUrl, modality, slotConnections, trustClaims, trustChecks, annotations, manifestNamespace};
   }
 
   static fromLiteral(literal: SerializedParticleSpec, options?: ParticleSpecOptions): ParticleSpec {
-    let {args, name, verbs, description, external, implFile, implBlobUrl, modality, slotConnections, trustClaims, trustChecks, annotations} = literal;
+    let {args, name, verbs, description, external, implFile, implBlobUrl, modality, slotConnections, trustClaims, trustChecks, annotations, manifestNamespace} = literal;
     const connectionFromLiteral = ({type, direction, relaxed, name, isOptional, dependentConnections, expression}: SerializedHandleConnectionSpec) =>
       ({type: asType(type), direction, relaxed, name, isOptional, dependentConnections: dependentConnections ? dependentConnections.map(connectionFromLiteral) : [], annotations: /*annotations ||*/ [], expression});
     args = args.map(connectionFromLiteral);
-    return new ParticleSpec({args, name, verbs: verbs || [], description, external, implFile, implBlobUrl, modality, slotConnections, trustClaims, trustChecks, annotations}, options);
+    return new ParticleSpec({args, name, verbs: verbs || [], description, external, implFile, implBlobUrl, modality, slotConnections, trustClaims, trustChecks, annotations, manifestNamespace}, options);
   }
 
   // Note: this method shouldn't be called directly.

--- a/src/tools/plan-generator.ts
+++ b/src/tools/plan-generator.ts
@@ -113,7 +113,7 @@ export class PlanGenerator {
 
     const handle = this.handleVariableName(connection.handle);
     const mode = this.createHandleMode(connection.direction, connection.type);
-    const type = await generateConnectionType(connection);
+    const type = await generateConnectionType(connection, {namespace: this.namespace});
     const annotations = PlanGenerator.createAnnotations(connection.handle.annotations);
     const args = [handle, mode, type, annotations];
     if (connection.spec.expression) {

--- a/src/tools/schema2kotlin.ts
+++ b/src/tools/schema2kotlin.ts
@@ -158,7 +158,7 @@ ${imports.join('\n')}
 
   private async handleSpec(handleName: string, connection: HandleConnectionSpec, nodes: SchemaNode[]): Promise<string> {
     const mode = this.handleMode(connection);
-    const type = await generateConnectionSpecType(connection, nodes);
+    const type = await generateConnectionSpecType(connection, nodes, {namespace: this.namespace});
     // Using full names of entities, as these are aliases available outside the particle scope.
     const entityNames = SchemaNode.topLevelNodes(connection, nodes).map(node => node.fullName(connection));
     return ktUtils.applyFun(

--- a/src/tools/tests/goldens/kotlin-connection-type-generator.cgtest
+++ b/src/tools/tests/goldens/kotlin-connection-type-generator.cgtest
@@ -58,3 +58,31 @@ arcs.core.data.CollectionType(
     )
 )
 [end]
+
+[name]
+does not use fully qualified name when in the same package
+[opts]
+{"namespace": "my.own.namespace"}
+[input]
+meta
+  namespace: my.own.namespace
+
+particle Module
+  data: reads Thing {name: Text}
+[results]
+arcs.core.data.SingletonType(arcs.core.data.EntityType(Module_Data.SCHEMA))
+[end]
+
+[name]
+uses fully qualified name when in different package
+[opts]
+{"namespace": "my.own.namespace"}
+[input]
+meta
+  namespace: foo.bar.baz
+
+particle Module
+  data: reads Thing {name: Text}
+[results]
+arcs.core.data.SingletonType(arcs.core.data.EntityType(foo.bar.baz.Module_Data.SCHEMA))
+[end]

--- a/src/tools/tests/kotlin-codegen-test-suite.ts
+++ b/src/tools/tests/kotlin-codegen-test-suite.ts
@@ -98,10 +98,10 @@ export const testSuite: CodegenUnitTest[] = [
         'kotlin-connection-type-generator.cgtest'
       );
     }
-    async computeFromManifest({particles}) {
+    async computeFromManifest({particles}, opts) {
       const schemaGraph = new SchemaGraph(particles[0]);
       const [connection] = particles[0].handleConnections;
-      return generateConnectionSpecType(connection, schemaGraph.nodes);
+      return generateConnectionSpecType(connection, schemaGraph.nodes, opts);
     }
   }(),
   new class extends ManifestCodegenUnitTest {


### PR DESCRIPTION
Fixes some or all of b/162462086, i.e. allows building Plans with particles from different Kotlin package names.