### PR TITLE
allocator-recipe-resolver supports mapping manifest stores

### DIFF
--- a/src/runtime/type.ts
+++ b/src/runtime/type.ts
@@ -1477,7 +1477,7 @@ export class TypeVariableInfo {
       return true;
     }
     if (this._canReadSubset) {
-      this._resolution = this._canReadSubset;
+      this.resolution = this._canReadSubset;
       return true;
     }
     return false;

--- a/src/tools/allocator-recipe-resolver.ts
+++ b/src/tools/allocator-recipe-resolver.ts
@@ -101,7 +101,7 @@ export class AllocatorRecipeResolver {
       handleById[store.id] = {store, handles: []};
     }
 
-    // Find all `map` and `copy` handles and add them to the map.
+    // Find all `map` handles and add them to the map.
     for (const recipe of recipes) {
       for (const handle of recipe.handles) {
         if (handle.fate === 'use' || handle.fate === 'copy') {


### PR DESCRIPTION
addresses b/165637376

and:
- remove support for copy fate stores.
- small type var resolution fix (follow up to #5940)