### PR TITLE
Fix type checking for ordered lists of schemas.

### DIFF
--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -644,7 +644,7 @@ ${e.message}
                 } else {
                   // Validate that the specified or inferred type matches the schema.
                   const externalType = schema.fields[name];
-                  if (externalType && !Schema.isAtLeastAsSpecificAs(externalType, type)) {
+                  if (externalType && !Schema.fieldTypeIsAtLeastAsSpecificAs(externalType, type)) {
                     throw new ManifestError(node.location, `Type of '${name}' does not match schema (${type} vs ${externalType})`);
                   }
                 }

--- a/src/runtime/schema.ts
+++ b/src/runtime/schema.ts
@@ -126,13 +126,17 @@ export class Schema {
     return Schema._typeString(fieldType1) === Schema._typeString(fieldType2);
   }
 
-  static isAtLeastAsSpecificAs(fieldType1, fieldType2): boolean {
+  // TODO(shans): output AtLeastAsSpecific here. This is necessary to support
+  // refinements on nested structures and references.
+  static fieldTypeIsAtLeastAsSpecificAs(fieldType1, fieldType2): boolean {
     assert(fieldType1.kind === fieldType2.kind);
     switch (fieldType1.kind) {
       case 'schema-reference':
+      case 'schema-nested':
         return fieldType1.schema.model.isAtLeastAsSpecificAs(fieldType2.schema.model);
       case 'schema-collection':
-        return Schema.isAtLeastAsSpecificAs(fieldType1.schema, fieldType2.schema);
+      case 'schema-ordered-list':
+        return Schema.fieldTypeIsAtLeastAsSpecificAs(fieldType1.schema, fieldType2.schema);
       // TODO(mmandlis): implement for other schema kinds.
       default:
         return Schema.typesEqual(fieldType1, fieldType2);
@@ -225,23 +229,7 @@ export class Schema {
       if (fields[name] == undefined) {
         return AtLeastAsSpecific.NO;
       }
-      if (type.kind && ['schema-nested', 'schema-reference'].includes(type.kind)) {
-        if (!(fields[name].kind && fields[name].kind === type.kind)) {
-          return AtLeastAsSpecific.NO;
-        }
-        const subResult = fields[name].schema.model.entitySchema.isEquivalentOrMoreSpecific(
-            type.schema.model.entitySchema);
-        switch (subResult) {
-          case AtLeastAsSpecific.NO:
-            return AtLeastAsSpecific.NO;
-          case AtLeastAsSpecific.UNKNOWN:
-            best = AtLeastAsSpecific.UNKNOWN;
-            break;
-          default:
-            break;
-        }
-      }
-      else if (!Schema.isAtLeastAsSpecificAs(fields[name], type)) {
+      if (!Schema.fieldTypeIsAtLeastAsSpecificAs(fields[name], type)) {
         return AtLeastAsSpecific.NO;
       }
       const fieldRes = Refinement.isAtLeastAsSpecificAs(fields[name].refinement, type.refinement);


### PR DESCRIPTION
We weren't recursing into checking whether lists of inline schema types
were compatible at a read/write level, and instead were just using
straight equality.

This CL also tidies up a previous fix (same issue but for direct
inline references) to keep everything consistent.