### PR TITLE
Removed ActiveMuxer

### DIFF
--- a/src/runtime/storage/storage.ts
+++ b/src/runtime/storage/storage.ts
@@ -22,9 +22,9 @@ import {SerializedReference, Reference} from '../reference.js';
 import {StoreInfo, AbstractStore, isMuxEntityStore} from './abstract-store.js';
 import {StorageKey} from './storage-key.js';
 import {Exists} from './drivers/driver.js';
-import {ActiveMuxer, isActiveMuxer} from './store-interface.js';
 import {EntityHandleFactory} from './entity-handle-factory.js';
 import {StorageProxyMuxer} from './storage-proxy-muxer.js';
+import {DirectStoreMuxer} from './direct-store-muxer.js';
 
 type HandleOptions = {
   type?: Type;
@@ -73,7 +73,7 @@ export type SingletonInterfaceHandle = SingletonHandle<ParticleSpec>;
 export type MuxEntityType = MuxType<EntityType>;
 export type CRDTMuxEntity = CRDTEntityTypeRecord<Identified, Identified>;
 export type MuxEntityStore = StoreMuxer<CRDTMuxEntity>;
-export type ActiveMuxEntityStore = ActiveMuxer<CRDTMuxEntity>;
+export type ActiveMuxEntityStore = ActiveStore<CRDTMuxEntity>;
 export type MuxEntityHandle = EntityHandleFactory<CRDTMuxEntity>;
 
 export type ToStore<T extends Type>
@@ -176,7 +176,7 @@ export function handleForActiveStore<T extends CRDTTypeRecord>(
   const canWrite = (options.canWrite != undefined) ? options.canWrite : true;
   const name = options.name || null;
   const generateID = arc.generateID ? () => arc.generateID().toString() : () => '';
-  if (isActiveMuxer(store)) {
+  if (store instanceof DirectStoreMuxer) {
     const proxyMuxer = new StorageProxyMuxer<CRDTMuxEntity>(store, type, storageKey);
     return new EntityHandleFactory(proxyMuxer) as ToHandle<T>;
   } else {

--- a/src/runtime/storage/store-interface.ts
+++ b/src/runtime/storage/store-interface.ts
@@ -70,10 +70,6 @@ export interface StorageCommunicationEndpointProvider<T extends CRDTTypeRecord> 
   getStorageEndpoint(storageProxy: StorageProxy<T> | StorageProxyMuxer<T>): StorageCommunicationEndpoint<T>;
 }
 
-export function isActiveMuxer(activeStore: ActiveStore<CRDTTypeRecord>): activeStore is ActiveMuxer<CRDTMuxEntity> {
-  return (activeStore.baseStore.type.isMux);
-}
-
 // A representation of an active store. Subclasses of this class provide specific
 // behaviour as controlled by the provided StorageMode.
 export abstract class ActiveStore<T extends CRDTTypeRecord>
@@ -154,26 +150,5 @@ export abstract class ActiveStore<T extends CRDTTypeRecord>
         };
       }
     };
-  }
-}
-export abstract class ActiveMuxer<T extends CRDTTypeRecord> extends ActiveStore<T> {
-  abstract readonly stores: Dictionary<StoreRecord<T>>;
-
-  abstract getLocalModel(muxId: string, id: number): CRDTModel<T>;
-
-  async cloneFrom(store: ActiveStore<T>): Promise<void> {
-    assert(store instanceof ActiveMuxer);
-    const activeMuxer : ActiveMuxer<T> = store as unknown as ActiveMuxer<T>;
-    for (const muxId of Object.keys(activeMuxer.stores)) {
-      await this.onProxyMessage({
-        type: ProxyMessageType.ModelUpdate,
-        model: activeMuxer.getLocalModel(muxId, 0).getData(),
-        id: 0
-      });
-    }
-  }
-
-  async serializeContents(): Promise<T['data']> {
-    throw new Error('Active Muxer contents can not be serialized.');
   }
 }

--- a/src/runtime/storage/store.ts
+++ b/src/runtime/storage/store.ts
@@ -11,7 +11,7 @@
 import {CRDTModel, CRDTTypeRecord} from '../../crdt/lib-crdt.js';
 import {Exists} from './drivers/driver.js';
 import {StorageKey} from './storage-key.js';
-import {StoreInterface, StorageMode, ActiveStore, ProxyMessageType, ProxyMessage, ProxyCallback, StorageCommunicationEndpoint, StorageCommunicationEndpointProvider, StoreConstructor, ActiveMuxer} from './store-interface.js';
+import {StoreInterface, StorageMode, ActiveStore, ProxyMessageType, ProxyMessage, ProxyCallback, StorageCommunicationEndpoint, StorageCommunicationEndpointProvider, StoreConstructor} from './store-interface.js';
 import {AbstractStore, StoreInfo} from './abstract-store.js';
 import {ReferenceModeStorageKey} from './reference-mode-storage-key.js';
 import {CRDTTypeRecordToType, CRDTMuxEntity} from './storage.js';
