### PR TITLE
Create a build_test automatically for jvm and android kt libraries

### DIFF
--- a/third_party/java/arcs/build_defs/internal/kotlin.bzl
+++ b/third_party/java/arcs/build_defs/internal/kotlin.bzl
@@ -2,7 +2,6 @@
 
 Rules are re-exported in build_defs.bzl -- use those instead.
 """
-
 load("//devtools/build_cleaner/skylark:build_defs.bzl", "register_extension_info")
 load(
     "//third_party/bazel_rules/rules_kotlin/kotlin/js:js_library.bzl",
@@ -31,7 +30,13 @@ load(
 )
 load(":kotlin_serviceloader_registry.bzl", "kotlin_serviceloader_registry")
 load(":kotlin_wasm_annotations.bzl", "kotlin_wasm_annotations")
-load(":util.bzl", "manifest_only", "merge_lists", "replace_arcs_suffix")
+load(
+    ":util.bzl",
+    "create_build_test",
+    "manifest_only",
+    "merge_lists",
+    "replace_arcs_suffix",
+)
 
 _WASM_SUFFIX = "-wasm"
 
@@ -121,6 +126,7 @@ def arcs_kt_jvm_library(**kwargs):
         )
 
     kt_jvm_library(**kwargs)
+    create_build_test(kwargs["name"])
 
 def arcs_kt_android_library(**kwargs):
     """Wrapper around kt_android_library for Arcs.
@@ -135,6 +141,7 @@ def arcs_kt_android_library(**kwargs):
     kotlincopts = kwargs.pop("kotlincopts", [])
     kwargs["kotlincopts"] = merge_lists(kotlincopts, COMMON_KOTLINC_OPTS + JVM_KOTLINC_OPTS)
     kt_android_library(**kwargs)
+    create_build_test(kwargs["name"])
 
 def arcs_kt_native_library(**kwargs):
     """Wrapper around kt_native_library for Arcs.

--- a/third_party/java/arcs/build_defs/internal/kotlin.bzl
+++ b/third_party/java/arcs/build_defs/internal/kotlin.bzl
@@ -2,6 +2,7 @@
 
 Rules are re-exported in build_defs.bzl -- use those instead.
 """
+
 load("//devtools/build_cleaner/skylark:build_defs.bzl", "register_extension_info")
 load(
     "//third_party/bazel_rules/rules_kotlin/kotlin/js:js_library.bzl",

--- a/third_party/java/arcs/build_defs/internal/util.bzl
+++ b/third_party/java/arcs/build_defs/internal/util.bzl
@@ -1,5 +1,7 @@
 """Shared utilities for Arcs internal rules"""
 
+load("//tools/build_defs/build_test:build_test.bzl", "build_test")
+
 def replace_arcs_suffix(src, suffix = ""):
     """Cleans up the given file name, and replaces the .arcs extension with the provided suffix."""
 
@@ -28,3 +30,14 @@ def manifest_only(deps = [], inverse = False):
     if inverse:
         return [d for d in deps if not d.endswith(".arcs")]
     return [d for d in deps if d.endswith(".arcs")]
+
+def create_build_test(name):
+    """Creates a build_test for the given target.
+
+    Build tests are useful mainly for the internal presubmit, to verify that
+    everything builds without error.
+    """
+    build_test(
+        name = name + "_build_test",
+        targets = [":" + name],
+    )

--- a/tools/build_defs/build_test/BUILD
+++ b/tools/build_defs/build_test/BUILD
@@ -1,0 +1,3 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])

--- a/tools/build_defs/build_test/build_test.bzl
+++ b/tools/build_defs/build_test/build_test.bzl
@@ -1,0 +1,5 @@
+"""Re-exports build_test rule."""
+
+load("@bazel_skylib//rules:build_test.bzl", _build_test = "build_test")
+
+build_test = _build_test


### PR DESCRIPTION
This is useful for the internal presubmit, to ensure that all libs build without error.