### PR TITLE
Lint warning for .only left in tests

### DIFF
--- a/tools/local-presubmit
+++ b/tools/local-presubmit
@@ -12,13 +12,19 @@ source $(dirname $0)/logging.sh
 # See https://github.com/PolymerLabs/arcs/issues/4550
 BAZELRC_OPTS=$1
 
+# Allows commands to state that the presubmit has failed but continue so that other checks
+# can be completed, to show all errors.
+FAILED=0
+
 cd $ROOT
 status "Testing all of the things."
 
 set -x
 
+./tools/sigh lint || FAILED=1
 ./tools/sigh webpack
 ./tools/bazelisk ${BAZELRC_OPTS} test --jvmopt="-DArcsStrictMode.strictHandles=true"  //java/... //javatests/... //src/... //particles/...
 ./tools/sigh testShells
-./tools/sigh lint
 ./tools/sigh test --all
+
+exit $FAILED

--- a/tools/sigh.ts
+++ b/tools/sigh.ts
@@ -524,7 +524,9 @@ function lint(args: string[]): boolean {
     string: ['format']
   });
 
-  if (!saneSpawnSync('git', ['--no-pager', 'grep', '"\\(describe\\.only(\\|it\\.only(\\)"', '*.ts'], {logCmd: true})) {
+  const result = saneSpawnSyncWithOutput('git', ['--no-pager', 'grep', '"\\(describe\\.only(\\|it\\.only(\\)"', '*.ts'], {logCmd: true});
+  if (result.stdout !== '') {
+    console.error(result.stdout);
     console.error('Please do not commit tests using .only (as it disables all other tests).');
     return false;
   }

--- a/tools/sigh.ts
+++ b/tools/sigh.ts
@@ -524,6 +524,11 @@ function lint(args: string[]): boolean {
     string: ['format']
   });
 
+  if (!saneSpawnSync('git', ['--no-pager', 'grep', '"\\(describe\\.only(\\|it\\.only(\\)"', '*.ts'], {logCmd: true})) {
+    console.error('Please do not commit tests using .only (as it disables all other tests).');
+    return false;
+  }
+
   const jsSources = [...findProjectFiles(process.cwd(), srcExclude, /\.[jt]s$/)];
   const cli = new CLIEngine({
     useEsLintRc: false,


### PR DESCRIPTION
This warns developers if on `local-presubmit` when `.only` is left in the typescript code.
This is to avoid accidentally disabling tests when testing code (I'd like to do a similar thing for `.skip` but there are good reasons to skip some tests, so it'd likely be a job of keeping a skip list centrally and checking if they changed without the secondary file being updated which seems less dev friendly).