### PR TITLE
Improve readability of .cgtest files with better separators

### DIFF
--- a/src/tools/tests/codegen-unit-tests-runner-test.ts
+++ b/src/tools/tests/codegen-unit-tests-runner-test.ts
@@ -24,6 +24,7 @@ for (const unit of testSuite) {
       it(test.name, async () => {
         assert.deepEqual(await runCompute(unit, test), test.results);
         if (test.require) {
+          // "results" is exposed for the eval'ed require expression.
           const results = test.results;
           test.require.split('\n').forEach(requireCase => assert.isTrue(eval(requireCase)));
         }

--- a/src/tools/tests/goldens/kotlin-connection-type-generator.cgtest
+++ b/src/tools/tests/goldens/kotlin-connection-type-generator.cgtest
@@ -1,88 +1,88 @@
-[header]
+-----[header]-----
 Kotlin Connection Type Generation
 
 Expectations can be updated with:
 $ ./tools/sigh updateCodegenUnitTests
-[end_header]
+-----[end_header]-----
 
-[name]
+-----[name]-----
 generates type for singleton entity
-[input]
+-----[input]-----
 particle Module
   data: reads Thing {name: Text}
-[results]
+-----[results]-----
 arcs.core.data.SingletonType(arcs.core.data.EntityType(Module_Data.SCHEMA))
-[end]
+-----[end]-----
 
-[name]
+-----[name]-----
 generates type for singleton reference
-[input]
+-----[input]-----
 particle Module
   data: reads &Thing {name: Text}
-[results]
+-----[results]-----
 arcs.core.data.SingletonType(
     arcs.core.data.ReferenceType(arcs.core.data.EntityType(Module_Data.SCHEMA))
 )
-[end]
+-----[end]-----
 
-[name]
+-----[name]-----
 generates type for collection of entities
-[input]
+-----[input]-----
 particle Module
   data: reads [Thing {name: Text}]
-[results]
+-----[results]-----
 arcs.core.data.CollectionType(arcs.core.data.EntityType(Module_Data.SCHEMA))
-[end]
+-----[end]-----
 
-[name]
+-----[name]-----
 generates type for collection of references
-[input]
+-----[input]-----
 particle Module
   data: reads [&Thing {name: Text}]
-[results]
+-----[results]-----
 arcs.core.data.CollectionType(
     arcs.core.data.ReferenceType(arcs.core.data.EntityType(Module_Data.SCHEMA))
 )
-[end]
+-----[end]-----
 
-[name]
+-----[name]-----
 generates type for collection of tuples
-[input]
+-----[input]-----
 particle Module
   data: reads [(&Thing {name: Text}, &Other {age: Number})]
-[results]
+-----[results]-----
 arcs.core.data.CollectionType(
     arcs.core.data.TupleType.of(
         arcs.core.data.ReferenceType(arcs.core.data.EntityType(Module_Data_0.SCHEMA)),
         arcs.core.data.ReferenceType(arcs.core.data.EntityType(Module_Data_1.SCHEMA))
     )
 )
-[end]
+-----[end]-----
 
-[name]
+-----[name]-----
 does not use fully qualified name when in the same package
-[opts]
-{"namespace": "my.own.namespace"}
-[input]
+-----[opts]-----
+{"namespace":"my.own.namespace"}
+-----[input]-----
 meta
   namespace: my.own.namespace
 
 particle Module
   data: reads Thing {name: Text}
-[results]
+-----[results]-----
 arcs.core.data.SingletonType(arcs.core.data.EntityType(Module_Data.SCHEMA))
-[end]
+-----[end]-----
 
-[name]
+-----[name]-----
 uses fully qualified name when in different package
-[opts]
-{"namespace": "my.own.namespace"}
-[input]
+-----[opts]-----
+{"namespace":"my.own.namespace"}
+-----[input]-----
 meta
   namespace: foo.bar.baz
 
 particle Module
   data: reads Thing {name: Text}
-[results]
+-----[results]-----
 arcs.core.data.SingletonType(arcs.core.data.EntityType(foo.bar.baz.Module_Data.SCHEMA))
-[end]
+-----[end]-----

--- a/src/tools/tests/goldens/kotlin-entity-class.cgtest
+++ b/src/tools/tests/goldens/kotlin-entity-class.cgtest
@@ -1,16 +1,16 @@
-[header]
+-----[header]-----
 Kotlin Entity Class Generation
 
 Expectations can be updated with:
 $ ./tools/sigh updateCodegenUnitTests
-[end_header]
+-----[end_header]-----
 
-[name]
+-----[name]-----
 generates entity with a public constructor
-[input]
+-----[input]-----
 particle T
   h1: reads Thing {num: Number}
-[results]
+-----[results]-----
 
     @Suppress("UNCHECKED_CAST")
     class Thing(
@@ -70,16 +70,16 @@ particle T
             }
         }
     }
-[end]
+-----[end]-----
 
-[name]
+-----[name]-----
 generates entity for WASM
-[opts]
+-----[opts]-----
 {"wasm":true}
-[input]
+-----[input]-----
 particle T
   h1: reads Thing {num: Number}
-[results]
+-----[results]-----
 
     @Suppress("UNCHECKED_CAST")
     class Thing(num: Double = 0.0) : WasmEntity {
@@ -150,14 +150,14 @@ particle T
             }
         }
     }
