### PR TITLE
Fail manifest2proto when imports are missing

### DIFF
--- a/src/tools/manifest2proto.ts
+++ b/src/tools/manifest2proto.ts
@@ -26,7 +26,7 @@ import {policyToProtoPayload} from './policy2proto.js';
 import {annotationToProtoPayload} from './annotation2proto.js';
 
 export async function encodeManifestToProto(path: string): Promise<Uint8Array> {
-  const manifest = await Runtime.parseFile(path);
+  const manifest = await Runtime.parseFile(path, {throwImportErrors: true});
   return encodePayload(await manifestToProtoPayload(manifest));
 }
 


### PR DESCRIPTION
Previously running the `arcs_manifest_proto` BUILD rule on a manifest file that imports a non-existent manifest file would print an error but would not fail the build. This makes it fail correctly.