### PR TITLE
Fix deadlock at DirectStore.close

### DIFF
--- a/java/arcs/core/storage/BUILD
+++ b/java/arcs/core/storage/BUILD
@@ -100,6 +100,7 @@ arcs_kt_library(
         ":storage_key",
         "//java/arcs/core/crdt",
         "//java/arcs/core/type",
+        "//third_party/kotlin/kotlinx_coroutines",
     ],
 )
 

--- a/java/arcs/core/storage/DirectStore.kt
+++ b/java/arcs/core/storage/DirectStore.kt
@@ -32,7 +32,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.ConflatedBroadcastChannel
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.launch
 
 // import kotlinx.coroutines.flow.debounce
 // import kotlinx.coroutines.flow.filter
@@ -83,6 +83,7 @@ class DirectStore<Data : CrdtData, Op : CrdtOperation, T> /* internal */ constru
         "direct",
         Random
     )
+    private val scope = options.coroutineScope
 
     private val storeIdlenessFlow =
         combine(stateFlow, writebackIdlenessFlow) { state, writebackIsIdle ->
@@ -123,8 +124,10 @@ class DirectStore<Data : CrdtData, Op : CrdtOperation, T> /* internal */ constru
             stateChannel.close()
             state.value = State.Closed()
             closeWriteBack()
-            runBlocking {
-                driver.close()
+            requireNotNull(scope) {
+                "store driver cannot be closed properly due to missing coroutine scope"
+            }.run {
+                launch { driver.close() }
             }
         }
     }

