### PR TITLE
Move Type.toSchema() to TypeUtil.kt in core/data

### DIFF
--- a/java/arcs/core/analysis/BUILD
+++ b/java/arcs/core/analysis/BUILD
@@ -15,7 +15,6 @@ arcs_kt_library(
     deps = [
         "//java/arcs/core/data",
         "//java/arcs/core/data:schema_fields",
-        "//java/arcs/core/host",
         "//java/arcs/core/policy",
         "//java/arcs/core/type",
         "//java/arcs/core/util",

--- a/java/arcs/core/analysis/PolicyVerifier.kt
+++ b/java/arcs/core/analysis/PolicyVerifier.kt
@@ -14,7 +14,7 @@ package arcs.core.analysis
 import arcs.core.data.AccessPath
 import arcs.core.data.Check
 import arcs.core.data.Recipe
-import arcs.core.host.toSchema
+import arcs.core.data.toSchema
 import arcs.core.policy.Policy
 import arcs.core.policy.PolicyConstraints
 import arcs.core.policy.PolicyOptions

--- a/java/arcs/core/data/TypeUtil.kt
+++ b/java/arcs/core/data/TypeUtil.kt
@@ -1,0 +1,14 @@
+package arcs.core.data
+
+import arcs.core.type.Type
+
+/**
+ * If this Type represents a [SingletonType], [CollectionType], or [EntityType], return the
+ * [Schema] used by the underlying [Entity] that this type represents.
+ */
+fun Type.toSchema() = when {
+    this is SingletonType<*> && containedType is EntityType -> containedType.entitySchema
+    this is CollectionType<*> && collectionType is EntityType -> collectionType.entitySchema
+    this is EntityType -> entitySchema
+    else -> throw IllegalArgumentException("Can't get entitySchema of unknown type $this")
+}

--- a/java/arcs/core/data/expression/BUILD
+++ b/java/arcs/core/data/expression/BUILD
@@ -30,7 +30,6 @@ arcs_kt_library(
     deps = [
         ":expression",
         "//java/arcs/core/data",
-        "//java/arcs/core/host",
         "//java/arcs/core/util",
         "//java/arcs/sdk",
         "//third_party/kotlin/kotlinx_coroutines",

--- a/java/arcs/core/data/expression/EvaluatorParticle.kt
+++ b/java/arcs/core/data/expression/EvaluatorParticle.kt
@@ -15,8 +15,8 @@ import arcs.core.data.CollectionType
 import arcs.core.data.Plan
 import arcs.core.data.Schema
 import arcs.core.data.SingletonType
+import arcs.core.data.toSchema
 import arcs.core.entity.EntitySpec
-import arcs.core.host.toSchema
 import arcs.sdk.BaseParticle
 import arcs.sdk.Entity
 import arcs.sdk.EntityBase

--- a/java/arcs/core/host/Utils.kt
+++ b/java/arcs/core/host/Utils.kt
@@ -10,13 +10,8 @@
  */
 package arcs.core.host
 
-import arcs.core.data.CollectionType
-import arcs.core.data.EntityType
 import arcs.core.data.Plan
-import arcs.core.data.Schema
-import arcs.core.data.SingletonType
 import arcs.core.host.api.Particle
-import arcs.core.type.Type
 import kotlin.reflect.KClass
 
 /**
@@ -46,26 +41,3 @@ inline fun <reified T : Particle> ((Plan.Particle?) -> T).toRegistration(): Part
     val construct: suspend (Plan.Particle?) -> T = { this.invoke(it) }
     return T::class.toParticleIdentifier() to construct
 }
-/**
- * If this Type represents a [SingletonType], [CollectionType], or [EntityType], return the
- * [Schema] used by the underlying [Entity] that this type represents.
- */
-fun Type.toSchema(): Schema {
-    when (this) {
-        is SingletonType<*> -> if (this.containedType is EntityType) {
-            return (this.containedType as EntityType).entitySchema
-        }
-        is CollectionType<*> -> if (this.collectionType is EntityType) {
-            return (this.collectionType as EntityType).entitySchema
-        }
-        is EntityType -> return this.entitySchema
-        else -> Unit
-    }
-    throw IllegalArgumentException("Can't get entitySchema of unknown type $this")
-}
-
-/**
-* If this Type represents a [SingletonType], [CollectionType], or [EntityType], return the
-* [Schema.hash] used by the underlying [Entity] that this type represents.
-*/
-fun Type.toSchemaHash(): String = this.toSchema().hash

--- a/javatests/arcs/core/host/TestReflectiveParticle.kt
+++ b/javatests/arcs/core/host/TestReflectiveParticle.kt
@@ -2,6 +2,7 @@ package arcs.core.host
 
 import arcs.core.data.Plan
 import arcs.core.data.Schema
+import arcs.core.data.toSchema
 import arcs.core.entity.EntityBaseSpec
 import arcs.sdk.BaseParticle
 import arcs.sdk.EntityBase

--- a/src/tools/tests/VariablePlanTest.kt
+++ b/src/tools/tests/VariablePlanTest.kt
@@ -6,7 +6,7 @@ import arcs.core.data.SchemaFields
 import arcs.core.data.proto.ManifestProto
 import arcs.core.data.proto.decodeRecipes
 import arcs.core.data.toPlan
-import arcs.core.host.toSchema
+import arcs.core.data.toSchema
 import arcs.core.storage.api.DriverAndKeyConfigurator
 import arcs.repoutils.runfilesDir
 import com.google.common.truth.Truth.assertThat


### PR DESCRIPTION
It is a useful function and we should not  require depending on arcs/core/host to use it.

I will want to use it in some new code where depending on /host did not seem right.