### PR TITLE
Adds a new `@ingress` particle annotation

### DIFF
--- a/java/arcs/core/analysis/PolicyVerifier.kt
+++ b/java/arcs/core/analysis/PolicyVerifier.kt
@@ -40,7 +40,7 @@ class PolicyVerifier(val options: PolicyOptions) {
 
         // Compute the egress check map.
         val egressCheckPredicate = policyConstraints.egressCheck
-        val egressParticles = recipe.particles.filterNot { it.spec.dataflowType.isolated }
+        val egressParticles = recipe.particles.filter { it.spec.dataflowType.egress }
         checkEgressParticles(policy, egressParticles)
         val egressChecks = egressParticles.associate { particle ->
             // Each handle connection needs its own check statement.

--- a/java/arcs/core/analysis/PolicyVerifier.kt
+++ b/java/arcs/core/analysis/PolicyVerifier.kt
@@ -40,7 +40,7 @@ class PolicyVerifier(val options: PolicyOptions) {
 
         // Compute the egress check map.
         val egressCheckPredicate = policyConstraints.egressCheck
-        val egressParticles = recipe.particles.filterNot { it.spec.isolated }
+        val egressParticles = recipe.particles.filterNot { it.spec.dataflowType.isolated }
         checkEgressParticles(policy, egressParticles)
         val egressChecks = egressParticles.associate { particle ->
             // Each handle connection needs its own check statement.
@@ -122,7 +122,7 @@ class PolicyVerifier(val options: PolicyOptions) {
     private fun checkEgressParticles(policy: Policy, egressParticles: List<Recipe.Particle>) {
         val invalidEgressParticles = egressParticles
             .map { it.spec }
-            .filter { it.egress && it.egressType != policy.egressType }
+            .filter { it.dataflowType.egress && it.egressType != policy.egressType }
         if (invalidEgressParticles.isNotEmpty()) {
             throw PolicyViolation.InvalidEgressTypeForParticles(
                 policy = policy,

--- a/java/arcs/core/data/Annotation.kt
+++ b/java/arcs/core/data/Annotation.kt
@@ -65,5 +65,8 @@ data class Annotation(val name: String, val params: Map<String, AnnotationParam>
 
         /** Annotation indicating that a particle is isolated. */
         val isolated = Annotation("isolated")
+
+        /** Annotation indicating that a particle has ingress. */
+        val ingress = Annotation("ingress")
     }
 }

--- a/javatests/arcs/core/data/ParticleSpecTest.kt
+++ b/javatests/arcs/core/data/ParticleSpecTest.kt
@@ -11,18 +11,21 @@ class ParticleSpecTest {
     @Test
     fun dataflowType_ingress() {
         val spec = createSpec(annotations = listOf(Annotation.ingress))
+
         assertThat(spec.dataflowType).isEqualTo(ParticleDataflowType.Ingress)
     }
 
     @Test
     fun dataflowType_egress() {
         val spec = createSpec(annotations = listOf(Annotation.createEgress()))
+
         assertThat(spec.dataflowType).isEqualTo(ParticleDataflowType.Egress)
     }
 
     @Test
     fun dataflowType_isolated() {
         val spec = createSpec(annotations = listOf(Annotation.isolated))
+
         assertThat(spec.dataflowType).isEqualTo(ParticleDataflowType.Isolated)
     }
 
@@ -34,12 +37,14 @@ class ParticleSpecTest {
     @Test
     fun dataflowType_cannotBeIsolatedAndIngress() {
         val spec = createSpec(annotations = listOf(Annotation.isolated, Annotation.ingress))
+
         assertFailsWith<IllegalArgumentException> { spec.dataflowType }
     }
 
     @Test
     fun dataflowType_cannotBeIsolatedAndEgress() {
         val spec = createSpec(annotations = listOf(Annotation.isolated, Annotation.createEgress()))
+
         assertFailsWith<IllegalArgumentException> { spec.dataflowType }
     }
 

--- a/javatests/arcs/core/data/ParticleSpecTest.kt
+++ b/javatests/arcs/core/data/ParticleSpecTest.kt
@@ -1,0 +1,59 @@
+package arcs.core.data
+
+import com.google.common.truth.Truth.assertThat
+import kotlin.test.assertFailsWith
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class ParticleSpecTest {
+    @Test
+    fun dataflowType_ingress() {
+        val spec = createSpec(annotations = listOf(Annotation.ingress))
+        assertThat(spec.dataflowType).isEqualTo(ParticleDataflowType.Ingress)
+    }
+
+    @Test
+    fun dataflowType_egress() {
+        val spec = createSpec(annotations = listOf(Annotation.createEgress()))
+        assertThat(spec.dataflowType).isEqualTo(ParticleDataflowType.Egress)
+    }
+
+    @Test
+    fun dataflowType_isolated() {
+        val spec = createSpec(annotations = listOf(Annotation.isolated))
+        assertThat(spec.dataflowType).isEqualTo(ParticleDataflowType.Isolated)
+    }
+
+    @Test
+    fun dataflowType_defaultsToIngressAndEgress() {
+        assertThat(createSpec().dataflowType).isEqualTo(ParticleDataflowType.IngressAndEgress)
+    }
+
+    @Test
+    fun dataflowType_cannotBeIsolatedAndIngress() {
+        val spec = createSpec(annotations = listOf(Annotation.isolated, Annotation.ingress))
+        assertFailsWith<IllegalArgumentException> { spec.dataflowType }
+    }
+
+    @Test
+    fun dataflowType_cannotBeIsolatedAndEgress() {
+        val spec = createSpec(annotations = listOf(Annotation.isolated, Annotation.createEgress()))
+        assertFailsWith<IllegalArgumentException> { spec.dataflowType }
+    }
+
+    companion object {
+        fun createSpec(
+            name: String = "Foo",
+            annotations: List<Annotation> = emptyList()
+        ): ParticleSpec {
+            return ParticleSpec(
+                name = name,
+                connections = emptyMap(),
+                location = "",
+                annotations = annotations
+            )
+        }
+    }
+}

--- a/src/runtime/canonical-manifest.ts
+++ b/src/runtime/canonical-manifest.ts
@@ -72,6 +72,11 @@ annotation egress(type: Text)
   retention: Source
   doc: 'Indicates that the given particle can egress data out of the system (i.e. is not isolated). Optionally supply an egress type.'
 
+annotation ingress
+  targets: [Particle]
+  retention: Source
+  doc: 'Indicates that the given particle can ingress data into of the system (i.e. is not isolated).'
+
 annotation policy(name: Text)
   targets: [Recipe]
   retention: Source


### PR DESCRIPTION
This will be used to indicate that a particle ingresses data from outside Arcs. It will eventually be used to replace the PolicyOptions object (but not in this PR).

I had to rework the representation of the isolated/egress properties, since there is now a valid combination state (ingress+egress).