### PR TITLE
Quicken DirectStoreMuxer.idle

### DIFF
--- a/java/arcs/core/storage/DirectStore.kt
+++ b/java/arcs/core/storage/DirectStore.kt
@@ -90,7 +90,11 @@ class DirectStore<Data : CrdtData, Op : CrdtOperation, T> /* internal */ constru
         }
 
     override suspend fun idle() {
-        // TODO: tune the debounce window
+        /**
+         * TODO: tune the debounce window
+         * Once this is enabled, change [DirectStoreMuxer.idle] accordingly to use
+         * simultaneous launches.
+         */
         // storeIdlenessFlow.debounce(50).filter { it }.first()
     }
 

--- a/java/arcs/core/storage/DirectStoreMuxer.kt
+++ b/java/arcs/core/storage/DirectStoreMuxer.kt
@@ -75,12 +75,12 @@ class DirectStoreMuxer<Data : CrdtData, Op : CrdtOperation, T>(
 
     /** Calls [idle] on all existing contained stores and waits for their completion. */
     suspend fun idle() = storeMutex.withLock {
-        stores.values.map {
-            withContext(coroutineContext) {
-                launch { it.store.idle() }
-            }
-        }.joinAll()
-    }
+        stores.values.toList()
+    }.map {
+        withContext(coroutineContext) {
+            launch { it.store.idle() }
+        }
+    }.joinAll()
 
     /**
      * Sends the provided [ProxyMessage] to the store backing the provided [referenceId].

--- a/java/arcs/core/storage/DirectStoreMuxer.kt
+++ b/java/arcs/core/storage/DirectStoreMuxer.kt
@@ -20,13 +20,8 @@ import arcs.core.storage.ProxyMessage.SyncRequest
 import arcs.core.type.Type
 import arcs.core.util.LruCacheMap
 import arcs.core.util.TaggedLog
-import kotlinx.coroutines.CoroutineScope
-import kotlin.coroutines.coroutineContext
-import kotlinx.coroutines.joinAll
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import kotlinx.coroutines.withContext
 
 /**
  * An collection of [DirectStore]s that allows multiple CRDT models to be stored as sub-keys


### PR DESCRIPTION
Observed a tons of DirectStoreMuxer.idle arrived while adding participants consecutively ends up
client apis `store` is blocked for a big variant time due to limited threads on the service end and
much contention on the lock `storeMutex` which also blocks other critical paths i.e. creating / evicting stores.

Work with #5928 to achieve much better write performance. (1.5s to 25 ms per participant (persistent)).