### PR TITLE
Removes a DB check for empty entity ID for inline entities.

### DIFF
--- a/java/arcs/android/storage/database/DatabaseImpl.kt
+++ b/java/arcs/android/storage/database/DatabaseImpl.kt
@@ -681,12 +681,9 @@ class DatabaseImpl(
         counters: Counters? = null
     ): StorageKeyId? = db.transaction {
         val childKey = InlineStorageKey(parentStorageKey, fieldName)
-        require(entity.id == "") {
-            "Inline Entities should never have non-empty ids"
-        }
         val childKeyId = createEntityStorageKeyId(
             childKey,
-            "",
+            entity.id,
             entity.creationTimestamp,
             entity.expirationTimestamp,
             typeId,


### PR DESCRIPTION
This check predates the current ID strategy for inline entities,
which is to generate a hash of the serialized entity and use that.