### PR TITLE
when merging crdtentities, check if the otherChange is empty. This wa…

### DIFF
--- a/java/arcs/core/crdt/CrdtEntity.kt
+++ b/java/arcs/core/crdt/CrdtEntity.kt
@@ -160,9 +160,20 @@ class CrdtEntity(
             )
         } else {
             val resultData = data // call `data` only once, since it's nontrivial to copy.
+
+            // Check if there are no other changes.
+            val otherChangesEmpty =
+                singletonChanges.values.all { it.otherChange.isEmpty() } &&
+                    collectionChanges.values.all { it.otherChange.isEmpty() }
+            val otherChange: CrdtChange<Data, Operation> = if (otherChangesEmpty) {
+                CrdtChange.Operations(mutableListOf())
+            } else {
+                CrdtChange.Data(resultData)
+            }
+
             MergeChanges(
                 modelChange = CrdtChange.Data(resultData),
-                otherChange = CrdtChange.Data(resultData)
+                otherChange = otherChange
             )
         }
     }

--- a/java/arcs/jvm/storage/database/testutil/FakeDatabaseManager.kt
+++ b/java/arcs/jvm/storage/database/testutil/FakeDatabaseManager.kt
@@ -83,6 +83,10 @@ class FakeDatabaseManager : DatabaseManager {
     override suspend fun resetAll() {
         throw UnsupportedOperationException("Fake database manager cannot resetAll.")
     }
+
+    suspend fun totalInsertUpdates() = snapshotStatistics().map {
+        it.value.insertUpdate.runtimeStatistics.measurements
+    }.sum()
 }
 
 @Suppress("EXPERIMENTAL_API_USAGE")

--- a/javatests/arcs/core/crdt/CrdtEntityTest.kt
+++ b/javatests/arcs/core/crdt/CrdtEntityTest.kt
@@ -385,4 +385,29 @@ class CrdtEntityTest {
             entity.merge(entity2.data)
         }
     }
+
+    @Test
+    fun mergeIntoEmptyModel() {
+        val rawEntity = RawEntity(
+            id = "an-id",
+            singletons = mapOf("foo" to Reference("fooRef")),
+            collections = mapOf(
+                "bar" to setOf(Reference("barRef1"), Reference("barRef2"))
+            )
+        )
+        val emptyRawEntity = RawEntity(
+            id = "an-id",
+            singletons = mapOf("foo" to null),
+            collections = mapOf(
+                "bar" to setOf()
+            )
+        )
+        val entity = CrdtEntity(VersionMap("me" to 1), rawEntity)
+        val emptyEntity = CrdtEntity(VersionMap(), emptyRawEntity)
+
+        val changes = emptyEntity.merge(entity.data)
+        println(changes)
+        assertThat(changes.modelChange.isEmpty()).isFalse()
+        assertThat(changes.otherChange.isEmpty()).isTrue()
+    }
 }


### PR DESCRIPTION
…s resulting in redundant driver updates as outlined in #5851. This is a fix alternative to #5851, I copied the test from that pr to show it solves the same problem