### PR TITLE
Two fixes for inline entities in Databases

### DIFF
--- a/java/arcs/android/storage/database/DatabaseImpl.kt
+++ b/java/arcs/android/storage/database/DatabaseImpl.kt
@@ -414,7 +414,11 @@ class DatabaseImpl(
                         (fieldName, value) -> rawCollections[fieldName] = value
                     }
                     RawEntity(
-                        id = entityId!!,
+                        id = requireNotNull(entityId) {
+                            "DB in an inconsistent state: entity data exists against " +
+                            "storage_key_id $inlineStorageKeyId without matching ID from " +
+                            "entities table"
+                        },
                         singletons = rawSingletons,
                         collections = rawCollections
                     )

--- a/java/arcs/android/storage/database/DatabaseImpl.kt
+++ b/java/arcs/android/storage/database/DatabaseImpl.kt
@@ -395,14 +395,26 @@ class DatabaseImpl(
                 ) {
                     val rawSingletons = mutableMapOf<FieldName, Referencable?>()
                     val rawCollections = mutableMapOf<FieldName, Set<Referencable>>()
+                    val inlineStorageKeyId = it.getLong(3)
+                    val entityId = db.rawQuery(
+                        """
+                            SELECT
+                                entity_id
+                            FROM entities
+                            WHERE storage_key_id = ?
+                        """.trimIndent(),
+                        arrayOf(inlineStorageKeyId.toString())
+                    ).forSingleResult {
+                        it.getString(0)
+                    }
                     val (dbSingletons, dbCollections) =
-                        getEntityFields(it.getLong(3), counters, db)
+                        getEntityFields(inlineStorageKeyId, counters, db)
                     dbSingletons.forEach { (fieldName, value) -> rawSingletons[fieldName] = value }
                     dbCollections.forEach {
                         (fieldName, value) -> rawCollections[fieldName] = value
                     }
                     RawEntity(
-                        id = "",
+                        id = entityId!!,
                         singletons = rawSingletons,
                         collections = rawCollections
                     )

--- a/java/arcs/core/storage/driver/Database.kt
+++ b/java/arcs/core/storage/driver/Database.kt
@@ -16,6 +16,7 @@ import arcs.core.crdt.CrdtEntity
 import arcs.core.crdt.CrdtSet
 import arcs.core.crdt.CrdtSingleton
 import arcs.core.crdt.extension.toCrdtEntityData
+import arcs.core.data.RawEntity
 import arcs.core.data.Schema
 import arcs.core.data.util.ReferencableList
 import arcs.core.storage.Driver
@@ -238,6 +239,7 @@ class DatabaseDriver<Data : Any>(
             is DatabaseData.Entity -> data.rawEntity.toCrdtEntityData(data.versionMap) {
                 when (it) {
                     is Reference -> it
+                    is RawEntity -> CrdtEntity.Reference.wrapReferencable(it)
                     is ReferencableList<*> -> CrdtEntity.Reference.wrapReferencable(it)
                     else -> CrdtEntity.Reference.buildReference(it)
                 }
@@ -295,6 +297,7 @@ class DatabaseDriver<Data : Any>(
                     it.rawEntity.toCrdtEntityData(it.versionMap) { refable ->
                         when (refable) {
                             is Reference -> refable
+                            is RawEntity -> CrdtEntity.Reference.wrapReferencable(refable)
                             is ReferencableList<*> -> CrdtEntity.Reference.wrapReferencable(refable)
                             else -> CrdtEntity.Reference.buildReference(refable)
                         }

--- a/javatests/arcs/android/entity/TtlHandleTest.kt
+++ b/javatests/arcs/android/entity/TtlHandleTest.kt
@@ -11,6 +11,7 @@ import arcs.core.data.SchemaRegistry
 import arcs.core.data.SingletonType
 import arcs.core.entity.DummyEntity
 import arcs.core.entity.HandleSpec
+import arcs.core.entity.InlineDummyEntity
 import arcs.core.entity.ReadWriteCollectionHandle
 import arcs.core.entity.ReadWriteSingletonHandle
 import arcs.core.entity.awaitReady
@@ -75,6 +76,7 @@ class TtlHandleTest {
         scheduler = schedulerProvider("myArc")
         StoreWriteBack.writeBackFactoryOverride = WriteBackForTesting
         SchemaRegistry.register(DummyEntity.SCHEMA)
+        SchemaRegistry.register(InlineDummyEntity.SCHEMA)
     }
 
     @After

--- a/javatests/arcs/android/storage/database/DatabaseGarbageCollectionPeriodicTaskTest.kt
+++ b/javatests/arcs/android/storage/database/DatabaseGarbageCollectionPeriodicTaskTest.kt
@@ -10,6 +10,7 @@ import arcs.core.data.HandleMode
 import arcs.core.data.SchemaRegistry
 import arcs.core.entity.DummyEntity
 import arcs.core.entity.HandleSpec
+import arcs.core.entity.InlineDummyEntity
 import arcs.core.entity.ReadWriteCollectionHandle
 import arcs.core.entity.awaitReady
 import arcs.core.host.EntityHandleManager
@@ -50,6 +51,7 @@ class DatabaseGarbageCollectionPeriodicTaskTest {
         databaseManager = AndroidSqliteDatabaseManager(ApplicationProvider.getApplicationContext())
         DriverAndKeyConfigurator.configure(databaseManager)
         SchemaRegistry.register(DummyEntity.SCHEMA)
+        SchemaRegistry.register(InlineDummyEntity.SCHEMA)
         worker = TestWorkerBuilder.from(
             ApplicationProvider.getApplicationContext(),
             DatabaseGarbageCollectionPeriodicTask::class.java

--- a/javatests/arcs/android/storage/service/StorageServiceEndToEndTest.kt
+++ b/javatests/arcs/android/storage/service/StorageServiceEndToEndTest.kt
@@ -93,7 +93,7 @@ class StorageServiceEndToEndTest {
     }
 
     @Test
-    fun testWriteThenReadOfInlineSingletonInCollectionOnDatabase() = runBlocking {
+    fun writeThenReadOfInlineSingletonInCollectionOnDatabase() = runBlocking {
         val handle = createCollectionHandle(databaseKey)
         val entity = entityForTest()
 
@@ -106,7 +106,7 @@ class StorageServiceEndToEndTest {
     }
 
     @Test
-    fun testWriteThenReadOfInlineSingletonInCollectionOnRamdisk() = runBlocking {
+    fun writeThenReadOfInlineSingletonInCollectionOnRamdisk() = runBlocking {
         val handle = createCollectionHandle(ramdiskKey)
         val entity = entityForTest()
 
@@ -119,7 +119,7 @@ class StorageServiceEndToEndTest {
     }
 
     @Test
-    fun testWriteThenReadOfInlineSingletonInCollectionOnVolatile() = runBlocking {
+    fun writeThenReadOfInlineSingletonInCollectionOnVolatile() = runBlocking {
         val handle = createCollectionHandle(volatileKey)
         val entity = entityForTest()
 

--- a/javatests/arcs/android/storage/service/StorageServiceEndToEndTest.kt
+++ b/javatests/arcs/android/storage/service/StorageServiceEndToEndTest.kt
@@ -20,8 +20,8 @@ import arcs.core.data.HandleMode
 import arcs.core.data.SchemaRegistry
 import arcs.core.data.SingletonType
 import arcs.core.entity.DummyEntity
-import arcs.core.entity.InlineDummyEntity
 import arcs.core.entity.HandleSpec
+import arcs.core.entity.InlineDummyEntity
 import arcs.core.entity.ReadWriteCollectionHandle
 import arcs.core.entity.ReadWriteSingletonHandle
 import arcs.core.entity.awaitReady
@@ -29,17 +29,12 @@ import arcs.core.host.EntityHandleManager
 import arcs.core.storage.DriverFactory
 import arcs.core.storage.StorageKey
 import arcs.core.storage.StoreWriteBack
-import arcs.core.storage.database.DatabaseData
-import arcs.core.storage.driver.DatabaseDriverProvider
 import arcs.core.storage.driver.RamDisk
-import arcs.core.storage.keys.DATABASE_NAME_DEFAULT
 import arcs.core.storage.keys.DatabaseStorageKey
 import arcs.core.storage.keys.RamDiskStorageKey
 import arcs.core.storage.keys.VolatileStorageKey
 import arcs.core.storage.referencemode.ReferenceModeStorageKey
 import arcs.core.storage.testutil.WriteBackForTesting
-import arcs.core.testutil.handles.dispatchFetch
-import arcs.core.testutil.handles.dispatchFetchAll
 import arcs.core.testutil.handles.dispatchStore
 import arcs.core.util.testutil.LogRule
 import arcs.jvm.host.JvmSchedulerProvider
@@ -50,7 +45,6 @@ import java.util.concurrent.ConcurrentHashMap
 import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.coroutines.coroutineContext
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withTimeout
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -138,19 +132,19 @@ class StorageServiceEndToEndTest {
     }
 
     private fun entityForTest() = DummyEntity().apply {
-      inlineEntity = InlineDummyEntity().apply {
-        text = "inline"
-      }
-      inlineList = listOf(
-        InlineDummyEntity().apply { text = "1" },
-        InlineDummyEntity().apply { text = "2" },
-        InlineDummyEntity().apply { text = "3" }
-      )
-      inlines = setOf(
-        InlineDummyEntity().apply { text = "C1" },
-        InlineDummyEntity().apply { text = "C2" },
-        InlineDummyEntity().apply { text = "C3" }
-      )
+        inlineEntity = InlineDummyEntity().apply {
+            text = "inline"
+        }
+        inlineList = listOf(
+            InlineDummyEntity().apply { text = "1" },
+            InlineDummyEntity().apply { text = "2" },
+            InlineDummyEntity().apply { text = "3" }
+        )
+        inlines = setOf(
+            InlineDummyEntity().apply { text = "C1" },
+            InlineDummyEntity().apply { text = "C2" },
+            InlineDummyEntity().apply { text = "C3" }
+        )
     }
 
     private suspend fun createSingletonHandle(storageKey: StorageKey) =

--- a/javatests/arcs/android/storage/service/StorageServiceEndToEndTest.kt
+++ b/javatests/arcs/android/storage/service/StorageServiceEndToEndTest.kt
@@ -93,7 +93,7 @@ class StorageServiceEndToEndTest {
     }
 
     @Test
-    fun writeThenReadOfInlineSingletonInCollectionOnDatabase() = runBlocking {
+    fun writeThenRead_inlineData_inCollection_onDatabase() = runBlocking {
         val handle = createCollectionHandle(databaseKey)
         val entity = entityForTest()
 
@@ -106,7 +106,7 @@ class StorageServiceEndToEndTest {
     }
 
     @Test
-    fun writeThenReadOfInlineSingletonInCollectionOnRamdisk() = runBlocking {
+    fun writeThenRead_inlineData_inCollection_onRamdisk() = runBlocking {
         val handle = createCollectionHandle(ramdiskKey)
         val entity = entityForTest()
 
@@ -119,7 +119,7 @@ class StorageServiceEndToEndTest {
     }
 
     @Test
-    fun writeThenReadOfInlineSingletonInCollectionOnVolatile() = runBlocking {
+    fun writeThenRead_inlineData_inCollection_onVolatile() = runBlocking {
         val handle = createCollectionHandle(volatileKey)
         val entity = entityForTest()
 

--- a/javatests/arcs/android/storage/service/StorageServiceManagerTest.kt
+++ b/javatests/arcs/android/storage/service/StorageServiceManagerTest.kt
@@ -20,8 +20,8 @@ import arcs.core.data.HandleMode
 import arcs.core.data.SchemaRegistry
 import arcs.core.data.SingletonType
 import arcs.core.entity.DummyEntity
-import arcs.core.entity.InlineDummyEntity
 import arcs.core.entity.HandleSpec
+import arcs.core.entity.InlineDummyEntity
 import arcs.core.entity.ReadWriteCollectionHandle
 import arcs.core.entity.ReadWriteSingletonHandle
 import arcs.core.entity.awaitReady

--- a/javatests/arcs/android/storage/ttl/PeriodicCleanupTaskTest.kt
+++ b/javatests/arcs/android/storage/ttl/PeriodicCleanupTaskTest.kt
@@ -13,6 +13,7 @@ import arcs.core.data.HandleMode
 import arcs.core.data.SchemaRegistry
 import arcs.core.entity.DummyEntity
 import arcs.core.entity.HandleSpec
+import arcs.core.entity.InlineDummyEntity
 import arcs.core.entity.ReadWriteCollectionHandle
 import arcs.core.entity.awaitReady
 import arcs.core.host.EntityHandleManager
@@ -47,6 +48,7 @@ class PeriodicCleanupTaskTest {
     @Before
     fun setUp() {
         SchemaRegistry.register(DummyEntity.SCHEMA)
+        SchemaRegistry.register(InlineDummyEntity.SCHEMA)
         StoreWriteBack.writeBackFactoryOverride = WriteBackForTesting
         worker = TestWorkerBuilder.from(context, PeriodicCleanupTask::class.java).build()
     }

--- a/javatests/arcs/core/entity/DummyEntity.kt
+++ b/javatests/arcs/core/entity/DummyEntity.kt
@@ -26,7 +26,10 @@ class DummyEntity : EntityBase(ENTITY_CLASS_NAME, SCHEMA), Storable {
     var refs: Set<Reference<DummyEntity>> by CollectionProperty()
     var inlines: Set<InlineDummyEntity> by CollectionProperty()
 
-    private val nestedEntitySpecs = mapOf(SCHEMA_HASH to DummyEntity, InlineDummyEntity.SCHEMA_HASH to InlineDummyEntity)
+    private val nestedEntitySpecs = mapOf(
+        SCHEMA_HASH to DummyEntity,
+        InlineDummyEntity.SCHEMA_HASH to InlineDummyEntity
+    )
 
     fun getSingletonValueForTest(field: String) = super.getSingletonValue(field)
 
@@ -42,7 +45,12 @@ class DummyEntity : EntityBase(ENTITY_CLASS_NAME, SCHEMA), Storable {
 
     companion object : EntitySpec<DummyEntity> {
         override fun deserialize(data: RawEntity): DummyEntity {
-            return DummyEntity().apply { deserialize(data, mapOf(SCHEMA_HASH to DummyEntity, InlineDummyEntity.SCHEMA_HASH to InlineDummyEntity)) }
+            return DummyEntity().apply {
+                deserialize(data, mapOf(
+                    SCHEMA_HASH to DummyEntity,
+                    InlineDummyEntity.SCHEMA_HASH to InlineDummyEntity
+                ))
+            }
         }
 
         const val ENTITY_CLASS_NAME = "DummyEntity"
@@ -60,7 +68,8 @@ class DummyEntity : EntityBase(ENTITY_CLASS_NAME, SCHEMA), Storable {
                     "primList" to FieldType.ListOf(FieldType.Number),
                     "refList" to FieldType.ListOf(FieldType.EntityRef(SCHEMA_HASH)),
                     "inlineEntity" to FieldType.InlineEntity(InlineDummyEntity.SCHEMA_HASH),
-                    "inlineList" to FieldType.ListOf(FieldType.InlineEntity(InlineDummyEntity.SCHEMA_HASH))
+                    "inlineList" to
+                        FieldType.ListOf(FieldType.InlineEntity(InlineDummyEntity.SCHEMA_HASH))
                 ),
                 collections = mapOf(
                     "texts" to FieldType.Text,
@@ -75,14 +84,14 @@ class DummyEntity : EntityBase(ENTITY_CLASS_NAME, SCHEMA), Storable {
     }
 }
 
-class InlineDummyEntity : EntityBase(ENTITY_CLASS_NAME, SCHEMA, isInlineEntity=true), Storable {
+class InlineDummyEntity : EntityBase(ENTITY_CLASS_NAME, SCHEMA, isInlineEntity = true), Storable {
     var text: String? by SingletonProperty()
 
     private val nestedEntitySpecs = mapOf(SCHEMA_HASH to InlineDummyEntity)
 
     companion object : EntitySpec<InlineDummyEntity> {
         override fun deserialize(data: RawEntity) =
-            InlineDummyEntity().apply { deserialize(data, mapOf(SCHEMA_HASH to InlineDummyEntity))}
+            InlineDummyEntity().apply { deserialize(data, mapOf(SCHEMA_HASH to InlineDummyEntity)) }
 
         const val ENTITY_CLASS_NAME = "InlineDummyEntity"
 

--- a/javatests/arcs/core/entity/DummyEntity.kt
+++ b/javatests/arcs/core/entity/DummyEntity.kt
@@ -18,12 +18,15 @@ class DummyEntity : EntityBase(ENTITY_CLASS_NAME, SCHEMA), Storable {
     var ref: Reference<DummyEntity>? by SingletonProperty()
     var primList: List<Double> by SingletonProperty()
     var refList: List<Reference<DummyEntity>> by SingletonProperty()
+    var inlineEntity: InlineDummyEntity by SingletonProperty()
+    var inlineList: List<InlineDummyEntity> by SingletonProperty()
     var bools: Set<Boolean> by CollectionProperty()
     var nums: Set<Double> by CollectionProperty()
     var texts: Set<String> by CollectionProperty()
     var refs: Set<Reference<DummyEntity>> by CollectionProperty()
+    var inlines: Set<InlineDummyEntity> by CollectionProperty()
 
-    private val nestedEntitySpecs = mapOf(SCHEMA_HASH to DummyEntity)
+    private val nestedEntitySpecs = mapOf(SCHEMA_HASH to DummyEntity, InlineDummyEntity.SCHEMA_HASH to InlineDummyEntity)
 
     fun getSingletonValueForTest(field: String) = super.getSingletonValue(field)
 
@@ -38,8 +41,9 @@ class DummyEntity : EntityBase(ENTITY_CLASS_NAME, SCHEMA), Storable {
     fun deserializeForTest(rawEntity: RawEntity) = super.deserialize(rawEntity, nestedEntitySpecs)
 
     companion object : EntitySpec<DummyEntity> {
-        override fun deserialize(data: RawEntity) =
-            DummyEntity().apply { deserialize(data, mapOf(SCHEMA_HASH to DummyEntity)) }
+        override fun deserialize(data: RawEntity): DummyEntity {
+            return DummyEntity().apply { deserialize(data, mapOf(SCHEMA_HASH to DummyEntity, InlineDummyEntity.SCHEMA_HASH to InlineDummyEntity)) }
+        }
 
         const val ENTITY_CLASS_NAME = "DummyEntity"
 
@@ -54,14 +58,43 @@ class DummyEntity : EntityBase(ENTITY_CLASS_NAME, SCHEMA), Storable {
                     "bool" to FieldType.Boolean,
                     "ref" to FieldType.EntityRef(SCHEMA_HASH),
                     "primList" to FieldType.ListOf(FieldType.Number),
-                    "refList" to FieldType.ListOf(FieldType.EntityRef(SCHEMA_HASH))
+                    "refList" to FieldType.ListOf(FieldType.EntityRef(SCHEMA_HASH)),
+                    "inlineEntity" to FieldType.InlineEntity(InlineDummyEntity.SCHEMA_HASH),
+                    "inlineList" to FieldType.ListOf(FieldType.InlineEntity(InlineDummyEntity.SCHEMA_HASH))
                 ),
                 collections = mapOf(
                     "texts" to FieldType.Text,
                     "nums" to FieldType.Number,
                     "bools" to FieldType.Boolean,
-                    "refs" to FieldType.EntityRef(SCHEMA_HASH)
+                    "refs" to FieldType.EntityRef(SCHEMA_HASH),
+                    "inlines" to FieldType.InlineEntity(InlineDummyEntity.SCHEMA_HASH)
                 )
+            ),
+            hash = SCHEMA_HASH
+        )
+    }
+}
+
+class InlineDummyEntity : EntityBase(ENTITY_CLASS_NAME, SCHEMA, isInlineEntity=true), Storable {
+    var text: String? by SingletonProperty()
+
+    private val nestedEntitySpecs = mapOf(SCHEMA_HASH to InlineDummyEntity)
+
+    companion object : EntitySpec<InlineDummyEntity> {
+        override fun deserialize(data: RawEntity) =
+            InlineDummyEntity().apply { deserialize(data, mapOf(SCHEMA_HASH to InlineDummyEntity))}
+
+        const val ENTITY_CLASS_NAME = "InlineDummyEntity"
+
+        const val SCHEMA_HASH = "inline_abcdef"
+
+        override val SCHEMA = Schema(
+            names = setOf(SchemaName(ENTITY_CLASS_NAME)),
+            fields = SchemaFields(
+                singletons = mapOf(
+                    "text" to FieldType.Text
+                ),
+                collections = emptyMap()
             ),
             hash = SCHEMA_HASH
         )

--- a/javatests/arcs/core/entity/EntityBaseTest.kt
+++ b/javatests/arcs/core/entity/EntityBaseTest.kt
@@ -38,6 +38,7 @@ class EntityBaseTest {
     @Before
     fun setUp() {
         SchemaRegistry.register(DummyEntity.SCHEMA)
+        SchemaRegistry.register(InlineDummyEntity.SCHEMA)
         entity = DummyEntity()
     }
 
@@ -430,7 +431,8 @@ class EntityBaseTest {
             bools = setOf(true, false)
         }
         assertThat(entity.toString()).isEqualTo(
-            "DummyEntity(bool = true, bools = [true, false], num = 12.0, nums = [1.0, 2.0], " +
+            "DummyEntity(bool = true, bools = [true, false], inlineEntity = null, " +
+                "inlineList = null, inlines = [], num = 12.0, nums = [1.0, 2.0], " +
                 "primList = [1.0, 1.0], ref = null, refList = null, refs = [], text = abc, " +
                 "texts = [aa, bb])"
         )

--- a/javatests/arcs/core/entity/ReferenceTest.kt
+++ b/javatests/arcs/core/entity/ReferenceTest.kt
@@ -55,6 +55,7 @@ class ReferenceTest {
         RamDisk.clear()
         DriverAndKeyConfigurator.configure(null)
         SchemaRegistry.register(DummyEntity.SCHEMA)
+        SchemaRegistry.register(InlineDummyEntity.SCHEMA)
 
         scheduler = Scheduler(Executors.newSingleThreadExecutor().asCoroutineDispatcher())
         stores = StoreManager()

--- a/javatests/arcs/core/entity/StorageAdapterTest.kt
+++ b/javatests/arcs/core/entity/StorageAdapterTest.kt
@@ -36,6 +36,7 @@ class StorageAdapterTest {
     @Before
     fun setUp() {
         SchemaRegistry.register(DummyEntity.SCHEMA)
+        SchemaRegistry.register(InlineDummyEntity.SCHEMA)
     }
 
     @Test

--- a/javatests/arcs/core/entity/VariableEntityBaseTest.kt
+++ b/javatests/arcs/core/entity/VariableEntityBaseTest.kt
@@ -22,6 +22,7 @@ class VariableEntityBaseTest {
     fun setUp() {
         SchemaRegistry.register(DummyEntity.SCHEMA)
         SchemaRegistry.register(DummyVariableEntity.SCHEMA)
+        SchemaRegistry.register(InlineDummyEntity.SCHEMA)
         entity = DummyVariableEntity()
         biggerEntity = DummyEntity()
             .apply {


### PR DESCRIPTION
(1) ensure that inline entities get returned from the Database driver as
RawEntities rather than as References. We were incorrectly building
references for them rather than wrapping as Referencables due to a
missing case in the Database driver.
(2) ensure that inline entity IDs are returned from the Database driver.
We were previously not fetching these as an extra query is required;
however this meant that collections were deduping all but one entity on
return from the DB.

Also added some simple end-to-end store-and-retrieve tests in the new
StorageServiceEndToEndTest file.