### PR TITLE
Create simple helper extension for running on particle dispatcher

### DIFF
--- a/java/arcs/sdk/Particle.kt
+++ b/java/arcs/sdk/Particle.kt
@@ -15,6 +15,7 @@ import arcs.core.entity.awaitReady
 import arcs.core.host.api.Particle
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
 
 /**
  * Interface used by [ArcHost]s to interact dynamically with code-generated [Handle] fields
@@ -24,6 +25,11 @@ typealias HandleHolder = arcs.core.host.api.HandleHolder
 
 /** Base interface for all particles. */
 typealias Particle = Particle
+
+/** A convenience method for moving onto the dispatcher associated with a particle. */
+suspend inline fun <T : Particle, U> T.withParticleContext(
+    crossinline block: suspend () -> U
+): U = withContext(handles.dispatcher) { block() }
 
 /**
  * Base class used by `schema2kotlin` code-generator tool to generate a class containing all

--- a/javatests/arcs/showcase/inline/Reader.kt
+++ b/javatests/arcs/showcase/inline/Reader.kt
@@ -3,16 +3,16 @@
 package arcs.showcase.inline
 
 import arcs.jvm.host.TargetHost
+import arcs.sdk.withParticleContext
 import arcs.showcase.ShowcaseHost
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.withContext
 
 @ExperimentalCoroutinesApi
 @TargetHost(ShowcaseHost::class)
 class Reader0 : AbstractReader0() {
     private fun Level0.fromArcs() = MyLevel0(name)
 
-    suspend fun read(): List<MyLevel0> = withContext(handles.level0.dispatcher) {
+    suspend fun read(): List<MyLevel0> = withParticleContext {
         handles.awaitReady()
         handles.level0.fetchAll().map { it.fromArcs() }
     }
@@ -23,12 +23,12 @@ class Reader0 : AbstractReader0() {
 class Reader1 : AbstractReader1() {
     private fun Level0.fromArcs() = MyLevel0(name)
 
-    private suspend fun Level1.fromArcs() = MyLevel1(
+    private fun Level1.fromArcs() = MyLevel1(
         name = name,
         children = children.map { it.fromArcs() }.toSet()
     )
 
-    suspend fun read(): List<MyLevel1> = withContext(handles.level1.dispatcher) {
+    suspend fun read(): List<MyLevel1> = withParticleContext {
         handles.awaitReady()
         handles.level1.fetchAll().map { it.fromArcs() }
     }
@@ -49,7 +49,7 @@ class Reader2 : AbstractReader2() {
         children = children.map { it.fromArcs() }.toSet()
     )
 
-    suspend fun read(): List<MyLevel2> = withContext(handles.level2.dispatcher) {
+    suspend fun read(): List<MyLevel2> = withParticleContext {
         handles.awaitReady()
         handles.level2.fetchAll().map { it.fromArcs() }
     }

--- a/javatests/arcs/showcase/inline/Writer.kt
+++ b/javatests/arcs/showcase/inline/Writer.kt
@@ -3,16 +3,16 @@
 package arcs.showcase.inline
 
 import arcs.jvm.host.TargetHost
+import arcs.sdk.withParticleContext
 import arcs.showcase.ShowcaseHost
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.withContext
 
 @ExperimentalCoroutinesApi
 @TargetHost(ShowcaseHost::class)
 class Writer0 : AbstractWriter0() {
     private fun MyLevel0.toArcs() = Level0(name)
 
-    suspend fun write(item: MyLevel0) = withContext(handles.level0.dispatcher) {
+    suspend fun write(item: MyLevel0) = withParticleContext {
         handles.awaitReady()
         handles.level0.store(item.toArcs())
     }
@@ -28,7 +28,7 @@ class Writer1 : AbstractWriter1() {
         children = children.map { it.toArcs() }.toSet()
     )
 
-    suspend fun write(item: MyLevel1) = withContext(handles.level1.dispatcher) {
+    suspend fun write(item: MyLevel1) = withParticleContext {
         handles.awaitReady()
         handles.level1.store(item.toArcs())
     }
@@ -49,7 +49,7 @@ class Writer2 : AbstractWriter2() {
         children = children.map { it.toArcs() }.toSet()
     )
 
-    suspend fun write(item: MyLevel2) = withContext(handles.level2.dispatcher) {
+    suspend fun write(item: MyLevel2) = withParticleContext {
         handles.awaitReady()
         handles.level2.store(item.toArcs())
     }

--- a/javatests/arcs/showcase/references/Reader.kt
+++ b/javatests/arcs/showcase/references/Reader.kt
@@ -6,9 +6,9 @@ import arcs.jvm.host.TargetHost
 import arcs.sdk.Entity
 import arcs.sdk.ReadCollectionHandle
 import arcs.sdk.Reference
+import arcs.sdk.withParticleContext
 import arcs.showcase.ShowcaseHost
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.withContext
 
 /**
  * TODO(b/162781220) - Remove this helper in favor of the [dereference] method on the entity.
@@ -22,7 +22,7 @@ fun <T : Entity> Reference<T>.dereferenceViaHandle(handle: ReadCollectionHandle<
 class Reader0 : AbstractReader0() {
     private fun Level0.fromArcs() = MyLevel0(name)
 
-    suspend fun read(): List<MyLevel0> = withContext(handles.level0.dispatcher) {
+    suspend fun read(): List<MyLevel0> = withParticleContext {
         handles.awaitReady()
         handles.level0.fetchAll().map { it.fromArcs() }
     }
@@ -38,7 +38,7 @@ class Reader1 : AbstractReader1() {
         children = children.map { it.dereferenceViaHandle(handles.level0)!!.fromArcs() }.toSet()
     )
 
-    suspend fun read(): List<MyLevel1> = withContext(handles.level1.dispatcher) {
+    suspend fun read(): List<MyLevel1> = withParticleContext {
         handles.awaitReady()
         handles.level1.fetchAll().map { it.fromArcs() }
     }
@@ -59,7 +59,7 @@ class Reader2 : AbstractReader2() {
         children = children.map { it.dereferenceViaHandle(handles.level1)!!.fromArcs() }.toSet()
     )
 
-    suspend fun read(): List<MyLevel2> = withContext(handles.level2.dispatcher) {
+    suspend fun read(): List<MyLevel2> = withParticleContext {
         handles.awaitReady()
         handles.level2.fetchAll().map { it.fromArcs() }
     }

--- a/javatests/arcs/showcase/references/Writer.kt
+++ b/javatests/arcs/showcase/references/Writer.kt
@@ -2,14 +2,13 @@
 
 package arcs.showcase.references
 
-import arcs.core.entity.awaitReady
 import arcs.jvm.host.TargetHost
 import arcs.sdk.Entity
 import arcs.sdk.ReadWriteCollectionHandle
 import arcs.sdk.Reference
+import arcs.sdk.withParticleContext
 import arcs.showcase.ShowcaseHost
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.withContext
 
 suspend fun <T : Entity> T.toReference(handle: ReadWriteCollectionHandle<T>): Reference<T> {
     if (this@toReference.entityId == null) {
@@ -23,7 +22,7 @@ suspend fun <T : Entity> T.toReference(handle: ReadWriteCollectionHandle<T>): Re
 class Writer0 : AbstractWriter0() {
     private fun MyLevel0.toArcs() = Level0(name)
 
-    suspend fun write(item: MyLevel0) = withContext(handles.level0.dispatcher) {
+    suspend fun write(item: MyLevel0) = withParticleContext {
         handles.awaitReady()
         handles.level0.store(item.toArcs())
     }
@@ -39,7 +38,7 @@ class Writer1 : AbstractWriter1() {
         children = children.map { it.toArcs().toReference(handles.level0) }.toSet()
     )
 
-    suspend fun write(item: MyLevel1) = withContext(handles.level1.dispatcher) {
+    suspend fun write(item: MyLevel1) = withParticleContext {
         handles.awaitReady()
         handles.level1.store(item.toArcs())
     }
@@ -60,7 +59,7 @@ class Writer2 : AbstractWriter2() {
         children = children.map { it.toArcs().toReference(handles.level1) }.toSet()
     )
 
-    suspend fun write(item: MyLevel2) = withContext(handles.level2.dispatcher) {
+    suspend fun write(item: MyLevel2) = withParticleContext {
         handles.awaitReady()
         handles.level2.store(item.toArcs())
     }


### PR DESCRIPTION
* Makes the intent a little more obvious than `withContext(handles.dispatcher)`
* Hides the implementation detail that the particle dispatcher is, in
  fact, any one of the handle dispatchers
* Requires typing slightly fewer characters