--- a/java/arcs/core/storage/DirectStoreMuxer.kt
+++ b/java/arcs/core/storage/DirectStoreMuxer.kt
@@ -36,7 +36,8 @@ import kotlinx.coroutines.withContext
 class DirectStoreMuxer<Data : CrdtData, Op : CrdtOperation, T>(
     val storageKey: StorageKey,
     val backingType: Type,
-    val callbackFactory: (String) -> ProxyCallback<Data, Op, T>
+    val callbackFactory: (String) -> ProxyCallback<Data, Op, T>,
+    private val options: StoreOptions? = null
 ) {
     private val storeMutex = Mutex()
     private val log = TaggedLog { "DirectStoreMuxer" }
@@ -106,7 +107,8 @@ class DirectStoreMuxer<Data : CrdtData, Op : CrdtOperation, T>(
         val store = DirectStore.create<Data, Op, T>(
             StoreOptions(
                 storageKey = storageKey.childKeyWithComponent(referenceId),
-                type = backingType
+                type = backingType,
+                coroutineScope = options?.coroutineScope
             )
         )
 

--- a/java/arcs/core/storage/ReferenceModeStore.kt
+++ b/java/arcs/core/storage/ReferenceModeStore.kt
@@ -159,7 +159,8 @@ class ReferenceModeStore private constructor(
                     handleBackingStoreMessage(message, muxId)
                 }
             }
-        }
+        },
+        options = options
     )
 
     init {
@@ -723,7 +724,8 @@ class ReferenceModeStore private constructor(
                 StoreOptions(
                     storageKey = storageKey.storageKey,
                     type = refType,
-                    versionToken = options.versionToken
+                    versionToken = options.versionToken,
+                    coroutineScope = options.coroutineScope
                 )
             )
 

--- a/java/arcs/core/storage/StoreInterface.kt
+++ b/java/arcs/core/storage/StoreInterface.kt
@@ -27,5 +27,15 @@ data class StoreOptions(
     val storageKey: StorageKey,
     val type: Type,
     val versionToken: String? = null,
+    /**
+     * The field is for internal use on [StorageService] and its subclasses to
+     * plumb a [CoroutineScope] through storage stack on the service end.
+     * It is not encapsulated in a parcel and should only be initialized on
+     * [StorageService] and its subclasses.
+     *
+     * TODO: remove it completely and plumb service coroutine scope via
+     * class constructor either as an independent parameter or a configuration
+     * data class object.
+     */
     val coroutineScope: CoroutineScope? = null
 )

--- a/java/arcs/core/storage/StoreInterface.kt
+++ b/java/arcs/core/storage/StoreInterface.kt
@@ -14,6 +14,7 @@ package arcs.core.storage
 import arcs.core.crdt.CrdtData
 import arcs.core.crdt.CrdtOperation
 import arcs.core.type.Type
+import kotlinx.coroutines.CoroutineScope
 
 /** Base interface which all store implementations must extend from. */
 interface IStore<Data : CrdtData, Op : CrdtOperation, ConsumerData> {
@@ -25,5 +26,6 @@ interface IStore<Data : CrdtData, Op : CrdtOperation, ConsumerData> {
 data class StoreOptions(
     val storageKey: StorageKey,
     val type: Type,
-    val versionToken: String? = null
+    val versionToken: String? = null,
+    val coroutineScope: CoroutineScope? = null
 )

--- a/java/arcs/sdk/android/storage/service/StorageService.kt
+++ b/java/arcs/sdk/android/storage/service/StorageService.kt
@@ -165,7 +165,9 @@ open class StorageService : ResurrectorService() {
         return BindingContext(
             stores.computeIfAbsent(options.storageKey) {
                 @Suppress("UNCHECKED_CAST")
-                DeferredStore<CrdtData, CrdtOperation, Any>(options)
+                DeferredStore<CrdtData, CrdtOperation, Any>(
+                    options.copy(coroutineScope = CoroutineScope(coroutineContext))
+                )
             },
             coroutineContext,
             stats,

--- a/java/arcs/sdk/android/storage/service/StorageService.kt
+++ b/java/arcs/sdk/android/storage/service/StorageService.kt
@@ -78,6 +78,7 @@ open class StorageService : ResurrectorService() {
     open val config = StorageServiceConfig(ttlJobEnabled = true, garbageCollectionJobEnabled = true)
     private val workManager: WorkManager by lazy { WorkManager.getInstance(this) }
     private var devToolsProxy: DevToolsProxyImpl? = null
+    private val storesScope by lazy { CoroutineScope(coroutineContext) }
 
     @ExperimentalCoroutinesApi
     override fun onCreate() {
@@ -166,7 +167,7 @@ open class StorageService : ResurrectorService() {
             stores.computeIfAbsent(options.storageKey) {
                 @Suppress("UNCHECKED_CAST")
                 DeferredStore<CrdtData, CrdtOperation, Any>(
-                    options.copy(coroutineScope = CoroutineScope(coroutineContext))
+                    options.copy(coroutineScope = storesScope)
                 )
             },
             coroutineContext,
@@ -183,6 +184,7 @@ open class StorageService : ResurrectorService() {
 
     override fun onDestroy() {
         super.onDestroy()
+        storesScope.cancel()
         writeBackScope.cancel()
     }
 

--- a/java/arcs/sdk/android/storage/service/StorageService.kt
+++ b/java/arcs/sdk/android/storage/service/StorageService.kt
@@ -162,13 +162,11 @@ open class StorageService : ResurrectorService() {
             intent.getParcelableExtra<ParcelableStoreOptions?>(EXTRA_OPTIONS)
         ) { "No StoreOptions found in Intent" }
 
-        val options = parcelableOptions.actual.copy()
+        val options = parcelableOptions.actual.copy(coroutineScope = storesScope)
         return BindingContext(
             stores.computeIfAbsent(options.storageKey) {
                 @Suppress("UNCHECKED_CAST")
-                DeferredStore<CrdtData, CrdtOperation, Any>(
-                    options.copy(coroutineScope = storesScope)
-                )
+                DeferredStore<CrdtData, CrdtOperation, Any>(options)
             },
             coroutineContext,
             stats,


### PR DESCRIPTION
deadlock mutex: DatabaseImpl.clientMutex

The observation:
```
T1: held clientMutex                                                                        -> released clientMutex and resumed scope.launch {} coroutine of T2
T2: scope.launch { clientMutex.withLock { ... } } -> runBlocking {.clientMutex.withLock { ... }  }
```
The scope.launch {} coroutine cannot be resumed as the runBlocking blocked T2 and entered its inner event loop.

This patch also makes latency of pexxx writes much more steady.
Work with #5918 to achieve much better write performance. (1.5s to 25 ms per participant (persistent)).