### PR TITLE
Simplify coroutine logic in DatabaseManagers

### DIFF
--- a/java/arcs/android/storage/database/DatabaseGarbageCollectionPeriodicTask.kt
+++ b/java/arcs/android/storage/database/DatabaseGarbageCollectionPeriodicTask.kt
@@ -33,7 +33,7 @@ class DatabaseGarbageCollectionPeriodicTask(
         // Use the DatabaseDriverProvider instance of the databaseManager to make sure changes by
         // GC are propagated to listening Stores.
         val databaseManager = DatabaseDriverProvider.manager
-        databaseManager.runGarbageCollection().join()
+        databaseManager.runGarbageCollection()
         log.debug { "Success." }
         // Indicate whether the task finished successfully with the Result
         Result.success()

--- a/java/arcs/android/storage/ttl/PeriodicCleanupTask.kt
+++ b/java/arcs/android/storage/ttl/PeriodicCleanupTask.kt
@@ -33,7 +33,7 @@ class PeriodicCleanupTask(
         // Use the DatabaseDriverProvider instance of the databaseManager to make sure changes by
         // TTL expiry are propagated to listening Stores.
         val databaseManager = DatabaseDriverProvider.manager
-        databaseManager.removeExpiredEntities().join()
+        databaseManager.removeExpiredEntities()
         log.debug { "Success." }
         // Indicate whether the task finished successfully with the Result
         Result.success()

--- a/java/arcs/core/storage/database/DatabaseManager.kt
+++ b/java/arcs/core/storage/database/DatabaseManager.kt
@@ -11,8 +11,6 @@
 
 package arcs.core.storage.database
 
-import kotlinx.coroutines.Job
-
 /**
  * Defines an abstract factory capable of instantiating (or re-using, when necessary) a [Database].
  */
@@ -41,7 +39,7 @@ interface DatabaseManager {
         Map<DatabaseIdentifier, DatabasePerformanceStatistics.Snapshot>
 
     /** Clears all expired entities, in all known databases.  */
-    suspend fun removeExpiredEntities(): Job
+    suspend fun removeExpiredEntities()
 
     /** Clears all entities, in all known databases.  */
     suspend fun removeAllEntities()
@@ -57,7 +55,7 @@ interface DatabaseManager {
     suspend fun resetAll()
 
     /** Garbage collection run: removes unused entities. */
-    suspend fun runGarbageCollection(): Job
+    suspend fun runGarbageCollection()
 }
 
 /** Identifier for an individual [Database] instance. */

--- a/java/arcs/jvm/storage/database/testutil/FakeDatabaseManager.kt
+++ b/java/arcs/jvm/storage/database/testutil/FakeDatabaseManager.kt
@@ -64,7 +64,7 @@ class FakeDatabaseManager : DatabaseManager {
         Map<DatabaseIdentifier, DatabasePerformanceStatistics.Snapshot> =
         mutex.withLock { cache.mapValues { it.value.snapshotStatistics() } }
 
-    override suspend fun removeExpiredEntities(): Job {
+    override suspend fun removeExpiredEntities() {
         throw UnsupportedOperationException("Fake database manager cannot remove entities.")
     }
 
@@ -76,7 +76,7 @@ class FakeDatabaseManager : DatabaseManager {
         throw UnsupportedOperationException("Fake database manager cannot remove entities.")
     }
 
-    override suspend fun runGarbageCollection(): Job {
+    override suspend fun runGarbageCollection() {
         throw UnsupportedOperationException("Fake database does not gargbage collect.")
     }
 

--- a/javatests/arcs/android/entity/TtlHandleTest.kt
+++ b/javatests/arcs/android/entity/TtlHandleTest.kt
@@ -126,7 +126,7 @@ class TtlHandleTest {
 
         // Simulate periodic job triggering.
         log("Removing Expired Entities")
-        databaseManager.removeExpiredEntities().join()
+        databaseManager.removeExpiredEntities()
         updateJob.join()
         assertThat(handle.dispatchFetch()).isEqualTo(null)
 
@@ -229,7 +229,7 @@ class TtlHandleTest {
 
         // Simulate periodic job triggering.
         log("removing expired entities")
-        databaseManager.removeExpiredEntities().join()
+        databaseManager.removeExpiredEntities()
         deferred.await()
         activeWrites.joinAll()
         activeWrites.clear()
@@ -303,7 +303,7 @@ class TtlHandleTest {
         }
 
         // Simulate periodic job triggering.
-        databaseManager.removeExpiredEntities().join()
+        databaseManager.removeExpiredEntities()
 
         deferred1.await()
         deferred2.await()
@@ -363,7 +363,7 @@ class TtlHandleTest {
 
         // Simulate periodic job triggering.
         log("Removing Expired Entities")
-        databaseManager.removeExpiredEntities().join()
+        databaseManager.removeExpiredEntities()
         updateJob.join()
 
         assertThat(handle.dispatchFetchAll()).isEmpty()


### PR DESCRIPTION
Offshoot of #5798

`coroutineScope` will not return until all child jobs have completed so
removing the `coroutineScope { launch {` wrapping these database removal
tasks will not change the behavior.