### PR TITLE
Set size of core HandleMangerTests to 'medium'

### DIFF
--- a/javatests/arcs/core/entity/BUILD
+++ b/javatests/arcs/core/entity/BUILD
@@ -17,6 +17,7 @@ arcs_kt_schema(
 arcs_kt_jvm_test_suite(
     name = "entity",
     srcs = TEST_SRCS,
+    size = "medium",
     package = "arcs.core.entity",
     deps = [
         ":lib",

--- a/javatests/arcs/core/entity/BUILD
+++ b/javatests/arcs/core/entity/BUILD
@@ -16,8 +16,8 @@ arcs_kt_schema(
 
 arcs_kt_jvm_test_suite(
     name = "entity",
-    srcs = TEST_SRCS,
     size = "medium",
+    srcs = TEST_SRCS,
     package = "arcs.core.entity",
     deps = [
         ":lib",


### PR DESCRIPTION
Temporary fix for the handle manager tests timing out frequently as of late.