### PR TITLE
Fix race where processModelUpdate can be called after close()

### DIFF
--- a/java/arcs/core/storage/StorageProxy.kt
+++ b/java/arcs/core/storage/StorageProxy.kt
@@ -271,7 +271,7 @@ class StorageProxy<Data : CrdtData, Op : CrdtOperationAtTime, T>(
             store.close()
             stateHolder.update { it.setState(ProxyState.CLOSED) }
             _crdt = null
-        }
+        }.join()
     }
 
     /**

--- a/java/arcs/core/storage/StorageProxy.kt
+++ b/java/arcs/core/storage/StorageProxy.kt
@@ -267,8 +267,8 @@ class StorageProxy<Data : CrdtData, Op : CrdtOperationAtTime, T>(
     suspend fun close() {
         if (stateHolder.value.state == ProxyState.CLOSED) return
         waitForIdle()
-        store.close()
         scheduler.scope.launch {
+            store.close()
             stateHolder.update { it.setState(ProxyState.CLOSED) }
             _crdt = null
         }

--- a/java/arcs/core/storage/StorageProxy.kt
+++ b/java/arcs/core/storage/StorageProxy.kt
@@ -264,13 +264,14 @@ class StorageProxy<Data : CrdtData, Op : CrdtOperationAtTime, T>(
      * Attempting to perform an operation on a closed [StorageProxy] will result in an exception
      * being thrown.
      */
-    fun close() {
+    suspend fun close() {
         if (stateHolder.value.state == ProxyState.CLOSED) return
+        waitForIdle()
+        store.close()
         scheduler.scope.launch {
+            stateHolder.update { it.setState(ProxyState.CLOSED) }
             _crdt = null
         }
-        store.close()
-        stateHolder.update { it.setState(ProxyState.CLOSED) }
     }
 
     /**


### PR DESCRIPTION
Fixes processModelUpdate vs close() race

close() can be called and processModelUpdate() can be invoked after the check for CLOSED

This fix waits for idle, then closes the store, lowering the change of an incoming onMessage() happening while the scheduler moves the state to CLOSED and nulls out the model.

10k/10k passed multiple times.
