### PR TITLE
Use strings for the `when` helper in hot.ts to catch mismatching case lengths

### DIFF
--- a/src/runtime/hot.ts
+++ b/src/runtime/hot.ts
@@ -86,6 +86,6 @@ export interface Dictionary<T> {
  *   }
  *
  */
-export function when(...conditions: boolean[]): number {
-  return conditions.reduce((acc: number, x: boolean, idx: number) => Number(x) << idx | acc, 0) + conditions.length;
+export function when(...conditions: boolean[]): string {
+  return conditions.reduce((acc: string, x: boolean) => acc + (x ? '1' : '0'), '');
 }

--- a/src/runtime/tests/hot-test.ts
+++ b/src/runtime/tests/hot-test.ts
@@ -12,15 +12,33 @@ import {assert} from '../../platform/chai-web.js';
 import {when} from '../hot.js';
 
 describe('hot', () => {
-  it('when combines booleans into integers', () => assert.isNumber(when(true, false)));
-  it('when cases of different length will not be equivalent.', () => assert.notEqual(when(true), when(true, true)));
+  it('when combines booleans into strings', () => assert.isString(when(true, false)));
+  it('when cases of different length will not be equivalent.', () => {
+    assert.notEqual(when(true), when(true, true));
+    assert.notEqual(when(true, false), when(false, false, false));
+    switch (when(true, false)) {
+      case when(true, false, false): assert.fail(); break;
+      case when(true, false, true): assert.fail(); break;
+      case when(true, false): assert.isOk(true); break;
+      default: break;
+    }
+  });
   it('when reflects distinction between boolean expressions', () => {
     assert.notEqual(when(true, true), when(false, false));
     assert.notEqual(when(true, false), when(false, false));
     assert.notEqual(when(false, true), when(false, false));
     assert.notEqual(when(true, true), when(false, true));
-    assert.notEqual(when(true, true), when(true, false));
+    assert.notEqual(when(false, true), when(true, false));
+
+    assert.strictEqual(when(false, false), when(false, false));
+    assert.strictEqual(when(false, true), when(false, true));
+    assert.strictEqual(when(true, false), when(true, false));
     assert.strictEqual(when(true, true), when(true, true));
+
+    assert.notEqual(when(false, false, true), when(false, false, false));
+    assert.notEqual(when(true, false, true, false), when(true, false, false, false));
+    assert.strictEqual(when(true, true, true), when(true, true, true));
+    assert.strictEqual(when(false, false, true, false), when(false, false, true, false));
   });
   it('when works within switch cases', () => {
     const x = 10;


### PR DESCRIPTION
Adding the conditions.length doesn't always work: `when(true, false)` and `when(false, false, false)` both return 3.