### PR TITLE
Clarify StorageKeyParser interface, make global instance thread-safe

### DIFF
--- a/java/arcs/android/demo/DemoApplication.kt
+++ b/java/arcs/android/demo/DemoApplication.kt
@@ -17,7 +17,6 @@ import arcs.android.util.initLogForAndroid
 import arcs.core.storage.api.DriverAndKeyConfigurator
 import arcs.core.storage.driver.RamDisk
 import arcs.core.storage.driver.RamDiskDriverProvider
-import arcs.core.storage.referencemode.ReferenceModeStorageKey
 import arcs.core.util.Log
 
 /** Application class for Arcs Demo. */
@@ -35,8 +34,6 @@ class DemoApplication : Application(), Configuration.Provider {
         RamDiskDriverProvider()
 
         DriverAndKeyConfigurator.configureKeyParsers()
-
-        ReferenceModeStorageKey.registerParser()
 
         initLogForAndroid(Log.Level.Debug)
     }

--- a/java/arcs/android/host/parcelables/BUILD
+++ b/java/arcs/android/host/parcelables/BUILD
@@ -15,5 +15,6 @@ arcs_kt_android_library(
         "//java/arcs/core/data/expression",
         "//java/arcs/core/host",
         "//java/arcs/core/storage:storage_key",
+        "//java/arcs/core/storage/referencemode",
     ],
 )

--- a/java/arcs/core/data/CreatableStorageKey.kt
+++ b/java/arcs/core/data/CreatableStorageKey.kt
@@ -11,14 +11,14 @@
 package arcs.core.data
 
 import arcs.core.storage.StorageKey
