### PR TITLE
Adds some helper methods for Result

### DIFF
--- a/java/arcs/core/data/proto/ManifestProtoDecoder.kt
+++ b/java/arcs/core/data/proto/ManifestProtoDecoder.kt
@@ -12,7 +12,6 @@
 package arcs.core.data.proto
 
 import arcs.core.data.Recipe
-import arcs.core.util.Result
 
 /** Extracts [Recipe]s from the [ManifestProto]. */
 fun ManifestProto.decodeRecipes(): List<Recipe> {
@@ -21,9 +20,4 @@ fun ManifestProto.decodeRecipes(): List<Recipe> {
 }
 
 /** Extracts [ParticleSpec]s from the [ManifestProto]. */
-fun ManifestProto.decodeParticleSpecs() = particleSpecsList.map {
-    when (val result = it.decode()) {
-        is Result.Ok -> result.value
-        is Result.Err -> throw result.thrown
-    }
-}
+fun ManifestProto.decodeParticleSpecs() = particleSpecsList.map { it.decode() }

--- a/java/arcs/core/data/proto/ParticleSpecProtoDecoder.kt
+++ b/java/arcs/core/data/proto/ParticleSpecProtoDecoder.kt
@@ -15,8 +15,6 @@ import arcs.core.data.Check
 import arcs.core.data.HandleConnectionSpec
 import arcs.core.data.HandleMode
 import arcs.core.data.ParticleSpec
-import arcs.core.util.Result
-import arcs.core.util.resultOf
 
 typealias DirectionProto = HandleConnectionSpecProto.Direction
 
@@ -41,7 +39,7 @@ fun HandleConnectionSpecProto.decode() = HandleConnectionSpec(
 )
 
 /** Converts a [ParticleSpecProto] to the corresponding [ParticleSpec] instance. */
-fun ParticleSpecProto.decode(): Result<ParticleSpec> = resultOf {
+fun ParticleSpecProto.decode(): ParticleSpec {
     val connections = mutableMapOf<String, HandleConnectionSpec>()
     connectionsList.forEach {
         val oldValue = connections.put(it.name, it.decode())
@@ -54,5 +52,5 @@ fun ParticleSpecProto.decode(): Result<ParticleSpec> = resultOf {
         Check.Assert(it.accessPath.decode(connections), it.predicate.decode())
     }
     val annotations = annotationsList.map { it.decode() }
-    ParticleSpec(name, connections, location, claims, checks, annotations)
+    return ParticleSpec(name, connections, location, claims, checks, annotations)
 }

--- a/java/arcs/core/util/Result.kt
+++ b/java/arcs/core/util/Result.kt
@@ -13,8 +13,25 @@ package arcs.core.util
 
 /** Simple success/failure result type. */
 sealed class Result<T> {
-    class Ok<T>(val value: T) : Result<T>()
-    class Err<T>(val thrown: Throwable) : Result<T>()
+    /** Returns [T] if the result is [Ok], otherwise throws the failure exception. */
+    abstract fun unwrap(): T
+
+    /** Returns [T] if the result is [Ok], otherwise returns null. */
+    abstract fun get(): T?
+
+    class Ok<T>(val value: T) : Result<T>() {
+        override fun unwrap(): T = value
+
+        override fun get(): T? = value
+    }
+
+    class Err<T>(val thrown: Throwable) : Result<T>() {
+        override fun unwrap(): T {
+            throw thrown
+        }
+
+        override fun get(): T? = null
+    }
 }
 
 /** Returns a [Result] object after trying to execute a block which returns [T]. */

--- a/javatests/arcs/core/data/proto/ParticleSpecProtoDecoderTest.kt
+++ b/javatests/arcs/core/data/proto/ParticleSpecProtoDecoderTest.kt
@@ -15,7 +15,6 @@ import arcs.core.data.ParticleSpec
 import arcs.core.data.Schema
 import arcs.core.data.SchemaFields
 import arcs.core.data.SchemaName
-import arcs.core.util.Result
 import com.google.common.truth.Truth.assertThat
 import com.google.protobuf.TextFormat
 import kotlin.test.assertFailsWith
@@ -38,11 +37,7 @@ fun decodeHandleConnectionSpecProto(protoText: String): HandleConnectionSpec {
 fun decodeParticleSpecProto(protoText: String): ParticleSpec {
     val builder = ParticleSpecProto.newBuilder()
     TextFormat.getParser().merge(protoText, builder)
-    val result = builder.build().decode()
-    return when (result) {
-        is Result.Ok -> result.value
-        is Result.Err -> throw result.thrown
-    }
+    return builder.build().decode()
 }
 
 @RunWith(JUnit4::class)


### PR DESCRIPTION
Also stops using Result in `ParticleSpecProto.decode()`. The only places it was used it was unwrapped anyway, so it's actually not helpful.

I started adding the `unwrap()` and `get()` methods when it looked like I needed to use them. After removing the usage of `Result` from `ParticleSpecProto.decode()` I no longer need to, but I've left them in in case they're useful for someone else later on... 