### PR TITLE
Fix: Duplicate inline entities cause schema2graph cyclic dependency issue

### DIFF
--- a/src/tools/schema2graph.ts
+++ b/src/tools/schema2graph.ts
@@ -204,7 +204,7 @@ export class SchemaGraph {
 
       // Aggregate nodes with the same schema together.
       if (!candidate.variableName) {
-        return schema.equals(candidate.schema) && candidate.isNested === isNested;
+        return schema.equals(candidate.schema);
       }
 
       return false;

--- a/src/tools/schema2graph.ts
+++ b/src/tools/schema2graph.ts
@@ -225,7 +225,7 @@ export class SchemaGraph {
           } else if (!a.variableName && !b.variableName &&
             b.schema.isEquivalentOrMoreSpecific(a.schema) === AtLeastAsSpecific.YES) {
             if (b.descendants.has(a)) {
-              throw new Error(`Cannot add ${b} to ${a}.descendants as it would create a cycle.`);
+              throw new Error(`Cannot add ${b.schema.name} to ${a.schema.name}.descendants as it would create a cycle.`);
             }
             a.descendants.add(b);  // b can be sliced to a
             b.parents = [];        // non-null to indicate this has parents; will be filled later

--- a/src/tools/tests/schema2graph-test.ts
+++ b/src/tools/tests/schema2graph-test.ts
@@ -748,7 +748,7 @@ describe('schema2graph', () => {
     });
   });
 
-  it.only('nested inline entities', async () => {
+  it('duplicate nested inline entities', async () => {
     const manifest = await Manifest.parse(`
       schema Tea
         name: Text
@@ -764,5 +764,13 @@ describe('schema2graph', () => {
     `);
 
     const res = convert(new SchemaGraph(manifest.particles[0]));
+    assert.deepStrictEqual(res.nodes, [
+      {name: 'Foo_Data_FavTea', parents: '', children: ''},
+      {name: 'Foo_Data', parents: '', children: ''},
+    ]);
+    assert.deepStrictEqual(res.aliases, {
+      'Foo_Data_FavTea': ['Foo_Data_Contents', 'Foo_Data_FavTea'],
+      'Foo_Data': ['Foo_Data'],
+    });
   });
 });

--- a/src/tools/tests/schema2graph-test.ts
+++ b/src/tools/tests/schema2graph-test.ts
@@ -747,4 +747,22 @@ describe('schema2graph', () => {
       'T_Baz': ['T_Baz']
     });
   });
+
+  it.only('nested inline entities', async () => {
+    const manifest = await Manifest.parse(`
+      schema Tea
+        name: Text
+        variety: Text
+      
+      schema Container
+        id: Text
+        favTea: inline Tea
+        contents: [inline Tea]
+      
+      particle Foo
+        data: reads [Container]
+    `);
+
+    const res = convert(new SchemaGraph(manifest.particles[0]));
+  });
 });


### PR DESCRIPTION
This PR updates schema2graph to fix a bug (title). It also makes error messages for schema2graph cyclic dependencies better. 

CC: @shans @mykmartin 