### PR TITLE
Introduce a `HandleManager` interface

### DIFF
--- a/java/arcs/core/host/AbstractArcHost.kt
+++ b/java/arcs/core/host/AbstractArcHost.kt
@@ -222,7 +222,7 @@ abstract class AbstractArcHost(
 
     private fun createArcHostContext(arcId: String) = ArcHostContext(
         arcId = arcId,
-        entityHandleManager = entityHandleManager(arcId)
+        handleManager = entityHandleManager(arcId)
     )
 
     override suspend fun addOnArcStateChange(
@@ -391,7 +391,7 @@ abstract class AbstractArcHost(
         // time by the ParticleContext state machine.
         spec.handles.forEach { (handleName, handleConnection) ->
             createHandle(
-                context.entityHandleManager,
+                context.handleManager,
                 handleName,
                 handleConnection,
                 particle.handles,
@@ -475,7 +475,7 @@ abstract class AbstractArcHost(
      * triggered according to the rules of the [Scheduler].
      */
     protected suspend fun createHandle(
-        handleManager: EntityHandleManager,
+        handleManager: HandleManager,
         handleName: String,
         connectionSpec: Plan.HandleConnection,
         holder: HandleHolder,
@@ -531,7 +531,7 @@ abstract class AbstractArcHost(
             context.arcState = ArcState.Stopped
             updateArcHostContext(arcId, context)
         } finally {
-            context.entityHandleManager.close()
+            context.handleManager.close()
         }
     }
 
@@ -549,7 +549,7 @@ abstract class AbstractArcHost(
     /**
      * Return an instance of [EntityHandleManager] to be used to create [Handle]s.
      */
-    open fun entityHandleManager(arcId: String) = EntityHandleManager(
+    open fun entityHandleManager(arcId: String): HandleManager = EntityHandleManager(
         arcId,
         hostId,
         platformTime,

--- a/java/arcs/core/host/ArcHostContext.kt
+++ b/java/arcs/core/host/ArcHostContext.kt
@@ -23,12 +23,13 @@ import arcs.core.util.TaggedLog
 data class ArcHostContext(
     var arcId: String,
     var particles: MutableList<ParticleContext> = mutableListOf(),
-    var entityHandleManager: EntityHandleManager
+    var handleManager: HandleManager,
+    val initialArcState: ArcState = ArcState.NeverStarted
 ) {
     private val stateChangeCallbacks: MutableMap<ArcStateChangeRegistration,
         ArcStateChangeCallback> = mutableMapOf()
 
-    private var _arcState = ArcState.NeverStarted
+    private var _arcState = initialArcState
 
     var arcState: ArcState
         get() = _arcState
@@ -39,17 +40,8 @@ data class ArcHostContext(
             }
         }
 
-    constructor(
-        arcId: String,
-        particles: MutableList<ParticleContext> = mutableListOf(),
-        arcState: ArcState = ArcState.NeverStarted,
-        entityHandleManager: EntityHandleManager
-    ) : this(arcId, particles, entityHandleManager) {
-        _arcState = arcState
-    }
-
     override fun toString() = "ArcHostContext(arcId=$arcId, arcState=$arcState, " +
-            "particles=$particles, entityHandleManager=$entityHandleManager)"
+            "particles=$particles, entityHandleManager=$handleManager)"
 
     internal fun addOnArcStateChange(
         registration: ArcStateChangeRegistration,

--- a/java/arcs/core/host/ArcHostContextParticle.kt
+++ b/java/arcs/core/host/ArcHostContextParticle.kt
@@ -44,7 +44,7 @@ typealias ArcHostContextParticle_PlanHandle = AbstractArcHostContextParticle.Pla
  */
 class ArcHostContextParticle(
     private val hostId: String,
-    private val handleManager: EntityHandleManager,
+    private val handleManager: HandleManager,
     private val instantiateParticle: suspend (ParticleIdentifier, Plan.Particle?) -> Particle,
     private val instantiatedParticles: MutableMap<String, Particle> = mutableMapOf()
 ) : AbstractArcHostContextParticle() {
@@ -146,8 +146,8 @@ class ArcHostContextParticle(
             return@onHandlesReady ArcHostContext(
                 arcId,
                 particles.toMutableList(),
-                ArcState.fromString(arcStateEntity.arcState),
-                entityHandleManager = arcHostContext.entityHandleManager
+                handleManager = arcHostContext.handleManager,
+                initialArcState = ArcState.fromString(arcStateEntity.arcState)
             )
         } catch (e: Exception) {
             throw IllegalStateException("Unable to deserialize $arcId for $hostId", e)

--- a/java/arcs/core/host/EntityHandleManager.kt
+++ b/java/arcs/core/host/EntityHandleManager.kt
@@ -84,7 +84,7 @@ class EntityHandleManager(
     private val idGenerator: Id.Generator = Id.Generator.newSession(),
     private val coroutineContext: CoroutineContext = Dispatchers.Default,
     private val analytics: Analytics? = null
-) {
+) : HandleManager {
 
     @Deprecated(
         message = "prefer primary constructor",
@@ -128,12 +128,12 @@ class EntityHandleManager(
     }
 
     @ExperimentalCoroutinesApi
-    suspend fun createHandle(
+    override suspend fun createHandle(
         spec: HandleSpec,
         storageKey: StorageKey,
-        ttl: Ttl = Ttl.Infinite(),
-        particleId: String = "",
-        immediateSync: Boolean = true
+        ttl: Ttl,
+        particleId: String,
+        immediateSync: Boolean
     ): Handle {
         val handleName = idGenerator.newChildId(
             idGenerator.newChildId(arcId.toArcId(), hostId),
@@ -187,7 +187,7 @@ class EntityHandleManager(
     }
 
     /** Close all [StorageProxy] instances in this [EntityHandleManager]. */
-    suspend fun close() {
+    override suspend fun close() {
         proxyMutex.withLock {
             // Needed to avoid receiving ModelUpdate after Proxy closed error
             scheduler.waitForIdle()

--- a/java/arcs/core/host/HandleManager.kt
+++ b/java/arcs/core/host/HandleManager.kt
@@ -1,0 +1,28 @@
+package arcs.core.host
+
+import arcs.core.data.Capability
+import arcs.core.entity.Handle
+import arcs.core.entity.HandleSpec
+import arcs.core.storage.StorageKey
+
+/**
+ * This interface defines the functionality of a component that manages all of the active
+ * handles for one particular scope.
+ *
+ * In most cases, "scope" means an Arc. It is possible to use a [HandleManager] to manage groups
+ * of [Handle]s for other groupings. This is currently not a supported use case for Arcs clients,
+ * but we may use this internally for storage stack testing.
+ */
+interface HandleManager {
+    /** Create a new handle owned by this handle manager. */
+    suspend fun createHandle(
+        spec: HandleSpec,
+        storageKey: StorageKey,
+        ttl: Capability.Ttl = Capability.Ttl.Infinite(),
+        particleId: String = "",
+        immediateSync: Boolean = true
+    ): Handle
+
+    /** Close all handles created by this handle manager. */
+    suspend fun close()
+}

--- a/javatests/arcs/core/host/TestingHost.kt
+++ b/javatests/arcs/core/host/TestingHost.kt
@@ -114,9 +114,11 @@ open class TestingHost(
             "TestHolder",
             mapOf(handleName to entitySpecs)
         )
-        val handle = createHandle(
-            arcHostContext.entityHandleManager, handleName, readWriteConnection, handleHolder
+        return createHandle(
+            arcHostContext.handleManager,
+            handleName,
+            readWriteConnection,
+            handleHolder
         )
-        return handle
     }
 }


### PR DESCRIPTION
This helps us to clarify the functionality that we expect to be
exposed from a handle manager implementation, and paves the way for
further cleanup.

Also includes two minor style cleanups:
* Remove 2nd ArcHostContext constructor in favor of default param value
* Fix a just-use-direct-return style warning in TestingHost