### PR TITLE
Wrap various calls to sigh_command in new macros in tools.oss.bzl

### DIFF
--- a/src/tests/BUILD
+++ b/src/tests/BUILD
@@ -1,4 +1,4 @@
-load("//third_party/java/arcs/build_defs:build_defs.bzl", "arcs_ts_test")
+load("//third_party/java/arcs/build_defs:arcs_ts_test.bzl", "arcs_ts_test")
 
 arcs_ts_test(
     name = "hotreload-integration-test",

--- a/src/tools/tests/BUILD
+++ b/src/tools/tests/BUILD
@@ -1,3 +1,4 @@
+load("//third_party/java/arcs/build_defs:arcs_ts_test.bzl", "arcs_ts_test")
 load(
     "//third_party/java/arcs/build_defs:build_defs.bzl",
     "arcs_cc_schema",
@@ -5,7 +6,6 @@ load(
     "arcs_kt_jvm_test_suite",
     "arcs_kt_schema",
     "arcs_proto_plan",
-    "arcs_ts_test",
 )
 
 filegroup(

--- a/src/wasm/tests/BUILD
+++ b/src/wasm/tests/BUILD
@@ -1,8 +1,5 @@
-load(
-    "//third_party/java/arcs/build_defs:build_defs.bzl",
-    "arcs_manifest_json",
-    "arcs_ts_test",
-)
+load("//third_party/java/arcs/build_defs:arcs_ts_test.bzl", "arcs_ts_test")
+load("//third_party/java/arcs/build_defs:build_defs.bzl", "arcs_manifest_json")
 
 exports_files(["manifest.arcs"])
 

--- a/third_party/java/arcs/build_defs/arcs_ts_test.bzl
+++ b/third_party/java/arcs/build_defs/arcs_ts_test.bzl
@@ -1,0 +1,14 @@
+"""Macro for running TypeScript tests with bazel."""
+
+load(":sigh.bzl", "sigh_command")
+
+def arcs_ts_test(name, src, deps, flaky = False):
+    """Runs a TypeScript test file using `sigh test`."""
+    sigh_command(
+        name = name,
+        srcs = [src],
+        execute = False,
+        flaky = flaky,
+        sigh_cmd = "test --bazel --file {SRC}",
+        deps = deps,
+    )

--- a/third_party/java/arcs/build_defs/build_defs.bzl
+++ b/third_party/java/arcs/build_defs/build_defs.bzl
@@ -34,7 +34,6 @@ load(
     "//third_party/java/arcs/build_defs/internal:tools.oss.bzl",
     _arcs_manifest_parse_test = "arcs_manifest_parse_test",
 )
-load(":sigh.bzl", "sigh_command")
 
 # Re-export rules from various other files.
 
@@ -106,14 +105,3 @@ arcs_manifest_proto = _arcs_manifest_proto
 arcs_proto_plan = _arcs_proto_plan
 
 kt_js_library = _kt_js_library
-
-def arcs_ts_test(name, src, deps, flaky = False):
-    """Runs a TypeScript test file using `sigh test`."""
-    sigh_command(
-        name = name,
-        srcs = [src],
-        execute = False,
-        flaky = flaky,
-        sigh_cmd = "test --bazel --file {SRC}",
-        deps = deps,
-    )

--- a/third_party/java/arcs/build_defs/internal/kotlin.bzl
+++ b/third_party/java/arcs/build_defs/internal/kotlin.bzl
@@ -22,7 +22,6 @@ load(
     "java_library",
     "java_test",
 )
-load("//third_party/java/arcs/build_defs:sigh.bzl", "sigh_command")
 load("//tools/build_defs/android:rules.bzl", "android_local_test")
 load(
     "//tools/build_defs/kotlin:rules.bzl",
@@ -31,6 +30,7 @@ load(
 )
 load(":kotlin_serviceloader_registry.bzl", "kotlin_serviceloader_registry")
 load(":kotlin_wasm_annotations.bzl", "kotlin_wasm_annotations")
+load(":tools.oss.bzl", "arcs_tool_recipe2plan")
 load(
     ":util.bzl",
     "create_build_test",
@@ -475,12 +475,10 @@ def arcs_kt_plan(
         out = replace_arcs_suffix(src, "_GeneratedPlan.kt")
         outs.append(out)
         rest = [s for s in srcs if s != src]
-        sigh_command(
+        arcs_tool_recipe2plan(
             name = genrule_name,
             srcs = [src],
             outs = [out],
-            progress_message = "Generating Kotlin Plans",
-            sigh_cmd = "recipe2plan --quiet --outdir $(dirname {OUT}) --outfile $(basename {OUT}) {SRC}",
             deps = deps + data + rest,
         )
 

--- a/third_party/java/arcs/build_defs/internal/manifest.bzl
+++ b/third_party/java/arcs/build_defs/internal/manifest.bzl
@@ -1,6 +1,11 @@
 """Arcs manifest bundling rules."""
 
-load("//third_party/java/arcs/build_defs:sigh.bzl", "sigh_command")
+load(
+    ":tools.oss.bzl",
+    "arcs_tool_manifest2json",
+    "arcs_tool_manifest2proto",
+    "arcs_tool_recipe2plan",
+)
 load(":util.bzl", "replace_arcs_suffix")
 
 def arcs_manifest(name, srcs, deps = [], visibility = None):
@@ -41,13 +46,11 @@ def arcs_manifest_json(name, srcs = [], deps = [], out = None, visibility = None
     """
     outs = [out] if out != None else [replace_arcs_suffix(name, ".json")]
 
-    sigh_command(
+    arcs_tool_manifest2json(
         name = name,
         srcs = srcs,
         outs = outs,
         deps = deps,
-        progress_message = "Serializing manifest",
-        sigh_cmd = "manifest2json --outdir $(dirname {OUT}) --outfile $(basename {OUT}) {SRC}",
     )
 
 def arcs_manifest_proto(name, src, deps = [], out = None, visibility = None):
@@ -64,13 +67,11 @@ def arcs_manifest_proto(name, src, deps = [], out = None, visibility = None):
     """
     outs = [out] if out != None else [replace_arcs_suffix(name, ".pb.bin")]
 
-    sigh_command(
+    arcs_tool_manifest2proto(
         name = name,
         srcs = [src],
         outs = outs,
         deps = deps,
-        progress_message = "Serializing manifest",
-        sigh_cmd = "manifest2proto --quiet --outdir $(dirname {OUT}) --outfile $(basename {OUT}) {SRC}",
     )
 
 def arcs_proto_plan(name, src, recipe = None, deps = []):
@@ -97,17 +98,12 @@ def arcs_proto_plan(name, src, recipe = None, deps = []):
       recipe: an optional name of the recipe to filter output plans by name
       deps: list of dependencies - other manifests that are imported by src manifest
     """
-
-    sigh_cmd = "recipe2plan --quiet --outdir $(dirname {OUT}) --outfile $(basename {OUT}) --format proto {SRC}"
-    if recipe:
-        sigh_cmd += " --recipe %s" % (recipe)
-
-    sigh_command(
+    arcs_tool_recipe2plan(
         name = name,
         srcs = [src],
         outs = [name + ".pb.bin"],
-        progress_message = "Generating Plan Proto",
-        sigh_cmd = sigh_cmd,
+        recipe = recipe,
+        generate_proto = True,
         deps = deps,
     )
 

--- a/third_party/java/arcs/build_defs/internal/schemas.bzl
+++ b/third_party/java/arcs/build_defs/internal/schemas.bzl
@@ -4,10 +4,10 @@ Rules are re-exported in build_defs.bzl -- use those instead.
 """
 
 load("//devtools/build_cleaner/skylark:build_defs.bzl", "register_extension_info")
-load("//third_party/java/arcs/build_defs:sigh.bzl", "sigh_command")
-load("//third_party/java/arcs/build_defs/internal:util.bzl", "manifest_only", "replace_arcs_suffix")
 load(":kotlin.bzl", "arcs_kt_library", "arcs_kt_plan")
 load(":manifest.bzl", "arcs_manifest")
+load(":tools.oss.bzl", "arcs_tool_schema2wasm")
+load(":util.bzl", "manifest_only", "replace_arcs_suffix")
 
 def _run_schema2wasm(
         name,
@@ -29,22 +29,15 @@ def _run_schema2wasm(
     if type(deps) == str:
         fail("deps must be a list")
 
-    sigh_command(
+    arcs_tool_schema2wasm(
         name = name,
         srcs = [src],
         outs = [out],
         deps = deps,
-        progress_message = "Generating {} entity schemas".format(language_name),
-
-        # TODO: generated header guard should contain whole workspace-relative
-        # path to file.
-        sigh_cmd = "schema2wasm " +
-                   language_flag + " " +
-                   ("--wasm " if wasm else "") +
-                   ("--test_harness " if test_harness else "") +
-                   "--outdir $(dirname {OUT}) " +
-                   "--outfile $(basename {OUT}) " +
-                   "{SRC}",
+        language_name = language_name,
+        language_flag = language_flag,
+        wasm = wasm,
+        test_harness = test_harness,
     )
 
 def arcs_cc_schema(name, src, deps = [], out = None):

--- a/third_party/java/arcs/build_defs/internal/tools.oss.bzl
+++ b/third_party/java/arcs/build_defs/internal/tools.oss.bzl
@@ -39,11 +39,13 @@ def arcs_tool_recipe2plan(name, srcs, outs, deps, generate_proto = False, recipe
         sigh_cmd += " --recipe " + recipe
     sigh_cmd += " {SRC}"
 
+    plan_type = "Proto" if generate_proto else "Kotlin"
+
     sigh_command(
         name = name,
         srcs = srcs,
         outs = outs,
-        progress_message = "Generating Kotlin Plans",
+        progress_message = "Generating Arcs Plan (%s)" % plan_type,
         sigh_cmd = sigh_cmd,
         deps = deps,
     )

--- a/third_party/java/arcs/build_defs/internal/tools.oss.bzl
+++ b/third_party/java/arcs/build_defs/internal/tools.oss.bzl
@@ -1,7 +1,11 @@
-"""Rules that invoke sigh scripts."""
+"""Rules that invoke sigh scripts or other binary tools.
+
+Put as little logic/validation here as possible. Prefer adding proper wrapper
+functions and documentation in other .bzl files, and reserve this file for only
+the actual sigh_command invocations.
+"""
 
 load("//third_party/java/arcs/build_defs:sigh.bzl", "sigh_command")
-load(":manifest.bzl", "arcs_manifest")
 
 def arcs_manifest_parse_test(name, srcs, deps = []):
     """Tests that Arcs manifest files parse correctly.
@@ -15,21 +19,73 @@ def arcs_manifest_parse_test(name, srcs, deps = []):
         if not src.endswith(".arcs"):
             fail("src must be an .arcs manifest file, found %s" % src)
 
-    manifest_name = name + "_sources"
-
-    arcs_manifest(
-        name = manifest_name,
-        srcs = srcs,
-        deps = deps,
-    )
-
     test_args = " ".join(["--src $(location %s)" % src for src in srcs])
 
     sigh_command(
         name = name,
         srcs = srcs,
-        deps = deps + [":" + manifest_name],
+        deps = deps,
         sigh_cmd = "run manifestChecker " + test_args,
         progress_message = "Checking Arcs manifest",
         execute = False,
+    )
+
+# buildifier: disable=function-docstring
+def arcs_tool_recipe2plan(name, srcs, outs, deps, generate_proto = False, recipe = None):
+    sigh_cmd = "recipe2plan --quiet --outdir $(dirname {OUT}) --outfile $(basename {OUT})"
+    if generate_proto:
+        sigh_cmd += " --format proto"
+    if recipe:
+        sigh_cmd += " --recipe " + recipe
+    sigh_cmd += " {SRC}"
+
+    sigh_command(
+        name = name,
+        srcs = srcs,
+        outs = outs,
+        progress_message = "Generating Kotlin Plans",
+        sigh_cmd = sigh_cmd,
+        deps = deps,
+    )
+
+# buildifier: disable=function-docstring
+def arcs_tool_manifest2json(name, srcs, outs, deps):
+    sigh_command(
+        name = name,
+        srcs = srcs,
+        outs = outs,
+        progress_message = "Serializing manifest",
+        sigh_cmd = "manifest2json --outdir $(dirname {OUT}) --outfile $(basename {OUT}) {SRC}",
+        deps = deps,
+    )
+
+# buildifier: disable=function-docstring
+def arcs_tool_manifest2proto(name, srcs, outs, deps):
+    sigh_command(
+        name = name,
+        srcs = srcs,
+        outs = outs,
+        deps = deps,
+        progress_message = "Serializing manifest",
+        sigh_cmd = "manifest2proto --quiet --outdir $(dirname {OUT}) --outfile $(basename {OUT}) {SRC}",
+    )
+
+# buildifier: disable=function-docstring
+def arcs_tool_schema2wasm(name, srcs, outs, deps, language_name, language_flag, wasm, test_harness):
+    # TODO: generated header guard should contain whole workspace-relative
+    # path to file.
+    sigh_cmd = "schema2wasm " + language_flag
+    if wasm:
+        sigh_cmd += " --wasm"
+    if test_harness:
+        sigh_cmd += " --test_harness"
+    sigh_cmd += " --outdir $(dirname {OUT}) --outfile $(basename {OUT}) {SRC}"
+
+    sigh_command(
+        name = name,
+        srcs = srcs,
+        outs = outs,
+        deps = deps,
+        progress_message = "Generating %s entity schemas" % language_name,
+        sigh_cmd = sigh_cmd,
     )


### PR DESCRIPTION
sigh isn't imported internally, so we don't want to call it directly. Instead we call these wrappers in tools.oss.bzl, which are easily swappable for new implementations.