### PR TITLE
Restore acking `sendProxyMessage` immediately

### DIFF
--- a/java/arcs/android/storage/service/BindingContext.kt
+++ b/java/arcs/android/storage/service/BindingContext.kt
@@ -144,6 +144,10 @@ class BindingContext(
         scope.launch {
             bindingContextStatisticsSink.traceTransaction("sendProxyMessage") {
                 bindingContextStatisticsSink.measure {
+                    // For performance reasons, we respond immediately here to the caller, before
+                    // sending the proxy message.
+                    resultCallback.takeIf { it.asBinder().isBinderAlive }?.onResult(null)
+
                     val actualMessage = proxyMessage.decodeProxyMessage()
                     // TODO: (sarahheimlich) remove once we dive into stores (b/162955831)
                     devToolsProxy?.onBindingContextProxyMessage(proxyMessage)
@@ -153,7 +157,6 @@ class BindingContext(
                             onProxyMessage(store.storageKey, actualMessage)
                         }
                     }
-                    resultCallback.takeIf { it.asBinder().isBinderAlive }?.onResult(null)
                 }
             }
         }

--- a/java/arcs/android/storage/service/BindingContext.kt
+++ b/java/arcs/android/storage/service/BindingContext.kt
@@ -86,6 +86,9 @@ class BindingContext(
         parentCoroutineContext + job + CoroutineName("BindingContext-$id")
     private val scope = CoroutineScope(coroutineContext)
 
+    suspend fun awaitAllJobs() {
+        scope.coroutineContext[Job.Key]!!.children.forEach { it.join() }
+    }
     override fun idle(timeoutMillis: Long, resultCallback: IResultCallback) {
         scope.launch {
             bindingContextStatisticsSink.traceTransaction("idle") {

--- a/javatests/arcs/sdk/android/storage/service/StorageServiceTest.kt
+++ b/javatests/arcs/sdk/android/storage/service/StorageServiceTest.kt
@@ -41,6 +41,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Robolectric
 import org.robolectric.Shadows.shadowOf
+import kotlin.coroutines.coroutineContext
 
 @Suppress("EXPERIMENTAL_API_USAGE")
 @RunWith(AndroidJUnit4::class)
@@ -105,6 +106,11 @@ class StorageServiceTest {
             deferredResult.await()
         }
         assertThat(success).isTrue()
+
+        // Wait for the storage service to return to idle after the proxy messagee.
+        runBlocking {
+            context.awaitAllJobs()
+        }
 
         // Verify:
         // Pass the nextStartedService to the resurrectionHelper. If it was a resurrection intent,


### PR DESCRIPTION
It was changed in https://github.com/PolymerLabs/arcs/pull/5866 because
I didn't realize it was intentional to ack immediately instead of
waiting for the command to be sent.