### PR TITLE
Derive binary manifest proto file name from BUILD target name

### DIFF
--- a/javatests/arcs/core/analysis/InformationFlowTest.kt
+++ b/javatests/arcs/core/analysis/InformationFlowTest.kt
@@ -16,8 +16,7 @@ class InformationFlowTest {
 
     /** Returns the path for the manifest proto binary file for the test. */
     private fun getManifestProtoTextPath(test: String): String {
-        val testText = test.replace("-", "_")
-        return runfilesDir() + "javatests/arcs/core/analysis/testdata/$testText.arcs"
+        return runfilesDir() + "javatests/arcs/core/analysis/testdata/$test.arcs"
     }
 
     /** Returns the path for the manifest proto binary file for the test. */
@@ -75,87 +74,87 @@ class InformationFlowTest {
     @Test
     fun checksAreVerifiedInDFA() {
         val failingTests = listOf(
-            "fail-different-tag",
-            "fail-no-tags",
-            "fail-not-tag-claim",
-            "fail-not-tag-cancels",
-            "fail-negated-tag-present",
-            "fail-read-write-mismatch-claim-check",
-            "fail-multiple-inputs-one-untagged",
-            "fail-check-multiple-or-tags",
-            "fail-multiple-checks",
-            "fail-no-inputs",
-            "fail-mixer",
-            "fail-derives-from-cycle",
-            "fail-derives-from-multiple",
-            "fail-join-tuple-components",
-            "fail-check-on-subpaths",
-            "fail-no-claim-is-empty-labels"
+            "fail_different_tag",
+            "fail_no_tags",
+            "fail_not_tag_claim",
+            "fail_not_tag_cancels",
+            "fail_negated_tag_present",
+            "fail_read_write_mismatch_claim_check",
+            "fail_multiple_inputs_one_untagged",
+            "fail_check_multiple_or_tags",
+            "fail_multiple_checks",
+            "fail_no_inputs",
+            "fail_mixer",
+            "fail_derives_from_cycle",
+            "fail_derives_from_multiple",
+            "fail_join_tuple_components",
+            "fail_check_on_subpaths",
+            "fail_no_claim_is_empty_labels"
         )
         val okTests = listOf(
-            "ok-directly-satisfied",
-            "ok-not-tag-claim-no-checks",
-            "ok-not-tag-claim-reclaimed",
-            "ok-negated-missing-tag",
-            "ok-read-write-match-claim-check",
-            "ok-multiple-inputs-correct-tags",
-            "ok-claim-propagates",
-            "ok-claim-not-overriden-later",
-            "ok-check-multiple-or-tags",
-            "ok-check-multiple-and-single-claim",
-            "ok-check-multiple-or-single-claim",
-            "ok-derives-from-cycle",
-            "ok-derives-from-multiple",
-            "ok-join-simple",
-            "ok-join-tuple-components",
-            "ok-check-on-subpaths"
+            "ok_directly_satisfied",
+            "ok_not_tag_claim_no_checks",
+            "ok_not_tag_claim_reclaimed",
+            "ok_negated_missing_tag",
+            "ok_read_write_match_claim_check",
+            "ok_multiple_inputs_correct_tags",
+            "ok_claim_propagates",
+            "ok_claim_not_overriden_later",
+            "ok_check_multiple_or_tags",
+            "ok_check_multiple_and_single_claim",
+            "ok_check_multiple_or_single_claim",
+            "ok_derives_from_cycle",
+            "ok_derives_from_multiple",
+            "ok_join_simple",
+            "ok_join_tuple_components",
+            "ok_check_on_subpaths"
         )
         val failingFieldTests = listOf(
-            "fail-field-entity-direct",
-            "fail-field-entity-ref-direct",
-            "fail-field-entity-ref-field",
-            "fail-field-collection-direct",
-            "fail-field-inline-entity-direct",
-            "fail-field-list-direct",
-            "fail-field-tuple-direct",
-            "fail-field-inline-entity-slicing",
-            "fail-field-claim-propagates",
-            "fail-field-claim-propagates-type-variables",
-            "fail-field-merge-multiple-paths"
+            "fail_field_entity_direct",
+            "fail_field_entity_ref_direct",
+            "fail_field_entity_ref_field",
+            "fail_field_collection_direct",
+            "fail_field_inline_entity_direct",
+            "fail_field_list_direct",
+            "fail_field_tuple_direct",
+            "fail_field_inline_entity_slicing",
+            "fail_field_claim_propagates",
+            "fail_field_claim_propagates_type_variables",
+            "fail_field_merge_multiple_paths"
         )
         val okFieldTests = listOf(
-            "ok-field-entity-direct",
-            "ok-field-entity-ref-direct",
-            "ok-field-entity-ref-field",
-            "ok-field-collection-direct",
-            "ok-field-inline-entity-direct",
-            "ok-field-list-direct",
-            "ok-field-tuple-direct",
-            "ok-field-inline-entity-slicing",
-            "ok-field-claim-propagates",
-            "ok-field-claim-propagates-type-variables",
-            "ok-field-merge-multiple-paths"
+            "ok_field_entity_direct",
+            "ok_field_entity_ref_direct",
+            "ok_field_entity_ref_field",
+            "ok_field_collection_direct",
+            "ok_field_inline_entity_direct",
+            "ok_field_list_direct",
+            "ok_field_tuple_direct",
+            "ok_field_inline_entity_slicing",
+            "ok_field_claim_propagates",
+            "ok_field_claim_propagates_type_variables",
+            "ok_field_merge_multiple_paths"
         )
         val okCycleTests = listOf(
-            "ok-cycle-overlapping",
-            "ok-cycle-single-particle",
-            "ok-cycle-two-particles",
-            "ok-cycle-claim-propagates",
-            "ok-cycle-two-origin"
+            "ok_cycle_overlapping",
+            "ok_cycle_single_particle",
+            "ok_cycle_two_particles",
+            "ok_cycle_claim_propagates",
+            "ok_cycle_two_origin"
         )
         val failingCycleTests = listOf(
-            "fail-cycle-overlapping-a",
-            "fail-cycle-overlapping-b",
-            "fail-cycle-remove-tag",
-            "fail-cycle-remove-tag-in-chain"
+            "fail_cycle_overlapping_a",
+            "fail_cycle_overlapping_b",
+            "fail_cycle_remove_tag",
+            "fail_cycle_remove_tag_in_chain"
         )
         val typeVariableTests = listOf(
-            "fail-type-variables",
-            "fail-type-variables-no-constraints",
-            "fail-type-variables-collection",
-            "fail-type-variables-tuples",
-            "fail-type-variables-tuples-collection",
-            "fail-type-variables-multiple-constraints"
+            "fail_type_variables",
+            "fail_type_variables_no_constraints",
+            "fail_type_variables_collection",
+            "fail_type_variables_tuples",
+            "fail_type_variables_tuples_collection",
+            "fail_type_variables_multiple_constraints"
         )
         val tests = (
             okTests + failingTests +

--- a/javatests/arcs/core/analysis/PolicyVerifierTest.kt
+++ b/javatests/arcs/core/analysis/PolicyVerifierTest.kt
@@ -15,7 +15,7 @@ import org.junit.runners.JUnit4
 class PolicyVerifierTest {
     // Test context.
     private val storeMap = mapOf("action" to "Action", "selection" to "Selection")
-    private val manifestProto = loadManifestBinaryProto(getManifestProtoBinPath("policy-test"))
+    private val manifestProto = loadManifestBinaryProto(getManifestProtoBinPath("policy_test"))
     private val recipes = manifestProto.decodeRecipes().associateBy { it.name!! }
     private val policy = manifestProto.policiesList.single { it.name == "TestPolicy" }.decode()
     private val verifier = PolicyVerifier(PolicyOptions(storeMap))

--- a/javatests/arcs/core/analysis/RecipeGraphToDotGraphTest.kt
+++ b/javatests/arcs/core/analysis/RecipeGraphToDotGraphTest.kt
@@ -22,7 +22,7 @@ class RecipeGraphToDotGraphTest {
 
     @Test
     fun dotGraph_DefaultNodeLabels() {
-        val recipe = parseManifestWithSingleRecipe("ok-directly-satisfied")
+        val recipe = parseManifestWithSingleRecipe("ok_directly_satisfied")
         val graph = RecipeGraph(recipe)
         val dotGraphLines = graph.toDotGraph().lines()
 
@@ -44,7 +44,7 @@ class RecipeGraphToDotGraphTest {
 
     @Test
     fun dotGraph_CustomNodeLabels() {
-        val recipe = parseManifestWithSingleRecipe("ok-directly-satisfied")
+        val recipe = parseManifestWithSingleRecipe("ok_directly_satisfied")
         val graph = RecipeGraph(recipe)
         val dotGraphLines = graph.toDotGraph { node -> "~~${node.debugName}~~" }.lines()
 

--- a/third_party/java/arcs/build_defs/internal/manifest.bzl
+++ b/third_party/java/arcs/build_defs/internal/manifest.bzl
@@ -6,12 +6,12 @@ load(
     "arcs_tool_recipe2plan",
     "arcs_tool_verify_policy",
 )
-load(":util.bzl", "replace_arcs_suffix")
 
 def arcs_manifest(
         name,
         srcs,
         manifest_proto = True,
+        manifest_proto_out = None,
         policy_test = False,
         policy_options = None,
         deps = [],
@@ -25,6 +25,8 @@ def arcs_manifest(
       srcs: list of Arcs manifest files to include
       manifest_proto: if True, generates a binary proto representation of the
           manifest
+      manifest_proto_out: Optional output file name for the generated manifest
+          proto. Only relevant if manifest_proto is true.
       policy_test: If True, generates a test to check that all recipes in the
           manifest satisfy policy rules. Requires policy_options and
           manifest_proto.
@@ -46,6 +48,9 @@ def arcs_manifest(
         visibility = visibility,
     )
 
+    if manifest_proto_out == None:
+        manifest_proto_out = name + ".binarypb"
+
     if manifest_proto:
         if len(srcs) != 1:
             # TODO(csilvestrini): This rule should only accept one src.
@@ -53,6 +58,7 @@ def arcs_manifest(
         arcs_manifest_proto(
             name = name + "_proto",
             src = srcs[0],
+            out = manifest_proto_out,
             deps = deps,
         )
 
@@ -70,7 +76,8 @@ def arcs_manifest(
 def arcs_manifest_proto(name, src, deps = [], out = None, visibility = None):
     """Serialize a manifest file.
 
-    This converts a '.arcs' file into a protobuf representation, using manifest2proto.
+    This converts a '.arcs' file into a protobuf representation, using
+    manifest2proto.
 
     Args:
       name: the name of the target to create
@@ -79,7 +86,7 @@ def arcs_manifest_proto(name, src, deps = [], out = None, visibility = None):
       out: the name of the output artifact (a proto file).
       visibility: list of visibilities
     """
-    outs = [out] if out != None else [replace_arcs_suffix(name, ".binarypb")]
+    outs = [out] if out != None else [name + ".binarypb"]
 
     arcs_tool_manifest2proto(
         name = name,
@@ -110,7 +117,8 @@ def arcs_proto_plan(name, src, recipe = None, deps = []):
       name: the name of the target to create
       src: an Arcs manifest file to source recipes from
       recipe: an optional name of the recipe to filter output plans by name
-      deps: list of dependencies - other manifests that are imported by src manifest
+      deps: list of dependencies - other manifests that are imported by src
+          manifest
     """
     arcs_tool_recipe2plan(
         name = name,


### PR DESCRIPTION
Previously this was trying to use the name of the .arcs file sometimes, but was actually using the target name.

Also changed the interaction between `arcs_manifest` and `arcs_manifest_proto` slightly. `arcs_manifest(name = "foo_bar")` generates an `arcs_manifest_proto` target named `foo_bar_proto`, which previously would generate a file named `foo-bar-proto.binarypb`. Now we generate the more predictable and obvious file name: `foo_bar.binarypb`.

(Only need to review last commit)