### PR TITLE
Use restricted Schema to serialize EntityBase

### DIFF
--- a/java/arcs/core/entity/Entity.kt
+++ b/java/arcs/core/entity/Entity.kt
@@ -42,6 +42,11 @@ interface Entity : Storable {
         ttl: Ttl = Ttl.Infinite()
     )
 
+    /**
+     * Takes a concrete entity class [T] and convert it to [RawEntity].
+     * @param storeSchema an optional [Schema] restricting entity serialization only to fields
+     * allowed by the policies.
+     */
     fun serialize(storeSchema: Schema? = null): RawEntity
 
     /** Resets all fields to the default value. */

--- a/java/arcs/core/entity/Entity.kt
+++ b/java/arcs/core/entity/Entity.kt
@@ -42,7 +42,7 @@ interface Entity : Storable {
         ttl: Ttl = Ttl.Infinite()
     )
 
-    fun serialize(restrictedSchema: Schema? = null): RawEntity
+    fun serialize(storeSchema: Schema? = null): RawEntity
 
     /** Resets all fields to the default value. */
     fun reset()

--- a/java/arcs/core/entity/Entity.kt
+++ b/java/arcs/core/entity/Entity.kt
@@ -42,7 +42,7 @@ interface Entity : Storable {
         ttl: Ttl = Ttl.Infinite()
     )
 
-    fun serialize(restrictedSchema: Schema? = null): RawEntity
+    fun serialize(): RawEntity
 
     /** Resets all fields to the default value. */
     fun reset()

--- a/java/arcs/core/entity/Entity.kt
+++ b/java/arcs/core/entity/Entity.kt
@@ -42,7 +42,7 @@ interface Entity : Storable {
         ttl: Ttl = Ttl.Infinite()
     )
 
-    fun serialize(): RawEntity
+    fun serialize(restrictedSchema: Schema? = null): RawEntity
 
     /** Resets all fields to the default value. */
     fun reset()