-[end]
+-----[end]-----
 
-[name]
+-----[name]-----
 generates variable entity with private constructor
-[input]
+-----[input]-----
 particle T
   h1: reads ~a with {num: Number}
-[results]
+-----[results]-----
 
     @Suppress("UNCHECKED_CAST")
     class T_H1 private constructor(
@@ -225,4 +225,4 @@ particle T
             }
         }
     }
-[end]
+-----[end]-----

--- a/src/tools/tests/goldens/kotlin-entity-fields.cgtest
+++ b/src/tools/tests/goldens/kotlin-entity-fields.cgtest
@@ -1,16 +1,16 @@
-[header]
+-----[header]-----
 Kotlin Entity Fields Generation
 
 Expectations can be updated with:
 $ ./tools/sigh updateCodegenUnitTests
-[end_header]
+-----[end_header]-----
 
-[name]
+-----[name]-----
 generates fields for entity when available
-[input]
+-----[input]-----
 particle T
   h1: reads Thing {num: Number}
-[results]
+-----[results]-----
 
         var num: Double
             get() = super.getSingletonValue("num") as Double? ?: 0.0
@@ -20,14 +20,14 @@ particle T
             this.num = num
         }
         
-[end]
+-----[end]-----
 
-[name]
+-----[name]-----
 generates field for a list of primitives
-[input]
+-----[input]-----
 particle T
   h1: reads Thing {num: List<Number>}
-[results]
+-----[results]-----
 
         var num: List<Double>
             get() = super.getSingletonValue("num") as List<Double>? ?: emptyList()
@@ -37,16 +37,16 @@ particle T
             this.num = num
         }
         
-[end]
+-----[end]-----
 
-[name]
+-----[name]-----
 generates field for a reference
-[opts]
+-----[opts]-----
 {"assertedSchema":"Thing"}
-[input]
+-----[input]-----
 particle T
   h1: reads Thing {other: &Other {name: Text}}
-[results]
+-----[results]-----
 
         var other: arcs.sdk.Reference<Other>?
             get() = super.getSingletonValue("other") as arcs.sdk.Reference<Other>?
@@ -56,16 +56,16 @@ particle T
             this.other = other
         }
         
-[end]
+-----[end]-----
 
-[name]
+-----[name]-----
 generates field for a list of references
-[opts]
+-----[opts]-----
 {"assertedSchema":"Thing"}
-[input]
+-----[input]-----
 particle T
   h1: reads Thing {other: List<&Other {name: Text}>}
-[results]
+-----[results]-----
 
         var other: List<arcs.sdk.Reference<Other>>
             get() = super.getSingletonValue("other") as List<arcs.sdk.Reference<Other>>? ?: emptyList()
@@ -75,16 +75,16 @@ particle T
             this.other = other
         }
         
-[end]
+-----[end]-----
 
-[name]
+-----[name]-----
 generates an entityId property with Wasm
-[opts]
+-----[opts]-----
 {"wasm":true}
-[input]
+-----[input]-----
 particle T
   h1: reads Thing {num: Number}
-[results]
+-----[results]-----
 
         var num = num
             get() = field
@@ -93,4 +93,4 @@ particle T
             }
         
         override var entityId = ""
-[end]
+-----[end]-----

--- a/src/tools/tests/goldens/kotlin-handle-interface-types.cgtest
+++ b/src/tools/tests/goldens/kotlin-handle-interface-types.cgtest
@@ -1,170 +1,170 @@
-[header]
+-----[header]-----
 Kotlin Handle Interface Types
 
 Expectations can be updated with:
 $ ./tools/sigh updateCodegenUnitTests
-[end_header]
+-----[end_header]-----
 
-[name]
+-----[name]-----
 read singleton entity
-[input]
+-----[input]-----
 particle P
   h: reads Thing {name: Text}
-[results]
+-----[results]-----
 arcs.sdk.ReadSingletonHandle<Thing>
-[end]
+-----[end]-----
 
-[name]
+-----[name]-----
 write singleton entity
-[input]
+-----[input]-----
 particle P
   h: writes Thing {name: Text}
-[results]
+-----[results]-----
 arcs.sdk.WriteSingletonHandle<Thing>
-[end]
+-----[end]-----
 
-[name]
+-----[name]-----
 read write singleton entity
-[input]
+-----[input]-----
 particle P
   h: reads writes Thing {name: Text}
-[results]
+-----[results]-----
 arcs.sdk.ReadWriteSingletonHandle<Thing>
-[end]
+-----[end]-----
 
-[name]
+-----[name]-----
 read write anonymous entity
-[input]
+-----[input]-----
 particle P
   h: reads writes * {name: Text}
-[results]
+-----[results]-----
 arcs.sdk.ReadWriteSingletonHandle<P_H>
-[end]
+-----[end]-----
 
-[name]
+-----[name]-----
 read collection of entities
-[input]
+-----[input]-----
 particle P
   h: reads [Thing {name: Text}]
-[results]
+-----[results]-----
 arcs.sdk.ReadCollectionHandle<Thing>
-[end]
+-----[end]-----
 
-[name]
+-----[name]-----
 write collection of entities
-[input]
+-----[input]-----
 particle P
   h: writes [Thing {name: Text}]
-[results]
+-----[results]-----
 arcs.sdk.WriteCollectionHandle<Thing>
