### PR TITLE
Create RawDevToolsMessage

### DIFF
--- a/java/arcs/android/devtools/DevToolsMessage.kt
+++ b/java/arcs/android/devtools/DevToolsMessage.kt
@@ -4,7 +4,6 @@ package arcs.android.devtools
  * An interface for messages between [DevToolsService] and the client.
  */
 interface DevToolsMessage {
-
     /** The type of DevToolsMessage */
     val kind: String
     /** The message to be passed */
@@ -15,6 +14,7 @@ interface DevToolsMessage {
 
     /** Track message types */
     companion object {
+        /** a RAW_MESSAGE should be used to send raw [ProxyMessage]s to the client. */
         val RAW_MESSAGE: String = "RawStoreMessage"
     }
 }

--- a/java/arcs/android/devtools/DevToolsMessage.kt
+++ b/java/arcs/android/devtools/DevToolsMessage.kt
@@ -14,7 +14,7 @@ interface DevToolsMessage {
 
     /** Track message types */
     companion object {
-        /** a RAW_MESSAGE should be used to send raw [ProxyMessage]s to the client. */
+        /** A [RAW_MESSAGE] should be used to send raw [ProxyMessage]s to the client. */
         val RAW_MESSAGE: String = "RawStoreMessage"
     }
 }

--- a/java/arcs/android/devtools/DevToolsMessage.kt
+++ b/java/arcs/android/devtools/DevToolsMessage.kt
@@ -1,0 +1,20 @@
+package arcs.android.devtools
+
+/**
+ * An interface for messages between [DevToolsService] and the client.
+ */
+interface DevToolsMessage {
+
+    /** The type of DevToolsMessage */
+    val kind: String
+    /** The message to be passed */
+    val message: String
+
+    /** Return a JSON string that can be passed to the client. */
+    fun toJson(): String
+
+    /** Track message types */
+    companion object {
+        val RAW_MESSAGE: String = "RawStoreMessage"
+    }
+}

--- a/java/arcs/android/devtools/DevToolsService.kt
+++ b/java/arcs/android/devtools/DevToolsService.kt
@@ -47,8 +47,8 @@ class DevToolsService : Service() {
     private val forwardProxyMessage = object : IStorageServiceCallback.Stub() {
         override fun onProxyMessage(proxyMessage: ByteArray) {
             scope.launch {
-                val actualMessage = proxyMessage.decodeProxyMessage()
-                devToolsServer.send(actualMessage.toString())
+                val rawMessage = RawDevToolsMessage(proxyMessage.decodeProxyMessage().toString())
+                devToolsServer.send(rawMessage.toJson())
             }
         }
     }

--- a/java/arcs/android/devtools/RawDevToolsMessage.kt
+++ b/java/arcs/android/devtools/RawDevToolsMessage.kt
@@ -1,6 +1,7 @@
 package arcs.android.devtools
 
 import arcs.android.devtools.DevToolsMessage.Companion.RAW_MESSAGE
+import org.json.JSONObject
 
 /**
  * An implementation of [DevToolsMessage] to pass raw [ProxyMessage]s.
@@ -9,6 +10,9 @@ class RawDevToolsMessage(override val message: String) : DevToolsMessage {
     override val kind: String = RAW_MESSAGE
 
     override fun toJson(): String {
-        return "{kind: \"$kind\", message: \"$message\"}"
+        val jo = JSONObject()
+        jo.put("kind", kind)
+        jo.put("message", message)
+        return jo.toString()
     }
 }

--- a/java/arcs/android/devtools/RawDevToolsMessage.kt
+++ b/java/arcs/android/devtools/RawDevToolsMessage.kt
@@ -1,0 +1,14 @@
+package arcs.android.devtools
+
+import arcs.android.devtools.DevToolsMessage.Companion.RAW_MESSAGE
+
+/**
+ * An implementation of [DevToolsMessage] to pass raw [ProxyMessage]s.
+ */
+class RawDevToolsMessage(override val message: String) : DevToolsMessage {
+    override val kind: String = RAW_MESSAGE
+
+    override fun toJson(): String {
+        return "{kind: \"$kind\", message: \"$message\"}"
+    }
+}


### PR DESCRIPTION
**Changes**
- Create DevToolsMessage interface
- Implement RawDevToolsMessage and update DevToolsService to send a JSON-ified RawDevToolsMessage instead of a string.

This PR starts implementing the DevTools Communications protocol. In talking to @sjmiles I started with a "RawMessage" type that simply forwards the raw CRDT messages.
