### PR TITLE
Defines a run_test helper BUILD rule and policy_test for manifest files

### DIFF
--- a/javatests/arcs/tools/BUILD
+++ b/javatests/arcs/tools/BUILD
@@ -1,0 +1,12 @@
+load("//third_party/java/arcs/build_defs:build_defs.bzl", "arcs_manifest")
+
+licenses(["notice"])
+
+# Test case for policy_test, which exercises the policy_test BUILD rules and
+# the VerifyPolicy binary.
+arcs_manifest(
+    name = "policy_testcase",
+    srcs = ["policy_testcase.arcs"],
+    policy_options = "options.textproto",
+    policy_test = True,
+)

--- a/javatests/arcs/tools/options.textproto
+++ b/javatests/arcs/tools/options.textproto
@@ -1,0 +1,4 @@
+# PolicyOptionsProto .textproto file, for use with policy_testcase.arcs
+store_id_to_type: [
+  { key: "secret_sauce", value: "SecretSauce" }
+]

--- a/javatests/arcs/tools/policy_testcase.arcs
+++ b/javatests/arcs/tools/policy_testcase.arcs
@@ -1,0 +1,38 @@
+schema SecretSauce
+  water: Number
+  salt: Number
+  sugar: Number
+  secret_herbs_and_spices: Number
+
+@egressType('Supermarket')
+policy SecretSaucePolicy {
+  from SecretSauce access {
+    water,
+    salt,
+    sugar,
+  }
+}
+
+@isolated
+particle IngredientProducer
+  sauce: writes SecretSauce {water, salt, sugar, secret_herbs_and_spices}
+
+@isolated
+particle Manufacturer
+  sauce: reads SecretSauce {water, salt, sugar}
+  product: writes Product {ingredients: Text}
+
+@egress('Supermarket')
+particle SupermarketCourier
+  shipment: reads ~a
+
+@policy('SecretSaucePolicy')
+recipe ManufactureRecipe
+  sauce: create 'secret_sauce'
+  IngredientProducer
+    sauce: sauce
+  Manufacturer
+    sauce: sauce
+    product: product
+  SupermarketCourier
+    shipment: product

--- a/particles/Native/Wasm/BUILD
+++ b/particles/Native/Wasm/BUILD
@@ -60,6 +60,7 @@ arcs_manifest(
 arcs_manifest(
     name = "harness_manifest",
     srcs = ["Harness.arcs"],
+    manifest_proto = False,
     deps = [":test_particle"],
 )
 

--- a/third_party/bazel_skylib/lib/BUILD
+++ b/third_party/bazel_skylib/lib/BUILD
@@ -1,0 +1,3 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])

--- a/third_party/bazel_skylib/lib/shell.bzl
+++ b/third_party/bazel_skylib/lib/shell.bzl
@@ -1,0 +1,5 @@
+"""Re-exports shell rule."""
+
+load("@bazel_skylib//lib:shell.bzl", _shell = "shell")
+
+shell = _shell

--- a/third_party/java/arcs/build_defs/internal/run_test.bzl
+++ b/third_party/java/arcs/build_defs/internal/run_test.bzl
@@ -1,0 +1,65 @@
+"""Defines a run_test helper rule for invoking a test binary."""
+
+load("//third_party/bazel_skylib/lib:shell.bzl", "shell")
+
+# Template for a bash script to run a binary with arguments.
+_RUN_TEST_TEMPLATE = """\
+#!/bin/bash
+{binary_path} {args}
+"""
+
+def _run_test_impl(ctx):
+    # Expand $(location ...) templates in the test args.
+    data = ctx.attr.data
+    args = [ctx.expand_location(arg, data) for arg in ctx.attr.test_args]
+    args = " ".join([shell.quote(arg) for arg in args])
+
+    # Compute the path to the test binary.
+    binary_label = ctx.attr.test_binary.label
+    binary_path = "%s/%s" % (binary_label.package, binary_label.name)
+
+    # Generate a script to run the test binary with the given args.
+    content = _RUN_TEST_TEMPLATE.format(binary_path = binary_path, args = args)
+    script = ctx.actions.declare_file(ctx.label.name)
+    ctx.actions.write(
+        output = script,
+        content = content,
+        is_executable = True,
+    )
+
+    # Merge the runfiles from the test binary and data dependencies.
+    runfiles = ctx.attr.test_binary[DefaultInfo].default_runfiles
+    files = []
+    for datum in data:
+        info = datum[DefaultInfo]
+        runfiles = runfiles.merge(info.default_runfiles)
+        files.append(info.files)
+    runfiles = runfiles.merge(ctx.runfiles(transitive_files = depset(transitive = files)))
+
+    return [DefaultInfo(
+        executable = script,
+        runfiles = runfiles,
+    )]
+
+run_test = rule(
+    implementation = _run_test_impl,
+    test = True,
+    doc = "Runs the given test binary with given arguments.",
+    attrs = {
+        "test_binary": attr.label(
+            executable = True,
+            mandatory = True,
+            cfg = "target",
+            doc = "The test binary to run.",
+        ),
+        "test_args": attr.string_list(
+            allow_empty = True,
+            doc = "Command line flags to pass to the test binary.",
+        ),
+        "data": attr.label_list(
+            allow_empty = True,
+            allow_files = True,
+            doc = "Extra data files needed when running the test.",
+        ),
+    },
+)

--- a/third_party/java/arcs/build_defs/internal/schemas.bzl
+++ b/third_party/java/arcs/build_defs/internal/schemas.bzl
@@ -190,6 +190,7 @@ def arcs_kt_gen(
     arcs_manifest(
         name = manifest_name,
         srcs = srcs,
+        manifest_proto = False,
         deps = manifest_only(deps) + data,
     )
 

--- a/third_party/java/arcs/build_defs/internal/tools.oss.bzl
+++ b/third_party/java/arcs/build_defs/internal/tools.oss.bzl
@@ -6,6 +6,7 @@ the actual sigh_command invocations.
 """
 
 load("//third_party/java/arcs/build_defs:sigh.bzl", "sigh_command")
+load(":run_test.bzl", "run_test")
 
 # buildifier: disable=function-docstring
 def arcs_tool_recipe2plan(name, srcs, outs, deps, generate_proto = False, recipe = None):
@@ -56,4 +57,21 @@ def arcs_tool_schema2wasm(name, srcs, outs, deps, language_name, language_flag, 
         deps = deps,
         progress_message = "Generating %s entity schemas" % language_name,
         sigh_cmd = sigh_cmd,
+    )
+
+def arcs_tool_verify_policy(name, manifest_proto, policy_options_proto):
+    """Creates a test to check that a recipe is compliant with policy."""
+    run_test(
+        name = name,
+        test_binary = "//java/arcs/tools:verify_policy",
+        test_args = [
+            "--manifest",
+            "$(rootpath %s)" % manifest_proto,
+            "--options",
+            "$(rootpath %s)" % policy_options_proto,
+        ],
+        data = [
+            manifest_proto,
+            policy_options_proto,
+        ],
     )


### PR DESCRIPTION
The run_test helper rule is there to invoke a test binary with custom args, which is apparently something that bazel does not support out of the box.

The arcs_manifest BUILD rule can now also generate a policy_test rule, which runs the VerifyPolicy program against the manifest.

Also added a testcase to exercise the new rule.

Just review 2nd commit.