### PR TITLE
Support type variables in data flow analysis.

### DIFF
--- a/javatests/arcs/core/analysis/InformationFlowTest.kt
+++ b/javatests/arcs/core/analysis/InformationFlowTest.kt
@@ -149,10 +149,18 @@ class InformationFlowTest {
             "fail-cycle-remove-tag",
             "fail-cycle-remove-tag-in-chain"
         )
+        val typeVariableTests = listOf(
+            "fail-type-variables",
+            "fail-type-variables-collection",
+            "fail-type-variables-tuples",
+            "fail-type-variables-tuples-collection",
+            "fail-type-variables-multiple-constraints"
+        )
         val tests = (
             okTests + failingTests +
             okFieldTests + failingFieldTests +
-            okCycleTests + failingCycleTests
+            okCycleTests + failingCycleTests +
+            typeVariableTests
         )
         tests.forEach { verifyChecksInTestFile(it) }
     }

--- a/javatests/arcs/core/analysis/testdata/fail_type_variables.arcs
+++ b/javatests/arcs/core/analysis/testdata/fail_type_variables.arcs
@@ -1,0 +1,47 @@
+// #Ingress: Mixed
+// #Ingress: Meh
+// #FAIL: hc:FailingCheck.input.bad is bad
+particle Mixed
+  output: writes Mixed {good: Text, bad: Text}
+  claim output.good is good
+  claim output.bad is bad
+
+particle Meh
+  output: writes Meh {meh: Text}
+  claim output.meh is meh
+
+particle DoStuff
+  input1: reads ~a with {bad: Text}
+  input2: reads ~b with {*}
+  output: writes ~a
+
+particle PassingChecks
+  input: reads Mixed {good: Text, bad: Text}
+  // This would pass, as "good" field was not accessible to DoStuff
+  // and could not have been modified.
+  check input.good is good
+  // This would pass, as input.bad could have been modified by DoStuff,
+  // but could only have been tainted by meh stuff, not by good stuff
+  // (which was not read).
+  check input.bad is bad or is meh
+  check input is good or is bad or is meh
+
+particle FailingCheck
+  input: reads Mixed {good: Text, bad: Text}
+  // This would fail, as input.bad could have been modified by DoStuff,
+  // and could have been tainted by meh stuff.
+  check input.bad is bad
+
+recipe
+  Mixed
+    output: mixed
+  Meh
+    output: meh
+  DoStuff
+    input1: mixed
+    input2: meh
+    output: stuff
+  PassingChecks
+    input: stuff
+  FailingCheck
+    input: stuff

--- a/javatests/arcs/core/analysis/testdata/fail_type_variables_collection.arcs
+++ b/javatests/arcs/core/analysis/testdata/fail_type_variables_collection.arcs
@@ -1,0 +1,47 @@
+// #Ingress: Mixed
+// #Ingress: Meh
+// #FAIL: hc:FailingCheck.input.bad is bad
+particle Mixed
+  output: writes [Mixed {good: Text, bad: Text}]
+  claim output.good is good
+  claim output.bad is bad
+
+particle Meh
+  output: writes [Meh {meh: Text}]
+  claim output.meh is meh
+
+particle DoStuff
+  input1: reads [~a with {bad: Text}]
+  input2: reads [~b with {*}]
+  output: writes ~a
+
+particle PassingChecks
+  input: reads Mixed {good: Text, bad: Text}
+  // This would pass, as "good" field was not accessible to DoStuff
+  // and could not have been modified.
+  check input.good is good
+  // This would pass, as input.bad could have been modified by DoStuff,
+  // but could only have been tainted by meh stuff, not by good stuff
+  // (which was not read).
+  check input.bad is bad or is meh
+  check input is good or is bad or is meh
+
+particle FailingCheck
+  input: reads Mixed {good: Text, bad: Text}
+  // This would fail, as input.bad could have been modified by DoStuff,
+  // and could have been tainted by meh stuff.
+  check input.bad is bad
+
+recipe
+  Mixed
+    output: mixed
+  Meh
+    output: meh
+  DoStuff
+    input1: mixed
+    input2: meh
+    output: stuff
+  PassingChecks
+    input: stuff
+  FailingCheck
+    input: stuff

--- a/javatests/arcs/core/analysis/testdata/fail_type_variables_multiple_constraints.arcs
+++ b/javatests/arcs/core/analysis/testdata/fail_type_variables_multiple_constraints.arcs
@@ -1,0 +1,47 @@
+// #Ingress: Mixed
+// #Ingress: Meh
+// #FAIL: hc:FailingCheck.input.bad is bad
+particle Mixed
+  output: writes Mixed {good: Text, bad: Text, ugly: Text}
+  claim output.good is good
+  claim output.bad is bad
+  claim output.ugly is ugly
+
+particle Meh
+  output: writes Meh {meh: Text}
+  claim output.meh is meh
+
+particle DoStuff
+  input1: reads ~a with {bad: Text}
+  input2: reads ~a with {ugly: Text}
+  input3: reads ~b with {*}
+  output: writes ~a
+
+particle PassingChecks
+  input: reads Mixed {good: Text, bad: Text, ugly: Text}
+  // This would pass, as "good" field was not accessible to DoStuff
+  // and could not have been modified.
+  check input.good is good
+  check input.bad is bad or is meh or is ugly
+  check input is good or is bad or is meh or is ugly
+
+particle FailingCheck
+  input: reads Mixed {good: Text, bad: Text, ugly: Text}
+  // This would fail, as input.bad could have been modified by DoStuff,
+  // and could have been tainted by meh stuff.
+  check input.bad is bad
+
+recipe
+  Mixed
+    output: mixed
+  Meh
+    output: meh
+  DoStuff
+    input1: mixed
+    input2: mixed
+    input3: meh
+    output: stuff
+  PassingChecks
+    input: stuff
+  FailingCheck
+    input: stuff

