### PR TITLE
Rewrite dot only check to work on GCB (without .git)

### DIFF
--- a/tools/sigh.ts
+++ b/tools/sigh.ts
@@ -518,6 +518,8 @@ function lint(args: string[]): boolean {
     string: ['format']
   });
 
+  console.log(saneSpawnSyncWithOutput('pwd', [], {logCmd: true}).stdout);
+  console.log(saneSpawnSyncWithOutput('ls', ['-la'], {logCmd: true}).stdout);
   const result = saneSpawnSyncWithOutput('git', ['--no-pager', 'grep', '"\\(describe\\.only(\\|it\\.only(\\)"', '*.ts'], {logCmd: true});
   if (result.stdout !== '') {
     console.error(result.stdout);

--- a/tools/sigh.ts
+++ b/tools/sigh.ts
@@ -518,9 +518,11 @@ function lint(args: string[]): boolean {
     string: ['format']
   });
 
-  console.log(saneSpawnSyncWithOutput('pwd', [], {logCmd: true}).stdout);
-  console.log(saneSpawnSyncWithOutput('ls', ['-la'], {logCmd: true}).stdout);
-  const result = saneSpawnSyncWithOutput('git', ['--no-pager', 'grep', '"\\(describe\\.only(\\|it\\.only(\\)"', '*.ts'], {logCmd: true});
+  const result = saneSpawnSyncWithOutput(
+    'grep',
+    ['--include', '\\*.ts', '-R', '"\\(describe\\|it\\)\\.only"', './src'],
+    {logCmd: true}
+  );
   if (result.stdout !== '') {
     console.error(result.stdout);
     console.error('Please do not commit tests using .only (as it disables all other tests).');


### PR DESCRIPTION
This should fix the check I wrote so that it works on GCB (where .git isn't copied in). It should also be a little faster as it only checks .ts files and only looks in `src` but that isn't the goal of the change.