### PR TITLE
Expedite entity queries from database while initializing handles at Arc startup

### DIFF
--- a/java/arcs/android/storage/database/DatabaseImpl.kt
+++ b/java/arcs/android/storage/database/DatabaseImpl.kt
@@ -265,7 +265,7 @@ class DatabaseImpl(
         storageKey: StorageKey,
         schema: Schema,
         counters: Counters? = null
-    ): DatabaseData.Entity? = readableDatabase.transaction {
+    ): DatabaseData.Entity? = with(readableDatabase) {
         val db = this
         // Fetch the entity's type by storage key.
         counters?.increment(DatabaseCounters.GET_ENTITY_TYPE_BY_STORAGEKEY)


### PR DESCRIPTION
**Android SQLite transaction** always use the **primary** connection to access a database even if it's in WAL journal mode. (the primary transaction is mainly for all write operations like insert/update/delete/create table/index statements and so on). **beginTransaction** and **endTransaction** are required for these write operations (or **non-Select** statements).

For read (Select), using rawQuery/query/simpleQuery directly as no db records are modified.
This improve around 36% `constructPendingIdsAndModel` time (1.14s to 0.73s) at internal use-cases where there are 4 persistent handles initialized concurrently.