### PR TITLE
Update TestBase to be Kotlin/Native 1.4 compatible.

### DIFF
--- a/javatests/arcs/sdk/wasm/TestBase.kt
+++ b/javatests/arcs/sdk/wasm/TestBase.kt
@@ -53,7 +53,8 @@ open class TestBase<T : WasmEntity>(
         fail(message, null)
     }
 
-    @Suppress("VIRTUAL_MEMBER_HIDDEN") // Override for Kotlin/Native 1.4
+    // Override for Kotlin/Native 1.4
+    @Suppress("VIRTUAL_MEMBER_HIDDEN")
     fun fail(message: String?, cause: Throwable?): Nothing {
         val err = if (message == null) ctor("Failure") else ctor(message)
         errors.store(err)

--- a/javatests/arcs/sdk/wasm/TestBase.kt
+++ b/javatests/arcs/sdk/wasm/TestBase.kt
@@ -50,7 +50,7 @@ open class TestBase<T : WasmEntity>(
     }
 
     override fun fail(message: String?): Nothing {
-      fail(message, null)
+        fail(message, null)
     }
 
     @Suppress("VIRTUAL_MEMBER_HIDDEN") // Override for Kotlin/Native 1.4

--- a/javatests/arcs/sdk/wasm/TestBase.kt
+++ b/javatests/arcs/sdk/wasm/TestBase.kt
@@ -50,13 +50,18 @@ open class TestBase<T : WasmEntity>(
     }
 
     override fun fail(message: String?): Nothing {
+      fail(message, null)
+    }
+
+    @Suppress("VIRTUAL_MEMBER_HIDDEN") // Override for Kotlin/Native 1.4
+    fun fail(message: String?, cause: Throwable?): Nothing {
         val err = if (message == null) ctor("Failure") else ctor(message)
         errors.store(err)
 
         if (message == null)
             throw AssertionError()
         else
-            throw AssertionError(message)
+            throw AssertionError(message, cause)
     }
 
     fun assertFalse(message: String?, actual: Boolean) = super.assertTrue(message, !actual)


### PR DESCRIPTION
Kotlin/Native 1.4 requires overriding `fail(message,cause)` as well.
Using the `override` keyword would break source compatibility with 1.3
so for now this is handled by supressing the virtual member hidden
check.