### PR TITLE
Update PolicyVerifier to use the new `@policy` recipe annotation.

### DIFF
--- a/java/arcs/core/analysis/PolicyVerifier.kt
+++ b/java/arcs/core/analysis/PolicyVerifier.kt
@@ -14,8 +14,6 @@ package arcs.core.analysis
 import arcs.core.data.AccessPath
 import arcs.core.data.Check
 import arcs.core.data.Claim
-import arcs.core.data.InformationFlowLabel.Predicate
-import arcs.core.data.ParticleSpec
 import arcs.core.data.Recipe
 import arcs.core.policy.Policy
 import arcs.core.policy.PolicyConstraints
@@ -30,7 +28,9 @@ class PolicyVerifier(val options: PolicyOptions) {
      *
      * @throws [PolicyViolation] if policy is violated by the recipe.
      */
-    public fun verifyPolicy(recipe: Recipe, policy: Policy): Boolean {
+    fun verifyPolicy(recipe: Recipe, policy: Policy): Boolean {
+        checkPolicyName(recipe, policy)
+
         // TODO(b/162083814): This should be moved to the compilation step.
         val policyConstraints = translatePolicy(policy, options)
         val graph = RecipeGraph(recipe)
@@ -90,51 +90,28 @@ class PolicyVerifier(val options: PolicyOptions) {
     }
 
     /**
-     * Returns the egress checks.
-     *
-     * @throws [PolicyViolation] if recipe violates egress requirements.
-     */
-    private fun getEgressChecks(
-        policy: Policy,
-        recipe: Recipe,
-        egressCheck: Predicate
-    ): Map<ParticleSpec, List<Check>> {
-        // Check that egress particles are compliant with policy.
-        val egressParticles = recipe.particles.filterNot { it.spec.isolated }
-        checkEgressParticles(policy, egressParticles)
-
-        // Create a check for each handle connection needs in the egress particles.
-        return egressParticles.associate { particle ->
-            val checks = particle.spec.connections.values
-                .filter {
-                    // TODO(b/157605232): Also check canQuery -- but first, need to add QUERY to
-                    // the Direction enum in the manifest proto.
-                    it.direction.canRead
-                }
-                .map { connectionSpec ->
-                    Check.Assert(AccessPath(particle, connectionSpec), egressCheck)
-                }
-            particle.spec to checks
-        }
-    }
-
-    /**
      * Verifies that the given egress particle nodes match the policy. The only egress particles
      * allowed to be used with a policy are in [options.policyEgresses] map.
      */
     private fun checkEgressParticles(policy: Policy, egressParticles: List<Recipe.Particle>) {
-        val allowedEgresses = options.policyEgresses.getOrElse(policy.name) {
-            throw PolicyViolation.PolicyHasNoEgressParticles(policy)
-        }
         val invalidEgressParticles = egressParticles
             .map { it.spec }
-            .filterNot { allowedEgresses.contains(it.name) }
+            .filter { it.egress && it.egressType != policy.egressType }
         if (invalidEgressParticles.isNotEmpty()) {
-            throw PolicyViolation.InvalidEgressParticles(
+            throw PolicyViolation.InvalidEgressTypeForParticles(
                 policy = policy,
-                allowedEgresses = allowedEgresses,
-                invalidEgresses = invalidEgressParticles.map { it.name }
+                invalidEgresses = invalidEgressParticles.associate { it.name to it.egressType }
             )
+        }
+    }
+
+    /** Checks that the given [policy] matches the recipe's `@policy` annotation. */
+    private fun checkPolicyName(recipe: Recipe, policy: Policy) {
+        val policyName = recipe.policyName
+        if (policyName == null) {
+            throw PolicyViolation.MissingPolicyAnnotation(recipe, policy)
+        } else if (policyName != policy.name) {
+            throw PolicyViolation.MismatchedPolicyName(policyName, policy)
         }
     }
 }

--- a/java/arcs/core/analysis/PolicyVerifier.kt
+++ b/java/arcs/core/analysis/PolicyVerifier.kt
@@ -90,8 +90,8 @@ class PolicyVerifier(val options: PolicyOptions) {
     }
 
     /**
-     * Verifies that the given egress particle nodes match the policy. The only egress particles
-     * allowed to be used with a policy are in [options.policyEgresses] map.
+     * Verifies that the given egress particle nodes match the policy. The egress type of the
+     * particles must match the egress type of the policy.
      */
     private fun checkEgressParticles(policy: Policy, egressParticles: List<Recipe.Particle>) {
         val invalidEgressParticles = egressParticles
@@ -100,7 +100,7 @@ class PolicyVerifier(val options: PolicyOptions) {
         if (invalidEgressParticles.isNotEmpty()) {
             throw PolicyViolation.InvalidEgressTypeForParticles(
                 policy = policy,
-                invalidEgresses = invalidEgressParticles.associate { it.name to it.egressType }
+                invalidEgressParticles = invalidEgressParticles
             )
         }
     }

--- a/java/arcs/core/data/Recipe.kt
+++ b/java/arcs/core/data/Recipe.kt
@@ -23,7 +23,7 @@ data class Recipe(
 ) {
     /** The name of the policy with which this recipe must comply. */
     val policyName: String?
-        get() = annotations.find { it.name === "policy" }?.getStringParam("name")
+        get() = annotations.find { it.name == "policy" }?.getStringParam("name")
 
     /** Representation of a particle in a recipe. */
     data class Particle(

--- a/java/arcs/core/policy/PolicyConstraints.kt
+++ b/java/arcs/core/policy/PolicyConstraints.kt
@@ -5,6 +5,7 @@ import arcs.core.data.Check
 import arcs.core.data.Claim
 import arcs.core.data.InformationFlowLabel.Predicate
 import arcs.core.data.InformationFlowLabel.SemanticTag
+import arcs.core.data.ParticleSpec
 import arcs.core.data.Recipe
 import arcs.core.data.StoreId
 
@@ -135,15 +136,12 @@ sealed class PolicyViolation(val policy: Policy, message: String) : Exception(
     /** Thrown when egress particles were found in the recipe that are not allowed by policy. */
     class InvalidEgressTypeForParticles(
         policy: Policy,
-        /** Maps from particle name to egress type. */
-        val invalidEgresses: Map<String, String?>
+        val invalidEgressParticles: List<ParticleSpec>
     ) : PolicyViolation(
         policy,
-        "Invalid egress types found for particles: ${invalidEgresses.toSortedMap().entries
-            .joinToString(prefix = "{", postfix = "}") { (name, egressType) ->
-                "$name ($egressType)"
-            }
-        }. Egress type allowed by policy: ${policy.egressType}."
+        "Invalid egress types found for particles: " +
+            invalidEgressParticles.namesAndEgressTypes() +
+            ". Egress type allowed by policy: ${policy.egressType}."
     )
 
     /** Thrown when there is no store associated with schema. */
@@ -172,4 +170,13 @@ sealed class PolicyViolation(val policy: Policy, message: String) : Exception(
         policy,
         "Recipe elected a policy named '$electedPolicyName'."
     )
+
+
+}
+
+/** Converts a list of particles into their names and egress types, as a string. */
+private fun List<ParticleSpec>.namesAndEgressTypes(): String {
+    return sortedBy { it.name }.joinToString(prefix = "{", postfix = "}") {
+        "${it.name} (${it.egressType})"
+    }
 }

--- a/java/arcs/core/policy/PolicyConstraints.kt
+++ b/java/arcs/core/policy/PolicyConstraints.kt
@@ -170,8 +170,6 @@ sealed class PolicyViolation(val policy: Policy, message: String) : Exception(
         policy,
         "Recipe elected a policy named '$electedPolicyName'."
     )
-
-
 }
 
 /** Converts a list of particles into their names and egress types, as a string. */

--- a/java/arcs/core/policy/PolicyOptions.kt
+++ b/java/arcs/core/policy/PolicyOptions.kt
@@ -10,12 +10,5 @@ data class PolicyOptions(
      *
      * Temporary measure until we have a proper way to designate these stores.
      */
-    val storeMap: Map<StoreId, String>,
-
-    /**
-     * Maps policy with the allowed egress particles.
-     *
-     * Temporary measure until we have a proper way to designate egress particles.
-     */
-    val policyEgresses: Map<String, List<String>>
+    val storeMap: Map<StoreId, String>
 )

--- a/javatests/arcs/core/analysis/BUILD
+++ b/javatests/arcs/core/analysis/BUILD
@@ -20,6 +20,7 @@ arcs_kt_jvm_test_suite(
         "//java/arcs/core/data:schema_fields",
         "//java/arcs/core/data/proto",
         "//java/arcs/core/data/proto:manifest_java_proto_lite",
+        "//java/arcs/core/data/proto:policy_java_proto_lite",
         "//java/arcs/core/policy",
         "//java/arcs/core/policy/proto",
         "//java/arcs/core/testutil/protoloader",

--- a/javatests/arcs/core/analysis/PolicyVerifierTest.kt
+++ b/javatests/arcs/core/analysis/PolicyVerifierTest.kt
@@ -14,12 +14,11 @@ import org.junit.runners.JUnit4
 @RunWith(JUnit4::class)
 class PolicyVerifierTest {
     // Test context.
-    val storeMap = mapOf("action" to "Action", "selection" to "Selection")
-    val egressMap = mapOf("TestPolicy" to listOf("Egress_TestPolicy", "LoggingEgress_TestPolicy"))
-    val manifestProto = loadManifestBinaryProto(getManifestProtoBinPath("policy-test"))
-    val recipes = manifestProto.decodeRecipes().associateBy { it.name!! }
-    val policy = manifestProto.policiesList.map { it.decode() }.single()
-    val verifier = PolicyVerifier(PolicyOptions(storeMap, egressMap))
+    private val storeMap = mapOf("action" to "Action", "selection" to "Selection")
+    private val manifestProto = loadManifestBinaryProto(getManifestProtoBinPath("policy-test"))
+    private val recipes = manifestProto.decodeRecipes().associateBy { it.name!! }
+    private val policy = manifestProto.policiesList.single { it.name == "TestPolicy" }.decode()
+    private val verifier = PolicyVerifier(PolicyOptions(storeMap))
 
     @Test
     fun egressingUnrestrictedFieldsIsAllowed() {
@@ -83,38 +82,36 @@ class PolicyVerifierTest {
 
     @Test
     fun invalidEgressesAreDisallowed() {
-        assertFailsWith<PolicyViolation.InvalidEgressParticles> {
+        assertFailsWith<PolicyViolation.InvalidEgressTypeForParticles> {
             verifier.verifyPolicy(
                 recipes.getValue("InvalidEgressParticles"),
                 policy
             )
         }.also {
             assertThat(it).hasMessageThat().contains(
-                "Invalid egress particles found: " +
-                "{Egress_AnotherPolicy, Egress_YetAnotherPolicy}, " +
-                "allowed egress particles: {Egress_TestPolicy, LoggingEgress_TestPolicy}"
+                "Policy TestPolicy violated: Invalid egress types found for particles: " +
+                    "{ParticleWithMissingEgressType (null), " +
+                    "ParticleWithWrongEgressType (SomeOtherEgress)}. " +
+                    "Egress type allowed by policy: TestEgressType."
             )
         }
     }
 
     @Test
-    fun policyWithNoEgressIsDetected() {
-        val testVerifier = PolicyVerifier(PolicyOptions(storeMap, emptyMap()))
-        assertFailsWith<PolicyViolation.PolicyHasNoEgressParticles> {
+    fun policyWithNoEgressIsAllowed() {
+        val testVerifier = PolicyVerifier(PolicyOptions(storeMap))
+        assertThat(
             testVerifier.verifyPolicy(
-                recipes.getValue("InvalidEgressParticles"),
+                recipes.getValue("NoEgressParticles"),
                 policy
             )
-        }.also {
-            assertThat(it).hasMessageThat()
-                .contains("No egress particles specified for policy")
-        }
+        ).isTrue()
     }
 
     @Test
     fun missingStoreIsDetected() {
         val incompleteStoreMap = mapOf("action" to "Action")
-        val testVerifier = PolicyVerifier(PolicyOptions(incompleteStoreMap, egressMap))
+        val testVerifier = PolicyVerifier(PolicyOptions(incompleteStoreMap))
         assertFailsWith<PolicyViolation.NoStoreForPolicyTarget> {
             testVerifier.verifyPolicy(
                 recipes.getValue("InvalidEgressParticles"),
@@ -126,14 +123,22 @@ class PolicyVerifierTest {
         }
     }
 
+    @Test
+    fun missingPolicyAnnotationIsDisallowed() {
+        assertFailsWith<PolicyViolation.MissingPolicyAnnotation> {
+            verifier.verifyPolicy(recipes.getValue("MissingPolicyAnnotation"), policy)
+        }
+    }
+
+    @Test
+    fun mismatchedPolicyNameIsDisallowed() {
+        assertFailsWith<PolicyViolation.MismatchedPolicyName> {
+            verifier.verifyPolicy(recipes.getValue("DifferentPolicyName"), policy)
+        }
+    }
+
     /** Returns the path for the manifest proto binary file for the test. */
     private fun getManifestProtoBinPath(test: String): String {
         return "javatests/arcs/core/analysis/testdata/$test.pb.bin"
-    }
-
-    companion object {
-        val INGRESS_PREFIX = "// #Ingress:"
-        val FAIL_PREFIX = "// #Fail:"
-        val OK_PREFIX = "// #OK"
     }
 }

--- a/javatests/arcs/core/analysis/testdata/policy_test.arcs
+++ b/javatests/arcs/core/analysis/testdata/policy_test.arcs
@@ -14,7 +14,7 @@ schema ActionAtSelection
   actionDetails: Text
 
 @intendedPurpose('Test the implementation of policy verification.')
-@egressType('FederatedAggregation')
+@egressType('TestEgressType')
 policy TestPolicy {
 
   from Action access {
@@ -56,17 +56,33 @@ particle ActionTimestampToDays
   claim output.id derives from input.id
   claim output.action derives from input.action
 
-particle Egress_TestPolicy
+@egress('TestEgressType')
+particle TestEgressParticle
   joinData: reads [~a]
 
-particle LoggingEgress_TestPolicy
+@egress('TestEgressType')
+particle AnotherTestEgressParticle
   joinData: reads [~a]
 
-particle Egress_AnotherPolicy
+@egress('SomeOtherEgress')
+particle ParticleWithWrongEgressType
   joinData: reads [~a]
 
-particle Egress_YetAnotherPolicy
+particle ParticleWithMissingEgressType
   joinData: reads [~a]
+
+//-----------------------------------------------------------
+// Complying by not having any egress particles.
+//-----------------------------------------------------------
+@isolated
+particle SomeIsolatedParticle
+  input: reads [~a]
+
+@policy('TestPolicy')
+recipe NoEgressParticles
+  input: create 'input'
+  SomeIsolatedParticle
+    input: input
 
 //-----------------------------------------------------------
 // Complying by not egressing restricted fields.
@@ -77,6 +93,7 @@ particle JoinActionSelection_EgressUnrestrictedFields
   selection: reads [Selection {id, selection}]
   joinData: writes [ActionAtSelection {id, actionDetails}]
 
+@policy('TestPolicy')
 recipe EgressUnrestrictedFields
   action: create 'action'
   selection: create 'selection'
@@ -85,10 +102,11 @@ recipe EgressUnrestrictedFields
     action: action
     selection: selection
     joinData: joinData
-  Egress_TestPolicy
+  TestEgressParticle
     joinData: joinData
 
 // Recipe that complies with policy even with multiple egresses.
+@policy('TestPolicy')
 recipe EgressAndLogUnrestrictedFields
   action: create 'action'
   selection: create 'selection'
@@ -97,9 +115,9 @@ recipe EgressAndLogUnrestrictedFields
     action: action
     selection: selection
     joinData: joinData
-  Egress_TestPolicy
+  TestEgressParticle
     joinData: joinData
-  LoggingEgress_TestPolicy
+  AnotherTestEgressParticle
     joinData: joinData
 
 //-----------------------------------------------------------
@@ -111,6 +129,7 @@ particle JoinActionSelection_EgressRedactedField
   selection: reads [Selection {id, selection}]
   joinData: writes [ActionAtSelection {id, actionDetails}]
 
+@policy('TestPolicy')
 recipe EgressRedactedField
   action: create 'action'
   selection: create 'selection'
@@ -122,7 +141,7 @@ recipe EgressRedactedField
     action: actionRedacted
     selection: selection
     joinData: joinData
-  Egress_TestPolicy
+  TestEgressParticle
     joinData: joinData
 
 //-----------------------------------------------------------------------
@@ -135,6 +154,7 @@ particle JoinActionSelection_EgressRestrictedFields
   selection: reads [Selection {id, selection, sensitiveSelection}]
   joinData: writes [ActionAtSelection {id, actionDetails}]
 
+@policy('TestPolicy')
 recipe AccessRestrictedFieldsNoEgress
   action: create 'action'
   selection: create 'selection'
@@ -156,6 +176,7 @@ particle JoinActionSelection_EgressRestrictedFields
   selection: reads [Selection {id, selection, sensitiveSelection}]
   joinData: writes [ActionAtSelection {id, actionDetails}]
 
+@policy('TestPolicy')
 recipe EgressRestrictedFields
   action: create 'action'
   selection: create 'selection'
@@ -167,7 +188,7 @@ recipe EgressRestrictedFields
     action: actionRedacted
     selection: selection
     joinData: joinData
-  Egress_TestPolicy
+  TestEgressParticle
     joinData: joinData
 
 //-----------------------------------------------------------------------
@@ -180,6 +201,7 @@ particle JoinActionSelection_EgressJoinOnlyField
   selection: reads [Selection {id, selection, sensitiveSelection}]
   joinData: writes [ActionAtSelection {id, actionDetails}]
 
+@policy('TestPolicy')
 recipe EgressJoinOnlyField
   action: create 'action'
   selection: create 'selection'
@@ -191,12 +213,13 @@ recipe EgressJoinOnlyField
     action: actionRedacted
     selection: selection
     joinData: joinData
-  Egress_TestPolicy
+  TestEgressParticle
     joinData: joinData
 
 //-----------------------------------------------------------------------
 // Policy violation by not redacting `timestampInMs` in `Action`.
 //-----------------------------------------------------------------------
+@policy('TestPolicy')
 recipe EgressUnredactedField
   action: create 'action'
   selection: create 'selection'
@@ -205,12 +228,13 @@ recipe EgressUnredactedField
     action: action
     selection: selection
     joinData: joinData
-  Egress_TestPolicy
+  TestEgressParticle
     joinData: joinData
 
 //-----------------------------------------------------------------------
 // Policy violation by having invalid egress particles.
 //-----------------------------------------------------------------------
+@policy('TestPolicy')
 recipe InvalidEgressParticles
   action: create 'action'
   selection: create 'selection'
@@ -219,11 +243,25 @@ recipe InvalidEgressParticles
     action: action
     selection: selection
     joinData: joinData
-  Egress_AnotherPolicy
+  ParticleWithWrongEgressType
     joinData: joinData
-  Egress_YetAnotherPolicy
+  ParticleWithMissingEgressType
     joinData: joinData
-  Egress_TestPolicy
+  TestEgressParticle
     joinData: joinData
-  LoggingEgress_TestPolicy
+  AnotherTestEgressParticle
     joinData: joinData
+
+//-----------------------------------------------------------------------
+// Policy violation by not having an @policy annotation.
+//-----------------------------------------------------------------------
+recipe MissingPolicyAnnotation
+
+//-----------------------------------------------------------------------
+// Policy violation by referring to a different policy.
+//-----------------------------------------------------------------------
+@egressType('Logging')
+policy SomeOtherPolicy {}
+
+@policy('SomeOtherPolicy')
+recipe DifferentPolicyName

--- a/javatests/arcs/core/policy/PolicyConstraintsTest.kt
+++ b/javatests/arcs/core/policy/PolicyConstraintsTest.kt
@@ -152,10 +152,7 @@ class PolicyConstraintsTest {
     companion object {
         private const val BLANK_POLICY_NAME = "BlankPolicy"
 
-        private val EMPTY_OPTIONS = PolicyOptions(
-            storeMap = emptyMap(),
-            policyEgresses = emptyMap()
-        )
+        private val EMPTY_OPTIONS = PolicyOptions(storeMap = emptyMap())
 
         private val BLANK_POLICY = Policy(name = BLANK_POLICY_NAME, egressType = "Logging")
 
@@ -174,13 +171,8 @@ class PolicyConstraintsTest {
             .map { it.decode() }
             .associateBy { it.name }
 
-        private val defaultPolicyEgresses = policies.keys.associateWith { listOf("Egress_$it") }
-
         private fun makePolicyOptions(storeMap: Map<StoreId, String>): PolicyOptions {
-            return PolicyOptions(
-                storeMap = storeMap,
-                policyEgresses = defaultPolicyEgresses
-            )
+            return PolicyOptions(storeMap = storeMap)
         }
     }
 }


### PR DESCRIPTION
This new annotation dictates which policy should apply to the recipe. Trying to use any other policy with the recipe will be a failure.

This also replaces the `PolicyOptions.allowedEgresses` field, which was used to indicate which egress particles are allowed by a policy. Instead, we will allow any egress particle whose egress type matches the egress type specified in the policy.