-[end]
+-----[end]-----
 
-[name]
+-----[name]-----
 read write collection of entities
-[input]
+-----[input]-----
 particle P
   h: reads writes [Thing {name: Text}]
-[results]
+-----[results]-----
 arcs.sdk.ReadWriteCollectionHandle<Thing>
-[end]
+-----[end]-----
 
-[name]
+-----[name]-----
 read collection of entities and query by string
-[input]
+-----[input]-----
 particle P
   h: reads [Thing {name: Text} [name == ?]]
-[results]
+-----[results]-----
 arcs.sdk.ReadQueryCollectionHandle<Thing, String>
-[end]
+-----[end]-----
 
-[name]
+-----[name]-----
 read write collection of entities and query by number
-[input]
+-----[input]-----
 particle P
   h: reads writes [Thing {age: Number} [age > ?]]
-[results]
+-----[results]-----
 arcs.sdk.ReadWriteQueryCollectionHandle<Thing, Double>
-[end]
+-----[end]-----
 
-[name]
+-----[name]-----
 read reference singleton
-[input]
+-----[input]-----
 particle P
   h: reads &Thing {name: Text}
-[results]
+-----[results]-----
 arcs.sdk.ReadSingletonHandle<arcs.sdk.Reference<Thing>>
-[end]
+-----[end]-----
 
-[name]
+-----[name]-----
 write reference singleton
-[input]
+-----[input]-----
 particle P
   h: writes &Thing {name: Text}
-[results]
+-----[results]-----
 arcs.sdk.WriteSingletonHandle<arcs.sdk.Reference<Thing>>
-[end]
+-----[end]-----
 
-[name]
+-----[name]-----
 read collection of references
-[input]
+-----[input]-----
 particle P
   h: reads [&Thing {name: Text}]
-[results]
+-----[results]-----
 arcs.sdk.ReadCollectionHandle<arcs.sdk.Reference<Thing>>
-[end]
+-----[end]-----
 
-[name]
+-----[name]-----
 write collection of references
-[input]
+-----[input]-----
 particle P
   h: writes [&Thing {name: Text}]
-[results]
+-----[results]-----
 arcs.sdk.WriteCollectionHandle<arcs.sdk.Reference<Thing>>
-[end]
+-----[end]-----
 
-[name]
+-----[name]-----
 read tuple of 2 references
-[input]
+-----[input]-----
 particle P
   h: reads (&Foo {name: Text}, &Bar {age: Number})
-[results]
+-----[results]-----
 arcs.sdk.ReadSingletonHandle<arcs.core.entity.Tuple2<arcs.sdk.Reference<Foo>, arcs.sdk.Reference<Bar>>>
-[end]
+-----[end]-----
 
-[name]
+-----[name]-----
 write collection of tuples of 3 references
-[input]
+-----[input]-----
 particle P
   h: writes [(&Foo {name: Text}, &Bar {age: Number}, &Baz {isThisIt: Boolean})]
-[results]
+-----[results]-----
 arcs.sdk.WriteCollectionHandle<
     arcs.core.entity.Tuple3<arcs.sdk.Reference<Foo>, arcs.sdk.Reference<Bar>, arcs.sdk.Reference<Baz>>
 >
-[end]
+-----[end]-----
 
-[name]
+-----[name]-----
 read singleton variable entity
-[input]
+-----[input]-----
 particle T
   h: reads ~a with {name: Text}
-[results]
+-----[results]-----
 arcs.sdk.ReadSingletonHandle<T_H>
-[end]
+-----[end]-----
 
-[name]
+-----[name]-----
 write singleton variable entity
-[input]
+-----[input]-----
 particle T
   h: writes ~a with {name: Text}
-[results]
+-----[results]-----
 arcs.sdk.WriteSingletonHandle<T_H>
-[end]
+-----[end]-----
 
-[name]
+-----[name]-----
 read write singleton unconstrained variable entity
-[input]
+-----[input]-----
 particle T
   h: reads writes ~a
-[results]
+-----[results]-----
 arcs.sdk.ReadWriteSingletonHandle<T_H>
-[end]
+-----[end]-----

--- a/src/tools/tests/goldens/kotlin-handles-class-declarations.cgtest
+++ b/src/tools/tests/goldens/kotlin-handles-class-declarations.cgtest
@@ -1,31 +1,31 @@
-[header]
+-----[header]-----
 Kotlin Handles Class Declarations
 
 Expectations can be updated with:
 $ ./tools/sigh updateCodegenUnitTests
-[end_header]
+-----[end_header]-----
 
-[name]
+-----[name]-----
 single read handle
-[input]
+-----[input]-----
 particle P
   h1: reads Person {name: Text}
-[results]
+-----[results]-----
 class Handles : arcs.sdk.HandleHolderBase(
         "P",
         mapOf("h1" to setOf(Person))
     ) {
         val h1: arcs.sdk.ReadSingletonHandle<Person> by handles
     }
-[end]
+-----[end]-----
 
-[name]
+-----[name]-----
 conflicting schema names
-[input]
+-----[input]-----
 particle P
   h1: reads Person {name: Text}
   h2: reads Person {age: Number}
