### PR TITLE
Allow generating empty schema2base output

### DIFF
--- a/src/tools/schema2base.ts
+++ b/src/tools/schema2base.ts
@@ -61,8 +61,7 @@ export abstract class Schema2Base {
 
     const classes = await this.processManifest(manifest);
     if (classes.length === 0) {
-      console.warn(`Could not find any particle connections with schemas in '${src}'`);
-      return;
+      console.warn(`Could not find any particle in '${src}'`);
     }
 
     const outFile = fs.openSync(outPath, 'w');


### PR DESCRIPTION
This should not be a fatal error (as it is right now, as Basel will complain if file is not generated) as folks use arcs_kt_gen for all their codegen needs, including manifests with only recipes.

I've thought through testing this, but it's hard to the in a unit testable way, and I don't want to create an empty golden just to test this case. Instead, we will use arcs_kt_gen in the upcoming showcase that will have some recipe-only manifests, which will do.