### PR TITLE
Eliminate redundant model sent to driver

### DIFF
--- a/java/arcs/core/storage/DirectStore.kt
+++ b/java/arcs/core/storage/DirectStore.kt
@@ -267,10 +267,10 @@ class DirectStore<Data : CrdtData, Op : CrdtOperation, T> /* internal */ constru
 
         /**
          * The [modelChange] is not empty against the first received model from the
-         * driver turns out a redundant model update sent to the driver just advancing
-         * the [version] with the exactly identical model. Such a redundant model update
-         * should be avoided during a new [DirectStore.create] which registers with the
-         * [DatabaseDriver] and applies the received model as its initial local model.
+         * driver turns out a redundant model update sent to the driver with the exactly
+         * identical model. Such a redundant model update should be avoided during a new
+         * [DirectStore.create] which registers with the [DatabaseDriver] and applies the
+         * received model as its initial local model.
          */
         if (state.value is State.Idle<Data> && firstModelFromDriver) {
             this.version.value = theVersion

--- a/java/arcs/core/storage/DirectStore.kt
+++ b/java/arcs/core/storage/DirectStore.kt
@@ -266,7 +266,7 @@ class DirectStore<Data : CrdtData, Op : CrdtOperation, T> /* internal */ constru
         }
 
         /**
-         * The [modelChange] is not empty against the first received model from the
+         * The [otherChange] is not empty against the first received model from the
          * driver turns out a redundant model update sent to the driver with the exactly
          * identical model. Such a redundant model update should be avoided during a new
          * [DirectStore.create] which registers with the [DatabaseDriver] and applies the

--- a/java/arcs/core/storage/DirectStore.kt
+++ b/java/arcs/core/storage/DirectStore.kt
@@ -276,7 +276,7 @@ class DirectStore<Data : CrdtData, Op : CrdtOperation, T> /* internal */ constru
             this.version.value = theVersion
             return
         }
-        
+
         updateStateAndAct(noDriverSideChanges, theVersion, messageFromDriver = true)
     }
 

--- a/java/arcs/core/storage/DirectStore.kt
+++ b/java/arcs/core/storage/DirectStore.kt
@@ -240,6 +240,7 @@ class DirectStore<Data : CrdtData, Op : CrdtOperation, T> /* internal */ constru
 
         var noDriverSideChanges = true
         var theVersion = 0
+        val firstModelFromDriver = localModel.versionMap.isEmpty()
         models.forEach { (model, version) ->
             try {
                 log.verbose { "Merging $model into ${localModel.data}" }
@@ -263,6 +264,19 @@ class DirectStore<Data : CrdtData, Op : CrdtOperation, T> /* internal */ constru
                 throw e
             }
         }
+
+        /**
+         * The [modelChange] is not empty against the first received model from the
+         * driver turns out a redundant model update sent to the driver just advancing
+         * the [version] with the exactly identical model. Such a redundant model update
+         * should be avoided during a new [DirectStore.create] which registers with the
+         * [DatabaseDriver] and applies the received model as its initial local model.
+         */
+        if (state.value is State.Idle<Data> && firstModelFromDriver) {
+            this.version.value = theVersion
+            return
+        }
+        
         updateStateAndAct(noDriverSideChanges, theVersion, messageFromDriver = true)
     }
 

--- a/java/arcs/jvm/storage/database/testutil/FakeDatabaseManager.kt
+++ b/java/arcs/jvm/storage/database/testutil/FakeDatabaseManager.kt
@@ -83,6 +83,10 @@ class FakeDatabaseManager : DatabaseManager {
     override suspend fun resetAll() {
         throw UnsupportedOperationException("Fake database manager cannot resetAll.")
     }
+
+    suspend fun totalInsertUpdates() = snapshotStatistics().map {
+        it.value.insertUpdate.runtimeStatistics.measurements
+    }.sum()
 }
 
 @Suppress("EXPERIMENTAL_API_USAGE")


### PR DESCRIPTION
The PR improves Arcs startup time particularly backing store preparation (syncing data from database, etc) 700+ ms.