### PR TITLE
Start moving recipe/ dependencies to a new lib-recipe.ts.

### DIFF
--- a/src/dataflow/analysis/analysis.ts
+++ b/src/dataflow/analysis/analysis.ts
@@ -11,7 +11,7 @@
 import {FlowGraph} from './flow-graph.js';
 import {assert} from '../../platform/assert-web.js';
 import {Edge, FlowModifier, FlowSet, FlowModifierSet, Flow} from './graph-internals.js';
-import {Recipe} from '../../runtime/recipe/recipe.js';
+import {Recipe} from '../../runtime/recipe/lib-recipe.js';
 import {Manifest} from '../../runtime/manifest.js';
 import {IndentingStringBuilder} from '../../utils/indenting-string-builder.js';
 

--- a/src/dataflow/analysis/flow-graph.ts
+++ b/src/dataflow/analysis/flow-graph.ts
@@ -8,7 +8,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {Recipe} from '../../runtime/recipe/recipe.js';
+import {Recipe} from '../../runtime/recipe/lib-recipe.js';
 import {ParticleNode, createParticleNodes, ParticleOutput, ParticleInput} from './particle-node.js';
 import {HandleNode, createHandleNodes, addHandleConnection} from './handle-node.js';
 import {SlotNode, createSlotNodes, addSlotConnection} from './slot-node.js';

--- a/src/dataflow/analysis/handle-node.ts
+++ b/src/dataflow/analysis/handle-node.ts
@@ -10,9 +10,8 @@
 
 import {Node, Edge} from './graph-internals.js';
 import {ParticleOutput, ParticleInput, ParticleNode} from './particle-node.js';
-import {HandleConnection} from '../../runtime/recipe/handle-connection.js';
 import {assert} from '../../platform/assert-web.js';
