### PR TITLE
add tests for TypeVariableInfo and AllocatorRecipeResolver (follow up for #5922)

### DIFF
--- a/src/runtime/recipe/internal/handle.ts
+++ b/src/runtime/recipe/internal/handle.ts
@@ -216,7 +216,7 @@ export class Handle implements Comparable<Handle>, PublicHandle {
     this.claims = storage.claims;
   }
   restrictType(restrictedType: Type) {
-    assert(this.type && this.type.isAtLeastAsSpecificAs(restrictedType));
+    assert(this.type && this.type.restrictTypeRanges(restrictedType));
     this._type = restrictedType;
   }
 


### PR DESCRIPTION
follow up for https://github.com/PolymerLabs/arcs/pull/5922
adding tests for:
- TypeVariableInfo::restrictTypeRanges
- TypeVariableInfo::isAtLeastAsSpecificAs
- allocator-recipe-resolver: generic reader particle in the same recipe as writer

