### PR TITLE
Introduce simpler `SchedulerProvider`

### DIFF
--- a/java/arcs/android/demo/DemoActivity.kt
+++ b/java/arcs/android/demo/DemoActivity.kt
@@ -18,12 +18,11 @@ import arcs.android.host.AndroidManifestHostRegistry
 import arcs.core.allocator.Allocator
 import arcs.core.host.EntityHandleManager
 import arcs.core.host.HostRegistry
+import arcs.core.host.SimpleSchedulerProvider
 import arcs.core.storage.StoreManager
-import arcs.jvm.host.JvmSchedulerProvider
 import arcs.jvm.util.JvmTime
 import arcs.sdk.android.storage.ServiceStoreFactory
 import kotlin.coroutines.CoroutineContext
-import kotlin.coroutines.EmptyCoroutineContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -38,7 +37,7 @@ class DemoActivity : AppCompatActivity() {
 
     private val coroutineContext: CoroutineContext = Job() + Dispatchers.Main
     private val scope: CoroutineScope = CoroutineScope(coroutineContext)
-    private val schedulerProvider = JvmSchedulerProvider(EmptyCoroutineContext)
+    private val schedulerProvider = SimpleSchedulerProvider(Dispatchers.Default)
 
     /**
      * Recipe hand translated from 'person.arcs'

--- a/java/arcs/android/demo/DemoService.kt
+++ b/java/arcs/android/demo/DemoService.kt
@@ -10,8 +10,8 @@ import arcs.android.sdk.host.ArcHostService
 import arcs.core.host.ArcHost
 import arcs.core.host.ParticleRegistration
 import arcs.core.host.SchedulerProvider
+import arcs.core.host.SimpleSchedulerProvider
 import arcs.core.host.toRegistration
-import arcs.jvm.host.JvmSchedulerProvider
 import arcs.jvm.util.JvmTime
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -31,7 +31,7 @@ class DemoService : ArcHostService() {
     override val arcHost = MyArcHost(
         this,
         this.lifecycle,
-        JvmSchedulerProvider(coroutineContext),
+        SimpleSchedulerProvider(coroutineContext),
         ::ReadPerson.toRegistration(),
         ::WritePerson.toRegistration()
     )

--- a/java/arcs/core/host/SimpleSchedulerProvider.kt
+++ b/java/arcs/core/host/SimpleSchedulerProvider.kt
@@ -1,0 +1,42 @@
+package arcs.core.host
+
+import arcs.core.util.Scheduler
+import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.Job
+
+/**
+ * Simple implementation of a [SchedulerProvider].
+ */
+class SimpleSchedulerProvider(
+    baseCoroutineContext: CoroutineContext
+) : SchedulerProvider {
+    private val providerParentJob = Job(baseCoroutineContext[Job])
+    private val providerCoroutineContext = baseCoroutineContext + providerParentJob
+    private val schedulers = mutableMapOf<String, Scheduler>()
+
+    @Synchronized
+    override fun invoke(arcId: String): Scheduler {
+        return schedulers.getOrPut(arcId) {
+            val schedulerJob = Job(providerParentJob).apply {
+                // Remove the scheduler from the internal map if its job completes.
+                invokeOnCompletion {
+                    synchronized(this) {
+                        schedulers.remove(arcId)
+                    }
+                }
+            }
+
+            Scheduler(
+                providerCoroutineContext +
+                schedulerJob +
+                CoroutineName("ArcId::$arcId")
+            )
+        }
+    }
+
+    @Synchronized
+    override fun cancelAll() {
+        providerParentJob.cancel()
+    }
+}

--- a/java/arcs/jvm/host/JvmRoundRobinSchedulerProvider.kt
+++ b/java/arcs/jvm/host/JvmRoundRobinSchedulerProvider.kt
@@ -26,6 +26,8 @@ import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.asCoroutineDispatcher
 
+typealias JvmSchedulerProvider = JvmRoundRobinSchedulerProvider
+
 /**
  * Implementation of a [SchedulerProvider] for the Java Virtual Machine (including Android).
  *
@@ -34,9 +36,9 @@ import kotlinx.coroutines.asCoroutineDispatcher
  * allocated to schedulers from a finite pool of dispatchers in a round-robin fashion - the size
  * of that pool is defined by [maxThreadCount].
  *
- * Each [ArcHost] should generally use a separate [JvmSchedulerProvider].
+ * Each [ArcHost] should generally use a separate [JvmRoundRobinSchedulerProvider].
  */
-class JvmSchedulerProvider(
+class JvmRoundRobinSchedulerProvider(
     private val baseCoroutineContext: CoroutineContext,
     private val maxThreadCount: Int =
         maxOf(1, Runtime.getRuntime().availableProcessors() / 2),

--- a/java/arcs/sdk/testing/BaseTestHarness.kt
+++ b/java/arcs/sdk/testing/BaseTestHarness.kt
@@ -6,19 +6,19 @@ import arcs.core.entity.HandleDataType
 import arcs.core.entity.HandleSpec
 import arcs.core.host.EntityHandleManager
 import arcs.core.host.ParticleContext
+import arcs.core.host.SimpleSchedulerProvider
 import arcs.core.storage.api.DriverAndKeyConfigurator
 import arcs.core.storage.driver.RamDisk
 import arcs.core.storage.driver.RamDiskDriverProvider
 import arcs.core.storage.keys.RamDiskStorageKey
 import arcs.core.storage.referencemode.ReferenceModeStorageKey
 import arcs.core.util.Scheduler
-import arcs.jvm.host.JvmSchedulerProvider
 import arcs.jvm.util.JvmTime
 import arcs.sdk.Handle
 import arcs.sdk.Particle
 import com.google.common.truth.Truth.assertWithMessage
-import kotlin.coroutines.EmptyCoroutineContext
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.coroutineScope
@@ -93,7 +93,7 @@ open class BaseTestHarness<P : Particle>(
                 RamDiskDriverProvider()
                 DriverAndKeyConfigurator.configureKeyParsers()
 
-                val schedulerProvider = JvmSchedulerProvider(EmptyCoroutineContext)
+                val schedulerProvider = SimpleSchedulerProvider(Dispatchers.Default)
                 scheduler = schedulerProvider(description.methodName)
                 val handleManager = EntityHandleManager(
                     arcId = "testHarness",

--- a/javatests/arcs/android/e2e/testapp/PersonHostService.kt
+++ b/javatests/arcs/android/e2e/testapp/PersonHostService.kt
@@ -19,8 +19,8 @@ import arcs.android.sdk.host.ArcHostService
 import arcs.core.data.Plan
 import arcs.core.host.ParticleRegistration
 import arcs.core.host.SchedulerProvider
+import arcs.core.host.SimpleSchedulerProvider
 import arcs.core.host.toRegistration
-import arcs.jvm.host.JvmSchedulerProvider
 import arcs.jvm.util.JvmTime
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -37,7 +37,7 @@ class PersonHostService : ArcHostService() {
     override val arcHost = MyArcHost(
         this,
         this.lifecycle,
-        JvmSchedulerProvider(coroutineContext),
+        SimpleSchedulerProvider(coroutineContext),
         ::ReadPerson.toRegistration(),
         ::WritePerson.toRegistration()
     )

--- a/javatests/arcs/android/e2e/testapp/ReadAnimalHostService.kt
+++ b/javatests/arcs/android/e2e/testapp/ReadAnimalHostService.kt
@@ -19,8 +19,8 @@ import arcs.android.sdk.host.ArcHostService
 import arcs.core.host.ArcHost
 import arcs.core.host.ParticleRegistration
 import arcs.core.host.SchedulerProvider
+import arcs.core.host.SimpleSchedulerProvider
 import arcs.core.host.toRegistration
-import arcs.jvm.host.JvmSchedulerProvider
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
@@ -36,7 +36,7 @@ class ReadAnimalHostService : ArcHostService() {
     override val arcHost: ArcHost = MyArcHost(
         this,
         this.lifecycle,
-        JvmSchedulerProvider(coroutineContext),
+        SimpleSchedulerProvider(coroutineContext),
         ::ReadAnimal.toRegistration()
     )
 

--- a/javatests/arcs/android/e2e/testapp/TestActivity.kt
+++ b/javatests/arcs/android/e2e/testapp/TestActivity.kt
@@ -34,14 +34,13 @@ import arcs.core.data.SingletonType
 import arcs.core.entity.HandleSpec
 import arcs.core.entity.awaitReady
 import arcs.core.host.EntityHandleManager
+import arcs.core.host.SimpleSchedulerProvider
 import arcs.core.storage.StoreManager
-import arcs.jvm.host.JvmSchedulerProvider
 import arcs.jvm.util.JvmTime
 import arcs.sdk.ReadWriteCollectionHandle
 import arcs.sdk.ReadWriteSingletonHandle
 import arcs.sdk.android.storage.ServiceStoreFactory
 import kotlin.coroutines.CoroutineContext
-import kotlin.coroutines.EmptyCoroutineContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -63,7 +62,7 @@ class TestActivity : AppCompatActivity() {
 
     private val coroutineContext: CoroutineContext = Job() + Dispatchers.Main
     private val scope: CoroutineScope = CoroutineScope(coroutineContext)
-    private val schedulerProvider = JvmSchedulerProvider(EmptyCoroutineContext)
+    private val schedulerProvider = SimpleSchedulerProvider(Dispatchers.Default)
     private var storageMode = TestEntity.StorageMode.IN_MEMORY
     private var isCollection = false
     private var setFromRemoteService = false

--- a/javatests/arcs/android/e2e/testapp/WriteAnimalHostService.kt
+++ b/javatests/arcs/android/e2e/testapp/WriteAnimalHostService.kt
@@ -18,8 +18,8 @@ import arcs.android.sdk.host.AndroidHost
 import arcs.android.sdk.host.ArcHostService
 import arcs.core.host.ParticleRegistration
 import arcs.core.host.SchedulerProvider
+import arcs.core.host.SimpleSchedulerProvider
 import arcs.core.host.toRegistration
-import arcs.jvm.host.JvmSchedulerProvider
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
@@ -36,7 +36,7 @@ class WriteAnimalHostService : ArcHostService() {
     override val arcHost: MyArcHost = MyArcHost(
         this,
         this.lifecycle,
-        JvmSchedulerProvider(coroutineContext),
+        SimpleSchedulerProvider(coroutineContext),
         ::WriteAnimal.toRegistration()
     )
 

--- a/javatests/arcs/android/entity/DifferentAndroidHandleManagerDifferentStoresTest.kt
+++ b/javatests/arcs/android/entity/DifferentAndroidHandleManagerDifferentStoresTest.kt
@@ -9,10 +9,8 @@ import arcs.core.entity.HandleManagerTestBase
 import arcs.core.host.EntityHandleManager
 import arcs.core.storage.StoreManager
 import arcs.core.storage.driver.DatabaseDriverProvider
-import arcs.jvm.host.JvmSchedulerProvider
 import arcs.sdk.android.storage.ServiceStoreFactory
 import arcs.sdk.android.storage.service.testutil.TestConnectionFactory
-import kotlin.coroutines.EmptyCoroutineContext
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Before
@@ -37,7 +35,6 @@ class DifferentAndroidHandleManagerDifferentStoresTest : HandleManagerTestBase()
             app,
             connectionFactory = TestConnectionFactory(app)
         )
-        schedulerProvider = JvmSchedulerProvider(EmptyCoroutineContext)
         readStores = StoreManager(activationFactory)
         readHandleManager = EntityHandleManager(
             arcId = "arcId",

--- a/javatests/arcs/android/entity/DifferentHandleManagerTest.kt
+++ b/javatests/arcs/android/entity/DifferentHandleManagerTest.kt
@@ -9,10 +9,8 @@ import arcs.core.entity.HandleManagerTestBase
 import arcs.core.host.EntityHandleManager
 import arcs.core.storage.StoreManager
 import arcs.core.storage.driver.DatabaseDriverProvider
-import arcs.jvm.host.JvmSchedulerProvider
 import arcs.sdk.android.storage.ServiceStoreFactory
 import arcs.sdk.android.storage.service.testutil.TestConnectionFactory
-import kotlin.coroutines.EmptyCoroutineContext
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Before
@@ -38,7 +36,6 @@ class DifferentHandleManagerTest : HandleManagerTestBase() {
             connectionFactory = TestConnectionFactory(app)
         )
         stores = StoreManager(activationFactory)
-        schedulerProvider = JvmSchedulerProvider(EmptyCoroutineContext)
         readHandleManager = EntityHandleManager(
             arcId = "arcId",
             hostId = "hostId",

--- a/javatests/arcs/android/entity/SameHandleManagerTest.kt
+++ b/javatests/arcs/android/entity/SameHandleManagerTest.kt
@@ -9,10 +9,8 @@ import arcs.core.entity.HandleManagerTestBase
 import arcs.core.host.EntityHandleManager
 import arcs.core.storage.StoreManager
 import arcs.core.storage.driver.DatabaseDriverProvider
-import arcs.jvm.host.JvmSchedulerProvider
 import arcs.sdk.android.storage.ServiceStoreFactory
 import arcs.sdk.android.storage.service.testutil.TestConnectionFactory
-import kotlin.coroutines.EmptyCoroutineContext
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Before
@@ -32,7 +30,6 @@ class SameHandleManagerTest : HandleManagerTestBase() {
         app = ApplicationProvider.getApplicationContext()
         val dbFactory = AndroidSqliteDatabaseManager(ApplicationProvider.getApplicationContext())
         DatabaseDriverProvider.configure(dbFactory) { throw UnsupportedOperationException() }
-        schedulerProvider = JvmSchedulerProvider(EmptyCoroutineContext)
         activationFactory = ServiceStoreFactory(
             app,
             connectionFactory = TestConnectionFactory(app)

--- a/javatests/arcs/android/entity/TtlHandleTest.kt
+++ b/javatests/arcs/android/entity/TtlHandleTest.kt
@@ -16,6 +16,7 @@ import arcs.core.entity.ReadWriteCollectionHandle
 import arcs.core.entity.ReadWriteSingletonHandle
 import arcs.core.entity.awaitReady
 import arcs.core.host.EntityHandleManager
+import arcs.core.host.SimpleSchedulerProvider
 import arcs.core.storage.StorageKey
 import arcs.core.storage.StoreWriteBack
 import arcs.core.storage.api.DriverAndKeyConfigurator
@@ -27,11 +28,10 @@ import arcs.core.testutil.handles.dispatchFetchAll
 import arcs.core.testutil.handles.dispatchStore
 import arcs.core.util.Scheduler
 import arcs.core.util.testutil.LogRule
-import arcs.jvm.host.JvmSchedulerProvider
 import arcs.jvm.util.testutil.FakeTime
 import com.google.common.truth.Truth.assertThat
-import kotlin.coroutines.EmptyCoroutineContext
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.runBlocking
@@ -47,7 +47,7 @@ class TtlHandleTest {
     @get:Rule
     val log = LogRule()
 
-    private val schedulerProvider = JvmSchedulerProvider(EmptyCoroutineContext)
+    private val schedulerProvider = SimpleSchedulerProvider(Dispatchers.Default)
     private val backingKey = DatabaseStorageKey.Persistent(
         "entities-backing",
         DummyEntity.SCHEMA_HASH

--- a/javatests/arcs/android/host/AndroidEntityHandleManagerTest.kt
+++ b/javatests/arcs/android/host/AndroidEntityHandleManagerTest.kt
@@ -21,6 +21,7 @@ import arcs.core.entity.WriteCollectionHandle
 import arcs.core.entity.WriteSingletonHandle
 import arcs.core.entity.awaitReady
 import arcs.core.host.EntityHandleManager
+import arcs.core.host.SimpleSchedulerProvider
 import arcs.core.storage.StoreManager
 import arcs.core.storage.api.DriverAndKeyConfigurator
 import arcs.core.storage.driver.RamDisk
@@ -31,16 +32,15 @@ import arcs.core.testutil.handles.dispatchFetchAll
 import arcs.core.testutil.handles.dispatchQuery
 import arcs.core.testutil.handles.dispatchStore
 import arcs.core.util.testutil.LogRule
-import arcs.jvm.host.JvmSchedulerProvider
 import arcs.jvm.util.testutil.FakeTime
 import arcs.sdk.android.storage.ServiceStoreFactory
 import arcs.sdk.android.storage.service.testutil.TestConnectionFactory
 import com.google.common.truth.Truth.assertThat
-import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
 import kotlin.test.assertFailsWith
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runBlockingTest
@@ -80,7 +80,7 @@ class AndroidEntityHandleManagerTest {
         storageKey = RamDiskStorageKey("collection-ent")
     )
 
-    private val schedulerProvider = JvmSchedulerProvider(EmptyCoroutineContext)
+    private val schedulerProvider = SimpleSchedulerProvider(Dispatchers.Default)
 
     @Before
     fun setUp() = runBlockingTest {

--- a/javatests/arcs/android/host/TestExternalArcHostService.kt
+++ b/javatests/arcs/android/host/TestExternalArcHostService.kt
@@ -10,6 +10,7 @@ import arcs.core.data.Capabilities
 import arcs.core.data.Capability.Shareable
 import arcs.core.host.ParticleRegistration
 import arcs.core.host.SchedulerProvider
+import arcs.core.host.SimpleSchedulerProvider
 import arcs.core.host.TestingHost
 import arcs.core.storage.StoreManager
 import arcs.sdk.android.storage.ResurrectionHelper
@@ -26,6 +27,8 @@ abstract class TestExternalArcHostService : Service() {
     protected val scope: CoroutineScope = MainScope()
 
     abstract val arcHost: TestingAndroidHost
+
+    val schedulerProvider = SimpleSchedulerProvider(Dispatchers.Default)
 
     val arcHostHelper: ArcHostHelper by lazy {
         ArcHostHelper(this, arcHost)

--- a/javatests/arcs/android/host/TestProdArcHostService.kt
+++ b/javatests/arcs/android/host/TestProdArcHostService.kt
@@ -4,9 +4,9 @@ import android.content.Context
 import arcs.android.host.prod.ProdArcHostService
 import arcs.core.host.ParticleRegistration
 import arcs.core.host.SchedulerProvider
+import arcs.core.host.SimpleSchedulerProvider
 import arcs.core.host.TestingJvmProdHost
 import arcs.core.storage.StoreManager
-import arcs.jvm.host.JvmSchedulerProvider
 import arcs.sdk.android.storage.ServiceStoreFactory
 import arcs.sdk.android.storage.service.testutil.TestConnectionFactory
 import kotlinx.coroutines.Dispatchers
@@ -15,13 +15,14 @@ import kotlinx.coroutines.runBlocking
 
 @ExperimentalCoroutinesApi
 class TestProdArcHostService : ProdArcHostService() {
-    override val arcHost = TestingAndroidProdHost(
-        this,
-        JvmSchedulerProvider(scope.coroutineContext)
-    )
-
     override val coroutineContext = Dispatchers.Default
     override val arcSerializationCoroutineContext = Dispatchers.Default
+    val schedulerProvider = SimpleSchedulerProvider(coroutineContext)
+
+    override val arcHost = TestingAndroidProdHost(
+        this,
+        schedulerProvider
+    )
 
     override val arcHosts = listOf(arcHost)
 

--- a/javatests/arcs/android/host/TestReadingExternalHostService.kt
+++ b/javatests/arcs/android/host/TestReadingExternalHostService.kt
@@ -2,14 +2,13 @@ package arcs.android.host
 
 import arcs.core.host.ReadPerson
 import arcs.core.host.toRegistration
-import arcs.jvm.host.JvmSchedulerProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 
 @ExperimentalCoroutinesApi
 class TestReadingExternalHostService : TestExternalArcHostService() {
     override val arcHost = object : TestingAndroidHost(
         this@TestReadingExternalHostService,
-        JvmSchedulerProvider(scope.coroutineContext),
+        schedulerProvider,
         ::ReadPerson.toRegistration()
     ) {}
 }

--- a/javatests/arcs/android/host/TestWritingExternalHostService.kt
+++ b/javatests/arcs/android/host/TestWritingExternalHostService.kt
@@ -2,14 +2,13 @@ package arcs.android.host
 
 import arcs.core.host.WritePerson
 import arcs.core.host.toRegistration
-import arcs.jvm.host.JvmSchedulerProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 
 @ExperimentalCoroutinesApi
 class TestWritingExternalHostService : TestExternalArcHostService() {
     override val arcHost = object : TestingAndroidHost(
         this@TestWritingExternalHostService,
-        JvmSchedulerProvider(scope.coroutineContext),
+        schedulerProvider,
         ::WritePerson.toRegistration()
     ) {}
 }

--- a/javatests/arcs/android/storage/database/DatabaseGarbageCollectionPeriodicTaskTest.kt
+++ b/javatests/arcs/android/storage/database/DatabaseGarbageCollectionPeriodicTaskTest.kt
@@ -14,6 +14,7 @@ import arcs.core.entity.InlineDummyEntity
 import arcs.core.entity.ReadWriteCollectionHandle
 import arcs.core.entity.awaitReady
 import arcs.core.host.EntityHandleManager
+import arcs.core.host.SimpleSchedulerProvider
 import arcs.core.storage.api.DriverAndKeyConfigurator
 import arcs.core.storage.keys.DatabaseStorageKey
 import arcs.core.storage.referencemode.ReferenceModeStorageKey
@@ -21,10 +22,9 @@ import arcs.core.testutil.handles.dispatchCreateReference
 import arcs.core.testutil.handles.dispatchFetchAll
 import arcs.core.testutil.handles.dispatchRemove
 import arcs.core.testutil.handles.dispatchStore
-import arcs.jvm.host.JvmSchedulerProvider
 import arcs.jvm.util.testutil.FakeTime
 import com.google.common.truth.Truth.assertThat
-import kotlin.coroutines.EmptyCoroutineContext
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import org.junit.Before
 import org.junit.Test
@@ -33,7 +33,7 @@ import org.junit.runner.RunWith
 @Suppress("EXPERIMENTAL_API_USAGE", "UNCHECKED_CAST")
 @RunWith(AndroidJUnit4::class)
 class DatabaseGarbageCollectionPeriodicTaskTest {
-    private val schedulerProvider = JvmSchedulerProvider(EmptyCoroutineContext)
+    private val schedulerProvider = SimpleSchedulerProvider(Dispatchers.Default)
     private val backingKey = DatabaseStorageKey.Persistent(
         "entities-backing",
         DummyEntity.SCHEMA_HASH

--- a/javatests/arcs/android/storage/service/StorageServiceManagerTest.kt
+++ b/javatests/arcs/android/storage/service/StorageServiceManagerTest.kt
@@ -26,6 +26,7 @@ import arcs.core.entity.ReadWriteCollectionHandle
 import arcs.core.entity.ReadWriteSingletonHandle
 import arcs.core.entity.awaitReady
 import arcs.core.host.EntityHandleManager
+import arcs.core.host.SimpleSchedulerProvider
 import arcs.core.storage.DriverFactory
 import arcs.core.storage.StorageKey
 import arcs.core.storage.StoreWriteBack
@@ -42,13 +43,12 @@ import arcs.core.testutil.handles.dispatchFetch
 import arcs.core.testutil.handles.dispatchFetchAll
 import arcs.core.testutil.handles.dispatchStore
 import arcs.core.util.testutil.LogRule
-import arcs.jvm.host.JvmSchedulerProvider
 import arcs.jvm.util.testutil.FakeTime
 import arcs.sdk.android.storage.AndroidDriverAndKeyConfigurator
 import com.google.common.truth.Truth.assertThat
 import java.util.concurrent.ConcurrentHashMap
-import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.coroutines.coroutineContext
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import org.junit.After
@@ -67,7 +67,7 @@ class StorageServiceManagerTest {
     private suspend fun buildManager() =
         StorageServiceManager(coroutineContext, ConcurrentHashMap())
     private val time = FakeTime()
-    private val scheduler = JvmSchedulerProvider(EmptyCoroutineContext).invoke("test")
+    private val scheduler = SimpleSchedulerProvider(Dispatchers.Default).invoke("test")
     private val ramdiskKey = ReferenceModeStorageKey(
         backingKey = RamDiskStorageKey("backing"),
         storageKey = RamDiskStorageKey("container")

--- a/javatests/arcs/android/storage/ttl/PeriodicCleanupTaskTest.kt
+++ b/javatests/arcs/android/storage/ttl/PeriodicCleanupTaskTest.kt
@@ -17,6 +17,7 @@ import arcs.core.entity.InlineDummyEntity
 import arcs.core.entity.ReadWriteCollectionHandle
 import arcs.core.entity.awaitReady
 import arcs.core.host.EntityHandleManager
+import arcs.core.host.SimpleSchedulerProvider
 import arcs.core.storage.StoreWriteBack
 import arcs.core.storage.api.DriverAndKeyConfigurator
 import arcs.core.storage.keys.DatabaseStorageKey
@@ -24,11 +25,10 @@ import arcs.core.storage.referencemode.ReferenceModeStorageKey
 import arcs.core.storage.testutil.WriteBackForTesting
 import arcs.core.testutil.handles.dispatchFetchAll
 import arcs.core.testutil.handles.dispatchStore
-import arcs.jvm.host.JvmSchedulerProvider
 import arcs.jvm.util.JvmTime
 import arcs.jvm.util.testutil.FakeTime
 import com.google.common.truth.Truth.assertThat
-import kotlin.coroutines.EmptyCoroutineContext
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import org.junit.Before
 import org.junit.Test
@@ -133,7 +133,7 @@ class PeriodicCleanupTaskTest {
     private suspend fun createCollectionHandle() =
         EntityHandleManager(
             time = fakeTime,
-            scheduler = JvmSchedulerProvider(EmptyCoroutineContext)("test")
+            scheduler = SimpleSchedulerProvider(Dispatchers.Default)("test")
         ).createHandle(
             HandleSpec(
                 "name",

--- a/javatests/arcs/android/systemhealth/testapp/TestActivity.kt
+++ b/javatests/arcs/android/systemhealth/testapp/TestActivity.kt
@@ -35,8 +35,8 @@ import arcs.core.entity.HandleSpec
 import arcs.core.entity.ReadSingletonHandle
 import arcs.core.entity.awaitReady
 import arcs.core.host.EntityHandleManager
+import arcs.core.host.SimpleSchedulerProvider
 import arcs.core.storage.StoreManager
-import arcs.jvm.host.JvmSchedulerProvider
 import arcs.jvm.util.JvmTime
 import arcs.sdk.ReadCollectionHandle
 import arcs.sdk.ReadWriteCollectionHandle
@@ -44,7 +44,6 @@ import arcs.sdk.ReadWriteSingletonHandle
 import arcs.sdk.android.storage.ServiceStoreFactory
 import java.util.concurrent.Executors
 import kotlin.coroutines.CoroutineContext
-import kotlin.coroutines.EmptyCoroutineContext
 import kotlinx.atomicfu.atomic
 import kotlinx.atomicfu.update
 import kotlinx.coroutines.CoroutineScope
@@ -64,7 +63,7 @@ class TestActivity : AppCompatActivity() {
     private val coroutineContext: CoroutineContext =
         Executors.newSingleThreadExecutor().asCoroutineDispatcher()
     private val scope: CoroutineScope = CoroutineScope(coroutineContext)
-    private val schedulerProvider = JvmSchedulerProvider(EmptyCoroutineContext)
+    private val schedulerProvider = SimpleSchedulerProvider(Dispatchers.Default)
     private lateinit var handleManager: EntityHandleManager
 
     private var handleType = SystemHealthEnums.HandleType.SINGLETON

--- a/javatests/arcs/core/allocator/AllocatorTestBase.kt
+++ b/javatests/arcs/core/allocator/AllocatorTestBase.kt
@@ -18,6 +18,7 @@ import arcs.core.host.ParticleState
 import arcs.core.host.PersonPlan
 import arcs.core.host.ReadPerson
 import arcs.core.host.ReadPerson_Person
+import arcs.core.host.SimpleSchedulerProvider
 import arcs.core.host.TestingHost
 import arcs.core.host.TestingJvmProdHost
 import arcs.core.host.WritePerson
@@ -34,7 +35,6 @@ import arcs.core.util.plus
 import arcs.core.util.testutil.LogRule
 import arcs.core.util.traverse
 import arcs.jvm.host.ExplicitHostRegistry
-import arcs.jvm.host.JvmSchedulerProvider
 import arcs.jvm.util.testutil.FakeTime
 import com.google.common.truth.Truth.assertThat
 import java.lang.IllegalArgumentException
@@ -42,6 +42,7 @@ import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
 import org.junit.Before
@@ -56,7 +57,7 @@ open class AllocatorTestBase {
     @get:Rule
     val log = LogRule(Log.Level.Warning)
 
-    private val schedulerProvider = JvmSchedulerProvider(EmptyCoroutineContext)
+    private val schedulerProvider = SimpleSchedulerProvider(Dispatchers.Default)
 
     /**
      * Recipe hand translated from 'person.arcs'
@@ -73,12 +74,12 @@ open class AllocatorTestBase {
     private lateinit var pureHost: TestingJvmProdHost
 
     private class WritingHost : TestingHost(
-        JvmSchedulerProvider(EmptyCoroutineContext),
+        SimpleSchedulerProvider(EmptyCoroutineContext),
         ::WritePerson.toRegistration()
     )
 
     private class ReadingHost : TestingHost(
-        JvmSchedulerProvider(EmptyCoroutineContext),
+        SimpleSchedulerProvider(EmptyCoroutineContext),
         ::ReadPerson.toRegistration()
     )
 

--- a/javatests/arcs/core/entity/DifferentHandleManagerDifferentStoresTest.kt
+++ b/javatests/arcs/core/entity/DifferentHandleManagerDifferentStoresTest.kt
@@ -4,8 +4,6 @@ import arcs.core.host.EntityHandleManager
 import arcs.core.storage.StoreManager
 import arcs.core.storage.StoreWriteBack
 import arcs.core.storage.testutil.WriteBackForTesting
-import arcs.jvm.host.JvmSchedulerProvider
-import kotlin.coroutines.EmptyCoroutineContext
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Before
@@ -25,7 +23,6 @@ class DifferentHandleManagerDifferentStoresTest : HandleManagerTestBase() {
         super.setUp()
         i++
         StoreWriteBack.writeBackFactoryOverride = WriteBackForTesting
-        schedulerProvider = JvmSchedulerProvider(EmptyCoroutineContext)
         readStores = StoreManager()
         readHandleManager = EntityHandleManager(
             arcId = "testArcId",

--- a/javatests/arcs/core/entity/DifferentHandleManagerTest.kt
+++ b/javatests/arcs/core/entity/DifferentHandleManagerTest.kt
@@ -4,8 +4,6 @@ import arcs.core.host.EntityHandleManager
 import arcs.core.storage.StoreManager
 import arcs.core.storage.StoreWriteBack
 import arcs.core.storage.testutil.WriteBackForTesting
-import arcs.jvm.host.JvmSchedulerProvider
-import kotlin.coroutines.EmptyCoroutineContext
 import org.junit.After
 import org.junit.Before
 import org.junit.runner.RunWith
@@ -22,7 +20,6 @@ class DifferentHandleManagerTest : HandleManagerTestBase() {
         val stores = StoreManager()
         i++
         StoreWriteBack.writeBackFactoryOverride = WriteBackForTesting
-        schedulerProvider = JvmSchedulerProvider(EmptyCoroutineContext)
         readHandleManager = EntityHandleManager(
             arcId = "testArc",
             hostId = "testHost",

--- a/javatests/arcs/core/entity/HandleManagerCloseTest.kt
+++ b/javatests/arcs/core/entity/HandleManagerCloseTest.kt
@@ -9,6 +9,7 @@ import arcs.core.data.SingletonType
 import arcs.core.entity.HandleManagerTestBase.CoolnessIndex
 import arcs.core.entity.HandleManagerTestBase.Person
 import arcs.core.host.EntityHandleManager
+import arcs.core.host.SimpleSchedulerProvider
 import arcs.core.storage.StorageKey
 import arcs.core.storage.api.DriverAndKeyConfigurator
 import arcs.core.storage.keys.RamDiskStorageKey
@@ -17,11 +18,10 @@ import arcs.core.testutil.assertSuspendingThrows
 import arcs.core.testutil.handles.dispatchStore
 import arcs.core.util.Scheduler
 import arcs.core.util.testutil.LogRule
-import arcs.jvm.host.JvmSchedulerProvider
 import arcs.jvm.util.testutil.FakeTime
 import com.google.common.truth.Truth.assertThat
 import java.lang.IllegalStateException
-import kotlin.coroutines.EmptyCoroutineContext
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.runBlocking
@@ -55,12 +55,12 @@ class HandleManagerCloseTest {
         storageKey = collectionRefKey
     )
 
-    private lateinit var schedulerProvider: JvmSchedulerProvider
+    private lateinit var schedulerProvider: SimpleSchedulerProvider
     private lateinit var scheduler: Scheduler
 
     @Before
     fun setUp() {
-        schedulerProvider = JvmSchedulerProvider(EmptyCoroutineContext)
+        schedulerProvider = SimpleSchedulerProvider(Dispatchers.Default)
         scheduler = schedulerProvider("test")
         DriverAndKeyConfigurator.configure(null)
         SchemaRegistry.register(Person.SCHEMA)

--- a/javatests/arcs/core/entity/HandleManagerTestBase.kt
+++ b/javatests/arcs/core/entity/HandleManagerTestBase.kt
@@ -24,6 +24,8 @@ import arcs.core.data.util.ReferencableList
 import arcs.core.data.util.ReferencablePrimitive
 import arcs.core.data.util.toReferencable
 import arcs.core.host.EntityHandleManager
+import arcs.core.host.SchedulerProvider
+import arcs.core.host.SimpleSchedulerProvider
 import arcs.core.storage.ActivationFactory
 import arcs.core.storage.DefaultActivationFactory
 import arcs.core.storage.Reference as StorageReference
@@ -48,12 +50,13 @@ import arcs.core.testutil.handles.dispatchStore
 import arcs.core.util.ArcsStrictMode
 import arcs.core.util.Time
 import arcs.core.util.testutil.LogRule
-import arcs.jvm.host.JvmSchedulerProvider
 import arcs.jvm.util.testutil.FakeTime
 import com.google.common.truth.Truth.assertThat
+import java.util.concurrent.Executors
 import kotlin.test.assertFailsWith
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.debounce
@@ -118,7 +121,10 @@ open class HandleManagerTestBase {
     )
 
     var activationFactory: ActivationFactory = DefaultActivationFactory
-    lateinit var schedulerProvider: JvmSchedulerProvider
+
+    val schedulerCoroutineContext = Executors.newSingleThreadExecutor().asCoroutineDispatcher()
+    val schedulerProvider: SchedulerProvider = SimpleSchedulerProvider(schedulerCoroutineContext)
+
     lateinit var readHandleManager: EntityHandleManager
     lateinit var writeHandleManager: EntityHandleManager
     lateinit var monitorHandleManager: EntityHandleManager

--- a/javatests/arcs/core/entity/SameHandleManagerTest.kt
+++ b/javatests/arcs/core/entity/SameHandleManagerTest.kt
@@ -4,8 +4,6 @@ import arcs.core.host.EntityHandleManager
 import arcs.core.storage.StoreManager
 import arcs.core.storage.StoreWriteBack
 import arcs.core.storage.testutil.WriteBackForTesting
-import arcs.jvm.host.JvmSchedulerProvider
-import kotlin.coroutines.EmptyCoroutineContext
 import org.junit.After
 import org.junit.Before
 import org.junit.runner.RunWith
@@ -18,7 +16,6 @@ class SameHandleManagerTest : HandleManagerTestBase() {
     override fun setUp() {
         super.setUp()
         StoreWriteBack.writeBackFactoryOverride = WriteBackForTesting
-        schedulerProvider = JvmSchedulerProvider(EmptyCoroutineContext)
         readHandleManager = EntityHandleManager(
             arcId = "testArc",
             hostId = "testHost",

--- a/javatests/arcs/core/host/AbstractArcHostTest.kt
+++ b/javatests/arcs/core/host/AbstractArcHostTest.kt
@@ -15,7 +15,6 @@ import arcs.core.storage.driver.RamDiskDriverProvider
 import arcs.core.storage.keys.RamDiskStorageKey
 import arcs.core.storage.referencemode.ReferenceModeStorageKey
 import arcs.core.testutil.handles.dispatchStore
-import arcs.jvm.host.JvmSchedulerProvider
 import arcs.jvm.util.testutil.FakeTime
 import arcs.sdk.BaseParticle
 import arcs.sdk.HandleHolderBase
@@ -77,7 +76,7 @@ open class AbstractArcHostTest {
 
     @Test
     fun pause_Unpause() = runBlocking {
-        val schedulerProvider = JvmSchedulerProvider(coroutineContext)
+        val schedulerProvider = SimpleSchedulerProvider(coroutineContext)
         val host = MyTestHost(schedulerProvider)
         val partition = Plan.Partition("arcId", "arcHost", listOf())
         val partition2 = Plan.Partition("arcId2", "arcHost", listOf())
@@ -107,7 +106,7 @@ open class AbstractArcHostTest {
     // Regression test for b/152713120.
     @Test
     fun ttlUsed() = runBlocking {
-        val schedulerProvider = JvmSchedulerProvider(coroutineContext)
+        val schedulerProvider = SimpleSchedulerProvider(coroutineContext)
         val host = MyTestHost(schedulerProvider, ::TestParticle.toRegistration())
         val handleStorageKey = ReferenceModeStorageKey(
             backingKey = RamDiskStorageKey("backing"),
@@ -145,7 +144,7 @@ open class AbstractArcHostTest {
     @Suppress("UNCHECKED_CAST")
     @Test
     fun storeRestrictedHandleSchema() = runBlocking {
-        val schedulerProvider = JvmSchedulerProvider(coroutineContext)
+        val schedulerProvider = SimpleSchedulerProvider(coroutineContext)
         val host = MyTestHost(schedulerProvider, ::TestParticle.toRegistration())
         val handleStorageKey = ReferenceModeStorageKey(
             backingKey = RamDiskStorageKey("backing"),
@@ -188,7 +187,7 @@ open class AbstractArcHostTest {
     fun errorStateHoldsExceptionsFromParticles() = runBlocking {
         TestParticle.failAtStart = true
 
-        val schedulerProvider = JvmSchedulerProvider(coroutineContext)
+        val schedulerProvider = SimpleSchedulerProvider(coroutineContext)
         val host = MyTestHost(schedulerProvider, ::TestParticle.toRegistration())
         val particle = Plan.Particle(
             "Test",

--- a/javatests/arcs/core/host/ArcHostManagerTest.kt
+++ b/javatests/arcs/core/host/ArcHostManagerTest.kt
@@ -5,7 +5,6 @@ import arcs.core.storage.api.DriverAndKeyConfigurator
 import arcs.core.storage.driver.RamDisk
 import arcs.core.storage.driver.RamDiskDriverProvider
 import arcs.jvm.host.ExplicitHostRegistry
-import arcs.jvm.host.JvmSchedulerProvider
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
@@ -27,7 +26,7 @@ open class ArcHostManagerTest {
 
     @Test
     fun pauseAllHostsFor() = runBlocking {
-        val schedulerProvider = JvmSchedulerProvider(coroutineContext)
+        val schedulerProvider = SimpleSchedulerProvider(coroutineContext)
         val host = TestHost(schedulerProvider("arcId"))
         val hostRegistry = ExplicitHostRegistry()
         hostRegistry.registerHost(host)

--- a/javatests/arcs/core/host/HandleAdapterTest.kt
+++ b/javatests/arcs/core/host/HandleAdapterTest.kt
@@ -42,7 +42,6 @@ import arcs.core.testutil.handles.dispatchStore
 import arcs.core.testutil.runTest
 import arcs.core.util.Scheduler
 import arcs.core.util.testutil.LogRule
-import arcs.jvm.host.JvmSchedulerProvider
 import arcs.jvm.util.testutil.FakeTime
 import arcs.sdk.ReadWriteCollectionHandle
 import com.google.common.truth.Truth.assertThat
@@ -70,14 +69,14 @@ class HandleAdapterTest {
     private lateinit var manager: EntityHandleManager
     private lateinit var monitorManager: EntityHandleManager
     private val idGenerator = Id.Generator.newForTest("session")
-    private lateinit var schedulerProvider: JvmSchedulerProvider
+    private lateinit var schedulerProvider: SimpleSchedulerProvider
     private lateinit var scheduler: Scheduler
 
     @Before
     fun setUp() = runBlocking {
         RamDisk.clear()
         DriverAndKeyConfigurator.configure(null)
-        schedulerProvider = JvmSchedulerProvider(EmptyCoroutineContext)
+        schedulerProvider = SimpleSchedulerProvider(EmptyCoroutineContext)
         scheduler = schedulerProvider("tests")
         manager = EntityHandleManager(
             "testArc",

--- a/javatests/arcs/core/host/LifecycleTest.kt
+++ b/javatests/arcs/core/host/LifecycleTest.kt
@@ -44,7 +44,7 @@ class LifecycleTest {
     @get:Rule
     val log = LogRule()
 
-    private lateinit var schedulerProvider: JvmSchedulerProvider
+    private lateinit var schedulerProvider: SchedulerProvider
     private lateinit var scheduler: Scheduler
     private lateinit var testHost: TestingHost
     private lateinit var hostRegistry: HostRegistry

--- a/javatests/arcs/core/host/ParticleRegistrationTest.kt
+++ b/javatests/arcs/core/host/ParticleRegistrationTest.kt
@@ -1,7 +1,6 @@
 package arcs.core.host
 
 import arcs.jvm.host.ExplicitHostRegistry
-import arcs.jvm.host.JvmSchedulerProvider
 import arcs.jvm.util.JvmTime
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.Dispatchers
@@ -32,7 +31,7 @@ class ParticleRegistrationTest {
         var foundTestHost = false
 
         val hostRegistry = ExplicitHostRegistry()
-        val schedulerProvider = JvmSchedulerProvider(coroutineContext)
+        val schedulerProvider = SimpleSchedulerProvider(coroutineContext)
 
         hostRegistry.registerHost(
             JvmProdHost(

--- a/javatests/arcs/core/host/ReflectiveParticleConstructionTest.kt
+++ b/javatests/arcs/core/host/ReflectiveParticleConstructionTest.kt
@@ -10,11 +10,9 @@ import arcs.core.storage.driver.VolatileDriverProviderFactory
 import arcs.core.util.TaggedLog
 import arcs.core.util.testutil.LogRule
 import arcs.jvm.host.ExplicitHostRegistry
-import arcs.jvm.host.JvmSchedulerProvider
 import arcs.jvm.util.JvmTime
 import arcs.jvm.util.testutil.FakeTime
 import com.google.common.truth.Truth.assertThat
-import kotlin.coroutines.EmptyCoroutineContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
@@ -68,7 +66,7 @@ class ReflectiveParticleConstructionTest {
         VolatileDriverProviderFactory()
 
         val hostRegistry = ExplicitHostRegistry()
-        val schedulerProvider = JvmSchedulerProvider(EmptyCoroutineContext)
+        val schedulerProvider = SimpleSchedulerProvider(Dispatchers.Default)
 
         val fakeRegistration = Pair(
             TestReflectiveParticle::class.toParticleIdentifier(),

--- a/javatests/arcs/core/host/SimpleSchedulerProviderTest.kt
+++ b/javatests/arcs/core/host/SimpleSchedulerProviderTest.kt
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.core.host
+
+import arcs.core.testutil.assertSuspendingThrows
+import arcs.core.testutil.runTest
+import arcs.core.util.Scheduler
+import arcs.core.util.testutil.LogRule
+import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.Truth.assertWithMessage
+import java.util.concurrent.Executors
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.withContext
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class SimpleSchedulerProviderTest {
+    @get:Rule
+    val log = LogRule()
+
+    @Test
+    fun one_thread_multipleSchedulers() = runTest {
+        val coroutineContext = Executors.newSingleThreadExecutor().asCoroutineDispatcher()
+        val schedulerProvider = SimpleSchedulerProvider(coroutineContext)
+
+        val schedulerA = schedulerProvider("a")
+        val schedulerB = schedulerProvider("b")
+        val schedulerC = schedulerProvider("c")
+
+        // All should be separate instances.
+        assertThat(schedulerA).isNotEqualTo(schedulerB)
+        assertThat(schedulerA).isNotEqualTo(schedulerC)
+        assertThat(schedulerB).isNotEqualTo(schedulerC)
+
+        // Re-fetching the provider with the same arc-id gives the same scheduler.
+        assertThat(schedulerProvider("a")).isSameInstanceAs(schedulerA)
+        assertThat(schedulerProvider("b")).isSameInstanceAs(schedulerB)
+        assertThat(schedulerProvider("c")).isSameInstanceAs(schedulerC)
+
+        val schedulerAThread = CompletableDeferred<Thread>()
+        val schedulerBThread = CompletableDeferred<Thread>()
+        val schedulerCThread = CompletableDeferred<Thread>()
+
+        // All three run on the same thread.
+        schedulerA.schedule(
+            SimpleProc("a") { schedulerAThread.complete(Thread.currentThread()) }
+        )
+        schedulerB.schedule(
+            SimpleProc("b") { schedulerBThread.complete(Thread.currentThread()) }
+        )
+        schedulerC.schedule(
+            SimpleProc("c") { schedulerCThread.complete(Thread.currentThread()) }
+        )
+        assertThat(schedulerAThread.await()).isEqualTo(schedulerBThread.await())
+        assertThat(schedulerBThread.await()).isEqualTo(schedulerCThread.await())
+
+        schedulerProvider.cancelAll()
+    }
+
+    @Test
+    fun throwing_from_a_task_failsTheParentContext() = runTest {
+        val e = assertSuspendingThrows(IllegalStateException::class) {
+            withContext(coroutineContext) {
+                val schedulerProvider = SimpleSchedulerProvider(coroutineContext)
+
+                val scheduler = schedulerProvider("a")
+
+                scheduler.schedule(
+                    SimpleProc("test") {
+                        throw IllegalStateException("Washington DC is not a state.")
+                    }
+                )
+
+                scheduler.waitForIdle()
+            }
+        }
+
+        assertThat(e).hasMessageThat().contains("Washington DC is not a state.")
+    }
+
+    @Test
+    fun canceling_thenReInvoking_givesNewScheduler() = runTest {
+        val coroutineContext = Executors.newSingleThreadExecutor().asCoroutineDispatcher()
+        val schedulerProvider = SimpleSchedulerProvider(coroutineContext)
+
+        val scheduler = schedulerProvider("a")
+        val schedulerJob = scheduler.scope.coroutineContext[Job.Key]
+
+        val sameScheduler = schedulerProvider("a")
+        assertWithMessage(
+            "While the scheduler is still active, the provider returns the same scheduler " +
+                "for additional calls with the same arcId."
+        ).that(sameScheduler).isSameInstanceAs(scheduler)
+
+        // Cancel the scheduler, and wait until its job has completed before trying to create
+        // another scheduler with the same arcId.
+        val schedulerJobCanceled = Job()
+        schedulerJob?.invokeOnCompletion { schedulerJobCanceled.complete() }
+        scheduler.cancel()
+        schedulerJobCanceled.join()
+
+        val newScheduler = schedulerProvider("a")
+        assertWithMessage(
+            "After canceling the original scheduler, we should get a new one, even with the " +
+                "same arcId."
+        ).that(newScheduler).isNotEqualTo(scheduler)
+
+        schedulerProvider.cancelAll()
+    }
+
+    private class SimpleProc(
+        val name: String,
+        block: () -> Unit
+    ) : Scheduler.Task.Processor(block) {
+        override fun toString() = "SimpleProc($name)"
+    }
+}

--- a/javatests/arcs/jvm/host/JvmRoundRobinSchedulerProviderTest.kt
+++ b/javatests/arcs/jvm/host/JvmRoundRobinSchedulerProviderTest.kt
@@ -26,13 +26,13 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 @RunWith(JUnit4::class)
-class JvmSchedulerProviderTest {
+class JvmRoundRobinSchedulerProviderTest {
     @get:Rule
     val log = LogRule()
 
     @Test
     fun one_thread_multipleSchedulers() = runTest {
-        val schedulerProvider = JvmSchedulerProvider(coroutineContext, 1)
+        val schedulerProvider = JvmRoundRobinSchedulerProvider(coroutineContext, 1)
 
         val schedulerA = schedulerProvider("a")
         val schedulerB = schedulerProvider("b")
@@ -70,7 +70,7 @@ class JvmSchedulerProviderTest {
 
     @Test
     fun two_threads_threeSchedulers_roundRobin() = runTest {
-        val schedulerProvider = JvmSchedulerProvider(coroutineContext, 2)
+        val schedulerProvider = JvmRoundRobinSchedulerProvider(coroutineContext, 2)
 
         val schedulerA = schedulerProvider("a")
         val schedulerB = schedulerProvider("b")
@@ -101,7 +101,7 @@ class JvmSchedulerProviderTest {
     fun throwing_from_a_task_failsTheParentContext() = runTest {
         val e = assertSuspendingThrows(IllegalStateException::class) {
             withContext(coroutineContext) {
-                val schedulerProvider = JvmSchedulerProvider(coroutineContext, 1)
+                val schedulerProvider = JvmRoundRobinSchedulerProvider(coroutineContext, 1)
 
                 val scheduler = schedulerProvider("a")
 
@@ -120,7 +120,7 @@ class JvmSchedulerProviderTest {
 
     @Test
     fun canceling_thenReInvoking_givesNewScheduler() = runTest {
-        val schedulerProvider = JvmSchedulerProvider(coroutineContext, 1)
+        val schedulerProvider = JvmRoundRobinSchedulerProvider(coroutineContext, 1)
 
         val scheduler = schedulerProvider("a")
         val schedulerJob = scheduler.scope.coroutineContext[Job.Key]

--- a/javatests/arcs/showcase/ShowcaseEnvironment.kt
+++ b/javatests/arcs/showcase/ShowcaseEnvironment.kt
@@ -156,7 +156,6 @@ class ShowcaseEnvironment(
 
         DriverAndKeyConfigurator.configure(dbManager)
 
-        // Create a single scheduler provider for both the ArcHost as well as the Allocator.
         val schedulerProvider = JvmSchedulerProvider(EmptyCoroutineContext)
 
         // Ensure we're using the StorageService (via the TestConnectionFactory)


### PR DESCRIPTION
This is based on an implementation we were using elsewhere. It's
slightly simplified: instead of maintaining an internal map of
`Scheduler`s to cancel them, there's a single parent job that's
create as the parent of all schedulers for this provided, to cancel, we
can just cancel that job.