-[results]
+-----[results]-----
 class Handles : arcs.sdk.HandleHolderBase(
         "P",
         mapOf("h1" to setOf(P_H1), "h2" to setOf(P_H2))
@@ -33,16 +33,16 @@ class Handles : arcs.sdk.HandleHolderBase(
         val h1: arcs.sdk.ReadSingletonHandle<P_H1> by handles
         val h2: arcs.sdk.ReadSingletonHandle<P_H2> by handles
     }
-[end]
+-----[end]-----
 
-[name]
+-----[name]-----
 read, write and query handles
-[input]
+-----[input]-----
 particle P
   h1: reads Person {name: Text}
   h2: writes Person {name: Text}
   h3: reads [Person {name: Text} [name == ?]]
-[results]
+-----[results]-----
 class Handles : arcs.sdk.HandleHolderBase(
         "P",
         mapOf("h1" to setOf(P_H1), "h2" to setOf(P_H2), "h3" to setOf(P_H3))
@@ -51,11 +51,11 @@ class Handles : arcs.sdk.HandleHolderBase(
         val h2: arcs.sdk.WriteSingletonHandle<P_H2> by handles
         val h3: arcs.sdk.ReadQueryCollectionHandle<P_H3, String> by handles
     }
-[end]
+-----[end]-----
 
-[name]
+-----[name]-----
 handle with references
-[input]
+-----[input]-----
 particle P
   h1: reads Person {
     name: Text,
@@ -67,25 +67,25 @@ particle P
       }
     }
   }
-[results]
+-----[results]-----
 class Handles : arcs.sdk.HandleHolderBase(
         "P",
         mapOf("h1" to setOf(Person))
     ) {
         val h1: arcs.sdk.ReadSingletonHandle<Person> by handles
     }
-[end]
+-----[end]-----
 
-[name]
+-----[name]-----
 handle with a tuple
-[input]
+-----[input]-----
 particle P
   h1: reads (
     &Person {name: Text},
     &Accommodation {squareFootage: Number},
     &Address {streetAddress: Text, postCode: Text}
   )
-[results]
+-----[results]-----
 class Handles : arcs.sdk.HandleHolderBase(
         "P",
         mapOf("h1" to setOf(Person, Accommodation, Address))
@@ -94,16 +94,16 @@ class Handles : arcs.sdk.HandleHolderBase(
     arcs.core.entity.Tuple3<arcs.sdk.Reference<Person>, arcs.sdk.Reference<Accommodation>, arcs.sdk.Reference<Address>>
 > by handles
     }
-[end]
+-----[end]-----
 
-[name]
+-----[name]-----
 progressively constrained variable handles
-[input]
+-----[input]-----
 particle T
   h1: reads ~a
   h2: writes ~a with {amt: Number}
   h3: reads writes ~a with {name: Text, age: Number}
-[results]
+-----[results]-----
 class Handles : arcs.sdk.HandleHolderBase(
         "T",
         mapOf("h1" to setOf(T_H1), "h2" to setOf(T_H2), "h3" to setOf(T_H3))
@@ -112,4 +112,4 @@ class Handles : arcs.sdk.HandleHolderBase(
         val h2: arcs.sdk.WriteSingletonHandle<T_H2> by handles
         val h3: arcs.sdk.ReadWriteSingletonHandle<T_H3> by handles
     }
-[end]
+-----[end]-----

--- a/src/tools/tests/goldens/kotlin-refinement-generator.cgtest
+++ b/src/tools/tests/goldens/kotlin-refinement-generator.cgtest
@@ -1,69 +1,69 @@
-[header]
+-----[header]-----
 Kotlin Refinement Generator
 
 Expectations can be updated with:
 $ ./tools/sigh updateCodegenUnitTests
-[end_header]
+-----[end_header]-----
 
-[name]
+-----[name]-----
 creates queries from refinement expressions involving math expressions
-[input]
+-----[input]-----
 particle Foo
   input: reads Something {a: Number [ a > 3 and a != 100 ], b: Number [b > 20 and b < 100] } [a + b/3 > 100]
-[results]
+-----[results]-----
 (300.asExpr() lt (CurrentScope<Number>(mapOf())["b"] + (CurrentScope<Number>(mapOf())["a"] * 3.asExpr()))) and ((CurrentScope<Number>(mapOf())["a"] gt 3.asExpr()) and (CurrentScope<Number>(mapOf())["a"] neq 100.asExpr())) and ((CurrentScope<Number>(mapOf())["b"] gt 20.asExpr()) and (CurrentScope<Number>(mapOf())["b"] lt 100.asExpr()))
-[end]
+-----[end]-----
 
-[name]
+-----[name]-----
 creates queries from refinement expressions involving boolean expressions
-[input]
+-----[input]-----
 particle Foo
   input: reads Something {uuid: Text, value: Number} [uuid == 'test-uuid']
-[results]
+-----[results]-----
 (CurrentScope<String>(mapOf())["uuid"] eq "test-uuid".asExpr())
-[end]
+-----[end]-----
 
-[name]
+-----[name]-----
 creates queries from refinement expressions involving text expressions
-[input]
+-----[input]-----
 particle Foo
   input: reads Something {a: Number [ a > 3 and a != 100 ], b: Number [b > 20 and b < 100] } [a + b/3 > 100]
-[results]
+-----[results]-----
 (300.asExpr() lt (CurrentScope<Number>(mapOf())["b"] + (CurrentScope<Number>(mapOf())["a"] * 3.asExpr()))) and ((CurrentScope<Number>(mapOf())["a"] gt 3.asExpr()) and (CurrentScope<Number>(mapOf())["a"] neq 100.asExpr())) and ((CurrentScope<Number>(mapOf())["b"] gt 20.asExpr()) and (CurrentScope<Number>(mapOf())["b"] lt 100.asExpr()))
-[end]
+-----[end]-----
 
-[name]
+-----[name]-----
 creates queries where field refinement is null
-[input]
+-----[input]-----
 particle Foo
   input: reads Something {a: Boolean, b: Boolean} [a and b]
-[results]
+-----[results]-----
 (CurrentScope<Boolean>(mapOf())["b"] and CurrentScope<Boolean>(mapOf())["a"])
-[end]
+-----[end]-----
 
-[name]
+-----[name]-----
 creates queries where schema refinement is null
-[input]
+-----[input]-----
 particle Foo
   input: reads Something {a: Boolean [not a], b: Boolean [b]}
-[results]
+-----[results]-----
 (!CurrentScope<Boolean>(mapOf())["a"]) and CurrentScope<Boolean>(mapOf())["b"]
-[end]
+-----[end]-----
 
-[name]
+-----[name]-----
 creates queries where there is no refinement
-[input]
+-----[input]-----
 particle Foo
   input: reads Something {a: Boolean, b: Boolean}
-[results]
+-----[results]-----
 true.asExpr()
-[end]
+-----[end]-----
 
-[name]
+-----[name]-----
 escapes text in queries from refinement expressions
-[input]
+-----[input]-----
 particle Foo
   input: reads Something {str: Text} [str == '\t\b\n\r\'\"$']
-[results]
+-----[results]-----
 (CurrentScope<String>(mapOf())["str"] eq "\t\b\n\r\'\"\$".asExpr())
-[end]
+-----[end]-----

--- a/src/tools/tests/goldens/kotlin-schema-aliases.cgtest
+++ b/src/tools/tests/goldens/kotlin-schema-aliases.cgtest
@@ -1,35 +1,35 @@
-[header]
+-----[header]-----
 Kotlin Schema Aliases
 
 Expectations can be updated with:
 $ ./tools/sigh updateCodegenUnitTests
-[end_header]
+-----[end_header]-----
 
-[name]
+-----[name]-----
 single entity
-[input]
+-----[input]-----
 particle P
   h1: reads Person {name: Text}
-[results]
+-----[results]-----
 typealias P_H1 = AbstractP.Person
-[end]
+-----[end]-----
 
-[name]
+-----[name]-----
 multiple connections with the same schema
-[input]
+-----[input]-----
 particle P
   h1: reads Person {name: Text}
   h2: reads [Person {name: Text}]
   h3: reads [&Person {name: Text}]
-[results:per-line]
+-----[results:per-line]-----
 typealias P_H1 = AbstractP.Person
 typealias P_H2 = AbstractP.Person
 typealias P_H3 = AbstractP.Person
-[end]
+-----[end]-----
 
-[name]
+-----[name]-----
 handle with references
-[input]
+-----[input]-----
 particle P
   h1: reads Person {
     name: Text,
@@ -41,62 +41,62 @@ particle P
       }
     }
   }
