### PR TITLE
DFA: Handle inline entities, lists and tuple fields properly. 

### DIFF
--- a/java/arcs/core/analysis/InformationFlow.kt
+++ b/java/arcs/core/analysis/InformationFlow.kt
@@ -293,8 +293,10 @@ class InformationFlow private constructor(
             // For primitives and references we don't go down to collect access paths.
             FieldType.Tag.Primitive,
             FieldType.Tag.EntityRef -> setOf(prefix)
-            FieldType.Tag.Tuple,
-            FieldType.Tag.List -> setOf(prefix)
+            FieldType.Tag.Tuple -> setOf(prefix)
+            FieldType.Tag.List -> {
+                setOf(prefix) + (this as FieldType.ListOf).primitiveType.accessPathSelectors(prefix)
+            }
             FieldType.Tag.InlineEntity -> {
                 val schema = SchemaRegistry.getSchema((this as FieldType.InlineEntity).schemaHash)
                 setOf(prefix) + schema.accessPathSelectors(prefix)

--- a/java/arcs/core/analysis/InformationFlow.kt
+++ b/java/arcs/core/analysis/InformationFlow.kt
@@ -293,7 +293,17 @@ class InformationFlow private constructor(
             // For primitives and references we don't go down to collect access paths.
             FieldType.Tag.Primitive,
             FieldType.Tag.EntityRef -> setOf(prefix)
-            FieldType.Tag.Tuple -> setOf(prefix)
+            FieldType.Tag.Tuple -> {
+                // Access path selectors of all components.
+                val componentSelectors = (this as FieldType.Tuple).types
+                    .foldIndexed(emptySet<List<AccessPath.Selector>>()) { index, result, cur ->
+                        result + cur.accessPathSelectors(prefix).map {
+                            // Prepend the component selector to the component's access paths.
+                            listOf(getTupleField(index)) + it
+                        }
+                    }
+                setOf(prefix) + componentSelectors
+            }
             FieldType.Tag.List -> {
                 setOf(prefix) + (this as FieldType.ListOf).primitiveType.accessPathSelectors(prefix)
             }

--- a/javatests/arcs/core/analysis/InformationFlowTest.kt
+++ b/javatests/arcs/core/analysis/InformationFlowTest.kt
@@ -114,6 +114,9 @@ class InformationFlowTest {
             "fail-field-entity-direct",
             "fail-field-entity-ref-direct",
             "fail-field-collection-direct",
+            "fail-field-inline-entity-direct",
+            "fail-field-list-direct",
+            "fail-field-tuple-direct",
             "fail-field-claim-propagates",
             "fail-field-claim-propagates-type-variables",
             "fail-field-merge-multiple-paths"
@@ -122,6 +125,9 @@ class InformationFlowTest {
             "ok-field-entity-direct",
             "ok-field-entity-ref-direct",
             "ok-field-collection-direct",
+            "ok-field-inline-entity-direct",
+            "ok-field-list-direct",
+            "ok-field-tuple-direct",
             "ok-field-claim-propagates",
             "ok-field-claim-propagates-type-variables",
             "ok-field-merge-multiple-paths"
@@ -141,9 +147,9 @@ class InformationFlowTest {
         )
         val tests = (
             okTests + failingTests +
-                okFieldTests + failingFieldTests +
-                okCycleTests + failingCycleTests
-            )
+            okFieldTests + failingFieldTests +
+            okCycleTests + failingCycleTests
+        )
         tests.forEach { verifyChecksInTestFile(it) }
     }
 

--- a/javatests/arcs/core/analysis/InformationFlowTest.kt
+++ b/javatests/arcs/core/analysis/InformationFlowTest.kt
@@ -117,6 +117,7 @@ class InformationFlowTest {
             "fail-field-inline-entity-direct",
             "fail-field-list-direct",
             "fail-field-tuple-direct",
+            "fail-field-inline-entity-slicing",
             "fail-field-claim-propagates",
             "fail-field-claim-propagates-type-variables",
             "fail-field-merge-multiple-paths"
@@ -128,6 +129,7 @@ class InformationFlowTest {
             "ok-field-inline-entity-direct",
             "ok-field-list-direct",
             "ok-field-tuple-direct",
+            "ok-field-inline-entity-slicing",
             "ok-field-claim-propagates",
             "ok-field-claim-propagates-type-variables",
             "ok-field-merge-multiple-paths"

--- a/javatests/arcs/core/analysis/InformationFlowTest.kt
+++ b/javatests/arcs/core/analysis/InformationFlowTest.kt
@@ -113,6 +113,7 @@ class InformationFlowTest {
         val failingFieldTests = listOf(
             "fail-field-entity-direct",
             "fail-field-entity-ref-direct",
+            "fail-field-entity-ref-field",
             "fail-field-collection-direct",
             "fail-field-inline-entity-direct",
             "fail-field-list-direct",
@@ -125,6 +126,7 @@ class InformationFlowTest {
         val okFieldTests = listOf(
             "ok-field-entity-direct",
             "ok-field-entity-ref-direct",
+            "ok-field-entity-ref-field",
             "ok-field-collection-direct",
             "ok-field-inline-entity-direct",
             "ok-field-list-direct",

--- a/javatests/arcs/core/analysis/testdata/fail_field_entity_ref_field.arcs
+++ b/javatests/arcs/core/analysis/testdata/fail_field_entity_ref_field.arcs
@@ -1,0 +1,38 @@
+// #Ingress: P1
+// #FAIL: hc:P2.foo is ((trusted or untrusted) or deep)
+// #FAIL: hc:P2.foo.untrusted is (untrusted or deep)
+particle P1
+  foo: writes &Foo {
+    trusted: Text,
+    untrusted: &Bar {
+       c: &Baz {
+         deep: Number,
+         sensitive: Text
+       }
+    }
+  }
+  claim foo.trusted is trusted
+  claim foo.untrusted is untrusted
+  claim foo.untrusted.c.deep is deep
+  claim foo.untrusted.c.sensitive is sensitive
+
+particle P2
+  foo: reads &Foo {
+    trusted: Text,
+    untrusted: &Bar {
+       c: &Baz {
+         deep: Number,
+         sensitive: Text // This should not be accessed.
+       }
+    }
+  }
+  check foo is trusted or is untrusted or is deep
+  check foo.trusted is trusted
+  check foo.untrusted is untrusted or is deep
+  check foo.untrusted.c.deep is deep
+
+recipe R
+  P1
+    foo: writes h
+  P2
+    foo: reads h

--- a/javatests/arcs/core/analysis/testdata/fail_field_inline_entity_direct.arcs
+++ b/javatests/arcs/core/analysis/testdata/fail_field_inline_entity_direct.arcs
@@ -1,0 +1,28 @@
+// #Ingress: P1
+// #FAIL: hc:P2.foo.a.c is untrusted
+// #FAIL: hc:P2.foo is trusted
+// #FAIL: hc:P2.foo.a.d is trusted
+particle P1
+  foo: writes Foo {
+    a: inline Bar {c: Text, d: inline Baz {e: Number} }
+  }
+  claim foo.a.c is trusted
+  claim foo.a.d is trusted
+  claim foo.a.d.e is untrusted
+
+particle P2
+  foo: reads Foo {
+    a: inline Bar {c: Text, d: inline Baz {e: Number} }
+  }
+  check foo.a.c is untrusted
+  // Labels on foo and foo.a.d is a combination of labels
+  // for foo.a.d.e and foo.a.d
+  check foo is trusted
+  check foo.a.d is trusted 
+  check foo.a.d.e is untrusted
+
+recipe R
+  P1
+    foo: writes h
+  P2
+    foo: reads h

--- a/javatests/arcs/core/analysis/testdata/fail_field_inline_entity_slicing.arcs
+++ b/javatests/arcs/core/analysis/testdata/fail_field_inline_entity_slicing.arcs
@@ -1,0 +1,32 @@
+// #Ingress: P1
+// #FAIL: hc:P2.foo is trusted
+particle P1
+  foo: writes FooList {
+    elements: List<inline Foo {
+      ok: Text,
+      notOk: Number,
+      mixed: inline Baz {
+        ok: Text,
+        notOk: Number,
+      }
+    }> 
+  }
+  claim foo.elements.ok is trusted
+  claim foo.elements.notOk is untrusted
+  claim foo.elements.mixed.ok is trusted
+  claim foo.elements.mixed.notOk is untrusted
+
+particle P2
+  foo: reads FooList {
+    elements: List<inline Foo {
+      ok: Text,
+      mixed: inline Baz { notOk: Number }
+    }>
+  }
+  check foo is trusted
+
+recipe R
+  P1
+    foo: writes h
+  P2
+    foo: reads h

--- a/javatests/arcs/core/analysis/testdata/fail_field_list_direct.arcs
+++ b/javatests/arcs/core/analysis/testdata/fail_field_list_direct.arcs
@@ -1,0 +1,29 @@
+// #Ingress: P1
+// #FAIL: hc:P2.foo.elements.c is untrusted
+// #FAIL: hc:P2.foo.elements.d is trusted
+
+schema FooList
+  elements: List<inline Foo {
+    c: Text, 
+    d: inline Baz {e: Number}
+  }>
+
+particle P1
+  foo: writes FooList
+  claim foo.elements.c is trusted
+  claim foo.elements.d is trusted
+  claim foo.elements.d.e is untrusted
+
+particle P2
+  foo: reads FooList
+  check foo.elements.c is untrusted
+  // Label on foo.elements.d is the combination of labels for
+  // foo.elements.d.e and foo.elements.d
+  check foo.elements.d is trusted 
+  check foo.elements.d.e is untrusted
+
+recipe R
+  P1
+    foo: writes h
+  P2
+    foo: reads h

--- a/javatests/arcs/core/analysis/testdata/fail_field_tuple_direct.arcs
+++ b/javatests/arcs/core/analysis/testdata/fail_field_tuple_direct.arcs
@@ -1,0 +1,34 @@
+// #Ingress: P1
+// #FAIL: hc:P2.foo.first.elements.c is untrusted
+// #FAIL: hc:P2.foo.first.elements.d is trusted
+// #FAIL: hc:P2.foo.second.b.e is trusted
+schema FooList
+  elements: List<inline Foo {
+    c: Text,
+    d: inline Baz {e: Number}
+  }>
+
+schema Bar
+  b: inline Baz {e: Number}
+
+particle P1
+  foo: writes (FooList, Bar)
+  claim foo.first.elements.c is trusted
+  claim foo.first.elements.d is trusted
+  claim foo.first.elements.d.e is untrusted
+  claim foo.second.b.e is public
+
+particle P2
+  foo: reads (FooList, Bar)
+  check foo.first.elements.c is untrusted
+  // Label on foo.first.elements.d is the combination of labels for
+  // foo.first.elements.d.e and foo.first.elements.d
+  check foo.first.elements.d is trusted
+  check foo.first.elements.d.e is untrusted
+  check foo.second.b.e is trusted
+
+recipe R
+  P1
+    foo: writes h
+  P2
+    foo: reads h

--- a/javatests/arcs/core/analysis/testdata/ok_field_entity_ref_field.arcs
+++ b/javatests/arcs/core/analysis/testdata/ok_field_entity_ref_field.arcs
@@ -1,0 +1,37 @@
+// #Ingress: P1
+// #OK
+particle P1
+  foo: writes &Foo {
+    trusted: Text,
+    untrusted: &Bar {
+       c: &Baz {
+         deep: Number,
+         sensitive: Text
+       }
+    }
+  }
+  claim foo.trusted is trusted
+  claim foo.untrusted is untrusted
+  claim foo.untrusted.c.deep is deep
+  claim foo.untrusted.c.sensitive is sensitive
+
+particle P2
+  foo: reads &Foo {
+    trusted: Text,
+    untrusted: &Bar {
+       c: &Baz {
+         deep: Number,
+         // sensitive: Text
+       }
+    }
+  }
+  check foo is trusted or is untrusted or is deep
+  check foo.trusted is trusted
+  check foo.untrusted is untrusted or is deep
+  check foo.untrusted.c.deep is deep
+
+recipe R
+  P1
+    foo: writes h
+  P2
+    foo: reads h

--- a/javatests/arcs/core/analysis/testdata/ok_field_inline_entity_direct.arcs
+++ b/javatests/arcs/core/analysis/testdata/ok_field_inline_entity_direct.arcs
@@ -1,0 +1,26 @@
+// #Ingress: P1
+// #OK
+particle P1
+  foo: writes Foo {
+    a: inline Bar {c: Text, d: inline Baz {e: Number} }
+  }
+  claim foo.a.c is trusted
+  claim foo.a.d is trusted
+  claim foo.a.d.e is untrusted
+
+particle P2
+  foo: reads Foo {
+    a: inline Bar {c: Text, d: inline Baz {e: Number} }
+  }
+  check foo.a.c is trusted
+  // Labels on foo and foo.a.d is the combination of labels
+  // for foo.a.d.e and foo.a.d
+  check foo is trusted or is untrusted
+  check foo.a.d is trusted or is untrusted
+  check foo.a.d.e is untrusted
+
+recipe R
+  P1
+    foo: writes h
+  P2
+    foo: reads h

--- a/javatests/arcs/core/analysis/testdata/ok_field_inline_entity_slicing.arcs
+++ b/javatests/arcs/core/analysis/testdata/ok_field_inline_entity_slicing.arcs
@@ -1,0 +1,32 @@
+// #Ingress: P1
+// #OK
+particle P1
+  foo: writes FooList {
+    elements: List<inline Foo {
+      ok: Text,
+      notOk: Number,
+      mixed: inline Baz {
+        ok: Text,
+        notOk: Number,
+      }
+    }>
+  }
+  claim foo.elements.ok is trusted
+  claim foo.elements.notOk is untrusted
+  claim foo.elements.mixed.ok is trusted
+  claim foo.elements.mixed.notOk is untrusted
+
+particle P2
+  foo: reads FooList {
+    elements: List<inline Foo {
+      ok: Text,
+      mixed: inline Baz { ok: Text }
+    }>
+  }
+  check foo is trusted
+
+recipe R
+  P1
+    foo: writes h
+  P2
+    foo: reads h

--- a/javatests/arcs/core/analysis/testdata/ok_field_list_direct.arcs
+++ b/javatests/arcs/core/analysis/testdata/ok_field_list_direct.arcs
@@ -1,0 +1,27 @@
+// #Ingress: P1
+// #OK
+schema FooList
+  elements: List<inline Foo {
+    c: Text, 
+    d: inline Baz {e: Number}
+  }>
+
+particle P1
+  foo: writes FooList
+  claim foo.elements.c is trusted
+  claim foo.elements.d is trusted
+  claim foo.elements.d.e is untrusted
+
+particle P2
+  foo: reads FooList
+  check foo.elements.c is trusted
+  // Label on foo.elements.d is the combination of labels for
+  // foo.elements.d.e and foo.elements.d
+  check foo.elements.d is trusted or is untrusted
+  check foo.elements.d.e is untrusted
+
+recipe R
+  P1
+    foo: writes h
+  P2
+    foo: reads h

--- a/javatests/arcs/core/analysis/testdata/ok_field_tuple_direct.arcs
+++ b/javatests/arcs/core/analysis/testdata/ok_field_tuple_direct.arcs
@@ -1,0 +1,32 @@
+// #Ingress: P1
+// #OK
+schema FooList
+  elements: List<inline Foo {
+    c: Text,
+    d: inline Baz {e: Number}
+  }>
+
+schema Bar
+  b: inline Baz {e: Number}
+
+particle P1
+  foo: writes (FooList, Bar)
+  claim foo.first.elements.c is trusted
+  claim foo.first.elements.d is trusted
+  claim foo.first.elements.d.e is untrusted
+  claim foo.second.b.e is public
+
+particle P2
+  foo: reads (FooList, Bar)
+  check foo.first.elements.c is trusted
+  // Label on foo.first.elements.d is the combination of labels for
+  // foo.first.elements.d.e and foo.first.elements.d
+  check foo.first.elements.d is trusted or is untrusted
+  check foo.first.elements.d.e is untrusted
+  check foo.second.b.e is public
+
+recipe R
+  P1
+    foo: writes h
+  P2
+    foo: reads h


### PR DESCRIPTION
DFA was not drilling into the inline entity, lists, and tuple fields to determine the access paths of a handle. This PR fixes that issue. 