--- a/javatests/arcs/core/analysis/testdata/fail_type_variables_tuples.arcs
+++ b/javatests/arcs/core/analysis/testdata/fail_type_variables_tuples.arcs
@@ -1,0 +1,39 @@
+// #Ingress: Tupler
+// #FAIL: hc:FailingCheck.input.bad is bad
+particle Tupler
+  output: writes (Mixed {good: Text, bad: Text},  Meh {meh: Text})
+  claim output.first.good is good
+  claim output.first.bad is bad
+  claim output.second.meh is meh
+
+particle DoStuff
+  input: reads (~a with {bad: Text}, ~b with {*})
+  output: writes ~a
+
+particle PassingChecks
+  input: reads Mixed {good: Text, bad: Text}
+  // This would pass, as "good" field was not accessible to DoStuff
+  // and could not have been modified.
+  check input.good is good
+  // This would pass, as input.bad could have been modified by DoStuff,
+  // but could only have been tainted by meh stuff, not by good stuff
+  // (which was not read).
+  check input.bad is bad or is meh
+  check input is good or is bad or is meh
+
+particle FailingCheck
+  input: reads Mixed {good: Text, bad: Text}
+  // This would fail, as input.bad could have been modified by DoStuff,
+  // and could have been tainted by meh stuff.
+  check input.bad is bad
+
+recipe
+  Tupler
+    output: tuple
+  DoStuff
+    input: tuple
+    output: stuff
+  PassingChecks
+    input: stuff
+  FailingCheck
+    input: stuff

--- a/javatests/arcs/core/analysis/testdata/fail_type_variables_tuples_collection.arcs
+++ b/javatests/arcs/core/analysis/testdata/fail_type_variables_tuples_collection.arcs
@@ -1,0 +1,39 @@
+// #Ingress: Tupler
+// #FAIL: hc:FailingCheck.input.bad is bad
+particle Tupler
+  output: writes ([Mixed {good: Text, bad: Text}],  [Meh {meh: Text}])
+  claim output.first.good is good
+  claim output.first.bad is bad
+  claim output.second.meh is meh
+
+particle DoStuff
+  input: reads ([~a with {bad: Text}], [~b with {*}])
+  output: writes ~a
+
+particle PassingChecks
+  input: reads Mixed {good: Text, bad: Text}
+  // This would pass, as "good" field was not accessible to DoStuff
+  // and could not have been modified.
+  check input.good is good
+  // This would pass, as input.bad could have been modified by DoStuff,
+  // but could only have been tainted by meh stuff, not by good stuff
+  // (which was not read).
+  check input.bad is bad or is meh
+  check input is good or is bad or is meh
+
+particle FailingCheck
+  input: reads Mixed {good: Text, bad: Text}
+  // This would fail, as input.bad could have been modified by DoStuff,
+  // and could have been tainted by meh stuff.
+  check input.bad is bad
+
+recipe
+  Tupler
+    output: tuple
+  DoStuff
+    input: tuple
+    output: stuff
+  PassingChecks
+    input: stuff
+  FailingCheck
+    input: stuff

--- a/javatests/arcs/core/analysis/testdata/policy_test.arcs
+++ b/javatests/arcs/core/analysis/testdata/policy_test.arcs
@@ -75,12 +75,18 @@ particle ParticleWithMissingEgressType
 // Complying by not having any egress particles.
 //-----------------------------------------------------------
 @isolated
+particle SomeIsolatedWriter
+  input: writes [Person {name: Text}]
+
+@isolated
 particle SomeIsolatedParticle
   input: reads [~a]
 
 @policy('TestPolicy')
 recipe NoEgressParticles
   input: create 'input'
+  SomeIsolatedWriter
+    input: input
   SomeIsolatedParticle
     input: input
 


### PR DESCRIPTION
For each particle, we create the following additional information:
   - Derives from claims induced by type variables and the constraints.
   - Inacessible paths due to type variables and the contraints.

The above information is used appropriately in the node transfer functions.

**NOTE:** a type variable with a `null` in the `constraint` field is treated as a type variable that has a `with {*}` constraint. This is sound. When the information about `{*}` is plumbed in, we can handle it appropriately.

**Codehealth**: Ideally, we want the code that generates this information in a separate file and have unit tests. However, that would require quite a bit of refactoring at this point. I will do them in a series of subsequent PRs.  b/158526199 tracks this.