### PR TITLE
Ensure inline entities are also deleted when a parent entity is.

### DIFF
--- a/java/arcs/android/storage/database/DatabaseImpl.kt
+++ b/java/arcs/android/storage/database/DatabaseImpl.kt
@@ -939,7 +939,7 @@ class DatabaseImpl(
                     FROM storage_keys 
                     WHERE storage_key = ? OR storage_key LIKE ?
                 """.trimIndent(),
-                arrayOf(storageKey.toString(), "inline://{%$storageKey%")
+                arrayOf(storageKey.toString(), "inline://{%$storageKey%}%")
             ).forEach {
                 val dataType = DataType.values()[it.getInt(1)]
                 var collectionId: Long? = null

--- a/javatests/arcs/android/storage/database/DatabaseImplTest.kt
+++ b/javatests/arcs/android/storage/database/DatabaseImplTest.kt
@@ -670,11 +670,21 @@ class DatabaseImplTest {
         val childSchema = newSchema("child")
         database.getSchemaTypeId(childSchema, db)
         newSchema(
+            "inlineInlineHash",
+            SchemaFields(
+                singletons = mapOf(
+                    "text" to FieldType.Text
+                ),
+                collections = emptyMap()
+            )
+        )
+        newSchema(
             "inlineHash",
             SchemaFields(
                 singletons = mapOf(
                     "text" to FieldType.Text,
-                    "num" to FieldType.Number
+                    "num" to FieldType.Number,
+                    "inline" to FieldType.InlineEntity("inlineInlineHash")
                 ),
                 collections = emptyMap()
             )
@@ -700,11 +710,17 @@ class DatabaseImplTest {
             )
         )
 
+        val inlineInlineEntity = RawEntity(
+            "",
+            singletons = mapOf("text" to "iinnlliinnee".toReferencable())
+        )
+
         fun toInlineEntity(text: String, num: Double) = RawEntity(
             "",
             singletons = mapOf(
                 "text" to text.toReferencable(),
-                "num" to num.toReferencable()
+                "num" to num.toReferencable(),
+                "inline" to inlineInlineEntity
             )
         )
 
@@ -1556,7 +1572,7 @@ class DatabaseImplTest {
 
     @Test
     fun garbageCollection_cleans_inlineEntities() = runBlockingTest {
-        val inlineSchema = newSchema(
+        newSchema(
             "inlineHash",
             SchemaFields(
                 singletons = mapOf("text" to FieldType.Text),

--- a/javatests/arcs/android/storage/database/DatabaseImplTest.kt
+++ b/javatests/arcs/android/storage/database/DatabaseImplTest.kt
@@ -804,11 +804,43 @@ class DatabaseImplTest {
             VersionMap("actor" to 2)
         )
 
+        val clearedEntity = DatabaseData.Entity(
+            RawEntity(
+                entityId,
+                mapOf(
+                    "text" to null,
+                    "bool" to null,
+                    "num" to null,
+                    "ref" to null,
+                    "inline" to null,
+                    "inlinelist" to null
+                ),
+                mapOf(
+                    "texts" to emptySet(),
+                    "bools" to emptySet(),
+                    "nums" to emptySet(),
+                    "refs" to emptySet(),
+                    "inlines" to emptySet()
+                )
+            ),
+            schema,
+            3,
+            VersionMap("actor" to 3)
+        )
+
         database.insertOrUpdateEntity(key, entity1)
         database.insertOrUpdateEntity(key, entity2)
         val entityOut = database.getEntity(key, schema)
 
         assertThat(entityOut).isEqualTo(entity2)
+        database.insertOrUpdateEntity(key, clearedEntity)
+
+        assertTableIsEmpty("field_values")
+
+        // the toplevel entity should remain in the entities and storage_keys 
+        // tables, but all record of child inline entities should be removed.
+        assertTableIsSize("entities", 1)
+        assertTableIsSize("storage_keys", 1)
     }
 
     @Test
@@ -1520,6 +1552,56 @@ class DatabaseImplTest {
         )
         assertThat(database.getCollection(collectionKey, schema))
             .isEqualTo(collection.copy(values = newValues))
+    }
+
+    @Test
+    fun garbageCollection_cleans_inlineEntities() = runBlockingTest {
+        val inlineSchema = newSchema(
+            "inlineHash",
+            SchemaFields(
+                singletons = mapOf("text" to FieldType.Text),
+                collections = emptyMap()
+            )
+        )
+        val schema = newSchema(
+            "hash",
+            SchemaFields(
+                singletons = mapOf("inline" to FieldType.InlineEntity("inlineHash")),
+                collections = mapOf("inlines" to FieldType.InlineEntity("inlineHash"))
+            )
+        )
+
+        val inlineEntity1 = RawEntity(
+            "ie1",
+            singletons = mapOf("text" to "ie1".toReferencable())
+        )
+
+        val inlineEntity2 = RawEntity(
+            "ie2",
+            singletons = mapOf("text" to "ie2".toReferencable())
+        )
+
+        val entity = DatabaseData.Entity(
+            RawEntity(
+                "entity",
+                singletons = mapOf("inline" to inlineEntity1),
+                collections = mapOf("inlines" to setOf(inlineEntity2)),
+                creationTimestamp = 100
+            ),
+            schema,
+            FIRST_VERSION_NUMBER,
+            VERSION_MAP
+        )
+
+        val entityKey = DummyStorageKey("backing/entity")
+        database.insertOrUpdate(entityKey, entity)
+
+        database.runGarbageCollection()
+        database.runGarbageCollection()
+
+        assertTableIsEmpty("entities")
+        assertTableIsEmpty("storage_keys")
+        assertTableIsEmpty("field_values")
     }
 
     @Test


### PR DESCRIPTION
Prior to this patch, inline entities were not being removed when
a parent entity was rewritten, nor were they being removed as
part of garbage collection.

Both these processes make use of delete() to remove the parent
entity. This patch allows delete() to renmove inline entities as
well.

How this works:

Inline entity storage keys are of the pattern
  inline://{<parent key>}<extra data>

Hence, when a storage key is deleted using delete(), we now
look for that exact storage key, as well as any storage keys
that are LIKE "inline://{%storageKey%}%". This will match
inline keys that have the parent key somewhere in their
chain of parent keys.