### PR TITLE
Introduce the new `StorageEndpointManager` interface

### DIFF
--- a/java/arcs/core/host/StorageEndpointManager.kt
+++ b/java/arcs/core/host/StorageEndpointManager.kt
@@ -1,0 +1,61 @@
+package arcs.core.host
+
+import arcs.core.crdt.CrdtData
+import arcs.core.crdt.CrdtOperationAtTime
+import arcs.core.storage.ProxyCallback
+import arcs.core.storage.ProxyMessage
+import arcs.core.storage.StorageEndpoint
+import arcs.core.storage.StorageEndpointProvider
+import arcs.core.storage.StoreManager
+import arcs.core.storage.StoreOptions
+
+/**
+ * A [StorageEndpointManager] gives us [StorageEndpointProvider]s of particular types.
+ */
+interface StorageEndpointManager {
+    /**
+     * Returns a [StorageEndpointProvider] for the requested [StoreOptions], of the specified
+     * type parameters.
+     *
+     * Implementations *may* choose to cache [StorageEndpointProvider] instances internally, so a
+     * call to get for the same parameters may or may not return the same object, depending on the
+     * implementation.
+     */
+    suspend fun <Data : CrdtData, Op : CrdtOperationAtTime, T> get(
+        storeOptions: StoreOptions
+    ): StorageEndpointProvider<Data, Op, T>
+}
+
+/**
+ * This is a temporary facade that adapts the provided [StoreManager] to be a
+ * [StorageEndpointProvider], with the goal of reducing the scope of change in a single PR.
+ *
+ * Eventually, we will remove this in favor of a [StorageEndpointProvider] passed directly to
+ * [EntityHandleManager].
+ */
+fun StoreManager.asStoreEndpointManager() = object :
+    StorageEndpointManager {
+    override suspend fun <Data : CrdtData, Op : CrdtOperationAtTime, ConsumerData> get(
+        storeOptions: StoreOptions
+    ): StorageEndpointProvider<Data, Op, ConsumerData> {
+        val store = this@asStoreEndpointManager.get<Data, Op, ConsumerData>(storeOptions)
+
+        return object :
+            StorageEndpointProvider<Data, Op, ConsumerData> {
+            override val storageKey = storeOptions.storageKey
+            override fun create(
+                callback: ProxyCallback<Data, Op, ConsumerData>
+            ) = object :
+                StorageEndpoint<Data, Op, ConsumerData> {
+                private val id = store.on(callback)
+                override suspend fun idle() = store.idle()
+
+                override suspend fun onProxyMessage(
+                    message: ProxyMessage<Data, Op, ConsumerData>
+                ) = store.onProxyMessage(message.withId(id))
+
+                override fun close() = store.off(id)
+            }
+        }
+    }
+}