@@ -118,7 +118,7 @@ export class StoreMuxer<T extends CRDTMuxEntity> extends AbstractStore implement
   // reconstituting an ActiveStore.
   model: T['data'] | null;
 
-  private activeStore: ActiveMuxer<T> | null;
+  private activeStore: ActiveStore<T> | null;
 
   // This map creates a cyclic dependency, so it is inject from store-constructors
   // instead of being defined here.
@@ -141,7 +141,7 @@ export class StoreMuxer<T extends CRDTMuxEntity> extends AbstractStore implement
     return this.parsedVersionToken;
   }
 
-  async activate(): Promise<ActiveMuxer<T>> {
+  async activate(): Promise<ActiveStore<T>> {
     if (this.activeStore) {
       return this.activeStore;
     }
@@ -161,7 +161,7 @@ export class StoreMuxer<T extends CRDTMuxEntity> extends AbstractStore implement
       mode: this.mode,
       baseStore: this,
       versionToken: this.parsedVersionToken
-    }) as ActiveMuxer<T>;
+    }) as ActiveStore<T>;
     this.exists = Exists.ShouldExist;
     this.activeStore = activeStore;
     return activeStore;

--- a/src/runtime/tests/arc-test.ts
+++ b/src/runtime/tests/arc-test.ts
@@ -23,7 +23,7 @@ import {RecipeResolver} from '../recipe-resolver.js';
 import {DriverFactory} from '../storage/drivers/driver-factory.js';
 import {VolatileStorageKey, VolatileDriver, VolatileStorageKeyFactory} from '../storage/drivers/volatile.js';
 import {StorageKey} from '../storage/storage-key.js';
-import {Store, ActiveStore} from '../storage/store.js';
+import {Store} from '../storage/store.js';
 import {ReferenceModeStore} from '../storage/reference-mode-store.js';
 import {DirectStoreMuxer} from '../storage/direct-store-muxer.js';
 import {CRDTTypeRecord} from '../../crdt/lib-crdt.js';
@@ -35,7 +35,6 @@ import {ReferenceModeStorageKey} from '../storage/reference-mode-storage-key.js'
 import {TestVolatileMemoryProvider} from '../testing/test-volatile-memory-provider.js';
 import {SingletonEntityStore, CollectionEntityStore, handleForStore} from '../storage/storage.js';
 import {Capabilities, Ttl, Queryable, Persistence} from '../capabilities.js';
-import {isActiveMuxer} from '../storage/store-interface.js';
 import {StorageServiceImpl} from '../storage/storage-service.js';
 
 async function setup(storageKeyPrefix:  (arcId: ArcId) => StorageKey) {
@@ -1107,8 +1106,8 @@ describe('Arc storage migration', () => {
     };
 
     const things0Store = await getStoreByConnectionName('things0');
-    if (isActiveMuxer(things0Store)) {
-      assert.fail('things0 store can not be an active muxer');
+    if (things0Store instanceof DirectStoreMuxer) {
+      assert.fail('things0 store can not be a direct store muxer');
     }
     const helloThing0 = await getStoreValue(await things0Store.serializeContents(), 0, 2);
     assert.equal(helloThing0.rawData.name, 'hello');
@@ -1124,15 +1123,15 @@ describe('Arc storage migration', () => {
     assert.isTrue(worldThing0.expirationTimestamp - helloThing0.expirationTimestamp >= 1000);
 
     const things1Store = await getStoreByConnectionName('things1');
-    if (isActiveMuxer(things1Store)) {
-      assert.fail('things1 store can not be an active muxer');
+    if (things1Store instanceof DirectStoreMuxer) {
+      assert.fail('things1 store can not be a direct store muxer');
     }
     const fooThing1 = await getStoreValue(await things1Store.serializeContents(), 0, 1);
     assert.equal(fooThing1.rawData.name, 'foo');
 
     const things2Store = await getStoreByConnectionName('things2');
-    if (isActiveMuxer(things2Store)) {
-      assert.fail('things2 store can not be an active muxer');
+    if (things2Store instanceof DirectStoreMuxer) {
+      assert.fail('things2 store can not be a direct store muxer');
     }
     const barThing2 = await getStoreValue(await things2Store.serializeContents(), 0, 1);
     assert.equal(barThing2.rawData.name, 'bar');


### PR DESCRIPTION
This is the second step to redesigning storage class relationships in order for the DSM to extend an active store. It involves removing ActiveMuxer and making DirectStoreMuxer extend ActiveStore.