### PR TITLE
Allow referring to policies from imported .arcs files

### DIFF
--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -1328,7 +1328,7 @@ ${e.message}
 
     const policyName = recipe.policyName;
     if (policyName != null) {
-      const policy = manifest.policies.find(p => p.name === policyName);
+      const policy = manifest.allPolicies.find(p => p.name === policyName);
       if (policy == null) {
         throw new Error(`No policy named '${policyName}' was found in the manifest.`);
       }

--- a/src/runtime/tests/manifest-test.ts
+++ b/src/runtime/tests/manifest-test.ts
@@ -4635,6 +4635,24 @@ recipe
     `), `You must provide a policy name in the @policy annotation.`);
   });
 
+  it('supports importing policies from another file', async () => {
+    const loader = new Loader(null, {
+      '/policy.arcs': `
+        policy MyPolicy {}
+      `,
+      '/recipe.arcs': `
+        import './policy.arcs'
+
+        @policy('MyPolicy')
+        recipe
+          foo: create
+      `,
+    });
+    const manifest = await Manifest.load('/recipe.arcs', loader);
+    const recipe = manifest.recipes[0];
+    assert.strictEqual(recipe.policy.name, 'MyPolicy');
+  });
+
   describe('isolated and egress particles', () => {
     it('particles are egress by default', async () => {
       const manifest = await Manifest.parse(`


### PR DESCRIPTION
Previously the `@policy` annotation would only let you refer to policy definitions from the same file. Now it looks at imported files too.