### PR TITLE
If a protected store is not marked, policy verifier rejects recipes.

### DIFF
--- a/javatests/arcs/core/analysis/PolicyVerifierTest.kt
+++ b/javatests/arcs/core/analysis/PolicyVerifierTest.kt
@@ -81,6 +81,26 @@ class PolicyVerifierTest {
     }
 
     @Test
+    fun unmarkedProtectedStoresRestrictUsage() {
+        assertFailsWith<PolicyViolation.ChecksViolated> {
+            verifier.verifyPolicy(
+                recipes.getValue("UnmarkedProtectedStore"),
+                policy
+            )
+        }
+    }
+
+    @Test
+    fun unmarkedIngressParticlesRestrictUsage() {
+        assertFailsWith<PolicyViolation.ChecksViolated> {
+            verifier.verifyPolicy(
+                recipes.getValue("UnmarkedIngress"),
+                policy
+            )
+        }
+    }
+
+    @Test
     fun invalidEgressesAreDisallowed() {
         assertFailsWith<PolicyViolation.InvalidEgressTypeForParticles> {
             verifier.verifyPolicy(

--- a/javatests/arcs/core/analysis/testdata/policy_test.arcs
+++ b/javatests/arcs/core/analysis/testdata/policy_test.arcs
@@ -238,6 +238,47 @@ recipe EgressUnredactedField
     joinData: joinData
 
 //-----------------------------------------------------------------------
+// Policy violation by not marking an ingress store appropriately.
+//-----------------------------------------------------------------------
+@policy('TestPolicy')
+recipe UnmarkedProtectedStore
+  // This should have been marked as 'action' for it to be matched with
+  // the allowed usages in `TestPolicy`. Given that this is not marked at
+  // all, we assume that nothing can be done with the data on `action` handle.
+  action: create
+  selection: create 'selection'
+  joinData: create @ttl('30m')
+  JoinActionSelection_EgressUnrestrictedFields
+    action: action
+    selection: selection
+    joinData: joinData
+  TestEgressParticle
+    joinData: joinData
+
+@isolated
+particle IngestAction
+  action: writes [Action]
+
+@policy('TestPolicy')
+recipe UnmarkedIngress
+  // `IngestAction` should have been for `action` to be matched with allowed usages
+  // in `TestPolicy`. As `IngestAction` is not marked as ingress, we assume that
+  // nothing can be done with the data on `action` handle.
+  // TODO(b/164153178): we simulate the absence of `@ingress` by not naming the
+  // store id as 'action`. When we have proper `@ingress` annotation, we should fix it.
+  action: create
+  selection: create 'selection'
+  joinData: create @ttl('30m')
+  IngestAction
+    action: action
+  JoinActionSelection_EgressUnrestrictedFields
+    action: action
+    selection: selection
+    joinData: joinData
+  TestEgressParticle
+    joinData: joinData
+
+//-----------------------------------------------------------------------
 // Policy violation by having invalid egress particles.
 //-----------------------------------------------------------------------
 @policy('TestPolicy')


### PR DESCRIPTION
Currently, we assume that all stores that need to be protected by a policy are present in the `storeClaims` map of the `PolicyConstraints` data structure. However, it is possible we may accidentally not identify all the protected stores (if a store is not named correctly in the recipe, for instance). If that happens, the policy verifier should do the safest action, which would be to reject the recipes.

To do so, if a store corresponding to a handle is not in `storeClaims`, we consider that the store has data that cannot be accessed if any of the following holds:
   - handle has only read connections.
   - handle is written by a particle that only has write connections.

Both the above conditions indicate that the data was possibly ingested into Arcs from outside and should have been protected. (b/164153178)