### PR TITLE
fix race in StorageWriteBackTest

### DIFF
--- a/java/arcs/jvm/storage/database/testutil/FakeDatabaseManager.kt
+++ b/java/arcs/jvm/storage/database/testutil/FakeDatabaseManager.kt
@@ -102,7 +102,7 @@ open class FakeDatabase : Database {
     open val clients = mutableMapOf<Int, Pair<StorageKey, DatabaseClient>>()
 
     private val clientFlow: Flow<DatabaseClient> =
-        flow { clientMutex.withLock { clients.values }.forEach { emit(it.second) } }
+        flow { clientMutex.withLock { clients.values.toList() }.forEach { emit(it.second) } }
 
     private val dataMutex = Mutex()
     open val data = mutableMapOf<StorageKey, DatabaseData>()


### PR DESCRIPTION
The flow holds open a long running iterator over the map, and so throws ConcurrentModificationException eventually.

This makes a copy on flow creation.

10k/10k pass on G3