--- a/java/arcs/core/storage/ActiveStore.kt
+++ b/java/arcs/core/storage/ActiveStore.kt
@@ -23,7 +23,7 @@ import arcs.core.type.Type
  */
 abstract class ActiveStore<Data : CrdtData, Op : CrdtOperation, ConsumerData>(
     options: StoreOptions
-) : IStore<Data, Op, ConsumerData>, StorageCommunicationEndpointProvider<Data, Op, ConsumerData> {
+) : IStore<Data, Op, ConsumerData> {
     override val storageKey: StorageKey = options.storageKey
     override val type: Type = options.type
     open val versionToken: String? = options.versionToken
@@ -45,22 +45,4 @@ abstract class ActiveStore<Data : CrdtData, Op : CrdtOperation, ConsumerData>(
 
     /** Performs any operations that are needed to release resources held by this [ActiveStore]. */
     open fun close() = Unit
-
-    /**
-     * Return a storage endpoint that will receive messages from the store via the
-     * provided callback
-     */
-    override fun getStorageEndpoint(
-        callback: ProxyCallback<Data, Op, ConsumerData>
-    ) = object : StorageCommunicationEndpoint<Data, Op, ConsumerData> {
-        val id = on(callback)
-
-        override suspend fun idle() = this@ActiveStore.idle()
-
-        override suspend fun onProxyMessage(
-            message: ProxyMessage<Data, Op, ConsumerData>
-        ) = this@ActiveStore.onProxyMessage(message.withId(id))
-
-        override fun close() = off(id)
-    }
 }

--- a/java/arcs/core/storage/BUILD
+++ b/java/arcs/core/storage/BUILD
@@ -11,6 +11,10 @@ PROXY_SRCS = [
     "ProxyInterface.kt",
 ]
 
+STORE_SRCS = [
+    "StoreInterface.kt",
+]
+
 STORAGE_KEY_SRCS = [
     "StorageKey.kt",
     "StorageKeyParser.kt",
@@ -29,18 +33,20 @@ arcs_kt_library(
     name = "storage",
     srcs = glob(
         ["*.kt"],
-        exclude = PROXY_SRCS + STORAGE_KEY_SRCS + REFERENCE_SRCS + WRITEBACK_SRCS,
+        exclude = PROXY_SRCS + STORAGE_KEY_SRCS + REFERENCE_SRCS + WRITEBACK_SRCS + STORE_SRCS,
     ),
     exports = [
         ":proxy",
         ":reference",
         ":storage_key",
+        ":store",
         ":writeback",
     ],
     deps = [
         ":proxy",
         ":reference",
         ":storage_key",
+        ":store",
         ":writeback",
         "//java/arcs/core/analytics",
         "//java/arcs/core/common",
@@ -83,7 +89,18 @@ arcs_kt_library(
     srcs = PROXY_SRCS,
     deps = [
         ":storage_key",
+        ":store",
         "//java/arcs/core/crdt",
+    ],
+)
+
+arcs_kt_library(
+    name = "store",
+    srcs = STORE_SRCS,
+    deps = [
+        ":storage_key",
+        "//java/arcs/core/crdt",
+        "//java/arcs/core/type",
     ],
 )
 

--- a/java/arcs/core/storage/ProxyInterface.kt
+++ b/java/arcs/core/storage/ProxyInterface.kt
@@ -109,14 +109,15 @@ interface StorageEndpoint<Data : CrdtData, Op : CrdtOperation, ConsumerData> {
 }
 
 /** Provider of a [StorageCommunicationEndpoint]s. */
-interface StorageEndpointProvider {
+interface StorageEndpointProvider <Data : CrdtData, Op : CrdtOperationAtTime, ConsumerData> {
     /**
      * Returns a communications channel to an [ActiveStore] that reflects the provided
      * [StoreOptions]. This is not necessarily an [ActiveStore] implementation, though a basic
      * implementation may provide a simple wrapper around an in-process instance of [ActiveStore].
      */
-    fun <Data : CrdtData, Op : CrdtOperationAtTime, ConsumerData> createStorageEndpoint(
-        storeOptions: StoreOptions,
+    fun create(
         callback: ProxyCallback<Data, Op, ConsumerData>
     ): StorageEndpoint<Data, Op, ConsumerData>
+
+    val storageKey: StorageKey
 }

--- a/java/arcs/core/storage/ProxyInterface.kt
+++ b/java/arcs/core/storage/ProxyInterface.kt
@@ -13,7 +13,7 @@ package arcs.core.storage
 
 import arcs.core.crdt.CrdtData
 import arcs.core.crdt.CrdtOperation
-import arcs.core.storage.ProxyMessage.Type
+import arcs.core.crdt.CrdtOperationAtTime
 
 /** A message coming from the storage proxy into one of the [IStore] implementations. */
 sealed class ProxyMessage<Data : CrdtData, Op : CrdtOperation, ConsumerData>(
@@ -92,7 +92,7 @@ fun <Data : CrdtData, Op : CrdtOperation, ConsumerData> ProxyCallback(
 }
 
 /** Interface common to an [ActiveStore] and the PEC, used by the Storage Proxy. */
-interface StorageCommunicationEndpoint<Data : CrdtData, Op : CrdtOperation, ConsumerData> {
+interface StorageEndpoint<Data : CrdtData, Op : CrdtOperation, ConsumerData> {
     /**
      * Suspends until the endpoint has become idle (typically: when it is finished flushing data to
      * storage media.
@@ -108,16 +108,15 @@ interface StorageCommunicationEndpoint<Data : CrdtData, Op : CrdtOperation, Cons
     fun close()
 }
 
-/** Provider of a [StorageCommunicationEndpoint]. */
-interface StorageCommunicationEndpointProvider<Data : CrdtData, Op : CrdtOperation, ConsumerData> {
+/** Provider of a [StorageCommunicationEndpoint]s. */
+interface StorageEndpointProvider {
     /**
-     * Implementers should return a [StorageCommunicationEndpoint] that signals information back to
-     * the agent using the provided [callback].
+     * Returns a communications channel to an [ActiveStore] that reflects the provided
+     * [StoreOptions]. This is not necessarily an [ActiveStore] implementation, though a basic
+     * implementation may provide a simple wrapper around an in-process instance of [ActiveStore].
      */
-    fun getStorageEndpoint(
+    fun <Data : CrdtData, Op : CrdtOperationAtTime, ConsumerData> getStorageEndpoint(
+        storeOptions: StoreOptions,
         callback: ProxyCallback<Data, Op, ConsumerData>
-    ): StorageCommunicationEndpoint<Data, Op, ConsumerData>
-
-    /** Return the [StorageKey] that the store behind this implementation is representing. */
-    val storageKey: StorageKey
+    ): StorageEndpoint<Data, Op, ConsumerData>
 }

--- a/java/arcs/core/storage/ProxyInterface.kt
+++ b/java/arcs/core/storage/ProxyInterface.kt
@@ -115,7 +115,7 @@ interface StorageEndpointProvider {
      * [StoreOptions]. This is not necessarily an [ActiveStore] implementation, though a basic
      * implementation may provide a simple wrapper around an in-process instance of [ActiveStore].
      */
-    fun <Data : CrdtData, Op : CrdtOperationAtTime, ConsumerData> getStorageEndpoint(
+    fun <Data : CrdtData, Op : CrdtOperationAtTime, ConsumerData> createStorageEndpoint(
         storeOptions: StoreOptions,
         callback: ProxyCallback<Data, Op, ConsumerData>
     ): StorageEndpoint<Data, Op, ConsumerData>

--- a/java/arcs/core/storage/StorageProxy.kt
+++ b/java/arcs/core/storage/StorageProxy.kt
@@ -77,7 +77,7 @@ class StorageProxy<Data : CrdtData, Op : CrdtOperationAtTime, T>(
     private val log = TaggedLog { "StorageProxy" }
     private val handleCallbacks = atomic(HandleCallbacks<T>())
     private val stateHolder = atomic(StateHolder<T>(ProxyState.NO_SYNC))
-    private val store: StorageEndpoint<Data, Op, T> = storeEndpointProvider.getStorageEndpoint(
+    private val store: StorageEndpoint<Data, Op, T> = storeEndpointProvider.createStorageEndpoint(
         storeOptions,
         ProxyCallback(::onMessage)
     )

--- a/java/arcs/core/storage/StorageProxy.kt
+++ b/java/arcs/core/storage/StorageProxy.kt
@@ -51,8 +51,7 @@ import kotlinx.coroutines.withTimeoutOrNull
  */
 @Suppress("EXPERIMENTAL_API_USAGE")
 class StorageProxy<Data : CrdtData, Op : CrdtOperationAtTime, T>(
-    storeOptions: StoreOptions,
-    storeEndpointProvider: StorageEndpointProvider,
+    storageEndpointProvider: StorageEndpointProvider<Data, Op, T>,
     crdt: CrdtModel<Data, Op, T>,
     private val scheduler: Scheduler,
     private val time: Time,
@@ -64,7 +63,7 @@ class StorageProxy<Data : CrdtData, Op : CrdtOperationAtTime, T>(
     private val crdt: CrdtModel<Data, Op, T>
         get() = _crdt ?: throw IllegalStateException("StorageProxy closed")
 
-    val storageKey = storeOptions.storageKey
+    val storageKey = storageEndpointProvider.storageKey
 
     /**
      * If you need to interact with the data managed by this [StorageProxy], and you're not a
@@ -77,8 +76,7 @@ class StorageProxy<Data : CrdtData, Op : CrdtOperationAtTime, T>(
     private val log = TaggedLog { "StorageProxy" }
     private val handleCallbacks = atomic(HandleCallbacks<T>())
     private val stateHolder = atomic(StateHolder<T>(ProxyState.NO_SYNC))
-    private val store: StorageEndpoint<Data, Op, T> = storeEndpointProvider.createStorageEndpoint(
-        storeOptions,
+    private val store: StorageEndpoint<Data, Op, T> = storageEndpointProvider.create(
         ProxyCallback(::onMessage)
     )
 

--- a/java/arcs/core/storage/StoreManager.kt
+++ b/java/arcs/core/storage/StoreManager.kt
@@ -70,7 +70,7 @@ class StoreManager(
  * [EntityHandleManager].
  */
 fun StoreManager.asStoreEndpointProvider() = object : StorageEndpointProvider {
-    override fun <Data : CrdtData, Op : CrdtOperationAtTime, ConsumerData> getStorageEndpoint(
+    override fun <Data : CrdtData, Op : CrdtOperationAtTime, ConsumerData> createStorageEndpoint(
         storeOptions: StoreOptions,
         callback: ProxyCallback<Data, Op, ConsumerData>
     ): StorageEndpoint<Data, Op, ConsumerData> {

--- a/java/arcs/core/storage/StoreManager.kt
+++ b/java/arcs/core/storage/StoreManager.kt
@@ -13,7 +13,6 @@ package arcs.core.storage
 import arcs.core.crdt.CrdtData
 import arcs.core.crdt.CrdtOperationAtTime
 import arcs.core.util.guardedBy
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
@@ -58,35 +57,6 @@ class StoreManager(
             }
         }.forEach {
             it.close()
-        }
-    }
-}
-
-/**
- * This is a temporary facade that adapts the provided [StoreManager] to be a
- * [StorageEndpointProvider], with the goal of reducing the scope of change in a single PR.
- *
- * Eventually, we will remove this in favor of a [StorageEndpointProvider] passed directly to
- * [EntityHandleManager].
- */
-fun StoreManager.asStoreEndpointProvider() = object : StorageEndpointProvider {
-    override fun <Data : CrdtData, Op : CrdtOperationAtTime, ConsumerData> createStorageEndpoint(
-        storeOptions: StoreOptions,
-        callback: ProxyCallback<Data, Op, ConsumerData>
-    ): StorageEndpoint<Data, Op, ConsumerData> {
-        val store = runBlocking {
-            get<Data, Op, ConsumerData>(storeOptions)
-        }
-
-        return object : StorageEndpoint<Data, Op, ConsumerData> {
-            private val id = store.on(callback)
-            override suspend fun idle() = store.idle()
-
-            override suspend fun onProxyMessage(
-                message: ProxyMessage<Data, Op, ConsumerData>
-            ) = store.onProxyMessage(message.withId(id))
-
-            override fun close() = store.off(id)
         }
     }
 }

--- a/java/arcs/core/storage/api/BUILD
+++ b/java/arcs/core/storage/api/BUILD
@@ -19,5 +19,6 @@ arcs_kt_library(
         "//java/arcs/core/storage/driver",
         "//java/arcs/core/storage/keys",
         "//java/arcs/core/storage/referencemode",
+        "//java/arcs/core/type",
     ],
 )

--- a/javatests/arcs/core/storage/StorageProxyTest.kt
+++ b/javatests/arcs/core/storage/StorageProxyTest.kt
@@ -66,7 +66,9 @@ class StorageProxyTest {
     private lateinit var fakeStoreEndpoint: StoreEndpointFake<CrdtData, CrdtOperationAtTime, String>
 
     @Mock
-    private lateinit var mockStorageEndpointProvider: StorageEndpointProvider
+    private lateinit var mockStorageEndpointProvider:
+        StorageEndpointProvider<CrdtData, CrdtOperationAtTime, String>
+
     @Mock
     private lateinit var mockCrdtOperation: CrdtOperationAtTime
     @Mock
@@ -90,10 +92,7 @@ class StorageProxyTest {
         scheduler = Scheduler(Executors.newSingleThreadExecutor().asCoroutineDispatcher() + Job())
         MockitoAnnotations.initMocks(this)
         fakeStoreEndpoint = StoreEndpointFake()
-        whenever(
-            mockStorageEndpointProvider
-                .createStorageEndpoint<CrdtData, CrdtOperationAtTime, String>(any(), any())
-        ).thenReturn(fakeStoreEndpoint)
+        whenever(mockStorageEndpointProvider.create(any())).thenReturn(fakeStoreEndpoint)
         setupMockModel()
         whenever(mockCrdtOperation.clock).thenReturn(VersionMap())
     }
@@ -112,7 +111,6 @@ class StorageProxyTest {
     }
 
     private fun mockProxy() = StorageProxy(
-        StoreOptions(mockStorageKey, mockType),
         mockStorageEndpointProvider,
         mockCrdtModel,
         scheduler,
@@ -751,11 +749,8 @@ class StorageProxyTest {
                 }
             }
 
+        whenever(mockStorageEndpointProvider.storageKey).thenReturn(volatileStorageKey)
         val proxy = StorageProxy(
-            StoreOptions(
-                volatileStorageKey,
-                mockType
-            ),
             mockStorageEndpointProvider,
             mockCrdtModel,
             scheduler,
@@ -811,12 +806,9 @@ class StorageProxyTest {
         val dbReferenceModeStorageKey =
             ReferenceModeStorageKey(dbBackingStorageKey, dbStorageKey)
 
+        whenever(mockStorageEndpointProvider.storageKey).thenReturn(dbReferenceModeStorageKey)
         val proxy =
             StorageProxy(
-                StoreOptions(
-                    dbReferenceModeStorageKey,
-                    mockType
-                ),
                 mockStorageEndpointProvider,
                 mockCrdtModel,
                 scheduler,

--- a/javatests/arcs/core/storage/StorageProxyTest.kt
+++ b/javatests/arcs/core/storage/StorageProxyTest.kt
@@ -92,7 +92,7 @@ class StorageProxyTest {
         fakeStoreEndpoint = StoreEndpointFake()
         whenever(
             mockStorageEndpointProvider
-                .getStorageEndpoint<CrdtData, CrdtOperationAtTime, String>(any(), any())
+                .createStorageEndpoint<CrdtData, CrdtOperationAtTime, String>(any(), any())
         ).thenReturn(fakeStoreEndpoint)
         setupMockModel()
         whenever(mockCrdtOperation.clock).thenReturn(VersionMap())

--- a/javatests/arcs/core/storage/StoreEndpointFake.kt
+++ b/javatests/arcs/core/storage/StoreEndpointFake.kt
@@ -14,7 +14,7 @@ import kotlinx.coroutines.sync.withLock
  */
 @Suppress("EXPERIMENTAL_API_USAGE")
 class StoreEndpointFake<Data : CrdtData, Op : CrdtOperation, T> :
-    StorageCommunicationEndpoint<Data, Op, T> {
+    StorageEndpoint<Data, Op, T> {
     private val log = TaggedLog { "StoreEndpointFake" }
     private var proxyMessages = emptyList<ProxyMessage<Data, Op, T>>()
     private val targetMutex = Mutex()


### PR DESCRIPTION
    The `StorageEndpointManager` interface serves out
    `StorageEndpointProviders`, which could be thin wrappers around
    `ActiveStores`, but could also be something that communicates over
    process or network boundaries to something else that's managing stores
    (for example, an Android service).
    
    This helps us to build a distinction between a `Store` and a
    `StorageEndpoint`.
    
    This PR also removes the storage endpoint generation code from
    `ActiveStore` and puts it in the provider implementation, to further
    cement the different between a `Store` and ` StorageEndpoint`.
    
    In this PR, we draw a boundary for changes in `EntityHandleManager`, by
    providing an adapter method that converts a `StoreManager` into a
    `StorageEndpointProvider.
    
    Follow-up work will remove `StoreManager` and `ActivationFactory`
    completely, instead providing concrete `StorageEndpointProvider`
    implementations for Android and vanilla JVM.