-[results:per-line]
+-----[results:per-line]-----
 typealias P_H1 = AbstractP.Person
 typealias P_H1_Home = AbstractP.Accommodation
 typealias P_H1_Home_Address = AbstractP.Address
-[end]
+-----[end]-----
 
-[name]
+-----[name]-----
 handle with a tuple
-[input]
+-----[input]-----
 particle P
   h1: reads (
     &Person {name: Text},
     &Accommodation {squareFootage: Number},
     &Address {streetAddress: Text, postCode: Text}
   )
-[results:per-line]
+-----[results:per-line]-----
 typealias P_H1_0 = AbstractP.Person
 typealias P_H1_1 = AbstractP.Accommodation
 typealias P_H1_2 = AbstractP.Address
-[end]
+-----[end]-----
 
-[name]
+-----[name]-----
 unconstrained variables
-[input]
+-----[input]-----
 particle T
   h1: reads ~a
   h2: writes ~a
-[results:per-line]
+-----[results:per-line]-----
 typealias T_H1 = AbstractT.TInternal1
 typealias T_H2 = AbstractT.TInternal1
-[end]
+-----[end]-----
 
-[name]
+-----[name]-----
 variable constrained at multiple connections
-[input]
+-----[input]-----
 particle T
   h1: reads ~a
   h2: writes ~a with {amt: Number}
   h3: reads writes ~a with {name: Text, age: Number}
-[results:per-line]
+-----[results:per-line]-----
 typealias T_H1 = AbstractT.TInternal1
 typealias T_H2 = AbstractT.TInternal1
 typealias T_H3 = AbstractT.TInternal1
-[end]
+-----[end]-----
 
-[name]
+-----[name]-----
 different internal entities for distinct aliases
-[input]
+-----[input]-----
 particle T
   h1: reads ~a
   h2: writes &~a with {x: Number}
   h3: reads ~b
   h4: reads [~b with {a: Text}]
-[results:per-line]
+-----[results:per-line]-----
 typealias T_H1 = AbstractT.TInternal1
 typealias T_H2 = AbstractT.TInternal1
 typealias T_H3 = AbstractT.TInternal2
 typealias T_H4 = AbstractT.TInternal2
