### PR TITLE
Make arcs_sdk_deps to be an explicit argument to skylark macros

### DIFF
--- a/third_party/java/arcs/build_defs/build_defs.bzl
+++ b/third_party/java/arcs/build_defs/build_defs.bzl
@@ -38,13 +38,23 @@ load(":sigh.bzl", "sigh_command")
 
 # Re-export rules from various other files.
 
+# The default Arcs SDK to use.
+DEFAULT_ARCS_SDK_DEPS = ["//third_party/java/arcs"]
+
 arcs_cc_schema = _arcs_cc_schema
 
 arcs_kt_android_library = _arcs_kt_android_library
 
 arcs_kt_android_test_suite = _arcs_kt_android_test_suite
 
-arcs_kt_gen = _arcs_kt_gen
+def arcs_kt_gen(**kwargs):
+    """Wrapper around _arcs_kt_gen that sets the default Arcs SDK
+
+    Args:
+      **kwargs: Set of args to forward to _arcs_kt_gen
+    """
+    kwargs.setdefault("arcs_sdk_deps", DEFAULT_ARCS_SDK_DEPS)
+    _arcs_kt_gen(**kwargs)
 
 arcs_kt_jvm_library = _arcs_kt_jvm_library
 
@@ -56,11 +66,32 @@ arcs_kt_js_library = _arcs_kt_js_library
 
 arcs_kt_native_library = _arcs_kt_native_library
 
-arcs_kt_particles = _arcs_kt_particles
+def arcs_kt_particles(**kwargs):
+    """Wrapper around _arcs_kt_particles that sets the default Arcs SDK
 
-arcs_kt_plan = _arcs_kt_plan
+    Args:
+      **kwargs: Set of args to forward to _arcs_kt_particles
+    """
+    kwargs.setdefault("arcs_sdk_deps", DEFAULT_ARCS_SDK_DEPS)
+    _arcs_kt_particles(**kwargs)
 
-arcs_kt_schema = _arcs_kt_schema
+def arcs_kt_plan(**kwargs):
+    """Wrapper around _arcs_kt_plan that sets the default Arcs SDK
+
+    Args:
+      **kwargs: Set of args to forward to _arcs_kt_plan
+    """
+    kwargs.setdefault("arcs_sdk_deps", DEFAULT_ARCS_SDK_DEPS)
+    _arcs_kt_plan(**kwargs)
+
+def arcs_kt_schema(**kwargs):
+    """Wrapper around _arcs_kt_schema that sets the default Arcs SDK
+
+    Args:
+      **kwargs: Set of args to forward to _arcs_kt_schema
+    """
+    kwargs.setdefault("arcs_sdk_deps", DEFAULT_ARCS_SDK_DEPS)
+    _arcs_kt_schema(**kwargs)
 
 arcs_manifest = _arcs_manifest
 

--- a/third_party/java/arcs/build_defs/internal/kotlin.bzl
+++ b/third_party/java/arcs/build_defs/internal/kotlin.bzl
@@ -33,8 +33,6 @@ load(":kotlin_serviceloader_registry.bzl", "kotlin_serviceloader_registry")
 load(":kotlin_wasm_annotations.bzl", "kotlin_wasm_annotations")
 load(":util.bzl", "manifest_only", "merge_lists", "replace_arcs_suffix")
 
-ARCS_SDK_DEPS = ["//third_party/java/arcs"]
-
 _WASM_SUFFIX = "-wasm"
 
 _JS_SUFFIX = "-js"