-import {Handle} from '../../runtime/recipe/handle.js';
+import {Handle, HandleConnection} from '../../runtime/recipe/lib-recipe.js';
 
 export class HandleNode extends Node {
   readonly nodeId: string;

--- a/src/dataflow/analysis/particle-node.ts
+++ b/src/dataflow/analysis/particle-node.ts
@@ -11,13 +11,11 @@
 import {Node, Edge, FlowModifier, FlowCheck} from './graph-internals.js';
 import {ClaimExpression} from '../../runtime/arcs-types/claim.js';
 import {ClaimType} from '../../runtime/arcs-types/enums.js';
-import {Particle} from '../../runtime/recipe/particle.js';
+import {Particle, HandleConnection, Handle} from '../../runtime/recipe/lib-recipe.js';
 import {assert} from '../../platform/assert-web.js';
 import {HandleConnectionSpec} from '../../runtime/arcs-types/particle-spec.js';
-import {HandleConnection} from '../../runtime/recipe/handle-connection.js';
 import {Type, ReferenceType} from '../../runtime/type.js';
 import {TypeChecker} from '../../runtime/recipe/type-checker.js';
-import {Handle} from '../../runtime/recipe/handle.js';
 
 export class ParticleNode extends Node {
   readonly inEdgesByName: Map<string, ParticleInput> = new Map();

--- a/src/dataflow/analysis/slot-node.ts
+++ b/src/dataflow/analysis/slot-node.ts
@@ -9,9 +9,8 @@
  */
 
 import {Node, Edge, FlowCheck, FlowModifier} from './graph-internals.js';
-import {Slot} from '../../runtime/type.js';
+import {Slot, SlotConnection} from '../../runtime/recipe/lib-recipe.js';
 import {ParticleNode} from './particle-node.js';
-import {SlotConnection} from '../../runtime/recipe/slot-connection.js';
 
 export class SlotNode extends Node {
   // For now, slots can only have in-edges (from the particles that consume them).

--- a/src/runtime/arcs-types/enums.ts
+++ b/src/runtime/arcs-types/enums.ts
@@ -11,5 +11,5 @@
 // String-based enums.
 // TODO: convert to actual enums so that they can be iterated over.
 
-import {Direction, SlotDirection, ClaimType, CheckType} from '../manifest-ast-types/enums.js';
-export {Direction, SlotDirection, ClaimType, CheckType};
+import {Direction, SlotDirection, ClaimType, CheckType, Fate} from '../manifest-ast-types/enums.js';
+export {Direction, SlotDirection, ClaimType, CheckType, Fate};

--- a/src/runtime/manifest-ast-types/enums.ts
+++ b/src/runtime/manifest-ast-types/enums.ts
@@ -29,3 +29,4 @@ export enum CheckType {
   Implication = 'implication',
 }
 
+export type Fate = 'use' | 'create' | 'map' | 'copy' | 'join' | '?' | '`slot';

--- a/src/runtime/manifest-ast-types/manifest-ast-nodes.ts
+++ b/src/runtime/manifest-ast-types/manifest-ast-nodes.ts
@@ -7,8 +7,8 @@
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
-import {Direction, SlotDirection, ClaimType, CheckType} from '../arcs-types/enums.js';
-export {Direction, SlotDirection, ClaimType, CheckType};
+import {Direction, SlotDirection, ClaimType, CheckType, Fate} from '../manifest-ast-types/enums.js';
+export {Direction, SlotDirection, ClaimType, CheckType, Fate};
 /**
  * Complete set of tokens used by `manifest-parser.pegjs`. To use this you
  * need to follow some simple guidelines:
@@ -965,8 +965,6 @@ export function preSlandlesDirectionToDirection(direction: Direction, isOptional
       throw new Error(`Bad pre slandles direction ${direction}`);
   }
 }
-
-export type Fate = 'use' | 'create' | 'map' | 'copy' | 'join' | '?' | '`slot';
 
 export type ParticleHandleConnectionType = TypeVariable|CollectionType|
     BigCollectionType|ReferenceType|MuxType|SlotType|SchemaInline|TypeName;

--- a/src/runtime/recipe/lib-recipe.ts
+++ b/src/runtime/recipe/lib-recipe.ts
@@ -1,0 +1,52 @@
+/**
+ * @license
+ * Copyright (c) 2020 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {Fate, Direction} from "../arcs-types/enums.js";
+import {HandleConnectionSpec, ConsumeSlotConnectionSpec} from "../arcs-types/particle-spec.js";
+import {Dictionary} from "../../utils/hot.js";
+import {ClaimIsTag} from "../arcs-types/claim.js";
+
+export interface Particle {
+  name: string;
+}
+
+export interface Handle {
+  id: string;
+  fate: Fate;
+  claims: Dictionary<ClaimIsTag[]>;
+}
+
+export interface Slot {
+}
+
+export interface SlotConnection {
+  particle: Particle;
+  targetSlot: Slot;
+  providedSlots: Dictionary<Slot>;
+  getSlotSpec(): ConsumeSlotConnectionSpec;
+  name: string;
+}
+
+export interface HandleConnection {
+  particle: Particle;
+  handle: Handle;
+  spec: HandleConnectionSpec;
+  name: string;
+  direction: Direction;
+}
+
+export interface Recipe {
+  isResolved(): boolean;
+  particles: Particle[];
+  handles: Handle[];
+  slots: Slot[];
+  handleConnections: HandleConnection[];
+  slotConnections: SlotConnection[];
+}

--- a/src/runtime/recipe/lib-recipe.ts
+++ b/src/runtime/recipe/lib-recipe.ts
@@ -8,10 +8,10 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {Fate, Direction} from "../arcs-types/enums.js";
-import {HandleConnectionSpec, ConsumeSlotConnectionSpec} from "../arcs-types/particle-spec.js";
-import {Dictionary} from "../../utils/hot.js";
-import {ClaimIsTag} from "../arcs-types/claim.js";
+import {Fate, Direction} from '../arcs-types/enums.js';
+import {HandleConnectionSpec, ConsumeSlotConnectionSpec} from '../arcs-types/particle-spec.js';
+import {Dictionary} from '../../utils/hot.js';
+import {ClaimIsTag} from '../arcs-types/claim.js';
 
 export interface Particle {
   name: string;
@@ -20,7 +20,7 @@ export interface Particle {
 export interface Handle {
   id: string;
   fate: Fate;
-  claims: Dictionary<ClaimIsTag[]>;
+  claims: Map<string, ClaimIsTag[]>;
 }
 
 export interface Slot {


### PR DESCRIPTION
This is getting us ready to move lib-recipe into arcs-types and keep internal recipe details independent of the rest of the codebase.

There are 3 activities here; all need to be completed before we are modular / in a good place:
(1) make all non-recipe code that depends on recipe/ do so through lib-recipe.ts (e.g. this patch)
(2) make sure recipe/ files only depend on things inside recipe/, or arc-types.
(3) rationalize the lib-recipe.ts API.