### PR TITLE
Make Particle Test Harness more flexible

### DIFF
--- a/javatests/arcs/sdk/testing/BaseTestHarnessTest.kt
+++ b/javatests/arcs/sdk/testing/BaseTestHarnessTest.kt
@@ -31,34 +31,31 @@ class BaseTestHarnessTest {
             harness.start()
 
             // Singleton handles
-            val particleData = harness.particle.handles.data
-
             harness.data.dispatchStore(arcs.core.host.MultiHandleParticle_Data(7.0))
-            assertThat(particleData.dispatchFetch()?.num).isEqualTo(7.0)
+            assertThat(harness.data.dispatchFetch()?.num).isEqualTo(7.0)
 
             harness.data.dispatchClear()
-            assertThat(particleData.dispatchFetch()).isNull()
+            assertThat(harness.data.dispatchFetch()).isNull()
 
             // Collection handles
-            val particleList = harness.particle.handles.list
             val e1 = arcs.core.host.MultiHandleParticle_List("element1")
             val e2 = arcs.core.host.MultiHandleParticle_List("element2")
             val e3 = arcs.core.host.MultiHandleParticle_List("element3")
 
             harness.list.dispatchStore(e1, e2, e3)
-            assertThat(particleList.dispatchSize()).isEqualTo(3)
-            assertThat(particleList.dispatchIsEmpty()).isEqualTo(false)
-            assertThat(particleList.dispatchFetchAll()).isEqualTo(setOf(e1, e2, e3))
+            assertThat(harness.list.dispatchSize()).isEqualTo(3)
+            assertThat(harness.list.dispatchIsEmpty()).isEqualTo(false)
+            assertThat(harness.list.dispatchFetchAll()).isEqualTo(setOf(e1, e2, e3))
 
             harness.list.dispatchRemove(e2)
-            assertThat(particleList.dispatchSize()).isEqualTo(2)
-            assertThat(particleList.dispatchIsEmpty()).isEqualTo(false)
-            assertThat(particleList.dispatchFetchAll()).isEqualTo(setOf(e1, e3))
+            assertThat(harness.list.dispatchSize()).isEqualTo(2)
+            assertThat(harness.list.dispatchIsEmpty()).isEqualTo(false)
+            assertThat(harness.list.dispatchFetchAll()).isEqualTo(setOf(e1, e3))
 
             harness.list.dispatchClear()
-            assertThat(particleList.dispatchSize()).isEqualTo(0)
-            assertThat(particleList.dispatchIsEmpty()).isEqualTo(true)
-            assertThat(particleList.dispatchFetchAll()).isEmpty()
+            assertThat(harness.list.dispatchSize()).isEqualTo(0)
+            assertThat(harness.list.dispatchIsEmpty()).isEqualTo(true)
+            assertThat(harness.list.dispatchFetchAll()).isEmpty()
         }
     }
 

--- a/src/tools/schema2kotlin.ts
+++ b/src/tools/schema2kotlin.ts
@@ -33,6 +33,7 @@ export class Schema2Kotlin extends Schema2Base {
 
     if (this.opts.test_harness) {
       imports.push(
+        'import arcs.sdk.Particle',
         'import arcs.sdk.testing.*',
         'import java.math.BigInteger',
         'import kotlinx.coroutines.CoroutineScope',
@@ -252,7 +253,7 @@ abstract class Abstract${particle.name} : ${this.opts.wasm ? 'WasmParticleImpl' 
 
     return `
 @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
-class ${particleName}TestHarness<P : Abstract${particleName}>(
+class ${particleName}TestHarness<P : Particle>(
     factory : (CoroutineScope) -> P
 ) : BaseTestHarness<P>(factory, listOf(
     ${handleSpecs.join(',\n    ')}

--- a/src/tools/tests/goldens/generated-test-harness.kt
+++ b/src/tools/tests/goldens/generated-test-harness.kt
@@ -8,12 +8,13 @@ package arcs.golden
 //
 // Current implementation doesn't support optional field detection
 
+import arcs.sdk.Particle
 import arcs.sdk.testing.*
 import java.math.BigInteger
 import kotlinx.coroutines.CoroutineScope
 
 @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
-class GoldTestHarness<P : AbstractGold>(
+class GoldTestHarness<P : Particle>(
     factory : (CoroutineScope) -> P
 ) : BaseTestHarness<P>(factory, listOf(
     arcs.core.entity.HandleSpec(

--- a/src/tools/tests/goldens/kotlin-test-harness.cgtest
+++ b/src/tools/tests/goldens/kotlin-test-harness.cgtest
@@ -14,7 +14,7 @@ particle P
 -----[results]-----
 
 @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
-class PTestHarness<P : AbstractP>(
+class PTestHarness<P : Particle>(
     factory : (CoroutineScope) -> P
 ) : BaseTestHarness<P>(factory, listOf(
     arcs.core.entity.HandleSpec(
@@ -48,7 +48,7 @@ particle P
 -----[results]-----
 
 @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
-class PTestHarness<P : AbstractP>(
+class PTestHarness<P : Particle>(
     factory : (CoroutineScope) -> P
 ) : BaseTestHarness<P>(factory, listOf(
     arcs.core.entity.HandleSpec(


### PR DESCRIPTION
Don't require the instantiated particle to be the subclass of the code-generated base class, as particle could be implemented without codegen.

This will be useful for testing Paxel particles as well as other non-codegened particles.