### PR TITLE
Optimize size queries of collection handles

### DIFF
--- a/java/arcs/core/entity/CollectionHandle.kt
+++ b/java/arcs/core/entity/CollectionHandle.kt
@@ -46,21 +46,18 @@ class CollectionHandle<T : Storable, R : Referencable>(
         check(spec.containerType == HandleContainerType.Collection)
     }
 
+    // Filter out expired models.
+    private fun fetchValidModels() = checkPreconditions {
+        storageProxy.getParticleViewUnsafe().filterNot {
+            storageAdapter.isExpired(it)
+        }
+    }
+
     // region implement ReadCollectionHandle<T>
 
-    // Filter out expired items.
-    override fun size() = checkPreconditions {
-        storageProxy.getParticleViewUnsafe().filterNot {
-            storageAdapter.isExpired(it)
-        }.size
-    }
+    override fun size() = fetchValidModels().size
 
-    // Filter out expired items.
-    override fun isEmpty() = checkPreconditions {
-        storageProxy.getParticleViewUnsafe().filterNot {
-            storageAdapter.isExpired(it)
-        }.isEmpty()
-    }
+    override fun isEmpty() = fetchValidModels().isEmpty()
 
     override fun fetchAll() = checkPreconditions {
         adaptValues(storageProxy.getParticleViewUnsafe())

--- a/java/arcs/core/entity/CollectionHandle.kt
+++ b/java/arcs/core/entity/CollectionHandle.kt
@@ -48,11 +48,19 @@ class CollectionHandle<T : Storable, R : Referencable>(
 
     // region implement ReadCollectionHandle<T>
 
-    // Use fetchAll to filter out expired items.
-    override fun size() = fetchAll().size
+    // Filter out expired items.
+    override fun size() = checkPreconditions {
+        storageProxy.getParticleViewUnsafe().filterNot {
+            storageAdapter.isExpired(it)
+        }.size
+    }
 
-    // Use fetchAll to filter out expired items.
-    override fun isEmpty() = fetchAll().isEmpty()
+    // Filter out expired items.
+    override fun isEmpty() = checkPreconditions {
+        storageProxy.getParticleViewUnsafe().filterNot {
+            storageAdapter.isExpired(it)
+        }.isEmpty()
+    }
 
     override fun fetchAll() = checkPreconditions {
         adaptValues(storageProxy.getParticleViewUnsafe())


### PR DESCRIPTION
Remove unnecessary adaption for each entity in the collection just in order to query collection size.
This improves 80-100ms to pecan startup time.