### PR TITLE
Fix a bug with GC in databases.

### DIFF
--- a/java/arcs/android/storage/database/DatabaseImpl.kt
+++ b/java/arcs/android/storage/database/DatabaseImpl.kt
@@ -1028,6 +1028,7 @@ class DatabaseImpl(
                     HAVING entities.creation_timestamp < $twoDaysAgo
                     AND storage_keys.storage_key NOT LIKE 'inline%'
                     AND (orphan OR noRef)
+                    AND storage_keys.storage_key NOT LIKE 'inline%'
                 """.trimIndent(),
                 arrayOf()
             ).forEach {

--- a/java/arcs/android/storage/database/DatabaseImpl.kt
+++ b/java/arcs/android/storage/database/DatabaseImpl.kt
@@ -1028,7 +1028,6 @@ class DatabaseImpl(
                     HAVING entities.creation_timestamp < $twoDaysAgo
                     AND storage_keys.storage_key NOT LIKE 'inline%'
                     AND (orphan OR noRef)
-                    AND storage_keys.storage_key NOT LIKE 'inline%'
                 """.trimIndent(),
                 arrayOf()
             ).forEach {

--- a/javatests/arcs/android/storage/service/BUILD
+++ b/javatests/arcs/android/storage/service/BUILD
@@ -12,6 +12,7 @@ arcs_kt_android_test_suite(
     manifest = "//java/arcs/android/common:AndroidManifest.xml",
     package = "arcs.android.storage.service",
     deps = [
+        "j//ava/arcs/android/storage/database",
         "//java/arcs/android/crdt",
         "//java/arcs/android/crdt:crdt_exception_android_proto",
         "//java/arcs/android/storage",
@@ -23,6 +24,7 @@ arcs_kt_android_test_suite(
         "//java/arcs/core/entity",
         "//java/arcs/core/host",
         "//java/arcs/core/storage",
+        "//java/arcs/core/storage/api",
         "//java/arcs/core/storage/database",
         "//java/arcs/core/storage/driver",
         "//java/arcs/core/storage/keys",

--- a/javatests/arcs/android/storage/service/BUILD
+++ b/javatests/arcs/android/storage/service/BUILD
@@ -12,11 +12,11 @@ arcs_kt_android_test_suite(
     manifest = "//java/arcs/android/common:AndroidManifest.xml",
     package = "arcs.android.storage.service",
     deps = [
-        "j//ava/arcs/android/storage/database",
         "//java/arcs/android/crdt",
         "//java/arcs/android/crdt:crdt_exception_android_proto",
         "//java/arcs/android/storage",
         "//java/arcs/android/storage:proxy_message_android_proto",
+        "//java/arcs/android/storage/database",
         "//java/arcs/android/storage/service",
         "//java/arcs/core/common",
         "//java/arcs/core/crdt",

--- a/javatests/arcs/android/storage/service/StorageServiceEndToEndTest.kt
+++ b/javatests/arcs/android/storage/service/StorageServiceEndToEndTest.kt
@@ -13,7 +13,9 @@ package arcs.android.storage.service
 
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import arcs.android.storage.database.AndroidSqliteDatabaseManager
 import arcs.core.common.ArcId
+import arcs.core.data.Capability.Ttl
 import arcs.core.data.CollectionType
 import arcs.core.data.EntityType
 import arcs.core.data.HandleMode
@@ -31,6 +33,7 @@ import arcs.core.storage.DriverFactory
 import arcs.core.storage.StorageKey
 import arcs.core.storage.StoreManager
 import arcs.core.storage.StoreWriteBack
+import arcs.core.storage.api.DriverAndKeyConfigurator
 import arcs.core.storage.driver.RamDisk
 import arcs.core.storage.keys.DatabaseStorageKey
 import arcs.core.storage.keys.RamDiskStorageKey
@@ -41,7 +44,6 @@ import arcs.core.testutil.handles.dispatchStore
 import arcs.core.util.testutil.LogRule
 import arcs.jvm.host.JvmSchedulerProvider
 import arcs.jvm.util.testutil.FakeTime
-import arcs.sdk.android.storage.AndroidDriverAndKeyConfigurator
 import com.google.common.truth.Truth.assertThat
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.coroutines.EmptyCoroutineContext
@@ -62,7 +64,7 @@ class StorageServiceEndToEndTest {
 
     private suspend fun buildManager() =
         StorageServiceManager(coroutineContext, ConcurrentHashMap())
-    private val time = FakeTime()
+
     private val scheduler = JvmSchedulerProvider(EmptyCoroutineContext).invoke("test")
     private val ramdiskKey = ReferenceModeStorageKey(
         backingKey = RamDiskStorageKey("backing"),
@@ -78,10 +80,20 @@ class StorageServiceEndToEndTest {
         storageKey = DatabaseStorageKey.Persistent("container", DummyEntity.SCHEMA_HASH)
     )
 
+    private lateinit var databaseManager: AndroidSqliteDatabaseManager
+    private lateinit var time: FakeTime
+
     @Before
     fun setUp() {
+        time = FakeTime()
         StoreWriteBack.writeBackFactoryOverride = WriteBackForTesting
-        AndroidDriverAndKeyConfigurator.configure(ApplicationProvider.getApplicationContext())
+        databaseManager = AndroidSqliteDatabaseManager(
+            ApplicationProvider.getApplicationContext(),
+            null
+        )
+        DriverAndKeyConfigurator.configure(databaseManager)
+
+        //AndroidDriverAndKeyConfigurator.configure(ApplicationProvider.getApplicationContext())
         SchemaRegistry.register(DummyEntity.SCHEMA)
         SchemaRegistry.register(InlineDummyEntity.SCHEMA)
     }
@@ -95,11 +107,59 @@ class StorageServiceEndToEndTest {
     }
 
     @Test
+    fun writeThenRead_nullInlines_inCollection_onDatabase() = runBlocking {
+        val handle = createCollectionHandle(databaseKey)
+        val entity = emptyEntityForTest()
+
+        handle.dispatchStore(entity)
+
+        val handle2 = createCollectionHandle(databaseKey)
+        val data = handle2.fetchAll()
+        assertThat(data.size).isEqualTo(1)
+        assertThat(data.toList()[0]).isEqualTo(entity)
+    }
+
+    @Test
     fun writeThenRead_inlineData_inCollection_onDatabase() = runBlocking {
         val handle = createCollectionHandle(databaseKey)
         val entity = entityForTest()
 
         handle.dispatchStore(entity)
+
+        databaseManager.runGarbageCollection()
+
+        val handle2 = createCollectionHandle(databaseKey)
+        val data = handle2.fetchAll()
+        assertThat(data.size).isEqualTo(1)
+        assertThat(data.toList()[0]).isEqualTo(entity)
+    }
+
+    @Test
+    fun writeThenRead_inlineData_inCollection_onDatabase_withExpiry() = runBlocking {
+        val handle = createCollectionHandle(databaseKey)
+        val entity = entityForTest()
+        val entity2 = entityForTest()
+
+        time.millis = System.currentTimeMillis()
+        handle.dispatchStore(entity)
+        time.millis = 1L
+        handle.dispatchStore(entity2)
+
+        val handle2 = createCollectionHandle(databaseKey)
+        time.millis = System.currentTimeMillis()
+        val data = handle2.fetchAll()
+        assertThat(data.size).isEqualTo(1)
+        assertThat(data.toList()[0]).isEqualTo(entity)
+    }
+
+    @Test
+    fun writeThenRead_inlineData_inCollection_onDatabase_withGC() = runBlocking {
+        val handle = createCollectionHandle(databaseKey)
+        val entity = entityForTest()
+
+        handle.dispatchStore(entity)
+
+        databaseManager.runGarbageCollection()
 
         val handle2 = createCollectionHandle(databaseKey)
         val data = handle2.fetchAll()
@@ -132,6 +192,8 @@ class StorageServiceEndToEndTest {
         assertThat(data.size).isEqualTo(1)
         assertThat(data.toList()[0]).isEqualTo(entity)
     }
+
+    private fun emptyEntityForTest() = DummyEntity()
 
     private fun entityForTest() = DummyEntity().apply {
         inlineEntity = InlineDummyEntity().apply {
@@ -177,6 +239,7 @@ class StorageServiceEndToEndTest {
                 CollectionType(EntityType(DummyEntity.SCHEMA)),
                 DummyEntity
             ),
-            storageKey
+            storageKey,
+            Ttl.Hours(1)
         ).awaitReady() as ReadWriteCollectionHandle<DummyEntity>
 }

--- a/javatests/arcs/android/storage/service/StorageServiceEndToEndTest.kt
+++ b/javatests/arcs/android/storage/service/StorageServiceEndToEndTest.kt
@@ -141,6 +141,8 @@ class StorageServiceEndToEndTest {
         time.millis = 1L
         handle.dispatchStore(entity2)
 
+        databaseManager.removeExpiredEntities()
+
         val handle2 = createCollectionHandle(databaseKey)
         time.millis = System.currentTimeMillis()
         assertThat(handle2.dispatchFetchAll()).containsExactly(entity)


### PR DESCRIPTION
#5953 fixes an issue where  Garbage Collection was selecting all entities including inline entities for removal; this was causing issues because the GC reporter was attempting to parse internal inline storage keys in order to send notifications about them.

This patch adds end-to-end tests to assert that GC is working correctly, as well as extra tests around TTL expiry and null inline entities.

