### PR TITLE
Define a new allowed-packages-tools package group for using Arcs CLI tools

### DIFF
--- a/java/arcs/BUILD
+++ b/java/arcs/BUILD
@@ -10,3 +10,13 @@ package_group(
         "//...",
     ],
 )
+
+# Wider list of packages that can invoke Arcs CLI tools (via BUILD rules).
+# Public visibility for now.
+package_group(
+    name = "allowed-packages-tools",
+    includes = [":allowed-packages"],
+    packages = [
+        "//...",
+    ],
+)

--- a/java/arcs/tools/BUILD
+++ b/java/arcs/tools/BUILD
@@ -7,7 +7,7 @@ load("//tools/build_defs/kotlin:rules.bzl", "kt_jvm_library")
 
 licenses(["notice"])
 
-package(default_visibility = ["//java/arcs:allowed-packages"])
+package(default_visibility = ["//java/arcs:allowed-packages-tools"])
 
 # We use `java_test` and not `java_binary` as `run_dfa` requires testonly targets.
 # This would still create a java binary.


### PR DESCRIPTION
This is meaningless in our public repo, but is important internally.