-[end]
+-----[end]-----

--- a/src/tools/tests/goldens/kotlin-schema-fields.cgtest
+++ b/src/tools/tests/goldens/kotlin-schema-fields.cgtest
@@ -1,13 +1,13 @@
-[header]
+-----[header]-----
 Kotlin Schema Fields
 
 Expectations can be updated with:
 $ ./tools/sigh updateCodegenUnitTests
-[end_header]
+-----[end_header]-----
 
-[name]
+-----[name]-----
 generates Kotlin Types
-[input]
+-----[input]-----
 particle Foo
   thing: reads Thing {
     field01: Number,
@@ -31,7 +31,7 @@ particle Foo
     field19: [&Ref2 {name: Text}],
     field20: List<&Ref3 {name: Text}>,
   }
-[results:per-line]
+-----[results:per-line]-----
 Double
 String
 String
@@ -52,15 +52,15 @@ List<Other3>
 arcs.sdk.Reference<Ref1>?
 Set<arcs.sdk.Reference<Ref2>>
 List<arcs.sdk.Reference<Ref3>>
-[end]
+-----[end]-----
 
-[name]
+-----[name]-----
 generates Kotlin Types for reference to external schema
-[input]
+-----[input]-----
 schema Ref
   name: Text
 particle Foo
   num: reads Thing {ref: &Ref}
-[results]
+-----[results]-----
 arcs.sdk.Reference<Ref>?
-[end]
+-----[end]-----

--- a/src/tools/tests/goldens/kotlin-schema-generation.cgtest
+++ b/src/tools/tests/goldens/kotlin-schema-generation.cgtest
@@ -1,25 +1,25 @@
-[header]
+-----[header]-----
 Kotlin Schema Generation
 
 Expectations can be updated with:
 $ ./tools/sigh updateCodegenUnitTests
-[end_header]
+-----[end_header]-----
 
-[name]
+-----[name]-----
 generates empty schema
-[input]
+-----[input]-----
 particle P
   h1: reads {}
-[results]
+-----[results]-----
 arcs.core.data.Schema.EMPTY
-[end]
+-----[end]-----
 
-[name]
+-----[name]-----
 generates a schema with multiple names
-[input]
+-----[input]-----
 particle P
   h1: reads Person Friend Parent {}
