### PR TITLE
Define PolicyOptionsProto with encode/decode functions

### DIFF
--- a/java/arcs/core/data/proto/policy.proto
+++ b/java/arcs/core/data/proto/policy.proto
@@ -106,3 +106,9 @@ message PolicyConfigProto {
   // name.
   map<string, string> metadata = 2;
 }
+
+// General options for policy enforcement.
+message PolicyOptionsProto {
+  // Maps from store ID to type name.
+  map<string, string> store_id_to_type = 1;
+}

--- a/java/arcs/core/policy/proto/PolicyOptionsProto.kt
+++ b/java/arcs/core/policy/proto/PolicyOptionsProto.kt
@@ -1,0 +1,10 @@
+package arcs.core.policy.proto
+
+import arcs.core.data.proto.PolicyOptionsProto
+import arcs.core.policy.PolicyOptions
+
+fun PolicyOptionsProto.decode() = PolicyOptions(storeIdToTypeMap)
+
+fun PolicyOptions.encode(): PolicyOptionsProto {
+    return PolicyOptionsProto.newBuilder().putAllStoreIdToType(storeMap).build()
+}

--- a/javatests/arcs/core/policy/proto/PolicyOptionsProtoTest.kt
+++ b/javatests/arcs/core/policy/proto/PolicyOptionsProtoTest.kt
@@ -1,0 +1,16 @@
+package arcs.core.policy.proto
+
+import arcs.core.policy.PolicyOptions
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class PolicyOptionsProtoTest {
+    @Test
+    fun roundTrip() {
+        val options = PolicyOptions(storeMap = mapOf("id1" to "Type1", "id2" to "Type2"))
+        assertThat(options.encode().decode()).isEqualTo(options)
+    }
+}


### PR DESCRIPTION
We'll need this to serialise PolicyOptions to disk for compile-time verifications.

PolicyOptions is still just a temporary measure, we'll replace it with some annotations later on.