### PR TITLE
Add legacy multi-dex configuration to testapp

### DIFF
--- a/javatests/arcs/android/systemhealth/testapp/BUILD
+++ b/javatests/arcs/android/systemhealth/testapp/BUILD
@@ -60,8 +60,8 @@ android_binary(
     testonly = 1,
     dexopts = ["--force-jumbo"],
     incremental_dexing = 0,
-    manifest = ":AndroidManifest.xml",
     main_dex_proguard_specs = ["mainDexClasses.rules"],
+    manifest = ":AndroidManifest.xml",
     multidex = "legacy",
     deps = [":test_app_lib"],
 )

--- a/javatests/arcs/android/systemhealth/testapp/BUILD
+++ b/javatests/arcs/android/systemhealth/testapp/BUILD
@@ -61,6 +61,7 @@ android_binary(
     dexopts = ["--force-jumbo"],
     incremental_dexing = 0,
     manifest = ":AndroidManifest.xml",
-    multidex = "native",
+    main_dex_proguard_specs = ["mainDexClasses.rules"],
+    multidex = "legacy",
     deps = [":test_app_lib"],
 )

--- a/javatests/arcs/android/systemhealth/testapp/mainDexClasses.rules
+++ b/javatests/arcs/android/systemhealth/testapp/mainDexClasses.rules
@@ -1,0 +1,19 @@
+  -keep public class * extends android.app.Instrumentation {
+    <init>();
+    void onCreate(android.os.Bundle);
+    android.app.Application newApplication(...);
+    void callApplicationOnCreate(android.app.Application);
+  }
+  -keep public class * extends android.app.Application {
+    <init>();
+    void attachBaseContext(android.content.Context);
+  }
+  -keep public class * extends android.app.backup.BackupAgent {
+    <init>();
+    void attachBaseContext(android.content.Context);
+  }
+# We need to keep all annotation classes because proguard does not trace annotation attribute
+# it just filter the annotation attributes according to annotation classes it already kept.
+  -keep public class * extends java.lang.annotation.Annotation {
+    *;
+  }


### PR DESCRIPTION
The testapp is a multi-dex application, and for running on pre-L devices
a main-dex configuration is required.

Bazel will at some point make it a compilation error to build a
multi-dex app withouti a main-dex configuration.