@@ -229,6 +227,7 @@ def _extract_particle_name(src):
 def arcs_kt_particles(
         name,
         package,
+        arcs_sdk_deps,
         srcs = [],
         deps = [],
         platforms = DEFAULT_PARTICLE_PLATFORMS,
@@ -240,6 +239,7 @@ def arcs_kt_particles(
     Args:
       name: name of the target to create
       package: Kotlin package for the particles
+      arcs_sdk_deps: build targets for the Arcs SDK to be included
       srcs: List of source files to include. Each file must contain a Kotlin
         class of the same name, which must match the name of a particle defined
         in a .arcs file.
@@ -252,7 +252,7 @@ def arcs_kt_particles(
     """
     _check_platforms(platforms)
 
-    deps = ARCS_SDK_DEPS + deps
+    deps = arcs_sdk_deps + deps
 
     if "jvm" in platforms and "wasm" in platforms:
         fail("Particles can only depend on one of jvm or wasm")
@@ -413,7 +413,14 @@ def arcs_kt_android_test_suite(
             deps = android_local_test_deps,
         )
 
-def arcs_kt_plan(name, srcs = [], data = [], deps = [], platforms = ["jvm"], visibility = None):
+def arcs_kt_plan(
+        name,
+        arcs_sdk_deps,
+        srcs = [],
+        data = [],
+        deps = [],
+        platforms = ["jvm"],
+        visibility = None):
     """Converts recipes from manifests into Kotlin plans.
 
     Example:
@@ -441,6 +448,7 @@ def arcs_kt_plan(name, srcs = [], data = [], deps = [], platforms = ["jvm"], vis
 
     Args:
       name: the name of the target to create
+      arcs_sdk_deps: build targets for the Arcs SDK to be included
       srcs: list of Arcs manifest files
       data: list of Arcs manifests needed at runtime
       deps: list of dependencies (jars)
@@ -475,9 +483,9 @@ def arcs_kt_plan(name, srcs = [], data = [], deps = [], platforms = ["jvm"], vis
         srcs = outs,
         platforms = platforms,
         visibility = visibility,
-        deps = ARCS_SDK_DEPS + deps,
+        deps = arcs_sdk_deps + deps,
     )
-    return {"outs": outs, "deps": ARCS_SDK_DEPS}
+    return {"outs": outs, "deps": arcs_sdk_deps}
 
 def arcs_kt_jvm_test_suite(
         name,

--- a/third_party/java/arcs/build_defs/internal/schemas.bzl
+++ b/third_party/java/arcs/build_defs/internal/schemas.bzl
@@ -6,7 +6,7 @@ Rules are re-exported in build_defs.bzl -- use those instead.
 load("//devtools/build_cleaner/skylark:build_defs.bzl", "register_extension_info")
 load("//third_party/java/arcs/build_defs:sigh.bzl", "sigh_command")
 load("//third_party/java/arcs/build_defs/internal:util.bzl", "manifest_only", "replace_arcs_suffix")
-load(":kotlin.bzl", "ARCS_SDK_DEPS", "arcs_kt_library", "arcs_kt_plan")
+load(":kotlin.bzl", "arcs_kt_library", "arcs_kt_plan")
 load(":manifest.bzl", "arcs_manifest")
 
 def _run_schema2wasm(
@@ -62,6 +62,7 @@ def arcs_cc_schema(name, src, deps = [], out = None):
 def arcs_kt_schema(
         name,
         srcs,
+        arcs_sdk_deps,
         data = [],
         deps = [],
         platforms = ["jvm"],
@@ -89,6 +90,7 @@ def arcs_kt_schema(
     Args:
       name: name of the target to create
       srcs: list of Arcs manifest files to include
+      arcs_sdk_deps: build targets for the Arcs SDK to be included
       data: list of Arcs manifests needed at runtime
       deps: list of imported manifests
       platforms: list of target platforms (currently, `jvm` and `wasm` supported).
@@ -130,10 +132,10 @@ def arcs_kt_schema(
         name = name,
         srcs = outs,
         platforms = platforms,
-        deps = ARCS_SDK_DEPS,
+        deps = arcs_sdk_deps,
         visibility = visibility,
     )
-    outdeps = outdeps + ARCS_SDK_DEPS
+    outdeps = outdeps + arcs_sdk_deps
 
     if (test_harness):
         test_harness_outs = []
@@ -156,7 +158,7 @@ def arcs_kt_schema(
             name = name + "_test_harness",
             testonly = 1,
             srcs = test_harness_outs,
-            deps = ARCS_SDK_DEPS + [
+            deps = arcs_sdk_deps + [
                 ":" + name,
                 "//third_party/java/arcs:testing",
                 "//third_party/kotlin/kotlinx_coroutines",
@@ -167,6 +169,7 @@ def arcs_kt_schema(
 def arcs_kt_gen(
         name,
         srcs,
+        arcs_sdk_deps,
         data = [],
         deps = [],
         platforms = ["jvm"],
@@ -179,6 +182,7 @@ def arcs_kt_gen(
     Args:
       name: name of the target to create
       srcs: list of Arcs manifest files to include
+      arcs_sdk_deps: build targets for the Arcs SDK to be included
       data: list of Arcs manifests needed at runtime
       deps: list of dependent arcs targets, such as an arcs_kt_gen target in a different package
       platforms: list of target platforms (currently, `jvm` and `wasm` supported).
@@ -199,6 +203,7 @@ def arcs_kt_gen(
     schema = arcs_kt_schema(
         name = schema_name,
         srcs = srcs,
+        arcs_sdk_deps = arcs_sdk_deps,
         deps = deps + [":" + manifest_name],
         platforms = platforms,
         test_harness = test_harness,
@@ -207,6 +212,7 @@ def arcs_kt_gen(
     plan = arcs_kt_plan(
         name = plan_name,
         srcs = srcs,
+        arcs_sdk_deps = arcs_sdk_deps,
         data = [":" + manifest_name],
         deps = deps + [":" + schema_name],
         platforms = platforms,


### PR DESCRIPTION
This change is  intended to provide control over what SDK target is used for linking. In the short term, we need this to tweak the visibility of some internal google targets. e.g., when building internal code, we need to link to one SDK and for building third party code, we need to link a different SDK. 

Note that it should never be the case that we mix multiple SDKs. If we mix them, it should be caught at compile or link time.

 In the long term, this might be the way we do version control and releases.