### PR TITLE
Remove compilation warnings from DevTools/e2e TestApp

### DIFF
--- a/java/arcs/android/devtools/DevToolsService.kt
+++ b/java/arcs/android/devtools/DevToolsService.kt
@@ -24,6 +24,7 @@ import arcs.sdk.android.storage.service.StorageServiceConnection
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
@@ -32,6 +33,7 @@ import kotlinx.coroutines.suspendCancellableCoroutine
  * Implementation of [Service] for devtools to enable a [DevWebSocket] connection to a remote
  * device by exposing the [IDevToolsService] API.
  */
+@OptIn(ExperimentalCoroutinesApi::class)
 class DevToolsService : Service() {
 
     private val coroutineContext = Dispatchers.Default + CoroutineName("DevtoolsService")
@@ -67,6 +69,7 @@ class DevToolsService : Service() {
         }
     }
 
+    @Suppress("UNCHECKED_CAST")
     override fun onBind(intent: Intent): IBinder? {
         scope.launch {
             val extras = intent.extras
@@ -82,7 +85,7 @@ class DevToolsService : Service() {
 
             binder.send(service.getStorageKeys() ?: "")
             devToolsServer.addOnOpenWebsocketCallback {
-                devToolsServer.send(service?.getStorageKeys() ?: "")
+                devToolsServer.send(service.getStorageKeys() ?: "")
             }
 
             storageService = service

--- a/java/arcs/android/storage/service/DevToolsProxyImpl.kt
+++ b/java/arcs/android/storage/service/DevToolsProxyImpl.kt
@@ -14,7 +14,7 @@ class DevToolsProxyImpl : IDevToolsProxy.Stub() {
      * Execute the callbacks to be called with the [BindingContext] receives a [ProxyMessage]
      */
     fun onBindingContextProxyMessage(proxyMessage: ByteArray) {
-        onBindingContextProxyMessageCallbacks.forEach { key, callback ->
+        onBindingContextProxyMessageCallbacks.forEach { _, callback ->
             callback.onProxyMessage(proxyMessage)
         }
     }

--- a/java/arcs/android/storage/service/DevToolsStorageManager.kt
+++ b/java/arcs/android/storage/service/DevToolsStorageManager.kt
@@ -13,7 +13,6 @@ package arcs.android.storage.service
 
 import arcs.core.storage.StorageKey
 import java.util.concurrent.ConcurrentHashMap
-import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 
 /**
@@ -22,8 +21,6 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
  */
 @ExperimentalCoroutinesApi
 class DevToolsStorageManager(
-    /** [CoroutineContext] on which to build one specific to this [DevToolsStorageManager]. */
-    parentCoroutineContext: CoroutineContext,
     /** The stores managed by StorageService. */
     val stores: ConcurrentHashMap<StorageKey, DeferredStore<*, *, *>>,
     val proxy: IDevToolsProxy

--- a/java/arcs/sdk/android/storage/service/StorageService.kt
+++ b/java/arcs/sdk/android/storage/service/StorageService.kt
@@ -154,7 +154,7 @@ open class StorageService : ResurrectorService() {
         }
 
         if (intent.action == DEVTOOLS_ACTION && ApplicationInfo.FLAG_DEBUGGABLE != 0) {
-            return DevToolsStorageManager(coroutineContext, stores, devToolsProxy!!)
+            return DevToolsStorageManager(stores, devToolsProxy!!)
         }
 
         val parcelableOptions = requireNotNull(

--- a/javatests/arcs/android/e2e/testapp/StorageAccessService.kt
+++ b/javatests/arcs/android/e2e/testapp/StorageAccessService.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class StorageAccessService : LifecycleService() {
 
     private val coroutineContext: CoroutineContext = Job() + Dispatchers.Main
@@ -33,7 +34,6 @@ class StorageAccessService : LifecycleService() {
         )
     )
 
-    @ExperimentalCoroutinesApi
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         super.onStartCommand(intent, flags, startId)
 


### PR DESCRIPTION
Get rid of the warnings when compiling the e2e testapp by:
- Oping in to ExperimentalCoroutinesApi for DevToolsService and the e2e test StorageAccessService
- Add a Suppress("UNCHECKED_CAST") annotation to DevToolsService.onBind
- Minor nit fixes (removing unused variables, null checks, etc.)