--- a/java/arcs/core/entity/EntityBase.kt
+++ b/java/arcs/core/entity/EntityBase.kt
@@ -36,8 +36,7 @@ open class EntityBase(
     entityId: String? = null,
     creationTimestamp: Long = UNINITIALIZED_TIMESTAMP,
     expirationTimestamp: Long = UNINITIALIZED_TIMESTAMP,
-    private val isInlineEntity: Boolean = false,
-    private val restrictedEntitySchema: Schema? = null
+    private val isInlineEntity: Boolean = false
 ) : Entity {
     /**
      * Only this class should be able to change these fields (in the [deserialize] and
@@ -243,8 +242,8 @@ open class EntityBase(
         schema.fields.collections.keys.forEach { collections[it] = emptySet() }
     }
 
-    override fun serialize(): RawEntity {
-        val serializationFields = restrictedEntitySchema?.fields ?: schema.fields
+    override fun serialize(restrictedSchema: Schema?): RawEntity {
+        val serializationFields = restrictedSchema?.fields ?: schema.fields
         val serialization = RawEntity(
             id = entityId ?: NO_REFERENCE_ID,
             singletons = serializationFields.singletons.mapValues { (field, _) ->

--- a/java/arcs/core/entity/EntityBase.kt
+++ b/java/arcs/core/entity/EntityBase.kt
@@ -242,8 +242,8 @@ open class EntityBase(
         schema.fields.collections.keys.forEach { collections[it] = emptySet() }
     }
 
-    override fun serialize(restrictedSchema: Schema?): RawEntity {
-        val serializationFields = restrictedSchema?.fields ?: schema.fields
+    override fun serialize(storeSchema: Schema?): RawEntity {
+        val serializationFields = storeSchema?.fields ?: schema.fields
         val serialization = RawEntity(
             id = entityId ?: NO_REFERENCE_ID,
             singletons = serializationFields.singletons.mapValues { (field, _) ->

--- a/java/arcs/core/entity/StorageAdapter.kt
+++ b/java/arcs/core/entity/StorageAdapter.kt
@@ -14,6 +14,7 @@ import arcs.core.common.Id
 import arcs.core.common.Referencable
 import arcs.core.data.Capability.Ttl
 import arcs.core.data.RawEntity
+import arcs.core.data.Schema
 import arcs.core.storage.Reference as StorageReference
 import arcs.core.storage.StorageKey
 import arcs.core.storage.keys.DatabaseStorageKey
@@ -63,12 +64,13 @@ class EntityStorageAdapter<T : Entity>(
     private val ttl: Ttl,
     private val time: Time,
     private val dereferencerFactory: EntityDereferencerFactory,
-    private val storageKey: StorageKey
+    private val storageKey: StorageKey,
+    private val restrictedEntitySchema: Schema? = null
 ) : StorageAdapter<T, RawEntity>() {
     override fun storableToReferencable(value: T): RawEntity {
         value.ensureEntityFields(idGenerator, handleName, time, ttl)
 
-        val rawEntity = value.serialize()
+        val rawEntity = value.serialize(restrictedEntitySchema)
         // Check storage key for all reference fields.
         rawEntity.allData.forEach { (_, value) ->
             if (value is StorageReference) { checkStorageKey(storageKey, value.storageKey) }

--- a/java/arcs/core/entity/StorageAdapter.kt
+++ b/java/arcs/core/entity/StorageAdapter.kt
@@ -14,6 +14,7 @@ import arcs.core.common.Id
 import arcs.core.common.Referencable
 import arcs.core.data.Capability.Ttl
 import arcs.core.data.RawEntity
+import arcs.core.data.Schema
 import arcs.core.storage.Reference as StorageReference
 import arcs.core.storage.StorageKey
 import arcs.core.storage.keys.DatabaseStorageKey
@@ -63,12 +64,12 @@ class EntityStorageAdapter<T : Entity>(
     private val ttl: Ttl,
     private val time: Time,
     private val dereferencerFactory: EntityDereferencerFactory,
-    private val storageKey: StorageKey
+    private val storageKey: StorageKey,
+    private val restrictedEntitySchema: Schema? = null
 ) : StorageAdapter<T, RawEntity>() {
     override fun storableToReferencable(value: T): RawEntity {
         value.ensureEntityFields(idGenerator, handleName, time, ttl)
-
-        val rawEntity = value.serialize()
+        val rawEntity = value.serialize(restrictedEntitySchema)
         // Check storage key for all reference fields.
         rawEntity.allData.forEach { (_, value) ->
             if (value is StorageReference) { checkStorageKey(storageKey, value.storageKey) }

--- a/java/arcs/core/entity/StorageAdapter.kt
+++ b/java/arcs/core/entity/StorageAdapter.kt
@@ -14,7 +14,6 @@ import arcs.core.common.Id
 import arcs.core.common.Referencable
 import arcs.core.data.Capability.Ttl
 import arcs.core.data.RawEntity
-import arcs.core.data.Schema
 import arcs.core.storage.Reference as StorageReference
 import arcs.core.storage.StorageKey
 import arcs.core.storage.keys.DatabaseStorageKey
@@ -64,12 +63,12 @@ class EntityStorageAdapter<T : Entity>(
     private val ttl: Ttl,
     private val time: Time,
     private val dereferencerFactory: EntityDereferencerFactory,
-    private val storageKey: StorageKey,
-    private val restrictedEntitySchema: Schema? = null
+    private val storageKey: StorageKey
 ) : StorageAdapter<T, RawEntity>() {
     override fun storableToReferencable(value: T): RawEntity {
         value.ensureEntityFields(idGenerator, handleName, time, ttl)
-        val rawEntity = value.serialize(restrictedEntitySchema)
+
+        val rawEntity = value.serialize()
         // Check storage key for all reference fields.
         rawEntity.allData.forEach { (_, value) ->
             if (value is StorageReference) { checkStorageKey(storageKey, value.storageKey) }

--- a/java/arcs/core/entity/VariableEntityBase.kt
+++ b/java/arcs/core/entity/VariableEntityBase.kt
@@ -34,8 +34,8 @@ open class VariableEntityBase(
     private val rawSingletons = mutableMapOf<FieldName, Referencable?>()
     private val rawCollections = mutableMapOf<FieldName, Set<Referencable>>()
 
-    override fun serialize(): RawEntity {
-        val rawEntity = super.serialize()
+    override fun serialize(restrictedSchema: Schema?): RawEntity {
+        val rawEntity = super.serialize(restrictedSchema)
         return rawEntity.copy(
             singletons = rawSingletons + rawEntity.singletons,
             collections = rawCollections + rawEntity.collections

--- a/java/arcs/core/entity/VariableEntityBase.kt
+++ b/java/arcs/core/entity/VariableEntityBase.kt
@@ -34,8 +34,8 @@ open class VariableEntityBase(
     private val rawSingletons = mutableMapOf<FieldName, Referencable?>()
     private val rawCollections = mutableMapOf<FieldName, Set<Referencable>>()
 
-    override fun serialize(restrictedSchema: Schema?): RawEntity {
-        val rawEntity = super.serialize(restrictedSchema)
+    override fun serialize(storeSchema: Schema?): RawEntity {
+        val rawEntity = super.serialize(storeSchema)
         return rawEntity.copy(
             singletons = rawSingletons + rawEntity.singletons,
             collections = rawCollections + rawEntity.collections

--- a/java/arcs/core/entity/VariableEntityBase.kt
+++ b/java/arcs/core/entity/VariableEntityBase.kt
@@ -34,8 +34,8 @@ open class VariableEntityBase(
     private val rawSingletons = mutableMapOf<FieldName, Referencable?>()
     private val rawCollections = mutableMapOf<FieldName, Set<Referencable>>()
 
-    override fun serialize(restrictedSchema: Schema?): RawEntity {
-        val rawEntity = super.serialize(restrictedSchema)
+    override fun serialize(): RawEntity {
+        val rawEntity = super.serialize()
         return rawEntity.copy(
             singletons = rawSingletons + rawEntity.singletons,
             collections = rawCollections + rawEntity.collections

--- a/java/arcs/core/host/EntityHandleManager.kt
+++ b/java/arcs/core/host/EntityHandleManager.kt
@@ -149,7 +149,8 @@ class EntityHandleManager(
                     ttl,
                     time,
                     dereferencerFactory,
-                    storageKey
+                    storageKey,
+                    spec.entitySpecs.single().SCHEMA
                 )
             }
             HandleDataType.Reference -> {

--- a/java/arcs/core/host/EntityHandleManager.kt
+++ b/java/arcs/core/host/EntityHandleManager.kt
@@ -149,8 +149,7 @@ class EntityHandleManager(
                     ttl,
                     time,
                     dereferencerFactory,
-                    storageKey,
-                    spec.entitySpecs.single().SCHEMA
+                    storageKey
                 )
             }
             HandleDataType.Reference -> {

--- a/javatests/arcs/core/entity/DummyEntity.kt
+++ b/javatests/arcs/core/entity/DummyEntity.kt
@@ -11,11 +11,7 @@ import arcs.core.data.SchemaName
  * in the test. Also adds convenient getters and setters for entity fields, similar to what a
  * code-generated subclass would do.
  */
-class DummyEntity(restrictedEntitySchema: Schema? = null) : EntityBase(
-    entityClassName = ENTITY_CLASS_NAME,
-    schema = SCHEMA,
-    restrictedEntitySchema = restrictedEntitySchema
-), Storable {
+class DummyEntity : EntityBase(ENTITY_CLASS_NAME, SCHEMA), Storable {
     var bool: Boolean? by SingletonProperty()
     var num: Double? by SingletonProperty()
     var text: String? by SingletonProperty()

--- a/javatests/arcs/core/entity/DummyEntity.kt
+++ b/javatests/arcs/core/entity/DummyEntity.kt
@@ -11,7 +11,11 @@ import arcs.core.data.SchemaName
  * in the test. Also adds convenient getters and setters for entity fields, similar to what a
  * code-generated subclass would do.
  */
-class DummyEntity : EntityBase(ENTITY_CLASS_NAME, SCHEMA), Storable {
+class DummyEntity(restrictedEntitySchema: Schema? = null) : EntityBase(
+    entityClassName = ENTITY_CLASS_NAME,
+    schema = SCHEMA,
+    restrictedEntitySchema = restrictedEntitySchema
+), Storable {
     var bool: Boolean? by SingletonProperty()
     var num: Double? by SingletonProperty()
     var text: String? by SingletonProperty()

--- a/javatests/arcs/core/entity/HandleManagerTestBase.kt
+++ b/javatests/arcs/core/entity/HandleManagerTestBase.kt
@@ -1271,7 +1271,7 @@ open class HandleManagerTestBase {
             }
         }
 
-        override fun serialize(restrictedSchema: Schema?) = RawEntity(
+        override fun serialize() = RawEntity(
             entityId,
             mapOf(
                 "pairs_of_shoes_owned" to pairsOfShoesOwned.toReferencable(),
@@ -1339,7 +1339,7 @@ open class HandleManagerTestBase {
             }
         }
 
-        override fun serialize(restrictedSchema: Schema?) = RawEntity(
+        override fun serialize() = RawEntity(
             entityId,
             singletons = mapOf(
                 "name" to name.toReferencable(),
@@ -1418,7 +1418,7 @@ open class HandleManagerTestBase {
             ttl: Ttl
         ) = Unit
 
-        override fun serialize(restrictedSchema: Schema?) = RawEntity(
+        override fun serialize() = RawEntity(
             entityId,
             singletons = mapOf(
                 "style" to style.toReferencable()

--- a/javatests/arcs/core/entity/HandleManagerTestBase.kt
+++ b/javatests/arcs/core/entity/HandleManagerTestBase.kt
@@ -1271,7 +1271,7 @@ open class HandleManagerTestBase {
             }
         }
 
-        override fun serialize(restrictedSchema: Schema?) = RawEntity(
+        override fun serialize(storeSchema: Schema?) = RawEntity(
             entityId,
             mapOf(
                 "pairs_of_shoes_owned" to pairsOfShoesOwned.toReferencable(),
@@ -1339,7 +1339,7 @@ open class HandleManagerTestBase {
             }
         }
 
-        override fun serialize(restrictedSchema: Schema?) = RawEntity(
+        override fun serialize(storeSchema: Schema?) = RawEntity(
             entityId,
             singletons = mapOf(
                 "name" to name.toReferencable(),
@@ -1418,7 +1418,7 @@ open class HandleManagerTestBase {
             ttl: Ttl
         ) = Unit
 
-        override fun serialize(restrictedSchema: Schema?) = RawEntity(
+        override fun serialize(storeSchema: Schema?) = RawEntity(
             entityId,
             singletons = mapOf(
                 "style" to style.toReferencable()

--- a/javatests/arcs/core/entity/HandleManagerTestBase.kt
+++ b/javatests/arcs/core/entity/HandleManagerTestBase.kt
@@ -1271,7 +1271,7 @@ open class HandleManagerTestBase {
             }
         }
 
-        override fun serialize() = RawEntity(
+        override fun serialize(restrictedSchema: Schema?) = RawEntity(
             entityId,
             mapOf(
                 "pairs_of_shoes_owned" to pairsOfShoesOwned.toReferencable(),
@@ -1339,7 +1339,7 @@ open class HandleManagerTestBase {
             }
         }
 
-        override fun serialize() = RawEntity(
+        override fun serialize(restrictedSchema: Schema?) = RawEntity(
             entityId,
             singletons = mapOf(
                 "name" to name.toReferencable(),
@@ -1418,7 +1418,7 @@ open class HandleManagerTestBase {
             ttl: Ttl
         ) = Unit
 
-        override fun serialize() = RawEntity(
+        override fun serialize(restrictedSchema: Schema?) = RawEntity(
             entityId,
             singletons = mapOf(
                 "style" to style.toReferencable()

--- a/javatests/arcs/core/entity/StorageAdapterTest.kt
+++ b/javatests/arcs/core/entity/StorageAdapterTest.kt
@@ -4,6 +4,7 @@ import arcs.core.common.Id
 import arcs.core.crdt.VersionMap
 import arcs.core.data.Capability.Ttl
 import arcs.core.data.FieldType
+import arcs.core.data.RawEntity
 import arcs.core.data.RawEntity.Companion.NO_REFERENCE_ID
 import arcs.core.data.Schema
 import arcs.core.data.SchemaFields
@@ -64,8 +65,35 @@ class StorageAdapterTest {
         assertThat(adapter.referencableToStorable(rawEntity)).isEqualTo(entity)
     }
 
+    // A restricted version of DummyEntity with less fields.	
+    class RestrictedDummyEntity : EntityBase(ENTITY_CLASS_NAME, SCHEMA), Storable {
+        var text: String? by SingletonProperty()
+
+        companion object : EntitySpec<RestrictedDummyEntity> {
+            override fun deserialize(data: RawEntity) =
+                RestrictedDummyEntity().apply {
+                    deserialize(data, mapOf(SCHEMA_HASH to RestrictedDummyEntity))
+                }
+
+            const val ENTITY_CLASS_NAME = "RestrictedDummyEntity"
+
+            const val SCHEMA_HASH = "klmnop"
+
+            override val SCHEMA = Schema(
+                names = setOf(SchemaName(ENTITY_CLASS_NAME)),
+                fields = SchemaFields(
+                    singletons = mapOf(
+                        "text" to FieldType.Text
+                    ),
+                    collections = emptyMap()
+                ),
+                hash = SCHEMA_HASH
+            )
+        }
+    }
+
     @Test
-    fun entityStorageAdapterNew() {
+    fun entityStorageAdapterRestricted() {
         val adapter = EntityStorageAdapter(
             "name",
             idGenerator,
@@ -73,19 +101,10 @@ class StorageAdapterTest {
             Ttl.Minutes(1),
             time,
             dereferencerFactory,
-            storageKey
+            storageKey,
+            RestrictedDummyEntity.SCHEMA
         )
-        val restrictedSchema = Schema(
-            names = setOf(SchemaName(DummyEntity.ENTITY_CLASS_NAME)),
-            fields = SchemaFields(
-                singletons = mapOf(
-                    "text" to FieldType.Text
-                ),
-                collections = emptyMap()
-            ),
-            hash = "wxyzzyxw"
-        )
-        var entity = DummyEntity(restrictedSchema).apply {
+        var entity = DummyEntity().apply {
             text = "Watson"
             num = 42.0
             bool = true
@@ -100,7 +119,7 @@ class StorageAdapterTest {
         assertThat(rawEntity.expirationTimestamp).isEqualTo(time.currentTimeMillis + 60000)
         assertThat(rawEntity.singletons.size).isEqualTo(1)
         assertThat(rawEntity.singletons).containsEntry("text", "Watson".toReferencable())
-        assertThat(entity.serialize()).isEqualTo(rawEntity)
+        assertThat(entity.serialize(RestrictedDummyEntity.SCHEMA)).isEqualTo(rawEntity)
 
         // Convert back from storage format again.
         entity = entity.apply { num = null }.apply { bool = null }


### PR DESCRIPTION
(b/159143604) Ingress restricting: add optional `restrictedSchema` parameter to StorageAdapter to use at EntityBase serialization to RawEntity (the restricted schema must be compliant with the Entity Type's schema, and fields not in the restricted schema are dropped at serialization).

Next steps: 
- more tests for dropping / keeping fields of non-primitive types
- propagating the restrictedSchema all the way from Plan.kt `Handle`.