-[results]
+-----[results]-----
 arcs.core.data.Schema(
     setOf(
     arcs.core.data.SchemaName("Person"),
@@ -34,14 +34,14 @@ arcs.core.data.Schema(
     refinementExpression = true.asExpr(),
     queryExpression = true.asExpr()
 )
-[end]
+-----[end]-----
 
-[name]
+-----[name]-----
 generates a schema with primitive fields
-[input]
+-----[input]-----
 particle P
   h1: reads Person {name: Text, age: Number, friendNames: [Text]}
-[results]
+-----[results]-----
 arcs.core.data.Schema(
     setOf(arcs.core.data.SchemaName("Person")),
     arcs.core.data.SchemaFields(
@@ -55,11 +55,11 @@ arcs.core.data.Schema(
     refinementExpression = true.asExpr(),
     queryExpression = true.asExpr()
 )
-[end]
+-----[end]-----
 
-[name]
+-----[name]-----
 generates a schema with Kotlin types
-[input]
+-----[input]-----
 particle P
   h1: reads Data {
     bt: Byte,
@@ -70,7 +70,7 @@ particle P
     flt: Float,
     dbl: Double,
   }
-[results]
+-----[results]-----
 arcs.core.data.Schema(
     setOf(arcs.core.data.SchemaName("Data")),
     arcs.core.data.SchemaFields(
@@ -89,14 +89,14 @@ arcs.core.data.Schema(
     refinementExpression = true.asExpr(),
     queryExpression = true.asExpr()
 )
-[end]
+-----[end]-----
 
-[name]
+-----[name]-----
 generates a schema with lists of primitive fields
-[input]
+-----[input]-----
 particle P
   h1: reads Person {names: List<Text>, favNumbers: List<Number>}
-[results]
+-----[results]-----
 arcs.core.data.Schema(
     setOf(arcs.core.data.SchemaName("Person")),
     arcs.core.data.SchemaFields(
@@ -110,14 +110,14 @@ arcs.core.data.Schema(
     refinementExpression = true.asExpr(),
     queryExpression = true.asExpr()
 )
-[end]
+-----[end]-----
 
-[name]
+-----[name]-----
 generates schemas for a reference
-[input]
+-----[input]-----
 particle P
   h1: reads Person {address: &Address {streetAddress: Text}}
-[results]
+-----[results]-----
 arcs.core.data.Schema(
     setOf(arcs.core.data.SchemaName("Person")),
     arcs.core.data.SchemaFields(
@@ -130,7 +130,7 @@ arcs.core.data.Schema(
     refinementExpression = true.asExpr(),
     queryExpression = true.asExpr()
 )
-[next]
+-----[next]-----
 arcs.core.data.Schema(
     setOf(arcs.core.data.SchemaName("Address")),
     arcs.core.data.SchemaFields(
@@ -141,14 +141,14 @@ arcs.core.data.Schema(
     refinementExpression = true.asExpr(),
     queryExpression = true.asExpr()
 )
-[end]
+-----[end]-----
 
-[name]
+-----[name]-----
 generates schemas for a collection of references
-[input]
+-----[input]-----
 particle P
   h1: reads Person {address: [&Address {streetAddress: Text}]}
-[results]
+-----[results]-----
 arcs.core.data.Schema(
     setOf(arcs.core.data.SchemaName("Person")),
     arcs.core.data.SchemaFields(
@@ -161,7 +161,7 @@ arcs.core.data.Schema(
     refinementExpression = true.asExpr(),
     queryExpression = true.asExpr()
 )
-[next]
+-----[next]-----
 arcs.core.data.Schema(
     setOf(arcs.core.data.SchemaName("Address")),
     arcs.core.data.SchemaFields(
@@ -172,14 +172,14 @@ arcs.core.data.Schema(
     refinementExpression = true.asExpr(),
     queryExpression = true.asExpr()
 )
-[end]
+-----[end]-----
 
-[name]
+-----[name]-----
 generates schemas for a nested entity
-[input]
+-----[input]-----
 particle P
   h1: reads Person {address: inline Address {streetAddress: Text}}
-[results]
+-----[results]-----
 arcs.core.data.Schema(
     setOf(arcs.core.data.SchemaName("Person")),
     arcs.core.data.SchemaFields(
@@ -192,7 +192,7 @@ arcs.core.data.Schema(
     refinementExpression = true.asExpr(),
     queryExpression = true.asExpr()
 )
-[next]
+-----[next]-----
 arcs.core.data.Schema(
     setOf(arcs.core.data.SchemaName("Address")),
     arcs.core.data.SchemaFields(
@@ -203,13 +203,13 @@ arcs.core.data.Schema(
     refinementExpression = true.asExpr(),
     queryExpression = true.asExpr()
 )
-[require]
+-----[require]-----
 results[0].match(/InlineEntity\("([a-f0-9]+)"\)/)[1] == results[1].match(/\n *"([a-f0-9]+)",\n/m)[1];
-[end]
+-----[end]-----
 
-[name]
+-----[name]-----
 generates schemas for a nested entity referencing an external schema
-[input]
+-----[input]-----
 schema External
   name: Text
 
@@ -217,7 +217,7 @@ particle P
   h1: reads Thing {
     other: inline External
   }
-[results]
+-----[results]-----
 arcs.core.data.Schema(
     setOf(arcs.core.data.SchemaName("Thing")),
     arcs.core.data.SchemaFields(
@@ -230,7 +230,7 @@ arcs.core.data.Schema(
     refinementExpression = true.asExpr(),
     queryExpression = true.asExpr()
 )
-[next]
+-----[next]-----
 arcs.core.data.Schema(
     setOf(arcs.core.data.SchemaName("External")),
     arcs.core.data.SchemaFields(
@@ -241,13 +241,13 @@ arcs.core.data.Schema(
     refinementExpression = true.asExpr(),
     queryExpression = true.asExpr()
 )
-[require]
+-----[require]-----
 results[0].match(/InlineEntity\("([a-f0-9]+)"\)/)[1] == results[1].match(/\n *"([a-f0-9]+)",\n/m)[1];
-[end]
+-----[end]-----
 
-[name]
+-----[name]-----
 generates schemas for a double nested entity
-[input]
+-----[input]-----
 particle P
   h1: reads Person {
     address: inline Address {
@@ -255,7 +255,7 @@ particle P
       city: inline City {name: Text}
     }
   }
-[results]
+-----[results]-----
 arcs.core.data.Schema(
     setOf(arcs.core.data.SchemaName("Person")),
     arcs.core.data.SchemaFields(
@@ -268,7 +268,7 @@ arcs.core.data.Schema(
     refinementExpression = true.asExpr(),
     queryExpression = true.asExpr()
 )
-[next]
+-----[next]-----
 arcs.core.data.Schema(
     setOf(arcs.core.data.SchemaName("Address")),
     arcs.core.data.SchemaFields(
@@ -282,7 +282,7 @@ arcs.core.data.Schema(
     refinementExpression = true.asExpr(),
     queryExpression = true.asExpr()
 )
-[next]
+-----[next]-----
 arcs.core.data.Schema(
     setOf(arcs.core.data.SchemaName("City")),
     arcs.core.data.SchemaFields(
@@ -293,17 +293,17 @@ arcs.core.data.Schema(
     refinementExpression = true.asExpr(),
     queryExpression = true.asExpr()
 )
-[require]
+-----[require]-----
 results[0].match(/InlineEntity\("([a-f0-9]+)"\)/)[1] == results[1].match(/\n *"([a-f0-9]+)",\n/m)[1];
 results[1].match(/InlineEntity\("([a-f0-9]+)"\)/)[1] == results[2].match(/\n *"([a-f0-9]+)",\n/m)[1];
-[end]
+-----[end]-----
 
-[name]
+-----[name]-----
 generates a schema with a refinement
-[input]
+-----[input]-----
 particle P
   h1: reads Person {name: Text, age: Number} [age >= 21]
-[results]
+-----[results]-----
 arcs.core.data.Schema(
     setOf(arcs.core.data.SchemaName("Person")),
     arcs.core.data.SchemaFields(
@@ -317,14 +317,14 @@ arcs.core.data.Schema(
     refinementExpression =         ((CurrentScope<Number>(mapOf())["age"] gt 21.asExpr()) or (CurrentScope<Number>(mapOf())["age"] eq 21.asExpr())),
     queryExpression = true.asExpr()
 )
-[end]
+-----[end]-----
 
-[name]
+-----[name]-----
 generates a schema with a query
-[input]
+-----[input]-----
 particle P
   h1: reads Person {name: Text, age: Number} [age >= ?]
-[results]
+-----[results]-----
 arcs.core.data.Schema(
     setOf(arcs.core.data.SchemaName("Person")),
     arcs.core.data.SchemaFields(
@@ -338,14 +338,14 @@ arcs.core.data.Schema(
     refinementExpression = true.asExpr(),
     queryExpression =         ((CurrentScope<Number>(mapOf())["age"] gt query<Number>("queryArgument")) or (CurrentScope<Number>(mapOf())["age"] eq query<Number>("queryArgument")))
 )
-[end]
+-----[end]-----
 
-[name]
+-----[name]-----
 generates schemas for a tuple connection
-[input]
+-----[input]-----
 particle P
   h1: reads (&Person {name: Text}, &Product {sku: Text})
-[results]
+-----[results]-----
 arcs.core.data.Schema(
     setOf(arcs.core.data.SchemaName("Person")),
     arcs.core.data.SchemaFields(
@@ -356,7 +356,7 @@ arcs.core.data.Schema(
     refinementExpression = true.asExpr(),
     queryExpression = true.asExpr()
 )
-[next]
+-----[next]-----
 arcs.core.data.Schema(
     setOf(arcs.core.data.SchemaName("Product")),
     arcs.core.data.SchemaFields(
@@ -367,4 +367,4 @@ arcs.core.data.Schema(
     refinementExpression = true.asExpr(),
     queryExpression = true.asExpr()
 )
-[end]
+-----[end]-----

--- a/src/tools/tests/goldens/kotlin-test-harness.cgtest
+++ b/src/tools/tests/goldens/kotlin-test-harness.cgtest
@@ -1,17 +1,17 @@
-[header]
+-----[header]-----
 Kotlin Test Harness
 
 Expectations can be updated with:
 $ ./tools/sigh updateCodegenUnitTests
-[end_header]
+-----[end_header]-----
 
-[name]
+-----[name]-----
 exposes harness handles as a read write handle regardless of particle spec direction
-[input]
+-----[input]-----
 particle P
   h1: reads Person {name: Text}
   h2: writes Address {streetAddress: Text}
-[results]
+-----[results]-----
 
 @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
 class PTestHarness<P : AbstractP>(
@@ -34,18 +34,18 @@ class PTestHarness<P : AbstractP>(
     val h2: arcs.sdk.ReadWriteSingletonHandle<P_H2> by handleMap
 }
 
-[end]
+-----[end]-----
 
-[name]
+-----[name]-----
 specifies handle type correctly - singleton, collection, entity, reference, tuples
-[input]
+-----[input]-----
 particle P
   singletonEntity: reads Person {name: Text}
   singletonReference: writes &Person {name: Text}
   collectionEntity: writes [Person {name: Text}]
   collectionReference: reads [&Person {name: Text}]
   collectionTuples: reads writes [(&Product {name: Text}, &Manufacturer {name: Text})]
-[results]
+-----[results]-----
 
 @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
 class PTestHarness<P : AbstractP>(
@@ -100,4 +100,4 @@ class PTestHarness<P : AbstractP>(
 > by handleMap
 }
 
-[end]
+-----[end]-----

--- a/src/tools/tests/goldens/kotlin-type-generator.cgtest
+++ b/src/tools/tests/goldens/kotlin-type-generator.cgtest
@@ -1,16 +1,16 @@
-[header]
+-----[header]-----
 Kotlin Type Generation
 
 Expectations can be updated with:
 $ ./tools/sigh updateCodegenUnitTests
-[end_header]
+-----[end_header]-----
 
-[name]
+-----[name]-----
 generates an entity type
-[input]
+-----[input]-----
 particle Module
   data: reads {count: Number}
-[results]
+-----[results]-----
 arcs.core.data.EntityType(
     arcs.core.data.Schema(
         setOf(),
@@ -23,14 +23,14 @@ arcs.core.data.EntityType(
         queryExpression = true.asExpr()
     )
 )
-[end]
+-----[end]-----
 
-[name]
+-----[name]-----
 generates a collection of entities
-[input]
+-----[input]-----
 particle Module
   data: reads [Thing {name: Text}]
-[results]
+-----[results]-----
 arcs.core.data.CollectionType(
     arcs.core.data.EntityType(
         arcs.core.data.Schema(
@@ -45,14 +45,14 @@ arcs.core.data.CollectionType(
         )
     )
 )
-[end]
+-----[end]-----
 
-[name]
+-----[name]-----
 generates a reference type
-[input]
+-----[input]-----
 particle Module
   data: reads &Thing {name: Text}
-[results]
+-----[results]-----
 arcs.core.data.ReferenceType(
     arcs.core.data.EntityType(
         arcs.core.data.Schema(
@@ -67,4 +67,4 @@ arcs.core.data.ReferenceType(
         )
     )
 )
-[end]
+-----[end]-----


### PR DESCRIPTION
Plus some minor improvements:
- comment on the utility of unused variable.
- pass input file + test name as the filename for manifest parsing, to improve debuggability.