-import arcs.core.storage.StorageKeyParser
+import arcs.core.storage.StorageKeySpec
 
 /**
  * This class represents a storage key in a compiled [Plan] with 'create' fate.
  */
 data class CreatableStorageKey(
     val nameFromManifest: String
-) : StorageKey(CREATABLE_KEY_PROTOCOL) {
+) : StorageKey(protocol) {
 
     override fun toKeyString() = nameFromManifest
 
@@ -28,17 +28,13 @@ data class CreatableStorageKey(
 
     override fun toString(): String = super.toString()
 
-    companion object {
-        const val CREATABLE_KEY_PROTOCOL = "create"
+    companion object : StorageKeySpec<CreatableStorageKey> {
+        override val protocol = "create"
 
         private val CREATABLE_STORAGE_KEY_PATTERN =
             ("^([^:^?]*)\$").toRegex()
 
-        fun registerParser() {
-            StorageKeyParser.addParser(CREATABLE_KEY_PROTOCOL, ::parse)
-        }
-
-        private fun parse(rawKeyString: String): CreatableStorageKey {
+        override fun parse(rawKeyString: String): CreatableStorageKey {
             val match =
                 requireNotNull(CREATABLE_STORAGE_KEY_PATTERN.matchEntire(rawKeyString)) {
                     "Not a valid CreatableStorageKey: $rawKeyString"

--- a/java/arcs/core/storage/StorageKey.kt
+++ b/java/arcs/core/storage/StorageKey.kt
@@ -33,3 +33,9 @@ abstract class StorageKey(val protocol: String) {
 
     override fun hashCode() = toString().hashCode()
 }
+
+/**
+ * This describes the metadata related to a [StorageKey] type. The [companion] object of a
+ * [StorageKey] implementation should implement this interface.
+ */
+interface StorageKeySpec<T : StorageKey> : StorageKeyParser<T>

--- a/java/arcs/core/storage/StorageKeyParser.kt
+++ b/java/arcs/core/storage/StorageKeyParser.kt
@@ -19,8 +19,24 @@ package arcs.core.storage
  * [reset] in the tear-down method.
  */
 interface StorageKeyManager {
+    /**
+     * Return a structured [StorageKey] instance for the provided raw key string. Implementations
+     * may throw an exception if:
+     *   * The key string has invalid structure.
+     *   * The key string uses a protocol that doesn't have a registered parser.
+     *   * The key doesn't match the parser's structural expectations.
+     */
     fun parse(rawKeyString: String): StorageKey
+
+    /**
+     * Add a new [StorageKeyParser] to the internal list of parsers. Adding a [parser] for a
+     * protocol which already exists should replace the existing implementation.
+     */
     fun addParser(parser: StorageKeyParser<*>)
+
+    /**
+     * Remove all currently registered parsers, and replace them with the values provided.
+     */
     fun reset(vararg initialSet: StorageKeyParser<*>)
 }
 
@@ -28,7 +44,7 @@ interface StorageKeyManager {
  * The interface for a parser of a specific protocol type.
  *
  * By convention, when implementing [StorageKey], you should also include in the companion object
- * a [PROTOCOL] field that defines the protocol for the name, and a [PARSER] that implements this
+ * a [protocol] field that defines the protocol for the name, and a [parser] that implements this
  * interface.
  *
  * The companion object for this interface implements a thread-safe global instance of
@@ -36,7 +52,16 @@ interface StorageKeyManager {
  * key management.
  */
 interface StorageKeyParser<T : StorageKey> {
+    /** The protocol that this [StorageKeyParser] supports. */
     val protocol: String
+
+    /** Returns a structured key of type [T] give the [rawKeyString]. May throw an exception if:
+     *   * The [rawKeyString] has invalid structure.
+     *   * The structure of the key doesn't meet the specific requirements for this [protocol].
+     *
+     *   Note that implementations are not guaranteed to check the protocol of the [rawKeyString]
+     *   provided, so callers should verify this themselves before using the parser.
+     */
     fun parse(rawKeyString: String): T
 
     /**

--- a/java/arcs/core/storage/api/DriverAndKeyConfigurator.kt
+++ b/java/arcs/core/storage/api/DriverAndKeyConfigurator.kt
@@ -59,19 +59,19 @@ object DriverAndKeyConfigurator {
     // TODO: make the set of keyparsers configurable.
     fun configureKeyParsers() {
         // Start fresh.
-        StorageKeyParser.reset()
-        CapabilitiesResolver.reset()
+        StorageKeyParser.reset(
+            VolatileStorageKey,
+            RamDiskStorageKey,
+            DatabaseStorageKey.Persistent,
+            DatabaseStorageKey.Memory,
+            CreatableStorageKey,
+            ReferenceModeStorageKey,
+            JoinStorageKey
+        )
 
-        VolatileStorageKey.registerParser()
+        CapabilitiesResolver.reset()
         VolatileStorageKey.registerKeyCreator()
-        RamDiskStorageKey.registerParser()
         RamDiskStorageKey.registerKeyCreator()
-        DatabaseStorageKey.registerParser()
         DatabaseStorageKey.registerKeyCreator()
-        // Below storage keys don't have respective drivers,
-        // and therefore they don't have key creators.
-        CreatableStorageKey.registerParser()
-        ReferenceModeStorageKey.registerParser()
-        JoinStorageKey.registerParser()
     }
 }

--- a/java/arcs/core/storage/driver/Database.kt
+++ b/java/arcs/core/storage/driver/Database.kt
@@ -107,7 +107,6 @@ object DatabaseDriverProvider : DriverProvider {
     fun configure(databaseManager: DatabaseManager, schemaLookup: (String) -> Schema?) = apply {
         this._manager = databaseManager
         this.schemaLookup = schemaLookup
-        DatabaseStorageKey.registerParser()
         DriverFactory.register(this)
     }
 

--- a/java/arcs/core/storage/keys/JoinStorageKey.kt
+++ b/java/arcs/core/storage/keys/JoinStorageKey.kt
@@ -12,17 +12,14 @@
 package arcs.core.storage.keys
 
 import arcs.core.storage.StorageKey
-import arcs.core.storage.StorageKeyParser
+import arcs.core.storage.StorageKeySpec
 import arcs.core.storage.StorageKeyUtils
 import arcs.core.storage.embed
-
-/** Protocol to be used when the StorageKey is composed of multiple StorageKeys. */
-const val COMPOSITE_PROTOCOL = "join"
 
 /** Implementation for a composite [StorageKey] for joining entities. */
 class JoinStorageKey(
     val components: List<StorageKey>
-) : StorageKey(COMPOSITE_PROTOCOL) {
+) : StorageKey(protocol) {
     override fun toKeyString(): String {
         val builder = StringBuilder()
         builder.append("${components.size}/")
@@ -35,26 +32,19 @@ class JoinStorageKey(
         TODO("Not yet implemented for JoinStorageKey")
     }
 
-    companion object {
-        init {
-            StorageKeyParser.addParser(COMPOSITE_PROTOCOL, ::fromString)
-        }
-
-        /** Register [JoinStorageKey] with the [StorageKeyParser]. */
-        fun registerParser() {
-            StorageKeyParser.addParser(COMPOSITE_PROTOCOL, ::fromString)
-        }
-
-        private fun fromString(rawValue: String): JoinStorageKey {
+    companion object : StorageKeySpec<JoinStorageKey> {
+        /** Protocol to be used when the StorageKey is composed of multiple StorageKeys. */
+        override val protocol = "join"
+        override fun parse(rawKeyString: String): JoinStorageKey {
             val invalidFormatMessage: () -> String =
-                { "Invalid format for JoinStorageKey: $rawValue" }
+                { "Invalid format for JoinStorageKey: $rawKeyString" }
 
             // We will support < 10 joins.
-            val numberOfJoins: Int = rawValue[0] - '0'
+            val numberOfJoins: Int = rawKeyString[0] - '0'
             require(numberOfJoins in 1..9, invalidFormatMessage)
-            require(rawValue[1] == '/', invalidFormatMessage)
+            require(rawKeyString[1] == '/', invalidFormatMessage)
 
-            val storageKeys = StorageKeyUtils.extractKeysFromString(rawValue.substring(2))
+            val storageKeys = StorageKeyUtils.extractKeysFromString(rawKeyString.substring(2))
             require(storageKeys.size == numberOfJoins, invalidFormatMessage)
             return JoinStorageKey(storageKeys)
         }

--- a/java/arcs/core/storage/referencemode/ReferenceModeStorageKey.kt
+++ b/java/arcs/core/storage/referencemode/ReferenceModeStorageKey.kt
@@ -12,11 +12,9 @@
 package arcs.core.storage.referencemode
 
 import arcs.core.storage.StorageKey
-import arcs.core.storage.StorageKeyParser
+import arcs.core.storage.StorageKeySpec
 import arcs.core.storage.StorageKeyUtils
 import arcs.core.storage.embed
-
-const val REFERENCE_MODE_PROTOCOL = "reference-mode"
 
 /**
  * Special subclass of [StorageKey] used to identify data managed by a
@@ -25,7 +23,7 @@ const val REFERENCE_MODE_PROTOCOL = "reference-mode"
 data class ReferenceModeStorageKey(
     val backingKey: StorageKey,
     val storageKey: StorageKey
-) : StorageKey(REFERENCE_MODE_PROTOCOL) {
+) : StorageKey(protocol) {
 
     init {
         // This is a overly strict check as some combinations of different protocols are fine, so it
@@ -44,19 +42,12 @@ data class ReferenceModeStorageKey(
 
     override fun toString(): String = super.toString()
 
-    companion object {
-        init {
-            StorageKeyParser.addParser(REFERENCE_MODE_PROTOCOL, ::fromString)
-        }
-
-        fun registerParser() {
-            StorageKeyParser.addParser(REFERENCE_MODE_PROTOCOL, ::fromString)
-        }
-
-        private fun fromString(rawValue: String): ReferenceModeStorageKey {
+    companion object : StorageKeySpec<ReferenceModeStorageKey> {
+        override val protocol = "reference-mode"
+        override fun parse(rawKeyString: String): ReferenceModeStorageKey {
             val invalidFormatMessage: () -> String =
-                { "Invalid format for ReferenceModeStorageKey: $rawValue" }
-            val storageKeys = StorageKeyUtils.extractKeysFromString(rawValue)
+                { "Invalid format for ReferenceModeStorageKey: $rawKeyString" }
+            val storageKeys = StorageKeyUtils.extractKeysFromString(rawKeyString)
             require(storageKeys.size == 2, invalidFormatMessage)
 
             return ReferenceModeStorageKey(

--- a/java/arcs/core/storage/testutil/DummyStorageKey.kt
+++ b/java/arcs/core/storage/testutil/DummyStorageKey.kt
@@ -21,13 +21,8 @@ class DummyStorageKey(val key: String) : StorageKey(protocol) {
     override fun childKeyWithComponent(component: String): StorageKey =
         DummyStorageKey("$key/$component")
 
-    companion object {
-        const val protocol = "dummy"
-
-        fun parse(rawKeyString: String): DummyStorageKey = DummyStorageKey(rawKeyString)
-
-        fun registerParser() {
-            StorageKeyParser.addParser(protocol, ::parse)
-        }
+    companion object : StorageKeyParser<DummyStorageKey> {
+        override val protocol = "dummy"
+        override fun parse(rawKeyString: String) = DummyStorageKey(rawKeyString)
     }
 }

--- a/java/arcs/sdk/android/storage/ResurrectionHelper.kt
+++ b/java/arcs/sdk/android/storage/ResurrectionHelper.kt
@@ -71,7 +71,7 @@ class ResurrectionHelper(
             ResurrectionRequest.EXTRA_RESURRECT_NOTIFIER
         ) ?: return
 
-        onResurrected(targetId, notifiers.map(StorageKeyParser::parse))
+        onResurrected(targetId, notifiers.map(StorageKeyParser.Companion::parse))
     }
 
     /**

--- a/java/arcs/sdk/storage/StorageKey.kt
+++ b/java/arcs/sdk/storage/StorageKey.kt
@@ -12,10 +12,6 @@
 package arcs.sdk.storage
 
 import arcs.core.storage.StorageKeyParser
-import arcs.core.storage.keys.DatabaseStorageKey
-import arcs.core.storage.keys.RamDiskStorageKey
-import arcs.core.storage.keys.VolatileStorageKey
-import arcs.core.storage.referencemode.ReferenceModeStorageKey
 
 /**
  * Represents a location in Arcs' storage system where an [Entity], [Collection], [Singleton], or a
@@ -26,13 +22,4 @@ inline class StorageKey(val raw: String) {
     /** Converts this SDK [StorageKey] into a core [arcs.core.storage.StorageKey]. */
     /* internal */
     fun toCoreStorageKey(): arcs.core.storage.StorageKey = StorageKeyParser.parse(raw)
-
-    companion object {
-        init {
-            VolatileStorageKey.registerParser()
-            RamDiskStorageKey.registerParser()
-            DatabaseStorageKey.registerParser()
-            ReferenceModeStorageKey.registerParser()
-        }
-    }
 }

--- a/javatests/arcs/android/common/resurrection/ResurrectionRequestTest.kt
+++ b/javatests/arcs/android/common/resurrection/ResurrectionRequestTest.kt
@@ -18,9 +18,11 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.ActivityTestRule
 import arcs.android.common.resurrection.ResurrectionRequest.UnregisterRequest
 import arcs.core.storage.StorageKey
+import arcs.core.storage.StorageKeyParser
 import arcs.core.storage.keys.RamDiskStorageKey
 import arcs.core.testutil.fail
 import com.google.common.truth.Truth.assertThat
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -29,6 +31,11 @@ import org.junit.runner.RunWith
 class ResurrectionRequestTest {
     @get:Rule
     val activity = ActivityTestRule(ClientActivity::class.java)
+
+    @Before
+    fun setup() {
+        StorageKeyParser.reset(RamDiskStorageKey)
+    }
 
     @Test
     fun createDefault() {

--- a/javatests/arcs/android/common/resurrection/ResurrectorServiceTest.kt
+++ b/javatests/arcs/android/common/resurrection/ResurrectorServiceTest.kt
@@ -19,6 +19,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import arcs.android.common.resurrection.ResurrectionRequest.Companion.ACTION_RESURRECT
 import arcs.android.common.resurrection.ResurrectionRequest.Companion.EXTRA_REGISTRATION_TARGET_ID
 import arcs.android.common.resurrection.ResurrectionRequest.Companion.EXTRA_RESURRECT_NOTIFIER
+import arcs.core.storage.StorageKeyParser
 import arcs.core.storage.keys.RamDiskStorageKey
 import com.google.common.truth.Truth.assertThat
 import java.io.PrintWriter
@@ -43,6 +44,7 @@ class ResurrectorServiceTest {
 
     @Before
     fun setUp() {
+        StorageKeyParser.reset(RamDiskStorageKey)
         context = ApplicationProvider.getApplicationContext<Application>()
         resurrectionRequest = ResurrectionRequest.createDefault(context, storageKeys, "test")
         resurrectionRequestIntent = Intent(context, ResurrectorServiceImpl::class.java)

--- a/javatests/arcs/android/crdt/BUILD
+++ b/javatests/arcs/android/crdt/BUILD
@@ -21,6 +21,7 @@ arcs_kt_android_test_suite(
         "//java/arcs/core/data:schema_fields",
         "//java/arcs/core/data/util:data-util",
         "//java/arcs/core/storage:reference",
+        "//java/arcs/core/storage:storage_key",
         "//java/arcs/core/storage/keys",
         "//third_party/android/androidx_test/ext/junit",
         "//third_party/java/junit:junit-android",

--- a/javatests/arcs/android/crdt/ReferenceProtoTest.kt
+++ b/javatests/arcs/android/crdt/ReferenceProtoTest.kt
@@ -17,6 +17,7 @@ import arcs.android.util.writeProto
 import arcs.core.crdt.VersionMap
 import arcs.core.data.RawEntity
 import arcs.core.storage.Reference
+import arcs.core.storage.StorageKeyParser
 import arcs.core.storage.keys.RamDiskStorageKey
 import com.google.common.truth.Truth.assertThat
 import org.junit.Before
@@ -27,7 +28,7 @@ import org.junit.runner.RunWith
 class ReferenceProtoTest {
     @Before
     fun setUp() {
-        RamDiskStorageKey.registerParser()
+        StorageKeyParser.addParser(RamDiskStorageKey)
     }
 
     @Test

--- a/javatests/arcs/android/e2e/testapp/TestApplication.kt
+++ b/javatests/arcs/android/e2e/testapp/TestApplication.kt
@@ -19,8 +19,6 @@ import arcs.core.storage.api.DriverAndKeyConfigurator
 import arcs.core.storage.driver.DatabaseDriverProvider
 import arcs.core.storage.driver.RamDisk
 import arcs.core.storage.driver.RamDiskDriverProvider
-import arcs.core.storage.keys.DatabaseStorageKey
-import arcs.core.storage.referencemode.ReferenceModeStorageKey
 import arcs.core.util.Log
 
 /** Application class for Arcs Test. */
@@ -39,12 +37,9 @@ class TestApplication : Application(), Configuration.Provider {
 
         DriverAndKeyConfigurator.configureKeyParsers()
 
-        DatabaseStorageKey.registerParser()
         DatabaseDriverProvider.configure(AndroidSqliteDatabaseManager(this)) {
             TestEntity.SCHEMA
         }
-
-        ReferenceModeStorageKey.registerParser()
 
         initLogForAndroid(Log.Level.Debug)
     }

--- a/javatests/arcs/android/host/parcelables/BUILD
+++ b/javatests/arcs/android/host/parcelables/BUILD
@@ -20,6 +20,7 @@ arcs_kt_android_test_suite(
         "//java/arcs/core/host",
         "//java/arcs/core/storage/driver",
         "//java/arcs/core/storage/keys",
+        "//java/arcs/core/storage/referencemode",
         "//java/arcs/core/type",
         "//java/arcs/sdk",
         "//third_party/android/androidx_test/core",

--- a/javatests/arcs/android/host/parcelables/ParcelableHandleConnectionTest.kt
+++ b/javatests/arcs/android/host/parcelables/ParcelableHandleConnectionTest.kt
@@ -23,8 +23,10 @@ import arcs.core.data.Schema
 import arcs.core.data.SchemaFields
 import arcs.core.data.SchemaName
 import arcs.core.data.expression.asExpr
+import arcs.core.storage.StorageKeyParser
 import arcs.core.storage.keys.VolatileStorageKey
 import com.google.common.truth.Truth.assertThat
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -40,6 +42,10 @@ class ParcelableHandleConnectionTest {
     private val storageKey = VolatileStorageKey(ArcId.newForTest("foo"), "bar")
     private val personType = EntityType(personSchema)
 
+    @Before
+    fun setup() {
+        StorageKeyParser.reset(VolatileStorageKey)
+    }
     @Test
     fun handleConnection_parcelableRoundTrip_works() {
         val handleConnection = HandleConnection(

--- a/javatests/arcs/android/host/parcelables/ParcelableHandleTest.kt
+++ b/javatests/arcs/android/host/parcelables/ParcelableHandleTest.kt
@@ -20,8 +20,10 @@ import arcs.core.data.Plan.Handle
 import arcs.core.data.Schema
 import arcs.core.data.SchemaFields
 import arcs.core.data.SchemaName
+import arcs.core.storage.StorageKeyParser
 import arcs.core.storage.keys.VolatileStorageKey
 import com.google.common.truth.Truth.assertThat
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -34,6 +36,11 @@ class ParcelableHandleTest {
         SchemaFields(mapOf("name" to Text), emptyMap()),
         "42"
     )
+
+    @Before
+    fun setup() {
+        StorageKeyParser.reset(VolatileStorageKey)
+    }
 
     @Test
     fun handle_parcelableRoundTrip_works() {

--- a/javatests/arcs/android/host/parcelables/ParcelableParticleTest.kt
+++ b/javatests/arcs/android/host/parcelables/ParcelableParticleTest.kt
@@ -21,14 +21,26 @@ import arcs.core.data.Plan
 import arcs.core.data.Schema
 import arcs.core.data.SchemaFields
 import arcs.core.data.SchemaName
+import arcs.core.storage.StorageKeyParser
+import arcs.core.storage.keys.RamDiskStorageKey
 import arcs.core.storage.keys.VolatileStorageKey
+import arcs.core.storage.referencemode.ReferenceModeStorageKey
 import com.google.common.truth.Truth.assertThat
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 
 /** Tests for [ParcelableParticle]'s classes. */
 @RunWith(AndroidJUnit4::class)
 class ParcelableParticleTest {
+    @Before
+    fun setup() {
+        StorageKeyParser.reset(
+            ReferenceModeStorageKey,
+            RamDiskStorageKey,
+            VolatileStorageKey
+        )
+    }
 
     @Test
     fun particle_parcelableRoundTrip_works() {

--- a/javatests/arcs/android/host/parcelables/ParcelablePlanPartitionTest.kt
+++ b/javatests/arcs/android/host/parcelables/ParcelablePlanPartitionTest.kt
@@ -21,8 +21,10 @@ import arcs.core.data.Plan
 import arcs.core.data.Schema
 import arcs.core.data.SchemaFields
 import arcs.core.data.SchemaName
+import arcs.core.storage.StorageKeyParser
 import arcs.core.storage.keys.VolatileStorageKey
 import com.google.common.truth.Truth.assertThat
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -35,6 +37,11 @@ class ParcelablePlanPartitionTest {
         SchemaFields(mapOf("name" to FieldType.Text), emptyMap()),
         "42"
     )
+
+    @Before
+    fun setup() {
+        StorageKeyParser.reset(VolatileStorageKey)
+    }
 
     @Test
     fun PlanPartition_parcelableRoundTrip_works() {

--- a/javatests/arcs/android/host/parcelables/ParcelablePlanTest.kt
+++ b/javatests/arcs/android/host/parcelables/ParcelablePlanTest.kt
@@ -22,8 +22,10 @@ import arcs.core.data.Plan
 import arcs.core.data.Schema
 import arcs.core.data.SchemaFields
 import arcs.core.data.SchemaName
+import arcs.core.storage.StorageKeyParser
 import arcs.core.storage.keys.VolatileStorageKey
 import com.google.common.truth.Truth.assertThat
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -38,6 +40,11 @@ class ParcelablePlanTest {
     )
 
     private val personType = EntityType(personSchema)
+
+    @Before
+    fun setup() {
+        StorageKeyParser.reset(VolatileStorageKey)
+    }
 
     @Test
     fun plan_parcelableRoundTrip_works() {

--- a/javatests/arcs/android/storage/ParcelableStoreOptionsTest.kt
+++ b/javatests/arcs/android/storage/ParcelableStoreOptionsTest.kt
@@ -15,16 +15,26 @@ import android.os.Parcel
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import arcs.android.crdt.ParcelableCrdtType
 import arcs.core.data.CountType
+import arcs.core.storage.StorageKeyParser
 import arcs.core.storage.StoreOptions
 import arcs.core.storage.keys.RamDiskStorageKey
 import arcs.core.storage.referencemode.ReferenceModeStorageKey
 import com.google.common.truth.Truth.assertThat
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 
 /** Tests for [ParcelableStoreOptions]. */
 @RunWith(AndroidJUnit4::class)
 class ParcelableStoreOptionsTest {
+    @Before
+    fun setup() {
+        StorageKeyParser.reset(
+            ReferenceModeStorageKey,
+            RamDiskStorageKey
+        )
+    }
+
     @Test
     fun parcelableRoundtrip_works() {
         val storeOptions = StoreOptions(

--- a/javatests/arcs/android/storage/ReferenceModeStoreDatabaseImplIntegrationTest.kt
+++ b/javatests/arcs/android/storage/ReferenceModeStoreDatabaseImplIntegrationTest.kt
@@ -33,6 +33,7 @@ import arcs.core.storage.ProxyCallback
 import arcs.core.storage.ProxyMessage
 import arcs.core.storage.Reference
 import arcs.core.storage.ReferenceModeStore
+import arcs.core.storage.StorageKeyParser
 import arcs.core.storage.StoreOptions
 import arcs.core.storage.StoreWriteBack
 import arcs.core.storage.database.DatabaseData
@@ -100,6 +101,7 @@ class ReferenceModeStoreDatabaseImplIntegrationTest {
         SchemaRegistry.register(inlineSchema)
         databaseFactory = AndroidSqliteDatabaseManager(ApplicationProvider.getApplicationContext())
         StoreWriteBack.writeBackFactoryOverride = WriteBackForTesting
+        StorageKeyParser.reset(DatabaseStorageKey.Persistent)
         DatabaseDriverProvider.configure(databaseFactory) {
             when (it) {
                 hash -> schema

--- a/javatests/arcs/android/storage/database/AndroidSqliteDatabaseManagerTest.kt
+++ b/javatests/arcs/android/storage/database/AndroidSqliteDatabaseManagerTest.kt
@@ -19,6 +19,7 @@ import arcs.core.data.RawEntity
 import arcs.core.data.Schema
 import arcs.core.data.SchemaFields
 import arcs.core.data.util.toReferencable
+import arcs.core.storage.StorageKeyParser
 import arcs.core.storage.database.DatabaseData
 import arcs.core.storage.database.DatabaseManager
 import arcs.core.storage.testutil.DummyStorageKey
@@ -55,7 +56,7 @@ class AndroidSqliteDatabaseManagerTest {
     fun setUp() {
         manager = AndroidSqliteDatabaseManager(ApplicationProvider.getApplicationContext())
         random = Random(System.currentTimeMillis())
-        DummyStorageKey.registerParser()
+        StorageKeyParser.addParser(DummyStorageKey)
     }
 
     @Test

--- a/javatests/arcs/android/storage/database/DatabaseImplTest.kt
+++ b/javatests/arcs/android/storage/database/DatabaseImplTest.kt
@@ -65,7 +65,7 @@ class DatabaseImplTest {
     fun setUp() {
         database = DatabaseImpl(ApplicationProvider.getApplicationContext(), "test.sqlite3")
         db = database.writableDatabase
-        DummyStorageKey.registerParser()
+        StorageKeyParser.addParser(DummyStorageKey)
     }
 
     @After

--- a/javatests/arcs/core/storage/keys/DatabaseStorageKeyTest.kt
+++ b/javatests/arcs/core/storage/keys/DatabaseStorageKeyTest.kt
@@ -24,26 +24,27 @@ import org.junit.runners.JUnit4
 class DatabaseStorageKeyTest {
     @Before
     fun setUp() {
-        DatabaseStorageKey.registerParser()
+        StorageKeyParser.addParser(DatabaseStorageKey.Memory)
+        StorageKeyParser.addParser(DatabaseStorageKey.Persistent)
     }
 
     @Test
     fun toString_renders_correctly_persistent() {
         val key = DatabaseStorageKey.Persistent("foo", "1234a", dbName = "myDb")
         assertThat(key.toString())
-            .isEqualTo("$DATABASE_DRIVER_PROTOCOL://1234a@myDb/foo")
+            .isEqualTo("${DatabaseStorageKey.Persistent.protocol}://1234a@myDb/foo")
     }
 
     @Test
     fun toString_renders_correctly_nonPersistent() {
         val key = DatabaseStorageKey.Memory("foo", "1234a", dbName = "myDb")
         assertThat(key.toString())
-            .isEqualTo("$MEMORY_DATABASE_DRIVER_PROTOCOL://1234a@myDb/foo")
+            .isEqualTo("${DatabaseStorageKey.Memory.protocol}://1234a@myDb/foo")
     }
 
     @Test
     fun fromString_parses_correctly_persistent() {
-        val key = DatabaseStorageKey.persistentFromString("1234a@myDb/foo")
+        val key = DatabaseStorageKey.Persistent.parse("1234a@myDb/foo")
         assertThat(key).isInstanceOf(DatabaseStorageKey.Persistent::class.java)
         assertThat(key.unique).isEqualTo("foo")
         assertThat(key.entitySchemaHash).isEqualTo("1234a")
@@ -52,7 +53,7 @@ class DatabaseStorageKeyTest {
 
     @Test
     fun fromString_parses_correctly_nonPersistent() {
-        val key = DatabaseStorageKey.memoryFromString("1234a@myDb/foo")
+        val key = DatabaseStorageKey.Memory.parse("1234a@myDb/foo")
         assertThat(key).isInstanceOf(DatabaseStorageKey.Memory::class.java)
         assertThat(key.unique).isEqualTo("foo")
         assertThat(key.entitySchemaHash).isEqualTo("1234a")
@@ -141,7 +142,7 @@ class DatabaseStorageKeyTest {
 
     @Test
     fun registers_self_withParser_persistent() {
-        val keyString = "$DATABASE_DRIVER_PROTOCOL://1234a@myDb/foo"
+        val keyString = "${DatabaseStorageKey.Persistent.protocol}://1234a@myDb/foo"
         val key = StorageKeyParser.parse(keyString) as? DatabaseStorageKey.Persistent
             ?: fail("Expected a DatabaseStorageKey")
         assertThat(key.dbName).isEqualTo("myDb")
@@ -151,7 +152,7 @@ class DatabaseStorageKeyTest {
 
     @Test
     fun registers_self_withParser_memory() {
-        val keyString = "$MEMORY_DATABASE_DRIVER_PROTOCOL://1234a@myDb/foo"
+        val keyString = "${DatabaseStorageKey.Memory.protocol}://1234a@myDb/foo"
         val key = StorageKeyParser.parse(keyString) as? DatabaseStorageKey.Memory
             ?: fail("Expected a DatabaseStorageKey")
         assertThat(key.dbName).isEqualTo("myDb")
@@ -164,7 +165,7 @@ class DatabaseStorageKeyTest {
         val parent = DatabaseStorageKey.Persistent("parent", "1234a")
         val child = parent.childKeyWithComponent("child") as DatabaseStorageKey.Persistent
         assertThat(child.toString())
-            .isEqualTo("$DATABASE_DRIVER_PROTOCOL://${parent.toKeyString()}/child")
+            .isEqualTo("${DatabaseStorageKey.Persistent.protocol}://${parent.toKeyString()}/child")
     }
 
     @Test
@@ -172,6 +173,6 @@ class DatabaseStorageKeyTest {
         val parent = DatabaseStorageKey.Memory("parent", "1234a")
         val child = parent.childKeyWithComponent("child") as DatabaseStorageKey.Memory
         assertThat(child.toString())
-            .isEqualTo("$MEMORY_DATABASE_DRIVER_PROTOCOL://${parent.toKeyString()}/child")
+            .isEqualTo("${DatabaseStorageKey.Memory.protocol}://${parent.toKeyString()}/child")
     }
 }

--- a/javatests/arcs/core/storage/keys/JoinStorageKeyTest.kt
+++ b/javatests/arcs/core/storage/keys/JoinStorageKeyTest.kt
@@ -13,6 +13,7 @@ package arcs.core.storage.keys
 import arcs.core.storage.StorageKeyParser
 import arcs.core.storage.embed
 import com.google.common.truth.Truth.assertThat
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
@@ -20,6 +21,14 @@ import org.junit.runners.JUnit4
 /** Tests for [JoinStorageKey]. */
 @RunWith(JUnit4::class)
 class JoinStorageKeyTest {
+    @Before
+    fun setup() {
+        StorageKeyParser.reset(
+            JoinStorageKey,
+            RamDiskStorageKey
+        )
+    }
+
     @Test
     fun toString_rendersCorrectly() {
         val key1 = RamDiskStorageKey("key1")

--- a/javatests/arcs/core/storage/keys/RamDiskStorageKeyTest.kt
+++ b/javatests/arcs/core/storage/keys/RamDiskStorageKeyTest.kt
@@ -12,6 +12,7 @@ package arcs.core.storage.keys
 
 import arcs.core.storage.StorageKeyParser
 import com.google.common.truth.Truth.assertThat
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
@@ -19,17 +20,23 @@ import org.junit.runners.JUnit4
 /** Tests for [RamDiskStorageKey]. */
 @RunWith(JUnit4::class)
 class RamDiskStorageKeyTest {
+
+    @Before
+    fun setup() {
+        StorageKeyParser.reset(RamDiskStorageKey)
+    }
+
     @Test
     fun toString_rendersCorrectly() {
         val key = RamDiskStorageKey("foo")
-        assertThat(key.toString()).isEqualTo("$RAMDISK_DRIVER_PROTOCOL://foo")
+        assertThat(key.toString()).isEqualTo("${RamDiskStorageKey.protocol}://foo")
     }
 
     @Test
     fun childKey_hasCorrectFormat() {
         val parent = RamDiskStorageKey("parent")
         val child = parent.childKeyWithComponent("child")
-        assertThat(child.toString()).isEqualTo("$RAMDISK_DRIVER_PROTOCOL://parent/child")
+        assertThat(child.toString()).isEqualTo("${RamDiskStorageKey.protocol}://parent/child")
     }
 
     @Test

--- a/javatests/arcs/core/storage/keys/VolatileStorageKeyTest.kt
+++ b/javatests/arcs/core/storage/keys/VolatileStorageKeyTest.kt
@@ -13,6 +13,7 @@ package arcs.core.storage.keys
 import arcs.core.common.ArcId
 import arcs.core.storage.StorageKeyParser
 import com.google.common.truth.Truth.assertThat
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
@@ -20,11 +21,16 @@ import org.junit.runners.JUnit4
 /** Tests for [VolatileStorageKey]. */
 @RunWith(JUnit4::class)
 class VolatileStorageKeyTest {
+    @Before
+    fun setup() {
+        StorageKeyParser.reset(VolatileStorageKey)
+    }
+
     @Test
     fun toString_rendersCorrectly() {
         val arcId = ArcId.newForTest("arc")
         val key = VolatileStorageKey(arcId, "foo")
-        assertThat(key.toString()).isEqualTo("$VOLATILE_DRIVER_PROTOCOL://$arcId/foo")
+        assertThat(key.toString()).isEqualTo("${VolatileStorageKey.protocol}://$arcId/foo")
     }
 
     @Test
@@ -32,7 +38,8 @@ class VolatileStorageKeyTest {
         val arcId = ArcId.newForTest("arc")
         val parent = VolatileStorageKey(arcId, "parent")
         val child = parent.childKeyWithComponent("child")
-        assertThat(child.toString()).isEqualTo("$VOLATILE_DRIVER_PROTOCOL://$arcId/parent/child")
+        assertThat(child.toString())
+            .isEqualTo("${VolatileStorageKey.protocol}://$arcId/parent/child")
     }
 
     @Test

--- a/javatests/arcs/core/storage/referencemode/ReferenceModeStorageKeyTest.kt
+++ b/javatests/arcs/core/storage/referencemode/ReferenceModeStorageKeyTest.kt
@@ -16,6 +16,7 @@ import arcs.core.storage.keys.DatabaseStorageKey
 import arcs.core.storage.keys.RamDiskStorageKey
 import com.google.common.truth.Truth.assertThat
 import kotlin.test.assertFailsWith
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
@@ -23,6 +24,14 @@ import org.junit.runners.JUnit4
 /** Tests for [ReferenceModeStorageKey]. */
 @RunWith(JUnit4::class)
 class ReferenceModeStorageKeyTest {
+
+    @Before
+    fun setup() {
+        StorageKeyParser.reset(
+            ReferenceModeStorageKey,
+            RamDiskStorageKey
+        )
+    }
     @Test
     fun differentProtocolsThrows() {
         val backing = DatabaseStorageKey.Persistent("db", "abcdef")
@@ -42,7 +51,7 @@ class ReferenceModeStorageKeyTest {
         val key = ReferenceModeStorageKey(backing, direct)
 
         assertThat(key.toString())
-            .isEqualTo("$REFERENCE_MODE_PROTOCOL://{$backing}{$direct}")
+            .isEqualTo("${ReferenceModeStorageKey.protocol}://{$backing}{$direct}")
     }
 
     @Test
@@ -57,7 +66,7 @@ class ReferenceModeStorageKeyTest {
         val embeddedDirect = directReference.embed()
 
         assertThat(parent.toString())
-            .isEqualTo("$REFERENCE_MODE_PROTOCOL://{$embeddedBacking}{$embeddedDirect}")
+            .isEqualTo("${ReferenceModeStorageKey.protocol}://{$embeddedBacking}{$embeddedDirect}")
     }
 
     @Test

--- a/javatests/arcs/sdk/HandleUtilsTest.kt
+++ b/javatests/arcs/sdk/HandleUtilsTest.kt
@@ -20,6 +20,7 @@ import arcs.core.entity.awaitReady
 import arcs.core.host.EntityHandleManager
 import arcs.core.host.HandleMode
 import arcs.core.storage.StorageKey
+import arcs.core.storage.StorageKeyParser
 import arcs.core.storage.StoreManager
 import arcs.core.storage.driver.RamDisk
 import arcs.core.storage.driver.RamDiskDriverProvider
@@ -61,7 +62,7 @@ class HandleUtilsTest {
     fun setUp() = runBlocking {
         RamDisk.clear()
         RamDiskDriverProvider()
-        ReferenceModeStorageKey.registerParser()
+        StorageKeyParser.reset(ReferenceModeStorageKey)
         stores = StoreManager()
         scheduler = Scheduler(Executors.newSingleThreadExecutor().asCoroutineDispatcher() + Job())
         manager = EntityHandleManager(

--- a/javatests/arcs/sdk/android/storage/ResurrectionHelperTest.kt
+++ b/javatests/arcs/sdk/android/storage/ResurrectionHelperTest.kt
@@ -23,6 +23,7 @@ import arcs.android.common.resurrection.ResurrectionRequest.Companion.EXTRA_REGI
 import arcs.android.common.resurrection.ResurrectionRequest.Companion.EXTRA_REGISTRATION_PACKAGE_NAME
 import arcs.android.common.resurrection.ResurrectionRequest.Companion.EXTRA_REGISTRATION_TARGET_ID
 import arcs.core.storage.StorageKey
+import arcs.core.storage.StorageKeyParser
 import arcs.core.storage.keys.RamDiskStorageKey
 import com.google.common.truth.Truth.assertThat
 import org.junit.Before
@@ -40,6 +41,7 @@ class ResurrectionHelperTest {
 
     @Before
     fun setUp() {
+        StorageKeyParser.reset(RamDiskStorageKey)
         service = Robolectric.setupService(ResurrectionHelperDummyService::class.java)
         context = InstrumentationRegistry.getInstrumentation().targetContext
 

--- a/javatests/arcs/sdk/android/storage/service/StorageServiceTest.kt
+++ b/javatests/arcs/sdk/android/storage/service/StorageServiceTest.kt
@@ -30,6 +30,7 @@ import arcs.core.crdt.CrdtCount
 import arcs.core.data.CountType
 import arcs.core.storage.ProxyMessage
 import arcs.core.storage.StorageKey
+import arcs.core.storage.StorageKeyParser
 import arcs.core.storage.StoreOptions
 import arcs.core.storage.keys.RamDiskStorageKey
 import arcs.sdk.android.storage.ResurrectionHelper
@@ -54,6 +55,7 @@ class StorageServiceTest {
 
     @Before
     fun setUp() {
+        StorageKeyParser.reset(RamDiskStorageKey)
         app = ApplicationProvider.getApplicationContext()
         WorkManagerTestInitHelper.initializeTestWorkManager(app)
         workManager = WorkManager.getInstance(app)


### PR DESCRIPTION
This introduces an official interface for StorageKeyParsers, and uses a
consistent pattern for defining them in the storage key classes.

Along with this, the current “StorageKeyParser” top-level object now
implements a StorageKeyManager interface, which describes an object that
can delegate parsing to a collection of registered parsers.

The global manager object’s internal map is now accessed in a
thread-safe manner.

b/164161757