### PR TITLE
Remove `runBlocking` from DirectStore

### DIFF
--- a/java/arcs/core/storage/ActiveStore.kt
+++ b/java/arcs/core/storage/ActiveStore.kt
@@ -44,5 +44,5 @@ abstract class ActiveStore<Data : CrdtData, Op : CrdtOperation, ConsumerData>(
     abstract suspend fun onProxyMessage(message: ProxyMessage<Data, Op, ConsumerData>): Boolean
 
     /** Performs any operations that are needed to release resources held by this [ActiveStore]. */
-    open fun close() = Unit
+    open suspend fun close() = Unit
 }

--- a/java/arcs/core/storage/DirectStore.kt
+++ b/java/arcs/core/storage/DirectStore.kt
@@ -100,7 +100,7 @@ class DirectStore<Data : CrdtData, Op : CrdtOperation, T> /* internal */ constru
     fun getLocalData(): Data = synchronized(this) { localModel.data }
 
     override fun on(callback: ProxyCallback<Data, Op, T>): Int {
-        synchronized(closed) {
+        synchronized(proxyManager) {
             check(!closed) {
                 "Cannot add proxy callback after closing."
             }
@@ -109,14 +109,14 @@ class DirectStore<Data : CrdtData, Op : CrdtOperation, T> /* internal */ constru
     }
 
     override fun off(callbackToken: Int) {
-        synchronized(closed) {
+        synchronized(proxyManager) {
             proxyManager.unregister(callbackToken)
         }
     }
 
     /** Closes the store. Once closed, it cannot be re-opened. A new instance must be created. */
     override suspend fun close() {
-        val wasClosed = synchronized(closed) {
+        val wasClosed = synchronized(proxyManager) {
             closed.also {
                 closed = true
             }

--- a/java/arcs/sdk/android/storage/ServiceStore.kt
+++ b/java/arcs/sdk/android/storage/ServiceStore.kt
@@ -162,7 +162,7 @@ class ServiceStore<Data : CrdtData, Op : CrdtOperation, ConsumerData>(
     }
 
     @VisibleForTesting(otherwise = VisibleForTesting.PACKAGE_PRIVATE)
-    override fun close() {
+    override suspend fun close() {
         serviceConnection?.disconnect()
         storageService = null
         scope.coroutineContext[Job.Key]?.cancelChildren()


### PR DESCRIPTION
This means that we can no longer directly close stores as part of
LruCacheMap eviction, since the get/put methods of the map are not
suspendable.

I tried one approach where I just made a parallel implementation of
LruCache map with suspendable get/put. That worked ok, but was a lot of
code duplication.

In this approach, I try queueing the stores for closure by the suspend
method that's creating them.