### PR TITLE
Register schemas that are encountered when decoding protos.

### DIFF
--- a/java/arcs/core/data/proto/TypeProtoDecoders.kt
+++ b/java/arcs/core/data/proto/TypeProtoDecoders.kt
@@ -17,6 +17,7 @@ import arcs.core.data.EntityType
 import arcs.core.data.FieldType
 import arcs.core.data.PrimitiveType
 import arcs.core.data.ReferenceType
+import arcs.core.data.SchemaRegistry
 import arcs.core.data.SingletonType
 import arcs.core.data.TupleType
 import arcs.core.data.TypeVariable
@@ -67,7 +68,7 @@ fun ListTypeProto.decodeAsFieldType(): FieldType.ListOf {
  */
 fun EntityTypeProto.decodeAsFieldType(): FieldType.InlineEntity {
     require(inline) { "Cannot decode non-inline entities to FieldType.InlineEntity" }
-    return FieldType.InlineEntity(schema.hash)
+    return FieldType.InlineEntity(schema.hash).also { SchemaRegistry.register(schema.decode()) }
 }
 
 /**
@@ -96,7 +97,7 @@ fun TypeProto.decodeAsFieldType(): FieldType = when (dataCase) {
  */
 fun EntityTypeProto.decode(): EntityType {
     require(!inline) { "Cannot decode inline entities to EntityType." }
-    return EntityType(schema.decode())
+    return EntityType(schema.decode()).also { SchemaRegistry.register(it.entitySchema) }
 }
 
 /** Converts a [SingletonTypeProto] protobuf instance into a Kotlin [SingletonType] instance. */

--- a/javatests/arcs/core/data/proto/TypeProtoDecodersTest.kt
+++ b/javatests/arcs/core/data/proto/TypeProtoDecodersTest.kt
@@ -13,6 +13,7 @@ import arcs.core.data.SingletonType
 import arcs.core.data.TupleType
 import arcs.core.data.TypeVariable
 import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.Truth.assertWithMessage
 import com.google.protobuf.TextFormat
 import kotlin.test.assertFailsWith
 import org.junit.After
@@ -80,6 +81,9 @@ class TypeProtoDecodersTest {
             )
         )
         assertThat(type.encode().decode()).isEqualTo(type)
+        assertWithMessage("Schema should have been registered!")
+            .that(SchemaRegistry.getSchema(type.entitySchema.hash))
+            .isEqualTo(type.entitySchema)
 
         val e = assertFailsWith<IllegalArgumentException> { type.encode().decodeAsFieldType() }
         assertThat(e).hasMessageThat().isEqualTo(
@@ -91,6 +95,9 @@ class TypeProtoDecodersTest {
     fun roundTrip_inlineEntityFieldType() {
         val type = FieldType.InlineEntity(DUMMY_ENTITY_HASH)
         assertThat(type.encode().decodeAsFieldType()).isEqualTo(type)
+        assertWithMessage("Schema should have been registered!")
+            .that(SchemaRegistry.getSchema(DUMMY_ENTITY_HASH))
+            .isEqualTo(DUMMY_ENTITY_TYPE.entitySchema)
 
         val e = assertFailsWith<IllegalArgumentException> { type.encode().decode() }
         assertThat(e).hasMessageThat().isEqualTo("Cannot decode inline entities to EntityType.")


### PR DESCRIPTION
This ensures that schemas are available with the  `SchemaRegistry.get()` API, as we only have the schema hash in certain places like `EntityRef` and `InlineEntity`.

A much better solution would be to actually do the registration as part of the construction of the `Schema` instance.