### PR TITLE
Fix bug with clearing all data with inline entities in the database

### DIFF
--- a/java/arcs/android/storage/database/DatabaseImpl.kt
+++ b/java/arcs/android/storage/database/DatabaseImpl.kt
@@ -1022,6 +1022,7 @@ class DatabaseImpl(
                     LEFT JOIN entity_refs ON entity_storage_key = storage_keys.storage_key
                     GROUP BY storage_key_id, storage_key, orphan
                     HAVING entities.creation_timestamp < $twoDaysAgo
+                    AND storage_keys.storage_key NOT LIKE 'inline%'
                     AND (orphan OR noRef)
                 """.trimIndent(),
                 arrayOf()
@@ -1078,7 +1079,7 @@ class DatabaseImpl(
             FROM entities 
             LEFT JOIN storage_keys
                 ON entities.storage_key_id = storage_keys.id
-            WHERE creation_timestamp > -1        
+            WHERE storage_keys.storage_key NOT LIKE 'inline%'
             """)
     }
 
@@ -1090,6 +1091,7 @@ class DatabaseImpl(
                 ON entities.storage_key_id = storage_keys.id
             WHERE creation_timestamp >= $startTimeMillis
             AND creation_timestamp <= $endTimeMillis
+            AND storage_keys.storage_key NOT LIKE 'inline%'
             """)
     }
 
@@ -1112,6 +1114,7 @@ class DatabaseImpl(
             LEFT JOIN storage_keys
                 ON entities.storage_key_id = storage_keys.id
             WHERE expiration_timestamp > -1 AND expiration_timestamp < $nowMillis
+            AND storage_keys.storage_key NOT LIKE 'inline%'
         """
         clearEntities(query)
     }

--- a/javatests/arcs/android/storage/database/AndroidSqliteDatabaseManagerTest.kt
+++ b/javatests/arcs/android/storage/database/AndroidSqliteDatabaseManagerTest.kt
@@ -46,7 +46,7 @@ class AndroidSqliteDatabaseManagerTest {
         "hash"
     )
     val entity = DatabaseData.Entity(
-        RawEntity("entity", mapOf("text" to "abc".toReferencable()), mapOf()),
+        RawEntity("entity", mapOf("text" to "abc".toReferencable()), mapOf(), 123),
         schema,
         1,
         VersionMap("me" to 1)

--- a/javatests/arcs/android/storage/database/AndroidSqliteDatabaseManagerTest.kt
+++ b/javatests/arcs/android/storage/database/AndroidSqliteDatabaseManagerTest.kt
@@ -118,7 +118,7 @@ class AndroidSqliteDatabaseManagerTest {
 
         // The database has been reset and the entity has been tombstoned.
         val nulledEntity = DatabaseData.Entity(
-            RawEntity("entity", mapOf("text" to null), mapOf()),
+            RawEntity("entity", mapOf("text" to null), mapOf(), 123),
             schema,
             1,
             VersionMap("me" to 1)

--- a/javatests/arcs/android/storage/service/StorageServiceManagerTest.kt
+++ b/javatests/arcs/android/storage/service/StorageServiceManagerTest.kt
@@ -129,38 +129,14 @@ class StorageServiceManagerTest {
     }
 
     @Test
-    fun repro() = runBlocking {
-        val handle = createSingletonHandle(databaseKey)
+    fun resetDatabases() = runBlocking {
+        val handle = createCollectionHandle(databaseKey)
         val entity = DummyEntity().apply {
             num = 1.0
             texts = setOf("1", "one")
             inlineEntity = InlineDummyEntity().apply {
                 text = "inline"
             }
-        }
-        handle.dispatchStore(entity)
-        log("Wrote entity")
-
-        val manager = buildManager()
-        val deferredResult = DeferredResult(kotlin.coroutines.coroutineContext)
-        log("Clearing databases")
-        manager.clearAll(deferredResult)
-
-        withTimeout(2000) {
-            assertThat(deferredResult.await()).isTrue()
-        }
-
-        // Create a new handle (with new Entity manager) to confirm data is gone from storage.
-        val newHandle = createSingletonHandle(databaseKey)
-        assertThat(newHandle.dispatchFetch()).isNull()
-    }
-
-    @Test
-    fun resetDatabases() = runBlocking {
-        val handle = createCollectionHandle(databaseKey)
-        val entity = DummyEntity().apply {
-            num = 1.0
-            texts = setOf("1", "one")
         }
         handle.dispatchStore(entity)
         log("Wrote entity")
@@ -193,6 +169,9 @@ class StorageServiceManagerTest {
         val entity = DummyEntity().apply {
             num = 1.0
             texts = setOf("1", "one")
+            inlineEntity = InlineDummyEntity().apply {
+                text = "inline"
+            }
         }
         handle.dispatchStore(entity)
         log("Wrote entity")

--- a/javatests/arcs/android/storage/ttl/PeriodicCleanupTaskTest.kt
+++ b/javatests/arcs/android/storage/ttl/PeriodicCleanupTaskTest.kt
@@ -60,7 +60,12 @@ class PeriodicCleanupTaskTest {
         fakeTime.millis = 1L
 
         val handle = createCollectionHandle()
-        val entity = DummyEntity().apply { num = 1.0 }
+        val entity = DummyEntity().apply {
+            num = 1.0
+            inlineEntity = InlineDummyEntity().apply {
+                text = "inline"
+            }
+        }
         handle.dispatchStore(entity)
 
         // Make sure the write has reached storage.


### PR DESCRIPTION
see b/165140617
removeAllEntities selects all entities in the entities table (including inline entities) then call clearEntities with entitiesAreTopLevel=true. However the entities will be a mix of inline and non-inline in this case. This causes clearEntities to try parse inline storage keys which cannot be parsed. 

so change every caller of clearEntities to check for storage keys prefixed by "inline"

Also fix garbage collection query in the same way.

Note: grepping string is very unefficient so it would be better to add a boolean field or something like that.
